### PR TITLE
TCRS adjective order had accidentally become unseeded

### DIFF
--- a/data/TCRS/TCRS_Accordion_Thief_Blender.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Blender.txt
@@ -11,7 +11,7 @@
 11	stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	dried gray moxie weed	1		
-15	dehydrated bouncing wobbly strongness elixir	1		
+15	dehydrated wobbly bouncing strongness elixir	1		
 16	denatured ghostly magicalness-in-a-can	1		
 17	decent squat noodles	3	good	
 18	tortoise's blessing	0		
@@ -37,15 +37,15 @@
 38	mirror therapeutic Knob Goblin pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	casino pass	0		
-41	weak perfectly mixed enchanted ice-cold Sir Schlitz	2	EPIC	Effect: "Meadulla Oblongota", Effect Duration: 15
+41	perfectly mixed enchanted weak ice-cold Sir Schlitz	2	EPIC	Effect: "Meadulla Oblongota", Effect Duration: 15
 42	wobbly hermit permit	0		
 43	worthless trinket	0		
 44	green worthless gewgaw	0		
 45	wobbly worthless knick-knack	0		
 46	figurine	0		
-47	miniature flavorless hot buttered roll	2	decent	
+47	flavorless miniature hot buttered roll	2	decent	
 48	heart of rock and roll	0		
-49	adequate gigantic bowl of cottage cheese	6	good	
+49	gigantic adequate bowl of cottage cheese	6	good	
 50	green aromatic Rock and Roll Legend	0		Stench Resistance: +1, Class: "Accordion Thief", Song Duration: 10
 51	Jeselnik's Knob Goblin Uberpants	0		Sleaze Damage: +25, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	jittery banjo strings	0		
@@ -54,7 +54,7 @@
 55	jaba&ntilde;ero pepper	0		
 56	hot sauce	0		
 57	chilly 5-Alarm Saucepan	0		Cold Damage: +5, Class: "Sauceror"
-58	cyan skewed stone turtle	0		
+58	skewed cyan stone turtle	0		
 59	red slingshot	0		
 60	Tesla Mace of the Tortoise	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Turtle Tamer"
 61	half-sized stale jittery fortune cookie	2	decent	
@@ -62,7 +62,7 @@
 63	tumbling action figure body	0		
 64	action figure head	0		
 65	Mighty Bjorn action figure	0		
-66	fuchsia tumbling twig	0		
+66	tumbling fuchsia twig	0		
 67	spaghetti with rock-balls	0		
 68	ghostly mansplainer's Pasta Spoon of Peril of Gandalf	0		Spell Critical Percent: +20, Monster Level: +15, Class: "Pastamancer"
 69	spinning Newbiesport&trade; tent	0		
@@ -130,9 +130,9 @@
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
 133	twirling Certificate of Participation	0		
-134	purple blinking bitchin' meatcar	0		
+134	blinking purple bitchin' meatcar	0		
 135	sweet rims	0		
-136	spinning bouncing blinking tires	0		
+136	blinking bouncing spinning tires	0		
 137	ghostly dope wheels	0		
 138	ice-cold six-pack	0		
 139	valuable trinket	0		
@@ -141,7 +141,7 @@
 142	anticheese	0		
 143	cottage	0		
 144	bouncing stone of eXtreme power	0		
-145	jittery spinning barbed-wire fence	0		
+145	spinning jittery barbed-wire fence	0		
 146	dinghy plans	0		
 147	censurious eXtreme meat sword	0		Sleaze Resistance: +3
 148	smartaleck's eXtreme meat staff	0		Moxie Percent: +30
@@ -158,7 +158,7 @@
 159	wad of dough	0		
 160	pie crust	0		
 161	rotten ghuol egg	3	crappy	
-162	tiny bland ghuol egg quiche	1	decent	
+162	bland tiny ghuol egg quiche	1	decent	
 163	skewed smartaleck's skeleton bone	0		Moxie Percent: +30
 164	squat cyan smart skull	0		
 165	skewer	0		
@@ -176,7 +176,7 @@
 177	brainy skull	0		
 178	detective skull	0		
 179	spoiled bite-sized chorizo taco	1	crappy	
-180	hand-crafted triple-distilled ice-cold fotie	7	EPIC	
+180	triple-distilled hand-crafted ice-cold fotie	7	EPIC	
 181	baseball	0		
 182	batgut	0		
 183	twirling fuchsia bat wing	0		
@@ -196,11 +196,11 @@
 198	rat appendix	0		
 199	spinning yellow ring of the sweet-tooth	0		Candy Drop: +100
 200	adequate half-sized jittery jittery rat appendix kabob	2	good	
-201	rotten miniature bat wing kabob	2	crappy	
+201	miniature rotten bat wing kabob	2	crappy	
 202	big normal bouncing carob chunks	5	good	
 203	herbs	0		
-204	diet special bland tumbling carob chunk cookies	1	decent	Effect: "Toothy Grin", Effect Duration: 25
-205	twirling green secret blend of herbs and spices	0		
+204	bland diet special tumbling carob chunk cookies	1	decent	Effect: "Toothy Grin", Effect Duration: 25
+205	green twirling secret blend of herbs and spices	0		
 206	pulsating piercing post	0		
 207	green hippy herbal tea	1	decent	
 208	patchouli incense stick	0		
@@ -212,7 +212,7 @@
 214	spinning savvy filthy knitted dread sack	0		Mysticality Percent: +20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	squat Uncle Jick's Brownie Mix	0		
 216	tiny rotten carob brownies	1	crappy	
-217	half-sized tasty yellow mirror herb brownies	2	awesome	
+217	tasty half-sized mirror yellow herb brownies	2	awesome	
 218	shaking hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -220,7 +220,7 @@
 222	phat turquoise bead	0		
 223	foul-smelling phat turquoise bracelet	0		Stench Damage: +10
 224	teal eyepatch of the pedagogue	0		Experience: +3, Familiar Effect: "3xBarrr, cap 6"
-225	adequate small skewed pulsating tofu casserole	2	good	
+225	small adequate skewed pulsating tofu casserole	2	good	
 226	dried blurry can of Red Minotaur	1	awesome	
 227	Kentucky-fried meat sword of courage	0		Spooky Resistance: +3
 228	mirror Temple Grandin's Kentucky-fried meat staff	0		Familiar Weight: +7
@@ -238,9 +238,9 @@
 240	jittery curative banded Orcish cargo shorts	0		Damage Absorption: +100, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	baleful Orcish frat-paddle	0		Spell Damage: +25
 242	half-sized normal	2	good	
-243	tasty gigantic grapefruit	9	awesome	
-244	normal jumbo jittery grapes	5	good	
-245	bite-sized stale narrow olive	1	decent	
+243	gigantic tasty grapefruit	9	awesome	
+244	jumbo normal jittery grapes	5	good	
+245	stale bite-sized narrow olive	1	decent	
 246	decent tomato	3	good	
 247	tumbling maroon fermenting powder	0		
 248	delicious red squat salty dog	4	awesome	
@@ -248,9 +248,9 @@
 250	watered-down lousy screwdriver	2	decent	
 251	tolerable special martini	4	good	Effect: "Adapt to Change Eventually", Effect Duration: 10
 252	bad bloody beer	3	decent	
-253	mediocre distilled spinning shot of schnapps	5	decent	
+253	distilled mediocre spinning shot of schnapps	5	decent	
 254	tolerable mirror shot of grapefruit schnapps	3	good	
-255	mediocre practically non-alcoholic bouncing fine wine	1	decent	
+255	practically non-alcoholic mediocre bouncing fine wine	1	decent	
 256	artisanal shot of tomato schnapps	4	EPIC	
 257	aged extra-spicy bloody mary	3	awesome	
 258	upside-down dense meat stack	0		
@@ -258,7 +258,7 @@
 260	spoiled snack-sized White Citadel fries	2	crappy	
 261	adequate thick White Citadel burger	5	good	
 262	stale enchanted piece of wedding cake	3	decent	Effect: "Human-Horror Hybrid", Effect Duration: 25
-263	half-sized moldy skewed chocolate chips	2	crappy	
+263	moldy half-sized skewed chocolate chips	2	crappy	
 264	rotten gray chocolate chip cookies	4	crappy	
 265	foul-smelling satin pants	0		Stench Damage: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	smooth irresponsibly strong green lightning	9	awesome	
@@ -302,7 +302,7 @@
 304	twirling dry noodles	0		
 305	skewed electrified Knob Goblin harem pants	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	Knob Goblin harem veil of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "5xLep, cap 2"
-307	alkaline upside-down wobbly Knob Goblin perfume	0		Effect: "Gyromitra Gymnastics", Effect Duration: 61
+307	alkaline wobbly upside-down Knob Goblin perfume	0		Effect: "Gyromitra Gymnastics", Effect Duration: 61
 308	squat Knob Goblin elite helm of the bloodbag	0		Maximum HP: +100, Familiar Effect: "2xFairy, cap 15"
 309	baleful Knob Goblin elite pants	0		Spell Damage: +25, Familiar Effect: "2xBarrr, cap 15"
 310	nasty Knob Goblin elite polearm	0		Stench Damage: +5
@@ -312,12 +312,12 @@
 314	rotten wobbly bean burrito	4	crappy	
 315	normal bean burrito	3	good	
 316	flavorless shaking insanely bean burrito	3	decent	
-317	snack-sized adequate mirror bean burrito	2	good	
+317	adequate snack-sized mirror bean burrito	2	good	
 318	thick spoiled bean burrito	5	crappy	
 319	moldy red insanely bean burrito	3	crappy	
 320	moldy skewed bat haggis	3	crappy	
 321	spoiled menudo	4	crappy	
-322	bland fancy bouncing skewed goat cheese	3	decent	Effect: "Hella Smart", Effect Duration: 5
+322	fancy bland skewed bouncing goat cheese	3	decent	Effect: "Hella Smart", Effect Duration: 5
 323	decent upside-down plain pizza	3	good	
 324	bland sausage pizza	4	decent	
 325	normal goat cheese pizza	4	good	
@@ -325,7 +325,7 @@
 327	goat	0		
 328	lousy bottle of whiskey	3	decent	
 329	dangerous goat beard	0		Weapon Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
-330	green narrow glass of goat's milk	1	good	
+330	narrow green glass of goat's milk	1	good	
 331	bad Canadian	4	decent	
 332	spoiled enchanted lemon	3	crappy	Effect: "Tightly-Wound Spine", Effect Duration: 5
 333	moldy diet green lime	1	crappy	
@@ -340,7 +340,7 @@
 342	Knob Goblin stink bomb	0		
 343	diffused improved upside-down Knob Goblin sharpening spray	0		Effect: "Egg Burps", Effect Duration: 51
 344	Knob Goblin seltzer	0		
-345	green blinking Knob Goblin superseltzer	0		
+345	blinking green Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
 347	squat Dyspepsi-Cola	0		
 348	Annie Oakley's ninja mask	0		Critical Hit Percent: +20, Familiar Effect: "cold atk, 1xBarrr, cap 20"
@@ -396,7 +396,7 @@
 398	perfumed hippopotamus pants	0		Stench Resistance: +5, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
 399	eXtreme mittens of the brazier	0		Hot Spell Damage: +25
 400	upside-down handful of drink tickets	0		
-401	blinking mirror mirror Knob Kitchen grab-bag	0		
+401	mirror blinking mirror Knob Kitchen grab-bag	0		
 402	beefy swashbuckling pants	0		Muscle: +10, Familiar Effect: "3xPotato, 1.5xFairy, cap 20"
 403	wobbly ghostly resourceful shoulder parrot	0		Maximum MP: +50
 404	chilly acoustic guitarrr	0		Cold Damage: +5
@@ -465,7 +465,7 @@
 467	flavorless pixel pie	3	decent	
 468	ruby W	0		
 469	wobbly wussiness potion	0		
-470	practically non-alcoholic acceptable maroon Imp Ale	1	good	
+470	acceptable practically non-alcoholic maroon Imp Ale	1	good	
 471	moldy hot wing	3	crappy	
 472	groovy diamond-studded cane	0		Moxie Percent: +10, Class: "Disco Bandit"
 473	red Tesla crutch	0		MP Regen Min: 7, MP Regen Max: 10
@@ -474,8 +474,8 @@
 476	hellion cube	0		
 477	lion tamer's infernal insoles of wisdom	0		Mysticality: +15, Experience (familiar): +2
 478	twirling evil arch	0		
-479	blinking pulsating dodecagram	0		
-480	spinning blurry box of birthday candles	0		
+479	pulsating blinking dodecagram	0		
+480	blurry spinning box of birthday candles	0		
 481	twirling eldritch butterknife	0		
 482	stanky Mr. Container	0		Stench Spell Damage: +25, Last Available: "2004-12"
 483	lime green Van der Graaf Newbiesport&trade; backpack	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2004-12"
@@ -496,7 +496,7 @@
 498	moldy papaya	3	crappy	
 499	stylish denim axe of dire peril	0		Moxie: +25, Weapon Damage: +20
 500	blinking huge Elf Farm Raffle ticket	0		
-501	tiny stale mirror Elfin shortbread	1	decent	
+501	stale tiny mirror Elfin shortbread	1	decent	
 502	shaking pagoda plans	0		
 503	moldy squat skewered cat appendix	3	crappy	
 504	evil arches	0		
@@ -508,7 +508,7 @@
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	normal small tumbling Boris's key lime pie	2	good	
+513	small normal tumbling Boris's key lime pie	2	good	
 514	huge bland Jarlsberg's key lime pie	8	decent	
 515	flavorless Sneaky Pete's key lime pie	3	decent	
 516	Hey Deze map	0		
@@ -520,7 +520,7 @@
 522	one-winged stab bat	0		
 523	upside-down rewinged stab bat	0		
 524	hand-crafted papaya sling	3	EPIC	
-525	blue twirling grue egg	0		
+525	twirling blue grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	purple mirror volleyball	0		
 528	blood-faced volleyball	0		
@@ -540,7 +540,7 @@
 542	bouncing lime green censurious dog trainer's 1337 7r0uZ0RZ	0		Experience (familiar): +1, Sleaze Resistance: +3, Familiar Effect: "2xPotato, cap 27"
 543	adequate spinning upside-down Trollhouse cookies	4	good	
 544	sage talons of the businessman	0		Mysticality Percent: +10, Meat Drop: +50
-545	spoiled fancy half-sized huge Spam Witch sammich	2	crappy	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 30
+545	half-sized spoiled fancy huge Spam Witch sammich	2	crappy	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 30
 546	pulsating meat vortex	0		
 547	huge skewed 334 scroll	0		
 548	wobbly 668 scroll	0		
@@ -548,8 +548,8 @@
 550	33398 scroll	0		
 551	squat 64067 scroll	0		
 552	blurry 64735 scroll	0		
-553	pulsating bouncing 31337 scroll	0		
-554	thick adequate pr0n cocktail	5	good	
+553	bouncing pulsating 31337 scroll	0		
+554	adequate thick pr0n cocktail	5	good	
 555	brainy strapping drywall axe	0		Muscle: +5, Mysticality: +5
 556	Pine-Fresh air freshener of the storm	0		Maximum MP Percent: +40
 557	mediocre skewed whiskey and cola	3	decent	
@@ -563,22 +563,22 @@
 565	hobo gloves of bravery	0		Spooky Resistance: +5, Single Equip
 566	healthy bum cheek	0		Maximum HP Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	twirling squat hermit script	0		
-568	moldy jumbo Double Bacon Beelzeburger	5	crappy	
+568	jumbo moldy Double Bacon Beelzeburger	5	crappy	
 569	huge spoiled Lord of the Flies-sized fries	7	crappy	
 570	rotten Chicken Sandwich	3	crappy	
 571	twirling Jumbo Dr. Lucifer	1	good	
 572	toothsome squat Children's Meal of the Damned	3	awesome	
 573	decent lime green noodles	3	good	
-574	fancy tasty noodles	4	awesome	Effect: "Broken Bone Nubs", Effect Duration: 45
+574	tasty fancy noodles	4	awesome	Effect: "Broken Bone Nubs", Effect Duration: 45
 575	moldy painful penne pasta	3	crappy	
 576	rotten ravioli della hippy	3	crappy	
 577	spoiled pr0n m4nic0tti	3	crappy	
 578	decent wobbly Hell ramen	3	good	
-579	toothsome jumbo boring spaghetti	5	awesome	
+579	jumbo toothsome boring spaghetti	5	awesome	
 580	sauce of the ages	0		
 581	upside-down schmancy cheese sauce	0		
-582	blurry skewed Himalayan Hidalgo sauce	0		
-583	decent thick olive fettucini Inconnu	5	good	
+582	skewed blurry Himalayan Hidalgo sauce	0		
+583	thick decent olive fettucini Inconnu	5	good	
 584	moldy spaghetti with Skullheads	4	crappy	
 585	decent gnocchetti di Nietzsche	3	good	
 586	shaking wobbly studded forbidden ridiculously huge sword	0		Spell Damage Percent: +50, Damage Absorption: +80
@@ -613,7 +613,7 @@
 615	blinking chaos butterfly	0		
 616	furry fur	0		
 617	super-boiled warmed Angry Farmer candy	0		Effect: "Hot Jellied", Effect Duration: 63
-618	alkaline spinning mirror Mick's IcyVapoHotness Rub	0		Effect: "One Foot Heavier", Effect Duration: 21
+618	alkaline mirror spinning Mick's IcyVapoHotness Rub	0		Effect: "One Foot Heavier", Effect Duration: 21
 619	teal spinning forbidden needle	0		Spell Damage Percent: +50
 620	dry thin candle	0		Effect: "Tomato Power", Effect Duration: 56
 621	Warm Subject gift certificate	0		
@@ -621,7 +621,7 @@
 623	WA	0		
 624	purple NG	0		
 625	wang	0		
-626	twirling lime green mirror Wand of Nagamar	0		
+626	mirror twirling lime green Wand of Nagamar	0		
 627	ND	0		
 628	squat metallic A	0		
 629	scandalous eye	0		Sleaze Damage: +5
@@ -636,7 +636,7 @@
 638	skewed manspreader's wizardly asshat	0		Mysticality: +25, Monster Level: +10, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	flavorless abominable snowcone	4	decent	
 640	Ent cider	1	good	
-641	enchanted stale toast	3	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25
+641	stale enchanted toast	3	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	blurry Crimbo pressie	0		Last Available: "2003-12"
@@ -668,8 +668,8 @@
 670	mirror blinking lihc face of the detective	0		Item Drop: +20, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	MacGyver's therapeutic grave robbing shovel	0		Maximum MP: +100, HP Regen Min: 5, HP Regen Max: 7
 672	toothsome cranberries	3	awesome	
-673	practically non-alcoholic artisanal vodka and cranberry	1	EPIC	
-674	delicious high-proof whiskey	6	awesome	
+673	artisanal practically non-alcoholic vodka and cranberry	1	EPIC	
+674	high-proof delicious whiskey	6	awesome	
 675	pulsating manspreader's skull of the Bonerdagon	0		Monster Level: +10
 676	dragonbone belt buckle	0		
 677	razor-sharp badass belt	0		Weapon Damage Percent: +25
@@ -677,9 +677,9 @@
 679	aged practically non-alcoholic roll in the hay	1	awesome	
 680	irresponsibly strong drinkable squat slap and tickle	8	good	
 681	triple-distilled tolerable slip 'n' slide	10	good	
-682	tolerable boozy pulsating olive a sump'm sump'm	5	good	
+682	tolerable boozy olive pulsating a sump'm sump'm	5	good	
 683	hand-crafted horizontal tango	4	EPIC	
-684	watered-down perfectly mixed pink pony	2	EPIC	
+684	perfectly mixed watered-down pink pony	2	EPIC	
 685	crafty hardened Mr. Shirt of extreme caution	0		Damage Reduction: 3, Maximum MP: +10, Monster Level: -25
 686	bouncing smooth knuckles	0		Moxie: +15
 687	alkaline pickled shaking blood of the Wereseal	0		Effect: "Gr8ness", Effect Duration: 40
@@ -720,7 +720,7 @@
 724	bland mushroom	3	decent	
 725	one million meat pancakes	0		
 726	skewed groovy huge mirror shard	0		Moxie Percent: +10
-727	purple blurry hedge maze puzzle	0		
+727	blurry purple hedge maze puzzle	0		
 728	mirror hedge maze key	0		
 729	upside-down fishbowl	0		
 730	fishtank	0		
@@ -730,25 +730,25 @@
 734	Socratic strapping makeshift SCUBA gear of terror	0		Muscle: +5, Experience (Mysticality): +1, Spooky Spell Damage: +10, Adventure Underwater
 735	twirling Jack Frost's easter egg balloon	0		Cold Spell Damage: +50
 736	twirling stone tablet (Sinister Strumming)	0		
-737	lime green upside-down stone tablet (Squeezings of Woe)	0		
+737	upside-down lime green stone tablet (Squeezings of Woe)	0		
 738	stone tablet (Really Evil Rhythm)	0		
 739	bouncing tambourine bells	0		
 740	lard-coated tambourine	0		Sleaze Spell Damage: +25
 741	broken skull	0		
-742	jumbo flavorless spinning Knoll shroomkabob	5	decent	
+742	flavorless jumbo spinning Knoll shroomkabob	5	decent	
 743	rotten snack-sized mushroom	2	crappy	
 744	energized spinning hair spray	0		Effect: "Stench Jellied", Effect Duration: 68
 746	spinning stat script	0		
 747	Knob Goblin firecracker	0		
 748	wobbly gourd potion	0		
-749	super-sized stale warm mushroom	5	decent	
+749	stale super-sized warm mushroom	5	decent	
 750	moldy mushroom quesadilla	4	crappy	
-751	bite-sized moldy jittery cool mushroom	1	crappy	
+751	moldy bite-sized jittery cool mushroom	1	crappy	
 752	spoiled cool mushroom casserole	3	crappy	
-753	jumbo stale pointy mushroom	5	decent	
-754	rotten big cream of pointy mushroom soup	5	crappy	
+753	stale jumbo pointy mushroom	5	decent	
+754	big rotten cream of pointy mushroom soup	5	crappy	
 755	bland mushroom	3	decent	
-756	snack-sized adequate lime green mushroom	2	good	
+756	adequate snack-sized lime green mushroom	2	good	
 757	bite-sized yummy green mushroom	1	awesome	
 758	huge spoiled cyan ghost cucumber	7	crappy	
 759	dill	0		
@@ -759,7 +759,7 @@
 764	moldy spectral pickle	3	crappy	
 765	ghostly briny vinegar	0		
 766	blinking ghost pickle on a stick	0		
-767	frozen blinking maroon cologne of contempt	0		Effect: "Ooh, Bitter!", Effect Duration: 48
+767	frozen maroon blinking cologne of contempt	0		Effect: "Ooh, Bitter!", Effect Duration: 48
 768	smelly spork	0		Stench Spell Damage: +10
 769	hale voodoo doll	0		Maximum HP: +20
 770	nippy Van der Graaf basic meat fez	0		Cold Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "3xLep, cap 11"
@@ -776,10 +776,10 @@
 781	double-oxidized quadruple-deionized mafia aria	0		Effect: "Red Around the Gills", Effect Duration: 50
 782	teal Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	bad weak Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
-785	tumbling skewed raffle ticket	0		
+784	weak bad Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
+785	skewed tumbling raffle ticket	0		
 786	special adequate olive bouncing strawberry	3	good	Effect: "Motion", Effect Duration: 40
-787	high-proof artisanal olive bottle of rum	7	EPIC	
+787	artisanal high-proof olive bottle of rum	7	EPIC	
 788	mediocre watered-down strawberry daiquiri	2	decent	
 789	acceptable special rum and cola	4	good	Effect: "Frost Tea", Effect Duration: 15
 790	acceptable watered-down grog	2	good	
@@ -787,27 +787,27 @@
 792	Golden Mr. Accessory of Flo-Jo	0		Initiative: +100, Softcore Only
 793	moist blinking oil of stability	0		Effect: "Earthen Fist", Effect Duration: 30
 794	quantum oil of slipperiness	0		Effect: "Hopped Up on Goofballs", Effect Duration: 45
-795	high-proof fancy drinkable Acque Luride Grezze Cabernet	7	good	Effect: "Cockroach Scurry", Effect Duration: 50, Last Available: "2004-10"
+795	drinkable fancy high-proof Acque Luride Grezze Cabernet	7	good	Effect: "Cockroach Scurry", Effect Duration: 50, Last Available: "2004-10"
 796	Lo Pan's cement shoes of temperance of the businessman	0		Spell Critical Percent: +30, Sleaze Resistance: +5, Meat Drop: +50, Last Available: "2004-10"
-797	watered-down smooth mirror olive rockin' wagon	2	awesome	
-798	perfectly mixed weak green ocean motion	2	EPIC	
+797	watered-down smooth olive mirror rockin' wagon	2	awesome	
+798	weak perfectly mixed green ocean motion	2	EPIC	
 799	smooth blinking fuzzbump	4	awesome	
-800	immense adequate poutine	8	good	
+800	adequate immense poutine	8	good	
 801	bland green twirling Knob stir-fry	3	decent	
-804	low-calorie yummy ghostly Knoll stir-fry	1	awesome	
-805	spoiled thick stir-fry	5	crappy	
-806	rotten small asparagus stir-fry	2	crappy	
+804	yummy low-calorie ghostly Knoll stir-fry	1	awesome	
+805	thick spoiled stir-fry	5	crappy	
+806	small rotten asparagus stir-fry	2	crappy	
 807	yummy green olive stir-fry	4	awesome	
 808	half-sized rotten Knob sausage stir-fry	2	crappy	
-809	diet yummy narrow bat wing stir-fry	1	awesome	
-810	rotten huge rat appendix stir-fry	9	crappy	
+809	yummy diet narrow bat wing stir-fry	1	awesome	
+810	huge rotten rat appendix stir-fry	9	crappy	
 811	stale tofu stir-fry	4	decent	
 812	spoiled pr0n stir-fry	3	crappy	
-813	moldy immense teal wobbly Knob shells	10	crappy	
+813	moldy immense wobbly teal Knob shells	10	crappy	
 814	flavorless spinning b&auml;tzle	3	decent	
-815	special tasty half-sized upside-down ratini	2	awesome	Effect: "Red Around the Gills", Effect Duration: 15
+815	tasty special half-sized upside-down ratini	2	awesome	Effect: "Red Around the Gills", Effect Duration: 15
 816	stale super-sized Knob stroganoff	5	decent	
-817	diet adequate red menudo ravioli	1	good	
+817	adequate diet red menudo ravioli	1	good	
 818	spinning shaking plus sign	0		
 819	blinking milky potion	0		
 820	swirly potion	0		
@@ -831,7 +831,7 @@
 838	wobbly wool lard-coated Mafia stogie	0		Sleaze Spell Damage: +25, Cold Resistance: +1, Last Available: "2004-10"
 839	acceptable Maiali Sifilitici Pinot Noir	4	good	Last Available: "2004-10"
 840	jittery hardy Mafia violin case of chilblains	0		Maximum HP: +50, Cold Damage: +25, Last Available: "2004-10"
-841	drinkable irresponsibly strong tomato daiquiri	7	good	
+841	irresponsibly strong drinkable tomato daiquiri	7	good	
 842	mediocre beertini	3	decent	
 843	watered-down hand-crafted skewed salty slug	2	EPIC	
 844	hand-crafted papaya slung	4	EPIC	
@@ -844,7 +844,7 @@
 852	shaker of salt	0		Familiar Weight: +5
 853	blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
-855	mirror tumbling balloon knife	0		Familiar Weight: +5
+855	tumbling mirror balloon knife	0		Familiar Weight: +5
 856	pulsating shock collar	0		
 857	huge moonglasses	0		
 858	squat palm-frond toupee	0		Familiar Weight: +5
@@ -861,7 +861,7 @@
 870	gray sharpshooter's fetus-smashing club	0		Critical Hit Percent: +10
 871	meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
-873	twirling mirror rolling pin	0		
+873	mirror twirling rolling pin	0		
 874	unrolling pin	0		
 875	olive narrow veiny experienced groovy crazy bastard sword	0		Moxie Percent: +10, Experience: +2, Maximum HP: +10
 876	greasy frosty nippy incredibly dense meat gem	0		Cold Damage: +10, Cold Spell Damage: +10, Sleaze Spell Damage: +10
@@ -878,7 +878,7 @@
 887	leaf	0		
 888	maple leaf	0		
 889	narrow Annie Oakley's balaclava	0		Critical Hit Percent: +20, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	moldy tiny bouncing balaclava baklava	1	crappy	
+890	tiny moldy bouncing balaclava baklava	1	crappy	
 891	twirling lime green Warehouse 23 bling of the wise owl	0		Mysticality: +20
 892	narrow flame-retardant ruddy smooth bugbear-smiting sword	0		Moxie: +15, Maximum HP Percent: +40, Hot Resistance: +1
 893	perfectly mixed squat lumbering jack	3	EPIC	
@@ -895,12 +895,12 @@
 904	mirror family-friendly Samson's school Mafia knickerbockers of the brazier	0		Experience (Muscle): +5, Hot Spell Damage: +25, Sleaze Resistance: +1, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	dry extra-liquefied twirling Yummy Tummy bean	0		Effect: "On the Trolley", Effect Duration: 66
 906	wet ionized Rock Pops	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 48
-907	colloidal olive blinking Mr. Mediocrebar	0		Effect: "Thick-Skinned", Effect Duration: 25
+907	colloidal blinking olive Mr. Mediocrebar	0		Effect: "Thick-Skinned", Effect Duration: 25
 908	extra-ionized Cold Hots candy	0		Effect: "Squirming Like a Toad", Effect Duration: 11
 909	galvanized Wint-O-Fresh mint	0		Effect: "Blessing of Charcoatl", Effect Duration: 42
 910	moldy dwarf bread	4	crappy	
 911	tarnished ionized ghostly Senior Mints	0		Effect: "Rampage!", Effect Duration: 22
-912	modified twirling gray pixellated candy heart	0		Effect: "Gyromitra Gymnastics", Effect Duration: 15
+912	modified gray twirling pixellated candy heart	0		Effect: "Gyromitra Gymnastics", Effect Duration: 15
 913	tarnished aerosolized wobbly kobold	0		Effect: "Floundering", Effect Duration: 48
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	red yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -909,19 +909,19 @@
 918	Radio Free Baseball Cap of the cheetah	0		Initiative: +60, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
 919	spinning Jack Frost's Radio Free Pants	0		Cold Spell Damage: +50, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	purple sage Radio Free Foil	0		Mysticality Percent: +10, Last Available: "2006-07"
-921	flavorless huge radio button candy	7	decent	
+921	huge flavorless radio button candy	7	decent	
 922	censurious severed rocking horse head	0		Sleaze Resistance: +3
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
-926	improved huge shaking Hawking's Elixir of Brilliance	0		Effect: "Cold Hard Skin", Effect Duration: 34
+926	improved shaking huge Hawking's Elixir of Brilliance	0		Effect: "Cold Hard Skin", Effect Duration: 34
 927	tolerable gray Ferita Del Petto Zinfandel	4	good	Last Available: "2006-12"
 928	squat auspicious fuzzy bracelets	0		Item Drop: +10
 929	arse-shooting crossbow of bravery	0		Spooky Resistance: +5
-931	acceptable practically non-alcoholic enchanted spiced rum	1	good	Effect: "Vanity Rage", Effect Duration: 40
+931	enchanted acceptable practically non-alcoholic spiced rum	1	good	Effect: "Vanity Rage", Effect Duration: 40
 932	mediocre practically non-alcoholic mirror eggnog	1	decent	
 933	decent candy cane	3	good	
-934	flavorless bouncing teal gingerbread bugbear	3	decent	
+934	flavorless teal bouncing gingerbread bugbear	3	decent	
 935	prompt imitation nice watch	0		Adventures: +3, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -988,18 +988,18 @@
 1000	Meat maid	0		
 1002	occult Xlyinia's notebook	0		Spell Damage Percent: +25
 1003	ghostly soda water	0		
-1004	drinkable watered-down yellow bottle of tequila	2	good	
+1004	watered-down drinkable yellow bottle of tequila	2	good	
 1005	tolerable boxed wine	3	good	
 1006	normal special cherry	3	good	Effect: "Cheered Up", Effect Duration: 25
 1007	coconut shell of extreme caution	0		Monster Level: -25, Familiar Effect: "1xFairy, cap 7"
 1008	green wicked ice cubes	0		Spell Damage: +5
 1009	bad vodka martini	3	decent	
-1010	smooth watered-down whiskey and soda	2	awesome	
+1010	watered-down smooth whiskey and soda	2	awesome	
 1011	mediocre olive monkey wrench	4	decent	
 1012	drinkable olive tequila sunrise	3	good	
 1013	aged narrow margarita	3	awesome	
 1014	drinkable fuchsia strawberry wine	4	good	
-1015	watered-down special artisanal wine spritzer	2	EPIC	Effect: "Bricked-In", Effect Duration: 45
+1015	watered-down artisanal special wine spritzer	2	EPIC	Effect: "Bricked-In", Effect Duration: 45
 1016	lousy perpendicular hula	3	decent	
 1017	tolerable ducha de oro	3	good	
 1018	mediocre calle de miel	4	decent	
@@ -1017,7 +1017,7 @@
 1030	penguin whip of the storm	0		Maximum MP Percent: +40
 1031	stanky yak whip	0		Stench Spell Damage: +25
 1032	sage gnauga hide whip	0		Mysticality Percent: +10
-1033	upside-down huge gnauga hide	0		
+1033	huge upside-down gnauga hide	0		
 1034	pulsating hippo skin buckler of Flo-Jo	0		Initiative: +100, Damage Reduction: 5
 1035	penguin skin buckler of the glutton	0		Food Drop: +100, Damage Reduction: 5
 1036	jittery yakskin buckler of mayonnaise	0		Sleaze Spell Damage: +50, Damage Reduction: 5
@@ -1030,11 +1030,11 @@
 1044	shaking ghostly steel-toed string of beads	0		Damage Reduction: 9
 1045	twirling plastic bottle opener of the boozehound	0		Booze Drop: +100
 1046	scandalous traffic cone of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +5, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	aged enchanted triple-distilled N. O. Beer	10	awesome	Effect: "Phairly Balanced", Effect Duration: 10
+1047	aged triple-distilled enchanted N. O. Beer	10	awesome	Effect: "Phairly Balanced", Effect Duration: 10
 1048	denatured oyster egg	1		
 1049	powdered squat oyster egg	1		
 1050	powdered oyster egg	1		
-1051	olive upside-down plastic oyster egg	0		
+1051	upside-down olive plastic oyster egg	0		
 1052	compressed huge oyster egg	1		
 1053	denatured oyster egg	1		
 1054	diluted oyster egg	1		Effect: "Sappy Blood", Effect Duration: 50
@@ -1056,7 +1056,7 @@
 1070	dehydrated jittery oyster egg	1		
 1071	upside-down plastic oyster egg	0		
 1072	modified jittery skewed off-white oyster egg	1		Effect: "Wet Jaw", Effect Duration: 50
-1073	boiled fuchsia skewed mirror off-white oyster egg	1		
+1073	boiled skewed fuchsia mirror off-white oyster egg	1		
 1074	denatured cyan mirror off-white oyster egg	1		Effect: "Wax On Your Shoes", Effect Duration: 45
 1075	bouncing off-white plastic oyster egg	0		
 1076	dehydrated oyster egg	1		Effect: "Fishy", Effect Duration: 40
@@ -1124,7 +1124,7 @@
 1138	mushroom fermenting solution	0		
 1139	tolerable ghostly mushroom wine	3	good	
 1140	lousy cyan icy mushroom wine	3	decent	
-1141	special hand-crafted mushroom wine	3	EPIC	Effect: "No Worries", Effect Duration: 50
+1141	hand-crafted special mushroom wine	3	EPIC	Effect: "No Worries", Effect Duration: 50
 1142	tolerable pointy mushroom wine	3	good	
 1143	practically non-alcoholic perfectly mixed flat mushroom wine	1	super ultra mega turbo EPIC	
 1144	perfectly mixed cool mushroom wine	4	EPIC	
@@ -1132,7 +1132,7 @@
 1146	delicious fancy knoll mushroom wine	4	awesome	Effect: "5 Pounds Lighter", Effect Duration: 5
 1147	bad mushroom wine	3	decent	
 1148	bad shot of flower schnapps	4	decent	
-1149	fancy immense yummy twirling flower petal pie	7	awesome	Effect: "Black Eyes", Effect Duration: 35
+1149	immense yummy fancy twirling flower petal pie	7	awesome	Effect: "Black Eyes", Effect Duration: 35
 1150	bad bottle of single-barrel whiskey	3	decent	
 1151	pulsating fortified discarded plastic fork of mayonnaise	0		Damage Absorption: +60, Sleaze Spell Damage: +50
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1141,7 +1141,7 @@
 1155	twirling letter from King Ralph XI	0		
 1157	wholeberd of courage	0		Spooky Resistance: +3
 1158	alkaline warmed Meleegra&trade; pills	0		Effect: "Space Tripping", Effect Duration: 12
-1159	purple narrow mirror mariachi G-string	0		
+1159	mirror purple narrow mariachi G-string	0		
 1160	Herculean irate sombrero	0		Experience (Muscle): +1, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
 1162	ionized boiled handsomeness potion	0		Effect: "Fishy", Effect Duration: 63
@@ -1172,7 +1172,7 @@
 1187	deadly nightshade	0		
 1188	jittery lotus	0		
 1189	olive can of asparagus	0		
-1190	red spinning dodecapede	0		
+1190	spinning red dodecapede	0		
 1191	tumbling ghuol whelp	0		
 1192	zmobie	0		
 1193	huge Raggedy Hippy doll	0		
@@ -1185,11 +1185,11 @@
 1200	rotten massive mugcake	10	crappy	
 1201	huge flavorless mirror urinal cake	9	decent	
 1202	massive spoiled jittery Happy Birthday, Claude! cake	10	crappy	
-1203	rotten tumbling squat personalized birthday cake	3	crappy	
+1203	rotten squat tumbling personalized birthday cake	3	crappy	
 1204	spoiled blurry three-tiered wedding cake	3	crappy	
 1205	spoiled upside-down babycakes	3	crappy	
 1206	stale velvet cake	4	decent	
-1207	bland wobbly green congratulatory cake	3	decent	
+1207	bland green wobbly congratulatory cake	3	decent	
 1208	normal angel-food cake	4	good	
 1209	tasty devil's-food cake	4	awesome	
 1210	diet flavorless birthday party jellybean cheesecake	1	decent	
@@ -1224,7 +1224,7 @@
 1240	limburger biker boots	0		Familiar Weight: +5
 1241	carton of clove cigarettes	0		Familiar Weight: +5
 1242	tumbling deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
-1243	yellow skewed toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
+1243	skewed yellow toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
 1244	huge Glass Balls of the Goblin King of the dark arts	0		Spell Damage Percent: +100
 1245	Codpiece of the Goblin King of dire peril	0		Weapon Damage: +20, Single Equip
 1246	blurry fortified educational rib of the Bonerdagon of dire peril	0		Experience: +1, Weapon Damage: +20, Damage Absorption: +60
@@ -1291,7 +1291,7 @@
 1307	spinning calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
-1310	jittery ghostly funky fez	0		Familiar Weight: +5
+1310	ghostly jittery funky fez	0		Familiar Weight: +5
 1311	shaking comfy blanket	0		Last Available: "2005-10"
 1312	experienced Baron von Ratsworth's monocle	0		Experience: +2, Single Equip
 1313	bouncing executive Baron von Ratsworth's money clip	0		Meat Drop: +40, Single Equip
@@ -1313,7 +1313,7 @@
 1329	boxer's Dyspepsi-Cola shield	0		Muscle Percent: +10, Damage Reduction: 4
 1330	pulsating wobbly Dyspepsi-Cola fatigues of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "3.5xPotato, 3xVolley, cap 7"
 1331	Cloaca-Cola helmet of the wise owl	0		Mysticality: +20, Familiar Effect: "3xFairy, cap 7"
-1332	spinning red Cloaca-Cola knapsack	0		
+1332	red spinning Cloaca-Cola knapsack	0		
 1333	bouncing Dyspepsi-Cola knapsack	0		
 1334	Cloaca-Cola	0		
 1335	bouncing Dyspepsi grenade	0		
@@ -1348,8 +1348,8 @@
 1365	small spoiled tofurkey leg	2	crappy	
 1366	tasty tofurkey gravy	4	awesome	
 1367	moldy herbal stuffing	3	crappy	
-1368	spoiled tiny can-shaped gelatinous cranberry sauce	1	crappy	
-1369	bland diet upside-down yams	1	decent	
+1368	tiny spoiled can-shaped gelatinous cranberry sauce	1	crappy	
+1369	diet bland upside-down yams	1	decent	
 1370	rosewater-soaked rhinestone cowboy shirt	0		Stench Resistance: +3
 1371	Temple Grandin's gingham blouse	0		Familiar Weight: +7
 1372	spinning thinker's souvenir ski t-shirt	0		Mysticality: +10
@@ -1369,7 +1369,7 @@
 1387	block	0		
 1388	toy wheel	0		
 1389	yo-yo	0		Last Available: "2010-12"
-1390	blinking skewed top	0		Last Available: "2010-12"
+1390	skewed blinking top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
 1392	kite	0		Last Available: "2005-12"
 1393	gray pet rock	0		Last Available: "2005-12"
@@ -1387,10 +1387,10 @@
 1405	twirling greasy tree skirt	0		Sleaze Spell Damage: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	flavorless wreath-shaped Crimbo cookie	4	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	half-sized toothsome bell-shaped Crimbo cookie	2	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	spoiled immense skewed tree-shaped Crimbo cookie	7	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	immense spoiled skewed tree-shaped Crimbo cookie	7	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	frightening Unionize The Elves sign	0		Spooky Damage: +5, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	jittery Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	jittery Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	electrified snowcone	0		Effect: "Cravin' for a Ravin'", Effect Duration: 63, Last Available: "2006-01"
 1413	flattened triple-concentrated tumbling snowcone	0		Effect: "Stickler for Promptness", Effect Duration: 33, Last Available: "2006-01"
 1414	deionized snowcone	0		Effect: "Cinnamouth", Effect Duration: 69, Last Available: "2006-01"
@@ -1422,7 +1422,7 @@
 1440	colloidal powder	0		Effect: "Uncucumbered", Effect Duration: 26
 1441	activated pickled tumbling powder	0		Effect: "Staying Frosty", Effect Duration: 11
 1442	activated cyan stench powder	0		Effect: "Badger Underfoot", Effect Duration: 40
-1443	modified cyan narrow sleaze powder	0		Effect: "Burnt 'n' Turnt", Effect Duration: 60
+1443	modified narrow cyan sleaze powder	0		Effect: "Burnt 'n' Turnt", Effect Duration: 60
 1444	triple-tarnished dry twinkly nuggets	0		Effect: "Ghost Finger", Effect Duration: 69
 1445	wet oxidized blinking hot nuggets	0		Effect: "The Q Is Talking To You", Effect Duration: 41
 1446	energized alkaline nuggets	0		Effect: "Shredding, Sweating", Effect Duration: 50
@@ -1430,7 +1430,7 @@
 1448	galvanized dry stench nuggets	0		Effect: "Squatting and Thrusting", Effect Duration: 58
 1449	unsweetened flattened irradiated teal sleaze nuggets	0		Effect: "Wit Tea", Effect Duration: 64
 1450	distilled ghostly twinkly wad	1		Effect: "Adventurer's Best Friendship", Effect Duration: 40
-1451	vaporized tumbling upside-down twirling hot wad	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 35
+1451	vaporized twirling upside-down tumbling hot wad	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 35
 1452	boiled wobbly ghostly wad	1		
 1453	altered wad	1		Effect: "Burnt 'n' Turnt", Effect Duration: 40
 1454	modified narrow stench wad	1		
@@ -1452,7 +1452,7 @@
 1470	lead yo-yo	0		
 1471	slightly peevedbow	0		
 1472	huge sack of doorknobs	0		
-1473	cyan mirror ball-and-chain	0		
+1473	mirror cyan ball-and-chain	0		
 1474	automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
@@ -1468,7 +1468,7 @@
 1486	olive huge massive bag of catnip	0		
 1487	olive hang glider	0		
 1488	March hat	0		Free Pull
-1489	mirror twirling dormouse	0		
+1489	twirling mirror dormouse	0		
 1490	scorching chilly chopsticks	0		Cold Damage: +5, Hot Damage: +25
 1491	lime green occult rice bowl	0		Spell Damage Percent: +25
 1492	narrow groovy ninja mop	0		Moxie Percent: +10
@@ -1477,23 +1477,23 @@
 1495	rosy-cheeked traffic cone of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	drinkable fuchsia gloomy mushroom wine	3	good	
 1497	lousy mushroom wine	4	decent	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
-1501	frozen adjusted quantum jittery spinning explosion-flavored chewing gum	0		Effect: "Fit To Be Tide", Effect Duration: 18, Last Available: "2006-04"
+1501	frozen adjusted quantum spinning jittery explosion-flavored chewing gum	0		Effect: "Fit To Be Tide", Effect Duration: 18, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	double-nitrogenated activated snowcone	0		Effect: "Ticking Clock", Effect Duration: 22, Last Available: "2006-04"
 1505	blinking ice cube with a fly in it	0		Last Available: "2006-04"
-1506	fortified drinkable upside-down tumbling calle de miel with a fly in it	5	good	Last Available: "2006-04"
+1506	drinkable fortified tumbling upside-down calle de miel with a fly in it	5	good	Last Available: "2006-04"
 1507	hand-crafted purple rockin' wagon with a fly in it	3	EPIC	Last Available: "2006-04"
 1508	acceptable tumbling perpendicular hula with a fly in it	4	good	Last Available: "2006-04"
-1509	drinkable spinning blurry slap and tickle with a fly in it	3	good	Last Available: "2006-04"
+1509	drinkable blurry spinning slap and tickle with a fly in it	3	good	Last Available: "2006-04"
 1510	bouncing bag of airline peanuts	0		Last Available: "2006-04"
 1511	extremely unsafe fake hand	0		Weapon Damage Percent: +100, Last Available: "2006-04"
 1512	twisted mirror Knob Goblin pet-buffing spray	1		
-1513	powdered mirror skewed Knob Goblin learning pill	1		Effect: "Bananas!", Effect Duration: 20
-1514	dried huge lime green spinning Knob Goblin eyedrops	1		
+1513	powdered skewed mirror Knob Goblin learning pill	1		Effect: "Bananas!", Effect Duration: 20
+1514	dried lime green spinning huge Knob Goblin eyedrops	1		
 1515	diluted upside-down Knob Goblin nasal spray	1		
 1516	blinking KWE-brand transistor radio	0		
 1518	blurry vampire heart	0		
@@ -1513,7 +1513,7 @@
 1532	grass hat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	resourceful grass blade	0		Maximum MP: +50, Last Available: "2011-01"
 1534	purple raffle prize box	0		
-1536	fuchsia pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
+1536	pulsating fuchsia homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	shellacked sparkly engagement ring	0		Damage Reduction: 7, Single Equip
 1539	mirror Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
@@ -1529,25 +1529,25 @@
 1549	ghostly MSG	0		
 1550	veiny second-hand knockoff engagement ring	0		Maximum HP: +10, Single Equip
 1551	tolerable blinking bottle of Domesticated Turkey	4	good	
-1552	practically non-alcoholic drinkable fuchsia bottle of Definit	1	good	
+1552	drinkable practically non-alcoholic fuchsia bottle of Definit	1	good	
 1553	delicious bottle of Calcutta Emerald	3	awesome	
 1554	hand-crafted high-proof bottle of Lieutenant Freeman	10	EPIC	
-1555	practically non-alcoholic mediocre ghostly yellow wobbly bottle of Jorge Sinsonte	1	decent	
-1556	smooth weak boxed champagne	2	awesome	
+1555	mediocre practically non-alcoholic wobbly ghostly yellow bottle of Jorge Sinsonte	1	decent	
+1556	weak smooth boxed champagne	2	awesome	
 1557	bland special blurry kumquat	4	decent	Effect: "Warm Belly", Effect Duration: 50
-1558	moldy half-sized tangerine	2	crappy	
+1558	half-sized moldy tangerine	2	crappy	
 1559	tonic water	0		
-1560	immense stale skewed cocktail onion	7	decent	
+1560	stale immense skewed cocktail onion	7	decent	
 1561	gigantic spoiled raspberry	9	crappy	
 1562	flavorless kiwi	3	decent	
 1563	weak hand-crafted skewed whiskey bittersweet	2	EPIC	
 1564	acceptable mimosette	4	good	
-1565	aged practically non-alcoholic bouncing tequila sunset	1	awesome	
+1565	practically non-alcoholic aged bouncing tequila sunset	1	awesome	
 1566	smooth zmobie	3	awesome	Wiki Name: "Zmobie (drink)"
-1567	practically non-alcoholic tolerable gin and tonic	1	good	
-1568	practically non-alcoholic tolerable vodka and tonic	1	good	
+1567	tolerable practically non-alcoholic gin and tonic	1	good	
+1568	tolerable practically non-alcoholic vodka and tonic	1	good	
 1569	lousy practically non-alcoholic vodka gibson	1	decent	
-1570	weak smooth blinking gibson	2	awesome	
+1570	smooth weak blinking gibson	2	awesome	
 1571	bad mirror parisian cathouse	4	decent	
 1572	delicious jittery rabbit punch	3	awesome	
 1573	drinkable weak upside-down caipifruta	2	good	
@@ -1557,29 +1557,29 @@
 1577	acceptable narrow tangarita	4	good	
 1578	watered-down drinkable jittery mandarina colada	2	good	
 1579	drinkable gimlet	4	good	
-1580	bad weak brick road	2	decent	
-1581	watered-down lousy vodka stratocaster	2	decent	
+1580	weak bad brick road	2	decent	
+1581	lousy watered-down vodka stratocaster	2	decent	
 1582	drinkable Neuromancer	4	good	
 1583	tolerable green prussian cathouse	4	good	
 1584	bad Mae West	3	decent	
 1585	hand-crafted practically non-alcoholic Mon Tiki	1	super ultra mega turbo EPIC	
 1586	bad teqiwila slammer	4	decent	
 1587	adequate spinning Knob lo mein	4	good	
-1588	flavorless huge asparagus lo mein	6	decent	
-1589	fancy thick flavorless Knoll lo mein	5	decent	Effect: "A Few Extra Pounds", Effect Duration: 20
-1590	moldy thick blinking squat lo mein	5	crappy	
+1588	huge flavorless asparagus lo mein	6	decent	
+1589	flavorless thick fancy Knoll lo mein	5	decent	Effect: "A Few Extra Pounds", Effect Duration: 20
+1590	moldy thick squat blinking lo mein	5	crappy	
 1591	stale olive lo mein	4	decent	
 1592	flavorless hot hi mein	4	decent	
 1593	stale narrow hi mein	3	decent	
 1594	moldy hi mein	3	crappy	
 1595	half-sized stale blurry tumbling hi mein	2	decent	
-1596	special normal sleazy hi mein	4	good	Effect: "The Magic of LOV", Effect Duration: 40
+1596	normal special sleazy hi mein	4	good	Effect: "The Magic of LOV", Effect Duration: 40
 1597	mirror fireproof Junior LAAAAME merit badge	0		Hot Resistance: +3, Last Available: "2006-05"
 1598	double-paned Senior LAAAAME merit badge	0		Cold Resistance: +5, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	weak delicious tangarita with a fly in it	2	awesome	
-1601	acceptable fortified mandarina colada with a fly in it	5	good	
-1602	bad boozy enchanted prussian cathouse with a fly in it	5	decent	Effect: "Space Tripping", Effect Duration: 45
+1600	delicious weak tangarita with a fly in it	2	awesome	
+1601	fortified acceptable mandarina colada with a fly in it	5	good	
+1602	boozy bad enchanted prussian cathouse with a fly in it	5	decent	Effect: "Space Tripping", Effect Duration: 45
 1603	acceptable Mae West with a fly in it	3	good	
 1604	denatured astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1587,9 +1587,9 @@
 1607	corrupted libation of liveliness	0		Effect: "Fudgehound", Effect Duration: 13
 1608	colloidal twirling blurry eyedrops of the ermine	0		Effect: "Bells in the Batfry", Effect Duration: 64
 1609	tarnished perfume of prejudice	0		Effect: "Superheroic", Effect Duration: 69
-1610	boiled ghostly upside-down green eyedrops of the ocelot	0		Effect: "Pwnd", Effect Duration: 51
+1610	boiled upside-down ghostly green eyedrops of the ocelot	0		Effect: "Pwnd", Effect Duration: 51
 1611	enhanced potent potion of potency	0		Effect: "Greasy Flavor", Effect Duration: 20
-1612	magnetized wet blue pulsating huge concentrated cordial of concentration	0		Effect: "Human-Machine Hybrid", Effect Duration: 39
+1612	magnetized wet pulsating huge blue concentrated cordial of concentration	0		Effect: "Human-Machine Hybrid", Effect Duration: 39
 1613	stiffened coffin lid	0		Damage Reduction: 4
 1614	Temple Grandin's satin shield	0		Familiar Weight: +7, Damage Reduction: 5
 1615	Oprah's Cerebral Cloche	0		Maximum MP Percent: +50, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
@@ -1648,7 +1648,7 @@
 1668	rosewater-soaked star boomerang	0		Stench Resistance: +3
 1669	skewed Fonzie's star stiletto	0		Experience (Moxie): +1
 1670	spinning fraudwort	0		
-1671	tumbling narrow shysterweed	0		
+1671	narrow tumbling shysterweed	0		
 1672	huge swindleblossom	0		
 1673	personal trainer's grave robbing shovel of horror	0		Experience Percent (Muscle): +10, Spooky Spell Damage: +25
 1674	friendly superhero mask	0		Familiar Weight: +3, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
@@ -1673,7 +1673,7 @@
 1693	quadruple-colloidal double-concentrated huge eyedrops of newt	0		Effect: "Demonic Flavor", Effect Duration: 40
 1694	ionized Frogade	0		Effect: "Impregnabili Tea", Effect Duration: 41
 1695	moist papotion of papower	0		Effect: "Permafrosty", Effect Duration: 17
-1696	decent huge royal jelly taco	8	good	
+1696	huge decent royal jelly taco	8	good	
 1697	miniature bland tofu taco	2	decent	
 1698	moldy blue jumping bean taco	4	crappy	
 1699	normal blinking catgut taco	4	good	
@@ -1744,13 +1744,13 @@
 1765	Spookyraven gallery key	0		
 1766	Spookyraven ballroom key	0		
 1767	narrow pack of chewing gum	0		
-1768	mirror spinning Gnomish toolbox	0		
+1768	spinning mirror Gnomish toolbox	0		
 1769	flavorless fricasseed brains	4	decent	
-1770	stale tiny fancy brains casserole	1	decent	Effect: "Elemental Mastery", Effect Duration: 25
+1770	fancy stale tiny brains casserole	1	decent	Effect: "Elemental Mastery", Effect Duration: 25
 1771	butcherknife of the wise owl	0		Mysticality: +20
 1772	frosty corn holder	0		Cold Spell Damage: +10
 1773	tumbling eggbeater of the bloodbag	0		Maximum HP: +100
-1774	fancy drinkable practically non-alcoholic bouncing bottle of popskull	1	good	Effect: "Rampage!", Effect Duration: 25
+1774	practically non-alcoholic drinkable fancy bouncing bottle of popskull	1	good	Effect: "Rampage!", Effect Duration: 25
 1775	spinning cool dishrag	0		Moxie: +5
 1776	moldy half-sized stale baguette	2	crappy	
 1777	leftovers of indeterminate origin	0		
@@ -1766,7 +1766,7 @@
 1787	oxidized dry dry upside-down bag of Cheat-Os	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 34
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	artisanal distilled Ram's Face Lager	5	EPIC	
+1790	distilled artisanal Ram's Face Lager	5	EPIC	
 1791	ram horns	0		
 1792	jittery wobbly arcane researcher's Travoltan trousers of Flo-Jo	0		Experience Percent (Mysticality): +10, Item Drop: +5, Initiative: +100, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	blurry family-friendly frosty pool cue	0		Cold Spell Damage: +10, Sleaze Resistance: +1
@@ -1782,14 +1782,14 @@
 1803	upside-down second cervical vertebra	0		
 1804	pulsating third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
-1806	olive blinking fifth cervical vertebra	0		
+1806	blinking olive fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
 1809	pulsating first thoracic vertebra	0		
 1810	blinking second thoracic vertebra	0		
 1811	third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
-1813	squat red fifth thoracic vertebra	0		
+1813	red squat fifth thoracic vertebra	0		
 1814	wobbly fuchsia sixth thoracic vertebra	0		
 1815	skewed seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
@@ -1853,7 +1853,7 @@
 1874	left femur	0		
 1875	wobbly right femur	0		
 1876	left tibia	0		
-1877	mirror tumbling right tibia	0		
+1877	tumbling mirror right tibia	0		
 1878	fuchsia pulsating left fibula	0		
 1879	right fibula	0		
 1880	left kneecap	0		
@@ -1874,7 +1874,7 @@
 1895	left fourth rear claw	0		
 1896	ghostly right first rear claw	0		
 1897	right second rear claw	0		
-1898	bouncing mirror right third rear claw	0		
+1898	mirror bouncing right third rear claw	0		
 1899	twirling right fourth rear claw	0		
 1900	hale 1-ball	0		Maximum HP: +20
 1901	wobbly 2-ball of the dark arts of the sewer	0		Spell Damage Percent: +100, Stench Damage: +25
@@ -1888,7 +1888,7 @@
 1911	mirror miser's perfumed therapeutic clockwork staff	0		Stench Resistance: +5, Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7
 1912	fuchsia skewed gravedigger's wicked clockwork crossbow of wisdom	0		Mysticality: +15, Spell Damage: +5, Spooky Damage: +10
 1913	clockwork handle	0		
-1914	maroon squat clockwork rod	0		
+1914	squat maroon clockwork rod	0		
 1915	gray clockwork shank	0		
 1916	jittery Lord Spookyraven's spectacles	0		
 1917	wallet	0		
@@ -1923,16 +1923,16 @@
 1946	accordion pin of the brute of terror	0		Muscle Percent: +30, Spooky Spell Damage: +10, Class: "Accordion Thief", Single Equip
 1947	twirling purple occult beefcake's worn tophat	0		Muscle: +25, Spell Damage Percent: +25, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	squat dangerous tap shoes of the glutton	0		Weapon Damage: +10, Food Drop: +100, Single Equip
-1949	half-sized decent Manetwich	2	good	
+1949	decent half-sized Manetwich	2	good	
 1950	bottle of Vangoghbitussin	0		
 1951	strong artisanal red bottle of Pinot Renoir	5	EPIC	
 1952	flavorless desiccated apricot	3	decent	
-1953	strong mediocre bouncing flute of flat champagne	5	decent	
+1953	mediocre strong bouncing flute of flat champagne	5	decent	
 1954	tasty dehydrated caviar	3	awesome	
 1955	mirror fuchsia styrofoam peanuts	0		
 1956	artisanal snifter of thoroughly aged brandy	4	EPIC	
 1957	quill pen	0		
-1958	pulsating ghostly inkwell	0		
+1958	ghostly pulsating inkwell	0		
 1959	tattered scrap of paper	0		
 1960	yellow scroll of forbidden unspeakable evil	0		
 1961	blurry can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
@@ -1945,12 +1945,12 @@
 1968	shaking blurry bottle of perfume	0		Familiar Weight: +5
 1969	spoon!	0		Familiar Weight: +5
 1970	twirling nervous tick egg	0		Free Pull, Last Available: "2007-10"
-1971	shaking teal plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
+1971	teal shaking plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	mirror ribald horrifying shrimp fork	0		Spooky Damage: +25, Sleaze Damage: +10
 1973	gray half of a memo	0		
 1974	blurry cocoabo	0		
 1975	baby gravy fairy	0		
-1976	pulsating yellow gravy fairy	0		
+1976	yellow pulsating gravy fairy	0		
 1977	gravy fairy	0		
 1978	gravy fairy	0		
 1979	gravy fairy	0		
@@ -1959,7 +1959,7 @@
 1982	MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	snowy owl	0		
-1985	mirror yellow scary death orb	0		
+1985	yellow mirror scary death orb	0		
 1986	pulsating mind flayer	0		
 1987	undead elbow macaroni	0		
 1988	angry cow	0		
@@ -1994,12 +1994,12 @@
 2017	lime green spade necklace	0		
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
-2020	spoiled super-sized cherry pie	5	crappy	
+2020	super-sized spoiled cherry pie	5	crappy	
 2021	spoiled snack-sized strawberry pie	2	crappy	
 2022	gigantic bland shaking lemon meringue pie	8	decent	
 2023	Genalen&trade; Bottle	1	decent	
-2024	gigantic rotten spinning mixed wildflower greens	8	crappy	
-2025	spoiled bite-sized fuchsia handful of walnuts	1	crappy	
+2024	rotten gigantic spinning mixed wildflower greens	8	crappy	
+2025	bite-sized spoiled fuchsia handful of walnuts	1	crappy	
 2026	stale nutty organic salad	3	decent	
 2027	small flavorless super salad	2	decent	
 2028	huge toothsome tofu wonton	7	awesome	
@@ -2011,7 +2011,7 @@
 2034	cyan mirror thinker's wicker shield	0		Mysticality: +10, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
 2036	altered radium-flavored potato chips	0		Effect: "Grumpy and Ornery", Effect Duration: 65
-2037	unsweetened pickled dry olive narrow huge wintergreen-flavored potato chips	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 44
+2037	unsweetened pickled dry huge narrow olive wintergreen-flavored potato chips	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 44
 2038	extra-pickled tumbling ennui-flavored potato chips	0		Effect: "Burning Hands", Effect Duration: 17
 2039	ghostly x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
@@ -2020,9 +2020,9 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	flavorless special brain-meltingly-hot chicken wings	4	decent	Effect: "Neuromancy", Effect Duration: 40
-2046	normal immense upside-down frat brats	7	good	
+2046	immense normal upside-down frat brats	7	good	
 2047	decent knob ka-bobs	3	good	
-2049	weak perfectly mixed can of Swiller	2	EPIC	
+2049	perfectly mixed weak can of Swiller	2	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
@@ -2036,7 +2036,7 @@
 2060	ribald frightening sword	0		Spooky Damage: +5, Sleaze Damage: +10
 2061	cyan upside-down helmet of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xFairy, cap 40"
 2062	pulsating squat padded beefy shield	0		Muscle: +10, Damage Absorption: +20, Damage Reduction: 10
-2063	yummy huge blackberry	10	awesome	
+2063	huge yummy blackberry	10	awesome	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	thinker's kick-ass kicks of the cheetah	0		Mysticality: +10, Initiative: +60, Single Equip
@@ -2060,14 +2060,14 @@
 2084	can of starch	0		
 2085	vaporized bottle of ultravitamins	1		
 2086	altered bottle of cough syrup	1		
-2087	denatured blinking fuchsia tube of hair oil	1		
+2087	denatured fuchsia blinking tube of hair oil	1		
 2088	pickled Vulcanized Daffy Taffy	0		Effect: "Helping Comes Second", Effect Duration: 28
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	wool ruddy dangerous pilgrim shield of the bloodbag of bravery	0		Weapon Damage: +10, Maximum HP Percent: +40, Maximum HP: +100, Cold Resistance: +1, Spooky Resistance: +5, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	shaking bath salts	0		
 2092	hand mirror	0		
 2093	twirling shellacked hors d'oeuvre tray	0		Damage Reduction: 12
-2094	bite-sized adequate bouncing ballroom blintz	1	good	
+2094	adequate bite-sized bouncing ballroom blintz	1	good	
 2095	towel	0		
 2096	diluted guy made of bee pollen	1		
 2097	scandalous 17-ball	0		Sleaze Damage: +5
@@ -2087,7 +2087,7 @@
 2111	tooth	0		
 2112	blinking leaf	0		Last Available: "2011-12"
 2113	blue occult wheel	0		Spell Damage Percent: +25, Last Available: "2006-12"
-2114	spinning narrow yo	0		Last Available: "2006-12"
+2114	narrow spinning yo	0		Last Available: "2006-12"
 2115	maroon prehistoric spear of temperance	0		Sleaze Resistance: +5, Last Available: "2006-12"
 2116	lime green stick-on-a-string	0		Last Available: "2006-12"
 2117	extremely unsafe fire of the glutton	0		Weapon Damage Percent: +100, Food Drop: +100, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
@@ -2127,7 +2127,7 @@
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	teal carbon nanotube frame	0		Last Available: "2011-12"
 2154	red ion grid	0		Last Available: "2011-12"
-2155	yellow tumbling Feynman gate	0		Last Available: "2011-12"
+2155	tumbling yellow Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
@@ -2137,7 +2137,7 @@
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
-2165	wobbly ghostly atomic vector plotter	0		Last Available: "2011-12"
+2165	ghostly wobbly atomic vector plotter	0		Last Available: "2011-12"
 2166	fuchsia ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	curative wicked toy ray gun	0		Spell Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-12"
@@ -2168,7 +2168,7 @@
 2193	normal gray candy stake	3	good	Last Available: "2006-12"
 2194	artisanal eggnog	3	EPIC	Last Available: "2006-12"
 2195	moldy unspeakable fruitcake	3	crappy	Last Available: "2006-12"
-2196	stale huge gingerbread horror	8	decent	Last Available: "2006-12"
+2196	huge stale gingerbread horror	8	decent	Last Available: "2006-12"
 2197	ionized twirling but probably evil chocolate	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 13, Last Available: "2006-12"
 2198	flavorless bat-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	adequate massive skull-shaped Crimboween cookie	7	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2185,19 +2185,19 @@
 2210	pulsating toasty supercool Tiki lighter	0		Moxie Percent: +20, Hot Damage: +5, Stat Tuning: "Moxie", Last Available: "2006-12"
 2211	brawny deck of tropical cards of Calamity Jane	0		Muscle Percent: +20, Critical Hit Percent: +15, Stat Tuning: "Mysticality", Last Available: "2006-12"
 2212	resourceful tropical paperweight of terror	0		Maximum MP: +50, Spooky Spell Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
-2213	maroon jittery bouncing tropical Crimbo pressie	0		Last Available: "2006-12"
+2213	bouncing maroon jittery tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	lime green tropical wrapping paper	0		Last Available: "2006-12"
 2215	banded Tropical Crimbo Hat	0		Damage Absorption: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	Tropical Crimbo Shorts of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	half-sized bland super ka-bob	2	decent	
-2218	snack-sized toothsome beer basted brat	2	awesome	
+2218	toothsome snack-sized beer basted brat	2	awesome	
 2219	shellacked Tropical Crimbo Sword	0		Damage Reduction: 7, Last Available: "2006-12"
 2220	nitrogenated quadruple-ionized and Crimboween candy	0		Effect: "You Know Who to Call", Effect Duration: 57, Last Available: "2020-09"
 2221	wobbly Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	savvy sage liar's pants	0		Mysticality Percent: 30, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	frightening Sinatra's juggler's balls	0		Experience (Moxie): +5, Spooky Damage: +5, Softcore Only, Last Available: "2007-01"
 2224	fuchsia beefcake's pink shirt	0		Muscle: +25, Softcore Only, Last Available: "2007-01"
-2225	squat blue familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
+2225	blue squat familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	nasty deadly evil eyeball pendant	0		Weapon Damage: +5, Stench Damage: +5, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	double-polarized green arse-a'fire elixir	0		Effect: "Hyperoxygenated Blood", Effect Duration: 53, Last Available: "2007-01"
 2228	extra-alkaline galvanized cosmic lemonade	0		Effect: "Craft Tea", Effect Duration: 27, Last Available: "2007-01"
@@ -2229,14 +2229,14 @@
 2255	chilly furry turtle	0		Cold Damage: +5, Familiar Effect: "2xPotato, 2xFairy, cap 11"
 2256	squat Sherlock's furry earmuffs	0		Item Drop: +25
 2257	bouncing prompt reinforced furry underpants of mayonnaise	0		Sleaze Spell Damage: +50, Adventures: +3
-2258	olive shaking &quot;I Love Me, Vol. I&quot;	0		
+2258	shaking olive &quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
 2260	skewed hard rock candy	0		
 2261	spinning hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
 2264	spoiled bite-sized mirror stunt nuts	1	crappy	
-2265	jumbo toothsome wobbly bouncing wet stew	5	awesome	
+2265	jumbo toothsome bouncing wobbly wet stew	5	awesome	
 2266	mirror wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	fuchsia twirling sage Staff of Fats	0		Mysticality Percent: +10
@@ -2269,12 +2269,12 @@
 2295	tumbling marinated stakes	0		
 2296	knob butter	0		
 2297	vial of ectoplasm	0		
-2298	wobbly squat boock of darck magicks	0		
+2298	squat wobbly boock of darck magicks	0		
 2299	EZ-Play Harmonica Book	0		
 2300	narrow spinning fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	boiled candy heart	0		Effect: "Ticking Clock", Effect Duration: 32, Last Available: "2007-02"
 2305	wet gray pink candy heart	0		Effect: "Shawarma Warm War", Effect Duration: 67, Last Available: "2007-02"
 2306	polarized double-frozen red candy heart	0		Effect: "Mortarfied", Effect Duration: 11, Last Available: "2007-02"
@@ -2310,10 +2310,10 @@
 2336	squat fuchsia Jim Carey's pipe of the storm	0		Maximum MP Percent: +40, Monster Level: +25
 2337	frosty reinforced beaded headband	0		Cold Spell Damage: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	decent pudding	4	good	Wiki Name: "black pudding (food)"
-2339	irresponsibly strong perfectly mixed twirling olive Blackfly Chardonnay	6	EPIC	
+2339	perfectly mixed irresponsibly strong olive twirling Blackfly Chardonnay	6	EPIC	
 2340	perfectly mixed red & tan	3	EPIC	
 2341	pepper	0		
-2342	moldy blurry skewed cyan forest cake	3	crappy	
+2342	moldy cyan skewed blurry forest cake	3	crappy	
 2343	tasty yellow forest ham	4	awesome	
 2344	polymerized frozen pulsating filthworm hatchling scent gland	0		Effect: "Cake Caked", Effect Duration: 38
 2345	polymerized filthworm drone scent gland	0		Effect: "In Vino Vires", Effect Duration: 11
@@ -2346,7 +2346,7 @@
 2372	bunch of bananas	0		
 2373	stale huge spinning banana	7	decent	
 2374	narrow gray banana peel	0		
-2375	enchanted bland jittery banana cream pie	3	decent	Effect: "You Know Where to Go", Effect Duration: 30
+2375	bland enchanted jittery banana cream pie	3	decent	Effect: "You Know Where to Go", Effect Duration: 30
 2376	artisanal shaking banana daiquiri	3	EPIC	
 2377	mediocre bungle in the jungle	3	decent	
 2378	skewed banana spritzer	0		
@@ -2367,7 +2367,7 @@
 2393	Herculean wreath of laurels of the sewer	0		Experience (Muscle): +1, Stench Damage: +25, Familiar Effect: "0.5xLep, 0.5xFairy"
 2394	supercharged Danglin' Chad's loincloth of the businessman	0		Maximum MP Percent: +30, Meat Drop: +50, Familiar Effect: "stench atk, 0.5xVolley"
 2395	cool tube sock	0		Moxie: +5, Single Equip
-2396	narrow squat chloroform rag	0		
+2396	squat narrow chloroform rag	0		
 2397	depantsing bomb	0		
 2398	toasty energy drink IV	0		Hot Damage: +5, Single Equip
 2399	thinker's Elmley shades of the storm	0		Mysticality: +10, Maximum MP Percent: +40, Single Equip
@@ -2391,7 +2391,7 @@
 2417	zippy bounty-hunting rifle	0		Initiative: +20
 2418	squat bounty-hunting pants of courage	0		Spooky Resistance: +3, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	electrified deionized blinking cyan bottle of rhinoceros hormones	0		Effect: "Hot Blooded", Effect Duration: 20
-2420	magnetized maroon huge teeny-tiny magic scroll	0		Effect: "The Smeezingtons", Effect Duration: 20
+2420	magnetized huge maroon teeny-tiny magic scroll	0		Effect: "The Smeezingtons", Effect Duration: 20
 2421	anodized triple-moist bottle of pirate juice	0		Effect: "Mystic Circle", Effect Duration: 50
 2422	denatured wet unsweetened huge irradiated pet snacks	0		Effect: "New Zeal", Effect Duration: 50
 2423	modified Mick's IcyVapoHotness Inhaler	0		Effect: "Extra Terrestrial", Effect Duration: 68
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	nasty Socratic pink glowstick	0		Experience (Mysticality): +1, Stench Damage: +5, Last Available: "2007-03"
-2444	weak mediocre Supernova Champagne	2	decent	
+2444	mediocre weak Supernova Champagne	2	decent	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	fuchsia bad penguin egg	0		Free Pull
@@ -2434,8 +2434,8 @@
 2460	manspreader's yak toupee	0		Monster Level: +10, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	moldy low-calorie twirling bowl of Bounty-Os	1	crappy	
-2465	lousy watered-down Oreille Divis&eacute;e brandy	2	decent	
+2464	low-calorie moldy twirling bowl of Bounty-Os	1	crappy	
+2465	watered-down lousy Oreille Divis&eacute;e brandy	2	decent	
 2466	ghostly pompadour'd puppy	0		
 2467	pulsating ghostly suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2490,14 +2490,14 @@
 2517	spinning zippy chain necklace of the cougar	0		Moxie: +20, Initiative: +20
 2518	fortified sawblade shield	0		Damage Absorption: +60, Damage Reduction: 11
 2519	lousy McMillicancuddy's Special Lager	4	decent	
-2520	delicious practically non-alcoholic melted Jell-o shot	1	awesome	
+2520	practically non-alcoholic delicious melted Jell-o shot	1	awesome	
 2521	irresponsibly strong acceptable cruelty-free wine	7	good	
 2522	mediocre thistle wine	4	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	stale fish	3	decent	
 2526	rotten fish casserole	3	crappy	
-2527	miniature decent fish lasagna	2	good	
+2527	decent miniature fish lasagna	2	good	
 2528	mirror filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	jumbo normal green gnatloaf	5	good	
 2530	toothsome upside-down gnatloaf casserole	4	awesome	
@@ -2559,7 +2559,7 @@
 2586	asbestos-lined General Sage's Lonely Diamonds Club Jacket	0		Hot Resistance: +5
 2587	blue extremely unsafe Corporal Fennel's Lonely Clubs Club Jacket	0		Weapon Damage Percent: +100
 2588	mirror frosty Private Pepper's Lonely Hearts Club Jacket	0		Cold Spell Damage: +10
-2589	bland bite-sized hot date	1	decent	
+2589	bite-sized bland hot date	1	decent	
 2590	fortified artisanal distilled fortified wine	5	EPIC	
 2591	huge bland tasty tart	7	decent	
 2592	Knob Goblin lunchbox	0		
@@ -2590,7 +2590,7 @@
 2617	boom	0		
 2618	Iiti Kitty phone charm of Flo-Jo	0		Initiative: +100, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	half-sized bland squat unidentified jerky	2	decent	
+2620	bland half-sized squat unidentified jerky	2	decent	
 2621	twirling blurry lightning-fast auspicious nasty rat mask	0		Item Drop: +10, Initiative: +40, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	censurious mansplainer's ratskin belt	0		Monster Level: +15, Sleaze Resistance: +3, Single Equip
 2623	up-at-dawn supercool rattail whip	0		Moxie Percent: +20, Adventures: +5
@@ -2622,12 +2622,12 @@
 2649	blurry nippy Lord Spookyraven's ear trumpet	0		Cold Damage: +10, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	half-sized bland wobbly S.T.L.T.	2	decent	Last Available: "2007-06"
+2652	bland half-sized wobbly S.T.L.T.	2	decent	Last Available: "2007-06"
 2653	stale blinking honey-dew	4	decent	Last Available: "2007-06"
 2654	weak artisanal Xanadian	2	EPIC	Last Available: "2007-06"
 2655	unsweetened shaking bottle of absinthe	0		Effect: "Purpose", Effect Duration: 68, Last Available: "2007-06"
 2656	Annie Oakley's Drowsy Sword of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +20
-2657	flavorless jumbo escargotsicle	5	decent	Last Available: "2007-06"
+2657	jumbo flavorless escargotsicle	5	decent	Last Available: "2007-06"
 2658	acceptable bottle of realpagne	3	good	Last Available: "2007-06"
 2659	beefy albatross necklace	0		Muscle: +10, Single Equip, Last Available: "2007-06"
 2660	boiled green pulsating not-a-pipe	1	crappy	Effect: "Flamibili Tea", Effect Duration: 15, Last Available: "2007-06"
@@ -2638,10 +2638,10 @@
 2665	nitrogenated nitrogenated bottled inspiration	0		Effect: "Coal-Powered", Effect Duration: 41, Last Available: "2007-06"
 2666	vacuum-sealed energized bellhop bell	0		Effect: "Thunderheart", Effect Duration: 54, Last Available: "2007-06"
 2667	polarized wobbly spiky collar	0		Effect: "Charrrming", Effect Duration: 60, Last Available: "2007-06"
-2668	altered pulsating huge red can-can-in-a-can	1		Last Available: "2007-06"
+2668	altered pulsating red huge can-can-in-a-can	1		Last Available: "2007-06"
 2669	denatured upside-down patent antipsychotics	1		Last Available: "2007-06"
-2670	dried green jittery Mariner's Friend cough drops	1		Effect: "Ooh, Umami!", Effect Duration: 45, Last Available: "2007-06"
-2671	weak mediocre purple shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
+2670	dried jittery green Mariner's Friend cough drops	1		Effect: "Ooh, Umami!", Effect Duration: 45, Last Available: "2007-06"
+2671	mediocre weak purple shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
 2672	green library card	0		Last Available: "2007-06"
 2673	narrow Bohemian rhapsody	0		Last Available: "2007-06"
 2674	irradiated tarnished teal bottle of cat tonic	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 67, Last Available: "2007-06"
@@ -2694,14 +2694,14 @@
 2721	up-at-dawn auspicious Temple Grandin's hand-carved staff	0		Familiar Weight: +7, Item Drop: +10, Adventures: +5
 2722	shaking flame-retardant wholesome steel-toed Staff of the Greasefire of bravery	0		Damage Reduction: 9, Maximum HP Percent: +10, Hot Resistance: +1, Spooky Resistance: +5
 2723	aromatic supercharged Staff of the Grand Flamb&eacute; of the blizzard	0		Maximum MP Percent: +30, Cold Spell Damage: +25, Stench Resistance: +1
-2724	miniature flavorless blue bowl of rye sprouts	2	decent	
-2725	half-sized bland cob of corn	2	decent	
+2724	flavorless miniature blue bowl of rye sprouts	2	decent	
+2725	bland half-sized cob of corn	2	decent	
 2726	rotten juniper berries	3	crappy	
 2727	rotten half-sized blurry gray plum	2	crappy	
 2728	enchanted delicious olive pear	3	awesome	Effect: "Hair on Your Chest", Effect Duration: 45
 2729	super-sized decent tumbling peach	5	good	
 2730	hand-crafted high-proof plum wine	8	EPIC	
-2731	enchanted hand-crafted weak shot of pear schnapps	2	EPIC	Effect: "Sweet and Yellow", Effect Duration: 40
+2731	hand-crafted enchanted weak shot of pear schnapps	2	EPIC	Effect: "Sweet and Yellow", Effect Duration: 40
 2732	acceptable weak shot of peach schnapps	2	good	
 2733	fancy moldy blinking bunch of square grapes	3	crappy	Effect: "License to Punch", Effect Duration: 35
 2734	immense spoiled pulsating brown sugar cane	6	crappy	
@@ -2712,7 +2712,7 @@
 2739	altered energized spinning panty raider camouflage	0		Effect: "Brother Corsican's Blessing", Effect Duration: 15
 2740	Usain Bolt's quilted Staff of the Walk-In Freezer of wisdom	0		Mysticality: +15, Damage Absorption: +40, Initiative: +80
 2741	perfectly mixed boilermaker	4	EPIC	
-2742	stale enchanted steel lasagna	3	quest	Effect: "La Bamba", Effect Duration: 45
+2742	enchanted stale steel lasagna	3	quest	Effect: "La Bamba", Effect Duration: 45
 2743	aged steel margarita	3	quest	
 2744	altered steel-scented air freshener	1		Effect: "Uncucumbered", Effect Duration: 30
 2745	nitrogenated enhanced gremlin mutagen	0		Effect: "White-boy Angst", Effect Duration: 41
@@ -2736,9 +2736,9 @@
 2763	wholesome boxer's Pink Heart of Spirit	0		Muscle Percent: +10, Maximum HP Percent: +10, Single Equip
 2764	gray energetic Rosewater's savvy Order of the Silver Wossname	0		Mysticality Percent: 50, Maximum MP Percent: +20, Single Equip
 2765	tumbling Harold's bell	0		
-2766	upside-down maroon jittery huge bowling ball	0		
+2766	huge upside-down jittery maroon bowling ball	0		
 2767	spoiled ghostly Crimbo pie	4	crappy	
-2768	normal gigantic pear tart	10	good	
+2768	gigantic normal pear tart	10	good	
 2769	moldy peach pie	4	crappy	
 2770	dry chunk of rock salt	0		Effect: "EVISCERATE!", Effect Duration: 17
 2771	corrupted adjusted handful of pine needles	0		Effect: "Brother Corsican's Blessing", Effect Duration: 65
@@ -2777,7 +2777,7 @@
 2804	corrupted ghostly vial of hamethyst juice	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 54
 2805	energized wobbly vial of baconstone juice	0		Effect: "Feet of Watermelon", Effect Duration: 44
 2806	corrupted squat vial of porquoise juice	0		Effect: "Trivia Master", Effect Duration: 13
-2807	ionized upside-down tumbling blinking flask of hamethyst juice	0		Effect: "Tomato Power", Effect Duration: 13
+2807	ionized upside-down blinking tumbling flask of hamethyst juice	0		Effect: "Tomato Power", Effect Duration: 13
 2808	oxidized triple-pickled wobbly flask of baconstone juice	0		Effect: "Square to be Hip", Effect Duration: 26
 2809	aerosolized spinning flask of porquoise juice	0		Effect: "Bilious Briskness", Effect Duration: 16
 2810	deionized jug of hamethyst juice	0		Effect: "Turtle Titters", Effect Duration: 22
@@ -2799,19 +2799,19 @@
 2826	purple executive stanky groovy Staff of the Kitchen Floor	0		Moxie Percent: +10, Stench Spell Damage: +25, Meat Drop: +40
 2827	anniversary gift box	0		
 2828	upside-down loaded dice	0		
-2829	green jittery really dense meat stack	0		
+2829	jittery green really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	flavorless skewed digital key lime pie	4	decent	
-2833	flavorless yellow skewed star key lime pie	3	decent	
+2833	flavorless skewed yellow star key lime pie	3	decent	
 2834	gravedigger's dance instructor's bottle-rocket crossbow of bravery	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Spooky Resistance: +5, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	huge chaotic indie comic hipster glasses	0		Spell Critical Percent: +10, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	spinning mint-condition magic wand	0		Last Available: "2011-12"
 2838	supercool glowstick of dire peril	0		Moxie Percent: +20, Weapon Damage: +20, Last Available: "2007-08"
 2839	skewed hardy Periodical Paintbrush	0		Maximum HP: +50, Softcore Only
-2840	enchanted artisanal squat bottle of cooking sherry	3	EPIC	Effect: "Frosty the Hitman", Effect Duration: 5
-2841	miniature moldy packet of ketchup	2	crappy	
+2840	artisanal enchanted squat bottle of cooking sherry	3	EPIC	Effect: "Frosty the Hitman", Effect Duration: 5
+2841	moldy miniature packet of ketchup	2	crappy	
 2842	perfectly mixed weak accidental cider	2	EPIC	
 2843	decent tumbling dire fudgesicle	3	good	
 2844	blinking smelly vibrating navel ring of navel gazing of the scaredy-cat of the businessman	0		Maximum MP Percent: +10, Monster Level: -15, Stench Spell Damage: +10, Meat Drop: +50, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2821,14 +2821,14 @@
 2848	ghostly Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	fancy delicious moonberry wine cooler	3	awesome	Effect: "Adapt to Change Eventually", Effect Duration: 25
-2851	immense decent fine aged cheddarwurst	6	good	
+2851	decent immense fine aged cheddarwurst	6	good	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	nippy huge mosquito proboscis of the storm	0		Maximum MP Percent: +40, Cold Damage: +10
 2856	tarnished fuchsia swamp lolly	0		Effect: "Twinklebritches", Effect Duration: 42
 2857	chilled frozen seegar butt	0		Effect: "Deadly Flashing Blade", Effect Duration: 53
-2858	cyan bouncing bottled swamp gas	0		
+2858	bouncing cyan bottled swamp gas	0		
 2859	blurry witch wart of the brute of doom	0		Muscle Percent: +30, Spooky Spell Damage: +50
 2860	moldy diet bouncing swamp muck	1	crappy	
 2861	rock-hard experienced leechknife of Flo-Jo	0		Experience: +2, Damage Reduction: 5, Initiative: +100
@@ -2912,12 +2912,12 @@
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	bland Surprise Egg	4	decent	
 2941	triple-colloidal Steal This Candy	0		Effect: "Stenchtastic", Effect Duration: 55
-2942	irradiated blue twirling huge chocolate filthy lucre	0		Effect: "Goldentongue", Effect Duration: 26
+2942	irradiated twirling blue huge chocolate filthy lucre	0		Effect: "Goldentongue", Effect Duration: 26
 2943	vacuum-sealed Angry Farmer's Wife Candy	0		Effect: "Sated and Furious", Effect Duration: 16
 2945	twirling friendly party hat of the early riser	0		Familiar Weight: +3, Adventures: +7, Familiar Effect: "4xLep, cap 7"
 2946	squat zippy V for Vivala mask of the cheetah	0		Initiative: 80, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
-2947	ghostly twirling The Big Book of Pirate Insults	0		
-2948	perfectly mixed practically non-alcoholic teal shot of rotgut	1	EPIC	
+2947	twirling ghostly The Big Book of Pirate Insults	0		
+2948	practically non-alcoholic perfectly mixed teal shot of rotgut	1	EPIC	
 2949	adjusted quadruple-warmed cold-filtered jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "[800]Chocolate Reign", Effect Duration: 60
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2927,28 +2927,28 @@
 2955	yummy tumbling yam candy	4	awesome	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	moldy immense tube of cranberry Go-Goo	10	crappy	
+2958	immense moldy tube of cranberry Go-Goo	10	crappy	
 2959	huge lard-coated rum barrel charrrm bracelet	0		Sleaze Spell Damage: +25
-2960	adequate snack-sized single-serving herbal stuffing	2	good	
+2960	snack-sized adequate single-serving herbal stuffing	2	good	
 2961	bland packet of tofurkey gravy	4	decent	
 2962	bland gray tofurkey nugget	4	decent	
 2963	narrow rigging shampoo	0		
-2964	mirror blue ball polish	0		
+2964	blue mirror ball polish	0		
 2965	mizzenmast mop	0		
 2966	narrow Tom's of the Spanish Main Toothpaste	0		
 2967	magnetized irradiated tarnished upside-down Swabbie&trade; swab	0		Effect: "Amorous Avarice", Effect Duration: 32
 2968	nitrogenated twirling Oil of Parrrlay	0		Effect: "Spiky Hair", Effect Duration: 56
-2969	bite-sized decent creamsicle	1	good	
-2970	drinkable practically non-alcoholic jittery huge cream stout	1	good	
+2969	decent bite-sized creamsicle	1	good	
+2970	drinkable practically non-alcoholic huge jittery cream stout	1	good	
 2971	rosy-cheeked curmudgel of the glutton	0		Maximum HP Percent: +30, Food Drop: +100
-2972	upside-down mirror grumpy man charrrm	0		
+2972	mirror upside-down grumpy man charrrm	0		
 2973	spinning savvy grumpy man charrrm bracelet	0		Mysticality Percent: +20, Single Equip
 2974	mirror tarrrnish charrrm	0		
 2975	skewed ruddy rosy-cheeked tarrrnished charrrm bracelet	0		Maximum HP Percent: 70, Single Equip
 2976	weak drinkable bilge wine	2	good	
 2977	curative witty rapier	0		HP Regen Min: 3, HP Regen Max: 5
 2978	smartaleck's yohohoyo of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15
-2979	deionized frozen twirling bouncing fish-liver oil	0		Effect: "Analog Drunk", Effect Duration: 55
+2979	deionized frozen bouncing twirling fish-liver oil	0		Effect: "Analog Drunk", Effect Duration: 55
 2980	booty chest charrrm	0		
 2981	shaking mirror booty chest charrrm bracelet of James Dean	0		Experience (Moxie): +3, Single Equip
 2982	cannonball charrrm	0		
@@ -3001,7 +3001,7 @@
 3029	enchanted delicious red-headed corpse	4	awesome	Effect: "Serenity", Effect Duration: 45
 3030	distilled hand-crafted kamicorpse-ee	5	EPIC	
 3031	aged bouncing corpsel	3	awesome	
-3032	weak perfectly mixed corpsebite	2	EPIC	
+3032	perfectly mixed weak corpsebite	2	EPIC	
 3033	pirate fledges of vim and vigor	0		Maximum HP Percent: +50
 3034	piece of thirteen	0		
 3035	rotten shaking pearl onion	3	crappy	
@@ -3014,7 +3014,7 @@
 3042	narrow Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	twirling metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	toothsome thick nanite-infested gingerbread bugbear	5	awesome	Last Available: "2007-12"
+3045	thick toothsome nanite-infested gingerbread bugbear	5	awesome	Last Available: "2007-12"
 3046	yummy massive nanite-infested candy cane	8	awesome	Last Available: "2020-09"
 3047	stale shaking nanite-infested fruitcake	3	decent	Last Available: "2007-12"
 3048	perfectly mixed skewed nanite-infested eggnog	3	EPIC	Last Available: "2007-12"
@@ -3028,8 +3028,8 @@
 3056	deadly metallic foil cat ears	0		Weapon Damage: +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	wobbly nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
-3059	maroon tumbling theoretical string	0		Last Available: "2007-12"
-3060	twirling huge synthetic stuffing	0		Last Available: "2007-12"
+3059	tumbling maroon theoretical string	0		Last Available: "2007-12"
+3060	huge twirling synthetic stuffing	0		Last Available: "2007-12"
 3061	huge toy hoverpad	0		Last Available: "2007-12"
 3062	LED block	0		Last Available: "2007-12"
 3063	gyroscope	0		Last Available: "2010-12"
@@ -3085,8 +3085,8 @@
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
-3116	red huge Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3116	huge red Hodgman	0		
+3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	huge divine blowout	0		Last Available: "2008-01"
@@ -3142,9 +3142,9 @@
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	lime green Samson's evil paper umbrella	0		Experience (Muscle): +5
-3173	vacuum-sealed blinking spinning evil vihuela	0		Effect: "Badger Underfoot", Effect Duration: 42
+3173	vacuum-sealed spinning blinking evil vihuela	0		Effect: "Badger Underfoot", Effect Duration: 42
 3174	bland small evil boring spaghetti	2	decent	
-3175	moldy diet evil noodles	1	crappy	
+3175	diet moldy evil noodles	1	crappy	
 3176	stale tiny maroon evil noodles	1	decent	
 3177	small stale evil painful penne pasta	2	decent	
 3178	adequate 3vi1 pr0n m4nic0tti	3	good	
@@ -3153,11 +3153,11 @@
 3181	altered boiled wobbly evil potion of potency	0		Effect: "Filled with Magic", Effect Duration: 62
 3182	extra-adjusted evil libation of liveliness	0		Effect: "Permanent Halloween", Effect Duration: 39
 3183	double-tarnished polymerized evil tomato juice of powerful power	0		Effect: "Arcane in the Brain", Effect Duration: 18
-3184	oxidized tumbling wobbly shaking evil eyedrops of the ermine	0		Effect: "Dweeby", Effect Duration: 24
+3184	oxidized tumbling shaking wobbly evil eyedrops of the ermine	0		Effect: "Dweeby", Effect Duration: 24
 3185	cold-filtered blurry jittery evil ointment of the occult	0		Effect: "Tingly Elbows", Effect Duration: 19
 3186	liquefied extra-electrified deionized blurry evil serum of sarcasm	0		Effect: "So You Can Work More...", Effect Duration: 48
-3187	moist bouncing wobbly evil philter of phorce	0		Effect: "Turtle Titters", Effect Duration: 28
-3188	watered-down lousy an evil sump'm sump'm	2	decent	
+3187	moist wobbly bouncing evil philter of phorce	0		Effect: "Turtle Titters", Effect Duration: 28
+3188	lousy watered-down an evil sump'm sump'm	2	decent	
 3189	tolerable watered-down pulsating evil ducha de oro	2	good	
 3190	perfectly mixed evil horizontal tango	4	EPIC	
 3191	aged enchanted evil roll in the hay	4	awesome	Effect: "Frog In Your Throat", Effect Duration: 50
@@ -3194,7 +3194,7 @@
 3222	bouncing Samson's stylish gatorskin umbrella	0		Moxie: +25, Experience (Muscle): +5
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	triple-distilled delicious bottle of sewage schnapps	8	awesome	
+3225	delicious triple-distilled bottle of sewage schnapps	8	awesome	
 3226	mediocre tumbling bottle of Ooze-O	4	decent	
 3227	spoiled C.H.U.M. chum	3	crappy	
 3228	jumbo moldy unfortunate dumplings	5	crappy	
@@ -3202,7 +3202,7 @@
 3230	polarized jittery oil of oiliness	0		Effect: "Frost Tea", Effect Duration: 51
 3231	resourceful tattered paper crown	0		Maximum MP: +50, Familiar Effect: "1xSombrero, cap 15"
 3232	stale vanilla-frosted king cake	3	decent	Last Available: "2008-03"
-3233	olive skewed inflatable duck	0		
+3233	skewed olive inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	teal noodle	0		
 3236	Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
@@ -3213,7 +3213,7 @@
 3241	Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
-3244	shaking blinking Summer Nights	0		Skill: "Grease Lightning"
+3244	blinking shaking Summer Nights	0		Skill: "Grease Lightning"
 3245	Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	lightning-fast Ol' Scratch's ol' britches of the brazier	0		Hot Spell Damage: +25, Initiative: +40, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
 3247	narrow ruddy Herculean Ol' Scratch's stovepipe hat	0		Experience (Muscle): +1, Maximum HP Percent: +40, Class: "Sauceror", Familiar Effect: "hot atk"
@@ -3232,21 +3232,21 @@
 3260	quilted Chester's moustache of the boozehound of Flo-Jo	0		Damage Absorption: +40, Booze Drop: +100, Initiative: +100, Class: "Disco Bandit", Single Equip
 3261	greedy Herculean Chester's bag of candy	0		Experience (Muscle): +1, Meat Drop: +20, Class: "Disco Bandit"
 3262	shaking red mansplainer's Van der Graaf Chester's cutoffs	0		Monster Level: +15, MP Regen Min: 5, MP Regen Max: 7, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	red Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	red Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	red candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	twirling bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	non-pickled handful of Crotchety Pine needles	0		Effect: "Mortarfied", Effect Duration: 54
 3269	pickled dry narrow lump of Saccharine Maple sap	0		Effect: "Macho Profundo", Effect Duration: 67
-3270	anodized colloidal mirror squat handful of Laughing Willow bark	0		Effect: "Space Cadet", Effect Duration: 58
+3270	anodized colloidal squat mirror handful of Laughing Willow bark	0		Effect: "Space Cadet", Effect Duration: 58
 3271	miser's crotchety pants	0		Meat Drop: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	tumbling double-paned Saccharine Maple pendant	0		Cold Resistance: +5, Conditional Skill (Equipped): "Spray Sap"
 3273	pulsating therapeutic willowy bonnet	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	narrow dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
-3277	skewed wobbly Loudmouth Larry Lamprey	0		Last Available: "2008-04"
+3277	wobbly skewed Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	studded belt of incineration	0		Hot Spell Damage: +50, Last Available: "2008-04"
 3279	fuchsia personal massager	0		Last Available: "2008-04"
 3280	pulsating maroon personalized coffee mug	0		Free Pull, Last Available: "2008-04"
@@ -3295,8 +3295,8 @@
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	strong hand-crafted jar of fermented pickle juice	5	EPIC	
-3326	compressed twirling wobbly voodoo snuff	1	crappy	
-3327	miniature decent extra-greasy slider	2	good	
+3326	compressed wobbly twirling voodoo snuff	1	crappy	
+3327	decent miniature extra-greasy slider	2	good	
 3328	experienced crumpled felt fedora of dire peril	0		Experience: +2, Weapon Damage: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	brawny battered top-hat of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	yellow shaking blurry dangerous Samson's shapeless wide-brimmed hat	0		Experience (Muscle): +5, Weapon Damage: +10, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3307,7 +3307,7 @@
 3335	huge rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	ghostly dead guy's piece of double-sided tape	0		
 3337	maroon Usain Bolt's smooth dead guy's memento	0		Moxie: +15, Initiative: +80, Single Equip
-3338	moldy jumbo jittery banquet	5	crappy	
+3338	jumbo moldy jittery banquet	5	crappy	
 3339	blurry sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3323,7 +3323,7 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	narrow zen motorcycle	0		Last Available: "2008-06"
 3353	cold-filtered purple squat llama lama gong	0		Effect: "The Strength...  of the Future", Effect Duration: 44, Last Available: "2008-06"
-3354	flavorless small banana-frosted king cake	2	decent	Last Available: "2008-08"
+3354	small flavorless banana-frosted king cake	2	decent	Last Available: "2008-08"
 3355	razor-sharp brown plastic baby	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3368,9 +3368,9 @@
 3396	shaking hale Da Vinci's Hodgman's lobsterskin pants	0		Experience (Mysticality): +5, Maximum HP: +20, Familiar Effect: "atk, 1xPotato"
 3397	jittery wobbly chilly personal trainer's Hodgman's bow tie	0		Experience Percent (Muscle): +10, Cold Damage: +5, Single Equip
 3398	tolerable wobbly Hodgman's blanket	4	good	
-3399	high-proof mediocre jar of squeeze	9	decent	
+3399	mediocre high-proof jar of squeeze	9	decent	
 3400	adequate bowl of fishysoisse	4	good	
-3401	diffused wobbly olive deadly lampshade	0		Effect: "Muscle Unbound", Effect Duration: 69
+3401	diffused olive wobbly deadly lampshade	0		Effect: "Muscle Unbound", Effect Duration: 69
 3402	galvanized liquefied ghostly concentrated garbage juice	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 47
 3403	huge pulsating lewd playing card	0		
 3404	deck of lewd playing cards of the cougar of Leguizamo of horror	0		Moxie: +20, Monster Level: +20, Spooky Spell Damage: +25
@@ -3433,7 +3433,7 @@
 3466	gravedigger's arcane researcher's smooth haiku katana	0		Moxie: +15, Experience Percent (Mysticality): +10, Spooky Damage: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	twirling bargain flash powder	0		
 3468	boxer's plastic baby	0		Muscle Percent: +10, Single Equip, Last Available: "2008-12"
-3469	super-sized flavorless spinning wobbly blueberry-frosted king cake	5	decent	Last Available: "2008-12"
+3469	super-sized flavorless wobbly spinning blueberry-frosted king cake	5	decent	Last Available: "2008-12"
 3470	wobbly bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	olive prompt Sherlock's stanky Seasonal Beret	0		Stench Spell Damage: +25, Item Drop: +25, Adventures: +3, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3448,7 +3448,7 @@
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	narrow passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
-3484	wobbly spinning eye 'n' horn shampoo	0		Familiar Weight: +5
+3484	spinning wobbly eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	frozen electrified spinning glittery mascara	0		Effect: "Demonic Taint", Effect Duration: 21
 3486	bouncing dull fish scale	0		
 3487	huge rough fish scale	0		
@@ -3459,19 +3459,19 @@
 3492	crafty quilted fish scimitar	0		Damage Absorption: +40, Maximum MP: +10
 3493	careful fish stick of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: -10
 3494	blurry Oprah's supercharged fish bazooka	0		Maximum MP Percent: 80
-3495	activated liquefied lime green tumbling sea salt crystal	0		Effect: "Feet of Watermelon", Effect Duration: 39
+3495	activated liquefied tumbling lime green sea salt crystal	0		Effect: "Feet of Watermelon", Effect Duration: 39
 3496	irradiated lime green bazookafish bubble gum	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 69
-3497	delicious weak teal bottle of Pete's Sake	2	awesome	
+3497	weak delicious teal bottle of Pete's Sake	2	awesome	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	narrow witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	olive beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	toothsome thick canap&eacute;s	5	awesome	
-3502	boiled red wobbly narrow thermos of brew	1	good	Last Available: "2011-12"
+3502	boiled wobbly red narrow thermos of brew	1	good	Last Available: "2011-12"
 3503	perfectly mixed glass of brandy	4	EPIC	Last Available: "2011-12"
 3504	red French slippers	0		
 3505	fortified LWA ring	0		Damage Absorption: +60
 3506	shaking LARP membership card	0		Last Available: "2008-10"
-3507	upside-down Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	upside-down Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	fuchsia Newton's scratch 'n' sniff sword	0		Experience (Mysticality): +3, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3500,7 +3500,7 @@
 3533	narrow cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	maroon jittery plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
-3536	wobbly bouncing plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
+3536	bouncing wobbly plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	shaking plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
@@ -3523,10 +3523,10 @@
 3556	rotten sea cucumber	3	crappy	
 3557	rotten mirror sea avocado	3	crappy	
 3558	flavorless mirror sea lychee	3	decent	
-3559	stale diet sea tangelo	1	decent	
-3560	toothsome fancy snack-sized sea honeydew	2	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 50
+3559	diet stale sea tangelo	1	decent	
+3560	fancy toothsome snack-sized sea honeydew	2	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 50
 3561	quantum pressurized potion of puissance	0		Effect: "Liquid Courage", Effect Duration: 39
-3562	irradiated huge shaking pressurized potion of perspicacity	0		Effect: "Magically Fingered", Effect Duration: 44
+3562	irradiated shaking huge pressurized potion of perspicacity	0		Effect: "Magically Fingered", Effect Duration: 44
 3563	triple-moist pressurized potion of pulchritude	0		Effect: "Three Days Slow", Effect Duration: 16
 3564	drinkable watered-down mirror berry-infused sake	2	good	
 3565	perfectly mixed special shaking citrus-infused sake	3	EPIC	Effect: "Expert Vacationer", Effect Duration: 20
@@ -3542,13 +3542,13 @@
 3575	mirror sand dollar	0		
 3576	flytrap bezoar	0		
 3577	bezoar ring	0		
-3578	narrow skewed candy cornucopia	0		Free Pull, Last Available: "2011-12"
+3578	skewed narrow candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	twirling ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	toothsome rice	4	awesome	
-3584	flavorless small irradiated candy cane	2	decent	Last Available: "2008-12"
-3585	miniature toothsome gingerbread mutant bugbear	2	awesome	Last Available: "2008-12"
+3584	small flavorless irradiated candy cane	2	decent	Last Available: "2008-12"
+3585	toothsome miniature gingerbread mutant bugbear	2	awesome	Last Available: "2008-12"
 3586	bad oozenog	4	decent	Last Available: "2008-12"
 3587	alkaline polarized denatured sugar plum	0		Effect: "Deadly Lampblade", Effect Duration: 53, Last Available: "2008-12"
 3588	boiled deionized sugar banana	0		Effect: "Strawberry Alarm", Effect Duration: 24, Last Available: "2008-12"
@@ -3583,10 +3583,10 @@
 3617	corrupted ionized unstable DNA	0		Effect: "Comic Violence", Effect Duration: 21, Last Available: "2008-12"
 3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	wriggling tentacle	0		Last Available: "2008-12"
-3620	blinking narrow mass of wriggling tentacles	0		Last Available: "2008-12"
+3620	narrow blinking mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
-3623	spinning upside-down chitinous pod	0		Last Available: "2008-12"
+3623	upside-down spinning chitinous pod	0		Last Available: "2008-12"
 3624	hale parasitic claw	0		Maximum HP: +20, Last Available: "2008-12"
 3625	green parasitic tentacles of the cougar	0		Moxie: +20, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
 3626	twirling prompt parasitic headgnawer	0		Adventures: +3, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
@@ -3609,12 +3609,12 @@
 3643	tumbling pufferfish spine	0		
 3644	studded depleted Grimacite kneecapping stick	0		Damage Absorption: +80, Last Available: "2007-06"
 3645	mediocre practically non-alcoholic bouncing canteen of wine	1	decent	Last Available: "2008-12"
-3646	thick decent twirling elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
+3646	decent thick twirling elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
 3647	skewed elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	stale toast with jam	3	decent	Last Available: "2008-12"
-3651	upside-down bouncing antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	bouncing upside-down antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	artisanal practically non-alcoholic elven moonshine	1	super ultra EPIC	Last Available: "2008-12"
 3653	small stale knuckle sandwich	2	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	MacGyver's hale psycho sweater	0		Maximum HP: +20, Maximum MP: +100, Last Available: "2008-12"
@@ -3635,9 +3635,9 @@
 3669	Newton's glow-in-the-dark dart gun	0		Experience (Mysticality): +3, Last Available: "2009-01"
 3670	quilted glow-in-the-dark burrowgrub	0		Damage Absorption: +40, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	rotten super-sized jittery can of franks 'n' beans	5	crappy	Last Available: "2010-12"
+3672	super-sized rotten jittery can of franks 'n' beans	5	crappy	Last Available: "2010-12"
 3673	mediocre bottle of peppermint schnapps	3	decent	Last Available: "2010-12"
-3674	ghostly blinking throbbing rage gland	0		Skill: "Vent Rage Gland"
+3674	blinking ghostly throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	wholesome diving muff	0		Maximum HP Percent: +10, Single Equip
@@ -3662,7 +3662,7 @@
 3696	anemone nematocyst	0		
 3697	cyan high-pressure seltzer bottle	0		
 3698	squat velcro ore	0		
-3699	lime green jittery teflon ore	0		
+3699	jittery lime green teflon ore	0		
 3700	vinyl ore	0		
 3701	map to Anemone Mine	0		
 3702	marine aquamarine	0		
@@ -3714,25 +3714,25 @@
 3749	modified galvanized lime green concoction of clumsiness	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 47
 3750	vampire pearl earring of the detective	0		Item Drop: +20, Single Equip
 3751	decent chocolate chip brownies	3	good	
-3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	ionized love song of vague ambiguity	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 60, Last Available: "2009-02"
 3755	boiled love song of smoldering passion	0		Effect: "Broberry Brotality", Effect Duration: 45, Last Available: "2009-02"
 3756	cold-filtered extra-dry blurry love song of icy revenge	0		Effect: "Omphalotus Omnipresence", Effect Duration: 53, Last Available: "2009-02"
 3757	dry oxidized love song of sugary cuteness	0		Effect: "Bananas!", Effect Duration: 53, Last Available: "2009-02"
 3758	alkaline non-adjusted jittery love song of disturbing obsession	0		Effect: "Banono", Effect Duration: 50, Last Available: "2009-02"
 3759	anodized corrupted olive love song of naughty innuendo	0		Effect: "Pill Power", Effect Duration: 20, Last Available: "2009-02"
-3760	Vulcanized pickled energized upside-down bouncing breath mint	0		Effect: "Eau de Tortue", Effect Duration: 57
+3760	Vulcanized pickled energized bouncing upside-down breath mint	0		Effect: "Eau de Tortue", Effect Duration: 57
 3761	Annie Oakley's vampire pearl ring	0		Critical Hit Percent: +20, Single Equip
 3762	spinning MacGyver's vampire pearl necklace	0		Maximum MP: +100, Single Equip
-3763	smooth practically non-alcoholic slug of vodka	1	awesome	
+3763	practically non-alcoholic smooth slug of vodka	1	awesome	
 3764	lousy pulsating slug of rum	3	decent	
 3765	acceptable slug of shochu	3	good	
 3766	acceptable screwdiver	4	good	
 3767	bad blurry dew yoana lei	3	decent	
 3768	smooth lychee chuhai	4	awesome	
 3769	artisanal salacious screwdiver	4	EPIC	
-3770	strong delicious dew yoana salacious lei	5	awesome	
-3771	irresponsibly strong hand-crafted salacious lychee chuhai	6	EPIC	
+3770	delicious strong dew yoana salacious lei	5	awesome	
+3771	hand-crafted irresponsibly strong salacious lychee chuhai	6	EPIC	
 3772	acceptable Alewife&trade; Ale	4	good	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
@@ -3743,13 +3743,13 @@
 3779	magnetized concentrated hair of the fish	0		Effect: "Adrenaline Rush", Effect Duration: 58
 3780	up-at-dawn nasty nurse's hat of the overflowing toilet	0		Stench Damage: +5, Stench Spell Damage: +50, Adventures: +5, Familiar Effect: "atk"
 3781	green blank prescription sheet	0		
-3782	modified tumbling lime green pulsating bottle of melodramamine	1		
+3782	modified pulsating tumbling lime green bottle of melodramamine	1		
 3783	denatured ghostly lime green bouncing bottle of extra-strength melodramamine	1		
 3784	paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
-3788	bouncing spinning crumbling rat skull	0		Class: "Pastamancer"
+3788	spinning bouncing crumbling rat skull	0		Class: "Pastamancer"
 3789	gray twitching trigger finger	0		Class: "Pastamancer"
 3799	spinning Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
@@ -3768,13 +3768,13 @@
 3813	upside-down blinking scorching plastic baby	0		Hot Damage: +25, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	bland huge sea radish	9	decent	
+3817	huge bland sea radish	9	decent	
 3818	Sherlock's padded razor-sharp halibut	0		Weapon Damage Percent: +25, Damage Absorption: +20, Item Drop: +25
 3819	squat eel sauce	0		
 3820	Jim Carey's water-polo mitt	0		Monster Level: +25, Single Equip
 3821	extra-concentrated double-anodized syringe	0		Effect: "Balls of Ectoplasm", Effect Duration: 61
 3822	pulsating wand	0		Familiar Effect: "fishy spells"
-3823	frozen twirling mirror wad of cotton	0		Effect: "Physicali Tea", Effect Duration: 23
+3823	frozen mirror twirling wad of cotton	0		Effect: "Physicali Tea", Effect Duration: 23
 3824	Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	blue Grandma's Chartreuse Yarn	0		
@@ -3784,7 +3784,7 @@
 3830	auspicious water-polo cap	0		Item Drop: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	acceptable tumbling Typical Tavern swill	3	good	
 3832	watered-down lousy tropical swill	2	decent	
-3833	mediocre spirit-forward fruity girl swill	5	decent	
+3833	spirit-forward mediocre fruity girl swill	5	decent	
 3834	smooth blended swill	3	awesome	
 3835	costume wardrobe	0		Softcore Only
 3836	skewed aromatic ribald stanky Elvish sunglasses of chilblains	0		Cold Damage: +25, Stench Spell Damage: +25, Sleaze Damage: +10, Stench Resistance: +1, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3834,7 +3834,7 @@
 3880	hellseal disguise	0		
 3881	energetic fouet de tortue-dressage of the scaredy-cat	0		Maximum MP Percent: +20, Monster Level: -15, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
-3883	lime green upside-down cult memo	0		
+3883	upside-down lime green cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	quantum nitrogenated lime green vial of slime	0		Effect: "Ack!  Barred!", Effect Duration: 45
 3886	quantum blue vial of slime	0		Effect: "Superioreo", Effect Duration: 57
@@ -3855,7 +3855,7 @@
 3903	narrow squat figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
-3906	skewed mirror teal figurine of a sleek seal	0		Class: "Seal Clubber"
+3906	mirror teal skewed figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	wobbly figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	ghostly figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	fuchsia figurine of a charred seal	0		Class: "Seal Clubber"
@@ -3884,7 +3884,7 @@
 3932	ingot of seal-iron	0		
 3933	Van der Graaf bad-ass club of the wise owl	0		Mysticality: +20, MP Regen Min: 5, MP Regen Max: 7, Class: "Seal Clubber"
 3934	sealbone	0		
-3935	activated narrow pulsating hyperinflated seal lung	0		Effect: "Heart of Green", Effect Duration: 32
+3935	activated pulsating narrow hyperinflated seal lung	0		Effect: "Heart of Green", Effect Duration: 32
 3936	concentrated scrap of shadow	0		Effect: "Nas Tea", Effect Duration: 19
 3937	deionized modified fustulent seal grulch	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 50
 3938	studded club of corruption	0		Damage Absorption: +80, Class: "Seal Clubber"
@@ -3896,14 +3896,14 @@
 3944	asbestos-lined Fonzie's shadowy seal eye	0		Experience (Moxie): +1, Hot Resistance: +5, Class: "Seal Clubber"
 3945	shaking strapping oyster egg balloon	0		Muscle: +5
 3946	Clan VIP Lounge invitation	0		Free Pull
-3947	bouncing blurry Clan VIP Lounge key	0		Free Pull
+3947	blurry bouncing Clan VIP Lounge key	0		Free Pull
 3948	huge Meat	0		
 3949	treasure chest	0		
 3950	blinking key	0		
 3951	Baron von Ratsworth	0		
 3952	green pulsating monocle	0		
 3953	mink	0		
-3954	yellow pulsating teddy butler	0		
+3954	pulsating yellow teddy butler	0		
 3955	martini	0		
 3956	ghostly crazy bastard sword	0		
 3957	tin of caviar	0		
@@ -3954,7 +3954,7 @@
 4002	auspicious tortoboggan shield of mayonnaise	0		Sleaze Spell Damage: +50, Item Drop: +10, Damage Reduction: 6
 4003	pulsating bottle of moontan lotion	0		
 4004	twirling razor-sharp soup-chucks	0		Weapon Damage Percent: +25
-4005	moist extra-diffused double-corrupted shaking bouncing ballast turtle	0		Effect: "Cold as Ice", Effect Duration: 57
+4005	moist extra-diffused double-corrupted bouncing shaking ballast turtle	0		Effect: "Cold as Ice", Effect Duration: 57
 4006	memory of some amino acids	0		Last Available: "2009-06"
 4007	memory of a C	0		Last Available: "2009-06"
 4008	memory of an A	0		Last Available: "2009-06"
@@ -3965,7 +3965,7 @@
 4013	skewed memory of a CT base pair	0		Last Available: "2009-06"
 4014	mirror memory of an AG base pair	0		Last Available: "2009-06"
 4015	huge memory of an AT base pair	0		Last Available: "2009-06"
-4016	upside-down bouncing memory of a GT base pair	0		Last Available: "2009-06"
+4016	bouncing upside-down memory of a GT base pair	0		Last Available: "2009-06"
 4017	jittery squirming Slime larva	0		
 4018	shaking greaves of chilblains	0		Cold Damage: +25, Familiar Effect: "1xBarrr, cap 37"
 4019	undissolvable contact lenses	0		
@@ -3995,7 +3995,7 @@
 4043	jittery narrow slick pig-iron bracers of terror	0		Moxie: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
-4046	ghostly teal wumpus-hair net	0		Last Available: "2009-06"
+4046	teal ghostly wumpus-hair net	0		Last Available: "2009-06"
 4047	wobbly blue nippy wumpus-hair whip	0		Cold Damage: +10, Last Available: "2009-06"
 4048	Jeselnik's Oprah's wumpus-hair wig of the detective	0		Maximum MP Percent: +50, Sleaze Damage: +25, Item Drop: +20, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
 4049	shaking censurious lion tamer's friendly wumpus-hair loincloth	0		Familiar Weight: +3, Experience (familiar): +2, Sleaze Resistance: +3, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	medical-grade ring of teleportation	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4052	glass of baboon milk	1	good	Last Available: "2009-06"
 4053	banana milkshake	1	decent	Last Available: "2009-06"
-4054	bad high-proof upside-down White Hyborian	7	decent	Last Available: "2009-06"
+4054	high-proof bad upside-down White Hyborian	7	decent	Last Available: "2009-06"
 4055	huge Tesla goblin hunting spear	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-06"
 4056	wool rosy-cheeked goblin autoblowgun	0		Maximum HP Percent: +30, Cold Resistance: +1, Last Available: "2009-06"
 4057	steel-toed tribal beads	0		Damage Reduction: 9, Last Available: "2009-06"
@@ -4021,7 +4021,7 @@
 4069	essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
-4072	upside-down squat essence of	0		Last Available: "2009-06"
+4072	squat upside-down essence of	0		Last Available: "2009-06"
 4073	tumbling Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
 4075	supercharged villainous scythe of Leguizamo	0		Maximum MP Percent: +30, Monster Level: +20, Slime Hates It: +2
@@ -4032,7 +4032,7 @@
 4080	olive bouncing scorching crafty grisly shield	0		Maximum MP: +10, Hot Damage: +25, Slime Hates It: +1, Damage Reduction: 13
 4081	jittery boxer's beefy corroded breeches	0		Muscle: +10, Muscle Percent: +10, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	Newton's pernicious cudgel of the sewer	0		Experience (Mysticality): +3, Stench Damage: +25, Slime Hates It: +1
-4083	special moldy super-sized cupcake-in-a-cup	5	crappy	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30, Last Available: "2009-06"
+4083	moldy special super-sized cupcake-in-a-cup	5	crappy	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30, Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	yummy protein paste	4	awesome	Last Available: "2009-06"
 4086	pulsating blurry nippy cyber-mattock of the glutton	0		Cold Damage: +10, Food Drop: +100, Last Available: "2009-06"
@@ -4056,7 +4056,7 @@
 4104	catseye marble of the glutton	0		Food Drop: +100
 4105	bumboozer marble of courage	0		Spooky Resistance: +3
 4106	rosewater-soaked chamoisole	0		Stench Resistance: +3
-4107	corrupted diffused denatured jittery pulsating bitter pill	0		Effect: "Sticky Hands", Effect Duration: 63
+4107	corrupted diffused denatured pulsating jittery bitter pill	0		Effect: "Sticky Hands", Effect Duration: 63
 4108	supercool brainy monstrous monocle	0		Mysticality: +5, Moxie Percent: +20, Last Available: "2009-06"
 4109	lightning-fast ruddy musty moccasins	0		Maximum HP Percent: +40, Initiative: +40, Last Available: "2009-06"
 4110	jittery cool molten medallion of doom	0		Moxie: +5, Spooky Spell Damage: +50, Last Available: "2009-06"
@@ -4109,7 +4109,7 @@
 4157	blurry gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	gray rock lobster	0		Last Available: "2009-09"
-4160	lousy irresponsibly strong pebblebr&auml;u	7	decent	Last Available: "2009-09"
+4160	irresponsibly strong lousy pebblebr&auml;u	7	decent	Last Available: "2009-09"
 4161	flavorless rocky road ice cream	3	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	altered cyan children of the candy corn	0		Effect: "Buzzard Breath", Effect Duration: 46
@@ -4132,13 +4132,13 @@
 4180	squat sugar shank of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2009-09"
 4181	deadly brainy sugar chapeau of the brazier	0		Mysticality: +5, Weapon Damage: +5, Hot Spell Damage: +25, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
 4182	vibrating sugar shorts	0		Maximum MP Percent: +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
-4183	ghostly skewed sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4183	skewed ghostly sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	ghostly slime convention swag bag	0		
 4185	slime convention flyers	0		
 4186	slime convention coupons	0		
 4187	razor-sharp slime convention pin	0		Weapon Damage Percent: +25
 4188	slime convention t-shirt	0		
-4189	skewed squat inverse geode	0		
+4189	squat skewed inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	squat Jeselnik's sugar shirt	0		Sleaze Damage: +25, Last Available: "2009-09"
 4192	sugar shard	0		Last Available: "2009-09"
@@ -4147,12 +4147,12 @@
 4195	upside-down squat pacifier necklace of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
 4196	sea cowbell	0		
 4197	mirror sea	0		
-4198	blurry red sea lasso	0		
+4198	red blurry sea lasso	0		
 4199	double-paned sea cowboy hat of the storm of bravery	0		Maximum MP Percent: +40, Cold Resistance: +5, Spooky Resistance: +5, Familiar Effect: "1xLep"
 4200	tumbling grouper fangirl	0		
 4201	gill rings	0		Familiar Weight: +5
 4202	spinning urchin roe	0		
-4203	shaking blinking pet anemone	0		Familiar Weight: +5
+4203	blinking shaking pet anemone	0		Familiar Weight: +5
 4204	skewed Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
 4206	miser's wholesome brand new key	0		Maximum HP Percent: +10, Meat Drop: +10
@@ -4187,7 +4187,7 @@
 4235	jittery salt-shaker	0		
 4236	can of sterno	0		
 4237	hardened cheese-slicer	0		Damage Reduction: 3
-4238	diet normal gray jittery beef jerky	1	good	
+4238	normal diet jittery gray beef jerky	1	good	
 4239	blinking bouncing lard-coated pipe wrench	0		Sleaze Spell Damage: +25
 4240	electrified gun cleaning kit	0		Effect: "Antarctic Memories", Effect Duration: 65
 4241	mansplainer's sleep mask	0		Monster Level: +15, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4198,7 +4198,7 @@
 4246	mirror frightening ivory cue ball	0		Spooky Damage: +5
 4247	hand-crafted decanter of fine Scotch	4	EPIC	
 4248	altered expensive cigar	1		
-4249	ghostly fuchsia tophat	0		Familiar Weight: +5
+4249	fuchsia ghostly tophat	0		Familiar Weight: +5
 4250	yellow fisherman's sack	0		
 4251	squat fish-oil smoke bomb	0		
 4252	deionized irradiated upside-down vial of squid ink	0		Effect: "Well-Swabbed Ear", Effect Duration: 68
@@ -4279,7 +4279,7 @@
 4327	double-paned La Hebilla del Cintur&oacute;n de Lopez of vim and vigor of terror	0		Maximum HP Percent: +50, Spooky Spell Damage: +10, Cold Resistance: +5, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	skewed bag of many confections	0		Last Available: "2009-12"
-4330	miniature spoiled candy kneecapping stick	2	crappy	Last Available: "2009-12"
+4330	spoiled miniature candy kneecapping stick	2	crappy	Last Available: "2009-12"
 4331	spoiled licorice garrote	4	crappy	Last Available: "2009-12"
 4332	cyan strapping candy knuckles	0		Muscle: +5, Last Available: "2009-12"
 4333	rotten jawbruiser	4	crappy	Last Available: "2010-12"
@@ -4310,7 +4310,7 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	twirling A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	bland small expired can of franks 'n' beans	2	decent	Last Available: "2009-12"
-4361	enchanted watered-down perfectly mixed expired bottle of peppermint schnapps	2	EPIC	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2009-12"
+4361	perfectly mixed enchanted watered-down expired bottle of peppermint schnapps	2	EPIC	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	ghostly elf resistance button	0		Last Available: "2009-12"
 4364	irradiated huge elven suicide capsule	0		Effect: "Holiday Bliss", Effect Duration: 20, Last Available: "2009-12"
@@ -4320,7 +4320,7 @@
 4368	wrench handle	0		Last Available: "2009-12"
 4369	mirror handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
-4371	lime green shaking handful of wires	0		Last Available: "2009-12"
+4371	shaking lime green handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
@@ -4408,14 +4408,14 @@
 4460	steel-toed dance instructor's snailmail hauberk	0		Experience Percent (Moxie): +10, Damage Reduction: 9
 4461	tarnished seal-brain elixir	0		Effect: "A Few Extra Pounds", Effect Duration: 22
 4462	altered fuchsia chocolate seal-clubbing club	0		Effect: "Bilious Brains", Effect Duration: 56
-4463	tarnished wet wobbly squat teal chocolate turtle totem	0		Effect: "Beta Carotene Overdose", Effect Duration: 52
-4464	Vulcanized adjusted cyan twirling chocolate pasta spoon	0		Effect: "Stuck That Way", Effect Duration: 59
+4463	tarnished wet teal squat wobbly chocolate turtle totem	0		Effect: "Beta Carotene Overdose", Effect Duration: 52
+4464	Vulcanized adjusted twirling cyan chocolate pasta spoon	0		Effect: "Stuck That Way", Effect Duration: 59
 4465	ionized enhanced chocolate saucepan	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 61
 4466	frozen alkaline chocolate disco ball	0		Effect: "Ass Over Teakettle", Effect Duration: 32
 4467	electrified aerosolized spinning chocolate stolen accordion	0		Effect: "Stop the Presses!", Effect Duration: 43
-4468	huge maroon Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	huge maroon Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
-4470	pulsating shaking BRICKO eye brick	0		Last Available: "2010-02"
+4470	shaking pulsating BRICKO eye brick	0		Last Available: "2010-02"
 4471	lightning-fast BRICKO hat	0		Initiative: +40, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
 4472	dance instructor's BRICKO pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	friendly BRICKO sword	0		Familiar Weight: +3, Last Available: "2010-02"
@@ -4456,12 +4456,12 @@
 4508	moist nitrogenated huge &quot;DRINK ME&quot; potion	0		Effect: "Feet of Watermelon", Effect Duration: 47, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	massive decent walrus ice cream	9	good	Last Available: "2010-03"
-4511	super-sized rotten beautiful soup	5	crappy	Last Available: "2010-03"
+4511	rotten super-sized beautiful soup	5	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	wobbly Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	spoiled Humpty Dumplings	4	crappy	Last Available: "2010-03"
 4515	bland Lobster <i>qua</i> Grill	3	decent	Last Available: "2010-03"
-4516	practically non-alcoholic tolerable fancy narrow missing wine	1	good	Effect: "Mystic Circle", Effect Duration: 40, Last Available: "2010-03"
+4516	practically non-alcoholic fancy tolerable narrow missing wine	1	good	Effect: "Mystic Circle", Effect Duration: 40, Last Available: "2010-03"
 4517	spoiled matter custard	4	crappy	Last Available: "2010-03"
 4518	polarized dry comfit?	0		Effect: "Florid Cheeks", Effect Duration: 55, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4471,15 +4471,15 @@
 4523	wizardly eye of the Tiger-lily of dire peril	0		Mysticality: +25, Weapon Damage: +20, Last Available: "2010-03"
 4524	executive horrifying wig	0		Spooky Damage: +25, Meat Drop: +40, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	moldy donut	3	crappy	Last Available: "2010-03"
-4526	spoiled immense bucket of honey	9	crappy	Last Available: "2010-03"
+4526	immense spoiled bucket of honey	9	crappy	Last Available: "2010-03"
 4527	bouncing steel-toed fortified elephant stinger	0		Damage Absorption: +60, Damage Reduction: 9, Last Available: "2010-03"
 4528	stale dragon snaps	3	decent	Last Available: "2010-03"
 4529	squat electrified experienced snapdragon pistil	0		Experience: +2, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-03"
 4530	ghostly puff of smoke	0		Last Available: "2010-03"
 4531	bland rook cookie	4	decent	Last Available: "2010-03"
 4532	stale blue bishop cookie	3	decent	Last Available: "2010-03"
-4533	delicious massive knight cookie	8	awesome	Last Available: "2010-03"
-4534	rotten tiny narrow king cookie	1	crappy	Last Available: "2010-03"
+4533	massive delicious knight cookie	8	awesome	Last Available: "2010-03"
+4534	tiny rotten narrow king cookie	1	crappy	Last Available: "2010-03"
 4535	adequate small queen cookie	2	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	blurry mirror fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	lightning-fast insane tophat	0		Initiative: +40, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4498,7 +4498,7 @@
 4550	dodo	0		Last Available: "2010-03"
 4551	ribald detour shield	0		Sleaze Damage: +10, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
-4553	ghostly narrow lowercase a	0		
+4553	narrow ghostly lowercase a	0		
 4554	percent sign	0		
 4555	yellow left bracket	0		
 4556	right parenthesis	0		
@@ -4510,11 +4510,11 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	mediocre squat world's most unappetizing beverage	3	decent	Last Available: "2010-04"
 4564	slippery when wet shield of the empath	0		Familiar Weight: +5, Damage Reduction: 6, Last Available: "2010-04"
-4565	adequate special raisin	3	good	Effect: "Goldentongue", Effect Duration: 20, Last Available: "2010-04"
+4565	special adequate raisin	3	good	Effect: "Goldentongue", Effect Duration: 20, Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	hardened Fonzie's flyest of shirts	0		Experience (Moxie): +1, Damage Reduction: 3, Last Available: "2010-04"
 4568	normal snack-sized a dance upon the palate	2	good	Last Available: "2010-04"
-4569	flavorless super-sized green prehistoric meteorite jawbreaker	5	decent	Last Available: "2010-04"
+4569	super-sized flavorless green prehistoric meteorite jawbreaker	5	decent	Last Available: "2010-04"
 4570	green Crazyleg's razor	0		Last Available: "2010-04"
 4571	delicious squirmy violent party snack	4	awesome	Last Available: "2010-04"
 4572	huge lard-coated can-you-dig-it?	0		Sleaze Spell Damage: +25, Last Available: "2010-04"
@@ -4529,10 +4529,10 @@
 4581	teal T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of wisdom of the pedagogue	0		Mysticality: +15, Experience: +3, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	moldy super-sized six wedges of goat cheese	5	crappy	
+4584	super-sized moldy six wedges of goat cheese	5	crappy	
 4585	collection of objects	0		
 4586	olive boulder	0		
-4587	blinking jittery goth	0		
+4587	jittery blinking goth	0		
 4588	red brown pixel	0		
 4589	stylish pixel whip	0		Moxie: +25
 4590	sizzling pixel chain whip	0		Hot Damage: +10, Last Available: "2010-07"
@@ -4551,8 +4551,8 @@
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	scandalous brainy bottle of Goldschn&ouml;ckered	0		Mysticality: +5, Sleaze Damage: +5, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	tiny spoiled yellow sun-dried tofu	1	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	smooth special spirit-forward maroon soyburger juice	5	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	spoiled tiny yellow sun-dried tofu	1	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	smooth spirit-forward special maroon soyburger juice	5	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	concentrated essential soy	0		Effect: "Chunky", Effect Duration: 23, Last Available: "2010-08"
@@ -4564,7 +4564,7 @@
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
-4619	twirling maroon frisbee	0		Free Pull, Last Available: "2011-12"
+4619	maroon twirling frisbee	0		Free Pull, Last Available: "2011-12"
 4620	olive motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	squat Game Grid token	0		Last Available: "2010-06"
 4622	wobbly Game Grid ticket	0		Last Available: "2010-06"
@@ -4616,11 +4616,11 @@
 4668	observational glasses of chilblains	0		Cold Damage: +25
 4669	inspector's hilarious comedy prop	0		Item Drop: +15
 4670	wobbly beer-scented teddy bear	0		
-4671	enchanted triple-distilled perfectly mixed booze-soaked cherry	9	EPIC	Effect: "Preternatural Greed", Effect Duration: 10
+4671	perfectly mixed triple-distilled enchanted booze-soaked cherry	9	EPIC	Effect: "Preternatural Greed", Effect Duration: 10
 4672	comfy pillow	0		
 4673	yummy marshmallow	3	awesome	
-4674	enchanted moldy sponge cake	3	crappy	Effect: "Virgo Rising", Effect Duration: 50
-4675	artisanal practically non-alcoholic olive gin-soaked blotter paper	1	EPIC	
+4674	moldy enchanted sponge cake	3	crappy	Effect: "Virgo Rising", Effect Duration: 50
+4675	practically non-alcoholic artisanal olive gin-soaked blotter paper	1	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
@@ -4662,18 +4662,18 @@
 4714	adequate lemon popsicle	4	good	
 4715	adequate popsicle	4	good	
 4716	normal huge strawberry popsicle	10	good	
-4717	moldy snack-sized liver popsicle	2	crappy	
+4717	snack-sized moldy liver popsicle	2	crappy	
 4718	squat mariachi hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, cap 2"
 4719	Temple Grandin's Hollandaise helmet	0		Familiar Weight: +7, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	big tasty purple liver and let pie	5	awesome	Last Available: "2010-10"
-4723	normal fancy low-calorie badass pie	1	good	Effect: "Mo' Hobo", Effect Duration: 25, Last Available: "2010-10"
-4724	spoiled immense wobbly jittery shoo-fish pie	6	crappy	Last Available: "2010-10"
+4723	fancy normal low-calorie badass pie	1	good	Effect: "Mo' Hobo", Effect Duration: 25, Last Available: "2010-10"
+4724	immense spoiled jittery wobbly shoo-fish pie	6	crappy	Last Available: "2010-10"
 4725	stale piping organ pie	4	decent	Last Available: "2010-10"
 4726	flavorless squat igloo pie	3	decent	Last Available: "2010-10"
 4727	rotten stomach turnover	3	crappy	Last Available: "2010-10"
-4728	immense bland dead lights pie	7	decent	Last Available: "2010-10"
+4728	bland immense dead lights pie	7	decent	Last Available: "2010-10"
 4729	rotten tumbling throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	squat Tesla stop shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4692,8 +4692,8 @@
 4744	magnetized blue PlexiPips	0		Effect: "Puzzle Fury", Effect Duration: 60
 4745	Vulcanized fuchsia Wax Flask	0		Effect: "Crotchety, Pining", Effect Duration: 30
 4746	polarized purple Pain Dip	0		Effect: "Heal Thy Nanoself", Effect Duration: 33
-4747	small flavorless bone meal	2	decent	Last Available: "2010-10"
-4748	delicious practically non-alcoholic bone aperitif	1	awesome	Last Available: "2010-10"
+4747	flavorless small bone meal	2	decent	Last Available: "2010-10"
+4748	practically non-alcoholic delicious bone aperitif	1	awesome	Last Available: "2010-10"
 4749	jittery quilted bonerang	0		Damage Absorption: +40, Last Available: "2010-10"
 4750	lime green bone and arrows of James Dean	0		Experience (Moxie): +3, Last Available: "2010-10"
 4751	scandalous boning knife	0		Sleaze Damage: +5, Last Available: "2010-10"
@@ -4708,7 +4708,7 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	tiny flavorless pumpkin pie	1	decent	Last Available: "2010-11"
+4763	flavorless tiny pumpkin pie	1	decent	Last Available: "2010-11"
 4764	weak acceptable pumpkin beer	2	good	Last Available: "2010-11"
 4765	nitrogenated pumpkin juice	0		Effect: "Neuromancy", Effect Duration: 63, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	wobbly Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	immense rotten CRIMBCOIDS mints	8	crappy	Last Available: "2011-01"
+4818	rotten immense CRIMBCOIDS mints	8	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	bland twirling CRIMBCOLOAF	3	decent	Last Available: "2011-01"
 4821	normal circular CRIMBCOOKIE	4	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,7 +4745,7 @@
 4836	narrow robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	upside-down robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	adequate immense triangular CRIMBCOOKIE	8	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	immense adequate triangular CRIMBCOOKIE	8	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	spoiled square CRIMBCOOKIE	3	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	shaking yellow Newton's Samson's bindlestocking of the scaredy-cat	0		Experience (Muscle): +5, Experience (Mysticality): +3, Monster Level: -15, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
@@ -4781,18 +4781,18 @@
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	upside-down photocopied monster	0		Last Available: "2011-01"
 4874	tumbling gaudy key	0		
-4875	cyan shaking ghostly BGE merchandise order form	0		Last Available: "2010-12"
+4875	shaking cyan ghostly BGE merchandise order form	0		Last Available: "2010-12"
 4876	super-vacuum-sealed wet chocolate bath ball	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 44, Last Available: "2011-01"
 4877	altered Vulcanized bouncing bacon bath ball	0		Effect: "Fungal Fortification", Effect Duration: 16, Last Available: "2011-01"
 4878	aerosolized unsweetened twirling blinking incense bath ball	0		Effect: "Truly Gritty", Effect Duration: 13, Last Available: "2011-01"
 4879	Vulcanized extra-diffused myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Inner Warmth", Effect Duration: 46, Last Available: "2011-01"
 4880	bouncing CRIMBCO mug	0		Last Available: "2011-01"
-4881	smooth extra-dry enchanted CRIMBCO wine	5	awesome	Effect: "Held Closer", Effect Duration: 45, Last Available: "2011-01"
+4881	enchanted extra-dry smooth CRIMBCO wine	5	awesome	Effect: "Held Closer", Effect Duration: 45, Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	squat toe jam	0		Last Available: "2011-01"
 4884	stale toe jam toast	3	decent	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	rotten miniature shaking blinking traffic jam toast	2	crappy	Last Available: "2011-01"
+4886	rotten miniature blinking shaking traffic jam toast	2	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	normal space jam toast	4	good	Last Available: "2011-01"
 4889	Vulcanized motivational poster	0		Effect: "Smoky Third Eye", Effect Duration: 54, Last Available: "2011-01"
@@ -4800,7 +4800,7 @@
 4891	shaking bath ball gift set	0		Last Available: "2011-01"
 4892	purple slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	snack-sized fancy moldy blinking bouncing festive sausage	2	crappy	Effect: "Punchy, Murdery", Effect Duration: 15, Last Available: "2011-01"
+4894	moldy snack-sized fancy bouncing blinking festive sausage	2	crappy	Effect: "Punchy, Murdery", Effect Duration: 15, Last Available: "2011-01"
 4895	bland holiday cheese log	4	decent	Last Available: "2011-01"
 4896	tumbling holiday log	0		Last Available: "2011-01"
 4897	therapeutic hale BGE 'ferocious fruit' shirt	0		Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-12"
@@ -4841,10 +4841,10 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	low-calorie spoiled Knob jelly donut	1	crappy	
+4941	spoiled low-calorie Knob jelly donut	1	crappy	
 4942	narrow Knob cake	0		
 4943	Knob cake pan	0		
-4944	pulsating blinking Knob batter	0		
+4944	blinking pulsating Knob batter	0		
 4945	Knob frosting	0		
 4946	skewed unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
@@ -4859,13 +4859,13 @@
 4956	yummy enchanted super-sized philosopher's scone	5	awesome	Effect: "Improved Candy Vision", Effect Duration: 5
 4957	galvanized deionized squat half-baked potion	0		Effect: "Turkey-Agitated", Effect Duration: 62
 4958	mirror Sherlock's Knob Goblin deluxe scimitar	0		Item Drop: +25
-4959	bite-sized normal Knob nuts	1	good	
-4960	aged weak squat Cobb's Knob Wurstbrau	2	awesome	
+4959	normal bite-sized Knob nuts	1	good	
+4960	weak aged squat Cobb's Knob Wurstbrau	2	awesome	
 4961	teal Subject 37 file	0		
 4962	skewed mysterious lapel pin of Leguizamo of Flo-Jo	0		Monster Level: +20, Initiative: +100, Single Equip
 4963	state loom	0		Familiar Weight: +10
 4964	spinning Evilometer	0		
-4965	twirling tumbling Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
+4965	tumbling twirling Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	cyan Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
@@ -4893,7 +4893,7 @@
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	pulsating Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	Alice's Army Foil Wallman	0		Last Available: "2011-03"
-4993	maroon skewed Alice's Army Foil Ninja	0		Last Available: "2011-03"
+4993	skewed maroon Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	twirling wobbly Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
@@ -4913,21 +4913,21 @@
 5010	maroon evil eye	0		
 5011	spinning Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	shaking Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	half-sized spoiled wasabi pocky	2	crappy	Last Available: "2011-03"
-5014	rotten half-sized tobiko pocky	2	crappy	Last Available: "2011-03"
+5013	spoiled half-sized wasabi pocky	2	crappy	Last Available: "2011-03"
+5014	half-sized rotten tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	spoiled miniature spinning natto pocky	2	crappy	Last Available: "2011-03"
-5016	hand-crafted weak wasabi-infused sake	2	EPIC	Last Available: "2011-03"
-5017	mediocre practically non-alcoholic teal tobiko-infused sake	1	decent	Last Available: "2011-03"
+5016	weak hand-crafted wasabi-infused sake	2	EPIC	Last Available: "2011-03"
+5017	practically non-alcoholic mediocre teal tobiko-infused sake	1	decent	Last Available: "2011-03"
 5018	mediocre natto-infused sake	3	decent	Last Available: "2011-03"
-5019	anodized mirror skewed wasabi marble soda	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 33, Last Available: "2011-03"
+5019	anodized skewed mirror wasabi marble soda	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 33, Last Available: "2011-03"
 5020	adjusted tobiko marble soda	0		Effect: "Fortunate Resolve", Effect Duration: 50, Last Available: "2011-03"
 5021	concentrated fuchsia natto marble soda	0		Effect: "Saucefingers", Effect Duration: 59, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	moist non-chilled elderly jawbreaker	0		Effect: "Cold Throat", Effect Duration: 13, Last Available: "2020-09"
 5024	artisanal bouncing marshmallow flamb&eacute;	4	EPIC	Last Available: "2011-03"
 5025	mediocre cranberry schnapps	3	decent	Last Available: "2011-03"
-5026	triple-distilled perfectly mixed breaded beer	6	EPIC	Last Available: "2011-03"
-5027	watered-down mediocre tumbling soy cordial	2	decent	Last Available: "2011-03"
+5026	perfectly mixed triple-distilled breaded beer	6	EPIC	Last Available: "2011-03"
+5027	mediocre watered-down tumbling soy cordial	2	decent	Last Available: "2011-03"
 5028	bouncing steel-toed groovy slick astral bludgeon	0		Moxie: +10, Moxie Percent: +10, Damage Reduction: 9
 5029	baleful astral shield of bravery	0		Spell Damage: +25, Spooky Resistance: +5, Damage Reduction: 15
 5030	jittery experienced smooth astral chapeau of mayonnaise	0		Moxie: +15, Experience: +2, Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4944,7 +4944,7 @@
 5041	blurry zippy Da Vinci's astral shirt of chilblains	0		Experience (Mysticality): +5, Cold Damage: +25, Initiative: +20
 5042	purple Tesla resourceful astral belt	0		Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10
 5043	yummy super-sized blinking astral hot dog	5		
-5044	hand-crafted strong astral pilsner	5		
+5044	strong hand-crafted astral pilsner	5		
 5045	cyan astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -5007,7 +5007,7 @@
 5104	deionized nitrogenated fish juice box	0		Effect: "Barking Mad", Effect Duration: 26, Last Available: "2011-05"
 5105	purple bouncing paint bomb	0		Last Available: "2011-05"
 5106	pulsating hideous egg	0		Last Available: "2011-05"
-5107	high-proof bad blinking Jeppson's Malort	9	decent	Last Available: "2011-06"
+5107	bad high-proof blinking Jeppson's Malort	9	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	blinking zippy stress ball	0		Initiative: +20, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5016,7 +5016,7 @@
 5113	packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	squat hedge trimmers	0		
-5116	teal blurry A. W. O. L. commendation	0		Last Available: "2011-05"
+5116	blurry teal A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	pulsating bird brain	0		
 5119	busted wings	0		
@@ -5040,14 +5040,14 @@
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	squat E.M.U. harness	0		Last Available: "2011-06"
 5139	teal carton of astral energy drinks	0		
-5140	pickled yellow upside-down astral energy drink	1		Effect: "Turkey-Ambitious", Effect Duration: 40
+5140	pickled upside-down yellow astral energy drink	1		Effect: "Turkey-Ambitious", Effect Duration: 40
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	colloidal narrow honeypot	0		Effect: "[800]Chocolate Reign", Effect Duration: 13
 5146	stale upside-down wild honey pie	3	decent	
-5147	drinkable watered-down gray honey mead	2	good	
+5147	watered-down drinkable gray honey mead	2	good	
 5148	nippy curative honey dipper of the businessman	0		Cold Damage: +10, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5
 5149	blurry inspector's Jack Frost's honeybritches	0		Cold Spell Damage: +50, Item Drop: 20, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	lightning-fast rock-hard stiffened honeycap	0		Damage Reduction: 12, Initiative: +40, Familiar Effect: "1xPotato, cap 43"
@@ -5074,10 +5074,10 @@
 5171	tumbling spinning Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	fuchsia elven magi-pack	0		Last Available: "2011-06"
-5174	special artisanal jittery Saison du Lune	3	EPIC	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2011-06"
-5175	high-proof tolerable Moonthril Schnapps	8	good	Last Available: "2011-06"
+5174	artisanal special jittery Saison du Lune	3	EPIC	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2011-06"
+5175	tolerable high-proof Moonthril Schnapps	8	good	Last Available: "2011-06"
 5176	weak artisanal Wrecked Generator	2	super ultra mega turbo EPIC	Last Available: "2011-06"
-5177	adequate big wobbly Spaghetti with Moonballs	5	good	Last Available: "2011-06"
+5177	big adequate wobbly Spaghetti with Moonballs	5	good	Last Available: "2011-06"
 5178	flavorless Crepes a la Lune	3	decent	Last Available: "2011-06"
 5179	bland small Moon Pie	2	decent	Last Available: "2011-06"
 5180	oxidized Comet Pop	0		Effect: "Conspiratory Eyes", Effect Duration: 19, Last Available: "2011-06"
@@ -5092,7 +5092,7 @@
 5189	polymerized tarnished squat upside-down double-ice gum	0		Effect: "Perfect Hair", Effect Duration: 40, Last Available: "2011-04"
 5190	miser's strapping Operation Patriot Shield of the ox	0		Muscle: 25, Meat Drop: +10, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
-5192	warmed irradiated shaking twirling jittery corrupted data	0		Effect: "Bubblin' Rage", Effect Duration: 28, Last Available: "2011-06"
+5192	warmed irradiated jittery twirling shaking corrupted data	0		Effect: "Bubblin' Rage", Effect Duration: 28, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
 5194	exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
@@ -5108,26 +5108,26 @@
 5205	powdered teal orc paste	1	good	Last Available: "2011-08"
 5206	dried bouncing demonic paste	1	good	Last Available: "2011-08"
 5207	vaporized indescribably horrible paste	1	decent	Last Available: "2011-08"
-5208	distilled wobbly narrow paste	1	awesome	Effect: "Fudge Headache", Effect Duration: 25, Last Available: "2011-08"
-5209	denatured twirling lime green goblin paste	1	awesome	Effect: "Vanity Rage", Effect Duration: 25, Last Available: "2011-08"
+5208	distilled narrow wobbly paste	1	awesome	Effect: "Fudge Headache", Effect Duration: 25, Last Available: "2011-08"
+5209	denatured lime green twirling goblin paste	1	awesome	Effect: "Vanity Rage", Effect Duration: 25, Last Available: "2011-08"
 5210	compressed squat pirate paste	1	decent	Last Available: "2011-08"
 5211	dried chlorophyll paste	1	good	Effect: "Sticks and Stones", Effect Duration: 10, Last Available: "2011-08"
 5212	compressed mirror ghostly paste	1	decent	Last Available: "2011-08"
 5213	compressed Mer-kin paste	1	crappy	Effect: "Super Accuracy", Effect Duration: 40, Last Available: "2011-08"
-5214	pickled yellow shaking slimy paste	1	awesome	Last Available: "2011-08"
+5214	pickled shaking yellow slimy paste	1	awesome	Last Available: "2011-08"
 5215	pickled wobbly penguin paste	1	EPIC	Effect: "Incensed", Effect Duration: 25, Last Available: "2011-08"
 5216	denatured pulsating huge elemental paste	1	decent	Last Available: "2011-08"
 5217	dehydrated bouncing cosmic paste	1	good	Last Available: "2011-08"
 5218	compressed red hobo paste	1	good	Last Available: "2011-08"
 5219	denatured blurry Crimbo paste	1	crappy	Last Available: "2011-08"
 5220	narrow Teachings of the Fist	0		
-5221	purple upside-down fat loot token	0		No Pull
+5221	upside-down purple fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	tumbling Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	toothsome miniature teal Ur-Donut	2	awesome	Last Available: "2011-09"
+5223	tumbling Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5224	miniature toothsome teal Ur-Donut	2	awesome	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	squat box of Familiar Jacks	0		Last Available: "2011-09"
-5227	triple-distilled mediocre bucket of wine	10	decent	Last Available: "2011-09"
+5227	mediocre triple-distilled bucket of wine	10	decent	Last Available: "2011-09"
 5228	adequate ultrafondue	3	good	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	mirror snowflake	0		Last Available: "2011-09"
@@ -5140,7 +5140,7 @@
 5237	time halo of the pedagogue	0		Experience: +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	acceptable Lumineux Limnio	3	good	Last Available: "2011-09"
 5239	acceptable Morto Moreto	4	good	Last Available: "2011-09"
-5240	irresponsibly strong hand-crafted bouncing Temps Tempranillo	7	EPIC	Last Available: "2011-09"
+5240	hand-crafted irresponsibly strong bouncing Temps Tempranillo	7	EPIC	Last Available: "2011-09"
 5241	lousy Bordeaux Marteaux	3	decent	Last Available: "2011-09"
 5242	hand-crafted skewed Fromage Pinotage	3	EPIC	Last Available: "2011-09"
 5243	bad Beignet Milgranet	3	decent	Last Available: "2011-09"
@@ -5149,12 +5149,12 @@
 5246	flavorless jumbo cyan shrapnel jelly donut	5	decent	Last Available: "2011-09"
 5247	special bland olive occult jelly donut	4	decent	Effect: "Heart of Green", Effect Duration: 30, Last Available: "2011-09"
 5248	spoiled thyme jelly donut	3	crappy	Last Available: "2011-09"
-5249	immense decent danish	10	good	Last Available: "2011-09"
-5250	adequate small gray smashed danish	2	good	Last Available: "2011-09"
+5249	decent immense danish	10	good	Last Available: "2011-09"
+5250	small adequate gray smashed danish	2	good	Last Available: "2011-09"
 5251	fancy low-calorie flavorless pulsating pulsating forbidden danish	1	decent	Effect: "Knightlife", Effect Duration: 15, Last Available: "2011-09"
-5252	half-sized bland blue cool cat claw	2	decent	Last Available: "2011-09"
+5252	bland half-sized blue cool cat claw	2	decent	Last Available: "2011-09"
 5253	normal olive blunt cat claw	3	good	Last Available: "2011-09"
-5254	huge adequate shadowy cat claw	9	good	Last Available: "2011-09"
+5254	adequate huge shadowy cat claw	9	good	Last Available: "2011-09"
 5255	spoiled jumbo cheezburger	5	crappy	Last Available: "2011-09"
 5256	adequate blinking toasted brie	3	good	Last Available: "2011-09"
 5257	non-boiled potion of the field gar	0		Effect: "Psalm of Pointiness", Effect Duration: 61, Last Available: "2011-09"
@@ -5170,7 +5170,7 @@
 5267	flattened tarnished alkaline potion of punctual companionship	0		Effect: "Gingerbread Robust", Effect Duration: 39, Last Available: "2011-09"
 5268	wobbly holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
-5270	huge fuchsia ghostly chocolate frosted sugar bomb	0		Last Available: "2011-09"
+5270	huge ghostly fuchsia chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	wobbly broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	beefcake's broken clock	0		Muscle: +25, Last Available: "2011-09"
 5282	chaotic dethklok	0		Spell Critical Percent: +10, Last Available: "2011-09"
 5283	MacGyver's glacial clock	0		Maximum MP: +100, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	pulsating d8	0		Last Available: "2011-09"
@@ -5213,7 +5213,7 @@
 5310	shotgun shell	0		Last Available: "2011-10"
 5311	funhouse mirror	0		Last Available: "2011-10"
 5312	boiled wet blinking blue ghostly body paint	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 57, Last Available: "2011-10"
-5313	wet magnetized blinking teal necrotizing body spray	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 26, Last Available: "2011-10"
+5313	wet magnetized teal blinking necrotizing body spray	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 26, Last Available: "2011-10"
 5314	diffused ghostly bite-me-red lipstick	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 46, Last Available: "2011-10"
 5315	flattened non-oxidized whisker pencil	0		Effect: "Heart of Yellow", Effect Duration: 43, Last Available: "2011-10"
 5316	pickled frozen dry press-on ribs	0		Effect: "Oily Flavor", Effect Duration: 44, Last Available: "2011-10"
@@ -5226,7 +5226,7 @@
 5323	artisanal extra-dry pulsating Bartles and BRAAAINS wine cooler	5	EPIC	Last Available: "2011-10"
 5324	artisanal Blood Light	4	EPIC	Last Available: "2011-10"
 5325	bad Silver Bullet beer	3	decent	Last Available: "2011-10"
-5326	weak perfectly mixed blurry Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
+5326	perfectly mixed weak blurry Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	non-denatured galvanized shaking mirror sorority brain	0		Effect: "Icy Composition", Effect Duration: 27, Last Available: "2011-10"
 5329	improved modified cyan Nightstalker perfume	0		Effect: "Blood-Gorged", Effect Duration: 20, Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	Sherlock's therapeutic razor-sharp The Necbromancer's Shorts	0		Weapon Damage Percent: +25, Item Drop: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	friendly Rosewater's The Necbromancer's Wizard Staff of the boozehound	0		Mysticality Percent: +30, Familiar Weight: +3, Booze Drop: +100, Last Available: "2011-10"
 5341	jittery The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	drinkable practically non-alcoholic The Cooler Out of Space	1	good	Last Available: "2011-10"
+5342	practically non-alcoholic drinkable The Cooler Out of Space	1	good	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	green sorority girl's box	0		Last Available: "2011-10"
 5345	triple-oxidized frozen jittery Necbro wafers	0		Effect: "Gyromitra Gymnastics", Effect Duration: 36, Last Available: "2020-09"
@@ -5281,7 +5281,7 @@
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	compressed blinking groose grease	1	awesome	Effect: "Florid Cheeks", Effect Duration: 25, Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
-5381	spinning gray bananagate	0		Last Available: "2011-11"
+5381	gray spinning bananagate	0		Last Available: "2011-11"
 5382	bouncing blinking pearidot	0		Last Available: "2011-11"
 5383	tourmalime	0		Last Available: "2011-11"
 5384	kumquartz	0		Last Available: "2011-11"
@@ -5289,7 +5289,7 @@
 5386	family-friendly ridiculous belt	0		Sleaze Resistance: +1, Last Available: "2011-11"
 5387	occult ridiculous earring	0		Spell Damage Percent: +25, Last Available: "2011-11"
 5388	ridiculous sunglasses of the empath	0		Familiar Weight: +5, Last Available: "2011-11"
-5389	tiny normal squat ridiculous sandwich	1	good	Last Available: "2011-11"
+5389	normal tiny squat ridiculous sandwich	1	good	Last Available: "2011-11"
 5390	acceptable watered-down ridiculous cocktail	2	good	Last Available: "2011-11"
 5391	spinning flame-wreathed zombie monkey necklace of the blizzard	0		Cold Spell Damage: +25, Hot Spell Damage: +10
 5392	Thwaitgold butterfly statuette	0		
@@ -5308,7 +5308,7 @@
 5405	Usain Bolt's avaricious shellacked cane-mail shirt	0		Damage Reduction: 7, Meat Drop: +30, Initiative: +80, Last Available: "2011-12"
 5406	Jim Carey's supercool strapping cane-mail pants	0		Muscle: +5, Moxie Percent: +20, Monster Level: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	hand-crafted teal Vodka Matryoshka	3	EPIC	Last Available: "2011-12"
-5408	weak drinkable bouncing Gin Mint	2	good	Last Available: "2011-12"
+5408	drinkable weak bouncing Gin Mint	2	good	Last Available: "2011-12"
 5409	perfectly mixed Tequiz Navidad	4	EPIC	Last Available: "2011-12"
 5410	weak smooth Mint Yulep	2	awesome	Last Available: "2011-12"
 5411	mediocre irresponsibly strong Crimbojito	8	decent	Last Available: "2011-12"
@@ -5344,7 +5344,7 @@
 5441	olive narrow wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
-5444	magnetized activated maroon tumbling devilish folio	0		Effect: "Incensed", Effect Duration: 64, Last Available: "2012-12"
+5444	magnetized activated tumbling maroon devilish folio	0		Effect: "Incensed", Effect Duration: 64, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	skewed dangerous jerkcicle	0		Last Available: "2012-12"
@@ -5359,11 +5359,11 @@
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	tarnished wobbly Fudgie Roll	0		Effect: "It's Soporiffic!", Effect Duration: 57, Last Available: "2011-11"
 5458	rotten fudge bunny	3	crappy	Last Available: "2011-11"
-5459	bouncing spinning fudge spork	0		Last Available: "2011-11"
+5459	spinning bouncing fudge spork	0		Last Available: "2011-11"
 5460	tumbling fudgecycle of the dark arts of the empath of the sewer	0		Spell Damage Percent: +100, Familiar Weight: +5, Stench Damage: +25, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	vacuum-sealed double-energized fuchsia resolution: be wealthier	0		Effect: "Full-Body Tan", Effect Duration: 63, Last Available: "2012-01"
 5465	improved resolution: be happier	0		Effect: "Voracious Gorging", Effect Duration: 61, Last Available: "2012-01"
 5466	polymerized electrified jittery resolution: be stronger	0		Effect: "Bilious Brains", Effect Duration: 27, Last Available: "2012-01"
@@ -5383,7 +5383,7 @@
 5480	toothsome teal gummi bear	3	awesome	Last Available: "2011-11"
 5481	delicious miniature gummi bear	2	awesome	Last Available: "2011-11"
 5482	snack-sized decent drunki-bear	2	good	Last Available: "2011-11"
-5483	miniature spoiled drunki-bear	2	crappy	Last Available: "2011-11"
+5483	spoiled miniature drunki-bear	2	crappy	Last Available: "2011-11"
 5484	yummy miniature drunki-bear	2	awesome	Last Available: "2011-11"
 5485	aromatic gummi bowtie	0		Stench Resistance: +1, Last Available: "2011-11"
 5486	sinister fudge pocket square	0		Spell Damage: +10, Last Available: "2011-11"
@@ -5394,9 +5394,9 @@
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	squat belemnite candy mold	0		Last Available: "2011-11"
-5494	ionized mirror huge jittery gummi trilobite	0		Effect: "Hobo Flavor", Effect Duration: 46, Last Available: "2011-11"
+5494	ionized jittery mirror huge gummi trilobite	0		Effect: "Hobo Flavor", Effect Duration: 46, Last Available: "2011-11"
 5495	aerosolized warmed green gummi ammonite	0		Effect: "Broken Fast", Effect Duration: 52, Last Available: "2011-11"
-5496	altered teal twirling gummi belemnite	0		Effect: "Bone Homie", Effect Duration: 54, Last Available: "2011-11"
+5496	altered twirling teal gummi belemnite	0		Effect: "Bone Homie", Effect Duration: 54, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	narrow heart of dark chocolate	0		Last Available: "2011-11"
 5499	pulsating pulsating therapeutic healthy Big Candy's tophat	0		Maximum HP Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
@@ -5424,7 +5424,7 @@
 5521	squat huge pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
-5524	huge yellow pog #10 (hobo)	0		Last Available: "2011-11"
+5524	yellow huge pog #10 (hobo)	0		Last Available: "2011-11"
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	electrified Atomic Pop	0		Effect: "Jungle Juiced", Effect Duration: 33, Last Available: "2020-09"
 5527	red do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
@@ -5432,7 +5432,7 @@
 5529	bite-sized moldy bouncing berries of suffering	1	crappy	Last Available: "2012-12"
 5530	double-ionized improved wobbly twirling baobab sap	0		Effect: "Deadly Lampblade", Effect Duration: 57, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
-5532	shaking olive magnolia blossom	0		Last Available: "2012-12"
+5532	olive shaking magnolia blossom	0		Last Available: "2012-12"
 5533	wet boiled upside-down Mortimer's nostrum	0		Effect: "Pemmican't", Effect Duration: 23, Last Available: "2012-12"
 5534	irresponsibly strong lousy Barulio's bottle	10	decent	Last Available: "2012-12"
 5535	triple-denatured gray jittery Marvin's marvelous pill	0		Effect: "Whole Latte Love", Effect Duration: 15, Last Available: "2012-12"
@@ -5444,7 +5444,7 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	gray crafty deadly Leapin' Trousers	0		Weapon Damage: +5, Maximum MP: +10
-5544	delicious watered-down blue shaking eggnog	2	awesome	Last Available: "2012-12"
+5544	delicious watered-down shaking blue eggnog	2	awesome	Last Available: "2012-12"
 5545	adequate gray hamhock	3	good	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
@@ -5465,83 +5465,83 @@
 5562	electrified deadly Rain-Doh violet bo	0		Weapon Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	thick adequate blue ghostly PB&BP	5	good	
+5565	adequate thick blue ghostly PB&BP	5	good	
 5566	stale tiny club sandwich	1	decent	
-5567	flavorless snack-sized corned-beef Reuben	2	decent	
+5567	snack-sized flavorless corned-beef Reuben	2	decent	
 5568	frayed ninja rope	0		
 5569	wobbly dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	teal Thwaitgold stag beetle statuette	0		
-5573	hand-crafted weak narrow Drac & Tan	2	EPIC	Last Available: "2012-03"
-5574	drinkable watered-down Transylvania Sling	2	good	Last Available: "2012-03"
-5575	weak aged Shot of the Living Dead	2	awesome	Last Available: "2012-03"
+5573	weak hand-crafted narrow Drac & Tan	2	EPIC	Last Available: "2012-03"
+5574	watered-down drinkable Transylvania Sling	2	good	Last Available: "2012-03"
+5575	aged weak Shot of the Living Dead	2	awesome	Last Available: "2012-03"
 5576	perfectly mixed blinking Buttery Knob	3	EPIC	Last Available: "2012-03"
 5577	delicious watered-down Slippery Knob	2	awesome	Last Available: "2012-03"
 5578	artisanal Flaming Knob	4	EPIC	Last Available: "2012-03"
 5579	tolerable squat Grasshopper	4	good	Last Available: "2012-03"
 5580	lousy spirit-forward twirling Locust	5	decent	Last Available: "2012-03"
 5581	practically non-alcoholic bad Plague of Locusts	1	decent	Last Available: "2012-03"
-5582	bad enchanted Red Dwarf	4	decent	Effect: "Dance of the Sugar Fairy", Effect Duration: 35, Last Available: "2012-03"
+5582	enchanted bad Red Dwarf	4	decent	Effect: "Dance of the Sugar Fairy", Effect Duration: 35, Last Available: "2012-03"
 5583	perfectly mixed Golden Mean	3	EPIC	Last Available: "2012-03"
-5584	acceptable wobbly huge Green Giant	3	good	Last Available: "2012-03"
+5584	acceptable huge wobbly Green Giant	3	good	Last Available: "2012-03"
 5585	bad Aye Aye	4	decent	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	4	decent	Last Available: "2012-03"
-5587	boozy mediocre Aye Aye, Tooth Tooth	5	decent	Last Available: "2012-03"
+5587	mediocre boozy Aye Aye, Tooth Tooth	5	decent	Last Available: "2012-03"
 5588	acceptable upside-down Humanitini	4	good	Last Available: "2012-03"
-5589	lousy triple-distilled More Humanitini than Humanitini	10	decent	Last Available: "2012-03"
+5589	triple-distilled lousy More Humanitini than Humanitini	10	decent	Last Available: "2012-03"
 5590	mediocre Oh, the Humanitini	4	decent	Last Available: "2012-03"
-5591	watered-down tolerable cyan Great Older Fashioned	2	good	Last Available: "2012-03"
+5591	tolerable watered-down cyan Great Older Fashioned	2	good	Last Available: "2012-03"
 5592	mediocre irresponsibly strong Fuzzy Tentacle	8	decent	Last Available: "2012-03"
-5593	fortified lousy enchanted Crazymaker	5	decent	Effect: "Standard Cheer", Effect Duration: 35, Last Available: "2012-03"
-5594	fancy aged blinking Zoodriver	3	awesome	Effect: "Hustlin'", Effect Duration: 15, Last Available: "2012-03"
+5593	enchanted lousy fortified Crazymaker	5	decent	Effect: "Standard Cheer", Effect Duration: 35, Last Available: "2012-03"
+5594	aged fancy blinking Zoodriver	3	awesome	Effect: "Hustlin'", Effect Duration: 15, Last Available: "2012-03"
 5595	tolerable Sloe Comfortable Zoo	3	good	Last Available: "2012-03"
 5596	artisanal Sloe Comfortable Zoo on Fire	4	EPIC	Last Available: "2012-03"
-5597	practically non-alcoholic mediocre Suffering Sinner	1	decent	Last Available: "2012-03"
+5597	mediocre practically non-alcoholic Suffering Sinner	1	decent	Last Available: "2012-03"
 5598	lousy Suppurating Sinner	4	decent	Last Available: "2012-03"
 5599	watered-down hand-crafted Sizzling Sinner	2	EPIC	Last Available: "2012-03"
-5600	distilled aged Firewater	5	awesome	Last Available: "2012-03"
+5600	aged distilled Firewater	5	awesome	Last Available: "2012-03"
 5601	lousy Earth and Firewater	4	decent	Last Available: "2012-03"
-5602	tolerable weak enchanted Earth, Wind and Firewater	2	good	Effect: "Heavily Breathing", Effect Duration: 40, Last Available: "2012-03"
+5602	tolerable enchanted weak Earth, Wind and Firewater	2	good	Effect: "Heavily Breathing", Effect Duration: 40, Last Available: "2012-03"
 5603	acceptable Slimosa	4	good	Last Available: "2012-03"
 5604	perfectly mixed practically non-alcoholic Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
 5605	perfectly mixed weak Slimebite	2	EPIC	Last Available: "2012-03"
 5606	aged watered-down Cement Mixer	2	awesome	Last Available: "2012-03"
 5607	practically non-alcoholic tolerable Jackhammer	1	good	Last Available: "2012-03"
-5608	enchanted smooth Dump Truck	4	awesome	Effect: "Haunted Liver", Effect Duration: 25, Last Available: "2012-03"
+5608	smooth enchanted Dump Truck	4	awesome	Effect: "Haunted Liver", Effect Duration: 25, Last Available: "2012-03"
 5609	spirit-forward aged blinking Fauna Libre	5	awesome	Last Available: "2012-03"
 5610	tolerable special Chakra Libre	4	good	Effect: "Cold Hard Skin", Effect Duration: 25, Last Available: "2012-03"
 5611	acceptable Aura Libre	3	good	Last Available: "2012-03"
 5612	acceptable special Sazerorc	3	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 20, Last Available: "2012-03"
 5613	hand-crafted Sazuruk-hai	3	EPIC	Last Available: "2012-03"
-5614	practically non-alcoholic drinkable fancy Flaming Sazerorc	1	good	Effect: "Toast Tea", Effect Duration: 40, Last Available: "2012-03"
+5614	practically non-alcoholic fancy drinkable Flaming Sazerorc	1	good	Effect: "Toast Tea", Effect Duration: 40, Last Available: "2012-03"
 5615	aged Green Velvet	3	awesome	Last Available: "2012-03"
 5616	smooth practically non-alcoholic Green Muslin	1	awesome	Last Available: "2012-03"
 5617	artisanal weak Green Burlap	2	EPIC	Last Available: "2012-03"
 5618	hand-crafted Mohobo	4	EPIC	Last Available: "2012-03"
-5619	practically non-alcoholic mediocre spinning Moonshine Mohobo	1	decent	Last Available: "2012-03"
+5619	mediocre practically non-alcoholic spinning Moonshine Mohobo	1	decent	Last Available: "2012-03"
 5620	drinkable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	perfectly mixed Drunken Philosopher	3	EPIC	Last Available: "2012-03"
 5622	bad watered-down green Drunken Neurologist	2	decent	Last Available: "2012-03"
 5623	smooth upside-down Drunken Astrophysicist	3	awesome	Last Available: "2012-03"
 5624	mediocre blurry Dark & Starry	4	decent	Last Available: "2012-03"
-5625	lousy practically non-alcoholic Black Hole	1	decent	Last Available: "2012-03"
-5626	mediocre practically non-alcoholic Event Horizon	1	decent	Last Available: "2012-03"
-5627	weak artisanal Herring Daiquiri	2	EPIC	Last Available: "2012-03"
-5628	acceptable special practically non-alcoholic Herring Wallbanger	1	good	Effect: "Human-Hippy Hybrid", Effect Duration: 20, Last Available: "2012-03"
+5625	practically non-alcoholic lousy Black Hole	1	decent	Last Available: "2012-03"
+5626	practically non-alcoholic mediocre Event Horizon	1	decent	Last Available: "2012-03"
+5627	artisanal weak Herring Daiquiri	2	EPIC	Last Available: "2012-03"
+5628	acceptable practically non-alcoholic special Herring Wallbanger	1	good	Effect: "Human-Hippy Hybrid", Effect Duration: 20, Last Available: "2012-03"
 5629	lousy spinning Herringtini	3	decent	Last Available: "2012-03"
 5630	perfectly mixed bouncing Lollipop Drop	3	EPIC	Last Available: "2012-03"
-5631	weak bad yellow Candy Alexander	2	decent	Last Available: "2012-03"
-5632	enchanted watered-down acceptable Candicaine	2	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 50, Last Available: "2012-03"
+5631	bad weak yellow Candy Alexander	2	decent	Last Available: "2012-03"
+5632	acceptable watered-down enchanted Candicaine	2	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 50, Last Available: "2012-03"
 5633	drinkable squat blinking Caipiranha	3	good	Last Available: "2012-03"
 5634	fortified acceptable Flying Caipiranha	5	good	Last Available: "2012-03"
-5635	watered-down bad Flaming Caipiranha	2	decent	Last Available: "2012-03"
+5635	bad watered-down Flaming Caipiranha	2	decent	Last Available: "2012-03"
 5636	lousy mirror Punchplanter	4	decent	Last Available: "2012-03"
-5637	practically non-alcoholic aged huge Doublepunchplanter	1	awesome	Last Available: "2012-03"
-5638	distilled tolerable huge Haymaker	5	good	Last Available: "2012-03"
+5637	aged practically non-alcoholic huge Doublepunchplanter	1	awesome	Last Available: "2012-03"
+5638	tolerable distilled huge Haymaker	5	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	shaking crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	snack-sized flavorless fungus	2	decent	
+5641	flavorless snack-sized fungus	2	decent	
 5642	huge poisoned dart	0		
 5643	super-dry altered purple stone wool	0		Effect: "Top Dog", Effect Duration: 56
 5644	stones	0		
@@ -5618,7 +5618,7 @@
 5717	bland FDKOL hotcakes	3	decent	Last Available: "2012-07"
 5718	yellow hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	jumbo bland shaking fiery wing	5	decent	Last Available: "2012-07"
+5720	bland jumbo shaking fiery wing	5	decent	Last Available: "2012-07"
 5721	Jack Frost's smooth wings of fire	0		Moxie: +15, Cold Spell Damage: +50, Last Available: "2012-07"
 5722	Tesla FDKOL fire hose	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-07"
 5723	altered energized dry bottle of fire	0		Effect: "Carrrsmic", Effect Duration: 54, Last Available: "2012-07"
@@ -5632,22 +5632,22 @@
 5731	lousy shaking 5-hour acrimony	3	decent	
 5732	wobbly blank note	0		
 5733	eerily silent box	0		
-5734	diet bland fuchsia forbidden sausage	1	decent	
+5734	bland diet fuchsia forbidden sausage	1	decent	
 5735	skewed arcane researcher's Lord Flameface's cloak	0		Experience Percent (Mysticality): +10, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	colloidal moist Drizzlers&trade; Black Licorice	0		Effect: "Sharp Weapon", Effect Duration: 23
 5737	denatured cold-filtered quadruple-galvanized daub-breaker	0		Effect: "Preemptive Medicine", Effect Duration: 60, Last Available: "2020-09"
 5738	ghostly Sherlock's Camp Scout backpack	0		Item Drop: +25, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	huge adequate bag of GORP	9	good	Last Available: "2012-07"
-5741	high-proof acceptable water purification pills	8	good	Last Available: "2012-07"
-5742	yellow bouncing Camp Scout pup tent	0		Last Available: "2012-07"
-5743	practically non-alcoholic perfectly mixed wobbly pulsating blinking CSA scoutmaster's &quot;water&quot;	1	super ultra EPIC	Last Available: "2012-07"
+5740	adequate huge bag of GORP	9	good	Last Available: "2012-07"
+5741	acceptable high-proof water purification pills	8	good	Last Available: "2012-07"
+5742	bouncing yellow Camp Scout pup tent	0		Last Available: "2012-07"
+5743	perfectly mixed practically non-alcoholic wobbly blinking pulsating CSA scoutmaster's &quot;water&quot;	1	super ultra EPIC	Last Available: "2012-07"
 5744	decent bag of GORF	4	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	low-calorie toothsome twirling wobbly bag of QWOP	1	awesome	Last Available: "2012-07"
+5746	toothsome low-calorie twirling wobbly bag of QWOP	1	awesome	Last Available: "2012-07"
 5747	non-pressed CSA bravery badge	0		Effect: "Dreadful Smell", Effect Duration: 12, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	artisanal watered-down enchanted CSA cheerfulness ration	2	EPIC	Effect: "Swimming Head", Effect Duration: 45, Last Available: "2012-07"
+5749	watered-down enchanted artisanal CSA cheerfulness ration	2	EPIC	Effect: "Swimming Head", Effect Duration: 45, Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	upside-down Tales of the Word Realms	0		
 5752	bland crappy brain	3	decent	
@@ -5664,7 +5664,7 @@
 5764	strapping fuzzy busby of James Dean	0		Muscle: +5, Experience (Moxie): +3, Familiar Effect: "1.5xVolley, cap 32"
 5765	reassuring Tesla fuzzy earmuffs	0		Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5766	cyan bouncing smelly steel-toed fuzzy montera of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 9, Stench Spell Damage: +10, Familiar Effect: "1.5xVolley, cap 32"
-5767	cyan bouncing Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
+5767	bouncing cyan Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
 5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5770	fuchsia twirling gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
@@ -5674,7 +5674,7 @@
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	mansplainer's Van der Graaf Barney's rake	0		Monster Level: +15, MP Regen Min: 5, MP Regen Max: 7
-5778	thick adequate idiot brain	5	good	
+5778	adequate thick idiot brain	5	good	
 5779	clever keel-haulin' knife	0		Maximum MP: +20
 5780	olive wicked ice cream scoop	0		Spell Damage: +5
 5781	irresponsibly strong smooth soft echo eyedrop antidote martini	9	awesome	
@@ -5693,7 +5693,7 @@
 5794	ionized tarnished maroon Enchanted Plunger	0		Effect: "Salamander In Your Stomach", Effect Duration: 63
 5795	double-ionized Enchanted Flyswatter	0		Effect: "Pemmican't", Effect Duration: 33
 5796	extra-frozen quadruple-ionized Gearhead Goo	0		Effect: "Greasy Visage", Effect Duration: 63
-5797	cold-filtered dry squat shaking Missing Eye Simulation Device	0		Effect: "Engorged Weapon", Effect Duration: 38
+5797	cold-filtered dry shaking squat Missing Eye Simulation Device	0		Effect: "Engorged Weapon", Effect Duration: 38
 5798	adjusted Gnollish Crossdress	0		Effect: "The Halls of Mysticality", Effect Duration: 50
 5799	boiled spinning eldritch dough	0		Effect: "Macho, Macho Dog", Effect Duration: 50
 5800	Vulcanized pickled green Charity's choker	0		Effect: "Elron's Explosive Etude", Effect Duration: 17
@@ -5704,7 +5704,7 @@
 5805	oxidized extra-denatured polymerized twirling breath mint	0		Effect: "Incredibly Hulking", Effect Duration: 37
 5806	chilled triple-quantum dry wobbly jittery muesli	0		Effect: "You Drank Fish Wine", Effect Duration: 25
 5807	colloidal liquefied adjusted glass of warm milk	0		Effect: "Rootin' Around", Effect Duration: 65
-5808	ionized blinking narrow glass of gnat milk	0		Effect: "Tennis Elbow-wow", Effect Duration: 13
+5808	ionized narrow blinking glass of gnat milk	0		Effect: "Tennis Elbow-wow", Effect Duration: 13
 5809	liquefied lime green Knob Goblin Mutagen	0		Effect: "Jelly Combed", Effect Duration: 20
 5810	corrupted magnetized wobbly lime green Tears of the Quiet Healer	0		Effect: "Bright!", Effect Duration: 52
 5811	polarized alkaline skewed tube of lipstick	0		Effect: "Takin' It Greasy", Effect Duration: 65
@@ -5714,7 +5714,7 @@
 5815	improved flayed mind	0		Effect: "Scrappy, Shadowy", Effect Duration: 58
 5816	magnetized shaking kobold kibble	0		Effect: "Super-Electrified", Effect Duration: 54
 5817	triple-nitrogenated magnetized forest spirit rattle	0		Effect: "Ninja, Please", Effect Duration: 63
-5818	magnetized flattened galvanized upside-down cyan Stone Golem pebbles	0		Effect: "Tomato Power", Effect Duration: 18
+5818	magnetized flattened galvanized cyan upside-down Stone Golem pebbles	0		Effect: "Tomato Power", Effect Duration: 18
 5819	ionized twirling gravy fairy warlock hat	0		Effect: "Chalky Hand", Effect Duration: 49
 5820	chilled non-vacuum-sealed bull blubber	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 32
 5821	oxidized electrified extra-dry red frog lip-print	0		Effect: "Flamingly Floral", Effect Duration: 45
@@ -5724,13 +5724,13 @@
 5825	quadruple-improved vacuum-sealed Skullery Maid's Knee	0		Effect: "Be a Mind Master", Effect Duration: 33
 5826	magnetized polarized pickled zombie hollandaise	0		Effect: "Mitre Cut", Effect Duration: 21
 5827	concentrated teal skeletal banana	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 41
-5828	magnetized dry skewed tumbling gilt perfume bottle	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 31
+5828	magnetized dry tumbling skewed gilt perfume bottle	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 31
 5829	pressed frozen janglin' bones	0		Effect: "Rain Dancin'", Effect Duration: 26
 5830	wet triple-pickled blurry pygmy papers	0		Effect: "Weasels Underfoot", Effect Duration: 25
 5831	alkaline galvanized green pygmy dart	0		Effect: "Chief Executive Optimism", Effect Duration: 20
 5832	moist irradiated purple twirling secret mummy herbs and spices	0		Effect: "Balls of Ectoplasm", Effect Duration: 36
 5833	unsweetened brigand brittle	0		Effect: "Angry like the Wolf", Effect Duration: 43
-5834	polymerized quantum cyan shaking holistic headache remedy	0		Effect: "The Real Deal", Effect Duration: 69
+5834	polymerized quantum shaking cyan holistic headache remedy	0		Effect: "The Real Deal", Effect Duration: 69
 5835	boiled concentrated double-polymerized purple scrunchie tourniquet	0		Effect: "familiar.enq", Effect Duration: 62
 5836	super-wet adjusted embezzler's oil	0		Effect: "Good Motivator", Effect Duration: 54
 5837	extra-ionized moist Fu Manchu Wax	0		Effect: "Beta Carotene Overdose", Effect Duration: 25
@@ -5738,12 +5738,12 @@
 5839	aerosolized ravenous eye	0		Effect: "Proprie Tea", Effect Duration: 53
 5840	cold-filtered concentrated spinning Rogue Windmill Rouge	0		Effect: "stats.enq", Effect Duration: 47
 5841	frozen polarized aerosolized jittery A muse-bouche	0		Effect: "Your Eyes are Peeled!", Effect Duration: 42
-5842	double-adjusted shaking olive toothbrush	0		Effect: "The Halls of Muscularity", Effect Duration: 34
+5842	double-adjusted olive shaking toothbrush	0		Effect: "The Halls of Muscularity", Effect Duration: 34
 5843	dry maroon upside-down pirate cream pie	0		Effect: "Extra Backbone", Effect Duration: 52
 5844	pickled electrified liquefied una poca de gracia	0		Effect: "Sugar, Hello", Effect Duration: 32
-5845	alkaline pickled spinning jittery blue compressed air canister	0		Effect: "Cheered Up", Effect Duration: 27
+5845	alkaline pickled spinning blue jittery compressed air canister	0		Effect: "Cheered Up", Effect Duration: 27
 5846	nitrogenated blinking salt water taffy	0		Effect: "init.enh", Effect Duration: 68
-5847	dry spinning yellow blurry unholy water	0		Effect: "Flambé-a-thon", Effect Duration: 15
+5847	dry yellow blurry spinning unholy water	0		Effect: "Flambé-a-thon", Effect Duration: 15
 5848	quadruple-activated irradiated Bangyomaman battle juice	0		Effect: "Winning Smile", Effect Duration: 43
 5849	liquefied ghostly handyman &quot;hand soap&quot;	0		Effect: "Stop the Presses!", Effect Duration: 24
 5850	electrified space marine flash grenade	0		Effect: "Oriental Mysticism", Effect Duration: 46
@@ -5758,7 +5758,7 @@
 5859	Vulcanized upside-down booby trap	0		Effect: "Mental A-cue-ity", Effect Duration: 36
 5860	unsweetened Agent Corrigan's cigarette	0		Effect: "Hot Hands", Effect Duration: 62
 5861	electrified dry good ash	0		Effect: "Quadrilled", Effect Duration: 34
-5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	Vulcanized unsweetened papier-mochi	0		Effect: "Notably Lovely", Effect Duration: 25, Last Available: "2012-09"
@@ -5769,7 +5769,7 @@
 5870	wobbly teal Herculean papier-masque of Flo-Jo	0		Experience (Muscle): +1, Initiative: +100, Single Equip, Last Available: "2012-09"
 5871	deadly supercool papier-mitre	0		Moxie Percent: +20, Weapon Damage: +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
 5872	twirling lion tamer's clever papier-m&acirc;churidars	0		Maximum MP: +20, Experience (familiar): +2, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
-5873	blinking narrow papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
+5873	narrow blinking papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
 5876	papier-m&acirc;ch&eacute; bowl	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	teal packet of dragon's teeth	0		Last Available: "2012-10"
 5881	wobbly skeleton	0		Last Available: "2012-10"
 5882	hale healthy cool skeleton skis	0		Moxie: +5, Maximum HP Percent: +20, Maximum HP: +20, Single Equip, Last Available: "2012-10"
-5883	small bland skeleton quiche	2	decent	Last Available: "2012-10"
+5883	bland small skeleton quiche	2	decent	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	rosewater-soaked Jack Frost's coward's Jim Carey's Bonestabber	0		Monster Level: 5, Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2012-10"
@@ -5868,7 +5868,7 @@
 5970	scorching soul mask	0		Hot Damage: +25, Single Equip
 5971	skewed record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
 5972	record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
-5973	olive blurry record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
+5973	blurry olive record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
@@ -5885,7 +5885,7 @@
 5987	blurry dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	squat potion	0		Last Available: "2013-02"
-5990	strong mediocre bouncing bottle of wine	5	decent	Last Available: "2013-02"
+5990	mediocre strong bouncing bottle of wine	5	decent	Last Available: "2013-02"
 5991	pulsating blinking round bomb	0		Last Available: "2013-02"
 5992	prompt deadly iron helmet of the cougar	0		Moxie: +20, Weapon Damage: +5, Adventures: +3, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	scorching clever banded steel sword	0		Damage Absorption: +100, Maximum MP: +20, Hot Damage: +25, Last Available: "2013-02"
@@ -5931,7 +5931,7 @@
 6033	Rosewater's thinker's stolen necklace	0		Mysticality: +10, Mysticality Percent: +30
 6034	mirror veiny troll britches of chilblains	0		Maximum HP: +10, Cold Damage: +25, Familiar Effect: "1.5xPotato, cap 28"
 6035	triple-moist alkaline spinning vial of The Glistening	0		Effect: "Milk Studly", Effect Duration: 29
-6036	tolerable weak red twirling artisanal limoncello	2	good	
+6036	tolerable weak twirling red artisanal limoncello	2	good	
 6037	ginger ale	0		
 6038	bland incredible pizza	3	decent	
 6039	lime green up-at-dawn personal trainer's oil cap	0		Experience Percent (Muscle): +10, Adventures: +5, Familiar Effect: "cap 28"
@@ -5947,9 +5947,9 @@
 6049	perfumed rock-hard Sinatra's Misty Cape	0		Experience (Moxie): +5, Damage Reduction: 5, Stench Resistance: +5
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	adequate gigantic Taco Dan's Taco Stand Taco	10	good	Last Available: "2012-12"
+6052	gigantic adequate Taco Dan's Taco Stand Taco	10	good	Last Available: "2012-12"
 6053	drinkable irresponsibly strong pulsating Taco Dan's Taco Stand Chimichangarita	7	good	Last Available: "2012-12"
-6054	double-dry olive wobbly Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Extra Terrestrial", Effect Duration: 27, Last Available: "2012-12"
+6054	double-dry wobbly olive Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Extra Terrestrial", Effect Duration: 27, Last Available: "2012-12"
 6055	blurry psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	Meatcleaver of the scaredy-cat of mayonnaise	0		Monster Level: -15, Sleaze Spell Damage: +50, Last Available: "2013-12"
@@ -5966,7 +5966,7 @@
 6068	loose blade	0		
 6069	green goblin bone hilt	0		
 6070	twirling twirling sword blade	0		
-6071	blinking huge Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	huge blinking Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	vacuum-sealed tumbling upside-down haggis-infused soap	0		Effect: "Took Eleven", Effect Duration: 35, Last Available: "2012-12"
 6074	tarnished narrow magicberry tablets	0		Effect: "Castaway Physique", Effect Duration: 41, Last Available: "2012-12"
@@ -5996,7 +5996,7 @@
 6098	gourd potion	0		Last Available: "2013-12"
 6099	maroon Thinknerd T-Shirt of the early riser	0		Adventures: +7, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
-6101	gray upside-down twirling homemade robot	0		Last Available: "2012-12"
+6101	twirling upside-down gray homemade robot	0		Last Available: "2012-12"
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
@@ -6007,7 +6007,7 @@
 6109	bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
 6110	bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	upside-down wobbly bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
-6112	blinking lime green zaibatsu lobby card	0		Last Available: "2013-12"
+6112	lime green blinking zaibatsu lobby card	0		Last Available: "2013-12"
 6113	blinking zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	maroon zaibatsu level 3 card	0		Last Available: "2013-12"
@@ -6016,11 +6016,11 @@
 6118	teal goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	artisanal boozy Chinese beer	5	EPIC	Last Available: "2013-12"
+6121	boozy artisanal Chinese beer	5	EPIC	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	blinking furry pink pillow	0		Last Available: "2013-12"
-6125	polymerized maroon blinking bottle of limeade	0		Effect: "Psalm of Pointiness", Effect Duration: 33, Last Available: "2013-12"
+6125	polymerized blinking maroon bottle of limeade	0		Effect: "Psalm of Pointiness", Effect Duration: 33, Last Available: "2013-12"
 6126	Temple Grandin's novelty tattoo sleeves of dire peril	0		Weapon Damage: +20, Familiar Weight: +7, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	upside-down furry brown pillow	0		Last Available: "2013-12"
@@ -6038,7 +6038,7 @@
 6140	wobbly Chinese curse words	0		Last Available: "2013-12"
 6141	fuchsia triad summoning scroll	0		Last Available: "2013-12"
 6142	jumbo stale roasted duck	5	decent	Last Available: "2013-12"
-6143	enchanted spoiled big dead meat bun	5	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 35, Last Available: "2013-12"
+6143	big enchanted spoiled dead meat bun	5	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 35, Last Available: "2013-12"
 6144	cat collar of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2013-12"
 6145	miser's padded suspicious-looking fedora	0		Damage Absorption: +20, Meat Drop: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	maroon Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6046,11 +6046,11 @@
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	rotten enchanted upside-down carrot cake	4	crappy	Effect: "Feelin' Philosophical", Effect Duration: 25, Last Available: "2013-01"
+6152	enchanted rotten upside-down carrot cake	4	crappy	Effect: "Feelin' Philosophical", Effect Duration: 25, Last Available: "2013-01"
 6153	artisanal yellow carrot claret	3	EPIC	Last Available: "2013-01"
 6154	denatured twirling carrot juice	1	good	Effect: "In the Limelight", Effect Duration: 35, Last Available: "2013-01"
 6155	blinking pixel power cell	0		Last Available: "2013-12"
-6156	blue spinning flickering pixel	0		Last Available: "2013-12"
+6156	spinning blue flickering pixel	0		Last Available: "2013-12"
 6157	prompt Byte of the sewer	0		Stench Damage: +25, Adventures: +3, Last Available: "2013-12"
 6158	rock-hard anger blaster	0		Damage Reduction: 5, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
 6159	foul-smelling doubt cannon	0		Stench Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
@@ -6063,7 +6063,7 @@
 6166	teal ribald stanky deck cannon	0		Stench Spell Damage: +25, Sleaze Damage: +10, Last Available: "2013-12"
 6167	chaotic ornamental sextant	0		Spell Critical Percent: +10, Last Available: "2013-12"
 6168	ghostly skewed studded Bloodbath of the detective	0		Damage Absorption: +80, Item Drop: +20, Last Available: "2013-12"
-6169	strong tolerable narrow Hundred Headed IPA	5	good	Last Available: "2013-12"
+6169	tolerable strong narrow Hundred Headed IPA	5	good	Last Available: "2013-12"
 6170	diet rotten tumbling chum	1	crappy	Last Available: "2013-12"
 6171	colloidal activated spinning crude crudit&eacute;s	0		Effect: "Red Misty-Eyed", Effect Duration: 15
 6172	ionized upside-down candy crayons	0		Effect: "Coming Up Roses", Effect Duration: 60, Last Available: "2020-09"
@@ -6074,65 +6074,65 @@
 6177	huge cosmic dough	0		
 6178	cosmic vegetable	0		
 6179	cosmic cheese	0		
-6180	upside-down skewed cosmic potted meat product	0		
-6181	yellow pulsating cosmic potato	0		
+6180	skewed upside-down cosmic potted meat product	0		
+6181	pulsating yellow cosmic potato	0		
 6182	cosmic cream	0		
 6183	bouncing cosmic fruit	0		
 6184	quilted weightlifter's Jarlsberg's hat of the businessman	0		Muscle: +15, Damage Absorption: +40, Meat Drop: +50
 6185	flavorless consummate hard-boiled egg	3	decent	
 6186	toothsome fancy consummate fried egg	3	awesome	Effect: "Deadly Flashing Blade", Effect Duration: 10
 6187	decent super-sized consummate egg salad	5	good	
-6188	fancy thick delicious narrow consummate bagel	5	awesome	Effect: "Egg Burps", Effect Duration: 45
-6189	immense rotten teal consummate sliced bread	9	crappy	
+6188	delicious fancy thick narrow consummate bagel	5	awesome	Effect: "Egg Burps", Effect Duration: 45
+6189	rotten immense teal consummate sliced bread	9	crappy	
 6190	miniature rotten consummate hot dog bun	2	crappy	
 6191	rotten consummate brownie	3	crappy	
 6192	normal tiny consummate toast	1	good	
-6193	delicious watered-down blurry passable stout	2	awesome	
+6193	watered-down delicious blurry passable stout	2	awesome	
 6194	decent purple consummate soup	3	good	
 6195	snack-sized bland consummate corn chips	2	decent	
-6196	special delicious consummate salad	3	awesome	Effect: "Inner Warmth", Effect Duration: 35
+6196	delicious special consummate salad	3	awesome	Effect: "Inner Warmth", Effect Duration: 35
 6197	rotten consummate salsa	3	crappy	
-6198	jumbo flavorless consummate sauerkraut	5	decent	
+6198	flavorless jumbo consummate sauerkraut	5	decent	
 6199	rotten consummate cheese slice	3	crappy	
-6200	miniature decent consummate melted cheese	2	good	
+6200	decent miniature consummate melted cheese	2	good	
 6201	bland consummate bacon	4	decent	
 6202	rotten enchanted shaking consummate meatloaf	3	crappy	Effect: "Can Has Cyborger", Effect Duration: 10
 6203	decent consummate steak	3	good	
 6204	bland thick consummate cuts	5	decent	
 6205	diet flavorless consummate frankfurter	1	decent	
-6206	bite-sized delicious consummate french fries	1	awesome	
+6206	delicious bite-sized consummate french fries	1	awesome	
 6207	spoiled miniature ghostly consummate baked potato	2	crappy	
 6208	aged acceptable vodka	3	awesome	
 6209	spoiled consummate ice cream	4	crappy	
 6210	normal huge consummate whipped cream	3	good	
 6211	bland gray consummate cream	3	decent	
-6212	special rotten red consummate strawberries	3	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 15
-6213	snack-sized flavorless consummate sorbet	2	decent	
+6212	rotten special red consummate strawberries	3	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 15
+6213	flavorless snack-sized consummate sorbet	2	decent	
 6214	drinkable jittery adequate rum	4	good	
-6215	delicious special mediocre lager	4	awesome	Effect: "Seal Clubbing Frenzy", Effect Duration: 45
+6215	special delicious mediocre lager	4	awesome	Effect: "Seal Clubbing Frenzy", Effect Duration: 45
 6216	moldy immaculate grilled cheese	4	crappy	
-6217	adequate immense jittery immaculate ice cream sandwich	7	good	
-6218	decent big immaculate hot dog	5	good	
+6217	immense adequate jittery immaculate ice cream sandwich	7	good	
+6218	big decent immaculate hot dog	5	good	
 6219	stale immaculate egg salad sandwich	4	decent	
-6220	normal small perfect sandwich	2	good	
-6221	immense adequate perfect chef salad	9	good	
-6222	snack-sized moldy perfect breakfast	2	crappy	
+6220	small normal perfect sandwich	2	good	
+6221	adequate immense perfect chef salad	9	good	
+6222	moldy snack-sized perfect breakfast	2	crappy	
 6223	stale sublime deluxe hot dog	3	decent	
 6224	toothsome sublime stew	3	awesome	
-6225	special big decent sublime nachos	5	good	Effect: "Dancing Prowess", Effect Duration: 35
+6225	big special decent sublime nachos	5	good	Effect: "Dancing Prowess", Effect Duration: 35
 6226	moldy Ultimate Breakfast Sandwich	4	crappy	
 6227	rotten narrow Loaded Baked Potato	3	crappy	
 6228	moldy Omega Sundae	3	crappy	
-6229	bad enchanted twirling Das Sauerlager	4	decent	Effect: "New and Improved", Effect Duration: 10
+6229	enchanted bad twirling Das Sauerlager	4	decent	Effect: "New and Improved", Effect Duration: 10
 6230	hand-crafted Bologna Lambic	3	EPIC	
 6231	tolerable Vodka Dog	4	good	
-6232	weak artisanal Disappointed Russian	2	EPIC	
+6232	artisanal weak Disappointed Russian	2	EPIC	
 6233	aged Chunky Mary	4	awesome	
 6234	aged Nachojito	4	awesome	
-6235	fortified drinkable Le Roi	5	good	
+6235	drinkable fortified Le Roi	5	good	
 6236	practically non-alcoholic lousy Over Easy Rider	1	decent	
 6237	purple cosmic six-pack	0		
-6239	double-dry dry bouncing shaking cube of ectoplasm	0		Effect: "Big", Effect Duration: 27
+6239	double-dry dry shaking bouncing cube of ectoplasm	0		Effect: "Big", Effect Duration: 27
 6240	galvanized wet gray Illuminati earpiece	0		Effect: "Orchid Blood", Effect Duration: 41
 6241	triple-boiled censored can label	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 19
 6242	colloidal corrupted oxidized ectoplasm <i>au jus</i>	0		Effect: "Eye of the Lihc", Effect Duration: 66
@@ -6160,7 +6160,7 @@
 6264	chaotic medical-grade Staff of Fruit Salad of mayonnaise	0		Spell Critical Percent: +10, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Jiggle: "Deal Some Prismatic Damage"
 6265	perfumed hale Staff of the Cream of the Cream of the early riser	0		Maximum HP: +20, Stench Resistance: +5, Adventures: +7, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	miniature delicious grain of protein powder	2	awesome	
+6267	delicious miniature grain of protein powder	2	awesome	
 6268	ionized irradiated pec oil	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 64
 6269	nasty gym membership card	0		Stench Damage: +5
 6270	galvanized Squat-Thrust Magazine	0		Effect: "Insulated Trousers", Effect Duration: 32
@@ -6207,12 +6207,12 @@
 6311	pulsating Uncle Buck of the ox	0		Muscle: +20, Softcore Only
 6312	blurry crate of fish meat	0		
 6313	damp wallet	0		
-6314	squat yellow pipe	0		Effect: "Fishy", Effect Duration: 10
+6314	yellow squat pipe	0		Effect: "Fishy", Effect Duration: 10
 6315	blue zippy brainy SCUBA tank	0		Mysticality: +5, Initiative: +20, Adventure Underwater
 6316	huge mansplainer's deep six-shooter of extreme caution	0		Monster Level: -10
 6317	mirror Rosewater's thinker's sea chaps	0		Mysticality: +10, Mysticality Percent: +30, Familiar Effect: "atk, 2xBarrr"
 6318	pulsating ghostly studded Herculean beefcake's sea holster	0		Muscle: +25, Experience (Muscle): +1, Damage Absorption: +80, Single Equip
-6319	cold-filtered shaking blurry shavin' razor	0		Effect: "The Dinsey Way", Effect Duration: 59
+6319	cold-filtered blurry shaking shavin' razor	0		Effect: "The Dinsey Way", Effect Duration: 59
 6320	Sherlock's long-forgotten necklace	0		Item Drop: +25
 6321	pearl	0		
 6322	sea lace	0		
@@ -6236,7 +6236,7 @@
 6340	sizzling rock-hard floral-print skirt	0		Damage Reduction: 5, Hot Damage: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	Temple Grandin's Newton's spectral axe	0		Experience (Mysticality): +3, Familiar Weight: +7
 6342	chaotic Rosewater's super-strong air freshener	0		Mysticality Percent: +30, Spell Critical Percent: +10
-6343	adjusted red shaking Mer-kin lipstick	0		Effect: "Space Cowboy", Effect Duration: 65
+6343	adjusted shaking red Mer-kin lipstick	0		Effect: "Space Cowboy", Effect Duration: 65
 6344	Mer-kin mouthsoap	0		
 6345	energized electrified Mer-kin strongjuice	0		Effect: "[1609]Dancin' Fool", Effect Duration: 25
 6346	skewed teal Mer-kin fitbrine	0		
@@ -6251,9 +6251,9 @@
 6355	anodized tumbling Mer-kin cooljuice	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 60
 6356	shaking Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
-6358	blinking ghostly Mer-kin darkbook	0		Skill: "Deep Dark Visions"
+6358	ghostly blinking Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	perfumed Mer-kin begsign	0		Stench Resistance: +5, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	activated pulled taffy	0		Effect: "Disco State of Mind", Effect Duration: 49, Last Available: "2013-04"
 6362	flattened extra-frozen pulled indigo taffy	0		Effect: "Worth Your Salt", Effect Duration: 52, Last Available: "2013-04"
 6363	non-corrupted pulled taffy	0		Effect: "Squid Squint", Effect Duration: 67, Last Available: "2013-04"
@@ -6264,7 +6264,7 @@
 6368	maroon Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	artisanal enchanted fortified can of the cheapest beer	5	EPIC	Effect: "Hyperoffended", Effect Duration: 5
+6371	fortified artisanal enchanted can of the cheapest beer	5	EPIC	Effect: "Hyperoffended", Effect Duration: 5
 6372	practically non-alcoholic mediocre bottle of fruity &quot;wine&quot;	1	decent	
 6373	hand-crafted single swig of vodka	3	EPIC	
 6374	olive angry inch	0		
@@ -6295,7 +6295,7 @@
 6400	Mer-kin lunchbox	0		
 6401	energized quadruple-pressed wobbly tear	0		Effect: "Filled with Magic", Effect Duration: 53
 6402	altered squat jagged tooth	0		Effect: "Jelly Combed", Effect Duration: 37
-6403	enhanced narrow wobbly grisly shell fragment	0		Effect: "Oily Flavor", Effect Duration: 57
+6403	enhanced wobbly narrow grisly shell fragment	0		Effect: "Oily Flavor", Effect Duration: 57
 6404	adjusted deionized violent pastilles	0		Effect: "Human-Orc Hybrid", Effect Duration: 30
 6405	concentrated nitrogenated worst candy	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 17
 6406	improved concentrated teal fudge-shaped hole in space-time	0		Effect: "Ooh, Sweet!", Effect Duration: 39
@@ -6307,7 +6307,7 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	half-sized decent mirror flavorless gruel	2	good	
+6415	decent half-sized mirror flavorless gruel	2	good	
 6416	moldy mana curds	4	crappy	
 6417	twirling twist of lime	0		
 6418	pencil stub	0		
@@ -6345,7 +6345,7 @@
 6450	huge hardy Great Wolf's rocket launcher of the cheetah	0		Maximum HP: +50, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	skewed lard-coated wholesome savvy Great Wolf's beastly trousers	0		Mysticality Percent: +20, Maximum HP Percent: +10, Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, 1.5xWhelp"
 6452	huge ghostly Great Wolf's lice	0		
-6453	double-liquefied spinning jittery gray Hunger&trade; Sauce	0		Effect: "Far Out", Effect Duration: 32
+6453	double-liquefied gray spinning jittery Hunger&trade; Sauce	0		Effect: "Far Out", Effect Duration: 32
 6454	cyan gravedigger's Lo Pan's resourceful zombie mariachi hat	0		Maximum MP: +50, Spell Critical Percent: +30, Spooky Damage: +10, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	shaking miser's flame-wreathed dance instructor's zombie accordion	0		Experience Percent (Moxie): +10, Hot Spell Damage: +10, Meat Drop: +10, Class: "Accordion Thief", Single Equip, Song Duration: 20
 6456	supercharged zombie mariachi pants of Tarzan of the boozehound	0		Experience (Muscle): +3, Maximum MP Percent: +30, Booze Drop: +100, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
@@ -6367,7 +6367,7 @@
 6472	skewed Drunkula's bell	0		
 6473	Samson's smartaleck's Drunkula's ring of haze of bravery	0		Moxie Percent: +30, Experience (Muscle): +5, Spooky Resistance: +5, Avoid Attack: 1, Single Equip
 6474	Sherlock's Drunkula's wineglass	0		Item Drop: +25
-6475	acceptable watered-down bottle of Bloodweiser	2	good	
+6475	watered-down acceptable bottle of Bloodweiser	2	good	
 6476	shaking miser's inspector's foul-smelling Unkillable Skeleton's skullcap	0		Stench Damage: +10, Item Drop: +15, Meat Drop: +10, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	bouncing rock-hard quilted Unkillable Skeleton's breastplate of the cheetah	0		Damage Absorption: +40, Damage Reduction: 5, Initiative: +60, Class: "Turtle Tamer"
 6478	sharpshooter's energetic padded Unkillable Skeleton's shinguards	0		Damage Absorption: +20, Maximum MP Percent: +20, Critical Hit Percent: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	spinning dreadful roast	0		
 6487	twirling stinking agaricus	0		
-6488	yummy fancy miniature Dreadsylvanian shepherd's pie	2	awesome	Effect: "Hangdog", Effect Duration: 30
+6488	fancy yummy miniature Dreadsylvanian shepherd's pie	2	awesome	Effect: "Hangdog", Effect Duration: 30
 6489	music box parts	0		
 6490	ghostly unwound mechanical songbird	0		
 6491	purple tailfeathers	0		Familiar Weight: +5
@@ -6390,7 +6390,7 @@
 6495	sage Dreadsylvania Auditor's badge	0		Mysticality Percent: +10, Kruegerand Drop: 5, Single Equip
 6496	skewed blood kiwi	0		
 6497	eau de mort	0		
-6498	weak aged bloody kiwitini	2	awesome	
+6498	aged weak bloody kiwitini	2	awesome	
 6499	moon-amber	0		
 6500	blinking polished moon-amber	0		
 6501	mirror shellacked stiffened moon-amber necklace of the glutton	0		Damage Reduction: 16, Food Drop: +100, Single Equip
@@ -6421,7 +6421,7 @@
 6526	occult bag of unfinished business of incineration	0		Spell Damage Percent: +25, Hot Spell Damage: +50
 6527	chilly transparent pants of Leguizamo	0		Monster Level: +20, Cold Damage: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	nasty hothammer	0		Stench Damage: +5
-6529	watered-down bad Thriller Ice	2	decent	
+6529	bad watered-down Thriller Ice	2	decent	
 6530	green nasty grandfather watch	0		Stench Damage: +5, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	Lo Pan's Samson's spyglass	0		Experience (Muscle): +5, Spell Critical Percent: +30
@@ -6455,13 +6455,13 @@
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	Jack Frost's hand of Mr. Cards	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	spoiled super-sized upside-down Dreadsylvanian hot pocket	5	crappy	
-6565	thick flavorless Dreadsylvanian pocket	5	decent	
-6566	stale small narrow teal Dreadsylvanian pocket	2	decent	
+6564	super-sized spoiled upside-down Dreadsylvanian hot pocket	5	crappy	
+6565	flavorless thick Dreadsylvanian pocket	5	decent	
+6566	small stale narrow teal Dreadsylvanian pocket	2	decent	
 6567	spoiled pulsating blurry Dreadsylvanian stink pocket	3	crappy	
 6568	rotten Dreadsylvanian sleaze pocket	4	crappy	
-6569	practically non-alcoholic mediocre Dreadsylvanian hot toddy	1	decent	
-6570	practically non-alcoholic drinkable Dreadsylvanian cold-fashioned	1	good	
+6569	mediocre practically non-alcoholic Dreadsylvanian hot toddy	1	decent	
+6570	drinkable practically non-alcoholic Dreadsylvanian cold-fashioned	1	good	
 6571	aged watered-down wobbly Dreadsylvanian grimlet	2	awesome	
 6572	perfectly mixed Dreadsylvanian dank and stormy	3	super ultra mega turbo EPIC	
 6573	hand-crafted Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
@@ -6504,7 +6504,7 @@
 6610	clockwork numeral X	0		
 6611	squat clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
-6613	squat blurry clockwork cuckoo	0		
+6613	blurry squat clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	tolerable mirror Cold One	4	???	
 6616	toothsome spaghetti breakfast	3	???	
@@ -6518,7 +6518,7 @@
 6624	bouncing folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	twirling folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
-6627	shaking skewed folder (D-Team)	0		Last Available: "2013-08"
+6627	skewed shaking folder (D-Team)	0		Last Available: "2013-08"
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	bouncing folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
@@ -6526,7 +6526,7 @@
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	skewed folder (barbarian)	0		Last Available: "2013-08"
 6634	folder (rainbow unicorn)	0		Last Available: "2013-08"
-6635	blue jittery folder (Seawolf)	0		Last Available: "2013-08"
+6635	jittery blue folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	tumbling folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
@@ -6563,7 +6563,7 @@
 6671	vacuum-sealed nitrogenated gray sodium pentasomething	0		Effect: "Trash-Wrapped", Effect Duration: 32
 6672	grains of salt	0		
 6673	green yellowcake bomb	0		
-6674	blue wobbly stinkbomb	0		
+6674	wobbly blue stinkbomb	0		
 6675	activated twirling superwater	0		Effect: "Devil Inside", Effect Duration: 16
 6676	Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
@@ -6594,7 +6594,7 @@
 6702	wobbly bowler	0		
 6703	imitation White Russian	1	awesome	
 6704	greasy short-handled mop of the brazier	0		Hot Spell Damage: +25, Sleaze Spell Damage: +10
-6705	moldy narrow upside-down jungle floor wax	3	crappy	
+6705	moldy upside-down narrow jungle floor wax	3	crappy	
 6706	tumbling smirking shrunken head	0		
 6707	electrified warmed colorful toad	0		Effect: "Deadly Flashing Blade", Effect Duration: 47
 6708	crude voodoo doll	0		
@@ -6634,7 +6634,7 @@
 6742	skewed MacGyver's junk band	0		Maximum MP: +100
 6743	junk trunks of the businessman	0		Meat Drop: +50, Familiar Effect: "cap 15"
 6744	pulsating up-at-dawn junk-mail shirt	0		Adventures: +5
-6745	stale half-sized junk food	2	decent	
+6745	half-sized stale junk food	2	decent	
 6746	watered-down artisanal junk yard	2	EPIC	
 6747	skewed lightning-fast shellacked swordzall	0		Damage Reduction: 7, Initiative: +40
 6748	ruddy arm buzzer	0		Maximum HP Percent: +40, Damage Reduction: 6
@@ -6642,19 +6642,19 @@
 6750	shaking shaking Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	blue packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
-6753	narrow blue cluster of hops	0		
+6753	blue narrow cluster of hops	0		
 6754	beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	tolerable triple-distilled blinking can of Br&uuml;talbr&auml;u	6	good	Last Available: "2013-09"
-6758	perfectly mixed irresponsibly strong can of Drooling Monk	7	EPIC	Last Available: "2013-09"
+6757	triple-distilled tolerable blinking can of Br&uuml;talbr&auml;u	6	good	Last Available: "2013-09"
+6758	irresponsibly strong perfectly mixed can of Drooling Monk	7	EPIC	Last Available: "2013-09"
 6759	mediocre can of Impetuous Scofflaw	4	decent	Last Available: "2013-09"
 6760	triple-distilled lousy tumbling bottle of Old Pugilist	9	decent	Last Available: "2013-09"
 6761	tolerable strong bottle of Professor Beer	5	good	Last Available: "2013-09"
-6762	special practically non-alcoholic perfectly mixed bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Effect: "Nightstalkin'", Effect Duration: 50, Last Available: "2013-09"
-6763	artisanal fancy bottle of Race Car Red	3	EPIC	Effect: "Black Eyes", Effect Duration: 25, Last Available: "2013-09"
+6762	practically non-alcoholic perfectly mixed special bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Effect: "Nightstalkin'", Effect Duration: 50, Last Available: "2013-09"
+6763	fancy artisanal bottle of Race Car Red	3	EPIC	Effect: "Black Eyes", Effect Duration: 25, Last Available: "2013-09"
 6764	bad bottle of Greedy Dog	3	decent	Last Available: "2013-09"
-6765	watered-down lousy bottle of Lambada Lambic	2	decent	Last Available: "2013-09"
+6765	lousy watered-down bottle of Lambada Lambic	2	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	squat artisanal homebrew gift package	0		
 6768	liquid bread	1	awesome	Last Available: "2013-09"
@@ -6664,9 +6664,9 @@
 6772	wobbly sage tin drum of the brute of the brazier	0		Muscle Percent: +30, Mysticality Percent: +10, Hot Spell Damage: +25, Last Available: "2013-09"
 6773	blue tin roof (rusted)	0		Last Available: "2013-09"
 6774	red tin snips	0		Last Available: "2013-09"
-6775	teal bouncing upside-down tin lizzie	0		Last Available: "2013-09"
+6775	upside-down teal bouncing tin lizzie	0		Last Available: "2013-09"
 6776	flattened diffused foetid seal tear	0		Effect: "Fancy Feasted", Effect Duration: 44
-6777	ionized unsweetened maroon spinning shaking seal sweat	0		Effect: "Dreams and Lights", Effect Duration: 23
+6777	ionized unsweetened spinning shaking maroon seal sweat	0		Effect: "Dreams and Lights", Effect Duration: 23
 6778	corrupted anodized mirror boiling seal blood	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 60
 6779	crystalline seal eye	0		Single Equip
 6780	nasty studded sealhide shield of horror	0		Stench Damage: +5, Spooky Spell Damage: +25, Damage Reduction: 7
@@ -6684,15 +6684,15 @@
 6795	deionized concentrated wobbly disco horoscope (Aquarius)	0		Effect: "Stuck That Way", Effect Duration: 35
 6796	dry disco horoscope (Pisces)	0		Effect: "There Wolf", Effect Duration: 63
 6797	ionized disco horoscope (Aries)	0		Effect: "Carrrsmic", Effect Duration: 49
-6798	chilled pulsating pulsating upside-down disco horoscope (Taurus)	0		Effect: "Coldfinger", Effect Duration: 21
+6798	chilled pulsating upside-down pulsating disco horoscope (Taurus)	0		Effect: "Coldfinger", Effect Duration: 21
 6799	improved quantum disco horoscope (Gemini)	0		Effect: "Pronounced Potency", Effect Duration: 47
 6800	irradiated dry cyan disco horoscope (Cancer)	0		Effect: "Fever From the Flavor", Effect Duration: 63
 6801	quantum disco horoscope (Leo)	0		Effect: "Beta Carotene Overdose", Effect Duration: 11
-6802	quadruple-chilled non-altered non-quantum maroon shaking disco horoscope (Virgo)	0		Effect: "Ooh, Salty!", Effect Duration: 22
+6802	quadruple-chilled non-altered non-quantum shaking maroon disco horoscope (Virgo)	0		Effect: "Ooh, Salty!", Effect Duration: 22
 6803	ionized irradiated polymerized ghostly disco horoscope (Libra)	0		Effect: "Slimed Stomach", Effect Duration: 62
 6804	galvanized oxidized disco horoscope (Scorpio)	0		Effect: "White-boy Angst", Effect Duration: 25
 6805	triple-deionized disco horoscope (Sagittarius)	0		Effect: "Can Has Cyborger", Effect Duration: 18
-6806	double-pressed nitrogenated twirling upside-down disco horoscope (Capricorn)	0		Effect: "Swordholder", Effect Duration: 64
+6806	double-pressed nitrogenated upside-down twirling disco horoscope (Capricorn)	0		Effect: "Swordholder", Effect Duration: 64
 6807	huge Jack Frost's strapping The Sagittarian's leisure pants	0		Muscle: +5, Cold Spell Damage: +50, Familiar Effect: "atk, cap 18"
 6808	toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
@@ -6750,7 +6750,7 @@
 6861	massive decent can of sardines	8	good	Last Available: "2013-11"
 6862	half-sized normal purple high-calorie sugar substitute	2	good	Last Available: "2013-11"
 6863	rotten shaking pat of butter	3	crappy	Last Available: "2013-11"
-6864	thick moldy dinner roll	5	crappy	Last Available: "2013-11"
+6864	moldy thick dinner roll	5	crappy	Last Available: "2013-11"
 6865	tasty mashed potatoes	3	awesome	Last Available: "2013-11"
 6866	flavorless whole turkey leg	3	decent	Last Available: "2013-11"
 6867	bland deviled egg	4	decent	Last Available: "2013-11"
@@ -6759,7 +6759,7 @@
 6870	quadruple-alkaline triple-deionized love note	0		Effect: "Shawarma Initiative", Effect Duration: 13, Last Available: "2013-11"
 6871	gray school beer pull tab	0		Last Available: "2013-11"
 6872	modified ionized nail file	0		Effect: "Punch Another Day", Effect Duration: 68, Last Available: "2013-11"
-6873	non-liquefied activated twirling narrow candy wrapper	0		Effect: "Liquidy Smoky", Effect Duration: 16, Last Available: "2013-11"
+6873	non-liquefied activated narrow twirling candy wrapper	0		Effect: "Liquidy Smoky", Effect Duration: 16, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	activated post-holiday sale coupon	0		Effect: "In Vino Vires", Effect Duration: 17, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
@@ -6781,8 +6781,8 @@
 6892	aerosolized blinking spoonful of Linguine-Os	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 14, Last Available: "2013-11"
 6893	corrupted colloidal freezer-burned frost-bitten tortellini	0		Effect: "Ancient Protected", Effect Duration: 61, Last Available: "2013-11"
 6894	oxidized blinking blob of Alphredo&trade;	0		Effect: "Gr8ness", Effect Duration: 36, Last Available: "2013-11"
-6895	polarized green tumbling handful of crafty noodles	0		Effect: "French Bronilla Brogueishness", Effect Duration: 53, Last Available: "2013-11"
-6896	corrupted chilled altered fuchsia pulsating tangled mass of pasta	0		Effect: "Extra-Sharp Weapon", Effect Duration: 29, Last Available: "2013-11"
+6895	polarized tumbling green handful of crafty noodles	0		Effect: "French Bronilla Brogueishness", Effect Duration: 53, Last Available: "2013-11"
+6896	corrupted chilled altered pulsating fuchsia tangled mass of pasta	0		Effect: "Extra-Sharp Weapon", Effect Duration: 29, Last Available: "2013-11"
 6897	vacuum-sealed Can of Spaghetto	0		Effect: "Protection from Bad Stuff", Effect Duration: 60, Last Available: "2013-11"
 6898	gray Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	skewed Thwaitgold ant statuette	0		
@@ -6792,7 +6792,7 @@
 6903	oxidized corrupted polymerized nuts	0		Effect: "Sappy Blood", Effect Duration: 68, Last Available: "2013-12"
 6904	pickled enhanced bolts	0		Effect: "Whole Latte Love", Effect Duration: 30, Last Available: "2013-12"
 6905	decent gingerbread robot	3	good	Last Available: "2013-12"
-6906	jumbo fancy delicious petit 4.1	5	awesome	Effect: "Orchid Blood", Effect Duration: 35, Last Available: "2013-12"
+6906	delicious fancy jumbo petit 4.1	5	awesome	Effect: "Orchid Blood", Effect Duration: 35, Last Available: "2013-12"
 6907	flavorless nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
 6908	veiny plastic GORM-8	0		Maximum HP: +10, Last Available: "2013-12"
 6909	Jeselnik's plastic warbear	0		Sleaze Damage: +25, Last Available: "2013-12"
@@ -6810,7 +6810,7 @@
 6921	yummy warbear feasting bread	3	awesome	Last Available: "2013-12"
 6922	small moldy warbear warrior bread	2	crappy	Last Available: "2013-12"
 6923	immense flavorless warbear thermoregulator bread	7	decent	Last Available: "2013-12"
-6924	perfectly mixed extra-dry mirror huge warbear feasting mead	5	EPIC	Last Available: "2013-12"
+6924	extra-dry perfectly mixed huge mirror warbear feasting mead	5	EPIC	Last Available: "2013-12"
 6925	lousy distilled warbear bearserker mead	5	decent	Last Available: "2013-12"
 6926	perfectly mixed special warbear blizzard mead	4	EPIC	Effect: "Metal Speed", Effect Duration: 5, Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	hale die-cast Don Crimbo of Tarzan	0		Experience (Muscle): +3, Maximum HP: +20, Last Available: "2013-12"
 7001	quilted die-cast Uncle Hobo of the glutton	0		Damage Absorption: +40, Food Drop: +100, Last Available: "2013-12"
 7002	tumbling ribald smelly die-cast Father Crimbo	0		Stench Spell Damage: +10, Sleaze Damage: +10, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	nitrogenated Flaskfull of Hollow	0		Effect: "Chief Executive Optimism", Effect Duration: 21, Last Available: "2013-12"
 7005	fuchsia lump of Brituminous coal	0		Last Available: "2013-12"
 7006	denatured handful of Smithereens	1	crappy	Last Available: "2013-12"
 7007	decent Every Day is Like This Sundae	4	good	Last Available: "2013-12"
-7008	tiny adequate Miserable Pie	1	good	Last Available: "2013-12"
+7008	adequate tiny Miserable Pie	1	good	Last Available: "2013-12"
 7009	moldy This Charming Flan	3	crappy	Last Available: "2013-12"
 7010	weak hand-crafted huge Irish Coffee, English Heart	2	EPIC	Last Available: "2013-12"
 7011	acceptable twirling Strikes Again Bigmouth	3	good	Last Available: "2013-12"
-7012	watered-down artisanal Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
+7012	artisanal watered-down Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	skewed Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	upside-down huge resourceful ruddy Shakespeare's Sister's Accordion of the boozehound	0		Maximum HP Percent: +40, Maximum MP: +50, Booze Drop: +100, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	huge Jeselnik's third-hand lantern	0		Sleaze Damage: +25
 7031	spinning loose purse strings	0		
-7032	miniature stale enchanted skewed pickled egg	2	decent	Effect: "Partially Ghosted", Effect Duration: 35
+7032	enchanted stale miniature skewed pickled egg	2	decent	Effect: "Partially Ghosted", Effect Duration: 35
 7033	cup of lukewarm tea	1	EPIC	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	bouncing warbear box	0		Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	bland special huge breakfast mess	3	decent	Effect: "Rave Nirvana", Effect Duration: 5, Last Available: "2013-12"
+7055	special bland huge breakfast mess	3	decent	Effect: "Rave Nirvana", Effect Duration: 5, Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	rotten breakfast miracle	3	crappy	Last Available: "2013-12"
 7058	quantum Cloaca Cola Polar	0		Effect: "Spookyravin'", Effect Duration: 50, Last Available: "2013-12"
@@ -6957,14 +6957,14 @@
 7068	pressed wet pulsating single of Donho's Bubbly Ballad	0		Effect: "The Spy Who Loved XP", Effect Duration: 69
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	decent half-sized snow berries	2	good	Last Available: "2014-01"
+7071	half-sized decent snow berries	2	good	Last Available: "2014-01"
 7072	diet decent ice harvest	1	good	Last Available: "2014-01"
 7073	electrified spinning frost flower	0		Effect: "Surreally Buff", Effect Duration: 23, Last Available: "2014-01"
 7074	magnetized colloidal snow cleats	0		Effect: "Full-Body Tan", Effect Duration: 55, Last Available: "2014-01"
 7075	warmed adjusted jittery liquid ice pack	0		Effect: "Toast Tea", Effect Duration: 62, Last Available: "2014-01"
 7076	upside-down maroon snow boards	0		Last Available: "2014-01"
 7077	rotten snow crab	3	crappy	Last Available: "2014-01"
-7078	triple-distilled hand-crafted ghostly Ice Island Long Tea	6	EPIC	Last Available: "2014-01"
+7078	hand-crafted triple-distilled ghostly Ice Island Long Tea	6	EPIC	Last Available: "2014-01"
 7079	tumbling unfinished ice sculpture	0		Last Available: "2014-01"
 7080	blinking ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6992,16 +6992,16 @@
 7103	alkaline ionized powder	0		Effect: "Violent Night", Effect Duration: 57, Last Available: "2014-12"
 7104	bouncing shaking hardy licorice whip	0		Maximum HP: +50, Last Available: "2014-12"
 7105	gray anise-flavored venom	0		Last Available: "2014-12"
-7106	watered-down fancy acceptable snakebite	2	good	Effect: "Hammertime", Effect Duration: 25, Last Available: "2014-12"
+7106	fancy acceptable watered-down snakebite	2	good	Effect: "Hammertime", Effect Duration: 25, Last Available: "2014-12"
 7107	nippy candy stick of chilblains	0		Cold Damage: 35, Last Available: "2014-12"
-7108	bland small upside-down pecan	2	decent	Last Available: "2014-12"
+7108	small bland upside-down pecan	2	decent	Last Available: "2014-12"
 7109	adequate mirror pecan pie	4	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	special bland small candy mountain oyster	2	decent	Effect: "Frog In Your Throat", Effect Duration: 35, Last Available: "2014-12"
 7112	enchanted delicious pulsating chocotini	3	awesome	Effect: "Hare-o-dynamic", Effect Duration: 5, Last Available: "2014-12"
 7113	sage brawny weightlifter's chocolate rabbit's foot	0		Muscle: +15, Muscle Percent: +20, Mysticality Percent: +10, Last Available: "2014-12"
-7114	bland big candy carrot	5	decent	Last Available: "2014-12"
-7115	bland big candy carrot cake	5	decent	Last Available: "2014-12"
+7114	big bland candy carrot	5	decent	Last Available: "2014-12"
+7115	big bland candy carrot cake	5	decent	Last Available: "2014-12"
 7116	family-friendly electrified carrot-on-a-stick	0		Sleaze Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7117	boxer's weasel stomping pants of Tarzan	0		Muscle Percent: +10, Experience (Muscle): +3, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	special flavorless teal mulberry	3	decent	Effect: "Items Are Forever", Effect Duration: 35, Last Available: "2014-12"
@@ -7024,7 +7024,7 @@
 7135	adequate witch's bread	4	good	Last Available: "2014-12"
 7136	alkaline witch's brew	0		Effect: "Warm Shoulders", Effect Duration: 61, Last Available: "2014-12"
 7137	nippy Tesla witch's bra of the wise owl	0		Mysticality: +20, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12"
-7138	tolerable irresponsibly strong mid-level medieval mead	6	good	Last Available: "2014-12"
+7138	irresponsibly strong tolerable mid-level medieval mead	6	good	Last Available: "2014-12"
 7139	dry moist R&uuml;mpelstiltz	0		Effect: "Infernal Thirst", Effect Duration: 69, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	vacuum-sealed hi-octane carrot juice	0		Effect: "All Blued Up", Effect Duration: 46, Last Available: "2014-12"
@@ -7042,20 +7042,20 @@
 7153	maroon ghostly clay	0		Last Available: "2014-12"
 7154	wobbly filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
-7156	narrow blurry squat glass	0		Last Available: "2014-12"
+7156	squat blurry narrow glass	0		Last Available: "2014-12"
 7157	Temple Grandin's chaotic fire hose of the businessman	0		Spell Critical Percent: +10, Familiar Weight: +7, Meat Drop: +50, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	huge rotten ghostly fireman's lunch	6	crappy	Last Available: "2014-12"
+7158	rotten huge ghostly fireman's lunch	6	crappy	Last Available: "2014-12"
 7159	green lightning-fast stylish plain paper hat of dire peril	0		Moxie: +25, Weapon Damage: +20, Initiative: +40, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	low-calorie decent ice cream sandwich	1	good	Last Available: "2014-12"
+7160	decent low-calorie ice cream sandwich	1	good	Last Available: "2014-12"
 7161	blinking zippy &quot;honey&quot; dipper of the dark arts of the scaredy-cat	0		Spell Damage Percent: +100, Monster Level: -15, Initiative: +20, Last Available: "2014-12"
 7162	decent low-calorie plumber's lunch	1	good	Last Available: "2014-12"
 7163	flame-retardant savvy skull gearshift knob of the detective	0		Mysticality Percent: +20, Hot Resistance: +1, Item Drop: +20, Last Available: "2014-12"
 7164	jumbo flavorless nachos of the night	5	decent	Last Available: "2014-12"
 7165	blue medical-grade baleful Sketcherz&trade; of the cougar	0		Moxie: +20, Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12"
-7166	small bland can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
+7166	bland small can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
 7167	dry smudge stick	0		Effect: "Granolarrrgh", Effect Duration: 32, Last Available: "2014-12"
 7168	quadruple-polymerized wall	0		Effect: "Ooh, Salty!", Effect Duration: 58, Last Available: "2014-12"
-7169	hand-crafted distilled tankard of ale	5	EPIC	Last Available: "2014-12"
+7169	distilled hand-crafted tankard of ale	5	EPIC	Last Available: "2014-12"
 7170	double-unsweetened pressed gray scroll case	0		Effect: "Less Pervious", Effect Duration: 64, Last Available: "2014-12"
 7171	moist warmed jug of &quot;wine&quot;	0		Effect: "Frisky Spirit", Effect Duration: 35, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7067,7 +7067,7 @@
 7178	spinning Copperhead Charm	0		
 7179	The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
-7181	mirror ghostly The Eye of the Stars	0		
+7181	ghostly mirror The Eye of the Stars	0		
 7182	The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	Oprah's Buddy Bjorn	0		Maximum MP Percent: +50, Softcore Only, Last Available: "2014-02"
 7201	narrow rosewater-soaked ruddy The Nuge's favorite crossbow of the glutton	0		Maximum HP Percent: +40, Stench Resistance: +3, Food Drop: +100
-7202	stale thick sweet roll Alabama	5	decent	
+7202	thick stale sweet roll Alabama	5	decent	
 7203	spinning skewed Jeselnik's Saturday Night Special	0		Sleaze Damage: +25
 7204	lynyrd snare	0		
 7205	fuchsia banded fleetwood chain	0		Damage Absorption: +100
@@ -7096,7 +7096,7 @@
 7207	frosty blade	0		Cold Spell Damage: +10
 7208	fire of unknown origin	0		
 7209	blinking eagle's milk	1	awesome	
-7210	super-wet polymerized jittery blinking eagle feather	0		Effect: "Compensatory Cruelness", Effect Duration: 12
+7210	super-wet polymerized blinking jittery eagle feather	0		Effect: "Compensatory Cruelness", Effect Duration: 12
 7211	colloidal denatured bouncing one pill	0		Effect: "Lifted Spirits", Effect Duration: 15
 7212	olive Jefferson wings of the cheetah	0		Initiative: +60
 7213	skewed fleetwood macaroni	0		
@@ -7108,16 +7108,16 @@
 7219	twirling wicked lynyrdskin breeches	0		Spell Damage: +5, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	watered-down drinkable twirling blinking Flamin' Whatshisname	2	good	
+7222	drinkable watered-down twirling blinking Flamin' Whatshisname	2	good	
 7223	alkaline super-galvanized blue lynyrd musk	0		Effect: "All Blued Up", Effect Duration: 22
 7224	Usain Bolt's crafty Kashmir sweater	0		Maximum MP: +10, Initiative: +80
 7225	decent custard pie	3	good	
 7226	tea for one	1	good	
-7227	practically non-alcoholic smooth bottle of Evermore	1	awesome	
-7228	blurry blue box	0		
-7229	aged distilled huge wine	5	awesome	
+7227	smooth practically non-alcoholic bottle of Evermore	1	awesome	
+7228	blue blurry box	0		
+7229	distilled aged huge wine	5	awesome	
 7230	mediocre rum	4	decent	
-7231	perfectly mixed weak Murderer's Punch	2	EPIC	
+7231	weak perfectly mixed Murderer's Punch	2	EPIC	
 7232	flavorless velvet cake	3	decent	
 7233	triple-altered letter	0		Effect: "Sticks and Stones", Effect Duration: 34
 7234	Jack Frost's Oprah's book	0		Maximum MP Percent: +50, Cold Spell Damage: +50
@@ -7131,17 +7131,17 @@
 7242	button	0		
 7243	blurry button	0		
 7244	concentrated enhanced blurry blood cells	0		Effect: "Disdain of the War Snapper", Effect Duration: 46
-7245	non-wet double-ionized huge red twirling eye	0		Effect: "Antsy in your Pantsy", Effect Duration: 13
+7245	non-wet double-ionized twirling red huge eye	0		Effect: "Antsy in your Pantsy", Effect Duration: 13
 7246	glark cable	0		
 7247	stanky Red Fox glove of the boozehound	0		Stench Spell Damage: +25, Booze Drop: +100, Attacks Can't Miss, Single Equip
 7248	concentrated energized polymerized foxglove	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 19
-7249	tumbling spinning Thwaitgold dragonfly statuette	0		
+7249	spinning tumbling Thwaitgold dragonfly statuette	0		
 7250	bouncing Temple Grandin's arcane researcher's Sneaky Pete's jacket of wisdom of the sewer	0		Mysticality: +15, Experience Percent (Mysticality): +10, Familiar Weight: +7, Stench Damage: +25, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	jug of Sneaky Pete's Mojo	0		Free Pull
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	drinkable weak mini-martini	2	good	
+7255	weak drinkable mini-martini	2	good	
 7256	smoke grenade	0		
 7257	vaporized molotov soda	1	decent	
 7258	altered aerosolized pile of ashes	0		Effect: "Partially Ghosted", Effect Duration: 32
@@ -7169,14 +7169,14 @@
 7280	chilled wind-up vampire teeth	0		Effect: "Impregnably Delicious", Effect Duration: 69
 7281	pressed wind-up navigation droid	0		Effect: "Extra Backbone", Effect Duration: 45
 7282	altered irradiated wind-up owl	0		Effect: "Cold Throat", Effect Duration: 52
-7283	tarnished energized blinking red bouncing wind-up ensign	0		Effect: "Object Detection", Effect Duration: 37
+7283	tarnished energized blinking bouncing red wind-up ensign	0		Effect: "Object Detection", Effect Duration: 37
 7284	upside-down blue careful Newton's crying statue earrings	0		Experience (Mysticality): +3, Monster Level: -10, Single Equip, Lasts Until Rollover
 7285	blurry gray sizzling Sinatra's plastic Duskwalker necklace	0		Experience (Moxie): +5, Hot Damage: +10, Single Equip, Lasts Until Rollover
 7286	friendly wicked plastic replica blaster pistol	0		Spell Damage: +5, Familiar Weight: +3, Lasts Until Rollover
 7287	friendly Tesla Gary Claybender's Time Screwer	0		Familiar Weight: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover
 7288	banded Space Tourist palmdoctor of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Lasts Until Rollover
 7289	curative dance instructor's boxer's amok putter	0		Muscle Percent: +10, Experience Percent (Moxie): +10, HP Regen Min: 3, HP Regen Max: 5
-7290	fancy rotten amok pudding	3	crappy	Effect: "Buttermilk Boogie", Effect Duration: 35
+7290	rotten fancy amok pudding	3	crappy	Effect: "Buttermilk Boogie", Effect Duration: 35
 7291	deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	tarnished enhanced quantum yellow spinning can of V-11	0		Effect: "Thicker, Sicker", Effect Duration: 33, Last Available: "2014-03"
@@ -7196,9 +7196,9 @@
 7307	red Lady Spookyraven's dancing shoes	0		
 7308	diffused eyebrow pencil	0		Effect: "This Is Where You're a Viking", Effect Duration: 24
 7309	dry vacuum-sealed jittery rosewater cream	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 58
-7310	energized altered yellow spinning bronzer	0		Effect: "Hoity Toity", Effect Duration: 66
+7310	energized altered spinning yellow bronzer	0		Effect: "Hoity Toity", Effect Duration: 66
 7311	tumbling rock-hard sage elegant nightstick	0		Mysticality Percent: +10, Damage Reduction: 5
-7312	pulsating upside-down still grill	0		Free Pull, Last Available: "2014-06"
+7312	upside-down pulsating still grill	0		Free Pull, Last Available: "2014-06"
 7313	purple box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	rickety rocking horse	0		
@@ -7210,7 +7210,7 @@
 7321	electrified Stephen's lab coat of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5
 7322	unsweetened quadruple-adjusted Vulcanized Stephen's secret formula	0		Effect: "License to Punch", Effect Duration: 58
 7323	greasy Jeselnik's Jacob's rung	0		Sleaze Damage: +25, Sleaze Spell Damage: +10
-7324	compressed upside-down bouncing battery	1		
+7324	compressed bouncing upside-down battery	1		
 7325	mediocre practically non-alcoholic snakebite	1	decent	
 7326	bouncing rosewater-soaked Da Vinci's rubber ribcage	0		Experience (Mysticality): +5, Stench Resistance: +3, Damage Reduction: 7
 7327	dehydrated blurry synthetic marrow	1		
@@ -7234,8 +7234,8 @@
 7345	shaking ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	perfumed ghost toga of the detective	0		Stench Resistance: +5, Item Drop: +20
-7348	bland small sheet cake	2	decent	
-7349	ghostly shaking ghost key	0		
+7348	small bland sheet cake	2	decent	
+7349	shaking ghostly ghost key	0		
 7350	picture of you	0		
 7351	lime green Sherlock's supercharged smartaleck's Staff of the Electric Range	0		Moxie Percent: +30, Maximum MP Percent: +30, Item Drop: +25
 7352	stale miniature deluxe layer cake	2	decent	
@@ -7249,7 +7249,7 @@
 7360	plaid bandage	0		
 7361	scorching plaid pocket square	0		Hot Damage: +25
 7362	Temple Grandin's Oprah's plaid skirt	0		Maximum MP Percent: +50, Familiar Weight: +7, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-7363	triple-polymerized blinking pulsating maroon bloodstain stick	0		Effect: "Top Dog", Effect Duration: 58
+7363	triple-polymerized pulsating blinking maroon bloodstain stick	0		Effect: "Top Dog", Effect Duration: 58
 7364	pulsating fabric softener	0		
 7365	denatured fabric hardener	0		Effect: "Chock Full o' Nanites", Effect Duration: 42
 7366	weak acceptable bottle of laundry sherry	2	good	
@@ -7273,14 +7273,14 @@
 7384	wet modified pulsating Gene Tonic: Dude	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 22, Last Available: "2014-04"
 7385	ionized unsweetened twirling Gene Tonic: Beast	0		Effect: "Cookie Backup", Effect Duration: 56, Last Available: "2014-04"
 7386	corrupted Gene Tonic: Construct	0		Effect: "Got Your Boots On", Effect Duration: 12, Last Available: "2014-04"
-7387	frozen quadruple-pickled squat huge fuchsia Gene Tonic: Undead	0		Effect: "Nut-Rition", Effect Duration: 69, Last Available: "2014-04"
+7387	frozen quadruple-pickled huge fuchsia squat Gene Tonic: Undead	0		Effect: "Nut-Rition", Effect Duration: 69, Last Available: "2014-04"
 7388	liquefied huge Gene Tonic: Humanoid	0		Effect: "License to Punch", Effect Duration: 64, Last Available: "2014-04"
 7389	moist vacuum-sealed Gene Tonic: Insect	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 19, Last Available: "2014-04"
 7390	electrified quadruple-altered shaking Gene Tonic: Hippy	0		Effect: "White Blooded", Effect Duration: 59, Last Available: "2014-04"
 7391	super-flattened triple-enhanced tumbling Gene Tonic: Orc	0		Effect: "Healthy Blue Glow", Effect Duration: 54, Last Available: "2014-04"
 7392	pickled Gene Tonic: Demon	0		Effect: "Pasty", Effect Duration: 13, Last Available: "2014-04"
 7393	deionized purple Gene Tonic: Horror	0		Effect: "Superhuman Sarcasm", Effect Duration: 55, Last Available: "2014-04"
-7394	galvanized magnetized red mirror squat Gene Tonic: Fish	0		Effect: "Blackberry Politeness", Effect Duration: 20, Last Available: "2014-04"
+7394	galvanized magnetized squat mirror red Gene Tonic: Fish	0		Effect: "Blackberry Politeness", Effect Duration: 20, Last Available: "2014-04"
 7395	frozen Gene Tonic: Goblin	0		Effect: "Nigh-Invincible", Effect Duration: 46, Last Available: "2014-04"
 7396	polymerized triple-Vulcanized Gene Tonic: Pirate	0		Effect: "Angry like the Wolf", Effect Duration: 46, Last Available: "2014-04"
 7397	energized Gene Tonic: Plant	0		Effect: "The Dinsey Way", Effect Duration: 55, Last Available: "2014-04"
@@ -7292,7 +7292,7 @@
 7403	dry wobbly Gene Tonic: Elemental	0		Effect: "Spiritually Awake", Effect Duration: 32, Last Available: "2014-04"
 7404	altered extra-modified Gene Tonic: Constellation	0		Effect: "Bloody-minded", Effect Duration: 31, Last Available: "2014-04"
 7405	anodized galvanized enhanced Gene Tonic: Hobo	0		Effect: "Slimy Hands", Effect Duration: 49, Last Available: "2014-04"
-7406	bouncing pulsating Steam Card: Dungeon Fist (#1)	0		
+7406	pulsating bouncing Steam Card: Dungeon Fist (#1)	0		
 7407	blinking Steam Card: Dungeon Fist (#2)	0		
 7408	Steam Card: Dungeon Fist (#3)	0		
 7409	skewed Steam Card: Space Trip (#1)	0		
@@ -7307,7 +7307,7 @@
 7418	Steam Card: Jackass Plumber (#1)	0		
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
-7421	teal twirling pencil thin mushroom	0		Last Available: "2014-05"
+7421	twirling teal pencil thin mushroom	0		Last Available: "2014-05"
 7422	Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
@@ -7324,25 +7324,25 @@
 7435	pickled wobbly Stemonitis Staticus mushroom	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 44, Last Available: "2014-05"
 7436	double-altered Tremella Tarantella mushroom	0		Effect: "Hardened Fabric", Effect Duration: 15, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	big moldy narrow Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
-7439	big toothsome twirling Brain Food Pastaco	5	awesome	Last Available: "2014-05"
-7440	flavorless teal twirling Cool Brunch Pastaco	4	decent	Last Available: "2014-05"
+7438	moldy big narrow Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
+7439	toothsome big twirling Brain Food Pastaco	5	awesome	Last Available: "2014-05"
+7440	flavorless twirling teal Cool Brunch Pastaco	4	decent	Last Available: "2014-05"
 7441	decent Medical Pastaco	4	good	Last Available: "2014-05"
 7442	bland huge Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	rotten diet Ludovico Pastaco	1	crappy	Last Available: "2014-05"
-7444	triple-distilled mediocre overpowering mushroom wine	10	decent	Last Available: "2014-05"
+7444	mediocre triple-distilled overpowering mushroom wine	10	decent	Last Available: "2014-05"
 7445	lousy practically non-alcoholic complex mushroom wine	1	decent	Last Available: "2014-05"
-7446	hand-crafted practically non-alcoholic smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
-7447	lousy irresponsibly strong blood-red mushroom wine	9	decent	Last Available: "2014-05"
+7446	practically non-alcoholic hand-crafted smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7447	irresponsibly strong lousy blood-red mushroom wine	9	decent	Last Available: "2014-05"
 7448	drinkable buzzing mushroom wine	4	good	Last Available: "2014-05"
-7449	watered-down lousy swirling mushroom wine	2	decent	Last Available: "2014-05"
+7449	lousy watered-down swirling mushroom wine	2	decent	Last Available: "2014-05"
 7450	rotten Taco Dan's Basic Taco Dan Taco	4	crappy	Last Available: "2014-05"
-7451	special decent pulsating spinning Taco Dan's Taco Fish Fish Taco	3	good	Effect: "Barking Mad", Effect Duration: 25, Last Available: "2014-05"
+7451	special decent spinning pulsating Taco Dan's Taco Fish Fish Taco	3	good	Effect: "Barking Mad", Effect Duration: 25, Last Available: "2014-05"
 7452	bouncing gray Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	artisanal practically non-alcoholic regular-size brogurt	1	EPIC	Last Available: "2014-05"
-7454	extra-dry perfectly mixed yellow super-size brogurt	5	EPIC	Last Available: "2014-05"
+7454	perfectly mixed extra-dry yellow super-size brogurt	5	EPIC	Last Available: "2014-05"
 7455	drinkable high-proof broberry brogurt	10	good	Last Available: "2014-05"
-7456	mediocre practically non-alcoholic brocolate brogurt	1	decent	Last Available: "2014-05"
+7456	practically non-alcoholic mediocre brocolate brogurt	1	decent	Last Available: "2014-05"
 7457	acceptable French bronilla brogurt	4	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
@@ -7368,10 +7368,10 @@
 7479	flattened blurry upside-down sugar fairy	0		Effect: "One For Tea", Effect Duration: 26, Last Available: "2014-05"
 7480	energized cold-filtered quantum shaking sugar bunny	0		Effect: "Afternoon Insight", Effect Duration: 54, Last Available: "2014-05"
 7481	mirror sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	fortified perfectly mixed Rompedores de Fantasmas	5	EPIC	
+7482	perfectly mixed fortified Rompedores de Fantasmas	5	EPIC	
 7483	weak mediocre wobbly La Fantasma y La Oscuridad	2	decent	
 7484	bad Fantasma en la M&aacute;quina	3	decent	
-7485	spinning yellow loosening powder	0		
+7485	yellow spinning loosening powder	0		
 7486	castoreum	0		
 7487	blinking drain dissolver	0		
 7488	triple-distilled turpentine	0		
@@ -7405,8 +7405,8 @@
 7516	witch's spare house key	0		
 7517	mirror healthy slick spider leg	0		Moxie: +10, Maximum HP Percent: +20
 7518	wand of pigification	0		
-7519	drinkable fancy glass of bourbon	3	good	Effect: "Stone-Faced", Effect Duration: 45
-7520	gray squat burned government manual fragment	0		Last Available: "2014-05"
+7519	fancy drinkable glass of bourbon	3	good	Effect: "Stone-Faced", Effect Duration: 45
+7520	squat gray burned government manual fragment	0		Last Available: "2014-05"
 7521	stale government cheese	4	decent	Last Available: "2014-05"
 7522	bouncing lion tamer's pair of government shades	0		Experience (familiar): +2, Single Equip, Last Available: "2014-05"
 7523	purple space junk	0		Last Available: "2014-05"
@@ -7415,10 +7415,10 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	electrified government-issued night-vision goggles of bravery	0		Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2014-05"
-7529	adequate low-calorie loaf of alien bread	1	good	Last Available: "2014-05"
+7529	low-calorie adequate loaf of alien bread	1	good	Last Available: "2014-05"
 7530	bland ghostly grilled cheese sandwich	4	decent	Last Available: "2014-05"
 7531	vaporized green alien protein powder	1	decent	Last Available: "2014-05"
-7532	practically non-alcoholic fancy mediocre rocket fuel	1	decent	Effect: "Curse of the Black Pearl Onion", Effect Duration: 15, Last Available: "2014-05"
+7532	fancy practically non-alcoholic mediocre rocket fuel	1	decent	Effect: "Curse of the Black Pearl Onion", Effect Duration: 15, Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	triple-distilled hand-crafted stealth bomber	6	EPIC	Last Available: "2014-05"
@@ -7439,19 +7439,19 @@
 7550	pickled dry liquid smoke	0		Effect: "Sweet Taste", Effect Duration: 44, Last Available: "2014-06"
 7551	concentrated irradiated huge dollop of barbecue sauce	0		Effect: "5 Pounds Lighter", Effect Duration: 51, Last Available: "2014-06"
 7552	colloidal unsweetened bowl of marinade	0		Effect: "Human-Horror Hybrid", Effect Duration: 60, Last Available: "2014-06"
-7553	shaking mirror shaker of dry rub	0		Last Available: "2014-06"
+7553	mirror shaking shaker of dry rub	0		Last Available: "2014-06"
 7554	anodized bottle of lighter fluid	0		Effect: "Pill Power", Effect Duration: 24, Last Available: "2014-06"
 7555	page	0		
 7556	mirror elephant gift	0		
-7557	vacuum-sealed twirling squat red blood cells	0		Effect: "Whole Latte Love", Effect Duration: 19
-7558	weak lousy wine	2	decent	
+7557	vacuum-sealed squat twirling red blood cells	0		Effect: "Whole Latte Love", Effect Duration: 19
+7558	lousy weak wine	2	decent	
 7559	denatured extra-activated gummi turtle	0		Effect: "Antsy in your Pantsy", Effect Duration: 33
 7560	turtle-shaped rock	0		
 7561	super-Vulcanized giraffe-necked turtle	0		Effect: "Heart of Orange", Effect Duration: 39
 7562	triple-electrified jittery musk turtle	0		Effect: "Salt Rockin'", Effect Duration: 58
 7563	wet programmable turtle	0		Effect: "Tiki Temerity", Effect Duration: 69
 7564	double-ionized aerosolized spinning mocking turtle	0		Effect: "Ooh, Salty!", Effect Duration: 64
-7565	rotten olive bouncing ham steak	3	crappy	
+7565	rotten bouncing olive ham steak	3	crappy	
 7566	time-twitching toolbelt of the brute	0		Muscle Percent: +30, Single Equip, Free Pull
 7567	Chroner	0		
 7568	Jim Carey's Van der Graaf dance instructor's Time Lord Badge of Honor	0		Experience Percent (Moxie): +10, Monster Level: +25, MP Regen Min: 5, MP Regen Max: 7
@@ -7468,7 +7468,7 @@
 7579	blurry twitching time capsule	0		
 7580	denatured tumbling liquid shifting time weirdness	1		
 7581	shaking shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	special small bland rack of dinosaur ribs	2	decent	Effect: "OMG WTF", Effect Duration: 5
+7582	bland small special rack of dinosaur ribs	2	decent	Effect: "OMG WTF", Effect Duration: 5
 7583	perfectly mixed scotch on the rocks	3	EPIC	
 7584	fuchsia gravedigger's yabba dabba doo rag of the pedagogue	0		Experience: +3, Spooky Damage: +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	wooly loincloth of mayonnaise of Flo-Jo	0		Sleaze Spell Damage: +50, Initiative: +100, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7477,15 +7477,15 @@
 7588	spinning Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	mediocre glass of &quot;milk&quot;	4	decent	Last Available: "2014-07"
 7590	acceptable cup of &quot;tea&quot;	3	good	Last Available: "2014-07"
-7591	fancy weak hand-crafted thermos of &quot;whiskey&quot;	2	EPIC	Effect: "Well-Lubed", Effect Duration: 40, Last Available: "2014-07"
+7591	hand-crafted fancy weak thermos of &quot;whiskey&quot;	2	EPIC	Effect: "Well-Lubed", Effect Duration: 40, Last Available: "2014-07"
 7592	lousy practically non-alcoholic Lucky Lindy	1	decent	Last Available: "2014-07"
 7593	lousy practically non-alcoholic green Bee's Knees	1	decent	Last Available: "2014-07"
 7594	tolerable Sockdollager	4	good	Last Available: "2014-07"
 7595	extra-dry bad Ish Kabibble	5	decent	Last Available: "2014-07"
-7596	triple-distilled delicious blurry Hot Socks	7	awesome	Last Available: "2014-07"
+7596	delicious triple-distilled blurry Hot Socks	7	awesome	Last Available: "2014-07"
 7597	mediocre weak Phonus Balonus	2	decent	Last Available: "2014-07"
 7598	special drinkable Flivver	4	good	Effect: "Weather, Man", Effect Duration: 35, Last Available: "2014-07"
-7599	watered-down hand-crafted Sloppy Jalopy	2	super ultra mega EPIC	Last Available: "2014-07"
+7599	hand-crafted watered-down Sloppy Jalopy	2	super ultra mega EPIC	Last Available: "2014-07"
 7600	tarnished twirling flame	0		Effect: "Vented Spleen", Effect Duration: 26
 7601	wet temporary yak tattoo	0		Effect: "Turtle Titters", Effect Duration: 61
 7602	warmed mirror Fitspiration&trade; poster	0		Effect: "Compensatory Cruelness", Effect Duration: 19
@@ -7497,13 +7497,13 @@
 7608	corrupted squat turtle mud	0		Effect: "Fancy Feasted", Effect Duration: 69
 7609	oxidized Redeye&trade; Eyedrops	0		Effect: "Virgo Rising", Effect Duration: 52
 7610	chilled energized Dweebisol&trade; inhaler	0		Effect: "Spiky Frozen Hair", Effect Duration: 56
-7611	quadruple-pickled boiled squat spinning ghostly Lewd Lemmy Hair Oil	0		Effect: "Scrappy, Shadowy", Effect Duration: 41
+7611	quadruple-pickled boiled ghostly squat spinning Lewd Lemmy Hair Oil	0		Effect: "Scrappy, Shadowy", Effect Duration: 41
 7612	liquefied flattened teal tomato soup poster	0		Effect: "Jingle Jangle Jingle", Effect Duration: 64
 7613	aerosolized pressed adjusted bubblin' chemistry solution	0		Effect: "Hardened Fabric", Effect Duration: 34
 7614	extra-pickled wet jittery voodoo glowskull	0		Effect: "Aries Rising", Effect Duration: 59
 7615	deionized teal pygmy adder oil	0		Effect: "Funky Coal Patina", Effect Duration: 32
 7616	enhanced ghostly mirror pygmy witchhazel	0		Effect: "So You Can Work More...", Effect Duration: 44
-7617	electrified jittery ghostly jittery short deposition	0		Effect: "One Very Clear Eye", Effect Duration: 56
+7617	electrified jittery jittery ghostly short deposition	0		Effect: "One Very Clear Eye", Effect Duration: 56
 7618	improved tarnished straw pole	0		Effect: "[1701]Hip to the Jive", Effect Duration: 31
 7619	denatured copperhead potion	0		Effect: "Deeply Ironic", Effect Duration: 23
 7620	denatured blurry ninja fear powder	0		Effect: "Dreams and Lights", Effect Duration: 37
@@ -7527,7 +7527,7 @@
 7638	brainy whatsit-covered turtle shell	0		Mysticality: +5, Class: "Turtle Tamer"
 7639	tumbling brawny oil shell	0		Muscle Percent: +20, Class: "Turtle Tamer"
 7640	foul-smelling scorching healthy turtle shell	0		Maximum HP Percent: +20, Hot Damage: +25, Stench Damage: +10, Class: "Turtle Tamer"
-7641	bouncing shaking shocked shell	0		Class: "Turtle Tamer"
+7641	shaking bouncing shocked shell	0		Class: "Turtle Tamer"
 7642	ingot turtle	0		
 7643	duty umbrella	0		
 7644	pool skimmer	0		
@@ -7535,7 +7535,7 @@
 7646	huge lightning milk	0		
 7647	aquaconda brain	0		
 7648	shaking thunder thigh	0		
-7649	moist denatured dry narrow squat gourmet gourami oil	0		Effect: "Memory of Smarts", Effect Duration: 42
+7649	moist denatured dry squat narrow gourmet gourami oil	0		Effect: "Memory of Smarts", Effect Duration: 42
 7650	triple-alkaline magnetized catfish whiskers	0		Effect: "Stimulated Body", Effect Duration: 22
 7651	jittery freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
@@ -7543,12 +7543,12 @@
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
-7657	blinking lime green fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
+7657	lime green blinking fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	stiffened neoprene skullcap	0		Damage Reduction: 1, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	boiled goblin water	0		Effect: "Aries Rising", Effect Duration: 63
 7661	skewed dumb mud	0		
-7662	delicious miniature wobbly Sogg-Os	2	awesome	
+7662	miniature delicious wobbly Sogg-Os	2	awesome	
 7663	up-at-dawn Lord Soggyraven's Slippers of vim and vigor of the blizzard	0		Maximum HP Percent: +50, Cold Spell Damage: +25, Adventures: +5, Single Equip
 7664	oxidized ghostly Ancient Protector Soda	0		Effect: "Tingling Feeling", Effect Duration: 22
 7665	extra-Vulcanized liquid ice	0		Effect: "Sweet and Green", Effect Duration: 25
@@ -7559,9 +7559,9 @@
 7670	teal rosewater-soaked smartaleck's famous raincoat of bravery	0		Moxie Percent: +30, Spooky Resistance: +5, Stench Resistance: +3, Lasts Until Rollover
 7671	resourceful dance instructor's lightning rod of mayonnaise	0		Experience Percent (Moxie): +10, Maximum MP: +50, Sleaze Spell Damage: +50, Lasts Until Rollover
 7672	tumbling Sherlock's law-abiding citizen cane	0		Item Drop: +25, Single Equip
-7673	weak mediocre legitimate business on the beach	2	decent	
+7673	mediocre weak legitimate business on the beach	2	decent	
 7674	bouncing ghostly friendly hep waders	0		Familiar Weight: +3, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	normal enchanted jive turkey leg	3	good	Effect: "Knightlife", Effect Duration: 30
+7675	enchanted normal jive turkey leg	3	good	Effect: "Knightlife", Effect Duration: 30
 7676	olive friendly birdbone corset	0		Familiar Weight: +3
 7677	boiled ionized bouncing candy cigarette	0		Effect: "Lit Up", Effect Duration: 12
 7678	yellow 4-dimensional fez of the ox	0		Muscle: +20, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7592,13 +7592,13 @@
 7703	maroon bouncing LCD game: Food Eater	0		Last Available: "2014-08"
 7704	blinking LCD game: Garbage River	0		Last Available: "2014-08"
 7705	tumbling LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	jittery The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	jittery The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	electrified aerosolized twirling rubber nubbin	0		Effect: "Oth-Jeal-O", Effect Duration: 64, Last Available: "2014-08"
 7708	forbidden occult rubber cape	0		Spell Damage Percent: 75, Last Available: "2014-08"
 7709	electrified supercharged Thor's Pliers of the sweet-tooth of the cheetah	0		Maximum MP Percent: +30, Candy Drop: +100, Initiative: +60, MP Regen Min: 3, MP Regen Max: 5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	Vulcanized teal candy UFOs	0		Effect: "Slimily Strong", Effect Duration: 54
 7711	chilly water wings for babies of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5
-7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	rotten blinking Strix stix	3	crappy	
 7714	knitted Jim Carey's ruddy vampire pellet	0		Maximum HP Percent: +40, Monster Level: +25, Cold Resistance: +3
 7715	perfectly mixed non-aged vinegar	3	EPIC	
@@ -7642,8 +7642,8 @@
 7753	healthy Xiblaxian stealth cowl of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	red inspector's scorching Xiblaxian stealth trousers	0		Hot Damage: +25, Item Drop: +15, Last Available: "2014-09"
 7755	Jeselnik's Xiblaxian stealth vest of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +25, Last Available: "2014-09"
-7756	flavorless blurry narrow Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
-7757	distilled hand-crafted enchanted blue Xiblaxian space-whiskey	5	EPIC	Effect: "Is This Your Card?", Effect Duration: 50, Last Available: "2014-09"
+7756	flavorless narrow blurry Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
+7757	hand-crafted distilled enchanted blue Xiblaxian space-whiskey	5	EPIC	Effect: "Is This Your Card?", Effect Duration: 50, Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	adjusted unsweetened ghostly They liver	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 31, Last Available: "2014-09"
 7760	small stale They liver popsicle	2	decent	Last Available: "2014-09"
@@ -7668,7 +7668,7 @@
 7779	warmed enhanced twirling experimental serum G-9	0		Effect: "Ruthlessly Efficient", Effect Duration: 33, Last Available: "2014-10"
 7780	up-at-dawn studded wicked heavy-duty clipboard	0		Spell Damage: +5, Damage Absorption: +80, Adventures: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	Jeselnik's razor-sharp Samson's stylish battery-powered drill	0		Moxie: +25, Experience (Muscle): +5, Weapon Damage Percent: +25, Sleaze Damage: +25, Last Available: "2014-10"
-7782	special adequate limp broccoli	4	good	Effect: "Good Motivator", Effect Duration: 35, Last Available: "2014-10"
+7782	adequate special limp broccoli	4	good	Effect: "Good Motivator", Effect Duration: 35, Last Available: "2014-10"
 7783	MacGyver's supercool sage hat	0		Mysticality Percent: +10, Moxie Percent: +20, Maximum MP: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	aerosolized monkey barf	0		Effect: "Ghost Finger", Effect Duration: 16, Last Available: "2014-10"
 7785	denatured ghostly candy	0		Effect: "Compensatory Cruelness", Effect Duration: 56, Last Available: "2014-10"
@@ -7676,15 +7676,15 @@
 7787	boxer's cuddly teddy bear	0		Muscle Percent: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	wicked weightlifter's first-aid pouch	0		Muscle: +15, Spell Damage: +5, Last Available: "2014-10"
-7790	pulsating narrow squat khaki duffel bag	0		Last Available: "2014-10"
+7790	narrow squat pulsating khaki duffel bag	0		Last Available: "2014-10"
 7791	ionized airborne mutagen	0		Effect: "Nas Tea", Effect Duration: 26, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	tumbling bottle-opener keycard	0		Last Available: "2014-10"
 7794	twirling Armory keycard	0		Last Available: "2014-10"
-7795	huge spoiled bouncing ghostly initiative shawarma	9	crappy	Last Available: "2014-10"
+7795	spoiled huge bouncing ghostly initiative shawarma	9	crappy	Last Available: "2014-10"
 7796	bland immense warm war shawarma	6	decent	Last Available: "2014-10"
 7797	toothsome karma shawarma	3	awesome	Last Available: "2014-10"
-7798	special spirit-forward bad Jungle Juice	5	decent	Effect: "For Your Brain Only", Effect Duration: 20, Last Available: "2014-10"
+7798	spirit-forward bad special Jungle Juice	5	decent	Effect: "For Your Brain Only", Effect Duration: 20, Last Available: "2014-10"
 7799	practically non-alcoholic aged shaking Amnesiac Ale	1	awesome	Last Available: "2014-10"
 7800	watered-down perfectly mixed Highest Bitter	2	super EPIC	Last Available: "2014-10"
 7801	chilly personal trainer's mercenary pistol	0		Experience Percent (Muscle): +10, Cold Damage: +5, Last Available: "2014-10"
@@ -7700,7 +7700,7 @@
 7811	viral DNA	0		
 7812	twirling tarnished bottlecap	0		
 7813	stale seared dino steak	3	decent	
-7814	bad watered-down bottle of drinkin' gas	2	decent	
+7814	watered-down bad bottle of drinkin' gas	2	decent	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	ghostly twirling gelatinous meat mass	0		
@@ -7714,13 +7714,13 @@
 7825	Temple Grandin's coward's smartaleck's earbuds	0		Moxie Percent: +30, Monster Level: -20, Familiar Weight: +7, Single Equip
 7826	green skewed Annie Oakley's iFlail of the overflowing toilet of the sweet-tooth	0		Critical Hit Percent: +20, Stench Spell Damage: +50, Candy Drop: +100
 7827	delicious pulsating unidentifiable dried fruit	3	awesome	
-7828	drinkable triple-distilled gray flat cider	8	good	
+7828	triple-distilled drinkable gray flat cider	8	good	
 7829	prompt ruddy rosy-cheeked trench lighter	0		Maximum HP Percent: 70, Adventures: +3, Last Available: "2014-10"
 7830	moist experimental serum P-00	0		Effect: "Flamingly Floral", Effect Duration: 22, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
-7834	green jittery pack of smokes	0		Last Available: "2014-10"
+7834	jittery green pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	blurry GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	teal Project T. L. B.	0		Last Available: "2014-10"
@@ -7732,9 +7732,9 @@
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	blinking special clip: graveburpers	0		Last Available: "2014-10"
 7845	non-deionized pressed perl necklace	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 42, Last Available: "2014-12"
-7846	concentrated magnetized pulsating olive bouncing Fudge Fiber Armor Plating	0		Effect: "Ripping, Dripping", Effect Duration: 15, Last Available: "2014-12"
+7846	concentrated magnetized olive pulsating bouncing Fudge Fiber Armor Plating	0		Effect: "Ripping, Dripping", Effect Duration: 15, Last Available: "2014-12"
 7847	enhanced ruby on canes	0		Effect: "Radiant Personality", Effect Duration: 66, Last Available: "2014-12"
-7848	gigantic spoiled special petit fortran	7	crappy	Effect: "Al Dente Inferno", Effect Duration: 50, Last Available: "2014-12"
+7848	gigantic special spoiled petit fortran	7	crappy	Effect: "Al Dente Inferno", Effect Duration: 50, Last Available: "2014-12"
 7849	bland snack-sized yellow spinning java cookie	2	decent	Last Available: "2014-12"
 7850	stale cookie cookie	3	decent	Last Available: "2014-12"
 7851	fuchsia plastic exo-suited miner of the businessman	0		Meat Drop: +50, Last Available: "2014-12"
@@ -7753,11 +7753,11 @@
 7864	Petite Paintbrush	0		Adventures: +1
 7865	narrow Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	tumbling Crimbot schematic: Big Head	0		Last Available: "2014-12"
-7867	green squat Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
+7867	squat green Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	olive Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
-7871	huge pulsating Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
+7871	pulsating huge Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	wobbly Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	mirror Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
@@ -7794,7 +7794,7 @@
 7905	recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
 7907	recovered elf sleeping pills	0		Last Available: "2014-12"
-7908	upside-down jittery recovered elf underpants	0		Last Available: "2014-12"
+7908	jittery upside-down recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	upside-down recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	gray recovered elf photo album	0		Last Available: "2014-12"
@@ -7812,7 +7812,7 @@
 7923	bad special Agitated Turkey	3	decent	Effect: "Spooky Weapon", Effect Duration: 35, Last Available: "2014-11"
 7924	acceptable shaking skewed Ambitious Turkey	4	good	Last Available: "2014-11"
 7925	half-sized tasty neutron lollipop	2	awesome	Last Available: "2014-12"
-7926	hand-crafted weak gamma nog	2	EPIC	Last Available: "2014-12"
+7926	weak hand-crafted gamma nog	2	EPIC	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	cyan Thwaitgold nit statuette	0		
 7936	tumbling picky tweezers	0		Last Available: "2015-02"
@@ -7826,7 +7826,7 @@
 7944	tooth	0		
 7945	table	0		
 7946	careful MacGyver's steel-toed outlaw bandana	0		Damage Reduction: 9, Maximum MP: +100, Monster Level: -10
-7947	watered-down smooth whiskey in a broken glass	2	awesome	
+7947	smooth watered-down whiskey in a broken glass	2	awesome	
 7948	delicious shot of mescal	3	awesome	
 7949	fancy mediocre yellow glass of herbal tequila	3	decent	Effect: "Category", Effect Duration: 35
 7950	minin' dynamite	0		
@@ -7851,7 +7851,7 @@
 7969	beehive	0		
 7970	ghostly boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
-7972	boiled narrow jittery mummified fig	1	EPIC	
+7972	boiled jittery narrow mummified fig	1	EPIC	
 7973	vaporized blue mummified loaf of bread	1	decent	
 7974	dried squat mummified beef haunch	1	awesome	Effect: "Barking Mad", Effect Duration: 45
 7975	linen bandages	0		
@@ -7894,12 +7894,12 @@
 8012	Lo Pan's Socratic Crimbomega drive chain of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +1, Spell Critical Percent: +30, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	tumbling Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8015	blinking shaking Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8015	shaking blinking Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	alkaline fitness wristband	0		Effect: "Marbles in Your Mouth", Effect Duration: 15, Last Available: "2014-12"
 8017	quantum flask of tainted mining oil	0		Effect: "Tremella Tremens", Effect Duration: 35, Last Available: "2014-12"
 8018	corrupted and rain stick	0		Effect: "Sleazy Weapon", Effect Duration: 53
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	toothsome miniature shaking Choco-Mint patty	2	awesome	Last Available: "2015-01"
+8020	miniature toothsome shaking Choco-Mint patty	2	awesome	Last Available: "2015-01"
 8021	bad hot mint schnocolate	3	decent	Last Available: "2015-01"
 8022	modified homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
@@ -8015,7 +8015,7 @@
 8141	bouncing savvy macroplane grater	0		Mysticality Percent: +20
 8142	knitted bastard baster	0		Cold Resistance: +3
 8143	mirror Sinatra's obsidian nutcracker	0		Experience (Moxie): +5
-8144	ghostly maroon talisman of Seshat	0		Free Pull
+8144	maroon ghostly talisman of Seshat	0		Free Pull
 8145	baleful glass eye of the early riser	0		Spell Damage: +25, Adventures: +7, Single Equip
 8146	double-deionized quadruple-enhanced invisible potion	0		Effect: "Cravin' for a Ravin'", Effect Duration: 50
 8147	time shuriken	0		
@@ -8023,7 +8023,7 @@
 8149	anodized ghostly Glo-Pop	0		Effect: "Egged On", Effect Duration: 25
 8150	denatured sugar sphere	0		Effect: "It Didn't Kill You", Effect Duration: 38
 8151	boiled irradiated Shrubble Bubble	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 62
-8152	oxidized colloidal bouncing pulsating twirling polyeaster egg	0		Effect: "Radiated and Grodiated", Effect Duration: 30
+8152	oxidized colloidal twirling bouncing pulsating polyeaster egg	0		Effect: "Radiated and Grodiated", Effect Duration: 30
 8153	unsweetened dry oxidized blurry candy dish	0		Effect: "Aloofah", Effect Duration: 64
 8154	aerosolized dry Spechunky bar	0		Effect: "Big Meat Big Prizes", Effect Duration: 19
 8155	non-moist upside-down blinking talisman of Horus	0		Effect: "Impregnably Delicious", Effect Duration: 37
@@ -8038,11 +8038,11 @@
 8164	lightning-fast fortified remaindered axe	0		Damage Absorption: +60, Initiative: +40
 8165	squat low-budget shield	0		Damage Reduction: 3
 8166	jittery sharpshooter's smooth cr&ecirc;epy mask	0		Moxie: +15, Critical Hit Percent: +10, Familiar Effect: "spooky atk, cap 5"
-8167	thick bland mirror baguette	5	decent	
+8167	bland thick mirror baguette	5	decent	
 8168	mirror glob of icing	0		
 8169	electrified ginger snaps	0		Effect: "Unrunnable Face", Effect Duration: 62
 8170	flattened moist olive mostly-broken sunglasses	0		Effect: "Vitali Tea", Effect Duration: 56
-8171	tolerable high-proof skewed blinking unflavored wine cooler	10	good	
+8171	high-proof tolerable skewed blinking unflavored wine cooler	10	good	
 8172	carton of snake milk	1	good	
 8173	scandalous sewer snake	0		Sleaze Damage: +5
 8174	stale pigeon egg	3	decent	
@@ -8053,25 +8053,25 @@
 8179	baleful ring of telling skeletons what to do	0		Spell Damage: +25, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
 8180	slick breadwand	0		Moxie: +10
 8181	studded loafers	0		Damage Absorption: +80, Single Equip
-8182	skewed yellow Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
+8182	yellow skewed Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	twirling veiny bread basket	0		Maximum HP: +10
 8184	Ed the Undying exhibit crate	0		
 8185	pulsating knitted steel-toed The Crown of Ed the Undying	0		Damage Reduction: 9, Cold Resistance: +3, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	huge Doc Galaktik's Invigorating Tonic	0		
 8187	narrow squat gray map to a hidden booze cache	0		
 8188	smooth Cherrytastrophe wine cooler	3	awesome	
-8189	artisanal weak Radberry Rip wine cooler	2	EPIC	
+8189	weak artisanal Radberry Rip wine cooler	2	EPIC	
 8190	lousy skewed Orangemageddon wine cooler	3	decent	
 8191	hand-crafted Breakfast Blast wine cooler	4	EPIC	
 8192	special mediocre blurry Citrus Crush wine cooler	4	decent	Effect: "Spring Training", Effect Duration: 30
 8193	spoiled plain bagel	4	crappy	
 8194	stale glob of cream cheese	4	decent	
-8195	normal immense loaf of soda bread	7	good	
+8195	immense normal loaf of soda bread	7	good	
 8196	stale shaking acceptable bagel	3	decent	
 8197	rotten diet standard-issue cupcake	1	crappy	
 8198	rotten ultra-deluxe cupcake	4	crappy	
-8199	jittery gray wobbly hypnotic breadcrumbs	0		
-8200	snack-sized bland popular tart	2	decent	
+8199	wobbly jittery gray hypnotic breadcrumbs	0		
+8200	bland snack-sized popular tart	2	decent	
 8201	narrow no-handed pie	0		
 8202	dry alkaline Doc Galaktik's Vitality Serum	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 49
 8203	lime green bouncing airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8144,15 +8144,15 @@
 8270	rotten unappetizing mayolus	4	crappy	Last Available: "2015-05"
 8271	toothsome uninteresting mayolus	4	awesome	Last Available: "2015-05"
 8272	gigantic stale acceptable mayolus	10	decent	Last Available: "2015-05"
-8273	moldy spinning skewed enticing mayolus	4	crappy	Last Available: "2015-05"
-8274	stale snack-sized mouth-watering mayolus	2	decent	Last Available: "2015-05"
+8273	moldy skewed spinning enticing mayolus	4	crappy	Last Available: "2015-05"
+8274	snack-sized stale mouth-watering mayolus	2	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	purple mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
 8278	perfectly mixed olive Afternoon Delight	3	EPIC	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	tumbling Golden Kokomo Resort Chip	0		Last Available: "2015-04"
-8281	pressed quadruple-diffused upside-down pulsating Kokomo Resort Brand Suntan Oil	0		Effect: "Takin' It Greasy", Effect Duration: 37, Last Available: "2015-04"
+8281	pressed quadruple-diffused pulsating upside-down Kokomo Resort Brand Suntan Oil	0		Effect: "Takin' It Greasy", Effect Duration: 37, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	triple-quantum anodized shaking Kokomo Resort Pass	0		Effect: "Tiki Temerity", Effect Duration: 19, Last Available: "2023-08"
@@ -8179,7 +8179,7 @@
 8305	huge pumps	0		Last Available: "2015-06"
 8306	oxidized vacuum-sealed sludgesicle	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 63
 8307	extra-aerosolized &Uuml;berraschthexengebr&auml;u	0		Effect: "It Didn't Kill You", Effect Duration: 40
-8308	modified jittery squat piggy tattoo	0		Effect: "Human-Orc Hybrid", Effect Duration: 11
+8308	modified squat jittery piggy tattoo	0		Effect: "Human-Orc Hybrid", Effect Duration: 11
 8309	super-energized galvanized baggie of regular-sized tardigrades	0		Effect: "Gemini Rising", Effect Duration: 69
 8310	triple-electrified .epub file	0		Effect: "Cancer Rising", Effect Duration: 45
 8311	electrified BUBBLE GUM	0		Effect: "Using Protection", Effect Duration: 49
@@ -8192,7 +8192,7 @@
 8318	dry irradiated sinister-looking cat	0		Effect: "Innately Strong", Effect Duration: 47
 8319	double-frozen oxidized galvanized twirling jazzy cigarette holder	0		Effect: "Yes, Can Haz", Effect Duration: 22
 8320	adjusted oxidized one glove	0		Effect: "Peppermint Bite", Effect Duration: 14
-8321	modified dry ghostly yellow glove	0		Effect: "Chari Tea", Effect Duration: 12
+8321	modified dry yellow ghostly glove	0		Effect: "Chari Tea", Effect Duration: 12
 8322	corrupted triple-magnetized ghostly twirling handful of fire	0		Effect: "Melancholy Burden", Effect Duration: 39
 8323	energized colloidal Cracklin' Oat Bran	0		Effect: "The Smile of Mr. A.", Effect Duration: 51
 8324	flattened unsweetened blurry disposable lighter	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 67
@@ -8245,7 +8245,7 @@
 8371	liquefied Vulcanized bucket of fish juice	0		Effect: "Trufflin'", Effect Duration: 61
 8372	cold-filtered alkaline flashy pirate dreadlocks	0		Effect: "Serendipi Tea", Effect Duration: 21
 8373	ionized triple-quantum gray captured boozles	0		Effect: "Tomato Power", Effect Duration: 56
-8374	non-anodized squat blinking drinks tray	0		Effect: "You Know When to Walk Away", Effect Duration: 27
+8374	non-anodized blinking squat drinks tray	0		Effect: "You Know When to Walk Away", Effect Duration: 27
 8375	Vulcanized modified bouncing eyebrow lifter	0		Effect: "Egg-headedness", Effect Duration: 14
 8376	submarine	0		Last Available: "2015-06"
 8377	moldy pixel lemon	3	crappy	Last Available: "2015-06"
@@ -8262,7 +8262,7 @@
 8388	blurry mana	0		Last Available: "2015-07"
 8389	fuchsia mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
-8391	twirling purple mana	0		Last Available: "2015-07"
+8391	purple twirling mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
 8394	skewed spinning The Emperor's dry cleaning	0		Last Available: "2015-07"
@@ -8277,14 +8277,14 @@
 8403	squat olive Lo Pan's revolver of the storm	0		Maximum MP Percent: +40, Spell Critical Percent: +30, Lasts Until Rollover, Last Available: "2015-07"
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	blinking talking spade	0		Free Pull
-8406	jittery teal savory dry noodles	0		
+8406	teal jittery savory dry noodles	0		
 8407	low-calorie rotten pestopiary	1	crappy	
 8408	dry irradiated jittery ectoplasmic orbs	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 63
 8409	rotten half-sized crudles	2	crappy	
-8410	toothsome massive twirling agnolotti arboli	6	awesome	
-8411	tasty small enchanted blinking spaghetti with ghost balls	2	awesome	Effect: "Stimulated Body", Effect Duration: 40
+8410	massive toothsome twirling agnolotti arboli	6	awesome	
+8411	enchanted small tasty blinking spaghetti with ghost balls	2	awesome	Effect: "Stimulated Body", Effect Duration: 40
 8412	decent succulent marrow	3	good	
-8413	small normal enchanted salacious crumbs	2	good	Effect: "Ichorous Eyesight", Effect Duration: 40
+8413	small enchanted normal salacious crumbs	2	good	Effect: "Ichorous Eyesight", Effect Duration: 40
 8414	flavorless fusilli marrownarrow	4	decent	
 8415	adequate suggestive strozzapreti	3	good	
 8416	Mountain Stream gastrique	0		
@@ -8345,11 +8345,11 @@
 8471	cyan huge toasty personal trainer's lava-proof pants	0		Experience Percent (Muscle): +10, Hot Damage: +5, Last Available: "2015-08"
 8472	lard-coated thinker's heat-resistant necktie	0		Mysticality: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8473	foul-smelling chaotic therapeutic heat-resistant gloves	0		Spell Critical Percent: +10, Stench Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2015-08"
-8474	flavorless tiny very hot lunch	1	decent	Last Available: "2015-08"
-8475	spirit-forward tolerable asbestos thermos	5	good	Last Available: "2015-08"
+8474	tiny flavorless very hot lunch	1	decent	Last Available: "2015-08"
+8475	tolerable spirit-forward asbestos thermos	5	good	Last Available: "2015-08"
 8476	altered alkaline liquid rhinestones	0		Effect: "Weepy, Creepy", Effect Duration: 31, Last Available: "2015-08"
 8477	thick moldy disco biscuit	5	crappy	Last Available: "2015-08"
-8478	perfectly mixed blinking upside-down Quaatorade&trade;	3	EPIC	Last Available: "2015-08"
+8478	perfectly mixed upside-down blinking Quaatorade&trade;	3	EPIC	Last Available: "2015-08"
 8479	asbestos-lined fireproof smartaleck's biker's hat	0		Moxie Percent: +30, Hot Resistance: 8, Familiar Effect: "atk", Last Available: "2015-08"
 8480	fuchsia frightening beefy feathered headdress of doom	0		Muscle: +10, Spooky Damage: +5, Spooky Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
 8481	scorching fortified electrician's hardhat of the bloodbag	0		Damage Absorption: +60, Maximum HP: +100, Hot Damage: +25, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8358,7 +8358,7 @@
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	huge one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	olive narrow airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	narrow olive airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
 8490	smooth velvet pants of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
@@ -8400,13 +8400,13 @@
 8526	spoiled pink slime	4	crappy	
 8527	wobbly Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	rotten enchanted immense bouncing cyan devil hair pasta	10	crappy	Effect: "Unrunnable Face", Effect Duration: 45
-8530	snack-sized special normal huge spagecialetti	2	good	Effect: "Permanent Halloween", Effect Duration: 10
+8529	enchanted immense rotten bouncing cyan devil hair pasta	10	crappy	Effect: "Unrunnable Face", Effect Duration: 45
+8530	normal snack-sized special huge spagecialetti	2	good	Effect: "Permanent Halloween", Effect Duration: 10
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	gigantic adequate upside-down libertagliatelle	6	good	
-8535	normal big mirror turkish mostaccioli	5	good	
+8535	big normal mirror turkish mostaccioli	5	good	
 8536	thick rotten linguini of the sea	5	crappy	
 8537	irradiated quantum extra-denatured Hersey&trade; SMOOCH	0		Effect: "Patent Prevention", Effect Duration: 64
 8539	Alexy sauce	0		
@@ -8418,13 +8418,13 @@
 8545	mixed yellow blood-drive sticker	1	decent	
 8546	chilled dry bag of grain	0		Effect: "Liquidy Smoky", Effect Duration: 31
 8547	tarnished frozen pocket maze	0		Effect: "Proprie Tea", Effect Duration: 40
-8548	activated upside-down fuchsia shady shades	0		Effect: "Thanksgot", Effect Duration: 43
+8548	activated fuchsia upside-down shady shades	0		Effect: "Thanksgot", Effect Duration: 43
 8549	dry adjusted squeaky toy rose	0		Effect: "Improved Candy Vision", Effect Duration: 37
 8550	normal weird gazelle steak	4	good	
 8551	normal small sausage without a cause	2	good	
 8552	chilled face paint	0		Effect: "Gleaming White Teeth", Effect Duration: 65
-8553	fortified lousy emergency margarita	5	decent	
-8554	aged weak special vintage smart drink	2	awesome	Effect: "Human-Plant Hybrid", Effect Duration: 10
+8553	lousy fortified emergency margarita	5	decent	
+8554	aged special weak vintage smart drink	2	awesome	Effect: "Human-Plant Hybrid", Effect Duration: 10
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8448,7 +8448,7 @@
 8575	blurry rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	enchanted artisanal blue twirling bottle of Amontillado	3	EPIC	Effect: "Cuts Like a Buttered Knife", Effect Duration: 45, Last Available: "2015-09"
+8578	artisanal enchanted blue twirling bottle of Amontillado	3	EPIC	Effect: "Cuts Like a Buttered Knife", Effect Duration: 45, Last Available: "2015-09"
 8579	hand-crafted blurry barrel-aged martini	4	EPIC	Last Available: "2015-09"
 8580	stale barrel pickle	4	decent	Last Available: "2015-09"
 8581	adequate spinning barrel cracker	3	good	Last Available: "2015-09"
@@ -8495,17 +8495,17 @@
 8622	cold-filtered triple-dry cuppa Mediocri tea	0		Effect: "Fungal Flambé", Effect Duration: 31, Last Available: "2015-09"
 8623	wet activated twirling cuppa Loyal tea	0		Effect: "You Know Where to Go", Effect Duration: 52, Last Available: "2015-09"
 8624	pickled cuppa Activi tea	1	decent	Last Available: "2015-09"
-8625	powdered olive tumbling blinking cuppa Cruel tea	1		Last Available: "2015-09"
+8625	powdered tumbling blinking olive cuppa Cruel tea	1		Last Available: "2015-09"
 8626	liquefied green cuppa Alacri tea	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 53, Last Available: "2015-09"
 8627	anodized triple-adjusted oxidized cuppa Vitali tea	0		Effect: "Standard Issue Bravery", Effect Duration: 20, Last Available: "2015-09"
 8628	liquefied triple-magnetized maroon cuppa Mana tea	0		Effect: "The Dinsey Way", Effect Duration: 40, Last Available: "2015-09"
 8629	extra-galvanized cuppa Monstrosi tea	0		Effect: "Feet of Watermelon", Effect Duration: 18, Last Available: "2015-09"
 8630	energized boiled cuppa Twen tea	0		Effect: "Salt Rockin'", Effect Duration: 61, Last Available: "2015-09"
 8631	liquefied enhanced cuppa Gill tea	0		Effect: "Amorphous Cheer", Effect Duration: 19, Last Available: "2015-09"
-8632	frozen vacuum-sealed spinning wobbly cuppa Uncertain tea	0		Effect: "Scarysauce", Effect Duration: 44, Last Available: "2015-09"
+8632	frozen vacuum-sealed wobbly spinning cuppa Uncertain tea	0		Effect: "Scarysauce", Effect Duration: 44, Last Available: "2015-09"
 8633	jittery jittery cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
-8635	mirror red cuppa Royal tea	0		Last Available: "2015-09"
+8635	red mirror cuppa Royal tea	0		Last Available: "2015-09"
 8636	boiled olive cuppa Craft tea	0		Effect: "Deadly Flashing Blade", Effect Duration: 53, Last Available: "2015-09"
 8637	diffused moist cuppa Insani tea	0		Effect: "Sugar, Hello", Effect Duration: 14, Last Available: "2015-09"
 8638	executive shellacked Da Vinci's Royal scepter	0		Experience (Mysticality): +5, Damage Reduction: 7, Meat Drop: +40, Last Available: "2015-09"
@@ -8513,14 +8513,14 @@
 8640	pulsating Ghost Dog Chow	0		Last Available: "2015-10"
 8641	adequate bowl of eyeballs	4	good	Last Available: "2015-10"
 8642	decent bowl of mummy guts	4	good	Last Available: "2015-10"
-8643	gigantic normal bowl of maggots	10	good	Last Available: "2015-10"
+8643	normal gigantic bowl of maggots	10	good	Last Available: "2015-10"
 8644	weak bad blood and blood	2	decent	Last Available: "2015-10"
 8645	delicious Jack-O-Lantern beer	4	awesome	Last Available: "2015-10"
 8646	perfectly mixed zombie	3	EPIC	Last Available: "2015-10"
 8647	narrow Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
-8650	squat twirling tennis ball	0		Last Available: "2015-10"
+8650	twirling squat tennis ball	0		Last Available: "2015-10"
 8651	spinning family-friendly toasty crown of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Sleaze Resistance: +1, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
 8653	stink-penny	0		
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	pulsating How to Play Othello	0		
 8662	Oprah's rosy-cheeked stylish ghostly dagger	0		Moxie: +25, Maximum HP Percent: +30, Maximum MP Percent: +50
-8663	aged spirit-forward ghost beer	5	awesome	
+8663	spirit-forward aged ghost beer	5	awesome	
 8664	sage Othello set	0		Mysticality Percent: +10
 8665	huge rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8586,7 +8586,7 @@
 8713	vaporized wobbly abstraction: perception	1		Effect: "Tapped In", Effect Duration: 15, Last Available: "2015-12"
 8714	dried bouncing abstraction: motion	1		Effect: "Cautious Prowl", Effect Duration: 25, Last Available: "2015-12"
 8715	compressed abstraction: joy	1		Last Available: "2015-12"
-8716	dehydrated mirror ghostly maroon abstraction: certainty	1		Effect: "Patent Alacrity", Effect Duration: 5, Last Available: "2015-12"
+8716	dehydrated ghostly mirror maroon abstraction: certainty	1		Effect: "Patent Alacrity", Effect Duration: 5, Last Available: "2015-12"
 8717	powdered skewed abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	decent miniature spinning VYKEA meatballs	2	good	Last Available: "2015-11"
@@ -8601,7 +8601,7 @@
 8728	spinning VYKEA dowel	0		Last Available: "2015-11"
 8729	narrow twirling Sherlock's scorching VYKEA hex key of Flo-Jo	0		Hot Damage: +25, Item Drop: +25, Initiative: +100, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	special adequate miniature bouncing tin of submardines	2	good	Effect: "Eyes of the Dragon", Effect Duration: 15, Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	miniature special adequate bouncing tin of submardines	2	good	Effect: "Eyes of the Dragon", Effect Duration: 15, Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	tolerable blinking bottle of norwhiskey	4	good	Last Available: "2015-11"
 8733	vaporized huge octolus oculus	1	EPIC	Last Available: "2015-11"
 8734	prompt censurious quilted sardine can key	0		Damage Absorption: +40, Sleaze Resistance: +3, Adventures: +3, Last Available: "2015-11"
@@ -8609,7 +8609,7 @@
 8736	upside-down double-paned Jim Carey's educational octolus-skin cloak	0		Experience: +1, Monster Level: +25, Cold Resistance: +5, Last Available: "2015-11"
 8737	fancy perfectly mixed lime green perfect cosmopolitan	4	EPIC	Effect: "Pyromania", Effect Duration: 5, Last Available: "2015-11"
 8738	perfectly mixed perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	artisanal weak perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
+8739	weak artisanal perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
 8740	aged perfect mimosa	3	awesome	Last Available: "2015-11"
 8741	mediocre perfect old-fashioned	3	decent	Last Available: "2015-11"
 8742	artisanal perfect paloma	4	EPIC	Last Available: "2015-11"
@@ -8617,7 +8617,7 @@
 8744	super-warmed adjusted Wal-Mart &quot;diamond&quot; ring	0		Effect: "Bilious Brains", Effect Duration: 12, Last Available: "2015-11"
 8745	flattened pressed Puffstone cigar	0		Effect: "The Smile of Mr. A.", Effect Duration: 58, Last Available: "2015-11"
 8746	chilled purple Conspiracy&trade; mascara	0		Effect: "Mutated", Effect Duration: 39, Last Available: "2015-11"
-8747	irradiated adjusted fuchsia blinking Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 18, Last Available: "2015-11"
+8747	irradiated adjusted blinking fuchsia Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 18, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
 8749	unsweetened blinking Deep Machine Tunnels snowglobe	0		Effect: "Rainbow Bright", Effect Duration: 29, Last Available: "2015-12"
 8750	polymerized aerosolized tumbling hemp candy necklace	0		Effect: "Devil Inside", Effect Duration: 56, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	yellow BACON	0		Last Available: "2016-05"
 8764	huge box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	perfectly mixed watered-down enchanted Gratitude chocolate (bourbon-filled)	2	EPIC	Effect: "Ooh, Umami!", Effect Duration: 20, Last Available: "2016-02"
+8766	enchanted perfectly mixed watered-down Gratitude chocolate (bourbon-filled)	2	EPIC	Effect: "Ooh, Umami!", Effect Duration: 20, Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	shaking Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	mirror chocolate bowtie	0		Familiar Weight: +5
@@ -8654,7 +8654,7 @@
 8782	groovy reindeer hammer	0		Moxie Percent: +10, Last Available: "2015-12"
 8783	lime green forbidden elf ploughshare	0		Spell Damage Percent: +50, Last Available: "2015-12"
 8784	upside-down circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	jittery faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8678,7 +8678,7 @@
 8806	mirror high-grade explosives	0		Last Available: "2017-01"
 8807	tumbling experimental gene therapy	0		Last Available: "2017-01"
 8808	squat shaking ultracoagulator	0		Last Available: "2017-01"
-8809	tumbling pulsating self-defense training	0		Last Available: "2017-01"
+8809	pulsating tumbling self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	pulsating confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
@@ -8687,12 +8687,12 @@
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	adequate teal Kudzu salad	4	good	Last Available: "2016-12"
 8817	twisted mirror Mansquito Serum	1		Last Available: "2016-12"
-8818	tolerable high-proof Miss Graves' vermouth	6	good	Last Available: "2016-12"
+8818	high-proof tolerable Miss Graves' vermouth	6	good	Last Available: "2016-12"
 8819	delicious The Plumber's mushroom stew	3	awesome	Last Available: "2016-12"
 8820	twisted blurry The Author's ink	1		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 40, Last Available: "2016-02"
 8821	perfectly mixed The Mad Liquor	3	super EPIC	Last Available: "2016-12"
-8822	irresponsibly strong bad wobbly Doc Clock's thyme cocktail	10	decent	Last Available: "2016-12"
-8823	big spoiled pulsating skewed upside-down Mr. Burnsger	5	crappy	Last Available: "2016-12"
+8822	bad irresponsibly strong wobbly Doc Clock's thyme cocktail	10	decent	Last Available: "2016-12"
+8823	spoiled big pulsating upside-down skewed Mr. Burnsger	5	crappy	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	forbidden brainy The Jokester's gun of the blizzard	0		Mysticality: +5, Spell Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
 8826	censurious baleful The Jokester's wig of the sweet-tooth	0		Spell Damage: +25, Sleaze Resistance: +3, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
@@ -8703,10 +8703,10 @@
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	diffused narrow robin's egg	0		Effect: "Black Lung", Effect Duration: 26, Last Available: "2016-12"
-8834	small decent robin flan	2	good	Last Available: "2016-12"
-8835	watered-down perfectly mixed narrow robin nog	2	EPIC	Last Available: "2016-12"
+8834	decent small robin flan	2	good	Last Available: "2016-12"
+8835	perfectly mixed watered-down narrow robin nog	2	EPIC	Last Available: "2016-12"
 8836	lime green LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
-8837	spinning blurry plaintive telegram	0		Last Available: "2016-02"
+8837	blurry spinning plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
 8839	root beer barrel	0		
 8840	improved energized extra-deionized Kudzu slaw	0		Effect: "Sweet, Nuts", Effect Duration: 58
@@ -8745,7 +8745,7 @@
 8873	lightning-fast Pork 'n' Pork 'n' Pork 'n' Beans	0		Initiative: +40, Last Available: "2016-02"
 8874	squat crafty vibrating extremely unsafe dangerous brainy Val-U Brand Every Bean Salad	0		Mysticality: +5, Weapon Damage: +10, Weapon Damage Percent: +100, Maximum MP Percent: +10, Maximum MP: +10, Last Available: "2016-02"
 8875	family-friendly perfumed healthy Shrub's Premium Baked Beans	0		Maximum HP Percent: +20, Stench Resistance: +5, Sleaze Resistance: +1, Last Available: "2016-02"
-8876	enchanted miniature moldy narrow plate of Heimz Fortified Kidney Beans	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2016-02"
+8876	miniature moldy enchanted narrow plate of Heimz Fortified Kidney Beans	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2016-02"
 8877	decent plate of Tesla's Electroplated Beans	3	good	Last Available: "2016-02"
 8878	low-calorie bland spinning plate of Mixed Garbanzos and Chickpeas	1	decent	Last Available: "2016-02"
 8879	normal plate of Hellfire Spicy Beans	4	good	Last Available: "2016-02"
@@ -8753,7 +8753,7 @@
 8881	enchanted bland plate of World's Blackest-Eyed Peas	3	decent	Effect: "Muscle Unbound", Effect Duration: 30, Last Available: "2016-02"
 8882	diet decent bouncing plate of Trader Olaf's Exotic Stinkbeans	1	good	Last Available: "2016-02"
 8883	decent spinning plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	good	Last Available: "2016-02"
-8884	tiny flavorless plate of Val-U Brand Every Bean Salad	1	decent	Last Available: "2016-02"
+8884	flavorless tiny plate of Val-U Brand Every Bean Salad	1	decent	Last Available: "2016-02"
 8885	adequate plate of Shrub's Premium Baked Beans	3	good	Last Available: "2016-02"
 8886	Jeselnik's stanky Fancy Jeff's pocket square	0		Stench Spell Damage: +25, Sleaze Damage: +25, Last Available: "2016-02"
 8887	pulsating greasy studded beefcake's Daisy's unclean bloomers	0		Muscle: +25, Damage Absorption: +80, Sleaze Spell Damage: +10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
@@ -8800,10 +8800,10 @@
 8928	disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	dry electrified demonic cow's blood	0		Effect: "Tingly Wrists", Effect Duration: 57, Last Available: "2016-02"
-8931	bouncing skewed rinky-dink sixgun	0		Last Available: "2016-02"
+8931	skewed bouncing rinky-dink sixgun	0		Last Available: "2016-02"
 8932	green makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
-8934	wobbly tumbling baconstone-handled sixgun	0		Last Available: "2016-02"
+8934	tumbling wobbly baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
@@ -8841,7 +8841,7 @@
 8969	frosty medical-grade eleven-gallon hat	0		Cold Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10
 8970	toy sixgun	0		
 8971	snake oil	0		
-8972	liquefied oxidized yellow pulsating skin oil	0		Effect: "Bootyliciousness", Effect Duration: 18
+8972	liquefied oxidized pulsating yellow skin oil	0		Effect: "Bootyliciousness", Effect Duration: 18
 8973	wet unusual oil	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 68
 8974	quantum aerosolized eldritch oil	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 33
 8975	exclusive club	0		
@@ -8892,23 +8892,23 @@
 9020	plus one	0		Last Available: "2016-05"
 9021	miniature stale gallon of milk	2	decent	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
-9023	blinking mirror screencapped monster	0		Last Available: "2016-05"
+9023	mirror blinking screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
 9025	infinite BACON machine	0		Last Available: "2016-05"
 9026	First Post shirt package	0		Last Available: "2016-05"
 9027	double-paned manspreader's Newton's First Post shirt - Cir Senam	0		Experience (Mysticality): +3, Monster Level: +10, Cold Resistance: +5, Last Available: "2016-05"
 9028	pulsating high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	skewed no spoon	0		
-9030	thick moldy star salad	5	crappy	
+9030	moldy thick star salad	5	crappy	
 9031	Thwaitgold moth statuette	0		
-9032	enchanted big adequate squat bowl of Tastee-Wheet&trade;	5	good	Effect: "Compensatory Cruelness", Effect Duration: 25
+9032	adequate big enchanted squat bowl of Tastee-Wheet&trade;	5	good	Effect: "Compensatory Cruelness", Effect Duration: 25
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	maroon Source essence	0		Last Available: "2016-06"
-9035	thick moldy browser cookie	5	crappy	Last Available: "2016-06"
+9035	moldy thick browser cookie	5	crappy	Last Available: "2016-06"
 9036	watered-down hand-crafted hacked gibson	2	super ultra mega EPIC	Last Available: "2016-06"
 9037	Herculean Source shades	0		Experience (Muscle): +1, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
-9039	bouncing jittery missing semicolon	0		Familiar Weight: +11
+9039	jittery bouncing missing semicolon	0		Familiar Weight: +11
 9040	fuchsia Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	ghostly Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	Source terminal SPAM chip	0		Last Available: "2016-06"
@@ -8930,8 +8930,8 @@
 9058	ghostly wobbly Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	wobbly Source terminal file: familiar.ext	0		Last Available: "2016-06"
-9061	ghostly tumbling Source terminal file: pram.ext	0		Last Available: "2016-06"
-9062	cyan shaking jittery Source terminal file: gram.ext	0		Last Available: "2016-06"
+9061	tumbling ghostly Source terminal file: pram.ext	0		Last Available: "2016-06"
+9062	jittery cyan shaking Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	cyan Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
@@ -8948,11 +8948,11 @@
 9076	Jeselnik's noir fedora of Leguizamo of the cheetah	0		Monster Level: +20, Sleaze Damage: +25, Initiative: +60, Last Available: "2016-07"
 9077	shaking greasy Fonzie's smooth trench coat	0		Moxie: +15, Experience (Moxie): +1, Sleaze Spell Damage: +10, Last Available: "2016-07"
 9078	smooth distilled upside-down Falcon&trade; Maltese Liquor	5	awesome	Last Available: "2016-07"
-9079	special moldy low-calorie hardboiled egg	1	crappy	Effect: "Strength of Ten Ettins", Effect Duration: 35, Last Available: "2016-07"
+9079	moldy low-calorie special hardboiled egg	1	crappy	Effect: "Strength of Ten Ettins", Effect Duration: 35, Last Available: "2016-07"
 9080	pulsating detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	upside-down ribald horrifying ruddy groovy protonic accelerator pack of the wise owl of the early riser	0		Mysticality: +20, Moxie Percent: +10, Maximum HP Percent: +40, Spooky Damage: +25, Sleaze Damage: +10, Adventures: +7, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
-9083	mirror red pulsating almost-dead walkie-talkie	0		Last Available: "2016-08"
+9083	pulsating red mirror almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	lightning-fast Adventurer bobblehead	0		Initiative: +40, Last Available: "2016-11"
 9085	blinking psychokinetic energy blob	0		Last Available: "2016-08"
 9086	bindle of the pedagogue of dire peril	0		Experience: +3, Weapon Damage: +20, Last Available: "2016-08"
@@ -8975,7 +8975,7 @@
 9103	spinning Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
 9105	compounded experience	0		Last Available: "2016-09"
-9106	upside-down olive Rad-B-Gone (1 lb.)	0		
+9106	olive upside-down Rad-B-Gone (1 lb.)	0		
 9107	flattened tumbling Rad-Pro (1 oz.)	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 55
 9108	lead umbrella	0		
 9109	anodized Vulcanized improved spinning Shrieking Weasel holo-record	0		Effect: "Grumpy and Ornery", Effect Duration: 55
@@ -8995,7 +8995,7 @@
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	delicious triple-distilled unidentified drink	9	awesome	
+9126	triple-distilled delicious unidentified drink	9	awesome	
 9127	olive extremely unsafe beefy KoL Con 13 T-shirt	0		Muscle: +10, Weapon Damage Percent: +100
 9128	ghostly prompt brainy discarded swimming trunks of Leguizamo	0		Mysticality: +5, Monster Level: +20, Adventures: +3
 9129	boiled diffused tarnished jittery diluted makeup	0		Effect: "Fit To Be Tide", Effect Duration: 31
@@ -9004,7 +9004,7 @@
 9132	executive horrifying pistol	0		Spooky Damage: +25, Meat Drop: +40
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	flavorless leftover pasty	4	decent	
-9135	drinkable special squat very whiskey	3	good	Effect: "Medieval Mage Mayhem", Effect Duration: 20
+9135	special drinkable squat very whiskey	3	good	Effect: "Medieval Mage Mayhem", Effect Duration: 20
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
@@ -9015,7 +9015,7 @@
 9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9144	shaking li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9146	quadruple-pressed lime green blinking hoarded candy wad	0		Effect: "Purpose", Effect Duration: 35, Last Available: "2016-10"
+9146	quadruple-pressed blinking lime green hoarded candy wad	0		Effect: "Purpose", Effect Duration: 35, Last Available: "2016-10"
 9147	super-nitrogenated gray Prunets	0		Effect: "Sweet, Nuts", Effect Duration: 41
 9148	bouncing Twitching Television Tattoo	0		
 9149	wobbly baby scorpion	0		Familiar Weight: +10
@@ -9024,11 +9024,11 @@
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	flavorless ghostly teal raw sweet potato	4	decent	Last Available: "2016-11"
 9154	adequate shaking raw beans	3	good	Last Available: "2016-11"
-9155	snack-sized rotten raw stuffing	2	crappy	Last Available: "2016-11"
+9155	rotten snack-sized raw stuffing	2	crappy	Last Available: "2016-11"
 9156	bland raw cranberry sauce	4	decent	Last Available: "2016-11"
 9157	moldy raw turkey	4	crappy	Last Available: "2016-11"
-9158	rotten low-calorie raw mincemeat	1	crappy	Last Available: "2016-11"
-9159	rotten tiny raw potato	1	crappy	Last Available: "2016-11"
+9158	low-calorie rotten raw mincemeat	1	crappy	Last Available: "2016-11"
+9159	tiny rotten raw potato	1	crappy	Last Available: "2016-11"
 9160	enchanted moldy raw gravy	4	crappy	Effect: "Ten out of Ten", Effect Duration: 15, Last Available: "2016-11"
 9161	low-calorie flavorless raw bread	1	decent	Last Available: "2016-11"
 9162	fuchsia Usain Bolt's scorching mini-marshmallow dispenser	0		Hot Damage: +25, Initiative: +80, Last Available: "2016-11"
@@ -9040,7 +9040,7 @@
 9168	twirling greedy lard-coated potato masher	0		Sleaze Spell Damage: +25, Meat Drop: +20, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	wobbly bread mold	0		Last Available: "2016-11"
-9171	stale miniature sweet potatoes	2	decent	Last Available: "2016-11"
+9171	miniature stale sweet potatoes	2	decent	Last Available: "2016-11"
 9172	normal bean casserole	4	good	Last Available: "2016-11"
 9173	delicious pulsating baked stuffing	3	awesome	Last Available: "2016-11"
 9174	super-sized adequate purple cranberry cylinder	5	good	Last Available: "2016-11"
@@ -9048,7 +9048,7 @@
 9176	rotten mince pie	3	crappy	Last Available: "2016-11"
 9177	toothsome snack-sized mashed potatoes	2	awesome	Last Available: "2016-11"
 9178	rotten warm gravy	4	crappy	Last Available: "2016-11"
-9179	snack-sized stale bread roll	2	decent	Last Available: "2016-11"
+9179	stale snack-sized bread roll	2	decent	Last Available: "2016-11"
 9180	delicious leftovers	3	awesome	Last Available: "2016-11"
 9181	stale red leftovers sandwich	3	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9063,12 +9063,12 @@
 9191	extra-dry eldritch concentrate	0		Effect: "The Dinsey Way", Effect Duration: 53, Last Available: "2016-11"
 9192	artisanal watered-down eldritch extract	2	EPIC	Last Available: "2016-11"
 9193	curative smartaleck's Official Council Aide Pin	0		Moxie Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
-9194	fancy artisanal watered-down eldritch distillate	2	EPIC	Effect: "Cancer Rising", Effect Duration: 15, Last Available: "2016-11"
-9195	pickled tumbling yellow eldritch essence	1		Last Available: "2016-11"
+9194	watered-down fancy artisanal eldritch distillate	2	EPIC	Effect: "Cancer Rising", Effect Duration: 15, Last Available: "2016-11"
+9195	pickled yellow tumbling eldritch essence	1		Last Available: "2016-11"
 9196	coward's Science Notebook	0		Monster Level: -20
 9197	twirling lion tamer's extremely unsafe eldritch hat of mayonnaise	0		Weapon Damage Percent: +100, Experience (familiar): +2, Sleaze Spell Damage: +50, Last Available: "2016-11"
 9198	mirror lightning-fast stylish eldritch pants of James Dean	0		Moxie: +25, Experience (Moxie): +3, Initiative: +40, Last Available: "2016-11"
-9199	mediocre watered-down eldritch elixir	2	decent	Last Available: "2016-11"
+9199	watered-down mediocre eldritch elixir	2	decent	Last Available: "2016-11"
 9200	scandalous Quartet of Flare Masters Jacket of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +5, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9122,7 +9122,7 @@
 9250	ionized deionized Inner Strength	0		Effect: "Elemental Mastery", Effect Duration: 22, Last Available: "2016-12"
 9251	polarized tumbling Inner Truth	0		Effect: "Corona de la Salsa", Effect Duration: 69, Last Available: "2016-12"
 9252	decent spiritual candy cane	4	good	Last Available: "2016-12"
-9253	weak drinkable enchanted blurry squat spiritual eggnog	2	good	Effect: "meat.enh", Effect Duration: 40, Last Available: "2016-12"
+9253	weak enchanted drinkable blurry squat spiritual eggnog	2	good	Effect: "meat.enh", Effect Duration: 40, Last Available: "2016-12"
 9254	miniature flavorless spiritual fruitcake	2	decent	Last Available: "2016-12"
 9255	bland spiritual gingerbread	4	decent	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	ionized spinning rock candy	0		Effect: "Antsy in your Pantsy", Effect Duration: 34, Last Available: "2016-12"
-9267	yummy low-calorie green-iced sweet roll	1	awesome	Last Available: "2016-12"
+9267	low-calorie yummy green-iced sweet roll	1	awesome	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	huge chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9145,10 +9145,10 @@
 9273	lightning-fast Sinatra's Third Eye	0		Experience (Moxie): +5, Initiative: +40, Last Available: "2016-12"
 9274	supercharged Krampus Horn of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25, Single Equip, Last Available: "2016-12"
 9275	spoiled hambrosier	4	crappy	Last Available: "2016-12"
-9276	acceptable high-proof chakra-mental wine	10	good	Last Available: "2016-12"
+9276	high-proof acceptable chakra-mental wine	10	good	Last Available: "2016-12"
 9277	cold-filtered chakra malt	0		Effect: "Punch Another Day", Effect Duration: 65, Last Available: "2016-12"
 9278	decent Black Angus blackburger	3	good	Last Available: "2016-12"
-9279	practically non-alcoholic smooth brandy	1	awesome	Last Available: "2016-12"
+9279	smooth practically non-alcoholic brandy	1	awesome	Last Available: "2016-12"
 9280	diffused Vulcanized blinking potion of spiritual gunkifying	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 54, Last Available: "2016-12"
 9281	flame-wreathed arcane researcher's bad vibroknife	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +10, Last Available: "2016-12"
 9282	lime green crystal belt buckle of wisdom of the wise owl	0		Mysticality: 35, Last Available: "2016-12"
@@ -9160,7 +9160,7 @@
 9288	jittery gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	nippy coward's Newton's Uncle Crimbo's hat	0		Experience (Mysticality): +3, Monster Level: -20, Cold Damage: +10, Last Available: "2016-12"
 9290	bland tumbling Eldritch snap	4	decent	Last Available: "2017-01"
-9291	compressed pulsating tumbling hot jelly	1		Last Available: "2017-01"
+9291	compressed tumbling pulsating hot jelly	1		Last Available: "2017-01"
 9292	altered bouncing jelly	1		Last Available: "2017-01"
 9293	denatured jittery olive jelly	1		Last Available: "2017-01"
 9294	boiled sleaze jelly	1		Last Available: "2017-01"
@@ -9169,18 +9169,18 @@
 9297	moldy shaking toast with hot jelly	4	crappy	Last Available: "2017-01"
 9298	yummy toast with jelly	4	awesome	Last Available: "2017-01"
 9299	normal toast with jelly	4	good	Last Available: "2017-01"
-9300	diet fancy rotten toast with sleaze jelly	1	crappy	Effect: "Bloodstain-Resistant", Effect Duration: 5, Last Available: "2017-01"
+9300	rotten fancy diet toast with sleaze jelly	1	crappy	Effect: "Bloodstain-Resistant", Effect Duration: 5, Last Available: "2017-01"
 9301	immense flavorless toast with stench jelly	6	decent	Last Available: "2017-01"
 9302	green space jellybicycle	0		Familiar Weight: +5
 9303	narrow hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	wobbly pewter candlestick	0		Familiar Weight: +10
 9305	blurry family-friendly wax hand of bravery	0		Spooky Resistance: +5, Sleaze Resistance: +1, Last Available: "2017-01"
 9306	frightening brawny candle	0		Muscle Percent: +20, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2017-01"
-9307	immense flavorless wax pancake	7	decent	Last Available: "2017-01"
+9307	flavorless immense wax pancake	7	decent	Last Available: "2017-01"
 9308	frightening fortified wax face	0		Damage Absorption: +60, Spooky Damage: +5, Last Available: "2017-01"
-9309	acceptable extra-dry wax booze	5	good	Last Available: "2017-01"
+9309	extra-dry acceptable wax booze	5	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	dehydrated maroon spinning sea jelly	1		Effect: "Blubbered Up", Effect Duration: 40, Last Available: "2017-01"
+9311	dehydrated spinning maroon sea jelly	1		Effect: "Blubbered Up", Effect Duration: 40, Last Available: "2017-01"
 9312	spoiled narrow sea truffle	3	crappy	Last Available: "2017-01"
 9313	bouncing tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
@@ -9203,7 +9203,7 @@
 9331	ghostly wobbly scorching electrified eldritch hammer of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2017-01"
 9332	flavorless eldritch mushroom	4	decent	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	miniature bland skewed eldritch mushroom pizza	2	decent	Last Available: "2017-03"
+9334	bland miniature skewed eldritch mushroom pizza	2	decent	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	alkaline eldritch rub	0		Effect: "Slimy Flavor", Effect Duration: 66, Last Available: "2017-02"
@@ -9235,27 +9235,27 @@
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	high-proof acceptable pulsating literal grasshopper	6	good	Last Available: "2017-03"
-9366	weak enchanted tolerable double entendre	2	good	Effect: "Quantum of Moxie", Effect Duration: 50, Last Available: "2017-03"
-9367	watered-down acceptable huge yellow Phlegethon	2	good	Last Available: "2017-03"
+9366	tolerable enchanted weak double entendre	2	good	Effect: "Quantum of Moxie", Effect Duration: 50, Last Available: "2017-03"
+9367	acceptable watered-down yellow huge Phlegethon	2	good	Last Available: "2017-03"
 9368	weak acceptable Siberian sunrise	2	good	Last Available: "2017-03"
-9369	watered-down hand-crafted mentholated wine	2	EPIC	Last Available: "2017-03"
+9369	hand-crafted watered-down mentholated wine	2	EPIC	Last Available: "2017-03"
 9370	smooth watered-down low tide martini	2	awesome	Last Available: "2017-03"
 9371	perfectly mixed blurry shroomtini	4	EPIC	Last Available: "2017-03"
-9372	weak artisanal morning dew	2	EPIC	Last Available: "2017-03"
+9372	artisanal weak morning dew	2	EPIC	Last Available: "2017-03"
 9373	mediocre spinning whiskey squeeze	3	decent	Last Available: "2017-03"
 9374	acceptable great fashioned	3	good	Last Available: "2017-03"
-9375	weak mediocre Gnomish sagngria	2	decent	Last Available: "2017-03"
-9376	practically non-alcoholic bad ghostly vodka stinger	1	decent	Last Available: "2017-03"
-9377	spirit-forward hand-crafted extremely slippery nipple	5	EPIC	Last Available: "2017-03"
-9378	artisanal special piscatini	3	EPIC	Effect: "The Chains Down In The Belly-O", Effect Duration: 40, Last Available: "2017-03"
+9375	mediocre weak Gnomish sagngria	2	decent	Last Available: "2017-03"
+9376	bad practically non-alcoholic ghostly vodka stinger	1	decent	Last Available: "2017-03"
+9377	hand-crafted spirit-forward extremely slippery nipple	5	EPIC	Last Available: "2017-03"
+9378	special artisanal piscatini	3	EPIC	Effect: "The Chains Down In The Belly-O", Effect Duration: 40, Last Available: "2017-03"
 9379	lousy Churchill	4	decent	Last Available: "2017-03"
 9380	acceptable soilzerac	4	good	Last Available: "2017-03"
-9381	artisanal weak special London frog	2	EPIC	Effect: "Angry Bone", Effect Duration: 40, Last Available: "2017-03"
+9381	artisanal special weak London frog	2	EPIC	Effect: "Angry Bone", Effect Duration: 40, Last Available: "2017-03"
 9382	aged red nothingtini	4	awesome	Last Available: "2017-03"
 9383	strong hand-crafted eighth plague	5	EPIC	Last Available: "2017-03"
 9384	artisanal narrow single entendre	4	EPIC	Last Available: "2017-03"
 9385	drinkable reverse Tantalus	4	good	Last Available: "2017-03"
-9386	aged practically non-alcoholic elemental caipiroska	1	awesome	Last Available: "2017-03"
+9386	practically non-alcoholic aged elemental caipiroska	1	awesome	Last Available: "2017-03"
 9387	acceptable Feliz Navidad	3	good	Last Available: "2017-03"
 9388	lousy yellow Bloody Nora	4	decent	Last Available: "2017-03"
 9389	bad moreltini	3	decent	Last Available: "2017-03"
@@ -9277,10 +9277,10 @@
 9405	upside-down filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	mirror exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
-9408	pulsating yellow gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9408	yellow pulsating gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	blurry high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
-9411	jittery yellow alien rock sample	0		Last Available: "2017-04"
+9411	yellow jittery alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9303,7 +9303,7 @@
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	moist quadruple-magnetized alien medicine	0		Effect: "Boletus Swoletus", Effect Duration: 20, Last Available: "2017-04"
 9433	diet stale alien salad	1	decent	Last Available: "2017-04"
-9434	artisanal enchanted ghostly alien booze	4	EPIC	Effect: "Singer's Faithful Ocelot", Effect Duration: 5, Last Available: "2017-04"
+9434	enchanted artisanal ghostly alien booze	4	EPIC	Effect: "Singer's Faithful Ocelot", Effect Duration: 5, Last Available: "2017-04"
 9435	lion tamer's dance instructor's experienced alien mask	0		Experience: +2, Experience Percent (Moxie): +10, Experience (familiar): +2, Last Available: "2017-04"
 9436	perfumed frosty quilted alien spear	0		Damage Absorption: +40, Cold Spell Damage: +10, Stench Resistance: +5, Last Available: "2017-04"
 9437	squat frightening Jack Frost's alien blowgun of the blizzard	0		Cold Spell Damage: 75, Spooky Damage: +5, Last Available: "2017-04"
@@ -9337,13 +9337,13 @@
 9465	skewed Spacegate	0		Last Available: "2017-04"
 9466	toothsome Aldebaran sardines	3	awesome	Last Available: "2017-04"
 9467	perfectly mixed twirling Centauri fish wine	3	EPIC	Last Available: "2017-04"
-9468	dehydrated teal huge oxygen	1		Effect: "Punch Another Day", Effect Duration: 50, Last Available: "2017-04"
+9468	dehydrated huge teal oxygen	1		Effect: "Punch Another Day", Effect Duration: 50, Last Available: "2017-04"
 9469	blurry vibrating stylish Spacegate scientist's insignia	0		Moxie: +25, Maximum MP Percent: +10, Single Equip, Last Available: "2017-04"
 9470	censurious Spacegate military insignia of Tarzan	0		Experience (Muscle): +3, Sleaze Resistance: +3, Single Equip, Last Available: "2017-04"
 9471	electrified Spacegate diplomat's insignia of James Dean of courage	0		Experience (Moxie): +3, Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2017-04"
-9472	squat olive Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
+9472	olive squat Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	fancy stale alien sandwich	3	decent	Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2017-04"
+9474	stale fancy alien sandwich	3	decent	Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	corrupted moist Spant eggs	0		Effect: "Swordholder", Effect Duration: 64
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9372,7 +9372,7 @@
 9500	gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	spinning vibrating occult plastic gundam of the sweet-tooth	0		Spell Damage Percent: +25, Maximum MP Percent: +10, Candy Drop: +100, Last Available: "2017-06"
-9503	yellow squat License to Chill	0		Last Available: "2017-07"
+9503	squat yellow License to Chill	0		Last Available: "2017-07"
 9504	tumbling Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
@@ -9384,7 +9384,7 @@
 9512	squat jittery Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	rotten jittery meteoreo	4	crappy	Last Available: "2017-08"
-9515	bad practically non-alcoholic meadeorite	1	decent	Last Available: "2017-08"
+9515	practically non-alcoholic bad meadeorite	1	decent	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	wicked meteortarboard of the cougar of the sweet-tooth	0		Moxie: +20, Spell Damage: +5, Candy Drop: +100, Last Available: "2017-08"
 9518	yellow fortified experienced meteorite guard of the brazier	0		Experience: +2, Damage Absorption: +60, Hot Spell Damage: +25, Damage Reduction: 9, Last Available: "2017-08"
@@ -9416,10 +9416,10 @@
 9544	O	0		Last Available: "2017-10"
 9545	tolerable DUFRESNE Suds	4	good	Last Available: "2017-09"
 9546	manspreader's mafia pinky ring of the brute	0		Muscle Percent: +30, Monster Level: +10, Single Equip
-9547	drinkable enchanted watered-down flask of port	2	good	Effect: "The Smile of Mr. A.", Effect Duration: 25
+9547	drinkable watered-down enchanted flask of port	2	good	Effect: "The Smile of Mr. A.", Effect Duration: 25
 9548	frightening fortified contract enforcement stick	0		Damage Absorption: +60, Spooky Damage: +5
 9549	spoiled Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
-9550	tolerable enchanted jug of booze	4	good	Effect: "Joyful Resolve", Effect Duration: 45, Last Available: "2017-10"
+9550	enchanted tolerable jug of booze	4	good	Effect: "Joyful Resolve", Effect Duration: 45, Last Available: "2017-10"
 9551	triple-moist deionized pair of candy glasses	0		Effect: "Stenchtastic", Effect Duration: 47, Last Available: "2017-10"
 9552	activated extra-vacuum-sealed adjusted teal temporary X tattoos	0		Effect: "Creepypasted", Effect Duration: 58, Last Available: "2017-10"
 9553	vaporized purple glyph of athleticism	1		Last Available: "2017-10"
@@ -9464,9 +9464,9 @@
 9592	blinking pulsating green mumming trunk	0		Last Available: "2017-12"
 9593	huge temperance whiskey	1	decent	Last Available: "2017-11"
 9594	irradiated polymerized tumbling mirror wishbone	0		Effect: "The Sweats", Effect Duration: 47, Last Available: "2017-11"
-9595	weak lousy Racisto Ruidoso	2	decent	Last Available: "2017-11"
+9595	lousy weak Racisto Ruidoso	2	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	massive toothsome bran muffin	8	awesome	
+9597	toothsome massive bran muffin	8	awesome	
 9598	bland blueberry muffin	3	decent	
 9599	bouncing silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
@@ -9479,8 +9479,8 @@
 9607	spinning silent I	0		Last Available: "2017-12"
 9608	silent J	0		Last Available: "2017-12"
 9609	fuchsia silent K	0		Last Available: "2017-12"
-9610	bouncing fuchsia silent L	0		Last Available: "2017-12"
-9611	olive twirling silent M	0		Last Available: "2017-12"
+9610	fuchsia bouncing silent L	0		Last Available: "2017-12"
+9611	twirling olive silent M	0		Last Available: "2017-12"
 9612	spinning silent N	0		Last Available: "2017-12"
 9613	silent O	0		Last Available: "2017-12"
 9614	silent P	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	tolerable stale cheer wine	4	good	Last Available: "2017-12"
-9630	decent thick tumbling stale Cheer-E-Os	5	good	Last Available: "2017-12"
+9630	thick decent tumbling stale Cheer-E-Os	5	good	Last Available: "2017-12"
 9631	shaking cheer-o-gram	0		Last Available: "2017-12"
 9632	weightlifter's cheerful antler hat of the brazier	0		Muscle: +15, Hot Spell Damage: +25, Last Available: "2017-12"
 9633	bouncing healthy cheerful Crimbo sweater of the sweet-tooth	0		Maximum HP Percent: +20, Candy Drop: +100, Last Available: "2017-12"
@@ -9511,14 +9511,14 @@
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	blurry The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9642	jittery huge The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9642	huge jittery The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	artisanal executive mime flask	3	EPIC	Last Available: "2017-12"
-9649	flavorless enchanted thick nega-mushroom	5	decent	Effect: "Gemini Rising", Effect Duration: 45, Last Available: "2017-12"
+9649	enchanted thick flavorless nega-mushroom	5	decent	Effect: "Gemini Rising", Effect Duration: 45, Last Available: "2017-12"
 9650	lousy watered-down mirror nega-mushroom wine	2	decent	Last Available: "2017-12"
 9651	dry Cheer-Up soda	0		Effect: "Spell Transfer Complete", Effect Duration: 31, Last Available: "2017-12"
 9652	stale low-calorie gray mime army rations	1	decent	Last Available: "2017-12"
@@ -9572,14 +9572,14 @@
 9700	novelty monorail ticket of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5
 9701	altered cyan pills	1		Effect: "Phorcefullness", Effect Duration: 45
 9702	twisted spinning furry pill	1		Effect: "Extra-Wet", Effect Duration: 50
-9703	vaporized olive huge beefy pill	1		Effect: "Cold as Ice", Effect Duration: 45
+9703	vaporized huge olive beefy pill	1		Effect: "Cold as Ice", Effect Duration: 45
 9704	modified excitement pill	1		
 9705	twisted huge vitamin G pill	1		
 9706	mixed red tumbling lucky-ish pill	1		
 9707	powdered dieting pill	1		Effect: "5 Pounds Lighter", Effect Duration: 5
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
-9714	lime green twirling huge Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
+9714	huge twirling lime green Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	squat Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
@@ -9593,13 +9593,13 @@
 9725	MacGyver's psychic's pslacks of mayonnaise	0		Maximum MP: +100, Sleaze Spell Damage: +50, Last Available: "2018-02"
 9726	Van der Graaf thinker's psychic's amulet	0		Mysticality: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-02"
 9727	spoiled purple heart-shaped candy whetstone	3	crappy	Last Available: "2018-02"
-9728	adequate tiny special twirling Swedish massage fish	1	good	Effect: "Yuletide Industry", Effect Duration: 10, Last Available: "2018-02"
+9728	tiny special adequate twirling Swedish massage fish	1	good	Effect: "Yuletide Industry", Effect Duration: 10, Last Available: "2018-02"
 9729	aged Third Base	3	awesome	Last Available: "2018-02"
-9730	weak drinkable twirling huge Bustle Hustler	2	good	Last Available: "2018-02"
-9731	pickled gray shaking Fabiotion	0		Effect: "Innately Truthy", Effect Duration: 61, Last Available: "2018-02"
+9730	drinkable weak twirling huge Bustle Hustler	2	good	Last Available: "2018-02"
+9731	pickled shaking gray Fabiotion	0		Effect: "Innately Truthy", Effect Duration: 61, Last Available: "2018-02"
 9732	pickled mirror Bettie page	0		Effect: "Hair on Your Chest", Effect Duration: 32, Last Available: "2018-02"
 9733	pickled unsweetened squat tonic o' Banderas	0		Effect: "Vented Spleen", Effect Duration: 33, Last Available: "2018-02"
-9734	unsweetened spinning blue twirling heather graham cracker	0		Effect: "Vital", Effect Duration: 48, Last Available: "2018-02"
+9734	unsweetened twirling blue spinning heather graham cracker	0		Effect: "Vital", Effect Duration: 48, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	jittery heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
@@ -9640,7 +9640,7 @@
 9772	Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
-9775	wobbly yellow Turtive	0		Last Available: "2018-03"
+9775	yellow wobbly Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
@@ -9663,7 +9663,7 @@
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
-9798	pulsating gray wobbly Oppossum	0		Last Available: "2018-03"
+9798	wobbly gray pulsating Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	bouncing Vulgure	0		Last Available: "2018-03"
@@ -9671,10 +9671,10 @@
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	huge Slotter	0		Last Available: "2018-03"
 9805	shaking Shudder	0		Last Available: "2018-03"
-9806	ghostly pulsating Glamare	0		Last Available: "2018-03"
+9806	pulsating ghostly Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
-9809	blinking tumbling Disgeist	0		Last Available: "2018-03"
+9809	tumbling blinking Disgeist	0		Last Available: "2018-03"
 9810	Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
@@ -9701,7 +9701,7 @@
 9833	dried blurry lustrous oyster egg	1		Effect: "Guts Feeling", Effect Duration: 50
 9834	distilled gleaming oyster egg	1		
 9835	blinking FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
-9836	cyan shaking mirror FantasyRealm guest pass	0		Last Available: "2018-04"
+9836	shaking cyan mirror FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	skewed blinking cyan grievous FantasyRealm G. E. M. of the pedagogue of the boozehound	0		Experience: +3, Weapon Damage Percent: +50, Booze Drop: +100, Lasts Until Rollover, Last Available: "2018-04"
 9838	Rubee&trade;	0		Last Available: "2018-04"
 9839	scorching FantasyRealm Warrior's Helm	0		Hot Damage: +25, Last Available: "2018-04"
@@ -9709,7 +9709,7 @@
 9841	energetic FantasyRealm Rogue's Mask	0		Maximum MP Percent: +20, Last Available: "2018-04"
 9842	lump of bauxite	0		Last Available: "2018-12"
 9843	lightning-fast stanky personal trainer's &quot;Remember the Trees&quot; Shirt	0		Experience Percent (Muscle): +10, Stench Spell Damage: +25, Initiative: +40
-9844	blinking upside-down maroon FantasyRealm key	0		Last Available: "2018-04"
+9844	upside-down blinking maroon FantasyRealm key	0		Last Available: "2018-04"
 9845	squat plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9727,9 +9727,9 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	bouncing LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	enchanted rotten diet FantasyRealm turkey leg	1	crappy	Effect: "Eyes Wide Propped", Effect Duration: 40, Last Available: "2018-04"
-9863	boozy bad FantasyRealm mead	5	decent	Last Available: "2018-04"
-9864	cyan twirling nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
+9862	rotten diet enchanted FantasyRealm turkey leg	1	crappy	Effect: "Eyes Wide Propped", Effect Duration: 40, Last Available: "2018-04"
+9863	bad boozy FantasyRealm mead	5	decent	Last Available: "2018-04"
+9864	twirling cyan nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	upside-down arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	twirling hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	huge map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	gray map to the Cursed Village	0		Last Available: "2018-04"
 9877	shaking map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	miniature normal denastified haunch	2	good	Last Available: "2018-04"
+9878	normal miniature denastified haunch	2	good	Last Available: "2018-04"
 9879	hand-crafted bad rum and good cola	3	EPIC	Last Available: "2018-04"
 9880	cold-filtered activated blurry Potion of Heroism	0		Effect: "Big Flaming Whip", Effect Duration: 60, Last Available: "2018-04"
 9881	frosty steel-toed Herculean leggings of the Spider Queen	0		Experience (Muscle): +1, Damage Reduction: 9, Cold Spell Damage: +10, Last Available: "2018-04"
@@ -9764,10 +9764,10 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	pulsating notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	triple-distilled drinkable two meat muck	9	good	
-9899	rotten jittery narrow chocolate Ogre Chieftain	3	crappy	
+9899	rotten narrow jittery chocolate Ogre Chieftain	3	crappy	
 9900	bland tiny chocolate &quot;Phoenix&quot;	1	decent	
-9901	decent miniature lime green chocolate Spider Queen	2	good	
-9902	watered-down acceptable hipster cocktail	2	good	
+9901	miniature decent lime green chocolate Spider Queen	2	good	
+9902	acceptable watered-down hipster cocktail	2	good	
 9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
 9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
 9905	jittery God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
@@ -9823,7 +9823,7 @@
 9955	auspicious ponytail clip of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Last Available: "2018-09"
 9956	paint palette of the sewer	0		Stench Damage: +25, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	blinking unremarkable duffel bag	0		Last Available: "2018-09"
-9958	pickled skewed wobbly twirling Purple Beast energy drink	1		Effect: "Angry like the Wolf", Effect Duration: 35, Last Available: "2018-09"
+9958	pickled wobbly twirling skewed Purple Beast energy drink	1		Effect: "Angry like the Wolf", Effect Duration: 35, Last Available: "2018-09"
 9959	pulsating Herculean cosmetic football	0		Experience (Muscle): +1, Last Available: "2018-09"
 9960	baleful smartaleck's shoe ad T-shirt	0		Moxie Percent: +30, Spell Damage: +25, Last Available: "2018-09"
 9961	shaking fortified pump-up high-tops	0		Damage Absorption: +60, Single Equip, Last Available: "2018-09"
@@ -9831,7 +9831,7 @@
 9963	tumbling very small dress	0		Last Available: "2018-09"
 9964	wobbly executive noticeable pumps of the storm	0		Maximum MP Percent: +40, Meat Drop: +40, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	lousy watered-down everfull glass	2		Last Available: "2018-09"
+9966	watered-down lousy everfull glass	2		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
 9968	jittery jam band bootleg	0		Last Available: "2018-09"
 9969	huge crafty experienced denim jacket	0		Experience: +2, Maximum MP: +10, Last Available: "2018-09"
@@ -9844,11 +9844,11 @@
 9977	smartaleck's party whip of the brute of Leguizamo	0		Muscle Percent: +30, Moxie Percent: +30, Monster Level: +20, Last Available: "2018-09"
 9978	tumbling Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	acceptable TRIO cup of beer	3	good	Last Available: "2018-09"
-9980	special normal maroon party platter for one	3	good	Effect: "Macho Profundo", Effect Duration: 10, Last Available: "2018-09"
+9980	normal special maroon party platter for one	3	good	Effect: "Macho Profundo", Effect Duration: 10, Last Available: "2018-09"
 9981	denatured Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	hardened personal trainer's party crasher	0		Experience Percent (Muscle): +10, Damage Reduction: 12, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
@@ -9876,12 +9876,12 @@
 10010	moldy ghostly ectoplasm	4	crappy	Last Available: "2018-11"
 10011	toothsome	4	awesome	Last Available: "2018-11"
 10012	hand-crafted bottle of vodka	4	EPIC	Last Available: "2018-11"
-10013	bland half-sized pizza	2	decent	Last Available: "2018-11"
-10014	bad watered-down martini	2	decent	Last Available: "2018-11"
-10015	special flavorless cherry pie	3	decent	Effect: "Heart of Pink", Effect Duration: 45, Last Available: "2018-11"
+10013	half-sized bland pizza	2	decent	Last Available: "2018-11"
+10014	watered-down bad martini	2	decent	Last Available: "2018-11"
+10015	flavorless special cherry pie	3	decent	Effect: "Heart of Pink", Effect Duration: 45, Last Available: "2018-11"
 10016	acceptable eggnog	3	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	low-calorie toothsome Hell ramen	1	awesome	Last Available: "2018-11"
+10018	toothsome low-calorie Hell ramen	1	awesome	Last Available: "2018-11"
 10019	drinkable squat squat gimlet	3	good	Last Available: "2018-11"
 10020	high-proof acceptable twice-haunted screwdriver	9	good	Last Available: "2018-11"
 10021	normal tumbling candy cane	3	good	Last Available: "2018-12"
@@ -9897,7 +9897,7 @@
 10031	skewed yellow Braindeer	0		Last Available: "2018-12"
 10032	Crimbo dog sweater	0		Familiar Weight: +5
 10033	inspector's ribald pristine walrus tusk	0		Sleaze Damage: +10, Item Drop: +15, Last Available: "2018-12"
-10034	squat spinning thick walrus blubber	0		Last Available: "2018-12"
+10034	spinning squat thick walrus blubber	0		Last Available: "2018-12"
 10035	frightening mansplainer's MacGyver's studded Staff of Frozen Lard	0		Damage Absorption: +80, Maximum MP: +100, Monster Level: +15, Spooky Damage: +5, Last Available: "2018-12"
 10036	narrow bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
@@ -9915,7 +9915,7 @@
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	miniature normal glass of raw eggs	2	good	Last Available: "2018-12"
 10051	watered-down perfectly mixed squat punch-drunk punch	2	EPIC	Last Available: "2018-12"
-10052	distilled narrow olive shaking body spradium	1		Effect: "Boletus Swoletus", Effect Duration: 40, Last Available: "2018-12"
+10052	distilled narrow shaking olive body spradium	1		Effect: "Boletus Swoletus", Effect Duration: 40, Last Available: "2018-12"
 10053	mirror Jeselnik's bauxite beret	0		Sleaze Damage: +25, Last Available: "2018-12"
 10054	brainy bauxite boxers	0		Mysticality: +5, Last Available: "2018-12"
 10055	cyan blurry experienced bauxite bow-tie	0		Experience: +2, Single Equip, Last Available: "2018-12"
@@ -9933,12 +9933,12 @@
 10067	fancy toothsome yule gruel	4	awesome	Effect: "Yet tea", Effect Duration: 45, Last Available: "2018-12"
 10068	tolerable jittery hot watered rum	4	good	Last Available: "2018-12"
 10069	perfectly mixed mirror bottle of Crimbognac	4	EPIC	Last Available: "2018-12"
-10070	stale tiny Crimboysters Rockefeller	1	decent	Last Available: "2018-12"
+10070	tiny stale Crimboysters Rockefeller	1	decent	Last Available: "2018-12"
 10071	twisted purple Crimbeau de toilette	1		Effect: "Hoity Toity", Effect Duration: 30, Last Available: "2018-12"
 10072	narrow Crimbo candle	0		Last Available: "2018-12"
 10073	narrow fuchsia Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10075	twirling blinking blinking Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10075	blinking twirling blinking Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
@@ -9959,7 +9959,7 @@
 10093	ghostly Jack Frost's energetic marble mignonette bowl	0		Maximum MP Percent: +20, Cold Spell Damage: +50, Last Available: "2019-12"
 10094	skewed curative marble medallion of chilblains	0		Cold Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2019-12"
 10095	padded slick marble mariachi hat	0		Moxie: +10, Damage Absorption: +20, Last Available: "2019-12"
-10096	modified twirling mirror marble molecules	1		Effect: "Piratastic", Effect Duration: 10, Last Available: "2019-12"
+10096	modified mirror twirling marble molecules	1		Effect: "Piratastic", Effect Duration: 10, Last Available: "2019-12"
 10097	polarized Mallomarbles	0		Effect: "Twen Tea", Effect Duration: 57
 10098	bouncing stanky baleful punching bag	0		Spell Damage: +25, Stench Spell Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10099	jittery double-paned fortified pith helmet	0		Damage Absorption: +60, Cold Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
@@ -9991,7 +9991,7 @@
 10125	baleful glass spectacles of the early riser	0		Spell Damage: +25, Adventures: +7, Single Equip, Last Available: "2021-12"
 10126	spinning flame-retardant boxer's glass shiv	0		Muscle Percent: +10, Hot Resistance: +1, Last Available: "2021-12"
 10127	reassuring dangerous glass serape	0		Weapon Damage: +10, Spooky Resistance: +1, Last Available: "2021-12"
-10128	dehydrated mirror blurry glass shards	1		Last Available: "2021-12"
+10128	dehydrated blurry mirror glass shards	1		Last Available: "2021-12"
 10129	corrupted frozen quadruple-dry hard candy	0		Effect: "Orc Chops", Effect Duration: 66
 10130	up-at-dawn loofah lumberjack's hat of horror	0		Spooky Spell Damage: +25, Adventures: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
 10131	reassuring double-paned loofah lei	0		Cold Resistance: +5, Spooky Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
@@ -10013,7 +10013,7 @@
 10147	squat red-and-green microcamera	0		Familiar Weight: +5
 10148	coward's cobbled-together Meat detector	0		Monster Level: -20, Lasts Until Rollover, Last Available: "2019-12"
 10149	cold-filtered tin thermos of chai	0		Effect: "Super Vision", Effect Duration: 61, Last Available: "2019-12"
-10150	dehydrated ghostly shaking prototype stimulant	1		Last Available: "2019-12"
+10150	dehydrated shaking ghostly prototype stimulant	1		Last Available: "2019-12"
 10151	tailored vest of the brute	0		Muscle Percent: +30, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
@@ -10021,10 +10021,10 @@
 10155	tasty bite-sized elf army field rations	1	awesome	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	tumbling twirling thinker's discarded bowtie of the pedagogue	0		Mysticality: +10, Experience: +3, Lasts Until Rollover, Last Available: "2019-12"
-10158	triple-distilled lousy martiny	9	decent	Last Available: "2019-12"
-10159	tumbling wobbly tryptophan dart	0		Last Available: "2019-12"
+10158	lousy triple-distilled martiny	9	decent	Last Available: "2019-12"
+10159	wobbly tumbling tryptophan dart	0		Last Available: "2019-12"
 10160	diffused Vulcanized narrow licorice snake	0		Effect: "Radiated and Grodiated", Effect Duration: 32
-10161	denatured purple shaking virgin jello shot	0		Effect: "Wreathed in Smoke", Effect Duration: 60
+10161	denatured shaking purple virgin jello shot	0		Effect: "Wreathed in Smoke", Effect Duration: 60
 10162	aerosolized extra-corrupted mutated candy lump	0		Effect: "Hangdog", Effect Duration: 69
 10163	extra-adjusted energized mirror government-issued candy	0		Effect: "This Is Where You're a Viking", Effect Duration: 58
 10164	colloidal Pneumo bar	0		Effect: "Brocolate Brostidigitation", Effect Duration: 15
@@ -10033,12 +10033,12 @@
 10168	shaking squat blood bag	0		
 10169	stale bloodstick	3	decent	
 10170	weak perfectly mixed bottle of Sanguiovese	2	EPIC	
-10171	delicious enchanted snack-sized actual blood sausage	2	awesome	Effect: "Ooh, Sweet!", Effect Duration: 45
+10171	enchanted snack-sized delicious actual blood sausage	2	awesome	Effect: "Ooh, Sweet!", Effect Duration: 45
 10172	artisanal mulled blood	3	EPIC	
 10173	thick special spoiled blood snowcone	5	crappy	Effect: "Can Has Cyborger", Effect Duration: 25
-10174	artisanal practically non-alcoholic Red Russian	1	super ultra mega turbo EPIC	
+10174	practically non-alcoholic artisanal Red Russian	1	super ultra mega turbo EPIC	
 10175	bland blood roll-up	3	decent	
-10176	acceptable practically non-alcoholic fancy tumbling bottle of blood	1	good	Effect: "Antsy in your Pantsy", Effect Duration: 45
+10176	fancy practically non-alcoholic acceptable tumbling bottle of blood	1	good	Effect: "Antsy in your Pantsy", Effect Duration: 45
 10177	small moldy wobbly blood-soaked sponge cake	2	crappy	
 10178	acceptable enchanted vampagne	4	good	Effect: "The Magic of LOV", Effect Duration: 30
 10179	spoiled yellow plain snowcone	3	crappy	
@@ -10061,7 +10061,7 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	squat tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	miniature stale crabsicle	2	decent	Last Available: "2019-04"
+10199	stale miniature crabsicle	2	decent	Last Available: "2019-04"
 10200	mirror melty plastic grenade	0		Last Available: "2019-04"
 10201	irresponsibly strong artisanal bottle of dark rhum	9	EPIC	Last Available: "2019-04"
 10202	strong hand-crafted bottle of extra-dark rhum	5	EPIC	Last Available: "2019-04"
@@ -10084,8 +10084,8 @@
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
-10222	cyan blurry Red Roger's skull	0		Last Available: "2019-04"
-10223	pickled upside-down skewed pewter shavings	1		Last Available: "2019-04"
+10222	blurry cyan Red Roger's skull	0		Last Available: "2019-04"
+10223	pickled skewed upside-down pewter shavings	1		Last Available: "2019-04"
 10224	squat Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	pulsating PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	medical-grade plush sea serpent	0		HP Regen Min: 7, HP Regen Max: 10, Monster Level: -100, Single Equip, Last Available: "2019-04"
@@ -10095,11 +10095,11 @@
 10230	twirling ruddy piratical blunderbuss	0		Maximum HP Percent: +40, Item Drop: +5, Last Available: "2019-04"
 10231	spinning quilted personal trainer's PirateRealm party hat of the storm	0		Experience Percent (Muscle): +10, Damage Absorption: +40, Maximum MP Percent: +40, Last Available: "2019-04"
 10232	acceptable Island Landslide	4	good	Last Available: "2019-04"
-10233	watered-down lousy red Island Thunderstorm	2	decent	Last Available: "2019-04"
-10234	weak acceptable Island Hurricane	2	good	Last Available: "2019-04"
+10233	lousy watered-down red Island Thunderstorm	2	decent	Last Available: "2019-04"
+10234	acceptable weak Island Hurricane	2	good	Last Available: "2019-04"
 10235	delicious fuchsia twirling Skull Punch	3	awesome	Last Available: "2019-04"
 10236	aged Electric Punch	3	awesome	Last Available: "2019-04"
-10237	bad irresponsibly strong Smuggler's Punch	9	decent	Last Available: "2019-04"
+10237	irresponsibly strong bad Smuggler's Punch	9	decent	Last Available: "2019-04"
 10238	watered-down artisanal ghostly Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10239	drinkable Turtle Bowl	4	good	Last Available: "2019-04"
 10240	tolerable boozy gray Cobra Bowl	5	good	Last Available: "2019-04"
@@ -10165,9 +10165,9 @@
 10300	greasy Jack Frost's Lo Pan's whittled owl figurine	0		Spell Critical Percent: +30, Cold Spell Damage: +50, Sleaze Spell Damage: +10, Single Equip, Last Available: "2019-08"
 10301	rosy-cheeked whittled fox figurine of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: 80, Single Equip, Last Available: "2019-08"
 10302	lime green Lo Pan's electrified hardy Newton's whittled walking stick	0		Experience (Mysticality): +3, Maximum HP: +50, Spell Critical Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-08"
-10303	adequate miniature enchanted campfire hot dog	2	good	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 35, Last Available: "2019-08"
-10304	small yummy campfire baked potato	2	awesome	Last Available: "2019-08"
-10305	small moldy campfire s'more	2	crappy	Last Available: "2019-08"
+10303	miniature enchanted adequate campfire hot dog	2	good	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 35, Last Available: "2019-08"
+10304	yummy small campfire baked potato	2	awesome	Last Available: "2019-08"
+10305	moldy small campfire s'more	2	crappy	Last Available: "2019-08"
 10306	moldy campfire beans	4	crappy	Last Available: "2019-08"
 10307	normal campfire stew	3	good	Last Available: "2019-08"
 10308	blinking campfire coffee	1	good	Last Available: "2019-08"
@@ -10195,14 +10195,14 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	special moldy jittery bu&ntilde;uelos Jaliscos	3	crappy	Effect: "Texas Elegance", Effect Duration: 20, Last Available: "2019-12"
 10338	moldy flan del mar	4	crappy	Last Available: "2019-12"
-10339	stale enchanted bite-sized Baja sopapilla	1	decent	Effect: "Stuck That Way", Effect Duration: 45, Last Available: "2019-12"
+10339	bite-sized stale enchanted Baja sopapilla	1	decent	Effect: "Stuck That Way", Effect Duration: 45, Last Available: "2019-12"
 10340	nippy plastic Mer-kin baker	0		Cold Damage: +10, Last Available: "2019-12"
 10341	chaotic plastic sea elf	0		Spell Critical Percent: +10, Last Available: "2019-12"
 10342	plastic yuleviathan of the dark arts	0		Spell Damage Percent: +100, Last Available: "2019-12"
 10343	Sinatra's plastic dolphin &quot;orphan&quot;	0		Experience (Moxie): +5, Single Equip, Last Available: "2019-12"
 10344	Da Vinci's plastic Dolph Bossin	0		Experience (Mysticality): +5, Last Available: "2019-12"
 10345	maroon red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	stale miniature mana-coated yams	2	decent	Last Available: "2019-11"
+10346	miniature stale mana-coated yams	2	decent	Last Available: "2019-11"
 10347	decent twirling mana-basted tofurkey leg	3	good	Last Available: "2019-11"
 10348	rotten mana-fortified cranberry sauce	3	crappy	Last Available: "2019-11"
 10349	bland twirling pulsating mana-stuffed herbal stuffing	3	decent	Last Available: "2019-11"
@@ -10215,7 +10215,7 @@
 10356	quantum unsweetened organic potpourri	0		Effect: "Christmessy", Effect Duration: 16, Last Available: "2019-12"
 10357	bad boot flask	4	decent	Last Available: "2019-12"
 10358	irradiated infernal snowball	0		Effect: "Flaming Weapon", Effect Duration: 35, Last Available: "2019-12"
-10359	ghostly upside-down madness	0		Last Available: "2019-12"
+10359	upside-down ghostly madness	0		Last Available: "2019-12"
 10360	altered fish sauce	1		Last Available: "2019-12"
 10361	normal guffin	4	good	Last Available: "2019-12"
 10362	modified tumbling Shantix&trade;	1		Last Available: "2019-12"
@@ -10227,7 +10227,7 @@
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	modified purple livid energy	1		Effect: "Berry Experiential", Effect Duration: 20, Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	twisted ghostly green beggin' cologne	1		Last Available: "2019-12"
+10371	twisted green ghostly beggin' cologne	1		Last Available: "2019-12"
 10372	family-friendly oxygenated eggnog helmet of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +1, Adventure Underwater, Last Available: "2019-12"
 10373	hand-knitted diving booties	0		Last Available: "2019-12"
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10240,12 +10240,12 @@
 10381	shaking The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	denatured shaking olive salty gumdrop	0		Effect: "Tingly Elbows", Effect Duration: 62, Last Available: "2019-12"
+10384	denatured olive shaking salty gumdrop	0		Effect: "Tingly Elbows", Effect Duration: 62, Last Available: "2019-12"
 10385	purple Fonzie's ribbon candy ascot of the sewer	0		Experience (Moxie): +1, Stench Damage: +25, Single Equip, Last Available: "2019-12"
 10386	green moist Crimbo spices	0		Last Available: "2019-12"
 10387	squat intact anemone spike	0		Last Available: "2019-12"
 10388	spinning careful anemoney clip	0		Monster Level: -10, Single Equip, Last Available: "2019-12"
-10389	spinning squat blue runny icing	0		Last Available: "2019-12"
+10389	squat spinning blue runny icing	0		Last Available: "2019-12"
 10390	mixed super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	smelly occult icing poncho	0		Spell Damage Percent: +25, Stench Spell Damage: +10, Item Drop: +5, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
@@ -10254,8 +10254,8 @@
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	wobbly tinsel fin	0		Familiar Weight: +5
 10397	bland bowl of mernudo	3	decent	Last Available: "2019-12"
-10398	tolerable weak fishelada	2	good	Last Available: "2019-12"
-10399	miniature spoiled fuchsia huge ojo de pez burrito	2	crappy	Last Available: "2019-12"
+10398	weak tolerable fishelada	2	good	Last Available: "2019-12"
+10399	spoiled miniature huge fuchsia ojo de pez burrito	2	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	upside-down waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	decent salt plum	3	good	Last Available: "2019-12"
 10416	blue peppermint eel sauce	0		Last Available: "2019-12"
-10417	diet spoiled and bean	1	crappy	Last Available: "2019-12"
+10417	spoiled diet and bean	1	crappy	Last Available: "2019-12"
 10418	teal miser's manspreader's brawny kelp-holly gun	0		Muscle Percent: +20, Monster Level: +10, Meat Drop: +10, Last Available: "2019-12"
 10419	narrow narrow experienced Yuleviathan necklace of temperance	0		Experience: +2, Sleaze Resistance: +5, Single Equip, Last Available: "2019-12"
 10420	foul-smelling slick peppermint spine	0		Moxie: +10, Stench Damage: +10, Last Available: "2019-12"
@@ -10281,11 +10281,11 @@
 10422	yellow flame-retardant ruddy Crimbylow-rise jeans	0		Maximum HP Percent: +40, Hot Resistance: +1, Last Available: "2019-12"
 10423	wool kelp-holly drape of the bloodbag	0		Maximum HP: +100, Cold Resistance: +1, Last Available: "2019-12"
 10424	Van der Graaf hale Staff of the Peppermint Twist of the dark arts of the blizzard	0		Spell Damage Percent: +100, Maximum HP: +20, Cold Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
-10425	jumbo delicious tempura and bean	5	awesome	Last Available: "2019-12"
+10425	delicious jumbo tempura and bean	5	awesome	Last Available: "2019-12"
 10426	tolerable gray salt plum sake	4	good	Last Available: "2019-12"
 10427	extra-improved magnetized super-ionized pressurized potion of possessiveness	0		Effect: "Super-Charged", Effect Duration: 27, Last Available: "2019-12"
 10428	activated anodized squat jittery almond	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14
-10429	modified improved skewed gray upside-down handful of mixed nuts	0		Effect: "Savage Beast Inside", Effect Duration: 51, Last Available: "2019-12"
+10429	modified improved upside-down skewed gray handful of mixed nuts	0		Effect: "Savage Beast Inside", Effect Duration: 51, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	greasy studded quilted Retrospecs	0		Damage Absorption: 120, Sleaze Spell Damage: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
@@ -10335,15 +10335,15 @@
 10478	plastic doll arms	0		
 10479	spinning plastic doll legs	0		
 10480	rubber baby doll	0		
-10481	ghostly jittery olive Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
+10481	olive jittery ghostly Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
-10483	narrow mirror free-range mushroom	0		Last Available: "2020-03"
+10483	mirror narrow free-range mushroom	0		Last Available: "2020-03"
 10484	ghostly plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	low-calorie flavorless shaking mushroom filet	1	decent	Last Available: "2020-03"
+10489	flavorless low-calorie shaking mushroom filet	1	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	compressed mushroom tea	1		Last Available: "2020-03"
 10492	perfectly mixed mushroom whiskey	4	EPIC	Last Available: "2020-03"
@@ -10395,11 +10395,11 @@
 10539	blurry reassuring Guzzlr souvenir stein	0		Spooky Resistance: +1, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	lousy spinning Ghiaccio Colada	4	decent	Last Available: "2020-05"
-10542	watered-down hand-crafted Sourfinger	2	EPIC	Last Available: "2020-05"
+10542	hand-crafted watered-down Sourfinger	2	EPIC	Last Available: "2020-05"
 10543	mediocre practically non-alcoholic Nog-on-the-Cob	1	decent	Last Available: "2020-05"
 10544	hand-crafted Steamboat	4	EPIC	Last Available: "2020-05"
 10545	watered-down drinkable Buttery Boy	2	good	Last Available: "2020-05"
-10546	blinking lime green Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
+10546	lime green blinking Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	ghostly sharpshooter's strapping clown car key	0		Muscle: +5, Critical Hit Percent: +10, Last Available: "2020-08"
 10548	ghostly twirling Usain Bolt's toasty nippy batting cage key	0		Cold Damage: +10, Hot Damage: +5, Initiative: +80, Last Available: "2020-08"
 10549	narrow blue frosty Samson's aqu&iacute; of chilblains	0		Experience (Muscle): +5, Cold Damage: +25, Cold Spell Damage: +10, Last Available: "2020-08"
@@ -10432,10 +10432,10 @@
 10576	quadruple-polymerized triple-enhanced salty drippy candy bar	0		Effect: "Patience of the Tortoise", Effect Duration: 32
 10577	warmed writhing drippy candy bar	0		Effect: "Mer-kindliness", Effect Duration: 47
 10578	irradiated gooey drippy candy bar	0		Effect: "Big", Effect Duration: 67
-10579	lime green wobbly narrow baby camelCalf	0		Free Pull, Last Available: "2020-07"
+10579	narrow wobbly lime green baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	narrow dromedary drinking helmet	0		
 10581	narrow packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
-10582	mirror fuchsia SpinMaster&trade; lathe	0		Last Available: "2020-08"
+10582	fuchsia mirror SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	greasy frosty birch battery	0		Cold Spell Damage: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-08"
 10585	narrow green careful therapeutic quilted ebony epee	0		Damage Absorption: +40, Monster Level: -10, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
@@ -10484,7 +10484,7 @@
 10628	huge onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
 10630	alabaster queen	0		Last Available: "2020-09"
-10631	jittery huge alabaster rook	0		Last Available: "2020-09"
+10631	huge jittery alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
 10633	blinking alabaster knight	0		Last Available: "2020-09"
 10634	alabaster pawn	0		Last Available: "2020-09"
@@ -10506,7 +10506,7 @@
 10650	ghostly grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	tumbling greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
-10653	aerosolized extra-unsweetened wobbly narrow fortifying hot cocoa	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 26, Last Available: "2020-12"
+10653	aerosolized extra-unsweetened narrow wobbly fortifying hot cocoa	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 26, Last Available: "2020-12"
 10654	oxidized anodized colloidal skewed boiling hot cocoa	0		Effect: "From Nantucket", Effect Duration: 54, Last Available: "2020-12"
 10655	diffused cool hot cocoa	0		Effect: "Capricorn Rising", Effect Duration: 61, Last Available: "2020-12"
 10656	quantum overly-fancy hot cocoa	0		Effect: "Toast Tea", Effect Duration: 48, Last Available: "2020-12"
@@ -10541,7 +10541,7 @@
 10685	government food shipment	0		Last Available: "2020-12"
 10686	gray government booze shipment	0		Last Available: "2020-12"
 10687	cyan government candy shipment	0		Last Available: "2020-12"
-10688	pulsating twirling Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
+10688	twirling pulsating Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
@@ -10576,7 +10576,7 @@
 10720	mediocre weak barrel-aged eggnog	2	decent	Last Available: "2020-12"
 10721	moldy hand-crafted candy cane	3	crappy	Last Available: "2020-12"
 10722	rotten super-sized drive-thru burger	5	crappy	Last Available: "2020-12"
-10723	drinkable fancy Boulevardier cocktail	4	good	Effect: "Pumped Stomach", Effect Duration: 5, Last Available: "2020-12"
+10723	fancy drinkable Boulevardier cocktail	4	good	Effect: "Pumped Stomach", Effect Duration: 5, Last Available: "2020-12"
 10724	enhanced blinking Hotwire&trade; brand candy rope	0		Effect: "Oth-Jeal-O", Effect Duration: 67, Last Available: "2020-12"
 10725	decent bowl full of jelly	4	good	Last Available: "2020-12"
 10726	delicious Eye and a Twist	3	awesome	Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	mirror crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	twirling emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	blurry teal spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	twirling emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	blurry teal spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	shaking robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10606,7 +10606,7 @@
 10750	narrow shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	pulsating plate	0		Familiar Weight: +5
 10752	cold-filtered narrow pulsating short beer	0		Effect: "Broken Bone Nubs", Effect Duration: 47, Last Available: "2021-05"
-10753	polarized red shaking short stack of pancakes	0		Effect: "Heart of Green", Effect Duration: 55, Last Available: "2021-05"
+10753	polarized shaking red short stack of pancakes	0		Effect: "Heart of Green", Effect Duration: 55, Last Available: "2021-05"
 10754	diffused liquefied ionized short stick of butter	0		Effect: "Enraged", Effect Duration: 61, Last Available: "2021-05"
 10755	non-polymerized Vulcanized short glass of water	0		Effect: "Greedy Resolve", Effect Duration: 49, Last Available: "2021-05"
 10756	pressed dry moist spinning short	0		Effect: "Dancing Prowess", Effect Duration: 16, Last Available: "2021-05"
@@ -10659,7 +10659,7 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	mansplainer's padded Daylight Shavings Helmet of dire peril	0		Weapon Damage: +20, Damage Absorption: +20, Monster Level: +15, Last Available: "2021-11"
 10805	olive eggwater	1	awesome	Last Available: "2021-12"
-10806	decent gigantic spinning bread man	8	good	Last Available: "2021-12"
+10806	gigantic decent spinning bread man	8	good	Last Available: "2021-12"
 10807	rotten plain candy cane	3	crappy	Last Available: "2021-12"
 10808	super-sized decent flour cookie	5	good	Last Available: "2021-12"
 10809	skewed dance instructor's plastic food lab	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2021-12"
@@ -10667,19 +10667,19 @@
 10811	gray veiny plastic chem lab	0		Maximum HP: +10, Single Equip, Last Available: "2021-12"
 10812	Sinatra's plastic primary lab	0		Experience (Moxie): +5, Single Equip, Last Available: "2021-12"
 10813	shellacked plastic Cheer Core	0		Damage Reduction: 7, Single Equip, Last Available: "2021-12"
-10814	huge green packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
+10814	green huge packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
 10815	medicine cabinet	0		Last Available: "2021-12"
 10816	energetic supercool ice crown of courage	0		Moxie Percent: +20, Maximum MP Percent: +20, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2021-12"
 10817	smelly vibrating deadly jeans	0		Weapon Damage: +5, Maximum MP Percent: +10, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-12"
 10818	cyan perfumed nasty Newton's ice wrap	0		Experience (Mysticality): +3, Stench Damage: +5, Stench Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	normal immense pulsating tofu pop	6	good	Last Available: "2021-12"
+10819	immense normal pulsating tofu pop	6	good	Last Available: "2021-12"
 10820	snack-sized normal pulsating bowl of prescription candy	2	good	Last Available: "2021-12"
 10821	decent fishcake	4	good	Last Available: "2021-12"
 10822	rotten bone broth	4	crappy	Last Available: "2021-12"
-10823	bland blinking mirror yellow star pop	3	decent	Last Available: "2021-12"
+10823	bland yellow mirror blinking star pop	3	decent	Last Available: "2021-12"
 10824	perfectly mixed Doc's Fortifying Wine	4	EPIC	Last Available: "2021-12"
-10825	tolerable high-proof Doc's Smartifying Wine	7	good	Last Available: "2021-12"
-10826	hand-crafted fancy practically non-alcoholic Doc's Limbering Wine	1	EPIC	Effect: "Sweet Tooth", Effect Duration: 10, Last Available: "2021-12"
+10825	high-proof tolerable Doc's Smartifying Wine	7	good	Last Available: "2021-12"
+10826	fancy practically non-alcoholic hand-crafted Doc's Limbering Wine	1	EPIC	Effect: "Sweet Tooth", Effect Duration: 10, Last Available: "2021-12"
 10827	triple-distilled hand-crafted Doc's Medical-Grade Wine	9	EPIC	Last Available: "2021-12"
 10828	dehydrated upside-down Homebodyl&trade;	1		Last Available: "2021-12"
 10829	pickled squat Extrovermectin&trade;	1		Last Available: "2021-12"
@@ -10691,9 +10691,9 @@
 10835	anodized anti-odor cream	0		Effect: "Pumped Up", Effect Duration: 28, Last Available: "2021-12"
 10836	enhanced tumbling anti-creep cream	0		Effect: "Mistified", Effect Duration: 64, Last Available: "2021-12"
 10837	polarized triple-irradiated maroon anti-pain cream	0		Effect: "Spell Transfer Complete", Effect Duration: 54, Last Available: "2021-12"
-10838	delicious spirit-forward bouncing skewed Doc's Special Reserve Wine	5	awesome	Last Available: "2021-12"
+10838	spirit-forward delicious bouncing skewed Doc's Special Reserve Wine	5	awesome	Last Available: "2021-12"
 10839	delicious bread pie	4	awesome	Last Available: "2021-12"
-10840	lousy weak clear Russian	2	decent	Last Available: "2021-12"
+10840	weak lousy clear Russian	2	decent	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	teal Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	shaking goo magnet	0		Last Available: "2021-12"
 10851	blinking Socratic cozy scarf	0		Experience (Mysticality): +1, Last Available: "2021-12"
-10852	gigantic bland mirror blue huge Crimbo cookie	8	decent	Last Available: "2023-06"
+10852	gigantic bland blue mirror huge Crimbo cookie	8	decent	Last Available: "2023-06"
 10853	oxidized squat squat fleshy putty	0		Effect: "Mayeaugh", Effect Duration: 46, Last Available: "2021-12"
 10854	ghostly shaking resourceful third ear	0		Maximum MP: +50, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10729,11 +10729,11 @@
 10873	toasty MacGyver's can of mixed everything of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +100, Hot Damage: +5, Last Available: "2021-12"
 10874	spinning Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	rotten jumbo bouncing meatball	5	crappy	Last Available: "2021-12"
+10876	jumbo rotten bouncing meatball	5	crappy	Last Available: "2021-12"
 10877	upside-down upside-down cloned monster	0		Last Available: "2021-12"
 10878	huge meatball machine	0		Last Available: "2021-12"
 10879	twirling refurbished air fryer	0		Last Available: "2021-12"
-10880	distilled shaking squat fried air	1		Last Available: "2021-12"
+10880	distilled squat shaking fried air	1		Last Available: "2021-12"
 10881	shaking 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	pickled astral energy drink	1		
@@ -10748,7 +10748,7 @@
 10892	combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	squat purple censurious combat lover's locket	0		Sleaze Resistance: +3, Single Equip, Last Available: "2022-02"
 10894	Thwaitgold protozoa statuette	0		
-10895	upside-down twirling grey gosling	0		Free Pull, Last Available: "2022-03"
+10895	twirling upside-down grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	grey down vest	0		Experience (familiar): +2
 10897	shaking trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
@@ -10767,9 +10767,9 @@
 10911	pressed red gaffer's tape	0		Effect: "Stick Emporium Membership", Effect Duration: 34, Last Available: "2022-05"
 10912	adequate 20-lb can of rice and beans	3	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	miniature rotten expired MRE	2	crappy	Last Available: "2022-05"
-10915	enchanted spoiled cool mint precipice bar	3	crappy	Effect: "Human-Pirate Hybrid", Effect Duration: 15, Last Available: "2022-05"
-10916	super-sized bland carrot cake precipice bar	5	decent	Last Available: "2022-05"
+10914	rotten miniature expired MRE	2	crappy	Last Available: "2022-05"
+10915	spoiled enchanted cool mint precipice bar	3	crappy	Effect: "Human-Pirate Hybrid", Effect Duration: 15, Last Available: "2022-05"
+10916	bland super-sized carrot cake precipice bar	5	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	cyan packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10777,7 +10777,7 @@
 10921	smooth blurry jittery Dad's brandy	4	awesome	Last Available: "2022-06"
 10922	avaricious rosy-cheeked teacher's pen	0		Maximum HP Percent: +30, Meat Drop: +30, Last Available: "2022-06"
 10923	half-sized delicious fire-roasted lake trout	2	awesome	Last Available: "2022-06"
-10924	snack-sized normal skewed guilty sprout	2	good	Last Available: "2022-06"
+10924	normal snack-sized skewed guilty sprout	2	good	Last Available: "2022-06"
 10925	vibrating mother's necklace of the scaredy-cat	0		Maximum MP Percent: +10, Monster Level: -15, Last Available: "2022-06"
 10926	anodized non-improved trampled ticket stub	0		Effect: "Cold Throat", Effect Duration: 61, Last Available: "2022-06"
 10927	enhanced bouncing savings bond	0		Effect: "Egg-stortionary Tactics", Effect Duration: 60, Last Available: "2022-06"
@@ -10836,24 +10836,24 @@
 10980	jittery Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	squat blurry Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10983	blurry squat Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
 10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	lime green spinning Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10986	spinning lime green Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	normal baked veggie ricotta casserole	4	good	Last Available: "2022-11"
 10989	stale special plain calzone	4	decent	Effect: "Sugar Smacks", Effect Duration: 10, Last Available: "2022-11"
-10990	thick flavorless roasted vegetable focaccia	5	decent	Last Available: "2022-11"
+10990	flavorless thick roasted vegetable focaccia	5	decent	Last Available: "2022-11"
 10991	flavorless pulsating Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	rotten Calzone of Legend	3	crappy	Last Available: "2022-11"
 10993	jittery maroon Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
 10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	shaking tumbling Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10995	tumbling shaking Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
 10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
 10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	teal cookbookbat book	0		Familiar Weight: +5
 10999	squat Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	decent small Deep Dish of Legend	2	good	Last Available: "2022-11"
+11000	small decent Deep Dish of Legend	2	good	Last Available: "2022-11"
 11001	squat deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10866,11 +10866,11 @@
 11010	stale blurry swamp haunch	4	decent	
 11011	jittery blurry blue Sinatra's gator shades of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +5, Single Equip
 11012	milk cap	0		
-11013	lousy weak special maroon Charleston Choo-Choo	2	decent	Effect: "Beta Carotene Overdose", Effect Duration: 30
+11013	weak lousy special maroon Charleston Choo-Choo	2	decent	Effect: "Beta Carotene Overdose", Effect Duration: 30
 11014	boozy tolerable Velvet Veil	5	good	
 11015	practically non-alcoholic tolerable lime green Marltini	1	good	
 11016	bad Strong, Silent Type	3	decent	
-11017	aged ghostly spinning Mysterious Stranger	4	awesome	
+11017	aged spinning ghostly Mysterious Stranger	4	awesome	
 11018	artisanal watered-down skewed Champagne Shimmy	2	EPIC	
 11019	the Sot's parcel	0		
 11020	blurry brainy ceramic cestus of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
@@ -10890,7 +10890,7 @@
 11034	distilled jittery chiffon carbage	1		Last Available: "2023-12"
 11035	polymerized corrupted chiffon lemon	0		Effect: "Cold Hands", Effect Duration: 53
 11036	flavorless chocomotive	4	decent	Last Available: "2022-12"
-11037	adequate miniature ghostly freightcake	2	good	Last Available: "2022-12"
+11037	miniature adequate ghostly freightcake	2	good	Last Available: "2022-12"
 11038	smooth cabooze	4	awesome	Last Available: "2022-12"
 11039	blinking maroon plastic caboose	0		Last Available: "2022-12"
 11040	wobbly occult plastic passenger car	0		Spell Damage Percent: +25, Last Available: "2022-12"
@@ -10909,7 +10909,7 @@
 11053	improved blue Trainbot optics	0		Effect: "Cute Vision", Effect Duration: 62
 11054	chilled Trainbot servomotors	0		Effect: "Egg on your Face", Effect Duration: 22
 11055	frozen nitrogenated pulsating Trainbot linkages	0		Effect: "Berry Defensive", Effect Duration: 27
-11056	wobbly squat ping-pong paddle	0		Single Equip
+11056	squat wobbly ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	olive ghostly sage Trainbot harness	0		Mysticality Percent: +10
 11059	jittery ping-pong table	0		
@@ -10924,7 +10924,7 @@
 11068	lost elf luggage	0		
 11069	ghostly Trainbot luggage hook	0		Single Equip
 11070	flavorless big squat honey-drenched ham slice	5	decent	
-11071	triple-distilled artisanal mostly-empty bottle of cookie wine	10	EPIC	
+11071	artisanal triple-distilled mostly-empty bottle of cookie wine	10	EPIC	
 11072	bland upside-down Crimbo food scraps	3	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	spinning automatic wine thief	0		Single Equip
@@ -10937,8 +10937,8 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	artisanal irresponsibly strong blurry Crimbosmopolitan	6	EPIC	Last Available: "2022-12"
-11085	half-sized bland Crimbo dinner	2	decent	Last Available: "2022-12"
+11084	irresponsibly strong artisanal blurry Crimbosmopolitan	6	EPIC	Last Available: "2022-12"
+11085	bland half-sized Crimbo dinner	2	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	olive train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10956,7 +10956,7 @@
 11100	blurry packet of rock seeds	0		Last Available: "2023-01"
 11101	teal groveling gravel	0		Last Available: "2023-01"
 11102	vaporized ghostly fruity pebble	1		Last Available: "2023-01"
-11103	jittery yellow tumbling lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
+11103	jittery tumbling yellow lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	huge milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	teal molehill mountain	0		Last Available: "2023-01"
@@ -10968,7 +10968,7 @@
 11113	drinkable narrow pixel whiskey	3	good	
 11114	pixel rock	0		
 11115	shaking S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
-11116	blurry spinning S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
+11116	spinning blurry S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	dry glob of extra-green chlorophyll	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 35, Last Available: "2023-02"
 11118	ionized maroon mushroom	0		Effect: "Oxygenated Blood", Effect Duration: 31, Last Available: "2023-02"
 11119	boiled five-fingered fern resin	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 37, Last Available: "2023-02"
@@ -10986,12 +10986,12 @@
 11131	boiled modified pile of gritty sand	0		Effect: "Earthen Fist", Effect Duration: 33, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	pickled dry altered huge angry agate	0		Effect: "Nano-juiced", Effect Duration: 22, Last Available: "2023-02"
-11134	quadruple-polarized huge pulsating lump of loyal latite	0		Effect: "Impregnabili Tea", Effect Duration: 63, Last Available: "2023-02"
-11135	miniature stale bouncing skewed cyan shadow sausage	2	decent	Last Available: "2023-03"
+11134	quadruple-polarized pulsating huge lump of loyal latite	0		Effect: "Impregnabili Tea", Effect Duration: 63, Last Available: "2023-02"
+11135	stale miniature skewed bouncing cyan shadow sausage	2	decent	Last Available: "2023-03"
 11136	nasty shadow skin of the wise owl	0		Mysticality: +20, Stench Damage: +5, Last Available: "2023-03"
-11137	adjusted wet wobbly green shadow flame	0		Effect: "On Pins and Needles", Effect Duration: 37, Last Available: "2023-03"
-11138	moldy snack-sized spinning upside-down shadow bread	2	crappy	Last Available: "2023-03"
-11139	olive skewed shadow ice	0		Last Available: "2023-03"
+11137	adjusted wet green wobbly shadow flame	0		Effect: "On Pins and Needles", Effect Duration: 37, Last Available: "2023-03"
+11138	snack-sized moldy spinning upside-down shadow bread	2	crappy	Last Available: "2023-03"
+11139	skewed olive shadow ice	0		Last Available: "2023-03"
 11140	hand-crafted ghostly shadow fluid	3	EPIC	Last Available: "2023-03"
 11141	tumbling shadow glass	0		Last Available: "2023-03"
 11142	cyan shadow brick	0		Last Available: "2023-03"
@@ -11036,10 +11036,10 @@
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	big toothsome shadow hot dog	5	awesome	
 11183	fortified perfectly mixed shadow martini	5	EPIC	
-11184	dehydrated bouncing blue shadow pill	1		
+11184	dehydrated blue bouncing shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
-11187	spinning olive monkey glove	0		Free Pull, Last Available: "2023-04"
+11187	olive spinning monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	dry deionized shadow candy	0		Effect: "Aided and Abetted", Effect Duration: 27
 11189	replica Mr. Accessory	0		
 11190	jittery jittery replica Dark Jill-O-Lantern	0		
@@ -11091,7 +11091,7 @@
 11236	red replica unpowered Robortender	0		
 11237	replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
-11239	fuchsia pulsating mirror replica God Lobster Egg	0		
+11239	pulsating mirror fuchsia replica God Lobster Egg	0		
 11240	inspector's MacGyver's hale replica Fourth of May Cosplay Saber	0		Maximum HP: +20, Maximum MP: +100, Item Drop: +15, Conditional Skill (Equipped): "Use the Force"
 11241	resourceful grievous Sinatra's smooth replica Kramco Sausage-o-Matic&trade; of the detective	0		Moxie: +15, Experience (Moxie): +5, Weapon Damage Percent: +50, Maximum MP: +50, Item Drop: +20
 11242	reassuring fireproof double-paned flame-wreathed frosty Van der Graaf sinister extremely unsafe Fonzie's replica hewn moon-rune spoon of chilblains of mayonnaise	0		Experience (Moxie): +1, Weapon Damage Percent: +100, Spell Damage: +10, Cold Damage: +25, Cold Spell Damage: +10, Hot Spell Damage: +10, Sleaze Spell Damage: +50, Cold Resistance: +5, Hot Resistance: +3, Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
@@ -11117,7 +11117,7 @@
 11262	huge Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	narrow veiny Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	jittery Sherlock's smelly Amulet of Perpetual Darkness of the wise owl of the businessman	0		Mysticality: +20, Stench Spell Damage: +10, Item Drop: +25, Meat Drop: +50, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11168,14 +11168,14 @@
 11313	careful cat o' nine teeth of Tarzan	0		Experience (Muscle): +3, Monster Level: -10
 11314	ghostly sinister groovy tooth cap	0		Moxie Percent: +10, Spell Damage: +10
 11315	miser's lard-coated toothy trousers	0		Sleaze Spell Damage: +25, Meat Drop: +10
-11316	moldy immense banana split	9	crappy	
+11316	immense moldy banana split	9	crappy	
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	triple-distilled perfectly mixed huge bottle of Cabernet Sauvignon	8	EPIC	
 11321	Usain Bolt's dog trainer's baywatch of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +1, Initiative: +80, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	fuchsia Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	fuchsia Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	yellow Thwaitgold fairyfly statue	0		
@@ -11230,9 +11230,9 @@
 11375	Boltsmann ID badge	0		
 11376	green housekeeping automa-core	0		
 11377	maroon housekeeping robot	0		
-11378	low-calorie moldy pickled bread	1	crappy	Last Available: "2023-12"
-11379	jumbo bland salted mutton	5	decent	Last Available: "2023-12"
-11380	gigantic rotten corned beet	10	crappy	Last Available: "2023-12"
+11378	moldy low-calorie pickled bread	1	crappy	Last Available: "2023-12"
+11379	bland jumbo salted mutton	5	decent	Last Available: "2023-12"
+11380	rotten gigantic corned beet	10	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11274,7 +11274,7 @@
 11419	gravedigger's lion tamer's Elf Guard broom	0		Experience (familiar): +2, Spooky Damage: +10, Last Available: "2023-12"
 11420	Jeselnik's gravedigger's nasty Crimbuccaneer tavern swab	0		Stench Damage: +5, Spooky Damage: +10, Sleaze Damage: +25, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	artisanal weak old-school pirate grog	2	EPIC	Last Available: "2023-12"
+11422	weak artisanal old-school pirate grog	2	EPIC	Last Available: "2023-12"
 11423	flavorless huge grog nuts	3	decent	Last Available: "2023-12"
 11424	blue Sherlock's frosty baleful sawed-off blunderbuss	0		Spell Damage: +25, Cold Spell Damage: +10, Item Drop: +25, Last Available: "2023-12"
 11425	hand-crafted officer's nog	4	EPIC	Last Available: "2023-12"
@@ -11311,12 +11311,12 @@
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	spinning olive bouncing shellacked Elvish underarmor of Calamity Jane of extreme caution	0		Damage Reduction: 7, Critical Hit Percent: +15, Monster Level: -25, Single Equip, Last Available: "2023-12"
 11458	green supercool Crimbuccaneer bombjacket of the bloodbag	0		Moxie Percent: +20, Maximum HP: +100, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	bite-sized normal sugarplum ration	1	good	Last Available: "2023-12"
-11460	rotten jumbo gingerbread nylons	5	crappy	Last Available: "2023-12"
-11461	snack-sized normal maroon rum-soaked fruitcake	2	good	Last Available: "2023-12"
+11459	normal bite-sized sugarplum ration	1	good	Last Available: "2023-12"
+11460	jumbo rotten gingerbread nylons	5	crappy	Last Available: "2023-12"
+11461	normal snack-sized maroon rum-soaked fruitcake	2	good	Last Available: "2023-12"
 11462	immense decent lime	7	good	Last Available: "2023-12"
 11463	bland gingerbread pirate	4	decent	Last Available: "2023-12"
-11464	special normal fruit-stuffed rumcake	3	good	Effect: "Pecan Pied Piper", Effect Duration: 20, Last Available: "2023-12"
+11464	normal special fruit-stuffed rumcake	3	good	Effect: "Pecan Pied Piper", Effect Duration: 20, Last Available: "2023-12"
 11465	bad mulled wine	4	decent	Last Available: "2023-12"
 11466	drinkable Swedish coffee	4	good	Last Available: "2023-12"
 11467	tolerable canteen of eggnog	3	good	Last Available: "2023-12"
@@ -11327,8 +11327,8 @@
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	lousy yule grog	3	decent	Last Available: "2023-12"
-11475	moldy super-sized wet tack	5	crappy	Last Available: "2023-12"
-11476	spoiled small whalecake	2	crappy	Last Available: "2023-12"
+11475	super-sized moldy wet tack	5	crappy	Last Available: "2023-12"
+11476	small spoiled whalecake	2	crappy	Last Available: "2023-12"
 11477	bouncing MacGyver's forbidden gunwale whalegun of the sweet-tooth	0		Spell Damage Percent: +50, Maximum MP: +100, Candy Drop: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	watered-down hand-crafted and claret	2	super ultra mega EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
@@ -11345,7 +11345,7 @@
 11490	twirling Usain Bolt's therapeutic barnacle-encrusted sweater of Flo-Jo	0		Initiative: 180, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-12"
 11491	auspicious wicked Crimbuccaneer nose ring of the brazier	0		Spell Damage: +5, Hot Spell Damage: +25, Item Drop: +10, Last Available: "2023-12"
 11492	bouncing pet anchor	0		Last Available: "2023-12"
-11493	tumbling upside-down Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
+11493	upside-down tumbling Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	twirling Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
@@ -11354,7 +11354,7 @@
 11499	red Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11502	pickled alkaline spinning red military candy cane	0		Effect: "One Very Clear Eye", Effect Duration: 44
+11502	pickled alkaline red spinning military candy cane	0		Effect: "One Very Clear Eye", Effect Duration: 44
 11503	colloidal groggipop	0		Effect: "Deeply Ironic", Effect Duration: 65
 11504	skewed manspreader's moss mace of the cougar	0		Moxie: +20, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
 11505	bouncing upside-down padded brainy moss megaphone	0		Mysticality: +5, Damage Absorption: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
@@ -11367,10 +11367,10 @@
 11512	skewed adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	bouncing adobe abacus	0		Last Available: "2024-12"
-11515	shaking blinking adobe ayam	0		Last Available: "2024-12"
+11515	blinking shaking adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	skewed adobe abaya	0		Last Available: "2024-12"
-11518	powdered tumbling jittery adobe assortment	1		Effect: "Hella Tough", Effect Duration: 50, Last Available: "2024-12"
+11518	powdered jittery tumbling adobe assortment	1		Effect: "Hella Tough", Effect Duration: 50, Last Available: "2024-12"
 11519	modified frozen adobe brittle	0		Effect: "Always In Motion", Effect Duration: 18
 11520	up-at-dawn experienced beefy crepe paper phrygian cap	0		Muscle: +10, Experience: +2, Adventures: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	Jim Carey's arcane researcher's crepe paper parachute cape of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Monster Level: +25, Last Available: "2025-12"
@@ -11425,13 +11425,13 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	yellow boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	rotten jumbo squat yam	5	crappy	Last Available: "2024-05"
-11574	boozy hand-crafted yam martini	5	EPIC	Last Available: "2024-05"
+11573	jumbo rotten squat yam	5	crappy	Last Available: "2024-05"
+11574	hand-crafted boozy yam martini	5	EPIC	Last Available: "2024-05"
 11575	bad sweet potato o' mine	4	decent	Last Available: "2024-05"
 11576	watered-down drinkable Southern yam	2	good	Last Available: "2024-05"
 11577	artisanal lime green blinking sweet potato punch	3	EPIC	Last Available: "2024-05"
 11578	normal low-calorie Mayam spinach	1	good	Last Available: "2024-05"
-11579	tasty snack-sized yam and swiss	2	awesome	Last Available: "2024-05"
+11579	snack-sized tasty yam and swiss	2	awesome	Last Available: "2024-05"
 11580	aromatic Lo Pan's educational yam cannon	0		Experience: +1, Spell Critical Percent: +30, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-05"
 11581	mirror upside-down yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11440,7 +11440,7 @@
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	grievous Rosewater's yamtility belt of the sweet-tooth	0		Mysticality Percent: +30, Weapon Damage Percent: +50, Candy Drop: +100, Lasts Until Rollover, Last Available: "2024-05"
 11587	rotten yam slider	3	crappy	Last Available: "2024-05"
-11588	delicious big skewed yam mayo	5	awesome	Last Available: "2024-05"
+11588	big delicious skewed yam mayo	5	awesome	Last Available: "2024-05"
 11589	flavorless ghostly yam burrito	3	decent	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	twirling mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11455,7 +11455,7 @@
 11600	mini kiwi tipi	0		
 11601	decent mini kiwi digitized cookies	3	good	
 11602	drinkable mini kiwi intoxicating spirits	4	good	
-11603	moist corrupted bouncing cyan mini kiwi antimilitaristic hippy petition	0		Effect: "Headstrong", Effect Duration: 65
+11603	moist corrupted cyan bouncing mini kiwi antimilitaristic hippy petition	0		Effect: "Headstrong", Effect Duration: 65
 11604	chilled mirror mini kiwi illicit antibiotic	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 19
 11605	mini kiwi whipping stick of the cougar of the pedagogue	0		Moxie: +20, Experience: +3
 11606	hardy mini kiwi icepick	0		Maximum HP: +50
@@ -11471,7 +11471,7 @@
 11616	bouncing blurry flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	rotten snack-sized bacteria bisque	2	crappy	
-11619	snack-sized stale teal ciliophora chowder	2	decent	
+11619	stale snack-sized teal ciliophora chowder	2	decent	
 11620	thick delicious cream of chloroplasts	5	awesome	
 11621	yellow synaptic soup	0		
 11622	muscular soup	0		
@@ -11508,7 +11508,7 @@
 11653	head of emberg lettuce	0		Last Available: "2024-09"
 11654	fuchsia embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
-11656	spinning huge photo booth sized crate	0		Free Pull, Last Available: "2024-10"
+11656	huge spinning photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
 11658	family-friendly strapping bat wings of extreme caution	0		Muscle: +5, Monster Level: -25, Sleaze Resistance: +1, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
@@ -11530,11 +11530,11 @@
 11675	moldy gigantic peaza	10	crappy	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	pickled huge drenchrome 2.0	1		Last Available: "2025-12"
-11678	vaporized fuchsia mirror shaking Synapse Blaster	1		Last Available: "2025-12"
+11678	vaporized mirror fuchsia shaking Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	maroon quantum watch	0		Adventures: +2
 11681	shaking quantized familiar experience	0		
-11682	quadruple-dry extra-deionized skewed blinking pea brittle	0		Effect: "Sweet Tooth", Effect Duration: 62, Last Available: "2024-11"
+11682	quadruple-dry extra-deionized blinking skewed pea brittle	0		Effect: "Sweet Tooth", Effect Duration: 62, Last Available: "2024-11"
 11683	lousy distilled peasco	5	decent	Last Available: "2024-11"
 11684	normal piece of cake	3	good	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
@@ -11562,14 +11562,14 @@
 11707	gravedigger's curative silky pirate drawers	0		Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-12"
 11708	olive pulsating profane eye patch	0		Sleaze Damage: +3
 11709	boiled concentrated skewed pulsating peppermint pegleg	0		Effect: "Appeteyes", Effect Duration: 55, Last Available: "2024-12"
-11710	practically non-alcoholic bad hard cocoa	1	decent	Last Available: "2024-12"
+11710	bad practically non-alcoholic hard cocoa	1	decent	Last Available: "2024-12"
 11711	snack-sized rotten salmagumdi	2	crappy	Last Available: "2024-12"
 11712	olive lion tamer's plastic Easter Island Bunny	0		Experience (familiar): +2, Last Available: "2024-12"
 11713	upside-down mansplainer's plastic St. Patrick	0		Monster Level: +15, Last Available: "2024-12"
 11714	Tesla dance instructor's plastic Colonel Brando	0		Experience Percent (Moxie): +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12"
 11715	wholesome plastic Jedediah and Boiling Cloud	0		Maximum HP Percent: +10, Last Available: "2024-12"
 11716	frosty plastic &quot;Santa Claus&quot;	0		Cold Spell Damage: +10, Last Available: "2024-12"
-11717	mirror wobbly Spirit of Easter	0		Last Available: "2024-12"
+11717	wobbly mirror Spirit of Easter	0		Last Available: "2024-12"
 11718	Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	shaking Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	blurry Spirit of Thanksgiving	0		Last Available: "2024-12"
@@ -11578,10 +11578,10 @@
 11723	unsweetened dark chocolate egg	0		Effect: "Slimily Strong", Effect Duration: 42, Last Available: "2024-12"
 11724	special mediocre moai toai	4	decent	Effect: "You Read The Manual", Effect Duration: 20
 11725	medical-grade therapeutic moaiball of horror	0		Spooky Spell Damage: +25, HP Regen Min: 12, HP Regen Max: 17, Last Available: "2024-12"
-11726	tumbling upside-down half-digested rat	0		Last Available: "2024-12"
+11726	upside-down tumbling half-digested rat	0		Last Available: "2024-12"
 11727	electrified blinking four-leaf potato sprout	0		Effect: "Pie in the Sky", Effect Duration: 34, Last Available: "2024-12"
 11728	red jittery crafty deadly potato jacket of courage	0		Weapon Damage: +5, Maximum MP: +10, Spooky Resistance: +3, Last Available: "2024-12"
-11729	teal bouncing traumatic holiday memory	0		Last Available: "2024-12"
+11729	bouncing teal traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
 11731	twirling wicked Socratic military orb	0		Experience (Mysticality): +1, Spell Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	denatured flattened gray rum ball	0		Effect: "No Worries", Effect Duration: 67
@@ -11591,7 +11591,7 @@
 11736	careful stylish gravyskin skirt	0		Moxie: +25, Monster Level: -10, Last Available: "2024-12"
 11737	Jim Carey's gravyskin pants of extreme caution	0		Monster Level: 0, Last Available: "2024-12"
 11738	wet green crystallized pumpkin spice	0		Effect: "Oth-Jeal-O", Effect Duration: 40, Last Available: "2024-12"
-11739	huge adequate room scale bean casserole	7	good	Last Available: "2024-12"
+11739	adequate huge room scale bean casserole	7	good	Last Available: "2024-12"
 11740	teal fragile Christmas ornament	0		Last Available: "2024-12"
 11741	huge ragged wool yarn	0		Last Available: "2024-12"
 11742	skewed rosewater-soaked perfect Christmas scarf of wisdom of the blizzard	0		Mysticality: [+15*event(December)], Cold Spell Damage: [+25*event(December)], Stench Resistance: [+3*event(December)], Single Equip, Last Available: "2024-12"
@@ -11602,27 +11602,27 @@
 11747	practically non-alcoholic mediocre blurry Easter grasshopper	1	decent	Last Available: "2024-12"
 11748	triple-distilled acceptable Irish eggnog	10	good	Last Available: "2024-12"
 11749	drinkable weak red canteen of jungle juice	2	good	Last Available: "2024-12"
-11750	artisanal weak turchucken	2	EPIC	Last Available: "2024-12"
+11750	weak artisanal turchucken	2	EPIC	Last Available: "2024-12"
 11751	tolerable upside-down mechanically-mulled cider	3	good	Last Available: "2024-12"
 11752	delicious irresponsibly strong holiday trip around the world	6	awesome	Last Available: "2024-12"
-11753	snack-sized spoiled chocolate ostrich egg	2	crappy	Last Available: "2024-12"
+11753	spoiled snack-sized chocolate ostrich egg	2	crappy	Last Available: "2024-12"
 11754	jumbo spoiled beef and cabbage	5	crappy	Last Available: "2024-12"
 11755	stale candy rations	3	decent	Last Available: "2024-12"
 11756	half-sized stale blue double-candied yams	2	decent	Last Available: "2024-12"
 11757	small moldy Christmas ham	2	crappy	Last Available: "2024-12"
-11758	bland super-sized special wobbly huge holiday smorgasbord	5	decent	Effect: "Bloody Bloody Bloody!", Effect Duration: 25, Last Available: "2024-12"
+11758	bland special super-sized huge wobbly holiday smorgasbord	5	decent	Effect: "Bloody Bloody Bloody!", Effect Duration: 25, Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	wobbly double-paned bejazzled eyepatch	0		Cold Resistance: +5, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	tumbling Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	lime green Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	tumbling Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	lime green Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	Oprah's padded slick egg gun of Gandalf	0		Moxie: +10, Damage Absorption: +20, Maximum MP Percent: +50, Spell Critical Percent: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	shaking pulsating Sherlock's family-friendly Sinatra's thinker's army helmet	0		Mysticality: +10, Experience (Moxie): +5, Sleaze Resistance: +1, Item Drop: +25, Last Available: "2024-12"
@@ -11644,7 +11644,7 @@
 11789	0	0		Last Available: "2025-12"
 11790	vaporized eXpand	1		Effect: "World's Shortest Giant", Effect Duration: 35, Last Available: "2025-12"
 11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
-11792	bouncing narrow upside-down datastick	0		Last Available: "2025-12"
+11792	narrow bouncing upside-down datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	bouncing dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
@@ -11692,7 +11692,7 @@
 11837	tumbling toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
 11839	scrape	0		
-11840	teal jittery phantom digit	0		
+11840	jittery teal phantom digit	0		
 11841	cyan shaking foul line	0		
 11842	blinking dark manioc	0		
 11843	Observer source code	0		
@@ -11716,9 +11716,9 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	dried mirror scoop of pre-workout powder	1		Effect: "Tingly Elbows", Effect Duration: 10, Last Available: "2025-03"
 11863	jittery table tennis ball	0		Last Available: "2025-03"
-11864	extra-dry delicious maroon pint of Leprechaun Stout	5	awesome	Last Available: "2025-03"
-11865	powdered spinning tumbling phosphor traces	1		Last Available: "2025-03"
-11866	twirling squat crafting plans	0		Last Available: "2025-03"
+11864	delicious extra-dry maroon pint of Leprechaun Stout	5	awesome	Last Available: "2025-03"
+11865	powdered tumbling spinning phosphor traces	1		Last Available: "2025-03"
+11866	squat twirling crafting plans	0		Last Available: "2025-03"
 11867	skewed Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	spinning unironic knife	0		
@@ -11726,13 +11726,13 @@
 11871	pickled leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	spoiled Heck ramen	3	crappy	Last Available: "2025-03"
 11873	flavorless burrito	3	decent	Last Available: "2025-03"
-11874	stale diet gray small beer brat	1	decent	Last Available: "2025-03"
-11875	rotten diet peach pie	1	crappy	Last Available: "2025-03"
-11876	flavorless jumbo pulsating incredible mini-pizza	5	decent	Last Available: "2025-03"
+11874	diet stale gray small beer brat	1	decent	Last Available: "2025-03"
+11875	diet rotten peach pie	1	crappy	Last Available: "2025-03"
+11876	jumbo flavorless pulsating incredible mini-pizza	5	decent	Last Available: "2025-03"
 11877	mediocre Divine sidecar	3	decent	Last Available: "2025-03"
-11878	enchanted practically non-alcoholic smooth shaking tangarita sidecar	1	awesome	Effect: "Human-Hippy Hybrid", Effect Duration: 15, Last Available: "2025-03"
-11879	aged practically non-alcoholic huge gimlet sidecar	1	awesome	Last Available: "2025-03"
-11880	hand-crafted watered-down vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
+11878	practically non-alcoholic enchanted smooth shaking tangarita sidecar	1	awesome	Effect: "Human-Hippy Hybrid", Effect Duration: 15, Last Available: "2025-03"
+11879	practically non-alcoholic aged huge gimlet sidecar	1	awesome	Last Available: "2025-03"
+11880	watered-down hand-crafted vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
 11881	triple-distilled delicious prussian cathouse sidecar	9	awesome	Last Available: "2025-03"
 11882	acceptable Mon Tiki sidecar	3	good	Last Available: "2025-03"
 11883	skewed Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
@@ -11743,7 +11743,7 @@
 11888	lousy Three Sheets to the Wind	3	decent	Last Available: "2025-04"
 11889	bland pile of wet dates	4	decent	Last Available: "2025-04"
 11890	mirror papier Mach 1 airplane	0		Last Available: "2025-04"
-11891	pulsating yellow wet blanket	0		Last Available: "2025-04"
+11891	yellow pulsating wet blanket	0		Last Available: "2025-04"
 11892	Jack Frost's wet shower cap	0		Cold Spell Damage: +50, Last Available: "2025-04"
 11893	blurry clever wet shower shoes	0		Maximum MP: +20, Last Available: "2025-04"
 11894	tumbling friendly wet shower shorts	0		Familiar Weight: +3, Last Available: "2025-04"
@@ -11779,7 +11779,7 @@
 11924	clever baleful Axis helmet	0		Spell Damage: +25, Maximum MP: +20
 11925	smelly Axis fatigues of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10
 11926	stiffened Axis suspenders of vim and vigor	0		Damage Reduction: 1, Maximum HP Percent: +50, Single Equip
-11927	twirling upside-down maroon stolen artifact	0		
+11927	twirling maroon upside-down stolen artifact	0		
 11928	really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	chocolate rations	0		
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	half-sized rotten squat Skeleton Wars rations	2	crappy	
+11937	rotten half-sized squat Skeleton Wars rations	2	crappy	
 11938	enchanted drinkable skeleton war fuel can	3	good	Effect: "Smoky Third Eye", Effect Duration: 15
 11939	wobbly skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11806,21 +11806,21 @@
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	pickled spinning mixed berry jelly	1		Effect: "Salad Days", Effect Duration: 20, Last Available: "2025-08"
 11953	yummy toast with mixed berry jelly	4	awesome	Last Available: "2025-08"
-11954	bland diet blurry cup of sugar	1	decent	Last Available: "2025-08"
+11954	diet bland blurry cup of sugar	1	decent	Last Available: "2025-08"
 11955	toothsome Susie's cupcake	4	awesome	Last Available: "2025-08"
 11956	olive clock	0		Last Available: "2025-08"
 11957	Socratic smartaleck's the gun of wisdom	0		Mysticality: +15, Moxie Percent: +30, Experience (Mysticality): +1, Last Available: "2025-08"
 11958	special bad squat wine	4	decent	Effect: "Tapped In", Effect Duration: 25, Last Available: "2025-08"
-11960	spinning spinning lime green really, really nice swimming trunks	0		
+11960	spinning lime green spinning really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	undersea surveying goggles of the blizzard	0		Cold Spell Damage: +25, Lasts Until Rollover
 11963	watered-down acceptable Ocean-Touched Rum	2	good	
 11964	twisted huge water-logged pill	1		
-11965	spoiled tiny skewed kelp puck	1	crappy	
+11965	tiny spoiled skewed kelp puck	1	crappy	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	skewed scroll of sea smarm	0		
-11969	upside-down spinning waterlogged scroll of healing	0		
+11969	spinning upside-down waterlogged scroll of healing	0		
 11970	sea gel	0		
 11971	corrupted enhanced octopus ink bladder	0		Effect: "Hammertime", Effect Duration: 44
 11972	durable dolphin whistle	0		
@@ -11840,9 +11840,9 @@
 12050	huge small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	perfectly mixed mirror Smoking Pope	3	EPIC	
-12053	miniature bland prize turkey	2	decent	
+12053	bland miniature prize turkey	2	decent	
 12054	powdered twirling olive medicinal gruel	1		
-12055	rotten bite-sized shaking bouncing full-sized pumpkin pie	1	crappy	Last Available: "2025-11"
+12055	bite-sized rotten shaking bouncing full-sized pumpkin pie	1	crappy	Last Available: "2025-11"
 12056	perfectly mixed practically non-alcoholic vodka cranberry sauce	1	super ultra mega turbo EPIC	Last Available: "2025-11"
 12057	cold-filtered vacuum-sealed blinking yammed candy	0		Effect: "It's Soporiffic!", Effect Duration: 20, Last Available: "2025-11"
 12058	snack-sized adequate blinking treasure chestnut	2	good	Last Available: "2025-12"
@@ -11876,10 +11876,10 @@
 12118	twirling burnt radius	0		Last Available: "2025-12"
 12119	mirror burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
-12121	ghostly yellow Crymbocurrency	0		Last Available: "2025-12"
+12121	yellow ghostly Crymbocurrency	0		Last Available: "2025-12"
 12122	miser's extra-thick Crimbo sweater	0		Meat Drop: +10, Last Available: "2025-12"
 12123	huge The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	acceptable watered-down spinning Steve Abrams' Holiday Sampler Beer	2	good	Last Available: "2025-12"
+12124	watered-down acceptable spinning Steve Abrams' Holiday Sampler Beer	2	good	Last Available: "2025-12"
 12125	purple crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	mediocre practically non-alcoholic bottle of prize-winning rum	1	decent	Last Available: "2025-12"
 12127	scandalous Jim Carey's Santa-Slayer medal of mayonnaise	0		Monster Level: +25, Sleaze Damage: +5, Sleaze Spell Damage: +50, Single Equip, Last Available: "2025-12"
@@ -11910,7 +11910,7 @@
 12152	mirror family-friendly fortified scorched skeleton shirt	0		Damage Absorption: +60, Sleaze Resistance: +1, Last Available: "2025-12"
 12153	huge perfumed medical-grade scorched skeleton pants	0		Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12"
 12154	messenger parrot egg	0		Last Available: "2025-12"
-12155	squat olive buryable chest	0		Last Available: "2025-12"
+12155	olive squat buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	stale tumbling traditional gingerloaf	3	decent	Last Available: "2025-12"
 12172	tolerable Scotch and eggnog	4	good	Last Available: "2025-12"
 12173	altered aerosolized skewed counterskeleton elixir	0		Effect: "Carrion' On", Effect Duration: 12, Last Available: "2025-12"
-12174	lousy practically non-alcoholic &quot;salvaged&quot; wine	1	decent	Last Available: "2025-12"
+12174	practically non-alcoholic lousy &quot;salvaged&quot; wine	1	decent	Last Available: "2025-12"
 12175	blurry The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	pulsating crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	stale immense ghostly wedge of prize-winning cheese	8	decent	Last Available: "2025-12"
@@ -11939,7 +11939,7 @@
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	skewed loose Meats	0		
-12184	yellow upside-down Archaeologist's Spade	0		Last Available: "2026-03"
+12184	upside-down yellow Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	red dinosaur bone fragment	0		Last Available: "2026-03"
 12187	pulsating Pork Elf pottery shard	0		Last Available: "2026-03"
@@ -11949,7 +11949,7 @@
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	upside-down Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	vacuum-sealed Pork Elf mouthwash	0		Effect: "Serendipi Tea", Effect Duration: 38, Last Available: "2026-03"
-12194	dry maroon wobbly Pork Elf deodorant	0		Effect: "[800]Chocolate Reign", Effect Duration: 41, Last Available: "2026-03"
+12194	dry wobbly maroon Pork Elf deodorant	0		Effect: "[800]Chocolate Reign", Effect Duration: 41, Last Available: "2026-03"
 12195	nitrogenated blurry Pork Elf toothpaste	0		Effect: "Serenity", Effect Duration: 27, Last Available: "2026-03"
 12196	blurry bolt of fabric	0		Last Available: "2026-03"
 12197	Jeselnik's and dress of bravery	0		Sleaze Damage: +25, Spooky Resistance: +5, Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	huge Pork Elf sink	0		Last Available: "2026-03"
 12208	bouncing bouncing Pork Elf toilet	0		Last Available: "2026-03"
-12209	spoiled bite-sized rat pizza	1	crappy	Last Available: "2026-03"
+12209	bite-sized spoiled rat pizza	1	crappy	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	maroon sizzling lion tamer's Jim Carey's hoverboard	0		Monster Level: +25, Experience (familiar): +2, Hot Damage: +10, Single Equip, Last Available: "2026-03"
 12212	upside-down family-friendly resourceful left shark fin of Tarzan	0		Experience (Muscle): +3, Maximum MP: +50, Sleaze Resistance: +1, Last Available: "2026-03"
@@ -11972,8 +11972,8 @@
 12214	powdered candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	fancy stale miniature tumbling discarded hot dog	2	decent	Effect: "Bread Burps", Effect Duration: 20, Last Available: "2026-04"
-12218	hand-crafted watered-down pulsating most of a beer	2	EPIC	Last Available: "2026-04"
+12217	miniature fancy stale tumbling discarded hot dog	2	decent	Effect: "Bread Burps", Effect Duration: 20, Last Available: "2026-04"
+12218	watered-down hand-crafted pulsating most of a beer	2	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
@@ -11989,11 +11989,11 @@
 12235	bland half-sized Frutti di Scatoletta	2	decent	Last Available: "2026-05"
 12236	tasty pulsating Pesto alla Marziano	3	awesome	Last Available: "2026-05"
 12237	small bland olive Arrattabbattabiata	2	decent	Last Available: "2026-05"
-12238	bland snack-sized Orzo di Riso	2	decent	Last Available: "2026-05"
+12238	snack-sized bland Orzo di Riso	2	decent	Last Available: "2026-05"
 12239	stale Pasta Grimavera	3	decent	Last Available: "2026-05"
-12240	spoiled small Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
+12240	small spoiled Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
 12241	rotten Formica e Pepe	4	crappy	Last Available: "2026-05"
-12242	snack-sized bland Tubetto Gelatto	2	decent	Last Available: "2026-05"
+12242	bland snack-sized Tubetto Gelatto	2	decent	Last Available: "2026-05"
 12243	yummy jittery Gnocci Domani	3	awesome	Last Available: "2026-05"
 12244	yellow Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12005,10 +12005,10 @@
 12255	sword of doom	0		Spooky Spell Damage: +50
 12256	family-friendly staff	0		Sleaze Resistance: +1
 12257	greasy lute	0		Sleaze Spell Damage: +10
-12258	upside-down pulsating shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
+12258	pulsating upside-down shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	purple perfumed rosewater-soaked wholesome The Wizard's Android	0		Maximum HP Percent: +10, Stench Resistance: 8
-12261	blinking maroon flash paperwad	0		
+12261	maroon blinking flash paperwad	0		
 12262	twirling juggling ball	0		
 12263	teal flame-wreathed wizardly tactical jester's cap	0		Mysticality: +25, Hot Spell Damage: +10, Combat Item Damage Percent: 50
 12264	single-use sword	0		
@@ -12019,15 +12019,15 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	dog trainer's quilted Portable Laughing Stock of chilblains	0		Damage Absorption: +40, Experience (familiar): +1, Cold Damage: +25, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	reassuring veiny Staff of Anachronistic Churning of the sweet-tooth	0		Maximum HP: +10, Spooky Resistance: +1, Candy Drop: +100
-12272	decent super-sized yellow classic banana	5	good	Last Available: "2026-07"
-12273	moldy half-sized watermelon	2	crappy	Last Available: "2026-07"
+12272	super-sized decent yellow classic banana	5	good	Last Available: "2026-07"
+12273	half-sized moldy watermelon	2	crappy	Last Available: "2026-07"
 12274	jumbo flavorless quince	5	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	narrow Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	stale classic banana pie	4	decent	Last Available: "2026-07"
 12278	denatured essential banana decoction	0		Effect: "BOOsted", Effect Duration: 17, Last Available: "2026-07"
 12279	irradiated banana quintessence	0		Effect: "Aquarius Rising", Effect Duration: 20, Last Available: "2026-07"
-12280	fancy practically non-alcoholic artisanal Aesop Daiquiri	1	super EPIC	Effect: "Insatiable Hunger", Effect Duration: 20, Last Available: "2026-07"
+12280	artisanal practically non-alcoholic fancy Aesop Daiquiri	1	super EPIC	Effect: "Insatiable Hunger", Effect Duration: 20, Last Available: "2026-07"
 12281	delicious watered-down mirror Monkey Congress	2	awesome	Last Available: "2026-07"
 12282	flavorless watermelon pie	3	decent	Last Available: "2026-07"
 12283	nitrogenated moist blurry concentrated watermelon juice	0		Effect: "Moose Wisdom", Effect Duration: 60, Last Available: "2026-07"
@@ -12037,8 +12037,8 @@
 12287	super-sized adequate wobbly ghostly quince pie	5	good	Last Available: "2026-07"
 12288	corrupted warmed quince quaff	0		Effect: "Slime Time", Effect Duration: 16, Last Available: "2026-07"
 12289	boiled fuchsia Quickquince	0		Effect: "Army of One", Effect Duration: 63, Last Available: "2026-07"
-12290	practically non-alcoholic artisanal jittery fuchsia Quiskey Sour	1	super EPIC	Last Available: "2026-07"
-12291	practically non-alcoholic tolerable Quincea&ntilde;era Cooler	1	good	Last Available: "2026-07"
+12290	artisanal practically non-alcoholic fuchsia jittery Quiskey Sour	1	super EPIC	Last Available: "2026-07"
+12291	tolerable practically non-alcoholic Quincea&ntilde;era Cooler	1	good	Last Available: "2026-07"
 12292	lousy Roth IPA	3	decent	Last Available: "2026-08"
 12293	brainy underdraft protection of terror	0		Mysticality: +5, Spooky Spell Damage: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
@@ -12057,7 +12057,7 @@
 12307	enhanced mint	0		Effect: "Hot Blooded", Effect Duration: 16, Last Available: "2026-08"
 12308	huge savings bondo	0		Last Available: "2026-08"
 12309	fuchsia homeowner's loam	0		Last Available: "2026-08"
-12310	compressed pulsating upside-down toxic asset	1		Effect: "Appeteyes", Effect Duration: 5, Last Available: "2026-08"
+12310	compressed upside-down pulsating toxic asset	1		Effect: "Appeteyes", Effect Duration: 5, Last Available: "2026-08"
 12311	diluted intangible asset	1		Last Available: "2026-08"
 12312	distilled pulsating twirling liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Accordion_Thief_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Blender_cafe_booze.txt
@@ -1,6 +1,6 @@
 -1	hand-crafted Petite Porter	3	EPIC	
 -2	lousy Scrawny Stout	3	decent	
--3	tolerable watered-down maroon spinning Infinitesimal IPA	2	good	
+-3	watered-down tolerable spinning maroon Infinitesimal IPA	2	good	
 -4	lousy narrow eggnogtini	4	decent	
 -5	tolerable candycaine	4	good	
 -6	perfectly mixed braincracker sweet	3	EPIC	
@@ -9,25 +9,25 @@
 -18	smooth gin	3	awesome	
 -19	bad jittery ecto-nog	3	decent	
 -20	drinkable hot toady	3	good	
--21	watered-down artisanal fancy hot choculate	2	EPIC	
--49	weak lousy Cyder	2	decent	
--50	lousy irresponsibly strong enchanted Oil Nog	10	decent	
--51	practically non-alcoholic bad Hi-Octane Peppermint Jet Fuel	1	decent	
+-21	watered-down fancy artisanal hot choculate	2	EPIC	
+-49	lousy weak Cyder	2	decent	
+-50	lousy enchanted irresponsibly strong Oil Nog	10	decent	
+-51	bad practically non-alcoholic Hi-Octane Peppermint Jet Fuel	1	decent	
 -58	distilled fancy smooth mirror Grimacider	5	awesome	
 -59	mediocre Isotope Nog	4	decent	
--60	perfectly mixed practically non-alcoholic Mutagin 'n' Tonic	1	EPIC	
--70	weak bad olive Gin and Herring	2	decent	
--71	special drinkable spirit-forward tumbling ghostly Black and Tan and Red All Over	5	good	
--72	mediocre watered-down narrow Antarctic Ice Tea	2	decent	
--76	weak bad lime green CRIMBCO Ribbon Candy Schnapps	2	decent	
--77	distilled lousy special wobbly CRIMBCO Egg Substitute Nog Substitute	5	decent	
--78	fancy weak smooth maroon CRIMBCO Extreme Braincracker Sour	2	awesome	
+-60	practically non-alcoholic perfectly mixed Mutagin 'n' Tonic	1	EPIC	
+-70	bad weak olive Gin and Herring	2	decent	
+-71	drinkable special spirit-forward ghostly tumbling Black and Tan and Red All Over	5	good	
+-72	watered-down mediocre narrow Antarctic Ice Tea	2	decent	
+-76	bad weak lime green CRIMBCO Ribbon Candy Schnapps	2	decent	
+-77	lousy distilled special wobbly CRIMBCO Egg Substitute Nog Substitute	5	decent	
+-78	weak fancy smooth maroon CRIMBCO Extreme Braincracker Sour	2	awesome	
 -82	aged practically non-alcoholic Horseradish-infused Vodka	1	awesome	
 -83	artisanal irresponsibly strong huge Jerkitini	6	EPIC	
--84	watered-down lousy Desert Island Iced Tea	2	decent	
+-84	lousy watered-down Desert Island Iced Tea	2	decent	
 -88	bad teal Crimbo Saketini	4	decent	
 -89	perfectly mixed blurry Crimboku Drop	4	EPIC	
 -90	hand-crafted Flaming Crimbo Log	4	EPIC	
 -107	drinkable Fortified Eggnog Slurry	3	good	
 -108	hand-crafted fuchsia Hot Buttered Rum	3	EPIC	
--109	fancy acceptable Spicy Hot Chocolate	3	good	
+-109	acceptable fancy Spicy Hot Chocolate	3	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Blender_cafe_food.txt
@@ -1,27 +1,27 @@
 -1	normal Peche a la Frog	3	good	
 -2	spoiled As Jus Gezund Heit	3	crappy	
 -3	half-sized flavorless spinning maroon Bouillabaise Coucher Avec Moi	2	decent	
--7	adequate gigantic fancy gumdrop chow mein	6	good	
+-7	fancy adequate gigantic gumdrop chow mein	6	good	
 -8	tasty huge candy cane pizza	3	awesome	
 -9	rotten half-sized blue gingerbread stir-fry	2	crappy	
--10	spoiled super-sized twigs and gravel	5	crappy	
+-10	super-sized spoiled twigs and gravel	5	crappy	
 -11	toothsome shoots and leaves	4	awesome	
--12	rotten diet bowl of unidentifiable goo	1	crappy	
+-12	diet rotten bowl of unidentifiable goo	1	crappy	
 -13	half-sized moldy spinning fuchsia gingerbread massacre	2	crappy	
--14	decent massive It Came From Beyond Dessert	9	good	
--15	moldy snack-sized vampire cake	2	crappy	
+-14	massive decent It Came From Beyond Dessert	9	good	
+-15	snack-sized moldy vampire cake	2	crappy	
 -52	bland Soylent Red and Green	3	decent	
 -53	bland Disc-Shaped Nutrition Unit	4	decent	
 -54	bland half-sized Gingerborg Hive	2	decent	
--61	snack-sized stale Candy Cane Surprise	2	decent	
+-61	stale snack-sized Candy Cane Surprise	2	decent	
 -62	miniature toothsome Grimdrop Chow Mein	2	awesome	
 -63	yummy squat squat Grimgerbread House	3	awesome	
--67	special half-sized stale Caviar Carbonara	2	decent	
--68	thick bland Halibut Alfredo	5	decent	
--69	moldy tumbling spinning blue Red Herring Velvet Cake	4	crappy	
+-67	special stale half-sized Caviar Carbonara	2	decent	
+-68	bland thick Halibut Alfredo	5	decent	
+-69	moldy spinning blue tumbling Red Herring Velvet Cake	4	crappy	
 -73	decent CRIMBCO Reconstituted Gruel	4	good	
 -74	bland New and Improved CRIMBCO Reconstituted Gruel	3	decent	
--75	half-sized fancy rotten CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	crappy	
+-75	rotten half-sized fancy CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	crappy	
 -79	super-sized moldy blinking Brussels Sprout Stir-Fry	5	crappy	
 -80	decent Carrot, Cabbage, and Kale Pizza	4	good	
 -81	spoiled Turnip and Rutabaga Pie	4	crappy	
@@ -31,13 +31,13 @@
 -92	yummy huge wobbly basic hot dog	6	awesome	
 -93	flavorless diet blurry savage macho dog	1	decent	
 -94	decent one with everything	3	good	
--95	normal half-sized squat blinking lime green sly dog	2	good	
--96	stale diet devil dog	1	decent	
+-95	normal half-sized lime green blinking squat sly dog	2	good	
+-96	diet stale devil dog	1	decent	
 -97	stale chilly dog	4	decent	
 -98	jumbo decent ghost dog	5	good	
 -99	rotten upside-down junkyard dog	3	crappy	
 -100	jumbo adequate wet dog	5	good	
--101	bite-sized normal sleeping dog	1	good	
+-101	normal bite-sized sleeping dog	1	good	
 -102	delicious small optimal dog	2	awesome	
 -103	flavorless video games hot dog	4	decent	
 -104	adequate snack-sized squat Peppermint Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Marmot.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Marmot.txt
@@ -24,9 +24,9 @@
 25	narrow meat paste	0		
 26	Dolphin King's map	0		
 27	lime green skewed spider web	0		
-28	narrow pulsating really spider web	0		
+28	pulsating narrow really spider web	0		
 29	really really spider web	0		
-30	lime green mirror rock	0		
+30	mirror lime green rock	0		
 31	wobbly seal-toothed rock	0		
 32	wholesome Bjorn's Hammer	0		Maximum HP Percent: +10, Class: "Seal Clubber"
 33	snorkel	0		Familiar Effect: "atk, cap 2"
@@ -35,17 +35,17 @@
 36	bouncing huge nasty Knob Goblin tongs	0		Stench Damage: +5
 37	smartaleck's viking helmet	0		Moxie Percent: +30, Familiar Effect: "atk, cap 5"
 38	Oprah's Knob Goblin pants	0		Maximum MP Percent: +50, Familiar Effect: "atk, 5xPotato, cap 6"
-39	lime green jittery pretty flower	0		
+39	jittery lime green pretty flower	0		
 40	squat casino pass	0		
-41	drinkable special practically non-alcoholic ice-cold Sir Schlitz	1	good	Effect: "Shoesauce", Effect Duration: 10
+41	practically non-alcoholic special drinkable ice-cold Sir Schlitz	1	good	Effect: "Shoesauce", Effect Duration: 10
 42	hermit permit	0		
 43	olive worthless trinket	0		
 44	lime green mirror worthless gewgaw	0		
 45	squat worthless knick-knack	0		
 46	figurine	0		
 47	decent tumbling hot buttered roll	4	good	
-48	red wobbly heart of rock and roll	0		
-49	massive adequate bowl of cottage cheese	7	good	
+48	wobbly red heart of rock and roll	0		
+49	adequate massive bowl of cottage cheese	7	good	
 50	teal twirling Rock and Roll Legend of doom	0		Spooky Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10
 51	blurry Knob Goblin Uberpants	0		Item Drop: +5, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	mirror banjo strings	0		
@@ -57,7 +57,7 @@
 58	ghostly stone turtle	0		
 59	slingshot	0		
 60	Mace of the Tortoise of the glutton	0		Food Drop: +100, Class: "Turtle Tamer"
-61	stale enchanted green fortune cookie	3	decent	Effect: "Mercenary", Effect Duration: 10
+61	enchanted stale green fortune cookie	3	decent	Effect: "Mercenary", Effect Duration: 10
 62	jittery sage oriole-feather headdress	0		Mysticality Percent: +10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	mirror action figure head	0		
@@ -77,7 +77,7 @@
 78	greedy pretty bouquet	0		Meat Drop: +20
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	narrow fairy gravy boat	0		
-81	extra-dry lousy ice-cold Willer	5	decent	
+81	lousy extra-dry ice-cold Willer	5	decent	
 82	blinking ring	0		
 83	shaft	0		
 84	bouncing mirror Orcish meat locker	0		
@@ -167,7 +167,7 @@
 168	blinking gravedigger's bone rattle	0		Spooky Damage: +10
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	spoiled half-sized lihc eye pie	2	crappy	
+171	half-sized spoiled lihc eye pie	2	crappy	
 172	jittery upside-down gnoll lips	0		
 173	purple taco shell	0		
 174	ghostly Gnollish casserole dish	0		
@@ -183,9 +183,9 @@
 184	blinking briefcase	0		
 185	teal fat stacks of cash	0		
 186	bean	0		
-187	skewed shaking loose teeth	0		
+187	shaking skewed loose teeth	0		
 188	bouncing bat guano	0		
-189	ghostly red guano coffee cup	0		
+189	red ghostly guano coffee cup	0		
 191	perfumed batskin belt	0		Stench Resistance: +5
 192	twirling batskin belt	0		
 193	birthday candle	0		
@@ -197,7 +197,7 @@
 199	ring of the cheetah	0		Initiative: +60
 200	small delicious rat appendix kabob	2	awesome	
 201	delicious pulsating bat wing kabob	3	awesome	
-202	gigantic bland carob chunks	9	decent	
+202	bland gigantic carob chunks	9	decent	
 203	herbs	0		
 204	normal carob chunk cookies	4	good	
 205	secret blend of herbs and spices	0		
@@ -211,7 +211,7 @@
 213	Lo Pan's clever filthy corduroys	0		Maximum MP: +20, Spell Critical Percent: +30, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	lime green tumbling jittery filthy knitted dread sack of the empath	0		Familiar Weight: +5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	enchanted adequate narrow carob brownies	4	good	Effect: "Human-Fish Hybrid", Effect Duration: 15
+216	adequate enchanted narrow carob brownies	4	good	Effect: "Human-Fish Hybrid", Effect Duration: 15
 217	bland lime green herb brownies	3	decent	
 218	hemp string	0		
 219	necklace chain	0		
@@ -229,36 +229,36 @@
 231	skewed Doc Galaktik's Pungent Unguent	0		
 232	Doc Galaktik's Ailment Ointment	0		
 233	Doc Galaktik's Restorative Balm	0		
-234	gray huge Doc Galaktik's Homeopathic Elixir	0		
+234	huge gray Doc Galaktik's Homeopathic Elixir	0		
 235	blinking Oprah's weightlifter's Bigger Bugfinder Blade	0		Muscle: +15, Maximum MP Percent: +50
 236	Queue Du Coq cocktailcrafting kit	0		
 237	acceptable practically non-alcoholic bottle of gin	1	good	
-238	mediocre watered-down bottle of vodka	2	decent	
+238	watered-down mediocre bottle of vodka	2	decent	
 239	slick Orcish baseball cap of Calamity Jane	0		Moxie: +10, Critical Hit Percent: +15, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	zippy Orcish cargo shorts of vim and vigor	0		Maximum HP Percent: +50, Initiative: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Orcish frat-paddle of Leguizamo	0		Monster Level: +20
 242	decent	3	good	
-243	miniature delicious fancy grapefruit	2	awesome	Effect: "Pretending to Pretend", Effect Duration: 30
+243	fancy miniature delicious grapefruit	2	awesome	Effect: "Pretending to Pretend", Effect Duration: 30
 244	miniature adequate grapes	2	good	
 245	rotten olive	4	crappy	
 246	tasty tomato	3	awesome	
 247	fermenting powder	0		
-248	bad spirit-forward fancy salty dog	5	decent	Effect: "Smoky Third Eye", Effect Duration: 5
-249	tolerable watered-down fancy bloody mary	2	good	Effect: "Chari Tea", Effect Duration: 35
+248	fancy spirit-forward bad salty dog	5	decent	Effect: "Smoky Third Eye", Effect Duration: 5
+249	fancy watered-down tolerable bloody mary	2	good	Effect: "Chari Tea", Effect Duration: 35
 250	drinkable screwdriver	3	good	
 251	weak tolerable martini	2	good	
 252	weak aged bloody beer	2	awesome	
 253	artisanal mirror shot of schnapps	4	EPIC	
-254	mediocre watered-down special blinking shot of grapefruit schnapps	2	decent	Effect: "Dirty Pear", Effect Duration: 10
+254	special mediocre watered-down blinking shot of grapefruit schnapps	2	decent	Effect: "Dirty Pear", Effect Duration: 10
 255	delicious strong fine wine	5	awesome	
 256	lousy triple-distilled shot of tomato schnapps	9	decent	
 257	practically non-alcoholic acceptable extra-spicy bloody mary	1	good	
 258	blinking dense meat stack	0		
 259	snake skin	0		
-260	huge toothsome gray White Citadel fries	6	awesome	
-261	big bland White Citadel burger	5	decent	
+260	toothsome huge gray White Citadel fries	6	awesome	
+261	bland big White Citadel burger	5	decent	
 262	normal piece of wedding cake	4	good	
-263	half-sized bland chocolate chips	2	decent	
+263	bland half-sized chocolate chips	2	decent	
 264	stale chocolate chip cookies	4	decent	
 265	squat cyan wool satin pants	0		Cold Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
 266	delicious weak purple lightning	2	awesome	
@@ -272,7 +272,7 @@
 274	shaking Familiar-Gro&trade; Terrarium	0		
 275	twirling mosquito larva	0		
 276	leprechaun hatchling	0		
-277	boiled squat maroon blurry extra-strength strongness elixir	1		
+277	boiled maroon squat blurry extra-strength strongness elixir	1		
 278	compressed twirling jug-o-magicalness	1		
 279	pickled suntan lotion of moxiousness	1		
 280	shaking Pick-O-Matic lockpicks	0		
@@ -292,7 +292,7 @@
 294	auspicious pail	0		Item Drop: +10, Familiar Effect: "2xFairy, cap 7"
 295	foul-smelling demonskin trousers	0		Stench Damage: +10, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	gray weightlifter's dungeoneer's dungarees	0		Muscle: +15, Familiar Effect: "stench atk, 4xPotato, cap 7"
-297	flattened concentrated blinking ghostly tamarind-flavored chewing gum	0		Effect: "Yes, Can Haz", Effect Duration: 13
+297	flattened concentrated ghostly blinking tamarind-flavored chewing gum	0		Effect: "Yes, Can Haz", Effect Duration: 13
 298	flattened oxidized upside-down lime-and-chile-flavored chewing gum	0		Effect: "Turtle Titters", Effect Duration: 41
 299	non-denatured pickle-flavored chewing gum	0		Effect: "Nothing Is Impossible", Effect Duration: 13
 300	non-boiled jaba&ntilde;ero-flavored chewing gum	0		Effect: "Good Karma", Effect Duration: 26
@@ -311,22 +311,22 @@
 313	teal Lo Pan's Crown of the Goblin King	0		Spell Critical Percent: +30, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	moldy bean burrito	4	crappy	
 315	rotten bouncing upside-down bean burrito	3	crappy	
-316	tiny stale insanely bean burrito	1	decent	
+316	stale tiny insanely bean burrito	1	decent	
 317	stale enchanted bean burrito	3	decent	Effect: "La Bamba", Effect Duration: 30
 318	moldy bean burrito	3	crappy	
 319	big moldy insanely bean burrito	5	crappy	
 320	spoiled pulsating bat haggis	3	crappy	
-321	small spoiled menudo	2	crappy	
+321	spoiled small menudo	2	crappy	
 322	spoiled goat cheese	3	crappy	
-323	bland bite-sized special pulsating plain pizza	1	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 20
-324	low-calorie toothsome maroon sausage pizza	1	awesome	
+323	bite-sized special bland pulsating plain pizza	1	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 20
+324	toothsome low-calorie maroon sausage pizza	1	awesome	
 325	stale thick goat cheese pizza	5	decent	
 326	bland mushroom pizza	3	decent	
 327	goat	0		
 328	tolerable bottle of whiskey	4	good	
 329	gravedigger's goat beard	0		Spooky Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	jittery glass of goat's milk	1	good	
-331	watered-down lousy huge Canadian	2	decent	
+331	lousy watered-down huge Canadian	2	decent	
 332	rotten lemon	4	crappy	
 333	spoiled shaking lime	4	crappy	
 334	wool sabre teeth	0		Cold Resistance: +1
@@ -348,13 +348,13 @@
 350	mirror hot katana blade	0		
 351	jittery horrifying frosty icy-hot katana	0		Cold Spell Damage: +10, Spooky Damage: +25
 352	huge extremely unsafe ninja hot pants	0		Weapon Damage Percent: +100, Familiar Effect: "hot atk, 3xPotato, cap 17"
-353	squat green ninja stars	0		
+353	green squat ninja stars	0		
 354	tumbling arcane researcher's beefy nunchaku	0		Muscle: +10, Experience Percent (Mysticality): +10
 355	Van der Graaf eXtreme scarf	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	medical-grade snowboarder pants	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	normal fancy half-sized gr8ps	2	good	Effect: "Virgo Rising", Effect Duration: 50
-359	spoiled bite-sized t8r tots	1	crappy	
+359	bite-sized spoiled t8r tots	1	crappy	
 360	lime green miner's helmet of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	purple mansplainer's miner's pants	0		Monster Level: +15, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	narrow twirling lard-coated 7-Foot Dwarven mattock	0		Sleaze Spell Damage: +25
@@ -364,7 +364,7 @@
 366	blinking linoleum sword hilt	0		
 367	wobbly linoleum stick	0		
 368	lime green linoleum crossbow string	0		
-369	wobbly upside-down asbestos sword hilt	0		
+369	upside-down wobbly asbestos sword hilt	0		
 370	narrow asbestos stick	0		
 371	upside-down asbestos crossbow string	0		
 372	chrome sword hilt	0		
@@ -401,7 +401,7 @@
 403	mansplainer's shoulder parrot	0		Monster Level: +15
 404	forbidden acoustic guitarrr	0		Spell Damage Percent: +50
 405	sunken chest	0		
-406	blurry red pirate pelvis	0		
+406	red blurry pirate pelvis	0		
 407	pirate skull	0		
 408	tumbling pirate skeleton	0		
 409	gray vial of patchouli oil	0		
@@ -428,7 +428,7 @@
 430	acid-squirting flower	0		Single Equip
 431	Sherlock's clown shoes	0		Item Drop: +25, Clowniness: 25
 432	bouncing mirror studded bloody clown pants	0		Damage Absorption: +80, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
-433	red spinning shaking skinny balloon	0		
+433	shaking red spinning skinny balloon	0		
 434	wobbly veiny balloon helmet	0		Maximum HP: +10, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	ghostly blue knitted balloon sword of the early riser	0		Cold Resistance: +3, Adventures: +7, Clowniness: 50
 436	balloon monkey	0		
@@ -465,7 +465,7 @@
 467	adequate pixel pie	3	good	
 468	ruby W	0		
 469	wussiness potion	0		
-470	practically non-alcoholic delicious huge twirling Imp Ale	1	awesome	
+470	practically non-alcoholic delicious twirling huge Imp Ale	1	awesome	
 471	yummy massive spinning hot wing	9	awesome	
 472	diamond-studded cane of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Disco Bandit"
 473	frosty crutch	0		Cold Spell Damage: +10
@@ -501,7 +501,7 @@
 503	adequate small skewered cat appendix	2	good	
 504	green evil arches	0		
 505	Usain Bolt's smooth gnatwing earring	0		Moxie: +15, Initiative: +80
-506	huge tasty tumbling bouncing Hell broth	10	awesome	
+506	huge tasty bouncing tumbling Hell broth	10	awesome	
 507	padded thunderrr guitarrr	0		Damage Absorption: +20
 508	sonata	0		
 509	Hey Deze nuts	0		
@@ -510,7 +510,7 @@
 512	jittery Sneaky Pete's key lime	0		
 513	flavorless Boris's key lime pie	4	decent	
 514	yummy Jarlsberg's key lime pie	3	awesome	
-515	rotten fancy jittery skewed Sneaky Pete's key lime pie	4	crappy	Effect: "Bone Chilling", Effect Duration: 5
+515	fancy rotten skewed jittery Sneaky Pete's key lime pie	4	crappy	Effect: "Bone Chilling", Effect Duration: 5
 516	blinking Hey Deze map	0		
 517	upside-down groovy bejeweled accordion strap	0		Moxie Percent: +10, Class: "Accordion Thief"
 518	huge mystery juice	0		
@@ -519,7 +519,7 @@
 521	narrow kickback cookbook of Calamity Jane	0		Critical Hit Percent: +15
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	perfectly mixed weak blinking papaya sling	2	EPIC	
+524	weak perfectly mixed blinking papaya sling	2	EPIC	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -532,7 +532,7 @@
 534	abridged dictionary	0		
 535	bridge	0		
 536	dictionary	0		
-537	wobbly shaking pr0n legs	0		
+537	shaking wobbly pr0n legs	0		
 538	shaking clever f3d0r4	0		Maximum MP: +20, Familiar Effect: "atk, 1xLep, cap 27"
 539	lowercase N	0		
 540	nitrogenated Tasty Fun Good rice candy	0		Effect: "Chilblains of the Corn", Effect Duration: 62
@@ -549,13 +549,13 @@
 551	64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	immense spoiled pulsating pr0n cocktail	8	crappy	
+554	spoiled immense pulsating pr0n cocktail	8	crappy	
 555	Lo Pan's wizardly drywall axe	0		Mysticality: +25, Spell Critical Percent: +30
 556	Pine-Fresh air freshener of incineration	0		Hot Spell Damage: +50
 557	perfectly mixed twirling whiskey and cola	4	EPIC	
 558	normal fuchsia papaya taco	3	good	
 559	lime green razor-sharp can lid	0		
-560	miniature moldy stalk of asparagus	2	crappy	
+560	moldy miniature stalk of asparagus	2	crappy	
 561	green pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -565,26 +565,26 @@
 567	hermit script	0		
 568	moldy yellow Double Bacon Beelzeburger	3	crappy	
 569	miniature normal Lord of the Flies-sized fries	2	good	
-570	decent gigantic pulsating Chicken Sandwich	6	good	
+570	gigantic decent pulsating Chicken Sandwich	6	good	
 571	fancy huge Jumbo Dr. Lucifer	1	good	Effect: "Yeah, It's Just Gasoline", Effect Duration: 25
-572	immense yummy bouncing Children's Meal of the Damned	9	awesome	
+572	yummy immense bouncing Children's Meal of the Damned	9	awesome	
 573	tasty noodles	3	awesome	
-574	gigantic delicious mirror noodles	6	awesome	
-575	fancy normal painful penne pasta	3	good	Effect: "Ponderous Potency", Effect Duration: 25
-576	adequate tiny ravioli della hippy	1	good	
+574	delicious gigantic mirror noodles	6	awesome	
+575	normal fancy painful penne pasta	3	good	Effect: "Ponderous Potency", Effect Duration: 25
+576	tiny adequate ravioli della hippy	1	good	
 577	immense stale pr0n m4nic0tti	7	decent	
 578	adequate jumbo red Hell ramen	5	good	
 579	diet rotten special boring spaghetti	1	crappy	Effect: "Booooooze", Effect Duration: 5
 580	huge sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	enchanted diet stale fettucini Inconnu	1	decent	Effect: "Cringle's Curative Carol", Effect Duration: 10
+583	enchanted stale diet fettucini Inconnu	1	decent	Effect: "Cringle's Curative Carol", Effect Duration: 10
 584	delicious spaghetti with Skullheads	3	awesome	
 585	low-calorie decent teal gnocchetti di Nietzsche	1	good	
 586	rock-hard ridiculously huge sword of the cheetah	0		Damage Reduction: 5, Initiative: +60
 587	unsweetened dry blurry super-spiky hair gel	0		Effect: "Vitamin-Maxed", Effect Duration: 25
 588	wobbly bouncing soft echo eyedrop antidote	0		
-589	stale miniature cocoa eggshell fragment	2	decent	
+589	miniature stale cocoa eggshell fragment	2	decent	
 590	huge toothsome bouncing cocoa eggshell fragment	8	awesome	
 591	maroon cocoa egg	0		
 592	house	0		
@@ -610,13 +610,13 @@
 612	twirling original G	0		
 613	skewed plot hole	0		
 614	wet shaking probability potion	0		Effect: "Human-Hippy Hybrid", Effect Duration: 38
-615	jittery skewed chaos butterfly	0		
-616	blinking bouncing furry fur	0		
+615	skewed jittery chaos butterfly	0		
+616	bouncing blinking furry fur	0		
 617	alkaline tarnished twirling Angry Farmer candy	0		Effect: "Ancient Protected", Effect Duration: 35
 618	electrified adjusted purple Mick's IcyVapoHotness Rub	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 44
 619	needle of dire peril	0		Weapon Damage: +20
 620	unsweetened improved diffused gray thin candle	0		Effect: "Riboflavin'", Effect Duration: 15
-621	skewed purple Warm Subject gift certificate	0		
+621	purple skewed Warm Subject gift certificate	0		
 622	awful poetry journal	0		
 623	WA	0		
 624	NG	0		
@@ -641,11 +641,11 @@
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	mirror wrapping paper	0		Last Available: "2003-12"
-646	toothsome snack-sized pulsating fruitcake	2	awesome	
+646	snack-sized toothsome pulsating fruitcake	2	awesome	
 647	present	0		Last Available: "2004-11"
 648	perfumed Crimbo sword	0		Stench Resistance: +5, Last Available: "2004-10"
-649	bouncing educational Crimbo hat	0		Experience: +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	Crimbo pants of the glutton	0		Food Drop: +100, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	bouncing educational Crimbo hat	0		Experience: +1, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	Crimbo pants of the glutton	0		Food Drop: +100, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	exclusive ultra-rare item of the ox	0		Muscle: +20
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -667,18 +667,18 @@
 669	stale huge ghuol guolash	3	decent	
 670	Jack Frost's lihc face	0		Cold Spell Damage: +50, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	sinister grave robbing shovel of incineration	0		Spell Damage: +10, Hot Spell Damage: +50
-672	rotten snack-sized cranberries	2	crappy	
-673	drinkable extra-dry pulsating vodka and cranberry	5	good	
+672	snack-sized rotten cranberries	2	crappy	
+673	extra-dry drinkable pulsating vodka and cranberry	5	good	
 674	aged whiskey	3	awesome	
 675	skull of the Bonerdagon of the scaredy-cat	0		Monster Level: -15
 676	squat dragonbone belt buckle	0		
 677	chaotic badass belt	0		Spell Critical Percent: +10
 678	chest of the Bonerdagon	0		
 679	bad practically non-alcoholic roll in the hay	1	decent	
-680	acceptable watered-down gray slap and tickle	2	good	
+680	watered-down acceptable gray slap and tickle	2	good	
 681	hand-crafted slip 'n' slide	4	EPIC	
-682	lousy weak narrow a sump'm sump'm	2	decent	
-683	practically non-alcoholic perfectly mixed horizontal tango	1	super ultra mega turbo EPIC	
+682	weak lousy narrow a sump'm sump'm	2	decent	
+683	perfectly mixed practically non-alcoholic horizontal tango	1	super ultra mega turbo EPIC	
 684	bad gray pink pony	3	decent	
 685	blue lightning-fast boxer's Mr. Shirt of the businessman	0		Muscle Percent: +10, Meat Drop: +50, Initiative: +40
 686	knuckles of incineration	0		Hot Spell Damage: +50
@@ -686,7 +686,7 @@
 688	spinning dangerous pixel hat	0		Weapon Damage: +10, Familiar Effect: "atk, 2xVolley, cap 12"
 689	bouncing bouncing horrifying pixel pants	0		Spooky Damage: +25, Familiar Effect: "atk, 4xPotato, cap 12"
 690	gray bouncing Jim Carey's pixel sword	0		Monster Level: +25
-691	lime green bouncing mirror digital key	0		
+691	bouncing lime green mirror digital key	0		
 692	Ascension Souvenir T-Shirt	0		
 693	blinking grievous harem girl t-shirt	0		Weapon Damage Percent: +50
 694	zippy Knob Goblin elite shirt	0		Initiative: +20
@@ -717,7 +717,7 @@
 721	dog trainer's Herculean porquoise bracelet	0		Experience (Muscle): +1, Experience (familiar): +1
 722	bouncing foul-smelling friendly stiffened porquoise ring	0		Damage Reduction: 1, Familiar Weight: +3, Stench Damage: +10, Single Equip
 723	spoiled Knoll mushroom	4	crappy	
-724	normal diet mushroom	1	good	
+724	diet normal mushroom	1	good	
 725	one million meat pancakes	0		
 726	bouncing occult huge mirror shard	0		Spell Damage Percent: +25
 727	hedge maze puzzle	0		
@@ -748,13 +748,13 @@
 753	spoiled diet cyan pointy mushroom	1	crappy	
 754	normal cream of pointy mushroom soup	3	good	
 755	enchanted stale snack-sized mushroom	2	decent	Effect: "Sucrose-Colored Glasses", Effect Duration: 30
-756	half-sized normal mirror yellow mushroom	2	good	
+756	half-sized normal yellow mirror mushroom	2	good	
 757	tasty jittery mushroom	3	awesome	
 758	bite-sized normal blurry ghost cucumber	1	good	
 759	dill	0		
 760	upside-down vinegar	0		
 761	brine	0		
-762	smooth fortified especially salty dog	5	awesome	
+762	fortified smooth especially salty dog	5	awesome	
 763	ghostly pickling solution	0		
 764	decent blinking spectral pickle	3	good	
 765	ghostly briny vinegar	0		
@@ -776,16 +776,16 @@
 781	alkaline pulsating mafia aria	0		Effect: "Fancy Feasted", Effect Duration: 24
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	mediocre practically non-alcoholic Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
+784	practically non-alcoholic mediocre Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	yummy teal strawberry	3	awesome	
 787	artisanal bottle of rum	3	EPIC	
 788	watered-down acceptable gray strawberry daiquiri	2	good	
 789	tolerable rum and cola	3	good	
-790	practically non-alcoholic tolerable spinning grog	1	good	
+790	tolerable practically non-alcoholic spinning grog	1	good	
 791	medical-grade Mafia bow tie of extreme caution	0		Monster Level: -25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10"
 792	resourceful Golden Mr. Accessory	0		Maximum MP: +50, Softcore Only
-793	chilled quantum ionized ghostly squat shaking oil of stability	0		Effect: "Adorable Lookout", Effect Duration: 34
+793	chilled quantum ionized squat ghostly shaking oil of stability	0		Effect: "Adorable Lookout", Effect Duration: 34
 794	pressed wet oil of slipperiness	0		Effect: "New and Improved", Effect Duration: 19
 795	high-proof delicious Acque Luride Grezze Cabernet	8	awesome	Last Available: "2004-10"
 796	narrow executive Van der Graaf vibrating cement shoes	0		Maximum MP Percent: +10, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2004-10"
@@ -794,23 +794,23 @@
 799	extra-dry tolerable fancy fuzzbump	5	good	Effect: "Sleazy Hands", Effect Duration: 20
 800	toothsome poutine	3	awesome	
 801	decent shaking Knob stir-fry	4	good	
-804	normal half-sized Knoll stir-fry	2	good	
+804	half-sized normal Knoll stir-fry	2	good	
 805	diet delicious stir-fry	1	awesome	
 806	decent asparagus stir-fry	3	good	
-807	bland small olive stir-fry	2	decent	
+807	small bland olive stir-fry	2	decent	
 808	stale Knob sausage stir-fry	4	decent	
 809	bland bat wing stir-fry	3	decent	
-810	decent big rat appendix stir-fry	5	good	
-811	special stale tofu stir-fry	3	decent	Effect: "Dance of the Sugar Fairy", Effect Duration: 35
-812	small stale pr0n stir-fry	2	decent	
+810	big decent rat appendix stir-fry	5	good	
+811	stale special tofu stir-fry	3	decent	Effect: "Dance of the Sugar Fairy", Effect Duration: 35
+812	stale small pr0n stir-fry	2	decent	
 813	decent Knob shells	3	good	
 814	delicious super-sized b&auml;tzle	5	awesome	
 815	decent snack-sized ratini	2	good	
-816	toothsome small Knob stroganoff	2	awesome	
-817	stale small menudo ravioli	2	decent	
+816	small toothsome Knob stroganoff	2	awesome	
+817	small stale menudo ravioli	2	decent	
 818	blurry plus sign	0		
 819	milky potion	0		
-820	bouncing narrow swirly potion	0		
+820	narrow bouncing swirly potion	0		
 821	bubbly potion	0		
 822	smoky potion	0		
 823	cloudy potion	0		
@@ -822,7 +822,7 @@
 829	pulsating anti-anti-antidote	0		
 830	spoiled miniature royal jelly	2	crappy	
 831	small box	0		
-832	narrow bouncing box	0		
+832	bouncing narrow box	0		
 833	Lo Pan's vorpal blade	0		Spell Critical Percent: +30
 834	dangerous smartaleck's cornuthaum	0		Moxie Percent: +30, Weapon Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	Jeselnik's ring of aggravate monster	0		Sleaze Damage: +25
@@ -833,8 +833,8 @@
 840	skewed horrifying Mafia violin case of the ox	0		Muscle: +20, Spooky Damage: +25, Last Available: "2004-10"
 841	delicious tomato daiquiri	4	awesome	
 842	acceptable fortified beertini	5	good	
-843	acceptable watered-down blinking salty slug	2	good	
-844	watered-down drinkable papaya slung	2	good	
+843	watered-down acceptable blinking salty slug	2	good	
+844	drinkable watered-down papaya slung	2	good	
 845	narrow Samson's MAHI fez	0		Experience (Muscle): +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	tumbling narrow heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -849,7 +849,7 @@
 857	wobbly moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	narrow knife and fork	0		Familiar Weight: +5
-860	huge jittery green eye-pod	0		Familiar Weight: +5
+860	green jittery huge eye-pod	0		Familiar Weight: +5
 861	blurry mirror chocolate spurs	0		Familiar Weight: +5
 862	magnifying glass	0		Familiar Weight: +5
 863	blinking skewer-mounted razor blade	0		Familiar Weight: +5
@@ -878,10 +878,10 @@
 887	leaf	0		
 888	maple leaf	0		
 889	blurry family-friendly balaclava	0		Sleaze Resistance: +1, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	decent big balaclava baklava	5	good	
+890	big decent balaclava baklava	5	good	
 891	huge Lo Pan's Warehouse 23 bling	0		Spell Critical Percent: +30
 892	wobbly personal trainer's groovy bugbear-smiting sword of the early riser	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Adventures: +7
-893	acceptable weak lumbering jack	2	good	
+893	weak acceptable lumbering jack	2	good	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	Samson's Ms. Accessory	0		Experience (Muscle): +5, Softcore Only
 896	yellow skewed fireproof Socratic Mr. Accessory Jr.	0		Experience (Mysticality): +1, Hot Resistance: +3, Softcore Only
@@ -892,9 +892,9 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	perfectly mixed blurry Spasmi Dolorosi Del Rene Champagne	3	super EPIC	Last Available: "2004-10"
-904	knitted scandalous school Mafia knickerbockers of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +5, Cold Resistance: +3, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	knitted scandalous school Mafia knickerbockers of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +5, Cold Resistance: +3, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	moist vacuum-sealed teal Yummy Tummy bean	0		Effect: "Vitamin-Maxed", Effect Duration: 47
-906	anodized super-corrupted blurry narrow Rock Pops	0		Effect: "Deadly Lampblade", Effect Duration: 50
+906	anodized super-corrupted narrow blurry Rock Pops	0		Effect: "Deadly Lampblade", Effect Duration: 50
 907	irradiated jittery Mr. Mediocrebar	0		Effect: "Liquid Luck", Effect Duration: 67
 908	galvanized wet Cold Hots candy	0		Effect: "Craft Tea", Effect Duration: 53
 909	polarized warmed pressed Wint-O-Fresh mint	0		Effect: "Cat Class, Cat Style", Effect Duration: 68
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	intergalactic pom poms of dire peril of the scaredy-cat	0		Weapon Damage: +20, Monster Level: -15
 917	Mob Penguin protection contract	0		
-918	shellacked Radio Free Baseball Cap	0		Damage Reduction: 7, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	grievous Radio Free Pants	0		Weapon Damage Percent: +50, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	shellacked Radio Free Baseball Cap	0		Damage Reduction: 7, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	grievous Radio Free Pants	0		Weapon Damage Percent: +50, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	perfumed Radio Free Foil	0		Stench Resistance: +5, Last Available: "2006-07"
 921	spoiled radio button candy	3	crappy	
 922	skewed skewed thinker's severed rocking horse head	0		Mysticality: +10
@@ -920,7 +920,7 @@
 929	arse-shooting crossbow of the sweet-tooth	0		Candy Drop: +100
 931	lousy watered-down spiced rum	2	decent	
 932	aged eggnog	4	awesome	
-933	special moldy candy cane	4	crappy	Effect: "Salty Dogs", Effect Duration: 40
+933	moldy special candy cane	4	crappy	Effect: "Salty Dogs", Effect Duration: 40
 934	normal spinning gingerbread bugbear	4	good	
 935	slick imitation nice watch	0		Moxie: +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,21 +929,21 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	narrow bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	green bowler of the boozehound	0		Booze Drop: +100, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	green bowler of the boozehound	0		Booze Drop: +100, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	double-paned sizzling bow staff	0		Hot Damage: +10, Cold Resistance: +5, Last Available: "2004-12"
-944	ruddy bowlegged pants	0		Maximum HP Percent: +40, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
-945	skewed red skewered jumbo olive	0		Last Available: "2004-12"
+944	ruddy bowlegged pants	0		Maximum HP Percent: +40, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+945	red skewed skewered jumbo olive	0		Last Available: "2004-12"
 946	ghostly skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	watered-down lousy enchanted martini	2	decent	Effect: "Al Dente Inferno", Effect Duration: 10, Last Available: "2004-12"
-949	high-proof delicious grogtini	9	awesome	Last Available: "2004-12"
+949	delicious high-proof grogtini	9	awesome	Last Available: "2004-12"
 950	lousy cherry bomb	4	decent	Last Available: "2004-12"
 951	purple tumbling extra special Crimbo stocking	0		Last Available: "2004-12"
 952	blinking hockey mask of Gandalf of the cheetah	0		Spell Critical Percent: +20, Initiative: +60, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	squat penguin-smacking club	0		Familiar Damage: +15
 954	wobbly orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	dance instructor's fez of etymology	0		Experience Percent (Moxie): +10, Familiar Effect: "1xLep, cap 30"
-956	jumbo adequate fancy skewed carob chunk noodles	5	good	Effect: "Purpose", Effect Duration: 25
+956	adequate fancy jumbo skewed carob chunk noodles	5	good	Effect: "Purpose", Effect Duration: 25
 957	delicious chorizo brownies	3	awesome	
 958	decent upside-down chocolate and tomato pizza	4	good	
 959	flange	0		
@@ -989,8 +989,8 @@
 1002	spinning teal thinker's Xlyinia's notebook	0		Mysticality: +10
 1003	bouncing soda water	0		
 1004	drinkable huge bottle of tequila	3	good	
-1005	fancy acceptable boxed wine	4	good	Effect: "Squatting and Thrusting", Effect Duration: 40
-1006	normal jumbo jittery cherry	5	good	
+1005	acceptable fancy boxed wine	4	good	Effect: "Squatting and Thrusting", Effect Duration: 40
+1006	jumbo normal jittery cherry	5	good	
 1007	brawny coconut shell	0		Muscle Percent: +20, Familiar Effect: "1xFairy, cap 7"
 1008	avaricious ice cubes	0		Meat Drop: +30
 1009	tolerable spinning bouncing vodka martini	3	good	
@@ -998,18 +998,18 @@
 1011	drinkable monkey wrench	3	good	
 1012	artisanal tumbling tequila sunrise	3	EPIC	
 1013	artisanal margarita	3	EPIC	
-1014	bad watered-down strawberry wine	2	decent	
+1014	watered-down bad strawberry wine	2	decent	
 1015	hand-crafted wine spritzer	3	EPIC	
 1016	smooth perpendicular hula	3	awesome	
-1017	hand-crafted high-proof ducha de oro	6	EPIC	
+1017	high-proof hand-crafted ducha de oro	6	EPIC	
 1018	lousy calle de miel	4	decent	
 1019	drinkable dry vodka martini	4	good	
 1020	mediocre pulsating old-fashioned	4	decent	
-1021	tolerable practically non-alcoholic huge tequila with training wheels	1	good	
+1021	practically non-alcoholic tolerable huge tequila with training wheels	1	good	
 1022	practically non-alcoholic smooth twirling sangria	1	awesome	
 1023	hand-crafted vesper	3	super ultra EPIC	Last Available: "2004-12"
-1024	weak enchanted tolerable bodyslam	2	good	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2004-12"
-1025	distilled artisanal upside-down sangria del diablo	5	EPIC	Last Available: "2004-12"
+1024	tolerable enchanted weak bodyslam	2	good	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2004-12"
+1025	artisanal distilled upside-down sangria del diablo	5	EPIC	Last Available: "2004-12"
 1026	maroon wobbly Valentine	0		Free Pull
 1027	narrow whip kit	0		
 1028	buckler buckle	0		
@@ -1017,7 +1017,7 @@
 1030	blinking lard-coated penguin whip	0		Sleaze Spell Damage: +25
 1031	hardy yak whip	0		Maximum HP: +50
 1032	gnauga hide whip of mayonnaise	0		Sleaze Spell Damage: +50
-1033	yellow wobbly gnauga hide	0		
+1033	wobbly yellow gnauga hide	0		
 1034	fuchsia blurry savvy hippo skin buckler	0		Mysticality Percent: +20, Damage Reduction: 5
 1035	penguin skin buckler of bravery	0		Spooky Resistance: +5, Damage Reduction: 5
 1036	Sinatra's yakskin buckler	0		Experience (Moxie): +5, Damage Reduction: 5
@@ -1029,15 +1029,15 @@
 1043	lime green slick string of beads	0		Moxie: +10
 1044	Oprah's string of beads	0		Maximum MP Percent: +50
 1045	auspicious plastic bottle opener	0		Item Drop: +10
-1046	slick traffic cone of incineration	0		Moxie: +10, Hot Spell Damage: +50, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	slick traffic cone of incineration	0		Moxie: +10, Hot Spell Damage: +50, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	perfectly mixed N. O. Beer	4	EPIC	
 1048	diluted jittery oyster egg	1		
 1049	boiled upside-down oyster egg	1		
 1050	mixed ghostly oyster egg	1		Effect: "Ooh, Sour!", Effect Duration: 15
-1051	yellow blurry plastic oyster egg	0		
-1052	denatured twirling narrow lime green upside-down oyster egg	1		
+1051	blurry yellow plastic oyster egg	0		
+1052	denatured twirling upside-down lime green narrow oyster egg	1		
 1053	twisted oyster egg	1		Effect: "Held Closer", Effect Duration: 35
-1054	denatured huge gray spinning oyster egg	1		Effect: "In the Slimelight", Effect Duration: 25
+1054	denatured spinning gray huge oyster egg	1		Effect: "In the Slimelight", Effect Duration: 25
 1055	blinking plastic oyster egg	0		
 1056	mixed puce oyster egg	1		
 1057	modified maroon puce oyster egg	1		
@@ -1052,14 +1052,14 @@
 1066	altered teal oyster egg	1		Effect: "Disdain of the War Snapper", Effect Duration: 40
 1067	tumbling plastic oyster egg	0		
 1068	twisted oyster egg	1		
-1069	modified skewed teal blurry bouncing oyster egg	1		
+1069	modified skewed teal bouncing blurry oyster egg	1		
 1070	twisted olive oyster egg	1		
 1071	teal plastic oyster egg	0		
-1072	mixed blurry ghostly shaking off-white oyster egg	1		
+1072	mixed shaking blurry ghostly off-white oyster egg	1		
 1073	diluted ghostly off-white oyster egg	1		
 1074	mixed off-white oyster egg	1		Effect: "stats.enq", Effect Duration: 40
 1075	blurry blinking off-white plastic oyster egg	0		
-1076	pickled pulsating maroon bouncing oyster egg	1		
+1076	pickled bouncing pulsating maroon oyster egg	1		
 1077	modified oyster egg	1		Effect: "Berry Statistical", Effect Duration: 45
 1078	powdered mirror oyster egg	1		
 1079	blurry plastic oyster egg	0		
@@ -1126,8 +1126,8 @@
 1140	lousy purple icy mushroom wine	3	decent	
 1141	hand-crafted mushroom wine	3	EPIC	
 1142	bad pointy mushroom wine	3	decent	
-1143	practically non-alcoholic perfectly mixed flat mushroom wine	1	super ultra mega turbo EPIC	
-1144	distilled aged cool mushroom wine	5	awesome	
+1143	perfectly mixed practically non-alcoholic flat mushroom wine	1	super ultra mega turbo EPIC	
+1144	aged distilled cool mushroom wine	5	awesome	
 1145	delicious practically non-alcoholic mirror knob mushroom wine	1	awesome	
 1146	hand-crafted knoll mushroom wine	3	EPIC	
 1147	watered-down perfectly mixed pulsating mushroom wine	2	EPIC	
@@ -1136,7 +1136,7 @@
 1150	acceptable cyan bottle of single-barrel whiskey	3	good	
 1151	wobbly greedy sage discarded plastic fork	0		Mysticality Percent: +10, Meat Drop: +20
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	immense moldy Retenez L'Herbe Pat&eacute;	6	crappy	
+1153	moldy immense Retenez L'Herbe Pat&eacute;	6	crappy	
 1154	altered skewed Breathetastic&trade; Premium Canned Air	1	good	
 1155	letter from King Ralph XI	0		
 1157	slick wholeberd	0		Moxie: +10
@@ -1155,14 +1155,14 @@
 1170	chocolate box	0		
 1171	coffin	0		
 1172	asbestos box	0		
-1173	shaking pulsating linoleum box	0		
+1173	pulsating shaking linoleum box	0		
 1174	chrome box	0		
 1175	bouncing cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	spinning magnetic field	0		
 1178	narrow jittery potted cactus	0		
 1179	purple daisy	0		
-1180	jittery maroon potted fern	0		
+1180	maroon jittery potted fern	0		
 1181	tumbling tulip	0		
 1182	Venus flytrap	0		
 1183	pulsating all-purpose flower	0		
@@ -1185,15 +1185,15 @@
 1200	massive decent gray mugcake	8	good	
 1201	bland urinal cake	4	decent	
 1202	miniature flavorless tumbling Happy Birthday, Claude! cake	2	decent	
-1203	toothsome immense personalized birthday cake	9	awesome	
+1203	immense toothsome personalized birthday cake	9	awesome	
 1204	bland shaking three-tiered wedding cake	3	decent	
-1205	jumbo rotten babycakes	5	crappy	
-1206	stale low-calorie velvet cake	1	decent	
+1205	rotten jumbo babycakes	5	crappy	
+1206	low-calorie stale velvet cake	1	decent	
 1207	spoiled jittery congratulatory cake	3	crappy	
 1208	stale spinning angel-food cake	4	decent	
-1209	small stale ghostly devil's-food cake	2	decent	
+1209	stale small ghostly devil's-food cake	2	decent	
 1210	half-sized moldy birthday party jellybean cheesecake	2	crappy	
-1211	shaking red balloon	0		
+1211	red shaking balloon	0		
 1212	blurry balloon	0		
 1213	heart-shaped balloon	0		
 1214	anniversary balloon	0		
@@ -1233,14 +1233,14 @@
 1249	toasty Boss Bat britches	0		Hot Damage: +5, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	twirling brainy Boss Bat bling of the sweet-tooth	0		Mysticality: +5, Candy Drop: +100
 1251	adequate low-calorie Knob shroomkabob	1	good	
-1252	delicious special shroomkabob	3	awesome	Effect: "Hot Hands", Effect Duration: 10
+1252	special delicious shroomkabob	3	awesome	Effect: "Hot Hands", Effect Duration: 10
 1253	fuchsia pile of jumping beans	0		
 1254	normal jumping bean burrito	3	good	
 1255	flavorless miniature jumping bean burrito	2	decent	
 1256	spoiled insanely jumping bean burrito	4	crappy	
 1257	moldy rat scrapple	3	crappy	
 1258	pail of pretentious paint	0		
-1259	wicked razor-sharp traffic cone	0		Weapon Damage Percent: +25, Spell Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	wicked razor-sharp traffic cone	0		Weapon Damage Percent: +25, Spell Damage: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	altered teal Hatorade	1		
 1262	ghostly lightning-fast energetic deadly off-hand balloon	0		Weapon Damage: +5, Maximum MP Percent: +20, Initiative: +40
@@ -1271,7 +1271,7 @@
 1287	upside-down energetic furry kilt	0		Maximum MP Percent: +20, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 1288	Fonzie's gnauga hide skirt	0		Experience (Moxie): +1, Familiar Effect: "2.5xFairy, cap 20"
 1289	fuchsia ghostly brawny gnauga hide kilt	0		Muscle Percent: +20, Familiar Effect: "2.5xFairy, cap 20"
-1290	flattened adjusted ghostly upside-down wind-up clock	0		Effect: "Jungle Juiced", Effect Duration: 68
+1290	flattened adjusted upside-down ghostly wind-up clock	0		Effect: "Jungle Juiced", Effect Duration: 68
 1291	Jekyllin hide belt of vim and vigor	0		Maximum HP Percent: +50, Softcore Only, Last Available: "2005-09"
 1292	skirt / kilt kit	0		
 1293	purple personal trainer's ring of adornment	0		Experience Percent (Muscle): +10
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	ghostly makeup kit	0		Familiar Weight: +15
-1306	Newton's traffic cone of Calamity Jane	0		Experience (Mysticality): +3, Critical Hit Percent: +15, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	Newton's traffic cone of Calamity Jane	0		Experience (Mysticality): +3, Critical Hit Percent: +15, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	spinning calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	moldy questionable taco	3	crappy	
 1321	jittery Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	wobbly dangerous time helmet	0		Weapon Damage: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	time trousers of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	wobbly dangerous time helmet	0		Weapon Damage: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	time trousers of the scaredy-cat	0		Monster Level: -15, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	lightning-fast time sword	0		Initiative: +40, Last Available: "2005-10"
 1326	upside-down Usain Bolt's Dyspepsi-Cola helmet	0		Initiative: +80, Familiar Effect: "3xFairy, cap 7"
 1327	groovy Cloaca-Cola shield	0		Moxie Percent: +10, Damage Reduction: 4
@@ -1327,17 +1327,17 @@
 1344	pickled wet Gummi-Gnauga	0		Effect: "Wet and Greedy", Effect Duration: 68
 1345	moist nitrogenated shaking Now and Earlier	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 37, Last Available: "2020-09"
 1346	liquefied wobbly Sugar Cog	0		Effect: "Arcane in the Brain", Effect Duration: 26
-1347	tumbling twirling blinking loaded serum blowgun	0		Last Available: "2005-11"
+1347	blinking twirling tumbling loaded serum blowgun	0		Last Available: "2005-11"
 1348	jittery tumbling empty blowgun	0		Last Available: "2005-11"
 1349	green miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
-1350	upside-down red squat 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
+1350	red squat upside-down 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	pinky ring of Leguizamo	0		Monster Level: +20, Single Equip
 1352	spirit-forward hand-crafted redrum	5	EPIC	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	low-calorie flavorless blue bowl of oriole's nest soup	1	decent	
+1355	flavorless low-calorie blue bowl of oriole's nest soup	1	decent	
 1356	bouncing bunny liver	0		
-1357	artisanal high-proof Mt. Noob Pale Ale	6	EPIC	
+1357	high-proof artisanal Mt. Noob Pale Ale	6	EPIC	
 1358	huge pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pulsating pirate zombie robot head	0		Last Available: "2005-11"
@@ -1345,23 +1345,23 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	blinking rhesus monkey	0		Familiar Weight: +5
-1365	flavorless jumbo blurry tofurkey leg	5	decent	
+1365	jumbo flavorless blurry tofurkey leg	5	decent	
 1366	stale tofurkey gravy	4	decent	
 1367	stale herbal stuffing	4	decent	
-1368	gigantic delicious can-shaped gelatinous cranberry sauce	9	awesome	
+1368	delicious gigantic can-shaped gelatinous cranberry sauce	9	awesome	
 1369	toothsome yams	4	awesome	
 1370	pulsating lion tamer's rhinestone cowboy shirt	0		Experience (familiar): +2
 1371	shaking narrow studded gingham blouse	0		Damage Absorption: +80
 1372	fuchsia manspreader's souvenir ski t-shirt	0		Monster Level: +10
 1373	sweet nutcracker	0		Free Pull, Last Available: "2005-12"
-1374	mirror bouncing mandible	0		Familiar Weight: +5, Last Available: "2005-12"
+1374	bouncing mirror mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	chilly plastic Crimbo wreath	0		Cold Damage: +5, Single Equip, Last Available: "2005-12"
 1376	Rosewater's plastic Uncle Crimbo	0		Mysticality Percent: +30, Last Available: "2005-12"
 1377	family-friendly plastic Crimbo elf	0		Sleaze Resistance: +1, Last Available: "2005-12"
 1378	blinking frightening plastic sweet nutcracker	0		Spooky Damage: +5, Last Available: "2005-12"
 1379	blue ribald plastic Crimbo reindeer	0		Sleaze Damage: +10, Single Equip, Last Available: "2005-12"
 1381	jittery pulsating aspirin	0		Last Available: "2005-12"
-1382	super-energized modified narrow olive chocolate	0		Effect: "Painted-On Bikini", Effect Duration: 58, Last Available: "2015-11"
+1382	super-energized modified olive narrow chocolate	0		Effect: "Painted-On Bikini", Effect Duration: 58, Last Available: "2015-11"
 1383	length of string	0		
 1384	pulsating googly eye	0		
 1385	maroon stuffing	0		
@@ -1384,10 +1384,10 @@
 1402	blinking blue Jeselnik's rag doll	0		Sleaze Damage: +25, Last Available: "2005-12"
 1403	blurry sinister can of fake snow	0		Spell Damage: +10, Last Available: "2005-12"
 1404	Oprah's colored-light &quot;necklace&quot;	0		Maximum MP Percent: +50, Last Available: "2005-12"
-1405	tree skirt of the wise owl	0		Mysticality: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	stale massive wreath-shaped Crimbo cookie	8	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	tree skirt of the wise owl	0		Mysticality: +20, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1406	massive stale wreath-shaped Crimbo cookie	8	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	spoiled gray bell-shaped Crimbo cookie	3	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	stale small jittery tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	small stale jittery tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	ruddy Unionize The Elves sign	0		Maximum HP Percent: +40, Last Available: "2005-12"
 1410	mirror sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	improved snowcone	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 49, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	red teddy bear sewing kit	0		Last Available: "2006-01"
-1420	maroon knitted Fonzie's traffic cone	0		Experience (Moxie): +1, Cold Resistance: +3, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	maroon knitted Fonzie's traffic cone	0		Experience (Moxie): +1, Cold Resistance: +3, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	shaking Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	narrow iceberglet	0		Last Available: "2006-02"
 1424	blinking lion tamer's ice sickle of the sewer	0		Experience (familiar): +2, Stench Damage: +25, Softcore Only, Last Available: "2006-02"
 1425	huge huge Da Vinci's ice baby	0		Experience (Mysticality): +5, Softcore Only, Last Available: "2006-02"
-1426	censurious ice pick	0		Sleaze Resistance: +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	censurious ice pick	0		Sleaze Resistance: +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	blurry greedy beefy ice skates	0		Muscle: +10, Meat Drop: +20, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	rotten grue egg omelette	4	crappy	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	massive adequate mushroom	7	good	
+1432	adequate massive mushroom	7	good	
 1433	fruit bowl	0		
 1434	green pulsating fruit basket	0		
 1435	blurry hot pink lipstick	0		Familiar Weight: +5
@@ -1424,17 +1424,17 @@
 1442	quadruple-deionized stench powder	0		Effect: "Wet Jaw", Effect Duration: 41
 1443	polymerized pickled jittery sleaze powder	0		Effect: "Liquid Luck", Effect Duration: 65
 1444	ionized green twinkly nuggets	0		Effect: "Mushroom Might", Effect Duration: 48
-1445	electrified ionized shaking tumbling hot nuggets	0		Effect: "Angry Bone", Effect Duration: 15
+1445	electrified ionized tumbling shaking hot nuggets	0		Effect: "Angry Bone", Effect Duration: 15
 1446	denatured nuggets	0		Effect: "Livin' Large", Effect Duration: 43
 1447	ionized boiled nuggets	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 56
 1448	polymerized stench nuggets	0		Effect: "Flower Power", Effect Duration: 17
-1449	deionized cyan wobbly huge sleaze nuggets	0		Effect: "Sagittarius Rising", Effect Duration: 41
-1450	pickled narrow cyan squat twinkly wad	1		
+1449	deionized cyan huge wobbly sleaze nuggets	0		Effect: "Sagittarius Rising", Effect Duration: 41
+1450	pickled cyan squat narrow twinkly wad	1		
 1451	powdered hot wad	1		
-1452	denatured wobbly squat wad	1		
+1452	denatured squat wobbly wad	1		
 1453	mixed wad	1		
-1454	compressed teal shaking stench wad	1		
-1455	distilled wobbly lime green upside-down sleaze wad	1		Effect: "Raging Animal", Effect Duration: 10
+1454	compressed shaking teal stench wad	1		
+1455	distilled upside-down wobbly lime green sleaze wad	1		Effect: "Raging Animal", Effect Duration: 10
 1456	double daisy	0		
 1457	bouncing Goth Giant	0		
 1458	low-calorie moldy Valentine's Day cake	1	crappy	
@@ -1467,16 +1467,16 @@
 1485	knitted resourceful rabbit's foot	0		Maximum MP: +50, Cold Resistance: +3
 1486	massive bag of catnip	0		
 1487	squat hang glider	0		
-1488	mirror red March hat	0		Free Pull
+1488	red mirror March hat	0		Free Pull
 1489	dormouse	0		
 1490	skewed frightening Sinatra's chopsticks	0		Experience (Moxie): +5, Spooky Damage: +5
 1491	rice bowl of the detective	0		Item Drop: +20
 1492	greedy ninja mop	0		Meat Drop: +20
 1493	huge ridiculously overelaborate ninja weapon of chilblains of the overflowing toilet	0		Cold Damage: +25, Stench Spell Damage: +50
-1494	pressed vacuum-sealed lime green upside-down wobbly sugar-coated pine cone	0		Effect: "Uncanny Shot", Effect Duration: 27, Last Available: "2020-09"
-1495	studded Socratic traffic cone	0		Experience (Mysticality): +1, Damage Absorption: +80, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	acceptable weak gloomy mushroom wine	2	good	
-1497	hand-crafted watered-down mushroom wine	2	super EPIC	
+1494	pressed vacuum-sealed upside-down wobbly lime green sugar-coated pine cone	0		Effect: "Uncanny Shot", Effect Duration: 27, Last Available: "2020-09"
+1495	studded Socratic traffic cone	0		Experience (Mysticality): +1, Damage Absorption: +80, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1496	weak acceptable gloomy mushroom wine	2	good	
+1497	watered-down hand-crafted mushroom wine	2	super EPIC	
 1498	blinking McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
@@ -1486,13 +1486,13 @@
 1504	dry snowcone	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 22, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	mediocre calle de miel with a fly in it	4	decent	Last Available: "2006-04"
-1507	weak tolerable rockin' wagon with a fly in it	2	good	Last Available: "2006-04"
+1507	tolerable weak rockin' wagon with a fly in it	2	good	Last Available: "2006-04"
 1508	high-proof bad perpendicular hula with a fly in it	8	decent	Last Available: "2006-04"
 1509	watered-down artisanal slap and tickle with a fly in it	2	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of chilblains	0		Cold Damage: +25, Last Available: "2006-04"
 1512	denatured Knob Goblin pet-buffing spray	1		
-1513	boiled blurry narrow Knob Goblin learning pill	1		
+1513	boiled narrow blurry Knob Goblin learning pill	1		
 1514	vaporized blurry maroon Knob Goblin eyedrops	1		
 1515	powdered jittery Knob Goblin nasal spray	1		
 1516	squat KWE-brand transistor radio	0		
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	shaking wind-up chattering teeth	0		Last Available: "2006-04"
 1525	wobbly joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	skewed red pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	red skewed pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	blurry huge diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	jittery steel-toed corkscrew of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	jittery up-at-dawn grass skirt	0		Adventures: +5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	avaricious grass hat	0		Meat Drop: +30, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	jittery up-at-dawn grass skirt	0		Adventures: +5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	avaricious grass hat	0		Meat Drop: +30, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	skewed Tesla grass blade	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-01"
 1534	skewed raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	blue weegee sqouija	0		Last Available: "2011-12"
 1538	mirror toasty sparkly engagement ring	0		Hot Damage: +5, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	scandalous foul-smelling Grimacite goggles	0		Stench Damage: +10, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	scandalous foul-smelling Grimacite goggles	0		Stench Damage: +10, Sleaze Damage: +5, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	gravedigger's sage Grimacite glaive	0		Mysticality Percent: +10, Spooky Damage: +10, Last Available: "2008-10"
-1542	flame-wreathed hardened Grimacite greaves	0		Damage Reduction: 3, Hot Spell Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	flame-wreathed hardened Grimacite greaves	0		Damage Reduction: 3, Hot Spell Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	twirling inspector's knitted Grimacite garter	0		Cold Resistance: +3, Item Drop: +15, Last Available: "2008-10"
 1544	boxer's Grimacite galoshes of the empath	0		Muscle Percent: +10, Familiar Weight: +5, Last Available: "2008-10"
 1545	bouncing ribald clever Grimacite gorget	0		Maximum MP: +20, Sleaze Damage: +10, Last Available: "2008-10"
@@ -1532,54 +1532,54 @@
 1552	high-proof artisanal bottle of Definit	10	EPIC	
 1553	tolerable practically non-alcoholic bottle of Calcutta Emerald	1	good	
 1554	lousy bottle of Lieutenant Freeman	4	decent	
-1555	special weak acceptable tumbling bottle of Jorge Sinsonte	2	good	Effect: "Liquid Luck", Effect Duration: 50
+1555	acceptable weak special tumbling bottle of Jorge Sinsonte	2	good	Effect: "Liquid Luck", Effect Duration: 50
 1556	triple-distilled perfectly mixed boxed champagne	7	EPIC	
-1557	huge stale shaking huge kumquat	7	decent	
+1557	stale huge shaking huge kumquat	7	decent	
 1558	bland tangerine	3	decent	
 1559	teal tonic water	0		
 1560	yummy wobbly cocktail onion	3	awesome	
 1561	moldy raspberry	3	crappy	
 1562	jumbo normal kiwi	5	good	
-1563	fortified artisanal teal whiskey bittersweet	5	EPIC	
+1563	artisanal fortified teal whiskey bittersweet	5	EPIC	
 1564	lousy mimosette	4	decent	
 1565	acceptable fuchsia tequila sunset	4	good	
 1566	bad boozy teal zmobie	5	decent	Wiki Name: "Zmobie (drink)"
-1567	watered-down bad special gin and tonic	2	decent	Effect: "Riboflavin'", Effect Duration: 40
-1568	practically non-alcoholic drinkable vodka and tonic	1	good	
-1569	boozy hand-crafted maroon vodka gibson	5	EPIC	
+1567	watered-down special bad gin and tonic	2	decent	Effect: "Riboflavin'", Effect Duration: 40
+1568	drinkable practically non-alcoholic vodka and tonic	1	good	
+1569	hand-crafted boozy maroon vodka gibson	5	EPIC	
 1570	acceptable gibson	3	good	
 1571	drinkable parisian cathouse	3	good	
-1572	distilled mediocre rabbit punch	5	decent	
+1572	mediocre distilled rabbit punch	5	decent	
 1573	weak drinkable caipifruta	2	good	
-1574	drinkable special teqiwila	4	good	Effect: "Held Closer", Effect Duration: 15
+1574	special drinkable teqiwila	4	good	Effect: "Held Closer", Effect Duration: 15
 1575	bad watered-down Divine	2	decent	
 1576	practically non-alcoholic acceptable Gordon Bennett	1	good	
 1577	watered-down smooth tangarita	2	awesome	
 1578	perfectly mixed mirror mandarina colada	4	EPIC	
-1579	lousy weak narrow pulsating gimlet	2	decent	
-1580	bad fancy boozy shaking brick road	5	decent	Effect: "Rampage!", Effect Duration: 50
-1581	fancy mediocre irresponsibly strong vodka stratocaster	7	decent	Effect: "Wet Jaw", Effect Duration: 15
+1579	weak lousy pulsating narrow gimlet	2	decent	
+1580	fancy bad boozy shaking brick road	5	decent	Effect: "Rampage!", Effect Duration: 50
+1581	fancy irresponsibly strong mediocre vodka stratocaster	7	decent	Effect: "Wet Jaw", Effect Duration: 15
 1582	aged Neuromancer	3	awesome	
-1583	weak drinkable spinning prussian cathouse	2	good	
+1583	drinkable weak spinning prussian cathouse	2	good	
 1584	aged Mae West	3	awesome	
 1585	hand-crafted Mon Tiki	4	EPIC	
-1586	lousy triple-distilled red teqiwila slammer	10	decent	
+1586	triple-distilled lousy red teqiwila slammer	10	decent	
 1587	normal Knob lo mein	3	good	
 1588	rotten asparagus lo mein	3	crappy	
 1589	moldy Knoll lo mein	3	crappy	
 1590	bland lo mein	3	decent	
-1591	miniature moldy olive lo mein	2	crappy	
-1592	gigantic bland green hot hi mein	10	decent	
+1591	moldy miniature olive lo mein	2	crappy	
+1592	bland gigantic green hot hi mein	10	decent	
 1593	yummy hi mein	4	awesome	
 1594	massive stale hi mein	9	decent	
 1595	bland big lime green hi mein	5	decent	
-1596	spoiled fancy snack-sized sleazy hi mein	2	crappy	Effect: "Happy Trails", Effect Duration: 20
+1596	fancy spoiled snack-sized sleazy hi mein	2	crappy	Effect: "Happy Trails", Effect Duration: 20
 1597	Junior LAAAAME merit badge of terror	0		Spooky Spell Damage: +10, Last Available: "2006-05"
 1598	gray pulsating MacGyver's Senior LAAAAME merit badge	0		Maximum MP: +100, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	hand-crafted tangarita with a fly in it	4	EPIC	
 1601	irresponsibly strong bad mandarina colada with a fly in it	10	decent	
-1602	fancy artisanal prussian cathouse with a fly in it	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25
+1602	artisanal fancy prussian cathouse with a fly in it	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25
 1603	hand-crafted upside-down Mae West with a fly in it	4	EPIC	
 1604	twisted maroon jittery astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1592,8 +1592,8 @@
 1612	adjusted upside-down concentrated cordial of concentration	0		Effect: "Fan-Cooled", Effect Duration: 17
 1613	bouncing thinker's coffin lid	0		Mysticality: +10, Damage Reduction: 3
 1614	nasty satin shield	0		Stench Damage: +5, Damage Reduction: 5
-1615	energetic Cerebral Cloche	0		Maximum MP Percent: +20, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	banded Cerebral Culottes	0		Damage Absorption: +100, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	energetic Cerebral Cloche	0		Maximum MP Percent: +20, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	banded Cerebral Culottes	0		Damage Absorption: +100, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	blue Oprah's Cerebral Crossbow of vim and vigor of incineration	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Hot Spell Damage: +50, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1601,7 +1601,7 @@
 1621	ghostly astral badger	0		Free Pull, Last Available: "2006-06"
 1622	irradiated astral mushroom	0		Effect: "Hairless and Airless", Effect Duration: 59, Last Available: "2006-06"
 1623	huge badger badge	0		Last Available: "2006-06"
-1624	unsweetened quantum upside-down wobbly blue-frosted astral cupcake	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 28, Last Available: "2006-06"
+1624	unsweetened quantum wobbly upside-down blue-frosted astral cupcake	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 28, Last Available: "2006-06"
 1625	irradiated upside-down green-frosted astral cupcake	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 21, Last Available: "2006-06"
 1626	quadruple-flattened warmed orange-frosted astral cupcake	0		Effect: "Heightened Senses", Effect Duration: 59, Last Available: "2006-06"
 1627	extra-cold-filtered green tumbling purple-frosted astral cupcake	0		Effect: "Coming Up Roses", Effect Duration: 25, Last Available: "2006-06"
@@ -1620,7 +1620,7 @@
 1640	pickled improved lotion of stench	0		Effect: "Heart Aflame", Effect Duration: 63
 1641	adjusted squat lotion of sleaziness	0		Effect: "Limber as Mortimer", Effect Duration: 20
 1642	acceptable Grimacite Bock	3	good	Last Available: "2008-11"
-1643	fancy stale small wedge of gray cheese	2	decent	Effect: "Thought", Effect Duration: 25, Last Available: "2008-11"
+1643	stale small fancy wedge of gray cheese	2	decent	Effect: "Thought", Effect Duration: 25, Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
@@ -1628,9 +1628,9 @@
 1648	upside-down sleazy and sauce	0		
 1649	spinning brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	decent gigantic twirling foie gras	8	good	
+1651	gigantic decent twirling foie gras	8	good	
 1652	frozen squat candy brain	0		Effect: "Inebriate Pride", Effect Duration: 13, Last Available: "2020-09"
-1653	ribald veiny stiffened jewel-eyed wizard hat	0		Damage Reduction: 1, Maximum HP: +10, Sleaze Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	ribald veiny stiffened jewel-eyed wizard hat	0		Damage Reduction: 1, Maximum HP: +10, Sleaze Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	electrified wad of Crovacite of the pedagogue	0		Experience: +3, MP Regen Min: 3, MP Regen Max: 5
 1655	bouncing padded collar of the pedagogue	0		Experience: +3, Damage Absorption: +20
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	gray bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	red lightning-fast scorching sword	0		Hot Damage: +25, Initiative: +40
 1680	slick staff of the blizzard	0		Moxie: +10, Cold Spell Damage: +25
 1681	sage bubblewrap sword of the early riser	0		Mysticality Percent: +10, Adventures: +7
@@ -1664,19 +1664,19 @@
 1684	red styrofoam sword of James Dean	0		Experience (Moxie): +3, Item Drop: +5
 1685	styrofoam staff of terror of mayonnaise	0		Spooky Spell Damage: +10, Sleaze Spell Damage: +50
 1686	blurry studded padded styrofoam crossbow	0		Damage Absorption: 100
-1687	huge blue Platinum Yendorian Express Card	0		
+1687	blue huge Platinum Yendorian Express Card	0		
 1688	olive sinister crossbow of Calamity Jane	0		Spell Damage: +10, Critical Hit Percent: +15
 1689	careful ribbon	0		Monster Level: -10, Last Available: "2006-07"
 1690	stanky discarded bottlecap of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	rosewater-soaked medical-grade discarded torn-up glove	0		Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	triple-aerosolized blinking mirror salamander slurry	0		Effect: "OMG WTF", Effect Duration: 19
+1692	triple-aerosolized mirror blinking salamander slurry	0		Effect: "OMG WTF", Effect Duration: 19
 1693	polymerized aerosolized eyedrops of newt	0		Effect: "Human-Demon Hybrid", Effect Duration: 43
 1694	anodized Frogade	0		Effect: "Egged On", Effect Duration: 27
 1695	nitrogenated warmed tumbling papotion of papower	0		Effect: "The Best a Pirate Can Get", Effect Duration: 40
 1696	half-sized rotten fuchsia royal jelly taco	2	crappy	
 1697	spoiled tofu taco	3	crappy	
 1698	moldy big jumping bean taco	5	crappy	
-1699	stale snack-sized spinning catgut taco	2	decent	
+1699	snack-sized stale spinning catgut taco	2	decent	
 1700	yummy goat cheese taco	3	awesome	
 1701	spoiled pr0n taco	3	crappy	
 1702	warmed double-anodized upside-down alphabet gum	0		Effect: "Patent Avarice", Effect Duration: 59
@@ -1766,9 +1766,9 @@
 1787	flattened polymerized triple-flattened bag of Cheat-Os	0		Effect: "Ready to Snap", Effect Duration: 24
 1788	unrefined Mountain Stream syrup	0		
 1789	pulsating Mob Penguin	0		
-1790	weak artisanal Ram's Face Lager	2	EPIC	
-1791	cyan shaking ram horns	0		
-1792	double-paned brawny Travoltan trousers of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, Cold Resistance: +5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1790	artisanal weak Ram's Face Lager	2	EPIC	
+1791	shaking cyan ram horns	0		
+1792	double-paned brawny Travoltan trousers of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, Cold Resistance: +5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	narrow Samson's pool cue of the scaredy-cat	0		Experience (Muscle): +5, Monster Level: -15
 1794	boiled altered handful of hand chalk	0		Effect: "Bilious Briskness", Effect Duration: 25
 1795	skewed boxer's Counterclockwise Watch	0		Muscle Percent: +10, Single Equip
@@ -1797,25 +1797,25 @@
 1818	tenth thoracic vertebra	0		
 1819	jittery eleventh thoracic vertebra	0		
 1820	squat upside-down twelfth thoracic vertebra	0		
-1821	blinking gray first lumbar vertebra	0		
+1821	gray blinking first lumbar vertebra	0		
 1822	blue second lumbar vertebra	0		
 1823	teal third lumbar vertebra	0		
 1824	spinning fourth lumbar vertebra	0		
-1825	mirror cyan fifth lumbar vertebra	0		
+1825	cyan mirror fifth lumbar vertebra	0		
 1826	sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
 1829	first caudal vertebra	0		
 1830	teal ghostly second caudal vertebra	0		
 1831	third caudal vertebra	0		
-1832	tumbling shaking fourth caudal vertebra	0		
+1832	shaking tumbling fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
 1836	pulsating eighth caudal vertebra	0		
 1837	shaking blinking ninth caudal vertebra	0		
 1838	tenth caudal vertebra	0		
-1839	bouncing tumbling left first rib	0		
+1839	tumbling bouncing left first rib	0		
 1840	left second rib	0		
 1841	left third rib	0		
 1842	left fourth rib	0		
@@ -1856,7 +1856,7 @@
 1877	right tibia	0		
 1878	left fibula	0		
 1879	spinning right fibula	0		
-1880	bouncing fuchsia left kneecap	0		
+1880	fuchsia bouncing left kneecap	0		
 1881	upside-down right kneecap	0		
 1882	upside-down left first front claw	0		
 1883	left second front claw	0		
@@ -1893,7 +1893,7 @@
 1916	olive Lord Spookyraven's spectacles	0		
 1917	wallet	0		
 1918	coin purse	0		
-1919	blue blurry English to A. F. U. E. Dictionary	0		
+1919	blurry blue English to A. F. U. E. Dictionary	0		
 1920	bizarre illegible sheet music	0		
 1921	gray wakizashi of the early riser	0		Adventures: +7
 1922	gob of wet hair	0		
@@ -1923,14 +1923,14 @@
 1946	manspreader's occult accordion pin	0		Spell Damage Percent: +25, Monster Level: +10, Class: "Accordion Thief", Single Equip
 1947	huge careful worn tophat of the ox	0		Muscle: +20, Monster Level: -10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	grievous Newton's tap shoes	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Single Equip
-1949	diet stale pulsating Manetwich	1	decent	
+1949	stale diet pulsating Manetwich	1	decent	
 1950	green bottle of Vangoghbitussin	0		
 1951	acceptable bottle of Pinot Renoir	3	good	
 1952	flavorless desiccated apricot	4	decent	
-1953	weak smooth flute of flat champagne	2	awesome	
+1953	smooth weak flute of flat champagne	2	awesome	
 1954	decent pulsating dehydrated caviar	3	good	
 1955	styrofoam peanuts	0		
-1956	artisanal practically non-alcoholic snifter of thoroughly aged brandy	1	EPIC	
+1956	practically non-alcoholic artisanal snifter of thoroughly aged brandy	1	EPIC	
 1957	quill pen	0		
 1958	jittery spinning inkwell	0		
 1959	tattered scrap of paper	0		
@@ -1961,7 +1961,7 @@
 1984	snowy owl	0		
 1985	scary death orb	0		
 1986	blinking mind flayer	0		
-1987	blue wobbly undead elbow macaroni	0		
+1987	wobbly blue undead elbow macaroni	0		
 1988	angry cow	0		
 1989	blinking Cheshire bitten	0		
 1990	spinning yo-yo	0		
@@ -1984,7 +1984,7 @@
 2007	twirling Princess Rutabaga trading card	0		
 2008	blurry Roo trading card	0		
 2009	Woldo trading card	0		
-2010	green tumbling The Snake trading card	0		
+2010	tumbling green The Snake trading card	0		
 2011	jittery Nayztameetjoo trading card	0		
 2012	Arrrmetia trading card	0		
 2013	cyan Serenity trading card	0		
@@ -1998,9 +1998,9 @@
 2021	decent strawberry pie	4	good	
 2022	thick decent lemon meringue pie	5	good	
 2023	Genalen&trade; Bottle	1	crappy	
-2024	enchanted bland mixed wildflower greens	3	decent	Effect: "Crying, Dying", Effect Duration: 35
+2024	bland enchanted mixed wildflower greens	3	decent	Effect: "Crying, Dying", Effect Duration: 35
 2025	stale massive handful of walnuts	6	decent	
-2026	half-sized rotten nutty organic salad	2	crappy	
+2026	rotten half-sized nutty organic salad	2	crappy	
 2027	normal squat super salad	4	good	
 2028	spoiled tofu wonton	3	crappy	
 2029	shaking hippy protest button	0		Single Equip
@@ -2019,7 +2019,7 @@
 2042	pulsating exploding hacky-sack	0		
 2043	twirling hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	bland special small brain-meltingly-hot chicken wings	2	decent	Effect: "Full Bottle in front of Me", Effect Duration: 15
+2045	special small bland brain-meltingly-hot chicken wings	2	decent	Effect: "Full Bottle in front of Me", Effect Duration: 15
 2046	half-sized tasty frat brats	2	awesome	
 2047	moldy knob ka-bobs	4	crappy	
 2049	drinkable can of Swiller	4	good	
@@ -2027,10 +2027,10 @@
 2051	blurry sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
-2054	yellow squat market map	0		
+2054	squat yellow market map	0		
 2055	snake skin	0		
 2056	moist nitrogenated yellow blinking adder bladder	0		Effect: "Crud&eacute;", Effect Duration: 47
-2057	squat gray pension check	0		
+2057	gray squat pension check	0		
 2058	twirling picnic basket	0		
 2059	polarized anodized super-Vulcanized Black No. 2	0		Effect: "Gr8ness", Effect Duration: 50
 2060	nippy hardy sword	0		Maximum HP: +50, Cold Damage: +10
@@ -2076,21 +2076,21 @@
 2100	shredded can label	0		
 2101	bloodstained briquette	0		
 2102	greasy dreadlock	0		
-2103	skewed maroon vial of pirate sweat	0		
+2103	maroon skewed vial of pirate sweat	0		
 2104	empty aftershave bottle	0		
 2105	coal button	0		
 2106	burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
 2108	blurry rock	0		
-2109	ghostly spinning stringy sinew	0		Last Available: "2011-12"
+2109	spinning ghostly stringy sinew	0		Last Available: "2011-12"
 2110	stick	0		Last Available: "2011-12"
 2111	tooth	0		
 2112	leaf	0		Last Available: "2011-12"
 2113	Rosewater's wheel	0		Mysticality Percent: +30, Last Available: "2006-12"
-2114	wobbly skewed yo	0		Last Available: "2006-12"
+2114	skewed wobbly yo	0		Last Available: "2006-12"
 2115	jittery brawny prehistoric spear	0		Muscle Percent: +20, Last Available: "2006-12"
 2116	narrow stick-on-a-string	0		Last Available: "2006-12"
-2117	resourceful boxer's fire	0		Muscle Percent: +10, Maximum MP: +50, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	resourceful boxer's fire	0		Muscle Percent: +10, Maximum MP: +50, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	spinning lit cigar	0		Last Available: "2011-12"
 2120	blurry Grateful Undead T-shirt of the pedagogue	0		Experience: +3
@@ -2122,13 +2122,13 @@
 2147	evil teddy bear sewing kit	0		
 2148	spinning toothsome rock	0		
 2149	stale frank	3	decent	Last Available: "2011-12"
-2150	gigantic stale narrow plate of franks and beans	9	decent	Last Available: "2011-12"
+2150	stale gigantic narrow plate of franks and beans	9	decent	Last Available: "2011-12"
 2151	delicious shot of blackberry schnapps	3	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	blinking twirling carbon nanotube frame	0		Last Available: "2011-12"
 2154	teal bouncing ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
-2156	ghostly spinning logic synthesizer	0		Last Available: "2011-12"
+2156	spinning ghostly logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
@@ -2141,11 +2141,11 @@
 2166	spinning ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	cyan pulsating hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	ghostly smooth toy ray gun of the scaredy-cat	0		Moxie: +15, Monster Level: -15, Last Available: "2006-12"
-2169	miser's toy space helmet of Tarzan	0		Experience (Muscle): +3, Meat Drop: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	miser's toy space helmet of Tarzan	0		Experience (Muscle): +3, Meat Drop: +10, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	jittery MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	MacGyver's vibrating astronaut pants	0		Maximum MP Percent: +10, Maximum MP: +100, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	MacGyver's vibrating astronaut pants	0		Maximum MP Percent: +10, Maximum MP: +100, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	bouncing Sinatra's toy jet pack	0		Experience (Moxie): +5, Last Available: "2006-12"
-2173	bouncing blinking triangular stone	0		
+2173	blinking bouncing triangular stone	0		
 2174	mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	cracked stone sphere	0		
@@ -2153,24 +2153,24 @@
 2178	Van der Graaf obsidian dagger	0		MP Regen Min: 5, MP Regen Max: 7
 2179	fuchsia archaeologist's notebook	0		
 2180	teal amulet	0		
-2181	narrow blue upside-down chocolate lump	0		Last Available: "2011-12"
-2182	jittery narrow Harold's hammer head	0		
+2181	upside-down narrow blue chocolate lump	0		Last Available: "2011-12"
+2182	narrow jittery Harold's hammer head	0		
 2183	Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	coward's Kiss the Knob apron	0		Monster Level: -20
 2186	pulsating olive unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	awesome	Last Available: "2006-12"
-2189	aged bouncing jittery flask of peppermint schnapps	4	awesome	Last Available: "2006-12"
+2189	aged jittery bouncing flask of peppermint schnapps	4	awesome	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	blue book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	moldy gigantic upside-down candy stake	10	crappy	Last Available: "2006-12"
+2193	gigantic moldy upside-down candy stake	10	crappy	Last Available: "2006-12"
 2194	tolerable yellow eggnog	3	good	Last Available: "2006-12"
 2195	bland immense unspeakable fruitcake	7	decent	Last Available: "2006-12"
-2196	special stale gingerbread horror	4	decent	Effect: "Sleazy Hands", Effect Duration: 5, Last Available: "2006-12"
+2196	stale special gingerbread horror	4	decent	Effect: "Sleazy Hands", Effect Duration: 5, Last Available: "2006-12"
 2197	anodized narrow but probably evil chocolate	0		Effect: "Winning Smile", Effect Duration: 62, Last Available: "2006-12"
-2198	snack-sized spoiled bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	spoiled snack-sized bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	moldy skull-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	adequate red tombstone-shaped Crimboween cookie	4	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	ruddy plastic gift-wrapping vampire	0		Maximum HP Percent: +40, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	purple narrow boxer's Crimbo tiki necklace	0		Muscle Percent: +10, Last Available: "2006-12"
 2208	lightning-fast brainy bobble-hip hula elf doll	0		Mysticality: +5, Initiative: +40, Last Available: "2006-12"
 2209	extremely unsafe Crimbo ukulele	0		Weapon Damage Percent: +100, Last Available: "2006-12"
-2210	savvy Tiki lighter of mayonnaise	0		Mysticality Percent: +20, Sleaze Spell Damage: +50, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	supercool deck of tropical cards of the blizzard	0		Moxie Percent: +20, Cold Spell Damage: +25, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	lard-coated banded tropical paperweight	0		Damage Absorption: +100, Sleaze Spell Damage: +25, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	savvy Tiki lighter of mayonnaise	0		Mysticality Percent: +20, Sleaze Spell Damage: +50, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	supercool deck of tropical cards of the blizzard	0		Moxie Percent: +20, Cold Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	lard-coated banded tropical paperweight	0		Damage Absorption: +100, Sleaze Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	shaking Jim Carey's Tropical Crimbo Hat	0		Monster Level: +25, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	fuchsia ribald Tropical Crimbo Shorts	0		Sleaze Damage: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	shaking Jim Carey's Tropical Crimbo Hat	0		Monster Level: +25, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	fuchsia ribald Tropical Crimbo Shorts	0		Sleaze Damage: +10, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	toothsome jumbo super ka-bob	5	awesome	
 2218	stale huge blurry beer basted brat	7	decent	
 2219	brawny Tropical Crimbo Sword	0		Muscle Percent: +20, Last Available: "2006-12"
 2220	frozen huge and Crimboween candy	0		Effect: "Virgo Rising", Effect Duration: 46, Last Available: "2020-09"
 2221	jittery Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	red skewed Usain Bolt's fireproof liar's pants	0		Hot Resistance: +3, Initiative: +80, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	red skewed Usain Bolt's fireproof liar's pants	0		Hot Resistance: +3, Initiative: +80, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	resourceful medical-grade juggler's balls	0		Maximum MP: +50, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2007-01"
 2224	chaotic pink shirt	0		Spell Critical Percent: +10, Softcore Only, Last Available: "2007-01"
 2225	wobbly familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2236,7 +2236,7 @@
 2262	bouncing bird rib	0		
 2263	huge lion oil	0		
 2264	rotten stunt nuts	3	crappy	
-2265	miniature stale maroon wet stew	2	decent	
+2265	stale miniature maroon wet stew	2	decent	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Tesla Staff of Fats	0		MP Regen Min: 7, MP Regen Max: 10
@@ -2244,8 +2244,8 @@
 2270	supercool belt of mayonnaise	0		Moxie Percent: +20, Sleaze Spell Damage: +50, Single Equip
 2271	acceptable narrow bottle of Merlot	3	good	
 2272	drinkable pulsating bottle of Port	4	good	
-2273	smooth weak bottle of Pinot Noir	2	awesome	
-2274	high-proof drinkable bottle of Zinfandel	8	good	
+2273	weak smooth bottle of Pinot Noir	2	awesome	
+2274	drinkable high-proof bottle of Zinfandel	8	good	
 2275	boozy delicious bottle of Marsala	5	awesome	
 2276	mediocre bottle of Muscat	4	decent	
 2277	Fernswarthy's key	0		
@@ -2278,12 +2278,12 @@
 2304	electrified frozen candy heart	0		Effect: "Adapt to Change Eventually", Effect Duration: 51, Last Available: "2007-02"
 2305	pressed pink candy heart	0		Effect: "Sweet Nostalgia", Effect Duration: 19, Last Available: "2007-02"
 2306	unsweetened polymerized candy heart	0		Effect: "You Know What's Up", Effect Duration: 33, Last Available: "2007-02"
-2307	non-enhanced squat purple candy heart	0		Effect: "Fury of the Bells", Effect Duration: 32, Last Available: "2007-02"
+2307	non-enhanced purple squat candy heart	0		Effect: "Fury of the Bells", Effect Duration: 32, Last Available: "2007-02"
 2308	deionized candy heart	0		Effect: "Sweet and Yellow", Effect Duration: 30, Last Available: "2007-02"
 2309	colloidal candy heart	0		Effect: "Feet of Grapefruit", Effect Duration: 42, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
-2312	blurry cyan squat candygram	0		Last Available: "2007-02"
+2312	squat blurry cyan candygram	0		Last Available: "2007-02"
 2313	candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
@@ -2302,19 +2302,19 @@
 2328	lime green drum machine	0		
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
-2331	blinking skewed bouquet of circular saw blades	0		
+2331	skewed blinking bouquet of circular saw blades	0		
 2332	normal Better Than Cuddling Cake	3	good	
 2333	narrow mirror ninja snowman	0		
 2334	Holy MacGuffin	0		
-2335	cyan narrow rubber WWBBDD? bracelet	0		
+2335	narrow cyan rubber WWBBDD? bracelet	0		
 2336	upside-down nippy razor-sharp pipe	0		Weapon Damage Percent: +25, Cold Damage: +10
 2337	reinforced beaded headband of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	adequate snack-sized blurry pudding	2	good	Wiki Name: "black pudding (food)"
-2339	fancy acceptable weak wobbly Blackfly Chardonnay	2	good	Effect: "Wintry Breath", Effect Duration: 5
+2338	snack-sized adequate blurry pudding	2	good	Wiki Name: "black pudding (food)"
+2339	weak fancy acceptable wobbly Blackfly Chardonnay	2	good	Effect: "Wintry Breath", Effect Duration: 5
 2340	mediocre twirling & tan	3	decent	
 2341	pepper	0		
-2342	small rotten forest cake	2	crappy	
-2343	half-sized spoiled forest ham	2	crappy	
+2342	rotten small forest cake	2	crappy	
+2343	spoiled half-sized forest ham	2	crappy	
 2344	liquefied activated filthworm hatchling scent gland	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 15
 2345	triple-altered alkaline adjusted blinking ghostly filthworm drone scent gland	0		Effect: "Prince of Seaside Town", Effect Duration: 54
 2346	pressed jittery filthworm royal guard scent gland	0		Effect: "Grape Expectations", Effect Duration: 56
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	jittery bunch of bananas	0		
-2373	half-sized flavorless banana	2	decent	
+2373	flavorless half-sized banana	2	decent	
 2374	banana peel	0		
-2375	rotten big banana cream pie	5	crappy	
+2375	big rotten banana cream pie	5	crappy	
 2376	bad red banana daiquiri	3	decent	
 2377	mediocre huge bungle in the jungle	4	decent	
 2378	banana spritzer	0		
@@ -2390,7 +2390,7 @@
 2416	shaking bounty-hunting helmet of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1.5xFairy, cap 25"
 2417	jittery hale bounty-hunting rifle	0		Maximum HP: +20
 2418	pulsating smelly bounty-hunting pants	0		Stench Spell Damage: +10, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	super-altered purple upside-down bottle of rhinoceros hormones	0		Effect: "Stogied", Effect Duration: 60
+2419	super-altered upside-down purple bottle of rhinoceros hormones	0		Effect: "Stogied", Effect Duration: 60
 2420	moist quantum bouncing teeny-tiny magic scroll	0		Effect: "Livin' Large", Effect Duration: 17
 2421	polymerized blinking bottle of pirate juice	0		Effect: "Disco Concentration", Effect Duration: 20
 2422	magnetized pulsating irradiated pet snacks	0		Effect: "Eldritch Concentration", Effect Duration: 22
@@ -2403,8 +2403,8 @@
 2429	cold-filtered Eau de Guaneau	0		Effect: "Polar Express", Effect Duration: 34
 2430	polarized unsweetened bag of lard	0		Effect: "Human-Human Hybrid", Effect Duration: 35
 2431	triple-cold-filtered alkaline bottle of Mystic Shell	0		Effect: "Took Eleven", Effect Duration: 49
-2432	anodized modified twirling red SPF 451 lip balm	0		Effect: "Taurus Rising", Effect Duration: 41
-2433	altered quadruple-flattened bouncing squat bottle of antifreeze	0		Effect: "You Liver", Effect Duration: 15
+2432	anodized modified red twirling SPF 451 lip balm	0		Effect: "Taurus Rising", Effect Duration: 41
+2433	altered quadruple-flattened squat bouncing bottle of antifreeze	0		Effect: "You Liver", Effect Duration: 15
 2434	frozen red eyedrops	0		Effect: "Once Bitten Twice Fried", Effect Duration: 61
 2435	quantum concentrated Dogsgotnonoz pills	0		Effect: "Cool, Catlike", Effect Duration: 14
 2436	warmed cold-filtered modified fuchsia donkey flipbook	0		Effect: "Bone Homie", Effect Duration: 43
@@ -2435,12 +2435,12 @@
 2462	cyan odor extractor	0		Last Available: "2019-12"
 2463	wobbly Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	rotten bite-sized blurry bowl of Bounty-Os	1	crappy	
-2465	aged practically non-alcoholic bouncing Oreille Divis&eacute;e brandy	1	awesome	
+2465	practically non-alcoholic aged bouncing Oreille Divis&eacute;e brandy	1	awesome	
 2466	gray pompadour'd puppy	0		
 2467	shaking wobbly suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	bundle of receipts	0		
-2470	jittery squat cork	0		
+2470	squat jittery cork	0		
 2471	pulsating stardust	0		
 2472	upside-down wilted lettuce	0		
 2473	empty greasepaint tube	0		
@@ -2476,12 +2476,12 @@
 2503	purple extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	necklace chain	0		
-2506	squat red beach glass bead	0		
+2506	red squat beach glass bead	0		
 2507	tumbling huge clay peace-sign bead	0		
 2508	beach glass necklace of the detective	0		Item Drop: +20
 2509	beefy peace-sign necklace	0		Muscle: +10
 2510	banded round sunglasses of the glutton	0		Damage Absorption: +100, Food Drop: +100, Single Equip
-2511	wobbly maroon Frat Army FGF	0		
+2511	maroon wobbly Frat Army FGF	0		
 2512	Hippy Army MPE	0		
 2513	Herculean smartaleck's spark plug earring	0		Moxie Percent: +30, Experience (Muscle): +1
 2514	experienced woven baling wire bracelets of vim and vigor	0		Experience: +2, Maximum HP Percent: +50
@@ -2489,21 +2489,21 @@
 2516	supercharged wrench bracelet of Leguizamo	0		Maximum MP Percent: +30, Monster Level: +20
 2517	reassuring chain necklace of the pedagogue	0		Experience: +3, Spooky Resistance: +1
 2518	lime green upside-down family-friendly sawblade shield	0		Sleaze Resistance: +1, Damage Reduction: 11
-2519	practically non-alcoholic bad McMillicancuddy's Special Lager	1	decent	
+2519	bad practically non-alcoholic McMillicancuddy's Special Lager	1	decent	
 2520	watered-down perfectly mixed melted Jell-o shot	2	EPIC	
 2521	acceptable fortified cruelty-free wine	5	good	
 2522	hand-crafted thistle wine	4	EPIC	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	rotten cyan spinning spinning fish	3	crappy	
+2525	rotten spinning spinning cyan fish	3	crappy	
 2526	bland fish casserole	3	decent	
-2527	spoiled special fish lasagna	3	crappy	Effect: "Fitter, Happier", Effect Duration: 30
+2527	special spoiled fish lasagna	3	crappy	Effect: "Fitter, Happier", Effect Duration: 30
 2528	yellow filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	normal gnatloaf	3	good	
 2530	normal gnatloaf casserole	4	good	
 2531	flavorless gnat lasagna	3	decent	
 2532	pork	0		
-2533	moldy miniature fancy pork chop sandwiches	2	crappy	Effect: "Sated and Furious", Effect Duration: 40
+2533	fancy miniature moldy pork chop sandwiches	2	crappy	Effect: "Sated and Furious", Effect Duration: 40
 2534	moldy pork casserole	4	crappy	
 2535	decent fancy yellow pork lasagna	4	good	Effect: "Gummi Badass", Effect Duration: 10
 2536	canopic jar	0		
@@ -2518,7 +2518,7 @@
 2545	non-denatured alkaline upsy daisy	0		Effect: "Hennaliciousness", Effect Duration: 20, Last Available: "2007-05"
 2546	denatured shaking half-orchid	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 47, Last Available: "2007-05"
 2547	miser's dangerous tin star	0		Weapon Damage: +10, Meat Drop: +10, Last Available: "2007-05"
-2548	blurry careful thinker's outrageous sombrero	0		Mysticality: +10, Monster Level: -10, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	blurry careful thinker's outrageous sombrero	0		Mysticality: +10, Monster Level: -10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	pulsating therapeutic quilted &quot;Humorous&quot; T-shirt	0		Damage Absorption: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	upside-down vial of mojo	0		
@@ -2541,7 +2541,7 @@
 2568	Azazel's tutu	0		
 2569	flattened ant agonist	0		Effect: "Punch Another Day", Effect Duration: 52
 2570	upside-down ant hoe	0		Familiar Effect: "sleaze damage, meat"
-2571	ghostly twirling ant rake	0		Familiar Effect: "hot damage, meat"
+2571	twirling ghostly ant rake	0		Familiar Effect: "hot damage, meat"
 2572	shaking ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	jittery ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	tumbling ant pick	0		Familiar Effect: "cold damage, meat"
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	resourceful cactus quill of the empath	0		Maximum MP: +50, Familiar Weight: +5
 2578	smooth beefy Staff of the Short Order Cook of the scaredy-cat	0		Muscle: +10, Moxie: +15, Monster Level: -15
-2579	bland big bouncing cactus fruit	5	decent	
+2579	big bland bouncing cactus fruit	5	decent	
 2580	personal trainer's experienced scorpion whip	0		Experience: +2, Experience Percent (Muscle): +10
 2581	handful of sand	0		
 2582	brick of sand	0		
@@ -2564,7 +2564,7 @@
 2591	snack-sized toothsome tasty tart	2	awesome	
 2592	Knob Goblin lunchbox	0		
 2593	half-sized stale Knob pasty	2	decent	
-2594	weak smooth thermos full of Knob coffee	2	awesome	
+2594	smooth weak thermos full of Knob coffee	2	awesome	
 2595	energized blurry Ben-Gal&trade; Balm	0		Effect: "Infernal Thirst", Effect Duration: 24
 2596	pulsating leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2628,12 +2628,12 @@
 2655	super-cold-filtered bottle of absinthe	0		Effect: "Salt Rockin'", Effect Duration: 37, Last Available: "2007-06"
 2656	stanky Tesla Drowsy Sword	0		Stench Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10
 2657	bland escargotsicle	4	decent	Last Available: "2007-06"
-2658	watered-down tolerable bottle of realpagne	2	good	Last Available: "2007-06"
+2658	tolerable watered-down bottle of realpagne	2	good	Last Available: "2007-06"
 2659	stiffened albatross necklace	0		Damage Reduction: 1, Single Equip, Last Available: "2007-06"
 2660	distilled not-a-pipe	1	good	Last Available: "2007-06"
 2661	weak bad flask of Amontillado	2	decent	Last Available: "2007-06"
-2662	twirling smooth ball mask	0		Moxie: +15, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	Jack Frost's Can-Can skirt	0		Cold Spell Damage: +50, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	twirling smooth ball mask	0		Moxie: +15, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	Jack Frost's Can-Can skirt	0		Cold Spell Damage: +50, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	denatured sensitive poetry journal	0		Effect: "Jerky, Boy", Effect Duration: 25, Last Available: "2007-06"
 2665	triple-oxidized purple bottled inspiration	0		Effect: "Barbecue Saucy", Effect Duration: 65, Last Available: "2007-06"
 2666	double-warmed anodized ghostly bellhop bell	0		Effect: "Unrunnable Face", Effect Duration: 56, Last Available: "2007-06"
@@ -2645,7 +2645,7 @@
 2672	teal skewed library card	0		Last Available: "2007-06"
 2673	ghostly Bohemian rhapsody	0		Last Available: "2007-06"
 2674	alkaline double-wet dry olive bottle of cat tonic	0		Effect: "Coated Arms", Effect Duration: 21, Last Available: "2007-06"
-2675	modified pulsating skewed handful of moss	1		Effect: "The Wisdom... of the Future", Effect Duration: 15
+2675	modified skewed pulsating handful of moss	1		Effect: "The Wisdom... of the Future", Effect Duration: 15
 2676	diluted bit-o-cactus	1		
 2677	boiled protein powder	1		
 2678	spectre scepter	0		
@@ -2681,7 +2681,7 @@
 2708	colloidal funky dried mushroom	0		Effect: "Space Tripping", Effect Duration: 35
 2709	shaking exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
-2711	modified activated narrow huge facepaint	0		Effect: "Muddled", Effect Duration: 18
+2711	modified activated huge narrow facepaint	0		Effect: "Muddled", Effect Duration: 18
 2712	electrified denatured sheepskin diploma	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 39
 2713	frozen triple-irradiated Black Body&trade; spray	0		Effect: "Billiards Belligerence", Effect Duration: 57
 2714	floorboard cruft	0		
@@ -2697,16 +2697,16 @@
 2724	massive normal ghostly bowl of rye sprouts	7	good	
 2725	rotten cob of corn	3	crappy	
 2726	moldy jittery juniper berries	3	crappy	
-2727	snack-sized adequate plum	2	good	
-2728	immense rotten squat pear	10	crappy	
+2727	adequate snack-sized plum	2	good	
+2728	rotten immense squat pear	10	crappy	
 2729	small rotten yellow peach	2	crappy	
 2730	artisanal plum wine	3	EPIC	
-2731	practically non-alcoholic hand-crafted shot of pear schnapps	1	EPIC	
-2732	special drinkable shaking shot of peach schnapps	3	good	Effect: "Eyes of the Dragon", Effect Duration: 25
+2731	hand-crafted practically non-alcoholic shot of pear schnapps	1	EPIC	
+2732	drinkable special shaking shot of peach schnapps	3	good	Effect: "Eyes of the Dragon", Effect Duration: 25
 2733	bland huge bunch of square grapes	4	decent	
 2734	spoiled brown sugar cane	3	crappy	
 2735	decent tiny sandwich of the gods	1	good	
-2736	high-proof hand-crafted spinning Pan-Dimensional Gargle Blaster	7	EPIC	
+2736	hand-crafted high-proof spinning Pan-Dimensional Gargle Blaster	7	EPIC	
 2737	boiled leopard-print barbell	1	good	
 2738	jittery pile of smoking rags	0		
 2739	colloidal panty raider camouflage	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 23
@@ -2776,11 +2776,11 @@
 2803	jug of Gnomochloric acid	0		
 2804	wet altered vial of hamethyst juice	0		Effect: "Capricorn Rising", Effect Duration: 59
 2805	corrupted polymerized mirror vial of baconstone juice	0		Effect: "Educated (Sorta)", Effect Duration: 21
-2806	ionized purple spinning vial of porquoise juice	0		Effect: "OMG WTF", Effect Duration: 59
+2806	ionized spinning purple vial of porquoise juice	0		Effect: "OMG WTF", Effect Duration: 59
 2807	electrified spinning flask of hamethyst juice	0		Effect: "Sweet, Nuts", Effect Duration: 39
 2808	altered teal jittery flask of baconstone juice	0		Effect: "One For Tea", Effect Duration: 51
 2809	non-warmed flask of porquoise juice	0		Effect: "Gunky Dory", Effect Duration: 35
-2810	diffused polarized huge blurry jug of hamethyst juice	0		Effect: "Patience of the Tortoise", Effect Duration: 21
+2810	diffused polarized blurry huge jug of hamethyst juice	0		Effect: "Patience of the Tortoise", Effect Duration: 21
 2811	oxidized colloidal twirling jug of baconstone juice	0		Effect: "Permanent Halloween", Effect Duration: 59
 2812	aerosolized activated jug of porquoise juice	0		Effect: "You Drank Fish Wine", Effect Duration: 39
 2813	lard-coated Beret of the glutton	0		Sleaze Spell Damage: +25, Food Drop: +100, Four Songs, Familiar Effect: "1xVolley, 1xLep"
@@ -2789,9 +2789,9 @@
 2816	ghostly asbestos-lined friendly padded Boxers	0		Damage Absorption: +20, Familiar Weight: +3, Hot Resistance: +5, Familiar Effect: "1xVolley, 1xLep"
 2817	teal Van der Graaf baleful Brooch of Flo-Jo	0		Spell Damage: +25, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2818	flame-retardant Bracelet of temperance of the early riser	0		Hot Resistance: +1, Sleaze Resistance: +5, Adventures: +7, Single Equip
-2819	olive sizzling Grimacite gasmask of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	olive sizzling Grimacite gasmask of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	greedy Grimacite gat of the cougar	0		Moxie: +20, Meat Drop: +20, Last Available: "2008-11"
-2821	savvy Grimacite gaiters of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	savvy Grimacite gaiters of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	Rosewater's Grimacite gauntlets of vim and vigor	0		Mysticality Percent: +30, Maximum HP Percent: +50, Single Equip, Last Available: "2008-11"
 2823	squat executive sage Grimacite go-go boots	0		Mysticality Percent: +10, Meat Drop: +40, Single Equip, Last Available: "2008-11"
 2824	auspicious Newton's Grimacite girdle	0		Experience (Mysticality): +3, Item Drop: +10, Single Equip, Last Available: "2008-11"
@@ -2802,8 +2802,8 @@
 2829	really dense meat stack	0		
 2830	twirling mirror digital key lime	0		
 2831	twirling star key lime	0		
-2832	tiny normal digital key lime pie	1	good	
-2833	super-sized spoiled maroon star key lime pie	5	crappy	
+2832	normal tiny digital key lime pie	1	good	
+2833	spoiled super-sized maroon star key lime pie	5	crappy	
 2834	steel-toed Newton's bottle-rocket crossbow of the empath	0		Experience (Mysticality): +3, Damage Reduction: 9, Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	stylish indie comic hipster glasses	0		Moxie: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2811,8 +2811,8 @@
 2838	teal twirling forbidden beefy glowstick	0		Muscle: +10, Spell Damage Percent: +50, Last Available: "2007-08"
 2839	Periodical Paintbrush of the dark arts	0		Spell Damage Percent: +100, Softcore Only
 2840	perfectly mixed bottle of cooking sherry	3	EPIC	
-2841	rotten ghostly spinning packet of ketchup	4	crappy	
-2842	practically non-alcoholic tolerable accidental cider	1	good	
+2841	rotten spinning ghostly packet of ketchup	4	crappy	
+2842	tolerable practically non-alcoholic accidental cider	1	good	
 2843	normal dire fudgesicle	3	good	
 2844	spinning purple scorching navel ring of navel gazing of the wise owl of the businessman of the glutton	0		Mysticality: +20, Hot Damage: +25, Meat Drop: +50, Food Drop: +100, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2826,14 +2826,14 @@
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	asbestos-lined huge mosquito proboscis of the boozehound	0		Hot Resistance: +5, Booze Drop: +100
-2856	enhanced jittery olive swamp lolly	0		Effect: "Balls of Ectoplasm", Effect Duration: 32
+2856	enhanced olive jittery swamp lolly	0		Effect: "Balls of Ectoplasm", Effect Duration: 32
 2857	triple-concentrated adjusted seegar butt	0		Effect: "Gummiheart", Effect Duration: 57
 2858	bottled swamp gas	0		
 2859	chilly slick witch wart	0		Moxie: +10, Cold Damage: +5
 2860	stale swamp muck	4	decent	
 2861	squat ruddy extremely unsafe leechknife of the scaredy-cat	0		Weapon Damage Percent: +100, Maximum HP Percent: +40, Monster Level: -15
 2862	decomposed boot	0		
-2863	anodized diffused pulsating huge dribbly candle	0		Effect: "Poker Faced", Effect Duration: 49
+2863	anodized diffused huge pulsating dribbly candle	0		Effect: "Poker Faced", Effect Duration: 49
 2864	twirling stolen meatpouch	0		
 2865	cyan lightning-fast therapeutic beaver spear	0		Initiative: +40, HP Regen Min: 5, HP Regen Max: 7
 2866	blue quilted shamanic beads of Flo-Jo	0		Damage Absorption: +40, Initiative: +100
@@ -2916,8 +2916,8 @@
 2943	ionized Angry Farmer's Wife Candy	0		Effect: "Oth-Jeal-O", Effect Duration: 16
 2945	maroon fireproof party hat of Leguizamo	0		Monster Level: +20, Hot Resistance: +3, Familiar Effect: "4xLep, cap 7"
 2946	fuchsia auspicious arcane researcher's V for Vivala mask	0		Experience Percent (Mysticality): +10, Item Drop: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
-2947	pulsating twirling The Big Book of Pirate Insults	0		
-2948	aged weak shot of rotgut	2	awesome	
+2947	twirling pulsating The Big Book of Pirate Insults	0		
+2948	weak aged shot of rotgut	2	awesome	
 2949	cold-filtered magnetized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 45
 2950	upside-down Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2929,7 +2929,7 @@
 2957	blurry rum barrel charrrm	0		
 2958	spoiled huge tube of cranberry Go-Goo	4	crappy	
 2959	hardy rum barrel charrrm bracelet	0		Maximum HP: +50
-2960	diet spoiled single-serving herbal stuffing	1	crappy	
+2960	spoiled diet single-serving herbal stuffing	1	crappy	
 2961	stale packet of tofurkey gravy	3	decent	
 2962	gigantic decent green tofurkey nugget	9	good	
 2963	tumbling rigging shampoo	0		
@@ -2962,7 +2962,7 @@
 2990	jittery grievous slick clingfilm cap	0		Moxie: +10, Weapon Damage Percent: +50, Familiar Effect: "1xVolley, cap 37"
 2991	blinking hale clingfilm slippers	0		Maximum HP: +20, Single Equip
 2992	clingfilm tangle	0		
-2993	adequate miniature vinegar-soaked lemon slice	2	good	
+2993	miniature adequate vinegar-soaked lemon slice	2	good	
 2994	pressed triple-modified cyan true grit	0		Effect: "A Few Extra Pounds", Effect Duration: 43
 2995	spinning gravedigger's resourceful wicked buoybottoms	0		Spell Damage: +5, Maximum MP: +50, Spooky Damage: +10, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	lion tamer's grungy flannel shirt	0		Experience (familiar): +2
@@ -2996,7 +2996,7 @@
 3024	upside-down stone pyramid	0		
 3025	smooth corpse on the beach	3	awesome	
 3026	aged corpsetini	3	awesome	
-3027	weak drinkable corpsedriver	2	good	
+3027	drinkable weak corpsedriver	2	good	
 3028	practically non-alcoholic drinkable Corpse Island iced tea	1	good	
 3029	artisanal red-headed corpse	3	EPIC	
 3030	delicious yellow kamicorpse-ee	3	awesome	
@@ -3010,14 +3010,14 @@
 3038	mediocre bottle of black-label rum	4	decent	
 3039	cannonball	0		
 3040	voodoo skull	0		
-3041	twirling teal joke scroll	0		
+3041	teal twirling joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
-3043	lime green narrow metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3043	narrow lime green metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	massive normal squat nanite-infested gingerbread bugbear	9	good	Last Available: "2007-12"
-3046	miniature spoiled nanite-infested candy cane	2	crappy	Last Available: "2020-09"
+3046	spoiled miniature nanite-infested candy cane	2	crappy	Last Available: "2020-09"
 3047	spoiled nanite-infested fruitcake	3	crappy	Last Available: "2007-12"
-3048	watered-down aged nanite-infested eggnog	2	awesome	Last Available: "2007-12"
+3048	aged watered-down nanite-infested eggnog	2	awesome	Last Available: "2007-12"
 3049	squat El Vibrato power sphere	0		
 3050	pulsating lime green eyepatch of the businessman	0		Meat Drop: +50, Familiar Effect: "spooky atk, 1xBarrr"
 3051	slick cutlass	0		Moxie: +10
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	denatured activated galvanized spinning candy heart	0		Effect: "Human-Human Hybrid", Effect Duration: 35, Last Available: "2007-02"
 3055	quadruple-pressed vacuum-sealed cymbal syrup	0		Free Pull, Effect: "Optimist Primal", Effect Duration: 54, Last Available: "2007-02"
-3056	strapping metallic foil cat ears	0		Muscle: +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	strapping metallic foil cat ears	0		Muscle: +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	skewed nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	coward's extremely unsafe roboduck-on-a-string	0		Weapon Damage Percent: +100, Monster Level: -20, Last Available: "2007-12"
 3086	olive squat mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	forbidden brawny biomechanical crimborg helmet	0		Muscle Percent: +20, Spell Damage Percent: +50, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	forbidden brawny biomechanical crimborg helmet	0		Muscle Percent: +20, Spell Damage Percent: +50, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	resourceful baleful C.B.F.G.	0		Spell Damage: +25, Maximum MP: +50, Last Available: "2007-12"
-3090	Sherlock's chaotic biomechanical crimborg leg armor	0		Spell Critical Percent: +10, Item Drop: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	Sherlock's chaotic biomechanical crimborg leg armor	0		Spell Critical Percent: +10, Item Drop: +25, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	alkaline mirror vitachoconutriment capsule	0		Effect: "Demonic Taint", Effect Duration: 64, Last Available: "2007-12"
 3092	quilted handmade hobby horse	0		Damage Absorption: +40, Last Available: "2007-12"
 3093	spinning bouncing ball-in-a-cup of the empath	0		Familiar Weight: +5, Last Available: "2007-12"
@@ -3098,9 +3098,9 @@
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	squat marshmallow	0		
-3129	spoiled ghostly mirror roasted marshmallow	3	crappy	
+3129	spoiled mirror ghostly roasted marshmallow	3	crappy	
 3130	disc	0		Last Available: "2008-01"
-3131	diet rotten tin cup of mulligan stew	1	crappy	
+3131	rotten diet tin cup of mulligan stew	1	crappy	
 3132	olive healthy flamin' bindle of extreme caution	0		Maximum HP Percent: +20, Monster Level: -25
 3133	mirror steel-toed sinister freezin' bindle	0		Spell Damage: +10, Damage Reduction: 9
 3134	blurry Jeselnik's stinkin' bindle of the early riser	0		Sleaze Damage: +25, Adventures: +7
@@ -3128,7 +3128,7 @@
 3156	upside-down El Vibrato punchcard (104 holes)	0		
 3157	mirror El Vibrato drone	0		
 3158	squat sparking El Vibrato drone	0		
-3159	double-corrupted ghostly mirror warm El Vibrato drone	0		Effect: "Radiated and Grodiated", Effect Duration: 44
+3159	double-corrupted mirror ghostly warm El Vibrato drone	0		Effect: "Radiated and Grodiated", Effect Duration: 44
 3160	magnetized nitrogenated narrow humming El Vibrato drone	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 29
 3161	wet oxidized El Vibrato drone	0		Effect: "You Know When to Walk Away", Effect Duration: 42
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
@@ -3138,18 +3138,18 @@
 3166	repaired El Vibrato drone	0		
 3167	cyan augmented El Vibrato drone	0		
 3168	super-energized wet seal eyeball	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 51
-3169	small flavorless turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	flavorless small turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	ghostly Fonzie's evil paper umbrella	0		Experience (Moxie): +1
 3173	oxidized ionized evil vihuela	0		Effect: "Ogred and Oublietted", Effect Duration: 67
-3174	gigantic fancy decent evil boring spaghetti	9	good	Effect: "Coated Arms", Effect Duration: 15
-3175	flavorless big evil noodles	5	decent	
+3174	fancy gigantic decent evil boring spaghetti	9	good	Effect: "Coated Arms", Effect Duration: 15
+3175	big flavorless evil noodles	5	decent	
 3176	adequate evil noodles	3	good	
 3177	normal evil painful penne pasta	3	good	
 3178	spoiled 3vi1 pr0n m4nic0tti	4	crappy	
 3179	decent wobbly evil ravioli della hippy	3	good	
-3180	bite-sized rotten evil noodles	1	crappy	
+3180	rotten bite-sized evil noodles	1	crappy	
 3181	activated super-modified evil potion of potency	0		Effect: "Heart of Green", Effect Duration: 51
 3182	flattened evil libation of liveliness	0		Effect: "Hiding in Plain Sight", Effect Duration: 39
 3183	flattened flattened tumbling evil tomato juice of powerful power	0		Effect: "Ginger Snapped", Effect Duration: 66
@@ -3157,7 +3157,7 @@
 3185	denatured unsweetened blinking evil ointment of the occult	0		Effect: "Memory of Speed", Effect Duration: 32
 3186	extra-energized moist evil serum of sarcasm	0		Effect: "Boilermade", Effect Duration: 40
 3187	pickled evil philter of phorce	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 31
-3188	tolerable high-proof spinning wobbly an evil sump'm sump'm	6	good	
+3188	tolerable high-proof wobbly spinning an evil sump'm sump'm	6	good	
 3189	lousy evil ducha de oro	3	decent	
 3190	mediocre evil horizontal tango	3	decent	
 3191	lousy evil roll in the hay	4	decent	
@@ -3201,7 +3201,7 @@
 3229	huge decaying goldfish liver	0		
 3230	magnetized blurry oil of oiliness	0		Effect: "Hair on Your Chest", Effect Duration: 44
 3231	wobbly tattered paper crown of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xSombrero, cap 15"
-3232	rotten snack-sized vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
+3232	snack-sized rotten vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	lime green skewed water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3238,7 +3238,7 @@
 3266	bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	super-ionized fuchsia handful of Crotchety Pine needles	0		Effect: "Memories of Puppy Love", Effect Duration: 67
-3269	flattened activated teal mirror lump of Saccharine Maple sap	0		Effect: "Flashing Eyes", Effect Duration: 65
+3269	flattened activated mirror teal lump of Saccharine Maple sap	0		Effect: "Flashing Eyes", Effect Duration: 65
 3270	magnetized handful of Laughing Willow bark	0		Effect: "Swimming Head", Effect Duration: 34
 3271	groovy crotchety pants	0		Moxie Percent: +10, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	Saccharine Maple pendant of mayonnaise	0		Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Spray Sap"
@@ -3261,7 +3261,7 @@
 3289	scintillating powder	0		Class: "Pastamancer"
 3290	huge abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
-3292	blinking red adorable seal larva	0		
+3292	red blinking adorable seal larva	0		
 3293	gray untamable turtle	0		
 3294	macaroni duck	0		
 3295	red friendly cheez blob	0		
@@ -3307,29 +3307,29 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	mirror dead guy's piece of double-sided tape	0		
 3337	upside-down careful Tesla dead guy's memento	0		Monster Level: -10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-3338	adequate small banquet	2	good	
+3338	small adequate banquet	2	good	
 3339	sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	upside-down hobo monkey	0		
 3343	wobbly bindle	0		Familiar Weight: +5
-3344	red narrow bed of coals	0		
+3344	narrow red bed of coals	0		
 3345	air mattress	0		
 3346	filth-encrusted futon	0		
 3347	olive comfy coffin	0		
-3348	blurry huge mattress	0		
+3348	huge blurry mattress	0		
 3349	dinged-up triangle	0		
 3350	distilled artisanal jittery Ralph IX cognac	5	super ultra mega turbo EPIC	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	narrow zen motorcycle	0		Last Available: "2008-06"
 3353	galvanized super-nitrogenated polarized mirror llama lama gong	0		Effect: "Shawarma Warm War", Effect Duration: 23, Last Available: "2008-06"
-3354	super-sized spoiled banana-frosted king cake	5	crappy	Last Available: "2008-08"
+3354	spoiled super-sized banana-frosted king cake	5	crappy	Last Available: "2008-08"
 3355	Usain Bolt's brown plastic baby	0		Initiative: +80, Single Equip, Last Available: "2008-08"
 3356	bouncing plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	scrumptious ice ant	0		Last Available: "2008-06"
-3360	shaking yellow stinkbug	0		Last Available: "2008-06"
+3360	yellow shaking stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	blue tasty louse	0		Last Available: "2008-06"
 3363	toothsome wobbly mole mol&eacute;	4	awesome	Last Available: "2008-06"
@@ -3342,13 +3342,13 @@
 3370	vaporized glimmering penguin feather	1		Last Available: "2008-06"
 3371	dried blinking glimmering buzzard feather	1		Last Available: "2008-06"
 3372	vaporized glimmering raven feather	1		Last Available: "2008-06"
-3373	altered bouncing shaking glimmering great tit feather	1		Effect: "Adventurer's Best Friendship", Effect Duration: 45, Last Available: "2008-06"
+3373	altered shaking bouncing glimmering great tit feather	1		Effect: "Adventurer's Best Friendship", Effect Duration: 45, Last Available: "2008-06"
 3374	spinning house of twigs and spit	0		Last Available: "2008-06"
 3375	spinning The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	teal Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	Chorale of Companionship	0		Skill: "Chorale of Companionship"
-3379	pulsating upside-down Prelude of Precision	0		Skill: "Prelude of Precision"
+3379	upside-down pulsating Prelude of Precision	0		Skill: "Prelude of Precision"
 3380	fireproof Jim Carey's Ol' Scratch's infernal pitchfork	0		Monster Level: +25, Hot Resistance: +3
 3381	Ol' Scratch's stove door of the cheetah	0		Initiative: +60, Damage Reduction: 15
 3382	flame-wreathed smartaleck's cool Ol' Scratch's manacles	0		Moxie: +5, Moxie Percent: +30, Hot Spell Damage: +10, Single Equip
@@ -3368,7 +3368,7 @@
 3396	twirling Tesla resourceful Hodgman's lobsterskin pants	0		Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xPotato"
 3397	blue huge hardy Hodgman's bow tie of the glutton	0		Maximum HP: +50, Food Drop: +100, Single Equip
 3398	drinkable huge Hodgman's blanket	4	good	
-3399	watered-down bad jar of squeeze	2	decent	
+3399	bad watered-down jar of squeeze	2	decent	
 3400	spoiled bowl of fishysoisse	4	crappy	
 3401	extra-corrupted deadly lampshade	0		Effect: "The Magic of Sharing", Effect Duration: 16
 3402	irradiated extra-electrified narrow concentrated garbage juice	0		Effect: "Bootyliciousness", Effect Duration: 13
@@ -3410,7 +3410,7 @@
 3443	huge kitten	0		
 3444	shaking hale webbed comic mask	0		Maximum HP: +20, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 3445	Junior Adventurer's kit	0		
-3446	teal huge groovy prism necklace	0		Single Equip
+3446	huge teal groovy prism necklace	0		Single Equip
 3447	arcane researcher's six-rainbow shield of doom	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +50, Damage Reduction: 12, Last Available: "2008-07"
 3448	rainbow bomb	0		Last Available: "2008-07"
 3449	mirror cotton candy cone	0		Last Available: "2008-08"
@@ -3424,12 +3424,12 @@
 3457	wicked Junior Adventurer's merit badge	0		Spell Damage: +5
 3458	oxidized STYX deodorant body spray	0		Effect: "Incensed", Effect Duration: 54
 3459	weak acceptable white-label gin	2	good	
-3460	half-sized rotten tin rations	2	crappy	
+3460	rotten half-sized tin rations	2	crappy	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	practically non-alcoholic hand-crafted special upside-down bottle of sake	1	EPIC	Effect: "Pop-eyed", Effect Duration: 10
+3463	special hand-crafted practically non-alcoholic upside-down bottle of sake	1	EPIC	Effect: "Pop-eyed", Effect Duration: 10
 3464	fireproof round pebble	0		Hot Resistance: +3
-3465	stale special squat Bash-&#332;s cereal	3	decent	Effect: "Cringle's Curative Carol", Effect Duration: 5, Wiki Name: "Bash-Os cereal"
+3465	special stale squat Bash-&#332;s cereal	3	decent	Effect: "Cringle's Curative Carol", Effect Duration: 5, Wiki Name: "Bash-Os cereal"
 3466	wool therapeutic ruddy haiku katana	0		Maximum HP Percent: +40, Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	yellow bargain flash powder	0		
 3468	red hardy plastic baby	0		Maximum HP: +50, Single Equip, Last Available: "2008-12"
@@ -3452,7 +3452,7 @@
 3485	super-unsweetened glittery mascara	0		Effect: "items.enh", Effect Duration: 54
 3486	shaking dull fish scale	0		
 3487	rough fish scale	0		
-3488	twirling mirror pristine fish scale	0		
+3488	mirror twirling pristine fish scale	0		
 3489	rotten beefy fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
 3490	yummy glistening fish meat	3	awesome	Effect: "Fishy", Effect Duration: 5
 3491	spoiled slick fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
@@ -3461,10 +3461,10 @@
 3494	twirling olive miser's manspreader's fish bazooka	0		Monster Level: +10, Meat Drop: +10
 3495	flattened super-modified lime green sea salt crystal	0		Effect: "Mer-kindliness", Effect Duration: 18
 3496	diffused bazookafish bubble gum	0		Effect: "Morbidi Tea", Effect Duration: 66
-3497	tolerable fortified bottle of Pete's Sake	5	good	
-3498	narrow invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	twirling witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3497	fortified tolerable bottle of Pete's Sake	5	good	
+3498	narrow invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	twirling witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	bland gigantic canap&eacute;s	9	decent	
 3502	distilled thermos of brew	1	decent	Last Available: "2011-12"
 3503	artisanal glass of brandy	4	EPIC	Last Available: "2011-12"
@@ -3475,7 +3475,7 @@
 3508	skewed ruddy scratch 'n' sniff sword	0		Maximum HP Percent: +40, Last Available: "2008-11"
 3509	upside-down scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
-3511	wobbly yellow wobbly scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
+3511	yellow wobbly wobbly scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	teal scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	upside-down scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	forbidden depleted Grimacite gravy boat of the boozehound	0		Spell Damage Percent: +50, Booze Drop: +100, Last Available: "2011-12"
 3544	asbestos-lined chaotic depleted Grimacite weightlifting belt	0		Spell Critical Percent: +10, Hot Resistance: +5, Single Equip, Last Available: "2011-12"
 3545	shaking Usain Bolt's horrifying depleted Grimacite grappling hook	0		Spooky Damage: +25, Initiative: +80, Single Equip, Last Available: "2011-12"
-3546	stiffened grievous depleted Grimacite ninja mask	0		Weapon Damage Percent: +50, Damage Reduction: 1, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	tumbling frightening thinker's depleted Grimacite shinguards	0		Mysticality: +10, Spooky Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	stiffened grievous depleted Grimacite ninja mask	0		Weapon Damage Percent: +50, Damage Reduction: 1, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	tumbling frightening thinker's depleted Grimacite shinguards	0		Mysticality: +10, Spooky Damage: +5, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	maroon Jeselnik's razor-sharp depleted Grimacite astrolabe	0		Weapon Damage Percent: +25, Sleaze Damage: +25, Single Equip, Last Available: "2011-12"
 3549	ribald arcane researcher's KoL Con Cinco Pi&ntilde;ata Bat	0		Experience Percent (Mysticality): +10, Sleaze Damage: +10, Softcore Only, Last Available: "2008-09"
 3550	Oprah's propeller beanie	0		Maximum MP Percent: +50, Familiar Effect: "atk, cap 7"
@@ -3524,12 +3524,12 @@
 3557	bland tumbling sea avocado	3	decent	
 3558	normal gigantic sea lychee	6	good	
 3559	stale spinning sea tangelo	4	decent	
-3560	jumbo enchanted normal spinning sea honeydew	5	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 10
+3560	normal enchanted jumbo spinning sea honeydew	5	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 10
 3561	magnetized quadruple-concentrated spinning pressurized potion of puissance	0		Effect: "Stands Alone", Effect Duration: 56
 3562	ionized dry pressurized potion of perspicacity	0		Effect: "Muscle Unbound", Effect Duration: 36
 3563	vacuum-sealed anodized cyan pressurized potion of pulchritude	0		Effect: "I See Everything Thrice!", Effect Duration: 53
-3564	lousy practically non-alcoholic berry-infused sake	1	decent	
-3565	fancy practically non-alcoholic delicious citrus-infused sake	1	awesome	Effect: "Nano-juiced", Effect Duration: 40
+3564	practically non-alcoholic lousy berry-infused sake	1	decent	
+3565	fancy delicious practically non-alcoholic citrus-infused sake	1	awesome	Effect: "Nano-juiced", Effect Duration: 40
 3566	hand-crafted melon-infused sake	3	EPIC	
 3567	slab of sponge	0		
 3568	tumbling green Jim Carey's deadly strapping sponge helmet	0		Muscle: +5, Weapon Damage: +5, Monster Level: +25, Familiar Effect: "atk, 1xFairy"
@@ -3547,7 +3547,7 @@
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	rotten spinning rice	4	crappy	
-3584	flavorless half-sized wobbly irradiated candy cane	2	decent	Last Available: "2008-12"
+3584	half-sized flavorless wobbly irradiated candy cane	2	decent	Last Available: "2008-12"
 3585	stale blinking gingerbread mutant bugbear	3	decent	Last Available: "2008-12"
 3586	fortified artisanal oozenog	5	EPIC	Last Available: "2008-12"
 3587	non-dry energized gray narrow sugar plum	0		Effect: "Voracious Gorging", Effect Duration: 31, Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	skewed gnashing teeth	0		Last Available: "2008-12"
 3623	ghostly chitinous pod	0		Last Available: "2008-12"
 3624	horrifying parasitic claw	0		Spooky Damage: +25, Last Available: "2008-12"
-3625	green spinning parasitic tentacles of doom	0		Spooky Spell Damage: +50, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	Jack Frost's parasitic headgnawer	0		Cold Spell Damage: +50, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	green spinning parasitic tentacles of doom	0		Spooky Spell Damage: +50, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	Jack Frost's parasitic headgnawer	0		Cold Spell Damage: +50, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	blinking lard-coated parasitic strangleworm	0		Sleaze Spell Damage: +25, Last Available: "2008-12"
 3628	yellow narrow pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,23 +3598,23 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	narrow flame-retardant curative elven socks	0		Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-12"
 3634	friendly rosy-cheeked elven gloves	0		Maximum HP Percent: +30, Familiar Weight: +3, Last Available: "2008-12"
-3635	gray razor-sharp dance instructor's festive holiday hat	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	gray razor-sharp dance instructor's festive holiday hat	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	reassuring patent shoes of courage	0		Spooky Resistance: 4, Last Available: "2008-12"
 3637	teal arcane researcher's gray bow tie of Gandalf	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +20, Last Available: "2008-12"
 3638	penguin thesaurus of Gandalf of the scaredy-cat	0		Spell Critical Percent: +20, Monster Level: -15, Last Available: "2008-12"
 3639	huge normal blob-shaped Crimbo cookie	10	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	blurry jamfish jam	0		
-3642	jittery cyan dragonfish caviar	0		
+3642	cyan jittery dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	therapeutic depleted Grimacite kneecapping stick	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-06"
 3645	bad canteen of wine	3	decent	Last Available: "2008-12"
-3646	low-calorie delicious elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
+3646	delicious low-calorie elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	gray magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	stale toast with jam	4	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	weak perfectly mixed elven moonshine	2	EPIC	Last Available: "2008-12"
 3653	normal shaking knuckle sandwich	4	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	reassuring psycho sweater of dire peril	0		Weapon Damage: +20, Spooky Resistance: +1, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	upside-down spinning wool plastic strand of DNA	0		Cold Resistance: +1, Last Available: "2008-12"
 3660	dog trainer's plastic chunk of depleted Grimacite	0		Experience (familiar): +1, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	gray dance instructor's Putty mitre	0		Experience Percent (Moxie): +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	twirling lightning-fast resourceful Putty leotard	0		Maximum MP: +50, Initiative: +40, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	gray dance instructor's Putty mitre	0		Experience Percent (Moxie): +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	twirling lightning-fast resourceful Putty leotard	0		Maximum MP: +50, Initiative: +40, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	brawny Putty ball	0		Muscle Percent: +20, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	flame-retardant careful Putty snake of the bloodbag	0		Maximum HP: +100, Monster Level: -10, Hot Resistance: +1, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	sinister glow-in-the-dark burrowgrub	0		Spell Damage: +10, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	stale can of franks 'n' beans	4	decent	Last Available: "2010-12"
-3673	weak perfectly mixed bottle of peppermint schnapps	2	EPIC	Last Available: "2010-12"
+3673	perfectly mixed weak bottle of peppermint schnapps	2	EPIC	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	spinning Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
@@ -3654,13 +3654,13 @@
 3688	flavorless gigantic sea cauliflower	8	decent	
 3689	adequate special tempura broccoli	3	good	Effect: "Disdain of She-Who-Was", Effect Duration: 30
 3690	stale tempura cauliflower	4	decent	
-3691	flavorless jumbo sea blueberry	5	decent	
+3691	jumbo flavorless sea blueberry	5	decent	
 3692	decent ghostly sea persimmon	3	good	
 3693	flattened pressurized potion of perception	0		Effect: "Beastly Flavor", Effect Duration: 50
 3694	double-frozen vacuum-sealed fuchsia pressurized potion of proficiency	0		Effect: "I See Everything Thrice!", Effect Duration: 27
 3695	extremely unsafe Mer-kin digpick	0		Weapon Damage Percent: +100
 3696	shaking anemone nematocyst	0		
-3697	olive twirling high-pressure seltzer bottle	0		
+3697	twirling olive high-pressure seltzer bottle	0		
 3698	velcro ore	0		
 3699	teflon ore	0		
 3700	squat gray vinyl ore	0		
@@ -3690,7 +3690,7 @@
 3724	skewed bouncing brittle plastic handle	0		
 3725	foggy glass globe	0		
 3726	possessed tomato	0		
-3727	maroon twirling blurry Nardz energy beverage	0		
+3727	maroon blurry twirling Nardz energy beverage	0		
 3728	pile of coins	0		
 3729	hand grenegg	0		
 3730	caret	0		
@@ -3725,14 +3725,14 @@
 3761	forbidden vampire pearl ring	0		Spell Damage Percent: +50, Single Equip
 3762	Temple Grandin's vampire pearl necklace	0		Familiar Weight: +7, Single Equip
 3763	hand-crafted weak slug of vodka	2	EPIC	
-3764	weak acceptable slug of rum	2	good	
+3764	acceptable weak slug of rum	2	good	
 3765	perfectly mixed practically non-alcoholic slug of shochu	1	EPIC	
 3766	acceptable practically non-alcoholic screwdiver	1	good	
 3767	mediocre extra-dry dew yoana lei	5	decent	
-3768	enchanted delicious lychee chuhai	4	awesome	Effect: "Shot in the Arse", Effect Duration: 5
+3768	delicious enchanted lychee chuhai	4	awesome	Effect: "Shot in the Arse", Effect Duration: 5
 3769	extra-dry tolerable salacious screwdiver	5	good	
-3770	practically non-alcoholic hand-crafted dew yoana salacious lei	1	super ultra mega turbo EPIC	
-3771	watered-down aged salacious lychee chuhai	2	awesome	
+3770	hand-crafted practically non-alcoholic dew yoana salacious lei	1	super ultra mega turbo EPIC	
+3771	aged watered-down salacious lychee chuhai	2	awesome	
 3772	lousy huge Alewife&trade; Ale	3	decent	
 3773	seaode	0		
 3774	jittery map to the Dive Bar	0		
@@ -3742,19 +3742,19 @@
 3778	miser's careful boxer's amber aviator shades	0		Muscle Percent: +10, Monster Level: -10, Meat Drop: +10, Single Equip
 3779	vacuum-sealed blue hair of the fish	0		Effect: "Egg-stra Arm", Effect Duration: 50
 3780	ghostly jittery greedy Tesla nurse's hat of terror	0		Spooky Spell Damage: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk"
-3781	teal twirling blank prescription sheet	0		
+3781	twirling teal blank prescription sheet	0		
 3782	dehydrated lime green bottle of melodramamine	1		
 3783	mixed ghostly spinning bottle of extra-strength melodramamine	1		Effect: "Arabian Knighthood", Effect Duration: 35
 3784	ghostly paranormal ricotta	0		Class: "Pastamancer"
 3785	skewed smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
-3787	huge cyan tumbling wine-soaked bone chips	0		Class: "Pastamancer"
+3787	cyan huge tumbling wine-soaked bone chips	0		Class: "Pastamancer"
 3788	crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	narrow aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	ghostly crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	ghostly crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	foul-smelling Socratic Mer-kin roundshield of the brazier	0		Experience (Mysticality): +1, Hot Spell Damage: +25, Stench Damage: +10, Damage Reduction: 14
 3804	bouncing toasty Mer-kin breastplate of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +5
 3805	frightening Mer-kin sneakmask of temperance	0		Spooky Damage: +5, Sleaze Resistance: +5, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3764,7 +3764,7 @@
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	mirror Mer-kin stashbox	0		
-3812	decent half-sized pulsating chocolate-frosted king cake	2	good	Last Available: "2009-06"
+3812	half-sized decent pulsating chocolate-frosted king cake	2	good	Last Available: "2009-06"
 3813	deadly plastic baby	0		Weapon Damage: +5, Single Equip, Last Available: "2009-06"
 3815	maroon midget clownfish	0		
 3816	lime green half-height unicycle	0		Familiar Weight: +5
@@ -3783,7 +3783,7 @@
 3829	flavorless super-sized tempura radish	5	decent	
 3830	maroon Jim Carey's water-polo cap	0		Monster Level: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	lousy blinking Typical Tavern swill	4	decent	
-3832	hand-crafted weak shaking tropical swill	2	EPIC	
+3832	weak hand-crafted shaking tropical swill	2	EPIC	
 3833	tolerable fruity girl swill	3	good	
 3834	tolerable irresponsibly strong blended swill	10	good	
 3835	green costume wardrobe	0		Softcore Only
@@ -3791,7 +3791,7 @@
 3837	anniversary safety glass vest of Tarzan	0		Experience (Muscle): +3
 3838	Da Vinci's anniversary burlap belt	0		Experience (Mysticality): +5
 3839	mirror flame-retardant anniversary balsa wood socks	0		Hot Resistance: +1
-3840	gray tumbling huge anniversary latex mask	0		Familiar Weight: +1
+3840	tumbling gray huge anniversary latex mask	0		Familiar Weight: +1
 3841	extremely unsafe anniversary pewter cape	0		Weapon Damage Percent: +100
 3842	beefcake's out-of-tune biwa	0		Muscle: +25
 3843	dented harmonica of the bloodbag	0		Maximum HP: +100
@@ -3812,7 +3812,7 @@
 3858	studded bone flute	0		Damage Absorption: +80
 3859	strapping infernal fife	0		Muscle: +5
 3860	beefcake's charming flute	0		Muscle: +25
-3861	fuchsia squat leaf of grass	0		
+3861	squat fuchsia leaf of grass	0		
 3862	Jeselnik's brawny grass whistle	0		Muscle Percent: +20, Sleaze Damage: +25
 3863	nasty stiffened plastic guitar	0		Damage Reduction: 1, Stench Damage: +5
 3864	narrow Van der Graaf finger cymbals	0		MP Regen Min: 5, MP Regen Max: 7
@@ -3840,18 +3840,18 @@
 3886	altered concentrated twirling vial of slime	0		Effect: "Heart of Orange", Effect Duration: 21
 3887	moist vial of slime	0		Effect: "Transcendental Wind", Effect Duration: 51
 3888	adjusted vial of slime	0		Effect: "Shortened", Effect Duration: 67
-3889	corrupted quadruple-anodized tumbling green vial of slime	0		Effect: "Ham-Fisted", Effect Duration: 57
+3889	corrupted quadruple-anodized green tumbling vial of slime	0		Effect: "Ham-Fisted", Effect Duration: 57
 3890	improved pickled vial of violet slime	0		Effect: "Patent Alacrity", Effect Duration: 53
 3891	corrupted vial of vermilion slime	0		Effect: "Bootyliciousness", Effect Duration: 49
 3892	double-unsweetened cyan vial of amber slime	0		Effect: "Burning Hands", Effect Duration: 29
 3893	liquefied vial of chartreuse slime	0		Effect: "Banono", Effect Duration: 35
 3894	nitrogenated irradiated vial of teal slime	0		Effect: "Uncucumbered", Effect Duration: 31
-3895	pressed tumbling upside-down vial of indigo slime	0		Effect: "Sinuses For Miles", Effect Duration: 67
+3895	pressed upside-down tumbling vial of indigo slime	0		Effect: "Sinuses For Miles", Effect Duration: 67
 3896	modified bouncing vial of slime	0		Effect: "Whippin' It Good", Effect Duration: 43
 3897	activated vial of brown slime	0		Effect: "Thunderspell", Effect Duration: 47
 3898	blinking bottle of G&uuml;-Gone	0		
 3901	squat seal-blubber candle	0		Class: "Seal Clubber"
-3902	green squat figurine of a wretched-looking seal	0		Class: "Seal Clubber"
+3902	squat green figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	aged squat skewed huge blended swill with a fly in it	3	awesome	
+3913	aged huge squat skewed blended swill with a fly in it	3	awesome	
 3914	mirror turtle wax	0		
 3915	wobbly nasty turtle wax shield	0		Stench Damage: +5, Damage Reduction: 2
 3916	dog trainer's turtle wax helmet	0		Experience (familiar): +1, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3940,7 +3940,7 @@
 3988	shaking turtle shell	0		
 3989	turtle shell powder	0		
 3990	fuchsia blurry careful turtle shell helmet	0		Monster Level: -10, Familiar Effect: "hot atk, cap 8"
-3991	mirror lime green slime-soaked hypophysis	0		Skill: "Slimy Sinews"
+3991	lime green mirror slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
@@ -3990,15 +3990,15 @@
 4038	tolerable weak slimy fermented bile bladder	2	good	
 4039	compressed maroon slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	frightening stanky pig-iron helm	0		Stench Spell Damage: +25, Spooky Damage: +5, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	squat dance instructor's cool pig-iron shinguards	0		Moxie: +5, Experience Percent (Moxie): +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	frightening stanky pig-iron helm	0		Stench Spell Damage: +25, Spooky Damage: +5, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	squat dance instructor's cool pig-iron shinguards	0		Moxie: +5, Experience Percent (Moxie): +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	miser's baleful pig-iron bracers	0		Spell Damage: +25, Meat Drop: +10, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	twirling wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	arcane researcher's wumpus-hair whip	0		Experience Percent (Mysticality): +10, Last Available: "2009-06"
-4048	bouncing shaking crafty experienced wumpus-hair wig of the businessman	0		Experience: +2, Maximum MP: +10, Meat Drop: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	auspicious wumpus-hair loincloth of doom	0		Spooky Spell Damage: +50, Item Drop: 15, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	bouncing shaking crafty experienced wumpus-hair wig of the businessman	0		Experience: +2, Maximum MP: +10, Meat Drop: +50, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	auspicious wumpus-hair loincloth of doom	0		Spooky Spell Damage: +50, Item Drop: 15, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	Newton's wumpus-hair sweater of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Last Available: "2009-06"
 4051	wobbly Sinatra's ring of teleportation	0		Experience (Moxie): +5, Single Equip
 4052	wobbly glass of baboon milk	1	decent	Last Available: "2009-06"
@@ -4010,7 +4010,7 @@
 4058	studded stone fist of the sweet-tooth	0		Damage Absorption: +80, Candy Drop: +100, Last Available: "2009-06"
 4059	skewed Jeselnik's stone head	0		Sleaze Damage: +25, Damage Reduction: 5, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
-4061	blue shaking Violet Hunt Invitation	0		Last Available: "2009-06"
+4061	shaking blue Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	yellow jittery 'Smuggler Shot First' Button	0		Last Available: "2009-06"
@@ -4056,7 +4056,7 @@
 4104	ghostly Annie Oakley's catseye marble	0		Critical Hit Percent: +20
 4105	bumboozer marble of wisdom	0		Mysticality: +15
 4106	hale chamoisole	0		Maximum HP: +20
-4107	moist wobbly skewed blinking bitter pill	0		Effect: "Eyes Wide Propped", Effect Duration: 45
+4107	moist wobbly blinking skewed bitter pill	0		Effect: "Eyes Wide Propped", Effect Duration: 45
 4108	shaking spinning studded monstrous monocle of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50, Last Available: "2009-06"
 4109	nasty occult musty moccasins	0		Spell Damage Percent: +25, Stench Damage: +5, Last Available: "2009-06"
 4110	sizzling arcane researcher's molten medallion	0		Experience Percent (Mysticality): +10, Hot Damage: +10, Last Available: "2009-06"
@@ -4107,7 +4107,7 @@
 4155	wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
 4157	pulsating gravel	0		Last Available: "2009-09"
-4158	fuchsia spinning rock	0		Last Available: "2009-09"
+4158	spinning fuchsia rock	0		Last Available: "2009-09"
 4159	squat rock lobster	0		Last Available: "2009-09"
 4160	smooth pebblebr&auml;u	3	awesome	Last Available: "2009-09"
 4161	spoiled half-sized rocky road ice cream	2	crappy	Last Available: "2009-09"
@@ -4130,8 +4130,8 @@
 4178	sugar shotgun of the storm	0		Maximum MP Percent: +40, Last Available: "2009-09"
 4179	jittery wool sugar shillelagh	0		Cold Resistance: +1, Last Available: "2009-09"
 4180	lightning-fast sugar shank	0		Initiative: +40, Last Available: "2009-09"
-4181	up-at-dawn censurious curative sugar chapeau	0		Sleaze Resistance: +3, Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	grievous sugar shorts	0		Weapon Damage Percent: +50, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	up-at-dawn censurious curative sugar chapeau	0		Sleaze Resistance: +3, Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	grievous sugar shorts	0		Weapon Damage Percent: +50, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	pulsating blurry sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	purple slime convention flyers	0		
@@ -4166,7 +4166,7 @@
 4214	spangly unitard	0		
 4215	ghostly forbidden Da Vinci's collapsible baton	0		Experience (Mysticality): +5, Spell Damage Percent: +50
 4216	groupie lipstick	0		
-4217	fuchsia blurry groupie bra	0		
+4217	blurry fuchsia groupie bra	0		
 4218	colloidal unsweetened pulsating groupie spangles	0		Effect: "Human-Penguin Hybrid", Effect Duration: 40
 4219	ghostly energetic beefcake's skate board	0		Muscle: +25, Maximum MP Percent: +20
 4220	S.A.V.E. flyer	0		
@@ -4178,7 +4178,7 @@
 4226	ruddy Star of Bravery	0		Maximum HP Percent: +40, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	mirror perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	twirling amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	twirling amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	olive ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	can of sterno	0		
 4237	mirror ghostly dangerous cheese-slicer	0		Weapon Damage: +10
-4238	big stale beef jerky	5	decent	
+4238	stale big beef jerky	5	decent	
 4239	tumbling pipe wrench of the wise owl	0		Mysticality: +20
 4240	ionized dry upside-down narrow gun cleaning kit	0		Effect: "Gummiskin", Effect Duration: 60
 4241	sleep mask of doom	0		Spooky Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4196,7 +4196,7 @@
 4244	jittery leather-bound tome of the glutton	0		Food Drop: +100
 4245	blue bookmark	0		
 4246	strapping ivory cue ball	0		Muscle: +5
-4247	perfectly mixed fancy decanter of fine Scotch	3	super EPIC	Effect: "Crotchety, Pining", Effect Duration: 25
+4247	fancy perfectly mixed decanter of fine Scotch	3	super EPIC	Effect: "Crotchety, Pining", Effect Duration: 25
 4248	mixed teal blinking expensive cigar	1		Effect: "Okee-Dokee, Smokee", Effect Duration: 10
 4249	tophat	0		Familiar Weight: +5
 4250	red fisherman's sack	0		
@@ -4206,15 +4206,15 @@
 4254	wobbly shaking bark	0		Last Available: "2009-10"
 4255	wobbly Wolfman Nardz	0		Last Available: "2009-10"
 4256	colloidal bouncing sap	0		Effect: "Cotton Mouthed", Effect Duration: 61, Last Available: "2009-10"
-4257	lime green blurry petrified wood	0		Last Available: "2009-10"
+4257	blurry lime green petrified wood	0		Last Available: "2009-10"
 4258	snack-sized spoiled chocolate-covered scarab beetle	2	crappy	Last Available: "2009-10"
 4259	spirit-forward artisanal mulled cider	5	EPIC	Last Available: "2009-10"
-4260	gray wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	maroon mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	gray wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	maroon mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	skewed shaking Ax of L'rose	0		Last Available: "2009-10"
-4264	ruddy bark boxers	0		Maximum HP Percent: +40, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	bark beret of temperance	0		Sleaze Resistance: +5, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	ruddy bark boxers	0		Maximum HP Percent: +40, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	bark beret of temperance	0		Sleaze Resistance: +5, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	up-at-dawn bark bracelet	0		Adventures: +5, Single Equip
 4267	ribald shellacked Krakrox's Loincloth	0		Damage Reduction: 7, Sleaze Damage: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	up-at-dawn cool Galapagosian Cuisses	0		Moxie: +5, Adventures: +5, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4277,7 +4277,7 @@
 4325	teal tumbling miser's knitted Rosewater's Gravyskin Belt of the Sauceblob	0		Mysticality Percent: +30, Cold Resistance: +3, Meat Drop: +10, Class: "Sauceror", Single Equip
 4326	bouncing padded Bling of the New Wave of the brute of mayonnaise	0		Muscle Percent: +30, Damage Absorption: +20, Sleaze Spell Damage: +50, Class: "Disco Bandit", Single Equip
 4327	Temple Grandin's stiffened sinister La Hebilla del Cintur&oacute;n de Lopez	0		Spell Damage: +10, Damage Reduction: 1, Familiar Weight: +7, Class: "Accordion Thief", Single Equip
-4328	olive tumbling suspicious stocking	0		Free Pull, Last Available: "2009-12"
+4328	tumbling olive suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	huge decent skewed candy kneecapping stick	10	good	Last Available: "2009-12"
 4331	moldy gigantic pulsating licorice garrote	8	crappy	Last Available: "2009-12"
@@ -4298,12 +4298,12 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	mirror teal snow hat of the bloodbag	0		Maximum HP: +100, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	snow pants of chilblains	0		Cold Damage: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	mirror teal snow hat of the bloodbag	0		Maximum HP: +100, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	snow pants of chilblains	0		Cold Damage: +25, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	wobbly smartaleck's snow belly	0		Moxie Percent: +30, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
-4354	jittery huge olive A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	olive huge jittery A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	twirling A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	twirling A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
@@ -4314,7 +4314,7 @@
 4362	twirling snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	dry extra-pressed elven suicide capsule	0		Effect: "X-Ray Vision", Effect Duration: 50, Last Available: "2009-12"
-4365	normal small upside-down spinning penguin focaccia bread	2	good	Last Available: "2009-12"
+4365	normal small spinning upside-down penguin focaccia bread	2	good	Last Available: "2009-12"
 4366	irresponsibly strong acceptable blinking herringcello	6	good	Last Available: "2009-12"
 4367	hand-crafted tumbling elven cellocello	3	EPIC	Last Available: "2009-12"
 4368	blinking wrench handle	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	blinking knitted pocketwatch on a chain of the wise owl	0		Mysticality: +20, Cold Resistance: +3, Last Available: "2009-12"
 4386	maroon auspicious manspreader's cement sandals	0		Monster Level: +10, Item Drop: +10, Single Equip, Last Available: "2009-12"
 4387	Sherlock's studded night-vision goggles	0		Damage Absorption: +80, Item Drop: +25, Single Equip, Last Available: "2009-12"
-4388	narrow teal passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	teal narrow passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	foul-smelling peanut brittle shield	0		Stench Damage: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	reassuring frosty Red Rover BB gun	0		Cold Spell Damage: +10, Spooky Resistance: +1, Last Available: "2009-12"
 4391	steel-toed red-and-green sweater	0		Damage Reduction: 9, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	cheese sword of the storm	0		Maximum MP Percent: +40, Softcore Only, Last Available: "2010-01"
-4400	ruddy cheese diaper	0		Maximum HP Percent: +40, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	ruddy cheese diaper	0		Maximum HP Percent: +40, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	tumbling clever cheese wheel	0		Maximum MP: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	greasy cheese eye	0		Sleaze Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	mirror wobbly squat scandalous ruddy brainy Staff of Queso Escusado	0		Mysticality: +5, Maximum HP Percent: +40, Sleaze Damage: +5, Softcore Only, Last Available: "2010-01"
@@ -4360,8 +4360,8 @@
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	bouncing squat The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	jittery Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	enchanted miniature moldy quantum taco	0		Effect: "Pronounced Potency", Effect Duration: 25, Last Available: "2010-10"
-4413	practically non-alcoholic acceptable jittery cyan Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	moldy enchanted miniature quantum taco	0		Effect: "Pronounced Potency", Effect Duration: 25, Last Available: "2010-10"
+4413	acceptable practically non-alcoholic jittery cyan Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	fuchsia censurious sealhide hood	0		Sleaze Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	perfumed sealhide leggings	0		Stench Resistance: +5, Familiar Effect: "1xVolley, cap 40"
@@ -4378,7 +4378,7 @@
 4428	wobbly banded glowstick on a string	0		Damage Absorption: +100
 4429	beefcake's candy necklace	0		Muscle: +25, Single Equip
 4430	zippy teddybear backpack	0		Initiative: +20
-4431	teal tumbling NPZR chemistry set	0		Last Available: "2011-08"
+4431	tumbling teal NPZR chemistry set	0		Last Available: "2011-08"
 4432	non-vacuum-sealed tumbling invisibility potion	0		Effect: "Powdered", Effect Duration: 35, Last Available: "2011-08"
 4433	adjusted jittery irresistibility potion	0		Effect: "Ooh, Bitter!", Effect Duration: 37, Last Available: "2011-08"
 4434	colloidal twirling irritability potion	0		Effect: "Stuck-Up Hair", Effect Duration: 67, Last Available: "2011-08"
@@ -4396,10 +4396,10 @@
 4448	mixed wobbly Instant Karma	1	decent	Effect: "Phairly Balanced", Effect Duration: 45
 4449	pulsating painting of a landscape	0		Last Available: "2010-04"
 4450	huge gray map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	clever pointy hat	0		Maximum MP: +20, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	clever pointy hat	0		Maximum MP: +20, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	Jack Frost's machetito	0		Cold Spell Damage: +50, Last Available: "2010-04"
 4453	hardened lawnmower blade	0		Damage Reduction: 3, Last Available: "2010-04"
-4454	tumbling spinning grass clippings	0		Last Available: "2023-12"
+4454	spinning tumbling grass clippings	0		Last Available: "2023-12"
 4455	The Landscaper's leafblower of James Dean	0		Experience (Moxie): +3, Last Available: "2010-04"
 4456	ghostly snowball	0		
 4457	shaking snailmail bits	0		
@@ -4416,8 +4416,8 @@
 4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	hale BRICKO hat	0		Maximum HP: +20, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	teal bouncing BRICKO pants of temperance	0		Sleaze Resistance: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	hale BRICKO hat	0		Maximum HP: +20, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	teal bouncing BRICKO pants of temperance	0		Sleaze Resistance: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	BRICKO sword	0		Item Drop: +5, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	blue BRICKO bat	0		Last Available: "2010-02"
@@ -4426,7 +4426,7 @@
 4478	BRICKO elephant	0		Last Available: "2010-02"
 4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	maroon BRICKO python	0		Last Available: "2010-02"
-4481	jittery yellow shaking BRICKO vacuum cleaner	0		Last Available: "2010-02"
+4481	jittery shaking yellow BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	skewed BRICKO airship	0		Last Available: "2010-02"
 4483	BRICKO cathedral	0		Last Available: "2010-02"
 4484	shaking BRICKO gargantuchicken	0		Last Available: "2010-02"
@@ -4439,7 +4439,7 @@
 4491	BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
 4493	tumbling broken BRICKO brick	0		Last Available: "2010-02"
-4494	skewed blinking BRICKO reactor	0		Last Available: "2010-02"
+4494	blinking skewed BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	ghostly extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	cold-filtered recording of The Ballad of Richie Thingfinder	0		Effect: "Resilient Spirit", Effect Duration: 69
@@ -4469,23 +4469,23 @@
 4521	bouncing croquet hedgehog	0		Last Available: "2010-03"
 4522	skewed Tiger-lily's milk	1	EPIC	Last Available: "2010-03"
 4523	bouncing dog trainer's Fonzie's eye of the Tiger-lily	0		Experience (Moxie): +1, Experience (familiar): +1, Last Available: "2010-03"
-4524	wool toasty wig	0		Hot Damage: +5, Cold Resistance: +1, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	wool toasty wig	0		Hot Damage: +5, Cold Resistance: +1, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	decent small donut	2	good	Last Available: "2010-03"
 4526	decent bucket of honey	3	good	Last Available: "2010-03"
 4527	shaking MacGyver's elephant stinger of the empath	0		Maximum MP: +100, Familiar Weight: +5, Last Available: "2010-03"
-4528	fancy rotten dragon snaps	4	crappy	Effect: "Just Aged Enough", Effect Duration: 10, Last Available: "2010-03"
+4528	rotten fancy dragon snaps	4	crappy	Effect: "Just Aged Enough", Effect Duration: 10, Last Available: "2010-03"
 4529	skewed curative supercool snapdragon pistil	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	snack-sized tasty rook cookie	2	awesome	Last Available: "2010-03"
-4532	bland thick huge bishop cookie	5	decent	Last Available: "2010-03"
+4532	thick bland huge bishop cookie	5	decent	Last Available: "2010-03"
 4533	bland knight cookie	3	decent	Last Available: "2010-03"
 4534	adequate mirror king cookie	3	good	Last Available: "2010-03"
 4535	tiny stale queen cookie	1	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	huge fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	insane tophat of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	scandalous Da Vinci's helm of the knight	0		Experience (Mysticality): +5, Sleaze Damage: +5, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	insane tophat of Gandalf	0		Spell Critical Percent: +20, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	scandalous Da Vinci's helm of the knight	0		Experience (Mysticality): +5, Sleaze Damage: +5, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	inspector's wristwatch of the knight of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Single Equip, Last Available: "2010-03"
-4540	yellow blinking auspicious rosewater-soaked trousers of the knight	0		Stench Resistance: +3, Item Drop: +10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	yellow blinking auspicious rosewater-soaked trousers of the knight	0		Stench Resistance: +3, Item Drop: +10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	shellacked tophat	0		Damage Reduction: 7, Familiar Effect: "1xBarrr, cap 25"
 4542	greedy tie	0		Meat Drop: +20, Single Equip
 4543	maroon tuxedo pants of the businessman	0		Meat Drop: +50, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4514,17 +4514,17 @@
 4566	shaking fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	coward's flyest of shirts of the scaredy-cat	0		Monster Level: -35, Last Available: "2010-04"
 4568	decent lime green a dance upon the palate	3	good	Last Available: "2010-04"
-4569	decent jumbo spinning teal prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
+4569	jumbo decent teal spinning prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	miniature delicious squirmy violent party snack	2	awesome	Last Available: "2010-04"
 4572	can-you-dig-it? of the empath	0		Familiar Weight: +5, Last Available: "2010-04"
 4573	squat The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	skewed wobbly bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	twirling bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	skewed wobbly bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	twirling bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	non-corrupted gray blurry Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "meat.enh", Effect Duration: 20, Last Available: "2010-04"
+4579	non-corrupted blurry gray Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "meat.enh", Effect Duration: 20, Last Available: "2010-04"
 4580	groovy school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Moxie Percent: +10, Last Available: "2010-04"
 4581	spinning supercool boxer's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Muscle Percent: +10, Moxie Percent: +20, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
@@ -4532,27 +4532,27 @@
 4584	enchanted spoiled six wedges of goat cheese	3	crappy	Effect: "Rage of the Reindeer", Effect Duration: 50
 4585	upside-down collection of objects	0		
 4586	boulder	0		
-4587	narrow cyan goth	0		
+4587	cyan narrow goth	0		
 4588	brown pixel	0		
 4589	blurry padded pixel whip	0		Damage Absorption: +20
 4590	arcane researcher's pixel chain whip	0		Experience Percent (Mysticality): +10, Last Available: "2010-07"
 4591	green vibrating pixel morning star	0		Maximum MP Percent: +10, Last Available: "2010-07"
 4592	pixel orb	0		Last Available: "2010-07"
-4593	shaking upside-down pixellated moneybag	0		Last Available: "2010-07"
+4593	upside-down shaking pixellated moneybag	0		Last Available: "2010-07"
 4594	ghostly pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
 4597	8-Bit Power magazine	0		Last Available: "2010-07"
 4598	narrow pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
-4600	ghostly spinning map to the Kegger in the Woods	0		Last Available: "2010-06"
+4600	spinning ghostly map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	artisanal pulsating plastic cup of beer	4	EPIC	Last Available: "2010-06"
 4602	green orquette's phone number	0		Last Available: "2010-06"
 4603	wobbly bronze handcuffs	0		Last Available: "2010-06"
 4604	tumbling keg	0		Last Available: "2010-06"
 4605	lime green dance instructor's strapping bottle of Goldschn&ouml;ckered	0		Muscle: +5, Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	rotten sun-dried tofu	3	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	practically non-alcoholic enchanted tolerable soyburger juice	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	enchanted practically non-alcoholic tolerable soyburger juice	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	ghostly respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	super-concentrated super-pressed upside-down essential soy	0		Effect: "Here to Kick Ass", Effect Duration: 13, Last Available: "2010-08"
@@ -4569,7 +4569,7 @@
 4621	narrow Game Grid token	0		Last Available: "2010-06"
 4622	mirror Game Grid ticket	0		Last Available: "2010-06"
 4623	corrupted diffused chocolate-covered caviar	0		Effect: "Trash-Wrapped", Effect Duration: 51, Last Available: "2020-09"
-4624	small spoiled pawn cookie	2	crappy	Last Available: "2010-06"
+4624	spoiled small pawn cookie	2	crappy	Last Available: "2010-06"
 4625	dried maroon coffee pixie stick	1	crappy	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
@@ -4577,12 +4577,12 @@
 4629	Sherlock's plastic spider ring	0		Item Drop: +25, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	jittery reassuring plastic kazoo	0		Spooky Resistance: +1, Last Available: "2010-06"
 4631	purple bouncing brawny inflatable baseball bat	0		Muscle Percent: +20, Last Available: "2010-06"
-4632	sage googly-star hat of the early riser	0		Mysticality Percent: +10, Adventures: +7, Familiar Effect: "atk", Last Available: "2010-06"
+4632	sage googly-star hat of the early riser	0		Mysticality Percent: +10, Adventures: +7, Last Available: "2010-06", Familiar Effect: "atk"
 4633	blurry blinking ribald experienced googly-ball hat	0		Experience: +2, Sleaze Damage: +10, Last Available: "2010-06"
 4634	wobbly therapeutic steel-toed googly-heart hat	0		Damage Reduction: 9, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-06"
 4635	lard-coated Jeselnik's super-sweet boom box	0		Sleaze Damage: +25, Sleaze Spell Damage: +25, Four Songs, Last Available: "2010-06"
 4636	ghostly Game Grid valued membership card	0		Last Available: "2010-06"
-4637	spinning horrifying rosy-cheeked sinister demon mask of doom	0		Maximum HP Percent: +30, Spooky Damage: +25, Spooky Spell Damage: +50, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	spinning horrifying rosy-cheeked sinister demon mask of doom	0		Maximum HP Percent: +30, Spooky Damage: +25, Spooky Spell Damage: +50, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	medical-grade savvy streetfighting champion's belt of the empath	0		Mysticality Percent: +20, Familiar Weight: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2010-06"
 4639	family-friendly smartaleck's wizardly Space Trip safety headphones	0		Mysticality: +25, Moxie Percent: +30, Sleaze Resistance: +1, Single Equip, Last Available: "2010-06"
 4640	flame-retardant LARP carp	0		Hot Resistance: +1
@@ -4594,8 +4594,8 @@
 4646	chilly sharpshooter's weightlifter's Meteoid ice beam	0		Muscle: +15, Critical Hit Percent: +10, Cold Damage: +5, Last Available: "2011-12"
 4647	wobbly gray rosewater-soaked sizzling supercool Dungeon Fist gauntlet	0		Moxie Percent: +20, Hot Damage: +10, Stench Resistance: +3, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	narrow chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	spinning fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	narrow chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	spinning fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	upside-down ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	blurry gray Tesla ironic knit cap of the brute	0		Muscle Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	pulsating ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	cyan executive blackberry galoshes	0		Meat Drop: +40, Single Equip
 4660	rosy-cheeked trout fang of courage	0		Maximum HP Percent: +30, Spooky Resistance: +3, Last Available: "2010-09"
-4661	decent low-calorie poisonous caviar	1	good	Last Available: "2010-09"
+4661	low-calorie decent poisonous caviar	1	good	Last Available: "2010-09"
 4662	oxidized polarized wet venom duct	0		Effect: "Mmmmmelon", Effect Duration: 43, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	padded Ellsbury's skull of horror	0		Damage Absorption: +20, Spooky Spell Damage: +25, Last Available: "2010-09"
@@ -4627,12 +4627,12 @@
 4679	narrow volcanic ash	0		
 4680	smoked potsherd	0		
 4681	knitted pottery shield	0		Cold Resistance: +3, Damage Reduction: 3, Last Available: "2010-09"
-4682	energetic medical-grade pottery hat	0		Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	shaking miser's double-paned pottery training pants	0		Cold Resistance: +5, Meat Drop: +10, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	energetic medical-grade pottery hat	0		Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	shaking miser's double-paned pottery training pants	0		Cold Resistance: +5, Meat Drop: +10, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	shaking banded pottery club	0		Damage Absorption: +100, Last Available: "2010-09"
 4685	skewed pottery yo-yo of the brute	0		Muscle Percent: +30, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
-4687	lime green squat wobbly fossilized bat skull	0		Last Available: "2010-09"
+4687	wobbly lime green squat fossilized bat skull	0		Last Available: "2010-09"
 4688	narrow fossilized serpent skull	0		Last Available: "2010-09"
 4689	spinning fossilized baboon skull	0		Last Available: "2010-09"
 4690	blinking fossilized wyrm skull	0		Last Available: "2010-09"
@@ -4641,10 +4641,10 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	Jeselnik's sage Greatest American Pants of the storm	0		Mysticality Percent: +10, Maximum MP Percent: +40, Sleaze Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	Jeselnik's sage Greatest American Pants of the storm	0		Mysticality Percent: +10, Maximum MP Percent: +40, Sleaze Damage: +25, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	pulsating razor-sharp fossilized necklace	0		Weapon Damage Percent: +25, Last Available: "2010-09"
 4698	maroon imp air	0		
-4699	shaking blurry bus pass	0		
+4699	blurry shaking bus pass	0		
 4700	fossilized spike	0		Last Available: "2010-09"
 4701	waterlogged crate	0		Last Available: "2011-12"
 4702	archaeologing shovel	0		Last Available: "2011-12"
@@ -4653,15 +4653,15 @@
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	jittery sinister tablet	0		
 4707	gray E-Z Cook&trade; oven	0		
-4708	red shaking My First Shaker&trade;	0		
+4708	shaking red My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	blinking GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	ghostly popsicle stick	0		
-4714	special huge bland lemon popsicle	6	decent	Effect: "Hennaliciousness", Effect Duration: 25
+4714	huge special bland lemon popsicle	6	decent	Effect: "Hennaliciousness", Effect Duration: 25
 4715	toothsome special red popsicle	3	awesome	Effect: "Inscrutable exoskeleton", Effect Duration: 30
-4716	adequate snack-sized spinning strawberry popsicle	2	good	
+4716	snack-sized adequate spinning strawberry popsicle	2	good	
 4717	fancy flavorless mirror liver popsicle	4	decent	Effect: "Bloodstain-Resistant", Effect Duration: 5
 4718	flame-wreathed mariachi hat	0		Hot Spell Damage: +10, Familiar Effect: "atk, cap 2"
 4719	blinking extremely unsafe Hollandaise helmet	0		Weapon Damage Percent: +100, Familiar Effect: "atk, cap 2"
@@ -4670,10 +4670,10 @@
 4722	bland liver and let pie	4	decent	Last Available: "2010-10"
 4723	rotten badass pie	4	crappy	Last Available: "2010-10"
 4724	rotten shaking shoo-fish pie	4	crappy	Last Available: "2010-10"
-4725	stale small piping organ pie	2	decent	Last Available: "2010-10"
+4725	small stale piping organ pie	2	decent	Last Available: "2010-10"
 4726	diet normal igloo pie	1	good	Last Available: "2010-10"
-4727	stale low-calorie stomach turnover	1	decent	Last Available: "2010-10"
-4728	bite-sized adequate dead lights pie	1	good	Last Available: "2010-10"
+4727	low-calorie stale stomach turnover	1	decent	Last Available: "2010-10"
+4728	adequate bite-sized dead lights pie	1	good	Last Available: "2010-10"
 4729	moldy squat throbbing organ pie	4	crappy	Last Available: "2010-10"
 4730	beefy stop shield	0		Muscle: +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4686,7 +4686,7 @@
 4738	hand-crafted day-old beer	4	EPIC	
 4739	mediocre plain beer	4	decent	
 4740	mediocre overpriced &quot;imported&quot; beer	4	decent	
-4741	mirror skewed smiling rat	0		
+4741	skewed mirror smiling rat	0		
 4742	lime green rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	moist PlexiPips	0		Effect: "Stop the Presses!", Effect Duration: 21
@@ -4699,16 +4699,16 @@
 4751	skewed studded boning knife	0		Damage Absorption: +80, Last Available: "2010-10"
 4752	bone crusher of the boozehound	0		Booze Drop: +100, Last Available: "2010-10"
 4753	yellow curative bone spurs	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2010-10"
-4754	mirror huge friendly bonedanna of the storm	0		Maximum MP Percent: +40, Familiar Weight: +3, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	sizzling frosty boneana hammock	0		Cold Spell Damage: +10, Hot Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	mirror huge friendly bonedanna of the storm	0		Maximum MP Percent: +40, Familiar Weight: +3, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	sizzling frosty boneana hammock	0		Cold Spell Damage: +10, Hot Damage: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
-4757	red blurry narrow Stabonic scroll	0		Last Available: "2010-10"
+4757	blurry narrow red Stabonic scroll	0		Last Available: "2010-10"
 4758	galvanized oxidized blurry candy skeleton	0		Effect: "Greasy Flavor", Effect Duration: 43, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	red twirling packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	lime green squat pumpkin	0		Last Available: "2010-11"
 4762	upside-down huge pumpkin	0		Last Available: "2010-11"
-4763	rotten thick squat pumpkin pie	5	crappy	Last Available: "2010-11"
+4763	thick rotten squat pumpkin pie	5	crappy	Last Available: "2010-11"
 4764	perfectly mixed narrow pumpkin beer	3	EPIC	Last Available: "2010-11"
 4765	pickled diffused gray pumpkin juice	0		Effect: "You Know Who to Call", Effect Duration: 32, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4717,14 +4717,14 @@
 4769	blue pumpkin carriage	0		Last Available: "2010-11"
 4770	squat Desert Bus pass	0		
 4771	teal ginormous pumpkin	0		Last Available: "2010-11"
-4804	ghostly blue Essence of Annoyance	0		Skill: "Summon Annoyance"
+4804	blue ghostly Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	twirling Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	shaking Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	adequate special CRIMBCOIDS mints	3	good	Effect: "Robocamo", Effect Duration: 15, Last Available: "2011-01"
+4818	special adequate CRIMBCOIDS mints	3	good	Effect: "Robocamo", Effect Duration: 15, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	stale immense CRIMBCOLOAF	8	decent	Last Available: "2011-01"
 4821	yummy circular CRIMBCOOKIE	3	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,15 +4745,15 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	lime green robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	super-sized stale triangular CRIMBCOOKIE	5	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	stale super-sized triangular CRIMBCOOKIE	5	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	stale diet square CRIMBCOOKIE	1	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	shaking Lo Pan's bindlestocking of the early riser	0		Spell Critical Percent: +30, Item Drop: +5, Adventures: +7, Last Available: "2010-12"
 4842	maroon tumbling sleeping stocking	0		Last Available: "2010-12"
 4843	huge Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	toasty Temple Grandin's Uncle Hobo's stocking cap	0		Familiar Weight: +7, Hot Damage: +5, Familiar Effect: "atk", Last Available: "2010-12"
+4845	toasty Temple Grandin's Uncle Hobo's stocking cap	0		Familiar Weight: +7, Hot Damage: +5, Last Available: "2010-12", Familiar Effect: "atk"
 4846	fortified Uncle Hobo's epic beard of the detective	0		Damage Absorption: +60, Item Drop: +20, Single Equip, Last Available: "2010-12"
-4847	jittery auspicious careful Uncle Hobo's gift baggy pants	0		Monster Level: -10, Item Drop: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	jittery auspicious careful Uncle Hobo's gift baggy pants	0		Monster Level: -10, Item Drop: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	scandalous friendly Uncle Hobo's fingerless tinsel gloves	0		Familiar Weight: +3, Sleaze Damage: +5, Single Equip, Last Available: "2010-12"
 4849	pulsating tumbling rosy-cheeked Uncle Hobo's highest bough of the blizzard	0		Maximum HP Percent: +30, Cold Spell Damage: +25, Last Available: "2010-12"
 4850	thinker's Uncle Hobo's belt of the boozehound	0		Mysticality: +10, Booze Drop: +100, Single Equip, Last Available: "2010-12"
@@ -4767,7 +4767,7 @@
 4858	pulsating CRIMBCO lanyard of the early riser	0		Adventures: +7, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-4861	yellow wobbly CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
+4861	wobbly yellow CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	wobbly photocopier	0		Last Available: "2011-01"
@@ -4775,22 +4775,22 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	ribald paperclip-on tie of the scaredy-cat of courage	0		Monster Level: -15, Sleaze Damage: +10, Spooky Resistance: +3, Single Equip, Last Available: "2011-01"
-4869	nippy paperclip pants of the pedagogue	0		Experience: +3, Cold Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	baleful wizardly beefy paperclip turban	0		Muscle: +10, Mysticality: +25, Spell Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	nippy paperclip pants of the pedagogue	0		Experience: +3, Cold Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	baleful wizardly beefy paperclip turban	0		Muscle: +10, Mysticality: +25, Spell Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	tumbling knitted paperclip cape	0		Cold Resistance: +3, Last Available: "2011-01"
 4872	tumbling glob of Blank-Out	0		Last Available: "2011-01"
-4873	twirling shaking photocopied monster	0		Last Available: "2011-01"
+4873	shaking twirling photocopied monster	0		Last Available: "2011-01"
 4874	fuchsia gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	super-flattened chocolate bath ball	0		Effect: "Shot in the Arse", Effect Duration: 63, Last Available: "2011-01"
 4877	double-pickled huge bacon bath ball	0		Effect: "Fangs and Pangs", Effect Duration: 55, Last Available: "2011-01"
-4878	liquefied teal bouncing incense bath ball	0		Effect: "Perfect Hair", Effect Duration: 40, Last Available: "2011-01"
+4878	liquefied bouncing teal incense bath ball	0		Effect: "Perfect Hair", Effect Duration: 40, Last Available: "2011-01"
 4879	altered myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 33, Last Available: "2011-01"
 4880	narrow CRIMBCO mug	0		Last Available: "2011-01"
 4881	smooth CRIMBCO wine	4	awesome	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	moldy low-calorie cyan toe jam toast	1	crappy	Last Available: "2011-01"
+4884	low-calorie moldy cyan toe jam toast	1	crappy	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	snack-sized rotten traffic jam toast	2	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
@@ -4800,7 +4800,7 @@
 4891	squat bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	tiny adequate jittery bouncing festive sausage	1	good	Last Available: "2011-01"
+4894	adequate tiny jittery bouncing festive sausage	1	good	Last Available: "2011-01"
 4895	rotten holiday cheese log	4	crappy	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	pulsating aromatic smartaleck's BGE 'ferocious fruit' shirt	0		Moxie Percent: +30, Stench Resistance: +1, Last Available: "2010-12"
@@ -4844,7 +4844,7 @@
 4941	normal big Knob jelly donut	5	good	
 4942	Knob cake	0		
 4943	bouncing Knob cake pan	0		
-4944	ghostly upside-down Knob batter	0		
+4944	upside-down ghostly Knob batter	0		
 4945	Knob frosting	0		
 4946	jittery unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
@@ -4860,7 +4860,7 @@
 4957	pressed spinning half-baked potion	0		Effect: "Brother Smothers's Blessing", Effect Duration: 56
 4958	huge supercharged Knob Goblin deluxe scimitar	0		Maximum MP Percent: +30
 4959	stale Knob nuts	3	decent	
-4960	artisanal watered-down maroon wobbly Cobb's Knob Wurstbrau	2	EPIC	
+4960	artisanal watered-down wobbly maroon Cobb's Knob Wurstbrau	2	EPIC	
 4961	Subject 37 file	0		
 4962	Jack Frost's medical-grade mysterious lapel pin	0		Cold Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4891,7 +4891,7 @@
 4988	lime green bouncing Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
-4991	gray narrow Alice's Army Foil Guard	0		Last Available: "2011-03"
+4991	narrow gray Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
@@ -4900,7 +4900,7 @@
 4997	upside-down huge Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	Alice's Army Foil Hammerman	0		Last Available: "2011-03"
-5000	jittery skewed Alice's Army Foil Bowman	0		Last Available: "2011-03"
+5000	skewed jittery Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	purple Alice's Army Foil Coward	0		Last Available: "2011-03"
@@ -4911,21 +4911,21 @@
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	spinning strapping card sleeve	0		Muscle: +5, Last Available: "2011-03"
 5010	evil eye	0		
-5011	blinking narrow Alice's Army Foil tattoo	0		Last Available: "2011-03"
+5011	narrow blinking Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	moldy bite-sized wasabi pocky	1	crappy	Last Available: "2011-03"
 5014	adequate tobiko pocky	3	good	Last Available: "2011-03"
 5015	decent natto pocky	4	good	Last Available: "2011-03"
 5016	high-proof bad wasabi-infused sake	9	decent	Last Available: "2011-03"
-5017	fancy weak hand-crafted tobiko-infused sake	2	EPIC	Effect: "Nothing Is Impossible", Effect Duration: 50, Last Available: "2011-03"
-5018	smooth practically non-alcoholic natto-infused sake	1	awesome	Last Available: "2011-03"
+5017	hand-crafted weak fancy tobiko-infused sake	2	EPIC	Effect: "Nothing Is Impossible", Effect Duration: 50, Last Available: "2011-03"
+5018	practically non-alcoholic smooth natto-infused sake	1	awesome	Last Available: "2011-03"
 5019	galvanized red ghostly wasabi marble soda	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 13, Last Available: "2011-03"
 5020	dry alkaline twirling tobiko marble soda	0		Effect: "Deadly Lampblade", Effect Duration: 29, Last Available: "2011-03"
 5021	dry adjusted natto marble soda	0		Effect: "Phorcefullness", Effect Duration: 49, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	warmed irradiated elderly jawbreaker	0		Effect: "Thaumodynamic", Effect Duration: 41, Last Available: "2020-09"
 5024	acceptable mirror marshmallow flamb&eacute;	4	good	Last Available: "2011-03"
-5025	practically non-alcoholic perfectly mixed cranberry schnapps	1	super ultra mega turbo EPIC	Last Available: "2011-03"
+5025	perfectly mixed practically non-alcoholic cranberry schnapps	1	super ultra mega turbo EPIC	Last Available: "2011-03"
 5026	tolerable practically non-alcoholic breaded beer	1	good	Last Available: "2011-03"
 5027	hand-crafted soy cordial	3	super ultra mega EPIC	Last Available: "2011-03"
 5028	lion tamer's banded sage astral bludgeon	0		Mysticality Percent: +10, Damage Absorption: +100, Experience (familiar): +2
@@ -4944,15 +4944,15 @@
 5041	upside-down Temple Grandin's cool astral shirt of the brute	0		Moxie: +5, Muscle Percent: +30, Familiar Weight: +7
 5042	maroon asbestos-lined electrified astral belt	0		Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5
 5043	snack-sized flavorless mirror astral hot dog	2		
-5044	perfectly mixed weak astral pilsner	2		
+5044	weak perfectly mixed astral pilsner	2		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	avaricious clever double-ice cap of Flo-Jo	0		Maximum MP: +20, Meat Drop: +30, Initiative: +100, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	avaricious clever double-ice cap of Flo-Jo	0		Maximum MP: +20, Meat Drop: +30, Initiative: +100, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	horrifying wholesome sinister double-ice box	0		Spell Damage: +10, Maximum HP Percent: +10, Spooky Damage: +25, Last Available: "2011-04"
-5051	blurry fireproof Annie Oakley's double-ice britches of the glutton	0		Critical Hit Percent: +20, Hot Resistance: +3, Food Drop: +100, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
-5052	jittery twirling handful of numbers	0		Last Available: "2020-09"
+5051	blurry fireproof Annie Oakley's double-ice britches of the glutton	0		Critical Hit Percent: +20, Hot Resistance: +3, Food Drop: +100, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5052	twirling jittery handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	obnoxious riddle	0		Last Available: "2011-04"
@@ -4967,7 +4967,7 @@
 5064	narrow Salsa de las Epocas	0		Last Available: "2011-04"
 5065	adequate spaghetti con calaveras	3	good	Last Available: "2011-04"
 5066	blinking s'more gun	0		Last Available: "2011-04"
-5067	stale big popcorn	5	decent	Last Available: "2011-04"
+5067	big stale popcorn	5	decent	Last Available: "2011-04"
 5068	bland snack-sized chaos popcorn	2	decent	Last Available: "2011-04"
 5069	inspector's perfumed weightlifter's hole	0		Muscle: +15, Stench Resistance: +5, Item Drop: +15, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	aged Russian Ice	4	awesome	Last Available: "2011-04"
 5074	Newton's clay ashtray	0		Experience (Mysticality): +3, Damage Reduction: 3, Last Available: "2011-05"
 5075	blurry Tesla lanyard	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-05"
-5076	flame-retardant monster pants	0		Hot Resistance: +1, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	flame-retardant monster pants	0		Hot Resistance: +1, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	chilled narrow huge Pok&euml;mann band-aid	0		Effect: "Salty Dogs", Effect Duration: 14, Last Available: "2011-05"
-5079	double-paned Van der Graaf helmet of incineration	0		Hot Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	double-paned Van der Graaf helmet of incineration	0		Hot Spell Damage: +50, Cold Resistance: +5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	crutch of the empath	0		Familiar Weight: +5, Last Available: "2011-05"
 5081	gray shock belt of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5082	polymerized nitrogenated Okee-Dokee soda	0		Effect: "Cat-Alyzed", Effect Duration: 30, Last Available: "2011-05"
 5083	red ghostly vibrating rubber band gun	0		Maximum MP Percent: +10, Last Available: "2011-05"
-5084	pin-stripe slacks of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	pin-stripe slacks of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	cyan narrow gloves of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2011-05"
 5086	energized squat correction fluid	0		Effect: "All Fired Up", Effect Duration: 48, Last Available: "2011-05"
 5087	razor-sharp Pok&euml;mann figurine: Porkachu	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2011-05"
@@ -5021,19 +5021,19 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	skewed Sherlock's rosewater-soaked knitted Admiral's hat	0		Cold Resistance: +3, Stench Resistance: +3, Item Drop: +25, Familiar Effect: "atk", Last Available: "2011-05"
-5122	wholesome forbidden aviator's cap of the bloodbag	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Maximum HP: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	skewed Sherlock's rosewater-soaked knitted Admiral's hat	0		Cold Resistance: +3, Stench Resistance: +3, Item Drop: +25, Last Available: "2011-05", Familiar Effect: "atk"
+5122	wholesome forbidden aviator's cap of the bloodbag	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Maximum HP: +100, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	tumbling stanky Van der Graaf mirrored aviator shades	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	spinning Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
-5127	gray tumbling Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
+5127	tumbling gray Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	dry tarnished red Ultrasoldier Serum	0		Effect: "Abyssal Sweat", Effect Duration: 36, Last Available: "2011-06"
-5132	decent snack-sized huge elven hardtack	2	good	Last Available: "2011-06"
-5133	lousy watered-down shaking elven squeeze	2	decent	Last Available: "2011-06"
+5132	snack-sized decent huge elven hardtack	2	good	Last Available: "2011-06"
+5133	watered-down lousy shaking elven squeeze	2	decent	Last Available: "2011-06"
 5134	ghostly lunar isotope	0		Last Available: "2011-06"
 5135	spinning E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	vibrating Da Vinci's honey dipper of the detective	0		Experience (Mysticality): +5, Maximum MP Percent: +10, Item Drop: +20
 5149	cyan miser's sharpshooter's honeybritches of terror	0		Critical Hit Percent: +10, Spooky Spell Damage: +10, Meat Drop: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	squat mansplainer's honeycap of incineration of the boozehound	0		Monster Level: +15, Hot Spell Damage: +50, Booze Drop: +100, Familiar Effect: "1xPotato, cap 43"
-5151	Moonthril Circlet of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	avaricious Moonthril Greaves	0		Meat Drop: +30, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	Moonthril Circlet of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	avaricious Moonthril Greaves	0		Meat Drop: +30, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	vibrating Moonthril Flamberge	0		Maximum MP Percent: +10, Last Available: "2011-06"
 5154	Herculean Moonthril Longbow	0		Experience (Muscle): +1, Last Available: "2011-06"
 5155	toasty Moonthril Cuirass	0		Hot Damage: +5, Softcore Only, Last Available: "2011-06"
@@ -5072,14 +5072,14 @@
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	moist moist cold-filtered transporter transponder	0		Effect: "Gyromitra Gymnastics", Effect Duration: 29, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
-5172	yellow upside-down Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
+5172	upside-down yellow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	perfectly mixed weak shaking Saison du Lune	2	EPIC	Last Available: "2011-06"
-5175	delicious high-proof red shaking Moonthril Schnapps	10	awesome	Last Available: "2011-06"
-5176	watered-down hand-crafted gray Wrecked Generator	2	super ultra mega turbo EPIC	Last Available: "2011-06"
+5175	high-proof delicious shaking red Moonthril Schnapps	10	awesome	Last Available: "2011-06"
+5176	hand-crafted watered-down gray Wrecked Generator	2	super ultra mega turbo EPIC	Last Available: "2011-06"
 5177	half-sized stale Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
 5178	delicious thick lime green Crepes a la Lune	5	awesome	Last Available: "2011-06"
-5179	stale bite-sized narrow Moon Pie	1	decent	Last Available: "2011-06"
+5179	bite-sized stale narrow Moon Pie	1	decent	Last Available: "2011-06"
 5180	polymerized skewed upside-down Comet Pop	0		Effect: "Jingle Jangle Jingle", Effect Duration: 54, Last Available: "2011-06"
 5181	warmed activated aerosolized bouncing Flan in the Moon	0		Effect: "Floundering", Effect Duration: 23, Last Available: "2011-06"
 5182	unsweetened magnetized purple 1/6th Pound Cake	0		Effect: "Macho Profundo", Effect Duration: 66, Last Available: "2011-06"
@@ -5089,7 +5089,7 @@
 5186	bouncing Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	huge Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	irradiated pressed mirror honey stick	0		Effect: "Nut-Rition", Effect Duration: 56
-5189	activated Vulcanized aerosolized twirling blinking double-ice gum	0		Effect: "Larger", Effect Duration: 17, Last Available: "2011-04"
+5189	activated Vulcanized aerosolized blinking twirling double-ice gum	0		Effect: "Larger", Effect Duration: 17, Last Available: "2011-04"
 5190	lard-coated Jim Carey's smooth Operation Patriot Shield	0		Moxie: +15, Monster Level: +25, Sleaze Spell Damage: +25, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	huge squirming egg sac	0		Last Available: "2011-06"
 5192	liquefied adjusted adjusted corrupted data	0		Effect: "All Is Forgiven", Effect Duration: 53, Last Available: "2011-06"
@@ -5101,8 +5101,8 @@
 5198	diluted yellow gooey paste	1	crappy	Last Available: "2011-08"
 5199	denatured beastly paste	1	awesome	Last Available: "2011-08"
 5200	dried tumbling ghostly paste	1	EPIC	Last Available: "2011-08"
-5201	dried yellow tumbling ectoplasmic paste	1	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2011-08"
-5202	mixed teal jittery greasy paste	1	awesome	Last Available: "2011-08"
+5201	dried tumbling yellow ectoplasmic paste	1	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2011-08"
+5202	mixed jittery teal greasy paste	1	awesome	Last Available: "2011-08"
 5203	diluted bug paste	1	EPIC	Last Available: "2011-08"
 5204	altered tumbling hippy paste	1	awesome	Effect: "Human-Elemental Hybrid", Effect Duration: 20, Last Available: "2011-08"
 5205	modified cyan orc paste	1	decent	Effect: "Held Closer", Effect Duration: 35, Last Available: "2011-08"
@@ -5116,7 +5116,7 @@
 5213	mixed ghostly bouncing Mer-kin paste	1	decent	Effect: "Disdain of She-Who-Was", Effect Duration: 5, Last Available: "2011-08"
 5214	boiled wobbly slimy paste	1	EPIC	Effect: "Industrial Strength Starch", Effect Duration: 15, Last Available: "2011-08"
 5215	distilled narrow penguin paste	1	EPIC	Last Available: "2011-08"
-5216	compressed wobbly mirror elemental paste	1	awesome	Last Available: "2011-08"
+5216	compressed mirror wobbly elemental paste	1	awesome	Last Available: "2011-08"
 5217	denatured olive wobbly cosmic paste	1	decent	Effect: "Mercenary", Effect Duration: 30, Last Available: "2011-08"
 5218	boiled hobo paste	1	EPIC	Last Available: "2011-08"
 5219	altered skewed Crimbo paste	1	decent	Last Available: "2011-08"
@@ -5125,10 +5125,10 @@
 5222	wobbly Thwaitgold grasshopper statuette	0		
 5223	jittery Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	decent half-sized upside-down Ur-Donut	2	good	Last Available: "2011-09"
-5225	mirror skewed The Bomb	0		Last Available: "2011-09"
+5225	skewed mirror The Bomb	0		Last Available: "2011-09"
 5226	ghostly box of Familiar Jacks	0		Last Available: "2011-09"
 5227	watered-down perfectly mixed bucket of wine	2	super ultra EPIC	Last Available: "2011-09"
-5228	big yummy mirror ultrafondue	5	awesome	Last Available: "2011-09"
+5228	yummy big mirror ultrafondue	5	awesome	Last Available: "2011-09"
 5229	teal unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	zippy furry halo	0		Initiative: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	knitted frosty halo	0		Cold Resistance: +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	nasty time halo	0		Stench Damage: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	enchanted practically non-alcoholic tolerable Lumineux Limnio	1	good	Effect: "New Zeal", Effect Duration: 35, Last Available: "2011-09"
-5239	drinkable distilled Morto Moreto	5	good	Last Available: "2011-09"
+5238	practically non-alcoholic tolerable enchanted Lumineux Limnio	1	good	Effect: "New Zeal", Effect Duration: 35, Last Available: "2011-09"
+5239	distilled drinkable Morto Moreto	5	good	Last Available: "2011-09"
 5240	smooth Temps Tempranillo	3	awesome	Last Available: "2011-09"
-5241	hand-crafted fancy skewed Bordeaux Marteaux	3	EPIC	Effect: "Heightened Senses", Effect Duration: 45, Last Available: "2011-09"
+5241	fancy hand-crafted skewed Bordeaux Marteaux	3	EPIC	Effect: "Heightened Senses", Effect Duration: 45, Last Available: "2011-09"
 5242	tolerable weak Fromage Pinotage	2	good	Last Available: "2011-09"
-5243	special artisanal squat Beignet Milgranet	3	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 5, Last Available: "2011-09"
+5243	artisanal special squat Beignet Milgranet	3	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 5, Last Available: "2011-09"
 5244	fancy artisanal blurry Muschat	3	EPIC	Effect: "Bloodstain-Resistant", Effect Duration: 50, Last Available: "2011-09"
 5245	toothsome cool jelly donut	4	awesome	Last Available: "2011-09"
-5246	enchanted toothsome blurry shrapnel jelly donut	3	awesome	Effect: "Macho Profundo", Effect Duration: 40, Last Available: "2011-09"
-5247	miniature bland occult jelly donut	2	decent	Last Available: "2011-09"
+5246	toothsome enchanted blurry shrapnel jelly donut	3	awesome	Effect: "Macho Profundo", Effect Duration: 40, Last Available: "2011-09"
+5247	bland miniature occult jelly donut	2	decent	Last Available: "2011-09"
 5248	tasty thyme jelly donut	4	awesome	Last Available: "2011-09"
-5249	normal bite-sized upside-down danish	1	good	Last Available: "2011-09"
-5250	moldy snack-sized bouncing narrow smashed danish	2	crappy	Last Available: "2011-09"
+5249	bite-sized normal upside-down danish	1	good	Last Available: "2011-09"
+5250	snack-sized moldy bouncing narrow smashed danish	2	crappy	Last Available: "2011-09"
 5251	moldy forbidden danish	3	crappy	Last Available: "2011-09"
 5252	moldy ghostly cool cat claw	4	crappy	Last Available: "2011-09"
 5253	flavorless blunt cat claw	4	decent	Last Available: "2011-09"
-5254	fancy moldy shadowy cat claw	3	crappy	Effect: "Sweet Tooth", Effect Duration: 50, Last Available: "2011-09"
+5254	moldy fancy shadowy cat claw	3	crappy	Effect: "Sweet Tooth", Effect Duration: 50, Last Available: "2011-09"
 5255	moldy small cheezburger	2	crappy	Last Available: "2011-09"
-5256	fancy decent maroon toasted brie	3	good	Effect: "Conspiratory Eyes", Effect Duration: 35, Last Available: "2011-09"
+5256	decent fancy maroon toasted brie	3	good	Effect: "Conspiratory Eyes", Effect Duration: 35, Last Available: "2011-09"
 5257	corrupted magnetized potion of the field gar	0		Effect: "Heavily Breathing", Effect Duration: 50, Last Available: "2011-09"
 5258	activated galvanized corrupted ghostly too legit potion	0		Effect: "[1701]Hip to the Jive", Effect Duration: 59, Last Available: "2011-09"
 5259	moist Bright Water	0		Effect: "Sugary World View", Effect Duration: 49, Last Available: "2011-09"
@@ -5171,7 +5171,7 @@
 5268	huge holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
-5271	mirror ghostly broken glass grenade	0		Last Available: "2011-09"
+5271	ghostly mirror broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	blinking skull with a fuse in it	0		Last Available: "2011-09"
 5274	tumbling twirling boozebomb	0		Last Available: "2011-09"
@@ -5224,7 +5224,7 @@
 5321	chilled oxidized vacuum-sealed narrow blue Sweet Sword	0		Effect: "Memories of Puppy Love", Effect Duration: 21, Last Available: "2011-10"
 5322	aged Ecto-Cooler	4	awesome	Last Available: "2011-10"
 5323	bad triple-distilled Bartles and BRAAAINS wine cooler	10	decent	Last Available: "2011-10"
-5324	strong aged Blood Light	5	awesome	Last Available: "2011-10"
+5324	aged strong Blood Light	5	awesome	Last Available: "2011-10"
 5325	artisanal Silver Bullet beer	3	EPIC	Last Available: "2011-10"
 5326	hand-crafted upside-down Bone's Farm &quot;wine&quot;	4	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	adjusted dry quantum ghostly drum of pomade	0		Effect: "Leisurely Amblin'", Effect Duration: 37, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	energetic extra-see-thru nightie	0		Maximum MP Percent: +20, Last Available: "2011-10"
-5333	grievous BRAINS shorts of the sewer	0		Weapon Damage Percent: +50, Stench Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	grievous BRAINS shorts of the sewer	0		Weapon Damage Percent: +50, Stench Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	medical-grade Mesmereyes&trade; contact lenses	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2011-10"
 5335	jittery scrunchie of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Last Available: "2011-10"
-5336	asbestos-lined Da Vinci's extremely skinny jeans	0		Experience (Mysticality): +5, Hot Resistance: +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	blurry wholesome The Necbromancer's Hat of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	asbestos-lined Da Vinci's extremely skinny jeans	0		Experience (Mysticality): +5, Hot Resistance: +5, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	blurry wholesome The Necbromancer's Hat of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	inspector's The Necbromancer's Stein of the storm of the overflowing toilet	0		Maximum MP Percent: +40, Stench Spell Damage: +50, Item Drop: +15, Last Available: "2011-10"
-5339	grievous The Necbromancer's Shorts of the sweet-tooth of Flo-Jo	0		Weapon Damage Percent: +50, Candy Drop: +100, Initiative: +100, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	grievous The Necbromancer's Shorts of the sweet-tooth of Flo-Jo	0		Weapon Damage Percent: +50, Candy Drop: +100, Initiative: +100, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	miser's hardened The Necbromancer's Wizard Staff of Gandalf	0		Damage Reduction: 3, Spell Critical Percent: +20, Meat Drop: +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	practically non-alcoholic delicious The Cooler Out of Space	1	awesome	Last Available: "2011-10"
@@ -5278,7 +5278,7 @@
 5375	narrow auspicious plastic colollilossus	0		Item Drop: +10, Last Available: "2011-12"
 5376	MacGyver's Sinatra's plastic Big Candy	0		Experience (Moxie): +5, Maximum MP: +100, Last Available: "2011-12"
 5377	blue The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
-5378	ghostly blinking twirling spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
+5378	ghostly twirling blinking spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	altered upside-down groose grease	1	decent	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 15, Last Available: "2012-12"
 5380	maroon lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
@@ -5290,7 +5290,7 @@
 5387	ridiculous earring of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2011-11"
 5388	ridiculous sunglasses of wisdom	0		Mysticality: +15, Last Available: "2011-11"
 5389	delicious ridiculous sandwich	3	awesome	Last Available: "2011-11"
-5390	weak drinkable yellow ridiculous cocktail	2	good	Last Available: "2011-11"
+5390	drinkable weak yellow ridiculous cocktail	2	good	Last Available: "2011-11"
 5391	fireproof zombie monkey necklace of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3
 5392	Thwaitgold butterfly statuette	0		
 5393	blue scrap of paper	0		
@@ -5304,10 +5304,10 @@
 5401	upside-down peppermint parasol	0		Last Available: "2011-11"
 5402	shaking candy cane of terror	0		Spooky Spell Damage: +10, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
-5404	tumbling spinning Peppermint Pip Packet	0		Last Available: "2011-11"
+5404	spinning tumbling Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	blinking ghostly perfumed smartaleck's cane-mail shirt of bravery	0		Moxie Percent: +30, Spooky Resistance: +5, Stench Resistance: +5, Last Available: "2011-12"
-5406	up-at-dawn auspicious cane-mail pants of courage	0		Spooky Resistance: +3, Item Drop: +10, Adventures: +5, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	acceptable irresponsibly strong Vodka Matryoshka	9	good	Last Available: "2011-12"
+5406	up-at-dawn auspicious cane-mail pants of courage	0		Spooky Resistance: +3, Item Drop: +10, Adventures: +5, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5407	irresponsibly strong acceptable Vodka Matryoshka	9	good	Last Available: "2011-12"
 5408	bad squat Gin Mint	3	decent	Last Available: "2011-12"
 5409	special lousy blurry Tequiz Navidad	3	decent	Effect: "Bubblin' Rage", Effect Duration: 5, Last Available: "2011-12"
 5410	practically non-alcoholic acceptable Mint Yulep	1	good	Last Available: "2011-12"
@@ -5316,7 +5316,7 @@
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	huge licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	unsweetened mirror licorice root	0		Effect: "Quantum of Moxie", Effect Duration: 41, Last Available: "2011-12"
-5416	chilled non-corrupted jittery ghostly banana supersucker	0		Effect: "Liquid Luck", Effect Duration: 38, Last Available: "2011-11"
+5416	chilled non-corrupted ghostly jittery banana supersucker	0		Effect: "Liquid Luck", Effect Duration: 38, Last Available: "2011-11"
 5417	improved wobbly pear supersucker	0		Effect: "Soles of Glass", Effect Duration: 21, Last Available: "2011-11"
 5418	denatured energized lime supersucker	0		Effect: "Slimed Stomach", Effect Duration: 36, Last Available: "2011-11"
 5419	galvanized quadruple-tarnished kumquat supersucker	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 56, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	up-at-dawn kumquartz ring	0		Adventures: +5, Single Equip, Last Available: "2011-11"
 5425	flame-wreathed strawberyl necklace	0		Hot Spell Damage: +10, Single Equip, Last Available: "2011-11"
 5426	prompt toasty sucker bucket	0		Hot Damage: +5, Adventures: +3, Last Available: "2011-11"
-5427	chilly sucker hakama	0		Cold Damage: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	forbidden sucker kabuto	0		Spell Damage Percent: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	chilly sucker hakama	0		Cold Damage: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	forbidden sucker kabuto	0		Spell Damage Percent: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	skewed weightlifter's sucker tachi	0		Muscle: +15, Last Available: "2011-11"
 5430	skewed sucker scaffold	0		Last Available: "2011-11"
 5431	blue cinnamon troll doll	0		Last Available: "2011-11"
@@ -5338,9 +5338,9 @@
 5435	pulsating fudgecule	0		Last Available: "2011-11"
 5436	enhanced fudge lily	0		Effect: "Human-Penguin Hybrid", Effect Duration: 45, Last Available: "2011-11"
 5437	twirling superheated fudge	0		Last Available: "2011-11"
-5438	colloidal purple bouncing bouncing fluid of fudge-finding	0		Effect: "Slightly Larger Than Usual", Effect Duration: 48, Last Available: "2011-11"
+5438	colloidal bouncing purple bouncing fluid of fudge-finding	0		Effect: "Slightly Larger Than Usual", Effect Duration: 48, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	moldy super-sized twirling fudgesicle	5	crappy	Last Available: "2011-11"
+5440	super-sized moldy twirling fudgesicle	5	crappy	Last Available: "2011-11"
 5441	teal wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	mirror miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5353,7 +5353,7 @@
 5450	blue lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	avarice stone	0		Last Available: "2012-12"
-5453	tumbling twirling gluttonous stone	0		Last Available: "2012-12"
+5453	twirling tumbling gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	maroon gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
@@ -5379,7 +5379,7 @@
 5476	quadruple-vacuum-sealed gummi salamander	0		Effect: "El Vibrations", Effect Duration: 39, Last Available: "2011-11"
 5477	quadruple-cold-filtered mirror gummi snake	0		Effect: "Towering Strength", Effect Duration: 22, Last Available: "2011-11"
 5478	dry gummi canary	0		Effect: "Pyromania", Effect Duration: 38, Last Available: "2011-11"
-5479	snack-sized rotten gummi bear	2	crappy	Last Available: "2011-11"
+5479	rotten snack-sized gummi bear	2	crappy	Last Available: "2011-11"
 5480	flavorless enchanted blurry gummi bear	3	decent	Effect: "Patent Prevention", Effect Duration: 40, Last Available: "2011-11"
 5481	spoiled gummi bear	3	crappy	Last Available: "2011-11"
 5482	flavorless blue drunki-bear	4	decent	Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	ionized gummi belemnite	0		Effect: "Inappropriate Spirit", Effect Duration: 38, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	fuchsia mirror Big Candy's tophat of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	fuchsia mirror Big Candy's tophat of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5411,7 +5411,7 @@
 5508	quadruple-nitrogenated Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Pockets of Fire", Effect Duration: 27, Last Available: "2011-11"
 5509	warmed upside-down bottle of bubbles	0		Effect: "Greased-Up Familiar", Effect Duration: 50, Last Available: "2011-11"
 5510	double-enhanced cold-filtered cyan twirling wind-up meatcar	0		Effect: "Salamander In Your Stomach", Effect Duration: 34, Last Available: "2011-11"
-5511	shaking cyan Trivial Avocations Card: What?	0		Last Available: "2011-11"
+5511	cyan shaking Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	shaking Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	tumbling Trivial Avocations Card: Where?	0		Last Available: "2011-11"
@@ -5421,7 +5421,7 @@
 5518	gray pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
-5521	pulsating blinking pog #07 (orcish frat boy)	0		Last Available: "2011-11"
+5521	blinking pulsating pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	lime green pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	teal magnolia blossom	0		Last Available: "2012-12"
 5533	modified polymerized Mortimer's nostrum	0		Effect: "Adorable Lookout", Effect Duration: 29, Last Available: "2012-12"
-5534	lousy irresponsibly strong Barulio's bottle	10	decent	Last Available: "2012-12"
+5534	irresponsibly strong lousy Barulio's bottle	10	decent	Last Available: "2012-12"
 5535	wet narrow Marvin's marvelous pill	0		Effect: "Hammered", Effect Duration: 18, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5459,16 +5459,16 @@
 5556	Herculean Rain-Doh wings of the overflowing toilet	0		Experience (Muscle): +1, Stench Spell Damage: +50, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	asbestos-lined sizzling Rain-Doh laser gun	0		Hot Damage: +10, Hot Resistance: +5, Softcore Only, Last Available: "2012-02"
-5559	resourceful Rain-Doh lantern of Calamity Jane	0		Maximum MP: +50, Critical Hit Percent: +15, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	resourceful Rain-Doh lantern of Calamity Jane	0		Maximum MP: +50, Critical Hit Percent: +15, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	squat energetic shellacked Rain-Doh violet bo	0		Damage Reduction: 7, Maximum MP Percent: +20, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	spoiled PB&BP	3	crappy	
-5566	normal enchanted club sandwich	3	good	Effect: "Twinkly Weapon", Effect Duration: 35
+5566	enchanted normal club sandwich	3	good	Effect: "Twinkly Weapon", Effect Duration: 35
 5567	normal purple corned-beef Reuben	4	good	
-5568	ghostly skewed frayed ninja rope	0		
+5568	skewed ghostly frayed ninja rope	0		
 5569	wobbly dull ninja crampons	0		
 5570	tumbling loose ninja carabiner	0		
 5571	huge Groar's fur	0		
@@ -5478,83 +5478,83 @@
 5575	hand-crafted practically non-alcoholic Shot of the Living Dead	1	super ultra EPIC	Last Available: "2012-03"
 5576	smooth Buttery Knob	3	awesome	Last Available: "2012-03"
 5577	triple-distilled tolerable Slippery Knob	10	good	Last Available: "2012-03"
-5578	weak mediocre Flaming Knob	2	decent	Last Available: "2012-03"
+5578	mediocre weak Flaming Knob	2	decent	Last Available: "2012-03"
 5579	lousy Grasshopper	3	decent	Last Available: "2012-03"
 5580	acceptable pulsating Locust	4	good	Last Available: "2012-03"
-5581	weak bad Plague of Locusts	2	decent	Last Available: "2012-03"
-5582	bad weak Red Dwarf	2	decent	Last Available: "2012-03"
+5581	bad weak Plague of Locusts	2	decent	Last Available: "2012-03"
+5582	weak bad Red Dwarf	2	decent	Last Available: "2012-03"
 5583	artisanal watered-down Golden Mean	2	EPIC	Last Available: "2012-03"
-5584	watered-down smooth upside-down Green Giant	2	awesome	Last Available: "2012-03"
+5584	smooth watered-down upside-down Green Giant	2	awesome	Last Available: "2012-03"
 5585	watered-down artisanal Aye Aye	2	EPIC	Last Available: "2012-03"
-5586	tolerable pulsating huge Aye Aye, Captain	3	good	Last Available: "2012-03"
+5586	tolerable huge pulsating Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	acceptable weak cyan Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
 5588	acceptable Humanitini	3	good	Last Available: "2012-03"
-5589	bad practically non-alcoholic More Humanitini than Humanitini	1	decent	Last Available: "2012-03"
+5589	practically non-alcoholic bad More Humanitini than Humanitini	1	decent	Last Available: "2012-03"
 5590	drinkable yellow Oh, the Humanitini	4	good	Last Available: "2012-03"
 5591	lousy Great Older Fashioned	4	decent	Last Available: "2012-03"
-5592	high-proof mediocre huge Fuzzy Tentacle	9	decent	Last Available: "2012-03"
+5592	mediocre high-proof huge Fuzzy Tentacle	9	decent	Last Available: "2012-03"
 5593	irresponsibly strong tolerable Crazymaker	6	good	Last Available: "2012-03"
 5594	smooth special Zoodriver	3	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 15, Last Available: "2012-03"
-5595	fortified lousy special spinning Sloe Comfortable Zoo	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2012-03"
+5595	fortified special lousy spinning Sloe Comfortable Zoo	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2012-03"
 5596	aged red Sloe Comfortable Zoo on Fire	3	awesome	Last Available: "2012-03"
 5597	practically non-alcoholic artisanal Suffering Sinner	1	EPIC	Last Available: "2012-03"
 5598	drinkable Suppurating Sinner	4	good	Last Available: "2012-03"
-5599	watered-down artisanal huge Sizzling Sinner	2	EPIC	Last Available: "2012-03"
+5599	artisanal watered-down huge Sizzling Sinner	2	EPIC	Last Available: "2012-03"
 5600	perfectly mixed Firewater	4	EPIC	Last Available: "2012-03"
-5601	drinkable boozy Earth and Firewater	5	good	Last Available: "2012-03"
+5601	boozy drinkable Earth and Firewater	5	good	Last Available: "2012-03"
 5602	aged green Earth, Wind and Firewater	4	awesome	Last Available: "2012-03"
 5603	artisanal Slimosa	4	EPIC	Last Available: "2012-03"
 5604	hand-crafted bouncing Extra-slimy Slimosa	3	EPIC	Last Available: "2012-03"
 5605	bad Slimebite	4	decent	Last Available: "2012-03"
-5606	boozy drinkable Cement Mixer	5	good	Last Available: "2012-03"
+5606	drinkable boozy Cement Mixer	5	good	Last Available: "2012-03"
 5607	lousy bouncing Jackhammer	4	decent	Last Available: "2012-03"
 5608	bad Dump Truck	4	decent	Last Available: "2012-03"
 5609	bad practically non-alcoholic Fauna Libre	1	decent	Last Available: "2012-03"
 5610	mediocre gray upside-down Chakra Libre	3	decent	Last Available: "2012-03"
 5611	artisanal practically non-alcoholic olive Aura Libre	1	super ultra EPIC	Last Available: "2012-03"
-5612	aged fancy Sazerorc	3	awesome	Effect: "Electrolit Up", Effect Duration: 35, Last Available: "2012-03"
-5613	mediocre high-proof Sazuruk-hai	7	decent	Last Available: "2012-03"
+5612	fancy aged Sazerorc	3	awesome	Effect: "Electrolit Up", Effect Duration: 35, Last Available: "2012-03"
+5613	high-proof mediocre Sazuruk-hai	7	decent	Last Available: "2012-03"
 5614	high-proof lousy spinning Flaming Sazerorc	8	decent	Last Available: "2012-03"
 5615	irresponsibly strong bad Green Velvet	10	decent	Last Available: "2012-03"
 5616	artisanal Green Muslin	3	EPIC	Last Available: "2012-03"
 5617	hand-crafted Green Burlap	3	EPIC	Last Available: "2012-03"
 5618	perfectly mixed distilled Mohobo	5	EPIC	Last Available: "2012-03"
-5619	lousy weak Moonshine Mohobo	2	decent	Last Available: "2012-03"
-5620	tolerable watered-down Flaming Mohobo	2	good	Last Available: "2012-03"
+5619	weak lousy Moonshine Mohobo	2	decent	Last Available: "2012-03"
+5620	watered-down tolerable Flaming Mohobo	2	good	Last Available: "2012-03"
 5621	weak tolerable blinking Drunken Philosopher	2	good	Last Available: "2012-03"
-5622	lousy spirit-forward gray Drunken Neurologist	5	decent	Last Available: "2012-03"
+5622	spirit-forward lousy gray Drunken Neurologist	5	decent	Last Available: "2012-03"
 5623	lousy wobbly Drunken Astrophysicist	3	decent	Last Available: "2012-03"
 5624	drinkable Dark & Starry	3	good	Last Available: "2012-03"
 5625	hand-crafted Black Hole	4	EPIC	Last Available: "2012-03"
 5626	fortified mediocre tumbling Event Horizon	5	decent	Last Available: "2012-03"
 5627	drinkable blinking Herring Daiquiri	3	good	Last Available: "2012-03"
 5628	tolerable Herring Wallbanger	3	good	Last Available: "2012-03"
-5629	irresponsibly strong mediocre blinking Herringtini	6	decent	Last Available: "2012-03"
+5629	mediocre irresponsibly strong blinking Herringtini	6	decent	Last Available: "2012-03"
 5630	perfectly mixed Lollipop Drop	3	EPIC	Last Available: "2012-03"
 5631	drinkable weak Candy Alexander	2	good	Last Available: "2012-03"
-5632	watered-down perfectly mixed Candicaine	2	EPIC	Last Available: "2012-03"
+5632	perfectly mixed watered-down Candicaine	2	EPIC	Last Available: "2012-03"
 5633	artisanal huge Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	artisanal Flying Caipiranha	3	EPIC	Last Available: "2012-03"
 5635	acceptable Flaming Caipiranha	4	good	Last Available: "2012-03"
 5636	watered-down mediocre Punchplanter	2	decent	Last Available: "2012-03"
-5637	hand-crafted high-proof Doublepunchplanter	7	EPIC	Last Available: "2012-03"
-5638	hand-crafted fancy Haymaker	3	EPIC	Effect: "Brother Smothers's Blessing", Effect Duration: 50, Last Available: "2012-03"
+5637	high-proof hand-crafted Doublepunchplanter	7	EPIC	Last Available: "2012-03"
+5638	fancy hand-crafted Haymaker	3	EPIC	Effect: "Brother Smothers's Blessing", Effect Duration: 50, Last Available: "2012-03"
 5639	red Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	huge crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	bite-sized rotten fungus	1	crappy	
+5641	rotten bite-sized fungus	1	crappy	
 5642	poisoned dart	0		
-5643	moist boiled narrow huge stone wool	0		Effect: "Faboooo", Effect Duration: 23
+5643	moist boiled huge narrow stone wool	0		Effect: "Faboooo", Effect Duration: 23
 5644	stones	0		
 5645	shaking the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	calendar of Gandalf	0		Spell Critical Percent: +20, Damage Reduction: 4
-5648	executive scorching Boris's Helm	0		Hot Damage: +25, Meat Drop: +40, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	executive scorching Boris's Helm	0		Hot Damage: +25, Meat Drop: +40, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	vibrating healthy staph of homophones	0		Maximum HP Percent: +20, Maximum MP Percent: +10
-5650	arcane researcher's experienced Boris's Helm (askew) of the ox	0		Muscle: +20, Experience: +2, Experience Percent (Mysticality): +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	arcane researcher's experienced Boris's Helm (askew) of the ox	0		Muscle: +20, Experience: +2, Experience Percent (Mysticality): +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	bland big nailswurst	5	decent	
+5654	big bland nailswurst	5	decent	
 5655	hand-crafted upside-down used beer	3	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5564,24 +5564,24 @@
 5661	sizzling hairshirt	0		Hot Damage: +10
 5662	Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	shaking microwave	0		Free Pull
-5664	fuchsia pulsating pony keg	0		Free Pull
+5664	pulsating fuchsia pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	blurry How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	blurry puppet strings	0		Free Pull
 5668	gray narrow bagged &quot;L&quot;	0		
 5669	club	0		
 5670	decent bouncing fettucini &eacute;pines Inconnu	3	good	
-5671	watered-down bad slap and slap again	2	decent	
+5671	bad watered-down slap and slap again	2	decent	
 5672	gunpowder burrito	2	good	
-5673	blurry spinning pulsating beery blood	2	good	
+5673	spinning blurry pulsating beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	diluted squat lime green watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	executive Ze&trade; goggles	0		Meat Drop: +40, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	executive Ze&trade; goggles	0		Meat Drop: +40, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	stylish swimsuit of Calamity Jane of the early riser	0		Critical Hit Percent: +15, Adventures: +7, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	stylish swimsuit of Calamity Jane of the early riser	0		Critical Hit Percent: +15, Adventures: +7, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	ghostly lost key	0		Last Available: "2012-05"
-5681	jumbo normal purple spinning P.B.L.T.	5	good	
+5681	jumbo normal spinning purple P.B.L.T.	5	good	
 5682	skewed note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	handful of juicy garbage	0		
@@ -5605,17 +5605,17 @@
 5702	lime green mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	squat wax bugbear	0		Last Available: "2012-06"
-5705	lion tamer's wax hat of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	huge wobbly careful Oprah's wax pants	0		Maximum MP Percent: +50, Monster Level: -10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	lion tamer's wax hat of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	huge wobbly careful Oprah's wax pants	0		Maximum MP Percent: +50, Monster Level: -10, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	dry tarnished narrow drop of water-37	0		Effect: "Disdain of the War Snapper", Effect Duration: 41, Last Available: "2012-07"
-5709	nasty MacGyver's fireman's helmet	0		Maximum MP: +100, Stench Damage: +5, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	nasty MacGyver's fireman's helmet	0		Maximum MP: +100, Stench Damage: +5, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	shellacked fire axe	0		Damage Reduction: 7, Last Available: "2012-07"
 5713	horrifying stanky scorching fire extinguisher	0		Hot Damage: +25, Stench Spell Damage: +25, Spooky Damage: +25, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	gray Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	big spoiled jittery FDKOL hotcakes	5	crappy	Last Available: "2012-07"
+5717	spoiled big jittery FDKOL hotcakes	5	crappy	Last Available: "2012-07"
 5718	gray hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	huge spoiled fiery wing	9	crappy	Last Available: "2012-07"
@@ -5624,12 +5624,12 @@
 5723	frozen Vulcanized altered bottle of fire	0		Effect: "Bottle in front of Me", Effect Duration: 36, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	wool scandalous hot daub bun	0		Sleaze Damage: +5, Cold Resistance: +1, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	hardened boxer's hot daub stand	0		Muscle Percent: +10, Damage Reduction: 3, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	wool scandalous hot daub bun	0		Sleaze Damage: +5, Cold Resistance: +1, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	hardened boxer's hot daub stand	0		Muscle Percent: +10, Damage Reduction: 3, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	foot-long hot daub of wisdom	0		Mysticality: +15, Item Drop: +5, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	adequate enchanted shaking angst burger	3	good	Effect: "Adorable Lookout", Effect Duration: 25
-5731	special smooth irresponsibly strong 5-hour acrimony	8	awesome	Effect: "Cranberry Cordiality", Effect Duration: 15
+5731	irresponsibly strong smooth special 5-hour acrimony	8	awesome	Effect: "Cranberry Cordiality", Effect Duration: 15
 5732	narrow blank note	0		
 5733	eerily silent box	0		
 5734	yummy forbidden sausage	3	awesome	
@@ -5647,12 +5647,12 @@
 5746	stale spinning bag of QWOP	3	decent	Last Available: "2012-07"
 5747	super-corrupted CSA bravery badge	0		Effect: "Ghostly Shell", Effect Duration: 18, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	mediocre practically non-alcoholic twirling blue CSA cheerfulness ration	1	decent	Last Available: "2012-07"
+5749	mediocre practically non-alcoholic blue twirling CSA cheerfulness ration	1	decent	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	flavorless fancy wobbly crappy brain	3	decent	Effect: "Big Flaming Whip", Effect Duration: 20
+5752	fancy flavorless wobbly crappy brain	3	decent	Effect: "Big Flaming Whip", Effect Duration: 20
 5753	big stale decent brain	5	decent	
-5754	yummy half-sized good brain	2	awesome	
+5754	half-sized yummy good brain	2	awesome	
 5755	bland boss brain	3	decent	
 5756	rotten ghostly hunter brain	4	crappy	
 5758	narrow upside-down forbidden Sinatra's Staff of Holiday Sensations of the dark arts	0		Experience (Moxie): +5, Spell Damage Percent: 150, Last Available: "2011-11"
@@ -5665,11 +5665,11 @@
 5765	inspector's wicked fuzzy earmuffs	0		Spell Damage: +5, Item Drop: +15, Familiar Effect: "1.5xVolley, cap 32"
 5766	lard-coated ruddy arcane researcher's fuzzy montera	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, Sleaze Spell Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5767	purple Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	mirror gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	upside-down gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	huge gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	mirror gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	upside-down gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	huge gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	lime green talkative skull	0		
 5775	yellow fronts	0		Familiar Weight: +5
@@ -5706,21 +5706,21 @@
 5807	colloidal polarized jittery glass of warm milk	0		Effect: "Feroci Tea", Effect Duration: 28
 5808	non-corrupted squat glass of gnat milk	0		Effect: "Waxing", Effect Duration: 66
 5809	colloidal non-pickled upside-down Knob Goblin Mutagen	0		Effect: "Wreathed in Merriment", Effect Duration: 46
-5810	pressed red ghostly Tears of the Quiet Healer	0		Effect: "Egged On", Effect Duration: 65
+5810	pressed ghostly red Tears of the Quiet Healer	0		Effect: "Egged On", Effect Duration: 65
 5811	deionized concentrated tumbling tube of lipstick	0		Effect: "Pretending to Pretend", Effect Duration: 54
 5812	irradiated pickled skelelton spine	0		Effect: "Jungle Juiced", Effect Duration: 55
 5813	electrified vacuum-sealed wet tumbling smut orc sunglasses	0		Effect: "Berry Experiential", Effect Duration: 26
 5814	altered frozen nitrogenated blob of acid	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 67
 5815	cold-filtered flayed mind	0		Effect: "Human-Plant Hybrid", Effect Duration: 50
-5816	anodized blurry skewed kobold kibble	0		Effect: "Berry Critical", Effect Duration: 58
-5817	polymerized green ghostly forest spirit rattle	0		Effect: "Heart of Yellow", Effect Duration: 22
+5816	anodized skewed blurry kobold kibble	0		Effect: "Berry Critical", Effect Duration: 58
+5817	polymerized ghostly green forest spirit rattle	0		Effect: "Heart of Yellow", Effect Duration: 22
 5818	modified magnetized mirror Stone Golem pebbles	0		Effect: "Hardened Fabric", Effect Duration: 36
 5819	flattened gravy fairy warlock hat	0		Effect: "Busy Bein' Delicious", Effect Duration: 13
 5820	non-galvanized nitrogenated bull blubber	0		Effect: "Rat-Faced", Effect Duration: 12
 5821	Vulcanized frog lip-print	0		Effect: "Less Pervious", Effect Duration: 51
 5822	double-activated ionized huge gazely stare	0		Effect: "The Living Hitpoints", Effect Duration: 37
 5823	Vulcanized boiled canopic jar	0		Effect: "Morninja", Effect Duration: 57
-5824	magnetized polymerized skewed mirror clove-flavored lip balm	0		Effect: "Gonna Get You, Sucker", Effect Duration: 15
+5824	magnetized polymerized mirror skewed clove-flavored lip balm	0		Effect: "Gonna Get You, Sucker", Effect Duration: 15
 5825	corrupted Skullery Maid's Knee	0		Effect: "Spiritually Awake", Effect Duration: 49
 5826	triple-irradiated zombie hollandaise	0		Effect: "Jawin'", Effect Duration: 34
 5827	unsweetened super-polarized skeletal banana	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 58
@@ -5731,7 +5731,7 @@
 5832	double-wet ionized secret mummy herbs and spices	0		Effect: "Baconstoned", Effect Duration: 50
 5833	deionized spinning brigand brittle	0		Effect: "Craft Tea", Effect Duration: 60
 5834	adjusted pressed holistic headache remedy	0		Effect: "Ginger Snapped", Effect Duration: 64
-5835	vacuum-sealed pickled dry huge teal scrunchie tourniquet	0		Effect: "Ice Packed", Effect Duration: 31
+5835	vacuum-sealed pickled dry teal huge scrunchie tourniquet	0		Effect: "Ice Packed", Effect Duration: 31
 5836	Vulcanized huge embezzler's oil	0		Effect: "Took Eleven", Effect Duration: 36
 5837	non-enhanced extra-polymerized nitrogenated huge Fu Manchu Wax	0		Effect: "Creepin' Up on You", Effect Duration: 38
 5838	modified pressed Iiti Kitty Gumdrop	0		Effect: "Ghostly Shell", Effect Duration: 28
@@ -5741,9 +5741,9 @@
 5842	chilled dry colloidal toothbrush	0		Effect: "Tenacity of the Snapper", Effect Duration: 45
 5843	quadruple-denatured pirate cream pie	0		Effect: "Crimbo Nostalgia", Effect Duration: 12
 5844	tarnished denatured una poca de gracia	0		Effect: "The Smile of Mr. A.", Effect Duration: 18
-5845	quantum enhanced teal narrow compressed air canister	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 42
+5845	quantum enhanced narrow teal compressed air canister	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 42
 5846	extra-altered salt water taffy	0		Effect: "Wallflowering", Effect Duration: 62
-5847	extra-unsweetened spinning yellow unholy water	0		Effect: "Loyal Tea", Effect Duration: 19
+5847	extra-unsweetened yellow spinning unholy water	0		Effect: "Loyal Tea", Effect Duration: 19
 5848	non-chilled wet Bangyomaman battle juice	0		Effect: "Jelly Combed", Effect Duration: 32
 5849	flattened handyman &quot;hand soap&quot;	0		Effect: "Blubbered Up", Effect Duration: 58
 5850	improved space marine flash grenade	0		Effect: "Using Protection", Effect Duration: 62
@@ -5767,8 +5767,8 @@
 5868	fuchsia coward's papier-m&acirc;ch&eacute;te of the detective	0		Monster Level: -20, Item Drop: +20, Last Available: "2012-09"
 5869	green wicked Sinatra's papier-m&acirc;chine gun	0		Experience (Moxie): +5, Spell Damage: +5, Last Available: "2012-09"
 5870	sharpshooter's forbidden papier-masque	0		Spell Damage Percent: +50, Critical Hit Percent: +10, Single Equip, Last Available: "2012-09"
-5871	vibrating Newton's papier-mitre	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	crafty groovy papier-m&acirc;churidars	0		Moxie Percent: +10, Maximum MP: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	vibrating Newton's papier-mitre	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	crafty groovy papier-m&acirc;churidars	0		Moxie Percent: +10, Maximum MP: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	red papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,11 +5779,11 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	Lo Pan's medical-grade beefcake's skeleton skis	0		Muscle: +25, Spell Critical Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2012-10"
-5883	moldy big skeleton quiche	5	crappy	Last Available: "2012-10"
+5883	big moldy skeleton quiche	5	crappy	Last Available: "2012-10"
 5884	skewed skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	blurry skeletal skiff	0		Last Available: "2012-10"
 5886	jittery Temple Grandin's Jim Carey's arcane researcher's Bonestabber of the sewer	0		Experience Percent (Mysticality): +10, Monster Level: +25, Familiar Weight: +7, Stench Damage: +25, Last Available: "2012-10"
-5887	drinkable watered-down crystal skeleton vodka	2	good	Last Available: "2012-10"
+5887	watered-down drinkable crystal skeleton vodka	2	good	Last Available: "2012-10"
 5888	narrow Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	wool auxiliary backbone	0		Cold Resistance: +1, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5811,7 +5811,7 @@
 5913	liquefied candy sushi set	0		Effect: "Pasta Oneness", Effect Duration: 22, Last Available: "2012-12"
 5914	quadruple-anodized Vulcanized yellow sweet mochi ball	0		Effect: "Well-Lubed", Effect Duration: 26, Last Available: "2012-12"
 5915	electrified modified dry beet-flavored Mr. Mediocrebar	0		Effect: "Earthen Fist", Effect Duration: 53, Last Available: "2012-12"
-5916	polymerized electrified warmed jittery shaking bouncing sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Liquidy Smoky", Effect Duration: 22, Last Available: "2012-12"
+5916	polymerized electrified warmed jittery bouncing shaking sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Liquidy Smoky", Effect Duration: 22, Last Available: "2012-12"
 5917	wet dry pressed maroon cabbage-flavored Mr. Mediocrebar	0		Effect: "Scorpio Rising", Effect Duration: 51, Last Available: "2012-12"
 5918	wobbly zippy plastic animelf	0		Initiative: +20, Last Available: "2012-12"
 5919	upside-down ghostly chaotic plastic ChibiBuddy&trade;	0		Spell Critical Percent: +10, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	pulsating ghostly strapping brainwave-controlled unicorn horn	0		Muscle: +5, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	pulsating ghostly strapping brainwave-controlled unicorn horn	0		Muscle: +5, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	olive shaking zippy brainy plastic four-shadowed mime of wisdom	0		Mysticality: 20, Initiative: +20, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	teal manspreader's plastic Father McGruber	0		Monster Level: +10, Last Available: "2012-12"
 5961	squat ruddy plastic Hank North, Photojournalist	0		Maximum HP Percent: +40, Last Available: "2012-12"
 5962	plastic blazing bat of extreme caution	0		Monster Level: -25, Last Available: "2012-12"
-5963	MacGyver's electronic dulcimer pants of the sewer	0		Maximum MP: +100, Stench Damage: +25, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	MacGyver's electronic dulcimer pants of the sewer	0		Maximum MP: +100, Stench Damage: +25, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	up-at-dawn cool Frown Exerciser	0		Moxie: +5, Adventures: +5, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5879,29 +5879,29 @@
 5981	star	0		Last Available: "2013-02"
 5982	artisanal tankard of ale	3	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	sizzling experienced boxer's cloth cap	0		Muscle Percent: +10, Experience: +2, Hot Damage: +10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	sizzling experienced boxer's cloth cap	0		Muscle Percent: +10, Experience: +2, Hot Damage: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	blue smelly nippy iron dagger of courage	0		Cold Damage: +10, Stench Spell Damage: +10, Spooky Resistance: +3, Last Available: "2013-02"
 5986	rotten hamburger	4	crappy	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
 5990	artisanal yellow bottle of wine	3	EPIC	Last Available: "2013-02"
-5991	tumbling gray narrow round bomb	0		Last Available: "2013-02"
-5992	teal dog trainer's crafty iron helmet of the overflowing toilet	0		Maximum MP: +10, Experience (familiar): +1, Stench Spell Damage: +50, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5991	gray narrow tumbling round bomb	0		Last Available: "2013-02"
+5992	teal dog trainer's crafty iron helmet of the overflowing toilet	0		Maximum MP: +10, Experience (familiar): +1, Stench Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	wool steel sword of extreme caution of temperance	0		Monster Level: -25, Cold Resistance: +1, Sleaze Resistance: +5, Last Available: "2013-02"
 5994	flavorless whole roasted chicken	3	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
-5997	squat fuchsia potion	0		Last Available: "2013-02"
-5998	high-proof mediocre blinking shining goblet	10	decent	Last Available: "2013-02"
+5997	fuchsia squat potion	0		Last Available: "2013-02"
+5998	mediocre high-proof blinking shining goblet	10	decent	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	double-paned banded Samson's crown	0		Experience (Muscle): +5, Damage Absorption: +100, Cold Resistance: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	double-paned banded Samson's crown	0		Experience (Muscle): +5, Damage Absorption: +100, Cold Resistance: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	Jeselnik's Tesla sword of the glutton	0		Sleaze Damage: +25, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02"
-6002	vibrating banded dance instructor's Helm of the Scream Emperor	0		Experience Percent (Moxie): +10, Damage Absorption: +100, Maximum MP Percent: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	vibrating banded dance instructor's Helm of the Scream Emperor	0		Experience Percent (Moxie): +10, Damage Absorption: +100, Maximum MP Percent: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	red blinking double-paned ribald coward's Cloak of Dire Shadows	0		Monster Level: -20, Sleaze Damage: +10, Cold Resistance: +5, Last Available: "2013-02"
 6004	yellow rock-hard Herculean supercool Sword of Dark Omens	0		Moxie Percent: +20, Experience (Muscle): +1, Damage Reduction: 5, Last Available: "2013-02"
 6005	lime green wicked Shield of Icy Fate of the blizzard of doom	0		Spell Damage: +5, Cold Spell Damage: +25, Spooky Spell Damage: +50, Damage Reduction: 7, Last Available: "2013-02"
-6006	skewed sharpshooter's hardy strapping Greaves of the Murk Lord	0		Muscle: +5, Maximum HP: +50, Critical Hit Percent: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	skewed sharpshooter's hardy strapping Greaves of the Murk Lord	0		Muscle: +5, Maximum HP: +50, Critical Hit Percent: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	Sherlock's inspector's Newton's Gauntlets of the Blood Moon	0		Experience (Mysticality): +3, Item Drop: 40, Single Equip, Last Available: "2013-02"
 6008	narrow Temple Grandin's padded smartaleck's Boots of Twilight Whispers	0		Moxie Percent: +30, Damage Absorption: +20, Familiar Weight: +7, Single Equip, Last Available: "2013-02"
 6009	cyan twirling greedy hale rosy-cheeked Belt of Howling Anger	0		Maximum HP Percent: +30, Maximum HP: +20, Meat Drop: +20, Single Equip, Last Available: "2013-02"
@@ -5912,8 +5912,8 @@
 6014	strapping screwing pooch	0		Muscle: +5
 6015	enhanced ionized orcish hand lotion	0		Effect: "Vitamin-Maxed", Effect Duration: 34
 6016	super-irradiated anodized orcish rubber	0		Effect: "Sausage Festive", Effect Duration: 65
-6017	improved denatured squat skewed orcish nailing lube	0		Effect: "Sagittarius Rising", Effect Duration: 17
-6018	mediocre irresponsibly strong backwoods screwdriver	10	decent	
+6017	improved denatured skewed squat orcish nailing lube	0		Effect: "Sagittarius Rising", Effect Duration: 17
+6018	irresponsibly strong mediocre backwoods screwdriver	10	decent	
 6019	tumbling hale loadstone	0		Maximum HP: +20
 6020	scorching Rosewater's Claybender glasses	0		Mysticality Percent: +30, Hot Damage: +25, Single Equip
 6021	zippy beefcake's Duskwalker fangs	0		Muscle: +25, Initiative: +20
@@ -5931,7 +5931,7 @@
 6033	miser's sage stolen necklace	0		Mysticality Percent: +10, Meat Drop: +10
 6034	sharpshooter's beefy troll britches	0		Muscle: +10, Critical Hit Percent: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	liquefied vial of The Glistening	0		Effect: "Whole Latte Love", Effect Duration: 60
-6036	watered-down tolerable blurry artisanal limoncello	2	good	
+6036	tolerable watered-down blurry artisanal limoncello	2	good	
 6037	ginger ale	0		
 6038	normal incredible pizza	3	good	
 6039	cyan careful wholesome oil cap	0		Maximum HP Percent: +10, Monster Level: -10, Familiar Effect: "cap 28"
@@ -5947,7 +5947,7 @@
 6049	Van der Graaf energetic Sinatra's Misty Cape	0		Experience (Moxie): +5, Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7
 6050	gray woimbook	0		Familiar Weight: +5
 6051	squat huge Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	toothsome skewed huge Taco Dan's Taco Stand Taco	3	awesome	Last Available: "2012-12"
+6052	toothsome huge skewed Taco Dan's Taco Stand Taco	3	awesome	Last Available: "2012-12"
 6053	tolerable mirror mirror Taco Dan's Taco Stand Chimichangarita	3	good	Last Available: "2012-12"
 6054	boiled cold-filtered ghostly Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Sealed Brain", Effect Duration: 65, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
@@ -5970,7 +5970,7 @@
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	polymerized deionized haggis-infused soap	0		Effect: "Mutated", Effect Duration: 66, Last Available: "2012-12"
 6074	quadruple-liquefied magicberry tablets	0		Effect: "Loco Motives", Effect Duration: 36, Last Available: "2012-12"
-6075	denatured enhanced twirling pulsating 37x37x37 puzzle cube	0		Effect: "No Worries", Effect Duration: 55, Last Available: "2012-12"
+6075	denatured enhanced pulsating twirling 37x37x37 puzzle cube	0		Effect: "No Worries", Effect Duration: 55, Last Available: "2012-12"
 6076	smooth McLeod's Hard Haggis-Ade	3	awesome	Last Available: "2012-12"
 6077	toothsome gray jittery haggis-wrapped haggis-stuffed haggis	3	awesome	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
@@ -5996,7 +5996,7 @@
 6098	gourd potion	0		Last Available: "2013-12"
 6099	supercool Thinknerd T-Shirt	0		Moxie Percent: +20, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
-6101	blinking spinning upside-down homemade robot	0		Last Available: "2012-12"
+6101	upside-down spinning blinking homemade robot	0		Last Available: "2012-12"
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
@@ -6040,13 +6040,13 @@
 6142	normal roasted duck	4	good	Last Available: "2013-12"
 6143	adequate dead meat bun	4	good	Last Available: "2013-12"
 6144	rosewater-soaked cat collar	0		Stench Resistance: +3, Single Equip, Last Available: "2013-12"
-6145	gray stanky suspicious-looking fedora of the brute	0		Muscle Percent: +30, Stench Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	gray stanky suspicious-looking fedora of the brute	0		Muscle Percent: +30, Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	miniature decent fuchsia carrot cake	2	good	Last Available: "2013-01"
+6152	decent miniature fuchsia carrot cake	2	good	Last Available: "2013-01"
 6153	smooth carrot claret	3	awesome	Last Available: "2013-01"
 6154	diluted spinning carrot juice	1	EPIC	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
@@ -6058,8 +6058,8 @@
 6161	regret hose of the ox	0		Muscle: +20, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	purple Annie Oakley's therapeutic commodore's hat	0		Critical Hit Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	shellacked naval trousers	0		Damage Reduction: 7, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	purple Annie Oakley's therapeutic commodore's hat	0		Critical Hit Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	shellacked naval trousers	0		Damage Reduction: 7, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	greasy deck cannon of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10, Last Available: "2013-12"
 6167	avaricious ornamental sextant	0		Meat Drop: +30, Last Available: "2013-12"
 6168	toasty ruddy Bloodbath	0		Maximum HP Percent: +40, Hot Damage: +5, Last Available: "2013-12"
@@ -6071,7 +6071,7 @@
 6174	skewed GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
-6177	bouncing teal cosmic dough	0		
+6177	teal bouncing cosmic dough	0		
 6178	cosmic vegetable	0		
 6179	lime green cosmic cheese	0		
 6180	purple cosmic potted meat product	0		
@@ -6079,7 +6079,7 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	boxer's Jarlsberg's hat of Tarzan of the glutton	0		Muscle Percent: +10, Experience (Muscle): +3, Food Drop: +100
-6185	moldy thick blurry consummate hard-boiled egg	5	crappy	
+6185	thick moldy blurry consummate hard-boiled egg	5	crappy	
 6186	snack-sized delicious consummate fried egg	2	awesome	
 6187	small decent consummate egg salad	2	good	
 6188	adequate consummate bagel	3	good	
@@ -6088,29 +6088,29 @@
 6191	moldy consummate brownie	4	crappy	
 6192	delicious consummate toast	4	awesome	
 6193	mediocre huge passable stout	3	decent	
-6194	tasty diet consummate soup	1	awesome	
-6195	spoiled small consummate corn chips	2	crappy	
+6194	diet tasty consummate soup	1	awesome	
+6195	small spoiled consummate corn chips	2	crappy	
 6196	rotten yellow consummate salad	4	crappy	
-6197	immense decent teal consummate salsa	6	good	
-6198	normal diet narrow consummate sauerkraut	1	good	
-6199	fancy normal consummate cheese slice	4	good	Effect: "Shrimpin' Ain't Easy", Effect Duration: 40
-6200	tiny adequate consummate melted cheese	1	good	
+6197	decent immense teal consummate salsa	6	good	
+6198	diet normal narrow consummate sauerkraut	1	good	
+6199	normal fancy consummate cheese slice	4	good	Effect: "Shrimpin' Ain't Easy", Effect Duration: 40
+6200	adequate tiny consummate melted cheese	1	good	
 6201	spoiled big consummate bacon	5	crappy	
 6202	miniature decent consummate meatloaf	2	good	
 6203	flavorless shaking consummate steak	3	decent	
 6204	spoiled diet consummate cuts	1	crappy	
-6205	stale special small consummate frankfurter	2	decent	Effect: "Mighty Shout", Effect Duration: 30
+6205	small stale special consummate frankfurter	2	decent	Effect: "Mighty Shout", Effect Duration: 30
 6206	stale ghostly consummate french fries	4	decent	
 6207	rotten twirling consummate baked potato	3	crappy	
 6208	acceptable acceptable vodka	4	good	
 6209	normal consummate ice cream	4	good	
-6210	spoiled snack-sized enchanted squat jittery consummate whipped cream	2	crappy	Effect: "Total Protonic Reversal", Effect Duration: 15
+6210	enchanted snack-sized spoiled jittery squat consummate whipped cream	2	crappy	Effect: "Total Protonic Reversal", Effect Duration: 15
 6211	stale consummate cream	4	decent	
 6212	snack-sized stale consummate strawberries	2	decent	
 6213	spoiled enchanted consummate sorbet	4	crappy	Effect: "High Blood Chocolate Content", Effect Duration: 15
 6214	acceptable adequate rum	3	good	
 6215	aged weak mediocre lager	2	awesome	
-6216	adequate bite-sized immaculate grilled cheese	1	good	
+6216	bite-sized adequate immaculate grilled cheese	1	good	
 6217	small moldy tumbling immaculate ice cream sandwich	2	crappy	
 6218	bland immaculate hot dog	4	decent	
 6219	stale miniature immaculate egg salad sandwich	2	decent	
@@ -6118,20 +6118,20 @@
 6221	toothsome perfect chef salad	3	awesome	
 6222	rotten blue perfect breakfast	3	crappy	
 6223	stale sublime deluxe hot dog	4	decent	
-6224	rotten massive sublime stew	7	crappy	
+6224	massive rotten sublime stew	7	crappy	
 6225	moldy cyan sublime nachos	3	crappy	
 6226	spoiled Ultimate Breakfast Sandwich	4	crappy	
 6227	adequate Loaded Baked Potato	3	good	
-6228	diet stale Omega Sundae	1	decent	
-6229	drinkable high-proof Das Sauerlager	6	good	
+6228	stale diet Omega Sundae	1	decent	
+6229	high-proof drinkable Das Sauerlager	6	good	
 6230	lousy mirror Bologna Lambic	3	decent	
 6231	artisanal Vodka Dog	3	EPIC	
 6232	hand-crafted Disappointed Russian	4	EPIC	
 6233	tolerable Chunky Mary	3	good	
 6234	artisanal twirling Nachojito	3	EPIC	
 6235	aged huge Le Roi	3	awesome	
-6236	watered-down tolerable twirling Over Easy Rider	2	good	
-6237	blinking blurry cosmic six-pack	0		
+6236	tolerable watered-down twirling Over Easy Rider	2	good	
+6237	blurry blinking cosmic six-pack	0		
 6239	colloidal boiled cube of ectoplasm	0		Effect: "Taurus Rising", Effect Duration: 58
 6240	quantum Illuminati earpiece	0		Effect: "Horrid, Torrid", Effect Duration: 63
 6241	electrified magnetized mirror censored can label	0		Effect: "Ode to Booze", Effect Duration: 50
@@ -6160,21 +6160,21 @@
 6264	Oprah's brawny Staff of Fruit Salad of bravery	0		Muscle Percent: +20, Maximum MP Percent: +50, Spooky Resistance: +5, Jiggle: "Deal Some Prismatic Damage"
 6265	squat miser's flame-retardant Staff of the Cream of the Cream of incineration	0		Hot Spell Damage: +50, Hot Resistance: +1, Meat Drop: +10, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	bland massive fancy olive tumbling grain of protein powder	6	decent	Effect: "Innately Strong", Effect Duration: 30
+6267	massive bland fancy tumbling olive grain of protein powder	6	decent	Effect: "Innately Strong", Effect Duration: 30
 6268	concentrated ghostly pec oil	0		Effect: "Enraged", Effect Duration: 37
 6269	fuchsia gym membership card of Tarzan	0		Experience (Muscle): +3
 6270	energized nitrogenated chilled Squat-Thrust Magazine	0		Effect: "Discomfited", Effect Duration: 67
 6271	massive dumbbell	0		
 6272	narrow inspector's chaotic penguin keychain	0		Spell Critical Percent: +10, Item Drop: +15, Damage Reduction: 10
 6273	galvanized non-anodized jittery O'RLY manual	0		Effect: "Dreams and Lights", Effect Duration: 29
-6274	practically non-alcoholic acceptable open sauce	1	good	
+6274	acceptable practically non-alcoholic open sauce	1	good	
 6275	huge Samson's turkey leg of the empath	0		Experience (Muscle): +5, Familiar Weight: +5
 6276	bad tumbling Ye Olde Meade	4	decent	
 6277	unsweetened yellow Ye Olde Bawdy Limerick	0		Effect: "Milk Studly", Effect Duration: 23
 6278	Ye Olde Medieval Insult	0		
 6279	frosty pewter claymore	0		Cold Spell Damage: +10
 6280	purple Jim Carey's artisanal rice peeler	0		Monster Level: +25
-6281	snack-sized moldy heirloom grape tomato	2	crappy	
+6281	moldy snack-sized heirloom grape tomato	2	crappy	
 6282	gray chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6264,9 +6264,9 @@
 6368	Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	practically non-alcoholic tolerable special spinning mirror can of the cheapest beer	1	good	Effect: "Human-Slime Hybrid", Effect Duration: 5
+6371	special tolerable practically non-alcoholic mirror spinning can of the cheapest beer	1	good	Effect: "Human-Slime Hybrid", Effect Duration: 5
 6372	hand-crafted lime green bottle of fruity &quot;wine&quot;	3	EPIC	
-6373	practically non-alcoholic artisanal special fuchsia single swig of vodka	1	EPIC	Effect: "Wreathed in Smoke", Effect Duration: 5
+6373	special artisanal practically non-alcoholic fuchsia single swig of vodka	1	EPIC	Effect: "Wreathed in Smoke", Effect Duration: 5
 6374	squat angry inch	0		
 6375	wobbly smartaleck's testy toolbox	0		Moxie Percent: +30
 6376	squat Jick-o-User	0		
@@ -6276,7 +6276,7 @@
 6381	anodized mysterious chemical residue	0		Effect: "Like a Fish to Walter", Effect Duration: 60
 6382	shaking nugget of sodium	0		
 6383	root beer	1	crappy	
-6384	blinking huge jigsaw blade	0		
+6384	huge blinking jigsaw blade	0		
 6385	skewed wood screw	0		
 6386	balsa plank	0		
 6387	blob of wood glue	0		
@@ -6312,7 +6312,7 @@
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	galvanized moth dust	0		Effect: "Sugar Smacks", Effect Duration: 27
-6420	flattened maroon blurry glob of spoiled mayo	0		Effect: "Deadly Flashing Blade", Effect Duration: 51
+6420	flattened blurry maroon glob of spoiled mayo	0		Effect: "Deadly Flashing Blade", Effect Duration: 51
 6421	tonic djinn	0		
 6422	decent vampire chowder	3	good	
 6423	Tales of Dread	0		Free Pull
@@ -6320,17 +6320,17 @@
 6425	jittery Official Seal of Dreadsylvania	0		
 6426	decent Dreadsylvanian stew	3	good	
 6427	drinkable Dreadsylvanian	3	good	
-6428	warmed mirror fuchsia Dreadsylvanian flask	0		Effect: "Towering Strength", Effect Duration: 18
+6428	warmed fuchsia mirror Dreadsylvanian flask	0		Effect: "Towering Strength", Effect Duration: 18
 6429	quantum wet mirror Dreadsylvanian flask	0		Effect: "Eye of the Seal", Effect Duration: 69
 6430	family-friendly brawny dreadful fedora	0		Muscle Percent: +20, Sleaze Resistance: +1, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	dreadful sweater of the empath	0		Familiar Weight: +5, Kruegerand Drop: 5
 6432	narrow auspicious dreadful glove	0		Item Drop: +10, Kruegerand Drop: 5
 6433	Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
-6435	huge upside-down Mark of the Werewolf	0		
+6435	upside-down huge Mark of the Werewolf	0		
 6436	pulsating blue Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
-6438	pulsating blinking Mark of the Vampire	0		
+6438	blinking pulsating Mark of the Vampire	0		
 6439	green jittery Mark of the Skeleton	0		
 6440	clever brainy Covers-Your-Head of mayonnaise	0		Mysticality: +5, Maximum MP: +20, Sleaze Spell Damage: +50, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
 6441	resourceful Sinatra's Socratic Drapes-You-Regally	0		Experience (Mysticality): +1, Experience (Moxie): +5, Maximum MP: +50, Class: "Disco Bandit"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	skewed dreadful roast	0		
 6487	huge stinking agaricus	0		
-6488	special decent mirror Dreadsylvanian shepherd's pie	3	good	Effect: "Demonic Flavor", Effect Duration: 30
+6488	decent special mirror Dreadsylvanian shepherd's pie	3	good	Effect: "Demonic Flavor", Effect Duration: 30
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6448,14 +6448,14 @@
 6554	stench cluster	0		
 6555	sleaze cluster	0		
 6556	vacuum-sealed adjusted blurry jittery phial of hotness	0		Effect: "Ruby-ous", Effect Duration: 50
-6557	vacuum-sealed blurry shaking twirling phial of coldness	0		Effect: "Thicker, Sicker", Effect Duration: 21
+6557	vacuum-sealed shaking twirling blurry phial of coldness	0		Effect: "Thicker, Sicker", Effect Duration: 21
 6558	corrupted oxidized phial of spookiness	0		Effect: "Gummiheart", Effect Duration: 36
 6559	activated phial of stench	0		Effect: "Memory of Speed", Effect Duration: 28
 6560	dry altered spinning spinning phial of sleaziness	0		Effect: "Pasta Oneness", Effect Duration: 23
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	wobbly mini-Mr. Accessory	0		Familiar Weight: +5
 6563	tumbling hand of Mr. Cards of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	fancy stale Dreadsylvanian hot pocket	3	decent	Effect: "Riboflavin'", Effect Duration: 45
+6564	stale fancy Dreadsylvanian hot pocket	3	decent	Effect: "Riboflavin'", Effect Duration: 45
 6565	spoiled super-sized squat Dreadsylvanian pocket	5	crappy	
 6566	decent snack-sized Dreadsylvanian pocket	2	good	
 6567	toothsome maroon Dreadsylvanian stink pocket	3	awesome	
@@ -6465,7 +6465,7 @@
 6571	watered-down drinkable Dreadsylvanian grimlet	2	good	
 6572	perfectly mixed Dreadsylvanian dank and stormy	3	super ultra mega turbo EPIC	
 6573	hand-crafted cyan Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
-6574	pulsating blue hot clusterbomb	0		
+6574	blue pulsating hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
 6577	stench clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	padded Fonzie's gnawed-up dog bone	0		Experience (Moxie): +1, Damage Absorption: +20
 6589	cyan energetic Grey Guanon	0		Maximum MP Percent: +20
 6590	supercharged studded wizardly Engorged Sausages and You	0		Mysticality: +25, Damage Absorption: +80, Maximum MP Percent: +30
-6591	watered-down tolerable dream of a dog	2	good	
+6591	tolerable watered-down dream of a dog	2	good	
 6592	red forbidden optimal spreadsheet of Tarzan of extreme caution	0		Experience (Muscle): +3, Spell Damage Percent: +50, Monster Level: -25
 6593	blinking defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
@@ -6496,7 +6496,7 @@
 6602	clockwork numeral II	0		
 6603	clockwork numeral III	0		
 6604	teal clockwork numeral IV	0		
-6605	ghostly cyan clockwork numeral V	0		
+6605	cyan ghostly clockwork numeral V	0		
 6606	skewed clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
 6608	maroon skewed clockwork numeral VIII	0		
@@ -6507,7 +6507,7 @@
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	hand-crafted Cold One	3	???	
-6616	half-sized flavorless squat spaghetti breakfast	2	???	
+6616	flavorless half-sized squat spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	super-energized Ogres and Oubliettes&trade; module	0		Effect: "Educated (Kinda)", Effect Duration: 23
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	delicious strong stepmom's booze	5	awesome	
+6652	strong delicious stepmom's booze	5	awesome	
 6653	surgical tape	0		
 6654	supercool band T-shirt	0		Moxie Percent: +20
 6655	lousy spinning narrow olive fountain 'soda'	4	decent	
@@ -6556,7 +6556,7 @@
 6664	bouncing world's most dangerous birdhouse	0		
 6665	deathchucks of the ox of the overflowing toilet	0		Muscle: +20, Stench Spell Damage: +50
 6666	eraser	0		
-6667	mirror wobbly quasireligious sculpture	0		
+6667	wobbly mirror quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	modeling claymore	0		
 6670	twirling clay homunculus	0		
@@ -6565,11 +6565,11 @@
 6673	gray yellowcake bomb	0		
 6674	twirling stinkbomb	0		
 6675	colloidal magnetized superwater	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 51
-6676	huge jittery Thwaitgold bookworm statuette	0		
+6676	jittery huge Thwaitgold bookworm statuette	0		
 6677	upside-down crude monster sculpture	0		
 6678	skewed Samson's Yearbook Club Camera	0		Experience (Muscle): +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	executive machete	0		Meat Drop: +40
-6680	enchanted artisanal fuchsia Cursed Punch	3	EPIC	Effect: "Shawarma Initiative", Effect Duration: 25
+6680	artisanal enchanted fuchsia Cursed Punch	3	EPIC	Effect: "Shawarma Initiative", Effect Duration: 25
 6681	drinkable fancy Bowl of Scorpions	4	good	Effect: "Very Clean Guns", Effect Duration: 45
 6682	bad mirror Fog Murderer	3	decent	
 6683	book of matches	0		
@@ -6579,7 +6579,7 @@
 6687	healthy surgical apron	0		Maximum HP Percent: +20, Surgeonosity: +1
 6688	upside-down Temple Grandin's bloodied surgical dungarees	0		Familiar Weight: +7, Surgeonosity: +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 6689	tumbling McClusky file (page 1)	0		
-6690	blinking olive McClusky file (page 2)	0		
+6690	olive blinking McClusky file (page 2)	0		
 6691	McClusky file (page 3)	0		
 6692	twirling blue McClusky file (page 4)	0		
 6693	McClusky file (page 5)	0		
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	purple imitation White Russian	1	decent	
 6704	skewed executive Da Vinci's short-handled mop	0		Experience (Mysticality): +5, Meat Drop: +40
-6705	normal fancy jungle floor wax	3	good	Effect: "Pumped Up", Effect Duration: 30
+6705	fancy normal jungle floor wax	3	good	Effect: "Pumped Up", Effect Duration: 30
 6706	spinning smirking shrunken head	0		
 6707	non-galvanized liquefied unsweetened tumbling colorful toad	0		Effect: "Holiday Disappointment", Effect Duration: 44
 6708	ghostly crude voodoo doll	0		
@@ -6612,13 +6612,13 @@
 6720	pickled unsweetened spinning huge pill cup	0		Effect: "Worth Your Salt", Effect Duration: 57
 6721	sharpshooter's supercharged fortified water bottle	0		Damage Absorption: +60, Maximum MP Percent: +30, Critical Hit Percent: +10, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	improved tarnished denatured pygmy phone number	0		Effect: "Healthy Red Glow", Effect Duration: 47
-6723	huge purple Boozehounds Anonymous token	0		
+6723	purple huge Boozehounds Anonymous token	0		
 6724	stale diet exotic jungle fruit	1	decent	
 6725	upside-down Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
-6729	upside-down blurry UV-resistant compass	0		
+6729	blurry upside-down UV-resistant compass	0		
 6730	blurry funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
@@ -6628,14 +6628,14 @@
 6736	skewed Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	jagged scrap	0		
-6739	triple-aerosolized twirling wobbly olive bent scrap	0		Effect: "Extra Terrestrial", Effect Duration: 11
+6739	triple-aerosolized twirling olive wobbly bent scrap	0		Effect: "Extra Terrestrial", Effect Duration: 11
 6740	molten scrap	0		
 6741	eternal car battery	0		
 6742	gravedigger's junk band	0		Spooky Damage: +10
 6743	brawny junk trunks	0		Muscle Percent: +20, Familiar Effect: "cap 15"
 6744	nasty junk-mail shirt	0		Stench Damage: +5
 6745	huge yummy pulsating junk food	7	awesome	
-6746	practically non-alcoholic perfectly mixed narrow junk yard	1	EPIC	
+6746	perfectly mixed practically non-alcoholic narrow junk yard	1	EPIC	
 6747	Sherlock's razor-sharp swordzall	0		Weapon Damage Percent: +25, Item Drop: +25
 6748	arm buzzer	0		Item Drop: +5, Damage Reduction: 6
 6749	Sherlock's clever boilgun	0		Maximum MP: +20, Item Drop: +25
@@ -6650,15 +6650,15 @@
 6758	tolerable irresponsibly strong narrow can of Drooling Monk	9	good	Last Available: "2013-09"
 6759	lousy can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
 6760	perfectly mixed twirling bottle of Old Pugilist	4	EPIC	Last Available: "2013-09"
-6761	mediocre distilled shaking narrow bottle of Professor Beer	5	decent	Last Available: "2013-09"
+6761	mediocre distilled narrow shaking bottle of Professor Beer	5	decent	Last Available: "2013-09"
 6762	practically non-alcoholic smooth bottle of Rapier Witbier	1	awesome	Last Available: "2013-09"
 6763	mediocre bottle of Race Car Red	4	decent	Last Available: "2013-09"
-6764	lousy irresponsibly strong bottle of Greedy Dog	7	decent	Last Available: "2013-09"
+6764	irresponsibly strong lousy bottle of Greedy Dog	7	decent	Last Available: "2013-09"
 6765	triple-distilled tolerable bottle of Lambada Lambic	10	good	Last Available: "2013-09"
 6766	blurry tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
-6769	knitted hale grievous tin tam	0		Weapon Damage Percent: +50, Maximum HP: +20, Cold Resistance: +3, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	knitted hale grievous tin tam	0		Weapon Damage Percent: +50, Maximum HP: +20, Cold Resistance: +3, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	diffused wobbly tin cup	0		Effect: "Hot Hands", Effect Duration: 69, Last Available: "2013-09"
 6771	studded tin foil of extreme caution of courage	0		Damage Absorption: +80, Monster Level: -25, Spooky Resistance: +3, Last Available: "2013-09"
 6772	pulsating greasy mansplainer's stiffened tin drum	0		Damage Reduction: 1, Monster Level: +15, Sleaze Spell Damage: +10, Last Available: "2013-09"
@@ -6717,7 +6717,7 @@
 6828	weak perfectly mixed discocktail	2	EPIC	
 6829	hardened KoL Con X Bingo Card	0		Damage Reduction: 3
 6830	wizardly Temporal Tempera Tube	0		Mysticality: +25
-6831	electrified deionized squat fuchsia Tallowcreme Halloween Pumpkin	0		Effect: "Moon-Eyed", Effect Duration: 49
+6831	electrified deionized fuchsia squat Tallowcreme Halloween Pumpkin	0		Effect: "Moon-Eyed", Effect Duration: 49
 6832	blue Way More Tears&trade; pepper spray	0		
 6833	warmed dry Milk Studs	0		Effect: "Alchemical, Brother", Effect Duration: 19
 6834	moist box of Dweebs	0		Effect: "Aided and Abetted", Effect Duration: 25
@@ -6726,7 +6726,7 @@
 6837	colloidal polarized ghostly Swizzler	0		Effect: "Tingling Feeling", Effect Duration: 59
 6838	flattened narrow Bugbearclaw Donut	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 27
 6839	deionized non-dry jam	0		Effect: "Dreadful Fear", Effect Duration: 11
-6840	polarized alkaline blinking red Whenchamacallit bar	0		Effect: "Bark of the Dog", Effect Duration: 59
+6840	polarized alkaline red blinking Whenchamacallit bar	0		Effect: "Bark of the Dog", Effect Duration: 59
 6841	enhanced extra-denatured teal 8-bit banana	0		Effect: "The Moxie of LOV", Effect Duration: 64
 6842	modified pulsating vial of blood simple syrup	0		Effect: "Bear Clawed", Effect Duration: 21
 6843	activated galvanized flattened bone bons	0		Effect: "Stregngth of the Gnome", Effect Duration: 23
@@ -6746,13 +6746,13 @@
 6857	blurry ghostly smelly Cajun accordion	0		Stench Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	foul-smelling quirky accordion	0		Stench Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	teal Fonzie's Socratic Skipper's accordion	0		Experience (Mysticality): +1, Experience (Moxie): +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	Lo Pan's rosy-cheeked brawny beefcake's Pantsgiving	0		Muscle: +25, Muscle Percent: +20, Maximum HP Percent: +30, Spell Critical Percent: +30, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
-6861	toothsome small red can of sardines	2	awesome	Last Available: "2013-11"
+6860	Lo Pan's rosy-cheeked brawny beefcake's Pantsgiving	0		Muscle: +25, Muscle Percent: +20, Maximum HP Percent: +30, Spell Critical Percent: +30, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	small toothsome red can of sardines	2	awesome	Last Available: "2013-11"
 6862	rotten massive high-calorie sugar substitute	7	crappy	Last Available: "2013-11"
-6863	super-sized decent pat of butter	5	good	Last Available: "2013-11"
-6864	huge tasty dinner roll	7	awesome	Last Available: "2013-11"
+6863	decent super-sized pat of butter	5	good	Last Available: "2013-11"
+6864	tasty huge dinner roll	7	awesome	Last Available: "2013-11"
 6865	spoiled half-sized mashed potatoes	2	crappy	Last Available: "2013-11"
-6866	moldy half-sized squat whole turkey leg	2	crappy	Last Available: "2013-11"
+6866	half-sized moldy squat whole turkey leg	2	crappy	Last Available: "2013-11"
 6867	jumbo adequate deviled egg	5	good	Last Available: "2013-11"
 6868	oxidized wobbly finger exerciser	0		Effect: "There Wolf", Effect Duration: 42, Last Available: "2013-11"
 6869	non-polymerized huge dented spoon	0		Effect: "Macho, Macho Dog", Effect Duration: 30, Last Available: "2013-11"
@@ -6793,7 +6793,7 @@
 6904	corrupted cold-filtered jittery bolts	0		Effect: "Jacked In", Effect Duration: 57, Last Available: "2013-12"
 6905	moldy blinking gingerbread robot	3	crappy	Last Available: "2013-12"
 6906	adequate petit 4.1	4	good	Last Available: "2013-12"
-6907	immense decent nut-shaped Crimbo cookie	7	good	Last Available: "2023-06"
+6907	decent immense nut-shaped Crimbo cookie	7	good	Last Available: "2023-06"
 6908	personal trainer's plastic GORM-8	0		Experience Percent (Muscle): +10, Last Available: "2013-12"
 6909	upside-down chaotic plastic warbear	0		Spell Critical Percent: +10, Last Available: "2013-12"
 6910	blurry Tesla plastic Toybot	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
@@ -6802,37 +6802,37 @@
 6913	blinking warbear whosit	0		Last Available: "2013-12"
 6914	blue warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	zippy executive warbear hoverbelt of James Dean	0		Experience (Moxie): +3, Meat Drop: +40, Initiative: +20, Single Equip, Last Available: "2013-12"
-6916	mirror huge warbear battery	0		Last Available: "2013-12"
+6916	huge mirror warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
 6918	unsweetened diffused spinning warbear wardance potion	0		Effect: "Mathematically Precise", Effect Duration: 34, Last Available: "2013-12"
 6919	anodized warbear bearserker potion	0		Effect: "Quantum of Moxie", Effect Duration: 65, Last Available: "2013-12"
 6920	denatured warbear liquid overcoat	0		Effect: "Quadrilled", Effect Duration: 59, Last Available: "2013-12"
 6921	bite-sized spoiled jittery warbear feasting bread	1	crappy	Last Available: "2013-12"
 6922	normal warbear warrior bread	3	good	Last Available: "2013-12"
-6923	low-calorie bland mirror warbear thermoregulator bread	1	decent	Last Available: "2013-12"
+6923	bland low-calorie mirror warbear thermoregulator bread	1	decent	Last Available: "2013-12"
 6924	tolerable distilled warbear feasting mead	5	good	Last Available: "2013-12"
-6925	lousy ghostly blurry warbear bearserker mead	4	decent	Last Available: "2013-12"
-6926	practically non-alcoholic drinkable warbear blizzard mead	1	good	Last Available: "2013-12"
+6925	lousy blurry ghostly warbear bearserker mead	4	decent	Last Available: "2013-12"
+6926	drinkable practically non-alcoholic warbear blizzard mead	1	good	Last Available: "2013-12"
 6927	huge warbear helm fragment	0		Last Available: "2013-12"
-6928	Usain Bolt's nippy warbear plain fedora of the cheetah	0		Cold Damage: +10, Initiative: 140, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	censurious warbear feathered fedora	0		Sleaze Resistance: +3, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	olive lion tamer's arcane researcher's warbear fedora of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Experience (familiar): +2, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	hale educational warbear plain helm of extreme caution	0		Experience: +1, Maximum HP: +20, Monster Level: -25, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	warbear spiked helm of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	stylish warbear electro-spiked helm of Leguizamo of the glutton	0		Moxie: +25, Monster Level: +20, Food Drop: +100, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	spinning zippy wool supercool warbear plain ushanka	0		Moxie Percent: +20, Cold Resistance: +1, Initiative: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	ghostly educational warbear lined ushanka	0		Experience: +1, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	zippy foul-smelling healthy warbear heated ushanka	0		Maximum HP Percent: +20, Stench Damage: +10, Initiative: +20, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	Usain Bolt's nippy warbear plain fedora of the cheetah	0		Cold Damage: +10, Initiative: 140, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	censurious warbear feathered fedora	0		Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	olive lion tamer's arcane researcher's warbear fedora of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Experience (familiar): +2, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	hale educational warbear plain helm of extreme caution	0		Experience: +1, Maximum HP: +20, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	warbear spiked helm of Tarzan	0		Experience (Muscle): +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	stylish warbear electro-spiked helm of Leguizamo of the glutton	0		Moxie: +25, Monster Level: +20, Food Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	spinning zippy wool supercool warbear plain ushanka	0		Moxie Percent: +20, Cold Resistance: +1, Initiative: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	ghostly educational warbear lined ushanka	0		Experience: +1, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	zippy foul-smelling healthy warbear heated ushanka	0		Maximum HP Percent: +20, Stench Damage: +10, Initiative: +20, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	narrow clever veiny warbear party pants of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +10, Maximum MP: +20, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	Temple Grandin's warbear ceremonial party pants	0		Familiar Weight: +7, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	executive baleful sinister warbear high festival pants	0		Spell Damage: 35, Meat Drop: +40, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	horrifying quilted warbear battle greaves of the storm	0		Damage Absorption: +40, Maximum MP Percent: +40, Spooky Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	cyan avaricious warbear officer greaves	0		Meat Drop: +30, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	foul-smelling clever warbear bearserker greaves of horror	0		Maximum MP: +20, Stench Damage: +10, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	double-paned rosy-cheeked strapping warbear johns	0		Muscle: +5, Maximum HP Percent: +30, Cold Resistance: +5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	blue boxer's warbear fleece-lined johns	0		Muscle Percent: +10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	wobbly veiny steel-toed weightlifter's warbear johns	0		Muscle: +15, Damage Reduction: 9, Maximum HP: +10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	narrow clever veiny warbear party pants of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +10, Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	Temple Grandin's warbear ceremonial party pants	0		Familiar Weight: +7, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	executive baleful sinister warbear high festival pants	0		Spell Damage: 35, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	horrifying quilted warbear battle greaves of the storm	0		Damage Absorption: +40, Maximum MP Percent: +40, Spooky Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	cyan avaricious warbear officer greaves	0		Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	foul-smelling clever warbear bearserker greaves of horror	0		Maximum MP: +20, Stench Damage: +10, Spooky Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	double-paned rosy-cheeked strapping warbear johns	0		Muscle: +5, Maximum HP Percent: +30, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	blue boxer's warbear fleece-lined johns	0		Muscle Percent: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	wobbly veiny steel-toed weightlifter's warbear johns	0		Muscle: +15, Damage Reduction: 9, Maximum HP: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	ghostly warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	spinning wobbly horrifying Da Vinci's warbear goggles of terror	0		Experience (Mysticality): +5, Spooky Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6949	curative warbear snowblindness goggles	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	smelly Samson's thinker's warbear warscarf	0		Mysticality: +10, Experience (Muscle): +5, Stench Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6957	wobbly warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	upside-down warbear foil hat of Calamity Jane	0		Critical Hit Percent: +15, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	upside-down warbear foil hat of Calamity Jane	0		Critical Hit Percent: +15, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	ghostly warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	family-friendly warbear oil pan of the pedagogue	0		Experience: +3, Sleaze Resistance: +1, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6896,10 +6896,10 @@
 7007	small bland Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
 7008	bland Miserable Pie	3	decent	Last Available: "2013-12"
 7009	toothsome green This Charming Flan	3	awesome	Last Available: "2013-12"
-7010	bad special Irish Coffee, English Heart	4	decent	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2013-12"
+7010	special bad Irish Coffee, English Heart	4	decent	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2013-12"
 7011	lousy Strikes Again Bigmouth	3	decent	Last Available: "2013-12"
 7012	smooth blurry Paint A Vulgar Pitcher	3	awesome	Last Available: "2013-12"
-7013	jittery fuchsia Golden Light	0		Last Available: "2013-12"
+7013	fuchsia jittery Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	teal Handsome Devil	0		Last Available: "2013-12"
 7016	greedy flame-retardant sharpshooter's Herculean Work is a Four Letter Sword	0		Experience (Muscle): +1, Critical Hit Percent: +10, Hot Resistance: +1, Meat Drop: +20, Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	narrow sharpshooter's studded Rosewater's strapping Sheila Take a Crossbow	0		Muscle: +5, Mysticality Percent: +30, Damage Absorption: +80, Critical Hit Percent: +10, Last Available: "2013-12"
 7019	fuchsia manspreader's groovy A Light that Never Goes Out of the empath of the overflowing toilet	0		Moxie Percent: +10, Monster Level: +10, Familiar Weight: +5, Stench Spell Damage: +50, Last Available: "2013-12"
 7020	green smelly Jim Carey's Oprah's Half a Purse of temperance	0		Maximum MP Percent: +50, Monster Level: +25, Stench Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2013-12"
-7021	upside-down frosty resourceful studded Hairpiece On Fire of the glutton	0		Damage Absorption: +80, Maximum MP: +50, Cold Spell Damage: +10, Food Drop: +100, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	sizzling Annie Oakley's Rosewater's Vicar's Tutu of the bloodbag	0		Mysticality Percent: +30, Maximum HP: +100, Critical Hit Percent: +20, Hot Damage: +10, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	upside-down frosty resourceful studded Hairpiece On Fire of the glutton	0		Damage Absorption: +80, Maximum MP: +50, Cold Spell Damage: +10, Food Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	sizzling Annie Oakley's Rosewater's Vicar's Tutu of the bloodbag	0		Mysticality Percent: +30, Maximum HP: +100, Critical Hit Percent: +20, Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	healthy Sinatra's Hand in Glove of the detective	0		Experience (Moxie): +5, Maximum HP Percent: +20, Item Drop: +20, Single Equip, Last Available: "2013-12"
 7024	Temple Grandin's manspreader's supercool Meat Tenderizer is Murder	0		Moxie Percent: +20, Monster Level: +10, Familiar Weight: +7, Class: "Seal Clubber", Last Available: "2013-12"
 7025	spinning manspreader's Ouija Board, Ouija Board of extreme caution	0		Monster Level: -15, Item Drop: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6933,7 +6933,7 @@
 7044	deionized blinking glass slipper	0		Effect: "Savage Beast Inside", Effect Duration: 53, Last Available: "2014-12"
 7045	distilled antimatter wad	1	decent	Last Available: "2013-12"
 7046	liquefied ionized fuchsia warbear superpotion	0		Effect: "Highland Sheen", Effect Duration: 63, Last Available: "2013-12"
-7047	non-boiled liquefied wobbly olive warbear liquid lasers	0		Effect: "World's Shortest Giant", Effect Duration: 63, Last Available: "2013-12"
+7047	non-boiled liquefied olive wobbly warbear liquid lasers	0		Effect: "World's Shortest Giant", Effect Duration: 63, Last Available: "2013-12"
 7048	moist aerosolized modified shaking warbear rejuvenation potion	0		Effect: "Armor-Plated", Effect Duration: 36, Last Available: "2013-12"
 7049	bouncing green broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	toothsome wobbly warbear gyro	4	awesome	Last Available: "2013-12"
@@ -6949,7 +6949,7 @@
 7060	upside-down festive warbear bank	0		Last Available: "2013-12"
 7061	grimstone mask	0		Last Available: "2014-12"
 7062	pulsating praying Grim Brother	0		Free Pull, Last Available: "2014-12"
-7063	blue twirling Grim Brothers' story book	0		Familiar Weight: +5
+7063	twirling blue Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	modified upside-down grim fairy tale	1	EPIC	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
@@ -6963,13 +6963,13 @@
 7074	double-unsweetened magnetized mirror snow cleats	0		Effect: "Overstimulated", Effect Duration: 18, Last Available: "2014-01"
 7075	quantum denatured liquid ice pack	0		Effect: "Oh Snap", Effect Duration: 67, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	thick moldy snow crab	5	crappy	Last Available: "2014-01"
+7077	moldy thick snow crab	5	crappy	Last Available: "2014-01"
 7078	acceptable boozy Ice Island Long Tea	5	good	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	brainy snow mobile	0		Mysticality: +5, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	brainy snow mobile	0		Mysticality: +5, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	lion tamer's ice bucket	0		Experience (familiar): +2, Lasts Until Rollover, Last Available: "2014-01"
 7085	bouncing zippy snow shovel of terror	0		Spooky Spell Damage: +10, Initiative: +20, Lasts Until Rollover, Last Available: "2014-01"
 7086	lime green perfumed gravedigger's toasty bod-ice	0		Hot Damage: +5, Spooky Damage: +10, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,23 +6978,23 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	drinkable En Una Fila Tequila	3	good	
 7091	ghostly Skully's hot chocolate	1	awesome	
-7092	blurry up-at-dawn sharpshooter's warbear dress helmet	0		Critical Hit Percent: +10, Adventures: +5, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	blurry up-at-dawn sharpshooter's warbear dress helmet	0		Critical Hit Percent: +10, Adventures: +5, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	squat maroon blinking thinker's warbear dress bracers of dire peril	0		Mysticality: +10, Weapon Damage: +20, Single Equip, Last Available: "2013-12"
-7094	upside-down inspector's warbear dress greaves of Tarzan	0		Experience (Muscle): +3, Item Drop: +15, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	jittery double-paned brainy sweatband	0		Mysticality: +5, Cold Resistance: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	blinking wicked cool gym shorts	0		Moxie: +5, Spell Damage: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	upside-down inspector's warbear dress greaves of Tarzan	0		Experience (Muscle): +3, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	jittery double-paned brainy sweatband	0		Mysticality: +5, Cold Resistance: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	blinking wicked cool gym shorts	0		Moxie: +5, Spell Damage: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	squat Sherlock's weightlifter's ankleweights	0		Muscle: +15, Item Drop: +25, Single Equip, Last Available: "2014-12"
 7098	wholesome slick sweat socks of Tarzan of courage	0		Moxie: +10, Experience (Muscle): +3, Maximum HP Percent: +10, Spooky Resistance: +3, Last Available: "2014-12"
 7099	blinking pint of sweat	0		Last Available: "2014-12"
 7100	cyan Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	dehydrated shaking Five Second Energy&trade;	1		Effect: "Slimily Sagacious", Effect Duration: 25, Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
-7103	vacuum-sealed upside-down wobbly shaking powder	0		Effect: "Violent Night", Effect Duration: 11, Last Available: "2014-12"
+7103	vacuum-sealed upside-down shaking wobbly powder	0		Effect: "Violent Night", Effect Duration: 11, Last Available: "2014-12"
 7104	resourceful licorice whip	0		Maximum MP: +50, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	aged snakebite	3	awesome	Last Available: "2014-12"
 7107	prompt rosewater-soaked candy stick	0		Stench Resistance: +3, Adventures: +3, Last Available: "2014-12"
-7108	decent diet pecan	1	good	Last Available: "2014-12"
+7108	diet decent pecan	1	good	Last Available: "2014-12"
 7109	flavorless pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	half-sized adequate candy mountain oyster	2	good	Last Available: "2014-12"
@@ -7003,13 +7003,13 @@
 7114	rotten candy carrot	3	crappy	Last Available: "2014-12"
 7115	moldy pulsating candy carrot cake	3	crappy	Last Available: "2014-12"
 7116	friendly carrot-on-a-stick of Gandalf	0		Spell Critical Percent: +20, Familiar Weight: +3, Last Available: "2014-12"
-7117	toasty forbidden weasel stomping pants	0		Spell Damage Percent: +50, Hot Damage: +5, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	toasty forbidden weasel stomping pants	0		Spell Damage Percent: +50, Hot Damage: +5, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	diet normal bouncing mulberry	1	good	Last Available: "2014-12"
 7119	tolerable lime green mulled berry wine	4	good	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	jittery padded lemon party hat	0		Damage Absorption: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	jittery padded lemon party hat	0		Damage Absorption: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	skewed studded lemon shirt	0		Damage Absorption: +80, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of the detective	0		Item Drop: +20, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	lemon drop trousers of the detective	0		Item Drop: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	non-diffused moist vacuum-sealed lemonhead caviar	0		Effect: "Heart of Green", Effect Duration: 62, Last Available: "2014-12"
 7125	olive nasty groovy gummi sword	0		Moxie Percent: +10, Stench Damage: +5, Last Available: "2014-12"
 7126	boiled unsweetened small gummi fin	0		Effect: "Saucemastery", Effect Duration: 61, Last Available: "2014-12"
@@ -7021,7 +7021,7 @@
 7132	activated wet Outer Wolf&trade; cologne	0		Effect: "Big Meat Big Prizes", Effect Duration: 35, Last Available: "2014-12"
 7133	teal lupine appetite hormones	0		Last Available: "2014-12"
 7134	clever cool wolf whistle	0		Moxie: +5, Maximum MP: +20, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	normal snack-sized mirror witch's bread	2	good	Last Available: "2014-12"
+7135	snack-sized normal mirror witch's bread	2	good	Last Available: "2014-12"
 7136	enhanced aerosolized witch's brew	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 36, Last Available: "2014-12"
 7137	upside-down scorching Temple Grandin's veiny witch's bra	0		Maximum HP: +10, Familiar Weight: +7, Hot Damage: +25, Last Available: "2014-12"
 7138	hand-crafted narrow mid-level medieval mead	3	EPIC	Last Available: "2014-12"
@@ -7043,20 +7043,20 @@
 7154	skewed filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	purple flame-wreathed dog trainer's Tesla fire hose	0		Experience (familiar): +1, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	purple flame-wreathed dog trainer's Tesla fire hose	0		Experience (familiar): +1, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	small rotten twirling fireman's lunch	2	crappy	Last Available: "2014-12"
-7159	olive hardy plain paper hat of wisdom of the blizzard	0		Mysticality: +15, Maximum HP: +50, Cold Spell Damage: +25, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	olive hardy plain paper hat of wisdom of the blizzard	0		Mysticality: +15, Maximum HP: +50, Cold Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	special bland wobbly ice cream sandwich	3	decent	Effect: "Mushroom Moxiousness", Effect Duration: 50, Last Available: "2014-12"
 7161	rosy-cheeked personal trainer's &quot;honey&quot; dipper of James Dean	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Maximum HP Percent: +30, Last Available: "2014-12"
-7162	stale bite-sized shaking ghostly plumber's lunch	1	decent	Last Available: "2014-12"
+7162	bite-sized stale ghostly shaking plumber's lunch	1	decent	Last Available: "2014-12"
 7163	fortified Sinatra's skull gearshift knob of the sewer	0		Experience (Moxie): +5, Damage Absorption: +60, Stench Damage: +25, Last Available: "2014-12"
-7164	thick moldy nachos of the night	5	crappy	Last Available: "2014-12"
+7164	moldy thick nachos of the night	5	crappy	Last Available: "2014-12"
 7165	pulsating auspicious steel-toed deadly Sketcherz&trade;	0		Weapon Damage: +5, Damage Reduction: 9, Item Drop: +10, Last Available: "2014-12"
-7166	small stale squat can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
+7166	stale small squat can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
 7167	polarized pulsating tumbling smudge stick	0		Effect: "Hammertime", Effect Duration: 59, Last Available: "2014-12"
-7168	triple-aerosolized huge fuchsia wall	0		Effect: "Abyssal Sweat", Effect Duration: 14, Last Available: "2014-12"
+7168	triple-aerosolized fuchsia huge wall	0		Effect: "Abyssal Sweat", Effect Duration: 14, Last Available: "2014-12"
 7169	hand-crafted tankard of ale	4	EPIC	Last Available: "2014-12"
-7170	pickled unsweetened blinking maroon wobbly scroll case	0		Effect: "Sewer-Drenched", Effect Duration: 22, Last Available: "2014-12"
+7170	pickled unsweetened maroon blinking wobbly scroll case	0		Effect: "Sewer-Drenched", Effect Duration: 22, Last Available: "2014-12"
 7171	extra-polarized jug of &quot;wine&quot;	0		Effect: "Liquidy Smoky", Effect Duration: 59, Last Available: "2014-12"
 7172	huge juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
@@ -7073,7 +7073,7 @@
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	aged practically non-alcoholic unnamed cocktail	1	awesome	
+7187	practically non-alcoholic aged unnamed cocktail	1	awesome	
 7188	handful of tips	0		
 7189	jittery unrequired jacket of bravery	0		Spooky Resistance: +5
 7190	spinning nasty tommy gun	0		Stench Damage: +5, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7092,16 +7092,16 @@
 7203	blinking stylish Saturday Night Special	0		Moxie: +25
 7204	skewed lynyrd snare	0		
 7205	lion tamer's fleetwood chain	0		Experience (familiar): +2
-7206	perfectly mixed pulsating wobbly Green Manalishi	4	EPIC	
+7206	perfectly mixed wobbly pulsating Green Manalishi	4	EPIC	
 7207	blurry blade of the brute	0		Muscle Percent: +30
 7208	jittery fire of unknown origin	0		
 7209	shaking eagle's milk	1	decent	
-7210	wet green upside-down eagle feather	0		Effect: "Ogred and Oublietted", Effect Duration: 50
+7210	wet upside-down green eagle feather	0		Effect: "Ogred and Oublietted", Effect Duration: 50
 7211	oxidized one pill	0		Effect: "Woad Warrior", Effect Duration: 19
 7212	Jefferson wings of Tarzan	0		Experience (Muscle): +3
 7213	lime green fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	rotten low-calorie fleetwood mac 'n' cheese	1	crappy	
+7215	low-calorie rotten fleetwood mac 'n' cheese	1	crappy	
 7216	lynyrd skin	0		
 7217	stanky lynyrdskin cap	0		Stench Spell Damage: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	blurry Temple Grandin's lynyrdskin tunic	0		Familiar Weight: +7
@@ -7113,11 +7113,11 @@
 7224	twirling veiny Kashmir sweater of mayonnaise	0		Maximum HP: +10, Sleaze Spell Damage: +50
 7225	normal custard pie	4	good	
 7226	tea for one	1	good	
-7227	aged weak bottle of Evermore	2	awesome	
+7227	weak aged bottle of Evermore	2	awesome	
 7228	gray box	0		
 7229	acceptable blinking wine	4	good	
-7230	watered-down hand-crafted rum	2	EPIC	
-7231	practically non-alcoholic mediocre enchanted Murderer's Punch	1	decent	Effect: "Muddled", Effect Duration: 50
+7230	hand-crafted watered-down rum	2	EPIC	
+7231	practically non-alcoholic enchanted mediocre Murderer's Punch	1	decent	Effect: "Muddled", Effect Duration: 50
 7232	flavorless velvet cake	4	decent	
 7233	improved skewed letter	0		Effect: "Stop and Smell the Fudge", Effect Duration: 62
 7234	teal rosy-cheeked Sinatra's book	0		Experience (Moxie): +5, Maximum HP Percent: +30
@@ -7141,9 +7141,9 @@
 7252	twirling shot of Sneaky Pete's Mojo	0		Free Pull
 7253	blinking Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	mediocre watered-down bouncing mini-martini	2	decent	
+7255	watered-down mediocre bouncing mini-martini	2	decent	
 7256	smoke grenade	0		
-7257	mixed tumbling shaking molotov soda	1	good	
+7257	mixed shaking tumbling molotov soda	1	good	
 7258	anodized non-magnetized pile of ashes	0		Effect: "Preemptive Medicine", Effect Duration: 40
 7259	crate of firebombs	0		
 7260	firebomb	0		
@@ -7166,7 +7166,7 @@
 7277	pickled jittery robot grease	0		Effect: "Towering Strength", Effect Duration: 62
 7278	pulsating returned Thinknerd package	0		
 7279	adjusted wind-up Whatsian robot	0		Effect: "Wet Rub", Effect Duration: 42
-7280	energized magnetized adjusted tumbling gray wind-up vampire teeth	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 20
+7280	energized magnetized adjusted gray tumbling wind-up vampire teeth	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 20
 7281	altered pickled wind-up navigation droid	0		Effect: "Macho, Macho Dog", Effect Duration: 38
 7282	moist irradiated wind-up owl	0		Effect: "Supafly", Effect Duration: 49
 7283	modified wind-up ensign	0		Effect: "Swimming Head", Effect Duration: 52
@@ -7176,8 +7176,8 @@
 7287	mirror Annie Oakley's veiny Gary Claybender's Time Screwer	0		Maximum HP: +10, Critical Hit Percent: +20, Single Equip, Lasts Until Rollover
 7288	Space Tourist palmdoctor of mayonnaise of the detective	0		Sleaze Spell Damage: +50, Item Drop: +20, Lasts Until Rollover
 7289	Usain Bolt's thinker's beefy amok putter	0		Muscle: +10, Mysticality: +10, Initiative: +80
-7290	tiny bland fuchsia amok pudding	1	decent	
-7291	jittery huge deactivated putty buddy	0		
+7290	bland tiny fuchsia amok pudding	1	decent	
+7291	huge jittery deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	ionized can of V-11	0		Effect: "Tingling Feeling", Effect Duration: 36, Last Available: "2014-03"
 7294	aromatic elevennis shoes of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +1, Last Available: "2014-03"
@@ -7202,7 +7202,7 @@
 7313	box of hickory chips	0		Familiar Weight: +5
 7314	teal poppet	0		
 7315	ghostly rickety rocking horse	0		
-7316	twirling yellow jack-in-the-box	0		
+7316	yellow twirling jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	up-at-dawn friendly manspreader's ghost of a necklace	0		Monster Level: +10, Familiar Weight: +3, Adventures: +5
 7319	blurry skewed Fonzie's Elizabeth's Dollie of Calamity Jane	0		Experience (Moxie): +1, Critical Hit Percent: +15
@@ -7211,12 +7211,12 @@
 7322	tarnished Stephen's secret formula	0		Effect: "Frozen Shoulders", Effect Duration: 54
 7323	skewed gray wool Jacob's rung of bravery	0		Cold Resistance: +1, Spooky Resistance: +5
 7324	distilled narrow battery	1		
-7325	lousy boozy spinning snakebite	5	decent	
+7325	boozy lousy spinning snakebite	5	decent	
 7326	rubber ribcage of Gandalf of Flo-Jo	0		Spell Critical Percent: +20, Initiative: +100, Damage Reduction: 7
 7327	denatured skewed synthetic marrow	1		
 7328	deionized frozen diffused narrow funny bone	0		Effect: "Uncanny Shot", Effect Duration: 31
 7329	prompt dance instructor's half-melted spoon	0		Experience Percent (Moxie): +10, Adventures: +3
-7330	mixed red mirror squat the funk	1		Effect: "Fit To Be Tide", Effect Duration: 10
+7330	mixed squat mirror red the funk	1		Effect: "Fit To Be Tide", Effect Duration: 10
 7331	moldy spinning gunky chicken	3	crappy	
 7332	bouncing olive personal trainer's doll head	0		Experience Percent (Muscle): +10
 7333	droopy doll eye	0		
@@ -7229,7 +7229,7 @@
 7340	tumbling censurious moose antlers	0		Sleaze Resistance: +3, Familiar Effect: "atk, 1xLep, cap 27"
 7341	double-denatured jittery moose thought	0		Effect: "Hammered", Effect Duration: 68
 7342	immense stale moose chocolate	7	decent	
-7343	hand-crafted fortified squat twirling painting of a glass of wine	5	EPIC	
+7343	fortified hand-crafted twirling squat painting of a glass of wine	5	EPIC	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7251,17 +7251,17 @@
 7362	frightening Samson's plaid skirt	0		Experience (Muscle): +5, Spooky Damage: +5, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	ionized bloodstain stick	0		Effect: "Ponderous Potency", Effect Duration: 58
 7364	fabric softener	0		
-7365	quadruple-warmed blinking ghostly fabric hardener	0		Effect: "Feeling No Pain", Effect Duration: 58
+7365	quadruple-warmed ghostly blinking fabric hardener	0		Effect: "Feeling No Pain", Effect Duration: 58
 7366	delicious huge bottle of laundry sherry	4	awesome	
 7367	irradiated skewed industrial strength starch	0		Effect: "Crying, Dying", Effect Duration: 41, Wiki Name: "industrial strength starch"
 7368	low-calorie spoiled extra-flat panini	1	crappy	
 7369	enhanced oxidized mangled finger	0		Effect: "Concentrated Concentration", Effect Duration: 69
 7370	delicious cyan Psychotic Train wine	4	awesome	
 7371	crazy hobo notebook	0		
-7372	special yummy gigantic pie man was not meant to eat	10	awesome	Effect: "Venomous Weapon", Effect Duration: 35
+7372	special gigantic yummy pie man was not meant to eat	10	awesome	Effect: "Venomous Weapon", Effect Duration: 35
 7373	sommelier's towel of the storm	0		Maximum MP Percent: +40
 7374	Lo Pan's tarnished tastevin	0		Spell Critical Percent: +30, Single Equip
-7375	huge stale bouncing actual tapas	9	decent	
+7375	stale huge bouncing actual tapas	9	decent	
 7376	ghast iron ingot	0		
 7377	squat fuchsia asbestos-lined ghast iron cleaver of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +5
 7378	shaking reassuring ghast iron Garibaldi of temperance	0		Spooky Resistance: +1, Sleaze Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7283,15 +7283,15 @@
 7394	deionized moist blinking Gene Tonic: Fish	0		Effect: "Bustle Hustlin'", Effect Duration: 59, Last Available: "2014-04"
 7395	ionized quadruple-deionized extra-anodized blurry Gene Tonic: Goblin	0		Effect: "Initiative and Let Die", Effect Duration: 36, Last Available: "2014-04"
 7396	irradiated activated tumbling Gene Tonic: Pirate	0		Effect: "Oily Flavor", Effect Duration: 51, Last Available: "2014-04"
-7397	concentrated bouncing tumbling Gene Tonic: Plant	0		Effect: "Bastard!", Effect Duration: 43, Last Available: "2014-04"
+7397	concentrated tumbling bouncing Gene Tonic: Plant	0		Effect: "Bastard!", Effect Duration: 43, Last Available: "2014-04"
 7398	diffused adjusted Gene Tonic: Weird	0		Effect: "Weapon of Mass Destruction", Effect Duration: 66, Last Available: "2014-04"
-7399	adjusted chilled ghostly jittery Gene Tonic: Elf	0		Effect: "Reedy Pipes", Effect Duration: 43, Last Available: "2014-04"
+7399	adjusted chilled jittery ghostly Gene Tonic: Elf	0		Effect: "Reedy Pipes", Effect Duration: 43, Last Available: "2014-04"
 7400	unsweetened red Gene Tonic: Mer-kin	0		Effect: "Egg-stra Arm", Effect Duration: 57, Last Available: "2014-04"
 7401	pickled blinking pulsating Gene Tonic: Slime	0		Effect: "Cravin' for a Ravin'", Effect Duration: 48, Last Available: "2014-04"
 7402	polarized liquefied blinking Gene Tonic: Penguin	0		Effect: "Puzzle Fury", Effect Duration: 27, Last Available: "2014-04"
 7403	enhanced ghostly Gene Tonic: Elemental	0		Effect: "Wistfully Nostalgic", Effect Duration: 45, Last Available: "2014-04"
 7404	super-aerosolized deionized blinking Gene Tonic: Constellation	0		Effect: "Sticky Hands", Effect Duration: 65, Last Available: "2014-04"
-7405	pressed super-alkaline twirling squat Gene Tonic: Hobo	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 44, Last Available: "2014-04"
+7405	pressed super-alkaline squat twirling Gene Tonic: Hobo	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 44, Last Available: "2014-04"
 7406	bouncing Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
 7408	bouncing Steam Card: Dungeon Fist (#3)	0		
@@ -7324,15 +7324,15 @@
 7435	wet irradiated Stemonitis Staticus mushroom	0		Effect: "Extra-Thick Blood", Effect Duration: 54, Last Available: "2014-05"
 7436	adjusted teal Tremella Tarantella mushroom	0		Effect: "Norwhalloped", Effect Duration: 35, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	super-sized decent upside-down Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
+7438	decent super-sized upside-down Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
 7439	adequate Brain Food Pastaco	3	good	Last Available: "2014-05"
-7440	small moldy mirror Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
+7440	moldy small mirror Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
 7441	bland Medical Pastaco	4	decent	Last Available: "2014-05"
 7442	spoiled Energy Buzz Pastaco	4	crappy	Last Available: "2014-05"
-7443	spoiled tiny upside-down wobbly Ludovico Pastaco	1	crappy	Last Available: "2014-05"
+7443	spoiled tiny wobbly upside-down Ludovico Pastaco	1	crappy	Last Available: "2014-05"
 7444	drinkable overpowering mushroom wine	3	good	Last Available: "2014-05"
 7445	hand-crafted practically non-alcoholic complex mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
-7446	weak mediocre gray smooth mushroom wine	2	decent	Last Available: "2014-05"
+7446	mediocre weak gray smooth mushroom wine	2	decent	Last Available: "2014-05"
 7447	hand-crafted blood-red mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
 7448	mediocre squat buzzing mushroom wine	4	decent	Last Available: "2014-05"
 7449	bad swirling mushroom wine	4	decent	Last Available: "2014-05"
@@ -7340,21 +7340,21 @@
 7451	stale Taco Dan's Taco Fish Fish Taco	3	decent	Last Available: "2014-05"
 7452	ghostly Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	hand-crafted regular-size brogurt	4	EPIC	Last Available: "2014-05"
-7454	practically non-alcoholic tolerable super-size brogurt	1	good	Last Available: "2014-05"
+7454	tolerable practically non-alcoholic super-size brogurt	1	good	Last Available: "2014-05"
 7455	high-proof artisanal broberry brogurt	7	EPIC	Last Available: "2014-05"
 7456	artisanal blurry brocolate brogurt	3	EPIC	Last Available: "2014-05"
 7457	acceptable squat French bronilla brogurt	4	good	Last Available: "2014-05"
-7458	squat twirling History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
+7458	twirling squat History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	red Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	mirror Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	gravedigger's Brogre brorts	0		Spooky Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	gravedigger's Brogre brorts	0		Spooky Damage: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	experienced Brogre brolo shirt	0		Experience: +2, Last Available: "2014-05"
-7464	resourceful Brogre bucket hat	0		Maximum MP: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	resourceful Brogre bucket hat	0		Maximum MP: +50, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	huge airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	pulsating one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	flame-retardant brawny 8-billed baseball cap of chilblains	0		Muscle Percent: +20, Cold Damage: +25, Hot Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	flame-retardant brawny 8-billed baseball cap of chilblains	0		Muscle Percent: +20, Cold Damage: +25, Hot Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	lime green reassuring wholesome stylish extremely wet T-shirt	0		Moxie: +25, Maximum HP Percent: +10, Spooky Resistance: +1, Last Available: "2014-05"
 7470	narrow scorching Temple Grandin's shrimp fork of the empath	0		Familiar Weight: 12, Hot Damage: +25, Last Available: "2014-05"
 7471	vacuum-sealed shaking gray BROS Energy Drink	0		Effect: "Extra-Sharp Weapon", Effect Duration: 31, Last Available: "2014-05"
@@ -7363,7 +7363,7 @@
 7474	concentrated ghostly Yolo&trade; chocolates	0		Effect: "Fratty Flavor", Effect Duration: 42, Last Available: "2020-09"
 7475	string of moist beads of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
-7477	colloidal double-nitrogenated chilled green shaking Meat-inflating powder	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 30, Last Available: "2014-05"
+7477	colloidal double-nitrogenated chilled shaking green Meat-inflating powder	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 30, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	galvanized sugar fairy	0		Effect: "Faboooo", Effect Duration: 23, Last Available: "2014-05"
 7480	moist tumbling tumbling sugar bunny	0		Effect: "Puddingskin", Effect Duration: 55, Last Available: "2014-05"
@@ -7380,7 +7380,7 @@
 7491	practically non-alcoholic mediocre squat bottle of Chateau de Vinegar	1	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
-7494	huge blue wine bomb	0		
+7494	blue huge wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
 7496	squat bottled day	0		
 7497	shaking ghost formula	0		
@@ -7388,7 +7388,7 @@
 7499	aerosolized Hot 'n' Scarys	0		Effect: "Took Eleven", Effect Duration: 57
 7500	map	0		
 7501		0		
-7502	liquefied oxidized bouncing blinking Texas tea	0		Effect: "Dwarven Hardiness", Effect Duration: 67
+7502	liquefied oxidized blinking bouncing Texas tea	0		Effect: "Dwarven Hardiness", Effect Duration: 67
 7503	tumbling tumbling dark hamethyst ring of the cougar	0		Moxie: +20
 7504	manspreader's dark baconstone ring	0		Monster Level: +10
 7505	mirror friendly dark porquoise ring	0		Familiar Weight: +3
@@ -7425,8 +7425,8 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	blinking twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	upside-down Usain Bolt's space beast fur hat	0		Initiative: +80, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	shaking cool space beast fur pants	0		Moxie: +5, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	upside-down Usain Bolt's space beast fur hat	0		Initiative: +80, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	shaking cool space beast fur pants	0		Moxie: +5, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	space beast fur whip of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	spinning stylish space heater of the storm	0		Moxie: +25, Maximum MP Percent: +40, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7480,11 +7480,11 @@
 7591	artisanal skewed thermos of &quot;whiskey&quot;	3	EPIC	Last Available: "2014-07"
 7592	drinkable tumbling Lucky Lindy	4	good	Last Available: "2014-07"
 7593	hand-crafted Bee's Knees	4	EPIC	Last Available: "2014-07"
-7594	weak acceptable Sockdollager	2	good	Last Available: "2014-07"
-7595	extra-dry acceptable special blurry Ish Kabibble	5	good	Effect: "Purity of Spirit", Effect Duration: 5, Last Available: "2014-07"
+7594	acceptable weak Sockdollager	2	good	Last Available: "2014-07"
+7595	extra-dry special acceptable blurry Ish Kabibble	5	good	Effect: "Purity of Spirit", Effect Duration: 5, Last Available: "2014-07"
 7596	lousy Hot Socks	4	decent	Last Available: "2014-07"
 7597	acceptable red Phonus Balonus	3	good	Last Available: "2014-07"
-7598	smooth watered-down skewed Flivver	2	awesome	Last Available: "2014-07"
+7598	watered-down smooth skewed Flivver	2	awesome	Last Available: "2014-07"
 7599	acceptable irresponsibly strong bouncing Sloppy Jalopy	6	good	Last Available: "2014-07"
 7600	ionized narrow flame	0		Effect: "Frostbeard", Effect Duration: 53
 7601	super-vacuum-sealed altered temporary yak tattoo	0		Effect: "Proprie Tea", Effect Duration: 47
@@ -7495,7 +7495,7 @@
 7606	enhanced galvanized tarnished steampunk potion	0		Effect: "Wet and Greedy", Effect Duration: 11
 7607	electrified vial of swamp vapors	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 57
 7608	tarnished upside-down bouncing turtle mud	0		Effect: "Brain Freeze", Effect Duration: 17
-7609	quadruple-vacuum-sealed green bouncing Redeye&trade; Eyedrops	0		Effect: "Good Motivator", Effect Duration: 18
+7609	quadruple-vacuum-sealed bouncing green Redeye&trade; Eyedrops	0		Effect: "Good Motivator", Effect Duration: 18
 7610	Vulcanized improved Dweebisol&trade; inhaler	0		Effect: "Snobby", Effect Duration: 32
 7611	cold-filtered irradiated ionized tumbling Lewd Lemmy Hair Oil	0		Effect: "Booooooze", Effect Duration: 50
 7612	pressed dry diffused bouncing bouncing tomato soup poster	0		Effect: "In Tuna", Effect Duration: 21
@@ -7506,7 +7506,7 @@
 7617	denatured pulsating purple short deposition	0		Effect: "Old Time Hydration", Effect Duration: 54
 7618	altered bouncing straw pole	0		Effect: "Morninja", Effect Duration: 43
 7619	cold-filtered copperhead potion	0		Effect: "Slightly Mutated", Effect Duration: 35
-7620	denatured ionized liquefied olive narrow blurry ninja fear powder	0		Effect: "Tenacity of the Snapper", Effect Duration: 45
+7620	denatured ionized liquefied narrow olive blurry ninja fear powder	0		Effect: "Tenacity of the Snapper", Effect Duration: 45
 7621	quantum adjusted ninja eyeblack	0		Effect: "Salad Days", Effect Duration: 30
 7622	extra-improved non-pickled quadruple-dry button rouge	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 15
 7623	frozen Red Army camouflage kit	0		Effect: "Pisces in the Skyces", Effect Duration: 41
@@ -7540,7 +7540,7 @@
 7651	freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
-7654	red twirling fishbone corset	0		
+7654	twirling red fishbone corset	0		
 7655	fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
@@ -7561,7 +7561,7 @@
 7672	steel-toed law-abiding citizen cane	0		Damage Reduction: 9, Single Equip
 7673	hand-crafted legitimate business on the beach	3	EPIC	
 7674	lightning-fast hep waders	0		Initiative: +40, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	small spoiled wobbly jive turkey leg	2	crappy	
+7675	spoiled small wobbly jive turkey leg	2	crappy	
 7676	boxer's birdbone corset	0		Muscle Percent: +10
 7677	anodized candy cigarette	0		Effect: "Altered Wavelengths", Effect Duration: 29
 7678	4-dimensional fez of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7590,7 +7590,7 @@
 7701	concentrated aerosolized colloidal confiscated cell phone	0		Effect: "Oh Snap", Effect Duration: 61, Last Available: "2014-08"
 7702	activated warmed tumbling confiscated love note	0		Effect: "Meatwise", Effect Duration: 64, Last Available: "2014-08"
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
-7704	narrow green LCD game: Garbage River	0		Last Available: "2014-08"
+7704	green narrow LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	modified non-cold-filtered rubber nubbin	0		Effect: "Tennis Elbow-wow", Effect Duration: 40, Last Available: "2014-08"
@@ -7601,13 +7601,13 @@
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	rotten Strix stix	3	crappy	
 7714	twirling greedy frosty vampire pellet of Leguizamo	0		Monster Level: +20, Cold Spell Damage: +10, Meat Drop: +20
-7715	weak drinkable jittery wobbly non-aged vinegar	2	good	
+7715	drinkable weak jittery wobbly non-aged vinegar	2	good	
 7716	blurry prompt unsanitized scalpel	0		Adventures: +3
 7717	blinking squat sharpshooter's gladiator tunica	0		Critical Hit Percent: +10
 7718	narrow skewed prompt Roman sadnals	0		Adventures: +3, Single Equip
 7719	manspreader's madius	0		Monster Level: +10
 7720	Van der Graaf radiator heater shield	0		MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 6
-7721	colloidal maroon jittery twirling pulsating salt wages	0		Effect: "White Blooded", Effect Duration: 16
+7721	colloidal jittery maroon twirling pulsating salt wages	0		Effect: "White Blooded", Effect Duration: 16
 7722	mirror gravedigger's centurion helmet	0		Spooky Damage: +10, Familiar Effect: "1xFairy, atk, cap 25"
 7723	Chroner cross	0		
 7724	pteruges of the glutton	0		Food Drop: +100, Familiar Effect: "1xFairy, atk, cap 25"
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	lime green bouncing Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	red foul-smelling Xiblaxian xeno-detection goggles	0		Stench Damage: +10, Single Equip, Last Available: "2014-09"
-7753	blinking rosewater-soaked sinister Xiblaxian stealth cowl	0		Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	blinking rosewater-soaked sinister Xiblaxian stealth cowl	0		Spell Damage: +10, Stench Resistance: +3, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	teal shellacked Xiblaxian stealth trousers of the cheetah	0		Damage Reduction: 7, Initiative: +60, Last Available: "2014-09"
 7755	lard-coated Lo Pan's Xiblaxian stealth vest	0		Spell Critical Percent: +30, Sleaze Spell Damage: +25, Last Available: "2014-09"
 7756	half-sized bland Xiblaxian ultraburrito	2	decent	Last Available: "2014-09"
@@ -7669,7 +7669,7 @@
 7780	heavy-duty clipboard of wisdom of horror of the businessman	0		Mysticality: +15, Spooky Spell Damage: +25, Meat Drop: +50, Damage Reduction: 8, Last Available: "2014-10"
 7781	smelly Samson's battery-powered drill of the dark arts of the blizzard	0		Experience (Muscle): +5, Spell Damage Percent: +100, Cold Spell Damage: +25, Stench Spell Damage: +10, Last Available: "2014-10"
 7782	jumbo decent limp broccoli	5	good	Last Available: "2014-10"
-7783	twirling prompt crafty savvy hat	0		Mysticality Percent: +20, Maximum MP: +10, Adventures: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	twirling prompt crafty savvy hat	0		Mysticality Percent: +20, Maximum MP: +10, Adventures: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	extra-tarnished red monkey barf	0		Effect: "Smelly Pants", Effect Duration: 25, Last Available: "2014-10"
 7785	deionized candy	0		Effect: "Tomato Power", Effect Duration: 59, Last Available: "2014-10"
 7786	blinking scorching Samson's Rosewater's jangly bracelet	0		Mysticality Percent: +30, Experience (Muscle): +5, Hot Damage: +25, Last Available: "2014-10"
@@ -7677,15 +7677,15 @@
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	quilted first-aid pouch of the sewer	0		Damage Absorption: +40, Stench Damage: +25, Last Available: "2014-10"
 7790	jittery khaki duffel bag	0		Last Available: "2014-10"
-7791	polarized spinning narrow airborne mutagen	0		Effect: "Saucegoggles", Effect Duration: 64, Last Available: "2014-10"
+7791	polarized narrow spinning airborne mutagen	0		Effect: "Saucegoggles", Effect Duration: 64, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	narrow Armory keycard	0		Last Available: "2014-10"
-7795	bland massive skewed initiative shawarma	8	decent	Last Available: "2014-10"
-7796	adequate low-calorie tumbling fuchsia warm war shawarma	1	good	Last Available: "2014-10"
+7795	massive bland skewed initiative shawarma	8	decent	Last Available: "2014-10"
+7796	adequate low-calorie fuchsia tumbling warm war shawarma	1	good	Last Available: "2014-10"
 7797	rotten special karma shawarma	3	crappy	Effect: "Bolts about Candy", Effect Duration: 30, Last Available: "2014-10"
 7798	artisanal tumbling Jungle Juice	4	EPIC	Last Available: "2014-10"
-7799	bad practically non-alcoholic jittery Amnesiac Ale	1	decent	Last Available: "2014-10"
+7799	practically non-alcoholic bad jittery Amnesiac Ale	1	decent	Last Available: "2014-10"
 7800	artisanal Highest Bitter	3	EPIC	Last Available: "2014-10"
 7801	huge shellacked mercenary pistol of the brute	0		Muscle Percent: +30, Damage Reduction: 7, Last Available: "2014-10"
 7802	narrow greasy mercenary rifle of doom	0		Spooky Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2014-10"
@@ -7743,13 +7743,13 @@
 7854	red plastic Crimbot of the cheetah	0		Initiative: +60, Last Available: "2014-12"
 7855	aromatic plastic Crimbomega	0		Stench Resistance: +1, Last Available: "2014-12"
 7856	aerosolized blinking flask of mining oil	0		Effect: "You Liver", Effect Duration: 34, Last Available: "2014-12"
-7857	smooth radiation-resistant helmet	0		Moxie: +15, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	miser's servo-assisted exo-pants	0		Meat Drop: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	smooth radiation-resistant helmet	0		Moxie: +15, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	miser's servo-assisted exo-pants	0		Meat Drop: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	Oprah's banded high-energy mining laser	0		Damage Absorption: +100, Maximum MP Percent: +50, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
 7862	cylindrical mold	0		Last Available: "2014-12"
-7863	olive shaking Crimbonium fuel rod	0		Last Available: "2014-12"
+7863	shaking olive Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	bouncing huge Petite Paintbrush	0		Adventures: +1
 7865	squat Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	ghostly Crimbot schematic: Big Head	0		Last Available: "2014-12"
@@ -7762,7 +7762,7 @@
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	jittery narrow Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
-7876	shaking tumbling Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
+7876	tumbling shaking Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
@@ -7808,15 +7808,15 @@
 7919	oxidized deionized energized Big Punk	0		Effect: "Coy to the Hurled", Effect Duration: 42
 7920	bouncing green fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	purple turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	smooth practically non-alcoholic Friendly Turkey	1	awesome	Last Available: "2014-11"
+7922	practically non-alcoholic smooth Friendly Turkey	1	awesome	Last Available: "2014-11"
 7923	artisanal weak purple Agitated Turkey	2	EPIC	Last Available: "2014-11"
 7924	acceptable Ambitious Turkey	4	good	Last Available: "2014-11"
-7925	flavorless fancy neutron lollipop	4	decent	Effect: "Boon of the Storm Tortoise", Effect Duration: 40, Last Available: "2014-12"
+7925	fancy flavorless neutron lollipop	4	decent	Effect: "Boon of the Storm Tortoise", Effect Duration: 40, Last Available: "2014-12"
 7926	strong aged cyan gamma nog	5	awesome	Last Available: "2014-12"
 7934	upside-down sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
-7936	twirling wobbly picky tweezers	0		Last Available: "2015-02"
-7937	huge upside-down Crimbo Credit	0		
+7936	wobbly twirling picky tweezers	0		Last Available: "2015-02"
+7937	upside-down huge Crimbo Credit	0		
 7938	pickled maroon single atom	1	decent	Last Available: "2015-02"
 7939	huge Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
@@ -7827,11 +7827,11 @@
 7945	table	0		
 7946	wholesome studded outlaw bandana of Calamity Jane	0		Damage Absorption: +80, Maximum HP Percent: +10, Critical Hit Percent: +15
 7947	hand-crafted whiskey in a broken glass	4	EPIC	
-7948	weak fancy delicious huge shot of mescal	2	awesome	Effect: "Bilious Brains", Effect Duration: 5
-7949	acceptable fancy weak glass of herbal tequila	2	good	Effect: "One For Tea", Effect Duration: 10
+7948	weak delicious fancy huge shot of mescal	2	awesome	Effect: "Bilious Brains", Effect Duration: 5
+7949	weak acceptable fancy glass of herbal tequila	2	good	Effect: "One For Tea", Effect Duration: 10
 7950	minin' dynamite	0		
 7951	quilted plaid cowboy hat of dire peril	0		Weapon Damage: +20, Damage Absorption: +40, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-7952	pulsating green lasso	0		
+7952	green pulsating lasso	0		
 7953	rusted-out shootin' iron of incineration of horror of the early riser	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, Adventures: +7
 7954	tumbling rattler rattle	0		
 7955	bag of money	0		
@@ -7844,7 +7844,7 @@
 7962	Eye of Ed	0		
 7963	shaking amulet	0		
 7964	stiffened Staff of Fats	0		Damage Reduction: 1
-7965	skewed gray Holy MacGuffin	0		
+7965	gray skewed Holy MacGuffin	0		
 7966	spinning Ka coin	0		
 7967	Usain Bolt's World's Best Adventurer sash	0		Initiative: +80
 7968	topiary nugglet	0		
@@ -7853,7 +7853,7 @@
 7971	Aggressive Carrot	0		Free Pull
 7972	vaporized squat mummified fig	1	awesome	
 7973	vaporized mummified loaf of bread	1	decent	
-7974	boiled red huge upside-down mummified beef haunch	1	decent	Effect: "Heightened Senses", Effect Duration: 35
+7974	boiled upside-down huge red mummified beef haunch	1	decent	Effect: "Heightened Senses", Effect Duration: 35
 7975	linen bandages	0		
 7976	maroon cotton bandages	0		
 7977	silk bandages	0		
@@ -7861,7 +7861,7 @@
 7979	squat spirit beer	0		
 7980	sacramental wine	0		
 7981	talisman of Thoth	0		
-7982	fuchsia squat wobbly cure-all	0		
+7982	squat fuchsia wobbly cure-all	0		
 7983	wobbly Sister Accessory of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Softcore Only
 7984	warmed quadruple-deionized Boosty Juice	0		Effect: "Squirming Like a Toad", Effect Duration: 48
 7985	fuchsia huge greedy parachute of temperance	0		Sleaze Resistance: +5, Meat Drop: +20, Last Available: "2015-12"
@@ -7879,13 +7879,13 @@
 7997	altered polyesterene powder	1		Last Available: "2015-12"
 7998	altered blurry powder	1		Last Available: "2015-12"
 7999	flattened vacuum-sealed tarnished shaking choco-Crimbot	0		Effect: "Blood-Rich", Effect Duration: 13, Last Available: "2014-12"
-8000	aerosolized nitrogenated bouncing blue smart watch	0		Effect: "Uncaged Power", Effect Duration: 46, Last Available: "2014-12"
+8000	aerosolized nitrogenated blue bouncing smart watch	0		Effect: "Uncaged Power", Effect Duration: 46, Last Available: "2014-12"
 8001	dry dry augmented-reality shades	0		Effect: "Berry Berry Cold", Effect Duration: 22, Last Available: "2014-12"
-8002	nasty toy Crimbot mega face	0		Stench Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8002	nasty toy Crimbot mega face	0		Stench Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	fuchsia lard-coated toy Crimbot power glove	0		Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	shaking chilly toy Crimbot super fist	0		Cold Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	resourceful toy Crimbot rocket legs	0		Maximum MP: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
-8006	dry tumbling jittery Crimbot battery	0		Effect: "Bootyliciousness", Effect Duration: 47, Last Available: "2014-12"
+8006	dry jittery tumbling Crimbot battery	0		Effect: "Bootyliciousness", Effect Duration: 47, Last Available: "2014-12"
 8007	jittery Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	blinking Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	skewed blinking maroon Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7900,11 +7900,11 @@
 8018	tarnished ghostly and rain stick	0		Effect: "Meadulla Oblongota", Effect Duration: 12
 8019	blue Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	flavorless Choco-Mint patty	3	decent	Last Available: "2015-01"
-8021	mediocre watered-down hot mint schnocolate	2	decent	Last Available: "2015-01"
+8021	watered-down mediocre hot mint schnocolate	2	decent	Last Available: "2015-01"
 8022	altered maroon homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	spinning mirror foreign language tapes	0		Last Available: "2015-01"
-8025	wobbly yellow bowl of potpourri	0		Last Available: "2015-01"
+8025	yellow wobbly bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
 8028	wobbly artificial skylight	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	supercool beefcake's tope&eacute;	0		Muscle: +25, Moxie Percent: +20, Familiar Effect: "3xBarrr, cap 12"
 8035	blinking wobbly wicked topiary tights of terror	0		Spell Damage: +5, Spooky Spell Damage: +10
 8036	tumbling topiary necktie of the glutton	0		Food Drop: +100
-8037	immense stale enchanted bouncing bowl of topioca	10	decent	Effect: "Ninja, Please", Effect Duration: 35
+8037	stale immense enchanted bouncing bowl of topioca	10	decent	Effect: "Ninja, Please", Effect Duration: 35
 8038	blurry topiary skunk	0		
 8039	pulsating topiary noseplugs	0		Familiar Weight: +5
 8040	cyan trusty whip	0		
@@ -7944,7 +7944,7 @@
 8063	gray Tales of Spelunking	0		Last Available: "2015-12"
 8064	squat wobbly monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	lime green banana	0		Familiar Weight: +5
-8066	pickled narrow skewed ghostly	1	awesome	Last Available: "2015-12"
+8066	pickled ghostly skewed narrow	1	awesome	Last Available: "2015-12"
 8067	nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	dog trainer's personal trainer's Samson's Spelunker's fedora	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Experience (familiar): +1, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	dog trainer's personal trainer's Samson's Spelunker's fedora	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Experience (familiar): +1, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	ruddy rosy-cheeked Spelunker's whip of mayonnaise	0		Maximum HP Percent: 70, Sleaze Spell Damage: +50, Last Available: "2015-12"
-8076	curative cool Spelunker's khakis of the dark arts	0		Moxie: +5, Spell Damage Percent: +100, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	curative cool Spelunker's khakis of the dark arts	0		Moxie: +5, Spell Damage Percent: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	blue tumbling Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7962,7 +7962,7 @@
 8087	Thwaitgold scarab beetle statuette	0		
 8088	tumbling narrow jewel	0		
 8089	yellow headless sparrow	0		
-8090	yellow jittery mangled squirrel	0		
+8090	jittery yellow mangled squirrel	0		
 8091	rat carcass	0		
 8092	squat thinker's beefy wicker kickers	0		Muscle: +10, Mysticality: +10, Single Equip, Last Available: "2016-12"
 8093	rosy-cheeked wicker slicker of the empath	0		Maximum HP Percent: +30, Familiar Weight: +5, Last Available: "2016-12"
@@ -7984,14 +7984,14 @@
 8109	blurry ghostly asbestos-lined ribald ascot	0		Sleaze Damage: +10, Hot Resistance: +5, Single Equip, Last Available: "2017-12"
 8110	blurry gravedigger's personal trainer's attache case	0		Experience Percent (Muscle): +10, Spooky Damage: +10, Last Available: "2017-12"
 8111	green coward's mansplainer's accordion	0		Monster Level: -5, Song Duration: 10, Last Available: "2017-12"
-8112	dehydrated squat gray aerosolized	1		Last Available: "2017-12"
+8112	dehydrated gray squat aerosolized	1		Last Available: "2017-12"
 8113	sage brawny wig	0		Muscle Percent: +20, Mysticality Percent: +10, Last Available: "2017-12"
 8114	huge jittery winch crank of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Single Equip, Last Available: "2017-12"
 8115	gravedigger's occult widget	0		Spell Damage Percent: +25, Spooky Damage: +10, Single Equip, Last Available: "2017-12"
 8116	purple mirror wicked whisk of horror	0		Spell Damage: +5, Spooky Spell Damage: +25, Last Available: "2017-12"
 8117	fireproof walker of Flo-Jo	0		Hot Resistance: +3, Initiative: +100, Single Equip, Last Available: "2017-12"
 8118	wobbly veiny savvy waders	0		Mysticality Percent: +20, Maximum HP: +10, Last Available: "2017-12"
-8119	pickled blurry purple flakes	1		Last Available: "2017-12"
+8119	pickled purple blurry flakes	1		Last Available: "2017-12"
 8120	experienced gaiters of the bloodbag	0		Experience: +2, Maximum HP: +100, Last Available: "2018-12"
 8121	friendly mansplainer's garland	0		Monster Level: +15, Familiar Weight: +3, Single Equip, Last Available: "2018-12"
 8122	blue stylish gunnysack of mayonnaise	0		Moxie: +25, Sleaze Spell Damage: +50, Last Available: "2018-12"
@@ -8005,7 +8005,7 @@
 8130	friendly resourceful fiberglass frock	0		Maximum MP: +50, Familiar Weight: +3, Last Available: "2018-12"
 8131	double-paned Tesla fiberglass fingerguard	0		Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2018-12"
 8132	lime green fiberglass fedora of chilblains of the sweet-tooth	0		Cold Damage: +25, Candy Drop: +100, Last Available: "2018-12"
-8133	dried maroon jittery fiberglass fibers	1		Last Available: "2018-12"
+8133	dried jittery maroon fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	talisman of Renenutet	0		
@@ -8042,7 +8042,7 @@
 8168	skewed huge glob of icing	0		
 8169	irradiated fuchsia ginger snaps	0		Effect: "Stogied", Effect Duration: 68
 8170	polarized alkaline mostly-broken sunglasses	0		Effect: "You Know Where to Go", Effect Duration: 56
-8171	drinkable triple-distilled unflavored wine cooler	8	good	
+8171	triple-distilled drinkable unflavored wine cooler	8	good	
 8172	blue carton of snake milk	1	EPIC	
 8173	twirling ruddy sewer snake	0		Maximum HP Percent: +40
 8174	normal pigeon egg	4	good	
@@ -8056,18 +8056,18 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	smartaleck's bread basket	0		Moxie Percent: +30
 8184	ghostly Ed the Undying exhibit crate	0		
-8185	squat sizzling The Crown of Ed the Undying of the overflowing toilet	0		Stench Spell Damage: +50, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	squat sizzling The Crown of Ed the Undying of the overflowing toilet	0		Stench Spell Damage: +50, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	narrow map to a hidden booze cache	0		
 8188	bad wobbly Cherrytastrophe wine cooler	3	decent	
 8189	strong mediocre yellow Radberry Rip wine cooler	5	decent	
 8190	tolerable Orangemageddon wine cooler	4	good	
-8191	lousy red narrow Breakfast Blast wine cooler	4	decent	
+8191	lousy narrow red Breakfast Blast wine cooler	4	decent	
 8192	practically non-alcoholic bad Citrus Crush wine cooler	1	decent	
 8193	bland plain bagel	4	decent	
 8194	immense decent bouncing glob of cream cheese	6	good	
-8195	small normal loaf of soda bread	2	good	
-8196	half-sized normal enchanted acceptable bagel	2	good	Effect: "Blessing of Charcoatl", Effect Duration: 50
+8195	normal small loaf of soda bread	2	good	
+8196	enchanted half-sized normal acceptable bagel	2	good	Effect: "Blessing of Charcoatl", Effect Duration: 50
 8197	miniature toothsome narrow narrow standard-issue cupcake	2	awesome	
 8198	adequate ultra-deluxe cupcake	4	good	
 8199	bouncing hypnotic breadcrumbs	0		
@@ -8091,8 +8091,8 @@
 8217	huge clever perfume-soaked bandana of incineration	0		Maximum MP: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2015-04"
 8218	blinking toxic globule	0		Last Available: "2015-04"
 8219	bland green toxo	4	decent	Last Available: "2015-04"
-8220	spirit-forward acceptable pulsating Lemonade-235	5	good	Last Available: "2015-04"
-8221	upside-down stanky nasty isotophat	0		Stench Damage: +5, Stench Spell Damage: +25, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	acceptable spirit-forward pulsating Lemonade-235	5	good	Last Available: "2015-04"
+8221	upside-down stanky nasty isotophat	0		Stench Damage: +5, Stench Spell Damage: +25, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Three Mile Island shorts of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2015-04"
 8223	jittery double-paned Samson's toxic mop	0		Experience (Muscle): +5, Cold Resistance: +5, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8143,7 +8143,7 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	bland squat unappetizing mayolus	3	decent	Last Available: "2015-05"
 8271	decent uninteresting mayolus	4	good	Last Available: "2015-05"
-8272	rotten miniature acceptable mayolus	2	crappy	Last Available: "2015-05"
+8272	miniature rotten acceptable mayolus	2	crappy	Last Available: "2015-05"
 8273	flavorless tumbling enticing mayolus	3	decent	Last Available: "2015-05"
 8274	rotten low-calorie jittery mouth-watering mayolus	1	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8173,8 +8173,8 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	double-galvanized pressed power pill	0		Effect: "Strawberry Alarm", Effect Duration: 62, Last Available: "2015-06"
 8301	non-flattened ionized pixel star	0		Effect: "Pwnd", Effect Duration: 24, Last Available: "2015-06"
-8302	thick flavorless twirling pixel banana	5	decent	Last Available: "2015-06"
-8303	aged watered-down twirling pixel beer	2	awesome	Last Available: "2015-06"
+8302	flavorless thick twirling pixel banana	5	decent	Last Available: "2015-06"
+8303	watered-down aged twirling pixel beer	2	awesome	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	twirling pumps	0		Last Available: "2015-06"
 8306	colloidal sludgesicle	0		Effect: "Berry Statistical", Effect Duration: 32
@@ -8210,7 +8210,7 @@
 8336	corrupted shamanic ham	0		Effect: "Stands Alone", Effect Duration: 47
 8337	polarized altered huge porkpocket	0		Effect: "Spring Training", Effect Duration: 50
 8338	altered blurry Leonard's glasses	0		Effect: "The Strength...  of the Future", Effect Duration: 41
-8339	quadruple-warmed squat yellow warehouse walkie-talkie	0		Effect: "Frozen Shoulders", Effect Duration: 62
+8339	quadruple-warmed yellow squat warehouse walkie-talkie	0		Effect: "Frozen Shoulders", Effect Duration: 62
 8340	modified modified janitor's mop	0		Effect: "Fireproof Lips", Effect Duration: 68
 8341	flattened super-magnetized fuchsia warehouse clerk's glasses	0		Effect: "Human-Fish Hybrid", Effect Duration: 40
 8342	aerosolized huge baloney rotgut	0		Effect: "Charrrming", Effect Duration: 41
@@ -8231,7 +8231,7 @@
 8357	alkaline flattened blinking radioactive spider venom	0		Effect: "Carrrsmic", Effect Duration: 17
 8358	concentrated unsweetened twirling yellow x-ray mirror	0		Effect: "Red Misty-Eyed", Effect Duration: 54
 8359	magnetized Vulcanized wrestling mask	0		Effect: "License to Punch", Effect Duration: 56
-8360	warmed pressed Vulcanized ghostly purple hawkface potion	0		Effect: "Memory of Speed", Effect Duration: 30
+8360	warmed pressed Vulcanized purple ghostly hawkface potion	0		Effect: "Memory of Speed", Effect Duration: 30
 8361	nitrogenated denatured child-sized dracula cloak	0		Effect: "Spooky Demeanor", Effect Duration: 34
 8362	quantum cold-filtered green devil-summoning hat	0		Effect: "Faboooo", Effect Duration: 49
 8363	dry shopkeeper beard	0		Effect: "Elbow Sauce", Effect Duration: 21
@@ -8245,13 +8245,13 @@
 8371	dry upside-down bucket of fish juice	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 20
 8372	ionized cyan flashy pirate dreadlocks	0		Effect: "Dance Interpreter", Effect Duration: 43
 8373	aerosolized vacuum-sealed captured boozles	0		Effect: "Is This Your Card?", Effect Duration: 65
-8374	ionized tumbling mirror drinks tray	0		Effect: "Marinated", Effect Duration: 57
+8374	ionized mirror tumbling drinks tray	0		Effect: "Marinated", Effect Duration: 57
 8375	magnetized double-polarized eyebrow lifter	0		Effect: "Ass Over Teakettle", Effect Duration: 12
 8376	gray submarine	0		Last Available: "2015-06"
-8377	rotten jumbo blurry pixel lemon	5	crappy	Last Available: "2015-06"
-8378	triple-distilled bad narrow pulsating pixel daiquiri	10	decent	Last Available: "2015-06"
+8377	jumbo rotten blurry pixel lemon	5	crappy	Last Available: "2015-06"
+8378	bad triple-distilled pulsating narrow pixel daiquiri	10	decent	Last Available: "2015-06"
 8379	irradiated pulsating power pill	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 40, Last Available: "2015-06"
-8380	altered aerosolized aerosolized skewed bouncing pixel potion	0		Effect: "Frost Tea", Effect Duration: 62, Last Available: "2015-06"
+8380	altered aerosolized aerosolized bouncing skewed pixel potion	0		Effect: "Frost Tea", Effect Duration: 62, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	yellow Deck of Every Card	0		Last Available: "2015-07"
 8383	upside-down ghostly popular part	0		
@@ -8275,22 +8275,22 @@
 8401	candlestick of Tarzan of dire peril	0		Experience (Muscle): +3, Weapon Damage: +20, Lasts Until Rollover, Last Available: "2015-07"
 8402	banded Fonzie's knife	0		Experience (Moxie): +1, Damage Absorption: +100, Lasts Until Rollover, Last Available: "2015-07"
 8403	inspector's revolver of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Lasts Until Rollover, Last Available: "2015-07"
-8404	squat jittery blinking teal 1952 Mickey Mantle card	0		Last Available: "2015-07"
+8404	teal jittery squat blinking 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	narrow talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	bland bite-sized upside-down pestopiary	1	decent	
+8407	bite-sized bland upside-down pestopiary	1	decent	
 8408	corrupted activated ectoplasmic orbs	0		Effect: "20-20 Second Sight", Effect Duration: 22
 8409	bland crudles	4	decent	
-8410	stale tiny agnolotti arboli	1	decent	
-8411	bite-sized flavorless fancy spaghetti with ghost balls	1	decent	Effect: "Vinegavotte", Effect Duration: 20
+8410	tiny stale agnolotti arboli	1	decent	
+8411	flavorless fancy bite-sized spaghetti with ghost balls	1	decent	Effect: "Vinegavotte", Effect Duration: 20
 8412	yummy huge succulent marrow	3	awesome	
 8413	decent purple salacious crumbs	3	good	
 8414	tasty gray fusilli marrownarrow	4	awesome	
 8415	moldy suggestive strozzapreti	3	crappy	
 8416	Mountain Stream gastrique	0		
-8417	delicious half-sized mirror Mt. McLargeHuge oyster	2	awesome	
+8417	half-sized delicious mirror Mt. McLargeHuge oyster	2	awesome	
 8418	oyster sauce	0		
-8419	moldy huge yellow linguini immondizia bianco	10	crappy	
+8419	huge moldy yellow linguini immondizia bianco	10	crappy	
 8420	spoiled shells a la shellfish	4	crappy	
 8421	jittery Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8329,9 +8329,9 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	shaking crystalline light bulb	0		Last Available: "2015-08"
 8457	bouncing broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	ribald baleful high-temperature mining mask	0		Spell Damage: +25, Sleaze Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	ribald baleful high-temperature mining mask	0		Spell Damage: +25, Sleaze Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	squat therapeutic grievous fireproof megaphone	0		Weapon Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-08"
-8460	big decent pulsating mineapple	5	good	Last Available: "2015-08"
+8460	decent big pulsating mineapple	5	good	Last Available: "2015-08"
 8461	watered-down mediocre Gold Velvet&trade; whiskey	2	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	awesome	Last Available: "2015-08"
 8463	diet decent tumbling smelted roe	1	good	Last Available: "2015-08"
@@ -8346,13 +8346,13 @@
 8472	asbestos-lined hale heat-resistant necktie	0		Maximum HP: +20, Hot Resistance: +5, Single Equip, Last Available: "2015-08"
 8473	ribald rosy-cheeked quilted heat-resistant gloves	0		Damage Absorption: +40, Maximum HP Percent: +30, Sleaze Damage: +10, Single Equip, Last Available: "2015-08"
 8474	fancy adequate very hot lunch	3	good	Effect: "Can't Be a Chooser", Effect Duration: 50, Last Available: "2015-08"
-8475	mediocre practically non-alcoholic asbestos thermos	1	decent	Last Available: "2015-08"
+8475	practically non-alcoholic mediocre asbestos thermos	1	decent	Last Available: "2015-08"
 8476	improved squat spinning liquid rhinestones	0		Effect: "Quantum of Moxie", Effect Duration: 60, Last Available: "2015-08"
 8477	flavorless disco biscuit	4	decent	Last Available: "2015-08"
 8478	bad practically non-alcoholic Quaatorade&trade;	1	decent	Last Available: "2015-08"
-8479	greedy double-paned biker's hat of extreme caution	0		Monster Level: -25, Cold Resistance: +5, Meat Drop: +20, Familiar Effect: "atk", Last Available: "2015-08"
-8480	huge maroon lightning-fast asbestos-lined Samson's feathered headdress	0		Experience (Muscle): +5, Hot Resistance: +5, Initiative: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	blinking avaricious sizzling Da Vinci's electrician's hardhat	0		Experience (Mysticality): +5, Hot Damage: +10, Meat Drop: +30, Familiar Effect: "atk", Last Available: "2015-08"
+8479	greedy double-paned biker's hat of extreme caution	0		Monster Level: -25, Cold Resistance: +5, Meat Drop: +20, Last Available: "2015-08", Familiar Effect: "atk"
+8480	huge maroon lightning-fast asbestos-lined Samson's feathered headdress	0		Experience (Muscle): +5, Hot Resistance: +5, Initiative: +40, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	blinking avaricious sizzling Da Vinci's electrician's hardhat	0		Experience (Mysticality): +5, Hot Damage: +10, Meat Drop: +30, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	blinking airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	bouncing skewed Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	skewed Annie Oakley's smooth velvet pants	0		Critical Hit Percent: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	skewed Annie Oakley's smooth velvet pants	0		Critical Hit Percent: +20, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	chilly smooth velvet shirt	0		Cold Damage: +5, Last Available: "2015-08"
 8492	smooth velvet hat of James Dean	0		Experience (Moxie): +3, Last Available: "2015-08"
 8493	mirror Sherlock's smooth velvet pocket square	0		Item Drop: +25, Single Equip, Last Available: "2015-08"
@@ -8377,8 +8377,8 @@
 8503	signed deuce	0		Last Available: "2015-08"
 8504	twirling Lavalos core	0		Last Available: "2015-08"
 8505	teal half-melted hula girl	0		Last Available: "2015-08"
-8506	pulsating upside-down upside-down lime green glass ceiling fragments	0		Last Available: "2015-08"
-8507	denatured skewed fuchsia SMOOCH coffee cup	1	decent	Last Available: "2015-08"
+8506	upside-down lime green upside-down pulsating glass ceiling fragments	0		Last Available: "2015-08"
+8507	denatured fuchsia skewed SMOOCH coffee cup	1	decent	Last Available: "2015-08"
 8508	energized unsweetened labrador cookie	0		Effect: "Banono", Effect Duration: 13, Last Available: "2015-08"
 8509	spinning zippy sharpshooter's wizardly Mr. Cheeng's spectacles	0		Mysticality: +25, Critical Hit Percent: +10, Initiative: +20, Single Equip, Last Available: "2015-08"
 8510	red foul-smelling cool grease cannon	0		Moxie: +5, Stench Damage: +10, Last Available: "2015-08"
@@ -8391,15 +8391,15 @@
 8517	mansplainer's curative SMOOCH bracers	0		Monster Level: +15, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2015-08"
 8518	hardened SMOOCH kneepads	0		Damage Reduction: 3, Single Equip, Last Available: "2015-08"
 8519	wobbly beefy SMOOCH spaulders	0		Muscle: +10, Single Equip, Last Available: "2015-08"
-8520	jittery Sinatra's SMOOCH codpiece of the businessman	0		Experience (Moxie): +5, Meat Drop: +50, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	jittery Sinatra's SMOOCH codpiece of the businessman	0		Experience (Moxie): +5, Meat Drop: +50, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	spinning executive SMOOCH breastplate	0		Meat Drop: +40, Last Available: "2015-08"
 8522	mirror superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	blinking superheated	0		Last Available: "2015-08"
-8525	enchanted adequate immense spinning lava cake	8	good	Effect: "Berry Elemental", Effect Duration: 50, Last Available: "2015-08"
+8525	adequate enchanted immense spinning lava cake	8	good	Effect: "Berry Elemental", Effect Duration: 50, Last Available: "2015-08"
 8526	stale pink slime	3	decent	
 8527	teal ghostly Devil's Elbow Hot Sauce	0		
-8528	purple ghostly Special&trade; Sauce	0		
+8528	ghostly purple Special&trade; Sauce	0		
 8529	toothsome devil hair pasta	4	awesome	
 8530	special stale spagecialetti	4	decent	Effect: "Disco State of Mind", Effect Duration: 35
 8531	Salsa Libre	0		
@@ -8407,7 +8407,7 @@
 8533	spinning illicit fish sauce	0		
 8534	tasty diet libertagliatelle	1	awesome	
 8535	delicious turkish mostaccioli	4	awesome	
-8536	thick moldy linguini of the sea	5	crappy	
+8536	moldy thick linguini of the sea	5	crappy	
 8537	ionized nitrogenated blue Hersey&trade; SMOOCH	0		Effect: "Empty Inside", Effect Duration: 40
 8539	spinning Alexy sauce	0		
 8540	ghostly rainbow sauce	0		
@@ -8416,30 +8416,30 @@
 8543	normal fusillocybin	4	good	
 8544	adequate prescription noodles	3	good	
 8545	pickled green blood-drive sticker	1	EPIC	
-8546	altered purple narrow bag of grain	0		Effect: "Castaway Physique", Effect Duration: 40
+8546	altered narrow purple bag of grain	0		Effect: "Castaway Physique", Effect Duration: 40
 8547	concentrated triple-enhanced narrow pocket maze	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 54
 8548	triple-pressed shady shades	0		Effect: "What's That Smell?", Effect Duration: 30
 8549	triple-altered double-boiled ghostly squeaky toy rose	0		Effect: "Sweet Nostalgia", Effect Duration: 58
-8550	stale small pulsating weird gazelle steak	2	decent	
-8551	toothsome fancy sausage without a cause	3	awesome	Effect: "Human-Pirate Hybrid", Effect Duration: 15
+8550	small stale pulsating weird gazelle steak	2	decent	
+8551	fancy toothsome sausage without a cause	3	awesome	Effect: "Human-Pirate Hybrid", Effect Duration: 15
 8552	pressed pulsating face paint	0		Effect: "Voracious Gorging", Effect Duration: 29
 8553	perfectly mixed emergency margarita	4	super ultra mega EPIC	
-8554	drinkable spirit-forward vintage smart drink	5	good	
+8554	spirit-forward drinkable vintage smart drink	5	good	
 8555	a ten-percent bonus	0		
 8556	pulsating Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	modified twirling Wickers bar	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 12
-8559	concentrated jittery upside-down bakelite-covered bacon	0		Effect: "Puzzle Fury", Effect Duration: 26
+8559	concentrated upside-down jittery bakelite-covered bacon	0		Effect: "Puzzle Fury", Effect Duration: 26
 8560	aerosolized improved wobbly Aerheads	0		Effect: "Quaaaaaaa", Effect Duration: 51
 8561	wet enhanced jittery Wrotz	0		Effect: "Woad Warrior", Effect Duration: 19
-8562	unsweetened ghostly squat Gabarbar	0		Effect: "Gummiskin", Effect Duration: 13
+8562	unsweetened squat ghostly Gabarbar	0		Effect: "Gummiskin", Effect Duration: 13
 8563	alkaline teal fiberglass insulation	0		Effect: "Afternoon Insight", Effect Duration: 41
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	frightening quilted barrel lid of the brute	0		Muscle Percent: +30, Damage Absorption: +40, Spooky Damage: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Jim Carey's rock-hard barrel hoop earring of incineration	0		Damage Reduction: 5, Monster Level: +25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2015-09"
-8567	rock-hard razor-sharp Newton's bankruptcy barrel	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Damage Reduction: 5, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	rock-hard razor-sharp Newton's bankruptcy barrel	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Damage Reduction: 5, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
-8569	twirling bouncing normal barrel	0		Last Available: "2015-09"
+8569	bouncing twirling normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
 8572	spinning barrel	0		Last Available: "2015-09"
@@ -8447,9 +8447,9 @@
 8574	blue moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
-8577	huge maroon barnacled barrel	0		Last Available: "2015-09"
+8577	maroon huge barnacled barrel	0		Last Available: "2015-09"
 8578	triple-distilled bad bottle of Amontillado	10	decent	Last Available: "2015-09"
-8579	drinkable watered-down barrel-aged martini	2	good	Last Available: "2015-09"
+8579	watered-down drinkable barrel-aged martini	2	good	Last Available: "2015-09"
 8580	stale lime green barrel pickle	3	decent	Last Available: "2015-09"
 8581	bland barrel cracker	4	decent	Last Available: "2015-09"
 8582	mixed blinking vibrating mushroom	1	EPIC	Last Available: "2015-09"
@@ -8536,7 +8536,7 @@
 8663	perfectly mixed huge ghost beer	3	EPIC	
 8664	steel-toed Othello set	0		Damage Reduction: 9
 8665	tumbling rotten tomato	0		
-8666	purple spinning Twelve Night Energy	0		
+8666	spinning purple Twelve Night Energy	0		
 8667	scandalous energetic beefcake's Yorick	0		Muscle: +25, Maximum MP Percent: +20, Sleaze Damage: +5
 8668	rose	0		
 8669	tulip	0		
@@ -8547,7 +8547,7 @@
 8674	teal blinking airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	pulsating one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	oxidized shoulder-warming lotion	0		Effect: "Bats in the Belfry", Effect Duration: 34, Last Available: "2015-11"
-8677	half-sized rotten iceberg lettuce	2	crappy	Last Available: "2015-11"
+8677	rotten half-sized iceberg lettuce	2	crappy	Last Available: "2015-11"
 8678	artisanal ice wine	3	EPIC	Last Available: "2015-11"
 8679	bouncing lard-coated cool Wal-Mart snowglobe of the sewer	0		Moxie: +5, Stench Damage: +25, Sleaze Spell Damage: +25, Last Available: "2015-11"
 8680	rock-hard thinker's Wal-Mart nametag of the pedagogue	0		Mysticality: +10, Experience: +3, Damage Reduction: 5, Last Available: "2015-11"
@@ -8558,20 +8558,20 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	brawny bellhop's hat	0		Muscle Percent: +20, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	triple-distilled tolerable huge ice porter	7	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	brawny bellhop's hat	0		Muscle Percent: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	tolerable triple-distilled huge ice porter	7	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	ionized wet squat exotic travel brochure	0		Effect: "For Your Brain Only", Effect Duration: 35, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
-8692	activated green upside-down shampoo-conditioner	0		Effect: "Got Your Boots On", Effect Duration: 16, Last Available: "2015-11"
+8692	activated upside-down green shampoo-conditioner	0		Effect: "Got Your Boots On", Effect Duration: 16, Last Available: "2015-11"
 8693	upside-down hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	dried medicinal herbs	1		Last Available: "2016-01"
-8697	fancy bland ice rice	4	decent	Effect: "PERL of Great Price", Effect Duration: 25, Last Available: "2016-01"
-8698	fortified hand-crafted lime green iced plum wine	5	EPIC	Last Available: "2016-01"
+8697	bland fancy ice rice	4	decent	Effect: "PERL of Great Price", Effect Duration: 25, Last Available: "2016-01"
+8698	hand-crafted fortified lime green iced plum wine	5	EPIC	Last Available: "2016-01"
 8699	teal MacGyver's training belt of the ox of the boozehound	0		Muscle: +20, Maximum MP: +100, Booze Drop: +100, Single Equip, Last Available: "2016-01"
 8700	flame-retardant frosty beefy training legwarmers	0		Muscle: +10, Cold Spell Damage: +10, Hot Resistance: +1, Single Equip, Last Available: "2016-01"
-8701	MacGyver's stylish training helmet of Leguizamo	0		Moxie: +25, Maximum MP: +100, Monster Level: +20, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	MacGyver's stylish training helmet of Leguizamo	0		Moxie: +25, Maximum MP: +100, Monster Level: +20, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	olive training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8582,15 +8582,15 @@
 8709	denatured abstraction: thought	1		Effect: "Amorous", Effect Duration: 5, Last Available: "2015-12"
 8710	dried maroon abstraction: sensation	1		Last Available: "2015-12"
 8711	denatured jittery gray abstraction: purpose	1		Effect: "The Halls of Muscularity", Effect Duration: 20, Last Available: "2015-12"
-8712	altered shaking purple abstraction: category	1		Effect: "Mushroom Moxiousness", Effect Duration: 25, Last Available: "2015-12"
+8712	altered purple shaking abstraction: category	1		Effect: "Mushroom Moxiousness", Effect Duration: 25, Last Available: "2015-12"
 8713	powdered fuchsia twirling jittery abstraction: perception	1		Effect: "The Real Deal", Effect Duration: 10, Last Available: "2015-12"
 8714	dehydrated squat abstraction: motion	1		Effect: "Cock of the Walk", Effect Duration: 15, Last Available: "2015-12"
-8715	compressed huge yellow tumbling abstraction: joy	1		Last Available: "2015-12"
+8715	compressed tumbling huge yellow abstraction: joy	1		Last Available: "2015-12"
 8716	powdered abstraction: certainty	1		Effect: "Broken Bone Nubs", Effect Duration: 5, Last Available: "2015-12"
 8717	altered abstraction: comprehension	1		Last Available: "2015-12"
 8718	narrow jittery modern picture frame	0		Last Available: "2015-12"
 8719	decent half-sized VYKEA meatballs	2	good	Last Available: "2015-11"
-8720	perfectly mixed weak VYKEA mead	2	EPIC	Last Available: "2015-11"
+8720	weak perfectly mixed VYKEA mead	2	EPIC	Last Available: "2015-11"
 8721	warmed tarnished VYKEA woadpaint	0		Effect: "Concentrated Concentration", Effect Duration: 53, Last Available: "2015-11"
 8722	blinking VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8605,13 +8605,13 @@
 8732	bad bottle of norwhiskey	3	decent	Last Available: "2015-11"
 8733	denatured bouncing octolus oculus	1	crappy	Last Available: "2015-11"
 8734	chaotic savvy sardine can key of the pedagogue	0		Mysticality Percent: +20, Experience: +3, Spell Critical Percent: +10, Last Available: "2015-11"
-8735	blinking executive lard-coated Fonzie's norwhal helmet	0		Experience (Moxie): +1, Sleaze Spell Damage: +25, Meat Drop: +40, Familiar Effect: "atk", Last Available: "2015-11"
+8735	blinking executive lard-coated Fonzie's norwhal helmet	0		Experience (Moxie): +1, Sleaze Spell Damage: +25, Meat Drop: +40, Last Available: "2015-11", Familiar Effect: "atk"
 8736	censurious cool weightlifter's octolus-skin cloak	0		Muscle: +15, Moxie: +5, Sleaze Resistance: +3, Last Available: "2015-11"
 8737	triple-distilled mediocre perfect cosmopolitan	9	decent	Last Available: "2015-11"
 8738	hand-crafted perfect negroni	3	EPIC	Last Available: "2015-11"
 8739	acceptable perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	artisanal practically non-alcoholic tumbling perfect mimosa	1	super ultra mega turbo EPIC	Last Available: "2015-11"
-8741	drinkable triple-distilled perfect old-fashioned	6	good	Last Available: "2015-11"
+8741	triple-distilled drinkable perfect old-fashioned	6	good	Last Available: "2015-11"
 8742	tolerable special perfect paloma	3	good	Effect: "Saucemastery", Effect Duration: 45, Last Available: "2015-11"
 8743	triple-frozen pressed spinning That 70s Cologne	0		Effect: "Very Clean Teeth", Effect Duration: 62, Last Available: "2015-11"
 8744	pickled tarnished Wal-Mart &quot;diamond&quot; ring	0		Effect: "Squid Squint", Effect Duration: 59, Last Available: "2015-11"
@@ -8624,7 +8624,7 @@
 8751	aerosolized ionized dry squat olive communal gobstopper	0		Effect: "Gummiskin", Effect Duration: 42, Last Available: "2015-12"
 8752	normal red Crimbo salad	3	good	Last Available: "2015-12"
 8753	small decent bread line	2	good	Last Available: "2015-12"
-8754	weak smooth special bark rootbeer	2	awesome	Effect: "Serendipi Tea", Effect Duration: 30, Last Available: "2015-12"
+8754	special smooth weak bark rootbeer	2	awesome	Effect: "Serendipi Tea", Effect Duration: 30, Last Available: "2015-12"
 8755	artisanal ale	4	EPIC	Last Available: "2015-12"
 8756	maroon dance instructor's plastic Tammy the Tambourine Elf	0		Experience Percent (Moxie): +10, Last Available: "2015-12"
 8757	narrow vibrating plastic Rudolph the Red	0		Maximum MP Percent: +10, Last Available: "2015-12"
@@ -8676,7 +8676,7 @@
 8804	bouncing high-grade	0		Last Available: "2017-01"
 8805	purple high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
-8807	tumbling narrow experimental gene therapy	0		Last Available: "2017-01"
+8807	narrow tumbling experimental gene therapy	0		Last Available: "2017-01"
 8808	upside-down ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
@@ -8692,10 +8692,10 @@
 8820	altered spinning blinking The Author's ink	1		Effect: "Beastly Flavor", Effect Duration: 50, Last Available: "2016-02"
 8821	mediocre extra-dry twirling The Mad Liquor	5	decent	Last Available: "2016-12"
 8822	hand-crafted Doc Clock's thyme cocktail	3	super ultra EPIC	Last Available: "2016-12"
-8823	bite-sized moldy pulsating Mr. Burnsger	1	crappy	Last Available: "2016-12"
+8823	moldy bite-sized pulsating Mr. Burnsger	1	crappy	Last Available: "2016-12"
 8824	compressed The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	prompt horrifying The Jokester's gun of the scaredy-cat	0		Monster Level: -15, Spooky Damage: +25, Adventures: +3, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	mirror Van der Graaf arcane researcher's The Jokester's wig of horror	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8826	mirror Van der Graaf arcane researcher's The Jokester's wig of horror	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	double-paned smooth The Jokester's pants of the boozehound	0		Moxie: +15, Cold Resistance: +5, Booze Drop: +100, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	concentrated fuchsia Jokester makeup	0		Effect: "Pumped Up", Effect Duration: 29, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
@@ -8703,8 +8703,8 @@
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	narrow domino mask	0		Familiar Weight: +5
 8833	deionized dry robin's egg	0		Effect: "Tiki Thoughtfulness", Effect Duration: 48, Last Available: "2016-12"
-8834	normal fancy snack-sized robin flan	2	good	Effect: "Sugar High", Effect Duration: 5, Last Available: "2016-12"
-8835	tolerable watered-down robin nog	2	good	Last Available: "2016-12"
+8834	fancy normal snack-sized robin flan	2	good	Effect: "Sugar High", Effect Duration: 5, Last Available: "2016-12"
+8835	watered-down tolerable robin nog	2	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	spinning plaintive telegram	0		Last Available: "2016-02"
 8838	yellow exploding gum	0		
@@ -8713,7 +8713,7 @@
 8841	pickled spinning Mansquito's blood	0		Effect: "Fudge Headache", Effect Duration: 28
 8842	enhanced infrablack lipstick	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 38
 8843	polymerized activated twirling shaking can of drain cleaner	0		Effect: "The Power of Negative Thinking", Effect Duration: 29
-8844	polymerized magnetized narrow teal wobbly The Author's inkwell	0		Effect: "Rushin' Hands", Effect Duration: 63
+8844	polymerized magnetized wobbly narrow teal The Author's inkwell	0		Effect: "Rushin' Hands", Effect Duration: 63
 8845	aerosolized cold-filtered bag of random words	0		Effect: "Mucilaginous Muscle", Effect Duration: 56
 8846	super-chilled irradiated upside-down tube of pendulum lube	0		Effect: "Celestial Sheen", Effect Duration: 38
 8847	enhanced quantum red-hot jawbreaker	0		Effect: "Toothy Grin", Effect Duration: 65
@@ -8722,12 +8722,12 @@
 8850	your cowboy boots of the brazier	0		Hot Spell Damage: +25, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	twirling inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
-8853	spinning tumbling nugget of thicksilver	0		Last Available: "2016-02"
+8853	tumbling spinning nugget of thicksilver	0		Last Available: "2016-02"
 8854	nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
-8858	upside-down olive nugget of ticksilver	0		Last Available: "2016-02"
+8858	olive upside-down nugget of ticksilver	0		Last Available: "2016-02"
 8859	blinking auspicious quicksilver ring	0		Item Drop: +10, Single Equip, Last Available: "2016-02"
 8860	flame-retardant horrifying electrified thicksilver ring	0		Spooky Damage: +25, Hot Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-02"
 8861	fuchsia Jim Carey's shellacked wicksilver ring of the bloodbag	0		Damage Reduction: 7, Maximum HP: +100, Monster Level: +25, Single Equip, Last Available: "2016-02"
@@ -8748,17 +8748,17 @@
 8876	bland huge plate of Heimz Fortified Kidney Beans	9	decent	Last Available: "2016-02"
 8877	flavorless plate of Tesla's Electroplated Beans	3	decent	Last Available: "2016-02"
 8878	normal squat plate of Mixed Garbanzos and Chickpeas	3	good	Last Available: "2016-02"
-8879	big adequate blinking plate of Hellfire Spicy Beans	5	good	Last Available: "2016-02"
-8880	immense normal plate of Frigid Northern Beans	8	good	Last Available: "2016-02"
+8879	adequate big blinking plate of Hellfire Spicy Beans	5	good	Last Available: "2016-02"
+8880	normal immense plate of Frigid Northern Beans	8	good	Last Available: "2016-02"
 8881	flavorless plate of World's Blackest-Eyed Peas	3	decent	Last Available: "2016-02"
 8882	adequate half-sized huge plate of Trader Olaf's Exotic Stinkbeans	2	good	Last Available: "2016-02"
 8883	moldy plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	crappy	Last Available: "2016-02"
 8884	special small flavorless upside-down plate of Val-U Brand Every Bean Salad	2	decent	Effect: "Burning Tongue", Effect Duration: 5, Last Available: "2016-02"
-8885	bite-sized yummy plate of Shrub's Premium Baked Beans	1	awesome	Last Available: "2016-02"
+8885	yummy bite-sized plate of Shrub's Premium Baked Beans	1	awesome	Last Available: "2016-02"
 8886	upside-down Samson's Fancy Jeff's pocket square of the bloodbag	0		Experience (Muscle): +5, Maximum HP: +100, Last Available: "2016-02"
-8887	asbestos-lined hale experienced Daisy's unclean bloomers	0		Experience: +2, Maximum HP: +20, Hot Resistance: +5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	asbestos-lined hale experienced Daisy's unclean bloomers	0		Experience: +2, Maximum HP: +20, Hot Resistance: +5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	jittery Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	fireproof flame-wreathed extremely unsafe Amoon-Ra Cowtep's nemes	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Hot Resistance: +3, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	fireproof flame-wreathed extremely unsafe Amoon-Ra Cowtep's nemes	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Hot Resistance: +3, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	yellow Glenn's dice	0		Last Available: "2016-02"
 8891	auspicious stanky studded weightlifter's Former Sheriff Dan's tin star of the storm	0		Muscle: +15, Damage Absorption: +80, Maximum MP Percent: +40, Stench Spell Damage: +25, Item Drop: +10, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	ionized spinning mirror rattler gland	0		Effect: "The Grass...  Is Blue...", Effect Duration: 65, Last Available: "2016-02"
 8907	ionized unsweetened narrow half-digested coal	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 51, Last Available: "2016-02"
 8908	improved tightly-wound spine	0		Effect: "Melancholy Burden", Effect Duration: 48, Last Available: "2016-02"
-8909	jumbo toothsome rotting beefsteak	5	awesome	Last Available: "2016-02"
+8909	toothsome jumbo rotting beefsteak	5	awesome	Last Available: "2016-02"
 8910	delicious firemilk	3	awesome	Last Available: "2016-02"
 8911	galvanized non-anodized lime green spidercow eye-cluster	0		Effect: "Uncucumbered", Effect Duration: 15, Last Available: "2016-02"
 8912	distilled moomy dust	1		Last Available: "2016-02"
@@ -8795,7 +8795,7 @@
 8923	disc (white)	0		
 8924	disc (black)	0		
 8925	disc (red)	0		
-8926	yellow shaking mirror disc (green)	0		
+8926	mirror shaking yellow disc (green)	0		
 8927	disc (blue)	0		
 8928	disc (yellow)	0		
 8929	narrow red-hot knucklebone	0		Last Available: "2016-02"
@@ -8823,7 +8823,7 @@
 8951	sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
-8954	spinning huge special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
+8954	huge spinning special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	fuchsia Tales of the West: Cow Punching	0		
 8956	upside-down Tales of the West: Beanslinging	0		
 8957	ghostly Tales of the West: Snake Oiling	0		
@@ -8841,7 +8841,7 @@
 8969	olive upside-down eleven-gallon hat of the overflowing toilet of terror	0		Stench Spell Damage: +50, Spooky Spell Damage: +10
 8970	toy sixgun	0		
 8971	snake oil	0		
-8972	nitrogenated vacuum-sealed mirror blurry skin oil	0		Effect: "Ticking Clock", Effect Duration: 15
+8972	nitrogenated vacuum-sealed blurry mirror skin oil	0		Effect: "Ticking Clock", Effect Duration: 15
 8973	Vulcanized dry dry unusual oil	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 60
 8974	dry shaking eldritch oil	0		Effect: "Stinky Hands", Effect Duration: 51
 8975	exclusive club	0		
@@ -8867,12 +8867,12 @@
 8995	non-anodized Greek fire	0		Effect: "Scavengers Scavenging", Effect Duration: 59, Last Available: "2016-03"
 8996	flame-wreathed dog trainer's beefy ox-head shield of the brute of the boozehound	0		Muscle: +10, Muscle Percent: +30, Experience (familiar): +1, Hot Spell Damage: +10, Booze Drop: +100, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	pulsating Jack Frost's healthy Fonzie's Rosewater's stylish dented scepter	0		Moxie: +25, Mysticality Percent: +30, Experience (Moxie): +1, Maximum HP Percent: +20, Cold Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	purple rosewater-soaked crafty very pointy crown of the pedagogue of the dark arts of incineration	0		Experience: +3, Spell Damage Percent: +100, Maximum MP: +10, Hot Spell Damage: +50, Stench Resistance: +3, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	purple rosewater-soaked crafty very pointy crown of the pedagogue of the dark arts of incineration	0		Experience: +3, Spell Damage Percent: +100, Maximum MP: +10, Hot Spell Damage: +50, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	family-friendly Jeselnik's battle broom of the wise owl of the pedagogue of the detective	0		Mysticality: +20, Experience: +3, Sleaze Damage: +25, Sleaze Resistance: +1, Item Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	yellow knitted Rosewater's carpe of the brazier of the boozehound	0		Mysticality Percent: +30, Hot Spell Damage: +25, Cold Resistance: +3, Booze Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9002	upside-down lightning-fast nippy codpiece of wisdom of the pedagogue	0		Mysticality: +15, Experience: +3, Cold Damage: +10, Initiative: +40, Lasts Until Rollover, Last Available: "2016-04"
-9003	asbestos-lined hardened extremely unsafe stylish troutsers	0		Moxie: +25, Weapon Damage Percent: +100, Damage Reduction: 3, Hot Resistance: +5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	asbestos-lined hardened extremely unsafe stylish troutsers	0		Moxie: +25, Weapon Damage Percent: +100, Damage Reduction: 3, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	dog trainer's quilted smartaleck's bass clarinet of the storm	0		Moxie Percent: +30, Damage Absorption: +40, Maximum MP Percent: +40, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2016-04"
 9005	miser's Jim Carey's Oprah's fish hatchet of the detective	0		Maximum MP Percent: +50, Monster Level: +25, Item Drop: +20, Meat Drop: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	lime green pulsating studded Fonzie's tunac of the cougar of temperance	0		Moxie: +20, Experience (Moxie): +1, Damage Absorption: +80, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
@@ -8884,18 +8884,18 @@
 9012	teal huge Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
 9013	smooth sonar fishfinder	0		Moxie: +15, Last Available: "2016-04"
 9014	twirling luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
-9015	wobbly twirling tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
+9015	twirling wobbly tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	lime green meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	low-calorie rotten gallon of milk	1	crappy	Last Available: "2016-05"
+9021	rotten low-calorie gallon of milk	1	crappy	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	cyan daily dungeon malware	0		Last Available: "2016-05"
 9025	infinite BACON machine	0		Last Available: "2016-05"
-9026	pulsating skewed First Post shirt package	0		Last Available: "2016-05"
+9026	skewed pulsating First Post shirt package	0		Last Available: "2016-05"
 9027	squat friendly vibrating First Post shirt - Cir Senam of terror	0		Maximum MP Percent: +10, Familiar Weight: +3, Spooky Spell Damage: +10, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
@@ -8905,7 +8905,7 @@
 9033	shaking Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	normal huge browser cookie	10	good	Last Available: "2016-06"
-9036	weak drinkable hacked gibson	2	good	Last Available: "2016-06"
+9036	drinkable weak hacked gibson	2	good	Last Available: "2016-06"
 9037	narrow Source shades of the empath	0		Familiar Weight: +5, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8927,7 +8927,7 @@
 9055	Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
-9058	maroon narrow Source terminal file: portscan.edu	0		Last Available: "2016-06"
+9058	narrow maroon Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	maroon Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	Source terminal file: pram.ext	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	chilly Mr. Screege's spectacles	0		Cold Damage: +5, Single Equip, Last Available: "2016-08"
 9092	blinking squat twirling fireproof Lo Pan's Spookyraven signet of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Hot Resistance: +3, Single Equip, Last Available: "2016-08"
 9093	blue educational Rosewater's tie-dyed fannypack	0		Mysticality Percent: +30, Experience: +1, Single Equip, Last Available: "2016-08"
-9094	narrow medical-grade burnt snowpants of the empath	0		Familiar Weight: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	narrow medical-grade burnt snowpants of the empath	0		Familiar Weight: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	weightlifter's standards and practices guide	0		Muscle: +15, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	chaotic grievous brawny Carpathian longsword	0		Muscle Percent: +20, Weapon Damage Percent: +50, Spell Critical Percent: +10, Last Available: "2016-08"
 9097	miser's Liam's mail of the sewer of the cheetah	0		Stench Damage: +25, Meat Drop: +10, Initiative: +60, Last Available: "2016-08"
@@ -8988,48 +8988,48 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	narrow MacGyver's repaid diaper	0		Maximum MP: +100
 9118	squat twirling Riker's Search History	0		Last Available: "2016-09"
-9119	smooth practically non-alcoholic Shot of Kardashian Gin	1	awesome	Last Available: "2016-09"
+9119	practically non-alcoholic smooth Shot of Kardashian Gin	1	awesome	Last Available: "2016-09"
 9120	toasty Unstable Pointy Ears	0		Hot Damage: +5, Lasts Until Rollover, Last Available: "2016-09"
 9121	teal Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	mirror Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
 9123	narrow School of Hard Knocks Diploma	0		
-9124	blurry yellow baby bark scorpion	0		
+9124	yellow blurry baby bark scorpion	0		
 9125	gray droppable microphone	0		
-9126	practically non-alcoholic aged unidentified drink	1	awesome	
+9126	aged practically non-alcoholic unidentified drink	1	awesome	
 9127	teal curative supercool KoL Con 13 T-shirt	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5
 9128	personal trainer's discarded swimming trunks of vim and vigor of the blizzard	0		Experience Percent (Muscle): +10, Maximum HP Percent: +50, Cold Spell Damage: +25
-9129	deionized polarized shaking red diluted makeup	0		Effect: "Muscularrr", Effect Duration: 23
+9129	deionized polarized red shaking diluted makeup	0		Effect: "Muscularrr", Effect Duration: 23
 9130	irradiated purple charisma potion	0		Effect: "Devil Inside", Effect Duration: 29
 9131	extremely confusing manual	0		
 9132	mirror wobbly fortified cool pistol	0		Moxie: +5, Damage Absorption: +60
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	rotten miniature cyan leftover pasty	2	crappy	
-9135	watered-down bad very whiskey	2	decent	
+9134	miniature rotten cyan leftover pasty	2	crappy	
+9135	bad watered-down very whiskey	2	decent	
 9136	jittery li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	bouncing li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	yellow li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	huge li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	bouncing li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	bouncing li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	yellow li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	huge li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	bouncing li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	moist hoarded candy wad	0		Effect: "Pumped Up", Effect Duration: 58, Last Available: "2016-10"
 9147	aerosolized nitrogenated cyan Prunets	0		Effect: "Influence of Sphere", Effect Duration: 65
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	super-nitrogenated invisible string	0		Lasts Until Rollover, Effect: "Nut-Rition", Effect Duration: 58, Last Available: "2016-10"
 9151	alkaline alkaline squat invisible seam ripper	0		Lasts Until Rollover, Effect: "Spore-Wreathed", Effect Duration: 41, Last Available: "2016-10"
-9152	upside-down li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	adequate snack-sized jittery wobbly fuchsia raw sweet potato	2	good	Last Available: "2016-11"
+9152	upside-down li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9153	snack-sized adequate jittery wobbly fuchsia raw sweet potato	2	good	Last Available: "2016-11"
 9154	bland diet maroon raw beans	1	decent	Last Available: "2016-11"
 9155	stale wobbly raw stuffing	4	decent	Last Available: "2016-11"
 9156	adequate raw cranberry sauce	4	good	Last Available: "2016-11"
 9157	toothsome raw turkey	3	awesome	Last Available: "2016-11"
 9158	flavorless mirror raw mincemeat	3	decent	Last Available: "2016-11"
 9159	rotten small blinking raw potato	2	crappy	Last Available: "2016-11"
-9160	flavorless immense raw gravy	6	decent	Last Available: "2016-11"
+9160	immense flavorless raw gravy	6	decent	Last Available: "2016-11"
 9161	flavorless raw bread	4	decent	Last Available: "2016-11"
 9162	mini-marshmallow dispenser of the ox of bravery	0		Muscle: +20, Spooky Resistance: +5, Last Available: "2016-11"
 9163	lard-coated vibrating dance instructor's glass casserole dish	0		Experience Percent (Moxie): +10, Maximum MP Percent: +10, Sleaze Spell Damage: +25, Last Available: "2016-11"
@@ -9044,13 +9044,13 @@
 9172	spoiled bean casserole	4	crappy	Last Available: "2016-11"
 9173	normal baked stuffing	3	good	Last Available: "2016-11"
 9174	stale olive squat cranberry cylinder	4	decent	Last Available: "2016-11"
-9175	gigantic bland thanksgiving turkey	8	decent	Last Available: "2016-11"
+9175	bland gigantic thanksgiving turkey	8	decent	Last Available: "2016-11"
 9176	rotten huge mince pie	3	crappy	Last Available: "2016-11"
 9177	bland mashed potatoes	3	decent	Last Available: "2016-11"
-9178	bland bite-sized warm gravy	1	decent	Last Available: "2016-11"
+9178	bite-sized bland warm gravy	1	decent	Last Available: "2016-11"
 9179	flavorless bread roll	3	decent	Last Available: "2016-11"
 9180	super-sized spoiled gray leftovers	5	crappy	Last Available: "2016-11"
-9181	bland miniature fuchsia leftovers sandwich	2	decent	Last Available: "2016-11"
+9181	miniature bland fuchsia leftovers sandwich	2	decent	Last Available: "2016-11"
 9182	narrow mirror Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
@@ -9090,7 +9090,7 @@
 9218	blue sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	flavorless animal part cracker	4	decent	Last Available: "2016-12"
 9220	bad gingerbread wine	4	decent	Last Available: "2016-12"
-9221	small adequate enchanted gingerbread mug	2	good	Effect: "Preternatural Greed", Effect Duration: 30, Last Available: "2016-12"
+9221	enchanted adequate small gingerbread mug	2	good	Effect: "Preternatural Greed", Effect Duration: 30, Last Available: "2016-12"
 9222	extremely unsafe gingerbread mask	0		Weapon Damage Percent: +100, Last Available: "2016-12"
 9223	squat sharpshooter's hardy savvy gingerservo	0		Mysticality Percent: +20, Maximum HP: +50, Critical Hit Percent: +10, Single Equip, Last Available: "2016-12"
 9224	quadruple-dry ghostly tainted icing	0		Effect: "Cotton Mouthed", Effect Duration: 37, Last Available: "2016-12"
@@ -9124,7 +9124,7 @@
 9252	adequate spiritual candy cane	3	good	Last Available: "2016-12"
 9253	bad twirling spiritual eggnog	3	decent	Last Available: "2016-12"
 9254	normal spiritual fruitcake	3	good	Last Available: "2016-12"
-9255	snack-sized bland spiritual gingerbread	2	decent	Last Available: "2016-12"
+9255	bland snack-sized spiritual gingerbread	2	decent	Last Available: "2016-12"
 9256	yellow chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9133,10 +9133,10 @@
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
-9264	purple bouncing briefcase full of sprinkles	0		Last Available: "2016-12"
+9264	bouncing purple briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	electrified colloidal wet rock candy	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 65, Last Available: "2016-12"
-9267	toothsome huge wobbly green-iced sweet roll	9	awesome	Last Available: "2016-12"
+9267	huge toothsome wobbly green-iced sweet roll	9	awesome	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9159,7 +9159,7 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	auspicious toasty friendly Uncle Crimbo's hat	0		Familiar Weight: +3, Hot Damage: +5, Item Drop: +10, Last Available: "2016-12"
-9290	rotten diet Eldritch snap	1	crappy	Last Available: "2017-01"
+9290	diet rotten Eldritch snap	1	crappy	Last Available: "2017-01"
 9291	dehydrated twirling hot jelly	1		Last Available: "2017-01"
 9292	diluted twirling twirling jelly	1		Last Available: "2017-01"
 9293	dried jittery jelly	1		Last Available: "2017-01"
@@ -9169,7 +9169,7 @@
 9297	spoiled shaking wobbly toast with hot jelly	4	crappy	Last Available: "2017-01"
 9298	tasty toast with jelly	4	awesome	Last Available: "2017-01"
 9299	flavorless gigantic toast with jelly	7	decent	Last Available: "2017-01"
-9300	enchanted bland toast with sleaze jelly	4	decent	Effect: "White-boy Angst", Effect Duration: 20, Last Available: "2017-01"
+9300	bland enchanted toast with sleaze jelly	4	decent	Effect: "White-boy Angst", Effect Duration: 20, Last Available: "2017-01"
 9301	moldy immense toast with stench jelly	10	crappy	Last Available: "2017-01"
 9302	squat space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9178,7 +9178,7 @@
 9306	chilly dance instructor's candle	0		Experience Percent (Moxie): +10, Cold Damage: +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	decent fancy wax pancake	3	good	Effect: "In Tuna", Effect Duration: 35, Last Available: "2017-01"
 9308	jittery MacGyver's Socratic wax face	0		Experience (Mysticality): +1, Maximum MP: +100, Last Available: "2017-01"
-9309	triple-distilled bad yellow wax booze	7	decent	Last Available: "2017-01"
+9309	bad triple-distilled yellow wax booze	7	decent	Last Available: "2017-01"
 9310	bouncing glob of melted wax	0		Last Available: "2017-01"
 9311	pickled upside-down sea jelly	1		Effect: "Heart of Yellow", Effect Duration: 25, Last Available: "2017-01"
 9312	decent tumbling sea truffle	3	good	Last Available: "2017-01"
@@ -9201,7 +9201,7 @@
 9329	dry alkaline chilled eldritch alignment spray	0		Effect: "How to Scam Tourists", Effect Duration: 55, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	purple huge stanky smartaleck's eldritch hammer of the businessman	0		Moxie Percent: +30, Stench Spell Damage: +25, Meat Drop: +50, Last Available: "2017-01"
-9332	bland jittery huge eldritch mushroom	4	decent	Last Available: "2017-03"
+9332	bland huge jittery eldritch mushroom	4	decent	Last Available: "2017-03"
 9333	teal eldritch ichor	0		
 9334	bland eldritch mushroom pizza	3	decent	Last Available: "2017-03"
 9335	ghostly eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9215,13 +9215,13 @@
 9343	bottlecap	0		
 9344	squat discarded button	0		
 9345	Gummi-Memory	0		
-9346	shaking tumbling Thwaitgold amoeba statuette	0		
-9347	ghostly twirling pickled grasshopper	0		Last Available: "2017-03"
+9346	tumbling shaking Thwaitgold amoeba statuette	0		
+9347	twirling ghostly pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	red bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	skewed elemental sugarcube	0		Last Available: "2017-03"
 9351	fuchsia peppermint sprig	0		Last Available: "2017-03"
-9352	blinking spinning bottle of clam juice	0		Last Available: "2017-03"
+9352	spinning blinking bottle of clam juice	0		Last Available: "2017-03"
 9353	squat cocktail mushroom	0		Last Available: "2017-03"
 9354	teal shot of granola liqueur	0		Last Available: "2017-03"
 9355	mirror can of cherry-flavored sterno	0		Last Available: "2017-03"
@@ -9232,44 +9232,44 @@
 9360	fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
 9362	huge pile of dirt	0		Last Available: "2017-03"
-9363	shaking olive slime shooter	0		Last Available: "2017-03"
+9363	olive shaking slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	acceptable literal grasshopper	3	good	Last Available: "2017-03"
-9366	artisanal watered-down mirror upside-down double entendre	2	EPIC	Last Available: "2017-03"
+9366	watered-down artisanal mirror upside-down double entendre	2	EPIC	Last Available: "2017-03"
 9367	smooth Phlegethon	3	awesome	Last Available: "2017-03"
 9368	weak aged upside-down Siberian sunrise	2	awesome	Last Available: "2017-03"
 9369	aged mentholated wine	3	awesome	Last Available: "2017-03"
-9370	hand-crafted weak low tide martini	2	EPIC	Last Available: "2017-03"
+9370	weak hand-crafted low tide martini	2	EPIC	Last Available: "2017-03"
 9371	aged bouncing shroomtini	3	awesome	Last Available: "2017-03"
 9372	drinkable watered-down morning dew	2	good	Last Available: "2017-03"
-9373	triple-distilled acceptable teal whiskey squeeze	6	good	Last Available: "2017-03"
+9373	acceptable triple-distilled teal whiskey squeeze	6	good	Last Available: "2017-03"
 9374	drinkable fortified pulsating great fashioned	5	good	Last Available: "2017-03"
-9375	watered-down acceptable Gnomish sagngria	2	good	Last Available: "2017-03"
-9376	special artisanal vodka stinger	4	EPIC	Effect: "Deadly Flashing Blade", Effect Duration: 10, Last Available: "2017-03"
+9375	acceptable watered-down Gnomish sagngria	2	good	Last Available: "2017-03"
+9376	artisanal special vodka stinger	4	EPIC	Effect: "Deadly Flashing Blade", Effect Duration: 10, Last Available: "2017-03"
 9377	bad extremely slippery nipple	3	decent	Last Available: "2017-03"
 9378	bad piscatini	3	decent	Last Available: "2017-03"
-9379	delicious weak Churchill	2	awesome	Last Available: "2017-03"
-9380	watered-down tolerable soilzerac	2	good	Last Available: "2017-03"
+9379	weak delicious Churchill	2	awesome	Last Available: "2017-03"
+9380	tolerable watered-down soilzerac	2	good	Last Available: "2017-03"
 9381	mediocre red London frog	3	decent	Last Available: "2017-03"
 9382	drinkable fortified nothingtini	5	good	Last Available: "2017-03"
 9383	hand-crafted strong eighth plague	5	EPIC	Last Available: "2017-03"
 9384	tolerable olive shaking single entendre	3	good	Last Available: "2017-03"
 9385	hand-crafted reverse Tantalus	4	EPIC	Last Available: "2017-03"
 9386	perfectly mixed elemental caipiroska	3	EPIC	Last Available: "2017-03"
-9387	bad special watered-down wobbly Feliz Navidad	2	decent	Effect: "Warm Belly", Effect Duration: 50, Last Available: "2017-03"
+9387	watered-down bad special wobbly Feliz Navidad	2	decent	Effect: "Warm Belly", Effect Duration: 50, Last Available: "2017-03"
 9388	perfectly mixed Bloody Nora	4	EPIC	Last Available: "2017-03"
 9389	lousy moreltini	4	decent	Last Available: "2017-03"
 9390	perfectly mixed blurry hell in a bucket	4	EPIC	Last Available: "2017-03"
-9391	bad practically non-alcoholic Newark	1	decent	Last Available: "2017-03"
+9391	practically non-alcoholic bad Newark	1	decent	Last Available: "2017-03"
 9392	extra-dry hand-crafted pulsating R'lyeh	5	EPIC	Last Available: "2017-03"
 9393	bad Gnollish sangria	3	decent	Last Available: "2017-03"
 9394	aged vodka barracuda	3	awesome	Last Available: "2017-03"
-9395	acceptable practically non-alcoholic jittery Mysterious Island iced tea	1	good	Last Available: "2017-03"
-9396	irresponsibly strong fancy drinkable tumbling fuchsia drive-by shooting	9	good	Effect: "Aries Rising", Effect Duration: 10, Last Available: "2017-03"
+9395	practically non-alcoholic acceptable jittery Mysterious Island iced tea	1	good	Last Available: "2017-03"
+9396	drinkable irresponsibly strong fancy fuchsia tumbling drive-by shooting	9	good	Effect: "Aries Rising", Effect Duration: 10, Last Available: "2017-03"
 9397	lousy gunner's daughter	3	decent	Last Available: "2017-03"
-9398	bad weak dirt julep	2	decent	Last Available: "2017-03"
+9398	weak bad dirt julep	2	decent	Last Available: "2017-03"
 9399	mediocre Simepore slime	3	decent	Last Available: "2017-03"
-9400	strong bad Phil Collins	5	decent	Last Available: "2017-03"
+9400	bad strong Phil Collins	5	decent	Last Available: "2017-03"
 9401	upside-down unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9289,7 +9289,7 @@
 9417	squat alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	altered upside-down wobbly alien plant goo	1		Last Available: "2017-04"
+9420	altered wobbly upside-down alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	decent alien meat	3	good	Last Available: "2017-04"
@@ -9336,7 +9336,7 @@
 9464	narrow Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	adequate spinning Aldebaran sardines	3	good	Last Available: "2017-04"
-9467	irresponsibly strong mediocre spinning tumbling Centauri fish wine	7	decent	Last Available: "2017-04"
+9467	mediocre irresponsibly strong tumbling spinning Centauri fish wine	7	decent	Last Available: "2017-04"
 9468	mixed pulsating oxygen	1		Last Available: "2017-04"
 9469	spinning lion tamer's crafty Spacegate scientist's insignia	0		Maximum MP: +10, Experience (familiar): +2, Single Equip, Last Available: "2017-04"
 9470	Sherlock's Spacegate military insignia of incineration	0		Hot Spell Damage: +50, Item Drop: +25, Single Equip, Last Available: "2017-04"
@@ -9364,12 +9364,12 @@
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	reassuring strapping Kremlin's Greatest Briefcase of Calamity Jane	0		Muscle: +5, Critical Hit Percent: +15, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	acceptable basic martini	3	good	Last Available: "2017-06"
-9495	lousy irresponsibly strong shaking improved martini	7	decent	Last Available: "2017-06"
+9495	irresponsibly strong lousy shaking improved martini	7	decent	Last Available: "2017-06"
 9496	smooth weak splendid martini	2	awesome	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	squat jittery can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	pulsating tattoo gun	0		Last Available: "2017-06"
-9500	shaking wobbly gun	0		Free Pull, Last Available: "2017-06"
+9500	wobbly shaking gun	0		Free Pull, Last Available: "2017-06"
 9501	mirror gum	0		Free Pull, Last Available: "2017-06"
 9502	huge nippy electrified stylish plastic gundam	0		Moxie: +25, Cold Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2017-06"
 9503	License to Chill	0		Last Available: "2017-07"
@@ -9383,12 +9383,12 @@
 9511	gray Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	flavorless miniature meteoreo	2	decent	Last Available: "2017-08"
+9514	miniature flavorless meteoreo	2	decent	Last Available: "2017-08"
 9515	drinkable watered-down narrow meadeorite	2	good	Last Available: "2017-08"
 9516	huge meteoroid	0		Last Available: "2017-08"
 9517	purple wicked arcane researcher's meteortarboard of the detective	0		Experience Percent (Mysticality): +10, Spell Damage: +5, Item Drop: +20, Last Available: "2017-08"
 9518	upside-down lion tamer's Tesla occult meteorite guard	0		Spell Damage Percent: +25, Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 9, Last Available: "2017-08"
-9519	upside-down shaking auspicious shellacked meteorb	0		Damage Reduction: 7, Item Drop: +10, Lantern Element: "Hot", Last Available: "2017-08"
+9519	upside-down shaking auspicious shellacked meteorb	0		Damage Reduction: 7, Item Drop: +10, Last Available: "2017-08", Lantern Element: "Hot"
 9520	baleful sage asteroid belt	0		Mysticality Percent: +10, Spell Damage: +25, Single Equip, Last Available: "2017-08"
 9521	purple Temple Grandin's meteorthopedic shoes of James Dean of the empath	0		Experience (Moxie): +3, Familiar Weight: 12, Single Equip, Last Available: "2017-08"
 9522	blurry lion tamer's thinker's shooting morning star of the blizzard	0		Mysticality: +10, Experience (familiar): +2, Cold Spell Damage: +25, Single Equip, Last Available: "2017-08"
@@ -9408,18 +9408,18 @@
 9536	tumbling pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
-9539	cyan blinking hunk of granite	0		
+9539	blinking cyan hunk of granite	0		
 9540	narrow olive shovelful of dirt	0		
 9541	spinning xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	spinning X	0		Last Available: "2017-10"
 9544	green O	0		Last Available: "2017-10"
-9545	extra-dry bad wobbly DUFRESNE Suds	5	decent	Last Available: "2017-09"
+9545	bad extra-dry wobbly DUFRESNE Suds	5	decent	Last Available: "2017-09"
 9546	smartaleck's mafia pinky ring of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Single Equip
 9547	drinkable blurry flask of port	3	good	
 9548	banded baleful contract enforcement stick	0		Spell Damage: +25, Damage Absorption: +100
-9549	tasty small Hide-rox&trade; cookie	2	awesome	Last Available: "2017-10"
-9550	tolerable practically non-alcoholic jug of booze	1	good	Last Available: "2017-10"
+9549	small tasty Hide-rox&trade; cookie	2	awesome	Last Available: "2017-10"
+9550	practically non-alcoholic tolerable jug of booze	1	good	Last Available: "2017-10"
 9551	activated magnetized diffused pair of candy glasses	0		Effect: "Heart of Lavender", Effect Duration: 59, Last Available: "2017-10"
 9552	chilled blinking temporary X tattoos	0		Effect: "Balls of Ectoplasm", Effect Duration: 41, Last Available: "2017-10"
 9553	twisted glyph of athleticism	1		Last Available: "2017-10"
@@ -9449,7 +9449,7 @@
 9577	maroon mafia filofax	0		
 9578	transparent nog	1	good	Last Available: "2017-12"
 9579	moldy unfinished fruitcake	3	crappy	Last Available: "2017-12"
-9580	corrupted skewed gray and cracker	0		Effect: "Prideful Strut", Effect Duration: 34, Last Available: "2017-12"
+9580	corrupted gray skewed and cracker	0		Effect: "Prideful Strut", Effect Duration: 34, Last Available: "2017-12"
 9581	smooth neg grog	3	awesome	Last Available: "2017-12"
 9582	moldy half double fruitcake	3	crappy	Last Available: "2017-12"
 9583	bite-sized spoiled hushed puppy	1	crappy	Last Available: "2017-12"
@@ -9462,16 +9462,16 @@
 9590	huge hardened plastic The Silent Nightmare	0		Damage Reduction: 3, Last Available: "2017-12"
 9591	locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	blurry mumming trunk	0		Last Available: "2017-12"
-9593	ghostly lime green blurry temperance whiskey	1	crappy	Last Available: "2017-11"
+9593	lime green blurry ghostly temperance whiskey	1	crappy	Last Available: "2017-11"
 9594	pickled modified red wishbone	0		Effect: "Alchemical, Brother", Effect Duration: 58, Last Available: "2017-11"
 9595	artisanal Racisto Ruidoso	3	super ultra mega turbo EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	normal bite-sized bran muffin	1	good	
-9598	moldy tiny blueberry muffin	1	crappy	
+9598	tiny moldy blueberry muffin	1	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
-9602	huge bouncing silent D	0		Last Available: "2017-12"
+9602	bouncing huge silent D	0		Last Available: "2017-12"
 9603	silent E	0		Last Available: "2017-12"
 9604	silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
@@ -9522,7 +9522,7 @@
 9650	acceptable nega-mushroom wine	3	good	Last Available: "2017-12"
 9651	Vulcanized narrow Cheer-Up soda	0		Effect: "Bolts about Candy", Effect Duration: 21, Last Available: "2017-12"
 9652	big delicious mime army rations	5	awesome	Last Available: "2017-12"
-9653	high-proof tolerable mime army wine	10	good	Last Available: "2017-12"
+9653	tolerable high-proof mime army wine	10	good	Last Available: "2017-12"
 9654	distilled mirror mime army superserum	1		Last Available: "2017-12"
 9655	deionized activated purple mime army camouflage kit	0		Effect: "Hagnk's Gratitude", Effect Duration: 50, Last Available: "2017-12"
 9656	miming beret of the blizzard of the detective	0		Cold Spell Damage: +25, Item Drop: +20, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	modified unsweetened oxidized blurry digital honeypot	0		Effect: "Human-Plant Hybrid", Effect Duration: 57, Last Available: "2025-12"
 9666	pulsating mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	thinker's mime army insignia (infantry)	0		Mysticality: +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	brawny mime army insignia (intelligence)	0		Muscle Percent: +20, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	huge experienced mime army insignia (espionage)	0		Experience: +2, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	thinker's mime army insignia (infantry)	0		Mysticality: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	brawny mime army insignia (intelligence)	0		Muscle Percent: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	huge experienced mime army insignia (espionage)	0		Experience: +2, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	pulsating mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	green fireproof skip lid	0		Familiar Weight: +5
-9681	normal bite-sized extra-toasted half sandwich	1	good	Last Available: "2018-12"
+9681	bite-sized normal extra-toasted half sandwich	1	good	Last Available: "2018-12"
 9682	mediocre mulled hobo wine	4	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	curative forbidden baleful burning paper hat	0		Spell Damage: +25, Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2018-12"
@@ -9573,7 +9573,7 @@
 9701	boiled cyan pills	1		Effect: "Slimily Speedy", Effect Duration: 25
 9702	powdered skewed maroon furry pill	1		
 9703	modified gray beefy pill	1		
-9704	distilled fuchsia spinning blurry excitement pill	1		
+9704	distilled fuchsia blurry spinning excitement pill	1		
 9705	vaporized ghostly vitamin G pill	1		
 9706	modified huge lucky-ish pill	1		
 9707	vaporized dieting pill	1		Effect: "Mucilaginous Muscle", Effect Duration: 45
@@ -9593,7 +9593,7 @@
 9725	ghostly up-at-dawn Oprah's psychic's pslacks	0		Maximum MP Percent: +50, Adventures: +5, Last Available: "2018-02"
 9726	lightning-fast psychic's amulet of the scaredy-cat	0		Monster Level: -15, Initiative: +40, Last Available: "2018-02"
 9727	stale heart-shaped candy whetstone	3	decent	Last Available: "2018-02"
-9728	huge normal Swedish massage fish	10	good	Last Available: "2018-02"
+9728	normal huge Swedish massage fish	10	good	Last Available: "2018-02"
 9729	bad watered-down Third Base	2	decent	Last Available: "2018-02"
 9730	aged weak Bustle Hustler	2	awesome	Last Available: "2018-02"
 9731	adjusted Fabiotion	0		Effect: "Libra Rising", Effect Duration: 46, Last Available: "2018-02"
@@ -9616,7 +9616,7 @@
 9748	metandienone	0		
 9749	riboflavin	0		
 9750	bronze	0		
-9751	spinning blue piracetam	0		
+9751	blue spinning piracetam	0		
 9752	ultracalcium	0		
 9753	bouncing ginseng	0		
 9754	aromatic Team Avarice cap	0		Stench Resistance: +1
@@ -9629,7 +9629,7 @@
 9761	teal wobbly Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
-9764	tumbling wobbly Faux	0		Last Available: "2018-03"
+9764	wobbly tumbling Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
@@ -9642,7 +9642,7 @@
 9774	Peaclock	0		Last Available: "2018-03"
 9775	Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
-9777	wobbly cyan Aiolion	0		Last Available: "2018-03"
+9777	cyan wobbly Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
 9779	Gorillape	0		Last Available: "2018-03"
 9780	shaking Wendtigo	0		Last Available: "2018-03"
@@ -9676,7 +9676,7 @@
 9808	Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
 9810	Bowlet	0		Last Available: "2018-03"
-9811	huge wobbly tumbling Cornbeefadon	0		Last Available: "2018-03"
+9811	wobbly huge tumbling Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
@@ -9710,24 +9710,24 @@
 9842	spinning lump of bauxite	0		Last Available: "2018-12"
 9843	Lo Pan's Annie Oakley's &quot;Remember the Trees&quot; Shirt of chilblains	0		Critical Hit Percent: +20, Spell Critical Percent: +30, Cold Damage: +25
 9844	FantasyRealm key	0		Last Available: "2018-04"
-9845	maroon mirror plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
+9845	mirror maroon plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	mirror LyleCo premium rope	0		Last Available: "2018-04"
 9850	wobbly My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	upside-down jittery dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	jittery upside-down dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	purple faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	blue skewed druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	skewed cyan flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
-9857	moist polymerized purple upside-down upside-down universal antivenin	0		Lasts Until Rollover, Effect: "Dreadful Fear", Effect Duration: 32, Last Available: "2018-04"
+9857	moist polymerized upside-down purple upside-down universal antivenin	0		Lasts Until Rollover, Effect: "Dreadful Fear", Effect Duration: 32, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	blinking FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	thick stale FantasyRealm turkey leg	5	decent	Last Available: "2018-04"
+9862	stale thick FantasyRealm turkey leg	5	decent	Last Available: "2018-04"
 9863	practically non-alcoholic artisanal FantasyRealm mead	1	super EPIC	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9735,7 +9735,7 @@
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	gigantic adequate druidic s'more	8	good	Last Available: "2018-04"
-9870	vaporized pulsating cyan sachet of powder	1		Effect: "Stop and Smell the Fudge", Effect Duration: 10, Last Available: "2018-04"
+9870	vaporized cyan pulsating sachet of powder	1		Effect: "Stop and Smell the Fudge", Effect Duration: 10, Last Available: "2018-04"
 9871	drinkable mourning wine	3	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	wobbly map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	flavorless small huge denastified haunch	2	decent	Last Available: "2018-04"
+9878	small flavorless huge denastified haunch	2	decent	Last Available: "2018-04"
 9879	acceptable watered-down bad rum and good cola	2	good	Last Available: "2018-04"
 9880	corrupted tumbling spinning Potion of Heroism	0		Effect: "The Grass...  Is Blue...", Effect Duration: 63, Last Available: "2018-04"
 9881	tumbling leggings of the Spider Queen of the brute of the bloodbag of the detective	0		Muscle Percent: +30, Maximum HP: +100, Item Drop: +20, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	lousy spinning two meat muck	4	decent	
-9899	bland big cyan bouncing chocolate Ogre Chieftain	5	decent	
+9899	big bland cyan bouncing chocolate Ogre Chieftain	5	decent	
 9900	rotten blinking chocolate &quot;Phoenix&quot;	3	crappy	
 9901	snack-sized spoiled chocolate Spider Queen	2	crappy	
-9902	acceptable weak hipster cocktail	2	good	
-9903	teal God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	squat yellow skewed God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	green God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9902	weak acceptable hipster cocktail	2	good	
+9903	teal God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	skewed yellow squat God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	green God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,10 +9780,10 @@
 9912	A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	tumbling crude oil congealer	0		
-9915	normal enchanted good guava	4	good	Effect: "Nothing Is Impossible", Effect Duration: 35
+9915	enchanted normal good guava	4	good	Effect: "Nothing Is Impossible", Effect Duration: 35
 9916	triple-distilled tolerable pulsating gin and ginger	9	good	
 9917	blurry wobbly Thwaitgold chigger statuette	0		
-9918	powdered squat maroon shaking gaseous gravy	1		
+9918	powdered shaking squat maroon gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
@@ -9799,7 +9799,7 @@
 9931	censurious studded Socratic Nouveau nosering of temperance	0		Experience (Mysticality): +1, Damage Absorption: +80, Sleaze Resistance: 8, Lasts Until Rollover, Last Available: "2018-07"
 9932	denatured sharkfin gumbo	0		Effect: "Familial Ties", Effect Duration: 30, Last Available: "2018-07"
 9933	electrified boiling broth	0		Effect: "Thaumodynamic", Effect Duration: 42, Last Available: "2018-07"
-9934	moist energized ghostly jittery interrogative elixir	0		Effect: "Stenchtastic", Effect Duration: 43, Last Available: "2018-07"
+9934	moist energized jittery ghostly interrogative elixir	0		Effect: "Stenchtastic", Effect Duration: 43, Last Available: "2018-07"
 9935	spinning Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	bouncing Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	Bastille Battalion cheese wheel	0		Last Available: "2018-07"
@@ -9813,7 +9813,7 @@
 9945	blurry Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	strong artisanal special Middle of the Road&trade; brand whiskey	5	EPIC	Effect: "Truly Gritty", Effect Duration: 5, Last Available: "2018-09"
+9948	strong special artisanal Middle of the Road&trade; brand whiskey	5	EPIC	Effect: "Truly Gritty", Effect Duration: 5, Last Available: "2018-09"
 9949	narrow neverending wallet chain	0		Last Available: "2018-09"
 9950	lard-coated fortified pentagram bandana	0		Damage Absorption: +60, Sleaze Spell Damage: +25, Last Available: "2018-09"
 9951	skull ring of horror	0		Spooky Spell Damage: +25, Single Equip, Last Available: "2018-09"
@@ -9843,9 +9843,9 @@
 9976	lion tamer's party pants of the overflowing toilet	0		Experience (familiar): +2, Stench Spell Damage: +50, Last Available: "2018-09"
 9977	Sherlock's educational party whip of the cougar	0		Moxie: +20, Experience: +1, Item Drop: +25, Last Available: "2018-09"
 9978	green tumbling Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	artisanal high-proof special TRIO cup of beer	10	EPIC	Effect: "Dragged Through the Coals", Effect Duration: 5, Last Available: "2018-09"
+9979	artisanal special high-proof TRIO cup of beer	10	EPIC	Effect: "Dragged Through the Coals", Effect Duration: 5, Last Available: "2018-09"
 9980	bland blinking party platter for one	3	decent	Last Available: "2018-09"
-9981	diluted mirror cyan huge Party-in-a-Can&trade;	1		Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2018-09"
+9981	diluted huge cyan mirror Party-in-a-Can&trade;	1		Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2018-09"
 9982	shaking party pup	0		Last Available: "2018-09"
 9983	olive steel-toed party crasher of doom	0		Damage Reduction: 18, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
@@ -9874,17 +9874,17 @@
 10008	asbestos-lined mutant legs of Calamity Jane of the businessman	0		Critical Hit Percent: +15, Hot Resistance: +5, Meat Drop: +50, Last Available: "2018-11"
 10009	wool Samson's mutant crown of horror	0		Experience (Muscle): +5, Spooky Spell Damage: +25, Cold Resistance: +1, Last Available: "2018-11"
 10010	delicious ghostly ectoplasm	4	awesome	Last Available: "2018-11"
-10011	small stale skewed	2	decent	Last Available: "2018-11"
-10012	hand-crafted weak bottle of vodka	2	EPIC	Last Available: "2018-11"
+10011	stale small skewed	2	decent	Last Available: "2018-11"
+10012	weak hand-crafted bottle of vodka	2	EPIC	Last Available: "2018-11"
 10013	spoiled pizza	4	crappy	Last Available: "2018-11"
 10014	lousy martini	3	decent	Last Available: "2018-11"
 10015	delicious cherry pie	4	awesome	Last Available: "2018-11"
 10016	aged eggnog	3	awesome	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	half-sized toothsome huge Hell ramen	2	awesome	Last Available: "2018-11"
-10019	bad high-proof spinning gimlet	9	decent	Last Available: "2018-11"
-10020	lousy practically non-alcoholic twice-haunted screwdriver	1	decent	Last Available: "2018-11"
-10021	tasty bite-sized purple candy cane	1	awesome	Last Available: "2018-12"
+10019	high-proof bad spinning gimlet	9	decent	Last Available: "2018-11"
+10020	practically non-alcoholic lousy twice-haunted screwdriver	1	decent	Last Available: "2018-11"
+10021	bite-sized tasty purple candy cane	1	awesome	Last Available: "2018-12"
 10022	fortified mediocre blinking lime green runny fermented egg	5	decent	Last Available: "2018-12"
 10023	normal oldcake	3	good	Last Available: "2018-12"
 10024	normal traditional Crimbo cookie	3	good	Last Available: "2023-06"
@@ -9903,11 +9903,11 @@
 10037	wobbly plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	bland tumbling grilled mooseflank	4	decent	Last Available: "2018-12"
-10040	snack-sized spoiled moosemeat pie	2	crappy	Last Available: "2018-12"
+10040	spoiled snack-sized moosemeat pie	2	crappy	Last Available: "2018-12"
 10041	blue spinning jittery Sinatra's balanced antler	0		Experience (Moxie): +5, Last Available: "2018-12"
 10042	baleful dam	0		Spell Damage: +25, Damage Reduction: 9, Last Available: "2018-12"
 10043	acceptable beavermouth	3	good	Last Available: "2018-12"
-10044	practically non-alcoholic smooth fancy blinking beaver punch (papaya)	1	awesome	Effect: "Gonna Get You, Sucker", Effect Duration: 30, Last Available: "2018-12"
+10044	fancy smooth practically non-alcoholic blinking beaver punch (papaya)	1	awesome	Effect: "Gonna Get You, Sucker", Effect Duration: 30, Last Available: "2018-12"
 10045	drinkable practically non-alcoholic beaver punch (peach)	1	good	Last Available: "2018-12"
 10046	delicious spinning beaver punch (cherry)	3	awesome	Last Available: "2018-12"
 10047	medical-grade beefcake's Canadian lantern	0		Muscle: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-12"
@@ -9923,17 +9923,17 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	spinning lightning-fast sizzling manspreader's ruddy wicked Kramco Sausage-o-Matic&trade;	0		Spell Damage: +5, Maximum HP Percent: +40, Monster Level: +10, Hot Damage: +10, Initiative: +40, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	tasty enchanted sausage	4	awesome	Effect: "Innately Strong", Effect Duration: 40, Last Available: "2019-01"
+10060	enchanted tasty sausage	4	awesome	Effect: "Innately Strong", Effect Duration: 40, Last Available: "2019-01"
 10061	Jack Frost's thinker's red-hot sausage fork	0		Mysticality: +10, Cold Spell Damage: +50, Last Available: "2019-01"
 10062	upside-down bag of sausage links	0		Last Available: "2019-01"
 10063	purple tumbling wobbly sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	practically non-alcoholic tolerable beer	1	good	Last Available: "2018-12"
+10066	tolerable practically non-alcoholic beer	1	good	Last Available: "2018-12"
 10067	rotten thick yule gruel	5	crappy	Last Available: "2018-12"
 10068	acceptable enchanted hot watered rum	3	good	Effect: "Extra Backbone", Effect Duration: 25, Last Available: "2018-12"
 10069	artisanal bottle of Crimbognac	4	EPIC	Last Available: "2018-12"
-10070	enchanted toothsome small Crimboysters Rockefeller	2	awesome	Effect: "Fit To Be Tide", Effect Duration: 50, Last Available: "2018-12"
+10070	small enchanted toothsome Crimboysters Rockefeller	2	awesome	Effect: "Fit To Be Tide", Effect Duration: 50, Last Available: "2018-12"
 10071	dried Crimbeau de toilette	1		Last Available: "2018-12"
 10072	tumbling Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9959,7 +9959,7 @@
 10093	marble mignonette bowl of the overflowing toilet of the detective	0		Stench Spell Damage: +50, Item Drop: +20, Last Available: "2019-12"
 10094	foul-smelling Herculean marble medallion	0		Experience (Muscle): +1, Stench Damage: +10, Single Equip, Last Available: "2019-12"
 10095	mirror greasy marble mariachi hat of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10, Last Available: "2019-12"
-10096	altered fuchsia blurry ghostly marble molecules	1		Effect: "Hustlin'", Effect Duration: 10, Last Available: "2019-12"
+10096	altered ghostly fuchsia blurry marble molecules	1		Effect: "Hustlin'", Effect Duration: 10, Last Available: "2019-12"
 10097	extra-energized blue Mallomarbles	0		Effect: "White Blooded", Effect Duration: 27
 10098	nasty punching bag of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10099	skewed mansplainer's Samson's pith helmet	0		Experience (Muscle): +5, Monster Level: +15, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
@@ -10034,10 +10034,10 @@
 10169	moldy blinking bloodstick	4	crappy	
 10170	bad watered-down bottle of Sanguiovese	2	decent	
 10171	flavorless actual blood sausage	3	decent	
-10172	watered-down acceptable mulled blood	2	good	
-10173	snack-sized flavorless blood snowcone	2	decent	
+10172	acceptable watered-down mulled blood	2	good	
+10173	flavorless snack-sized blood snowcone	2	decent	
 10174	tolerable Red Russian	3	good	
-10175	fancy normal jumbo twirling blood roll-up	5	good	Effect: "[1609]Dancin' Fool", Effect Duration: 35
+10175	jumbo normal fancy twirling blood roll-up	5	good	Effect: "[1609]Dancin' Fool", Effect Duration: 35
 10176	irresponsibly strong lousy bottle of blood	8	decent	
 10177	moldy twirling blood-soaked sponge cake	4	crappy	
 10178	perfectly mixed vampagne	4	EPIC	
@@ -10064,7 +10064,7 @@
 10199	spoiled crabsicle	4	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	mediocre bottle of dark rhum	4	decent	Last Available: "2019-04"
-10202	mediocre practically non-alcoholic bottle of extra-dark rhum	1	decent	Last Available: "2019-04"
+10202	practically non-alcoholic mediocre bottle of extra-dark rhum	1	decent	Last Available: "2019-04"
 10203	mediocre shaking bottle of super-extra-dark rhum	3	decent	Last Available: "2019-04"
 10204	quadruple-boiled denatured upside-down pirate shaving cream	0		Effect: "Human-Beast Hybrid", Effect Duration: 54, Last Available: "2019-04"
 10205	weightlifter's conquistador's breastplate of the sewer	0		Muscle: +15, Stench Damage: +25, Last Available: "2019-04"
@@ -10074,13 +10074,13 @@
 10209	mirror jittery windicle	0		Last Available: "2019-04"
 10210	upside-down Herculean pirate radio ring of Tarzan	0		Experience (Muscle): 4, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	normal miniature pineapple slab	2	good	Last Available: "2019-04"
-10213	normal miniature blue hibiscus petal	2	good	Last Available: "2019-04"
+10212	miniature normal pineapple slab	2	good	Last Available: "2019-04"
+10213	miniature normal blue hibiscus petal	2	good	Last Available: "2019-04"
 10214	pressed olive huge mint leaf	0		Effect: "Adrenaline Rush", Effect Duration: 34, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	dehydrated upside-down ice molecule	1		Effect: "Mathematically Precise", Effect Duration: 20, Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
-10218	skewed blue pulsating Red Roger's right hand	0		Last Available: "2019-04"
+10218	blue skewed pulsating Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	shaking Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
@@ -10096,12 +10096,12 @@
 10231	inspector's veiny PirateRealm party hat of the overflowing toilet	0		Maximum HP: +10, Stench Spell Damage: +50, Item Drop: +15, Last Available: "2019-04"
 10232	artisanal irresponsibly strong Island Landslide	7	EPIC	Last Available: "2019-04"
 10233	special hand-crafted Island Thunderstorm	3	EPIC	Effect: "Almost Cool", Effect Duration: 50, Last Available: "2019-04"
-10234	triple-distilled artisanal olive Island Hurricane	6	EPIC	Last Available: "2019-04"
+10234	artisanal triple-distilled olive Island Hurricane	6	EPIC	Last Available: "2019-04"
 10235	hand-crafted Skull Punch	3	EPIC	Last Available: "2019-04"
-10236	weak perfectly mixed Electric Punch	2	super ultra EPIC	Last Available: "2019-04"
+10236	perfectly mixed weak Electric Punch	2	super ultra EPIC	Last Available: "2019-04"
 10237	mediocre purple Smuggler's Punch	3	decent	Last Available: "2019-04"
 10238	aged practically non-alcoholic Scorpion Bowl	1	awesome	Last Available: "2019-04"
-10239	high-proof hand-crafted tumbling purple Turtle Bowl	6	EPIC	Last Available: "2019-04"
+10239	high-proof hand-crafted purple tumbling Turtle Bowl	6	EPIC	Last Available: "2019-04"
 10240	artisanal Cobra Bowl	3	super EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	chaotic resourceful clever supercharged vampyric cloake of the boozehound	0		Maximum MP Percent: +30, Maximum MP: 70, Spell Critical Percent: +10, Booze Drop: +100, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
@@ -10123,19 +10123,19 @@
 10258	huge avaricious electrified weightlifter's Beach Comb	0		Muscle: +15, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
-10261	narrow olive pile of sand	0		Last Available: "2019-07"
+10261	olive narrow pile of sand	0		Last Available: "2019-07"
 10262	twirling pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	fuchsia shaking hourglass	0		Last Available: "2019-07"
 10265	maroon etched hourglass	0		Last Available: "2019-07"
-10266	diffused pulsating shaking magenta seashell	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 40, Last Available: "2019-07"
-10267	warmed pulsating ghostly shaking cyan seashell	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 39, Last Available: "2019-07"
+10266	diffused shaking pulsating magenta seashell	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 40, Last Available: "2019-07"
+10267	warmed shaking pulsating ghostly cyan seashell	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 39, Last Available: "2019-07"
 10268	quantum yellow gray seashell	0		Effect: "Superhuman Sarcasm", Effect Duration: 57, Last Available: "2019-07"
 10269	modified pickled twirling seashell	0		Effect: "Pie in the Sky", Effect Duration: 63, Last Available: "2019-07"
 10270	colloidal warmed red blurry seashell	0		Effect: "Industrial Strength Starch", Effect Duration: 41, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
 10272	acceptable bottle of sea wine	3	good	Last Available: "2019-07"
-10273	dehydrated skewed wobbly kelp	1		Last Available: "2019-07"
+10273	dehydrated wobbly skewed kelp	1		Last Available: "2019-07"
 10274	squat up-at-dawn lightning-fast avaricious scorching Van der Graaf groovy wizardly driftwood hat of vim and vigor of temperance	0		Mysticality: +25, Moxie Percent: +10, Maximum HP Percent: +50, Hot Damage: +25, Sleaze Resistance: +5, Meat Drop: +30, Initiative: +40, Adventures: +5, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2019-07"
 10275	wobbly skewed auspicious gravedigger's lion tamer's friendly hardened banded sinister dangerous driftwood pants of the cheetah	0		Weapon Damage: +10, Spell Damage: +10, Damage Absorption: +100, Damage Reduction: 3, Familiar Weight: +3, Experience (familiar): +2, Spooky Damage: +10, Item Drop: +10, Initiative: +60, Lasts Until Rollover, Last Available: "2019-07"
 10276	mirror wobbly family-friendly horrifying frightening lion tamer's manspreader's curative forbidden razor-sharp dance instructor's driftwood bracelet	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Spell Damage Percent: +50, Monster Level: +10, Experience (familiar): +2, Spooky Damage: 30, Sleaze Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10143,7 +10143,7 @@
 10278	blurry lime green avaricious fortified spearfish fishing spear of James Dean	0		Experience (Moxie): +3, Damage Absorption: +60, Meat Drop: +30, Last Available: "2019-07"
 10279	huge deadly rabbitfish fin of dire peril of bravery	0		Weapon Damage: 25, Spooky Resistance: +5, Single Equip, Last Available: "2019-07"
 10280	piece of coral	0		Last Available: "2019-07"
-10281	blurry yellow piece of driftwood	0		Last Available: "2019-07"
+10281	yellow blurry piece of driftwood	0		Last Available: "2019-07"
 10282	blurry aromatic Herculean cool pirate cutlass	0		Moxie: +5, Experience (Muscle): +1, Stench Resistance: +1, Single Equip, Last Available: "2019-07"
 10283	gray hale strapping tricorn hat of the scaredy-cat	0		Muscle: +5, Maximum HP: +20, Monster Level: -15, Last Available: "2019-07"
 10284	blue upside-down padded Samson's brainy swash buckle	0		Mysticality: +5, Experience (Muscle): +5, Damage Absorption: +20, Single Equip, Last Available: "2019-07"
@@ -10165,7 +10165,7 @@
 10300	fuchsia grievous supercool smooth whittled owl figurine	0		Moxie: +15, Moxie Percent: +20, Weapon Damage Percent: +50, Single Equip, Last Available: "2019-08"
 10301	horrifying Socratic cool whittled fox figurine	0		Moxie: +5, Experience (Mysticality): +1, Spooky Damage: +25, Single Equip, Last Available: "2019-08"
 10302	wholesome sinister Samson's whittled walking stick of courage	0		Experience (Muscle): +5, Spell Damage: +10, Maximum HP Percent: +10, Spooky Resistance: +3, Last Available: "2019-08"
-10303	spoiled fancy twirling campfire hot dog	3	crappy	Effect: "Wreathed in Merriment", Effect Duration: 5, Last Available: "2019-08"
+10303	fancy spoiled twirling campfire hot dog	3	crappy	Effect: "Wreathed in Merriment", Effect Duration: 5, Last Available: "2019-08"
 10304	bland fuchsia campfire baked potato	3	decent	Last Available: "2019-08"
 10305	spoiled campfire s'more	3	crappy	Last Available: "2019-08"
 10306	adequate campfire beans	4	good	Last Available: "2019-08"
@@ -10178,7 +10178,7 @@
 10313	campfire smoke	0		
 10314	Murgatroyd diode	0		
 10315	wobbly jittery signal receiver	0		
-10316	wobbly cyan space shield	0		Damage Reduction: 9
+10316	cyan wobbly space shield	0		Damage Reduction: 9
 10317	signal jammer	0		Single Equip
 10318	shaking low-pressure oxygen tank	0		Single Equip
 10319	ghostly wobbly Thwaitgold bombardier beetle statuette	0		
@@ -10194,7 +10194,7 @@
 10335	blurry diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bouncing bu&ntilde;uelos Jaliscos	3	decent	Last Available: "2019-12"
-10338	gigantic rotten skewed yellow flan del mar	10	crappy	Last Available: "2019-12"
+10338	rotten gigantic skewed yellow flan del mar	10	crappy	Last Available: "2019-12"
 10339	spoiled Baja sopapilla	3	crappy	Last Available: "2019-12"
 10340	bouncing lard-coated plastic Mer-kin baker	0		Sleaze Spell Damage: +25, Last Available: "2019-12"
 10341	frosty plastic sea elf	0		Cold Spell Damage: +10, Last Available: "2019-12"
@@ -10203,8 +10203,8 @@
 10344	frightening plastic Dolph Bossin	0		Spooky Damage: +5, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	stale jumbo mana-coated yams	5	decent	Last Available: "2019-11"
-10347	snack-sized adequate mana-basted tofurkey leg	2	good	Last Available: "2019-11"
-10348	tiny bland mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
+10347	adequate snack-sized mana-basted tofurkey leg	2	good	Last Available: "2019-11"
+10348	bland tiny mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
 10349	bland super-sized mana-stuffed herbal stuffing	5	decent	Last Available: "2019-11"
 10350	upside-down narrow skewed human musk	0		Last Available: "2019-12"
 10351	chilled patch of extra-warm fur	0		Effect: "Mystically Oiled", Effect Duration: 54, Last Available: "2019-12"
@@ -10217,7 +10217,7 @@
 10358	unsweetened infernal snowball	0		Effect: "Baconstoned", Effect Duration: 69, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	dehydrated spinning squat fish sauce	1		Last Available: "2019-12"
-10361	adequate bouncing maroon guffin	3	good	Last Available: "2019-12"
+10361	adequate maroon bouncing guffin	3	good	Last Available: "2019-12"
 10362	boiled Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	altered skewed non-Euclidean angle	1		Effect: "BOOsted", Effect Duration: 5, Last Available: "2019-12"
@@ -10246,16 +10246,16 @@
 10387	huge pulsating intact anemone spike	0		Last Available: "2019-12"
 10388	red stiffened anemoney clip	0		Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10389	twirling runny icing	0		Last Available: "2019-12"
-10390	twisted twirling olive super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	twisted olive twirling super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	huge chilly smooth icing poncho of the dark arts	0		Moxie: +15, Spell Damage Percent: +100, Cold Damage: +5, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	pickled wobbly glob of salty molasses	0		Effect: "Happy Salamander", Effect Duration: 54, Last Available: "2019-12"
 10394	dog trainer's stiffened Mer-kin rollpin	0		Damage Reduction: 1, Experience (familiar): +1, Last Available: "2019-12"
 10395	blinking personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
-10397	toothsome massive shaking bowl of mernudo	6	awesome	Last Available: "2019-12"
+10397	massive toothsome shaking bowl of mernudo	6	awesome	Last Available: "2019-12"
 10398	irresponsibly strong hand-crafted fishelada	10	EPIC	Last Available: "2019-12"
-10399	stale snack-sized ojo de pez burrito	2	decent	Last Available: "2019-12"
+10399	snack-sized stale ojo de pez burrito	2	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10291,7 +10291,7 @@
 10432	yellow miser's Retrospecs of dire peril of mayonnaise	0		Weapon Damage: +20, Sleaze Spell Damage: +50, Meat Drop: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	blurry blurry Bird-a-Day calendar	0		Last Available: "2020-01"
-10437	cyan blurry mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
+10437	blurry cyan mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	fuchsia avaricious double-paned nasty careful Powerful Glove of the glutton	0		Monster Level: -10, Stench Damage: +5, Cold Resistance: +5, Meat Drop: +30, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	ghostly enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
@@ -10398,7 +10398,7 @@
 10542	perfectly mixed Sourfinger	3	EPIC	Last Available: "2020-05"
 10543	artisanal watered-down Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
 10544	special tolerable Steamboat	3	good	Effect: "Nano-juiced", Effect Duration: 25, Last Available: "2020-05"
-10545	fancy strong drinkable Buttery Boy	5	good	Effect: "Armor-Plated", Effect Duration: 30, Last Available: "2020-05"
+10545	strong fancy drinkable Buttery Boy	5	good	Effect: "Armor-Plated", Effect Duration: 30, Last Available: "2020-05"
 10546	cyan Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	baleful razor-sharp clown car key	0		Weapon Damage Percent: +25, Spell Damage: +25, Last Available: "2020-08"
 10548	shaking green Jack Frost's batting cage key of the ox of courage	0		Muscle: +20, Cold Spell Damage: +50, Spooky Resistance: +3, Last Available: "2020-08"
@@ -10450,7 +10450,7 @@
 10594	nitrogenated huge redwood rain stick	0		Effect: "Mushroom Magicalness", Effect Duration: 44, Last Available: "2020-08"
 10595	purpleheart logs	0		Last Available: "2020-08"
 10596	frosty smooth purpleheart &quot;pants&quot; of the dark arts	0		Moxie: +15, Spell Damage Percent: +100, Cold Spell Damage: +10, Last Available: "2020-08"
-10597	cyan blinking shaking wormwood stick	0		Last Available: "2020-08"
+10597	blinking cyan shaking wormwood stick	0		Last Available: "2020-08"
 10598	family-friendly Annie Oakley's hale weightlifter's wormwood wedding ring of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50, Maximum HP: +20, Critical Hit Percent: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2020-08"
 10599	Dripwood slab	0		Last Available: "2020-08"
 10600	drippy diadem	0		Last Available: "2020-08"
@@ -10460,7 +10460,7 @@
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	skewed Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	warmed jittery Yeg's Motel toothbrush	0		Effect: "Horrid, Torrid", Effect Duration: 27, Last Available: "2020-09"
-10607	warmed squat huge Yeg's Motel hand soap	0		Effect: "Al Dente Inferno", Effect Duration: 57, Last Available: "2020-09"
+10607	warmed huge squat Yeg's Motel hand soap	0		Effect: "Al Dente Inferno", Effect Duration: 57, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	rotten skewed red Yeg's Motel pillow mint	4	crappy	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
@@ -10507,7 +10507,7 @@
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	double-galvanized frozen fortifying hot cocoa	0		Effect: "Thaumodynamic", Effect Duration: 46, Last Available: "2020-12"
-10654	magnetized chilled mirror purple boiling hot cocoa	0		Effect: "Witch's Brood", Effect Duration: 26, Last Available: "2020-12"
+10654	magnetized chilled purple mirror boiling hot cocoa	0		Effect: "Witch's Brood", Effect Duration: 26, Last Available: "2020-12"
 10655	polymerized frozen irradiated cool hot cocoa	0		Effect: "Big Punkin'", Effect Duration: 37, Last Available: "2020-12"
 10656	non-electrified mirror overly-fancy hot cocoa	0		Effect: "Is This Your Card?", Effect Duration: 13, Last Available: "2020-12"
 10657	denatured hot cocoa au beurre	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 62, Last Available: "2020-12"
@@ -10516,7 +10516,7 @@
 10660	MacGyver's Crimbo smile	0		Maximum MP: [+100*event(December)], Last Available: "2020-12"
 10661	tumbling shaking inspector's SalesCo sample kit	0		Item Drop: [+15*event(December)], Last Available: "2020-12"
 10662	oxidized candy harmonica	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 51, Last Available: "2020-12"
-10663	denatured dry deionized green bouncing sugar	0		Effect: "Aquarius Rising", Effect Duration: 56, Last Available: "2020-12"
+10663	denatured dry deionized bouncing green sugar	0		Effect: "Aquarius Rising", Effect Duration: 56, Last Available: "2020-12"
 10664	energized denatured cold-filtered multi-level marzipan	0		Effect: "Sleazy Jellied", Effect Duration: 23, Last Available: "2020-12"
 10665	reassuring plastic Crimbo caroler	0		Spooky Resistance: +1, Last Available: "2020-12"
 10666	spinning chilly plastic multi-level marketer	0		Cold Damage: +5, Last Available: "2020-12"
@@ -10545,7 +10545,7 @@
 10689	narrow Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	green mirror Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	skewed food drive button	0		Single Equip, Last Available: "2020-12"
-10692	purple narrow booze drive button	0		Single Equip, Last Available: "2020-12"
+10692	narrow purple booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	huge food mailing list	0		Last Available: "2020-12"
 10695	tumbling booze mailing list	0		Last Available: "2020-12"
@@ -10575,8 +10575,8 @@
 10719	shaking goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	acceptable barrel-aged eggnog	3	good	Last Available: "2020-12"
 10721	flavorless hand-crafted candy cane	3	decent	Last Available: "2020-12"
-10722	spoiled miniature huge drive-thru burger	2	crappy	Last Available: "2020-12"
-10723	tolerable weak Boulevardier cocktail	2	good	Last Available: "2020-12"
+10722	miniature spoiled huge drive-thru burger	2	crappy	Last Available: "2020-12"
+10723	weak tolerable Boulevardier cocktail	2	good	Last Available: "2020-12"
 10724	irradiated activated Hotwire&trade; brand candy rope	0		Effect: "Jerky, Boy", Effect Duration: 43, Last Available: "2020-12"
 10725	jumbo flavorless bowl full of jelly	5	decent	Last Available: "2020-12"
 10726	mediocre watered-down Eye and a Twist	2	decent	Last Available: "2020-12"
@@ -10591,13 +10591,13 @@
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	ghostly yellow power seed	0		Free Pull, Last Available: "2021-03"
-10738	olive wobbly twirling potted power plant	0		Last Available: "2021-03"
+10738	olive twirling wobbly potted power plant	0		Last Available: "2021-03"
 10739	extra-unsweetened ionized activated huge battery (AAA)	0		Effect: "What's That Smell?", Effect Duration: 36, Last Available: "2021-03"
 10740	alkaline nitrogenated tumbling battery (AA)	0		Effect: "Tenacity of the Snapper", Effect Duration: 26, Last Available: "2021-03"
 10741	improved ghostly battery (D)	0		Effect: "Alchemical, Brother", Effect Duration: 59, Last Available: "2021-03"
 10742	anodized flattened shaking battery (9-Volt)	0		Effect: "Ancient Protected", Effect Duration: 53, Last Available: "2021-03"
 10743	activated battery (lantern)	0		Effect: "Fancy Feasted", Effect Duration: 47, Last Available: "2021-03"
-10744	dry chilled concentrated twirling wobbly battery (car)	0		Effect: "Bolts about Candy", Effect Duration: 30, Last Available: "2021-03"
+10744	dry chilled concentrated wobbly twirling battery (car)	0		Effect: "Bolts about Candy", Effect Duration: 30, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
 10747	artisanal special marshmallow bomb	4	EPIC	Effect: "Pemmican't", Effect Duration: 15, Last Available: "2021-03"
@@ -10661,7 +10661,7 @@
 10805	huge eggwater	1	decent	Last Available: "2021-12"
 10806	moldy bread man	3	crappy	Last Available: "2021-12"
 10807	jumbo moldy plain candy cane	5	crappy	Last Available: "2021-12"
-10808	adequate huge flour cookie	10	good	Last Available: "2021-12"
+10808	huge adequate flour cookie	10	good	Last Available: "2021-12"
 10809	resourceful plastic food lab	0		Maximum MP: +50, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2021-12"
 10811	purple groovy plastic chem lab	0		Moxie Percent: +10, Single Equip, Last Available: "2021-12"
@@ -10674,8 +10674,8 @@
 10818	mirror clever Oprah's deadly ice wrap	0		Weapon Damage: +5, Maximum MP Percent: +50, Maximum MP: +20, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	normal tofu pop	4	good	Last Available: "2021-12"
 10820	stale bowl of prescription candy	3	decent	Last Available: "2021-12"
-10821	adequate small fishcake	2	good	Last Available: "2021-12"
-10822	bland enchanted bone broth	3	decent	Effect: "Hustlin'", Effect Duration: 50, Last Available: "2021-12"
+10821	small adequate fishcake	2	good	Last Available: "2021-12"
+10822	enchanted bland bone broth	3	decent	Effect: "Hustlin'", Effect Duration: 50, Last Available: "2021-12"
 10823	adequate star pop	3	good	Last Available: "2021-12"
 10824	drinkable spirit-forward Doc's Fortifying Wine	5	good	Last Available: "2021-12"
 10825	mediocre Doc's Smartifying Wine	4	decent	Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	twirling goo magnet	0		Last Available: "2021-12"
 10851	narrow cozy scarf of the sweet-tooth	0		Candy Drop: +100, Last Available: "2021-12"
-10852	small decent huge Crimbo cookie	2	good	Last Available: "2023-06"
+10852	decent small huge Crimbo cookie	2	good	Last Available: "2023-06"
 10853	activated fleshy putty	0		Effect: "Salamander In Your Stomach", Effect Duration: 66, Last Available: "2021-12"
 10854	purple up-at-dawn third ear	0		Adventures: +5, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10721,7 +10721,7 @@
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	brawny yule hatchet	0		Muscle Percent: +20, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	fancy gigantic rotten shaking lab-grown meat	7	crappy	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2021-12"
+10868	gigantic rotten fancy shaking lab-grown meat	7	crappy	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2021-12"
 10869	double-paned fleece	0		Cold Resistance: +5, Last Available: "2021-12"
 10870	yellow boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10733,7 +10733,7 @@
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
-10880	denatured jittery mirror blue fried air	1		Last Available: "2021-12"
+10880	denatured mirror jittery blue fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	jittery carton of astral energy drinks	0		
 10883	powdered jittery astral energy drink	1		
@@ -10761,14 +10761,14 @@
 10905	ghostly family-friendly headlamp	0		Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2022-05"
 10906	foul-smelling thermal blanket of the scaredy-cat of Flo-Jo	0		Monster Level: -15, Stench Damage: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2022-05"
 10907	rosy-cheeked atlas of local maps	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2022-05"
-10908	moist diffused blinking gray spare battery	0		Effect: "Wise Spirit", Effect Duration: 65, Last Available: "2022-05"
+10908	moist diffused gray blinking spare battery	0		Effect: "Wise Spirit", Effect Duration: 65, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
 10910	triple-polarized single-use dust mask	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 47, Last Available: "2022-05"
 10911	pickled spinning twirling gaffer's tape	0		Effect: "El Vibrations", Effect Duration: 46, Last Available: "2022-05"
 10912	snack-sized decent wobbly 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	gray bar of freeze-dried water	1	decent	Last Available: "2022-05"
-10914	normal tiny expired MRE	1	good	Last Available: "2022-05"
-10915	bland half-sized twirling pulsating cool mint precipice bar	2	decent	Last Available: "2022-05"
+10914	tiny normal expired MRE	1	good	Last Available: "2022-05"
+10915	half-sized bland twirling pulsating cool mint precipice bar	2	decent	Last Available: "2022-05"
 10916	bland skewed carrot cake precipice bar	4	decent	Last Available: "2022-05"
 10917	upside-down The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
@@ -10780,9 +10780,9 @@
 10924	moldy guilty sprout	3	crappy	Last Available: "2022-06"
 10925	horrifying scorching mother's necklace	0		Hot Damage: +25, Spooky Damage: +25, Last Available: "2022-06"
 10926	ionized mirror trampled ticket stub	0		Effect: "Cosmic Flavor", Effect Duration: 43, Last Available: "2022-06"
-10927	electrified ionized narrow teal savings bond	0		Effect: "Artificially Sweet", Effect Duration: 65, Last Available: "2022-06"
+10927	electrified ionized teal narrow savings bond	0		Effect: "Artificially Sweet", Effect Duration: 65, Last Available: "2022-06"
 10928	skewed designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	shaking designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	shaking designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	twisted sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10824,36 +10824,36 @@
 10968	fuchsia St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	toothsome special pulsating olive ratatouille de Jarlsberg	3	awesome	Effect: "Red-Shirted Escort", Effect Duration: 35, Last Available: "2022-11"
-10971	bite-sized tasty Jarlsberg's vegetable soup	1	awesome	Last Available: "2022-11"
+10971	tasty bite-sized Jarlsberg's vegetable soup	1	awesome	Last Available: "2022-11"
 10972	moldy roasted vegetable of Jarlsberg	4	crappy	Last Available: "2022-11"
 10973	spoiled ghostly St. Pete's sneaky smoothie	3	crappy	Last Available: "2022-11"
 10974	moldy Pete's wiley whey bar	4	crappy	Last Available: "2022-11"
 10975	spoiled upside-down Pete's rich ricotta	3	crappy	Last Available: "2022-11"
-10976	mediocre weak shaking Boris's beer	2	decent	Last Available: "2022-11"
+10976	weak mediocre shaking Boris's beer	2	decent	Last Available: "2022-11"
 10977	half-sized moldy honey bun of Boris	2	crappy	Last Available: "2022-11"
 10978	flavorless skewed Boris's bread	3	decent	Last Available: "2022-11"
-10979	narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	blinking Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	tumbling Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	blinking Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	pulsating Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	tumbling Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	blinking Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	tumbling Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	blinking Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	pulsating Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	tumbling Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	rotten snack-sized wobbly baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
 10989	tasty tumbling plain calzone	3	awesome	Last Available: "2022-11"
 10990	decent skewed roasted vegetable focaccia	3	good	Last Available: "2022-11"
 10991	adequate blinking twirling Pizza of Legend	3	good	Last Available: "2022-11"
 10992	super-sized stale mirror Calzone of Legend	5	decent	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	pulsating huge Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	purple Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	huge pulsating Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	purple Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	low-calorie flavorless Deep Dish of Legend	1	decent	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	flavorless low-calorie Deep Dish of Legend	1	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	shaking drink chit	0		
 11003	government per-diem	0		
@@ -10863,15 +10863,15 @@
 11007	booze bindle	0		
 11008	wobbly wobbly crafty healthy rare oboe	0		Maximum HP Percent: +20, Maximum MP: +10
 11009	aromatic Jeselnik's bullet necklace	0		Sleaze Damage: +25, Stench Resistance: +1, Single Equip
-11010	half-sized rotten jittery spinning swamp haunch	2	crappy	
+11010	rotten half-sized spinning jittery swamp haunch	2	crappy	
 11011	skewed prompt aromatic gator shades	0		Stench Resistance: +1, Adventures: +3, Single Equip
 11012	milk cap	0		
 11013	acceptable cyan Charleston Choo-Choo	3	good	
-11014	weak lousy upside-down Velvet Veil	2	decent	
+11014	lousy weak upside-down Velvet Veil	2	decent	
 11015	perfectly mixed Marltini	3	EPIC	
-11016	drinkable strong special ghostly spinning Strong, Silent Type	5	good	Effect: "Strong Spirit", Effect Duration: 30
+11016	drinkable special strong spinning ghostly Strong, Silent Type	5	good	Effect: "Strong Spirit", Effect Duration: 30
 11017	artisanal Mysterious Stranger	3	EPIC	
-11018	boozy perfectly mixed blinking jittery Champagne Shimmy	5	EPIC	
+11018	perfectly mixed boozy jittery blinking Champagne Shimmy	5	EPIC	
 11019	the Sot's parcel	0		
 11020	jittery up-at-dawn manspreader's ceramic cestus	0		Monster Level: +10, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
 11021	resourceful thinker's ceramic centurion shield of the businessman	0		Mysticality: +10, Maximum MP: +50, Meat Drop: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
@@ -10912,39 +10912,39 @@
 11056	ping-pong paddle	0		Single Equip
 11057	cyan blinking ping-pong ball	0		
 11058	medical-grade Trainbot harness	0		HP Regen Min: 7, HP Regen Max: 10
-11059	jittery bouncing ping-pong table	0		
+11059	bouncing jittery ping-pong table	0		
 11060	maroon Crimbo train emergency brake	0		
 11061	blurry olive Trainbot autoassembly module	0		
 11062	skewed inspector's Annie Oakley's Herculean head-mounted Trainbot	0		Experience (Muscle): +1, Critical Hit Percent: +20, Item Drop: +15, Last Available: "2022-12"
 11063	Usain Bolt's lard-coated rosy-cheeked leg-mounted Trainbots	0		Maximum HP Percent: +30, Sleaze Spell Damage: +25, Initiative: +80, Last Available: "2022-12"
 11064	narrow upside-down perfumed sage shoulder-mounted Trainbot of the boozehound	0		Mysticality Percent: +10, Stench Resistance: +5, Booze Drop: +100, Single Equip, Last Available: "2022-12"
 11065	shaking cinnamon machine oil	0		
-11066	bouncing tumbling Crimbo crystal shards	0		
+11066	tumbling bouncing Crimbo crystal shards	0		
 11067	smooth teal dregs of a Crimbo cocktail	3	awesome	
 11068	lost elf luggage	0		
 11069	pulsating Trainbot luggage hook	0		Single Equip
-11070	spoiled purple mirror honey-drenched ham slice	3	crappy	
+11070	spoiled mirror purple honey-drenched ham slice	3	crappy	
 11071	drinkable mostly-empty bottle of cookie wine	4	good	
-11072	decent special miniature Crimbo food scraps	2	good	Effect: "Unusual Perspective", Effect Duration: 50
+11072	special miniature decent Crimbo food scraps	2	good	Effect: "Unusual Perspective", Effect Duration: 50
 11073	maroon wobbly arm towel	0		Last Available: "2022-12"
-11074	fuchsia ghostly narrow automatic wine thief	0		Single Equip
+11074	ghostly fuchsia narrow automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	tumbling Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	rotten super-sized steamed oyster	5	crappy	
+11078	super-sized rotten steamed oyster	5	crappy	
 11079	fuchsia really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	upside-down ghostly steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	drinkable bouncing Crimbosmopolitan	3	good	Last Available: "2022-12"
-11085	bland tiny Crimbo dinner	1	decent	Last Available: "2022-12"
+11085	tiny bland Crimbo dinner	1	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	spinning unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	upside-down half-height cigar	0		Familiar Weight: +5
-11091	tumbling yellow grubby wool	0		
+11091	yellow tumbling grubby wool	0		
 11092	Herculean beefcake's grubby wool hat of extreme caution	0		Muscle: +25, Experience (Muscle): +1, Monster Level: -25
 11093	lightning-fast savvy grubby wool scarf	0		Mysticality Percent: +20, Initiative: +40, Single Equip
 11094	frightening flame-wreathed arcane researcher's grubby wool trousers	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +10, Spooky Damage: +5
@@ -10956,7 +10956,7 @@
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	skewed gray groveling gravel	0		Last Available: "2023-01"
 11102	compressed squat fruity pebble	1		Last Available: "2023-01"
-11103	huge fuchsia lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
+11103	fuchsia huge lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	cyan bolder boulder	0		Last Available: "2023-01"
 11106	jittery molehill mountain	0		Last Available: "2023-01"
@@ -10974,13 +10974,13 @@
 11119	corrupted five-fingered fern resin	0		Effect: "Insulated Trousers", Effect Duration: 20, Last Available: "2023-02"
 11120	rotten super good fruit	4	crappy	Last Available: "2023-02"
 11121	twisted energized spores	1		Last Available: "2023-02"
-11122	reassuring Rosewater's hot pepper	0		Mysticality Percent: +30, Spooky Resistance: +1, Lantern Element: "Hot", Last Available: "2023-02"
+11122	reassuring Rosewater's hot pepper	0		Mysticality Percent: +30, Spooky Resistance: +1, Last Available: "2023-02", Lantern Element: "Hot"
 11123	pickled skewed out-of-work circus flea	0		Effect: "Thanksgot", Effect Duration: 24, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
-11125	electrified oxidized pulsating shaking pulsating fire ant pheromones	0		Effect: "Nature's Bounty", Effect Duration: 20, Last Available: "2023-02"
+11125	electrified oxidized shaking pulsating pulsating fire ant pheromones	0		Effect: "Nature's Bounty", Effect Duration: 20, Last Available: "2023-02"
 11126	galvanized quadruple-unsweetened magnetized squat squat flapper fly	0		Effect: "On the Shoulders of Giants", Effect Duration: 14, Last Available: "2023-02"
 11127	artisanal blurry shot of wasp venom	3	EPIC	Last Available: "2023-02"
-11128	adjusted fuchsia shaking filled mosquito	0		Effect: "Vitali Tea", Effect Duration: 19, Last Available: "2023-02"
+11128	adjusted shaking fuchsia filled mosquito	0		Effect: "Vitali Tea", Effect Duration: 19, Last Available: "2023-02"
 11129	improved warmed shim of shame shale	0		Effect: "Venomous Weapon", Effect Duration: 59, Last Available: "2023-02"
 11130	super-Vulcanized pebble of proud pyrite	0		Effect: "La Bamba", Effect Duration: 25, Last Available: "2023-02"
 11131	irradiated pile of gritty sand	0		Effect: "Permanent Halloween", Effect Duration: 15, Last Available: "2023-02"
@@ -11015,7 +11015,7 @@
 11160	cyan uncursed blanket	0		
 11161	cyan Tesla Sinatra's medallion of the sweet-tooth	0		Experience (Moxie): +5, Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10
 11162	uncursed medallion of dire peril	0		Weapon Damage: +20
-11163	gray tumbling Advanced Pig Skinning	0		
+11163	tumbling gray Advanced Pig Skinning	0		
 11164	The Cheese Wizard's Companion	0		
 11165	Jazz Agent sheet music	0		
 11166	bouncing skewed Thwaitgold anti-moth statuette	0		
@@ -11034,8 +11034,8 @@
 11179	sinister groovy shadow hammer	0		Moxie Percent: +10, Spell Damage: +10
 11180	blinking slick shadow monocle of the brazier of the businessman	0		Moxie: +10, Hot Spell Damage: +25, Meat Drop: +50, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	tiny spoiled shadow hot dog	1	crappy	
-11183	special weak drinkable shaking spinning blinking shadow martini	2	good	Effect: "Prince of Seaside Town", Effect Duration: 15
+11182	spoiled tiny shadow hot dog	1	crappy	
+11183	special weak drinkable spinning shaking blinking shadow martini	2	good	Effect: "Prince of Seaside Town", Effect Duration: 15
 11184	diluted shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
@@ -11047,7 +11047,7 @@
 11192	replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	spinning dedigitizer schematic: cyburger	0		Last Available: "2025-12"
-11195	lime green upside-down replica gravy-covered maypole	0		Item Drop: +25
+11195	upside-down lime green replica gravy-covered maypole	0		Item Drop: +25
 11196	replica wax lips	0		Experience: +3
 11197	replica Tome of Snowcone Summoning	0		
 11198	ghostly dedigitizer schematic: cybeer	0		Last Available: "2025-12"
@@ -11074,7 +11074,7 @@
 11219	replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
-11222	blurry bouncing red shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
+11222	blurry red bouncing shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	jittery dog trainer's stiffened Cincho de Mayo of the storm of the glutton	0		Damage Reduction: 1, Maximum MP Percent: +40, Experience (familiar): +1, Food Drop: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	bouncing replica Little Geneticist DNA-Splicing Lab	0		
@@ -11103,7 +11103,7 @@
 11248	blinking replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	Van der Graaf smooth replica Jurassic Parka	0		Moxie: +15, MP Regen Min: 5, MP Regen Max: 7
 11250	blurry replica grey gosling	0		
-11251	teal skewed replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	skewed teal replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	red replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	skewed horrifying healthy Socratic replica Cincho de Mayo of terror	0		Experience (Mysticality): +1, Maximum HP Percent: +20, Spooky Damage: +25, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11123,7 +11123,7 @@
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	purple Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
-11271	corrupted energized jittery ghostly scroll of minor invulnerability	0		Effect: "Swordholder", Effect Duration: 48, Last Available: "2023-06"
+11271	corrupted energized ghostly jittery scroll of minor invulnerability	0		Effect: "Swordholder", Effect Duration: 48, Last Available: "2023-06"
 11272	twirling Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
@@ -11163,25 +11163,25 @@
 11308	twirling watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
-11311	decent low-calorie waffle	1	good	
+11311	low-calorie decent waffle	1	good	
 11312	fixodent	0		
 11313	boxer's cat o' nine teeth of the cougar	0		Moxie: +20, Muscle Percent: +10
 11314	upside-down jittery blinking quilted Rosewater's tooth cap	0		Mysticality Percent: +30, Damage Absorption: +40
 11315	occult Herculean toothy trousers	0		Experience (Muscle): +1, Spell Damage Percent: +25
-11316	toothsome enchanted yellow banana split	4	awesome	Effect: "Bloody-minded", Effect Duration: 45
+11316	enchanted toothsome yellow banana split	4	awesome	Effect: "Bloody-minded", Effect Duration: 45
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	skewed medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	weak bad bottle of Cabernet Sauvignon	2	decent	
+11320	bad weak bottle of Cabernet Sauvignon	2	decent	
 11321	reassuring lion tamer's Jim Carey's baywatch	0		Monster Level: +25, Experience (familiar): +2, Spooky Resistance: +1, Lasts Until Rollover
-11322	tumbling blurry upside-down Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	upside-down tumbling blurry Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	pulsating Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	distilled concentrated cooking	1		
-11329	altered maroon narrow meat	1		
+11329	altered narrow maroon meat	1		
 11330	compressed spinning sparkling orb	1		Effect: "Square to be Hip", Effect Duration: 5
 11331	powdered hardening cream	1		Effect: "World's Shortest Giant", Effect Duration: 40
 11332	distilled blinking pool shark hair oil	1		Effect: "Broberry Brotality", Effect Duration: 45
@@ -11212,9 +11212,9 @@
 11357	flame-wreathed ruddy smoldering drape	0		Maximum HP Percent: +40, Hot Spell Damage: +10, Lasts Until Rollover
 11358	blurry squat smoldering leafcutter ant egg	0		
 11359	perfumed Jack Frost's Van der Graaf vibrating forbidden extremely unsafe leaf crown	0		Weapon Damage Percent: +100, Spell Damage Percent: +50, Maximum MP Percent: +10, Cold Spell Damage: +50, Stench Resistance: +5, MP Regen Min: 5, MP Regen Max: 7
-11360	gigantic normal leafy browns	7	good	
+11360	normal gigantic leafy browns	7	good	
 11361	pressed unsweetened purple autumnic balm	0		Effect: "Slippery Tongue", Effect Duration: 42
-11362	non-pressed yellow bouncing coping juice	0		Effect: "You Know When to Walk Away", Effect Duration: 56
+11362	non-pressed bouncing yellow coping juice	0		Effect: "You Know When to Walk Away", Effect Duration: 56
 11363	toasty arcane researcher's smooth strapping candy cane sword cane	0		Muscle: +5, Moxie: +15, Experience Percent (Mysticality): +10, Hot Damage: +5, Item Drop: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
@@ -11230,7 +11230,7 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	bite-sized yummy lime green pickled bread	1	awesome	Last Available: "2023-12"
+11378	yummy bite-sized lime green pickled bread	1	awesome	Last Available: "2023-12"
 11379	tasty miniature salted mutton	2	awesome	Last Available: "2023-12"
 11380	rotten diet corned beet	1	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11263,7 +11263,7 @@
 11408	lime green Elf Guard MPC	0		Last Available: "2023-12"
 11409	olive Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	maroon ribald Elf Guard commandeering gloves	0		Sleaze Damage: +10, Single Equip, Last Available: "2023-12"
-11411	colloidal colloidal maroon mirror Elf Guard eyedrops	0		Effect: "Preternatural Greed", Effect Duration: 56, Last Available: "2023-12"
+11411	colloidal colloidal mirror maroon Elf Guard eyedrops	0		Effect: "Preternatural Greed", Effect Duration: 56, Last Available: "2023-12"
 11412	Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	narrow Elf Guard honor present	0		Last Available: "2023-12"
 11414	medical-grade Elf Guard officer's sidearm of mayonnaise	0		Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
@@ -11274,13 +11274,13 @@
 11419	wobbly mansplainer's hardened Elf Guard broom	0		Damage Reduction: 3, Monster Level: +15, Last Available: "2023-12"
 11420	ribald coward's Crimbuccaneer tavern swab of doom	0		Monster Level: -20, Spooky Spell Damage: +50, Sleaze Damage: +10, Last Available: "2023-12"
 11421	twirling Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	boozy delicious fuchsia old-school pirate grog	5	awesome	Last Available: "2023-12"
-11423	stale half-sized skewed teal grog nuts	2	decent	Last Available: "2023-12"
+11422	delicious boozy fuchsia old-school pirate grog	5	awesome	Last Available: "2023-12"
+11423	stale half-sized teal skewed grog nuts	2	decent	Last Available: "2023-12"
 11424	brainy sawed-off blunderbuss of the empath of chilblains	0		Mysticality: +5, Familiar Weight: +5, Cold Damage: +25, Last Available: "2023-12"
-11425	spirit-forward tolerable officer's nog	5	good	Last Available: "2023-12"
+11425	tolerable spirit-forward officer's nog	5	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	spoiled skewed sundae ration	3	crappy	Last Available: "2023-12"
-11428	low-calorie decent peppermint tack	1	good	Last Available: "2023-12"
+11428	decent low-calorie peppermint tack	1	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	enchanted bite-sized yummy whalesteak	1	awesome	Effect: "What's That Smell?", Effect Duration: 5, Last Available: "2023-12"
 11431	Usain Bolt's strapping whalegun of doom	0		Muscle: +5, Spooky Spell Damage: +50, Initiative: +80, Last Available: "2023-12"
@@ -11313,13 +11313,13 @@
 11458	rosewater-soaked Crimbuccaneer bombjacket of the sweet-tooth	0		Stench Resistance: +3, Candy Drop: +100, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	gigantic decent sugarplum ration	6	good	Last Available: "2023-12"
 11460	bland fancy gingerbread nylons	3	decent	Effect: "Kindly Resolve", Effect Duration: 40, Last Available: "2023-12"
-11461	jumbo stale twirling rum-soaked fruitcake	5	decent	Last Available: "2023-12"
-11462	small adequate fancy fuchsia lime	2	good	Effect: "Boon of She-Who-Was", Effect Duration: 45, Last Available: "2023-12"
-11463	thick spoiled gingerbread pirate	5	crappy	Last Available: "2023-12"
+11461	stale jumbo twirling rum-soaked fruitcake	5	decent	Last Available: "2023-12"
+11462	fancy small adequate fuchsia lime	2	good	Effect: "Boon of She-Who-Was", Effect Duration: 45, Last Available: "2023-12"
+11463	spoiled thick gingerbread pirate	5	crappy	Last Available: "2023-12"
 11464	moldy fruit-stuffed rumcake	4	crappy	Last Available: "2023-12"
 11465	drinkable shaking mulled wine	3	good	Last Available: "2023-12"
 11466	acceptable boozy Swedish coffee	5	good	Last Available: "2023-12"
-11467	mediocre weak shaking huge canteen of eggnog	2	decent	Last Available: "2023-12"
+11467	mediocre weak huge shaking canteen of eggnog	2	decent	Last Available: "2023-12"
 11468	lousy hot wine	3	decent	Last Available: "2023-12"
 11469	lousy Jamaican coffee	3	decent	Last Available: "2023-12"
 11470	artisanal flask of egggrog	3	super EPIC	Last Available: "2023-12"
@@ -11349,7 +11349,7 @@
 11494	Elf Guard safety bear	0		Last Available: "2023-12"
 11495	green kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
-11497	tumbling jittery cyan Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
+11497	cyan jittery tumbling Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	tumbling Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	shaking The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
@@ -11382,8 +11382,8 @@
 11527	nitrogenated anodized mirror blurry crepe paper peanut candy	0		Effect: "Hippy Flavor", Effect Duration: 21
 11528	deadly Samson's petrified wood war pike	0		Experience (Muscle): +5, Weapon Damage: +5, Last Available: "2025-12"
 11529	stylish petrified wood waist protector of the businessman	0		Moxie: +25, Meat Drop: +50, Single Equip, Last Available: "2025-12"
-11530	hale petrified wood wizard's pouch of the bloodbag	0		Maximum HP: 120, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	bouncing Van der Graaf petrified wood water purifier of Flo-Jo	0		Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	hale petrified wood wizard's pouch of the bloodbag	0		Maximum HP: 120, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	bouncing Van der Graaf petrified wood water purifier of Flo-Jo	0		Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	Jeselnik's petrified wood whoopie panama of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +25, Last Available: "2025-12"
 11533	sage brainy petrified wood walking pants	0		Mysticality: +5, Mysticality Percent: +10, Last Available: "2025-12"
 11534	denatured wobbly petrified wood waste parts	1		Last Available: "2025-12"
@@ -11441,7 +11441,7 @@
 11586	squat Annie Oakley's extremely unsafe yamtility belt of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +100, Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2024-05"
 11587	normal yam slider	4	good	Last Available: "2024-05"
 11588	delicious yam mayo	3	awesome	Last Available: "2024-05"
-11589	gigantic adequate yam burrito	10	good	Last Available: "2024-05"
+11589	adequate gigantic yam burrito	10	good	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
@@ -11453,7 +11453,7 @@
 11598	mini kiwi aioli	0		
 11599	squat frightening Temple Grandin's personal trainer's mini kiwi silicon tiepin	0		Experience Percent (Muscle): +10, Familiar Weight: +7, Spooky Damage: +5
 11600	mini kiwi tipi	0		
-11601	flavorless huge mini kiwi digitized cookies	10	decent	
+11601	huge flavorless mini kiwi digitized cookies	10	decent	
 11602	lousy blinking mini kiwi intoxicating spirits	3	decent	
 11603	improved wobbly mini kiwi antimilitaristic hippy petition	0		Effect: "Pronounced Potency", Effect Duration: 17
 11604	pickled mini kiwi illicit antibiotic	0		Effect: "All Branned Up", Effect Duration: 43
@@ -11470,7 +11470,7 @@
 11615	slick messenger bag RNA of terror of temperance	0		Moxie: +10, Spooky Spell Damage: +10, Sleaze Resistance: +5
 11616	blue flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	normal fancy bacteria bisque	3	good	Effect: "Brocolate Brostidigitation", Effect Duration: 15
+11618	fancy normal bacteria bisque	3	good	Effect: "Brocolate Brostidigitation", Effect Duration: 15
 11619	yummy ciliophora chowder	3	awesome	
 11620	flavorless snack-sized cream of chloroplasts	2	decent	
 11621	synaptic soup	0		
@@ -11479,11 +11479,11 @@
 11624	shaking elbow soup	0		
 11625	fuchsia twirling lip soup	0		
 11626	unevolved organism	0		Free Pull
-11627	green twirling jittery extra ooze	0		
+11627	green jittery twirling extra ooze	0		
 11628	squat extra DNA	0		Experience (familiar): +1
 11629	untorn tearaway pants package	0		Free Pull
 11630	sharpshooter's hardened extremely unsafe personal trainer's savvy tearaway pants	0		Mysticality Percent: +20, Experience Percent (Muscle): +10, Weapon Damage Percent: +100, Damage Reduction: 3, Critical Hit Percent: +10, Conditional Skill (Equipped): "Tear Away your Pants!"
-11631	blue twirling baby bodyguard	0		
+11631	twirling blue baby bodyguard	0		
 11632	Doll Moll violin case	0		
 11633	green Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
@@ -11526,8 +11526,8 @@
 11671	sizzling photo booth supply list of wisdom	0		Mysticality: +15, Hot Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	blinking tie-dye headband	0		
-11674	small stale whirled peas	2	decent	Last Available: "2024-11"
-11675	normal snack-sized peaza	2	good	Last Available: "2024-11"
+11674	stale small whirled peas	2	decent	Last Available: "2024-11"
+11675	snack-sized normal peaza	2	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	mixed drenchrome 2.0	1		Effect: "Permanent Halloween", Effect Duration: 45, Last Available: "2025-12"
 11678	altered bouncing Synapse Blaster	1		Last Available: "2025-12"
@@ -11545,15 +11545,15 @@
 11690	lard-coated jolly roger flag	0		Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	high-proof tolerable tankard of spiced rum	9	good	Last Available: "2024-12"
-11694	bad high-proof tankard of spiced Goldschlepper	10	decent	Last Available: "2024-12"
+11693	tolerable high-proof tankard of spiced rum	9	good	Last Available: "2024-12"
+11694	high-proof bad tankard of spiced Goldschlepper	10	decent	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	governor's daughter's lace collar of Gandalf	0		Spell Critical Percent: +20, Last Available: "2024-12"
 11697	greasy governor's daughter's petticoats	0		Sleaze Spell Damage: +10, Last Available: "2024-12"
 11698	governor's daughter's pearl hairpin of temperance	0		Sleaze Resistance: +5, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	blurry perfumed chili powder cutlass	0		Stench Resistance: +5, Last Available: "2024-12"
-11701	decent half-sized Aztec tamale	2	good	Last Available: "2024-12"
+11701	half-sized decent Aztec tamale	2	good	Last Available: "2024-12"
 11702	wobbly jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	fuchsia Rosewater's groggles	0		Mysticality Percent: +30, Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	wicked silky pirate drawers of the brute	0		Muscle Percent: +30, Spell Damage: +5, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	concentrated magnetized cyan peppermint pegleg	0		Effect: "Weird Flavor", Effect Duration: 27, Last Available: "2024-12"
-11710	mediocre practically non-alcoholic hard cocoa	1	decent	Last Available: "2024-12"
+11710	practically non-alcoholic mediocre hard cocoa	1	decent	Last Available: "2024-12"
 11711	stale immense salmagumdi	8	decent	Last Available: "2024-12"
 11712	nippy plastic Easter Island Bunny	0		Cold Damage: +10, Last Available: "2024-12"
 11713	plastic St. Patrick of the scaredy-cat	0		Monster Level: -15, Last Available: "2024-12"
@@ -11576,7 +11576,7 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	massive spoiled coney haunch	6	crappy	Last Available: "2024-12"
 11723	super-diffused unsweetened frozen dark chocolate egg	0		Effect: "init.enh", Effect Duration: 18, Last Available: "2024-12"
-11724	strong lousy squat huge moai toai	5	decent	
+11724	strong lousy huge squat moai toai	5	decent	
 11725	executive hale quilted moaiball	0		Damage Absorption: +40, Maximum HP: +20, Meat Drop: +40, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	energized four-leaf potato sprout	0		Effect: "Sharp Weapon", Effect Duration: 31, Last Available: "2024-12"
@@ -11601,12 +11601,12 @@
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	artisanal narrow skewed Easter grasshopper	3	EPIC	Last Available: "2024-12"
 11748	perfectly mixed Irish eggnog	3	EPIC	Last Available: "2024-12"
-11749	artisanal triple-distilled canteen of jungle juice	8	EPIC	Last Available: "2024-12"
+11749	triple-distilled artisanal canteen of jungle juice	8	EPIC	Last Available: "2024-12"
 11750	artisanal blinking turchucken	4	EPIC	Last Available: "2024-12"
-11751	weak acceptable mechanically-mulled cider	2	good	Last Available: "2024-12"
-11752	smooth watered-down shaking holiday trip around the world	2	awesome	Last Available: "2024-12"
+11751	acceptable weak mechanically-mulled cider	2	good	Last Available: "2024-12"
+11752	watered-down smooth shaking holiday trip around the world	2	awesome	Last Available: "2024-12"
 11753	half-sized rotten chocolate ostrich egg	2	crappy	Last Available: "2024-12"
-11754	bland snack-sized pulsating beef and cabbage	2	decent	Last Available: "2024-12"
+11754	snack-sized bland pulsating beef and cabbage	2	decent	Last Available: "2024-12"
 11755	adequate candy rations	4	good	Last Available: "2024-12"
 11756	flavorless upside-down double-candied yams	4	decent	Last Available: "2024-12"
 11757	stale super-sized bouncing Christmas ham	5	decent	Last Available: "2024-12"
@@ -11633,7 +11633,7 @@
 11778	dried clovermint	1		Last Available: "2024-12"
 11779	educational beefy nylon Christmas stockings of the overflowing toilet of mayonnaise	0		Muscle: +10, Experience: +1, Stench Spell Damage: +50, Sleaze Spell Damage: +50, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
-11781	electrified pressed tarnished ghostly cyan deviled candy egg	0		Effect: "Ass Over Teakettle", Effect Duration: 23, Last Available: "2024-12"
+11781	electrified pressed tarnished cyan ghostly deviled candy egg	0		Effect: "Ass Over Teakettle", Effect Duration: 23, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	deadly McHugeLarge duffel bag of the detective	0		Weapon Damage: +5, Item Drop: +20, Last Available: "2025-01"
 11784	miser's energetic smartaleck's McHugeLarge left pole	0		Moxie Percent: +30, Maximum MP Percent: +20, Meat Drop: +10, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
@@ -11653,7 +11653,7 @@
 11798	dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	pulsating dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
-11801	blurry twirling dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
+11801	twirling blurry dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	twirling dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
@@ -11671,8 +11671,8 @@
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
-11819	ghostly gray dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	red skewed dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11819	gray ghostly dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
+11820	skewed red dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	shaking OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	shaking STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
@@ -11685,7 +11685,7 @@
 11830	ninja rope	0		
 11831	ninja crampons	0		
 11832	spinning ninja carabiner	0		
-11833	warmed narrow green synthetic coffee	0		Effect: "Human-Goblin Hybrid", Effect Duration: 23
+11833	warmed green narrow synthetic coffee	0		Effect: "Human-Goblin Hybrid", Effect Duration: 23
 11834	magnetized concentrated fuchsia iDrops	0		Effect: "Reedy Pipes", Effect Duration: 64
 11835	yellow shame coil	0		
 11836	blue new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
@@ -11707,7 +11707,7 @@
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	blurry grim cellophane	0		Combat Rate: -5
-11855	twirling upside-down twirling rift oculus	0		Combat Rate: +5
+11855	upside-down twirling twirling rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	bouncing carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	glover liners	0		Pickpocket Chance: +10
@@ -11716,24 +11716,24 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	dehydrated huge scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	artisanal irresponsibly strong pint of Leprechaun Stout	9	EPIC	Last Available: "2025-03"
+11864	irresponsibly strong artisanal pint of Leprechaun Stout	9	EPIC	Last Available: "2025-03"
 11865	compressed phosphor traces	1		Last Available: "2025-03"
 11866	tumbling crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
-11868	blue blinking spoon	0		
+11868	blinking blue spoon	0		
 11869	unironic knife	0		
-11870	olive wobbly jittery bar dart	0		Last Available: "2025-03"
+11870	jittery olive wobbly bar dart	0		Last Available: "2025-03"
 11871	dehydrated leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	stale upside-down Heck ramen	3	decent	Last Available: "2025-03"
 11873	moldy burrito	3	crappy	Last Available: "2025-03"
 11874	normal mirror small beer brat	4	good	Last Available: "2025-03"
 11875	adequate diet peach pie	1	good	Last Available: "2025-03"
-11876	moldy special miniature narrow incredible mini-pizza	2	crappy	Effect: "Initiative and Let Die", Effect Duration: 30, Last Available: "2025-03"
+11876	special miniature moldy narrow incredible mini-pizza	2	crappy	Effect: "Initiative and Let Die", Effect Duration: 30, Last Available: "2025-03"
 11877	special bad twirling Divine sidecar	3	decent	Effect: "Marbles in Your Mouth", Effect Duration: 5, Last Available: "2025-03"
-11878	practically non-alcoholic perfectly mixed maroon blurry tangarita sidecar	1	super ultra EPIC	Last Available: "2025-03"
+11878	perfectly mixed practically non-alcoholic blurry maroon tangarita sidecar	1	super ultra EPIC	Last Available: "2025-03"
 11879	acceptable gimlet sidecar	3	good	Last Available: "2025-03"
 11880	artisanal practically non-alcoholic maroon vodka stratocaster sidecar	1	super ultra EPIC	Last Available: "2025-03"
-11881	weak drinkable prussian cathouse sidecar	2	good	Last Available: "2025-03"
+11881	drinkable weak prussian cathouse sidecar	2	good	Last Available: "2025-03"
 11882	bad Mon Tiki sidecar	3	decent	Last Available: "2025-03"
 11883	squat Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	pulsating April Shower Thoughts shield of doom of Flo-Jo	0		Spooky Spell Damage: +50, Initiative: +100, Damage Reduction: 6, Last Available: "2025-04"
@@ -11814,7 +11814,7 @@
 11960	narrow really, really nice swimming trunks	0		
 11961	shaking sand penny	0		
 11962	tumbling ribald undersea surveying goggles	0		Sleaze Damage: +10, Lasts Until Rollover
-11963	watered-down artisanal wobbly bouncing Ocean-Touched Rum	2	EPIC	
+11963	artisanal watered-down bouncing wobbly Ocean-Touched Rum	2	EPIC	
 11964	denatured fuchsia shaking water-logged pill	1		
 11965	stale huge special kelp puck	6	decent	Effect: "Ruthlessly Efficient", Effect Duration: 40
 11966	scroll of sea strength	0		
@@ -11827,12 +11827,12 @@
 11973	cyan Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
-11976	skewed shaking unblemished pearl	0		
+11976	shaking skewed unblemished pearl	0		
 11977	gray dentadent of Tarzan	0		Experience (Muscle): +3
 11986	skewed lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	Usain Bolt's therapeutic hardened stiffened sage blood cubic zirconia of the businessman	0		Mysticality Percent: +10, Damage Reduction: 8, Meat Drop: +50, Initiative: +80, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	denatured shaking blood thinner	1		Effect: "Oh Snap", Effect Duration: 15, Last Available: "2025-10"
-12045	smooth high-proof pheromone cocktail	7	awesome	Last Available: "2025-10"
+12045	high-proof smooth pheromone cocktail	7	awesome	Last Available: "2025-10"
 12046	flavorless spinal tapas	4	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	hardened strapping shrunken head of the brazier	0		Muscle: +5, Damage Reduction: 3, Hot Spell Damage: +25, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
@@ -11840,9 +11840,9 @@
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	drinkable Smoking Pope	4	good	
-12053	massive bland prize turkey	9	decent	
+12053	bland massive prize turkey	9	decent	
 12054	twisted ghostly upside-down medicinal gruel	1		
-12055	bland fancy full-sized pumpkin pie	3	decent	Effect: "Icy Demeanor", Effect Duration: 35, Last Available: "2025-11"
+12055	fancy bland full-sized pumpkin pie	3	decent	Effect: "Icy Demeanor", Effect Duration: 35, Last Available: "2025-11"
 12056	delicious vodka cranberry sauce	3	awesome	Last Available: "2025-11"
 12057	unsweetened yammed candy	0		Effect: "Flaming Weapon", Effect Duration: 63, Last Available: "2025-11"
 12058	adequate upside-down treasure chestnut	3	good	Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	arcane researcher's extra-thick Crimbo sweater	0		Experience Percent (Mysticality): +10, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	extra-dry mediocre Steve Abrams' Holiday Sampler Beer	5	decent	Last Available: "2025-12"
+12124	mediocre extra-dry Steve Abrams' Holiday Sampler Beer	5	decent	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	perfectly mixed bottle of prize-winning rum	3	EPIC	Last Available: "2025-12"
 12127	maroon bouncing aromatic frosty sage Santa-Slayer medal	0		Mysticality Percent: +10, Cold Spell Damage: +10, Stench Resistance: +1, Single Equip, Last Available: "2025-12"
@@ -11890,14 +11890,14 @@
 12132	Jack Frost's padded smoldering vertebra of the scaredy-cat	0		Damage Absorption: +20, Monster Level: -15, Cold Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12133	shaking seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
-12135	red mirror huge smoldering bone dust	0		Last Available: "2025-12"
+12135	mirror huge red smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	dog trainer's crafty arcane researcher's hot boning knife	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Experience (familiar): +1, Single Equip, Last Available: "2025-12"
 12138	tumbling razor-sharp Socratic fistbone of doom	0		Experience (Mysticality): +1, Weapon Damage Percent: +25, Spooky Spell Damage: +50, Last Available: "2025-12"
 12139	shaking horrifying Jack Frost's Newton's burnt bone belt	0		Experience (Mysticality): +3, Cold Spell Damage: +50, Spooky Damage: +25, Single Equip, Last Available: "2025-12"
 12140	baleful scorched skull trophy	0		Spell Damage: +25, Last Available: "2025-12"
 12141	bland super-sized wing bone	5	decent	Last Available: "2025-12"
-12142	mediocre enchanted practically non-alcoholic weak skeleton venom	1	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2025-12"
+12142	practically non-alcoholic enchanted mediocre weak skeleton venom	1	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2025-12"
 12143	compressed green baked bone meal	1		Effect: "Stinky Weapon", Effect Duration: 30, Last Available: "2025-12"
 12144	chilly plastic skeleton rib cage	0		Cold Damage: +5, Last Available: "2025-12"
 12145	sizzling plastic skeleton skull	0		Hot Damage: +10, Last Available: "2025-12"
@@ -11914,7 +11914,7 @@
 12156	tumbling Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
-12159	green wobbly Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
+12159	wobbly green Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	maroon Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
@@ -11927,12 +11927,12 @@
 12169	flame-retardant ship's lantern	0		Hot Resistance: +1, Last Available: "2025-12"
 12170	forbidden heat-resistant harpoon pistol of the dark arts	0		Spell Damage Percent: 150, Last Available: "2025-12"
 12171	stale traditional gingerloaf	3	decent	Last Available: "2025-12"
-12172	tolerable irresponsibly strong upside-down Scotch and eggnog	8	good	Last Available: "2025-12"
+12172	irresponsibly strong tolerable upside-down Scotch and eggnog	8	good	Last Available: "2025-12"
 12173	concentrated vacuum-sealed counterskeleton elixir	0		Effect: "Cock of the Walk", Effect Duration: 38, Last Available: "2025-12"
 12174	acceptable bouncing wobbly &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	tumbling crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	normal blinking skewed wedge of prize-winning cheese	3	good	Last Available: "2025-12"
+12177	normal skewed blinking wedge of prize-winning cheese	3	good	Last Available: "2025-12"
 12178	polymerized gummi fingerbone	0		Effect: "Disdain of the War Snapper", Effect Duration: 19
 12179	jittery greedy censurious glimmering crystal	0		Sleaze Resistance: +3, Meat Drop: +20, Last Available: "2025-12"
 12180	green boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11961,7 +11961,7 @@
 12203	narrow frosty electrified shellacked dinosaur bone corset	0		Damage Reduction: 7, Cold Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2026-03"
 12204	aged green Pork Elf cough syrup	4	awesome	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
-12206	blurry blinking Pork Elf medicine cabinet	0		Last Available: "2026-03"
+12206	blinking blurry Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
 12209	bland rat pizza	3	decent	Last Available: "2026-03"
@@ -11983,7 +11983,7 @@
 12229	spoiled big onigiri	5	crappy	
 12230	tasty miniature crudit&eacute;s	2	awesome	
 12231	rotten sauced mutton	3	crappy	
-12232	delicious jumbo hot honey ant	5	awesome	
+12232	jumbo delicious hot honey ant	5	awesome	
 12233	jumbo moldy tomb aspic	5	crappy	
 12234	stale later tots	4	decent	
 12235	normal Frutti di Scatoletta	4	good	Last Available: "2026-05"
@@ -11991,13 +11991,13 @@
 12237	rotten Arrattabbattabiata	4	crappy	Last Available: "2026-05"
 12238	rotten bite-sized bouncing Orzo di Riso	1	crappy	Last Available: "2026-05"
 12239	yummy Pasta Grimavera	4	awesome	Last Available: "2026-05"
-12240	snack-sized moldy Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
+12240	moldy snack-sized Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
 12241	stale bouncing Formica e Pepe	4	decent	Last Available: "2026-05"
 12242	normal Tubetto Gelatto	3	good	Last Available: "2026-05"
 12243	moldy squat Gnocci Domani	3	crappy	Last Available: "2026-05"
 12244	blurry Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
-12246	blurry bouncing second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
+12246	bouncing blurry second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	Jim Carey's hardened Space Soldier Helmet	0		Damage Reduction: 3, Monster Level: +25
 12253	spoiled premium turkey leg	4	crappy	
@@ -12009,37 +12009,37 @@
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	censurious sharpshooter's The Wizard's Android of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +10, Sleaze Resistance: +3
 12261	huge flash paperwad	0		
-12262	narrow olive juggling ball	0		
+12262	olive narrow juggling ball	0		
 12263	skewed fortified tactical jester's cap of the bloodbag	0		Damage Absorption: +60, Maximum HP: +100, Combat Item Damage Percent: 50
 12264	blinking single-use sword	0		
 12265	bouncing flimsy plastic helmet of the dark arts	0		Spell Damage Percent: +100
 12266	executive flimsy plastic greaves	0		Meat Drop: +40
 12267	bouncing blinking quilted flimsy plastic breastplate	0		Damage Absorption: +40
 12268	beefy flimsy plastic shield	0		Muscle: +10, Damage Reduction: 3
-12269	mirror purple packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
+12269	purple mirror packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	spinning wobbly tumbling sage beefy Portable Laughing Stock of the bloodbag	0		Muscle: +10, Mysticality Percent: +10, Maximum HP: +100, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	asbestos-lined fireproof personal trainer's Staff of Anachronistic Churning	0		Experience Percent (Muscle): +10, Hot Resistance: 8
-12272	adequate half-sized special classic banana	2	good	Effect: "You Know What's Up", Effect Duration: 25, Last Available: "2026-07"
-12273	decent enchanted blurry watermelon	3	good	Effect: "Rave Concentration", Effect Duration: 45, Last Available: "2026-07"
+12272	half-sized adequate special classic banana	2	good	Effect: "You Know What's Up", Effect Duration: 25, Last Available: "2026-07"
+12273	enchanted decent blurry watermelon	3	good	Effect: "Rave Concentration", Effect Duration: 45, Last Available: "2026-07"
 12274	bland quince	3	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	ghostly squat Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	snack-sized moldy classic banana pie	2	crappy	Last Available: "2026-07"
+12277	moldy snack-sized classic banana pie	2	crappy	Last Available: "2026-07"
 12278	super-frozen upside-down wobbly essential banana decoction	0		Effect: "Spore-Wreathed", Effect Duration: 69, Last Available: "2026-07"
 12279	super-chilled colloidal banana quintessence	0		Effect: "Chalked Weapon", Effect Duration: 56, Last Available: "2026-07"
-12280	aged spirit-forward Aesop Daiquiri	5	awesome	Last Available: "2026-07"
-12281	strong artisanal Monkey Congress	5	EPIC	Last Available: "2026-07"
+12280	spirit-forward aged Aesop Daiquiri	5	awesome	Last Available: "2026-07"
+12281	artisanal strong Monkey Congress	5	EPIC	Last Available: "2026-07"
 12282	adequate upside-down watermelon pie	3	good	Last Available: "2026-07"
 12283	triple-ionized corrupted triple-tarnished olive upside-down concentrated watermelon juice	0		Effect: "BOOsted", Effect Duration: 15, Last Available: "2026-07"
 12284	pressed bouncing Aqua Citrulanatae	0		Effect: "Bored Stiff", Effect Duration: 52, Last Available: "2026-07"
 12285	bad practically non-alcoholic upside-down Melonegroni	1	decent	Last Available: "2026-07"
 12286	mediocre watered-down Melonade Spritz	2	decent	Last Available: "2026-07"
 12287	immense adequate quince pie	7	good	Last Available: "2026-07"
-12288	alkaline vacuum-sealed huge gray pulsating quince quaff	0		Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2026-07"
+12288	alkaline vacuum-sealed huge pulsating gray quince quaff	0		Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2026-07"
 12289	warmed flattened denatured Quickquince	0		Effect: "Patched In", Effect Duration: 13, Last Available: "2026-07"
 12290	artisanal watered-down Quiskey Sour	2	EPIC	Last Available: "2026-07"
-12291	artisanal enchanted Quincea&ntilde;era Cooler	3	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 5, Last Available: "2026-07"
-12292	hand-crafted weak Roth IPA	2	EPIC	Last Available: "2026-08"
+12291	enchanted artisanal Quincea&ntilde;era Cooler	3	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 5, Last Available: "2026-07"
+12292	weak hand-crafted Roth IPA	2	EPIC	Last Available: "2026-08"
 12293	energetic underdraft protection of the brazier	0		Maximum MP Percent: +20, Hot Spell Damage: +25, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	miniature flavorless red soybean futures	2	decent	Last Available: "2026-08"
@@ -12048,11 +12048,11 @@
 12298	tumbling foul-smelling financial instrument of the boozehound	0		Stench Damage: +10, Booze Drop: +100, Last Available: "2026-08"
 12299	spinning cool hedge fund clippers of the brazier	0		Moxie: +5, Hot Spell Damage: +25, Last Available: "2026-08"
 12300	MacGyver's selling shorts	0		Maximum MP: +100, Last Available: "2026-08"
-12301	blurry skewed bear tattoo	0		Last Available: "2026-08"
+12301	skewed blurry bear tattoo	0		Last Available: "2026-08"
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	yellow stiffened occult 401k ring	0		Spell Damage Percent: +25, Damage Reduction: 1, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
-12305	liquefied twirling huge lime green invisible hand	0		Effect: "Techno Bliss", Effect Duration: 53, Last Available: "2026-08"
+12305	liquefied twirling lime green huge invisible hand	0		Effect: "Techno Bliss", Effect Duration: 53, Last Available: "2026-08"
 12306	ionized extra-frozen squat circle of overdraft protection scroll	0		Effect: "Crocodile Tear", Effect Duration: 33, Last Available: "2026-08"
 12307	moist liquefied blurry mint	0		Effect: "All Blued Up", Effect Duration: 27, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Accordion_Thief_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Marmot_cafe_booze.txt
@@ -2,21 +2,21 @@
 -2	watered-down lousy Scrawny Stout	2	decent	
 -3	artisanal jittery Infinitesimal IPA	3	EPIC	
 -4	practically non-alcoholic tolerable eggnogtini	1	good	
--5	tolerable weak candycaine	2	good	
+-5	weak tolerable candycaine	2	good	
 -6	perfectly mixed braincracker sweet	3	EPIC	
 -16	perfectly mixed fermented honey	4	EPIC	
 -17	mediocre moons-shine	3	decent	
 -18	bad gin	4	decent	
 -19	lousy ecto-nog	3	decent	
 -20	acceptable huge mirror hot toady	4	good	
--21	distilled acceptable hot choculate	5	good	
+-21	acceptable distilled hot choculate	5	good	
 -49	bad Cyder	3	decent	
--50	high-proof drinkable Oil Nog	6	good	
+-50	drinkable high-proof Oil Nog	6	good	
 -51	high-proof artisanal Hi-Octane Peppermint Jet Fuel	8	EPIC	
 -58	bad Grimacider	4	decent	
--59	drinkable irresponsibly strong ghostly Isotope Nog	9	good	
--60	fortified aged Mutagin 'n' Tonic	5	awesome	
--70	enchanted high-proof drinkable wobbly tumbling Gin and Herring	9	good	
+-59	irresponsibly strong drinkable ghostly Isotope Nog	9	good	
+-60	aged fortified Mutagin 'n' Tonic	5	awesome	
+-70	high-proof drinkable enchanted tumbling wobbly Gin and Herring	9	good	
 -71	watered-down artisanal pulsating Black and Tan and Red All Over	2	EPIC	
 -72	smooth Antarctic Ice Tea	3	awesome	
 -76	bad CRIMBCO Ribbon Candy Schnapps	3	decent	
@@ -27,7 +27,7 @@
 -84	artisanal twirling Desert Island Iced Tea	3	EPIC	
 -88	mediocre purple Crimbo Saketini	4	decent	
 -89	practically non-alcoholic delicious Crimboku Drop	1	awesome	
--90	mediocre watered-down special Flaming Crimbo Log	2	decent	
+-90	watered-down special mediocre Flaming Crimbo Log	2	decent	
 -107	smooth Fortified Eggnog Slurry	3	awesome	
 -108	lousy Hot Buttered Rum	4	decent	
 -109	artisanal huge maroon Spicy Hot Chocolate	3	EPIC	

--- a/data/TCRS/TCRS_Accordion_Thief_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Marmot_cafe_food.txt
@@ -1,4 +1,4 @@
--1	diet spoiled Peche a la Frog	1	crappy	
+-1	spoiled diet Peche a la Frog	1	crappy	
 -2	half-sized spoiled As Jus Gezund Heit	2	crappy	
 -3	adequate jittery Bouillabaise Coucher Avec Moi	3	good	
 -7	tasty tiny mirror gumdrop chow mein	1	awesome	
@@ -6,20 +6,20 @@
 -9	half-sized spoiled gingerbread stir-fry	2	crappy	
 -10	normal ghostly twigs and gravel	3	good	
 -11	decent shoots and leaves	3	good	
--12	bite-sized normal wobbly bowl of unidentifiable goo	1	good	
+-12	normal bite-sized wobbly bowl of unidentifiable goo	1	good	
 -13	toothsome small gingerbread massacre	2	awesome	
 -14	miniature adequate blinking It Came From Beyond Dessert	2	good	
 -15	stale blurry vampire cake	4	decent	
 -52	tasty shaking Soylent Red and Green	4	awesome	
 -53	enchanted flavorless pulsating Disc-Shaped Nutrition Unit	3	decent	
--54	big spoiled Gingerborg Hive	5	crappy	
+-54	spoiled big Gingerborg Hive	5	crappy	
 -61	miniature stale Candy Cane Surprise	2	decent	
 -62	moldy skewed Grimdrop Chow Mein	3	crappy	
 -63	rotten small Grimgerbread House	2	crappy	
 -67	spoiled teal huge Caviar Carbonara	4	crappy	
 -68	flavorless Halibut Alfredo	3	decent	
--69	delicious blurry bouncing purple Red Herring Velvet Cake	3	awesome	
--73	massive bland skewed CRIMBCO Reconstituted Gruel	8	decent	
+-69	delicious bouncing purple blurry Red Herring Velvet Cake	3	awesome	
+-73	bland massive skewed CRIMBCO Reconstituted Gruel	8	decent	
 -74	rotten huge blinking New and Improved CRIMBCO Reconstituted Gruel	3	crappy	
 -75	super-sized toothsome cyan CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	awesome	
 -79	rotten half-sized Brussels Sprout Stir-Fry	2	crappy	
@@ -32,14 +32,14 @@
 -93	rotten savage macho dog	4	crappy	
 -94	small spoiled olive one with everything	2	crappy	
 -95	big bland bouncing sly dog	5	decent	
--96	decent half-sized devil dog	2	good	
+-96	half-sized decent devil dog	2	good	
 -97	rotten blurry chilly dog	3	crappy	
 -98	decent ghost dog	4	good	
 -99	bland junkyard dog	3	decent	
 -100	flavorless wet dog	4	decent	
--101	jumbo bland twirling sleeping dog	5	decent	
+-101	bland jumbo twirling sleeping dog	5	decent	
 -102	rotten skewed optimal dog	3	crappy	
 -103	tasty miniature huge video games hot dog	2	awesome	
 -104	flavorless Peppermint Nutrition Block	4	decent	
 -105	yummy diet Gingerbread Nutrition Block	1	awesome	
--106	bland special Cinnamon Nutrition Block	4	decent	
+-106	special bland Cinnamon Nutrition Block	4	decent	

--- a/data/TCRS/TCRS_Accordion_Thief_Mongoose.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Mongoose.txt
@@ -11,8 +11,8 @@
 11	fuchsia stolen accordion	0		Song Duration: 5
 12	mirror mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	denatured moxie weed	1		
-15	modified bouncing cyan strongness elixir	1		
-16	twisted huge mirror magicalness-in-a-can	1		
+15	modified cyan bouncing strongness elixir	1		
+16	twisted mirror huge magicalness-in-a-can	1		
 17	flavorless noodles	4	decent	
 18	twirling tortoise's blessing	0		
 19	stylish asparagus knife	0		Moxie: +25
@@ -24,7 +24,7 @@
 25	tumbling meat paste	0		
 26	Dolphin King's map	0		
 27	spider web	0		
-28	pulsating green really spider web	0		
+28	green pulsating really spider web	0		
 29	really really spider web	0		
 30	rock	0		
 31	seal-toothed rock	0		
@@ -57,7 +57,7 @@
 58	green skewed stone turtle	0		
 59	blurry slingshot	0		
 60	Mace of the Tortoise of the blizzard	0		Cold Spell Damage: +25, Class: "Turtle Tamer"
-61	immense moldy fortune cookie	7	crappy	
+61	moldy immense fortune cookie	7	crappy	
 62	oriole-feather headdress of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -70,15 +70,15 @@
 71	lime green stakes of doom	0		Spooky Spell Damage: +50
 72	narrow perfumed barskin hat	0		Stench Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 13"
 73	blurry barskin tent	0		
-74	jittery huge Temple map	0		
+74	huge jittery Temple map	0		
 75	purple sapling	0		
 76	cyan Spooky-Gro fertilizer	0		
 77	mirror blinking careful stick	0		Monster Level: -10
 78	olive greasy pretty bouquet	0		Sleaze Spell Damage: +10
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	spirit-forward acceptable twirling ice-cold Willer	5	good	
-82	narrow tumbling ring	0		
+81	acceptable spirit-forward twirling ice-cold Willer	5	good	
+82	tumbling narrow ring	0		
 83	shaft	0		
 84	narrow Orcish meat locker	0		
 85	unlocked meat locker	0		
@@ -161,7 +161,7 @@
 162	delicious miniature tumbling ghuol egg quiche	2	awesome	
 163	flame-wreathed skeleton bone	0		Hot Spell Damage: +10
 164	smart skull	0		
-165	tumbling gray skewer	0		
+165	gray tumbling skewer	0		
 166	ghuol ears	0		
 167	yummy pulsating huge ghuol-ear kabob	4	awesome	
 168	bone rattle of James Dean	0		Experience (Moxie): +3
@@ -175,8 +175,8 @@
 176	disembodied brain	0		
 177	mirror brainy skull	0		
 178	tumbling detective skull	0		
-179	tasty special shaking chorizo taco	3	awesome	Effect: "You Liver", Effect Duration: 30
-180	delicious practically non-alcoholic ice-cold fotie	1	awesome	
+179	special tasty shaking chorizo taco	3	awesome	Effect: "You Liver", Effect Duration: 30
+180	practically non-alcoholic delicious ice-cold fotie	1	awesome	
 181	tumbling baseball	0		
 182	batgut	0		
 183	bat wing	0		
@@ -201,7 +201,7 @@
 203	huge herbs	0		
 204	delicious big fuchsia carob chunk cookies	5	awesome	
 205	secret blend of herbs and spices	0		
-206	blue twirling piercing post	0		
+206	twirling blue piercing post	0		
 207	hippy herbal tea	1	decent	
 208	patchouli incense stick	0		
 209	tumbling wad of tofu	0		
@@ -211,8 +211,8 @@
 213	chilly filthy corduroys of extreme caution	0		Monster Level: -25, Cold Damage: +5, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	Rosewater's filthy knitted dread sack	0		Mysticality Percent: +30, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	blurry Uncle Jick's Brownie Mix	0		
-216	tiny enchanted rotten carob brownies	1	crappy	Effect: "Thunderspell", Effect Duration: 40
-217	snack-sized yummy herb brownies	2	awesome	
+216	tiny rotten enchanted carob brownies	1	crappy	Effect: "Thunderspell", Effect Duration: 40
+217	yummy snack-sized herb brownies	2	awesome	
 218	spinning hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -220,7 +220,7 @@
 222	narrow phat turquoise bead	0		
 223	Jeselnik's phat turquoise bracelet	0		Sleaze Damage: +25
 224	fuchsia eyepatch of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "3xBarrr, cap 6"
-225	gigantic stale tofu casserole	7	decent	
+225	stale gigantic tofu casserole	7	decent	
 226	altered can of Red Minotaur	1	good	
 227	censurious Kentucky-fried meat sword	0		Sleaze Resistance: +3
 228	deadly Kentucky-fried meat staff	0		Weapon Damage: +5
@@ -228,35 +228,35 @@
 230	perfumed dead guy's watch	0		Stench Resistance: +5, Single Equip
 231	Doc Galaktik's Pungent Unguent	0		
 232	Doc Galaktik's Ailment Ointment	0		
-233	wobbly mirror Doc Galaktik's Restorative Balm	0		
+233	mirror wobbly Doc Galaktik's Restorative Balm	0		
 234	jittery bouncing Doc Galaktik's Homeopathic Elixir	0		
 235	cyan hardened baleful Bigger Bugfinder Blade	0		Spell Damage: +25, Damage Reduction: 3
 236	maroon Queue Du Coq cocktailcrafting kit	0		
 237	bad practically non-alcoholic bottle of gin	1	decent	
-238	artisanal practically non-alcoholic bottle of vodka	1	EPIC	
+238	practically non-alcoholic artisanal bottle of vodka	1	EPIC	
 239	perfumed supercool Orcish baseball cap	0		Moxie Percent: +20, Stench Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	groovy Orcish cargo shorts of the early riser	0		Moxie Percent: +10, Adventures: +7, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	flame-wreathed Orcish frat-paddle	0		Hot Spell Damage: +10
-242	enchanted flavorless miniature	2	decent	Effect: "Dreadful Fear", Effect Duration: 30
+242	flavorless enchanted miniature	2	decent	Effect: "Dreadful Fear", Effect Duration: 30
 243	moldy massive grapefruit	8	crappy	
 244	tasty grapes	3	awesome	
 245	stale olive	3	decent	
 246	toothsome tomato	3	awesome	
 247	mirror fermenting powder	0		
 248	watered-down mediocre pulsating salty dog	2	decent	
-249	mediocre enchanted wobbly mirror lime green bloody mary	4	decent	Effect: "items.enh", Effect Duration: 30
-250	perfectly mixed weak screwdriver	2	EPIC	
-251	practically non-alcoholic tolerable squat martini	1	good	
+249	enchanted mediocre lime green wobbly mirror bloody mary	4	decent	Effect: "items.enh", Effect Duration: 30
+250	weak perfectly mixed screwdriver	2	EPIC	
+251	tolerable practically non-alcoholic squat martini	1	good	
 252	acceptable shaking bloody beer	4	good	
 253	tolerable shot of schnapps	3	good	
 254	bad fancy shot of grapefruit schnapps	3	decent	Effect: "Reedy Pipes", Effect Duration: 15
-255	smooth watered-down fine wine	2	awesome	
+255	watered-down smooth fine wine	2	awesome	
 256	perfectly mixed purple shot of tomato schnapps	3	EPIC	
 257	weak lousy extra-spicy bloody mary	2	decent	
 258	dense meat stack	0		
 259	blurry snake skin	0		
-260	small stale White Citadel fries	2	decent	
-261	half-sized toothsome skewed White Citadel burger	2	awesome	
+260	stale small White Citadel fries	2	decent	
+261	toothsome half-sized skewed White Citadel burger	2	awesome	
 262	low-calorie delicious olive piece of wedding cake	1	awesome	
 263	rotten chocolate chips	4	crappy	
 264	flavorless purple wobbly chocolate chip cookies	3	decent	
@@ -297,8 +297,8 @@
 299	wet pickle-flavored chewing gum	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 13
 300	dry quadruple-deionized skewed jaba&ntilde;ero-flavored chewing gum	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 13
 301	flat dough	0		
-302	miniature spoiled Knob sausage	2	crappy	
-303	miniature special bland Knob mushroom	2	decent	Effect: "Permanent Halloween", Effect Duration: 40
+302	spoiled miniature Knob sausage	2	crappy	
+303	special miniature bland Knob mushroom	2	decent	Effect: "Permanent Halloween", Effect Duration: 40
 304	dry noodles	0		
 305	upside-down mansplainer's Knob Goblin harem pants	0		Monster Level: +15, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	rosy-cheeked Knob Goblin harem veil	0		Maximum HP Percent: +30, Familiar Effect: "5xLep, cap 2"
@@ -309,12 +309,12 @@
 311	hill of beans	0		
 312	studded Knob Goblin visor	0		Damage Absorption: +80, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	careful Crown of the Goblin King	0		Monster Level: -10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	tasty thick skewed bean burrito	5	awesome	
+314	thick tasty skewed bean burrito	5	awesome	
 315	half-sized spoiled bean burrito	2	crappy	
 316	decent big insanely bean burrito	5	good	
-317	spoiled tiny bean burrito	1	crappy	
+317	tiny spoiled bean burrito	1	crappy	
 318	flavorless bean burrito	4	decent	
-319	low-calorie bland fuchsia insanely bean burrito	1	decent	
+319	bland low-calorie fuchsia insanely bean burrito	1	decent	
 320	tasty snack-sized bat haggis	2	awesome	
 321	bland menudo	3	decent	
 322	flavorless teal goat cheese	3	decent	
@@ -322,12 +322,12 @@
 324	flavorless half-sized sausage pizza	2	decent	
 325	delicious goat cheese pizza	3	awesome	
 326	huge yummy mushroom pizza	8	awesome	
-327	shaking green goat	0		
+327	green shaking goat	0		
 328	triple-distilled perfectly mixed mirror bottle of whiskey	10	EPIC	
 329	goat beard of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 15"
 330	teal glass of goat's milk	1	awesome	
-331	acceptable fancy Canadian	4	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 25
-332	rotten massive lemon	10	crappy	
+331	fancy acceptable Canadian	4	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 25
+332	massive rotten lemon	10	crappy	
 333	miniature moldy ghostly tumbling lime	2	crappy	
 334	sabre teeth of dire peril	0		Weapon Damage: +20
 335	wobbly sabre-toothed lime cub	0		
@@ -363,7 +363,7 @@
 365	lime green spinning chrome ore	0		
 366	linoleum sword hilt	0		
 367	linoleum stick	0		
-368	wobbly jittery linoleum crossbow string	0		
+368	jittery wobbly linoleum crossbow string	0		
 369	asbestos sword hilt	0		
 370	asbestos stick	0		
 371	blinking asbestos crossbow string	0		
@@ -402,7 +402,7 @@
 404	squat up-at-dawn acoustic guitarrr	0		Adventures: +5
 405	sunken chest	0		
 406	pirate pelvis	0		
-407	purple narrow pirate skull	0		
+407	narrow purple pirate skull	0		
 408	shaking pirate skeleton	0		
 409	blinking vial of patchouli oil	0		
 410	blurry manspreader's sk8board	0		Monster Level: +10
@@ -417,7 +417,7 @@
 419	liquefied ionized skewed fuchsia serum of sarcasm	0		Effect: "Sweetened and Fattened", Effect Duration: 45
 420	colloidal dry tumbling tomato juice of powerful power	0		Effect: "Full-Body Tan", Effect Duration: 49
 421	ionized philter of phorce	0		Effect: "Amplified Fabulousness", Effect Duration: 54
-422	aerosolized narrow gray potion of potency	0		Effect: "Oth-Jeal-O", Effect Duration: 61
+422	aerosolized gray narrow potion of potency	0		Effect: "Oth-Jeal-O", Effect Duration: 61
 423	modified cordial of concentration	0		Effect: "Nightstalkin'", Effect Duration: 42
 424	denatured ghostly ointment of the occult	0		Effect: "Ancient Protected", Effect Duration: 14
 425	denatured unsweetened oil of expertise	0		Effect: "Pyromania", Effect Duration: 17
@@ -432,7 +432,7 @@
 434	upside-down strapping balloon helmet	0		Muscle: +5, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	chilly balloon sword of the glutton	0		Cold Damage: +5, Food Drop: +100, Clowniness: 50
 436	skewed balloon monkey	0		
-437	purple blinking chef skull	0		
+437	blinking purple chef skull	0		
 438	narrow chef-in-the-box	0		
 439	squat bartender skull	0		
 440	bartender-in-the-box	0		
@@ -462,10 +462,10 @@
 464	huge pixel potion	0		
 465	green pixel potion	0		
 466	pixel potion	0		
-467	thick normal pixel pie	5	good	
+467	normal thick pixel pie	5	good	
 468	ruby W	0		
 469	wussiness potion	0		
-470	weak drinkable Imp Ale	2	good	
+470	drinkable weak Imp Ale	2	good	
 471	decent hot wing	4	good	
 472	teal toasty diamond-studded cane	0		Hot Damage: +5, Class: "Disco Bandit"
 473	frosty crutch	0		Cold Spell Damage: +10
@@ -496,12 +496,12 @@
 498	stale papaya	4	decent	
 499	ribald weightlifter's denim axe	0		Muscle: +15, Sleaze Damage: +10
 500	Elf Farm Raffle ticket	0		
-501	diet flavorless Elfin shortbread	1	decent	
+501	flavorless diet Elfin shortbread	1	decent	
 502	cyan pagoda plans	0		
-503	miniature flavorless maroon skewered cat appendix	2	decent	
-504	narrow bouncing evil arches	0		
+503	flavorless miniature maroon skewered cat appendix	2	decent	
+504	bouncing narrow evil arches	0		
 505	gray pulsating Sinatra's sage gnatwing earring	0		Mysticality Percent: +10, Experience (Moxie): +5
-506	bland jumbo Hell broth	5	decent	
+506	jumbo bland Hell broth	5	decent	
 507	careful thunderrr guitarrr	0		Monster Level: -10
 508	skewed purple sonata	0		
 509	Hey Deze nuts	0		
@@ -510,7 +510,7 @@
 512	Sneaky Pete's key lime	0		
 513	delicious Boris's key lime pie	4	awesome	
 514	rotten Jarlsberg's key lime pie	3	crappy	
-515	spoiled huge Sneaky Pete's key lime pie	8	crappy	
+515	huge spoiled Sneaky Pete's key lime pie	8	crappy	
 516	wobbly Hey Deze map	0		
 517	shaking executive bejeweled accordion strap	0		Meat Drop: +40, Class: "Accordion Thief"
 518	blinking skewed mystery juice	0		
@@ -519,10 +519,10 @@
 521	sizzling kickback cookbook	0		Hot Damage: +10
 522	teal one-winged stab bat	0		
 523	green rewinged stab bat	0		
-524	irresponsibly strong mediocre papaya sling	9	decent	
+524	mediocre irresponsibly strong papaya sling	9	decent	
 525	grue egg	0		
 526	lime green bouncing Frobozz Real-Estate Company Instant House (TM)	0		
-527	wobbly blinking volleyball	0		
+527	blinking wobbly volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
 530	altered teal spray paint	0		Effect: "Elemental Mastery", Effect Duration: 39
@@ -555,7 +555,7 @@
 557	mediocre whiskey and cola	3	decent	
 558	normal papaya taco	4	good	
 559	green razor-sharp can lid	0		
-560	low-calorie adequate enchanted shaking stalk of asparagus	1	good	Effect: "You're Not Cooking", Effect Duration: 50
+560	adequate enchanted low-calorie shaking stalk of asparagus	1	good	Effect: "You're Not Cooking", Effect Duration: 50
 561	blinking pregnant mushroom	0		
 562	ratgut	0		
 563	shaking sonar-in-a-biscuit	0		
@@ -563,13 +563,13 @@
 565	boxer's hobo gloves	0		Muscle Percent: +10, Single Equip
 566	perfumed bum cheek	0		Stench Resistance: +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	cyan hermit script	0		
-568	small yummy tumbling Double Bacon Beelzeburger	2	awesome	
+568	yummy small tumbling Double Bacon Beelzeburger	2	awesome	
 569	tasty bite-sized Lord of the Flies-sized fries	1	awesome	
-570	special rotten jittery Chicken Sandwich	4	crappy	Effect: "Norwhalloped", Effect Duration: 20
+570	rotten special jittery Chicken Sandwich	4	crappy	Effect: "Norwhalloped", Effect Duration: 20
 571	special Jumbo Dr. Lucifer	1	decent	Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 30
 572	moldy Children's Meal of the Damned	3	crappy	
 573	decent green noodles	3	good	
-574	small moldy noodles	2	crappy	
+574	moldy small noodles	2	crappy	
 575	adequate painful penne pasta	4	good	
 576	moldy narrow teal ravioli della hippy	3	crappy	
 577	moldy pr0n m4nic0tti	4	crappy	
@@ -577,14 +577,14 @@
 579	toothsome big boring spaghetti	5	awesome	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
-582	olive skewed Himalayan Hidalgo sauce	0		
-583	moldy super-sized skewed fettucini Inconnu	5	crappy	
+582	skewed olive Himalayan Hidalgo sauce	0		
+583	super-sized moldy skewed fettucini Inconnu	5	crappy	
 584	bland spaghetti with Skullheads	3	decent	
-585	immense decent gnocchetti di Nietzsche	7	good	
+585	decent immense gnocchetti di Nietzsche	7	good	
 586	energetic stiffened ridiculously huge sword	0		Damage Reduction: 1, Maximum MP Percent: +20
 587	double-deionized super-spiky hair gel	0		Effect: "The Dinsey Way", Effect Duration: 29
 588	olive soft echo eyedrop antidote	0		
-589	tiny bland ghostly cocoa eggshell fragment	1	decent	
+589	bland tiny ghostly cocoa eggshell fragment	1	decent	
 590	toothsome fancy cocoa eggshell fragment	4	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 25
 591	cocoa egg	0		
 592	house	0		
@@ -603,15 +603,15 @@
 605	pulsating Tissue Paper Immateria	0		
 606	Tin Foil Immateria	0		
 607	Gauze Immateria	0		
-608	squat gray Plastic Wrap Immateria	0		
+608	gray squat Plastic Wrap Immateria	0		
 609	mirror S.O.C.K.	0		
 610	skewed procrastination potion	0		
 611	squat D	0		
 612	original G	0		
 613	plot hole	0		
 614	chilled cyan probability potion	0		Effect: "Heart of Pink", Effect Duration: 26
-615	pulsating green chaos butterfly	0		
-616	maroon twirling furry fur	0		
+615	green pulsating chaos butterfly	0		
+616	twirling maroon furry fur	0		
 617	extra-activated Angry Farmer candy	0		Effect: "Bark of the Dog", Effect Duration: 68
 618	oxidized energized Mick's IcyVapoHotness Rub	0		Effect: "Mayeaugh", Effect Duration: 30
 619	bouncing perfumed needle	0		Stench Resistance: +5
@@ -623,7 +623,7 @@
 625	wang	0		
 626	jittery Wand of Nagamar	0		
 627	bouncing ND	0		
-628	cyan twirling blurry metallic A	0		
+628	blurry twirling cyan metallic A	0		
 629	frosty eye	0		Cold Spell Damage: +10
 630	photoprotoneutron torpedo	0		
 631	ghostly Temple Grandin's furry pants	0		Familiar Weight: +7, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
@@ -634,14 +634,14 @@
 636	meat globe	0		
 637	toaster	0		
 638	greedy asshat of incineration	0		Hot Spell Damage: +50, Meat Drop: +20, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	tiny adequate abominable snowcone	1	good	
+639	adequate tiny abominable snowcone	1	good	
 640	Ent cider	1	EPIC	
-641	delicious small toast	2	awesome	
+641	small delicious toast	2	awesome	
 642	skeleton key	0		
 643	blurry skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	tiny spoiled fruitcake	1	crappy	
+646	spoiled tiny fruitcake	1	crappy	
 647	present	0		Last Available: "2004-11"
 648	Crimbo sword of James Dean	0		Experience (Moxie): +3, Last Available: "2004-10"
 649	smooth Crimbo hat	0		Moxie: +15, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
@@ -674,8 +674,8 @@
 676	wobbly dragonbone belt buckle	0		
 677	shaking badass belt of the overflowing toilet	0		Stench Spell Damage: +50
 678	chest of the Bonerdagon	0		
-679	watered-down fancy perfectly mixed narrow roll in the hay	2	EPIC	Effect: "Antarctic Memories", Effect Duration: 5
-680	watered-down drinkable pulsating slap and tickle	2	good	
+679	perfectly mixed watered-down fancy narrow roll in the hay	2	EPIC	Effect: "Antarctic Memories", Effect Duration: 5
+680	drinkable watered-down pulsating slap and tickle	2	good	
 681	weak artisanal slip 'n' slide	2	EPIC	
 682	watered-down mediocre a sump'm sump'm	2	decent	
 683	artisanal horizontal tango	3	EPIC	
@@ -723,9 +723,9 @@
 727	upside-down skewed hedge maze puzzle	0		
 728	hedge maze key	0		
 729	red fishbowl	0		
-730	wobbly tumbling fishtank	0		
+730	tumbling wobbly fishtank	0		
 731	fish hose	0		
-732	blinking gray hosed tank	0		
+732	gray blinking hosed tank	0		
 733	hosed fishbowl	0		
 734	squat skewed hardy rock-hard hardened makeshift SCUBA gear	0		Damage Reduction: 16, Maximum HP: +50, Adventure Underwater
 735	pulsating upside-down mirror arcane researcher's easter egg balloon	0		Experience Percent (Mysticality): +10
@@ -736,7 +736,7 @@
 740	coward's tambourine	0		Monster Level: -20
 741	broken skull	0		
 742	flavorless Knoll shroomkabob	4	decent	
-743	special rotten snack-sized blue wobbly mushroom	2	crappy	Effect: "Mer-kinny Flavor", Effect Duration: 15
+743	snack-sized special rotten wobbly blue mushroom	2	crappy	Effect: "Mer-kinny Flavor", Effect Duration: 15
 744	cold-filtered hair spray	0		Effect: "Object Detection", Effect Duration: 38
 746	wobbly skewed stat script	0		
 747	Knob Goblin firecracker	0		
@@ -745,10 +745,10 @@
 750	flavorless lime green mushroom quesadilla	4	decent	
 751	rotten cool mushroom	3	crappy	
 752	delicious gigantic cool mushroom casserole	6	awesome	
-753	spoiled diet pointy mushroom	1	crappy	
+753	diet spoiled pointy mushroom	1	crappy	
 754	bland cream of pointy mushroom soup	3	decent	
 755	big moldy mushroom	5	crappy	
-756	huge toothsome mushroom	6	awesome	
+756	toothsome huge mushroom	6	awesome	
 757	stale purple mushroom	4	decent	
 758	half-sized spoiled bouncing ghost cucumber	2	crappy	
 759	squat dill	0		
@@ -776,13 +776,13 @@
 781	magnetized mafia aria	0		Effect: "Orc Chops", Effect Duration: 48
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	irresponsibly strong special bad Acqua Del Piatto Merlot	9	decent	Effect: "Healthy Green Glow", Effect Duration: 5, Last Available: "2004-10"
-785	blue mirror raffle ticket	0		
+784	special bad irresponsibly strong Acqua Del Piatto Merlot	9	decent	Effect: "Healthy Green Glow", Effect Duration: 5, Last Available: "2004-10"
+785	mirror blue raffle ticket	0		
 786	spoiled snack-sized strawberry	2	crappy	
 787	bad irresponsibly strong jittery bottle of rum	10	decent	
 788	hand-crafted strawberry daiquiri	3	EPIC	
-789	mediocre weak rum and cola	2	decent	
-790	distilled aged grog	5	awesome	
+789	weak mediocre rum and cola	2	decent	
+790	aged distilled grog	5	awesome	
 791	Mafia bow tie of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100, Last Available: "2004-10"
 792	Golden Mr. Accessory of the bloodbag	0		Maximum HP: +100, Softcore Only
 793	colloidal oil of stability	0		Effect: "Polka of Plenty", Effect Duration: 48
@@ -792,21 +792,21 @@
 797	drinkable rockin' wagon	3	good	
 798	tolerable ocean motion	4	good	
 799	lousy pulsating fuzzbump	4	decent	
-800	low-calorie adequate pulsating poutine	1	good	
+800	adequate low-calorie pulsating poutine	1	good	
 801	moldy spinning Knob stir-fry	3	crappy	
 804	bland twirling Knoll stir-fry	4	decent	
-805	jumbo toothsome stir-fry	5	awesome	
+805	toothsome jumbo stir-fry	5	awesome	
 806	rotten miniature asparagus stir-fry	2	crappy	
 807	immense decent olive olive stir-fry	9	good	
-808	special stale Knob sausage stir-fry	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 5
-809	snack-sized stale bat wing stir-fry	2	decent	
+808	stale special Knob sausage stir-fry	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 5
+809	stale snack-sized bat wing stir-fry	2	decent	
 810	enchanted toothsome rat appendix stir-fry	3	awesome	Effect: "Dexteri Tea", Effect Duration: 20
-811	rotten big skewed tofu stir-fry	5	crappy	
+811	big rotten skewed tofu stir-fry	5	crappy	
 812	bland pr0n stir-fry	4	decent	
-813	moldy bite-sized Knob shells	1	crappy	
+813	bite-sized moldy Knob shells	1	crappy	
 814	bland big wobbly b&auml;tzle	5	decent	
-815	stale wobbly bouncing ratini	3	decent	
-816	rotten small Knob stroganoff	2	crappy	
+815	stale bouncing wobbly ratini	3	decent	
+816	small rotten Knob stroganoff	2	crappy	
 817	stale menudo ravioli	4	decent	
 818	plus sign	0		
 819	milky potion	0		
@@ -826,15 +826,15 @@
 833	vorpal blade of the blizzard	0		Cold Spell Damage: +25
 834	upside-down electrified steel-toed cornuthaum	0		Damage Reduction: 9, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	yellow curative ring of aggravate monster	0		HP Regen Min: 3, HP Regen Max: 5
-836	flavorless gigantic narrow mind flayer corpse	8	decent	
+836	gigantic flavorless narrow mind flayer corpse	8	decent	
 837	delicious Uovo Marcio Shiraz	3	awesome	Last Available: "2004-10"
 838	blue curative beefcake's Mafia stogie	0		Muscle: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10"
 839	smooth irresponsibly strong Maiali Sifilitici Pinot Noir	10	awesome	Last Available: "2004-10"
 840	green auspicious rock-hard Mafia violin case	0		Damage Reduction: 5, Item Drop: +10, Last Available: "2004-10"
 841	hand-crafted special tomato daiquiri	3	EPIC	Effect: "Pumped Stomach", Effect Duration: 45
 842	artisanal olive beertini	3	EPIC	
-843	irresponsibly strong hand-crafted salty slug	10	EPIC	
-844	weak enchanted lousy papaya slung	2	decent	Effect: "Net Tea", Effect Duration: 50
+843	hand-crafted irresponsibly strong salty slug	10	EPIC	
+844	weak lousy enchanted papaya slung	2	decent	Effect: "Net Tea", Effect Duration: 50
 845	grievous MAHI fez	0		Weapon Damage Percent: +50, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	upside-down lime green hypodermic needle	0		Familiar Weight: +5
@@ -852,7 +852,7 @@
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
 862	magnifying glass	0		Familiar Weight: +5
-863	tumbling huge ghostly skewer-mounted razor blade	0		Familiar Weight: +5
+863	huge tumbling ghostly skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
@@ -891,7 +891,7 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	twirling espresso maker	0		Familiar Weight: +5
 902	twirling 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	perfectly mixed weak enchanted Spasmi Dolorosi Del Rene Champagne	2	super ultra mega EPIC	Effect: "Litterboxing", Effect Duration: 10, Last Available: "2004-10"
+903	perfectly mixed enchanted weak Spasmi Dolorosi Del Rene Champagne	2	super ultra mega EPIC	Effect: "Litterboxing", Effect Duration: 10, Last Available: "2004-10"
 904	spinning greedy sage school Mafia knickerbockers of bravery	0		Mysticality Percent: +10, Spooky Resistance: +5, Meat Drop: +20, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	ionized blinking Yummy Tummy bean	0		Effect: "Toothy Grin", Effect Duration: 23
 906	dry electrified Rock Pops	0		Effect: "Disdain of the War Snapper", Effect Duration: 58
@@ -946,7 +946,7 @@
 956	super-sized bland carob chunk noodles	5	decent	
 957	yummy chorizo brownies	4	awesome	
 958	normal blurry chocolate and tomato pizza	3	good	
-959	tumbling blue flange	0		
+959	blue tumbling flange	0		
 960	squat clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
 962	velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -993,21 +993,21 @@
 1006	toothsome cherry	3	awesome	
 1007	jittery prompt coconut shell	0		Adventures: +3, Familiar Effect: "1xFairy, cap 7"
 1008	narrow hale ice cubes	0		Maximum HP: +20
-1009	hand-crafted spirit-forward upside-down vodka martini	5	EPIC	
+1009	spirit-forward hand-crafted upside-down vodka martini	5	EPIC	
 1010	drinkable watered-down whiskey and soda	2	good	
 1011	acceptable blue monkey wrench	3	good	
-1012	hand-crafted weak tequila sunrise	2	EPIC	
+1012	weak hand-crafted tequila sunrise	2	EPIC	
 1013	bad fortified margarita	5	decent	
 1014	acceptable strawberry wine	4	good	
 1015	artisanal watered-down wine spritzer	2	EPIC	
 1016	drinkable perpendicular hula	3	good	
-1017	mediocre watered-down bouncing lime green ducha de oro	2	decent	
+1017	watered-down mediocre bouncing lime green ducha de oro	2	decent	
 1018	hand-crafted calle de miel	3	EPIC	
 1019	delicious dry vodka martini	4	awesome	
 1020	enchanted artisanal old-fashioned	4	EPIC	Effect: "Cold Throat", Effect Duration: 30
 1021	boozy lousy tequila with training wheels	5	decent	
 1022	acceptable sangria	4	good	
-1023	acceptable weak vesper	2	good	Last Available: "2004-12"
+1023	weak acceptable vesper	2	good	Last Available: "2004-12"
 1024	delicious bodyslam	3	awesome	Last Available: "2004-12"
 1025	mediocre fancy sangria del diablo	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 30, Last Available: "2004-12"
 1026	fuchsia Valentine	0		Free Pull
@@ -1024,7 +1024,7 @@
 1037	gnauga hide buckler of the storm	0		Maximum MP Percent: +40, Damage Reduction: 5
 1038	irradiated gray Connery's Elixir of Audacity	0		Effect: "Phoenix, Right?", Effect Duration: 32
 1040	twirling squat Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	weak acceptable beer	2	good	
+1041	acceptable weak beer	2	good	
 1042	ghostly smartaleck's string of beads	0		Moxie Percent: +30
 1043	chaotic string of beads	0		Spell Critical Percent: +10
 1044	pulsating greedy string of beads	0		Meat Drop: +20
@@ -1043,7 +1043,7 @@
 1057	mixed puce oyster egg	1		
 1058	denatured puce oyster egg	1		
 1059	puce plastic oyster egg	0		
-1060	pickled ghostly green mauve oyster egg	1		Effect: "Prince of Seaside Town", Effect Duration: 20
+1060	pickled green ghostly mauve oyster egg	1		Effect: "Prince of Seaside Town", Effect Duration: 20
 1061	distilled mauve oyster egg	1		
 1062	pickled mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
@@ -1052,9 +1052,9 @@
 1066	compressed twirling oyster egg	1		Effect: "Protection from Bad Stuff", Effect Duration: 35
 1067	plastic oyster egg	0		
 1068	diluted oyster egg	1		
-1069	denatured twirling blurry oyster egg	1		Effect: "stats.enq", Effect Duration: 20
-1070	mixed maroon blinking oyster egg	1		
-1071	wobbly lime green plastic oyster egg	0		
+1069	denatured blurry twirling oyster egg	1		Effect: "stats.enq", Effect Duration: 20
+1070	mixed blinking maroon oyster egg	1		
+1071	lime green wobbly plastic oyster egg	0		
 1072	mixed off-white oyster egg	1		
 1073	pickled off-white oyster egg	1		Effect: "Eagle Eyes", Effect Duration: 20
 1074	pickled green tumbling off-white oyster egg	1		Effect: "Ginger Snapped", Effect Duration: 10
@@ -1067,7 +1067,7 @@
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
-1084	blue narrow rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
+1084	narrow blue rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	clockwork widget	0		
 1086	clockwork thingamajig	0		
 1087	upside-down clockwork doohickey	0		
@@ -1075,7 +1075,7 @@
 1089	cyan clockwork spine	0		
 1090	clockwork rings	0		
 1091	mirror clockwork claws	0		
-1092	yellow ghostly clockwork sheet	0		
+1092	ghostly yellow clockwork sheet	0		
 1093	tumbling clockwork counterclockwise dome	0		
 1094	squat clockwork sphere	0		
 1095	narrow blinking deactivated MicroMechaMech	0		
@@ -1129,14 +1129,14 @@
 1143	smooth flat mushroom wine	3	awesome	
 1144	acceptable fortified cool mushroom wine	5	good	
 1145	mediocre knob mushroom wine	3	decent	
-1146	practically non-alcoholic mediocre squat bouncing knoll mushroom wine	1	decent	
+1146	practically non-alcoholic mediocre bouncing squat knoll mushroom wine	1	decent	
 1147	lousy mushroom wine	3	decent	
-1148	acceptable weak fancy fuchsia shot of flower schnapps	2	good	Effect: "Super Speed", Effect Duration: 10
+1148	fancy weak acceptable fuchsia shot of flower schnapps	2	good	Effect: "Super Speed", Effect Duration: 10
 1149	delicious flower petal pie	3	awesome	
 1150	drinkable bottle of single-barrel whiskey	3	good	
 1151	olive avaricious discarded plastic fork of the boozehound	0		Meat Drop: +30, Booze Drop: +100
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	massive spoiled Retenez L'Herbe Pat&eacute;	6	crappy	
+1153	spoiled massive Retenez L'Herbe Pat&eacute;	6	crappy	
 1154	altered fuchsia Breathetastic&trade; Premium Canned Air	1	decent	Effect: "Okee-Dokee, Smokee", Effect Duration: 30
 1155	letter from King Ralph XI	0		
 1157	wholeberd of Flo-Jo	0		Initiative: +100
@@ -1145,14 +1145,14 @@
 1160	blue pulsating savvy irate sombrero	0		Mysticality Percent: +20, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
 1162	pickled handsomeness potion	0		Effect: "Earthen Fist", Effect Duration: 38
-1163	unsweetened mirror gray marzipan skull	0		Effect: "Smoking like a Bandit", Effect Duration: 67
+1163	unsweetened gray mirror marzipan skull	0		Effect: "Smoking like a Bandit", Effect Duration: 67
 1164	poultrygeist	0		
 1165	hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
-1170	maroon twirling chocolate box	0		
+1170	twirling maroon chocolate box	0		
 1171	coffin	0		
 1172	asbestos box	0		
 1173	linoleum box	0		
@@ -1161,7 +1161,7 @@
 1176	refrigerated biohazard container	0		
 1177	magnetic field	0		
 1178	purple potted cactus	0		
-1179	gray twirling bouncing daisy	0		
+1179	bouncing gray twirling daisy	0		
 1180	twirling potted fern	0		
 1181	tulip	0		
 1182	Venus flytrap	0		
@@ -1185,18 +1185,18 @@
 1200	tiny moldy mugcake	1	crappy	
 1201	normal urinal cake	3	good	
 1202	stale Happy Birthday, Claude! cake	3	decent	
-1203	toothsome tiny shaking personalized birthday cake	1	awesome	
+1203	tiny toothsome shaking personalized birthday cake	1	awesome	
 1204	low-calorie bland three-tiered wedding cake	1	decent	
 1205	adequate babycakes	4	good	
 1206	delicious jittery velvet cake	3	awesome	
-1207	flavorless half-sized tumbling ghostly congratulatory cake	2	decent	
+1207	half-sized flavorless ghostly tumbling congratulatory cake	2	decent	
 1208	spoiled angel-food cake	3	crappy	
 1209	decent wobbly devil's-food cake	4	good	
 1210	stale birthday party jellybean cheesecake	4	decent	
 1211	jittery balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
-1214	narrow wobbly anniversary balloon	0		
+1214	wobbly narrow anniversary balloon	0		
 1215	Mylar balloon	0		
 1216	upside-down blurry Kevlar balloon	0		
 1217	squat twirling thought balloon	0		
@@ -1228,16 +1228,16 @@
 1244	spinning maroon rock-hard Glass Balls of the Goblin King	0		Damage Reduction: 5
 1245	baleful Codpiece of the Goblin King	0		Spell Damage: +25, Single Equip
 1246	zippy nippy stylish rib of the Bonerdagon	0		Moxie: +25, Cold Damage: +10, Initiative: +20
-1247	pulsating bouncing vertebra of the Bonerdagon	0		
+1247	bouncing pulsating vertebra of the Bonerdagon	0		
 1248	up-at-dawn extremely unsafe Bonerdagon necklace of the empath	0		Weapon Damage Percent: +100, Familiar Weight: +5, Adventures: +5
 1249	Boss Bat britches of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	curative Boss Bat bling of the businessman	0		Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5
-1251	half-sized spoiled gray Knob shroomkabob	2	crappy	
-1252	spoiled snack-sized shroomkabob	2	crappy	
+1251	spoiled half-sized gray Knob shroomkabob	2	crappy	
+1252	snack-sized spoiled shroomkabob	2	crappy	
 1253	pile of jumping beans	0		
 1254	special adequate blinking jumping bean burrito	4	good	Effect: "Burning Ears", Effect Duration: 20
-1255	half-sized bland jumping bean burrito	2	decent	
-1256	special toothsome half-sized narrow olive insanely jumping bean burrito	2	awesome	Effect: "Going Ape", Effect Duration: 25
+1255	bland half-sized jumping bean burrito	2	decent	
+1256	special half-sized toothsome narrow olive insanely jumping bean burrito	2	awesome	Effect: "Going Ape", Effect Duration: 25
 1257	rotten diet rat scrapple	1	crappy	
 1258	bouncing pail of pretentious paint	0		
 1259	shaking dog trainer's traffic cone of Flo-Jo	0		Experience (familiar): +1, Initiative: +100, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
@@ -1255,7 +1255,7 @@
 1271	skewed aluminum wand	0		
 1272	marble wand	0		
 1273	forbidden magic lamp	0		Spell Damage Percent: +50
-1274	modified twirling jittery Medicinal Herb's medicinal herbs	1		
+1274	modified jittery twirling Medicinal Herb's medicinal herbs	1		
 1275	censurious basic meat skirt	0		Sleaze Resistance: +3, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	hand-crafted Otorian Battle Scar	3	EPIC	
 1277	bouncing frightening basic meat kilt	0		Spooky Damage: +5, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1332,21 +1332,21 @@
 1349	skewed miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	shellacked pinky ring	0		Damage Reduction: 7, Single Equip
-1352	weak hand-crafted special shaking redrum	2	EPIC	Effect: "Locks Like the Raven", Effect Duration: 50
+1352	hand-crafted weak special shaking redrum	2	EPIC	Effect: "Locks Like the Raven", Effect Duration: 50
 1353	narrow ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	huge rotten bowl of oriole's nest soup	6	crappy	
+1355	rotten huge bowl of oriole's nest soup	6	crappy	
 1356	bunny liver	0		
-1357	fancy triple-distilled perfectly mixed ghostly wobbly Mt. Noob Pale Ale	8	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 50
+1357	triple-distilled fancy perfectly mixed wobbly ghostly Mt. Noob Pale Ale	8	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 50
 1358	pirate zombie head	0		Last Available: "2005-11"
-1359	fuchsia spinning ninja pirate zombie robot head	0		Last Available: "2005-11"
+1359	spinning fuchsia ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	weightlifter's disembodied smile	0		Muscle: +15, Single Equip
 1362	cyan sausage	0		
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	delicious tiny tofurkey leg	1	awesome	
-1366	normal diet tofurkey gravy	1	good	
+1365	tiny delicious tofurkey leg	1	awesome	
+1366	diet normal tofurkey gravy	1	good	
 1367	flavorless snack-sized herbal stuffing	2	decent	
 1368	decent tumbling can-shaped gelatinous cranberry sauce	4	good	
 1369	bland mirror yams	3	decent	
@@ -1386,7 +1386,7 @@
 1404	yellow strapping colored-light &quot;necklace&quot;	0		Muscle: +5, Last Available: "2005-12"
 1405	tree skirt of Flo-Jo	0		Initiative: +100, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	bland twirling wreath-shaped Crimbo cookie	4	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	adequate small enchanted bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	adequate enchanted small bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	toothsome narrow tree-shaped Crimbo cookie	3	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of the businessman	0		Meat Drop: +50, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
@@ -1394,11 +1394,11 @@
 1412	electrified moist unsweetened blinking snowcone	0		Effect: "Kernel Panic!", Effect Duration: 12, Last Available: "2006-01"
 1413	galvanized extra-boiled snowcone	0		Effect: "Ooh, Sweet!", Effect Duration: 13, Last Available: "2006-01"
 1414	irradiated shaking snowcone	0		Effect: "Larger", Effect Duration: 40, Last Available: "2006-01"
-1415	activated upside-down shaking snowcone	0		Effect: "Chief Executive Optimism", Effect Duration: 49, Last Available: "2006-01"
+1415	activated shaking upside-down snowcone	0		Effect: "Chief Executive Optimism", Effect Duration: 49, Last Available: "2006-01"
 1416	magnetized alkaline snowcone	0		Effect: "Berry Berry Cold", Effect Duration: 58, Last Available: "2006-01"
 1417	galvanized fuchsia snowcone	0		Effect: "Chief Executive Optimism", Effect Duration: 65, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
-1419	ghostly spinning teddy bear sewing kit	0		Last Available: "2006-01"
+1419	spinning ghostly teddy bear sewing kit	0		Last Available: "2006-01"
 1420	maroon flame-wreathed traffic cone of courage	0		Hot Spell Damage: +10, Spooky Resistance: +3, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	mirror Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	tumbling Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
@@ -1411,7 +1411,7 @@
 1429	spinning blinking roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	huge pregnant mushroom	0		
-1432	decent huge purple mushroom	3	good	
+1432	decent purple huge mushroom	3	good	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	narrow hot pink lipstick	0		Familiar Weight: +5
@@ -1437,7 +1437,7 @@
 1455	boiled blurry sleaze wad	1		
 1456	double daisy	0		
 1457	pulsating Goth Giant	0		
-1458	normal jumbo wobbly Valentine's Day cake	5	good	
+1458	jumbo normal wobbly Valentine's Day cake	5	good	
 1459	huge arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1473,9 +1473,9 @@
 1491	mirror knitted rice bowl	0		Cold Resistance: +3
 1492	ninja mop of Leguizamo	0		Monster Level: +20
 1493	foul-smelling ridiculously overelaborate ninja weapon of the glutton	0		Stench Damage: +10, Food Drop: +100
-1494	colloidal blinking upside-down sugar-coated pine cone	0		Effect: "Provocative Perkiness", Effect Duration: 50, Last Available: "2020-09"
+1494	colloidal upside-down blinking sugar-coated pine cone	0		Effect: "Provocative Perkiness", Effect Duration: 50, Last Available: "2020-09"
 1495	huge traffic cone of the empath of the businessman	0		Familiar Weight: +5, Meat Drop: +50, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	lousy special extra-dry blue gloomy mushroom wine	5	decent	Effect: "Tapped In", Effect Duration: 30
+1496	special extra-dry lousy blue gloomy mushroom wine	5	decent	Effect: "Tapped In", Effect Duration: 30
 1497	perfectly mixed mushroom wine	4	EPIC	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	mirror teal whoopie cushion	0		Last Available: "2006-04"
@@ -1486,7 +1486,7 @@
 1504	colloidal blinking snowcone	0		Effect: "Hiding in Plain Sight", Effect Duration: 41, Last Available: "2006-04"
 1505	twirling ice cube with a fly in it	0		Last Available: "2006-04"
 1506	lousy practically non-alcoholic bouncing calle de miel with a fly in it	1	decent	Last Available: "2006-04"
-1507	aged watered-down rockin' wagon with a fly in it	2	awesome	Last Available: "2006-04"
+1507	watered-down aged rockin' wagon with a fly in it	2	awesome	Last Available: "2006-04"
 1508	mediocre jittery perpendicular hula with a fly in it	3	decent	Last Available: "2006-04"
 1509	bad watered-down slap and tickle with a fly in it	2	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
@@ -1495,7 +1495,7 @@
 1513	dried huge Knob Goblin learning pill	1		Effect: "Sweet Taste", Effect Duration: 35
 1514	modified skewed Knob Goblin eyedrops	1		
 1515	twisted Knob Goblin nasal spray	1		
-1516	narrow teal KWE-brand transistor radio	0		
+1516	teal narrow KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	yellow wobbly Rosewater's Radio KoL Coffee Mug of the bloodbag	0		Mysticality Percent: +30, Maximum HP: +100
@@ -1508,7 +1508,7 @@
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Samson's corkscrew of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Last Available: "2006-04"
 1529	skewed St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
-1530	shaking wobbly fake plastic grass	0		Last Available: "2011-01"
+1530	wobbly shaking fake plastic grass	0		Last Available: "2011-01"
 1531	blurry Socratic grass skirt	0		Experience (Mysticality): +1, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
 1532	bouncing experienced grass hat	0		Experience: +2, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	blue twirling nippy grass blade	0		Cold Damage: +10, Last Available: "2011-01"
@@ -1533,57 +1533,57 @@
 1553	acceptable bottle of Calcutta Emerald	4	good	
 1554	lousy weak bottle of Lieutenant Freeman	2	decent	
 1555	practically non-alcoholic smooth tumbling bottle of Jorge Sinsonte	1	awesome	
-1556	weak hand-crafted purple boxed champagne	2	EPIC	
+1556	hand-crafted weak purple boxed champagne	2	EPIC	
 1557	spoiled kumquat	3	crappy	
-1558	jumbo special spoiled tangerine	5	crappy	Effect: "Spookyravin'", Effect Duration: 5
+1558	special jumbo spoiled tangerine	5	crappy	Effect: "Spookyravin'", Effect Duration: 5
 1559	squat tonic water	0		
-1560	low-calorie toothsome cocktail onion	1	awesome	
+1560	toothsome low-calorie cocktail onion	1	awesome	
 1561	normal raspberry	4	good	
 1562	bland kiwi	4	decent	
-1563	hand-crafted practically non-alcoholic whiskey bittersweet	1	super EPIC	
-1564	weak drinkable wobbly mimosette	2	good	
+1563	practically non-alcoholic hand-crafted whiskey bittersweet	1	super EPIC	
+1564	drinkable weak wobbly mimosette	2	good	
 1565	irresponsibly strong mediocre tequila sunset	10	decent	
 1566	high-proof lousy shaking zmobie	6	decent	Wiki Name: "Zmobie (drink)"
 1567	practically non-alcoholic perfectly mixed gin and tonic	1	super EPIC	
-1568	strong tolerable vodka and tonic	5	good	
+1568	tolerable strong vodka and tonic	5	good	
 1569	lousy cyan vodka gibson	3	decent	
-1570	hand-crafted irresponsibly strong maroon gibson	7	EPIC	
-1571	hand-crafted watered-down parisian cathouse	2	EPIC	
+1570	irresponsibly strong hand-crafted maroon gibson	7	EPIC	
+1571	watered-down hand-crafted parisian cathouse	2	EPIC	
 1572	spirit-forward delicious rabbit punch	5	awesome	
 1573	practically non-alcoholic acceptable caipifruta	1	good	
 1574	drinkable teqiwila	4	good	
-1575	tolerable practically non-alcoholic maroon Divine	1	good	
-1576	acceptable high-proof upside-down purple Gordon Bennett	9	good	
+1575	practically non-alcoholic tolerable maroon Divine	1	good	
+1576	high-proof acceptable upside-down purple Gordon Bennett	9	good	
 1577	smooth tangarita	4	awesome	
 1578	mediocre mandarina colada	3	decent	
-1579	delicious weak yellow gimlet	2	awesome	
+1579	weak delicious yellow gimlet	2	awesome	
 1580	mediocre brick road	3	decent	
-1581	watered-down lousy upside-down vodka stratocaster	2	decent	
+1581	lousy watered-down upside-down vodka stratocaster	2	decent	
 1582	lousy Neuromancer	3	decent	
-1583	artisanal weak enchanted prussian cathouse	2	super ultra EPIC	Effect: "Took Eleven", Effect Duration: 30
+1583	enchanted artisanal weak prussian cathouse	2	super ultra EPIC	Effect: "Took Eleven", Effect Duration: 30
 1584	artisanal practically non-alcoholic Mae West	1	super ultra mega turbo EPIC	
 1585	drinkable fuchsia Mon Tiki	3	good	
 1586	acceptable teqiwila slammer	4	good	
-1587	moldy huge huge huge Knob lo mein	7	crappy	
+1587	huge moldy huge huge Knob lo mein	7	crappy	
 1588	decent asparagus lo mein	3	good	
 1589	massive decent Knoll lo mein	10	good	
 1590	spoiled diet yellow lo mein	1	crappy	
 1591	miniature adequate olive lo mein	2	good	
 1592	rotten upside-down hot hi mein	4	crappy	
-1593	gigantic flavorless hi mein	6	decent	
+1593	flavorless gigantic hi mein	6	decent	
 1594	spoiled hi mein	3	crappy	
 1595	moldy jittery hi mein	4	crappy	
 1596	decent miniature olive sleazy hi mein	2	good	
 1597	censurious Junior LAAAAME merit badge	0		Sleaze Resistance: +3, Last Available: "2006-05"
 1598	narrow ruddy Senior LAAAAME merit badge	0		Maximum HP Percent: +40, Last Available: "2006-05"
 1599	huge jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	high-proof fancy lousy bouncing tangarita with a fly in it	9	decent	Effect: "Neuromancy", Effect Duration: 5
+1600	fancy high-proof lousy bouncing tangarita with a fly in it	9	decent	Effect: "Neuromancy", Effect Duration: 5
 1601	perfectly mixed mandarina colada with a fly in it	3	EPIC	
 1602	practically non-alcoholic smooth wobbly prussian cathouse with a fly in it	1	awesome	
-1603	high-proof hand-crafted gray Mae West with a fly in it	9	EPIC	
+1603	hand-crafted high-proof gray Mae West with a fly in it	9	EPIC	
 1604	pickled jittery astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
-1606	altered shaking green ultimate wad	1		
+1606	altered green shaking ultimate wad	1		
 1607	electrified quantum alkaline ghostly libation of liveliness	0		Effect: "Drunk With Power", Effect Duration: 25
 1608	boiled quantum eyedrops of the ermine	0		Effect: "On a Roll", Effect Duration: 64
 1609	ionized cold-filtered gray perfume of prejudice	0		Effect: "Boo Tea", Effect Duration: 27
@@ -1597,7 +1597,7 @@
 1617	fortified Cerebral Crossbow of the blizzard of horror	0		Damage Absorption: +60, Cold Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
-1620	narrow bouncing homeopathic healing powder	0		Last Available: "2006-06"
+1620	bouncing narrow homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
 1622	aerosolized astral mushroom	0		Effect: "Sinuses For Miles", Effect Duration: 60, Last Available: "2006-06"
 1623	badger badge	0		Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	blinking beer cartilage	0		
 1632	gray Spanish fly trap	0		
 1633	Spanish fly	0		
-1634	watered-down hand-crafted around the world	2	EPIC	
+1634	hand-crafted watered-down around the world	2	EPIC	
 1635	skewed scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	oxidized colloidal maroon lotion of hotness	0		Effect: "All Branned Up", Effect Duration: 34
@@ -1620,7 +1620,7 @@
 1640	anodized diffused lotion of stench	0		Effect: "Feroci Tea", Effect Duration: 26
 1641	non-ionized fuchsia lotion of sleaziness	0		Effect: "Wreathed in Smoke", Effect Duration: 40
 1642	strong acceptable Grimacite Bock	5	good	Last Available: "2008-11"
-1643	enchanted moldy wedge of gray cheese	3	crappy	Effect: "Uncucumbered", Effect Duration: 40, Last Available: "2008-11"
+1643	moldy enchanted wedge of gray cheese	3	crappy	Effect: "Uncucumbered", Effect Duration: 40, Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	blurry and sauce	0		
 1646	and sauce	0		
@@ -1664,7 +1664,7 @@
 1684	red forbidden styrofoam sword of temperance	0		Spell Damage Percent: +50, Sleaze Resistance: +5
 1685	gray executive styrofoam staff of the pedagogue	0		Experience: +3, Meat Drop: +40
 1686	dance instructor's savvy styrofoam crossbow	0		Mysticality Percent: +20, Experience Percent (Moxie): +10
-1687	huge cyan Platinum Yendorian Express Card	0		
+1687	cyan huge Platinum Yendorian Express Card	0		
 1688	fireproof crossbow of temperance	0		Hot Resistance: +3, Sleaze Resistance: +5
 1689	Da Vinci's ribbon	0		Experience (Mysticality): +5, Last Available: "2006-07"
 1690	wool boxer's discarded bottlecap	0		Muscle Percent: +10, Cold Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 38"
@@ -1676,9 +1676,9 @@
 1696	spoiled blurry royal jelly taco	4	crappy	
 1697	decent narrow tofu taco	3	good	
 1698	flavorless blurry jumping bean taco	3	decent	
-1699	normal snack-sized huge red catgut taco	2	good	
+1699	normal snack-sized red huge catgut taco	2	good	
 1700	big bland squat goat cheese taco	5	decent	
-1701	moldy huge pr0n taco	8	crappy	
+1701	huge moldy pr0n taco	8	crappy	
 1702	aerosolized pressed yellow alphabet gum	0		Effect: "Tingly Elbows", Effect Duration: 28
 1703	Comma Chameleon egg	0		Free Pull
 1704	pulsating shingle	0		
@@ -1745,16 +1745,16 @@
 1766	Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	diet spoiled fricasseed brains	1	crappy	
-1770	half-sized fancy normal brains casserole	2	good	Effect: "Triangle, Man", Effect Duration: 35
+1769	spoiled diet fricasseed brains	1	crappy	
+1770	normal half-sized fancy brains casserole	2	good	Effect: "Triangle, Man", Effect Duration: 35
 1771	banded butcherknife	0		Damage Absorption: +100
 1772	narrow cool corn holder	0		Moxie: +5
 1773	cyan twirling eggbeater of the early riser	0		Adventures: +7
 1774	tolerable watered-down bottle of popskull	2	good	
 1775	prompt dishrag	0		Adventures: +3
-1776	tiny yummy stale baguette	1	awesome	
+1776	yummy tiny stale baguette	1	awesome	
 1777	fuchsia leftovers of indeterminate origin	0		
-1778	rotten jumbo dinner	5	crappy	
+1778	jumbo rotten dinner	5	crappy	
 1779	katana of the cheetah	0		Initiative: +60
 1780	frightening ram stick	0		Spooky Damage: +5
 1781	squat enchantlers of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1777,7 +1777,7 @@
 1798	pile of animal bones	0		
 1799	animal skull	0		
 1800	jittery animal cranium	0		
-1801	lime green jittery animal jawbone	0		
+1801	jittery lime green animal jawbone	0		
 1802	spinning first cervical vertebra	0		
 1803	squat second cervical vertebra	0		
 1804	red third cervical vertebra	0		
@@ -1804,7 +1804,7 @@
 1825	fifth lumbar vertebra	0		
 1826	sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
-1828	skewed lime green sacral vertebrae	0		
+1828	lime green skewed sacral vertebrae	0		
 1829	narrow first caudal vertebra	0		
 1830	lime green second caudal vertebra	0		
 1831	purple third caudal vertebra	0		
@@ -1815,7 +1815,7 @@
 1836	skewed bouncing eighth caudal vertebra	0		
 1837	ninth caudal vertebra	0		
 1838	tenth caudal vertebra	0		
-1839	yellow spinning left first rib	0		
+1839	spinning yellow left first rib	0		
 1840	left second rib	0		
 1841	left third rib	0		
 1842	left fourth rib	0		
@@ -1873,7 +1873,7 @@
 1894	left third rear claw	0		
 1895	left fourth rear claw	0		
 1896	right first rear claw	0		
-1897	skewed spinning right second rear claw	0		
+1897	spinning skewed right second rear claw	0		
 1898	right third rear claw	0		
 1899	fuchsia huge right fourth rear claw	0		
 1900	twirling horrifying 1-ball	0		Spooky Damage: +25
@@ -1928,7 +1928,7 @@
 1951	artisanal huge bottle of Pinot Renoir	4	EPIC	
 1952	delicious desiccated apricot	4	awesome	
 1953	tolerable spinning flute of flat champagne	3	good	
-1954	jumbo toothsome dehydrated caviar	5	awesome	
+1954	toothsome jumbo dehydrated caviar	5	awesome	
 1955	spinning styrofoam peanuts	0		
 1956	mediocre snifter of thoroughly aged brandy	4	decent	
 1957	quill pen	0		
@@ -1995,9 +1995,9 @@
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
 2020	delicious miniature cherry pie	2	awesome	
-2021	miniature normal ghostly blurry strawberry pie	2	good	
+2021	normal miniature ghostly blurry strawberry pie	2	good	
 2022	flavorless upside-down twirling lemon meringue pie	3	decent	
-2023	tumbling upside-down Genalen&trade; Bottle	1	EPIC	
+2023	upside-down tumbling Genalen&trade; Bottle	1	EPIC	
 2024	miniature rotten red blurry mixed wildflower greens	2	crappy	
 2025	rotten handful of walnuts	3	crappy	
 2026	rotten nutty organic salad	3	crappy	
@@ -2011,7 +2011,7 @@
 2034	beefcake's wicker shield	0		Muscle: +25, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
 2036	ionized blue radium-flavored potato chips	0		Effect: "Browbeaten", Effect Duration: 34
-2037	denatured spinning upside-down wintergreen-flavored potato chips	0		Effect: "Healthy Green Glow", Effect Duration: 20
+2037	denatured upside-down spinning wintergreen-flavored potato chips	0		Effect: "Healthy Green Glow", Effect Duration: 20
 2038	warmed electrified ennui-flavored potato chips	0		Effect: "Preemptive Medicine", Effect Duration: 12
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
@@ -2019,16 +2019,16 @@
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	twirling your father's MacGuffin diary	0		
-2045	tasty small brain-meltingly-hot chicken wings	2	awesome	
+2045	small tasty brain-meltingly-hot chicken wings	2	awesome	
 2046	low-calorie spoiled mirror frat brats	1	crappy	
-2047	bland super-sized knob ka-bobs	5	decent	
+2047	super-sized bland knob ka-bobs	5	decent	
 2049	perfectly mixed tumbling can of Swiller	3	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	lime green reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	spinning market map	0		
-2055	tumbling olive snake skin	0		
+2055	olive tumbling snake skin	0		
 2056	wet electrified adder bladder	0		Effect: "Inscrutable exoskeleton", Effect Duration: 16
 2057	yellow pension check	0		
 2058	blurry picnic basket	0		
@@ -2036,7 +2036,7 @@
 2060	toasty curative sword	0		Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5
 2061	stylish helmet	0		Moxie: +25, Familiar Effect: "1xFairy, cap 40"
 2062	groovy cool shield	0		Moxie: +5, Moxie Percent: +10, Damage Reduction: 10
-2063	moldy special snack-sized wobbly upside-down blackberry	2	crappy	Effect: "License to Punch", Effect Duration: 40
+2063	moldy snack-sized special upside-down wobbly blackberry	2	crappy	Effect: "License to Punch", Effect Duration: 40
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	censurious flame-wreathed kick-ass kicks	0		Hot Spell Damage: +10, Sleaze Resistance: +3, Single Equip
@@ -2060,7 +2060,7 @@
 2084	can of starch	0		
 2085	vaporized bottle of ultravitamins	1		
 2086	boiled wobbly bottle of cough syrup	1		
-2087	diluted cyan jittery narrow tube of hair oil	1		Effect: "For Your Brain Only", Effect Duration: 30
+2087	diluted jittery narrow cyan tube of hair oil	1		Effect: "For Your Brain Only", Effect Duration: 30
 2088	oxidized Daffy Taffy	0		Effect: "Peppermint Bite", Effect Duration: 63
 2089	ghostly Crimboween memo	0		Last Available: "2006-10"
 2090	upside-down chaotic crafty vibrating personal trainer's pilgrim shield of horror	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Maximum MP: +10, Spell Critical Percent: +10, Spooky Spell Damage: +25, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
@@ -2071,7 +2071,7 @@
 2095	towel	0		
 2096	denatured red wobbly guy made of bee pollen	1		
 2097	executive 17-ball	0		Meat Drop: +40
-2098	upside-down shaking filthy lucre	0		
+2098	shaking upside-down filthy lucre	0		
 2099	fuchsia hobo gristle	0		
 2100	shredded can label	0		
 2101	bloodstained briquette	0		
@@ -2120,8 +2120,8 @@
 2145	jittery stuffing	0		Last Available: "2011-12"
 2146	olive evil teddy bear	0		Last Available: "2006-12"
 2147	bouncing evil teddy bear sewing kit	0		
-2148	narrow green toothsome rock	0		
-2149	massive moldy blinking frank	9	crappy	Last Available: "2011-12"
+2148	green narrow toothsome rock	0		
+2149	moldy massive blinking frank	9	crappy	Last Available: "2011-12"
 2150	spoiled plate of franks and beans	3	crappy	Last Available: "2011-12"
 2151	aged shot of blackberry schnapps	3	awesome	
 2152	upside-down capacitor relay	0		Last Available: "2011-12"
@@ -2168,10 +2168,10 @@
 2193	moldy special candy stake	3	crappy	Effect: "Bolts about Candy", Effect Duration: 45, Last Available: "2006-12"
 2194	hand-crafted eggnog	4	EPIC	Last Available: "2006-12"
 2195	moldy unspeakable fruitcake	3	crappy	Last Available: "2006-12"
-2196	adequate low-calorie gingerbread horror	1	good	Last Available: "2006-12"
+2196	low-calorie adequate gingerbread horror	1	good	Last Available: "2006-12"
 2197	double-unsweetened warmed but probably evil chocolate	0		Effect: "Stickler for Promptness", Effect Duration: 57, Last Available: "2006-12"
 2198	flavorless bat-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	normal half-sized narrow skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2199	half-sized normal narrow skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	toothsome tombstone-shaped Crimboween cookie	4	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	wobbly plastic gift-wrapping vampire of dire peril	0		Weapon Damage: +20, Last Available: "2006-12"
 2202	supercool plastic yuletide troll	0		Moxie Percent: +20, Last Available: "2006-12"
@@ -2235,19 +2235,19 @@
 2261	ghostly hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	squat lion oil	0		
-2264	normal jumbo skewed mirror stunt nuts	5	good	
-2265	rotten thick enchanted red wet stew	5	crappy	Effect: "Square to be Hip", Effect Duration: 45
-2266	mirror jittery wet stunt nut stew	0		
+2264	normal jumbo mirror skewed stunt nuts	5	good	
+2265	thick enchanted rotten red wet stew	5	crappy	Effect: "Square to be Hip", Effect Duration: 45
+2266	jittery mirror wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	green Fonzie's Staff of Fats	0		Experience (Moxie): +1
 2269	rotten sausage wonton	3	crappy	
 2270	bouncing lion tamer's belt of the wise owl	0		Mysticality: +20, Experience (familiar): +2, Single Equip
-2271	bad weak bottle of Merlot	2	decent	
+2271	weak bad bottle of Merlot	2	decent	
 2272	perfectly mixed ghostly bottle of Port	3	EPIC	
 2273	drinkable blurry bottle of Pinot Noir	3	good	
 2274	perfectly mixed bottle of Zinfandel	3	EPIC	
-2275	weak mediocre bottle of Marsala	2	decent	
-2276	enchanted mediocre mirror blurry bottle of Muscat	4	decent	Effect: "Egged On", Effect Duration: 15
+2275	mediocre weak bottle of Marsala	2	decent	
+2276	mediocre enchanted blurry mirror bottle of Muscat	4	decent	Effect: "Egged On", Effect Duration: 15
 2277	fuchsia Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
 2279	book	0		
@@ -2305,16 +2305,16 @@
 2331	bouquet of circular saw blades	0		
 2332	toothsome half-sized narrow Better Than Cuddling Cake	2	awesome	
 2333	ninja snowman	0		
-2334	upside-down huge Holy MacGuffin	0		
+2334	huge upside-down Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
 2336	upside-down personal trainer's pipe of extreme caution	0		Experience Percent (Muscle): +10, Monster Level: -25
 2337	reinforced beaded headband of the cougar	0		Moxie: +20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	massive flavorless blurry huge pudding	7	decent	Wiki Name: "black pudding (food)"
-2339	artisanal practically non-alcoholic Blackfly Chardonnay	1	EPIC	
-2340	hand-crafted fancy & tan	3	EPIC	Effect: "Squatting and Thrusting", Effect Duration: 25
+2338	flavorless massive huge blurry pudding	7	decent	Wiki Name: "black pudding (food)"
+2339	practically non-alcoholic artisanal Blackfly Chardonnay	1	EPIC	
+2340	fancy hand-crafted & tan	3	EPIC	Effect: "Squatting and Thrusting", Effect Duration: 25
 2341	pepper	0		
 2342	bland forest cake	4	decent	
-2343	diet bland huge twirling forest ham	1	decent	
+2343	bland diet twirling huge forest ham	1	decent	
 2344	super-oxidized mirror filthworm hatchling scent gland	0		Effect: "Disco Nirvana", Effect Duration: 49
 2345	liquefied flattened gray filthworm drone scent gland	0		Effect: "It Didn't Kill You", Effect Duration: 15
 2346	flattened wet spinning filthworm royal guard scent gland	0		Effect: "Engorged Weapon", Effect Duration: 64
@@ -2344,7 +2344,7 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	jittery bunch of bananas	0		
-2373	big flavorless banana	5	decent	
+2373	flavorless big banana	5	decent	
 2374	banana peel	0		
 2375	adequate banana cream pie	3	good	
 2376	lousy irresponsibly strong banana daiquiri	10	decent	
@@ -2407,18 +2407,18 @@
 2433	pickled ghostly bottle of antifreeze	0		Effect: "Orchid Blood", Effect Duration: 27
 2434	extra-warmed dry pressed eyedrops	0		Effect: "Phoenix, Right?", Effect Duration: 41
 2435	Vulcanized gray Dogsgotnonoz pills	0		Effect: "Lobos Fresh", Effect Duration: 61
-2436	denatured wet dry fuchsia shaking shaking donkey flipbook	0		Effect: "stats.enq", Effect Duration: 14
+2436	denatured wet dry shaking fuchsia shaking donkey flipbook	0		Effect: "stats.enq", Effect Duration: 14
 2437	New Cloaca-Cola	0		
 2438	scented massage oil	0		
 2439	jittery poltergeist-in-the-jar-o	0		
 2440	yellow unnatural gas	0		
 2441	Knob Goblin Encryption Key	0		
-2442	blinking blurry Cobb's Knob map	0		
+2442	blurry blinking Cobb's Knob map	0		
 2443	ghostly pink glowstick of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10, Last Available: "2007-03"
 2444	tolerable Supernova Champagne	4	good	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	mirror hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
-2447	fuchsia skewed bad penguin egg	0		Free Pull
+2447	skewed fuchsia bad penguin egg	0		Free Pull
 2448	tasteful bow tie	0		Familiar Weight: +5
 2449	pulsating six-pack of New Cloaca-Cola	0		
 2450	huge empty Cloaca-Cola bottle	0		
@@ -2434,8 +2434,8 @@
 2460	pulsating inspector's yak toupee	0		Item Drop: +15, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	stale gigantic special pulsating bowl of Bounty-Os	9	decent	Effect: "Polka Face", Effect Duration: 30
-2465	high-proof perfectly mixed Oreille Divis&eacute;e brandy	7	EPIC	
+2464	stale special gigantic pulsating bowl of Bounty-Os	9	decent	Effect: "Polka Face", Effect Duration: 30
+2465	perfectly mixed high-proof Oreille Divis&eacute;e brandy	7	EPIC	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2489,10 +2489,10 @@
 2516	ghostly MacGyver's extremely unsafe wrench bracelet	0		Weapon Damage Percent: +100, Maximum MP: +100
 2517	tumbling smelly chain necklace of mayonnaise	0		Stench Spell Damage: +10, Sleaze Spell Damage: +50
 2518	spinning teal smooth sawblade shield	0		Moxie: +15, Damage Reduction: 11
-2519	acceptable watered-down McMillicancuddy's Special Lager	2	good	
+2519	watered-down acceptable McMillicancuddy's Special Lager	2	good	
 2520	tolerable weak jittery teal melted Jell-o shot	2	good	
 2521	irresponsibly strong drinkable cruelty-free wine	8	good	
-2522	weak artisanal special huge thistle wine	2	EPIC	Effect: "Berry Thorny", Effect Duration: 40
+2522	special artisanal weak huge thistle wine	2	EPIC	Effect: "Berry Thorny", Effect Duration: 40
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	bland miniature shaking fish	2	decent	
@@ -2501,7 +2501,7 @@
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	rotten gnatloaf	4	crappy	
 2530	bland gnatloaf casserole	4	decent	
-2531	spoiled super-sized gnat lasagna	5	crappy	
+2531	super-sized spoiled gnat lasagna	5	crappy	
 2532	pork	0		
 2533	flavorless pork chop sandwiches	3	decent	
 2534	rotten pork casserole	3	crappy	
@@ -2539,7 +2539,7 @@
 2566	Azazel's unicorn	0		
 2567	blurry Azazel's lollipop	0		
 2568	Azazel's tutu	0		
-2569	liquefied oxidized magnetized shaking huge ant agonist	0		Effect: "Cinnamouth", Effect Duration: 42
+2569	liquefied oxidized magnetized huge shaking ant agonist	0		Effect: "Cinnamouth", Effect Duration: 42
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	maroon ant rake	0		Familiar Effect: "hot damage, meat"
 2572	blinking ant pitchfork	0		Familiar Effect: "stench damage, meat"
@@ -2553,7 +2553,7 @@
 2580	friendly sharpshooter's scorpion whip	0		Critical Hit Percent: +10, Familiar Weight: +3
 2581	handful of sand	0		
 2582	jittery brick of sand	0		
-2583	spoiled low-calorie pulsating blinking centipede eggs	1	crappy	
+2583	low-calorie spoiled pulsating blinking centipede eggs	1	crappy	
 2584	olive double-paned wonderwall shield	0		Cold Resistance: +5, Damage Reduction: 12
 2585	foul-smelling Colonel Mustard's Lonely Spades Club Jacket	0		Stench Damage: +10
 2586	therapeutic General Sage's Lonely Diamonds Club Jacket	0		HP Regen Min: 5, HP Regen Max: 7
@@ -2576,7 +2576,7 @@
 2603	smoldering box	0		
 2604	knitted Tuesday's ruby	0		Cold Resistance: +3
 2605	palm frond	0		
-2606	blurry spinning palm-frond fan	0		
+2606	spinning blurry palm-frond fan	0		
 2607	gray Jim Carey's palm-frond whip	0		Monster Level: +25
 2608	cyan palm-frond net	0		
 2609	squat crafty Da Vinci's palm-frond capris	0		Experience (Mysticality): +5, Maximum MP: +10, Familiar Effect: "1.5xGhuol, cap 35"
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	maroon rocky raccoon	0		
 2614	mojo filter	0		
-2615	immense yummy savoy truffle	10	awesome	
+2615	yummy immense savoy truffle	10	awesome	
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	slick Iiti Kitty phone charm	0		Moxie: +10, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	normal twirling lime green unidentified jerky	3	good	
+2620	normal lime green twirling unidentified jerky	3	good	
 2621	occult brawny nasty rat mask	0		Muscle Percent: +20, Spell Damage Percent: +25, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	pulsating mansplainer's ratskin belt of horror	0		Monster Level: +15, Spooky Spell Damage: +25, Single Equip
 2623	wobbly wool energetic rattail whip	0		Maximum MP Percent: +20, Cold Resistance: +1
@@ -2609,7 +2609,7 @@
 2636	twirling olive censurious mummy mask	0		Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	careful grievous gauze shorts	0		Weapon Damage Percent: +50, Monster Level: -10, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
 2638	gauze hammock	0		
-2639	jittery ghostly cherry soda	0		
+2639	ghostly jittery cherry soda	0		
 2640	scorching greaves of the scaredy-cat	0		Monster Level: -15, Hot Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
 2641	maroon pulsating Usain Bolt's smartaleck's cowboy hat	0		Moxie Percent: +30, Initiative: +80, Familiar Effect: "1xBarrr, 1xLep, cap 41"
 2642	slick Maxwell's Silver Hammer of the brute	0		Moxie: +10, Muscle Percent: +30
@@ -2623,15 +2623,15 @@
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	toothsome S.T.L.T.	3	awesome	Last Available: "2007-06"
-2653	miniature special tasty honey-dew	2	awesome	Effect: "[800]Chocolate Reign", Effect Duration: 30, Last Available: "2007-06"
-2654	weak bad Xanadian	2	decent	Last Available: "2007-06"
+2653	miniature tasty special honey-dew	2	awesome	Effect: "[800]Chocolate Reign", Effect Duration: 30, Last Available: "2007-06"
+2654	bad weak Xanadian	2	decent	Last Available: "2007-06"
 2655	enhanced bottle of absinthe	0		Effect: "5 Pounds Lighter", Effect Duration: 54, Last Available: "2007-06"
 2656	blinking hale personal trainer's Drowsy Sword	0		Experience Percent (Muscle): +10, Maximum HP: +20
-2657	jumbo moldy escargotsicle	5	crappy	Last Available: "2007-06"
+2657	moldy jumbo escargotsicle	5	crappy	Last Available: "2007-06"
 2658	spirit-forward acceptable spinning bottle of realpagne	5	good	Last Available: "2007-06"
 2659	padded albatross necklace	0		Damage Absorption: +20, Single Equip, Last Available: "2007-06"
 2660	twisted not-a-pipe	1	good	Last Available: "2007-06"
-2661	lousy high-proof flask of Amontillado	8	decent	Last Available: "2007-06"
+2661	high-proof lousy flask of Amontillado	8	decent	Last Available: "2007-06"
 2662	cyan electrified ball mask	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 2663	smartaleck's Can-Can skirt	0		Moxie Percent: +30, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	vacuum-sealed sensitive poetry journal	0		Effect: "You Drank Fish Wine", Effect Duration: 40, Last Available: "2007-06"
@@ -2640,18 +2640,18 @@
 2667	altered pulsating spiky collar	0		Effect: "Gleaming White Teeth", Effect Duration: 59, Last Available: "2007-06"
 2668	dried tumbling yellow can-can-in-a-can	1		Last Available: "2007-06"
 2669	dried olive patent antipsychotics	1		Last Available: "2007-06"
-2670	pickled olive wobbly blinking Mariner's Friend cough drops	1		Last Available: "2007-06"
+2670	pickled olive blinking wobbly Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	aged shot of nepenthe schnapps	3	awesome	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	oxidized bouncing bottle of cat tonic	0		Effect: "Ermine Eyes", Effect Duration: 19, Last Available: "2007-06"
 2675	twisted handful of moss	1		
 2676	powdered huge bit-o-cactus	1		
-2677	denatured bouncing upside-down protein powder	1		
+2677	denatured upside-down bouncing protein powder	1		
 2678	blinking spectre scepter	0		
 2679	polymerized tumbling sparkler	0		Effect: "Salty Dogs", Effect Duration: 30
 2680	dry cyan twirling snake	0		Effect: "Red-Shirted Escort", Effect Duration: 19, Wiki Name: "snake"
-2681	liquefied tarnished yellow spinning M-242	0		Effect: "Super Skill", Effect Duration: 37
+2681	liquefied tarnished spinning yellow M-242	0		Effect: "Super Skill", Effect Duration: 37
 2682	purple detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	sharpshooter's healthy armgun	0		Maximum HP Percent: +20, Critical Hit Percent: +10
@@ -2674,7 +2674,7 @@
 2701	olive mansplainer's duct tape sword of the cheetah	0		Monster Level: +15, Initiative: +60
 2702	lime green fireproof coward's duct tape dockers	0		Monster Level: -20, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol, cap 48"
 2703	wholesome duct tape buckler	0		Maximum HP Percent: +10, Damage Reduction: 12
-2704	purple upside-down shrinking powder	0		
+2704	upside-down purple shrinking powder	0		
 2705	lard-coated thinker's blackberry slippers of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Sleaze Spell Damage: +25, Single Equip
 2706	horrifying supercharged savvy blackberry moccasins	0		Mysticality Percent: +20, Maximum MP Percent: +30, Spooky Damage: +25, Single Equip
 2707	flame-retardant razor-sharp blackberry combat boots of incineration	0		Weapon Damage Percent: +25, Hot Spell Damage: +50, Hot Resistance: +1, Single Equip
@@ -2699,7 +2699,7 @@
 2726	spoiled fuchsia huge juniper berries	4	crappy	
 2727	toothsome diet spinning plum	1	awesome	
 2728	toothsome blue pear	3	awesome	
-2729	stale special peach	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 40
+2729	special stale peach	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 40
 2730	perfectly mixed green plum wine	4	EPIC	
 2731	boozy hand-crafted shaking shot of pear schnapps	5	EPIC	
 2732	lousy mirror shot of peach schnapps	4	decent	
@@ -2707,7 +2707,7 @@
 2734	spoiled bouncing brown sugar cane	4	crappy	
 2735	special decent sandwich of the gods	3	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 25
 2736	tolerable Pan-Dimensional Gargle Blaster	4	good	
-2737	powdered purple ghostly leopard-print barbell	1	awesome	
+2737	powdered ghostly purple leopard-print barbell	1	awesome	
 2738	fuchsia wobbly pile of smoking rags	0		
 2739	boiled pressed galvanized panty raider camouflage	0		Effect: "Think Win-Lose", Effect Duration: 63
 2740	squat lard-coated frosty Newton's Staff of the Walk-In Freezer	0		Experience (Mysticality): +3, Cold Spell Damage: +10, Sleaze Spell Damage: +25
@@ -2715,7 +2715,7 @@
 2742	adequate enchanted blurry steel lasagna	3	quest	Effect: "Sugar Smacks", Effect Duration: 20
 2743	bad spirit-forward steel margarita	5	quest	
 2744	dried huge steel-scented air freshener	1		
-2745	extra-chilled twirling jittery gremlin mutagen	0		Effect: "Brain Freeze", Effect Duration: 39
+2745	extra-chilled jittery twirling gremlin mutagen	0		Effect: "Brain Freeze", Effect Duration: 39
 2746	alkaline flattened extra-potent gremlin mutagen	0		Effect: "Fudge Headache", Effect Duration: 69
 2747	upside-down chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of Tarzan	0		Experience (Muscle): +3, Single Equip
@@ -2737,11 +2737,11 @@
 2764	friendly experienced Order of the Silver Wossname of James Dean	0		Experience: +2, Experience (Moxie): +3, Familiar Weight: +3, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	bland miniature Crimbo pie	2	decent	
+2767	miniature bland Crimbo pie	2	decent	
 2768	spoiled pear tart	4	crappy	
 2769	bland tumbling peach pie	3	decent	
 2770	moist super-anodized mirror chunk of rock salt	0		Effect: "Trufflin'", Effect Duration: 16
-2771	dry non-electrified wobbly upside-down handful of pine needles	0		Effect: "Super Vision", Effect Duration: 24
+2771	dry non-electrified upside-down wobbly handful of pine needles	0		Effect: "Super Vision", Effect Duration: 24
 2772	steamy ruby	0		
 2773	olive glacial sapphire	0		
 2774	unearthly onyx	0		
@@ -2776,11 +2776,11 @@
 2803	jug of Gnomochloric acid	0		
 2804	dry blinking vial of hamethyst juice	0		Effect: "Super-Charged", Effect Duration: 49
 2805	altered vial of baconstone juice	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 52
-2806	wet liquefied yellow huge vial of porquoise juice	0		Effect: "Holiday Disappointment", Effect Duration: 52
+2806	wet liquefied huge yellow vial of porquoise juice	0		Effect: "Holiday Disappointment", Effect Duration: 52
 2807	pickled unsweetened lime green flask of hamethyst juice	0		Effect: "Abyssal Tears", Effect Duration: 54
 2808	polymerized flask of baconstone juice	0		Effect: "Truly Gritty", Effect Duration: 40
 2809	wet blurry flask of porquoise juice	0		Effect: "Salsa Satanica", Effect Duration: 39
-2810	ionized activated cyan huge jug of hamethyst juice	0		Effect: "Super-Electrified", Effect Duration: 49
+2810	ionized activated huge cyan jug of hamethyst juice	0		Effect: "Super-Electrified", Effect Duration: 49
 2811	irradiated upside-down jug of baconstone juice	0		Effect: "Angry Bone", Effect Duration: 31
 2812	chilled jug of porquoise juice	0		Effect: "Nightstalkin'", Effect Duration: 42
 2813	tumbling Oprah's stiffened Beret	0		Damage Reduction: 1, Maximum MP Percent: +50, Four Songs, Familiar Effect: "1xVolley, 1xLep"
@@ -2813,14 +2813,14 @@
 2840	triple-distilled mediocre bottle of cooking sherry	7	decent	
 2841	yummy pulsating lime green packet of ketchup	4	awesome	
 2842	mediocre accidental cider	4	decent	
-2843	bland snack-sized bouncing dire fudgesicle	2	decent	
+2843	snack-sized bland bouncing dire fudgesicle	2	decent	
 2844	upside-down fireproof knitted sage navel ring of navel gazing of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3, Cold Resistance: +3, Hot Resistance: +3, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	lime green class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
 2847	Van der Graaf Dallas Dynasty Falcon Crest shield	0		MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 15
 2848	blinking Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	perfectly mixed high-proof upside-down moonberry wine cooler	6	EPIC	
+2850	high-proof perfectly mixed upside-down moonberry wine cooler	6	EPIC	
 2851	decent spinning fine aged cheddarwurst	3	good	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2830,7 +2830,7 @@
 2857	pickled seegar butt	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 60
 2858	skewed bottled swamp gas	0		
 2859	chaotic witch wart of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +10
-2860	miniature decent spinning swamp muck	2	good	
+2860	decent miniature spinning swamp muck	2	good	
 2861	maroon blurry knitted healthy leechknife of the pedagogue	0		Experience: +3, Maximum HP Percent: +20, Cold Resistance: +3
 2862	tumbling decomposed boot	0		
 2863	deionized super-polymerized skewed jittery dribbly candle	0		Effect: "Rainbow Bright", Effect Duration: 61
@@ -2924,13 +2924,13 @@
 2952	upside-down sharpshooter's Rosewater's glowstick	0		Mysticality Percent: +30, Critical Hit Percent: +10, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	energetic tip jar	0		Maximum MP Percent: +20
-2955	tiny normal bouncing yam candy	1	good	
+2955	normal tiny bouncing yam candy	1	good	
 2956	purple cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	flavorless tube of cranberry Go-Goo	3	decent	
 2959	red lightning-fast rum barrel charrrm bracelet	0		Initiative: +40
-2960	half-sized bland single-serving herbal stuffing	2	decent	
-2961	low-calorie decent packet of tofurkey gravy	1	good	
+2960	bland half-sized single-serving herbal stuffing	2	decent	
+2961	decent low-calorie packet of tofurkey gravy	1	good	
 2962	spoiled tofurkey nugget	3	crappy	
 2963	maroon rigging shampoo	0		
 2964	ball polish	0		
@@ -2982,7 +2982,7 @@
 3010	narrow stanky MacGyver's Emblem of Ak'gyxoth	0		Maximum MP: +100, Stench Spell Damage: +25
 3011	sinister altar fragment	0		
 3012	shimmering rainbow sand	0		
-3013	twirling huge simple key	0		
+3013	huge twirling simple key	0		
 3014	narrow ornate key	0		
 3015	jittery gilded key	0		
 3016	foot locker	0		
@@ -2997,7 +2997,7 @@
 3025	hand-crafted corpse on the beach	3	super EPIC	
 3026	acceptable corpsetini	3	good	
 3027	bad wobbly corpsedriver	3	decent	
-3028	tolerable enchanted extra-dry wobbly Corpse Island iced tea	5	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 25
+3028	extra-dry enchanted tolerable wobbly Corpse Island iced tea	5	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 25
 3029	bad red-headed corpse	4	decent	
 3030	tolerable kamicorpse-ee	3	good	
 3031	artisanal triple-distilled bouncing corpsel	8	EPIC	
@@ -3005,8 +3005,8 @@
 3033	tumbling prompt pirate fledges	0		Adventures: +3
 3034	piece of thirteen	0		
 3035	normal pearl onion	4	good	
-3036	snack-sized stale sea biscuit	2	decent	
-3037	delicious fortified fancy upside-down tumbling bottle of rum	5	awesome	Effect: "Gr8ness", Effect Duration: 45
+3036	stale snack-sized sea biscuit	2	decent	
+3037	delicious fancy fortified upside-down tumbling bottle of rum	5	awesome	Effect: "Gr8ness", Effect Duration: 45
 3038	practically non-alcoholic lousy tumbling bottle of black-label rum	1	decent	
 3039	cannonball	0		
 3040	voodoo skull	0		
@@ -3014,7 +3014,7 @@
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	stale small enchanted twirling nanite-infested gingerbread bugbear	2	decent	Effect: "Mo' Hobo", Effect Duration: 5, Last Available: "2007-12"
+3045	small enchanted stale twirling nanite-infested gingerbread bugbear	2	decent	Effect: "Mo' Hobo", Effect Duration: 5, Last Available: "2007-12"
 3046	rotten nanite-infested candy cane	4	crappy	Last Available: "2020-09"
 3047	decent tumbling nanite-infested fruitcake	4	good	Last Available: "2007-12"
 3048	mediocre nanite-infested eggnog	3	decent	Last Available: "2007-12"
@@ -3030,7 +3030,7 @@
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
 3060	synthetic stuffing	0		Last Available: "2007-12"
-3061	squat shaking toy hoverpad	0		Last Available: "2007-12"
+3061	shaking squat toy hoverpad	0		Last Available: "2007-12"
 3062	shaking shaking LED block	0		Last Available: "2007-12"
 3063	gyroscope	0		Last Available: "2010-12"
 3064	sinister cyborg doll	0		Spell Damage: +10, Last Available: "2007-12"
@@ -3084,7 +3084,7 @@
 3112	bouncing Miniborg beeper	0		Last Available: "2007-12"
 3113	gray Miniborg hiveminder	0		Last Available: "2007-12"
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
-3115	ghostly red old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
+3115	red ghostly old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
 3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	shaking divine noisemaker	0		Last Available: "2008-01"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	rotten green roasted marshmallow	3	crappy	
 3130	twirling disc	0		Last Available: "2008-01"
-3131	adequate snack-sized tin cup of mulligan stew	2	good	
+3131	snack-sized adequate tin cup of mulligan stew	2	good	
 3132	stiffened flamin' bindle of the pedagogue	0		Experience: +3, Damage Reduction: 1
 3133	jittery upside-down banded freezin' bindle of the sweet-tooth	0		Damage Absorption: +100, Candy Drop: +100
 3134	lard-coated stinkin' bindle of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +25
@@ -3135,7 +3135,7 @@
 3163	wobbly El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	yellow broken El Vibrato drone	0		
-3166	olive upside-down repaired El Vibrato drone	0		
+3166	upside-down olive repaired El Vibrato drone	0		
 3167	pulsating augmented El Vibrato drone	0		
 3168	ionized seal eyeball	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 39
 3169	flavorless turtle soup	3	decent	Effect: "[598]A Little Bit Evil"
@@ -3143,11 +3143,11 @@
 3171	nauseating reagent	0		
 3172	baleful evil paper umbrella	0		Spell Damage: +25
 3173	ionized evil vihuela	0		Effect: "Paging Betty", Effect Duration: 12
-3174	yummy low-calorie purple spinning evil boring spaghetti	1	awesome	
-3175	snack-sized flavorless evil noodles	2	decent	
-3176	small stale skewed evil noodles	2	decent	
+3174	low-calorie yummy purple spinning evil boring spaghetti	1	awesome	
+3175	flavorless snack-sized evil noodles	2	decent	
+3176	stale small skewed evil noodles	2	decent	
 3177	rotten evil painful penne pasta	3	crappy	
-3178	stale bouncing lime green 3vi1 pr0n m4nic0tti	3	decent	
+3178	stale lime green bouncing 3vi1 pr0n m4nic0tti	3	decent	
 3179	bland bouncing huge evil ravioli della hippy	4	decent	
 3180	bland evil noodles	4	decent	
 3181	quadruple-moist evil potion of potency	0		Effect: "Hombre Muerto Caminando", Effect Duration: 17
@@ -3157,10 +3157,10 @@
 3185	improved blurry evil ointment of the occult	0		Effect: "Stinky Hands", Effect Duration: 23
 3186	flattened frozen evil serum of sarcasm	0		Effect: "Sepia Tan", Effect Duration: 41
 3187	liquefied quadruple-adjusted evil philter of phorce	0		Effect: "Slippery Tongue", Effect Duration: 57
-3188	practically non-alcoholic bad an evil sump'm sump'm	1	decent	
-3189	watered-down aged evil ducha de oro	2	awesome	
-3190	weak tolerable evil horizontal tango	2	good	
-3191	artisanal twirling mirror evil roll in the hay	3	EPIC	
+3188	bad practically non-alcoholic an evil sump'm sump'm	1	decent	
+3189	aged watered-down evil ducha de oro	2	awesome	
+3190	tolerable weak evil horizontal tango	2	good	
+3191	artisanal mirror twirling evil roll in the hay	3	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3170,7 +3170,7 @@
 3198	El Vibrato trapezoid	0		
 3199	lump of coal	0		
 3200	narrow lump of diamond	0		
-3201	blue jittery tumbling thick padded envelope	0		
+3201	blue tumbling jittery thick padded envelope	0		
 3202	lion tamer's KoL Con IV Pole of vim and vigor of doom	0		Maximum HP Percent: +50, Experience (familiar): +2, Spooky Spell Damage: +50, Last Available: "2007-09"
 3203	dwarvish magazine	0		
 3204	upside-down dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
@@ -3178,7 +3178,7 @@
 3206	blinking dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	small laminated card	0		
-3209	twirling skewed laminated card	0		
+3209	skewed twirling laminated card	0		
 3210	notbig laminated card	0		
 3211	unlarge laminated card	0		
 3212	gray dwarvish document	0		
@@ -3252,7 +3252,7 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	lime green wool stick-on eyebrow piercing	0		Cold Resistance: +1, Last Available: "2008-04"
-3283	stale small salad	2	decent	
+3283	small stale salad	2	decent	
 3284	twirling Tesla Oprah's C.H.U.M. lantern	0		Maximum MP Percent: +50, MP Regen Min: 7, MP Regen Max: 10
 3285	scorching C.H.U.M. knife	0		Hot Damage: +25
 3286	Frosty's snowball sack of the sweet-tooth	0		Candy Drop: +100
@@ -3285,7 +3285,7 @@
 3313	tumbling thinker's marinara jug	0		Mysticality: +10, Class: "Sauceror"
 3314	makeshift castanets of doom	0		Spooky Spell Damage: +50, Class: "Disco Bandit"
 3315	mirror Oprah's left-handed melodica	0		Maximum MP Percent: +50, Class: "Accordion Thief"
-3316	pickled shaking huge epic wad	1	good	
+3316	pickled huge shaking epic wad	1	good	
 3317	avaricious bottlecap	0		Meat Drop: +30, Single Equip
 3318	spinning grievous corncob pipe	0		Weapon Damage Percent: +50, Single Equip
 3319	Mr. Joe's bangles of the dark arts	0		Spell Damage Percent: +100, Single Equip
@@ -3307,14 +3307,14 @@
 3335	jittery rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	skewed healthy Sinatra's dead guy's memento	0		Experience (Moxie): +5, Maximum HP Percent: +20, Single Equip
-3338	fancy miniature stale banquet	2	decent	Effect: "Bilious Brains", Effect Duration: 30
+3338	stale fancy miniature banquet	2	decent	Effect: "Bilious Brains", Effect Duration: 30
 3339	jittery sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	olive hobo monkey	0		
 3343	blurry bindle	0		Familiar Weight: +5
 3344	bed of coals	0		
-3345	blurry mirror air mattress	0		
+3345	mirror blurry air mattress	0		
 3346	filth-encrusted futon	0		
 3347	tumbling comfy coffin	0		
 3348	narrow mattress	0		
@@ -3340,7 +3340,7 @@
 3368	dehydrated ghostly bouncing glimmering roc feather	1	decent	Effect: "Heightened Senses", Effect Duration: 45, Last Available: "2008-06"
 3369	mixed squat glimmering phoenix feather	1		Last Available: "2008-06"
 3370	compressed twirling glimmering penguin feather	1		Effect: "Big Flaming Whip", Effect Duration: 35, Last Available: "2008-06"
-3371	powdered jittery blurry twirling glimmering buzzard feather	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20, Last Available: "2008-06"
+3371	powdered jittery twirling blurry glimmering buzzard feather	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20, Last Available: "2008-06"
 3372	modified red glimmering raven feather	1		Last Available: "2008-06"
 3373	powdered mirror mirror glimmering great tit feather	1		Effect: "Chalked-Up Teeth", Effect Duration: 30, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
@@ -3367,9 +3367,9 @@
 3395	Hodgman's porkpie hat of Calamity Jane of the glutton	0		Critical Hit Percent: +15, Food Drop: +100, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	blurry stylish Hodgman's lobsterskin pants of the dark arts	0		Moxie: +25, Spell Damage Percent: +100, Familiar Effect: "atk, 1xPotato"
 3397	dangerous Hodgman's bow tie of horror	0		Weapon Damage: +10, Spooky Spell Damage: +25, Single Equip
-3398	fancy acceptable spirit-forward Hodgman's blanket	5	good	Effect: "Mushroom Magicalness", Effect Duration: 5
-3399	perfectly mixed triple-distilled shaking jar of squeeze	10	EPIC	
-3400	miniature spoiled bowl of fishysoisse	2	crappy	
+3398	fancy spirit-forward acceptable Hodgman's blanket	5	good	Effect: "Mushroom Magicalness", Effect Duration: 5
+3399	triple-distilled perfectly mixed shaking jar of squeeze	10	EPIC	
+3400	spoiled miniature bowl of fishysoisse	2	crappy	
 3401	extra-frozen wobbly deadly lampshade	0		Effect: "Liquidy Smoky", Effect Duration: 24
 3402	modified concentrated garbage juice	0		Effect: "Greedy Resolve", Effect Duration: 67
 3403	skewed lewd playing card	0		
@@ -3388,7 +3388,7 @@
 3416	hobo fortress blueprints	0		
 3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	altered sterno-flavored Hob-O	0		Effect: "Thicker, Sicker", Effect Duration: 17
-3423	quadruple-ionized ionized blinking shaking frostbite-flavored Hob-O	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 21
+3423	quadruple-ionized ionized shaking blinking frostbite-flavored Hob-O	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 21
 3424	altered extra-electrified spinning fry-oil-flavored Hob-O	0		Effect: "Texas Elegance", Effect Duration: 48
 3425	galvanized garbage-juice-flavored Hob-O	0		Effect: "Extra Backbone", Effect Duration: 24
 3426	cold-filtered activated green mirror strawberry-flavored Hob-O	0		Effect: "Moose Wisdom", Effect Duration: 31
@@ -3413,7 +3413,7 @@
 3446	groovy prism necklace	0		Single Equip
 3447	crafty six-rainbow shield of Calamity Jane	0		Maximum MP: +10, Critical Hit Percent: +15, Damage Reduction: 12, Last Available: "2008-07"
 3448	rainbow bomb	0		Last Available: "2008-07"
-3449	ghostly twirling cotton candy cone	0		Last Available: "2008-08"
+3449	twirling ghostly cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
 3452	cotton candy skoshe	0		Last Available: "2008-08"
@@ -3423,7 +3423,7 @@
 3456	stanky trusty torch	0		Stench Spell Damage: +25, Last Available: "2011-12"
 3457	huge lime green quilted Junior Adventurer's merit badge	0		Damage Absorption: +40
 3458	deionized STYX deodorant body spray	0		Effect: "Dreams and Lights", Effect Duration: 23
-3459	drinkable tumbling spinning white-label gin	4	good	
+3459	drinkable spinning tumbling white-label gin	4	good	
 3460	normal tin rations	3	good	
 3461	tumbling haiku challenge map	0		
 3462	terrible poem	0		
@@ -3433,7 +3433,7 @@
 3466	greedy electrified wholesome haiku katana	0		Maximum HP Percent: +10, Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	upside-down bargain flash powder	0		
 3468	smooth plastic baby	0		Moxie: +15, Single Equip, Last Available: "2008-12"
-3469	decent skewed narrow blueberry-frosted king cake	3	good	Last Available: "2008-12"
+3469	decent narrow skewed blueberry-frosted king cake	3	good	Last Available: "2008-12"
 3470	twirling bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	Sherlock's scandalous steel-toed Seasonal Beret	0		Damage Reduction: 9, Sleaze Damage: +5, Item Drop: +25, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3455,11 +3455,11 @@
 3488	pristine fish scale	0		
 3489	decent beefy fish meat	3	good	Effect: "Fishy", Effect Duration: 5
 3490	huge decent glistening fish meat	9	good	Effect: "Fishy", Effect Duration: 5
-3491	flavorless jumbo slick fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
+3491	jumbo flavorless slick fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
 3492	tumbling mirror blue shaking scandalous Annie Oakley's fish scimitar	0		Critical Hit Percent: +20, Sleaze Damage: +5
 3493	lard-coated vibrating fish stick	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25
 3494	narrow vibrating padded fish bazooka	0		Damage Absorption: +20, Maximum MP Percent: +10
-3495	double-cold-filtered huge wobbly sea salt crystal	0		Effect: "OMG WTF", Effect Duration: 23
+3495	double-cold-filtered wobbly huge sea salt crystal	0		Effect: "OMG WTF", Effect Duration: 23
 3496	aerosolized concentrated cold-filtered bazookafish bubble gum	0		Effect: "Stemonitis Storm", Effect Duration: 41
 3497	perfectly mixed watered-down squat bottle of Pete's Sake	2	EPIC	
 3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
@@ -3467,7 +3467,7 @@
 3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	moldy enchanted twirling canap&eacute;s	3	crappy	Effect: "Nut-Rition", Effect Duration: 45
 3502	dehydrated blurry thermos of brew	1	crappy	Last Available: "2011-12"
-3503	weak perfectly mixed glass of brandy	2	EPIC	Last Available: "2011-12"
+3503	perfectly mixed weak glass of brandy	2	EPIC	Last Available: "2011-12"
 3504	squat French slippers	0		
 3505	shaking smooth LWA ring	0		Moxie: +15
 3506	LARP membership card	0		Last Available: "2008-10"
@@ -3521,10 +3521,10 @@
 3554	glob of slime	0		
 3555	decent sea carrot	3	good	
 3556	delicious sea cucumber	4	awesome	
-3557	moldy immense sea avocado	6	crappy	
+3557	immense moldy sea avocado	6	crappy	
 3558	normal shaking sea lychee	4	good	
 3559	normal thick sea tangelo	5	good	
-3560	massive tasty sea honeydew	10	awesome	
+3560	tasty massive sea honeydew	10	awesome	
 3561	cold-filtered unsweetened jittery pressurized potion of puissance	0		Effect: "Some Cheese with Your Wine", Effect Duration: 62
 3562	double-flattened anodized pressurized potion of perspicacity	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 67
 3563	dry pulsating pressurized potion of pulchritude	0		Effect: "Broken Bone Nubs", Effect Duration: 40
@@ -3614,9 +3614,9 @@
 3648	bouncing magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	stale toast with jam	4	decent	Last Available: "2008-12"
-3651	spinning antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	spinning antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	perfectly mixed elven moonshine	3	EPIC	Last Available: "2008-12"
-3653	special adequate knuckle sandwich	3	good	Effect: "items.enh", Effect Duration: 50, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	adequate special knuckle sandwich	3	good	Effect: "items.enh", Effect Duration: 50, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	arcane researcher's psycho sweater of horror	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +25, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	greasy plastic Mob Penguin	0		Sleaze Spell Damage: +10, Last Available: "2008-12"
@@ -3641,23 +3641,23 @@
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	banded diving muff	0		Damage Absorption: +100, Single Equip
-3678	practically non-alcoholic artisanal wobbly salinated mint julep	1	EPIC	
+3678	artisanal practically non-alcoholic wobbly salinated mint julep	1	EPIC	
 3679	ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	wobbly map to the Marinara Trench	0		
-3684	jumbo spoiled squat tempura carrot	5	crappy	
+3684	spoiled jumbo squat tempura carrot	5	crappy	
 3685	normal tempura cucumber	3	good	
-3686	bite-sized adequate shaking tempura avocado	1	good	
+3686	adequate bite-sized shaking tempura avocado	1	good	
 3687	flavorless small skewed sea broccoli	2	decent	
-3688	massive rotten sea cauliflower	7	crappy	
+3688	rotten massive sea cauliflower	7	crappy	
 3689	stale tempura broccoli	4	decent	
-3690	yummy bite-sized special tempura cauliflower	1	awesome	Effect: "Burnt 'n' Turnt", Effect Duration: 25
+3690	bite-sized special yummy tempura cauliflower	1	awesome	Effect: "Burnt 'n' Turnt", Effect Duration: 25
 3691	adequate spinning sea blueberry	4	good	
 3692	stale upside-down sea persimmon	4	decent	
 3693	quadruple-dry colloidal pressurized potion of perception	0		Effect: "Billiards Belligerence", Effect Duration: 25
-3694	corrupted colloidal upside-down ghostly pressurized potion of proficiency	0		Effect: "Ichorous Intensity", Effect Duration: 28
+3694	corrupted colloidal ghostly upside-down pressurized potion of proficiency	0		Effect: "Ichorous Intensity", Effect Duration: 28
 3695	scandalous Mer-kin digpick	0		Sleaze Damage: +5
 3696	anemone nematocyst	0		
 3697	high-pressure seltzer bottle	0		
@@ -3684,8 +3684,8 @@
 3718	squat fishhook	0		
 3719	lantern	0		
 3720	decaying pole	0		
-3721	fuchsia wobbly decaying paddle	0		
-3722	narrow upside-down tarnished ring	0		
+3721	wobbly fuchsia decaying paddle	0		
+3722	upside-down narrow tarnished ring	0		
 3723	tarnished rod	0		
 3724	brittle plastic handle	0		
 3725	foggy glass globe	0		
@@ -3707,13 +3707,13 @@
 3741	spectral jelly	0		
 3742	deionized jellyfish gel	0		Effect: "You're Not Cooking", Effect Duration: 67
 3743	unstable quark	0		
-3744	wobbly lime green software glitch	0		
+3744	lime green wobbly software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	blurry maroon vampire pearl	0		
 3747	lime green mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	denatured polymerized modified concoction of clumsiness	0		Effect: "Booing Radly", Effect Duration: 49
 3750	stiffened vampire pearl earring	0		Damage Reduction: 1, Single Equip
-3751	super-sized moldy blinking chocolate chip brownies	5	crappy	
+3751	moldy super-sized blinking chocolate chip brownies	5	crappy	
 3753	purple Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	activated adjusted love song of vague ambiguity	0		Effect: "White Blooded", Effect Duration: 18, Last Available: "2009-02"
 3755	super-irradiated energized blue love song of smoldering passion	0		Effect: "Eagle Eyes", Effect Duration: 35, Last Available: "2009-02"
@@ -3728,7 +3728,7 @@
 3764	tolerable weak slug of rum	2	good	
 3765	bad slug of shochu	4	decent	
 3766	hand-crafted ghostly screwdiver	4	EPIC	
-3767	boozy tolerable dew yoana lei	5	good	
+3767	tolerable boozy dew yoana lei	5	good	
 3768	tolerable lychee chuhai	4	good	
 3769	irresponsibly strong tolerable salacious screwdiver	7	good	
 3770	drinkable dew yoana salacious lei	4	good	
@@ -3754,7 +3754,7 @@
 3799	huge Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
 3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	yellow squat charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3802	squat yellow charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	purple perfumed asbestos-lined deadly Mer-kin roundshield	0		Weapon Damage: +5, Hot Resistance: +5, Stench Resistance: +5, Damage Reduction: 14
 3804	olive Mer-kin breastplate of doom of the boozehound	0		Spooky Spell Damage: +50, Booze Drop: +100
 3805	Samson's Mer-kin sneakmask of the sewer	0		Experience (Muscle): +5, Stench Damage: +25, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3766,24 +3766,24 @@
 3811	tumbling Mer-kin stashbox	0		
 3812	yummy big twirling chocolate-frosted king cake	5	awesome	Last Available: "2009-06"
 3813	coward's plastic baby	0		Monster Level: -20, Single Equip, Last Available: "2009-06"
-3815	shaking gray midget clownfish	0		
-3816	skewed gray blurry half-height unicycle	0		Familiar Weight: +5
-3817	adequate big sea radish	5	good	
+3815	gray shaking midget clownfish	0		
+3816	skewed blurry gray half-height unicycle	0		Familiar Weight: +5
+3817	big adequate sea radish	5	good	
 3818	skewed olive Lo Pan's sinister halibut of the bloodbag	0		Spell Damage: +10, Maximum HP: +100, Spell Critical Percent: +30
 3819	narrow cyan eel sauce	0		
 3820	olive ghostly smartaleck's water-polo mitt	0		Moxie Percent: +30, Single Equip
-3821	denatured extra-vacuum-sealed super-improved teal blinking blinking syringe	0		Effect: "Memento Moir&eacute;", Effect Duration: 69
+3821	denatured extra-vacuum-sealed super-improved blinking blinking teal syringe	0		Effect: "Memento Moir&eacute;", Effect Duration: 69
 3822	blurry wand	0		Familiar Effect: "fishy spells"
 3823	polymerized tumbling wad of cotton	0		Effect: "Buzzard Breath", Effect Duration: 52
 3824	Grandma's Note	0		
-3825	pulsating purple Grandma's Fuchsia Yarn	0		
+3825	purple pulsating Grandma's Fuchsia Yarn	0		
 3826	Grandma's Chartreuse Yarn	0		
 3827	lime green plastic oyster egg	0		
 3828	Grandma's Map	0		
 3829	toothsome tempura radish	4	awesome	
 3830	tumbling water-polo cap of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xBarrr"
-3831	acceptable special Typical Tavern swill	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10
-3832	watered-down hand-crafted wobbly tropical swill	2	EPIC	
+3831	special acceptable Typical Tavern swill	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10
+3832	hand-crafted watered-down wobbly tropical swill	2	EPIC	
 3833	drinkable fruity girl swill	3	good	
 3834	weak delicious blended swill	2	awesome	
 3835	costume wardrobe	0		Softcore Only
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	green imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	triple-distilled drinkable blended swill with a fly in it	6	good	
+3913	drinkable triple-distilled blended swill with a fly in it	6	good	
 3914	turtle wax	0		
 3915	experienced turtle wax shield	0		Experience: +2, Damage Reduction: 2
 3916	sage turtle wax helmet	0		Mysticality Percent: +10, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3877,7 +3877,7 @@
 3925	spiky turtle shoulderpads of the cheetah	0		Initiative: +60, Single Equip
 3926	mirror spinning studded Fonzie's spiky turtle shield	0		Experience (Moxie): +1, Damage Absorption: +80, Damage Reduction: 8
 3927	turtling rod	0		Class: "Turtle Tamer"
-3928	blinking huge syncopated turtle	0		
+3928	huge blinking syncopated turtle	0		
 3929	narrow grinning turtle	0		
 3930	anodized enhanced tainted seal's blood	0		Effect: "Dance Interpreter", Effect Duration: 15
 3931	huge jittery slick severed flipper of the cheetah	0		Moxie: +10, Initiative: +60, Class: "Seal Clubber"
@@ -3896,11 +3896,11 @@
 3944	smelly crafty shadowy seal eye	0		Maximum MP: +10, Stench Spell Damage: +10, Class: "Seal Clubber"
 3945	censurious oyster egg balloon	0		Sleaze Resistance: +3
 3946	Clan VIP Lounge invitation	0		Free Pull
-3947	squat jittery Clan VIP Lounge key	0		Free Pull
+3947	jittery squat Clan VIP Lounge key	0		Free Pull
 3948	squat Meat	0		
 3949	treasure chest	0		
 3950	green key	0		
-3951	ghostly yellow blinking Baron von Ratsworth	0		
+3951	blinking ghostly yellow Baron von Ratsworth	0		
 3952	monocle	0		
 3953	mink	0		
 3954	teddy butler	0		
@@ -3922,7 +3922,7 @@
 3970	squat curative Socratic Abyssal ember	0		Experience (Mysticality): +1, HP Regen Min: 3, HP Regen Max: 5, Class: "Seal Clubber"
 3971	colloidal irradiated bouncing frost-rimed seal hide	0		Effect: "Mayeaugh", Effect Duration: 56
 3972	auspicious seal spine of the brute	0		Muscle Percent: +30, Item Drop: +10, Class: "Seal Clubber"
-3973	electrified huge lime green seal lube	0		Effect: "Jammin'", Effect Duration: 31
+3973	electrified lime green huge seal lube	0		Effect: "Jammin'", Effect Duration: 31
 3974	stanky mannequin leg of the empath	0		Familiar Weight: +5, Stench Spell Damage: +25, Class: "Seal Clubber"
 3975	clever padded tortoise of the businessman	0		Maximum MP: +20, Meat Drop: +50, Damage Reduction: 6
 3976	knitted tortoboggan of the storm	0		Maximum MP Percent: +40, Cold Resistance: +3, Single Equip
@@ -3938,7 +3938,7 @@
 3986	samurai turtle	0		
 3987	wobbly fuchsia huge foul-smelling Jim Carey's samurai turtle helmet	0		Monster Level: +25, Stench Damage: +10, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	pulsating turtle shell	0		
-3989	cyan jittery turtle shell powder	0		
+3989	jittery cyan turtle shell powder	0		
 3990	turtle shell helmet of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	twirling slime-soaked brain	0		Skill: "Slimy Synapses"
@@ -4003,7 +4003,7 @@
 4051	pulsating dangerous ring of teleportation	0		Weapon Damage: +10, Single Equip
 4052	tumbling glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	enchanted mediocre White Hyborian	3	decent	Effect: "You're High as a Crow, Marty", Effect Duration: 20, Last Available: "2009-06"
+4054	mediocre enchanted White Hyborian	3	decent	Effect: "You're High as a Crow, Marty", Effect Duration: 20, Last Available: "2009-06"
 4055	goblin hunting spear of Gandalf	0		Spell Critical Percent: +20, Last Available: "2009-06"
 4056	inspector's medical-grade goblin autoblowgun	0		Item Drop: +15, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-06"
 4057	smartaleck's tribal beads	0		Moxie Percent: +30, Last Available: "2009-06"
@@ -4032,17 +4032,17 @@
 4080	tumbling up-at-dawn Fonzie's grisly shield	0		Experience (Moxie): +1, Adventures: +5, Slime Hates It: +1, Damage Reduction: 13
 4081	double-paned dog trainer's corroded breeches	0		Experience (familiar): +1, Cold Resistance: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	hardy savvy pernicious cudgel	0		Mysticality Percent: +20, Maximum HP: +50, Slime Hates It: +1
-4083	enchanted moldy thick skewed cupcake-in-a-cup	5	crappy	Effect: "Liquid Courage", Effect Duration: 35, Last Available: "2009-06"
+4083	thick moldy enchanted skewed cupcake-in-a-cup	5	crappy	Effect: "Liquid Courage", Effect Duration: 35, Last Available: "2009-06"
 4084	tumbling pool of liquid	0		Last Available: "2009-06"
-4085	spoiled shaking lime green protein paste	3	crappy	Last Available: "2009-06"
+4085	spoiled lime green shaking protein paste	3	crappy	Last Available: "2009-06"
 4086	occult cyber-mattock of the overflowing toilet	0		Spell Damage Percent: +25, Stench Spell Damage: +50, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
-4089	anodized Vulcanized blurry green neurostim pill	0		Effect: "Crimbo Nostalgia", Effect Duration: 60, Last Available: "2009-06"
+4089	anodized Vulcanized green blurry neurostim pill	0		Effect: "Crimbo Nostalgia", Effect Duration: 60, Last Available: "2009-06"
 4090	moist shaking physiostim pill	0		Effect: "Patent Avarice", Effect Duration: 51, Last Available: "2009-06"
 4091	slimy cyst	0		
 4092	gray small slimy cyst	0		
-4093	upside-down purple medium slimy cyst	0		
+4093	purple upside-down medium slimy cyst	0		
 4094	slimy cyst	0		
 4095	spinning electrified peawee marble	0		MP Regen Min: 3, MP Regen Max: 5
 4096	clever brown crock marble	0		Maximum MP: +20
@@ -4090,10 +4090,10 @@
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
 4140	a folded paper strip	0		
-4141	wobbly maroon squat shaking a crinkled paper strip	0		
+4141	squat maroon wobbly shaking a crinkled paper strip	0		
 4142	a crumpled paper strip	0		
 4143	a ragged paper strip	0		
-4144	lime green narrow a ripped paper strip	0		
+4144	narrow lime green a ripped paper strip	0		
 4145	huge supercharged funny paper hat	0		Maximum MP Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 2"
 4146	aerosolized sand	0		Effect: "Stick Emporium Membership", Effect Duration: 18
 4147	huge huge nasty charged magnet of Flo-Jo	0		Stench Damage: +5, Initiative: +100, Last Available: "2009-09"
@@ -4101,7 +4101,7 @@
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	lint	0		Last Available: "2011-12"
 4151	pressed cold-filtered oxidized blinking dubious peppermint	0		Effect: "Human-Insect Hybrid", Effect Duration: 30, Last Available: "2020-09"
-4152	pickled red blurry Elvish delight	0		Effect: "Disdain of the War Snapper", Effect Duration: 62
+4152	pickled blurry red Elvish delight	0		Effect: "Disdain of the War Snapper", Effect Duration: 62
 4153	lime green rockfish stomach	0		Last Available: "2009-09"
 4154	huge live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
@@ -4109,7 +4109,7 @@
 4157	gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	weak bad pebblebr&auml;u	2	decent	Last Available: "2009-09"
+4160	bad weak pebblebr&auml;u	2	decent	Last Available: "2009-09"
 4161	normal rocky road ice cream	3	good	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	dry galvanized jittery children of the candy corn	0		Effect: "The Living Hitpoints", Effect Duration: 11
@@ -4185,7 +4185,7 @@
 4233	hacienda key	0		
 4234	weightlifter's pat&eacute; knife	0		Muscle: +15
 4235	teal salt-shaker	0		
-4236	pulsating bouncing can of sterno	0		
+4236	bouncing pulsating can of sterno	0		
 4237	blurry wholesome cheese-slicer	0		Maximum HP Percent: +10
 4238	decent jumbo bouncing beef jerky	5	good	
 4239	shaking pipe wrench of the blizzard	0		Cold Spell Damage: +25
@@ -4196,7 +4196,7 @@
 4244	blurry Usain Bolt's leather-bound tome	0		Initiative: +80
 4245	bookmark	0		
 4246	red smartaleck's ivory cue ball	0		Moxie Percent: +30
-4247	distilled smooth decanter of fine Scotch	5	awesome	
+4247	smooth distilled decanter of fine Scotch	5	awesome	
 4248	vaporized pulsating expensive cigar	1		Effect: "Just Aged Enough", Effect Duration: 45
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4207,8 +4207,8 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	liquefied altered sap	0		Effect: "Material Witness", Effect Duration: 26, Last Available: "2009-10"
 4257	cyan petrified wood	0		Last Available: "2009-10"
-4258	big delicious chocolate-covered scarab beetle	5	awesome	Last Available: "2009-10"
-4259	weak perfectly mixed mulled cider	2	EPIC	Last Available: "2009-10"
+4258	delicious big chocolate-covered scarab beetle	5	awesome	Last Available: "2009-10"
+4259	perfectly mixed weak mulled cider	2	EPIC	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4279,8 +4279,8 @@
 4327	shaking upside-down rosewater-soaked supercool La Hebilla del Cintur&oacute;n de Lopez of temperance	0		Moxie Percent: +20, Stench Resistance: +3, Sleaze Resistance: +5, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	blue bag of many confections	0		Last Available: "2009-12"
-4330	diet adequate candy kneecapping stick	1	good	Last Available: "2009-12"
-4331	small bland licorice garrote	2	decent	Last Available: "2009-12"
+4330	adequate diet candy kneecapping stick	1	good	Last Available: "2009-12"
+4331	bland small licorice garrote	2	decent	Last Available: "2009-12"
 4332	savvy candy knuckles	0		Mysticality Percent: +20, Last Available: "2009-12"
 4333	adequate jawbruiser	3	good	Last Available: "2010-12"
 4334	quadruple-polymerized narrow chocolate car	0		Effect: "Tenacity of the Snapper", Effect Duration: 43, Last Available: "2009-12"
@@ -4303,18 +4303,18 @@
 4351	deadly snow belly	0		Weapon Damage: +5, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	yellow Crimbough	0		Last Available: "2009-12"
-4354	squat purple A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	purple squat A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	twirling A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	yellow A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	stale expired can of franks 'n' beans	4	decent	Last Available: "2009-12"
-4361	practically non-alcoholic lousy spinning expired bottle of peppermint schnapps	1	decent	Last Available: "2009-12"
+4361	lousy practically non-alcoholic spinning expired bottle of peppermint schnapps	1	decent	Last Available: "2009-12"
 4362	tumbling snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	ionized moist elven suicide capsule	0		Effect: "Angry like the Wolf", Effect Duration: 19, Last Available: "2009-12"
-4365	spoiled bite-sized fancy cyan twirling penguin focaccia bread	1	crappy	Effect: "Lemon Enlightenment", Effect Duration: 5, Last Available: "2009-12"
+4365	bite-sized spoiled fancy twirling cyan penguin focaccia bread	1	crappy	Effect: "Lemon Enlightenment", Effect Duration: 5, Last Available: "2009-12"
 4366	fancy hand-crafted herringcello	4	EPIC	Effect: "Moose Wisdom", Effect Duration: 45, Last Available: "2009-12"
 4367	bad elven cellocello	3	decent	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
@@ -4341,7 +4341,7 @@
 4389	peanut brittle shield of the pedagogue	0		Experience: +3, Damage Reduction: 3, Last Available: "2009-12"
 4390	savvy Red Rover BB gun of wisdom	0		Mysticality: +15, Mysticality Percent: +20, Last Available: "2009-12"
 4391	huge clever red-and-green sweater	0		Maximum MP: +20, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
-4392	pulsating blinking Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
+4392	blinking pulsating Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	dry twirling Crimbo peppermint bark	0		Effect: "You're Rubber", Effect Duration: 23, Last Available: "2009-12"
 4394	extra-enhanced pickled Crimbo fudge	0		Effect: "Feelin' Philosophical", Effect Duration: 57, Last Available: "2009-12"
 4395	vacuum-sealed Crimbo pecan	0		Effect: "World's Shortest Giant", Effect Duration: 67, Last Available: "2009-12"
@@ -4381,7 +4381,7 @@
 4431	shaking NPZR chemistry set	0		Last Available: "2011-08"
 4432	modified invisibility potion	0		Effect: "Standard Issue Bravery", Effect Duration: 15, Last Available: "2011-08"
 4433	ionized activated tarnished irresistibility potion	0		Effect: "Once Bitten Twice Fried", Effect Duration: 18, Last Available: "2011-08"
-4434	activated ghostly squat irritability potion	0		Effect: "Neuroplastici Tea", Effect Duration: 11, Last Available: "2011-08"
+4434	activated squat ghostly irritability potion	0		Effect: "Neuroplastici Tea", Effect Duration: 11, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	teal hellseal whisker	0		
 4439	hellseal claw	0		
@@ -4389,7 +4389,7 @@
 4441	stanky crowbar	0		Stench Spell Damage: +25
 4442	sinister spaghetti cult rosary	0		Spell Damage: +10
 4443	Usain Bolt's spaghetti cult mask	0		Initiative: +80, Familiar Effect: "1xBarrr, 1xGhuol, cap 38"
-4444	blue upside-down guard turtle collar	0		Familiar Damage: +10
+4444	upside-down blue guard turtle collar	0		Familiar Damage: +10
 4445	fuchsia Newton's spangly mariachi pants	0		Experience (Mysticality): +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	teal zippy shellacked spangly mariachi vest	0		Damage Reduction: 7, Initiative: +20
 4447	clever spangly sombrero	0		Maximum MP: +20, Familiar Effect: "2xFairy, 2xPotato, cap 37"
@@ -4430,7 +4430,7 @@
 4482	BRICKO airship	0		Last Available: "2010-02"
 4483	BRICKO cathedral	0		Last Available: "2010-02"
 4484	BRICKO gargantuchicken	0		Last Available: "2010-02"
-4485	green spinning BRICKO pyramid	0		Last Available: "2010-02"
+4485	spinning green BRICKO pyramid	0		Last Available: "2010-02"
 4486	blue BRICKO pearl	0		Last Available: "2010-02"
 4487	tumbling BRICKO bulwark of terror	0		Spooky Spell Damage: +10, Damage Reduction: 3, Last Available: "2010-02"
 4488	BRICKO trunk	0		Last Available: "2010-02"
@@ -4450,13 +4450,13 @@
 4502	aerosolized activated enhanced recording of Donho's Bubbly Ballad	0		Effect: "Old Time Hydration", Effect Duration: 55
 4503	concentrated anodized recording of Inigo's Incantation of Inspiration	0		Effect: "Ack!  Barred!", Effect Duration: 15, Last Available: "2010-02"
 4504	curative wholesome heart of the volcano	0		Maximum HP Percent: +10, HP Regen Min: 3, HP Regen Max: 5
-4505	denatured squat twirling skewed Northern pemmican	0		Effect: "Discomfited", Effect Duration: 69
+4505	denatured twirling skewed squat Northern pemmican	0		Effect: "Discomfited", Effect Duration: 69
 4506	puzzling ribbon	0		
 4507	gray Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	flattened gray wobbly &quot;DRINK ME&quot; potion	0		Effect: "Stinky Hands", Effect Duration: 69, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	moldy small tumbling walrus ice cream	2	crappy	Last Available: "2010-03"
-4511	spoiled jumbo skewed beautiful soup	5	crappy	Last Available: "2010-03"
+4510	small moldy tumbling walrus ice cream	2	crappy	Last Available: "2010-03"
+4511	jumbo spoiled skewed beautiful soup	5	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	spoiled Humpty Dumplings	3	crappy	Last Available: "2010-03"
@@ -4477,9 +4477,9 @@
 4529	vibrating quilted snapdragon pistil	0		Damage Absorption: +40, Maximum MP Percent: +10, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	tasty blue rook cookie	3	awesome	Last Available: "2010-03"
-4532	fancy decent cyan bishop cookie	3	good	Effect: "You're Rubber", Effect Duration: 5, Last Available: "2010-03"
+4532	decent fancy cyan bishop cookie	3	good	Effect: "You're Rubber", Effect Duration: 5, Last Available: "2010-03"
 4533	spoiled yellow skewed knight cookie	4	crappy	Last Available: "2010-03"
-4534	enchanted small adequate ghostly king cookie	2	good	Effect: "Punch Another Day", Effect Duration: 5, Last Available: "2010-03"
+4534	small adequate enchanted ghostly king cookie	2	good	Effect: "Punch Another Day", Effect Duration: 5, Last Available: "2010-03"
 4535	spoiled queen cookie	3	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	Oprah's insane tophat	0		Maximum MP Percent: +50, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
@@ -4498,7 +4498,7 @@
 4550	dodo	0		Last Available: "2010-03"
 4551	detour shield of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
-4553	green wobbly lowercase a	0		
+4553	wobbly green lowercase a	0		
 4554	percent sign	0		
 4555	left bracket	0		
 4556	skewed right parenthesis	0		
@@ -4506,9 +4506,9 @@
 4558	bouncing equal sign	0		
 4559	tumbling record album	0		Last Available: "2010-04"
 4560	olive map to Professor Jacking's laboratory	0		Last Available: "2010-04"
-4561	ghostly tumbling can of depilatory cream	0		Last Available: "2010-04"
+4561	tumbling ghostly can of depilatory cream	0		Last Available: "2010-04"
 4562	mirror hair of the calf	0		Last Available: "2010-04"
-4563	delicious practically non-alcoholic world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
+4563	practically non-alcoholic delicious world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
 4564	Van der Graaf slippery when wet shield	0		MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 6, Last Available: "2010-04"
 4565	tasty half-sized raisin	2	awesome	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4529,7 +4529,7 @@
 4581	resourceful educational T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience: +1, Maximum MP: +50, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	bite-sized yummy six wedges of goat cheese	1	awesome	
+4584	yummy bite-sized six wedges of goat cheese	1	awesome	
 4585	collection of objects	0		
 4586	tumbling boulder	0		
 4587	shaking goth	0		
@@ -4546,9 +4546,9 @@
 4598	squat pixel stopwatch	0		Last Available: "2010-07"
 4599	upside-down bottle opener	0		Last Available: "2010-06"
 4600	bouncing map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	high-proof artisanal special plastic cup of beer	8	EPIC	Effect: "Turtle Power", Effect Duration: 35, Last Available: "2010-06"
+4601	high-proof special artisanal plastic cup of beer	8	EPIC	Effect: "Turtle Power", Effect Duration: 35, Last Available: "2010-06"
 4602	bouncing squat orquette's phone number	0		Last Available: "2010-06"
-4603	ghostly blinking bronze handcuffs	0		Last Available: "2010-06"
+4603	blinking ghostly bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	mirror deadly bottle of Goldschn&ouml;ckered of wisdom	0		Mysticality: +15, Weapon Damage: +5, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	flavorless lime green sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	mansplainer's Crown of Thrones	0		Monster Level: +15, Softcore Only, Last Available: "2010-05"
-4615	boozy hand-crafted Cinco Mayo Lager	5	EPIC	Last Available: "2010-05"
+4615	hand-crafted boozy Cinco Mayo Lager	5	EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4569,7 +4569,7 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	triple-wet chocolate-covered caviar	0		Effect: "Abyssal Sweat", Effect Duration: 22, Last Available: "2020-09"
-4624	moldy miniature fuchsia shaking twirling pawn cookie	2	crappy	Last Available: "2010-06"
+4624	miniature moldy shaking twirling fuchsia pawn cookie	2	crappy	Last Available: "2010-06"
 4625	mixed coffee pixie stick	1	good	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
@@ -4598,7 +4598,7 @@
 4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	lime green ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	shaking scandalous ironic knit cap of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
-4653	blinking shaking ironic sunglasses	0		Single Equip
+4653	shaking blinking ironic sunglasses	0		Single Equip
 4654	executive ironic battle spoon	0		Meat Drop: +40
 4655	wool Jack Frost's Van der Graaf ironic jogging shorts	0		Cold Spell Damage: +50, Cold Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	mole skin notebook of the ox	0		Muscle: +20
@@ -4607,8 +4607,8 @@
 4659	blue blackberry galoshes of extreme caution	0		Monster Level: -25, Single Equip
 4660	olive vibrating forbidden trout fang	0		Spell Damage Percent: +50, Maximum MP Percent: +10, Last Available: "2010-09"
 4661	adequate gigantic poisonous caviar	7	good	Last Available: "2010-09"
-4662	diffused quantum huge shaking wet venom duct	0		Effect: "Stregngth of the Gnome", Effect Duration: 21, Last Available: "2010-09"
-4663	blurry cyan Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
+4662	diffused quantum shaking huge wet venom duct	0		Effect: "Stregngth of the Gnome", Effect Duration: 21, Last Available: "2010-09"
+4663	cyan blurry Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	thinker's Ellsbury's skull of temperance	0		Mysticality: +10, Sleaze Resistance: +5, Last Available: "2010-09"
 4665	cool hot plate	0		Moxie: +5, Damage Reduction: 3
 4666	frightening friendly imp unity ring	0		Familiar Weight: +3, Spooky Damage: +5
@@ -4620,7 +4620,7 @@
 4672	comfy pillow	0		
 4673	bland miniature squat marshmallow	2	decent	
 4674	decent narrow sponge cake	3	good	
-4675	watered-down bad green gin-soaked blotter paper	2	decent	
+4675	bad watered-down green gin-soaked blotter paper	2	decent	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
@@ -4645,13 +4645,13 @@
 4697	supercool fossilized necklace	0		Moxie Percent: +20, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
-4700	pulsating jittery fossilized spike	0		Last Available: "2010-09"
+4700	jittery pulsating fossilized spike	0		Last Available: "2010-09"
 4701	waterlogged crate	0		Last Available: "2011-12"
 4702	narrow archaeologing shovel	0		Last Available: "2011-12"
 4703	blinking Jim Carey's red-hot medallion	0		Monster Level: +25, Single Equip, Last Available: "2010-09"
 4704	purple fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
-4706	tumbling maroon sinister tablet	0		
+4706	maroon tumbling sinister tablet	0		
 4707	olive E-Z Cook&trade; oven	0		
 4708	My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
@@ -4661,7 +4661,7 @@
 4713	red popsicle stick	0		
 4714	stale diet blurry lemon popsicle	1	decent	
 4715	stale popsicle	4	decent	
-4716	normal miniature strawberry popsicle	2	good	
+4716	miniature normal strawberry popsicle	2	good	
 4717	normal liver popsicle	4	good	
 4718	purple mariachi hat of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, cap 2"
 4719	jittery Hollandaise helmet of the early riser	0		Adventures: +7, Familiar Effect: "atk, cap 2"
@@ -4674,7 +4674,7 @@
 4726	moldy igloo pie	3	crappy	Last Available: "2010-10"
 4727	flavorless stomach turnover	4	decent	Last Available: "2010-10"
 4728	flavorless upside-down dead lights pie	4	decent	Last Available: "2010-10"
-4729	gigantic stale throbbing organ pie	10	decent	Last Available: "2010-10"
+4729	stale gigantic throbbing organ pie	10	decent	Last Available: "2010-10"
 4730	purple stop shield of mayonnaise	0		Sleaze Spell Damage: +50, Damage Reduction: 6, Last Available: "2009-12"
 4731	gray nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4690,9 +4690,9 @@
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	altered alkaline red PlexiPips	0		Effect: "Punchy, Murdery", Effect Duration: 56
-4745	extra-galvanized huge pulsating Wax Flask	0		Effect: "Amorous", Effect Duration: 19
+4745	extra-galvanized pulsating huge Wax Flask	0		Effect: "Amorous", Effect Duration: 19
 4746	warmed irradiated narrow upside-down Pain Dip	0		Effect: "Spiky Frozen Hair", Effect Duration: 36
-4747	flavorless diet yellow bone meal	1	decent	Last Available: "2010-10"
+4747	diet flavorless yellow bone meal	1	decent	Last Available: "2010-10"
 4748	triple-distilled acceptable bone aperitif	8	good	Last Available: "2010-10"
 4749	dangerous bonerang	0		Weapon Damage: +10, Last Available: "2010-10"
 4750	upside-down bone and arrows of the empath	0		Familiar Weight: +5, Last Available: "2010-10"
@@ -4743,7 +4743,7 @@
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	blurry mirror robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	mirror blurry robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	bland triangular CRIMBCOOKIE	3	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	big rotten blurry square CRIMBCOOKIE	5	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
@@ -4765,7 +4765,7 @@
 4856	paperclip	0		Last Available: "2011-01"
 4857	skewed bottle of Blank-Out	0		Last Available: "2011-01"
 4858	boxer's CRIMBCO lanyard	0		Muscle Percent: +10, Single Equip, Last Available: "2011-01"
-4859	skewed jittery CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+4859	jittery skewed CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	blue CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
@@ -4792,10 +4792,10 @@
 4883	toe jam	0		Last Available: "2011-01"
 4884	moldy toe jam toast	4	crappy	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	flavorless super-sized traffic jam toast	5	decent	Last Available: "2011-01"
+4886	super-sized flavorless traffic jam toast	5	decent	Last Available: "2011-01"
 4887	skewed space jam	0		Last Available: "2011-01"
-4888	fancy spoiled tiny space jam toast	1	crappy	Effect: "Thanksgot", Effect Duration: 25, Last Available: "2011-01"
-4889	pressed extra-chilled olive narrow motivational poster	0		Effect: "Fustulent", Effect Duration: 24, Last Available: "2011-01"
+4888	tiny spoiled fancy space jam toast	1	crappy	Effect: "Thanksgot", Effect Duration: 25, Last Available: "2011-01"
+4889	pressed extra-chilled narrow olive motivational poster	0		Effect: "Fustulent", Effect Duration: 24, Last Available: "2011-01"
 4890	green sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
@@ -4814,7 +4814,7 @@
 4905	pulsating coal paperweight	0		Last Available: "2010-12"
 4906	jingle bell	0		Last Available: "2010-12"
 4907	veiny Socratic Seven Loco	0		Experience (Mysticality): +1, Maximum HP: +10, Last Available: "2010-09"
-4908	pulsating lime green Loathing Legion knife	0		Last Available: "2011-01"
+4908	lime green pulsating Loathing Legion knife	0		Last Available: "2011-01"
 4909	wobbly Loathing Legion many-purpose hook of temperance	0		Sleaze Resistance: +5, Softcore Only, Last Available: "2011-01"
 4910	brawny Loathing Legion moondial	0		Muscle Percent: +20, Softcore Only, Last Available: "2011-01"
 4911	asbestos-lined Loathing Legion necktie	0		Hot Resistance: +5, Single Equip, Softcore Only, Last Available: "2011-01"
@@ -4830,14 +4830,14 @@
 4921	red frightening Loathing Legion tape measure	0		Spooky Damage: +5, Softcore Only, Last Available: "2011-01"
 4922	Loathing Legion kitchen sink of Flo-Jo	0		Initiative: +100, Softcore Only, Last Available: "2011-01"
 4923	smooth Loathing Legion abacus	0		Moxie: +15, Softcore Only, Last Available: "2011-01"
-4924	squat bouncing Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
+4924	bouncing squat Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
 4925	lightning-fast Loathing Legion pizza stone	0		Initiative: +40, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
 4926	tumbling Loathing Legion universal screwdriver	0		Last Available: "2011-01"
 4927	purple Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
 4928	manspreader's Loathing Legion hammer	0		Monster Level: +10, Softcore Only, Last Available: "2011-01"
 4929	blue Uncle Crimbo's Sack	0		Last Available: "2011-01"
-4930	pulsating huge Folder Holder	0		Last Available: "2013-08"
-4937	mirror wobbly a angel	0		Free Pull, Last Available: "2011-12"
+4930	huge pulsating Folder Holder	0		Last Available: "2013-08"
+4937	wobbly mirror a angel	0		Free Pull, Last Available: "2011-12"
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	skewed time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
@@ -4855,15 +4855,15 @@
 4952	galvanized deionized yellow baggie of sugar	0		Effect: "Coming Up Roses", Effect Duration: 44
 4953	prompt whalebone corset of the scaredy-cat	0		Monster Level: -15, Adventures: +3, Single Equip
 4954	tumbling oven mitts of terror	0		Spooky Spell Damage: +10, Single Equip
-4955	flavorless miniature overcookie	2	decent	
-4956	bland special philosopher's scone	3	decent	Effect: "Once Bitten Twice Fried", Effect Duration: 50
+4955	miniature flavorless overcookie	2	decent	
+4956	special bland philosopher's scone	3	decent	Effect: "Once Bitten Twice Fried", Effect Duration: 50
 4957	dry cyan half-baked potion	0		Effect: "Cat-Alyzed", Effect Duration: 16
 4958	Knob Goblin deluxe scimitar of the glutton	0		Food Drop: +100
 4959	decent Knob nuts	4	good	
 4960	bad weak Cobb's Knob Wurstbrau	2	decent	
 4961	narrow Subject 37 file	0		
 4962	lightning-fast supercool mysterious lapel pin	0		Moxie Percent: +20, Initiative: +40, Single Equip
-4963	jittery shaking state loom	0		Familiar Weight: +10
+4963	shaking jittery state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
 4965	mirror ghostly Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
@@ -4918,10 +4918,10 @@
 5015	decent mirror natto pocky	4	good	Last Available: "2011-03"
 5016	bad wasabi-infused sake	3	decent	Last Available: "2011-03"
 5017	acceptable tobiko-infused sake	3	good	Last Available: "2011-03"
-5018	acceptable weak upside-down natto-infused sake	2	good	Last Available: "2011-03"
+5018	weak acceptable upside-down natto-infused sake	2	good	Last Available: "2011-03"
 5019	double-wet blurry wasabi marble soda	0		Effect: "In the Slimelight", Effect Duration: 55, Last Available: "2011-03"
 5020	extra-ionized tobiko marble soda	0		Effect: "Punch Another Day", Effect Duration: 54, Last Available: "2011-03"
-5021	polymerized bouncing narrow natto marble soda	0		Effect: "Human-Elf Hybrid", Effect Duration: 59, Last Available: "2011-03"
+5021	polymerized narrow bouncing natto marble soda	0		Effect: "Human-Elf Hybrid", Effect Duration: 59, Last Available: "2011-03"
 5022	narrow Alice's Army booster box	0		Last Available: "2011-03"
 5023	anodized nitrogenated ionized squat elderly jawbreaker	0		Effect: "Stench Jellied", Effect Duration: 33, Last Available: "2020-09"
 5024	distilled artisanal marshmallow flamb&eacute;	5	EPIC	Last Available: "2011-03"
@@ -4943,8 +4943,8 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	jittery double-paned horrifying extremely unsafe astral shirt	0		Weapon Damage Percent: +100, Spooky Damage: +25, Cold Resistance: +5
 5042	padded astral belt of terror	0		Damage Absorption: +20, Spooky Spell Damage: +10
-5043	half-sized toothsome astral hot dog	2		
-5044	bad narrow blinking astral pilsner	3		
+5043	toothsome half-sized astral hot dog	2		
+5044	bad blinking narrow astral pilsner	3		
 5045	ghostly upside-down astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	skewed Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4958,7 +4958,7 @@
 5055	tumbling obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	quadruple-aerosolized unsweetened Atomic Comic	0		Effect: "Jelly Combed", Effect Duration: 16, Last Available: "2011-04"
-5058	quadruple-ionized Vulcanized spinning cyan Red Pill	0		Effect: "Barking Mad", Effect Duration: 32, Last Available: "2011-04"
+5058	quadruple-ionized Vulcanized cyan spinning Red Pill	0		Effect: "Barking Mad", Effect Duration: 32, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
 5061	boxing-glove-in-a-box	0		Last Available: "2011-04"
@@ -4967,11 +4967,11 @@
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
 5065	delicious gigantic spaghetti con calaveras	10	awesome	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	normal jittery jittery tumbling popcorn	4	good	Last Available: "2011-04"
+5067	normal jittery tumbling jittery popcorn	4	good	Last Available: "2011-04"
 5068	bite-sized bland chaos popcorn	1	decent	Last Available: "2011-04"
 5069	gray mirror frightening beefy hole of the brazier	0		Muscle: +10, Hot Spell Damage: +25, Spooky Damage: +5, Last Available: "2011-04"
 5070	pulsating innuendo	0		Last Available: "2011-04"
-5071	thick adequate fancy olive s'more	0	good	Effect: "Radiant Personality", Effect Duration: 35, Last Available: "2011-04"
+5071	thick fancy adequate olive s'more	0	good	Effect: "Radiant Personality", Effect Duration: 35, Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
 5073	aged practically non-alcoholic teal Russian Ice	1	awesome	Last Available: "2011-04"
 5074	clay ashtray of the ox	0		Muscle: +20, Damage Reduction: 3, Last Available: "2011-05"
@@ -5031,13 +5031,13 @@
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	bouncing spinning Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
-5131	wet energized skewed teal Ultrasoldier Serum	0		Effect: "Discomfited", Effect Duration: 17, Last Available: "2011-06"
+5131	wet energized teal skewed Ultrasoldier Serum	0		Effect: "Discomfited", Effect Duration: 17, Last Available: "2011-06"
 5132	rotten elven hardtack	3	crappy	Last Available: "2011-06"
 5133	perfectly mixed skewed elven squeeze	4	EPIC	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	shaking E.M.U. rocket thrusters	0		Last Available: "2011-06"
-5137	ghostly shaking E.M.U. helmet	0		Last Available: "2011-06"
+5137	shaking ghostly E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
 5140	diluted astral energy drink	1		
@@ -5057,7 +5057,7 @@
 5154	stylish Moonthril Longbow	0		Moxie: +25, Last Available: "2011-06"
 5155	shaking Sinatra's Moonthril Cuirass	0		Experience (Moxie): +5, Softcore Only, Last Available: "2011-06"
 5156	horrifying plush alielf	0		Spooky Damage: +25, Last Available: "2011-06"
-5157	pickled irradiated blurry jittery tumbling Comet Drop	0		Effect: "Badger Underfoot", Effect Duration: 40, Last Available: "2020-09"
+5157	pickled irradiated tumbling jittery blurry Comet Drop	0		Effect: "Badger Underfoot", Effect Duration: 40, Last Available: "2020-09"
 5158	Temple Grandin's plush dogcat	0		Familiar Weight: +7, Last Available: "2011-06"
 5159	narrow frightening plush hamsterpus	0		Spooky Damage: +5, Last Available: "2011-06"
 5160	miser's plush ferrelf	0		Meat Drop: +10, Last Available: "2011-06"
@@ -5074,11 +5074,11 @@
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	weak lousy Saison du Lune	2	decent	Last Available: "2011-06"
+5174	lousy weak Saison du Lune	2	decent	Last Available: "2011-06"
 5175	lousy Moonthril Schnapps	3	decent	Last Available: "2011-06"
 5176	bad tumbling Wrecked Generator	3	decent	Last Available: "2011-06"
 5177	moldy Spaghetti with Moonballs	4	crappy	Last Available: "2011-06"
-5178	delicious snack-sized blue Crepes a la Lune	2	awesome	Last Available: "2011-06"
+5178	snack-sized delicious blue Crepes a la Lune	2	awesome	Last Available: "2011-06"
 5179	diet moldy bouncing Moon Pie	1	crappy	Last Available: "2011-06"
 5180	oxidized Comet Pop	0		Effect: "Steroid Boost", Effect Duration: 59, Last Available: "2011-06"
 5181	galvanized yellow Flan in the Moon	0		Effect: "Sleazy Weapon", Effect Duration: 39, Last Available: "2011-06"
@@ -5111,12 +5111,12 @@
 5208	vaporized paste	1	EPIC	Last Available: "2011-08"
 5209	boiled ghostly pulsating goblin paste	1	EPIC	Last Available: "2011-08"
 5210	denatured pirate paste	1	decent	Effect: "Saucemastery", Effect Duration: 45, Last Available: "2011-08"
-5211	diluted teal jittery chlorophyll paste	1	good	Effect: "Tea-hee", Effect Duration: 35, Last Available: "2011-08"
+5211	diluted jittery teal chlorophyll paste	1	good	Effect: "Tea-hee", Effect Duration: 35, Last Available: "2011-08"
 5212	powdered paste	1	decent	Effect: "Deadly Lampblade", Effect Duration: 30, Last Available: "2011-08"
 5213	distilled Mer-kin paste	1	crappy	Last Available: "2011-08"
 5214	diluted maroon slimy paste	1	good	Effect: "White-boy Angst", Effect Duration: 20, Last Available: "2011-08"
 5215	mixed teal penguin paste	1	crappy	Last Available: "2011-08"
-5216	dried jittery spinning yellow upside-down elemental paste	1	EPIC	Last Available: "2011-08"
+5216	dried jittery upside-down yellow spinning elemental paste	1	EPIC	Last Available: "2011-08"
 5217	denatured cosmic paste	1	decent	Effect: "Mer-kindliness", Effect Duration: 20, Last Available: "2011-08"
 5218	vaporized narrow hobo paste	1	good	Last Available: "2011-08"
 5219	twisted twirling Crimbo paste	1	decent	Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	twirling Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	moldy enchanted immense huge Ur-Donut	7	crappy	Effect: "Strong Spirit", Effect Duration: 15, Last Available: "2011-09"
+5224	immense moldy enchanted huge Ur-Donut	7	crappy	Effect: "Strong Spirit", Effect Duration: 15, Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	fortified tolerable bucket of wine	5	good	Last Available: "2011-09"
@@ -5138,31 +5138,31 @@
 5235	MacGyver's furry halo	0		Maximum MP: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	chaotic frosty halo	0		Spell Critical Percent: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	skewed wobbly asbestos-lined time halo	0		Hot Resistance: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	drinkable triple-distilled huge Lumineux Limnio	7	good	Last Available: "2011-09"
+5238	triple-distilled drinkable huge Lumineux Limnio	7	good	Last Available: "2011-09"
 5239	boozy delicious blurry Morto Moreto	5	awesome	Last Available: "2011-09"
-5240	aged fancy ghostly Temps Tempranillo	3	awesome	Last Available: "2011-09"
+5240	fancy aged ghostly Temps Tempranillo	3	awesome	Last Available: "2011-09"
 5241	drinkable high-proof spinning Bordeaux Marteaux	6	good	Last Available: "2011-09"
-5242	high-proof tolerable Fromage Pinotage	8	good	Last Available: "2011-09"
+5242	tolerable high-proof Fromage Pinotage	8	good	Last Available: "2011-09"
 5243	hand-crafted Beignet Milgranet	3	EPIC	Last Available: "2011-09"
 5244	lousy Muschat	3	decent	Last Available: "2011-09"
-5245	special bland thick tumbling cool jelly donut	5	decent	Effect: "Okee-Dokee Computer", Effect Duration: 50, Last Available: "2011-09"
+5245	bland special thick tumbling cool jelly donut	5	decent	Effect: "Okee-Dokee Computer", Effect Duration: 50, Last Available: "2011-09"
 5246	bland shrapnel jelly donut	3	decent	Last Available: "2011-09"
 5247	flavorless occult jelly donut	4	decent	Last Available: "2011-09"
 5248	rotten massive thyme jelly donut	7	crappy	Last Available: "2011-09"
-5249	moldy immense danish	7	crappy	Last Available: "2011-09"
-5250	enchanted spoiled big smashed danish	5	crappy	Effect: "Alacri Tea", Effect Duration: 5, Last Available: "2011-09"
-5251	huge bland forbidden danish	8	decent	Last Available: "2011-09"
+5249	immense moldy danish	7	crappy	Last Available: "2011-09"
+5250	enchanted big spoiled smashed danish	5	crappy	Effect: "Alacri Tea", Effect Duration: 5, Last Available: "2011-09"
+5251	bland huge forbidden danish	8	decent	Last Available: "2011-09"
 5252	toothsome jittery cool cat claw	3	awesome	Last Available: "2011-09"
 5253	gigantic decent blunt cat claw	7	good	Last Available: "2011-09"
 5254	tiny adequate fuchsia shadowy cat claw	1	good	Last Available: "2011-09"
-5255	normal small cheezburger	2	good	Last Available: "2011-09"
+5255	small normal cheezburger	2	good	Last Available: "2011-09"
 5256	stale toasted brie	4	decent	Last Available: "2011-09"
 5257	pressed deionized lime green potion of the field gar	0		Effect: "Mental A-cue-ity", Effect Duration: 34, Last Available: "2011-09"
 5258	flattened cyan pulsating too legit potion	0		Effect: "On a Roll", Effect Duration: 45, Last Available: "2011-09"
 5259	warmed Bright Water	0		Effect: "Human-Horror Hybrid", Effect Duration: 41, Last Available: "2011-09"
 5260	boiled dry mirror cold-filtered water	0		Effect: "Action", Effect Duration: 21, Last Available: "2011-09"
 5261	double-ionized magnetized moist graveyard snowglobe	0		Effect: "Cock of the Walk", Effect Duration: 19, Last Available: "2011-09"
-5262	magnetized squat ghostly green cool cat elixir	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 11, Last Available: "2011-09"
+5262	magnetized squat green ghostly cool cat elixir	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 11, Last Available: "2011-09"
 5263	pickled polarized improved potion of the captain's hammer	0		Effect: "Oiled Skin", Effect Duration: 19, Last Available: "2011-09"
 5264	frozen potion of X-ray vision	0		Effect: "Improprie Tea", Effect Duration: 64, Last Available: "2011-09"
 5265	vacuum-sealed potion of the litterbox	0		Effect: "Appeteyes", Effect Duration: 16, Last Available: "2011-09"
@@ -5172,7 +5172,7 @@
 5269	blurry bobcat grenade	0		Last Available: "2011-09"
 5270	narrow chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	wobbly maroon broken glass grenade	0		Last Available: "2011-09"
-5272	pulsating gray noxious gas grenade	0		Last Available: "2011-09"
+5272	gray pulsating noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	mirror savvy hammerus	0		Mysticality Percent: +20, Last Available: "2011-09"
@@ -5216,17 +5216,17 @@
 5313	pressed super-corrupted necrotizing body spray	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 56, Last Available: "2011-10"
 5314	boiled nitrogenated lime green bite-me-red lipstick	0		Effect: "Virgo Rising", Effect Duration: 36, Last Available: "2011-10"
 5315	colloidal pickled bouncing whisker pencil	0		Effect: "Milk Studly", Effect Duration: 12, Last Available: "2011-10"
-5316	unsweetened pulsating mirror press-on ribs	0		Effect: "Electrolit Up", Effect Duration: 50, Last Available: "2011-10"
-5317	anodized alkaline shaking teal tumbling Rattlin' Chains	0		Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2011-10"
-5318	aerosolized skewed pulsating Gummy Brains	0		Effect: "Corona de la Salsa", Effect Duration: 58, Last Available: "2011-10"
-5319	dry non-dry pulsating lime green Blood 'n' Plenty	0		Effect: "Walberg's Dim Bulb", Effect Duration: 56, Last Available: "2011-10"
+5316	unsweetened mirror pulsating press-on ribs	0		Effect: "Electrolit Up", Effect Duration: 50, Last Available: "2011-10"
+5317	anodized alkaline teal tumbling shaking Rattlin' Chains	0		Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2011-10"
+5318	aerosolized pulsating skewed Gummy Brains	0		Effect: "Corona de la Salsa", Effect Duration: 58, Last Available: "2011-10"
+5319	dry non-dry lime green pulsating Blood 'n' Plenty	0		Effect: "Walberg's Dim Bulb", Effect Duration: 56, Last Available: "2011-10"
 5320	energized corrupted upside-down Lobos Mints	0		Effect: "Marco Polarity", Effect Duration: 19, Last Available: "2011-10"
 5321	quadruple-irradiated yellow Sweet Sword	0		Effect: "Rushtacean'", Effect Duration: 52, Last Available: "2011-10"
 5322	bad Ecto-Cooler	3	decent	Last Available: "2011-10"
 5323	lousy huge Bartles and BRAAAINS wine cooler	3	decent	Last Available: "2011-10"
-5324	spirit-forward perfectly mixed Blood Light	5	EPIC	Last Available: "2011-10"
+5324	perfectly mixed spirit-forward Blood Light	5	EPIC	Last Available: "2011-10"
 5325	delicious Silver Bullet beer	3	awesome	Last Available: "2011-10"
-5326	mediocre triple-distilled Bone's Farm &quot;wine&quot;	10	decent	Last Available: "2011-10"
+5326	triple-distilled mediocre Bone's Farm &quot;wine&quot;	10	decent	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	activated moist sorority brain	0		Effect: "Sweet Incentive", Effect Duration: 38, Last Available: "2011-10"
 5329	pressed Nightstalker perfume	0		Effect: "Mushroom Moxiousness", Effect Duration: 68, Last Available: "2011-10"
@@ -5279,7 +5279,7 @@
 5376	nippy wicked plastic Big Candy	0		Spell Damage: +5, Cold Damage: +10, Last Available: "2011-12"
 5377	The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	upside-down blue spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	altered bouncing shaking groose grease	1	awesome	Effect: "Reptilian Fortitude", Effect Duration: 15, Last Available: "2012-12"
+5379	altered shaking bouncing groose grease	1	awesome	Effect: "Reptilian Fortitude", Effect Duration: 15, Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	spinning bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
@@ -5290,7 +5290,7 @@
 5387	lion tamer's ridiculous earring	0		Experience (familiar): +2, Last Available: "2011-11"
 5388	blurry ridiculous sunglasses of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-11"
 5389	adequate gigantic ridiculous sandwich	8	good	Last Available: "2011-11"
-5390	lousy irresponsibly strong ridiculous cocktail	7	decent	Last Available: "2011-11"
+5390	irresponsibly strong lousy ridiculous cocktail	7	decent	Last Available: "2011-11"
 5391	narrow ghostly teal stiffened zombie monkey necklace of terror	0		Damage Reduction: 1, Spooky Spell Damage: +10
 5392	tumbling Thwaitgold butterfly statuette	0		
 5393	lime green scrap of paper	0		
@@ -5309,9 +5309,9 @@
 5406	green flame-retardant studded Samson's cane-mail pants	0		Experience (Muscle): +5, Damage Absorption: +80, Hot Resistance: +1, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	smooth Vodka Matryoshka	4	awesome	Last Available: "2011-12"
 5408	fancy bad Gin Mint	3	decent	Effect: "Hairless and Airless", Effect Duration: 40, Last Available: "2011-12"
-5409	triple-distilled fancy tolerable shaking Tequiz Navidad	6	good	Effect: "Stimulated Brain", Effect Duration: 5, Last Available: "2011-12"
+5409	fancy triple-distilled tolerable shaking Tequiz Navidad	6	good	Effect: "Stimulated Brain", Effect Duration: 5, Last Available: "2011-12"
 5410	acceptable Mint Yulep	4	good	Last Available: "2011-12"
-5411	extra-dry acceptable Crimbojito	5	good	Last Available: "2011-12"
+5411	acceptable extra-dry Crimbojito	5	good	Last Available: "2011-12"
 5412	mediocre weak ghostly Sangria de Menthe	2	decent	Last Available: "2011-12"
 5413	pulsating candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5336,11 +5336,11 @@
 5433	pulsating cyan raspberry troll doll	0		Last Available: "2011-11"
 5434	green DNOTC Box	0		Last Available: "2017-12"
 5435	gray fudgecule	0		Last Available: "2011-11"
-5436	double-altered pickled lime green tumbling twirling fudge lily	0		Effect: "Cold Throat", Effect Duration: 34, Last Available: "2011-11"
+5436	double-altered pickled lime green twirling tumbling fudge lily	0		Effect: "Cold Throat", Effect Duration: 34, Last Available: "2011-11"
 5437	skewed superheated fudge	0		Last Available: "2011-11"
 5438	corrupted improved fluid of fudge-finding	0		Effect: "Turtle Power", Effect Duration: 18, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	bland red pulsating fudgesicle	4	decent	Last Available: "2011-11"
+5440	bland pulsating red fudgesicle	4	decent	Last Available: "2011-11"
 5441	maroon wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	pulsating miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5379,9 +5379,9 @@
 5476	irradiated tarnished upside-down gummi salamander	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 35, Last Available: "2011-11"
 5477	liquefied gummi snake	0		Effect: "Gingerbread Robust", Effect Duration: 28, Last Available: "2011-11"
 5478	modified gummi canary	0		Effect: "Spooky Demeanor", Effect Duration: 11, Last Available: "2011-11"
-5479	snack-sized decent bouncing gummi bear	2	good	Last Available: "2011-11"
+5479	decent snack-sized bouncing gummi bear	2	good	Last Available: "2011-11"
 5480	half-sized stale blinking gummi bear	2	decent	Last Available: "2011-11"
-5481	tiny flavorless gummi bear	1	decent	Last Available: "2011-11"
+5481	flavorless tiny gummi bear	1	decent	Last Available: "2011-11"
 5482	normal huge drunki-bear	7	good	Last Available: "2011-11"
 5483	spoiled drunki-bear	3	crappy	Last Available: "2011-11"
 5484	delicious narrow drunki-bear	4	awesome	Last Available: "2011-11"
@@ -5394,7 +5394,7 @@
 5491	maroon trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	fuchsia belemnite candy mold	0		Last Available: "2011-11"
-5494	polarized spinning spinning bouncing gummi trilobite	0		Effect: "Your Favorite Flavor", Effect Duration: 20, Last Available: "2011-11"
+5494	polarized bouncing spinning spinning gummi trilobite	0		Effect: "Your Favorite Flavor", Effect Duration: 20, Last Available: "2011-11"
 5495	ionized warmed gummi ammonite	0		Effect: "Old Time Hydration", Effect Duration: 30, Last Available: "2011-11"
 5496	dry gummi belemnite	0		Effect: "Ruthlessly Efficient", Effect Duration: 45, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
@@ -5444,7 +5444,7 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	twirling pink-belly slapper	0		Last Available: "2012-12"
 5543	Newton's Leapin' Trousers of incineration	0		Experience (Mysticality): +3, Hot Spell Damage: +50
-5544	strong bad maroon squat eggnog	5	decent	Last Available: "2012-12"
+5544	bad strong maroon squat eggnog	5	decent	Last Available: "2012-12"
 5545	adequate small hamhock	2	good	Last Available: "2012-12"
 5546	narrow The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	huge lime green Clancy's sackbut	0		Last Available: "2012-12"
@@ -5466,79 +5466,79 @@
 5563	yellow Rain-Doh box	0		Last Available: "2012-02"
 5564	bouncing Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	tasty PB&BP	3	awesome	
-5566	low-calorie flavorless club sandwich	1	decent	
-5567	massive delicious corned-beef Reuben	7	awesome	
+5566	flavorless low-calorie club sandwich	1	decent	
+5567	delicious massive corned-beef Reuben	7	awesome	
 5568	lime green frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
-5572	wobbly twirling Thwaitgold stag beetle statuette	0		
-5573	aged weak ghostly Drac & Tan	2	awesome	Last Available: "2012-03"
-5574	watered-down enchanted acceptable Transylvania Sling	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2012-03"
+5572	twirling wobbly Thwaitgold stag beetle statuette	0		
+5573	weak aged ghostly Drac & Tan	2	awesome	Last Available: "2012-03"
+5574	enchanted acceptable watered-down Transylvania Sling	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2012-03"
 5575	watered-down mediocre Shot of the Living Dead	2	decent	Last Available: "2012-03"
 5576	perfectly mixed Buttery Knob	3	EPIC	Last Available: "2012-03"
-5577	distilled fancy mediocre Slippery Knob	5	decent	Effect: "Hot Blooded", Effect Duration: 20, Last Available: "2012-03"
-5578	smooth weak Flaming Knob	2	awesome	Last Available: "2012-03"
+5577	fancy distilled mediocre Slippery Knob	5	decent	Effect: "Hot Blooded", Effect Duration: 20, Last Available: "2012-03"
+5578	weak smooth Flaming Knob	2	awesome	Last Available: "2012-03"
 5579	perfectly mixed irresponsibly strong Grasshopper	7	EPIC	Last Available: "2012-03"
 5580	hand-crafted shaking pulsating Locust	3	EPIC	Last Available: "2012-03"
-5581	tolerable weak Plague of Locusts	2	good	Last Available: "2012-03"
+5581	weak tolerable Plague of Locusts	2	good	Last Available: "2012-03"
 5582	practically non-alcoholic artisanal Red Dwarf	1	EPIC	Last Available: "2012-03"
 5583	acceptable Golden Mean	3	good	Last Available: "2012-03"
-5584	smooth fortified Green Giant	5	awesome	Last Available: "2012-03"
-5585	mediocre weak Aye Aye	2	decent	Last Available: "2012-03"
-5586	practically non-alcoholic aged Aye Aye, Captain	1	awesome	Last Available: "2012-03"
+5584	fortified smooth Green Giant	5	awesome	Last Available: "2012-03"
+5585	weak mediocre Aye Aye	2	decent	Last Available: "2012-03"
+5586	aged practically non-alcoholic Aye Aye, Captain	1	awesome	Last Available: "2012-03"
 5587	special tolerable Aye Aye, Tooth Tooth	4	good	Effect: "Strength of Ten Ettins", Effect Duration: 15, Last Available: "2012-03"
 5588	acceptable practically non-alcoholic pulsating Humanitini	1	good	Last Available: "2012-03"
 5589	tolerable watered-down More Humanitini than Humanitini	2	good	Last Available: "2012-03"
-5590	watered-down tolerable Oh, the Humanitini	2	good	Last Available: "2012-03"
-5591	high-proof mediocre Great Older Fashioned	10	decent	Last Available: "2012-03"
+5590	tolerable watered-down Oh, the Humanitini	2	good	Last Available: "2012-03"
+5591	mediocre high-proof Great Older Fashioned	10	decent	Last Available: "2012-03"
 5592	high-proof artisanal Fuzzy Tentacle	8	EPIC	Last Available: "2012-03"
 5593	perfectly mixed Crazymaker	3	EPIC	Last Available: "2012-03"
-5594	boozy drinkable narrow Zoodriver	5	good	Last Available: "2012-03"
+5594	drinkable boozy narrow Zoodriver	5	good	Last Available: "2012-03"
 5595	perfectly mixed ghostly jittery Sloe Comfortable Zoo	3	EPIC	Last Available: "2012-03"
 5596	lousy Sloe Comfortable Zoo on Fire	3	decent	Last Available: "2012-03"
 5597	practically non-alcoholic aged Suffering Sinner	1	awesome	Last Available: "2012-03"
 5598	mediocre practically non-alcoholic Suppurating Sinner	1	decent	Last Available: "2012-03"
-5599	lousy triple-distilled Sizzling Sinner	8	decent	Last Available: "2012-03"
+5599	triple-distilled lousy Sizzling Sinner	8	decent	Last Available: "2012-03"
 5600	tolerable blurry Firewater	3	good	Last Available: "2012-03"
-5601	enchanted perfectly mixed Earth and Firewater	3	EPIC	Effect: "Sugar, Hello", Effect Duration: 35, Last Available: "2012-03"
+5601	perfectly mixed enchanted Earth and Firewater	3	EPIC	Effect: "Sugar, Hello", Effect Duration: 35, Last Available: "2012-03"
 5602	drinkable Earth, Wind and Firewater	4	good	Last Available: "2012-03"
-5603	watered-down lousy Slimosa	2	decent	Last Available: "2012-03"
+5603	lousy watered-down Slimosa	2	decent	Last Available: "2012-03"
 5604	bad Extra-slimy Slimosa	3	decent	Last Available: "2012-03"
-5605	perfectly mixed watered-down Slimebite	2	EPIC	Last Available: "2012-03"
+5605	watered-down perfectly mixed Slimebite	2	EPIC	Last Available: "2012-03"
 5606	acceptable Cement Mixer	4	good	Last Available: "2012-03"
 5607	bad twirling Jackhammer	3	decent	Last Available: "2012-03"
-5608	tolerable irresponsibly strong blurry pulsating Dump Truck	9	good	Last Available: "2012-03"
-5609	watered-down hand-crafted Fauna Libre	2	EPIC	Last Available: "2012-03"
+5608	irresponsibly strong tolerable blurry pulsating Dump Truck	9	good	Last Available: "2012-03"
+5609	hand-crafted watered-down Fauna Libre	2	EPIC	Last Available: "2012-03"
 5610	acceptable irresponsibly strong blue Chakra Libre	8	good	Last Available: "2012-03"
-5611	mediocre high-proof Aura Libre	9	decent	Last Available: "2012-03"
-5612	fortified hand-crafted Sazerorc	5	EPIC	Last Available: "2012-03"
+5611	high-proof mediocre Aura Libre	9	decent	Last Available: "2012-03"
+5612	hand-crafted fortified Sazerorc	5	EPIC	Last Available: "2012-03"
 5613	tolerable strong Sazuruk-hai	5	good	Last Available: "2012-03"
 5614	drinkable Flaming Sazerorc	4	good	Last Available: "2012-03"
 5615	practically non-alcoholic artisanal Green Velvet	1	EPIC	Last Available: "2012-03"
 5616	drinkable lime green Green Muslin	3	good	Last Available: "2012-03"
 5617	tolerable Green Burlap	3	good	Last Available: "2012-03"
 5618	bad Mohobo	3	decent	Last Available: "2012-03"
-5619	triple-distilled tolerable narrow Moonshine Mohobo	7	good	Last Available: "2012-03"
-5620	acceptable irresponsibly strong Flaming Mohobo	8	good	Last Available: "2012-03"
+5619	tolerable triple-distilled narrow Moonshine Mohobo	7	good	Last Available: "2012-03"
+5620	irresponsibly strong acceptable Flaming Mohobo	8	good	Last Available: "2012-03"
 5621	watered-down artisanal purple Drunken Philosopher	2	EPIC	Last Available: "2012-03"
 5622	drinkable Drunken Neurologist	3	good	Last Available: "2012-03"
 5623	perfectly mixed mirror Drunken Astrophysicist	3	EPIC	Last Available: "2012-03"
-5624	tolerable fancy irresponsibly strong narrow Dark & Starry	7	good	Effect: "Danish Cunning", Effect Duration: 10, Last Available: "2012-03"
-5625	boozy artisanal wobbly Black Hole	5	EPIC	Last Available: "2012-03"
-5626	practically non-alcoholic artisanal skewed Event Horizon	1	super ultra EPIC	Last Available: "2012-03"
-5627	acceptable enchanted Herring Daiquiri	3	good	Effect: "Cold Hands", Effect Duration: 10, Last Available: "2012-03"
+5624	fancy irresponsibly strong tolerable narrow Dark & Starry	7	good	Effect: "Danish Cunning", Effect Duration: 10, Last Available: "2012-03"
+5625	artisanal boozy wobbly Black Hole	5	EPIC	Last Available: "2012-03"
+5626	artisanal practically non-alcoholic skewed Event Horizon	1	super ultra EPIC	Last Available: "2012-03"
+5627	enchanted acceptable Herring Daiquiri	3	good	Effect: "Cold Hands", Effect Duration: 10, Last Available: "2012-03"
 5628	drinkable skewed Herring Wallbanger	3	good	Last Available: "2012-03"
 5629	mediocre practically non-alcoholic Herringtini	1	decent	Last Available: "2012-03"
-5630	bad strong Lollipop Drop	5	decent	Last Available: "2012-03"
+5630	strong bad Lollipop Drop	5	decent	Last Available: "2012-03"
 5631	acceptable weak Candy Alexander	2	good	Last Available: "2012-03"
-5632	mediocre watered-down Candicaine	2	decent	Last Available: "2012-03"
+5632	watered-down mediocre Candicaine	2	decent	Last Available: "2012-03"
 5633	hand-crafted pulsating Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	lousy Flying Caipiranha	4	decent	Last Available: "2012-03"
 5635	extra-dry perfectly mixed Flaming Caipiranha	5	EPIC	Last Available: "2012-03"
 5636	perfectly mixed watered-down Punchplanter	2	EPIC	Last Available: "2012-03"
-5637	practically non-alcoholic tolerable Doublepunchplanter	1	good	Last Available: "2012-03"
-5638	triple-distilled drinkable Haymaker	8	good	Last Available: "2012-03"
+5637	tolerable practically non-alcoholic Doublepunchplanter	1	good	Last Available: "2012-03"
+5638	drinkable triple-distilled Haymaker	8	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	normal fungus	3	good	
@@ -5546,7 +5546,7 @@
 5643	chilled boiled jittery stone wool	0		Effect: "Hair on Your Chest", Effect Duration: 33
 5644	stones	0		
 5645	maroon the Nostril of the Serpent	0		
-5646	shaking blinking calendar fragment	0		
+5646	blinking shaking calendar fragment	0		
 5647	calendar of horror	0		Spooky Spell Damage: +25, Damage Reduction: 4
 5648	medical-grade stiffened Boris's Helm	0		Damage Reduction: 1, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	baleful staph of homophones of the brute	0		Muscle Percent: +30, Spell Damage: +25
@@ -5566,10 +5566,10 @@
 5663	microwave	0		Free Pull
 5664	ghostly pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
-5666	green jittery How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
+5666	jittery green How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
-5669	upside-down bouncing shaking club	0		
+5669	upside-down shaking bouncing club	0		
 5670	flavorless wobbly fettucini &eacute;pines Inconnu	4	decent	
 5671	drinkable slap and slap again	3	good	
 5672	bouncing gunpowder burrito	2	good	
@@ -5628,11 +5628,11 @@
 5727	sharpshooter's extremely unsafe hot daub stand	0		Weapon Damage Percent: +100, Critical Hit Percent: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	upside-down wizardly foot-long hot daub of the boozehound	0		Mysticality: +25, Booze Drop: +100, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	jumbo moldy fancy angst burger	5	crappy	Effect: "Disdain of the War Snapper", Effect Duration: 50
-5731	weak delicious pulsating mirror 5-hour acrimony	2	awesome	
+5730	fancy jumbo moldy angst burger	5	crappy	Effect: "Disdain of the War Snapper", Effect Duration: 50
+5731	delicious weak mirror pulsating 5-hour acrimony	2	awesome	
 5732	ghostly blank note	0		
 5733	eerily silent box	0		
-5734	rotten bite-sized mirror forbidden sausage	1	crappy	
+5734	bite-sized rotten mirror forbidden sausage	1	crappy	
 5735	personal trainer's Lord Flameface's cloak	0		Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	deionized Drizzlers&trade; Black Licorice	0		Effect: "Void Between the Stars", Effect Duration: 55
 5737	moist polymerized daub-breaker	0		Effect: "Sparkling Consciousness", Effect Duration: 22, Last Available: "2020-09"
@@ -5641,7 +5641,7 @@
 5740	delicious low-calorie bag of GORP	1	awesome	Last Available: "2012-07"
 5741	lousy narrow water purification pills	4	decent	Last Available: "2012-07"
 5742	blinking Camp Scout pup tent	0		Last Available: "2012-07"
-5743	distilled aged CSA scoutmaster's &quot;water&quot;	5	awesome	Last Available: "2012-07"
+5743	aged distilled CSA scoutmaster's &quot;water&quot;	5	awesome	Last Available: "2012-07"
 5744	diet tasty wobbly bag of GORF	1	awesome	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	moldy bag of QWOP	3	crappy	Last Available: "2012-07"
@@ -5652,9 +5652,9 @@
 5751	Tales of the Word Realms	0		
 5752	decent green twirling crappy brain	4	good	
 5753	stale green decent brain	3	decent	
-5754	toothsome miniature good brain	2	awesome	
+5754	miniature toothsome good brain	2	awesome	
 5755	flavorless boss brain	4	decent	
-5756	spoiled special small bouncing jittery hunter brain	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10
+5756	small special spoiled jittery bouncing hunter brain	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10
 5758	double-paned Samson's boxer's Staff of Holiday Sensations	0		Muscle Percent: +10, Experience (Muscle): +5, Cold Resistance: +5, Last Available: "2011-11"
 5759	bouncing ghostly supercharged studded staff	0		Damage Absorption: +80, Maximum MP Percent: +30
 5760	narrow skewed Herculean beefcake's staff of temperance	0		Muscle: +25, Experience (Muscle): +1, Sleaze Resistance: +5
@@ -5677,7 +5677,7 @@
 5778	normal diet blinking mirror idiot brain	1	good	
 5779	blurry brainy keel-haulin' knife	0		Mysticality: +5
 5780	Rosewater's ice cream scoop	0		Mysticality Percent: +30
-5781	triple-distilled perfectly mixed jittery soft echo eyedrop antidote martini	6	EPIC	
+5781	perfectly mixed triple-distilled jittery soft echo eyedrop antidote martini	6	EPIC	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5694,13 +5694,13 @@
 5795	polarized Enchanted Flyswatter	0		Effect: "Egg-headedness", Effect Duration: 51
 5796	ionized Gearhead Goo	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 23
 5797	wet warmed Missing Eye Simulation Device	0		Effect: "Phoenix, Right?", Effect Duration: 52
-5798	oxidized red pulsating Gnollish Crossdress	0		Effect: "There Wolf", Effect Duration: 48
+5798	oxidized pulsating red Gnollish Crossdress	0		Effect: "There Wolf", Effect Duration: 48
 5799	polarized eldritch dough	0		Effect: "Sinuses For Miles", Effect Duration: 55
 5800	polarized improved cold-filtered Charity's choker	0		Effect: "Healthy Green Glow", Effect Duration: 27
 5801	polarized wobbly Smart Bone Dust	0		Effect: "Unusual Fashion Sense", Effect Duration: 12
 5802	nitrogenated diffused triple-warmed ghostly perpendicular guano	0		Effect: "Space Cadet", Effect Duration: 60
 5803	concentrated green White Chocolate Golem Seeds	0		Effect: "Scavengers Scavenging", Effect Duration: 31
-5804	dry chilled wobbly shaking Shivering Ch&egrave;vre	0		Effect: "Texas Elegance", Effect Duration: 55
+5804	dry chilled shaking wobbly Shivering Ch&egrave;vre	0		Effect: "Texas Elegance", Effect Duration: 55
 5805	double-Vulcanized enhanced jittery breath mint	0		Effect: "Man's Worst Enemy", Effect Duration: 24
 5806	energized super-quantum muesli	0		Effect: "Pisces in the Skyces", Effect Duration: 50
 5807	dry vacuum-sealed glass of warm milk	0		Effect: "Experimental Effect G-9", Effect Duration: 27
@@ -5709,14 +5709,14 @@
 5810	denatured super-flattened double-electrified jittery Tears of the Quiet Healer	0		Effect: "Sated and Furious", Effect Duration: 44
 5811	activated improved tube of lipstick	0		Effect: "Riboflavin'", Effect Duration: 23
 5812	non-aerosolized green ghostly skelelton spine	0		Effect: "Salad Days", Effect Duration: 54
-5813	deionized huge pulsating smut orc sunglasses	0		Effect: "Crimbo Flavor", Effect Duration: 18
+5813	deionized pulsating huge smut orc sunglasses	0		Effect: "Crimbo Flavor", Effect Duration: 18
 5814	pressed warmed blob of acid	0		Effect: "Destructive Resolve", Effect Duration: 33
 5815	magnetized flayed mind	0		Effect: "Orchid Blood", Effect Duration: 25
 5816	alkaline kobold kibble	0		Effect: "Heart of Pink", Effect Duration: 11
 5817	electrified pickled forest spirit rattle	0		Effect: "One For Tea", Effect Duration: 33
 5818	wet olive Stone Golem pebbles	0		Effect: "Knightlife", Effect Duration: 25
-5819	modified galvanized bouncing wobbly gravy fairy warlock hat	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 21
-5820	vacuum-sealed improved gray huge bull blubber	0		Effect: "Inappropriate Spirit", Effect Duration: 64
+5819	modified galvanized wobbly bouncing gravy fairy warlock hat	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 21
+5820	vacuum-sealed improved huge gray bull blubber	0		Effect: "Inappropriate Spirit", Effect Duration: 64
 5821	polymerized frog lip-print	0		Effect: "Butt-Rock Hair", Effect Duration: 58
 5822	pressed quadruple-altered unsweetened spinning gazely stare	0		Effect: "Craft Tea", Effect Duration: 28
 5823	pickled ionized canopic jar	0		Effect: "Red Misty-Eyed", Effect Duration: 17
@@ -5742,7 +5742,7 @@
 5843	triple-pressed jittery pirate cream pie	0		Effect: "The Rich Get Richer", Effect Duration: 37
 5844	deionized double-aerosolized huge twirling una poca de gracia	0		Effect: "All Fired Up", Effect Duration: 45
 5845	aerosolized squat compressed air canister	0		Effect: "Spooky Jellied", Effect Duration: 57
-5846	irradiated wobbly skewed purple salt water taffy	0		Effect: "Sharp Weapon", Effect Duration: 44
+5846	irradiated skewed purple wobbly salt water taffy	0		Effect: "Sharp Weapon", Effect Duration: 44
 5847	moist unholy water	0		Effect: "Standard Issue Bravery", Effect Duration: 25
 5848	anodized tumbling Bangyomaman battle juice	0		Effect: "Adapt to Change Eventually", Effect Duration: 69
 5849	double-altered extra-altered mirror handyman &quot;hand soap&quot;	0		Effect: "Stinky Weapon", Effect Duration: 52
@@ -5798,7 +5798,7 @@
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	skewed fuchsia jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	jar of psychoses (The Old Man)	0		Last Available: "2013-12"
-5902	squat shaking jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
+5902	shaking squat jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	huge jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	upside-down pixel pill	0		
@@ -5862,7 +5862,7 @@
 5964	twirling A-Boo clue	0		
 5965	twirling stylish Frown Exerciser of the brazier	0		Moxie: +25, Hot Spell Damage: +25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
-5967	green mirror soul doorbell	0		
+5967	mirror green soul doorbell	0		
 5968	soul coin	0		
 5969	soul knife	0		
 5970	friendly soul mask	0		Familiar Weight: +3, Single Equip
@@ -5873,8 +5873,8 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	skewed record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	shaking toasty medical-grade brainy silent beret	0		Mysticality: +5, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley, cap 3"
-5978	immense decent enchanted slice of pizza	10	good	Effect: "Human-Penguin Hybrid", Effect Duration: 10, Last Available: "2013-02"
-5979	bouncing red huge coin	0		Last Available: "2013-02"
+5978	immense enchanted decent slice of pizza	10	good	Effect: "Human-Penguin Hybrid", Effect Duration: 10, Last Available: "2013-02"
+5979	red bouncing huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	weak lousy shaking tankard of ale	2	decent	Last Available: "2013-02"
@@ -5894,7 +5894,7 @@
 5996	blinking extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	tolerable shining goblet	3	good	Last Available: "2013-02"
-5999	huge upside-down fireball	0		Last Available: "2013-02"
+5999	upside-down huge fireball	0		Last Available: "2013-02"
 6000	Newton's savvy crown of the glutton	0		Mysticality Percent: +20, Experience (Mysticality): +3, Food Drop: +100, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	sword of chilblains of the glutton	0		Cold Damage: +25, Item Drop: +5, Food Drop: +100, Last Available: "2013-02"
 6002	Oprah's shellacked personal trainer's Helm of the Scream Emperor	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Maximum MP Percent: +50, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
@@ -5931,14 +5931,14 @@
 6033	skewed nasty arcane researcher's stolen necklace	0		Experience Percent (Mysticality): +10, Stench Damage: +5
 6034	skewed experienced troll britches of wisdom	0		Mysticality: +15, Experience: +2, Familiar Effect: "1.5xPotato, cap 28"
 6035	quantum olive vial of The Glistening	0		Effect: "Dragged Through the Coals", Effect Duration: 66
-6036	mediocre cyan ghostly artisanal limoncello	4	decent	
+6036	mediocre ghostly cyan artisanal limoncello	4	decent	
 6037	blue ginger ale	0		
-6038	jumbo adequate incredible pizza	5	good	
+6038	adequate jumbo incredible pizza	5	good	
 6039	blurry fireproof oil cap of the cheetah	0		Hot Resistance: +3, Initiative: +60, Familiar Effect: "cap 28"
 6040	tumbling manspreader's MacGyver's oil lamp	0		Maximum MP: +100, Monster Level: +10
 6041	mirror blurry oil slacks	0		Item Drop: +5, Familiar Effect: "1xPotato, cap 30"
 6042	oil pan of the storm	0		Maximum MP Percent: +40
-6043	skewed upside-down boid	0		
+6043	upside-down skewed boid	0		
 6044	bouncing woim	0		
 6045	mirror Thwaitgold praying mantis statuette	0		
 6046	BittyCar SoulCar	0		Last Available: "2012-12"
@@ -5966,12 +5966,12 @@
 6068	gray narrow loose blade	0		
 6069	squat goblin bone hilt	0		
 6070	cyan sword blade	0		
-6071	teal wobbly Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	wobbly teal Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	teal confusing LED clock	0		Last Available: "2012-12"
 6073	modified energized haggis-infused soap	0		Effect: "Executive Greed", Effect Duration: 38, Last Available: "2012-12"
 6074	altered denatured warmed magicberry tablets	0		Effect: "Pumped Stomach", Effect Duration: 62, Last Available: "2012-12"
 6075	ionized polarized corrupted 37x37x37 puzzle cube	0		Effect: "Cold Jellied", Effect Duration: 55, Last Available: "2012-12"
-6076	weak hand-crafted McLeod's Hard Haggis-Ade	2	EPIC	Last Available: "2012-12"
+6076	hand-crafted weak McLeod's Hard Haggis-Ade	2	EPIC	Last Available: "2012-12"
 6077	rotten upside-down haggis-wrapped haggis-stuffed haggis	4	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -6001,7 +6001,7 @@
 6103	shaking Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	Artist's Spatula of Despair	0		Last Available: "2013-12"
-6106	tumbling squat Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
+6106	squat tumbling Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	up-at-dawn Ginsu&trade; of vim and vigor	0		Maximum HP Percent: +50, Adventures: +5, Last Available: "2013-12"
 6109	wobbly bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
@@ -6012,15 +6012,15 @@
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	maroon zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	fuchsia jittery CEO office card	0		Last Available: "2013-12"
-6117	pulsating fuchsia test site key	0		Last Available: "2013-12"
+6117	fuchsia pulsating test site key	0		Last Available: "2013-12"
 6118	goggles	0		Last Available: "2013-12"
 6119	huge abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
 6121	lousy watered-down Chinese beer	2	decent	Last Available: "2013-12"
-6122	ghostly cyan upside-down cat statue	0		Last Available: "2013-12"
+6122	upside-down ghostly cyan cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
-6125	magnetized quadruple-frozen green skewed bottle of limeade	0		Effect: "Ticking Clock", Effect Duration: 48, Last Available: "2013-12"
+6125	magnetized quadruple-frozen skewed green bottle of limeade	0		Effect: "Ticking Clock", Effect Duration: 48, Last Available: "2013-12"
 6126	teal Temple Grandin's weightlifter's novelty tattoo sleeves	0		Muscle: +15, Familiar Weight: +7, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	upside-down furry brown pillow	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	Tesla rubber gloves	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 6140	green Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	gigantic tasty tumbling roasted duck	10	awesome	Last Available: "2013-12"
+6142	tasty gigantic tumbling roasted duck	10	awesome	Last Available: "2013-12"
 6143	stale small dead meat bun	2	decent	Last Available: "2013-12"
 6144	brainy cat collar	0		Mysticality: +5, Single Equip, Last Available: "2013-12"
 6145	dangerous Fonzie's suspicious-looking fedora	0		Experience (Moxie): +1, Weapon Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
@@ -6079,12 +6079,12 @@
 6182	cosmic cream	0		
 6183	twirling cosmic fruit	0		
 6184	up-at-dawn grievous Jarlsberg's hat of the detective	0		Weapon Damage Percent: +50, Item Drop: +20, Adventures: +5
-6185	bland snack-sized fancy consummate hard-boiled egg	2	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 5
+6185	fancy snack-sized bland consummate hard-boiled egg	2	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 5
 6186	normal thick ghostly consummate fried egg	5	good	
-6187	stale immense enchanted consummate egg salad	10	decent	Effect: "Flaming Weapon", Effect Duration: 25
+6187	immense enchanted stale consummate egg salad	10	decent	Effect: "Flaming Weapon", Effect Duration: 25
 6188	stale consummate bagel	3	decent	
 6189	stale special consummate sliced bread	3	decent	Effect: "Angry like the Wolf", Effect Duration: 15
-6190	huge flavorless consummate hot dog bun	8	decent	
+6190	flavorless huge consummate hot dog bun	8	decent	
 6191	bland upside-down consummate brownie	3	decent	
 6192	rotten consummate toast	3	crappy	
 6193	extra-dry hand-crafted cyan passable stout	5	EPIC	
@@ -6096,40 +6096,40 @@
 6199	normal wobbly consummate cheese slice	4	good	
 6200	decent massive jittery consummate melted cheese	6	good	
 6201	rotten consummate bacon	3	crappy	
-6202	bland small consummate meatloaf	2	decent	
-6203	toothsome thick teal consummate steak	5	awesome	
+6202	small bland consummate meatloaf	2	decent	
+6203	thick toothsome teal consummate steak	5	awesome	
 6204	spoiled small twirling consummate cuts	2	crappy	
-6205	rotten gigantic consummate frankfurter	9	crappy	
+6205	gigantic rotten consummate frankfurter	9	crappy	
 6206	rotten consummate french fries	3	crappy	
 6207	super-sized rotten consummate baked potato	5	crappy	
-6208	acceptable skewed blurry acceptable vodka	3	good	
+6208	acceptable blurry skewed acceptable vodka	3	good	
 6209	immense bland consummate ice cream	9	decent	
-6210	yummy huge consummate whipped cream	10	awesome	
+6210	huge yummy consummate whipped cream	10	awesome	
 6211	spoiled consummate cream	3	crappy	
 6212	flavorless fancy consummate strawberries	3	decent	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 20
 6213	spoiled consummate sorbet	3	crappy	
-6214	lousy weak ghostly adequate rum	2	decent	
+6214	weak lousy ghostly adequate rum	2	decent	
 6215	acceptable twirling mediocre lager	3	good	
 6216	delicious immaculate grilled cheese	3	awesome	
-6217	flavorless low-calorie immaculate ice cream sandwich	1	decent	
+6217	low-calorie flavorless immaculate ice cream sandwich	1	decent	
 6218	moldy super-sized immaculate hot dog	5	crappy	
 6219	spoiled pulsating immaculate egg salad sandwich	3	crappy	
 6220	bland pulsating perfect sandwich	4	decent	
 6221	spoiled miniature perfect chef salad	2	crappy	
 6222	snack-sized rotten perfect breakfast	2	crappy	
 6223	spoiled sublime deluxe hot dog	3	crappy	
-6224	stale small sublime stew	2	decent	
-6225	jumbo yummy blurry sublime nachos	5	awesome	
+6224	small stale sublime stew	2	decent	
+6225	yummy jumbo blurry sublime nachos	5	awesome	
 6226	moldy Ultimate Breakfast Sandwich	3	crappy	
-6227	spoiled special Loaded Baked Potato	3	crappy	Effect: "Some Cheese with Your Wine", Effect Duration: 30
+6227	special spoiled Loaded Baked Potato	3	crappy	Effect: "Some Cheese with Your Wine", Effect Duration: 30
 6228	jumbo rotten lime green Omega Sundae	5	crappy	
 6229	perfectly mixed high-proof teal Das Sauerlager	10	EPIC	
-6230	aged weak blurry Bologna Lambic	2	awesome	
+6230	weak aged blurry Bologna Lambic	2	awesome	
 6231	watered-down drinkable Vodka Dog	2	good	
-6232	mediocre high-proof Disappointed Russian	6	decent	
+6232	high-proof mediocre Disappointed Russian	6	decent	
 6233	perfectly mixed upside-down Chunky Mary	4	EPIC	
 6234	bad jittery Nachojito	3	decent	
-6235	lousy weak Le Roi	2	decent	
+6235	weak lousy Le Roi	2	decent	
 6236	weak mediocre Over Easy Rider	2	decent	
 6237	cosmic six-pack	0		
 6239	irradiated squat cube of ectoplasm	0		Effect: "Riboflavin'", Effect Duration: 65
@@ -6139,7 +6139,7 @@
 6243	electrified Vulcanized the kindest cut	0		Effect: "Mighty Shout", Effect Duration: 53
 6244	Vulcanized altered cat's paw	0		Effect: "Kernel Panic!", Effect Duration: 45
 6245	altered super-Vulcanized colloidal spinning ASCII fu manchu	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 57
-6246	irradiated cold-filtered olive pulsating demonic surgical gloves	0		Effect: "Dances with Tweedles", Effect Duration: 23
+6246	irradiated cold-filtered pulsating olive demonic surgical gloves	0		Effect: "Dances with Tweedles", Effect Duration: 23
 6247	colloidal non-activated squat blurry clip-on ninja tie	0		Effect: "Yuletide Sappiness", Effect Duration: 38
 6248	triple-irradiated electrified lime green gamer slurry	0		Effect: "Flame-Retardant Trousers", Effect Duration: 39
 6249	skewed dungeoneering kit	0		Last Available: "2013-02"
@@ -6169,13 +6169,13 @@
 6273	polymerized aerosolized O'RLY manual	0		Effect: "Oiled Skin", Effect Duration: 61
 6274	drinkable open sauce	3	good	
 6275	wobbly miser's chilly turkey leg	0		Cold Damage: +5, Meat Drop: +10
-6276	bad weak Ye Olde Meade	2	decent	
+6276	weak bad Ye Olde Meade	2	decent	
 6277	quadruple-unsweetened galvanized Ye Olde Bawdy Limerick	0		Effect: "Bananas!", Effect Duration: 34
 6278	upside-down Ye Olde Medieval Insult	0		
 6279	pewter claymore of wisdom	0		Mysticality: +15
 6280	educational artisanal rice peeler	0		Experience: +1
-6281	moldy small tumbling heirloom grape tomato	2	crappy	
-6282	shaking blurry ghostly chipotle wasabi cilantro aioli	0		
+6281	small moldy tumbling heirloom grape tomato	2	crappy	
+6282	shaking ghostly blurry chipotle wasabi cilantro aioli	0		
 6283	fuchsia brown felt tophat of the cougar	0		Moxie: +20, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
 6285	wobbly family-friendly cool Mark I Steam-Hat	0		Moxie: +5, Sleaze Resistance: +1, Familiar Effect: "1xLep, cap 37"
@@ -6186,7 +6186,7 @@
 6290	steam-powered model rocketship	0		
 6291	smartaleck's supercool punk rock jacket	0		Moxie Percent: 50
 6292	cyan lightning-fast Da Vinci's safety pin	0		Experience (Mysticality): +5, Initiative: +40
-6293	jumbo rotten stolen sushi	5	crappy	
+6293	rotten jumbo stolen sushi	5	crappy	
 6294	pulsating very overdue library book	0		
 6295	spinning drum 'n' bass 'n' drum 'n' bass record	0		
 6296	ghostly cosmic bucket	0		Free Pull
@@ -6238,7 +6238,7 @@
 6342	Socratic super-strong air freshener of the scaredy-cat	0		Experience (Mysticality): +1, Monster Level: -15
 6343	flattened improved Mer-kin lipstick	0		Effect: "Bastard!", Effect Duration: 45
 6344	blurry Mer-kin mouthsoap	0		
-6345	altered magnetized tumbling skewed Mer-kin strongjuice	0		Effect: "Square to be Hip", Effect Duration: 21
+6345	altered magnetized skewed tumbling Mer-kin strongjuice	0		Effect: "Square to be Hip", Effect Duration: 21
 6346	Mer-kin fitbrine	0		
 6347	triple-denatured alkaline jittery Mer-kin ragejuice	0		Effect: "Hiding in Plain Sight", Effect Duration: 32
 6348	squat supercharged Mer-kin dragbelt	0		Maximum MP Percent: +30, Experience (Muscle): +20, Single Equip
@@ -6256,10 +6256,10 @@
 6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	improved dry narrow pulled taffy	0		Effect: "Wings of the Grasshopper", Effect Duration: 17, Last Available: "2013-04"
 6362	dry magnetized concentrated wobbly pulled indigo taffy	0		Effect: "Fan-Cooled", Effect Duration: 21, Last Available: "2013-04"
-6363	diffused pressed pulsating fuchsia pulled taffy	0		Effect: "Stuck-Up Hair", Effect Duration: 68, Last Available: "2013-04"
+6363	diffused pressed fuchsia pulsating pulled taffy	0		Effect: "Stuck-Up Hair", Effect Duration: 68, Last Available: "2013-04"
 6364	ionized improved pulled taffy	0		Effect: "Aided and Abetted", Effect Duration: 19, Last Available: "2013-04"
 6365	liquefied polymerized pulled taffy	0		Effect: "Hypercubed", Effect Duration: 54, Last Available: "2013-04"
-6366	wet twirling ghostly pulled violet taffy	0		Effect: "Nuts about Candy", Effect Duration: 66, Last Available: "2013-04"
+6366	wet ghostly twirling pulled violet taffy	0		Effect: "Nuts about Candy", Effect Duration: 66, Last Available: "2013-04"
 6367	irradiated boiled upside-down pulled taffy	0		Effect: "Gunky Dory", Effect Duration: 49, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
 6369	narrow gray lump of clay	0		
@@ -6286,7 +6286,7 @@
 6391	triple-modified energized gray Mer-kin saltsquid	0		Effect: "Cravin' for a Ravin'", Effect Duration: 62
 6392	coward's scale-mail underwear of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Familiar Effect: "2xVolley"
 6393	denatured flattened twirling comb jelly	0		Effect: "Carrrsmic", Effect Duration: 15
-6394	huge mirror lime green anemone sauce	0		
+6394	huge lime green mirror anemone sauce	0		
 6395	inky squid sauce	0		
 6396	wobbly wobbly Mer-kin weaksauce	0		
 6397	peanut sauce	0		
@@ -6296,7 +6296,7 @@
 6401	adjusted double-tarnished mirror tear	0		Effect: "Insatiable Hunger", Effect Duration: 67
 6402	extra-oxidized frozen quantum huge jagged tooth	0		Effect: "Innately Strong", Effect Duration: 49
 6403	ionized huge narrow grisly shell fragment	0		Effect: "Irresistible Resolve", Effect Duration: 57
-6404	liquefied bouncing blue violent pastilles	0		Effect: "Cancer Rising", Effect Duration: 29
+6404	liquefied blue bouncing violent pastilles	0		Effect: "Cancer Rising", Effect Duration: 29
 6405	double-alkaline huge worst candy	0		Effect: "Okee-Dokee Computer", Effect Duration: 54
 6406	nitrogenated fudge-shaped hole in space-time	0		Effect: "Morninja", Effect Duration: 16
 6407	lard-coated clever energetic Pocket Square of Loathing	0		Maximum MP Percent: +20, Maximum MP: +20, Sleaze Spell Damage: +25, Single Equip
@@ -6307,7 +6307,7 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	small yummy flavorless gruel	2	awesome	
+6415	yummy small flavorless gruel	2	awesome	
 6416	miniature stale mana curds	2	decent	
 6417	jittery twist of lime	0		
 6418	pencil stub	0		
@@ -6338,7 +6338,7 @@
 6443	stanky deadly Helps-You-Sleep	0		Weapon Damage: +5, Stench Spell Damage: +25, Single Equip
 6444	friendly forbidden Quiets-Your-Steps of wisdom	0		Mysticality: +15, Spell Damage Percent: +50, Familiar Weight: +3, Single Equip
 6445	dance instructor's boxer's Protects-Your-Junk	0		Muscle Percent: +10, Experience Percent (Moxie): +10, Single Equip
-6446	artisanal irresponsibly strong tumbling Gets-You-Drunk	10	EPIC	
+6446	irresponsibly strong artisanal tumbling Gets-You-Drunk	10	EPIC	
 6447	asbestos-lined smooth Great Wolf's headband of extreme caution	0		Moxie: +15, Monster Level: -25, Hot Resistance: +5, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	Van der Graaf Great Wolf's left paw of wisdom of the cheetah	0		Mysticality: +15, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	blinking inspector's resourceful grievous Great Wolf's right paw	0		Weapon Damage Percent: +50, Maximum MP: +50, Item Drop: +15, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6381,7 +6381,7 @@
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
 6488	flavorless miniature shaking Dreadsylvanian shepherd's pie	2	decent	
-6489	fuchsia bouncing music box parts	0		
+6489	bouncing fuchsia music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	green twirling tailfeathers	0		Familiar Weight: +5
 6492	wax banana	0		
@@ -6410,7 +6410,7 @@
 6515	wool eerie fetish	0		Cold Resistance: +1, Single Equip
 6516	practically non-alcoholic delicious blinking stinkwater	1	awesome	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	bland tiny squat accidental mutton	1	decent	
+6518	tiny bland squat accidental mutton	1	decent	
 6519	jittery frosty nippy drafty drawers	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Effect: "1.5xVolley"
 6520	dog trainer's Jim Carey's wolfskull mask	0		Monster Level: +25, Experience (familiar): +1, Familiar Effect: "spooky atk, 1xBarrr"
 6521	manspreader's guts necklace	0		Monster Level: +10, Single Equip
@@ -6421,7 +6421,7 @@
 6526	skewed fuchsia savvy bag of unfinished business of dire peril	0		Mysticality Percent: +20, Weapon Damage: +20
 6527	maroon hardy beefcake's transparent pants	0		Muscle: +25, Maximum HP: +50, Familiar Effect: "sleaze atk, 1xPotato"
 6528	Annie Oakley's hothammer	0		Critical Hit Percent: +20
-6529	tolerable practically non-alcoholic pulsating Thriller Ice	1	good	
+6529	practically non-alcoholic tolerable pulsating Thriller Ice	1	good	
 6530	hardy grandfather watch	0		Maximum HP: +50, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	avaricious lard-coated spyglass	0		Sleaze Spell Damage: +25, Meat Drop: +30
@@ -6455,16 +6455,16 @@
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	wobbly mini-Mr. Accessory	0		Familiar Weight: +5
 6563	rock-hard hand of Mr. Cards	0		Damage Reduction: 5, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	spoiled blinking skewed Dreadsylvanian hot pocket	4	crappy	
-6565	spoiled special Dreadsylvanian pocket	3	crappy	Effect: "Bone Chilling", Effect Duration: 25
+6564	spoiled skewed blinking Dreadsylvanian hot pocket	4	crappy	
+6565	special spoiled Dreadsylvanian pocket	3	crappy	Effect: "Bone Chilling", Effect Duration: 25
 6566	flavorless blinking Dreadsylvanian pocket	3	decent	
 6567	normal Dreadsylvanian stink pocket	4	good	
-6568	immense spoiled fancy skewed Dreadsylvanian sleaze pocket	8	crappy	Effect: "Rage of the Reindeer", Effect Duration: 10
+6568	fancy spoiled immense skewed Dreadsylvanian sleaze pocket	8	crappy	Effect: "Rage of the Reindeer", Effect Duration: 10
 6569	practically non-alcoholic acceptable Dreadsylvanian hot toddy	1	good	
 6570	mediocre narrow Dreadsylvanian cold-fashioned	3	decent	
 6571	irresponsibly strong hand-crafted Dreadsylvanian grimlet	6	EPIC	
-6572	fancy weak hand-crafted wobbly blinking Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	Effect: "A Contender", Effect Duration: 5
-6573	acceptable tumbling fuchsia Dreadsylvanian slithery nipple	3	good	
+6572	weak fancy hand-crafted wobbly blinking Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	Effect: "A Contender", Effect Duration: 5
+6573	acceptable fuchsia tumbling Dreadsylvanian slithery nipple	3	good	
 6574	hot clusterbomb	0		
 6575	twirling clusterbomb	0		
 6576	clusterbomb	0		
@@ -6474,15 +6474,15 @@
 6580	skewed length of fuse	0		
 6581	blurry dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	squat red vicious spiked collar	0		Familiar Damage: +20
+6583	red squat vicious spiked collar	0		Familiar Damage: +20
 6584	Oprah's hot dog wrapper	0		Maximum MP Percent: +50
 6585	chaotic experienced debonair deboner	0		Experience: +2, Spell Critical Percent: +10
-6586	pickled electrified teal blinking chicle de salchicha	0		Effect: "Amorous", Effect Duration: 31
+6586	pickled electrified blinking teal chicle de salchicha	0		Effect: "Amorous", Effect Duration: 31
 6587	Lo Pan's jar of frostigkraut	0		Spell Critical Percent: +30
 6588	squat ghostly wizardly gnawed-up dog bone of courage	0		Mysticality: +25, Spooky Resistance: +3
 6589	Oprah's Grey Guanon	0		Maximum MP Percent: +50
 6590	jittery narrow healthy arcane researcher's Engorged Sausages and You	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +20, Item Drop: +5
-6591	tolerable weak dream of a dog	2	good	
+6591	weak tolerable dream of a dog	2	good	
 6592	maroon forbidden Socratic optimal spreadsheet of the early riser	0		Experience (Mysticality): +1, Spell Damage Percent: +50, Adventures: +7
 6593	defective Game Grid token	0		
 6594	cyan squat hot Dreadsylvanian cocoa	0		
@@ -6506,7 +6506,7 @@
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	perfectly mixed practically non-alcoholic twirling Cold One	1	???	
+6615	practically non-alcoholic perfectly mixed twirling Cold One	1	???	
 6616	fancy bland spaghetti breakfast	3	???	Effect: "Human-Constellation Hybrid", Effect Duration: 20
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6521,7 +6521,7 @@
 6627	huge folder (D-Team)	0		Last Available: "2013-08"
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
-6630	twirling teal folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
+6630	teal twirling folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	folder (barbarian)	0		Last Available: "2013-08"
@@ -6562,7 +6562,7 @@
 6670	maroon clay homunculus	0		
 6671	modified bouncing sodium pentasomething	0		Effect: "Space Cadet", Effect Duration: 45
 6672	ghostly grains of salt	0		
-6673	skewed spinning yellowcake bomb	0		
+6673	spinning skewed yellowcake bomb	0		
 6674	stinkbomb	0		
 6675	liquefied upside-down superwater	0		Effect: "Bright!", Effect Duration: 57
 6676	Thwaitgold bookworm statuette	0		
@@ -6648,8 +6648,8 @@
 6756	artisanal homebrew sampler	0		
 6757	smooth lime green can of Br&uuml;talbr&auml;u	3	awesome	Last Available: "2013-09"
 6758	drinkable weak can of Drooling Monk	2	good	Last Available: "2013-09"
-6759	practically non-alcoholic lousy olive can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
-6760	hand-crafted spirit-forward squat bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
+6759	lousy practically non-alcoholic olive can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
+6760	spirit-forward hand-crafted squat bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
 6761	delicious bottle of Professor Beer	3	awesome	Last Available: "2013-09"
 6762	delicious weak spinning bottle of Rapier Witbier	2	awesome	Last Available: "2013-09"
 6763	aged bottle of Race Car Red	3	awesome	Last Available: "2013-09"
@@ -6667,7 +6667,7 @@
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	triple-frozen foetid seal tear	0		Effect: "Booze Goozles", Effect Duration: 53
 6777	ionized chilled spinning seal sweat	0		Effect: "Neutered Nostrils", Effect Duration: 60
-6778	moist diffused twirling tumbling upside-down boiling seal blood	0		Effect: "Cosmic Flavor", Effect Duration: 27
+6778	moist diffused tumbling upside-down twirling boiling seal blood	0		Effect: "Cosmic Flavor", Effect Duration: 27
 6779	olive crystalline seal eye	0		Single Equip
 6780	skewed maroon perfumed knitted studded sealhide shield	0		Cold Resistance: +3, Stench Resistance: +5, Damage Reduction: 7
 6781	lime green savvy scabrous seal epaulets of temperance	0		Mysticality Percent: +20, Sleaze Resistance: +5, Single Equip
@@ -6677,21 +6677,21 @@
 6785	olive flask of embalming fluid	0		
 6788	blank diary	0		
 6789	boot knife	0		
-6790	purple mirror blurry broken beer bottle	0		
-6791	fuchsia blinking sharpened spoon	0		
+6790	blurry mirror purple broken beer bottle	0		
+6791	blinking fuchsia sharpened spoon	0		
 6792	candy knife	0		
 6793	wobbly soap knife	0		
 6795	Vulcanized pulsating disco horoscope (Aquarius)	0		Effect: "Mercenary", Effect Duration: 49
 6796	vacuum-sealed improved disco horoscope (Pisces)	0		Effect: "Stench Jellied", Effect Duration: 41
 6797	modified cyan disco horoscope (Aries)	0		Effect: "Warm Belly", Effect Duration: 31
 6798	ionized disco horoscope (Taurus)	0		Effect: "Can't Be a Chooser", Effect Duration: 57
-6799	polarized enhanced lime green twirling disco horoscope (Gemini)	0		Effect: "Morbidi Tea", Effect Duration: 40
+6799	polarized enhanced twirling lime green disco horoscope (Gemini)	0		Effect: "Morbidi Tea", Effect Duration: 40
 6800	pickled disco horoscope (Cancer)	0		Effect: "Liquidy Smoky", Effect Duration: 55
 6801	enhanced chilled disco horoscope (Leo)	0		Effect: "In the Limelight", Effect Duration: 22
 6802	tarnished disco horoscope (Virgo)	0		Effect: "On a Roll", Effect Duration: 56
 6803	activated ionized frozen disco horoscope (Libra)	0		Effect: "Penguinny Flavor", Effect Duration: 30
 6804	non-concentrated disco horoscope (Scorpio)	0		Effect: "Flambé-a-thon", Effect Duration: 42
-6805	alkaline moist spinning lime green disco horoscope (Sagittarius)	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 52
+6805	alkaline moist lime green spinning disco horoscope (Sagittarius)	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 52
 6806	denatured blue disco horoscope (Capricorn)	0		Effect: "Mitre Cut", Effect Duration: 41
 6807	fireproof groovy The Sagittarian's leisure pants	0		Moxie Percent: +10, Hot Resistance: +3, Familiar Effect: "atk, cap 18"
 6808	toy accordion	0		Song Duration: 5
@@ -6737,7 +6737,7 @@
 6848	security flashlight of the businessman	0		Meat Drop: +50
 6849	super-nitrogenated dry adjusted olive wobbly mirror Effermint&trade; tablets	0		Effect: "Virgo Rising", Effect Duration: 41
 6850	manspreader's energetic brainy sturdy cane	0		Mysticality: +5, Maximum MP Percent: +20, Monster Level: +10
-6851	bouncing skewed huge bowl of candy	0		
+6851	skewed bouncing huge bowl of candy	0		
 6852	fuchsia Ultra Mega Sour Ball	0		
 6853	blinking carton of rotten eggs	0		
 6854	desert sightseeing pamphlet	0		
@@ -6751,13 +6751,13 @@
 6862	yummy massive high-calorie sugar substitute	7	awesome	Last Available: "2013-11"
 6863	diet normal pat of butter	1	good	Last Available: "2013-11"
 6864	big moldy dinner roll	5	crappy	Last Available: "2013-11"
-6865	fancy moldy thick blurry mashed potatoes	5	crappy	Effect: "Bone Homie", Effect Duration: 45, Last Available: "2013-11"
-6866	flavorless diet whole turkey leg	1	decent	Last Available: "2013-11"
+6865	moldy fancy thick blurry mashed potatoes	5	crappy	Effect: "Bone Homie", Effect Duration: 45, Last Available: "2013-11"
+6866	diet flavorless whole turkey leg	1	decent	Last Available: "2013-11"
 6867	rotten deviled egg	3	crappy	Last Available: "2013-11"
 6868	liquefied huge finger exerciser	0		Effect: "Frozen Shoulders", Effect Duration: 31, Last Available: "2013-11"
 6869	activated lime green dented spoon	0		Effect: "Minerva's Zen", Effect Duration: 34, Last Available: "2013-11"
 6870	ionized extra-deionized teal love note	0		Effect: "Aided and Abetted", Effect Duration: 53, Last Available: "2013-11"
-6871	bouncing skewed school beer pull tab	0		Last Available: "2013-11"
+6871	skewed bouncing school beer pull tab	0		Last Available: "2013-11"
 6872	improved nail file	0		Effect: "Brain Freeze", Effect Duration: 27, Last Available: "2013-11"
 6873	modified candy wrapper	0		Effect: "Waxing", Effect Duration: 58, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
@@ -6772,7 +6772,7 @@
 6883	bouncing studded groovy wool sock of the ox of dire peril	0		Muscle: +20, Moxie Percent: +10, Weapon Damage: +20, Damage Absorption: +80, Single Equip, Last Available: "2013-11"
 6884	toasty Oprah's moustache sock of chilblains of terror	0		Maximum MP Percent: +50, Cold Damage: +25, Hot Damage: +5, Spooky Spell Damage: +10, Single Equip, Last Available: "2013-11"
 6885	pickled red tumbling spirit gum	0		Effect: "Amorous Avarice", Effect Duration: 45
-6886	olive blurry spirit pillow	0		
+6886	blurry olive spirit pillow	0		
 6887	spirit sheet	0		
 6888	spirit mattress	0		
 6889	narrow spirit blanket	0		
@@ -6811,8 +6811,8 @@
 6922	yummy snack-sized warbear warrior bread	2	awesome	Last Available: "2013-12"
 6923	flavorless warbear thermoregulator bread	3	decent	Last Available: "2013-12"
 6924	mediocre spinning warbear feasting mead	3	decent	Last Available: "2013-12"
-6925	bad fortified enchanted warbear bearserker mead	5	decent	Effect: "Mortarfied", Effect Duration: 10, Last Available: "2013-12"
-6926	smooth weak warbear blizzard mead	2	awesome	Last Available: "2013-12"
+6925	enchanted bad fortified warbear bearserker mead	5	decent	Effect: "Mortarfied", Effect Duration: 10, Last Available: "2013-12"
+6926	weak smooth warbear blizzard mead	2	awesome	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
 6928	blinking dog trainer's smartaleck's warbear plain fedora of the dark arts	0		Moxie Percent: +30, Spell Damage Percent: +100, Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	dangerous warbear feathered fedora	0		Weapon Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6894,10 +6894,10 @@
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	mixed jittery handful of Smithereens	1	decent	Last Available: "2013-12"
 7007	bland Every Day is Like This Sundae	4	decent	Last Available: "2013-12"
-7008	spoiled immense Miserable Pie	7	crappy	Last Available: "2013-12"
-7009	diet bland This Charming Flan	1	decent	Last Available: "2013-12"
-7010	bad triple-distilled Irish Coffee, English Heart	9	decent	Last Available: "2013-12"
-7011	bad watered-down mirror ghostly Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
+7008	immense spoiled Miserable Pie	7	crappy	Last Available: "2013-12"
+7009	bland diet This Charming Flan	1	decent	Last Available: "2013-12"
+7010	triple-distilled bad Irish Coffee, English Heart	9	decent	Last Available: "2013-12"
+7011	watered-down bad ghostly mirror Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
 7012	weak smooth squat Paint A Vulgar Pitcher	2	awesome	Last Available: "2013-12"
 7013	squat Golden Light	0		Last Available: "2013-12"
 7014	pulsating Louder Than Bomb	0		Last Available: "2013-12"
@@ -6918,9 +6918,9 @@
 7029	prompt zippy Fonzie's Shakespeare's Sister's Accordion	0		Experience (Moxie): +1, Initiative: +20, Adventures: +3, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	stanky third-hand lantern	0		Stench Spell Damage: +25
 7031	loose purse strings	0		
-7032	decent fancy narrow pickled egg	3	good	Effect: "Hyphemariffic", Effect Duration: 35
+7032	fancy decent narrow pickled egg	3	good	Effect: "Hyphemariffic", Effect Duration: 35
 7033	cup of lukewarm tea	1	awesome	
-7034	blue pulsating warbear soda machine assembler	0		Last Available: "2013-12"
+7034	pulsating blue warbear soda machine assembler	0		Last Available: "2013-12"
 7035	cyan warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
@@ -6957,18 +6957,18 @@
 7068	aerosolized dry upside-down single of Donho's Bubbly Ballad	0		Effect: "Pumped Up", Effect Duration: 32
 7069	bouncing mirror Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	massive spoiled snow berries	8	crappy	Last Available: "2014-01"
+7071	spoiled massive snow berries	8	crappy	Last Available: "2014-01"
 7072	toothsome ice harvest	3	awesome	Last Available: "2014-01"
 7073	activated dry bouncing frost flower	0		Effect: "Permanent Halloween", Effect Duration: 48, Last Available: "2014-01"
 7074	triple-flattened quadruple-pickled teal snow cleats	0		Effect: "Bone Chilling", Effect Duration: 21, Last Available: "2014-01"
 7075	improved twirling liquid ice pack	0		Effect: "Natural 20", Effect Duration: 19, Last Available: "2014-01"
 7076	mirror snow boards	0		Last Available: "2014-01"
 7077	toothsome snack-sized snow crab	2	awesome	Last Available: "2014-01"
-7078	practically non-alcoholic lousy Ice Island Long Tea	1	decent	Last Available: "2014-01"
+7078	lousy practically non-alcoholic Ice Island Long Tea	1	decent	Last Available: "2014-01"
 7079	teal unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
-7082	blue narrow snow machine	0		Last Available: "2014-01"
+7082	narrow blue snow machine	0		Last Available: "2014-01"
 7083	snow mobile of horror	0		Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	huge auspicious ice bucket	0		Item Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	red double-paned greasy snow shovel	0		Sleaze Spell Damage: +10, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6992,21 +6992,21 @@
 7103	double-energized powder	0		Effect: "Full of Vinegar", Effect Duration: 12, Last Available: "2014-12"
 7104	spinning Rosewater's licorice whip	0		Mysticality Percent: +30, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	practically non-alcoholic bad skewed snakebite	1	decent	Last Available: "2014-12"
+7106	bad practically non-alcoholic skewed snakebite	1	decent	Last Available: "2014-12"
 7107	rosy-cheeked candy stick of the cheetah	0		Maximum HP Percent: +30, Initiative: +60, Last Available: "2014-12"
 7108	flavorless pecan	4	decent	Last Available: "2014-12"
 7109	adequate huge pecan pie	3	good	Last Available: "2014-12"
 7110	squat chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	small flavorless candy mountain oyster	2	decent	Last Available: "2014-12"
+7111	flavorless small candy mountain oyster	2	decent	Last Available: "2014-12"
 7112	lousy chocotini	3	decent	Last Available: "2014-12"
 7113	skewed auspicious toasty Sinatra's chocolate rabbit's foot	0		Experience (Moxie): +5, Hot Damage: +5, Item Drop: +10, Last Available: "2014-12"
 7114	rotten snack-sized candy carrot	2	crappy	Last Available: "2014-12"
-7115	immense delicious tumbling candy carrot cake	10	awesome	Last Available: "2014-12"
+7115	delicious immense tumbling candy carrot cake	10	awesome	Last Available: "2014-12"
 7116	wobbly Jack Frost's sharpshooter's carrot-on-a-stick	0		Critical Hit Percent: +10, Cold Spell Damage: +50, Last Available: "2014-12"
 7117	aromatic strapping weasel stomping pants	0		Muscle: +5, Stench Resistance: +1, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	flavorless mulberry	3	decent	Last Available: "2014-12"
 7119	lousy triple-distilled mulled berry wine	9	decent	Last Available: "2014-12"
-7120	fuchsia mirror lemony scales	0		Last Available: "2014-12"
+7120	mirror fuchsia lemony scales	0		Last Available: "2014-12"
 7121	olive lemon party hat of the detective	0		Item Drop: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	fortified lemon shirt	0		Damage Absorption: +60, Lasts Until Rollover, Last Available: "2014-12"
 7123	stylish lemon drop trousers	0		Moxie: +25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
@@ -7024,14 +7024,14 @@
 7135	tasty squat witch's bread	4	awesome	Last Available: "2014-12"
 7136	oxidized anodized witch's brew	0		Effect: "Witch Breaded", Effect Duration: 49, Last Available: "2014-12"
 7137	resourceful wicked witch's bra of Leguizamo	0		Spell Damage: +5, Maximum MP: +50, Monster Level: +20, Last Available: "2014-12"
-7138	hand-crafted enchanted boozy mid-level medieval mead	5	EPIC	Effect: "Sweet and Red", Effect Duration: 5, Last Available: "2014-12"
+7138	enchanted boozy hand-crafted mid-level medieval mead	5	EPIC	Effect: "Sweet and Red", Effect Duration: 5, Last Available: "2014-12"
 7139	galvanized dry R&uuml;mpelstiltz	0		Effect: "Patience of the Tortoise", Effect Duration: 30, Last Available: "2014-12"
 7140	green pulsating spinning wheel	0		Last Available: "2014-12"
 7141	pressed red hi-octane carrot juice	0		Effect: "Hardened Fabric", Effect Duration: 57, Last Available: "2014-12"
 7142	double-activated oxidized hare brush	0		Effect: "Raging Animal", Effect Duration: 60, Last Available: "2014-12"
 7143	hare pin of Leguizamo of courage	0		Monster Level: +20, Spooky Resistance: +3, Single Equip, Last Available: "2014-12"
 7144	huge odd coin	0		Last Available: "2014-12"
-7145	super-sized flavorless cinnamon cannoli	5	decent	Last Available: "2014-12"
+7145	flavorless super-sized cinnamon cannoli	5	decent	Last Available: "2014-12"
 7146	weak acceptable expensive champagne	2	good	Last Available: "2014-12"
 7147	ionized boiled anodized polo trophy	0		Effect: "Bootyliciousness", Effect Duration: 62, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7050,7 +7050,7 @@
 7161	jittery ruddy &quot;honey&quot; dipper of the ox of Leguizamo	0		Muscle: +20, Maximum HP Percent: +40, Monster Level: +20, Last Available: "2014-12"
 7162	normal plumber's lunch	3	good	Last Available: "2014-12"
 7163	ribald energetic personal trainer's skull gearshift knob	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Sleaze Damage: +10, Last Available: "2014-12"
-7164	tiny flavorless nachos of the night	1	decent	Last Available: "2014-12"
+7164	flavorless tiny nachos of the night	1	decent	Last Available: "2014-12"
 7165	scorching nippy medical-grade Sketcherz&trade;	0		Cold Damage: +10, Hot Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12"
 7166	small spoiled can of Adultwitch&trade;	2	crappy	Last Available: "2014-12"
 7167	irradiated mirror smudge stick	0		Effect: "Permafrosty", Effect Duration: 39, Last Available: "2014-12"
@@ -7061,11 +7061,11 @@
 7172	upside-down juggling ball	0		Last Available: "2014-12"
 7173	upside-down crappy camera	0		Last Available: "2014-12"
 7174	rotten humble pie	3	crappy	Last Available: "2014-12"
-7175	gray jittery spinning small golem	0		Last Available: "2014-12"
+7175	spinning gray jittery small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	extra-anodized ghostly tumbling crappy waiter disguise	0		Effect: "Spiky Frozen Hair", Effect Duration: 37
 7178	tumbling Copperhead Charm	0		
-7179	pulsating shaking The First Pizza	0		
+7179	shaking pulsating The First Pizza	0		
 7180	cyan narrow The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7090,33 +7090,33 @@
 7201	family-friendly personal trainer's The Nuge's favorite crossbow of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Sleaze Resistance: +1
 7202	decent sweet roll Alabama	3	good	
 7203	jittery padded Saturday Night Special	0		Damage Absorption: +20
-7204	bouncing blurry lynyrd snare	0		
+7204	blurry bouncing lynyrd snare	0		
 7205	pulsating padded fleetwood chain	0		Damage Absorption: +20
 7206	triple-distilled perfectly mixed Green Manalishi	7	EPIC	
 7207	purple narrow careful blade	0		Monster Level: -10
 7208	fire of unknown origin	0		
 7209	eagle's milk	1	decent	
 7210	Vulcanized moist yellow eagle feather	0		Effect: "Big Punkin'", Effect Duration: 11
-7211	unsweetened skewed ghostly narrow one pill	0		Effect: "Rain Dancin'", Effect Duration: 44
+7211	unsweetened ghostly narrow skewed one pill	0		Effect: "Rain Dancin'", Effect Duration: 44
 7212	blurry veiny Jefferson wings	0		Maximum HP: +10
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	bland tiny fleetwood mac 'n' cheese	1	decent	
+7215	tiny bland fleetwood mac 'n' cheese	1	decent	
 7216	lynyrd skin	0		
 7217	Da Vinci's lynyrdskin cap	0		Experience (Mysticality): +5, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	sinister lynyrdskin tunic	0		Spell Damage: +10
 7219	clever lynyrdskin breeches	0		Maximum MP: +20, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	hand-crafted watered-down cyan Flamin' Whatshisname	2	EPIC	
+7222	watered-down hand-crafted cyan Flamin' Whatshisname	2	EPIC	
 7223	oxidized alkaline lynyrd musk	0		Effect: "Innately Wise", Effect Duration: 61
 7224	sizzling rock-hard Kashmir sweater	0		Damage Reduction: 5, Hot Damage: +10
 7225	massive moldy shaking custard pie	9	crappy	
 7226	blinking tea for one	1	awesome	
-7227	acceptable watered-down teal bottle of Evermore	2	good	
+7227	watered-down acceptable teal bottle of Evermore	2	good	
 7228	squat box	0		
 7229	watered-down bad pulsating wine	2	decent	
-7230	drinkable distilled rum	5	good	
+7230	distilled drinkable rum	5	good	
 7231	artisanal Murderer's Punch	3	EPIC	
 7232	jumbo decent velvet cake	5	good	
 7233	altered concentrated upside-down letter	0		Effect: "Ready to Snap", Effect Duration: 54
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	high-proof special perfectly mixed mini-martini	8	EPIC	Effect: "Flame-Retardant Trousers", Effect Duration: 45
+7255	high-proof perfectly mixed special mini-martini	8	EPIC	Effect: "Flame-Retardant Trousers", Effect Duration: 45
 7256	pulsating smoke grenade	0		
 7257	compressed narrow molotov soda	1	decent	Effect: "Grrrrrrreat!", Effect Duration: 30
 7258	corrupted pile of ashes	0		Effect: "Broken Bone Nubs", Effect Duration: 62
@@ -7179,7 +7179,7 @@
 7290	rotten pulsating amok pudding	3	crappy	
 7291	deactivated putty buddy	0		
 7292	blue putty coat	0		Familiar Weight: +5
-7293	warmed nitrogenated improved jittery purple can of V-11	0		Effect: "Irresistible Resolve", Effect Duration: 16, Last Available: "2014-03"
+7293	warmed nitrogenated improved purple jittery can of V-11	0		Effect: "Irresistible Resolve", Effect Duration: 16, Last Available: "2014-03"
 7294	fireproof supercool elevennis shoes	0		Moxie Percent: +20, Hot Resistance: +3, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
 7296	foul-smelling elevenderizing hammer of the bloodbag	0		Maximum HP: +100, Stench Damage: +10, Last Available: "2014-03"
@@ -7206,18 +7206,18 @@
 7317	spinning jar of baby ghosts	0		
 7318	lightning-fast arcane researcher's ghost of a necklace of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Initiative: +40
 7319	jittery pulsating Elizabeth's Dollie of extreme caution of doom	0		Monster Level: -25, Spooky Spell Damage: +50
-7320	aerosolized jittery ghostly narrow Elizabeth's paintbrush	0		Effect: "Space Cadet", Effect Duration: 26
+7320	aerosolized narrow ghostly jittery Elizabeth's paintbrush	0		Effect: "Space Cadet", Effect Duration: 26
 7321	twirling teal blinking family-friendly greasy Stephen's lab coat	0		Sleaze Spell Damage: +10, Sleaze Resistance: +1
 7322	alkaline polarized jittery Stephen's secret formula	0		Effect: "Shot in the Arse", Effect Duration: 48
 7323	groovy brainy Jacob's rung	0		Mysticality: +5, Moxie Percent: +10
 7324	dried blue battery	1		
 7325	watered-down hand-crafted snakebite	2	EPIC	
 7326	pulsating spinning ruddy rubber ribcage of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +40, Damage Reduction: 7
-7327	denatured blurry narrow synthetic marrow	1		Effect: "Glittering Eyelashes", Effect Duration: 45
+7327	denatured narrow blurry synthetic marrow	1		Effect: "Glittering Eyelashes", Effect Duration: 45
 7328	cold-filtered altered funny bone	0		Effect: "Bonelording", Effect Duration: 50
 7329	toasty half-melted spoon of the brazier	0		Hot Damage: +5, Hot Spell Damage: +25
 7330	pickled skewed the funk	1		
-7331	moldy half-sized gunky chicken	2	crappy	
+7331	half-sized moldy gunky chicken	2	crappy	
 7332	rock-hard doll head	0		Damage Reduction: 5
 7333	mirror droopy doll eye	0		
 7334	spinning voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7230,17 +7230,17 @@
 7341	irradiated quantum maroon moose thought	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 55
 7342	bland moose chocolate	4	decent	
 7343	watered-down mediocre painting of a glass of wine	2	decent	
-7344	maroon wobbly oil painting of yourself	0		
+7344	wobbly maroon oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	chaotic supercharged ghost toga	0		Maximum MP Percent: +30, Spell Critical Percent: +10
-7348	bland miniature jittery sheet cake	2	decent	
+7348	miniature bland jittery sheet cake	2	decent	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	ribald lion tamer's Staff of the Electric Range of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Sleaze Damage: +10
 7352	enchanted normal deluxe layer cake	3	good	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 45
 7353	green chunk of hot iron	0		
-7354	lousy fortified red-hot boilermaker	5	decent	
+7354	fortified lousy red-hot boilermaker	5	decent	
 7355	skewed wobbly fireproof coal shovel	0		Hot Resistance: +3, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	aerosolized dry hot coal	0		Effect: "Thanksgot", Effect Duration: 35
 7357	modified triple-moist coal dust	0		Effect: "Mushroom Moxiousness", Effect Duration: 44
@@ -7258,7 +7258,7 @@
 7369	quantum mangled finger	0		Effect: "Flamingly Floral", Effect Duration: 50
 7370	hand-crafted Psychotic Train wine	4	EPIC	
 7371	lime green crazy hobo notebook	0		
-7372	half-sized decent pie man was not meant to eat	2	good	
+7372	decent half-sized pie man was not meant to eat	2	good	
 7373	smartaleck's sommelier's towel	0		Moxie Percent: +30
 7374	brainy tarnished tastevin	0		Mysticality: +5, Single Equip
 7375	bland half-sized actual tapas	2	decent	
@@ -7278,12 +7278,12 @@
 7389	cold-filtered deionized Gene Tonic: Insect	0		Effect: "Salty Mouth", Effect Duration: 23, Last Available: "2014-04"
 7390	galvanized Gene Tonic: Hippy	0		Effect: "Human-Penguin Hybrid", Effect Duration: 20, Last Available: "2014-04"
 7391	vacuum-sealed vacuum-sealed Gene Tonic: Orc	0		Effect: "Purpose", Effect Duration: 67, Last Available: "2014-04"
-7392	liquefied aerosolized maroon twirling jittery Gene Tonic: Demon	0		Effect: "Jungle Juiced", Effect Duration: 69, Last Available: "2014-04"
+7392	liquefied aerosolized maroon jittery twirling Gene Tonic: Demon	0		Effect: "Jungle Juiced", Effect Duration: 69, Last Available: "2014-04"
 7393	non-ionized Gene Tonic: Horror	0		Effect: "Oth-Jeal-O", Effect Duration: 54, Last Available: "2014-04"
 7394	oxidized skewed Gene Tonic: Fish	0		Effect: "Three Days Slow", Effect Duration: 39, Last Available: "2014-04"
 7395	irradiated Gene Tonic: Goblin	0		Effect: "A Taste of Rainbow", Effect Duration: 60, Last Available: "2014-04"
 7396	activated activated squat Gene Tonic: Pirate	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 54, Last Available: "2014-04"
-7397	altered altered squat maroon Gene Tonic: Plant	0		Effect: "In the Limelight", Effect Duration: 38, Last Available: "2014-04"
+7397	altered altered maroon squat Gene Tonic: Plant	0		Effect: "In the Limelight", Effect Duration: 38, Last Available: "2014-04"
 7398	colloidal Gene Tonic: Weird	0		Effect: "Hairy Palms", Effect Duration: 40, Last Available: "2014-04"
 7399	pressed vacuum-sealed Gene Tonic: Elf	0		Effect: "Corruption of Wretched Wally", Effect Duration: 59, Last Available: "2014-04"
 7400	galvanized galvanized mirror shaking Gene Tonic: Mer-kin	0		Effect: "Pasta Oneness", Effect Duration: 29, Last Available: "2014-04"
@@ -7327,10 +7327,10 @@
 7438	stale immense gray Beefy Crunch Pastaco	7	decent	Last Available: "2014-05"
 7439	toothsome Brain Food Pastaco	3	awesome	Last Available: "2014-05"
 7440	flavorless miniature twirling Cool Brunch Pastaco	2	decent	Last Available: "2014-05"
-7441	bland bite-sized red Medical Pastaco	1	decent	Last Available: "2014-05"
+7441	bite-sized bland red Medical Pastaco	1	decent	Last Available: "2014-05"
 7442	adequate Energy Buzz Pastaco	3	good	Last Available: "2014-05"
 7443	rotten pulsating Ludovico Pastaco	4	crappy	Last Available: "2014-05"
-7444	practically non-alcoholic mediocre spinning overpowering mushroom wine	1	decent	Last Available: "2014-05"
+7444	mediocre practically non-alcoholic spinning overpowering mushroom wine	1	decent	Last Available: "2014-05"
 7445	tolerable complex mushroom wine	3	good	Last Available: "2014-05"
 7446	lousy lime green smooth mushroom wine	4	decent	Last Available: "2014-05"
 7447	mediocre blood-red mushroom wine	4	decent	Last Available: "2014-05"
@@ -7341,9 +7341,9 @@
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	tolerable watered-down regular-size brogurt	2	good	Last Available: "2014-05"
 7454	watered-down tolerable cyan super-size brogurt	2	good	Last Available: "2014-05"
-7455	special mediocre weak broberry brogurt	2	decent	Effect: "Anytwo Five Elevenis?", Effect Duration: 20, Last Available: "2014-05"
-7456	weak perfectly mixed brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7457	acceptable high-proof tumbling squat French bronilla brogurt	10	good	Last Available: "2014-05"
+7455	weak special mediocre broberry brogurt	2	decent	Effect: "Anytwo Five Elevenis?", Effect Duration: 20, Last Available: "2014-05"
+7456	perfectly mixed weak brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7457	acceptable high-proof squat tumbling French bronilla brogurt	10	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7353,11 +7353,11 @@
 7464	tumbling curative Brogre bucket hat	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	jittery Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	narrow airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
-7467	skewed ghostly one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
+7467	ghostly skewed one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
 7468	pulsating slick 8-billed baseball cap of the wise owl of the brute	0		Mysticality: +20, Moxie: +10, Muscle Percent: +30, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	Oprah's grievous extremely wet T-shirt of the overflowing toilet	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Stench Spell Damage: +50, Last Available: "2014-05"
 7470	mansplainer's shrimp fork of the empath of Flo-Jo	0		Monster Level: +15, Familiar Weight: +5, Initiative: +100, Last Available: "2014-05"
-7471	pressed shaking maroon BROS Energy Drink	0		Effect: "Larger", Effect Duration: 53, Last Available: "2014-05"
+7471	pressed maroon shaking BROS Energy Drink	0		Effect: "Larger", Effect Duration: 53, Last Available: "2014-05"
 7472	magnetized chilled go-go potion	0		Effect: "Partially Ghosted", Effect Duration: 36, Last Available: "2014-05"
 7473	vacuum-sealed magnetized blue shrimp cocktail	0		Effect: "[800]Chocolate Reign", Effect Duration: 22, Last Available: "2014-05"
 7474	diffused jittery fuchsia Yolo&trade; chocolates	0		Effect: "Earthen Fist", Effect Duration: 23, Last Available: "2020-09"
@@ -7369,9 +7369,9 @@
 7480	super-diffused sugar bunny	0		Effect: "Super Vision", Effect Duration: 49, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	tolerable Rompedores de Fantasmas	4	good	
-7483	practically non-alcoholic lousy La Fantasma y La Oscuridad	1	decent	
+7483	lousy practically non-alcoholic La Fantasma y La Oscuridad	1	decent	
 7484	delicious spirit-forward Fantasma en la M&aacute;quina	5	awesome	
-7485	gray pulsating loosening powder	0		
+7485	pulsating gray loosening powder	0		
 7486	gray castoreum	0		
 7487	drain dissolver	0		
 7488	triple-distilled turpentine	0		
@@ -7405,9 +7405,9 @@
 7516	witch's spare house key	0		
 7517	blurry brainy spider leg of the dark arts	0		Mysticality: +5, Spell Damage Percent: +100
 7518	squat wand of pigification	0		
-7519	acceptable strong special glass of bourbon	5	good	Effect: "items.enh", Effect Duration: 45
+7519	special acceptable strong glass of bourbon	5	good	Effect: "items.enh", Effect Duration: 45
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	moldy maroon tumbling government cheese	4	crappy	Last Available: "2014-05"
+7521	moldy tumbling maroon government cheese	4	crappy	Last Available: "2014-05"
 7522	forbidden pair of government shades	0		Spell Damage Percent: +50, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	liquefied government	0		Effect: "Human-Plant Hybrid", Effect Duration: 32, Last Available: "2014-05"
@@ -7434,7 +7434,7 @@
 7545	hand-crafted pulsating space port	4	EPIC	Last Available: "2014-05"
 7546	mansplainer's space needle of the sewer	0		Monster Level: +15, Stench Damage: +25, Last Available: "2014-05"
 7547	flattened buffed alien drugs	0		Effect: "Fortunate Resolve", Effect Duration: 47, Last Available: "2014-05"
-7548	lime green twirling narrow hot ashes	0		Last Available: "2014-06"
+7548	narrow twirling lime green hot ashes	0		Last Available: "2014-06"
 7549	flattened deionized blue ash soda	0		Effect: "Spooky Weapon", Effect Duration: 64, Last Available: "2014-06"
 7550	vacuum-sealed ghostly liquid smoke	0		Effect: "Vitamin-Maxed", Effect Duration: 15, Last Available: "2014-06"
 7551	quadruple-irradiated dollop of barbecue sauce	0		Effect: "Milk Studly", Effect Duration: 30, Last Available: "2014-06"
@@ -7444,14 +7444,14 @@
 7555	page	0		
 7556	elephant gift	0		
 7557	adjusted blinking blood cells	0		Effect: "Stogied", Effect Duration: 12
-7558	spirit-forward artisanal wine	5	EPIC	
+7558	artisanal spirit-forward wine	5	EPIC	
 7559	quadruple-anodized energized mirror gummi turtle	0		Effect: "Sweet and Green", Effect Duration: 47
 7560	turtle-shaped rock	0		
 7561	diffused giraffe-necked turtle	0		Effect: "Burning Hands", Effect Duration: 42
 7562	ionized mirror blinking musk turtle	0		Effect: "Crocodile Tear", Effect Duration: 61
-7563	enhanced Vulcanized skewed ghostly programmable turtle	0		Effect: "Ooh, Sweet!", Effect Duration: 42
+7563	enhanced Vulcanized ghostly skewed programmable turtle	0		Effect: "Ooh, Sweet!", Effect Duration: 42
 7564	pressed flattened concentrated mocking turtle	0		Effect: "Cold Blooded", Effect Duration: 34
-7565	adequate half-sized bouncing ham steak	2	good	
+7565	half-sized adequate bouncing ham steak	2	good	
 7566	Jim Carey's time-twitching toolbelt	0		Monster Level: +25, Single Equip, Free Pull
 7567	Chroner	0		
 7568	censurious MacGyver's steel-toed Time Lord Badge of Honor	0		Damage Reduction: 9, Maximum MP: +100, Sleaze Resistance: +3
@@ -7467,8 +7467,8 @@
 7578	liquefied super-aerosolized yellow future drug: Coolscaline	0		Effect: "Broken Fast", Effect Duration: 61
 7579	twitching time capsule	0		
 7580	compressed liquid shifting time weirdness	1		Effect: "Stickler for Promptness", Effect Duration: 5
-7581	yellow ghostly shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	decent jumbo rack of dinosaur ribs	5	good	
+7581	ghostly yellow shifting time weirdness	0		Adventures: +4, PvP Fights: +4
+7582	jumbo decent rack of dinosaur ribs	5	good	
 7583	drinkable spinning scotch on the rocks	4	good	
 7584	personal trainer's yabba dabba doo rag of temperance	0		Experience Percent (Muscle): +10, Sleaze Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	Temple Grandin's personal trainer's wooly loincloth	0		Experience Percent (Muscle): +10, Familiar Weight: +7, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7483,7 +7483,7 @@
 7594	delicious lime green Sockdollager	3	awesome	Last Available: "2014-07"
 7595	mediocre Ish Kabibble	4	decent	Last Available: "2014-07"
 7596	hand-crafted pulsating Hot Socks	4	EPIC	Last Available: "2014-07"
-7597	perfectly mixed olive bouncing Phonus Balonus	3	EPIC	Last Available: "2014-07"
+7597	perfectly mixed bouncing olive Phonus Balonus	3	EPIC	Last Available: "2014-07"
 7598	hand-crafted Flivver	3	EPIC	Last Available: "2014-07"
 7599	weak drinkable twirling Sloppy Jalopy	2	good	Last Available: "2014-07"
 7600	ionized oxidized flame	0		Effect: "Mmmmmelon", Effect Duration: 60
@@ -7491,7 +7491,7 @@
 7602	adjusted cyan Fitspiration&trade; poster	0		Effect: "The Best a Pirate Can Get", Effect Duration: 48
 7603	alkaline neckbeard	0		Effect: "Celestial Body", Effect Duration: 18
 7604	wet magnetized jittery artisanal hand-squeezed wheatgrass juice	0		Effect: "Punch Another Day", Effect Duration: 19
-7605	quadruple-pressed nitrogenated blurry jittery punk patch	0		Effect: "Kernel Panic!", Effect Duration: 31
+7605	quadruple-pressed nitrogenated jittery blurry punk patch	0		Effect: "Kernel Panic!", Effect Duration: 31
 7606	wet steampunk potion	0		Effect: "Rampage!", Effect Duration: 46
 7607	enhanced pressed denatured squat jittery vial of swamp vapors	0		Effect: "Gummiheart", Effect Duration: 44
 7608	colloidal mirror turtle mud	0		Effect: "Amorphous Cheer", Effect Duration: 59
@@ -7499,10 +7499,10 @@
 7610	vacuum-sealed skewed Dweebisol&trade; inhaler	0		Effect: "Slimily Strong", Effect Duration: 20
 7611	magnetized extra-flattened deionized wobbly Lewd Lemmy Hair Oil	0		Effect: "Oiled Skin", Effect Duration: 23
 7612	denatured tomato soup poster	0		Effect: "Dance Interpreter", Effect Duration: 23
-7613	concentrated triple-quantum warmed yellow shaking bubblin' chemistry solution	0		Effect: "Spooky Demeanor", Effect Duration: 58
+7613	concentrated triple-quantum warmed shaking yellow bubblin' chemistry solution	0		Effect: "Spooky Demeanor", Effect Duration: 58
 7614	anodized oxidized cold-filtered squat voodoo glowskull	0		Effect: "Feroci Tea", Effect Duration: 66
 7615	flattened dry skewed shaking pygmy adder oil	0		Effect: "Melancholy Burden", Effect Duration: 59
-7616	super-enhanced ionized teal upside-down wobbly pygmy witchhazel	0		Effect: "Smokin'", Effect Duration: 51
+7616	super-enhanced ionized teal wobbly upside-down pygmy witchhazel	0		Effect: "Smokin'", Effect Duration: 51
 7617	unsweetened upside-down short deposition	0		Effect: "Yuletide Mutations", Effect Duration: 40
 7618	vacuum-sealed triple-liquefied straw pole	0		Effect: "Extra Terrestrial", Effect Duration: 44
 7619	non-warmed ionized blurry teal copperhead potion	0		Effect: "Thanksgot", Effect Duration: 38
@@ -7510,13 +7510,13 @@
 7621	chilled upside-down ninja eyeblack	0		Effect: "A View to Some Meat", Effect Duration: 19
 7622	pickled modified button rouge	0		Effect: "Burning Tongue", Effect Duration: 57
 7623	dry triple-dry cyan Red Army camouflage kit	0		Effect: "Clyde's Blessing", Effect Duration: 52
-7624	oxidized maroon jittery jittery lynyrd skinner toothblack	0		Effect: "Physicali Tea", Effect Duration: 22
+7624	oxidized jittery jittery maroon lynyrd skinner toothblack	0		Effect: "Physicali Tea", Effect Duration: 22
 7625	nitrogenated bouncing flask of rainwater	0		Effect: "Nature's Bounty", Effect Duration: 15
 7626	double-modified oyster badge	0		Effect: "5 Pounds Lighter", Effect Duration: 62
 7627	chilled denatured bouncing plastic Jefferson wings	0		Effect: "Human-Undead Hybrid", Effect Duration: 44
 7628	unsweetened enhanced dancing fan	0		Effect: "Alacri Tea", Effect Duration: 50
 7629	irradiated page of the Necrohobocon	0		Effect: "Boon of She-Who-Was", Effect Duration: 43
-7630	aerosolized magnetized polymerized shaking squat magic powder	0		Effect: "Bustle Hustlin'", Effect Duration: 15
+7630	aerosolized magnetized polymerized squat shaking magic powder	0		Effect: "Bustle Hustlin'", Effect Duration: 15
 7631	triple-ionized polarized friar's tonsure	0		Effect: "Make Meat FA$T!", Effect Duration: 58
 7632	electrified electrified government-issue identification badge	0		Effect: "Quiet 'n' Good", Effect Duration: 27
 7633	triple-adjusted cyan alien hologram projector	0		Effect: "Tapped In", Effect Duration: 36
@@ -7535,7 +7535,7 @@
 7646	lightning milk	0		
 7647	skewed aquaconda brain	0		
 7648	thunder thigh	0		
-7649	adjusted huge yellow gourmet gourami oil	0		Effect: "Gonna Get You, Sucker", Effect Duration: 54
+7649	adjusted yellow huge gourmet gourami oil	0		Effect: "Gonna Get You, Sucker", Effect Duration: 54
 7650	activated galvanized squat catfish whiskers	0		Effect: "Wallflowering", Effect Duration: 46
 7651	freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
@@ -7548,7 +7548,7 @@
 7659	narrow supercharged neoprene skullcap	0		Maximum MP Percent: +30, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	oxidized galvanized jittery narrow goblin water	0		Effect: "Fastbreaker", Effect Duration: 46
 7661	dumb mud	0		
-7662	immense flavorless squat Sogg-Os	9	decent	
+7662	flavorless immense squat Sogg-Os	9	decent	
 7663	olive hale Lord Soggyraven's Slippers of the storm of the sweet-tooth	0		Maximum HP: +20, Maximum MP Percent: +40, Candy Drop: +100, Single Equip
 7664	triple-deionized Ancient Protector Soda	0		Effect: "Category", Effect Duration: 62
 7665	quantum liquid ice	0		Effect: "Blood-Rich", Effect Duration: 54
@@ -7561,7 +7561,7 @@
 7672	law-abiding citizen cane of wisdom	0		Mysticality: +15, Single Equip
 7673	drinkable legitimate business on the beach	3	good	
 7674	brawny hep waders	0		Muscle Percent: +20, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	stale fancy jive turkey leg	3	decent	Effect: "Tingly Elbows", Effect Duration: 5
+7675	fancy stale jive turkey leg	3	decent	Effect: "Tingly Elbows", Effect Duration: 5
 7676	birdbone corset	0		Item Drop: +5
 7677	altered candy cigarette	0		Effect: "Concentration", Effect Duration: 63
 7678	toasty 4-dimensional fez	0		Hot Damage: +5, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7599,9 +7599,9 @@
 7710	dry tumbling candy UFOs	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 38
 7711	jittery hale brainy water wings for babies	0		Mysticality: +5, Maximum HP: +20
 7712	ghostly beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	spoiled fancy spinning Strix stix	3	crappy	Effect: "Salty Mouth", Effect Duration: 35
+7713	fancy spoiled spinning Strix stix	3	crappy	Effect: "Salty Mouth", Effect Duration: 35
 7714	wobbly horrifying curative ruddy vampire pellet	0		Maximum HP Percent: +40, Spooky Damage: +25, HP Regen Min: 3, HP Regen Max: 5
-7715	weak tolerable non-aged vinegar	2	good	
+7715	tolerable weak non-aged vinegar	2	good	
 7716	maroon smartaleck's unsanitized scalpel	0		Moxie Percent: +30
 7717	prompt gladiator tunica	0		Adventures: +3
 7718	toasty Roman sadnals	0		Hot Damage: +5, Single Equip
@@ -7659,7 +7659,7 @@
 7770	Annie Oakley's fortified Personal Ventilation Unit of the wise owl	0		Mysticality: +20, Damage Absorption: +60, Critical Hit Percent: +20, Single Equip, Last Available: "2014-10"
 7771	anodized tumbling the most dangerous bait	0		Effect: "Sausage Festive", Effect Duration: 15, Last Available: "2014-10"
 7772	bland tiny &quot;meat&quot; stick	1	decent	Last Available: "2014-10"
-7773	altered twirling blurry transdermal smoke patch	1	awesome	Effect: "Badger Underfoot", Effect Duration: 20, Last Available: "2014-10"
+7773	altered blurry twirling transdermal smoke patch	1	awesome	Effect: "Badger Underfoot", Effect Duration: 20, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	lightning-fast scandalous pair of plants of terror	0		Spooky Spell Damage: +10, Sleaze Damage: +5, Initiative: +40, Last Available: "2014-10"
 7776	olive scandalous Sinatra's Sasq&trade; watch of Flo-Jo	0		Experience (Moxie): +5, Sleaze Damage: +5, Initiative: +100, Single Equip, Last Available: "2014-10"
@@ -7671,7 +7671,7 @@
 7782	big special bland limp broccoli	5	decent	Effect: "Clyde's Blessing", Effect Duration: 25, Last Available: "2014-10"
 7783	blinking Annie Oakley's electrified beefcake's hat	0		Muscle: +25, Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	concentrated tarnished electrified huge monkey barf	0		Effect: "Charrrming", Effect Duration: 25, Last Available: "2014-10"
-7785	dry lime green ghostly candy	0		Effect: "Puzzle Fury", Effect Duration: 60, Last Available: "2014-10"
+7785	dry ghostly lime green candy	0		Effect: "Puzzle Fury", Effect Duration: 60, Last Available: "2014-10"
 7786	crafty ruddy Sinatra's jangly bracelet	0		Experience (Moxie): +5, Maximum HP Percent: +40, Maximum MP: +10, Last Available: "2014-10"
 7787	asbestos-lined cuddly teddy bear	0		Hot Resistance: +5, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	shaking ice-cold Cloaca Zero	0		Last Available: "2014-10"
@@ -7686,7 +7686,7 @@
 7797	decent karma shawarma	3	good	Last Available: "2014-10"
 7798	acceptable Jungle Juice	3	good	Last Available: "2014-10"
 7799	hand-crafted Amnesiac Ale	4	EPIC	Last Available: "2014-10"
-7800	practically non-alcoholic artisanal Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
+7800	artisanal practically non-alcoholic Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
 7801	savvy wizardly mercenary pistol	0		Mysticality: +25, Mysticality Percent: +20, Last Available: "2014-10"
 7802	studded mercenary rifle of incineration	0		Damage Absorption: +80, Hot Spell Damage: +50, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7694,11 +7694,11 @@
 7805	Merc Core challenge coin	0		Last Available: "2014-10"
 7806	teal Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
-7808	ghostly skewed unused soap	0		
+7808	skewed ghostly unused soap	0		
 7809	impure gasoline	0		
 7810	Z-Bone steak	0		
 7811	yellow viral DNA	0		
-7812	tumbling blinking tarnished bottlecap	0		
+7812	blinking tumbling tarnished bottlecap	0		
 7813	rotten miniature jittery seared dino steak	2	crappy	
 7814	acceptable bottle of drinkin' gas	4	good	
 7815	ghostly handful of napalm	0		
@@ -7713,8 +7713,8 @@
 7824	bouncing Oprah's ruddy brawny iShield	0		Muscle Percent: +20, Maximum HP Percent: +40, Maximum MP Percent: +50, Damage Reduction: 6
 7825	cyan up-at-dawn educational supercool earbuds	0		Moxie Percent: +20, Experience: +1, Adventures: +5, Single Equip
 7826	bouncing maroon family-friendly iFlail of the sweet-tooth of the cheetah	0		Sleaze Resistance: +1, Candy Drop: +100, Initiative: +60
-7827	stale low-calorie tumbling unidentifiable dried fruit	1	decent	
-7828	tolerable huge fuchsia flat cider	4	good	
+7827	low-calorie stale tumbling unidentifiable dried fruit	1	decent	
+7828	tolerable fuchsia huge flat cider	4	good	
 7829	mansplainer's smooth trench lighter of doom	0		Moxie: +15, Monster Level: +15, Spooky Spell Damage: +50, Last Available: "2014-10"
 7830	magnetized polymerized experimental serum P-00	0		Effect: "Bear Clawed", Effect Duration: 34, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7734,8 +7734,8 @@
 7845	diffused polymerized perl necklace	0		Effect: "New Zeal", Effect Duration: 25, Last Available: "2014-12"
 7846	anodized Fudge Fiber Armor Plating	0		Effect: "Grrrrrrreat!", Effect Duration: 39, Last Available: "2014-12"
 7847	pressed wobbly cyan ruby on canes	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 14, Last Available: "2014-12"
-7848	decent miniature bouncing petit fortran	2	good	Last Available: "2014-12"
-7849	normal small java cookie	2	good	Last Available: "2014-12"
+7848	miniature decent bouncing petit fortran	2	good	Last Available: "2014-12"
+7849	small normal java cookie	2	good	Last Available: "2014-12"
 7850	rotten low-calorie cookie cookie	1	crappy	Last Available: "2014-12"
 7851	shellacked plastic exo-suited miner	0		Damage Reduction: 7, Last Available: "2014-12"
 7852	mirror experienced plastic semi-autonomous drill unit	0		Experience: +2, Last Available: "2014-12"
@@ -7778,7 +7778,7 @@
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	shaking Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
-7892	bouncing tumbling Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
+7892	tumbling bouncing Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	upside-down Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
@@ -7808,16 +7808,16 @@
 7919	vacuum-sealed activated tumbling Big Punk	0		Effect: "Mer-kindliness", Effect Duration: 35
 7920	skewed fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	practically non-alcoholic lousy special jittery Friendly Turkey	1	decent	Effect: "Larger", Effect Duration: 40, Last Available: "2014-11"
+7922	special practically non-alcoholic lousy jittery Friendly Turkey	1	decent	Effect: "Larger", Effect Duration: 40, Last Available: "2014-11"
 7923	drinkable Agitated Turkey	3	good	Last Available: "2014-11"
 7924	lousy Ambitious Turkey	4	decent	Last Available: "2014-11"
-7925	stale big skewed neutron lollipop	5	decent	Last Available: "2014-12"
-7926	watered-down lousy gamma nog	2	decent	Last Available: "2014-12"
+7925	big stale skewed neutron lollipop	5	decent	Last Available: "2014-12"
+7926	lousy watered-down gamma nog	2	decent	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	boiled blinking upside-down single atom	1	awesome	Last Available: "2015-02"
+7938	boiled upside-down blinking single atom	1	awesome	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	jittery Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
@@ -7829,7 +7829,7 @@
 7947	weak acceptable whiskey in a broken glass	2	good	
 7948	watered-down artisanal narrow shot of mescal	2	EPIC	
 7949	hand-crafted wobbly glass of herbal tequila	4	EPIC	
-7950	olive upside-down minin' dynamite	0		
+7950	upside-down olive minin' dynamite	0		
 7951	twirling plaid cowboy hat of James Dean of the detective	0		Experience (Moxie): +3, Item Drop: +20, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
 7953	upside-down asbestos-lined resourceful rusted-out shootin' iron of Leguizamo	0		Maximum MP: +50, Monster Level: +20, Hot Resistance: +5
@@ -7854,13 +7854,13 @@
 7972	diluted cyan mummified fig	1	decent	
 7973	denatured pulsating mummified loaf of bread	1	EPIC	Effect: "Browbeaten", Effect Duration: 45
 7974	distilled wobbly mummified beef haunch	1	EPIC	
-7975	squat ghostly linen bandages	0		
+7975	ghostly squat linen bandages	0		
 7976	cotton bandages	0		
 7977	silk bandages	0		
 7978	holy spring water	0		
 7979	spirit beer	0		
 7980	squat cyan sacramental wine	0		
-7981	upside-down wobbly talisman of Thoth	0		
+7981	wobbly upside-down talisman of Thoth	0		
 7982	upside-down cure-all	0		
 7983	Van der Graaf wholesome Sister Accessory	0		Maximum HP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Softcore Only
 7984	frozen super-modified twirling Boosty Juice	0		Effect: "BOOsted", Effect Duration: 27
@@ -7876,8 +7876,8 @@
 7994	chilly Fonzie's pepper mill	0		Experience (Moxie): +1, Cold Damage: +5, Last Available: "2015-12"
 7995	pulsating horrifying pelerine of James Dean	0		Experience (Moxie): +3, Spooky Damage: +25, Last Available: "2015-12"
 7996	careful brawny phantom mask	0		Muscle Percent: +20, Monster Level: -10, Single Equip, Last Available: "2015-12"
-7997	compressed wobbly tumbling polyesterene powder	1		Last Available: "2015-12"
-7998	modified twirling fuchsia mirror powder	1		Last Available: "2015-12"
+7997	compressed tumbling wobbly polyesterene powder	1		Last Available: "2015-12"
+7998	modified mirror twirling fuchsia powder	1		Last Available: "2015-12"
 7999	extra-cold-filtered mirror choco-Crimbot	0		Effect: "Swordholder", Effect Duration: 53, Last Available: "2014-12"
 8000	irradiated smart watch	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 15, Last Available: "2014-12"
 8001	boiled jittery augmented-reality shades	0		Effect: "Mighty Shout", Effect Duration: 37, Last Available: "2014-12"
@@ -7907,7 +7907,7 @@
 8025	twirling bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
-8028	blurry spinning artificial skylight	0		Last Available: "2015-01"
+8028	spinning blurry artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	spinning continental juice bar	0		Last Available: "2015-01"
 8031	tumbling stationery set	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	coward's tope&eacute; of the brute	0		Muscle Percent: +30, Monster Level: -20, Familiar Effect: "3xBarrr, cap 12"
 8035	twirling stylish topiary tights of the empath	0		Moxie: +25, Familiar Weight: +5
 8036	topiary necktie of Flo-Jo	0		Initiative: +100
-8037	jumbo spoiled skewed bowl of topioca	5	crappy	
+8037	spoiled jumbo skewed bowl of topioca	5	crappy	
 8038	topiary skunk	0		
 8039	pulsating topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -7931,7 +7931,7 @@
 8050	stylish X-ray goggles	0		Moxie: +25, Luck: +5
 8051	blurry dog trainer's cape	0		Experience (familiar): +1
 8052	greasy jetpack	0		Sleaze Spell Damage: +10
-8053	upside-down olive spring boots	0		
+8053	olive upside-down spring boots	0		
 8054	spiked boots	0		
 8055	lightning-fast pickaxe	0		Initiative: +40
 8056	torch	0		
@@ -7984,7 +7984,7 @@
 8109	shellacked ascot of horror	0		Damage Reduction: 7, Spooky Spell Damage: +25, Single Equip, Last Available: "2017-12"
 8110	attache case of James Dean of the cheetah	0		Experience (Moxie): +3, Initiative: +60, Last Available: "2017-12"
 8111	lard-coated accordion of temperance	0		Sleaze Spell Damage: +25, Sleaze Resistance: +5, Song Duration: 10, Last Available: "2017-12"
-8112	altered yellow spinning twirling aerosolized	1		Last Available: "2017-12"
+8112	altered yellow twirling spinning aerosolized	1		Last Available: "2017-12"
 8113	zippy sharpshooter's wig	0		Critical Hit Percent: +10, Initiative: +20, Last Available: "2017-12"
 8114	hale ruddy winch crank	0		Maximum HP Percent: +40, Maximum HP: +20, Single Equip, Last Available: "2017-12"
 8115	blinking squat aromatic widget of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +1, Single Equip, Last Available: "2017-12"
@@ -7998,7 +7998,7 @@
 8123	cyan mansplainer's strapping garibaldi	0		Muscle: +5, Monster Level: +15, Last Available: "2018-12"
 8124	blinking knitted chaotic girdle	0		Spell Critical Percent: +10, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	blurry fortified brawny gloves	0		Muscle Percent: +20, Damage Absorption: +60, Single Equip, Last Available: "2018-12"
-8126	modified pulsating skewed smithereens	1		Last Available: "2018-12"
+8126	modified skewed pulsating smithereens	1		Last Available: "2018-12"
 8127	scandalous chaotic fiberglass fetish	0		Spell Critical Percent: +10, Sleaze Damage: +5, Last Available: "2018-12"
 8128	chilly Socratic fiberglass foil	0		Experience (Mysticality): +1, Cold Damage: +5, Last Available: "2018-12"
 8129	lard-coated Fonzie's fiberglass fannypack	0		Experience (Moxie): +1, Sleaze Spell Damage: +25, Single Equip, Last Available: "2018-12"
@@ -8040,7 +8040,7 @@
 8166	foul-smelling dance instructor's cr&ecirc;epy mask	0		Experience Percent (Moxie): +10, Stench Damage: +10, Familiar Effect: "spooky atk, cap 5"
 8167	bland massive baguette	6	decent	
 8168	glob of icing	0		
-8169	warmed double-pickled wobbly narrow ginger snaps	0		Effect: "Blood-Rich", Effect Duration: 28
+8169	warmed double-pickled narrow wobbly ginger snaps	0		Effect: "Blood-Rich", Effect Duration: 28
 8170	concentrated wobbly mostly-broken sunglasses	0		Effect: "Stinky Hands", Effect Duration: 46
 8171	lousy unflavored wine cooler	3	decent	
 8172	carton of snake milk	1	decent	
@@ -8065,13 +8065,13 @@
 8191	smooth Breakfast Blast wine cooler	3	awesome	
 8192	lousy Citrus Crush wine cooler	3	decent	
 8193	flavorless plain bagel	4	decent	
-8194	flavorless tiny glob of cream cheese	1	decent	
+8194	tiny flavorless glob of cream cheese	1	decent	
 8195	spoiled loaf of soda bread	3	crappy	
 8196	tiny flavorless acceptable bagel	1	decent	
 8197	toothsome red standard-issue cupcake	3	awesome	
-8198	normal jumbo skewed ultra-deluxe cupcake	5	good	
+8198	jumbo normal skewed ultra-deluxe cupcake	5	good	
 8199	hypnotic breadcrumbs	0		
-8200	spoiled enchanted big jittery upside-down popular tart	5	crappy	Effect: "Capricorn Rising", Effect Duration: 10
+8200	enchanted spoiled big jittery upside-down popular tart	5	crappy	Effect: "Capricorn Rising", Effect Duration: 10
 8201	pulsating tumbling no-handed pie	0		
 8202	galvanized corrupted Doc Galaktik's Vitality Serum	0		Effect: "Hammered", Effect Duration: 44
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	blinking trash net	0		Last Available: "2015-04"
 8246	frightening sizzling therapeutic Dinsey mascot mask	0		Hot Damage: +10, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-04"
 8247	adequate Dinsey food-cone	3	good	Last Available: "2015-04"
-8248	distilled perfectly mixed blurry Dinsey Whinskey	5	EPIC	Last Available: "2015-04"
+8248	perfectly mixed distilled blurry Dinsey Whinskey	5	EPIC	Last Available: "2015-04"
 8249	enhanced blue blinking Dinsey face paint	0		Effect: "Fudge Headache", Effect Duration: 16, Last Available: "2015-04"
 8250	energetic arcane researcher's fannypack	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Last Available: "2015-04"
 8251	huge avaricious knitted wool supercharged extremely unsafe garbage sticker of mayonnaise	0		Weapon Damage Percent: +100, Maximum MP Percent: +30, Sleaze Spell Damage: +50, Cold Resistance: 4, Meat Drop: +30, Last Available: "2015-04"
@@ -8141,10 +8141,10 @@
 8267	gravedigger's sphygmayomanometer	0		Spooky Damage: +10, Lasts Until Rollover, Last Available: "2015-05"
 8268	jittery tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	immense stale unappetizing mayolus	8	decent	Last Available: "2015-05"
+8270	stale immense unappetizing mayolus	8	decent	Last Available: "2015-05"
 8271	bland uninteresting mayolus	3	decent	Last Available: "2015-05"
-8272	miniature yummy acceptable mayolus	2	awesome	Last Available: "2015-05"
-8273	huge bland enticing mayolus	10	decent	Last Available: "2015-05"
+8272	yummy miniature acceptable mayolus	2	awesome	Last Available: "2015-05"
+8273	bland huge enticing mayolus	10	decent	Last Available: "2015-05"
 8274	stale pulsating mouth-watering mayolus	3	decent	Last Available: "2015-05"
 8275	pulsating squat newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
@@ -8204,17 +8204,17 @@
 8330	galvanized tumbling assassin's cheese knife	0		Effect: "Smokin'", Effect Duration: 63
 8331	concentrated Vulcanized upside-down filthy armor	0		Effect: "Morninja", Effect Duration: 31
 8332	aerosolized plague pie	0		Effect: "Burnt 'n' Turnt", Effect Duration: 19
-8333	vacuum-sealed huge blurry batarang	0		Effect: "Ham-Fisted", Effect Duration: 18
+8333	vacuum-sealed blurry huge batarang	0		Effect: "Ham-Fisted", Effect Duration: 18
 8334	dry spare neck bolts	0		Effect: "Christmessy", Effect Duration: 56
 8335	energized adjusted non-oxidized yellow bouncing grease trap	0		Effect: "Earthen Fist", Effect Duration: 14
 8336	concentrated oxidized teal shamanic ham	0		Effect: "Smugness", Effect Duration: 34
 8337	flattened colloidal porkpocket	0		Effect: "Polar Express", Effect Duration: 27
-8338	improved diffused squat tumbling Leonard's glasses	0		Effect: "Adorable Lookout", Effect Duration: 33
+8338	improved diffused tumbling squat Leonard's glasses	0		Effect: "Adorable Lookout", Effect Duration: 33
 8339	corrupted warehouse walkie-talkie	0		Effect: "PERL of Great Price", Effect Duration: 27
 8340	ionized aerosolized janitor's mop	0		Effect: "Astral Shell", Effect Duration: 69
 8341	wet mirror warehouse clerk's glasses	0		Effect: "Well-Swabbed Ear", Effect Duration: 17
 8342	nitrogenated alkaline ionized baloney rotgut	0		Effect: "Bandersnatched", Effect Duration: 18
-8343	liquefied double-galvanized skewed green carton of gaspers	0		Effect: "Cybernetic Muscles", Effect Duration: 13
+8343	liquefied double-galvanized green skewed carton of gaspers	0		Effect: "Cybernetic Muscles", Effect Duration: 13
 8344	super-dry boiled bronze polish	0		Effect: "Antsy in your Pantsy", Effect Duration: 27
 8345	dry blurry crident	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 12
 8346	dry triple-dry totally sweet mohawk helmet	0		Effect: "Larger", Effect Duration: 14
@@ -8224,7 +8224,7 @@
 8350	deionized damp bar rag	0		Effect: "Browbeaten", Effect Duration: 40
 8351	extra-quantum triple-denatured bouncing lump of goofball ore	0		Effect: "Hella Smart", Effect Duration: 37
 8352	adjusted triple-vacuum-sealed skeleton beans	0		Effect: "Bilious Brawn", Effect Duration: 24
-8353	alkaline extra-dry upside-down cyan grimy lab coat	0		Effect: "Pronounced Potency", Effect Duration: 60
+8353	alkaline extra-dry cyan upside-down grimy lab coat	0		Effect: "Pronounced Potency", Effect Duration: 60
 8354	nitrogenated irradiated pulsating nursery rhyme	0		Effect: "Uncaged Power", Effect Duration: 67
 8355	ionized extra-anodized iron torso box	0		Effect: "Seriously Mutated", Effect Duration: 33
 8356	electrified corrupted mercenary headband	0		Effect: "Hobo Flavor", Effect Duration: 61
@@ -8239,7 +8239,7 @@
 8365	magnetized tumbling novelty fruit hat	0		Effect: "Strange Mental Acuity", Effect Duration: 67
 8366	boiled wet adjusted shaking invisibility cream	0		Effect: "Glittering Eyelashes", Effect Duration: 25
 8367	modified galvanized handful of stubble	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 65
-8368	quantum upside-down purple garbage juice slurpee	0		Effect: "Mer-kinny Flavor", Effect Duration: 53
+8368	quantum purple upside-down garbage juice slurpee	0		Effect: "Mer-kinny Flavor", Effect Duration: 53
 8369	unsweetened plunge-leg	0		Effect: "The Halls of Moxiousness", Effect Duration: 16
 8370	activated energized pulsating maroon funky eyepatch	0		Effect: "Mighty Shout", Effect Duration: 20
 8371	activated cyan bucket of fish juice	0		Effect: "Natural 20", Effect Duration: 50
@@ -8249,7 +8249,7 @@
 8375	electrified eyebrow lifter	0		Effect: "Ice Packed", Effect Duration: 12
 8376	submarine	0		Last Available: "2015-06"
 8377	bland pixel lemon	3	decent	Last Available: "2015-06"
-8378	acceptable irresponsibly strong jittery pixel daiquiri	9	good	Last Available: "2015-06"
+8378	irresponsibly strong acceptable jittery pixel daiquiri	9	good	Last Available: "2015-06"
 8379	altered boiled teal power pill	0		Effect: "[1701]Hip to the Jive", Effect Duration: 34, Last Available: "2015-06"
 8380	magnetized moist quantum blue pixel potion	0		Effect: "Outer Wolf&trade;", Effect Duration: 55, Last Available: "2015-06"
 8381	wobbly Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8280,18 +8280,18 @@
 8406	upside-down savory dry noodles	0		
 8407	flavorless twirling pestopiary	3	decent	
 8408	enhanced ectoplasmic orbs	0		Effect: "Mortarfied", Effect Duration: 26
-8409	rotten special miniature squat crudles	2	crappy	Effect: "Lifted Spirits", Effect Duration: 25
-8410	spoiled snack-sized agnolotti arboli	2	crappy	
+8409	special rotten miniature squat crudles	2	crappy	Effect: "Lifted Spirits", Effect Duration: 25
+8410	snack-sized spoiled agnolotti arboli	2	crappy	
 8411	moldy spaghetti with ghost balls	4	crappy	
 8412	bland huge succulent marrow	3	decent	
 8413	spoiled half-sized spinning salacious crumbs	2	crappy	
 8414	special immense normal fusilli marrownarrow	8	good	Effect: "Human-Hobo Hybrid", Effect Duration: 40
 8415	moldy suggestive strozzapreti	4	crappy	
-8416	mirror pulsating Mountain Stream gastrique	0		
+8416	pulsating mirror Mountain Stream gastrique	0		
 8417	bland lime green Mt. McLargeHuge oyster	3	decent	
 8418	oyster sauce	0		
-8419	rotten gigantic enchanted linguini immondizia bianco	6	crappy	Effect: "Marinated", Effect Duration: 5
-8420	snack-sized moldy fancy mirror shells a la shellfish	2	crappy	Effect: "Cautious Prowl", Effect Duration: 50
+8419	rotten enchanted gigantic linguini immondizia bianco	6	crappy	Effect: "Marinated", Effect Duration: 5
+8420	moldy snack-sized fancy mirror shells a la shellfish	2	crappy	Effect: "Cautious Prowl", Effect Duration: 50
 8421	jittery Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8305,7 +8305,7 @@
 8431	spore pod	0		
 8432	bouncing hot spore pod	0		
 8433	cool spore pod	0		
-8434	gray ghostly spinning skewed jingling spore pod	0		
+8434	gray ghostly skewed spinning jingling spore pod	0		
 8435	olive blinking Oprah's LavaCo Lamp&trade; of courage	0		Maximum MP Percent: +50, Spooky Resistance: +3, Last Available: "2015-08"
 8436	quilted LavaCo Lamp&trade; of Calamity Jane	0		Damage Absorption: +40, Critical Hit Percent: +15, Last Available: "2015-08"
 8437	yellow sizzling electrified LavaCo Lamp&trade;	0		Hot Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08"
@@ -8331,22 +8331,22 @@
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	wool Da Vinci's high-temperature mining mask	0		Experience (Mysticality): +5, Cold Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	bouncing narrow dog trainer's curative fireproof megaphone	0		Experience (familiar): +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-08"
-8460	stale small mineapple	2	decent	Last Available: "2015-08"
-8461	acceptable watered-down Gold Velvet&trade; whiskey	2	good	Last Available: "2015-08"
+8460	small stale mineapple	2	decent	Last Available: "2015-08"
+8461	watered-down acceptable Gold Velvet&trade; whiskey	2	good	Last Available: "2015-08"
 8462	mirror SMOOCH soda	1	awesome	Last Available: "2015-08"
-8463	flavorless snack-sized narrow smelted roe	2	decent	Last Available: "2015-08"
-8464	lousy practically non-alcoholic blinking lavawater	1	decent	Last Available: "2015-08"
+8463	snack-sized flavorless narrow smelted roe	2	decent	Last Available: "2015-08"
+8464	practically non-alcoholic lousy blinking lavawater	1	decent	Last Available: "2015-08"
 8465	tarnished basaltamander tongue	0		Effect: "Quaaaaaaa", Effect Duration: 64, Last Available: "2015-08"
 8466	reassuring educational lavalarva of dire peril	0		Experience: +1, Weapon Damage: +20, Spooky Resistance: +1, Last Available: "2015-08"
 8467	censurious mansplainer's educational lava balaclava	0		Experience: +1, Monster Level: +15, Sleaze Resistance: +3, Last Available: "2015-08"
 8468	blinking stanky basaltamander buckler of chilblains of the boozehound	0		Cold Damage: +25, Stench Spell Damage: +25, Booze Drop: +100, Damage Reduction: 15, Last Available: "2015-08"
 8469	quantum magnetized moist lava globs	0		Effect: "Egg-stortionary Tactics", Effect Duration: 21, Last Available: "2015-08"
-8470	rotten huge enchanted upside-down gooey lava globs	8	crappy	Effect: "Joy", Effect Duration: 25, Last Available: "2015-08"
+8470	enchanted huge rotten upside-down gooey lava globs	8	crappy	Effect: "Joy", Effect Duration: 25, Last Available: "2015-08"
 8471	Lo Pan's lava-proof pants of the overflowing toilet	0		Spell Critical Percent: +30, Stench Spell Damage: +50, Last Available: "2015-08"
 8472	pulsating sage heat-resistant necktie of mayonnaise	0		Mysticality Percent: +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8473	smelly healthy heat-resistant gloves of chilblains	0		Maximum HP Percent: +20, Cold Damage: +25, Stench Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8474	normal very hot lunch	3	good	Last Available: "2015-08"
-8475	practically non-alcoholic delicious asbestos thermos	1	awesome	Last Available: "2015-08"
+8475	delicious practically non-alcoholic asbestos thermos	1	awesome	Last Available: "2015-08"
 8476	flattened cold-filtered liquid rhinestones	0		Effect: "Bootyliciousness", Effect Duration: 37, Last Available: "2015-08"
 8477	normal low-calorie disco biscuit	1	good	Last Available: "2015-08"
 8478	perfectly mixed skewed Quaatorade&trade;	3	EPIC	Last Available: "2015-08"
@@ -8396,7 +8396,7 @@
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	rotten super-sized narrow lava cake	5	crappy	Last Available: "2015-08"
+8525	super-sized rotten narrow lava cake	5	crappy	Last Available: "2015-08"
 8526	snack-sized normal pink slime	2	good	
 8527	Devil's Elbow Hot Sauce	0		
 8528	red Special&trade; Sauce	0		
@@ -8411,16 +8411,16 @@
 8537	cold-filtered ionized huge Hersey&trade; SMOOCH	0		Effect: "Human-Horror Hybrid", Effect Duration: 54
 8539	red Alexy sauce	0		
 8540	rainbow sauce	0		
-8541	pulsating wobbly drug cocktail sauce	0		
+8541	wobbly pulsating drug cocktail sauce	0		
 8542	gigantic flavorless Fettris	6	decent	
-8543	stale big fusillocybin	5	decent	
-8544	half-sized normal prescription noodles	2	good	
+8543	big stale fusillocybin	5	decent	
+8544	normal half-sized prescription noodles	2	good	
 8545	distilled blinking blinking blood-drive sticker	1	good	
 8546	extra-vacuum-sealed wet activated shaking bag of grain	0		Effect: "Improprie Tea", Effect Duration: 67
 8547	aerosolized teal pocket maze	0		Effect: "Blackberry Politeness", Effect Duration: 41
 8548	tarnished adjusted olive shady shades	0		Effect: "Thunderspell", Effect Duration: 19
 8549	flattened flattened mirror squeaky toy rose	0		Effect: "Corona de la Salsa", Effect Duration: 25
-8550	stale diet weird gazelle steak	1	decent	
+8550	diet stale weird gazelle steak	1	decent	
 8551	stale spinning sausage without a cause	3	decent	
 8552	nitrogenated double-activated face paint	0		Effect: "Deep-Seated Rage", Effect Duration: 60
 8553	mediocre shaking emergency margarita	3	decent	
@@ -8429,7 +8429,7 @@
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	diffused non-denatured magnetized blue Wickers bar	0		Effect: "Heart of Yellow", Effect Duration: 58
-8559	double-pickled non-dry adjusted red twirling bakelite-covered bacon	0		Effect: "Briny Blood", Effect Duration: 55
+8559	double-pickled non-dry adjusted twirling red bakelite-covered bacon	0		Effect: "Briny Blood", Effect Duration: 55
 8560	modified twirling squat Aerheads	0		Effect: "Tearful, Fearful", Effect Duration: 58
 8561	non-energized ionized energized Wrotz	0		Effect: "Yes, Can Haz", Effect Duration: 35
 8562	extra-adjusted nitrogenated Gabarbar	0		Effect: "Bootyliciousness", Effect Duration: 66
@@ -8449,8 +8449,8 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	upside-down huge barnacled barrel	0		Last Available: "2015-09"
 8578	perfectly mixed enchanted red bottle of Amontillado	3	EPIC	Effect: "Meatwise", Effect Duration: 50, Last Available: "2015-09"
-8579	perfectly mixed practically non-alcoholic barrel-aged martini	1	EPIC	Last Available: "2015-09"
-8580	tasty massive cyan blurry barrel pickle	6	awesome	Last Available: "2015-09"
+8579	practically non-alcoholic perfectly mixed barrel-aged martini	1	EPIC	Last Available: "2015-09"
+8580	tasty massive blurry cyan barrel pickle	6	awesome	Last Available: "2015-09"
 8581	bite-sized bland tumbling barrel cracker	1	decent	Last Available: "2015-09"
 8582	altered vibrating mushroom	1	good	Effect: "Sugary World View", Effect Duration: 5, Last Available: "2015-09"
 8583	boiled green mushroom	1	decent	Last Available: "2015-09"
@@ -8474,7 +8474,7 @@
 8601	dry skewed cuppa Flamibili tea	0		Effect: "Notably Lovely", Effect Duration: 19, Last Available: "2015-09"
 8602	enhanced triple-tarnished cuppa Yet tea	0		Effect: "Heart of Green", Effect Duration: 15, Last Available: "2015-09"
 8603	denatured ionized dry cuppa Boo tea	0		Effect: "Ninja, Please", Effect Duration: 23, Last Available: "2015-09"
-8604	denatured boiled huge narrow cuppa Nas tea	0		Effect: "Tennis Elbow-wow", Effect Duration: 37, Last Available: "2015-09"
+8604	denatured boiled narrow huge cuppa Nas tea	0		Effect: "Tennis Elbow-wow", Effect Duration: 37, Last Available: "2015-09"
 8605	pickled pulsating cuppa Improprie tea	0		Effect: "Bolts about Candy", Effect Duration: 11, Last Available: "2015-09"
 8606	non-nitrogenated enhanced cuppa Frost tea	0		Effect: "Spooky Weapon", Effect Duration: 31, Last Available: "2015-09"
 8607	triple-aerosolized triple-warmed deionized cuppa Toast tea	0		Effect: "Gemini Rising", Effect Duration: 15, Last Available: "2015-09"
@@ -8484,7 +8484,7 @@
 8611	double-Vulcanized unsweetened cuppa Chari tea	0		Effect: "Ode to Booze", Effect Duration: 40, Last Available: "2015-09"
 8612	nitrogenated nitrogenated cyan cuppa Serendipi tea	0		Effect: "Material Witness", Effect Duration: 46, Last Available: "2015-09"
 8613	cold-filtered cyan cuppa Feroci tea	0		Effect: "Material Witness", Effect Duration: 18, Last Available: "2015-09"
-8614	ionized spinning upside-down teal cuppa Physicali tea	0		Effect: "Aided and Abetted", Effect Duration: 55, Last Available: "2015-09"
+8614	ionized teal upside-down spinning cuppa Physicali tea	0		Effect: "Aided and Abetted", Effect Duration: 55, Last Available: "2015-09"
 8615	polarized tarnished cuppa Wit tea	0		Effect: "Disdain of She-Who-Was", Effect Duration: 32, Last Available: "2015-09"
 8616	activated cuppa Neuroplastici tea	0		Effect: "Dragged Through the Coals", Effect Duration: 68, Last Available: "2015-09"
 8617	concentrated irradiated liquefied cuppa Dexteri tea	0		Effect: "Magically Fingered", Effect Duration: 41, Last Available: "2015-09"
@@ -8495,7 +8495,7 @@
 8622	electrified cuppa Mediocri tea	0		Effect: "Aries Rising", Effect Duration: 22, Last Available: "2015-09"
 8623	activated cuppa Loyal tea	0		Effect: "Mushroom Moxiousness", Effect Duration: 22, Last Available: "2015-09"
 8624	pickled pulsating cuppa Activi tea	1	crappy	Last Available: "2015-09"
-8625	dehydrated green mirror cuppa Cruel tea	1		Last Available: "2015-09"
+8625	dehydrated mirror green cuppa Cruel tea	1		Last Available: "2015-09"
 8626	dry chilled mirror cuppa Alacri tea	0		Effect: "Psalm of Pointiness", Effect Duration: 14, Last Available: "2015-09"
 8627	denatured cuppa Vitali tea	0		Effect: "Berry Defensive", Effect Duration: 37, Last Available: "2015-09"
 8628	polymerized cuppa Mana tea	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 30, Last Available: "2015-09"
@@ -8510,22 +8510,22 @@
 8637	quadruple-denatured magnetized cuppa Insani tea	0		Effect: "Stinky Weapon", Effect Duration: 21, Last Available: "2015-09"
 8638	zippy Royal scepter of the ox of Calamity Jane	0		Muscle: +20, Critical Hit Percent: +15, Initiative: +20, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
-8640	bouncing ghostly Ghost Dog Chow	0		Last Available: "2015-10"
+8640	ghostly bouncing Ghost Dog Chow	0		Last Available: "2015-10"
 8641	spoiled squat bowl of eyeballs	4	crappy	Last Available: "2015-10"
-8642	tasty snack-sized bowl of mummy guts	2	awesome	Last Available: "2015-10"
+8642	snack-sized tasty bowl of mummy guts	2	awesome	Last Available: "2015-10"
 8643	stale special huge bowl of maggots	4	decent	Effect: "Mitre Cut", Effect Duration: 40, Last Available: "2015-10"
 8644	hand-crafted blood and blood	4	EPIC	Last Available: "2015-10"
-8645	triple-distilled tolerable purple Jack-O-Lantern beer	8	good	Last Available: "2015-10"
+8645	tolerable triple-distilled purple Jack-O-Lantern beer	8	good	Last Available: "2015-10"
 8646	hand-crafted weak zombie	2	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
-8650	spinning squat tennis ball	0		Last Available: "2015-10"
+8650	squat spinning tennis ball	0		Last Available: "2015-10"
 8651	flame-wreathed Rosewater's savvy crown	0		Mysticality Percent: 50, Hot Spell Damage: +10, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	bouncing blinking hawk of the pedagogue of the sewer of the overflowing toilet	0		Experience: +3, Stench Damage: +25, Stench Spell Damage: +50
-8655	decent low-calorie hamlet sandwich	1	good	
+8655	low-calorie decent hamlet sandwich	1	good	
 8656	Othello's military jacket of dire peril	0		Weapon Damage: +20
 8657	twirling flame-retardant Othello's dagger	0		Hot Resistance: +1, Single Equip
 8658	jittery curative Othello's handkerchief	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	blurry mansplainer's curative Samson's ghostly dagger	0		Experience (Muscle): +5, Monster Level: +15, HP Regen Min: 3, HP Regen Max: 5
-8663	special practically non-alcoholic smooth ghost beer	1	awesome	Effect: "Tremella Tremens", Effect Duration: 10
+8663	special smooth practically non-alcoholic ghost beer	1	awesome	Effect: "Tremella Tremens", Effect Duration: 10
 8664	spinning Othello set of wisdom	0		Mysticality: +15
 8665	rotten tomato	0		
 8666	tumbling Twelve Night Energy	0		
@@ -8547,7 +8547,7 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	spinning one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	Vulcanized tumbling shoulder-warming lotion	0		Effect: "Ten out of Ten", Effect Duration: 40, Last Available: "2015-11"
-8677	rotten low-calorie iceberg lettuce	1	crappy	Last Available: "2015-11"
+8677	low-calorie rotten iceberg lettuce	1	crappy	Last Available: "2015-11"
 8678	hand-crafted ice wine	4	EPIC	Last Available: "2015-11"
 8679	narrow dangerous sage beefcake's Wal-Mart snowglobe	0		Muscle: +25, Mysticality Percent: +10, Weapon Damage: +10, Last Available: "2015-11"
 8680	jittery up-at-dawn Herculean boxer's Wal-Mart nametag	0		Muscle Percent: +10, Experience (Muscle): +1, Adventures: +5, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	upside-down perfect ice cube	0		Last Available: "2015-11"
 8687	ghostly The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	slick bellhop's hat	0		Moxie: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	extra-dry tolerable special skewed ice porter	5	good	Effect: "For Your Brain Only", Effect Duration: 20, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	tolerable special extra-dry skewed ice porter	5	good	Effect: "For Your Brain Only", Effect Duration: 20, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	ionized diffused exotic travel brochure	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 18, Last Available: "2015-11"
 8691	purple bag of foreign bribes	0		Last Available: "2015-11"
 8692	Vulcanized shampoo-conditioner	0		Effect: "Horrid, Torrid", Effect Duration: 34, Last Available: "2015-11"
@@ -8577,19 +8577,19 @@
 8704	yellow training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	skewed X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	bouncing machine elf capsule	0		Free Pull, Last Available: "2015-12"
-8707	mirror upside-down self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
-8708	mixed wobbly olive abstraction: action	1		Last Available: "2015-12"
+8707	upside-down mirror self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
+8708	mixed olive wobbly abstraction: action	1		Last Available: "2015-12"
 8709	dehydrated abstraction: thought	1		Last Available: "2015-12"
 8710	diluted blinking huge abstraction: sensation	1		Last Available: "2015-12"
 8711	powdered abstraction: purpose	1		Effect: "[800]Chocolate Reign", Effect Duration: 20, Last Available: "2015-12"
 8712	powdered shaking abstraction: category	1		Effect: "Guts Feeling", Effect Duration: 45, Last Available: "2015-12"
 8713	vaporized abstraction: perception	1		Last Available: "2015-12"
-8714	altered blurry tumbling maroon abstraction: motion	1		Last Available: "2015-12"
-8715	dried blurry jittery abstraction: joy	1		Last Available: "2015-12"
+8714	altered maroon blurry tumbling abstraction: motion	1		Last Available: "2015-12"
+8715	dried jittery blurry abstraction: joy	1		Last Available: "2015-12"
 8716	modified abstraction: certainty	1		Last Available: "2015-12"
 8717	denatured abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	delicious jumbo VYKEA meatballs	5	awesome	Last Available: "2015-11"
+8719	jumbo delicious VYKEA meatballs	5	awesome	Last Available: "2015-11"
 8720	lousy VYKEA mead	3	decent	Last Available: "2015-11"
 8721	unsweetened VYKEA woadpaint	0		Effect: "Patent Avarice", Effect Duration: 54, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8603,7 +8603,7 @@
 8730	VYKEA instructions	0		Last Available: "2015-11"
 8731	decent blue tin of submardines	3	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	mediocre extra-dry bottle of norwhiskey	5	decent	Last Available: "2015-11"
-8733	compressed yellow narrow octolus oculus	1	decent	Last Available: "2015-11"
+8733	compressed narrow yellow octolus oculus	1	decent	Last Available: "2015-11"
 8734	pulsating zippy razor-sharp sardine can key of the sweet-tooth	0		Weapon Damage Percent: +25, Candy Drop: +100, Initiative: +20, Last Available: "2015-11"
 8735	reassuring Socratic norwhal helmet of James Dean	0		Experience (Mysticality): +1, Experience (Moxie): +3, Spooky Resistance: +1, Last Available: "2015-11", Familiar Effect: "atk"
 8736	therapeutic slick octolus-skin cloak of the glutton	0		Moxie: +10, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-11"
@@ -8612,7 +8612,7 @@
 8739	artisanal perfect dark and stormy	4	EPIC	Last Available: "2015-11"
 8740	tolerable twirling ghostly perfect mimosa	3	good	Last Available: "2015-11"
 8741	acceptable perfect old-fashioned	3	good	Last Available: "2015-11"
-8742	mediocre extra-dry blurry lime green huge perfect paloma	5	decent	Last Available: "2015-11"
+8742	extra-dry mediocre blurry huge lime green perfect paloma	5	decent	Last Available: "2015-11"
 8743	quadruple-polarized ionized That 70s Cologne	0		Effect: "White Knuckles", Effect Duration: 41, Last Available: "2015-11"
 8744	triple-polymerized vacuum-sealed blurry Wal-Mart &quot;diamond&quot; ring	0		Effect: "Jelly Combed", Effect Duration: 20, Last Available: "2015-11"
 8745	dry Puffstone cigar	0		Effect: "You're High as a Crow, Marty", Effect Duration: 34, Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	enhanced pressed chilled hemp candy necklace	0		Effect: "Boletus Swoletus", Effect Duration: 63, Last Available: "2015-12"
 8751	warmed moist tumbling communal gobstopper	0		Effect: "Spiritually Awake", Effect Duration: 51, Last Available: "2015-12"
 8752	miniature spoiled Crimbo salad	2	crappy	Last Available: "2015-12"
-8753	normal half-sized bread line	2	good	Last Available: "2015-12"
+8753	half-sized normal bread line	2	good	Last Available: "2015-12"
 8754	acceptable blue bark rootbeer	3	good	Last Available: "2015-12"
 8755	tolerable practically non-alcoholic shaking squat ale	1	good	Last Available: "2015-12"
 8756	ruddy plastic Tammy the Tambourine Elf	0		Maximum HP Percent: +40, Last Available: "2015-12"
@@ -8633,7 +8633,7 @@
 8760	plastic Crimbodhisattva	0		Item Drop: +5, Last Available: "2015-12"
 8761	twirling bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
-8763	jittery blurry BACON	0		Last Available: "2016-05"
+8763	blurry jittery BACON	0		Last Available: "2016-05"
 8764	twirling box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	pulsating Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
 8766	perfectly mixed Gratitude chocolate (bourbon-filled)	4	EPIC	Last Available: "2016-02"
@@ -8673,7 +8673,7 @@
 8801	spinning incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
 8803	kidnapped orphan	0		Last Available: "2017-01"
-8804	blurry teal narrow high-grade	0		Last Available: "2017-01"
+8804	narrow blurry teal high-grade	0		Last Available: "2017-01"
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	pulsating high-grade explosives	0		Last Available: "2017-01"
 8807	shaking experimental gene therapy	0		Last Available: "2017-01"
@@ -8685,13 +8685,13 @@
 8813	narrow glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	teal bat-bearing	0		Last Available: "2017-01"
-8816	normal thick Kudzu salad	5	good	Last Available: "2016-12"
+8816	thick normal Kudzu salad	5	good	Last Available: "2016-12"
 8817	boiled red Mansquito Serum	1		Last Available: "2016-12"
 8818	mediocre irresponsibly strong squat Miss Graves' vermouth	10	decent	Last Available: "2016-12"
 8819	stale The Plumber's mushroom stew	3	decent	Last Available: "2016-12"
 8820	twisted The Author's ink	1		Last Available: "2016-02"
-8821	practically non-alcoholic drinkable The Mad Liquor	1	good	Last Available: "2016-12"
-8822	strong acceptable fancy Doc Clock's thyme cocktail	5	good	Effect: "Tingly Elbows", Effect Duration: 10, Last Available: "2016-12"
+8821	drinkable practically non-alcoholic The Mad Liquor	1	good	Last Available: "2016-12"
+8822	strong fancy acceptable Doc Clock's thyme cocktail	5	good	Effect: "Tingly Elbows", Effect Duration: 10, Last Available: "2016-12"
 8823	toothsome Mr. Burnsger	3	awesome	Last Available: "2016-12"
 8824	boiled upside-down The Inquisitor's unidentifiable object	1		Effect: "Strawberry Alarm", Effect Duration: 10, Last Available: "2016-12"
 8825	coward's electrified slick The Jokester's gun	0		Moxie: +10, Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
@@ -8748,8 +8748,8 @@
 8876	spoiled plate of Heimz Fortified Kidney Beans	3	crappy	Last Available: "2016-02"
 8877	toothsome plate of Tesla's Electroplated Beans	3	awesome	Last Available: "2016-02"
 8878	moldy plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
-8879	half-sized rotten plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
-8880	normal big upside-down huge plate of Frigid Northern Beans	5	good	Last Available: "2016-02"
+8879	rotten half-sized plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
+8880	big normal huge upside-down plate of Frigid Northern Beans	5	good	Last Available: "2016-02"
 8881	stale plate of World's Blackest-Eyed Peas	3	decent	Last Available: "2016-02"
 8882	flavorless plate of Trader Olaf's Exotic Stinkbeans	4	decent	Last Available: "2016-02"
 8883	tiny decent narrow plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	good	Last Available: "2016-02"
@@ -8850,10 +8850,10 @@
 8978	quantum electrified spinning patent aggression tonic	0		Effect: "Sizzling with Fury", Effect Duration: 19
 8979	pressed patent sallowness tonic	0		Effect: "Oxygenated Blood", Effect Duration: 64
 8980	corrupted double-frozen patent avarice tonic	0		Effect: "Ready to Snap", Effect Duration: 36
-8981	tarnished pickled blinking yellow bouncing patent alacrity tonic	0		Effect: "Standard Cheer", Effect Duration: 44
-8982	polarized blue blurry corrupted marrow	0		Effect: "Once Bitten Twice Fried", Effect Duration: 59
+8981	tarnished pickled bouncing yellow blinking patent alacrity tonic	0		Effect: "Standard Cheer", Effect Duration: 44
+8982	polarized blurry blue corrupted marrow	0		Effect: "Once Bitten Twice Fried", Effect Duration: 59
 8983	artisanal jittery rodeo whiskey	3	EPIC	
-8984	cyan squat Thwaitgold scorpion statuette	0		
+8984	squat cyan Thwaitgold scorpion statuette	0		
 8985	real cowboy hat of chilblains	0		Cold Damage: +25
 8986	Memories of Cow Punching	0		Free Pull
 8987	Memories of Beanslinging	0		Free Pull
@@ -8862,7 +8862,7 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	compressed squat armored prawn	1		Effect: "EVISCERATE!", Effect Duration: 45, Last Available: "2016-03"
-8993	super-sized normal squat jumping horseradish	5	good	Last Available: "2016-03"
+8993	normal super-sized squat jumping horseradish	5	good	Last Available: "2016-03"
 8994	artisanal Sacramento wine	4	EPIC	Last Available: "2016-03"
 8995	super-liquefied anodized Greek fire	0		Effect: "Hood Ridin'", Effect Duration: 22, Last Available: "2016-03"
 8996	greasy scorching Jack Frost's manspreader's ox-head shield of the brute	0		Muscle Percent: +30, Monster Level: +10, Cold Spell Damage: +50, Hot Damage: +25, Sleaze Spell Damage: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
@@ -8878,7 +8878,7 @@
 9006	tumbling up-at-dawn sizzling friendly deadly tunac	0		Weapon Damage: +5, Familiar Weight: +3, Hot Damage: +10, Adventures: +5, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	energized jittery wriggling worm	0		Effect: "Ooh, Sweet!", Effect Duration: 14, Last Available: "2016-04"
-9009	watered-down perfectly mixed bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
+9009	perfectly mixed watered-down bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
 9010	unsweetened mirror high-test fishing line	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 67, Last Available: "2016-04"
 9011	executive fishin' hat	0		Meat Drop: +40, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8899,9 +8899,9 @@
 9027	personal trainer's First Post shirt - Cir Senam of the pedagogue of doom	0		Experience: +3, Experience Percent (Muscle): +10, Spooky Spell Damage: +50, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	blinking no spoon	0		
-9030	half-sized flavorless tumbling star salad	2	decent	
+9030	flavorless half-sized tumbling star salad	2	decent	
 9031	Thwaitgold moth statuette	0		
-9032	miniature moldy bowl of Tastee-Wheet&trade;	2	crappy	
+9032	moldy miniature bowl of Tastee-Wheet&trade;	2	crappy	
 9033	huge Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	spoiled browser cookie	3	crappy	Last Available: "2016-06"
@@ -8948,8 +8948,8 @@
 9076	Sherlock's manspreader's noir fedora of the empath	0		Monster Level: +10, Familiar Weight: +5, Item Drop: +25, Last Available: "2016-07"
 9077	twirling energetic hardened trench coat of Flo-Jo	0		Damage Reduction: 3, Maximum MP Percent: +20, Initiative: +100, Last Available: "2016-07"
 9078	perfectly mixed teal Falcon&trade; Maltese Liquor	4	EPIC	Last Available: "2016-07"
-9079	stale low-calorie hardboiled egg	1	decent	Last Available: "2016-07"
-9080	blinking bouncing detective tattoo	0		Last Available: "2016-07"
+9079	low-calorie stale hardboiled egg	1	decent	Last Available: "2016-07"
+9080	bouncing blinking detective tattoo	0		Last Available: "2016-07"
 9081	blinking DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	nippy sharpshooter's therapeutic protonic accelerator pack of the pedagogue of Tarzan of the cheetah	0		Experience: +3, Experience (Muscle): +3, Critical Hit Percent: +10, Cold Damage: +10, Initiative: +60, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
@@ -8995,15 +8995,15 @@
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	gray droppable microphone	0		
-9126	mediocre ghostly skewed unidentified drink	4	decent	
+9126	mediocre skewed ghostly unidentified drink	4	decent	
 9127	scandalous hardened KoL Con 13 T-shirt	0		Damage Reduction: 3, Sleaze Damage: +5
 9128	curative baleful discarded swimming trunks of vim and vigor	0		Spell Damage: +25, Maximum HP Percent: +50, HP Regen Min: 3, HP Regen Max: 5
-9129	irradiated concentrated purple blurry upside-down diluted makeup	0		Effect: "Yet tea", Effect Duration: 14
-9130	magnetized ionized maroon ghostly charisma potion	0		Effect: "Memento Moir&eacute;", Effect Duration: 31
+9129	irradiated concentrated blurry upside-down purple diluted makeup	0		Effect: "Yet tea", Effect Duration: 14
+9130	magnetized ionized ghostly maroon charisma potion	0		Effect: "Memento Moir&eacute;", Effect Duration: 31
 9131	extremely confusing manual	0		
 9132	miser's chaotic pistol	0		Spell Critical Percent: +10, Meat Drop: +10
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	bland thick leftover pasty	5	decent	
+9134	thick bland leftover pasty	5	decent	
 9135	hand-crafted very whiskey	4	EPIC	
 9136	shaking li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9016,7 +9016,7 @@
 9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	boiled mirror jittery hoarded candy wad	0		Effect: "Jerky, Boy", Effect Duration: 53, Last Available: "2016-10"
-9147	chilled bouncing huge Prunets	0		Effect: "Certainty", Effect Duration: 24
+9147	chilled huge bouncing Prunets	0		Effect: "Certainty", Effect Duration: 24
 9148	pulsating Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	dry invisible string	0		Lasts Until Rollover, Effect: "Bubblin' Rage", Effect Duration: 29, Last Available: "2016-10"
@@ -9024,12 +9024,12 @@
 9152	pulsating li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	spoiled half-sized raw sweet potato	2	crappy	Last Available: "2016-11"
 9154	normal raw beans	3	good	Last Available: "2016-11"
-9155	special miniature stale yellow raw stuffing	2	decent	Effect: "Cotton Mouthed", Effect Duration: 40, Last Available: "2016-11"
-9156	adequate snack-sized raw cranberry sauce	2	good	Last Available: "2016-11"
-9157	adequate fancy raw turkey	4	good	Effect: "Happy Trails", Effect Duration: 15, Last Available: "2016-11"
+9155	miniature stale special yellow raw stuffing	2	decent	Effect: "Cotton Mouthed", Effect Duration: 40, Last Available: "2016-11"
+9156	snack-sized adequate raw cranberry sauce	2	good	Last Available: "2016-11"
+9157	fancy adequate raw turkey	4	good	Effect: "Happy Trails", Effect Duration: 15, Last Available: "2016-11"
 9158	moldy raw mincemeat	4	crappy	Last Available: "2016-11"
 9159	spoiled spinning red raw potato	4	crappy	Last Available: "2016-11"
-9160	rotten snack-sized special raw gravy	2	crappy	Effect: "The Moxious Madrigal", Effect Duration: 15, Last Available: "2016-11"
+9160	special rotten snack-sized raw gravy	2	crappy	Effect: "The Moxious Madrigal", Effect Duration: 15, Last Available: "2016-11"
 9161	stale raw bread	3	decent	Last Available: "2016-11"
 9162	blue mini-marshmallow dispenser of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100, Last Available: "2016-11"
 9163	squat blurry greasy coward's beefcake's glass casserole dish	0		Muscle: +25, Monster Level: -20, Sleaze Spell Damage: +10, Last Available: "2016-11"
@@ -9041,13 +9041,13 @@
 9169	gravy boat	0		Last Available: "2016-11"
 9170	blurry bread mold	0		Last Available: "2016-11"
 9171	thick toothsome jittery sweet potatoes	5	awesome	Last Available: "2016-11"
-9172	massive bland bean casserole	9	decent	Last Available: "2016-11"
-9173	super-sized moldy baked stuffing	5	crappy	Last Available: "2016-11"
+9172	bland massive bean casserole	9	decent	Last Available: "2016-11"
+9173	moldy super-sized baked stuffing	5	crappy	Last Available: "2016-11"
 9174	super-sized rotten cranberry cylinder	5	crappy	Last Available: "2016-11"
 9175	moldy thanksgiving turkey	3	crappy	Last Available: "2016-11"
 9176	normal mince pie	4	good	Last Available: "2016-11"
-9177	gigantic moldy skewed mashed potatoes	8	crappy	Last Available: "2016-11"
-9178	yummy immense squat warm gravy	10	awesome	Last Available: "2016-11"
+9177	moldy gigantic skewed mashed potatoes	8	crappy	Last Available: "2016-11"
+9178	immense yummy squat warm gravy	10	awesome	Last Available: "2016-11"
 9179	stale bread roll	4	decent	Last Available: "2016-11"
 9180	normal thick maroon leftovers	5	good	Last Available: "2016-11"
 9181	low-calorie flavorless leftovers sandwich	1	decent	Last Available: "2016-11"
@@ -9108,7 +9108,7 @@
 9236	Usain Bolt's gingerbread gavel of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +80, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	triple-distilled tolerable jittery ginger beer	6	good	Last Available: "2016-12"
+9239	tolerable triple-distilled jittery ginger beer	6	good	Last Available: "2016-12"
 9240	narrow spare chocolate parts	0		Last Available: "2016-12"
 9241	diffused adjusted industrial frosting	0		Effect: "Super Vision", Effect Duration: 20, Last Available: "2016-12"
 9242	tarnished cyan fake cocktail	0		Effect: "Itchy Trigger Finger", Effect Duration: 24, Last Available: "2016-12"
@@ -9122,7 +9122,7 @@
 9250	quantum blinking Inner Strength	0		Effect: "Heavily Breathing", Effect Duration: 31, Last Available: "2016-12"
 9251	alkaline twirling Inner Truth	0		Effect: "Sweet Tooth", Effect Duration: 36, Last Available: "2016-12"
 9252	rotten snack-sized narrow spiritual candy cane	2	crappy	Last Available: "2016-12"
-9253	perfectly mixed spirit-forward spiritual eggnog	5	EPIC	Last Available: "2016-12"
+9253	spirit-forward perfectly mixed spiritual eggnog	5	EPIC	Last Available: "2016-12"
 9254	moldy twirling spiritual fruitcake	4	crappy	Last Available: "2016-12"
 9255	stale lime green spiritual gingerbread	4	decent	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
@@ -9134,21 +9134,21 @@
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
-9265	teal blinking teethpick	0		Last Available: "2016-12"
+9265	blinking teal teethpick	0		Last Available: "2016-12"
 9266	dry olive rock candy	0		Effect: "Full-Body Tan", Effect Duration: 67, Last Available: "2016-12"
-9267	flavorless thick green-iced sweet roll	5	decent	Last Available: "2016-12"
+9267	thick flavorless green-iced sweet roll	5	decent	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	squat chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	chakra sludge	0		
-9272	huge green negative lump	0		
+9272	green huge negative lump	0		
 9273	lard-coated Third Eye of Leguizamo	0		Monster Level: +20, Sleaze Spell Damage: +25, Last Available: "2016-12"
 9274	red stanky Temple Grandin's Krampus Horn	0		Familiar Weight: +7, Stench Spell Damage: +25, Single Equip, Last Available: "2016-12"
 9275	stale snack-sized hambrosier	2	decent	Last Available: "2016-12"
 9276	tolerable narrow chakra-mental wine	3	good	Last Available: "2016-12"
 9277	deionized triple-electrified enhanced wobbly chakra malt	0		Effect: "Compensatory Cruelness", Effect Duration: 44, Last Available: "2016-12"
-9278	diet flavorless Black Angus blackburger	1	decent	Last Available: "2016-12"
-9279	hand-crafted weak brandy	2	EPIC	Last Available: "2016-12"
+9278	flavorless diet Black Angus blackburger	1	decent	Last Available: "2016-12"
+9279	weak hand-crafted brandy	2	EPIC	Last Available: "2016-12"
 9280	extra-boiled corrupted lime green potion of spiritual gunkifying	0		Effect: "Sweet Incentive", Effect Duration: 21, Last Available: "2016-12"
 9281	electrified banded bad vibroknife	0		Damage Absorption: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9282	crystal belt buckle of dire peril of the businessman	0		Weapon Damage: +20, Meat Drop: +50, Last Available: "2016-12"
@@ -9157,19 +9157,19 @@
 9285	Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
 9286	eternal knot tattoo	0		Last Available: "2016-12"
 9287	pet bad vibe	0		Last Available: "2016-12"
-9288	wobbly blurry gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
+9288	blurry wobbly gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	lion tamer's energetic Uncle Crimbo's hat of the sweet-tooth	0		Maximum MP Percent: +20, Experience (familiar): +2, Candy Drop: +100, Last Available: "2016-12"
-9290	special jumbo bland wobbly Eldritch snap	5	decent	Effect: "Ancient Protected", Effect Duration: 10, Last Available: "2017-01"
+9290	special bland jumbo wobbly Eldritch snap	5	decent	Effect: "Ancient Protected", Effect Duration: 10, Last Available: "2017-01"
 9291	vaporized shaking hot jelly	1		Last Available: "2017-01"
 9292	diluted huge jelly	1		Effect: "Flame-Retardant Trousers", Effect Duration: 20, Last Available: "2017-01"
-9293	pickled jittery wobbly tumbling jelly	1		Last Available: "2017-01"
+9293	pickled jittery tumbling wobbly jelly	1		Last Available: "2017-01"
 9294	compressed tumbling sleaze jelly	1		Last Available: "2017-01"
 9295	compressed stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal toast with hot jelly	4	good	Last Available: "2017-01"
-9298	moldy snack-sized tumbling toast with jelly	2	crappy	Last Available: "2017-01"
+9298	snack-sized moldy tumbling toast with jelly	2	crappy	Last Available: "2017-01"
 9299	decent snack-sized toast with jelly	2	good	Last Available: "2017-01"
-9300	snack-sized moldy toast with sleaze jelly	2	crappy	Last Available: "2017-01"
+9300	moldy snack-sized toast with sleaze jelly	2	crappy	Last Available: "2017-01"
 9301	spoiled toast with stench jelly	3	crappy	Last Available: "2017-01"
 9302	teal space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9180,14 +9180,14 @@
 9308	educational wax face of vim and vigor	0		Experience: +1, Maximum HP Percent: +50, Last Available: "2017-01"
 9309	perfectly mixed irresponsibly strong green wax booze	10	EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	denatured spinning skewed sea jelly	1		Last Available: "2017-01"
-9312	special flavorless sea truffle	3	decent	Effect: "Engorged Weapon", Effect Duration: 50, Last Available: "2017-01"
+9311	denatured skewed spinning sea jelly	1		Last Available: "2017-01"
+9312	flavorless special sea truffle	3	decent	Effect: "Engorged Weapon", Effect Duration: 50, Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	baleful recovered cufflinks	0		Spell Damage: +25, Single Equip, Last Available: "2017-01"
 9316	heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	irradiated narrow LOV Elixir #3	0		Effect: "Toothy Grin", Effect Duration: 18, Last Available: "2017-02"
-9318	triple-activated Vulcanized purple bouncing LOV Elixir #6	0		Effect: "Sweetened and Fattened", Effect Duration: 12, Last Available: "2017-02"
+9318	triple-activated Vulcanized bouncing purple LOV Elixir #6	0		Effect: "Sweetened and Fattened", Effect Duration: 12, Last Available: "2017-02"
 9319	warmed cyan LOV Elixir #9	0		Effect: "Spell Transfer Complete", Effect Duration: 29, Last Available: "2017-02"
 9320	twirling foul-smelling curative cool LOV Eardigan	0		Moxie: +5, Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2017-02"
 9321	Tesla weightlifter's LOV Epaulettes of the storm	0		Muscle: +15, Maximum MP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2017-02"
@@ -9198,16 +9198,16 @@
 9326	vaporized LOV Echinacea Bouquet	1		Effect: "Puzzle Fury", Effect Duration: 45, Last Available: "2017-02"
 9327	olive LOV Elephant of the pedagogue	0		Experience: +3, Damage Reduction: 6, Last Available: "2017-02"
 9328	scandalous eldritch scanner	0		Sleaze Damage: +5, Last Available: "2017-02"
-9329	double-boiled pickled super-concentrated skewed jittery huge eldritch alignment spray	0		Effect: "Flashing Eyes", Effect Duration: 22, Last Available: "2017-02"
+9329	double-boiled pickled super-concentrated huge skewed jittery eldritch alignment spray	0		Effect: "Flashing Eyes", Effect Duration: 22, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	clever razor-sharp eldritch hammer of vim and vigor	0		Weapon Damage Percent: +25, Maximum HP Percent: +50, Maximum MP: +20, Last Available: "2017-01"
-9332	massive delicious eldritch mushroom	6	awesome	Last Available: "2017-03"
-9333	wobbly ghostly purple eldritch ichor	0		
-9334	adequate thick olive jittery eldritch mushroom pizza	5	good	Last Available: "2017-03"
+9332	delicious massive eldritch mushroom	6	awesome	Last Available: "2017-03"
+9333	ghostly wobbly purple eldritch ichor	0		
+9334	adequate thick jittery olive eldritch mushroom pizza	5	good	Last Available: "2017-03"
 9335	upside-down eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	non-flattened diffused eldritch rub	0		Effect: "Retrograde Relaxation", Effect Duration: 69, Last Available: "2017-02"
-9338	huge skewed HP-35 Calculator	0		
+9338	skewed huge HP-35 Calculator	0		
 9339	ghostly Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
@@ -9234,18 +9234,18 @@
 9362	skewed pile of dirt	0		Last Available: "2017-03"
 9363	gray slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
-9365	smooth spirit-forward blue upside-down literal grasshopper	5	awesome	Last Available: "2017-03"
-9366	acceptable yellow ghostly double entendre	4	good	Last Available: "2017-03"
-9367	artisanal high-proof fancy Phlegethon	7	EPIC	Effect: "Tearful, Fearful", Effect Duration: 35, Last Available: "2017-03"
+9365	spirit-forward smooth upside-down blue literal grasshopper	5	awesome	Last Available: "2017-03"
+9366	acceptable ghostly yellow double entendre	4	good	Last Available: "2017-03"
+9367	high-proof artisanal fancy Phlegethon	7	EPIC	Effect: "Tearful, Fearful", Effect Duration: 35, Last Available: "2017-03"
 9368	hand-crafted Siberian sunrise	4	EPIC	Last Available: "2017-03"
 9369	hand-crafted bouncing mentholated wine	3	EPIC	Last Available: "2017-03"
 9370	fancy smooth low tide martini	4	awesome	Effect: "Faboooo", Effect Duration: 50, Last Available: "2017-03"
 9371	drinkable shroomtini	3	good	Last Available: "2017-03"
 9372	tolerable pulsating morning dew	3	good	Last Available: "2017-03"
-9373	strong drinkable wobbly whiskey squeeze	5	good	Last Available: "2017-03"
+9373	drinkable strong wobbly whiskey squeeze	5	good	Last Available: "2017-03"
 9374	special acceptable great fashioned	3	good	Effect: "Angry like the Wolf", Effect Duration: 25, Last Available: "2017-03"
 9375	lousy watered-down pulsating tumbling Gnomish sagngria	2	decent	Last Available: "2017-03"
-9376	practically non-alcoholic perfectly mixed vodka stinger	1	EPIC	Last Available: "2017-03"
+9376	perfectly mixed practically non-alcoholic vodka stinger	1	EPIC	Last Available: "2017-03"
 9377	practically non-alcoholic perfectly mixed extremely slippery nipple	1	EPIC	Last Available: "2017-03"
 9378	triple-distilled delicious piscatini	7	awesome	Last Available: "2017-03"
 9379	tolerable skewed Churchill	3	good	Last Available: "2017-03"
@@ -9253,19 +9253,19 @@
 9381	artisanal watered-down London frog	2	EPIC	Last Available: "2017-03"
 9382	drinkable nothingtini	3	good	Last Available: "2017-03"
 9383	lousy eighth plague	3	decent	Last Available: "2017-03"
-9384	practically non-alcoholic enchanted tolerable single entendre	1	good	Effect: "Cool, Catlike", Effect Duration: 45, Last Available: "2017-03"
-9385	enchanted hand-crafted reverse Tantalus	3	EPIC	Effect: "Sticks and Stones", Effect Duration: 45, Last Available: "2017-03"
+9384	enchanted tolerable practically non-alcoholic single entendre	1	good	Effect: "Cool, Catlike", Effect Duration: 45, Last Available: "2017-03"
+9385	hand-crafted enchanted reverse Tantalus	3	EPIC	Effect: "Sticks and Stones", Effect Duration: 45, Last Available: "2017-03"
 9386	hand-crafted high-proof elemental caipiroska	6	EPIC	Last Available: "2017-03"
-9387	practically non-alcoholic smooth Feliz Navidad	1	awesome	Last Available: "2017-03"
+9387	smooth practically non-alcoholic Feliz Navidad	1	awesome	Last Available: "2017-03"
 9388	practically non-alcoholic mediocre Bloody Nora	1	decent	Last Available: "2017-03"
-9389	distilled bad moreltini	5	decent	Last Available: "2017-03"
+9389	bad distilled moreltini	5	decent	Last Available: "2017-03"
 9390	tolerable practically non-alcoholic hell in a bucket	1	good	Last Available: "2017-03"
 9391	artisanal extra-dry Newark	5	EPIC	Last Available: "2017-03"
 9392	drinkable yellow R'lyeh	4	good	Last Available: "2017-03"
 9393	artisanal Gnollish sangria	4	EPIC	Last Available: "2017-03"
 9394	mediocre vodka barracuda	3	decent	Last Available: "2017-03"
 9395	perfectly mixed Mysterious Island iced tea	4	EPIC	Last Available: "2017-03"
-9396	drinkable watered-down enchanted gray drive-by shooting	2	good	Effect: "Bestial Sympathy", Effect Duration: 45, Last Available: "2017-03"
+9396	watered-down drinkable enchanted gray drive-by shooting	2	good	Effect: "Bestial Sympathy", Effect Duration: 45, Last Available: "2017-03"
 9397	hand-crafted gunner's daughter	4	EPIC	Last Available: "2017-03"
 9398	irresponsibly strong mediocre dirt julep	9	decent	Last Available: "2017-03"
 9399	acceptable Simepore slime	4	good	Last Available: "2017-03"
@@ -9276,7 +9276,7 @@
 9404	squat Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
-9407	olive huge rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
+9407	huge olive rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	blinking gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	pulsating Spacegate Research	0		Last Available: "2017-04"
@@ -9284,13 +9284,13 @@
 9412	bouncing alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	spoiled jumbo enchanted edible alien plant bit	5	crappy	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 35, Last Available: "2017-04"
+9415	jumbo enchanted spoiled edible alien plant bit	5	crappy	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 35, Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	bouncing alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	dried blurry skewed alien plant goo	1		Last Available: "2017-04"
-9421	shaking olive shaking alien plant pod	0		Last Available: "2017-04"
+9420	dried skewed blurry alien plant goo	1		Last Available: "2017-04"
+9421	olive shaking shaking alien plant pod	0		Last Available: "2017-04"
 9422	upside-down tumbling zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	flavorless teal alien meat	3	decent	Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	jittery wobbly spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	double-aerosolized blinking alien medicine	0		Effect: "Berry Elemental", Effect Duration: 52, Last Available: "2017-04"
-9433	normal miniature fancy upside-down alien salad	2	good	Effect: "Armor-Plated", Effect Duration: 5, Last Available: "2017-04"
+9433	miniature fancy normal upside-down alien salad	2	good	Effect: "Armor-Plated", Effect Duration: 5, Last Available: "2017-04"
 9434	triple-distilled acceptable alien booze	8	good	Last Available: "2017-04"
 9435	squat scandalous hardened Socratic alien mask	0		Experience (Mysticality): +1, Damage Reduction: 3, Sleaze Damage: +5, Last Available: "2017-04"
 9436	ribald coward's mansplainer's alien spear	0		Monster Level: -5, Sleaze Damage: +10, Last Available: "2017-04"
@@ -9317,7 +9317,7 @@
 9445	censurious occult spant shoulderpads	0		Spell Damage Percent: +25, Sleaze Resistance: +3, Single Equip, Last Available: "2017-04"
 9446	ribald arcane researcher's spant backplate	0		Experience Percent (Mysticality): +10, Sleaze Damage: +10, Last Available: "2017-04"
 9447	miser's baleful spant spear	0		Spell Damage: +25, Meat Drop: +10, Last Available: "2017-04"
-9448	gray blurry spinning murderbot power cell	0		Last Available: "2017-04"
+9448	blurry spinning gray murderbot power cell	0		Last Available: "2017-04"
 9449	murderbot component casing	0		Last Available: "2017-04"
 9450	murderbot monofilament	0		Last Available: "2017-04"
 9451	non-concentrated ghostly murderbot shield unit	0		Effect: "Electrolit Up", Effect Duration: 64, Last Available: "2017-04"
@@ -9334,7 +9334,7 @@
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	squat Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
-9465	squat tumbling Spacegate	0		Last Available: "2017-04"
+9465	tumbling squat Spacegate	0		Last Available: "2017-04"
 9466	big normal Aldebaran sardines	5	good	Last Available: "2017-04"
 9467	drinkable olive Centauri fish wine	3	good	Last Available: "2017-04"
 9468	vaporized green oxygen	1		Last Available: "2017-04"
@@ -9354,7 +9354,7 @@
 9482	tarnished yellow Daily Affirmation: Adapt to Change Eventually	0		Effect: "In the Slimelight", Effect Duration: 18, Last Available: "2017-05"
 9483	double-aerosolized unsweetened unsweetened bouncing Daily Affirmation: Be a Mind Master	0		Effect: "Cotton Mouthed", Effect Duration: 60, Last Available: "2017-05"
 9484	adjusted deionized anodized wobbly Daily Affirmation: Work For Hours a Week	0		Effect: "Squirming Like a Toad", Effect Duration: 32, Last Available: "2017-05"
-9485	moist triple-modified ghostly twirling Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "So Fresh and So Clean", Effect Duration: 27, Last Available: "2017-05"
+9485	moist triple-modified twirling ghostly Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "So Fresh and So Clean", Effect Duration: 27, Last Available: "2017-05"
 9486	stale narrow Affirmation Cookie	3	decent	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
@@ -9363,7 +9363,7 @@
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	twirling chaotic Annie Oakley's Kremlin's Greatest Briefcase of the wise owl	0		Mysticality: +20, Critical Hit Percent: +20, Spell Critical Percent: +10, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	weak lousy basic martini	2	decent	Last Available: "2017-06"
+9494	lousy weak basic martini	2	decent	Last Available: "2017-06"
 9495	weak acceptable improved martini	2	good	Last Available: "2017-06"
 9496	hand-crafted splendid martini	4	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
@@ -9382,7 +9382,7 @@
 9510	Dust bunny	0		
 9511	tumbling Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
-9513	blinking squat Meteorite-Ade	0		Last Available: "2017-08"
+9513	squat blinking Meteorite-Ade	0		Last Available: "2017-08"
 9514	spoiled meteoreo	3	crappy	Last Available: "2017-08"
 9515	bad meadeorite	4	decent	Last Available: "2017-08"
 9516	upside-down meteoroid	0		Last Available: "2017-08"
@@ -9414,7 +9414,7 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	teal O	0		Last Available: "2017-10"
-9545	lousy watered-down DUFRESNE Suds	2	decent	Last Available: "2017-09"
+9545	watered-down lousy DUFRESNE Suds	2	decent	Last Available: "2017-09"
 9546	skewed razor-sharp beefy mafia pinky ring	0		Muscle: +10, Weapon Damage Percent: +25, Single Equip
 9547	acceptable practically non-alcoholic blue flask of port	1	good	
 9548	tumbling contract enforcement stick of the sewer of terror	0		Stench Damage: +25, Spooky Spell Damage: +10
@@ -9424,7 +9424,7 @@
 9552	super-concentrated extra-colloidal temporary X tattoos	0		Effect: "The Style... of the Future", Effect Duration: 55, Last Available: "2017-10"
 9553	diluted glyph of athleticism	1		Effect: "Loyal Tea", Effect Duration: 50, Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
-9555	anodized quadruple-tarnished cyan mirror tumbling new habit	0		Effect: "Salamander In Your Stomach", Effect Duration: 57, Last Available: "2017-10"
+9555	anodized quadruple-tarnished mirror tumbling cyan new habit	0		Effect: "Salamander In Your Stomach", Effect Duration: 57, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
 9557	fireproof coward's forbidden pearl necklace	0		Spell Damage Percent: +50, Monster Level: -20, Hot Resistance: +3, Single Equip, Last Available: "2017-10"
 9558	amorphous blob	0		Last Available: "2017-11"
@@ -9448,12 +9448,12 @@
 9576	mafia organizer badge of the pedagogue	0		Experience: +3, Single Equip
 9577	mafia filofax	0		
 9578	transparent nog	1	awesome	Last Available: "2017-12"
-9579	miniature decent unfinished fruitcake	2	good	Last Available: "2017-12"
+9579	decent miniature unfinished fruitcake	2	good	Last Available: "2017-12"
 9580	anodized pulsating and cracker	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 11, Last Available: "2017-12"
 9581	special fortified smooth neg grog	5	awesome	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2017-12"
 9582	decent gigantic half double fruitcake	9	good	Last Available: "2017-12"
 9583	adequate hushed puppy	3	good	Last Available: "2017-12"
-9584	spoiled snack-sized muffled muffuletta	2	crappy	Last Available: "2017-12"
+9584	snack-sized spoiled muffled muffuletta	2	crappy	Last Available: "2017-12"
 9585	low-calorie decent narrow shushed potatoes	1	good	Last Available: "2017-12"
 9586	jittery yellow flame-retardant plastic mime functionary	0		Hot Resistance: +1, Last Available: "2017-12"
 9587	crafty plastic mime scientist	0		Maximum MP: +10, Last Available: "2017-12"
@@ -9494,7 +9494,7 @@
 9622	blinking silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
 9624	mirror silent Z	0		Last Available: "2017-12"
-9625	green mirror crystalline cheer	0		Last Available: "2017-12"
+9625	mirror green crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
@@ -9510,15 +9510,15 @@
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	spinning The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
-9641	purple pulsating The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9641	pulsating purple The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9642	The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	blue The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	distilled bad upside-down executive mime flask	5	decent	Last Available: "2017-12"
-9649	small decent nega-mushroom	2	good	Last Available: "2017-12"
+9648	bad distilled upside-down executive mime flask	5	decent	Last Available: "2017-12"
+9649	decent small nega-mushroom	2	good	Last Available: "2017-12"
 9650	tolerable nega-mushroom wine	4	good	Last Available: "2017-12"
 9651	quadruple-cold-filtered activated Cheer-Up soda	0		Effect: "The Spy Who Loved XP", Effect Duration: 39, Last Available: "2017-12"
 9652	moldy mime army rations	4	crappy	Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	mirror cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	half-sized tasty extra-toasted half sandwich	2	awesome	Last Available: "2018-12"
+9681	tasty half-sized extra-toasted half sandwich	2	awesome	Last Available: "2018-12"
 9682	smooth irresponsibly strong mulled hobo wine	10	awesome	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	twirling mansplainer's rock-hard sage burning paper hat	0		Mysticality Percent: +10, Damage Reduction: 5, Monster Level: +15, Lasts Until Rollover, Last Available: "2018-12"
@@ -9570,7 +9570,7 @@
 9698	cold-filtered Vulcanized pulsating ghostly hot button candy	0		Effect: "Saucefingers", Effect Duration: 34
 9699	curative makeshift garbage shirt of extreme caution of the brazier	0		Monster Level: -25, Hot Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-01"
 9700	upside-down baleful novelty monorail ticket of the boozehound	0		Spell Damage: +25, Booze Drop: +100
-9701	dehydrated blinking skewed pills	1		
+9701	dehydrated skewed blinking pills	1		
 9702	distilled furry pill	1		Effect: "Heal Thy Nanoself", Effect Duration: 50
 9703	boiled wobbly beefy pill	1		
 9704	boiled excitement pill	1		
@@ -9592,12 +9592,12 @@
 9724	upside-down psychic's crystal ball of wisdom of Tarzan	0		Mysticality: +15, Experience (Muscle): +3, Last Available: "2018-02"
 9725	green weightlifter's psychic's pslacks of the overflowing toilet	0		Muscle: +15, Stench Spell Damage: +50, Last Available: "2018-02"
 9726	shaking olive Samson's psychic's amulet of chilblains	0		Experience (Muscle): +5, Cold Damage: +25, Last Available: "2018-02"
-9727	spoiled olive blurry heart-shaped candy whetstone	4	crappy	Last Available: "2018-02"
+9727	spoiled blurry olive heart-shaped candy whetstone	4	crappy	Last Available: "2018-02"
 9728	gigantic stale skewed Swedish massage fish	9	decent	Last Available: "2018-02"
 9729	lousy narrow Third Base	3	decent	Last Available: "2018-02"
 9730	tolerable Bustle Hustler	3	good	Last Available: "2018-02"
 9731	dry aerosolized Fabiotion	0		Effect: "Eldritch Concentration", Effect Duration: 55, Last Available: "2018-02"
-9732	flattened diffused gray twirling Bettie page	0		Effect: "Winklered", Effect Duration: 24, Last Available: "2018-02"
+9732	flattened diffused twirling gray Bettie page	0		Effect: "Winklered", Effect Duration: 24, Last Available: "2018-02"
 9733	modified teal tonic o' Banderas	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 48, Last Available: "2018-02"
 9734	quadruple-cold-filtered deionized electrified heather graham cracker	0		Effect: "Frostbeard", Effect Duration: 65, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
@@ -9611,7 +9611,7 @@
 9743	vacuum-sealed frozen spinning rainbow jellybean	0		Effect: "I See Everything Thrice!", Effect Duration: 31
 9744	dry electrified shaking mystery lollipop	0		Effect: "Hennaliciousness", Effect Duration: 40
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
-9746	energized ghostly wobbly rhinestone	0		Effect: "Omphalotus Omnipresence", Effect Duration: 64
+9746	energized wobbly ghostly rhinestone	0		Effect: "Omphalotus Omnipresence", Effect Duration: 64
 9747	red 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	riboflavin	0		
@@ -9662,7 +9662,7 @@
 9794	Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	mirror Ungulant	0		Last Available: "2018-03"
-9797	huge bouncing Caramel	0		Last Available: "2018-03"
+9797	bouncing huge Caramel	0		Last Available: "2018-03"
 9798	bouncing wobbly Oppossum	0		Last Available: "2018-03"
 9799	narrow Amanitee	0		Last Available: "2018-03"
 9800	upside-down Smashmoth	0		Last Available: "2018-03"
@@ -9678,7 +9678,7 @@
 9810	Bowlet	0		Last Available: "2018-03"
 9811	ghostly huge Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
-9813	tumbling pulsating blurry Glum berry	0		Last Available: "2018-03"
+9813	blurry pulsating tumbling Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
@@ -9688,20 +9688,20 @@
 9820	Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9823	tumbling blurry muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9823	blurry tumbling muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	blinking razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
 9828	dried pulsating gray magnificent oyster egg	1		
-9829	altered bouncing teal brilliant oyster egg	1		Effect: "Improprie Tea", Effect Duration: 25
+9829	altered teal bouncing brilliant oyster egg	1		Effect: "Improprie Tea", Effect Duration: 25
 9830	twisted spinning glistening oyster egg	1		
-9831	distilled fuchsia pulsating scintillating oyster egg	1		Effect: "Far Out", Effect Duration: 25
+9831	distilled pulsating fuchsia scintillating oyster egg	1		Effect: "Far Out", Effect Duration: 25
 9832	dehydrated huge pearlescent oyster egg	1		
 9833	dehydrated wobbly lustrous oyster egg	1		Effect: "Dirge of Dreadfulness", Effect Duration: 20
-9834	boiled red blinking blinking gleaming oyster egg	1		
+9834	boiled blinking red blinking gleaming oyster egg	1		
 9835	twirling FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
-9836	shaking ghostly cyan FantasyRealm guest pass	0		Last Available: "2018-04"
+9836	cyan ghostly shaking FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	rock-hard stiffened FantasyRealm G. E. M. of the storm	0		Damage Reduction: 12, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2018-04"
 9838	blurry Rubee&trade;	0		Last Available: "2018-04"
 9839	Socratic FantasyRealm Warrior's Helm	0		Experience (Mysticality): +1, Last Available: "2018-04"
@@ -9734,7 +9734,7 @@
 9866	lime green arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	huge hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	flavorless thick narrow druidic s'more	5	decent	Last Available: "2018-04"
+9869	thick flavorless narrow druidic s'more	5	decent	Last Available: "2018-04"
 9870	twisted sachet of powder	1		Last Available: "2018-04"
 9871	bad mourning wine	3	decent	Last Available: "2018-04"
 9872	gray sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9763,7 +9763,7 @@
 9895	red charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	artisanal boozy maroon two meat muck	5	EPIC	
+9898	boozy artisanal maroon two meat muck	5	EPIC	
 9899	spoiled fancy chocolate Ogre Chieftain	4	crappy	Effect: "Gamer Rage", Effect Duration: 50
 9900	moldy chocolate &quot;Phoenix&quot;	3	crappy	
 9901	decent chocolate Spider Queen	4	good	
@@ -9772,16 +9772,16 @@
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	huge God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
 9906	maroon bouncing God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	fuchsia blinking God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9907	blinking fuchsia God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	green Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
-9911	skewed mirror gattoo	0		
+9911	mirror skewed gattoo	0		
 9912	A-Boo glue	0		
 9913	blurry blinking glued A-Boo clue	0		
-9914	blinking wobbly crude oil congealer	0		
+9914	wobbly blinking crude oil congealer	0		
 9915	adequate good guava	4	good	
-9916	triple-distilled tolerable gin and ginger	10	good	
+9916	tolerable triple-distilled gin and ginger	10	good	
 9917	narrow Thwaitgold chigger statuette	0		
 9918	dried mirror gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9838,7 +9838,7 @@
 9970	sharpshooter's ratty knitted cap of incineration	0		Critical Hit Percent: +10, Hot Spell Damage: +50, Last Available: "2018-09"
 9972	squat skewed Temple Grandin's experienced intimidating chainsaw	0		Experience: +2, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2018-09"
 9973	aged party beer bomb	4	awesome	Last Available: "2018-09"
-9974	gigantic normal sweet party mix	10	good	Last Available: "2018-09"
+9974	normal gigantic sweet party mix	10	good	Last Available: "2018-09"
 9975	denatured party balloon	1		Last Available: "2018-09"
 9976	tumbling perfumed party pants of doom	0		Spooky Spell Damage: +50, Stench Resistance: +5, Last Available: "2018-09"
 9977	squat auspicious padded party whip of temperance	0		Damage Absorption: +20, Sleaze Resistance: +5, Item Drop: +10, Last Available: "2018-09"
@@ -9853,7 +9853,7 @@
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
-9989	spinning green squat voter registration form	0		Free Pull, Last Available: "2018-11"
+9989	green spinning squat voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	twirling lime green MacGyver's &quot;I Voted!&quot; sticker	0		Maximum MP: +100, Lasts Until Rollover, Last Available: "2018-11"
 9991	absentee voter ballot	0		Last Available: "2018-11"
 9992	ghostly snake skin	0		Last Available: "2018-11"
@@ -9877,14 +9877,14 @@
 10011	flavorless huge	3	decent	Last Available: "2018-11"
 10012	weak artisanal ghostly bottle of vodka	2	EPIC	Last Available: "2018-11"
 10013	yummy pulsating pizza	3	awesome	Last Available: "2018-11"
-10014	watered-down tolerable huge martini	2	good	Last Available: "2018-11"
+10014	tolerable watered-down huge martini	2	good	Last Available: "2018-11"
 10015	massive yummy narrow cherry pie	9	awesome	Last Available: "2018-11"
-10016	practically non-alcoholic delicious eggnog	1	awesome	Last Available: "2018-11"
+10016	delicious practically non-alcoholic eggnog	1	awesome	Last Available: "2018-11"
 10017	lime green glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	rotten Hell ramen	3	crappy	Last Available: "2018-11"
 10019	mediocre weak ghostly gimlet	2	decent	Last Available: "2018-11"
 10020	tolerable weak twice-haunted screwdriver	2	good	Last Available: "2018-11"
-10021	decent fancy candy cane	3	good	Effect: "Cake Caked", Effect Duration: 40, Last Available: "2018-12"
+10021	fancy decent candy cane	3	good	Effect: "Cake Caked", Effect Duration: 40, Last Available: "2018-12"
 10022	hand-crafted fancy runny fermented egg	4	EPIC	Effect: "Bananas!", Effect Duration: 35, Last Available: "2018-12"
 10023	flavorless oldcake	3	decent	Last Available: "2018-12"
 10024	adequate ghostly traditional Crimbo cookie	3	good	Last Available: "2023-06"
@@ -9902,7 +9902,7 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	narrow plastic bazooka	0		Last Available: "2018-12"
 10038	skewed mooseflank	0		Last Available: "2018-12"
-10039	low-calorie decent grilled mooseflank	1	good	Last Available: "2018-12"
+10039	decent low-calorie grilled mooseflank	1	good	Last Available: "2018-12"
 10040	bite-sized rotten bouncing moosemeat pie	1	crappy	Last Available: "2018-12"
 10041	lion tamer's balanced antler	0		Experience (familiar): +2, Last Available: "2018-12"
 10042	Samson's dam	0		Experience (Muscle): +5, Damage Reduction: 9, Last Available: "2018-12"
@@ -9915,7 +9915,7 @@
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	toothsome glass of raw eggs	4	awesome	Last Available: "2018-12"
 10051	mediocre punch-drunk punch	4	decent	Last Available: "2018-12"
-10052	compressed huge gray body spradium	1		Last Available: "2018-12"
+10052	compressed gray huge body spradium	1		Last Available: "2018-12"
 10053	bauxite beret of the glutton	0		Food Drop: +100, Last Available: "2018-12"
 10054	blurry executive bauxite boxers	0		Meat Drop: +40, Last Available: "2018-12"
 10055	lightning-fast bauxite bow-tie	0		Initiative: +40, Single Equip, Last Available: "2018-12"
@@ -9928,10 +9928,10 @@
 10062	blurry bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
-10065	yellow twirling Toyleporter	0		Last Available: "2018-12"
+10065	twirling yellow Toyleporter	0		Last Available: "2018-12"
 10066	hand-crafted beer	4	EPIC	Last Available: "2018-12"
 10067	tiny normal yule gruel	1	good	Last Available: "2018-12"
-10068	drinkable practically non-alcoholic hot watered rum	1	good	Last Available: "2018-12"
+10068	practically non-alcoholic drinkable hot watered rum	1	good	Last Available: "2018-12"
 10069	tolerable bottle of Crimbognac	4	good	Last Available: "2018-12"
 10070	yummy Crimboysters Rockefeller	3	awesome	Last Available: "2018-12"
 10071	diluted Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9951,7 +9951,7 @@
 10085	wool stiffened chalk chinos	0		Damage Reduction: 1, Cold Resistance: +1, Last Available: "2019-12"
 10086	shaking chalk chapeau of the brute of the brazier	0		Muscle Percent: +30, Hot Spell Damage: +25, Last Available: "2019-12"
 10087	MacGyver's chalk choker of bravery	0		Maximum MP: +100, Spooky Resistance: +5, Single Equip, Last Available: "2019-12"
-10088	compressed ghostly huge chalk chunks	1		Effect: "Shawarma Warm War", Effect Duration: 45, Last Available: "2019-12"
+10088	compressed huge ghostly chalk chunks	1		Effect: "Shawarma Warm War", Effect Duration: 45, Last Available: "2019-12"
 10089	polarized yellow candy chalk	0		Effect: "Sweet and Yellow", Effect Duration: 40
 10090	Socratic marble maebari of temperance	0		Experience (Mysticality): +1, Sleaze Resistance: +5, Last Available: "2019-12"
 10091	curative marble mantle of the bloodbag	0		Maximum HP: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
@@ -9959,7 +9959,7 @@
 10093	grievous marble mignonette bowl	0		Weapon Damage Percent: +50, Item Drop: +5, Last Available: "2019-12"
 10094	crafty marble medallion of the detective	0		Maximum MP: +10, Item Drop: +20, Single Equip, Last Available: "2019-12"
 10095	electrified studded marble mariachi hat	0		Damage Absorption: +80, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-12"
-10096	pickled olive shaking marble molecules	1		Last Available: "2019-12"
+10096	pickled shaking olive marble molecules	1		Last Available: "2019-12"
 10097	adjusted galvanized jittery Mallomarbles	0		Effect: "Stands Alone", Effect Duration: 66
 10098	ghostly lion tamer's strapping punching bag	0		Muscle: +5, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10099	prompt pith helmet of extreme caution	0		Monster Level: -25, Adventures: +3, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
@@ -10013,12 +10013,12 @@
 10147	red-and-green microcamera	0		Familiar Weight: +5
 10148	jittery mirror Da Vinci's cobbled-together Meat detector	0		Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2019-12"
 10149	ionized tin thermos of chai	0		Effect: "Took Eleven", Effect Duration: 19, Last Available: "2019-12"
-10150	twisted ghostly spinning prototype stimulant	1		Last Available: "2019-12"
+10150	twisted spinning ghostly prototype stimulant	1		Last Available: "2019-12"
 10151	zippy tailored vest	0		Initiative: +20, Lasts Until Rollover, Last Available: "2019-12"
 10152	shaking sew-on bandage	0		Last Available: "2019-12"
 10153	blurry really nice net	0		Last Available: "2019-12"
 10154	wobbly twirling Tesla elf army poncho	0		MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-12"
-10155	tiny spoiled spinning elf army field rations	1	crappy	Last Available: "2019-12"
+10155	spoiled tiny spinning elf army field rations	1	crappy	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	discarded bowtie of the boozehound of the sweet-tooth	0		Booze Drop: +100, Candy Drop: +100, Lasts Until Rollover, Last Available: "2019-12"
 10158	lousy martiny	4	decent	Last Available: "2019-12"
@@ -10032,13 +10032,13 @@
 10166	greedy wholesome Lil' Doctor&trade; bag	0		Maximum HP Percent: +10, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	decent bloodstick	4	good	
-10170	artisanal special high-proof bottle of Sanguiovese	6	EPIC	Effect: "Nasty, Nasty Breath", Effect Duration: 40
+10170	high-proof special artisanal bottle of Sanguiovese	6	EPIC	Effect: "Nasty, Nasty Breath", Effect Duration: 40
 10171	yummy actual blood sausage	4	awesome	
 10172	practically non-alcoholic hand-crafted mulled blood	1	super ultra mega turbo EPIC	
 10173	adequate bouncing blood snowcone	3	good	
 10174	perfectly mixed Red Russian	3	EPIC	
 10175	rotten narrow blood roll-up	3	crappy	
-10176	irresponsibly strong hand-crafted lime green bottle of blood	8	EPIC	
+10176	hand-crafted irresponsibly strong lime green bottle of blood	8	EPIC	
 10177	flavorless blood-soaked sponge cake	3	decent	
 10178	artisanal vampagne	4	EPIC	
 10179	fancy normal plain snowcone	3	good	Effect: "Tea-hee", Effect Duration: 40
@@ -10054,17 +10054,17 @@
 10189	flame-retardant scorching PirateRealm eyepatch of bravery	0		Hot Damage: +25, Hot Resistance: +1, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2019-04"
 10190	bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	squat compass	0		Lasts Until Rollover, Last Available: "2019-04"
-10192	green mirror skull key	0		Lasts Until Rollover, Last Available: "2019-04"
+10192	mirror green skull key	0		Lasts Until Rollover, Last Available: "2019-04"
 10193	curious anemometer	0		Lasts Until Rollover, Last Available: "2019-04"
 10194	Red Roger's flag	0		Lasts Until Rollover, Last Available: "2019-04"
 10195	jittery ghostly Glass Jack's spyglass	0		Lasts Until Rollover, Last Available: "2019-04"
 10196	blurry recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
-10198	lime green blurry Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
+10198	blurry lime green Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	decent crabsicle	3	good	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	bad practically non-alcoholic bottle of dark rhum	1	decent	Last Available: "2019-04"
-10202	strong hand-crafted bottle of extra-dark rhum	5	EPIC	Last Available: "2019-04"
+10201	practically non-alcoholic bad bottle of dark rhum	1	decent	Last Available: "2019-04"
+10202	hand-crafted strong bottle of extra-dark rhum	5	EPIC	Last Available: "2019-04"
 10203	weak delicious bottle of super-extra-dark rhum	2	awesome	Last Available: "2019-04"
 10204	polarized enhanced gray pirate shaving cream	0		Effect: "Sated and Furious", Effect Duration: 53, Last Available: "2019-04"
 10205	shellacked sinister conquistador's breastplate	0		Spell Damage: +10, Damage Reduction: 7, Last Available: "2019-04"
@@ -10075,15 +10075,15 @@
 10210	wicked pirate radio ring of the ox	0		Muscle: +20, Spell Damage: +5, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	massive spoiled pineapple slab	7	crappy	Last Available: "2019-04"
-10213	flavorless fancy miniature hibiscus petal	2	decent	Effect: "Wise Spirit", Effect Duration: 50, Last Available: "2019-04"
-10214	adjusted blinking gray huge mint leaf	0		Effect: "Stimulated Brain", Effect Duration: 17, Last Available: "2019-04"
+10213	flavorless miniature fancy hibiscus petal	2	decent	Effect: "Wise Spirit", Effect Duration: 50, Last Available: "2019-04"
+10214	adjusted gray blinking huge mint leaf	0		Effect: "Stimulated Brain", Effect Duration: 17, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	compressed ice molecule	1		Last Available: "2019-04"
 10217	blue Red Roger's reliquary	0		Last Available: "2019-04"
 10218	skewed Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
-10220	tumbling huge Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
-10221	tumbling purple Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
+10220	huge tumbling Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10221	purple tumbling Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	distilled skewed pewter shavings	1		Last Available: "2019-04"
 10224	jittery Red Roger tattoo kit	0		Last Available: "2019-04"
@@ -10095,23 +10095,23 @@
 10230	avaricious nippy piratical blunderbuss	0		Cold Damage: +10, Meat Drop: +30, Last Available: "2019-04"
 10231	supercharged hale Fonzie's PirateRealm party hat	0		Experience (Moxie): +1, Maximum HP: +20, Maximum MP Percent: +30, Last Available: "2019-04"
 10232	artisanal green Island Landslide	3	EPIC	Last Available: "2019-04"
-10233	weak acceptable fancy Island Thunderstorm	2	good	Effect: "Red Door Syndrome", Effect Duration: 45, Last Available: "2019-04"
+10233	fancy weak acceptable Island Thunderstorm	2	good	Effect: "Red Door Syndrome", Effect Duration: 45, Last Available: "2019-04"
 10234	bad Island Hurricane	3	decent	Last Available: "2019-04"
 10235	tolerable upside-down Skull Punch	3	good	Last Available: "2019-04"
 10236	hand-crafted Electric Punch	3	EPIC	Last Available: "2019-04"
 10237	perfectly mixed boozy Smuggler's Punch	5	EPIC	Last Available: "2019-04"
 10238	mediocre red Scorpion Bowl	3	decent	Last Available: "2019-04"
-10239	weak aged Turtle Bowl	2	awesome	Last Available: "2019-04"
-10240	acceptable practically non-alcoholic Cobra Bowl	1	good	Last Available: "2019-04"
+10239	aged weak Turtle Bowl	2	awesome	Last Available: "2019-04"
+10240	practically non-alcoholic acceptable Cobra Bowl	1	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	knitted foul-smelling studded sinister vampyric cloake of dire peril	0		Weapon Damage: +20, Spell Damage: +10, Damage Absorption: +80, Stench Damage: +10, Cold Resistance: +3, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	purple plastic pirate hat	0		Familiar Weight: +5
 10244	deionized warmed shaking one piece of bubble gum	0		Effect: "Fishy", Effect Duration: 17
-10245	jittery bouncing arcanoferric housing	0		
+10245	bouncing jittery arcanoferric housing	0		
 10246	tumbling intact medium-wave antenna	0		
 10247	red 18-picohertz resonator crystal	0		
 10248	blown-out speaker cone	0		
-10249	twirling blinking overloaded short-pulse transistor	0		
+10249	blinking twirling overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
 10251	manspreader's hardy stiffened Fourth of May Cosplay Saber	0		Damage Reduction: 1, Maximum HP: +50, Monster Level: +10, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
@@ -10128,7 +10128,7 @@
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	hourglass	0		Last Available: "2019-07"
 10265	etched hourglass	0		Last Available: "2019-07"
-10266	anodized blurry green magenta seashell	0		Effect: "Filled with Magic", Effect Duration: 64, Last Available: "2019-07"
+10266	anodized green blurry magenta seashell	0		Effect: "Filled with Magic", Effect Duration: 64, Last Available: "2019-07"
 10267	Vulcanized cyan seashell	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 66, Last Available: "2019-07"
 10268	nitrogenated gray seashell	0		Effect: "Empty Inside", Effect Duration: 30, Last Available: "2019-07"
 10269	ionized wobbly seashell	0		Effect: "Rosewater Mark", Effect Duration: 43, Last Available: "2019-07"
@@ -10167,9 +10167,9 @@
 10302	perfumed medical-grade whittled walking stick of the ox of Gandalf	0		Muscle: +20, Spell Critical Percent: +20, Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-08"
 10303	spoiled campfire hot dog	3	crappy	Last Available: "2019-08"
 10304	yummy campfire baked potato	4	awesome	Last Available: "2019-08"
-10305	big rotten campfire s'more	5	crappy	Last Available: "2019-08"
-10306	decent big campfire beans	5	good	Last Available: "2019-08"
-10307	huge yummy campfire stew	6	awesome	Last Available: "2019-08"
+10305	rotten big campfire s'more	5	crappy	Last Available: "2019-08"
+10306	big decent campfire beans	5	good	Last Available: "2019-08"
+10307	yummy huge campfire stew	6	awesome	Last Available: "2019-08"
 10308	campfire coffee	1	awesome	Last Available: "2019-08"
 10309	oxidized olive leftover chocolate bar	0		Effect: "I See Everything Thrice!", Effect Duration: 46
 10310	yellow rare Meat isotope	0		
@@ -10203,7 +10203,7 @@
 10344	plastic Dolph Bossin of Tarzan	0		Experience (Muscle): +3, Last Available: "2019-12"
 10345	jittery red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	stale mana-coated yams	4	decent	Last Available: "2019-11"
-10347	immense moldy mana-basted tofurkey leg	6	crappy	Last Available: "2019-11"
+10347	moldy immense mana-basted tofurkey leg	6	crappy	Last Available: "2019-11"
 10348	tasty half-sized spinning spinning mana-fortified cranberry sauce	2	awesome	Last Available: "2019-11"
 10349	adequate mana-stuffed herbal stuffing	4	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
@@ -10211,9 +10211,9 @@
 10352	altered jittery industrial lubricant	1		Last Available: "2019-12"
 10353	galvanized extra-pressed lime green unfinished pleasure	0		Effect: "Whole Latte Love", Effect Duration: 64, Last Available: "2019-12"
 10354	distilled vial of humanoid growth hormone	1		Last Available: "2019-12"
-10355	modified ghostly huge a bug's lymph	1		Last Available: "2019-12"
-10356	galvanized ghostly bouncing organic potpourri	0		Effect: "Supafly", Effect Duration: 53, Last Available: "2019-12"
-10357	delicious irresponsibly strong boot flask	9	awesome	Last Available: "2019-12"
+10355	modified huge ghostly a bug's lymph	1		Last Available: "2019-12"
+10356	galvanized bouncing ghostly organic potpourri	0		Effect: "Supafly", Effect Duration: 53, Last Available: "2019-12"
+10357	irresponsibly strong delicious boot flask	9	awesome	Last Available: "2019-12"
 10358	ionized altered activated blinking infernal snowball	0		Effect: "Adorable Lookout", Effect Duration: 63, Last Available: "2019-12"
 10359	skewed madness	0		Last Available: "2019-12"
 10360	denatured huge fish sauce	1		Last Available: "2019-12"
@@ -10253,9 +10253,9 @@
 10394	jittery nippy Mer-kin rollpin of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +10, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	purple tinsel fin	0		Familiar Weight: +5
-10397	decent enchanted bowl of mernudo	4	good	Effect: "Wet Rub", Effect Duration: 30, Last Available: "2019-12"
+10397	enchanted decent bowl of mernudo	4	good	Effect: "Wet Rub", Effect Duration: 30, Last Available: "2019-12"
 10398	acceptable fishelada	4	good	Last Available: "2019-12"
-10399	thick enchanted normal squat ojo de pez burrito	5	good	Effect: "Prelude of Precision", Effect Duration: 45, Last Available: "2019-12"
+10399	thick normal enchanted squat ojo de pez burrito	5	good	Effect: "Prelude of Precision", Effect Duration: 45, Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	huge waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10289,7 +10289,7 @@
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	rosewater-soaked steel-toed Retrospecs of the cheetah	0		Damage Reduction: 9, Stench Resistance: +3, Initiative: +60, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
-10433	maroon ghostly unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
+10433	ghostly maroon unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	olive mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	perfumed Jeselnik's electrified hardened personal trainer's Powerful Glove	0		Experience Percent (Muscle): +10, Damage Reduction: 3, Sleaze Damage: +25, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
@@ -10338,7 +10338,7 @@
 10481	red Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
-10484	ghostly narrow plump free-range mushroom	0		Last Available: "2020-03"
+10484	narrow ghostly plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	narrow immense free-range mushroom	0		Last Available: "2020-03"
@@ -10346,13 +10346,13 @@
 10489	spoiled tumbling mushroom filet	3	crappy	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	twisted mushroom tea	1		Effect: "Omphalotus Omnipresence", Effect Duration: 35, Last Available: "2020-03"
-10492	watered-down hand-crafted mushroom whiskey	2	EPIC	Last Available: "2020-03"
+10492	hand-crafted watered-down mushroom whiskey	2	EPIC	Last Available: "2020-03"
 10493	Usain Bolt's supercharged mushroom cap of bravery	0		Maximum MP Percent: +30, Spooky Resistance: +5, Initiative: +80, Last Available: "2020-03"
 10494	executive greasy Tesla energetic mushroom shield	0		Maximum MP Percent: +20, Sleaze Spell Damage: +10, Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 6, Last Available: "2020-03"
 10495	blinking zippy horrifying mushroom pants of Leguizamo of the brazier	0		Monster Level: +20, Hot Spell Damage: +25, Spooky Damage: +25, Initiative: +20, Last Available: "2020-03"
 10496	blurry smelly wicked mushroom badge of the cougar of James Dean	0		Moxie: +20, Experience (Moxie): +3, Spell Damage: +5, Stench Spell Damage: +10, Single Equip, Last Available: "2020-03"
 10497	house-sized mushroom	0		Last Available: "2020-03"
-10498	ghostly tumbling pristine piranha seed	0		Last Available: "2020-03"
+10498	tumbling ghostly pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	quantum deionized deionized piranha pollen	0		Effect: "Alchemical, Brother", Effect Duration: 29, Last Available: "2020-03"
 10501	plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
@@ -10371,7 +10371,7 @@
 10514	narrow drippy seed	0		
 10515	jittery drippy grub	0		
 10516	drippy bezoar	0		
-10517	red wobbly bouncing Drip Institute petri dish	0		
+10517	bouncing red wobbly Drip Institute petri dish	0		
 10518	drippy ichor	0		
 10519	drippy enzyme	0		
 10520	drippy salt	0		
@@ -10396,9 +10396,9 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	aged Ghiaccio Colada	4	awesome	Last Available: "2020-05"
 10542	artisanal shaking Sourfinger	4	EPIC	Last Available: "2020-05"
-10543	lousy boozy cyan Nog-on-the-Cob	5	decent	Last Available: "2020-05"
+10543	boozy lousy cyan Nog-on-the-Cob	5	decent	Last Available: "2020-05"
 10544	perfectly mixed blinking Steamboat	4	EPIC	Last Available: "2020-05"
-10545	lousy weak Buttery Boy	2	decent	Last Available: "2020-05"
+10545	weak lousy Buttery Boy	2	decent	Last Available: "2020-05"
 10546	skewed Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	Fonzie's clown car key of Leguizamo	0		Experience (Moxie): +1, Monster Level: +20, Last Available: "2020-08"
 10548	Jeselnik's gravedigger's savvy batting cage key	0		Mysticality Percent: +20, Spooky Damage: +10, Sleaze Damage: +25, Last Available: "2020-08"
@@ -10423,7 +10423,7 @@
 10567	Herculean actual skeleton key of James Dean	0		Experience (Muscle): +1, Experience (Moxie): +3, Last Available: "2020-08"
 10568	friendly stiffened deep-fried key of the detective	0		Damage Reduction: 1, Familiar Weight: +3, Item Drop: +20, Last Available: "2020-08"
 10569	dangerous savvy discarded bike lock key	0		Mysticality Percent: +20, Weapon Damage: +10, Last Available: "2020-08"
-10570	maroon blurry Thwaitgold keyhole spider statuette	0		
+10570	blurry maroon Thwaitgold keyhole spider statuette	0		
 10571	ghostly blinking Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	galvanized olive marshroom	0		Effect: "Pyramid Power", Effect Duration: 26
 10573	yellow bag of Iunion stones	0		Free Pull
@@ -10456,7 +10456,7 @@
 10600	drippy diadem	0		Last Available: "2020-08"
 10601	Thwaitgold slug statuette	0		
 10602	Annie Oakley's ert grey goo ring	0		Critical Hit Percent: +20
-10603	shaking tumbling fistful of wood shavings	0		
+10603	tumbling shaking fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	double-liquefied frozen twirling Yeg's Motel toothbrush	0		Effect: "Always be Collecting", Effect Duration: 60, Last Available: "2020-09"
@@ -10464,15 +10464,15 @@
 10608	twirling Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	moldy Yeg's Motel pillow mint	3	crappy	Last Available: "2020-09"
 10610	skewed Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	concentrated dry skewed gray Yeg's Motel mouthwash	0		Effect: "Uncanny Shot", Effect Duration: 13, Last Available: "2020-09"
+10611	concentrated dry gray skewed Yeg's Motel mouthwash	0		Effect: "Uncanny Shot", Effect Duration: 13, Last Available: "2020-09"
 10612	Sherlock's slick Yeg's Motel shower cap	0		Moxie: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2020-09"
 10613	ghostly brawny Yeg's Motel bathrobe	0		Muscle Percent: +20, Item Drop: +5, Lasts Until Rollover, Last Available: "2020-09"
 10614	wobbly Annie Oakley's electrified Yeg's Motel slippers	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
-10615	purple narrow blinking Yeg's Motel stationery	0		Last Available: "2020-09"
+10615	blinking narrow purple Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	green Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	blinking frost-rimed desk bell	0		Last Available: "2020-09"
-10619	upside-down teal huge uncanny desk bell	0		Last Available: "2020-09"
+10619	upside-down huge teal uncanny desk bell	0		Last Available: "2020-09"
 10620	nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
@@ -10493,10 +10493,10 @@
 10637	shaking complicated device	0		Last Available: "2020-09"
 10638	weak artisanal flask of moonshine	2	EPIC	Last Available: "2020-09"
 10639	Jeselnik's nasty weightlifter's sea-worn candlestick	0		Muscle: +15, Stench Damage: +5, Sleaze Damage: +25, Last Available: "2020-09"
-10640	cyan pulsating Universal Seasoning	0		
+10640	pulsating cyan Universal Seasoning	0		
 10641	boiled teal null-day exploit	0		Effect: "Barbecue Saucy", Effect Duration: 33, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	adequate big chocolate chip muffin	5	good	
+10643	big adequate chocolate chip muffin	5	good	
 10644	tumbling huge Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	bouncing packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10545,7 +10545,7 @@
 10689	Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
-10692	skewed yellow booze drive button	0		Single Equip, Last Available: "2020-12"
+10692	yellow skewed booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
 10695	booze mailing list	0		Last Available: "2020-12"
@@ -10575,12 +10575,12 @@
 10719	shaking goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	enchanted tolerable huge barrel-aged eggnog	4	good	Effect: "Minerva's Zen", Effect Duration: 15, Last Available: "2020-12"
 10721	normal hand-crafted candy cane	3	good	Last Available: "2020-12"
-10722	decent fancy drive-thru burger	4	good	Effect: "Scorpio Rising", Effect Duration: 30, Last Available: "2020-12"
+10722	fancy decent drive-thru burger	4	good	Effect: "Scorpio Rising", Effect Duration: 30, Last Available: "2020-12"
 10723	acceptable narrow Boulevardier cocktail	4	good	Last Available: "2020-12"
 10724	moist Hotwire&trade; brand candy rope	0		Effect: "Pumped Up", Effect Duration: 20, Last Available: "2020-12"
 10725	small delicious bowl full of jelly	2	awesome	Last Available: "2020-12"
 10726	bad Eye and a Twist	3	decent	Last Available: "2020-12"
-10727	aerosolized ghostly purple upside-down Chubby and Plump bar	0		Effect: "[1701]Hip to the Jive", Effect Duration: 63, Last Available: "2020-12"
+10727	aerosolized ghostly upside-down purple Chubby and Plump bar	0		Effect: "[1701]Hip to the Jive", Effect Duration: 63, Last Available: "2020-12"
 10728	squat digibritches	0		Last Available: "2025-12"
 10729	shaking packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	pulsating crystal ball	0		Initiative: +50, Last Available: "2021-01"
@@ -10606,15 +10606,15 @@
 10750	blurry shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	oxidized corrupted short beer	0		Effect: "Heightened Senses", Effect Duration: 62, Last Available: "2021-05"
-10753	altered ghostly huge short stack of pancakes	0		Effect: "Polka Face", Effect Duration: 22, Last Available: "2021-05"
+10753	altered huge ghostly short stack of pancakes	0		Effect: "Polka Face", Effect Duration: 22, Last Available: "2021-05"
 10754	pressed blinking short stick of butter	0		Effect: "Slime Time", Effect Duration: 26, Last Available: "2021-05"
 10755	nitrogenated modified short glass of water	0		Effect: "Human-Fish Hybrid", Effect Duration: 66, Last Available: "2021-05"
-10756	corrupted energized ghostly bouncing short	0		Effect: "Trash-Wrapped", Effect Duration: 24, Last Available: "2021-05"
+10756	corrupted energized bouncing ghostly short	0		Effect: "Trash-Wrapped", Effect Duration: 24, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
 10759	tumbling Temple Grandin's familiar scrapbook of the empath	0		Familiar Weight: 12, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
-10761	twirling upside-down yellow clan underground fireworks shop	0		Last Available: "2021-07"
+10761	upside-down twirling yellow clan underground fireworks shop	0		Last Available: "2021-07"
 10762	blinking censurious ribald fedora-mounted fountain of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +10, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2021-07"
 10763	narrow chilly sombrero-mounted sparkler of dire peril of the glutton	0		Weapon Damage: +20, Cold Damage: +5, Food Drop: +100, Lasts Until Rollover, Last Available: "2021-07"
 10764	smelly stylish porkpie-mounted popper of the ox	0		Muscle: +20, Moxie: +25, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
@@ -10627,10 +10627,10 @@
 10771	supercool boxer's rocket boots	0		Muscle Percent: +10, Moxie Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	skewed teal crafty sparkler of the wise owl	0		Mysticality: +20, Maximum MP: +10, Lasts Until Rollover, Last Available: "2021-07"
 10773	upside-down Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
-10774	double-dry tumbling bouncing Scent of a Human&trade; candle	0		Effect: "Stregngth of the Gnome", Effect Duration: 56, Last Available: "2021-08"
+10774	double-dry bouncing tumbling Scent of a Human&trade; candle	0		Effect: "Stregngth of the Gnome", Effect Duration: 56, Last Available: "2021-08"
 10775	electrified The Beast Within&trade; candle	0		Effect: "Rat-Faced", Effect Duration: 48, Last Available: "2021-08"
 10776	dry mirror Salsa Caliente&trade; candle	0		Effect: "Crotchety, Pining", Effect Duration: 50, Last Available: "2021-08"
-10777	boiled Vulcanized red mirror Smoldering Clover&trade; candle	0		Effect: "How to Scam Tourists", Effect Duration: 52, Last Available: "2021-08"
+10777	boiled Vulcanized mirror red Smoldering Clover&trade; candle	0		Effect: "How to Scam Tourists", Effect Duration: 52, Last Available: "2021-08"
 10778	galvanized Napalm In The Morning&trade; candle	0		Effect: "Mayeaugh", Effect Duration: 12, Last Available: "2021-08"
 10779	mirror miser's Newton's extra-large utility candle	0		Experience (Mysticality): +3, Meat Drop: +10, Lasts Until Rollover, Last Available: "2021-08"
 10780	Usain Bolt's runed taper candle of horror	0		Spooky Spell Damage: +25, Initiative: +80, Lasts Until Rollover, Last Available: "2021-08"
@@ -10660,7 +10660,7 @@
 10804	maroon ribald electrified Daylight Shavings Helmet of the businessman	0		Sleaze Damage: +10, Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2021-11"
 10805	eggwater	1	decent	Last Available: "2021-12"
 10806	normal bread man	4	good	Last Available: "2021-12"
-10807	massive rotten fancy plain candy cane	7	crappy	Effect: "Pronounced Potency", Effect Duration: 5, Last Available: "2021-12"
+10807	fancy rotten massive plain candy cane	7	crappy	Effect: "Pronounced Potency", Effect Duration: 5, Last Available: "2021-12"
 10808	spoiled flour cookie	3	crappy	Last Available: "2021-12"
 10809	blinking steel-toed plastic food lab	0		Damage Reduction: 9, Single Equip, Last Available: "2021-12"
 10810	chaotic plastic nog lab	0		Spell Critical Percent: +10, Single Equip, Last Available: "2021-12"
@@ -10674,7 +10674,7 @@
 10818	mansplainer's rock-hard ice wrap of vim and vigor	0		Damage Reduction: 5, Maximum HP Percent: +50, Monster Level: +15, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	decent tofu pop	4	good	Last Available: "2021-12"
 10820	half-sized bland ghostly bowl of prescription candy	2	decent	Last Available: "2021-12"
-10821	stale super-sized special fishcake	5	decent	Effect: "Shawarma Warm War", Effect Duration: 50, Last Available: "2021-12"
+10821	special super-sized stale fishcake	5	decent	Effect: "Shawarma Warm War", Effect Duration: 50, Last Available: "2021-12"
 10822	stale bone broth	4	decent	Last Available: "2021-12"
 10823	toothsome star pop	3	awesome	Last Available: "2021-12"
 10824	perfectly mixed Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
@@ -10684,7 +10684,7 @@
 10828	mixed olive Homebodyl&trade;	1		Effect: "Fire Inside", Effect Duration: 25, Last Available: "2021-12"
 10829	altered Extrovermectin&trade;	1		Effect: "Surreally Buff", Effect Duration: 10, Last Available: "2021-12"
 10830	distilled spinning Breathitin&trade;	1		Effect: "Hypercubed", Effect Duration: 45, Last Available: "2021-12"
-10831	powdered blurry maroon Fleshazole&trade;	1		Last Available: "2021-12"
+10831	powdered maroon blurry Fleshazole&trade;	1		Last Available: "2021-12"
 10832	corrupted cold-filtered polymerized huge anti-burn cream	0		Effect: "Just Aged Enough", Effect Duration: 17, Last Available: "2021-12"
 10833	double-quantum non-liquefied anti-freeze cream	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 69, Last Available: "2021-12"
 10834	activated oxidized blurry anti-goosebump cream	0		Effect: "Trufflin'", Effect Duration: 68, Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	blurry goo magnet	0		Last Available: "2021-12"
 10851	frosty cozy scarf	0		Cold Spell Damage: +10, Last Available: "2021-12"
-10852	bland jumbo ghostly huge Crimbo cookie	5	decent	Last Available: "2023-06"
+10852	jumbo bland ghostly huge Crimbo cookie	5	decent	Last Available: "2023-06"
 10853	boiled moist altered shaking narrow fleshy putty	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 52, Last Available: "2021-12"
 10854	huge dangerous third ear	0		Weapon Damage: +10, Single Equip, Last Available: "2021-12"
 10855	shaking festive egg sac	0		Last Available: "2021-12"
@@ -10721,7 +10721,7 @@
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	skewed sizzling yule hatchet	0		Hot Damage: +10, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	small stale mirror lab-grown meat	2	decent	Last Available: "2021-12"
+10868	stale small mirror lab-grown meat	2	decent	Last Available: "2021-12"
 10869	Newton's fleece	0		Experience (Mysticality): +3, Last Available: "2021-12"
 10870	cyan boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10740,7 +10740,7 @@
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	huge red Lo Pan's dance instructor's magnifying glass of horror	0		Experience Percent (Moxie): +10, Spell Critical Percent: +30, Spooky Spell Damage: +25, Last Available: "2022-12"
 10886	drinkable triple-distilled void lager	7	good	Last Available: "2022-12"
-10887	spoiled miniature void burger	2	crappy	Last Available: "2022-12"
+10887	miniature spoiled void burger	2	crappy	Last Available: "2022-12"
 10888	purple void stone	0		Last Available: "2022-12"
 10889	nasty smooth void shard of Leguizamo of Flo-Jo	0		Moxie: +15, Monster Level: +20, Stench Damage: +5, Initiative: +100, Last Available: "2022-12"
 10890	blue undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10780,21 +10780,21 @@
 10924	adequate ghostly guilty sprout	3	good	Last Available: "2022-06"
 10925	ghostly strapping mother's necklace of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Last Available: "2022-06"
 10926	irradiated anodized trampled ticket stub	0		Effect: "Slightly Mutated", Effect Duration: 31, Last Available: "2022-06"
-10927	pickled vacuum-sealed skewed spinning savings bond	0		Effect: "Top Dog", Effect Duration: 69, Last Available: "2022-06"
-10928	upside-down shaking designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
+10927	pickled vacuum-sealed spinning skewed savings bond	0		Effect: "Top Dog", Effect Duration: 69, Last Available: "2022-06"
+10928	shaking upside-down designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
 10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	dehydrated sweat-ade	1		Last Available: "2022-07"
 10931	yellow skewed unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	blurry spinning thick dinosaur	0		
 10934	dinosaur scale	0		
-10935	wobbly bouncing mirror pristine dinosaur feather	0		
+10935	wobbly mirror bouncing pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	gray bouncing pterodactyl rifle of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
 10939	flatusaur gasmask	0		
-10940	cyan jittery dinosaur dart	0		
-10941	polymerized maroon tumbling Dino DNAde&trade;	0		Effect: "Itchy Trigger Finger", Effect Duration: 24
+10940	jittery cyan dinosaur dart	0		
+10941	polymerized tumbling maroon Dino DNAde&trade;	0		Effect: "Itchy Trigger Finger", Effect Duration: 24
 10942	dinosaur repellent	0		
 10943	camouflage vest of the businessman	0		Meat Drop: +50
 10944	Dinodollar	0		
@@ -10809,7 +10809,7 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	pulsating autumn-aton	0		Last Available: "2022-10"
 10955	modified denatured autumn leaf	0		Effect: "Provocative Perkiness", Effect Duration: 11, Last Available: "2022-10"
-10956	distilled lousy AutumnFest ale	5	decent	Last Available: "2022-10"
+10956	lousy distilled AutumnFest ale	5	decent	Last Available: "2022-10"
 10957	pulsating therapeutic experienced smooth autumn sweater-weather sweater	0		Moxie: +15, Experience: +2, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2022-10"
 10958	wool frightening Jim Carey's autumn debris shield of the early riser	0		Monster Level: +25, Spooky Damage: +5, Cold Resistance: +1, Adventures: +7, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	bland pulsating autumn-spice donut	4	decent	Last Available: "2022-10"
@@ -10818,20 +10818,20 @@
 10962	boiled autumn breeze	1		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 50, Last Available: "2022-10"
 10963	dry autumn years wisdom	0		Effect: "Melancholy Burden", Effect Duration: 20, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	perfectly mixed fortified Oopsie IPA	5	EPIC	Last Available: "2022-10"
+10965	fortified perfectly mixed Oopsie IPA	5	EPIC	Last Available: "2022-10"
 10966	red bouncing mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	ghostly Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	bland ratatouille de Jarlsberg	4	decent	Last Available: "2022-11"
 10971	bland fancy Jarlsberg's vegetable soup	3	decent	Effect: "Twinkly Weapon", Effect Duration: 35, Last Available: "2022-11"
-10972	immense rotten roasted vegetable of Jarlsberg	7	crappy	Last Available: "2022-11"
+10972	rotten immense roasted vegetable of Jarlsberg	7	crappy	Last Available: "2022-11"
 10973	moldy shaking St. Pete's sneaky smoothie	3	crappy	Last Available: "2022-11"
 10974	rotten Pete's wiley whey bar	4	crappy	Last Available: "2022-11"
-10975	normal huge bouncing spinning Pete's rich ricotta	6	good	Last Available: "2022-11"
-10976	perfectly mixed spirit-forward Boris's beer	5	EPIC	Last Available: "2022-11"
+10975	huge normal bouncing spinning Pete's rich ricotta	6	good	Last Available: "2022-11"
+10976	spirit-forward perfectly mixed Boris's beer	5	EPIC	Last Available: "2022-11"
 10977	bland honey bun of Boris	3	decent	Last Available: "2022-11"
-10978	stale miniature Boris's bread	2	decent	Last Available: "2022-11"
+10978	miniature stale Boris's bread	2	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
 10981	blinking Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
@@ -10845,7 +10845,7 @@
 10989	delicious jittery plain calzone	3	awesome	Last Available: "2022-11"
 10990	spoiled snack-sized roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
 10991	stale skewed Pizza of Legend	3	decent	Last Available: "2022-11"
-10992	immense bland blinking red tumbling Calzone of Legend	6	decent	Last Available: "2022-11"
+10992	bland immense tumbling blinking red Calzone of Legend	6	decent	Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
@@ -10869,7 +10869,7 @@
 11013	perfectly mixed huge Charleston Choo-Choo	4	EPIC	
 11014	bad tumbling Velvet Veil	3	decent	
 11015	fortified smooth Marltini	5	awesome	
-11016	smooth weak Strong, Silent Type	2	awesome	
+11016	weak smooth Strong, Silent Type	2	awesome	
 11017	acceptable jittery Mysterious Stranger	4	good	
 11018	lousy fancy Champagne Shimmy	3	decent	Effect: "Gobliny Flavor", Effect Duration: 35
 11019	maroon the Sot's parcel	0		
@@ -10889,7 +10889,7 @@
 11033	spinning scorching nippy chiffon chaps of Leguizamo	0		Monster Level: +20, Cold Damage: +10, Hot Damage: +25, Last Available: "2023-12"
 11034	compressed jittery bouncing chiffon carbage	1		Last Available: "2023-12"
 11035	Vulcanized energized shaking chiffon lemon	0		Effect: "Salty Dogs", Effect Duration: 26
-11036	fancy normal chocomotive	3	good	Effect: "Full-Body Tan", Effect Duration: 30, Last Available: "2022-12"
+11036	normal fancy chocomotive	3	good	Effect: "Full-Body Tan", Effect Duration: 30, Last Available: "2022-12"
 11037	tiny delicious freightcake	1	awesome	Last Available: "2022-12"
 11038	bad pulsating cabooze	4	decent	Last Available: "2022-12"
 11039	mirror plastic caboose	0		Last Available: "2022-12"
@@ -10897,17 +10897,17 @@
 11041	twirling twirling curative plastic dining car	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2022-12"
 11042	steel-toed plastic coal car of James Dean	0		Experience (Moxie): +3, Damage Reduction: 9, Last Available: "2022-12"
 11043	squat educational plastic locomotive	0		Experience: +1, Last Available: "2022-12"
-11044	olive tumbling packaged model train set	0		Free Pull, Last Available: "2022-12"
+11044	tumbling olive packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	model train set	0		Last Available: "2022-12"
 11046	Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
-11050	chilled liquefied cyan shaking Trainbot circuitry	0		Effect: "Pride of the Vampire", Effect Duration: 57
+11050	chilled liquefied shaking cyan Trainbot circuitry	0		Effect: "Pride of the Vampire", Effect Duration: 57
 11051	Vulcanized Trainbot tubing	0		Effect: "Piratastic", Effect Duration: 64
 11052	improved diffused nitrogenated purple Trainbot plating	0		Effect: "Elemental Saucesphere", Effect Duration: 62
 11053	vacuum-sealed boiled dry shaking Trainbot optics	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 18
-11054	magnetized extra-nitrogenated shaking cyan Trainbot servomotors	0		Effect: "Squatting and Thrusting", Effect Duration: 12
+11054	magnetized extra-nitrogenated cyan shaking Trainbot servomotors	0		Effect: "Squatting and Thrusting", Effect Duration: 12
 11055	extra-ionized adjusted Trainbot linkages	0		Effect: "Mushroom Samba", Effect Duration: 11
 11056	ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
@@ -10923,9 +10923,9 @@
 11067	artisanal weak dregs of a Crimbo cocktail	2	EPIC	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	miniature decent tumbling honey-drenched ham slice	2	good	
+11070	decent miniature tumbling honey-drenched ham slice	2	good	
 11071	aged skewed mostly-empty bottle of cookie wine	3	awesome	
-11072	snack-sized moldy Crimbo food scraps	2	crappy	
+11072	moldy snack-sized Crimbo food scraps	2	crappy	
 11073	cyan mirror arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	squat table-scraper	0		Single Equip
@@ -10934,10 +10934,10 @@
 11078	spoiled jittery steamed oyster	3	crappy	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
-11081	twirling skewed maroon steam unit	0		Last Available: "2022-12"
+11081	twirling maroon skewed steam unit	0		Last Available: "2022-12"
 11082	mirror crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	mediocre weak maroon narrow Crimbosmopolitan	2	decent	Last Available: "2022-12"
+11084	mediocre weak narrow maroon Crimbosmopolitan	2	decent	Last Available: "2022-12"
 11085	huge yummy huge Crimbo dinner	9	awesome	Last Available: "2022-12"
 11086	huge overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10950,7 +10950,7 @@
 11094	perfumed Herculean slick grubby wool trousers	0		Moxie: +10, Experience (Muscle): +1, Stench Resistance: +5
 11095	red zippy nippy savvy grubby wool gloves of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Cold Damage: +10, Initiative: +20, Single Equip
 11096	spinning grubby wool beerwarmer	0		
-11097	weak drinkable nice warm beer	2	good	
+11097	drinkable weak nice warm beer	2	good	
 11098	grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	blue packet of rock seeds	0		Last Available: "2023-01"
@@ -10970,7 +10970,7 @@
 11115	wobbly pulsating narrow S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	super-colloidal cold-filtered extra-moist wobbly glob of extra-green chlorophyll	0		Effect: "Quiet 'n' Good", Effect Duration: 22, Last Available: "2023-02"
-11118	polarized wobbly skewed squat mushroom	0		Effect: "Vanity Rage", Effect Duration: 30, Last Available: "2023-02"
+11118	polarized skewed squat wobbly mushroom	0		Effect: "Vanity Rage", Effect Duration: 30, Last Available: "2023-02"
 11119	quantum five-fingered fern resin	0		Effect: "Ichorous Intensity", Effect Duration: 53, Last Available: "2023-02"
 11120	stale super good fruit	3	decent	Last Available: "2023-02"
 11121	distilled tumbling jittery energized spores	1		Last Available: "2023-02"
@@ -10983,7 +10983,7 @@
 11128	anodized filled mosquito	0		Effect: "Strawberry Alarm", Effect Duration: 58, Last Available: "2023-02"
 11129	moist dry fuchsia shim of shame shale	0		Effect: "Object Detection", Effect Duration: 69, Last Available: "2023-02"
 11130	vacuum-sealed pickled pebble of proud pyrite	0		Effect: "Category", Effect Duration: 43, Last Available: "2023-02"
-11131	modified shaking gray pile of gritty sand	0		Effect: "Emotion Sickness", Effect Duration: 47, Last Available: "2023-02"
+11131	modified gray shaking pile of gritty sand	0		Effect: "Emotion Sickness", Effect Duration: 47, Last Available: "2023-02"
 11132	yellow hollow rock	0		Last Available: "2023-02"
 11133	energized green angry agate	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 69, Last Available: "2023-02"
 11134	boiled pickled twirling lump of loyal latite	0		Effect: "Flagrantly Fragrant", Effect Duration: 21, Last Available: "2023-02"
@@ -11041,7 +11041,7 @@
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	irradiated moist shadow candy	0		Effect: "Patent Prevention", Effect Duration: 22
-11189	blurry narrow replica Mr. Accessory	0		
+11189	narrow blurry replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
 11192	replica crimbo elfling	0		
@@ -11134,7 +11134,7 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	wobbly wobbly Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	fancy lousy strong Sexy Cosmo	5	decent	Effect: "Liquidy Smoky", Effect Duration: 20, Last Available: "2023-06"
+11282	lousy fancy strong Sexy Cosmo	5	decent	Effect: "Liquidy Smoky", Effect Duration: 20, Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	tumbling lion tamer's hardened red-soled high heels of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 3, Experience (familiar): +2, Last Available: "2023-06"
 11285	spoiled super-sized cyburger	5	crappy	Last Available: "2025-12"
@@ -11153,7 +11153,7 @@
 11298	super-tarnished chilled jittery haemolymphnode	0		Effect: "You Know What's Up", Effect Duration: 64
 11299	triple-denatured chitin powder paste	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 62
 11300	sleeping patriotic eagle	0		Free Pull
-11301	huge olive claw-held flag	0		Familiar Weight: +5
+11301	olive huge claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
 11303	name change form	0		
 11304	replica sleeping patriotic eagle	0		
@@ -11163,7 +11163,7 @@
 11308	lime green watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
-11311	decent snack-sized waffle	2	good	
+11311	snack-sized decent waffle	2	good	
 11312	fixodent	0		
 11313	squat ghostly perfumed cat o' nine teeth of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +5
 11314	bouncing supercharged deadly tooth cap	0		Weapon Damage: +5, Maximum MP Percent: +30
@@ -11182,12 +11182,12 @@
 11327	ghostly residual chitin paste	0		Skill: "Chitinous Soul"
 11328	powdered olive concentrated cooking	1		
 11329	mixed meat	1		Effect: "Berry Experiential", Effect Duration: 40
-11330	diluted bouncing huge sparkling orb	1		
+11330	diluted huge bouncing sparkling orb	1		
 11331	twisted jittery hardening cream	1		Effect: "Ooh, Umami!", Effect Duration: 30
 11332	denatured pool shark hair oil	1		
 11333	pulsating book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
-11335	squat yellow Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
+11335	yellow squat Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
 11337	lime green map to a candy-rich block	0		Last Available: "2023-10"
 11338	modified sampler size toothpaste	0		Effect: "Sleazy Weapon", Effect Duration: 57
@@ -11212,7 +11212,7 @@
 11357	tumbling blinking Tesla wicked smoldering drape	0		Spell Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	blue upside-down miser's nippy ruddy sinister Da Vinci's leaf crown of courage	0		Experience (Mysticality): +5, Spell Damage: +10, Maximum HP Percent: +40, Cold Damage: +10, Spooky Resistance: +3, Meat Drop: +10
-11360	moldy big pulsating leafy browns	5	crappy	
+11360	big moldy pulsating leafy browns	5	crappy	
 11361	boiled liquefied autumnic balm	0		Effect: "Helvella Health", Effect Duration: 20
 11362	tarnished quantum pulsating coping juice	0		Effect: "Nightlit", Effect Duration: 27
 11363	zippy wizardly strapping candy cane sword cane of mayonnaise of the businessman	0		Muscle: +5, Mysticality: +25, Sleaze Spell Damage: +50, Meat Drop: +50, Initiative: +20, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11239,7 +11239,7 @@
 11384	tiny Crimbuccaneer Foundry	0		Initiative: +3
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	skewed pirate encryption key alpha	0		Last Available: "2023-12"
-11387	maroon shaking pirate encryption key bravo	0		Last Available: "2023-12"
+11387	shaking maroon pirate encryption key bravo	0		Last Available: "2023-12"
 11388	pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
 11390	wardrobe-o-matic	0		
@@ -11253,7 +11253,7 @@
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	huge Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	twirling Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	drinkable weak enchanted Crimbuccaneer mologrog cocktail	2	good	Effect: "Gummiheart", Effect Duration: 25, Last Available: "2023-12"
+11401	drinkable enchanted weak Crimbuccaneer mologrog cocktail	2	good	Effect: "Gummiheart", Effect Duration: 25, Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	dog trainer's steel-toed forbidden Crimbuccaneer lantern	0		Spell Damage Percent: +50, Damage Reduction: 9, Experience (familiar): +1, Last Available: "2023-12"
@@ -11269,15 +11269,15 @@
 11414	ribald curative Elf Guard officer's sidearm	0		Sleaze Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
 11415	huge ghostly ruddy Elf Guard insignia (general) of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Single Equip, Last Available: "2023-12"
 11416	lousy Crimbow Rainbo	4	decent	Last Available: "2023-12"
-11417	red blinking Elf Guard strategic map	0		Last Available: "2023-12"
+11417	blinking red Elf Guard strategic map	0		Last Available: "2023-12"
 11418	blinking Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	scandalous Elf Guard broom of the glutton	0		Sleaze Damage: +5, Food Drop: +100, Last Available: "2023-12"
 11420	zippy nasty supercool Crimbuccaneer tavern swab	0		Moxie Percent: +20, Stench Damage: +5, Initiative: +20, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	bad irresponsibly strong old-school pirate grog	7	decent	Last Available: "2023-12"
-11423	normal thick bouncing grog nuts	5	good	Last Available: "2023-12"
+11422	irresponsibly strong bad old-school pirate grog	7	decent	Last Available: "2023-12"
+11423	thick normal bouncing grog nuts	5	good	Last Available: "2023-12"
 11424	fireproof occult sawed-off blunderbuss	0		Spell Damage Percent: +25, Hot Resistance: +3, Item Drop: +5, Last Available: "2023-12"
-11425	watered-down artisanal officer's nog	2	EPIC	Last Available: "2023-12"
+11425	artisanal watered-down officer's nog	2	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	bland sundae ration	4	decent	Last Available: "2023-12"
 11428	decent peppermint tack	3	good	Last Available: "2023-12"
@@ -11288,12 +11288,12 @@
 11433	gray Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	prompt friendly fortified Elf Guard clipboard	0		Damage Absorption: +60, Familiar Weight: +3, Adventures: +3, Last Available: "2023-12"
 11435	spinning cyan dangerous pegfinger	0		Weapon Damage: +10, Single Equip, Last Available: "2023-12"
-11436	practically non-alcoholic drinkable and claret	1	good	Last Available: "2023-12"
+11436	drinkable practically non-alcoholic and claret	1	good	Last Available: "2023-12"
 11437	tumbling brawny Elf Guard and beret	0		Muscle Percent: [+20*event(December)], Last Available: "2023-12"
 11438	Sherlock's fireproof smelly shipwright's hammer	0		Stench Spell Damage: +10, Hot Resistance: +3, Item Drop: +25, Last Available: "2023-12"
 11439	blinking chaotic therapeutic gunwale of the cougar	0		Moxie: +20, Spell Critical Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 9, Last Available: "2023-12"
 11440	aromatic experienced Rosewater's Kelflar vest	0		Mysticality Percent: +30, Experience: +2, Stench Resistance: +1, Last Available: "2023-12"
-11441	alkaline pulsating skewed whale cerebrospinal fluid	0		Effect: "Guts Feeling", Effect Duration: 54, Last Available: "2023-12"
+11441	alkaline skewed pulsating whale cerebrospinal fluid	0		Effect: "Guts Feeling", Effect Duration: 54, Last Available: "2023-12"
 11442	bouncing flame-wreathed Annie Oakley's Crimbuccaneer runebone	0		Critical Hit Percent: +20, Hot Spell Damage: +10, Single Equip, Last Available: "2023-12"
 11443	lime green cannonbomb	0		Last Available: "2023-12"
 11444	energetic Elf Guard mouthknife of temperance	0		Maximum MP Percent: +20, Sleaze Resistance: +5, Last Available: "2023-12"
@@ -11313,26 +11313,26 @@
 11458	Da Vinci's brainy Crimbuccaneer bombjacket	0		Mysticality: +5, Experience (Mysticality): +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	moldy special spinning olive sugarplum ration	3	crappy	Effect: "Vented Spleen", Effect Duration: 25, Last Available: "2023-12"
 11460	rotten gingerbread nylons	3	crappy	Last Available: "2023-12"
-11461	immense moldy huge rum-soaked fruitcake	8	crappy	Last Available: "2023-12"
-11462	thick stale lime	5	decent	Last Available: "2023-12"
+11461	moldy immense huge rum-soaked fruitcake	8	crappy	Last Available: "2023-12"
+11462	stale thick lime	5	decent	Last Available: "2023-12"
 11463	moldy gingerbread pirate	4	crappy	Last Available: "2023-12"
-11464	small normal fruit-stuffed rumcake	2	good	Last Available: "2023-12"
+11464	normal small fruit-stuffed rumcake	2	good	Last Available: "2023-12"
 11465	acceptable mulled wine	4	good	Last Available: "2023-12"
 11466	drinkable distilled Swedish coffee	5	good	Last Available: "2023-12"
-11467	lousy practically non-alcoholic ghostly canteen of eggnog	1	decent	Last Available: "2023-12"
+11467	practically non-alcoholic lousy ghostly canteen of eggnog	1	decent	Last Available: "2023-12"
 11468	bad hot wine	3	decent	Last Available: "2023-12"
-11469	perfectly mixed strong olive twirling Jamaican coffee	5	EPIC	Last Available: "2023-12"
+11469	strong perfectly mixed twirling olive Jamaican coffee	5	EPIC	Last Available: "2023-12"
 11470	bad flask of egggrog	4	decent	Last Available: "2023-12"
-11471	shaking teal Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
+11471	teal shaking Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	mediocre watered-down pulsating yule grog	2	decent	Last Available: "2023-12"
 11475	snack-sized normal squat wet tack	2	good	Last Available: "2023-12"
-11476	miniature bland fuchsia whalecake	2	decent	Last Available: "2023-12"
+11476	bland miniature fuchsia whalecake	2	decent	Last Available: "2023-12"
 11477	deadly Socratic gunwale whalegun of dire peril	0		Experience (Mysticality): +1, Weapon Damage: 25, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	drinkable huge and claret	3	good	Last Available: "2023-12"
 11479	teal rigging knot	0		Familiar Weight: +5
-11480	ghostly narrow trick coin	0		Last Available: "2023-12"
+11480	narrow ghostly trick coin	0		Last Available: "2023-12"
 11481	asbestos-lined veiny Elf Guard squirtgun	0		Maximum HP: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	tumbling chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	aromatic sequin-encrusted sweater	0		Stench Resistance: +1, Last Available: "2023-12"
@@ -11362,7 +11362,7 @@
 11507	fortified moss mitre of temperance	0		Damage Absorption: +60, Sleaze Resistance: +5, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
 11508	bouncing slick moss mantle of the storm	0		Moxie: +10, Maximum MP Percent: +40, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	green smelly moss marlinspike of courage	0		Stench Spell Damage: +10, Spooky Resistance: +3, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	mixed pulsating upside-down moss mulch	1		Last Available: "2024-12"
+11510	mixed upside-down pulsating moss mulch	1		Last Available: "2024-12"
 11511	diffused moss floss	0		Effect: "Morninja", Effect Duration: 61
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11388,7 +11388,7 @@
 11533	ghostly fireproof petrified wood walking pants of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +3, Last Available: "2025-12"
 11534	boiled petrified wood waste parts	1		Effect: "Antibiotic Saucesphere", Effect Duration: 30, Last Available: "2025-12"
 11535	alkaline Vulcanized petrified wood wafer praline	0		Effect: "Unusual Fashion Sense", Effect Duration: 47
-11536	irresponsibly strong hand-crafted special cybeer	10	EPIC	Effect: "Neutered Nostrils", Effect Duration: 20, Last Available: "2025-12"
+11536	hand-crafted irresponsibly strong special cybeer	10	EPIC	Effect: "Neutered Nostrils", Effect Duration: 20, Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	olive wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
@@ -11401,10 +11401,10 @@
 11546	aromatic chaotic sharpshooter's spring shoes	0		Critical Hit Percent: +10, Spell Critical Percent: +10, Stench Resistance: +1, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	activated tarnished alkaline ultra-soft ferns	0		Effect: "Rushtacean'", Effect Duration: 12, Last Available: "2024-02"
 11548	energized crunchy brush	0		Effect: "Sleazy Jellied", Effect Duration: 40, Last Available: "2024-02"
-11549	skewed tumbling smashed scientific equipment	0		
+11549	tumbling skewed smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	bouncing triphasic molecular oculus	0		
-11552	shaking pulsating high-tension exoskeleton	0		
+11552	pulsating shaking high-tension exoskeleton	0		
 11553	narrow ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	teal quick-release belt pouch	0		Single Equip
@@ -11412,7 +11412,7 @@
 11557	quick-release utility belt	0		Single Equip
 11558	motion sensor of Flo-Jo	0		Initiative: +100, Single Equip
 11559	focused magnetron pistol	0		Single Equip
-11560	wobbly huge packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
+11560	huge wobbly packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	rosewater-soaked healthy Everfull Dart Holster	0		Maximum HP Percent: +20, Stench Resistance: +3, Single Equip, Last Available: "2024-03"
 11562	jittery cyan research fragment	0		
 11563	Thwaitgold wolf spider statuette	0		
@@ -11425,11 +11425,11 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	fuchsia Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	immense bland teal yam	6	decent	Last Available: "2024-05"
+11573	bland immense teal yam	6	decent	Last Available: "2024-05"
 11574	bad fancy yam martini	3	decent	Effect: "The Grass...  Is Blue...", Effect Duration: 5, Last Available: "2024-05"
-11575	smooth pulsating lime green wobbly sweet potato o' mine	3	awesome	Last Available: "2024-05"
+11575	smooth wobbly lime green pulsating sweet potato o' mine	3	awesome	Last Available: "2024-05"
 11576	triple-distilled artisanal Southern yam	10	EPIC	Last Available: "2024-05"
-11577	weak bad sweet potato punch	2	decent	Last Available: "2024-05"
+11577	bad weak sweet potato punch	2	decent	Last Available: "2024-05"
 11578	bland Mayam spinach	3	decent	Last Available: "2024-05"
 11579	gigantic spoiled yam and swiss	6	crappy	Last Available: "2024-05"
 11580	Jim Carey's wicked yam cannon of the overflowing toilet	0		Spell Damage: +5, Monster Level: +25, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,39 +11439,39 @@
 11584	frosty furry yam buckler of the bloodbag of the glutton	0		Maximum HP: +100, Cold Spell Damage: +10, Food Drop: +100, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	family-friendly Herculean yamtility belt of the brute	0		Muscle Percent: +30, Experience (Muscle): +1, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2024-05"
-11587	tasty gigantic spinning yam slider	6	awesome	Last Available: "2024-05"
+11587	gigantic tasty spinning yam slider	6	awesome	Last Available: "2024-05"
 11588	normal yam mayo	4	good	Last Available: "2024-05"
-11589	adequate enchanted ghostly yam burrito	4	good	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2024-05"
+11589	enchanted adequate ghostly yam burrito	4	good	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2024-05"
 11590	green visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	blinking aviator goggles	0		
 11593	squat Thwaitgold Illinigina illinoiensis model	0		
-11594	bite-sized rotten mirror mini kiwi	1	crappy	Last Available: "2024-06"
+11594	rotten bite-sized mirror mini kiwi	1	crappy	Last Available: "2024-06"
 11595	shaking cyan energetic hale smooth mini kiwi bikini	0		Moxie: +15, Maximum HP: +20, Maximum MP Percent: +20, Last Available: "2024-06"
-11596	lousy red skewed mini kiwitini	4	decent	Last Available: "2024-06"
-11597	maroon mirror mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
+11596	lousy skewed red mini kiwitini	4	decent	Last Available: "2024-06"
+11597	mirror maroon mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	healthy rock-hard thinker's mini kiwi silicon tiepin	0		Mysticality: +10, Damage Reduction: 5, Maximum HP Percent: +20
 11600	mini kiwi tipi	0		
-11601	gigantic decent gray twirling mini kiwi digitized cookies	8	good	
-11602	practically non-alcoholic acceptable mini kiwi intoxicating spirits	1	good	
-11603	aerosolized quadruple-concentrated spinning shaking mini kiwi antimilitaristic hippy petition	0		Effect: "Wintry Breath", Effect Duration: 12
+11601	gigantic decent twirling gray mini kiwi digitized cookies	8	good	
+11602	acceptable practically non-alcoholic mini kiwi intoxicating spirits	1	good	
+11603	aerosolized quadruple-concentrated shaking spinning mini kiwi antimilitaristic hippy petition	0		Effect: "Wintry Breath", Effect Duration: 12
 11604	wet flattened aerosolized mini kiwi illicit antibiotic	0		Effect: "Good with the Ladies", Effect Duration: 54
 11605	bouncing skewed ribald Tesla mini kiwi whipping stick	0		Sleaze Damage: +10, MP Regen Min: 7, MP Regen Max: 10
 11606	chaotic mini kiwi icepick	0		Spell Critical Percent: +10
 11607	moist mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Thicker, Sicker", Effect Duration: 38
 11608	green packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
-11610	ghostly pulsating protogenetic chunklet (synapse)	0		
+11610	pulsating ghostly protogenetic chunklet (synapse)	0		
 11611	mirror blinking green protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
-11613	maroon ghostly protogenetic chunklet (elbow)	0		
+11613	ghostly maroon protogenetic chunklet (elbow)	0		
 11614	protogenetic chunklet (lips)	0		
 11615	lightning-fast wool scorching messenger bag RNA	0		Hot Damage: +25, Cold Resistance: +1, Initiative: +40
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	toothsome bacteria bisque	3	awesome	
-11619	stale snack-sized ciliophora chowder	2	decent	
+11619	snack-sized stale ciliophora chowder	2	decent	
 11620	toothsome cream of chloroplasts	3	awesome	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11481,13 +11481,13 @@
 11626	unevolved organism	0		Free Pull
 11627	extra ooze	0		
 11628	extra DNA	0		Experience (familiar): +1
-11629	bouncing ghostly untorn tearaway pants package	0		Free Pull
+11629	ghostly bouncing untorn tearaway pants package	0		Free Pull
 11630	gravedigger's nasty ruddy extremely unsafe educational tearaway pants	0		Experience: +1, Weapon Damage Percent: +100, Maximum HP Percent: +40, Stench Damage: +5, Spooky Damage: +10, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	cyan baby bodyguard	0		
 11632	tumbling Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	artisanal fancy weak Colera Peste Nebbiolo	2	EPIC	Effect: "All Blued Up", Effect Duration: 30
+11635	fancy weak artisanal Colera Peste Nebbiolo	2	EPIC	Effect: "All Blued Up", Effect Duration: 30
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	red bodyguard badge	0		
@@ -11529,14 +11529,14 @@
 11674	bland whirled peas	3	decent	Last Available: "2024-11"
 11675	normal peaza	4	good	Last Available: "2024-11"
 11676	blurry peace shooter	0		Last Available: "2024-11"
-11677	compressed blurry shaking drenchrome 2.0	1		Last Available: "2025-12"
+11677	compressed shaking blurry drenchrome 2.0	1		Last Available: "2025-12"
 11678	dehydrated Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	yellow quantum watch	0		Adventures: +2
 11681	pulsating quantized familiar experience	0		
 11682	polymerized electrified bouncing pea brittle	0		Effect: "Blood-Gorged", Effect Duration: 58, Last Available: "2024-11"
 11683	tolerable peasco	4	good	Last Available: "2024-11"
-11684	yummy fancy jittery piece of cake	4	awesome	Effect: "Sweet Tooth", Effect Duration: 40, Last Available: "2024-11"
+11684	fancy yummy jittery piece of cake	4	awesome	Effect: "Sweet Tooth", Effect Duration: 40, Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	olive Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	tumbling TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11545,7 +11545,7 @@
 11690	smelly jolly roger flag	0		Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 11691	wobbly sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	triple-distilled tolerable bouncing tankard of spiced rum	9	good	Last Available: "2024-12"
+11693	tolerable triple-distilled bouncing tankard of spiced rum	9	good	Last Available: "2024-12"
 11694	perfectly mixed cyan tankard of spiced Goldschlepper	3	EPIC	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	green governor's daughter's lace collar of the dark arts	0		Spell Damage Percent: +100, Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	mirror resourceful governor's daughter's pearl hairpin	0		Maximum MP: +50, Last Available: "2024-12"
 11699	blurry harpoon	0		Last Available: "2024-12"
 11700	tumbling lightning-fast chili powder cutlass	0		Initiative: +40, Last Available: "2024-12"
-11701	normal diet Aztec tamale	1	good	Last Available: "2024-12"
+11701	diet normal Aztec tamale	1	good	Last Available: "2024-12"
 11702	skewed jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	fuchsia greedy groggles	0		Meat Drop: +20, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	moist vacuum-sealed jittery tumbling peppermint pegleg	0		Effect: "Hella Smart", Effect Duration: 31, Last Available: "2024-12"
 11710	special lousy hard cocoa	4	decent	Effect: "Wise Spirit", Effect Duration: 25, Last Available: "2024-12"
-11711	immense bland salmagumdi	9	decent	Last Available: "2024-12"
+11711	bland immense salmagumdi	9	decent	Last Available: "2024-12"
 11712	plastic Easter Island Bunny of the glutton	0		Food Drop: +100, Last Available: "2024-12"
 11713	quilted plastic St. Patrick	0		Damage Absorption: +40, Last Available: "2024-12"
 11714	jittery sinister plastic Colonel Brando of the bloodbag	0		Spell Damage: +10, Maximum HP: +100, Last Available: "2024-12"
@@ -11574,9 +11574,9 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	tumbling Spirit of Christmas	0		Last Available: "2024-12"
-11722	immense rotten coney haunch	9	crappy	Last Available: "2024-12"
+11722	rotten immense coney haunch	9	crappy	Last Available: "2024-12"
 11723	cold-filtered dry pulsating dark chocolate egg	0		Effect: "Good with the Ladies", Effect Duration: 66, Last Available: "2024-12"
-11724	lousy fancy weak moai toai	2	decent	Effect: "Greasy Visage", Effect Duration: 40
+11724	weak fancy lousy moai toai	2	decent	Effect: "Greasy Visage", Effect Duration: 40
 11725	greasy flame-wreathed moaiball of the cheetah	0		Hot Spell Damage: +10, Sleaze Spell Damage: +10, Initiative: +60, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	diffused four-leaf potato sprout	0		Effect: "On a Roll", Effect Duration: 62, Last Available: "2024-12"
@@ -11606,9 +11606,9 @@
 11751	hand-crafted twirling mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
 11752	watered-down lousy red holiday trip around the world	2	decent	Last Available: "2024-12"
 11753	rotten chocolate ostrich egg	4	crappy	Last Available: "2024-12"
-11754	big spoiled beef and cabbage	5	crappy	Last Available: "2024-12"
+11754	spoiled big beef and cabbage	5	crappy	Last Available: "2024-12"
 11755	moldy candy rations	3	crappy	Last Available: "2024-12"
-11756	stale small double-candied yams	2	decent	Last Available: "2024-12"
+11756	small stale double-candied yams	2	decent	Last Available: "2024-12"
 11757	low-calorie stale Christmas ham	1	decent	Last Available: "2024-12"
 11758	flavorless immense holiday smorgasbord	9	decent	Last Available: "2024-12"
 11759	green Bowl of Infinite Jelly	0		Last Available: "2024-12"
@@ -11618,11 +11618,11 @@
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	huge How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	squat upside-down Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	upside-down squat Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	fuchsia Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	jittery maroon Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	maroon jittery Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	narrow moai statuette	0		Last Available: "2024-12"
 11772	perfumed manspreader's Newton's egg gun of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Monster Level: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	Sherlock's crafty Sinatra's experienced army helmet	0		Experience: +2, Experience (Moxie): +5, Maximum MP: +10, Item Drop: +25, Last Available: "2024-12"
@@ -11664,7 +11664,7 @@
 11809	wobbly 3d printed server room key	0		Last Available: "2025-12"
 11810	wobbly dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	tumbling logic grenade	0		Last Available: "2025-12"
-11812	twisted skewed upside-down psilocyber mushroom	1		Effect: "Full of Vinegar", Effect Duration: 30, Last Available: "2025-12"
+11812	twisted upside-down skewed psilocyber mushroom	1		Effect: "Full of Vinegar", Effect Duration: 30, Last Available: "2025-12"
 11813	twirling blue dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	pulsating dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
@@ -11694,7 +11694,7 @@
 11839	ghostly scrape	0		
 11840	phantom digit	0		
 11841	shaking foul line	0		
-11842	red pulsating dark manioc	0		
+11842	pulsating red dark manioc	0		
 11843	blurry Observer source code	0		
 11844	chill gherkin	0		
 11845	twirling childrens' stapler	0		
@@ -11710,17 +11710,17 @@
 11855	wobbly rift oculus	0		Combat Rate: +5
 11856	twirling sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
-11858	upside-down narrow glover liners	0		Pickpocket Chance: +10
+11858	narrow upside-down glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
 11860	huge assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	pickled scoop of pre-workout powder	1		Effect: "Ripping, Dripping", Effect Duration: 25, Last Available: "2025-03"
-11863	cyan huge table tennis ball	0		Last Available: "2025-03"
-11864	watered-down perfectly mixed pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
+11863	huge cyan table tennis ball	0		Last Available: "2025-03"
+11864	perfectly mixed watered-down pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
 11865	twisted phosphor traces	1		Last Available: "2025-03"
 11866	wobbly crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
-11868	maroon skewed spoon	0		
+11868	skewed maroon spoon	0		
 11869	skewed unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	boiled leprechaun antidepressant pill	1		Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2025-03"
@@ -11730,11 +11730,11 @@
 11875	rotten peach pie	3	crappy	Last Available: "2025-03"
 11876	yummy twirling incredible mini-pizza	3	awesome	Last Available: "2025-03"
 11877	mediocre Divine sidecar	4	decent	Last Available: "2025-03"
-11878	mediocre practically non-alcoholic huge tangarita sidecar	1	decent	Last Available: "2025-03"
+11878	practically non-alcoholic mediocre huge tangarita sidecar	1	decent	Last Available: "2025-03"
 11879	tolerable gimlet sidecar	4	good	Last Available: "2025-03"
 11880	lousy watered-down vodka stratocaster sidecar	2	decent	Last Available: "2025-03"
 11881	weak lousy upside-down prussian cathouse sidecar	2	decent	Last Available: "2025-03"
-11882	distilled lousy Mon Tiki sidecar	5	decent	Last Available: "2025-03"
+11882	lousy distilled Mon Tiki sidecar	5	decent	Last Available: "2025-03"
 11883	bouncing Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	auspicious frightening April Shower Thoughts shield	0		Spooky Damage: +5, Item Drop: +10, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
@@ -11779,15 +11779,15 @@
 11924	wholesome experienced Axis helmet	0		Experience: +2, Maximum HP Percent: +10
 11925	shaking pulsating vibrating studded Axis fatigues	0		Damage Absorption: +80, Maximum MP Percent: +10
 11926	clever rock-hard Axis suspenders	0		Damage Reduction: 5, Maximum MP: +20, Single Equip
-11927	blinking cyan bouncing stolen artifact	0		
+11927	cyan blinking bouncing stolen artifact	0		
 11928	narrow really expensive stolen artifact	0		
 11929	blue priceless stolen artifact	0		
 11930	chocolate rations	0		
-11931	tumbling purple nice nylon stockings	0		
+11931	purple tumbling nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	bouncing aromatic banded Allied Radio Backpack of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Stench Resistance: +1, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
-11935	narrow fuchsia ordnance magnet	0		Single Equip
+11935	fuchsia narrow ordnance magnet	0		Single Equip
 11936	wobbly confetti grenade	0		
 11937	normal Skeleton Wars rations	3	good	
 11938	bad skeleton war fuel can	3	decent	
@@ -11797,7 +11797,7 @@
 11942	M&ouml;bius ring	0		Last Available: "2025-08"
 11943	maroon bone pacifier	0		Familiar Weight: +5
 11944	banded Allied Forces insignia of the dark arts of incineration	0		Spell Damage Percent: +100, Damage Absorption: +100, Hot Spell Damage: +50, Single Equip
-11945	skewed shaking lime green Allied Tattoo Kit	0		
+11945	lime green shaking skewed Allied Tattoo Kit	0		
 11946	cyan handheld Allied radio	0		
 11947	Axis codebook	0		
 11948	concentrated bouncing shaking Life Goals Pamphlet	0		Effect: "Employee of the Month", Effect Duration: 11, Last Available: "2025-08"
@@ -11810,21 +11810,21 @@
 11955	spoiled Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	wobbly lard-coated weightlifter's the gun of the businessman	0		Muscle: +15, Sleaze Spell Damage: +25, Meat Drop: +50, Last Available: "2025-08"
-11958	weak perfectly mixed wine	2	EPIC	Last Available: "2025-08"
+11958	perfectly mixed weak wine	2	EPIC	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	blue twirling auspicious undersea surveying goggles	0		Item Drop: +10, Lasts Until Rollover
 11963	hand-crafted Ocean-Touched Rum	3	EPIC	
 11964	boiled blinking water-logged pill	1		Effect: "Florid Cheeks", Effect Duration: 50
 11965	small delicious kelp puck	2	awesome	
-11966	tumbling blinking scroll of sea strength	0		
+11966	blinking tumbling scroll of sea strength	0		
 11967	lime green scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
 11969	twirling waterlogged scroll of healing	0		
 11970	pulsating sea gel	0		
 11971	dry octopus ink bladder	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 15
 11972	durable dolphin whistle	0		
-11973	skewed lime green Thwaitgold lobster statuette	0		
+11973	lime green skewed Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
@@ -11839,11 +11839,11 @@
 12049	shaking stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	pulsating knucklebone	0		
-12052	watered-down lousy teal Smoking Pope	2	decent	
+12052	lousy watered-down teal Smoking Pope	2	decent	
 12053	rotten yellow prize turkey	4	crappy	
 12054	compressed green medicinal gruel	1		
 12055	decent bite-sized full-sized pumpkin pie	1	good	Last Available: "2025-11"
-12056	hand-crafted high-proof vodka cranberry sauce	10	EPIC	Last Available: "2025-11"
+12056	high-proof hand-crafted vodka cranberry sauce	10	EPIC	Last Available: "2025-11"
 12057	irradiated wobbly yammed candy	0		Effect: "Hair on Your Chest", Effect Duration: 21, Last Available: "2025-11"
 12058	normal jittery treasure chestnut	4	good	Last Available: "2025-12"
 12059	acceptable spinning mulled butter rum	3	good	Last Available: "2025-12"
@@ -11879,9 +11879,9 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	extra-thick Crimbo sweater of Gandalf	0		Spell Critical Percent: +20, Last Available: "2025-12"
 12123	fuchsia The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	practically non-alcoholic acceptable Steve Abrams' Holiday Sampler Beer	1	good	Last Available: "2025-12"
+12124	acceptable practically non-alcoholic Steve Abrams' Holiday Sampler Beer	1	good	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	drinkable weak bottle of prize-winning rum	2	good	Last Available: "2025-12"
+12126	weak drinkable bottle of prize-winning rum	2	good	Last Available: "2025-12"
 12127	huge rosewater-soaked Santa-Slayer medal of the dark arts of the empath	0		Spell Damage Percent: +100, Familiar Weight: +5, Stench Resistance: +3, Single Equip, Last Available: "2025-12"
 12128	cyan Skull of Claus	0		Last Available: "2025-12"
 12129	modified spinning boiling bone marrow	0		Effect: "OMG WTF", Effect Duration: 54, Last Available: "2025-12"
@@ -11897,8 +11897,8 @@
 12139	perfumed Annie Oakley's Oprah's burnt bone belt	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Stench Resistance: +5, Single Equip, Last Available: "2025-12"
 12140	gravedigger's scorched skull trophy	0		Spooky Damage: +10, Last Available: "2025-12"
 12141	spoiled wing bone	3	crappy	Last Available: "2025-12"
-12142	mediocre special triple-distilled narrow weak skeleton venom	10	decent	Effect: "Memory of Speed", Effect Duration: 45, Last Available: "2025-12"
-12143	powdered lime green wobbly baked bone meal	1		Last Available: "2025-12"
+12142	special triple-distilled mediocre narrow weak skeleton venom	10	decent	Effect: "Memory of Speed", Effect Duration: 45, Last Available: "2025-12"
+12143	powdered wobbly lime green baked bone meal	1		Last Available: "2025-12"
 12144	pulsating flame-wreathed plastic skeleton rib cage	0		Hot Spell Damage: +10, Last Available: "2025-12"
 12145	plastic skeleton skull of wisdom	0		Mysticality: +15, Last Available: "2025-12"
 12146	hale plastic skeleton Crimbo hat	0		Maximum HP: +20, Last Available: "2025-12"
@@ -11915,7 +11915,7 @@
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
-12160	huge olive Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12160	olive huge Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	green Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
@@ -11937,7 +11937,7 @@
 12179	Sherlock's medical-grade glimmering crystal	0		Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12"
 12180	narrow boxed Heartstone	0		Free Pull, Last Available: "2026-02"
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
-12182	narrow cyan pulsating Thwaitgold meat bee statuette	0		
+12182	pulsating cyan narrow Thwaitgold meat bee statuette	0		
 12183	pulsating loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
@@ -11954,8 +11954,8 @@
 12196	bolt of fabric	0		Last Available: "2026-03"
 12197	fireproof quilted and dress	0		Damage Absorption: +40, Hot Resistance: +3, Last Available: "2026-03"
 12198	and dress of Tarzan of the empath	0		Experience (Muscle): +3, Familiar Weight: +5, Last Available: "2026-03"
-12199	flattened magnetized wobbly shaking dinosaur bone broth	0		Effect: "Weepy, Creepy", Effect Duration: 68, Last Available: "2026-03"
-12200	squat wobbly gnawing bone	0		Last Available: "2026-03"
+12199	flattened magnetized shaking wobbly dinosaur bone broth	0		Effect: "Weepy, Creepy", Effect Duration: 68, Last Available: "2026-03"
+12200	wobbly squat gnawing bone	0		Last Available: "2026-03"
 12201	tumbling greedy dinosaur bone club	0		Meat Drop: +20, Last Available: "2026-03"
 12202	nasty Van der Graaf dinosaur skull helmet	0		Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-03"
 12203	miser's chilly banded dinosaur bone corset	0		Damage Absorption: +100, Cold Damage: +5, Meat Drop: +10, Last Available: "2026-03"
@@ -11972,35 +11972,35 @@
 12214	dried bouncing candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	flavorless immense red discarded hot dog	10	decent	Last Available: "2026-04"
+12217	immense flavorless red discarded hot dog	10	decent	Last Available: "2026-04"
 12218	lousy most of a beer	4	decent	Last Available: "2026-04"
 12222	spinning pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	spoiled huge can of tuna	4	crappy	
-12227	yummy massive jittery squat blinking alien salad	7	awesome	
+12227	massive yummy squat blinking jittery alien salad	7	awesome	
 12228	bland thick ratbatatouille	5	decent	
-12229	stale enchanted snack-sized onigiri	2	decent	Effect: "Spiky Hair", Effect Duration: 5
+12229	snack-sized stale enchanted onigiri	2	decent	Effect: "Spiky Hair", Effect Duration: 5
 12230	spoiled bouncing crudit&eacute;s	3	crappy	
 12231	thick delicious sauced mutton	5	awesome	
-12232	flavorless half-sized hot honey ant	2	decent	
+12232	half-sized flavorless hot honey ant	2	decent	
 12233	stale tomb aspic	4	decent	
 12234	rotten pulsating later tots	3	crappy	
 12235	normal olive Frutti di Scatoletta	3	good	Last Available: "2026-05"
-12236	yummy thick Pesto alla Marziano	5	awesome	Last Available: "2026-05"
+12236	thick yummy Pesto alla Marziano	5	awesome	Last Available: "2026-05"
 12237	adequate Arrattabbattabiata	4	good	Last Available: "2026-05"
-12238	jumbo stale Orzo di Riso	5	decent	Last Available: "2026-05"
+12238	stale jumbo Orzo di Riso	5	decent	Last Available: "2026-05"
 12239	spoiled blinking Pasta Grimavera	3	crappy	Last Available: "2026-05"
 12240	enchanted rotten Linguini Ubriacapa	4	crappy	Effect: "Like a Fish to Walter", Effect Duration: 50, Last Available: "2026-05"
 12241	delicious huge Formica e Pepe	4	awesome	Last Available: "2026-05"
-12242	decent huge blue Tubetto Gelatto	9	good	Last Available: "2026-05"
+12242	huge decent blue Tubetto Gelatto	9	good	Last Available: "2026-05"
 12243	adequate big teal Gnocci Domani	5	good	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	mirror sizzling rosy-cheeked Space Soldier Helmet	0		Maximum HP Percent: +30, Hot Damage: +10
-12253	flavorless miniature bouncing premium turkey leg	2	decent	
+12253	miniature flavorless bouncing premium turkey leg	2	decent	
 12254	drinkable olive styrofoam cup of mead	3	good	
 12255	brainy sword	0		Mysticality: +5
 12256	ghostly dance instructor's staff	0		Experience Percent (Moxie): +10
@@ -12020,35 +12020,35 @@
 12270	educational Portable Laughing Stock of Calamity Jane of doom	0		Experience: +1, Critical Hit Percent: +15, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	squat Jim Carey's steel-toed Staff of Anachronistic Churning of courage	0		Damage Reduction: 9, Monster Level: +25, Spooky Resistance: +3
 12272	stale classic banana	3	decent	Last Available: "2026-07"
-12273	delicious huge watermelon	10	awesome	Last Available: "2026-07"
+12273	huge delicious watermelon	10	awesome	Last Available: "2026-07"
 12274	stale quince	4	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	pulsating Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	flavorless pulsating classic banana pie	4	decent	Last Available: "2026-07"
-12278	quantum polarized ghostly huge essential banana decoction	0		Effect: "Smelly Pants", Effect Duration: 16, Last Available: "2026-07"
+12278	quantum polarized huge ghostly essential banana decoction	0		Effect: "Smelly Pants", Effect Duration: 16, Last Available: "2026-07"
 12279	cold-filtered corrupted anodized squat banana quintessence	0		Effect: "You're Rubber", Effect Duration: 66, Last Available: "2026-07"
-12280	fancy practically non-alcoholic aged Aesop Daiquiri	1	awesome	Effect: "Lemon Enlightenment", Effect Duration: 15, Last Available: "2026-07"
+12280	practically non-alcoholic aged fancy Aesop Daiquiri	1	awesome	Effect: "Lemon Enlightenment", Effect Duration: 15, Last Available: "2026-07"
 12281	perfectly mixed ghostly Monkey Congress	3	EPIC	Last Available: "2026-07"
-12282	super-sized yummy watermelon pie	5	awesome	Last Available: "2026-07"
+12282	yummy super-sized watermelon pie	5	awesome	Last Available: "2026-07"
 12283	triple-polymerized mirror concentrated watermelon juice	0		Effect: "You're High as a Crow, Marty", Effect Duration: 41, Last Available: "2026-07"
 12284	ionized Aqua Citrulanatae	0		Effect: "Smoky Third Eye", Effect Duration: 42, Last Available: "2026-07"
 12285	lousy Melonegroni	3	decent	Last Available: "2026-07"
 12286	hand-crafted Melonade Spritz	4	EPIC	Last Available: "2026-07"
-12287	stale massive quince pie	10	decent	Last Available: "2026-07"
+12287	massive stale quince pie	10	decent	Last Available: "2026-07"
 12288	quantum moist quince quaff	0		Effect: "Butt-Rock Hair", Effect Duration: 68, Last Available: "2026-07"
 12289	irradiated red Quickquince	0		Effect: "Cold Blooded", Effect Duration: 42, Last Available: "2026-07"
 12290	triple-distilled aged Quiskey Sour	10	awesome	Last Available: "2026-07"
-12291	watered-down drinkable skewed Quincea&ntilde;era Cooler	2	good	Last Available: "2026-07"
+12291	drinkable watered-down skewed Quincea&ntilde;era Cooler	2	good	Last Available: "2026-07"
 12292	tolerable watered-down jittery Roth IPA	2	good	Last Available: "2026-08"
 12293	mansplainer's Annie Oakley's underdraft protection	0		Critical Hit Percent: +20, Monster Level: +15, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	miniature normal soybean futures	2	good	Last Available: "2026-08"
+12295	normal miniature soybean futures	2	good	Last Available: "2026-08"
 12296	deionized housing bubble	0		Effect: "You Can Taste the Darkness", Effect Duration: 22, Last Available: "2026-08"
 12297	oxidized frozen skewed Pixie-Swordz	0		Effect: "Winklered", Effect Duration: 28
 12298	upside-down wool Tesla financial instrument	0		Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2026-08"
 12299	pulsating stanky cool hedge fund clippers	0		Moxie: +5, Stench Spell Damage: +25, Last Available: "2026-08"
 12300	jittery selling shorts of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2026-08"
-12301	red shaking bear tattoo	0		Last Available: "2026-08"
+12301	shaking red bear tattoo	0		Last Available: "2026-08"
 12302	tumbling bull tattoo	0		Last Available: "2026-08"
 12303	occult 401k ring of the boozehound	0		Spell Damage Percent: +25, Booze Drop: +100, Last Available: "2026-08"
 12304	pulsating balance sheet	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Accordion_Thief_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Mongoose_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	smooth practically non-alcoholic Petite Porter	1	awesome	
--2	drinkable distilled olive Scrawny Stout	5	good	
+-1	practically non-alcoholic smooth Petite Porter	1	awesome	
+-2	distilled drinkable olive Scrawny Stout	5	good	
 -3	delicious bouncing Infinitesimal IPA	4	awesome	
 -4	perfectly mixed strong eggnogtini	5	EPIC	
 -5	smooth candycaine	3	awesome	
--6	drinkable watered-down braincracker sweet	2	good	
+-6	watered-down drinkable braincracker sweet	2	good	
 -16	irresponsibly strong acceptable fermented honey	7	good	
 -17	perfectly mixed practically non-alcoholic moons-shine	1	EPIC	
 -18	drinkable spinning gin	3	good	
--19	aged watered-down ecto-nog	2	awesome	
+-19	watered-down aged ecto-nog	2	awesome	
 -20	aged hot toady	4	awesome	
 -21	weak aged hot choculate	2	awesome	
 -49	practically non-alcoholic acceptable ghostly Cyder	1	good	
 -50	tolerable lime green Oil Nog	3	good	
 -51	bad strong ghostly Hi-Octane Peppermint Jet Fuel	5	decent	
--58	bad enchanted weak Grimacider	2	decent	
--59	hand-crafted watered-down Isotope Nog	2	EPIC	
--60	practically non-alcoholic lousy squat Mutagin 'n' Tonic	1	decent	
+-58	weak bad enchanted Grimacider	2	decent	
+-59	watered-down hand-crafted Isotope Nog	2	EPIC	
+-60	lousy practically non-alcoholic squat Mutagin 'n' Tonic	1	decent	
 -70	mediocre bouncing Gin and Herring	3	decent	
 -71	aged Black and Tan and Red All Over	3	awesome	
 -72	high-proof bad red Antarctic Ice Tea	9	decent	
 -76	acceptable shaking CRIMBCO Ribbon Candy Schnapps	4	good	
--77	practically non-alcoholic tolerable CRIMBCO Egg Substitute Nog Substitute	1	good	
+-77	tolerable practically non-alcoholic CRIMBCO Egg Substitute Nog Substitute	1	good	
 -78	perfectly mixed distilled CRIMBCO Extreme Braincracker Sour	5	EPIC	
 -82	mediocre Horseradish-infused Vodka	4	decent	
 -83	lousy Jerkitini	4	decent	
--84	practically non-alcoholic perfectly mixed cyan Desert Island Iced Tea	1	EPIC	
+-84	perfectly mixed practically non-alcoholic cyan Desert Island Iced Tea	1	EPIC	
 -88	acceptable mirror Crimbo Saketini	3	good	
--89	lousy practically non-alcoholic enchanted Crimboku Drop	1	decent	
+-89	enchanted lousy practically non-alcoholic Crimboku Drop	1	decent	
 -90	artisanal Flaming Crimbo Log	3	EPIC	
--107	weak special hand-crafted Fortified Eggnog Slurry	2	EPIC	
+-107	special hand-crafted weak Fortified Eggnog Slurry	2	EPIC	
 -108	drinkable Hot Buttered Rum	4	good	
 -109	perfectly mixed Spicy Hot Chocolate	3	EPIC	

--- a/data/TCRS/TCRS_Accordion_Thief_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Mongoose_cafe_food.txt
@@ -1,24 +1,24 @@
--1	adequate low-calorie Peche a la Frog	1	good	
+-1	low-calorie adequate Peche a la Frog	1	good	
 -2	super-sized stale olive As Jus Gezund Heit	5	decent	
 -3	decent bouncing Bouillabaise Coucher Avec Moi	4	good	
--7	thick moldy gumdrop chow mein	5	crappy	
+-7	moldy thick gumdrop chow mein	5	crappy	
 -8	stale candy cane pizza	4	decent	
--9	huge rotten gingerbread stir-fry	7	crappy	
+-9	rotten huge gingerbread stir-fry	7	crappy	
 -10	half-sized rotten twigs and gravel	2	crappy	
--11	toothsome thick tumbling shoots and leaves	5	awesome	
--12	spoiled huge narrow bowl of unidentifiable goo	10	crappy	
+-11	thick toothsome tumbling shoots and leaves	5	awesome	
+-12	huge spoiled narrow bowl of unidentifiable goo	10	crappy	
 -13	normal gingerbread massacre	3	good	
 -14	diet bland pulsating It Came From Beyond Dessert	1	decent	
--15	bite-sized normal jittery vampire cake	1	good	
--52	decent enchanted Soylent Red and Green	4	good	
+-15	normal bite-sized jittery vampire cake	1	good	
+-52	enchanted decent Soylent Red and Green	4	good	
 -53	jumbo rotten maroon Disc-Shaped Nutrition Unit	5	crappy	
 -54	stale Gingerborg Hive	3	decent	
 -61	half-sized decent squat Candy Cane Surprise	2	good	
--62	jumbo normal Grimdrop Chow Mein	5	good	
+-62	normal jumbo Grimdrop Chow Mein	5	good	
 -63	flavorless gigantic bouncing Grimgerbread House	9	decent	
--67	flavorless jumbo red Caviar Carbonara	5	decent	
--68	low-calorie tasty Halibut Alfredo	1	awesome	
--69	enchanted tiny normal gray twirling Red Herring Velvet Cake	1	good	
+-67	jumbo flavorless red Caviar Carbonara	5	decent	
+-68	tasty low-calorie Halibut Alfredo	1	awesome	
+-69	tiny enchanted normal twirling gray Red Herring Velvet Cake	1	good	
 -73	rotten tumbling CRIMBCO Reconstituted Gruel	3	crappy	
 -74	normal New and Improved CRIMBCO Reconstituted Gruel	3	good	
 -75	normal blue CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
@@ -29,17 +29,17 @@
 -86	half-sized stale huge Vegas Volcano Lava Roll	2	decent	
 -87	moldy Crazy Dragon Shogun Buddha Roll	4	crappy	
 -92	stale skewed basic hot dog	3	decent	
--93	low-calorie spoiled huge savage macho dog	1	crappy	
--94	immense rotten one with everything	9	crappy	
+-93	spoiled low-calorie huge savage macho dog	1	crappy	
+-94	rotten immense one with everything	9	crappy	
 -95	stale sly dog	4	decent	
 -96	toothsome devil dog	3	awesome	
 -97	adequate special tumbling chilly dog	3	good	
--98	delicious small ghost dog	2	awesome	
--99	fancy moldy green wobbly junkyard dog	3	crappy	
+-98	small delicious ghost dog	2	awesome	
+-99	moldy fancy green wobbly junkyard dog	3	crappy	
 -100	spoiled wet dog	3	crappy	
 -101	half-sized spoiled sleeping dog	2	crappy	
 -102	bland optimal dog	4	decent	
--103	rotten low-calorie video games hot dog	1	crappy	
+-103	low-calorie rotten video games hot dog	1	crappy	
 -104	gigantic normal Peppermint Nutrition Block	8	good	
 -105	normal Gingerbread Nutrition Block	3	good	
 -106	normal narrow Cinnamon Nutrition Block	4	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Opossum.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Opossum.txt
@@ -12,8 +12,8 @@
 12	huge mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	dried moxie weed	1		Effect: "Disco Neuropathy", Effect Duration: 50
 15	diluted narrow strongness elixir	1		
-16	dried squat skewed magicalness-in-a-can	1		
-17	spoiled bite-sized huge noodles	1	crappy	
+16	dried skewed squat magicalness-in-a-can	1		
+17	bite-sized spoiled huge noodles	1	crappy	
 18	tortoise's blessing	0		
 19	asparagus knife of the boozehound	0		Booze Drop: +100
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -42,7 +42,7 @@
 43	worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
-46	shaking tumbling figurine	0		
+46	tumbling shaking figurine	0		
 47	immense spoiled teal upside-down hot buttered roll	7	crappy	
 48	ghostly heart of rock and roll	0		
 49	decent bowl of cottage cheese	3	good	
@@ -84,7 +84,7 @@
 85	unlocked meat locker	0		
 86	twirling key	0		
 87	meat from yesterday	0		
-88	shaking wobbly meat stack	0		
+88	wobbly shaking meat stack	0		
 89	sword hilt	0		
 90	helmet recipe	0		
 91	pants kit	0		
@@ -103,7 +103,7 @@
 104	scarecrow	0		
 105	flavorless jumbo ghostly bowl of charms	5	decent	
 106	upside-down ketchup	1	EPIC	
-107	mirror gray catsup	1	EPIC	
+107	gray mirror catsup	1	EPIC	
 108	fuchsia stick	0		
 109	crossbow string	0		
 110	family-friendly basic meat staff	0		Sleaze Resistance: +1
@@ -157,13 +157,13 @@
 158	Gnollish pie tin	0		
 159	wad of dough	0		
 160	pie crust	0		
-161	half-sized bland ghuol egg	2	decent	
+161	bland half-sized ghuol egg	2	decent	
 162	bland small pulsating ghuol egg quiche	2	decent	
 163	greedy skeleton bone	0		Meat Drop: +20
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	low-calorie yummy ghuol-ear kabob	1	awesome	
+167	yummy low-calorie ghuol-ear kabob	1	awesome	
 168	therapeutic bone rattle	0		HP Regen Min: 5, HP Regen Max: 7
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -204,10 +204,10 @@
 206	piercing post	0		
 207	hippy herbal tea	1	good	
 208	patchouli incense stick	0		
-209	teal spinning wad of tofu	0		
+209	spinning teal wad of tofu	0		
 210	narrow bouncing Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
-212	narrow twirling windchimes	0		
+212	twirling narrow windchimes	0		
 213	Lo Pan's thinker's filthy corduroys	0		Mysticality: +10, Spell Critical Percent: +30, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	filthy knitted dread sack of the sewer	0		Stench Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
@@ -232,36 +232,36 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	yellow family-friendly razor-sharp Bigger Bugfinder Blade	0		Weapon Damage Percent: +25, Sleaze Resistance: +1
 236	Queue Du Coq cocktailcrafting kit	0		
-237	hand-crafted maroon spinning bottle of gin	3	EPIC	
+237	hand-crafted spinning maroon bottle of gin	3	EPIC	
 238	watered-down perfectly mixed bottle of vodka	2	EPIC	
 239	executive Orcish baseball cap	0		Item Drop: +5, Meat Drop: +40, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	upside-down rosewater-soaked resourceful Orcish cargo shorts	0		Maximum MP: +50, Stench Resistance: +3, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Orcish frat-paddle of the boozehound	0		Booze Drop: +100
-242	miniature adequate	2	good	
+242	adequate miniature	2	good	
 243	tiny spoiled grapefruit	1	crappy	
 244	yummy grapes	4	awesome	
-245	rotten jumbo olive	5	crappy	
+245	jumbo rotten olive	5	crappy	
 246	normal small squat tomato	2	good	
 247	fermenting powder	0		
 248	acceptable high-proof salty dog	9	good	
 249	delicious bloody mary	4	awesome	
-250	distilled perfectly mixed screwdriver	5	EPIC	
+250	perfectly mixed distilled screwdriver	5	EPIC	
 251	tolerable martini	3	good	
-252	practically non-alcoholic fancy lousy bouncing bloody beer	1	decent	Effect: "Blessing of the Hot Linguine", Effect Duration: 30
+252	fancy lousy practically non-alcoholic bouncing bloody beer	1	decent	Effect: "Blessing of the Hot Linguine", Effect Duration: 30
 253	hand-crafted shot of schnapps	3	EPIC	
-254	bad practically non-alcoholic shot of grapefruit schnapps	1	decent	
+254	practically non-alcoholic bad shot of grapefruit schnapps	1	decent	
 255	delicious fine wine	4	awesome	
 256	tolerable shot of tomato schnapps	3	good	
 257	lousy extra-spicy bloody mary	3	decent	
 258	red dense meat stack	0		
 259	snake skin	0		
 260	tasty White Citadel fries	3	awesome	
-261	delicious small White Citadel burger	2	awesome	
+261	small delicious White Citadel burger	2	awesome	
 262	moldy snack-sized piece of wedding cake	2	crappy	
 263	massive decent chocolate chips	8	good	
-264	thick normal chocolate chip cookies	5	good	
+264	normal thick chocolate chip cookies	5	good	
 265	savvy satin pants	0		Mysticality Percent: +20, Familiar Effect: "atk, 2xPotato, cap 10"
-266	high-proof delicious lightning	7	awesome	
+266	delicious high-proof lightning	7	awesome	
 267	twirling mullet wig of the early riser	0		Adventures: +7, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	meat cowboy hat of courage	0		Spooky Resistance: +3, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	grievous sword	0		Weapon Damage Percent: +50
@@ -275,7 +275,7 @@
 277	denatured extra-strength strongness elixir	1		
 278	modified wobbly jug-o-magicalness	1		
 279	compressed jittery suntan lotion of moxiousness	1		Effect: "Protection from Bad Stuff", Effect Duration: 10
-280	skewed pulsating Pick-O-Matic lockpicks	0		
+280	pulsating skewed Pick-O-Matic lockpicks	0		
 281	gasmask of the sewer	0		Stench Damage: +25, Familiar Effect: "1xBarrr, cap 12"
 282	Boris's key	0		
 283	Jarlsberg's key	0		
@@ -318,7 +318,7 @@
 320	tasty bat haggis	4	awesome	
 321	special stale half-sized menudo	2	decent	Effect: "You Know What's Up", Effect Duration: 30
 322	rotten miniature goat cheese	2	crappy	
-323	special adequate tiny plain pizza	1	good	Effect: "Vanity Rage", Effect Duration: 15
+323	tiny special adequate plain pizza	1	good	Effect: "Vanity Rage", Effect Duration: 15
 324	flavorless thick sausage pizza	5	decent	
 325	stale pulsating goat cheese pizza	3	decent	
 326	immense rotten mushroom pizza	8	crappy	
@@ -336,7 +336,7 @@
 338	tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
 340	non-boiled alkaline Knob Goblin steroids	0		Effect: "Dancing Prowess", Effect Duration: 36
-341	quadruple-activated double-polarized pulsating maroon Knob Goblin love potion	0		Effect: "Jammin'", Effect Duration: 44
+341	quadruple-activated double-polarized maroon pulsating Knob Goblin love potion	0		Effect: "Jammin'", Effect Duration: 44
 342	pulsating Knob Goblin stink bomb	0		
 343	alkaline anodized tumbling Knob Goblin sharpening spray	0		Effect: "Intimidating Mien", Effect Duration: 47
 344	Knob Goblin seltzer	0		
@@ -360,7 +360,7 @@
 362	MacGyver's 7-Foot Dwarven mattock	0		Maximum MP: +100
 363	teal linoleum ore	0		
 364	asbestos ore	0		
-365	jittery spinning chrome ore	0		
+365	spinning jittery chrome ore	0		
 366	huge linoleum sword hilt	0		
 367	skewed linoleum stick	0		
 368	upside-down linoleum crossbow string	0		
@@ -370,9 +370,9 @@
 372	chrome sword hilt	0		
 373	huge chrome stick	0		
 374	chrome crossbow string	0		
-375	olive shaking linoleum meat stack	0		
-376	tumbling blurry asbestos meat stack	0		
-377	blurry twirling chrome meat stack	0		
+375	shaking olive linoleum meat stack	0		
+376	blurry tumbling asbestos meat stack	0		
+377	twirling blurry chrome meat stack	0		
 378	censurious Da Vinci's linoleum sword	0		Experience (Mysticality): +5, Sleaze Resistance: +3
 379	nasty brainy linoleum staff	0		Mysticality: +5, Stench Damage: +5
 380	rosy-cheeked smooth linoleum crossbow	0		Moxie: +15, Maximum HP Percent: +30
@@ -418,13 +418,13 @@
 420	pressed pulsating tomato juice of powerful power	0		Effect: "Coal-Powered", Effect Duration: 52
 421	moist philter of phorce	0		Effect: "Fishily Speeding", Effect Duration: 23
 422	nitrogenated blurry potion of potency	0		Effect: "Turkey-Friendly", Effect Duration: 46
-423	colloidal quantum narrow fuchsia cordial of concentration	0		Effect: "Rotten Memories", Effect Duration: 19
-424	liquefied vacuum-sealed green wobbly huge ointment of the occult	0		Effect: "Comprehensively Nourished", Effect Duration: 29
+423	colloidal quantum fuchsia narrow cordial of concentration	0		Effect: "Rotten Memories", Effect Duration: 19
+424	liquefied vacuum-sealed huge wobbly green ointment of the occult	0		Effect: "Comprehensively Nourished", Effect Duration: 29
 425	improved oil of expertise	0		Effect: "Musky", Effect Duration: 61
 426	quantum blurry potion of temporary gr8ness	0		Effect: "Hammertime", Effect Duration: 29
 427	shaking Da Vinci's box	0		Experience (Mysticality): +5, Wiki Name: "box"
 428	nothing-in-the-box	0		
-429	skewed shaking beanbag chair	0		
+429	shaking skewed beanbag chair	0		
 430	acid-squirting flower	0		Single Equip
 431	clown shoes of the detective	0		Item Drop: +20, Clowniness: 25
 432	veiny bloody clown pants	0		Maximum HP: +10, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
@@ -493,24 +493,24 @@
 495	catgut	0		
 496	twirling cat appendix	0		
 497	gnatwing	0		
-498	spoiled diet papaya	1	crappy	
+498	diet spoiled papaya	1	crappy	
 499	spinning blinking stanky sinister denim axe	0		Spell Damage: +10, Stench Spell Damage: +25
 500	Elf Farm Raffle ticket	0		
 501	thick tasty Elfin shortbread	5	awesome	
 502	tumbling pagoda plans	0		
-503	small flavorless skewered cat appendix	2	decent	
+503	flavorless small skewered cat appendix	2	decent	
 504	blurry evil arches	0		
 505	horrifying Temple Grandin's gnatwing earring	0		Familiar Weight: +7, Spooky Damage: +25
-506	rotten half-sized Hell broth	2	crappy	
+506	half-sized rotten Hell broth	2	crappy	
 507	smooth thunderrr guitarrr	0		Moxie: +15
 508	sonata	0		
 509	Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	huge Sneaky Pete's key lime	0		
-513	moldy special blurry Boris's key lime pie	4	crappy	Effect: "Optimist Primal", Effect Duration: 40
+513	special moldy blurry Boris's key lime pie	4	crappy	Effect: "Optimist Primal", Effect Duration: 40
 514	tasty Jarlsberg's key lime pie	3	awesome	
-515	bite-sized adequate spinning Sneaky Pete's key lime pie	1	good	
+515	adequate bite-sized spinning Sneaky Pete's key lime pie	1	good	
 516	Hey Deze map	0		
 517	wobbly hardy bejeweled accordion strap	0		Maximum HP: +50, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -540,20 +540,20 @@
 542	greedy 1337 7r0uZ0RZ of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +20, Familiar Effect: "2xPotato, cap 27"
 543	normal small upside-down maroon Trollhouse cookies	2	good	
 544	sinister arcane researcher's talons	0		Experience Percent (Mysticality): +10, Spell Damage: +10
-545	huge normal mirror blurry Spam Witch sammich	7	good	
+545	huge normal blurry mirror Spam Witch sammich	7	good	
 546	shaking meat vortex	0		
 547	wobbly 334 scroll	0		
-548	huge olive 668 scroll	0		
+548	olive huge 668 scroll	0		
 549	30669 scroll	0		
 550	33398 scroll	0		
-551	lime green wobbly 64067 scroll	0		
+551	wobbly lime green 64067 scroll	0		
 552	64735 scroll	0		
 553	jittery 31337 scroll	0		
-554	tiny decent pr0n cocktail	1	good	
+554	decent tiny pr0n cocktail	1	good	
 555	medical-grade experienced drywall axe	0		Experience: +2, HP Regen Min: 7, HP Regen Max: 10
 556	Tesla Pine-Fresh air freshener	0		MP Regen Min: 7, MP Regen Max: 10
 557	extra-dry acceptable whiskey and cola	5	good	
-558	diet delicious papaya taco	1	awesome	
+558	delicious diet papaya taco	1	awesome	
 559	cyan razor-sharp can lid	0		
 560	stale narrow stalk of asparagus	4	decent	
 561	pregnant mushroom	0		
@@ -563,29 +563,29 @@
 565	friendly hobo gloves	0		Familiar Weight: +3, Single Equip
 566	supercool bum cheek	0		Moxie Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	pulsating hermit script	0		
-568	bite-sized bland spinning Double Bacon Beelzeburger	1	decent	
+568	bland bite-sized spinning Double Bacon Beelzeburger	1	decent	
 569	fancy yummy Lord of the Flies-sized fries	3	awesome	Effect: "Human-Beast Hybrid", Effect Duration: 40
 570	bland huge Chicken Sandwich	7	decent	
 571	skewed blue Jumbo Dr. Lucifer	1	EPIC	
-572	snack-sized stale Children's Meal of the Damned	2	decent	
+572	stale snack-sized Children's Meal of the Damned	2	decent	
 573	flavorless noodles	4	decent	
 574	stale snack-sized noodles	2	decent	
-575	spoiled small painful penne pasta	2	crappy	
+575	small spoiled painful penne pasta	2	crappy	
 576	flavorless ravioli della hippy	3	decent	
 577	normal fuchsia pr0n m4nic0tti	3	good	
-578	normal snack-sized Hell ramen	2	good	
+578	snack-sized normal Hell ramen	2	good	
 579	bland boring spaghetti	4	decent	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	rotten fettucini Inconnu	4	crappy	
-584	special moldy spaghetti with Skullheads	4	crappy	Effect: "Ninja, Please", Effect Duration: 15
-585	adequate bite-sized pulsating jittery gnocchetti di Nietzsche	1	good	
+584	moldy special spaghetti with Skullheads	4	crappy	Effect: "Ninja, Please", Effect Duration: 15
+585	bite-sized adequate pulsating jittery gnocchetti di Nietzsche	1	good	
 586	scandalous electrified ridiculously huge sword	0		Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5
-587	extra-nitrogenated unsweetened huge shaking super-spiky hair gel	0		Effect: "This Is Where You're a Viking", Effect Duration: 43
+587	extra-nitrogenated unsweetened shaking huge super-spiky hair gel	0		Effect: "This Is Where You're a Viking", Effect Duration: 43
 588	soft echo eyedrop antidote	0		
-589	flavorless super-sized cocoa eggshell fragment	5	decent	
-590	adequate snack-sized upside-down blinking cocoa eggshell fragment	2	good	
+589	super-sized flavorless cocoa eggshell fragment	5	decent	
+590	snack-sized adequate blinking upside-down cocoa eggshell fragment	2	good	
 591	cocoa egg	0		
 592	red house	0		
 593	teal skewed phonics down	0		
@@ -613,9 +613,9 @@
 615	chaos butterfly	0		
 616	jittery furry fur	0		
 617	tarnished Angry Farmer candy	0		Effect: "Spooky Demeanor", Effect Duration: 18
-618	altered corrupted double-liquefied maroon huge Mick's IcyVapoHotness Rub	0		Effect: "Crud&eacute;", Effect Duration: 41
+618	altered corrupted double-liquefied huge maroon Mick's IcyVapoHotness Rub	0		Effect: "Crud&eacute;", Effect Duration: 41
 619	pulsating blue Tesla needle	0		MP Regen Min: 7, MP Regen Max: 10
-620	anodized purple pulsating thin candle	0		Effect: "Comprehensively Nourished", Effect Duration: 17
+620	anodized pulsating purple thin candle	0		Effect: "Comprehensively Nourished", Effect Duration: 17
 621	huge wobbly Warm Subject gift certificate	0		
 622	awful poetry journal	0		
 623	WA	0		
@@ -634,7 +634,7 @@
 636	shaking meat globe	0		
 637	bouncing toaster	0		
 638	huge rock-hard experienced asshat	0		Experience: +2, Damage Reduction: 5, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	stale special small maroon abominable snowcone	2	decent	Effect: "Ticking Clock", Effect Duration: 30
+639	small special stale maroon abominable snowcone	2	decent	Effect: "Ticking Clock", Effect Duration: 30
 640	Ent cider	1	good	
 641	decent toast	4	good	
 642	skeleton key	0		
@@ -644,8 +644,8 @@
 646	moldy green fruitcake	4	crappy	
 647	present	0		Last Available: "2004-11"
 648	groovy Crimbo sword	0		Moxie Percent: +10, Last Available: "2004-10"
-649	lion tamer's Crimbo hat	0		Experience (familiar): +2, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	olive beefy Crimbo pants	0		Muscle: +10, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	lion tamer's Crimbo hat	0		Experience (familiar): +2, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	olive beefy Crimbo pants	0		Muscle: +10, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	rock-hard exclusive ultra-rare item	0		Damage Reduction: 5
 652	upside-down quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,20 +664,20 @@
 666	double-paned clever deadly steaming evil	0		Weapon Damage: +5, Maximum MP: +20, Cold Resistance: +5
 667	castle map	0		
 668	fuchsia blurry spiked femur of the blizzard	0		Cold Spell Damage: +25
-669	low-calorie moldy ghuol guolash	1	crappy	
+669	moldy low-calorie ghuol guolash	1	crappy	
 670	lightning-fast lihc face	0		Initiative: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	spinning stanky Herculean grave robbing shovel	0		Experience (Muscle): +1, Stench Spell Damage: +25
-672	jumbo decent cranberries	5	good	
-673	spirit-forward acceptable vodka and cranberry	5	good	
-674	strong delicious whiskey	5	awesome	
+672	decent jumbo cranberries	5	good	
+673	acceptable spirit-forward vodka and cranberry	5	good	
+674	delicious strong whiskey	5	awesome	
 675	skull of the Bonerdagon of the empath	0		Familiar Weight: +5
 676	dragonbone belt buckle	0		
 677	huge rosy-cheeked badass belt	0		Maximum HP Percent: +30
 678	pulsating chest of the Bonerdagon	0		
-679	enchanted artisanal roll in the hay	3	EPIC	Effect: "Poker Faced", Effect Duration: 15
+679	artisanal enchanted roll in the hay	3	EPIC	Effect: "Poker Faced", Effect Duration: 15
 680	aged slap and tickle	3	awesome	
 681	mediocre slip 'n' slide	4	decent	
-682	bad irresponsibly strong a sump'm sump'm	7	decent	
+682	irresponsibly strong bad a sump'm sump'm	7	decent	
 683	bad horizontal tango	4	decent	
 684	perfectly mixed irresponsibly strong pink pony	9	EPIC	
 685	up-at-dawn smelly Mr. Shirt of bravery	0		Stench Spell Damage: +10, Spooky Resistance: +5, Adventures: +5
@@ -717,7 +717,7 @@
 721	twirling Fonzie's porquoise bracelet of the cheetah	0		Experience (Moxie): +1, Initiative: +60
 722	blue ghostly lard-coated smartaleck's porquoise ring of the wise owl	0		Mysticality: +20, Moxie Percent: +30, Sleaze Spell Damage: +25, Single Equip
 723	bland Knoll mushroom	3	decent	
-724	huge flavorless huge mushroom	8	decent	
+724	flavorless huge huge mushroom	8	decent	
 725	one million meat pancakes	0		
 726	curative huge mirror shard	0		HP Regen Min: 3, HP Regen Max: 5
 727	hedge maze puzzle	0		
@@ -725,7 +725,7 @@
 729	fishbowl	0		
 730	bouncing fishtank	0		
 731	fish hose	0		
-732	ghostly red hosed tank	0		
+732	red ghostly hosed tank	0		
 733	hosed fishbowl	0		
 734	chaotic padded makeshift SCUBA gear of Gandalf	0		Damage Absorption: +20, Spell Critical Percent: 30, Adventure Underwater
 735	easter egg balloon of extreme caution	0		Monster Level: -25
@@ -734,29 +734,29 @@
 738	stone tablet (Really Evil Rhythm)	0		
 739	skewed tambourine bells	0		
 740	tambourine of temperance	0		Sleaze Resistance: +5
-741	upside-down twirling broken skull	0		
+741	twirling upside-down broken skull	0		
 742	immense moldy Knoll shroomkabob	8	crappy	
 743	decent diet mushroom	1	good	
-744	tarnished wobbly teal hair spray	0		Effect: "Spring Training", Effect Duration: 32
+744	tarnished teal wobbly hair spray	0		Effect: "Spring Training", Effect Duration: 32
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	skewed gourd potion	0		
-749	spoiled thick warm mushroom	5	crappy	
-750	moldy tumbling squat mushroom quesadilla	3	crappy	
+749	thick spoiled warm mushroom	5	crappy	
+750	moldy squat tumbling mushroom quesadilla	3	crappy	
 751	stale cool mushroom	3	decent	
 752	half-sized flavorless cool mushroom casserole	2	decent	
 753	decent pointy mushroom	3	good	
-754	normal small cream of pointy mushroom soup	2	good	
+754	small normal cream of pointy mushroom soup	2	good	
 755	moldy small mushroom	2	crappy	
-756	jumbo flavorless squat mushroom	5	decent	
-757	flavorless fancy wobbly mushroom	3	decent	Effect: "Ooh, Umami!", Effect Duration: 40
+756	flavorless jumbo squat mushroom	5	decent	
+757	fancy flavorless wobbly mushroom	3	decent	Effect: "Ooh, Umami!", Effect Duration: 40
 758	stale ghost cucumber	4	decent	
 759	teal dill	0		
 760	narrow vinegar	0		
 761	upside-down brine	0		
 762	mediocre ghostly especially salty dog	3	decent	
 763	maroon ghostly pickling solution	0		
-764	yummy massive spectral pickle	9	awesome	
+764	massive yummy spectral pickle	9	awesome	
 765	purple briny vinegar	0		
 766	tumbling ghost pickle on a stick	0		
 767	ionized energized moist cologne of contempt	0		Effect: "Adrenaline Rush", Effect Duration: 45
@@ -778,38 +778,38 @@
 783	upside-down 'Villa' document	0		
 784	drinkable huge Acqua Del Piatto Merlot	3	good	Last Available: "2004-10"
 785	raffle ticket	0		
-786	low-calorie adequate strawberry	1	good	
+786	adequate low-calorie strawberry	1	good	
 787	bad strong bottle of rum	5	decent	
-788	acceptable practically non-alcoholic strawberry daiquiri	1	good	
+788	practically non-alcoholic acceptable strawberry daiquiri	1	good	
 789	perfectly mixed practically non-alcoholic jittery rum and cola	1	EPIC	
-790	strong perfectly mixed grog	5	EPIC	
+790	perfectly mixed strong grog	5	EPIC	
 791	therapeutic Mafia bow tie of the ox	0		Muscle: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-10"
 792	huge Golden Mr. Accessory of Tarzan	0		Experience (Muscle): +3, Softcore Only
 793	moist shaking oil of stability	0		Effect: "Heart of Green", Effect Duration: 26
 794	improved anodized deionized oil of slipperiness	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 68
 795	lousy Acque Luride Grezze Cabernet	4	decent	Last Available: "2004-10"
 796	narrow ghostly reassuring therapeutic cement shoes of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-10"
-797	watered-down lousy enchanted rockin' wagon	2	decent	Effect: "Hoity Toity", Effect Duration: 45
+797	watered-down enchanted lousy rockin' wagon	2	decent	Effect: "Hoity Toity", Effect Duration: 45
 798	artisanal ocean motion	3	EPIC	
 799	hand-crafted watered-down mirror fuzzbump	2	EPIC	
-800	jumbo normal upside-down poutine	5	good	
+800	normal jumbo upside-down poutine	5	good	
 801	rotten super-sized Knob stir-fry	5	crappy	
 804	bland tumbling Knoll stir-fry	4	decent	
 805	normal stir-fry	3	good	
 806	adequate asparagus stir-fry	3	good	
-807	moldy small olive stir-fry	2	crappy	
+807	small moldy olive stir-fry	2	crappy	
 808	rotten teal Knob sausage stir-fry	4	crappy	
 809	tasty maroon bat wing stir-fry	3	awesome	
 810	moldy rat appendix stir-fry	4	crappy	
 811	small spoiled tofu stir-fry	2	crappy	
 812	flavorless pr0n stir-fry	4	decent	
-813	rotten pulsating huge Knob shells	4	crappy	
+813	rotten huge pulsating Knob shells	4	crappy	
 814	toothsome b&auml;tzle	3	awesome	
-815	toothsome red tumbling ratini	4	awesome	
-816	decent tiny special Knob stroganoff	1	good	Effect: "French Bronilla Brogueishness", Effect Duration: 40
+815	toothsome tumbling red ratini	4	awesome	
+816	special decent tiny Knob stroganoff	1	good	Effect: "French Bronilla Brogueishness", Effect Duration: 40
 817	moldy menudo ravioli	4	crappy	
 818	plus sign	0		
-819	tumbling ghostly milky potion	0		
+819	ghostly tumbling milky potion	0		
 820	swirly potion	0		
 821	bubbly potion	0		
 822	smoky potion	0		
@@ -820,26 +820,26 @@
 827	bouncing murky potion	0		
 828	twirling baby killer bee	0		
 829	anti-anti-antidote	0		
-830	adequate enchanted royal jelly	4	good	Effect: "The Real Deal", Effect Duration: 50
+830	enchanted adequate royal jelly	4	good	Effect: "The Real Deal", Effect Duration: 50
 831	small box	0		
 832	box	0		
 833	personal trainer's vorpal blade	0		Experience Percent (Muscle): +10
 834	blurry family-friendly smartaleck's cornuthaum	0		Moxie Percent: +30, Sleaze Resistance: +1, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	padded ring of aggravate monster	0		Damage Absorption: +20
 836	moldy blurry mind flayer corpse	4	crappy	
-837	tolerable watered-down blue Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
+837	watered-down tolerable blue Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
 838	narrow Annie Oakley's baleful Mafia stogie	0		Spell Damage: +25, Critical Hit Percent: +20, Last Available: "2004-10"
 839	delicious Maiali Sifilitici Pinot Noir	4	awesome	Last Available: "2004-10"
 840	gray wool hardened Mafia violin case	0		Damage Reduction: 3, Cold Resistance: +1, Last Available: "2004-10"
 841	artisanal green tomato daiquiri	4	EPIC	
-842	bad practically non-alcoholic beertini	1	decent	
-843	watered-down tolerable mirror salty slug	2	good	
+842	practically non-alcoholic bad beertini	1	decent	
+843	tolerable watered-down mirror salty slug	2	good	
 844	mediocre papaya slung	3	decent	
 845	weightlifter's MAHI fez	0		Muscle: +15, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
 849	olive Meat detector	0		Familiar Weight: +5
-850	huge purple many-eyed glasses	0		Familiar Weight: +5
+850	purple huge many-eyed glasses	0		Familiar Weight: +5
 851	spinning prosthetic forehead	0		Familiar Weight: +5
 852	jittery shaker of salt	0		Familiar Weight: +5
 853	squat blundarrrbus	0		Familiar Weight: +5
@@ -848,7 +848,7 @@
 856	shock collar	0		
 857	moonglasses	0		
 858	blinking palm-frond toupee	0		Familiar Weight: +5
-859	fuchsia skewed bouncing knife and fork	0		Familiar Weight: +5
+859	bouncing skewed fuchsia knife and fork	0		Familiar Weight: +5
 860	green eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
 862	magnifying glass	0		Familiar Weight: +5
@@ -892,7 +892,7 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	perfectly mixed jittery Spasmi Dolorosi Del Rene Champagne	4	EPIC	Last Available: "2004-10"
-904	greasy groovy school Mafia knickerbockers of courage	0		Moxie Percent: +10, Sleaze Spell Damage: +10, Spooky Resistance: +3, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	greasy groovy school Mafia knickerbockers of courage	0		Moxie Percent: +10, Sleaze Spell Damage: +10, Spooky Resistance: +3, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	ionized activated wobbly Yummy Tummy bean	0		Effect: "Amorphous Cheer", Effect Duration: 36
 906	enhanced upside-down Rock Pops	0		Effect: "Mayeaugh", Effect Duration: 66
 907	dry Mr. Mediocrebar	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 38
@@ -902,12 +902,12 @@
 911	magnetized Senior Mints	0		Effect: "Broken Fast", Effect Duration: 37
 912	flattened non-wet spinning mirror pixellated candy heart	0		Effect: "Spookyravin'", Effect Duration: 21
 913	dry blinking kobold	0		Effect: "Pride of the Vampire", Effect Duration: 62
-914	bouncing teal hand turkey outline	0		Free Pull, Last Available: "2004-11"
+914	teal bouncing hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	grievous intergalactic pom poms of terror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +10
 917	Mob Penguin protection contract	0		
-918	fuchsia ribald Radio Free Baseball Cap	0		Sleaze Damage: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	rosy-cheeked Radio Free Pants	0		Maximum HP Percent: +30, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	fuchsia ribald Radio Free Baseball Cap	0		Sleaze Damage: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	rosy-cheeked Radio Free Pants	0		Maximum HP Percent: +30, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	frosty Radio Free Foil	0		Cold Spell Damage: +10, Last Available: "2006-07"
 921	small flavorless radio button candy	2	decent	
 922	blinking bouncing fortified severed rocking horse head	0		Damage Absorption: +60
@@ -915,13 +915,13 @@
 924	skewed crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	irradiated double-modified Hawking's Elixir of Brilliance	0		Effect: "Punch Another Day", Effect Duration: 11
-927	practically non-alcoholic drinkable teal Ferita Del Petto Zinfandel	1	good	Last Available: "2006-12"
+927	drinkable practically non-alcoholic teal Ferita Del Petto Zinfandel	1	good	Last Available: "2006-12"
 928	Samson's fuzzy bracelets	0		Experience (Muscle): +5
 929	nippy arse-shooting crossbow	0		Cold Damage: +10
 931	tolerable spiced rum	3	good	
 932	drinkable eggnog	3	good	
 933	tiny decent mirror candy cane	1	good	
-934	stale miniature mirror gingerbread bugbear	2	decent	
+934	miniature stale mirror gingerbread bugbear	2	decent	
 935	tumbling deadly imitation nice watch	0		Weapon Damage: +5, Single Equip, Last Available: "2004-12"
 936	fuchsia Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	shaking menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,13 +929,13 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	spinning Crimbo stocking	0		Last Available: "2004-12"
-942	bowler of extreme caution	0		Monster Level: -25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	bowler of extreme caution	0		Monster Level: -25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	flame-wreathed occult bow staff	0		Spell Damage Percent: +25, Hot Spell Damage: +10, Last Available: "2004-12"
-944	huge therapeutic bowlegged pants	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
-945	jittery twirling skewered jumbo olive	0		Last Available: "2004-12"
+944	huge therapeutic bowlegged pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+945	twirling jittery skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	lousy weak ghostly martini	2	decent	Last Available: "2004-12"
+948	weak lousy ghostly martini	2	decent	Last Available: "2004-12"
 949	drinkable grogtini	3	good	Last Available: "2004-12"
 950	drinkable cherry bomb	4	good	Last Available: "2004-12"
 951	teal wobbly extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -943,9 +943,9 @@
 953	penguin-smacking club	0		Familiar Damage: +15
 954	squat orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	twirling fez of etymology of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xLep, cap 30"
-956	jumbo bland carob chunk noodles	5	decent	
-957	fancy normal chorizo brownies	4	good	Effect: "Swimming with Sharks", Effect Duration: 25
-958	massive adequate chocolate and tomato pizza	10	good	
+956	bland jumbo carob chunk noodles	5	decent	
+957	normal fancy chorizo brownies	4	good	Effect: "Swimming with Sharks", Effect Duration: 25
+958	adequate massive chocolate and tomato pizza	10	good	
 959	red flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -988,26 +988,26 @@
 1000	Meat maid	0		
 1002	upside-down Xlyinia's notebook of temperance	0		Sleaze Resistance: +5
 1003	wobbly soda water	0		
-1004	watered-down bad bottle of tequila	2	decent	
+1004	bad watered-down bottle of tequila	2	decent	
 1005	artisanal irresponsibly strong boxed wine	9	EPIC	
 1006	delicious cherry	3	awesome	
 1007	smartaleck's coconut shell	0		Moxie Percent: +30, Familiar Effect: "1xFairy, cap 7"
 1008	gravedigger's ice cubes	0		Spooky Damage: +10
 1009	practically non-alcoholic drinkable skewed vodka martini	1	good	
-1010	spirit-forward smooth whiskey and soda	5	awesome	
+1010	smooth spirit-forward whiskey and soda	5	awesome	
 1011	lousy monkey wrench	4	decent	
 1012	bad tequila sunrise	3	decent	
-1013	strong fancy mediocre margarita	5	decent	Effect: "Bananas!", Effect Duration: 20
+1013	fancy strong mediocre margarita	5	decent	Effect: "Bananas!", Effect Duration: 20
 1014	aged mirror strawberry wine	4	awesome	
 1015	watered-down mediocre wine spritzer	2	decent	
 1016	watered-down bad twirling perpendicular hula	2	decent	
-1017	special spirit-forward mediocre bouncing ducha de oro	5	decent	Effect: "Bloody-minded", Effect Duration: 5
-1018	hand-crafted triple-distilled calle de miel	8	EPIC	
+1017	special mediocre spirit-forward bouncing ducha de oro	5	decent	Effect: "Bloody-minded", Effect Duration: 5
+1018	triple-distilled hand-crafted calle de miel	8	EPIC	
 1019	practically non-alcoholic hand-crafted red dry vodka martini	1	super EPIC	
 1020	perfectly mixed old-fashioned	3	EPIC	
 1021	perfectly mixed tequila with training wheels	3	EPIC	
-1022	enchanted tolerable practically non-alcoholic sangria	1	good	Effect: "Swordholder", Effect Duration: 45
-1023	watered-down mediocre narrow vesper	2	decent	Last Available: "2004-12"
+1022	tolerable enchanted practically non-alcoholic sangria	1	good	Effect: "Swordholder", Effect Duration: 45
+1023	mediocre watered-down narrow vesper	2	decent	Last Available: "2004-12"
 1024	bad bodyslam	4	decent	Last Available: "2004-12"
 1025	hand-crafted upside-down sangria del diablo	3	super ultra EPIC	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
@@ -1029,11 +1029,11 @@
 1043	bouncing string of beads of the blizzard	0		Cold Spell Damage: +25
 1044	bouncing string of beads of James Dean	0		Experience (Moxie): +3
 1045	plastic bottle opener of the sewer	0		Stench Damage: +25
-1046	aromatic beefy traffic cone	0		Muscle: +10, Stench Resistance: +1, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	aromatic beefy traffic cone	0		Muscle: +10, Stench Resistance: +1, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	acceptable N. O. Beer	3	good	
 1048	mixed huge oyster egg	1		
 1049	twisted oyster egg	1		
-1050	pickled mirror pulsating oyster egg	1		Effect: "Bilious Brains", Effect Duration: 50
+1050	pickled pulsating mirror oyster egg	1		Effect: "Bilious Brains", Effect Duration: 50
 1051	plastic oyster egg	0		
 1052	denatured oyster egg	1		
 1053	pickled huge oyster egg	1		Effect: "Stinkybeard", Effect Duration: 10
@@ -1052,12 +1052,12 @@
 1066	compressed cyan oyster egg	1		Effect: "Eyes for Miles", Effect Duration: 30
 1067	tumbling plastic oyster egg	0		
 1068	pickled huge fuchsia oyster egg	1		
-1069	twisted narrow squat oyster egg	1		
+1069	twisted squat narrow oyster egg	1		
 1070	dried twirling oyster egg	1		Effect: "Crimbo Nostalgia", Effect Duration: 40
 1071	plastic oyster egg	0		
 1072	altered blurry off-white oyster egg	1		Effect: "Milk Studly", Effect Duration: 35
 1073	mixed off-white oyster egg	1		Effect: "Flexibili Tea", Effect Duration: 10
-1074	pickled upside-down wobbly off-white oyster egg	1		
+1074	pickled wobbly upside-down off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	altered oyster egg	1		
 1077	boiled oyster egg	1		Effect: "Thicker, Sicker", Effect Duration: 45
@@ -1122,16 +1122,16 @@
 1136	chilled moist lipstick	0		Effect: "Here's Mud in Your Eye", Effect Duration: 21
 1137	lard-coated brawny bicycle chain	0		Muscle Percent: +20, Sleaze Spell Damage: +25
 1138	mirror mushroom fermenting solution	0		
-1139	artisanal special mushroom wine	4	EPIC	Effect: "Greasy Visage", Effect Duration: 35
-1140	delicious watered-down lime green icy mushroom wine	2	awesome	
+1139	special artisanal mushroom wine	4	EPIC	Effect: "Greasy Visage", Effect Duration: 35
+1140	watered-down delicious lime green icy mushroom wine	2	awesome	
 1141	tolerable spinning mushroom wine	4	good	
-1142	mediocre fortified pointy mushroom wine	5	decent	
+1142	fortified mediocre pointy mushroom wine	5	decent	
 1143	weak drinkable flat mushroom wine	2	good	
 1144	fancy perfectly mixed spinning cool mushroom wine	3	EPIC	Effect: "Mystically Oiled", Effect Duration: 40
 1145	tolerable watered-down knob mushroom wine	2	good	
 1146	artisanal knoll mushroom wine	3	EPIC	
 1147	practically non-alcoholic aged mushroom wine	1	awesome	
-1148	fancy artisanal shot of flower schnapps	4	EPIC	Effect: "Tremella Tremens", Effect Duration: 45
+1148	artisanal fancy shot of flower schnapps	4	EPIC	Effect: "Tremella Tremens", Effect Duration: 45
 1149	toothsome flower petal pie	3	awesome	
 1150	tolerable bouncing bottle of single-barrel whiskey	3	good	
 1151	prompt arcane researcher's discarded plastic fork	0		Experience Percent (Mysticality): +10, Adventures: +3
@@ -1141,7 +1141,7 @@
 1155	letter from King Ralph XI	0		
 1157	olive wholeberd of the scaredy-cat	0		Monster Level: -15
 1158	boiled pickled bouncing Meleegra&trade; pills	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 59
-1159	squat pulsating mariachi G-string	0		
+1159	pulsating squat mariachi G-string	0		
 1160	narrow toasty irate sombrero	0		Hot Damage: +5, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
 1162	pressed twirling handsomeness potion	0		Effect: "Wet Rub", Effect Duration: 36
@@ -1157,7 +1157,7 @@
 1172	asbestos box	0		
 1173	linoleum box	0		
 1174	wobbly chrome box	0		
-1175	blurry squat cryptic puzzle box	0		
+1175	squat blurry cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	yellow magnetic field	0		
 1178	potted cactus	0		
@@ -1186,11 +1186,11 @@
 1201	moldy urinal cake	3	crappy	
 1202	rotten Happy Birthday, Claude! cake	3	crappy	
 1203	rotten personalized birthday cake	3	crappy	
-1204	moldy jumbo three-tiered wedding cake	5	crappy	
+1204	jumbo moldy three-tiered wedding cake	5	crappy	
 1205	decent mirror babycakes	4	good	
 1206	stale velvet cake	4	decent	
 1207	stale congratulatory cake	4	decent	
-1208	normal tiny angel-food cake	1	good	
+1208	tiny normal angel-food cake	1	good	
 1209	stale devil's-food cake	3	decent	
 1210	spoiled fuchsia birthday party jellybean cheesecake	3	crappy	
 1211	cyan balloon	0		
@@ -1218,9 +1218,9 @@
 1234	spinning prompt medical-grade studded pants	0		Damage Absorption: +80, Adventures: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley, 1xLep, cap 45"
 1235	pulsating Temple Grandin's pendant of temperance	0		Familiar Weight: +7, Sleaze Resistance: +5, Four Songs, Single Equip
 1236	wobbly smelly wholesome hockey stick of furious angry rage	0		Maximum HP Percent: +10, Stench Spell Damage: +10
-1237	wobbly pulsating tapped lotus	0		
+1237	pulsating wobbly tapped lotus	0		
 1238	glowsticks	0		Familiar Weight: +5
-1239	huge blue blurry iced-out bling	0		Familiar Weight: +5
+1239	blurry blue huge iced-out bling	0		Familiar Weight: +5
 1240	tumbling limburger biker boots	0		Familiar Weight: +5
 1241	pulsating carton of clove cigarettes	0		Familiar Weight: +5
 1242	deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
@@ -1233,21 +1233,21 @@
 1249	bouncing Boss Bat britches of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	sizzling Boss Bat bling of temperance	0		Hot Damage: +10, Sleaze Resistance: +5
 1251	decent Knob shroomkabob	4	good	
-1252	gigantic adequate shroomkabob	10	good	
+1252	adequate gigantic shroomkabob	10	good	
 1253	pile of jumping beans	0		
 1254	stale jumping bean burrito	4	decent	
-1255	decent tiny upside-down jumping bean burrito	1	good	
+1255	tiny decent upside-down jumping bean burrito	1	good	
 1256	stale insanely jumping bean burrito	3	decent	
-1257	small toothsome tumbling rat scrapple	2	awesome	
+1257	toothsome small tumbling rat scrapple	2	awesome	
 1258	spinning pail of pretentious paint	0		
-1259	Usain Bolt's perfumed traffic cone	0		Stench Resistance: +5, Initiative: +80, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	Usain Bolt's perfumed traffic cone	0		Stench Resistance: +5, Initiative: +80, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wobbly wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	vaporized narrow Hatorade	1		Effect: "Heart of Green", Effect Duration: 10
 1262	blurry sinister educational off-hand balloon of the dark arts	0		Experience: +1, Spell Damage: +10, Spell Damage Percent: +100
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	decent half-sized green mirror gloomy mushroom	2	good	
+1266	half-sized decent mirror green gloomy mushroom	2	good	
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	ebony wand	0		
@@ -1257,7 +1257,7 @@
 1273	bouncing stiffened magic lamp	0		Damage Reduction: 1
 1274	altered twirling Medicinal Herb's medicinal herbs	1		
 1275	Jack Frost's basic meat skirt	0		Cold Spell Damage: +50, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	watered-down artisanal Otorian Battle Scar	2	EPIC	
+1276	artisanal watered-down Otorian Battle Scar	2	EPIC	
 1277	baleful basic meat kilt	0		Spell Damage: +25, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	meat skirt of the boozehound	0		Booze Drop: +100, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	upside-down stanky meat kilt	0		Stench Spell Damage: +25, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1286,8 +1286,8 @@
 1302	super-ionized reodorant	0		Effect: "Woad Warrior", Effect Duration: 67
 1303	shaking Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
-1305	blinking olive pulsating makeup kit	0		Familiar Weight: +15
-1306	spinning upside-down careful traffic cone of the brute	0		Muscle Percent: +30, Monster Level: -10, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1305	olive blinking pulsating makeup kit	0		Familiar Weight: +15
+1306	spinning upside-down careful traffic cone of the brute	0		Muscle Percent: +30, Monster Level: -10, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	tumbling teal unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	blood flower	0		
 1318	mirror mirror lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	spoiled immense green questionable taco	9	crappy	
+1320	immense spoiled green questionable taco	9	crappy	
 1321	cyan Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	green petrified time	0		Last Available: "2005-10"
-1323	time helmet of the businessman	0		Meat Drop: +50, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	huge studded time trousers	0		Damage Absorption: +80, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	time helmet of the businessman	0		Meat Drop: +50, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	huge studded time trousers	0		Damage Absorption: +80, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	frightening time sword	0		Spooky Damage: +5, Last Available: "2005-10"
 1326	huge yellow Dyspepsi-Cola helmet of the businessman	0		Meat Drop: +50, Familiar Effect: "3xFairy, cap 7"
 1327	blue double-paned Cloaca-Cola shield	0		Cold Resistance: +5, Damage Reduction: 4
@@ -1323,7 +1323,7 @@
 1340	bouncing Cloaca-Cola-issue combat knife	0		
 1341	chaotic Dyspepsi-Cola-issue canteen	0		Spell Critical Percent: +10, Single Equip
 1342	picture of a dead guy's girlfriend	0		
-1343	squat wobbly zombie pineal gland	0		Last Available: "2005-11"
+1343	wobbly squat zombie pineal gland	0		Last Available: "2005-11"
 1344	quadruple-denatured electrified super-activated Gummi-Gnauga	0		Effect: "Jammin'", Effect Duration: 57
 1345	dry irradiated huge Now and Earlier	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 12, Last Available: "2020-09"
 1346	extra-unsweetened ionized Sugar Cog	0		Effect: "Hippy Flavor", Effect Duration: 18
@@ -1338,7 +1338,7 @@
 1355	toothsome gray bowl of oriole's nest soup	3	awesome	
 1356	bunny liver	0		
 1357	weak hand-crafted Mt. Noob Pale Ale	2	EPIC	
-1358	shaking green narrow pirate zombie head	0		Last Available: "2005-11"
+1358	narrow green shaking pirate zombie head	0		Last Available: "2005-11"
 1359	jittery ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	Oprah's disembodied smile	0		Maximum MP Percent: +50, Single Equip
@@ -1347,9 +1347,9 @@
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	moldy tofurkey leg	4	crappy	
 1366	adequate tofurkey gravy	4	good	
-1367	special adequate herbal stuffing	4	good	Effect: "Crimbo Epiphany", Effect Duration: 15
+1367	adequate special herbal stuffing	4	good	Effect: "Crimbo Epiphany", Effect Duration: 15
 1368	spoiled can-shaped gelatinous cranberry sauce	3	crappy	
-1369	toothsome shaking olive narrow yams	4	awesome	
+1369	toothsome shaking narrow olive yams	4	awesome	
 1370	green rhinestone cowboy shirt of Gandalf	0		Spell Critical Percent: +20
 1371	sharpshooter's gingham blouse	0		Critical Hit Percent: +10
 1372	souvenir ski t-shirt of terror	0		Spooky Spell Damage: +10
@@ -1384,13 +1384,13 @@
 1402	dance instructor's rag doll	0		Experience Percent (Moxie): +10, Last Available: "2005-12"
 1403	stylish can of fake snow	0		Moxie: +25, Last Available: "2005-12"
 1404	smooth colored-light &quot;necklace&quot;	0		Moxie: +15, Last Available: "2005-12"
-1405	quilted tree skirt	0		Damage Absorption: +40, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	enchanted flavorless miniature wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	diet normal bell-shaped Crimbo cookie	1	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1405	quilted tree skirt	0		Damage Absorption: +40, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1406	flavorless miniature enchanted wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1407	normal diet bell-shaped Crimbo cookie	1	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	rotten tree-shaped Crimbo cookie	4	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	executive Unionize The Elves sign	0		Meat Drop: +40, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	Vulcanized super-adjusted energized snowcone	0		Effect: "Red Around the Gills", Effect Duration: 29, Last Available: "2006-01"
 1413	wet non-pressed teal ghostly snowcone	0		Effect: "Florid Cheeks", Effect Duration: 62, Last Available: "2006-01"
 1414	corrupted dry snowcone	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 30, Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	tarnished twirling snowcone	0		Effect: "Boletus Swoletus", Effect Duration: 27, Last Available: "2006-01"
 1418	wobbly Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	Lo Pan's razor-sharp traffic cone	0		Weapon Damage Percent: +25, Spell Critical Percent: +30, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	Lo Pan's razor-sharp traffic cone	0		Weapon Damage Percent: +25, Spell Critical Percent: +30, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	frosty ice sickle of bravery	0		Cold Spell Damage: +10, Spooky Resistance: +5, Softcore Only, Last Available: "2006-02"
 1425	personal trainer's ice baby	0		Experience Percent (Muscle): +10, Softcore Only, Last Available: "2006-02"
-1426	bouncing strapping ice pick	0		Muscle: +5, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	bouncing strapping ice pick	0		Muscle: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	teal smelly wicked ice skates	0		Spell Damage: +5, Stench Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	enchanted moldy grue egg omelette	3	crappy	Effect: "Full Bottle in front of Me", Effect Duration: 30
+1428	moldy enchanted grue egg omelette	3	crappy	Effect: "Full Bottle in front of Me", Effect Duration: 30
 1429	roll of drink tickets	0		
 1430	olive pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	immense adequate mushroom	10	good	
+1432	adequate immense mushroom	10	good	
 1433	fruit bowl	0		
 1434	narrow fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1440,7 +1440,7 @@
 1458	adequate twirling blinking Valentine's Day cake	3	good	
 1459	purple arrow'd heart balloon	0		
 1460	velvet box	0		
-1461	mirror gray upside-down squashed frog	0		
+1461	upside-down mirror gray squashed frog	0		
 1462	eye of newt	0		
 1463	upside-down salamander spleen	0		
 1464	skewed sleazy fairy gravy	0		
@@ -1474,10 +1474,10 @@
 1492	blurry mirror ninja mop of bravery	0		Spooky Resistance: +5
 1493	boxer's ridiculously overelaborate ninja weapon of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3
 1494	dry gray sugar-coated pine cone	0		Effect: "Insulated Trousers", Effect Duration: 23, Last Available: "2020-09"
-1495	rosy-cheeked traffic cone of chilblains	0		Maximum HP Percent: +30, Cold Damage: +25, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	artisanal triple-distilled gloomy mushroom wine	10	EPIC	
+1495	rosy-cheeked traffic cone of chilblains	0		Maximum HP Percent: +30, Cold Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1496	triple-distilled artisanal gloomy mushroom wine	10	EPIC	
 1497	watered-down mediocre mushroom wine	2	decent	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	shaking fake fake vomit	0		Last Available: "2006-04"
 1501	chilled ghostly pulsating tumbling explosion-flavored chewing gum	0		Effect: "Abominably Slippery", Effect Duration: 48, Last Available: "2006-04"
@@ -1487,8 +1487,8 @@
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	mediocre triple-distilled calle de miel with a fly in it	7	decent	Last Available: "2006-04"
 1507	drinkable rockin' wagon with a fly in it	3	good	Last Available: "2006-04"
-1508	aged weak perpendicular hula with a fly in it	2	awesome	Last Available: "2006-04"
-1509	drinkable spirit-forward slap and tickle with a fly in it	5	good	Last Available: "2006-04"
+1508	weak aged perpendicular hula with a fly in it	2	awesome	Last Available: "2006-04"
+1509	spirit-forward drinkable slap and tickle with a fly in it	5	good	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of Flo-Jo	0		Initiative: +100, Last Available: "2006-04"
 1512	pickled pulsating Knob Goblin pet-buffing spray	1		
@@ -1503,23 +1503,23 @@
 1522	auspicious Tesla Radio Free Jersey	0		Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	blinking pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	rock-hard weightlifter's corkscrew	0		Muscle: +15, Damage Reduction: 5, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	huge fake plastic grass	0		Last Available: "2011-01"
-1531	nasty grass skirt	0		Stench Damage: +5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	brawny grass hat	0		Muscle Percent: +20, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	nasty grass skirt	0		Stench Damage: +5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	brawny grass hat	0		Muscle Percent: +20, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	twirling smooth grass blade	0		Moxie: +15, Last Available: "2011-01"
 1534	mirror raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	blinking stanky sparkly engagement ring	0		Stench Spell Damage: +25, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	huge Usain Bolt's Grimacite goggles of the boozehound	0		Booze Drop: +100, Initiative: +80, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	huge Usain Bolt's Grimacite goggles of the boozehound	0		Booze Drop: +100, Initiative: +80, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	inspector's quilted Grimacite glaive	0		Damage Absorption: +40, Item Drop: +15, Last Available: "2008-10"
-1542	nasty educational Grimacite greaves	0		Experience: +1, Stench Damage: +5, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	nasty educational Grimacite greaves	0		Experience: +1, Stench Damage: +5, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	lime green zippy banded Grimacite garter	0		Damage Absorption: +100, Initiative: +20, Last Available: "2008-10"
 1544	upside-down ghostly stanky Grimacite galoshes of temperance	0		Stench Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2008-10"
 1545	sizzling ruddy Grimacite gorget	0		Maximum HP Percent: +40, Hot Damage: +10, Last Available: "2008-10"
@@ -1529,13 +1529,13 @@
 1549	MSG	0		
 1550	supercharged second-hand knockoff engagement ring	0		Maximum MP Percent: +30, Single Equip
 1551	mediocre bottle of Domesticated Turkey	3	decent	
-1552	watered-down lousy bottle of Definit	2	decent	
+1552	lousy watered-down bottle of Definit	2	decent	
 1553	drinkable bottle of Calcutta Emerald	3	good	
 1554	smooth watered-down blinking bottle of Lieutenant Freeman	2	awesome	
 1555	bad blinking bottle of Jorge Sinsonte	3	decent	
 1556	bad maroon boxed champagne	3	decent	
 1557	flavorless kumquat	4	decent	
-1558	flavorless jumbo tangerine	5	decent	
+1558	jumbo flavorless tangerine	5	decent	
 1559	tonic water	0		
 1560	delicious cocktail onion	3	awesome	
 1561	adequate olive raspberry	4	good	
@@ -1545,11 +1545,11 @@
 1565	bad tequila sunset	4	decent	
 1566	aged zmobie	3	awesome	Wiki Name: "Zmobie (drink)"
 1567	bad gin and tonic	3	decent	
-1568	drinkable practically non-alcoholic fuchsia upside-down vodka and tonic	1	good	
+1568	drinkable practically non-alcoholic upside-down fuchsia vodka and tonic	1	good	
 1569	smooth shaking vodka gibson	3	awesome	
-1570	delicious narrow yellow tumbling gibson	3	awesome	
+1570	delicious yellow narrow tumbling gibson	3	awesome	
 1571	enchanted drinkable parisian cathouse	3	good	Effect: "Can't Smell Nothin'", Effect Duration: 20
-1572	practically non-alcoholic perfectly mixed enchanted rabbit punch	1	super EPIC	Effect: "Wet Willied", Effect Duration: 40
+1572	perfectly mixed practically non-alcoholic enchanted rabbit punch	1	super EPIC	Effect: "Wet Willied", Effect Duration: 40
 1573	acceptable caipifruta	4	good	
 1574	lousy teqiwila	3	decent	
 1575	artisanal Divine	3	EPIC	
@@ -1557,28 +1557,28 @@
 1577	drinkable spinning tangarita	3	good	
 1578	watered-down acceptable mandarina colada	2	good	
 1579	hand-crafted gimlet	4	EPIC	
-1580	irresponsibly strong artisanal brick road	6	EPIC	
+1580	artisanal irresponsibly strong brick road	6	EPIC	
 1581	perfectly mixed vodka stratocaster	4	EPIC	
 1582	bad Neuromancer	4	decent	
 1583	aged prussian cathouse	4	awesome	
 1584	lousy huge Mae West	4	decent	
 1585	bad watered-down cyan Mon Tiki	2	decent	
 1586	acceptable teqiwila slammer	3	good	
-1587	gigantic yummy twirling Knob lo mein	6	awesome	
+1587	yummy gigantic twirling Knob lo mein	6	awesome	
 1588	jumbo flavorless asparagus lo mein	5	decent	
-1589	rotten jumbo Knoll lo mein	5	crappy	
-1590	small stale lo mein	2	decent	
+1589	jumbo rotten Knoll lo mein	5	crappy	
+1590	stale small lo mein	2	decent	
 1591	decent jittery olive lo mein	3	good	
 1592	rotten hot hi mein	3	crappy	
 1593	flavorless hi mein	4	decent	
 1594	bland hi mein	3	decent	
-1595	rotten enchanted tumbling hi mein	4	crappy	Effect: "Night Vision", Effect Duration: 35
-1596	bite-sized flavorless sleazy hi mein	1	decent	
+1595	enchanted rotten tumbling hi mein	4	crappy	Effect: "Night Vision", Effect Duration: 35
+1596	flavorless bite-sized sleazy hi mein	1	decent	
 1597	squat skewed knitted Junior LAAAAME merit badge	0		Cold Resistance: +3, Last Available: "2006-05"
 1598	ghostly Jack Frost's Senior LAAAAME merit badge	0		Cold Spell Damage: +50, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	artisanal tangarita with a fly in it	3	EPIC	
-1601	watered-down mediocre special twirling mandarina colada with a fly in it	2	decent	Effect: "Turkey-Friendly", Effect Duration: 15
+1601	watered-down special mediocre twirling mandarina colada with a fly in it	2	decent	Effect: "Turkey-Friendly", Effect Duration: 15
 1602	watered-down fancy bad prussian cathouse with a fly in it	2	decent	Effect: "Uncanny Shot", Effect Duration: 35
 1603	perfectly mixed Mae West with a fly in it	3	EPIC	
 1604	denatured blurry astronaut ice-cream	1		Last Available: "2006-05"
@@ -1592,8 +1592,8 @@
 1612	cold-filtered double-dry blinking concentrated cordial of concentration	0		Effect: "Nightstalkin'", Effect Duration: 45
 1613	jittery coffin lid of the glutton	0		Food Drop: +100, Damage Reduction: 3
 1614	jittery careful satin shield	0		Monster Level: -10, Damage Reduction: 5
-1615	family-friendly Cerebral Cloche	0		Sleaze Resistance: +1, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	huge dog trainer's Cerebral Culottes	0		Experience (familiar): +1, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	family-friendly Cerebral Cloche	0		Sleaze Resistance: +1, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	huge dog trainer's Cerebral Culottes	0		Experience (familiar): +1, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	nippy careful Cerebral Crossbow of James Dean	0		Experience (Moxie): +3, Monster Level: -10, Cold Damage: +10, Last Available: "2006-06"
 1618	mirror ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	jittery beer cartilage	0		
 1632	yellow Spanish fly trap	0		
 1633	blurry Spanish fly	0		
-1634	special aged watered-down cyan around the world	2	awesome	Effect: "Butt-Rock Hair", Effect Duration: 15
+1634	aged watered-down special cyan around the world	2	awesome	Effect: "Butt-Rock Hair", Effect Duration: 15
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	denatured blurry lotion of hotness	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 43
@@ -1619,18 +1619,18 @@
 1639	flattened lotion of spookiness	0		Effect: "Low on the Hog", Effect Duration: 61
 1640	oxidized colloidal lotion of stench	0		Effect: "Employee of the Month", Effect Duration: 29
 1641	extra-denatured moist lotion of sleaziness	0		Effect: "Empty Inside", Effect Duration: 44
-1642	weak tolerable Grimacite Bock	2	good	Last Available: "2008-11"
-1643	low-calorie spoiled mirror wedge of gray cheese	1	crappy	Last Available: "2008-11"
+1642	tolerable weak Grimacite Bock	2	good	Last Available: "2008-11"
+1643	spoiled low-calorie mirror wedge of gray cheese	1	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
 1647	stench and sauce	0		
-1648	fuchsia tumbling sleazy and sauce	0		
+1648	tumbling fuchsia sleazy and sauce	0		
 1649	bouncing brick	0		Free Pull
 1650	pulsating milk of magnesium	0		
-1651	moldy spinning upside-down foie gras	3	crappy	
+1651	moldy upside-down spinning foie gras	3	crappy	
 1652	anodized oxidized shaking candy brain	0		Effect: "Phairly Balanced", Effect Duration: 61, Last Available: "2020-09"
-1653	twirling frightening chilly thinker's jewel-eyed wizard hat	0		Mysticality: +10, Cold Damage: +5, Spooky Damage: +5, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1653	twirling frightening chilly thinker's jewel-eyed wizard hat	0		Mysticality: +10, Cold Damage: +5, Spooky Damage: +5, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
 1654	aromatic energetic wad of Crovacite	0		Maximum MP Percent: +20, Stench Resistance: +1
 1655	ghostly Newton's Herculean collar	0		Experience (Muscle): +1, Experience (Mysticality): +3
 1656	White Citadel Satisfaction Satchel	0		
@@ -1673,8 +1673,8 @@
 1693	moist super-alkaline eyedrops of newt	0		Effect: "Smoking like a Bandit", Effect Duration: 64
 1694	triple-galvanized dry squat Frogade	0		Effect: "Comic Violence", Effect Duration: 68
 1695	alkaline skewed papotion of papower	0		Effect: "Capricorn Rising", Effect Duration: 57
-1696	massive yummy fancy royal jelly taco	8	awesome	Effect: "Butt-Rock Hair", Effect Duration: 50
-1697	toothsome snack-sized tofu taco	2	awesome	
+1696	yummy fancy massive royal jelly taco	8	awesome	Effect: "Butt-Rock Hair", Effect Duration: 50
+1697	snack-sized toothsome tofu taco	2	awesome	
 1698	adequate jumping bean taco	3	good	
 1699	moldy catgut taco	3	crappy	
 1700	decent goat cheese taco	4	good	
@@ -1745,7 +1745,7 @@
 1766	Spookyraven ballroom key	0		
 1767	mirror purple pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	gigantic rotten fricasseed brains	10	crappy	
+1769	rotten gigantic fricasseed brains	10	crappy	
 1770	spoiled brains casserole	4	crappy	
 1771	gray medical-grade butcherknife	0		HP Regen Min: 7, HP Regen Max: 10
 1772	manspreader's corn holder	0		Monster Level: +10
@@ -1768,7 +1768,7 @@
 1789	blurry Mob Penguin	0		
 1790	weak drinkable mirror Ram's Face Lager	2	good	
 1791	ram horns	0		
-1792	jittery censurious Temple Grandin's Travoltan trousers of the cheetah	0		Familiar Weight: +7, Sleaze Resistance: +3, Initiative: +60, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	jittery censurious Temple Grandin's Travoltan trousers of the cheetah	0		Familiar Weight: +7, Sleaze Resistance: +3, Initiative: +60, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	yellow wicked pool cue of courage	0		Spell Damage: +5, Spooky Resistance: +3
 1794	nitrogenated handful of hand chalk	0		Effect: "Adorable Lookout", Effect Duration: 12
 1795	MacGyver's Counterclockwise Watch	0		Maximum MP: +100, Single Equip
@@ -1816,14 +1816,14 @@
 1837	huge ninth caudal vertebra	0		
 1838	tenth caudal vertebra	0		
 1839	left first rib	0		
-1840	huge ghostly left second rib	0		
+1840	ghostly huge left second rib	0		
 1841	left third rib	0		
 1842	left fourth rib	0		
 1843	left fifth rib	0		
 1844	left sixth rib	0		
 1845	left seventh rib	0		
-1846	shaking spinning left eighth rib	0		
-1847	maroon bouncing blinking left ninth rib	0		
+1846	spinning shaking left eighth rib	0		
+1847	maroon blinking bouncing left ninth rib	0		
 1848	maroon left tenth rib	0		
 1849	purple left eleventh rib	0		
 1850	huge left twelfth rib	0		
@@ -1846,7 +1846,7 @@
 1867	jittery right clavicle	0		
 1868	left humerus	0		
 1869	red right humerus	0		
-1870	teal tumbling left radius	0		
+1870	tumbling teal left radius	0		
 1871	right radius	0		
 1872	bouncing lime green left ulna	0		
 1873	lime green right ulna	0		
@@ -1891,7 +1891,7 @@
 1914	clockwork rod	0		
 1915	clockwork shank	0		
 1916	Lord Spookyraven's spectacles	0		
-1917	teal bouncing wallet	0		
+1917	bouncing teal wallet	0		
 1918	huge coin purse	0		
 1919	huge English to A. F. U. E. Dictionary	0		
 1920	bizarre illegible sheet music	0		
@@ -1925,12 +1925,12 @@
 1948	spinning lime green sizzling brawny tap shoes	0		Muscle Percent: +20, Hot Damage: +10, Single Equip
 1949	miniature moldy twirling Manetwich	2	crappy	
 1950	bottle of Vangoghbitussin	0		
-1951	triple-distilled aged bottle of Pinot Renoir	9	awesome	
+1951	aged triple-distilled bottle of Pinot Renoir	9	awesome	
 1952	yummy twirling desiccated apricot	3	awesome	
 1953	high-proof aged special huge flute of flat champagne	8	awesome	Effect: "Ermine Eyes", Effect Duration: 35
 1954	decent dehydrated caviar	3	good	
-1955	yellow upside-down styrofoam peanuts	0		
-1956	weak mediocre snifter of thoroughly aged brandy	2	decent	
+1955	upside-down yellow styrofoam peanuts	0		
+1956	mediocre weak snifter of thoroughly aged brandy	2	decent	
 1957	quill pen	0		
 1958	yellow inkwell	0		
 1959	tumbling tattered scrap of paper	0		
@@ -1965,7 +1965,7 @@
 1988	angry cow	0		
 1989	Cheshire bitten	0		
 1990	yo-yo	0		
-1991	bouncing tumbling rubber WWJD? bracelet	0		
+1991	tumbling bouncing rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
 1993	rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
@@ -1983,7 +1983,7 @@
 2006	blurry Poison Oak trading card	0		
 2007	Princess Rutabaga trading card	0		
 2008	Roo trading card	0		
-2009	spinning wobbly Woldo trading card	0		
+2009	wobbly spinning Woldo trading card	0		
 2010	The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
 2012	wobbly Arrrmetia trading card	0		
@@ -2011,7 +2011,7 @@
 2034	skewed fireproof wicker shield	0		Hot Resistance: +3, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
 2036	pressed ionized shaking radium-flavored potato chips	0		Effect: "Stench Jellied", Effect Duration: 54
-2037	liquefied wobbly shaking wintergreen-flavored potato chips	0		Effect: "Pecan Pied Piper", Effect Duration: 41
+2037	liquefied shaking wobbly wintergreen-flavored potato chips	0		Effect: "Pecan Pied Piper", Effect Duration: 41
 2038	diffused pickled bouncing ennui-flavored potato chips	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 25
 2039	narrow x-ray specs	0		Last Available: "2011-12"
 2040	shaking patchouli oil bomb	0		
@@ -2036,7 +2036,7 @@
 2060	scandalous sword of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Damage: +5
 2061	wholesome helmet	0		Maximum HP Percent: +10, Familiar Effect: "1xFairy, cap 40"
 2062	educational shield of the detective	0		Experience: +1, Item Drop: +20, Damage Reduction: 10
-2063	small normal blackberry	2	good	
+2063	normal small blackberry	2	good	
 2064	forged identification documents	0		
 2065	cyan PADL Phone	0		
 2066	skewed rosy-cheeked boxer's kick-ass kicks	0		Muscle Percent: +10, Maximum HP Percent: +30, Single Equip
@@ -2090,7 +2090,7 @@
 2114	bouncing yo	0		Last Available: "2006-12"
 2115	prehistoric spear of the boozehound	0		Booze Drop: +100, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	Herculean fire of mayonnaise	0		Experience (Muscle): +1, Sleaze Spell Damage: +50, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	Herculean fire of mayonnaise	0		Experience (Muscle): +1, Sleaze Spell Damage: +50, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	blinking medical-grade Grateful Undead T-shirt	0		HP Regen Min: 7, HP Regen Max: 10
@@ -2107,12 +2107,12 @@
 2132	slick incredibly marionette	0		Moxie: +10, Last Available: "2006-12"
 2133	dress ball	0		Last Available: "2010-12"
 2134	shaking mad scientist's sock monkey of extreme caution	0		Monster Level: -25, Last Available: "2006-12"
-2135	wobbly blurry cyan alien blob	0		Last Available: "2006-12"
+2135	cyan wobbly blurry alien blob	0		Last Available: "2006-12"
 2136	wobbly avaricious vampire duck-on-a-string of bravery	0		Spooky Resistance: +5, Meat Drop: +30, Last Available: "2006-12"
 2137	toy crazy train of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2006-12"
 2138	razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	toy mercenary	0		Last Available: "2006-12"
-2140	mirror fuchsia length of string	0		Last Available: "2011-12"
+2140	fuchsia mirror length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
 2142	ghostly block	0		Last Available: "2011-12"
 2143	jittery felt	0		Last Available: "2011-12"
@@ -2121,8 +2121,8 @@
 2146	squat evil teddy bear	0		Last Available: "2006-12"
 2147	squat evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	spoiled jumbo frank	5	crappy	Last Available: "2011-12"
-2150	miniature moldy plate of franks and beans	2	crappy	Last Available: "2011-12"
+2149	jumbo spoiled frank	5	crappy	Last Available: "2011-12"
+2150	moldy miniature plate of franks and beans	2	crappy	Last Available: "2011-12"
 2151	smooth cyan shot of blackberry schnapps	4	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	pulsating carbon nanotube frame	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	skewed hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	Herculean toy ray gun of Gandalf	0		Experience (Muscle): +1, Spell Critical Percent: +20, Last Available: "2006-12"
-2169	Temple Grandin's toy space helmet of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	Temple Grandin's toy space helmet of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	banded astronaut pants	0		Damage Absorption: +100, Item Drop: +5, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	banded astronaut pants	0		Damage Absorption: +100, Item Drop: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	narrow family-friendly toy jet pack	0		Sleaze Resistance: +1, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	squat mossy stone sphere	0		
@@ -2167,10 +2167,10 @@
 2192	sheet music	0		Last Available: "2006-12"
 2193	massive tasty candy stake	6	awesome	Last Available: "2006-12"
 2194	drinkable eggnog	3	good	Last Available: "2006-12"
-2195	flavorless huge mirror unspeakable fruitcake	3	decent	Last Available: "2006-12"
+2195	flavorless mirror huge unspeakable fruitcake	3	decent	Last Available: "2006-12"
 2196	bland gingerbread horror	3	decent	Last Available: "2006-12"
 2197	ionized but probably evil chocolate	0		Effect: "La Bamba", Effect Duration: 48, Last Available: "2006-12"
-2198	adequate tiny bat-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	tiny adequate bat-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	immense adequate skull-shaped Crimboween cookie	8	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	tasty squat tombstone-shaped Crimboween cookie	4	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	ribald plastic gift-wrapping vampire	0		Sleaze Damage: +10, Last Available: "2006-12"
@@ -2182,22 +2182,22 @@
 2207	mirror Crimbo tiki necklace of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2006-12"
 2208	clever strapping bobble-hip hula elf doll	0		Muscle: +5, Maximum MP: +20, Last Available: "2006-12"
 2209	twirling skewed narrow stanky Crimbo ukulele	0		Stench Spell Damage: +25, Last Available: "2006-12"
-2210	groovy Rosewater's Tiki lighter	0		Mysticality Percent: +30, Moxie Percent: +10, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	mirror blurry Socratic thinker's deck of tropical cards	0		Mysticality: +10, Experience (Mysticality): +1, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	tropical paperweight of the brute of horror	0		Muscle Percent: +30, Spooky Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	groovy Rosewater's Tiki lighter	0		Mysticality Percent: +30, Moxie Percent: +10, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	mirror blurry Socratic thinker's deck of tropical cards	0		Mysticality: +10, Experience (Mysticality): +1, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	tropical paperweight of the brute of horror	0		Muscle Percent: +30, Spooky Spell Damage: +25, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	green tropical Crimbo pressie	0		Last Available: "2006-12"
-2214	mirror tumbling tropical wrapping paper	0		Last Available: "2006-12"
-2215	twirling mirror foul-smelling Tropical Crimbo Hat	0		Stench Damage: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	personal trainer's Tropical Crimbo Shorts	0		Experience Percent (Muscle): +10, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
-2217	thick enchanted rotten spinning super ka-bob	5	crappy	Effect: "Sugary World View", Effect Duration: 45
-2218	enchanted normal beer basted brat	3	good	Effect: "Melancholy Burden", Effect Duration: 45
+2214	tumbling mirror tropical wrapping paper	0		Last Available: "2006-12"
+2215	twirling mirror foul-smelling Tropical Crimbo Hat	0		Stench Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	personal trainer's Tropical Crimbo Shorts	0		Experience Percent (Muscle): +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2217	enchanted thick rotten spinning super ka-bob	5	crappy	Effect: "Sugary World View", Effect Duration: 45
+2218	normal enchanted beer basted brat	3	good	Effect: "Melancholy Burden", Effect Duration: 45
 2219	shaking padded Tropical Crimbo Sword	0		Damage Absorption: +20, Last Available: "2006-12"
 2220	liquefied olive and Crimboween candy	0		Effect: "Berry Thorny", Effect Duration: 60, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	family-friendly liar's pants of the cougar	0		Moxie: +20, Sleaze Resistance: +1, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	family-friendly liar's pants of the cougar	0		Moxie: +20, Sleaze Resistance: +1, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	blinking juggler's balls of James Dean of incineration	0		Experience (Moxie): +3, Hot Spell Damage: +50, Softcore Only, Last Available: "2007-01"
 2224	upside-down beefy pink shirt	0		Muscle: +10, Softcore Only, Last Available: "2007-01"
-2225	skewed red familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
+2225	red skewed familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	yellow steel-toed evil eyeball pendant of mayonnaise	0		Damage Reduction: 9, Sleaze Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	tarnished pulsating arse-a'fire elixir	0		Effect: "Texas Elegance", Effect Duration: 56, Last Available: "2007-01"
 2228	adjusted concentrated cosmic lemonade	0		Effect: "Broken Fast", Effect Duration: 42, Last Available: "2007-01"
@@ -2212,7 +2212,7 @@
 2237	mirror pygmy blowgun	0		
 2238	mirror MacGyver's pygmy nose-bone	0		Maximum MP: +100, Single Equip
 2239	Newton's bad voodoo mask of the cougar	0		Moxie: +20, Experience (Mysticality): +3, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
-2240	wobbly tumbling bottle of alcohol	0		
+2240	tumbling wobbly bottle of alcohol	0		
 2241	pygmy spear of the cheetah	0		Initiative: +60
 2242	triple-warmed warmed pygmy pygment	0		Effect: "Improprie Tea", Effect Duration: 42
 2243	occult Socratic headhunter necktie	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Single Equip
@@ -2232,15 +2232,15 @@
 2258	spinning &quot;I Love Me, Vol. I&quot;	0		
 2259	blinking photograph of God	0		
 2260	narrow hard rock candy	0		
-2261	shaking squat hard-boiled ostrich egg	0		
+2261	squat shaking hard-boiled ostrich egg	0		
 2262	upside-down bird rib	0		
 2263	lion oil	0		
 2264	moldy super-sized stunt nuts	5	crappy	
-2265	tiny decent narrow wet stew	1	good	
+2265	decent tiny narrow wet stew	1	good	
 2266	upside-down wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	rock-hard Staff of Fats	0		Damage Reduction: 5
-2269	rotten half-sized sausage wonton	2	crappy	
+2269	half-sized rotten sausage wonton	2	crappy	
 2270	Usain Bolt's belt of the ox	0		Muscle: +20, Initiative: +80, Single Equip
 2271	spirit-forward acceptable bottle of Merlot	5	good	
 2272	artisanal bottle of Port	3	EPIC	
@@ -2249,7 +2249,7 @@
 2275	acceptable bottle of Marsala	3	good	
 2276	mediocre bottle of Muscat	3	decent	
 2277	Fernswarthy's key	0		
-2278	wobbly blurry Fernswarthy's letter	0		
+2278	blurry wobbly Fernswarthy's letter	0		
 2279	bouncing book	0		
 2280	mirror Manual of Labor	0		
 2281	narrow Manual of Transmission	0		
@@ -2262,8 +2262,8 @@
 2288	encoder ring	0		Single Equip
 2289	paperclip	0		
 2290	really house	0		
-2291	narrow upside-down Non-Essential Amulet	0		
-2292	blue blurry wine vinaigrette	0		
+2291	upside-down narrow Non-Essential Amulet	0		
+2292	blurry blue wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
 2294	Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	marinated stakes	0		
@@ -2274,21 +2274,21 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	squat worm-riding hooks	0		
-2303	narrow upside-down Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	upside-down narrow Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	diffused jittery candy heart	0		Effect: "Tearful, Fearful", Effect Duration: 12, Last Available: "2007-02"
 2305	anodized pink candy heart	0		Effect: "Phorcefullness", Effect Duration: 22, Last Available: "2007-02"
 2306	dry dry wobbly candy heart	0		Effect: "Work For Hours a Week", Effect Duration: 55, Last Available: "2007-02"
-2307	non-oxidized mirror ghostly candy heart	0		Effect: "La Bamba", Effect Duration: 23, Last Available: "2007-02"
+2307	non-oxidized ghostly mirror candy heart	0		Effect: "La Bamba", Effect Duration: 23, Last Available: "2007-02"
 2308	pressed magnetized candy heart	0		Effect: "Demonic Taint", Effect Duration: 35, Last Available: "2007-02"
 2309	wet candy heart	0		Effect: "Neuroplastici Tea", Effect Duration: 18, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
-2312	blinking gray candygram	0		Last Available: "2007-02"
+2312	gray blinking candygram	0		Last Available: "2007-02"
 2313	spinning candygram	0		Last Available: "2007-02"
 2314	maroon candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
 2316	pulsating broken carburetor	0		
-2317	spinning narrow bronze token	0		
+2317	narrow spinning bronze token	0		
 2318	bomb	0		
 2319	bouncing yellow carved wheel	0		
 2320	tumbling tumbling worm-riding manual page	0		
@@ -2303,7 +2303,7 @@
 2329	huge handful of confetti	0		
 2330	skewed chocolate-covered diamond-studded roses	0		
 2331	narrow skewed bouquet of circular saw blades	0		
-2332	tiny special adequate Better Than Cuddling Cake	1	good	Effect: "Carrrsmic", Effect Duration: 45
+2332	special tiny adequate Better Than Cuddling Cake	1	good	Effect: "Carrrsmic", Effect Duration: 45
 2333	ninja snowman	0		
 2334	pulsating Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2313,7 +2313,7 @@
 2339	lousy extra-dry Blackfly Chardonnay	5	decent	
 2340	smooth & tan	3	awesome	
 2341	pepper	0		
-2342	super-sized decent skewed forest cake	5	good	
+2342	decent super-sized skewed forest cake	5	good	
 2343	rotten skewed forest ham	4	crappy	
 2344	activated teal squat filthworm hatchling scent gland	0		Effect: "Celestial Vision", Effect Duration: 38
 2345	modified filthworm drone scent gland	0		Effect: "Well-Lubed", Effect Duration: 65
@@ -2338,7 +2338,7 @@
 2364	tumbling resourceful Zim Merman's guitar	0		Maximum MP: +50
 2365	mansplainer's C.A.R.N.I.V.O.R.E. button	0		Monster Level: +15
 2366	reassuring peel hat	0		Spooky Resistance: +1, Familiar Effect: "atk, 1xVolley"
-2367	pulsating twirling carbonated soy milk	0		
+2367	twirling pulsating carbonated soy milk	0		
 2368	wobbly skewed greasy cool flowing hippy skirt	0		Moxie: +5, Sleaze Spell Damage: +10, Familiar Effect: "stench atk, 1xFairy, cap 45"
 2369	filthy poultice	0		
 2370	blinking natural fennel soda	0		
@@ -2347,7 +2347,7 @@
 2373	decent banana	3	good	
 2374	banana peel	0		
 2375	fancy adequate banana cream pie	4	good	Effect: "Braaaains Over Braaaawwn", Effect Duration: 15
-2376	smooth weak skewed banana daiquiri	2	awesome	
+2376	weak smooth skewed banana daiquiri	2	awesome	
 2377	high-proof acceptable bungle in the jungle	7	good	
 2378	banana spritzer	0		
 2379	quadruple-warmed adjusted banana smoothie	0		Effect: "Superhuman Sarcasm", Effect Duration: 15
@@ -2355,7 +2355,7 @@
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	wobbly class ring	0		
 2383	blinking class ring	0		
-2384	bouncing gray class ring	0		
+2384	gray bouncing class ring	0		
 2385	maroon bottle opener belt buckle	0		Single Equip
 2386	wobbly Annie Oakley's keg shield of Tarzan	0		Experience (Muscle): +3, Critical Hit Percent: +20, Damage Reduction: 11
 2387	medical-grade finger	0		HP Regen Min: 7, HP Regen Max: 10
@@ -2415,10 +2415,10 @@
 2441	yellow Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	Jim Carey's cool pink glowstick	0		Moxie: +5, Monster Level: +25, Last Available: "2007-03"
-2444	special drinkable Supernova Champagne	3	good	Effect: "Inner Warmth", Effect Duration: 5
+2444	drinkable special Supernova Champagne	3	good	Effect: "Inner Warmth", Effect Duration: 5
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
-2447	upside-down skewed bad penguin egg	0		Free Pull
+2447	skewed upside-down bad penguin egg	0		Free Pull
 2448	tasteful bow tie	0		Familiar Weight: +5
 2449	spinning six-pack of New Cloaca-Cola	0		
 2450	empty Cloaca-Cola bottle	0		
@@ -2490,12 +2490,12 @@
 2517	lime green Socratic stylish chain necklace	0		Moxie: +25, Experience (Mysticality): +1
 2518	blurry knitted sawblade shield	0		Cold Resistance: +3, Damage Reduction: 11
 2519	perfectly mixed upside-down McMillicancuddy's Special Lager	3	EPIC	
-2520	bad practically non-alcoholic squat melted Jell-o shot	1	decent	
-2521	perfectly mixed practically non-alcoholic cruelty-free wine	1	EPIC	
-2522	irresponsibly strong bad mirror thistle wine	6	decent	
+2520	practically non-alcoholic bad squat melted Jell-o shot	1	decent	
+2521	practically non-alcoholic perfectly mixed cruelty-free wine	1	EPIC	
+2522	bad irresponsibly strong mirror thistle wine	6	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	adequate super-sized fish	5	good	
+2525	super-sized adequate fish	5	good	
 2526	rotten fish casserole	3	crappy	
 2527	normal wobbly fish lasagna	4	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
@@ -2518,7 +2518,7 @@
 2545	altered altered narrow upsy daisy	0		Effect: "Magically Delicious", Effect Duration: 43, Last Available: "2007-05"
 2546	boiled blurry half-orchid	0		Effect: "Squid Squint", Effect Duration: 45, Last Available: "2007-05"
 2547	wobbly ghostly tin star of the ox of the storm	0		Muscle: +20, Maximum MP Percent: +40, Last Available: "2007-05"
-2548	tumbling dog trainer's coward's outrageous sombrero	0		Monster Level: -20, Experience (familiar): +1, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	tumbling dog trainer's coward's outrageous sombrero	0		Monster Level: -20, Experience (familiar): +1, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	Usain Bolt's Socratic &quot;Humorous&quot; T-shirt	0		Experience (Mysticality): +1, Initiative: +80, Last Available: "2007-05"
 2550	huge Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2535,7 +2535,7 @@
 2562	half-rotten brain	0		
 2563	bonesaw	0		
 2564	plus-sized phylactery	0		
-2565	bouncing ghostly can of Ghuol-B-Gone&trade;	0		
+2565	ghostly bouncing can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	twirling Azazel's lollipop	0		
 2568	Azazel's tutu	0		
@@ -2564,7 +2564,7 @@
 2591	spoiled tasty tart	3	crappy	
 2592	twirling Knob Goblin lunchbox	0		
 2593	rotten Knob pasty	4	crappy	
-2594	practically non-alcoholic lousy lime green thermos full of Knob coffee	1	decent	
+2594	lousy practically non-alcoholic lime green thermos full of Knob coffee	1	decent	
 2595	frozen quadruple-galvanized Ben-Gal&trade; Balm	0		Effect: "Burning Ears", Effect Duration: 55
 2596	leathery cat skin	0		
 2597	olive leathery bat skin	0		
@@ -2584,13 +2584,13 @@
 2611	ghostly palm-frond cloak of the brazier	0		Hot Spell Damage: +25
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
-2614	twirling gray mojo filter	0		
-2615	adequate snack-sized savoy truffle	2	good	
-2616	spinning squat Magi-Wipes	0		
+2614	gray twirling mojo filter	0		
+2615	snack-sized adequate savoy truffle	2	good	
+2616	squat spinning Magi-Wipes	0		
 2617	boom	0		
 2618	Iiti Kitty phone charm of dire peril	0		Weapon Damage: +20, Single Equip
 2619	green jar of swamp gas	0		Last Available: "2007-05"
-2620	low-calorie bland unidentified jerky	1	decent	
+2620	bland low-calorie unidentified jerky	1	decent	
 2621	resourceful vibrating nasty rat mask	0		Maximum MP Percent: +10, Maximum MP: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	wool careful ratskin belt	0		Monster Level: -10, Cold Resistance: +1, Single Equip
 2623	studded rattail whip of the businessman	0		Damage Absorption: +80, Meat Drop: +50
@@ -2624,7 +2624,7 @@
 2651	lime green pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	delicious fancy S.T.L.T.	4	awesome	Effect: "Sealed Brain", Effect Duration: 50, Last Available: "2007-06"
 2653	bland honey-dew	4	decent	Last Available: "2007-06"
-2654	spirit-forward mediocre Xanadian	5	decent	Last Available: "2007-06"
+2654	mediocre spirit-forward Xanadian	5	decent	Last Available: "2007-06"
 2655	ionized spinning bottle of absinthe	0		Effect: "Corona de la Salsa", Effect Duration: 64, Last Available: "2007-06"
 2656	smelly Drowsy Sword of Gandalf	0		Spell Critical Percent: +20, Stench Spell Damage: +10
 2657	moldy escargotsicle	4	crappy	Last Available: "2007-06"
@@ -2632,12 +2632,12 @@
 2659	lard-coated albatross necklace	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2007-06"
 2660	altered shaking yellow not-a-pipe	1	good	Last Available: "2007-06"
 2661	enchanted perfectly mixed pulsating flask of Amontillado	3	EPIC	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2007-06"
-2662	twirling sizzling ball mask	0		Hot Damage: +10, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	perfumed Can-Can skirt	0		Stench Resistance: +5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
-2664	unsweetened narrow blue sensitive poetry journal	0		Effect: "Outer Wolf&trade;", Effect Duration: 15, Last Available: "2007-06"
+2662	twirling sizzling ball mask	0		Hot Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	perfumed Can-Can skirt	0		Stench Resistance: +5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2664	unsweetened blue narrow sensitive poetry journal	0		Effect: "Outer Wolf&trade;", Effect Duration: 15, Last Available: "2007-06"
 2665	denatured bottled inspiration	0		Effect: "Bread-Lined", Effect Duration: 56, Last Available: "2007-06"
 2666	extra-dry bellhop bell	0		Effect: "Sugary World View", Effect Duration: 38, Last Available: "2007-06"
-2667	aerosolized triple-Vulcanized pulsating bouncing spiky collar	0		Effect: "Orc Chops", Effect Duration: 69, Last Available: "2007-06"
+2667	aerosolized triple-Vulcanized bouncing pulsating spiky collar	0		Effect: "Orc Chops", Effect Duration: 69, Last Available: "2007-06"
 2668	mixed twirling can-can-in-a-can	1		Last Available: "2007-06"
 2669	twisted ghostly patent antipsychotics	1		Last Available: "2007-06"
 2670	vaporized Mariner's Friend cough drops	1		Last Available: "2007-06"
@@ -2688,13 +2688,13 @@
 2715	sausage bomb	0		
 2716	banded Newton's battered hubcap of Flo-Jo	0		Experience (Mysticality): +3, Damage Absorption: +100, Initiative: +100, Damage Reduction: 14
 2717	Sherlock's hood ornament of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Item Drop: +25
-2718	upside-down red spare kidney	0		
+2718	red upside-down spare kidney	0		
 2719	family-friendly hand-carved bokken of courage of the glutton	0		Spooky Resistance: +3, Sleaze Resistance: +1, Food Drop: +100
 2720	mirror lightning-fast frightening toasty hand-carved bow	0		Hot Damage: +5, Spooky Damage: +5, Initiative: +40
 2721	huge toasty hand-carved staff of wisdom of the boozehound	0		Mysticality: +15, Hot Damage: +5, Booze Drop: +100
 2722	zippy Socratic Staff of the Greasefire of the bloodbag	0		Experience (Mysticality): +1, Maximum HP: +100, Item Drop: +5, Initiative: +20
 2723	Sherlock's shellacked Staff of the Grand Flamb&eacute; of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Item Drop: +25
-2724	thick adequate bouncing upside-down bowl of rye sprouts	5	good	
+2724	adequate thick bouncing upside-down bowl of rye sprouts	5	good	
 2725	low-calorie rotten cob of corn	1	crappy	
 2726	moldy juniper berries	3	crappy	
 2727	flavorless tumbling plum	3	decent	
@@ -2705,7 +2705,7 @@
 2732	drinkable watered-down shot of peach schnapps	2	good	
 2733	stale bunch of square grapes	3	decent	
 2734	yummy brown sugar cane	4	awesome	
-2735	normal half-sized blue sandwich of the gods	2	good	
+2735	half-sized normal blue sandwich of the gods	2	good	
 2736	weak tolerable upside-down Pan-Dimensional Gargle Blaster	2	good	
 2737	dehydrated leopard-print barbell	1	decent	
 2738	pile of smoking rags	0		
@@ -2713,7 +2713,7 @@
 2740	censurious crafty thinker's Staff of the Walk-In Freezer	0		Mysticality: +10, Maximum MP: +10, Sleaze Resistance: +3
 2741	mediocre boilermaker	3	decent	
 2742	yummy steel lasagna	4	quest	
-2743	high-proof mediocre steel margarita	8	quest	
+2743	mediocre high-proof steel margarita	8	quest	
 2744	distilled skewed squat steel-scented air freshener	1		Effect: "Spore-Wreathed", Effect Duration: 45
 2745	super-modified blinking gremlin mutagen	0		Effect: "Indescribable Flavor", Effect Duration: 66
 2746	alkaline wobbly extra-potent gremlin mutagen	0		Effect: "Steroid Boost", Effect Duration: 28
@@ -2738,7 +2738,7 @@
 2765	Harold's bell	0		
 2766	bowling ball	0		
 2767	decent bouncing Crimbo pie	3	good	
-2768	thick stale wobbly pear tart	5	decent	
+2768	stale thick wobbly pear tart	5	decent	
 2769	moldy miniature peach pie	2	crappy	
 2770	pressed chunk of rock salt	0		Effect: "Trivia Master", Effect Duration: 69
 2771	modified alkaline red jittery handful of pine needles	0		Effect: "Good with the Ladies", Effect Duration: 60
@@ -2789,9 +2789,9 @@
 2816	pulsating skewed fireproof healthy Boxers of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +20, Hot Resistance: +3, Familiar Effect: "1xVolley, 1xLep"
 2817	red inspector's Temple Grandin's studded Brooch	0		Damage Absorption: +80, Familiar Weight: +7, Item Drop: +15, Single Equip
 2818	wobbly rosewater-soaked supercharged Bracelet of Gandalf	0		Maximum MP Percent: +30, Spell Critical Percent: +20, Stench Resistance: +3, Single Equip
-2819	flame-wreathed Grimacite gasmask of the empath	0		Familiar Weight: +5, Hot Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	flame-wreathed Grimacite gasmask of the empath	0		Familiar Weight: +5, Hot Spell Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	blinking censurious cool Grimacite gat	0		Moxie: +5, Sleaze Resistance: +3, Last Available: "2008-11"
-2821	shaking chilly Samson's Grimacite gaiters	0		Experience (Muscle): +5, Cold Damage: +5, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	shaking chilly Samson's Grimacite gaiters	0		Experience (Muscle): +5, Cold Damage: +5, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	Usain Bolt's Grimacite gauntlets of the ox	0		Muscle: +20, Initiative: +80, Single Equip, Last Available: "2008-11"
 2823	extremely unsafe razor-sharp Grimacite go-go boots	0		Weapon Damage Percent: 125, Single Equip, Last Available: "2008-11"
 2824	prompt wholesome Grimacite girdle	0		Maximum HP Percent: +10, Adventures: +3, Single Equip, Last Available: "2008-11"
@@ -2804,16 +2804,16 @@
 2831	star key lime	0		
 2832	rotten digital key lime pie	4	crappy	
 2833	stale special star key lime pie	3	decent	Effect: "Permanent Halloween", Effect Duration: 50
-2834	jittery gray banded bottle-rocket crossbow of the cougar of the sewer	0		Moxie: +20, Damage Absorption: +100, Stench Damage: +25, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	jittery gray banded bottle-rocket crossbow of the cougar of the sewer	0		Moxie: +20, Damage Absorption: +100, Stench Damage: +25, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	twirling clever indie comic hipster glasses	0		Maximum MP: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	thinker's glowstick of Flo-Jo	0		Mysticality: +10, Initiative: +100, Last Available: "2007-08"
 2839	Periodical Paintbrush of Tarzan	0		Experience (Muscle): +3, Softcore Only
-2840	artisanal mirror blurry bottle of cooking sherry	3	EPIC	
+2840	artisanal blurry mirror bottle of cooking sherry	3	EPIC	
 2841	moldy packet of ketchup	3	crappy	
-2842	high-proof hand-crafted accidental cider	6	EPIC	
-2843	stale jumbo dire fudgesicle	5	decent	
+2842	hand-crafted high-proof accidental cider	6	EPIC	
+2843	jumbo stale dire fudgesicle	5	decent	
 2844	prompt beefy navel ring of navel gazing of the storm of Calamity Jane	0		Muscle: +10, Maximum MP Percent: +40, Critical Hit Percent: +15, Adventures: +3, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	jittery class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	ghostly plastic bib	0		Last Available: "2011-12"
@@ -2821,7 +2821,7 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	bad practically non-alcoholic moonberry wine cooler	1	decent	
-2851	toothsome small fine aged cheddarwurst	2	awesome	
+2851	small toothsome fine aged cheddarwurst	2	awesome	
 2852	fuchsia squat branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
@@ -2913,9 +2913,9 @@
 2940	stale miniature Surprise Egg	2	decent	
 2941	quadruple-enhanced warmed extra-quantum yellow Steal This Candy	0		Effect: "Employee of the Month", Effect Duration: 22
 2942	warmed dry pickled chocolate filthy lucre	0		Effect: "Stogied", Effect Duration: 56
-2943	adjusted boiled polymerized mirror teal Angry Farmer's Wife Candy	0		Effect: "Bread Burps", Effect Duration: 33
+2943	adjusted boiled polymerized teal mirror Angry Farmer's Wife Candy	0		Effect: "Bread Burps", Effect Duration: 33
 2945	ghostly stanky party hat of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +25, Familiar Effect: "4xLep, cap 7"
-2946	Jeselnik's manspreader's V for Vivala mask	0		Monster Level: +10, Sleaze Damage: +25, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	Jeselnik's manspreader's V for Vivala mask	0		Monster Level: +10, Sleaze Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	drinkable shot of rotgut	4	good	
 2949	improved oxidized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Elvish", Effect Duration: 52
@@ -2924,14 +2924,14 @@
 2952	red vibrating glowstick of the cougar	0		Moxie: +20, Maximum MP Percent: +10, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	blurry fuchsia energetic tip jar	0		Maximum MP Percent: +20
-2955	snack-sized bland yam candy	2	decent	
+2955	bland snack-sized yam candy	2	decent	
 2956	cocktail napkin	0		
 2957	mirror rum barrel charrrm	0		
 2958	spoiled tube of cranberry Go-Goo	3	crappy	
 2959	wholesome rum barrel charrrm bracelet	0		Maximum HP Percent: +10
 2960	spoiled skewed single-serving herbal stuffing	3	crappy	
-2961	diet rotten squat packet of tofurkey gravy	1	crappy	
-2962	moldy miniature blinking tofurkey nugget	2	crappy	
+2961	rotten diet squat packet of tofurkey gravy	1	crappy	
+2962	miniature moldy blinking tofurkey nugget	2	crappy	
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	cyan mizzenmast mop	0		
@@ -2981,7 +2981,7 @@
 3009	dog trainer's ruddy Idol of Ak'gyxoth	0		Maximum HP Percent: +40, Experience (familiar): +1
 3010	scorching Emblem of Ak'gyxoth of the businessman	0		Hot Damage: +25, Meat Drop: +50
 3011	sinister altar fragment	0		
-3012	cyan upside-down shimmering rainbow sand	0		
+3012	upside-down cyan shimmering rainbow sand	0		
 3013	simple key	0		
 3014	ornate key	0		
 3015	gilded key	0		
@@ -2994,20 +2994,20 @@
 3022	green jittery medium stone triangle	0		
 3023	small stone triangle	0		
 3024	stone pyramid	0		
-3025	tolerable irresponsibly strong corpse on the beach	7	good	
-3026	watered-down mediocre corpsetini	2	decent	
+3025	irresponsibly strong tolerable corpse on the beach	7	good	
+3026	mediocre watered-down corpsetini	2	decent	
 3027	hand-crafted corpsedriver	3	super EPIC	
 3028	drinkable ghostly Corpse Island iced tea	4	good	
-3029	high-proof hand-crafted red-headed corpse	9	EPIC	
+3029	hand-crafted high-proof red-headed corpse	9	EPIC	
 3030	weak perfectly mixed kamicorpse-ee	2	EPIC	
 3031	acceptable corpsel	3	good	
-3032	fortified smooth mirror corpsebite	5	awesome	
+3032	smooth fortified mirror corpsebite	5	awesome	
 3033	pirate fledges of extreme caution	0		Monster Level: -25
 3034	bouncing piece of thirteen	0		
 3035	bland miniature pearl onion	2	decent	
 3036	rotten mirror sea biscuit	3	crappy	
 3037	strong smooth bottle of rum	5	awesome	
-3038	tolerable irresponsibly strong bottle of black-label rum	9	good	
+3038	irresponsibly strong tolerable bottle of black-label rum	9	good	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
@@ -3017,7 +3017,7 @@
 3045	bland nanite-infested gingerbread bugbear	4	decent	Last Available: "2007-12"
 3046	rotten green nanite-infested candy cane	4	crappy	Last Available: "2020-09"
 3047	normal nanite-infested fruitcake	3	good	Last Available: "2007-12"
-3048	watered-down drinkable nanite-infested eggnog	2	good	Last Available: "2007-12"
+3048	drinkable watered-down nanite-infested eggnog	2	good	Last Available: "2007-12"
 3049	pulsating El Vibrato power sphere	0		
 3050	inspector's eyepatch	0		Item Drop: +15, Familiar Effect: "spooky atk, 1xBarrr"
 3051	lard-coated cutlass	0		Sleaze Spell Damage: +25
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	ionized super-boiled bouncing candy heart	0		Effect: "Thick, Sick", Effect Duration: 14, Last Available: "2007-02"
 3055	flattened cymbal syrup	0		Free Pull, Effect: "Mer-kindliness", Effect Duration: 27, Last Available: "2007-02"
-3056	frightening metallic foil cat ears	0		Spooky Damage: +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	frightening metallic foil cat ears	0		Spooky Damage: +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3041,7 +3041,7 @@
 3069	laser cannon	0		Last Available: "2007-12"
 3070	plexifoam chin strap	0		Last Available: "2007-12"
 3071	shaking silicon-infused gluteal shield	0		Last Available: "2007-12"
-3072	blue squat carbonite visor	0		Last Available: "2007-12"
+3072	squat blue carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
 3074	polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	blue General Assembly Module	0		Last Available: "2007-12"
@@ -3057,14 +3057,14 @@
 3085	arcane researcher's wizardly roboduck-on-a-string	0		Mysticality: +25, Experience Percent (Mysticality): +10, Last Available: "2007-12"
 3086	green mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	biomechanical crimborg helmet of the brazier of courage	0		Hot Spell Damage: +25, Spooky Resistance: +3, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	biomechanical crimborg helmet of the brazier of courage	0		Hot Spell Damage: +25, Spooky Resistance: +3, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	huge MacGyver's C.B.F.G. of the wise owl	0		Mysticality: +20, Maximum MP: +100, Last Available: "2007-12"
-3090	rosy-cheeked fortified biomechanical crimborg leg armor	0		Damage Absorption: +60, Maximum HP Percent: +30, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	rosy-cheeked fortified biomechanical crimborg leg armor	0		Damage Absorption: +60, Maximum HP Percent: +30, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	chilled spinning vitachoconutriment capsule	0		Effect: "Alpine Mintiness", Effect Duration: 47, Last Available: "2007-12"
 3092	beefcake's handmade hobby horse	0		Muscle: +25, Last Available: "2007-12"
 3093	blurry Van der Graaf ball-in-a-cup	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-12"
 3094	fireproof set of jacks	0		Hot Resistance: +3, Last Available: "2007-12"
-3095	tasty huge green laser-broiled pear	7	awesome	Last Available: "2007-12"
+3095	huge tasty green laser-broiled pear	7	awesome	Last Available: "2007-12"
 3096	ghostly stylish polyalloy shield of incineration	0		Moxie: +25, Hot Spell Damage: +50, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
@@ -3086,19 +3086,19 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	yellow old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	blinking Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
-3119	blinking shaking maroon divine can of silly string	0		Last Available: "2008-01"
+3119	blinking maroon shaking divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
 3121	narrow divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
 3123	green divine champagne flute	0		Last Available: "2008-01"
 3124	diffused electrified bouncing fruitfilm	0		Effect: "Libra Rising", Effect Duration: 39
 3125	double-unsweetened gray piece of after eight	0		Effect: "Overstimulated", Effect Duration: 60
-3126	narrow upside-down hobo nickel	0		
+3126	upside-down narrow hobo nickel	0		
 3127	sandcastle	0		
 3128	blinking marshmallow	0		
-3129	adequate low-calorie fancy roasted marshmallow	1	good	Effect: "Devil Inside", Effect Duration: 5
+3129	fancy adequate low-calorie roasted marshmallow	1	good	Effect: "Devil Inside", Effect Duration: 5
 3130	fuchsia disc	0		Last Available: "2008-01"
 3131	diet adequate tin cup of mulligan stew	1	good	
 3132	flamin' bindle of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100
@@ -3126,26 +3126,26 @@
 3154	squat El Vibrato punchcard (182 holes)	0		
 3155	El Vibrato punchcard (176 holes)	0		
 3156	El Vibrato punchcard (104 holes)	0		
-3157	blinking blue El Vibrato drone	0		
+3157	blue blinking El Vibrato drone	0		
 3158	sparking El Vibrato drone	0		
 3159	ionized warm El Vibrato drone	0		Effect: "Sleazy Weapon", Effect Duration: 30
 3160	pressed humming El Vibrato drone	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 56
-3161	concentrated activated alkaline blinking wobbly El Vibrato drone	0		Effect: "Mo' Hobo", Effect Duration: 56
+3161	concentrated activated alkaline wobbly blinking El Vibrato drone	0		Effect: "Mo' Hobo", Effect Duration: 56
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	blue upside-down broken El Vibrato drone	0		
 3166	narrow repaired El Vibrato drone	0		
 3167	narrow augmented El Vibrato drone	0		
-3168	vacuum-sealed improved corrupted pulsating bouncing skewed seal eyeball	0		Effect: "Using Protection", Effect Duration: 17
+3168	vacuum-sealed improved corrupted bouncing skewed pulsating seal eyeball	0		Effect: "Using Protection", Effect Duration: 17
 3169	super-sized rotten turtle soup	5	crappy	Effect: "[598]A Little Bit Evil"
-3170	bouncing skewed evil noodles	0		
+3170	skewed bouncing evil noodles	0		
 3171	nauseating reagent	0		
 3172	spinning evil paper umbrella of the brazier	0		Hot Spell Damage: +25
 3173	extra-frozen evil vihuela	0		Effect: "Stop and Smell the Fudge", Effect Duration: 30
 3174	adequate evil boring spaghetti	3	good	
 3175	spoiled evil noodles	4	crappy	
-3176	jumbo stale blurry evil noodles	5	decent	
+3176	stale jumbo blurry evil noodles	5	decent	
 3177	normal evil painful penne pasta	3	good	
 3178	moldy blue 3vi1 pr0n m4nic0tti	4	crappy	
 3179	adequate evil ravioli della hippy	4	good	
@@ -3154,13 +3154,13 @@
 3182	enhanced red evil libation of liveliness	0		Effect: "Extra-Thick Blood", Effect Duration: 55
 3183	deionized Vulcanized evil tomato juice of powerful power	0		Effect: "Chalky White Pallor", Effect Duration: 64
 3184	moist evil eyedrops of the ermine	0		Effect: "The Solution", Effect Duration: 55
-3185	magnetized double-polymerized blinking twirling evil ointment of the occult	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 19
+3185	magnetized double-polymerized twirling blinking evil ointment of the occult	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 19
 3186	tarnished diffused jittery teal evil serum of sarcasm	0		Effect: "The Real Deal", Effect Duration: 67
 3187	denatured Vulcanized oxidized evil philter of phorce	0		Effect: "Pla-see-bo", Effect Duration: 66
 3188	perfectly mixed an evil sump'm sump'm	4	EPIC	
 3189	mediocre evil ducha de oro	3	decent	
-3190	extra-dry hand-crafted skewed evil horizontal tango	5	EPIC	
-3191	triple-distilled tolerable yellow evil roll in the hay	7	good	
+3190	hand-crafted extra-dry skewed evil horizontal tango	5	EPIC	
+3191	tolerable triple-distilled yellow evil roll in the hay	7	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	tumbling naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3179,7 +3179,7 @@
 3207	jittery dwarvish punchcard	0		
 3208	small laminated card	0		
 3209	wobbly laminated card	0		
-3210	green huge notbig laminated card	0		
+3210	huge green notbig laminated card	0		
 3211	mirror unlarge laminated card	0		
 3212	dwarvish document	0		
 3213	twirling dwarvish paper	0		
@@ -3196,14 +3196,14 @@
 3224	sewer wad	0		
 3225	irresponsibly strong acceptable fuchsia bottle of sewage schnapps	10	good	
 3226	mediocre bottle of Ooze-O	3	decent	
-3227	decent low-calorie C.H.U.M. chum	1	good	
+3227	low-calorie decent C.H.U.M. chum	1	good	
 3228	bland fancy unfortunate dumplings	4	decent	Effect: "There Wolf", Effect Duration: 45
 3229	decaying goldfish liver	0		
 3230	flattened quantum anodized oil of oiliness	0		Effect: "Booooooze", Effect Duration: 21
 3231	tattered paper crown of the cougar	0		Moxie: +20, Familiar Effect: "1xSombrero, cap 15"
-3232	stale thick skewed vanilla-frosted king cake	5	decent	Last Available: "2008-03"
+3232	thick stale skewed vanilla-frosted king cake	5	decent	Last Available: "2008-03"
 3233	inflatable duck	0		
-3234	teal blinking water wings	0		Wiki Name: "water wings"
+3234	blinking teal water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
 3236	blurry Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	wobbly Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
@@ -3232,7 +3232,7 @@
 3260	slick Chester's moustache of the blizzard of doom	0		Moxie: +10, Cold Spell Damage: +25, Spooky Spell Damage: +50, Class: "Disco Bandit", Single Equip
 3261	gravedigger's Lo Pan's Chester's bag of candy	0		Spell Critical Percent: +30, Spooky Damage: +10, Class: "Disco Bandit"
 3262	executive knitted Chester's cutoffs	0		Cold Resistance: +3, Meat Drop: +40, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	huge lime green candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	blinking bag of Saccharine Maple saplings	0		
@@ -3291,10 +3291,10 @@
 3319	Mr. Joe's bangles of Flo-Jo	0		Initiative: +100, Single Equip
 3320	wool frayed rope belt	0		Cold Resistance: +1, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	padded mayfly bait necklace of wisdom	0		Mysticality: +15, Damage Absorption: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	padded mayfly bait necklace of wisdom	0		Mysticality: +15, Damage Absorption: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	weak bad jar of fermented pickle juice	2	decent	
+3325	bad weak jar of fermented pickle juice	2	decent	
 3326	modified blurry shaking voodoo snuff	1	crappy	
 3327	rotten upside-down extra-greasy slider	3	crappy	
 3328	slick crumpled felt fedora of the detective	0		Moxie: +10, Item Drop: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3309,7 +3309,7 @@
 3337	bouncing aromatic weightlifter's dead guy's memento	0		Muscle: +15, Stench Resistance: +1, Single Equip
 3338	moldy banquet	3	crappy	
 3339	sharpened hubcap	0		
-3340	shaking ghostly maroon very caltrop	0		
+3340	maroon ghostly shaking very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	twirling hobo monkey	0		
 3343	gray bindle	0		Familiar Weight: +5
@@ -3320,7 +3320,7 @@
 3348	mattress	0		
 3349	squat dinged-up triangle	0		
 3350	smooth watered-down Ralph IX cognac	2	awesome	
-3351	tumbling tumbling twirling teal llama lama cria	0		Free Pull, Last Available: "2008-06"
+3351	tumbling tumbling teal twirling llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	enhanced unsweetened llama lama gong	0		Effect: "Berry Experiential", Effect Duration: 69, Last Available: "2008-06"
 3354	half-sized toothsome banana-frosted king cake	2	awesome	Last Available: "2008-08"
@@ -3332,8 +3332,8 @@
 3360	shaking stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	blinking tasty louse	0		Last Available: "2008-06"
-3363	special flavorless squat mole mol&eacute;	3	decent	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2008-06"
-3364	bad strong Morlock's Mark Bourbon	5	decent	Last Available: "2008-06"
+3363	flavorless special squat mole mol&eacute;	3	decent	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2008-06"
+3364	strong bad Morlock's Mark Bourbon	5	decent	Last Available: "2008-06"
 3365	denatured denatured Climate Colada	0		Effect: "Can Has Cyborger", Effect Duration: 20, Last Available: "2008-06"
 3366	adjusted pickled polarized blue digital underground potion	0		Effect: "Superheroic", Effect Duration: 27, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3368,8 +3368,8 @@
 3396	toasty razor-sharp Hodgman's lobsterskin pants	0		Weapon Damage Percent: +25, Hot Damage: +5, Familiar Effect: "atk, 1xPotato"
 3397	bouncing hale Hodgman's bow tie of Leguizamo	0		Maximum HP: +20, Monster Level: +20, Single Equip
 3398	mediocre blue Hodgman's blanket	4	decent	
-3399	enchanted artisanal jar of squeeze	3	super ultra EPIC	Effect: "Dreams and Lights", Effect Duration: 25
-3400	toothsome enchanted blue skewed bowl of fishysoisse	4	awesome	Effect: "Barking Mad", Effect Duration: 35
+3399	artisanal enchanted jar of squeeze	3	super ultra EPIC	Effect: "Dreams and Lights", Effect Duration: 25
+3400	enchanted toothsome blue skewed bowl of fishysoisse	4	awesome	Effect: "Barking Mad", Effect Duration: 35
 3401	ionized deadly lampshade	0		Effect: "Seeing Colors", Effect Duration: 20
 3402	irradiated concentrated garbage juice	0		Effect: "Tightly-Wound Spine", Effect Duration: 38
 3403	gray lewd playing card	0		
@@ -3386,14 +3386,14 @@
 3414	pulsating Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	quantum enhanced denatured jittery sterno-flavored Hob-O	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 58
 3423	magnetized dry squat skewed frostbite-flavored Hob-O	0		Effect: "Disdain of the War Snapper", Effect Duration: 47
 3424	triple-polarized flattened enhanced fry-oil-flavored Hob-O	0		Effect: "Ripping, Dripping", Effect Duration: 47
-3425	extra-colloidal chilled blinking olive shaking garbage-juice-flavored Hob-O	0		Effect: "Really Deep Breath", Effect Duration: 19
+3425	extra-colloidal chilled olive shaking blinking garbage-juice-flavored Hob-O	0		Effect: "Really Deep Breath", Effect Duration: 19
 3426	electrified yellow strawberry-flavored Hob-O	0		Effect: "Wings of the Grasshopper", Effect Duration: 55
 3427	roll of Hob-Os	0		
-3428	triple-activated pulsating narrow Everlasting Deckswabber	0		Effect: "Cold Jellied", Effect Duration: 34
+3428	triple-activated narrow pulsating Everlasting Deckswabber	0		Effect: "Cold Jellied", Effect Duration: 34
 3430	mirror bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
@@ -3404,7 +3404,7 @@
 3437	aromatic lard-coated fortified Staff of the Black Kettle	0		Damage Absorption: +60, Sleaze Spell Damage: +25, Stench Resistance: +1
 3438	skewed upside-down reassuring crafty rosy-cheeked Staff of the Well-Tempered Cauldron	0		Maximum HP Percent: +30, Maximum MP: +10, Spooky Resistance: +1
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	vaporized cyan squat prismatic wad	1	decent	Effect: "Muscle Unbound", Effect Duration: 45, Last Available: "2008-07"
+3440	vaporized squat cyan prismatic wad	1	decent	Effect: "Muscle Unbound", Effect Duration: 45, Last Available: "2008-07"
 3441	blurry maroon shellacked club of the five seasons	0		Damage Reduction: 7, Last Available: "2008-07"
 3442	rainbow crossbow of the sweet-tooth	0		Candy Drop: +100, Last Available: "2008-07"
 3443	kitten	0		
@@ -3427,10 +3427,10 @@
 3460	stale tin rations	3	decent	
 3461	ghostly haiku challenge map	0		
 3462	terrible poem	0		
-3463	drinkable weak tumbling bottle of sake	2	good	
+3463	weak drinkable tumbling bottle of sake	2	good	
 3464	round pebble of the sweet-tooth	0		Candy Drop: +100
 3465	massive normal Bash-&#332;s cereal	10	good	Wiki Name: "Bash-Os cereal"
-3466	dog trainer's banded haiku katana of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100, Experience (familiar): +1, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	dog trainer's banded haiku katana of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100, Experience (familiar): +1, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	blue bargain flash powder	0		
 3468	banded plastic baby	0		Damage Absorption: +100, Single Equip, Last Available: "2008-12"
 3469	massive tasty olive blueberry-frosted king cake	6	awesome	Last Available: "2008-12"
@@ -3438,7 +3438,7 @@
 3471	damp boot	0		
 3472	squat aromatic foul-smelling wholesome Seasonal Beret	0		Maximum HP Percent: +10, Stench Damage: +10, Stench Resistance: +1, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
-3474	diffused extra-vacuum-sealed tarnished squat lime green cranberry cordial	0		Effect: "Aquarius Rising", Effect Duration: 62
+3474	diffused extra-vacuum-sealed tarnished lime green squat cranberry cordial	0		Effect: "Aquarius Rising", Effect Duration: 62
 3475	galvanized magnetized aerosolized blackberry polite	0		Effect: "Physicali Tea", Effect Duration: 46
 3476	pickled plum lozenge	0		Effect: "Hopped Up on Goofballs", Effect Duration: 46
 3477	quadruple-diffused corrupted blue pear lozenge	0		Effect: "Heart of Green", Effect Duration: 61
@@ -3455,23 +3455,23 @@
 3488	pristine fish scale	0		
 3489	moldy beefy fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
 3490	stale glistening fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
-3491	small moldy special blurry slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
+3491	special small moldy blurry slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3492	skewed olive inspector's ruddy fish scimitar	0		Maximum HP Percent: +40, Item Drop: +15
 3493	censurious fish stick of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3
 3494	jittery smartaleck's fish bazooka of Gandalf	0		Moxie Percent: +30, Spell Critical Percent: +20
-3495	double-modified extra-modified skewed lime green sea salt crystal	0		Effect: "Reedy Pipes", Effect Duration: 27
+3495	double-modified extra-modified lime green skewed sea salt crystal	0		Effect: "Reedy Pipes", Effect Duration: 27
 3496	cold-filtered pressed gray wobbly bazookafish bubble gum	0		Effect: "Slimily Strong", Effect Duration: 67
 3497	tolerable bouncing bottle of Pete's Sake	4	good	
-3498	spinning invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	shaking upside-down beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	spinning invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	upside-down shaking beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	stale canap&eacute;s	4	decent	
 3502	twisted mirror thermos of brew	1	awesome	Last Available: "2011-12"
-3503	artisanal weak glass of brandy	2	EPIC	Last Available: "2011-12"
+3503	weak artisanal glass of brandy	2	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	huge Sinatra's LWA ring	0		Experience (Moxie): +5
-3506	twirling mirror LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3506	mirror twirling LARP membership card	0		Last Available: "2008-10"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	energetic scratch 'n' sniff sword	0		Maximum MP Percent: +20, Last Available: "2008-11"
 3509	mirror scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	Da Vinci's beefy depleted Grimacite gravy boat	0		Muscle: +10, Experience (Mysticality): +5, Last Available: "2011-12"
 3544	depleted Grimacite weightlifting belt of mayonnaise of the cheetah	0		Sleaze Spell Damage: +50, Initiative: +60, Single Equip, Last Available: "2011-12"
 3545	Jeselnik's brawny depleted Grimacite grappling hook	0		Muscle Percent: +20, Sleaze Damage: +25, Single Equip, Last Available: "2011-12"
-3546	huge baleful smooth depleted Grimacite ninja mask	0		Moxie: +15, Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	tumbling mansplainer's personal trainer's depleted Grimacite shinguards	0		Experience Percent (Muscle): +10, Monster Level: +15, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	huge baleful smooth depleted Grimacite ninja mask	0		Moxie: +15, Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	tumbling mansplainer's personal trainer's depleted Grimacite shinguards	0		Experience Percent (Muscle): +10, Monster Level: +15, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	upside-down twirling electrified medical-grade depleted Grimacite astrolabe	0		MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2011-12"
 3549	inspector's personal trainer's KoL Con Cinco Pi&ntilde;ata Bat	0		Experience Percent (Muscle): +10, Item Drop: +15, Softcore Only, Last Available: "2008-09"
 3550	pulsating Jeselnik's propeller beanie	0		Sleaze Damage: +25, Familiar Effect: "atk, cap 7"
@@ -3523,14 +3523,14 @@
 3556	spoiled sea cucumber	3	crappy	
 3557	delicious sea avocado	4	awesome	
 3558	miniature tasty sea lychee	2	awesome	
-3559	bland tiny enchanted sea tangelo	1	decent	Effect: "Sweet Incentive", Effect Duration: 40
-3560	rotten big lime green sea honeydew	5	crappy	
+3559	enchanted tiny bland sea tangelo	1	decent	Effect: "Sweet Incentive", Effect Duration: 40
+3560	big rotten lime green sea honeydew	5	crappy	
 3561	chilled ionized lime green pressurized potion of puissance	0		Effect: "Sealed Brain", Effect Duration: 30
 3562	flattened deionized pressurized potion of perspicacity	0		Effect: "Heart of Green", Effect Duration: 34
 3563	corrupted pulsating pressurized potion of pulchritude	0		Effect: "Tingling Feeling", Effect Duration: 63
 3564	weak hand-crafted berry-infused sake	2	super EPIC	
-3565	enchanted perfectly mixed watered-down citrus-infused sake	2	super EPIC	Effect: "Riboflavin'", Effect Duration: 30
-3566	special mediocre melon-infused sake	3	decent	Effect: "Chilblains of the Corn", Effect Duration: 40
+3565	perfectly mixed watered-down enchanted citrus-infused sake	2	super EPIC	Effect: "Riboflavin'", Effect Duration: 30
+3566	mediocre special melon-infused sake	3	decent	Effect: "Chilblains of the Corn", Effect Duration: 40
 3567	fuchsia slab of sponge	0		
 3568	aromatic lion tamer's Sinatra's sponge helmet	0		Experience (Moxie): +5, Experience (familiar): +2, Stench Resistance: +1, Familiar Effect: "atk, 1xFairy"
 3569	jittery lard-coated groovy beefy spongy shield	0		Muscle: +10, Moxie Percent: +10, Sleaze Spell Damage: +25, Damage Reduction: 14
@@ -3546,9 +3546,9 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	flavorless super-sized rice	5	decent	
+3582	super-sized flavorless rice	5	decent	
 3584	bland irradiated candy cane	3	decent	Last Available: "2008-12"
-3585	small adequate gingerbread mutant bugbear	2	good	Last Available: "2008-12"
+3585	adequate small gingerbread mutant bugbear	2	good	Last Available: "2008-12"
 3586	bad oozenog	4	decent	Last Available: "2008-12"
 3587	galvanized ghostly sugar plum	0		Effect: "Kindly Resolve", Effect Duration: 23, Last Available: "2008-12"
 3588	double-irradiated sugar banana	0		Effect: "Goldentongue", Effect Duration: 44, Last Available: "2008-12"
@@ -3561,7 +3561,7 @@
 3595	liquefied non-improved Mer-kin fastjuice	0		Effect: "Baconstoned", Effect Duration: 49
 3596	imitation crab crate	0		
 3597	huge imitation crab meat	0		
-3598	ghostly mirror imitation crab zoea	0		
+3598	mirror ghostly imitation crab zoea	0		
 3599	grievous Sinatra's moist sailor's cap of Calamity Jane	0		Experience (Moxie): +5, Weapon Damage Percent: +50, Critical Hit Percent: +15, Familiar Effect: "stench atk"
 3600	blue family-friendly wicked speargun	0		Spell Damage: +5, Sleaze Resistance: +1
 3601	shaking compass of the empath	0		Familiar Weight: +5
@@ -3581,28 +3581,28 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	double-chilled colloidal unstable DNA	0		Effect: "Cinnamouth", Effect Duration: 58, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	squat mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	huge parasitic claw of the storm	0		Maximum MP Percent: +40, Last Available: "2008-12"
-3625	chaotic parasitic tentacles	0		Spell Critical Percent: +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	huge Temple Grandin's parasitic headgnawer	0		Familiar Weight: +7, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	chaotic parasitic tentacles	0		Spell Critical Percent: +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	huge Temple Grandin's parasitic headgnawer	0		Familiar Weight: +7, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	energetic parasitic strangleworm	0		Maximum MP Percent: +20, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
-3630	lime green upside-down Crimbo crate	0		Last Available: "2008-12"
+3630	upside-down lime green Crimbo crate	0		Last Available: "2008-12"
 3631	warmed pressed bouncing Gummi-DNA	0		Effect: "Mercenary", Effect Duration: 23, Last Available: "2020-09"
 3632	skewed radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	toasty ruddy elven socks	0		Maximum HP Percent: +40, Hot Damage: +5, Last Available: "2008-12"
 3634	beefy elven gloves of the empath	0		Muscle: +10, Familiar Weight: +5, Last Available: "2008-12"
-3635	jittery wobbly sizzling clever festive holiday hat	0		Maximum MP: +20, Hot Damage: +10, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	jittery wobbly sizzling clever festive holiday hat	0		Maximum MP: +20, Hot Damage: +10, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	narrow asbestos-lined Jack Frost's patent shoes	0		Cold Spell Damage: +50, Hot Resistance: +5, Last Available: "2008-12"
 3637	huge purple Jeselnik's flame-wreathed gray bow tie	0		Hot Spell Damage: +10, Sleaze Damage: +25, Last Available: "2008-12"
 3638	lard-coated penguin thesaurus of courage	0		Sleaze Spell Damage: +25, Spooky Resistance: +3, Last Available: "2008-12"
-3639	enchanted rotten blob-shaped Crimbo cookie	3	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	rotten enchanted blob-shaped Crimbo cookie	3	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	shaking jamfish jam	0		
 3642	wobbly dragonfish caviar	0		
@@ -3614,7 +3614,7 @@
 3648	magic dragonfish fry	0		
 3649	bouncing map to Madness Reef	0		
 3650	spoiled toast with jam	4	crappy	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	perfectly mixed elven moonshine	4	EPIC	Last Available: "2008-12"
 3653	diet tasty olive knuckle sandwich	1	awesome	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	psycho sweater of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	upside-down frightening plastic strand of DNA	0		Spooky Damage: +5, Last Available: "2008-12"
 3660	padded plastic chunk of depleted Grimacite	0		Damage Absorption: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	blinking Oprah's Putty mitre	0		Maximum MP Percent: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	careful Putty leotard of incineration	0		Monster Level: -10, Hot Spell Damage: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	blinking Oprah's Putty mitre	0		Maximum MP Percent: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	careful Putty leotard of incineration	0		Monster Level: -10, Hot Spell Damage: +50, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	Putty ball of the detective	0		Item Drop: +20, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	frightening fortified Putty snake	0		Damage Absorption: +60, Spooky Damage: +5, Item Drop: +5, Softcore Only, Last Available: "2009-01"
@@ -3641,18 +3641,18 @@
 3675	twirling Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	curative diving muff	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
-3678	drinkable weak salinated mint julep	2	good	
+3678	weak drinkable salinated mint julep	2	good	
 3679	huge ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	lime green map to the Marinara Trench	0		
 3684	flavorless snack-sized tempura carrot	2	decent	
-3685	snack-sized stale teal tempura cucumber	2	decent	
+3685	stale snack-sized teal tempura cucumber	2	decent	
 3686	moldy tempura avocado	3	crappy	
-3687	adequate big sea broccoli	5	good	
-3688	half-sized special tasty cyan sea cauliflower	2	awesome	Effect: "A Contender", Effect Duration: 45
-3689	small adequate ghostly tempura broccoli	2	good	
+3687	big adequate sea broccoli	5	good	
+3688	tasty special half-sized cyan sea cauliflower	2	awesome	Effect: "A Contender", Effect Duration: 45
+3689	adequate small ghostly tempura broccoli	2	good	
 3690	normal thick gray tempura cauliflower	5	good	
 3691	half-sized flavorless sea blueberry	2	decent	
 3692	adequate twirling sea persimmon	3	good	
@@ -3690,9 +3690,9 @@
 3724	ghostly brittle plastic handle	0		
 3725	foggy glass globe	0		
 3726	possessed tomato	0		
-3727	yellow skewed Nardz energy beverage	0		
+3727	skewed yellow Nardz energy beverage	0		
 3728	pile of coins	0		
-3729	lime green pulsating hand grenegg	0		
+3729	pulsating lime green hand grenegg	0		
 3730	skewed caret	0		
 3731	huge crafty glass gnoll eye	0		Maximum MP: +10
 3732	irradiated cigar butt	0		Effect: "Well Owl Be!", Effect Duration: 43
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	spinning Jim Carey's smooth handwarmer	0		Moxie: +15, Monster Level: +25, Single Equip
 3737	mansplainer's curative lighter	0		Monster Level: +15, HP Regen Min: 3, HP Regen Max: 5
-3738	massive flavorless packet of beer nuts	10	decent	
+3738	flavorless massive packet of beer nuts	10	decent	
 3739	tumbling Boozehounds Anonymous token	0		
 3740	wobbly handful of bees	0		
 3741	spectral jelly	0		
@@ -3714,7 +3714,7 @@
 3749	concentrated modified wobbly concoction of clumsiness	0		Effect: "Heal Thy Nanoself", Effect Duration: 30
 3750	ghostly gravedigger's vampire pearl earring	0		Spooky Damage: +10, Single Equip
 3751	stale jumbo chocolate chip brownies	5	decent	
-3753	ghostly yellow Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	ghostly yellow Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	nitrogenated love song of vague ambiguity	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 27, Last Available: "2009-02"
 3755	irradiated extra-liquefied polarized wobbly love song of smoldering passion	0		Effect: "Vinegavotte", Effect Duration: 68, Last Available: "2009-02"
 3756	pressed skewed love song of icy revenge	0		Effect: "Red-Shirted Escort", Effect Duration: 28, Last Available: "2009-02"
@@ -3724,17 +3724,17 @@
 3760	polarized enhanced upside-down breath mint	0		Effect: "Booing Radly", Effect Duration: 59
 3761	skewed vampire pearl ring	0		Item Drop: +5, Single Equip
 3762	vampire pearl necklace of Leguizamo	0		Monster Level: +20, Single Equip
-3763	smooth fuchsia upside-down slug of vodka	4	awesome	
+3763	smooth upside-down fuchsia slug of vodka	4	awesome	
 3764	weak tolerable slug of rum	2	good	
 3765	artisanal mirror slug of shochu	3	EPIC	
 3766	acceptable spinning screwdiver	3	good	
-3767	drinkable irresponsibly strong huge huge dew yoana lei	9	good	
-3768	watered-down hand-crafted lychee chuhai	2	EPIC	
+3767	irresponsibly strong drinkable huge huge dew yoana lei	9	good	
+3768	hand-crafted watered-down lychee chuhai	2	EPIC	
 3769	acceptable salacious screwdiver	3	good	
 3770	lousy tumbling dew yoana salacious lei	4	decent	
 3771	perfectly mixed green salacious lychee chuhai	3	EPIC	
-3772	perfectly mixed watered-down Alewife&trade; Ale	2	EPIC	
-3773	red bouncing seaode	0		
+3772	watered-down perfectly mixed Alewife&trade; Ale	2	EPIC	
+3773	bouncing red seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
 3776	squat pink pinkslip slip of Tarzan of doom	0		Experience (Muscle): +3, Spooky Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr"
@@ -3753,16 +3753,16 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	skewed charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	skewed charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	asbestos-lined greasy gravedigger's Mer-kin roundshield	0		Spooky Damage: +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Damage Reduction: 14
 3804	shaking blurry gravedigger's Mer-kin breastplate of the glutton	0		Spooky Damage: +10, Food Drop: +100
 3805	cyan wool Mer-kin sneakmask of the cougar	0		Moxie: +20, Cold Resistance: +1, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
 3807	alkaline unsweetened twirling mirror Mer-kin hidepaint	0		Effect: "The Smile of Mr. A.", Effect Duration: 35
-3808	green narrow Mer-kin trailmap	0		
+3808	narrow green Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
-3810	blurry pulsating gray Mer-kin lockkey	0		
+3810	gray blurry pulsating Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
 3812	stale chocolate-frosted king cake	4	decent	Last Available: "2009-06"
 3813	spinning frosty plastic baby	0		Cold Spell Damage: +10, Single Equip, Last Available: "2009-06"
@@ -3772,22 +3772,22 @@
 3818	teal toasty crafty therapeutic halibut	0		Maximum MP: +10, Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7
 3819	eel sauce	0		
 3820	executive water-polo mitt	0		Meat Drop: +40, Single Equip
-3821	irradiated polymerized upside-down huge syringe	0		Effect: "Ironclad", Effect Duration: 64
+3821	irradiated polymerized huge upside-down syringe	0		Effect: "Ironclad", Effect Duration: 64
 3822	wand	0		Familiar Effect: "fishy spells"
 3823	triple-wet anodized dry blurry wad of cotton	0		Effect: "Hella Tough", Effect Duration: 68
 3824	Grandma's Note	0		
-3825	shaking jittery Grandma's Fuchsia Yarn	0		
+3825	jittery shaking Grandma's Fuchsia Yarn	0		
 3826	Grandma's Chartreuse Yarn	0		
 3827	blue plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	low-calorie decent tempura radish	1	good	
+3829	decent low-calorie tempura radish	1	good	
 3830	water-polo cap of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable Typical Tavern swill	4	good	
-3832	mediocre triple-distilled jittery tropical swill	9	decent	
+3832	triple-distilled mediocre jittery tropical swill	9	decent	
 3833	hand-crafted fruity girl swill	4	EPIC	
 3834	tolerable blended swill	3	good	
 3835	skewed costume wardrobe	0		Softcore Only
-3836	yellow sharpshooter's forbidden baleful arcane researcher's Elvish sunglasses	0		Experience Percent (Mysticality): +10, Spell Damage: +25, Spell Damage Percent: +50, Critical Hit Percent: +10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	yellow sharpshooter's forbidden baleful arcane researcher's Elvish sunglasses	0		Experience Percent (Mysticality): +10, Spell Damage: +25, Spell Damage Percent: +50, Critical Hit Percent: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	anniversary safety glass vest of the cheetah	0		Initiative: +60
 3838	teal anniversary burlap belt of Leguizamo	0		Monster Level: +20
 3839	blinking rosewater-soaked anniversary balsa wood socks	0		Stench Resistance: +3
@@ -3837,7 +3837,7 @@
 3883	cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	double-nitrogenated electrified vial of slime	0		Effect: "Compensatory Cruelness", Effect Duration: 62
-3886	corrupted liquefied ghostly cyan vial of slime	0		Effect: "Sweet, Nuts", Effect Duration: 40
+3886	corrupted liquefied cyan ghostly vial of slime	0		Effect: "Sweet, Nuts", Effect Duration: 40
 3887	pickled magnetized vial of slime	0		Effect: "Aloofah", Effect Duration: 24
 3888	triple-Vulcanized shaking vial of slime	0		Effect: "Booing Radly", Effect Duration: 11
 3889	moist polarized cold-filtered tumbling vial of slime	0		Effect: "Orchid Blood", Effect Duration: 63
@@ -3911,7 +3911,7 @@
 3959	cyan blinking garish pinky ring of wisdom	0		Mysticality: +15
 3960	resourceful designer sunglasses	0		Maximum MP: +50, Single Equip
 3961	rosy-cheeked opera glasses of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50
-3962	pulsating twirling designer handbag	0		
+3962	twirling pulsating designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
 3965	boiled shaking cube of billiard chalk	0		Effect: "Antsy in your Pantsy", Effect Duration: 54
@@ -3957,7 +3957,7 @@
 4005	frozen deionized ballast turtle	0		Effect: "Ice Packed", Effect Duration: 37
 4006	skewed memory of some amino acids	0		Last Available: "2009-06"
 4007	narrow narrow memory of a C	0		Last Available: "2009-06"
-4008	green twirling memory of an A	0		Last Available: "2009-06"
+4008	twirling green memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
@@ -3987,23 +3987,23 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	red caustic slime nodule	0		
 4037	stale gigantic wobbly slimy sweetbreads	9	decent	
-4038	acceptable watered-down pulsating slimy fermented bile bladder	2	good	
-4039	dried huge shaking slimy alveolus	1		Effect: "In Tuna", Effect Duration: 15
+4038	watered-down acceptable pulsating slimy fermented bile bladder	2	good	
+4039	dried shaking huge slimy alveolus	1		Effect: "In Tuna", Effect Duration: 15
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	gravedigger's healthy pig-iron helm	0		Maximum HP Percent: +20, Spooky Damage: +10, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	mirror knitted scorching pig-iron shinguards	0		Hot Damage: +25, Cold Resistance: +3, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	gravedigger's healthy pig-iron helm	0		Maximum HP Percent: +20, Spooky Damage: +10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	mirror knitted scorching pig-iron shinguards	0		Hot Damage: +25, Cold Resistance: +3, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	sharpshooter's pig-iron bracers of the scaredy-cat	0		Critical Hit Percent: +10, Monster Level: -15, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	shaking wumpus-hair bolo	0		Last Available: "2009-06"
 4046	blinking wumpus-hair net	0		Last Available: "2009-06"
 4047	shaking maroon educational wumpus-hair whip	0		Experience: +1, Last Available: "2009-06"
-4048	olive hardy wumpus-hair wig of Tarzan of extreme caution	0		Experience (Muscle): +3, Maximum HP: +50, Monster Level: -25, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	steel-toed Fonzie's brawny wumpus-hair loincloth	0		Muscle Percent: +20, Experience (Moxie): +1, Damage Reduction: 9, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	olive hardy wumpus-hair wig of Tarzan of extreme caution	0		Experience (Muscle): +3, Maximum HP: +50, Monster Level: -25, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	steel-toed Fonzie's brawny wumpus-hair loincloth	0		Muscle Percent: +20, Experience (Moxie): +1, Damage Reduction: 9, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	toasty wumpus-hair sweater of the empath	0		Familiar Weight: +5, Hot Damage: +5, Last Available: "2009-06"
 4051	thinker's ring of teleportation	0		Mysticality: +10, Single Equip
 4052	glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	banana milkshake	1	decent	Last Available: "2009-06"
-4054	special practically non-alcoholic hand-crafted White Hyborian	1	EPIC	Effect: "Healthy Green Glow", Effect Duration: 30, Last Available: "2009-06"
+4054	special hand-crafted practically non-alcoholic White Hyborian	1	EPIC	Effect: "Healthy Green Glow", Effect Duration: 30, Last Available: "2009-06"
 4055	family-friendly goblin hunting spear	0		Sleaze Resistance: +1, Last Available: "2009-06"
 4056	skewed aromatic clever goblin autoblowgun	0		Maximum MP: +20, Stench Resistance: +1, Last Available: "2009-06"
 4057	tribal beads of bravery	0		Spooky Resistance: +5, Last Available: "2009-06"
@@ -4012,7 +4012,7 @@
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
-4063	wobbly ghostly Mecha Mayhem Club Card	0		Last Available: "2009-06"
+4063	ghostly wobbly Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
@@ -4032,9 +4032,9 @@
 4080	grisly shield of the glutton	0		Item Drop: +5, Food Drop: +100, Slime Hates It: +1, Damage Reduction: 13
 4081	blinking horrifying corroded breeches	0		Spooky Damage: +25, Item Drop: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	spinning inspector's pernicious cudgel of Leguizamo	0		Monster Level: +20, Item Drop: +15, Slime Hates It: +1
-4083	toothsome tiny shaking cupcake-in-a-cup	1	awesome	Last Available: "2009-06"
+4083	tiny toothsome shaking cupcake-in-a-cup	1	awesome	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	spoiled special protein paste	3	crappy	Effect: "Eggs-tra Sensory Perception", Effect Duration: 40, Last Available: "2009-06"
+4085	special spoiled protein paste	3	crappy	Effect: "Eggs-tra Sensory Perception", Effect Duration: 40, Last Available: "2009-06"
 4086	hale cyber-mattock of temperance	0		Maximum HP: +20, Sleaze Resistance: +5, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4079,13 +4079,13 @@
 4127	wobbly spinning sage hardened slime hat of chilblains of the detective	0		Mysticality Percent: +10, Cold Damage: +25, Item Drop: +20, Familiar Effect: "1xFairy"
 4128	censurious family-friendly hardened slime pants of the detective	0		Sleaze Resistance: 4, Item Drop: +20, Familiar Effect: "atk, 1xPotato"
 4129	squat smelly lion tamer's hardened slime belt of courage	0		Experience (familiar): +2, Stench Spell Damage: +10, Spooky Resistance: +3, Single Equip
-4130	bouncing shaking empty agua de vida bottle	0		Last Available: "2009-06"
+4130	shaking bouncing empty agua de vida bottle	0		Last Available: "2009-06"
 4131	dehydrated jittery boot plant	1	awesome	Effect: "Kindly Resolve", Effect Duration: 20, Last Available: "2009-06"
 4132	perfectly mixed high-proof sham champagne	10	EPIC	Last Available: "2009-06"
 4133	extra-pressed activated tempura air	0		Effect: "Ninja, Please", Effect Duration: 56
 4134	alkaline pressurized potion of pneumaticity	0		Effect: "Hammered", Effect Duration: 36
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	Usain Bolt's ruddy padded Bag o' Tricks of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Maximum HP Percent: +40, Initiative: +80, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	Usain Bolt's ruddy padded Bag o' Tricks of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Maximum HP Percent: +40, Initiative: +80, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4109,7 +4109,7 @@
 4157	gravel	0		Last Available: "2009-09"
 4158	wobbly rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	extra-dry artisanal pebblebr&auml;u	5	EPIC	Last Available: "2009-09"
+4160	artisanal extra-dry pebblebr&auml;u	5	EPIC	Last Available: "2009-09"
 4161	stale tumbling rocky road ice cream	4	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	quantum dry colloidal green children of the candy corn	0		Effect: "Ooh, Salty!", Effect Duration: 36
@@ -4125,13 +4125,13 @@
 4173	extremely unsafe rock pants	0		Weapon Damage Percent: +100, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
 4174	lime green Tesla rock necklace	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 4175	spaghetti cult robe	0		
-4176	maroon upside-down sugar sheet	0		Last Available: "2009-09"
+4176	upside-down maroon sugar sheet	0		Last Available: "2009-09"
 4177	Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	dangerous sugar shotgun	0		Weapon Damage: +10, Last Available: "2009-09"
 4179	sugar shillelagh of Flo-Jo	0		Initiative: +100, Last Available: "2009-09"
 4180	wool sugar shank	0		Cold Resistance: +1, Last Available: "2009-09"
-4181	greedy auspicious fireproof sugar chapeau	0		Hot Resistance: +3, Item Drop: +10, Meat Drop: +20, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	squat Sinatra's sugar shorts	0		Experience (Moxie): +5, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	greedy auspicious fireproof sugar chapeau	0		Hot Resistance: +3, Item Drop: +10, Meat Drop: +20, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	squat Sinatra's sugar shorts	0		Experience (Moxie): +5, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	gray sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4178,7 +4178,7 @@
 4226	upside-down steel-toed Star of Bravery	0		Damage Reduction: 9, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	bouncing perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	upside-down bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	blurry ice skate doll	0		
@@ -4197,7 +4197,7 @@
 4245	bookmark	0		
 4246	maroon wizardly ivory cue ball	0		Mysticality: +25
 4247	drinkable weak decanter of fine Scotch	2	good	
-4248	mixed skewed tumbling jittery expensive cigar	1		
+4248	mixed skewed jittery tumbling expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	pulsating fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	normal upside-down chocolate-covered scarab beetle	3	good	Last Available: "2009-10"
 4259	bad mulled cider	4	decent	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	squat Ax of L'rose	0		Last Available: "2009-10"
-4264	crafty bark boxers	0		Maximum MP: +10, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	smartaleck's bark beret	0		Moxie Percent: +30, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	crafty bark boxers	0		Maximum MP: +10, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	smartaleck's bark beret	0		Moxie Percent: +30, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	hale bark bracelet	0		Maximum HP: +20, Single Equip
 4267	wobbly wobbly prompt groovy Krakrox's Loincloth	0		Moxie Percent: +10, Adventures: +3, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	jittery censurious crafty Galapagosian Cuisses	0		Maximum MP: +10, Sleaze Resistance: +3, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4282,7 +4282,7 @@
 4330	decent candy kneecapping stick	3	good	Last Available: "2009-12"
 4331	normal licorice garrote	3	good	Last Available: "2009-12"
 4332	spinning candy knuckles of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-12"
-4333	special flavorless skewed jawbruiser	3	decent	Effect: "Abyssal Tears", Effect Duration: 15, Last Available: "2010-12"
+4333	flavorless special skewed jawbruiser	3	decent	Effect: "Abyssal Tears", Effect Duration: 15, Last Available: "2010-12"
 4334	non-cold-filtered tarnished chocolate car	0		Effect: "Blubbered Up", Effect Duration: 62, Last Available: "2009-12"
 4335	pulsating plastic 11 Dealer of the businessman	0		Meat Drop: +50, Last Available: "2009-12"
 4336	perfumed plastic Crimbo Casino	0		Stench Resistance: +5, Last Available: "2009-12"
@@ -4298,24 +4298,24 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	lime green leftover Crimbo rations	0		Last Available: "2009-12"
-4349	teal huge frosty snow hat	0		Cold Spell Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	narrow veiny snow pants	0		Maximum HP: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	teal huge frosty snow hat	0		Cold Spell Damage: +10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	narrow veiny snow pants	0		Maximum HP: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	studded snow belly	0		Damage Absorption: +80, Single Equip, Last Available: "2009-12"
 4352	wobbly pile of loose snow	0		Last Available: "2009-12"
 4353	upside-down Crimbough	0		Last Available: "2009-12"
 4354	A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	upside-down A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	narrow A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
-4357	tumbling huge A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
+4357	huge tumbling A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	teal A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	wobbly A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	spoiled expired can of franks 'n' beans	4	crappy	Last Available: "2009-12"
-4361	triple-distilled tolerable expired bottle of peppermint schnapps	8	good	Last Available: "2009-12"
+4361	tolerable triple-distilled expired bottle of peppermint schnapps	8	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
-4364	pressed corrupted squat green elven suicide capsule	0		Effect: "Ooh, Salty!", Effect Duration: 47, Last Available: "2009-12"
+4364	pressed corrupted green squat elven suicide capsule	0		Effect: "Ooh, Salty!", Effect Duration: 47, Last Available: "2009-12"
 4365	bland pulsating penguin focaccia bread	3	decent	Last Available: "2009-12"
-4366	bad irresponsibly strong herringcello	10	decent	Last Available: "2009-12"
+4366	irresponsibly strong bad herringcello	10	decent	Last Available: "2009-12"
 4367	artisanal wobbly elven cellocello	4	EPIC	Last Available: "2009-12"
 4368	mirror wrench handle	0		Last Available: "2009-12"
 4369	lime green handful of headless bolts	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	inspector's pocketwatch on a chain of the storm	0		Maximum MP Percent: +40, Item Drop: +15, Last Available: "2009-12"
 4386	healthy boxer's cement sandals	0		Muscle Percent: +10, Maximum HP Percent: +20, Single Equip, Last Available: "2009-12"
 4387	pulsating grievous night-vision goggles of vim and vigor	0		Weapon Damage Percent: +50, Maximum HP Percent: +50, Single Equip, Last Available: "2009-12"
-4388	jittery pulsating passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	pulsating jittery passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	coward's peanut brittle shield	0		Monster Level: -20, Damage Reduction: 3, Last Available: "2009-12"
 4390	bouncing smelly medical-grade Red Rover BB gun	0		Stench Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-12"
-4391	skewed toasty red-and-green sweater	0		Hot Damage: +5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	skewed toasty red-and-green sweater	0		Hot Damage: +5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	alkaline Crimbo peppermint bark	0		Effect: "Crimbo Epiphany", Effect Duration: 33, Last Available: "2009-12"
 4394	frozen Crimbo fudge	0		Effect: "Blood-Rich", Effect Duration: 42, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	skewed Tesla cheese sword	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2010-01"
-4400	huge cheese diaper of bravery	0		Spooky Resistance: +5, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	huge cheese diaper of bravery	0		Spooky Resistance: +5, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	bouncing cheese wheel of the detective	0		Item Drop: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	jittery fireproof cheese eye	0		Hot Resistance: +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	jittery fireproof cheese eye	0		Hot Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	red Jack Frost's energetic cool Staff of Queso Escusado	0		Moxie: +5, Maximum MP Percent: +20, Cold Spell Damage: +50, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	bouncing The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	flavorless pulsating quantum taco	0		Last Available: "2010-10"
-4413	enchanted artisanal watered-down Schr&ouml;dinger's thermos	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 25, Last Available: "2010-04"
+4413	watered-down enchanted artisanal Schr&ouml;dinger's thermos	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 25, Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	sharpshooter's sealhide hood	0		Critical Hit Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	upside-down sealhide leggings of the glutton	0		Food Drop: +100, Familiar Effect: "1xVolley, cap 40"
@@ -4393,10 +4393,10 @@
 4445	olive Newton's spangly mariachi pants	0		Experience (Mysticality): +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	skewed horrifying spangly mariachi vest of Flo-Jo	0		Spooky Damage: +25, Initiative: +100
 4447	wobbly spinning Usain Bolt's spangly sombrero	0		Initiative: +80, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	pickled fuchsia shaking blurry Instant Karma	1	good	Effect: "Become Intensely interested", Effect Duration: 40
+4448	pickled shaking blurry fuchsia Instant Karma	1	good	Effect: "Become Intensely interested", Effect Duration: 40
 4449	cyan painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	narrow pointy hat of the pedagogue	0		Experience: +3, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	narrow pointy hat of the pedagogue	0		Experience: +3, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	fuchsia family-friendly machetito	0		Sleaze Resistance: +1, Last Available: "2010-04"
 4453	lawnmower blade of the cougar	0		Moxie: +20, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4413,11 +4413,11 @@
 4465	irradiated narrow chocolate saucepan	0		Effect: "Radiant Personality", Effect Duration: 28
 4466	dry narrow chocolate disco ball	0		Effect: "Sludgesick", Effect Duration: 44
 4467	diffused chocolate stolen accordion	0		Effect: "Total Protonic Reversal", Effect Duration: 21
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	twirling tumbling BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	BRICKO hat of the pedagogue	0		Experience: +3, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	Lo Pan's BRICKO pants	0		Spell Critical Percent: +30, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	BRICKO hat of the pedagogue	0		Experience: +3, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	Lo Pan's BRICKO pants	0		Spell Critical Percent: +30, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	squat BRICKO sword of the boozehound	0		Booze Drop: +100, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4427,7 +4427,7 @@
 4479	squat BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	blinking BRICKO python	0		Last Available: "2010-02"
 4481	spinning BRICKO vacuum cleaner	0		Last Available: "2010-02"
-4482	mirror yellow BRICKO airship	0		Last Available: "2010-02"
+4482	yellow mirror BRICKO airship	0		Last Available: "2010-02"
 4483	squat BRICKO cathedral	0		Last Available: "2010-02"
 4484	BRICKO gargantuchicken	0		Last Available: "2010-02"
 4485	teal BRICKO pyramid	0		Last Available: "2010-02"
@@ -4457,10 +4457,10 @@
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	delicious walrus ice cream	4	awesome	Last Available: "2010-03"
 4511	small moldy red beautiful soup	2	crappy	Last Available: "2010-03"
-4512	wobbly blinking narrow cyan eggman noodles	0		Last Available: "2010-03"
+4512	narrow wobbly blinking cyan eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	yummy Humpty Dumplings	4	awesome	Last Available: "2010-03"
-4515	stale bite-sized narrow Lobster <i>qua</i> Grill	1	decent	Last Available: "2010-03"
+4515	bite-sized stale narrow Lobster <i>qua</i> Grill	1	decent	Last Available: "2010-03"
 4516	mediocre missing wine	3	decent	Last Available: "2010-03"
 4517	big bland matter custard	5	decent	Last Available: "2010-03"
 4518	anodized comfit?	0		Effect: "Stinky Weapon", Effect Duration: 24, Last Available: "2010-03"
@@ -4469,9 +4469,9 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	squat Tiger-lily's milk	1	EPIC	Last Available: "2010-03"
 4523	inspector's Rosewater's eye of the Tiger-lily	0		Mysticality Percent: +30, Item Drop: +15, Last Available: "2010-03"
-4524	Herculean wig of the glutton	0		Experience (Muscle): +1, Food Drop: +100, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	Herculean wig of the glutton	0		Experience (Muscle): +1, Food Drop: +100, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	special half-sized rotten donut	2	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2010-03"
-4526	moldy fancy bucket of honey	3	crappy	Effect: "Salty Mouth", Effect Duration: 15, Last Available: "2010-03"
+4526	fancy moldy bucket of honey	3	crappy	Effect: "Salty Mouth", Effect Duration: 15, Last Available: "2010-03"
 4527	lion tamer's elephant stinger of horror	0		Experience (familiar): +2, Spooky Spell Damage: +25, Last Available: "2010-03"
 4528	moldy dragon snaps	4	crappy	Last Available: "2010-03"
 4529	green rosewater-soaked snapdragon pistil of the bloodbag	0		Maximum HP: +100, Stench Resistance: +3, Last Available: "2010-03"
@@ -4482,10 +4482,10 @@
 4534	delicious king cookie	4	awesome	Last Available: "2010-03"
 4535	massive normal queen cookie	10	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	blinking wobbly sharpshooter's insane tophat	0		Critical Hit Percent: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	executive energetic helm of the knight	0		Maximum MP Percent: +20, Meat Drop: +40, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	blinking wobbly sharpshooter's insane tophat	0		Critical Hit Percent: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	executive energetic helm of the knight	0		Maximum MP Percent: +20, Meat Drop: +40, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	lime green lard-coated wristwatch of the knight of the blizzard	0		Cold Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip, Last Available: "2010-03"
-4540	lime green frightening trousers of the knight of the sewer	0		Stench Damage: +25, Spooky Damage: +5, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	lime green frightening trousers of the knight of the sewer	0		Stench Damage: +25, Spooky Damage: +5, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	brainy tophat	0		Mysticality: +5, Familiar Effect: "1xBarrr, cap 25"
 4542	lightning-fast tie	0		Initiative: +40, Single Equip
 4543	blue tuxedo pants of the cougar	0		Moxie: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4498,7 +4498,7 @@
 4550	blinking lime green dodo	0		Last Available: "2010-03"
 4551	lion tamer's detour shield	0		Experience (familiar): +2, Damage Reduction: 6, Last Available: "2010-03"
 4552	blinking left parenthesis	0		
-4553	gray blinking lowercase a	0		
+4553	blinking gray lowercase a	0		
 4554	percent sign	0		
 4555	pulsating left bracket	0		
 4556	right parenthesis	0		
@@ -4508,13 +4508,13 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	narrow hair of the calf	0		Last Available: "2010-04"
-4563	delicious watered-down olive world's most unappetizing beverage	2	awesome	Last Available: "2010-04"
+4563	watered-down delicious olive world's most unappetizing beverage	2	awesome	Last Available: "2010-04"
 4564	ghostly squat slippery when wet shield of the early riser	0		Adventures: +7, Damage Reduction: 6, Last Available: "2010-04"
 4565	moldy raisin	4	crappy	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	forbidden flyest of shirts of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Last Available: "2010-04"
-4568	decent half-sized red a dance upon the palate	2	good	Last Available: "2010-04"
-4569	normal immense prehistoric meteorite jawbreaker	9	good	Last Available: "2010-04"
+4568	half-sized decent red a dance upon the palate	2	good	Last Available: "2010-04"
+4569	immense normal prehistoric meteorite jawbreaker	9	good	Last Available: "2010-04"
 4570	pulsating Crazyleg's razor	0		Last Available: "2010-04"
 4571	stale squirmy violent party snack	3	decent	Last Available: "2010-04"
 4572	spinning friendly can-you-dig-it?	0		Familiar Weight: +3, Last Available: "2010-04"
@@ -4524,7 +4524,7 @@
 4576	teal bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	double-flattened oxidized jittery lime green Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Expert Vacationer", Effect Duration: 28, Last Available: "2010-04"
+4579	double-flattened oxidized lime green jittery Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Expert Vacationer", Effect Duration: 28, Last Available: "2010-04"
 4580	maroon wobbly vibrating school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Maximum MP Percent: +10, Last Available: "2010-04"
 4581	huge nippy studded T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Damage Absorption: +80, Cold Damage: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
@@ -4533,7 +4533,7 @@
 4585	collection of objects	0		
 4586	boulder	0		
 4587	yellow goth	0		
-4588	olive mirror brown pixel	0		
+4588	mirror olive brown pixel	0		
 4589	huge resourceful pixel whip	0		Maximum MP: +50
 4590	wholesome pixel chain whip	0		Maximum HP Percent: +10, Last Available: "2010-07"
 4591	Samson's pixel morning star	0		Experience (Muscle): +5, Last Available: "2010-07"
@@ -4550,7 +4550,7 @@
 4602	tumbling orquette's phone number	0		Last Available: "2010-06"
 4603	tumbling bronze handcuffs	0		Last Available: "2010-06"
 4604	red keg	0		Last Available: "2010-06"
-4605	resourceful quilted bottle of Goldschn&ouml;ckered	0		Damage Absorption: +40, Maximum MP: +50, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	resourceful quilted bottle of Goldschn&ouml;ckered	0		Damage Absorption: +40, Maximum MP: +50, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	snack-sized moldy pulsating sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	watered-down hand-crafted soyburger juice	2	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4569,20 +4569,20 @@
 4621	narrow Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	corrupted electrified chocolate-covered caviar	0		Effect: "Flaming Weapon", Effect Duration: 36, Last Available: "2020-09"
-4624	miniature bland pawn cookie	2	decent	Last Available: "2010-06"
+4624	bland miniature pawn cookie	2	decent	Last Available: "2010-06"
 4625	compressed coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	upside-down superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	squat dog trainer's plastic spider ring	0		Experience (familiar): +1, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	squat dog trainer's plastic spider ring	0		Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	plastic kazoo of wisdom	0		Mysticality: +15, Last Available: "2010-06"
 4631	bouncing healthy inflatable baseball bat	0		Maximum HP Percent: +20, Last Available: "2010-06"
-4632	jittery googly-star hat of Calamity Jane of temperance	0		Critical Hit Percent: +15, Sleaze Resistance: +5, Last Available: "2010-06", Familiar Effect: "atk"
+4632	jittery googly-star hat of Calamity Jane of temperance	0		Critical Hit Percent: +15, Sleaze Resistance: +5, Familiar Effect: "atk", Last Available: "2010-06"
 4633	red family-friendly chaotic googly-ball hat	0		Spell Critical Percent: +10, Sleaze Resistance: +1, Last Available: "2010-06"
 4634	coward's googly-heart hat of incineration	0		Monster Level: -20, Hot Spell Damage: +50, Last Available: "2010-06"
 4635	studded brainy super-sweet boom box	0		Mysticality: +5, Damage Absorption: +80, Four Songs, Last Available: "2010-06"
 4636	bouncing Game Grid valued membership card	0		Last Available: "2010-06"
-4637	green family-friendly occult sinister demon mask of mayonnaise	0		Spell Damage Percent: +25, Sleaze Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	green family-friendly occult sinister demon mask of mayonnaise	0		Spell Damage Percent: +25, Sleaze Spell Damage: +50, Sleaze Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	red personal trainer's streetfighting champion's belt of the blizzard of terror	0		Experience Percent (Muscle): +10, Cold Spell Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2010-06"
 4639	jittery crafty deadly Space Trip safety headphones of the brute	0		Muscle Percent: +30, Weapon Damage: +5, Maximum MP: +10, Single Equip, Last Available: "2010-06"
 4640	spinning Tesla LARP carp	0		MP Regen Min: 7, MP Regen Max: 10
@@ -4594,8 +4594,8 @@
 4646	ghostly horrifying careful studded Meteoid ice beam	0		Damage Absorption: +80, Monster Level: -10, Spooky Damage: +25, Last Available: "2011-12"
 4647	olive avaricious supercharged groovy Dungeon Fist gauntlet	0		Moxie Percent: +10, Maximum MP Percent: +30, Meat Drop: +30, Last Available: "2011-06"
 4648	upside-down Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	shaking chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	teal fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	shaking chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	teal fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	baleful grievous ironic knit cap	0		Weapon Damage Percent: +50, Spell Damage: +25, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4616,7 +4616,7 @@
 4668	observational glasses of James Dean	0		Experience (Moxie): +3
 4669	huge zippy hilarious comedy prop	0		Initiative: +20
 4670	blue skewed beer-scented teddy bear	0		
-4671	practically non-alcoholic artisanal booze-soaked cherry	1	EPIC	
+4671	artisanal practically non-alcoholic booze-soaked cherry	1	EPIC	
 4672	blurry comfy pillow	0		
 4673	rotten marshmallow	4	crappy	
 4674	flavorless shaking sponge cake	4	decent	
@@ -4627,8 +4627,8 @@
 4679	mirror volcanic ash	0		
 4680	red narrow shaking smoked potsherd	0		
 4681	pottery shield of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 3, Last Available: "2010-09"
-4682	reassuring smartaleck's pottery hat	0		Moxie Percent: +30, Spooky Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	MacGyver's Sinatra's pottery training pants	0		Experience (Moxie): +5, Maximum MP: +100, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	reassuring smartaleck's pottery hat	0		Moxie Percent: +30, Spooky Resistance: +1, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	MacGyver's Sinatra's pottery training pants	0		Experience (Moxie): +5, Maximum MP: +100, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	brainy pottery club	0		Mysticality: +5, Last Available: "2010-09"
 4685	skewed blue wobbly pottery yo-yo of the cheetah	0		Initiative: +60, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	lime green fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	upside-down affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	coward's beefcake's Greatest American Pants of the pedagogue	0		Muscle: +25, Experience: +3, Monster Level: -20, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	coward's beefcake's Greatest American Pants of the pedagogue	0		Muscle: +25, Experience: +3, Monster Level: -20, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	brawny fossilized necklace	0		Muscle Percent: +20, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4659,7 +4659,7 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	red popsicle stick	0		
-4714	immense yummy lemon popsicle	10	awesome	
+4714	yummy immense lemon popsicle	10	awesome	
 4715	toothsome narrow popsicle	4	awesome	
 4716	bland mirror strawberry popsicle	4	decent	
 4717	moldy mirror liver popsicle	4	crappy	
@@ -4672,9 +4672,9 @@
 4724	big spoiled shoo-fish pie	5	crappy	Last Available: "2010-10"
 4725	spoiled thick upside-down piping organ pie	5	crappy	Last Available: "2010-10"
 4726	stale igloo pie	4	decent	Last Available: "2010-10"
-4727	normal jumbo fuchsia squat stomach turnover	5	good	Last Available: "2010-10"
+4727	jumbo normal squat fuchsia stomach turnover	5	good	Last Available: "2010-10"
 4728	spoiled dead lights pie	3	crappy	Last Available: "2010-10"
-4729	bland thick throbbing organ pie	5	decent	Last Available: "2010-10"
+4729	thick bland throbbing organ pie	5	decent	Last Available: "2010-10"
 4730	green quilted stop shield	0		Damage Absorption: +40, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	cyan sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4691,16 +4691,16 @@
 4743	bone chips	0		Last Available: "2011-12"
 4744	frozen oxidized PlexiPips	0		Effect: "Fan-Cooled", Effect Duration: 13
 4745	activated activated blurry Wax Flask	0		Effect: "Spooky Blur", Effect Duration: 12
-4746	colloidal concentrated warmed skewed purple Pain Dip	0		Effect: "Venomous Weapon", Effect Duration: 36
-4747	thick adequate bone meal	5	good	Last Available: "2010-10"
+4746	colloidal concentrated warmed purple skewed Pain Dip	0		Effect: "Venomous Weapon", Effect Duration: 36
+4747	adequate thick bone meal	5	good	Last Available: "2010-10"
 4748	acceptable narrow bone aperitif	3	good	Last Available: "2010-10"
 4749	twirling bonerang of the sewer	0		Stench Damage: +25, Last Available: "2010-10"
 4750	bone and arrows of incineration	0		Hot Spell Damage: +50, Last Available: "2010-10"
 4751	tumbling curative boning knife	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-10"
 4752	gray deadly bone crusher	0		Weapon Damage: +5, Last Available: "2010-10"
 4753	spinning reassuring bone spurs	0		Spooky Resistance: +1, Single Equip, Last Available: "2010-10"
-4754	bouncing olive rosewater-soaked bonedanna of the brazier	0		Hot Spell Damage: +25, Stench Resistance: +3, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	smelly boneana hammock of Calamity Jane	0		Critical Hit Percent: +15, Stench Spell Damage: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	bouncing olive rosewater-soaked bonedanna of the brazier	0		Hot Spell Damage: +25, Stench Resistance: +3, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	smelly boneana hammock of Calamity Jane	0		Critical Hit Percent: +15, Stench Spell Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	skewed bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	anodized candy skeleton	0		Effect: "White Blooded", Effect Duration: 38, Last Available: "2020-09"
@@ -4708,7 +4708,7 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	jittery pumpkin	0		Last Available: "2010-11"
 4762	skewed huge pumpkin	0		Last Available: "2010-11"
-4763	snack-sized stale pumpkin pie	2	decent	Last Available: "2010-11"
+4763	stale snack-sized pumpkin pie	2	decent	Last Available: "2010-11"
 4764	artisanal squat pumpkin beer	3	EPIC	Last Available: "2010-11"
 4765	Vulcanized energized upside-down pumpkin juice	0		Effect: "Twen Tea", Effect Duration: 39, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4745,15 +4745,15 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	bite-sized toothsome triangular CRIMBCOOKIE	1	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	toothsome bite-sized triangular CRIMBCOOKIE	1	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	spoiled ghostly square CRIMBCOOKIE	3	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	foul-smelling vibrating brawny bindlestocking	0		Muscle Percent: +20, Maximum MP Percent: +10, Stench Damage: +10, Last Available: "2010-12"
 4842	skewed sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	mirror The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	Jeselnik's friendly Uncle Hobo's stocking cap	0		Familiar Weight: +3, Sleaze Damage: +25, Last Available: "2010-12", Familiar Effect: "atk"
+4845	Jeselnik's friendly Uncle Hobo's stocking cap	0		Familiar Weight: +3, Sleaze Damage: +25, Familiar Effect: "atk", Last Available: "2010-12"
 4846	squat Uncle Hobo's epic beard of the dark arts of the boozehound	0		Spell Damage Percent: +100, Booze Drop: +100, Single Equip, Last Available: "2010-12"
-4847	knitted electrified Uncle Hobo's gift baggy pants	0		Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	knitted electrified Uncle Hobo's gift baggy pants	0		Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	skewed nippy Uncle Hobo's fingerless tinsel gloves of the glutton	0		Cold Damage: +10, Food Drop: +100, Single Equip, Last Available: "2010-12"
 4849	twirling perfumed fireproof Uncle Hobo's highest bough	0		Hot Resistance: +3, Stench Resistance: +5, Last Available: "2010-12"
 4850	resourceful Uncle Hobo's belt of bravery	0		Maximum MP: +50, Spooky Resistance: +5, Single Equip, Last Available: "2010-12"
@@ -4768,15 +4768,15 @@
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
-4862	tumbling maroon CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-4863	pulsating yellow CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+4862	maroon tumbling CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
+4863	yellow pulsating CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	yellow photocopier	0		Last Available: "2011-01"
 4865	deluxe fax machine	0		Last Available: "2011-01"
-4866	ghostly cyan Workytime Tea	0		Last Available: "2011-01"
+4866	cyan ghostly Workytime Tea	0		Last Available: "2011-01"
 4867	bouncing paperclip sproinger	0		Last Available: "2011-01"
 4868	lard-coated flame-wreathed scorching paperclip-on tie	0		Hot Damage: +25, Hot Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2011-01"
-4869	blurry sharpshooter's paperclip pants of the cheetah	0		Critical Hit Percent: +10, Initiative: +60, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	blurry auspicious medical-grade paperclip turban of terror	0		Spooky Spell Damage: +10, Item Drop: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	blurry sharpshooter's paperclip pants of the cheetah	0		Critical Hit Percent: +10, Initiative: +60, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	blurry auspicious medical-grade paperclip turban of terror	0		Spooky Spell Damage: +10, Item Drop: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	savvy paperclip cape	0		Mysticality Percent: +20, Last Available: "2011-01"
 4872	olive glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4786,7 +4786,7 @@
 4877	corrupted narrow bacon bath ball	0		Effect: "Preemptive Medicine", Effect Duration: 54, Last Available: "2011-01"
 4878	anodized pressed incense bath ball	0		Effect: "Good with the Ladies", Effect Duration: 24, Last Available: "2011-01"
 4879	super-dry teal myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "The Rich Get Richer", Effect Duration: 59, Last Available: "2011-01"
-4880	huge red wobbly CRIMBCO mug	0		Last Available: "2011-01"
+4880	huge wobbly red CRIMBCO mug	0		Last Available: "2011-01"
 4881	mediocre distilled CRIMBCO wine	5	decent	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	blurry toe jam	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	bouncing slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	massive decent tumbling festive sausage	10	good	Last Available: "2011-01"
-4895	low-calorie toothsome skewed gray holiday cheese log	1	awesome	Last Available: "2011-01"
+4895	low-calorie toothsome gray skewed holiday cheese log	1	awesome	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	wizardly BGE 'ferocious fruit' shirt of the scaredy-cat	0		Mysticality: +25, Monster Level: -15, Last Available: "2010-12"
 4898	huge steel-toed groovy BGE 'cuddly critter' shirt	0		Moxie Percent: +10, Damage Reduction: 9, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	decent small huge blue Knob jelly donut	2	good	
+4941	small decent huge blue Knob jelly donut	2	good	
 4942	Knob cake	0		
 4943	olive Knob cake pan	0		
 4944	wobbly Knob batter	0		
@@ -4884,7 +4884,7 @@
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
 4983	Alice's Army Cleric	0		Last Available: "2011-03"
-4984	tumbling ghostly Alice's Army Sniper	0		Last Available: "2011-03"
+4984	ghostly tumbling Alice's Army Sniper	0		Last Available: "2011-03"
 4985	Alice's Army Dervish	0		Last Available: "2011-03"
 4986	bouncing teal Alice's Army Martyr	0		Last Available: "2011-03"
 4987	shaking Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
@@ -4914,11 +4914,11 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	normal fancy wasabi pocky	3	good	Effect: "Supafly", Effect Duration: 10, Last Available: "2011-03"
-5014	miniature bland tobiko pocky	2	decent	Last Available: "2011-03"
+5014	bland miniature tobiko pocky	2	decent	Last Available: "2011-03"
 5015	snack-sized stale natto pocky	2	decent	Last Available: "2011-03"
-5016	tolerable enchanted weak wasabi-infused sake	2	good	Effect: "Saucemastery", Effect Duration: 40, Last Available: "2011-03"
-5017	irresponsibly strong delicious special tobiko-infused sake	9	awesome	Effect: "Dreadful Chill", Effect Duration: 15, Last Available: "2011-03"
-5018	watered-down mediocre natto-infused sake	2	decent	Last Available: "2011-03"
+5016	enchanted weak tolerable wasabi-infused sake	2	good	Effect: "Saucemastery", Effect Duration: 40, Last Available: "2011-03"
+5017	special delicious irresponsibly strong tobiko-infused sake	9	awesome	Effect: "Dreadful Chill", Effect Duration: 15, Last Available: "2011-03"
+5018	mediocre watered-down natto-infused sake	2	decent	Last Available: "2011-03"
 5019	Vulcanized unsweetened upside-down wasabi marble soda	0		Effect: "Gunky Dory", Effect Duration: 62, Last Available: "2011-03"
 5020	dry magnetized red tobiko marble soda	0		Effect: "Burnt 'n' Turnt", Effect Duration: 69, Last Available: "2011-03"
 5021	polymerized nitrogenated natto marble soda	0		Effect: "Liquid Luck", Effect Duration: 40, Last Available: "2011-03"
@@ -4949,9 +4949,9 @@
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	wobbly shard of double-ice	0		Last Available: "2011-04"
-5049	blurry nippy stylish double-ice cap of the detective	0		Moxie: +25, Cold Damage: +10, Item Drop: +20, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	blurry nippy stylish double-ice cap of the detective	0		Moxie: +25, Cold Damage: +10, Item Drop: +20, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	executive shellacked brawny double-ice box	0		Muscle Percent: +20, Damage Reduction: 7, Meat Drop: +40, Last Available: "2011-04"
-5051	blue sharpshooter's Herculean wizardly double-ice britches	0		Mysticality: +25, Experience (Muscle): +1, Critical Hit Percent: +10, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	blue sharpshooter's Herculean wizardly double-ice britches	0		Mysticality: +25, Experience (Muscle): +1, Critical Hit Percent: +10, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	twirling handful of numbers	0		Last Available: "2020-09"
 5053	tumbling Lars the Cyberian	0		Last Available: "2011-04"
 5054	bouncing intriguing puzzle box	0		Last Available: "2011-04"
@@ -4959,7 +4959,7 @@
 5056	best joke ever	0		Last Available: "2011-04"
 5057	polarized quadruple-magnetized super-wet Atomic Comic	0		Effect: "Sharp Weapon", Effect Duration: 11, Last Available: "2011-04"
 5058	flattened anodized Red Pill	0		Effect: "Arcane in the Brain", Effect Duration: 57, Last Available: "2011-04"
-5059	cyan blinking Skullhead's Screw	0		Last Available: "2011-04"
+5059	blinking cyan Skullhead's Screw	0		Last Available: "2011-04"
 5060	skewed mysterious present	0		Last Available: "2011-04"
 5061	boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	blurry voodoo doll	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	hand-crafted Russian Ice	4	EPIC	Last Available: "2011-04"
 5074	shaking Sherlock's clay ashtray	0		Item Drop: +25, Damage Reduction: 3, Last Available: "2011-05"
 5075	blinking experienced lanyard	0		Experience: +2, Single Equip, Last Available: "2011-05"
-5076	gray knitted monster pants	0		Cold Resistance: +3, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	gray knitted monster pants	0		Cold Resistance: +3, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	magnetized anodized Pok&euml;mann band-aid	0		Effect: "Once Bitten Twice Fried", Effect Duration: 26, Last Available: "2011-05"
-5079	blurry hardy Van der Graaf helmet of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	blurry hardy Van der Graaf helmet of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	tumbling maroon tumbling friendly crutch	0		Familiar Weight: +3, Last Available: "2011-05"
 5081	studded shock belt	0		Damage Absorption: +80, Single Equip, Last Available: "2011-05"
 5082	corrupted unsweetened teal Okee-Dokee soda	0		Effect: "Discomfited", Effect Duration: 22, Last Available: "2011-05"
 5083	stanky rubber band gun	0		Stench Spell Damage: +25, Last Available: "2011-05"
-5084	double-paned pin-stripe slacks	0		Cold Resistance: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	double-paned pin-stripe slacks	0		Cold Resistance: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	twirling gloves of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5086	anodized jittery correction fluid	0		Effect: "Gummibrain", Effect Duration: 29, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of the glutton	0		Food Drop: +100, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	watered-down acceptable Jeppson's Malort	2	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	crafty stress ball	0		Maximum MP: +10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	crafty stress ball	0		Maximum MP: +10, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	stylish Ultracolor&trade; shirt	0		Moxie: +25, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5019,12 +5019,12 @@
 5116	tumbling A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	lime green bird brain	0		
-5119	mirror purple jittery busted wings	0		
+5119	purple jittery mirror busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	Samson's smartaleck's Admiral's hat of James Dean	0		Moxie Percent: +30, Experience (Muscle): +5, Experience (Moxie): +3, Last Available: "2011-05", Familiar Effect: "atk"
-5122	perfumed knitted flame-wreathed aviator's cap	0		Hot Spell Damage: +10, Cold Resistance: +3, Stench Resistance: +5, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	Samson's smartaleck's Admiral's hat of James Dean	0		Moxie Percent: +30, Experience (Muscle): +5, Experience (Moxie): +3, Familiar Effect: "atk", Last Available: "2011-05"
+5122	perfumed knitted flame-wreathed aviator's cap	0		Hot Spell Damage: +10, Cold Resistance: +3, Stench Resistance: +5, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	wobbly resourceful mirrored aviator shades of mayonnaise	0		Maximum MP: +50, Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-05"
-5124	squat purple Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
+5124	purple squat Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	jittery Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	narrow Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	tumbling Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	tumbling purple avaricious toasty honey dipper of chilblains	0		Cold Damage: +25, Hot Damage: +5, Meat Drop: +30
 5149	avaricious fireproof Newton's honeybritches	0		Experience (Mysticality): +3, Hot Resistance: +3, Meat Drop: +30, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	rosy-cheeked dance instructor's honeycap of Gandalf	0		Experience Percent (Moxie): +10, Maximum HP Percent: +30, Spell Critical Percent: +20, Familiar Effect: "1xPotato, cap 43"
-5151	wholesome Moonthril Circlet	0		Maximum HP Percent: +10, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	tumbling scorching Moonthril Greaves	0		Hot Damage: +25, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	wholesome Moonthril Circlet	0		Maximum HP Percent: +10, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	tumbling scorching Moonthril Greaves	0		Hot Damage: +25, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	blinking wizardly Moonthril Flamberge	0		Mysticality: +25, Last Available: "2011-06"
 5154	savvy Moonthril Longbow	0		Mysticality Percent: +20, Last Available: "2011-06"
 5155	slick Moonthril Cuirass	0		Moxie: +10, Softcore Only, Last Available: "2011-06"
@@ -5070,14 +5070,14 @@
 5167	purple synthetic dog hair pill	0		Last Available: "2011-06"
 5168	wobbly distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
-5170	chilled wet shaking bouncing blinking transporter transponder	0		Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2011-06"
+5170	chilled wet bouncing shaking blinking transporter transponder	0		Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2011-06"
 5171	green Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	tumbling elven magi-pack	0		Last Available: "2011-06"
-5174	fancy practically non-alcoholic hand-crafted Saison du Lune	1	super ultra EPIC	Effect: "Greased-Up Familiar", Effect Duration: 5, Last Available: "2011-06"
+5174	practically non-alcoholic fancy hand-crafted Saison du Lune	1	super ultra EPIC	Effect: "Greased-Up Familiar", Effect Duration: 5, Last Available: "2011-06"
 5175	weak smooth Moonthril Schnapps	2	awesome	Last Available: "2011-06"
-5176	perfectly mixed weak fancy Wrecked Generator	2	super ultra mega turbo EPIC	Effect: "Sweet Incentive", Effect Duration: 45, Last Available: "2011-06"
-5177	immense moldy Spaghetti with Moonballs	7	crappy	Last Available: "2011-06"
+5176	fancy perfectly mixed weak Wrecked Generator	2	super ultra mega turbo EPIC	Effect: "Sweet Incentive", Effect Duration: 45, Last Available: "2011-06"
+5177	moldy immense Spaghetti with Moonballs	7	crappy	Last Available: "2011-06"
 5178	moldy Crepes a la Lune	4	crappy	Last Available: "2011-06"
 5179	rotten Moon Pie	4	crappy	Last Available: "2011-06"
 5180	triple-pickled Comet Pop	0		Effect: "Celestial Body", Effect Duration: 27, Last Available: "2011-06"
@@ -5088,9 +5088,9 @@
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	red Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
-5188	colloidal boiled yellow blinking honey stick	0		Effect: "Boletus Swoletus", Effect Duration: 28
+5188	colloidal boiled blinking yellow honey stick	0		Effect: "Boletus Swoletus", Effect Duration: 28
 5189	irradiated bouncing double-ice gum	0		Effect: "Smokin'", Effect Duration: 29, Last Available: "2011-04"
-5190	perfumed toasty occult Operation Patriot Shield	0		Spell Damage Percent: +25, Hot Damage: +5, Stench Resistance: +5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	perfumed toasty occult Operation Patriot Shield	0		Spell Damage Percent: +25, Hot Damage: +5, Stench Resistance: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	pulsating squirming egg sac	0		Last Available: "2011-06"
 5192	flattened oxidized maroon corrupted data	0		Effect: "Memory of Smarts", Effect Duration: 46, Last Available: "2011-06"
 5193	twirling 11-inch knob sausage	0		
@@ -5107,23 +5107,23 @@
 5204	powdered wobbly hippy paste	1	good	Effect: "Almost Cool", Effect Duration: 25, Last Available: "2011-08"
 5205	dehydrated skewed orc paste	1	EPIC	Effect: "You Know What's Up", Effect Duration: 45, Last Available: "2011-08"
 5206	boiled olive demonic paste	1	EPIC	Effect: "Bark of the Dog", Effect Duration: 5, Last Available: "2011-08"
-5207	diluted gray upside-down jittery indescribably horrible paste	1	good	Effect: "Heart of Orange", Effect Duration: 15, Last Available: "2011-08"
+5207	diluted upside-down jittery gray indescribably horrible paste	1	good	Effect: "Heart of Orange", Effect Duration: 15, Last Available: "2011-08"
 5208	powdered olive paste	1	EPIC	Effect: "Devil Inside", Effect Duration: 20, Last Available: "2011-08"
 5209	denatured spinning cyan goblin paste	1	decent	Last Available: "2011-08"
 5210	powdered blinking pirate paste	1	decent	Last Available: "2011-08"
 5211	altered fuchsia chlorophyll paste	1	crappy	Effect: "Sewer-Drenched", Effect Duration: 20, Last Available: "2011-08"
-5212	distilled olive shaking paste	1	decent	Effect: "Optimist Primal", Effect Duration: 30, Last Available: "2011-08"
-5213	dehydrated lime green squat Mer-kin paste	1	crappy	Last Available: "2011-08"
+5212	distilled shaking olive paste	1	decent	Effect: "Optimist Primal", Effect Duration: 30, Last Available: "2011-08"
+5213	dehydrated squat lime green Mer-kin paste	1	crappy	Last Available: "2011-08"
 5214	altered upside-down slimy paste	1	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 25, Last Available: "2011-08"
 5215	compressed squat penguin paste	1	awesome	Effect: "Broken Bone Nubs", Effect Duration: 20, Last Available: "2011-08"
 5216	diluted elemental paste	1	awesome	Effect: "Burnt 'n' Turnt", Effect Duration: 10, Last Available: "2011-08"
 5217	mixed blurry cosmic paste	1	EPIC	Last Available: "2011-08"
-5218	compressed teal mirror ghostly hobo paste	1	decent	Last Available: "2011-08"
+5218	compressed ghostly mirror teal hobo paste	1	decent	Last Available: "2011-08"
 5219	distilled blue Crimbo paste	1	good	Effect: "Patent Avarice", Effect Duration: 35, Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	jittery Thwaitgold grasshopper statuette	0		
-5223	mirror Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	mirror Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	rotten Ur-Donut	4	crappy	Last Available: "2011-09"
 5225	tumbling The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	green family-friendly furry halo	0		Sleaze Resistance: +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	sage frosty halo	0		Mysticality Percent: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	tumbling crafty time halo	0		Maximum MP: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	high-proof bad skewed ghostly Lumineux Limnio	7	decent	Last Available: "2011-09"
-5239	fortified artisanal Morto Moreto	5	EPIC	Last Available: "2011-09"
+5238	high-proof bad ghostly skewed Lumineux Limnio	7	decent	Last Available: "2011-09"
+5239	artisanal fortified Morto Moreto	5	EPIC	Last Available: "2011-09"
 5240	bad Temps Tempranillo	3	decent	Last Available: "2011-09"
-5241	tolerable fortified Bordeaux Marteaux	5	good	Last Available: "2011-09"
+5241	fortified tolerable Bordeaux Marteaux	5	good	Last Available: "2011-09"
 5242	bad Fromage Pinotage	4	decent	Last Available: "2011-09"
-5243	lousy enchanted triple-distilled lime green Beignet Milgranet	6	decent	Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2011-09"
+5243	triple-distilled enchanted lousy lime green Beignet Milgranet	6	decent	Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2011-09"
 5244	lousy Muschat	3	decent	Last Available: "2011-09"
-5245	normal immense pulsating cool jelly donut	9	good	Last Available: "2011-09"
+5245	immense normal pulsating cool jelly donut	9	good	Last Available: "2011-09"
 5246	normal shrapnel jelly donut	4	good	Last Available: "2011-09"
 5247	spoiled pulsating occult jelly donut	4	crappy	Last Available: "2011-09"
 5248	spoiled half-sized upside-down thyme jelly donut	2	crappy	Last Available: "2011-09"
 5249	jumbo flavorless yellow danish	5	decent	Last Available: "2011-09"
-5250	snack-sized stale smashed danish	2	decent	Last Available: "2011-09"
+5250	stale snack-sized smashed danish	2	decent	Last Available: "2011-09"
 5251	small stale forbidden danish	2	decent	Last Available: "2011-09"
-5252	normal half-sized cool cat claw	2	good	Last Available: "2011-09"
+5252	half-sized normal cool cat claw	2	good	Last Available: "2011-09"
 5253	tasty squat blunt cat claw	4	awesome	Last Available: "2011-09"
-5254	flavorless miniature gray shadowy cat claw	2	decent	Last Available: "2011-09"
-5255	bite-sized spoiled upside-down cheezburger	1	crappy	Last Available: "2011-09"
-5256	gigantic adequate pulsating toasted brie	9	good	Last Available: "2011-09"
+5254	miniature flavorless gray shadowy cat claw	2	decent	Last Available: "2011-09"
+5255	spoiled bite-sized upside-down cheezburger	1	crappy	Last Available: "2011-09"
+5256	adequate gigantic pulsating toasted brie	9	good	Last Available: "2011-09"
 5257	super-irradiated potion of the field gar	0		Effect: "Funky Coal Patina", Effect Duration: 23, Last Available: "2011-09"
 5258	moist too legit potion	0		Effect: "One Very Clear Eye", Effect Duration: 66, Last Available: "2011-09"
 5259	non-pickled non-magnetized vacuum-sealed Bright Water	0		Effect: "Sweet, Nuts", Effect Duration: 58, Last Available: "2011-09"
@@ -5184,22 +5184,22 @@
 5281	cyan broken clock of horror	0		Spooky Spell Damage: +25, Last Available: "2011-09"
 5282	squat mirror MacGyver's dethklok	0		Maximum MP: +100, Last Available: "2011-09"
 5283	twirling blurry reassuring glacial clock	0		Spooky Resistance: +1, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	green blurry d6	0		Last Available: "2011-09"
 5287	ghostly d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
-5289	mirror olive d12	0		Last Available: "2011-09"
+5289	olive mirror d12	0		Last Available: "2011-09"
 5290	d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
 5293	ghostly generic restorative potion	0		Last Available: "2011-09"
-5294	upside-down ghostly kobold treasure hoard	0		Last Available: "2011-09"
+5294	ghostly upside-down kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	huge slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	blurry dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy phish stick	4	crappy	Last Available: "2011-09"
-5299	supercharged deadly Socratic plastic vampire fangs	0		Experience (Mysticality): +1, Weapon Damage: +5, Maximum MP Percent: +30, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	supercharged deadly Socratic plastic vampire fangs	0		Experience (Mysticality): +1, Weapon Damage: +5, Maximum MP Percent: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	twirling Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	upside-down Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	lime green your own heart	0		Last Available: "2011-10"
@@ -5222,30 +5222,30 @@
 5319	ionized improved Blood 'n' Plenty	0		Effect: "Radiated and Grodiated", Effect Duration: 25, Last Available: "2011-10"
 5320	electrified frozen unsweetened Lobos Mints	0		Effect: "Arabian Knighthood", Effect Duration: 54, Last Available: "2011-10"
 5321	Vulcanized polymerized fuchsia Sweet Sword	0		Effect: "Trash-Wrapped", Effect Duration: 60, Last Available: "2011-10"
-5322	practically non-alcoholic hand-crafted narrow cyan Ecto-Cooler	1	EPIC	Last Available: "2011-10"
+5322	hand-crafted practically non-alcoholic cyan narrow Ecto-Cooler	1	EPIC	Last Available: "2011-10"
 5323	fortified drinkable jittery Bartles and BRAAAINS wine cooler	5	good	Last Available: "2011-10"
 5324	drinkable practically non-alcoholic wobbly Blood Light	1	good	Last Available: "2011-10"
 5325	acceptable Silver Bullet beer	3	good	Last Available: "2011-10"
-5326	distilled bad mirror jittery Bone's Farm &quot;wine&quot;	5	decent	Last Available: "2011-10"
-5327	twirling mirror ghost protocol	0		Last Available: "2011-10"
+5326	bad distilled mirror jittery Bone's Farm &quot;wine&quot;	5	decent	Last Available: "2011-10"
+5327	mirror twirling ghost protocol	0		Last Available: "2011-10"
 5328	boiled vacuum-sealed green sorority brain	0		Effect: "Rat-Faced", Effect Duration: 22, Last Available: "2011-10"
 5329	modified Nightstalker perfume	0		Effect: "Moon'd", Effect Duration: 16, Last Available: "2011-10"
 5330	frozen mirror drum of pomade	0		Effect: "Just the Brown Ones", Effect Duration: 61, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	savvy extra-see-thru nightie	0		Mysticality Percent: +20, Last Available: "2011-10"
-5333	extremely unsafe Rosewater's BRAINS shorts	0		Mysticality Percent: +30, Weapon Damage Percent: +100, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	extremely unsafe Rosewater's BRAINS shorts	0		Mysticality Percent: +30, Weapon Damage Percent: +100, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	ghostly Jack Frost's Mesmereyes&trade; contact lenses	0		Cold Spell Damage: +50, Single Equip, Last Available: "2011-10"
 5335	skewed scrunchie of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2011-10"
-5336	sage extremely skinny jeans of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	rock-hard strapping The Necbromancer's Hat	0		Muscle: +5, Damage Reduction: 5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	sage extremely skinny jeans of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	rock-hard strapping The Necbromancer's Hat	0		Muscle: +5, Damage Reduction: 5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	Usain Bolt's smooth The Necbromancer's Stein of horror	0		Moxie: +15, Spooky Spell Damage: +25, Initiative: +80, Last Available: "2011-10"
-5339	reassuring Socratic The Necbromancer's Shorts of the pedagogue	0		Experience: +3, Experience (Mysticality): +1, Spooky Resistance: +1, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	reassuring Socratic The Necbromancer's Shorts of the pedagogue	0		Experience: +3, Experience (Mysticality): +1, Spooky Resistance: +1, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	twirling clever steel-toed The Necbromancer's Wizard Staff of courage	0		Damage Reduction: 9, Maximum MP: +20, Spooky Resistance: +3, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	weak bad The Cooler Out of Space	2	decent	Last Available: "2011-10"
+5342	bad weak The Cooler Out of Space	2	decent	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
-5345	magnetized Vulcanized shaking teal Necbro wafers	0		Effect: "Ooh, Sweet!", Effect Duration: 22, Last Available: "2020-09"
+5345	magnetized Vulcanized teal shaking Necbro wafers	0		Effect: "Ooh, Sweet!", Effect Duration: 22, Last Available: "2020-09"
 5346	death blossom	0		
 5347	yellow A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -5277,7 +5277,7 @@
 5374	blue censurious plastic abominable fudgeman	0		Sleaze Resistance: +3, Last Available: "2011-12"
 5375	stanky plastic colollilossus	0		Stench Spell Damage: +25, Last Available: "2011-12"
 5376	crafty plastic Big Candy of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Last Available: "2011-12"
-5377	blinking gray The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
+5377	gray blinking The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	boiled blurry groose grease	1	awesome	Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
@@ -5306,8 +5306,8 @@
 5403	blurry Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	spinning purple tumbling mansplainer's healthy cane-mail shirt of the cougar	0		Moxie: +20, Maximum HP Percent: +20, Monster Level: +15, Last Available: "2011-12"
-5406	blurry chilly Tesla Herculean cane-mail pants	0		Experience (Muscle): +1, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	extra-dry bad narrow Vodka Matryoshka	5	decent	Last Available: "2011-12"
+5406	blurry chilly Tesla Herculean cane-mail pants	0		Experience (Muscle): +1, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5407	bad extra-dry narrow Vodka Matryoshka	5	decent	Last Available: "2011-12"
 5408	mediocre pulsating Gin Mint	3	decent	Last Available: "2011-12"
 5409	extra-dry smooth Tequiz Navidad	5	awesome	Last Available: "2011-12"
 5410	drinkable Mint Yulep	4	good	Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	skewed scorching kumquartz ring	0		Hot Damage: +25, Single Equip, Last Available: "2011-11"
 5425	pulsating clever strawberyl necklace	0		Maximum MP: +20, Single Equip, Last Available: "2011-11"
 5426	wobbly Van der Graaf sucker bucket of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-11"
-5427	sucker hakama of the ox	0		Muscle: +20, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	narrow smelly sucker kabuto	0		Stench Spell Damage: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	sucker hakama of the ox	0		Muscle: +20, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	narrow smelly sucker kabuto	0		Stench Spell Damage: +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	shaking stanky sucker tachi	0		Stench Spell Damage: +25, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	blurry cinnamon troll doll	0		Last Available: "2011-11"
@@ -5338,13 +5338,13 @@
 5435	fudgecule	0		Last Available: "2011-11"
 5436	adjusted fudge lily	0		Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
-5438	corrupted oxidized huge upside-down fluid of fudge-finding	0		Effect: "Graham Crackling", Effect Duration: 32, Last Available: "2011-11"
+5438	corrupted oxidized upside-down huge fluid of fudge-finding	0		Effect: "Graham Crackling", Effect Duration: 32, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	small adequate fudgesicle	2	good	Last Available: "2011-11"
+5440	adequate small fudgesicle	2	good	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	lime green The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	blinking miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
-5444	activated narrow tumbling devilish folio	0		Effect: "Crying, Dying", Effect Duration: 47, Last Available: "2012-12"
+5444	activated tumbling narrow devilish folio	0		Effect: "Crying, Dying", Effect Duration: 47, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	upside-down dangerous jerkcicle	0		Last Available: "2012-12"
@@ -5352,18 +5352,18 @@
 5449	fuchsia vanity stone	0		Last Available: "2012-12"
 5450	lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
-5452	bouncing teal avarice stone	0		Last Available: "2012-12"
+5452	teal bouncing avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	narrow gummi ingot	0		Last Available: "2011-11"
 5457	flattened quantum Fudgie Roll	0		Effect: "Can't Be a Chooser", Effect Duration: 60, Last Available: "2011-11"
-5458	special tasty fudge bunny	4	awesome	Effect: "Expert Vacationer", Effect Duration: 10, Last Available: "2011-11"
+5458	tasty special fudge bunny	4	awesome	Effect: "Expert Vacationer", Effect Duration: 10, Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	executive resourceful brainy fudgecycle	0		Mysticality: +5, Maximum MP: +50, Meat Drop: +40, Single Equip, Last Available: "2011-11"
 5461	huge fudge cube	0		Last Available: "2011-11"
-5462	green upside-down blank fudge mold	0		Last Available: "2011-11"
-5463	mirror Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5462	upside-down green blank fudge mold	0		Last Available: "2011-11"
+5463	mirror Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	pickled wobbly wobbly resolution: be wealthier	0		Effect: "Hairless and Airless", Effect Duration: 23, Last Available: "2012-01"
 5465	dry resolution: be happier	0		Effect: "Almost Cool", Effect Duration: 43, Last Available: "2012-01"
 5466	dry quadruple-boiled wobbly resolution: be stronger	0		Effect: "Blubbered Up", Effect Duration: 45, Last Available: "2012-01"
@@ -5384,7 +5384,7 @@
 5481	small toothsome gummi bear	2	awesome	Last Available: "2011-11"
 5482	stale drunki-bear	3	decent	Last Available: "2011-11"
 5483	rotten drunki-bear	4	crappy	Last Available: "2011-11"
-5484	bite-sized spoiled drunki-bear	1	crappy	Last Available: "2011-11"
+5484	spoiled bite-sized drunki-bear	1	crappy	Last Available: "2011-11"
 5485	supercharged gummi bowtie	0		Maximum MP Percent: +30, Last Available: "2011-11"
 5486	wobbly educational fudge pocket square	0		Experience: +1, Last Available: "2011-11"
 5487	wobbly lollipop cufflinks of wisdom	0		Mysticality: +15, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	corrupted activated irradiated gummi belemnite	0		Effect: "Bastard!", Effect Duration: 56, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	fuchsia heart of dark chocolate	0		Last Available: "2011-11"
-5499	Big Candy's tophat of the pedagogue of the dark arts	0		Experience: +3, Spell Damage Percent: +100, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	Big Candy's tophat of the pedagogue of the dark arts	0		Experience: +3, Spell Damage Percent: +100, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5412,11 +5412,11 @@
 5509	improved activated blurry bottle of bubbles	0		Effect: "One Foot Heavier", Effect Duration: 50, Last Available: "2011-11"
 5510	tarnished altered blurry wind-up meatcar	0		Effect: "Strange Mental Acuity", Effect Duration: 15, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
-5512	shaking upside-down Trivial Avocations Card: When?	0		Last Available: "2011-11"
+5512	upside-down shaking Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	wobbly Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	pog #01 (spider)	0		Last Available: "2011-11"
-5516	lime green jittery blurry pog #02 (Knob goblin)	0		Last Available: "2011-11"
+5516	jittery lime green blurry pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	pulsating pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
@@ -5432,9 +5432,9 @@
 5529	flavorless berries of suffering	3	decent	Last Available: "2012-12"
 5530	alkaline Vulcanized teal baobab sap	0		Effect: "Sludgesick", Effect Duration: 17, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
-5532	narrow blinking magnolia blossom	0		Last Available: "2012-12"
-5533	alkaline irradiated magnetized yellow tumbling Mortimer's nostrum	0		Effect: "License to Punch", Effect Duration: 67, Last Available: "2012-12"
-5534	lousy weak ghostly lime green Barulio's bottle	2	decent	Last Available: "2012-12"
+5532	blinking narrow magnolia blossom	0		Last Available: "2012-12"
+5533	alkaline irradiated magnetized tumbling yellow Mortimer's nostrum	0		Effect: "License to Punch", Effect Duration: 67, Last Available: "2012-12"
+5534	lousy weak lime green ghostly Barulio's bottle	2	decent	Last Available: "2012-12"
 5535	unsweetened adjusted galvanized Marvin's marvelous pill	0		Effect: "Frosty the Hitman", Effect Duration: 23, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5453,7 +5453,7 @@
 5550	twirling The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	spinning Clancy's lute	0		Last Available: "2012-12"
 5552	yellow rosy-cheeked Trusty	0		Maximum HP Percent: +30
-5553	blurry red can of Rain-Doh	0		Last Available: "2012-02"
+5553	red blurry can of Rain-Doh	0		Last Available: "2012-02"
 5554	olive empty Rain-Doh can	0		Last Available: "2012-02"
 5555	pickled moist narrow fireclutch	0		Effect: "License to Punch", Effect Duration: 65
 5556	perfumed Rain-Doh wings of the cheetah	0		Stench Resistance: +5, Initiative: +60, Softcore Only, Last Available: "2012-02"
@@ -5467,25 +5467,25 @@
 5564	cyan Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	stale PB&BP	3	decent	
 5566	rotten small club sandwich	2	crappy	
-5567	stale diet narrow corned-beef Reuben	1	decent	
+5567	diet stale narrow corned-beef Reuben	1	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
-5570	mirror upside-down loose ninja carabiner	0		
+5570	upside-down mirror loose ninja carabiner	0		
 5571	twirling Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	enchanted practically non-alcoholic hand-crafted Drac & Tan	1	EPIC	Effect: "On the Shoulders of Giants", Effect Duration: 50, Last Available: "2012-03"
-5574	weak acceptable Transylvania Sling	2	good	Last Available: "2012-03"
+5574	acceptable weak Transylvania Sling	2	good	Last Available: "2012-03"
 5575	triple-distilled fancy tolerable upside-down Shot of the Living Dead	8	good	Effect: "Mayeaugh", Effect Duration: 40, Last Available: "2012-03"
 5576	bad Buttery Knob	3	decent	Last Available: "2012-03"
 5577	acceptable spinning Slippery Knob	3	good	Last Available: "2012-03"
-5578	distilled perfectly mixed spinning Flaming Knob	5	EPIC	Last Available: "2012-03"
-5579	tolerable watered-down upside-down Grasshopper	2	good	Last Available: "2012-03"
+5578	perfectly mixed distilled spinning Flaming Knob	5	EPIC	Last Available: "2012-03"
+5579	watered-down tolerable upside-down Grasshopper	2	good	Last Available: "2012-03"
 5580	delicious Locust	4	awesome	Last Available: "2012-03"
-5581	lousy weak green Plague of Locusts	2	decent	Last Available: "2012-03"
+5581	weak lousy green Plague of Locusts	2	decent	Last Available: "2012-03"
 5582	drinkable Red Dwarf	4	good	Last Available: "2012-03"
-5583	hand-crafted cyan tumbling Golden Mean	3	EPIC	Last Available: "2012-03"
+5583	hand-crafted tumbling cyan Golden Mean	3	EPIC	Last Available: "2012-03"
 5584	mediocre Green Giant	3	decent	Last Available: "2012-03"
-5585	perfectly mixed watered-down bouncing Aye Aye	2	EPIC	Last Available: "2012-03"
+5585	watered-down perfectly mixed bouncing Aye Aye	2	EPIC	Last Available: "2012-03"
 5586	drinkable Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	smooth watered-down Aye Aye, Tooth Tooth	2	awesome	Last Available: "2012-03"
 5588	tolerable jittery Humanitini	4	good	Last Available: "2012-03"
@@ -5493,36 +5493,36 @@
 5590	tolerable watered-down Oh, the Humanitini	2	good	Last Available: "2012-03"
 5591	hand-crafted weak Great Older Fashioned	2	EPIC	Last Available: "2012-03"
 5592	lousy Fuzzy Tentacle	3	decent	Last Available: "2012-03"
-5593	artisanal practically non-alcoholic Crazymaker	1	super ultra EPIC	Last Available: "2012-03"
+5593	practically non-alcoholic artisanal Crazymaker	1	super ultra EPIC	Last Available: "2012-03"
 5594	mediocre watered-down shaking Zoodriver	2	decent	Last Available: "2012-03"
 5595	hand-crafted triple-distilled Sloe Comfortable Zoo	7	EPIC	Last Available: "2012-03"
 5596	boozy delicious Sloe Comfortable Zoo on Fire	5	awesome	Last Available: "2012-03"
 5597	drinkable Suffering Sinner	4	good	Last Available: "2012-03"
-5598	practically non-alcoholic acceptable special Suppurating Sinner	1	good	Effect: "Biologically Shocked", Effect Duration: 50, Last Available: "2012-03"
+5598	special practically non-alcoholic acceptable Suppurating Sinner	1	good	Effect: "Biologically Shocked", Effect Duration: 50, Last Available: "2012-03"
 5599	drinkable Sizzling Sinner	4	good	Last Available: "2012-03"
 5600	aged weak Firewater	2	awesome	Last Available: "2012-03"
 5601	perfectly mixed Earth and Firewater	3	EPIC	Last Available: "2012-03"
-5602	acceptable weak Earth, Wind and Firewater	2	good	Last Available: "2012-03"
+5602	weak acceptable Earth, Wind and Firewater	2	good	Last Available: "2012-03"
 5603	lousy Slimosa	3	decent	Last Available: "2012-03"
 5604	lousy squat Extra-slimy Slimosa	3	decent	Last Available: "2012-03"
-5605	acceptable weak Slimebite	2	good	Last Available: "2012-03"
+5605	weak acceptable Slimebite	2	good	Last Available: "2012-03"
 5606	bad Cement Mixer	3	decent	Last Available: "2012-03"
 5607	lousy bouncing Jackhammer	4	decent	Last Available: "2012-03"
 5608	delicious Dump Truck	3	awesome	Last Available: "2012-03"
 5609	tolerable Fauna Libre	3	good	Last Available: "2012-03"
-5610	bad practically non-alcoholic Chakra Libre	1	decent	Last Available: "2012-03"
+5610	practically non-alcoholic bad Chakra Libre	1	decent	Last Available: "2012-03"
 5611	acceptable Aura Libre	3	good	Last Available: "2012-03"
-5612	watered-down smooth purple Sazerorc	2	awesome	Last Available: "2012-03"
+5612	smooth watered-down purple Sazerorc	2	awesome	Last Available: "2012-03"
 5613	mediocre enchanted green Sazuruk-hai	4	decent	Effect: "In Tuna", Effect Duration: 25, Last Available: "2012-03"
 5614	acceptable skewed Flaming Sazerorc	3	good	Last Available: "2012-03"
 5615	drinkable Green Velvet	3	good	Last Available: "2012-03"
-5616	aged watered-down Green Muslin	2	awesome	Last Available: "2012-03"
+5616	watered-down aged Green Muslin	2	awesome	Last Available: "2012-03"
 5617	practically non-alcoholic hand-crafted Green Burlap	1	super ultra EPIC	Last Available: "2012-03"
 5618	mediocre Mohobo	3	decent	Last Available: "2012-03"
-5619	smooth practically non-alcoholic Moonshine Mohobo	1	awesome	Last Available: "2012-03"
+5619	practically non-alcoholic smooth Moonshine Mohobo	1	awesome	Last Available: "2012-03"
 5620	bad Flaming Mohobo	3	decent	Last Available: "2012-03"
 5621	hand-crafted special Drunken Philosopher	3	EPIC	Effect: "Demonic Taint", Effect Duration: 50, Last Available: "2012-03"
-5622	drinkable watered-down Drunken Neurologist	2	good	Last Available: "2012-03"
+5622	watered-down drinkable Drunken Neurologist	2	good	Last Available: "2012-03"
 5623	mediocre watered-down Drunken Astrophysicist	2	decent	Last Available: "2012-03"
 5624	hand-crafted Dark & Starry	3	EPIC	Last Available: "2012-03"
 5625	lousy pulsating blurry Black Hole	3	decent	Last Available: "2012-03"
@@ -5530,32 +5530,32 @@
 5627	triple-distilled bad Herring Daiquiri	10	decent	Last Available: "2012-03"
 5628	special lousy Herring Wallbanger	4	decent	Effect: "Phairly Pheromonal", Effect Duration: 10, Last Available: "2012-03"
 5629	practically non-alcoholic perfectly mixed Herringtini	1	super ultra EPIC	Last Available: "2012-03"
-5630	artisanal watered-down blinking Lollipop Drop	2	EPIC	Last Available: "2012-03"
+5630	watered-down artisanal blinking Lollipop Drop	2	EPIC	Last Available: "2012-03"
 5631	smooth Candy Alexander	3	awesome	Last Available: "2012-03"
 5632	tolerable twirling Candicaine	3	good	Last Available: "2012-03"
 5633	smooth upside-down Caipiranha	4	awesome	Last Available: "2012-03"
-5634	bad weak Flying Caipiranha	2	decent	Last Available: "2012-03"
-5635	aged extra-dry blue narrow Flaming Caipiranha	5	awesome	Last Available: "2012-03"
+5634	weak bad Flying Caipiranha	2	decent	Last Available: "2012-03"
+5635	aged extra-dry narrow blue Flaming Caipiranha	5	awesome	Last Available: "2012-03"
 5636	tolerable Punchplanter	4	good	Last Available: "2012-03"
 5637	bad teal Doublepunchplanter	3	decent	Last Available: "2012-03"
 5638	delicious mirror Haymaker	4	awesome	Last Available: "2012-03"
 5639	fuchsia Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	yellow crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	adequate massive fungus	9	good	
+5641	massive adequate fungus	9	good	
 5642	poisoned dart	0		
 5643	ionized modified red stone wool	0		Effect: "Deadly Lampblade", Effect Duration: 58
 5644	stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	calendar of the wise owl	0		Mysticality: +20, Damage Reduction: 4
-5648	spinning scandalous vibrating Boris's Helm	0		Maximum MP Percent: +10, Sleaze Damage: +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	spinning scandalous vibrating Boris's Helm	0		Maximum MP Percent: +10, Sleaze Damage: +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	pulsating sharpshooter's groovy staph of homophones	0		Moxie Percent: +10, Critical Hit Percent: +10
-5650	razor-sharp Boris's Helm (askew) of James Dean of Flo-Jo	0		Experience (Moxie): +3, Weapon Damage Percent: +25, Initiative: +100, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	razor-sharp Boris's Helm (askew) of James Dean of Flo-Jo	0		Experience (Moxie): +3, Weapon Damage Percent: +25, Initiative: +100, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	rotten big nailswurst	5	crappy	
-5655	artisanal practically non-alcoholic used beer	1	EPIC	
+5655	practically non-alcoholic artisanal used beer	1	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5577,13 +5577,13 @@
 5674	&quot;L&quot;	0		
 5675	modified wobbly watered-down Red Minotaur	1		
 5676	cyan pulsating pool torpedo	0		Last Available: "2012-05"
-5677	teal knitted Ze&trade; goggles	0		Cold Resistance: +3, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	teal knitted Ze&trade; goggles	0		Cold Resistance: +3, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	ghostly soggy used band-aid	0		Last Available: "2012-05"
-5679	smelly stylish swimsuit of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	smelly stylish swimsuit of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	ghostly lost key	0		Last Available: "2012-05"
 5681	toothsome mirror P.B.L.T.	3	awesome	
 5682	note from Clancy	0		Skill: "Request Sandwich"
-5683	twirling shaking BURT	0		
+5683	shaking twirling BURT	0		
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	ghostly yellow crayon shavings	0		Last Available: "2012-06"
 5704	twirling wax bugbear	0		Last Available: "2012-06"
-5705	mirror shellacked wax hat of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	stanky Lo Pan's wax pants	0		Spell Critical Percent: +30, Stench Spell Damage: +25, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	mirror shellacked wax hat of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	stanky Lo Pan's wax pants	0		Spell Critical Percent: +30, Stench Spell Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
-5708	altered deionized ghostly lime green spinning drop of water-37	0		Effect: "Thick-Skinned", Effect Duration: 16, Last Available: "2012-07"
-5709	jittery yellow zippy chaotic fireman's helmet	0		Spell Critical Percent: +10, Initiative: +20, Last Available: "2012-07", Familiar Effect: "cold atk"
+5708	altered deionized spinning ghostly lime green drop of water-37	0		Effect: "Thick-Skinned", Effect Duration: 16, Last Available: "2012-07"
+5709	jittery yellow zippy chaotic fireman's helmet	0		Spell Critical Percent: +10, Initiative: +20, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	huge hardy fire axe	0		Maximum HP: +50, Last Available: "2012-07"
 5713	ruddy banded fortified fire extinguisher	0		Damage Absorption: 160, Maximum HP Percent: +40, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,22 +5618,22 @@
 5717	spoiled fancy jumbo FDKOL hotcakes	5	crappy	Effect: "Braaaains Over Braaaawwn", Effect Duration: 50, Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	thick stale fiery wing	5	decent	Last Available: "2012-07"
+5720	stale thick fiery wing	5	decent	Last Available: "2012-07"
 5721	pulsating vibrating stiffened wings of fire	0		Damage Reduction: 1, Maximum MP Percent: +10, Last Available: "2012-07"
 5722	prompt FDKOL fire hose	0		Adventures: +3, Last Available: "2012-07"
 5723	boiled colloidal pulsating bottle of fire	0		Effect: "Less Pervious", Effect Duration: 55, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
-5725	spinning skewed lime green mirror hot daub	0		Last Available: "2012-07"
-5726	shaking Tesla dangerous hot daub bun	0		Weapon Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	huge MacGyver's wicked hot daub stand	0		Spell Damage: +5, Maximum MP: +100, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5725	skewed mirror lime green spinning hot daub	0		Last Available: "2012-07"
+5726	shaking Tesla dangerous hot daub bun	0		Weapon Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	huge MacGyver's wicked hot daub stand	0		Spell Damage: +5, Maximum MP: +100, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	nasty nippy foot-long hot daub	0		Cold Damage: +10, Stench Damage: +5, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	stale angst burger	4	decent	
 5731	hand-crafted blinking 5-hour acrimony	3	EPIC	
 5732	tumbling blank note	0		
 5733	blue eerily silent box	0		
-5734	rotten tiny forbidden sausage	1	crappy	
-5735	lightning-fast Lord Flameface's cloak	0		Initiative: +40, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5734	tiny rotten forbidden sausage	1	crappy	
+5735	lightning-fast Lord Flameface's cloak	0		Initiative: +40, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	denatured squat Drizzlers&trade; Black Licorice	0		Effect: "Nutrient-Rich", Effect Duration: 67
 5737	double-irradiated colloidal blue daub-breaker	0		Effect: "Jawin'", Effect Duration: 26, Last Available: "2020-09"
 5738	cyan bouncing sharpshooter's Camp Scout backpack	0		Critical Hit Percent: +10, Softcore Only, Last Available: "2012-07"
@@ -5665,16 +5665,16 @@
 5765	fireproof fuzzy earmuffs of terror	0		Spooky Spell Damage: +10, Hot Resistance: +3, Familiar Effect: "1.5xVolley, cap 32"
 5766	Sherlock's personal trainer's fuzzy montera of the early riser	0		Experience Percent (Muscle): +10, Item Drop: +25, Adventures: +7, Familiar Effect: "1.5xVolley, cap 32"
 5767	blurry Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	huge gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	upside-down gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5769	huge gnomish coal miner's lung	0		Familiar Effect: "block", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5771	upside-down gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
 5773	Thwaitgold maggot statuette	0		
 5774	upside-down talkative skull	0		
-5775	bouncing jittery fronts	0		Familiar Weight: +5
+5775	jittery bouncing fronts	0		Familiar Weight: +5
 5776	jittery shaking rosewater-soaked wholesome Barney's rake	0		Maximum HP Percent: +10, Stench Resistance: +3
-5778	small bland pulsating idiot brain	2	decent	
+5778	bland small pulsating idiot brain	2	decent	
 5779	twirling shaking Socratic keel-haulin' knife	0		Experience (Mysticality): +1
 5780	up-at-dawn ice cream scoop	0		Adventures: +5
 5781	drinkable soft echo eyedrop antidote martini	4	good	
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	huge greasy curative right bear arm	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	wobbly pulsating prompt executive left bear arm of the cheetah	0		Meat Drop: +40, Initiative: +60, Adventures: +3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	huge greasy curative right bear arm	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	wobbly pulsating prompt executive left bear arm of the cheetah	0		Meat Drop: +40, Initiative: +60, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	red savvy Hat O' Nine Tails	0		Mysticality Percent: +20
 5794	cold-filtered pickled anodized cyan Enchanted Plunger	0		Effect: "Gummi Badass", Effect Duration: 50
 5795	concentrated jittery Enchanted Flyswatter	0		Effect: "Memory of Resilience", Effect Duration: 43
@@ -5711,12 +5711,12 @@
 5812	polarized skelelton spine	0		Effect: "Meat the Flintstones", Effect Duration: 43
 5813	enhanced extra-nitrogenated magnetized bouncing smut orc sunglasses	0		Effect: "Quadrilled", Effect Duration: 21
 5814	ionized teal tumbling blob of acid	0		Effect: "Action", Effect Duration: 41
-5815	electrified gray blinking tumbling flayed mind	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 44
+5815	electrified blinking tumbling gray flayed mind	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 44
 5816	cold-filtered kobold kibble	0		Effect: "Human-Slime Hybrid", Effect Duration: 21
 5817	improved frozen forest spirit rattle	0		Effect: "Jelly Combed", Effect Duration: 58
 5818	warmed vacuum-sealed Stone Golem pebbles	0		Effect: "Fratty Flavor", Effect Duration: 18
 5819	galvanized gravy fairy warlock hat	0		Effect: "Alacri Tea", Effect Duration: 23
-5820	dry deionized tumbling mirror bull blubber	0		Effect: "Raging Animal", Effect Duration: 21
+5820	dry deionized mirror tumbling bull blubber	0		Effect: "Raging Animal", Effect Duration: 21
 5821	pickled bouncing frog lip-print	0		Effect: "Dweeby", Effect Duration: 36
 5822	ionized gazely stare	0		Effect: "Burnt 'n' Turnt", Effect Duration: 64
 5823	quantum canopic jar	0		Effect: "Feet of Grapefruit", Effect Duration: 18
@@ -5758,7 +5758,7 @@
 5859	wet triple-dry narrow booby trap	0		Effect: "Hippy Flavor", Effect Duration: 67
 5860	quantum dry Agent Corrigan's cigarette	0		Effect: "Nightlit", Effect Duration: 16
 5861	dry colloidal good ash	0		Effect: "Wolf's Bane", Effect Duration: 12
-5862	narrow Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	narrow Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	spinning papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	ionized papier-mochi	0		Effect: "Become Intensely interested", Effect Duration: 56, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	twirling lard-coated Sinatra's papier-m&acirc;ch&eacute;te	0		Experience (Moxie): +5, Sleaze Spell Damage: +25, Last Available: "2012-09"
 5869	shaking Temple Grandin's Samson's papier-m&acirc;chine gun	0		Experience (Muscle): +5, Familiar Weight: +7, Last Available: "2012-09"
 5870	beefcake's papier-masque of temperance	0		Muscle: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2012-09"
-5871	purple weightlifter's papier-mitre of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	Usain Bolt's reassuring papier-m&acirc;churidars	0		Spooky Resistance: +1, Initiative: +80, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	purple weightlifter's papier-mitre of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	Usain Bolt's reassuring papier-m&acirc;churidars	0		Spooky Resistance: +1, Initiative: +80, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5790,17 +5790,17 @@
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	activated super-tarnished ionized pulsating that gum you like	0		Effect: "Shot in the Arse", Effect Duration: 22
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
-5894	cyan squat Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
+5894	squat cyan Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	huge avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
-5896	ghostly gray canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
+5896	gray ghostly canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	vaporized Unconscious Collective Dream Jar	1	crappy	Last Available: "2013-12"
 5898	skewed jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	ghostly jar of psychoses (The Old Man)	0		Last Available: "2013-12"
-5902	wobbly gray jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
+5902	gray wobbly jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	bouncing jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
-5905	huge pulsating jar of psychoses (Jick)	0		Last Available: "2013-12"
+5905	pulsating huge jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	pixel pill	0		
 5907	pixel energy tank	0		
 5908	ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
@@ -5821,9 +5821,9 @@
 5923	squat plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	pulsating red BittyCar MeatCar	0		Last Available: "2012-12"
+5926	red pulsating BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	squat horrifying brainwave-controlled unicorn horn	0		Spooky Damage: +25, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	squat horrifying brainwave-controlled unicorn horn	0		Spooky Damage: +25, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blurry blind-packed capsule toy	0		Last Available: "2012-12"
 5931	nippy occult plastic four-shadowed mime of bravery	0		Spell Damage Percent: +25, Cold Damage: +10, Spooky Resistance: +5, Single Equip, Last Available: "2012-12"
@@ -5858,10 +5858,10 @@
 5960	tumbling resourceful plastic Father McGruber	0		Maximum MP: +50, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of the cheetah	0		Initiative: +60, Last Available: "2012-12"
 5962	beefcake's plastic blazing bat	0		Muscle: +25, Last Available: "2012-12"
-5963	greasy friendly electronic dulcimer pants	0		Familiar Weight: +3, Sleaze Spell Damage: +10, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	greasy friendly electronic dulcimer pants	0		Familiar Weight: +3, Sleaze Spell Damage: +10, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	inspector's ruddy Frown Exerciser	0		Maximum HP Percent: +40, Item Drop: +15, Single Equip, Last Available: "2012-12"
-5966	wobbly blinking soul monocle	0		Single Equip
+5966	blinking wobbly soul monocle	0		Single Equip
 5967	bouncing soul doorbell	0		
 5968	maroon soul coin	0		
 5969	huge tumbling soul knife	0		
@@ -5877,31 +5877,31 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	mediocre triple-distilled tankard of ale	7	decent	Last Available: "2013-02"
+5982	triple-distilled mediocre tankard of ale	7	decent	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	greasy cloth cap of extreme caution of incineration	0		Monster Level: -25, Hot Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	greasy cloth cap of extreme caution of incineration	0		Monster Level: -25, Hot Spell Damage: +50, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	aromatic toasty iron dagger of Flo-Jo	0		Hot Damage: +5, Stench Resistance: +1, Initiative: +100, Last Available: "2013-02"
 5986	normal big hamburger	5	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	pulsating potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	strong bad bottle of wine	5	decent	Last Available: "2013-02"
+5990	bad strong bottle of wine	5	decent	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	asbestos-lined banded iron helmet of the overflowing toilet	0		Damage Absorption: +100, Stench Spell Damage: +50, Hot Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	asbestos-lined banded iron helmet of the overflowing toilet	0		Damage Absorption: +100, Stench Spell Damage: +50, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	Usain Bolt's clever steel sword of the sewer	0		Maximum MP: +20, Stench Damage: +25, Initiative: +80, Last Available: "2013-02"
-5994	moldy big whole roasted chicken	5	crappy	Last Available: "2013-02"
-5995	narrow skewed massive gemstone	0		Last Available: "2013-02"
+5994	big moldy whole roasted chicken	5	crappy	Last Available: "2013-02"
+5995	skewed narrow massive gemstone	0		Last Available: "2013-02"
 5996	blinking extra-strength potion	0		Last Available: "2013-02"
 5997	ghostly potion	0		Last Available: "2013-02"
-5998	fancy weak tolerable shining goblet	2	good	Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2013-02"
+5998	tolerable fancy weak shining goblet	2	good	Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	miser's Samson's crown of the cheetah	0		Experience (Muscle): +5, Meat Drop: +10, Initiative: +60, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	miser's Samson's crown of the cheetah	0		Experience (Muscle): +5, Meat Drop: +10, Initiative: +60, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	wobbly lion tamer's beefy sword of terror	0		Muscle: +10, Experience (familiar): +2, Spooky Spell Damage: +10, Last Available: "2013-02"
-6002	auspicious Jim Carey's Helm of the Scream Emperor of James Dean	0		Experience (Moxie): +3, Monster Level: +25, Item Drop: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	auspicious Jim Carey's Helm of the Scream Emperor of James Dean	0		Experience (Moxie): +3, Monster Level: +25, Item Drop: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	resourceful wholesome Cloak of Dire Shadows of wisdom	0		Mysticality: +15, Maximum HP Percent: +10, Maximum MP: +50, Last Available: "2013-02"
 6004	bouncing stylish Sword of Dark Omens of the detective of the boozehound	0		Moxie: +25, Item Drop: +20, Booze Drop: +100, Last Available: "2013-02"
 6005	olive sharpshooter's rosy-cheeked wicked Shield of Icy Fate	0		Spell Damage: +5, Maximum HP Percent: +30, Critical Hit Percent: +10, Damage Reduction: 7, Last Available: "2013-02"
-6006	Jeselnik's hardy wholesome Greaves of the Murk Lord	0		Maximum HP Percent: +10, Maximum HP: +50, Sleaze Damage: +25, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	Jeselnik's hardy wholesome Greaves of the Murk Lord	0		Maximum HP Percent: +10, Maximum HP: +50, Sleaze Damage: +25, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	squat Usain Bolt's nippy weightlifter's Gauntlets of the Blood Moon	0		Muscle: +15, Cold Damage: +10, Initiative: +80, Single Equip, Last Available: "2013-02"
 6008	inspector's coward's Boots of Twilight Whispers of Tarzan	0		Experience (Muscle): +3, Monster Level: -20, Item Drop: +15, Single Equip, Last Available: "2013-02"
 6009	frightening deadly beefcake's Belt of Howling Anger	0		Muscle: +25, Weapon Damage: +5, Spooky Damage: +5, Single Equip, Last Available: "2013-02"
@@ -5911,7 +5911,7 @@
 6013	blinking Temple Grandin's energetic orcish stud-finder	0		Maximum MP Percent: +20, Familiar Weight: +7
 6014	blue Samson's screwing pooch	0		Experience (Muscle): +5
 6015	frozen polymerized altered orcish hand lotion	0		Effect: "So Fresh and So Clean", Effect Duration: 36
-6016	quantum cold-filtered shaking gray orcish rubber	0		Effect: "Employee of the Month", Effect Duration: 16
+6016	quantum cold-filtered gray shaking orcish rubber	0		Effect: "Employee of the Month", Effect Duration: 16
 6017	extra-irradiated orcish nailing lube	0		Effect: "Wit Tea", Effect Duration: 39
 6018	special smooth backwoods screwdriver	4	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 30
 6019	curative loadstone	0		HP Regen Min: 3, HP Regen Max: 5
@@ -5931,9 +5931,9 @@
 6033	scandalous wizardly stolen necklace	0		Mysticality: +25, Sleaze Damage: +5
 6034	wholesome deadly troll britches	0		Weapon Damage: +5, Maximum HP Percent: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	tarnished vial of The Glistening	0		Effect: "Dragged Through the Coals", Effect Duration: 45
-6036	practically non-alcoholic perfectly mixed tumbling artisanal limoncello	1	EPIC	
+6036	perfectly mixed practically non-alcoholic tumbling artisanal limoncello	1	EPIC	
 6037	maroon ginger ale	0		
-6038	small adequate fancy incredible pizza	2	good	Effect: "Barbecue Saucy", Effect Duration: 25
+6038	adequate small fancy incredible pizza	2	good	Effect: "Barbecue Saucy", Effect Duration: 25
 6039	ghostly rosewater-soaked frosty oil cap	0		Cold Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "cap 28"
 6040	sizzling oil lamp of dire peril	0		Weapon Damage: +20, Hot Damage: +10
 6041	blurry oil slacks of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xPotato, cap 30"
@@ -5941,7 +5941,7 @@
 6043	boid	0		
 6044	woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	spinning pulsating BittyCar SoulCar	0		Last Available: "2012-12"
+6046	pulsating spinning BittyCar SoulCar	0		Last Available: "2012-12"
 6047	tumbling fireproof personal trainer's Misty Cloak	0		Experience Percent (Muscle): +10, Hot Resistance: +3
 6048	boxer's Misty Robe of the dark arts	0		Muscle Percent: +10, Spell Damage Percent: +100
 6049	wobbly foul-smelling Annie Oakley's quilted Misty Cape	0		Damage Absorption: +40, Critical Hit Percent: +20, Stench Damage: +10
@@ -5966,17 +5966,17 @@
 6068	yellow loose blade	0		
 6069	mirror goblin bone hilt	0		
 6070	bouncing sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	double-electrified unsweetened ionized haggis-infused soap	0		Effect: "Texas Elegance", Effect Duration: 43, Last Available: "2012-12"
 6074	triple-pressed shaking skewed magicberry tablets	0		Effect: "Human-Machine Hybrid", Effect Duration: 23, Last Available: "2012-12"
 6075	quadruple-adjusted Vulcanized 37x37x37 puzzle cube	0		Effect: "Creepin' Up on You", Effect Duration: 21, Last Available: "2012-12"
-6076	fancy artisanal irresponsibly strong blue McLeod's Hard Haggis-Ade	7	EPIC	Effect: "Pasta Oneness", Effect Duration: 20, Last Available: "2012-12"
-6077	fancy moldy half-sized haggis-wrapped haggis-stuffed haggis	2	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 25, Last Available: "2012-12"
+6076	irresponsibly strong artisanal fancy blue McLeod's Hard Haggis-Ade	7	EPIC	Effect: "Pasta Oneness", Effect Duration: 20, Last Available: "2012-12"
+6077	fancy half-sized moldy haggis-wrapped haggis-stuffed haggis	2	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 25, Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	narrow school calculator watch	0		Last Available: "2012-12"
-6080	blurry haggis socks of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	blurry haggis socks of the wise owl	0		Mysticality: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	maroon actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -5997,7 +5997,7 @@
 6099	purple gravedigger's Thinknerd T-Shirt	0		Spooky Damage: +10, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
 6101	homemade robot	0		Last Available: "2012-12"
-6102	bouncing pulsating homemade robot gear	0		Last Available: "2012-12"
+6102	pulsating bouncing homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	upside-down Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	Artist's Spatula of Despair	0		Last Available: "2013-12"
@@ -6012,11 +6012,11 @@
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	green CEO office card	0		Last Available: "2013-12"
-6117	spinning narrow gray test site key	0		Last Available: "2013-12"
+6117	narrow spinning gray test site key	0		Last Available: "2013-12"
 6118	goggles	0		Last Available: "2013-12"
 6119	blurry abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	bad watered-down Chinese beer	2	decent	Last Available: "2013-12"
+6121	watered-down bad Chinese beer	2	decent	Last Available: "2013-12"
 6122	wobbly fuchsia cat statue	0		Last Available: "2013-12"
 6123	ghostly rhinoceros horn	0		Last Available: "2013-12"
 6124	olive furry pink pillow	0		Last Available: "2013-12"
@@ -6040,10 +6040,10 @@
 6142	rotten roasted duck	3	crappy	Last Available: "2013-12"
 6143	toothsome blurry dead meat bun	4	awesome	Last Available: "2013-12"
 6144	blinking squat therapeutic cat collar	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
-6145	bouncing nasty dance instructor's suspicious-looking fedora	0		Experience Percent (Moxie): +10, Stench Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	bouncing nasty dance instructor's suspicious-looking fedora	0		Experience Percent (Moxie): +10, Stench Damage: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
-6149	blinking tumbling MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
+6149	tumbling blinking MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	moldy upside-down carrot cake	3	crappy	Last Available: "2013-01"
@@ -6052,14 +6052,14 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	wobbly flickering pixel	0		Last Available: "2013-12"
 6157	nippy supercool Byte	0		Moxie Percent: +20, Cold Damage: +10, Last Available: "2013-12"
-6158	red jittery personal trainer's anger blaster	0		Experience Percent (Muscle): +10, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	censurious doubt cannon	0		Sleaze Resistance: +3, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	fear condenser of Tarzan	0		Experience (Muscle): +3, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	upside-down lard-coated regret hose	0		Sleaze Spell Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	red jittery personal trainer's anger blaster	0		Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	censurious doubt cannon	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	fear condenser of Tarzan	0		Experience (Muscle): +3, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	upside-down lard-coated regret hose	0		Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	skewed Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	strapping commodore's hat of the sewer	0		Muscle: +5, Stench Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	naval trousers of the businessman	0		Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	strapping commodore's hat of the sewer	0		Muscle: +5, Stench Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	naval trousers of the businessman	0		Meat Drop: +50, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	rosy-cheeked deck cannon of the cheetah	0		Maximum HP Percent: +30, Initiative: +60, Last Available: "2013-12"
 6167	squat energetic ornamental sextant	0		Maximum MP Percent: +20, Last Available: "2013-12"
 6168	purple brawny Bloodbath of the cheetah	0		Muscle Percent: +20, Initiative: +60, Last Available: "2013-12"
@@ -6079,10 +6079,10 @@
 6182	cosmic cream	0		
 6183	upside-down cosmic fruit	0		
 6184	huge avaricious therapeutic Jarlsberg's hat of doom	0		Spooky Spell Damage: +50, Meat Drop: +30, HP Regen Min: 5, HP Regen Max: 7
-6185	enchanted stale small consummate hard-boiled egg	2	decent	Effect: "Deep-Seated Rage", Effect Duration: 20
+6185	small stale enchanted consummate hard-boiled egg	2	decent	Effect: "Deep-Seated Rage", Effect Duration: 20
 6186	adequate consummate fried egg	3	good	
 6187	tasty consummate egg salad	4	awesome	
-6188	super-sized decent tumbling huge consummate bagel	5	good	
+6188	decent super-sized tumbling huge consummate bagel	5	good	
 6189	toothsome half-sized blurry upside-down consummate sliced bread	2	awesome	
 6190	flavorless consummate hot dog bun	4	decent	
 6191	super-sized decent consummate brownie	5	good	
@@ -6090,32 +6090,32 @@
 6193	lousy passable stout	3	decent	
 6194	diet spoiled gray consummate soup	1	crappy	
 6195	bland consummate corn chips	4	decent	
-6196	super-sized yummy mirror consummate salad	5	awesome	
+6196	yummy super-sized mirror consummate salad	5	awesome	
 6197	moldy consummate salsa	3	crappy	
 6198	spoiled blurry consummate sauerkraut	3	crappy	
 6199	toothsome consummate cheese slice	3	awesome	
 6200	tasty special consummate melted cheese	3	awesome	Effect: "Industrial Strength Starch", Effect Duration: 25
 6201	moldy consummate bacon	4	crappy	
 6202	decent consummate meatloaf	3	good	
-6203	yummy jumbo consummate steak	5	awesome	
+6203	jumbo yummy consummate steak	5	awesome	
 6204	stale pulsating yellow consummate cuts	3	decent	
 6205	flavorless gigantic consummate frankfurter	9	decent	
 6206	immense bland ghostly consummate french fries	6	decent	
 6207	yummy diet fuchsia consummate baked potato	1	awesome	
 6208	drinkable acceptable vodka	3	good	
-6209	small fancy moldy squat consummate ice cream	2	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 5
+6209	fancy small moldy squat consummate ice cream	2	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 5
 6210	moldy small consummate whipped cream	2	crappy	
 6211	moldy mirror consummate cream	3	crappy	
 6212	yummy twirling consummate strawberries	4	awesome	
 6213	decent half-sized consummate sorbet	2	good	
 6214	drinkable upside-down adequate rum	3	good	
-6215	watered-down tolerable mediocre lager	2	good	
+6215	tolerable watered-down mediocre lager	2	good	
 6216	flavorless huge immaculate grilled cheese	3	decent	
 6217	half-sized bland immaculate ice cream sandwich	2	decent	
 6218	spoiled low-calorie immaculate hot dog	1	crappy	
 6219	decent immaculate egg salad sandwich	3	good	
 6220	small rotten pulsating perfect sandwich	2	crappy	
-6221	normal bite-sized perfect chef salad	1	good	
+6221	bite-sized normal perfect chef salad	1	good	
 6222	spoiled gigantic perfect breakfast	8	crappy	
 6223	adequate sublime deluxe hot dog	4	good	
 6224	spoiled shaking sublime stew	4	crappy	
@@ -6124,13 +6124,13 @@
 6227	spoiled Loaded Baked Potato	4	crappy	
 6228	normal diet Omega Sundae	1	good	
 6229	tolerable Das Sauerlager	3	good	
-6230	high-proof smooth Bologna Lambic	7	awesome	
+6230	smooth high-proof Bologna Lambic	7	awesome	
 6231	drinkable Vodka Dog	4	good	
-6232	artisanal practically non-alcoholic Disappointed Russian	1	super ultra EPIC	
-6233	practically non-alcoholic smooth Chunky Mary	1	awesome	
+6232	practically non-alcoholic artisanal Disappointed Russian	1	super ultra EPIC	
+6233	smooth practically non-alcoholic Chunky Mary	1	awesome	
 6234	acceptable Nachojito	4	good	
 6235	perfectly mixed Le Roi	3	EPIC	
-6236	watered-down tolerable Over Easy Rider	2	good	
+6236	tolerable watered-down Over Easy Rider	2	good	
 6237	cosmic six-pack	0		
 6239	moist improved wet cube of ectoplasm	0		Effect: "Pronounced Potency", Effect Duration: 39
 6240	ionized diffused spinning Illuminati earpiece	0		Effect: "Elvish", Effect Duration: 39
@@ -6138,7 +6138,7 @@
 6242	adjusted upside-down ectoplasm <i>au jus</i>	0		Effect: "Slimily Strong", Effect Duration: 61
 6243	adjusted ionized the kindest cut	0		Effect: "Larger", Effect Duration: 14
 6244	oxidized deionized cat's paw	0		Effect: "Gonna Get You, Sucker", Effect Duration: 57
-6245	dry super-vacuum-sealed blurry gray shaking ASCII fu manchu	0		Effect: "Radiated and Grodiated", Effect Duration: 52
+6245	dry super-vacuum-sealed blurry shaking gray ASCII fu manchu	0		Effect: "Radiated and Grodiated", Effect Duration: 52
 6246	liquefied upside-down demonic surgical gloves	0		Effect: "Quiet 'n' Good", Effect Duration: 23
 6247	wet blurry clip-on ninja tie	0		Effect: "Amplified Fabulousness", Effect Duration: 46
 6248	anodized mirror gamer slurry	0		Effect: "Night Vision", Effect Duration: 34
@@ -6149,7 +6149,7 @@
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
-6256	squat wobbly fuchsia dried gelatinous cube	0		
+6256	wobbly fuchsia squat dried gelatinous cube	0		
 6257	cyan pile of dungeon junk	0		Familiar Weight: +5
 6258	bouncing bouncing hardened padded razor-sharp dance instructor's Staff of the Healthy Breakfast	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Damage Absorption: +20, Damage Reduction: 3, Jiggle: "Recover Some HP"
 6259	bouncing censurious frosty rock-hard Staff of the Staff of Life of bravery	0		Damage Reduction: 5, Cold Spell Damage: +10, Spooky Resistance: +5, Sleaze Resistance: +3, Jiggle: "Full HP Recovery"
@@ -6160,7 +6160,7 @@
 6264	maroon greedy Rosewater's wizardly Staff of Fruit Salad	0		Mysticality: +25, Mysticality Percent: +30, Meat Drop: +20, Jiggle: "Deal Some Prismatic Damage"
 6265	frosty sage Staff of the Cream of the Cream of the blizzard	0		Mysticality Percent: +10, Cold Spell Damage: 35, Jiggle: "Attune to Monster's Essence"
 6266	pulsating jar of protein powder	0		
-6267	snack-sized toothsome grain of protein powder	2	awesome	
+6267	toothsome snack-sized grain of protein powder	2	awesome	
 6268	super-dry pec oil	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 28
 6269	arcane researcher's gym membership card	0		Experience Percent (Mysticality): +10
 6270	adjusted vacuum-sealed pulsating green Squat-Thrust Magazine	0		Effect: "Sugary Tongue", Effect Duration: 64
@@ -6169,7 +6169,7 @@
 6273	adjusted alkaline O'RLY manual	0		Effect: "Chock Full o' Nanites", Effect Duration: 59
 6274	lousy distilled open sauce	5	decent	
 6275	zippy nippy turkey leg	0		Cold Damage: +10, Initiative: +20
-6276	weak mediocre narrow spinning Ye Olde Meade	2	decent	
+6276	mediocre weak spinning narrow Ye Olde Meade	2	decent	
 6277	triple-boiled electrified wobbly Ye Olde Bawdy Limerick	0		Effect: "Patent Alacrity", Effect Duration: 18
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of incineration	0		Hot Spell Damage: +50
@@ -6186,7 +6186,7 @@
 6290	olive steam-powered model rocketship	0		
 6291	lion tamer's dangerous punk rock jacket	0		Weapon Damage: +10, Experience (familiar): +2
 6292	mirror ribald beefcake's safety pin	0		Muscle: +25, Sleaze Damage: +10
-6293	miniature tasty spinning stolen sushi	2	awesome	
+6293	tasty miniature spinning stolen sushi	2	awesome	
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6238,7 +6238,7 @@
 6342	manspreader's super-strong air freshener of Gandalf	0		Spell Critical Percent: +20, Monster Level: +10
 6343	concentrated cyan Mer-kin lipstick	0		Effect: "Mushroom Might", Effect Duration: 26
 6344	Mer-kin mouthsoap	0		
-6345	dry double-enhanced frozen narrow fuchsia Mer-kin strongjuice	0		Effect: "Mushroom Magicalness", Effect Duration: 51
+6345	dry double-enhanced frozen fuchsia narrow Mer-kin strongjuice	0		Effect: "Mushroom Magicalness", Effect Duration: 51
 6346	Mer-kin fitbrine	0		
 6347	frozen twirling Mer-kin ragejuice	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 33
 6348	wool Mer-kin dragbelt	0		Cold Resistance: +1, Experience (Muscle): +20, Single Equip
@@ -6253,7 +6253,7 @@
 6357	upside-down Mer-kin knucklebone	0		
 6358	huge teal Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	quilted Mer-kin begsign	0		Damage Absorption: +40, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	extra-ionized aerosolized dry pulled taffy	0		Effect: "Nas Tea", Effect Duration: 60, Last Available: "2013-04"
 6362	ionized Vulcanized ghostly pulled indigo taffy	0		Effect: "Oiled Skin", Effect Duration: 40, Last Available: "2013-04"
 6363	vacuum-sealed liquefied oxidized pulled taffy	0		Effect: "Hiding in Plain Sight", Effect Duration: 41, Last Available: "2013-04"
@@ -6266,7 +6266,7 @@
 6370	tumbling twisted piece of wire	0		
 6371	watered-down tolerable can of the cheapest beer	2	good	
 6372	irresponsibly strong acceptable bottle of fruity &quot;wine&quot;	7	good	
-6373	aged watered-down single swig of vodka	2	awesome	
+6373	watered-down aged single swig of vodka	2	awesome	
 6374	angry inch	0		
 6375	testy toolbox of Tarzan	0		Experience (Muscle): +3
 6376	Jick-o-User	0		
@@ -6292,7 +6292,7 @@
 6397	peanut sauce	0		
 6398	glass	0		
 6399	adjusted modified Boss Drops	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 28
-6400	fuchsia wobbly Mer-kin lunchbox	0		
+6400	wobbly fuchsia Mer-kin lunchbox	0		
 6401	flattened tear	0		Effect: "[800]Chocolate Reign", Effect Duration: 20
 6402	anodized blurry jagged tooth	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 69
 6403	non-galvanized grisly shell fragment	0		Effect: "Superioreo", Effect Duration: 41
@@ -6319,7 +6319,7 @@
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	yummy huge Dreadsylvanian stew	4	awesome	
-6427	special watered-down lousy shaking Dreadsylvanian	2	decent	Effect: "Mushroom Magicalness", Effect Duration: 5
+6427	lousy special watered-down shaking Dreadsylvanian	2	decent	Effect: "Mushroom Magicalness", Effect Duration: 5
 6428	enhanced twirling purple Dreadsylvanian flask	0		Effect: "Celestial Sheen", Effect Duration: 61
 6429	irradiated moist anodized skewed Dreadsylvanian flask	0		Effect: "Heal Thy Nanoself", Effect Duration: 59
 6430	weightlifter's dreadful fedora of the ox	0		Muscle: 35, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6367,7 +6367,7 @@
 6472	Drunkula's bell	0		
 6473	Usain Bolt's inspector's extremely unsafe Drunkula's ring of haze	0		Weapon Damage Percent: +100, Item Drop: +15, Initiative: +80, Avoid Attack: 1, Single Equip
 6474	steel-toed Drunkula's wineglass	0		Damage Reduction: 9
-6475	watered-down hand-crafted bottle of Bloodweiser	2	EPIC	
+6475	hand-crafted watered-down bottle of Bloodweiser	2	EPIC	
 6476	blue scandalous flame-wreathed Unkillable Skeleton's skullcap of incineration	0		Hot Spell Damage: 60, Sleaze Damage: +5, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	huge bouncing Jeselnik's scorching boxer's Unkillable Skeleton's breastplate	0		Muscle Percent: +10, Hot Damage: +25, Sleaze Damage: +25, Class: "Turtle Tamer"
 6478	family-friendly Van der Graaf experienced Unkillable Skeleton's shinguards	0		Experience: +2, Sleaze Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6375,12 +6375,12 @@
 6480	reassuring electrified Unkillable Skeleton's shield	0		Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 23
 6481	upside-down chilly crafty Unkillable Skeleton's restless leg	0		Maximum MP: +10, Cold Damage: +5
 6482	executive frosty crafty Staff of the Roaring Hearth	0		Maximum MP: +10, Cold Spell Damage: +10, Meat Drop: +40
-6483	twirling tumbling Kool-Aid	1	good	
+6483	tumbling twirling Kool-Aid	1	good	
 6484	dread tarragon	0		
 6485	bone flour	0		
 6486	tumbling dreadful roast	0		
 6487	stinking agaricus	0		
-6488	bland pulsating jittery Dreadsylvanian shepherd's pie	3	decent	
+6488	bland jittery pulsating Dreadsylvanian shepherd's pie	3	decent	
 6489	pulsating music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6457,13 +6457,13 @@
 6563	padded hand of Mr. Cards	0		Damage Absorption: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	rotten half-sized Dreadsylvanian hot pocket	2	crappy	
 6565	stale fancy Dreadsylvanian pocket	4	decent	Effect: "Bolts about Candy", Effect Duration: 15
-6566	special adequate purple Dreadsylvanian pocket	3	good	Effect: "Elemental Saucesphere", Effect Duration: 10
-6567	delicious miniature Dreadsylvanian stink pocket	2	awesome	
+6566	adequate special purple Dreadsylvanian pocket	3	good	Effect: "Elemental Saucesphere", Effect Duration: 10
+6567	miniature delicious Dreadsylvanian stink pocket	2	awesome	
 6568	moldy yellow Dreadsylvanian sleaze pocket	3	crappy	
 6569	lousy Dreadsylvanian hot toddy	3	decent	
-6570	artisanal watered-down maroon Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
+6570	watered-down artisanal maroon Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
 6571	weak hand-crafted Dreadsylvanian grimlet	2	super ultra mega turbo EPIC	
-6572	practically non-alcoholic aged wobbly Dreadsylvanian dank and stormy	1	awesome	
+6572	aged practically non-alcoholic wobbly Dreadsylvanian dank and stormy	1	awesome	
 6573	triple-distilled bad Dreadsylvanian slithery nipple	10	decent	
 6574	huge hot clusterbomb	0		
 6575	upside-down clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	steel-toed gnawed-up dog bone of the empath	0		Damage Reduction: 9, Familiar Weight: +5
 6589	mansplainer's Grey Guanon	0		Monster Level: +15
 6590	twirling censurious crafty educational Engorged Sausages and You	0		Experience: +1, Maximum MP: +10, Sleaze Resistance: +3
-6591	weak bad dream of a dog	2	decent	
+6591	bad weak dream of a dog	2	decent	
 6592	wool brawny boxer's optimal spreadsheet	0		Muscle Percent: 30, Cold Resistance: +1
 6593	defective Game Grid token	0		
 6594	blurry hot Dreadsylvanian cocoa	0		
@@ -6496,7 +6496,7 @@
 6602	ghostly clockwork numeral II	0		
 6603	clockwork numeral III	0		
 6604	clockwork numeral IV	0		
-6605	bouncing squat clockwork numeral V	0		
+6605	squat bouncing clockwork numeral V	0		
 6606	clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
 6608	blurry clockwork numeral VIII	0		
@@ -6525,7 +6525,7 @@
 6631	shaking folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	yellow folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	folder (barbarian)	0		Last Available: "2013-08"
-6634	blinking wobbly folder (rainbow unicorn)	0		Last Available: "2013-08"
+6634	wobbly blinking folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	shaking folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	drinkable stepmom's booze	3	good	
 6653	surgical tape	0		
 6654	twirling scorching band T-shirt	0		Hot Damage: +25
-6655	tolerable fancy high-proof fountain 'soda'	10	good	Effect: "Bone Chilling", Effect Duration: 40
+6655	high-proof tolerable fancy fountain 'soda'	10	good	Effect: "Bone Chilling", Effect Duration: 40
 6656	illegal firecracker	0		
 6657	pickelhaube of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	triple-pickled quadruple-pressed hair oil	0		Effect: "Faboooo", Effect Duration: 48
@@ -6559,7 +6559,7 @@
 6667	quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	cyan modeling claymore	0		
-6670	shaking blue clay homunculus	0		
+6670	blue shaking clay homunculus	0		
 6671	nitrogenated pulsating sodium pentasomething	0		Effect: "Briny Blood", Effect Duration: 50
 6672	twirling grains of salt	0		
 6673	tumbling yellowcake bomb	0		
@@ -6595,10 +6595,10 @@
 6703	imitation White Russian	1	decent	
 6704	cool beefcake's short-handled mop	0		Muscle: +25, Moxie: +5
 6705	massive normal jungle floor wax	7	good	
-6706	pulsating blinking smirking shrunken head	0		
+6706	blinking pulsating smirking shrunken head	0		
 6707	super-frozen colorful toad	0		Effect: "Patent Alacrity", Effect Duration: 16
-6708	jittery mirror crude voodoo doll	0		
-6709	blue spinning attorney's badge	0		Single Equip
+6708	mirror jittery crude voodoo doll	0		
+6709	spinning blue attorney's badge	0		Single Equip
 6710	miser's flame-wreathed pygmy briefs	0		Hot Spell Damage: +10, Meat Drop: +10, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
 6712	bone abacus	0		
@@ -6606,7 +6606,7 @@
 6714	huge short calculator	0		
 6715	cyan chilly sphygmomanometer of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +5
 6716	cold-filtered double-denatured narrow bag of pygmy blood	0		Effect: "Black Lung", Effect Duration: 62
-6717	huge gray tongue depressor	0		
+6717	gray huge tongue depressor	0		
 6718	squat Jeselnik's quilted compression stocking	0		Damage Absorption: +40, Sleaze Damage: +25
 6719	Annie Oakley's midriff scrubs of the detective	0		Critical Hit Percent: +20, Item Drop: +20
 6720	aerosolized polarized twirling pill cup	0		Effect: "Bread-Lined", Effect Duration: 19
@@ -6619,7 +6619,7 @@
 6727	maroon tropical island souvenir crate	0		
 6728	blurry blinking ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
-6730	lime green spinning funky junk key	0		
+6730	spinning lime green funky junk key	0		
 6731	blue Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	clothesline pole	0		
@@ -6634,7 +6634,7 @@
 6742	gray greasy junk band	0		Sleaze Spell Damage: +10
 6743	strapping junk trunks	0		Muscle: +5, Familiar Effect: "cap 15"
 6744	purple occult junk-mail shirt	0		Spell Damage Percent: +25
-6745	delicious special junk food	3	awesome	Effect: "Strange Mental Acuity", Effect Duration: 40
+6745	special delicious junk food	3	awesome	Effect: "Strange Mental Acuity", Effect Duration: 40
 6746	bad junk yard	3	decent	
 6747	bouncing spinning zippy Socratic swordzall	0		Experience (Mysticality): +1, Initiative: +20
 6748	skewed Sinatra's arm buzzer	0		Experience (Moxie): +5, Damage Reduction: 6
@@ -6646,19 +6646,19 @@
 6754	beer bottle	0		
 6755	olive beer label	0		
 6756	spinning artisanal homebrew sampler	0		
-6757	weak special delicious pulsating can of Br&uuml;talbr&auml;u	2	awesome	Effect: "Strong Spirit", Effect Duration: 40, Last Available: "2013-09"
-6758	irresponsibly strong mediocre twirling can of Drooling Monk	8	decent	Last Available: "2013-09"
+6757	delicious special weak pulsating can of Br&uuml;talbr&auml;u	2	awesome	Effect: "Strong Spirit", Effect Duration: 40, Last Available: "2013-09"
+6758	mediocre irresponsibly strong twirling can of Drooling Monk	8	decent	Last Available: "2013-09"
 6759	mediocre triple-distilled can of Impetuous Scofflaw	6	decent	Last Available: "2013-09"
 6760	acceptable bottle of Old Pugilist	3	good	Last Available: "2013-09"
-6761	tolerable weak narrow bottle of Professor Beer	2	good	Last Available: "2013-09"
-6762	special artisanal practically non-alcoholic bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Effect: "Larger", Effect Duration: 10, Last Available: "2013-09"
+6761	weak tolerable narrow bottle of Professor Beer	2	good	Last Available: "2013-09"
+6762	artisanal special practically non-alcoholic bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Effect: "Larger", Effect Duration: 10, Last Available: "2013-09"
 6763	watered-down aged mirror bottle of Race Car Red	2	awesome	Last Available: "2013-09"
 6764	tolerable bottle of Greedy Dog	4	good	Last Available: "2013-09"
 6765	tolerable bottle of Lambada Lambic	4	good	Last Available: "2013-09"
 6766	narrow tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
-6769	up-at-dawn inspector's tin tam of the cougar	0		Moxie: +20, Item Drop: +15, Adventures: +5, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	up-at-dawn inspector's tin tam of the cougar	0		Moxie: +20, Item Drop: +15, Adventures: +5, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	enhanced polarized tin cup	0		Effect: "Bilious Briskness", Effect Duration: 12, Last Available: "2013-09"
 6771	beefcake's tin foil of Tarzan of the overflowing toilet	0		Muscle: +25, Experience (Muscle): +3, Stench Spell Damage: +50, Last Available: "2013-09"
 6772	fireproof chaotic tin drum of the early riser	0		Spell Critical Percent: +10, Hot Resistance: +3, Adventures: +7, Last Available: "2013-09"
@@ -6714,7 +6714,7 @@
 6825	huge alarm accordion of horror of the glutton	0		Spooky Spell Damage: +25, Food Drop: +100, Class: "Accordion Thief", Song Duration: 20
 6826	savvy smooth All-Hallow's Steve's fright wig of the wise owl	0		Mysticality: +20, Moxie: +15, Mysticality Percent: +20, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	frosty quilted KoL Con X Treasure Map	0		Damage Absorption: +40, Cold Spell Damage: +10
-6828	fancy bad discocktail	4	decent	Effect: "Mercenary", Effect Duration: 40
+6828	bad fancy discocktail	4	decent	Effect: "Mercenary", Effect Duration: 40
 6829	KoL Con X Bingo Card of the bloodbag	0		Maximum HP: +100
 6830	Newton's Temporal Tempera Tube	0		Experience (Mysticality): +3
 6831	enhanced altered vacuum-sealed Tallowcreme Halloween Pumpkin	0		Effect: "Mystically Oiled", Effect Duration: 32
@@ -6726,12 +6726,12 @@
 6837	pickled Swizzler	0		Effect: "Cold Blooded", Effect Duration: 57
 6838	improved anodized cold-filtered Bugbearclaw Donut	0		Effect: "Mucilaginous Mentalism", Effect Duration: 38
 6839	cold-filtered blue jam	0		Effect: "Gemini Rising", Effect Duration: 24
-6840	electrified moist blurry tumbling Whenchamacallit bar	0		Effect: "Fit To Be Tide", Effect Duration: 53
+6840	electrified moist tumbling blurry Whenchamacallit bar	0		Effect: "Fit To Be Tide", Effect Duration: 53
 6841	modified jittery 8-bit banana	0		Effect: "Space Cadet", Effect Duration: 40
 6842	triple-moist vial of blood simple syrup	0		Effect: "Salsa Satanica", Effect Duration: 17
 6843	flattened polymerized altered bone bons	0		Effect: "Sweet and Red", Effect Duration: 67
 6844	pickled ironic mint	0		Effect: "Feeling No Pain", Effect Duration: 29
-6845	spinning twirling unused walkie-talkie	0		Free Pull
+6845	twirling spinning unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
 6847	blinking killing jar	0		
 6848	shaking auspicious security flashlight	0		Item Drop: +10
@@ -6746,22 +6746,22 @@
 6857	tumbling sizzling Cajun accordion	0		Hot Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	quirky accordion of the dark arts	0		Spell Damage Percent: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	auspicious Skipper's accordion of the businessman	0		Item Drop: +10, Meat Drop: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	squat energetic slick Pantsgiving of dire peril of extreme caution	0		Moxie: +10, Weapon Damage: +20, Maximum MP Percent: +20, Monster Level: -25, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	moldy miniature pulsating can of sardines	2	crappy	Last Available: "2013-11"
-6862	small spoiled high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
+6860	squat energetic slick Pantsgiving of dire peril of extreme caution	0		Moxie: +10, Weapon Damage: +20, Maximum MP Percent: +20, Monster Level: -25, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
+6861	miniature moldy pulsating can of sardines	2	crappy	Last Available: "2013-11"
+6862	spoiled small high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
 6863	bland half-sized pat of butter	2	decent	Last Available: "2013-11"
 6864	moldy gray dinner roll	3	crappy	Last Available: "2013-11"
-6865	delicious enchanted massive mashed potatoes	6	awesome	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25, Last Available: "2013-11"
+6865	massive enchanted delicious mashed potatoes	6	awesome	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25, Last Available: "2013-11"
 6866	snack-sized stale lime green whole turkey leg	2	decent	Last Available: "2013-11"
 6867	bland deviled egg	3	decent	Last Available: "2013-11"
 6868	nitrogenated finger exerciser	0		Effect: "Staying Frosty", Effect Duration: 19, Last Available: "2013-11"
 6869	diffused wobbly dented spoon	0		Effect: "Chilblains of the Corn", Effect Duration: 28, Last Available: "2013-11"
 6870	vacuum-sealed love note	0		Effect: "20-20 Second Sight", Effect Duration: 32, Last Available: "2013-11"
-6871	ghostly blue school beer pull tab	0		Last Available: "2013-11"
+6871	blue ghostly school beer pull tab	0		Last Available: "2013-11"
 6872	ionized super-modified nail file	0		Effect: "Mmmmmelon", Effect Duration: 65, Last Available: "2013-11"
 6873	denatured frozen twirling candy wrapper	0		Effect: "Natural 20", Effect Duration: 20, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
-6875	triple-denatured shaking tumbling post-holiday sale coupon	0		Effect: "Bone Homie", Effect Duration: 30, Last Available: "2013-11"
+6875	triple-denatured tumbling shaking post-holiday sale coupon	0		Effect: "Bone Homie", Effect Duration: 30, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
@@ -6774,7 +6774,7 @@
 6885	polarized extra-ionized concentrated blue upside-down spirit gum	0		Effect: "Wintergreen Warmongery", Effect Duration: 39
 6886	spirit pillow	0		
 6887	shaking spirit sheet	0		
-6888	purple twirling spirit mattress	0		
+6888	twirling purple spirit mattress	0		
 6889	spirit blanket	0		
 6890	spirit bed	0		
 6891	sizzling Fonzie's brainy spirit bell	0		Mysticality: +5, Experience (Moxie): +1, Hot Damage: +10, Class: "Turtle Tamer"
@@ -6789,9 +6789,9 @@
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	huge Sherlock's Samson's flask flops	0		Experience (Muscle): +5, Item Drop: +25, Single Equip
-6903	polarized pulsating cyan nuts	0		Effect: "Oriental Mysticism", Effect Duration: 26, Last Available: "2013-12"
+6903	polarized cyan pulsating nuts	0		Effect: "Oriental Mysticism", Effect Duration: 26, Last Available: "2013-12"
 6904	concentrated narrow bolts	0		Effect: "Chalky White Pallor", Effect Duration: 18, Last Available: "2013-12"
-6905	delicious blue blinking gingerbread robot	3	awesome	Last Available: "2013-12"
+6905	delicious blinking blue gingerbread robot	3	awesome	Last Available: "2013-12"
 6906	tasty petit 4.1	3	awesome	Last Available: "2013-12"
 6907	bite-sized decent nut-shaped Crimbo cookie	1	good	Last Available: "2023-06"
 6908	auspicious plastic GORM-8	0		Item Drop: +10, Last Available: "2013-12"
@@ -6804,35 +6804,35 @@
 6915	skewed padded brainy beefcake's warbear hoverbelt	0		Muscle: +25, Mysticality: +5, Damage Absorption: +20, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
-6918	flattened blurry ghostly warbear wardance potion	0		Effect: "Stuck-Up Hair", Effect Duration: 43, Last Available: "2013-12"
+6918	flattened ghostly blurry warbear wardance potion	0		Effect: "Stuck-Up Hair", Effect Duration: 43, Last Available: "2013-12"
 6919	flattened warbear bearserker potion	0		Effect: "Inappropriate Spirit", Effect Duration: 25, Last Available: "2013-12"
 6920	double-nitrogenated warbear liquid overcoat	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 43, Last Available: "2013-12"
 6921	toothsome teal warbear feasting bread	3	awesome	Last Available: "2013-12"
-6922	massive decent warbear warrior bread	7	good	Last Available: "2013-12"
-6923	huge tasty warbear thermoregulator bread	9	awesome	Last Available: "2013-12"
-6924	artisanal triple-distilled warbear feasting mead	7	EPIC	Last Available: "2013-12"
+6922	decent massive warbear warrior bread	7	good	Last Available: "2013-12"
+6923	tasty huge warbear thermoregulator bread	9	awesome	Last Available: "2013-12"
+6924	triple-distilled artisanal warbear feasting mead	7	EPIC	Last Available: "2013-12"
 6925	drinkable warbear bearserker mead	4	good	Last Available: "2013-12"
-6926	acceptable weak warbear blizzard mead	2	good	Last Available: "2013-12"
+6926	weak acceptable warbear blizzard mead	2	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	cyan frosty chilly warbear plain fedora of the overflowing toilet	0		Cold Damage: +5, Cold Spell Damage: +10, Stench Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	weightlifter's warbear feathered fedora	0		Muscle: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	cool warbear fedora of chilblains of the businessman	0		Moxie: +5, Cold Damage: +25, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	upside-down curative Herculean warbear plain helm of the storm	0		Experience (Muscle): +1, Maximum MP Percent: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	sage warbear spiked helm	0		Mysticality Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	fireproof veiny forbidden warbear electro-spiked helm	0		Spell Damage Percent: +50, Maximum HP: +10, Hot Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	lightning-fast Sherlock's fortified warbear plain ushanka	0		Damage Absorption: +60, Item Drop: +25, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	warbear lined ushanka	0		Item Drop: +5, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	boxer's weightlifter's warbear heated ushanka of the boozehound	0		Muscle: +15, Muscle Percent: +10, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	cyan frosty chilly warbear plain fedora of the overflowing toilet	0		Cold Damage: +5, Cold Spell Damage: +10, Stench Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	weightlifter's warbear feathered fedora	0		Muscle: +15, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	cool warbear fedora of chilblains of the businessman	0		Moxie: +5, Cold Damage: +25, Meat Drop: +50, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	upside-down curative Herculean warbear plain helm of the storm	0		Experience (Muscle): +1, Maximum MP Percent: +40, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	sage warbear spiked helm	0		Mysticality Percent: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	fireproof veiny forbidden warbear electro-spiked helm	0		Spell Damage Percent: +50, Maximum HP: +10, Hot Resistance: +3, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	lightning-fast Sherlock's fortified warbear plain ushanka	0		Damage Absorption: +60, Item Drop: +25, Initiative: +40, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	warbear lined ushanka	0		Item Drop: +5, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	boxer's weightlifter's warbear heated ushanka of the boozehound	0		Muscle: +15, Muscle Percent: +10, Booze Drop: +100, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	spinning warbear trouser fragment	0		Last Available: "2013-12"
-6938	lightning-fast Jeselnik's warbear party pants of the brute	0		Muscle Percent: +30, Sleaze Damage: +25, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	upside-down prompt warbear ceremonial party pants	0		Adventures: +3, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	rosewater-soaked clever warbear high festival pants of Leguizamo	0		Maximum MP: +20, Monster Level: +20, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	Van der Graaf sage warbear battle greaves of the bloodbag	0		Mysticality Percent: +10, Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	friendly warbear officer greaves	0		Familiar Weight: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	Lo Pan's warbear bearserker greaves of the cougar of vim and vigor	0		Moxie: +20, Maximum HP Percent: +50, Spell Critical Percent: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	sizzling dance instructor's warbear johns of the dark arts	0		Experience Percent (Moxie): +10, Spell Damage Percent: +100, Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	Sinatra's warbear fleece-lined johns	0		Experience (Moxie): +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	twirling zippy family-friendly toasty warbear johns	0		Hot Damage: +5, Sleaze Resistance: +1, Initiative: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	lightning-fast Jeselnik's warbear party pants of the brute	0		Muscle Percent: +30, Sleaze Damage: +25, Initiative: +40, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	upside-down prompt warbear ceremonial party pants	0		Adventures: +3, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	rosewater-soaked clever warbear high festival pants of Leguizamo	0		Maximum MP: +20, Monster Level: +20, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	Van der Graaf sage warbear battle greaves of the bloodbag	0		Mysticality Percent: +10, Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	friendly warbear officer greaves	0		Familiar Weight: +3, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	Lo Pan's warbear bearserker greaves of the cougar of vim and vigor	0		Moxie: +20, Maximum HP Percent: +50, Spell Critical Percent: +30, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	sizzling dance instructor's warbear johns of the dark arts	0		Experience Percent (Moxie): +10, Spell Damage Percent: +100, Hot Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	Sinatra's warbear fleece-lined johns	0		Experience (Moxie): +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	twirling zippy family-friendly toasty warbear johns	0		Hot Damage: +5, Sleaze Resistance: +1, Initiative: +20, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	narrow warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	Annie Oakley's occult warbear goggles of the scaredy-cat	0		Spell Damage Percent: +25, Critical Hit Percent: +20, Monster Level: -15, Single Equip, Last Available: "2013-12"
 6949	shaking green warbear snowblindness goggles of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	hale banded warbear warscarf of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +100, Maximum HP: +20, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	spinning warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	cyan thinker's warbear foil hat	0		Mysticality: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	cyan thinker's warbear foil hat	0		Mysticality: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	blurry warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	jittery sizzling frosty warbear oil pan	0		Cold Spell Damage: +10, Hot Damage: +10, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	jittery sizzling frosty warbear oil pan	0		Cold Spell Damage: +10, Hot Damage: +10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	cyan warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	warbear exhaust manifold of incineration	0		Hot Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	pulsating warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,14 +6889,14 @@
 7000	spinning Socratic die-cast Don Crimbo of dire peril	0		Experience (Mysticality): +1, Weapon Damage: +20, Last Available: "2013-12"
 7001	razor-sharp thinker's die-cast Uncle Hobo	0		Mysticality: +10, Weapon Damage Percent: +25, Last Available: "2013-12"
 7002	skewed Jeselnik's sharpshooter's die-cast Father Crimbo	0		Critical Hit Percent: +10, Sleaze Damage: +25, Last Available: "2013-12"
-7003	twirling The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	twirling The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	galvanized altered blurry huge Flaskfull of Hollow	0		Effect: "Stuck That Way", Effect Duration: 43, Last Available: "2013-12"
 7005	upside-down maroon lump of Brituminous coal	0		Last Available: "2013-12"
 7006	modified gray skewed handful of Smithereens	1	decent	Last Available: "2013-12"
 7007	small decent Every Day is Like This Sundae	2	good	Last Available: "2013-12"
-7008	flavorless miniature Miserable Pie	2	decent	Last Available: "2013-12"
+7008	miniature flavorless Miserable Pie	2	decent	Last Available: "2013-12"
 7009	flavorless bite-sized shaking This Charming Flan	1	decent	Last Available: "2013-12"
-7010	delicious fortified Irish Coffee, English Heart	5	awesome	Last Available: "2013-12"
+7010	fortified delicious Irish Coffee, English Heart	5	awesome	Last Available: "2013-12"
 7011	hand-crafted tumbling Strikes Again Bigmouth	3	EPIC	Last Available: "2013-12"
 7012	bad Paint A Vulgar Pitcher	3	decent	Last Available: "2013-12"
 7013	red Golden Light	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	perfumed sinister Sheila Take a Crossbow of wisdom of the bloodbag	0		Mysticality: +15, Spell Damage: +10, Maximum HP: +100, Stench Resistance: +5, Last Available: "2013-12"
 7019	up-at-dawn scorching Jim Carey's resourceful A Light that Never Goes Out	0		Maximum MP: +50, Monster Level: +25, Hot Damage: +25, Adventures: +5, Last Available: "2013-12"
 7020	inspector's coward's crafty Half a Purse of wisdom	0		Mysticality: +15, Maximum MP: +10, Monster Level: -20, Item Drop: +15, Last Available: "2013-12"
-7021	gravedigger's lion tamer's vibrating hale Hairpiece On Fire	0		Maximum HP: +20, Maximum MP Percent: +10, Experience (familiar): +2, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	razor-sharp deadly brawny Vicar's Tutu of dire peril	0		Muscle Percent: +20, Weapon Damage: 25, Weapon Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	gravedigger's lion tamer's vibrating hale Hairpiece On Fire	0		Maximum HP: +20, Maximum MP Percent: +10, Experience (familiar): +2, Spooky Damage: +10, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	razor-sharp deadly brawny Vicar's Tutu of dire peril	0		Muscle Percent: +20, Weapon Damage: 25, Weapon Damage Percent: +25, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	squat sizzling energetic savvy Hand in Glove	0		Mysticality Percent: +20, Maximum MP Percent: +20, Hot Damage: +10, Single Equip, Last Available: "2013-12"
 7024	lion tamer's brainy Meat Tenderizer is Murder of Tarzan	0		Mysticality: +5, Experience (Muscle): +3, Experience (familiar): +2, Class: "Seal Clubber", Last Available: "2013-12"
 7025	perfumed reassuring Ouija Board, Ouija Board of doom	0		Spooky Spell Damage: +50, Spooky Resistance: +1, Stench Resistance: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6928,7 +6928,7 @@
 7039	improved wet blurry warbear robo-camouflage unit	0		Effect: "Gunky Dory", Effect Duration: 55, Last Available: "2013-12"
 7040	spinning jittery warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
-7042	narrow blinking twirling warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
+7042	twirling blinking narrow warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	tumbling huge warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	ionized glass slipper	0		Effect: "There Wolf", Effect Duration: 29, Last Available: "2014-12"
 7045	distilled antimatter wad	1	awesome	Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	normal special breakfast mess	4	good	Effect: "Swimming Head", Effect Duration: 50, Last Available: "2013-12"
+7055	special normal breakfast mess	4	good	Effect: "Swimming Head", Effect Duration: 50, Last Available: "2013-12"
 7056	teal warbear breakfast machine	0		Last Available: "2013-12"
 7057	small bland fuchsia blurry breakfast miracle	2	decent	Last Available: "2013-12"
 7058	activated polymerized green Cloaca Cola Polar	0		Effect: "Pumped Stomach", Effect Duration: 47, Last Available: "2013-12"
@@ -6951,7 +6951,7 @@
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	skewed hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	modified twirling olive grim fairy tale	1	decent	Last Available: "2014-12"
+7065	modified olive twirling grim fairy tale	1	decent	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	concentrated polymerized moist maroon single of Inigo's Incantation of Inspiration	0		Effect: "Swimming Head", Effect Duration: 22, Last Available: "2010-02"
 7068	magnetized single of Donho's Bubbly Ballad	0		Effect: "Familial Ties", Effect Duration: 26
@@ -6964,7 +6964,7 @@
 7075	nitrogenated denatured red liquid ice pack	0		Effect: "Inappropriate Spirit", Effect Duration: 66, Last Available: "2014-01"
 7076	blue snow boards	0		Last Available: "2014-01"
 7077	decent narrow pulsating snow crab	3	good	Last Available: "2014-01"
-7078	special mediocre weak cyan Ice Island Long Tea	2	decent	Effect: "Biologically Shocked", Effect Duration: 15, Last Available: "2014-01"
+7078	mediocre special weak cyan Ice Island Long Tea	2	decent	Effect: "Biologically Shocked", Effect Duration: 15, Last Available: "2014-01"
 7079	narrow unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	perfectly mixed weak upside-down En Una Fila Tequila	2	EPIC	
 7091	wobbly Skully's hot chocolate	1	awesome	
-7092	squat shaking greasy smooth warbear dress helmet	0		Moxie: +15, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	squat shaking greasy smooth warbear dress helmet	0		Moxie: +15, Sleaze Spell Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	stanky warbear dress bracers of the bloodbag	0		Maximum HP: +100, Stench Spell Damage: +25, Single Equip, Last Available: "2013-12"
-7094	spinning auspicious coward's warbear dress greaves	0		Monster Level: -20, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	gray Usain Bolt's vibrating sweatband	0		Maximum MP Percent: +10, Initiative: +80, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	wholesome Newton's gym shorts	0		Experience (Mysticality): +3, Maximum HP Percent: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	spinning auspicious coward's warbear dress greaves	0		Monster Level: -20, Item Drop: +10, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	gray Usain Bolt's vibrating sweatband	0		Maximum MP Percent: +10, Initiative: +80, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	wholesome Newton's gym shorts	0		Experience (Mysticality): +3, Maximum HP Percent: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	up-at-dawn ankleweights of terror	0		Spooky Spell Damage: +10, Adventures: +5, Single Equip, Last Available: "2014-12"
 7098	zippy horrifying Fonzie's sweat socks of mayonnaise	0		Experience (Moxie): +1, Spooky Damage: +25, Sleaze Spell Damage: +50, Initiative: +20, Last Available: "2014-12"
 7099	jittery pint of sweat	0		Last Available: "2014-12"
@@ -7001,15 +7001,15 @@
 7112	mediocre wobbly chocotini	3	decent	Last Available: "2014-12"
 7113	ghostly sharpshooter's veiny chocolate rabbit's foot of dire peril	0		Weapon Damage: +20, Maximum HP: +10, Critical Hit Percent: +10, Last Available: "2014-12"
 7114	yummy candy carrot	3	awesome	Last Available: "2014-12"
-7115	decent immense candy carrot cake	9	good	Last Available: "2014-12"
+7115	immense decent candy carrot cake	9	good	Last Available: "2014-12"
 7116	stanky deadly carrot-on-a-stick	0		Weapon Damage: +5, Stench Spell Damage: +25, Last Available: "2014-12"
-7117	shellacked hardened weasel stomping pants	0		Damage Reduction: 20, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	shellacked hardened weasel stomping pants	0		Damage Reduction: 20, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	miniature normal mulberry	2	good	Last Available: "2014-12"
 7119	special hand-crafted mulled berry wine	3	super EPIC	Effect: "Ruthlessly Efficient", Effect Duration: 15, Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of temperance	0		Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	lemon party hat of temperance	0		Sleaze Resistance: +5, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	yellow double-paned lemon shirt	0		Cold Resistance: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of wisdom	0		Mysticality: +15, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	lemon drop trousers of wisdom	0		Mysticality: +15, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	pressed colloidal bouncing lemonhead caviar	0		Effect: "Think Win-Lose", Effect Duration: 14, Last Available: "2014-12"
 7125	healthy stylish gummi sword	0		Moxie: +25, Maximum HP Percent: +20, Last Available: "2014-12"
 7126	deionized denatured blue blinking small gummi fin	0		Effect: "Egg on your Face", Effect Duration: 54, Last Available: "2014-12"
@@ -7020,11 +7020,11 @@
 7131	jittery lightning-fast inspector's shellacked cow creamer	0		Damage Reduction: 7, Item Drop: +15, Initiative: +40, Last Available: "2014-12"
 7132	pickled wobbly Outer Wolf&trade; cologne	0		Effect: "Alpine Mintiness", Effect Duration: 12, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	ribald crafty wolf whistle	0		Maximum MP: +10, Sleaze Damage: +10, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	ribald crafty wolf whistle	0		Maximum MP: +10, Sleaze Damage: +10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	rotten blurry green witch's bread	4	crappy	Last Available: "2014-12"
 7136	alkaline skewed witch's brew	0		Effect: "Inebriate Pride", Effect Duration: 25, Last Available: "2014-12"
 7137	jittery bouncing healthy cool witch's bra of doom	0		Moxie: +5, Maximum HP Percent: +20, Spooky Spell Damage: +50, Last Available: "2014-12"
-7138	enchanted lousy weak mid-level medieval mead	2	decent	Effect: "Steroid Boost", Effect Duration: 35, Last Available: "2014-12"
+7138	lousy weak enchanted mid-level medieval mead	2	decent	Effect: "Steroid Boost", Effect Duration: 35, Last Available: "2014-12"
 7139	diffused polymerized upside-down R&uuml;mpelstiltz	0		Effect: "Pride of the Vampire", Effect Duration: 19, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	chilled upside-down hi-octane carrot juice	0		Effect: "Old Time Hydration", Effect Duration: 12, Last Available: "2014-12"
@@ -7036,17 +7036,17 @@
 7147	enhanced polo trophy	0		Effect: "Leash of Linguini", Effect Duration: 60, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	upside-down rosary	0		Last Available: "2014-12"
-7150	mirror lime green tumbling ornate dowsing rod	0		Last Available: "2014-12"
+7150	tumbling mirror lime green ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
 7152	ghostly	0		Last Available: "2014-12"
 7153	clay	0		Last Available: "2014-12"
 7154	filling	0		Last Available: "2014-12"
 7155	pulsating parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	clever arcane researcher's fire hose of the detective	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Item Drop: +20, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	snack-sized rotten fireman's lunch	2	crappy	Last Available: "2014-12"
-7159	banded sinister plain paper hat of temperance	0		Spell Damage: +10, Damage Absorption: +100, Sleaze Resistance: +5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	normal bite-sized jittery ice cream sandwich	1	good	Last Available: "2014-12"
+7157	clever arcane researcher's fire hose of the detective	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Item Drop: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7158	rotten snack-sized fireman's lunch	2	crappy	Last Available: "2014-12"
+7159	banded sinister plain paper hat of temperance	0		Spell Damage: +10, Damage Absorption: +100, Sleaze Resistance: +5, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7160	bite-sized normal jittery ice cream sandwich	1	good	Last Available: "2014-12"
 7161	resourceful banded &quot;honey&quot; dipper	0		Damage Absorption: +100, Maximum MP: +50, Item Drop: +5, Last Available: "2014-12"
 7162	rotten blurry plumber's lunch	3	crappy	Last Available: "2014-12"
 7163	stiffened skull gearshift knob of the pedagogue of the storm	0		Experience: +3, Damage Reduction: 1, Maximum MP Percent: +40, Last Available: "2014-12"
@@ -7071,7 +7071,7 @@
 7182	spinning The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
-7185	squat wobbly Red Zeppelin ticket	0		
+7185	wobbly squat Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
 7187	acceptable unnamed cocktail	3	good	
 7188	handful of tips	0		
@@ -7100,7 +7100,7 @@
 7211	energized one pill	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 41
 7212	spinning jittery savvy Jefferson wings	0		Mysticality Percent: +20
 7213	fleetwood macaroni	0		
-7214	pulsating fuchsia blinking cheesy eagle sauce	0		
+7214	pulsating blinking fuchsia cheesy eagle sauce	0		
 7215	decent fleetwood mac 'n' cheese	3	good	
 7216	lynyrd skin	0		
 7217	smartaleck's lynyrdskin cap	0		Moxie Percent: +30, Familiar Effect: "1xPotato, 1xVolley, cap 42"
@@ -7116,7 +7116,7 @@
 7227	tolerable bottle of Evermore	4	good	
 7228	shaking box	0		
 7229	acceptable wine	4	good	
-7230	practically non-alcoholic bad rum	1	decent	
+7230	bad practically non-alcoholic rum	1	decent	
 7231	acceptable Murderer's Punch	4	good	
 7232	moldy cyan velvet cake	4	crappy	
 7233	galvanized ionized letter	0		Effect: "Hippy Flavor", Effect Duration: 15
@@ -7151,7 +7151,7 @@
 7262	jittery &quot;I Love Me, Vol. I&quot;	0		
 7263	blinking maroon photograph of a dog	0		
 7264	photograph of a nugget	0		
-7265	tumbling purple blinking photograph of an ostrich egg	0		
+7265	blinking purple tumbling photograph of an ostrich egg	0		
 7266	jittery disposable instant camera	0		
 7267	lion tamer's rosy-cheeked sage Sneaky Pete's jacket (collar popped) of terror	0		Mysticality Percent: +10, Maximum HP Percent: +30, Experience (familiar): +2, Spooky Spell Damage: +10, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
@@ -7165,7 +7165,7 @@
 7276	educational plastic Captain Kerkard	0		Experience: +1
 7277	super-anodized wet robot grease	0		Effect: "Piratey Flavor", Effect Duration: 59
 7278	lime green returned Thinknerd package	0		
-7279	chilled narrow maroon twirling wind-up Whatsian robot	0		Effect: "Warm Belly", Effect Duration: 28
+7279	chilled maroon twirling narrow wind-up Whatsian robot	0		Effect: "Warm Belly", Effect Duration: 28
 7280	adjusted deionized skewed wind-up vampire teeth	0		Effect: "Creepin' Up on You", Effect Duration: 37
 7281	frozen skewed wind-up navigation droid	0		Effect: "Ooh, Sweet!", Effect Duration: 44
 7282	magnetized wind-up owl	0		Effect: "Quiet 'n' Good", Effect Duration: 27
@@ -7176,7 +7176,7 @@
 7287	hale Gary Claybender's Time Screwer of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20, Single Equip, Lasts Until Rollover
 7288	jittery upside-down miser's nippy Space Tourist palmdoctor	0		Cold Damage: +10, Meat Drop: +10, Lasts Until Rollover
 7289	skewed double-paned coward's padded amok putter	0		Damage Absorption: +20, Monster Level: -20, Cold Resistance: +5
-7290	enchanted small moldy spinning amok pudding	2	crappy	Effect: "Toothy Grin", Effect Duration: 35
+7290	enchanted moldy small spinning amok pudding	2	crappy	Effect: "Toothy Grin", Effect Duration: 35
 7291	deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	liquefied can of V-11	0		Effect: "Low on the Hog", Effect Duration: 38, Last Available: "2014-03"
@@ -7217,7 +7217,7 @@
 7328	wet funny bone	0		Effect: "Arabian Knighthood", Effect Duration: 62
 7329	healthy half-melted spoon of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100
 7330	altered upside-down the funk	1		Effect: "The Moxious Madrigal", Effect Duration: 10
-7331	gigantic enchanted normal teal gunky chicken	8	good	Effect: "Leash of Linguini", Effect Duration: 15
+7331	enchanted normal gigantic teal gunky chicken	8	good	Effect: "Leash of Linguini", Effect Duration: 15
 7332	perfumed doll head	0		Stench Resistance: +5
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7228,7 +7228,7 @@
 7339	twirling music box mechanism	0		
 7340	nasty moose antlers	0		Stench Damage: +5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	moist warmed narrow moose thought	0		Effect: "Fishy Fortification", Effect Duration: 40
-7342	adequate snack-sized moose chocolate	2	good	
+7342	snack-sized adequate moose chocolate	2	good	
 7343	artisanal painting of a glass of wine	3	EPIC	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
@@ -7245,7 +7245,7 @@
 7356	energized non-oxidized pulsating hot coal	0		Effect: "Cancer Rising", Effect Duration: 60
 7357	anodized bouncing coal dust	0		Effect: "Wreathed in Smoke", Effect Duration: 21
 7358	Sherlock's Bram's choker of Gandalf of chilblains	0		Spell Critical Percent: +20, Cold Damage: +25, Item Drop: +25, Single Equip
-7359	twirling blurry plaid swatch	0		
+7359	blurry twirling plaid swatch	0		
 7360	plaid bandage	0		
 7361	ghostly educational plaid pocket square	0		Experience: +1
 7362	wobbly Rosewater's plaid skirt of temperance	0		Mysticality Percent: +30, Sleaze Resistance: +5, Familiar Effect: "1xPotato, 1xFairy, cap 38"
@@ -7254,14 +7254,14 @@
 7365	altered huge fabric hardener	0		Effect: "Tennis Elbow-wow", Effect Duration: 17
 7366	practically non-alcoholic artisanal cyan bottle of laundry sherry	1	super EPIC	
 7367	chilled industrial strength starch	0		Effect: "Burnt 'n' Turnt", Effect Duration: 67, Wiki Name: "industrial strength starch"
-7368	bite-sized bland extra-flat panini	1	decent	
+7368	bland bite-sized extra-flat panini	1	decent	
 7369	extra-dry warmed mangled finger	0		Effect: "Chief Executive Optimism", Effect Duration: 60
 7370	hand-crafted skewed Psychotic Train wine	4	EPIC	
 7371	crazy hobo notebook	0		
 7372	stale pie man was not meant to eat	4	decent	
 7373	spinning sommelier's towel of the empath	0		Familiar Weight: +5
 7374	rock-hard tarnished tastevin	0		Damage Reduction: 5, Single Equip
-7375	rotten fancy actual tapas	4	crappy	Effect: "Ice Packed", Effect Duration: 40
+7375	fancy rotten actual tapas	4	crappy	Effect: "Ice Packed", Effect Duration: 40
 7376	ghast iron ingot	0		
 7377	wobbly ghostly inspector's baleful ghast iron cleaver	0		Spell Damage: +25, Item Drop: +15
 7378	tumbling gray extremely unsafe Newton's ghast iron Garibaldi	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7286,7 +7286,7 @@
 7397	warmed pickled upside-down Gene Tonic: Plant	0		Effect: "Cautious Prowl", Effect Duration: 49, Last Available: "2014-04"
 7398	liquefied Vulcanized quantum Gene Tonic: Weird	0		Effect: "Ticking Clock", Effect Duration: 63, Last Available: "2014-04"
 7399	nitrogenated jittery Gene Tonic: Elf	0		Effect: "Arse-a'fire", Effect Duration: 30, Last Available: "2014-04"
-7400	chilled diffused upside-down skewed Gene Tonic: Mer-kin	0		Effect: "[1701]Hip to the Jive", Effect Duration: 30, Last Available: "2014-04"
+7400	chilled diffused skewed upside-down Gene Tonic: Mer-kin	0		Effect: "[1701]Hip to the Jive", Effect Duration: 30, Last Available: "2014-04"
 7401	polarized warmed Gene Tonic: Slime	0		Effect: "Dilated Pupils", Effect Duration: 12, Last Available: "2014-04"
 7402	unsweetened wobbly Gene Tonic: Penguin	0		Effect: "Super Accuracy", Effect Duration: 64, Last Available: "2014-04"
 7403	pickled flattened blurry upside-down Gene Tonic: Elemental	0		Effect: "Cold Blooded", Effect Duration: 23, Last Available: "2014-04"
@@ -7348,13 +7348,13 @@
 7459	spinning Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	smelly Brogre brorts	0		Stench Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	smelly Brogre brorts	0		Stench Spell Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	Brogre brolo shirt of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2014-05"
-7464	Brogre bucket hat of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	Brogre bucket hat of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	fuchsia Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	jittery one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	friendly 8-billed baseball cap of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Familiar Weight: +3, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	friendly 8-billed baseball cap of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Familiar Weight: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	maroon careful fortified savvy extremely wet T-shirt	0		Mysticality Percent: +20, Damage Absorption: +60, Monster Level: -10, Last Available: "2014-05"
 7470	double-paned scorching therapeutic shrimp fork	0		Hot Damage: +25, Cold Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-05"
 7471	cold-filtered anodized deionized bouncing narrow BROS Energy Drink	0		Effect: "There Wolf", Effect Duration: 51, Last Available: "2014-05"
@@ -7369,7 +7369,7 @@
 7480	activated tarnished spinning sugar bunny	0		Effect: "Human-Hippy Hybrid", Effect Duration: 41, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	lousy blinking Rompedores de Fantasmas	3	decent	
-7483	drinkable weak La Fantasma y La Oscuridad	2	good	
+7483	weak drinkable La Fantasma y La Oscuridad	2	good	
 7484	lousy Fantasma en la M&aacute;quina	3	decent	
 7485	loosening powder	0		
 7486	narrow castoreum	0		
@@ -7385,7 +7385,7 @@
 7496	tumbling bottled day	0		
 7497	ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
-7499	non-dry activated upside-down squat Hot 'n' Scarys	0		Effect: "Alpine Mintiness", Effect Duration: 42
+7499	non-dry activated squat upside-down Hot 'n' Scarys	0		Effect: "Alpine Mintiness", Effect Duration: 42
 7500	map	0		
 7501		0		
 7502	non-irradiated skewed Texas tea	0		Effect: "Familial Ties", Effect Duration: 46
@@ -7395,7 +7395,7 @@
 7506	rosy-cheeked book of horror	0		Maximum HP Percent: +30, Spooky Spell Damage: +25
 7507	dog trainer's cloak	0		Experience (familiar): +1
 7508	label	0		
-7509	half-sized rotten Mornington crescent roll	2	crappy	
+7509	rotten half-sized Mornington crescent roll	2	crappy	
 7510	aerosolized unsweetened double-adjusted lime green eye shadow	0		Effect: "Livin' Large", Effect Duration: 50
 7511	jittery crumbling wheel	0		
 7512	nitrogenated maroon poppy	0		Effect: "Rage of the Reindeer", Effect Duration: 18
@@ -7406,12 +7406,12 @@
 7517	tumbling Jim Carey's MacGyver's spider leg	0		Maximum MP: +100, Monster Level: +25
 7518	wand of pigification	0		
 7519	tolerable watered-down glass of bourbon	2	good	
-7520	narrow purple burned government manual fragment	0		Last Available: "2014-05"
-7521	bland ghostly red government cheese	4	decent	Last Available: "2014-05"
+7520	purple narrow burned government manual fragment	0		Last Available: "2014-05"
+7521	bland red ghostly government cheese	4	decent	Last Available: "2014-05"
 7522	ghostly sharpshooter's pair of government shades	0		Critical Hit Percent: +10, Single Equip, Last Available: "2014-05"
 7523	pulsating space junk	0		Last Available: "2014-05"
 7524	aerosolized squat government	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 61, Last Available: "2014-05"
-7525	flattened anodized spinning fuchsia alien drugs	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 34, Last Available: "2023-09"
+7525	flattened anodized fuchsia spinning alien drugs	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 34, Last Available: "2023-09"
 7526	ghostly weird space book	0		Last Available: "2014-05"
 7527	blurry alien force field disruptor bean	0		Last Available: "2014-05"
 7528	veiny personal trainer's government-issued night-vision goggles	0		Experience Percent (Muscle): +10, Maximum HP: +10, Single Equip, Last Available: "2014-05"
@@ -7425,12 +7425,12 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	yellow twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	Van der Graaf space beast fur hat	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	space beast fur pants of terror	0		Spooky Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	Van der Graaf space beast fur hat	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	space beast fur pants of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	Rosewater's space beast fur whip	0		Mysticality Percent: +30, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	inspector's space heater of chilblains	0		Cold Damage: +25, Item Drop: +15, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
-7544	mirror twirling space bar	0		Last Available: "2014-05"
+7543	inspector's space heater of chilblains	0		Cold Damage: +25, Item Drop: +15, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7544	twirling mirror space bar	0		Last Available: "2014-05"
 7545	fancy bad space port	3	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2014-05"
 7546	squat Jim Carey's Lo Pan's space needle	0		Spell Critical Percent: +30, Monster Level: +25, Last Available: "2014-05"
 7547	modified non-irradiated mirror buffed alien drugs	0		Effect: "Vitali Tea", Effect Duration: 43, Last Available: "2014-05"
@@ -7466,30 +7466,30 @@
 7577	energized irradiated cold-filtered future drug: Smartinex	0		Effect: "Superheroic", Effect Duration: 12
 7578	super-enhanced blurry future drug: Coolscaline	0		Effect: "Mitre Cut", Effect Duration: 37
 7579	spinning twitching time capsule	0		
-7580	distilled blinking twirling cyan liquid shifting time weirdness	1		
+7580	distilled cyan twirling blinking liquid shifting time weirdness	1		
 7581	olive shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	rotten half-sized upside-down jittery rack of dinosaur ribs	2	crappy	
+7582	half-sized rotten jittery upside-down rack of dinosaur ribs	2	crappy	
 7583	tolerable fuchsia scotch on the rocks	3	good	
 7584	Annie Oakley's yabba dabba doo rag of courage	0		Critical Hit Percent: +20, Spooky Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	purple clever wooly loincloth of the sewer	0		Maximum MP: +20, Stench Damage: +25, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	lime green helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	practically non-alcoholic lousy enchanted jittery glass of &quot;milk&quot;	1	decent	Effect: "Eagle Eyes", Effect Duration: 45, Last Available: "2014-07"
-7590	acceptable weak cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
-7591	lousy watered-down mirror thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
+7589	lousy enchanted practically non-alcoholic jittery glass of &quot;milk&quot;	1	decent	Effect: "Eagle Eyes", Effect Duration: 45, Last Available: "2014-07"
+7590	weak acceptable cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
+7591	watered-down lousy mirror thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
 7592	spirit-forward drinkable Lucky Lindy	5	good	Last Available: "2014-07"
-7593	extra-dry drinkable Bee's Knees	5	good	Last Available: "2014-07"
+7593	drinkable extra-dry Bee's Knees	5	good	Last Available: "2014-07"
 7594	mediocre practically non-alcoholic fuchsia Sockdollager	1	decent	Last Available: "2014-07"
-7595	perfectly mixed high-proof twirling Ish Kabibble	6	EPIC	Last Available: "2014-07"
+7595	high-proof perfectly mixed twirling Ish Kabibble	6	EPIC	Last Available: "2014-07"
 7596	strong lousy blue Hot Socks	5	decent	Last Available: "2014-07"
 7597	drinkable shaking Phonus Balonus	3	good	Last Available: "2014-07"
-7598	fortified delicious Flivver	5	awesome	Last Available: "2014-07"
+7598	delicious fortified Flivver	5	awesome	Last Available: "2014-07"
 7599	delicious Sloppy Jalopy	3	awesome	Last Available: "2014-07"
 7600	improved modified galvanized red flame	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 32
 7601	galvanized ionized energized twirling temporary yak tattoo	0		Effect: "Sagittarius Rising", Effect Duration: 11
 7602	Vulcanized liquefied upside-down Fitspiration&trade; poster	0		Effect: "Highland Sheen", Effect Duration: 52
-7603	pressed alkaline squat gray neckbeard	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13
+7603	pressed alkaline gray squat neckbeard	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13
 7604	polarized skewed artisanal hand-squeezed wheatgrass juice	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 31
 7605	electrified blue punk patch	0		Effect: "Meat the Flintstones", Effect Duration: 65
 7606	adjusted energized chilled steampunk potion	0		Effect: "Bat Attitude", Effect Duration: 48
@@ -7529,9 +7529,9 @@
 7640	Annie Oakley's dance instructor's Fonzie's turtle shell	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Critical Hit Percent: +20, Class: "Turtle Tamer"
 7641	teal mirror shocked shell	0		Class: "Turtle Tamer"
 7642	ingot turtle	0		
-7643	teal blinking duty umbrella	0		
+7643	blinking teal duty umbrella	0		
 7644	mirror pool skimmer	0		
-7645	pulsating gray life preserver	0		
+7645	gray pulsating life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
@@ -7544,7 +7544,7 @@
 7655	fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
-7658	ghostly teal fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
+7658	teal ghostly fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	ghostly neoprene skullcap of the early riser	0		Adventures: +7, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	magnetized goblin water	0		Effect: "Scrappy, Shadowy", Effect Duration: 46
 7661	twirling dumb mud	0		
@@ -7581,7 +7581,7 @@
 7692	spinning flame-wreathed rock-hard hand whip of temperance	0		Damage Reduction: 5, Hot Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2014-08"
 7693	lard-coated extremely unsafe glow-in-the-dark necklace of the glutton	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Food Drop: +100, Last Available: "2014-08"
 7694	green Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	wobbly purple jittery friendly MacGyver's sinister cap gun	0		Spell Damage: +10, Maximum MP: +100, Familiar Weight: +3, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	wobbly purple jittery friendly MacGyver's sinister cap gun	0		Spell Damage: +10, Maximum MP: +100, Familiar Weight: +3, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	stanky cassette player of the pedagogue	0		Experience: +3, Stench Spell Damage: +25, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	huge LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	ionized rubber nubbin	0		Effect: "Wet Willied", Effect Duration: 62, Last Available: "2014-08"
 7708	tumbling green narrow extremely unsafe rubber cape of the sweet-tooth	0		Weapon Damage Percent: +100, Candy Drop: +100, Last Available: "2014-08"
-7709	censurious Tesla sinister Thor's Pliers of horror	0		Spell Damage: +10, Spooky Spell Damage: +25, Sleaze Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	censurious Tesla sinister Thor's Pliers of horror	0		Spell Damage: +10, Spooky Spell Damage: +25, Sleaze Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	dry ionized activated candy UFOs	0		Effect: "Nano-juiced", Effect Duration: 66
 7711	blinking nippy water wings for babies of horror	0		Cold Damage: +10, Spooky Spell Damage: +25
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	bland Strix stix	4	decent	
 7714	upside-down knitted vibrating Samson's vampire pellet	0		Experience (Muscle): +5, Maximum MP Percent: +10, Cold Resistance: +3
 7715	mediocre non-aged vinegar	4	decent	
@@ -7628,7 +7628,7 @@
 7739	Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
-7742	twirling tumbling Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
+7742	tumbling twirling Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
 7743	lime green Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
 7744	Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	pulsating Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
@@ -7639,18 +7639,18 @@
 7750	green Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	upside-down Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	Fonzie's Xiblaxian xeno-detection goggles	0		Experience (Moxie): +1, Single Equip, Last Available: "2014-09"
-7753	Jack Frost's brawny Xiblaxian stealth cowl	0		Muscle Percent: +20, Cold Spell Damage: +50, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	Jack Frost's brawny Xiblaxian stealth cowl	0		Muscle Percent: +20, Cold Spell Damage: +50, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	vibrating healthy Xiblaxian stealth trousers	0		Maximum HP Percent: +20, Maximum MP Percent: +10, Last Available: "2014-09"
 7755	tumbling crafty Xiblaxian stealth vest of temperance	0		Maximum MP: +10, Sleaze Resistance: +5, Last Available: "2014-09"
 7756	adequate twirling Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
-7757	smooth watered-down Xiblaxian space-whiskey	2	awesome	Last Available: "2014-09"
+7757	watered-down smooth Xiblaxian space-whiskey	2	awesome	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	adjusted blurry They liver	0		Effect: "Corona de la Salsa", Effect Duration: 17, Last Available: "2014-09"
 7760	normal pulsating They liver popsicle	3	good	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	teal holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
-7764	diluted wobbly cyan ghostly residual zeal	1		Last Available: "2014-09"
+7764	diluted cyan wobbly ghostly residual zeal	1		Last Available: "2014-09"
 7765	bouncing Samson's Xiblaxian holo-wrist-puter	0		Experience (Muscle): +5, Last Available: "2014-09"
 7766	aromatic clever boxer's defective Golden Mr. Accessory	0		Muscle Percent: +10, Maximum MP: +20, Stench Resistance: +1
 7767	bouncing airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7659,7 +7659,7 @@
 7770	tumbling lion tamer's hale Personal Ventilation Unit of courage	0		Maximum HP: +20, Experience (familiar): +2, Spooky Resistance: +3, Single Equip, Last Available: "2014-10"
 7771	modified adjusted lime green the most dangerous bait	0		Effect: "Man's Worst Enemy", Effect Duration: 51, Last Available: "2014-10"
 7772	normal half-sized &quot;meat&quot; stick	2	good	Last Available: "2014-10"
-7773	modified cyan ghostly huge transdermal smoke patch	1	crappy	Last Available: "2014-10"
+7773	modified huge cyan ghostly transdermal smoke patch	1	crappy	Last Available: "2014-10"
 7774	skewed specialty ammo bandolier	0		Last Available: "2014-10"
 7775	knitted ribald medical-grade pair of plants	0		Sleaze Damage: +10, Cold Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10"
 7776	quilted Fonzie's brainy Sasq&trade; watch	0		Mysticality: +5, Experience (Moxie): +1, Damage Absorption: +40, Single Equip, Last Available: "2014-10"
@@ -7668,23 +7668,23 @@
 7779	quadruple-activated pulsating experimental serum G-9	0		Effect: "Spooky Demeanor", Effect Duration: 62, Last Available: "2014-10"
 7780	upside-down ghostly executive toasty Annie Oakley's heavy-duty clipboard	0		Critical Hit Percent: +20, Hot Damage: +5, Meat Drop: +40, Damage Reduction: 8, Last Available: "2014-10"
 7781	lion tamer's hale Samson's strapping battery-powered drill	0		Muscle: +5, Experience (Muscle): +5, Maximum HP: +20, Experience (familiar): +2, Last Available: "2014-10"
-7782	gigantic rotten limp broccoli	6	crappy	Last Available: "2014-10"
-7783	knitted chilly steel-toed hat	0		Damage Reduction: 9, Cold Damage: +5, Cold Resistance: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	rotten gigantic limp broccoli	6	crappy	Last Available: "2014-10"
+7783	knitted chilly steel-toed hat	0		Damage Reduction: 9, Cold Damage: +5, Cold Resistance: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	oxidized activated monkey barf	0		Effect: "Concentration", Effect Duration: 57, Last Available: "2014-10"
 7785	extra-quantum flattened huge candy	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 69, Last Available: "2014-10"
 7786	perfumed Samson's jangly bracelet of the scaredy-cat	0		Experience (Muscle): +5, Monster Level: -15, Stench Resistance: +5, Last Available: "2014-10"
-7787	cuddly teddy bear of wisdom	0		Mysticality: +15, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	cuddly teddy bear of wisdom	0		Mysticality: +15, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	twirling avaricious asbestos-lined first-aid pouch	0		Hot Resistance: +5, Meat Drop: +30, Last Available: "2014-10"
 7790	huge khaki duffel bag	0		Last Available: "2014-10"
 7791	boiled unsweetened airborne mutagen	0		Effect: "Memory of Resilience", Effect Duration: 51, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
-7793	bouncing gray bottle-opener keycard	0		Last Available: "2014-10"
+7793	gray bouncing bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	stale fancy spinning initiative shawarma	4	decent	Effect: "Blood-Rich", Effect Duration: 25, Last Available: "2014-10"
-7796	spoiled enchanted warm war shawarma	4	crappy	Effect: "Thought", Effect Duration: 20, Last Available: "2014-10"
+7796	enchanted spoiled warm war shawarma	4	crappy	Effect: "Thought", Effect Duration: 20, Last Available: "2014-10"
 7797	rotten enchanted cyan karma shawarma	3	crappy	Effect: "Weasels Underfoot", Effect Duration: 10, Last Available: "2014-10"
-7798	watered-down drinkable Jungle Juice	2	good	Last Available: "2014-10"
+7798	drinkable watered-down Jungle Juice	2	good	Last Available: "2014-10"
 7799	mediocre triple-distilled Amnesiac Ale	7	decent	Last Available: "2014-10"
 7800	smooth irresponsibly strong Highest Bitter	9	awesome	Last Available: "2014-10"
 7801	mirror lard-coated greasy mercenary pistol	0		Sleaze Spell Damage: 35, Last Available: "2014-10"
@@ -7722,7 +7722,7 @@
 7833	pulsating gore bucket	0		Last Available: "2014-10"
 7834	blurry pack of smokes	0		Last Available: "2014-10"
 7835	red ESP suppression collar	0		Last Available: "2014-10"
-7836	pulsating purple GPS-tracking wristwatch	0		Last Available: "2014-10"
+7836	purple pulsating GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	Project T. L. B.	0		Last Available: "2014-10"
 7838	bouncing Agent Mauve	0		Last Available: "2014-10"
 7839	special clip: tracers	0		Last Available: "2014-10"
@@ -7731,20 +7731,20 @@
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	wobbly special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
-7845	triple-tarnished quantum huge squat perl necklace	0		Effect: "Prideful Strut", Effect Duration: 12, Last Available: "2014-12"
+7845	triple-tarnished quantum squat huge perl necklace	0		Effect: "Prideful Strut", Effect Duration: 12, Last Available: "2014-12"
 7846	quadruple-corrupted triple-polarized Fudge Fiber Armor Plating	0		Effect: "Compensatory Cruelness", Effect Duration: 25, Last Available: "2014-12"
 7847	warmed huge ruby on canes	0		Effect: "Bananas!", Effect Duration: 62, Last Available: "2014-12"
 7848	bite-sized yummy petit fortran	1	awesome	Last Available: "2014-12"
 7849	spoiled low-calorie twirling upside-down java cookie	1	crappy	Last Available: "2014-12"
-7850	yummy tiny cookie cookie	1	awesome	Last Available: "2014-12"
+7850	tiny yummy cookie cookie	1	awesome	Last Available: "2014-12"
 7851	foul-smelling plastic exo-suited miner	0		Stench Damage: +10, Last Available: "2014-12"
 7852	plastic semi-autonomous drill unit of horror	0		Spooky Spell Damage: +25, Last Available: "2014-12"
 7853	plastic ambulatory robo-minecart of the boozehound	0		Booze Drop: +100, Last Available: "2014-12"
 7854	gravedigger's plastic Crimbot	0		Spooky Damage: +10, Last Available: "2014-12"
 7855	shaking plastic Crimbomega of the brute	0		Muscle Percent: +30, Last Available: "2014-12"
 7856	super-boiled huge flask of mining oil	0		Effect: "French Bronilla Brogueishness", Effect Duration: 28, Last Available: "2014-12"
-7857	bouncing rosy-cheeked radiation-resistant helmet	0		Maximum HP Percent: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	sinister servo-assisted exo-pants	0		Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	bouncing rosy-cheeked radiation-resistant helmet	0		Maximum HP Percent: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	sinister servo-assisted exo-pants	0		Spell Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	supercharged smooth high-energy mining laser	0		Moxie: +15, Maximum MP Percent: +30, Last Available: "2014-12"
 7860	cyan twirling peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7765,10 +7765,10 @@
 7876	bouncing Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	shaking Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
-7879	maroon jittery Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
+7879	jittery maroon Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
 7880	Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
-7882	tumbling fuchsia Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
+7882	fuchsia tumbling Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	wobbly olive Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	spinning Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	Crimbot schematic: Power Arm	0		Last Available: "2014-12"
@@ -7808,16 +7808,16 @@
 7919	pressed energized huge Big Punk	0		Effect: "Human-Constellation Hybrid", Effect Duration: 21
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	distilled smooth Friendly Turkey	5	awesome	Last Available: "2014-11"
+7922	smooth distilled Friendly Turkey	5	awesome	Last Available: "2014-11"
 7923	delicious Agitated Turkey	4	awesome	Last Available: "2014-11"
-7924	acceptable watered-down Ambitious Turkey	2	good	Last Available: "2014-11"
-7925	decent fancy diet neutron lollipop	1	good	Effect: "Hot Hands", Effect Duration: 15, Last Available: "2014-12"
+7924	watered-down acceptable Ambitious Turkey	2	good	Last Available: "2014-11"
+7925	fancy diet decent neutron lollipop	1	good	Effect: "Hot Hands", Effect Duration: 15, Last Available: "2014-12"
 7926	bad gamma nog	3	decent	Last Available: "2014-12"
 7934	tumbling sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	powdered upside-down huge yellow single atom	1	crappy	Last Available: "2015-02"
+7938	powdered yellow upside-down huge single atom	1	crappy	Last Available: "2015-02"
 7939	red Time Cape	0		Last Available: "2014-11"
 7940	tumbling Time Cloak	0		Last Available: "2014-11"
 7941	gray sleeve deuce	0		
@@ -7826,9 +7826,9 @@
 7944	tooth	0		
 7945	table	0		
 7946	upside-down nippy stiffened sage outlaw bandana	0		Mysticality Percent: +10, Damage Reduction: 1, Cold Damage: +10
-7947	weak tolerable whiskey in a broken glass	2	good	
-7948	extra-dry hand-crafted ghostly shot of mescal	5	EPIC	
-7949	distilled mediocre glass of herbal tequila	5	decent	
+7947	tolerable weak whiskey in a broken glass	2	good	
+7948	hand-crafted extra-dry ghostly shot of mescal	5	EPIC	
+7949	mediocre distilled glass of herbal tequila	5	decent	
 7950	jittery minin' dynamite	0		
 7951	shellacked thinker's plaid cowboy hat	0		Mysticality: +10, Damage Reduction: 7, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	upside-down lasso	0		
@@ -7853,8 +7853,8 @@
 7971	fuchsia Aggressive Carrot	0		Free Pull
 7972	pickled yellow mummified fig	1	EPIC	
 7973	vaporized wobbly squat mummified loaf of bread	1	decent	
-7974	compressed narrow green squat mummified beef haunch	1	crappy	Effect: "PERL of Great Price", Effect Duration: 10
-7975	bouncing wobbly linen bandages	0		
+7974	compressed green squat narrow mummified beef haunch	1	crappy	Effect: "PERL of Great Price", Effect Duration: 10
+7975	wobbly bouncing linen bandages	0		
 7976	huge cotton bandages	0		
 7977	silk bandages	0		
 7978	skewed holy spring water	0		
@@ -7876,28 +7876,28 @@
 7994	blinking squat grievous beefy pepper mill	0		Muscle: +10, Weapon Damage Percent: +50, Last Available: "2015-12"
 7995	greasy savvy pelerine	0		Mysticality Percent: +20, Sleaze Spell Damage: +10, Last Available: "2015-12"
 7996	studded arcane researcher's phantom mask	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Single Equip, Last Available: "2015-12"
-7997	vaporized mirror olive polyesterene powder	1		Last Available: "2015-12"
+7997	vaporized olive mirror polyesterene powder	1		Last Available: "2015-12"
 7998	diluted bouncing powder	1		Effect: "Amplified Fabulousness", Effect Duration: 40, Last Available: "2015-12"
 7999	tarnished non-modified fuchsia squat choco-Crimbot	0		Effect: "Super-Charged", Effect Duration: 11, Last Available: "2014-12"
 8000	dry smart watch	0		Effect: "Super Vision", Effect Duration: 15, Last Available: "2014-12"
 8001	deionized super-anodized augmented-reality shades	0		Effect: "Tearful, Fearful", Effect Duration: 56, Last Available: "2014-12"
-8002	toy Crimbot mega face of the early riser	0		Adventures: +7, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
-8003	yellow dance instructor's toy Crimbot power glove	0		Experience Percent (Moxie): +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	blurry clever toy Crimbot super fist	0		Maximum MP: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	brawny toy Crimbot rocket legs	0		Muscle Percent: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	toy Crimbot mega face of the early riser	0		Adventures: +7, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
+8003	yellow dance instructor's toy Crimbot power glove	0		Experience Percent (Moxie): +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	blurry clever toy Crimbot super fist	0		Maximum MP: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	brawny toy Crimbot rocket legs	0		Muscle Percent: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	pickled ionized Crimbot battery	0		Effect: "Powder Power", Effect Duration: 13, Last Available: "2014-12"
-8007	narrow pulsating Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
+8007	pulsating narrow Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	horrifying steel-toed Crimbomega drive chain of the businessman	0		Damage Reduction: 9, Spooky Damage: +25, Meat Drop: +50, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	horrifying steel-toed Crimbomega drive chain of the businessman	0		Damage Reduction: 9, Spooky Damage: +25, Meat Drop: +50, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	mirror Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	skewed ghostly Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	quadruple-chilled vacuum-sealed fitness wristband	0		Effect: "Bone Homie", Effect Duration: 68, Last Available: "2014-12"
 8017	galvanized enhanced flask of tainted mining oil	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 20, Last Available: "2014-12"
-8018	vacuum-sealed aerosolized activated shaking ghostly and rain stick	0		Effect: "The Power of LOV", Effect Duration: 23
+8018	vacuum-sealed aerosolized activated ghostly shaking and rain stick	0		Effect: "The Power of LOV", Effect Duration: 23
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	normal tiny Choco-Mint patty	1	good	Last Available: "2015-01"
 8021	delicious hot mint schnocolate	3	awesome	Last Available: "2015-01"
@@ -7939,7 +7939,7 @@
 8058	blurry narrow lion tamer's plasma rifle	0		Experience (familiar): +2
 8059	Bananubis's Staff	0		Luck: -6
 8060	tumbling brawny The Joke Book of the Dead of the cougar	0		Moxie: +20, Muscle Percent: +20, Luck: -6
-8061	gray narrow The Clown Crown	0		Luck: -6
+8061	narrow gray The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
 8063	twirling Tales of Spelunking	0		Last Available: "2015-12"
 8064	skewed monkey statuette	0		Free Pull, Last Available: "2015-12"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	upside-down janitor sponge	0		
 8073	blurry Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	greasy sage Spelunker's fedora of the sewer	0		Mysticality Percent: +10, Stench Damage: +25, Sleaze Spell Damage: +10, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	greasy sage Spelunker's fedora of the sewer	0		Mysticality Percent: +10, Stench Damage: +25, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	Jack Frost's deadly Spelunker's whip of the pedagogue	0		Experience: +3, Weapon Damage: +5, Cold Spell Damage: +50, Last Available: "2015-12"
-8076	wizardly Spelunker's khakis of the wise owl of the early riser	0		Mysticality: 45, Adventures: +7, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	wizardly Spelunker's khakis of the wise owl of the early riser	0		Mysticality: 45, Adventures: +7, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	blinking Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7996,7 +7996,7 @@
 8121	purple shellacked garland of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Single Equip, Last Available: "2018-12"
 8122	fortified gunnysack of the cheetah	0		Damage Absorption: +60, Initiative: +60, Last Available: "2018-12"
 8123	spinning Annie Oakley's stylish garibaldi	0		Moxie: +25, Critical Hit Percent: +20, Last Available: "2018-12"
-8124	electrified personal trainer's girdle	0		Experience Percent (Muscle): +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	electrified personal trainer's girdle	0		Experience Percent (Muscle): +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	miser's healthy gloves	0		Maximum HP Percent: +20, Meat Drop: +10, Single Equip, Last Available: "2018-12"
 8126	dehydrated upside-down smithereens	1		Last Available: "2018-12"
 8127	twirling jittery rosewater-soaked Fonzie's fiberglass fetish	0		Experience (Moxie): +1, Stench Resistance: +3, Last Available: "2018-12"
@@ -8056,22 +8056,22 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	bread basket of the brazier	0		Hot Spell Damage: +25
 8184	olive skewed Ed the Undying exhibit crate	0		
-8185	wobbly groovy The Crown of Ed the Undying of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	wobbly groovy The Crown of Ed the Undying of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	triple-distilled drinkable special blinking Cherrytastrophe wine cooler	7	good	Effect: "Seeing Colors", Effect Duration: 15
-8189	triple-distilled tolerable Radberry Rip wine cooler	8	good	
+8188	drinkable special triple-distilled blinking Cherrytastrophe wine cooler	7	good	Effect: "Seeing Colors", Effect Duration: 15
+8189	tolerable triple-distilled Radberry Rip wine cooler	8	good	
 8190	perfectly mixed Orangemageddon wine cooler	3	EPIC	
 8191	drinkable maroon Breakfast Blast wine cooler	3	good	
-8192	special hand-crafted strong huge Citrus Crush wine cooler	5	EPIC	Effect: "Rampage!", Effect Duration: 5
-8193	normal miniature plain bagel	2	good	
-8194	miniature bland upside-down glob of cream cheese	2	decent	
+8192	strong special hand-crafted huge Citrus Crush wine cooler	5	EPIC	Effect: "Rampage!", Effect Duration: 5
+8193	miniature normal plain bagel	2	good	
+8194	bland miniature upside-down glob of cream cheese	2	decent	
 8195	adequate spinning loaf of soda bread	4	good	
 8196	adequate diet acceptable bagel	1	good	
 8197	normal huge standard-issue cupcake	3	good	
 8198	half-sized adequate ultra-deluxe cupcake	2	good	
 8199	hypnotic breadcrumbs	0		
-8200	flavorless snack-sized popular tart	2	decent	
+8200	snack-sized flavorless popular tart	2	decent	
 8201	cyan no-handed pie	0		
 8202	concentrated tarnished huge Doc Galaktik's Vitality Serum	0		Effect: "The Moxious Madrigal", Effect Duration: 40
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8086,13 +8086,13 @@
 8212	jittery grogpagne	0		Last Available: "2021-07"
 8213	experienced rigging rope of the overflowing toilet	0		Experience: +2, Stench Spell Damage: +50, Last Available: "2015-04"
 8214	compressed nasty snuff	1	decent	Last Available: "2015-04"
-8215	Jeselnik's sewage-clogged pistol of extreme caution	0		Monster Level: -25, Sleaze Damage: +25, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	Jeselnik's sewage-clogged pistol of extreme caution	0		Monster Level: -25, Sleaze Damage: +25, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	moist extra-adjusted beard incense	0		Effect: "Meadulla Oblongota", Effect Duration: 28, Last Available: "2015-04"
 8217	wobbly Jeselnik's Herculean perfume-soaked bandana	0		Experience (Muscle): +1, Sleaze Damage: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	moldy toxo	4	crappy	Last Available: "2015-04"
-8220	tolerable enchanted Lemonade-235	3	good	Effect: "Super-Charged", Effect Duration: 15, Last Available: "2015-04"
-8221	deadly isotophat of chilblains	0		Weapon Damage: +5, Cold Damage: +25, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8220	enchanted tolerable Lemonade-235	3	good	Effect: "Super-Charged", Effect Duration: 15, Last Available: "2015-04"
+8221	deadly isotophat of chilblains	0		Weapon Damage: +5, Cold Damage: +25, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	dangerous Three Mile Island shorts of the businessman	0		Weapon Damage: +10, Meat Drop: +50, Last Available: "2015-04"
 8223	electrified toxic mop of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-04"
 8224	narrow inert sludgepuppy	0		Last Available: "2015-04"
@@ -8141,8 +8141,8 @@
 8267	Temple Grandin's sphygmayomanometer	0		Familiar Weight: +7, Lasts Until Rollover, Last Available: "2015-05"
 8268	twirling tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	rotten massive unappetizing mayolus	6	crappy	Last Available: "2015-05"
-8271	spoiled huge wobbly uninteresting mayolus	3	crappy	Last Available: "2015-05"
+8270	massive rotten unappetizing mayolus	6	crappy	Last Available: "2015-05"
+8271	spoiled wobbly huge uninteresting mayolus	3	crappy	Last Available: "2015-05"
 8272	flavorless miniature acceptable mayolus	2	decent	Last Available: "2015-05"
 8273	tasty yellow enticing mayolus	4	awesome	Last Available: "2015-05"
 8274	flavorless pulsating mouth-watering mayolus	4	decent	Last Available: "2015-05"
@@ -8168,7 +8168,7 @@
 8294	sinister dice-print do-rag	0		Spell Damage: +10
 8295	smelly dice sunglasses	0		Stench Spell Damage: +10, Single Equip
 8296	blinking Thwaitgold caterpillar statuette	0		
-8297	altered anodized moist mirror blinking cyan dice	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 34
+8297	altered anodized moist mirror cyan blinking dice	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 34
 8298	upside-down pixel	0		Last Available: "2015-06"
 8299	pixel coin	0		Last Available: "2015-06"
 8300	moist concentrated power pill	0		Effect: "Prince of Seaside Town", Effect Duration: 58, Last Available: "2015-06"
@@ -8195,14 +8195,14 @@
 8321	corrupted diffused liquefied glove	0		Effect: "Clean-Shaven", Effect Duration: 25
 8322	galvanized handful of fire	0		Effect: "Tiki Toughness", Effect Duration: 12
 8323	nitrogenated Cracklin' Oat Bran	0		Effect: "Infernal Thirst", Effect Duration: 33
-8324	pressed extra-oxidized green pulsating disposable lighter	0		Effect: "Here to Kick Ass", Effect Duration: 50
-8325	anodized shaking squat coal contact lenses	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 25
+8324	pressed extra-oxidized pulsating green disposable lighter	0		Effect: "Here to Kick Ass", Effect Duration: 50
+8325	anodized squat shaking coal contact lenses	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 25
 8326	chilled galvanized conjured ice cream	0		Effect: "Haunted Stomach", Effect Duration: 33
 8327	polymerized irradiated Iceberglar scarf	0		Effect: "Rosewater Mark", Effect Duration: 46
 8328	diffused dry frozen skewed icy hairspray	0		Effect: "Thought", Effect Duration: 50
 8329	warmed unsweetened blue smellbook	0		Effect: "Limber as Mortimer", Effect Duration: 28
 8330	colloidal electrified fuchsia assassin's cheese knife	0		Effect: "You Know Where to Go", Effect Duration: 58
-8331	anodized bouncing huge filthy armor	0		Effect: "Disco Concentration", Effect Duration: 64
+8331	anodized huge bouncing filthy armor	0		Effect: "Disco Concentration", Effect Duration: 64
 8332	chilled plague pie	0		Effect: "Gunky Dory", Effect Duration: 31
 8333	diffused diffused batarang	0		Effect: "Elemental Mastery", Effect Duration: 14
 8334	unsweetened spare neck bolts	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 50
@@ -8220,11 +8220,11 @@
 8346	irradiated warmed totally sweet mohawk helmet	0		Effect: "Well-Swabbed Ear", Effect Duration: 47
 8347	aerosolized corrupted spray chrome	0		Effect: "Charrrming", Effect Duration: 25
 8348	energized wet filthy monkey head	0		Effect: "Melancholy Burden", Effect Duration: 40
-8349	irradiated polarized ghostly olive hand of cards	0		Effect: "Hella Smooth", Effect Duration: 67
+8349	irradiated polarized olive ghostly hand of cards	0		Effect: "Hella Smooth", Effect Duration: 67
 8350	electrified concentrated damp bar rag	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 49
 8351	liquefied enhanced olive lump of goofball ore	0		Effect: "Pasta Oneness", Effect Duration: 33
-8352	non-nitrogenated spinning olive skeleton beans	0		Effect: "Fancy Feasted", Effect Duration: 36
-8353	quantum adjusted cyan skewed grimy lab coat	0		Effect: "Disco Concentration", Effect Duration: 61
+8352	non-nitrogenated olive spinning skeleton beans	0		Effect: "Fancy Feasted", Effect Duration: 36
+8353	quantum adjusted skewed cyan grimy lab coat	0		Effect: "Disco Concentration", Effect Duration: 61
 8354	colloidal nursery rhyme	0		Effect: "Tin, Man", Effect Duration: 11
 8355	alkaline blurry iron torso box	0		Effect: "Biologically Shocked", Effect Duration: 57
 8356	enhanced huge blurry mercenary headband	0		Effect: "Eyes for Miles", Effect Duration: 22
@@ -8233,7 +8233,7 @@
 8359	oxidized pulsating wrestling mask	0		Effect: "Improprie Tea", Effect Duration: 32
 8360	energized non-electrified hawkface potion	0		Effect: "Engorged Weapon", Effect Duration: 21
 8361	flattened enhanced child-sized dracula cloak	0		Effect: "Alpine Mintiness", Effect Duration: 36
-8362	adjusted bouncing blurry devil-summoning hat	0		Effect: "Wallflowering", Effect Duration: 65
+8362	adjusted blurry bouncing devil-summoning hat	0		Effect: "Wallflowering", Effect Duration: 65
 8363	modified ionized shopkeeper beard	0		Effect: "Eye of the Seal", Effect Duration: 11
 8364	non-corrupted green alien autoautopsy kit	0		Effect: "Rad-ish", Effect Duration: 52
 8365	chilled vacuum-sealed novelty fruit hat	0		Effect: "The Rich Get Richer", Effect Duration: 53
@@ -8249,8 +8249,8 @@
 8375	pickled warmed skewed eyebrow lifter	0		Effect: "damage.enh", Effect Duration: 69
 8376	blue submarine	0		Last Available: "2015-06"
 8377	stale pixel lemon	4	decent	Last Available: "2015-06"
-8378	watered-down acceptable pixel daiquiri	2	good	Last Available: "2015-06"
-8379	polymerized upside-down skewed power pill	0		Effect: "In the Slimelight", Effect Duration: 22, Last Available: "2015-06"
+8378	acceptable watered-down pixel daiquiri	2	good	Last Available: "2015-06"
+8379	polymerized skewed upside-down power pill	0		Effect: "In the Slimelight", Effect Duration: 22, Last Available: "2015-06"
 8380	nitrogenated pixel potion	0		Effect: "Purpose", Effect Duration: 38, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	blinking Deck of Every Card	0		Last Available: "2015-07"
@@ -8263,7 +8263,7 @@
 8389	mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	pulsating mana	0		Last Available: "2015-07"
-8392	wobbly narrow gift card	0		Last Available: "2015-07"
+8392	narrow wobbly gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
 8394	blurry The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	lightning-fast The Emperor's new hat	0		Initiative: +40, Last Available: "2015-07"
@@ -8278,11 +8278,11 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	mirror talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	spoiled super-sized tumbling pestopiary	5	crappy	
+8407	super-sized spoiled tumbling pestopiary	5	crappy	
 8408	ionized wet altered ectoplasmic orbs	0		Effect: "Fungal Flambé", Effect Duration: 62
-8409	snack-sized rotten crudles	2	crappy	
-8410	adequate half-sized agnolotti arboli	2	good	
-8411	rotten small gray spaghetti with ghost balls	2	crappy	
+8409	rotten snack-sized crudles	2	crappy	
+8410	half-sized adequate agnolotti arboli	2	good	
+8411	small rotten gray spaghetti with ghost balls	2	crappy	
 8412	flavorless succulent marrow	3	decent	
 8413	spoiled salacious crumbs	4	crappy	
 8414	bland fusilli marrownarrow	4	decent	
@@ -8301,10 +8301,10 @@
 8427	fizzing spore pod	0		
 8428	tumbling spore pod	0		
 8429	mirror veiny spore pod	0		
-8430	lime green upside-down narrow hard spore pod	0		
+8430	narrow lime green upside-down hard spore pod	0		
 8431	spore pod	0		
 8432	hot spore pod	0		
-8433	narrow blurry cool spore pod	0		
+8433	blurry narrow cool spore pod	0		
 8434	jingling spore pod	0		
 8435	Rosewater's LavaCo Lamp&trade; of the glutton	0		Mysticality Percent: +30, Food Drop: +100, Last Available: "2015-08"
 8436	deadly smooth LavaCo Lamp&trade;	0		Moxie: +15, Weapon Damage: +5, Last Available: "2015-08"
@@ -8329,7 +8329,7 @@
 8455	blurry New Age crystal	0		Last Available: "2015-08"
 8456	spinning crystalline light bulb	0		Last Available: "2015-08"
 8457	blurry broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	pulsating slick high-temperature mining mask of the detective	0		Moxie: +10, Item Drop: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	pulsating slick high-temperature mining mask of the detective	0		Moxie: +10, Item Drop: +20, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	narrow auspicious censurious fireproof megaphone	0		Sleaze Resistance: +3, Item Drop: +10, Last Available: "2015-08"
 8460	half-sized moldy mineapple	2	crappy	Last Available: "2015-08"
 8461	smooth weak olive Gold Velvet&trade; whiskey	2	awesome	Last Available: "2015-08"
@@ -8347,12 +8347,12 @@
 8473	groovy heat-resistant gloves of the blizzard of horror	0		Moxie Percent: +10, Cold Spell Damage: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8474	flavorless mirror squat very hot lunch	3	decent	Last Available: "2015-08"
 8475	tolerable watered-down asbestos thermos	2	good	Last Available: "2015-08"
-8476	electrified tumbling fuchsia liquid rhinestones	0		Effect: "Memory of Attractiveness", Effect Duration: 43, Last Available: "2015-08"
+8476	electrified fuchsia tumbling liquid rhinestones	0		Effect: "Memory of Attractiveness", Effect Duration: 43, Last Available: "2015-08"
 8477	moldy lime green disco biscuit	3	crappy	Last Available: "2015-08"
-8478	enchanted bad irresponsibly strong Quaatorade&trade;	10	decent	Effect: "Flower Power", Effect Duration: 20, Last Available: "2015-08"
-8479	up-at-dawn quilted biker's hat of the early riser	0		Damage Absorption: +40, Adventures: 12, Last Available: "2015-08", Familiar Effect: "atk"
-8480	nasty dog trainer's electrified feathered headdress	0		Experience (familiar): +1, Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	supercharged electrician's hardhat of vim and vigor of the empath	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Familiar Weight: +5, Last Available: "2015-08", Familiar Effect: "atk"
+8478	bad enchanted irresponsibly strong Quaatorade&trade;	10	decent	Effect: "Flower Power", Effect Duration: 20, Last Available: "2015-08"
+8479	up-at-dawn quilted biker's hat of the early riser	0		Damage Absorption: +40, Adventures: 12, Familiar Effect: "atk", Last Available: "2015-08"
+8480	nasty dog trainer's electrified feathered headdress	0		Experience (familiar): +1, Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	supercharged electrician's hardhat of vim and vigor of the empath	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Familiar Weight: +5, Familiar Effect: "atk", Last Available: "2015-08"
 8482	huge Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	yellow Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	blue Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	skewed New Age hurting crystal	0		Last Available: "2015-08"
-8490	electrified smooth velvet pants	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	electrified smooth velvet pants	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	upside-down maroon smooth velvet shirt of the bloodbag	0		Maximum HP: +100, Last Available: "2015-08"
 8492	ruddy smooth velvet hat	0		Maximum HP Percent: +40, Last Available: "2015-08"
 8493	narrow lion tamer's smooth velvet pocket square	0		Experience (familiar): +2, Single Equip, Last Available: "2015-08"
@@ -8391,23 +8391,23 @@
 8517	scandalous dance instructor's SMOOCH bracers	0		Experience Percent (Moxie): +10, Sleaze Damage: +5, Single Equip, Last Available: "2015-08"
 8518	Annie Oakley's SMOOCH kneepads	0		Critical Hit Percent: +20, Single Equip, Last Available: "2015-08"
 8519	mirror nippy SMOOCH spaulders	0		Cold Damage: +10, Single Equip, Last Available: "2015-08"
-8520	narrow scandalous curative SMOOCH codpiece	0		Sleaze Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	narrow scandalous curative SMOOCH codpiece	0		Sleaze Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	nippy SMOOCH breastplate	0		Cold Damage: +10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
-8523	shaking blue fused fuse	0		Last Available: "2015-08"
+8523	blue shaking fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	stale teal tumbling skewed lava cake	3	decent	Last Available: "2015-08"
+8525	stale teal skewed tumbling lava cake	3	decent	Last Available: "2015-08"
 8526	bite-sized bland wobbly pink slime	1	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	lime green Special&trade; Sauce	0		
-8529	special normal devil hair pasta	3	good	Effect: "Vitali Tea", Effect Duration: 25
+8529	normal special devil hair pasta	3	good	Effect: "Vitali Tea", Effect Duration: 25
 8530	bland spagecialetti	4	decent	
 8531	Salsa Libre	0		
 8532	twirling good gravy	0		
 8533	red illicit fish sauce	0		
 8534	adequate tiny libertagliatelle	1	good	
 8535	normal turkish mostaccioli	4	good	
-8536	moldy big linguini of the sea	5	crappy	
+8536	big moldy linguini of the sea	5	crappy	
 8537	double-wet Hersey&trade; SMOOCH	0		Effect: "Voracious Gorging", Effect Duration: 27
 8539	narrow Alexy sauce	0		
 8540	rainbow sauce	0		
@@ -8420,28 +8420,28 @@
 8547	anodized pickled magnetized upside-down pocket maze	0		Effect: "Patent Prevention", Effect Duration: 55
 8548	liquefied dry shady shades	0		Effect: "Berry Experiential", Effect Duration: 57
 8549	wet dry oxidized squeaky toy rose	0		Effect: "Indescribable Flavor", Effect Duration: 33
-8550	bland snack-sized weird gazelle steak	2	decent	
+8550	snack-sized bland weird gazelle steak	2	decent	
 8551	moldy sausage without a cause	3	crappy	
 8552	dry warmed huge face paint	0		Effect: "Warm Belly", Effect Duration: 35
-8553	hand-crafted practically non-alcoholic green emergency margarita	1	super ultra mega turbo EPIC	
-8554	mediocre watered-down vintage smart drink	2	decent	
+8553	practically non-alcoholic hand-crafted green emergency margarita	1	super ultra mega turbo EPIC	
+8554	watered-down mediocre vintage smart drink	2	decent	
 8555	yellow blurry a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	upside-down The Emperor's new cookie	0		
 8558	double-improved corrupted purple upside-down Wickers bar	0		Effect: "Spooky Blur", Effect Duration: 22
 8559	deionized double-enhanced bakelite-covered bacon	0		Effect: "Happy Trails", Effect Duration: 11
 8560	altered Aerheads	0		Effect: "On the Shoulders of Giants", Effect Duration: 59
-8561	nitrogenated non-pickled ghostly spinning Wrotz	0		Effect: "Thunderspell", Effect Duration: 52
+8561	nitrogenated non-pickled spinning ghostly Wrotz	0		Effect: "Thunderspell", Effect Duration: 52
 8562	non-unsweetened Gabarbar	0		Effect: "Angry like the Wolf", Effect Duration: 13
 8563	ionized enhanced fiberglass insulation	0		Effect: "Macho Profundo", Effect Duration: 20
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	barrel lid of Tarzan of Leguizamo of the glutton	0		Experience (Muscle): +3, Monster Level: +20, Food Drop: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	miser's dangerous barrel hoop earring of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	Sherlock's baleful sinister bankruptcy barrel	0		Spell Damage: 35, Item Drop: +25, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	Sherlock's baleful sinister bankruptcy barrel	0		Spell Damage: 35, Item Drop: +25, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	blurry purple firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
-8571	skewed red weathered barrel	0		Last Available: "2015-09"
+8571	red skewed weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
 8573	barrel	0		Last Available: "2015-09"
 8574	moist barrel	0		Last Available: "2015-09"
@@ -8450,8 +8450,8 @@
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	aged bottle of Amontillado	3	awesome	Last Available: "2015-09"
 8579	enchanted drinkable blurry barrel-aged martini	3	good	Effect: "Hagg-ard", Effect Duration: 40, Last Available: "2015-09"
-8580	snack-sized spoiled barrel pickle	2	crappy	Last Available: "2015-09"
-8581	immense normal barrel cracker	10	good	Last Available: "2015-09"
+8580	spoiled snack-sized barrel pickle	2	crappy	Last Available: "2015-09"
+8581	normal immense barrel cracker	10	good	Last Available: "2015-09"
 8582	boiled vibrating mushroom	1	decent	Last Available: "2015-09"
 8583	mixed ghostly mushroom	1	awesome	Last Available: "2015-09"
 8584	gray savvy KoL Con 12-gauge	0		Mysticality Percent: +20, Last Available: "2015-09"
@@ -8459,11 +8459,11 @@
 8586	wizardly barrel gun	0		Mysticality: +25, Last Available: "2015-09"
 8587	cyan barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	huge normal spinning tumbling water log	7	good	Last Available: "2015-09"
+8589	normal huge tumbling spinning water log	7	good	Last Available: "2015-09"
 8590	squat up-at-dawn Sinatra's barrelhead	0		Experience (Moxie): +5, Adventures: +5, Last Available: "2015-09"
 8591	tumbling greasy educational bottoms of the barrel	0		Experience: +1, Sleaze Spell Damage: +10, Last Available: "2015-09"
 8592	electrified dance instructor's chest barrel	0		Experience Percent (Moxie): +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
-8593	green mirror bung spigot	0		Equips On: "Lil' Barrel Mimic"
+8593	mirror green bung spigot	0		Equips On: "Lil' Barrel Mimic"
 8594	spinning foul-smelling wholesome double barreled barrel gun	0		Maximum HP Percent: +10, Stench Damage: +10, Last Available: "2015-09"
 8595	sharpshooter's studded triple barreled barrel gun of temperance	0		Damage Absorption: +80, Critical Hit Percent: +10, Sleaze Resistance: +5, Last Available: "2015-09"
 8596	gray Fonzie's barrel beryl choker of the early riser	0		Experience (Moxie): +1, Adventures: +7, Last Available: "2015-09"
@@ -8489,11 +8489,11 @@
 8616	concentrated triple-dry cuppa Neuroplastici tea	0		Effect: "Bloody-minded", Effect Duration: 43, Last Available: "2015-09"
 8617	non-polymerized purple cuppa Dexteri tea	0		Effect: "Elbow Sauce", Effect Duration: 38, Last Available: "2015-09"
 8618	unsweetened altered cuppa Flexibili tea	0		Effect: "Vital", Effect Duration: 67, Last Available: "2015-09"
-8619	irradiated blurry yellow wobbly cuppa Impregnabili tea	0		Effect: "Frisky Spirit", Effect Duration: 48, Last Available: "2015-09"
+8619	irradiated yellow blurry wobbly cuppa Impregnabili tea	0		Effect: "Frisky Spirit", Effect Duration: 48, Last Available: "2015-09"
 8620	adjusted frozen spinning cuppa Obscuri tea	0		Effect: "Swimming with Sharks", Effect Duration: 41, Last Available: "2015-09"
 8621	dry magnetized unsweetened blue cuppa Irritabili tea	0		Effect: "Antsy in your Pantsy", Effect Duration: 31, Last Available: "2015-09"
 8622	diffused activated cuppa Mediocri tea	0		Effect: "Thunderspell", Effect Duration: 16, Last Available: "2015-09"
-8623	electrified green blinking cuppa Loyal tea	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 61, Last Available: "2015-09"
+8623	electrified blinking green cuppa Loyal tea	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 61, Last Available: "2015-09"
 8624	dried red cuppa Activi tea	1	good	Effect: "Sharpened Sweet Tooth", Effect Duration: 10, Last Available: "2015-09"
 8625	modified cuppa Cruel tea	1		Last Available: "2015-09"
 8626	modified maroon cuppa Alacri tea	0		Effect: "Biologically Shocked", Effect Duration: 29, Last Available: "2015-09"
@@ -8511,11 +8511,11 @@
 8638	squat scandalous gravedigger's savvy Royal scepter	0		Mysticality Percent: +20, Spooky Damage: +10, Sleaze Damage: +5, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	normal miniature bowl of eyeballs	2	good	Last Available: "2015-10"
+8641	miniature normal bowl of eyeballs	2	good	Last Available: "2015-10"
 8642	spoiled bowl of mummy guts	4	crappy	Last Available: "2015-10"
 8643	spoiled maroon bowl of maggots	4	crappy	Last Available: "2015-10"
 8644	tolerable green blood and blood	3	good	Last Available: "2015-10"
-8645	weak bad Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
+8645	bad weak Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
 8646	acceptable zombie	3	good	Last Available: "2015-10"
 8647	lime green Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	clever steel-toed hawk of the glutton	0		Damage Reduction: 9, Maximum MP: +20, Food Drop: +100
-8655	bite-sized decent gray hamlet sandwich	1	good	
+8655	decent bite-sized gray hamlet sandwich	1	good	
 8656	sharpshooter's Othello's military jacket	0		Critical Hit Percent: +10
 8657	Othello's dagger of the businessman	0		Meat Drop: +50, Single Equip
 8658	shellacked Othello's handkerchief	0		Damage Reduction: 7, Single Equip
@@ -8548,18 +8548,18 @@
 8675	tumbling one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	frozen denatured tarnished spinning shoulder-warming lotion	0		Effect: "Weasels Underfoot", Effect Duration: 67, Last Available: "2015-11"
 8677	rotten iceberg lettuce	4	crappy	Last Available: "2015-11"
-8678	weak perfectly mixed squat blue ice wine	2	EPIC	Last Available: "2015-11"
+8678	perfectly mixed weak blue squat ice wine	2	EPIC	Last Available: "2015-11"
 8679	family-friendly Lo Pan's rosy-cheeked Wal-Mart snowglobe	0		Maximum HP Percent: +30, Spell Critical Percent: +30, Sleaze Resistance: +1, Last Available: "2015-11"
 8680	mansplainer's beefy Wal-Mart nametag of the businessman	0		Muscle: +10, Monster Level: +15, Meat Drop: +50, Last Available: "2015-11"
 8681	wool sizzling electrified Wal-Mart overalls	0		Hot Damage: +10, Cold Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
-8684	twirling spinning Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
+8684	spinning twirling Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	squat perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	huge studded bellhop's hat	0		Damage Absorption: +80, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	artisanal triple-distilled ice porter	8	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	huge studded bellhop's hat	0		Damage Absorption: +80, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	triple-distilled artisanal ice porter	8	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	vacuum-sealed huge exotic travel brochure	0		Effect: "Tightly-Wound Spine", Effect Duration: 16, Last Available: "2015-11"
 8691	wobbly bag of foreign bribes	0		Last Available: "2015-11"
 8692	ionized boiled wobbly shampoo-conditioner	0		Effect: "Feeling No Pain", Effect Duration: 49, Last Available: "2015-11"
@@ -8568,10 +8568,10 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered mirror medicinal herbs	1		Last Available: "2016-01"
 8697	adequate ice rice	4	good	Last Available: "2016-01"
-8698	triple-distilled hand-crafted iced plum wine	7	EPIC	Last Available: "2016-01"
+8698	hand-crafted triple-distilled iced plum wine	7	EPIC	Last Available: "2016-01"
 8699	lightning-fast supercharged slick training belt	0		Moxie: +10, Maximum MP Percent: +30, Initiative: +40, Single Equip, Last Available: "2016-01"
 8700	prompt medical-grade training legwarmers of the wise owl	0		Mysticality: +20, Adventures: +3, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2016-01"
-8701	auspicious stanky training helmet of the brute	0		Muscle Percent: +30, Stench Spell Damage: +25, Item Drop: +10, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	auspicious stanky training helmet of the brute	0		Muscle Percent: +30, Stench Spell Damage: +25, Item Drop: +10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	bouncing training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	blinking training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8582,14 +8582,14 @@
 8709	modified maroon abstraction: thought	1		Effect: "Blessing of Pikachutlotal", Effect Duration: 30, Last Available: "2015-12"
 8710	vaporized abstraction: sensation	1		Effect: "Rosewater Mark", Effect Duration: 50, Last Available: "2015-12"
 8711	denatured abstraction: purpose	1		Last Available: "2015-12"
-8712	powdered wobbly upside-down upside-down abstraction: category	1		Last Available: "2015-12"
+8712	powdered upside-down upside-down wobbly abstraction: category	1		Last Available: "2015-12"
 8713	twisted pulsating abstraction: perception	1		Last Available: "2015-12"
-8714	dried narrow jittery abstraction: motion	1		Last Available: "2015-12"
+8714	dried jittery narrow abstraction: motion	1		Last Available: "2015-12"
 8715	powdered abstraction: joy	1		Last Available: "2015-12"
 8716	denatured gray abstraction: certainty	1		Last Available: "2015-12"
 8717	dried upside-down abstraction: comprehension	1		Effect: "Adapt to Change Eventually", Effect Duration: 10, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	decent snack-sized VYKEA meatballs	2	good	Last Available: "2015-11"
+8719	snack-sized decent VYKEA meatballs	2	good	Last Available: "2015-11"
 8720	artisanal VYKEA mead	4	EPIC	Last Available: "2015-11"
 8721	wet VYKEA woadpaint	0		Effect: "Outer Wolf&trade;", Effect Duration: 68, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8605,13 +8605,13 @@
 8732	mediocre pulsating bottle of norwhiskey	3	decent	Last Available: "2015-11"
 8733	modified cyan octolus oculus	1	good	Effect: "Mana Tea", Effect Duration: 50, Last Available: "2015-11"
 8734	lightning-fast Sherlock's flame-wreathed sardine can key	0		Hot Spell Damage: +10, Item Drop: +25, Initiative: +40, Last Available: "2015-11"
-8735	ribald quilted norwhal helmet of temperance	0		Damage Absorption: +40, Sleaze Damage: +10, Sleaze Resistance: +5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	ribald quilted norwhal helmet of temperance	0		Damage Absorption: +40, Sleaze Damage: +10, Sleaze Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	wobbly avaricious flame-wreathed brawny octolus-skin cloak	0		Muscle Percent: +20, Hot Spell Damage: +10, Meat Drop: +30, Last Available: "2015-11"
 8737	practically non-alcoholic bad huge perfect cosmopolitan	1	decent	Last Available: "2015-11"
 8738	perfectly mixed blinking perfect negroni	3	EPIC	Last Available: "2015-11"
 8739	artisanal perfect dark and stormy	4	EPIC	Last Available: "2015-11"
 8740	hand-crafted weak perfect mimosa	2	super ultra EPIC	Last Available: "2015-11"
-8741	lousy watered-down narrow yellow perfect old-fashioned	2	decent	Last Available: "2015-11"
+8741	watered-down lousy narrow yellow perfect old-fashioned	2	decent	Last Available: "2015-11"
 8742	bad perfect paloma	4	decent	Last Available: "2015-11"
 8743	extra-chilled ghostly That 70s Cologne	0		Effect: "Unusual Perspective", Effect Duration: 62, Last Available: "2015-11"
 8744	warmed squat fuchsia Wal-Mart &quot;diamond&quot; ring	0		Effect: "Sweet Tooth", Effect Duration: 14, Last Available: "2015-11"
@@ -8636,7 +8636,7 @@
 8763	mirror BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	lousy watered-down huge Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
+8766	watered-down lousy huge Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
 8767	spinning Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	wobbly Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8654,7 +8654,7 @@
 8782	reindeer hammer of wisdom	0		Mysticality: +15, Last Available: "2015-12"
 8783	fuchsia greedy elf ploughshare	0		Meat Drop: +20, Last Available: "2015-12"
 8784	pulsating circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	narrow faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8663,14 +8663,14 @@
 8791	reindeer sickle of courage	0		Spooky Resistance: +3, Last Available: "2015-12"
 8792	face paint	0		Free Pull, Last Available: "2015-12"
 8793	spinning face paint	0		Free Pull, Last Available: "2015-12"
-8794	green shaking The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
+8794	shaking green The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	spinning Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	wobbly bat-jute	0		Last Available: "2017-01"
 8799	bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
-8801	ghostly blurry incriminating evidence	0		Last Available: "2017-01"
+8801	blurry ghostly incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
 8803	kidnapped orphan	0		Last Available: "2017-01"
 8804	high-grade	0		Last Available: "2017-01"
@@ -8686,21 +8686,21 @@
 8814	spinning Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	rotten wobbly Kudzu salad	4	crappy	Last Available: "2016-12"
-8817	mixed olive twirling Mansquito Serum	1		Last Available: "2016-12"
+8817	mixed twirling olive Mansquito Serum	1		Last Available: "2016-12"
 8818	enchanted tolerable Miss Graves' vermouth	3	good	Effect: "Whole Latte Love", Effect Duration: 10, Last Available: "2016-12"
-8819	decent tiny The Plumber's mushroom stew	1	good	Last Available: "2016-12"
+8819	tiny decent The Plumber's mushroom stew	1	good	Last Available: "2016-12"
 8820	compressed squat pulsating The Author's ink	1		Last Available: "2016-02"
 8821	bad The Mad Liquor	4	decent	Last Available: "2016-12"
 8822	bad Doc Clock's thyme cocktail	3	decent	Last Available: "2016-12"
 8823	bland red Mr. Burnsger	3	decent	Last Available: "2016-12"
 8824	altered tumbling maroon The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	blinking Usain Bolt's banded The Jokester's gun of bravery	0		Damage Absorption: +100, Spooky Resistance: +5, Initiative: +80, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	blinking sharpshooter's veiny The Jokester's wig of bravery	0		Maximum HP: +10, Critical Hit Percent: +10, Spooky Resistance: +5, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	avaricious hardened The Jokester's pants of the boozehound	0		Damage Reduction: 3, Meat Drop: +30, Booze Drop: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	blinking Usain Bolt's banded The Jokester's gun of bravery	0		Damage Absorption: +100, Spooky Resistance: +5, Initiative: +80, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	blinking sharpshooter's veiny The Jokester's wig of bravery	0		Maximum HP: +10, Critical Hit Percent: +10, Spooky Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
+8827	avaricious hardened The Jokester's pants of the boozehound	0		Damage Reduction: 3, Meat Drop: +30, Booze Drop: +100, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	vacuum-sealed enhanced Jokester makeup	0		Effect: "Fiery Spirit", Effect Duration: 16, Last Available: "2016-12"
 8829	blinking replica bat-oomerang	0		Last Available: "2016-12"
 8830	purple battoo kit	0		Last Available: "2016-12"
-8831	fuchsia squat basking robin	0		Free Pull, Last Available: "2016-12"
+8831	squat fuchsia basking robin	0		Free Pull, Last Available: "2016-12"
 8832	shaking domino mask	0		Familiar Weight: +5
 8833	dry wet blue robin's egg	0		Effect: "Stuck That Way", Effect Duration: 65, Last Available: "2016-12"
 8834	rotten fancy mirror robin flan	3	crappy	Effect: "Amorous Avarice", Effect Duration: 20, Last Available: "2016-12"
@@ -8719,7 +8719,7 @@
 8847	colloidal corrupted ionized squat red-hot jawbreaker	0		Effect: "Go-Gone", Effect Duration: 49
 8848	altered cold-filtered question juice	0		Effect: "Motion", Effect Duration: 47
 8849	non-irradiated tube of villain	0		Effect: "Tea-hee", Effect Duration: 58
-8850	upside-down beefy your cowboy boots	0		Muscle: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	upside-down beefy your cowboy boots	0		Muscle: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	wobbly inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8748,17 +8748,17 @@
 8876	flavorless maroon plate of Heimz Fortified Kidney Beans	3	decent	Last Available: "2016-02"
 8877	snack-sized decent plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
 8878	snack-sized moldy plate of Mixed Garbanzos and Chickpeas	2	crappy	Last Available: "2016-02"
-8879	tiny normal plate of Hellfire Spicy Beans	1	good	Last Available: "2016-02"
+8879	normal tiny plate of Hellfire Spicy Beans	1	good	Last Available: "2016-02"
 8880	adequate plate of Frigid Northern Beans	4	good	Last Available: "2016-02"
 8881	tasty plate of World's Blackest-Eyed Peas	4	awesome	Last Available: "2016-02"
 8882	bite-sized normal plate of Trader Olaf's Exotic Stinkbeans	1	good	Last Available: "2016-02"
-8883	special bland mirror lime green plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Effect: "Antarctic Memories", Effect Duration: 10, Last Available: "2016-02"
-8884	big bland plate of Val-U Brand Every Bean Salad	5	decent	Last Available: "2016-02"
+8883	special bland lime green mirror plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Effect: "Antarctic Memories", Effect Duration: 10, Last Available: "2016-02"
+8884	bland big plate of Val-U Brand Every Bean Salad	5	decent	Last Available: "2016-02"
 8885	miniature spoiled plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	dog trainer's fortified Fancy Jeff's pocket square	0		Damage Absorption: +60, Experience (familiar): +1, Last Available: "2016-02"
-8887	huge wicked razor-sharp Newton's Daisy's unclean bloomers	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Spell Damage: +5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	huge wicked razor-sharp Newton's Daisy's unclean bloomers	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Spell Damage: +5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	Amoon-Ra Cowtep's nemes of the dark arts of chilblains of the glutton	0		Spell Damage Percent: +100, Cold Damage: +25, Food Drop: +100, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	Amoon-Ra Cowtep's nemes of the dark arts of chilblains of the glutton	0		Spell Damage Percent: +100, Cold Damage: +25, Food Drop: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	blurry blue reassuring fireproof dance instructor's Former Sheriff Dan's tin star of the cougar of dire peril	0		Moxie: +20, Experience Percent (Moxie): +10, Weapon Damage: +20, Hot Resistance: +3, Spooky Resistance: +1, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8770,22 +8770,22 @@
 8898	tumbling realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	EPIC	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
-8901	triple-boiled quantum colloidal narrow green triggerfingerbone	0		Effect: "Night of the Nachos", Effect Duration: 19, Last Available: "2016-02"
+8901	triple-boiled quantum colloidal green narrow triggerfingerbone	0		Effect: "Night of the Nachos", Effect Duration: 19, Last Available: "2016-02"
 8902	moist galvanized altered spinning ghost bit	0		Effect: "Become Superficially interested", Effect Duration: 15, Last Available: "2016-02"
 8903	polarized frozen buzzard feather	0		Effect: "Hyperoxygenated Blood", Effect Duration: 67, Last Available: "2016-02"
-8904	diffused polymerized huge blinking lion musk	0		Effect: "Updated", Effect Duration: 60, Last Available: "2016-02"
+8904	diffused polymerized blinking huge lion musk	0		Effect: "Updated", Effect Duration: 60, Last Available: "2016-02"
 8905	decent bear claw	4	good	Last Available: "2016-02"
 8906	nitrogenated super-aerosolized rattler gland	0		Effect: "Boilermade", Effect Duration: 64, Last Available: "2016-02"
-8907	adjusted nitrogenated shaking yellow half-digested coal	0		Effect: "Proprie Tea", Effect Duration: 44, Last Available: "2016-02"
+8907	adjusted nitrogenated yellow shaking half-digested coal	0		Effect: "Proprie Tea", Effect Duration: 44, Last Available: "2016-02"
 8908	alkaline mirror tightly-wound spine	0		Effect: "Egg-headedness", Effect Duration: 24, Last Available: "2016-02"
 8909	miniature bland blue rotting beefsteak	2	decent	Last Available: "2016-02"
-8910	artisanal watered-down red firemilk	2	EPIC	Last Available: "2016-02"
+8910	watered-down artisanal red firemilk	2	EPIC	Last Available: "2016-02"
 8911	vacuum-sealed corrupted tumbling spidercow eye-cluster	0		Effect: "Stop the Presses!", Effect Duration: 45, Last Available: "2016-02"
 8912	pickled tumbling moomy dust	1		Last Available: "2016-02"
 8913	perfumed careful western-style skinning knife	0		Monster Level: -10, Stench Resistance: +5, Last Available: "2016-02"
 8914	narrow wobbly reliable sixgun	0		Last Available: "2016-02"
 8915	huge healthy steel knuckles	0		Maximum HP Percent: +20, Last Available: "2016-02"
-8916	lime green narrow Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
+8916	narrow lime green Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	cyan Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
 8918	The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
 8919	LT&T tattoo kit	0		Last Available: "2016-02"
@@ -8806,12 +8806,12 @@
 8934	blinking baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	ghostly hamethyst-handled sixgun	0		Last Available: "2016-02"
-8937	shaking blue mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
+8937	blue shaking mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	blinking coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
-8942	tumbling mirror rotting cowskin	0		Last Available: "2016-02"
+8942	mirror tumbling rotting cowskin	0		Last Available: "2016-02"
 8943	green shuddering cow skull	0		Last Available: "2016-02"
 8944	narrow rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
@@ -8861,18 +8861,18 @@
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	diluted blurry twirling armored prawn	1		Effect: "Squid Squint", Effect Duration: 25, Last Available: "2016-03"
-8993	miniature decent tumbling jumping horseradish	2	good	Last Available: "2016-03"
+8992	diluted twirling blurry armored prawn	1		Effect: "Squid Squint", Effect Duration: 25, Last Available: "2016-03"
+8993	decent miniature tumbling jumping horseradish	2	good	Last Available: "2016-03"
 8994	high-proof drinkable Sacramento wine	7	good	Last Available: "2016-03"
 8995	colloidal Greek fire	0		Effect: "Brother Corsican's Blessing", Effect Duration: 31, Last Available: "2016-03"
 8996	shaking Van der Graaf energetic hardy experienced ox-head shield of the sewer	0		Experience: +2, Maximum HP: +50, Maximum MP Percent: +20, Stench Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	mansplainer's therapeutic experienced boxer's dented scepter of extreme caution	0		Muscle Percent: +10, Experience: +2, Monster Level: -10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	teal asbestos-lined toasty experienced stylish very pointy crown of Leguizamo	0		Moxie: +25, Experience: +2, Monster Level: +20, Hot Damage: +5, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	teal asbestos-lined toasty experienced stylish very pointy crown of Leguizamo	0		Moxie: +25, Experience: +2, Monster Level: +20, Hot Damage: +5, Hot Resistance: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	Sherlock's MacGyver's Oprah's quilted padded battle broom	0		Damage Absorption: 60, Maximum MP Percent: +50, Maximum MP: +100, Item Drop: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	gravedigger's lion tamer's quilted carpe of temperance	0		Damage Absorption: +40, Experience (familiar): +2, Spooky Damage: +10, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
 9002	flame-wreathed Van der Graaf Fonzie's codpiece of dire peril	0		Experience (Moxie): +1, Weapon Damage: +20, Hot Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
-9003	greasy friendly slick troutsers of the blizzard	0		Moxie: +10, Familiar Weight: +3, Cold Spell Damage: +25, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	greasy friendly slick troutsers of the blizzard	0		Moxie: +10, Familiar Weight: +3, Cold Spell Damage: +25, Sleaze Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	ghostly nippy stiffened baleful stylish bass clarinet	0		Moxie: +25, Spell Damage: +25, Damage Reduction: 1, Cold Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9005	manspreader's fish hatchet of the sewer of horror of the early riser	0		Monster Level: +10, Stench Damage: +25, Spooky Spell Damage: +25, Adventures: +7, Lasts Until Rollover, Last Available: "2016-04"
 9006	perfumed knitted ribald fortified tunac	0		Damage Absorption: +60, Sleaze Damage: +10, Cold Resistance: +3, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	purple internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	fancy decent gallon of milk	3	good	Effect: "Minerva's Zen", Effect Duration: 30, Last Available: "2016-05"
+9021	decent fancy gallon of milk	3	good	Effect: "Minerva's Zen", Effect Duration: 30, Last Available: "2016-05"
 9022	cyan print screen button	0		Last Available: "2016-05"
 9023	upside-down screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8905,7 +8905,7 @@
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	toothsome bouncing browser cookie	4	awesome	Last Available: "2016-06"
-9036	triple-distilled bad hacked gibson	9	decent	Last Available: "2016-06"
+9036	bad triple-distilled hacked gibson	9	decent	Last Available: "2016-06"
 9037	Source shades of incineration	0		Hot Spell Damage: +50, Last Available: "2016-06"
 9038	fuchsia software bug	0		Last Available: "2016-06"
 9039	tumbling missing semicolon	0		Familiar Weight: +11
@@ -8919,7 +8919,7 @@
 9047	skewed Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	Source terminal SCRAM chip	0		Last Available: "2016-06"
-9050	cyan twirling Source terminal TRIGRAM chip	0		Last Available: "2016-06"
+9050	twirling cyan Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	mirror pulsating Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	lime green Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
@@ -8935,7 +8935,7 @@
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	red Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
-9066	skewed squat Source terminal file: tram.ext	0		Last Available: "2016-06"
+9066	squat skewed Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	purple pill	0		Last Available: "2016-06"
 9068	family-friendly thinker's plastic detective badge of wisdom of the glutton	0		Mysticality: 25, Sleaze Resistance: +1, Food Drop: +100, Last Available: "2016-07"
 9069	bouncing lard-coated lion tamer's padded bronze detective badge of temperance	0		Damage Absorption: +20, Experience (familiar): +2, Sleaze Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2016-07"
@@ -8947,11 +8947,11 @@
 9075	quadruple-adjusted ionized flattened shoe gum	0		Effect: "Far Out", Effect Duration: 66, Last Available: "2016-07"
 9076	upside-down blurry Temple Grandin's noir fedora of the cougar of the brute	0		Moxie: +20, Muscle Percent: +30, Familiar Weight: +7, Last Available: "2016-07"
 9077	Usain Bolt's censurious ribald trench coat	0		Sleaze Damage: +10, Sleaze Resistance: +3, Initiative: +80, Last Available: "2016-07"
-9078	special drinkable Falcon&trade; Maltese Liquor	4	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2016-07"
-9079	small normal mirror hardboiled egg	2	good	Last Available: "2016-07"
+9078	drinkable special Falcon&trade; Maltese Liquor	4	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2016-07"
+9079	normal small mirror hardboiled egg	2	good	Last Available: "2016-07"
 9080	skewed detective tattoo	0		Last Available: "2016-07"
 9081	upside-down DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	blinking inspector's Annie Oakley's extremely unsafe sage protonic accelerator pack of the blizzard of horror	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Critical Hit Percent: +20, Cold Spell Damage: +25, Spooky Spell Damage: +25, Item Drop: +15, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	blinking inspector's Annie Oakley's extremely unsafe sage protonic accelerator pack of the blizzard of horror	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Critical Hit Percent: +20, Cold Spell Damage: +25, Spooky Spell Damage: +25, Item Drop: +15, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	wobbly almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	Da Vinci's Adventurer bobblehead	0		Experience (Mysticality): +5, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	ghostly Mr. Screege's spectacles of extreme caution	0		Monster Level: -25, Single Equip, Last Available: "2016-08"
 9092	aromatic slick Spookyraven signet of the pedagogue	0		Moxie: +10, Experience: +3, Stench Resistance: +1, Single Equip, Last Available: "2016-08"
 9093	shellacked dangerous tie-dyed fannypack	0		Weapon Damage: +10, Damage Reduction: 7, Single Equip, Last Available: "2016-08"
-9094	fuchsia forbidden burnt snowpants of mayonnaise	0		Spell Damage Percent: +50, Sleaze Spell Damage: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	squat squat smartaleck's standards and practices guide	0		Moxie Percent: +30, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	fuchsia forbidden burnt snowpants of mayonnaise	0		Spell Damage Percent: +50, Sleaze Spell Damage: +50, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	squat squat smartaleck's standards and practices guide	0		Moxie Percent: +30, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	Van der Graaf deadly Carpathian longsword of temperance	0		Weapon Damage: +5, Sleaze Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-08"
 9097	lightning-fast family-friendly Liam's mail of the brute	0		Muscle Percent: +30, Sleaze Resistance: +1, Initiative: +40, Last Available: "2016-08"
 9098	resourceful brainy Unfortunato's foolscap of incineration	0		Mysticality: +5, Maximum MP: +50, Hot Spell Damage: +50, Last Available: "2016-08"
@@ -8979,9 +8979,9 @@
 9107	colloidal colloidal Rad-Pro (1 oz.)	0		Effect: "Mushroom Might", Effect Duration: 51
 9108	lead umbrella	0		
 9109	concentrated energized upside-down Shrieking Weasel holo-record	0		Effect: "Oiled Skin", Effect Duration: 14
-9110	double-vacuum-sealed gray tumbling Power-Guy 2000 holo-record	0		Effect: "Sticks and Stones", Effect Duration: 31
+9110	double-vacuum-sealed tumbling gray Power-Guy 2000 holo-record	0		Effect: "Sticks and Stones", Effect Duration: 31
 9111	Vulcanized polymerized Lucky Strikes holo-record	0		Effect: "Sleazy Jellied", Effect Duration: 25
-9112	extra-cold-filtered blinking cyan EMD holo-record	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 65
+9112	extra-cold-filtered cyan blinking EMD holo-record	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 65
 9113	denatured wet Superdrifter holo-record	0		Effect: "Coated Arms", Effect Duration: 18
 9114	super-electrified nitrogenated jittery The Pigs holo-record	0		Effect: "Antarctic Memories", Effect Duration: 44
 9115	corrupted anodized Drunk Uncles holo-record	0		Effect: "Mana Tea", Effect Duration: 32
@@ -8995,7 +8995,7 @@
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	perfectly mixed weak unidentified drink	2	EPIC	
+9126	weak perfectly mixed unidentified drink	2	EPIC	
 9127	ghostly Tesla smooth KoL Con 13 T-shirt	0		Moxie: +15, MP Regen Min: 7, MP Regen Max: 10
 9128	asbestos-lined Van der Graaf Da Vinci's discarded swimming trunks	0		Experience (Mysticality): +5, Hot Resistance: +5, MP Regen Min: 5, MP Regen Max: 7
 9129	polarized improved liquefied jittery diluted makeup	0		Effect: "Frog In Your Throat", Effect Duration: 38
@@ -9004,7 +9004,7 @@
 9132	lion tamer's savvy pistol	0		Mysticality Percent: +20, Experience (familiar): +2
 9133	narrow KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	fancy yummy shaking leftover pasty	3	awesome	Effect: "Cravin' for a Ravin'", Effect Duration: 35
-9135	strong drinkable very whiskey	5	good	
+9135	drinkable strong very whiskey	5	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9018,7 +9018,7 @@
 9146	quadruple-electrified hoarded candy wad	0		Effect: "The Solution", Effect Duration: 53, Last Available: "2016-10"
 9147	dry unsweetened Prunets	0		Effect: "Sludgesick", Effect Duration: 49
 9148	Twitching Television Tattoo	0		
-9149	bouncing blurry baby scorpion	0		Familiar Weight: +10
+9149	blurry bouncing baby scorpion	0		Familiar Weight: +10
 9150	super-vacuum-sealed tarnished extra-anodized ghostly invisible string	0		Lasts Until Rollover, Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 60, Last Available: "2016-10"
 9151	aerosolized chilled yellow invisible seam ripper	0		Lasts Until Rollover, Effect: "Crying, Dying", Effect Duration: 62, Last Available: "2016-10"
 9152	squat li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9040,17 +9040,17 @@
 9168	ghostly potato masher of bravery of the glutton	0		Spooky Resistance: +5, Food Drop: +100, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	skewed bread mold	0		Last Available: "2016-11"
-9171	moldy fancy diet sweet potatoes	1	crappy	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2016-11"
+9171	diet fancy moldy sweet potatoes	1	crappy	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2016-11"
 9172	moldy bean casserole	3	crappy	Last Available: "2016-11"
 9173	adequate special baked stuffing	3	good	Effect: "Lemony Goodness", Effect Duration: 25, Last Available: "2016-11"
 9174	enchanted moldy pulsating cranberry cylinder	3	crappy	Effect: "Chauve-Souris Merde Fou", Effect Duration: 5, Last Available: "2016-11"
 9175	diet normal thanksgiving turkey	1	good	Last Available: "2016-11"
 9176	moldy immense mirror mince pie	7	crappy	Last Available: "2016-11"
-9177	adequate miniature fuchsia mashed potatoes	2	good	Last Available: "2016-11"
+9177	miniature adequate fuchsia mashed potatoes	2	good	Last Available: "2016-11"
 9178	decent warm gravy	4	good	Last Available: "2016-11"
 9179	rotten half-sized blurry bread roll	2	crappy	Last Available: "2016-11"
-9180	moldy low-calorie leftovers	1	crappy	Last Available: "2016-11"
-9181	spoiled fancy shaking leftovers sandwich	3	crappy	Effect: "Wet Willied", Effect Duration: 20, Last Available: "2016-11"
+9180	low-calorie moldy leftovers	1	crappy	Last Available: "2016-11"
+9181	fancy spoiled shaking leftovers sandwich	3	crappy	Effect: "Wet Willied", Effect Duration: 20, Last Available: "2016-11"
 9182	gray Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	twirling cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
@@ -9061,7 +9061,7 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	purple eldritch effluvium	0		
 9191	pressed eldritch concentrate	0		Effect: "Blood-Gorged", Effect Duration: 57, Last Available: "2016-11"
-9192	spirit-forward tolerable tumbling eldritch extract	5	good	Last Available: "2016-11"
+9192	tolerable spirit-forward tumbling eldritch extract	5	good	Last Available: "2016-11"
 9193	educational smartaleck's Official Council Aide Pin	0		Moxie Percent: +30, Experience: +1, Last Available: "2016-11"
 9194	perfectly mixed boozy eldritch distillate	5	EPIC	Last Available: "2016-11"
 9195	dried eldritch essence	1		Last Available: "2016-11"
@@ -9089,8 +9089,8 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	tasty animal part cracker	4	awesome	Last Available: "2016-12"
-9220	triple-distilled drinkable mirror gingerbread wine	7	good	Last Available: "2016-12"
-9221	enchanted normal diet gingerbread mug	1	good	Effect: "Good Motivator", Effect Duration: 50, Last Available: "2016-12"
+9220	drinkable triple-distilled mirror gingerbread wine	7	good	Last Available: "2016-12"
+9221	diet normal enchanted gingerbread mug	1	good	Effect: "Good Motivator", Effect Duration: 50, Last Available: "2016-12"
 9222	wobbly gingerbread mask of the detective	0		Item Drop: +20, Last Available: "2016-12"
 9223	blue mansplainer's Sinatra's gingerservo of the early riser	0		Experience (Moxie): +5, Monster Level: +15, Adventures: +7, Single Equip, Last Available: "2016-12"
 9224	improved modified tainted icing	0		Effect: "Good Karma", Effect Duration: 66, Last Available: "2016-12"
@@ -9121,10 +9121,10 @@
 9249	improved non-activated green Inner Wisdom	0		Effect: "Hella Tough", Effect Duration: 63, Last Available: "2016-12"
 9250	altered altered improved Inner Strength	0		Effect: "Twinklebritches", Effect Duration: 31, Last Available: "2016-12"
 9251	pickled extra-modified blurry Inner Truth	0		Effect: "Bolts about Candy", Effect Duration: 20, Last Available: "2016-12"
-9252	tiny toothsome spiritual candy cane	1	awesome	Last Available: "2016-12"
+9252	toothsome tiny spiritual candy cane	1	awesome	Last Available: "2016-12"
 9253	bad tumbling spiritual eggnog	3	decent	Last Available: "2016-12"
-9254	toothsome fancy spiritual fruitcake	3	awesome	Effect: "No Vertigo", Effect Duration: 45, Last Available: "2016-12"
-9255	special spoiled spiritual gingerbread	4	crappy	Effect: "For Your Brain Only", Effect Duration: 5, Last Available: "2016-12"
+9254	fancy toothsome spiritual fruitcake	3	awesome	Effect: "No Vertigo", Effect Duration: 45, Last Available: "2016-12"
+9255	spoiled special spiritual gingerbread	4	crappy	Effect: "For Your Brain Only", Effect Duration: 5, Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	green My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9136,20 +9136,20 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	quadruple-oxidized alkaline triple-vacuum-sealed rock candy	0		Effect: "Lemon Enlightenment", Effect Duration: 38, Last Available: "2016-12"
-9267	adequate enchanted twirling green-iced sweet roll	3	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 30, Last Available: "2016-12"
+9267	enchanted adequate twirling green-iced sweet roll	3	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 30, Last Available: "2016-12"
 9268	spinning sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9269	jittery purple chocolate sculpture	0		Last Available: "2016-12"
+9269	purple jittery chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	chakra sludge	0		
 9272	negative lump	0		
 9273	squat executive Third Eye of wisdom	0		Mysticality: +15, Meat Drop: +40, Last Available: "2016-12"
 9274	Van der Graaf Samson's Krampus Horn	0		Experience (Muscle): +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2016-12"
-9275	gigantic stale skewed hambrosier	10	decent	Last Available: "2016-12"
+9275	stale gigantic skewed hambrosier	10	decent	Last Available: "2016-12"
 9276	mediocre chakra-mental wine	3	decent	Last Available: "2016-12"
 9277	flattened cold-filtered chakra malt	0		Effect: "Chlorophyll Flavor", Effect Duration: 47, Last Available: "2016-12"
-9278	massive adequate fuchsia Black Angus blackburger	7	good	Last Available: "2016-12"
+9278	adequate massive fuchsia Black Angus blackburger	7	good	Last Available: "2016-12"
 9279	tolerable brandy	3	good	Last Available: "2016-12"
-9280	energized spinning green narrow potion of spiritual gunkifying	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 15, Last Available: "2016-12"
+9280	energized narrow green spinning potion of spiritual gunkifying	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 15, Last Available: "2016-12"
 9281	horrifying bad vibroknife of the brute	0		Muscle Percent: +30, Spooky Damage: +25, Last Available: "2016-12"
 9282	gray wholesome dangerous crystal belt buckle	0		Weapon Damage: +10, Maximum HP Percent: +10, Last Available: "2016-12"
 9283	lightning-fast medical-grade saffron antaravasaka	0		Initiative: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12"
@@ -9166,11 +9166,11 @@
 9294	dehydrated sleaze jelly	1		Last Available: "2017-01"
 9295	compressed bouncing stench jelly	1		Last Available: "2017-01"
 9296	blinking space planula	0		Free Pull, Last Available: "2017-01"
-9297	super-sized enchanted moldy toast with hot jelly	5	crappy	Effect: "Berry Thorny", Effect Duration: 20, Last Available: "2017-01"
+9297	super-sized moldy enchanted toast with hot jelly	5	crappy	Effect: "Berry Thorny", Effect Duration: 20, Last Available: "2017-01"
 9298	big flavorless huge toast with jelly	5	decent	Last Available: "2017-01"
 9299	spoiled enchanted green toast with jelly	4	crappy	Effect: "Salad Days", Effect Duration: 40, Last Available: "2017-01"
 9300	bland toast with sleaze jelly	3	decent	Last Available: "2017-01"
-9301	bite-sized spoiled special cyan toast with stench jelly	1	crappy	Effect: "Grumpy and Ornery", Effect Duration: 40, Last Available: "2017-01"
+9301	special bite-sized spoiled cyan toast with stench jelly	1	crappy	Effect: "Grumpy and Ornery", Effect Duration: 40, Last Available: "2017-01"
 9302	olive space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	ghostly pewter candlestick	0		Familiar Weight: +10
@@ -9236,40 +9236,40 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	mediocre maroon literal grasshopper	3	decent	Last Available: "2017-03"
 9366	irresponsibly strong artisanal double entendre	9	EPIC	Last Available: "2017-03"
-9367	extra-dry special lousy Phlegethon	5	decent	Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2017-03"
+9367	lousy extra-dry special Phlegethon	5	decent	Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2017-03"
 9368	delicious Siberian sunrise	4	awesome	Last Available: "2017-03"
-9369	special perfectly mixed mentholated wine	3	EPIC	Effect: "Uncucumbered", Effect Duration: 30, Last Available: "2017-03"
+9369	perfectly mixed special mentholated wine	3	EPIC	Effect: "Uncucumbered", Effect Duration: 30, Last Available: "2017-03"
 9370	artisanal low tide martini	4	EPIC	Last Available: "2017-03"
 9371	watered-down hand-crafted shroomtini	2	EPIC	Last Available: "2017-03"
 9372	spirit-forward acceptable ghostly morning dew	5	good	Last Available: "2017-03"
-9373	extra-dry hand-crafted blurry whiskey squeeze	5	EPIC	Last Available: "2017-03"
+9373	hand-crafted extra-dry blurry whiskey squeeze	5	EPIC	Last Available: "2017-03"
 9374	hand-crafted fancy great fashioned	3	EPIC	Effect: "Itchy Trigger Finger", Effect Duration: 45, Last Available: "2017-03"
-9375	smooth high-proof blinking blurry Gnomish sagngria	7	awesome	Last Available: "2017-03"
+9375	high-proof smooth blurry blinking Gnomish sagngria	7	awesome	Last Available: "2017-03"
 9376	smooth vodka stinger	3	awesome	Last Available: "2017-03"
-9377	acceptable triple-distilled extremely slippery nipple	9	good	Last Available: "2017-03"
+9377	triple-distilled acceptable extremely slippery nipple	9	good	Last Available: "2017-03"
 9378	triple-distilled smooth piscatini	9	awesome	Last Available: "2017-03"
 9379	high-proof smooth tumbling Churchill	6	awesome	Last Available: "2017-03"
-9380	watered-down artisanal soilzerac	2	EPIC	Last Available: "2017-03"
-9381	practically non-alcoholic bad London frog	1	decent	Last Available: "2017-03"
+9380	artisanal watered-down soilzerac	2	EPIC	Last Available: "2017-03"
+9381	bad practically non-alcoholic London frog	1	decent	Last Available: "2017-03"
 9382	acceptable practically non-alcoholic nothingtini	1	good	Last Available: "2017-03"
-9383	practically non-alcoholic perfectly mixed eighth plague	1	EPIC	Last Available: "2017-03"
-9384	lousy boozy shaking single entendre	5	decent	Last Available: "2017-03"
+9383	perfectly mixed practically non-alcoholic eighth plague	1	EPIC	Last Available: "2017-03"
+9384	boozy lousy shaking single entendre	5	decent	Last Available: "2017-03"
 9385	artisanal reverse Tantalus	4	EPIC	Last Available: "2017-03"
-9386	drinkable extra-dry elemental caipiroska	5	good	Last Available: "2017-03"
-9387	bad practically non-alcoholic pulsating pulsating Feliz Navidad	1	decent	Last Available: "2017-03"
+9386	extra-dry drinkable elemental caipiroska	5	good	Last Available: "2017-03"
+9387	practically non-alcoholic bad pulsating pulsating Feliz Navidad	1	decent	Last Available: "2017-03"
 9388	mediocre practically non-alcoholic Bloody Nora	1	decent	Last Available: "2017-03"
 9389	perfectly mixed spinning wobbly moreltini	3	EPIC	Last Available: "2017-03"
 9390	tolerable watered-down blurry hell in a bucket	2	good	Last Available: "2017-03"
 9391	irresponsibly strong tolerable Newark	7	good	Last Available: "2017-03"
 9392	bad R'lyeh	4	decent	Last Available: "2017-03"
 9393	weak perfectly mixed huge Gnollish sangria	2	EPIC	Last Available: "2017-03"
-9394	hand-crafted practically non-alcoholic vodka barracuda	1	EPIC	Last Available: "2017-03"
+9394	practically non-alcoholic hand-crafted vodka barracuda	1	EPIC	Last Available: "2017-03"
 9395	hand-crafted Mysterious Island iced tea	3	EPIC	Last Available: "2017-03"
-9396	drinkable enchanted drive-by shooting	4	good	Effect: "Squatting and Thrusting", Effect Duration: 30, Last Available: "2017-03"
+9396	enchanted drinkable drive-by shooting	4	good	Effect: "Squatting and Thrusting", Effect Duration: 30, Last Available: "2017-03"
 9397	delicious gunner's daughter	3	awesome	Last Available: "2017-03"
 9398	aged dirt julep	3	awesome	Last Available: "2017-03"
 9399	lousy spinning Simepore slime	3	decent	Last Available: "2017-03"
-9400	artisanal wobbly bouncing Phil Collins	4	EPIC	Last Available: "2017-03"
+9400	artisanal bouncing wobbly Phil Collins	4	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9319,17 +9319,17 @@
 9447	pulsating manspreader's spant spear of chilblains	0		Monster Level: +10, Cold Damage: +25, Last Available: "2017-04"
 9448	shaking murderbot power cell	0		Last Available: "2017-04"
 9449	teal jittery murderbot component casing	0		Last Available: "2017-04"
-9450	red huge murderbot monofilament	0		Last Available: "2017-04"
-9451	extra-pressed vacuum-sealed purple blinking murderbot shield unit	0		Effect: "Here to Kick Ass", Effect Duration: 33, Last Available: "2017-04"
+9450	huge red murderbot monofilament	0		Last Available: "2017-04"
+9451	extra-pressed vacuum-sealed blinking purple murderbot shield unit	0		Effect: "Here to Kick Ass", Effect Duration: 33, Last Available: "2017-04"
 9452	tumbling murderbot live wire	0		Last Available: "2017-04"
 9453	scorching sinister wicked murderbot mask	0		Spell Damage: 15, Hot Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
 9454	quantum flattened skewed murderbot spring injector	0		Effect: "Experimental Effect G-9", Effect Duration: 30, Last Available: "2017-04"
 9455	murderbot whip of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Last Available: "2017-04"
-9456	lion tamer's murderbot plasma rifle of Gandalf	0		Spell Critical Percent: +20, Experience (familiar): +2, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	lion tamer's murderbot plasma rifle of Gandalf	0		Spell Critical Percent: +20, Experience (familiar): +2, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
-9460	tumbling upside-down narrow blue Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
+9460	narrow blue tumbling upside-down Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	yellow Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	upside-down Procrastinator locker key	0		Last Available: "2017-04"
 9463	upside-down Space Baby children's book	0		Last Available: "2017-04"
@@ -9343,15 +9343,15 @@
 9471	upside-down frosty nippy Spacegate diplomat's insignia of Flo-Jo	0		Cold Damage: +10, Cold Spell Damage: +10, Initiative: +100, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	ghostly huge Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	tasty half-sized teal alien sandwich	2	awesome	Last Available: "2017-04"
+9474	half-sized tasty teal alien sandwich	2	awesome	Last Available: "2017-04"
 9475	twirling glitched malware	0		Last Available: "2025-12"
 9476	cold-filtered spinning Spant eggs	0		Effect: "Fangs and Pangs", Effect Duration: 29
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	wet Daily Affirmation: Always be Collecting	0		Effect: "Bubblin' Rage", Effect Duration: 44, Last Available: "2017-05"
 9480	deionized unsweetened wet bouncing Daily Affirmation: Think Win-Lose	0		Effect: "Elron's Explosive Etude", Effect Duration: 50, Last Available: "2017-05"
-9481	super-enhanced wet activated mirror blurry Daily Affirmation: Be Superficially interested	0		Effect: "Pwnd", Effect Duration: 67, Last Available: "2017-05"
-9482	anodized dry shaking ghostly Daily Affirmation: Adapt to Change Eventually	0		Effect: "Perception", Effect Duration: 38, Last Available: "2017-05"
+9481	super-enhanced wet activated blurry mirror Daily Affirmation: Be Superficially interested	0		Effect: "Pwnd", Effect Duration: 67, Last Available: "2017-05"
+9482	anodized dry ghostly shaking Daily Affirmation: Adapt to Change Eventually	0		Effect: "Perception", Effect Duration: 38, Last Available: "2017-05"
 9483	pressed Daily Affirmation: Be a Mind Master	0		Effect: "Yuletide Sappiness", Effect Duration: 67, Last Available: "2017-05"
 9484	moist Daily Affirmation: Work For Hours a Week	0		Effect: "Object Detection", Effect Duration: 40, Last Available: "2017-05"
 9485	frozen chilled ionized tumbling blinking Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Held Closer", Effect Duration: 69, Last Available: "2017-05"
@@ -9362,14 +9362,14 @@
 9490	moist jittery Threatening Missive	0		Effect: "Joyful Resolve", Effect Duration: 24
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	Jeselnik's hale Kremlin's Greatest Briefcase of the brute	0		Muscle Percent: +30, Maximum HP: +20, Sleaze Damage: +25, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	special drinkable high-proof basic martini	7	good	Effect: "Also Schmeckt Zarathustra", Effect Duration: 10, Last Available: "2017-06"
+9493	Jeselnik's hale Kremlin's Greatest Briefcase of the brute	0		Muscle Percent: +30, Maximum HP: +20, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	high-proof drinkable special basic martini	7	good	Effect: "Also Schmeckt Zarathustra", Effect Duration: 10, Last Available: "2017-06"
 9495	hand-crafted improved martini	4	EPIC	Last Available: "2017-06"
 9496	smooth splendid martini	4	awesome	Last Available: "2017-06"
 9497	spinning exploding cigar	0		Last Available: "2017-06"
 9498	squat can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
-9500	lime green jittery gun	0		Free Pull, Last Available: "2017-06"
+9500	jittery lime green gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	asbestos-lined ribald plastic gundam of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +10, Hot Resistance: +5, Last Available: "2017-06"
 9503	License to Chill	0		Last Available: "2017-07"
@@ -9383,7 +9383,7 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	mirror Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	flavorless small meteoreo	2	decent	Last Available: "2017-08"
+9514	small flavorless meteoreo	2	decent	Last Available: "2017-08"
 9515	bad pulsating meadeorite	3	decent	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	double-paned grievous Da Vinci's meteortarboard	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Cold Resistance: +5, Last Available: "2017-08"
@@ -9414,9 +9414,9 @@
 9542	wobbly exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	blurry X	0		Last Available: "2017-10"
 9544	skewed O	0		Last Available: "2017-10"
-9545	practically non-alcoholic tolerable enchanted DUFRESNE Suds	1	good	Effect: "Big Flaming Whip", Effect Duration: 40, Last Available: "2017-09"
+9545	tolerable enchanted practically non-alcoholic DUFRESNE Suds	1	good	Effect: "Big Flaming Whip", Effect Duration: 40, Last Available: "2017-09"
 9546	narrow curative smartaleck's mafia pinky ring	0		Moxie Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Single Equip
-9547	practically non-alcoholic mediocre tumbling flask of port	1	decent	
+9547	mediocre practically non-alcoholic tumbling flask of port	1	decent	
 9548	Lo Pan's contract enforcement stick of the early riser	0		Spell Critical Percent: +30, Adventures: +7
 9549	massive normal blinking Hide-rox&trade; cookie	8	good	Last Available: "2017-10"
 9550	tolerable jug of booze	3	good	Last Available: "2017-10"
@@ -9450,8 +9450,8 @@
 9578	fancy blue transparent nog	1	decent	Effect: "Can't Be a Chooser", Effect Duration: 30, Last Available: "2017-12"
 9579	super-sized yummy unfinished fruitcake	5	awesome	Last Available: "2017-12"
 9580	chilled and cracker	0		Effect: "Halloweeny", Effect Duration: 16, Last Available: "2017-12"
-9581	watered-down mediocre neg grog	2	decent	Last Available: "2017-12"
-9582	stale thick pulsating gray half double fruitcake	5	decent	Last Available: "2017-12"
+9581	mediocre watered-down neg grog	2	decent	Last Available: "2017-12"
+9582	thick stale gray pulsating half double fruitcake	5	decent	Last Available: "2017-12"
 9583	flavorless blinking hushed puppy	4	decent	Last Available: "2017-12"
 9584	snack-sized yummy blinking muffled muffuletta	2	awesome	Last Available: "2017-12"
 9585	bland shushed potatoes	4	decent	Last Available: "2017-12"
@@ -9467,10 +9467,10 @@
 9595	bad high-proof Racisto Ruidoso	8	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	flavorless bran muffin	4	decent	
-9598	huge flavorless blueberry muffin	10	decent	
+9598	flavorless huge blueberry muffin	10	decent	
 9599	silent A	0		Last Available: "2017-12"
-9600	olive huge silent B	0		Last Available: "2017-12"
-9601	spinning mirror fuchsia silent C	0		Last Available: "2017-12"
+9600	huge olive silent B	0		Last Available: "2017-12"
+9601	mirror spinning fuchsia silent C	0		Last Available: "2017-12"
 9602	squat silent D	0		Last Available: "2017-12"
 9603	yellow silent E	0		Last Available: "2017-12"
 9604	blinking silent F	0		Last Available: "2017-12"
@@ -9521,7 +9521,7 @@
 9649	diet tasty nega-mushroom	1	awesome	Last Available: "2017-12"
 9650	tolerable watered-down mirror nega-mushroom wine	2	good	Last Available: "2017-12"
 9651	adjusted unsweetened upside-down Cheer-Up soda	0		Effect: "Castaway Physique", Effect Duration: 66, Last Available: "2017-12"
-9652	miniature delicious skewed mime army rations	2	awesome	Last Available: "2017-12"
+9652	delicious miniature skewed mime army rations	2	awesome	Last Available: "2017-12"
 9653	perfectly mixed upside-down mime army wine	3	super ultra mega EPIC	Last Available: "2017-12"
 9654	powdered mime army superserum	1		Last Available: "2017-12"
 9655	polymerized super-electrified jittery mime army camouflage kit	0		Effect: "Funky Coal Patina", Effect Duration: 32, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	pulsating donated candy	0		
 9665	dry non-dry shaking digital honeypot	0		Effect: "Purity of Spirit", Effect Duration: 48, Last Available: "2025-12"
 9666	narrow mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	jittery Da Vinci's mime army insignia (infantry)	0		Experience (Mysticality): +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	mime army insignia (intelligence) of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	mime army insignia (espionage) of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	jittery Da Vinci's mime army insignia (infantry)	0		Experience (Mysticality): +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	mime army insignia (intelligence) of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	mime army insignia (espionage) of Tarzan	0		Experience (Muscle): +3, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	maroon mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	blue mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	gray kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	skewed fireproof skip lid	0		Familiar Weight: +5
 9681	moldy extra-toasted half sandwich	3	crappy	Last Available: "2018-12"
-9682	fancy practically non-alcoholic bad mulled hobo wine	1	decent	Effect: "Shoesauce", Effect Duration: 50, Last Available: "2018-12"
+9682	fancy bad practically non-alcoholic mulled hobo wine	1	decent	Effect: "Shoesauce", Effect Duration: 50, Last Available: "2018-12"
 9683	maroon burning newspaper	0		Last Available: "2018-12"
 9684	grievous burning paper hat of the brute of Leguizamo	0		Muscle Percent: +30, Weapon Damage Percent: +50, Monster Level: +20, Lasts Until Rollover, Last Available: "2018-12"
 9685	red crafty wholesome thinker's burning cape	0		Mysticality: +10, Maximum HP Percent: +10, Maximum MP: +10, Lasts Until Rollover, Last Available: "2018-12"
@@ -9595,7 +9595,7 @@
 9727	adequate heart-shaped candy whetstone	3	good	Last Available: "2018-02"
 9728	adequate blinking Swedish massage fish	4	good	Last Available: "2018-02"
 9729	weak perfectly mixed narrow Third Base	2	EPIC	Last Available: "2018-02"
-9730	weak artisanal mirror Bustle Hustler	2	EPIC	Last Available: "2018-02"
+9730	artisanal weak mirror Bustle Hustler	2	EPIC	Last Available: "2018-02"
 9731	super-warmed Fabiotion	0		Effect: "Dirty Pear", Effect Duration: 55, Last Available: "2018-02"
 9732	ionized cold-filtered polymerized red Bettie page	0		Effect: "meat.enh", Effect Duration: 49, Last Available: "2018-02"
 9733	pressed oxidized huge tonic o' Banderas	0		Effect: "On the Shoulders of Giants", Effect Duration: 18, Last Available: "2018-02"
@@ -9631,7 +9631,7 @@
 9763	upside-down blinking Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
-9766	shaking teal Pimpsqueak	0		Last Available: "2018-03"
+9766	teal shaking Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	mirror Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
@@ -9649,12 +9649,12 @@
 9781	Snoutlet	0		Last Available: "2018-03"
 9782	Ruffalo	0		Last Available: "2018-03"
 9783	squat Vaporpoise	0		Last Available: "2018-03"
-9784	gray mirror mirror Ghosprey	0		Last Available: "2018-03"
+9784	mirror mirror gray Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
 9786	purple Flan	0		Last Available: "2018-03"
-9787	cyan skewed skewed Mustardigrade	0		Last Available: "2018-03"
+9787	skewed cyan skewed Mustardigrade	0		Last Available: "2018-03"
 9788	Ched	0		Last Available: "2018-03"
-9789	blurry fuchsia Gazelleton	0		Last Available: "2018-03"
+9789	fuchsia blurry Gazelleton	0		Last Available: "2018-03"
 9790	bouncing Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
@@ -9669,7 +9669,7 @@
 9801	Vulgure	0		Last Available: "2018-03"
 9802	mirror Squib	0		Last Available: "2018-03"
 9803	Trafikoan	0		Last Available: "2018-03"
-9804	mirror gray spinning Slotter	0		Last Available: "2018-03"
+9804	gray mirror spinning Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
 9807	narrow Unspeakachu	0		Last Available: "2018-03"
@@ -9700,7 +9700,7 @@
 9832	vaporized pearlescent oyster egg	1		Effect: "Wistfully Nostalgic", Effect Duration: 40
 9833	denatured lustrous oyster egg	1		
 9834	powdered gleaming oyster egg	1		
-9835	lime green huge FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
+9835	huge lime green FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	blinking manspreader's vibrating shellacked FantasyRealm G. E. M.	0		Damage Reduction: 7, Maximum MP Percent: +10, Monster Level: +10, Lasts Until Rollover, Last Available: "2018-04"
 9838	blinking Rubee&trade;	0		Last Available: "2018-04"
@@ -9716,32 +9716,32 @@
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	upside-down LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	narrow squat dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	squat narrow dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	huge faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	wobbly druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	cyan bouncing wobbly flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
-9857	polarized pickled jittery blinking huge universal antivenin	0		Lasts Until Rollover, Effect: "It Didn't Kill You", Effect Duration: 56, Last Available: "2018-04"
+9856	wobbly bouncing cyan flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9857	polarized pickled blinking huge jittery universal antivenin	0		Lasts Until Rollover, Effect: "It Didn't Kill You", Effect Duration: 56, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	ghostly LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
-9861	upside-down mirror LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	toothsome thick FantasyRealm turkey leg	5	awesome	Last Available: "2018-04"
+9861	mirror upside-down LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+9862	thick toothsome FantasyRealm turkey leg	5	awesome	Last Available: "2018-04"
 9863	tolerable lime green FantasyRealm mead	3	good	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
-9865	jittery lime green Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
+9865	lime green jittery Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	normal druidic s'more	3	good	Last Available: "2018-04"
-9870	powdered teal twirling shaking sachet of powder	1		Effect: "Powdered", Effect Duration: 50, Last Available: "2018-04"
-9871	high-proof smooth mourning wine	6	awesome	Last Available: "2018-04"
+9870	powdered shaking teal twirling sachet of powder	1		Effect: "Powdered", Effect Duration: 50, Last Available: "2018-04"
+9871	smooth high-proof mourning wine	6	awesome	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	skewed map to the Mystic Wood	0		Last Available: "2018-04"
 9875	bouncing map to the Putrid Swamp	0		Last Available: "2018-04"
-9876	green twirling map to the Cursed Village	0		Last Available: "2018-04"
+9876	twirling green map to the Cursed Village	0		Last Available: "2018-04"
 9877	green map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	stale immense red denastified haunch	9	decent	Last Available: "2018-04"
 9879	bad bad rum and good cola	4	decent	Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	skewed notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	acceptable practically non-alcoholic two meat muck	1	good	
-9899	bland half-sized chocolate Ogre Chieftain	2	decent	
+9899	half-sized bland chocolate Ogre Chieftain	2	decent	
 9900	miniature decent gray chocolate &quot;Phoenix&quot;	2	good	
 9901	moldy chocolate Spider Queen	4	crappy	
 9902	hand-crafted upside-down hipster cocktail	3	EPIC	
-9903	twirling God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	pulsating God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	narrow wobbly God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	jittery God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	twirling God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Last Available: "2018-05", Equips On: "God Lobster"
+9904	pulsating God Lobster's Ring	0		Familiar Effect: "sombrero", Last Available: "2018-05", Equips On: "God Lobster"
+9905	narrow wobbly God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Last Available: "2018-05", Equips On: "God Lobster"
+9907	jittery God Lobster's Crown	0		Familiar Effect: "fairy", Last Available: "2018-05", Equips On: "God Lobster"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	huge G	0		
 9910	Garland of Greatness	0		
@@ -9781,7 +9781,7 @@
 9913	wobbly glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	miniature decent good guava	2	good	
-9916	boozy lousy narrow gin and ginger	5	decent	
+9916	lousy boozy narrow gin and ginger	5	decent	
 9917	blurry Thwaitgold chigger statuette	0		
 9918	compressed spinning gaseous gravy	1		Effect: "Memories of Puppy Love", Effect Duration: 15
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9789,7 +9789,7 @@
 9921	A Guide to Safari	0		Skill: "Experience Safari"
 9922	dry Shielding Potion	0		Effect: "Ooh, Sweet!", Effect Duration: 61, Last Available: "2018-06"
 9923	tarnished jittery Punching Potion	0		Effect: "Bone Homie", Effect Duration: 55, Last Available: "2018-06"
-9924	blue narrow Special Seasoning	0		Last Available: "2018-06"
+9924	narrow blue Special Seasoning	0		Last Available: "2018-06"
 9925	compressed Nightmare Fuel	1		Effect: "Wings of the Grasshopper", Effect Duration: 20, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
@@ -9813,7 +9813,7 @@
 9945	huge Neverending Party favor	0		Last Available: "2018-09"
 9946	skewed deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	artisanal special Middle of the Road&trade; brand whiskey	3	EPIC	Effect: "Dancing Prowess", Effect Duration: 45, Last Available: "2018-09"
+9948	special artisanal Middle of the Road&trade; brand whiskey	3	EPIC	Effect: "Dancing Prowess", Effect Duration: 45, Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	manspreader's stiffened pentagram bandana	0		Damage Reduction: 1, Monster Level: +10, Last Available: "2018-09"
 9951	skull ring of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2018-09"
@@ -9821,7 +9821,7 @@
 9953	adequate PB&J with the crusts cut off	3	good	Last Available: "2018-09"
 9954	friendly groovy dorky glasses	0		Moxie Percent: +10, Familiar Weight: +3, Single Equip, Last Available: "2018-09"
 9955	wobbly Jim Carey's Van der Graaf ponytail clip	0		Monster Level: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-09"
-9956	green hardy paint palette	0		Maximum HP: +50, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	green hardy paint palette	0		Maximum HP: +50, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	skewed unremarkable duffel bag	0		Last Available: "2018-09"
 9958	modified blurry Purple Beast energy drink	1		Effect: "OMG WTF", Effect Duration: 10, Last Available: "2018-09"
 9959	cosmetic football of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-09"
@@ -9839,19 +9839,19 @@
 9972	blinking energetic strapping intimidating chainsaw	0		Muscle: +5, Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2018-09"
 9973	special acceptable party beer bomb	4	good	Effect: "Reedy Pipes", Effect Duration: 45, Last Available: "2018-09"
 9974	massive rotten sweet party mix	10	crappy	Last Available: "2018-09"
-9975	boiled tumbling blurry party balloon	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 20, Last Available: "2018-09"
+9975	boiled blurry tumbling party balloon	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 20, Last Available: "2018-09"
 9976	sinister smartaleck's party pants	0		Moxie Percent: +30, Spell Damage: +10, Last Available: "2018-09"
 9977	occult party whip of the scaredy-cat of temperance	0		Spell Damage Percent: +25, Monster Level: -15, Sleaze Resistance: +5, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	enchanted distilled acceptable olive TRIO cup of beer	5	good	Effect: "Brother Corsican's Blessing", Effect Duration: 40, Last Available: "2018-09"
-9980	tasty special bite-sized maroon party platter for one	1	awesome	Effect: "New Zeal", Effect Duration: 35, Last Available: "2018-09"
+9979	acceptable enchanted distilled olive TRIO cup of beer	5	good	Effect: "Brother Corsican's Blessing", Effect Duration: 40, Last Available: "2018-09"
+9980	bite-sized tasty special maroon party platter for one	1	awesome	Effect: "New Zeal", Effect Duration: 35, Last Available: "2018-09"
 9981	diluted Party-in-a-Can&trade;	1		Effect: "Celestial Vision", Effect Duration: 30, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	clever brainy party crasher	0		Mysticality: +5, Maximum MP: +20, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	cyan Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	clever brainy party crasher	0		Mysticality: +5, Maximum MP: +20, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	cyan Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	pulsating party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	manspreader's &quot;I Voted!&quot; sticker	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2018-11"
@@ -9873,20 +9873,20 @@
 10007	squat huge cyan groovy mutant arm of the brazier of bravery	0		Moxie Percent: +10, Hot Spell Damage: +25, Spooky Resistance: +5, Last Available: "2018-11"
 10008	upside-down vibrating hale mutant legs of James Dean	0		Experience (Moxie): +3, Maximum HP: +20, Maximum MP Percent: +10, Last Available: "2018-11"
 10009	Herculean strapping mutant crown of the boozehound	0		Muscle: +5, Experience (Muscle): +1, Booze Drop: +100, Last Available: "2018-11"
-10010	yummy immense ghostly ectoplasm	7	awesome	Last Available: "2018-11"
-10011	immense normal	9	good	Last Available: "2018-11"
+10010	immense yummy ghostly ectoplasm	7	awesome	Last Available: "2018-11"
+10011	normal immense	9	good	Last Available: "2018-11"
 10012	triple-distilled hand-crafted bottle of vodka	9	EPIC	Last Available: "2018-11"
 10013	normal pizza	3	good	Last Available: "2018-11"
-10014	smooth practically non-alcoholic blurry martini	1	awesome	Last Available: "2018-11"
+10014	practically non-alcoholic smooth blurry martini	1	awesome	Last Available: "2018-11"
 10015	spoiled cherry pie	3	crappy	Last Available: "2018-11"
 10016	perfectly mixed eggnog	3	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	tasty Hell ramen	3	awesome	Last Available: "2018-11"
 10019	tolerable watered-down gimlet	2	good	Last Available: "2018-11"
-10020	weak aged upside-down twirling twice-haunted screwdriver	2	awesome	Last Available: "2018-11"
-10021	miniature normal candy cane	2	good	Last Available: "2018-12"
+10020	weak aged twirling upside-down twice-haunted screwdriver	2	awesome	Last Available: "2018-11"
+10021	normal miniature candy cane	2	good	Last Available: "2018-12"
 10022	tolerable runny fermented egg	4	good	Last Available: "2018-12"
-10023	low-calorie rotten olive oldcake	1	crappy	Last Available: "2018-12"
+10023	rotten low-calorie olive oldcake	1	crappy	Last Available: "2018-12"
 10024	rotten ghostly traditional Crimbo cookie	3	crappy	Last Available: "2023-06"
 10025	chaotic plastic wild beaver	0		Spell Critical Percent: +10, Last Available: "2018-12"
 10026	mirror savvy plastic reindeer	0		Mysticality Percent: +20, Last Available: "2018-12"
@@ -9900,22 +9900,22 @@
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	shellacked banded quilted Staff of Frozen Lard of the detective	0		Damage Absorption: 140, Damage Reduction: 7, Item Drop: +20, Last Available: "2018-12"
 10036	bomb	0		Last Available: "2018-12"
-10037	squat olive plastic bazooka	0		Last Available: "2018-12"
+10037	olive squat plastic bazooka	0		Last Available: "2018-12"
 10038	twirling mooseflank	0		Last Available: "2018-12"
 10039	moldy grilled mooseflank	4	crappy	Last Available: "2018-12"
-10040	stale red narrow moosemeat pie	3	decent	Last Available: "2018-12"
+10040	stale narrow red moosemeat pie	3	decent	Last Available: "2018-12"
 10041	balanced antler of Flo-Jo	0		Initiative: +100, Last Available: "2018-12"
 10042	Da Vinci's dam	0		Experience (Mysticality): +5, Damage Reduction: 9, Last Available: "2018-12"
-10043	enchanted drinkable tumbling beavermouth	3	good	Effect: "Dreadful Chill", Effect Duration: 15, Last Available: "2018-12"
+10043	drinkable enchanted tumbling beavermouth	3	good	Effect: "Dreadful Chill", Effect Duration: 15, Last Available: "2018-12"
 10044	lousy blurry beaver punch (papaya)	3	decent	Last Available: "2018-12"
 10045	artisanal beaver punch (peach)	3	EPIC	Last Available: "2018-12"
-10046	smooth practically non-alcoholic lime green beaver punch (cherry)	1	awesome	Last Available: "2018-12"
+10046	practically non-alcoholic smooth lime green beaver punch (cherry)	1	awesome	Last Available: "2018-12"
 10047	pulsating huge Annie Oakley's electrified Canadian lantern	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-12"
 10048	twirling sinister muskox-skin cap	0		Spell Damage: +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	immense stale glass of raw eggs	9	decent	Last Available: "2018-12"
 10051	artisanal punch-drunk punch	3	EPIC	Last Available: "2018-12"
-10052	vaporized tumbling upside-down body spradium	1		Last Available: "2018-12"
+10052	vaporized upside-down tumbling body spradium	1		Last Available: "2018-12"
 10053	blinking frightening bauxite beret	0		Spooky Damage: +5, Last Available: "2018-12"
 10054	bauxite boxers of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-12"
 10055	flame-wreathed bauxite bow-tie	0		Hot Spell Damage: +10, Single Equip, Last Available: "2018-12"
@@ -9923,16 +9923,16 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	zippy knitted nasty supercharged boxer's Kramco Sausage-o-Matic&trade;	0		Muscle Percent: +10, Maximum MP Percent: +30, Stench Damage: +5, Cold Resistance: +3, Initiative: +20, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	low-calorie bland twirling sausage	1	decent	Last Available: "2019-01"
+10060	bland low-calorie twirling sausage	1	decent	Last Available: "2019-01"
 10061	supercool red-hot sausage fork of horror	0		Moxie Percent: +20, Spooky Spell Damage: +25, Last Available: "2019-01"
 10062	wobbly bag of sausage links	0		Last Available: "2019-01"
 10063	olive sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	pulsating Toyleporter	0		Last Available: "2018-12"
 10066	hand-crafted spirit-forward beer	5	EPIC	Last Available: "2018-12"
-10067	bland huge yule gruel	7	decent	Last Available: "2018-12"
-10068	perfectly mixed fancy watered-down hot watered rum	2	EPIC	Effect: "Jittery", Effect Duration: 30, Last Available: "2018-12"
-10069	watered-down artisanal bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
+10067	huge bland yule gruel	7	decent	Last Available: "2018-12"
+10068	watered-down perfectly mixed fancy hot watered rum	2	EPIC	Effect: "Jittery", Effect Duration: 30, Last Available: "2018-12"
+10069	artisanal watered-down bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
 10070	small normal Crimboysters Rockefeller	2	good	Last Available: "2018-12"
 10071	altered ghostly Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	Jack Frost's hardy marble mariachi hat	0		Maximum HP: +50, Cold Spell Damage: +50, Last Available: "2019-12"
 10096	twisted marble molecules	1		Effect: "Coal-Powered", Effect Duration: 15, Last Available: "2019-12"
 10097	triple-energized wobbly Mallomarbles	0		Effect: "Cold Blooded", Effect Duration: 49
-10098	chaotic slick punching bag	0		Moxie: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	Sherlock's Oprah's pith helmet	0		Maximum MP Percent: +50, Item Drop: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	Oprah's personal trainer's poncho	0		Experience Percent (Muscle): +10, Maximum MP Percent: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	teal arcane researcher's pendant of the early riser	0		Experience Percent (Mysticality): +10, Adventures: +7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	hardy beefcake's palazzos	0		Muscle: +25, Maximum HP: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	mirror blue Sherlock's Newton's pseudoaccordion	0		Experience (Mysticality): +3, Item Drop: +25, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	chaotic slick punching bag	0		Moxie: +10, Spell Critical Percent: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	Sherlock's Oprah's pith helmet	0		Maximum MP Percent: +50, Item Drop: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	Oprah's personal trainer's poncho	0		Experience Percent (Muscle): +10, Maximum MP Percent: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	teal arcane researcher's pendant of the early riser	0		Experience Percent (Mysticality): +10, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	hardy beefcake's palazzos	0		Muscle: +25, Maximum HP: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	mirror blue Sherlock's Newton's pseudoaccordion	0		Experience (Mysticality): +3, Item Drop: +25, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	altered fuchsia huge pieces	1		Effect: "Strange Mental Acuity", Effect Duration: 45, Last Available: "2020-12"
 10105	altered spinning Para-Pop	0		Effect: "Big", Effect Duration: 13
-10106	gray thinker's terra cotta truss of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	twirling beefcake's terra cotta trousers of Flo-Jo	0		Muscle: +25, Initiative: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	miser's flame-retardant terra cotta tongs	0		Hot Resistance: +1, Meat Drop: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	electrified veiny terra cotta train	0		Maximum HP: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	twirling Sherlock's terra cotta tie tack of the overflowing toilet	0		Stench Spell Damage: +50, Item Drop: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	grievous terra cotta tambourine of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	gray thinker's terra cotta truss of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	twirling beefcake's terra cotta trousers of Flo-Jo	0		Muscle: +25, Initiative: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	miser's flame-retardant terra cotta tongs	0		Hot Resistance: +1, Meat Drop: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	electrified veiny terra cotta train	0		Maximum HP: +10, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	twirling Sherlock's terra cotta tie tack of the overflowing toilet	0		Stench Spell Damage: +50, Item Drop: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	grievous terra cotta tambourine of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	twisted terra cotta tidbits	1		Last Available: "2020-12"
 10113	cold-filtered terra panna cotta	0		Effect: "Mortarfied", Effect Duration: 23
 10114	velour voulge of James Dean of the storm	0		Experience (Moxie): +3, Maximum MP Percent: +40, Last Available: "2021-12"
@@ -9984,29 +9984,29 @@
 10118	cyan velour valise of the blizzard of mayonnaise	0		Cold Spell Damage: +25, Sleaze Spell Damage: +50, Last Available: "2021-12"
 10119	steel-toed stylish velour vaqueros	0		Moxie: +25, Damage Reduction: 9, Last Available: "2021-12"
 10120	dried velour veneer	1		Effect: "Abominably Slippery", Effect Duration: 45, Last Available: "2021-12"
-10121	nitrogenated spinning blurry Velougats&trade;	0		Effect: "How to Scam Tourists", Effect Duration: 11
+10121	nitrogenated blurry spinning Velougats&trade;	0		Effect: "How to Scam Tourists", Effect Duration: 11
 10122	greedy glass suspenders of terror	0		Spooky Spell Damage: +10, Meat Drop: +20, Single Equip, Last Available: "2021-12"
 10123	up-at-dawn glass shield of James Dean	0		Experience (Moxie): +3, Adventures: +5, Damage Reduction: 7, Last Available: "2021-12"
 10124	auspicious glass stetson of extreme caution	0		Monster Level: -25, Item Drop: +10, Last Available: "2021-12"
 10125	miser's hardened glass spectacles	0		Damage Reduction: 3, Meat Drop: +10, Single Equip, Last Available: "2021-12"
 10126	avaricious knitted glass shiv	0		Cold Resistance: +3, Meat Drop: +30, Last Available: "2021-12"
 10127	jittery narrow stanky glass serape of terror	0		Stench Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2021-12"
-10128	pickled squat tumbling glass shards	1		Effect: "The Halls of Mysticality", Effect Duration: 20, Last Available: "2021-12"
+10128	pickled tumbling squat glass shards	1		Effect: "The Halls of Mysticality", Effect Duration: 20, Last Available: "2021-12"
 10129	boiled hard candy	0		Effect: "Stuck That Way", Effect Duration: 58
-10130	frightening Rosewater's loofah lumberjack's hat	0		Mysticality Percent: +30, Spooky Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	avaricious stanky loofah lei	0		Stench Spell Damage: +25, Meat Drop: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	Newton's Herculean loofah lederhosen	0		Experience (Muscle): +1, Experience (Mysticality): +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	prompt hale loofah ladle	0		Maximum HP: +20, Adventures: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	green gravedigger's razor-sharp loofah legwarmers	0		Weapon Damage Percent: +25, Spooky Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	narrow censurious loofah lavalier of the early riser	0		Sleaze Resistance: +3, Adventures: +7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	frightening Rosewater's loofah lumberjack's hat	0		Mysticality Percent: +30, Spooky Damage: +5, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	avaricious stanky loofah lei	0		Stench Spell Damage: +25, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	Newton's Herculean loofah lederhosen	0		Experience (Muscle): +1, Experience (Mysticality): +3, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	prompt hale loofah ladle	0		Maximum HP: +20, Adventures: +3, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	green gravedigger's razor-sharp loofah legwarmers	0		Weapon Damage Percent: +25, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	narrow censurious loofah lavalier of the early riser	0		Sleaze Resistance: +3, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	denatured teal jittery loofah lumps	1		Last Available: "2022-12"
 10137	frozen pressed chocolate-covered loofah	0		Effect: "Swimming Head", Effect Duration: 61
-10138	ruddy forbidden flagstone flag	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	upside-down hardened Fonzie's flagstone flail	0		Experience (Moxie): +1, Damage Reduction: 3, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	executive flagstone flip-flops of Tarzan	0		Experience (Muscle): +3, Meat Drop: +40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	pulsating executive aromatic flagstone fez	0		Stench Resistance: +1, Meat Drop: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	flame-retardant shellacked flagstone fleece	0		Damage Reduction: 7, Hot Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	clever flagstone fringe of the early riser	0		Maximum MP: +20, Adventures: +7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	ruddy forbidden flagstone flag	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	upside-down hardened Fonzie's flagstone flail	0		Experience (Moxie): +1, Damage Reduction: 3, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	executive flagstone flip-flops of Tarzan	0		Experience (Muscle): +3, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	pulsating executive aromatic flagstone fez	0		Stench Resistance: +1, Meat Drop: +40, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	flame-retardant shellacked flagstone fleece	0		Damage Reduction: 7, Hot Resistance: +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	clever flagstone fringe of the early riser	0		Maximum MP: +20, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	dehydrated blurry flagstone flagments	1		Last Available: "2022-12"
 10145	wet Flag by the Foot&trade;	0		Effect: "Nightlit", Effect Duration: 53
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10029,12 +10029,12 @@
 10163	alkaline government-issued candy	0		Effect: "Chalky White Pallor", Effect Duration: 64
 10164	tarnished electrified altered teal Pneumo bar	0		Effect: "Triangle, Man", Effect Duration: 49
 10165	bouncing mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	groovy Lil' Doctor&trade; bag of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	groovy Lil' Doctor&trade; bag of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	ghostly blood bag	0		
-10169	half-sized flavorless enchanted bloodstick	2	decent	Effect: "Crimbo Nostalgia", Effect Duration: 20
+10169	enchanted half-sized flavorless bloodstick	2	decent	Effect: "Crimbo Nostalgia", Effect Duration: 20
 10170	aged watered-down bottle of Sanguiovese	2	awesome	
 10171	delicious actual blood sausage	4	awesome	
-10172	high-proof aged mulled blood	10	awesome	
+10172	aged high-proof mulled blood	10	awesome	
 10173	rotten half-sized blood snowcone	2	crappy	
 10174	perfectly mixed watered-down teal Red Russian	2	super ultra EPIC	
 10175	diet adequate blood roll-up	1	good	
@@ -10063,7 +10063,7 @@
 10198	wobbly Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	spoiled special crabsicle	3	crappy	Effect: "Fudge Headache", Effect Duration: 25, Last Available: "2019-04"
 10200	squat melty plastic grenade	0		Last Available: "2019-04"
-10201	perfectly mixed boozy twirling bottle of dark rhum	5	EPIC	Last Available: "2019-04"
+10201	boozy perfectly mixed twirling bottle of dark rhum	5	EPIC	Last Available: "2019-04"
 10202	mediocre bottle of extra-dark rhum	4	decent	Last Available: "2019-04"
 10203	perfectly mixed mirror bottle of super-extra-dark rhum	4	EPIC	Last Available: "2019-04"
 10204	ionized Vulcanized wobbly pirate shaving cream	0		Effect: "Moon-Eyed", Effect Duration: 57, Last Available: "2019-04"
@@ -10075,7 +10075,7 @@
 10210	family-friendly brawny pirate radio ring	0		Muscle Percent: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	bite-sized rotten pineapple slab	1	crappy	Last Available: "2019-04"
-10213	miniature rotten upside-down hibiscus petal	2	crappy	Last Available: "2019-04"
+10213	rotten miniature upside-down hibiscus petal	2	crappy	Last Available: "2019-04"
 10214	pickled shaking huge mint leaf	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 41, Last Available: "2019-04"
 10215	squat cocoa of youth	0		Last Available: "2019-04"
 10216	dehydrated ice molecule	1		Effect: "Ruby-ous", Effect Duration: 10, Last Available: "2019-04"
@@ -10096,31 +10096,31 @@
 10231	narrow zippy Lo Pan's boxer's PirateRealm party hat	0		Muscle Percent: +10, Spell Critical Percent: +30, Initiative: +20, Last Available: "2019-04"
 10232	bad high-proof purple Island Landslide	9	decent	Last Available: "2019-04"
 10233	acceptable Island Thunderstorm	3	good	Last Available: "2019-04"
-10234	artisanal weak shaking Island Hurricane	2	super EPIC	Last Available: "2019-04"
+10234	weak artisanal shaking Island Hurricane	2	super EPIC	Last Available: "2019-04"
 10235	tolerable Skull Punch	4	good	Last Available: "2019-04"
 10236	artisanal spinning Electric Punch	3	EPIC	Last Available: "2019-04"
-10237	triple-distilled hand-crafted blinking Smuggler's Punch	10	EPIC	Last Available: "2019-04"
+10237	hand-crafted triple-distilled blinking Smuggler's Punch	10	EPIC	Last Available: "2019-04"
 10238	perfectly mixed Scorpion Bowl	3	super EPIC	Last Available: "2019-04"
-10239	artisanal weak Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10239	weak artisanal Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10240	bad blinking Cobra Bowl	3	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	executive smelly sharpshooter's groovy vampyric cloake of the overflowing toilet	0		Moxie Percent: +10, Critical Hit Percent: +10, Stench Spell Damage: 60, Meat Drop: +40, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	executive smelly sharpshooter's groovy vampyric cloake of the overflowing toilet	0		Moxie Percent: +10, Critical Hit Percent: +10, Stench Spell Damage: 60, Meat Drop: +40, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	pulsating plastic pirate hat	0		Familiar Weight: +5
-10244	polymerized ghostly bouncing one piece of bubble gum	0		Effect: "Quiet 'n' Good", Effect Duration: 53
+10244	polymerized bouncing ghostly one piece of bubble gum	0		Effect: "Quiet 'n' Good", Effect Duration: 53
 10245	arcanoferric housing	0		
 10246	lime green intact medium-wave antenna	0		
 10247	ghostly 18-picohertz resonator crystal	0		
 10248	squat blown-out speaker cone	0		
 10249	bouncing overloaded short-pulse transistor	0		
 10250	wobbly Fourth of May Cosplay Saber kit	0		Free Pull
-10251	huge Usain Bolt's inspector's beefcake's Fourth of May Cosplay Saber	0		Muscle: +25, Item Drop: +15, Initiative: +80, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	huge Usain Bolt's inspector's beefcake's Fourth of May Cosplay Saber	0		Muscle: +25, Item Drop: +15, Initiative: +80, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	jittery inspector's asbestos-lined foul-smelling chilly veiny shellacked wizardly hewn moon-rune spoon of the empath of courage of bravery of Flo-Jo	0		Mysticality: +25, Damage Reduction: 7, Maximum HP: +10, Familiar Weight: +5, Cold Damage: +5, Stench Damage: +10, Hot Resistance: +5, Spooky Resistance: 8, Item Drop: +15, Initiative: +100, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	jittery inspector's asbestos-lined foul-smelling chilly veiny shellacked wizardly hewn moon-rune spoon of the empath of courage of bravery of Flo-Jo	0		Mysticality: +25, Damage Reduction: 7, Maximum HP: +10, Familiar Weight: +5, Cold Damage: +5, Stench Damage: +10, Hot Resistance: +5, Spooky Resistance: 8, Item Drop: +15, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	ghostly cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	perfumed medical-grade Beach Comb of the glutton	0		Stench Resistance: +5, Food Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	perfumed medical-grade Beach Comb of the glutton	0		Stench Resistance: +5, Food Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	lime green grain of sand	0		Last Available: "2019-07"
 10260	olive small pile of sand	0		Last Available: "2019-07"
 10261	upside-down teal shaking pile of sand	0		Last Available: "2019-07"
@@ -10143,7 +10143,7 @@
 10278	greasy energetic personal trainer's spearfish fishing spear	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Sleaze Spell Damage: +10, Last Available: "2019-07"
 10279	teal flame-retardant hale grievous rabbitfish fin	0		Weapon Damage Percent: +50, Maximum HP: +20, Hot Resistance: +1, Single Equip, Last Available: "2019-07"
 10280	piece of coral	0		Last Available: "2019-07"
-10281	squat blurry piece of driftwood	0		Last Available: "2019-07"
+10281	blurry squat piece of driftwood	0		Last Available: "2019-07"
 10282	pirate cutlass of James Dean of the detective of the businessman	0		Experience (Moxie): +3, Item Drop: +20, Meat Drop: +50, Single Equip, Last Available: "2019-07"
 10283	tricorn hat of the cougar of horror of courage	0		Moxie: +20, Spooky Spell Damage: +25, Spooky Resistance: +3, Last Available: "2019-07"
 10284	quilted Samson's brawny swash buckle	0		Muscle Percent: +20, Experience (Muscle): +5, Damage Absorption: +40, Single Equip, Last Available: "2019-07"
@@ -10166,7 +10166,7 @@
 10301	spinning curative weightlifter's whittled fox figurine of Calamity Jane	0		Muscle: +15, Critical Hit Percent: +15, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2019-08"
 10302	chilly thinker's whittled walking stick of wisdom of terror	0		Mysticality: 25, Cold Damage: +5, Spooky Spell Damage: +10, Last Available: "2019-08"
 10303	delicious jumbo campfire hot dog	5	awesome	Last Available: "2019-08"
-10304	massive yummy campfire baked potato	10	awesome	Last Available: "2019-08"
+10304	yummy massive campfire baked potato	10	awesome	Last Available: "2019-08"
 10305	spoiled yellow campfire s'more	3	crappy	Last Available: "2019-08"
 10306	moldy campfire beans	3	crappy	Last Available: "2019-08"
 10307	bland campfire stew	4	decent	Last Available: "2019-08"
@@ -10203,8 +10203,8 @@
 10344	plastic Dolph Bossin of the brazier	0		Hot Spell Damage: +25, Last Available: "2019-12"
 10345	olive red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	flavorless mana-coated yams	4	decent	Last Available: "2019-11"
-10347	enchanted yummy jumbo mana-basted tofurkey leg	5	awesome	Effect: "Egg-stra Arm", Effect Duration: 20, Last Available: "2019-11"
-10348	moldy super-sized mana-fortified cranberry sauce	5	crappy	Last Available: "2019-11"
+10347	yummy enchanted jumbo mana-basted tofurkey leg	5	awesome	Effect: "Egg-stra Arm", Effect Duration: 20, Last Available: "2019-11"
+10348	super-sized moldy mana-fortified cranberry sauce	5	crappy	Last Available: "2019-11"
 10349	delicious gray mana-stuffed herbal stuffing	3	awesome	Last Available: "2019-11"
 10350	twirling human musk	0		Last Available: "2019-12"
 10351	galvanized shaking patch of extra-warm fur	0		Effect: "Inebriate Pride", Effect Duration: 60, Last Available: "2019-12"
@@ -10213,17 +10213,17 @@
 10354	twisted twirling vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dried shaking a bug's lymph	1		Effect: "Meadulla Oblongota", Effect Duration: 20, Last Available: "2019-12"
 10356	flattened pickled organic potpourri	0		Effect: "Bark of the Dog", Effect Duration: 53, Last Available: "2019-12"
-10357	practically non-alcoholic tolerable boot flask	1	good	Last Available: "2019-12"
+10357	tolerable practically non-alcoholic boot flask	1	good	Last Available: "2019-12"
 10358	unsweetened blinking infernal snowball	0		Effect: "Well-Lubed", Effect Duration: 58, Last Available: "2019-12"
 10359	shaking madness	0		Last Available: "2019-12"
 10360	modified fish sauce	1		Effect: "Sharpened Sweet Tooth", Effect Duration: 25, Last Available: "2019-12"
-10361	massive yummy guffin	6	awesome	Last Available: "2019-12"
+10361	yummy massive guffin	6	awesome	Last Available: "2019-12"
 10362	mixed Shantix&trade;	1		Effect: "Blessing of Squirtlcthulli", Effect Duration: 50, Last Available: "2019-12"
 10363	fuchsia goodberry	0		Last Available: "2019-12"
 10364	modified mirror narrow non-Euclidean angle	1		Last Available: "2019-12"
 10365	pickled wet peppermint syrup	0		Effect: "Abyssal Tears", Effect Duration: 51, Last Available: "2019-12"
 10366	enhanced Mer-kin eyedrops	0		Effect: "Browbeaten", Effect Duration: 22, Last Available: "2019-12"
-10367	super-oxidized upside-down pulsating extra-strength goo	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2019-12"
+10367	super-oxidized pulsating upside-down extra-strength goo	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	dehydrated livid energy	1		Effect: "Taurus Rising", Effect Duration: 25, Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
@@ -10259,7 +10259,7 @@
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	huge waterlogged stuffing	0		Last Available: "2019-12"
-10403	blurry olive mirror waterlogged	0		Last Available: "2019-12"
+10403	olive blurry mirror waterlogged	0		Last Available: "2019-12"
 10404	squat waterlogged	0		Last Available: "2019-12"
 10405	teal Newton's nutcracker hat of James Dean	0		Experience (Mysticality): +3, Experience (Moxie): +3, Last Available: "2019-12"
 10406	therapeutic shellacked nutcracker waistcoat	0		Damage Reduction: 7, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	chilly nutcracker cape of the cougar	0		Moxie: +20, Cold Damage: +5, Last Available: "2019-12"
 10413	family-friendly nutcracker epaulets of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +1, Single Equip, Last Available: "2019-12"
 10414	skewed nutcracker figurine	0		Last Available: "2019-12"
-10415	low-calorie rotten salt plum	1	crappy	Last Available: "2019-12"
+10415	rotten low-calorie salt plum	1	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	diet delicious wobbly cyan and bean	1	awesome	Last Available: "2019-12"
 10418	Socratic weightlifter's kelp-holly gun of extreme caution	0		Muscle: +15, Experience (Mysticality): +1, Monster Level: -25, Last Available: "2019-12"
@@ -10288,21 +10288,21 @@
 10429	adjusted handful of mixed nuts	0		Effect: "Improprie Tea", Effect Duration: 47, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	purple rosy-cheeked forbidden Retrospecs of the cheetah	0		Spell Damage Percent: +50, Maximum HP Percent: +30, Initiative: +60, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	purple rosy-cheeked forbidden Retrospecs of the cheetah	0		Spell Damage Percent: +50, Maximum HP Percent: +30, Initiative: +60, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	shaking Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	green mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	bouncing flame-wreathed hardy ruddy occult Sinatra's Powerful Glove	0		Experience (Moxie): +5, Spell Damage Percent: +25, Maximum HP Percent: +40, Maximum HP: +50, Hot Spell Damage: +10, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
-10439	fuchsia skewed enhanced signal receiver	0		
+10438	bouncing flame-wreathed hardy ruddy occult Sinatra's Powerful Glove	0		Experience (Moxie): +5, Spell Damage Percent: +25, Maximum HP Percent: +40, Maximum HP: +50, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10439	skewed fuchsia enhanced signal receiver	0		
 10440	fuchsia status cymbal	0		Last Available: "2020-02"
 10441	huge Jack Frost's Drip harness of incineration of temperance	0		Cold Spell Damage: +50, Hot Spell Damage: +50, Sleaze Resistance: +5
 10442	upside-down arcane researcher's drippy truncheon	0		Experience Percent (Mysticality): +10, Single Equip
 10443	shaking Driplet	0		
 10444	shaking drippy snail shell	0		
 10445	stale drippy nugget	3	drippy	
-10446	practically non-alcoholic smooth blue glass of drippy wine	1	drippy	
+10446	smooth practically non-alcoholic blue glass of drippy wine	1	drippy	
 10447	small spoiled blurry drippy caviar	2	drippy	
-10448	immense special stale jittery drippy plum(?)	6	drippy	Effect: "Cold Jellied", Effect Duration: 20
+10448	special immense stale jittery drippy plum(?)	6	drippy	Effect: "Cold Jellied", Effect Duration: 20
 10449	vibrating drippy stake	0		Maximum MP Percent: +10, Single Equip
 10450	blurry narrow The Eye of the Thing in the Basement	0		
 10451	shaking drippy khakis	0		
@@ -10343,7 +10343,7 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	fancy flavorless small mushroom filet	2	decent	Effect: "Over-Familiar With Dactyls", Effect Duration: 50, Last Available: "2020-03"
+10489	flavorless fancy small mushroom filet	2	decent	Effect: "Over-Familiar With Dactyls", Effect Duration: 50, Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	dehydrated bouncing bouncing mushroom tea	1		Last Available: "2020-03"
 10492	practically non-alcoholic lousy blue mushroom whiskey	1	decent	Last Available: "2020-03"
@@ -10351,7 +10351,7 @@
 10494	family-friendly steel-toed mushroom shield of horror of the detective	0		Damage Reduction: 15, Spooky Spell Damage: +25, Sleaze Resistance: +1, Item Drop: +20, Last Available: "2020-03"
 10495	Oprah's vibrating wicked mushroom pants of vim and vigor	0		Spell Damage: +5, Maximum HP Percent: +50, Maximum MP Percent: 60, Last Available: "2020-03"
 10496	lard-coated frightening clever veiny mushroom badge	0		Maximum HP: +10, Maximum MP: +20, Spooky Damage: +5, Sleaze Spell Damage: +25, Single Equip, Last Available: "2020-03"
-10497	wobbly shaking house-sized mushroom	0		Last Available: "2020-03"
+10497	shaking wobbly house-sized mushroom	0		Last Available: "2020-03"
 10498	pulsating pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	corrupted activated extra-diffused mirror piranha pollen	0		Effect: "Quantum of Moxie", Effect Duration: 26, Last Available: "2020-03"
@@ -10368,14 +10368,14 @@
 10511	toasty pizza box	0		Hot Damage: +5, Damage Reduction: 6, Last Available: "2020-04"
 10512	zippy family-friendly chipped coffee mug	0		Sleaze Resistance: +1, Initiative: +20, Last Available: "2020-04"
 10513	Left-Hand Man action figure of the sewer	0		Stench Damage: +25, Last Available: "2020-04"
-10514	green tumbling drippy seed	0		
+10514	tumbling green drippy seed	0		
 10515	drippy grub	0		
 10516	drippy bezoar	0		
 10517	maroon Drip Institute petri dish	0		
 10518	wobbly drippy ichor	0		
 10519	drippy enzyme	0		
 10520	purple jittery drippy salt	0		
-10521	wobbly maroon drippy pigment	0		
+10521	maroon wobbly drippy pigment	0		
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
@@ -10394,10 +10394,10 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	double-paned Guzzlr souvenir stein	0		Cold Resistance: +5, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	drinkable triple-distilled Ghiaccio Colada	7	good	Last Available: "2020-05"
-10542	mediocre special narrow olive Sourfinger	4	decent	Effect: "Super Accuracy", Effect Duration: 35, Last Available: "2020-05"
+10541	triple-distilled drinkable Ghiaccio Colada	7	good	Last Available: "2020-05"
+10542	special mediocre narrow olive Sourfinger	4	decent	Effect: "Super Accuracy", Effect Duration: 35, Last Available: "2020-05"
 10543	tolerable gray Nog-on-the-Cob	3	good	Last Available: "2020-05"
-10544	weak bad Steamboat	2	decent	Last Available: "2020-05"
+10544	bad weak Steamboat	2	decent	Last Available: "2020-05"
 10545	tolerable fortified Buttery Boy	5	good	Last Available: "2020-05"
 10546	mirror Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	Annie Oakley's clown car key	0		Critical Hit Percent: +20, Item Drop: +5, Last Available: "2020-08"
@@ -10438,9 +10438,9 @@
 10582	wobbly SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	twirling hardened wicked birch battery	0		Spell Damage: +5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2020-08"
-10585	ghostly family-friendly manspreader's energetic ebony epee	0		Maximum MP Percent: +20, Monster Level: +10, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	zippy thinker's weeping willow wand of the cheetah	0		Mysticality: +10, Initiative: 80, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	double-paned vibrating hardened beechwood blowgun	0		Damage Reduction: 3, Maximum MP Percent: +10, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	ghostly family-friendly manspreader's energetic ebony epee	0		Maximum MP Percent: +20, Monster Level: +10, Sleaze Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	zippy thinker's weeping willow wand of the cheetah	0		Mysticality: +10, Initiative: 80, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	double-paned vibrating hardened beechwood blowgun	0		Damage Reduction: 3, Maximum MP Percent: +10, Cold Resistance: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	veiny ruddy maple magnet of the cheetah	0		Maximum HP Percent: +40, Maximum HP: +10, Initiative: +60, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	bouncing scorching chaotic hemlock helm of James Dean	0		Experience (Moxie): +3, Spell Critical Percent: +10, Hot Damage: +25, Last Available: "2020-08"
@@ -10482,7 +10482,7 @@
 10626	skewed onyx bishop	0		Last Available: "2020-09"
 10627	narrow onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
-10629	ghostly shaking narrow alabaster king	0		Last Available: "2020-09"
+10629	ghostly narrow shaking alabaster king	0		Last Available: "2020-09"
 10630	narrow alabaster queen	0		Last Available: "2020-09"
 10631	alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
@@ -10496,7 +10496,7 @@
 10640	Universal Seasoning	0		
 10641	extra-adjusted null-day exploit	0		Effect: "Minerva's Zen", Effect Duration: 48, Last Available: "2025-12"
 10642	green flame orb	0		Last Available: "2020-09"
-10643	decent miniature jittery bouncing chocolate chip muffin	2	good	
+10643	miniature decent jittery bouncing chocolate chip muffin	2	good	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10568,17 +10568,17 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	blurry The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	huge The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	special moldy miniature and pepper (stale)	2	crappy	Effect: "Super-Charged", Effect Duration: 40, Last Available: "2020-12"
+10715	miniature special moldy and pepper (stale)	2	crappy	Effect: "Super-Charged", Effect Duration: 40, Last Available: "2020-12"
 10716	perfectly mixed cranberry margarita (brackish)	4	EPIC	Last Available: "2020-12"
 10717	upside-down fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	maroon nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	lousy green barrel-aged eggnog	3	decent	Last Available: "2020-12"
-10721	normal big teal hand-crafted candy cane	5	good	Last Available: "2020-12"
+10721	big normal teal hand-crafted candy cane	5	good	Last Available: "2020-12"
 10722	normal mirror drive-thru burger	3	good	Last Available: "2020-12"
 10723	weak acceptable huge Boulevardier cocktail	2	good	Last Available: "2020-12"
 10724	pickled quantum shaking Hotwire&trade; brand candy rope	0		Effect: "Frost Tea", Effect Duration: 48, Last Available: "2020-12"
-10725	normal immense bowl full of jelly	10	good	Last Available: "2020-12"
+10725	immense normal bowl full of jelly	10	good	Last Available: "2020-12"
 10726	bad Eye and a Twist	4	decent	Last Available: "2020-12"
 10727	dry purple Chubby and Plump bar	0		Effect: "Elron's Explosive Etude", Effect Duration: 17, Last Available: "2020-12"
 10728	gray digibritches	0		Last Available: "2025-12"
@@ -10586,8 +10586,8 @@
 10730	squat crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	cyan fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	marshmallow	0		
 10747	hand-crafted marshmallow bomb	4	EPIC	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	triple-chilled skewed short beer	0		Effect: "Frost Tea", Effect Duration: 43, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	triple-pickled tumbling short	0		Effect: "In a Lather", Effect Duration: 23, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	olive quantum of familiar	0		
-10759	rosy-cheeked familiar scrapbook of the sewer	0		Maximum HP Percent: +30, Stench Damage: +25, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	rosy-cheeked familiar scrapbook of the sewer	0		Maximum HP Percent: +30, Stench Damage: +25, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	lightning-fast executive Jim Carey's fedora-mounted fountain	0		Monster Level: +25, Meat Drop: +40, Initiative: +40, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,7 +10621,7 @@
 10765	maroon rocket	0		Last Available: "2021-07"
 10766	fuchsia rocket	0		Last Available: "2021-07"
 10767	shaking rocket	0		Last Available: "2021-07"
-10768	big adequate fire crackers	5	good	Last Available: "2021-07"
+10768	adequate big fire crackers	5	good	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	skewed rosy-cheeked Catherine Wheel of the cheetah	0		Maximum HP Percent: +30, Initiative: +60, Lasts Until Rollover, Last Available: "2021-07"
 10771	therapeutic rocket boots of temperance	0		Sleaze Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	shaking packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	executive knitted toasty Tesla dangerous beefcake's industrial fire extinguisher	0		Muscle: +25, Weapon Damage: +10, Hot Damage: +5, Cold Resistance: +3, Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	executive knitted toasty Tesla dangerous beefcake's industrial fire extinguisher	0		Muscle: +25, Weapon Damage: +10, Hot Damage: +5, Cold Resistance: +3, Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10678,12 +10678,12 @@
 10822	moldy bite-sized bone broth	1	crappy	Last Available: "2021-12"
 10823	moldy star pop	3	crappy	Last Available: "2021-12"
 10824	acceptable Doc's Fortifying Wine	4	good	Last Available: "2021-12"
-10825	watered-down special perfectly mixed Doc's Smartifying Wine	2	EPIC	Effect: "Polar Express", Effect Duration: 15, Last Available: "2021-12"
+10825	special watered-down perfectly mixed Doc's Smartifying Wine	2	EPIC	Effect: "Polar Express", Effect Duration: 15, Last Available: "2021-12"
 10826	acceptable pulsating Doc's Limbering Wine	3	good	Last Available: "2021-12"
 10827	mediocre Doc's Medical-Grade Wine	4	decent	Last Available: "2021-12"
 10828	boiled upside-down shaking Homebodyl&trade;	1		Last Available: "2021-12"
 10829	twisted narrow Extrovermectin&trade;	1		Effect: "Bloody Bloody Bloody!", Effect Duration: 45, Last Available: "2021-12"
-10830	dehydrated ghostly wobbly Breathitin&trade;	1		Last Available: "2021-12"
+10830	dehydrated wobbly ghostly Breathitin&trade;	1		Last Available: "2021-12"
 10831	pickled fuchsia Fleshazole&trade;	1		Effect: "Wet Willied", Effect Duration: 10, Last Available: "2021-12"
 10832	alkaline activated upside-down anti-burn cream	0		Effect: "Elron's Explosive Etude", Effect Duration: 21, Last Available: "2021-12"
 10833	warmed anti-freeze cream	0		Effect: "It's Electric!", Effect Duration: 28, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	irradiated cold-filtered anti-creep cream	0		Effect: "Cat-Alyzed", Effect Duration: 44, Last Available: "2021-12"
 10837	adjusted electrified twirling anti-pain cream	0		Effect: "Inner Warmth", Effect Duration: 50, Last Available: "2021-12"
 10838	acceptable Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
-10839	stale purple skewed bread pie	4	decent	Last Available: "2021-12"
+10839	stale skewed purple bread pie	4	decent	Last Available: "2021-12"
 10840	smooth clear Russian	4	awesome	Last Available: "2021-12"
 10841	blue zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10711,7 +10711,7 @@
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
 10857	auspicious peppermint-scented socks	0		Item Drop: +10, Last Available: "2021-12"
-10858	blinking green the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10858	green blinking the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	blinking projectile chemistry set	0		Last Available: "2021-12"
 10860	mirror smooth depleted Crimbonium football helmet	0		Moxie: +15, Last Available: "2021-12"
 10861	skewed upside-down synthetic rock	0		Last Available: "2021-12"
@@ -10740,7 +10740,7 @@
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	scandalous extremely unsafe magnifying glass of Gandalf	0		Weapon Damage Percent: +100, Spell Critical Percent: +20, Sleaze Damage: +5, Last Available: "2022-12"
 10886	tolerable void lager	4	good	Last Available: "2022-12"
-10887	spoiled small fuchsia void burger	2	crappy	Last Available: "2022-12"
+10887	small spoiled fuchsia void burger	2	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	narrow smelly friendly supercharged void shard of chilblains	0		Maximum MP Percent: +30, Familiar Weight: +3, Cold Damage: +25, Stench Spell Damage: +10, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10750,11 +10750,11 @@
 10894	Thwaitgold protozoa statuette	0		
 10895	grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	ghostly teal grey down vest	0		Experience (familiar): +2
-10897	jittery green trojan horseshoe	0		Last Available: "2025-12"
+10897	green jittery trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	fireproof frightening nasty unbreakable umbrella (broken) of mayonnaise	0		Stench Damage: +5, Spooky Damage: +5, Sleaze Spell Damage: +50, Hot Resistance: +3
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
-10901	blue narrow MayDay&trade; supply package	0		Last Available: "2022-05"
+10901	narrow blue MayDay&trade; supply package	0		Last Available: "2022-05"
 10902	dry blue shaking blurry emergency glowstick	0		Effect: "Going Ape", Effect Duration: 23, Last Available: "2022-05"
 10903	twirling pulsating fireproof survival knife	0		Hot Resistance: +3, Lasts Until Rollover, Last Available: "2022-05"
 10904	rosy-cheeked crank-powered radio on a lanyard	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2022-05"
@@ -10765,16 +10765,16 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	flattened unsweetened single-use dust mask	0		Effect: "The Real Deal", Effect Duration: 25, Last Available: "2022-05"
 10911	extra-nitrogenated diffused narrow gaffer's tape	0		Effect: "On a Roll", Effect Duration: 48, Last Available: "2022-05"
-10912	gigantic special flavorless 20-lb can of rice and beans	8	decent	Effect: "Wolf's Bane", Effect Duration: 25, Last Available: "2022-05"
+10912	special gigantic flavorless 20-lb can of rice and beans	8	decent	Effect: "Wolf's Bane", Effect Duration: 25, Last Available: "2022-05"
 10913	bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	decent spinning twirling expired MRE	3	good	Last Available: "2022-05"
-10915	stale snack-sized cool mint precipice bar	2	decent	Last Available: "2022-05"
-10916	normal immense cyan carrot cake precipice bar	9	good	Last Available: "2022-05"
+10915	snack-sized stale cool mint precipice bar	2	decent	Last Available: "2022-05"
+10916	immense normal cyan carrot cake precipice bar	9	good	Last Available: "2022-05"
 10917	blurry The Big Book of Every Skill	0		
 10918	bouncing Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	perfumed stanky sinister June cleaver	0		Spell Damage: +10, Stench Spell Damage: +25, Stench Resistance: +5, Attacks Can't Miss, Last Available: "2022-06"
-10921	smooth triple-distilled Dad's brandy	7	awesome	Last Available: "2022-06"
+10921	triple-distilled smooth Dad's brandy	7	awesome	Last Available: "2022-06"
 10922	narrow electrified occult teacher's pen	0		Spell Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-06"
 10923	flavorless gigantic wobbly fire-roasted lake trout	6	decent	Last Available: "2022-06"
 10924	adequate immense guilty sprout	10	good	Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	double-warmed pressed cold-filtered huge trampled ticket stub	0		Effect: "Unusual Fashion Sense", Effect Duration: 28, Last Available: "2022-06"
 10927	magnetized corrupted tumbling savings bond	0		Effect: "Ancient Protected", Effect Duration: 46, Last Available: "2022-06"
 10928	squat designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
 10930	dried narrow sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10799,13 +10799,13 @@
 10943	padded camouflage vest	0		Damage Absorption: +20
 10944	Dinodollar	0		
 10945	valuable dinosaur droppings	0		
-10946	blurry gray twirling jittery dinosaur pheromone kit	0		
+10946	gray jittery blurry twirling dinosaur pheromone kit	0		
 10947	Usain Bolt's Samson's wizardly awkward dinosaur research harness	0		Mysticality: +25, Experience (Muscle): +5, Initiative: +80
 10948	spinning chaotic reflective vest	0		Spell Critical Percent: +10
 10949	brainy dinosaur	0		Mysticality: +5
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	blinking smelly scorching Jurassic Parka	0		Hot Damage: +25, Stench Spell Damage: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	blinking smelly scorching Jurassic Parka	0		Hot Damage: +25, Stench Spell Damage: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	lime green boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	huge autumn-aton	0		Last Available: "2022-10"
 10955	concentrated non-aerosolized pulsating autumn leaf	0		Effect: "Papowerful", Effect Duration: 44, Last Available: "2022-10"
@@ -10821,19 +10821,19 @@
 10965	artisanal pulsating Oopsie IPA	3	EPIC	Last Available: "2022-10"
 10966	mirror mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
-10968	teal ghostly St. Sneaky Pete's Whey	0		Last Available: "2022-11"
+10968	ghostly teal St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	jumbo spoiled ratatouille de Jarlsberg	5	crappy	Last Available: "2022-11"
-10971	flavorless mirror spinning Jarlsberg's vegetable soup	3	decent	Last Available: "2022-11"
-10972	flavorless half-sized roasted vegetable of Jarlsberg	2	decent	Last Available: "2022-11"
+10970	spoiled jumbo ratatouille de Jarlsberg	5	crappy	Last Available: "2022-11"
+10971	flavorless spinning mirror Jarlsberg's vegetable soup	3	decent	Last Available: "2022-11"
+10972	half-sized flavorless roasted vegetable of Jarlsberg	2	decent	Last Available: "2022-11"
 10973	decent St. Pete's sneaky smoothie	3	good	Last Available: "2022-11"
 10974	decent olive tumbling Pete's wiley whey bar	4	good	Last Available: "2022-11"
 10975	snack-sized stale Pete's rich ricotta	2	decent	Last Available: "2022-11"
 10976	artisanal weak Boris's beer	2	EPIC	Last Available: "2022-11"
-10977	moldy red huge honey bun of Boris	4	crappy	Last Available: "2022-11"
-10978	spoiled gigantic Boris's bread	8	crappy	Last Available: "2022-11"
+10977	moldy huge red honey bun of Boris	4	crappy	Last Available: "2022-11"
+10978	gigantic spoiled Boris's bread	8	crappy	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	green blurry Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10980	blurry green Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
 10983	mirror wobbly Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
@@ -10842,9 +10842,9 @@
 10986	green Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	squat pulsating Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	miniature adequate baked veggie ricotta casserole	2	good	Last Available: "2022-11"
-10989	half-sized tasty plain calzone	2	awesome	Last Available: "2022-11"
+10989	tasty half-sized plain calzone	2	awesome	Last Available: "2022-11"
 10990	yummy jittery roasted vegetable focaccia	3	awesome	Last Available: "2022-11"
-10991	adequate red pulsating Pizza of Legend	3	good	Last Available: "2022-11"
+10991	adequate pulsating red Pizza of Legend	3	good	Last Available: "2022-11"
 10992	spoiled Calzone of Legend	3	crappy	Last Available: "2022-11"
 10993	green Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
@@ -10853,7 +10853,7 @@
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	gigantic flavorless Deep Dish of Legend	7	decent	Last Available: "2022-11"
+11000	flavorless gigantic Deep Dish of Legend	7	decent	Last Available: "2022-11"
 11001	olive deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10867,18 +10867,18 @@
 11011	stanky rosy-cheeked gator shades	0		Maximum HP Percent: +30, Stench Spell Damage: +25, Single Equip
 11012	maroon milk cap	0		
 11013	mediocre Charleston Choo-Choo	4	decent	
-11014	spirit-forward perfectly mixed shaking Velvet Veil	5	EPIC	
-11015	artisanal watered-down narrow Marltini	2	EPIC	
+11014	perfectly mixed spirit-forward shaking Velvet Veil	5	EPIC	
+11015	watered-down artisanal narrow Marltini	2	EPIC	
 11016	acceptable twirling Strong, Silent Type	3	good	
-11017	weak drinkable Mysterious Stranger	2	good	
+11017	drinkable weak Mysterious Stranger	2	good	
 11018	aged Champagne Shimmy	4	awesome	
 11019	the Sot's parcel	0		
-11020	skewed family-friendly Lo Pan's ceramic cestus	0		Spell Critical Percent: +30, Sleaze Resistance: +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	gravedigger's baleful ceramic centurion shield of James Dean	0		Experience (Moxie): +3, Spell Damage: +25, Spooky Damage: +10, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	jittery sage ceramic celery grater of the storm	0		Mysticality Percent: +10, Maximum MP Percent: +40, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	sizzling clever ceramic celsiturometer of the scaredy-cat	0		Maximum MP: +20, Monster Level: -15, Hot Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	reassuring therapeutic ceramic cerecloth belt of the glutton	0		Spooky Resistance: +1, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	clever forbidden ceramic cenobite's robe of courage	0		Spell Damage Percent: +50, Maximum MP: +20, Spooky Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	skewed family-friendly Lo Pan's ceramic cestus	0		Spell Critical Percent: +30, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	gravedigger's baleful ceramic centurion shield of James Dean	0		Experience (Moxie): +3, Spell Damage: +25, Spooky Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	jittery sage ceramic celery grater of the storm	0		Mysticality Percent: +10, Maximum MP Percent: +40, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	sizzling clever ceramic celsiturometer of the scaredy-cat	0		Maximum MP: +20, Monster Level: -15, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	reassuring therapeutic ceramic cerecloth belt of the glutton	0		Spooky Resistance: +1, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	clever forbidden ceramic cenobite's robe of courage	0		Spell Damage Percent: +50, Maximum MP: +20, Spooky Resistance: +3, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	altered squat ceramic scree	1		Last Available: "2023-12"
 11027	moist non-aerosolized blurry extra-hard jawbreaker	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 33
 11028	spinning Usain Bolt's avaricious chiffon chevrons of the storm	0		Maximum MP Percent: +40, Meat Drop: +30, Initiative: +80, Single Equip, Last Available: "2023-12"
@@ -10889,9 +10889,9 @@
 11033	Socratic chiffon chaps of dire peril of vim and vigor	0		Experience (Mysticality): +1, Weapon Damage: +20, Maximum HP Percent: +50, Last Available: "2023-12"
 11034	dehydrated red chiffon carbage	1		Last Available: "2023-12"
 11035	electrified chiffon lemon	0		Effect: "Pharmaceutically Cool", Effect Duration: 45
-11036	delicious miniature enchanted chocomotive	2	awesome	Effect: "Raging Animal", Effect Duration: 40, Last Available: "2022-12"
+11036	enchanted miniature delicious chocomotive	2	awesome	Effect: "Raging Animal", Effect Duration: 40, Last Available: "2022-12"
 11037	stale freightcake	4	decent	Last Available: "2022-12"
-11038	weak drinkable cabooze	2	good	Last Available: "2022-12"
+11038	drinkable weak cabooze	2	good	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	blurry clever plastic passenger car	0		Maximum MP: +20, Last Available: "2022-12"
 11041	stylish plastic dining car	0		Moxie: +25, Last Available: "2022-12"
@@ -10901,15 +10901,15 @@
 11045	model train set	0		Last Available: "2022-12"
 11046	blue Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
-11048	upside-down wobbly Trainbot radar monocle	0		Single Equip
+11048	wobbly upside-down Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
-11050	aerosolized non-polarized ghostly purple Trainbot circuitry	0		Effect: "Smoking like a Bandit", Effect Duration: 30
+11050	aerosolized non-polarized purple ghostly Trainbot circuitry	0		Effect: "Smoking like a Bandit", Effect Duration: 30
 11051	flattened altered jittery Trainbot tubing	0		Effect: "Bread Burps", Effect Duration: 54
 11052	ionized non-improved wobbly Trainbot plating	0		Effect: "Carol of the Bones", Effect Duration: 34
 11053	denatured alkaline Trainbot optics	0		Effect: "Squirming Like a Toad", Effect Duration: 50
 11054	Vulcanized Trainbot servomotors	0		Effect: "Mercenary", Effect Duration: 60
 11055	liquefied aerosolized Trainbot linkages	0		Effect: "Uncucumbered", Effect Duration: 20
-11056	ghostly blurry ping-pong paddle	0		Single Equip
+11056	blurry ghostly ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	green wobbly occult Trainbot harness	0		Spell Damage Percent: +25
 11059	huge ping-pong table	0		
@@ -10921,7 +10921,7 @@
 11065	cinnamon machine oil	0		
 11066	shaking Crimbo crystal shards	0		
 11067	perfectly mixed dregs of a Crimbo cocktail	3	EPIC	
-11068	blurry gray lost elf luggage	0		
+11068	gray blurry lost elf luggage	0		
 11069	skewed Trainbot luggage hook	0		Single Equip
 11070	bland miniature honey-drenched ham slice	2	decent	
 11071	extra-dry bad mostly-empty bottle of cookie wine	5	decent	
@@ -10938,7 +10938,7 @@
 11082	yellow crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	drinkable yellow Crimbosmopolitan	3	good	Last Available: "2022-12"
-11085	tasty thick enchanted blurry Crimbo dinner	5	awesome	Effect: "X-Ray Vision", Effect Duration: 35, Last Available: "2022-12"
+11085	thick enchanted tasty blurry Crimbo dinner	5	awesome	Effect: "X-Ray Vision", Effect Duration: 35, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	ghostly train whistle	0		Last Available: "2022-12"
 11088	huge The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10973,7 +10973,7 @@
 11118	vacuum-sealed galvanized bouncing mushroom	0		Effect: "Thick-Skinned", Effect Duration: 65, Last Available: "2023-02"
 11119	double-adjusted denatured wobbly five-fingered fern resin	0		Effect: "Sticks and Stones", Effect Duration: 50, Last Available: "2023-02"
 11120	normal super good fruit	3	good	Last Available: "2023-02"
-11121	altered twirling tumbling shaking energized spores	1		Last Available: "2023-02"
+11121	altered tumbling twirling shaking energized spores	1		Last Available: "2023-02"
 11122	lightning-fast double-paned hot pepper	0		Cold Resistance: +5, Initiative: +40, Last Available: "2023-02", Lantern Element: "Hot"
 11123	energized double-concentrated out-of-work circus flea	0		Effect: "Night Vision", Effect Duration: 22, Last Available: "2023-02"
 11124	blue extra-grubby grub	0		Last Available: "2023-02"
@@ -10990,10 +10990,10 @@
 11135	toothsome bouncing shadow sausage	3	awesome	Last Available: "2023-03"
 11136	nasty veiny shadow skin	0		Maximum HP: +10, Stench Damage: +5, Last Available: "2023-03"
 11137	quantum energized tumbling pulsating shadow flame	0		Effect: "Thaumodynamic", Effect Duration: 28, Last Available: "2023-03"
-11138	spoiled bite-sized shadow bread	1	crappy	Last Available: "2023-03"
+11138	bite-sized spoiled shadow bread	1	crappy	Last Available: "2023-03"
 11139	tumbling shadow ice	0		Last Available: "2023-03"
 11140	lousy shadow fluid	4	decent	Last Available: "2023-03"
-11141	twirling skewed shadow glass	0		Last Available: "2023-03"
+11141	skewed twirling shadow glass	0		Last Available: "2023-03"
 11142	skewed shadow brick	0		Last Available: "2023-03"
 11143	blue shadow sinew	0		Last Available: "2023-03"
 11144	mediocre shadow venom	3	decent	Last Available: "2023-03"
@@ -11034,16 +11034,16 @@
 11179	fuchsia gravedigger's Jack Frost's shadow hammer	0		Cold Spell Damage: +50, Spooky Damage: +10
 11180	red Usain Bolt's shadow monocle of the brazier of the businessman	0		Hot Spell Damage: +25, Meat Drop: +50, Initiative: +80, Single Equip
 11181	maroon shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	moldy skewed blinking shadow hot dog	4	crappy	
+11182	moldy blinking skewed shadow hot dog	4	crappy	
 11183	high-proof artisanal blurry shadow martini	9	EPIC	
-11184	twisted narrow ghostly fuchsia shadow pill	1		
+11184	twisted fuchsia ghostly narrow shadow pill	1		
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	warmed shadow candy	0		Effect: "Big Meat Big Prizes", Effect Duration: 63
 11189	skewed replica Mr. Accessory	0		
 11190	mirror replica Dark Jill-O-Lantern	0		
-11191	shaking mirror replica hand turkey outline	0		
+11191	mirror shaking replica hand turkey outline	0		
 11192	huge replica crimbo elfling	0		
 11193	pulsating replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	inspector's ribald frightening thinker's Cincho de Mayo	0		Mysticality: +10, Spooky Damage: +5, Sleaze Damage: +10, Item Drop: +15, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	inspector's ribald frightening thinker's Cincho de Mayo	0		Mysticality: +10, Spooky Damage: +5, Sleaze Damage: +10, Item Drop: +15, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	shaking dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11105,20 +11105,20 @@
 11250	huge blinking replica grey gosling	0		
 11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
-11253	skewed spinning teal replica Ten Dollars	0		
+11253	teal spinning skewed replica Ten Dollars	0		
 11254	Temple Grandin's replica Cincho de Mayo of the bloodbag of incineration of the boozehound	0		Maximum HP: +100, Familiar Weight: +7, Hot Spell Damage: +50, Booze Drop: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11255	cyan Thwaitgold splendor beetle statuette	0		
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	lime green blinking greedy Tesla steel-toed Samson's &quot;I survived Y2K&quot; T-Shirt of temperance of the sweet-tooth	0		Experience (Muscle): +5, Damage Reduction: 9, Sleaze Resistance: +5, Meat Drop: +20, Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-06"
 11259	yellow Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	auspicious double-paned pro skateboard	0		Cold Resistance: +5, Item Drop: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	auspicious double-paned pro skateboard	0		Cold Resistance: +5, Item Drop: +10, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	fuchsia Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	Flash Liquidizer Ultra Dousing Accessory of the sewer	0		Stench Damage: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	Flash Liquidizer Ultra Dousing Accessory of the sewer	0		Stench Damage: +25, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	jittery hale healthy brawny Amulet of Perpetual Darkness of mayonnaise	0		Muscle Percent: +20, Maximum HP Percent: +20, Maximum HP: +20, Sleaze Spell Damage: +50, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11163,19 +11163,19 @@
 11308	gray watermelon seed	0		
 11309	water balloon	0		
 11310	huge thriftshop coupon	0		
-11311	miniature adequate waffle	2	good	
+11311	adequate miniature waffle	2	good	
 11312	blue fixodent	0		
 11313	careful cat o' nine teeth of wisdom	0		Mysticality: +15, Monster Level: -10
 11314	wobbly extremely unsafe Da Vinci's tooth cap	0		Experience (Mysticality): +5, Weapon Damage Percent: +100
 11315	toothy trousers of wisdom of the boozehound	0		Mysticality: +15, Booze Drop: +100
-11316	thick stale banana split	5	decent	
+11316	stale thick banana split	5	decent	
 11317	blue handful of toilet paper	0		
 11318	blurry Mrs. Rush	0		
 11319	ghostly medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	lousy bottle of Cabernet Sauvignon	3	decent	
 11321	chilly therapeutic savvy baywatch	0		Mysticality Percent: +20, Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover
-11322	teal Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	yellow Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	teal Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	yellow Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	wobbly consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11230,8 +11230,8 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	red housekeeping robot	0		
-11378	rotten small pickled bread	2	crappy	Last Available: "2023-12"
-11379	delicious bite-sized salted mutton	1	awesome	Last Available: "2023-12"
+11378	small rotten pickled bread	2	crappy	Last Available: "2023-12"
+11379	bite-sized delicious salted mutton	1	awesome	Last Available: "2023-12"
 11380	stale gray corned beet	4	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11246,7 +11246,7 @@
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
-11394	mirror squat red crated wardrobe-o-matic	0		
+11394	red mirror squat crated wardrobe-o-matic	0		
 11395	super-sized tasty peppermint donut	5	awesome	
 11396	flame-wreathed Elf Guard insignia (private)	0		Hot Spell Damage: +10, Last Available: "2023-12"
 11397	bouncing Sherlock's Crimbuccaneer fledges (mint)	0		Item Drop: +25, Last Available: "2023-12"
@@ -11255,7 +11255,7 @@
 11400	ghostly Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	mediocre Crimbuccaneer mologrog cocktail	4	decent	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
-11403	bouncing lime green Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
+11403	lime green bouncing Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	dance instructor's arcane researcher's Herculean Crimbuccaneer lantern	0		Experience (Muscle): +1, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Last Available: "2023-12"
 11405	Crimbuccaneer flotsam	0		Last Available: "2023-12"
 11406	Crimbuccaneer invasion map	0		Last Available: "2023-12"
@@ -11274,10 +11274,10 @@
 11419	lightning-fast stylish Elf Guard broom	0		Moxie: +25, Initiative: +40, Last Available: "2023-12"
 11420	shaking electrified beefcake's Crimbuccaneer tavern swab of the wise owl	0		Muscle: +25, Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	hand-crafted jittery yellow old-school pirate grog	4	EPIC	Last Available: "2023-12"
+11422	hand-crafted yellow jittery old-school pirate grog	4	EPIC	Last Available: "2023-12"
 11423	flavorless tumbling grog nuts	3	decent	Last Available: "2023-12"
 11424	shaking perfumed reassuring chaotic sawed-off blunderbuss	0		Spell Critical Percent: +10, Spooky Resistance: +1, Stench Resistance: +5, Last Available: "2023-12"
-11425	fortified mediocre officer's nog	5	decent	Last Available: "2023-12"
+11425	mediocre fortified officer's nog	5	decent	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	immense moldy sundae ration	9	crappy	Last Available: "2023-12"
 11428	yummy peppermint tack	3	awesome	Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	auspicious scandalous fortified Sinatra's Elf dessert spoon of dire peril of the overflowing toilet	0		Experience (Moxie): +5, Weapon Damage: +20, Damage Absorption: +60, Stench Spell Damage: +50, Sleaze Damage: +5, Item Drop: +10, Last Available: "2023-12"
 11453	spinning executive Elf Guard SCUBA tank of the detective	0		Item Drop: +20, Meat Drop: +40, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	blinking MacGyver's free boots of mayonnaise	0		Maximum MP: +100, Sleaze Spell Damage: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	blinking MacGyver's free boots of mayonnaise	0		Maximum MP: +100, Sleaze Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	wool friendly medical-grade Elvish underarmor	0		Familiar Weight: +3, Cold Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2023-12"
 11458	blurry padded Crimbuccaneer bombjacket of the storm	0		Damage Absorption: +20, Maximum MP Percent: +40, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	fancy stale sugarplum ration	3	decent	Effect: "Berry Thorny", Effect Duration: 45, Last Available: "2023-12"
 11460	snack-sized adequate upside-down gingerbread nylons	2	good	Last Available: "2023-12"
 11461	miniature bland rum-soaked fruitcake	2	decent	Last Available: "2023-12"
-11462	rotten jumbo green lime	5	crappy	Last Available: "2023-12"
-11463	adequate tiny olive gingerbread pirate	1	good	Last Available: "2023-12"
+11462	jumbo rotten green lime	5	crappy	Last Available: "2023-12"
+11463	tiny adequate olive gingerbread pirate	1	good	Last Available: "2023-12"
 11464	rotten fruit-stuffed rumcake	4	crappy	Last Available: "2023-12"
 11465	hand-crafted mulled wine	3	EPIC	Last Available: "2023-12"
 11466	weak drinkable mirror Swedish coffee	2	good	Last Available: "2023-12"
-11467	triple-distilled aged wobbly canteen of eggnog	9	awesome	Last Available: "2023-12"
+11467	aged triple-distilled wobbly canteen of eggnog	9	awesome	Last Available: "2023-12"
 11468	tolerable hot wine	3	good	Last Available: "2023-12"
 11469	watered-down smooth mirror Jamaican coffee	2	awesome	Last Available: "2023-12"
-11470	watered-down lousy spinning flask of egggrog	2	decent	Last Available: "2023-12"
+11470	lousy watered-down spinning flask of egggrog	2	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	purple skewed pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	smooth yule grog	4	awesome	Last Available: "2023-12"
 11475	tasty wet tack	4	awesome	Last Available: "2023-12"
 11476	toothsome whalecake	3	awesome	Last Available: "2023-12"
-11477	double-paned healthy gunwale whalegun of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Cold Resistance: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	hand-crafted irresponsibly strong ghostly and claret	10	EPIC	Last Available: "2023-12"
+11477	double-paned healthy gunwale whalegun of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Cold Resistance: +5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	irresponsibly strong hand-crafted ghostly and claret	10	EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	wobbly trick coin	0		Last Available: "2023-12"
-11481	auspicious supercharged Elf Guard squirtgun	0		Maximum MP Percent: +30, Item Drop: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	auspicious supercharged Elf Guard squirtgun	0		Maximum MP Percent: +30, Item Drop: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	squat energetic sequin-encrusted sweater	0		Maximum MP Percent: +20, Last Available: "2023-12"
 11484	blue blinking vibrating experienced strapping replica Elf Guard medal	0		Muscle: +5, Experience: +2, Maximum MP Percent: +10, Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	bouncing Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	corrupted gray military candy cane	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 62
 11503	anodized dry blinking blurry groggipop	0		Effect: "Cinnamouth", Effect Duration: 45
-11504	forbidden dangerous moss mace	0		Weapon Damage: +10, Spell Damage Percent: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	nippy moss megaphone of the scaredy-cat	0		Monster Level: -15, Cold Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	greasy shellacked moss medal	0		Damage Reduction: 7, Sleaze Spell Damage: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	red flame-retardant Socratic moss mitre	0		Experience (Mysticality): +1, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	supercool moss mantle of the businessman	0		Moxie Percent: +20, Meat Drop: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	forbidden dangerous moss mace	0		Weapon Damage: +10, Spell Damage Percent: +50, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	nippy moss megaphone of the scaredy-cat	0		Monster Level: -15, Cold Damage: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	greasy shellacked moss medal	0		Damage Reduction: 7, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	red flame-retardant Socratic moss mitre	0		Experience (Mysticality): +1, Hot Resistance: +1, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	supercool moss mantle of the businessman	0		Moxie Percent: +20, Meat Drop: +50, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	gray blinking personal trainer's moss marlinspike of vim and vigor	0		Experience Percent (Muscle): +10, Maximum HP Percent: +50, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	diluted moss mulch	1		Effect: "Memory of Speed", Effect Duration: 30, Last Available: "2024-12"
 11511	oxidized ionized moss floss	0		Effect: "Black Eyes", Effect Duration: 19
@@ -11372,13 +11372,13 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	powdered skewed adobe assortment	1		Effect: "Booze Goozles", Effect Duration: 10, Last Available: "2024-12"
 11519	improved ionized blinking adobe brittle	0		Effect: "Eyes of the Dragon", Effect Duration: 27
-11520	knitted energetic shellacked crepe paper phrygian cap	0		Damage Reduction: 7, Maximum MP Percent: +20, Cold Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	knitted energetic shellacked crepe paper phrygian cap	0		Damage Reduction: 7, Maximum MP Percent: +20, Cold Resistance: +3, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	stiffened strapping crepe paper parachute cape of vim and vigor	0		Muscle: +5, Damage Reduction: 1, Maximum HP Percent: +50, Last Available: "2025-12"
-11522	inspector's chaotic Annie Oakley's crepe paper pie clip	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Item Drop: +15, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	Sherlock's fortified crepe paper puzzle cube of horror	0		Damage Absorption: +60, Spooky Spell Damage: +25, Item Drop: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	avaricious crepe paper plunge camisole of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Meat Drop: +30, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	greedy manspreader's vibrating crepe paper polka charm	0		Maximum MP Percent: +10, Monster Level: +10, Meat Drop: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
-11526	diluted red mirror crepe paper pared cuttings	1		Last Available: "2025-12"
+11522	inspector's chaotic Annie Oakley's crepe paper pie clip	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Item Drop: +15, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	Sherlock's fortified crepe paper puzzle cube of horror	0		Damage Absorption: +60, Spooky Spell Damage: +25, Item Drop: +25, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	avaricious crepe paper plunge camisole of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Meat Drop: +30, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	greedy manspreader's vibrating crepe paper polka charm	0		Maximum MP Percent: +10, Monster Level: +10, Meat Drop: +20, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11526	diluted mirror red crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	double-tarnished flattened twirling pulsating crepe paper peanut candy	0		Effect: "Coy to the Hurled", Effect Duration: 36
 11528	smelly Socratic petrified wood war pike	0		Experience (Mysticality): +1, Stench Spell Damage: +10, Last Available: "2025-12"
 11529	teal Temple Grandin's sinister petrified wood waist protector	0		Spell Damage: +10, Familiar Weight: +7, Single Equip, Last Available: "2025-12"
@@ -11390,20 +11390,20 @@
 11535	quantum petrified wood wafer praline	0		Effect: "Gutterminded", Effect Duration: 43
 11536	tolerable weak cybeer	2	good	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	pulsating wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	blurry encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	pulsating wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	blurry encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	pulsating baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	quilted smartaleck's Crimbuccaneer war standard	0		Moxie Percent: +30, Damage Absorption: +40, Last Available: "2023-12"
 11544	blinking savvy Elf Guard war standard of the boozehound	0		Mysticality Percent: +20, Booze Drop: +100, Last Available: "2023-12"
 11545	lime green in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	foul-smelling wizardly spring shoes of vim and vigor	0		Mysticality: +25, Maximum HP Percent: +50, Stench Damage: +10, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	foul-smelling wizardly spring shoes of vim and vigor	0		Mysticality: +25, Maximum HP Percent: +50, Stench Damage: +10, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	alkaline ultra-soft ferns	0		Effect: "Cotton Mouthed", Effect Duration: 67, Last Available: "2024-02"
 11548	activated crunchy brush	0		Effect: "Salty Mouth", Effect Duration: 30, Last Available: "2024-02"
 11549	teal smashed scientific equipment	0		
 11550	mirror biphasic molecular oculus	0		No Pull
-11551	blue twirling triphasic molecular oculus	0		
+11551	twirling blue triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
 11553	ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
@@ -11428,7 +11428,7 @@
 11573	stale massive yam	6	decent	Last Available: "2024-05"
 11574	hand-crafted yam martini	3	EPIC	Last Available: "2024-05"
 11575	tolerable sweet potato o' mine	3	good	Last Available: "2024-05"
-11576	tolerable practically non-alcoholic huge Southern yam	1	good	Last Available: "2024-05"
+11576	practically non-alcoholic tolerable huge Southern yam	1	good	Last Available: "2024-05"
 11577	tolerable sweet potato punch	3	good	Last Available: "2024-05"
 11578	stale thick Mayam spinach	5	decent	Last Available: "2024-05"
 11579	half-sized flavorless yam and swiss	2	decent	Last Available: "2024-05"
@@ -11448,20 +11448,20 @@
 11593	bouncing Thwaitgold Illinigina illinoiensis model	0		
 11594	spoiled big mirror mini kiwi	5	crappy	Last Available: "2024-06"
 11595	family-friendly thinker's mini kiwi bikini of the bloodbag	0		Mysticality: +10, Maximum HP: +100, Sleaze Resistance: +1, Last Available: "2024-06"
-11596	triple-distilled tolerable jittery jittery mini kiwitini	7	good	Last Available: "2024-06"
+11596	tolerable triple-distilled jittery jittery mini kiwitini	7	good	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	huge scandalous crafty arcane researcher's mini kiwi silicon tiepin	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Sleaze Damage: +5
 11600	pulsating mini kiwi tipi	0		
-11601	small toothsome special mini kiwi digitized cookies	2	awesome	Effect: "Motion", Effect Duration: 20
+11601	special toothsome small mini kiwi digitized cookies	2	awesome	Effect: "Motion", Effect Duration: 20
 11602	perfectly mixed mini kiwi intoxicating spirits	4	EPIC	
 11603	frozen alkaline pressed mirror mini kiwi antimilitaristic hippy petition	0		Effect: "Helping Comes Second", Effect Duration: 38
-11604	Vulcanized super-modified dry skewed green mini kiwi illicit antibiotic	0		Effect: "Be a Mind Master", Effect Duration: 39
+11604	Vulcanized super-modified dry green skewed mini kiwi illicit antibiotic	0		Effect: "Be a Mind Master", Effect Duration: 39
 11605	scorching boxer's mini kiwi whipping stick	0		Muscle Percent: +10, Hot Damage: +25
 11606	cyan zippy mini kiwi icepick	0		Initiative: +20
 11607	oxidized nitrogenated pulsating mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Sticky Fingers", Effect Duration: 65
 11608	gray twirling packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	maroon protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11471,7 +11471,7 @@
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	moldy maroon bacteria bisque	4	crappy	
-11619	normal massive ciliophora chowder	6	good	
+11619	massive normal ciliophora chowder	6	good	
 11620	flavorless cream of chloroplasts	4	decent	
 11621	skewed synaptic soup	0		
 11622	muscular soup	0		
@@ -11486,12 +11486,12 @@
 11631	baby bodyguard	0		
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
-11634	narrow blinking skewed tattoo gun	0		
-11635	strong tolerable Colera Peste Nebbiolo	5	good	
+11634	blinking skewed narrow tattoo gun	0		
+11635	tolerable strong Colera Peste Nebbiolo	5	good	
 11636	longbox of Batfellow comics	0		
 11637	green Thwaitgold shield bug statuette	0		
 11638	squat bodyguard badge	0		
-11639	mirror shaking Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
+11639	shaking mirror Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	Sept-Ember Censer	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	mirror fuchsia soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	smelly supercharged bat wings of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Stench Spell Damage: +10, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	smelly supercharged bat wings of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Stench Spell Damage: +10, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	tumbling ember	0		Cold Resistance: +1
 11661	hardened monocle on a stick of the overflowing toilet	0		Damage Reduction: 3, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,11 +11523,11 @@
 11668	padded Sheriff badge of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +20, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	gravedigger's friendly Sheriff pistol	0		Familiar Weight: +3, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
 11670	bouncing energetic wizardly Sheriff moustache	0		Mysticality: +25, Maximum MP Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	knitted Van der Graaf photo booth supply list	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	knitted Van der Graaf photo booth supply list	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	narrow twirling green peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	snack-sized flavorless whirled peas	2	decent	Last Available: "2024-11"
-11675	fancy big bland peaza	5	decent	Effect: "Paging Betty", Effect Duration: 5, Last Available: "2024-11"
+11675	bland fancy big peaza	5	decent	Effect: "Paging Betty", Effect Duration: 5, Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	mixed squat spinning drenchrome 2.0	1		Effect: "No Worries", Effect Duration: 25, Last Available: "2025-12"
 11678	pickled fuchsia Synapse Blaster	1		Effect: "The Living Hitpoints", Effect Duration: 35, Last Available: "2025-12"
@@ -11535,18 +11535,18 @@
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	non-pressed moist dry pea brittle	0		Effect: "Thickest, Sickest", Effect Duration: 50, Last Available: "2024-11"
-11683	weak perfectly mixed tumbling peasco	2	EPIC	Last Available: "2024-11"
+11683	perfectly mixed weak tumbling peasco	2	EPIC	Last Available: "2024-11"
 11684	moldy jittery piece of cake	3	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	cyan TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	friendly electrified deft pirate hook	0		Familiar Weight: +3, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-12"
-11689	wobbly jittery chaotic rosy-cheeked iron tricorn hat	0		Maximum HP Percent: +30, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	wobbly jittery chaotic rosy-cheeked iron tricorn hat	0		Maximum HP Percent: +30, Spell Critical Percent: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	bouncing jolly roger flag of Gandalf	0		Spell Critical Percent: +20, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	fortified bad fancy tankard of spiced rum	5	decent	Effect: "Chorale of Companionship", Effect Duration: 30, Last Available: "2024-12"
-11694	hand-crafted fancy tankard of spiced Goldschlepper	4	EPIC	Effect: "Lobos Fresh", Effect Duration: 15, Last Available: "2024-12"
+11693	fancy fortified bad tankard of spiced rum	5	decent	Effect: "Chorale of Companionship", Effect Duration: 30, Last Available: "2024-12"
+11694	fancy hand-crafted tankard of spiced Goldschlepper	4	EPIC	Effect: "Lobos Fresh", Effect Duration: 15, Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	yellow wicked governor's daughter's lace collar	0		Spell Damage: +5, Last Available: "2024-12"
 11697	gray quilted governor's daughter's petticoats	0		Damage Absorption: +40, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	tarnished colloidal cyan peppermint pegleg	0		Effect: "Moon-Eyed", Effect Duration: 58, Last Available: "2024-12"
 11710	hand-crafted hard cocoa	3	EPIC	Last Available: "2024-12"
-11711	moldy jumbo salmagumdi	5	crappy	Last Available: "2024-12"
+11711	jumbo moldy salmagumdi	5	crappy	Last Available: "2024-12"
 11712	spinning smartaleck's plastic Easter Island Bunny	0		Moxie Percent: +30, Last Available: "2024-12"
 11713	hardened plastic St. Patrick	0		Damage Reduction: 3, Last Available: "2024-12"
 11714	zippy plastic Colonel Brando of courage	0		Spooky Resistance: +3, Initiative: +20, Last Available: "2024-12"
@@ -11576,14 +11576,14 @@
 11721	cyan Spirit of Christmas	0		Last Available: "2024-12"
 11722	normal coney haunch	4	good	Last Available: "2024-12"
 11723	unsweetened cold-filtered mirror dark chocolate egg	0		Effect: "Souper Vengeful", Effect Duration: 22, Last Available: "2024-12"
-11724	fancy tolerable pulsating moai toai	3	good	Effect: "Fudgehound", Effect Duration: 10
+11724	tolerable fancy pulsating moai toai	3	good	Effect: "Fudgehound", Effect Duration: 10
 11725	sizzling Socratic moaiball of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Hot Damage: +10, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	denatured tumbling four-leaf potato sprout	0		Effect: "Texas Elegance", Effect Duration: 51, Last Available: "2024-12"
 11728	maroon perfumed chilly Tesla potato jacket	0		Cold Damage: +5, Stench Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	skewed ghostly military orb of the bloodbag of the boozehound	0		Maximum HP: +100, Booze Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	skewed ghostly military orb of the bloodbag of the boozehound	0		Maximum HP: +100, Booze Drop: +100, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	energized energized rum ball	0		Effect: "Ermine Eyes", Effect Duration: 13
 11733	squat gravy skin	0		Last Available: "2024-12"
 11734	dog trainer's gravyskin hat of James Dean	0		Experience (Moxie): +3, Experience (familiar): +1, Last Available: "2024-12"
@@ -11591,59 +11591,59 @@
 11736	veiny weightlifter's gravyskin skirt	0		Muscle: +15, Maximum HP: +10, Last Available: "2024-12"
 11737	resourceful supercool gravyskin pants	0		Moxie Percent: +20, Maximum MP: +50, Last Available: "2024-12"
 11738	frozen enhanced gray crystallized pumpkin spice	0		Effect: "Phairly Balanced", Effect Duration: 55, Last Available: "2024-12"
-11739	tasty huge narrow room scale bean casserole	9	awesome	Last Available: "2024-12"
+11739	huge tasty narrow room scale bean casserole	9	awesome	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	skewed ragged wool yarn	0		Last Available: "2024-12"
 11742	Lo Pan's Oprah's occult perfect Christmas scarf	0		Spell Damage Percent: [+25*event(December)], Maximum MP Percent: [+50*event(December)], Spell Critical Percent: [+30*event(December)], Single Equip, Last Available: "2024-12"
-11743	huge flame-retardant snowman-enchanting tophat of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	huge flame-retardant snowman-enchanting tophat of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	non-magnetized dry LIDAR candle	0		Effect: "All Branned Up", Effect Duration: 33, Last Available: "2024-12"
 11745	toasty manspreader's Congressional Medal of Insanity of the dark arts	0		Spell Damage Percent: +100, Monster Level: +10, Hot Damage: +5, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	acceptable weak Easter grasshopper	2	good	Last Available: "2024-12"
+11747	weak acceptable Easter grasshopper	2	good	Last Available: "2024-12"
 11748	tolerable blue Irish eggnog	4	good	Last Available: "2024-12"
 11749	drinkable purple canteen of jungle juice	3	good	Last Available: "2024-12"
 11750	delicious turchucken	4	awesome	Last Available: "2024-12"
-11751	delicious irresponsibly strong mechanically-mulled cider	7	awesome	Last Available: "2024-12"
+11751	irresponsibly strong delicious mechanically-mulled cider	7	awesome	Last Available: "2024-12"
 11752	special hand-crafted blurry holiday trip around the world	3	super ultra EPIC	Effect: "EVISCERATE!", Effect Duration: 10, Last Available: "2024-12"
 11753	stale gigantic chocolate ostrich egg	8	decent	Last Available: "2024-12"
-11754	diet stale beef and cabbage	1	decent	Last Available: "2024-12"
-11755	spoiled special small narrow candy rations	2	crappy	Effect: "Thaumodynamic", Effect Duration: 25, Last Available: "2024-12"
-11756	enchanted toothsome squat double-candied yams	4	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2024-12"
+11754	stale diet beef and cabbage	1	decent	Last Available: "2024-12"
+11755	spoiled small special narrow candy rations	2	crappy	Effect: "Thaumodynamic", Effect Duration: 25, Last Available: "2024-12"
+11756	toothsome enchanted squat double-candied yams	4	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2024-12"
 11757	spoiled miniature Christmas ham	2	crappy	Last Available: "2024-12"
 11758	bland twirling holiday smorgasbord	3	decent	Last Available: "2024-12"
 11759	blinking Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	upside-down bejazzled eyepatch of the bloodbag	0		Maximum HP: +100, Last Available: "2024-12"
-11761	fuchsia Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	cyan Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	blinking Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	twirling Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	huge Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	fuchsia Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	cyan Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	blinking Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	twirling Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	huge Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	lard-coated deadly egg gun of the pedagogue of doom	0		Experience: +3, Weapon Damage: +5, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	lard-coated deadly egg gun of the pedagogue of doom	0		Experience: +3, Weapon Damage: +5, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	asbestos-lined toasty Socratic army helmet of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Hot Damage: +5, Hot Resistance: +5, Last Available: "2024-12"
-11774	blue blurry candy egg deviler	0		Last Available: "2024-12"
+11774	blurry blue candy egg deviler	0		Last Available: "2024-12"
 11775	yellow napkin	0		Last Available: "2024-12"
 11776	delicious Thanksgiving ration	3	awesome	Last Available: "2024-12"
 11777	mediocre shaking Easter eggnog	3	decent	Last Available: "2024-12"
 11778	dehydrated wobbly clovermint	1		Last Available: "2024-12"
 11779	skewed knitted manspreader's Tesla grievous nylon Christmas stockings	0		Weapon Damage Percent: +50, Monster Level: +10, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2024-12"
 11780	huge tattoo of two turkeys	0		Last Available: "2024-12"
-11781	nitrogenated nitrogenated squat shaking deviled candy egg	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 50, Last Available: "2024-12"
+11781	nitrogenated nitrogenated shaking squat deviled candy egg	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 50, Last Available: "2024-12"
 11782	gray McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	blue avaricious forbidden McHugeLarge duffel bag	0		Spell Damage Percent: +50, Meat Drop: +30, Last Available: "2025-01"
-11784	baleful sinister smartaleck's McHugeLarge left pole	0		Moxie Percent: +30, Spell Damage: 35, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	wool McHugeLarge right pole of the dark arts of the cheetah	0		Spell Damage Percent: +100, Cold Resistance: +1, Initiative: +60, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	Jeselnik's dog trainer's McHugeLarge left ski	0		Experience (familiar): +1, Sleaze Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	Newton's McHugeLarge right ski of the bloodbag	0		Experience (Mysticality): +3, Maximum HP: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	baleful sinister smartaleck's McHugeLarge left pole	0		Moxie Percent: +30, Spell Damage: 35, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	wool McHugeLarge right pole of the dark arts of the cheetah	0		Spell Damage Percent: +100, Cold Resistance: +1, Initiative: +60, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	Jeselnik's dog trainer's McHugeLarge left ski	0		Experience (familiar): +1, Sleaze Damage: +25, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	Newton's McHugeLarge right ski of the bloodbag	0		Experience (Mysticality): +3, Maximum HP: +100, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	altered bouncing eXpand	1		Last Available: "2025-12"
-11791	upside-down brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	upside-down brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	jittery dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	huge retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	cyan 3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	red parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	narrow twirling virtual cybertattoo	0		Last Available: "2025-12"
 11830	red ninja rope	0		
@@ -11701,18 +11701,18 @@
 11846	jittery jittery plover's egg	0		
 11847	blurry flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
-11849	shaking blurry heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
+11849	blurry shaking heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	bouncing sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	upside-down stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
-11852	lime green narrow huge phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
+11852	lime green huge narrow phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	skewed foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
-11855	gray spinning rift oculus	0		Combat Rate: +5
+11855	spinning gray rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	blurry carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	pulsating glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
-11860	shaking skewed assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
+11860	skewed shaking assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	tumbling Leprecondo	0		Last Available: "2025-03"
 11862	powdered tumbling teal scoop of pre-workout powder	1		Effect: "Cautious Prowl", Effect Duration: 5, Last Available: "2025-03"
 11863	narrow wobbly table tennis ball	0		Last Available: "2025-03"
@@ -11724,11 +11724,11 @@
 11869	unironic knife	0		
 11870	shaking bar dart	0		Last Available: "2025-03"
 11871	distilled bouncing leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	half-sized fancy flavorless Heck ramen	2	decent	Effect: "Stenchtastic", Effect Duration: 10, Last Available: "2025-03"
+11872	flavorless half-sized fancy Heck ramen	2	decent	Effect: "Stenchtastic", Effect Duration: 10, Last Available: "2025-03"
 11873	bland jittery burrito	4	decent	Last Available: "2025-03"
 11874	normal small beer brat	4	good	Last Available: "2025-03"
 11875	super-sized rotten peach pie	5	crappy	Last Available: "2025-03"
-11876	super-sized normal incredible mini-pizza	5	good	Last Available: "2025-03"
+11876	normal super-sized incredible mini-pizza	5	good	Last Available: "2025-03"
 11877	perfectly mixed fancy Divine sidecar	3	EPIC	Effect: "Fangs and Pangs", Effect Duration: 50, Last Available: "2025-03"
 11878	artisanal watered-down blurry tangarita sidecar	2	EPIC	Last Available: "2025-03"
 11879	bad gimlet sidecar	3	decent	Last Available: "2025-03"
@@ -11741,7 +11741,7 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	wet maroon wet paper weights	0		Effect: "Ninja, Please", Effect Duration: 62, Last Available: "2025-04"
 11888	hand-crafted wobbly Three Sheets to the Wind	4	EPIC	Last Available: "2025-04"
-11889	thick adequate pile of wet dates	5	good	Last Available: "2025-04"
+11889	adequate thick pile of wet dates	5	good	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	cyan educational wet shower cap	0		Experience: +1, Last Available: "2025-04"
@@ -11755,7 +11755,7 @@
 11900	lime green jittery Samson's wet shower radio	0		Experience (Muscle): +5, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	bouncing wet shower stamp	0		Last Available: "2025-04"
 11902	dangerous birthday bloon	0		Weapon Damage: +10
-11903	extra-vacuum-sealed wet energized tumbling blurry jawwetter	0		Effect: "Muddled", Effect Duration: 38
+11903	extra-vacuum-sealed wet energized blurry tumbling jawwetter	0		Effect: "Muddled", Effect Duration: 38
 11904	blue Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
 11905	inspector's healthy wicked Peridot of Peril	0		Spell Damage: +5, Maximum HP Percent: +20, Item Drop: +15, Single Equip, Last Available: "2025-06"
 11906	bouncing careful terrycloth turban	0		Monster Level: -10
@@ -11771,7 +11771,7 @@
 11916	huge twirling zippy stylish bycocket	0		Initiative: +20
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	blurry packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11786,7 +11786,7 @@
 11931	nice nylon stockings	0		
 11932	twirling Allied Radio Backpack Pack	0		Free Pull
 11933	spinning dangerous Newton's Allied Radio Backpack of the empath	0		Experience (Mysticality): +3, Weapon Damage: +10, Familiar Weight: +5, Conditional Skill (Equipped): "Call in an Airstrike"
-11934	wobbly narrow orphaned baby skeleton	0		
+11934	narrow wobbly orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	immense flavorless huge Skeleton Wars rations	9	decent	
@@ -11816,33 +11816,33 @@
 11962	blinking undersea surveying goggles of Leguizamo	0		Monster Level: +20, Lasts Until Rollover
 11963	perfectly mixed Ocean-Touched Rum	4	EPIC	
 11964	denatured purple water-logged pill	1		Effect: "Boletus Swoletus", Effect Duration: 45
-11965	flavorless thick kelp puck	5	decent	
+11965	thick flavorless kelp puck	5	decent	
 11966	scroll of sea strength	0		
 11967	wobbly scroll of sea smarts	0		
 11968	fuchsia scroll of sea smarm	0		
-11969	fuchsia ghostly waterlogged scroll of healing	0		
+11969	ghostly fuchsia waterlogged scroll of healing	0		
 11970	sea gel	0		
 11971	magnetized octopus ink bladder	0		Effect: "Poker Faced", Effect Duration: 13
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	cyan unblemished pearl	0		
 11977	teal grievous dentadent	0		Weapon Damage Percent: +50
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	twirling perfumed sharpshooter's Van der Graaf supercool thinker's blood cubic zirconia of the glutton	0		Mysticality: +10, Moxie Percent: +20, Critical Hit Percent: +10, Stench Resistance: +5, Food Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
-12044	vaporized narrow yellow blood thinner	1		Last Available: "2025-10"
+11987	twirling perfumed sharpshooter's Van der Graaf supercool thinker's blood cubic zirconia of the glutton	0		Mysticality: +10, Moxie Percent: +20, Critical Hit Percent: +10, Stench Resistance: +5, Food Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+12044	vaporized yellow narrow blood thinner	1		Last Available: "2025-10"
 12045	watered-down delicious pheromone cocktail	2	awesome	Last Available: "2025-10"
-12046	diet adequate enchanted bouncing spinal tapas	1	good	Effect: "Bilious Briskness", Effect Duration: 20, Last Available: "2025-10"
+12046	enchanted diet adequate bouncing spinal tapas	1	good	Effect: "Bilious Briskness", Effect Duration: 20, Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	avaricious toasty beefcake's shrunken head	0		Muscle: +25, Hot Damage: +5, Meat Drop: +30, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	avaricious toasty beefcake's shrunken head	0		Muscle: +25, Hot Damage: +5, Meat Drop: +30, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	spinning knucklebone	0		
 12052	tolerable bouncing Smoking Pope	3	good	
 12053	bland prize turkey	4	decent	
 12054	diluted medicinal gruel	1		Effect: "Category", Effect Duration: 20
-12055	adequate bite-sized full-sized pumpkin pie	1	good	Last Available: "2025-11"
+12055	bite-sized adequate full-sized pumpkin pie	1	good	Last Available: "2025-11"
 12056	drinkable vodka cranberry sauce	3	good	Last Available: "2025-11"
 12057	galvanized yammed candy	0		Effect: "Inner Warmth", Effect Duration: 36, Last Available: "2025-11"
 12058	decent treasure chestnut	4	good	Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	denatured pulsating boiling synovial fluid	0		Effect: "Crusty Head", Effect Duration: 53, Last Available: "2025-12"
 12132	up-at-dawn banded smoldering vertebra of Leguizamo	0		Damage Absorption: +100, Monster Level: +20, Adventures: +5, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	blurry volatile bone bomb	0		Last Available: "2025-12"
 12137	miser's sizzling Samson's hot boning knife	0		Experience (Muscle): +5, Hot Damage: +10, Meat Drop: +10, Single Equip, Last Available: "2025-12"
@@ -11898,7 +11898,7 @@
 12140	grievous scorched skull trophy	0		Weapon Damage Percent: +50, Last Available: "2025-12"
 12141	moldy wing bone	4	crappy	Last Available: "2025-12"
 12142	hand-crafted weak skeleton venom	4	EPIC	Last Available: "2025-12"
-12143	pickled skewed pulsating baked bone meal	1		Last Available: "2025-12"
+12143	pickled pulsating skewed baked bone meal	1		Last Available: "2025-12"
 12144	twirling brawny plastic skeleton rib cage	0		Muscle Percent: +20, Last Available: "2025-12"
 12145	bouncing plastic skeleton skull of bravery	0		Spooky Resistance: +5, Last Available: "2025-12"
 12146	squat forbidden plastic skeleton Crimbo hat	0		Spell Damage Percent: +50, Last Available: "2025-12"
@@ -11926,17 +11926,17 @@
 12168	ruddy grievous vermiculite shield	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Damage Reduction: 9, Last Available: "2025-12"
 12169	executive ship's lantern	0		Meat Drop: +40, Last Available: "2025-12"
 12170	Oprah's occult heat-resistant harpoon pistol	0		Spell Damage Percent: +25, Maximum MP Percent: +50, Last Available: "2025-12"
-12171	special low-calorie adequate traditional gingerloaf	1	good	Effect: "Is This Your Card?", Effect Duration: 10, Last Available: "2025-12"
-12172	watered-down lousy Scotch and eggnog	2	decent	Last Available: "2025-12"
+12171	low-calorie special adequate traditional gingerloaf	1	good	Effect: "Is This Your Card?", Effect Duration: 10, Last Available: "2025-12"
+12172	lousy watered-down Scotch and eggnog	2	decent	Last Available: "2025-12"
 12173	dry counterskeleton elixir	0		Effect: "Piratastic", Effect Duration: 32, Last Available: "2025-12"
-12174	smooth watered-down green &quot;salvaged&quot; wine	2	awesome	Last Available: "2025-12"
+12174	watered-down smooth green &quot;salvaged&quot; wine	2	awesome	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	half-sized moldy wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
+12177	moldy half-sized wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
 12178	double-enhanced bouncing gummi fingerbone	0		Effect: "Busy Bein' Delicious", Effect Duration: 37
 12179	spinning sinister dangerous glimmering crystal	0		Weapon Damage: +10, Spell Damage: +10, Last Available: "2025-12"
 12180	huge boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	blurry Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11948,7 +11948,7 @@
 12190	tumbling fossilized cow femur	0		Familiar Weight: +5
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
-12193	diffused wobbly skewed jittery Pork Elf mouthwash	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 50, Last Available: "2026-03"
+12193	diffused jittery skewed wobbly Pork Elf mouthwash	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 50, Last Available: "2026-03"
 12194	quadruple-alkaline dry mirror Pork Elf deodorant	0		Effect: "Meadulla Oblongota", Effect Duration: 23, Last Available: "2026-03"
 12195	dry Pork Elf toothpaste	0		Effect: "Bustle Hustlin'", Effect Duration: 27, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
@@ -11973,28 +11973,28 @@
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	enchanted normal discarded hot dog	3	good	Effect: "Amorous Avarice", Effect Duration: 10, Last Available: "2026-04"
-12218	high-proof smooth most of a beer	7	awesome	Last Available: "2026-04"
+12218	smooth high-proof most of a beer	7	awesome	Last Available: "2026-04"
 12222	maroon pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	twirling legendary noodles	0		Last Available: "2026-05"
 12226	miniature adequate can of tuna	2	good	
 12227	decent alien salad	4	good	
-12228	moldy huge enchanted ratbatatouille	6	crappy	Effect: "Gummi Badass", Effect Duration: 40
+12228	huge enchanted moldy ratbatatouille	6	crappy	Effect: "Gummi Badass", Effect Duration: 40
 12229	flavorless onigiri	4	decent	
 12230	small bland crudit&eacute;s	2	decent	
 12231	huge spoiled sauced mutton	8	crappy	
 12232	moldy hot honey ant	3	crappy	
-12233	bite-sized stale tomb aspic	1	decent	
+12233	stale bite-sized tomb aspic	1	decent	
 12234	bland later tots	3	decent	
 12235	spoiled Frutti di Scatoletta	3	crappy	Last Available: "2026-05"
 12236	bland thick Pesto alla Marziano	5	decent	Last Available: "2026-05"
 12237	moldy huge Arrattabbattabiata	7	crappy	Last Available: "2026-05"
-12238	half-sized rotten Orzo di Riso	2	crappy	Last Available: "2026-05"
+12238	rotten half-sized Orzo di Riso	2	crappy	Last Available: "2026-05"
 12239	bland Pasta Grimavera	4	decent	Last Available: "2026-05"
 12240	big yummy Linguini Ubriacapa	5	awesome	Last Available: "2026-05"
-12241	bland miniature special mirror spinning Formica e Pepe	2	decent	Effect: "One Foot Heavier", Effect Duration: 15, Last Available: "2026-05"
-12242	immense adequate purple Tubetto Gelatto	9	good	Last Available: "2026-05"
-12243	tiny flavorless twirling Gnocci Domani	1	decent	Last Available: "2026-05"
+12241	bland miniature special spinning mirror Formica e Pepe	2	decent	Effect: "One Foot Heavier", Effect Duration: 15, Last Available: "2026-05"
+12242	adequate immense purple Tubetto Gelatto	9	good	Last Available: "2026-05"
+12243	flavorless tiny twirling Gnocci Domani	1	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	squat second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12011,15 +12011,15 @@
 12261	huge flash paperwad	0		
 12262	juggling ball	0		
 12263	Usain Bolt's tactical jester's cap of horror	0		Spooky Spell Damage: +25, Initiative: +80, Combat Item Damage Percent: 50
-12264	blurry mirror single-use sword	0		
+12264	mirror blurry single-use sword	0		
 12265	ruddy flimsy plastic helmet	0		Maximum HP Percent: +40
 12266	rock-hard flimsy plastic greaves	0		Damage Reduction: 5
 12267	nasty flimsy plastic breastplate	0		Stench Damage: +5
 12268	scorching flimsy plastic shield	0		Hot Damage: +25, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	twirling ribald Da Vinci's Portable Laughing Stock of the cougar	0		Moxie: +20, Experience (Mysticality): +5, Sleaze Damage: +10, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	twirling ribald Da Vinci's Portable Laughing Stock of the cougar	0		Moxie: +20, Experience (Mysticality): +5, Sleaze Damage: +10, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	scandalous horrifying thinker's Staff of Anachronistic Churning	0		Mysticality: +10, Spooky Damage: +25, Sleaze Damage: +5
-12272	yummy gigantic classic banana	10	awesome	Last Available: "2026-07"
+12272	gigantic yummy classic banana	10	awesome	Last Available: "2026-07"
 12273	spoiled squat watermelon	4	crappy	Last Available: "2026-07"
 12274	half-sized normal wobbly quince	2	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
@@ -12032,7 +12032,7 @@
 12282	thick spoiled watermelon pie	5	crappy	Last Available: "2026-07"
 12283	vacuum-sealed polarized shaking concentrated watermelon juice	0		Effect: "Filled with Magic", Effect Duration: 66, Last Available: "2026-07"
 12284	irradiated Aqua Citrulanatae	0		Effect: "Prelude of Precision", Effect Duration: 49, Last Available: "2026-07"
-12285	fortified drinkable lime green Melonegroni	5	good	Last Available: "2026-07"
+12285	drinkable fortified lime green Melonegroni	5	good	Last Available: "2026-07"
 12286	lousy weak Melonade Spritz	2	decent	Last Available: "2026-07"
 12287	spoiled blue quince pie	3	crappy	Last Available: "2026-07"
 12288	corrupted skewed quince quaff	0		Effect: "Locks Like the Raven", Effect Duration: 42, Last Available: "2026-07"
@@ -12052,7 +12052,7 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	double-paned grievous 401k ring	0		Weapon Damage Percent: +50, Cold Resistance: +5, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
-12305	magnetized boiled maroon skewed invisible hand	0		Effect: "Blood-Gorged", Effect Duration: 57, Last Available: "2026-08"
+12305	magnetized boiled skewed maroon invisible hand	0		Effect: "Blood-Gorged", Effect Duration: 57, Last Available: "2026-08"
 12306	unsweetened pulsating circle of overdraft protection scroll	0		Effect: "Dwarven Hardiness", Effect Duration: 25, Last Available: "2026-08"
 12307	tarnished corrupted jittery blurry mint	0		Effect: "Extra-Sharp Weapon", Effect Duration: 24, Last Available: "2026-08"
 12308	skewed savings bondo	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Accordion_Thief_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Opossum_cafe_booze.txt
@@ -1,16 +1,16 @@
 -1	bad mirror Petite Porter	4	decent	
 -2	bad practically non-alcoholic Scrawny Stout	1	decent	
 -3	tolerable squat Infinitesimal IPA	3	good	
--4	lousy weak purple eggnogtini	2	decent	
+-4	weak lousy purple eggnogtini	2	decent	
 -5	lousy candycaine	3	decent	
 -6	lousy braincracker sweet	4	decent	
 -16	watered-down smooth lime green ghostly fermented honey	2	awesome	
--17	triple-distilled mediocre moons-shine	6	decent	
--18	watered-down bad blinking gin	2	decent	
--19	boozy enchanted lousy ecto-nog	5	decent	
--20	irresponsibly strong hand-crafted hot toady	9	EPIC	
+-17	mediocre triple-distilled moons-shine	6	decent	
+-18	bad watered-down blinking gin	2	decent	
+-19	enchanted lousy boozy ecto-nog	5	decent	
+-20	hand-crafted irresponsibly strong hot toady	9	EPIC	
 -21	tolerable hot choculate	3	good	
--49	bad practically non-alcoholic Cyder	1	decent	
+-49	practically non-alcoholic bad Cyder	1	decent	
 -50	hand-crafted Oil Nog	3	EPIC	
 -51	practically non-alcoholic drinkable Hi-Octane Peppermint Jet Fuel	1	good	
 -58	lousy watered-down huge Grimacider	2	decent	
@@ -18,16 +18,16 @@
 -60	mediocre fuchsia Mutagin 'n' Tonic	4	decent	
 -70	hand-crafted Gin and Herring	3	EPIC	
 -71	tolerable Black and Tan and Red All Over	3	good	
--72	weak mediocre bouncing Antarctic Ice Tea	2	decent	
+-72	mediocre weak bouncing Antarctic Ice Tea	2	decent	
 -76	artisanal CRIMBCO Ribbon Candy Schnapps	4	EPIC	
 -77	drinkable CRIMBCO Egg Substitute Nog Substitute	3	good	
 -78	lousy CRIMBCO Extreme Braincracker Sour	4	decent	
--82	lousy weak mirror Horseradish-infused Vodka	2	decent	
--83	acceptable spirit-forward mirror Jerkitini	5	good	
--84	drinkable triple-distilled Desert Island Iced Tea	8	good	
+-82	weak lousy mirror Horseradish-infused Vodka	2	decent	
+-83	spirit-forward acceptable mirror Jerkitini	5	good	
+-84	triple-distilled drinkable Desert Island Iced Tea	8	good	
 -88	drinkable shaking Crimbo Saketini	4	good	
 -89	drinkable Crimboku Drop	3	good	
 -90	practically non-alcoholic acceptable Flaming Crimbo Log	1	good	
--107	tolerable watered-down Fortified Eggnog Slurry	2	good	
+-107	watered-down tolerable Fortified Eggnog Slurry	2	good	
 -108	perfectly mixed Hot Buttered Rum	3	EPIC	
--109	weak tolerable skewed Spicy Hot Chocolate	2	good	
+-109	tolerable weak skewed Spicy Hot Chocolate	2	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Opossum_cafe_food.txt
@@ -1,16 +1,16 @@
 -1	rotten mirror Peche a la Frog	4	crappy	
--2	diet rotten As Jus Gezund Heit	1	crappy	
+-2	rotten diet As Jus Gezund Heit	1	crappy	
 -3	flavorless squat Bouillabaise Coucher Avec Moi	3	decent	
 -7	bland gumdrop chow mein	3	decent	
 -8	big flavorless bouncing candy cane pizza	5	decent	
--9	bland fancy gingerbread stir-fry	4	decent	
+-9	fancy bland gingerbread stir-fry	4	decent	
 -10	toothsome snack-sized squat twigs and gravel	2	awesome	
 -11	stale snack-sized shoots and leaves	2	decent	
--12	miniature fancy yummy jittery bowl of unidentifiable goo	2	awesome	
--13	adequate olive skewed gingerbread massacre	3	good	
+-12	miniature yummy fancy jittery bowl of unidentifiable goo	2	awesome	
+-13	adequate skewed olive gingerbread massacre	3	good	
 -14	normal It Came From Beyond Dessert	4	good	
 -15	normal tumbling vampire cake	3	good	
--52	decent big Soylent Red and Green	5	good	
+-52	big decent Soylent Red and Green	5	good	
 -53	spoiled blue pulsating Disc-Shaped Nutrition Unit	3	crappy	
 -54	spoiled bouncing Gingerborg Hive	3	crappy	
 -61	flavorless super-sized Candy Cane Surprise	5	decent	
@@ -21,8 +21,8 @@
 -69	flavorless diet Red Herring Velvet Cake	1	decent	
 -73	flavorless CRIMBCO Reconstituted Gruel	3	decent	
 -74	tasty New and Improved CRIMBCO Reconstituted Gruel	3	awesome	
--75	spoiled super-sized CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	crappy	
--79	spoiled small Brussels Sprout Stir-Fry	2	crappy	
+-75	super-sized spoiled CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	crappy	
+-79	small spoiled Brussels Sprout Stir-Fry	2	crappy	
 -80	normal mirror Carrot, Cabbage, and Kale Pizza	3	good	
 -81	spoiled Turnip and Rutabaga Pie	3	crappy	
 -85	immense stale Rainbow Spider Fun Roll	8	decent	
@@ -32,14 +32,14 @@
 -93	bland savage macho dog	4	decent	
 -94	adequate one with everything	4	good	
 -95	adequate sly dog	4	good	
--96	gigantic moldy mirror devil dog	6	crappy	
+-96	moldy gigantic mirror devil dog	6	crappy	
 -97	miniature bland chilly dog	2	decent	
 -98	small bland ghost dog	2	decent	
 -99	spoiled junkyard dog	4	crappy	
--100	super-sized flavorless wet dog	5	decent	
--101	diet flavorless sleeping dog	1	decent	
+-100	flavorless super-sized wet dog	5	decent	
+-101	flavorless diet sleeping dog	1	decent	
 -102	toothsome half-sized optimal dog	2	awesome	
--103	small flavorless video games hot dog	2	decent	
--104	normal half-sized Peppermint Nutrition Block	2	good	
+-103	flavorless small video games hot dog	2	decent	
+-104	half-sized normal Peppermint Nutrition Block	2	good	
 -105	bland Gingerbread Nutrition Block	3	decent	
 -106	rotten low-calorie Cinnamon Nutrition Block	1	crappy	

--- a/data/TCRS/TCRS_Accordion_Thief_Packrat.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Packrat.txt
@@ -39,11 +39,11 @@
 40	blinking casino pass	0		
 41	lousy ice-cold Sir Schlitz	4	decent	
 42	hermit permit	0		
-43	jittery gray blinking worthless trinket	0		
+43	gray blinking jittery worthless trinket	0		
 44	jittery worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	figurine	0		
-47	spoiled massive hot buttered roll	7	crappy	
+47	massive spoiled hot buttered roll	7	crappy	
 48	mirror blue heart of rock and roll	0		
 49	decent bowl of cottage cheese	3	good	
 50	pulsating Rock and Roll Legend	0		Item Drop: +5, Class: "Accordion Thief", Song Duration: 10
@@ -51,13 +51,13 @@
 52	olive banjo strings	0		
 53	tumbling Oprah's stone banjo	0		Maximum MP Percent: +50
 54	wool MacGyver's Disco Banjo	0		Maximum MP: +100, Cold Resistance: +1, Class: "Disco Bandit"
-55	yellow tumbling jaba&ntilde;ero pepper	0		
+55	tumbling yellow jaba&ntilde;ero pepper	0		
 56	hot sauce	0		
 57	5-Alarm Saucepan of Flo-Jo	0		Initiative: +100, Class: "Sauceror"
 58	stone turtle	0		
 59	olive slingshot	0		
 60	spinning dance instructor's Mace of the Tortoise	0		Experience Percent (Moxie): +10, Class: "Turtle Tamer"
-61	massive decent gray fortune cookie	6	good	
+61	decent massive gray fortune cookie	6	good	
 62	oriole-feather headdress of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	shaking action figure head	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	banded smartaleck's staff	0		Moxie Percent: +30, Damage Absorption: +100
 104	scarecrow	0		
-105	small bland bowl of charms	2	decent	
+105	bland small bowl of charms	2	decent	
 106	fancy ketchup	1	EPIC	Effect: "Funky Coal Patina", Effect Duration: 35
 107	ghostly catsup	1	awesome	
 108	stick	0		
@@ -136,7 +136,7 @@
 137	dope wheels	0		
 138	ice-cold six-pack	0		
 139	twirling jittery valuable trinket	0		
-140	squat olive dingy planks	0		
+140	olive squat dingy planks	0		
 141	green dingy dinghy	0		
 142	anticheese	0		
 143	twirling cottage	0		
@@ -157,17 +157,17 @@
 158	gray Gnollish pie tin	0		
 159	mirror maroon wad of dough	0		
 160	pie crust	0		
-161	decent half-sized ghuol egg	2	good	
+161	half-sized decent ghuol egg	2	good	
 162	decent ghuol egg quiche	4	good	
 163	foul-smelling skeleton bone	0		Stench Damage: +10
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	immense bland ghuol-ear kabob	7	decent	
+167	bland immense ghuol-ear kabob	7	decent	
 168	miser's bone rattle	0		Meat Drop: +10
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	spinning lihc eye	0		
-171	gigantic adequate lihc eye pie	8	good	
+171	adequate gigantic lihc eye pie	8	good	
 172	gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
@@ -175,9 +175,9 @@
 176	fuchsia disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	stale small upside-down chorizo taco	2	decent	
+179	small stale upside-down chorizo taco	2	decent	
 180	perfectly mixed ghostly ice-cold fotie	3	EPIC	
-181	olive bouncing baseball	0		
+181	bouncing olive baseball	0		
 182	batgut	0		
 183	bat wing	0		
 184	briefcase	0		
@@ -195,7 +195,7 @@
 197	rat whisker	0		
 198	ghostly rat appendix	0		
 199	blurry skewed groovy ring	0		Moxie Percent: +10
-200	spoiled jumbo fuchsia rat appendix kabob	5	crappy	
+200	jumbo spoiled fuchsia rat appendix kabob	5	crappy	
 201	moldy bat wing kabob	3	crappy	
 202	decent carob chunks	3	good	
 203	herbs	0		
@@ -211,7 +211,7 @@
 213	miser's filthy corduroys of the detective	0		Item Drop: +20, Meat Drop: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	thinker's filthy knitted dread sack	0		Mysticality: +10, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	adequate shaking tumbling carob brownies	3	good	
+216	adequate tumbling shaking carob brownies	3	good	
 217	moldy spinning herb brownies	4	crappy	
 218	hemp string	0		
 219	necklace chain	0		
@@ -220,7 +220,7 @@
 222	bouncing phat turquoise bead	0		
 223	groovy phat turquoise bracelet	0		Moxie Percent: +10
 224	aromatic eyepatch	0		Stench Resistance: +1, Familiar Effect: "3xBarrr, cap 6"
-225	tiny adequate olive tofu casserole	1	good	
+225	adequate tiny olive tofu casserole	1	good	
 226	diluted red blurry squat can of Red Minotaur	1	good	
 227	mirror razor-sharp Kentucky-fried meat sword	0		Weapon Damage Percent: +25
 228	sizzling Kentucky-fried meat staff	0		Hot Damage: +10
@@ -237,8 +237,8 @@
 239	jittery Lo Pan's Orcish baseball cap of the sweet-tooth	0		Spell Critical Percent: +30, Candy Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	Fonzie's Orcish cargo shorts of James Dean	0		Experience (Moxie): 4, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	spinning purple stylish Orcish frat-paddle	0		Moxie: +25
-242	flavorless diet	1	decent	
-243	rotten snack-sized grapefruit	2	crappy	
+242	diet flavorless	1	decent	
+243	snack-sized rotten grapefruit	2	crappy	
 244	bland grapes	4	decent	
 245	stale olive	4	decent	
 246	moldy tomato	3	crappy	
@@ -250,18 +250,18 @@
 252	bad bloody beer	3	decent	
 253	strong perfectly mixed shot of schnapps	5	EPIC	
 254	fortified perfectly mixed tumbling blurry shot of grapefruit schnapps	5	EPIC	
-255	acceptable extra-dry ghostly pulsating fine wine	5	good	
+255	extra-dry acceptable ghostly pulsating fine wine	5	good	
 256	hand-crafted blurry shot of tomato schnapps	3	EPIC	
 257	mediocre weak maroon extra-spicy bloody mary	2	decent	
 258	dense meat stack	0		
 259	snake skin	0		
 260	big bland White Citadel fries	5	decent	
-261	spoiled fancy White Citadel burger	3	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 50
+261	fancy spoiled White Citadel burger	3	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 50
 262	stale super-sized huge piece of wedding cake	5	decent	
-263	flavorless miniature chocolate chips	2	decent	
+263	miniature flavorless chocolate chips	2	decent	
 264	bland bite-sized shaking chocolate chip cookies	1	decent	
 265	aromatic satin pants	0		Stench Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
-266	fancy aged practically non-alcoholic lightning	1	awesome	Effect: "Cravin' for a Ravin'", Effect Duration: 30
+266	aged fancy practically non-alcoholic lightning	1	awesome	Effect: "Cravin' for a Ravin'", Effect Duration: 30
 267	upside-down upside-down wholesome mullet wig	0		Maximum HP Percent: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	jittery rosewater-soaked meat cowboy hat	0		Stench Resistance: +3, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	purple sword of the cougar	0		Moxie: +20
@@ -309,10 +309,10 @@
 311	hill of beans	0		
 312	twirling Knob Goblin visor of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	zippy Crown of the Goblin King	0		Initiative: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	special tiny bland olive bean burrito	1	decent	Effect: "Phoenix, Right?", Effect Duration: 30
+314	bland tiny special olive bean burrito	1	decent	Effect: "Phoenix, Right?", Effect Duration: 30
 315	normal immense bean burrito	10	good	
 316	flavorless blinking insanely bean burrito	4	decent	
-317	immense flavorless bean burrito	8	decent	
+317	flavorless immense bean burrito	8	decent	
 318	flavorless bean burrito	3	decent	
 319	adequate fuchsia insanely bean burrito	3	good	
 320	decent wobbly bat haggis	3	good	
@@ -326,7 +326,7 @@
 328	lousy bottle of whiskey	3	decent	
 329	MacGyver's goat beard	0		Maximum MP: +100, Familiar Effect: "atk, 1xPotato, cap 15"
 330	shaking glass of goat's milk	1	good	
-331	tolerable spirit-forward Canadian	5	good	
+331	spirit-forward tolerable Canadian	5	good	
 332	spoiled gigantic lemon	9	crappy	
 333	delicious lime	4	awesome	
 334	twirling crafty sabre teeth	0		Maximum MP: +10
@@ -420,7 +420,7 @@
 422	improved corrupted potion of potency	0		Effect: "Big Meat Big Prizes", Effect Duration: 56
 423	improved green skewed cordial of concentration	0		Effect: "Flamibili Tea", Effect Duration: 34
 424	diffused ointment of the occult	0		Effect: "Disdain of the War Snapper", Effect Duration: 22
-425	non-deionized ghostly lime green oil of expertise	0		Effect: "Cringle's Curative Carol", Effect Duration: 63
+425	non-deionized lime green ghostly oil of expertise	0		Effect: "Cringle's Curative Carol", Effect Duration: 63
 426	alkaline energized narrow potion of temporary gr8ness	0		Effect: "Heart of Green", Effect Duration: 49
 427	frightening box	0		Spooky Damage: +5, Wiki Name: "box"
 428	lime green nothing-in-the-box	0		
@@ -435,7 +435,7 @@
 437	ghostly chef skull	0		
 438	chef-in-the-box	0		
 439	bartender skull	0		
-440	narrow teal bartender-in-the-box	0		
+440	teal narrow bartender-in-the-box	0		
 441	chef-skull-in-the-box	0		
 442	jittery bartender-skull-in-the-box	0		
 443	beer lens	0		
@@ -447,11 +447,11 @@
 449	curative clown nose	0		HP Regen Min: 3, HP Regen Max: 5, Clowniness: 25
 450	pretentious paintbrush	0		
 451	pretentious palette	0		
-452	blue upside-down mirror disease	0		
+452	upside-down blue mirror disease	0		
 453	olive sober pill	0		
 454	screwdriver	0		
 455	moldy gigantic jumbo olive	9	crappy	
-456	watered-down hand-crafted dry martini	2	EPIC	
+456	hand-crafted watered-down dry martini	2	EPIC	
 457	quilted ye olde golde frontes	0		Damage Absorption: +40, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	skewed pixel	0		
@@ -462,7 +462,7 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	blue pixel potion	0		
-467	flavorless thick fancy olive pixel pie	5	decent	Effect: "Innately Strong", Effect Duration: 15
+467	thick fancy flavorless olive pixel pie	5	decent	Effect: "Innately Strong", Effect Duration: 15
 468	blurry ruby W	0		
 469	wussiness potion	0		
 470	extra-dry smooth Imp Ale	5	awesome	
@@ -493,24 +493,24 @@
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	moldy wobbly shaking papaya	4	crappy	
+498	moldy shaking wobbly papaya	4	crappy	
 499	smartaleck's denim axe of the businessman	0		Moxie Percent: +30, Meat Drop: +50
 500	shaking Elf Farm Raffle ticket	0		
-501	flavorless snack-sized tumbling Elfin shortbread	2	decent	
+501	snack-sized flavorless tumbling Elfin shortbread	2	decent	
 502	pagoda plans	0		
-503	miniature stale skewered cat appendix	2	decent	
+503	stale miniature skewered cat appendix	2	decent	
 504	evil arches	0		
 505	blurry toasty Herculean gnatwing earring	0		Experience (Muscle): +1, Hot Damage: +5
-506	bite-sized bland shaking Hell broth	1	decent	
+506	bland bite-sized shaking Hell broth	1	decent	
 507	squat thunderrr guitarrr of the overflowing toilet	0		Stench Spell Damage: +50
 508	sonata	0		
 509	wobbly Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	twirling Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	delicious bite-sized huge Boris's key lime pie	1	awesome	
+513	bite-sized delicious huge Boris's key lime pie	1	awesome	
 514	rotten blinking Jarlsberg's key lime pie	4	crappy	
-515	low-calorie spoiled Sneaky Pete's key lime pie	1	crappy	
+515	spoiled low-calorie Sneaky Pete's key lime pie	1	crappy	
 516	Hey Deze map	0		
 517	Lo Pan's bejeweled accordion strap	0		Spell Critical Percent: +30, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -521,7 +521,7 @@
 523	rewinged stab bat	0		
 524	lousy papaya sling	4	decent	
 525	grue egg	0		
-526	green twirling Frobozz Real-Estate Company Instant House (TM)	0		
+526	twirling green Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	shaking fertilized ghuol egg	0		
@@ -540,7 +540,7 @@
 542	lightning-fast smartaleck's 1337 7r0uZ0RZ	0		Moxie Percent: +30, Initiative: +40, Familiar Effect: "2xPotato, cap 27"
 543	fancy decent fuchsia Trollhouse cookies	3	good	Effect: "Greasy Flavor", Effect Duration: 5
 544	twirling Lo Pan's talons of the sewer	0		Spell Critical Percent: +30, Stench Damage: +25
-545	snack-sized spoiled Spam Witch sammich	2	crappy	
+545	spoiled snack-sized Spam Witch sammich	2	crappy	
 546	meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -549,13 +549,13 @@
 551	64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	adequate half-sized pr0n cocktail	2	good	
+554	half-sized adequate pr0n cocktail	2	good	
 555	skewed dangerous drywall axe of the boozehound	0		Weapon Damage: +10, Booze Drop: +100
 556	bouncing fireproof Pine-Fresh air freshener	0		Hot Resistance: +3
-557	lousy spirit-forward whiskey and cola	5	decent	
+557	spirit-forward lousy whiskey and cola	5	decent	
 558	normal immense skewed papaya taco	6	good	
 559	twirling bouncing razor-sharp can lid	0		
-560	adequate big stalk of asparagus	5	good	
+560	big adequate stalk of asparagus	5	good	
 561	pregnant mushroom	0		
 562	squat ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -564,17 +564,17 @@
 566	nippy bum cheek	0		Cold Damage: +10, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	thick decent blinking Double Bacon Beelzeburger	5	good	
-569	moldy thick Lord of the Flies-sized fries	5	crappy	
-570	moldy half-sized Chicken Sandwich	2	crappy	
+569	thick moldy Lord of the Flies-sized fries	5	crappy	
+570	half-sized moldy Chicken Sandwich	2	crappy	
 571	fuchsia Jumbo Dr. Lucifer	1	good	
 572	adequate wobbly Children's Meal of the Damned	4	good	
-573	low-calorie bland noodles	1	decent	
+573	bland low-calorie noodles	1	decent	
 574	normal ghostly noodles	3	good	
 575	stale upside-down painful penne pasta	3	decent	
-576	half-sized moldy ravioli della hippy	2	crappy	
+576	moldy half-sized ravioli della hippy	2	crappy	
 577	flavorless pr0n m4nic0tti	3	decent	
-578	rotten tiny Hell ramen	1	crappy	
-579	rotten snack-sized boring spaghetti	2	crappy	
+578	tiny rotten Hell ramen	1	crappy	
+579	snack-sized rotten boring spaghetti	2	crappy	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	tumbling Himalayan Hidalgo sauce	0		
@@ -584,7 +584,7 @@
 586	educational ridiculously huge sword of doom	0		Experience: +1, Spooky Spell Damage: +50
 587	quadruple-boiled triple-denatured non-vacuum-sealed skewed super-spiky hair gel	0		Effect: "Castaway Physique", Effect Duration: 16
 588	soft echo eyedrop antidote	0		
-589	flavorless snack-sized cocoa eggshell fragment	2	decent	
+589	snack-sized flavorless cocoa eggshell fragment	2	decent	
 590	bland shaking cocoa eggshell fragment	3	decent	
 591	cocoa egg	0		
 592	house	0		
@@ -644,8 +644,8 @@
 646	rotten huge fruitcake	6	crappy	
 647	present	0		Last Available: "2004-11"
 648	dance instructor's Crimbo sword	0		Experience Percent (Moxie): +10, Last Available: "2004-10"
-649	pulsating nasty Crimbo hat	0		Stench Damage: +5, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	Crimbo pants of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	pulsating nasty Crimbo hat	0		Stench Damage: +5, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	Crimbo pants of James Dean	0		Experience (Moxie): +3, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	spinning green exclusive ultra-rare item of the cheetah	0		Initiative: +60
 652	quantum egg	0		
 653	shaking intragalactic rowboat	0		
@@ -678,7 +678,7 @@
 680	bad boozy slap and tickle	5	decent	
 681	hand-crafted bouncing slip 'n' slide	3	EPIC	
 682	mediocre a sump'm sump'm	4	decent	
-683	fancy lousy skewed green horizontal tango	3	decent	Effect: "Lubed", Effect Duration: 25
+683	fancy lousy green skewed horizontal tango	3	decent	Effect: "Lubed", Effect Duration: 25
 684	drinkable pink pony	3	good	
 685	censurious reassuring grievous Mr. Shirt	0		Weapon Damage Percent: +50, Spooky Resistance: +1, Sleaze Resistance: +3
 686	skewed spinning knuckles of the overflowing toilet	0		Stench Spell Damage: +50
@@ -716,7 +716,7 @@
 720	MacGyver's porquoise necklace of courage	0		Maximum MP: +100, Spooky Resistance: +3, Single Equip
 721	huge reassuring studded porquoise bracelet	0		Damage Absorption: +80, Spooky Resistance: +1
 722	ribald brawny porquoise ring of the detective	0		Muscle Percent: +20, Sleaze Damage: +10, Item Drop: +20, Single Equip
-723	big flavorless Knoll mushroom	5	decent	
+723	flavorless big Knoll mushroom	5	decent	
 724	adequate mushroom	3	good	
 725	one million meat pancakes	0		
 726	Sinatra's huge mirror shard	0		Experience (Moxie): +5
@@ -736,7 +736,7 @@
 740	Jack Frost's tambourine	0		Cold Spell Damage: +50
 741	wobbly broken skull	0		
 742	thick normal Knoll shroomkabob	5	good	
-743	gigantic enchanted bland mushroom	6	decent	Effect: "Salty Mouth", Effect Duration: 5
+743	bland gigantic enchanted mushroom	6	decent	Effect: "Salty Mouth", Effect Duration: 5
 744	double-anodized anodized hair spray	0		Effect: "Shredding, Sweating", Effect Duration: 53
 746	gray stat script	0		
 747	Knob Goblin firecracker	0		
@@ -745,11 +745,11 @@
 750	adequate bouncing mushroom quesadilla	4	good	
 751	stale half-sized cool mushroom	2	decent	
 752	decent cool mushroom casserole	4	good	
-753	massive bland huge pointy mushroom	8	decent	
+753	bland massive huge pointy mushroom	8	decent	
 754	small adequate cream of pointy mushroom soup	2	good	
 755	low-calorie rotten skewed mushroom	1	crappy	
 756	spoiled mushroom	3	crappy	
-757	tiny bland mushroom	1	decent	
+757	bland tiny mushroom	1	decent	
 758	moldy ghost cucumber	4	crappy	
 759	red dill	0		
 760	ghostly vinegar	0		
@@ -786,28 +786,28 @@
 791	Mafia bow tie of the pedagogue of extreme caution	0		Experience: +3, Monster Level: -25, Last Available: "2004-10"
 792	wobbly fireproof Golden Mr. Accessory	0		Hot Resistance: +3, Softcore Only
 793	tarnished unsweetened oil of stability	0		Effect: "Neutered Nostrils", Effect Duration: 56
-794	activated dry upside-down huge oil of slipperiness	0		Effect: "Strange Mental Acuity", Effect Duration: 60
+794	activated dry huge upside-down oil of slipperiness	0		Effect: "Strange Mental Acuity", Effect Duration: 60
 795	bad blurry Acque Luride Grezze Cabernet	4	decent	Last Available: "2004-10"
 796	yellow lion tamer's sharpshooter's ruddy cement shoes	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Experience (familiar): +2, Last Available: "2004-10"
-797	weak artisanal yellow rockin' wagon	2	EPIC	
-798	distilled acceptable bouncing ocean motion	5	good	
+797	artisanal weak yellow rockin' wagon	2	EPIC	
+798	acceptable distilled bouncing ocean motion	5	good	
 799	weak acceptable fuzzbump	2	good	
 800	bland poutine	3	decent	
-801	miniature moldy twirling Knob stir-fry	2	crappy	
+801	moldy miniature twirling Knob stir-fry	2	crappy	
 804	diet bland Knoll stir-fry	1	decent	
-805	big normal blurry stir-fry	5	good	
+805	normal big blurry stir-fry	5	good	
 806	low-calorie adequate asparagus stir-fry	1	good	
 807	stale tiny olive stir-fry	1	decent	
 808	flavorless Knob sausage stir-fry	4	decent	
-809	decent miniature bat wing stir-fry	2	good	
+809	miniature decent bat wing stir-fry	2	good	
 810	spoiled blinking green rat appendix stir-fry	4	crappy	
 811	adequate tofu stir-fry	3	good	
 812	delicious pr0n stir-fry	4	awesome	
-813	moldy small jittery Knob shells	2	crappy	
-814	flavorless thick b&auml;tzle	5	decent	
-815	moldy immense ratini	10	crappy	
+813	small moldy jittery Knob shells	2	crappy	
+814	thick flavorless b&auml;tzle	5	decent	
+815	immense moldy ratini	10	crappy	
 816	bland gigantic Knob stroganoff	6	decent	
-817	big delicious upside-down menudo ravioli	5	awesome	
+817	delicious big upside-down menudo ravioli	5	awesome	
 818	plus sign	0		
 819	mirror milky potion	0		
 820	swirly potion	0		
@@ -833,7 +833,7 @@
 840	flame-retardant groovy Mafia violin case	0		Moxie Percent: +10, Hot Resistance: +1, Last Available: "2004-10"
 841	practically non-alcoholic bad tomato daiquiri	1	decent	
 842	mediocre beertini	3	decent	
-843	drinkable boozy salty slug	5	good	
+843	boozy drinkable salty slug	5	good	
 844	mediocre papaya slung	3	decent	
 845	upside-down nasty MAHI fez	0		Stench Damage: +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -845,7 +845,7 @@
 853	blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
 855	huge balloon knife	0		Familiar Weight: +5
-856	ghostly lime green shock collar	0		
+856	lime green ghostly shock collar	0		
 857	moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	lime green knife and fork	0		Familiar Weight: +5
@@ -857,12 +857,12 @@
 865	lead necklace	0		Familiar Weight: +3
 866	teal shaving cream	0		
 867	anodized pine tar	0		Effect: "Pork Power", Effect Duration: 56
-869	blinking shaking forest tears	0		
+869	shaking blinking forest tears	0		
 870	fetus-smashing club of chilblains	0		Cold Damage: +25
 871	meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
 873	rolling pin	0		
-874	tumbling bouncing unrolling pin	0		
+874	bouncing tumbling unrolling pin	0		
 875	lard-coated occult Rosewater's crazy bastard sword	0		Mysticality Percent: +30, Spell Damage Percent: +25, Sleaze Spell Damage: +25
 876	family-friendly incredibly dense meat gem of the storm of the boozehound	0		Maximum MP Percent: +40, Sleaze Resistance: +1, Booze Drop: +100
 877	maroon stanky Talisman of Baio	0		Stench Spell Damage: +25
@@ -891,9 +891,9 @@
 900	narrow smile-sharpening stone	0		Familiar Weight: +5
 901	twirling espresso maker	0		Familiar Weight: +5
 902	jittery 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	practically non-alcoholic lousy Spasmi Dolorosi Del Rene Champagne	1	decent	Last Available: "2004-10"
-904	avaricious friendly school Mafia knickerbockers of chilblains	0		Familiar Weight: +3, Cold Damage: +25, Meat Drop: +30, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
-905	irradiated galvanized ghostly red Yummy Tummy bean	0		Effect: "damage.enh", Effect Duration: 17
+903	lousy practically non-alcoholic Spasmi Dolorosi Del Rene Champagne	1	decent	Last Available: "2004-10"
+904	avaricious friendly school Mafia knickerbockers of chilblains	0		Familiar Weight: +3, Cold Damage: +25, Meat Drop: +30, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+905	irradiated galvanized red ghostly Yummy Tummy bean	0		Effect: "damage.enh", Effect Duration: 17
 906	altered vacuum-sealed quantum Rock Pops	0		Effect: "Cake Caked", Effect Duration: 61
 907	warmed vacuum-sealed Mr. Mediocrebar	0		Effect: "Dreadful Heat", Effect Duration: 60
 908	warmed mirror Cold Hots candy	0		Effect: "Orchid Blood", Effect Duration: 20
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fireproof forbidden intergalactic pom poms	0		Spell Damage Percent: +50, Hot Resistance: +3
 917	Mob Penguin protection contract	0		
-918	upside-down groovy Radio Free Baseball Cap	0		Moxie Percent: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	Radio Free Pants of the ox	0		Muscle: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	upside-down groovy Radio Free Baseball Cap	0		Moxie Percent: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	Radio Free Pants of the ox	0		Muscle: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	huge wool Radio Free Foil	0		Cold Resistance: +1, Last Available: "2006-07"
 921	super-sized spoiled radio button candy	5	crappy	
 922	stiffened severed rocking horse head	0		Damage Reduction: 1
@@ -918,7 +918,7 @@
 927	delicious gray Ferita Del Petto Zinfandel	4	awesome	Last Available: "2006-12"
 928	yellow up-at-dawn fuzzy bracelets	0		Adventures: +5
 929	mansplainer's arse-shooting crossbow	0		Monster Level: +15
-931	weak aged spiced rum	2	awesome	
+931	aged weak spiced rum	2	awesome	
 932	perfectly mixed eggnog	4	EPIC	
 933	rotten jittery pulsating candy cane	4	crappy	
 934	rotten immense narrow gingerbread bugbear	10	crappy	
@@ -929,9 +929,9 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	huge skewed bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	Da Vinci's bowler	0		Experience (Mysticality): +5, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	Da Vinci's bowler	0		Experience (Mysticality): +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	jittery fireproof brawny bow staff	0		Muscle Percent: +20, Hot Resistance: +3, Last Available: "2004-12"
-944	stiffened bowlegged pants	0		Damage Reduction: 1, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	stiffened bowlegged pants	0		Damage Reduction: 1, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	maroon skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -949,7 +949,7 @@
 959	flange	0		
 960	lime green clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
-962	blurry shaking velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
+962	shaking blurry velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	spinning curative thinker's plastic seal clubber	0		Mysticality: +10, HP Regen Min: 3, HP Regen Max: 5
 964	Jeselnik's forbidden plastic turtle tamer	0		Spell Damage Percent: +50, Sleaze Damage: +25
 965	shaking family-friendly experienced plastic pastamancer	0		Experience: +2, Sleaze Resistance: +1
@@ -989,25 +989,25 @@
 1002	wobbly Xlyinia's notebook of incineration	0		Hot Spell Damage: +50
 1003	soda water	0		
 1004	acceptable bottle of tequila	4	good	
-1005	lousy practically non-alcoholic boxed wine	1	decent	
+1005	practically non-alcoholic lousy boxed wine	1	decent	
 1006	adequate shaking cherry	4	good	
 1007	blurry mirror up-at-dawn coconut shell	0		Adventures: +5, Familiar Effect: "1xFairy, cap 7"
 1008	squat electrified ice cubes	0		MP Regen Min: 3, MP Regen Max: 5
-1009	bad spirit-forward fancy vodka martini	5	decent	Effect: "Feelin' Philosophical", Effect Duration: 5
+1009	fancy spirit-forward bad vodka martini	5	decent	Effect: "Feelin' Philosophical", Effect Duration: 5
 1010	artisanal whiskey and soda	3	EPIC	
-1011	bad watered-down blinking monkey wrench	2	decent	
-1012	hand-crafted high-proof tequila sunrise	10	EPIC	
+1011	watered-down bad blinking monkey wrench	2	decent	
+1012	high-proof hand-crafted tequila sunrise	10	EPIC	
 1013	lousy margarita	3	decent	
-1014	watered-down lousy bouncing strawberry wine	2	decent	
+1014	lousy watered-down bouncing strawberry wine	2	decent	
 1015	smooth shaking wine spritzer	3	awesome	
-1016	drinkable practically non-alcoholic perpendicular hula	1	good	
+1016	practically non-alcoholic drinkable perpendicular hula	1	good	
 1017	acceptable green ducha de oro	3	good	
 1018	perfectly mixed bouncing calle de miel	4	EPIC	
 1019	lousy dry vodka martini	4	decent	
-1020	mediocre irresponsibly strong old-fashioned	6	decent	
-1021	mediocre enchanted blue tequila with training wheels	3	decent	Effect: "Psalm of Pointiness", Effect Duration: 35
+1020	irresponsibly strong mediocre old-fashioned	6	decent	
+1021	enchanted mediocre blue tequila with training wheels	3	decent	Effect: "Psalm of Pointiness", Effect Duration: 35
 1022	spirit-forward acceptable mirror sangria	5	good	
-1023	practically non-alcoholic tolerable spinning vesper	1	good	Last Available: "2004-12"
+1023	tolerable practically non-alcoholic spinning vesper	1	good	Last Available: "2004-12"
 1024	perfectly mixed fancy practically non-alcoholic bodyslam	1	super ultra mega turbo EPIC	Effect: "Haunted Liver", Effect Duration: 25, Last Available: "2004-12"
 1025	tolerable ghostly sangria del diablo	3	good	Last Available: "2004-12"
 1026	wobbly Valentine	0		Free Pull
@@ -1029,33 +1029,33 @@
 1043	string of beads of the pedagogue	0		Experience: +3
 1044	spinning string of beads of the cougar	0		Moxie: +20
 1045	careful plastic bottle opener	0		Monster Level: -10
-1046	banded traffic cone of the brazier	0		Damage Absorption: +100, Hot Spell Damage: +25, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	banded traffic cone of the brazier	0		Damage Absorption: +100, Hot Spell Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	watered-down tolerable huge N. O. Beer	2	good	
 1048	pickled bouncing oyster egg	1		
-1049	vaporized upside-down spinning gray oyster egg	1		
+1049	vaporized gray spinning upside-down oyster egg	1		
 1050	modified spinning oyster egg	1		
 1051	skewed plastic oyster egg	0		
-1052	mixed huge teal narrow oyster egg	1		
-1053	distilled wobbly olive oyster egg	1		
-1054	compressed lime green spinning oyster egg	1		
-1055	pulsating jittery plastic oyster egg	0		
+1052	mixed narrow huge teal oyster egg	1		
+1053	distilled olive wobbly oyster egg	1		
+1054	compressed spinning lime green oyster egg	1		
+1055	jittery pulsating plastic oyster egg	0		
 1056	distilled squat puce oyster egg	1		
 1057	distilled skewed mirror puce oyster egg	1		Effect: "Ancient Protected", Effect Duration: 25
 1058	dehydrated spinning puce oyster egg	1		Effect: "Violent Night", Effect Duration: 10
 1059	olive narrow puce plastic oyster egg	0		
-1060	altered cyan upside-down mauve oyster egg	1		Effect: "A Taste of Rainbow", Effect Duration: 15
-1061	altered narrow jittery mauve oyster egg	1		
+1060	altered upside-down cyan mauve oyster egg	1		Effect: "A Taste of Rainbow", Effect Duration: 15
+1061	altered jittery narrow mauve oyster egg	1		
 1062	altered tumbling mauve oyster egg	1		
 1063	wobbly mauve plastic oyster egg	0		
 1064	altered oyster egg	1		Effect: "Deadly Flashing Blade", Effect Duration: 10
 1065	mixed narrow oyster egg	1		Effect: "Stogied", Effect Duration: 5
 1066	denatured oyster egg	1		
 1067	plastic oyster egg	0		
-1068	altered shaking twirling purple oyster egg	1		
-1069	vaporized twirling tumbling oyster egg	1		
+1068	altered purple shaking twirling oyster egg	1		
+1069	vaporized tumbling twirling oyster egg	1		
 1070	dehydrated narrow yellow oyster egg	1		
 1071	skewed plastic oyster egg	0		
-1072	altered upside-down ghostly off-white oyster egg	1		
+1072	altered ghostly upside-down off-white oyster egg	1		
 1073	altered off-white oyster egg	1		Effect: "Nut-Rition", Effect Duration: 5
 1074	dehydrated off-white oyster egg	1		
 1075	maroon off-white plastic oyster egg	0		
@@ -1093,7 +1093,7 @@
 1107	clockwork maid head	0		
 1108	twirling clockwork detective skull	0		
 1109	green spinning twirling clockwork bartender-head-in-the-box	0		
-1110	bouncing fuchsia clockwork chef-head-in-the-box	0		
+1110	fuchsia bouncing clockwork chef-head-in-the-box	0		
 1111	huge clockwork bartender-in-the-box	0		
 1112	clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
@@ -1123,24 +1123,24 @@
 1137	red clever bicycle chain of mayonnaise	0		Maximum MP: +20, Sleaze Spell Damage: +50
 1138	mirror mushroom fermenting solution	0		
 1139	lousy wobbly mushroom wine	3	decent	
-1140	fancy artisanal icy mushroom wine	3	EPIC	Effect: "Warm Shoulders", Effect Duration: 45
+1140	artisanal fancy icy mushroom wine	3	EPIC	Effect: "Warm Shoulders", Effect Duration: 45
 1141	perfectly mixed ghostly upside-down mushroom wine	4	EPIC	
 1142	acceptable cyan pointy mushroom wine	3	good	
 1143	mediocre watered-down teal flat mushroom wine	2	decent	
 1144	drinkable spirit-forward cool mushroom wine	5	good	
 1145	boozy artisanal knob mushroom wine	5	EPIC	
-1146	practically non-alcoholic tolerable special knoll mushroom wine	1	good	Effect: "Bolts about Candy", Effect Duration: 25
+1146	practically non-alcoholic special tolerable knoll mushroom wine	1	good	Effect: "Bolts about Candy", Effect Duration: 25
 1147	mediocre practically non-alcoholic mushroom wine	1	decent	
 1148	hand-crafted blinking tumbling shot of flower schnapps	4	EPIC	
-1149	thick toothsome flower petal pie	5	awesome	
+1149	toothsome thick flower petal pie	5	awesome	
 1150	bad watered-down skewed huge bottle of single-barrel whiskey	2	decent	
 1151	stylish discarded plastic fork of courage	0		Moxie: +25, Spooky Resistance: +3
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	normal small ghostly mirror Retenez L'Herbe Pat&eacute;	2	good	
+1153	normal small mirror ghostly Retenez L'Herbe Pat&eacute;	2	good	
 1154	twisted Breathetastic&trade; Premium Canned Air	1	good	Effect: "Patent Avarice", Effect Duration: 5
 1155	letter from King Ralph XI	0		
 1157	cyan wholeberd of Gandalf	0		Spell Critical Percent: +20
-1158	concentrated purple blurry Meleegra&trade; pills	0		Effect: "The Dinsey Way", Effect Duration: 14
+1158	concentrated blurry purple Meleegra&trade; pills	0		Effect: "The Dinsey Way", Effect Duration: 14
 1159	mariachi G-string	0		
 1160	electrified irate sombrero	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
@@ -1162,7 +1162,7 @@
 1177	fuchsia magnetic field	0		
 1178	potted cactus	0		
 1179	green daisy	0		
-1180	bouncing maroon potted fern	0		
+1180	maroon bouncing potted fern	0		
 1181	tulip	0		
 1182	Venus flytrap	0		
 1183	all-purpose flower	0		
@@ -1183,15 +1183,15 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	adequate bite-sized red mugcake	1	good	
-1201	flavorless jumbo urinal cake	5	decent	
-1202	gigantic rotten Happy Birthday, Claude! cake	9	crappy	
-1203	miniature special flavorless twirling upside-down bouncing personalized birthday cake	2	decent	Effect: "Perception", Effect Duration: 30
+1201	jumbo flavorless urinal cake	5	decent	
+1202	rotten gigantic Happy Birthday, Claude! cake	9	crappy	
+1203	special miniature flavorless twirling bouncing upside-down personalized birthday cake	2	decent	Effect: "Perception", Effect Duration: 30
 1204	bland three-tiered wedding cake	3	decent	
 1205	flavorless upside-down babycakes	3	decent	
 1206	stale jumbo velvet cake	5	decent	
 1207	spoiled congratulatory cake	3	crappy	
 1208	small moldy angel-food cake	2	crappy	
-1209	normal super-sized skewed wobbly devil's-food cake	5	good	
+1209	super-sized normal skewed wobbly devil's-food cake	5	good	
 1210	adequate birthday party jellybean cheesecake	3	good	
 1211	balloon	0		
 1212	balloon	0		
@@ -1200,7 +1200,7 @@
 1215	Mylar balloon	0		
 1216	gray Kevlar balloon	0		
 1217	thought balloon	0		
-1218	skewed jittery rat head balloon	0		Familiar Weight: -3
+1218	jittery skewed rat head balloon	0		Familiar Weight: -3
 1219	mini-zeppelin	0		
 1220	Mr. Balloon of doom	0		Spooky Spell Damage: +50
 1221	twirling upside-down green balloon	0		
@@ -1238,14 +1238,14 @@
 1254	toothsome pulsating jumping bean burrito	3	awesome	
 1255	spoiled shaking jumping bean burrito	3	crappy	
 1256	diet adequate insanely jumping bean burrito	1	good	
-1257	huge bland ghostly rat scrapple	7	decent	
+1257	bland huge ghostly rat scrapple	7	decent	
 1258	pail of pretentious paint	0		
-1259	huge twirling Rosewater's beefcake's traffic cone	0		Muscle: +25, Mysticality Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	huge twirling Rosewater's beefcake's traffic cone	0		Muscle: +25, Mysticality Percent: +30, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	blue wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	denatured shaking blinking Hatorade	1		
+1261	denatured blinking shaking Hatorade	1		
 1262	shaking auspicious smelly manspreader's off-hand balloon	0		Monster Level: +10, Stench Spell Damage: +10, Item Drop: +10
 1263	upside-down pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
-1264	jittery gray nose-bone fetish	0		Last Available: "2011-12"
+1264	gray jittery nose-bone fetish	0		Last Available: "2011-12"
 1265	jittery box of sunshine	0		Free Pull
 1266	adequate gloomy mushroom	4	good	
 1267	dead mimic	0		
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	shaking doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	mirror auspicious vibrating traffic cone	0		Maximum MP Percent: +10, Item Drop: +10, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	mirror auspicious vibrating traffic cone	0		Maximum MP Percent: +10, Item Drop: +10, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	tumbling attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	tiny toothsome questionable taco	1	awesome	
 1321	blinking Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	stylish time helmet	0		Moxie: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	foul-smelling time trousers	0		Stench Damage: +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	stylish time helmet	0		Moxie: +25, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	foul-smelling time trousers	0		Stench Damage: +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	squat therapeutic time sword	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2005-10"
 1326	red chilly Dyspepsi-Cola helmet	0		Cold Damage: +5, Familiar Effect: "3xFairy, cap 7"
 1327	tumbling Cloaca-Cola shield of the bloodbag	0		Maximum HP: +100, Damage Reduction: 4
@@ -1318,7 +1318,7 @@
 1334	Cloaca-Cola	0		
 1335	Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
-1338	yellow blurry mirror Dyspepsi-Cola d-rations	0		
+1338	yellow mirror blurry Dyspepsi-Cola d-rations	0		
 1339	Cloaca-Cola c-rations	0		
 1340	Cloaca-Cola-issue combat knife	0		
 1341	jittery Herculean Dyspepsi-Cola-issue canteen	0		Experience (Muscle): +1, Single Equip
@@ -1384,14 +1384,14 @@
 1402	wobbly rag doll of the cougar	0		Moxie: +20, Last Available: "2005-12"
 1403	blurry smartaleck's can of fake snow	0		Moxie Percent: +30, Last Available: "2005-12"
 1404	colored-light &quot;necklace&quot; of Leguizamo	0		Monster Level: +20, Last Available: "2005-12"
-1405	tree skirt of the wise owl	0		Mysticality: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	tree skirt of the wise owl	0		Mysticality: +20, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	snack-sized decent wreath-shaped Crimbo cookie	2	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	adequate jumbo narrow huge bell-shaped Crimbo cookie	5	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	adequate jumbo huge narrow bell-shaped Crimbo cookie	5	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	rotten tree-shaped Crimbo cookie	4	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	sizzling Unionize The Elves sign	0		Hot Damage: +10, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
-1412	polarized pickled ghostly tumbling snowcone	0		Effect: "Human-Fish Hybrid", Effect Duration: 18, Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1412	polarized pickled tumbling ghostly snowcone	0		Effect: "Human-Fish Hybrid", Effect Duration: 18, Last Available: "2006-01"
 1413	energized triple-Vulcanized snowcone	0		Effect: "Bat Attitude", Effect Duration: 48, Last Available: "2006-01"
 1414	frozen vacuum-sealed green snowcone	0		Effect: "Locks Like the Raven", Effect Duration: 48, Last Available: "2006-01"
 1415	polarized non-frozen snowcone	0		Effect: "Tightly-Wound Spine", Effect Duration: 68, Last Available: "2006-01"
@@ -1399,13 +1399,13 @@
 1417	electrified snowcone	0		Effect: "Go-Gone", Effect Duration: 56, Last Available: "2006-01"
 1418	mirror Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	shaking sizzling careful traffic cone	0		Monster Level: -10, Hot Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	shaking sizzling careful traffic cone	0		Monster Level: -10, Hot Damage: +10, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	skewed Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	squat wobbly flame-wreathed ice sickle of the bloodbag	0		Maximum HP: +100, Hot Spell Damage: +10, Softcore Only, Last Available: "2006-02"
 1425	mirror censurious ice baby	0		Sleaze Resistance: +3, Softcore Only, Last Available: "2006-02"
-1426	Oprah's ice pick	0		Maximum MP Percent: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	Oprah's ice pick	0		Maximum MP Percent: +50, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	Newton's ice skates of vim and vigor	0		Experience (Mysticality): +3, Maximum HP Percent: +50, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	flavorless grue egg omelette	4	decent	
 1429	yellow roll of drink tickets	0		
@@ -1416,24 +1416,24 @@
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
-1437	narrow ghostly bouncing useless powder	0		
-1438	pressed blinking fuchsia twinkly powder	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 37
+1437	bouncing narrow ghostly useless powder	0		
+1438	pressed fuchsia blinking twinkly powder	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 37
 1439	concentrated hot powder	0		Effect: "Night of the Nachos", Effect Duration: 32
 1440	diffused tarnished mirror powder	0		Effect: "Bells in the Batfry", Effect Duration: 11
 1441	tarnished oxidized powder	0		Effect: "Punchy, Murdery", Effect Duration: 14
 1442	dry squat stench powder	0		Effect: "Intimidating Mien", Effect Duration: 65
-1443	cold-filtered spinning bouncing pulsating sleaze powder	0		Effect: "Headstrong", Effect Duration: 59
+1443	cold-filtered bouncing pulsating spinning sleaze powder	0		Effect: "Headstrong", Effect Duration: 59
 1444	non-anodized maroon twinkly nuggets	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 59
 1445	aerosolized polarized hot nuggets	0		Effect: "Rain Dancin'", Effect Duration: 60
 1446	anodized nuggets	0		Effect: "Dirty Pear", Effect Duration: 54
 1447	flattened spinning nuggets	0		Effect: "Permanent Halloween", Effect Duration: 25
 1448	flattened frozen upside-down stench nuggets	0		Effect: "Super Speed", Effect Duration: 18
 1449	extra-polymerized diffused red sleaze nuggets	0		Effect: "Inner Warmth", Effect Duration: 43
-1450	mixed blurry narrow twinkly wad	1		
+1450	mixed narrow blurry twinkly wad	1		
 1451	twisted huge blurry hot wad	1		
 1452	pickled bouncing wad	1		
 1453	powdered wad	1		
-1454	vaporized squat huge lime green stench wad	1		Effect: "Sweet Nostalgia", Effect Duration: 25
+1454	vaporized squat lime green huge stench wad	1		Effect: "Sweet Nostalgia", Effect Duration: 25
 1455	powdered twirling sleaze wad	1		Effect: "Surreally Buff", Effect Duration: 5
 1456	squat double daisy	0		
 1457	Goth Giant	0		
@@ -1457,7 +1457,7 @@
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	bouncing goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	plastic hard hat	0		Familiar Effect: "atk, cap 22"
-1478	bouncing blue salad bowl	0		Familiar Effect: "atk, cap 30"
+1478	blue bouncing salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	green shaking blurry football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
@@ -1474,10 +1474,10 @@
 1492	Annie Oakley's ninja mop	0		Critical Hit Percent: +20
 1493	tumbling teal executive scorching ridiculously overelaborate ninja weapon	0		Hot Damage: +25, Meat Drop: +40
 1494	super-alkaline pickled squat sugar-coated pine cone	0		Effect: "Happy Trails", Effect Duration: 25, Last Available: "2020-09"
-1495	toasty traffic cone of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	toasty traffic cone of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	artisanal gloomy mushroom wine	4	EPIC	
 1497	artisanal mushroom wine	4	EPIC	
-1498	shaking McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	shaking McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	tumbling fake fake vomit	0		Last Available: "2006-04"
 1501	pickled boiled enhanced squat gray blinking explosion-flavored chewing gum	0		Effect: "Think Win-Lose", Effect Duration: 22, Last Available: "2006-04"
@@ -1485,8 +1485,8 @@
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	vacuum-sealed frozen snowcone	0		Effect: "Winklered", Effect Duration: 63, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	extra-dry lousy fancy calle de miel with a fly in it	5	decent	Effect: "Marinated", Effect Duration: 30, Last Available: "2006-04"
-1507	perfectly mixed maroon pulsating rockin' wagon with a fly in it	4	EPIC	Last Available: "2006-04"
+1506	extra-dry fancy lousy calle de miel with a fly in it	5	decent	Effect: "Marinated", Effect Duration: 30, Last Available: "2006-04"
+1507	perfectly mixed pulsating maroon rockin' wagon with a fly in it	4	EPIC	Last Available: "2006-04"
 1508	acceptable fancy perpendicular hula with a fly in it	3	good	Effect: "You Can Taste the Darkness", Effect Duration: 20, Last Available: "2006-04"
 1509	lousy irresponsibly strong upside-down slap and tickle with a fly in it	7	decent	Last Available: "2006-04"
 1510	cyan bag of airline peanuts	0		Last Available: "2006-04"
@@ -1494,7 +1494,7 @@
 1512	boiled teal Knob Goblin pet-buffing spray	1		
 1513	twisted squat Knob Goblin learning pill	1		Effect: "Bright!", Effect Duration: 5
 1514	dried narrow Knob Goblin eyedrops	1		
-1515	diluted blinking jittery Knob Goblin nasal spray	1		Effect: "Hair on Your Chest", Effect Duration: 30
+1515	diluted jittery blinking Knob Goblin nasal spray	1		Effect: "Hair on Your Chest", Effect Duration: 30
 1516	KWE-brand transistor radio	0		
 1518	narrow vampire heart	0		
 1519	cyan Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1503,30 +1503,30 @@
 1522	blurry green shaking perfumed Socratic Radio Free Jersey	0		Experience (Mysticality): +1, Stench Resistance: +5
 1523	bottle of used blood	0		
 1524	tumbling wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	blue pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	blue pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Temple Grandin's arcane researcher's corkscrew	0		Experience Percent (Mysticality): +10, Familiar Weight: +7, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	purple fake plastic grass	0		Last Available: "2011-01"
-1531	prompt grass skirt	0		Adventures: +3, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	cyan lard-coated grass hat	0		Sleaze Spell Damage: +25, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	prompt grass skirt	0		Adventures: +3, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	cyan lard-coated grass hat	0		Sleaze Spell Damage: +25, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	Sinatra's grass blade	0		Experience (Moxie): +5, Last Available: "2011-01"
-1534	jittery blue raffle prize box	0		
+1534	blue jittery raffle prize box	0		
 1536	squat homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	wobbly weegee sqouija	0		Last Available: "2011-12"
 1538	gray forbidden sparkly engagement ring	0		Spell Damage Percent: +50, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	red padded Grimacite goggles of the ox	0		Muscle: +20, Damage Absorption: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	red padded Grimacite goggles of the ox	0		Muscle: +20, Damage Absorption: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	thinker's Grimacite glaive of the ox	0		Muscle: +20, Mysticality: +10, Last Available: "2008-10"
-1542	coward's beefcake's Grimacite greaves	0		Muscle: +25, Monster Level: -20, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	coward's beefcake's Grimacite greaves	0		Muscle: +25, Monster Level: -20, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	manspreader's curative Grimacite garter	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-10"
 1544	skewed mansplainer's Grimacite galoshes of the pedagogue	0		Experience: +3, Monster Level: +15, Last Available: "2008-10"
 1545	bouncing forbidden strapping Grimacite gorget	0		Muscle: +5, Spell Damage Percent: +50, Last Available: "2008-10"
 1546	upside-down Grimacite guayabera of Tarzan	0		Experience (Muscle): +3, Last Available: "2008-10"
 1547	olive frightening nasty Codex of Capsaicin Conjuration	0		Stench Damage: +5, Spooky Damage: +5
 1548	knitted crafty Gazpacho's Glacial Grimoire	0		Maximum MP: +10, Cold Resistance: +3
-1549	purple wobbly MSG	0		
+1549	wobbly purple MSG	0		
 1550	twirling lightning-fast second-hand knockoff engagement ring	0		Initiative: +40, Single Equip
 1551	perfectly mixed cyan bottle of Domesticated Turkey	3	EPIC	
 1552	perfectly mixed bottle of Definit	4	EPIC	
@@ -1536,13 +1536,13 @@
 1556	hand-crafted jittery boxed champagne	4	EPIC	
 1557	tasty special kumquat	4	awesome	Effect: "Piratastic", Effect Duration: 40
 1558	adequate huge tangerine	4	good	
-1559	blinking tumbling tonic water	0		
+1559	tumbling blinking tonic water	0		
 1560	delicious cocktail onion	4	awesome	
-1561	bland special snack-sized raspberry	2	decent	Effect: "Super Speed", Effect Duration: 20
+1561	snack-sized special bland raspberry	2	decent	Effect: "Super Speed", Effect Duration: 20
 1562	huge delicious narrow kiwi	10	awesome	
 1563	artisanal whiskey bittersweet	3	EPIC	
 1564	hand-crafted mimosette	3	EPIC	
-1565	hand-crafted high-proof jittery tequila sunset	7	EPIC	
+1565	high-proof hand-crafted jittery tequila sunset	7	EPIC	
 1566	hand-crafted zmobie	3	EPIC	Wiki Name: "Zmobie (drink)"
 1567	hand-crafted olive gin and tonic	3	EPIC	
 1568	delicious vodka and tonic	4	awesome	
@@ -1550,10 +1550,10 @@
 1570	drinkable fortified gibson	5	good	
 1571	tolerable watered-down parisian cathouse	2	good	
 1572	mediocre rabbit punch	4	decent	
-1573	distilled enchanted perfectly mixed gray caipifruta	5	EPIC	Effect: "Eye of the Lihc", Effect Duration: 25
+1573	distilled perfectly mixed enchanted gray caipifruta	5	EPIC	Effect: "Eye of the Lihc", Effect Duration: 25
 1574	lousy teqiwila	3	decent	
 1575	practically non-alcoholic perfectly mixed Divine	1	super ultra mega turbo EPIC	
-1576	perfectly mixed watered-down Gordon Bennett	2	super ultra EPIC	
+1576	watered-down perfectly mixed Gordon Bennett	2	super ultra EPIC	
 1577	perfectly mixed squat tangarita	3	EPIC	
 1578	spirit-forward aged cyan narrow mandarina colada	5	awesome	
 1579	artisanal gimlet	4	EPIC	
@@ -1561,17 +1561,17 @@
 1581	smooth vodka stratocaster	4	awesome	
 1582	mediocre twirling Neuromancer	3	decent	
 1583	perfectly mixed prussian cathouse	3	EPIC	
-1584	practically non-alcoholic tolerable jittery Mae West	1	good	
-1585	perfectly mixed extra-dry special Mon Tiki	5	EPIC	Effect: "Stuck-Up Hair", Effect Duration: 50
-1586	strong tolerable teqiwila slammer	5	good	
-1587	spoiled thick Knob lo mein	5	crappy	
+1584	tolerable practically non-alcoholic jittery Mae West	1	good	
+1585	extra-dry special perfectly mixed Mon Tiki	5	EPIC	Effect: "Stuck-Up Hair", Effect Duration: 50
+1586	tolerable strong teqiwila slammer	5	good	
+1587	thick spoiled Knob lo mein	5	crappy	
 1588	spoiled upside-down asparagus lo mein	3	crappy	
 1589	adequate narrow Knoll lo mein	4	good	
-1590	rotten maroon upside-down spinning lo mein	4	crappy	
+1590	rotten spinning upside-down maroon lo mein	4	crappy	
 1591	flavorless olive lo mein	4	decent	
 1592	stale hot hi mein	3	decent	
-1593	yummy small hi mein	2	awesome	
-1594	adequate jumbo mirror hi mein	5	good	
+1593	small yummy hi mein	2	awesome	
+1594	jumbo adequate mirror hi mein	5	good	
 1595	toothsome hi mein	4	awesome	
 1596	moldy fancy wobbly sleazy hi mein	3	crappy	Effect: "Peppermint Bite", Effect Duration: 50
 1597	spinning nippy Junior LAAAAME merit badge	0		Cold Damage: +10, Last Available: "2006-05"
@@ -1592,13 +1592,13 @@
 1612	non-tarnished tarnished concentrated cordial of concentration	0		Effect: "Eagle Eyes", Effect Duration: 34
 1613	nasty coffin lid	0		Stench Damage: +5, Damage Reduction: 3
 1614	wool satin shield	0		Cold Resistance: +1, Damage Reduction: 5
-1615	Cerebral Cloche	0		Item Drop: +5, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	cool Cerebral Culottes	0		Moxie: +5, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	Cerebral Cloche	0		Item Drop: +5, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	cool Cerebral Culottes	0		Moxie: +5, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	green sharpshooter's shellacked padded Cerebral Crossbow	0		Damage Absorption: +20, Damage Reduction: 7, Critical Hit Percent: +10, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
 1620	homeopathic healing powder	0		Last Available: "2006-06"
-1621	pulsating shaking astral badger	0		Free Pull, Last Available: "2006-06"
+1621	shaking pulsating astral badger	0		Free Pull, Last Available: "2006-06"
 1622	corrupted dry astral mushroom	0		Effect: "Warm Shoulders", Effect Duration: 28, Last Available: "2006-06"
 1623	badger badge	0		Last Available: "2006-06"
 1624	unsweetened blue-frosted astral cupcake	0		Effect: "You're High as a Crow, Marty", Effect Duration: 49, Last Available: "2006-06"
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	immense flavorless foie gras	6	decent	
 1652	galvanized candy brain	0		Effect: "Grrrrrrreat!", Effect Duration: 64, Last Available: "2020-09"
-1653	olive vibrating arcane researcher's jewel-eyed wizard hat of the boozehound	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +10, Booze Drop: +100, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	olive vibrating arcane researcher's jewel-eyed wizard hat of the boozehound	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +10, Booze Drop: +100, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	auspicious double-paned wad of Crovacite	0		Cold Resistance: +5, Item Drop: +10
 1655	wobbly sage collar of the glutton	0		Mysticality Percent: +10, Food Drop: +100
 1656	White Citadel Satisfaction Satchel	0		
@@ -1647,7 +1647,7 @@
 1667	upside-down Cat-Herding Prod of the ox	0		Muscle: +20
 1668	executive star boomerang	0		Meat Drop: +40
 1669	wizardly star stiletto	0		Mysticality: +25
-1670	bouncing red ghostly fraudwort	0		
+1670	ghostly bouncing red fraudwort	0		
 1671	shysterweed	0		
 1672	squat squat swindleblossom	0		
 1673	nasty grave robbing shovel of the early riser	0		Stench Damage: +5, Adventures: +7
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	blinking styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	narrow supercharged sword of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25
 1680	wobbly shellacked staff of incineration	0		Damage Reduction: 7, Hot Spell Damage: +50
 1681	spinning flame-retardant beefcake's bubblewrap sword	0		Muscle: +25, Hot Resistance: +1
@@ -1673,15 +1673,15 @@
 1693	dry blinking narrow eyedrops of newt	0		Effect: "Frosty the Hitman", Effect Duration: 38
 1694	double-alkaline triple-activated Frogade	0		Effect: "Bureaucratized", Effect Duration: 20
 1695	adjusted enhanced bouncing papotion of papower	0		Effect: "Greasy Visage", Effect Duration: 12
-1696	immense stale squat ghostly royal jelly taco	8	decent	
+1696	immense stale ghostly squat royal jelly taco	8	decent	
 1697	normal tofu taco	4	good	
 1698	yummy jumping bean taco	3	awesome	
 1699	bland catgut taco	4	decent	
-1700	normal fancy goat cheese taco	4	good	Effect: "Mutated", Effect Duration: 45
+1700	fancy normal goat cheese taco	4	good	Effect: "Mutated", Effect Duration: 45
 1701	normal pr0n taco	4	good	
 1702	super-unsweetened alphabet gum	0		Effect: "Sappy Blood", Effect Duration: 54
 1703	ghostly Comma Chameleon egg	0		Free Pull
-1704	tumbling red upside-down shingle	0		
+1704	upside-down tumbling red shingle	0		
 1705	blurry flaregun	0		
 1706	narrow miser's rosewater-soaked sword of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +3, Meat Drop: +10
 1707	shaking flypaper staff of the bloodbag of Leguizamo of bravery	0		Maximum HP: +100, Monster Level: +20, Spooky Resistance: +5
@@ -1750,11 +1750,11 @@
 1771	sharpshooter's butcherknife	0		Critical Hit Percent: +10
 1772	Socratic corn holder	0		Experience (Mysticality): +1
 1773	twirling crafty eggbeater	0		Maximum MP: +10
-1774	tolerable enchanted bottle of popskull	3	good	Effect: "Sepia Tan", Effect Duration: 25
+1774	enchanted tolerable bottle of popskull	3	good	Effect: "Sepia Tan", Effect Duration: 25
 1775	dishrag of the businessman	0		Meat Drop: +50
 1776	bland shaking stale baguette	3	decent	
 1777	blurry leftovers of indeterminate origin	0		
-1778	fancy rotten dinner	3	crappy	Effect: "Natural 20", Effect Duration: 10
+1778	rotten fancy dinner	3	crappy	Effect: "Natural 20", Effect Duration: 10
 1779	MacGyver's katana	0		Maximum MP: +100
 1780	narrow wool ram stick	0		Cold Resistance: +1
 1781	coward's enchantlers	0		Monster Level: -20, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	acceptable high-proof Ram's Face Lager	6	good	
 1791	ram horns	0		
-1792	wobbly stanky dangerous Fonzie's Travoltan trousers	0		Experience (Moxie): +1, Weapon Damage: +10, Stench Spell Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	wobbly stanky dangerous Fonzie's Travoltan trousers	0		Experience (Moxie): +1, Weapon Damage: +10, Stench Spell Damage: +25, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	Da Vinci's pool cue	0		Experience (Mysticality): +5, Item Drop: +5
 1794	energized oxidized handful of hand chalk	0		Effect: "Tingling Feeling", Effect Duration: 55
 1795	blue executive Counterclockwise Watch	0		Meat Drop: +40, Single Equip
@@ -1803,7 +1803,7 @@
 1824	fourth lumbar vertebra	0		
 1825	fifth lumbar vertebra	0		
 1826	shaking sixth lumbar vertebra	0		
-1827	blinking tumbling seventh lumbar vertebra	0		
+1827	tumbling blinking seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
 1829	first caudal vertebra	0		
 1830	ghostly second caudal vertebra	0		
@@ -1848,7 +1848,7 @@
 1869	right humerus	0		
 1870	shaking left radius	0		
 1871	mirror right radius	0		
-1872	ghostly squat twirling left ulna	0		
+1872	twirling squat ghostly left ulna	0		
 1873	right ulna	0		
 1874	left femur	0		
 1875	right femur	0		
@@ -1930,7 +1930,7 @@
 1953	aged practically non-alcoholic narrow flute of flat champagne	1	awesome	
 1954	rotten dehydrated caviar	3	crappy	
 1955	pulsating styrofoam peanuts	0		
-1956	lousy high-proof snifter of thoroughly aged brandy	10	decent	
+1956	high-proof lousy snifter of thoroughly aged brandy	10	decent	
 1957	lime green quill pen	0		
 1958	skewed inkwell	0		
 1959	lime green tattered scrap of paper	0		
@@ -1943,7 +1943,7 @@
 1966	narrow lion tamer's Amulet of Yendor of the brute	0		Muscle Percent: +30, Experience (familiar): +2, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	teal bottle of perfume	0		Familiar Weight: +5
-1969	bouncing purple spoon!	0		Familiar Weight: +5
+1969	purple bouncing spoon!	0		Familiar Weight: +5
 1970	squat nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	wholesome brainy shrimp fork	0		Mysticality: +5, Maximum HP Percent: +10
@@ -1960,7 +1960,7 @@
 1983	hand turkey	0		
 1984	snowy owl	0		
 1985	shaking purple scary death orb	0		
-1986	pulsating mirror mind flayer	0		
+1986	mirror pulsating mind flayer	0		
 1987	ghostly wobbly undead elbow macaroni	0		
 1988	angry cow	0		
 1989	Cheshire bitten	0		
@@ -1998,10 +1998,10 @@
 2021	spoiled gray strawberry pie	3	crappy	
 2022	delicious lemon meringue pie	4	awesome	
 2023	fuchsia Genalen&trade; Bottle	1	decent	
-2024	rotten miniature spinning mixed wildflower greens	2	crappy	
+2024	miniature rotten spinning mixed wildflower greens	2	crappy	
 2025	bland handful of walnuts	4	decent	
 2026	rotten small skewed nutty organic salad	2	crappy	
-2027	jumbo spoiled super salad	5	crappy	
+2027	spoiled jumbo super salad	5	crappy	
 2028	decent tofu wonton	4	good	
 2029	hippy protest button	0		Single Equip
 2030	blurry nasty lion tamer's Lockenstock&trade; sandals	0		Experience (familiar): +2, Stench Damage: +5, Single Equip
@@ -2020,15 +2020,15 @@
 2043	twirling hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	rotten brain-meltingly-hot chicken wings	3	crappy	
-2046	yummy small twirling frat brats	2	awesome	
+2046	small yummy twirling frat brats	2	awesome	
 2047	flavorless knob ka-bobs	4	decent	
-2049	high-proof acceptable can of Swiller	9	good	
+2049	acceptable high-proof can of Swiller	9	good	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	shaking bust of Pallas	0		Familiar Weight: +5
 2054	gray market map	0		
-2055	bouncing yellow snake skin	0		
+2055	yellow bouncing snake skin	0		
 2056	corrupted deionized adder bladder	0		Effect: "Memento Moir&eacute;", Effect Duration: 45
 2057	pension check	0		
 2058	skewed picnic basket	0		
@@ -2036,7 +2036,7 @@
 2060	lightning-fast toasty sword	0		Hot Damage: +5, Initiative: +40
 2061	squat dog trainer's helmet	0		Experience (familiar): +1, Familiar Effect: "1xFairy, cap 40"
 2062	shaking narrow energetic shield of chilblains	0		Maximum MP Percent: +20, Cold Damage: +25, Damage Reduction: 10
-2063	half-sized normal upside-down blackberry	2	good	
+2063	normal half-sized upside-down blackberry	2	good	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	wobbly red lion tamer's Tesla kick-ass kicks	0		Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -2057,17 +2057,17 @@
 2081	extremely unsafe makeshift skirt	0		Weapon Damage Percent: +100, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 2082	toothbrush	0		
 2083	makeshift crane	0		
-2084	mirror ghostly can of starch	0		
+2084	ghostly mirror can of starch	0		
 2085	dehydrated squat bottle of ultravitamins	1		
 2086	dried gray bottle of cough syrup	1		Effect: "Nightlit", Effect Duration: 25
 2087	pickled mirror tube of hair oil	1		
 2088	energized ghostly Daffy Taffy	0		Effect: "Ice Packed", Effect Duration: 69
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	lightning-fast fireproof crafty occult Rosewater's pilgrim shield	0		Mysticality Percent: +30, Spell Damage Percent: +25, Maximum MP: +10, Hot Resistance: +3, Initiative: +40, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
-2091	skewed teal bath salts	0		
+2091	teal skewed bath salts	0		
 2092	hand mirror	0		
 2093	dance instructor's hors d'oeuvre tray	0		Experience Percent (Moxie): +10, Damage Reduction: 5
-2094	low-calorie bland enchanted ballroom blintz	1	decent	Effect: "Superioreo", Effect Duration: 5
+2094	enchanted low-calorie bland ballroom blintz	1	decent	Effect: "Superioreo", Effect Duration: 5
 2095	lime green towel	0		
 2096	diluted pulsating guy made of bee pollen	1		
 2097	ghostly mansplainer's 17-ball	0		Monster Level: +15
@@ -2089,8 +2089,8 @@
 2113	stiffened wheel	0		Damage Reduction: 1, Last Available: "2006-12"
 2114	yo	0		Last Available: "2006-12"
 2115	dog trainer's prehistoric spear	0		Experience (familiar): +1, Last Available: "2006-12"
-2116	blurry tumbling stick-on-a-string	0		Last Available: "2006-12"
-2117	rosewater-soaked fire of the businessman	0		Stench Resistance: +3, Meat Drop: +50, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2116	tumbling blurry stick-on-a-string	0		Last Available: "2006-12"
+2117	rosewater-soaked fire of the businessman	0		Stench Resistance: +3, Meat Drop: +50, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	Grateful Undead T-shirt of Calamity Jane	0		Critical Hit Percent: +15
@@ -2122,7 +2122,7 @@
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	tasty frank	3	awesome	Last Available: "2011-12"
-2150	spoiled small plate of franks and beans	2	crappy	Last Available: "2011-12"
+2150	small spoiled plate of franks and beans	2	crappy	Last Available: "2011-12"
 2151	distilled perfectly mixed shot of blackberry schnapps	5	EPIC	
 2152	shaking capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	huge ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	huge hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	blue hale veiny toy ray gun	0		Maximum HP: 30, Last Available: "2006-12"
-2169	lard-coated toy space helmet of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	lard-coated toy space helmet of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	Fonzie's Samson's astronaut pants	0		Experience (Muscle): +5, Experience (Moxie): +1, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	Fonzie's Samson's astronaut pants	0		Experience (Muscle): +5, Experience (Moxie): +1, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	flame-retardant toy jet pack	0		Hot Resistance: +1, Last Available: "2006-12"
 2173	lime green triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2155,20 +2155,20 @@
 2180	amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	tumbling Harold's hammer head	0		
-2183	bouncing tumbling Harold's hammer handle	0		
+2183	tumbling bouncing Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	wholesome Kiss the Knob apron	0		Maximum HP Percent: +10
 2186	unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	bouncing flask of peppermint oil	1	crappy	Last Available: "2006-12"
-2189	mediocre twirling wobbly olive flask of peppermint schnapps	3	decent	Last Available: "2006-12"
+2189	mediocre twirling olive wobbly flask of peppermint schnapps	3	decent	Last Available: "2006-12"
 2190	mirror yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	blurry book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	stale gigantic candy stake	9	decent	Last Available: "2006-12"
-2194	weak bad eggnog	2	decent	Last Available: "2006-12"
+2194	bad weak eggnog	2	decent	Last Available: "2006-12"
 2195	normal unspeakable fruitcake	3	good	Last Available: "2006-12"
-2196	moldy small gingerbread horror	2	crappy	Last Available: "2006-12"
+2196	small moldy gingerbread horror	2	crappy	Last Available: "2006-12"
 2197	denatured tarnished but probably evil chocolate	0		Effect: "Bone Homie", Effect Duration: 29, Last Available: "2006-12"
 2198	moldy bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	stale shaking skull-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2182,24 +2182,24 @@
 2207	therapeutic Crimbo tiki necklace	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-12"
 2208	ghostly friendly deadly bobble-hip hula elf doll	0		Weapon Damage: +5, Familiar Weight: +3, Last Available: "2006-12"
 2209	blue horrifying Crimbo ukulele	0		Spooky Damage: +25, Last Available: "2006-12"
-2210	blinking fortified deadly Tiki lighter	0		Weapon Damage: +5, Damage Absorption: +60, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	Sherlock's healthy deck of tropical cards	0		Maximum HP Percent: +20, Item Drop: +25, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	avaricious quilted tropical paperweight	0		Damage Absorption: +40, Meat Drop: +30, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	blinking fortified deadly Tiki lighter	0		Weapon Damage: +5, Damage Absorption: +60, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	Sherlock's healthy deck of tropical cards	0		Maximum HP Percent: +20, Item Drop: +25, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	avaricious quilted tropical paperweight	0		Damage Absorption: +40, Meat Drop: +30, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
-2214	blue blinking tropical wrapping paper	0		Last Available: "2006-12"
-2215	blurry prompt Tropical Crimbo Hat	0		Adventures: +3, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	frosty Tropical Crimbo Shorts	0		Cold Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2214	blinking blue tropical wrapping paper	0		Last Available: "2006-12"
+2215	blurry prompt Tropical Crimbo Hat	0		Adventures: +3, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	frosty Tropical Crimbo Shorts	0		Cold Spell Damage: +10, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	stale blurry super ka-bob	4	decent	
 2218	flavorless beer basted brat	3	decent	
 2219	twirling Usain Bolt's Tropical Crimbo Sword	0		Initiative: +80, Last Available: "2006-12"
 2220	warmed alkaline vacuum-sealed and Crimboween candy	0		Effect: "Paging Betty", Effect Duration: 60, Last Available: "2020-09"
 2221	skewed Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	Sherlock's slick liar's pants	0		Moxie: +10, Item Drop: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	Sherlock's slick liar's pants	0		Moxie: +10, Item Drop: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	huge zippy clever juggler's balls	0		Maximum MP: +20, Initiative: +20, Softcore Only, Last Available: "2007-01"
 2224	twirling clever pink shirt	0		Maximum MP: +20, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	blinking lion tamer's evil eyeball pendant of temperance	0		Experience (familiar): +2, Sleaze Resistance: +5, Single Equip, Softcore Only, Last Available: "2007-01"
-2227	electrified polarized quadruple-wet skewed bouncing arse-a'fire elixir	0		Effect: "Drunk With Power", Effect Duration: 52, Last Available: "2007-01"
+2227	electrified polarized quadruple-wet bouncing skewed arse-a'fire elixir	0		Effect: "Drunk With Power", Effect Duration: 52, Last Available: "2007-01"
 2228	liquefied pressed narrow cosmic lemonade	0		Effect: "Demonic Flavor", Effect Duration: 45, Last Available: "2007-01"
 2229	enhanced tumbling toad horn	0		Effect: "Turtle Titters", Effect Duration: 13, Last Available: "2007-01"
 2230	squat icicle katana	0		Familiar Weight: +5
@@ -2235,7 +2235,7 @@
 2261	hard-boiled ostrich egg	0		
 2262	upside-down bird rib	0		
 2263	mirror lion oil	0		
-2264	spoiled miniature stunt nuts	2	crappy	
+2264	miniature spoiled stunt nuts	2	crappy	
 2265	bland wet stew	3	decent	
 2266	lime green wet stunt nut stew	0		
 2267	Mega Gem	0		
@@ -2265,16 +2265,16 @@
 2291	Non-Essential Amulet	0		
 2292	twirling wine vinaigrette	0		
 2293	blue cup of strong herbal tea	0		
-2294	blinking squat Curiously Shiny Ancient Evil-Bashing Axe	0		
+2294	squat blinking Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	marinated stakes	0		
 2296	knob butter	0		
 2297	vial of ectoplasm	0		
 2298	boock of darck magicks	0		
 2299	huge EZ-Play Harmonica Book	0		
-2300	narrow tumbling fingerless hobo gloves	0		
+2300	tumbling narrow fingerless hobo gloves	0		
 2301	jittery Chomsky's comic books	0		
 2302	yellow skewed worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	unsweetened diffused candy heart	0		Effect: "Motion", Effect Duration: 63, Last Available: "2007-02"
 2305	vacuum-sealed double-enhanced tumbling pink candy heart	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 31, Last Available: "2007-02"
 2306	anodized colloidal skewed candy heart	0		Effect: "Top Dog", Effect Duration: 50, Last Available: "2007-02"
@@ -2290,7 +2290,7 @@
 2316	maroon broken carburetor	0		
 2317	upside-down bronze token	0		
 2318	bomb	0		
-2319	blurry mirror carved wheel	0		
+2319	mirror blurry carved wheel	0		
 2320	worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
 2322	spinning worm-riding manual pages 3-15	0		
@@ -2303,17 +2303,17 @@
 2329	blurry handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	snack-sized decent Better Than Cuddling Cake	2	good	
+2332	decent snack-sized Better Than Cuddling Cake	2	good	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
 2336	ghostly spinning quilted pipe of mayonnaise	0		Damage Absorption: +40, Sleaze Spell Damage: +50
 2337	reinforced beaded headband of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	moldy diet pudding	1	crappy	Wiki Name: "black pudding (food)"
-2339	bad irresponsibly strong Blackfly Chardonnay	8	decent	
+2338	diet moldy pudding	1	crappy	Wiki Name: "black pudding (food)"
+2339	irresponsibly strong bad Blackfly Chardonnay	8	decent	
 2340	perfectly mixed bouncing & tan	3	EPIC	
 2341	squat pepper	0		
-2342	miniature fancy stale forest cake	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 30
+2342	fancy miniature stale forest cake	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 30
 2343	thick delicious forest ham	5	awesome	
 2344	anodized enhanced narrow filthworm hatchling scent gland	0		Effect: "Craft Tea", Effect Duration: 66
 2345	liquefied filthworm drone scent gland	0		Effect: "Egg on your Face", Effect Duration: 41
@@ -2374,7 +2374,7 @@
 2400	molotov cocktail cocktail	0		
 2401	beer bong of dire peril of Flo-Jo	0		Weapon Damage: +20, Initiative: +100
 2402	gauze garter	0		
-2403	huge spinning barrel of gunpowder	0		
+2403	spinning huge barrel of gunpowder	0		
 2404	fuchsia jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	blurry Cobb's Knob map	0		
 2443	red wool chilly pink glowstick	0		Cold Damage: +5, Cold Resistance: +1, Last Available: "2007-03"
-2444	artisanal high-proof Supernova Champagne	6	EPIC	
+2444	high-proof artisanal Supernova Champagne	6	EPIC	
 2445	upside-down Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	wobbly bad penguin egg	0		Free Pull
@@ -2491,7 +2491,7 @@
 2518	dog trainer's sawblade shield	0		Experience (familiar): +1, Damage Reduction: 11
 2519	artisanal McMillicancuddy's Special Lager	4	EPIC	
 2520	acceptable watered-down melted Jell-o shot	2	good	
-2521	lousy weak special cruelty-free wine	2	decent	Effect: "Mariachi Mood", Effect Duration: 20
+2521	special weak lousy cruelty-free wine	2	decent	Effect: "Mariachi Mood", Effect Duration: 20
 2522	smooth thistle wine	4	awesome	
 2523	megatofu	0		
 2524	displaced fish	0		
@@ -2499,11 +2499,11 @@
 2526	rotten fish casserole	4	crappy	
 2527	moldy fish lasagna	4	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	jumbo adequate yellow blinking gnatloaf	5	good	
+2529	adequate jumbo blinking yellow gnatloaf	5	good	
 2530	diet rotten red gnatloaf casserole	1	crappy	
-2531	fancy huge adequate mirror gnat lasagna	6	good	Effect: "Unusual Perspective", Effect Duration: 40
+2531	adequate fancy huge mirror gnat lasagna	6	good	Effect: "Unusual Perspective", Effect Duration: 40
 2532	blue pork	0		
-2533	flavorless low-calorie pork chop sandwiches	1	decent	
+2533	low-calorie flavorless pork chop sandwiches	1	decent	
 2534	tasty fancy pork casserole	4	awesome	Effect: "Coldfinger", Effect Duration: 40
 2535	snack-sized rotten teal pork lasagna	2	crappy	
 2536	canopic jar	0		
@@ -2512,13 +2512,13 @@
 2539	Ankh of Badahnkadh of the boozehound	0		Booze Drop: +100, Single Equip
 2540	tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
-2542	pickled triple-aerosolized nitrogenated purple mirror lesser grodulated violet	0		Effect: "Morbidi Tea", Effect Duration: 41, Last Available: "2007-05"
+2542	pickled triple-aerosolized nitrogenated mirror purple lesser grodulated violet	0		Effect: "Morbidi Tea", Effect Duration: 41, Last Available: "2007-05"
 2543	energized aerosolized pickled bouncing tin magnolia	0		Effect: "High Blood Chocolate Content", Effect Duration: 24, Last Available: "2007-05"
 2544	quadruple-deionized red begpwnia	0		Effect: "Inebriate Pride", Effect Duration: 60, Last Available: "2007-05"
 2545	pressed upsy daisy	0		Effect: "Antarctic Memories", Effect Duration: 66, Last Available: "2007-05"
 2546	wet wobbly half-orchid	0		Effect: "Beastly Flavor", Effect Duration: 17, Last Available: "2007-05"
 2547	auspicious tin star of the early riser	0		Item Drop: +10, Adventures: +7, Last Available: "2007-05"
-2548	greasy energetic outrageous sombrero	0		Maximum MP Percent: +20, Sleaze Spell Damage: +10, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	greasy energetic outrageous sombrero	0		Maximum MP Percent: +20, Sleaze Spell Damage: +10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	&quot;Humorous&quot; T-shirt of the wise owl of Flo-Jo	0		Mysticality: +20, Initiative: +100, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2538,7 +2538,7 @@
 2565	can of Ghuol-B-Gone&trade;	0		
 2566	fuchsia Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
-2568	maroon twirling Azazel's tutu	0		
+2568	twirling maroon Azazel's tutu	0		
 2569	pressed ionized ant agonist	0		Effect: "Sticks and Stones", Effect Duration: 20
 2570	skewed tumbling ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	Samson's beefcake's cactus quill	0		Muscle: +25, Experience (Muscle): +5
 2578	frightening mansplainer's brainy Staff of the Short Order Cook	0		Mysticality: +5, Monster Level: +15, Spooky Damage: +5
-2579	decent miniature cactus fruit	2	good	
+2579	miniature decent cactus fruit	2	good	
 2580	mirror huge Lo Pan's Van der Graaf scorpion whip	0		Spell Critical Percent: +30, MP Regen Min: 5, MP Regen Max: 7
 2581	handful of sand	0		
 2582	brick of sand	0		
@@ -2561,14 +2561,14 @@
 2588	greasy Private Pepper's Lonely Hearts Club Jacket	0		Sleaze Spell Damage: +10
 2589	huge moldy hot date	7	crappy	
 2590	drinkable spirit-forward huge distilled fortified wine	5	good	
-2591	miniature normal tasty tart	2	good	
-2592	spinning lime green Knob Goblin lunchbox	0		
+2591	normal miniature tasty tart	2	good	
+2592	lime green spinning Knob Goblin lunchbox	0		
 2593	moldy Knob pasty	4	crappy	
 2594	perfectly mixed thermos full of Knob coffee	3	EPIC	
 2595	deionized colloidal narrow Ben-Gal&trade; Balm	0		Effect: "Muddled", Effect Duration: 18
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
-2598	shaking narrow leathery rat skin	0		
+2598	narrow shaking leathery rat skin	0		
 2599	blinking Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	bouncing blue scorching wholesome Staff of the Midnight Snack of extreme caution	0		Maximum HP Percent: +10, Monster Level: -25, Hot Damage: +25
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	moldy fancy small savoy truffle	2	crappy	Effect: "Pumped Up", Effect Duration: 35
+2615	small fancy moldy savoy truffle	2	crappy	Effect: "Pumped Up", Effect Duration: 35
 2616	Magi-Wipes	0		
 2617	tumbling boom	0		
 2618	vibrating Iiti Kitty phone charm	0		Maximum MP Percent: +10, Single Equip
 2619	fuchsia jar of swamp gas	0		Last Available: "2007-05"
-2620	gigantic decent unidentified jerky	9	good	
+2620	decent gigantic unidentified jerky	9	good	
 2621	blurry knitted nasty rat mask of the cougar	0		Moxie: +20, Cold Resistance: +3, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	blue rosy-cheeked arcane researcher's ratskin belt	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +30, Single Equip
 2623	rattail whip of the dark arts of the blizzard	0		Spell Damage Percent: +100, Cold Spell Damage: +25
@@ -2622,18 +2622,18 @@
 2649	mirror Lord Spookyraven's ear trumpet of the ox	0		Muscle: +20, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	bite-sized toothsome ghostly S.T.L.T.	1	awesome	Last Available: "2007-06"
-2653	miniature yummy blurry honey-dew	2	awesome	Last Available: "2007-06"
+2652	toothsome bite-sized ghostly S.T.L.T.	1	awesome	Last Available: "2007-06"
+2653	yummy miniature blurry honey-dew	2	awesome	Last Available: "2007-06"
 2654	acceptable Xanadian	4	good	Last Available: "2007-06"
 2655	pickled quantum bottle of absinthe	0		Effect: "Hood Ridin'", Effect Duration: 36, Last Available: "2007-06"
 2656	perfumed Temple Grandin's Drowsy Sword	0		Familiar Weight: +7, Stench Resistance: +5
 2657	bland escargotsicle	4	decent	Last Available: "2007-06"
-2658	perfectly mixed weak bottle of realpagne	2	EPIC	Last Available: "2007-06"
+2658	weak perfectly mixed bottle of realpagne	2	EPIC	Last Available: "2007-06"
 2659	bouncing pulsating rosy-cheeked albatross necklace	0		Maximum HP Percent: +30, Single Equip, Last Available: "2007-06"
 2660	denatured huge jittery not-a-pipe	1	good	Effect: "Jacked In", Effect Duration: 50, Last Available: "2007-06"
 2661	aged wobbly flask of Amontillado	3	awesome	Last Available: "2007-06"
-2662	blue tumbling ball mask of the glutton	0		Food Drop: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	greedy Can-Can skirt	0		Meat Drop: +20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	blue tumbling ball mask of the glutton	0		Food Drop: +100, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	greedy Can-Can skirt	0		Meat Drop: +20, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	tarnished purple sensitive poetry journal	0		Effect: "Unusual Fashion Sense", Effect Duration: 64, Last Available: "2007-06"
 2665	tarnished squat bottled inspiration	0		Effect: "Castaway Physique", Effect Duration: 17, Last Available: "2007-06"
 2666	improved bellhop bell	0		Effect: "Punch Another Day", Effect Duration: 66, Last Available: "2007-06"
@@ -2646,7 +2646,7 @@
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	polarized bottle of cat tonic	0		Effect: "Icy Composition", Effect Duration: 50, Last Available: "2007-06"
 2675	pickled tumbling handful of moss	1		Effect: "Lemon Enlightenment", Effect Duration: 35
-2676	distilled ghostly blurry bit-o-cactus	1		
+2676	distilled blurry ghostly bit-o-cactus	1		
 2677	dried squat protein powder	1		Effect: "Three Days Slow", Effect Duration: 5
 2678	spectre scepter	0		
 2679	irradiated squat sparkler	0		Effect: "Leash of Linguini", Effect Duration: 62
@@ -2682,7 +2682,7 @@
 2709	exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
 2711	triple-dry polarized magnetized green facepaint	0		Effect: "Mushroom Samba", Effect Duration: 24
-2712	magnetized denatured bouncing purple sheepskin diploma	0		Effect: "Human-Elf Hybrid", Effect Duration: 55
+2712	magnetized denatured purple bouncing sheepskin diploma	0		Effect: "Human-Elf Hybrid", Effect Duration: 55
 2713	adjusted blue Black Body&trade; spray	0		Effect: "Super Skill", Effect Duration: 60
 2714	floorboard cruft	0		
 2715	sausage bomb	0		
@@ -2698,7 +2698,7 @@
 2725	normal cob of corn	4	good	
 2726	spoiled juniper berries	4	crappy	
 2727	rotten tiny plum	1	crappy	
-2728	rotten huge pear	8	crappy	
+2728	huge rotten pear	8	crappy	
 2729	moldy peach	3	crappy	
 2730	strong hand-crafted plum wine	5	EPIC	
 2731	irresponsibly strong hand-crafted twirling shot of pear schnapps	7	EPIC	
@@ -2739,7 +2739,7 @@
 2766	bowling ball	0		
 2767	bland Crimbo pie	3	decent	
 2768	moldy pear tart	3	crappy	
-2769	normal diet peach pie	1	good	
+2769	diet normal peach pie	1	good	
 2770	modified chunk of rock salt	0		Effect: "Stop the Presses!", Effect Duration: 25
 2771	nitrogenated dry handful of pine needles	0		Effect: "Smelly Pants", Effect Duration: 33
 2772	mirror steamy ruby	0		
@@ -2771,7 +2771,7 @@
 2798	red blurry clever Mudflap-Girl Earring of the storm	0		Maximum MP Percent: +40, Maximum MP: +20, Single Equip
 2799	knitted Van der Graaf Mudflap-Girl Necklace	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2800	upside-down dog trainer's Mudflap-Girl Ring of Flo-Jo	0		Experience (familiar): +1, Initiative: +100, Single Equip
-2801	tumbling blue vial of Gnomochloric acid	0		
+2801	blue tumbling vial of Gnomochloric acid	0		
 2802	flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	diffused twirling vial of hamethyst juice	0		Effect: "Human-Machine Hybrid", Effect Duration: 49
@@ -2789,9 +2789,9 @@
 2816	upside-down nasty chilly Boxers of mayonnaise	0		Cold Damage: +5, Stench Damage: +5, Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep"
 2817	supercharged therapeutic Brooch of the sweet-tooth	0		Maximum MP Percent: +30, Candy Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 2818	twirling fireproof vibrating personal trainer's Bracelet	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Hot Resistance: +3, Single Equip
-2819	wobbly squat aromatic friendly Grimacite gasmask	0		Familiar Weight: +3, Stench Resistance: +1, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	wobbly squat aromatic friendly Grimacite gasmask	0		Familiar Weight: +3, Stench Resistance: +1, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	resourceful Fonzie's Grimacite gat	0		Experience (Moxie): +1, Maximum MP: +50, Last Available: "2008-11"
-2821	bouncing hardened Grimacite gaiters of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 3, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	bouncing hardened Grimacite gaiters of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 3, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	Lo Pan's stiffened Grimacite gauntlets	0		Damage Reduction: 1, Spell Critical Percent: +30, Single Equip, Last Available: "2008-11"
 2823	spinning knitted wholesome Grimacite go-go boots	0		Maximum HP Percent: +10, Cold Resistance: +3, Single Equip, Last Available: "2008-11"
 2824	scorching cool Grimacite girdle	0		Moxie: +5, Hot Damage: +25, Single Equip, Last Available: "2008-11"
@@ -2804,15 +2804,15 @@
 2831	gray star key lime	0		
 2832	half-sized spoiled skewed digital key lime pie	2	crappy	
 2833	normal tumbling star key lime pie	3	good	
-2834	auspicious supercool bottle-rocket crossbow of the ox	0		Muscle: +20, Moxie Percent: +20, Item Drop: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	auspicious supercool bottle-rocket crossbow of the ox	0		Muscle: +20, Moxie Percent: +20, Item Drop: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	shaking indie comic hipster glasses of bravery	0		Spooky Resistance: +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	fuchsia Lo Pan's studded glowstick	0		Damage Absorption: +80, Spell Critical Percent: +30, Last Available: "2007-08"
 2839	educational Periodical Paintbrush	0		Experience: +1, Softcore Only
-2840	perfectly mixed special bottle of cooking sherry	3	EPIC	Effect: "Bells in the Batfry", Effect Duration: 10
+2840	special perfectly mixed bottle of cooking sherry	3	EPIC	Effect: "Bells in the Batfry", Effect Duration: 10
 2841	big decent packet of ketchup	5	good	
-2842	high-proof mediocre lime green twirling accidental cider	8	decent	
+2842	high-proof mediocre twirling lime green accidental cider	8	decent	
 2843	moldy dire fudgesicle	4	crappy	
 2844	huge zippy gravedigger's extremely unsafe navel ring of navel gazing of the sewer	0		Weapon Damage Percent: +100, Stench Damage: +25, Spooky Damage: +10, Initiative: +20, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	blue ghostly class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2820,7 +2820,7 @@
 2847	medical-grade Dallas Dynasty Falcon Crest shield	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	blinking jittery shrunken navigator head	0		
-2850	fortified perfectly mixed moonberry wine cooler	5	EPIC	
+2850	perfectly mixed fortified moonberry wine cooler	5	EPIC	
 2851	stale tumbling fine aged cheddarwurst	4	decent	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2841,7 +2841,7 @@
 2868	enhanced pirate pamphlet	0		Effect: "Litterboxing", Effect Duration: 63
 2869	frozen improved maroon pulsating pirate brochure	0		Effect: "Hangdog", Effect Duration: 40
 2870	diffused warmed pirate tract	0		Effect: "damage.enh", Effect Duration: 67
-2871	purple twirling burnt flower	0		
+2871	twirling purple burnt flower	0		
 2872	sinister plastic Naughty Sorceress of extreme caution	0		Spell Damage: +10, Monster Level: -25
 2873	purple thinker's plastic Ed the Undying of the early riser	0		Mysticality: +10, Adventures: +7
 2874	occult plastic Lord Spookyraven of the businessman	0		Spell Damage Percent: +25, Meat Drop: +50
@@ -2910,30 +2910,30 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	spoiled massive cyan Surprise Egg	10	crappy	
+2940	massive spoiled cyan Surprise Egg	10	crappy	
 2941	pressed Steal This Candy	0		Effect: "Human-Elf Hybrid", Effect Duration: 53
 2942	energized nitrogenated wobbly chocolate filthy lucre	0		Effect: "Egg-headedness", Effect Duration: 42
 2943	warmed electrified Angry Farmer's Wife Candy	0		Effect: "Alpine Mintiness", Effect Duration: 29
 2945	shaking lime green miser's wizardly party hat	0		Mysticality: +25, Meat Drop: +10, Familiar Effect: "4xLep, cap 7"
-2946	zippy padded V for Vivala mask	0		Damage Absorption: +20, Initiative: +20, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	zippy padded V for Vivala mask	0		Damage Absorption: +20, Initiative: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	high-proof lousy fuchsia shot of rotgut	8	decent	
 2949	nitrogenated energized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Sweet and Green", Effect Duration: 14
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
 2952	censurious glowstick of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Last Available: "2007-11"
-2953	huge narrow charrrm bracelet	0		
+2953	narrow huge charrrm bracelet	0		
 2954	skewed steel-toed tip jar	0		Damage Reduction: 9
 2955	flavorless yam candy	3	decent	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	snack-sized spoiled tube of cranberry Go-Goo	2	crappy	
+2958	spoiled snack-sized tube of cranberry Go-Goo	2	crappy	
 2959	tumbling careful rum barrel charrrm bracelet	0		Monster Level: -10
 2960	moldy tiny single-serving herbal stuffing	1	crappy	
 2961	stale wobbly packet of tofurkey gravy	4	decent	
 2962	normal snack-sized pulsating tofurkey nugget	2	good	
 2963	rigging shampoo	0		
-2964	huge upside-down ball polish	0		
+2964	upside-down huge ball polish	0		
 2965	twirling mizzenmast mop	0		
 2966	purple Tom's of the Spanish Main Toothpaste	0		
 2967	enhanced twirling Swabbie&trade; swab	0		Effect: "The Dinsey Spirit", Effect Duration: 30
@@ -2969,7 +2969,7 @@
 2997	steel-toed shellacked grungy bandana	0		Damage Reduction: 32, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
 2998	banded grassy cutlass	0		Damage Absorption: +100
 2999	green Cap'm Caronch's nasty booty	0		
-3000	yellow jittery Cap'm Caronch's dentures	0		
+3000	jittery yellow Cap'm Caronch's dentures	0		
 3001	jittery sizzling pegleg	0		Hot Damage: +10, Single Equip
 3002	squat executive lam&eacute; pants	0		Meat Drop: +40, Familiar Effect: "2xPotato, 1xLep, cap 25"
 3003	frosty enormous hoop earring	0		Cold Spell Damage: +10
@@ -2996,9 +2996,9 @@
 3024	narrow stone pyramid	0		
 3025	mediocre corpse on the beach	4	decent	
 3026	drinkable pulsating corpsetini	4	good	
-3027	practically non-alcoholic hand-crafted corpsedriver	1	super ultra mega turbo EPIC	
+3027	hand-crafted practically non-alcoholic corpsedriver	1	super ultra mega turbo EPIC	
 3028	acceptable Corpse Island iced tea	4	good	
-3029	watered-down hand-crafted red-headed corpse	2	EPIC	
+3029	hand-crafted watered-down red-headed corpse	2	EPIC	
 3030	perfectly mixed kamicorpse-ee	3	EPIC	
 3031	lousy corpsel	4	decent	
 3032	aged corpsebite	3	awesome	
@@ -3006,17 +3006,17 @@
 3034	piece of thirteen	0		
 3035	flavorless pearl onion	3	decent	
 3036	stale sea biscuit	3	decent	
-3037	tolerable watered-down shaking bottle of rum	2	good	
+3037	watered-down tolerable shaking bottle of rum	2	good	
 3038	practically non-alcoholic smooth bottle of black-label rum	1	awesome	
 3039	tumbling cannonball	0		
 3040	voodoo skull	0		
 3041	upside-down joke scroll	0		
 3042	bouncing bouncing Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	cyan metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	blurry metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	blurry metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	tasty huge nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
 3046	rotten nanite-infested candy cane	4	crappy	Last Available: "2020-09"
-3047	flavorless snack-sized nanite-infested fruitcake	2	decent	Last Available: "2007-12"
+3047	snack-sized flavorless nanite-infested fruitcake	2	decent	Last Available: "2007-12"
 3048	mediocre nanite-infested eggnog	3	decent	Last Available: "2007-12"
 3049	lime green El Vibrato power sphere	0		
 3050	purple eyepatch of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3025,7 +3025,7 @@
 3053	spinning mood ring	0		Last Available: "2007-02"
 3054	flattened quantum blinking candy heart	0		Effect: "Boletus Swoletus", Effect Duration: 53, Last Available: "2007-02"
 3055	super-ionized enhanced cymbal syrup	0		Free Pull, Effect: "Norwhalloped", Effect Duration: 36, Last Available: "2007-02"
-3056	mirror metallic foil cat ears of the ox	0		Muscle: +20, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	mirror metallic foil cat ears of the ox	0		Muscle: +20, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	blinking spinning nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	upside-down laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	jittery teddy borg	0		Last Available: "2007-12"
 3081	pulsating hale marionette collective	0		Maximum HP: +20, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	censurious therapeutic roboduck-on-a-string	0		Sleaze Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	shaking teddy borg sewing kit	0		Last Available: "2007-12"
-3088	electrified cool biomechanical crimborg helmet	0		Moxie: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	electrified cool biomechanical crimborg helmet	0		Moxie: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	friendly Oprah's C.B.F.G.	0		Maximum MP Percent: +50, Familiar Weight: +3, Last Available: "2007-12"
-3090	Usain Bolt's knitted biomechanical crimborg leg armor	0		Cold Resistance: +3, Initiative: +80, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	Usain Bolt's knitted biomechanical crimborg leg armor	0		Cold Resistance: +3, Initiative: +80, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	chilled electrified skewed vitachoconutriment capsule	0		Effect: "High Blood Chocolate Content", Effect Duration: 27, Last Available: "2007-12"
 3092	wizardly handmade hobby horse	0		Mysticality: +25, Last Available: "2007-12"
 3093	supercool ball-in-a-cup	0		Moxie Percent: +20, Last Available: "2007-12"
@@ -3068,7 +3068,7 @@
 3096	veiny polyalloy shield of bravery	0		Maximum HP: +10, Spooky Resistance: +5, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
-3099	huge olive ring	0		Last Available: "2007-12"
+3099	olive huge ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	rogue swarmer	0		Last Available: "2007-12"
 3102	lime green spinning sawblade fragment	0		Last Available: "2007-12"
@@ -3086,12 +3086,12 @@
 3114	blinking Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	olive Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	olive Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
 3121	twirling divine champagne popper	0		Last Available: "2008-01"
-3122	twirling shaking bouncing divine cracker	0		Last Available: "2008-01"
+3122	bouncing shaking twirling divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	extra-colloidal ghostly fruitfilm	0		Effect: "Disco Nirvana", Effect Duration: 65
 3125	improved pickled piece of after eight	0		Effect: "Hyperoxygenated Blood", Effect Duration: 54
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	flavorless roasted marshmallow	3	decent	
 3130	disc	0		Last Available: "2008-01"
-3131	fancy moldy tin cup of mulligan stew	3	crappy	Effect: "Destructive Resolve", Effect Duration: 15
+3131	moldy fancy tin cup of mulligan stew	3	crappy	Effect: "Destructive Resolve", Effect Duration: 15
 3132	greedy friendly flamin' bindle	0		Familiar Weight: +3, Meat Drop: +20
 3133	bouncing healthy extremely unsafe freezin' bindle	0		Weapon Damage Percent: +100, Maximum HP Percent: +20
 3134	perfumed stinkin' bindle of the cheetah	0		Stench Resistance: +5, Initiative: +60
@@ -3138,7 +3138,7 @@
 3166	narrow repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	adjusted deionized adjusted seal eyeball	0		Effect: "Flambé-a-thon", Effect Duration: 52
-3169	special yummy spinning turtle soup	4	awesome	Effect: "[598]A Little Bit Evil", Effect Duration: 5
+3169	yummy special spinning turtle soup	4	awesome	Effect: "[598]A Little Bit Evil", Effect Duration: 5
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	weightlifter's evil paper umbrella	0		Muscle: +15
@@ -3146,10 +3146,10 @@
 3174	delicious evil boring spaghetti	3	awesome	
 3175	moldy spinning evil noodles	4	crappy	
 3176	normal evil noodles	3	good	
-3177	rotten miniature evil painful penne pasta	2	crappy	
+3177	miniature rotten evil painful penne pasta	2	crappy	
 3178	normal bouncing 3vi1 pr0n m4nic0tti	3	good	
 3179	huge bland lime green evil ravioli della hippy	6	decent	
-3180	rotten thick evil noodles	5	crappy	
+3180	thick rotten evil noodles	5	crappy	
 3181	electrified mirror evil potion of potency	0		Effect: "Engorged Weapon", Effect Duration: 27
 3182	pressed tarnished denatured evil libation of liveliness	0		Effect: "Hot Blooded", Effect Duration: 58
 3183	warmed ionized skewed evil tomato juice of powerful power	0		Effect: "Purpose", Effect Duration: 59
@@ -3160,14 +3160,14 @@
 3188	drinkable spirit-forward cyan an evil sump'm sump'm	5	good	
 3189	bad evil ducha de oro	3	decent	
 3190	acceptable evil horizontal tango	3	good	
-3191	lousy watered-down evil roll in the hay	2	decent	
+3191	watered-down lousy evil roll in the hay	2	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	gray huge naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	blurry foul-smelling origami pasties	0		Stench Damage: +10, Softcore Only, Last Available: "2008-02"
 3197	fuchsia jittery prompt aromatic steel-toed origami riding crop	0		Damage Reduction: 9, Stench Resistance: +1, Adventures: +3, Softcore Only, Last Available: "2008-02"
-3198	fuchsia twirling El Vibrato trapezoid	0		
+3198	twirling fuchsia El Vibrato trapezoid	0		
 3199	blurry lump of coal	0		
 3200	lump of diamond	0		
 3201	huge red thick padded envelope	0		
@@ -3176,9 +3176,9 @@
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
-3207	yellow bouncing squat dwarvish punchcard	0		
+3207	bouncing squat yellow dwarvish punchcard	0		
 3208	blinking mirror mirror small laminated card	0		
-3209	blinking ghostly laminated card	0		
+3209	ghostly blinking laminated card	0		
 3210	spinning blinking notbig laminated card	0		
 3211	mirror unlarge laminated card	0		
 3212	pulsating dwarvish document	0		
@@ -3196,8 +3196,8 @@
 3224	sewer wad	0		
 3225	delicious bottle of sewage schnapps	3	awesome	
 3226	mediocre bottle of Ooze-O	3	decent	
-3227	jumbo moldy enchanted C.H.U.M. chum	5	crappy	Effect: "Physicali Tea", Effect Duration: 50
-3228	immense flavorless purple unfortunate dumplings	9	decent	
+3227	moldy jumbo enchanted C.H.U.M. chum	5	crappy	Effect: "Physicali Tea", Effect Duration: 50
+3228	flavorless immense purple unfortunate dumplings	9	decent	
 3229	decaying goldfish liver	0		
 3230	adjusted alkaline maroon oil of oiliness	0		Effect: "Provocative Perkiness", Effect Duration: 18
 3231	Annie Oakley's tattered paper crown	0		Critical Hit Percent: +20, Familiar Effect: "1xSombrero, cap 15"
@@ -3211,7 +3211,7 @@
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	Travels with Jerry	0		Skill: "Mudbath"
-3242	lime green jittery Let Me Be!	0		Skill: "Raise Backup Dancer"
+3242	jittery lime green Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	narrow Summer Nights	0		Skill: "Grease Lightning"
 3245	skewed Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
@@ -3232,7 +3232,7 @@
 3260	miser's stiffened Chester's moustache of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Meat Drop: +10, Class: "Disco Bandit", Single Equip
 3261	electrified Chester's bag of candy of the cougar	0		Moxie: +20, MP Regen Min: 3, MP Regen Max: 5, Class: "Disco Bandit"
 3262	Usain Bolt's MacGyver's Chester's cutoffs	0		Maximum MP: +100, Initiative: +80, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	green candygram	0		Last Available: "2008-04"
 3265	blurry bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3240,11 +3240,11 @@
 3268	alkaline polymerized handful of Crotchety Pine needles	0		Effect: "Bells in the Batfry", Effect Duration: 54
 3269	anodized dry wobbly lump of Saccharine Maple sap	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 23
 3270	non-pickled maroon handful of Laughing Willow bark	0		Effect: "Lubed", Effect Duration: 40
-3271	aromatic crotchety pants	0		Stench Resistance: +1, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	aromatic crotchety pants	0		Stench Resistance: +1, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	Jeselnik's Saccharine Maple pendant	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Spray Sap"
-3273	green supercharged willowy bonnet	0		Maximum MP Percent: +30, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	green supercharged willowy bonnet	0		Maximum MP Percent: +30, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
-3275	blue jittery dart	0		Last Available: "2008-04"
+3275	jittery blue dart	0		Last Available: "2008-04"
 3276	ghostly black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	skewed dangerous studded belt	0		Weapon Damage: +10, Last Available: "2008-04"
@@ -3257,7 +3257,7 @@
 3285	spinning C.H.U.M. knife of James Dean	0		Experience (Moxie): +3
 3286	twirling Frosty's snowball sack of horror	0		Spooky Spell Damage: +25
 3287	quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
-3288	twirling lime green shimmering tendrils	0		Class: "Pastamancer"
+3288	lime green twirling shimmering tendrils	0		Class: "Pastamancer"
 3289	spinning scintillating powder	0		Class: "Pastamancer"
 3290	blurry abandoned candy	0		
 3291	fuchsia secret tropical island volcano lair map	0		
@@ -3269,12 +3269,12 @@
 3297	shaking stray chihuahua	0		
 3298	pretty pink bow	0		
 3299	blinking smiley-face sticker	0		
-3300	fuchsia upside-down farfalle bow tie	0		
+3300	upside-down fuchsia farfalle bow tie	0		
 3301	pulsating jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
 3304	jittery Argarggagarg's fang	0		
-3305	ghostly skewed Safari Jack's moustache	0		
+3305	skewed ghostly Safari Jack's moustache	0		
 3306	huge Yakisoba's hat	0		
 3307	Heimandatz's heart	0		
 3308	Jocko Homo's head	0		
@@ -3291,12 +3291,12 @@
 3319	Da Vinci's Mr. Joe's bangles	0		Experience (Mysticality): +5, Single Equip
 3320	fireproof frayed rope belt	0		Hot Resistance: +3, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	avaricious mayfly bait necklace of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	avaricious mayfly bait necklace of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	huge Frosty's frosty mug	0		
-3325	boozy drinkable fuchsia jar of fermented pickle juice	5	good	
+3325	drinkable boozy fuchsia jar of fermented pickle juice	5	good	
 3326	boiled blue voodoo snuff	1	awesome	Effect: "In the Saucestream", Effect Duration: 5
-3327	yummy bite-sized mirror extra-greasy slider	1	awesome	
+3327	bite-sized yummy mirror extra-greasy slider	1	awesome	
 3328	clever steel-toed crumpled felt fedora	0		Damage Reduction: 9, Maximum MP: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	narrow narrow nippy forbidden battered top-hat	0		Spell Damage Percent: +50, Cold Damage: +10, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	therapeutic Rosewater's shapeless wide-brimmed hat	0		Mysticality Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3331,18 +3331,18 @@
 3359	scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
-3362	twirling yellow shaking tasty louse	0		Last Available: "2008-06"
+3362	yellow shaking twirling tasty louse	0		Last Available: "2008-06"
 3363	spoiled huge bouncing mole mol&eacute;	7	crappy	Last Available: "2008-06"
 3364	drinkable squat Morlock's Mark Bourbon	3	good	Last Available: "2008-06"
 3365	electrified anodized lime green twirling Climate Colada	0		Effect: "Bats in the Belfry", Effect Duration: 60, Last Available: "2008-06"
 3366	oxidized unsweetened enhanced yellow digital underground potion	0		Effect: "Neuromancy", Effect Duration: 48, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	modified blurry lime green glimmering roc feather	1	awesome	Last Available: "2008-06"
-3369	denatured red blurry glimmering phoenix feather	1		Last Available: "2008-06"
+3368	modified lime green blurry glimmering roc feather	1	awesome	Last Available: "2008-06"
+3369	denatured blurry red glimmering phoenix feather	1		Last Available: "2008-06"
 3370	diluted blinking glimmering penguin feather	1		Effect: "Grrrrrrreat!", Effect Duration: 50, Last Available: "2008-06"
 3371	dried upside-down glimmering buzzard feather	1		Last Available: "2008-06"
 3372	dried blurry wobbly glimmering raven feather	1		Last Available: "2008-06"
-3373	vaporized jittery purple glimmering great tit feather	1		Last Available: "2008-06"
+3373	vaporized purple jittery glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3357,7 +3357,7 @@
 3385	jittery lion tamer's Chester's Aquarius medallion of extreme caution	0		Monster Level: -25, Experience (familiar): +2, Single Equip
 3386	Oprah's supercool Zombo's shoulder blade	0		Moxie Percent: +20, Maximum MP Percent: +50
 3387	Zombo's skull ring of the storm of courage	0		Maximum MP Percent: +40, Spooky Resistance: +3, Single Equip
-3388	bouncing blinking olive Zombo's empty eye	0		
+3388	olive bouncing blinking Zombo's empty eye	0		
 3389	mirror aromatic dog trainer's Frosty's arm	0		Experience (familiar): +1, Stench Resistance: +1
 3390	bouncing MacGyver's sinister Staff of the Deepest Freeze of the ox	0		Muscle: +20, Spell Damage: +10, Maximum MP: +100
 3391	upside-down Frosty's iceball	0		
@@ -3369,7 +3369,7 @@
 3397	censurious aromatic Hodgman's bow tie	0		Stench Resistance: +1, Sleaze Resistance: +3, Single Equip
 3398	lousy Hodgman's blanket	3	decent	
 3399	practically non-alcoholic lousy jar of squeeze	1	decent	
-3400	huge decent bowl of fishysoisse	9	good	
+3400	decent huge bowl of fishysoisse	9	good	
 3401	irradiated alkaline polymerized blinking deadly lampshade	0		Effect: "Sated and Furious", Effect Duration: 11
 3402	diffused aerosolized concentrated garbage juice	0		Effect: "Tomato Power", Effect Duration: 18
 3403	lewd playing card	0		
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	tumbling Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	Vulcanized corrupted adjusted sterno-flavored Hob-O	0		Effect: "Oiled Skin", Effect Duration: 56
 3423	adjusted spinning frostbite-flavored Hob-O	0		Effect: "One Foot Heavier", Effect Duration: 35
 3424	pressed wet pulsating fry-oil-flavored Hob-O	0		Effect: "Disco Nirvana", Effect Duration: 64
@@ -3427,10 +3427,10 @@
 3460	stale fuchsia tin rations	3	decent	
 3461	haiku challenge map	0		
 3462	red terrible poem	0		
-3463	triple-distilled aged bottle of sake	6	awesome	
+3463	aged triple-distilled bottle of sake	6	awesome	
 3464	supercharged round pebble	0		Maximum MP Percent: +30
 3465	moldy miniature Bash-&#332;s cereal	2	crappy	Wiki Name: "Bash-Os cereal"
-3466	olive friendly haiku katana of the wise owl of the overflowing toilet	0		Mysticality: +20, Familiar Weight: +3, Stench Spell Damage: +50, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	olive friendly haiku katana of the wise owl of the overflowing toilet	0		Mysticality: +20, Familiar Weight: +3, Stench Spell Damage: +50, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	jittery bargain flash powder	0		
 3468	plastic baby of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2008-12"
 3469	normal blueberry-frosted king cake	4	good	Last Available: "2008-12"
@@ -3438,7 +3438,7 @@
 3471	damp boot	0		
 3472	spinning fireproof MacGyver's Seasonal Beret of the pedagogue	0		Experience: +3, Maximum MP: +100, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
-3474	quantum cold-filtered skewed ghostly cranberry cordial	0		Effect: "Wax On Your Shoes", Effect Duration: 19
+3474	quantum cold-filtered ghostly skewed cranberry cordial	0		Effect: "Wax On Your Shoes", Effect Duration: 19
 3475	moist bouncing blackberry polite	0		Effect: "Cool, Catlike", Effect Duration: 60
 3476	dry boiled plum lozenge	0		Effect: "Almost Cool", Effect Duration: 24
 3477	dry pear lozenge	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 13
@@ -3462,18 +3462,18 @@
 3495	quadruple-tarnished quantum sea salt crystal	0		Effect: "Winklered", Effect Duration: 13
 3496	non-quantum modified bouncing bazookafish bubble gum	0		Effect: "Sweet and Green", Effect Duration: 29
 3497	high-proof tolerable pulsating narrow bottle of Pete's Sake	8	good	
-3498	red invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	bouncing witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	cyan beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	huge rotten canap&eacute;s	6	crappy	
+3498	red invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	bouncing witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	cyan beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3501	rotten huge canap&eacute;s	6	crappy	
 3502	altered ghostly thermos of brew	1	crappy	Last Available: "2011-12"
 3503	mediocre glass of brandy	3	decent	Last Available: "2011-12"
 3504	French slippers	0		
 3505	upside-down LWA ring of the brute	0		Muscle Percent: +30
-3506	narrow pulsating LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3506	pulsating narrow LARP membership card	0		Last Available: "2008-10"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	twirling scratch 'n' sniff sword of the sewer	0		Stench Damage: +25, Last Available: "2008-11"
-3509	spinning lime green huge scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
+3509	lime green huge spinning scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	green scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	jittery scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
@@ -3489,7 +3489,7 @@
 3522	sage shark jumper of the brute	0		Muscle Percent: +30, Mysticality Percent: +10
 3523	vacuum-sealed unsweetened maroon shark cartilage	0		Effect: "Dirge of Dreadfulness", Effect Duration: 18
 3524	cold-filtered eel battery	0		Effect: "items.enh", Effect Duration: 14
-3525	moist blurry blinking temporary teardrop tattoo	0		Effect: "Robocamo", Effect Duration: 31
+3525	moist blinking blurry temporary teardrop tattoo	0		Effect: "Robocamo", Effect Duration: 31
 3526	Sinatra's scratch 'n' sniff crossbow	0		Experience (Moxie): +5, Last Available: "2008-11"
 3527	mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
@@ -3510,26 +3510,26 @@
 3543	ribald energetic depleted Grimacite gravy boat	0		Maximum MP Percent: +20, Sleaze Damage: +10, Last Available: "2011-12"
 3544	rosewater-soaked Jack Frost's depleted Grimacite weightlifting belt	0		Cold Spell Damage: +50, Stench Resistance: +3, Single Equip, Last Available: "2011-12"
 3545	depleted Grimacite grappling hook of dire peril of bravery	0		Weapon Damage: +20, Spooky Resistance: +5, Single Equip, Last Available: "2011-12"
-3546	ruddy depleted Grimacite ninja mask of the wise owl	0		Mysticality: +20, Maximum HP Percent: +40, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	crafty depleted Grimacite shinguards of chilblains	0		Maximum MP: +10, Cold Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	ruddy depleted Grimacite ninja mask of the wise owl	0		Mysticality: +20, Maximum HP Percent: +40, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	crafty depleted Grimacite shinguards of chilblains	0		Maximum MP: +10, Cold Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	pulsating censurious Herculean depleted Grimacite astrolabe	0		Experience (Muscle): +1, Sleaze Resistance: +3, Single Equip, Last Available: "2011-12"
 3549	Lo Pan's curative KoL Con Cinco Pi&ntilde;ata Bat	0		Spell Critical Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2008-09"
 3550	asbestos-lined propeller beanie	0		Hot Resistance: +5, Familiar Effect: "atk, cap 7"
 3551	narrow educational savvy straw hat of the storm	0		Mysticality Percent: +20, Experience: +1, Maximum MP Percent: +40, Familiar Effect: "1xFairy"
 3552	Jeselnik's sharpshooter's octopus's spade	0		Critical Hit Percent: +10, Sleaze Damage: +25, Item Drop: +5
 3553	soggy seed packet	0		
-3554	blue jittery mirror glob of slime	0		
+3554	mirror blue jittery glob of slime	0		
 3555	moldy sea carrot	3	crappy	
 3556	adequate sea cucumber	4	good	
 3557	normal bouncing sea avocado	3	good	
 3558	spoiled sea lychee	4	crappy	
 3559	half-sized spoiled tumbling sea tangelo	2	crappy	
-3560	special adequate half-sized sea honeydew	2	good	Effect: "Elron's Explosive Etude", Effect Duration: 15
+3560	special half-sized adequate sea honeydew	2	good	Effect: "Elron's Explosive Etude", Effect Duration: 15
 3561	tarnished energized pressurized potion of puissance	0		Effect: "You Know Who to Call", Effect Duration: 22
 3562	quantum pressurized potion of perspicacity	0		Effect: "Nothing Is Impossible", Effect Duration: 52
 3563	super-corrupted pressed pressurized potion of pulchritude	0		Effect: "Coy to the Hurled", Effect Duration: 60
-3564	aged watered-down berry-infused sake	2	awesome	
-3565	bad weak mirror tumbling citrus-infused sake	2	decent	
+3564	watered-down aged berry-infused sake	2	awesome	
+3565	bad weak tumbling mirror citrus-infused sake	2	decent	
 3566	practically non-alcoholic smooth mirror melon-infused sake	1	awesome	
 3567	slab of sponge	0		
 3568	zippy Newton's sponge helmet of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Initiative: +20, Familiar Effect: "atk, 1xFairy"
@@ -3545,10 +3545,10 @@
 3578	pulsating candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
-3581	pulsating upside-down gray sushi-rolling mat	0		
+3581	upside-down gray pulsating sushi-rolling mat	0		
 3582	adequate rice	3	good	
-3584	small decent irradiated candy cane	2	good	Last Available: "2008-12"
-3585	bite-sized bland blinking gingerbread mutant bugbear	1	decent	Last Available: "2008-12"
+3584	decent small irradiated candy cane	2	good	Last Available: "2008-12"
+3585	bland bite-sized blinking gingerbread mutant bugbear	1	decent	Last Available: "2008-12"
 3586	artisanal oozenog	3	EPIC	Last Available: "2008-12"
 3587	ionized jittery sugar plum	0		Effect: "Walberg's Dim Bulb", Effect Duration: 50, Last Available: "2008-12"
 3588	aerosolized magnetized twirling sugar banana	0		Effect: "Haunted Liver", Effect Duration: 68, Last Available: "2008-12"
@@ -3576,20 +3576,20 @@
 3610	imitation whetstone	0		
 3611	activated sea grease	0		Effect: "Compensatory Cruelness", Effect Duration: 24
 3612	sturdy Crimbo crate	0		Last Available: "2008-12"
-3613	teal upside-down battered Crimbo Crate	0		Last Available: "2008-12"
-3614	olive pulsating twitching claw	0		Last Available: "2008-12"
+3613	upside-down teal battered Crimbo Crate	0		Last Available: "2008-12"
+3614	pulsating olive twitching claw	0		Last Available: "2008-12"
 3615	blinking rigid carapace	0		Last Available: "2008-12"
 3616	green pulsing flesh	0		Last Available: "2008-12"
 3617	frozen unstable DNA	0		Effect: "Angry like the Wolf", Effect Duration: 52, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	huge wriggling tentacle	0		Last Available: "2008-12"
 3620	twirling mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	squat chilly parasitic claw	0		Cold Damage: +5, Last Available: "2008-12"
-3625	mirror parasitic tentacles of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	scorching parasitic headgnawer	0		Hot Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	mirror parasitic tentacles of the dark arts	0		Spell Damage Percent: +100, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	scorching parasitic headgnawer	0		Hot Damage: +25, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	upside-down upside-down stanky parasitic strangleworm	0		Stench Spell Damage: +25, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	maroon burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,25 +3598,25 @@
 3632	teal radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	smelly grievous elven socks	0		Weapon Damage Percent: +50, Stench Spell Damage: +10, Last Available: "2008-12"
 3634	elven gloves of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, Last Available: "2008-12"
-3635	nippy festive holiday hat of the businessman	0		Cold Damage: +10, Meat Drop: +50, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	nippy festive holiday hat of the businessman	0		Cold Damage: +10, Meat Drop: +50, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	savvy wizardly patent shoes	0		Mysticality: +25, Mysticality Percent: +20, Last Available: "2008-12"
 3637	twirling blinking manspreader's gray bow tie of the wise owl	0		Mysticality: +20, Monster Level: +10, Last Available: "2008-12"
 3638	double-paned dog trainer's penguin thesaurus	0		Experience (familiar): +1, Cold Resistance: +5, Last Available: "2008-12"
 3639	moldy gray blob-shaped Crimbo cookie	3	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	green seaweed	0		
-3641	bouncing cyan jamfish jam	0		
+3641	cyan bouncing jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	shaking pufferfish spine	0		
 3644	brainy depleted Grimacite kneecapping stick	0		Mysticality: +5, Last Available: "2007-06"
-3645	mediocre bouncing yellow blurry canteen of wine	4	decent	Last Available: "2008-12"
-3646	small spoiled elven <i>limbos</i> gingerbread	2	crappy	Last Available: "2008-12"
+3645	mediocre yellow bouncing blurry canteen of wine	4	decent	Last Available: "2008-12"
+3646	spoiled small elven <i>limbos</i> gingerbread	2	crappy	Last Available: "2008-12"
 3647	spinning elven whittling knife	0		Last Available: "2008-12"
 3648	huge pulsating magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	adequate gigantic toast with jam	8	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	acceptable special bouncing elven moonshine	4	good	Effect: "Marinated", Effect Duration: 25, Last Available: "2008-12"
-3653	normal purple knuckle sandwich	3	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	special acceptable bouncing elven moonshine	4	good	Effect: "Marinated", Effect Duration: 25, Last Available: "2008-12"
+3653	normal purple knuckle sandwich	3	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	scorching veiny psycho sweater	0		Maximum HP: +10, Hot Damage: +25, Last Available: "2008-12"
 3655	blurry fin-bit wax	0		Familiar Weight: +5
 3656	hale plastic Mob Penguin	0		Maximum HP: +20, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	slick plastic strand of DNA	0		Moxie: +10, Last Available: "2008-12"
 3660	huge dangerous plastic chunk of depleted Grimacite	0		Weapon Damage: +10, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	Putty mitre of the cougar	0		Moxie: +20, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	Van der Graaf banded Putty leotard	0		Damage Absorption: +100, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	Putty mitre of the cougar	0		Moxie: +20, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	Van der Graaf banded Putty leotard	0		Damage Absorption: +100, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	lime green Putty ball of Calamity Jane	0		Critical Hit Percent: +15, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	spinning auspicious Jack Frost's wizardly Putty snake	0		Mysticality: +25, Cold Spell Damage: +50, Item Drop: +10, Softcore Only, Last Available: "2009-01"
@@ -3642,7 +3642,7 @@
 3676	tumbling Mer-kin foodbucket	0		
 3677	blinking diving muff of the sewer	0		Stench Damage: +25, Single Equip
 3678	bad salinated mint julep	4	decent	
-3679	upside-down squat ink bladder	0		
+3679	squat upside-down ink bladder	0		
 3680	esca	0		
 3681	mirror bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
@@ -3652,9 +3652,9 @@
 3686	adequate tempura avocado	3	good	
 3687	flavorless squat sea broccoli	3	decent	
 3688	bland immense sea cauliflower	6	decent	
-3689	diet flavorless shaking tempura broccoli	1	decent	
+3689	flavorless diet shaking tempura broccoli	1	decent	
 3690	flavorless squat tempura cauliflower	3	decent	
-3691	normal fancy wobbly sea blueberry	4	good	Effect: "Bastard!", Effect Duration: 25
+3691	fancy normal wobbly sea blueberry	4	good	Effect: "Bastard!", Effect Duration: 25
 3692	miniature stale upside-down sea persimmon	2	decent	
 3693	galvanized corrupted lime green pressurized potion of perception	0		Effect: "Super Vision", Effect Duration: 32
 3694	galvanized pressurized potion of proficiency	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 37
@@ -3681,15 +3681,15 @@
 3715	twirling scorching resourceful banded vinyl shield	0		Damage Absorption: +100, Maximum MP: +50, Hot Damage: +25, Damage Reduction: 14
 3716	perfumed asbestos-lined deadly vinyl boots	0		Weapon Damage: +5, Hot Resistance: +5, Stench Resistance: +5, Single Equip
 3717	wobbly decaying oar	0		
-3718	purple ghostly twirling fishhook	0		
+3718	ghostly twirling purple fishhook	0		
 3719	cyan lantern	0		
 3720	wobbly decaying pole	0		
 3721	tumbling cyan decaying paddle	0		
-3722	squat ghostly spinning maroon tarnished ring	0		
+3722	maroon ghostly squat spinning tarnished ring	0		
 3723	cyan tarnished rod	0		
 3724	brittle plastic handle	0		
-3725	squat twirling foggy glass globe	0		
-3726	lime green ghostly squat possessed tomato	0		
+3725	twirling squat foggy glass globe	0		
+3726	squat lime green ghostly possessed tomato	0		
 3727	Nardz energy beverage	0		
 3728	narrow pile of coins	0		
 3729	hand grenegg	0		
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	ribald Herculean handwarmer	0		Experience (Muscle): +1, Sleaze Damage: +10, Single Equip
 3737	family-friendly lighter of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +1
-3738	toothsome tumbling yellow packet of beer nuts	3	awesome	
+3738	toothsome yellow tumbling packet of beer nuts	3	awesome	
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	wobbly spectral jelly	0		
@@ -3714,7 +3714,7 @@
 3749	extra-aerosolized wobbly concoction of clumsiness	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 20
 3750	wobbly Jeselnik's vampire pearl earring	0		Sleaze Damage: +25, Single Equip
 3751	normal diet chocolate chip brownies	1	good	
-3753	bouncing Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	bouncing Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	enhanced blurry love song of vague ambiguity	0		Effect: "Hot Hands", Effect Duration: 29, Last Available: "2009-02"
 3755	triple-quantum love song of smoldering passion	0		Effect: "Engorged Weapon", Effect Duration: 23, Last Available: "2009-02"
 3756	ionized pressed love song of icy revenge	0		Effect: "Mystic Circle", Effect Duration: 37, Last Available: "2009-02"
@@ -3726,13 +3726,13 @@
 3762	savvy vampire pearl necklace	0		Mysticality Percent: +20, Single Equip
 3763	lousy enchanted slug of vodka	3	decent	Effect: "Dilated Pupils", Effect Duration: 50
 3764	drinkable slug of rum	3	good	
-3765	weak drinkable blinking slug of shochu	2	good	
+3765	drinkable weak blinking slug of shochu	2	good	
 3766	perfectly mixed screwdiver	4	EPIC	
 3767	mediocre upside-down dew yoana lei	3	decent	
 3768	aged purple lychee chuhai	3	awesome	
-3769	bad boozy fancy wobbly salacious screwdiver	5	decent	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 25
+3769	boozy fancy bad wobbly salacious screwdiver	5	decent	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 25
 3770	boozy mediocre dew yoana salacious lei	5	decent	
-3771	lousy high-proof salacious lychee chuhai	8	decent	
+3771	high-proof lousy salacious lychee chuhai	8	decent	
 3772	hand-crafted practically non-alcoholic squat Alewife&trade; Ale	1	EPIC	
 3773	seaode	0		
 3774	narrow map to the Dive Bar	0		
@@ -3740,7 +3740,7 @@
 3776	gray padded wicked pink pinkslip slip	0		Spell Damage: +5, Damage Absorption: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3777	twirling lard-coated Oprah's sea salt scrubs	0		Maximum MP Percent: +50, Sleaze Spell Damage: +25
 3778	ghostly extremely unsafe supercool amber aviator shades of the boozehound	0		Moxie Percent: +20, Weapon Damage Percent: +100, Booze Drop: +100, Single Equip
-3779	flattened polarized blurry skewed hair of the fish	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 19
+3779	flattened polarized skewed blurry hair of the fish	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 19
 3780	resourceful therapeutic nurse's hat of extreme caution	0		Maximum MP: +50, Monster Level: -25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk"
 3781	blank prescription sheet	0		
 3782	vaporized pulsating bottle of melodramamine	1		Effect: "Elron's Explosive Etude", Effect Duration: 40
@@ -3753,8 +3753,8 @@
 3789	purple twitching trigger finger	0		Class: "Pastamancer"
 3799	shaking Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	yellow aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	stanky smelly brainy Mer-kin roundshield	0		Mysticality: +5, Stench Spell Damage: 35, Damage Reduction: 14
 3804	teal huge Fonzie's Mer-kin breastplate of temperance	0		Experience (Moxie): +1, Sleaze Resistance: +5
 3805	lime green lion tamer's Temple Grandin's Mer-kin sneakmask	0		Familiar Weight: +7, Experience (familiar): +2, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,7 +3768,7 @@
 3813	green supercool plastic baby	0		Moxie Percent: +20, Single Equip, Last Available: "2009-06"
 3815	yellow midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	bland snack-sized sea radish	2	decent	
+3817	snack-sized bland sea radish	2	decent	
 3818	mirror asbestos-lined halibut of dire peril of incineration	0		Weapon Damage: +20, Hot Spell Damage: +50, Hot Resistance: +5
 3819	blinking eel sauce	0		
 3820	Sinatra's water-polo mitt	0		Experience (Moxie): +5, Single Equip
@@ -3780,14 +3780,14 @@
 3826	blinking Grandma's Chartreuse Yarn	0		
 3827	ghostly plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	jumbo normal tempura radish	5	good	
+3829	normal jumbo tempura radish	5	good	
 3830	lightning-fast water-polo cap	0		Initiative: +40, Familiar Effect: "1xVolley, 1xBarrr"
-3831	bad watered-down Typical Tavern swill	2	decent	
+3831	watered-down bad Typical Tavern swill	2	decent	
 3832	bad tropical swill	3	decent	
-3833	lousy spirit-forward blinking fruity girl swill	5	decent	
+3833	spirit-forward lousy blinking fruity girl swill	5	decent	
 3834	delicious blended swill	3	awesome	
 3835	costume wardrobe	0		Softcore Only
-3836	squat zippy Annie Oakley's slick Elvish sunglasses of the sweet-tooth	0		Moxie: +10, Critical Hit Percent: +20, Candy Drop: +100, Initiative: +20, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	squat zippy Annie Oakley's slick Elvish sunglasses of the sweet-tooth	0		Moxie: +10, Critical Hit Percent: +20, Candy Drop: +100, Initiative: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	blurry brawny anniversary safety glass vest	0		Muscle Percent: +20
 3838	anniversary burlap belt of Calamity Jane	0		Critical Hit Percent: +15
 3839	sinister anniversary balsa wood socks	0		Spell Damage: +10
@@ -3835,7 +3835,7 @@
 3881	Lo Pan's fouet de tortue-dressage of horror	0		Spell Critical Percent: +30, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
 3883	cult memo	0		
-3884	skewed shaking decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
+3884	shaking skewed decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	colloidal vial of slime	0		Effect: "Extra Terrestrial", Effect Duration: 64
 3886	quantum boiled squat vial of slime	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 23
 3887	flattened irradiated pulsating vial of slime	0		Effect: "The Smeezingtons", Effect Duration: 17
@@ -3848,7 +3848,7 @@
 3894	unsweetened double-dry vial of teal slime	0		Effect: "Phoenix, Right?", Effect Duration: 43
 3895	concentrated vial of indigo slime	0		Effect: "Dirty Pear", Effect Duration: 65
 3896	flattened pickled mirror vial of slime	0		Effect: "Sticks and Stones", Effect Duration: 42
-3897	quadruple-magnetized skewed ghostly vial of brown slime	0		Effect: "Super Structure", Effect Duration: 24
+3897	quadruple-magnetized ghostly skewed vial of brown slime	0		Effect: "Super Structure", Effect Duration: 24
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	practically non-alcoholic special aged shaking blended swill with a fly in it	1	awesome	Effect: "Sweet, Nuts", Effect Duration: 5
+3913	aged special practically non-alcoholic shaking blended swill with a fly in it	1	awesome	Effect: "Sweet, Nuts", Effect Duration: 5
 3914	turtle wax	0		
 3915	brawny turtle wax shield	0		Muscle Percent: +20, Damage Reduction: 2
 3916	narrow razor-sharp turtle wax helmet	0		Weapon Damage Percent: +25, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3900,7 +3900,7 @@
 3948	Meat	0		
 3949	treasure chest	0		
 3950	huge key	0		
-3951	bouncing wobbly Baron von Ratsworth	0		
+3951	wobbly bouncing Baron von Ratsworth	0		
 3952	monocle	0		
 3953	mink	0		
 3954	teddy butler	0		
@@ -3911,7 +3911,7 @@
 3959	yellow garish pinky ring of the scaredy-cat	0		Monster Level: -15
 3960	baleful designer sunglasses	0		Spell Damage: +25, Single Equip
 3961	cyan avaricious opera glasses of the early riser	0		Meat Drop: +30, Adventures: +7
-3962	teal mirror designer handbag	0		
+3962	mirror teal designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
 3965	frozen deionized liquefied cube of billiard chalk	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 57
@@ -3949,7 +3949,7 @@
 3997	dolphin whistle	0		
 3998	metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
-4000	maroon squat string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
+4000	squat maroon string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	compressed spinning agua de vida	1	decent	Last Available: "2009-06"
 4002	Lo Pan's experienced tortoboggan shield	0		Experience: +2, Spell Critical Percent: +30, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
@@ -3987,18 +3987,18 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	upside-down caustic slime nodule	0		
 4037	stale teal slimy sweetbreads	4	decent	
-4038	perfectly mixed watered-down slimy fermented bile bladder	2	EPIC	
+4038	watered-down perfectly mixed slimy fermented bile bladder	2	EPIC	
 4039	distilled shaking slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	rosewater-soaked supercharged pig-iron helm	0		Maximum MP Percent: +30, Stench Resistance: +3, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	zippy pig-iron shinguards of chilblains	0		Cold Damage: +25, Initiative: +20, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	rosewater-soaked supercharged pig-iron helm	0		Maximum MP Percent: +30, Stench Resistance: +3, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	zippy pig-iron shinguards of chilblains	0		Cold Damage: +25, Initiative: +20, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	lime green inspector's pig-iron bracers of the glutton	0		Item Drop: +15, Food Drop: +100, Single Equip, Last Available: "2009-06"
 4044	shaking bouncing wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	dog trainer's wumpus-hair whip	0		Experience (familiar): +1, Last Available: "2009-06"
-4048	dangerous wumpus-hair wig of the scaredy-cat of extreme caution	0		Weapon Damage: +10, Monster Level: -40, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	cyan Annie Oakley's supercharged occult wumpus-hair loincloth	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Critical Hit Percent: +20, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	dangerous wumpus-hair wig of the scaredy-cat of extreme caution	0		Weapon Damage: +10, Monster Level: -40, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	cyan Annie Oakley's supercharged occult wumpus-hair loincloth	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Critical Hit Percent: +20, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	wumpus-hair sweater of the wise owl of horror	0		Mysticality: +20, Spooky Spell Damage: +25, Last Available: "2009-06"
 4051	squat Herculean ring of teleportation	0		Experience (Muscle): +1, Single Equip
 4052	glass of baboon milk	1	crappy	Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	boiled tumbling tempura air	0		Effect: "Good Karma", Effect Duration: 44
 4134	warmed twirling pressurized potion of pneumaticity	0		Effect: "Blessing of Charcoatl", Effect Duration: 53
 4135	wobbly moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	smelly coward's Oprah's Bag o' Tricks of incineration	0		Maximum MP Percent: +50, Monster Level: -20, Hot Spell Damage: +50, Stench Spell Damage: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	smelly coward's Oprah's Bag o' Tricks of incineration	0		Maximum MP Percent: +50, Monster Level: -20, Hot Spell Damage: +50, Stench Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	teal a creased paper strip	0		
@@ -4103,15 +4103,15 @@
 4151	ionized polymerized dubious peppermint	0		Effect: "Disco Inferno", Effect Duration: 64, Last Available: "2020-09"
 4152	quantum non-boiled Elvish delight	0		Effect: "Cute Vision", Effect Duration: 65
 4153	bouncing rockfish stomach	0		Last Available: "2009-09"
-4154	pulsating huge live lobster	0		Last Available: "2011-12"
+4154	huge pulsating live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
 4157	upside-down gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	hand-crafted strong pebblebr&auml;u	5	EPIC	Last Available: "2009-09"
+4160	strong hand-crafted pebblebr&auml;u	5	EPIC	Last Available: "2009-09"
 4161	bland massive jittery rocky road ice cream	10	decent	Last Available: "2009-09"
-4162	blue upside-down extra-strength rubber bands	0		Familiar Weight: +5
+4162	upside-down blue extra-strength rubber bands	0		Familiar Weight: +5
 4163	magnetized children of the candy corn	0		Effect: "Arresistible", Effect Duration: 47
 4164	warmed blurry Good 'n' Slimy	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 36
 4165	skewed greasy electrified baleful Staff of the Soupbone	0		Spell Damage: +25, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5
@@ -4130,8 +4130,8 @@
 4178	manspreader's sugar shotgun	0		Monster Level: +10, Last Available: "2009-09"
 4179	bouncing pulsating rosewater-soaked sugar shillelagh	0		Stench Resistance: +3, Last Available: "2009-09"
 4180	curative sugar shank	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09"
-4181	wobbly lard-coated scorching weightlifter's sugar chapeau	0		Muscle: +15, Hot Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	flame-retardant sugar shorts	0		Hot Resistance: +1, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	wobbly lard-coated scorching weightlifter's sugar chapeau	0		Muscle: +15, Hot Damage: +25, Sleaze Spell Damage: +25, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	flame-retardant sugar shorts	0		Hot Resistance: +1, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	lime green bouncing bouncing slime convention swag bag	0		
 4185	pulsating slime convention flyers	0		
@@ -4172,13 +4172,13 @@
 4220	S.A.V.E. flyer	0		
 4221	rock-hard yield shield	0		Damage Reduction: 11, Last Available: "2009-09"
 4222	shaking map to the Skate Park	0		
-4223	squat green squamous polyp	0		Free Pull, Last Available: "2011-12"
+4223	green squat squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	roller skate doll	0		
 4226	pulsating boxer's Star of Bravery	0		Muscle Percent: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	mirror perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	gray amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	gray amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bouncing bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	squat salt-shaker	0		
 4236	gray squat can of sterno	0		
 4237	cheese-slicer of the dark arts	0		Spell Damage Percent: +100
-4238	snack-sized adequate beef jerky	2	good	
+4238	adequate snack-sized beef jerky	2	good	
 4239	banded pipe wrench	0		Damage Absorption: +100
 4240	denatured flattened gun cleaning kit	0		Effect: "Winning Smile", Effect Duration: 67
 4241	avaricious sleep mask	0		Meat Drop: +30, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4205,16 +4205,16 @@
 4253	galvanized potion of speed	0		Effect: "Pie in the Sky", Effect Duration: 14
 4254	jittery squat bark	0		Last Available: "2009-10"
 4255	lime green Wolfman Nardz	0		Last Available: "2009-10"
-4256	super-galvanized enhanced galvanized gray upside-down huge sap	0		Effect: "Virgo Rising", Effect Duration: 61, Last Available: "2009-10"
+4256	super-galvanized enhanced galvanized gray huge upside-down sap	0		Effect: "Virgo Rising", Effect Duration: 61, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	adequate blurry jittery chocolate-covered scarab beetle	4	good	Last Available: "2009-10"
 4259	aged green mulled cider	3	awesome	Last Available: "2009-10"
-4260	twirling wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	twirling wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	Sinatra's bark boxers	0		Experience (Moxie): +5, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	upside-down grievous bark beret	0		Weapon Damage Percent: +50, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	Sinatra's bark boxers	0		Experience (Moxie): +5, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	upside-down grievous bark beret	0		Weapon Damage Percent: +50, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	pulsating bark bracelet of the glutton	0		Food Drop: +100, Single Equip
 4267	Sherlock's double-paned Krakrox's Loincloth	0		Cold Resistance: +5, Item Drop: +25, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	tumbling toasty sage Galapagosian Cuisses	0		Mysticality Percent: +10, Hot Damage: +5, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	wool grievous Ass-Stompers of Violence of extreme caution	0		Weapon Damage Percent: +50, Monster Level: -25, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	energetic stiffened personal trainer's Brand of Violence	0		Experience Percent (Muscle): +10, Damage Reduction: 1, Maximum MP Percent: +20, Conditional Skill (Equipped): "Brand"
 4299	Novelty Belt Buckle of Violence of the dark arts of the blizzard of mayonnaise	0		Spell Damage Percent: +100, Cold Spell Damage: +25, Sleaze Spell Damage: +50, Single Equip
-4300	knitted Fonzie's Lens of Violence of incineration	0		Experience (Moxie): +1, Hot Spell Damage: +50, Cold Resistance: +3, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	knitted Fonzie's Lens of Violence of incineration	0		Experience (Moxie): +1, Hot Spell Damage: +50, Cold Resistance: +3, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	twirling teal resourceful fortified Pigsticker of Violence of the sweet-tooth	0		Damage Absorption: +60, Maximum MP: +50, Candy Drop: +100
-4302	auspicious horrifying groovy Jodhpurs of Violence	0		Moxie Percent: +10, Spooky Damage: +25, Item Drop: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	auspicious horrifying groovy Jodhpurs of Violence	0		Moxie Percent: +10, Spooky Damage: +25, Item Drop: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	shellacked studded boxer's Cold Stone of Hatred	0		Muscle Percent: +10, Damage Absorption: +80, Damage Reduction: 7, Conditional Skill (Equipped): "Chilling Grip"
 4304	yellow prompt Samson's boxer's Girdle of Hatred	0		Muscle Percent: +10, Experience (Muscle): +5, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	vibrating veiny Staff of Simmering Hatred of the cougar	0		Moxie: +20, Maximum HP: +10, Maximum MP Percent: +10
-4306	friendly forbidden Pantaloons of Hatred of wisdom	0		Mysticality: +15, Spell Damage Percent: +50, Familiar Weight: +3, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	friendly forbidden Pantaloons of Hatred of wisdom	0		Mysticality: +15, Spell Damage Percent: +50, Familiar Weight: +3, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	prompt MacGyver's veiny Fuzzy Slippers of Hatred	0		Maximum HP: +10, Maximum MP: +100, Adventures: +3, Single Equip
-4308	twirling fuchsia gravedigger's Lens of Hatred of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Spooky Damage: +10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	twirling fuchsia gravedigger's Lens of Hatred of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Spooky Damage: +10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	executive lion tamer's MacGyver's Treads of Loathing	0		Maximum MP: +100, Experience (familiar): +2, Meat Drop: +40, Single Equip
 4310	frosty curative strapping Scepter of Loathing	0		Muscle: +5, Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 4311	spinning flame-retardant Jeselnik's stanky Belt of Loathing	0		Stench Spell Damage: +25, Sleaze Damage: +25, Hot Resistance: +1, Single Equip
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	blinking gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	chilly snow hat	0		Cold Damage: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	squat manspreader's snow pants	0		Monster Level: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	chilly snow hat	0		Cold Damage: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	squat manspreader's snow pants	0		Monster Level: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	squat razor-sharp snow belly	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4310,7 +4310,7 @@
 4358	maroon A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	spoiled gray ghostly expired can of franks 'n' beans	3	crappy	Last Available: "2009-12"
-4361	irresponsibly strong perfectly mixed expired bottle of peppermint schnapps	6	EPIC	Last Available: "2009-12"
+4361	perfectly mixed irresponsibly strong expired bottle of peppermint schnapps	6	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	cold-filtered maroon elven suicide capsule	0		Effect: "Frozen Hands", Effect Duration: 22, Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	savvy brainy pocketwatch on a chain	0		Mysticality: +5, Mysticality Percent: +20, Last Available: "2009-12"
 4386	experienced cement sandals of the brute	0		Muscle Percent: +30, Experience: +2, Single Equip, Last Available: "2009-12"
 4387	twirling Van der Graaf night-vision goggles of the dark arts	0		Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2009-12"
-4388	red passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	red passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	dance instructor's peanut brittle shield	0		Experience Percent (Moxie): +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	frightening smartaleck's Red Rover BB gun	0		Moxie Percent: +30, Spooky Damage: +5, Last Available: "2009-12"
-4391	pulsating wizardly red-and-green sweater	0		Mysticality: +25, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	pulsating wizardly red-and-green sweater	0		Mysticality: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	chilled polarized wobbly Crimbo peppermint bark	0		Effect: "Wintry Breath", Effect Duration: 28, Last Available: "2009-12"
 4394	super-warmed vacuum-sealed huge Crimbo fudge	0		Effect: "Fratty Flavor", Effect Duration: 41, Last Available: "2009-12"
@@ -4349,20 +4349,20 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	personal trainer's cheese sword	0		Experience Percent (Muscle): +10, Softcore Only, Last Available: "2010-01"
-4400	huge beefy cheese diaper	0		Muscle: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	huge beefy cheese diaper	0		Muscle: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	spinning friendly cheese wheel	0		Familiar Weight: +3, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	spinning ghostly wizardly cheese eye	0		Mysticality: +25, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	spinning ghostly wizardly cheese eye	0		Mysticality: +25, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	mirror Rosewater's Staff of Queso Escusado of the wise owl of terror	0		Mysticality: +20, Mysticality Percent: +30, Spooky Spell Damage: +10, Softcore Only, Last Available: "2010-01"
 4405	ghostly foreign box	0		
-4406	upside-down spinning The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+4406	spinning upside-down The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	skewed Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	twirling A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	fuchsia The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	twirling Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	flavorless snack-sized quantum taco	0		Last Available: "2010-10"
+4412	snack-sized flavorless quantum taco	0		Last Available: "2010-10"
 4413	mediocre Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
-4414	pulsating blue colorful plastic ball	0		Last Available: "2010-01"
+4414	blue pulsating colorful plastic ball	0		Last Available: "2010-01"
 4415	smelly sealhide hood	0		Stench Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	blurry sinister sealhide leggings	0		Spell Damage: +10, Familiar Effect: "1xVolley, cap 40"
 4417	Rosewater's sealhide cloak	0		Mysticality Percent: +30
@@ -4378,7 +4378,7 @@
 4428	olive groovy glowstick on a string	0		Moxie Percent: +10
 4429	stanky candy necklace	0		Stench Spell Damage: +25, Single Equip
 4430	teddybear backpack of the brute	0		Muscle Percent: +30
-4431	skewed upside-down NPZR chemistry set	0		Last Available: "2011-08"
+4431	upside-down skewed NPZR chemistry set	0		Last Available: "2011-08"
 4432	concentrated magnetized invisibility potion	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 34, Last Available: "2011-08"
 4433	colloidal flattened electrified irresistibility potion	0		Effect: "Bubblin' Rage", Effect Duration: 58, Last Available: "2011-08"
 4434	galvanized dry narrow irritability potion	0		Effect: "Spookyravin'", Effect Duration: 17, Last Available: "2011-08"
@@ -4393,10 +4393,10 @@
 4445	Da Vinci's spangly mariachi pants	0		Experience (Mysticality): +5, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	curative spangly mariachi vest of doom	0		Spooky Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 4447	spangly sombrero of the pedagogue	0		Experience: +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	powdered tumbling shaking shaking Instant Karma	1	good	
+4448	powdered shaking shaking tumbling Instant Karma	1	good	
 4449	blurry painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	pointy hat of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	pointy hat of bravery	0		Spooky Resistance: +5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	narrow stiffened machetito	0		Damage Reduction: 1, Last Available: "2010-04"
 4453	savvy lawnmower blade	0		Mysticality Percent: +20, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4406,25 +4406,25 @@
 4458	steel-toed sinister snailmail coif	0		Spell Damage: +10, Damage Reduction: 9, Familiar Effect: "1xPotato, 1xFairy, cap 41"
 4459	jittery greedy smartaleck's snailmail breeches	0		Moxie Percent: +30, Meat Drop: +20, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
 4460	flame-retardant snailmail hauberk of Tarzan	0		Experience (Muscle): +3, Hot Resistance: +1
-4461	liquefied wobbly pulsating wobbly seal-brain elixir	0		Effect: "Gyromitra Gymnastics", Effect Duration: 67
+4461	liquefied pulsating wobbly wobbly seal-brain elixir	0		Effect: "Gyromitra Gymnastics", Effect Duration: 67
 4462	warmed chocolate seal-clubbing club	0		Effect: "Lubed", Effect Duration: 52
 4463	dry twirling chocolate turtle totem	0		Effect: "Carrion' On", Effect Duration: 23
 4464	galvanized pulsating twirling chocolate pasta spoon	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 42
 4465	dry deionized chocolate saucepan	0		Effect: "Engorged Weapon", Effect Duration: 14
 4466	electrified double-modified chocolate disco ball	0		Effect: "Voracious Gorging", Effect Duration: 22
 4467	liquefied purple narrow chocolate stolen accordion	0		Effect: "Chorale of Companionship", Effect Duration: 35
-4468	twirling Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	twirling Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	scorching BRICKO hat	0		Hot Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	skewed sage BRICKO pants	0		Mysticality Percent: +10, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	scorching BRICKO hat	0		Hot Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	skewed sage BRICKO pants	0		Mysticality Percent: +10, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	toasty BRICKO sword	0		Hot Damage: +5, Last Available: "2010-02"
 4474	upside-down BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
-4476	narrow olive BRICKO oyster	0		Last Available: "2010-02"
+4476	olive narrow BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	wobbly green BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	green wobbly BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	yellow BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4434,7 +4434,7 @@
 4486	huge BRICKO pearl	0		Last Available: "2010-02"
 4487	thinker's BRICKO bulwark	0		Mysticality: +10, Damage Reduction: 3, Last Available: "2010-02"
 4488	huge BRICKO trunk	0		Last Available: "2010-02"
-4489	blurry gray gilded BRICKO brick	0		Last Available: "2010-02"
+4489	gray blurry gilded BRICKO brick	0		Last Available: "2010-02"
 4490	maroon gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	tumbling BRICKO brick	0		Last Available: "2010-02"
 4492	tumbling BRICKO brick	0		Last Available: "2010-02"
@@ -4455,22 +4455,22 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	adjusted jittery &quot;DRINK ME&quot; potion	0		Effect: "Bandersnatched", Effect Duration: 62, Last Available: "2010-03"
 4509	shaking reflection of a map	0		Last Available: "2010-03"
-4510	moldy small blue narrow walrus ice cream	2	crappy	Last Available: "2010-03"
+4510	small moldy narrow blue walrus ice cream	2	crappy	Last Available: "2010-03"
 4511	bland beautiful soup	3	decent	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	stale Humpty Dumplings	3	decent	Last Available: "2010-03"
-4515	snack-sized flavorless tumbling Lobster <i>qua</i> Grill	2	decent	Last Available: "2010-03"
+4515	flavorless snack-sized tumbling Lobster <i>qua</i> Grill	2	decent	Last Available: "2010-03"
 4516	strong aged bouncing blurry missing wine	5	awesome	Last Available: "2010-03"
-4517	special miniature tasty matter custard	2	awesome	Effect: "Cautious Prowl", Effect Duration: 25, Last Available: "2010-03"
+4517	miniature tasty special matter custard	2	awesome	Effect: "Cautious Prowl", Effect Duration: 25, Last Available: "2010-03"
 4518	vacuum-sealed extra-magnetized mirror comfit?	0		Effect: "Nuts about Candy", Effect Duration: 19, Last Available: "2010-03"
-4519	upside-down gray ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
+4519	gray upside-down ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	stanky hale flamingo mallet	0		Maximum HP: +20, Stench Spell Damage: +25, Last Available: "2010-03"
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	sharpshooter's Sinatra's eye of the Tiger-lily	0		Experience (Moxie): +5, Critical Hit Percent: +10, Last Available: "2010-03"
-4524	upside-down Rosewater's wig of the cougar	0		Moxie: +20, Mysticality Percent: +30, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	spoiled half-sized donut	2	crappy	Last Available: "2010-03"
+4524	upside-down Rosewater's wig of the cougar	0		Moxie: +20, Mysticality Percent: +30, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	half-sized spoiled donut	2	crappy	Last Available: "2010-03"
 4526	miniature tasty bucket of honey	2	awesome	Last Available: "2010-03"
 4527	hardy beefy elephant stinger	0		Muscle: +10, Maximum HP: +50, Last Available: "2010-03"
 4528	moldy blurry dragon snaps	3	crappy	Last Available: "2010-03"
@@ -4479,18 +4479,18 @@
 4531	bland rook cookie	4	decent	Last Available: "2010-03"
 4532	immense normal bishop cookie	8	good	Last Available: "2010-03"
 4533	adequate knight cookie	4	good	Last Available: "2010-03"
-4534	tiny normal king cookie	1	good	Last Available: "2010-03"
-4535	diet moldy red skewed queen cookie	1	crappy	Effect: "Towering Strength", Last Available: "2010-03"
+4534	normal tiny king cookie	1	good	Last Available: "2010-03"
+4535	diet moldy skewed red queen cookie	1	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	ghostly fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	bouncing insane tophat	0		Item Drop: +5, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	shaking blinking nasty helm of the knight of horror	0		Stench Damage: +5, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	bouncing insane tophat	0		Item Drop: +5, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	shaking blinking nasty helm of the knight of horror	0		Stench Damage: +5, Spooky Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	mirror reassuring ribald wristwatch of the knight	0		Sleaze Damage: +10, Spooky Resistance: +1, Single Equip, Last Available: "2010-03"
-4540	beefy trousers of the knight of the blizzard	0		Muscle: +10, Cold Spell Damage: +25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	beefy trousers of the knight of the blizzard	0		Muscle: +10, Cold Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	tophat of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xBarrr, cap 25"
 4542	Da Vinci's tie	0		Experience (Mysticality): +5, Single Equip
 4543	Samson's tuxedo pants	0		Experience (Muscle): +5, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 4544	blinking porpoise	0		Last Available: "2010-03"
-4545	squat mirror pocketwatch	0		Last Available: "2010-03"
+4545	mirror squat pocketwatch	0		Last Available: "2010-03"
 4546	bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
@@ -4501,7 +4501,7 @@
 4553	lowercase a	0		
 4554	percent sign	0		
 4555	left bracket	0		
-4556	pulsating gray right parenthesis	0		
+4556	gray pulsating right parenthesis	0		
 4557	dollar sign	0		
 4558	skewed equal sign	0		
 4559	cyan record album	0		Last Available: "2010-04"
@@ -4521,12 +4521,12 @@
 4573	blurry The Legendary Beat	0		Last Available: "2010-04"
 4574	wobbly panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	twirling huge meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	extra-oxidized Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Stogied", Effect Duration: 20, Last Available: "2010-04"
 4580	skewed school Mafi<i>a kni</i>cke&frac12;&aelig; of chilblains	0		Cold Damage: +25, Last Available: "2010-04"
-4581	Tesla T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	Tesla T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 7, MP Regen Max: 10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	blurry fat bottom quark	0		Last Available: "2010-05"
 4583	shaking glob of skin	0		
 4584	spoiled upside-down six wedges of goat cheese	4	crappy	
@@ -4543,16 +4543,16 @@
 4595	mirror pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
 4597	wobbly 8-Bit Power magazine	0		Last Available: "2010-07"
-4598	pulsating gray upside-down pixel stopwatch	0		Last Available: "2010-07"
+4598	pulsating upside-down gray pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	maroon map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	aged plastic cup of beer	4	awesome	Last Available: "2010-06"
 4602	blinking orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	smartaleck's bottle of Goldschn&ouml;ckered of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	half-sized special tasty sun-dried tofu	2	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	bad weak narrow maroon soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	smartaleck's bottle of Goldschn&ouml;ckered of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4606	tasty special half-sized sun-dried tofu	2	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	bad weak maroon narrow soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	pulsating respected companion biscuit	0		Last Available: "2010-08"
 4609	pulsating essential tofu	0		Last Available: "2010-08"
 4610	super-galvanized essential soy	0		Effect: "Smelly Pants", Effect Duration: 43, Last Available: "2010-08"
@@ -4568,21 +4568,21 @@
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	gray Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
-4623	quadruple-corrupted tumbling upside-down chocolate-covered caviar	0		Effect: "Musky", Effect Duration: 38, Last Available: "2020-09"
+4623	quadruple-corrupted upside-down tumbling chocolate-covered caviar	0		Effect: "Musky", Effect Duration: 38, Last Available: "2020-09"
 4624	jumbo bland pawn cookie	5	decent	Last Available: "2010-06"
 4625	modified spinning coffee pixie stick	1	crappy	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
-4627	blinking blurry finger cuffs	0		Last Available: "2010-06"
+4627	blurry blinking finger cuffs	0		Last Available: "2010-06"
 4628	cyan parachute guy	0		Last Available: "2010-06"
-4629	forbidden plastic spider ring	0		Spell Damage Percent: +50, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	forbidden plastic spider ring	0		Spell Damage Percent: +50, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	fuchsia executive plastic kazoo	0		Meat Drop: +40, Last Available: "2010-06"
 4631	curative inflatable baseball bat	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-06"
-4632	blue Annie Oakley's Herculean googly-star hat	0		Experience (Muscle): +1, Critical Hit Percent: +20, Familiar Effect: "atk", Last Available: "2010-06"
+4632	blue Annie Oakley's Herculean googly-star hat	0		Experience (Muscle): +1, Critical Hit Percent: +20, Last Available: "2010-06", Familiar Effect: "atk"
 4633	squat tumbling rosy-cheeked educational googly-ball hat	0		Experience: +1, Maximum HP Percent: +30, Last Available: "2010-06"
 4634	Socratic cool googly-heart hat	0		Moxie: +5, Experience (Mysticality): +1, Last Available: "2010-06"
 4635	quilted dangerous super-sweet boom box	0		Weapon Damage: +10, Damage Absorption: +40, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	flame-retardant frosty stiffened sinister demon mask	0		Damage Reduction: 1, Cold Spell Damage: +10, Hot Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	flame-retardant frosty stiffened sinister demon mask	0		Damage Reduction: 1, Cold Spell Damage: +10, Hot Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	aromatic sizzling streetfighting champion's belt of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Stench Resistance: +1, Single Equip, Last Available: "2010-06"
 4639	smooth Space Trip safety headphones of horror of the sweet-tooth	0		Moxie: +15, Spooky Spell Damage: +25, Candy Drop: +100, Single Equip, Last Available: "2010-06"
 4640	brawny LARP carp	0		Muscle Percent: +20
@@ -4594,8 +4594,8 @@
 4646	double-paned thinker's Meteoid ice beam of the detective	0		Mysticality: +10, Cold Resistance: +5, Item Drop: +20, Last Available: "2011-12"
 4647	censurious sharpshooter's Dungeon Fist gauntlet of the brazier	0		Critical Hit Percent: +10, Hot Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2011-06"
 4648	pulsating Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	double-paned padded ironic knit cap	0		Damage Absorption: +20, Cold Resistance: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4616,19 +4616,19 @@
 4668	narrow supercool observational glasses	0		Moxie Percent: +20
 4669	shaking cool hilarious comedy prop	0		Moxie: +5
 4670	beer-scented teddy bear	0		
-4671	acceptable watered-down booze-soaked cherry	2	good	
-4672	shaking lime green comfy pillow	0		
+4671	watered-down acceptable booze-soaked cherry	2	good	
+4672	lime green shaking comfy pillow	0		
 4673	spoiled mirror marshmallow	3	crappy	
 4674	bite-sized normal sponge cake	1	good	
-4675	artisanal triple-distilled pulsating gin-soaked blotter paper	8	EPIC	
+4675	triple-distilled artisanal pulsating gin-soaked blotter paper	8	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	huge unearthed potsherd	0		
-4679	cyan jittery volcanic ash	0		
+4679	jittery cyan volcanic ash	0		
 4680	smoked potsherd	0		
 4681	mirror pottery shield of the brute	0		Muscle Percent: +30, Damage Reduction: 3, Last Available: "2010-09"
-4682	Usain Bolt's razor-sharp pottery hat	0		Weapon Damage Percent: +25, Initiative: +80, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	lion tamer's pottery training pants of the ox	0		Muscle: +20, Experience (familiar): +2, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	Usain Bolt's razor-sharp pottery hat	0		Weapon Damage Percent: +25, Initiative: +80, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	lion tamer's pottery training pants of the ox	0		Muscle: +20, Experience (familiar): +2, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	censurious pottery club	0		Sleaze Resistance: +3, Last Available: "2010-09"
 4685	pottery yo-yo of the detective	0		Item Drop: +20, Last Available: "2010-09"
 4686	ghostly pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	narrow fossilized torso	0		Last Available: "2010-09"
 4694	yellow fossilized spine	0		Last Available: "2010-09"
 4695	teal affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	squat tumbling hardy razor-sharp beefy Greatest American Pants	0		Muscle: +10, Weapon Damage Percent: +25, Maximum HP: +50, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	squat tumbling hardy razor-sharp beefy Greatest American Pants	0		Muscle: +10, Weapon Damage Percent: +25, Maximum HP: +50, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	shaking Temple Grandin's fossilized necklace	0		Familiar Weight: +7, Last Available: "2010-09"
 4698	green imp air	0		
 4699	mirror bus pass	0		
@@ -4658,10 +4658,10 @@
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	yellow GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
-4713	skewed bouncing olive popsicle stick	0		
+4713	bouncing skewed olive popsicle stick	0		
 4714	stale red lemon popsicle	3	decent	
-4715	moldy snack-sized popsicle	2	crappy	
-4716	spoiled special pulsating strawberry popsicle	3	crappy	Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 5
+4715	snack-sized moldy popsicle	2	crappy	
+4716	special spoiled pulsating strawberry popsicle	3	crappy	Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 5
 4717	normal liver popsicle	4	good	
 4718	zippy mariachi hat	0		Initiative: +20, Familiar Effect: "atk, cap 2"
 4719	double-paned Hollandaise helmet	0		Cold Resistance: +5, Familiar Effect: "atk, cap 2"
@@ -4669,12 +4669,12 @@
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	miniature rotten liver and let pie	2	crappy	Last Available: "2010-10"
 4723	decent badass pie	3	good	Last Available: "2010-10"
-4724	fancy spoiled wobbly shoo-fish pie	4	crappy	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2010-10"
-4725	small spoiled piping organ pie	2	crappy	Last Available: "2010-10"
+4724	spoiled fancy wobbly shoo-fish pie	4	crappy	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2010-10"
+4725	spoiled small piping organ pie	2	crappy	Last Available: "2010-10"
 4726	rotten igloo pie	3	crappy	Last Available: "2010-10"
 4727	decent bite-sized stomach turnover	1	good	Last Available: "2010-10"
-4728	enchanted moldy ghostly dead lights pie	4	crappy	Effect: "Rain Dancin'", Effect Duration: 40, Last Available: "2010-10"
-4729	big flavorless throbbing organ pie	5	decent	Last Available: "2010-10"
+4728	moldy enchanted ghostly dead lights pie	4	crappy	Effect: "Rain Dancin'", Effect Duration: 40, Last Available: "2010-10"
+4729	flavorless big throbbing organ pie	5	decent	Last Available: "2010-10"
 4730	stop shield of the sewer	0		Stench Damage: +25, Damage Reduction: 6, Last Available: "2009-12"
 4731	skewed nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,9 +4683,9 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	therapeutic beer-soaked mop	0		HP Regen Min: 5, HP Regen Max: 7
-4738	practically non-alcoholic hand-crafted day-old beer	1	EPIC	
+4738	hand-crafted practically non-alcoholic day-old beer	1	EPIC	
 4739	hand-crafted weak plain beer	2	EPIC	
-4740	weak perfectly mixed blurry overpriced &quot;imported&quot; beer	2	EPIC	
+4740	perfectly mixed weak blurry overpriced &quot;imported&quot; beer	2	EPIC	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
@@ -4693,18 +4693,18 @@
 4745	aerosolized improved oxidized Wax Flask	0		Effect: "Spirit Bubble", Effect Duration: 49
 4746	denatured bouncing Pain Dip	0		Effect: "In Vino Vires", Effect Duration: 68
 4747	toothsome bone meal	3	awesome	Last Available: "2010-10"
-4748	irresponsibly strong hand-crafted narrow bone aperitif	10	EPIC	Last Available: "2010-10"
+4748	hand-crafted irresponsibly strong narrow bone aperitif	10	EPIC	Last Available: "2010-10"
 4749	skewed ruddy bonerang	0		Maximum HP Percent: +40, Last Available: "2010-10"
 4750	twirling bone and arrows of temperance	0		Sleaze Resistance: +5, Last Available: "2010-10"
 4751	Newton's boning knife	0		Experience (Mysticality): +3, Last Available: "2010-10"
 4752	medical-grade bone crusher	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-10"
 4753	teal flame-retardant bone spurs	0		Hot Resistance: +1, Single Equip, Last Available: "2010-10"
-4754	narrow up-at-dawn bonedanna of the brute	0		Muscle Percent: +30, Adventures: +5, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	auspicious Herculean boneana hammock	0		Experience (Muscle): +1, Item Drop: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	narrow up-at-dawn bonedanna of the brute	0		Muscle Percent: +30, Adventures: +5, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	auspicious Herculean boneana hammock	0		Experience (Muscle): +1, Item Drop: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	corrupted vacuum-sealed blue mirror candy skeleton	0		Effect: "Filled with Magic", Effect Duration: 35, Last Available: "2020-09"
-4759	twirling bouncing Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
+4759	bouncing twirling Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	teal packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	narrow huge pumpkin	0		Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	olive Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	stale small huge CRIMBCOIDS mints	2	decent	Last Available: "2011-01"
+4818	small stale huge CRIMBCOIDS mints	2	decent	Last Available: "2011-01"
 4819	spinning can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	bland CRIMBCOLOAF	4	decent	Last Available: "2011-01"
 4821	spoiled spinning circular CRIMBCOOKIE	3	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4746,14 +4746,14 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	pulsating robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	spoiled pulsating tumbling triangular CRIMBCOOKIE	3	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	gigantic adequate square CRIMBCOOKIE	6	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	adequate gigantic square CRIMBCOOKIE	6	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	flame-retardant bindlestocking of incineration of doom	0		Hot Spell Damage: +50, Spooky Spell Damage: +50, Hot Resistance: +1, Last Available: "2010-12"
 4842	spinning sleeping stocking	0		Last Available: "2010-12"
 4843	upside-down Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	coward's sharpshooter's Uncle Hobo's stocking cap	0		Critical Hit Percent: +10, Monster Level: -20, Familiar Effect: "atk", Last Available: "2010-12"
+4845	coward's sharpshooter's Uncle Hobo's stocking cap	0		Critical Hit Percent: +10, Monster Level: -20, Last Available: "2010-12", Familiar Effect: "atk"
 4846	shaking aromatic smartaleck's Uncle Hobo's epic beard	0		Moxie Percent: +30, Stench Resistance: +1, Single Equip, Last Available: "2010-12"
-4847	spinning dance instructor's Uncle Hobo's gift baggy pants of the scaredy-cat	0		Experience Percent (Moxie): +10, Monster Level: -15, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	spinning dance instructor's Uncle Hobo's gift baggy pants of the scaredy-cat	0		Experience Percent (Moxie): +10, Monster Level: -15, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	smelly boxer's Uncle Hobo's fingerless tinsel gloves	0		Muscle Percent: +10, Stench Spell Damage: +10, Single Equip, Last Available: "2010-12"
 4849	twirling wizardly Uncle Hobo's highest bough of the businessman	0		Mysticality: +25, Meat Drop: +50, Last Available: "2010-12"
 4850	foul-smelling brawny Uncle Hobo's belt	0		Muscle Percent: +20, Stench Damage: +10, Single Equip, Last Available: "2010-12"
@@ -4769,14 +4769,14 @@
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-4863	red pulsating jittery CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+4863	jittery red pulsating CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	photocopier	0		Last Available: "2011-01"
 4865	deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	skewed paperclip sproinger	0		Last Available: "2011-01"
 4868	miser's fireproof Socratic paperclip-on tie	0		Experience (Mysticality): +1, Hot Resistance: +3, Meat Drop: +10, Single Equip, Last Available: "2011-01"
-4869	paperclip pants of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	jittery Usain Bolt's clever paperclip turban of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100, Initiative: +80, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	paperclip pants of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	jittery Usain Bolt's clever paperclip turban of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100, Initiative: +80, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	sizzling paperclip cape	0		Hot Damage: +10, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4784,13 +4784,13 @@
 4875	squat blurry BGE merchandise order form	0		Last Available: "2010-12"
 4876	corrupted blue blurry chocolate bath ball	0		Effect: "Elron's Explosive Etude", Effect Duration: 64, Last Available: "2011-01"
 4877	denatured wobbly bacon bath ball	0		Effect: "Overstimulated", Effect Duration: 33, Last Available: "2011-01"
-4878	deionized quadruple-adjusted squat tumbling incense bath ball	0		Effect: "Pretending to Pretend", Effect Duration: 14, Last Available: "2011-01"
+4878	deionized quadruple-adjusted tumbling squat incense bath ball	0		Effect: "Pretending to Pretend", Effect Duration: 14, Last Available: "2011-01"
 4879	diffused moist myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Feline Ferocity", Effect Duration: 50, Last Available: "2011-01"
 4880	upside-down CRIMBCO mug	0		Last Available: "2011-01"
 4881	aged CRIMBCO wine	4	awesome	Last Available: "2011-01"
 4882	huge Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	ghostly toe jam	0		Last Available: "2011-01"
-4884	fancy super-sized bland toe jam toast	5	decent	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2011-01"
+4884	bland fancy super-sized toe jam toast	5	decent	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2011-01"
 4885	wobbly blinking traffic jam	0		Last Available: "2011-01"
 4886	spoiled traffic jam toast	4	crappy	Last Available: "2011-01"
 4887	huge space jam	0		Last Available: "2011-01"
@@ -4800,8 +4800,8 @@
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	spinning pulsating slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	big normal blinking festive sausage	5	good	Last Available: "2011-01"
-4895	delicious bite-sized holiday cheese log	1	awesome	Last Available: "2011-01"
+4894	normal big blinking festive sausage	5	good	Last Available: "2011-01"
+4895	bite-sized delicious holiday cheese log	1	awesome	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	purple twirling sizzling BGE 'ferocious fruit' shirt of the brazier	0		Hot Damage: +10, Hot Spell Damage: +25, Last Available: "2010-12"
 4898	stanky nippy BGE 'cuddly critter' shirt	0		Cold Damage: +10, Stench Spell Damage: +25, Last Available: "2010-12"
@@ -4841,10 +4841,10 @@
 4938	jittery quake of arrows	0		Last Available: "2011-12"
 4939	pulsating time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	normal purple blurry Knob jelly donut	4	good	
+4941	normal blurry purple Knob jelly donut	4	good	
 4942	maroon Knob cake	0		
 4943	Knob cake pan	0		
-4944	fuchsia twirling Knob batter	0		
+4944	twirling fuchsia Knob batter	0		
 4945	Knob frosting	0		
 4946	unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
@@ -4855,7 +4855,7 @@
 4952	aerosolized blue baggie of sugar	0		Effect: "[800]Chocolate Reign", Effect Duration: 56
 4953	wicked whalebone corset of the dark arts	0		Spell Damage: +5, Spell Damage Percent: +100, Single Equip
 4954	fireproof oven mitts	0		Hot Resistance: +3, Single Equip
-4955	half-sized toothsome overcookie	2	awesome	
+4955	toothsome half-sized overcookie	2	awesome	
 4956	rotten philosopher's scone	3	crappy	
 4957	nitrogenated shaking gray half-baked potion	0		Effect: "Innately Wise", Effect Duration: 50
 4958	inspector's Knob Goblin deluxe scimitar	0		Item Drop: +15
@@ -4872,7 +4872,7 @@
 4969	spinning Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
-4972	ghostly huge Alice's Army Ninja	0		Last Available: "2011-03"
+4972	huge ghostly Alice's Army Ninja	0		Last Available: "2011-03"
 4973	squat Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
@@ -4914,12 +4914,12 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	adequate wasabi pocky	3	good	Last Available: "2011-03"
-5014	gigantic tasty tobiko pocky	7	awesome	Last Available: "2011-03"
+5014	tasty gigantic tobiko pocky	7	awesome	Last Available: "2011-03"
 5015	flavorless natto pocky	3	decent	Last Available: "2011-03"
-5016	high-proof delicious squat wasabi-infused sake	8	awesome	Last Available: "2011-03"
+5016	delicious high-proof squat wasabi-infused sake	8	awesome	Last Available: "2011-03"
 5017	tolerable weak tobiko-infused sake	2	good	Last Available: "2011-03"
 5018	hand-crafted natto-infused sake	4	EPIC	Last Available: "2011-03"
-5019	ionized mirror spinning pulsating purple wasabi marble soda	0		Effect: "Holiday Bliss", Effect Duration: 16, Last Available: "2011-03"
+5019	ionized spinning purple pulsating mirror wasabi marble soda	0		Effect: "Holiday Bliss", Effect Duration: 16, Last Available: "2011-03"
 5020	wet ionized blue tobiko marble soda	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 28, Last Available: "2011-03"
 5021	extra-pickled narrow natto marble soda	0		Effect: "You Know Who to Call", Effect Duration: 65, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
@@ -4949,9 +4949,9 @@
 5046	bouncing olive astral six-pack	0		
 5047	twirling Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	maroon shard of double-ice	0		Last Available: "2011-04"
-5049	friendly smooth cool double-ice cap	0		Moxie: 20, Familiar Weight: +3, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	friendly smooth cool double-ice cap	0		Moxie: 20, Familiar Weight: +3, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	nasty Van der Graaf electrified double-ice box	0		Stench Damage: +5, MP Regen Min: 8, MP Regen Max: 12, Last Available: "2011-04"
-5051	hale rock-hard double-ice britches of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Maximum HP: +20, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	hale rock-hard double-ice britches of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Maximum HP: +20, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4963,8 +4963,8 @@
 5060	mysterious present	0		Last Available: "2011-04"
 5061	ghostly boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	mirror voodoo doll	0		Last Available: "2011-04"
-5063	huge squat narrow the finger	0		Last Available: "2011-04"
-5064	shaking maroon Salsa de las Epocas	0		Last Available: "2011-04"
+5063	narrow huge squat the finger	0		Last Available: "2011-04"
+5064	maroon shaking Salsa de las Epocas	0		Last Available: "2011-04"
 5065	decent spaghetti con calaveras	3	good	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	decent snack-sized jittery popcorn	2	good	Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	mediocre Russian Ice	3	decent	Last Available: "2011-04"
 5074	shaking clay ashtray of dire peril	0		Weapon Damage: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	crafty lanyard	0		Maximum MP: +10, Single Equip, Last Available: "2011-05"
-5076	huge hardened monster pants	0		Damage Reduction: 3, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	huge hardened monster pants	0		Damage Reduction: 3, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	blinking box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	colloidal mirror Pok&euml;mann band-aid	0		Effect: "Chief Executive Optimism", Effect Duration: 19, Last Available: "2011-05"
-5079	pulsating prompt beefcake's Van der Graaf helmet	0		Muscle: +25, Adventures: +3, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	pulsating prompt beefcake's Van der Graaf helmet	0		Muscle: +25, Adventures: +3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	cool crutch	0		Moxie: +5, Last Available: "2011-05"
 5081	gray Herculean shock belt	0		Experience (Muscle): +1, Single Equip, Last Available: "2011-05"
 5082	flattened anodized altered blurry gray Okee-Dokee soda	0		Effect: "Oily Flavor", Effect Duration: 16, Last Available: "2011-05"
 5083	spinning ghostly frightening rubber band gun	0		Spooky Damage: +5, Last Available: "2011-05"
-5084	smartaleck's pin-stripe slacks	0		Moxie Percent: +30, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	smartaleck's pin-stripe slacks	0		Moxie Percent: +30, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	knitted gloves	0		Cold Resistance: +3, Single Equip, Last Available: "2011-05"
 5086	moist unsweetened upside-down correction fluid	0		Effect: "Elvish", Effect Duration: 37, Last Available: "2011-05"
 5087	skewed flame-retardant Pok&euml;mann figurine: Porkachu	0		Hot Resistance: +1, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	perfectly mixed Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	stress ball of the detective	0		Item Drop: +20, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	stress ball of the detective	0		Item Drop: +20, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	narrow Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	maroon Ultracolor&trade; shirt of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-05"
 5112	mirror My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,15 +5021,15 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	blinking Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	blinking sinister dangerous Admiral's hat of Calamity Jane	0		Weapon Damage: +10, Spell Damage: +10, Critical Hit Percent: +15, Familiar Effect: "atk", Last Available: "2011-05"
-5122	vibrating arcane researcher's beefy aviator's cap	0		Muscle: +10, Experience Percent (Mysticality): +10, Maximum MP Percent: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	blinking sinister dangerous Admiral's hat of Calamity Jane	0		Weapon Damage: +10, Spell Damage: +10, Critical Hit Percent: +15, Last Available: "2011-05", Familiar Effect: "atk"
+5122	vibrating arcane researcher's beefy aviator's cap	0		Muscle: +10, Experience Percent (Mysticality): +10, Maximum MP Percent: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	upside-down rock-hard mirrored aviator shades of mayonnaise	0		Damage Reduction: 5, Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5124	lime green Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	narrow Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	blinking Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	twirling Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
-5129	purple jittery spinning Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
+5129	purple spinning jittery Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	liquefied modified vacuum-sealed squat Ultrasoldier Serum	0		Effect: "Cold Blooded", Effect Duration: 29, Last Available: "2011-06"
 5132	adequate elven hardtack	4	good	Last Available: "2011-06"
@@ -5041,7 +5041,7 @@
 5138	blinking E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
 5140	dehydrated twirling astral energy drink	1		
-5141	upside-down shaking Thwaitgold bee statuette	0		
+5141	shaking upside-down Thwaitgold bee statuette	0		
 5142	blinking moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	blurry handful of honey	0		
@@ -5051,8 +5051,8 @@
 5148	mirror green aromatic Fonzie's honey dipper of the ox	0		Muscle: +20, Experience (Moxie): +1, Stench Resistance: +1
 5149	yellow Temple Grandin's forbidden honeybritches of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50, Familiar Weight: +7, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	wool fortified honeycap of horror	0		Damage Absorption: +60, Spooky Spell Damage: +25, Cold Resistance: +1, Familiar Effect: "1xPotato, cap 43"
-5151	Tesla Moonthril Circlet	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	nasty Moonthril Greaves	0		Stench Damage: +5, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	Tesla Moonthril Circlet	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	nasty Moonthril Greaves	0		Stench Damage: +5, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	purple Sinatra's Moonthril Flamberge	0		Experience (Moxie): +5, Last Available: "2011-06"
 5154	banded Moonthril Longbow	0		Damage Absorption: +100, Last Available: "2011-06"
 5155	Moonthril Cuirass of terror	0		Spooky Spell Damage: +10, Softcore Only, Last Available: "2011-06"
@@ -5067,7 +5067,7 @@
 5164	mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	girl of the pedagogue	0		Experience: +3, Last Available: "2011-06"
 5166	top hat and cane	0		Last Available: "2011-06"
-5167	pulsating blinking fuchsia synthetic dog hair pill	0		Last Available: "2011-06"
+5167	blinking fuchsia pulsating synthetic dog hair pill	0		Last Available: "2011-06"
 5168	distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	deionized boiled transporter transponder	0		Effect: "Jittery", Effect Duration: 66, Last Available: "2011-06"
@@ -5075,7 +5075,7 @@
 5172	bouncing Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	strong hand-crafted Saison du Lune	5	EPIC	Last Available: "2011-06"
-5175	artisanal practically non-alcoholic Moonthril Schnapps	1	EPIC	Last Available: "2011-06"
+5175	practically non-alcoholic artisanal Moonthril Schnapps	1	EPIC	Last Available: "2011-06"
 5176	mediocre high-proof bouncing Wrecked Generator	8	decent	Last Available: "2011-06"
 5177	tasty ghostly Spaghetti with Moonballs	4	awesome	Last Available: "2011-06"
 5178	toothsome gigantic Crepes a la Lune	8	awesome	Last Available: "2011-06"
@@ -5089,13 +5089,13 @@
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	colloidal Vulcanized honey stick	0		Effect: "The Magic of Sharing", Effect Duration: 25
-5189	dry modified deionized maroon pulsating double-ice gum	0		Effect: "Weasels Underfoot", Effect Duration: 12, Last Available: "2011-04"
-5190	curative padded Operation Patriot Shield of the sweet-tooth	0		Damage Absorption: +20, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5189	dry modified deionized pulsating maroon double-ice gum	0		Effect: "Weasels Underfoot", Effect Duration: 12, Last Available: "2011-04"
+5190	curative padded Operation Patriot Shield of the sweet-tooth	0		Damage Absorption: +20, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	quadruple-colloidal corrupted data	0		Effect: "Hyperoffended", Effect Duration: 35, Last Available: "2011-06"
 5193	pulsating 11-inch knob sausage	0		
 5194	blue exorcised sandwich	0		
-5195	cyan jittery Banfoy's Boutique Order Form	0		Last Available: "2011-07"
+5195	jittery cyan Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	pulsating Great S-Cape of the early riser	0		Adventures: +7, Softcore Only, Last Available: "2011-07"
 5197	maroon resourceful Marvelous Unitard	0		Maximum MP: +50, Softcore Only, Last Available: "2011-07"
 5198	boiled wobbly gooey paste	1	good	Effect: "Norwhalloped", Effect Duration: 25, Last Available: "2011-08"
@@ -5103,17 +5103,17 @@
 5200	mixed paste	1	awesome	Last Available: "2011-08"
 5201	vaporized narrow ectoplasmic paste	1	decent	Last Available: "2011-08"
 5202	twisted upside-down greasy paste	1	crappy	Last Available: "2011-08"
-5203	pickled pulsating squat ghostly bug paste	1	EPIC	Last Available: "2011-08"
+5203	pickled squat pulsating ghostly bug paste	1	EPIC	Last Available: "2011-08"
 5204	modified bouncing hippy paste	1	decent	Last Available: "2011-08"
 5205	distilled mirror fuchsia orc paste	1	EPIC	Last Available: "2011-08"
-5206	modified blinking lime green mirror demonic paste	1	EPIC	Last Available: "2011-08"
+5206	modified lime green blinking mirror demonic paste	1	EPIC	Last Available: "2011-08"
 5207	vaporized huge olive indescribably horrible paste	1	EPIC	Effect: "Sizzling with Fury", Effect Duration: 45, Last Available: "2011-08"
 5208	powdered blinking paste	1	crappy	Effect: "Dexteri Tea", Effect Duration: 15, Last Available: "2011-08"
 5209	denatured spinning goblin paste	1	EPIC	Last Available: "2011-08"
-5210	compressed green upside-down blurry pirate paste	1	crappy	Last Available: "2011-08"
+5210	compressed upside-down blurry green pirate paste	1	crappy	Last Available: "2011-08"
 5211	modified shaking shaking chlorophyll paste	1	decent	Effect: "Analog Drunk", Effect Duration: 40, Last Available: "2011-08"
 5212	vaporized huge ghostly paste	1	awesome	Last Available: "2011-08"
-5213	compressed olive shaking Mer-kin paste	1	good	Last Available: "2011-08"
+5213	compressed shaking olive Mer-kin paste	1	good	Last Available: "2011-08"
 5214	dried squat slimy paste	1	good	Effect: "Human-Constellation Hybrid", Effect Duration: 35, Last Available: "2011-08"
 5215	distilled spinning penguin paste	1	awesome	Last Available: "2011-08"
 5216	diluted mirror elemental paste	1	decent	Effect: "Cold as Ice", Effect Duration: 45, Last Available: "2011-08"
@@ -5123,8 +5123,8 @@
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	blurry Thwaitgold grasshopper statuette	0		
-5223	bouncing twirling yellow Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	small stale Ur-Donut	2	decent	Last Available: "2011-09"
+5223	twirling bouncing yellow Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5224	stale small Ur-Donut	2	decent	Last Available: "2011-09"
 5225	teal The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	drinkable bucket of wine	3	good	Last Available: "2011-09"
@@ -5140,14 +5140,14 @@
 5237	flame-wreathed time halo	0		Hot Spell Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	bad Lumineux Limnio	4	decent	Last Available: "2011-09"
 5239	artisanal spirit-forward Morto Moreto	5	EPIC	Last Available: "2011-09"
-5240	lousy watered-down skewed Temps Tempranillo	2	decent	Last Available: "2011-09"
+5240	watered-down lousy skewed Temps Tempranillo	2	decent	Last Available: "2011-09"
 5241	delicious Bordeaux Marteaux	3	awesome	Last Available: "2011-09"
-5242	high-proof smooth Fromage Pinotage	6	awesome	Last Available: "2011-09"
+5242	smooth high-proof Fromage Pinotage	6	awesome	Last Available: "2011-09"
 5243	practically non-alcoholic acceptable Beignet Milgranet	1	good	Last Available: "2011-09"
 5244	lousy Muschat	4	decent	Last Available: "2011-09"
 5245	spoiled blue cool jelly donut	3	crappy	Last Available: "2011-09"
 5246	flavorless shrapnel jelly donut	3	decent	Last Available: "2011-09"
-5247	decent huge enchanted occult jelly donut	7	good	Effect: "Hardened Fabric", Effect Duration: 45, Last Available: "2011-09"
+5247	enchanted decent huge occult jelly donut	7	good	Effect: "Hardened Fabric", Effect Duration: 45, Last Available: "2011-09"
 5248	adequate thyme jelly donut	3	good	Last Available: "2011-09"
 5249	flavorless diet spinning danish	1	decent	Last Available: "2011-09"
 5250	bland smashed danish	3	decent	Last Available: "2011-09"
@@ -5156,7 +5156,7 @@
 5253	adequate blinking blunt cat claw	3	good	Last Available: "2011-09"
 5254	spoiled red shadowy cat claw	3	crappy	Last Available: "2011-09"
 5255	rotten cheezburger	4	crappy	Last Available: "2011-09"
-5256	immense normal toasted brie	9	good	Last Available: "2011-09"
+5256	normal immense toasted brie	9	good	Last Available: "2011-09"
 5257	polarized wobbly potion of the field gar	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 23, Last Available: "2011-09"
 5258	quantum jittery too legit potion	0		Effect: "Beta Carotene Overdose", Effect Duration: 66, Last Available: "2011-09"
 5259	unsweetened dry narrow narrow Bright Water	0		Effect: "Black Eyes", Effect Duration: 11, Last Available: "2011-09"
@@ -5171,7 +5171,7 @@
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
 5270	tumbling chocolate frosted sugar bomb	0		Last Available: "2011-09"
-5271	blurry fuchsia broken glass grenade	0		Last Available: "2011-09"
+5271	fuchsia blurry broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	olive skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	studded broken clock	0		Damage Absorption: +80, Last Available: "2011-09"
 5282	upside-down auspicious dethklok	0		Item Drop: +10, Last Available: "2011-09"
 5283	huge hardened glacial clock	0		Damage Reduction: 3, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	bouncing d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	huge slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	fuchsia bouncing dungeon dragon chest	0		Last Available: "2011-09"
 5298	normal phish stick	4	good	Last Available: "2011-09"
-5299	avaricious coward's plastic vampire fangs of the brute	0		Muscle Percent: +30, Monster Level: -20, Meat Drop: +30, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	avaricious coward's plastic vampire fangs of the brute	0		Muscle Percent: +30, Monster Level: -20, Meat Drop: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	jittery fuchsia Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5216,14 +5216,14 @@
 5313	altered blurry necrotizing body spray	0		Effect: "Neuromancy", Effect Duration: 24, Last Available: "2011-10"
 5314	alkaline irradiated bite-me-red lipstick	0		Effect: "Reptilian Fortitude", Effect Duration: 65, Last Available: "2011-10"
 5315	wet irradiated shaking whisker pencil	0		Effect: "Memento Moir&eacute;", Effect Duration: 22, Last Available: "2011-10"
-5316	dry jittery maroon narrow press-on ribs	0		Effect: "Enraged", Effect Duration: 52, Last Available: "2011-10"
+5316	dry narrow jittery maroon press-on ribs	0		Effect: "Enraged", Effect Duration: 52, Last Available: "2011-10"
 5317	enhanced Rattlin' Chains	0		Effect: "You Can Taste the Darkness", Effect Duration: 51, Last Available: "2011-10"
 5318	diffused cold-filtered tumbling Gummy Brains	0		Effect: "Can Has Cyborger", Effect Duration: 62, Last Available: "2011-10"
 5319	tarnished oxidized Blood 'n' Plenty	0		Effect: "Piratey Flavor", Effect Duration: 34, Last Available: "2011-10"
 5320	deionized unsweetened twirling Lobos Mints	0		Effect: "Memento Moir&eacute;", Effect Duration: 26, Last Available: "2011-10"
 5321	alkaline concentrated red Sweet Sword	0		Effect: "Certainty", Effect Duration: 55, Last Available: "2011-10"
-5322	lousy spirit-forward upside-down huge Ecto-Cooler	5	decent	Last Available: "2011-10"
-5323	irresponsibly strong mediocre gray huge Bartles and BRAAAINS wine cooler	10	decent	Last Available: "2011-10"
+5322	lousy spirit-forward huge upside-down Ecto-Cooler	5	decent	Last Available: "2011-10"
+5323	mediocre irresponsibly strong gray huge Bartles and BRAAAINS wine cooler	10	decent	Last Available: "2011-10"
 5324	bad Blood Light	4	decent	Last Available: "2011-10"
 5325	mediocre olive upside-down Silver Bullet beer	4	decent	Last Available: "2011-10"
 5326	bad Bone's Farm &quot;wine&quot;	3	decent	Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	pressed super-irradiated yellow drum of pomade	0		Effect: "Three Days Slow", Effect Duration: 15, Last Available: "2011-10"
 5331	fuchsia throwing bone	0		Last Available: "2011-10"
 5332	scandalous extra-see-thru nightie	0		Sleaze Damage: +5, Last Available: "2011-10"
-5333	jittery frosty sharpshooter's BRAINS shorts	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	jittery frosty sharpshooter's BRAINS shorts	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	wholesome Mesmereyes&trade; contact lenses	0		Maximum HP Percent: +10, Single Equip, Last Available: "2011-10"
 5335	pulsating savvy scrunchie	0		Mysticality Percent: +20, Single Equip, Last Available: "2011-10"
-5336	spinning scorching savvy extremely skinny jeans	0		Mysticality Percent: +20, Hot Damage: +25, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	ghostly The Necbromancer's Hat of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	spinning scorching savvy extremely skinny jeans	0		Mysticality Percent: +20, Hot Damage: +25, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	ghostly The Necbromancer's Hat of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	family-friendly ruddy The Necbromancer's Stein of vim and vigor	0		Maximum HP Percent: 90, Sleaze Resistance: +1, Last Available: "2011-10"
-5339	stiffened sinister The Necbromancer's Shorts of wisdom	0		Mysticality: +15, Spell Damage: +10, Damage Reduction: 1, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	stiffened sinister The Necbromancer's Shorts of wisdom	0		Mysticality: +15, Spell Damage: +10, Damage Reduction: 1, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	up-at-dawn lightning-fast scorching The Necbromancer's Wizard Staff	0		Hot Damage: +25, Initiative: +40, Adventures: +5, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	bad spinning The Cooler Out of Space	3	decent	Last Available: "2011-10"
@@ -5260,11 +5260,11 @@
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	red Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-5360	gray blinking Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
+5360	blinking gray Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	blurry The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	tumbling CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-5364	pulsating blinking CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
+5364	blinking pulsating CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 5366	CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
@@ -5297,25 +5297,25 @@
 5394	sandpaper	0		
 5395	peppermint sprout	0		Last Available: "2011-11"
 5396	deionized chilled mirror peppermint twist	0		Effect: "Cosmic Flavor", Effect Duration: 46, Last Available: "2011-11"
-5397	moldy special diet narrow peppermint patty	1	crappy	Effect: "Rootin' Around", Effect Duration: 35, Last Available: "2011-11"
+5397	special moldy diet narrow peppermint patty	1	crappy	Effect: "Rootin' Around", Effect Duration: 35, Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
-5399	bouncing maroon upside-down peppermint rhino baby	0		Last Available: "2011-11"
+5399	bouncing upside-down maroon peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
 5402	sizzling candy cane	0		Hot Damage: +10, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
-5404	blurry upside-down Peppermint Pip Packet	0		Last Available: "2011-11"
+5404	upside-down blurry Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	toasty dance instructor's Rosewater's cane-mail shirt	0		Mysticality Percent: +30, Experience Percent (Moxie): +10, Hot Damage: +5, Last Available: "2011-12"
-5406	jittery vibrating cane-mail pants of Leguizamo of the early riser	0		Maximum MP Percent: +10, Monster Level: +20, Adventures: +7, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	triple-distilled fancy perfectly mixed Vodka Matryoshka	8	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 15, Last Available: "2011-12"
-5408	weak fancy hand-crafted Gin Mint	2	EPIC	Effect: "Egg-cellent Vocabulary", Effect Duration: 20, Last Available: "2011-12"
+5406	jittery vibrating cane-mail pants of Leguizamo of the early riser	0		Maximum MP Percent: +10, Monster Level: +20, Adventures: +7, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5407	triple-distilled perfectly mixed fancy Vodka Matryoshka	8	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 15, Last Available: "2011-12"
+5408	fancy weak hand-crafted Gin Mint	2	EPIC	Effect: "Egg-cellent Vocabulary", Effect Duration: 20, Last Available: "2011-12"
 5409	bad Tequiz Navidad	3	decent	Last Available: "2011-12"
 5410	bad Mint Yulep	4	decent	Last Available: "2011-12"
-5411	enchanted perfectly mixed watered-down Crimbojito	2	EPIC	Effect: "Stimulated Body", Effect Duration: 5, Last Available: "2011-12"
+5411	watered-down enchanted perfectly mixed Crimbojito	2	EPIC	Effect: "Stimulated Body", Effect Duration: 5, Last Available: "2011-12"
 5412	drinkable Sangria de Menthe	3	good	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
-5415	altered wet aerosolized shaking tumbling olive licorice root	0		Effect: "In the Saucestream", Effect Duration: 38, Last Available: "2011-12"
+5415	altered wet aerosolized tumbling shaking olive licorice root	0		Effect: "In the Saucestream", Effect Duration: 38, Last Available: "2011-12"
 5416	improved corrupted banana supersucker	0		Effect: "Mayeaugh", Effect Duration: 49, Last Available: "2011-11"
 5417	enhanced pear supersucker	0		Effect: "Using Protection", Effect Duration: 23, Last Available: "2011-11"
 5418	oxidized lime supersucker	0		Effect: "Pockets of Fire", Effect Duration: 67, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	thinker's kumquartz ring	0		Mysticality: +10, Single Equip, Last Available: "2011-11"
 5425	slick strawberyl necklace	0		Moxie: +10, Single Equip, Last Available: "2011-11"
 5426	twirling rosewater-soaked flame-wreathed sucker bucket	0		Hot Spell Damage: +10, Stench Resistance: +3, Last Available: "2011-11"
-5427	gravedigger's sucker hakama	0		Spooky Damage: +10, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	huge chilly sucker kabuto	0		Cold Damage: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	gravedigger's sucker hakama	0		Spooky Damage: +10, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	huge chilly sucker kabuto	0		Cold Damage: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	twirling quilted sucker tachi	0		Damage Absorption: +40, Last Available: "2011-11"
 5430	narrow sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5363,8 +5363,8 @@
 5460	teal Sherlock's chaotic shellacked fudgecycle	0		Damage Reduction: 7, Spell Critical Percent: +10, Item Drop: +25, Single Equip, Last Available: "2011-11"
 5461	fuchsia fudge cube	0		Last Available: "2011-11"
 5462	tumbling blank fudge mold	0		Last Available: "2011-11"
-5463	yellow Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
-5464	polarized quantum mirror spinning resolution: be wealthier	0		Effect: "Memory of Strength", Effect Duration: 66, Last Available: "2012-01"
+5463	yellow Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5464	polarized quantum spinning mirror resolution: be wealthier	0		Effect: "Memory of Strength", Effect Duration: 66, Last Available: "2012-01"
 5465	anodized corrupted teal resolution: be happier	0		Effect: "Ice Packed", Effect Duration: 64, Last Available: "2012-01"
 5466	frozen resolution: be stronger	0		Effect: "Fustulent", Effect Duration: 65, Last Available: "2012-01"
 5467	energized liquefied tarnished gray resolution: be smarter	0		Effect: "Third Based", Effect Duration: 36, Last Available: "2012-01"
@@ -5379,11 +5379,11 @@
 5476	magnetized gummi salamander	0		Effect: "Floundering", Effect Duration: 62, Last Available: "2011-11"
 5477	galvanized quantum olive gummi snake	0		Effect: "Block-Rockin' Beet", Effect Duration: 25, Last Available: "2011-11"
 5478	nitrogenated non-corrupted narrow squat gummi canary	0		Effect: "Sweet Tooth", Effect Duration: 61, Last Available: "2011-11"
-5479	flavorless small mirror upside-down gummi bear	2	decent	Last Available: "2011-11"
+5479	small flavorless upside-down mirror gummi bear	2	decent	Last Available: "2011-11"
 5480	bite-sized tasty jittery gummi bear	1	awesome	Last Available: "2011-11"
-5481	miniature tasty gummi bear	2	awesome	Last Available: "2011-11"
+5481	tasty miniature gummi bear	2	awesome	Last Available: "2011-11"
 5482	spoiled low-calorie drunki-bear	1	crappy	Last Available: "2011-11"
-5483	miniature special normal drunki-bear	2	good	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 10, Last Available: "2011-11"
+5483	special miniature normal drunki-bear	2	good	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 10, Last Available: "2011-11"
 5484	flavorless blurry drunki-bear	3	decent	Last Available: "2011-11"
 5485	gummi bowtie of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-11"
 5486	yellow knitted fudge pocket square	0		Cold Resistance: +3, Last Available: "2011-11"
@@ -5396,10 +5396,10 @@
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	flattened colloidal ghostly mirror gummi trilobite	0		Effect: "Soles of Glass", Effect Duration: 11, Last Available: "2011-11"
 5495	oxidized shaking blurry gummi ammonite	0		Effect: "Here to Kick Ass", Effect Duration: 52, Last Available: "2011-11"
-5496	super-magnetized blinking huge gummi belemnite	0		Effect: "Liquid Luck", Effect Duration: 61, Last Available: "2011-11"
+5496	super-magnetized huge blinking gummi belemnite	0		Effect: "Liquid Luck", Effect Duration: 61, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	gray auspicious Big Candy's tophat of courage	0		Spooky Resistance: +3, Item Drop: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	gray auspicious Big Candy's tophat of courage	0		Spooky Resistance: +3, Item Drop: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	pulsating Jackass Plumber home game	0		Last Available: "2011-11"
 5502	tumbling Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	jumbo spoiled jerky coins	5	crappy	Last Available: "2011-11"
-5507	artisanal weak Go-Wassail	2	EPIC	Last Available: "2011-11"
+5507	weak artisanal Go-Wassail	2	EPIC	Last Available: "2011-11"
 5508	chilled ionized Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Vented Spleen", Effect Duration: 48, Last Available: "2011-11"
 5509	activated extra-ionized mirror bottle of bubbles	0		Effect: "Impregnably Delicious", Effect Duration: 45, Last Available: "2011-11"
 5510	energized extra-polarized wind-up meatcar	0		Effect: "Retrograde Relaxation", Effect Duration: 58, Last Available: "2011-11"
@@ -5434,17 +5434,17 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	lime green magnolia blossom	0		Last Available: "2012-12"
 5533	extra-oxidized quantum nitrogenated purple Mortimer's nostrum	0		Effect: "Slightly Mutated", Effect Duration: 37, Last Available: "2012-12"
-5534	acceptable high-proof jittery blue Barulio's bottle	7	good	Last Available: "2012-12"
+5534	high-proof acceptable blue jittery Barulio's bottle	7	good	Last Available: "2012-12"
 5535	deionized red Marvin's marvelous pill	0		Effect: "Flower Power", Effect Duration: 61, Last Available: "2012-12"
 5536	blinking Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	huge shaking half-empty carton of milk	0		Last Available: "2012-12"
 5539	glass of warm water	0		Free Pull
 5540	enhanced desktop zen garden	0		Effect: "In Vino Vires", Effect Duration: 68, Last Available: "2012-12"
-5541	pulsating upside-down Vivian's Vitamin	0		Last Available: "2012-12"
+5541	upside-down pulsating Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	sizzling friendly Leapin' Trousers	0		Familiar Weight: +3, Hot Damage: +10
-5544	high-proof bad eggnog	9	decent	Last Available: "2012-12"
+5544	bad high-proof eggnog	9	decent	Last Available: "2012-12"
 5545	tiny delicious hamhock	1	awesome	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
@@ -5459,16 +5459,16 @@
 5556	foul-smelling Jim Carey's Rain-Doh wings	0		Monster Level: +25, Stench Damage: +10, Softcore Only, Last Available: "2012-02"
 5557	narrow Rain-Doh agent	0		Last Available: "2012-02"
 5558	mirror Herculean Rain-Doh laser gun of dire peril	0		Experience (Muscle): +1, Weapon Damage: +20, Softcore Only, Last Available: "2012-02"
-5559	perfumed stanky Rain-Doh lantern	0		Stench Spell Damage: +25, Stench Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
-5560	blue mirror Rain-Doh balls	0		Last Available: "2012-02"
+5559	perfumed stanky Rain-Doh lantern	0		Stench Spell Damage: +25, Stench Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5560	mirror blue Rain-Doh balls	0		Last Available: "2012-02"
 5561	twirling Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	teal fireproof horrifying Rain-Doh violet bo	0		Spooky Damage: +25, Hot Resistance: +3, Softcore Only, Last Available: "2012-02"
 5563	green Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	adequate wobbly PB&BP	4	good	
-5566	small normal tumbling club sandwich	2	good	
+5566	normal small tumbling club sandwich	2	good	
 5567	moldy corned-beef Reuben	4	crappy	
-5568	squat wobbly frayed ninja rope	0		
+5568	wobbly squat frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
@@ -5477,84 +5477,84 @@
 5574	perfectly mixed tumbling Transylvania Sling	4	EPIC	Last Available: "2012-03"
 5575	delicious strong Shot of the Living Dead	5	awesome	Last Available: "2012-03"
 5576	acceptable Buttery Knob	3	good	Last Available: "2012-03"
-5577	drinkable triple-distilled Slippery Knob	6	good	Last Available: "2012-03"
-5578	practically non-alcoholic mediocre maroon Flaming Knob	1	decent	Last Available: "2012-03"
+5577	triple-distilled drinkable Slippery Knob	6	good	Last Available: "2012-03"
+5578	mediocre practically non-alcoholic maroon Flaming Knob	1	decent	Last Available: "2012-03"
 5579	acceptable Grasshopper	4	good	Last Available: "2012-03"
-5580	acceptable practically non-alcoholic lime green skewed Locust	1	good	Last Available: "2012-03"
+5580	acceptable practically non-alcoholic skewed lime green Locust	1	good	Last Available: "2012-03"
 5581	mediocre ghostly Plague of Locusts	3	decent	Last Available: "2012-03"
-5582	watered-down bad Red Dwarf	2	decent	Last Available: "2012-03"
+5582	bad watered-down Red Dwarf	2	decent	Last Available: "2012-03"
 5583	tolerable skewed Golden Mean	3	good	Last Available: "2012-03"
 5584	lousy irresponsibly strong Green Giant	8	decent	Last Available: "2012-03"
 5585	acceptable practically non-alcoholic Aye Aye	1	good	Last Available: "2012-03"
-5586	watered-down bad upside-down Aye Aye, Captain	2	decent	Last Available: "2012-03"
-5587	artisanal enchanted irresponsibly strong gray Aye Aye, Tooth Tooth	7	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2012-03"
-5588	artisanal special Humanitini	3	EPIC	Effect: "Pill Power", Effect Duration: 5, Last Available: "2012-03"
+5586	bad watered-down upside-down Aye Aye, Captain	2	decent	Last Available: "2012-03"
+5587	enchanted irresponsibly strong artisanal gray Aye Aye, Tooth Tooth	7	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2012-03"
+5588	special artisanal Humanitini	3	EPIC	Effect: "Pill Power", Effect Duration: 5, Last Available: "2012-03"
 5589	perfectly mixed More Humanitini than Humanitini	3	EPIC	Last Available: "2012-03"
 5590	aged Oh, the Humanitini	4	awesome	Last Available: "2012-03"
-5591	watered-down mediocre Great Older Fashioned	2	decent	Last Available: "2012-03"
+5591	mediocre watered-down Great Older Fashioned	2	decent	Last Available: "2012-03"
 5592	hand-crafted Fuzzy Tentacle	3	EPIC	Last Available: "2012-03"
-5593	drinkable watered-down cyan wobbly Crazymaker	2	good	Last Available: "2012-03"
+5593	drinkable watered-down wobbly cyan Crazymaker	2	good	Last Available: "2012-03"
 5594	artisanal Zoodriver	3	EPIC	Last Available: "2012-03"
 5595	fortified aged huge Sloe Comfortable Zoo	5	awesome	Last Available: "2012-03"
-5596	watered-down artisanal fancy Sloe Comfortable Zoo on Fire	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2012-03"
+5596	fancy watered-down artisanal Sloe Comfortable Zoo on Fire	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2012-03"
 5597	practically non-alcoholic mediocre Suffering Sinner	1	decent	Last Available: "2012-03"
-5598	weak perfectly mixed Suppurating Sinner	2	EPIC	Last Available: "2012-03"
+5598	perfectly mixed weak Suppurating Sinner	2	EPIC	Last Available: "2012-03"
 5599	acceptable Sizzling Sinner	3	good	Last Available: "2012-03"
 5600	acceptable weak Firewater	2	good	Last Available: "2012-03"
 5601	tolerable irresponsibly strong Earth and Firewater	9	good	Last Available: "2012-03"
 5602	lousy weak Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
-5603	practically non-alcoholic lousy fuchsia Slimosa	1	decent	Last Available: "2012-03"
+5603	lousy practically non-alcoholic fuchsia Slimosa	1	decent	Last Available: "2012-03"
 5604	practically non-alcoholic hand-crafted Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
-5605	extra-dry artisanal Slimebite	5	EPIC	Last Available: "2012-03"
-5606	practically non-alcoholic delicious Cement Mixer	1	awesome	Last Available: "2012-03"
-5607	extra-dry lousy Jackhammer	5	decent	Last Available: "2012-03"
+5605	artisanal extra-dry Slimebite	5	EPIC	Last Available: "2012-03"
+5606	delicious practically non-alcoholic Cement Mixer	1	awesome	Last Available: "2012-03"
+5607	lousy extra-dry Jackhammer	5	decent	Last Available: "2012-03"
 5608	mediocre Dump Truck	4	decent	Last Available: "2012-03"
 5609	hand-crafted Fauna Libre	3	EPIC	Last Available: "2012-03"
 5610	drinkable twirling Chakra Libre	4	good	Last Available: "2012-03"
 5611	aged strong Aura Libre	5	awesome	Last Available: "2012-03"
-5612	lousy practically non-alcoholic Sazerorc	1	decent	Last Available: "2012-03"
-5613	smooth fancy watered-down Sazuruk-hai	2	awesome	Effect: "Bone Homie", Effect Duration: 10, Last Available: "2012-03"
+5612	practically non-alcoholic lousy Sazerorc	1	decent	Last Available: "2012-03"
+5613	fancy smooth watered-down Sazuruk-hai	2	awesome	Effect: "Bone Homie", Effect Duration: 10, Last Available: "2012-03"
 5614	lousy triple-distilled ghostly Flaming Sazerorc	10	decent	Last Available: "2012-03"
 5615	delicious Green Velvet	3	awesome	Last Available: "2012-03"
 5616	artisanal Green Muslin	3	EPIC	Last Available: "2012-03"
 5617	hand-crafted Green Burlap	3	EPIC	Last Available: "2012-03"
-5618	perfectly mixed weak fancy twirling Mohobo	2	EPIC	Effect: "Jungle Juiced", Effect Duration: 15, Last Available: "2012-03"
-5619	special mediocre weak Moonshine Mohobo	2	decent	Effect: "Night of the Nachos", Effect Duration: 10, Last Available: "2012-03"
+5618	fancy weak perfectly mixed twirling Mohobo	2	EPIC	Effect: "Jungle Juiced", Effect Duration: 15, Last Available: "2012-03"
+5619	mediocre special weak Moonshine Mohobo	2	decent	Effect: "Night of the Nachos", Effect Duration: 10, Last Available: "2012-03"
 5620	aged Flaming Mohobo	3	awesome	Last Available: "2012-03"
-5621	smooth practically non-alcoholic Drunken Philosopher	1	awesome	Last Available: "2012-03"
+5621	practically non-alcoholic smooth Drunken Philosopher	1	awesome	Last Available: "2012-03"
 5622	practically non-alcoholic mediocre upside-down Drunken Neurologist	1	decent	Last Available: "2012-03"
-5623	smooth practically non-alcoholic Drunken Astrophysicist	1	awesome	Last Available: "2012-03"
+5623	practically non-alcoholic smooth Drunken Astrophysicist	1	awesome	Last Available: "2012-03"
 5624	acceptable blinking jittery Dark & Starry	3	good	Last Available: "2012-03"
 5625	artisanal Black Hole	4	EPIC	Last Available: "2012-03"
-5626	bad practically non-alcoholic Event Horizon	1	decent	Last Available: "2012-03"
-5627	practically non-alcoholic hand-crafted Herring Daiquiri	1	EPIC	Last Available: "2012-03"
+5626	practically non-alcoholic bad Event Horizon	1	decent	Last Available: "2012-03"
+5627	hand-crafted practically non-alcoholic Herring Daiquiri	1	EPIC	Last Available: "2012-03"
 5628	weak mediocre enchanted Herring Wallbanger	2	decent	Effect: "Sugar, Hello", Effect Duration: 20, Last Available: "2012-03"
 5629	bad Herringtini	4	decent	Last Available: "2012-03"
 5630	bad practically non-alcoholic Lollipop Drop	1	decent	Last Available: "2012-03"
-5631	practically non-alcoholic delicious Candy Alexander	1	awesome	Last Available: "2012-03"
+5631	delicious practically non-alcoholic Candy Alexander	1	awesome	Last Available: "2012-03"
 5632	weak mediocre Candicaine	2	decent	Last Available: "2012-03"
-5633	acceptable watered-down fancy Caipiranha	2	good	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2012-03"
-5634	special bad extra-dry jittery green Flying Caipiranha	5	decent	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2012-03"
-5635	smooth triple-distilled Flaming Caipiranha	7	awesome	Last Available: "2012-03"
-5636	triple-distilled tolerable Punchplanter	7	good	Last Available: "2012-03"
-5637	practically non-alcoholic artisanal Doublepunchplanter	1	EPIC	Last Available: "2012-03"
-5638	hand-crafted extra-dry enchanted Haymaker	5	EPIC	Effect: "Winning Smile", Effect Duration: 25, Last Available: "2012-03"
+5633	watered-down fancy acceptable Caipiranha	2	good	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2012-03"
+5634	extra-dry special bad jittery green Flying Caipiranha	5	decent	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2012-03"
+5635	triple-distilled smooth Flaming Caipiranha	7	awesome	Last Available: "2012-03"
+5636	tolerable triple-distilled Punchplanter	7	good	Last Available: "2012-03"
+5637	artisanal practically non-alcoholic Doublepunchplanter	1	EPIC	Last Available: "2012-03"
+5638	extra-dry enchanted hand-crafted Haymaker	5	EPIC	Effect: "Winning Smile", Effect Duration: 25, Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	flavorless immense special fungus	6	decent	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 15
 5642	poisoned dart	0		
-5643	diffused fuchsia upside-down stone wool	0		Effect: "Cute Vision", Effect Duration: 21
+5643	diffused upside-down fuchsia stone wool	0		Effect: "Cute Vision", Effect Duration: 21
 5644	stones	0		
 5645	skewed the Nostril of the Serpent	0		
 5646	huge calendar fragment	0		
 5647	up-at-dawn calendar	0		Adventures: +5, Damage Reduction: 4
-5648	Annie Oakley's Sinatra's Boris's Helm	0		Experience (Moxie): +5, Critical Hit Percent: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	Annie Oakley's Sinatra's Boris's Helm	0		Experience (Moxie): +5, Critical Hit Percent: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	miser's double-paned staph of homophones	0		Cold Resistance: +5, Meat Drop: +10
-5650	avaricious hale padded Boris's Helm (askew)	0		Damage Absorption: +20, Maximum HP: +20, Meat Drop: +30, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	avaricious hale padded Boris's Helm (askew)	0		Damage Absorption: +20, Maximum HP: +20, Meat Drop: +30, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	bouncing Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	spoiled small nailswurst	2	crappy	
+5654	small spoiled nailswurst	2	crappy	
 5655	tolerable used beer	3	good	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5570,16 +5570,16 @@
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
-5670	tiny spoiled fettucini &eacute;pines Inconnu	1	crappy	
+5670	spoiled tiny fettucini &eacute;pines Inconnu	1	crappy	
 5671	tolerable slap and slap again	3	good	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	skewed &quot;L&quot;	0		
 5675	vaporized watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	fireproof Ze&trade; goggles	0		Hot Resistance: +3, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	fireproof Ze&trade; goggles	0		Hot Resistance: +3, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	stylish smooth stylish swimsuit	0		Moxie: 40, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	stylish smooth stylish swimsuit	0		Moxie: 40, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	blurry lost key	0		Last Available: "2012-05"
 5681	normal P.B.L.T.	3	good	
 5682	tumbling note from Clancy	0		Skill: "Request Sandwich"
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	huge crayon shavings	0		Last Available: "2012-06"
 5704	cyan wax bugbear	0		Last Available: "2012-06"
-5705	red hardened wax hat of vim and vigor	0		Damage Reduction: 3, Maximum HP Percent: +50, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	purple toasty wax pants of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	red hardened wax hat of vim and vigor	0		Damage Reduction: 3, Maximum HP Percent: +50, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	purple toasty wax pants of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	blinking FDKOL commendation	0		Last Available: "2012-07"
 5708	Vulcanized super-nitrogenated drop of water-37	0		Effect: "The Sweats", Effect Duration: 30, Last Available: "2012-07"
-5709	inspector's fireman's helmet of the brute	0		Muscle Percent: +30, Item Drop: +15, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	inspector's fireman's helmet of the brute	0		Muscle Percent: +30, Item Drop: +15, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	sizzling fire axe	0		Hot Damage: +10, Last Available: "2012-07"
 5713	skewed narrow miser's educational fire extinguisher of horror	0		Experience: +1, Spooky Spell Damage: +25, Meat Drop: +10, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,14 +5618,14 @@
 5717	miniature toothsome FDKOL hotcakes	2	awesome	Last Available: "2012-07"
 5718	pulsating hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	flavorless tiny squat fiery wing	1	decent	Last Available: "2012-07"
+5720	tiny flavorless squat fiery wing	1	decent	Last Available: "2012-07"
 5721	scandalous wings of fire of the empath	0		Familiar Weight: +5, Sleaze Damage: +5, Last Available: "2012-07"
 5722	educational FDKOL fire hose	0		Experience: +1, Last Available: "2012-07"
 5723	galvanized quadruple-liquefied gray bottle of fire	0		Effect: "Cranberry Cordiality", Effect Duration: 30, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	cyan ghostly hot daub	0		Last Available: "2012-07"
-5726	ghostly wool hot daub bun of the bloodbag	0		Maximum HP: +100, Cold Resistance: +1, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	manspreader's vibrating hot daub stand	0		Maximum MP Percent: +10, Monster Level: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	ghostly wool hot daub bun of the bloodbag	0		Maximum HP: +100, Cold Resistance: +1, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	manspreader's vibrating hot daub stand	0		Maximum MP Percent: +10, Monster Level: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	hardy Sinatra's foot-long hot daub	0		Experience (Moxie): +5, Maximum HP: +50, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	bland small angst burger	2	decent	
@@ -5633,15 +5633,15 @@
 5732	twirling blank note	0		
 5733	lime green skewed eerily silent box	0		
 5734	decent super-sized forbidden sausage	5	good	
-5735	Lord Flameface's cloak of incineration	0		Hot Spell Damage: +50, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Lord Flameface's cloak of incineration	0		Hot Spell Damage: +50, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	corrupted mirror Drizzlers&trade; Black Licorice	0		Effect: "The Magic of Sharing", Effect Duration: 25
 5737	galvanized oxidized daub-breaker	0		Effect: "Spooky Jellied", Effect Duration: 55, Last Available: "2020-09"
 5738	forbidden Camp Scout backpack	0		Spell Damage Percent: +50, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	diet stale upside-down bag of GORP	1	decent	Last Available: "2012-07"
+5740	stale diet upside-down bag of GORP	1	decent	Last Available: "2012-07"
 5741	drinkable water purification pills	3	good	Last Available: "2012-07"
 5742	blurry Camp Scout pup tent	0		Last Available: "2012-07"
-5743	irresponsibly strong bad blurry CSA scoutmaster's &quot;water&quot;	9	decent	Last Available: "2012-07"
+5743	bad irresponsibly strong blurry CSA scoutmaster's &quot;water&quot;	9	decent	Last Available: "2012-07"
 5744	flavorless bag of GORF	3	decent	Last Available: "2012-07"
 5745	mirror CSA discount card	0		Last Available: "2020-09"
 5746	tasty blurry bag of QWOP	3	awesome	Last Available: "2012-07"
@@ -5650,7 +5650,7 @@
 5749	delicious CSA cheerfulness ration	3	awesome	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	jittery Tales of the Word Realms	0		
-5752	small spoiled crappy brain	2	crappy	
+5752	spoiled small crappy brain	2	crappy	
 5753	rotten lime green decent brain	4	crappy	
 5754	bland good brain	3	decent	
 5755	half-sized spoiled boss brain	2	crappy	
@@ -5665,16 +5665,16 @@
 5765	blurry boxer's cool fuzzy earmuffs	0		Moxie: +5, Muscle Percent: +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	flame-retardant Temple Grandin's fuzzy montera of bravery	0		Familiar Weight: +7, Hot Resistance: +1, Spooky Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	narrow ghostly gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	mirror gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	ghostly narrow gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	mirror gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	blinking Thwaitgold maggot statuette	0		
-5774	blurry huge talkative skull	0		
+5774	huge blurry talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	stiffened smartaleck's Barney's rake	0		Moxie Percent: +30, Damage Reduction: 1
-5778	thick normal enchanted bouncing idiot brain	5	good	Effect: "Shrimpin' Ain't Easy", Effect Duration: 25
+5778	normal thick enchanted bouncing idiot brain	5	good	Effect: "Shrimpin' Ain't Easy", Effect Duration: 25
 5779	auspicious keel-haulin' knife	0		Item Drop: +10
 5780	ice cream scoop of chilblains	0		Cold Damage: +25
 5781	acceptable red soft echo eyedrop antidote martini	3	good	
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	wobbly bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	perfumed quilted right bear arm	0		Damage Absorption: +40, Stench Resistance: +5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	Van der Graaf healthy thinker's left bear arm	0		Mysticality: +10, Maximum HP Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	perfumed quilted right bear arm	0		Damage Absorption: +40, Stench Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	Van der Graaf healthy thinker's left bear arm	0		Mysticality: +10, Maximum HP Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	pulsating gravedigger's Hat O' Nine Tails	0		Spooky Damage: +10
 5794	colloidal dry denatured Enchanted Plunger	0		Effect: "Mystic Circle", Effect Duration: 48
 5795	galvanized jittery Enchanted Flyswatter	0		Effect: "Human-Beast Hybrid", Effect Duration: 13
@@ -5709,7 +5709,7 @@
 5810	warmed adjusted Tears of the Quiet Healer	0		Effect: "Lemon Enlightenment", Effect Duration: 29
 5811	frozen triple-liquefied cyan tube of lipstick	0		Effect: "Total Protonic Reversal", Effect Duration: 53
 5812	wet adjusted dry skelelton spine	0		Effect: "Shredding, Sweating", Effect Duration: 31
-5813	enhanced extra-dry spinning fuchsia smut orc sunglasses	0		Effect: "Papowerful", Effect Duration: 48
+5813	enhanced extra-dry fuchsia spinning smut orc sunglasses	0		Effect: "Papowerful", Effect Duration: 48
 5814	polarized squat blob of acid	0		Effect: "Sticky Hands", Effect Duration: 59
 5815	cold-filtered wobbly flayed mind	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 55
 5816	Vulcanized kobold kibble	0		Effect: "Destructive Resolve", Effect Duration: 13
@@ -5718,7 +5718,7 @@
 5819	extra-modified blinking gravy fairy warlock hat	0		Effect: "Strong Grip", Effect Duration: 33
 5820	flattened bull blubber	0		Effect: "Superioreo", Effect Duration: 19
 5821	enhanced magnetized frog lip-print	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 64
-5822	triple-unsweetened narrow gray gazely stare	0		Effect: "Eldritch Concentration", Effect Duration: 36
+5822	triple-unsweetened gray narrow gazely stare	0		Effect: "Eldritch Concentration", Effect Duration: 36
 5823	moist squat canopic jar	0		Effect: "Leisurely Amblin'", Effect Duration: 14
 5824	vacuum-sealed oxidized skewed clove-flavored lip balm	0		Effect: "Fishily Speeding", Effect Duration: 29
 5825	non-frozen quadruple-ionized Skullery Maid's Knee	0		Effect: "Armor-Plated", Effect Duration: 36
@@ -5740,14 +5740,14 @@
 5841	moist triple-unsweetened A muse-bouche	0		Effect: "Wet Jaw", Effect Duration: 13
 5842	non-denatured yellow toothbrush	0		Effect: "Mucilaginous Mentalism", Effect Duration: 53
 5843	adjusted wobbly skewed pirate cream pie	0		Effect: "Sourpuss", Effect Duration: 28
-5844	ionized cold-filtered twirling skewed una poca de gracia	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 23
+5844	ionized cold-filtered skewed twirling una poca de gracia	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 23
 5845	denatured bouncing compressed air canister	0		Effect: "Chalked Weapon", Effect Duration: 23
 5846	corrupted denatured squat salt water taffy	0		Effect: "Woad Warrior", Effect Duration: 18
 5847	unsweetened ionized unholy water	0		Effect: "Optimist Primal", Effect Duration: 64
 5848	adjusted Bangyomaman battle juice	0		Effect: "Blood-Gorged", Effect Duration: 60
 5849	polarized nitrogenated green handyman &quot;hand soap&quot;	0		Effect: "Morbidi Tea", Effect Duration: 29
 5850	extra-electrified corrupted warmed space marine flash grenade	0		Effect: "Bilious Briskness", Effect Duration: 13
-5851	anodized unsweetened twirling bouncing temporary tribal tattoo	0		Effect: "Chalked Weapon", Effect Duration: 27
+5851	anodized unsweetened bouncing twirling temporary tribal tattoo	0		Effect: "Chalked Weapon", Effect Duration: 27
 5852	adjusted concentrated blurry oil-filled donut	0		Effect: "Jacked In", Effect Duration: 66
 5853	polarized colloidal skewed stick-on gnome beard	0		Effect: "Dreadful Sheen", Effect Duration: 29
 5854	irradiated chilled BRICKO stud	0		Effect: "Thaumodynamic", Effect Duration: 16
@@ -5755,10 +5755,10 @@
 5856	frozen Scuba Snack	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 50
 5857	pressed grey cube	0		Effect: "Dreadful Heat", Effect Duration: 57
 5858	magnetized quantum votive candle	0		Effect: "Void Between the Stars", Effect Duration: 24
-5859	colloidal modified blurry huge fuchsia booby trap	0		Effect: "PERL of Great Price", Effect Duration: 50
+5859	colloidal modified blurry fuchsia huge booby trap	0		Effect: "PERL of Great Price", Effect Duration: 50
 5860	non-polymerized quadruple-irradiated adjusted Agent Corrigan's cigarette	0		Effect: "Saucefingers", Effect Duration: 26
 5861	concentrated vacuum-sealed twirling good ash	0		Effect: "Rosewater Mark", Effect Duration: 33
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	narrow Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	polarized quadruple-alkaline twirling papier-mochi	0		Effect: "Trufflin'", Effect Duration: 18, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	Temple Grandin's papier-m&acirc;ch&eacute;te of the boozehound	0		Familiar Weight: +7, Booze Drop: +100, Last Available: "2012-09"
 5869	cyan spinning wicked smooth papier-m&acirc;chine gun	0		Moxie: +15, Spell Damage: +5, Last Available: "2012-09"
 5870	fuchsia toasty experienced papier-masque	0		Experience: +2, Hot Damage: +5, Single Equip, Last Available: "2012-09"
-5871	spinning blinking papier-mitre of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	executive Lo Pan's papier-m&acirc;churidars	0		Spell Critical Percent: +30, Meat Drop: +40, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	spinning blinking papier-mitre of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	executive Lo Pan's papier-m&acirc;churidars	0		Spell Critical Percent: +30, Meat Drop: +40, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	ghostly Jeselnik's nasty skeleton skis of the pedagogue	0		Experience: +3, Stench Damage: +5, Sleaze Damage: +25, Single Equip, Last Available: "2012-10"
-5883	small adequate skeleton quiche	2	good	Last Available: "2012-10"
+5883	adequate small skeleton quiche	2	good	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	red greedy rosy-cheeked beefy Bonestabber of terror	0		Muscle: +10, Maximum HP Percent: +30, Spooky Spell Damage: +10, Meat Drop: +20, Last Available: "2012-10"
@@ -5789,7 +5789,7 @@
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	bouncing ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	vacuum-sealed squat that gum you like	0		Effect: "Wreathed in Merriment", Effect Duration: 54
-5893	teal blurry dreaming Jung man	0		Free Pull, Last Available: "2013-12"
+5893	blurry teal dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	upside-down avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	olive canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	huge beefcake's brainwave-controlled unicorn horn	0		Muscle: +25, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	huge beefcake's brainwave-controlled unicorn horn	0		Muscle: +25, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	bouncing Rosewater's savvy plastic four-shadowed mime of mayonnaise	0		Mysticality Percent: 50, Sleaze Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,8 +5858,8 @@
 5960	plastic Father McGruber	0		Item Drop: +5, Last Available: "2012-12"
 5961	hale plastic Hank North, Photojournalist	0		Maximum HP: +20, Last Available: "2012-12"
 5962	supercharged plastic blazing bat	0		Maximum MP Percent: +30, Last Available: "2012-12"
-5963	fuchsia Tesla electronic dulcimer pants of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
-5964	green huge A-Boo clue	0		
+5963	fuchsia Tesla electronic dulcimer pants of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5964	huge green A-Boo clue	0		
 5965	censurious Socratic Frown Exerciser	0		Experience (Mysticality): +1, Sleaze Resistance: +3, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	blinking soul doorbell	0		
@@ -5876,10 +5876,10 @@
 5978	adequate blinking slice of pizza	3	good	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
-5981	shaking twirling star	0		Last Available: "2013-02"
-5982	drinkable fancy bouncing tankard of ale	3	good	Effect: "Sticks and Stones", Effect Duration: 30, Last Available: "2013-02"
+5981	twirling shaking star	0		Last Available: "2013-02"
+5982	fancy drinkable bouncing tankard of ale	3	good	Effect: "Sticks and Stones", Effect Duration: 30, Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	ribald Lo Pan's curative cloth cap	0		Spell Critical Percent: +30, Sleaze Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	ribald Lo Pan's curative cloth cap	0		Spell Critical Percent: +30, Sleaze Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	Sherlock's medical-grade beefcake's iron dagger	0		Muscle: +25, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02"
 5986	normal hamburger	4	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	potion	0		Last Available: "2013-02"
 5990	perfectly mixed bottle of wine	4	EPIC	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	yellow rosy-cheeked banded supercool iron helmet	0		Moxie Percent: +20, Damage Absorption: +100, Maximum HP Percent: +30, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	yellow rosy-cheeked banded supercool iron helmet	0		Moxie Percent: +20, Damage Absorption: +100, Maximum HP Percent: +30, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	blurry narrow sinister steel sword of Calamity Jane of horror	0		Spell Damage: +10, Critical Hit Percent: +15, Spooky Spell Damage: +25, Last Available: "2013-02"
 5994	flavorless special whole roasted chicken	3	decent	Effect: "Super Skill", Effect Duration: 20, Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
-5997	green ghostly potion	0		Last Available: "2013-02"
+5997	ghostly green potion	0		Last Available: "2013-02"
 5998	delicious practically non-alcoholic shining goblet	1	awesome	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	therapeutic smartaleck's crown of the brazier	0		Moxie Percent: +30, Hot Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	therapeutic smartaleck's crown of the brazier	0		Moxie Percent: +30, Hot Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	perfumed dangerous sage sword	0		Mysticality Percent: +10, Weapon Damage: +10, Stench Resistance: +5, Last Available: "2013-02"
-6002	wholesome groovy Helm of the Scream Emperor of the dark arts	0		Moxie Percent: +10, Spell Damage Percent: +100, Maximum HP Percent: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	wholesome groovy Helm of the Scream Emperor of the dark arts	0		Moxie Percent: +10, Spell Damage Percent: +100, Maximum HP Percent: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	skewed gravedigger's healthy Cloak of Dire Shadows of the empath	0		Maximum HP Percent: +20, Familiar Weight: +5, Spooky Damage: +10, Last Available: "2013-02"
 6004	shaking nasty Fonzie's Sword of Dark Omens of incineration	0		Experience (Moxie): +1, Hot Spell Damage: +50, Stench Damage: +5, Last Available: "2013-02"
 6005	family-friendly Annie Oakley's brawny Shield of Icy Fate	0		Muscle Percent: +20, Critical Hit Percent: +20, Sleaze Resistance: +1, Damage Reduction: 7, Last Available: "2013-02"
-6006	Herculean Greaves of the Murk Lord of the cougar of doom	0		Moxie: +20, Experience (Muscle): +1, Spooky Spell Damage: +50, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	Herculean Greaves of the Murk Lord of the cougar of doom	0		Moxie: +20, Experience (Muscle): +1, Spooky Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	rosewater-soaked strapping Gauntlets of the Blood Moon of mayonnaise	0		Muscle: +5, Sleaze Spell Damage: +50, Stench Resistance: +3, Single Equip, Last Available: "2013-02"
 6008	dance instructor's Samson's Boots of Twilight Whispers of James Dean	0		Experience (Muscle): +5, Experience (Moxie): +3, Experience Percent (Moxie): +10, Single Equip, Last Available: "2013-02"
 6009	avaricious double-paned Belt of Howling Anger of the sweet-tooth	0		Cold Resistance: +5, Meat Drop: +30, Candy Drop: +100, Single Equip, Last Available: "2013-02"
@@ -5910,10 +5910,10 @@
 6012	nippy freshwater pearl necklace	0		Cold Damage: +10
 6013	Socratic Samson's orcish stud-finder	0		Experience (Muscle): +5, Experience (Mysticality): +1
 6014	blue censurious screwing pooch	0		Sleaze Resistance: +3
-6015	frozen dry purple mirror orcish hand lotion	0		Effect: "Hyperoffended", Effect Duration: 41
+6015	frozen dry mirror purple orcish hand lotion	0		Effect: "Hyperoffended", Effect Duration: 41
 6016	ionized narrow orcish rubber	0		Effect: "Mariachi Mood", Effect Duration: 11
 6017	nitrogenated polarized green orcish nailing lube	0		Effect: "Norwhalloped", Effect Duration: 57
-6018	weak acceptable backwoods screwdriver	2	good	
+6018	acceptable weak backwoods screwdriver	2	good	
 6019	energetic loadstone	0		Maximum MP Percent: +20
 6020	Claybender glasses of the boozehound of the cheetah	0		Booze Drop: +100, Initiative: +60, Single Equip
 6021	foul-smelling slick Duskwalker fangs	0		Moxie: +10, Stench Damage: +10
@@ -5923,7 +5923,7 @@
 6025	deionized super-deionized Polysniff Perfume	0		Effect: "Disco Inferno", Effect Duration: 54
 6026	Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
-6028	blinking jittery Battlie Light Saver	0		
+6028	jittery blinking Battlie Light Saver	0		
 6029	shaking T.U.R.D.S. Key	0		
 6030	dress pants of temperance	0		Sleaze Resistance: +5, Familiar Effect: "2xFairy, cap 28"
 6031	Jeselnik's badge of authority	0		Sleaze Damage: +25, Single Equip
@@ -5933,7 +5933,7 @@
 6035	deionized purple vial of The Glistening	0		Effect: "Insulated Trousers", Effect Duration: 23
 6036	drinkable artisanal limoncello	3	good	
 6037	mirror ginger ale	0		
-6038	normal gigantic blinking jittery incredible pizza	7	good	
+6038	gigantic normal blinking jittery incredible pizza	7	good	
 6039	blinking steel-toed oil cap of courage	0		Damage Reduction: 9, Spooky Resistance: +3, Familiar Effect: "cap 28"
 6040	tumbling executive oil lamp of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +40
 6041	purple family-friendly oil slacks	0		Sleaze Resistance: +1, Familiar Effect: "1xPotato, cap 30"
@@ -5951,7 +5951,7 @@
 6053	perfectly mixed Taco Dan's Taco Stand Chimichangarita	3	EPIC	Last Available: "2012-12"
 6054	quadruple-denatured energized liquefied pulsating Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Wintergreen Warmongery", Effect Duration: 14, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	Jim Carey's beefcake's Meatcleaver	0		Muscle: +25, Monster Level: +25, Last Available: "2013-12"
 6058	shaking sinister Crimbo Elf bobble-head	0		Spell Damage: +10, Last Available: "2012-12"
 6059	toasty Crimbo stogie-scented room odorizer	0		Hot Damage: +5, Last Available: "2012-12"
@@ -5966,19 +5966,19 @@
 6068	olive loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	modified unsweetened mirror haggis-infused soap	0		Effect: "Violent Night", Effect Duration: 40, Last Available: "2012-12"
 6074	concentrated oxidized skewed wobbly magicberry tablets	0		Effect: "Healthy Red Glow", Effect Duration: 19, Last Available: "2012-12"
 6075	activated nitrogenated jittery purple narrow 37x37x37 puzzle cube	0		Effect: "[800]Chocolate Reign", Effect Duration: 69, Last Available: "2012-12"
 6076	perfectly mixed McLeod's Hard Haggis-Ade	3	EPIC	Last Available: "2012-12"
 6077	rotten haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
-6078	blinking upside-down home robotics kit	0		Last Available: "2012-12"
+6078	upside-down blinking home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	haggis socks of the cougar	0		Moxie: +20, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	wobbly airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	haggis socks of the cougar	0		Moxie: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	wobbly airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
-6083	spinning tumbling actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
+6083	tumbling spinning actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
 6086	shaking spinning blinking gravedigger's Microplushie: Otakulone	0		Spooky Damage: +10, Last Available: "2012-12"
@@ -6000,7 +6000,7 @@
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	wobbly Artist's Butterknife of Regret	0		Last Available: "2013-12"
-6105	jittery blurry Artist's Spatula of Despair	0		Last Available: "2013-12"
+6105	blurry jittery Artist's Spatula of Despair	0		Last Available: "2013-12"
 6106	Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	ghostly coward's vibrating Ginsu&trade;	0		Maximum MP Percent: +10, Monster Level: -20, Last Available: "2013-12"
@@ -6018,7 +6018,7 @@
 6120	tumbling bonsai tree	0		Last Available: "2013-12"
 6121	tolerable Chinese beer	4	good	Last Available: "2013-12"
 6122	skewed cat statue	0		Last Available: "2013-12"
-6123	bouncing purple rhinoceros horn	0		Last Available: "2013-12"
+6123	purple bouncing rhinoceros horn	0		Last Available: "2013-12"
 6124	yellow blinking furry pink pillow	0		Last Available: "2013-12"
 6125	frozen bottle of limeade	0		Effect: "Well-preserved", Effect Duration: 23, Last Available: "2013-12"
 6126	Van der Graaf novelty tattoo sleeves of chilblains	0		Cold Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-12"
@@ -6040,9 +6040,9 @@
 6142	bland roasted duck	3	decent	Last Available: "2013-12"
 6143	normal dead meat bun	4	good	Last Available: "2013-12"
 6144	cat collar of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2013-12"
-6145	tumbling Sherlock's chaotic suspicious-looking fedora	0		Spell Critical Percent: +10, Item Drop: +25, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	tumbling Sherlock's chaotic suspicious-looking fedora	0		Spell Critical Percent: +10, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
-6148	narrow tumbling Deactivated MiniMechaElf	0		Last Available: "2012-12"
+6148	tumbling narrow Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	olive MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	upside-down Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
@@ -6052,19 +6052,19 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	Byte of wisdom of extreme caution	0		Mysticality: +15, Monster Level: -25, Last Available: "2013-12"
-6158	reassuring anger blaster	0		Spooky Resistance: +1, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	dangerous doubt cannon	0		Weapon Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	censurious fear condenser	0		Sleaze Resistance: +3, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	regret hose of the blizzard	0		Cold Spell Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	reassuring anger blaster	0		Spooky Resistance: +1, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	dangerous doubt cannon	0		Weapon Damage: +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	censurious fear condenser	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	regret hose of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	narrow Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	commodore's hat of the ox of doom	0		Muscle: +20, Spooky Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	Rosewater's naval trousers	0		Mysticality Percent: +30, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	commodore's hat of the ox of doom	0		Muscle: +20, Spooky Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	Rosewater's naval trousers	0		Mysticality Percent: +30, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	tumbling stylish deck cannon of the ox	0		Muscle: +20, Moxie: +25, Last Available: "2013-12"
 6167	ornamental sextant of the dark arts	0		Spell Damage Percent: +100, Last Available: "2013-12"
 6168	horrifying Da Vinci's Bloodbath	0		Experience (Mysticality): +5, Spooky Damage: +25, Last Available: "2013-12"
-6169	watered-down tolerable Hundred Headed IPA	2	good	Last Available: "2013-12"
-6170	adequate diet chum	1	good	Last Available: "2013-12"
+6169	tolerable watered-down Hundred Headed IPA	2	good	Last Available: "2013-12"
+6170	diet adequate chum	1	good	Last Available: "2013-12"
 6171	energized red crude crudit&eacute;s	0		Effect: "Papowerful", Effect Duration: 19
 6172	frozen polymerized ionized candy crayons	0		Effect: "Vitali Tea", Effect Duration: 44, Last Available: "2020-09"
 6173	twirling supercharged slick pixel grappling hook	0		Moxie: +10, Maximum MP Percent: +30
@@ -6072,7 +6072,7 @@
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	red cosmic dough	0		
-6178	bouncing spinning cosmic vegetable	0		
+6178	spinning bouncing cosmic vegetable	0		
 6179	cosmic cheese	0		
 6180	cosmic potted meat product	0		
 6181	cosmic potato	0		
@@ -6083,18 +6083,18 @@
 6186	spoiled mirror consummate fried egg	4	crappy	
 6187	stale fancy consummate egg salad	3	decent	Effect: "Ooh, Salty!", Effect Duration: 35
 6188	bland blue consummate bagel	3	decent	
-6189	half-sized spoiled consummate sliced bread	2	crappy	
-6190	enchanted adequate consummate hot dog bun	3	good	Effect: "Fire Inside", Effect Duration: 25
-6191	tasty immense wobbly consummate brownie	9	awesome	
+6189	spoiled half-sized consummate sliced bread	2	crappy	
+6190	adequate enchanted consummate hot dog bun	3	good	Effect: "Fire Inside", Effect Duration: 25
+6191	immense tasty wobbly consummate brownie	9	awesome	
 6192	delicious enchanted consummate toast	3	awesome	Effect: "Fangs and Pangs", Effect Duration: 30
 6193	acceptable passable stout	3	good	
 6194	stale pulsating consummate soup	3	decent	
-6195	rotten huge consummate corn chips	8	crappy	
+6195	huge rotten consummate corn chips	8	crappy	
 6196	bland snack-sized narrow consummate salad	2	decent	
 6197	thick adequate yellow consummate salsa	5	good	
-6198	adequate miniature consummate sauerkraut	2	good	
+6198	miniature adequate consummate sauerkraut	2	good	
 6199	big moldy ghostly consummate cheese slice	5	crappy	
-6200	miniature yummy consummate melted cheese	2	awesome	
+6200	yummy miniature consummate melted cheese	2	awesome	
 6201	yummy consummate bacon	3	awesome	
 6202	spoiled maroon consummate meatloaf	4	crappy	
 6203	decent small consummate steak	2	good	
@@ -6102,19 +6102,19 @@
 6205	stale squat consummate frankfurter	3	decent	
 6206	low-calorie normal consummate french fries	1	good	
 6207	flavorless huge consummate baked potato	6	decent	
-6208	bad special practically non-alcoholic acceptable vodka	1	decent	Effect: "Wallflowering", Effect Duration: 45
-6209	fancy delicious half-sized shaking consummate ice cream	2	awesome	Effect: "Yeah, It's Just Gasoline", Effect Duration: 20
+6208	practically non-alcoholic bad special acceptable vodka	1	decent	Effect: "Wallflowering", Effect Duration: 45
+6209	half-sized delicious fancy shaking consummate ice cream	2	awesome	Effect: "Yeah, It's Just Gasoline", Effect Duration: 20
 6210	tiny adequate consummate whipped cream	1	good	
 6211	stale consummate cream	4	decent	
 6212	moldy special consummate strawberries	3	crappy	Effect: "Bilious Briskness", Effect Duration: 15
-6213	yummy miniature consummate sorbet	2	awesome	
-6214	weak tolerable twirling adequate rum	2	good	
-6215	perfectly mixed triple-distilled mediocre lager	10	EPIC	
+6213	miniature yummy consummate sorbet	2	awesome	
+6214	tolerable weak twirling adequate rum	2	good	
+6215	triple-distilled perfectly mixed mediocre lager	10	EPIC	
 6216	rotten small huge immaculate grilled cheese	2	crappy	
 6217	bland tumbling immaculate ice cream sandwich	4	decent	
-6218	rotten purple narrow immaculate hot dog	4	crappy	
+6218	rotten narrow purple immaculate hot dog	4	crappy	
 6219	moldy immaculate egg salad sandwich	4	crappy	
-6220	special bland massive blurry huge perfect sandwich	9	decent	Effect: "Pasta Oneness", Effect Duration: 40
+6220	special bland massive huge blurry perfect sandwich	9	decent	Effect: "Pasta Oneness", Effect Duration: 40
 6221	adequate miniature perfect chef salad	2	good	
 6222	adequate perfect breakfast	4	good	
 6223	thick adequate sublime deluxe hot dog	5	good	
@@ -6124,8 +6124,8 @@
 6227	normal Loaded Baked Potato	3	good	
 6228	spoiled Omega Sundae	4	crappy	
 6229	perfectly mixed cyan Das Sauerlager	4	EPIC	
-6230	acceptable practically non-alcoholic Bologna Lambic	1	good	
-6231	artisanal practically non-alcoholic Vodka Dog	1	super ultra EPIC	
+6230	practically non-alcoholic acceptable Bologna Lambic	1	good	
+6231	practically non-alcoholic artisanal Vodka Dog	1	super ultra EPIC	
 6232	tolerable Disappointed Russian	3	good	
 6233	lousy skewed Chunky Mary	3	decent	
 6234	triple-distilled tolerable yellow Nachojito	6	good	
@@ -6136,7 +6136,7 @@
 6240	chilled energized Illuminati earpiece	0		Effect: "Takin' It Greasy", Effect Duration: 50
 6241	anodized censored can label	0		Effect: "Muddled", Effect Duration: 48
 6242	wet Vulcanized ectoplasm <i>au jus</i>	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 65
-6243	activated pulsating maroon the kindest cut	0		Effect: "Bone Chilling", Effect Duration: 32
+6243	activated maroon pulsating the kindest cut	0		Effect: "Bone Chilling", Effect Duration: 32
 6244	deionized red cat's paw	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 13
 6245	enhanced ASCII fu manchu	0		Effect: "Crimbo Flavor", Effect Duration: 21
 6246	pressed demonic surgical gloves	0		Effect: "20-20 Second Sight", Effect Duration: 47
@@ -6160,29 +6160,29 @@
 6264	sizzling Staff of Fruit Salad of the cougar of doom	0		Moxie: +20, Hot Damage: +10, Spooky Spell Damage: +50, Jiggle: "Deal Some Prismatic Damage"
 6265	foul-smelling Rosewater's Staff of the Cream of the Cream of the bloodbag	0		Mysticality Percent: +30, Maximum HP: +100, Stench Damage: +10, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	half-sized rotten grain of protein powder	2	crappy	
+6267	rotten half-sized grain of protein powder	2	crappy	
 6268	triple-tarnished gray pec oil	0		Effect: "Slimily Speedy", Effect Duration: 44
 6269	cyan gym membership card of extreme caution	0		Monster Level: -25
 6270	vacuum-sealed Squat-Thrust Magazine	0		Effect: "Cold, Dead Hands", Effect Duration: 47
 6271	massive dumbbell	0		
 6272	bouncing Annie Oakley's thinker's penguin keychain	0		Mysticality: +10, Critical Hit Percent: +20, Damage Reduction: 10
-6273	dry dry ionized jittery ghostly O'RLY manual	0		Effect: "Trash-Wrapped", Effect Duration: 32
+6273	dry dry ionized ghostly jittery O'RLY manual	0		Effect: "Trash-Wrapped", Effect Duration: 32
 6274	mediocre shaking open sauce	4	decent	
 6275	flame-retardant Oprah's turkey leg	0		Maximum MP Percent: +50, Hot Resistance: +1
-6276	lousy practically non-alcoholic Ye Olde Meade	1	decent	
+6276	practically non-alcoholic lousy Ye Olde Meade	1	decent	
 6277	cold-filtered Ye Olde Bawdy Limerick	0		Effect: "Standard Issue Bravery", Effect Duration: 18
 6278	yellow Ye Olde Medieval Insult	0		
 6279	purple Usain Bolt's pewter claymore	0		Initiative: +80
 6280	artisanal rice peeler of the glutton	0		Food Drop: +100
-6281	miniature yummy heirloom grape tomato	2	awesome	
-6282	jittery cyan chipotle wasabi cilantro aioli	0		
+6281	yummy miniature heirloom grape tomato	2	awesome	
+6282	cyan jittery chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of extreme caution	0		Monster Level: -25, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
 6285	greasy stiffened Mark I Steam-Hat	0		Damage Reduction: 1, Sleaze Spell Damage: +10, Familiar Effect: "1xLep, cap 37"
 6286	frightening Mark II Steam-Hat of the wise owl of extreme caution	0		Mysticality: +20, Monster Level: -25, Spooky Damage: +5, Familiar Effect: "1xLep, cap 37"
 6287	bouncing lime green electrified Herculean savvy Mark III Steam-Hat of the sewer	0		Mysticality Percent: +20, Experience (Muscle): +1, Stench Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6288	Usain Bolt's censurious dog trainer's sinister extremely unsafe Mark IV Steam-Hat	0		Weapon Damage Percent: +100, Spell Damage: +10, Experience (familiar): +1, Sleaze Resistance: +3, Initiative: +80, Familiar Effect: "1xLep, cap 37"
-6289	lard-coated nippy careful brainy Mark V Steam-Hat of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Monster Level: -10, Cold Damage: +10, Sleaze Spell Damage: +25, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	lard-coated nippy careful brainy Mark V Steam-Hat of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Monster Level: -10, Cold Damage: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	blue vibrating strapping punk rock jacket	0		Muscle: +5, Maximum MP Percent: +10
 6292	censurious hardy safety pin	0		Maximum HP: +50, Sleaze Resistance: +3
@@ -6201,7 +6201,7 @@
 6305	huge asbestos-lined curative Jarlsberg's pan of the bloodbag of terror of the glutton	0		Maximum HP: +100, Spooky Spell Damage: +10, Hot Resistance: +5, Food Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Free Pull, Last Available: "2013-03"
 6306	Cosmic Calorie	0		Last Available: "2013-03"
 6307	warmed celestial olive oil	0		Effect: "Uncaged Power", Effect Duration: 57, Last Available: "2013-03"
-6308	moist alkaline ionized mirror narrow celestial carrot juice	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 22, Last Available: "2013-03"
+6308	moist alkaline ionized narrow mirror celestial carrot juice	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 22, Last Available: "2013-03"
 6309	irradiated warmed green blinking celestial au jus	0		Effect: "Truly Gritty", Effect Duration: 42, Last Available: "2013-03"
 6310	anodized anodized wet tumbling celestial squid ink	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 31, Last Available: "2013-03"
 6311	pulsating quilted Uncle Buck	0		Damage Absorption: +40, Softcore Only
@@ -6236,7 +6236,7 @@
 6340	manspreader's chaotic floral-print skirt	0		Spell Critical Percent: +10, Monster Level: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	narrow dog trainer's hale spectral axe	0		Maximum HP: +20, Experience (familiar): +1
 6342	up-at-dawn sizzling super-strong air freshener	0		Hot Damage: +10, Adventures: +5
-6343	boiled concentrated huge bouncing Mer-kin lipstick	0		Effect: "It's Electric!", Effect Duration: 44
+6343	boiled concentrated bouncing huge Mer-kin lipstick	0		Effect: "It's Electric!", Effect Duration: 44
 6344	Mer-kin mouthsoap	0		
 6345	nitrogenated warmed Mer-kin strongjuice	0		Effect: "Here to Kick Ass", Effect Duration: 41
 6346	Mer-kin fitbrine	0		
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	green rosy-cheeked Mer-kin begsign	0		Maximum HP Percent: +30, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	triple-cold-filtered denatured oxidized huge mirror pulled taffy	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 19, Last Available: "2013-04"
 6362	altered pulled indigo taffy	0		Effect: "Salt Rockin'", Effect Duration: 21, Last Available: "2013-04"
 6363	adjusted pulled taffy	0		Effect: "Egged On", Effect Duration: 25, Last Available: "2013-04"
@@ -6265,12 +6265,12 @@
 6369	lump of clay	0		
 6370	teal twisted piece of wire	0		
 6371	lousy can of the cheapest beer	3	decent	
-6372	fortified bad blinking mirror bottle of fruity &quot;wine&quot;	5	decent	
+6372	fortified bad mirror blinking bottle of fruity &quot;wine&quot;	5	decent	
 6373	hand-crafted single swig of vodka	4	EPIC	
 6374	angry inch	0		
 6375	shellacked testy toolbox	0		Damage Reduction: 7
 6376	blue Jick-o-User	0		
-6378	wobbly huge eraser nubbin	0		
+6378	huge wobbly eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	vacuum-sealed boiled green ph balancer	0		Effect: "Hare-o-dynamic", Effect Duration: 47
 6381	ionized liquefied mysterious chemical residue	0		Effect: "Memory of Strength", Effect Duration: 68
@@ -6279,14 +6279,14 @@
 6384	jigsaw blade	0		
 6385	wood screw	0		
 6386	blinking balsa plank	0		
-6387	shaking cyan blob of wood glue	0		
+6387	cyan shaking blob of wood glue	0		
 6388	skewed envyfish egg	0		Last Available: "2013-04"
 6389	Vulcanized warmed Mer-kin rocksalt	0		Effect: "Gonna Get You, Sucker", Effect Duration: 66
 6390	alkaline unsweetened cold-filtered Mer-kin saltmint	0		Effect: "Steroid Boost", Effect Duration: 56
 6391	corrupted non-dry Mer-kin saltsquid	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 44
 6392	nasty brawny scale-mail underwear	0		Muscle Percent: +20, Stench Damage: +5, Familiar Effect: "2xVolley"
 6393	dry comb jelly	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 34
-6394	tumbling olive anemone sauce	0		
+6394	olive tumbling anemone sauce	0		
 6395	upside-down inky squid sauce	0		
 6396	squat Mer-kin weaksauce	0		
 6397	peanut sauce	0		
@@ -6307,21 +6307,21 @@
 6412	shaking skull	0		No Pull
 6413	jittery Order of the Green Thumb Order Form	0		Free Pull
 6414	red clutch of dodecapede eggs	0		
-6415	moldy massive flavorless gruel	8	crappy	
+6415	massive moldy flavorless gruel	8	crappy	
 6416	stale mana curds	3	decent	
 6417	gray wobbly twist of lime	0		
 6418	pencil stub	0		
 6419	electrified concentrated upside-down moth dust	0		Effect: "Weird Flavor", Effect Duration: 28
 6420	unsweetened colloidal chilled glob of spoiled mayo	0		Effect: "Gummibrain", Effect Duration: 35
 6421	tonic djinn	0		
-6422	small yummy vampire chowder	2	awesome	
+6422	yummy small vampire chowder	2	awesome	
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	normal Dreadsylvanian stew	3	good	
 6427	hand-crafted practically non-alcoholic purple Dreadsylvanian	1	super ultra EPIC	
 6428	wet jittery twirling Dreadsylvanian flask	0		Effect: "Memory of Smarts", Effect Duration: 65
-6429	wet denatured blurry wobbly skewed Dreadsylvanian flask	0		Effect: "Good with the Ladies", Effect Duration: 24
+6429	wet denatured skewed wobbly blurry Dreadsylvanian flask	0		Effect: "Good with the Ladies", Effect Duration: 24
 6430	jittery lard-coated hardy dreadful fedora	0		Maximum HP: +50, Sleaze Spell Damage: +25, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	weightlifter's dreadful sweater	0		Muscle: +15, Kruegerand Drop: 5
 6432	Jeselnik's dreadful glove	0		Sleaze Damage: +25, Kruegerand Drop: 5
@@ -6338,7 +6338,7 @@
 6443	double-paned healthy Helps-You-Sleep	0		Maximum HP Percent: +20, Cold Resistance: +5, Single Equip
 6444	frosty manspreader's medical-grade Quiets-Your-Steps	0		Monster Level: +10, Cold Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 6445	foul-smelling stiffened Protects-Your-Junk	0		Damage Reduction: 1, Stench Damage: +10, Single Equip
-6446	lousy practically non-alcoholic lime green Gets-You-Drunk	1	decent	
+6446	practically non-alcoholic lousy lime green Gets-You-Drunk	1	decent	
 6447	executive Jim Carey's weightlifter's Great Wolf's headband	0		Muscle: +15, Monster Level: +25, Meat Drop: +40, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	Annie Oakley's Tesla therapeutic Great Wolf's left paw	0		Critical Hit Percent: +20, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 5, HP Regen Max: 7, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	Jack Frost's Oprah's Newton's Great Wolf's right paw	0		Experience (Mysticality): +3, Maximum MP Percent: +50, Cold Spell Damage: +50, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6364,7 +6364,7 @@
 6469	squat avaricious forbidden Thunkula's drinking cap of the glutton	0		Spell Damage Percent: +50, Meat Drop: +30, Food Drop: +100, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	upside-down nippy MacGyver's Drunkula's cape of the brazier	0		Maximum MP: +100, Cold Damage: +10, Hot Spell Damage: +25, Class: "Sauceror"
 6471	lion tamer's arcane researcher's Drunkula's silky pants of chilblains	0		Experience Percent (Mysticality): +10, Experience (familiar): +2, Cold Damage: +25, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
-6472	fuchsia huge Drunkula's bell	0		
+6472	huge fuchsia Drunkula's bell	0		
 6473	smartaleck's Drunkula's ring of haze of Tarzan of courage	0		Moxie Percent: +30, Experience (Muscle): +3, Spooky Resistance: +3, Avoid Attack: 1, Single Equip
 6474	wobbly Van der Graaf Drunkula's wineglass	0		MP Regen Min: 5, MP Regen Max: 7
 6475	acceptable bottle of Bloodweiser	4	good	
@@ -6376,11 +6376,11 @@
 6481	flame-retardant banded Unkillable Skeleton's restless leg	0		Damage Absorption: +100, Hot Resistance: +1
 6482	dog trainer's chaotic energetic Staff of the Roaring Hearth	0		Maximum MP Percent: +20, Spell Critical Percent: +10, Experience (familiar): +1
 6483	green narrow Kool-Aid	1	good	
-6484	spinning blinking dread tarragon	0		
+6484	blinking spinning dread tarragon	0		
 6485	upside-down bone flour	0		
 6486	skewed wobbly dreadful roast	0		
 6487	stinking agaricus	0		
-6488	decent miniature pulsating Dreadsylvanian shepherd's pie	2	good	
+6488	miniature decent pulsating Dreadsylvanian shepherd's pie	2	good	
 6489	music box parts	0		
 6490	bouncing bouncing unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6408,7 +6408,7 @@
 6513	bouncing warm fur of the dark arts	0		Spell Damage Percent: +100
 6514	sinister snowstick	0		Spell Damage: +10
 6515	dog trainer's eerie fetish	0		Experience (familiar): +1, Single Equip
-6516	smooth watered-down ghostly stinkwater	2	awesome	
+6516	watered-down smooth ghostly stinkwater	2	awesome	
 6517	blue dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	spoiled fancy accidental mutton	3	crappy	Effect: "Cravin' for a Ravin'", Effect Duration: 50
 6519	Annie Oakley's Fonzie's drafty drawers	0		Experience (Moxie): +1, Critical Hit Percent: +20, Familiar Effect: "1.5xVolley"
@@ -6421,7 +6421,7 @@
 6526	fortified savvy bag of unfinished business	0		Mysticality Percent: +20, Damage Absorption: +60
 6527	maroon auspicious extremely unsafe transparent pants	0		Weapon Damage Percent: +100, Item Drop: +10, Familiar Effect: "sleaze atk, 1xPotato"
 6528	educational hothammer	0		Experience: +1
-6529	fancy hand-crafted Thriller Ice	4	EPIC	Effect: "Dreadful Chill", Effect Duration: 50
+6529	hand-crafted fancy Thriller Ice	4	EPIC	Effect: "Dreadful Chill", Effect Duration: 50
 6530	upside-down grandfather watch of wisdom	0		Mysticality: +15, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	purple scandalous spyglass of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5
@@ -6468,7 +6468,7 @@
 6574	spinning hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	blinking clusterbomb	0		
-6577	jittery narrow stench clusterbomb	0		
+6577	narrow jittery stench clusterbomb	0		
 6578	narrow sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	cyan length of fuse	0		
@@ -6477,7 +6477,7 @@
 6583	vicious spiked collar	0		Familiar Damage: +20
 6584	frosty hot dog wrapper	0		Cold Spell Damage: +10
 6585	wool beefy debonair deboner	0		Muscle: +10, Cold Resistance: +1
-6586	extra-boiled ionized upside-down blurry chicle de salchicha	0		Effect: "Coal-Powered", Effect Duration: 59
+6586	extra-boiled ionized blurry upside-down chicle de salchicha	0		Effect: "Coal-Powered", Effect Duration: 59
 6587	jar of frostigkraut of the overflowing toilet	0		Stench Spell Damage: +50
 6588	knitted gnawed-up dog bone of the empath	0		Familiar Weight: +5, Cold Resistance: +3
 6589	Grey Guanon of chilblains	0		Cold Damage: +25
@@ -6486,7 +6486,7 @@
 6592	avaricious brainy optimal spreadsheet of the storm	0		Mysticality: +5, Maximum MP Percent: +40, Meat Drop: +30
 6593	olive defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
-6595	denatured cyan shaking epic cluster	1	EPIC	
+6595	denatured shaking cyan epic cluster	1	EPIC	
 6596	clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	clockwork disc	0		
@@ -6509,10 +6509,10 @@
 6615	mediocre squat Cold One	4	???	
 6616	snack-sized bland huge spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
-6618	squat shaking folder (red)	0		Muscle: +20, Last Available: "2013-08"
+6618	shaking squat folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
-6621	tumbling yellow jittery folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
+6621	yellow jittery tumbling folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	wobbly folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
@@ -6528,7 +6528,7 @@
 6634	twirling folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	teal skewed folder (Seawolf)	0		Last Available: "2013-08"
 6636	olive folder (dancing dolphins)	0		Last Available: "2013-08"
-6637	jittery skewed folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
+6637	skewed jittery folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	folder (owl)	0		Last Available: "2013-08"
 6640	upside-down folder (Stinky Trash Kid)	0		Last Available: "2013-08"
@@ -6548,7 +6548,7 @@
 6656	illegal firecracker	0		
 6657	medical-grade hardened pickelhaube	0		Damage Reduction: 3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	deionized hair oil	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 40
-6659	corrupted quadruple-liquefied skewed pulsating scrap	0		Effect: "Horrid, Torrid", Effect Duration: 58
+6659	corrupted quadruple-liquefied pulsating skewed scrap	0		Effect: "Horrid, Torrid", Effect Duration: 58
 6660	pulsating school spirit socket set	0		
 6661	huge suspension bridge	0		
 6662	jittery bouncing Sherlock's Staff of the Lunch Lady of Tarzan of the overflowing toilet of terror	0		Experience (Muscle): +3, Stench Spell Damage: +50, Spooky Spell Damage: +10, Item Drop: +25
@@ -6584,11 +6584,11 @@
 6692	McClusky file (page 4)	0		
 6693	twirling McClusky file (page 5)	0		
 6694	jittery boring binder clip	0		
-6695	huge ghostly McClusky file (complete)	0		
+6695	ghostly huge McClusky file (complete)	0		
 6696	olive bowling ball	0		
 6697	moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
-6699	narrow purple crackling stone sphere	0		
+6699	purple narrow crackling stone sphere	0		
 6700	scorched stone sphere	0		
 6701	shaking shaking stone triangle	0		
 6702	shaking mirror bowler	0		
@@ -6596,7 +6596,7 @@
 6704	family-friendly scorching short-handled mop	0		Hot Damage: +25, Sleaze Resistance: +1
 6705	delicious bite-sized jungle floor wax	1	awesome	
 6706	squat smirking shrunken head	0		
-6707	dry improved blurry cyan colorful toad	0		Effect: "Disco Concentration", Effect Duration: 25
+6707	dry improved cyan blurry colorful toad	0		Effect: "Disco Concentration", Effect Duration: 25
 6708	narrow twirling crude voodoo doll	0		
 6709	spinning attorney's badge	0		Single Equip
 6710	pulsating frightening forbidden pygmy briefs	0		Spell Damage Percent: +50, Spooky Damage: +5, Familiar Effect: "atk, 1xVolley, cap 41"
@@ -6621,7 +6621,7 @@
 6729	blue UV-resistant compass	0		
 6730	spinning funky junk key	0		
 6731	blinking Worse Homes and Gardens	0		
-6732	blinking skewed huge claw-foot bathtub	0		
+6732	skewed blinking huge claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	shaking squat cigar sign	0		
 6735	pulsating junk junk	0		
@@ -6629,7 +6629,7 @@
 6737	tangle of copper wire	0		
 6738	jagged scrap	0		
 6739	ionized bent scrap	0		Effect: "License to Punch", Effect Duration: 15
-6740	narrow blue blinking molten scrap	0		
+6740	narrow blinking blue molten scrap	0		
 6741	purple eternal car battery	0		
 6742	narrow shaking junk band of James Dean	0		Experience (Moxie): +3
 6743	beefcake's junk trunks	0		Muscle: +25, Familiar Effect: "cap 15"
@@ -6650,15 +6650,15 @@
 6758	aged can of Drooling Monk	3	awesome	Last Available: "2013-09"
 6759	hand-crafted can of Impetuous Scofflaw	3	EPIC	Last Available: "2013-09"
 6760	practically non-alcoholic perfectly mixed skewed bottle of Old Pugilist	1	super ultra mega turbo EPIC	Last Available: "2013-09"
-6761	practically non-alcoholic tolerable mirror bottle of Professor Beer	1	good	Last Available: "2013-09"
+6761	tolerable practically non-alcoholic mirror bottle of Professor Beer	1	good	Last Available: "2013-09"
 6762	fancy delicious bottle of Rapier Witbier	3	awesome	Effect: "Speed of the Internet", Effect Duration: 30, Last Available: "2013-09"
-6763	extra-dry perfectly mixed bottle of Race Car Red	5	EPIC	Last Available: "2013-09"
+6763	perfectly mixed extra-dry bottle of Race Car Red	5	EPIC	Last Available: "2013-09"
 6764	bad triple-distilled green bottle of Greedy Dog	9	decent	Last Available: "2013-09"
 6765	acceptable bottle of Lambada Lambic	4	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	squat artisanal homebrew gift package	0		
-6768	spinning narrow liquid bread	1	crappy	Last Available: "2013-09"
-6769	lightning-fast gravedigger's tin tam of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +10, Initiative: +40, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6768	narrow spinning liquid bread	1	crappy	Last Available: "2013-09"
+6769	lightning-fast gravedigger's tin tam of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +10, Initiative: +40, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	quantum quantum tumbling tin cup	0		Effect: "Feeling No Pain", Effect Duration: 22, Last Available: "2013-09"
 6771	blurry narrow flame-wreathed sharpshooter's padded tin foil	0		Damage Absorption: +20, Critical Hit Percent: +10, Hot Spell Damage: +10, Last Available: "2013-09"
 6772	nasty experienced tin drum of the overflowing toilet	0		Experience: +2, Stench Damage: +5, Stench Spell Damage: +50, Last Available: "2013-09"
@@ -6666,7 +6666,7 @@
 6774	tin snips	0		Last Available: "2013-09"
 6775	bouncing tin lizzie	0		Last Available: "2013-09"
 6776	anodized frozen foetid seal tear	0		Effect: "Poker Faced", Effect Duration: 37
-6777	denatured ghostly twirling seal sweat	0		Effect: "Eau de Tortue", Effect Duration: 65
+6777	denatured twirling ghostly seal sweat	0		Effect: "Eau de Tortue", Effect Duration: 65
 6778	frozen boiling seal blood	0		Effect: "Serendipi Tea", Effect Duration: 55
 6779	crystalline seal eye	0		Single Equip
 6780	blinking razor-sharp studded sealhide shield of the businessman	0		Weapon Damage Percent: +25, Meat Drop: +50, Damage Reduction: 7
@@ -6689,10 +6689,10 @@
 6800	dry upside-down disco horoscope (Cancer)	0		Effect: "Puzzle Fury", Effect Duration: 69
 6801	super-polarized disco horoscope (Leo)	0		Effect: "Leo Rising", Effect Duration: 33
 6802	ionized twirling disco horoscope (Virgo)	0		Effect: "Sourpuss", Effect Duration: 51
-6803	double-wet wobbly upside-down disco horoscope (Libra)	0		Effect: "Jingle Jangle Jingle", Effect Duration: 68
+6803	double-wet upside-down wobbly disco horoscope (Libra)	0		Effect: "Jingle Jangle Jingle", Effect Duration: 68
 6804	energized nitrogenated disco horoscope (Scorpio)	0		Effect: "Good Motivator", Effect Duration: 26
 6805	chilled jittery disco horoscope (Sagittarius)	0		Effect: "Frog In Your Throat", Effect Duration: 22
-6806	diffused squat huge disco horoscope (Capricorn)	0		Effect: "Extra-Sharp Weapon", Effect Duration: 22
+6806	diffused huge squat disco horoscope (Capricorn)	0		Effect: "Extra-Sharp Weapon", Effect Duration: 22
 6807	skewed fortified The Sagittarian's leisure pants of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Familiar Effect: "atk, cap 18"
 6808	toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
@@ -6717,12 +6717,12 @@
 6828	smooth discocktail	4	awesome	
 6829	stylish KoL Con X Bingo Card	0		Moxie: +25
 6830	Temporal Tempera Tube of the empath	0		Familiar Weight: +5
-6831	deionized unsweetened electrified twirling yellow Tallowcreme Halloween Pumpkin	0		Effect: "Warm Shoulders", Effect Duration: 42
+6831	deionized unsweetened electrified yellow twirling Tallowcreme Halloween Pumpkin	0		Effect: "Warm Shoulders", Effect Duration: 42
 6832	Way More Tears&trade; pepper spray	0		
 6833	double-chilled jittery Milk Studs	0		Effect: "Can't Smell Nothin'", Effect Duration: 64
-6834	adjusted fuchsia bouncing box of Dweebs	0		Effect: "Become Intensely interested", Effect Duration: 66
+6834	adjusted bouncing fuchsia box of Dweebs	0		Effect: "Become Intensely interested", Effect Duration: 66
 6835	deionized nitrogenated bag of W&Ws	0		Effect: "Salty Mouth", Effect Duration: 46
-6836	electrified triple-flattened huge cyan narrow PEEZ dispenser	0		Effect: "A Few Extra Pounds", Effect Duration: 57
+6836	electrified triple-flattened cyan huge narrow PEEZ dispenser	0		Effect: "A Few Extra Pounds", Effect Duration: 57
 6837	non-modified pressed boiled Swizzler	0		Effect: "Joy", Effect Duration: 20
 6838	activated Bugbearclaw Donut	0		Effect: "Sticky Hands", Effect Duration: 37
 6839	warmed energized jam	0		Effect: "Familial Ties", Effect Duration: 40
@@ -6741,19 +6741,19 @@
 6852	Ultra Mega Sour Ball	0		
 6853	pulsating carton of rotten eggs	0		
 6854	upside-down desert sightseeing pamphlet	0		
-6855	yellow narrow a suspicious address	0		
+6855	narrow yellow a suspicious address	0		
 6856	Bal-musette accordion of the ox	0		Muscle: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	hale Cajun accordion	0		Maximum HP: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	medical-grade quirky accordion	0		HP Regen Min: 7, HP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	fireproof Skipper's accordion	0		Hot Resistance: +3, Item Drop: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	blurry stanky manspreader's Pantsgiving of the empath of the glutton	0		Monster Level: +10, Familiar Weight: +5, Stench Spell Damage: +25, Food Drop: +100, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	rotten diet can of sardines	1	crappy	Last Available: "2013-11"
+6860	blurry stanky manspreader's Pantsgiving of the empath of the glutton	0		Monster Level: +10, Familiar Weight: +5, Stench Spell Damage: +25, Food Drop: +100, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	diet rotten can of sardines	1	crappy	Last Available: "2013-11"
 6862	spoiled high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
 6863	tasty pat of butter	3	awesome	Last Available: "2013-11"
 6864	spoiled dinner roll	4	crappy	Last Available: "2013-11"
 6865	rotten snack-sized mashed potatoes	2	crappy	Last Available: "2013-11"
 6866	rotten purple whole turkey leg	4	crappy	Last Available: "2013-11"
-6867	flavorless super-sized enchanted deviled egg	5	decent	Effect: "Egg-headedness", Effect Duration: 20, Last Available: "2013-11"
+6867	enchanted flavorless super-sized deviled egg	5	decent	Effect: "Egg-headedness", Effect Duration: 20, Last Available: "2013-11"
 6868	cold-filtered finger exerciser	0		Effect: "Staying Frosty", Effect Duration: 44, Last Available: "2013-11"
 6869	cold-filtered wet ghostly dented spoon	0		Effect: "Permafrosty", Effect Duration: 51, Last Available: "2013-11"
 6870	ionized love note	0		Effect: "Tiki Temerity", Effect Duration: 56, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	galvanized pressed nuts	0		Effect: "Ticking Clock", Effect Duration: 60, Last Available: "2013-12"
 6904	wet liquefied bolts	0		Effect: "Punch Another Day", Effect Duration: 64, Last Available: "2013-12"
 6905	adequate mirror gingerbread robot	3	good	Last Available: "2013-12"
-6906	immense bland petit 4.1	6	decent	Last Available: "2013-12"
+6906	bland immense petit 4.1	6	decent	Last Available: "2013-12"
 6907	toothsome upside-down nut-shaped Crimbo cookie	3	awesome	Last Available: "2023-06"
 6908	twirling greedy plastic GORM-8	0		Meat Drop: +20, Last Available: "2013-12"
 6909	padded plastic warbear	0		Damage Absorption: +20, Last Available: "2013-12"
@@ -6804,35 +6804,35 @@
 6915	stiffened cool warbear hoverbelt of Tarzan	0		Moxie: +5, Experience (Muscle): +3, Damage Reduction: 1, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
 6917	cyan huge warbear badge	0		Last Available: "2013-12"
-6918	oxidized blue twirling warbear wardance potion	0		Effect: "A Few Extra Pounds", Effect Duration: 12, Last Available: "2013-12"
+6918	oxidized twirling blue warbear wardance potion	0		Effect: "A Few Extra Pounds", Effect Duration: 12, Last Available: "2013-12"
 6919	unsweetened deionized concentrated shaking warbear bearserker potion	0		Effect: "Sewer-Drenched", Effect Duration: 65, Last Available: "2013-12"
 6920	activated pulsating gray warbear liquid overcoat	0		Effect: "Memory of Smarts", Effect Duration: 19, Last Available: "2013-12"
-6921	spoiled snack-sized warbear feasting bread	2	crappy	Last Available: "2013-12"
+6921	snack-sized spoiled warbear feasting bread	2	crappy	Last Available: "2013-12"
 6922	decent tumbling warbear warrior bread	3	good	Last Available: "2013-12"
 6923	low-calorie adequate warbear thermoregulator bread	1	good	Last Available: "2013-12"
 6924	bad warbear feasting mead	3	decent	Last Available: "2013-12"
 6925	weak hand-crafted mirror warbear bearserker mead	2	super EPIC	Last Available: "2013-12"
 6926	bad warbear blizzard mead	3	decent	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	coward's chaotic medical-grade warbear plain fedora	0		Spell Critical Percent: +10, Monster Level: -20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	Herculean warbear feathered fedora	0		Experience (Muscle): +1, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	blurry gray smelly resourceful clever warbear fedora	0		Maximum MP: 70, Stench Spell Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	jittery scorching medical-grade warbear plain helm of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	hardy warbear spiked helm	0		Maximum HP: +50, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	blurry reassuring flame-wreathed Samson's warbear electro-spiked helm	0		Experience (Muscle): +5, Hot Spell Damage: +10, Spooky Resistance: +1, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	pulsating studded cool warbear plain ushanka of extreme caution	0		Moxie: +5, Damage Absorption: +80, Monster Level: -25, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	auspicious warbear lined ushanka	0		Item Drop: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	blue foul-smelling chaotic Annie Oakley's warbear heated ushanka	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Stench Damage: +10, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	coward's chaotic medical-grade warbear plain fedora	0		Spell Critical Percent: +10, Monster Level: -20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	Herculean warbear feathered fedora	0		Experience (Muscle): +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	blurry gray smelly resourceful clever warbear fedora	0		Maximum MP: 70, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	jittery scorching medical-grade warbear plain helm of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	hardy warbear spiked helm	0		Maximum HP: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	blurry reassuring flame-wreathed Samson's warbear electro-spiked helm	0		Experience (Muscle): +5, Hot Spell Damage: +10, Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	pulsating studded cool warbear plain ushanka of extreme caution	0		Moxie: +5, Damage Absorption: +80, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	auspicious warbear lined ushanka	0		Item Drop: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	blue foul-smelling chaotic Annie Oakley's warbear heated ushanka	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	blue warbear trouser fragment	0		Last Available: "2013-12"
-6938	nasty vibrating sinister warbear party pants	0		Spell Damage: +10, Maximum MP Percent: +10, Stench Damage: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	warbear ceremonial party pants of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	skewed frosty MacGyver's warbear high festival pants of Flo-Jo	0		Maximum MP: +100, Cold Spell Damage: +10, Initiative: +100, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	ghostly Jim Carey's deadly warbear battle greaves of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40, Monster Level: +25, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	upside-down olive smelly warbear officer greaves	0		Stench Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	executive nasty warbear bearserker greaves of temperance	0		Stench Damage: +5, Sleaze Resistance: +5, Meat Drop: +40, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	spinning groovy warbear johns of Gandalf of Leguizamo	0		Moxie Percent: +10, Spell Critical Percent: +20, Monster Level: +20, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	warbear fleece-lined johns	0		Item Drop: +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	double-paned knitted padded warbear johns	0		Damage Absorption: +20, Cold Resistance: 8, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	nasty vibrating sinister warbear party pants	0		Spell Damage: +10, Maximum MP Percent: +10, Stench Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	warbear ceremonial party pants of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	skewed frosty MacGyver's warbear high festival pants of Flo-Jo	0		Maximum MP: +100, Cold Spell Damage: +10, Initiative: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	ghostly Jim Carey's deadly warbear battle greaves of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40, Monster Level: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	upside-down olive smelly warbear officer greaves	0		Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	executive nasty warbear bearserker greaves of temperance	0		Stench Damage: +5, Sleaze Resistance: +5, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	spinning groovy warbear johns of Gandalf of Leguizamo	0		Moxie Percent: +10, Spell Critical Percent: +20, Monster Level: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	warbear fleece-lined johns	0		Item Drop: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	double-paned knitted padded warbear johns	0		Damage Absorption: +20, Cold Resistance: 8, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	red warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	bouncing curative shellacked beefcake's warbear goggles	0		Muscle: +25, Damage Reduction: 7, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-12"
 6949	Lo Pan's warbear snowblindness goggles	0		Spell Critical Percent: +30, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	ribald educational warbear warscarf of the storm	0		Experience: +1, Maximum MP Percent: +40, Sleaze Damage: +10, Single Equip, Last Available: "2013-12"
 6957	teal warbear requisition box	0		Last Available: "2013-12"
 6958	ghostly warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	twirling careful warbear foil hat	0		Monster Level: -10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	twirling careful warbear foil hat	0		Monster Level: -10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	warbear oil pan of extreme caution of terror	0		Monster Level: -25, Spooky Spell Damage: +10, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	warbear oil pan of extreme caution of terror	0		Monster Level: -25, Spooky Spell Damage: +10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	tumbling cool warbear exhaust manifold	0		Moxie: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,7 +6889,7 @@
 7000	gravedigger's Rosewater's die-cast Don Crimbo	0		Mysticality Percent: +30, Spooky Damage: +10, Last Available: "2013-12"
 7001	electrified medical-grade die-cast Uncle Hobo	0		MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12"
 7002	smelly die-cast Father Crimbo of the cheetah	0		Stench Spell Damage: +10, Initiative: +60, Last Available: "2013-12"
-7003	tumbling narrow fuchsia The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	fuchsia narrow tumbling The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	polarized Flaskfull of Hollow	0		Effect: "Yet tea", Effect Duration: 28, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	compressed handful of Smithereens	1	EPIC	Effect: "Chauve-Souris Merde Fou", Effect Duration: 25, Last Available: "2013-12"
@@ -6897,7 +6897,7 @@
 7008	flavorless big squat Miserable Pie	5	decent	Last Available: "2013-12"
 7009	spoiled snack-sized This Charming Flan	2	crappy	Last Available: "2013-12"
 7010	tolerable Irish Coffee, English Heart	3	good	Last Available: "2013-12"
-7011	fancy watered-down lousy blinking Strikes Again Bigmouth	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 30, Last Available: "2013-12"
+7011	watered-down lousy fancy blinking Strikes Again Bigmouth	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 30, Last Available: "2013-12"
 7012	perfectly mixed practically non-alcoholic blurry Paint A Vulgar Pitcher	1	super ultra mega turbo EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	jittery prompt censurious rock-hard Sheila Take a Crossbow of the brute	0		Muscle Percent: +30, Damage Reduction: 5, Sleaze Resistance: +3, Adventures: +3, Last Available: "2013-12"
 7019	rock-hard studded Socratic A Light that Never Goes Out of chilblains	0		Experience (Mysticality): +1, Damage Absorption: +80, Damage Reduction: 5, Cold Damage: +25, Last Available: "2013-12"
 7020	green bouncing greedy miser's banded Half a Purse of the sweet-tooth	0		Damage Absorption: +100, Meat Drop: 30, Candy Drop: +100, Last Available: "2013-12"
-7021	cyan inspector's toasty weightlifter's Hairpiece On Fire of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Hot Damage: +5, Item Drop: +15, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	shellacked banded occult Vicar's Tutu of the cougar	0		Moxie: +20, Spell Damage Percent: +25, Damage Absorption: +100, Damage Reduction: 7, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	cyan inspector's toasty weightlifter's Hairpiece On Fire of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Hot Damage: +5, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	shellacked banded occult Vicar's Tutu of the cougar	0		Moxie: +20, Spell Damage Percent: +25, Damage Absorption: +100, Damage Reduction: 7, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	Van der Graaf dance instructor's Hand in Glove of the empath	0		Experience Percent (Moxie): +10, Familiar Weight: +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-12"
 7024	careful sinister Meat Tenderizer is Murder of horror	0		Spell Damage: +10, Monster Level: -10, Spooky Spell Damage: +25, Class: "Seal Clubber", Last Available: "2013-12"
 7025	aromatic hardened beefcake's Ouija Board, Ouija Board	0		Muscle: +25, Damage Reduction: 10, Stench Resistance: +1, Class: "Turtle Tamer", Last Available: "2013-12"
@@ -6921,7 +6921,7 @@
 7032	yummy pickled egg	3	awesome	
 7033	blinking cup of lukewarm tea	1	crappy	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
-7035	teal pulsating warbear box	0		Last Available: "2013-12"
+7035	pulsating teal warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	narrow warbear gyrocopter	0		Last Available: "2013-12"
@@ -6936,14 +6936,14 @@
 7047	double-moist warbear liquid lasers	0		Effect: "Witch's Brood", Effect Duration: 48, Last Available: "2013-12"
 7048	activated warbear rejuvenation potion	0		Effect: "Halloweeny", Effect Duration: 11, Last Available: "2013-12"
 7049	ghostly broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	bite-sized special rotten bouncing warbear gyro	1	crappy	Effect: "Crocodile Tear", Effect Duration: 40, Last Available: "2013-12"
+7050	special bite-sized rotten bouncing warbear gyro	1	crappy	Effect: "Crocodile Tear", Effect Duration: 40, Last Available: "2013-12"
 7051	enhanced recording of Rolando's Rondo of Resisto	0		Effect: "Abominably Slippery", Effect Duration: 43, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	spinning upside-down warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
 7055	normal breakfast mess	4	good	Last Available: "2013-12"
 7056	squat warbear breakfast machine	0		Last Available: "2013-12"
-7057	tiny bland fancy blurry breakfast miracle	1	decent	Effect: "Baconstoned", Effect Duration: 20, Last Available: "2013-12"
+7057	bland fancy tiny blurry breakfast miracle	1	decent	Effect: "Baconstoned", Effect Duration: 20, Last Available: "2013-12"
 7058	electrified Cloaca Cola Polar	0		Effect: "Gyromitra Gymnastics", Effect Duration: 46, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	tumbling festive warbear bank	0		Last Available: "2013-12"
@@ -6957,7 +6957,7 @@
 7068	vacuum-sealed triple-unsweetened tarnished maroon single of Donho's Bubbly Ballad	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 23
 7069	cyan wobbly Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	wobbly packet of winter seeds	0		Last Available: "2014-01"
-7071	moldy big snow berries	5	crappy	Last Available: "2014-01"
+7071	big moldy snow berries	5	crappy	Last Available: "2014-01"
 7072	adequate gigantic ice harvest	8	good	Last Available: "2014-01"
 7073	chilled nitrogenated gray frost flower	0		Effect: "Yuletide Industry", Effect Duration: 46, Last Available: "2014-01"
 7074	double-polarized snow cleats	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 30, Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	pulsating ice house	0		Last Available: "2014-01"
 7082	spinning snow machine	0		Last Available: "2014-01"
-7083	twirling snow mobile of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	twirling snow mobile of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	huge healthy ice bucket	0		Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2014-01"
 7085	twirling cool thinker's snow shovel	0		Mysticality: +10, Moxie: +5, Lasts Until Rollover, Last Available: "2014-01"
 7086	twirling Tesla bod-ice of horror of the detective	0		Spooky Spell Damage: +25, Item Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	tumbling snow fort	0		Last Available: "2014-01"
 7090	artisanal En Una Fila Tequila	4	EPIC	
 7091	Skully's hot chocolate	1	decent	
-7092	olive Sherlock's warbear dress helmet of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	olive Sherlock's warbear dress helmet of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	smartaleck's warbear dress bracers of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Single Equip, Last Available: "2013-12"
-7094	blurry frightening crafty warbear dress greaves	0		Maximum MP: +10, Spooky Damage: +5, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	flame-wreathed Samson's sweatband	0		Experience (Muscle): +5, Hot Spell Damage: +10, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	twirling forbidden stylish gym shorts	0		Moxie: +25, Spell Damage Percent: +50, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	blurry frightening crafty warbear dress greaves	0		Maximum MP: +10, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	flame-wreathed Samson's sweatband	0		Experience (Muscle): +5, Hot Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	twirling forbidden stylish gym shorts	0		Moxie: +25, Spell Damage Percent: +50, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	wobbly smelly baleful ankleweights	0		Spell Damage: +25, Stench Spell Damage: +10, Single Equip, Last Available: "2014-12"
 7098	perfumed dog trainer's occult sweat socks of Flo-Jo	0		Spell Damage Percent: +25, Experience (familiar): +1, Stench Resistance: +5, Initiative: +100, Last Available: "2014-12"
 7099	blurry pint of sweat	0		Last Available: "2014-12"
@@ -7000,28 +7000,28 @@
 7111	bland diet candy mountain oyster	1	decent	Last Available: "2014-12"
 7112	irresponsibly strong bad huge chocotini	6	decent	Last Available: "2014-12"
 7113	miser's Samson's chocolate rabbit's foot of horror	0		Experience (Muscle): +5, Spooky Spell Damage: +25, Meat Drop: +10, Last Available: "2014-12"
-7114	spoiled enchanted green ghostly candy carrot	3	crappy	Effect: "Devil Inside", Effect Duration: 25, Last Available: "2014-12"
+7114	enchanted spoiled green ghostly candy carrot	3	crappy	Effect: "Devil Inside", Effect Duration: 25, Last Available: "2014-12"
 7115	toothsome candy carrot cake	4	awesome	Last Available: "2014-12"
 7116	perfumed educational carrot-on-a-stick	0		Experience: +1, Stench Resistance: +5, Last Available: "2014-12"
-7117	scorching weasel stomping pants of the detective	0		Hot Damage: +25, Item Drop: +20, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	scorching weasel stomping pants of the detective	0		Hot Damage: +25, Item Drop: +20, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	delicious mulberry	3	awesome	Last Available: "2014-12"
 7119	perfectly mixed narrow mulled berry wine	4	EPIC	Last Available: "2014-12"
 7120	huge skewed lemony scales	0		Last Available: "2014-12"
-7121	teal Rosewater's lemon party hat	0		Mysticality Percent: +30, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	teal Rosewater's lemon party hat	0		Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	censurious lemon shirt	0		Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	lemon drop trousers of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	altered quadruple-diffused skewed lemonhead caviar	0		Effect: "Wistfully Nostalgic", Effect Duration: 11, Last Available: "2014-12"
 7125	Herculean Rosewater's gummi sword	0		Mysticality Percent: +30, Experience (Muscle): +1, Last Available: "2014-12"
 7126	electrified small gummi fin	0		Effect: "Stop the Presses!", Effect Duration: 31, Last Available: "2014-12"
 7127	blurry resourceful chocolate cow bone	0		Maximum MP: +50, Last Available: "2014-12"
 7128	double-galvanized narrow gummi fang	0		Effect: "The Power of LOV", Effect Duration: 44, Last Available: "2014-12"
 7129	half-sized spoiled skewed leftover canap&eacute;s	2	crappy	Last Available: "2014-12"
-7130	weak hand-crafted huge magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
+7130	hand-crafted weak huge magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
 7131	greasy dangerous Samson's cow creamer	0		Experience (Muscle): +5, Weapon Damage: +10, Sleaze Spell Damage: +10, Last Available: "2014-12"
 7132	warmed moist Outer Wolf&trade; cologne	0		Effect: "Busy Bein' Delicious", Effect Duration: 16, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	thinker's wolf whistle of the storm	0		Mysticality: +10, Maximum MP Percent: +40, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	bite-sized fancy rotten gray witch's bread	1	crappy	Effect: "Serendipi Tea", Effect Duration: 10, Last Available: "2014-12"
+7134	thinker's wolf whistle of the storm	0		Mysticality: +10, Maximum MP Percent: +40, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	bite-sized rotten fancy gray witch's bread	1	crappy	Effect: "Serendipi Tea", Effect Duration: 10, Last Available: "2014-12"
 7136	unsweetened chilled witch's brew	0		Effect: "Fever From the Flavor", Effect Duration: 24, Last Available: "2014-12"
 7137	steel-toed stiffened supercool witch's bra	0		Moxie Percent: +20, Damage Reduction: 20, Last Available: "2014-12"
 7138	hand-crafted mid-level medieval mead	4	EPIC	Last Available: "2014-12"
@@ -7043,14 +7043,14 @@
 7154	pulsating filling	0		Last Available: "2014-12"
 7155	jittery parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	shellacked fire hose of Calamity Jane of Gandalf	0		Damage Reduction: 7, Critical Hit Percent: +15, Spell Critical Percent: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	shellacked fire hose of Calamity Jane of Gandalf	0		Damage Reduction: 7, Critical Hit Percent: +15, Spell Critical Percent: +20, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	rotten fireman's lunch	4	crappy	Last Available: "2014-12"
-7159	spinning zippy wicked plain paper hat of the glutton	0		Spell Damage: +5, Food Drop: +100, Initiative: +20, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	spinning zippy wicked plain paper hat of the glutton	0		Spell Damage: +5, Food Drop: +100, Initiative: +20, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	spoiled blinking ice cream sandwich	4	crappy	Last Available: "2014-12"
 7161	bouncing lion tamer's &quot;honey&quot; dipper of Calamity Jane of horror	0		Critical Hit Percent: +15, Experience (familiar): +2, Spooky Spell Damage: +25, Last Available: "2014-12"
 7162	stale plumber's lunch	3	decent	Last Available: "2014-12"
 7163	knitted clever padded skull gearshift knob	0		Damage Absorption: +20, Maximum MP: +20, Cold Resistance: +3, Last Available: "2014-12"
-7164	special yummy ghostly maroon nachos of the night	3	awesome	Effect: "Puddingface", Effect Duration: 15, Last Available: "2014-12"
+7164	special yummy maroon ghostly nachos of the night	3	awesome	Effect: "Puddingface", Effect Duration: 15, Last Available: "2014-12"
 7165	toasty coward's Sketcherz&trade; of the bloodbag	0		Maximum HP: +100, Monster Level: -20, Hot Damage: +5, Last Available: "2014-12"
 7166	flavorless can of Adultwitch&trade;	4	decent	Last Available: "2014-12"
 7167	alkaline dry spinning smudge stick	0		Effect: "Cosmic Flavor", Effect Duration: 30, Last Available: "2014-12"
@@ -7058,7 +7058,7 @@
 7169	irresponsibly strong drinkable jittery tankard of ale	7	good	Last Available: "2014-12"
 7170	liquefied polymerized galvanized scroll case	0		Effect: "Cranberry Cordiality", Effect Duration: 66, Last Available: "2014-12"
 7171	boiled energized spinning jug of &quot;wine&quot;	0		Effect: "Spiky Hair", Effect Duration: 64, Last Available: "2014-12"
-7172	lime green bouncing juggling ball	0		Last Available: "2014-12"
+7172	bouncing lime green juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
 7174	bland humble pie	4	decent	Last Available: "2014-12"
 7175	olive small golem	0		Last Available: "2014-12"
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	lime green healthy Buddy Bjorn	0		Maximum HP Percent: +20, Softcore Only, Last Available: "2014-02"
 7201	squat foul-smelling frosty The Nuge's favorite crossbow of the glutton	0		Cold Spell Damage: +10, Stench Damage: +10, Food Drop: +100
-7202	low-calorie moldy sweet roll Alabama	1	crappy	
+7202	moldy low-calorie sweet roll Alabama	1	crappy	
 7203	smartaleck's Saturday Night Special	0		Moxie Percent: +30
 7204	blinking lynyrd snare	0		
 7205	energetic fleetwood chain	0		Maximum MP Percent: +20
@@ -7108,15 +7108,15 @@
 7219	upside-down flame-retardant lynyrdskin breeches	0		Hot Resistance: +1, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	hand-crafted watered-down Flamin' Whatshisname	2	EPIC	
+7222	watered-down hand-crafted Flamin' Whatshisname	2	EPIC	
 7223	flattened concentrated moist blue lynyrd musk	0		Effect: "Fudgehound", Effect Duration: 19
 7224	jittery foul-smelling Kashmir sweater of the cougar	0		Moxie: +20, Stench Damage: +10
-7225	yummy enchanted narrow custard pie	4	awesome	Effect: "Witch's Brood", Effect Duration: 15
+7225	enchanted yummy narrow custard pie	4	awesome	Effect: "Witch's Brood", Effect Duration: 15
 7226	olive tea for one	1	good	
 7227	perfectly mixed bottle of Evermore	3	EPIC	
 7228	box	0		
-7229	artisanal practically non-alcoholic wine	1	EPIC	
-7230	practically non-alcoholic special artisanal rum	1	EPIC	Effect: "Seriously Mutated", Effect Duration: 35
+7229	practically non-alcoholic artisanal wine	1	EPIC	
+7230	artisanal special practically non-alcoholic rum	1	EPIC	Effect: "Seriously Mutated", Effect Duration: 35
 7231	bad upside-down Murderer's Punch	4	decent	
 7232	decent velvet cake	4	good	
 7233	non-dry corrupted wobbly tumbling letter	0		Effect: "Flame-Retardant Trousers", Effect Duration: 55
@@ -7132,7 +7132,7 @@
 7243	spinning button	0		
 7244	flattened boiled ghostly blood cells	0		Effect: "Strawberry Alarm", Effect Duration: 43
 7245	ionized energized eye	0		Effect: "Celestial Vision", Effect Duration: 29
-7246	blurry ghostly glark cable	0		
+7246	ghostly blurry glark cable	0		
 7247	rosy-cheeked Newton's Red Fox glove	0		Experience (Mysticality): +3, Maximum HP Percent: +30, Attacks Can't Miss, Single Equip
 7248	modified frozen foxglove	0		Effect: "Less Pervious", Effect Duration: 56
 7249	Thwaitgold dragonfly statuette	0		
@@ -7150,7 +7150,7 @@
 7261	mirror double-paned nippy Sneaky Pete's basket of mayonnaise	0		Cold Damage: +10, Sleaze Spell Damage: +50, Cold Resistance: +5
 7262	huge &quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
-7264	spinning pulsating olive photograph of a nugget	0		
+7264	pulsating olive spinning photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
 7266	tumbling disposable instant camera	0		
 7267	asbestos-lined MacGyver's curative Sneaky Pete's jacket (collar popped) of the cheetah	0		Maximum MP: +100, Hot Resistance: +5, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7176,15 +7176,15 @@
 7287	up-at-dawn supercharged Gary Claybender's Time Screwer	0		Maximum MP Percent: +30, Adventures: +5, Single Equip, Lasts Until Rollover
 7288	quilted Space Tourist palmdoctor of the bloodbag	0		Damage Absorption: +40, Maximum HP: +100, Lasts Until Rollover
 7289	veiny amok putter of the brazier of courage	0		Maximum HP: +10, Hot Spell Damage: +25, Spooky Resistance: +3
-7290	decent special amok pudding	4	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50
+7290	special decent amok pudding	4	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50
 7291	mirror deactivated putty buddy	0		
 7292	wobbly skewed putty coat	0		Familiar Weight: +5
-7293	liquefied double-Vulcanized skewed red can of V-11	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2014-03"
+7293	liquefied double-Vulcanized red skewed can of V-11	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2014-03"
 7294	lime green blinking hardened elevennis shoes of the bloodbag	0		Damage Reduction: 3, Maximum HP: +100, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
 7296	miser's veiny elevenderizing hammer	0		Maximum HP: +10, Meat Drop: +10, Last Available: "2014-03"
 7297	squat pulsating chilly Professor What T-Shirt	0		Cold Damage: +5
-7298	olive narrow heavy-duty bendy straw	0		
+7298	narrow olive heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
 7300	sewing kit	0		
 7301	Spookyraven billiards room key	0		
@@ -7194,7 +7194,7 @@
 7305	upside-down Lady Spookyraven's powder puff	0		
 7306	lime green Lady Spookyraven's finest gown	0		
 7307	bouncing Lady Spookyraven's dancing shoes	0		
-7308	ionized double-ionized wobbly jittery eyebrow pencil	0		Effect: "Yuletide Mutations", Effect Duration: 32
+7308	ionized double-ionized jittery wobbly eyebrow pencil	0		Effect: "Yuletide Mutations", Effect Duration: 32
 7309	pickled oxidized rosewater cream	0		Effect: "Wet Rub", Effect Duration: 21
 7310	alkaline denatured polymerized bronzer	0		Effect: "Helvella Health", Effect Duration: 56
 7311	squat wicked cool elegant nightstick	0		Moxie: +5, Spell Damage: +5
@@ -7210,13 +7210,13 @@
 7321	horrifying wholesome Stephen's lab coat	0		Maximum HP Percent: +10, Spooky Damage: +25
 7322	quadruple-vacuum-sealed tumbling Stephen's secret formula	0		Effect: "Superhuman Sarcasm", Effect Duration: 32
 7323	teal twirling skewed experienced weightlifter's Jacob's rung	0		Muscle: +15, Experience: +2
-7324	boiled twirling yellow battery	1		Effect: "Pemmican't", Effect Duration: 25
+7324	boiled yellow twirling battery	1		Effect: "Pemmican't", Effect Duration: 25
 7325	smooth snakebite	3	awesome	
 7326	mirror energetic rubber ribcage of the cheetah	0		Maximum MP Percent: +20, Initiative: +60, Damage Reduction: 7
 7327	altered squat lime green synthetic marrow	1		Effect: "Weapon of Mass Destruction", Effect Duration: 45
 7328	denatured altered upside-down funny bone	0		Effect: "Protection from Bad Stuff", Effect Duration: 67
 7329	tumbling bouncing sinister arcane researcher's half-melted spoon	0		Experience Percent (Mysticality): +10, Spell Damage: +10
-7330	altered mirror shaking upside-down the funk	1		
+7330	altered shaking upside-down mirror the funk	1		
 7331	flavorless small gunky chicken	2	decent	
 7332	twirling fireproof doll head	0		Hot Resistance: +3
 7333	cyan droopy doll eye	0		
@@ -7228,8 +7228,8 @@
 7339	music box mechanism	0		
 7340	twirling moose antlers of chilblains	0		Cold Damage: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	polymerized polymerized dry upside-down moose thought	0		Effect: "Heavily Breathing", Effect Duration: 43
-7342	tiny flavorless shaking blue moose chocolate	1	decent	
-7343	bad spinning mirror painting of a glass of wine	3	decent	
+7342	tiny flavorless blue shaking moose chocolate	1	decent	
+7343	bad mirror spinning painting of a glass of wine	3	decent	
 7344	blinking oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7256,9 +7256,9 @@
 7367	enhanced spinning industrial strength starch	0		Effect: "Turkey-Ambitious", Effect Duration: 54, Wiki Name: "industrial strength starch"
 7368	toothsome extra-flat panini	3	awesome	
 7369	altered mangled finger	0		Effect: "Well-Lubed", Effect Duration: 37
-7370	enchanted acceptable watered-down Psychotic Train wine	2	good	Effect: "Super Speed", Effect Duration: 20
+7370	watered-down enchanted acceptable Psychotic Train wine	2	good	Effect: "Super Speed", Effect Duration: 20
 7371	crazy hobo notebook	0		
-7372	half-sized moldy pie man was not meant to eat	2	crappy	
+7372	moldy half-sized pie man was not meant to eat	2	crappy	
 7373	scorching sommelier's towel	0		Hot Damage: +25
 7374	therapeutic tarnished tastevin	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
 7375	tiny flavorless actual tapas	1	decent	
@@ -7276,7 +7276,7 @@
 7387	tarnished liquefied cyan jittery Gene Tonic: Undead	0		Effect: "A Taste of Rainbow", Effect Duration: 50, Last Available: "2014-04"
 7388	super-pickled tarnished squat purple Gene Tonic: Humanoid	0		Effect: "Permanent Halloween", Effect Duration: 25, Last Available: "2014-04"
 7389	quadruple-wet galvanized Gene Tonic: Insect	0		Effect: "Infernal Thirst", Effect Duration: 49, Last Available: "2014-04"
-7390	flattened enhanced ghostly skewed skewed Gene Tonic: Hippy	0		Effect: "Mayeaugh", Effect Duration: 36, Last Available: "2014-04"
+7390	flattened enhanced skewed skewed ghostly Gene Tonic: Hippy	0		Effect: "Mayeaugh", Effect Duration: 36, Last Available: "2014-04"
 7391	enhanced Gene Tonic: Orc	0		Effect: "Scorpio Rising", Effect Duration: 24, Last Available: "2014-04"
 7392	nitrogenated flattened Gene Tonic: Demon	0		Effect: "Feeling No Pain", Effect Duration: 61, Last Available: "2014-04"
 7393	diffused purple Gene Tonic: Horror	0		Effect: "Creepypasted", Effect Duration: 36, Last Available: "2014-04"
@@ -7291,7 +7291,7 @@
 7402	boiled triple-cold-filtered energized shaking Gene Tonic: Penguin	0		Effect: "Fit To Be Tide", Effect Duration: 63, Last Available: "2014-04"
 7403	ionized quadruple-magnetized Gene Tonic: Elemental	0		Effect: "Incredibly Hulking", Effect Duration: 45, Last Available: "2014-04"
 7404	electrified Gene Tonic: Constellation	0		Effect: "Mana Tea", Effect Duration: 24, Last Available: "2014-04"
-7405	modified ionized lime green spinning Gene Tonic: Hobo	0		Effect: "critical.enh", Effect Duration: 57, Last Available: "2014-04"
+7405	modified ionized spinning lime green Gene Tonic: Hobo	0		Effect: "critical.enh", Effect Duration: 57, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
 7408	Steam Card: Dungeon Fist (#3)	0		
@@ -7324,7 +7324,7 @@
 7435	enhanced boiled Stemonitis Staticus mushroom	0		Effect: "Alchemical, Brother", Effect Duration: 39, Last Available: "2014-05"
 7436	quantum flattened cyan Tremella Tarantella mushroom	0		Effect: "Papowerful", Effect Duration: 47, Last Available: "2014-05"
 7437	upside-down Pastaco shell	0		Last Available: "2014-05"
-7438	jumbo moldy squat bouncing Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
+7438	moldy jumbo squat bouncing Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
 7439	flavorless immense Brain Food Pastaco	6	decent	Last Available: "2014-05"
 7440	normal huge Cool Brunch Pastaco	9	good	Last Available: "2014-05"
 7441	enchanted decent Medical Pastaco	4	good	Effect: "Chilblains of the Corn", Effect Duration: 40, Last Available: "2014-05"
@@ -7333,8 +7333,8 @@
 7444	lousy twirling overpowering mushroom wine	3	decent	Last Available: "2014-05"
 7445	tolerable complex mushroom wine	4	good	Last Available: "2014-05"
 7446	drinkable jittery smooth mushroom wine	4	good	Last Available: "2014-05"
-7447	practically non-alcoholic drinkable blood-red mushroom wine	1	good	Last Available: "2014-05"
-7448	artisanal practically non-alcoholic buzzing mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7447	drinkable practically non-alcoholic blood-red mushroom wine	1	good	Last Available: "2014-05"
+7448	practically non-alcoholic artisanal buzzing mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7449	artisanal swirling mushroom wine	4	EPIC	Last Available: "2014-05"
 7450	stale Taco Dan's Basic Taco Dan Taco	3	decent	Last Available: "2014-05"
 7451	jumbo normal Taco Dan's Taco Fish Fish Taco	5	good	Last Available: "2014-05"
@@ -7348,28 +7348,28 @@
 7459	pulsating Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	shaking bouncing Brogre brorts of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	shaking bouncing Brogre brorts of the scaredy-cat	0		Monster Level: -15, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	greedy Brogre brolo shirt	0		Meat Drop: +20, Last Available: "2014-05"
-7464	asbestos-lined Brogre bucket hat	0		Hot Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	asbestos-lined Brogre bucket hat	0		Hot Resistance: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	maroon Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	blinking shaking airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	squat chilly ruddy personal trainer's 8-billed baseball cap	0		Experience Percent (Muscle): +10, Maximum HP Percent: +40, Cold Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	squat chilly ruddy personal trainer's 8-billed baseball cap	0		Experience Percent (Muscle): +10, Maximum HP Percent: +40, Cold Damage: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	tumbling upside-down Jeselnik's wholesome Socratic extremely wet T-shirt	0		Experience (Mysticality): +1, Maximum HP Percent: +10, Sleaze Damage: +25, Last Available: "2014-05"
 7470	Usain Bolt's shrimp fork of James Dean of the brazier	0		Experience (Moxie): +3, Hot Spell Damage: +25, Initiative: +80, Last Available: "2014-05"
 7471	altered ghostly BROS Energy Drink	0		Effect: "Berry Critical", Effect Duration: 19, Last Available: "2014-05"
 7472	wet blinking go-go potion	0		Effect: "Eyes All Black", Effect Duration: 21, Last Available: "2014-05"
 7473	dry huge shrimp cocktail	0		Effect: "Memory of Attractiveness", Effect Duration: 60, Last Available: "2014-05"
-7474	alkaline vacuum-sealed flattened maroon ghostly Yolo&trade; chocolates	0		Effect: "High Blood Chocolate Content", Effect Duration: 23, Last Available: "2020-09"
+7474	alkaline vacuum-sealed flattened ghostly maroon Yolo&trade; chocolates	0		Effect: "High Blood Chocolate Content", Effect Duration: 23, Last Available: "2020-09"
 7475	padded string of moist beads	0		Damage Absorption: +20, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	quantum teal Meat-inflating powder	0		Effect: "Dexteri Tea", Effect Duration: 29, Last Available: "2014-05"
 7478	twirling maroon possessed sugar cube	0		Last Available: "2014-05"
 7479	alkaline sugar fairy	0		Effect: "Big Punkin'", Effect Duration: 53, Last Available: "2014-05"
 7480	super-alkaline narrow sugar bunny	0		Effect: "Grrrrrrreat!", Effect Duration: 52, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	mediocre irresponsibly strong Rompedores de Fantasmas	7	decent	
-7483	weak artisanal blue La Fantasma y La Oscuridad	2	EPIC	
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	irresponsibly strong mediocre Rompedores de Fantasmas	7	decent	
+7483	artisanal weak blue La Fantasma y La Oscuridad	2	EPIC	
 7484	hand-crafted weak Fantasma en la M&aacute;quina	2	EPIC	
 7485	loosening powder	0		
 7486	castoreum	0		
@@ -7380,7 +7380,7 @@
 7491	bad mirror bottle of Chateau de Vinegar	4	decent	
 7492	blasting soda	0		
 7493	wobbly unstable fulminate	0		
-7494	pulsating yellow wine bomb	0		
+7494	yellow pulsating wine bomb	0		
 7495	mirror recipe: mortar-dissolving solution	0		
 7496	narrow bottled day	0		
 7497	ghost formula	0		
@@ -7407,7 +7407,7 @@
 7518	wand of pigification	0		
 7519	tolerable glass of bourbon	3	good	
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	rotten tumbling blurry government cheese	4	crappy	Last Available: "2014-05"
+7521	rotten blurry tumbling government cheese	4	crappy	Last Available: "2014-05"
 7522	toasty pair of government shades	0		Hot Damage: +5, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	dry twirling blue mirror government	0		Effect: "20-20 Second Sight", Effect Duration: 38, Last Available: "2014-05"
@@ -7421,17 +7421,17 @@
 7532	perfectly mixed rocket fuel	3	EPIC	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	practically non-alcoholic drinkable stealth bomber	1	good	Last Available: "2014-05"
+7535	drinkable practically non-alcoholic stealth bomber	1	good	Last Available: "2014-05"
 7536	spinning space beast fur	0		Last Available: "2014-05"
 7537	skewed twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	blurry veiny space beast fur hat	0		Maximum HP: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	huge sinister space beast fur pants	0		Spell Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	blurry veiny space beast fur hat	0		Maximum HP: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	huge sinister space beast fur pants	0		Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	mirror narrow flame-wreathed space beast fur whip	0		Hot Spell Damage: +10, Last Available: "2014-05"
 7542	maroon space invader	0		Last Available: "2014-05"
-7543	skewed friendly groovy space heater	0		Moxie Percent: +10, Familiar Weight: +3, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	skewed friendly groovy space heater	0		Moxie Percent: +10, Familiar Weight: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	pulsating space bar	0		Last Available: "2014-05"
-7545	watered-down lousy space port	2	decent	Last Available: "2014-05"
+7545	lousy watered-down space port	2	decent	Last Available: "2014-05"
 7546	blurry dog trainer's Sinatra's space needle	0		Experience (Moxie): +5, Experience (familiar): +1, Last Available: "2014-05"
 7547	cold-filtered skewed buffed alien drugs	0		Effect: "New Zeal", Effect Duration: 22, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7468,7 +7468,7 @@
 7579	huge twitching time capsule	0		
 7580	powdered gray liquid shifting time weirdness	1		
 7581	teal shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	low-calorie stale rack of dinosaur ribs	1	decent	
+7582	stale low-calorie rack of dinosaur ribs	1	decent	
 7583	lousy scotch on the rocks	3	decent	
 7584	teal sizzling yabba dabba doo rag of the sweet-tooth	0		Hot Damage: +10, Candy Drop: +100, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	spinning sharpshooter's wooly loincloth of the cheetah	0		Critical Hit Percent: +10, Initiative: +60, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7480,7 +7480,7 @@
 7591	smooth thermos of &quot;whiskey&quot;	4	awesome	Last Available: "2014-07"
 7592	smooth Lucky Lindy	3	awesome	Last Available: "2014-07"
 7593	hand-crafted Bee's Knees	4	EPIC	Last Available: "2014-07"
-7594	triple-distilled perfectly mixed maroon Sockdollager	9	EPIC	Last Available: "2014-07"
+7594	perfectly mixed triple-distilled maroon Sockdollager	9	EPIC	Last Available: "2014-07"
 7595	lousy twirling Ish Kabibble	4	decent	Last Available: "2014-07"
 7596	practically non-alcoholic perfectly mixed wobbly Hot Socks	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7597	artisanal fancy tumbling Phonus Balonus	4	EPIC	Effect: "Hiding in Plain Sight", Effect Duration: 40, Last Available: "2014-07"
@@ -7491,11 +7491,11 @@
 7602	enhanced Fitspiration&trade; poster	0		Effect: "Hardened Fabric", Effect Duration: 28
 7603	irradiated improved neckbeard	0		Effect: "Human-Horror Hybrid", Effect Duration: 45
 7604	magnetized frozen wobbly artisanal hand-squeezed wheatgrass juice	0		Effect: "Flower Power", Effect Duration: 33
-7605	super-quantum spinning narrow punk patch	0		Effect: "Hobonic", Effect Duration: 17
+7605	super-quantum narrow spinning punk patch	0		Effect: "Hobonic", Effect Duration: 17
 7606	boiled bouncing steampunk potion	0		Effect: "The Smile of Mr. A.", Effect Duration: 47
-7607	quantum unsweetened wobbly fuchsia vial of swamp vapors	0		Effect: "You Read The Manual", Effect Duration: 26
+7607	quantum unsweetened fuchsia wobbly vial of swamp vapors	0		Effect: "You Read The Manual", Effect Duration: 26
 7608	improved warmed blue turtle mud	0		Effect: "Three Days Slow", Effect Duration: 20
-7609	deionized spinning olive Redeye&trade; Eyedrops	0		Effect: "Sewer-Drenched", Effect Duration: 68
+7609	deionized olive spinning Redeye&trade; Eyedrops	0		Effect: "Sewer-Drenched", Effect Duration: 68
 7610	magnetized nitrogenated ionized huge Dweebisol&trade; inhaler	0		Effect: "Oxygenated Blood", Effect Duration: 17
 7611	aerosolized Lewd Lemmy Hair Oil	0		Effect: "Armored Innards", Effect Duration: 43
 7612	electrified alkaline frozen tomato soup poster	0		Effect: "Superioreo", Effect Duration: 33
@@ -7504,19 +7504,19 @@
 7615	vacuum-sealed pygmy adder oil	0		Effect: "Sealed Brain", Effect Duration: 21
 7616	deionized wet huge pygmy witchhazel	0		Effect: "Amplified Fabulousness", Effect Duration: 26
 7617	frozen electrified short deposition	0		Effect: "Bells in the Batfry", Effect Duration: 46
-7618	quantum non-Vulcanized blurry lime green squat straw pole	0		Effect: "Spore-Wreathed", Effect Duration: 15
+7618	quantum non-Vulcanized squat lime green blurry straw pole	0		Effect: "Spore-Wreathed", Effect Duration: 15
 7619	diffused squat copperhead potion	0		Effect: "The Moxious Madrigal", Effect Duration: 38
 7620	tarnished ionized shaking ghostly ninja fear powder	0		Effect: "Weather, Man", Effect Duration: 59
 7621	chilled concentrated blue ninja eyeblack	0		Effect: "Spell Transfer Complete", Effect Duration: 66
 7622	ionized magnetized button rouge	0		Effect: "Innately Wise", Effect Duration: 15
 7623	improved pickled Red Army camouflage kit	0		Effect: "Stinky Weapon", Effect Duration: 61
-7624	galvanized frozen wobbly mirror lynyrd skinner toothblack	0		Effect: "Sugary Tongue", Effect Duration: 54
+7624	galvanized frozen mirror wobbly lynyrd skinner toothblack	0		Effect: "Sugary Tongue", Effect Duration: 54
 7625	irradiated enhanced olive flask of rainwater	0		Effect: "Irresistible Resolve", Effect Duration: 26
 7626	modified pickled oyster badge	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 14
 7627	non-dry tumbling plastic Jefferson wings	0		Effect: "Bilious Briskness", Effect Duration: 51
 7628	liquefied improved upside-down dancing fan	0		Effect: "Bored Stiff", Effect Duration: 52
 7629	pickled squat teal page of the Necrohobocon	0		Effect: "Heart of Orange", Effect Duration: 44
-7630	activated unsweetened olive huge magic powder	0		Effect: "Chari Tea", Effect Duration: 66
+7630	activated unsweetened huge olive magic powder	0		Effect: "Chari Tea", Effect Duration: 66
 7631	irradiated unsweetened pulsating friar's tonsure	0		Effect: "Gummi Badass", Effect Duration: 14
 7632	quantum concentrated government-issue identification badge	0		Effect: "Tenacity of the Snapper", Effect Duration: 68
 7633	nitrogenated anodized oxidized squat alien hologram projector	0		Effect: "One For Tea", Effect Duration: 51
@@ -7540,9 +7540,9 @@
 7651	freshwater fishbone	0		
 7652	mirror fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
-7654	fuchsia blinking fishbone corset	0		
+7654	blinking fuchsia fishbone corset	0		
 7655	fishbone fins	0		Single Equip
-7656	wobbly twirling fishbone facemask	0		Monster Level: -30
+7656	twirling wobbly fishbone facemask	0		Monster Level: -30
 7657	red fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	red fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	narrow lion tamer's neoprene skullcap	0		Experience (familiar): +2, Familiar Effect: "atk, 1xFairy, cap 16"
@@ -7551,7 +7551,7 @@
 7662	stale huge Sogg-Os	8	decent	
 7663	blinking savvy weightlifter's Lord Soggyraven's Slippers of vim and vigor	0		Muscle: +15, Mysticality Percent: +20, Maximum HP Percent: +50, Single Equip
 7664	flattened triple-pickled boiled Ancient Protector Soda	0		Effect: "A Taste of Rainbow", Effect Duration: 33
-7665	galvanized tumbling spinning liquid ice	0		Effect: "Patience of the Tortoise", Effect Duration: 32
+7665	galvanized spinning tumbling liquid ice	0		Effect: "Patience of the Tortoise", Effect Duration: 32
 7666	practically non-alcoholic perfectly mixed Wet Russian	1	super ultra mega turbo EPIC	
 7667	stale bouncing filet of The Fish	3	decent	
 7668	Thwaitgold spider statuette	0		
@@ -7581,7 +7581,7 @@
 7692	lime green nippy Oprah's hand whip of the sweet-tooth	0		Maximum MP Percent: +50, Cold Damage: +10, Candy Drop: +100, Last Available: "2014-08"
 7693	ghostly ruddy Rosewater's glow-in-the-dark necklace of the early riser	0		Mysticality Percent: +30, Maximum HP Percent: +40, Adventures: +7, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	savvy cap gun of vim and vigor of Calamity Jane	0		Mysticality Percent: +20, Maximum HP Percent: +50, Critical Hit Percent: +15, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	savvy cap gun of vim and vigor of Calamity Jane	0		Mysticality Percent: +20, Maximum HP Percent: +50, Critical Hit Percent: +15, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	therapeutic shellacked cassette player	0		Damage Reduction: 7, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2014-08"
 7697	skewed chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,14 +7592,14 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	pulsating LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	diffused irradiated rubber nubbin	0		Effect: "Okee-Dokee Go!", Effect Duration: 46, Last Available: "2014-08"
 7708	shaking greasy rubber cape of the pedagogue	0		Experience: +3, Sleaze Spell Damage: +10, Last Available: "2014-08"
-7709	asbestos-lined sharpshooter's forbidden Thor's Pliers	0		Spell Damage Percent: +50, Critical Hit Percent: +10, Hot Resistance: +5, Item Drop: +5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	asbestos-lined sharpshooter's forbidden Thor's Pliers	0		Spell Damage Percent: +50, Critical Hit Percent: +10, Hot Resistance: +5, Item Drop: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	dry alkaline cold-filtered candy UFOs	0		Effect: "Mo' Hobo", Effect Duration: 49
 7711	frosty chaotic water wings for babies	0		Spell Critical Percent: +10, Cold Spell Damage: +10
-7712	wobbly beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	tiny spoiled twirling mirror Strix stix	1	crappy	
+7712	wobbly beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7713	tiny spoiled mirror twirling Strix stix	1	crappy	
 7714	executive Socratic smooth vampire pellet	0		Moxie: +15, Experience (Mysticality): +1, Meat Drop: +40
 7715	bad non-aged vinegar	4	decent	
 7716	mirror tumbling careful unsanitized scalpel	0		Monster Level: -10
@@ -7639,7 +7639,7 @@
 7750	olive Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	skewed Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	bouncing MacGyver's Xiblaxian xeno-detection goggles	0		Maximum MP: +100, Single Equip, Last Available: "2014-09"
-7753	blurry narrow up-at-dawn Samson's Xiblaxian stealth cowl	0		Experience (Muscle): +5, Adventures: +5, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	blurry narrow up-at-dawn Samson's Xiblaxian stealth cowl	0		Experience (Muscle): +5, Adventures: +5, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	lard-coated Xiblaxian stealth trousers of the brute	0		Muscle Percent: +30, Sleaze Spell Damage: +25, Last Available: "2014-09"
 7755	Oprah's sage Xiblaxian stealth vest	0		Mysticality Percent: +10, Maximum MP Percent: +50, Last Available: "2014-09"
 7756	normal tiny Xiblaxian ultraburrito	1	good	Last Available: "2014-09"
@@ -7669,15 +7669,15 @@
 7780	rock-hard grievous heavy-duty clipboard of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +50, Damage Reduction: 13, Last Available: "2014-10"
 7781	ghostly asbestos-lined Temple Grandin's dangerous battery-powered drill of the sweet-tooth	0		Weapon Damage: +10, Familiar Weight: +7, Hot Resistance: +5, Candy Drop: +100, Last Available: "2014-10"
 7782	snack-sized moldy tumbling limp broccoli	2	crappy	Last Available: "2014-10"
-7783	blue ghostly sizzling hat of wisdom of doom	0		Mysticality: +15, Hot Damage: +10, Spooky Spell Damage: +50, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	blue ghostly sizzling hat of wisdom of doom	0		Mysticality: +15, Hot Damage: +10, Spooky Spell Damage: +50, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	tarnished triple-frozen narrow monkey barf	0		Effect: "Jingle Jangle Jingle", Effect Duration: 29, Last Available: "2014-10"
 7785	unsweetened polarized candy	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 61, Last Available: "2014-10"
 7786	censurious jangly bracelet of extreme caution of incineration	0		Monster Level: -25, Hot Spell Damage: +50, Sleaze Resistance: +3, Last Available: "2014-10"
-7787	shaking cuddly teddy bear of the glutton	0		Food Drop: +100, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	shaking cuddly teddy bear of the glutton	0		Food Drop: +100, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	bouncing horrifying chilly first-aid pouch	0		Cold Damage: +5, Spooky Damage: +25, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
-7791	cold-filtered gray shaking airborne mutagen	0		Effect: "Executive Greed", Effect Duration: 62, Last Available: "2014-10"
+7791	cold-filtered shaking gray airborne mutagen	0		Effect: "Executive Greed", Effect Duration: 62, Last Available: "2014-10"
 7792	mirror SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bouncing bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
@@ -7689,17 +7689,17 @@
 7800	bad Highest Bitter	4	decent	Last Available: "2014-10"
 7801	purple Sherlock's beefy mercenary pistol	0		Muscle: +10, Item Drop: +25, Last Available: "2014-10"
 7802	Tesla mercenary rifle of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
-7803	gray blurry Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
+7803	blurry gray Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
 7804	Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	ghostly Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
-7809	yellow jittery impure gasoline	0		
+7809	jittery yellow impure gasoline	0		
 7810	spinning Z-Bone steak	0		
-7811	shaking mirror viral DNA	0		
+7811	mirror shaking viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	half-sized spoiled seared dino steak	2	crappy	
+7813	spoiled half-sized seared dino steak	2	crappy	
 7814	acceptable bottle of drinkin' gas	3	good	
 7815	handful of napalm	0		
 7816	spinning dove DNA	0		
@@ -7708,13 +7708,13 @@
 7819	simple AI	0		
 7820	squat corrupted bird DNA	0		
 7821	sentient meat mass	0		
-7822	tumbling gray zombie dinosaur egg	0		
+7822	gray tumbling zombie dinosaur egg	0		
 7823	french-fry grabber	0		Familiar Weight: +5
 7824	shaking nippy iShield of the overflowing toilet of horror	0		Cold Damage: +10, Stench Spell Damage: +50, Spooky Spell Damage: +25, Damage Reduction: 6
 7825	auspicious smartaleck's earbuds of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Item Drop: +10, Single Equip
 7826	narrow fireproof medical-grade iFlail of horror	0		Spooky Spell Damage: +25, Hot Resistance: +3, HP Regen Min: 7, HP Regen Max: 10
 7827	bland narrow unidentifiable dried fruit	4	decent	
-7828	strong hand-crafted blurry flat cider	5	EPIC	
+7828	hand-crafted strong blurry flat cider	5	EPIC	
 7829	green avaricious brainy trench lighter of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Meat Drop: +30, Last Available: "2014-10"
 7830	nitrogenated moist narrow mirror experimental serum P-00	0		Effect: "Deadly Lampblade", Effect Duration: 36, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7729,22 +7729,22 @@
 7840	lime green special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	pulsating special clip: splatterers	0		Last Available: "2014-10"
-7843	narrow skewed special clip: boneburners	0		Last Available: "2014-10"
+7843	skewed narrow special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
-7845	warmed pulsating bouncing perl necklace	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 20, Last Available: "2014-12"
+7845	warmed bouncing pulsating perl necklace	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 20, Last Available: "2014-12"
 7846	Vulcanized irradiated Fudge Fiber Armor Plating	0		Effect: "Turtle Power", Effect Duration: 69, Last Available: "2014-12"
 7847	super-irradiated enhanced ruby on canes	0		Effect: "Carrrsmic", Effect Duration: 61, Last Available: "2014-12"
 7848	stale petit fortran	3	decent	Last Available: "2014-12"
 7849	spoiled snack-sized java cookie	2	crappy	Last Available: "2014-12"
-7850	miniature rotten cookie cookie	2	crappy	Last Available: "2014-12"
+7850	rotten miniature cookie cookie	2	crappy	Last Available: "2014-12"
 7851	auspicious plastic exo-suited miner	0		Item Drop: +10, Last Available: "2014-12"
 7852	blue experienced plastic semi-autonomous drill unit	0		Experience: +2, Last Available: "2014-12"
 7853	teal beefy plastic ambulatory robo-minecart	0		Muscle: +10, Last Available: "2014-12"
 7854	Van der Graaf plastic Crimbot	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7855	greedy plastic Crimbomega	0		Meat Drop: +20, Last Available: "2014-12"
 7856	colloidal tarnished flask of mining oil	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 68, Last Available: "2014-12"
-7857	Lo Pan's radiation-resistant helmet	0		Spell Critical Percent: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	blurry aromatic servo-assisted exo-pants	0		Stench Resistance: +1, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	Lo Pan's radiation-resistant helmet	0		Spell Critical Percent: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	blurry aromatic servo-assisted exo-pants	0		Stench Resistance: +1, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	Jack Frost's wizardly high-energy mining laser	0		Mysticality: +25, Cold Spell Damage: +50, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	squat nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7806,7 +7806,7 @@
 7917	concentrated galvanized ghostly cyan BOOterfinger	0		Effect: "Intimidating Mien", Effect Duration: 32
 7918	Vulcanized mirror Moonds	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 63
 7919	dry maroon bouncing pulsating Big Punk	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 52
-7920	jittery skewed upside-down fist turkey outline	0		Free Pull, Last Available: "2014-11"
+7920	upside-down jittery skewed fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	aged strong maroon Friendly Turkey	5	awesome	Last Available: "2014-11"
 7923	delicious Agitated Turkey	4	awesome	Last Available: "2014-11"
@@ -7817,7 +7817,7 @@
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	modified jittery mirror bouncing single atom	1	good	Last Available: "2015-02"
+7938	modified bouncing jittery mirror single atom	1	good	Last Available: "2015-02"
 7939	blue Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
@@ -7826,8 +7826,8 @@
 7944	twirling tooth	0		
 7945	tumbling table	0		
 7946	fortified outlaw bandana of dire peril of the glutton	0		Weapon Damage: +20, Damage Absorption: +60, Food Drop: +100
-7947	high-proof mediocre whiskey in a broken glass	8	decent	
-7948	practically non-alcoholic drinkable gray shot of mescal	1	good	
+7947	mediocre high-proof whiskey in a broken glass	8	decent	
+7948	drinkable practically non-alcoholic gray shot of mescal	1	good	
 7949	lousy glass of herbal tequila	4	decent	
 7950	spinning minin' dynamite	0		
 7951	aromatic rock-hard plaid cowboy hat	0		Damage Reduction: 5, Stench Resistance: +1, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7845,7 +7845,7 @@
 7963	amulet	0		
 7964	ribald Staff of Fats	0		Sleaze Damage: +10
 7965	Holy MacGuffin	0		
-7966	spinning teal Ka coin	0		
+7966	teal spinning Ka coin	0		
 7967	groovy World's Best Adventurer sash	0		Moxie Percent: +10
 7968	mirror topiary nugglet	0		
 7969	beehive	0		
@@ -7881,17 +7881,17 @@
 7999	alkaline choco-Crimbot	0		Effect: "Ocelot Eyes", Effect Duration: 42, Last Available: "2014-12"
 8000	polymerized cold-filtered extra-deionized skewed smart watch	0		Effect: "Witch's Brood", Effect Duration: 35, Last Available: "2014-12"
 8001	cold-filtered blurry augmented-reality shades	0		Effect: "Squid Squint", Effect Duration: 21, Last Available: "2014-12"
-8002	toy Crimbot mega face of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	Samson's toy Crimbot power glove	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	deadly toy Crimbot super fist	0		Weapon Damage: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	jittery upside-down blurry perfumed toy Crimbot rocket legs	0		Stench Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
-8006	warmed olive jittery huge Crimbot battery	0		Effect: "Tingly Wrists", Effect Duration: 53, Last Available: "2014-12"
+8002	toy Crimbot mega face of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	Samson's toy Crimbot power glove	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	deadly toy Crimbot super fist	0		Weapon Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	jittery upside-down blurry perfumed toy Crimbot rocket legs	0		Stench Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8006	warmed huge olive jittery Crimbot battery	0		Effect: "Tingly Wrists", Effect Duration: 53, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	fuchsia heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	purple Van der Graaf Crimbomega drive chain of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	purple Van der Graaf Crimbomega drive chain of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	jittery huge Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	bouncing Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	lard-coated frosty hardy Spelunker's fedora	0		Maximum HP: +50, Cold Spell Damage: +10, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	lard-coated frosty hardy Spelunker's fedora	0		Maximum HP: +50, Cold Spell Damage: +10, Sleaze Spell Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	toasty chaotic slick Spelunker's whip	0		Moxie: +10, Spell Critical Percent: +10, Hot Damage: +5, Last Available: "2015-12"
-8076	bouncing scandalous Van der Graaf Spelunker's khakis of the empath	0		Familiar Weight: +5, Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	bouncing scandalous Van der Graaf Spelunker's khakis of the empath	0		Familiar Weight: +5, Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	jittery LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7996,7 +7996,7 @@
 8121	spinning MacGyver's hardy garland	0		Maximum HP: +50, Maximum MP: +100, Single Equip, Last Available: "2018-12"
 8122	narrow zippy gunnysack of the brute	0		Muscle Percent: +30, Initiative: +20, Last Available: "2018-12"
 8123	purple blurry Herculean Rosewater's garibaldi	0		Mysticality Percent: +30, Experience (Muscle): +1, Last Available: "2018-12"
-8124	lion tamer's hardened girdle	0		Damage Reduction: 3, Experience (familiar): +2, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	lion tamer's hardened girdle	0		Damage Reduction: 3, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	gray huge curative gloves of the overflowing toilet	0		Stench Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2018-12"
 8126	altered smithereens	1		Last Available: "2018-12"
 8127	sizzling Oprah's fiberglass fetish	0		Maximum MP Percent: +50, Hot Damage: +10, Last Available: "2018-12"
@@ -8015,7 +8015,7 @@
 8141	Samson's macroplane grater	0		Experience (Muscle): +5
 8142	shellacked bastard baster	0		Damage Reduction: 7
 8143	obsidian nutcracker of the overflowing toilet	0		Stench Spell Damage: +50
-8144	tumbling cyan talisman of Seshat	0		Free Pull
+8144	cyan tumbling talisman of Seshat	0		Free Pull
 8145	bouncing energetic glass eye of horror	0		Maximum MP Percent: +20, Spooky Spell Damage: +25, Single Equip
 8146	triple-cold-filtered invisible potion	0		Effect: "The Power of Negative Thinking", Effect Duration: 28
 8147	bouncing time shuriken	0		
@@ -8024,10 +8024,10 @@
 8150	unsweetened twirling sugar sphere	0		Effect: "Indescribable Flavor", Effect Duration: 54
 8151	enhanced vacuum-sealed Shrubble Bubble	0		Effect: "Hair on Your Chest", Effect Duration: 61
 8152	flattened polyeaster egg	0		Effect: "Slippery Tongue", Effect Duration: 27
-8153	polarized skewed huge candy dish	0		Effect: "Patent Alacrity", Effect Duration: 43
+8153	polarized huge skewed candy dish	0		Effect: "Patent Alacrity", Effect Duration: 43
 8154	liquefied flattened Spechunky bar	0		Effect: "Always be Collecting", Effect Duration: 13
 8155	magnetized tumbling fuchsia talisman of Horus	0		Effect: "Full-Body Tan", Effect Duration: 38
-8156	jittery ghostly check to the Meatsmith	0		
+8156	ghostly jittery check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
@@ -8045,7 +8045,7 @@
 8171	acceptable unflavored wine cooler	3	good	
 8172	gray carton of snake milk	1	decent	
 8173	blurry ghostly upside-down ribald sewer snake	0		Sleaze Damage: +10
-8174	normal tiny cyan pigeon egg	1	good	
+8174	tiny normal cyan pigeon egg	1	good	
 8175	yellow prompt flame-retardant jaunty feather	0		Hot Resistance: +1, Adventures: +3
 8176	acceptable fancy premium malt liquor	4	good	Effect: "Irresistible Resolve", Effect Duration: 15
 8177	Usain Bolt's brown paper pants of the sweet-tooth	0		Candy Drop: +100, Initiative: +80
@@ -8056,16 +8056,16 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	upside-down brawny bread basket	0		Muscle Percent: +20
 8184	wobbly Ed the Undying exhibit crate	0		
-8185	studded The Crown of Ed the Undying of incineration	0		Damage Absorption: +80, Hot Spell Damage: +50, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	studded The Crown of Ed the Undying of incineration	0		Damage Absorption: +80, Hot Spell Damage: +50, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	high-proof perfectly mixed Cherrytastrophe wine cooler	8	EPIC	
 8189	acceptable Radberry Rip wine cooler	4	good	
-8190	tolerable squat pulsating Orangemageddon wine cooler	4	good	
+8190	tolerable pulsating squat Orangemageddon wine cooler	4	good	
 8191	tolerable Breakfast Blast wine cooler	3	good	
 8192	watered-down hand-crafted Citrus Crush wine cooler	2	EPIC	
-8193	flavorless snack-sized upside-down plain bagel	2	decent	
-8194	miniature spoiled glob of cream cheese	2	crappy	
+8193	snack-sized flavorless upside-down plain bagel	2	decent	
+8194	spoiled miniature glob of cream cheese	2	crappy	
 8195	normal bouncing loaf of soda bread	3	good	
 8196	normal acceptable bagel	4	good	
 8197	adequate standard-issue cupcake	3	good	
@@ -8086,13 +8086,13 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	miser's Van der Graaf rigging rope	0		Meat Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-04"
 8214	diluted blurry nasty snuff	1	EPIC	Last Available: "2015-04"
-8215	smelly sage sewage-clogged pistol	0		Mysticality Percent: +10, Stench Spell Damage: +10, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	smelly sage sewage-clogged pistol	0		Mysticality Percent: +10, Stench Spell Damage: +10, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	pickled beard incense	0		Effect: "You Liver", Effect Duration: 36, Last Available: "2015-04"
 8217	gravedigger's perfume-soaked bandana of doom	0		Spooky Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2015-04"
 8218	maroon toxic globule	0		Last Available: "2015-04"
 8219	enchanted spoiled half-sized blinking toxo	2	crappy	Effect: "Sharp Weapon", Effect Duration: 50, Last Available: "2015-04"
-8220	weak lousy purple pulsating Lemonade-235	2	decent	Last Available: "2015-04"
-8221	upside-down prompt flame-wreathed isotophat	0		Hot Spell Damage: +10, Adventures: +3, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	lousy weak purple pulsating Lemonade-235	2	decent	Last Available: "2015-04"
+8221	upside-down prompt flame-wreathed isotophat	0		Hot Spell Damage: +10, Adventures: +3, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Three Mile Island shorts of the early riser	0		Item Drop: +5, Adventures: +7, Last Available: "2015-04"
 8223	upside-down perfumed nasty toxic mop	0		Stench Damage: +5, Stench Resistance: +5, Last Available: "2015-04"
 8224	blinking inert sludgepuppy	0		Last Available: "2015-04"
@@ -8112,7 +8112,7 @@
 8238	tumbling brain preservation fluid	0		Last Available: "2015-04"
 8239	ghostly keycard &alpha;	0		Last Available: "2015-04"
 8240	keycard &beta;	0		Last Available: "2015-04"
-8241	purple ghostly keycard &gamma;	0		Last Available: "2015-04"
+8241	ghostly purple keycard &gamma;	0		Last Available: "2015-04"
 8242	tumbling keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	careful lube-shoes	0		Monster Level: -10, Last Available: "2015-04"
@@ -8120,14 +8120,14 @@
 8246	green aromatic shellacked Herculean Dinsey mascot mask	0		Experience (Muscle): +1, Damage Reduction: 7, Stench Resistance: +1, Last Available: "2015-04"
 8247	bite-sized spoiled wobbly Dinsey food-cone	1	crappy	Last Available: "2015-04"
 8248	hand-crafted watered-down Dinsey Whinskey	2	EPIC	Last Available: "2015-04"
-8249	oxidized anodized blurry maroon twirling Dinsey face paint	0		Effect: "Thunderspell", Effect Duration: 11, Last Available: "2015-04"
+8249	oxidized anodized maroon twirling blurry Dinsey face paint	0		Effect: "Thunderspell", Effect Duration: 11, Last Available: "2015-04"
 8250	grievous fannypack	0		Weapon Damage Percent: +50, Item Drop: +5, Last Available: "2015-04"
 8251	supercool thinker's garbage sticker of the wise owl of extreme caution of incineration of mayonnaise	0		Mysticality: 30, Moxie Percent: +20, Monster Level: -25, Hot Spell Damage: +50, Sleaze Spell Damage: +50, Last Available: "2015-04"
 8252	lime green sharpshooter's hardened baleful arcane researcher's hazmat helmet of dire peril	0		Experience Percent (Mysticality): +10, Weapon Damage: +20, Spell Damage: +25, Damage Reduction: 3, Critical Hit Percent: +10, Last Available: "2015-04"
 8253	tumbling Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	tumbling Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
-8256	purple spinning Dinsey tattoo kit	0		Last Available: "2015-04"
+8256	spinning purple Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	moist nitrogenated bouncing nasty gum	0		Effect: "Ghost Finger", Effect Duration: 24
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	narrow gray The Lot's engagement ring of doom	0		Spooky Spell Damage: +50, Conditional Skill (Equipped): "Propose To Your Opponent"
@@ -8152,13 +8152,13 @@
 8278	practically non-alcoholic lousy Afternoon Delight	1	decent	Last Available: "2015-04"
 8279	blue Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	jittery Golden Kokomo Resort Chip	0		Last Available: "2015-04"
-8281	boiled tumbling pulsating Kokomo Resort Brand Suntan Oil	0		Effect: "The Moxie of LOV", Effect Duration: 69, Last Available: "2015-04"
+8281	boiled pulsating tumbling Kokomo Resort Brand Suntan Oil	0		Effect: "The Moxie of LOV", Effect Duration: 69, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	green The Cocktail Shaker	0		Last Available: "2015-04"
 8284	pickled tumbling Kokomo Resort Pass	0		Effect: "In the Saucestream", Effect Duration: 39, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	aerosolized cyan Mayo de Mayo&trade; mayo	0		Effect: "Heal Thy Nanoself", Effect Duration: 59
-8287	bouncing wobbly puck	0		Free Pull, Last Available: "2015-06"
+8287	wobbly bouncing puck	0		Free Pull, Last Available: "2015-06"
 8288	shaking skewed kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	squat tumbling toasty dice ring	0		Hot Damage: +5, Single Equip
@@ -8177,7 +8177,7 @@
 8303	mediocre narrow pixel beer	3	decent	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
-8306	modified green blurry sludgesicle	0		Effect: "Heart Aflame", Effect Duration: 43
+8306	modified blurry green sludgesicle	0		Effect: "Heart Aflame", Effect Duration: 43
 8307	Vulcanized altered &Uuml;berraschthexengebr&auml;u	0		Effect: "Hairy Palms", Effect Duration: 13
 8308	moist adjusted piggy tattoo	0		Effect: "Busy Bein' Delicious", Effect Duration: 47
 8309	anodized baggie of regular-sized tardigrades	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 55
@@ -8204,7 +8204,7 @@
 8330	dry assassin's cheese knife	0		Effect: "Very Clean Guns", Effect Duration: 12
 8331	colloidal maroon filthy armor	0		Effect: "Boilermade", Effect Duration: 62
 8332	triple-chilled modified plague pie	0		Effect: "Pyramid Power", Effect Duration: 19
-8333	dry diffused huge upside-down batarang	0		Effect: "Wax On Your Shoes", Effect Duration: 66
+8333	dry diffused upside-down huge batarang	0		Effect: "Wax On Your Shoes", Effect Duration: 66
 8334	anodized boiled spare neck bolts	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 43
 8335	boiled polymerized bouncing grease trap	0		Effect: "Void Between the Stars", Effect Duration: 66
 8336	energized enhanced lime green shamanic ham	0		Effect: "Ripping, Dripping", Effect Duration: 13
@@ -8212,10 +8212,10 @@
 8338	pressed denatured Leonard's glasses	0		Effect: "Greasy Flavor", Effect Duration: 68
 8339	polarized anodized narrow warehouse walkie-talkie	0		Effect: "Eyes of the Dragon", Effect Duration: 20
 8340	polymerized diffused pulsating janitor's mop	0		Effect: "Infernal Thirst", Effect Duration: 69
-8341	non-ionized ionized irradiated mirror shaking warehouse clerk's glasses	0		Effect: "Smelly Pants", Effect Duration: 62
+8341	non-ionized ionized irradiated shaking mirror warehouse clerk's glasses	0		Effect: "Smelly Pants", Effect Duration: 62
 8342	improved tarnished nitrogenated upside-down baloney rotgut	0		Effect: "Ooh, Salty!", Effect Duration: 56
 8343	moist vacuum-sealed liquefied carton of gaspers	0		Effect: "Prelude of Precision", Effect Duration: 14
-8344	alkaline skewed jittery bronze polish	0		Effect: "Twen Tea", Effect Duration: 67
+8344	alkaline jittery skewed bronze polish	0		Effect: "Twen Tea", Effect Duration: 67
 8345	boiled crident	0		Effect: "Dreadful Heat", Effect Duration: 30
 8346	nitrogenated blinking totally sweet mohawk helmet	0		Effect: "Blackberry Politeness", Effect Duration: 54
 8347	triple-liquefied ionized spray chrome	0		Effect: "Pwnd", Effect Duration: 58
@@ -8240,7 +8240,7 @@
 8366	adjusted cyan invisibility cream	0		Effect: "Mushroom Might", Effect Duration: 28
 8367	modified handful of stubble	0		Effect: "Heart of Pink", Effect Duration: 21
 8368	enhanced upside-down garbage juice slurpee	0		Effect: "Covetous Robbery", Effect Duration: 44
-8369	pickled altered purple upside-down plunge-leg	0		Effect: "Woad Warrior", Effect Duration: 64
+8369	pickled altered upside-down purple plunge-leg	0		Effect: "Woad Warrior", Effect Duration: 64
 8370	corrupted narrow funky eyepatch	0		Effect: "Cat Class, Cat Style", Effect Duration: 11
 8371	pressed warmed jittery bucket of fish juice	0		Effect: "Lit Up", Effect Duration: 27
 8372	dry flashy pirate dreadlocks	0		Effect: "Flamingly Floral", Effect Duration: 48
@@ -8248,8 +8248,8 @@
 8374	cold-filtered nitrogenated pulsating drinks tray	0		Effect: "Mortarfied", Effect Duration: 44
 8375	galvanized eyebrow lifter	0		Effect: "Wet Jaw", Effect Duration: 44
 8376	pulsating submarine	0		Last Available: "2015-06"
-8377	snack-sized bland pixel lemon	2	decent	Last Available: "2015-06"
-8378	hand-crafted fancy pixel daiquiri	4	EPIC	Effect: "Scavengers Scavenging", Effect Duration: 30, Last Available: "2015-06"
+8377	bland snack-sized pixel lemon	2	decent	Last Available: "2015-06"
+8378	fancy hand-crafted pixel daiquiri	4	EPIC	Effect: "Scavengers Scavenging", Effect Duration: 30, Last Available: "2015-06"
 8379	vacuum-sealed power pill	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 56, Last Available: "2015-06"
 8380	oxidized Vulcanized blinking pixel potion	0		Effect: "Crocodile Tear", Effect Duration: 12, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8258,7 +8258,7 @@
 8384	blurry bubblegum heart	0		Last Available: "2015-07"
 8385	cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
-8387	blurry teal shaking mana	0		Last Available: "2015-07"
+8387	teal shaking blurry mana	0		Last Available: "2015-07"
 8388	teal mana	0		Last Available: "2015-07"
 8389	mana	0		Last Available: "2015-07"
 8390	tumbling mana	0		Last Available: "2015-07"
@@ -8281,17 +8281,17 @@
 8407	normal pestopiary	4	good	
 8408	flattened ectoplasmic orbs	0		Effect: "Jawin'", Effect Duration: 54
 8409	decent ghostly crudles	4	good	
-8410	super-sized decent agnolotti arboli	5	good	
+8410	decent super-sized agnolotti arboli	5	good	
 8411	decent pulsating spaghetti with ghost balls	3	good	
 8412	spoiled succulent marrow	3	crappy	
 8413	decent miniature salacious crumbs	2	good	
-8414	rotten red upside-down fusilli marrownarrow	3	crappy	
+8414	rotten upside-down red fusilli marrownarrow	3	crappy	
 8415	stale pulsating suggestive strozzapreti	4	decent	
 8416	Mountain Stream gastrique	0		
 8417	bland blinking Mt. McLargeHuge oyster	3	decent	
 8418	oyster sauce	0		
 8419	normal upside-down linguini immondizia bianco	4	good	
-8420	stale gigantic shells a la shellfish	7	decent	
+8420	gigantic stale shells a la shellfish	7	decent	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8329,7 +8329,7 @@
 8455	tumbling New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	tumbling broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	wizardly high-temperature mining mask of the pedagogue	0		Mysticality: +25, Experience: +3, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	wizardly high-temperature mining mask of the pedagogue	0		Mysticality: +25, Experience: +3, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	padded fireproof megaphone of the cougar	0		Moxie: +20, Damage Absorption: +20, Last Available: "2015-08"
 8460	tiny decent tumbling mineapple	1	good	Last Available: "2015-08"
 8461	perfectly mixed Gold Velvet&trade; whiskey	4	EPIC	Last Available: "2015-08"
@@ -8340,19 +8340,19 @@
 8466	greasy thinker's lavalarva of the sewer	0		Mysticality: +10, Stench Damage: +25, Sleaze Spell Damage: +10, Last Available: "2015-08"
 8467	nasty lion tamer's Fonzie's lava balaclava	0		Experience (Moxie): +1, Experience (familiar): +2, Stench Damage: +5, Last Available: "2015-08"
 8468	spinning greedy slick basaltamander buckler of the glutton	0		Moxie: +10, Meat Drop: +20, Food Drop: +100, Damage Reduction: 15, Last Available: "2015-08"
-8469	oxidized electrified wobbly twirling lava globs	0		Effect: "Neuromancy", Effect Duration: 15, Last Available: "2015-08"
-8470	half-sized flavorless gooey lava globs	2	decent	Last Available: "2015-08"
+8469	oxidized electrified twirling wobbly lava globs	0		Effect: "Neuromancy", Effect Duration: 15, Last Available: "2015-08"
+8470	flavorless half-sized gooey lava globs	2	decent	Last Available: "2015-08"
 8471	careful curative lava-proof pants	0		Monster Level: -10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-08"
 8472	wool Oprah's heat-resistant necktie	0		Maximum MP Percent: +50, Cold Resistance: +1, Single Equip, Last Available: "2015-08"
 8473	purple careful wicked wizardly heat-resistant gloves	0		Mysticality: +25, Spell Damage: +5, Monster Level: -10, Single Equip, Last Available: "2015-08"
 8474	flavorless snack-sized skewed very hot lunch	2	decent	Last Available: "2015-08"
-8475	practically non-alcoholic drinkable asbestos thermos	1	good	Last Available: "2015-08"
+8475	drinkable practically non-alcoholic asbestos thermos	1	good	Last Available: "2015-08"
 8476	magnetized ionized warmed narrow liquid rhinestones	0		Effect: "Rain Dancin'", Effect Duration: 29, Last Available: "2015-08"
 8477	normal disco biscuit	3	good	Last Available: "2015-08"
 8478	acceptable practically non-alcoholic Quaatorade&trade;	1	good	Last Available: "2015-08"
-8479	twirling skewed dog trainer's Oprah's biker's hat of the cheetah	0		Maximum MP Percent: +50, Experience (familiar): +1, Initiative: +60, Familiar Effect: "atk", Last Available: "2015-08"
-8480	blurry lightning-fast foul-smelling feathered headdress of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +10, Initiative: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	Sherlock's careful smooth electrician's hardhat	0		Moxie: +15, Monster Level: -10, Item Drop: +25, Familiar Effect: "atk", Last Available: "2015-08"
+8479	twirling skewed dog trainer's Oprah's biker's hat of the cheetah	0		Maximum MP Percent: +50, Experience (familiar): +1, Initiative: +60, Last Available: "2015-08", Familiar Effect: "atk"
+8480	blurry lightning-fast foul-smelling feathered headdress of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +10, Initiative: +40, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	Sherlock's careful smooth electrician's hardhat	0		Moxie: +15, Monster Level: -10, Item Drop: +25, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	jittery Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	olive New Age hurting crystal	0		Last Available: "2015-08"
-8490	tumbling upside-down padded smooth velvet pants	0		Damage Absorption: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	tumbling upside-down padded smooth velvet pants	0		Damage Absorption: +20, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	smooth velvet shirt of the wise owl	0		Mysticality: +20, Last Available: "2015-08"
 8492	squat pulsating dog trainer's smooth velvet hat	0		Experience (familiar): +1, Last Available: "2015-08"
 8493	therapeutic smooth velvet pocket square	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	blinking bouncing Temple Grandin's educational SMOOCH bracers	0		Experience: +1, Familiar Weight: +7, Single Equip, Last Available: "2015-08"
 8518	pulsating Rosewater's SMOOCH kneepads	0		Mysticality Percent: +30, Single Equip, Last Available: "2015-08"
 8519	teal chaotic SMOOCH spaulders	0		Spell Critical Percent: +10, Single Equip, Last Available: "2015-08"
-8520	huge wizardly SMOOCH codpiece of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	huge wizardly SMOOCH codpiece of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	tumbling green blurry SMOOCH breastplate of incineration	0		Hot Spell Damage: +50, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8403,16 +8403,16 @@
 8529	flavorless huge devil hair pasta	7	decent	
 8530	moldy spagecialetti	4	crappy	
 8531	red Salsa Libre	0		
-8532	twirling green good gravy	0		
+8532	green twirling good gravy	0		
 8533	illicit fish sauce	0		
-8534	normal small libertagliatelle	2	good	
+8534	small normal libertagliatelle	2	good	
 8535	decent enchanted turkish mostaccioli	3	good	Effect: "Kissed By Fire", Effect Duration: 10
 8536	yummy linguini of the sea	4	awesome	
 8537	ionized Hersey&trade; SMOOCH	0		Effect: "Rage of the Reindeer", Effect Duration: 19
 8539	spinning Alexy sauce	0		
 8540	green rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	miniature decent blinking Fettris	2	good	
+8542	decent miniature blinking Fettris	2	good	
 8543	yummy fusillocybin	3	awesome	
 8544	normal tumbling prescription noodles	3	good	
 8545	dehydrated jittery upside-down blood-drive sticker	1	decent	
@@ -8423,21 +8423,21 @@
 8550	decent twirling weird gazelle steak	3	good	
 8551	tasty blurry sausage without a cause	3	awesome	
 8552	unsweetened pressed mirror face paint	0		Effect: "Disco Neuropathy", Effect Duration: 29
-8553	watered-down acceptable emergency margarita	2	good	
-8554	bad distilled blinking vintage smart drink	5	decent	
+8553	acceptable watered-down emergency margarita	2	good	
+8554	distilled bad blinking vintage smart drink	5	decent	
 8555	jittery a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	narrow The Emperor's new cookie	0		
 8558	polymerized purple Wickers bar	0		Effect: "Kernel Panic!", Effect Duration: 48
 8559	corrupted quadruple-warmed polymerized red bakelite-covered bacon	0		Effect: "Antibiotic Saucesphere", Effect Duration: 54
 8560	non-enhanced quantum Vulcanized ghostly Aerheads	0		Effect: "Banono", Effect Duration: 54
-8561	pickled spinning huge Wrotz	0		Effect: "Bilious Brawn", Effect Duration: 19
+8561	pickled huge spinning Wrotz	0		Effect: "Bilious Brawn", Effect Duration: 19
 8562	corrupted teal Gabarbar	0		Effect: "Vinegavotte", Effect Duration: 34
 8563	enhanced fiberglass insulation	0		Effect: "[1609]Dancin' Fool", Effect Duration: 57
 8564	blurry shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	ribald flame-wreathed medical-grade barrel lid	0		Hot Spell Damage: +10, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	blinking lime green up-at-dawn chaotic barrel hoop earring of the empath	0		Spell Critical Percent: +10, Familiar Weight: +5, Adventures: +5, Lasts Until Rollover, Last Available: "2015-09"
-8567	twirling fireproof Lo Pan's sharpshooter's bankruptcy barrel	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Hot Resistance: +3, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	twirling fireproof Lo Pan's sharpshooter's bankruptcy barrel	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	cyan tun	0		Last Available: "2015-09"
@@ -8450,8 +8450,8 @@
 8577	twirling barnacled barrel	0		Last Available: "2015-09"
 8578	mediocre bouncing bottle of Amontillado	4	decent	Last Available: "2015-09"
 8579	hand-crafted barrel-aged martini	3	EPIC	Last Available: "2015-09"
-8580	super-sized normal barrel pickle	5	good	Last Available: "2015-09"
-8581	normal tiny barrel cracker	1	good	Last Available: "2015-09"
+8580	normal super-sized barrel pickle	5	good	Last Available: "2015-09"
+8581	tiny normal barrel cracker	1	good	Last Available: "2015-09"
 8582	twisted gray vibrating mushroom	1	EPIC	Last Available: "2015-09"
 8583	denatured twirling mushroom	1	EPIC	Last Available: "2015-09"
 8584	KoL Con 12-gauge of bravery	0		Spooky Resistance: +5, Last Available: "2015-09"
@@ -8481,21 +8481,21 @@
 8608	cold-filtered spinning spinning cuppa Net tea	0		Effect: "Weasels Underfoot", Effect Duration: 67, Last Available: "2015-09"
 8609	nitrogenated cuppa Proprie tea	0		Effect: "Yuletide Industry", Effect Duration: 20, Last Available: "2015-09"
 8610	energized huge cuppa Morbidi tea	0		Effect: "Wit Tea", Effect Duration: 11, Last Available: "2015-09"
-8611	dry upside-down huge cuppa Chari tea	0		Effect: "Lubed", Effect Duration: 19, Last Available: "2015-09"
+8611	dry huge upside-down cuppa Chari tea	0		Effect: "Lubed", Effect Duration: 19, Last Available: "2015-09"
 8612	non-quantum ionized moist cuppa Serendipi tea	0		Effect: "Object Detection", Effect Duration: 48, Last Available: "2015-09"
-8613	quadruple-unsweetened modified denatured narrow twirling cuppa Feroci tea	0		Effect: "Comic Violence", Effect Duration: 29, Last Available: "2015-09"
+8613	quadruple-unsweetened modified denatured twirling narrow cuppa Feroci tea	0		Effect: "Comic Violence", Effect Duration: 29, Last Available: "2015-09"
 8614	alkaline cuppa Physicali tea	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 28, Last Available: "2015-09"
 8615	pickled ionized cuppa Wit tea	0		Effect: "Grumpy and Ornery", Effect Duration: 60, Last Available: "2015-09"
 8616	aerosolized huge narrow cuppa Neuroplastici tea	0		Effect: "Locks Like the Raven", Effect Duration: 31, Last Available: "2015-09"
 8617	moist alkaline diffused olive cuppa Dexteri tea	0		Effect: "Stemonitis Storm", Effect Duration: 51, Last Available: "2015-09"
 8618	ionized extra-adjusted blurry cuppa Flexibili tea	0		Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2015-09"
-8619	liquefied red wobbly cuppa Impregnabili tea	0		Effect: "Tea-hee", Effect Duration: 49, Last Available: "2015-09"
+8619	liquefied wobbly red cuppa Impregnabili tea	0		Effect: "Tea-hee", Effect Duration: 49, Last Available: "2015-09"
 8620	flattened chilled spinning cuppa Obscuri tea	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 58, Last Available: "2015-09"
 8621	boiled cuppa Irritabili tea	0		Effect: "Spooky Weapon", Effect Duration: 56, Last Available: "2015-09"
 8622	frozen cuppa Mediocri tea	0		Effect: "Turtle Power", Effect Duration: 22, Last Available: "2015-09"
 8623	boiled squat squat cuppa Loyal tea	0		Effect: "Grrrrrrreat!", Effect Duration: 12, Last Available: "2015-09"
 8624	boiled cuppa Activi tea	1	decent	Last Available: "2015-09"
-8625	altered green squat cuppa Cruel tea	1		Last Available: "2015-09"
+8625	altered squat green cuppa Cruel tea	1		Last Available: "2015-09"
 8626	enhanced quadruple-quantum maroon cuppa Alacri tea	0		Effect: "Bubblin' Rage", Effect Duration: 63, Last Available: "2015-09"
 8627	unsweetened flattened cuppa Vitali tea	0		Effect: "Fratty Flavor", Effect Duration: 37, Last Available: "2015-09"
 8628	polymerized red cuppa Mana tea	0		Effect: "It's Electric!", Effect Duration: 56, Last Available: "2015-09"
@@ -8511,11 +8511,11 @@
 8638	resourceful grievous Royal scepter of Calamity Jane	0		Weapon Damage Percent: +50, Maximum MP: +50, Critical Hit Percent: +15, Last Available: "2015-09"
 8639	pulsating doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	low-calorie stale narrow wobbly bowl of eyeballs	1	decent	Last Available: "2015-10"
-8642	miniature normal bowl of mummy guts	2	good	Last Available: "2015-10"
+8641	low-calorie stale wobbly narrow bowl of eyeballs	1	decent	Last Available: "2015-10"
+8642	normal miniature bowl of mummy guts	2	good	Last Available: "2015-10"
 8643	stale green bowl of maggots	3	decent	Last Available: "2015-10"
 8644	acceptable blood and blood	4	good	Last Available: "2015-10"
-8645	delicious triple-distilled Jack-O-Lantern beer	7	awesome	Last Available: "2015-10"
+8645	triple-distilled delicious Jack-O-Lantern beer	7	awesome	Last Available: "2015-10"
 8646	perfectly mixed upside-down zombie	4	EPIC	Last Available: "2015-10"
 8647	tumbling narrow Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8553,13 +8553,13 @@
 8680	toasty chaotic Herculean Wal-Mart nametag	0		Experience (Muscle): +1, Spell Critical Percent: +10, Hot Damage: +5, Last Available: "2015-11"
 8681	chilly rosy-cheeked Sinatra's Wal-Mart overalls	0		Experience (Moxie): +5, Maximum HP Percent: +30, Cold Damage: +5, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
-8683	spinning lime green The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
+8683	lime green spinning The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	narrow Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	Lo Pan's bellhop's hat	0		Spell Critical Percent: +30, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	practically non-alcoholic perfectly mixed ice porter	1	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	Lo Pan's bellhop's hat	0		Spell Critical Percent: +30, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	practically non-alcoholic perfectly mixed ice porter	1	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	quantum exotic travel brochure	0		Effect: "Sausage Festive", Effect Duration: 61, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	super-quantum blinking shampoo-conditioner	0		Effect: "Stogied", Effect Duration: 26, Last Available: "2015-11"
@@ -8568,10 +8568,10 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	pickled bouncing medicinal herbs	1		Last Available: "2016-01"
 8697	enchanted normal ice rice	3	good	Effect: "Lubed", Effect Duration: 5, Last Available: "2016-01"
-8698	high-proof artisanal iced plum wine	7	EPIC	Last Available: "2016-01"
+8698	artisanal high-proof iced plum wine	7	EPIC	Last Available: "2016-01"
 8699	squat quilted training belt of Leguizamo of the overflowing toilet	0		Damage Absorption: +40, Monster Level: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2016-01"
 8700	lightning-fast double-paned sharpshooter's training legwarmers	0		Critical Hit Percent: +10, Cold Resistance: +5, Initiative: +40, Single Equip, Last Available: "2016-01"
-8701	blinking stanky manspreader's training helmet of the empath	0		Monster Level: +10, Familiar Weight: +5, Stench Spell Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	blinking stanky manspreader's training helmet of the empath	0		Monster Level: +10, Familiar Weight: +5, Stench Spell Damage: +25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	pulsating ghostly training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	cyan training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8583,10 +8583,10 @@
 8710	modified blurry abstraction: sensation	1		Last Available: "2015-12"
 8711	dehydrated jittery abstraction: purpose	1		Effect: "Creepin' Up on You", Effect Duration: 10, Last Available: "2015-12"
 8712	vaporized upside-down abstraction: category	1		Last Available: "2015-12"
-8713	boiled skewed bouncing lime green abstraction: perception	1		Last Available: "2015-12"
+8713	boiled lime green skewed bouncing abstraction: perception	1		Last Available: "2015-12"
 8714	modified upside-down abstraction: motion	1		Last Available: "2015-12"
 8715	vaporized wobbly abstraction: joy	1		Last Available: "2015-12"
-8716	boiled jittery tumbling abstraction: certainty	1		Last Available: "2015-12"
+8716	boiled tumbling jittery abstraction: certainty	1		Last Available: "2015-12"
 8717	distilled narrow abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	flavorless jittery VYKEA meatballs	4	decent	Last Available: "2015-11"
@@ -8601,29 +8601,29 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	spinning family-friendly knitted curative VYKEA hex key	0		Cold Resistance: +3, Sleaze Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	gigantic toothsome twirling tin of submardines	6	awesome	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	gigantic toothsome twirling tin of submardines	6	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	hand-crafted twirling bottle of norwhiskey	4	EPIC	Last Available: "2015-11"
 8733	altered octolus oculus	1	decent	Last Available: "2015-11"
 8734	up-at-dawn zippy sardine can key of the cougar	0		Moxie: +20, Initiative: +20, Adventures: +5, Last Available: "2015-11"
-8735	family-friendly fortified stylish norwhal helmet	0		Moxie: +25, Damage Absorption: +60, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2015-11"
+8735	family-friendly fortified stylish norwhal helmet	0		Moxie: +25, Damage Absorption: +60, Sleaze Resistance: +1, Last Available: "2015-11", Familiar Effect: "atk"
 8736	avaricious Socratic octolus-skin cloak of chilblains	0		Experience (Mysticality): +1, Cold Damage: +25, Meat Drop: +30, Last Available: "2015-11"
 8737	tolerable enchanted blurry perfect cosmopolitan	3	good	Effect: "Abyssal Sweat", Effect Duration: 5, Last Available: "2015-11"
-8738	practically non-alcoholic tolerable perfect negroni	1	good	Last Available: "2015-11"
+8738	tolerable practically non-alcoholic perfect negroni	1	good	Last Available: "2015-11"
 8739	lousy perfect dark and stormy	3	decent	Last Available: "2015-11"
 8740	hand-crafted practically non-alcoholic jittery perfect mimosa	1	super ultra mega turbo EPIC	Last Available: "2015-11"
-8741	acceptable enchanted perfect old-fashioned	4	good	Effect: "Knightlife", Effect Duration: 30, Last Available: "2015-11"
+8741	enchanted acceptable perfect old-fashioned	4	good	Effect: "Knightlife", Effect Duration: 30, Last Available: "2015-11"
 8742	hand-crafted perfect paloma	4	EPIC	Last Available: "2015-11"
 8743	electrified blue That 70s Cologne	0		Effect: "Frigid Weapon", Effect Duration: 12, Last Available: "2015-11"
 8744	non-anodized corrupted Wal-Mart &quot;diamond&quot; ring	0		Effect: "This Is Where You're a Viking", Effect Duration: 32, Last Available: "2015-11"
 8745	ionized unsweetened skewed Puffstone cigar	0		Effect: "Emotion Sickness", Effect Duration: 40, Last Available: "2015-11"
-8746	denatured ghostly fuchsia Conspiracy&trade; mascara	0		Effect: "Alchemical, Brother", Effect Duration: 62, Last Available: "2015-11"
+8746	denatured fuchsia ghostly Conspiracy&trade; mascara	0		Effect: "Alchemical, Brother", Effect Duration: 62, Last Available: "2015-11"
 8747	unsweetened Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Human-Slime Hybrid", Effect Duration: 32, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
 8749	pressed Deep Machine Tunnels snowglobe	0		Effect: "Neuroplastici Tea", Effect Duration: 30, Last Available: "2015-12"
 8750	double-boiled irradiated hemp candy necklace	0		Effect: "Powdered", Effect Duration: 31, Last Available: "2015-12"
 8751	modified squat communal gobstopper	0		Effect: "Brocolate Brostidigitation", Effect Duration: 28, Last Available: "2015-12"
 8752	delicious shaking Crimbo salad	3	awesome	Last Available: "2015-12"
-8753	tasty huge bread line	10	awesome	Last Available: "2015-12"
+8753	huge tasty bread line	10	awesome	Last Available: "2015-12"
 8754	high-proof smooth bark rootbeer	6	awesome	Last Available: "2015-12"
 8755	artisanal ale	3	EPIC	Last Available: "2015-12"
 8756	plastic Tammy the Tambourine Elf of the cheetah	0		Initiative: +60, Last Available: "2015-12"
@@ -8636,9 +8636,9 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	skewed Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	tolerable practically non-alcoholic fuchsia Gratitude chocolate (bourbon-filled)	1	good	Last Available: "2016-02"
+8766	practically non-alcoholic tolerable fuchsia Gratitude chocolate (bourbon-filled)	1	good	Last Available: "2016-02"
 8767	blinking Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
-8768	ghostly narrow twirling Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
+8768	ghostly twirling narrow Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
 8770	improved pulsating huge pitted sheet	0		Effect: "Wet Rub", Effect Duration: 21, Last Available: "2015-12"
 8771	sparking robo-battery	0		Last Available: "2015-12"
@@ -8646,7 +8646,7 @@
 8773	tumbling banded boxer's reusable shopping bag of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Damage Absorption: +100, Last Available: "2015-12"
 8775	shaking Sinatra's coarse hemp socks	0		Experience (Moxie): +5, Single Equip, Last Available: "2015-12"
 8776	armband	0		Item Drop: +5, Single Equip, Last Available: "2015-12"
-8777	huge shaking bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
+8777	shaking huge bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	narrow pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	narrow manspreader's reindeer hammer	0		Monster Level: +10, Last Available: "2015-12"
 8783	elf ploughshare of the scaredy-cat	0		Monster Level: -15, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8683,7 +8683,7 @@
 8811	confidence-building hug	0		Last Available: "2017-01"
 8812	skewed exploding kickball	0		Last Available: "2017-01"
 8813	wobbly glob of Bat-Glue	0		Last Available: "2017-01"
-8814	squat jittery Bat-Aid&trade; bandage	0		Last Available: "2017-01"
+8814	jittery squat Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	spinning bat-bearing	0		Last Available: "2017-01"
 8816	stale blurry Kudzu salad	3	decent	Last Available: "2016-12"
 8817	diluted green Mansquito Serum	1		Last Available: "2016-12"
@@ -8693,10 +8693,10 @@
 8821	smooth The Mad Liquor	4	awesome	Last Available: "2016-12"
 8822	tolerable Doc Clock's thyme cocktail	3	good	Last Available: "2016-12"
 8823	spoiled Mr. Burnsger	3	crappy	Last Available: "2016-12"
-8824	diluted squat blurry red The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	blinking crafty shellacked padded The Jokester's gun	0		Damage Absorption: +20, Damage Reduction: 7, Maximum MP: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	wizardly The Jokester's wig of wisdom of the sewer	0		Mysticality: 40, Stench Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	blurry Van der Graaf arcane researcher's supercool The Jokester's pants	0		Moxie Percent: +20, Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8824	diluted red blurry squat The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
+8825	blinking crafty shellacked padded The Jokester's gun	0		Damage Absorption: +20, Damage Reduction: 7, Maximum MP: +10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	wizardly The Jokester's wig of wisdom of the sewer	0		Mysticality: 40, Stench Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	blurry Van der Graaf arcane researcher's supercool The Jokester's pants	0		Moxie Percent: +20, Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	pickled deionized quantum Jokester makeup	0		Effect: "Partially Ghosted", Effect Duration: 35, Last Available: "2016-12"
 8829	bouncing replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8719,7 +8719,7 @@
 8847	pickled red-hot jawbreaker	0		Effect: "Lifted Spirits", Effect Duration: 15
 8848	pressed dry huge question juice	0		Effect: "Elemental Flavor", Effect Duration: 20
 8849	energized shaking tube of villain	0		Effect: "Robocamo", Effect Duration: 14
-8850	jittery shellacked your cowboy boots	0		Damage Reduction: 7, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	jittery shellacked your cowboy boots	0		Damage Reduction: 7, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	blinking nugget of thicksilver	0		Last Available: "2016-02"
@@ -8745,10 +8745,10 @@
 8873	experienced Pork 'n' Pork 'n' Pork 'n' Beans	0		Experience: +2, Last Available: "2016-02"
 8874	Jack Frost's Temple Grandin's hardy shellacked Val-U Brand Every Bean Salad of horror	0		Damage Reduction: 7, Maximum HP: +50, Familiar Weight: +7, Cold Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2016-02"
 8875	wobbly ghostly experienced Shrub's Premium Baked Beans of Tarzan of Flo-Jo	0		Experience: +2, Experience (Muscle): +3, Initiative: +100, Last Available: "2016-02"
-8876	special yummy immense plate of Heimz Fortified Kidney Beans	7	awesome	Effect: "Mana Tea", Effect Duration: 50, Last Available: "2016-02"
+8876	yummy immense special plate of Heimz Fortified Kidney Beans	7	awesome	Effect: "Mana Tea", Effect Duration: 50, Last Available: "2016-02"
 8877	stale plate of Tesla's Electroplated Beans	4	decent	Last Available: "2016-02"
-8878	decent immense plate of Mixed Garbanzos and Chickpeas	6	good	Last Available: "2016-02"
-8879	miniature moldy skewed plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
+8878	immense decent plate of Mixed Garbanzos and Chickpeas	6	good	Last Available: "2016-02"
+8879	moldy miniature skewed plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
 8880	adequate bouncing plate of Frigid Northern Beans	3	good	Last Available: "2016-02"
 8881	spoiled twirling plate of World's Blackest-Eyed Peas	4	crappy	Last Available: "2016-02"
 8882	decent plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
@@ -8756,9 +8756,9 @@
 8884	delicious half-sized plate of Val-U Brand Every Bean Salad	2	awesome	Last Available: "2016-02"
 8885	bite-sized adequate plate of Shrub's Premium Baked Beans	1	good	Last Available: "2016-02"
 8886	therapeutic Fancy Jeff's pocket square of the detective	0		Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02"
-8887	blinking rock-hard studded Daisy's unclean bloomers of James Dean	0		Experience (Moxie): +3, Damage Absorption: +80, Damage Reduction: 5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	blinking rock-hard studded Daisy's unclean bloomers of James Dean	0		Experience (Moxie): +3, Damage Absorption: +80, Damage Reduction: 5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	blurry Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	Sherlock's dangerous Amoon-Ra Cowtep's nemes of the detective	0		Weapon Damage: +10, Item Drop: 45, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	Sherlock's dangerous Amoon-Ra Cowtep's nemes of the detective	0		Weapon Damage: +10, Item Drop: 45, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	curative Fonzie's smooth Former Sheriff Dan's tin star of chilblains of the businessman	0		Moxie: +15, Experience (Moxie): +1, Cold Damage: +25, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8766,7 +8766,7 @@
 8894	spinning censurious Jeselnik's beefcake's Granny Hackleton's Gatling gun	0		Muscle: +25, Sleaze Damage: +25, Sleaze Resistance: +3, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
-8897	improved improved blinking mirror poker face paint	0		Effect: "Tiki Temerity", Effect Duration: 42, Last Available: "2016-02"
+8897	improved improved mirror blinking poker face paint	0		Effect: "Tiki Temerity", Effect Duration: 42, Last Available: "2016-02"
 8898	red realistic cap gun	0		Last Available: "2016-02"
 8899	squat tainted milk	1	awesome	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
@@ -8778,10 +8778,10 @@
 8906	magnetized tarnished rattler gland	0		Effect: "Strong Spirit", Effect Duration: 59, Last Available: "2016-02"
 8907	super-denatured blinking half-digested coal	0		Effect: "Florid Cheeks", Effect Duration: 48, Last Available: "2016-02"
 8908	double-modified oxidized tightly-wound spine	0		Effect: "Inebriate Pride", Effect Duration: 14, Last Available: "2016-02"
-8909	yummy fancy rotting beefsteak	4	awesome	Effect: "Saucemastery", Effect Duration: 10, Last Available: "2016-02"
+8909	fancy yummy rotting beefsteak	4	awesome	Effect: "Saucemastery", Effect Duration: 10, Last Available: "2016-02"
 8910	artisanal firemilk	3	EPIC	Last Available: "2016-02"
 8911	Vulcanized concentrated electrified yellow blinking spidercow eye-cluster	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 21, Last Available: "2016-02"
-8912	distilled squat yellow narrow moomy dust	1		Last Available: "2016-02"
+8912	distilled narrow yellow squat moomy dust	1		Last Available: "2016-02"
 8913	personal trainer's weightlifter's western-style skinning knife	0		Muscle: +15, Experience Percent (Muscle): +10, Last Available: "2016-02"
 8914	squat reliable sixgun	0		Last Available: "2016-02"
 8915	healthy steel knuckles	0		Maximum HP Percent: +20, Last Available: "2016-02"
@@ -8801,20 +8801,20 @@
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	triple-moist ionized modified maroon demonic cow's blood	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 52, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
-8932	ghostly yellow makeshift sixgun	0		Last Available: "2016-02"
+8932	yellow ghostly makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	ghostly baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
-8939	bouncing mirror diamondback skin	0		Last Available: "2016-02"
+8939	mirror bouncing diamondback skin	0		Last Available: "2016-02"
 8940	squat coal snakeskin	0		Last Available: "2016-02"
 8941	mirror frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	mirror cyan shuddering cow skull	0		Last Available: "2016-02"
 8944	rhinestone cowhorn	0		Familiar Weight: +5
-8945	yellow squat cow skull	0		Last Available: "2016-02"
+8945	squat yellow cow skull	0		Last Available: "2016-02"
 8946	huge jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
@@ -8822,7 +8822,7 @@
 8950	slicksilver spurs	0		Last Available: "2016-02"
 8951	pulsating sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
-8953	skewed teal ticksilver spurs	0		Last Available: "2016-02"
+8953	teal skewed ticksilver spurs	0		Last Available: "2016-02"
 8954	special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	narrow Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
@@ -8842,13 +8842,13 @@
 8970	toy sixgun	0		
 8971	ghostly snake oil	0		
 8972	super-tarnished adjusted squat skin oil	0		Effect: "Amorous Avarice", Effect Duration: 67
-8973	dry blurry ghostly unusual oil	0		Effect: "Industrial Strength Starch", Effect Duration: 33
+8973	dry ghostly blurry unusual oil	0		Effect: "Industrial Strength Starch", Effect Duration: 33
 8974	diffused unsweetened eldritch oil	0		Effect: "Heart of Green", Effect Duration: 28
 8975	exclusive club	0		
-8976	colloidal pulsating shaking shaking patent preventative tonic	0		Effect: "Space Cowboy", Effect Duration: 38
+8976	colloidal shaking shaking pulsating patent preventative tonic	0		Effect: "Space Cowboy", Effect Duration: 38
 8977	tarnished polymerized ghostly patent invisibility tonic	0		Effect: "Bat Attitude", Effect Duration: 16
 8978	vacuum-sealed patent aggression tonic	0		Effect: "Halloweeny", Effect Duration: 19
-8979	oxidized mirror upside-down patent sallowness tonic	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 45
+8979	oxidized upside-down mirror patent sallowness tonic	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 45
 8980	altered ionized jittery patent avarice tonic	0		Effect: "Patent Alacrity", Effect Duration: 35
 8981	corrupted denatured huge patent alacrity tonic	0		Effect: "Waxing", Effect Duration: 39
 8982	adjusted vacuum-sealed chilled narrow twirling corrupted marrow	0		Effect: "Mystically Oiled", Effect Duration: 23
@@ -8862,17 +8862,17 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	pickled shaking armored prawn	1		Effect: "Hot Jellied", Effect Duration: 15, Last Available: "2016-03"
-8993	half-sized bland jumping horseradish	2	decent	Last Available: "2016-03"
-8994	hand-crafted high-proof Sacramento wine	9	EPIC	Last Available: "2016-03"
+8993	bland half-sized jumping horseradish	2	decent	Last Available: "2016-03"
+8994	high-proof hand-crafted Sacramento wine	9	EPIC	Last Available: "2016-03"
 8995	Vulcanized polarized blinking gray Greek fire	0		Effect: "protect.enq", Effect Duration: 46, Last Available: "2016-03"
 8996	fuchsia pulsating Annie Oakley's razor-sharp ox-head shield of Leguizamo of the sewer of the detective	0		Weapon Damage Percent: +25, Critical Hit Percent: +20, Monster Level: +20, Stench Damage: +25, Item Drop: +20, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	aromatic flame-retardant double-paned Da Vinci's smooth dented scepter	0		Moxie: +15, Experience (Mysticality): +5, Cold Resistance: +5, Hot Resistance: +1, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	frightening mansplainer's clever hale Herculean very pointy crown	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP: +20, Monster Level: +15, Spooky Damage: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	frightening mansplainer's clever hale Herculean very pointy crown	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP: +20, Monster Level: +15, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	greedy clever supercharged educational battle broom of Leguizamo	0		Experience: +1, Maximum MP Percent: +30, Maximum MP: +20, Monster Level: +20, Meat Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	huge smelly clever hardened carpe of Leguizamo	0		Damage Reduction: 3, Maximum MP: +20, Monster Level: +20, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9002	cyan stanky fortified Sinatra's savvy codpiece	0		Mysticality Percent: +20, Experience (Moxie): +5, Damage Absorption: +60, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
-9003	upside-down huge nippy dog trainer's resourceful arcane researcher's troutsers	0		Experience Percent (Mysticality): +10, Maximum MP: +50, Experience (familiar): +1, Cold Damage: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	upside-down huge nippy dog trainer's resourceful arcane researcher's troutsers	0		Experience Percent (Mysticality): +10, Maximum MP: +50, Experience (familiar): +1, Cold Damage: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	family-friendly Van der Graaf occult bass clarinet of the scaredy-cat	0		Spell Damage Percent: +25, Monster Level: -15, Sleaze Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
 9005	wobbly wool hale Socratic thinker's fish hatchet	0		Mysticality: +10, Experience (Mysticality): +1, Maximum HP: +20, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9006	jittery ribald tunac of Gandalf of the overflowing toilet of the early riser	0		Spell Critical Percent: +20, Stench Spell Damage: +50, Sleaze Damage: +10, Adventures: +7, Lasts Until Rollover, Last Available: "2016-04"
@@ -8899,13 +8899,13 @@
 9027	skewed sizzling healthy First Post shirt - Cir Senam of mayonnaise	0		Maximum HP Percent: +20, Hot Damage: +10, Sleaze Spell Damage: +50, Last Available: "2016-05"
 9028	maroon high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	super-sized decent star salad	5	good	
-9031	blurry lime green Thwaitgold moth statuette	0		
-9032	stale small shaking tumbling bowl of Tastee-Wheet&trade;	2	decent	
+9030	decent super-sized star salad	5	good	
+9031	lime green blurry Thwaitgold moth statuette	0		
+9032	stale small tumbling shaking bowl of Tastee-Wheet&trade;	2	decent	
 9033	yellow Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	decent browser cookie	3	good	Last Available: "2016-06"
-9036	perfectly mixed triple-distilled hacked gibson	9	EPIC	Last Available: "2016-06"
+9036	triple-distilled perfectly mixed hacked gibson	9	EPIC	Last Available: "2016-06"
 9037	upside-down dance instructor's Source shades	0		Experience Percent (Moxie): +10, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8948,10 +8948,10 @@
 9076	pulsating inspector's scandalous noir fedora of incineration	0		Hot Spell Damage: +50, Sleaze Damage: +5, Item Drop: +15, Last Available: "2016-07"
 9077	jittery jittery greasy trench coat of doom of the cheetah	0		Spooky Spell Damage: +50, Sleaze Spell Damage: +10, Initiative: +60, Last Available: "2016-07"
 9078	acceptable Falcon&trade; Maltese Liquor	4	good	Last Available: "2016-07"
-9079	half-sized stale hardboiled egg	2	decent	Last Available: "2016-07"
+9079	stale half-sized hardboiled egg	2	decent	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	skewed spinning up-at-dawn nippy Sinatra's beefy protonic accelerator pack of the storm of Leguizamo	0		Muscle: +10, Experience (Moxie): +5, Maximum MP Percent: +40, Monster Level: +20, Cold Damage: +10, Adventures: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	skewed spinning up-at-dawn nippy Sinatra's beefy protonic accelerator pack of the storm of Leguizamo	0		Muscle: +10, Experience (Moxie): +5, Maximum MP Percent: +40, Monster Level: +20, Cold Damage: +10, Adventures: +5, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	lime green mirror squat frightening Adventurer bobblehead	0		Spooky Damage: +5, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	ghostly gravedigger's Mr. Screege's spectacles	0		Spooky Damage: +10, Single Equip, Last Available: "2016-08"
 9092	lard-coated gravedigger's nasty Spookyraven signet	0		Stench Damage: +5, Spooky Damage: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2016-08"
 9093	forbidden strapping tie-dyed fannypack	0		Muscle: +5, Spell Damage Percent: +50, Single Equip, Last Available: "2016-08"
-9094	foul-smelling burnt snowpants of Leguizamo	0		Monster Level: +20, Stench Damage: +10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	fuchsia sizzling standards and practices guide	0		Hot Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	foul-smelling burnt snowpants of Leguizamo	0		Monster Level: +20, Stench Damage: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	fuchsia sizzling standards and practices guide	0		Hot Damage: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	zippy rock-hard smooth Carpathian longsword	0		Moxie: +15, Damage Reduction: 5, Initiative: +20, Last Available: "2016-08"
 9097	upside-down upside-down Usain Bolt's Liam's mail of the wise owl of the cheetah	0		Mysticality: +20, Initiative: 140, Last Available: "2016-08"
 9098	twirling frightening crafty weightlifter's Unfortunato's foolscap	0		Muscle: +15, Maximum MP: +10, Spooky Damage: +5, Last Available: "2016-08"
@@ -8983,7 +8983,7 @@
 9111	polarized jittery Lucky Strikes holo-record	0		Effect: "Holiday Disappointment", Effect Duration: 19
 9112	concentrated unsweetened lime green EMD holo-record	0		Effect: "Going Ape", Effect Duration: 59
 9113	alkaline Superdrifter holo-record	0		Effect: "Blubbered Up", Effect Duration: 39
-9114	unsweetened jittery olive The Pigs holo-record	0		Effect: "Paging Betty", Effect Duration: 27
+9114	unsweetened olive jittery The Pigs holo-record	0		Effect: "Paging Betty", Effect Duration: 27
 9115	deionized corrupted Drunk Uncles holo-record	0		Effect: "Knightlife", Effect Duration: 25
 9116	time residue	0		Last Available: "2016-09"
 9117	gravedigger's repaid diaper	0		Spooky Damage: +10
@@ -9004,32 +9004,32 @@
 9132	pulsating Usain Bolt's Da Vinci's pistol	0		Experience (Mysticality): +5, Initiative: +80
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	decent bite-sized blurry leftover pasty	1	good	
-9135	drinkable irresponsibly strong very whiskey	9	good	
+9135	irresponsibly strong drinkable very whiskey	9	good	
 9136	maroon li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	maroon li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	maroon li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	dry hoarded candy wad	0		Effect: "Macho, Macho Dog", Effect Duration: 22, Last Available: "2016-10"
 9147	corrupted ghostly Prunets	0		Effect: "Pisces Rising", Effect Duration: 51
-9148	lime green blurry Twitching Television Tattoo	0		
+9148	blurry lime green Twitching Television Tattoo	0		
 9149	mirror baby scorpion	0		Familiar Weight: +10
 9150	wet invisible string	0		Lasts Until Rollover, Effect: "What's That Smell?", Effect Duration: 20, Last Available: "2016-10"
 9151	altered skewed invisible seam ripper	0		Lasts Until Rollover, Effect: "Full of Wist", Effect Duration: 27, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	spoiled raw sweet potato	4	crappy	Last Available: "2016-11"
-9154	tiny normal raw beans	1	good	Last Available: "2016-11"
-9155	bland small enchanted raw stuffing	2	decent	Effect: "In the Slimelight", Effect Duration: 45, Last Available: "2016-11"
+9154	normal tiny raw beans	1	good	Last Available: "2016-11"
+9155	enchanted bland small raw stuffing	2	decent	Effect: "In the Slimelight", Effect Duration: 45, Last Available: "2016-11"
 9156	toothsome raw cranberry sauce	3	awesome	Last Available: "2016-11"
-9157	tasty immense raw turkey	8	awesome	Last Available: "2016-11"
+9157	immense tasty raw turkey	8	awesome	Last Available: "2016-11"
 9158	rotten raw mincemeat	4	crappy	Last Available: "2016-11"
-9159	small stale red raw potato	2	decent	Last Available: "2016-11"
-9160	small stale fancy raw gravy	2	decent	Effect: "Outer Wolf&trade;", Effect Duration: 5, Last Available: "2016-11"
+9159	stale small red raw potato	2	decent	Last Available: "2016-11"
+9160	fancy small stale raw gravy	2	decent	Effect: "Outer Wolf&trade;", Effect Duration: 5, Last Available: "2016-11"
 9161	low-calorie normal raw bread	1	good	Last Available: "2016-11"
 9162	smelly mini-marshmallow dispenser of the dark arts	0		Spell Damage Percent: +100, Stench Spell Damage: +10, Last Available: "2016-11"
 9163	mirror dangerous brainy glass casserole dish of the detective	0		Mysticality: +5, Weapon Damage: +10, Item Drop: +20, Last Available: "2016-11"
@@ -9050,7 +9050,7 @@
 9178	bland big twirling warm gravy	5	decent	Last Available: "2016-11"
 9179	flavorless bread roll	4	decent	Last Available: "2016-11"
 9180	stale bite-sized leftovers	1	decent	Last Available: "2016-11"
-9181	half-sized adequate leftovers sandwich	2	good	Last Available: "2016-11"
+9181	adequate half-sized leftovers sandwich	2	good	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	blurry megacopia	0		Last Available: "2016-11"
@@ -9063,7 +9063,7 @@
 9191	Vulcanized wobbly eldritch concentrate	0		Effect: "Simulation Stimulation", Effect Duration: 65, Last Available: "2016-11"
 9192	hand-crafted eldritch extract	4	EPIC	Last Available: "2016-11"
 9193	reassuring brawny Official Council Aide Pin	0		Muscle Percent: +20, Spooky Resistance: +1, Last Available: "2016-11"
-9194	weak artisanal eldritch distillate	2	EPIC	Last Available: "2016-11"
+9194	artisanal weak eldritch distillate	2	EPIC	Last Available: "2016-11"
 9195	mixed eldritch essence	1		Last Available: "2016-11"
 9196	curative Science Notebook	0		HP Regen Min: 3, HP Regen Max: 5
 9197	stanky Temple Grandin's eldritch hat of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +7, Stench Spell Damage: +25, Last Available: "2016-11"
@@ -9084,16 +9084,16 @@
 9212	padded arcane researcher's candy dress shoes of dire peril	0		Experience Percent (Mysticality): +10, Weapon Damage: +20, Damage Absorption: +20, Single Equip, Last Available: "2016-12"
 9213	prompt energetic studded candy necktie	0		Damage Absorption: +80, Maximum MP Percent: +20, Adventures: +3, Single Equip, Last Available: "2016-12"
 9214	ghostly chilly electrified sinister chocolate pocketwatch	0		Spell Damage: +10, Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-12"
-9215	blurry spinning broken chocolate pocketwatch	0		Last Available: "2016-12"
-9216	teal mirror blurry interesting clod of dirt	0		
+9215	spinning blurry broken chocolate pocketwatch	0		Last Available: "2016-12"
+9216	blurry teal mirror interesting clod of dirt	0		
 9217	huge gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	bland immense animal part cracker	10	decent	Last Available: "2016-12"
-9220	weak perfectly mixed gingerbread wine	2	EPIC	Last Available: "2016-12"
+9219	immense bland animal part cracker	10	decent	Last Available: "2016-12"
+9220	perfectly mixed weak gingerbread wine	2	EPIC	Last Available: "2016-12"
 9221	adequate immense narrow gingerbread mug	10	good	Last Available: "2016-12"
 9222	thinker's gingerbread mask	0		Mysticality: +10, Last Available: "2016-12"
 9223	double-paned horrifying vibrating gingerservo	0		Maximum MP Percent: +10, Spooky Damage: +25, Cold Resistance: +5, Single Equip, Last Available: "2016-12"
-9224	cold-filtered dry fuchsia upside-down tainted icing	0		Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2016-12"
+9224	cold-filtered dry upside-down fuchsia tainted icing	0		Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2016-12"
 9225	strapping gingerbeard	0		Muscle: +5, Single Equip, Last Available: "2016-12"
 9226	gingerbread smartphone	0		Last Available: "2016-12"
 9227	sharpshooter's gingerbread hoodie of the early riser	0		Critical Hit Percent: +10, Adventures: +7, Sprinkle Drop: +15, Last Available: "2016-12"
@@ -9110,7 +9110,7 @@
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	tolerable ginger beer	3	good	Last Available: "2016-12"
 9240	pulsating spare chocolate parts	0		Last Available: "2016-12"
-9241	wet gray twirling industrial frosting	0		Effect: "Covetous Robbery", Effect Duration: 64, Last Available: "2016-12"
+9241	wet twirling gray industrial frosting	0		Effect: "Covetous Robbery", Effect Duration: 64, Last Available: "2016-12"
 9242	electrified fake cocktail	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 65, Last Available: "2016-12"
 9243	mediocre high-end ginger wine	3	decent	Last Available: "2016-12"
 9244	twirling plastic bad vibe of the pedagogue	0		Experience: +3, Last Available: "2016-12"
@@ -9118,7 +9118,7 @@
 9246	plastic Knows About Chakras of Tarzan	0		Experience (Muscle): +3, Last Available: "2016-12"
 9247	blinking healthy plastic Your Brain	0		Maximum HP Percent: +20, Last Available: "2016-12"
 9248	zippy plastic Krampus	0		Initiative: +20, Last Available: "2016-12"
-9249	concentrated quantum purple blinking jittery squat Inner Wisdom	0		Effect: "Incensed", Effect Duration: 21, Last Available: "2016-12"
+9249	concentrated quantum squat purple jittery blinking Inner Wisdom	0		Effect: "Incensed", Effect Duration: 21, Last Available: "2016-12"
 9250	Vulcanized shaking Inner Strength	0		Effect: "Hammertime", Effect Duration: 39, Last Available: "2016-12"
 9251	alkaline Inner Truth	0		Effect: "Ticking Clock", Effect Duration: 46, Last Available: "2016-12"
 9252	rotten snack-sized spiritual candy cane	2	crappy	Last Available: "2016-12"
@@ -9132,11 +9132,11 @@
 9260	spinning No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
-9263	red huge gingerbread blackmail photos	0		Last Available: "2016-12"
+9263	huge red gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	flattened rock candy	0		Effect: "Yuletide Mutations", Effect Duration: 42, Last Available: "2016-12"
-9267	stale huge green-iced sweet roll	10	decent	Last Available: "2016-12"
+9267	huge stale green-iced sweet roll	10	decent	Last Available: "2016-12"
 9268	jittery sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	negative lump	0		
 9273	pulsating prompt reassuring Third Eye	0		Spooky Resistance: +1, Adventures: +3, Last Available: "2016-12"
 9274	Tesla occult Krampus Horn	0		Spell Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2016-12"
-9275	toothsome bite-sized hambrosier	1	awesome	Last Available: "2016-12"
+9275	bite-sized toothsome hambrosier	1	awesome	Last Available: "2016-12"
 9276	acceptable chakra-mental wine	3	good	Last Available: "2016-12"
 9277	ionized diffused teal chakra malt	0		Effect: "Work For Hours a Week", Effect Duration: 66, Last Available: "2016-12"
-9278	miniature decent twirling Black Angus blackburger	2	good	Last Available: "2016-12"
-9279	spirit-forward hand-crafted brandy	5	EPIC	Last Available: "2016-12"
+9278	decent miniature twirling Black Angus blackburger	2	good	Last Available: "2016-12"
+9279	hand-crafted spirit-forward brandy	5	EPIC	Last Available: "2016-12"
 9280	enhanced polarized potion of spiritual gunkifying	0		Effect: "Super-Mega-Charged", Effect Duration: 62, Last Available: "2016-12"
 9281	rosy-cheeked Newton's bad vibroknife	0		Experience (Mysticality): +3, Maximum HP Percent: +30, Last Available: "2016-12"
 9282	blurry ghostly groovy crystal belt buckle of the scaredy-cat	0		Moxie Percent: +10, Monster Level: -15, Last Available: "2016-12"
@@ -9159,18 +9159,18 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	skewed gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	cyan ribald MacGyver's boxer's Uncle Crimbo's hat	0		Muscle Percent: +10, Maximum MP: +100, Sleaze Damage: +10, Last Available: "2016-12"
-9290	adequate upside-down bouncing Eldritch snap	3	good	Last Available: "2017-01"
+9290	adequate bouncing upside-down Eldritch snap	3	good	Last Available: "2017-01"
 9291	dehydrated hot jelly	1		Effect: "Goldentongue", Effect Duration: 25, Last Available: "2017-01"
 9292	twisted upside-down jelly	1		Effect: "On the Trolley", Effect Duration: 10, Last Available: "2017-01"
 9293	pickled jelly	1		Effect: "Strong Grip", Effect Duration: 30, Last Available: "2017-01"
 9294	altered mirror sleaze jelly	1		Last Available: "2017-01"
-9295	dried spinning bouncing yellow stench jelly	1		Last Available: "2017-01"
+9295	dried yellow spinning bouncing stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	jumbo bland bouncing narrow toast with hot jelly	5	decent	Last Available: "2017-01"
+9297	jumbo bland narrow bouncing toast with hot jelly	5	decent	Last Available: "2017-01"
 9298	rotten blinking toast with jelly	3	crappy	Last Available: "2017-01"
 9299	massive moldy ghostly toast with jelly	7	crappy	Last Available: "2017-01"
-9300	jumbo flavorless huge toast with sleaze jelly	5	decent	Last Available: "2017-01"
-9301	normal massive toast with stench jelly	6	good	Last Available: "2017-01"
+9300	flavorless jumbo huge toast with sleaze jelly	5	decent	Last Available: "2017-01"
+9301	massive normal toast with stench jelly	6	good	Last Available: "2017-01"
 9302	bouncing space jellybicycle	0		Familiar Weight: +5
 9303	yellow hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9178,7 +9178,7 @@
 9306	mirror Sherlock's baleful candle	0		Spell Damage: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2017-01"
 9307	small rotten blinking wax pancake	2	crappy	Last Available: "2017-01"
 9308	nippy wax face of the ox	0		Muscle: +20, Cold Damage: +10, Last Available: "2017-01"
-9309	acceptable distilled wax booze	5	good	Last Available: "2017-01"
+9309	distilled acceptable wax booze	5	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	compressed sea jelly	1		Last Available: "2017-01"
 9312	tasty tumbling sea truffle	4	awesome	Last Available: "2017-01"
@@ -9241,54 +9241,54 @@
 9369	artisanal mentholated wine	3	EPIC	Last Available: "2017-03"
 9370	artisanal watered-down low tide martini	2	EPIC	Last Available: "2017-03"
 9371	bad shroomtini	4	decent	Last Available: "2017-03"
-9372	watered-down hand-crafted upside-down morning dew	2	EPIC	Last Available: "2017-03"
+9372	hand-crafted watered-down upside-down morning dew	2	EPIC	Last Available: "2017-03"
 9373	spirit-forward aged whiskey squeeze	5	awesome	Last Available: "2017-03"
-9374	special smooth watered-down jittery great fashioned	2	awesome	Effect: "Ghost Finger", Effect Duration: 45, Last Available: "2017-03"
-9375	watered-down artisanal Gnomish sagngria	2	EPIC	Last Available: "2017-03"
+9374	watered-down special smooth jittery great fashioned	2	awesome	Effect: "Ghost Finger", Effect Duration: 45, Last Available: "2017-03"
+9375	artisanal watered-down Gnomish sagngria	2	EPIC	Last Available: "2017-03"
 9376	watered-down artisanal vodka stinger	2	EPIC	Last Available: "2017-03"
-9377	weak artisanal extremely slippery nipple	2	EPIC	Last Available: "2017-03"
+9377	artisanal weak extremely slippery nipple	2	EPIC	Last Available: "2017-03"
 9378	bad practically non-alcoholic squat piscatini	1	decent	Last Available: "2017-03"
 9379	artisanal Churchill	3	EPIC	Last Available: "2017-03"
 9380	hand-crafted watered-down ghostly soilzerac	2	EPIC	Last Available: "2017-03"
-9381	drinkable watered-down London frog	2	good	Last Available: "2017-03"
-9382	extra-dry mediocre nothingtini	5	decent	Last Available: "2017-03"
+9381	watered-down drinkable London frog	2	good	Last Available: "2017-03"
+9382	mediocre extra-dry nothingtini	5	decent	Last Available: "2017-03"
 9383	smooth eighth plague	4	awesome	Last Available: "2017-03"
 9384	drinkable weak single entendre	2	good	Last Available: "2017-03"
-9385	fortified delicious blurry reverse Tantalus	5	awesome	Last Available: "2017-03"
+9385	delicious fortified blurry reverse Tantalus	5	awesome	Last Available: "2017-03"
 9386	drinkable elemental caipiroska	4	good	Last Available: "2017-03"
 9387	hand-crafted Feliz Navidad	3	EPIC	Last Available: "2017-03"
-9388	tolerable practically non-alcoholic blinking Bloody Nora	1	good	Last Available: "2017-03"
+9388	practically non-alcoholic tolerable blinking Bloody Nora	1	good	Last Available: "2017-03"
 9389	bad moreltini	3	decent	Last Available: "2017-03"
 9390	tolerable hell in a bucket	3	good	Last Available: "2017-03"
 9391	aged spinning Newark	3	awesome	Last Available: "2017-03"
-9392	bad watered-down R'lyeh	2	decent	Last Available: "2017-03"
+9392	watered-down bad R'lyeh	2	decent	Last Available: "2017-03"
 9393	perfectly mixed upside-down Gnollish sangria	4	EPIC	Last Available: "2017-03"
 9394	smooth pulsating vodka barracuda	4	awesome	Last Available: "2017-03"
 9395	acceptable Mysterious Island iced tea	3	good	Last Available: "2017-03"
 9396	delicious blinking drive-by shooting	3	awesome	Last Available: "2017-03"
 9397	perfectly mixed gunner's daughter	3	EPIC	Last Available: "2017-03"
-9398	high-proof mediocre olive dirt julep	6	decent	Last Available: "2017-03"
-9399	enchanted watered-down tolerable skewed Simepore slime	2	good	Effect: "Inebriate Pride", Effect Duration: 50, Last Available: "2017-03"
-9400	tolerable high-proof Phil Collins	6	good	Last Available: "2017-03"
+9398	mediocre high-proof olive dirt julep	6	decent	Last Available: "2017-03"
+9399	tolerable enchanted watered-down skewed Simepore slime	2	good	Effect: "Inebriate Pride", Effect Duration: 50, Last Available: "2017-03"
+9400	high-proof tolerable Phil Collins	6	good	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	lime green shaking toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
-9406	squat maroon exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
+9406	maroon squat exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	red rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9409	squat spinning high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9409	spinning squat high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	tumbling Spacegate Research	0		Last Available: "2017-04"
 9411	bouncing alien rock sample	0		Last Available: "2017-04"
 9412	tumbling alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	spinning botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	normal miniature jittery edible alien plant bit	2	good	Last Available: "2017-04"
+9415	miniature normal jittery edible alien plant bit	2	good	Last Available: "2017-04"
 9416	skewed alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
-9419	mirror shaking fascinating alien plant sample	0		Last Available: "2017-04"
+9419	shaking mirror fascinating alien plant sample	0		Last Available: "2017-04"
 9420	powdered alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	extra-dry unsweetened alien medicine	0		Effect: "Thunderheart", Effect Duration: 34, Last Available: "2017-04"
-9433	yummy low-calorie alien salad	1	awesome	Last Available: "2017-04"
+9433	low-calorie yummy alien salad	1	awesome	Last Available: "2017-04"
 9434	perfectly mixed high-proof skewed spinning alien booze	7	EPIC	Last Available: "2017-04"
 9435	zippy foul-smelling alien mask of horror	0		Stench Damage: +10, Spooky Spell Damage: +25, Initiative: +20, Last Available: "2017-04"
 9436	smelly frosty veiny alien spear	0		Maximum HP: +10, Cold Spell Damage: +10, Stench Spell Damage: +10, Last Available: "2017-04"
@@ -9325,18 +9325,18 @@
 9453	forbidden wicked weightlifter's murderbot mask	0		Muscle: +15, Spell Damage: +5, Spell Damage Percent: +50, Avatar: "Murderbot", Last Available: "2017-04"
 9454	galvanized energized murderbot spring injector	0		Effect: "Dreadful Fear", Effect Duration: 13, Last Available: "2017-04"
 9455	narrow frightening murderbot whip of terror	0		Spooky Damage: +5, Spooky Spell Damage: +10, Last Available: "2017-04"
-9456	bouncing chilly Lo Pan's murderbot plasma rifle	0		Spell Critical Percent: +30, Cold Damage: +5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	bouncing chilly Lo Pan's murderbot plasma rifle	0		Spell Critical Percent: +30, Cold Damage: +5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	pulsating murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	blinking twirling Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
-9461	blinking blurry Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
+9461	blurry blinking Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	fuchsia tumbling jittery Procrastinator locker key	0		Last Available: "2017-04"
 9463	pulsating Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	mirror Spacegate	0		Last Available: "2017-04"
-9466	yummy big Aldebaran sardines	5	awesome	Last Available: "2017-04"
-9467	mediocre fortified Centauri fish wine	5	decent	Last Available: "2017-04"
+9466	big yummy Aldebaran sardines	5	awesome	Last Available: "2017-04"
+9467	fortified mediocre Centauri fish wine	5	decent	Last Available: "2017-04"
 9468	powdered oxygen	1		Last Available: "2017-04"
 9469	frightening healthy Spacegate scientist's insignia	0		Maximum HP Percent: +20, Spooky Damage: +5, Single Equip, Last Available: "2017-04"
 9470	green up-at-dawn veiny Spacegate military insignia	0		Maximum HP: +10, Adventures: +5, Single Equip, Last Available: "2017-04"
@@ -9355,17 +9355,17 @@
 9483	boiled olive Daily Affirmation: Be a Mind Master	0		Effect: "Egged On", Effect Duration: 42, Last Available: "2017-05"
 9484	extra-altered adjusted tumbling Daily Affirmation: Work For Hours a Week	0		Effect: "5 Pounds Lighter", Effect Duration: 25, Last Available: "2017-05"
 9485	irradiated cyan Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Stench Jellied", Effect Duration: 14, Last Available: "2017-05"
-9486	flavorless immense yellow Affirmation Cookie	10	decent	Last Available: "2017-05"
+9486	immense flavorless yellow Affirmation Cookie	10	decent	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	gray Thwaitgold bug statuette	0		
 9489	gray Victor's Spoils	0		
 9490	super-aerosolized ionized upside-down Threatening Missive	0		Effect: "Dancing Prowess", Effect Duration: 26
 9491	Targeted Plague Vector	0		
 9492	ghostly pulsating suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	stanky chilly hale Kremlin's Greatest Briefcase	0		Maximum HP: +20, Cold Damage: +5, Stench Spell Damage: +25, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	mediocre watered-down basic martini	2	decent	Last Available: "2017-06"
-9495	extra-dry delicious fancy improved martini	5	awesome	Effect: "Egg on your Face", Effect Duration: 10, Last Available: "2017-06"
-9496	fancy acceptable tumbling splendid martini	3	good	Effect: "Thicker, Sicker", Effect Duration: 50, Last Available: "2017-06"
+9493	stanky chilly hale Kremlin's Greatest Briefcase	0		Maximum HP: +20, Cold Damage: +5, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	watered-down mediocre basic martini	2	decent	Last Available: "2017-06"
+9495	fancy delicious extra-dry improved martini	5	awesome	Effect: "Egg on your Face", Effect Duration: 10, Last Available: "2017-06"
+9496	acceptable fancy tumbling splendid martini	3	good	Effect: "Thicker, Sicker", Effect Duration: 50, Last Available: "2017-06"
 9497	jittery exploding cigar	0		Last Available: "2017-06"
 9498	ghostly can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9382,13 +9382,13 @@
 9510	Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
-9513	fuchsia shaking Meteorite-Ade	0		Last Available: "2017-08"
-9514	huge flavorless meteoreo	6	decent	Last Available: "2017-08"
+9513	shaking fuchsia Meteorite-Ade	0		Last Available: "2017-08"
+9514	flavorless huge meteoreo	6	decent	Last Available: "2017-08"
 9515	hand-crafted weak tumbling meadeorite	2	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	coward's cool meteortarboard of extreme caution	0		Moxie: +5, Monster Level: -45, Last Available: "2017-08"
 9518	Van der Graaf boxer's meteorite guard of the storm	0		Muscle Percent: +10, Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 9, Last Available: "2017-08"
-9519	mansplainer's Lo Pan's meteorb	0		Spell Critical Percent: +30, Monster Level: +15, Lantern Element: "Hot", Last Available: "2017-08"
+9519	mansplainer's Lo Pan's meteorb	0		Spell Critical Percent: +30, Monster Level: +15, Last Available: "2017-08", Lantern Element: "Hot"
 9520	frightening asteroid belt of the detective	0		Spooky Damage: +5, Item Drop: +20, Single Equip, Last Available: "2017-08"
 9521	chaotic quilted weightlifter's meteorthopedic shoes	0		Muscle: +15, Damage Absorption: +40, Spell Critical Percent: +10, Single Equip, Last Available: "2017-08"
 9522	zippy clever shooting morning star of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Initiative: +20, Single Equip, Last Available: "2017-08"
@@ -9414,13 +9414,13 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	squat X	0		Last Available: "2017-10"
 9544	pulsating O	0		Last Available: "2017-10"
-9545	hand-crafted boozy twirling maroon DUFRESNE Suds	5	EPIC	Last Available: "2017-09"
+9545	hand-crafted boozy maroon twirling DUFRESNE Suds	5	EPIC	Last Available: "2017-09"
 9546	up-at-dawn flame-wreathed mafia pinky ring	0		Hot Spell Damage: +10, Adventures: +5, Single Equip
-9547	lousy watered-down flask of port	2	decent	
+9547	watered-down lousy flask of port	2	decent	
 9548	shaking banded stylish contract enforcement stick	0		Moxie: +25, Damage Absorption: +100
 9549	bland Hide-rox&trade; cookie	4	decent	Last Available: "2017-10"
 9550	practically non-alcoholic tolerable blurry jug of booze	1	good	Last Available: "2017-10"
-9551	pickled warmed modified bouncing upside-down blurry pair of candy glasses	0		Effect: "You Know Who to Call", Effect Duration: 36, Last Available: "2017-10"
+9551	pickled warmed modified bouncing blurry upside-down pair of candy glasses	0		Effect: "You Know Who to Call", Effect Duration: 36, Last Available: "2017-10"
 9552	moist tumbling temporary X tattoos	0		Effect: "Educated (Kinda)", Effect Duration: 59, Last Available: "2017-10"
 9553	dehydrated glyph of athleticism	1		Last Available: "2017-10"
 9554	spinning pair of scissors	0		Last Available: "2017-10"
@@ -9448,12 +9448,12 @@
 9576	cyan smartaleck's mafia organizer badge	0		Moxie Percent: +30, Single Equip
 9577	mafia filofax	0		
 9578	transparent nog	1	decent	Last Available: "2017-12"
-9579	moldy miniature twirling unfinished fruitcake	2	crappy	Last Available: "2017-12"
+9579	miniature moldy twirling unfinished fruitcake	2	crappy	Last Available: "2017-12"
 9580	concentrated non-aerosolized maroon and cracker	0		Effect: "Litterboxing", Effect Duration: 48, Last Available: "2017-12"
-9581	weak artisanal shaking ghostly neg grog	2	EPIC	Last Available: "2017-12"
+9581	artisanal weak shaking ghostly neg grog	2	EPIC	Last Available: "2017-12"
 9582	adequate blinking half double fruitcake	3	good	Last Available: "2017-12"
-9583	toothsome special half-sized hushed puppy	2	awesome	Effect: "In Tuna", Effect Duration: 35, Last Available: "2017-12"
-9584	super-sized enchanted decent muffled muffuletta	5	good	Effect: "Transcendental Wind", Effect Duration: 5, Last Available: "2017-12"
+9583	special half-sized toothsome hushed puppy	2	awesome	Effect: "In Tuna", Effect Duration: 35, Last Available: "2017-12"
+9584	decent super-sized enchanted muffled muffuletta	5	good	Effect: "Transcendental Wind", Effect Duration: 5, Last Available: "2017-12"
 9585	spoiled shushed potatoes	3	crappy	Last Available: "2017-12"
 9586	plastic mime functionary of the ox	0		Muscle: +20, Last Available: "2017-12"
 9587	blurry boxer's plastic mime scientist	0		Muscle Percent: +10, Last Available: "2017-12"
@@ -9462,12 +9462,12 @@
 9590	skewed plastic The Silent Nightmare of the brute	0		Muscle Percent: +30, Last Available: "2017-12"
 9591	narrow locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	jittery mumming trunk	0		Last Available: "2017-12"
-9593	pulsating squat temperance whiskey	1	crappy	Last Available: "2017-11"
+9593	squat pulsating temperance whiskey	1	crappy	Last Available: "2017-11"
 9594	unsweetened colloidal wishbone	0		Effect: "Memories of Puppy Love", Effect Duration: 24, Last Available: "2017-11"
 9595	tolerable practically non-alcoholic Racisto Ruidoso	1	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	diet bland yellow bran muffin	1	decent	
-9598	special spoiled snack-sized blueberry muffin	2	crappy	Effect: "How to Scam Tourists", Effect Duration: 50
+9598	spoiled special snack-sized blueberry muffin	2	crappy	Effect: "How to Scam Tourists", Effect Duration: 50
 9599	tumbling cyan silent A	0		Last Available: "2017-12"
 9600	blue silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9488,7 +9488,7 @@
 9616	tumbling silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
-9619	olive tumbling silent U	0		Last Available: "2017-12"
+9619	tumbling olive silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
@@ -9512,17 +9512,17 @@
 9640	bouncing The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9642	blue The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9643	lime green shaking The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
-9644	maroon twirling The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
+9643	shaking lime green The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
+9644	twirling maroon The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	huge The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	blinking The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	huge mime eraser	0		Last Available: "2017-12"
 9648	high-proof drinkable executive mime flask	6	good	Last Available: "2017-12"
 9649	decent nega-mushroom	3	good	Last Available: "2017-12"
 9650	smooth nega-mushroom wine	4	awesome	Last Available: "2017-12"
-9651	Vulcanized ghostly red Cheer-Up soda	0		Effect: "Thickest, Sickest", Effect Duration: 69, Last Available: "2017-12"
+9651	Vulcanized red ghostly Cheer-Up soda	0		Effect: "Thickest, Sickest", Effect Duration: 69, Last Available: "2017-12"
 9652	adequate mime army rations	4	good	Last Available: "2017-12"
-9653	watered-down hand-crafted mime army wine	2	super ultra mega turbo EPIC	Last Available: "2017-12"
+9653	hand-crafted watered-down mime army wine	2	super ultra mega turbo EPIC	Last Available: "2017-12"
 9654	diluted spinning mime army superserum	1		Effect: "Shamboozled", Effect Duration: 25, Last Available: "2017-12"
 9655	triple-cold-filtered jittery mime army camouflage kit	0		Effect: "Thought", Effect Duration: 52, Last Available: "2017-12"
 9656	shaking occult miming beret of Leguizamo	0		Spell Damage Percent: +25, Monster Level: +20, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	electrified cold-filtered digital honeypot	0		Effect: "Elemental Flavor", Effect Duration: 56, Last Available: "2025-12"
 9666	cyan mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	flame-wreathed mime army insignia (infantry)	0		Hot Spell Damage: +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	smooth mime army insignia (intelligence)	0		Moxie: +15, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	executive mime army insignia (espionage)	0		Meat Drop: +40, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	flame-wreathed mime army insignia (infantry)	0		Hot Spell Damage: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	smooth mime army insignia (intelligence)	0		Moxie: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	executive mime army insignia (espionage)	0		Meat Drop: +40, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	tumbling mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9548,10 +9548,10 @@
 9676	mime army shotglass	0		Last Available: "2017-12"
 9677	mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
-9679	green upside-down kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
-9680	pulsating blurry fireproof skip lid	0		Familiar Weight: +5
-9681	diet moldy pulsating extra-toasted half sandwich	1	crappy	Last Available: "2018-12"
-9682	special tolerable pulsating mulled hobo wine	3	good	Effect: "Dirty Pear", Effect Duration: 25, Last Available: "2018-12"
+9679	upside-down green kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
+9680	blurry pulsating fireproof skip lid	0		Familiar Weight: +5
+9681	moldy diet pulsating extra-toasted half sandwich	1	crappy	Last Available: "2018-12"
+9682	tolerable special pulsating mulled hobo wine	3	good	Effect: "Dirty Pear", Effect Duration: 25, Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	Socratic smartaleck's brainy burning paper hat	0		Mysticality: +5, Moxie Percent: +30, Experience (Mysticality): +1, Lasts Until Rollover, Last Available: "2018-12"
 9685	nippy veiny groovy burning cape	0		Moxie Percent: +10, Maximum HP: +10, Cold Damage: +10, Lasts Until Rollover, Last Available: "2018-12"
@@ -9575,7 +9575,7 @@
 9703	twisted blurry beefy pill	1		
 9704	twisted upside-down excitement pill	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10
 9705	denatured squat vitamin G pill	1		
-9706	mixed upside-down red lucky-ish pill	1		
+9706	mixed red upside-down lucky-ish pill	1		
 9707	diluted pulsating dieting pill	1		Effect: "Frisky Spirit", Effect Duration: 15
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
@@ -9594,29 +9594,29 @@
 9726	yellow manspreader's psychic's amulet of Gandalf	0		Spell Critical Percent: +20, Monster Level: +10, Last Available: "2018-02"
 9727	stale heart-shaped candy whetstone	4	decent	Last Available: "2018-02"
 9728	rotten gigantic Swedish massage fish	10	crappy	Last Available: "2018-02"
-9729	weak aged Third Base	2	awesome	Last Available: "2018-02"
-9730	strong delicious twirling Bustle Hustler	5	awesome	Last Available: "2018-02"
+9729	aged weak Third Base	2	awesome	Last Available: "2018-02"
+9730	delicious strong twirling Bustle Hustler	5	awesome	Last Available: "2018-02"
 9731	triple-energized anodized Fabiotion	0		Effect: "Stuck-Up Hair", Effect Duration: 20, Last Available: "2018-02"
 9732	frozen Bettie page	0		Effect: "Litterboxing", Effect Duration: 45, Last Available: "2018-02"
 9733	dry bouncing green tonic o' Banderas	0		Effect: "Cool, Catlike", Effect Duration: 51, Last Available: "2018-02"
 9734	polymerized ionized heather graham cracker	0		Effect: "Unrunnable Face", Effect Duration: 19, Last Available: "2018-02"
 9735	upside-down Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
-9737	bouncing pulsating eaves droppers	0		Last Available: "2018-02"
+9737	pulsating bouncing eaves droppers	0		Last Available: "2018-02"
 9738	blurry personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	Mysterious Black Box	0		Last Available: "2018-02"
-9743	polarized extra-liquefied unsweetened cyan upside-down rainbow jellybean	0		Effect: "Become Intensely interested", Effect Duration: 28
+9743	polarized extra-liquefied unsweetened upside-down cyan rainbow jellybean	0		Effect: "Become Intensely interested", Effect Duration: 28
 9744	diffused moist mystery lollipop	0		Effect: "Afternoon Insight", Effect Duration: 41
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	boiled tarnished spinning rhinestone	0		Effect: "Stimulated Body", Effect Duration: 13
 9747	blinking 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	riboflavin	0		
-9750	spinning maroon bronze	0		
-9751	ghostly wobbly piracetam	0		
+9750	maroon spinning bronze	0		
+9751	wobbly ghostly piracetam	0		
 9752	ultracalcium	0		
 9753	ginseng	0		
 9754	Team Avarice cap of Tarzan	0		Experience (Muscle): +3
@@ -9636,7 +9636,7 @@
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
 9770	maroon Carpricorn	0		Last Available: "2018-03"
-9771	teal bouncing Turpin	0		Last Available: "2018-03"
+9771	bouncing teal Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
 9773	wobbly Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
@@ -9651,8 +9651,8 @@
 9783	bouncing Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
-9786	wobbly jittery Flan	0		Last Available: "2018-03"
-9787	ghostly blurry Mustardigrade	0		Last Available: "2018-03"
+9786	jittery wobbly Flan	0		Last Available: "2018-03"
+9787	blurry ghostly Mustardigrade	0		Last Available: "2018-03"
 9788	jittery Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
@@ -9661,7 +9661,7 @@
 9793	Wullabye	0		Last Available: "2018-03"
 9794	upside-down shaking Nursine	0		Last Available: "2018-03"
 9795	bouncing Cantelope	0		Last Available: "2018-03"
-9796	ghostly purple Ungulant	0		Last Available: "2018-03"
+9796	purple ghostly Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	shaking Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
@@ -9693,7 +9693,7 @@
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	jittery mirror smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
-9828	compressed lime green wobbly magnificent oyster egg	1		Effect: "Improprie Tea", Effect Duration: 30
+9828	compressed wobbly lime green magnificent oyster egg	1		Effect: "Improprie Tea", Effect Duration: 30
 9829	boiled fuchsia brilliant oyster egg	1		
 9830	powdered fuchsia upside-down glistening oyster egg	1		
 9831	dried pulsating scintillating oyster egg	1		Effect: "Takin' It Greasy", Effect Duration: 15
@@ -9719,7 +9719,7 @@
 9851	pulsating dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
-9854	mirror blinking druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
+9854	blinking mirror druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	spinning flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	oxidized universal antivenin	0		Lasts Until Rollover, Effect: "Flower Power", Effect Duration: 52, Last Available: "2018-04"
@@ -9728,22 +9728,22 @@
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	olive LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	stale FantasyRealm turkey leg	4	decent	Last Available: "2018-04"
-9863	irresponsibly strong artisanal FantasyRealm mead	8	EPIC	Last Available: "2018-04"
+9863	artisanal irresponsibly strong FantasyRealm mead	8	EPIC	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	huge Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	gray grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	decent blue druidic s'more	3	good	Last Available: "2018-04"
-9870	pickled blurry tumbling sachet of powder	1		Effect: "Three Days Slow", Effect Duration: 20, Last Available: "2018-04"
-9871	practically non-alcoholic delicious mourning wine	1	awesome	Last Available: "2018-04"
+9870	pickled tumbling blurry sachet of powder	1		Effect: "Three Days Slow", Effect Duration: 20, Last Available: "2018-04"
+9871	delicious practically non-alcoholic mourning wine	1	awesome	Last Available: "2018-04"
 9872	upside-down sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	mirror map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	bland snack-sized denastified haunch	2	decent	Last Available: "2018-04"
+9878	snack-sized bland denastified haunch	2	decent	Last Available: "2018-04"
 9879	aged blinking bad rum and good cola	3	awesome	Last Available: "2018-04"
 9880	pressed Potion of Heroism	0		Effect: "Wreathed in Smoke", Effect Duration: 59, Last Available: "2018-04"
 9881	prompt educational brawny leggings of the Spider Queen	0		Muscle Percent: +20, Experience: +1, Adventures: +3, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	aged practically non-alcoholic two meat muck	1	awesome	
-9899	stale miniature fuchsia chocolate Ogre Chieftain	2	decent	
-9900	bland miniature chocolate &quot;Phoenix&quot;	2	decent	
-9901	fancy jumbo moldy chocolate Spider Queen	5	crappy	Effect: "Crocodile Tear", Effect Duration: 25
+9898	practically non-alcoholic aged two meat muck	1	awesome	
+9899	miniature stale fuchsia chocolate Ogre Chieftain	2	decent	
+9900	miniature bland chocolate &quot;Phoenix&quot;	2	decent	
+9901	moldy jumbo fancy chocolate Spider Queen	5	crappy	Effect: "Crocodile Tear", Effect Duration: 25
 9902	tolerable purple hipster cocktail	3	good	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	blinking God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	squat God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	red bouncing God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	blinking God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	squat God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	bouncing red God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	skewed G	0		
 9910	Garland of Greatness	0		
@@ -9781,9 +9781,9 @@
 9913	glued A-Boo clue	0		
 9914	narrow crude oil congealer	0		
 9915	spoiled thick good guava	5	crappy	
-9916	practically non-alcoholic artisanal gray gin and ginger	1	super ultra mega turbo EPIC	
+9916	artisanal practically non-alcoholic gray gin and ginger	1	super ultra mega turbo EPIC	
 9917	maroon Thwaitgold chigger statuette	0		
-9918	distilled yellow skewed gaseous gravy	1		Effect: "Hombre Muerto Caminando", Effect Duration: 50
+9918	distilled skewed yellow gaseous gravy	1		Effect: "Hombre Muerto Caminando", Effect Duration: 50
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	wobbly A Guide to Safari	0		Skill: "Experience Safari"
@@ -9799,7 +9799,7 @@
 9931	tumbling nasty Van der Graaf hardened smooth Nouveau nosering	0		Moxie: +15, Damage Reduction: 3, Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2018-07"
 9932	denatured adjusted ghostly sharkfin gumbo	0		Effect: "Spiky Frozen Hair", Effect Duration: 13, Last Available: "2018-07"
 9933	quadruple-deionized boiling broth	0		Effect: "Weasels Underfoot", Effect Duration: 40, Last Available: "2018-07"
-9934	quadruple-liquefied skewed ghostly interrogative elixir	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 14, Last Available: "2018-07"
+9934	quadruple-liquefied ghostly skewed interrogative elixir	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 14, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	narrow Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	Bastille Battalion cheese wheel	0		Last Available: "2018-07"
@@ -9813,7 +9813,7 @@
 9945	red Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	aged weak Middle of the Road&trade; brand whiskey	2	awesome	Last Available: "2018-09"
+9948	weak aged Middle of the Road&trade; brand whiskey	2	awesome	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	ribald sinister pentagram bandana	0		Spell Damage: +10, Sleaze Damage: +10, Last Available: "2018-09"
 9951	sharpshooter's skull ring	0		Critical Hit Percent: +10, Single Equip, Last Available: "2018-09"
@@ -9821,7 +9821,7 @@
 9953	bland PB&J with the crusts cut off	3	decent	Last Available: "2018-09"
 9954	manspreader's electrified dorky glasses	0		Monster Level: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-09"
 9955	wicked ponytail clip of the ox	0		Muscle: +20, Spell Damage: +5, Last Available: "2018-09"
-9956	shaking paint palette of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	shaking paint palette of vim and vigor	0		Maximum HP Percent: +50, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	vaporized jittery Purple Beast energy drink	1		Last Available: "2018-09"
 9959	Jeselnik's cosmetic football	0		Sleaze Damage: +25, Last Available: "2018-09"
@@ -9838,7 +9838,7 @@
 9970	lime green personal trainer's ratty knitted cap of doom	0		Experience Percent (Muscle): +10, Spooky Spell Damage: +50, Last Available: "2018-09"
 9972	razor-sharp intimidating chainsaw of the storm	0		Weapon Damage Percent: +25, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2018-09"
 9973	hand-crafted skewed party beer bomb	3	EPIC	Last Available: "2018-09"
-9974	fancy super-sized flavorless sweet party mix	5	decent	Effect: "Superveiny 9000", Effect Duration: 40, Last Available: "2018-09"
+9974	flavorless fancy super-sized sweet party mix	5	decent	Effect: "Superveiny 9000", Effect Duration: 40, Last Available: "2018-09"
 9975	dehydrated pulsating squat party balloon	1		Last Available: "2018-09"
 9976	perfumed chaotic party pants	0		Spell Critical Percent: +10, Stench Resistance: +5, Last Available: "2018-09"
 9977	gravedigger's fortified smartaleck's party whip	0		Moxie Percent: +30, Damage Absorption: +60, Spooky Damage: +10, Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	decent party platter for one	3	good	Last Available: "2018-09"
 9981	dehydrated shaking Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	wobbly Lo Pan's grievous party crasher	0		Weapon Damage Percent: +50, Spell Critical Percent: +30, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	wobbly Lo Pan's grievous party crasher	0		Weapon Damage Percent: +50, Spell Critical Percent: +30, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	spinning latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	spinning latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	skewed voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	hale &quot;I Voted!&quot; sticker	0		Maximum HP: +20, Lasts Until Rollover, Last Available: "2018-11"
@@ -9874,19 +9874,19 @@
 10008	curative extremely unsafe mutant legs of the sweet-tooth	0		Weapon Damage Percent: +100, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-11"
 10009	curative sinister mutant crown of the empath	0		Spell Damage: +10, Familiar Weight: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-11"
 10010	adequate ghostly ectoplasm	3	good	Last Available: "2018-11"
-10011	super-sized rotten shaking	5	crappy	Last Available: "2018-11"
+10011	rotten super-sized shaking	5	crappy	Last Available: "2018-11"
 10012	aged olive bottle of vodka	3	awesome	Last Available: "2018-11"
 10013	stale pizza	4	decent	Last Available: "2018-11"
 10014	weak acceptable martini	2	good	Last Available: "2018-11"
 10015	adequate snack-sized twirling cherry pie	2	good	Last Available: "2018-11"
-10016	watered-down artisanal eggnog	2	EPIC	Last Available: "2018-11"
+10016	artisanal watered-down eggnog	2	EPIC	Last Available: "2018-11"
 10017	upside-down glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	gigantic stale Hell ramen	6	decent	Last Available: "2018-11"
-10019	high-proof tolerable bouncing squat gimlet	9	good	Last Available: "2018-11"
+10018	stale gigantic Hell ramen	6	decent	Last Available: "2018-11"
+10019	high-proof tolerable squat bouncing gimlet	9	good	Last Available: "2018-11"
 10020	hand-crafted wobbly twice-haunted screwdriver	3	EPIC	Last Available: "2018-11"
 10021	stale candy cane	3	decent	Last Available: "2018-12"
 10022	acceptable runny fermented egg	3	good	Last Available: "2018-12"
-10023	enchanted decent oldcake	3	good	Effect: "Natural 20", Effect Duration: 25, Last Available: "2018-12"
+10023	decent enchanted oldcake	3	good	Effect: "Natural 20", Effect Duration: 25, Last Available: "2018-12"
 10024	stale traditional Crimbo cookie	4	decent	Last Available: "2023-06"
 10025	Sinatra's plastic wild beaver	0		Experience (Moxie): +5, Last Available: "2018-12"
 10026	tumbling Usain Bolt's plastic reindeer	0		Initiative: +80, Last Available: "2018-12"
@@ -9895,7 +9895,7 @@
 10029	plastic Abuela Crimbo of the detective	0		Item Drop: +20, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
 10031	Braindeer	0		Last Available: "2018-12"
-10032	pulsating fuchsia Crimbo dog sweater	0		Familiar Weight: +5
+10032	fuchsia pulsating Crimbo dog sweater	0		Familiar Weight: +5
 10033	Van der Graaf rock-hard pristine walrus tusk	0		Damage Reduction: 5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	lightning-fast Oprah's Staff of Frozen Lard of the brazier of the detective	0		Maximum MP Percent: +50, Hot Spell Damage: +25, Item Drop: +20, Initiative: +40, Last Available: "2018-12"
@@ -9906,14 +9906,14 @@
 10040	thick normal wobbly bouncing moosemeat pie	5	good	Last Available: "2018-12"
 10041	bouncing cool balanced antler	0		Moxie: +5, Last Available: "2018-12"
 10042	ghostly razor-sharp dam	0		Weapon Damage Percent: +25, Damage Reduction: 9, Last Available: "2018-12"
-10043	aged weak beavermouth	2	awesome	Last Available: "2018-12"
+10043	weak aged beavermouth	2	awesome	Last Available: "2018-12"
 10044	tolerable beaver punch (papaya)	3	good	Last Available: "2018-12"
 10045	hand-crafted teal beaver punch (peach)	3	EPIC	Last Available: "2018-12"
 10046	perfectly mixed twirling beaver punch (cherry)	4	EPIC	Last Available: "2018-12"
 10047	resourceful stylish Canadian lantern	0		Moxie: +25, Maximum MP: +50, Last Available: "2018-12"
 10048	sinister muskox-skin cap	0		Spell Damage: +10, Last Available: "2018-12"
 10049	bouncing Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	half-sized stale glass of raw eggs	2	decent	Last Available: "2018-12"
+10050	stale half-sized glass of raw eggs	2	decent	Last Available: "2018-12"
 10051	perfectly mixed watered-down punch-drunk punch	2	EPIC	Last Available: "2018-12"
 10052	twisted ghostly body spradium	1		Last Available: "2018-12"
 10053	miser's bauxite beret	0		Meat Drop: +10, Last Available: "2018-12"
@@ -9923,19 +9923,19 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	shaking ghostly scorching manspreader's Lo Pan's Kramco Sausage-o-Matic&trade; of the dark arts of Leguizamo	0		Spell Damage Percent: +100, Spell Critical Percent: +30, Monster Level: 30, Hot Damage: +25, Last Available: "2019-01"
 10059	huge blinking sausage casing	0		Last Available: "2019-01"
-10060	fancy super-sized delicious sausage	5	awesome	Effect: "Oiled Skin", Effect Duration: 40, Last Available: "2019-01"
+10060	super-sized fancy delicious sausage	5	awesome	Effect: "Oiled Skin", Effect Duration: 40, Last Available: "2019-01"
 10061	studded red-hot sausage fork of the scaredy-cat	0		Damage Absorption: +80, Monster Level: -15, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
-10064	upside-down cyan jar of relish	0		Familiar Weight: +5
+10064	cyan upside-down jar of relish	0		Familiar Weight: +5
 10065	maroon shaking Toyleporter	0		Last Available: "2018-12"
 10066	triple-distilled enchanted tolerable beer	6	good	Effect: "Space Cowboy", Effect Duration: 45, Last Available: "2018-12"
 10067	spoiled yule gruel	3	crappy	Last Available: "2018-12"
-10068	practically non-alcoholic fancy acceptable hot watered rum	1	good	Effect: "Flamibili Tea", Effect Duration: 20, Last Available: "2018-12"
+10068	acceptable practically non-alcoholic fancy hot watered rum	1	good	Effect: "Flamibili Tea", Effect Duration: 20, Last Available: "2018-12"
 10069	smooth practically non-alcoholic mirror bottle of Crimbognac	1	awesome	Last Available: "2018-12"
 10070	rotten Crimboysters Rockefeller	4	crappy	Last Available: "2018-12"
 10071	mixed Crimbeau de toilette	1		Last Available: "2018-12"
-10072	cyan spinning Crimbo candle	0		Last Available: "2018-12"
+10072	spinning cyan Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
@@ -9959,22 +9959,22 @@
 10093	tumbling avaricious scorching marble mignonette bowl	0		Hot Damage: +25, Meat Drop: +30, Last Available: "2019-12"
 10094	mirror marble medallion of James Dean of vim and vigor	0		Experience (Moxie): +3, Maximum HP Percent: +50, Single Equip, Last Available: "2019-12"
 10095	ghostly greedy marble mariachi hat of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +20, Last Available: "2019-12"
-10096	distilled squat gray marble molecules	1		Last Available: "2019-12"
+10096	distilled gray squat marble molecules	1		Last Available: "2019-12"
 10097	deionized extra-galvanized Mallomarbles	0		Effect: "Gemini Rising", Effect Duration: 64
-10098	tumbling vibrating punching bag of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	strapping pith helmet of the empath	0		Muscle: +5, Familiar Weight: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	wobbly shellacked Fonzie's poncho	0		Experience (Moxie): +1, Damage Reduction: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	twirling therapeutic wizardly pendant	0		Mysticality: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	manspreader's Rosewater's palazzos	0		Mysticality Percent: +30, Monster Level: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	electrified pseudoaccordion of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	tumbling vibrating punching bag of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	strapping pith helmet of the empath	0		Muscle: +5, Familiar Weight: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	wobbly shellacked Fonzie's poncho	0		Experience (Moxie): +1, Damage Reduction: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	twirling therapeutic wizardly pendant	0		Mysticality: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	manspreader's Rosewater's palazzos	0		Mysticality Percent: +30, Monster Level: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	electrified pseudoaccordion of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	distilled ghostly pieces	1		Last Available: "2020-12"
-10105	altered energized spinning wobbly skewed Para-Pop	0		Effect: "Shamboozled", Effect Duration: 36
-10106	rosewater-soaked fireproof terra cotta truss	0		Hot Resistance: +3, Stench Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	Lo Pan's quilted terra cotta trousers	0		Damage Absorption: +40, Spell Critical Percent: +30, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	fortified terra cotta tongs of the blizzard	0		Damage Absorption: +60, Cold Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	pulsating Fonzie's experienced terra cotta train	0		Experience: +2, Experience (Moxie): +1, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	fireproof rosy-cheeked terra cotta tie tack	0		Maximum HP Percent: +30, Hot Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	studded supercool terra cotta tambourine	0		Moxie Percent: +20, Damage Absorption: +80, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10105	altered energized skewed wobbly spinning Para-Pop	0		Effect: "Shamboozled", Effect Duration: 36
+10106	rosewater-soaked fireproof terra cotta truss	0		Hot Resistance: +3, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	Lo Pan's quilted terra cotta trousers	0		Damage Absorption: +40, Spell Critical Percent: +30, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	fortified terra cotta tongs of the blizzard	0		Damage Absorption: +60, Cold Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	pulsating Fonzie's experienced terra cotta train	0		Experience: +2, Experience (Moxie): +1, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	fireproof rosy-cheeked terra cotta tie tack	0		Maximum HP Percent: +30, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	studded supercool terra cotta tambourine	0		Moxie Percent: +20, Damage Absorption: +80, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	pickled squat terra cotta tidbits	1		Last Available: "2020-12"
 10113	dry terra panna cotta	0		Effect: "Hammered", Effect Duration: 56
 10114	pulsating wicked velour voulge of the wise owl	0		Mysticality: +20, Spell Damage: +5, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	frosty veiny glass serape	0		Maximum HP: +10, Cold Spell Damage: +10, Last Available: "2021-12"
 10128	twisted narrow spinning glass shards	1		Last Available: "2021-12"
 10129	quadruple-enhanced teal hard candy	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 11
-10130	gravedigger's arcane researcher's loofah lumberjack's hat	0		Experience Percent (Mysticality): +10, Spooky Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	reassuring greasy loofah lei	0		Sleaze Spell Damage: +10, Spooky Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	olive smartaleck's loofah lederhosen of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	green scandalous extremely unsafe loofah ladle	0		Weapon Damage Percent: +100, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	gray energetic loofah legwarmers	0		Maximum MP Percent: +20, Item Drop: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	Jeselnik's shellacked loofah lavalier	0		Damage Reduction: 7, Sleaze Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	pickled cyan blurry loofah lumps	1		Last Available: "2022-12"
+10130	gravedigger's arcane researcher's loofah lumberjack's hat	0		Experience Percent (Mysticality): +10, Spooky Damage: +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	reassuring greasy loofah lei	0		Sleaze Spell Damage: +10, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	olive smartaleck's loofah lederhosen of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	green scandalous extremely unsafe loofah ladle	0		Weapon Damage Percent: +100, Sleaze Damage: +5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	gray energetic loofah legwarmers	0		Maximum MP Percent: +20, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	Jeselnik's shellacked loofah lavalier	0		Damage Reduction: 7, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10136	pickled blurry cyan loofah lumps	1		Last Available: "2022-12"
 10137	pickled ionized chocolate-covered loofah	0		Effect: "You're Not Cooking", Effect Duration: 63
-10138	careful manspreader's flagstone flag	0		Monster Level: 0, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	brawny flagstone flail of the sewer	0		Muscle Percent: +20, Stench Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	beefcake's flagstone flip-flops of the bloodbag	0		Muscle: +25, Maximum HP: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	red squat crafty flagstone fez of the early riser	0		Maximum MP: +10, Adventures: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	pulsating teal reassuring sharpshooter's flagstone fleece	0		Critical Hit Percent: +10, Spooky Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	yellow deadly flagstone fringe of the cougar	0		Moxie: +20, Weapon Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	careful manspreader's flagstone flag	0		Monster Level: 0, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	brawny flagstone flail of the sewer	0		Muscle Percent: +20, Stench Damage: +25, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	beefcake's flagstone flip-flops of the bloodbag	0		Muscle: +25, Maximum HP: +100, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	red squat crafty flagstone fez of the early riser	0		Maximum MP: +10, Adventures: +7, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	pulsating teal reassuring sharpshooter's flagstone fleece	0		Critical Hit Percent: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	yellow deadly flagstone fringe of the cougar	0		Moxie: +20, Weapon Damage: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	vaporized skewed flagstone flagments	1		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 40, Last Available: "2022-12"
 10145	vacuum-sealed Vulcanized narrow Flag by the Foot&trade;	0		Effect: "Fustulent", Effect Duration: 16
 10146	blurry elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10023,23 +10023,23 @@
 10157	mansplainer's hardy discarded bowtie	0		Maximum HP: +50, Monster Level: +15, Lasts Until Rollover, Last Available: "2019-12"
 10158	tolerable martiny	4	good	Last Available: "2019-12"
 10159	skewed tryptophan dart	0		Last Available: "2019-12"
-10160	triple-oxidized blurry ghostly licorice snake	0		Effect: "Staying Frosty", Effect Duration: 19
+10160	triple-oxidized ghostly blurry licorice snake	0		Effect: "Staying Frosty", Effect Duration: 19
 10161	modified mirror virgin jello shot	0		Effect: "Muscle Unbound", Effect Duration: 69
 10162	chilled activated colloidal cyan mutated candy lump	0		Effect: "Slightly Mutated", Effect Duration: 65
 10163	enhanced green government-issued candy	0		Effect: "Flambé-a-thon", Effect Duration: 35
 10164	quadruple-denatured Pneumo bar	0		Effect: "Ooh, Bitter!", Effect Duration: 64
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	spinning Lil' Doctor&trade; bag of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	spinning Lil' Doctor&trade; bag of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	rotten bloodstick	4	crappy	
-10170	special perfectly mixed weak twirling fuchsia wobbly bottle of Sanguiovese	2	EPIC	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 45
+10170	special weak perfectly mixed fuchsia twirling wobbly bottle of Sanguiovese	2	EPIC	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 45
 10171	tasty fancy miniature actual blood sausage	2	awesome	Effect: "Patent Alacrity", Effect Duration: 25
 10172	artisanal mulled blood	4	EPIC	
-10173	half-sized flavorless squat blood snowcone	2	decent	
+10173	flavorless half-sized squat blood snowcone	2	decent	
 10174	irresponsibly strong tolerable Red Russian	10	good	
 10175	normal big mirror blood roll-up	5	good	
 10176	mediocre fancy bottle of blood	4	decent	Effect: "Phoenix, Right?", Effect Duration: 50
-10177	tasty snack-sized blood-soaked sponge cake	2	awesome	
+10177	snack-sized tasty blood-soaked sponge cake	2	awesome	
 10178	mediocre blurry vampagne	4	decent	
 10179	bite-sized tasty plain snowcone	1	awesome	
 10180	Booke of Vampyric Knowledge	0		
@@ -10063,7 +10063,7 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	adequate snack-sized crabsicle	2	good	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	strong acceptable upside-down bottle of dark rhum	5	good	Last Available: "2019-04"
+10201	acceptable strong upside-down bottle of dark rhum	5	good	Last Available: "2019-04"
 10202	perfectly mixed triple-distilled bottle of extra-dark rhum	9	EPIC	Last Available: "2019-04"
 10203	drinkable teal pulsating bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
 10204	vacuum-sealed pirate shaving cream	0		Effect: "High Blood Chocolate Content", Effect Duration: 40, Last Available: "2019-04"
@@ -10089,7 +10089,7 @@
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	narrow PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	shaking banded plush sea serpent	0		Damage Absorption: +100, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	rotten gigantic pirate fork	10		Last Available: "2019-04"
+10227	gigantic rotten pirate fork	10		Last Available: "2019-04"
 10228	tumbling Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	cyan ring	0		Single Equip, Last Available: "2019-04"
 10230	scorching piratical blunderbuss of the sweet-tooth	0		Hot Damage: +25, Candy Drop: +100, Last Available: "2019-04"
@@ -10097,14 +10097,14 @@
 10232	perfectly mixed jittery Island Landslide	3	EPIC	Last Available: "2019-04"
 10233	artisanal Island Thunderstorm	4	EPIC	Last Available: "2019-04"
 10234	mediocre spinning Island Hurricane	3	decent	Last Available: "2019-04"
-10235	smooth irresponsibly strong upside-down Skull Punch	7	awesome	Last Available: "2019-04"
+10235	irresponsibly strong smooth upside-down Skull Punch	7	awesome	Last Available: "2019-04"
 10236	aged Electric Punch	4	awesome	Last Available: "2019-04"
-10237	fortified perfectly mixed Smuggler's Punch	5	EPIC	Last Available: "2019-04"
+10237	perfectly mixed fortified Smuggler's Punch	5	EPIC	Last Available: "2019-04"
 10238	watered-down drinkable Scorpion Bowl	2	good	Last Available: "2019-04"
 10239	perfectly mixed Turtle Bowl	3	super EPIC	Last Available: "2019-04"
 10240	acceptable Cobra Bowl	3	good	Last Available: "2019-04"
 10241	upside-down yellow vampyric cloake pattern	0		Free Pull
-10242	manspreader's MacGyver's hardened dangerous experienced vampyric cloake	0		Experience: +2, Weapon Damage: +10, Damage Reduction: 3, Maximum MP: +100, Monster Level: +10, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	manspreader's MacGyver's hardened dangerous experienced vampyric cloake	0		Experience: +2, Weapon Damage: +10, Damage Reduction: 3, Maximum MP: +100, Monster Level: +10, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	double-colloidal triple-dry lime green one piece of bubble gum	0		Effect: "A View to Some Meat", Effect Duration: 38
 10245	arcanoferric housing	0		
@@ -10113,21 +10113,21 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	lime green executive quilted personal trainer's Fourth of May Cosplay Saber	0		Experience Percent (Muscle): +10, Damage Absorption: +40, Meat Drop: +40, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	lime green executive quilted personal trainer's Fourth of May Cosplay Saber	0		Experience Percent (Muscle): +10, Damage Absorption: +40, Meat Drop: +40, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	squat executive miser's toasty Van der Graaf padded sinister dance instructor's brainy weightlifter's hewn moon-rune spoon of the brazier of temperance	0		Muscle: +15, Mysticality: +5, Experience Percent (Moxie): +10, Spell Damage: +10, Damage Absorption: +20, Hot Damage: +5, Hot Spell Damage: +25, Sleaze Resistance: +5, Meat Drop: 50, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
-10255	upside-down wobbly cartoon harpoon	0		Last Available: "2019-06"
+10254	squat executive miser's toasty Van der Graaf padded sinister dance instructor's brainy weightlifter's hewn moon-rune spoon of the brazier of temperance	0		Muscle: +15, Mysticality: +5, Experience Percent (Moxie): +10, Spell Damage: +10, Damage Absorption: +20, Hot Damage: +5, Hot Spell Damage: +25, Sleaze Resistance: +5, Meat Drop: 50, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10255	wobbly upside-down cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	wobbly Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	tumbling knitted occult deadly Beach Comb	0		Weapon Damage: +5, Spell Damage Percent: +25, Cold Resistance: +3, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	tumbling knitted occult deadly Beach Comb	0		Weapon Damage: +5, Spell Damage Percent: +25, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	olive grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	ghostly hourglass	0		Last Available: "2019-07"
-10265	ghostly green etched hourglass	0		Last Available: "2019-07"
+10265	green ghostly etched hourglass	0		Last Available: "2019-07"
 10266	quadruple-quantum magenta seashell	0		Effect: "Human-Human Hybrid", Effect Duration: 58, Last Available: "2019-07"
 10267	corrupted non-anodized blue cyan seashell	0		Effect: "Vinegavotte", Effect Duration: 56, Last Available: "2019-07"
 10268	modified modified tumbling gray seashell	0		Effect: "Clyde's Blessing", Effect Duration: 19, Last Available: "2019-07"
@@ -10142,7 +10142,7 @@
 10277	fireproof Sinatra's groovy waders	0		Moxie Percent: +10, Experience (Moxie): +5, Hot Resistance: +3, Last Available: "2019-07"
 10278	medical-grade spearfish fishing spear of the pedagogue of the storm	0		Experience: +3, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-07"
 10279	prompt nasty beefcake's rabbitfish fin	0		Muscle: +25, Stench Damage: +5, Adventures: +3, Single Equip, Last Available: "2019-07"
-10280	lime green skewed piece of coral	0		Last Available: "2019-07"
+10280	skewed lime green piece of coral	0		Last Available: "2019-07"
 10281	piece of driftwood	0		Last Available: "2019-07"
 10282	olive healthy hardened pirate cutlass of the brazier	0		Damage Reduction: 3, Maximum HP Percent: +20, Hot Spell Damage: +25, Single Equip, Last Available: "2019-07"
 10283	teal flame-retardant deadly arcane researcher's tricorn hat	0		Experience Percent (Mysticality): +10, Weapon Damage: +5, Hot Resistance: +1, Last Available: "2019-07"
@@ -10151,11 +10151,11 @@
 10286	huge auspicious flame-wreathed meteorite earring of incineration	0		Hot Spell Damage: 60, Item Drop: +10, Single Equip, Last Available: "2019-07"
 10287	spinning blinking stanky Samson's meteorite necklace of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: 75, Single Equip, Last Available: "2019-07"
 10288	green chilly supercool smooth meteorite ring	0		Moxie: +15, Moxie Percent: +20, Cold Damage: +5, Single Equip, Last Available: "2019-07"
-10289	ionized huge green Finnish Fish	0		Effect: "Amorous", Effect Duration: 15
+10289	ionized green huge Finnish Fish	0		Effect: "Amorous", Effect Duration: 15
 10290	pickled oxidized lime green twirling chocolate doubloon	0		Effect: "init.enh", Effect Duration: 27
 10291	Sherlock's Herculean driftwood beach comb of the overflowing toilet	0		Experience (Muscle): +1, Stench Spell Damage: +50, Item Drop: +25, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	twirling Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
-10293	bouncing fuchsia stick of firewood	0		Last Available: "2019-08"
+10293	fuchsia bouncing stick of firewood	0		Last Available: "2019-08"
 10294	knitted energetic Rosewater's whittled tiara	0		Mysticality Percent: +30, Maximum MP Percent: +20, Cold Resistance: +3, Last Available: "2019-08"
 10295	tumbling nasty clever sage whittled shorts	0		Mysticality Percent: +10, Maximum MP: +20, Stench Damage: +5, Last Available: "2019-08"
 10296	reassuring baleful whittled flail of mayonnaise	0		Spell Damage: +25, Sleaze Spell Damage: +50, Spooky Resistance: +1, Last Available: "2019-08"
@@ -10167,9 +10167,9 @@
 10302	censurious slick whittled walking stick of the boozehound	0		Moxie: +10, Sleaze Resistance: +3, Item Drop: +5, Booze Drop: +100, Last Available: "2019-08"
 10303	spoiled spinning campfire hot dog	3	crappy	Last Available: "2019-08"
 10304	normal campfire baked potato	3	good	Last Available: "2019-08"
-10305	enchanted tasty campfire s'more	3	awesome	Effect: "Mushroom Samba", Effect Duration: 15, Last Available: "2019-08"
+10305	tasty enchanted campfire s'more	3	awesome	Effect: "Mushroom Samba", Effect Duration: 15, Last Available: "2019-08"
 10306	decent low-calorie campfire beans	1	good	Last Available: "2019-08"
-10307	moldy miniature gray campfire stew	2	crappy	Last Available: "2019-08"
+10307	miniature moldy gray campfire stew	2	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
 10309	non-polarized frozen leftover chocolate bar	0		Effect: "Amorphous Cheer", Effect Duration: 52
 10310	rare Meat isotope	0		
@@ -10203,7 +10203,7 @@
 10344	blurry plastic Dolph Bossin of the sewer	0		Stench Damage: +25, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	normal green mana-coated yams	4	good	Last Available: "2019-11"
-10347	stale ghostly bouncing mana-basted tofurkey leg	3	decent	Last Available: "2019-11"
+10347	stale bouncing ghostly mana-basted tofurkey leg	3	decent	Last Available: "2019-11"
 10348	rotten narrow mana-fortified cranberry sauce	3	crappy	Last Available: "2019-11"
 10349	decent mana-stuffed herbal stuffing	3	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
@@ -10213,11 +10213,11 @@
 10354	modified vial of humanoid growth hormone	1		Effect: "Fever From the Flavor", Effect Duration: 15, Last Available: "2019-12"
 10355	compressed fuchsia a bug's lymph	1		Last Available: "2019-12"
 10356	galvanized cold-filtered organic potpourri	0		Effect: "Patience of the Tortoise", Effect Duration: 48, Last Available: "2019-12"
-10357	weak mediocre blinking boot flask	2	decent	Last Available: "2019-12"
+10357	mediocre weak blinking boot flask	2	decent	Last Available: "2019-12"
 10358	corrupted double-dry jittery infernal snowball	0		Effect: "Shawarma Warm War", Effect Duration: 47, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	diluted fish sauce	1		Last Available: "2019-12"
-10361	yummy small guffin	2	awesome	Last Available: "2019-12"
+10361	small yummy guffin	2	awesome	Last Available: "2019-12"
 10362	boiled Shantix&trade;	1		Effect: "Mitre Cut", Effect Duration: 5, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	boiled non-Euclidean angle	1		Effect: "The Chains Down In The Belly-O", Effect Duration: 50, Last Available: "2019-12"
@@ -10234,7 +10234,7 @@
 10375	corrupted energized jittery concentrated fish broth	0		Effect: "Almost Cool", Effect Duration: 63, Last Available: "2019-12"
 10376	chilled pressed upside-down liquid SONAR	0		Effect: "Wings of the Grasshopper", Effect Duration: 66, Last Available: "2019-12"
 10377	map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
-10378	teal huge Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
+10378	huge teal Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	Temple Grandin's sharpshooter's MacGyver's Dolph Bossin's Crimbo hat	0		Maximum MP: +100, Critical Hit Percent: +10, Familiar Weight: +7, Last Available: "2019-12"
 10380	pulsating The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
@@ -10253,8 +10253,8 @@
 10394	executive Mer-kin rollpin of the boozehound	0		Meat Drop: +40, Booze Drop: +100, Last Available: "2019-12"
 10395	tumbling personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
-10397	decent miniature yellow bowl of mernudo	2	good	Last Available: "2019-12"
-10398	triple-distilled bad fishelada	6	decent	Last Available: "2019-12"
+10397	miniature decent yellow bowl of mernudo	2	good	Last Available: "2019-12"
+10398	bad triple-distilled fishelada	6	decent	Last Available: "2019-12"
 10399	rotten ojo de pez burrito	3	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	bouncing veiny slick nutcracker cape	0		Moxie: +10, Maximum HP: +10, Last Available: "2019-12"
 10413	Annie Oakley's nutcracker epaulets of doom	0		Critical Hit Percent: +20, Spooky Spell Damage: +50, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	bland super-sized tumbling salt plum	5	decent	Last Available: "2019-12"
+10415	super-sized bland tumbling salt plum	5	decent	Last Available: "2019-12"
 10416	ghostly peppermint eel sauce	0		Last Available: "2019-12"
 10417	normal and bean	3	good	Last Available: "2019-12"
 10418	aromatic coward's Sinatra's kelp-holly gun	0		Experience (Moxie): +5, Monster Level: -20, Stench Resistance: +1, Last Available: "2019-12"
@@ -10288,11 +10288,11 @@
 10429	warmed corrupted handful of mixed nuts	0		Effect: "Greased-Up Familiar", Effect Duration: 12, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	miser's reassuring sizzling Retrospecs	0		Hot Damage: +10, Spooky Resistance: +1, Meat Drop: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	miser's reassuring sizzling Retrospecs	0		Hot Damage: +10, Spooky Resistance: +1, Meat Drop: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	jittery MacGyver's beefcake's Powerful Glove of the pedagogue of courage of Flo-Jo	0		Muscle: +25, Experience: +3, Maximum MP: +100, Spooky Resistance: +3, Initiative: +100, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	jittery MacGyver's beefcake's Powerful Glove of the pedagogue of courage of Flo-Jo	0		Muscle: +25, Experience: +3, Maximum MP: +100, Spooky Resistance: +3, Initiative: +100, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	blinking status cymbal	0		Last Available: "2020-02"
 10441	auspicious hale beefy Drip harness	0		Muscle: +10, Maximum HP: +20, Item Drop: +10
@@ -10312,10 +10312,10 @@
 10455	twirling mushroom	0		
 10456	deluxe mushroom	0		
 10457	super deluxe mushroom	0		
-10458	chilled polymerized squat shaking fizzy soda	0		Effect: "Ancient Protected", Effect Duration: 30
+10458	chilled polymerized shaking squat fizzy soda	0		Effect: "Ancient Protected", Effect Duration: 30
 10459	ionized healthy juice	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 65
 10460	huge hammer	0		
-10461	twirling narrow hammer	0		
+10461	narrow twirling hammer	0		
 10462	fire flower	0		
 10463	teal bonfire flower	0		
 10464	yellow work boots	0		Single Equip
@@ -10324,7 +10324,7 @@
 10467	nasty back shell of incineration	0		Hot Spell Damage: +50, Stench Damage: +5
 10468	shaking spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
-10470	upside-down huge Thwaitgold buzzy beetle statuette	0		
+10470	huge upside-down Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
 10472	spinning groovy bony back shell	0		Moxie Percent: +10
 10473	frosty button	0		Single Equip
@@ -10343,7 +10343,7 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	pulsating immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	flavorless jumbo mushroom filet	5	decent	Last Available: "2020-03"
+10489	jumbo flavorless mushroom filet	5	decent	Last Available: "2020-03"
 10490	huge mushroom slab	0		Last Available: "2020-03"
 10491	altered mushroom tea	1		Last Available: "2020-03"
 10492	triple-distilled bad mushroom whiskey	9	decent	Last Available: "2020-03"
@@ -10393,7 +10393,7 @@
 10537	shaking Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	olive Guzzlr pants	0		Last Available: "2020-05"
 10539	mansplainer's Guzzlr souvenir stein	0		Monster Level: +15, Last Available: "2020-05"
-10540	blurry twirling olive Guzzlr tattoo kit	0		Last Available: "2020-05"
+10540	olive blurry twirling Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	tolerable pulsating Ghiaccio Colada	3	good	Last Available: "2020-05"
 10542	artisanal Sourfinger	3	EPIC	Last Available: "2020-05"
 10543	artisanal Nog-on-the-Cob	3	EPIC	Last Available: "2020-05"
@@ -10430,7 +10430,7 @@
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	liquefied magnetized yellow salty drippy candy bar	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 19
-10577	activated enhanced shaking teal writhing drippy candy bar	0		Effect: "Stimulated Body", Effect Duration: 46
+10577	activated enhanced teal shaking writhing drippy candy bar	0		Effect: "Stimulated Body", Effect Duration: 46
 10578	non-polarized Vulcanized tumbling gooey drippy candy bar	0		Effect: "Punch Another Day", Effect Duration: 34
 10579	blue baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	maroon dromedary drinking helmet	0		
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	fuchsia flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	wicked birch battery of Flo-Jo	0		Spell Damage: +5, Initiative: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	yellow smelly steel-toed savvy ebony epee	0		Mysticality Percent: +20, Damage Reduction: 9, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	cyan baleful sinister Da Vinci's weeping willow wand	0		Experience (Mysticality): +5, Spell Damage: 35, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	beechwood blowgun of James Dean of Gandalf of extreme caution	0		Experience (Moxie): +3, Spell Critical Percent: +20, Monster Level: -25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	yellow smelly steel-toed savvy ebony epee	0		Mysticality Percent: +20, Damage Reduction: 9, Stench Spell Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	cyan baleful sinister Da Vinci's weeping willow wand	0		Experience (Mysticality): +5, Spell Damage: 35, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	beechwood blowgun of James Dean of Gandalf of extreme caution	0		Experience (Moxie): +3, Spell Critical Percent: +20, Monster Level: -25, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	twirling frosty stiffened maple magnet of mayonnaise	0		Damage Reduction: 1, Cold Spell Damage: +10, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	rosewater-soaked supercharged slick hemlock helm	0		Moxie: +10, Maximum MP Percent: +30, Stench Resistance: +3, Last Available: "2020-08"
@@ -10469,7 +10469,7 @@
 10613	mirror up-at-dawn deadly Yeg's Motel bathrobe	0		Weapon Damage: +5, Adventures: +5, Lasts Until Rollover, Last Available: "2020-09"
 10614	lightning-fast smartaleck's Yeg's Motel slippers	0		Moxie Percent: +30, Initiative: +40, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
-10616	wobbly narrow Yeg's Motel minibar key	0		Last Available: "2020-09"
+10616	narrow wobbly Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	pulsating sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
@@ -10488,7 +10488,7 @@
 10632	mirror alabaster bishop	0		Last Available: "2020-09"
 10633	alabaster knight	0		Last Available: "2020-09"
 10634	alabaster pawn	0		Last Available: "2020-09"
-10635	upside-down blinking bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
+10635	blinking upside-down bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	bouncing cyan zippy Sherlock's flame-retardant Oprah's Cargo Cultist Shorts	0		Maximum MP Percent: +50, Hot Resistance: +1, Item Drop: +25, Initiative: +20, Last Available: "2020-09"
 10637	narrow complicated device	0		Last Available: "2020-09"
 10638	delicious weak flask of moonshine	2	awesome	Last Available: "2020-09"
@@ -10501,7 +10501,7 @@
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
-10648	red tumbling box o' ghosts	0		Free Pull, Last Available: "2020-12"
+10648	tumbling red box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
@@ -10539,7 +10539,7 @@
 10683	polarized imported lemon lozenge	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 50, Last Available: "2020-12"
 10684	polymerized electrified blurry hermedisiac cologne	0		Effect: "Eldritch Concentration", Effect Duration: 23, Last Available: "2020-12"
 10685	shaking government food shipment	0		Last Available: "2020-12"
-10686	blurry gray government booze shipment	0		Last Available: "2020-12"
+10686	gray blurry government booze shipment	0		Last Available: "2020-12"
 10687	jittery government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	Crimbo Carol tattoo kit	0		Last Available: "2020-12"
@@ -10568,26 +10568,26 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	narrow The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	upside-down The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	flavorless immense upside-down and pepper (stale)	6	decent	Last Available: "2020-12"
+10715	immense flavorless upside-down and pepper (stale)	6	decent	Last Available: "2020-12"
 10716	acceptable wobbly cranberry margarita (brackish)	3	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	bad barrel-aged eggnog	4	decent	Last Available: "2020-12"
 10721	super-sized spoiled hand-crafted candy cane	5	crappy	Last Available: "2020-12"
-10722	fancy bland drive-thru burger	3	decent	Effect: "Turtle Titters", Effect Duration: 50, Last Available: "2020-12"
+10722	bland fancy drive-thru burger	3	decent	Effect: "Turtle Titters", Effect Duration: 50, Last Available: "2020-12"
 10723	triple-distilled aged Boulevardier cocktail	10	awesome	Last Available: "2020-12"
 10724	ionized altered Hotwire&trade; brand candy rope	0		Effect: "Sugar, Hello", Effect Duration: 56, Last Available: "2020-12"
 10725	moldy cyan bowl full of jelly	3	crappy	Last Available: "2020-12"
 10726	lousy boozy upside-down Eye and a Twist	5	decent	Last Available: "2020-12"
 10727	dry upside-down Chubby and Plump bar	0		Effect: "Stop and Smell the Fudge", Effect Duration: 33, Last Available: "2020-12"
-10728	green pulsating digibritches	0		Last Available: "2025-12"
+10728	pulsating green digibritches	0		Last Available: "2025-12"
 10729	olive packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	blinking fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	squat spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	squat spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	wobbly power seed	0		Free Pull, Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	marshmallow	0		
 10747	drinkable ghostly marshmallow bomb	4	good	Last Available: "2021-03"
 10748	huge packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	moist aerosolized short beer	0		Effect: "Fire Inside", Effect Duration: 15, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	modified spinning short	0		Effect: "Fancy Feasted", Effect Duration: 67, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	fuchsia quantum of familiar	0		
-10759	ribald familiar scrapbook of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	ribald familiar scrapbook of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	pulsating clan underground fireworks shop	0		Last Available: "2021-07"
 10762	jittery toasty lion tamer's hardy fedora-mounted fountain	0		Maximum HP: +50, Experience (familiar): +2, Hot Damage: +5, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,7 +10621,7 @@
 10765	squat rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	maroon huge rocket	0		Last Available: "2021-07"
-10768	bland fancy mirror fire crackers	3	decent	Effect: "Going Ape", Effect Duration: 15, Last Available: "2021-07"
+10768	fancy bland mirror fire crackers	3	decent	Effect: "Going Ape", Effect Duration: 15, Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	blue frosty friendly Catherine Wheel	0		Familiar Weight: +3, Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10771	ghostly lightning-fast weightlifter's rocket boots	0		Muscle: +15, Initiative: +40, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	mirror rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	lightning-fast inspector's Herculean smooth industrial fire extinguisher of the sweet-tooth	0		Moxie: +15, Experience (Muscle): +1, Item Drop: 20, Candy Drop: +100, Initiative: +40, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	lightning-fast inspector's Herculean smooth industrial fire extinguisher of the sweet-tooth	0		Moxie: +15, Experience (Muscle): +1, Item Drop: 20, Candy Drop: +100, Initiative: +40, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,8 +10660,8 @@
 10804	flame-retardant Oprah's Daylight Shavings Helmet of the scaredy-cat	0		Maximum MP Percent: +50, Monster Level: -15, Hot Resistance: +1, Last Available: "2021-11"
 10805	eggwater	1	good	Last Available: "2021-12"
 10806	normal upside-down bread man	3	good	Last Available: "2021-12"
-10807	fancy delicious massive blurry plain candy cane	10	awesome	Effect: "Disdain of She-Who-Was", Effect Duration: 15, Last Available: "2021-12"
-10808	spoiled gigantic skewed flour cookie	6	crappy	Last Available: "2021-12"
+10807	massive fancy delicious blurry plain candy cane	10	awesome	Effect: "Disdain of She-Who-Was", Effect Duration: 15, Last Available: "2021-12"
+10808	gigantic spoiled skewed flour cookie	6	crappy	Last Available: "2021-12"
 10809	toasty plastic food lab	0		Hot Damage: +5, Single Equip, Last Available: "2021-12"
 10810	purple extremely unsafe plastic nog lab	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2021-12"
 10811	energetic plastic chem lab	0		Maximum MP Percent: +20, Single Equip, Last Available: "2021-12"
@@ -10672,8 +10672,8 @@
 10816	narrow wobbly spinning lion tamer's Rosewater's ice crown of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2021-12"
 10817	red shaking thinker's jeans of the brazier of doom	0		Mysticality: +10, Hot Spell Damage: +25, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-12"
 10818	mirror extremely unsafe Socratic ice wrap of horror	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Spooky Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	tasty special tofu pop	4	awesome	Effect: "Tiki Temerity", Effect Duration: 5, Last Available: "2021-12"
-10820	spoiled enchanted tiny bowl of prescription candy	1	crappy	Effect: "Macho Profundo", Effect Duration: 30, Last Available: "2021-12"
+10819	special tasty tofu pop	4	awesome	Effect: "Tiki Temerity", Effect Duration: 5, Last Available: "2021-12"
+10820	tiny enchanted spoiled bowl of prescription candy	1	crappy	Effect: "Macho Profundo", Effect Duration: 30, Last Available: "2021-12"
 10821	low-calorie stale ghostly fishcake	1	decent	Last Available: "2021-12"
 10822	rotten bone broth	4	crappy	Last Available: "2021-12"
 10823	moldy star pop	3	crappy	Last Available: "2021-12"
@@ -10684,20 +10684,20 @@
 10828	boiled teal Homebodyl&trade;	1		Last Available: "2021-12"
 10829	pickled wobbly Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	denatured upside-down Breathitin&trade;	1		Effect: "Cosmic Flavor", Effect Duration: 35, Last Available: "2021-12"
-10831	powdered mirror squat Fleshazole&trade;	1		Effect: "Broberry Brotality", Effect Duration: 10, Last Available: "2021-12"
+10831	powdered squat mirror Fleshazole&trade;	1		Effect: "Broberry Brotality", Effect Duration: 10, Last Available: "2021-12"
 10832	Vulcanized ghostly purple anti-burn cream	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 57, Last Available: "2021-12"
-10833	galvanized modified green squat anti-freeze cream	0		Effect: "Stenchtastic", Effect Duration: 57, Last Available: "2021-12"
+10833	galvanized modified squat green anti-freeze cream	0		Effect: "Stenchtastic", Effect Duration: 57, Last Available: "2021-12"
 10834	ionized double-quantum unsweetened anti-goosebump cream	0		Effect: "Poker Faced", Effect Duration: 30, Last Available: "2021-12"
 10835	moist shaking anti-odor cream	0		Effect: "Extra-Sharp Weapon", Effect Duration: 38, Last Available: "2021-12"
 10836	anodized narrow anti-creep cream	0		Effect: "Your Favorite Flavor", Effect Duration: 28, Last Available: "2021-12"
 10837	irradiated concentrated twirling anti-pain cream	0		Effect: "Pasty", Effect Duration: 21, Last Available: "2021-12"
 10838	weak fancy perfectly mixed Doc's Special Reserve Wine	2	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 5, Last Available: "2021-12"
-10839	moldy thick bread pie	5	crappy	Last Available: "2021-12"
+10839	thick moldy bread pie	5	crappy	Last Available: "2021-12"
 10840	artisanal watered-down clear Russian	2	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
-10843	olive huge Crimbo ball	0		Last Available: "2021-12"
-10844	cyan blinking gooified animal matter	0		Last Available: "2021-12"
+10843	huge olive Crimbo ball	0		Last Available: "2021-12"
+10844	blinking cyan gooified animal matter	0		Last Available: "2021-12"
 10845	bouncing jittery gooified vegetable matter	0		Last Available: "2021-12"
 10846	wobbly gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10729,7 +10729,7 @@
 10873	Van der Graaf crafty energetic can of mixed everything	0		Maximum MP Percent: +20, Maximum MP: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	wobbly tumbling the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	bite-sized decent meatball	1	good	Last Available: "2021-12"
+10876	decent bite-sized meatball	1	good	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10740,7 +10740,7 @@
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	padded personal trainer's magnifying glass of the sewer	0		Experience Percent (Muscle): +10, Damage Absorption: +20, Stench Damage: +25, Last Available: "2022-12"
 10886	hand-crafted void lager	4	EPIC	Last Available: "2022-12"
-10887	flavorless bite-sized teal void burger	1	decent	Last Available: "2022-12"
+10887	bite-sized flavorless teal void burger	1	decent	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	pulsating shaking veiny strapping void shard of the brute of Flo-Jo	0		Muscle: +5, Muscle Percent: +30, Maximum HP: +10, Initiative: +100, Last Available: "2022-12"
 10890	cyan undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10769,8 +10769,8 @@
 10913	special bouncing bar of freeze-dried water	1	decent	Effect: "Poker Faced", Effect Duration: 45, Last Available: "2022-05"
 10914	big spoiled expired MRE	5	crappy	Last Available: "2022-05"
 10915	normal narrow bouncing cool mint precipice bar	3	good	Last Available: "2022-05"
-10916	big adequate carrot cake precipice bar	5	good	Last Available: "2022-05"
-10917	ghostly cyan ghostly The Big Book of Every Skill	0		
+10916	adequate big carrot cake precipice bar	5	good	Last Available: "2022-05"
+10917	ghostly ghostly cyan The Big Book of Every Skill	0		
 10918	yellow Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	bouncing Sinatra's Herculean June cleaver of the wise owl	0		Mysticality: +20, Experience (Muscle): +1, Experience (Moxie): +5, Attacks Can't Miss, Last Available: "2022-06"
@@ -10782,11 +10782,11 @@
 10926	altered green trampled ticket stub	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 65, Last Available: "2022-06"
 10927	super-oxidized irradiated yellow savings bond	0		Effect: "Red Around the Gills", Effect Duration: 58, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	denatured sweat-ade	1		Last Available: "2022-07"
 10931	cyan unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	blue stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
-10933	narrow shaking thick dinosaur	0		
+10933	shaking narrow thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
@@ -10797,7 +10797,7 @@
 10941	moist quadruple-dry Dino DNAde&trade;	0		Effect: "Spiky Hair", Effect Duration: 61
 10942	skewed dinosaur repellent	0		
 10943	green foul-smelling camouflage vest	0		Stench Damage: +10
-10944	pulsating blue Dinodollar	0		
+10944	blue pulsating Dinodollar	0		
 10945	spinning valuable dinosaur droppings	0		
 10946	dinosaur pheromone kit	0		
 10947	toasty curative awkward dinosaur research harness of Leguizamo	0		Monster Level: +20, Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5
@@ -10805,7 +10805,7 @@
 10949	dinosaur of the brute	0		Muscle Percent: +30
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	wobbly flame-retardant groovy Jurassic Parka	0		Moxie Percent: +10, Hot Resistance: +1, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	wobbly flame-retardant groovy Jurassic Parka	0		Moxie Percent: +10, Hot Resistance: +1, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	magnetized adjusted corrupted autumn leaf	0		Effect: "Dreadful Chill", Effect Duration: 34, Last Available: "2022-10"
@@ -10818,7 +10818,7 @@
 10962	vaporized autumn breeze	1		Last Available: "2022-10"
 10963	boiled warmed ionized gray tumbling autumn years wisdom	0		Effect: "Twinkly Weapon", Effect Duration: 69, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	aged fancy Oopsie IPA	3	awesome	Effect: "Hombre Muerto Caminando", Effect Duration: 45, Last Available: "2022-10"
+10965	fancy aged Oopsie IPA	3	awesome	Effect: "Hombre Muerto Caminando", Effect Duration: 45, Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	fuchsia Yeast of Boris	0		Last Available: "2022-11"
 10968	pulsating St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10826,33 +10826,33 @@
 10970	yummy ratatouille de Jarlsberg	3	awesome	Last Available: "2022-11"
 10971	low-calorie spoiled Jarlsberg's vegetable soup	1	crappy	Last Available: "2022-11"
 10972	stale roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
-10973	normal half-sized St. Pete's sneaky smoothie	2	good	Last Available: "2022-11"
+10973	half-sized normal St. Pete's sneaky smoothie	2	good	Last Available: "2022-11"
 10974	delicious Pete's wiley whey bar	4	awesome	Last Available: "2022-11"
 10975	adequate Pete's rich ricotta	4	good	Last Available: "2022-11"
-10976	artisanal special Boris's beer	4	EPIC	Effect: "Third Based", Effect Duration: 5, Last Available: "2022-11"
+10976	special artisanal Boris's beer	4	EPIC	Effect: "Third Based", Effect Duration: 5, Last Available: "2022-11"
 10977	rotten low-calorie honey bun of Boris	1	crappy	Last Available: "2022-11"
-10978	enchanted spoiled blurry Boris's bread	3	crappy	Effect: "Black Eyes", Effect Duration: 25, Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	fuchsia Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	teal ghostly Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	jittery Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10978	spoiled enchanted blurry Boris's bread	3	crappy	Effect: "Black Eyes", Effect Duration: 25, Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	fuchsia Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	ghostly teal Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	jittery Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	toothsome immense baked veggie ricotta casserole	9	awesome	Last Available: "2022-11"
-10989	low-calorie moldy plain calzone	1	crappy	Last Available: "2022-11"
+10989	moldy low-calorie plain calzone	1	crappy	Last Available: "2022-11"
 10990	normal skewed roasted vegetable focaccia	4	good	Last Available: "2022-11"
 10991	rotten low-calorie Pizza of Legend	1	crappy	Last Available: "2022-11"
-10992	tiny decent Calzone of Legend	1	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	jittery Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	lime green Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10992	decent tiny Calzone of Legend	1	good	Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	jittery Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	lime green Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	squat Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	squat Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	bland Deep Dish of Legend	3	decent	Last Available: "2022-11"
 11001	narrow deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
@@ -10860,26 +10860,26 @@
 11004	prohie's hat of the bloodbag	0		Maximum HP: +100
 11005	ionized imported taffy	0		Effect: "Beta Carotene Overdose", Effect Duration: 44
 11006	yellow brainy Charleston shoes of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Single Equip
-11007	mirror olive booze bindle	0		
+11007	olive mirror booze bindle	0		
 11008	jittery auspicious Rosewater's rare oboe	0		Mysticality Percent: +30, Item Drop: +10
 11009	squat purple censurious Temple Grandin's bullet necklace	0		Familiar Weight: +7, Sleaze Resistance: +3, Single Equip
 11010	normal super-sized huge swamp haunch	5	good	
 11011	Sinatra's gator shades of the wise owl	0		Mysticality: +20, Experience (Moxie): +5, Single Equip
 11012	milk cap	0		
-11013	drinkable practically non-alcoholic bouncing Charleston Choo-Choo	1	good	
+11013	practically non-alcoholic drinkable bouncing Charleston Choo-Choo	1	good	
 11014	weak bad Velvet Veil	2	decent	
-11015	bad extra-dry Marltini	5	decent	
-11016	special acceptable Strong, Silent Type	4	good	Effect: "Full Bottle in front of Me", Effect Duration: 10
-11017	enchanted weak acceptable Mysterious Stranger	2	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 45
+11015	extra-dry bad Marltini	5	decent	
+11016	acceptable special Strong, Silent Type	4	good	Effect: "Full Bottle in front of Me", Effect Duration: 10
+11017	acceptable enchanted weak Mysterious Stranger	2	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 45
 11018	acceptable Champagne Shimmy	4	good	
 11019	blinking the Sot's parcel	0		
-11020	mirror up-at-dawn executive ceramic cestus	0		Meat Drop: +40, Adventures: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	scandalous scorching ceramic centurion shield of the sewer	0		Hot Damage: +25, Stench Damage: +25, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	tumbling maroon ceramic celery grater of chilblains of Flo-Jo	0		Cold Damage: +25, Initiative: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	Annie Oakley's wizardly beefy ceramic celsiturometer	0		Muscle: +10, Mysticality: +25, Critical Hit Percent: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	Jim Carey's ceramic cerecloth belt of the sewer of horror	0		Monster Level: +25, Stench Damage: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	executive padded slick ceramic cenobite's robe	0		Moxie: +10, Damage Absorption: +20, Meat Drop: +40, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
-11026	mixed blinking cyan ghostly ceramic scree	1		Last Available: "2023-12"
+11020	mirror up-at-dawn executive ceramic cestus	0		Meat Drop: +40, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	scandalous scorching ceramic centurion shield of the sewer	0		Hot Damage: +25, Stench Damage: +25, Sleaze Damage: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	tumbling maroon ceramic celery grater of chilblains of Flo-Jo	0		Cold Damage: +25, Initiative: +100, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	Annie Oakley's wizardly beefy ceramic celsiturometer	0		Muscle: +10, Mysticality: +25, Critical Hit Percent: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	Jim Carey's ceramic cerecloth belt of the sewer of horror	0		Monster Level: +25, Stench Damage: +25, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	executive padded slick ceramic cenobite's robe	0		Moxie: +10, Damage Absorption: +20, Meat Drop: +40, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11026	mixed blinking ghostly cyan ceramic scree	1		Last Available: "2023-12"
 11027	non-ionized moist extra-hard jawbreaker	0		Effect: "Rotten Memories", Effect Duration: 30
 11028	huge dangerous groovy chiffon chevrons of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3, Weapon Damage: +10, Single Equip, Last Available: "2023-12"
 11029	lard-coated Rosewater's chiffon chapeau of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Sleaze Spell Damage: +25, Last Available: "2023-12"
@@ -10889,8 +10889,8 @@
 11033	twirling family-friendly mansplainer's Oprah's chiffon chaps	0		Maximum MP Percent: +50, Monster Level: +15, Sleaze Resistance: +1, Last Available: "2023-12"
 11034	vaporized squat gray chiffon carbage	1		Last Available: "2023-12"
 11035	galvanized flattened pressed chiffon lemon	0		Effect: "Human-Slime Hybrid", Effect Duration: 26
-11036	bland miniature ghostly chocomotive	2	decent	Last Available: "2022-12"
-11037	decent gigantic bouncing freightcake	8	good	Last Available: "2022-12"
+11036	miniature bland ghostly chocomotive	2	decent	Last Available: "2022-12"
+11037	gigantic decent bouncing freightcake	8	good	Last Available: "2022-12"
 11038	lousy practically non-alcoholic cabooze	1	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	prompt plastic passenger car	0		Adventures: +3, Last Available: "2022-12"
@@ -10907,7 +10907,7 @@
 11051	super-altered chilled Trainbot tubing	0		Effect: "Chock Full o' Nanites", Effect Duration: 61
 11052	alkaline Trainbot plating	0		Effect: "Hagg-ard", Effect Duration: 29
 11053	warmed modified narrow Trainbot optics	0		Effect: "Human-Machine Hybrid", Effect Duration: 12
-11054	ionized narrow squat purple Trainbot servomotors	0		Effect: "Thicker, Sicker", Effect Duration: 34
+11054	ionized purple squat narrow Trainbot servomotors	0		Effect: "Thicker, Sicker", Effect Duration: 34
 11055	wet pickled Trainbot linkages	0		Effect: "Gamer Rage", Effect Duration: 50
 11056	huge ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
@@ -10924,19 +10924,19 @@
 11068	skewed lost elf luggage	0		
 11069	blinking Trainbot luggage hook	0		Single Equip
 11070	snack-sized flavorless honey-drenched ham slice	2	decent	
-11071	practically non-alcoholic artisanal skewed mostly-empty bottle of cookie wine	1	EPIC	
+11071	artisanal practically non-alcoholic skewed mostly-empty bottle of cookie wine	1	EPIC	
 11072	thick bland Crimbo food scraps	5	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	squat table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	tumbling industrially-crushed ice	0		Last Available: "2022-12"
-11078	adequate small steamed oyster	2	good	
+11078	small adequate steamed oyster	2	good	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
-11083	spinning olive crystal Crimbo platter	0		
+11083	olive spinning crystal Crimbo platter	0		
 11084	weak acceptable jittery Crimbosmopolitan	2	good	Last Available: "2022-12"
 11085	diet bland enchanted Crimbo dinner	1	decent	Effect: "Peppermint Bite", Effect Duration: 50, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
@@ -10974,7 +10974,7 @@
 11119	pickled five-fingered fern resin	0		Effect: "Inebriate Pride", Effect Duration: 48, Last Available: "2023-02"
 11120	spoiled diet olive super good fruit	1	crappy	Last Available: "2023-02"
 11121	altered twirling energized spores	1		Last Available: "2023-02"
-11122	olive Samson's educational hot pepper	0		Experience: +1, Experience (Muscle): +5, Lantern Element: "Hot", Last Available: "2023-02"
+11122	olive Samson's educational hot pepper	0		Experience: +1, Experience (Muscle): +5, Last Available: "2023-02", Lantern Element: "Hot"
 11123	non-polymerized chilled ghostly out-of-work circus flea	0		Effect: "La Bamba", Effect Duration: 49, Last Available: "2023-02"
 11124	narrow narrow extra-grubby grub	0		Last Available: "2023-02"
 11125	anodized boiled fire ant pheromones	0		Effect: "Slightly Mutated", Effect Duration: 45, Last Available: "2023-02"
@@ -10989,14 +10989,14 @@
 11134	activated lump of loyal latite	0		Effect: "Hyperoxygenated Blood", Effect Duration: 55, Last Available: "2023-02"
 11135	flavorless snack-sized shadow sausage	2	decent	Last Available: "2023-03"
 11136	reassuring double-paned shadow skin	0		Cold Resistance: +5, Spooky Resistance: +1, Last Available: "2023-03"
-11137	dry irradiated maroon jittery shadow flame	0		Effect: "Cold Throat", Effect Duration: 50, Last Available: "2023-03"
-11138	huge normal spinning shadow bread	8	good	Last Available: "2023-03"
+11137	dry irradiated jittery maroon shadow flame	0		Effect: "Cold Throat", Effect Duration: 50, Last Available: "2023-03"
+11138	normal huge spinning shadow bread	8	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	perfectly mixed shadow fluid	3	EPIC	Last Available: "2023-03"
 11141	bouncing shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	fuchsia shadow sinew	0		Last Available: "2023-03"
-11144	aged watered-down bouncing shadow venom	2	awesome	Last Available: "2023-03"
+11144	watered-down aged bouncing shadow venom	2	awesome	Last Available: "2023-03"
 11145	compressed blue shadow nectar	1		Last Available: "2023-03"
 11146	aromatic greasy coward's shadow stick	0		Monster Level: -20, Sleaze Spell Damage: +10, Stench Resistance: +1, Last Available: "2023-03"
 11147	huge bat paw of the brazier of horror	0		Hot Spell Damage: +25, Spooky Spell Damage: +25
@@ -11022,7 +11022,7 @@
 11167	shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
-11170	blurry tumbling spinning shadow lighter	0		
+11170	spinning blurry tumbling shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	shadow snowflake	0		
 11173	shadow heart	0		
@@ -11035,10 +11035,10 @@
 11180	Socratic Herculean savvy shadow monocle	0		Mysticality Percent: +20, Experience (Muscle): +1, Experience (Mysticality): +1, Single Equip
 11181	huge shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	rotten immense wobbly shadow hot dog	7	crappy	
-11183	special perfectly mixed blue shadow martini	4	EPIC	Effect: "Bureaucratized", Effect Duration: 25
-11184	altered pulsating spinning shadow pill	1		Effect: "Stinky Hands", Effect Duration: 30
+11183	perfectly mixed special blue shadow martini	4	EPIC	Effect: "Bureaucratized", Effect Duration: 25
+11184	altered spinning pulsating shadow pill	1		Effect: "Stinky Hands", Effect Duration: 30
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	olive monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	moist improved shadow candy	0		Effect: "Nightlit", Effect Duration: 30
 11189	replica Mr. Accessory	0		
@@ -11056,7 +11056,7 @@
 11201	wobbly resourceful replica navel ring of navel gazing of the scaredy-cat of the detective	0		Maximum MP: +50, Monster Level: -15, Item Drop: 25, Single Equip
 11202	Temple Grandin's brawny replica V for Vivala mask	0		Muscle Percent: +20, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	olive medical-grade curative grievous replica haiku katana	0		Weapon Damage Percent: +50, HP Regen Min: 10, HP Regen Max: 15, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
-11204	upside-down fuchsia replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
+11204	fuchsia upside-down replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	replica cotton candy cocoon	0		
 11206	horrifying studded extremely unsafe replica Elvish sunglasses of the bloodbag	0		Weapon Damage Percent: +100, Damage Absorption: +80, Maximum HP: +100, Spooky Damage: +25, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	gray replica squamous polyp	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	mirror replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	huge green deadly Cincho de Mayo of Calamity Jane of the detective of the cheetah	0		Weapon Damage: +5, Critical Hit Percent: +15, Item Drop: +20, Initiative: +60, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	huge green deadly Cincho de Mayo of Calamity Jane of the detective of the cheetah	0		Weapon Damage: +5, Critical Hit Percent: +15, Item Drop: +20, Initiative: +60, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	blinking replica Little Geneticist DNA-Splicing Lab	0		
 11226	bouncing replica still grill	0		
@@ -11103,38 +11103,38 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	banded replica Jurassic Parka of doom	0		Damage Absorption: +100, Spooky Spell Damage: +50
 11250	replica grey gosling	0		
-11251	twirling replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	twirling replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
-11253	tumbling shaking replica Ten Dollars	0		
+11253	shaking tumbling replica Ten Dollars	0		
 11254	rosewater-soaked gravedigger's sinister extremely unsafe replica Cincho de Mayo	0		Weapon Damage Percent: +100, Spell Damage: +10, Spooky Damage: +10, Stench Resistance: +3, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11255	Thwaitgold splendor beetle statuette	0		
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	knitted supercharged energetic vibrating medical-grade hale &quot;I survived Y2K&quot; T-Shirt	0		Maximum HP: +20, Maximum MP Percent: 60, Cold Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	toasty pro skateboard of the cougar	0		Moxie: +20, Hot Damage: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	toasty pro skateboard of the cougar	0		Moxie: +20, Hot Damage: +5, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	mirror teal Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	wholesome Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP Percent: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	wholesome Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	maroon ghostly Newton's stylish beefcake's Amulet of Perpetual Darkness of the boozehound	0		Muscle: +25, Moxie: +25, Experience (Mysticality): +3, Booze Drop: +100, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	yellow Crimbo cookie sheet	0		Last Available: "2023-06"
-11270	cyan squat VHS Tape	0		Last Available: "2023-06"
+11270	squat cyan VHS Tape	0		Last Available: "2023-06"
 11271	polymerized Vulcanized liquefied scroll of minor invulnerability	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 25, Last Available: "2023-06"
 11272	huge Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	blue Arrow (+1)	0		Last Available: "2023-06"
-11276	oxidized ionized altered spinning twirling scroll of protection from lycanthropes	0		Effect: "Human-Constellation Hybrid", Effect Duration: 24, Last Available: "2023-06"
+11276	oxidized ionized altered twirling spinning scroll of protection from lycanthropes	0		Effect: "Human-Constellation Hybrid", Effect Duration: 24, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	jittery ghostly Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	maroon Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	enchanted distilled drinkable Sexy Cosmo	5	good	Effect: "Joyful Resolve", Effect Duration: 15, Last Available: "2023-06"
+11282	drinkable enchanted distilled Sexy Cosmo	5	good	Effect: "Joyful Resolve", Effect Duration: 15, Last Available: "2023-06"
 11283	wobbly Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	Samson's supercool red-soled high heels of Leguizamo	0		Moxie Percent: +20, Experience (Muscle): +5, Monster Level: +20, Last Available: "2023-06"
 11285	small spoiled wobbly cyburger	2	crappy	Last Available: "2025-12"
@@ -11142,7 +11142,7 @@
 11287	spinning shaking lard-coated rutabuga bag of the dark arts	0		Spell Damage Percent: +100, Sleaze Spell Damage: +25
 11288	mesquito proboscis of the wise owl	0		Mysticality: +20
 11289	frightening senate fly thorax	0		Spooky Damage: +5
-11290	chilled activated red mirror bug juice	0		Effect: "Shoesauce", Effect Duration: 52
+11290	chilled activated mirror red bug juice	0		Effect: "Shoesauce", Effect Duration: 52
 11291	blue dog trainer's spider leg	0		Experience (familiar): +1
 11292	narrow beetle antenna of the pedagogue	0		Experience: +3
 11293	green twirling Sherlock's mantis skull	0		Item Drop: +25
@@ -11155,7 +11155,7 @@
 11300	jittery sleeping patriotic eagle	0		Free Pull
 11301	ghostly claw-held flag	0		Familiar Weight: +5
 11302	olive souvenir flag	0		
-11303	blue narrow name change form	0		
+11303	narrow blue name change form	0		
 11304	upside-down replica sleeping patriotic eagle	0		
 11305	huge boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
@@ -11163,7 +11163,7 @@
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
-11311	miniature tasty twirling gray pulsating waffle	2	awesome	
+11311	tasty miniature gray twirling pulsating waffle	2	awesome	
 11312	gray fixodent	0		
 11313	cat o' nine teeth of terror of the glutton	0		Spooky Spell Damage: +10, Food Drop: +100
 11314	avaricious tooth cap of horror	0		Spooky Spell Damage: +25, Meat Drop: +30
@@ -11172,10 +11172,10 @@
 11317	fuchsia handful of toilet paper	0		
 11318	skewed Mrs. Rush	0		
 11319	gray medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	lousy fancy bottle of Cabernet Sauvignon	4	decent	Effect: "Super Structure", Effect Duration: 45
+11320	fancy lousy bottle of Cabernet Sauvignon	4	decent	Effect: "Super Structure", Effect Duration: 45
 11321	chaotic educational strapping baywatch	0		Muscle: +5, Experience: +1, Spell Critical Percent: +10, Lasts Until Rollover
-11322	red Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	olive Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	red Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	olive Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	upside-down consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11219,7 +11219,7 @@
 11364	wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	blurry Elf Guard hotpants	0		Last Available: "2023-12"
-11367	shaking pulsating Crimbuccaneer tricorn	0		Last Available: "2023-12"
+11367	pulsating shaking Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	automa-bot parts	0		
 11370	spinning security automa-core	0		
@@ -11230,8 +11230,8 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	bland gigantic pickled bread	9	decent	Last Available: "2023-12"
-11379	moldy huge salted mutton	7	crappy	Last Available: "2023-12"
+11378	gigantic bland pickled bread	9	decent	Last Available: "2023-12"
+11379	huge moldy salted mutton	7	crappy	Last Available: "2023-12"
 11380	moldy upside-down corned beet	3	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11241,16 +11241,16 @@
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
 11388	fuchsia pirate encryption key charlie	0		Last Available: "2023-12"
-11389	tumbling twirling pirate encryption key delta	0		Last Available: "2023-12"
+11389	twirling tumbling pirate encryption key delta	0		Last Available: "2023-12"
 11390	wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	bland snack-sized peppermint donut	2	decent	
+11395	snack-sized bland peppermint donut	2	decent	
 11396	shaking narrow Elf Guard insignia (private) of wisdom	0		Mysticality: +15, Last Available: "2023-12"
 11397	nasty Crimbuccaneer fledges (mint)	0		Stench Damage: +5, Last Available: "2023-12"
-11398	lime green ghostly military-grade peppermint oil	0		Last Available: "2023-12"
+11398	ghostly lime green military-grade peppermint oil	0		Last Available: "2023-12"
 11399	shaking Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	narrow Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	smooth Crimbuccaneer mologrog cocktail	3	awesome	Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	squat Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	huge friendly thinker's Elf Guard clipboard of the brute	0		Mysticality: +10, Muscle Percent: +30, Familiar Weight: +3, Last Available: "2023-12"
 11435	upside-down pulsating steel-toed pegfinger	0		Damage Reduction: 9, Single Equip, Last Available: "2023-12"
-11436	irresponsibly strong aged and claret	6	awesome	Last Available: "2023-12"
+11436	aged irresponsibly strong and claret	6	awesome	Last Available: "2023-12"
 11437	strapping Elf Guard and beret	0		Muscle: [+5*event(December)], Last Available: "2023-12"
 11438	bouncing smelly sharpshooter's arcane researcher's shipwright's hammer	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +10, Stench Spell Damage: +10, Last Available: "2023-12"
 11439	squat asbestos-lined nasty slick gunwale	0		Moxie: +10, Stench Damage: +5, Hot Resistance: +5, Damage Reduction: 9, Last Available: "2023-12"
@@ -11307,7 +11307,7 @@
 11452	tumbling skewed fireproof lion tamer's Lo Pan's supercharged grievous Sinatra's Elf dessert spoon	0		Experience (Moxie): +5, Weapon Damage Percent: +50, Maximum MP Percent: +30, Spell Critical Percent: +30, Experience (familiar): +2, Hot Resistance: +3, Last Available: "2023-12"
 11453	chilly Elf Guard SCUBA tank	0		Cold Damage: +5, Item Drop: +5, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	mirror purple tumbling rosewater-soaked steel-toed free boots	0		Damage Reduction: 9, Stench Resistance: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	mirror purple tumbling rosewater-soaked steel-toed free boots	0		Damage Reduction: 9, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	pulsating baby rigging snake	0		Last Available: "2023-12"
 11457	mirror asbestos-lined scorching Elvish underarmor of the storm	0		Maximum MP Percent: +40, Hot Damage: +25, Hot Resistance: +5, Single Equip, Last Available: "2023-12"
 11458	purple upside-down sinister Crimbuccaneer bombjacket of the sewer	0		Spell Damage: +10, Stench Damage: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
@@ -11321,19 +11321,19 @@
 11466	watered-down tolerable fuchsia Swedish coffee	2	good	Last Available: "2023-12"
 11467	drinkable canteen of eggnog	4	good	Last Available: "2023-12"
 11468	artisanal yellow hot wine	3	EPIC	Last Available: "2023-12"
-11469	distilled bad Jamaican coffee	5	decent	Last Available: "2023-12"
+11469	bad distilled Jamaican coffee	5	decent	Last Available: "2023-12"
 11470	drinkable practically non-alcoholic flask of egggrog	1	good	Last Available: "2023-12"
 11471	red blurry Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	pulsating Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	smooth weak yule grog	2	awesome	Last Available: "2023-12"
-11475	jumbo special decent wet tack	5	good	Effect: "Engorged Weapon", Effect Duration: 30, Last Available: "2023-12"
-11476	jumbo flavorless whalecake	5	decent	Last Available: "2023-12"
-11477	family-friendly forbidden experienced gunwale whalegun	0		Experience: +2, Spell Damage Percent: +50, Sleaze Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11475	special decent jumbo wet tack	5	good	Effect: "Engorged Weapon", Effect Duration: 30, Last Available: "2023-12"
+11476	flavorless jumbo whalecake	5	decent	Last Available: "2023-12"
+11477	family-friendly forbidden experienced gunwale whalegun	0		Experience: +2, Spell Damage Percent: +50, Sleaze Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	acceptable maroon and claret	3	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	greasy healthy Elf Guard squirtgun	0		Maximum HP Percent: +20, Sleaze Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	greasy healthy Elf Guard squirtgun	0		Maximum HP Percent: +20, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	extremely unsafe sequin-encrusted sweater	0		Weapon Damage Percent: +100, Last Available: "2023-12"
 11484	electrified Herculean replica Elf Guard medal of mayonnaise	0		Experience (Muscle): +1, Sleaze Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	shaking blinking Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	nitrogenated extra-polarized jittery military candy cane	0		Effect: "Altered Wavelengths", Effect Duration: 50
 11503	denatured mirror groggipop	0		Effect: "Litterboxing", Effect Duration: 36
-11504	smelly savvy moss mace	0		Mysticality Percent: +20, Stench Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	twirling baleful moss megaphone of temperance	0		Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	blue up-at-dawn moss medal of the sweet-tooth	0		Candy Drop: +100, Adventures: +5, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	twirling perfumed stylish moss mitre	0		Moxie: +25, Stench Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	flame-retardant Annie Oakley's moss mantle	0		Critical Hit Percent: +20, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	smelly savvy moss mace	0		Mysticality Percent: +20, Stench Spell Damage: +10, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	twirling baleful moss megaphone of temperance	0		Spell Damage: +25, Sleaze Resistance: +5, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	blue up-at-dawn moss medal of the sweet-tooth	0		Candy Drop: +100, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	twirling perfumed stylish moss mitre	0		Moxie: +25, Stench Resistance: +5, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	flame-retardant Annie Oakley's moss mantle	0		Critical Hit Percent: +20, Hot Resistance: +1, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	Rosewater's moss marlinspike of the businessman	0		Mysticality Percent: +30, Meat Drop: +50, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	mixed bouncing moss mulch	1		Last Available: "2024-12"
 11511	diffused moss floss	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 35
@@ -11372,33 +11372,33 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	pickled adobe assortment	1		Last Available: "2024-12"
 11519	improved modified adobe brittle	0		Effect: "The Solution", Effect Duration: 35
-11520	zippy stanky Jack Frost's crepe paper phrygian cap	0		Cold Spell Damage: +50, Stench Spell Damage: +25, Initiative: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	zippy stanky Jack Frost's crepe paper phrygian cap	0		Cold Spell Damage: +50, Stench Spell Damage: +25, Initiative: +20, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	Temple Grandin's educational crepe paper parachute cape of the brazier	0		Experience: +1, Familiar Weight: +7, Hot Spell Damage: +25, Last Available: "2025-12"
-11522	Jeselnik's grievous educational crepe paper pie clip	0		Experience: +1, Weapon Damage Percent: +50, Sleaze Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	pulsating wicked Sinatra's boxer's crepe paper puzzle cube	0		Muscle Percent: +10, Experience (Moxie): +5, Spell Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	Sherlock's veiny crepe paper plunge camisole of the overflowing toilet	0		Maximum HP: +10, Stench Spell Damage: +50, Item Drop: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	auspicious toasty crepe paper polka charm of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Item Drop: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	Jeselnik's grievous educational crepe paper pie clip	0		Experience: +1, Weapon Damage Percent: +50, Sleaze Damage: +25, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	pulsating wicked Sinatra's boxer's crepe paper puzzle cube	0		Muscle Percent: +10, Experience (Moxie): +5, Spell Damage: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	Sherlock's veiny crepe paper plunge camisole of the overflowing toilet	0		Maximum HP: +10, Stench Spell Damage: +50, Item Drop: +25, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	auspicious toasty crepe paper polka charm of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Item Drop: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	powdered crepe paper pared cuttings	1		Effect: "Cheered Up", Effect Duration: 35, Last Available: "2025-12"
 11527	nitrogenated dry crepe paper peanut candy	0		Effect: "Capricorn Rising", Effect Duration: 55
 11528	lightning-fast petrified wood war pike of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Last Available: "2025-12"
 11529	greasy banded petrified wood waist protector	0		Damage Absorption: +100, Sleaze Spell Damage: +10, Single Equip, Last Available: "2025-12"
-11530	mansplainer's dangerous petrified wood wizard's pouch	0		Weapon Damage: +10, Monster Level: +15, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	lime green asbestos-lined wicked petrified wood water purifier	0		Spell Damage: +5, Hot Resistance: +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	mansplainer's dangerous petrified wood wizard's pouch	0		Weapon Damage: +10, Monster Level: +15, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	lime green asbestos-lined wicked petrified wood water purifier	0		Spell Damage: +5, Hot Resistance: +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	gray coward's razor-sharp petrified wood whoopie panama	0		Weapon Damage Percent: +25, Monster Level: -20, Last Available: "2025-12"
 11533	foul-smelling smooth petrified wood walking pants	0		Moxie: +15, Stench Damage: +10, Last Available: "2025-12"
 11534	dehydrated spinning petrified wood waste parts	1		Last Available: "2025-12"
 11535	denatured electrified blinking petrified wood wafer praline	0		Effect: "Leo Rising", Effect Duration: 19
 11536	artisanal cybeer	3	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	skewed wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	pulsating encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	skewed wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	pulsating encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	bouncing blue baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	MacGyver's Fonzie's Crimbuccaneer war standard	0		Experience (Moxie): +1, Maximum MP: +100, Last Available: "2023-12"
 11544	rock-hard experienced Elf Guard war standard	0		Experience: +2, Damage Reduction: 5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	dance instructor's spring shoes of the bloodbag of the storm	0		Experience Percent (Moxie): +10, Maximum HP: +100, Maximum MP Percent: +40, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	dance instructor's spring shoes of the bloodbag of the storm	0		Experience Percent (Moxie): +10, Maximum HP: +100, Maximum MP Percent: +40, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	double-vacuum-sealed improved ultra-soft ferns	0		Effect: "Nightlit", Effect Duration: 24, Last Available: "2024-02"
 11548	tarnished wet crunchy brush	0		Effect: "Salamander In Your Stomach", Effect Duration: 54, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11427,14 +11427,14 @@
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	diet normal blurry yam	1	good	Last Available: "2024-05"
 11574	artisanal yam martini	4	EPIC	Last Available: "2024-05"
-11575	fortified hand-crafted sweet potato o' mine	5	EPIC	Last Available: "2024-05"
-11576	practically non-alcoholic acceptable blurry Southern yam	1	good	Last Available: "2024-05"
-11577	mediocre triple-distilled ghostly sweet potato punch	8	decent	Last Available: "2024-05"
-11578	spoiled small tumbling green Mayam spinach	2	crappy	Last Available: "2024-05"
+11575	hand-crafted fortified sweet potato o' mine	5	EPIC	Last Available: "2024-05"
+11576	acceptable practically non-alcoholic blurry Southern yam	1	good	Last Available: "2024-05"
+11577	triple-distilled mediocre ghostly sweet potato punch	8	decent	Last Available: "2024-05"
+11578	small spoiled tumbling green Mayam spinach	2	crappy	Last Available: "2024-05"
 11579	stale yam and swiss	3	decent	Last Available: "2024-05"
 11580	purple dangerous boxer's yam cannon of dire peril	0		Muscle Percent: +10, Weapon Damage: 30, Lasts Until Rollover, Last Available: "2024-05"
-11581	gray blurry ghostly yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
-11582	upside-down blinking yam battery	0		Last Available: "2024-05"
+11581	ghostly blurry gray yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
+11582	blinking upside-down yam battery	0		Last Available: "2024-05"
 11583	green yam stinkbomb	0		Last Available: "2024-05"
 11584	auspicious coward's mansplainer's furry yam buckler	0		Monster Level: -5, Item Drop: +10, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	blue twirling thanksgiving bomb	0		Last Available: "2024-05"
@@ -11444,9 +11444,9 @@
 11589	bland yam burrito	3	decent	Last Available: "2024-05"
 11590	huge visual packet sniffer	0		Last Available: "2025-12"
 11591	squat mini kiwi egg	0		Free Pull, Last Available: "2024-06"
-11592	mirror huge aviator goggles	0		
+11592	huge mirror aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	normal big mini kiwi	5	good	Last Available: "2024-06"
+11594	big normal mini kiwi	5	good	Last Available: "2024-06"
 11595	Da Vinci's mini kiwi bikini of Leguizamo of chilblains	0		Experience (Mysticality): +5, Monster Level: +20, Cold Damage: +25, Last Available: "2024-06"
 11596	perfectly mixed mini kiwitini	3	EPIC	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11461,7 +11461,7 @@
 11606	mini kiwi icepick of incineration	0		Hot Spell Damage: +50
 11607	unsweetened unsweetened jittery teal mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Yes, Can Haz", Effect Duration: 16
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	wobbly maroon protogenetic chunklet (flagellum)	0		
@@ -11490,7 +11490,7 @@
 11635	acceptable Colera Peste Nebbiolo	4	good	
 11636	jittery longbox of Batfellow comics	0		
 11637	pulsating maroon Thwaitgold shield bug statuette	0		
-11638	blinking wobbly shaking bodyguard badge	0		
+11638	blinking shaking wobbly bodyguard badge	0		
 11639	red Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	jittery Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	bouncing boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	pulsating photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	tumbling boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	lime green auspicious nasty scorching bat wings	0		Hot Damage: +25, Stench Damage: +5, Item Drop: +10, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	lime green auspicious nasty scorching bat wings	0		Hot Damage: +25, Stench Damage: +5, Item Drop: +10, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	coward's Lo Pan's monocle on a stick	0		Spell Critical Percent: +30, Monster Level: -20, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,30 +11523,30 @@
 11668	Oprah's Sheriff badge of the boozehound	0		Maximum MP Percent: +50, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	beefcake's Sheriff pistol of the empath	0		Muscle: +25, Familiar Weight: +5, Lasts Until Rollover, Last Available: "2024-10"
 11670	nasty beefy Sheriff moustache	0		Muscle: +10, Stench Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	manspreader's healthy photo booth supply list	0		Maximum HP Percent: +20, Monster Level: +10, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	manspreader's healthy photo booth supply list	0		Maximum HP Percent: +20, Monster Level: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	blurry tie-dye headband	0		
 11674	adequate low-calorie upside-down whirled peas	1	good	Last Available: "2024-11"
 11675	half-sized decent peaza	2	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	compressed twirling skewed drenchrome 2.0	1		Effect: "Slimily Speedy", Effect Duration: 20, Last Available: "2025-12"
-11678	vaporized upside-down skewed red Synapse Blaster	1		Last Available: "2025-12"
+11678	vaporized skewed upside-down red Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
-11680	purple squat quantum watch	0		Adventures: +2
+11680	squat purple quantum watch	0		Adventures: +2
 11681	wobbly wobbly quantized familiar experience	0		
 11682	nitrogenated ionized tumbling pea brittle	0		Effect: "Gemini Rising", Effect Duration: 20, Last Available: "2024-11"
-11683	weak bad twirling peasco	2	decent	Last Available: "2024-11"
+11683	bad weak twirling peasco	2	decent	Last Available: "2024-11"
 11684	delicious piece of cake	3	awesome	Last Available: "2024-11"
 11685	teal handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	fortified deft pirate hook of Leguizamo	0		Damage Absorption: +60, Monster Level: +20, Lasts Until Rollover, Last Available: "2024-12"
-11689	crafty medical-grade iron tricorn hat	0		Maximum MP: +10, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	crafty medical-grade iron tricorn hat	0		Maximum MP: +10, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	jittery experienced jolly roger flag	0		Experience: +2, Lasts Until Rollover, Last Available: "2024-12"
 11691	olive sleeping profane parrot	0		Last Available: "2024-12"
 11692	twirling pirrrate's currrse	0		Last Available: "2024-12"
 11693	tolerable pulsating tankard of spiced rum	4	good	Last Available: "2024-12"
-11694	watered-down aged yellow tankard of spiced Goldschlepper	2	awesome	Last Available: "2024-12"
+11694	aged watered-down yellow tankard of spiced Goldschlepper	2	awesome	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	mirror blurry fortified governor's daughter's lace collar	0		Damage Absorption: +60, Last Available: "2024-12"
 11697	blurry chaotic governor's daughter's petticoats	0		Spell Critical Percent: +10, Last Available: "2024-12"
@@ -11561,9 +11561,9 @@
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	wool crafty silky pirate drawers	0		Maximum MP: +10, Cold Resistance: +1, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
-11709	concentrated maroon bouncing tumbling peppermint pegleg	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 37, Last Available: "2024-12"
-11710	irresponsibly strong acceptable special huge hard cocoa	7	good	Effect: "The Smile of Mr. A.", Effect Duration: 20, Last Available: "2024-12"
-11711	massive rotten salmagumdi	10	crappy	Last Available: "2024-12"
+11709	concentrated bouncing tumbling maroon peppermint pegleg	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 37, Last Available: "2024-12"
+11710	special acceptable irresponsibly strong huge hard cocoa	7	good	Effect: "The Smile of Mr. A.", Effect Duration: 20, Last Available: "2024-12"
+11711	rotten massive salmagumdi	10	crappy	Last Available: "2024-12"
 11712	manspreader's plastic Easter Island Bunny	0		Monster Level: +10, Last Available: "2024-12"
 11713	hardy plastic St. Patrick	0		Maximum HP: +50, Last Available: "2024-12"
 11714	bouncing zippy wizardly plastic Colonel Brando	0		Mysticality: +25, Initiative: +20, Last Available: "2024-12"
@@ -11574,16 +11574,16 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	green blurry Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	shaking Spirit of Christmas	0		Last Available: "2024-12"
-11722	massive flavorless coney haunch	9	decent	Last Available: "2024-12"
+11722	flavorless massive coney haunch	9	decent	Last Available: "2024-12"
 11723	alkaline dark chocolate egg	0		Effect: "Macho, Macho Dog", Effect Duration: 38, Last Available: "2024-12"
 11724	smooth moai toai	4	awesome	
 11725	auspicious ribald moaiball of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Damage: +10, Item Drop: +10, Last Available: "2024-12"
-11726	squat gray half-digested rat	0		Last Available: "2024-12"
+11726	gray squat half-digested rat	0		Last Available: "2024-12"
 11727	chilled ionized four-leaf potato sprout	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 26, Last Available: "2024-12"
 11728	greedy experienced supercool potato jacket	0		Moxie Percent: +20, Experience: +2, Meat Drop: +20, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	olive mirror Brandonian footlocker key	0		Last Available: "2024-12"
-11731	nippy Socratic military orb	0		Experience (Mysticality): +1, Cold Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	nippy Socratic military orb	0		Experience (Mysticality): +1, Cold Damage: +10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	improved mirror rum ball	0		Effect: "Uncaged Power", Effect Duration: 28
 11733	huge gravy skin	0		Last Available: "2024-12"
 11734	fireproof gravyskin hat of the dark arts	0		Spell Damage Percent: +100, Hot Resistance: +3, Last Available: "2024-12"
@@ -11595,36 +11595,36 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	ghostly nasty healthy stiffened perfect Christmas scarf	0		Damage Reduction: [1*event(December)], Maximum HP Percent: [+20*event(December)], Stench Damage: [+5*event(December)], Single Equip, Last Available: "2024-12"
-11743	snowman-enchanting tophat of the scaredy-cat	0		Monster Level: -15, Item Drop: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	snowman-enchanting tophat of the scaredy-cat	0		Monster Level: -15, Item Drop: +5, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	adjusted altered teal LIDAR candle	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 63, Last Available: "2024-12"
 11745	up-at-dawn chilly experienced Congressional Medal of Insanity	0		Experience: +2, Cold Damage: +5, Adventures: +5, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	triple-distilled mediocre squat Easter grasshopper	7	decent	Last Available: "2024-12"
+11747	mediocre triple-distilled squat Easter grasshopper	7	decent	Last Available: "2024-12"
 11748	practically non-alcoholic aged Irish eggnog	1	awesome	Last Available: "2024-12"
 11749	artisanal canteen of jungle juice	4	EPIC	Last Available: "2024-12"
-11750	artisanal high-proof tumbling huge turchucken	10	EPIC	Last Available: "2024-12"
-11751	practically non-alcoholic smooth mechanically-mulled cider	1	awesome	Last Available: "2024-12"
+11750	artisanal high-proof huge tumbling turchucken	10	EPIC	Last Available: "2024-12"
+11751	smooth practically non-alcoholic mechanically-mulled cider	1	awesome	Last Available: "2024-12"
 11752	lousy pulsating holiday trip around the world	3	decent	Last Available: "2024-12"
 11753	flavorless chocolate ostrich egg	3	decent	Last Available: "2024-12"
-11754	stale jumbo beef and cabbage	5	decent	Last Available: "2024-12"
+11754	jumbo stale beef and cabbage	5	decent	Last Available: "2024-12"
 11755	moldy candy rations	4	crappy	Last Available: "2024-12"
 11756	yummy bouncing double-candied yams	3	awesome	Last Available: "2024-12"
 11757	delicious purple Christmas ham	3	awesome	Last Available: "2024-12"
 11758	decent bite-sized holiday smorgasbord	1	good	Last Available: "2024-12"
-11759	spinning green Bowl of Infinite Jelly	0		Last Available: "2024-12"
+11759	green spinning Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	stylish bejazzled eyepatch	0		Moxie: +25, Last Available: "2024-12"
-11761	spinning gray Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	spinning Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	blue Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	skewed Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	gray spinning Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	spinning Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	blue Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	skewed Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	mansplainer's clever Rosewater's stylish egg gun	0		Moxie: +25, Mysticality Percent: +30, Maximum MP: +20, Monster Level: +15, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	mansplainer's clever Rosewater's stylish egg gun	0		Moxie: +25, Mysticality Percent: +30, Maximum MP: +20, Monster Level: +15, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	executive family-friendly brawny army helmet of the glutton	0		Muscle Percent: +20, Sleaze Resistance: +1, Meat Drop: +40, Food Drop: +100, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	ghostly napkin	0		Last Available: "2024-12"
@@ -11636,29 +11636,29 @@
 11781	deionized aerosolized blurry deviled candy egg	0		Effect: "Ninja, Please", Effect Duration: 42, Last Available: "2024-12"
 11782	teal McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	bouncing frosty McHugeLarge duffel bag	0		Cold Spell Damage: +10, Item Drop: +5, Last Available: "2025-01"
-11784	nasty Lo Pan's smooth McHugeLarge left pole	0		Moxie: +15, Spell Critical Percent: +30, Stench Damage: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	perfumed sizzling quilted McHugeLarge right pole	0		Damage Absorption: +40, Hot Damage: +10, Stench Resistance: +5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	horrifying McHugeLarge left ski of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	Fonzie's McHugeLarge right ski of the early riser	0		Experience (Moxie): +1, Adventures: +7, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	nasty Lo Pan's smooth McHugeLarge left pole	0		Moxie: +15, Spell Critical Percent: +30, Stench Damage: +5, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	perfumed sizzling quilted McHugeLarge right pole	0		Damage Absorption: +40, Hot Damage: +10, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	horrifying McHugeLarge left ski of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +25, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	Fonzie's McHugeLarge right ski of the early riser	0		Experience (Moxie): +1, Adventures: +7, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	twirling upside-down 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	distilled mirror eXpand	1		Last Available: "2025-12"
-11791	blurry brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	blurry brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	squat datastick	0		Last Available: "2025-12"
-11793	twirling blue tumbling dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
+11793	blue twirling tumbling dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	huge fuchsia dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	yellow dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
-11800	jittery twirling dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
+11800	twirling jittery dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	blurry dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	bouncing dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	twirling cybervisor	0		Last Available: "2025-12"
 11804	ghostly retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11679,13 +11679,13 @@
 11824	huge insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	squat fuchsia geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	squat fuchsia geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	maroon geofencing shield	0		Last Available: "2025-12"
 11829	bouncing virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	ninja crampons	0		
 11832	ninja carabiner	0		
-11833	polymerized cold-filtered huge upside-down tumbling synthetic coffee	0		Effect: "Burnt 'n' Turnt", Effect Duration: 12
+11833	polymerized cold-filtered tumbling huge upside-down synthetic coffee	0		Effect: "Burnt 'n' Turnt", Effect Duration: 12
 11834	super-anodized boiled squat iDrops	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 18
 11835	shame coil	0		
 11836	fuchsia new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
@@ -11725,23 +11725,23 @@
 11870	bar dart	0		Last Available: "2025-03"
 11871	mixed leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	tasty Heck ramen	4	awesome	Last Available: "2025-03"
-11873	thick moldy burrito	5	crappy	Last Available: "2025-03"
-11874	snack-sized stale small beer brat	2	decent	Last Available: "2025-03"
+11873	moldy thick burrito	5	crappy	Last Available: "2025-03"
+11874	stale snack-sized small beer brat	2	decent	Last Available: "2025-03"
 11875	half-sized moldy peach pie	2	crappy	Last Available: "2025-03"
-11876	thick rotten spinning incredible mini-pizza	5	crappy	Last Available: "2025-03"
+11876	rotten thick spinning incredible mini-pizza	5	crappy	Last Available: "2025-03"
 11877	aged Divine sidecar	4	awesome	Last Available: "2025-03"
 11878	hand-crafted tangarita sidecar	3	EPIC	Last Available: "2025-03"
 11879	artisanal gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	artisanal vodka stratocaster sidecar	3	EPIC	Last Available: "2025-03"
-11881	perfectly mixed practically non-alcoholic prussian cathouse sidecar	1	EPIC	Last Available: "2025-03"
+11881	practically non-alcoholic perfectly mixed prussian cathouse sidecar	1	EPIC	Last Available: "2025-03"
 11882	lousy triple-distilled Mon Tiki sidecar	7	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	wobbly auspicious April Shower Thoughts shield of dire peril	0		Weapon Damage: +20, Item Drop: +10, Damage Reduction: 6, Last Available: "2025-04"
 11885	spinning glob of wet paper	0		Last Available: "2025-04"
 11886	mirror bouncing spitball	0		Last Available: "2025-04"
-11887	extra-altered dry upside-down mirror wet paper weights	0		Effect: "Uncanny Shot", Effect Duration: 58, Last Available: "2025-04"
-11888	drinkable practically non-alcoholic olive Three Sheets to the Wind	1	good	Last Available: "2025-04"
-11889	miniature decent pile of wet dates	2	good	Last Available: "2025-04"
+11887	extra-altered dry mirror upside-down wet paper weights	0		Effect: "Uncanny Shot", Effect Duration: 58, Last Available: "2025-04"
+11888	practically non-alcoholic drinkable olive Three Sheets to the Wind	1	good	Last Available: "2025-04"
+11889	decent miniature pile of wet dates	2	good	Last Available: "2025-04"
 11890	shaking papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	blue wet shower cap of the sweet-tooth	0		Candy Drop: +100, Last Available: "2025-04"
@@ -11771,9 +11771,9 @@
 11916	therapeutic stylish bycocket	0		HP Regen Min: 5, HP Regen Max: 7
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	gray packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
-11921	jittery squat Axis HQ Code	0		
+11921	squat jittery Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
 11923	exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
 11924	flame-wreathed educational Axis helmet	0		Experience: +1, Hot Spell Damage: +10
@@ -11791,7 +11791,7 @@
 11936	confetti grenade	0		
 11937	moldy Skeleton Wars rations	3	crappy	
 11938	acceptable skeleton war fuel can	3	good	
-11939	maroon spinning skeleton war grenade	0		
+11939	spinning maroon skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
 11942	M&ouml;bius ring	0		Last Available: "2025-08"
@@ -11806,11 +11806,11 @@
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	dried pulsating mixed berry jelly	1		Effect: "Super-Mega-Charged", Effect Duration: 25, Last Available: "2025-08"
 11953	moldy mirror teal blurry toast with mixed berry jelly	3	crappy	Last Available: "2025-08"
-11954	adequate cyan squat cup of sugar	3	good	Last Available: "2025-08"
+11954	adequate squat cyan cup of sugar	3	good	Last Available: "2025-08"
 11955	adequate Susie's cupcake	3	good	Last Available: "2025-08"
 11956	squat clock	0		Last Available: "2025-08"
 11957	aromatic nippy Annie Oakley's the gun	0		Critical Hit Percent: +20, Cold Damage: +10, Stench Resistance: +1, Last Available: "2025-08"
-11958	lousy fancy watered-down wine	2	decent	Effect: "Fire Inside", Effect Duration: 30, Last Available: "2025-08"
+11958	watered-down lousy fancy wine	2	decent	Effect: "Fire Inside", Effect Duration: 30, Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	blue inspector's undersea surveying goggles	0		Item Drop: +15, Lasts Until Rollover
@@ -11820,33 +11820,33 @@
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	lime green scroll of sea smarm	0		
-11969	tumbling narrow wobbly waterlogged scroll of healing	0		
+11969	narrow wobbly tumbling waterlogged scroll of healing	0		
 11970	mirror sea gel	0		
 11971	corrupted vacuum-sealed octopus ink bladder	0		Effect: "Human-Hobo Hybrid", Effect Duration: 20
 11972	durable dolphin whistle	0		
 11973	jittery Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	energetic dentadent	0		Maximum MP Percent: +20
 11986	wobbly lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	cyan gravedigger's curative banded extremely unsafe Newton's blood cubic zirconia of James Dean	0		Experience (Mysticality): +3, Experience (Moxie): +3, Weapon Damage Percent: +100, Damage Absorption: +100, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	cyan gravedigger's curative banded extremely unsafe Newton's blood cubic zirconia of James Dean	0		Experience (Mysticality): +3, Experience (Moxie): +3, Weapon Damage Percent: +100, Damage Absorption: +100, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	distilled tumbling ghostly blood thinner	1		Effect: "OMG WTF", Effect Duration: 25, Last Available: "2025-10"
 12045	mediocre maroon pheromone cocktail	3	decent	Last Available: "2025-10"
-12046	thick toothsome spinal tapas	5	awesome	Last Available: "2025-10"
+12046	toothsome thick spinal tapas	5	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	lightning-fast knitted Herculean shrunken head	0		Experience (Muscle): +1, Cold Resistance: +3, Initiative: +40, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	lightning-fast knitted Herculean shrunken head	0		Experience (Muscle): +1, Cold Resistance: +3, Initiative: +40, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	ghostly knucklebone	0		
 12052	mediocre practically non-alcoholic Smoking Pope	1	decent	
-12053	moldy miniature gray bouncing prize turkey	2	crappy	
+12053	moldy miniature bouncing gray prize turkey	2	crappy	
 12054	dehydrated medicinal gruel	1		
 12055	immense flavorless full-sized pumpkin pie	8	decent	Last Available: "2025-11"
-12056	spirit-forward artisanal bouncing mirror vodka cranberry sauce	5	EPIC	Last Available: "2025-11"
+12056	spirit-forward artisanal mirror bouncing vodka cranberry sauce	5	EPIC	Last Available: "2025-11"
 12057	deionized energized ghostly yammed candy	0		Effect: "Berry Berry Cold", Effect Duration: 34, Last Available: "2025-11"
-12058	small spoiled treasure chestnut	2	crappy	Last Available: "2025-12"
-12059	weak acceptable mulled butter rum	2	good	Last Available: "2025-12"
+12058	spoiled small treasure chestnut	2	crappy	Last Available: "2025-12"
+12059	acceptable weak mulled butter rum	2	good	Last Available: "2025-12"
 12060	extra-warmed deionized electrified cinnamon doubloon	0		Effect: "A Contender", Effect Duration: 67, Last Available: "2025-12"
 12061	shaking greedy plastic left skeleton arm	0		Meat Drop: +20, Last Available: "2025-12"
 12062	deadly plastic left skeleton leg	0		Weapon Damage: +5, Last Available: "2025-12"
@@ -11869,7 +11869,7 @@
 12079	pulsating devilbone corset of the cheetah	0		Initiative: +60, Last Available: "2026-12"
 12080	huge perfumed stylish devilbone flute	0		Moxie: +25, Stench Resistance: +5, Last Available: "2026-12"
 12081	frosty devilbone rosary	0		Cold Spell Damage: +10, Single Equip, Last Available: "2026-12"
-12082	altered green spinning devilbone chunks	1		Last Available: "2026-12"
+12082	altered spinning green devilbone chunks	1		Last Available: "2026-12"
 12083	improved olive Gehenna tattoo	0		Effect: "Rushtacean'", Effect Duration: 23
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11881,7 +11881,7 @@
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	artisanal Steve Abrams' Holiday Sampler Beer	3	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	bad irresponsibly strong bottle of prize-winning rum	6	decent	Last Available: "2025-12"
+12126	irresponsibly strong bad bottle of prize-winning rum	6	decent	Last Available: "2025-12"
 12127	auspicious wool rosy-cheeked Santa-Slayer medal	0		Maximum HP Percent: +30, Cold Resistance: +1, Item Drop: +10, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	concentrated quantum boiling bone marrow	0		Effect: "Fangs and Pangs", Effect Duration: 25, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	quadruple-galvanized boiling synovial fluid	0		Effect: "Booooooze", Effect Duration: 19, Last Available: "2025-12"
 12132	chilly forbidden smoldering vertebra of chilblains	0		Spell Damage Percent: +50, Cold Damage: 30, Single Equip, Last Available: "2025-12"
 12133	mirror seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
-12136	twirling blurry red volatile bone bomb	0		Last Available: "2025-12"
+12136	blurry red twirling volatile bone bomb	0		Last Available: "2025-12"
 12137	studded cool hot boning knife of temperance	0		Moxie: +5, Damage Absorption: +80, Sleaze Resistance: +5, Single Equip, Last Available: "2025-12"
 12138	zippy Lo Pan's arcane researcher's fistbone	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +30, Initiative: +20, Last Available: "2025-12"
 12139	mirror prompt clever burnt bone belt of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +20, Adventures: +3, Single Equip, Last Available: "2025-12"
 12140	razor-sharp scorched skull trophy	0		Weapon Damage Percent: +25, Last Available: "2025-12"
-12141	bland diet pulsating wing bone	1	decent	Last Available: "2025-12"
+12141	diet bland pulsating wing bone	1	decent	Last Available: "2025-12"
 12142	lousy high-proof weak skeleton venom	10	decent	Last Available: "2025-12"
 12143	twisted teal baked bone meal	1		Last Available: "2025-12"
 12144	Annie Oakley's plastic skeleton rib cage	0		Critical Hit Percent: +20, Last Available: "2025-12"
@@ -11927,16 +11927,16 @@
 12169	MacGyver's ship's lantern	0		Maximum MP: +100, Last Available: "2025-12"
 12170	skewed heat-resistant harpoon pistol of the brute of temperance	0		Muscle Percent: +30, Sleaze Resistance: +5, Last Available: "2025-12"
 12171	delicious traditional gingerloaf	3	awesome	Last Available: "2025-12"
-12172	practically non-alcoholic acceptable Scotch and eggnog	1	good	Last Available: "2025-12"
+12172	acceptable practically non-alcoholic Scotch and eggnog	1	good	Last Available: "2025-12"
 12173	oxidized Vulcanized maroon counterskeleton elixir	0		Effect: "Carrion' On", Effect Duration: 42, Last Available: "2025-12"
 12174	high-proof mediocre &quot;salvaged&quot; wine	8	decent	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	gray crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	normal maroon squat wedge of prize-winning cheese	3	good	Last Available: "2025-12"
+12177	normal squat maroon wedge of prize-winning cheese	3	good	Last Available: "2025-12"
 12178	triple-magnetized wobbly squat gummi fingerbone	0		Effect: "Phairly Balanced", Effect Duration: 38
 12179	executive stanky glimmering crystal	0		Stench Spell Damage: +25, Meat Drop: +40, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	teal Thwaitgold meat bee statuette	0		
 12183	upside-down loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11945,7 +11945,7 @@
 12187	Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	fuchsia 2015 landfill detritus	0		Last Available: "2026-03"
 12189	intact dinosaur egg	0		Last Available: "2026-03"
-12190	bouncing blue fossilized cow femur	0		Familiar Weight: +5
+12190	blue bouncing fossilized cow femur	0		Familiar Weight: +5
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	mirror Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	super-unsweetened Pork Elf mouthwash	0		Effect: "Booooooze", Effect Duration: 28, Last Available: "2026-03"
@@ -11969,7 +11969,7 @@
 12211	Jim Carey's experienced hoverboard of the blizzard	0		Experience: +2, Monster Level: +25, Cold Spell Damage: +25, Single Equip, Last Available: "2026-03"
 12212	lime green razor-sharp left shark fin of the brute of Leguizamo	0		Muscle Percent: +30, Weapon Damage Percent: +25, Monster Level: +20, Last Available: "2026-03"
 12213	fitness tracking bracelet of the cougar	0		Moxie: +20, Single Equip, Last Available: "2026-03"
-12214	diluted narrow lime green candy bone	1		
+12214	diluted lime green narrow candy bone	1		
 12215	skewed wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	yummy tumbling discarded hot dog	3	awesome	Last Available: "2026-04"
@@ -11977,31 +11977,31 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	rotten immense can of tuna	6	crappy	
+12226	immense rotten can of tuna	6	crappy	
 12227	half-sized spoiled alien salad	2	crappy	
 12228	yummy ratbatatouille	3	awesome	
 12229	stale olive onigiri	4	decent	
 12230	miniature rotten crudit&eacute;s	2	crappy	
-12231	snack-sized bland upside-down sauced mutton	2	decent	
-12232	bite-sized normal wobbly hot honey ant	1	good	
+12231	bland snack-sized upside-down sauced mutton	2	decent	
+12232	normal bite-sized wobbly hot honey ant	1	good	
 12233	rotten tomb aspic	3	crappy	
 12234	flavorless super-sized later tots	5	decent	
 12235	stale Frutti di Scatoletta	4	decent	Last Available: "2026-05"
-12236	decent low-calorie Pesto alla Marziano	1	good	Last Available: "2026-05"
+12236	low-calorie decent Pesto alla Marziano	1	good	Last Available: "2026-05"
 12237	spoiled spinning Arrattabbattabiata	4	crappy	Last Available: "2026-05"
 12238	bite-sized flavorless Orzo di Riso	1	decent	Last Available: "2026-05"
-12239	small moldy huge Pasta Grimavera	2	crappy	Last Available: "2026-05"
-12240	special moldy Linguini Ubriacapa	3	crappy	Effect: "Wit Tea", Effect Duration: 20, Last Available: "2026-05"
-12241	half-sized decent Formica e Pepe	2	good	Last Available: "2026-05"
+12239	moldy small huge Pasta Grimavera	2	crappy	Last Available: "2026-05"
+12240	moldy special Linguini Ubriacapa	3	crappy	Effect: "Wit Tea", Effect Duration: 20, Last Available: "2026-05"
+12241	decent half-sized Formica e Pepe	2	good	Last Available: "2026-05"
 12242	tasty Tubetto Gelatto	3	awesome	Last Available: "2026-05"
 12243	moldy ghostly Gnocci Domani	3	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
-12246	narrow jittery second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
+12246	jittery narrow second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	beefy Space Soldier Helmet of the storm	0		Muscle: +10, Maximum MP Percent: +40
 12253	stale premium turkey leg	4	decent	
-12254	artisanal high-proof styrofoam cup of mead	9	EPIC	
+12254	high-proof artisanal styrofoam cup of mead	9	EPIC	
 12255	knitted sword	0		Cold Resistance: +3
 12256	Usain Bolt's staff	0		Initiative: +80
 12257	lute of extreme caution	0		Monster Level: -25
@@ -12017,11 +12017,11 @@
 12267	flame-wreathed flimsy plastic breastplate	0		Hot Spell Damage: +10
 12268	sage flimsy plastic shield	0		Mysticality Percent: +10, Damage Reduction: 3
 12269	wobbly packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	blurry squat vibrating rock-hard Portable Laughing Stock of bravery	0		Damage Reduction: 5, Maximum MP Percent: +10, Spooky Resistance: +5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	blurry squat vibrating rock-hard Portable Laughing Stock of bravery	0		Damage Reduction: 5, Maximum MP Percent: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	hale dangerous Staff of Anachronistic Churning of chilblains	0		Weapon Damage: +10, Maximum HP: +20, Cold Damage: +25
-12272	decent miniature classic banana	2	good	Last Available: "2026-07"
+12272	miniature decent classic banana	2	good	Last Available: "2026-07"
 12273	flavorless watermelon	3	decent	Last Available: "2026-07"
-12274	spoiled miniature tumbling quince	2	crappy	Last Available: "2026-07"
+12274	miniature spoiled tumbling quince	2	crappy	Last Available: "2026-07"
 12275	blinking Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	huge bland classic banana pie	7	decent	Last Available: "2026-07"
@@ -12029,7 +12029,7 @@
 12279	super-quantum skewed bouncing banana quintessence	0		Effect: "Super Skill", Effect Duration: 68, Last Available: "2026-07"
 12280	lousy Aesop Daiquiri	3	decent	Last Available: "2026-07"
 12281	triple-distilled acceptable bouncing Monkey Congress	8	good	Last Available: "2026-07"
-12282	adequate miniature watermelon pie	2	good	Last Available: "2026-07"
+12282	miniature adequate watermelon pie	2	good	Last Available: "2026-07"
 12283	moist narrow concentrated watermelon juice	0		Effect: "Really Deep Breath", Effect Duration: 65, Last Available: "2026-07"
 12284	galvanized bouncing Aqua Citrulanatae	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 40, Last Available: "2026-07"
 12285	tolerable irresponsibly strong Melonegroni	10	good	Last Available: "2026-07"
@@ -12038,11 +12038,11 @@
 12288	improved ionized quince quaff	0		Effect: "Locks Like the Raven", Effect Duration: 69, Last Available: "2026-07"
 12289	diffused pickled gray Quickquince	0		Effect: "Chorale of Companionship", Effect Duration: 20, Last Available: "2026-07"
 12290	practically non-alcoholic drinkable Quiskey Sour	1	good	Last Available: "2026-07"
-12291	bad practically non-alcoholic Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
+12291	practically non-alcoholic bad Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
 12292	weak hand-crafted Roth IPA	2	EPIC	Last Available: "2026-08"
 12293	narrow aromatic underdraft protection of Tarzan	0		Experience (Muscle): +3, Stench Resistance: +1, Last Available: "2026-08"
 12294	green solvent	0		Last Available: "2026-08"
-12295	stale super-sized soybean futures	5	decent	Last Available: "2026-08"
+12295	super-sized stale soybean futures	5	decent	Last Available: "2026-08"
 12296	colloidal narrow housing bubble	0		Effect: "[1609]Dancin' Fool", Effect Duration: 28, Last Available: "2026-08"
 12297	tarnished dry squat Pixie-Swordz	0		Effect: "Very Clean Guns", Effect Duration: 41
 12298	horrifying mansplainer's financial instrument	0		Monster Level: +15, Spooky Damage: +25, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Accordion_Thief_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Packrat_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	watered-down artisanal squat Petite Porter	2	EPIC	
+-1	artisanal watered-down squat Petite Porter	2	EPIC	
 -2	lousy skewed Scrawny Stout	3	decent	
 -3	lousy Infinitesimal IPA	4	decent	
 -4	hand-crafted eggnogtini	3	EPIC	
 -5	practically non-alcoholic lousy candycaine	1	decent	
 -6	drinkable braincracker sweet	3	good	
--16	weak acceptable shaking fermented honey	2	good	
+-16	acceptable weak shaking fermented honey	2	good	
 -17	aged watered-down moons-shine	2	awesome	
--18	watered-down tolerable mirror jittery gin	2	good	
--19	lousy special bouncing ecto-nog	4	decent	
+-18	watered-down tolerable jittery mirror gin	2	good	
+-19	special lousy bouncing ecto-nog	4	decent	
 -20	mediocre hot toady	4	decent	
 -21	drinkable fancy hot choculate	3	good	
 -49	watered-down lousy Cyder	2	decent	
 -50	hand-crafted Oil Nog	3	EPIC	
 -51	tolerable Hi-Octane Peppermint Jet Fuel	4	good	
 -58	hand-crafted Grimacider	3	EPIC	
--59	practically non-alcoholic artisanal Isotope Nog	1	EPIC	
+-59	artisanal practically non-alcoholic Isotope Nog	1	EPIC	
 -60	smooth Mutagin 'n' Tonic	3	awesome	
--70	smooth irresponsibly strong Gin and Herring	9	awesome	
+-70	irresponsibly strong smooth Gin and Herring	9	awesome	
 -71	tolerable weak Black and Tan and Red All Over	2	good	
--72	weak lousy gray Antarctic Ice Tea	2	decent	
+-72	lousy weak gray Antarctic Ice Tea	2	decent	
 -76	boozy tolerable narrow CRIMBCO Ribbon Candy Schnapps	5	good	
 -77	weak hand-crafted CRIMBCO Egg Substitute Nog Substitute	2	EPIC	
--78	triple-distilled bad CRIMBCO Extreme Braincracker Sour	9	decent	
+-78	bad triple-distilled CRIMBCO Extreme Braincracker Sour	9	decent	
 -82	mediocre weak huge Horseradish-infused Vodka	2	decent	
 -83	perfectly mixed Jerkitini	3	EPIC	
--84	watered-down acceptable Desert Island Iced Tea	2	good	
--88	artisanal watered-down Crimbo Saketini	2	EPIC	
+-84	acceptable watered-down Desert Island Iced Tea	2	good	
+-88	watered-down artisanal Crimbo Saketini	2	EPIC	
 -89	delicious Crimboku Drop	4	awesome	
 -90	drinkable Flaming Crimbo Log	4	good	
 -107	drinkable bouncing yellow Fortified Eggnog Slurry	4	good	
 -108	irresponsibly strong mediocre Hot Buttered Rum	10	decent	
--109	weak lousy Spicy Hot Chocolate	2	decent	
+-109	lousy weak Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Accordion_Thief_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Packrat_cafe_food.txt
@@ -1,20 +1,20 @@
--1	miniature adequate squat Peche a la Frog	2	good	
+-1	adequate miniature squat Peche a la Frog	2	good	
 -2	spoiled skewed As Jus Gezund Heit	3	crappy	
 -3	spoiled Bouillabaise Coucher Avec Moi	4	crappy	
 -7	spoiled mirror upside-down gumdrop chow mein	3	crappy	
--8	jumbo decent candy cane pizza	5	good	
--9	bland miniature jittery gingerbread stir-fry	2	decent	
+-8	decent jumbo candy cane pizza	5	good	
+-9	miniature bland jittery gingerbread stir-fry	2	decent	
 -10	rotten twigs and gravel	4	crappy	
 -11	moldy shoots and leaves	3	crappy	
--12	gigantic spoiled narrow bowl of unidentifiable goo	8	crappy	
+-12	spoiled gigantic narrow bowl of unidentifiable goo	8	crappy	
 -13	stale jittery gingerbread massacre	4	decent	
 -14	normal diet It Came From Beyond Dessert	1	good	
 -15	thick adequate shaking purple vampire cake	5	good	
 -52	spoiled tiny Soylent Red and Green	1	crappy	
 -53	normal Disc-Shaped Nutrition Unit	3	good	
 -54	stale Gingerborg Hive	3	decent	
--61	half-sized rotten Candy Cane Surprise	2	crappy	
--62	jumbo moldy mirror skewed fuchsia Grimdrop Chow Mein	5	crappy	
+-61	rotten half-sized Candy Cane Surprise	2	crappy	
+-62	jumbo moldy fuchsia mirror skewed Grimdrop Chow Mein	5	crappy	
 -63	normal miniature ghostly Grimgerbread House	2	good	
 -67	special bland Caviar Carbonara	3	decent	
 -68	flavorless Halibut Alfredo	4	decent	
@@ -22,24 +22,24 @@
 -73	rotten CRIMBCO Reconstituted Gruel	4	crappy	
 -74	normal miniature New and Improved CRIMBCO Reconstituted Gruel	2	good	
 -75	stale ghostly CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
--79	normal blue upside-down Brussels Sprout Stir-Fry	3	good	
+-79	normal upside-down blue Brussels Sprout Stir-Fry	3	good	
 -80	thick spoiled Carrot, Cabbage, and Kale Pizza	5	crappy	
 -81	stale Turnip and Rutabaga Pie	4	decent	
--85	bland low-calorie Rainbow Spider Fun Roll	1	decent	
+-85	low-calorie bland Rainbow Spider Fun Roll	1	decent	
 -86	spoiled small Vegas Volcano Lava Roll	2	crappy	
--87	super-sized delicious Crazy Dragon Shogun Buddha Roll	5	awesome	
--92	normal jittery green basic hot dog	4	good	
--93	small spoiled savage macho dog	2	crappy	
+-87	delicious super-sized Crazy Dragon Shogun Buddha Roll	5	awesome	
+-92	normal green jittery basic hot dog	4	good	
+-93	spoiled small savage macho dog	2	crappy	
 -94	small stale one with everything	2	decent	
 -95	adequate sly dog	3	good	
 -96	thick normal devil dog	5	good	
--97	moldy red blinking chilly dog	4	crappy	
+-97	moldy blinking red chilly dog	4	crappy	
 -98	toothsome ghostly ghost dog	3	awesome	
 -99	normal junkyard dog	4	good	
--100	adequate massive wet dog	9	good	
+-100	massive adequate wet dog	9	good	
 -101	decent sleeping dog	4	good	
 -102	adequate teal optimal dog	3	good	
--103	half-sized adequate video games hot dog	2	good	
+-103	adequate half-sized video games hot dog	2	good	
 -104	moldy big Peppermint Nutrition Block	5	crappy	
 -105	adequate Gingerbread Nutrition Block	3	good	
--106	normal fancy immense Cinnamon Nutrition Block	7	good	
+-106	immense normal fancy Cinnamon Nutrition Block	7	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Platypus.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Platypus.txt
@@ -12,7 +12,7 @@
 12	spinning mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	dried ghostly blinking moxie weed	1		
 15	mixed strongness elixir	1		
-16	vaporized jittery huge magicalness-in-a-can	1		
+16	vaporized huge jittery magicalness-in-a-can	1		
 17	yummy noodles	3	awesome	
 18	blinking tortoise's blessing	0		
 19	asparagus knife of courage	0		Spooky Resistance: +3
@@ -23,7 +23,7 @@
 24	ten-leaf clover	0		
 25	meat paste	0		
 26	shaking Dolphin King's map	0		
-27	upside-down shaking spider web	0		
+27	shaking upside-down spider web	0		
 28	really spider web	0		
 29	olive really really spider web	0		
 30	squat rock	0		
@@ -37,7 +37,7 @@
 38	nippy Knob Goblin pants	0		Cold Damage: +10, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	casino pass	0		
-41	tolerable distilled skewed ice-cold Sir Schlitz	5	good	
+41	distilled tolerable skewed ice-cold Sir Schlitz	5	good	
 42	hermit permit	0		
 43	worthless trinket	0		
 44	worthless gewgaw	0		
@@ -57,7 +57,7 @@
 58	wobbly stone turtle	0		
 59	huge slingshot	0		
 60	clever Mace of the Tortoise	0		Maximum MP: +20, Class: "Turtle Tamer"
-61	delicious bite-sized fortune cookie	1	awesome	
+61	bite-sized delicious fortune cookie	1	awesome	
 62	Socratic oriole-feather headdress	0		Experience (Mysticality): +1, Familiar Effect: "atk, 3xVolley, cap 3"
 63	blinking gray action figure body	0		
 64	action figure head	0		
@@ -76,15 +76,15 @@
 77	pulsating Socratic stick	0		Experience (Mysticality): +1
 78	supercharged pretty bouquet	0		Maximum MP Percent: +30
 79	bouncing bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
-80	wobbly upside-down fairy gravy boat	0		
+80	upside-down wobbly fairy gravy boat	0		
 81	watered-down hand-crafted ice-cold Willer	2	EPIC	
 82	ring	0		
 83	squat shaft	0		
 84	Orcish meat locker	0		
-85	blue blinking unlocked meat locker	0		
+85	blinking blue unlocked meat locker	0		
 86	key	0		
 87	meat from yesterday	0		
-88	narrow blurry meat stack	0		
+88	blurry narrow meat stack	0		
 89	red sword hilt	0		
 90	helmet recipe	0		
 91	blue pants kit	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	staff of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50
 104	scarecrow	0		
-105	normal enchanted jumbo blurry bowl of charms	5	good	Effect: "Jawin'", Effect Duration: 5
+105	normal jumbo enchanted blurry bowl of charms	5	good	Effect: "Jawin'", Effect Duration: 5
 106	ketchup	1	decent	
 107	fancy catsup	1	good	Effect: "Afternoon Insight", Effect Duration: 25
 108	tumbling stick	0		
@@ -163,19 +163,19 @@
 164	smart skull	0		
 165	mirror green skewer	0		
 166	huge blinking ghuol ears	0		
-167	enchanted delicious miniature narrow ghuol-ear kabob	2	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
+167	delicious miniature enchanted narrow ghuol-ear kabob	2	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
 168	flame-wreathed bone rattle	0		Hot Spell Damage: +10
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
-170	teal huge lihc eye	0		
-171	toothsome tiny lihc eye pie	1	awesome	
+170	huge teal lihc eye	0		
+171	tiny toothsome lihc eye pie	1	awesome	
 172	shaking blinking gnoll lips	0		
 173	olive taco shell	0		
 174	Gnollish casserole dish	0		
-175	immense rotten uncooked chorizo	10	crappy	
+175	rotten immense uncooked chorizo	10	crappy	
 176	disembodied brain	0		
 177	pulsating brainy skull	0		
 178	detective skull	0		
-179	decent massive chorizo taco	10	good	
+179	massive decent chorizo taco	10	good	
 180	artisanal ice-cold fotie	3	EPIC	
 181	baseball	0		
 182	batgut	0		
@@ -195,7 +195,7 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	huge brawny ring	0		Muscle Percent: +20
-200	enchanted diet stale twirling rat appendix kabob	1	decent	Effect: "Wit Tea", Effect Duration: 5
+200	enchanted stale diet twirling rat appendix kabob	1	decent	Effect: "Wit Tea", Effect Duration: 5
 201	half-sized moldy bat wing kabob	2	crappy	
 202	small spoiled carob chunks	2	crappy	
 203	herbs	0		
@@ -204,7 +204,7 @@
 206	piercing post	0		
 207	red hippy herbal tea	1	decent	
 208	patchouli incense stick	0		
-209	teal shaking mirror wad of tofu	0		
+209	shaking mirror teal wad of tofu	0		
 210	Feng Shui for Big Dumb Idiots	0		
 211	huge decorative fountain	0		
 212	windchimes	0		
@@ -220,24 +220,24 @@
 222	blue shaking phat turquoise bead	0		
 223	lard-coated phat turquoise bracelet	0		Sleaze Spell Damage: +25
 224	inspector's eyepatch	0		Item Drop: +15, Familiar Effect: "3xBarrr, cap 6"
-225	spoiled half-sized tofu casserole	2	crappy	
+225	half-sized spoiled tofu casserole	2	crappy	
 226	diluted can of Red Minotaur	1	decent	Effect: "Toothy Grin", Effect Duration: 20
 227	wobbly Jack Frost's Kentucky-fried meat sword	0		Cold Spell Damage: +50
 228	rosewater-soaked Kentucky-fried meat staff	0		Stench Resistance: +3
 229	Kentucky-fried meat crossbow of wisdom	0		Mysticality: +15
 230	blinking sharpshooter's dead guy's watch	0		Critical Hit Percent: +10, Single Equip
 231	Doc Galaktik's Pungent Unguent	0		
-232	twirling squat Doc Galaktik's Ailment Ointment	0		
+232	squat twirling Doc Galaktik's Ailment Ointment	0		
 233	squat Doc Galaktik's Restorative Balm	0		
 234	squat squat Doc Galaktik's Homeopathic Elixir	0		
 235	ghostly reassuring deadly Bigger Bugfinder Blade	0		Weapon Damage: +5, Spooky Resistance: +1
 236	Queue Du Coq cocktailcrafting kit	0		
 237	hand-crafted bottle of gin	3	EPIC	
-238	bad watered-down pulsating bottle of vodka	2	decent	
+238	watered-down bad pulsating bottle of vodka	2	decent	
 239	auspicious boxer's Orcish baseball cap	0		Muscle Percent: +10, Item Drop: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	scorching smartaleck's Orcish cargo shorts	0		Moxie Percent: +30, Hot Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	wicked Orcish frat-paddle	0		Spell Damage: +5
-242	half-sized adequate blinking	2	good	
+242	adequate half-sized blinking	2	good	
 243	decent grapefruit	3	good	
 244	rotten grapes	4	crappy	
 245	small enchanted rotten blurry olive	2	crappy	Effect: "Voracious Gorging", Effect Duration: 45
@@ -246,11 +246,11 @@
 248	acceptable salty dog	3	good	
 249	acceptable watered-down mirror bloody mary	2	good	
 250	bad screwdriver	3	decent	
-251	drinkable fancy martini	4	good	Effect: "Bilious Brawn", Effect Duration: 45
+251	fancy drinkable martini	4	good	Effect: "Bilious Brawn", Effect Duration: 45
 252	mediocre bloody beer	4	decent	
 253	lousy enchanted shot of schnapps	4	decent	Effect: "Warm Shoulders", Effect Duration: 30
-254	fancy acceptable shot of grapefruit schnapps	3	good	Effect: "You're High as a Crow, Marty", Effect Duration: 35
-255	mediocre practically non-alcoholic red fine wine	1	decent	
+254	acceptable fancy shot of grapefruit schnapps	3	good	Effect: "You're High as a Crow, Marty", Effect Duration: 35
+255	practically non-alcoholic mediocre red fine wine	1	decent	
 256	tolerable tumbling shot of tomato schnapps	3	good	
 257	practically non-alcoholic tolerable narrow extra-spicy bloody mary	1	good	
 258	dense meat stack	0		
@@ -258,14 +258,14 @@
 260	decent White Citadel fries	3	good	
 261	adequate olive upside-down White Citadel burger	4	good	
 262	miniature adequate piece of wedding cake	2	good	
-263	decent gigantic chocolate chips	9	good	
+263	gigantic decent chocolate chips	9	good	
 264	bland chocolate chip cookies	4	decent	
 265	grievous satin pants	0		Weapon Damage Percent: +50, Familiar Effect: "atk, 2xPotato, cap 10"
 266	artisanal weak lightning	2	EPIC	
 267	ghostly slick mullet wig	0		Moxie: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	meat cowboy hat of the early riser	0		Adventures: +7, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	stiffened sword	0		Damage Reduction: 1
-270	purple pulsating picket fence	0		
+270	pulsating purple picket fence	0		
 271	twisted cyan barbell	1		Effect: "Powdered", Effect Duration: 30
 272	modified skewed blinking concentrated magicalness pill	1		
 273	altered shaking moxie weed	1		
@@ -297,7 +297,7 @@
 299	pressed quantum extra-wet pickle-flavored chewing gum	0		Effect: "Salty Mouth", Effect Duration: 36
 300	extra-pressed jaba&ntilde;ero-flavored chewing gum	0		Effect: "Salty Mouth", Effect Duration: 19
 301	flat dough	0		
-302	toothsome big squat teal Knob sausage	5	awesome	
+302	toothsome big teal squat Knob sausage	5	awesome	
 303	normal blinking Knob mushroom	3	good	
 304	gray dry noodles	0		
 305	Oprah's Knob Goblin harem pants	0		Maximum MP Percent: +50, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -311,19 +311,19 @@
 313	foul-smelling Crown of the Goblin King	0		Stench Damage: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	stale miniature shaking bean burrito	2	decent	
 315	moldy bean burrito	4	crappy	
-316	rotten massive skewed tumbling insanely bean burrito	8	crappy	
+316	rotten massive tumbling skewed insanely bean burrito	8	crappy	
 317	decent snack-sized bean burrito	2	good	
 318	moldy bean burrito	3	crappy	
 319	rotten spinning insanely bean burrito	4	crappy	
 320	spoiled bat haggis	3	crappy	
-321	tasty immense blue menudo	10	awesome	
+321	immense tasty blue menudo	10	awesome	
 322	snack-sized decent goat cheese	2	good	
 323	normal half-sized jittery plain pizza	2	good	
 324	bland bite-sized sausage pizza	1	decent	
-325	stale snack-sized goat cheese pizza	2	decent	
+325	snack-sized stale goat cheese pizza	2	decent	
 326	decent mushroom pizza	4	good	
 327	twirling goat	0		
-328	special smooth yellow bottle of whiskey	3	awesome	Effect: "Disco State of Mind", Effect Duration: 10
+328	smooth special yellow bottle of whiskey	3	awesome	Effect: "Disco State of Mind", Effect Duration: 10
 329	healthy goat beard	0		Maximum HP Percent: +20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	decent	
 331	strong special tolerable Canadian	5	good	Effect: "Braaaains Over Braaaawwn", Effect Duration: 10
@@ -334,10 +334,10 @@
 336	gray consolation ribbon of Leguizamo	0		Monster Level: +20
 337	ol' trophy	0		
 338	tenderizing hammer	0		
-339	jittery skewed Cobb's Knob lab key	0		
+339	skewed jittery Cobb's Knob lab key	0		
 340	colloidal non-pickled Knob Goblin steroids	0		Effect: "Retrograde Relaxation", Effect Duration: 46
 341	anodized skewed mirror Knob Goblin love potion	0		Effect: "Fan-Cooled", Effect Duration: 45
-342	shaking tumbling Knob Goblin stink bomb	0		
+342	tumbling shaking Knob Goblin stink bomb	0		
 343	liquefied Knob Goblin sharpening spray	0		Effect: "Sealed Brain", Effect Duration: 42
 344	Knob Goblin seltzer	0		
 345	blurry Knob Goblin superseltzer	0		
@@ -368,7 +368,7 @@
 370	asbestos stick	0		
 371	squat asbestos crossbow string	0		
 372	shaking chrome sword hilt	0		
-373	lime green mirror chrome stick	0		
+373	mirror lime green chrome stick	0		
 374	chrome crossbow string	0		
 375	blue linoleum meat stack	0		
 376	asbestos meat stack	0		
@@ -403,7 +403,7 @@
 405	sunken chest	0		
 406	upside-down pirate pelvis	0		
 407	huge pirate skull	0		
-408	spinning red pirate skeleton	0		
+408	red spinning pirate skeleton	0		
 409	blurry vial of patchouli oil	0		
 410	sk8board of the boozehound	0		Booze Drop: +100
 411	Jolly Roger charrrm	0		
@@ -431,7 +431,7 @@
 433	skinny balloon	0		
 434	balloon helmet of James Dean	0		Experience (Moxie): +3, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	wobbly friendly balloon sword of chilblains	0		Familiar Weight: +3, Cold Damage: +25, Clowniness: 50
-436	blurry huge balloon monkey	0		
+436	huge blurry balloon monkey	0		
 437	chef skull	0		
 438	squat chef-in-the-box	0		
 439	bartender skull	0		
@@ -448,7 +448,7 @@
 450	pretentious paintbrush	0		
 451	narrow pretentious palette	0		
 452	disease	0		
-453	skewed shaking sober pill	0		
+453	shaking skewed sober pill	0		
 454	screwdriver	0		
 455	enchanted stale narrow jumbo olive	3	decent	Effect: "Spooky Blur", Effect Duration: 15
 456	artisanal dry martini	4	EPIC	
@@ -466,7 +466,7 @@
 468	tumbling ruby W	0		
 469	wussiness potion	0		
 470	tolerable practically non-alcoholic blue Imp Ale	1	good	
-471	yummy half-sized hot wing	2	awesome	
+471	half-sized yummy hot wing	2	awesome	
 472	up-at-dawn diamond-studded cane	0		Adventures: +5, Class: "Disco Bandit"
 473	gray hardened crutch	0		Damage Reduction: 3
 474	cast	0		
@@ -493,7 +493,7 @@
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	adequate tiny papaya	1	good	
+498	tiny adequate papaya	1	good	
 499	blue ribald denim axe of the empath	0		Familiar Weight: +5, Sleaze Damage: +10
 500	Elf Farm Raffle ticket	0		
 501	decent fancy cyan Elfin shortbread	3	good	Effect: "Bestial Sympathy", Effect Duration: 30
@@ -538,7 +538,7 @@
 540	liquefied Tasty Fun Good rice candy	0		Effect: "Sticks and Stones", Effect Duration: 11
 541	vibrating stiffened draggin' ball hat	0		Damage Reduction: 1, Maximum MP Percent: +10, Familiar Effect: "atk, 1xVolley, cap 25"
 542	blurry frightening 1337 7r0uZ0RZ of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Familiar Effect: "2xPotato, cap 27"
-543	jumbo normal special Trollhouse cookies	5	good	Effect: "You Can Taste the Darkness", Effect Duration: 5
+543	jumbo special normal Trollhouse cookies	5	good	Effect: "You Can Taste the Darkness", Effect Duration: 5
 544	horrifying talons of extreme caution	0		Monster Level: -25, Spooky Damage: +25
 545	flavorless special Spam Witch sammich	3	decent	Effect: "Extra Terrestrial", Effect Duration: 50
 546	mirror meat vortex	0		
@@ -556,35 +556,35 @@
 558	spoiled papaya taco	3	crappy	
 559	wobbly razor-sharp can lid	0		
 560	spoiled stalk of asparagus	3	crappy	
-561	tumbling blinking pregnant mushroom	0		
+561	blinking tumbling pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	distilled drinkable Mad Train wine	5	good	
+564	drinkable distilled Mad Train wine	5	good	
 565	fireproof hobo gloves	0		Hot Resistance: +3, Single Equip
 566	occult bum cheek	0		Spell Damage Percent: +25, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	decent huge Double Bacon Beelzeburger	4	good	
 569	bland Lord of the Flies-sized fries	3	decent	
-570	huge rotten mirror huge Chicken Sandwich	10	crappy	
+570	huge rotten huge mirror Chicken Sandwich	10	crappy	
 571	Jumbo Dr. Lucifer	1	good	
-572	small spoiled spinning Children's Meal of the Damned	2	crappy	
+572	spoiled small spinning Children's Meal of the Damned	2	crappy	
 573	half-sized decent noodles	2	good	
 574	spoiled noodles	4	crappy	
 575	small bland painful penne pasta	2	decent	
 576	adequate ravioli della hippy	3	good	
-577	flavorless fancy snack-sized pr0n m4nic0tti	2	decent	Effect: "Moon'd", Effect Duration: 10
+577	fancy flavorless snack-sized pr0n m4nic0tti	2	decent	Effect: "Moon'd", Effect Duration: 10
 578	bland Hell ramen	4	decent	
 579	tiny rotten boring spaghetti	1	crappy	
 580	sauce of the ages	0		
 581	wobbly ghostly schmancy cheese sauce	0		
 582	mirror Himalayan Hidalgo sauce	0		
-583	normal special olive fettucini Inconnu	3	good	Effect: "Rave Concentration", Effect Duration: 45
+583	special normal olive fettucini Inconnu	3	good	Effect: "Rave Concentration", Effect Duration: 45
 584	normal spaghetti with Skullheads	3	good	
 585	decent gnocchetti di Nietzsche	3	good	
 586	rosewater-soaked Oprah's ridiculously huge sword	0		Maximum MP Percent: +50, Stench Resistance: +3
 587	oxidized polarized squat super-spiky hair gel	0		Effect: "Stimulated Brain", Effect Duration: 50
 588	maroon soft echo eyedrop antidote	0		
-589	miniature decent cocoa eggshell fragment	2	good	
+589	decent miniature cocoa eggshell fragment	2	good	
 590	bland blurry purple cocoa eggshell fragment	3	decent	
 591	cocoa egg	0		
 592	blurry house	0		
@@ -636,7 +636,7 @@
 638	flame-wreathed personal trainer's asshat	0		Experience Percent (Muscle): +10, Hot Spell Damage: +10, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	miniature decent pulsating abominable snowcone	2	good	
 640	cyan Ent cider	1	crappy	
-641	miniature tasty toast	2	awesome	
+641	tasty miniature toast	2	awesome	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	ghostly Crimbo pressie	0		Last Available: "2003-12"
@@ -644,8 +644,8 @@
 646	rotten fruitcake	4	crappy	
 647	present	0		Last Available: "2004-11"
 648	squat deadly Crimbo sword	0		Weapon Damage: +5, Last Available: "2004-10"
-649	razor-sharp Crimbo hat	0		Weapon Damage Percent: +25, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	cyan wool Crimbo pants	0		Cold Resistance: +1, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	razor-sharp Crimbo hat	0		Weapon Damage Percent: +25, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	cyan wool Crimbo pants	0		Cold Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	steel-toed exclusive ultra-rare item	0		Damage Reduction: 9
 652	quantum egg	0		
 653	huge intragalactic rowboat	0		
@@ -669,17 +669,17 @@
 671	jittery quilted grave robbing shovel of Leguizamo	0		Damage Absorption: +40, Monster Level: +20
 672	bland cranberries	3	decent	
 673	artisanal bouncing vodka and cranberry	3	EPIC	
-674	weak mediocre mirror narrow whiskey	2	decent	
+674	weak mediocre narrow mirror whiskey	2	decent	
 675	pulsating skull of the Bonerdagon	0		Item Drop: +5
 676	dragonbone belt buckle	0		
 677	extremely unsafe badass belt	0		Weapon Damage Percent: +100
 678	cyan chest of the Bonerdagon	0		
 679	drinkable roll in the hay	3	good	
-680	weak artisanal slap and tickle	2	EPIC	
+680	artisanal weak slap and tickle	2	EPIC	
 681	acceptable enchanted blurry slip 'n' slide	3	good	Effect: "Adrenaline Rush", Effect Duration: 10
-682	delicious irresponsibly strong a sump'm sump'm	9	awesome	
-683	special mediocre horizontal tango	3	decent	Effect: "Innately Truthy", Effect Duration: 15
-684	tolerable high-proof pink pony	8	good	
+682	irresponsibly strong delicious a sump'm sump'm	9	awesome	
+683	mediocre special horizontal tango	3	decent	Effect: "Innately Truthy", Effect Duration: 15
+684	high-proof tolerable pink pony	8	good	
 685	frosty supercharged extremely unsafe Mr. Shirt	0		Weapon Damage Percent: +100, Maximum MP Percent: +30, Cold Spell Damage: +10
 686	scandalous knuckles	0		Sleaze Damage: +5
 687	galvanized gray wobbly blood of the Wereseal	0		Effect: "Radiant Personality", Effect Duration: 59
@@ -742,17 +742,17 @@
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	adequate miniature cyan warm mushroom	2	good	
-750	flavorless small mushroom quesadilla	2	decent	
+750	small flavorless mushroom quesadilla	2	decent	
 751	huge moldy cool mushroom	7	crappy	
 752	normal cool mushroom casserole	4	good	
 753	decent twirling pointy mushroom	4	good	
 754	rotten cream of pointy mushroom soup	4	crappy	
 755	fancy spoiled wobbly mushroom	4	crappy	Effect: "Become Intensely interested", Effect Duration: 20
-756	tiny tasty mushroom	1	awesome	
-757	decent bite-sized mushroom	1	good	
-758	bland diet ghost cucumber	1	decent	
+756	tasty tiny mushroom	1	awesome	
+757	bite-sized decent mushroom	1	good	
+758	diet bland ghost cucumber	1	decent	
 759	shaking dill	0		
-760	twirling squat vinegar	0		
+760	squat twirling vinegar	0		
 761	brine	0		
 762	drinkable wobbly especially salty dog	3	good	
 763	ghostly pickling solution	0		
@@ -773,21 +773,21 @@
 778	healthy support cummerbund	0		Maximum HP Percent: +20
 779	fuchsia Mob Penguin cellular phone	0		
 780	upside-down scroll of pasta summoning	0		
-781	boiled maroon mirror mafia aria	0		Effect: "Cotton Mouthed", Effect Duration: 24
+781	boiled mirror maroon mafia aria	0		Effect: "Cotton Mouthed", Effect Duration: 24
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
 784	tolerable high-proof Acqua Del Piatto Merlot	10	good	Last Available: "2004-10"
 785	raffle ticket	0		
 786	rotten small strawberry	2	crappy	
-787	high-proof tolerable bottle of rum	8	good	
+787	tolerable high-proof bottle of rum	8	good	
 788	aged strawberry daiquiri	3	awesome	
-789	lousy weak rum and cola	2	decent	
-790	boozy enchanted perfectly mixed blinking olive grog	5	EPIC	Effect: "Pill Power", Effect Duration: 35
+789	weak lousy rum and cola	2	decent	
+790	perfectly mixed boozy enchanted blinking olive grog	5	EPIC	Effect: "Pill Power", Effect Duration: 35
 791	MacGyver's extremely unsafe Mafia bow tie	0		Weapon Damage Percent: +100, Maximum MP: +100, Last Available: "2004-10"
 792	MacGyver's Golden Mr. Accessory	0		Maximum MP: +100, Softcore Only
 793	alkaline skewed oil of stability	0		Effect: "Painted-On Bikini", Effect Duration: 40
 794	adjusted super-galvanized oil of slipperiness	0		Effect: "Eagle Eyes", Effect Duration: 43
-795	fortified artisanal ghostly Acque Luride Grezze Cabernet	5	EPIC	Last Available: "2004-10"
+795	artisanal fortified ghostly Acque Luride Grezze Cabernet	5	EPIC	Last Available: "2004-10"
 796	jittery coward's steel-toed stiffened cement shoes	0		Damage Reduction: 20, Monster Level: -20, Last Available: "2004-10"
 797	weak tolerable rockin' wagon	2	good	
 798	acceptable cyan ocean motion	3	good	
@@ -800,12 +800,12 @@
 807	moldy olive stir-fry	3	crappy	
 808	decent Knob sausage stir-fry	3	good	
 809	bland bat wing stir-fry	4	decent	
-810	stale tiny rat appendix stir-fry	1	decent	
+810	tiny stale rat appendix stir-fry	1	decent	
 811	bland pulsating tofu stir-fry	3	decent	
-812	fancy tasty miniature narrow pr0n stir-fry	2	awesome	Effect: "Spooky Demeanor", Effect Duration: 35
+812	miniature tasty fancy narrow pr0n stir-fry	2	awesome	Effect: "Spooky Demeanor", Effect Duration: 35
 813	decent Knob shells	3	good	
 814	fancy normal b&auml;tzle	3	good	Effect: "Pride of the Vampire", Effect Duration: 20
-815	bite-sized rotten mirror ratini	1	crappy	
+815	rotten bite-sized mirror ratini	1	crappy	
 816	tasty special blurry Knob stroganoff	4	awesome	Effect: "Frostbeard", Effect Duration: 5
 817	delicious menudo ravioli	4	awesome	
 818	plus sign	0		
@@ -827,7 +827,7 @@
 834	cornuthaum of the ox of doom	0		Muscle: +20, Spooky Spell Damage: +50, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	wobbly ring of aggravate monster of courage	0		Spooky Resistance: +3
 836	normal mind flayer corpse	3	good	
-837	lousy olive mirror Uovo Marcio Shiraz	3	decent	Last Available: "2004-10"
+837	lousy mirror olive Uovo Marcio Shiraz	3	decent	Last Available: "2004-10"
 838	ribald Mafia stogie of the sewer	0		Stench Damage: +25, Sleaze Damage: +10, Last Available: "2004-10"
 839	artisanal irresponsibly strong Maiali Sifilitici Pinot Noir	8	EPIC	Last Available: "2004-10"
 840	educational boxer's Mafia violin case	0		Muscle Percent: +10, Experience: +1, Last Available: "2004-10"
@@ -876,7 +876,7 @@
 885	fuchsia spinning axe of doom	0		Spooky Spell Damage: +50
 886	green leaflet	0		
 887	leaf	0		
-888	olive ghostly maple leaf	0		
+888	ghostly olive maple leaf	0		
 889	huge wobbly scandalous balaclava	0		Sleaze Damage: +5, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 890	flavorless balaclava baklava	3	decent	
 891	skewed steel-toed Warehouse 23 bling	0		Damage Reduction: 9
@@ -891,13 +891,13 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	enchanted mediocre Spasmi Dolorosi Del Rene Champagne	3	decent	Effect: "Empathy", Effect Duration: 20, Last Available: "2004-10"
-904	wobbly yellow medical-grade veiny stylish school Mafia knickerbockers	0		Moxie: +25, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+903	mediocre enchanted Spasmi Dolorosi Del Rene Champagne	3	decent	Effect: "Empathy", Effect Duration: 20, Last Available: "2004-10"
+904	wobbly yellow medical-grade veiny stylish school Mafia knickerbockers	0		Moxie: +25, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	magnetized Yummy Tummy bean	0		Effect: "Hairy Palms", Effect Duration: 42
 906	pickled Rock Pops	0		Effect: "Nano-juiced", Effect Duration: 52
 907	modified pressed lime green Mr. Mediocrebar	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 54
 908	irradiated Cold Hots candy	0		Effect: "Chalked Weapon", Effect Duration: 21
-909	deionized squat gray Wint-O-Fresh mint	0		Effect: "Human-Machine Hybrid", Effect Duration: 41
+909	deionized gray squat Wint-O-Fresh mint	0		Effect: "Human-Machine Hybrid", Effect Duration: 41
 910	moldy dwarf bread	4	crappy	
 911	activated adjusted shaking Senior Mints	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 31
 912	ionized vacuum-sealed pixellated candy heart	0		Effect: "Spiky Frozen Hair", Effect Duration: 29
@@ -906,8 +906,8 @@
 915	twirling yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	auspicious stanky intergalactic pom poms	0		Stench Spell Damage: +25, Item Drop: +10
 917	tumbling Mob Penguin protection contract	0		
-918	Jeselnik's Radio Free Baseball Cap	0		Sleaze Damage: +25, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	blinking Radio Free Pants of courage	0		Spooky Resistance: +3, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	Jeselnik's Radio Free Baseball Cap	0		Sleaze Damage: +25, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	blinking Radio Free Pants of courage	0		Spooky Resistance: +3, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	narrow reassuring Radio Free Foil	0		Spooky Resistance: +1, Last Available: "2006-07"
 921	spoiled radio button candy	3	crappy	
 922	executive severed rocking horse head	0		Meat Drop: +40
@@ -921,7 +921,7 @@
 931	artisanal weak gray spiced rum	2	EPIC	
 932	smooth eggnog	3	awesome	
 933	decent jumbo mirror candy cane	5	good	
-934	decent enchanted gingerbread bugbear	3	good	Effect: "Earthen Fist", Effect Duration: 40
+934	enchanted decent gingerbread bugbear	3	good	Effect: "Earthen Fist", Effect Duration: 40
 935	twirling imitation nice watch of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2004-12"
 936	green Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,14 +929,14 @@
 939	squat small Crimbo Pressie	0		Last Available: "2004-12"
 940	wobbly bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	blinking lion tamer's bowler	0		Experience (familiar): +2, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	blinking lion tamer's bowler	0		Experience (familiar): +2, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	teal blinking squat grievous bow staff of bravery	0		Weapon Damage Percent: +50, Spooky Resistance: +5, Last Available: "2004-12"
-944	bowlegged pants of the scaredy-cat	0		Monster Level: -15, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	bowlegged pants of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	blurry skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	hand-crafted watered-down bouncing martini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
-949	triple-distilled perfectly mixed grogtini	6	EPIC	Last Available: "2004-12"
+949	perfectly mixed triple-distilled grogtini	6	EPIC	Last Available: "2004-12"
 950	mediocre blue cherry bomb	4	decent	Last Available: "2004-12"
 951	mirror extra special Crimbo stocking	0		Last Available: "2004-12"
 952	miser's chaotic hockey mask	0		Spell Critical Percent: +10, Meat Drop: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
@@ -945,7 +945,7 @@
 955	hale fez of etymology	0		Maximum HP: +20, Familiar Effect: "1xLep, cap 30"
 956	decent narrow carob chunk noodles	4	good	
 957	miniature bland chorizo brownies	2	decent	
-958	bland jumbo mirror chocolate and tomato pizza	5	decent	
+958	jumbo bland mirror chocolate and tomato pizza	5	decent	
 959	flange	0		
 960	clockwork key	0		
 961	olive silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -988,26 +988,26 @@
 1000	jittery Meat maid	0		
 1002	jittery Xlyinia's notebook of the dark arts	0		Spell Damage Percent: +100
 1003	soda water	0		
-1004	aged bouncing blue bottle of tequila	3	awesome	
+1004	aged blue bouncing bottle of tequila	3	awesome	
 1005	lousy boxed wine	4	decent	
 1006	moldy cherry	4	crappy	
 1007	coconut shell of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xFairy, cap 7"
 1008	twirling ice cubes of the detective	0		Item Drop: +20
-1009	bad practically non-alcoholic upside-down vodka martini	1	decent	
+1009	practically non-alcoholic bad upside-down vodka martini	1	decent	
 1010	bad whiskey and soda	4	decent	
-1011	practically non-alcoholic bad monkey wrench	1	decent	
-1012	tolerable triple-distilled tequila sunrise	9	good	
+1011	bad practically non-alcoholic monkey wrench	1	decent	
+1012	triple-distilled tolerable tequila sunrise	9	good	
 1013	acceptable margarita	3	good	
-1014	practically non-alcoholic delicious strawberry wine	1	awesome	
+1014	delicious practically non-alcoholic strawberry wine	1	awesome	
 1015	tolerable irresponsibly strong wine spritzer	6	good	
 1016	hand-crafted perpendicular hula	3	EPIC	
 1017	fortified artisanal ducha de oro	5	EPIC	
-1018	aged special tumbling twirling calle de miel	3	awesome	Effect: "Weird Flavor", Effect Duration: 15
-1019	special tolerable dry vodka martini	4	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 15
+1018	special aged tumbling twirling calle de miel	3	awesome	Effect: "Weird Flavor", Effect Duration: 15
+1019	tolerable special dry vodka martini	4	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 15
 1020	hand-crafted narrow old-fashioned	3	EPIC	
 1021	drinkable tequila with training wheels	3	good	
 1022	lousy wobbly sangria	4	decent	
-1023	drinkable practically non-alcoholic vesper	1	good	Last Available: "2004-12"
+1023	practically non-alcoholic drinkable vesper	1	good	Last Available: "2004-12"
 1024	delicious bouncing bodyslam	3	awesome	Last Available: "2004-12"
 1025	drinkable sangria del diablo	3	good	Last Available: "2004-12"
 1026	spinning Valentine	0		Free Pull
@@ -1017,21 +1017,21 @@
 1030	Annie Oakley's penguin whip	0		Critical Hit Percent: +20
 1031	Van der Graaf yak whip	0		MP Regen Min: 5, MP Regen Max: 7
 1032	mirror blurry sharpshooter's gnauga hide whip	0		Critical Hit Percent: +10
-1033	bouncing blinking gnauga hide	0		
+1033	blinking bouncing gnauga hide	0		
 1034	hippo skin buckler of Flo-Jo	0		Initiative: +100, Damage Reduction: 5
 1035	blurry ruddy penguin skin buckler	0		Maximum HP Percent: +40, Damage Reduction: 5
 1036	green blinking wool yakskin buckler	0		Cold Resistance: +1, Damage Reduction: 5
 1037	wobbly reassuring gnauga hide buckler	0		Spooky Resistance: +1, Damage Reduction: 5
 1038	alkaline red skewed Connery's Elixir of Audacity	0		Effect: "Chorale of Companionship", Effect Duration: 54
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	bad weak beer	2	decent	
+1041	weak bad beer	2	decent	
 1042	scandalous string of beads	0		Sleaze Damage: +5
 1043	blinking flame-wreathed string of beads	0		Hot Spell Damage: +10
 1044	healthy string of beads	0		Maximum HP Percent: +20
 1045	brainy plastic bottle opener	0		Mysticality: +5
-1046	green family-friendly chaotic traffic cone	0		Spell Critical Percent: +10, Sleaze Resistance: +1, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	tolerable fuchsia mirror N. O. Beer	3	good	
-1048	vaporized spinning olive oyster egg	1		
+1046	green family-friendly chaotic traffic cone	0		Spell Critical Percent: +10, Sleaze Resistance: +1, Familiar Effect: "cap 15", Last Available: "2005-03"
+1047	tolerable mirror fuchsia N. O. Beer	3	good	
+1048	vaporized olive spinning oyster egg	1		
 1049	distilled oyster egg	1		Effect: "Fangs and Pangs", Effect Duration: 10
 1050	twisted oyster egg	1		Effect: "Favored by Lyle", Effect Duration: 15
 1051	plastic oyster egg	0		
@@ -1041,14 +1041,14 @@
 1055	plastic oyster egg	0		
 1056	mixed puce oyster egg	1		
 1057	compressed upside-down puce oyster egg	1		
-1058	altered blinking cyan puce oyster egg	1		
+1058	altered cyan blinking puce oyster egg	1		
 1059	ghostly puce plastic oyster egg	0		
-1060	denatured shaking skewed fuchsia mauve oyster egg	1		
-1061	distilled blinking fuchsia mauve oyster egg	1		
+1060	denatured fuchsia shaking skewed mauve oyster egg	1		
+1061	distilled fuchsia blinking mauve oyster egg	1		
 1062	pickled wobbly yellow mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
-1064	dehydrated fuchsia mirror oyster egg	1		Effect: "Salamander In Your Stomach", Effect Duration: 30
-1065	boiled maroon mirror oyster egg	1		Effect: "Je Ne Sais Porquoise", Effect Duration: 45
+1064	dehydrated mirror fuchsia oyster egg	1		Effect: "Salamander In Your Stomach", Effect Duration: 30
+1065	boiled mirror maroon oyster egg	1		Effect: "Je Ne Sais Porquoise", Effect Duration: 45
 1066	denatured upside-down oyster egg	1		
 1067	plastic oyster egg	0		
 1068	denatured huge oyster egg	1		
@@ -1057,7 +1057,7 @@
 1071	wobbly plastic oyster egg	0		
 1072	mixed yellow off-white oyster egg	1		
 1073	boiled twirling off-white oyster egg	1		Effect: "Mer-kindliness", Effect Duration: 30
-1074	pickled jittery narrow off-white oyster egg	1		
+1074	pickled narrow jittery off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	distilled twirling oyster egg	1		Effect: "Robocamo", Effect Duration: 20
 1077	powdered oyster egg	1		
@@ -1087,7 +1087,7 @@
 1101	blue false eyelashes	0		Familiar Weight: +5
 1102	targeting chip	0		
 1103	unwound clockwork grapefruit	0		
-1104	blurry ghostly Mountie hat	0		Familiar Weight: +5
+1104	ghostly blurry Mountie hat	0		Familiar Weight: +5
 1105	shaking clockwork bartender head	0		
 1106	clockwork chef head	0		
 1107	clockwork maid head	0		
@@ -1125,13 +1125,13 @@
 1139	distilled tolerable twirling mushroom wine	5	good	
 1140	weak drinkable icy mushroom wine	2	good	
 1141	acceptable mushroom wine	4	good	
-1142	artisanal strong pointy mushroom wine	5	EPIC	
-1143	mediocre spirit-forward flat mushroom wine	5	decent	
+1142	strong artisanal pointy mushroom wine	5	EPIC	
+1143	spirit-forward mediocre flat mushroom wine	5	decent	
 1144	artisanal cool mushroom wine	3	EPIC	
 1145	hand-crafted lime green knob mushroom wine	3	EPIC	
 1146	mediocre pulsating knoll mushroom wine	4	decent	
 1147	bad triple-distilled mushroom wine	6	decent	
-1148	irresponsibly strong mediocre shot of flower schnapps	10	decent	
+1148	mediocre irresponsibly strong shot of flower schnapps	10	decent	
 1149	toothsome flower petal pie	4	awesome	
 1150	perfectly mixed ghostly bottle of single-barrel whiskey	3	EPIC	
 1151	teal rosewater-soaked discarded plastic fork of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3
@@ -1223,7 +1223,7 @@
 1239	jittery iced-out bling	0		Familiar Weight: +5
 1240	limburger biker boots	0		Familiar Weight: +5
 1241	huge carton of clove cigarettes	0		Familiar Weight: +5
-1242	jittery ghostly deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
+1242	ghostly jittery deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
 1243	blue toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
 1244	Glass Balls of the Goblin King of the boozehound	0		Booze Drop: +100
 1245	blue Sinatra's Codpiece of the Goblin King	0		Experience (Moxie): +5, Single Equip
@@ -1236,11 +1236,11 @@
 1252	tasty fuchsia shroomkabob	4	awesome	
 1253	pile of jumping beans	0		
 1254	bland jumping bean burrito	3	decent	
-1255	bland big jumping bean burrito	5	decent	
+1255	big bland jumping bean burrito	5	decent	
 1256	stale insanely jumping bean burrito	4	decent	
-1257	gigantic normal skewed rat scrapple	9	good	
+1257	normal gigantic skewed rat scrapple	9	good	
 1258	tumbling purple pail of pretentious paint	0		
-1259	cyan bouncing curative cool traffic cone	0		Moxie: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	cyan bouncing curative cool traffic cone	0		Moxie: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	compressed wobbly wobbly Hatorade	1		
 1262	squat therapeutic hale Da Vinci's off-hand balloon	0		Experience (Mysticality): +5, Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 7
@@ -1253,7 +1253,7 @@
 1269	ebony wand	0		
 1270	hexagonal wand	0		
 1271	yellow aluminum wand	0		
-1272	blinking yellow marble wand	0		
+1272	yellow blinking marble wand	0		
 1273	family-friendly magic lamp	0		Sleaze Resistance: +1
 1274	boiled Medicinal Herb's medicinal herbs	1		Effect: "It Didn't Kill You", Effect Duration: 50
 1275	experienced basic meat skirt	0		Experience: +2, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
@@ -1287,11 +1287,11 @@
 1303	Mjolnir Jr.	0		
 1304	pulsating doppelshifter egg	0		Free Pull
 1305	wobbly makeup kit	0		Familiar Weight: +15
-1306	resourceful traffic cone of the businessman	0		Maximum MP: +50, Meat Drop: +50, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	resourceful traffic cone of the businessman	0		Maximum MP: +50, Meat Drop: +50, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	mirror calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	mirror unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
-1310	blurry blue funky fez	0		Familiar Weight: +5
+1310	blue blurry funky fez	0		Familiar Weight: +5
 1311	comfy blanket	0		Last Available: "2005-10"
 1312	jittery horrifying Baron von Ratsworth's monocle	0		Spooky Damage: +25, Single Equip
 1313	spinning narrow educational Baron von Ratsworth's money clip	0		Experience: +1, Single Equip
@@ -1304,8 +1304,8 @@
 1320	small yummy questionable taco	2	awesome	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	huge petrified time	0		Last Available: "2005-10"
-1323	teal tumbling shellacked time helmet	0		Damage Reduction: 7, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	Van der Graaf time trousers	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	teal tumbling shellacked time helmet	0		Damage Reduction: 7, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	Van der Graaf time trousers	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	mirror time sword of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2005-10"
 1326	squat gray Dyspepsi-Cola helmet of chilblains	0		Cold Damage: +25, Familiar Effect: "3xFairy, cap 7"
 1327	bouncing huge asbestos-lined Cloaca-Cola shield	0		Hot Resistance: +5, Damage Reduction: 4
@@ -1324,7 +1324,7 @@
 1341	Usain Bolt's Dyspepsi-Cola-issue canteen	0		Initiative: +80, Single Equip
 1342	picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
-1344	aerosolized quantum extra-chilled lime green pulsating Gummi-Gnauga	0		Effect: "Spirit Bubble", Effect Duration: 45
+1344	aerosolized quantum extra-chilled pulsating lime green Gummi-Gnauga	0		Effect: "Spirit Bubble", Effect Duration: 45
 1345	alkaline tarnished moist Now and Earlier	0		Effect: "Hyphemariffic", Effect Duration: 28, Last Available: "2020-09"
 1346	irradiated improved electrified olive Sugar Cog	0		Effect: "Painted-On Bikini", Effect Duration: 42
 1347	mirror loaded serum blowgun	0		Last Available: "2005-11"
@@ -1346,10 +1346,10 @@
 1363	clockwork pirate skull	0		
 1364	huge rhesus monkey	0		Familiar Weight: +5
 1365	adequate huge tofurkey leg	7	good	
-1366	jumbo stale maroon tofurkey gravy	5	decent	
+1366	stale jumbo maroon tofurkey gravy	5	decent	
 1367	miniature stale herbal stuffing	2	decent	
 1368	miniature adequate can-shaped gelatinous cranberry sauce	2	good	
-1369	normal special yams	3	good	Effect: "Transcendental Wind", Effect Duration: 30
+1369	special normal yams	3	good	Effect: "Transcendental Wind", Effect Duration: 30
 1370	bouncing Rosewater's rhinestone cowboy shirt	0		Mysticality Percent: +30
 1371	teal inspector's gingham blouse	0		Item Drop: +15
 1372	souvenir ski t-shirt of the early riser	0		Adventures: +7
@@ -1384,13 +1384,13 @@
 1402	blinking Newton's rag doll	0		Experience (Mysticality): +3, Last Available: "2005-12"
 1403	bouncing wobbly Annie Oakley's can of fake snow	0		Critical Hit Percent: +20, Last Available: "2005-12"
 1404	spinning quilted colored-light &quot;necklace&quot;	0		Damage Absorption: +40, Last Available: "2005-12"
-1405	zippy tree skirt	0		Initiative: +20, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	spoiled special wreath-shaped Crimbo cookie	4	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	zippy tree skirt	0		Initiative: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1406	special spoiled wreath-shaped Crimbo cookie	4	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	adequate bell-shaped Crimbo cookie	4	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	bland half-sized enchanted tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	rosy-cheeked Unionize The Elves sign	0		Maximum HP Percent: +30, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	modified extra-colloidal non-liquefied snowcone	0		Effect: "Mighty Shout", Effect Duration: 44, Last Available: "2006-01"
 1413	adjusted dry snowcone	0		Effect: "Hammered", Effect Duration: 44, Last Available: "2006-01"
 1414	diffused pressed snowcone	0		Effect: "Pie in the Sky", Effect Duration: 50, Last Available: "2006-01"
@@ -1399,16 +1399,16 @@
 1417	ionized quantum tumbling upside-down snowcone	0		Effect: "On the Shoulders of Giants", Effect Duration: 26, Last Available: "2006-01"
 1418	blurry Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	huge avaricious frosty traffic cone	0		Cold Spell Damage: +10, Meat Drop: +30, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	huge avaricious frosty traffic cone	0		Cold Spell Damage: +10, Meat Drop: +30, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	spinning iceberglet	0		Last Available: "2006-02"
 1424	bouncing bouncing Oprah's brainy ice sickle	0		Mysticality: +5, Maximum MP Percent: +50, Softcore Only, Last Available: "2006-02"
 1425	teal electrified ice baby	0		MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2006-02"
-1426	narrow chilly ice pick	0		Cold Damage: +5, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	narrow chilly ice pick	0		Cold Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	miser's Rosewater's ice skates	0		Mysticality Percent: +30, Meat Drop: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	stale grue egg omelette	3	decent	
-1429	mirror lime green roll of drink tickets	0		
+1429	lime green mirror roll of drink tickets	0		
 1430	twirling pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
 1432	flavorless bouncing mushroom	3	decent	
@@ -1419,8 +1419,8 @@
 1437	bouncing useless powder	0		
 1438	corrupted alkaline twinkly powder	0		Effect: "Liquidy Smoky", Effect Duration: 51
 1439	non-denatured improved energized upside-down hot powder	0		Effect: "Going Ape", Effect Duration: 15
-1440	corrupted denatured skewed green powder	0		Effect: "Beta Carotene Overdose", Effect Duration: 36
-1441	super-anodized wet tumbling ghostly powder	0		Effect: "Cinnamouth", Effect Duration: 63
+1440	corrupted denatured green skewed powder	0		Effect: "Beta Carotene Overdose", Effect Duration: 36
+1441	super-anodized wet ghostly tumbling powder	0		Effect: "Cinnamouth", Effect Duration: 63
 1442	moist polymerized triple-magnetized stench powder	0		Effect: "Well-Swabbed Ear", Effect Duration: 45
 1443	pickled corrupted twirling sleaze powder	0		Effect: "Punch Another Day", Effect Duration: 20
 1444	improved aerosolized twinkly nuggets	0		Effect: "Nano-juiced", Effect Duration: 21
@@ -1437,14 +1437,14 @@
 1455	mixed squat sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	fancy massive adequate squat Valentine's Day cake	8	good	Effect: "Baconstoned", Effect Duration: 35
+1458	fancy adequate massive squat Valentine's Day cake	8	good	Effect: "Baconstoned", Effect Duration: 35
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
 1462	eye of newt	0		
 1463	salamander spleen	0		
 1464	blinking sleazy fairy gravy	0		
-1465	green spinning suede shortsword	0		
+1465	spinning green suede shortsword	0		
 1466	blinking bamboo bokuto	0		
 1467	spinning 25-meat staff	0		
 1468	two-handed depthsword	0		
@@ -1458,9 +1458,9 @@
 1476	goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	upside-down salad bowl	0		Familiar Effect: "atk, cap 30"
-1479	olive bouncing football helmet	0		Familiar Effect: "atk, cap 37"
+1479	bouncing olive football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
-1481	twirling cyan union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
+1481	cyan twirling union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	lime green paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
@@ -1474,20 +1474,20 @@
 1492	blinking Sinatra's ninja mop	0		Experience (Moxie): +5
 1493	purple shaking auspicious clever ridiculously overelaborate ninja weapon	0		Maximum MP: +20, Item Drop: +10
 1494	flattened liquefied mirror sugar-coated pine cone	0		Effect: "Powder Power", Effect Duration: 34, Last Available: "2020-09"
-1495	horrifying traffic cone of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	horrifying traffic cone of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	bad extra-dry cyan gloomy mushroom wine	5	decent	
 1497	bad irresponsibly strong mushroom wine	8	decent	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	spinning whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
-1501	altered modified flattened upside-down lime green twirling explosion-flavored chewing gum	0		Effect: "Adapt to Change Eventually", Effect Duration: 17, Last Available: "2006-04"
+1501	altered modified flattened upside-down twirling lime green explosion-flavored chewing gum	0		Effect: "Adapt to Change Eventually", Effect Duration: 17, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	fuchsia rubber emo roe	0		Last Available: "2006-04"
 1504	diffused improved jittery snowcone	0		Effect: "Strength of Ten Ettins", Effect Duration: 49, Last Available: "2006-04"
 1505	gray ice cube with a fly in it	0		Last Available: "2006-04"
-1506	mediocre practically non-alcoholic upside-down calle de miel with a fly in it	1	decent	Last Available: "2006-04"
+1506	practically non-alcoholic mediocre upside-down calle de miel with a fly in it	1	decent	Last Available: "2006-04"
 1507	lousy rockin' wagon with a fly in it	4	decent	Last Available: "2006-04"
-1508	bad weak gray perpendicular hula with a fly in it	2	decent	Last Available: "2006-04"
+1508	weak bad gray perpendicular hula with a fly in it	2	decent	Last Available: "2006-04"
 1509	bad ghostly slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
 1510	ghostly bag of airline peanuts	0		Last Available: "2006-04"
 1511	tumbling rock-hard fake hand	0		Damage Reduction: 5, Last Available: "2006-04"
@@ -1504,22 +1504,22 @@
 1523	narrow bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	bouncing diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	cyan jittery fortified boxer's corkscrew	0		Muscle Percent: +10, Damage Absorption: +60, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	dance instructor's grass skirt	0		Experience Percent (Moxie): +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	wobbly Jack Frost's grass hat	0		Cold Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	dance instructor's grass skirt	0		Experience Percent (Moxie): +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	wobbly Jack Frost's grass hat	0		Cold Spell Damage: +50, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	veiny grass blade	0		Maximum HP: +10, Last Available: "2011-01"
 1534	mirror raffle prize box	0		
 1536	gray homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	lime green weegee sqouija	0		Last Available: "2011-12"
 1538	reassuring sparkly engagement ring	0		Spooky Resistance: +1, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	gravedigger's smartaleck's Grimacite goggles	0		Moxie Percent: +30, Spooky Damage: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	gravedigger's smartaleck's Grimacite goggles	0		Moxie Percent: +30, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	greasy Grimacite glaive of the boozehound	0		Sleaze Spell Damage: +10, Booze Drop: +100, Last Available: "2008-10"
-1542	cool Grimacite greaves of the wise owl	0		Mysticality: +20, Moxie: +5, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	cool Grimacite greaves of the wise owl	0		Mysticality: +20, Moxie: +5, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	bouncing inspector's supercharged Grimacite garter	0		Maximum MP Percent: +30, Item Drop: +15, Last Available: "2008-10"
 1544	knitted vibrating Grimacite galoshes	0		Maximum MP Percent: +10, Cold Resistance: +3, Last Available: "2008-10"
 1545	manspreader's brainy Grimacite gorget	0		Mysticality: +5, Monster Level: +10, Last Available: "2008-10"
@@ -1531,7 +1531,7 @@
 1551	tolerable bottle of Domesticated Turkey	3	good	
 1552	weak mediocre bottle of Definit	2	decent	
 1553	hand-crafted fortified bottle of Calcutta Emerald	5	EPIC	
-1554	practically non-alcoholic bad bottle of Lieutenant Freeman	1	decent	
+1554	bad practically non-alcoholic bottle of Lieutenant Freeman	1	decent	
 1555	lousy upside-down bottle of Jorge Sinsonte	4	decent	
 1556	bad boxed champagne	4	decent	
 1557	spoiled blurry kumquat	3	crappy	
@@ -1540,28 +1540,28 @@
 1560	toothsome cocktail onion	4	awesome	
 1561	stale raspberry	4	decent	
 1562	special stale kiwi	3	decent	Effect: "Healthy Blue Glow", Effect Duration: 20
-1563	tolerable watered-down whiskey bittersweet	2	good	
+1563	watered-down tolerable whiskey bittersweet	2	good	
 1564	delicious mimosette	3	awesome	
-1565	extra-dry perfectly mixed tequila sunset	5	EPIC	
+1565	perfectly mixed extra-dry tequila sunset	5	EPIC	
 1566	acceptable practically non-alcoholic upside-down zmobie	1	good	Wiki Name: "Zmobie (drink)"
-1567	spirit-forward acceptable gin and tonic	5	good	
+1567	acceptable spirit-forward gin and tonic	5	good	
 1568	smooth extra-dry vodka and tonic	5	awesome	
 1569	lousy practically non-alcoholic special vodka gibson	1	decent	Effect: "One Foot Heavier", Effect Duration: 10
 1570	lousy spirit-forward gibson	5	decent	
 1571	mediocre parisian cathouse	3	decent	
 1572	hand-crafted rabbit punch	3	EPIC	
 1573	drinkable caipifruta	4	good	
-1574	practically non-alcoholic tolerable teqiwila	1	good	
-1575	acceptable practically non-alcoholic skewed Divine	1	good	
-1576	tolerable red mirror Gordon Bennett	4	good	
-1577	perfectly mixed practically non-alcoholic shaking tangarita	1	super ultra mega turbo EPIC	
+1574	tolerable practically non-alcoholic teqiwila	1	good	
+1575	practically non-alcoholic acceptable skewed Divine	1	good	
+1576	tolerable mirror red Gordon Bennett	4	good	
+1577	practically non-alcoholic perfectly mixed shaking tangarita	1	super ultra mega turbo EPIC	
 1578	practically non-alcoholic lousy mandarina colada	1	decent	
-1579	delicious weak gimlet	2	awesome	
+1579	weak delicious gimlet	2	awesome	
 1580	lousy brick road	4	decent	
 1581	lousy enchanted vodka stratocaster	3	decent	Effect: "Black Lung", Effect Duration: 20
 1582	drinkable Neuromancer	4	good	
-1583	acceptable watered-down prussian cathouse	2	good	
-1584	smooth extra-dry Mae West	5	awesome	
+1583	watered-down acceptable prussian cathouse	2	good	
+1584	extra-dry smooth Mae West	5	awesome	
 1585	acceptable weak Mon Tiki	2	good	
 1586	tolerable teqiwila slammer	3	good	
 1587	moldy Knob lo mein	3	crappy	
@@ -1578,9 +1578,9 @@
 1598	huge quilted Senior LAAAAME merit badge	0		Damage Absorption: +40, Last Available: "2006-05"
 1599	wobbly jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	mediocre tangarita with a fly in it	3	decent	
-1601	tolerable practically non-alcoholic enchanted mandarina colada with a fly in it	1	good	Effect: "Action", Effect Duration: 20
+1601	tolerable enchanted practically non-alcoholic mandarina colada with a fly in it	1	good	Effect: "Action", Effect Duration: 20
 1602	perfectly mixed prussian cathouse with a fly in it	4	EPIC	
-1603	drinkable weak Mae West with a fly in it	2	good	
+1603	weak drinkable Mae West with a fly in it	2	good	
 1604	dried shaking astronaut ice-cream	1		Last Available: "2006-05"
 1605	pulsating delectable catalyst	0		
 1606	twisted ultimate wad	1		
@@ -1592,8 +1592,8 @@
 1612	modified concentrated cordial of concentration	0		Effect: "Flexibili Tea", Effect Duration: 28
 1613	smartaleck's coffin lid	0		Moxie Percent: +30, Damage Reduction: 3
 1614	wobbly sinister satin shield	0		Spell Damage: +10, Damage Reduction: 5
-1615	Oprah's Cerebral Cloche	0		Maximum MP Percent: +50, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	wobbly Cerebral Culottes of the ox	0		Muscle: +20, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	Oprah's Cerebral Cloche	0		Maximum MP Percent: +50, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	wobbly Cerebral Culottes of the ox	0		Muscle: +20, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	skewed coward's careful Cerebral Crossbow of the sweet-tooth	0		Monster Level: -30, Candy Drop: +100, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	fancy normal gray foie gras	4	good	Effect: "Whippin' It Good", Effect Duration: 30
 1652	moist alkaline candy brain	0		Effect: "Pie in the Sky", Effect Duration: 23, Last Available: "2020-09"
-1653	tumbling razor-sharp groovy jewel-eyed wizard hat of Flo-Jo	0		Moxie Percent: +10, Weapon Damage Percent: +25, Initiative: +100, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1653	tumbling razor-sharp groovy jewel-eyed wizard hat of Flo-Jo	0		Moxie Percent: +10, Weapon Damage Percent: +25, Initiative: +100, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	flame-wreathed wad of Crovacite of the detective	0		Hot Spell Damage: +10, Item Drop: +20
 1655	maroon nasty therapeutic collar	0		Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	wobbly ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	wobbly bouncing stanky sword of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25
 1680	yellow coward's Sinatra's staff	0		Experience (Moxie): +5, Monster Level: -20
 1681	asbestos-lined razor-sharp bubblewrap sword	0		Weapon Damage Percent: +25, Hot Resistance: +5
@@ -1673,13 +1673,13 @@
 1693	wet triple-diffused yellow eyedrops of newt	0		Effect: "Man's Worst Enemy", Effect Duration: 16
 1694	activated activated skewed Frogade	0		Effect: "20-20 Second Sight", Effect Duration: 59
 1695	denatured dry papotion of papower	0		Effect: "Mayeaugh", Effect Duration: 34
-1696	rotten snack-sized pulsating royal jelly taco	2	crappy	
+1696	snack-sized rotten pulsating royal jelly taco	2	crappy	
 1697	adequate green ghostly tofu taco	3	good	
-1698	jumbo decent jumping bean taco	5	good	
+1698	decent jumbo jumping bean taco	5	good	
 1699	normal catgut taco	3	good	
 1700	spoiled bite-sized bouncing goat cheese taco	1	crappy	
-1701	thick decent pr0n taco	5	good	
-1702	corrupted spinning blinking alphabet gum	0		Effect: "Adorable Lookout", Effect Duration: 12
+1701	decent thick pr0n taco	5	good	
+1702	corrupted blinking spinning alphabet gum	0		Effect: "Adorable Lookout", Effect Duration: 12
 1703	Comma Chameleon egg	0		Free Pull
 1704	huge shingle	0		
 1705	flaregun	0		
@@ -1750,7 +1750,7 @@
 1771	healthy butcherknife	0		Maximum HP Percent: +20
 1772	executive corn holder	0		Meat Drop: +40
 1773	eggbeater of the dark arts	0		Spell Damage Percent: +100
-1774	fortified tolerable bottle of popskull	5	good	
+1774	tolerable fortified bottle of popskull	5	good	
 1775	teal curative dishrag	0		HP Regen Min: 3, HP Regen Max: 5
 1776	rotten yellow huge stale baguette	3	crappy	
 1777	leftovers of indeterminate origin	0		
@@ -1759,20 +1759,20 @@
 1780	personal trainer's ram stick	0		Experience Percent (Muscle): +10
 1781	blinking banded enchantlers	0		Damage Absorption: +100, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	zippy frightening ram-battering staff	0		Spooky Damage: +5, Initiative: +20
-1783	tasty snack-sized skewed blue crazy Turkish delight	2	awesome	
+1783	tasty snack-sized blue skewed crazy Turkish delight	2	awesome	
 1784	censurious Snow Queen Crown of incineration	0		Hot Spell Damage: +50, Sleaze Resistance: +3, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	lion tamer's Jim Carey's ga-ga radio of the pedagogue	0		Experience: +3, Monster Level: +25, Experience (familiar): +2
 1786	six pack of Mountain Stream	0		
 1787	quadruple-frozen altered alkaline bag of Cheat-Os	0		Effect: "Slimily Strong", Effect Duration: 14
 1788	bouncing unrefined Mountain Stream syrup	0		
 1789	narrow Mob Penguin	0		
-1790	lousy irresponsibly strong Ram's Face Lager	9	decent	
+1790	irresponsibly strong lousy Ram's Face Lager	9	decent	
 1791	skewed ram horns	0		
-1792	rosy-cheeked strapping Travoltan trousers of Gandalf	0		Muscle: +5, Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	rosy-cheeked strapping Travoltan trousers of Gandalf	0		Muscle: +5, Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	ghostly ghostly asbestos-lined MacGyver's pool cue	0		Maximum MP: +100, Hot Resistance: +5
 1794	polarized ghostly handful of hand chalk	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 42
 1795	narrow razor-sharp Counterclockwise Watch	0		Weapon Damage Percent: +25, Single Equip
-1796	purple jittery bone collar	0		Familiar Weight: +5
+1796	jittery purple bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
 1798	pile of animal bones	0		
 1799	animal skull	0		
@@ -1783,14 +1783,14 @@
 1804	third cervical vertebra	0		
 1805	mirror fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
-1807	mirror maroon sixth cervical vertebra	0		
+1807	maroon mirror sixth cervical vertebra	0		
 1808	green seventh cervical vertebra	0		
 1809	first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
 1811	third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
-1814	bouncing twirling sixth thoracic vertebra	0		
+1814	twirling bouncing sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
@@ -1800,7 +1800,7 @@
 1821	first lumbar vertebra	0		
 1822	second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
-1824	gray squat fourth lumbar vertebra	0		
+1824	squat gray fourth lumbar vertebra	0		
 1825	fifth lumbar vertebra	0		
 1826	wobbly sixth lumbar vertebra	0		
 1827	blue seventh lumbar vertebra	0		
@@ -1837,7 +1837,7 @@
 1858	shaking right eighth rib	0		
 1859	twirling twirling right ninth rib	0		
 1860	yellow right tenth rib	0		
-1861	wobbly ghostly right eleventh rib	0		
+1861	ghostly wobbly right eleventh rib	0		
 1862	right twelfth rib	0		
 1863	animal pelvis	0		
 1864	squat left scapula	0		
@@ -1866,7 +1866,7 @@
 1887	red right second front claw	0		
 1888	spinning right third front claw	0		
 1889	right fourth front claw	0		
-1890	ghostly upside-down left thumb	0		
+1890	upside-down ghostly left thumb	0		
 1891	purple right thumb	0		
 1892	maroon left first rear claw	0		
 1893	mirror left second rear claw	0		
@@ -1897,11 +1897,11 @@
 1920	bizarre illegible sheet music	0		
 1921	Sherlock's wakizashi	0		Item Drop: +25
 1922	gob of wet hair	0		
-1923	blurry shaking roll of toilet paper	0		Free Pull
+1923	shaking blurry roll of toilet paper	0		Free Pull
 1924	tattered wolf standard	0		
 1925	narrow tattered snake standard	0		
-1926	blinking tumbling KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
-1927	jittery blinking scary death orb	0		
+1926	tumbling blinking KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1927	blinking jittery scary death orb	0		
 1928	tuning fork	0		
 1929	yellow tumbling quilted greaves	0		Damage Absorption: +40, Familiar Effect: "1xBarrr"
 1930	horrifying helmet of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Familiar Effect: "0.5xPotato, 0.5xFairy"
@@ -1926,11 +1926,11 @@
 1949	rotten miniature Manetwich	2	crappy	
 1950	twirling ghostly bottle of Vangoghbitussin	0		
 1951	high-proof aged shaking bottle of Pinot Renoir	10	awesome	
-1952	spoiled red ghostly desiccated apricot	3	crappy	
+1952	spoiled ghostly red desiccated apricot	3	crappy	
 1953	drinkable flute of flat champagne	3	good	
 1954	stale dehydrated caviar	3	decent	
 1955	styrofoam peanuts	0		
-1956	aged huge pulsating snifter of thoroughly aged brandy	3	awesome	
+1956	aged pulsating huge snifter of thoroughly aged brandy	3	awesome	
 1957	pulsating quill pen	0		
 1958	narrow inkwell	0		
 1959	blinking tattered scrap of paper	0		
@@ -1951,7 +1951,7 @@
 1974	cocoabo	0		
 1975	baby gravy fairy	0		
 1976	gravy fairy	0		
-1977	narrow pulsating gravy fairy	0		
+1977	pulsating narrow gravy fairy	0		
 1978	gravy fairy	0		
 1979	gravy fairy	0		
 1980	teal sleazy gravy fairy	0		
@@ -1967,7 +1967,7 @@
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
-1993	tumbling maroon rubber WWSPD? bracelet	0		
+1993	maroon tumbling rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	squat heart necklace	0		Free Pull
 1996	mirror right half of a heart necklace	0		
@@ -1994,14 +1994,14 @@
 2017	spade necklace	0		
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
-2020	decent thick blurry blurry cherry pie	5	good	
-2021	rotten thick spinning strawberry pie	5	crappy	
+2020	thick decent blurry blurry cherry pie	5	good	
+2021	thick rotten spinning strawberry pie	5	crappy	
 2022	spoiled miniature lemon meringue pie	2	crappy	
 2023	Genalen&trade; Bottle	1	good	
 2024	yummy mixed wildflower greens	3	awesome	
-2025	huge special stale handful of walnuts	8	decent	Effect: "La Bamba", Effect Duration: 50
+2025	huge stale special handful of walnuts	8	decent	Effect: "La Bamba", Effect Duration: 50
 2026	yummy wobbly nutty organic salad	3	awesome	
-2027	rotten fancy big wobbly super salad	5	crappy	Effect: "Elbow Sauce", Effect Duration: 20
+2027	rotten big fancy wobbly super salad	5	crappy	Effect: "Elbow Sauce", Effect Duration: 20
 2028	diet normal tofu wonton	1	good	
 2029	maroon hippy protest button	0		Single Equip
 2030	twirling executive sinister Lockenstock&trade; sandals	0		Spell Damage: +10, Meat Drop: +40, Single Equip
@@ -2014,8 +2014,8 @@
 2037	quadruple-colloidal galvanized moist tumbling tumbling wintergreen-flavored potato chips	0		Effect: "Insulated Trousers", Effect Duration: 46
 2038	triple-modified ennui-flavored potato chips	0		Effect: "Intimidating Mien", Effect Duration: 35
 2039	x-ray specs	0		Last Available: "2011-12"
-2040	wobbly purple patchouli oil bomb	0		
-2041	squat blinking ferret bait	0		
+2040	purple wobbly patchouli oil bomb	0		
+2041	blinking squat ferret bait	0		
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
@@ -2064,7 +2064,7 @@
 2088	wet squat Daffy Taffy	0		Effect: "Phorcefullness", Effect Duration: 36
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	skewed miser's therapeutic hardened pilgrim shield of the empath of horror	0		Damage Reduction: 4, Familiar Weight: +5, Spooky Spell Damage: +25, Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2006-11"
-2091	huge jittery bath salts	0		
+2091	jittery huge bath salts	0		
 2092	tumbling hand mirror	0		
 2093	cool hors d'oeuvre tray	0		Moxie: +5, Damage Reduction: 5
 2094	flavorless ballroom blintz	3	decent	
@@ -2090,7 +2090,7 @@
 2114	bouncing yo	0		Last Available: "2006-12"
 2115	hardy prehistoric spear	0		Maximum HP: +50, Last Available: "2006-12"
 2116	shaking stick-on-a-string	0		Last Available: "2006-12"
-2117	avaricious deadly fire	0		Weapon Damage: +5, Meat Drop: +30, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	avaricious deadly fire	0		Weapon Damage: +5, Meat Drop: +30, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	blue leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	squat gray grievous Grateful Undead T-shirt	0		Weapon Damage Percent: +50
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	jittery hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	veiny thinker's toy ray gun	0		Mysticality: +10, Maximum HP: +10, Last Available: "2006-12"
-2169	maroon toy space helmet of Tarzan of horror	0		Experience (Muscle): +3, Spooky Spell Damage: +25, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	maroon toy space helmet of Tarzan of horror	0		Experience (Muscle): +3, Spooky Spell Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	skewed MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	medical-grade dangerous astronaut pants	0		Weapon Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	medical-grade dangerous astronaut pants	0		Weapon Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	toy jet pack of bravery	0		Spooky Resistance: +5, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	narrow mossy stone sphere	0		
@@ -2158,20 +2158,20 @@
 2183	blinking Harold's hammer handle	0		
 2184	twirling Harold's hammer	0		
 2185	experienced Kiss the Knob apron	0		Experience: +2
-2186	pulsating upside-down unlit birthday cake	0		
+2186	upside-down pulsating unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	decent	Last Available: "2006-12"
-2189	practically non-alcoholic acceptable blurry flask of peppermint schnapps	1	good	Last Available: "2006-12"
+2189	acceptable practically non-alcoholic blurry flask of peppermint schnapps	1	good	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	blinking book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	immense tasty candy stake	8	awesome	Last Available: "2006-12"
+2193	tasty immense candy stake	8	awesome	Last Available: "2006-12"
 2194	perfectly mixed strong eggnog	5	EPIC	Last Available: "2006-12"
 2195	adequate huge unspeakable fruitcake	4	good	Last Available: "2006-12"
-2196	flavorless fancy big gingerbread horror	5	decent	Effect: "Rushtacean'", Effect Duration: 25, Last Available: "2006-12"
+2196	fancy big flavorless gingerbread horror	5	decent	Effect: "Rushtacean'", Effect Duration: 25, Last Available: "2006-12"
 2197	double-quantum unsweetened but probably evil chocolate	0		Effect: "Irresistible Resolve", Effect Duration: 25, Last Available: "2006-12"
-2198	huge tasty pulsating bat-shaped Crimboween cookie	6	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	miniature normal skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2198	tasty huge pulsating bat-shaped Crimboween cookie	6	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2199	normal miniature skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	adequate blinking tombstone-shaped Crimboween cookie	4	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	therapeutic plastic gift-wrapping vampire	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-12"
 2202	pulsating plastic yuletide troll of Flo-Jo	0		Initiative: +100, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	upside-down Crimbo tiki necklace of the sweet-tooth	0		Candy Drop: +100, Last Available: "2006-12"
 2208	bouncing Jack Frost's occult bobble-hip hula elf doll	0		Spell Damage Percent: +25, Cold Spell Damage: +50, Last Available: "2006-12"
 2209	skewed strapping Crimbo ukulele	0		Muscle: +5, Last Available: "2006-12"
-2210	steel-toed Tiki lighter of James Dean	0		Experience (Moxie): +3, Damage Reduction: 9, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	shaking frosty deck of tropical cards of horror	0		Cold Spell Damage: +10, Spooky Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	friendly tropical paperweight of terror	0		Familiar Weight: +3, Spooky Spell Damage: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	steel-toed Tiki lighter of James Dean	0		Experience (Moxie): +3, Damage Reduction: 9, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	shaking frosty deck of tropical cards of horror	0		Cold Spell Damage: +10, Spooky Spell Damage: +25, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	friendly tropical paperweight of terror	0		Familiar Weight: +3, Spooky Spell Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	scandalous Tropical Crimbo Hat	0		Sleaze Damage: +5, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	shaking Tropical Crimbo Shorts of incineration	0		Hot Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	scandalous Tropical Crimbo Hat	0		Sleaze Damage: +5, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	shaking Tropical Crimbo Shorts of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	spoiled thick super ka-bob	5	crappy	
-2218	snack-sized adequate gray beer basted brat	2	good	
+2218	adequate snack-sized gray beer basted brat	2	good	
 2219	shaking avaricious Tropical Crimbo Sword	0		Meat Drop: +30, Last Available: "2006-12"
-2220	electrified green pulsating skewed and Crimboween candy	0		Effect: "Stop and Smell the Fudge", Effect Duration: 31, Last Available: "2020-09"
+2220	electrified skewed green pulsating and Crimboween candy	0		Effect: "Stop and Smell the Fudge", Effect Duration: 31, Last Available: "2020-09"
 2221	red Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	groovy liar's pants of chilblains	0		Moxie Percent: +10, Cold Damage: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	groovy liar's pants of chilblains	0		Moxie Percent: +10, Cold Damage: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	ghostly foul-smelling rosy-cheeked juggler's balls	0		Maximum HP Percent: +30, Stench Damage: +10, Softcore Only, Last Available: "2007-01"
 2224	steel-toed pink shirt	0		Damage Reduction: 9, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2242,12 +2242,12 @@
 2268	crafty Staff of Fats	0		Maximum MP: +10
 2269	stale small sausage wonton	2	decent	
 2270	ghostly Usain Bolt's fireproof belt	0		Hot Resistance: +3, Initiative: +80, Single Equip
-2271	mediocre enchanted bottle of Merlot	3	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 10
+2271	enchanted mediocre bottle of Merlot	3	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 10
 2272	watered-down tolerable bottle of Port	2	good	
-2273	acceptable practically non-alcoholic blurry bottle of Pinot Noir	1	good	
+2273	practically non-alcoholic acceptable blurry bottle of Pinot Noir	1	good	
 2274	tolerable bottle of Zinfandel	3	good	
 2275	lousy olive bottle of Marsala	4	decent	
-2276	triple-distilled bad bottle of Muscat	9	decent	
+2276	bad triple-distilled bottle of Muscat	9	decent	
 2277	Fernswarthy's key	0		
 2278	pulsating Fernswarthy's letter	0		
 2279	book	0		
@@ -2269,12 +2269,12 @@
 2295	marinated stakes	0		
 2296	knob butter	0		
 2297	vial of ectoplasm	0		
-2298	skewed mirror boock of darck magicks	0		
+2298	mirror skewed boock of darck magicks	0		
 2299	squat EZ-Play Harmonica Book	0		
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	galvanized pressed twirling candy heart	0		Effect: "Salty Mouth", Effect Duration: 22, Last Available: "2007-02"
 2305	activated pink candy heart	0		Effect: "Danish Cunning", Effect Duration: 27, Last Available: "2007-02"
 2306	boiled bouncing candy heart	0		Effect: "Patent Avarice", Effect Duration: 20, Last Available: "2007-02"
@@ -2309,8 +2309,8 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	skewed flame-wreathed lion tamer's pipe	0		Experience (familiar): +2, Hot Spell Damage: +10
 2337	twirling groovy reinforced beaded headband	0		Moxie Percent: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	stale jumbo skewed pudding	5	decent	Wiki Name: "black pudding (food)"
-2339	distilled acceptable lime green Blackfly Chardonnay	5	good	
+2338	jumbo stale skewed pudding	5	decent	Wiki Name: "black pudding (food)"
+2339	acceptable distilled lime green Blackfly Chardonnay	5	good	
 2340	lousy & tan	3	decent	
 2341	pepper	0		
 2342	toothsome forest cake	4	awesome	
@@ -2329,8 +2329,8 @@
 2355	cold-filtered warmed narrow henna face paint	0		Effect: "Takin' It Greasy", Effect Duration: 55
 2356	adjusted huge tube of dread wax	0		Effect: "Blessing of Charcoatl", Effect Duration: 36
 2357	cyan rosy-cheeked Gaia beads of wisdom	0		Mysticality: +15, Maximum HP Percent: +30
-2358	gray shaking pink clay bead	0		
-2359	purple blurry clay bead	0		
+2358	shaking gray pink clay bead	0		
+2359	blurry purple clay bead	0		
 2360	clay bead	0		
 2361	padded hippy medical kit of the businessman	0		Damage Absorption: +20, Meat Drop: +50, Single Equip
 2362	friendly Tesla Slow Talkin' Elliot's dogtags	0		Familiar Weight: +3, MP Regen Min: 7, MP Regen Max: 10
@@ -2342,13 +2342,13 @@
 2368	Fonzie's brawny flowing hippy skirt	0		Muscle Percent: +20, Experience (Moxie): +1, Familiar Effect: "stench atk, 1xFairy, cap 45"
 2369	maroon filthy poultice	0		
 2370	natural fennel soda	0		
-2371	wobbly tumbling smoke bomb	0		
+2371	tumbling wobbly smoke bomb	0		
 2372	bunch of bananas	0		
 2373	bland blinking banana	3	decent	
 2374	teal banana peel	0		
-2375	normal miniature banana cream pie	2	good	
+2375	miniature normal banana cream pie	2	good	
 2376	watered-down mediocre twirling banana daiquiri	2	decent	
-2377	special high-proof artisanal bungle in the jungle	9	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 5
+2377	high-proof artisanal special bungle in the jungle	9	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 5
 2378	banana spritzer	0		
 2379	moist double-vacuum-sealed shaking banana smoothie	0		Effect: "Leash of Linguini", Effect Duration: 50
 2380	olive dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2404,18 +2404,18 @@
 2430	adjusted wet tumbling bag of lard	0		Effect: "Blubbered Up", Effect Duration: 65
 2431	altered activated narrow bottle of Mystic Shell	0		Effect: "Feeling No Pain", Effect Duration: 33
 2432	polymerized diffused SPF 451 lip balm	0		Effect: "Mayeaugh", Effect Duration: 15
-2433	oxidized denatured quadruple-modified blurry maroon bottle of antifreeze	0		Effect: "Fudge Headache", Effect Duration: 24
+2433	oxidized denatured quadruple-modified maroon blurry bottle of antifreeze	0		Effect: "Fudge Headache", Effect Duration: 24
 2434	non-unsweetened boiled eyedrops	0		Effect: "Cold as Ice", Effect Duration: 56
-2435	colloidal spinning wobbly Dogsgotnonoz pills	0		Effect: "Oleaginous Soles", Effect Duration: 59
+2435	colloidal wobbly spinning Dogsgotnonoz pills	0		Effect: "Oleaginous Soles", Effect Duration: 59
 2436	polymerized donkey flipbook	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 46
 2437	wobbly New Cloaca-Cola	0		
 2438	mirror scented massage oil	0		
 2439	olive mirror poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
-2441	upside-down maroon Knob Goblin Encryption Key	0		
+2441	maroon upside-down Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	blue rosy-cheeked forbidden pink glowstick	0		Spell Damage Percent: +50, Maximum HP Percent: +30, Last Available: "2007-03"
-2444	weak lousy Supernova Champagne	2	decent	
+2444	lousy weak Supernova Champagne	2	decent	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	blurry hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2438,7 +2438,7 @@
 2465	perfectly mixed watered-down Oreille Divis&eacute;e brandy	2	super EPIC	
 2466	ghostly pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
-2468	fuchsia bouncing callused fingerbone	0		
+2468	bouncing fuchsia callused fingerbone	0		
 2469	blinking bundle of receipts	0		
 2470	cork	0		
 2471	stardust	0		
@@ -2492,19 +2492,19 @@
 2519	hand-crafted jittery wobbly McMillicancuddy's Special Lager	4	EPIC	
 2520	mediocre melted Jell-o shot	4	decent	
 2521	tolerable cruelty-free wine	3	good	
-2522	distilled drinkable thistle wine	5	good	
+2522	drinkable distilled thistle wine	5	good	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	snack-sized normal jittery fish	2	good	
+2525	normal snack-sized jittery fish	2	good	
 2526	adequate fish casserole	3	good	
-2527	thick rotten fish lasagna	5	crappy	
+2527	rotten thick fish lasagna	5	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	tasty gnatloaf	4	awesome	
 2530	tiny spoiled wobbly gnatloaf casserole	1	crappy	
 2531	delicious gnat lasagna	4	awesome	
 2532	pork	0		
 2533	decent diet huge pork chop sandwiches	1	good	
-2534	miniature delicious pork casserole	2	awesome	
+2534	delicious miniature pork casserole	2	awesome	
 2535	bland pork lasagna	3	decent	
 2536	canopic jar	0		
 2537	spice	0		
@@ -2518,7 +2518,7 @@
 2545	polarized upsy daisy	0		Effect: "Coming Up Roses", Effect Duration: 11, Last Available: "2007-05"
 2546	electrified gray half-orchid	0		Effect: "Natural 20", Effect Duration: 38, Last Available: "2007-05"
 2547	ghostly pulsating asbestos-lined MacGyver's tin star	0		Maximum MP: +100, Hot Resistance: +5, Last Available: "2007-05"
-2548	hardy Da Vinci's outrageous sombrero	0		Experience (Mysticality): +5, Maximum HP: +50, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	hardy Da Vinci's outrageous sombrero	0		Experience (Mysticality): +5, Maximum HP: +50, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	frightening rosy-cheeked &quot;Humorous&quot; T-shirt	0		Maximum HP Percent: +30, Spooky Damage: +5, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2538,7 +2538,7 @@
 2565	bouncing can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
-2568	tumbling olive shaking Azazel's tutu	0		
+2568	olive tumbling shaking Azazel's tutu	0		
 2569	dry ant agonist	0		Effect: "Super Accuracy", Effect Duration: 40
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	twirling ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	hardened cactus quill of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 3
 2578	Tesla padded Staff of the Short Order Cook of chilblains	0		Damage Absorption: +20, Cold Damage: +25, MP Regen Min: 7, MP Regen Max: 10
-2579	rotten thick cactus fruit	5	crappy	
+2579	thick rotten cactus fruit	5	crappy	
 2580	curative padded scorpion whip	0		Damage Absorption: +20, HP Regen Min: 3, HP Regen Max: 5
 2581	upside-down upside-down jittery handful of sand	0		
 2582	brick of sand	0		
@@ -2564,7 +2564,7 @@
 2591	decent upside-down tasty tart	3	good	
 2592	Knob Goblin lunchbox	0		
 2593	stale Knob pasty	4	decent	
-2594	lousy triple-distilled upside-down thermos full of Knob coffee	7	decent	
+2594	triple-distilled lousy upside-down thermos full of Knob coffee	7	decent	
 2595	tarnished polarized Ben-Gal&trade; Balm	0		Effect: "20/20 Vision", Effect Duration: 64
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2573,7 +2573,7 @@
 2600	carbonated water lily	0		
 2601	lightning-fast mansplainer's smooth Staff of the Midnight Snack	0		Moxie: +15, Monster Level: +15, Initiative: +40
 2602	crafty educational groovy Staff of Blood and Pudding	0		Moxie Percent: +10, Experience: +1, Maximum MP: +10
-2603	twirling mirror smoldering box	0		
+2603	mirror twirling smoldering box	0		
 2604	Tuesday's ruby of the blizzard	0		Cold Spell Damage: +25
 2605	palm frond	0		
 2606	narrow palm-frond fan	0		
@@ -2590,7 +2590,7 @@
 2617	teal boom	0		
 2618	Iiti Kitty phone charm of the sewer	0		Stench Damage: +25, Single Equip
 2619	twirling jar of swamp gas	0		Last Available: "2007-05"
-2620	normal jumbo unidentified jerky	5	good	
+2620	jumbo normal unidentified jerky	5	good	
 2621	twirling tumbling family-friendly nasty rat mask of the brazier	0		Hot Spell Damage: +25, Sleaze Resistance: +1, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	perfumed ratskin belt of Tarzan	0		Experience (Muscle): +3, Stench Resistance: +5, Single Equip
 2623	blinking sage rattail whip of doom	0		Mysticality Percent: +10, Spooky Spell Damage: +50
@@ -2628,20 +2628,20 @@
 2655	aerosolized energized pickled bottle of absinthe	0		Effect: "Serendipi Tea", Effect Duration: 49, Last Available: "2007-06"
 2656	Newton's strapping Drowsy Sword	0		Muscle: +5, Experience (Mysticality): +3
 2657	enchanted adequate twirling narrow escargotsicle	3	good	Effect: "It Tickles!  It Tickles!", Effect Duration: 30, Last Available: "2007-06"
-2658	mediocre boozy bottle of realpagne	5	decent	Last Available: "2007-06"
+2658	boozy mediocre bottle of realpagne	5	decent	Last Available: "2007-06"
 2659	squat blinking albatross necklace of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2007-06"
 2660	vaporized bouncing not-a-pipe	1	good	Last Available: "2007-06"
-2661	bad practically non-alcoholic flask of Amontillado	1	decent	Last Available: "2007-06"
-2662	Lo Pan's ball mask	0		Spell Critical Percent: +30, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	hardy Can-Can skirt	0		Maximum HP: +50, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2661	practically non-alcoholic bad flask of Amontillado	1	decent	Last Available: "2007-06"
+2662	Lo Pan's ball mask	0		Spell Critical Percent: +30, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	hardy Can-Can skirt	0		Maximum HP: +50, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	magnetized sensitive poetry journal	0		Effect: "Salty Mouth", Effect Duration: 60, Last Available: "2007-06"
 2665	double-polymerized liquefied ghostly bottled inspiration	0		Effect: "Savage Beast Inside", Effect Duration: 37, Last Available: "2007-06"
 2666	moist quantum bellhop bell	0		Effect: "Dances with Tweedles", Effect Duration: 63, Last Available: "2007-06"
 2667	polymerized cold-filtered jittery spiky collar	0		Effect: "Sleazy Weapon", Effect Duration: 13, Last Available: "2007-06"
 2668	diluted upside-down can-can-in-a-can	1		Last Available: "2007-06"
-2669	vaporized narrow cyan patent antipsychotics	1		Effect: "Optimist Primal", Effect Duration: 45, Last Available: "2007-06"
+2669	vaporized cyan narrow patent antipsychotics	1		Effect: "Optimist Primal", Effect Duration: 45, Last Available: "2007-06"
 2670	dehydrated shaking Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	weak artisanal bouncing shot of nepenthe schnapps	2	EPIC	Last Available: "2007-06"
+2671	artisanal weak bouncing shot of nepenthe schnapps	2	EPIC	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	purple Bohemian rhapsody	0		Last Available: "2007-06"
 2674	concentrated irradiated jittery bottle of cat tonic	0		Effect: "Sauce Monocle", Effect Duration: 48, Last Available: "2007-06"
@@ -2652,7 +2652,7 @@
 2679	enhanced pressed ghostly sparkler	0		Effect: "Bat Attitude", Effect Duration: 66
 2680	dry snake	0		Effect: "Be a Mind Master", Effect Duration: 44, Wiki Name: "snake"
 2681	concentrated magnetized pulsating M-242	0		Effect: "Appeteyes", Effect Duration: 44
-2682	blinking jittery detuned radio	0		
+2682	jittery blinking detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	Lo Pan's supercool armgun	0		Moxie Percent: +20, Spell Critical Percent: +30
 2685	seashell necklace	0		
@@ -2697,23 +2697,23 @@
 2724	adequate bowl of rye sprouts	4	good	
 2725	bland cob of corn	3	decent	
 2726	enchanted rotten blinking narrow juniper berries	3	crappy	Effect: "Yeah, It's Just Gasoline", Effect Duration: 30
-2727	bite-sized decent plum	1	good	
+2727	decent bite-sized plum	1	good	
 2728	stale pear	3	decent	
 2729	moldy pulsating peach	3	crappy	
-2730	strong acceptable plum wine	5	good	
+2730	acceptable strong plum wine	5	good	
 2731	triple-distilled delicious shot of pear schnapps	8	awesome	
 2732	drinkable shot of peach schnapps	3	good	
-2733	flavorless bite-sized bunch of square grapes	1	decent	
+2733	bite-sized flavorless bunch of square grapes	1	decent	
 2734	small flavorless bouncing shaking brown sugar cane	2	decent	
 2735	bland jumbo sandwich of the gods	5	decent	
-2736	weak fancy mediocre pulsating Pan-Dimensional Gargle Blaster	2	decent	Effect: "Venomous Weapon", Effect Duration: 40
+2736	mediocre weak fancy pulsating Pan-Dimensional Gargle Blaster	2	decent	Effect: "Venomous Weapon", Effect Duration: 40
 2737	denatured leopard-print barbell	1	good	
 2738	mirror pile of smoking rags	0		
 2739	colloidal shaking panty raider camouflage	0		Effect: "Simulation Stimulation", Effect Duration: 26
 2740	padded dance instructor's Staff of the Walk-In Freezer of Flo-Jo	0		Experience Percent (Moxie): +10, Damage Absorption: +20, Initiative: +100
 2741	bad boilermaker	3	decent	
-2742	normal diet blurry steel lasagna	1	quest	
-2743	practically non-alcoholic hand-crafted steel margarita	1	quest	
+2742	diet normal blurry steel lasagna	1	quest	
+2743	hand-crafted practically non-alcoholic steel margarita	1	quest	
 2744	distilled steel-scented air freshener	1		
 2745	oxidized polarized liquefied olive gremlin mutagen	0		Effect: "Smelly Pants", Effect Duration: 34
 2746	warmed activated cyan extra-potent gremlin mutagen	0		Effect: "Glo-Face", Effect Duration: 69
@@ -2738,9 +2738,9 @@
 2765	squat Harold's bell	0		
 2766	bowling ball	0		
 2767	normal Crimbo pie	3	good	
-2768	moldy miniature lime green wobbly wobbly pear tart	2	crappy	
+2768	moldy miniature wobbly wobbly lime green pear tart	2	crappy	
 2769	flavorless peach pie	3	decent	
-2770	ionized wobbly pulsating chunk of rock salt	0		Effect: "Broberry Brotality", Effect Duration: 42
+2770	ionized pulsating wobbly chunk of rock salt	0		Effect: "Broberry Brotality", Effect Duration: 42
 2771	modified double-energized handful of pine needles	0		Effect: "Fortunate Resolve", Effect Duration: 30
 2772	steamy ruby	0		
 2773	squat glacial sapphire	0		
@@ -2776,12 +2776,12 @@
 2803	skewed jug of Gnomochloric acid	0		
 2804	boiled pickled vial of hamethyst juice	0		Effect: "Sticky Fingers", Effect Duration: 68
 2805	galvanized blue vial of baconstone juice	0		Effect: "Papowerful", Effect Duration: 22
-2806	super-Vulcanized jittery mirror vial of porquoise juice	0		Effect: "On Pins and Needles", Effect Duration: 52
+2806	super-Vulcanized mirror jittery vial of porquoise juice	0		Effect: "On Pins and Needles", Effect Duration: 52
 2807	quadruple-moist warmed flask of hamethyst juice	0		Effect: "Carrrsmic", Effect Duration: 62
 2808	tarnished blinking flask of baconstone juice	0		Effect: "Earthen Fist", Effect Duration: 43
-2809	energized anodized wobbly twirling flask of porquoise juice	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 36
+2809	energized anodized twirling wobbly flask of porquoise juice	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 36
 2810	energized dry jug of hamethyst juice	0		Effect: "Impregnably Delicious", Effect Duration: 11
-2811	chilled cyan wobbly jug of baconstone juice	0		Effect: "The Best a Pirate Can Get", Effect Duration: 30
+2811	chilled wobbly cyan jug of baconstone juice	0		Effect: "The Best a Pirate Can Get", Effect Duration: 30
 2812	irradiated jug of porquoise juice	0		Effect: "Nothing Is Impossible", Effect Duration: 28
 2813	teal rock-hard Rosewater's Beret	0		Mysticality Percent: +30, Damage Reduction: 5, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	lightning-fast Bludgeon of the boozehound of the cheetah	0		Booze Drop: +100, Initiative: 100
@@ -2789,9 +2789,9 @@
 2816	toasty boxer's Boxers of the businessman	0		Muscle Percent: +10, Hot Damage: +5, Meat Drop: +50, Familiar Effect: "1xVolley, 1xLep"
 2817	double-paned quilted boxer's Brooch	0		Muscle Percent: +10, Damage Absorption: +40, Cold Resistance: +5, Single Equip
 2818	jittery miser's sharpshooter's MacGyver's Bracelet	0		Maximum MP: +100, Critical Hit Percent: +10, Meat Drop: +10, Single Equip
-2819	healthy Grimacite gasmask of the boozehound	0		Maximum HP Percent: +20, Booze Drop: +100, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	healthy Grimacite gasmask of the boozehound	0		Maximum HP Percent: +20, Booze Drop: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	skewed fireproof stanky Grimacite gat	0		Stench Spell Damage: +25, Hot Resistance: +3, Last Available: "2008-11"
-2821	bouncing horrifying smooth Grimacite gaiters	0		Moxie: +15, Spooky Damage: +25, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	bouncing horrifying smooth Grimacite gaiters	0		Moxie: +15, Spooky Damage: +25, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	huge rock-hard Grimacite gauntlets of the empath	0		Damage Reduction: 5, Familiar Weight: +5, Single Equip, Last Available: "2008-11"
 2823	rosewater-soaked Socratic Grimacite go-go boots	0		Experience (Mysticality): +1, Stench Resistance: +3, Single Equip, Last Available: "2008-11"
 2824	narrow greedy rock-hard Grimacite girdle	0		Damage Reduction: 5, Meat Drop: +20, Single Equip, Last Available: "2008-11"
@@ -2800,7 +2800,7 @@
 2827	jittery anniversary gift box	0		
 2828	huge jittery loaded dice	0		
 2829	really dense meat stack	0		
-2830	twirling maroon digital key lime	0		
+2830	maroon twirling digital key lime	0		
 2831	pulsating star key lime	0		
 2832	bland digital key lime pie	3	decent	
 2833	rotten fancy star key lime pie	4	crappy	Effect: "Strange Mental Acuity", Effect Duration: 50
@@ -2910,8 +2910,8 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	upside-down Jacob's ladder	0		Familiar Weight: +5
 2939	shaking unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	decent fancy half-sized olive Surprise Egg	2	good	Effect: "The Two-Prong Crown", Effect Duration: 35
-2941	boiled ionized olive shaking Steal This Candy	0		Effect: "Sausage Festive", Effect Duration: 24
+2940	fancy decent half-sized olive Surprise Egg	2	good	Effect: "The Two-Prong Crown", Effect Duration: 35
+2941	boiled ionized shaking olive Steal This Candy	0		Effect: "Sausage Festive", Effect Duration: 24
 2942	irradiated anodized spinning spinning chocolate filthy lucre	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 48
 2943	improved Angry Farmer's Wife Candy	0		Effect: "Healthy Blue Glow", Effect Duration: 20
 2945	sizzling vibrating party hat	0		Maximum MP Percent: +10, Hot Damage: +10, Familiar Effect: "4xLep, cap 7"
@@ -2938,14 +2938,14 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	unsweetened tarnished Swabbie&trade; swab	0		Effect: "Trufflin'", Effect Duration: 68
 2968	activated adjusted wet Oil of Parrrlay	0		Effect: "Drenched With Filth", Effect Duration: 38
-2969	stale gigantic creamsicle	8	decent	
+2969	gigantic stale creamsicle	8	decent	
 2970	lousy olive cream stout	3	decent	
 2971	Sherlock's curmudgel of doom	0		Spooky Spell Damage: +50, Item Drop: +25
 2972	grumpy man charrrm	0		
 2973	twirling experienced grumpy man charrrm bracelet	0		Experience: +2, Single Equip
 2974	tarrrnish charrrm	0		
 2975	lime green cool tarrrnished charrrm bracelet of the bloodbag	0		Moxie: +5, Maximum HP: +100, Single Equip
-2976	strong lousy bilge wine	5	decent	
+2976	lousy strong bilge wine	5	decent	
 2977	Temple Grandin's witty rapier	0		Familiar Weight: +7
 2978	energetic yohohoyo of Calamity Jane	0		Maximum MP Percent: +20, Critical Hit Percent: +15
 2979	aerosolized fish-liver oil	0		Effect: "Crimbo Flavor", Effect Duration: 25
@@ -2995,29 +2995,29 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	artisanal corpse on the beach	3	super EPIC	
-3026	strong mediocre corpsetini	5	decent	
+3026	mediocre strong corpsetini	5	decent	
 3027	acceptable corpsedriver	3	good	
-3028	acceptable fortified Corpse Island iced tea	5	good	
+3028	fortified acceptable Corpse Island iced tea	5	good	
 3029	tolerable twirling red-headed corpse	3	good	
-3030	acceptable strong bouncing kamicorpse-ee	5	good	
-3031	fancy aged skewed corpsel	3	awesome	Effect: "Feet of Grapefruit", Effect Duration: 45
+3030	strong acceptable bouncing kamicorpse-ee	5	good	
+3031	aged fancy skewed corpsel	3	awesome	Effect: "Feet of Grapefruit", Effect Duration: 45
 3032	perfectly mixed corpsebite	3	EPIC	
 3033	mirror lime green spinning deadly pirate fledges	0		Weapon Damage: +5
 3034	lime green piece of thirteen	0		
 3035	thick adequate jittery pearl onion	5	good	
 3036	adequate sea biscuit	3	good	
 3037	watered-down perfectly mixed shaking bottle of rum	2	EPIC	
-3038	weak hand-crafted wobbly blue blurry bottle of black-label rum	2	EPIC	
+3038	hand-crafted weak wobbly blue blurry bottle of black-label rum	2	EPIC	
 3039	cannonball	0		
 3040	mirror voodoo skull	0		
 3041	joke scroll	0		
 3042	blue Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	squat metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	flavorless low-calorie nanite-infested gingerbread bugbear	1	decent	Last Available: "2007-12"
-3046	moldy miniature purple blurry nanite-infested candy cane	2	crappy	Last Available: "2020-09"
+3044	squat metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3045	low-calorie flavorless nanite-infested gingerbread bugbear	1	decent	Last Available: "2007-12"
+3046	moldy miniature blurry purple nanite-infested candy cane	2	crappy	Last Available: "2020-09"
 3047	toothsome nanite-infested fruitcake	4	awesome	Last Available: "2007-12"
-3048	practically non-alcoholic bad nanite-infested eggnog	1	decent	Last Available: "2007-12"
+3048	bad practically non-alcoholic nanite-infested eggnog	1	decent	Last Available: "2007-12"
 3049	huge upside-down El Vibrato power sphere	0		
 3050	green blinking fireproof eyepatch	0		Hot Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr"
 3051	fortified cutlass	0		Damage Absorption: +60
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	vacuum-sealed denatured blurry candy heart	0		Effect: "Papowerful", Effect Duration: 30, Last Available: "2007-02"
 3055	cold-filtered pulsating cymbal syrup	0		Free Pull, Effect: "Macho Profundo", Effect Duration: 24, Last Available: "2007-02"
-3056	metallic foil cat ears of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	metallic foil cat ears of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	fuchsia iGoogly	0		Last Available: "2007-12"
 3059	mirror theoretical string	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	up-at-dawn roboduck-on-a-string of the blizzard	0		Cold Spell Damage: +25, Adventures: +5, Last Available: "2007-12"
 3086	narrow mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	beefcake's strapping biomechanical crimborg helmet	0		Muscle: 30, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	beefcake's strapping biomechanical crimborg helmet	0		Muscle: 30, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	greedy sage C.B.F.G.	0		Mysticality Percent: +10, Meat Drop: +20, Last Available: "2007-12"
-3090	stanky supercool biomechanical crimborg leg armor	0		Moxie Percent: +20, Stench Spell Damage: +25, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	stanky supercool biomechanical crimborg leg armor	0		Moxie Percent: +20, Stench Spell Damage: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	quadruple-dry jittery vitachoconutriment capsule	0		Effect: "Mushroom Magicalness", Effect Duration: 63, Last Available: "2007-12"
 3092	olive vibrating handmade hobby horse	0		Maximum MP Percent: +10, Last Available: "2007-12"
 3093	baleful ball-in-a-cup	0		Spell Damage: +25, Last Available: "2007-12"
@@ -3076,7 +3076,7 @@
 3104	family-friendly electrified vibrating cyborg knife	0		Sleaze Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-12"
 3105	scorching immense cyborg hand of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +25, Last Available: "2007-12"
 3106	sharpshooter's quilted cyborg stompin' boot of temperance	0		Damage Absorption: +40, Critical Hit Percent: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2007-12"
-3107	gray wobbly deactivated RoboGoose	0		Last Available: "2007-12"
+3107	wobbly gray deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	twirling Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	cyan Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	pulsating Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	blinking divine blowout	0		Last Available: "2008-01"
@@ -3137,31 +3137,31 @@
 3165	tumbling broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
-3168	super-ionized boiled twirling mirror seal eyeball	0		Effect: "Pronounced Potency", Effect Duration: 49
-3169	moldy massive turtle soup	6	crappy	Effect: "[598]A Little Bit Evil"
+3168	super-ionized boiled mirror twirling seal eyeball	0		Effect: "Pronounced Potency", Effect Duration: 49
+3169	massive moldy turtle soup	6	crappy	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	squat evil paper umbrella of chilblains	0		Cold Damage: +25
 3173	frozen blinking evil vihuela	0		Effect: "Abominably Slippery", Effect Duration: 61
 3174	spoiled evil boring spaghetti	3	crappy	
-3175	snack-sized moldy spinning evil noodles	2	crappy	
-3176	half-sized spoiled fuchsia evil noodles	2	crappy	
+3175	moldy snack-sized spinning evil noodles	2	crappy	
+3176	spoiled half-sized fuchsia evil noodles	2	crappy	
 3177	decent evil painful penne pasta	4	good	
-3178	diet moldy 3vi1 pr0n m4nic0tti	1	crappy	
+3178	moldy diet 3vi1 pr0n m4nic0tti	1	crappy	
 3179	moldy wobbly evil ravioli della hippy	4	crappy	
-3180	rotten huge evil noodles	9	crappy	
-3181	alkaline purple blinking evil potion of potency	0		Effect: "Pasta Oneness", Effect Duration: 12
+3180	huge rotten evil noodles	9	crappy	
+3181	alkaline blinking purple evil potion of potency	0		Effect: "Pasta Oneness", Effect Duration: 12
 3182	polymerized moist blurry evil libation of liveliness	0		Effect: "Coldfinger", Effect Duration: 55
 3183	quadruple-electrified mirror evil tomato juice of powerful power	0		Effect: "Wolf's Bane", Effect Duration: 34
 3184	irradiated energized blinking evil eyedrops of the ermine	0		Effect: "Twinkly Weapon", Effect Duration: 13
 3185	electrified oxidized huge green evil ointment of the occult	0		Effect: "I See Everything Thrice!", Effect Duration: 21
-3186	energized twirling blue evil serum of sarcasm	0		Effect: "Sweet, Nuts", Effect Duration: 13
+3186	energized blue twirling evil serum of sarcasm	0		Effect: "Sweet, Nuts", Effect Duration: 13
 3187	non-concentrated galvanized evil philter of phorce	0		Effect: "On the Trolley", Effect Duration: 65
 3188	watered-down artisanal an evil sump'm sump'm	2	super EPIC	
 3189	drinkable ghostly evil ducha de oro	3	good	
 3190	drinkable jittery evil horizontal tango	3	good	
 3191	hand-crafted practically non-alcoholic narrow evil roll in the hay	1	super ultra mega turbo EPIC	
-3192	tumbling pulsating naughty origami kit	0		Last Available: "2008-02"
+3192	pulsating tumbling naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	spinning naughty paper shuriken	0		Last Available: "2008-02"
@@ -3189,13 +3189,13 @@
 3217	El Vibrato Megadrone	0		
 3218	wicked Herculean glowstick	0		Experience (Muscle): +1, Spell Damage: +5, Last Available: "2008-02"
 3219	tumbling sane hatrack	0		Free Pull, Last Available: "2011-12"
-3220	ghostly red hobo code binder	0		Free Pull
+3220	red ghostly hobo code binder	0		Free Pull
 3221	gator skin	0		
 3222	mirror lion tamer's beefcake's gatorskin umbrella	0		Muscle: +25, Experience (familiar): +2
 3223	sewer nuggets	0		
 3224	blurry skewed sewer wad	0		
 3225	acceptable watered-down green bottle of sewage schnapps	2	good	
-3226	artisanal extra-dry lime green bottle of Ooze-O	5	EPIC	
+3226	extra-dry artisanal lime green bottle of Ooze-O	5	EPIC	
 3227	normal C.H.U.M. chum	3	good	
 3228	bland unfortunate dumplings	3	decent	
 3229	squat decaying goldfish liver	0		
@@ -3232,10 +3232,10 @@
 3260	dangerous Da Vinci's supercool Chester's moustache	0		Moxie Percent: +20, Experience (Mysticality): +5, Weapon Damage: +10, Class: "Disco Bandit", Single Equip
 3261	gravedigger's razor-sharp Chester's bag of candy	0		Weapon Damage Percent: +25, Spooky Damage: +10, Class: "Disco Bandit"
 3262	upside-down banded sinister Chester's cutoffs	0		Spell Damage: +10, Damage Absorption: +100, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	upside-down candygram	0		Last Available: "2008-04"
 3265	wobbly bag of Crotchety Pine saplings	0		
-3266	mirror red bag of Saccharine Maple saplings	0		
+3266	red mirror bag of Saccharine Maple saplings	0		
 3267	purple bag of Laughing Willow saplings	0		
 3268	liquefied colloidal concentrated handful of Crotchety Pine needles	0		Effect: "Smugness", Effect Duration: 49
 3269	vacuum-sealed dry shaking lump of Saccharine Maple sap	0		Effect: "Sweet Incentive", Effect Duration: 12
@@ -3294,7 +3294,7 @@
 3322	lard-coated Samson's mayfly bait necklace	0		Experience (Muscle): +5, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	tolerable watered-down blurry bouncing jar of fermented pickle juice	2	good	
+3325	tolerable watered-down bouncing blurry jar of fermented pickle juice	2	good	
 3326	pickled mirror bouncing voodoo snuff	1	good	Effect: "Graham Crackling", Effect Duration: 5
 3327	huge tasty extra-greasy slider	7	awesome	
 3328	skewed twirling wizardly crumpled felt fedora of the ox	0		Muscle: +20, Mysticality: +25, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3331,17 +3331,17 @@
 3359	scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
-3362	skewed spinning olive tasty louse	0		Last Available: "2008-06"
+3362	spinning skewed olive tasty louse	0		Last Available: "2008-06"
 3363	small flavorless mole mol&eacute;	2	decent	Last Available: "2008-06"
 3364	perfectly mixed weak Morlock's Mark Bourbon	2	EPIC	Last Available: "2008-06"
-3365	electrified tumbling teal Climate Colada	0		Effect: "Heart of Orange", Effect Duration: 37, Last Available: "2008-06"
+3365	electrified teal tumbling Climate Colada	0		Effect: "Heart of Orange", Effect Duration: 37, Last Available: "2008-06"
 3366	nitrogenated upside-down digital underground potion	0		Effect: "Notably Lovely", Effect Duration: 20, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	dehydrated spinning blue glimmering roc feather	1	good	Last Available: "2008-06"
+3368	dehydrated blue spinning glimmering roc feather	1	good	Last Available: "2008-06"
 3369	vaporized fuchsia glimmering phoenix feather	1		Last Available: "2008-06"
 3370	vaporized skewed glimmering penguin feather	1		Effect: "Okee-Dokee Go!", Effect Duration: 15, Last Available: "2008-06"
 3371	altered narrow glimmering buzzard feather	1		Last Available: "2008-06"
-3372	boiled wobbly green glimmering raven feather	1		Last Available: "2008-06"
+3372	boiled green wobbly glimmering raven feather	1		Last Available: "2008-06"
 3373	compressed huge glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3397,7 +3397,7 @@
 3430	bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	pulsating cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
-3433	olive blurry spice melange	0		
+3433	blurry olive spice melange	0		
 3434	rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	deadly Newton's stirring stick	0		Experience (Mysticality): +3, Weapon Damage: +5
 3436	bouncing dance instructor's smooth Staff of the Teapot Tempest of the wise owl	0		Mysticality: +20, Moxie: +15, Experience Percent (Moxie): +10
@@ -3424,16 +3424,16 @@
 3457	blue razor-sharp Junior Adventurer's merit badge	0		Weapon Damage Percent: +25
 3458	double-polarized cold-filtered STYX deodorant body spray	0		Effect: "Weather, Man", Effect Duration: 55
 3459	artisanal white-label gin	4	EPIC	
-3460	miniature normal jittery pulsating tin rations	2	good	
+3460	normal miniature pulsating jittery tin rations	2	good	
 3461	bouncing haiku challenge map	0		
 3462	terrible poem	0		
 3463	acceptable bottle of sake	3	good	
 3464	Jeselnik's round pebble	0		Sleaze Damage: +25
-3465	huge bland huge Bash-&#332;s cereal	6	decent	Wiki Name: "Bash-Os cereal"
+3465	bland huge huge Bash-&#332;s cereal	6	decent	Wiki Name: "Bash-Os cereal"
 3466	miser's MacGyver's haiku katana of dire peril	0		Weapon Damage: +20, Maximum MP: +100, Meat Drop: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	Herculean plastic baby	0		Experience (Muscle): +1, Single Equip, Last Available: "2008-12"
-3469	immense decent huge wobbly blueberry-frosted king cake	6	good	Last Available: "2008-12"
+3469	decent immense huge wobbly blueberry-frosted king cake	6	good	Last Available: "2008-12"
 3470	gray bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	tumbling damp boot	0		
 3472	frightening lion tamer's shellacked Seasonal Beret	0		Damage Reduction: 7, Experience (familiar): +2, Spooky Damage: +5, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3459,19 +3459,19 @@
 3492	blinking fish scimitar of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100
 3493	rosewater-soaked Lo Pan's fish stick	0		Spell Critical Percent: +30, Stench Resistance: +3
 3494	shaking smartaleck's fish bazooka of the overflowing toilet	0		Moxie Percent: +30, Stench Spell Damage: +50
-3495	anodized ionized gray jittery bouncing sea salt crystal	0		Effect: "Gingerbread Robust", Effect Duration: 63
+3495	anodized ionized jittery gray bouncing sea salt crystal	0		Effect: "Gingerbread Robust", Effect Duration: 63
 3496	tarnished chilled twirling bazookafish bubble gum	0		Effect: "In the Slimelight", Effect Duration: 66
 3497	acceptable bottle of Pete's Sake	3	good	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	bouncing purple beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	bouncing purple beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	bland canap&eacute;s	3	decent	
 3502	altered upside-down thermos of brew	1	decent	Last Available: "2011-12"
 3503	watered-down bad enchanted blinking glass of brandy	2	decent	Effect: "Memories of Puppy Love", Effect Duration: 40, Last Available: "2011-12"
 3504	blinking French slippers	0		
 3505	yellow inspector's LWA ring	0		Item Drop: +15
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	spinning Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	spinning Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	blurry scratch 'n' sniff sword of the sweet-tooth	0		Candy Drop: +100, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,15 +3510,15 @@
 3543	smelly depleted Grimacite gravy boat of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10, Last Available: "2011-12"
 3544	Sherlock's medical-grade depleted Grimacite weightlifting belt	0		Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2011-12"
 3545	purple censurious depleted Grimacite grappling hook of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +3, Single Equip, Last Available: "2011-12"
-3546	hardy wholesome depleted Grimacite ninja mask	0		Maximum HP Percent: +10, Maximum HP: +50, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	squat supercharged depleted Grimacite shinguards of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	hardy wholesome depleted Grimacite ninja mask	0		Maximum HP Percent: +10, Maximum HP: +50, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	squat supercharged depleted Grimacite shinguards of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	foul-smelling Oprah's depleted Grimacite astrolabe	0		Maximum MP Percent: +50, Stench Damage: +10, Single Equip, Last Available: "2011-12"
 3549	huge green narrow electrified beefy KoL Con Cinco Pi&ntilde;ata Bat	0		Muscle: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2008-09"
 3550	lime green greasy propeller beanie	0		Sleaze Spell Damage: +10, Familiar Effect: "atk, cap 7"
 3551	grievous Newton's strapping straw hat	0		Muscle: +5, Experience (Mysticality): +3, Weapon Damage Percent: +50, Familiar Effect: "1xFairy"
 3552	Tesla studded octopus's spade of bravery	0		Damage Absorption: +80, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10
 3553	upside-down soggy seed packet	0		
-3554	tumbling mirror bouncing glob of slime	0		
+3554	mirror bouncing tumbling glob of slime	0		
 3555	rotten tiny lime green sea carrot	1	crappy	
 3556	tasty sea cucumber	3	awesome	
 3557	decent tumbling sea avocado	4	good	
@@ -3546,9 +3546,9 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	purple wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	spoiled tiny rice	1	crappy	
+3582	tiny spoiled rice	1	crappy	
 3584	adequate twirling irradiated candy cane	4	good	Last Available: "2008-12"
-3585	super-sized yummy gingerbread mutant bugbear	5	awesome	Last Available: "2008-12"
+3585	yummy super-sized gingerbread mutant bugbear	5	awesome	Last Available: "2008-12"
 3586	aged oozenog	4	awesome	Last Available: "2008-12"
 3587	anodized tarnished sugar plum	0		Effect: "Holiday Bliss", Effect Duration: 60, Last Available: "2008-12"
 3588	quadruple-enhanced denatured sugar banana	0		Effect: "Low on the Hog", Effect Duration: 13, Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	parasitic claw of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2008-12"
-3625	jittery auspicious parasitic tentacles	0		Item Drop: +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	Fonzie's parasitic headgnawer	0		Experience (Moxie): +1, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	jittery auspicious parasitic tentacles	0		Item Drop: +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	Fonzie's parasitic headgnawer	0		Experience (Moxie): +1, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	healthy parasitic strangleworm	0		Maximum HP Percent: +20, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,24 +3598,24 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	scandalous elven socks of the businessman	0		Sleaze Damage: +5, Meat Drop: +50, Last Available: "2008-12"
 3634	teal wizardly elven gloves of Leguizamo	0		Mysticality: +25, Monster Level: +20, Last Available: "2008-12"
-3635	wobbly Socratic festive holiday hat of doom	0		Experience (Mysticality): +1, Spooky Spell Damage: +50, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	wobbly Socratic festive holiday hat of doom	0		Experience (Mysticality): +1, Spooky Spell Damage: +50, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	friendly patent shoes of James Dean	0		Experience (Moxie): +3, Familiar Weight: +3, Last Available: "2008-12"
 3637	Jim Carey's gray bow tie of the glutton	0		Monster Level: +25, Food Drop: +100, Last Available: "2008-12"
 3638	blurry Sinatra's penguin thesaurus of horror	0		Experience (Moxie): +5, Spooky Spell Damage: +25, Last Available: "2008-12"
 3639	normal gray blurry blob-shaped Crimbo cookie	3	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
-3642	teal spinning dragonfish caviar	0		
+3642	spinning teal dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	smartaleck's depleted Grimacite kneecapping stick	0		Moxie Percent: +30, Last Available: "2007-06"
 3645	artisanal canteen of wine	4	EPIC	Last Available: "2008-12"
-3646	normal thick squat elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
+3646	thick normal squat elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	upside-down map to Madness Reef	0		
-3650	jumbo delicious toast with jam	5	awesome	Last Available: "2008-12"
-3651	blurry antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	acceptable irresponsibly strong enchanted elven moonshine	9	good	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2008-12"
+3650	delicious jumbo toast with jam	5	awesome	Last Available: "2008-12"
+3651	blurry antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	enchanted irresponsibly strong acceptable elven moonshine	9	good	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2008-12"
 3653	half-sized tasty huge knuckle sandwich	2	awesome	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	squat Van der Graaf rosy-cheeked psycho sweater	0		Maximum HP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-12"
 3655	squat fin-bit wax	0		Familiar Weight: +5
@@ -3625,8 +3625,8 @@
 3659	chaotic plastic strand of DNA	0		Spell Critical Percent: +10, Last Available: "2008-12"
 3660	family-friendly plastic chunk of depleted Grimacite	0		Sleaze Resistance: +1, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	blinking Putty mitre of the sweet-tooth	0		Candy Drop: +100, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	maroon Tesla wholesome Putty leotard	0		Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	blinking Putty mitre of the sweet-tooth	0		Candy Drop: +100, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	maroon Tesla wholesome Putty leotard	0		Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	steel-toed Putty ball	0		Damage Reduction: 9, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	avaricious auspicious Putty snake of Leguizamo	0		Monster Level: +20, Item Drop: +10, Meat Drop: +30, Softcore Only, Last Available: "2009-01"
@@ -3649,13 +3649,13 @@
 3683	map to the Marinara Trench	0		
 3684	flavorless tempura carrot	4	decent	
 3685	normal tempura cucumber	3	good	
-3686	rotten immense tempura avocado	10	crappy	
-3687	miniature stale jittery lime green sea broccoli	2	decent	
-3688	adequate fancy miniature bouncing sea cauliflower	2	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 35
+3686	immense rotten tempura avocado	10	crappy	
+3687	stale miniature lime green jittery sea broccoli	2	decent	
+3688	miniature fancy adequate bouncing sea cauliflower	2	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 35
 3689	small spoiled mirror tempura broccoli	2	crappy	
-3690	spoiled half-sized jittery tempura cauliflower	2	crappy	
+3690	half-sized spoiled jittery tempura cauliflower	2	crappy	
 3691	tasty sea blueberry	3	awesome	
-3692	special yummy bite-sized sea persimmon	1	awesome	Effect: "Nut-Rition", Effect Duration: 30
+3692	special bite-sized yummy sea persimmon	1	awesome	Effect: "Nut-Rition", Effect Duration: 30
 3693	energized dry teal bouncing pressurized potion of perception	0		Effect: "Litterboxing", Effect Duration: 28
 3694	cold-filtered quantum pressurized potion of proficiency	0		Effect: "Ode to Booze", Effect Duration: 19
 3695	Mer-kin digpick of temperance	0		Sleaze Resistance: +5
@@ -3689,13 +3689,13 @@
 3723	tarnished rod	0		
 3724	brittle plastic handle	0		
 3725	foggy glass globe	0		
-3726	spinning bouncing maroon possessed tomato	0		
+3726	maroon spinning bouncing possessed tomato	0		
 3727	spinning Nardz energy beverage	0		
 3728	yellow pile of coins	0		
 3729	jittery twirling hand grenegg	0		
 3730	caret	0		
 3731	glass gnoll eye of wisdom	0		Mysticality: +15
-3732	cold-filtered nitrogenated triple-aerosolized squat mirror huge cigar butt	0		Effect: "Broberry Brotality", Effect Duration: 52
+3732	cold-filtered nitrogenated triple-aerosolized mirror huge squat cigar butt	0		Effect: "Broberry Brotality", Effect Duration: 52
 3733	purple groovy boxer's manly bloomers	0		Muscle Percent: +10, Moxie Percent: +10, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
 3734	huge teal Colon Annihilation Hot Sauce	0		
 3735	huge fat wallet	0		
@@ -3710,12 +3710,12 @@
 3744	lime green software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	wobbly vampire pearl	0		
-3747	narrow mirror mother's secret recipe	0		Recipe: "white chocolate chip brownies"
+3747	mirror narrow mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	diffused spinning concoction of clumsiness	0		Effect: "Sparkling Consciousness", Effect Duration: 27
 3750	ghostly supercharged vampire pearl earring	0		Maximum MP Percent: +30, Single Equip
 3751	rotten special squat chocolate chip brownies	4	crappy	Effect: "[1609]Dancin' Fool", Effect Duration: 30
-3753	wobbly Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
-3754	non-aerosolized super-vacuum-sealed adjusted spinning wobbly love song of vague ambiguity	0		Effect: "Memory of Speed", Effect Duration: 22, Last Available: "2009-02"
+3753	wobbly Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3754	non-aerosolized super-vacuum-sealed adjusted wobbly spinning love song of vague ambiguity	0		Effect: "Memory of Speed", Effect Duration: 22, Last Available: "2009-02"
 3755	vacuum-sealed altered love song of smoldering passion	0		Effect: "Uncaged Power", Effect Duration: 58, Last Available: "2009-02"
 3756	quadruple-diffused altered love song of icy revenge	0		Effect: "Frozen Hands", Effect Duration: 64, Last Available: "2009-02"
 3757	pressed super-unsweetened twirling love song of sugary cuteness	0		Effect: "Nightstalkin'", Effect Duration: 12, Last Available: "2009-02"
@@ -3725,9 +3725,9 @@
 3761	mirror sinister vampire pearl ring	0		Spell Damage: +10, Single Equip
 3762	green experienced vampire pearl necklace	0		Experience: +2, Single Equip
 3763	lousy yellow slug of vodka	3	decent	
-3764	practically non-alcoholic artisanal slug of rum	1	EPIC	
-3765	practically non-alcoholic mediocre slug of shochu	1	decent	
-3766	fancy acceptable screwdiver	3	good	Effect: "Action", Effect Duration: 45
+3764	artisanal practically non-alcoholic slug of rum	1	EPIC	
+3765	mediocre practically non-alcoholic slug of shochu	1	decent	
+3766	acceptable fancy screwdiver	3	good	Effect: "Action", Effect Duration: 45
 3767	lousy dew yoana lei	3	decent	
 3768	delicious lychee chuhai	4	awesome	
 3769	hand-crafted purple salacious screwdiver	4	EPIC	
@@ -3749,12 +3749,12 @@
 3785	smoking talon	0		Class: "Pastamancer"
 3786	teal vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
-3788	huge shaking jittery crumbling rat skull	0		Class: "Pastamancer"
+3788	huge jittery shaking crumbling rat skull	0		Class: "Pastamancer"
 3789	twirling twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	red rosewater-soaked friendly educational Mer-kin roundshield	0		Experience: +1, Familiar Weight: +3, Stench Resistance: +3, Damage Reduction: 14
 3804	mansplainer's strapping Mer-kin breastplate	0		Muscle: +5, Monster Level: +15
 3805	horrifying Newton's Mer-kin sneakmask	0		Experience (Mysticality): +3, Spooky Damage: +25, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3762,7 +3762,7 @@
 3807	polymerized ionized ionized Mer-kin hidepaint	0		Effect: "Chlorophyll Flavor", Effect Duration: 51
 3808	skewed Mer-kin trailmap	0		
 3809	squat Mer-kin healscroll	0		
-3810	upside-down yellow squat Mer-kin lockkey	0		
+3810	squat yellow upside-down Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
 3812	normal upside-down chocolate-frosted king cake	4	good	Last Available: "2009-06"
 3813	huge sharpshooter's plastic baby	0		Critical Hit Percent: +10, Single Equip, Last Available: "2009-06"
@@ -3784,7 +3784,7 @@
 3830	aromatic water-polo cap	0		Stench Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr"
 3831	acceptable Typical Tavern swill	3	good	
 3832	artisanal practically non-alcoholic narrow tropical swill	1	super ultra mega turbo EPIC	
-3833	fancy artisanal distilled fruity girl swill	5	EPIC	Effect: "Abyssal Sweat", Effect Duration: 15
+3833	artisanal distilled fancy fruity girl swill	5	EPIC	Effect: "Abyssal Sweat", Effect Duration: 15
 3834	smooth blended swill	4	awesome	
 3835	costume wardrobe	0		Softcore Only
 3836	gray hardened supercool Rosewater's Elvish sunglasses of terror	0		Mysticality Percent: +30, Moxie Percent: +20, Damage Reduction: 3, Spooky Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3848,7 +3848,7 @@
 3894	frozen super-chilled vial of teal slime	0		Effect: "Hood Ridin'", Effect Duration: 15
 3895	wet chilled vial of indigo slime	0		Effect: "Healthy Red Glow", Effect Duration: 30
 3896	warmed vacuum-sealed wet vial of slime	0		Effect: "Going Ape", Effect Duration: 58
-3897	magnetized ionized skewed purple vial of brown slime	0		Effect: "Okee-Dokee Go!", Effect Duration: 39
+3897	magnetized ionized purple skewed vial of brown slime	0		Effect: "Okee-Dokee Go!", Effect Duration: 39
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	blinking figurine of a wretched-looking seal	0		Class: "Seal Clubber"
@@ -3896,7 +3896,7 @@
 3944	scorching toasty shadowy seal eye	0		Hot Damage: 30, Class: "Seal Clubber"
 3945	oyster egg balloon of the pedagogue	0		Experience: +3
 3946	Clan VIP Lounge invitation	0		Free Pull
-3947	wobbly jittery Clan VIP Lounge key	0		Free Pull
+3947	jittery wobbly Clan VIP Lounge key	0		Free Pull
 3948	Meat	0		
 3949	shaking treasure chest	0		
 3950	key	0		
@@ -3986,19 +3986,19 @@
 4034	wobbly memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	tiny delicious slimy sweetbreads	1	awesome	
-4038	enchanted bad wobbly slimy fermented bile bladder	3	decent	Effect: "Spiritually Awake", Effect Duration: 5
-4039	vaporized bouncing skewed slimy alveolus	1		
+4037	delicious tiny slimy sweetbreads	1	awesome	
+4038	bad enchanted wobbly slimy fermented bile bladder	3	decent	Effect: "Spiritually Awake", Effect Duration: 5
+4039	vaporized skewed bouncing slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	maroon pig-iron helm of James Dean of the detective	0		Experience (Moxie): +3, Item Drop: +20, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	yellow rosy-cheeked studded pig-iron shinguards	0		Damage Absorption: +80, Maximum HP Percent: +30, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	maroon pig-iron helm of James Dean of the detective	0		Experience (Moxie): +3, Item Drop: +20, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	yellow rosy-cheeked studded pig-iron shinguards	0		Damage Absorption: +80, Maximum HP Percent: +30, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	olive shaking greedy Sherlock's pig-iron bracers	0		Item Drop: +25, Meat Drop: +20, Single Equip, Last Available: "2009-06"
 4044	twirling wumpus hair	0		Last Available: "2009-06"
 4045	tumbling wumpus-hair bolo	0		Last Available: "2009-06"
 4046	pulsating wumpus-hair net	0		Last Available: "2009-06"
 4047	hale wumpus-hair whip	0		Maximum HP: +20, Last Available: "2009-06"
-4048	narrow gravedigger's frosty sinister wumpus-hair wig	0		Spell Damage: +10, Cold Spell Damage: +10, Spooky Damage: +10, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	greedy Jeselnik's thinker's wumpus-hair loincloth	0		Mysticality: +10, Sleaze Damage: +25, Meat Drop: +20, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	narrow gravedigger's frosty sinister wumpus-hair wig	0		Spell Damage: +10, Cold Spell Damage: +10, Spooky Damage: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	greedy Jeselnik's thinker's wumpus-hair loincloth	0		Mysticality: +10, Sleaze Damage: +25, Meat Drop: +20, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	jittery wumpus-hair sweater of Leguizamo of temperance	0		Monster Level: +20, Sleaze Resistance: +5, Last Available: "2009-06"
 4051	ring of teleportation of Leguizamo	0		Monster Level: +20, Single Equip
 4052	tumbling glass of baboon milk	1	awesome	Last Available: "2009-06"
@@ -4015,7 +4015,7 @@
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	jittery upside-down 'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	fuchsia Spacefleet Communicator Badge	0		Last Available: "2009-06"
-4066	squat tumbling Ruby Rod	0		Last Available: "2009-06"
+4066	tumbling squat Ruby Rod	0		Last Available: "2009-06"
 4067	squat essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	jittery essence of	0		Last Available: "2009-06"
@@ -4032,12 +4032,12 @@
 4080	olive censurious slick grisly shield	0		Moxie: +10, Sleaze Resistance: +3, Slime Hates It: +1, Damage Reduction: 13
 4081	corroded breeches of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	Annie Oakley's resourceful pernicious cudgel	0		Maximum MP: +50, Critical Hit Percent: +20, Slime Hates It: +1
-4083	tiny rotten cupcake-in-a-cup	1	crappy	Last Available: "2009-06"
+4083	rotten tiny cupcake-in-a-cup	1	crappy	Last Available: "2009-06"
 4084	tumbling pool of liquid	0		Last Available: "2009-06"
 4085	half-sized yummy protein paste	2	awesome	Last Available: "2009-06"
 4086	Oprah's cyber-mattock of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
-4088	squat spinning X-37 gun	0		Last Available: "2009-06"
+4088	spinning squat X-37 gun	0		Last Available: "2009-06"
 4089	frozen flattened neurostim pill	0		Effect: "Salty Mouth", Effect Duration: 67, Last Available: "2009-06"
 4090	concentrated physiostim pill	0		Effect: "Hammered", Effect Duration: 16, Last Available: "2009-06"
 4091	slimy cyst	0		
@@ -4080,7 +4080,7 @@
 4128	censurious Herculean brainy hardened slime pants	0		Mysticality: +5, Experience (Muscle): +1, Sleaze Resistance: +3, Familiar Effect: "atk, 1xPotato"
 4129	inspector's hardened slime belt of Tarzan of extreme caution	0		Experience (Muscle): +3, Monster Level: -25, Item Drop: +15, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
-4131	mixed mirror wobbly green boot plant	1	awesome	Last Available: "2009-06"
+4131	mixed mirror green wobbly boot plant	1	awesome	Last Available: "2009-06"
 4132	mediocre weak sham champagne	2	decent	Last Available: "2009-06"
 4133	chilled tempura air	0		Effect: "Red Misty-Eyed", Effect Duration: 55
 4134	adjusted pressurized potion of pneumaticity	0		Effect: "Astral Shell", Effect Duration: 22
@@ -4109,7 +4109,7 @@
 4157	ghostly gravel	0		Last Available: "2009-09"
 4158	squat red rock	0		Last Available: "2009-09"
 4159	bouncing rock lobster	0		Last Available: "2009-09"
-4160	delicious weak pebblebr&auml;u	2	awesome	Last Available: "2009-09"
+4160	weak delicious pebblebr&auml;u	2	awesome	Last Available: "2009-09"
 4161	stale rocky road ice cream	3	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	oxidized quadruple-colloidal children of the candy corn	0		Effect: "Pop-eyed", Effect Duration: 48
@@ -4130,8 +4130,8 @@
 4178	chilly sugar shotgun	0		Cold Damage: +5, Last Available: "2009-09"
 4179	sugar shillelagh of the sewer	0		Stench Damage: +25, Last Available: "2009-09"
 4180	fuchsia crafty sugar shank	0		Maximum MP: +10, Last Available: "2009-09"
-4181	manspreader's cool sugar chapeau of bravery	0		Moxie: +5, Monster Level: +10, Spooky Resistance: +5, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	skewed maroon arcane researcher's sugar shorts	0		Experience Percent (Mysticality): +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	manspreader's cool sugar chapeau of bravery	0		Moxie: +5, Monster Level: +10, Spooky Resistance: +5, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	skewed maroon arcane researcher's sugar shorts	0		Experience Percent (Mysticality): +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	shaking slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4178,7 +4178,7 @@
 4226	mansplainer's Star of Bravery	0		Monster Level: +15, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	yellow amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	yellow amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	lime green ice skate decoy	0		
 4232	pulsating ice skate doll	0		
@@ -4192,12 +4192,12 @@
 4240	enhanced electrified gun cleaning kit	0		Effect: "Highland Sheen", Effect Duration: 69
 4241	sage sleep mask	0		Mysticality Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	deadly sock garters	0		Weapon Damage: +5, Single Equip
-4243	quantum aerosolized blurry mirror mariachi toothpaste	0		Effect: "Sugar, Hello", Effect Duration: 53
+4243	quantum aerosolized mirror blurry mariachi toothpaste	0		Effect: "Sugar, Hello", Effect Duration: 53
 4244	Da Vinci's leather-bound tome	0		Experience (Mysticality): +5
 4245	pulsating bookmark	0		
 4246	flame-wreathed ivory cue ball	0		Hot Spell Damage: +10
 4247	mediocre huge decanter of fine Scotch	3	decent	
-4248	denatured huge maroon expensive cigar	1		
+4248	denatured maroon huge expensive cigar	1		
 4249	upside-down tophat	0		Familiar Weight: +5
 4250	blurry fisherman's sack	0		
 4251	upside-down fish-oil smoke bomb	0		
@@ -4207,14 +4207,14 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	vacuum-sealed corrupted sap	0		Effect: "You Know When to Walk Away", Effect Duration: 39, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	bite-sized enchanted flavorless chocolate-covered scarab beetle	1	decent	Effect: "Sausage Festive", Effect Duration: 10, Last Available: "2009-10"
+4258	bite-sized flavorless enchanted chocolate-covered scarab beetle	1	decent	Effect: "Sausage Festive", Effect Duration: 10, Last Available: "2009-10"
 4259	practically non-alcoholic lousy tumbling mulled cider	1	decent	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	upside-down toasty bark boxers	0		Hot Damage: +5, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	Fonzie's bark beret	0		Experience (Moxie): +1, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	upside-down toasty bark boxers	0		Hot Damage: +5, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	Fonzie's bark beret	0		Experience (Moxie): +1, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	bark bracelet of Leguizamo	0		Monster Level: +20, Single Equip
 4267	ribald Krakrox's Loincloth of the early riser	0		Sleaze Damage: +10, Adventures: +7, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	dog trainer's Galapagosian Cuisses of the sewer	0		Experience (familiar): +1, Stench Damage: +25, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4279,10 +4279,10 @@
 4327	purple ghostly greedy perfumed La Hebilla del Cintur&oacute;n de Lopez of the detective	0		Stench Resistance: +5, Item Drop: +20, Meat Drop: +20, Class: "Accordion Thief", Single Equip
 4328	ghostly suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	enchanted miniature yummy candy kneecapping stick	2	awesome	Effect: "Macho, Macho Dog", Effect Duration: 25, Last Available: "2009-12"
-4331	diet delicious licorice garrote	1	awesome	Last Available: "2009-12"
+4330	miniature yummy enchanted candy kneecapping stick	2	awesome	Effect: "Macho, Macho Dog", Effect Duration: 25, Last Available: "2009-12"
+4331	delicious diet licorice garrote	1	awesome	Last Available: "2009-12"
 4332	twirling friendly candy knuckles	0		Familiar Weight: +3, Last Available: "2009-12"
-4333	half-sized flavorless jawbruiser	2	decent	Last Available: "2010-12"
+4333	flavorless half-sized jawbruiser	2	decent	Last Available: "2010-12"
 4334	flattened triple-anodized spinning chocolate car	0		Effect: "Berry Critical", Effect Duration: 14, Last Available: "2009-12"
 4335	cool plastic 11 Dealer	0		Moxie: +5, Last Available: "2009-12"
 4336	lime green educational plastic Crimbo Casino	0		Experience: +1, Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	teal gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	mirror wholesome snow hat	0		Maximum HP Percent: +10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	wizardly snow pants	0		Mysticality: +25, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	mirror wholesome snow hat	0		Maximum HP Percent: +10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	wizardly snow pants	0		Mysticality: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	blue smooth snow belly	0		Moxie: +15, Single Equip, Last Available: "2009-12"
 4352	wobbly pile of loose snow	0		Last Available: "2009-12"
 4353	fuchsia Crimbough	0		Last Available: "2009-12"
@@ -4311,11 +4311,11 @@
 4359	upside-down A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	miniature delicious expired can of franks 'n' beans	2	awesome	Last Available: "2009-12"
 4361	drinkable expired bottle of peppermint schnapps	3	good	Last Available: "2009-12"
-4362	tumbling squat snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
+4362	squat tumbling snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	teal elf resistance button	0		Last Available: "2009-12"
 4364	galvanized skewed elven suicide capsule	0		Effect: "Incensed", Effect Duration: 28, Last Available: "2009-12"
-4365	low-calorie tasty penguin focaccia bread	1	awesome	Last Available: "2009-12"
-4366	weak acceptable special herringcello	2	good	Effect: "Starry-Eyed", Effect Duration: 45, Last Available: "2009-12"
+4365	tasty low-calorie penguin focaccia bread	1	awesome	Last Available: "2009-12"
+4366	special weak acceptable herringcello	2	good	Effect: "Starry-Eyed", Effect Duration: 45, Last Available: "2009-12"
 4367	smooth blue elven cellocello	4	awesome	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	narrow handful of headless bolts	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	miser's experienced pocketwatch on a chain	0		Experience: +2, Meat Drop: +10, Last Available: "2009-12"
 4386	Tesla cement sandals of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2009-12"
 4387	wizardly night-vision goggles of the early riser	0		Mysticality: +25, Adventures: +7, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	peanut brittle shield of the cheetah	0		Initiative: +60, Damage Reduction: 3, Last Available: "2009-12"
 4390	horrifying coward's Red Rover BB gun	0		Monster Level: -20, Spooky Damage: +25, Last Available: "2009-12"
 4391	purple quilted red-and-green sweater	0		Damage Absorption: +40, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
@@ -4349,18 +4349,18 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	tumbling cheese ball	0		Last Available: "2010-01"
 4399	fuchsia frightening cheese sword	0		Spooky Damage: +5, Softcore Only, Last Available: "2010-01"
-4400	blinking flame-retardant cheese diaper	0		Hot Resistance: +1, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	blinking flame-retardant cheese diaper	0		Hot Resistance: +1, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	cheese wheel of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	shaking cheese eye of incineration	0		Hot Spell Damage: +50, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	lime green chilly coward's crafty Staff of Queso Escusado	0		Maximum MP: +10, Monster Level: -20, Cold Damage: +5, Softcore Only, Last Available: "2010-01"
-4405	maroon spinning foreign box	0		
+4405	spinning maroon foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	mirror Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	low-calorie flavorless fancy quantum taco	0		Effect: "Pill Power", Effect Duration: 45, Last Available: "2010-10"
+4412	flavorless low-calorie fancy quantum taco	0		Effect: "Pill Power", Effect Duration: 45, Last Available: "2010-10"
 4413	watered-down delicious shaking Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	teal colorful plastic ball	0		Last Available: "2010-01"
 4415	boxer's sealhide hood	0		Muscle Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4373,7 +4373,7 @@
 4422	red sealhide belt of Calamity Jane	0		Critical Hit Percent: +15
 4423	sealhide snare	0		
 4424	puzzling trophy	0		
-4425	frozen altered huge bouncing sealhide seal doll	0		Effect: "Pla-see-bo", Effect Duration: 59
+4425	frozen altered bouncing huge sealhide seal doll	0		Effect: "Pla-see-bo", Effect Duration: 59
 4426	narrow hymnal	0		Skill: "Canticle of Carboloading"
 4428	horrifying glowstick on a string	0		Spooky Damage: +25
 4429	rosewater-soaked candy necklace	0		Stench Resistance: +3, Single Equip
@@ -4396,7 +4396,7 @@
 4448	modified yellow squat Instant Karma	1	crappy	
 4449	mirror huge painting of a landscape	0		Last Available: "2010-04"
 4450	blinking map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	horrifying pointy hat	0		Spooky Damage: +25, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	horrifying pointy hat	0		Spooky Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	aromatic machetito	0		Stench Resistance: +1, Last Available: "2010-04"
 4453	jittery quilted lawnmower blade	0		Damage Absorption: +40, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4409,15 +4409,15 @@
 4461	anodized deionized colloidal seal-brain elixir	0		Effect: "Human-Machine Hybrid", Effect Duration: 19
 4462	aerosolized chocolate seal-clubbing club	0		Effect: "Work For Hours a Week", Effect Duration: 35
 4463	electrified blue chocolate turtle totem	0		Effect: "Rave Nirvana", Effect Duration: 68
-4464	denatured quantum green blurry chocolate pasta spoon	0		Effect: "Stuck That Way", Effect Duration: 65
+4464	denatured quantum blurry green chocolate pasta spoon	0		Effect: "Stuck That Way", Effect Duration: 65
 4465	polymerized chocolate saucepan	0		Effect: "Eau de Tortue", Effect Duration: 17
 4466	improved dry chocolate disco ball	0		Effect: "Wings of the Grasshopper", Effect Duration: 40
 4467	polarized diffused ghostly chocolate stolen accordion	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 57
-4468	twirling upside-down Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	twirling upside-down Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	skewed BRICKO eye brick	0		Last Available: "2010-02"
-4471	skewed razor-sharp BRICKO hat	0		Weapon Damage Percent: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	gray scandalous BRICKO pants	0		Sleaze Damage: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	skewed razor-sharp BRICKO hat	0		Weapon Damage Percent: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	gray scandalous BRICKO pants	0		Sleaze Damage: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	personal trainer's BRICKO sword	0		Experience Percent (Muscle): +10, Last Available: "2010-02"
 4474	mirror purple BRICKO ooze	0		Last Available: "2010-02"
 4475	mirror BRICKO bat	0		Last Available: "2010-02"
@@ -4461,7 +4461,7 @@
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	toothsome miniature Humpty Dumplings	2	awesome	Last Available: "2010-03"
 4515	toothsome fancy Lobster <i>qua</i> Grill	4	awesome	Effect: "Oleaginous Soles", Effect Duration: 10, Last Available: "2010-03"
-4516	lousy distilled missing wine	5	decent	Last Available: "2010-03"
+4516	distilled lousy missing wine	5	decent	Last Available: "2010-03"
 4517	decent matter custard	3	good	Last Available: "2010-03"
 4518	quadruple-chilled red pulsating comfit?	0		Effect: "Hot Hands", Effect Duration: 53, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	cyan croquet hedgehog	0		Last Available: "2010-03"
 4522	huge Tiger-lily's milk	1	awesome	Last Available: "2010-03"
 4523	yellow sizzling eye of the Tiger-lily of chilblains	0		Cold Damage: +25, Hot Damage: +10, Last Available: "2010-03"
-4524	wig of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	wig of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	decent donut	4	good	Last Available: "2010-03"
-4526	spoiled enchanted huge upside-down bucket of honey	6	crappy	Effect: "Hagnk's Gratitude", Effect Duration: 45, Last Available: "2010-03"
+4526	spoiled huge enchanted upside-down bucket of honey	6	crappy	Effect: "Hagnk's Gratitude", Effect Duration: 45, Last Available: "2010-03"
 4527	ghostly smartaleck's elephant stinger of Gandalf	0		Moxie Percent: +30, Spell Critical Percent: +20, Last Available: "2010-03"
-4528	tiny decent dragon snaps	1	good	Last Available: "2010-03"
+4528	decent tiny dragon snaps	1	good	Last Available: "2010-03"
 4529	shaking Rosewater's snapdragon pistil	0		Mysticality Percent: +30, Item Drop: +5, Last Available: "2010-03"
 4530	upside-down puff of smoke	0		Last Available: "2010-03"
 4531	stale rook cookie	3	decent	Last Available: "2010-03"
 4532	rotten bishop cookie	4	crappy	Last Available: "2010-03"
-4533	small adequate knight cookie	2	good	Last Available: "2010-03"
+4533	adequate small knight cookie	2	good	Last Available: "2010-03"
 4534	bland half-sized king cookie	2	decent	Last Available: "2010-03"
 4535	decent bite-sized queen cookie	1	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	executive insane tophat	0		Meat Drop: +40, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	upside-down blinking Jim Carey's deadly helm of the knight	0		Weapon Damage: +5, Monster Level: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	executive insane tophat	0		Meat Drop: +40, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	upside-down blinking Jim Carey's deadly helm of the knight	0		Weapon Damage: +5, Monster Level: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	twirling executive rosewater-soaked wristwatch of the knight	0		Stench Resistance: +3, Meat Drop: +40, Single Equip, Last Available: "2010-03"
-4540	miser's dog trainer's trousers of the knight	0		Experience (familiar): +1, Meat Drop: +10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	miser's dog trainer's trousers of the knight	0		Experience (familiar): +1, Meat Drop: +10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	tophat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "1xBarrr, cap 25"
 4542	twirling Da Vinci's tie	0		Experience (Mysticality): +5, Single Equip
 4543	tuxedo pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4513,16 +4513,16 @@
 4565	immense decent raisin	7	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	mansplainer's flyest of shirts of the sweet-tooth	0		Monster Level: +15, Candy Drop: +100, Last Available: "2010-04"
-4568	flavorless massive huge twirling a dance upon the palate	8	decent	Last Available: "2010-04"
-4569	normal special prehistoric meteorite jawbreaker	3	good	Effect: "Disco Nirvana", Effect Duration: 20, Last Available: "2010-04"
+4568	flavorless massive twirling huge a dance upon the palate	8	decent	Last Available: "2010-04"
+4569	special normal prehistoric meteorite jawbreaker	3	good	Effect: "Disco Nirvana", Effect Duration: 20, Last Available: "2010-04"
 4570	twirling Crazyleg's razor	0		Last Available: "2010-04"
 4571	gigantic normal wobbly squirmy violent party snack	9	good	Last Available: "2010-04"
 4572	spinning dance instructor's can-you-dig-it?	0		Experience Percent (Moxie): +10, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	mirror meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	pressed denatured Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Incredibly Hulking", Effect Duration: 58, Last Available: "2010-04"
 4580	skewed therapeutic school Mafi<i>a kni</i>cke&frac12;&aelig;	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-04"
@@ -4530,14 +4530,14 @@
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	delicious mirror olive six wedges of goat cheese	4	awesome	
-4585	huge twirling collection of objects	0		
+4585	twirling huge collection of objects	0		
 4586	boulder	0		
 4587	goth	0		
 4588	brown pixel	0		
 4589	Annie Oakley's pixel whip	0		Critical Hit Percent: +20
 4590	pulsating lightning-fast pixel chain whip	0		Initiative: +40, Last Available: "2010-07"
 4591	pixel morning star of bravery	0		Spooky Resistance: +5, Last Available: "2010-07"
-4592	skewed upside-down pixel orb	0		Last Available: "2010-07"
+4592	upside-down skewed pixel orb	0		Last Available: "2010-07"
 4593	pixellated moneybag	0		Last Available: "2010-07"
 4594	upside-down cyan pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
@@ -4552,12 +4552,12 @@
 4604	keg	0		Last Available: "2010-06"
 4605	blinking stiffened Fonzie's bottle of Goldschn&ouml;ckered	0		Experience (Moxie): +1, Damage Reduction: 1, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	adequate skewed sun-dried tofu	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	bad weak soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	weak bad soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	quantum essential soy	0		Effect: "You're High as a Crow, Marty", Effect Duration: 20, Last Available: "2010-08"
 4611	triple-dry Vulcanized essential cameraderie	0		Effect: "Slimy Flavor", Effect Duration: 19, Last Available: "2010-08"
-4612	jittery lime green souvenir drawing	0		Last Available: "2010-08"
+4612	lime green jittery souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	Crown of Thrones of the bloodbag	0		Maximum HP: +100, Softcore Only, Last Available: "2010-05"
 4615	practically non-alcoholic perfectly mixed Cinco Mayo Lager	1	super ultra mega turbo EPIC	Last Available: "2010-05"
@@ -4567,7 +4567,7 @@
 4619	blurry frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
-4622	purple blurry Game Grid ticket	0		Last Available: "2010-06"
+4622	blurry purple Game Grid ticket	0		Last Available: "2010-06"
 4623	frozen double-ionized chocolate-covered caviar	0		Effect: "Compensatory Cruelness", Effect Duration: 67, Last Available: "2020-09"
 4624	special rotten pawn cookie	3	crappy	Effect: "Pasty", Effect Duration: 35, Last Available: "2010-06"
 4625	modified wobbly lime green coffee pixie stick	1	awesome	Effect: "Sweet, Nuts", Effect Duration: 30, Last Available: "2010-06"
@@ -4577,12 +4577,12 @@
 4629	dangerous plastic spider ring	0		Weapon Damage: +10, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	plastic kazoo of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-06"
 4631	bouncing grievous inflatable baseball bat	0		Weapon Damage Percent: +50, Last Available: "2010-06"
-4632	Newton's googly-star hat of the cheetah	0		Experience (Mysticality): +3, Initiative: +60, Last Available: "2010-06", Familiar Effect: "atk"
+4632	Newton's googly-star hat of the cheetah	0		Experience (Mysticality): +3, Initiative: +60, Familiar Effect: "atk", Last Available: "2010-06"
 4633	pulsating googly-ball hat of the cougar of chilblains	0		Moxie: +20, Cold Damage: +25, Last Available: "2010-06"
 4634	Temple Grandin's veiny googly-heart hat	0		Maximum HP: +10, Familiar Weight: +7, Last Available: "2010-06"
 4635	scandalous super-sweet boom box of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +5, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	censurious energetic strapping sinister demon mask	0		Muscle: +5, Maximum MP Percent: +20, Sleaze Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	censurious energetic strapping sinister demon mask	0		Muscle: +5, Maximum MP Percent: +20, Sleaze Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	stiffened sinister streetfighting champion's belt of the scaredy-cat	0		Spell Damage: +10, Damage Reduction: 1, Monster Level: -15, Single Equip, Last Available: "2010-06"
 4639	Jack Frost's hardy Space Trip safety headphones of Tarzan	0		Experience (Muscle): +3, Maximum HP: +50, Cold Spell Damage: +50, Single Equip, Last Available: "2010-06"
 4640	grievous LARP carp	0		Weapon Damage Percent: +50
@@ -4594,8 +4594,8 @@
 4646	stanky toasty extremely unsafe Meteoid ice beam	0		Weapon Damage Percent: +100, Hot Damage: +5, Stench Spell Damage: +25, Last Available: "2011-12"
 4647	baleful smartaleck's brawny Dungeon Fist gauntlet	0		Muscle Percent: +20, Moxie Percent: +30, Spell Damage: +25, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	tumbling ghostly chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	ghostly tumbling chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	upside-down ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	hardy experienced ironic knit cap	0		Experience: +2, Maximum HP: +50, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4618,17 +4618,17 @@
 4670	tumbling beer-scented teddy bear	0		
 4671	watered-down tolerable booze-soaked cherry	2	good	
 4672	comfy pillow	0		
-4673	half-sized tasty skewed marshmallow	2	awesome	
+4673	tasty half-sized skewed marshmallow	2	awesome	
 4674	bland huge blinking sponge cake	10	decent	
-4675	triple-distilled tolerable blinking gin-soaked blotter paper	10	good	
+4675	tolerable triple-distilled blinking gin-soaked blotter paper	10	good	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	blue smoked potsherd	0		
 4681	ruddy pottery shield	0		Maximum HP Percent: +40, Damage Reduction: 3, Last Available: "2010-09"
-4682	executive smartaleck's pottery hat	0		Moxie Percent: +30, Meat Drop: +40, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	blurry Sinatra's pottery training pants of the sewer	0		Experience (Moxie): +5, Stench Damage: +25, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	executive smartaleck's pottery hat	0		Moxie Percent: +30, Meat Drop: +40, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	blurry Sinatra's pottery training pants of the sewer	0		Experience (Moxie): +5, Stench Damage: +25, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	olive careful pottery club	0		Monster Level: -10, Last Available: "2010-09"
 4685	wizardly pottery yo-yo	0		Mysticality: +25, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	teal fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	mirror crafty Rosewater's Greatest American Pants of the glutton	0		Mysticality Percent: +30, Maximum MP: +10, Food Drop: +100, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	mirror crafty Rosewater's Greatest American Pants of the glutton	0		Mysticality Percent: +30, Maximum MP: +10, Food Drop: +100, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	deadly fossilized necklace	0		Weapon Damage: +5, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4661,7 +4661,7 @@
 4713	popsicle stick	0		
 4714	tasty lemon popsicle	3	awesome	
 4715	thick toothsome popsicle	5	awesome	
-4716	miniature flavorless upside-down strawberry popsicle	2	decent	
+4716	flavorless miniature upside-down strawberry popsicle	2	decent	
 4717	moldy shaking liver popsicle	3	crappy	
 4718	family-friendly mariachi hat	0		Sleaze Resistance: +1, Familiar Effect: "atk, cap 2"
 4719	yellow frosty Hollandaise helmet	0		Cold Spell Damage: +10, Familiar Effect: "atk, cap 2"
@@ -4672,13 +4672,13 @@
 4724	adequate skewed shoo-fish pie	4	good	Last Available: "2010-10"
 4725	decent big teal piping organ pie	5	good	Last Available: "2010-10"
 4726	adequate pulsating igloo pie	4	good	Last Available: "2010-10"
-4727	decent super-sized stomach turnover	5	good	Last Available: "2010-10"
+4727	super-sized decent stomach turnover	5	good	Last Available: "2010-10"
 4728	big bland blurry dead lights pie	5	decent	Last Available: "2010-10"
 4729	toothsome gray upside-down throbbing organ pie	4	awesome	Last Available: "2010-10"
 4730	lard-coated stop shield	0		Sleaze Spell Damage: +25, Damage Reduction: 6, Last Available: "2009-12"
 4731	ghostly nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
-4733	fuchsia ghostly kitty sheet music	0		Familiar Weight: +5
+4733	ghostly fuchsia kitty sheet music	0		Familiar Weight: +5
 4734	shaking rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	shaking prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
@@ -4699,8 +4699,8 @@
 4751	narrow chaotic boning knife	0		Spell Critical Percent: +10, Last Available: "2010-10"
 4752	dog trainer's bone crusher	0		Experience (familiar): +1, Last Available: "2010-10"
 4753	clever bone spurs	0		Maximum MP: +20, Single Equip, Last Available: "2010-10"
-4754	yellow ribald thinker's bonedanna	0		Mysticality: +10, Sleaze Damage: +10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	lightning-fast stiffened boneana hammock	0		Damage Reduction: 1, Initiative: +40, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	yellow ribald thinker's bonedanna	0		Mysticality: +10, Sleaze Damage: +10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	lightning-fast stiffened boneana hammock	0		Damage Reduction: 1, Initiative: +40, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	mirror bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	Vulcanized dry candy skeleton	0		Effect: "Natural 20", Effect Duration: 45, Last Available: "2020-09"
@@ -4724,7 +4724,7 @@
 4810	green Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	huge Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	special adequate CRIMBCOIDS mints	3	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2011-01"
+4818	adequate special CRIMBCOIDS mints	3	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2011-01"
 4819	jittery can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	spoiled pulsating CRIMBCOLOAF	4	crappy	Last Available: "2011-01"
 4821	bland circular CRIMBCOOKIE	3	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4751,15 +4751,15 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	tumbling Uncle Hobo's stocking cap of the brute of the dark arts	0		Muscle Percent: +30, Spell Damage Percent: +100, Last Available: "2010-12", Familiar Effect: "atk"
+4845	tumbling Uncle Hobo's stocking cap of the brute of the dark arts	0		Muscle Percent: +30, Spell Damage Percent: +100, Familiar Effect: "atk", Last Available: "2010-12"
 4846	greedy supercool Uncle Hobo's epic beard	0		Moxie Percent: +20, Meat Drop: +20, Single Equip, Last Available: "2010-12"
-4847	frosty crafty Uncle Hobo's gift baggy pants	0		Maximum MP: +10, Cold Spell Damage: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	frosty crafty Uncle Hobo's gift baggy pants	0		Maximum MP: +10, Cold Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	Van der Graaf Uncle Hobo's fingerless tinsel gloves of the boozehound	0		Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2010-12"
 4849	ribald weightlifter's Uncle Hobo's highest bough	0		Muscle: +15, Sleaze Damage: +10, Last Available: "2010-12"
 4850	mirror boxer's Uncle Hobo's belt of doom	0		Muscle Percent: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2010-12"
 4851	corrupted twirling chocolate cigar	0		Effect: "Artificially Sweet", Effect Duration: 33, Last Available: "2010-12"
 4852	gift-a-pult of the scaredy-cat	0		Monster Level: -15, Last Available: "2010-12"
-4853	triple-irradiated skewed twirling holly-flavored Hob-O	0		Effect: "Boilermade", Effect Duration: 29, Last Available: "2020-09"
+4853	triple-irradiated twirling skewed holly-flavored Hob-O	0		Effect: "Boilermade", Effect Duration: 29, Last Available: "2020-09"
 4854	teal CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	perfumed Jeselnik's scorching paperclip-on tie	0		Hot Damage: +25, Sleaze Damage: +25, Stench Resistance: +5, Single Equip, Last Available: "2011-01"
-4869	huge energetic paperclip pants of chilblains	0		Maximum MP Percent: +20, Cold Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	veiny deadly paperclip turban of the storm	0		Weapon Damage: +5, Maximum HP: +10, Maximum MP Percent: +40, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	huge energetic paperclip pants of chilblains	0		Maximum MP Percent: +20, Cold Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	veiny deadly paperclip turban of the storm	0		Weapon Damage: +5, Maximum HP: +10, Maximum MP Percent: +40, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	paperclip cape of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2011-01"
 4872	skewed jittery glob of Blank-Out	0		Last Available: "2011-01"
 4873	blinking photocopied monster	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	ionized incense bath ball	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 52, Last Available: "2011-01"
 4879	liquefied boiled myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Some Cheese with Your Wine", Effect Duration: 59, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	weak hand-crafted CRIMBCO wine	2	EPIC	Last Available: "2011-01"
+4881	hand-crafted weak CRIMBCO wine	2	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	flavorless toe jam toast	3	decent	Last Available: "2011-01"
@@ -4800,8 +4800,8 @@
 4891	tumbling bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	adequate gigantic festive sausage	9	good	Last Available: "2011-01"
-4895	spoiled miniature holiday cheese log	2	crappy	Last Available: "2011-01"
+4894	gigantic adequate festive sausage	9	good	Last Available: "2011-01"
+4895	miniature spoiled holiday cheese log	2	crappy	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	savvy BGE 'ferocious fruit' shirt of the brazier	0		Mysticality Percent: +20, Hot Spell Damage: +25, Last Available: "2010-12"
 4898	sizzling wholesome BGE 'cuddly critter' shirt	0		Maximum HP Percent: +10, Hot Damage: +10, Last Available: "2010-12"
@@ -4844,7 +4844,7 @@
 4941	moldy Knob jelly donut	4	crappy	
 4942	Knob cake	0		
 4943	Knob cake pan	0		
-4944	gray blurry Knob batter	0		
+4944	blurry gray Knob batter	0		
 4945	Knob frosting	0		
 4946	bouncing unfrosted Knob cake	0		
 4947	spinning Cobb's Knob Menagerie key	0		
@@ -4852,11 +4852,11 @@
 4949	ionized weremoose spit	0		Effect: "Total Protonic Reversal", Effect Duration: 28
 4950	triple-moist blurry abominable blubber	0		Effect: "Natural 20", Effect Duration: 34
 4951	Da Vinci's flimsy clipboard	0		Experience (Mysticality): +5, Damage Reduction: 3
-4952	pressed warmed dry narrow lime green baggie of sugar	0		Effect: "Egg-headedness", Effect Duration: 38
+4952	pressed warmed dry lime green narrow baggie of sugar	0		Effect: "Egg-headedness", Effect Duration: 38
 4953	prompt toasty whalebone corset	0		Hot Damage: +5, Adventures: +3, Single Equip
 4954	teal oven mitts of the cheetah	0		Initiative: +60, Single Equip
-4955	adequate tiny maroon overcookie	1	good	
-4956	spoiled diet philosopher's scone	1	crappy	
+4955	tiny adequate maroon overcookie	1	good	
+4956	diet spoiled philosopher's scone	1	crappy	
 4957	frozen anodized upside-down jittery half-baked potion	0		Effect: "Mushroom Magicalness", Effect Duration: 69
 4958	stanky Knob Goblin deluxe scimitar	0		Stench Spell Damage: +25
 4959	delicious Knob nuts	3	awesome	
@@ -4872,7 +4872,7 @@
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
 4971	purple Alice's Army Wallman	0		Last Available: "2011-03"
-4972	narrow wobbly Alice's Army Ninja	0		Last Available: "2011-03"
+4972	wobbly narrow Alice's Army Ninja	0		Last Available: "2011-03"
 4973	blinking Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	purple wobbly Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
@@ -4885,7 +4885,7 @@
 4982	upside-down Alice's Army Coward	0		Last Available: "2011-03"
 4983	spinning Alice's Army Cleric	0		Last Available: "2011-03"
 4984	Alice's Army Sniper	0		Last Available: "2011-03"
-4985	mirror shaking Alice's Army Dervish	0		Last Available: "2011-03"
+4985	shaking mirror Alice's Army Dervish	0		Last Available: "2011-03"
 4986	lime green Alice's Army Martyr	0		Last Available: "2011-03"
 4987	fuchsia Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	wobbly Alice's Army Foil Swordsman	0		Last Available: "2011-03"
@@ -4917,14 +4917,14 @@
 5014	adequate thick tobiko pocky	5	good	Last Available: "2011-03"
 5015	spoiled natto pocky	3	crappy	Last Available: "2011-03"
 5016	mediocre triple-distilled ghostly wasabi-infused sake	7	decent	Last Available: "2011-03"
-5017	watered-down bad tobiko-infused sake	2	decent	Last Available: "2011-03"
+5017	bad watered-down tobiko-infused sake	2	decent	Last Available: "2011-03"
 5018	drinkable natto-infused sake	3	good	Last Available: "2011-03"
 5019	alkaline moist fuchsia blinking wasabi marble soda	0		Effect: "Army of One", Effect Duration: 46, Last Available: "2011-03"
 5020	quantum electrified mirror shaking tobiko marble soda	0		Effect: "Graham Crackling", Effect Duration: 13, Last Available: "2011-03"
 5021	tarnished blurry natto marble soda	0		Effect: "One Foot Heavier", Effect Duration: 56, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	moist frozen mirror elderly jawbreaker	0		Effect: "Grrrrrrreat!", Effect Duration: 18, Last Available: "2020-09"
-5024	mediocre fancy irresponsibly strong spinning marshmallow flamb&eacute;	10	decent	Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2011-03"
+5024	irresponsibly strong mediocre fancy spinning marshmallow flamb&eacute;	10	decent	Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2011-03"
 5025	lousy cranberry schnapps	4	decent	Last Available: "2011-03"
 5026	perfectly mixed watered-down breaded beer	2	super ultra mega turbo EPIC	Last Available: "2011-03"
 5027	hand-crafted soy cordial	3	super ultra mega EPIC	Last Available: "2011-03"
@@ -4947,11 +4947,11 @@
 5044	weak delicious skewed astral pilsner	2		
 5045	astral hot dog dinner	0		
 5046	jittery astral six-pack	0		
-5047	bouncing lime green Clan shower	0		Free Pull, Last Available: "2011-04"
+5047	lime green bouncing Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	double-paned cool double-ice cap of the sweet-tooth	0		Moxie: +5, Cold Resistance: +5, Candy Drop: +100, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	double-paned cool double-ice cap of the sweet-tooth	0		Moxie: +5, Cold Resistance: +5, Candy Drop: +100, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	banded stylish double-ice box of Leguizamo	0		Moxie: +25, Damage Absorption: +100, Monster Level: +20, Last Available: "2011-04"
-5051	arcane researcher's savvy boxer's double-ice britches	0		Muscle Percent: +10, Mysticality Percent: +20, Experience Percent (Mysticality): +10, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	arcane researcher's savvy boxer's double-ice britches	0		Muscle Percent: +10, Mysticality Percent: +20, Experience Percent (Mysticality): +10, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	wobbly Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4961,30 +4961,30 @@
 5058	super-magnetized deionized magnetized narrow Red Pill	0		Effect: "Bananas!", Effect Duration: 20, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
-5061	yellow mirror boxing-glove-in-a-box	0		Last Available: "2011-04"
+5061	mirror yellow boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	narrow the finger	0		Last Available: "2011-04"
 5064	blurry Salsa de las Epocas	0		Last Available: "2011-04"
-5065	adequate tiny spaghetti con calaveras	1	good	Last Available: "2011-04"
+5065	tiny adequate spaghetti con calaveras	1	good	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	snack-sized bland bouncing popcorn	2	decent	Last Available: "2011-04"
-5068	small moldy teal chaos popcorn	2	crappy	Last Available: "2011-04"
+5067	bland snack-sized bouncing popcorn	2	decent	Last Available: "2011-04"
+5068	moldy small teal chaos popcorn	2	crappy	Last Available: "2011-04"
 5069	avaricious hole of dire peril of the brazier	0		Weapon Damage: +20, Hot Spell Damage: +25, Meat Drop: +30, Last Available: "2011-04"
-5070	narrow pulsating innuendo	0		Last Available: "2011-04"
-5071	diet adequate s'more	0	good	Last Available: "2011-04"
+5070	pulsating narrow innuendo	0		Last Available: "2011-04"
+5071	adequate diet s'more	0	good	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	acceptable weak tumbling Russian Ice	2	good	Last Available: "2011-04"
+5073	weak acceptable tumbling Russian Ice	2	good	Last Available: "2011-04"
 5074	Lo Pan's clay ashtray	0		Spell Critical Percent: +30, Damage Reduction: 3, Last Available: "2011-05"
 5075	lanyard of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2011-05"
-5076	mirror mirror spinning mansplainer's monster pants	0		Monster Level: +15, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	mirror mirror spinning mansplainer's monster pants	0		Monster Level: +15, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	blinking box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	colloidal Pok&euml;mann band-aid	0		Effect: "Fudge Headache", Effect Duration: 35, Last Available: "2011-05"
-5079	lime green up-at-dawn double-paned Van der Graaf helmet	0		Cold Resistance: +5, Adventures: +5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	lime green up-at-dawn double-paned Van der Graaf helmet	0		Cold Resistance: +5, Adventures: +5, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	ghostly Samson's crutch	0		Experience (Muscle): +5, Last Available: "2011-05"
 5081	mansplainer's shock belt	0		Monster Level: +15, Single Equip, Last Available: "2011-05"
 5082	improved mirror Okee-Dokee soda	0		Effect: "Wintry Breath", Effect Duration: 33, Last Available: "2011-05"
 5083	bouncing rubber band gun of the sweet-tooth	0		Candy Drop: +100, Last Available: "2011-05"
-5084	studded pin-stripe slacks	0		Damage Absorption: +80, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	studded pin-stripe slacks	0		Damage Absorption: +80, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	padded gloves	0		Damage Absorption: +20, Single Equip, Last Available: "2011-05"
 5086	oxidized altered bouncing correction fluid	0		Effect: "Banono", Effect Duration: 51, Last Available: "2011-05"
 5087	narrow blurry Pok&euml;mann figurine: Porkachu of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2011-05"
@@ -5003,11 +5003,11 @@
 5100	Pok&euml;mann figurine: Frank of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2011-05"
 5101	Sinatra's Pok&euml;mann figurine: Moog	0		Experience (Moxie): +5, Single Equip, Last Available: "2011-05"
 5102	flattened narrow willyweed	0		Effect: "Cold, Dead Hands", Effect Duration: 40, Last Available: "2011-05"
-5103	ionized lime green upside-down Nuclear Blastball	0		Effect: "Rad-ish", Effect Duration: 53, Last Available: "2011-05"
+5103	ionized upside-down lime green Nuclear Blastball	0		Effect: "Rad-ish", Effect Duration: 53, Last Available: "2011-05"
 5104	frozen jittery fish juice box	0		Effect: "Violent Night", Effect Duration: 40, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	bouncing hideous egg	0		Last Available: "2011-05"
-5107	lousy high-proof Jeppson's Malort	8	decent	Last Available: "2011-06"
+5107	high-proof lousy Jeppson's Malort	8	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	mirror stress ball of the detective	0		Item Drop: +20, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5021,8 +5021,8 @@
 5118	upside-down bird brain	0		
 5119	wobbly busted wings	0		
 5120	skewed Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	nasty chilly Admiral's hat of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +5, Stench Damage: +5, Last Available: "2011-05", Familiar Effect: "atk"
-5122	electrified brainy aviator's cap of the brute	0		Mysticality: +5, Muscle Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	nasty chilly Admiral's hat of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +5, Stench Damage: +5, Familiar Effect: "atk", Last Available: "2011-05"
+5122	electrified brainy aviator's cap of the brute	0		Mysticality: +5, Muscle Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	ribald mirrored aviator shades of mayonnaise	0		Sleaze Damage: +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	yellow Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5033,7 +5033,7 @@
 5130	wobbly Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	liquefied triple-wet lime green Ultrasoldier Serum	0		Effect: "Mystically Oiled", Effect Duration: 28, Last Available: "2011-06"
 5132	normal blinking elven hardtack	3	good	Last Available: "2011-06"
-5133	artisanal watered-down purple tumbling elven squeeze	2	EPIC	Last Available: "2011-06"
+5133	watered-down artisanal tumbling purple elven squeeze	2	EPIC	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	blinking E.M.U. joystick	0		Last Available: "2011-06"
 5136	twirling E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5047,12 +5047,12 @@
 5144	handful of honey	0		
 5145	activated tarnished energized honeypot	0		Effect: "Super Skill", Effect Duration: 43
 5146	decent wild honey pie	3	good	
-5147	watered-down tolerable maroon skewed honey mead	2	good	
+5147	tolerable watered-down skewed maroon honey mead	2	good	
 5148	arcane researcher's honey dipper of the empath of incineration	0		Experience Percent (Mysticality): +10, Familiar Weight: +5, Hot Spell Damage: +50
 5149	tumbling family-friendly sizzling honeybritches of the sewer	0		Hot Damage: +10, Stench Damage: +25, Sleaze Resistance: +1, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	fuchsia prompt Lo Pan's energetic honeycap	0		Maximum MP Percent: +20, Spell Critical Percent: +30, Adventures: +3, Familiar Effect: "1xPotato, cap 43"
-5151	Moonthril Circlet of Tarzan	0		Experience (Muscle): +3, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	stylish Moonthril Greaves	0		Moxie: +25, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	Moonthril Circlet of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	stylish Moonthril Greaves	0		Moxie: +25, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	Moonthril Flamberge of the brute	0		Muscle Percent: +30, Last Available: "2011-06"
 5154	teal rock-hard Moonthril Longbow	0		Damage Reduction: 5, Last Available: "2011-06"
 5155	avaricious Moonthril Cuirass	0		Meat Drop: +30, Softcore Only, Last Available: "2011-06"
@@ -5077,9 +5077,9 @@
 5174	bad tumbling Saison du Lune	3	decent	Last Available: "2011-06"
 5175	bad Moonthril Schnapps	3	decent	Last Available: "2011-06"
 5176	tolerable Wrecked Generator	3	good	Last Available: "2011-06"
-5177	gigantic bland Spaghetti with Moonballs	9	decent	Last Available: "2011-06"
-5178	special moldy squat Crepes a la Lune	3	crappy	Effect: "Turtle Titters", Effect Duration: 25, Last Available: "2011-06"
-5179	normal jumbo Moon Pie	5	good	Last Available: "2011-06"
+5177	bland gigantic Spaghetti with Moonballs	9	decent	Last Available: "2011-06"
+5178	moldy special squat Crepes a la Lune	3	crappy	Effect: "Turtle Titters", Effect Duration: 25, Last Available: "2011-06"
+5179	jumbo normal Moon Pie	5	good	Last Available: "2011-06"
 5180	boiled Comet Pop	0		Effect: "Berry Statistical", Effect Duration: 60, Last Available: "2011-06"
 5181	warmed purple Flan in the Moon	0		Effect: "You Can Taste the Darkness", Effect Duration: 21, Last Available: "2011-06"
 5182	triple-colloidal cyan 1/6th Pound Cake	0		Effect: "Kissed By Fire", Effect Duration: 26, Last Available: "2011-06"
@@ -5094,27 +5094,27 @@
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	cold-filtered corrupted data	0		Effect: "Magically Delicious", Effect Duration: 21, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
-5194	huge squat exorcised sandwich	0		
+5194	squat huge exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	supercharged Great S-Cape	0		Maximum MP Percent: +30, Softcore Only, Last Available: "2011-07"
 5197	Marvelous Unitard of the brazier	0		Hot Spell Damage: +25, Softcore Only, Last Available: "2011-07"
 5198	compressed spinning gooey paste	1	decent	Effect: "Cautious Prowl", Effect Duration: 5, Last Available: "2011-08"
 5199	dried spinning beastly paste	1	good	Last Available: "2011-08"
-5200	dried upside-down red wobbly paste	1	good	Last Available: "2011-08"
+5200	dried red wobbly upside-down paste	1	good	Last Available: "2011-08"
 5201	powdered cyan ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	dried greasy paste	1	crappy	Last Available: "2011-08"
 5203	dried ghostly narrow bug paste	1	decent	Effect: "Cranberry Cordiality", Effect Duration: 50, Last Available: "2011-08"
 5204	distilled ghostly hippy paste	1	EPIC	Last Available: "2011-08"
 5205	denatured lime green orc paste	1	crappy	Effect: "Amorous Avarice", Effect Duration: 35, Last Available: "2011-08"
 5206	boiled squat demonic paste	1	EPIC	Last Available: "2011-08"
-5207	modified tumbling maroon indescribably horrible paste	1	good	Last Available: "2011-08"
+5207	modified maroon tumbling indescribably horrible paste	1	good	Last Available: "2011-08"
 5208	mixed paste	1	crappy	Effect: "On the Trolley", Effect Duration: 30, Last Available: "2011-08"
 5209	compressed pulsating goblin paste	1	decent	Effect: "Wings of the Grasshopper", Effect Duration: 20, Last Available: "2011-08"
 5210	denatured shaking blurry pirate paste	1	good	Last Available: "2011-08"
 5211	powdered spinning chlorophyll paste	1	decent	Last Available: "2011-08"
 5212	boiled upside-down paste	1	EPIC	Last Available: "2011-08"
 5213	powdered mirror Mer-kin paste	1	good	Effect: "Dreadful Sheen", Effect Duration: 15, Last Available: "2011-08"
-5214	dried ghostly twirling slimy paste	1	decent	Last Available: "2011-08"
+5214	dried twirling ghostly slimy paste	1	decent	Last Available: "2011-08"
 5215	dried blinking penguin paste	1	crappy	Last Available: "2011-08"
 5216	modified elemental paste	1	good	Last Available: "2011-08"
 5217	modified tumbling cosmic paste	1	good	Last Available: "2011-08"
@@ -5123,12 +5123,12 @@
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	stale purple Ur-Donut	4	decent	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	narrow box of Familiar Jacks	0		Last Available: "2011-09"
 5227	drinkable bucket of wine	4	good	Last Available: "2011-09"
-5228	flavorless immense enchanted tumbling ultrafondue	9	decent	Effect: "Healthy Bronze Glow", Effect Duration: 30, Last Available: "2011-09"
+5228	flavorless enchanted immense tumbling ultrafondue	9	decent	Effect: "Healthy Bronze Glow", Effect Duration: 30, Last Available: "2011-09"
 5229	spinning unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	bouncing crystal skull	0		Last Available: "2011-09"
@@ -5139,23 +5139,23 @@
 5236	tumbling lard-coated frosty halo	0		Sleaze Spell Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of the cheetah	0		Initiative: +60, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	perfectly mixed Lumineux Limnio	3	EPIC	Last Available: "2011-09"
-5239	watered-down hand-crafted Morto Moreto	2	EPIC	Last Available: "2011-09"
-5240	weak mediocre fuchsia Temps Tempranillo	2	decent	Last Available: "2011-09"
-5241	lousy weak Bordeaux Marteaux	2	decent	Last Available: "2011-09"
-5242	strong artisanal Fromage Pinotage	5	EPIC	Last Available: "2011-09"
-5243	aged practically non-alcoholic Beignet Milgranet	1	awesome	Last Available: "2011-09"
+5239	hand-crafted watered-down Morto Moreto	2	EPIC	Last Available: "2011-09"
+5240	mediocre weak fuchsia Temps Tempranillo	2	decent	Last Available: "2011-09"
+5241	weak lousy Bordeaux Marteaux	2	decent	Last Available: "2011-09"
+5242	artisanal strong Fromage Pinotage	5	EPIC	Last Available: "2011-09"
+5243	practically non-alcoholic aged Beignet Milgranet	1	awesome	Last Available: "2011-09"
 5244	drinkable Muschat	3	good	Last Available: "2011-09"
-5245	immense rotten cool jelly donut	9	crappy	Last Available: "2011-09"
+5245	rotten immense cool jelly donut	9	crappy	Last Available: "2011-09"
 5246	huge flavorless blinking shrapnel jelly donut	6	decent	Last Available: "2011-09"
 5247	adequate occult jelly donut	4	good	Last Available: "2011-09"
 5248	stale wobbly thyme jelly donut	4	decent	Last Available: "2011-09"
 5249	bland danish	4	decent	Last Available: "2011-09"
 5250	bland big smashed danish	5	decent	Last Available: "2011-09"
-5251	moldy enchanted forbidden danish	4	crappy	Effect: "Memory of Strength", Effect Duration: 20, Last Available: "2011-09"
+5251	enchanted moldy forbidden danish	4	crappy	Effect: "Memory of Strength", Effect Duration: 20, Last Available: "2011-09"
 5252	miniature decent cool cat claw	2	good	Last Available: "2011-09"
 5253	tasty blunt cat claw	3	awesome	Last Available: "2011-09"
-5254	normal snack-sized skewed shadowy cat claw	2	good	Last Available: "2011-09"
-5255	special toothsome cheezburger	3	awesome	Effect: "Cock of the Walk", Effect Duration: 10, Last Available: "2011-09"
+5254	snack-sized normal skewed shadowy cat claw	2	good	Last Available: "2011-09"
+5255	toothsome special cheezburger	3	awesome	Effect: "Cock of the Walk", Effect Duration: 10, Last Available: "2011-09"
 5256	adequate toasted brie	3	good	Last Available: "2011-09"
 5257	concentrated super-colloidal potion of the field gar	0		Effect: "Frosty the Hitman", Effect Duration: 38, Last Available: "2011-09"
 5258	concentrated too legit potion	0		Effect: "Ichorous Eyesight", Effect Duration: 54, Last Available: "2011-09"
@@ -5184,10 +5184,10 @@
 5281	purple broken clock of the storm	0		Maximum MP Percent: +40, Last Available: "2011-09"
 5282	dethklok of terror	0		Spooky Spell Damage: +10, Last Available: "2011-09"
 5283	glacial clock of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	olive d6	0		Last Available: "2011-09"
-5287	green blinking d8	0		Last Available: "2011-09"
+5287	blinking green d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
 5289	d12	0		Last Available: "2011-09"
 5290	d20	0		Last Available: "2011-09"
@@ -5222,27 +5222,27 @@
 5319	double-modified non-ionized blinking Blood 'n' Plenty	0		Effect: "Memory of Strength", Effect Duration: 18, Last Available: "2011-10"
 5320	enhanced vacuum-sealed Lobos Mints	0		Effect: "The Rich Get Richer", Effect Duration: 12, Last Available: "2011-10"
 5321	Vulcanized quantum teal Sweet Sword	0		Effect: "Fudge Headache", Effect Duration: 22, Last Available: "2011-10"
-5322	aged weak Ecto-Cooler	2	awesome	Last Available: "2011-10"
+5322	weak aged Ecto-Cooler	2	awesome	Last Available: "2011-10"
 5323	smooth Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
-5324	smooth spirit-forward Blood Light	5	awesome	Last Available: "2011-10"
-5325	fancy spirit-forward perfectly mixed jittery Silver Bullet beer	5	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 15, Last Available: "2011-10"
-5326	practically non-alcoholic mediocre spinning Bone's Farm &quot;wine&quot;	1	decent	Last Available: "2011-10"
+5324	spirit-forward smooth Blood Light	5	awesome	Last Available: "2011-10"
+5325	fancy perfectly mixed spirit-forward jittery Silver Bullet beer	5	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 15, Last Available: "2011-10"
+5326	mediocre practically non-alcoholic spinning Bone's Farm &quot;wine&quot;	1	decent	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
-5328	boiled ionized mirror cyan sorority brain	0		Effect: "Radium Radicality", Effect Duration: 45, Last Available: "2011-10"
+5328	boiled ionized cyan mirror sorority brain	0		Effect: "Radium Radicality", Effect Duration: 45, Last Available: "2011-10"
 5329	polymerized aerosolized shaking Nightstalker perfume	0		Effect: "Steroid Boost", Effect Duration: 45, Last Available: "2011-10"
 5330	extra-warmed lime green drum of pomade	0		Effect: "Trivia Master", Effect Duration: 60, Last Available: "2011-10"
 5331	wobbly throwing bone	0		Last Available: "2011-10"
 5332	vibrating extra-see-thru nightie	0		Maximum MP Percent: +10, Last Available: "2011-10"
-5333	scorching chaotic BRAINS shorts	0		Spell Critical Percent: +10, Hot Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	scorching chaotic BRAINS shorts	0		Spell Critical Percent: +10, Hot Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	zippy Mesmereyes&trade; contact lenses	0		Initiative: +20, Single Equip, Last Available: "2011-10"
 5335	blurry scrunchie of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2011-10"
-5336	upside-down wholesome extremely skinny jeans of Flo-Jo	0		Maximum HP Percent: +10, Initiative: +100, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	electrified experienced The Necbromancer's Hat	0		Experience: +2, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	upside-down wholesome extremely skinny jeans of Flo-Jo	0		Maximum HP Percent: +10, Initiative: +100, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	electrified experienced The Necbromancer's Hat	0		Experience: +2, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	greedy nasty sizzling The Necbromancer's Stein	0		Hot Damage: +10, Stench Damage: +5, Meat Drop: +20, Last Available: "2011-10"
-5339	electrified wizardly The Necbromancer's Shorts of the cheetah	0		Mysticality: +25, Initiative: +60, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	electrified wizardly The Necbromancer's Shorts of the cheetah	0		Mysticality: +25, Initiative: +60, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	tumbling fireproof energetic weightlifter's The Necbromancer's Wizard Staff	0		Muscle: +15, Maximum MP Percent: +20, Hot Resistance: +3, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	bad enchanted triple-distilled The Cooler Out of Space	6	decent	Effect: "Buttermilk Boogie", Effect Duration: 5, Last Available: "2011-10"
+5342	enchanted bad triple-distilled The Cooler Out of Space	6	decent	Effect: "Buttermilk Boogie", Effect Duration: 5, Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	super-adjusted Vulcanized jittery Necbro wafers	0		Effect: "Inappropriate Spirit", Effect Duration: 35, Last Available: "2020-09"
@@ -5306,19 +5306,19 @@
 5403	wobbly Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	squat Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	wobbly horrifying extremely unsafe cane-mail shirt of the detective	0		Weapon Damage Percent: +100, Spooky Damage: +25, Item Drop: +20, Last Available: "2011-12"
-5406	executive Sinatra's cane-mail pants of the businessman	0		Experience (Moxie): +5, Meat Drop: 90, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	executive Sinatra's cane-mail pants of the businessman	0		Experience (Moxie): +5, Meat Drop: 90, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	hand-crafted fortified Vodka Matryoshka	5	EPIC	Last Available: "2011-12"
 5408	bad Gin Mint	4	decent	Last Available: "2011-12"
 5409	watered-down hand-crafted Tequiz Navidad	2	EPIC	Last Available: "2011-12"
-5410	watered-down tolerable Mint Yulep	2	good	Last Available: "2011-12"
+5410	tolerable watered-down Mint Yulep	2	good	Last Available: "2011-12"
 5411	artisanal Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	mediocre Sangria de Menthe	4	decent	Last Available: "2011-12"
 5413	tumbling green candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
-5415	oxidized bouncing ghostly licorice root	0		Effect: "Memory of Attractiveness", Effect Duration: 41, Last Available: "2011-12"
+5415	oxidized ghostly bouncing licorice root	0		Effect: "Memory of Attractiveness", Effect Duration: 41, Last Available: "2011-12"
 5416	quantum quadruple-aerosolized banana supersucker	0		Effect: "Stimulated Body", Effect Duration: 68, Last Available: "2011-11"
 5417	tarnished polarized narrow pear supersucker	0		Effect: "Spookyravin'", Effect Duration: 51, Last Available: "2011-11"
-5418	boiled upside-down mirror lime supersucker	0		Effect: "Paging Betty", Effect Duration: 12, Last Available: "2011-11"
+5418	boiled mirror upside-down lime supersucker	0		Effect: "Paging Betty", Effect Duration: 12, Last Available: "2011-11"
 5419	energized frozen yellow wobbly kumquat supersucker	0		Effect: "Spirit of Alph", Effect Duration: 56, Last Available: "2011-11"
 5420	alkaline diffused super-dry strawberry supersucker	0		Effect: "Fire Inside", Effect Duration: 25, Last Available: "2011-11"
 5421	skewed wool bananarama bangle	0		Cold Resistance: +1, Single Equip, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	huge Sherlock's kumquartz ring	0		Item Drop: +25, Single Equip, Last Available: "2011-11"
 5425	skewed Sinatra's strawberyl necklace	0		Experience (Moxie): +5, Single Equip, Last Available: "2011-11"
 5426	jittery purple stanky groovy sucker bucket	0		Moxie Percent: +10, Stench Spell Damage: +25, Last Available: "2011-11"
-5427	lime green wool sucker hakama	0		Cold Resistance: +1, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	sucker kabuto of the businessman	0		Meat Drop: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	lime green wool sucker hakama	0		Cold Resistance: +1, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	sucker kabuto of the businessman	0		Meat Drop: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	blinking crafty sucker tachi	0		Maximum MP: +10, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	blinking cinnamon troll doll	0		Last Available: "2011-11"
@@ -5337,7 +5337,7 @@
 5434	DNOTC Box	0		Last Available: "2017-12"
 5435	wobbly fudgecule	0		Last Available: "2011-11"
 5436	warmed fudge lily	0		Effect: "Third Based", Effect Duration: 50, Last Available: "2011-11"
-5437	squat blue superheated fudge	0		Last Available: "2011-11"
+5437	blue squat superheated fudge	0		Last Available: "2011-11"
 5438	quadruple-moist narrow fluid of fudge-finding	0		Effect: "Medieval Mage Mayhem", Effect Duration: 62, Last Available: "2011-11"
 5439	shaking fudgepuck	0		Last Available: "2011-11"
 5440	delicious narrow fudgesicle	3	awesome	Last Available: "2011-11"
@@ -5354,7 +5354,7 @@
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
-5454	skewed lime green gummi ingot	0		Last Available: "2011-11"
+5454	lime green skewed gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	extra-colloidal squat Fudgie Roll	0		Effect: "Meat the Flintstones", Effect Duration: 19, Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	jittery friendly therapeutic razor-sharp fudgecycle	0		Weapon Damage Percent: +25, Familiar Weight: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	spinning blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	dry polymerized nitrogenated lime green resolution: be wealthier	0		Effect: "Gemini Rising", Effect Duration: 38, Last Available: "2012-01"
 5465	altered resolution: be happier	0		Effect: "Buggy Flavor", Effect Duration: 60, Last Available: "2012-01"
 5466	oxidized boiled maroon resolution: be stronger	0		Effect: "Sleazy Hands", Effect Duration: 12, Last Available: "2012-01"
@@ -5379,11 +5379,11 @@
 5476	unsweetened polarized maroon skewed gummi salamander	0		Effect: "Tingling Feeling", Effect Duration: 68, Last Available: "2011-11"
 5477	oxidized polarized ghostly gummi snake	0		Effect: "On the Shoulders of Giants", Effect Duration: 19, Last Available: "2011-11"
 5478	boiled super-aerosolized gummi canary	0		Effect: "The Rich Get Richer", Effect Duration: 27, Last Available: "2011-11"
-5479	snack-sized normal gummi bear	2	good	Last Available: "2011-11"
-5480	bland thick blinking gummi bear	5	decent	Last Available: "2011-11"
+5479	normal snack-sized gummi bear	2	good	Last Available: "2011-11"
+5480	thick bland blinking gummi bear	5	decent	Last Available: "2011-11"
 5481	flavorless gummi bear	3	decent	Last Available: "2011-11"
 5482	moldy skewed ghostly drunki-bear	3	crappy	Last Available: "2011-11"
-5483	super-sized tasty huge drunki-bear	5	awesome	Last Available: "2011-11"
+5483	tasty super-sized huge drunki-bear	5	awesome	Last Available: "2011-11"
 5484	flavorless skewed drunki-bear	3	decent	Last Available: "2011-11"
 5485	mansplainer's gummi bowtie	0		Monster Level: +15, Last Available: "2011-11"
 5486	tumbling olive arcane researcher's fudge pocket square	0		Experience Percent (Mysticality): +10, Last Available: "2011-11"
@@ -5391,7 +5391,7 @@
 5488	huge trilobite fossil	0		Last Available: "2011-11"
 5489	wobbly ammonite fossil	0		Last Available: "2011-11"
 5490	belemnite fossil	0		Last Available: "2011-11"
-5491	blue twirling twirling trilobite candy mold	0		Last Available: "2011-11"
+5491	twirling twirling blue trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	altered triple-concentrated ghostly gummi trilobite	0		Effect: "Human-Hippy Hybrid", Effect Duration: 17, Last Available: "2011-11"
@@ -5399,17 +5399,17 @@
 5496	quadruple-dry corrupted gummi belemnite	0		Effect: "Surreally Buff", Effect Duration: 34, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	pulsating green sizzling personal trainer's Big Candy's tophat	0		Experience Percent (Muscle): +10, Hot Damage: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	pulsating green sizzling personal trainer's Big Candy's tophat	0		Experience Percent (Muscle): +10, Hot Damage: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
-5502	narrow cyan Trivial Avocations board game	0		Last Available: "2011-11"
+5502	cyan narrow Trivial Avocations board game	0		Last Available: "2011-11"
 5503	purple Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	fuchsia jittery blessed box	0		
-5505	twirling huge pack of pogs	0		Last Available: "2011-11"
-5506	flavorless bite-sized jerky coins	1	decent	Last Available: "2011-11"
-5507	acceptable fuchsia jittery Go-Wassail	3	good	Last Available: "2011-11"
+5505	huge twirling pack of pogs	0		Last Available: "2011-11"
+5506	bite-sized flavorless jerky coins	1	decent	Last Available: "2011-11"
+5507	acceptable jittery fuchsia Go-Wassail	3	good	Last Available: "2011-11"
 5508	electrified spinning Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Fireproof Lips", Effect Duration: 40, Last Available: "2011-11"
-5509	vacuum-sealed magnetized ghostly blinking bottle of bubbles	0		Effect: "Ooh, Salty!", Effect Duration: 52, Last Available: "2011-11"
+5509	vacuum-sealed magnetized blinking ghostly bottle of bubbles	0		Effect: "Ooh, Salty!", Effect Duration: 52, Last Available: "2011-11"
 5510	liquefied extra-oxidized extra-enhanced wind-up meatcar	0		Effect: "X-Ray Vision", Effect Duration: 46, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
@@ -5420,21 +5420,21 @@
 5517	spinning pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
-5520	mirror ghostly pog #06 (filthy hippy)	0		Last Available: "2011-11"
+5520	ghostly mirror pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	red pog #08 (hellion)	0		Last Available: "2011-11"
-5523	huge spinning fuchsia pog #09 (pirate)	0		Last Available: "2011-11"
+5523	fuchsia huge spinning pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
 5525	bouncing pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	activated polarized pulsating Atomic Pop	0		Effect: "Ghost Finger", Effect Duration: 27, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
 5529	bland berries of suffering	3	decent	Last Available: "2012-12"
-5530	colloidal squat lime green baobab sap	0		Effect: "Riboflavin'", Effect Duration: 22, Last Available: "2012-12"
+5530	colloidal lime green squat baobab sap	0		Effect: "Riboflavin'", Effect Duration: 22, Last Available: "2012-12"
 5531	upside-down cup of hickory chicory	0		Last Available: "2012-12"
 5532	bouncing magnolia blossom	0		Last Available: "2012-12"
 5533	triple-polarized spinning Mortimer's nostrum	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 13, Last Available: "2012-12"
-5534	watered-down drinkable Barulio's bottle	2	good	Last Available: "2012-12"
+5534	drinkable watered-down Barulio's bottle	2	good	Last Available: "2012-12"
 5535	wet Marvin's marvelous pill	0		Effect: "The Moxious Madrigal", Effect Duration: 15, Last Available: "2012-12"
 5536	pulsating olive Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5459,13 +5459,13 @@
 5556	skewed squat greedy Rain-Doh wings of the boozehound	0		Meat Drop: +20, Booze Drop: +100, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	blinking Jack Frost's Rain-Doh laser gun of Flo-Jo	0		Cold Spell Damage: +50, Initiative: +100, Softcore Only, Last Available: "2012-02"
-5559	Rain-Doh lantern of the scaredy-cat of the early riser	0		Monster Level: -15, Adventures: +7, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	Rain-Doh lantern of the scaredy-cat of the early riser	0		Monster Level: -15, Adventures: +7, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	hardened Rain-Doh violet bo of the overflowing toilet	0		Damage Reduction: 3, Stench Spell Damage: +50, Softcore Only, Last Available: "2012-02"
 5563	blinking Rain-Doh box	0		Last Available: "2012-02"
 5564	blurry Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	small adequate teal jittery PB&BP	2	good	
+5565	adequate small teal jittery PB&BP	2	good	
 5566	stale tumbling club sandwich	4	decent	
 5567	yummy bouncing corned-beef Reuben	4	awesome	
 5568	frayed ninja rope	0		
@@ -5478,9 +5478,9 @@
 5575	tolerable practically non-alcoholic Shot of the Living Dead	1	good	Last Available: "2012-03"
 5576	artisanal irresponsibly strong twirling squat Buttery Knob	8	EPIC	Last Available: "2012-03"
 5577	watered-down drinkable mirror Slippery Knob	2	good	Last Available: "2012-03"
-5578	practically non-alcoholic bad squat Flaming Knob	1	decent	Last Available: "2012-03"
+5578	bad practically non-alcoholic squat Flaming Knob	1	decent	Last Available: "2012-03"
 5579	practically non-alcoholic lousy jittery Grasshopper	1	decent	Last Available: "2012-03"
-5580	weak smooth Locust	2	awesome	Last Available: "2012-03"
+5580	smooth weak Locust	2	awesome	Last Available: "2012-03"
 5581	hand-crafted Plague of Locusts	4	EPIC	Last Available: "2012-03"
 5582	drinkable weak Red Dwarf	2	good	Last Available: "2012-03"
 5583	artisanal blurry Golden Mean	3	EPIC	Last Available: "2012-03"
@@ -5488,25 +5488,25 @@
 5585	watered-down acceptable Aye Aye	2	good	Last Available: "2012-03"
 5586	drinkable Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	perfectly mixed Aye Aye, Tooth Tooth	4	EPIC	Last Available: "2012-03"
-5588	boozy drinkable Humanitini	5	good	Last Available: "2012-03"
+5588	drinkable boozy Humanitini	5	good	Last Available: "2012-03"
 5589	irresponsibly strong drinkable More Humanitini than Humanitini	7	good	Last Available: "2012-03"
-5590	tolerable enchanted spinning pulsating Oh, the Humanitini	3	good	Effect: "Filled with Magic", Effect Duration: 45, Last Available: "2012-03"
-5591	tolerable high-proof fuchsia ghostly Great Older Fashioned	7	good	Last Available: "2012-03"
-5592	perfectly mixed weak Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5590	enchanted tolerable spinning pulsating Oh, the Humanitini	3	good	Effect: "Filled with Magic", Effect Duration: 45, Last Available: "2012-03"
+5591	high-proof tolerable fuchsia ghostly Great Older Fashioned	7	good	Last Available: "2012-03"
+5592	weak perfectly mixed Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	boozy tolerable Crazymaker	5	good	Last Available: "2012-03"
 5594	artisanal weak Zoodriver	2	EPIC	Last Available: "2012-03"
-5595	fancy aged Sloe Comfortable Zoo	3	awesome	Effect: "Spring Training", Effect Duration: 5, Last Available: "2012-03"
-5596	acceptable weak Sloe Comfortable Zoo on Fire	2	good	Last Available: "2012-03"
+5595	aged fancy Sloe Comfortable Zoo	3	awesome	Effect: "Spring Training", Effect Duration: 5, Last Available: "2012-03"
+5596	weak acceptable Sloe Comfortable Zoo on Fire	2	good	Last Available: "2012-03"
 5597	aged Suffering Sinner	4	awesome	Last Available: "2012-03"
 5598	aged Suppurating Sinner	3	awesome	Last Available: "2012-03"
 5599	special mediocre watered-down gray Sizzling Sinner	2	decent	Effect: "Sugar High", Effect Duration: 30, Last Available: "2012-03"
-5600	artisanal fancy weak Firewater	2	EPIC	Effect: "You Know Where to Go", Effect Duration: 5, Last Available: "2012-03"
-5601	acceptable irresponsibly strong Earth and Firewater	6	good	Last Available: "2012-03"
-5602	smooth watered-down Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
-5603	hand-crafted teal huge Slimosa	4	EPIC	Last Available: "2012-03"
+5600	fancy artisanal weak Firewater	2	EPIC	Effect: "You Know Where to Go", Effect Duration: 5, Last Available: "2012-03"
+5601	irresponsibly strong acceptable Earth and Firewater	6	good	Last Available: "2012-03"
+5602	watered-down smooth Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
+5603	hand-crafted huge teal Slimosa	4	EPIC	Last Available: "2012-03"
 5604	acceptable distilled Extra-slimy Slimosa	5	good	Last Available: "2012-03"
 5605	lousy Slimebite	4	decent	Last Available: "2012-03"
-5606	triple-distilled artisanal Cement Mixer	6	EPIC	Last Available: "2012-03"
+5606	artisanal triple-distilled Cement Mixer	6	EPIC	Last Available: "2012-03"
 5607	perfectly mixed boozy upside-down Jackhammer	5	EPIC	Last Available: "2012-03"
 5608	acceptable Dump Truck	4	good	Last Available: "2012-03"
 5609	aged Fauna Libre	3	awesome	Last Available: "2012-03"
@@ -5520,13 +5520,13 @@
 5617	lousy Green Burlap	3	decent	Last Available: "2012-03"
 5618	weak bad Mohobo	2	decent	Last Available: "2012-03"
 5619	hand-crafted Moonshine Mohobo	4	EPIC	Last Available: "2012-03"
-5620	acceptable spirit-forward Flaming Mohobo	5	good	Last Available: "2012-03"
+5620	spirit-forward acceptable Flaming Mohobo	5	good	Last Available: "2012-03"
 5621	hand-crafted wobbly Drunken Philosopher	3	EPIC	Last Available: "2012-03"
-5622	watered-down enchanted acceptable Drunken Neurologist	2	good	Effect: "Fruited", Effect Duration: 40, Last Available: "2012-03"
-5623	delicious narrow cyan Drunken Astrophysicist	4	awesome	Last Available: "2012-03"
+5622	acceptable watered-down enchanted Drunken Neurologist	2	good	Effect: "Fruited", Effect Duration: 40, Last Available: "2012-03"
+5623	delicious cyan narrow Drunken Astrophysicist	4	awesome	Last Available: "2012-03"
 5624	artisanal Dark & Starry	3	EPIC	Last Available: "2012-03"
 5625	bad mirror Black Hole	3	decent	Last Available: "2012-03"
-5626	practically non-alcoholic perfectly mixed Event Horizon	1	super ultra EPIC	Last Available: "2012-03"
+5626	perfectly mixed practically non-alcoholic Event Horizon	1	super ultra EPIC	Last Available: "2012-03"
 5627	acceptable Herring Daiquiri	4	good	Last Available: "2012-03"
 5628	bad shaking Herring Wallbanger	3	decent	Last Available: "2012-03"
 5629	perfectly mixed Herringtini	4	EPIC	Last Available: "2012-03"
@@ -5534,8 +5534,8 @@
 5631	smooth Candy Alexander	4	awesome	Last Available: "2012-03"
 5632	hand-crafted Candicaine	3	EPIC	Last Available: "2012-03"
 5633	delicious weak Caipiranha	2	awesome	Last Available: "2012-03"
-5634	watered-down artisanal Flying Caipiranha	2	EPIC	Last Available: "2012-03"
-5635	drinkable distilled Flaming Caipiranha	5	good	Last Available: "2012-03"
+5634	artisanal watered-down Flying Caipiranha	2	EPIC	Last Available: "2012-03"
+5635	distilled drinkable Flaming Caipiranha	5	good	Last Available: "2012-03"
 5636	bad watered-down Punchplanter	2	decent	Last Available: "2012-03"
 5637	aged watered-down Doublepunchplanter	2	awesome	Last Available: "2012-03"
 5638	perfectly mixed twirling Haymaker	3	EPIC	Last Available: "2012-03"
@@ -5548,9 +5548,9 @@
 5645	tumbling wobbly the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	frosty calendar	0		Cold Spell Damage: +10, Damage Reduction: 4
-5648	mansplainer's steel-toed Boris's Helm	0		Damage Reduction: 9, Monster Level: +15, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	mansplainer's steel-toed Boris's Helm	0		Damage Reduction: 9, Monster Level: +15, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	manspreader's staph of homophones of the cougar	0		Moxie: +20, Monster Level: +10
-5650	blurry knitted flame-wreathed Boris's Helm (askew) of temperance	0		Hot Spell Damage: +10, Cold Resistance: +3, Sleaze Resistance: +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	blurry knitted flame-wreathed Boris's Helm (askew) of temperance	0		Hot Spell Damage: +10, Cold Resistance: +3, Sleaze Resistance: +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	ghostly Monster Manuel	0		Free Pull
 5653	bouncing spinning key-o-tron	0		
@@ -5564,7 +5564,7 @@
 5661	ribald hairshirt	0		Sleaze Damage: +10
 5662	Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	microwave	0		Free Pull
-5664	spinning green upside-down pony keg	0		Free Pull
+5664	upside-down spinning green pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	cyan How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
@@ -5577,11 +5577,11 @@
 5674	&quot;L&quot;	0		
 5675	powdered watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	rock-hard Ze&trade; goggles	0		Damage Reduction: 5, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	rock-hard Ze&trade; goggles	0		Damage Reduction: 5, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	spinning soggy used band-aid	0		Last Available: "2012-05"
-5679	narrow crafty stylish swimsuit of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	narrow crafty stylish swimsuit of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
-5681	flavorless jumbo P.B.L.T.	5	decent	
+5681	jumbo flavorless P.B.L.T.	5	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	jittery BURT	0		
 5684	handful of juicy garbage	0		
@@ -5605,11 +5605,11 @@
 5702	squat mannequin	0		Familiar Weight: +5
 5703	teal crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	wholesome sage wax hat	0		Mysticality Percent: +10, Maximum HP Percent: +10, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	fuchsia smartaleck's wax pants of Calamity Jane	0		Moxie Percent: +30, Critical Hit Percent: +15, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	wholesome sage wax hat	0		Mysticality Percent: +10, Maximum HP Percent: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	fuchsia smartaleck's wax pants of Calamity Jane	0		Moxie Percent: +30, Critical Hit Percent: +15, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	enhanced dry drop of water-37	0		Effect: "Guts Feeling", Effect Duration: 21, Last Available: "2012-07"
-5709	wobbly Temple Grandin's fireman's helmet of the brute	0		Muscle Percent: +30, Familiar Weight: +7, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	wobbly Temple Grandin's fireman's helmet of the brute	0		Muscle Percent: +30, Familiar Weight: +7, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	yellow brawny fire axe	0		Muscle Percent: +20, Last Available: "2012-07"
 5713	knitted fire extinguisher of the blizzard of the overflowing toilet	0		Cold Spell Damage: +25, Stench Spell Damage: +50, Cold Resistance: +3, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,17 +5618,17 @@
 5717	bland miniature FDKOL hotcakes	2	decent	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	flavorless immense fiery wing	6	decent	Last Available: "2012-07"
+5720	immense flavorless fiery wing	6	decent	Last Available: "2012-07"
 5721	bouncing pulsating rosy-cheeked experienced wings of fire	0		Experience: +2, Maximum HP Percent: +30, Last Available: "2012-07"
 5722	huge upside-down prompt FDKOL fire hose	0		Adventures: +3, Last Available: "2012-07"
 5723	magnetized huge bottle of fire	0		Effect: "Takin' It Greasy", Effect Duration: 16, Last Available: "2012-07"
-5724	huge cyan molten brick	0		Last Available: "2012-07"
+5724	cyan huge molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	ribald Da Vinci's hot daub bun	0		Experience (Mysticality): +5, Sleaze Damage: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	baleful educational hot daub stand	0		Experience: +1, Spell Damage: +25, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	ribald Da Vinci's hot daub bun	0		Experience (Mysticality): +5, Sleaze Damage: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	baleful educational hot daub stand	0		Experience: +1, Spell Damage: +25, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	rosewater-soaked stiffened foot-long hot daub	0		Damage Reduction: 1, Stench Resistance: +3, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	tasty diet angst burger	1	awesome	
+5730	diet tasty angst burger	1	awesome	
 5731	spirit-forward drinkable 5-hour acrimony	5	good	
 5732	blank note	0		
 5733	green eerily silent box	0		
@@ -5639,7 +5639,7 @@
 5738	jittery toasty Camp Scout backpack	0		Hot Damage: +5, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	spoiled bag of GORP	4	crappy	Last Available: "2012-07"
-5741	practically non-alcoholic bad water purification pills	1	decent	Last Available: "2012-07"
+5741	bad practically non-alcoholic water purification pills	1	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	boozy lousy blue CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
 5744	toothsome jittery bag of GORF	3	awesome	Last Available: "2012-07"
@@ -5650,10 +5650,10 @@
 5749	fortified hand-crafted CSA cheerfulness ration	5	EPIC	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	yummy special crappy brain	4	awesome	Effect: "Enraged", Effect Duration: 40
+5752	special yummy crappy brain	4	awesome	Effect: "Enraged", Effect Duration: 40
 5753	half-sized delicious decent brain	2	awesome	
-5754	normal miniature bouncing good brain	2	good	
-5755	super-sized decent jittery boss brain	5	good	
+5754	miniature normal bouncing good brain	2	good	
+5755	decent super-sized jittery boss brain	5	good	
 5756	tasty hunter brain	3	awesome	
 5758	skewed scandalous vibrating Staff of Holiday Sensations of the brazier	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Sleaze Damage: +5, Last Available: "2011-11"
 5759	wool friendly staff	0		Familiar Weight: +3, Cold Resistance: +1
@@ -5665,16 +5665,16 @@
 5765	studded fuzzy earmuffs of dire peril	0		Weapon Damage: +20, Damage Absorption: +80, Familiar Effect: "1.5xVolley, cap 32"
 5766	smelly careful fuzzy montera of bravery	0		Monster Level: -10, Stench Spell Damage: +10, Spooky Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	mirror Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	upside-down gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	upside-down gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	fuchsia gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	upside-down gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	upside-down gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	fuchsia gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	purple Thwaitgold maggot statuette	0		
 5774	blue talkative skull	0		
 5775	olive fronts	0		Familiar Weight: +5
 5776	pulsating mansplainer's Herculean Barney's rake	0		Experience (Muscle): +1, Monster Level: +15
-5778	snack-sized adequate idiot brain	2	good	
+5778	adequate snack-sized idiot brain	2	good	
 5779	huge mansplainer's keel-haulin' knife	0		Monster Level: +15
 5780	savvy ice cream scoop	0		Mysticality Percent: +20
 5781	acceptable huge soft echo eyedrop antidote martini	3	good	
@@ -5700,7 +5700,7 @@
 5801	quantum nitrogenated Smart Bone Dust	0		Effect: "Man's Worst Enemy", Effect Duration: 59
 5802	adjusted moist polarized bouncing perpendicular guano	0		Effect: "Memory of Smarts", Effect Duration: 21
 5803	super-concentrated gray White Chocolate Golem Seeds	0		Effect: "Engorged Weapon", Effect Duration: 20
-5804	galvanized huge wobbly red Shivering Ch&egrave;vre	0		Effect: "You Know What's Up", Effect Duration: 69
+5804	galvanized wobbly red huge Shivering Ch&egrave;vre	0		Effect: "You Know What's Up", Effect Duration: 69
 5805	enhanced tarnished breath mint	0		Effect: "Squatting and Thrusting", Effect Duration: 17
 5806	frozen skewed muesli	0		Effect: "Swimming with Sharks", Effect Duration: 55
 5807	pressed tarnished narrow glass of warm milk	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 39
@@ -5718,12 +5718,12 @@
 5819	warmed squat gravy fairy warlock hat	0		Effect: "Mucilaginous Mentalism", Effect Duration: 56
 5820	magnetized blue bull blubber	0		Effect: "Electrolit Up", Effect Duration: 68
 5821	magnetized squat frog lip-print	0		Effect: "Ginger Snapped", Effect Duration: 63
-5822	alkaline olive upside-down spinning gazely stare	0		Effect: "Izchak's Blessing", Effect Duration: 37
+5822	alkaline spinning upside-down olive gazely stare	0		Effect: "Izchak's Blessing", Effect Duration: 37
 5823	quadruple-dry purple spinning canopic jar	0		Effect: "Neutered Nostrils", Effect Duration: 22
 5824	tarnished spinning olive clove-flavored lip balm	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 23
 5825	double-corrupted Skullery Maid's Knee	0		Effect: "The Smile of Mr. A.", Effect Duration: 54
 5826	quantum blurry zombie hollandaise	0		Effect: "Well-Lubed", Effect Duration: 65
-5827	wet double-Vulcanized cyan skewed skeletal banana	0		Effect: "Moose Wisdom", Effect Duration: 34
+5827	wet double-Vulcanized skewed cyan skeletal banana	0		Effect: "Moose Wisdom", Effect Duration: 34
 5828	altered oxidized blurry gilt perfume bottle	0		Effect: "Witch Breaded", Effect Duration: 59
 5829	warmed nitrogenated janglin' bones	0		Effect: "Bananas!", Effect Duration: 69
 5830	vacuum-sealed flattened pygmy papers	0		Effect: "Ripping, Dripping", Effect Duration: 36
@@ -5732,11 +5732,11 @@
 5833	wet non-ionized purple wobbly brigand brittle	0		Effect: "Rainbow Bright", Effect Duration: 62
 5834	non-chilled corrupted yellow holistic headache remedy	0		Effect: "Spooky Jellied", Effect Duration: 26
 5835	extra-warmed non-wet scrunchie tourniquet	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 51
-5836	extra-dry fuchsia jittery embezzler's oil	0		Effect: "Colorful Gratitude", Effect Duration: 37
+5836	extra-dry jittery fuchsia embezzler's oil	0		Effect: "Colorful Gratitude", Effect Duration: 37
 5837	diffused quantum tumbling Fu Manchu Wax	0		Effect: "Morninja", Effect Duration: 40
 5838	liquefied denatured blurry Iiti Kitty Gumdrop	0		Effect: "Adorable Lookout", Effect Duration: 55
 5839	liquefied Vulcanized blue ravenous eye	0		Effect: "Powder Power", Effect Duration: 63
-5840	alkaline wobbly twirling Rogue Windmill Rouge	0		Effect: "Analog Drunk", Effect Duration: 11
+5840	alkaline twirling wobbly Rogue Windmill Rouge	0		Effect: "Analog Drunk", Effect Duration: 11
 5841	polymerized A muse-bouche	0		Effect: "Less Pervious", Effect Duration: 58
 5842	irradiated toothbrush	0		Effect: "Spiky Frozen Hair", Effect Duration: 56
 5843	tarnished quadruple-irradiated pirate cream pie	0		Effect: "Takin' It Greasy", Effect Duration: 59
@@ -5745,7 +5745,7 @@
 5846	moist polarized salt water taffy	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 56
 5847	nitrogenated flattened unholy water	0		Effect: "Slimy Flavor", Effect Duration: 14
 5848	unsweetened triple-dry pulsating Bangyomaman battle juice	0		Effect: "Towering Strength", Effect Duration: 21
-5849	anodized pulsating upside-down handyman &quot;hand soap&quot;	0		Effect: "Castaway Physique", Effect Duration: 31
+5849	anodized upside-down pulsating handyman &quot;hand soap&quot;	0		Effect: "Castaway Physique", Effect Duration: 31
 5850	flattened energized space marine flash grenade	0		Effect: "Less Pervious", Effect Duration: 55
 5851	energized spinning fuchsia temporary tribal tattoo	0		Effect: "Eagle Eyes", Effect Duration: 16
 5852	denatured oil-filled donut	0		Effect: "Supafly", Effect Duration: 48
@@ -5758,7 +5758,7 @@
 5859	denatured mirror booby trap	0		Effect: "Got Your Boots On", Effect Duration: 39
 5860	non-galvanized mirror Agent Corrigan's cigarette	0		Effect: "Slimily Speedy", Effect Duration: 24
 5861	warmed cold-filtered good ash	0		Effect: "Gamer Rage", Effect Duration: 18
-5862	upside-down Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	upside-down Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	oxidized electrified electrified jittery olive papier-mochi	0		Effect: "The Rich Get Richer", Effect Duration: 55, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	nasty Temple Grandin's papier-m&acirc;ch&eacute;te	0		Familiar Weight: +7, Stench Damage: +5, Last Available: "2012-09"
 5869	spinning jittery Jack Frost's fortified papier-m&acirc;chine gun	0		Damage Absorption: +60, Cold Spell Damage: +50, Last Available: "2012-09"
 5870	extremely unsafe smartaleck's papier-masque	0		Moxie Percent: +30, Weapon Damage Percent: +100, Single Equip, Last Available: "2012-09"
-5871	chaotic clever papier-mitre	0		Maximum MP: +20, Spell Critical Percent: +10, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	narrow Jeselnik's papier-m&acirc;churidars of Gandalf	0		Spell Critical Percent: +20, Sleaze Damage: +25, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	chaotic clever papier-mitre	0		Maximum MP: +20, Spell Critical Percent: +10, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	narrow Jeselnik's papier-m&acirc;churidars of Gandalf	0		Spell Critical Percent: +20, Sleaze Damage: +25, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	blurry papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	twirling skeleton	0		Last Available: "2012-10"
 5882	purple foul-smelling skeleton skis of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Stench Damage: +10, Initiative: +60, Single Equip, Last Available: "2012-10"
-5883	jumbo tasty skeleton quiche	5	awesome	Last Available: "2012-10"
+5883	tasty jumbo skeleton quiche	5	awesome	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	squat skeletal skiff	0		Last Available: "2012-10"
 5886	squat zippy Temple Grandin's Bonestabber of the brute	0		Muscle Percent: +30, Familiar Weight: +7, Item Drop: +5, Initiative: +20, Last Available: "2012-10"
@@ -5787,12 +5787,12 @@
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	Samson's auxiliary backbone	0		Experience (Muscle): +5, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
-5891	wobbly squat ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
+5891	squat wobbly ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	corrupted electrified lime green that gum you like	0		Effect: "Vitamin-Maxed", Effect Duration: 31
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	blurry Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	fuchsia avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
-5896	skewed ghostly canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
+5896	ghostly skewed canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	modified Unconscious Collective Dream Jar	1	awesome	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	bouncing ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	yellow BittyCar HotCar	0		Last Available: "2012-12"
-5928	slick brainwave-controlled unicorn horn	0		Moxie: +10, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	slick brainwave-controlled unicorn horn	0		Moxie: +10, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	wobbly bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	chilly brawny plastic four-shadowed mime of mayonnaise	0		Muscle Percent: +20, Cold Damage: +5, Sleaze Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	plastic Father McGruber of the dark arts	0		Spell Damage Percent: +100, Last Available: "2012-12"
 5961	yellow shaking censurious plastic Hank North, Photojournalist	0		Sleaze Resistance: +3, Last Available: "2012-12"
 5962	censurious plastic blazing bat	0		Sleaze Resistance: +3, Last Available: "2012-12"
-5963	stanky stiffened electronic dulcimer pants	0		Damage Reduction: 1, Stench Spell Damage: +25, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	stanky stiffened electronic dulcimer pants	0		Damage Reduction: 1, Stench Spell Damage: +25, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	cyan A-Boo clue	0		
 5965	sinister Newton's Frown Exerciser	0		Experience (Mysticality): +3, Spell Damage: +10, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5873,35 +5873,35 @@
 5975	spinning record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	frosty rosy-cheeked dangerous silent beret	0		Weapon Damage: +10, Maximum HP Percent: +30, Cold Spell Damage: +10, Familiar Effect: "1xVolley, cap 3"
-5978	moldy snack-sized spinning shaking slice of pizza	2	crappy	Last Available: "2013-02"
+5978	snack-sized moldy shaking spinning slice of pizza	2	crappy	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	perfectly mixed tankard of ale	3	EPIC	Last Available: "2013-02"
 5983	spinning vial of holy water	0		Last Available: "2013-02"
-5984	huge tumbling rosewater-soaked Jack Frost's Temple Grandin's cloth cap	0		Familiar Weight: +7, Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	huge tumbling rosewater-soaked Jack Frost's Temple Grandin's cloth cap	0		Familiar Weight: +7, Cold Spell Damage: +50, Stench Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	hardened iron dagger of the bloodbag of Gandalf	0		Damage Reduction: 3, Maximum HP: +100, Spell Critical Percent: +20, Last Available: "2013-02"
-5986	adequate thick pulsating hamburger	5	good	Last Available: "2013-02"
+5986	thick adequate pulsating hamburger	5	good	Last Available: "2013-02"
 5987	wobbly dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	purple potion	0		Last Available: "2013-02"
 5990	bad bottle of wine	3	decent	Last Available: "2013-02"
 5991	squat round bomb	0		Last Available: "2013-02"
-5992	gray lion tamer's coward's hale iron helmet	0		Maximum HP: +20, Monster Level: -20, Experience (familiar): +2, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	gray lion tamer's coward's hale iron helmet	0		Maximum HP: +20, Monster Level: -20, Experience (familiar): +2, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	lightning-fast steel sword of the bloodbag of horror	0		Maximum HP: +100, Spooky Spell Damage: +25, Initiative: +40, Last Available: "2013-02"
-5994	snack-sized stale spinning whole roasted chicken	2	decent	Last Available: "2013-02"
+5994	stale snack-sized spinning whole roasted chicken	2	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	artisanal watered-down blinking shining goblet	2	super EPIC	Last Available: "2013-02"
+5998	watered-down artisanal blinking shining goblet	2	super EPIC	Last Available: "2013-02"
 5999	blinking fireball	0		Last Available: "2013-02"
-6000	squat prompt careful padded crown	0		Damage Absorption: +20, Monster Level: -10, Adventures: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	squat prompt careful padded crown	0		Damage Absorption: +20, Monster Level: -10, Adventures: +3, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	lightning-fast vibrating rock-hard sword	0		Damage Reduction: 5, Maximum MP Percent: +10, Initiative: +40, Last Available: "2013-02"
-6002	shellacked grievous savvy Helm of the Scream Emperor	0		Mysticality Percent: +20, Weapon Damage Percent: +50, Damage Reduction: 7, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	shellacked grievous savvy Helm of the Scream Emperor	0		Mysticality Percent: +20, Weapon Damage Percent: +50, Damage Reduction: 7, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	toasty nippy dog trainer's Cloak of Dire Shadows	0		Experience (familiar): +1, Cold Damage: +10, Hot Damage: +5, Last Available: "2013-02"
 6004	narrow Newton's Sword of Dark Omens of courage of the businessman	0		Experience (Mysticality): +3, Spooky Resistance: +3, Meat Drop: +50, Last Available: "2013-02"
 6005	executive Sherlock's fortified Shield of Icy Fate	0		Damage Absorption: +60, Item Drop: +25, Meat Drop: +40, Damage Reduction: 7, Last Available: "2013-02"
-6006	wobbly Usain Bolt's extremely unsafe Greaves of the Murk Lord of horror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +25, Initiative: +80, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	wobbly Usain Bolt's extremely unsafe Greaves of the Murk Lord of horror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +25, Initiative: +80, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	olive blinking Van der Graaf educational Gauntlets of the Blood Moon of the blizzard	0		Experience: +1, Cold Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-02"
 6008	ghostly teal Usain Bolt's thinker's Boots of Twilight Whispers of Leguizamo	0		Mysticality: +10, Monster Level: +20, Initiative: +80, Single Equip, Last Available: "2013-02"
 6009	spinning forbidden Sinatra's Belt of Howling Anger of Gandalf	0		Experience (Moxie): +5, Spell Damage Percent: +50, Spell Critical Percent: +20, Single Equip, Last Available: "2013-02"
@@ -5917,7 +5917,7 @@
 6019	squat narrow Rosewater's loadstone	0		Mysticality Percent: +30
 6020	Tesla Claybender glasses of the pedagogue	0		Experience: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 6021	tumbling flame-retardant Duskwalker fangs of incineration	0		Hot Spell Damage: +50, Hot Resistance: +1
-6022	squat olive Space Tourist Phaser	0		
+6022	olive squat Space Tourist Phaser	0		
 6023	Da Vinci's brawny Whoompa Fur Pants	0		Muscle Percent: +20, Experience (Mysticality): +5, Familiar Effect: "atk, cap 27"
 6024	Whatsian Ionic Pliers of the sewer	0		Stench Damage: +25
 6025	frozen mirror Polysniff Perfume	0		Effect: "Hare-o-dynamic", Effect Duration: 43
@@ -5931,9 +5931,9 @@
 6033	sizzling beefy stolen necklace	0		Muscle: +10, Hot Damage: +10
 6034	lime green knitted savvy troll britches	0		Mysticality Percent: +20, Cold Resistance: +3, Familiar Effect: "1.5xPotato, cap 28"
 6035	anodized oxidized vial of The Glistening	0		Effect: "Stogied", Effect Duration: 61
-6036	tolerable triple-distilled artisanal limoncello	8	good	
+6036	triple-distilled tolerable artisanal limoncello	8	good	
 6037	ghostly pulsating ginger ale	0		
-6038	decent diet blinking huge incredible pizza	1	good	
+6038	diet decent blinking huge incredible pizza	1	good	
 6039	huge shellacked dance instructor's oil cap	0		Experience Percent (Moxie): +10, Damage Reduction: 7, Familiar Effect: "cap 28"
 6040	wobbly greasy oil lamp of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10
 6041	Jack Frost's oil slacks	0		Cold Spell Damage: +50, Familiar Effect: "1xPotato, cap 30"
@@ -5941,13 +5941,13 @@
 6043	boid	0		
 6044	woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	yellow narrow BittyCar SoulCar	0		Last Available: "2012-12"
+6046	narrow yellow BittyCar SoulCar	0		Last Available: "2012-12"
 6047	manspreader's Misty Cloak of Gandalf	0		Spell Critical Percent: +20, Monster Level: +10
 6048	nippy cool Misty Robe	0		Moxie: +5, Cold Damage: +10
 6049	steel-toed Misty Cape of the brazier of the sweet-tooth	0		Damage Reduction: 9, Hot Spell Damage: +25, Candy Drop: +100
 6050	bouncing woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	small rotten blurry red Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
+6052	rotten small red blurry Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
 6053	fancy acceptable gray Taco Dan's Taco Stand Chimichangarita	3	good	Effect: "Carol of the Bones", Effect Duration: 10, Last Available: "2012-12"
 6054	enhanced chilled huge Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Capricorn Rising", Effect Duration: 45, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
@@ -5966,12 +5966,12 @@
 6068	loose blade	0		
 6069	upside-down goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	frozen haggis-infused soap	0		Effect: "Crimbo Flavor", Effect Duration: 22, Last Available: "2012-12"
 6074	dry super-warmed vacuum-sealed olive magicberry tablets	0		Effect: "Feline Ferocity", Effect Duration: 38, Last Available: "2012-12"
 6075	magnetized 37x37x37 puzzle cube	0		Effect: "Hella Tough", Effect Duration: 39, Last Available: "2012-12"
-6076	delicious special McLeod's Hard Haggis-Ade	4	awesome	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2012-12"
+6076	special delicious McLeod's Hard Haggis-Ade	4	awesome	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2012-12"
 6077	adequate skewed haggis-wrapped haggis-stuffed haggis	4	good	Last Available: "2012-12"
 6078	ghostly home robotics kit	0		Last Available: "2012-12"
 6079	blinking school calculator watch	0		Last Available: "2012-12"
@@ -5999,7 +5999,7 @@
 6101	homemade robot	0		Last Available: "2012-12"
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
-6104	spinning green Artist's Butterknife of Regret	0		Last Available: "2013-12"
+6104	green spinning Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	Artist's Spatula of Despair	0		Last Available: "2013-12"
 6106	wobbly narrow Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
@@ -6016,7 +6016,7 @@
 6118	upside-down tumbling goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	hand-crafted distilled Chinese beer	5	EPIC	Last Available: "2013-12"
+6121	distilled hand-crafted Chinese beer	5	EPIC	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	narrow rhinoceros horn	0		Last Available: "2013-12"
 6124	blurry furry pink pillow	0		Last Available: "2013-12"
@@ -6033,14 +6033,14 @@
 6135	tube of herbal ointment	0		Last Available: "2013-12"
 6136	pencil kunai	0		Last Available: "2013-12"
 6137	ghostly Usain Bolt's weighted paperclip chain	0		Initiative: +80, Last Available: "2013-12"
-6138	blurry maroon great capacitor	0		Last Available: "2013-12"
+6138	maroon blurry great capacitor	0		Last Available: "2013-12"
 6139	pulsating rubber gloves of bravery	0		Spooky Resistance: +5, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	toothsome roasted duck	4	awesome	Last Available: "2013-12"
 6143	stale teal dead meat bun	4	decent	Last Available: "2013-12"
 6144	purple twirling ribald cat collar	0		Sleaze Damage: +10, Single Equip, Last Available: "2013-12"
-6145	stiffened smartaleck's suspicious-looking fedora	0		Moxie Percent: +30, Damage Reduction: 1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	stiffened smartaleck's suspicious-looking fedora	0		Moxie Percent: +30, Damage Reduction: 1, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	pulsating Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	cyan MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,8 +6058,8 @@
 6161	tumbling grievous regret hose	0		Weapon Damage Percent: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	tumbling Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	spinning Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	shaking lime green commodore's hat of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	supercool naval trousers	0		Moxie Percent: +20, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	shaking lime green commodore's hat of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	supercool naval trousers	0		Moxie Percent: +20, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	upside-down resourceful Fonzie's deck cannon	0		Experience (Moxie): +1, Maximum MP: +50, Last Available: "2013-12"
 6167	squat brawny ornamental sextant	0		Muscle Percent: +20, Last Available: "2013-12"
 6168	frosty sage Bloodbath	0		Mysticality Percent: +10, Cold Spell Damage: +10, Last Available: "2013-12"
@@ -6077,10 +6077,10 @@
 6180	blurry cosmic potted meat product	0		
 6181	cosmic potato	0		
 6182	cosmic cream	0		
-6183	shaking twirling cosmic fruit	0		
+6183	twirling shaking cosmic fruit	0		
 6184	Tesla wizardly Jarlsberg's hat of the early riser	0		Mysticality: +25, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10
-6185	small adequate consummate hard-boiled egg	2	good	
-6186	decent gigantic consummate fried egg	10	good	
+6185	adequate small consummate hard-boiled egg	2	good	
+6186	gigantic decent consummate fried egg	10	good	
 6187	adequate gigantic bouncing consummate egg salad	8	good	
 6188	bland consummate bagel	4	decent	
 6189	small rotten consummate sliced bread	2	crappy	
@@ -6089,37 +6089,37 @@
 6192	adequate narrow consummate toast	3	good	
 6193	perfectly mixed passable stout	3	EPIC	
 6194	spoiled consummate soup	3	crappy	
-6195	moldy tiny twirling consummate corn chips	1	crappy	
+6195	tiny moldy twirling consummate corn chips	1	crappy	
 6196	flavorless pulsating consummate salad	3	decent	
-6197	big adequate lime green consummate salsa	5	good	
+6197	adequate big lime green consummate salsa	5	good	
 6198	bland huge consummate sauerkraut	3	decent	
 6199	miniature spoiled bouncing consummate cheese slice	2	crappy	
 6200	delicious consummate melted cheese	4	awesome	
-6201	half-sized normal mirror consummate bacon	2	good	
-6202	super-sized rotten consummate meatloaf	5	crappy	
-6203	miniature normal consummate steak	2	good	
+6201	normal half-sized mirror consummate bacon	2	good	
+6202	rotten super-sized consummate meatloaf	5	crappy	
+6203	normal miniature consummate steak	2	good	
 6204	spoiled consummate cuts	3	crappy	
-6205	immense flavorless consummate frankfurter	6	decent	
+6205	flavorless immense consummate frankfurter	6	decent	
 6206	moldy snack-sized skewed consummate french fries	2	crappy	
 6207	bland snack-sized blurry wobbly consummate baked potato	2	decent	
 6208	enchanted mediocre teal acceptable vodka	4	decent	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 30
-6209	moldy immense consummate ice cream	8	crappy	
+6209	immense moldy consummate ice cream	8	crappy	
 6210	decent mirror consummate whipped cream	3	good	
 6211	decent pulsating consummate cream	3	good	
-6212	moldy bite-sized spinning consummate strawberries	1	crappy	
+6212	bite-sized moldy spinning consummate strawberries	1	crappy	
 6213	normal spinning consummate sorbet	4	good	
 6214	artisanal adequate rum	3	EPIC	
-6215	fancy tolerable high-proof shaking mediocre lager	10	good	Effect: "Comic Violence", Effect Duration: 40
-6216	spoiled thick purple immaculate grilled cheese	5	crappy	
+6215	high-proof tolerable fancy shaking mediocre lager	10	good	Effect: "Comic Violence", Effect Duration: 40
+6216	thick spoiled purple immaculate grilled cheese	5	crappy	
 6217	decent spinning immaculate ice cream sandwich	4	good	
 6218	spoiled immaculate hot dog	4	crappy	
 6219	decent immaculate egg salad sandwich	4	good	
-6220	low-calorie flavorless lime green narrow perfect sandwich	1	decent	
-6221	adequate jumbo perfect chef salad	5	good	
+6220	low-calorie flavorless narrow lime green perfect sandwich	1	decent	
+6221	jumbo adequate perfect chef salad	5	good	
 6222	special stale perfect breakfast	3	decent	Effect: "Elemental Saucesphere", Effect Duration: 30
-6223	thick spoiled spinning sublime deluxe hot dog	5	crappy	
-6224	fancy tasty super-sized squat sublime stew	5	awesome	Effect: "Sweet Tooth", Effect Duration: 10
-6225	moldy massive shaking sublime nachos	9	crappy	
+6223	spoiled thick spinning sublime deluxe hot dog	5	crappy	
+6224	fancy super-sized tasty squat sublime stew	5	awesome	Effect: "Sweet Tooth", Effect Duration: 10
+6225	massive moldy shaking sublime nachos	9	crappy	
 6226	flavorless fuchsia Ultimate Breakfast Sandwich	4	decent	
 6227	normal Loaded Baked Potato	4	good	
 6228	spoiled ghostly Omega Sundae	3	crappy	
@@ -6167,7 +6167,7 @@
 6271	blue massive dumbbell	0		
 6272	penguin keychain of Leguizamo of the boozehound	0		Monster Level: +20, Booze Drop: +100, Damage Reduction: 10
 6273	warmed cold-filtered O'RLY manual	0		Effect: "Good Motivator", Effect Duration: 54
-6274	weak smooth open sauce	2	awesome	
+6274	smooth weak open sauce	2	awesome	
 6275	yellow Herculean turkey leg of the sweet-tooth	0		Experience (Muscle): +1, Candy Drop: +100
 6276	mediocre practically non-alcoholic special Ye Olde Meade	1	decent	Effect: "Coming Up Roses", Effect Duration: 30
 6277	tarnished enhanced diffused Ye Olde Bawdy Limerick	0		Effect: "Wet and Greedy", Effect Duration: 45
@@ -6236,9 +6236,9 @@
 6340	blurry sharpshooter's boxer's floral-print skirt	0		Muscle Percent: +10, Critical Hit Percent: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	Jack Frost's spectral axe of Leguizamo	0		Monster Level: +20, Cold Spell Damage: +50
 6342	green pulsating stiffened personal trainer's super-strong air freshener	0		Experience Percent (Muscle): +10, Damage Reduction: 1
-6343	deionized improved bouncing huge Mer-kin lipstick	0		Effect: "Good Karma", Effect Duration: 28
+6343	deionized improved huge bouncing Mer-kin lipstick	0		Effect: "Good Karma", Effect Duration: 28
 6344	Mer-kin mouthsoap	0		
-6345	quadruple-flattened magnetized blurry maroon Mer-kin strongjuice	0		Effect: "meat.enh", Effect Duration: 36
+6345	quadruple-flattened magnetized maroon blurry Mer-kin strongjuice	0		Effect: "meat.enh", Effect Duration: 36
 6346	skewed skewed Mer-kin fitbrine	0		
 6347	colloidal blurry Mer-kin ragejuice	0		Effect: "Angry like the Wolf", Effect Duration: 21
 6348	blinking Mer-kin dragbelt of the pedagogue	0		Experience: +3, Experience (Muscle): +20, Single Equip
@@ -6247,26 +6247,26 @@
 6351	narrow MacGyver's Mer-kin finpaddle	0		Maximum MP: +100
 6352	fireproof Mer-kin stopwatch	0		Hot Resistance: +3, Initiative: +50
 6353	spinning Mer-kin dreadscroll	0		
-6354	flattened pressed maroon narrow Mer-kin smartjuice	0		Effect: "Prideful Strut", Effect Duration: 55
+6354	flattened pressed narrow maroon Mer-kin smartjuice	0		Effect: "Prideful Strut", Effect Duration: 55
 6355	deionized corrupted Mer-kin cooljuice	0		Effect: "Steroid Boost", Effect Duration: 13
 6356	shaking Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	horrifying Mer-kin begsign	0		Spooky Damage: +25, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
-6361	pickled flattened ionized ghostly cyan pulled taffy	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34, Last Available: "2013-04"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6361	pickled flattened ionized cyan ghostly pulled taffy	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34, Last Available: "2013-04"
 6362	double-polarized pulled indigo taffy	0		Effect: "Fancy Feasted", Effect Duration: 52, Last Available: "2013-04"
 6363	extra-improved tumbling pulled taffy	0		Effect: "Red-Shirted Escort", Effect Duration: 43, Last Available: "2013-04"
 6364	vacuum-sealed cold-filtered narrow pulled taffy	0		Effect: "The Halls of Muscularity", Effect Duration: 65, Last Available: "2013-04"
 6365	enhanced magnetized pulled taffy	0		Effect: "Whippin' It Good", Effect Duration: 17, Last Available: "2013-04"
 6366	altered non-colloidal ghostly pulled violet taffy	0		Effect: "Object Detection", Effect Duration: 28, Last Available: "2013-04"
 6367	liquefied double-ionized pulled taffy	0		Effect: "Dreadful Sheen", Effect Duration: 65, Last Available: "2013-04"
-6368	mirror huge Mer-kin hallpass	0		
+6368	huge mirror Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	hand-crafted pulsating can of the cheapest beer	3	EPIC	
 6372	perfectly mixed bottle of fruity &quot;wine&quot;	3	EPIC	
-6373	artisanal weak single swig of vodka	2	EPIC	
+6373	weak artisanal single swig of vodka	2	EPIC	
 6374	tumbling angry inch	0		
 6375	huge curative testy toolbox	0		HP Regen Min: 3, HP Regen Max: 5
 6376	Jick-o-User	0		
@@ -6298,7 +6298,7 @@
 6403	unsweetened squat jittery grisly shell fragment	0		Effect: "Like a Fish to Walter", Effect Duration: 14
 6404	polymerized polarized lime green violent pastilles	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 58
 6405	energized worst candy	0		Effect: "Hyperoffended", Effect Duration: 26
-6406	cold-filtered jittery green upside-down fudge-shaped hole in space-time	0		Effect: "Al Dente Inferno", Effect Duration: 59
+6406	cold-filtered green upside-down jittery fudge-shaped hole in space-time	0		Effect: "Al Dente Inferno", Effect Duration: 59
 6407	maroon horrifying quilted educational Pocket Square of Loathing	0		Experience: +1, Damage Absorption: +40, Spooky Damage: +25, Single Equip
 6408	corrupted stardust	0		
 6409	ghostly Star Spawn	0		
@@ -6308,7 +6308,7 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	stale miniature teal flavorless gruel	2	decent	
-6416	flavorless massive mana curds	8	decent	
+6416	massive flavorless mana curds	8	decent	
 6417	twist of lime	0		
 6418	skewed tumbling pencil stub	0		
 6419	irradiated ionized bouncing moth dust	0		Effect: "Egg-stra Arm", Effect Duration: 63
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	yellow dreadful roast	0		
 6487	stinking agaricus	0		
-6488	spoiled tiny Dreadsylvanian shepherd's pie	1	crappy	
+6488	tiny spoiled Dreadsylvanian shepherd's pie	1	crappy	
 6489	ghostly music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	gray tailfeathers	0		Familiar Weight: +5
@@ -6429,7 +6429,7 @@
 6534	remorseless knife of Gandalf	0		Spell Critical Percent: +20
 6535	wobbly intimidating coiffure of the empath	0		Familiar Weight: +5, Familiar Effect: "hot afk, 1xPotato"
 6536	blurry coward's resourceful cod cape	0		Maximum MP: +50, Monster Level: -20
-6537	rotten massive blurry blood sausage	6	crappy	
+6537	massive rotten blurry blood sausage	6	crappy	
 6538	rosewater-soaked greasy frying brainpan	0		Sleaze Spell Damage: +10, Stench Resistance: +3
 6539	toasty Annie Oakley's ball and chain	0		Critical Hit Percent: +20, Hot Damage: +5, Single Equip
 6540	dry bone of the brazier	0		Hot Spell Damage: +25
@@ -6458,8 +6458,8 @@
 6564	big toothsome Dreadsylvanian hot pocket	5	awesome	
 6565	bland Dreadsylvanian pocket	3	decent	
 6566	stale Dreadsylvanian pocket	3	decent	
-6567	enchanted decent snack-sized Dreadsylvanian stink pocket	2	good	Effect: "Ice Packed", Effect Duration: 40
-6568	small yummy Dreadsylvanian sleaze pocket	2	awesome	
+6567	snack-sized decent enchanted Dreadsylvanian stink pocket	2	good	Effect: "Ice Packed", Effect Duration: 40
+6568	yummy small Dreadsylvanian sleaze pocket	2	awesome	
 6569	smooth Dreadsylvanian hot toddy	3	awesome	
 6570	lousy Dreadsylvanian cold-fashioned	3	decent	
 6571	aged practically non-alcoholic Dreadsylvanian grimlet	1	awesome	
@@ -6504,7 +6504,7 @@
 6610	clockwork numeral X	0		
 6611	narrow clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
-6613	narrow lime green clockwork cuckoo	0		
+6613	lime green narrow clockwork cuckoo	0		
 6614	maroon cuckoo clock	0		
 6615	watered-down mediocre Cold One	2	???	
 6616	decent cyan spaghetti breakfast	3	???	
@@ -6518,7 +6518,7 @@
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	spinning folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
-6627	yellow wobbly folder (D-Team)	0		Last Available: "2013-08"
+6627	wobbly yellow folder (D-Team)	0		Last Available: "2013-08"
 6628	teal folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
@@ -6541,10 +6541,10 @@
 6649	quantum olive Ogres and Oubliettes&trade; module	0		Effect: "Punchy, Murdery", Effect Duration: 28
 6650	Mountain Stream Code Black Alert	0		
 6651	ghostly twisted-up wet towel	0		
-6652	strong artisanal stepmom's booze	5	EPIC	
+6652	artisanal strong stepmom's booze	5	EPIC	
 6653	surgical tape	0		
 6654	wicked band T-shirt	0		Spell Damage: +5
-6655	tolerable ghostly blue fountain 'soda'	3	good	
+6655	tolerable blue ghostly fountain 'soda'	3	good	
 6656	illegal firecracker	0		
 6657	rock-hard padded pickelhaube	0		Damage Absorption: +20, Damage Reduction: 5, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	extra-electrified polarized pulsating hair oil	0		Effect: "Sparkling Consciousness", Effect Duration: 20
@@ -6566,7 +6566,7 @@
 6674	stinkbomb	0		
 6675	dry superwater	0		Effect: "Sourpuss", Effect Duration: 53
 6676	Thwaitgold bookworm statuette	0		
-6677	squat wobbly crude monster sculpture	0		
+6677	wobbly squat crude monster sculpture	0		
 6678	Oprah's Yearbook Club Camera	0		Maximum MP Percent: +50, Conditional Skill (Equipped): "Blinding Flash"
 6679	ruddy machete	0		Maximum HP Percent: +40
 6680	delicious practically non-alcoholic Cursed Punch	1	awesome	
@@ -6584,7 +6584,7 @@
 6692	McClusky file (page 4)	0		
 6693	wobbly McClusky file (page 5)	0		
 6694	boring binder clip	0		
-6695	narrow skewed McClusky file (complete)	0		
+6695	skewed narrow McClusky file (complete)	0		
 6696	bowling ball	0		
 6697	squat moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
@@ -6594,8 +6594,8 @@
 6702	bowler	0		
 6703	shaking imitation White Russian	1	good	
 6704	lard-coated short-handled mop of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +25
-6705	half-sized rotten jittery jungle floor wax	2	crappy	
-6706	twirling cyan squat smirking shrunken head	0		
+6705	rotten half-sized jittery jungle floor wax	2	crappy	
+6706	cyan twirling squat smirking shrunken head	0		
 6707	electrified colorful toad	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 17
 6708	crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
@@ -6645,21 +6645,21 @@
 6753	cluster of hops	0		
 6754	beer bottle	0		
 6755	tumbling beer label	0		
-6756	fuchsia tumbling twirling artisanal homebrew sampler	0		
-6757	acceptable practically non-alcoholic fancy huge can of Br&uuml;talbr&auml;u	1	good	Effect: "Employee of the Month", Effect Duration: 10, Last Available: "2013-09"
+6756	tumbling fuchsia twirling artisanal homebrew sampler	0		
+6757	practically non-alcoholic fancy acceptable huge can of Br&uuml;talbr&auml;u	1	good	Effect: "Employee of the Month", Effect Duration: 10, Last Available: "2013-09"
 6758	mediocre can of Drooling Monk	3	decent	Last Available: "2013-09"
 6759	drinkable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	artisanal enchanted bottle of Old Pugilist	3	EPIC	Effect: "Ruthlessly Efficient", Effect Duration: 35, Last Available: "2013-09"
-6761	fortified drinkable olive bottle of Professor Beer	5	good	Last Available: "2013-09"
+6761	drinkable fortified olive bottle of Professor Beer	5	good	Last Available: "2013-09"
 6762	perfectly mixed blinking bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
 6763	artisanal watered-down bottle of Race Car Red	2	super ultra mega EPIC	Last Available: "2013-09"
-6764	hand-crafted practically non-alcoholic pulsating bottle of Greedy Dog	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6764	practically non-alcoholic hand-crafted pulsating bottle of Greedy Dog	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6765	smooth fortified bottle of Lambada Lambic	5	awesome	Last Available: "2013-09"
 6766	mirror mirror tin beer can	0		
 6767	red narrow artisanal homebrew gift package	0		
 6768	liquid bread	1	awesome	Last Available: "2013-09"
-6769	mansplainer's beefcake's tin tam of Flo-Jo	0		Muscle: +25, Monster Level: +15, Initiative: +100, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
-6770	quantum tumbling cyan tin cup	0		Effect: "A View to Some Meat", Effect Duration: 29, Last Available: "2013-09"
+6769	mansplainer's beefcake's tin tam of Flo-Jo	0		Muscle: +25, Monster Level: +15, Initiative: +100, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6770	quantum cyan tumbling tin cup	0		Effect: "A View to Some Meat", Effect Duration: 29, Last Available: "2013-09"
 6771	mirror purple Lo Pan's rosy-cheeked Rosewater's tin foil	0		Mysticality Percent: +30, Maximum HP Percent: +30, Spell Critical Percent: +30, Last Available: "2013-09"
 6772	lightning-fast foul-smelling dangerous tin drum	0		Weapon Damage: +10, Stench Damage: +10, Initiative: +40, Last Available: "2013-09"
 6773	tin roof (rusted)	0		Last Available: "2013-09"
@@ -6679,7 +6679,7 @@
 6789	boot knife	0		
 6790	broken beer bottle	0		
 6791	sharpened spoon	0		
-6792	purple mirror candy knife	0		
+6792	mirror purple candy knife	0		
 6793	soap knife	0		
 6795	corrupted bouncing disco horoscope (Aquarius)	0		Effect: "The Solution", Effect Duration: 66
 6796	tarnished electrified shaking disco horoscope (Pisces)	0		Effect: "Mushroom Melody", Effect Duration: 58
@@ -6714,7 +6714,7 @@
 6825	crafty alarm accordion	0		Maximum MP: +10, Item Drop: +5, Class: "Accordion Thief", Song Duration: 20
 6826	gravedigger's healthy All-Hallow's Steve's fright wig of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Spooky Damage: +10, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	red rosewater-soaked stanky KoL Con X Treasure Map	0		Stench Spell Damage: +25, Stench Resistance: +3
-6828	weak tolerable cyan discocktail	2	good	
+6828	tolerable weak cyan discocktail	2	good	
 6829	blinking Sherlock's KoL Con X Bingo Card	0		Item Drop: +25
 6830	Temporal Tempera Tube of the pedagogue	0		Experience: +3
 6831	polarized energized pressed shaking purple Tallowcreme Halloween Pumpkin	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 40
@@ -6725,7 +6725,7 @@
 6836	tarnished improved PEEZ dispenser	0		Effect: "Influence of Sphere", Effect Duration: 39
 6837	pressed pressed jittery Swizzler	0		Effect: "Space Cowboy", Effect Duration: 41
 6838	quantum dry narrow Bugbearclaw Donut	0		Effect: "Memory of Attractiveness", Effect Duration: 51
-6839	non-warmed boiled shaking cyan jam	0		Effect: "Deeply Ironic", Effect Duration: 37
+6839	non-warmed boiled cyan shaking jam	0		Effect: "Deeply Ironic", Effect Duration: 37
 6840	activated quadruple-frozen galvanized blue squat Whenchamacallit bar	0		Effect: "Wintry Breath", Effect Duration: 50
 6841	oxidized cold-filtered skewed 8-bit banana	0		Effect: "Pyramid Power", Effect Duration: 37
 6842	galvanized wet maroon vial of blood simple syrup	0		Effect: "Spookypants", Effect Duration: 20
@@ -6746,12 +6746,12 @@
 6857	Cajun accordion of the scaredy-cat	0		Monster Level: -15, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	huge careful quirky accordion	0		Monster Level: -10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	wobbly perfumed strapping Skipper's accordion	0		Muscle: +5, Stench Resistance: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	frightening resourceful Da Vinci's Pantsgiving of James Dean	0		Experience (Mysticality): +5, Experience (Moxie): +3, Maximum MP: +50, Spooky Damage: +5, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	frightening resourceful Da Vinci's Pantsgiving of James Dean	0		Experience (Mysticality): +5, Experience (Moxie): +3, Maximum MP: +50, Spooky Damage: +5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	yummy massive can of sardines	6	awesome	Last Available: "2013-11"
-6862	moldy snack-sized high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
-6863	adequate pulsating blinking pat of butter	3	good	Last Available: "2013-11"
+6862	snack-sized moldy high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
+6863	adequate blinking pulsating pat of butter	3	good	Last Available: "2013-11"
 6864	normal diet dinner roll	1	good	Last Available: "2013-11"
-6865	normal fancy blue mashed potatoes	4	good	Effect: "Disco State of Mind", Effect Duration: 20, Last Available: "2013-11"
+6865	fancy normal blue mashed potatoes	4	good	Effect: "Disco State of Mind", Effect Duration: 20, Last Available: "2013-11"
 6866	stale whole turkey leg	3	decent	Last Available: "2013-11"
 6867	small stale deviled egg	2	decent	Last Available: "2013-11"
 6868	quadruple-liquefied upside-down finger exerciser	0		Effect: "Good Motivator", Effect Duration: 53, Last Available: "2013-11"
@@ -6761,7 +6761,7 @@
 6872	electrified pressed double-energized nail file	0		Effect: "Artificially Sweet", Effect Duration: 44, Last Available: "2013-11"
 6873	anodized blurry candy wrapper	0		Effect: "Devil Inside", Effect Duration: 27, Last Available: "2013-11"
 6874	lime green gym membership card	0		Last Available: "2013-11"
-6875	moist adjusted maroon twirling post-holiday sale coupon	0		Effect: "Grrrrrrreat!", Effect Duration: 48, Last Available: "2013-11"
+6875	moist adjusted twirling maroon post-holiday sale coupon	0		Effect: "Grrrrrrreat!", Effect Duration: 48, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
 6877	fuchsia pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
@@ -6810,29 +6810,29 @@
 6921	stale super-sized warbear feasting bread	5	decent	Last Available: "2013-12"
 6922	stale warbear warrior bread	3	decent	Last Available: "2013-12"
 6923	delicious warbear thermoregulator bread	4	awesome	Last Available: "2013-12"
-6924	tolerable triple-distilled warbear feasting mead	7	good	Last Available: "2013-12"
-6925	artisanal distilled warbear bearserker mead	5	EPIC	Last Available: "2013-12"
+6924	triple-distilled tolerable warbear feasting mead	7	good	Last Available: "2013-12"
+6925	distilled artisanal warbear bearserker mead	5	EPIC	Last Available: "2013-12"
 6926	mediocre warbear blizzard mead	4	decent	Last Available: "2013-12"
 6927	skewed warbear helm fragment	0		Last Available: "2013-12"
-6928	fortified educational supercool warbear plain fedora	0		Moxie Percent: +20, Experience: +1, Damage Absorption: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	blurry Annie Oakley's warbear feathered fedora	0		Critical Hit Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	wool shellacked warbear fedora of the businessman	0		Damage Reduction: 7, Cold Resistance: +1, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	yellow dance instructor's warbear plain helm of the pedagogue of terror	0		Experience: +3, Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	family-friendly warbear spiked helm	0		Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	lime green mirror greedy Van der Graaf Sinatra's warbear electro-spiked helm	0		Experience (Moxie): +5, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	green censurious studded warbear plain ushanka of Flo-Jo	0		Damage Absorption: +80, Sleaze Resistance: +3, Initiative: +100, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	wicked warbear lined ushanka	0		Spell Damage: +5, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	Usain Bolt's flame-retardant Da Vinci's warbear heated ushanka	0		Experience (Mysticality): +5, Hot Resistance: +1, Initiative: +80, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	fortified educational supercool warbear plain fedora	0		Moxie Percent: +20, Experience: +1, Damage Absorption: +60, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	blurry Annie Oakley's warbear feathered fedora	0		Critical Hit Percent: +20, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	wool shellacked warbear fedora of the businessman	0		Damage Reduction: 7, Cold Resistance: +1, Meat Drop: +50, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	yellow dance instructor's warbear plain helm of the pedagogue of terror	0		Experience: +3, Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	family-friendly warbear spiked helm	0		Sleaze Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	lime green mirror greedy Van der Graaf Sinatra's warbear electro-spiked helm	0		Experience (Moxie): +5, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	green censurious studded warbear plain ushanka of Flo-Jo	0		Damage Absorption: +80, Sleaze Resistance: +3, Initiative: +100, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	wicked warbear lined ushanka	0		Spell Damage: +5, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	Usain Bolt's flame-retardant Da Vinci's warbear heated ushanka	0		Experience (Mysticality): +5, Hot Resistance: +1, Initiative: +80, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	blinking warbear trouser fragment	0		Last Available: "2013-12"
-6938	deadly warbear party pants of James Dean of the bloodbag	0		Experience (Moxie): +3, Weapon Damage: +5, Maximum HP: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	wobbly shaking clever warbear ceremonial party pants	0		Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	blurry extremely unsafe warbear high festival pants of dire peril of the boozehound	0		Weapon Damage: +20, Weapon Damage Percent: +100, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	therapeutic forbidden slick warbear battle greaves	0		Moxie: +10, Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	narrow red warbear officer greaves of chilblains	0		Cold Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	twirling asbestos-lined Van der Graaf Sinatra's warbear bearserker greaves	0		Experience (Moxie): +5, Hot Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	executive Oprah's smooth warbear johns	0		Moxie: +15, Maximum MP Percent: +50, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	warbear fleece-lined johns of the sweet-tooth	0		Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	twirling grievous warbear johns of the overflowing toilet of the sweet-tooth	0		Weapon Damage Percent: +50, Stench Spell Damage: +50, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	deadly warbear party pants of James Dean of the bloodbag	0		Experience (Moxie): +3, Weapon Damage: +5, Maximum HP: +100, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	wobbly shaking clever warbear ceremonial party pants	0		Maximum MP: +20, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	blurry extremely unsafe warbear high festival pants of dire peril of the boozehound	0		Weapon Damage: +20, Weapon Damage Percent: +100, Booze Drop: +100, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	therapeutic forbidden slick warbear battle greaves	0		Moxie: +10, Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	narrow red warbear officer greaves of chilblains	0		Cold Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	twirling asbestos-lined Van der Graaf Sinatra's warbear bearserker greaves	0		Experience (Moxie): +5, Hot Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	executive Oprah's smooth warbear johns	0		Moxie: +15, Maximum MP Percent: +50, Meat Drop: +40, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	warbear fleece-lined johns of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	twirling grievous warbear johns of the overflowing toilet of the sweet-tooth	0		Weapon Damage Percent: +50, Stench Spell Damage: +50, Candy Drop: +100, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	green warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	inspector's horrifying manspreader's warbear goggles	0		Monster Level: +10, Spooky Damage: +25, Item Drop: +15, Single Equip, Last Available: "2013-12"
 6949	Temple Grandin's warbear snowblindness goggles	0		Familiar Weight: +7, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	squat toasty Da Vinci's warbear warscarf of Gandalf	0		Experience (Mysticality): +5, Spell Critical Percent: +20, Hot Damage: +5, Single Equip, Last Available: "2013-12"
 6957	jittery gray warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	veiny warbear foil hat	0		Maximum HP: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	veiny warbear foil hat	0		Maximum HP: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	up-at-dawn warbear oil pan of the empath	0		Familiar Weight: +5, Adventures: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	crafty die-cast Don Crimbo of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Last Available: "2013-12"
 7001	stiffened die-cast Uncle Hobo of Flo-Jo	0		Damage Reduction: 1, Initiative: +100, Last Available: "2013-12"
 7002	prompt mansplainer's die-cast Father Crimbo	0		Monster Level: +15, Adventures: +3, Last Available: "2013-12"
-7003	green The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	green The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	deionized Flaskfull of Hollow	0		Effect: "substats.enh", Effect Duration: 55, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
-7006	altered shaking purple handful of Smithereens	1	decent	Last Available: "2013-12"
-7007	decent squat red Every Day is Like This Sundae	3	good	Last Available: "2013-12"
-7008	half-sized stale Miserable Pie	2	decent	Last Available: "2013-12"
+7006	altered purple shaking handful of Smithereens	1	decent	Last Available: "2013-12"
+7007	decent red squat Every Day is Like This Sundae	3	good	Last Available: "2013-12"
+7008	stale half-sized Miserable Pie	2	decent	Last Available: "2013-12"
 7009	half-sized bland This Charming Flan	2	decent	Last Available: "2013-12"
-7010	irresponsibly strong drinkable Irish Coffee, English Heart	6	good	Last Available: "2013-12"
+7010	drinkable irresponsibly strong Irish Coffee, English Heart	6	good	Last Available: "2013-12"
 7011	smooth Strikes Again Bigmouth	4	awesome	Last Available: "2013-12"
-7012	weak bad teal Paint A Vulgar Pitcher	2	decent	Last Available: "2013-12"
+7012	bad weak teal Paint A Vulgar Pitcher	2	decent	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	blurry Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	friendly padded Sheila Take a Crossbow of the brute of the dark arts	0		Muscle Percent: +30, Spell Damage Percent: +100, Damage Absorption: +20, Familiar Weight: +3, Last Available: "2013-12"
 7019	cyan supercharged razor-sharp A Light that Never Goes Out of the dark arts of the blizzard	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Maximum MP Percent: +30, Cold Spell Damage: +25, Last Available: "2013-12"
 7020	upside-down gravedigger's Temple Grandin's Half a Purse of the scaredy-cat of doom	0		Monster Level: -15, Familiar Weight: +7, Spooky Damage: +10, Spooky Spell Damage: +50, Last Available: "2013-12"
-7021	spinning maroon scandalous dangerous Socratic experienced Hairpiece On Fire	0		Experience: +2, Experience (Mysticality): +1, Weapon Damage: +10, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	Jim Carey's Tesla Vicar's Tutu of dire peril of horror	0		Weapon Damage: +20, Monster Level: +25, Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	spinning maroon scandalous dangerous Socratic experienced Hairpiece On Fire	0		Experience: +2, Experience (Mysticality): +1, Weapon Damage: +10, Sleaze Damage: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	Jim Carey's Tesla Vicar's Tutu of dire peril of horror	0		Weapon Damage: +20, Monster Level: +25, Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	squat Lo Pan's sinister Hand in Glove of mayonnaise	0		Spell Damage: +10, Spell Critical Percent: +30, Sleaze Spell Damage: +50, Single Equip, Last Available: "2013-12"
 7024	nasty sizzling dance instructor's Meat Tenderizer is Murder	0		Experience Percent (Moxie): +10, Hot Damage: +10, Stench Damage: +5, Class: "Seal Clubber", Last Available: "2013-12"
 7025	aromatic horrifying slick Ouija Board, Ouija Board	0		Moxie: +10, Spooky Damage: +25, Stench Resistance: +1, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	jittery boxer's wizardly Shakespeare's Sister's Accordion of the ox	0		Muscle: +20, Mysticality: +25, Muscle Percent: +10, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	curative third-hand lantern	0		HP Regen Min: 3, HP Regen Max: 5
 7031	loose purse strings	0		
-7032	decent tiny pickled egg	1	good	
+7032	tiny decent pickled egg	1	good	
 7033	cup of lukewarm tea	1	good	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6929,7 +6929,7 @@
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
-7043	jittery huge warbear sequential gaiety distribution system	0		Last Available: "2013-12"
+7043	huge jittery warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	vacuum-sealed extra-unsweetened irradiated ghostly glass slipper	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 57, Last Available: "2014-12"
 7045	modified spinning antimatter wad	1	awesome	Last Available: "2013-12"
 7046	adjusted nitrogenated warbear superpotion	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 49, Last Available: "2013-12"
@@ -6969,7 +6969,7 @@
 7080	teal ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	snow mobile of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	snow mobile of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	steel-toed ice bucket	0		Damage Reduction: 9, Lasts Until Rollover, Last Available: "2014-01"
 7085	scorching snow shovel of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
 7086	Fonzie's bod-ice of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Experience (Moxie): +1, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	bad narrow En Una Fila Tequila	4	decent	
 7091	gray Skully's hot chocolate	1	good	
-7092	blurry fortified Herculean warbear dress helmet	0		Experience (Muscle): +1, Damage Absorption: +60, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	blurry fortified Herculean warbear dress helmet	0		Experience (Muscle): +1, Damage Absorption: +60, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	shaking slick warbear dress bracers of the wise owl	0		Mysticality: +20, Moxie: +10, Single Equip, Last Available: "2013-12"
-7094	reassuring nasty warbear dress greaves	0		Stench Damage: +5, Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	therapeutic sweatband of Calamity Jane	0		Critical Hit Percent: +15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	blinking huge lightning-fast smooth gym shorts	0		Moxie: +15, Initiative: +40, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	reassuring nasty warbear dress greaves	0		Stench Damage: +5, Spooky Resistance: +1, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	therapeutic sweatband of Calamity Jane	0		Critical Hit Percent: +15, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	blinking huge lightning-fast smooth gym shorts	0		Moxie: +15, Initiative: +40, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	careful dangerous ankleweights	0		Weapon Damage: +10, Monster Level: -10, Single Equip, Last Available: "2014-12"
 7098	chaotic Van der Graaf energetic healthy sweat socks	0		Maximum HP Percent: +20, Maximum MP Percent: +20, Spell Critical Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6994,22 +6994,22 @@
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	distilled bad snakebite	5	decent	Last Available: "2014-12"
 7107	shaking up-at-dawn candy stick of the dark arts	0		Spell Damage Percent: +100, Adventures: +5, Last Available: "2014-12"
-7108	massive flavorless pecan	7	decent	Last Available: "2014-12"
+7108	flavorless massive pecan	7	decent	Last Available: "2014-12"
 7109	rotten super-sized pecan pie	5	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	moldy candy mountain oyster	3	crappy	Last Available: "2014-12"
 7112	artisanal high-proof chocotini	10	EPIC	Last Available: "2014-12"
 7113	chocolate rabbit's foot of the wise owl of dire peril of temperance	0		Mysticality: +20, Weapon Damage: +20, Sleaze Resistance: +5, Last Available: "2014-12"
-7114	gigantic spoiled twirling candy carrot	7	crappy	Last Available: "2014-12"
-7115	huge enchanted adequate cyan ghostly candy carrot cake	9	good	Effect: "Berry Statistical", Effect Duration: 15, Last Available: "2014-12"
+7114	spoiled gigantic twirling candy carrot	7	crappy	Last Available: "2014-12"
+7115	enchanted huge adequate ghostly cyan candy carrot cake	9	good	Effect: "Berry Statistical", Effect Duration: 15, Last Available: "2014-12"
 7116	upside-down family-friendly carrot-on-a-stick of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +1, Last Available: "2014-12"
-7117	bouncing aromatic clever weasel stomping pants	0		Maximum MP: +20, Stench Resistance: +1, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	bouncing aromatic clever weasel stomping pants	0		Maximum MP: +20, Stench Resistance: +1, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	bland mulberry	3	decent	Last Available: "2014-12"
-7119	tolerable strong mulled berry wine	5	good	Last Available: "2014-12"
+7119	strong tolerable mulled berry wine	5	good	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of courage	0		Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	lemon party hat of courage	0		Spooky Resistance: +3, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	studded lemon shirt	0		Damage Absorption: +80, Lasts Until Rollover, Last Available: "2014-12"
-7123	cyan huge crafty lemon drop trousers	0		Maximum MP: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	cyan huge crafty lemon drop trousers	0		Maximum MP: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	non-modified moist lemonhead caviar	0		Effect: "Nothing Is Impossible", Effect Duration: 39, Last Available: "2014-12"
 7125	twirling manspreader's gummi sword of the sewer	0		Monster Level: +10, Stench Damage: +25, Last Available: "2014-12"
 7126	super-chilled polarized non-boiled bouncing small gummi fin	0		Effect: "Cravin' for a Ravin'", Effect Duration: 62, Last Available: "2014-12"
@@ -7021,18 +7021,18 @@
 7132	aerosolized maroon Outer Wolf&trade; cologne	0		Effect: "Deadly Flashing Blade", Effect Duration: 42, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	curative wolf whistle of the cheetah	0		Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	bland huge skewed witch's bread	4	decent	Last Available: "2014-12"
+7135	bland skewed huge witch's bread	4	decent	Last Available: "2014-12"
 7136	polymerized tarnished huge witch's brew	0		Effect: "Arresistible", Effect Duration: 64, Last Available: "2014-12"
 7137	frightening hale sinister witch's bra	0		Spell Damage: +10, Maximum HP: +20, Spooky Damage: +5, Last Available: "2014-12"
 7138	artisanal mid-level medieval mead	4	EPIC	Last Available: "2014-12"
 7139	chilled triple-diffused R&uuml;mpelstiltz	0		Effect: "Pla-see-bo", Effect Duration: 37, Last Available: "2014-12"
 7140	pulsating spinning wheel	0		Last Available: "2014-12"
-7141	chilled magnetized yellow blurry hi-octane carrot juice	0		Effect: "Smokin'", Effect Duration: 25, Last Available: "2014-12"
+7141	chilled magnetized blurry yellow hi-octane carrot juice	0		Effect: "Smokin'", Effect Duration: 25, Last Available: "2014-12"
 7142	tarnished blurry hare brush	0		Effect: "Stenchtastic", Effect Duration: 32, Last Available: "2014-12"
 7143	narrow sizzling supercharged hare pin	0		Maximum MP Percent: +30, Hot Damage: +10, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
 7145	gigantic stale cinnamon cannoli	8	decent	Last Available: "2014-12"
-7146	distilled drinkable expensive champagne	5	good	Last Available: "2014-12"
+7146	drinkable distilled expensive champagne	5	good	Last Available: "2014-12"
 7147	modified polo trophy	0		Effect: "Riboflavin'", Effect Duration: 44, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	teal rosary	0		Last Available: "2014-12"
@@ -7042,20 +7042,20 @@
 7153	clay	0		Last Available: "2014-12"
 7154	olive filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
-7156	shaking wobbly glass	0		Last Available: "2014-12"
-7157	grievous Herculean stylish fire hose	0		Moxie: +25, Experience (Muscle): +1, Weapon Damage Percent: +50, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7156	wobbly shaking glass	0		Last Available: "2014-12"
+7157	grievous Herculean stylish fire hose	0		Moxie: +25, Experience (Muscle): +1, Weapon Damage Percent: +50, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	bite-sized fancy delicious fireman's lunch	1	awesome	Effect: "Liquid Courage", Effect Duration: 20, Last Available: "2014-12"
-7159	knitted scandalous Samson's plain paper hat	0		Experience (Muscle): +5, Sleaze Damage: +5, Cold Resistance: +3, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	knitted scandalous Samson's plain paper hat	0		Experience (Muscle): +5, Sleaze Damage: +5, Cold Resistance: +3, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	stale red ice cream sandwich	3	decent	Last Available: "2014-12"
 7161	zippy slick &quot;honey&quot; dipper of the sweet-tooth	0		Moxie: +10, Candy Drop: +100, Initiative: +20, Last Available: "2014-12"
 7162	small stale plumber's lunch	2	decent	Last Available: "2014-12"
 7163	fortified quilted Newton's skull gearshift knob	0		Experience (Mysticality): +3, Damage Absorption: 100, Last Available: "2014-12"
-7164	big spoiled nachos of the night	5	crappy	Last Available: "2014-12"
+7164	spoiled big nachos of the night	5	crappy	Last Available: "2014-12"
 7165	lard-coated scorching rock-hard Sketcherz&trade;	0		Damage Reduction: 5, Hot Damage: +25, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7166	immense normal can of Adultwitch&trade;	10	good	Last Available: "2014-12"
+7166	normal immense can of Adultwitch&trade;	10	good	Last Available: "2014-12"
 7167	dry dry blue smudge stick	0		Effect: "Riboflavin'", Effect Duration: 59, Last Available: "2014-12"
 7168	quadruple-energized olive wall	0		Effect: "Wise Spirit", Effect Duration: 49, Last Available: "2014-12"
-7169	practically non-alcoholic artisanal tankard of ale	1	EPIC	Last Available: "2014-12"
+7169	artisanal practically non-alcoholic tankard of ale	1	EPIC	Last Available: "2014-12"
 7170	polymerized purple upside-down scroll case	0		Effect: "Stuck-Up Hair", Effect Duration: 64, Last Available: "2014-12"
 7171	concentrated blurry blinking jug of &quot;wine&quot;	0		Effect: "Winklered", Effect Duration: 50, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7071,9 +7071,9 @@
 7182	ghostly The Stankara Stone	0		
 7183	spinning Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
-7185	red pulsating huge Red Zeppelin ticket	0		
+7185	red huge pulsating Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	bad olive shaking unnamed cocktail	3	decent	
+7187	bad shaking olive unnamed cocktail	3	decent	
 7188	handful of tips	0		
 7189	auspicious unrequired jacket	0		Item Drop: +10
 7190	tommy gun of the storm	0		Maximum MP Percent: +40, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7092,7 +7092,7 @@
 7203	Jeselnik's Saturday Night Special	0		Sleaze Damage: +25
 7204	lynyrd snare	0		
 7205	spinning fleetwood chain of Leguizamo	0		Monster Level: +20
-7206	watered-down mediocre shaking Green Manalishi	2	decent	
+7206	mediocre watered-down shaking Green Manalishi	2	decent	
 7207	Rosewater's blade	0		Mysticality Percent: +30
 7208	fire of unknown origin	0		
 7209	purple eagle's milk	1	EPIC	
@@ -7101,7 +7101,7 @@
 7212	squat Jefferson wings of the early riser	0		Adventures: +7
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	half-sized flavorless olive tumbling fleetwood mac 'n' cheese	2	decent	
+7215	flavorless half-sized tumbling olive fleetwood mac 'n' cheese	2	decent	
 7216	green lynyrd skin	0		
 7217	squat Annie Oakley's lynyrdskin cap	0		Critical Hit Percent: +20, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	squat lime green Temple Grandin's lynyrdskin tunic	0		Familiar Weight: +7
@@ -7109,9 +7109,9 @@
 7220	shaking cigarette lighter	0		
 7221	priceless diamond	0		
 7222	tolerable purple Flamin' Whatshisname	3	good	
-7223	corrupted upside-down lime green lynyrd musk	0		Effect: "Slimy Flavor", Effect Duration: 67
+7223	corrupted lime green upside-down lynyrd musk	0		Effect: "Slimy Flavor", Effect Duration: 67
 7224	spinning savvy slick Kashmir sweater	0		Moxie: +10, Mysticality Percent: +20
-7225	tiny bland special custard pie	1	decent	Effect: "Ogred and Oublietted", Effect Duration: 45
+7225	tiny special bland custard pie	1	decent	Effect: "Ogred and Oublietted", Effect Duration: 45
 7226	tea for one	1	EPIC	
 7227	drinkable teal bottle of Evermore	3	good	
 7228	box	0		
@@ -7134,16 +7134,16 @@
 7245	adjusted dry eye	0		Effect: "Stop and Smell the Fudge", Effect Duration: 37
 7246	red glark cable	0		
 7247	chaotic ruddy Red Fox glove	0		Maximum HP Percent: +40, Spell Critical Percent: +10, Attacks Can't Miss, Single Equip
-7248	anodized twirling olive mirror foxglove	0		Effect: "Optimist Primal", Effect Duration: 43
+7248	anodized mirror olive twirling foxglove	0		Effect: "Optimist Primal", Effect Duration: 43
 7249	Thwaitgold dragonfly statuette	0		
 7250	wool veiny sinister Sneaky Pete's jacket of the dark arts	0		Spell Damage: +10, Spell Damage Percent: +100, Maximum HP: +10, Cold Resistance: +1, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	narrow jug of Sneaky Pete's Mojo	0		Free Pull
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	drinkable enchanted ghostly mini-martini	3	good	Effect: "Improved Candy Vision", Effect Duration: 5
+7255	enchanted drinkable ghostly mini-martini	3	good	Effect: "Improved Candy Vision", Effect Duration: 5
 7256	smoke grenade	0		
-7257	modified red narrow molotov soda	1	decent	
+7257	modified narrow red molotov soda	1	decent	
 7258	electrified mirror pile of ashes	0		Effect: "Nightstalkin'", Effect Duration: 33
 7259	yellow crate of firebombs	0		
 7260	huge firebomb	0		
@@ -7167,7 +7167,7 @@
 7278	bouncing returned Thinknerd package	0		
 7279	chilled non-Vulcanized skewed wind-up Whatsian robot	0		Effect: "You Know Who to Call", Effect Duration: 21
 7280	electrified deionized wind-up vampire teeth	0		Effect: "Turkey-Agitated", Effect Duration: 60
-7281	corrupted chilled olive skewed wind-up navigation droid	0		Effect: "Flambé-a-thon", Effect Duration: 56
+7281	corrupted chilled skewed olive wind-up navigation droid	0		Effect: "Flambé-a-thon", Effect Duration: 56
 7282	pickled alkaline upside-down wind-up owl	0		Effect: "20/20 Vision", Effect Duration: 25
 7283	irradiated adjusted diffused skewed wind-up ensign	0		Effect: "Sugary Tongue", Effect Duration: 25
 7284	bouncing dog trainer's Fonzie's crying statue earrings	0		Experience (Moxie): +1, Experience (familiar): +1, Single Equip, Lasts Until Rollover
@@ -7210,14 +7210,14 @@
 7321	avaricious curative Stephen's lab coat	0		Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5
 7322	altered spinning Stephen's secret formula	0		Effect: "Dirge of Dreadfulness", Effect Duration: 24
 7323	bouncing greasy careful Jacob's rung	0		Monster Level: -10, Sleaze Spell Damage: +10
-7324	dehydrated tumbling jittery teal battery	1		
-7325	acceptable weak snakebite	2	good	
+7324	dehydrated teal tumbling jittery battery	1		
+7325	weak acceptable snakebite	2	good	
 7326	rubber ribcage of dire peril of the bloodbag	0		Weapon Damage: +20, Maximum HP: +100, Damage Reduction: 7
 7327	altered synthetic marrow	1		
 7328	frozen extra-nitrogenated bouncing funny bone	0		Effect: "Salsa Satanica", Effect Duration: 21
 7329	blinking perfumed sizzling half-melted spoon	0		Hot Damage: +10, Stench Resistance: +5
 7330	diluted the funk	1		Effect: "Slippery Tongue", Effect Duration: 50
-7331	massive spoiled squat gunky chicken	8	crappy	
+7331	spoiled massive squat gunky chicken	8	crappy	
 7332	yellow doll head of the scaredy-cat	0		Monster Level: -15
 7333	skewed droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7228,7 +7228,7 @@
 7339	music box mechanism	0		
 7340	zippy moose antlers	0		Initiative: +20, Familiar Effect: "atk, 1xLep, cap 27"
 7341	colloidal denatured modified green moose thought	0		Effect: "Antsy in your Pantsy", Effect Duration: 20
-7342	bite-sized adequate moose chocolate	1	good	
+7342	adequate bite-sized moose chocolate	1	good	
 7343	delicious irresponsibly strong bouncing painting of a glass of wine	8	awesome	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
@@ -7238,7 +7238,7 @@
 7349	mirror ghost key	0		
 7350	upside-down picture of you	0		
 7351	lard-coated wholesome quilted Staff of the Electric Range	0		Damage Absorption: +40, Maximum HP Percent: +10, Sleaze Spell Damage: +25
-7352	massive special flavorless deluxe layer cake	7	decent	Effect: "Puddingface", Effect Duration: 30
+7352	special massive flavorless deluxe layer cake	7	decent	Effect: "Puddingface", Effect Duration: 30
 7353	cyan chunk of hot iron	0		
 7354	tolerable ghostly red-hot boilermaker	3	good	
 7355	coal shovel of Flo-Jo	0		Initiative: +100, Conditional Skill (Equipped): "Shovel Hot Coal"
@@ -7249,19 +7249,19 @@
 7360	pulsating plaid bandage	0		
 7361	upside-down plaid pocket square of Gandalf	0		Spell Critical Percent: +20
 7362	dog trainer's Annie Oakley's plaid skirt	0		Critical Hit Percent: +20, Experience (familiar): +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-7363	altered pulsating fuchsia bloodstain stick	0		Effect: "The Power of Positive Thinking", Effect Duration: 41
+7363	altered fuchsia pulsating bloodstain stick	0		Effect: "The Power of Positive Thinking", Effect Duration: 41
 7364	skewed fabric softener	0		
 7365	aerosolized blue fabric hardener	0		Effect: "Human-Horror Hybrid", Effect Duration: 61
 7366	artisanal huge bottle of laundry sherry	3	EPIC	
 7367	Vulcanized Vulcanized improved wobbly industrial strength starch	0		Effect: "Ruthlessly Efficient", Effect Duration: 29, Wiki Name: "industrial strength starch"
 7368	rotten jittery extra-flat panini	4	crappy	
-7369	improved oxidized blinking teal mangled finger	0		Effect: "Stregngth of the Gnome", Effect Duration: 40
+7369	improved oxidized teal blinking mangled finger	0		Effect: "Stregngth of the Gnome", Effect Duration: 40
 7370	drinkable Psychotic Train wine	4	good	
 7371	crazy hobo notebook	0		
 7372	fancy normal bouncing pie man was not meant to eat	4	good	Effect: "Comic Violence", Effect Duration: 25
 7373	sommelier's towel of incineration	0		Hot Spell Damage: +50
 7374	jittery Samson's tarnished tastevin	0		Experience (Muscle): +5, Single Equip
-7375	normal big actual tapas	5	good	
+7375	big normal actual tapas	5	good	
 7376	squat ghast iron ingot	0		
 7377	padded groovy ghast iron cleaver	0		Moxie Percent: +10, Damage Absorption: +20
 7378	nasty ghast iron Garibaldi of the cougar	0		Moxie: +20, Stench Damage: +5, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7283,7 +7283,7 @@
 7394	triple-alkaline Gene Tonic: Fish	0		Effect: "Heart of Yellow", Effect Duration: 11, Last Available: "2014-04"
 7395	frozen activated twirling Gene Tonic: Goblin	0		Effect: "Bilious Brawn", Effect Duration: 32, Last Available: "2014-04"
 7396	boiled Gene Tonic: Pirate	0		Effect: "Deep-Seated Rage", Effect Duration: 28, Last Available: "2014-04"
-7397	polarized ionized narrow olive Gene Tonic: Plant	0		Effect: "Sweet, Nuts", Effect Duration: 25, Last Available: "2014-04"
+7397	polarized ionized olive narrow Gene Tonic: Plant	0		Effect: "Sweet, Nuts", Effect Duration: 25, Last Available: "2014-04"
 7398	dry polymerized chilled cyan Gene Tonic: Weird	0		Effect: "Angry like the Wolf", Effect Duration: 62, Last Available: "2014-04"
 7399	vacuum-sealed modified Gene Tonic: Elf	0		Effect: "Memories of Puppy Love", Effect Duration: 36, Last Available: "2014-04"
 7400	diffused quantum red Gene Tonic: Mer-kin	0		Effect: "Orc Chops", Effect Duration: 45, Last Available: "2014-04"
@@ -7314,47 +7314,47 @@
 7425	Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	sprinkle shaker	0		Last Available: "2014-05"
 7427	activated irradiated tumbling tumbling sleight-of-hand mushroom	0		Effect: "Hagg-ard", Effect Duration: 57, Last Available: "2014-05"
-7428	red skewed Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
+7428	skewed red Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	bouncing Beach Buck	0		Last Available: "2014-05"
 7430	diffused Fun-Guy spore	0		Effect: "Peppermint Bite", Effect Duration: 16, Last Available: "2014-05"
 7431	unsweetened chilled Boletus Broletus mushroom	0		Effect: "Human-Elemental Hybrid", Effect Duration: 16, Last Available: "2014-05"
-7432	unsweetened galvanized Vulcanized wobbly huge Omphalotus Omphaloskepsis mushroom	0		Effect: "Spirit Bubble", Effect Duration: 44, Last Available: "2014-05"
+7432	unsweetened galvanized Vulcanized huge wobbly Omphalotus Omphaloskepsis mushroom	0		Effect: "Spirit Bubble", Effect Duration: 44, Last Available: "2014-05"
 7433	extra-Vulcanized Gyromitra Dynomita mushroom	0		Effect: "Stop the Presses!", Effect Duration: 22, Last Available: "2014-05"
 7434	deionized Helvella Haemophilia mushroom	0		Effect: "Musky", Effect Duration: 59, Last Available: "2014-05"
 7435	galvanized cold-filtered Stemonitis Staticus mushroom	0		Effect: "Puzzle Fury", Effect Duration: 18, Last Available: "2014-05"
 7436	tarnished warmed squat Tremella Tarantella mushroom	0		Effect: "The Halls of Moxiousness", Effect Duration: 21, Last Available: "2014-05"
 7437	ghostly Pastaco shell	0		Last Available: "2014-05"
 7438	toothsome yellow Beefy Crunch Pastaco	3	awesome	Last Available: "2014-05"
-7439	spoiled thick fuchsia Brain Food Pastaco	5	crappy	Last Available: "2014-05"
+7439	thick spoiled fuchsia Brain Food Pastaco	5	crappy	Last Available: "2014-05"
 7440	tasty Cool Brunch Pastaco	4	awesome	Last Available: "2014-05"
 7441	normal miniature Medical Pastaco	2	good	Last Available: "2014-05"
 7442	spoiled huge Energy Buzz Pastaco	10	crappy	Last Available: "2014-05"
 7443	moldy Ludovico Pastaco	4	crappy	Last Available: "2014-05"
-7444	watered-down perfectly mixed overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7444	perfectly mixed watered-down overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7445	bad complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	practically non-alcoholic artisanal smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	drinkable high-proof jittery blood-red mushroom wine	8	good	Last Available: "2014-05"
 7448	drinkable buzzing mushroom wine	4	good	Last Available: "2014-05"
-7449	fancy artisanal watered-down narrow swirling mushroom wine	2	super ultra mega turbo EPIC	Effect: "Standard Issue Bravery", Effect Duration: 25, Last Available: "2014-05"
+7449	artisanal watered-down fancy narrow swirling mushroom wine	2	super ultra mega turbo EPIC	Effect: "Standard Issue Bravery", Effect Duration: 25, Last Available: "2014-05"
 7450	normal Taco Dan's Basic Taco Dan Taco	4	good	Last Available: "2014-05"
 7451	flavorless Taco Dan's Taco Fish Fish Taco	4	decent	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	acceptable regular-size brogurt	3	good	Last Available: "2014-05"
-7454	artisanal enchanted watered-down super-size brogurt	2	EPIC	Effect: "BOOsted", Effect Duration: 40, Last Available: "2014-05"
+7454	enchanted watered-down artisanal super-size brogurt	2	EPIC	Effect: "BOOsted", Effect Duration: 40, Last Available: "2014-05"
 7455	bad broberry brogurt	3	decent	Last Available: "2014-05"
-7456	delicious weak brocolate brogurt	2	awesome	Last Available: "2014-05"
+7456	weak delicious brocolate brogurt	2	awesome	Last Available: "2014-05"
 7457	acceptable tumbling French bronilla brogurt	3	good	Last Available: "2014-05"
 7458	twirling History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	skewed Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	pulsating Brogre brorts of Flo-Jo	0		Initiative: +100, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	pulsating Brogre brorts of Flo-Jo	0		Initiative: +100, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	smooth Brogre brolo shirt	0		Moxie: +15, Last Available: "2014-05"
-7464	double-paned Brogre bucket hat	0		Cold Resistance: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	double-paned Brogre bucket hat	0		Cold Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	cyan Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	blinking gray airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	zippy scandalous flame-wreathed 8-billed baseball cap	0		Hot Spell Damage: +10, Sleaze Damage: +5, Initiative: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	zippy scandalous flame-wreathed 8-billed baseball cap	0		Hot Spell Damage: +10, Sleaze Damage: +5, Initiative: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	miser's Sherlock's vibrating extremely wet T-shirt	0		Maximum MP Percent: +10, Item Drop: +25, Meat Drop: +10, Last Available: "2014-05"
 7470	executive double-paned scorching shrimp fork	0		Hot Damage: +25, Cold Resistance: +5, Meat Drop: +40, Last Available: "2014-05"
 7471	ionized concentrated BROS Energy Drink	0		Effect: "The Style... of the Future", Effect Duration: 39, Last Available: "2014-05"
@@ -7377,7 +7377,7 @@
 7488	squat triple-distilled turpentine	0		
 7489	maroon detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	lousy high-proof bottle of Chateau de Vinegar	7	decent	
+7491	high-proof lousy bottle of Chateau de Vinegar	7	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	spinning wine bomb	0		
@@ -7386,7 +7386,7 @@
 7497	squat ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
 7499	irradiated flattened wobbly olive Hot 'n' Scarys	0		Effect: "So Fresh and So Clean", Effect Duration: 36
-7500	mirror narrow pulsating map	0		
+7500	narrow mirror pulsating map	0		
 7501		0		
 7502	galvanized green Texas tea	0		Effect: "familiar.enq", Effect Duration: 53
 7503	twirling frightening dark hamethyst ring	0		Spooky Damage: +5
@@ -7396,7 +7396,7 @@
 7507	scandalous cloak	0		Sleaze Damage: +5
 7508	cyan label	0		
 7509	spoiled Mornington crescent roll	3	crappy	
-7510	oxidized pressed upside-down twirling eye shadow	0		Effect: "Chlorophyll Flavor", Effect Duration: 19
+7510	oxidized pressed twirling upside-down eye shadow	0		Effect: "Chlorophyll Flavor", Effect Duration: 19
 7511	ghostly blinking crumbling wheel	0		
 7512	polarized blurry poppy	0		Effect: "Empty Inside", Effect Duration: 47
 7513	opium grenade	0		
@@ -7407,7 +7407,7 @@
 7518	wand of pigification	0		
 7519	artisanal glass of bourbon	3	EPIC	
 7520	blinking burned government manual fragment	0		Last Available: "2014-05"
-7521	special bland government cheese	3	decent	Effect: "Uncucumbered", Effect Duration: 45, Last Available: "2014-05"
+7521	bland special government cheese	3	decent	Effect: "Uncucumbered", Effect Duration: 45, Last Available: "2014-05"
 7522	purple tumbling ribald pair of government shades	0		Sleaze Damage: +10, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	extra-tarnished irradiated government	0		Effect: "Old Time Hydration", Effect Duration: 56, Last Available: "2014-05"
@@ -7416,31 +7416,31 @@
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	brawny government-issued night-vision goggles of Leguizamo	0		Muscle Percent: +20, Monster Level: +20, Single Equip, Last Available: "2014-05"
 7529	yummy narrow loaf of alien bread	4	awesome	Last Available: "2014-05"
-7530	rotten tiny grilled cheese sandwich	1	crappy	Last Available: "2014-05"
+7530	tiny rotten grilled cheese sandwich	1	crappy	Last Available: "2014-05"
 7531	diluted alien protein powder	1	good	Last Available: "2014-05"
 7532	lousy rocket fuel	4	decent	Last Available: "2014-05"
 7533	fuchsia jittery alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	artisanal wobbly stealth bomber	4	EPIC	Last Available: "2014-05"
-7536	shaking narrow space beast fur	0		Last Available: "2014-05"
+7536	narrow shaking space beast fur	0		Last Available: "2014-05"
 7537	mirror twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	fortified space beast fur hat	0		Damage Absorption: +60, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	experienced space beast fur pants	0		Experience: +2, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	fortified space beast fur hat	0		Damage Absorption: +60, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	experienced space beast fur pants	0		Experience: +2, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	space beast fur whip of extreme caution	0		Monster Level: -25, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	gravedigger's baleful space heater	0		Spell Damage: +25, Spooky Damage: +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	lime green pulsating space bar	0		Last Available: "2014-05"
-7545	mediocre practically non-alcoholic space port	1	decent	Last Available: "2014-05"
+7545	practically non-alcoholic mediocre space port	1	decent	Last Available: "2014-05"
 7546	grievous Da Vinci's space needle	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Last Available: "2014-05"
-7547	oxidized jittery bouncing buffed alien drugs	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24, Last Available: "2014-05"
+7547	oxidized bouncing jittery buffed alien drugs	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
 7549	moist quadruple-pickled ghostly ash soda	0		Effect: "Adventurer's Best Friendship", Effect Duration: 50, Last Available: "2014-06"
 7550	modified liquid smoke	0		Effect: "Smugness", Effect Duration: 65, Last Available: "2014-06"
 7551	oxidized dollop of barbecue sauce	0		Effect: "In the Saucestream", Effect Duration: 25, Last Available: "2014-06"
 7552	concentrated bowl of marinade	0		Effect: "Mad at Science", Effect Duration: 39, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
-7554	double-wet magnetized shaking spinning bottle of lighter fluid	0		Effect: "Unusual Perspective", Effect Duration: 25, Last Available: "2014-06"
+7554	double-wet magnetized spinning shaking bottle of lighter fluid	0		Effect: "Unusual Perspective", Effect Duration: 25, Last Available: "2014-06"
 7555	blurry page	0		
 7556	maroon ghostly elephant gift	0		
 7557	anodized corrupted blood cells	0		Effect: "On the Trolley", Effect Duration: 46
@@ -7451,7 +7451,7 @@
 7562	quantum oxidized huge musk turtle	0		Effect: "Extra-Wet", Effect Duration: 16
 7563	colloidal pickled polarized programmable turtle	0		Effect: "Big", Effect Duration: 32
 7564	dry non-cold-filtered mocking turtle	0		Effect: "Conspiratory Eyes", Effect Duration: 20
-7565	small normal skewed ham steak	2	good	
+7565	normal small skewed ham steak	2	good	
 7566	skewed resourceful time-twitching toolbelt	0		Maximum MP: +50, Single Equip, Free Pull
 7567	Chroner	0		
 7568	narrow greedy toasty chaotic Time Lord Badge of Honor	0		Spell Critical Percent: +10, Hot Damage: +5, Meat Drop: +20
@@ -7468,24 +7468,24 @@
 7579	twitching time capsule	0		
 7580	denatured liquid shifting time weirdness	1		
 7581	huge shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	decent massive skewed rack of dinosaur ribs	10	good	
+7582	massive decent skewed rack of dinosaur ribs	10	good	
 7583	weak perfectly mixed purple scotch on the rocks	2	super ultra EPIC	
 7584	wobbly gravedigger's Annie Oakley's yabba dabba doo rag	0		Critical Hit Percent: +20, Spooky Damage: +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	shellacked wooly loincloth of the scaredy-cat	0		Damage Reduction: 7, Monster Level: -15, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	boozy tolerable enchanted glass of &quot;milk&quot;	5	good	Effect: "Sappy Blood", Effect Duration: 45, Last Available: "2014-07"
+7589	enchanted boozy tolerable glass of &quot;milk&quot;	5	good	Effect: "Sappy Blood", Effect Duration: 45, Last Available: "2014-07"
 7590	lousy narrow cup of &quot;tea&quot;	3	decent	Last Available: "2014-07"
-7591	drinkable distilled pulsating thermos of &quot;whiskey&quot;	5	good	Last Available: "2014-07"
+7591	distilled drinkable pulsating thermos of &quot;whiskey&quot;	5	good	Last Available: "2014-07"
 7592	lousy Lucky Lindy	4	decent	Last Available: "2014-07"
-7593	weak special hand-crafted Bee's Knees	2	EPIC	Effect: "Ack!  Barred!", Effect Duration: 30, Last Available: "2014-07"
+7593	special weak hand-crafted Bee's Knees	2	EPIC	Effect: "Ack!  Barred!", Effect Duration: 30, Last Available: "2014-07"
 7594	fancy strong tolerable Sockdollager	5	good	Effect: "Rushin' Hands", Effect Duration: 10, Last Available: "2014-07"
 7595	delicious Ish Kabibble	4	awesome	Last Available: "2014-07"
-7596	strong artisanal Hot Socks	5	EPIC	Last Available: "2014-07"
+7596	artisanal strong Hot Socks	5	EPIC	Last Available: "2014-07"
 7597	acceptable pulsating Phonus Balonus	4	good	Last Available: "2014-07"
 7598	tolerable Flivver	3	good	Last Available: "2014-07"
-7599	weak acceptable Sloppy Jalopy	2	good	Last Available: "2014-07"
+7599	acceptable weak Sloppy Jalopy	2	good	Last Available: "2014-07"
 7600	tarnished mirror flame	0		Effect: "It's Soporiffic!", Effect Duration: 55
 7601	galvanized temporary yak tattoo	0		Effect: "Covetous Robbery", Effect Duration: 43
 7602	energized denatured gray Fitspiration&trade; poster	0		Effect: "Earthen Fist", Effect Duration: 51
@@ -7548,7 +7548,7 @@
 7659	neoprene skullcap of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	ionized Vulcanized extra-pickled goblin water	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 45
 7661	dumb mud	0		
-7662	snack-sized flavorless huge Sogg-Os	2	decent	
+7662	flavorless snack-sized huge Sogg-Os	2	decent	
 7663	greasy Fonzie's Lord Soggyraven's Slippers of the storm	0		Experience (Moxie): +1, Maximum MP Percent: +40, Sleaze Spell Damage: +10, Single Equip
 7664	quantum corrupted alkaline mirror pulsating Ancient Protector Soda	0		Effect: "Muddled", Effect Duration: 46
 7665	pickled corrupted liquid ice	0		Effect: "Holiday Bliss", Effect Duration: 65
@@ -7559,7 +7559,7 @@
 7670	jittery Usain Bolt's rosy-cheeked beefcake's famous raincoat	0		Muscle: +25, Maximum HP Percent: +30, Initiative: +80, Lasts Until Rollover
 7671	perfumed mansplainer's arcane researcher's lightning rod	0		Experience Percent (Mysticality): +10, Monster Level: +15, Stench Resistance: +5, Lasts Until Rollover
 7672	law-abiding citizen cane of the detective	0		Item Drop: +20, Single Equip
-7673	delicious triple-distilled mirror legitimate business on the beach	9	awesome	
+7673	triple-distilled delicious mirror legitimate business on the beach	9	awesome	
 7674	stylish hep waders	0		Moxie: +25, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	normal mirror jive turkey leg	4	good	
 7676	birdbone corset of vim and vigor	0		Maximum HP Percent: +50
@@ -7567,7 +7567,7 @@
 7678	4-dimensional fez of the storm	0		Maximum MP Percent: +40, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	super-absorbent tarp of vim and vigor	0		Maximum HP Percent: +50
-7681	tolerable practically non-alcoholic tumbling unquiet spirits	1	good	
+7681	practically non-alcoholic tolerable tumbling unquiet spirits	1	good	
 7682	arcane researcher's banjo kazoo mount	0		Experience Percent (Mysticality): +10, Single Equip
 7683	modified flattened ghostly grass	0		Effect: "Insatiable Hunger", Effect Duration: 42
 7684	jittery occult Time Lord Participation Mug	0		Spell Damage Percent: +25
@@ -7583,7 +7583,7 @@
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
 7695	skewed blurry careful cap gun of wisdom of mayonnaise	0		Mysticality: +15, Monster Level: -10, Sleaze Spell Damage: +50, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	inspector's extremely unsafe cassette player	0		Weapon Damage Percent: +100, Item Drop: +15, Single Equip, Last Available: "2014-08"
-7697	bouncing purple chewable paper	0		Free Pull, Last Available: "2014-08"
+7697	purple bouncing chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	quadruple-oxidized confiscated comic book	0		Effect: "Pretending to Pretend", Effect Duration: 25, Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	upside-down LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	moist spinning rubber nubbin	0		Effect: "Rage of the Reindeer", Effect Duration: 51, Last Available: "2014-08"
 7708	lime green sharpshooter's rubber cape of terror	0		Critical Hit Percent: +10, Spooky Spell Damage: +10, Last Available: "2014-08"
 7709	flame-wreathed vibrating wicked sage Thor's Pliers	0		Mysticality Percent: +10, Spell Damage: +5, Maximum MP Percent: +10, Hot Spell Damage: +10, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	irradiated candy UFOs	0		Effect: "Frog In Your Throat", Effect Duration: 65
 7711	knitted Oprah's water wings for babies	0		Maximum MP Percent: +50, Cold Resistance: +3
-7712	shaking beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	shaking beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	normal Strix stix	3	good	
 7714	dog trainer's chaotic sinister vampire pellet	0		Spell Damage: +10, Spell Critical Percent: +10, Experience (familiar): +1
 7715	bad non-aged vinegar	3	decent	
@@ -7607,7 +7607,7 @@
 7718	bouncing greasy Roman sadnals	0		Sleaze Spell Damage: +10, Single Equip
 7719	wobbly supercharged madius	0		Maximum MP Percent: +30
 7720	squat radiator heater shield of the sewer	0		Stench Damage: +25, Damage Reduction: 6
-7721	triple-Vulcanized warmed wobbly purple jittery salt wages	0		Effect: "Morninja", Effect Duration: 24
+7721	triple-Vulcanized warmed purple jittery wobbly salt wages	0		Effect: "Morninja", Effect Duration: 24
 7722	flame-retardant centurion helmet	0		Hot Resistance: +1, Familiar Effect: "1xFairy, atk, cap 25"
 7723	spinning Chroner cross	0		
 7724	tumbling razor-sharp pteruges	0		Weapon Damage Percent: +25, Familiar Effect: "1xFairy, atk, cap 25"
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	upside-down Van der Graaf Xiblaxian xeno-detection goggles	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2014-09"
-7753	spinning Xiblaxian stealth cowl of the detective of the cheetah	0		Item Drop: +20, Initiative: +60, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	spinning Xiblaxian stealth cowl of the detective of the cheetah	0		Item Drop: +20, Initiative: +60, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	flame-wreathed banded Xiblaxian stealth trousers	0		Damage Absorption: +100, Hot Spell Damage: +10, Last Available: "2014-09"
 7755	friendly personal trainer's Xiblaxian stealth vest	0		Experience Percent (Muscle): +10, Familiar Weight: +3, Last Available: "2014-09"
 7756	toothsome shaking Xiblaxian ultraburrito	3	awesome	Last Available: "2014-09"
@@ -7647,7 +7647,7 @@
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	energized They liver	0		Effect: "You're High as a Crow, Marty", Effect Duration: 53, Last Available: "2014-09"
 7760	stale They liver popsicle	4	decent	Last Available: "2014-09"
-7761	blinking green holo-tank	0		Last Available: "2014-09"
+7761	green blinking holo-tank	0		Last Available: "2014-09"
 7762	skewed holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
 7764	pickled residual zeal	1		Effect: "Wistfully Nostalgic", Effect Duration: 15, Last Available: "2014-09"
@@ -7657,7 +7657,7 @@
 7768	one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	inspector's Jim Carey's Personal Ventilation Unit of the early riser	0		Monster Level: +25, Item Drop: +15, Adventures: +7, Single Equip, Last Available: "2014-10"
-7771	triple-chilled extra-alkaline huge tumbling the most dangerous bait	0		Effect: "Gutterminded", Effect Duration: 53, Last Available: "2014-10"
+7771	triple-chilled extra-alkaline tumbling huge the most dangerous bait	0		Effect: "Gutterminded", Effect Duration: 53, Last Available: "2014-10"
 7772	rotten &quot;meat&quot; stick	3	crappy	Last Available: "2014-10"
 7773	modified transdermal smoke patch	1	EPIC	Effect: "Kindly Resolve", Effect Duration: 30, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
@@ -7669,7 +7669,7 @@
 7780	green censurious groovy brawny heavy-duty clipboard	0		Muscle Percent: +20, Moxie Percent: +10, Sleaze Resistance: +3, Damage Reduction: 8, Last Available: "2014-10"
 7781	shellacked wicked smartaleck's thinker's battery-powered drill	0		Mysticality: +10, Moxie Percent: +30, Spell Damage: +5, Damage Reduction: 7, Last Available: "2014-10"
 7782	miniature stale enchanted limp broccoli	2	decent	Effect: "Funky Coal Patina", Effect Duration: 30, Last Available: "2014-10"
-7783	ribald Annie Oakley's banded hat	0		Damage Absorption: +100, Critical Hit Percent: +20, Sleaze Damage: +10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7783	ribald Annie Oakley's banded hat	0		Damage Absorption: +100, Critical Hit Percent: +20, Sleaze Damage: +10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	modified wet squat monkey barf	0		Effect: "Hiding in Plain Sight", Effect Duration: 16, Last Available: "2014-10"
 7785	unsweetened colloidal Vulcanized tumbling candy	0		Effect: "Fruited", Effect Duration: 21, Last Available: "2014-10"
 7786	nippy Sinatra's brawny jangly bracelet	0		Muscle Percent: +20, Experience (Moxie): +5, Cold Damage: +10, Last Available: "2014-10"
@@ -7683,7 +7683,7 @@
 7794	blurry Armory keycard	0		Last Available: "2014-10"
 7795	decent thick jittery mirror initiative shawarma	5	good	Last Available: "2014-10"
 7796	spoiled warm war shawarma	3	crappy	Last Available: "2014-10"
-7797	snack-sized moldy twirling karma shawarma	2	crappy	Last Available: "2014-10"
+7797	moldy snack-sized twirling karma shawarma	2	crappy	Last Available: "2014-10"
 7798	aged yellow Jungle Juice	3	awesome	Last Available: "2014-10"
 7799	smooth blue Amnesiac Ale	4	awesome	Last Available: "2014-10"
 7800	drinkable cyan Highest Bitter	3	good	Last Available: "2014-10"
@@ -7727,24 +7727,24 @@
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	spinning special clip: tracers	0		Last Available: "2014-10"
 7840	special clip: wailers	0		Last Available: "2014-10"
-7841	twirling pulsating special clip: squelchers	0		Last Available: "2014-10"
+7841	pulsating twirling special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	vacuum-sealed non-polarized blinking blinking perl necklace	0		Effect: "Thick, Sick", Effect Duration: 29, Last Available: "2014-12"
 7846	chilled Fudge Fiber Armor Plating	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 29, Last Available: "2014-12"
-7847	quadruple-nitrogenated wet shaking twirling ruby on canes	0		Effect: "Sugary World View", Effect Duration: 13, Last Available: "2014-12"
+7847	quadruple-nitrogenated wet twirling shaking ruby on canes	0		Effect: "Sugary World View", Effect Duration: 13, Last Available: "2014-12"
 7848	normal twirling petit fortran	4	good	Last Available: "2014-12"
-7849	diet adequate upside-down java cookie	1	good	Last Available: "2014-12"
-7850	special decent massive cookie cookie	9	good	Effect: "Memory of Strength", Effect Duration: 30, Last Available: "2014-12"
+7849	adequate diet upside-down java cookie	1	good	Last Available: "2014-12"
+7850	massive special decent cookie cookie	9	good	Effect: "Memory of Strength", Effect Duration: 30, Last Available: "2014-12"
 7851	plastic exo-suited miner of the sweet-tooth	0		Candy Drop: +100, Last Available: "2014-12"
 7852	red skewed perfumed plastic semi-autonomous drill unit	0		Stench Resistance: +5, Last Available: "2014-12"
 7853	mirror maroon Samson's plastic ambulatory robo-minecart	0		Experience (Muscle): +5, Last Available: "2014-12"
 7854	brainy plastic Crimbot	0		Mysticality: +5, Last Available: "2014-12"
 7855	upside-down coward's plastic Crimbomega	0		Monster Level: -20, Last Available: "2014-12"
 7856	warmed fuchsia flask of mining oil	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 53, Last Available: "2014-12"
-7857	blinking censurious radiation-resistant helmet	0		Sleaze Resistance: +3, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	maroon servo-assisted exo-pants of the brazier	0		Hot Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	blinking censurious radiation-resistant helmet	0		Sleaze Resistance: +3, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	maroon servo-assisted exo-pants of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	nasty deadly high-energy mining laser	0		Weapon Damage: +5, Stench Damage: +5, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	blurry narrow nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7761,7 +7761,7 @@
 7872	jittery Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	maroon Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	upside-down Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
-7875	cyan spinning blinking Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
+7875	blinking spinning cyan Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
@@ -7805,17 +7805,17 @@
 7916	ghostly mimeplasm	0		
 7917	alkaline ionized BOOterfinger	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 56
 7918	aerosolized mirror Moonds	0		Effect: "Incredibly Hulking", Effect Duration: 29
-7919	activated irradiated blurry wobbly Big Punk	0		Effect: "Cinnamouth", Effect Duration: 48
+7919	activated irradiated wobbly blurry Big Punk	0		Effect: "Cinnamouth", Effect Duration: 48
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	special hand-crafted Friendly Turkey	3	EPIC	Effect: "Deeply Ironic", Effect Duration: 15, Last Available: "2014-11"
 7923	weak lousy Agitated Turkey	2	decent	Last Available: "2014-11"
-7924	practically non-alcoholic tolerable lime green Ambitious Turkey	1	good	Last Available: "2014-11"
-7925	low-calorie decent maroon neutron lollipop	1	good	Last Available: "2014-12"
+7924	tolerable practically non-alcoholic lime green Ambitious Turkey	1	good	Last Available: "2014-11"
+7925	decent low-calorie maroon neutron lollipop	1	good	Last Available: "2014-12"
 7926	acceptable gamma nog	3	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	spinning Thwaitgold nit statuette	0		
-7936	green mirror picky tweezers	0		Last Available: "2015-02"
+7936	mirror green picky tweezers	0		Last Available: "2015-02"
 7937	mirror Crimbo Credit	0		
 7938	mixed single atom	1	awesome	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
@@ -7826,9 +7826,9 @@
 7944	tooth	0		
 7945	table	0		
 7946	nasty lion tamer's outlaw bandana of the businessman	0		Experience (familiar): +2, Stench Damage: +5, Meat Drop: +50
-7947	tolerable watered-down whiskey in a broken glass	2	good	
+7947	watered-down tolerable whiskey in a broken glass	2	good	
 7948	hand-crafted shot of mescal	3	EPIC	
-7949	strong acceptable glass of herbal tequila	5	good	
+7949	acceptable strong glass of herbal tequila	5	good	
 7950	minin' dynamite	0		
 7951	purple steel-toed plaid cowboy hat of the pedagogue	0		Experience: +3, Damage Reduction: 9, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	tumbling lasso	0		
@@ -7851,7 +7851,7 @@
 7969	huge beehive	0		
 7970	mirror boning knife	0		
 7971	narrow Aggressive Carrot	0		Free Pull
-7972	pickled mirror skewed cyan mummified fig	1	decent	
+7972	pickled cyan skewed mirror mummified fig	1	decent	
 7973	altered mummified loaf of bread	1	decent	Effect: "Polar Express", Effect Duration: 5
 7974	compressed wobbly mummified beef haunch	1	good	Effect: "Trufflin'", Effect Duration: 40
 7975	linen bandages	0		
@@ -7863,7 +7863,7 @@
 7981	fuchsia talisman of Thoth	0		
 7982	blue cure-all	0		
 7983	MacGyver's hardened Sister Accessory	0		Damage Reduction: 3, Maximum MP: +100, Softcore Only
-7984	electrified maroon spinning skewed Boosty Juice	0		Effect: "Saucefingers", Effect Duration: 45
+7984	electrified spinning maroon skewed Boosty Juice	0		Effect: "Saucefingers", Effect Duration: 45
 7985	asbestos-lined friendly parachute	0		Familiar Weight: +3, Hot Resistance: +5, Last Available: "2015-12"
 7986	Rosewater's pad of incineration	0		Mysticality Percent: +30, Hot Spell Damage: +50, Damage Reduction: 3, Last Available: "2015-12"
 7987	tumbling Sinatra's peeler of horror	0		Experience (Moxie): +5, Spooky Spell Damage: +25, Last Available: "2015-12"
@@ -7881,7 +7881,7 @@
 7999	altered choco-Crimbot	0		Effect: "Stuck That Way", Effect Duration: 23, Last Available: "2014-12"
 8000	nitrogenated galvanized smart watch	0		Effect: "Preemptive Medicine", Effect Duration: 13, Last Available: "2014-12"
 8001	polymerized improved enhanced augmented-reality shades	0		Effect: "Wintergreen Warmongery", Effect Duration: 58, Last Available: "2014-12"
-8002	blinking wizardly toy Crimbot mega face	0		Mysticality: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
+8002	blinking wizardly toy Crimbot mega face	0		Mysticality: +25, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
 8003	shaking wicked toy Crimbot power glove	0		Spell Damage: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	mirror personal trainer's toy Crimbot super fist	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	grievous toy Crimbot rocket legs	0		Weapon Damage Percent: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
@@ -7897,7 +7897,7 @@
 8015	jittery Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	chilled pulsating fitness wristband	0		Effect: "Frigid Weapon", Effect Duration: 27, Last Available: "2014-12"
 8017	corrupted corrupted non-polarized flask of tainted mining oil	0		Effect: "Riboflavin'", Effect Duration: 45, Last Available: "2014-12"
-8018	magnetized triple-oxidized ionized blinking shaking and rain stick	0		Effect: "Prince of Seaside Town", Effect Duration: 60
+8018	magnetized triple-oxidized ionized shaking blinking and rain stick	0		Effect: "Prince of Seaside Town", Effect Duration: 60
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	rotten half-sized Choco-Mint patty	2	crappy	Last Available: "2015-01"
 8021	lousy hot mint schnocolate	4	decent	Last Available: "2015-01"
@@ -7944,7 +7944,7 @@
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	wobbly banana	0		Familiar Weight: +5
-8066	mixed bouncing cyan spinning	1	EPIC	Last Available: "2015-12"
+8066	mixed cyan bouncing spinning	1	EPIC	Last Available: "2015-12"
 8067	fuchsia nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	narrow Stembridge sidearm	0		Familiar Weight: +5
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	gray Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	wobbly squat jittery reassuring crafty Spelunker's fedora of the cougar	0		Moxie: +20, Maximum MP: +10, Spooky Resistance: +1, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	wobbly squat jittery reassuring crafty Spelunker's fedora of the cougar	0		Moxie: +20, Maximum MP: +10, Spooky Resistance: +1, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	frightening chilly Spelunker's whip of the businessman	0		Cold Damage: +5, Spooky Damage: +5, Meat Drop: +50, Last Available: "2015-12"
-8076	Usain Bolt's chaotic Spelunker's khakis of the scaredy-cat	0		Spell Critical Percent: +10, Monster Level: -15, Initiative: +80, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	Usain Bolt's chaotic Spelunker's khakis of the scaredy-cat	0		Spell Critical Percent: +10, Monster Level: -15, Initiative: +80, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	blurry Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	twirling LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8040,7 +8040,7 @@
 8166	lightning-fast cr&ecirc;epy mask of courage	0		Spooky Resistance: +3, Initiative: +40, Familiar Effect: "spooky atk, cap 5"
 8167	normal narrow baguette	4	good	
 8168	glob of icing	0		
-8169	anodized pulsating bouncing ginger snaps	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 56
+8169	anodized bouncing pulsating ginger snaps	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 56
 8170	alkaline improved cyan mostly-broken sunglasses	0		Effect: "In the Slimelight", Effect Duration: 39
 8171	enchanted acceptable red unflavored wine cooler	4	good	Effect: "Voracious Gorging", Effect Duration: 35
 8172	carton of snake milk	1	decent	
@@ -8056,11 +8056,11 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	bread basket of courage	0		Spooky Resistance: +3
 8184	twirling Ed the Undying exhibit crate	0		
-8185	pulsating ribald The Crown of Ed the Undying of bravery	0		Spooky Resistance: +5, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	pulsating ribald The Crown of Ed the Undying of bravery	0		Spooky Resistance: +5, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	fuchsia Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	fancy smooth Cherrytastrophe wine cooler	3	awesome	Effect: "Hoity Toity", Effect Duration: 10
-8189	fancy aged practically non-alcoholic bouncing Radberry Rip wine cooler	1	awesome	Effect: "Bloody-minded", Effect Duration: 25
+8188	smooth fancy Cherrytastrophe wine cooler	3	awesome	Effect: "Hoity Toity", Effect Duration: 10
+8189	practically non-alcoholic fancy aged bouncing Radberry Rip wine cooler	1	awesome	Effect: "Bloody-minded", Effect Duration: 25
 8190	triple-distilled artisanal squat Orangemageddon wine cooler	7	EPIC	
 8191	lousy Breakfast Blast wine cooler	3	decent	
 8192	fortified bad jittery Citrus Crush wine cooler	5	decent	
@@ -8078,7 +8078,7 @@
 8204	gray one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	FunFunds&trade;	0		Last Available: "2015-04"
 8206	Temple Grandin's baleful expensive camera	0		Spell Damage: +25, Familiar Weight: +7, Single Equip, Last Available: "2015-04"
-8207	blurry jittery spinning sunglasses	0		Single Equip, Last Available: "2015-04"
+8207	jittery spinning blurry sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	enhanced How to Avoid Scams	0		Effect: "Like a Fish to Walter", Effect Duration: 67, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	mirror bag of gross foreign snacks	0		Last Available: "2015-04"
@@ -8091,8 +8091,8 @@
 8217	Sherlock's chaotic perfume-soaked bandana	0		Spell Critical Percent: +10, Item Drop: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	rotten toxo	3	crappy	Last Available: "2015-04"
-8220	watered-down drinkable Lemonade-235	2	good	Last Available: "2015-04"
-8221	clever beefcake's isotophat	0		Muscle: +25, Maximum MP: +20, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8220	drinkable watered-down Lemonade-235	2	good	Last Available: "2015-04"
+8221	clever beefcake's isotophat	0		Muscle: +25, Maximum MP: +20, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	squat aromatic Van der Graaf Three Mile Island shorts	0		Stench Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-04"
 8223	maroon quilted extremely unsafe toxic mop	0		Weapon Damage Percent: +100, Damage Absorption: +40, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	trash net	0		Last Available: "2015-04"
 8246	careful clever Dinsey mascot mask of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +20, Monster Level: -10, Last Available: "2015-04"
 8247	normal Dinsey food-cone	3	good	Last Available: "2015-04"
-8248	acceptable strong special Dinsey Whinskey	5	good	Effect: "Superheroic", Effect Duration: 40, Last Available: "2015-04"
+8248	special strong acceptable Dinsey Whinskey	5	good	Effect: "Superheroic", Effect Duration: 40, Last Available: "2015-04"
 8249	activated upside-down Dinsey face paint	0		Effect: "Powdered", Effect Duration: 18, Last Available: "2015-04"
 8250	stanky fannypack of James Dean	0		Experience (Moxie): +3, Stench Spell Damage: +25, Last Available: "2015-04"
 8251	MacGyver's steel-toed educational slick thinker's brainy garbage sticker	0		Mysticality: 15, Moxie: +10, Experience: +1, Damage Reduction: 9, Maximum MP: +100, Last Available: "2015-04"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	adjusted tumbling power pill	0		Effect: "Chow Downed", Effect Duration: 60, Last Available: "2015-06"
 8301	pickled aerosolized yellow pixel star	0		Effect: "Leo Rising", Effect Duration: 32, Last Available: "2015-06"
-8302	half-sized flavorless lime green bouncing narrow pixel banana	2	decent	Last Available: "2015-06"
+8302	flavorless half-sized lime green narrow bouncing pixel banana	2	decent	Last Available: "2015-06"
 8303	tolerable pixel beer	4	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8183,7 +8183,7 @@
 8309	concentrated colloidal corrupted baggie of regular-sized tardigrades	0		Effect: "Army of One", Effect Duration: 61
 8310	oxidized dry .epub file	0		Effect: "Joy", Effect Duration: 39
 8311	wet non-chilled deionized cyan BUBBLE GUM	0		Effect: "Blessing of Charcoatl", Effect Duration: 24
-8312	ionized cold-filtered wobbly blinking hustler shades	0		Effect: "Spookyravin'", Effect Duration: 20
+8312	ionized cold-filtered blinking wobbly hustler shades	0		Effect: "Spookyravin'", Effect Duration: 20
 8313	pickled ionized mirror jerky stick	0		Effect: "Kissed By Fire", Effect Duration: 47
 8314	tarnished energized costume rental shop	0		Effect: "Coldfinger", Effect Duration: 44
 8315	modified colloidal polarized spinning muscle oil	0		Effect: "Mariachi Mood", Effect Duration: 32
@@ -8194,9 +8194,9 @@
 8320	altered flattened one glove	0		Effect: "Weasels Underfoot", Effect Duration: 12
 8321	anodized diffused glove	0		Effect: "Drunk With Power", Effect Duration: 62
 8322	cold-filtered handful of fire	0		Effect: "BOOsted", Effect Duration: 63
-8323	triple-energized wet tumbling jittery Cracklin' Oat Bran	0		Effect: "Rosewater Mark", Effect Duration: 55
+8323	triple-energized wet jittery tumbling Cracklin' Oat Bran	0		Effect: "Rosewater Mark", Effect Duration: 55
 8324	adjusted warmed galvanized disposable lighter	0		Effect: "Paging Betty", Effect Duration: 38
-8325	frozen Vulcanized cyan blurry coal contact lenses	0		Effect: "Ghostly Shell", Effect Duration: 21
+8325	frozen Vulcanized blurry cyan coal contact lenses	0		Effect: "Ghostly Shell", Effect Duration: 21
 8326	galvanized aerosolized tumbling conjured ice cream	0		Effect: "Filled with Magic", Effect Duration: 37
 8327	modified Iceberglar scarf	0		Effect: "Wallflowering", Effect Duration: 14
 8328	anodized Vulcanized icy hairspray	0		Effect: "Drunk With Power", Effect Duration: 47
@@ -8229,7 +8229,7 @@
 8355	quadruple-unsweetened iron torso box	0		Effect: "The Rich Get Richer", Effect Duration: 18
 8356	polymerized pressed denatured mercenary headband	0		Effect: "Tasting the Rainbow", Effect Duration: 55
 8357	concentrated green radioactive spider venom	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 19
-8358	extra-corrupted polymerized purple skewed x-ray mirror	0		Effect: "Big", Effect Duration: 24
+8358	extra-corrupted polymerized skewed purple x-ray mirror	0		Effect: "Big", Effect Duration: 24
 8359	extra-adjusted wrestling mask	0		Effect: "Crying, Dying", Effect Duration: 33
 8360	vacuum-sealed hawkface potion	0		Effect: "Radiant Personality", Effect Duration: 45
 8361	boiled child-sized dracula cloak	0		Effect: "Blood-Rich", Effect Duration: 31
@@ -8241,17 +8241,17 @@
 8367	vacuum-sealed quantum vacuum-sealed handful of stubble	0		Effect: "Trash-Wrapped", Effect Duration: 43
 8368	boiled spinning garbage juice slurpee	0		Effect: "Turtle Power", Effect Duration: 59
 8369	diffused quadruple-polymerized dry squat plunge-leg	0		Effect: "Your Interest is Peaked", Effect Duration: 36
-8370	tarnished huge teal funky eyepatch	0		Effect: "Super Structure", Effect Duration: 41
+8370	tarnished teal huge funky eyepatch	0		Effect: "Super Structure", Effect Duration: 41
 8371	dry pressed squat spinning bucket of fish juice	0		Effect: "Full-Body Tan", Effect Duration: 60
 8372	quadruple-warmed flashy pirate dreadlocks	0		Effect: "Feroci Tea", Effect Duration: 49
 8373	oxidized wobbly captured boozles	0		Effect: "Wistfully Nostalgic", Effect Duration: 37
 8374	cold-filtered galvanized drinks tray	0		Effect: "Gummiheart", Effect Duration: 26
 8375	modified enhanced eyebrow lifter	0		Effect: "Dreams and Lights", Effect Duration: 65
 8376	submarine	0		Last Available: "2015-06"
-8377	adequate jumbo pixel lemon	5	good	Last Available: "2015-06"
+8377	jumbo adequate pixel lemon	5	good	Last Available: "2015-06"
 8378	artisanal pixel daiquiri	4	EPIC	Last Available: "2015-06"
 8379	alkaline polymerized ghostly power pill	0		Effect: "Bootyliciousness", Effect Duration: 31, Last Available: "2015-06"
-8380	energized aerosolized concentrated shaking bouncing blinking pixel potion	0		Effect: "Pyramid Power", Effect Duration: 33, Last Available: "2015-06"
+8380	energized aerosolized concentrated blinking shaking bouncing pixel potion	0		Effect: "Pyramid Power", Effect Duration: 33, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
 8383	ghostly popular part	0		
@@ -8260,7 +8260,7 @@
 8386	valuable coin	0		Last Available: "2015-07"
 8387	pulsating mana	0		Last Available: "2015-07"
 8388	purple mana	0		Last Available: "2015-07"
-8389	fuchsia skewed mana	0		Last Available: "2015-07"
+8389	skewed fuchsia mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
@@ -8281,11 +8281,11 @@
 8407	adequate yellow pestopiary	3	good	
 8408	vacuum-sealed extra-wet polarized spinning ectoplasmic orbs	0		Effect: "Creepypasted", Effect Duration: 26
 8409	delicious crudles	4	awesome	
-8410	massive flavorless agnolotti arboli	10	decent	
-8411	moldy snack-sized fancy twirling ghostly spaghetti with ghost balls	2	crappy	Effect: "The Sweats", Effect Duration: 5
-8412	spoiled enchanted bite-sized bouncing succulent marrow	1	crappy	Effect: "Sticky Fingers", Effect Duration: 5
+8410	flavorless massive agnolotti arboli	10	decent	
+8411	snack-sized fancy moldy twirling ghostly spaghetti with ghost balls	2	crappy	Effect: "The Sweats", Effect Duration: 5
+8412	bite-sized spoiled enchanted bouncing succulent marrow	1	crappy	Effect: "Sticky Fingers", Effect Duration: 5
 8413	toothsome salacious crumbs	3	awesome	
-8414	normal massive fusilli marrownarrow	8	good	
+8414	massive normal fusilli marrownarrow	8	good	
 8415	decent suggestive strozzapreti	4	good	
 8416	Mountain Stream gastrique	0		
 8417	adequate jittery Mt. McLargeHuge oyster	3	good	
@@ -8299,7 +8299,7 @@
 8425	yellow ghostly New Age healing crystal	0		Last Available: "2015-08"
 8426	red Volcoino	0		Last Available: "2015-08"
 8427	bouncing fizzing spore pod	0		
-8428	shaking gray spore pod	0		
+8428	gray shaking spore pod	0		
 8429	ghostly veiny spore pod	0		
 8430	yellow hard spore pod	0		
 8431	spore pod	0		
@@ -8311,7 +8311,7 @@
 8437	family-friendly thinker's LavaCo Lamp&trade;	0		Mysticality: +10, Sleaze Resistance: +1, Last Available: "2015-08"
 8438	narrow thin wire	0		Last Available: "2015-08"
 8439	blurry insulated wire	0		Last Available: "2015-08"
-8440	mirror skewed empty lava bottle	0		Last Available: "2015-08"
+8440	skewed mirror empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	blue viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
@@ -8329,13 +8329,13 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	grievous high-temperature mining mask of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	grievous high-temperature mining mask of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	squat auspicious nippy fireproof megaphone	0		Cold Damage: +10, Item Drop: +10, Last Available: "2015-08"
-8460	adequate thick mineapple	5	good	Last Available: "2015-08"
-8461	bad boozy upside-down Gold Velvet&trade; whiskey	5	decent	Last Available: "2015-08"
+8460	thick adequate mineapple	5	good	Last Available: "2015-08"
+8461	boozy bad upside-down Gold Velvet&trade; whiskey	5	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	crappy	Last Available: "2015-08"
 8463	decent smelted roe	4	good	Last Available: "2015-08"
-8464	enchanted drinkable lavawater	4	good	Effect: "Pretending to Pretend", Effect Duration: 35, Last Available: "2015-08"
+8464	drinkable enchanted lavawater	4	good	Effect: "Pretending to Pretend", Effect Duration: 35, Last Available: "2015-08"
 8465	Vulcanized ionized jittery basaltamander tongue	0		Effect: "Coldfinger", Effect Duration: 16, Last Available: "2015-08"
 8466	jittery vibrating lavalarva of the brazier of the early riser	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Adventures: +7, Last Available: "2015-08"
 8467	lime green lion tamer's chaotic weightlifter's lava balaclava	0		Muscle: +15, Spell Critical Percent: +10, Experience (familiar): +2, Last Available: "2015-08"
@@ -8346,22 +8346,22 @@
 8472	tumbling blurry Sherlock's fireproof heat-resistant necktie	0		Hot Resistance: +3, Item Drop: +25, Single Equip, Last Available: "2015-08"
 8473	Sherlock's banded experienced heat-resistant gloves	0		Experience: +2, Damage Absorption: +100, Item Drop: +25, Single Equip, Last Available: "2015-08"
 8474	stale very hot lunch	3	decent	Last Available: "2015-08"
-8475	practically non-alcoholic tolerable asbestos thermos	1	good	Last Available: "2015-08"
+8475	tolerable practically non-alcoholic asbestos thermos	1	good	Last Available: "2015-08"
 8476	electrified polymerized unsweetened liquid rhinestones	0		Effect: "Nas Tea", Effect Duration: 18, Last Available: "2015-08"
 8477	stale yellow disco biscuit	4	decent	Last Available: "2015-08"
 8478	bad maroon Quaatorade&trade;	3	decent	Last Available: "2015-08"
-8479	knitted Oprah's hale biker's hat	0		Maximum HP: +20, Maximum MP Percent: +50, Cold Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
-8480	ghostly steel-toed cool feathered headdress of vim and vigor	0		Moxie: +5, Damage Reduction: 9, Maximum HP Percent: +50, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	auspicious rosy-cheeked electrician's hardhat of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +30, Item Drop: +10, Last Available: "2015-08", Familiar Effect: "atk"
+8479	knitted Oprah's hale biker's hat	0		Maximum HP: +20, Maximum MP Percent: +50, Cold Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8480	ghostly steel-toed cool feathered headdress of vim and vigor	0		Moxie: +5, Damage Reduction: 9, Maximum HP Percent: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	auspicious rosy-cheeked electrician's hardhat of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +30, Item Drop: +10, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	twirling The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	jittery one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	squat purple airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	purple squat airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	blinking Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	narrow executive smooth velvet pants	0		Meat Drop: +40, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	narrow executive smooth velvet pants	0		Meat Drop: +40, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	smooth velvet shirt of terror	0		Spooky Spell Damage: +10, Last Available: "2015-08"
 8492	slick smooth velvet hat	0		Moxie: +10, Last Available: "2015-08"
 8493	gray auspicious smooth velvet pocket square	0		Item Drop: +10, Single Equip, Last Available: "2015-08"
@@ -8391,17 +8391,17 @@
 8517	chaotic dangerous SMOOCH bracers	0		Weapon Damage: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2015-08"
 8518	maroon banded SMOOCH kneepads	0		Damage Absorption: +100, Single Equip, Last Available: "2015-08"
 8519	fireproof SMOOCH spaulders	0		Hot Resistance: +3, Single Equip, Last Available: "2015-08"
-8520	blinking Jack Frost's studded SMOOCH codpiece	0		Damage Absorption: +80, Cold Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	blinking Jack Frost's studded SMOOCH codpiece	0		Damage Absorption: +80, Cold Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	inspector's SMOOCH breastplate	0		Item Drop: +15, Last Available: "2015-08"
 8522	squat superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
-8524	spinning maroon blinking superheated	0		Last Available: "2015-08"
-8525	decent jittery cyan lava cake	4	good	Last Available: "2015-08"
-8526	normal miniature huge pink slime	2	good	
+8524	blinking maroon spinning superheated	0		Last Available: "2015-08"
+8525	decent cyan jittery lava cake	4	good	Last Available: "2015-08"
+8526	miniature normal huge pink slime	2	good	
 8527	Devil's Elbow Hot Sauce	0		
 8528	upside-down Special&trade; Sauce	0		
 8529	spoiled devil hair pasta	3	crappy	
-8530	rotten tiny spagecialetti	1	crappy	
+8530	tiny rotten spagecialetti	1	crappy	
 8531	lime green Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
@@ -8412,9 +8412,9 @@
 8539	wobbly Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	purple drug cocktail sauce	0		
-8542	yummy miniature upside-down Fettris	2	awesome	
+8542	miniature yummy upside-down Fettris	2	awesome	
 8543	big flavorless fusillocybin	5	decent	
-8544	toothsome big enchanted prescription noodles	5	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 5
+8544	enchanted big toothsome prescription noodles	5	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 5
 8545	denatured huge mirror blood-drive sticker	1	decent	
 8546	galvanized triple-galvanized green bag of grain	0		Effect: "Okee-Dokee Computer", Effect Duration: 54
 8547	pickled pocket maze	0		Effect: "Funky Coal Patina", Effect Duration: 34
@@ -8425,19 +8425,19 @@
 8552	moist cold-filtered face paint	0		Effect: "Radiated and Grodiated", Effect Duration: 34
 8553	practically non-alcoholic drinkable emergency margarita	1	good	
 8554	enchanted aged vintage smart drink	3	awesome	Effect: "Scavengers Scavenging", Effect Duration: 10
-8555	jittery bouncing a ten-percent bonus	0		
+8555	bouncing jittery a ten-percent bonus	0		
 8556	narrow Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	tarnished wobbly Wickers bar	0		Effect: "Snobby", Effect Duration: 41
 8559	colloidal oxidized polarized blinking bakelite-covered bacon	0		Effect: "protect.enq", Effect Duration: 13
 8560	improved pressed upside-down Aerheads	0		Effect: "Hyperoffended", Effect Duration: 37
-8561	liquefied jittery blurry Wrotz	0		Effect: "Bonelording", Effect Duration: 22
+8561	liquefied blurry jittery Wrotz	0		Effect: "Bonelording", Effect Duration: 22
 8562	double-tarnished Gabarbar	0		Effect: "stats.enq", Effect Duration: 18
 8563	magnetized Vulcanized flattened fiberglass insulation	0		Effect: "Overstimulated", Effect Duration: 54
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	blue bouncing inspector's asbestos-lined barrel lid of the businessman	0		Hot Resistance: +5, Item Drop: +15, Meat Drop: +50, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Herculean beefcake's barrel hoop earring of the dark arts	0		Muscle: +25, Experience (Muscle): +1, Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2015-09"
-8567	olive squat flame-retardant wool bankruptcy barrel of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +1, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	olive squat flame-retardant wool bankruptcy barrel of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +1, Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	jittery firkin	0		Last Available: "2015-09"
 8569	maroon skewed normal barrel	0		Last Available: "2015-09"
 8570	cyan tun	0		Last Available: "2015-09"
@@ -8448,8 +8448,8 @@
 8575	spinning rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	bouncing barnacled barrel	0		Last Available: "2015-09"
-8578	special high-proof drinkable twirling bottle of Amontillado	9	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 45, Last Available: "2015-09"
-8579	smooth spinning cyan barrel-aged martini	3	awesome	Last Available: "2015-09"
+8578	high-proof drinkable special twirling bottle of Amontillado	9	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 45, Last Available: "2015-09"
+8579	smooth cyan spinning barrel-aged martini	3	awesome	Last Available: "2015-09"
 8580	miniature spoiled jittery barrel pickle	2	crappy	Last Available: "2015-09"
 8581	flavorless barrel cracker	4	decent	Last Available: "2015-09"
 8582	dehydrated upside-down vibrating mushroom	1	good	Last Available: "2015-09"
@@ -8472,15 +8472,15 @@
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
 8601	vacuum-sealed improved cuppa Flamibili tea	0		Effect: "Witch Breaded", Effect Duration: 20, Last Available: "2015-09"
-8602	tarnished wobbly gray cuppa Yet tea	0		Effect: "Berry Experiential", Effect Duration: 13, Last Available: "2015-09"
+8602	tarnished gray wobbly cuppa Yet tea	0		Effect: "Berry Experiential", Effect Duration: 13, Last Available: "2015-09"
 8603	cold-filtered cuppa Boo tea	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 13, Last Available: "2015-09"
 8604	extra-aerosolized skewed green cuppa Nas tea	0		Effect: "The Rich Get Richer", Effect Duration: 18, Last Available: "2015-09"
-8605	cold-filtered narrow bouncing cuppa Improprie tea	0		Effect: "Cockroach Scurry", Effect Duration: 11, Last Available: "2015-09"
+8605	cold-filtered bouncing narrow cuppa Improprie tea	0		Effect: "Cockroach Scurry", Effect Duration: 11, Last Available: "2015-09"
 8606	energized non-modified cuppa Frost tea	0		Effect: "Faboooo", Effect Duration: 41, Last Available: "2015-09"
 8607	diffused magnetized cuppa Toast tea	0		Effect: "Elvish", Effect Duration: 20, Last Available: "2015-09"
 8608	warmed corrupted huge pulsating cuppa Net tea	0		Effect: "Cautious Prowl", Effect Duration: 64, Last Available: "2015-09"
 8609	vacuum-sealed modified extra-energized cuppa Proprie tea	0		Effect: "Crimbo Nostalgia", Effect Duration: 44, Last Available: "2015-09"
-8610	triple-moist bouncing skewed cuppa Morbidi tea	0		Effect: "Stregngth of the Gnome", Effect Duration: 67, Last Available: "2015-09"
+8610	triple-moist skewed bouncing cuppa Morbidi tea	0		Effect: "Stregngth of the Gnome", Effect Duration: 67, Last Available: "2015-09"
 8611	altered cuppa Chari tea	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 63, Last Available: "2015-09"
 8612	tarnished concentrated bouncing cuppa Serendipi tea	0		Effect: "Salty Mouth", Effect Duration: 65, Last Available: "2015-09"
 8613	unsweetened squat wobbly cuppa Feroci tea	0		Effect: "Ichorous Eyesight", Effect Duration: 50, Last Available: "2015-09"
@@ -8496,7 +8496,7 @@
 8623	galvanized activated cuppa Loyal tea	0		Effect: "Staying Frosty", Effect Duration: 26, Last Available: "2015-09"
 8624	vaporized upside-down cuppa Activi tea	1	awesome	Last Available: "2015-09"
 8625	compressed cuppa Cruel tea	1		Last Available: "2015-09"
-8626	altered jittery gray cuppa Alacri tea	0		Effect: "Salamander In Your Stomach", Effect Duration: 42, Last Available: "2015-09"
+8626	altered gray jittery cuppa Alacri tea	0		Effect: "Salamander In Your Stomach", Effect Duration: 42, Last Available: "2015-09"
 8627	denatured wet blurry cuppa Vitali tea	0		Effect: "All Blued Up", Effect Duration: 25, Last Available: "2015-09"
 8628	non-quantum cuppa Mana tea	0		Effect: "Powder Power", Effect Duration: 26, Last Available: "2015-09"
 8629	magnetized super-modified cuppa Monstrosi tea	0		Effect: "Mayeaugh", Effect Duration: 14, Last Available: "2015-09"
@@ -8511,8 +8511,8 @@
 8638	blue asbestos-lined frightening Royal scepter of the boozehound	0		Spooky Damage: +5, Hot Resistance: +5, Booze Drop: +100, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	rotten enchanted bowl of eyeballs	3	crappy	Effect: "Powder Power", Effect Duration: 15, Last Available: "2015-10"
-8642	decent thick red bowl of mummy guts	5	good	Last Available: "2015-10"
+8641	enchanted rotten bowl of eyeballs	3	crappy	Effect: "Powder Power", Effect Duration: 15, Last Available: "2015-10"
+8642	thick decent red bowl of mummy guts	5	good	Last Available: "2015-10"
 8643	miniature stale bowl of maggots	2	decent	Last Available: "2015-10"
 8644	mediocre high-proof blood and blood	7	decent	Last Available: "2015-10"
 8645	artisanal Jack-O-Lantern beer	4	EPIC	Last Available: "2015-10"
@@ -8558,7 +8558,7 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	teal baleful bellhop's hat	0		Spell Damage: +25, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8688	teal baleful bellhop's hat	0		Spell Damage: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
 8689	perfectly mixed ice porter	4	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	diffused non-dry exotic travel brochure	0		Effect: "Slimy Flavor", Effect Duration: 42, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
@@ -8568,10 +8568,10 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	altered medicinal herbs	1		Effect: "Horrid, Torrid", Effect Duration: 45, Last Available: "2016-01"
 8697	stale ice rice	4	decent	Last Available: "2016-01"
-8698	practically non-alcoholic perfectly mixed iced plum wine	1	EPIC	Last Available: "2016-01"
+8698	perfectly mixed practically non-alcoholic iced plum wine	1	EPIC	Last Available: "2016-01"
 8699	healthy beefy training belt of terror	0		Muscle: +10, Maximum HP Percent: +20, Spooky Spell Damage: +10, Single Equip, Last Available: "2016-01"
 8700	Sinatra's Da Vinci's training legwarmers of the pedagogue	0		Experience: +3, Experience (Mysticality): +5, Experience (Moxie): +5, Single Equip, Last Available: "2016-01"
-8701	fuchsia toasty friendly training helmet of Calamity Jane	0		Critical Hit Percent: +15, Familiar Weight: +3, Hot Damage: +5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	fuchsia toasty friendly training helmet of Calamity Jane	0		Critical Hit Percent: +15, Familiar Weight: +3, Hot Damage: +5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	tumbling spinning training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8582,12 +8582,12 @@
 8709	dried abstraction: thought	1		Last Available: "2015-12"
 8710	powdered blue abstraction: sensation	1		Effect: "5 Pounds Lighter", Effect Duration: 40, Last Available: "2015-12"
 8711	denatured skewed abstraction: purpose	1		Last Available: "2015-12"
-8712	twisted upside-down purple abstraction: category	1		Last Available: "2015-12"
+8712	twisted purple upside-down abstraction: category	1		Last Available: "2015-12"
 8713	denatured purple abstraction: perception	1		Last Available: "2015-12"
 8714	dried red upside-down abstraction: motion	1		Effect: "The Two-Prong Crown", Effect Duration: 15, Last Available: "2015-12"
 8715	powdered abstraction: joy	1		Last Available: "2015-12"
 8716	altered olive blurry abstraction: certainty	1		Effect: "Psalm of Pointiness", Effect Duration: 25, Last Available: "2015-12"
-8717	mixed upside-down ghostly abstraction: comprehension	1		Last Available: "2015-12"
+8717	mixed ghostly upside-down abstraction: comprehension	1		Last Available: "2015-12"
 8718	wobbly modern picture frame	0		Last Available: "2015-12"
 8719	tasty VYKEA meatballs	3	awesome	Last Available: "2015-11"
 8720	tolerable purple VYKEA mead	3	good	Last Available: "2015-11"
@@ -8600,16 +8600,16 @@
 8727	spinning pulsating VYKEA bracket	0		Last Available: "2015-11"
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	crafty rock-hard VYKEA hex key of the boozehound	0		Damage Reduction: 5, Maximum MP: +10, Booze Drop: +100, Last Available: "2015-11"
-8730	lime green jittery VYKEA instructions	0		Last Available: "2015-11"
-8731	adequate half-sized tin of submardines	2	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	weak bad maroon bottle of norwhiskey	2	decent	Last Available: "2015-11"
-8733	vaporized lime green squat octolus oculus	1	EPIC	Last Available: "2015-11"
+8730	jittery lime green VYKEA instructions	0		Last Available: "2015-11"
+8731	half-sized adequate tin of submardines	2	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8732	bad weak maroon bottle of norwhiskey	2	decent	Last Available: "2015-11"
+8733	vaporized squat lime green octolus oculus	1	EPIC	Last Available: "2015-11"
 8734	lime green flame-wreathed curative studded sardine can key	0		Damage Absorption: +80, Hot Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11"
-8735	skewed knitted electrified shellacked norwhal helmet	0		Damage Reduction: 7, Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	skewed knitted electrified shellacked norwhal helmet	0		Damage Reduction: 7, Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	upside-down Usain Bolt's flame-wreathed groovy octolus-skin cloak	0		Moxie Percent: +10, Hot Spell Damage: +10, Initiative: +80, Last Available: "2015-11"
-8737	delicious fancy practically non-alcoholic perfect cosmopolitan	1	awesome	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2015-11"
+8737	fancy delicious practically non-alcoholic perfect cosmopolitan	1	awesome	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2015-11"
 8738	watered-down tolerable perfect negroni	2	good	Last Available: "2015-11"
-8739	aged extra-dry perfect dark and stormy	5	awesome	Last Available: "2015-11"
+8739	extra-dry aged perfect dark and stormy	5	awesome	Last Available: "2015-11"
 8740	bad perfect mimosa	4	decent	Last Available: "2015-11"
 8741	bad perfect old-fashioned	4	decent	Last Available: "2015-11"
 8742	hand-crafted perfect paloma	3	EPIC	Last Available: "2015-11"
@@ -8624,7 +8624,7 @@
 8751	flattened wet ionized communal gobstopper	0		Effect: "Piratey Flavor", Effect Duration: 53, Last Available: "2015-12"
 8752	moldy Crimbo salad	3	crappy	Last Available: "2015-12"
 8753	big decent teal bread line	5	good	Last Available: "2015-12"
-8754	distilled smooth special mirror bark rootbeer	5	awesome	Effect: "Fortunate Resolve", Effect Duration: 50, Last Available: "2015-12"
+8754	smooth special distilled mirror bark rootbeer	5	awesome	Effect: "Fortunate Resolve", Effect Duration: 50, Last Available: "2015-12"
 8755	practically non-alcoholic mediocre ale	1	decent	Last Available: "2015-12"
 8756	blurry plastic Tammy the Tambourine Elf of the storm	0		Maximum MP Percent: +40, Last Available: "2015-12"
 8757	Socratic plastic Rudolph the Red	0		Experience (Mysticality): +1, Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	shaking friendly reindeer hammer	0		Familiar Weight: +3, Last Available: "2015-12"
 8783	Jack Frost's elf ploughshare	0		Cold Spell Damage: +50, Last Available: "2015-12"
 8784	purple circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8677,7 +8677,7 @@
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
 8807	experimental gene therapy	0		Last Available: "2017-01"
-8808	pulsating green ultracoagulator	0		Last Available: "2017-01"
+8808	green pulsating ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	confidence-building hug	0		Last Available: "2017-01"
@@ -8685,9 +8685,9 @@
 8813	wobbly glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	ghostly pulsating bat-bearing	0		Last Available: "2017-01"
-8816	snack-sized flavorless Kudzu salad	2	decent	Last Available: "2016-12"
+8816	flavorless snack-sized Kudzu salad	2	decent	Last Available: "2016-12"
 8817	mixed blue Mansquito Serum	1		Effect: "Red-Shirted Escort", Effect Duration: 25, Last Available: "2016-12"
-8818	artisanal weak bouncing Miss Graves' vermouth	2	super ultra EPIC	Last Available: "2016-12"
+8818	weak artisanal bouncing Miss Graves' vermouth	2	super ultra EPIC	Last Available: "2016-12"
 8819	decent bite-sized The Plumber's mushroom stew	1	good	Last Available: "2016-12"
 8820	pickled blurry The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed tumbling The Mad Liquor	4	EPIC	Last Available: "2016-12"
@@ -8695,7 +8695,7 @@
 8823	stale Mr. Burnsger	4	decent	Last Available: "2016-12"
 8824	powdered bouncing The Inquisitor's unidentifiable object	1		Effect: "Disco Inferno", Effect Duration: 45, Last Available: "2016-12"
 8825	fireproof manspreader's The Jokester's gun of temperance	0		Monster Level: +10, Hot Resistance: +3, Sleaze Resistance: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	avaricious frightening Jim Carey's The Jokester's wig	0		Monster Level: +25, Spooky Damage: +5, Meat Drop: +30, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8826	avaricious frightening Jim Carey's The Jokester's wig	0		Monster Level: +25, Spooky Damage: +5, Meat Drop: +30, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	executive smooth The Jokester's pants of Leguizamo	0		Moxie: +15, Monster Level: +20, Meat Drop: +40, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	adjusted dry Jokester makeup	0		Effect: "The Power of Positive Thinking", Effect Duration: 63, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
@@ -8716,17 +8716,17 @@
 8844	warmed nitrogenated ghostly The Author's inkwell	0		Effect: "Swimming Head", Effect Duration: 50
 8845	energized bag of random words	0		Effect: "Nuts about Candy", Effect Duration: 67
 8846	polymerized tumbling yellow tube of pendulum lube	0		Effect: "Going Ape", Effect Duration: 29
-8847	energized oxidized moist green pulsating red-hot jawbreaker	0		Effect: "Hobo Flavor", Effect Duration: 42
+8847	energized oxidized moist pulsating green red-hot jawbreaker	0		Effect: "Hobo Flavor", Effect Duration: 42
 8848	electrified flattened upside-down question juice	0		Effect: "Violent Night", Effect Duration: 55
 8849	irradiated tube of villain	0		Effect: "Bandersnatched", Effect Duration: 25
 8850	pulsating wool your cowboy boots	0		Cold Resistance: +1, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
-8851	lime green squat inflatable LT&T telegraph office	0		Last Available: "2016-02"
+8851	squat lime green inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	twirling nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
 8854	olive nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
-8857	teal shaking blurry nugget of nicksilver	0		Last Available: "2016-02"
+8857	blurry teal shaking nugget of nicksilver	0		Last Available: "2016-02"
 8858	nugget of ticksilver	0		Last Available: "2016-02"
 8859	blinking Usain Bolt's quicksilver ring	0		Initiative: +80, Single Equip, Last Available: "2016-02"
 8860	MacGyver's razor-sharp thicksilver ring of the storm	0		Weapon Damage Percent: +25, Maximum MP Percent: +40, Maximum MP: +100, Single Equip, Last Available: "2016-02"
@@ -8747,18 +8747,18 @@
 8875	medical-grade occult Shrub's Premium Baked Beans of the storm	0		Spell Damage Percent: +25, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-02"
 8876	normal shaking plate of Heimz Fortified Kidney Beans	3	good	Last Available: "2016-02"
 8877	normal cyan plate of Tesla's Electroplated Beans	3	good	Last Available: "2016-02"
-8878	super-sized special moldy maroon plate of Mixed Garbanzos and Chickpeas	5	crappy	Effect: "Aries Rising", Effect Duration: 35, Last Available: "2016-02"
+8878	special moldy super-sized maroon plate of Mixed Garbanzos and Chickpeas	5	crappy	Effect: "Aries Rising", Effect Duration: 35, Last Available: "2016-02"
 8879	decent plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
-8880	flavorless jumbo fancy plate of Frigid Northern Beans	5	decent	Effect: "Savage Beast Inside", Effect Duration: 50, Last Available: "2016-02"
-8881	stale immense ghostly plate of World's Blackest-Eyed Peas	9	decent	Last Available: "2016-02"
+8880	jumbo flavorless fancy plate of Frigid Northern Beans	5	decent	Effect: "Savage Beast Inside", Effect Duration: 50, Last Available: "2016-02"
+8881	immense stale ghostly plate of World's Blackest-Eyed Peas	9	decent	Last Available: "2016-02"
 8882	spoiled skewed plate of Trader Olaf's Exotic Stinkbeans	3	crappy	Last Available: "2016-02"
 8883	bite-sized flavorless plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Last Available: "2016-02"
-8884	special yummy plate of Val-U Brand Every Bean Salad	3	awesome	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2016-02"
+8884	yummy special plate of Val-U Brand Every Bean Salad	3	awesome	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2016-02"
 8885	adequate plate of Shrub's Premium Baked Beans	3	good	Last Available: "2016-02"
 8886	maroon prompt resourceful Fancy Jeff's pocket square	0		Maximum MP: +50, Adventures: +3, Last Available: "2016-02"
-8887	mirror nippy friendly savvy Daisy's unclean bloomers	0		Mysticality Percent: +20, Familiar Weight: +3, Cold Damage: +10, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	mirror nippy friendly savvy Daisy's unclean bloomers	0		Mysticality Percent: +20, Familiar Weight: +3, Cold Damage: +10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	upside-down Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	greasy frightening Lo Pan's Amoon-Ra Cowtep's nemes	0		Spell Critical Percent: +30, Spooky Damage: +5, Sleaze Spell Damage: +10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	greasy frightening Lo Pan's Amoon-Ra Cowtep's nemes	0		Spell Critical Percent: +30, Spooky Damage: +5, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	spinning censurious lard-coated Sinatra's educational Former Sheriff Dan's tin star of the sweet-tooth	0		Experience: +1, Experience (Moxie): +5, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Candy Drop: +100, Last Available: "2016-02"
 8892	spinning El Vibrato restraints	0		Last Available: "2016-02"
@@ -8766,7 +8766,7 @@
 8894	dog trainer's energetic extremely unsafe Granny Hackleton's Gatling gun	0		Weapon Damage Percent: +100, Maximum MP Percent: +20, Experience (familiar): +1, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
 8896	upside-down cow poker	0		Last Available: "2016-02"
-8897	irradiated squat green poker face paint	0		Effect: "Weather, Man", Effect Duration: 23, Last Available: "2016-02"
+8897	irradiated green squat poker face paint	0		Effect: "Weather, Man", Effect Duration: 23, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	decent	Last Available: "2016-02"
 8900	bouncing gun parts	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	non-modified electrified pickled skewed rattler gland	0		Effect: "Liquidy Smoky", Effect Duration: 27, Last Available: "2016-02"
 8907	moist bouncing tumbling half-digested coal	0		Effect: "Souper Vengeful", Effect Duration: 31, Last Available: "2016-02"
 8908	non-aerosolized modified improved tightly-wound spine	0		Effect: "Ready to Snap", Effect Duration: 53, Last Available: "2016-02"
-8909	spoiled narrow upside-down purple rotting beefsteak	3	crappy	Last Available: "2016-02"
+8909	spoiled upside-down purple narrow rotting beefsteak	3	crappy	Last Available: "2016-02"
 8910	lousy watered-down firemilk	2	decent	Last Available: "2016-02"
 8911	concentrated jittery spidercow eye-cluster	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 33, Last Available: "2016-02"
 8912	diluted moomy dust	1		Last Available: "2016-02"
@@ -8800,7 +8800,7 @@
 8928	cyan disc (yellow)	0		
 8929	ghostly red-hot knucklebone	0		Last Available: "2016-02"
 8930	energized extra-polarized skewed demonic cow's blood	0		Effect: "Chlorophyll Flavor", Effect Duration: 31, Last Available: "2016-02"
-8931	tumbling cyan rinky-dink sixgun	0		Last Available: "2016-02"
+8931	cyan tumbling rinky-dink sixgun	0		Last Available: "2016-02"
 8932	mirror makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	mirror baconstone-handled sixgun	0		Last Available: "2016-02"
@@ -8818,10 +8818,10 @@
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	pulsating thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
-8949	squat tumbling wicksilver spurs	0		Last Available: "2016-02"
+8949	tumbling squat wicksilver spurs	0		Last Available: "2016-02"
 8950	cyan slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
-8952	bouncing skewed nicksilver spurs	0		Last Available: "2016-02"
+8952	skewed bouncing nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
 8954	narrow special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
@@ -8840,24 +8840,24 @@
 8968	squat banded baleful ten-gallon hat	0		Spell Damage: +25, Damage Absorption: +100
 8969	miser's eleven-gallon hat of the pedagogue	0		Experience: +3, Meat Drop: +10
 8970	toy sixgun	0		
-8971	squat fuchsia snake oil	0		
+8971	fuchsia squat snake oil	0		
 8972	quantum irradiated green skin oil	0		Effect: "Rage of the Reindeer", Effect Duration: 14
 8973	denatured unusual oil	0		Effect: "Chock Full o' Nanites", Effect Duration: 64
 8974	liquefied wet eldritch oil	0		Effect: "Yuletide Industry", Effect Duration: 65
 8975	exclusive club	0		
-8976	extra-oxidized ionized altered shaking ghostly patent preventative tonic	0		Effect: "One Foot Heavier", Effect Duration: 56
+8976	extra-oxidized ionized altered ghostly shaking patent preventative tonic	0		Effect: "One Foot Heavier", Effect Duration: 56
 8977	concentrated aerosolized patent invisibility tonic	0		Effect: "Memory of Attractiveness", Effect Duration: 54
 8978	irradiated lime green patent aggression tonic	0		Effect: "Heart Aflame", Effect Duration: 12
 8979	adjusted patent sallowness tonic	0		Effect: "Swimming with Sharks", Effect Duration: 22
 8980	enhanced oxidized patent avarice tonic	0		Effect: "Spring Training", Effect Duration: 36
-8981	super-oxidized chilled quadruple-aerosolized squat twirling patent alacrity tonic	0		Effect: "Melancholy Burden", Effect Duration: 18
+8981	super-oxidized chilled quadruple-aerosolized twirling squat patent alacrity tonic	0		Effect: "Melancholy Burden", Effect Duration: 18
 8982	moist electrified skewed corrupted marrow	0		Effect: "Witch's Brood", Effect Duration: 15
 8983	smooth extra-dry mirror tumbling rodeo whiskey	5	awesome	
 8984	tumbling Thwaitgold scorpion statuette	0		
 8985	tumbling sage real cowboy hat	0		Mysticality Percent: +10
 8986	Memories of Cow Punching	0		Free Pull
 8987	Memories of Beanslinging	0		Free Pull
-8988	jittery twirling Memories of Snake Oiling	0		Free Pull
+8988	twirling jittery Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
@@ -8867,19 +8867,19 @@
 8995	unsweetened Greek fire	0		Effect: "Tearful, Fearful", Effect Duration: 26, Last Available: "2016-03"
 8996	wool foul-smelling clever baleful ox-head shield of Calamity Jane	0		Spell Damage: +25, Maximum MP: +20, Critical Hit Percent: +15, Stench Damage: +10, Cold Resistance: +1, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	ghostly miser's foul-smelling energetic occult dented scepter of extreme caution	0		Spell Damage Percent: +25, Maximum MP Percent: +20, Monster Level: -25, Stench Damage: +10, Meat Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	studded Fonzie's beefcake's very pointy crown of the sewer of the glutton	0		Muscle: +25, Experience (Moxie): +1, Damage Absorption: +80, Stench Damage: +25, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	studded Fonzie's beefcake's very pointy crown of the sewer of the glutton	0		Muscle: +25, Experience (Moxie): +1, Damage Absorption: +80, Stench Damage: +25, Food Drop: +100, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	prompt ribald sharpshooter's Tesla battle broom of bravery	0		Critical Hit Percent: +10, Sleaze Damage: +10, Spooky Resistance: +5, Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	skewed Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	lightning-fast avaricious careful carpe of Flo-Jo	0		Monster Level: -10, Meat Drop: +30, Initiative: 140, Lasts Until Rollover, Last Available: "2016-04"
 9002	yellow greedy medical-grade Newton's codpiece of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
-9003	pulsating Temple Grandin's manspreader's dangerous brainy troutsers	0		Mysticality: +5, Weapon Damage: +10, Monster Level: +10, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	pulsating Temple Grandin's manspreader's dangerous brainy troutsers	0		Mysticality: +5, Weapon Damage: +10, Monster Level: +10, Familiar Weight: +7, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	Usain Bolt's hardy grievous dance instructor's bass clarinet	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +50, Maximum HP: +50, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04"
 9005	blue avaricious frightening stylish thinker's fish hatchet	0		Mysticality: +10, Moxie: +25, Spooky Damage: +5, Meat Drop: +30, Lasts Until Rollover, Last Available: "2016-04"
 9006	blurry horrifying tunac of the bloodbag of mayonnaise of the businessman	0		Maximum HP: +100, Spooky Damage: +25, Sleaze Spell Damage: +50, Meat Drop: +50, Lasts Until Rollover, Last Available: "2016-04"
 9007	squat fishin' pole	0		Last Available: "2016-04"
 9008	deionized dry wriggling worm	0		Effect: "Sizzling with Fury", Effect Duration: 69, Last Available: "2016-04"
-9009	weak hand-crafted bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
-9010	pressed bouncing spinning high-test fishing line	0		Effect: "Tomato Power", Effect Duration: 56, Last Available: "2016-04"
+9009	hand-crafted weak bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
+9010	pressed spinning bouncing high-test fishing line	0		Effect: "Tomato Power", Effect Duration: 56, Last Available: "2016-04"
 9011	wobbly educational fishin' hat	0		Experience: +1, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
 9013	green sonar fishfinder of the businessman	0		Meat Drop: +50, Last Available: "2016-04"
@@ -8899,9 +8899,9 @@
 9027	sharpshooter's brainy First Post shirt - Cir Senam of Gandalf	0		Mysticality: +5, Critical Hit Percent: +10, Spell Critical Percent: +20, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	teal no spoon	0		
-9030	gigantic yummy star salad	8	awesome	
+9030	yummy gigantic star salad	8	awesome	
 9031	Thwaitgold moth statuette	0		
-9032	flavorless thick cyan bowl of Tastee-Wheet&trade;	5	decent	
+9032	thick flavorless cyan bowl of Tastee-Wheet&trade;	5	decent	
 9033	purple Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	moldy browser cookie	3	crappy	Last Available: "2016-06"
@@ -8930,7 +8930,7 @@
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	jittery Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
-9061	bouncing tumbling Source terminal file: pram.ext	0		Last Available: "2016-06"
+9061	tumbling bouncing Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	mirror olive nasty Mr. Screege's spectacles	0		Stench Damage: +5, Single Equip, Last Available: "2016-08"
 9092	hardy steel-toed Spookyraven signet of incineration	0		Damage Reduction: 9, Maximum HP: +50, Hot Spell Damage: +50, Single Equip, Last Available: "2016-08"
 9093	green Van der Graaf fortified tie-dyed fannypack	0		Damage Absorption: +60, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2016-08"
-9094	friendly burnt snowpants of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +3, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9094	friendly burnt snowpants of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +3, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
 9095	upside-down perfumed standards and practices guide	0		Stench Resistance: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	sizzling rock-hard occult Carpathian longsword	0		Spell Damage Percent: +25, Damage Reduction: 5, Hot Damage: +10, Last Available: "2016-08"
 9097	blurry smelly careful Fonzie's Liam's mail	0		Experience (Moxie): +1, Monster Level: -10, Stench Spell Damage: +10, Last Available: "2016-08"
@@ -9007,29 +9007,29 @@
 9135	irresponsibly strong bad very whiskey	10	decent	
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	blinking li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	olive twirling li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	jittery li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	ghostly squat li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	blurry li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	olive twirling li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	jittery li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	squat ghostly li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	blurry li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	super-vacuum-sealed tumbling hoarded candy wad	0		Effect: "Analog Drunk", Effect Duration: 60, Last Available: "2016-10"
 9147	irradiated upside-down narrow Prunets	0		Effect: "Graham Crackling", Effect Duration: 46
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	frozen ionized skewed invisible string	0		Lasts Until Rollover, Effect: "Fizzier Than Light", Effect Duration: 30, Last Available: "2016-10"
 9151	non-galvanized invisible seam ripper	0		Lasts Until Rollover, Effect: "Medieval Mage Mayhem", Effect Duration: 33, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	toothsome raw sweet potato	3	awesome	Last Available: "2016-11"
 9154	yummy huge raw beans	8	awesome	Last Available: "2016-11"
-9155	special miniature moldy raw stuffing	2	crappy	Effect: "Empty Inside", Effect Duration: 40, Last Available: "2016-11"
+9155	moldy special miniature raw stuffing	2	crappy	Effect: "Empty Inside", Effect Duration: 40, Last Available: "2016-11"
 9156	stale small raw cranberry sauce	2	decent	Last Available: "2016-11"
-9157	adequate snack-sized raw turkey	2	good	Last Available: "2016-11"
+9157	snack-sized adequate raw turkey	2	good	Last Available: "2016-11"
 9158	bland raw mincemeat	4	decent	Last Available: "2016-11"
 9159	jumbo flavorless blurry raw potato	5	decent	Last Available: "2016-11"
-9160	small adequate upside-down raw gravy	2	good	Last Available: "2016-11"
+9160	adequate small upside-down raw gravy	2	good	Last Available: "2016-11"
 9161	rotten cyan raw bread	3	crappy	Last Available: "2016-11"
 9162	jittery narrow Sinatra's thinker's mini-marshmallow dispenser	0		Mysticality: +10, Experience (Moxie): +5, Last Available: "2016-11"
 9163	dog trainer's Lo Pan's glass casserole dish of the cougar	0		Moxie: +20, Spell Critical Percent: +30, Experience (familiar): +1, Last Available: "2016-11"
@@ -9041,15 +9041,15 @@
 9169	gravy boat	0		Last Available: "2016-11"
 9170	wobbly bread mold	0		Last Available: "2016-11"
 9171	snack-sized stale mirror sweet potatoes	2	decent	Last Available: "2016-11"
-9172	normal small wobbly bean casserole	2	good	Last Available: "2016-11"
+9172	small normal wobbly bean casserole	2	good	Last Available: "2016-11"
 9173	spoiled miniature baked stuffing	2	crappy	Last Available: "2016-11"
-9174	enchanted bland cranberry cylinder	3	decent	Effect: "Amplified Fabulousness", Effect Duration: 5, Last Available: "2016-11"
+9174	bland enchanted cranberry cylinder	3	decent	Effect: "Amplified Fabulousness", Effect Duration: 5, Last Available: "2016-11"
 9175	bite-sized flavorless yellow thanksgiving turkey	1	decent	Last Available: "2016-11"
-9176	small decent mince pie	2	good	Last Available: "2016-11"
+9176	decent small mince pie	2	good	Last Available: "2016-11"
 9177	tasty tiny blurry mashed potatoes	1	awesome	Last Available: "2016-11"
-9178	moldy special warm gravy	3	crappy	Effect: "Lucky Cat Is Lucky", Effect Duration: 25, Last Available: "2016-11"
+9178	special moldy warm gravy	3	crappy	Effect: "Lucky Cat Is Lucky", Effect Duration: 25, Last Available: "2016-11"
 9179	bland blinking bread roll	3	decent	Last Available: "2016-11"
-9180	spoiled jumbo leftovers	5	crappy	Last Available: "2016-11"
+9180	jumbo spoiled leftovers	5	crappy	Last Available: "2016-11"
 9181	adequate leftovers sandwich	4	good	Last Available: "2016-11"
 9182	wobbly yellow Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9060,11 +9060,11 @@
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
-9191	non-moist dry skewed pulsating eldritch concentrate	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 32, Last Available: "2016-11"
+9191	non-moist dry pulsating skewed eldritch concentrate	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 32, Last Available: "2016-11"
 9192	mediocre watered-down eldritch extract	2	decent	Last Available: "2016-11"
 9193	ruddy steel-toed Official Council Aide Pin	0		Damage Reduction: 9, Maximum HP Percent: +40, Last Available: "2016-11"
-9194	tolerable boozy eldritch distillate	5	good	Last Available: "2016-11"
-9195	diluted upside-down wobbly eldritch essence	1		Last Available: "2016-11"
+9194	boozy tolerable eldritch distillate	5	good	Last Available: "2016-11"
+9195	diluted wobbly upside-down eldritch essence	1		Last Available: "2016-11"
 9196	gray resourceful Science Notebook	0		Maximum MP: +50
 9197	upside-down lion tamer's brainy eldritch hat of the boozehound	0		Mysticality: +5, Experience (familiar): +2, Booze Drop: +100, Last Available: "2016-11"
 9198	gray strapping eldritch pants of the wise owl of the businessman	0		Muscle: +5, Mysticality: +20, Meat Drop: +50, Last Available: "2016-11"
@@ -9089,7 +9089,7 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	normal animal part cracker	4	good	Last Available: "2016-12"
-9220	high-proof enchanted perfectly mixed gingerbread wine	10	EPIC	Effect: "Mutated", Effect Duration: 20, Last Available: "2016-12"
+9220	high-proof perfectly mixed enchanted gingerbread wine	10	EPIC	Effect: "Mutated", Effect Duration: 20, Last Available: "2016-12"
 9221	stale gingerbread mug	3	decent	Last Available: "2016-12"
 9222	rosewater-soaked gingerbread mask	0		Stench Resistance: +3, Last Available: "2016-12"
 9223	Sinatra's Fonzie's gingerservo of the storm	0		Experience (Moxie): 6, Maximum MP Percent: +40, Single Equip, Last Available: "2016-12"
@@ -9123,7 +9123,7 @@
 9251	altered huge Inner Truth	0		Effect: "Nigh-Invincible", Effect Duration: 33, Last Available: "2016-12"
 9252	decent maroon spiritual candy cane	3	good	Last Available: "2016-12"
 9253	drinkable spiritual eggnog	3	good	Last Available: "2016-12"
-9254	small decent spiritual fruitcake	2	good	Last Available: "2016-12"
+9254	decent small spiritual fruitcake	2	good	Last Available: "2016-12"
 9255	adequate spiritual gingerbread	3	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	extra-chilled denatured shaking rock candy	0		Effect: "Tiki Toughness", Effect Duration: 63, Last Available: "2016-12"
-9267	gigantic normal green-iced sweet roll	10	good	Last Available: "2016-12"
+9267	normal gigantic green-iced sweet roll	10	good	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	practically non-alcoholic drinkable chakra-mental wine	1	good	Last Available: "2016-12"
 9277	aerosolized polymerized deionized chakra malt	0		Effect: "Bat Attitude", Effect Duration: 62, Last Available: "2016-12"
 9278	decent bite-sized Black Angus blackburger	1	good	Last Available: "2016-12"
-9279	bad high-proof huge lime green brandy	6	decent	Last Available: "2016-12"
+9279	high-proof bad lime green huge brandy	6	decent	Last Available: "2016-12"
 9280	energized huge lime green potion of spiritual gunkifying	0		Effect: "You Know Who to Call", Effect Duration: 13, Last Available: "2016-12"
 9281	blue Annie Oakley's beefy bad vibroknife	0		Muscle: +10, Critical Hit Percent: +20, Last Available: "2016-12"
 9282	spinning shellacked crystal belt buckle of the brute	0		Muscle Percent: +30, Damage Reduction: 7, Last Available: "2016-12"
@@ -9169,25 +9169,25 @@
 9297	super-sized rotten toast with hot jelly	5	crappy	Last Available: "2017-01"
 9298	moldy shaking toast with jelly	3	crappy	Last Available: "2017-01"
 9299	bland blue toast with jelly	3	decent	Last Available: "2017-01"
-9300	adequate tiny toast with sleaze jelly	1	good	Last Available: "2017-01"
+9300	tiny adequate toast with sleaze jelly	1	good	Last Available: "2017-01"
 9301	moldy toast with stench jelly	3	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	wobbly pewter candlestick	0		Familiar Weight: +10
 9305	ghostly chilly groovy wax hand	0		Moxie Percent: +10, Cold Damage: +5, Last Available: "2017-01"
 9306	smelly candle of the glutton	0		Stench Spell Damage: +10, Food Drop: +100, Lasts Until Rollover, Last Available: "2017-01"
-9307	low-calorie delicious wax pancake	1	awesome	Last Available: "2017-01"
+9307	delicious low-calorie wax pancake	1	awesome	Last Available: "2017-01"
 9308	squat arcane researcher's wax face of chilblains	0		Experience Percent (Mysticality): +10, Cold Damage: +25, Last Available: "2017-01"
 9309	watered-down bad blinking wax booze	2	decent	Last Available: "2017-01"
 9310	tumbling glob of melted wax	0		Last Available: "2017-01"
-9311	dried shaking bouncing sea jelly	1		Effect: "Berry Statistical", Effect Duration: 5, Last Available: "2017-01"
+9311	dried bouncing shaking sea jelly	1		Effect: "Berry Statistical", Effect Duration: 5, Last Available: "2017-01"
 9312	flavorless gigantic pulsating blinking sea truffle	6	decent	Last Available: "2017-01"
 9313	bouncing tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	shaking bouncing recovered cufflinks of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2017-01"
 9316	red heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	modified liquefied LOV Elixir #3	0		Effect: "Fastbreaker", Effect Duration: 66, Last Available: "2017-02"
-9318	ionized ionized concentrated skewed pulsating LOV Elixir #6	0		Effect: "Patent Alacrity", Effect Duration: 13, Last Available: "2017-02"
+9318	ionized ionized concentrated pulsating skewed LOV Elixir #6	0		Effect: "Patent Alacrity", Effect Duration: 13, Last Available: "2017-02"
 9319	tarnished anodized tarnished blurry LOV Elixir #9	0		Effect: "Buzzard Breath", Effect Duration: 55, Last Available: "2017-02"
 9320	fuchsia frightening Tesla beefy LOV Eardigan	0		Muscle: +10, Spooky Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2017-02"
 9321	teal flame-wreathed mansplainer's veiny LOV Epaulettes	0		Maximum HP: +10, Monster Level: +15, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2017-02"
@@ -9203,7 +9203,7 @@
 9331	jittery stanky hardy eldritch hammer of wisdom	0		Mysticality: +15, Maximum HP: +50, Stench Spell Damage: +25, Last Available: "2017-01"
 9332	stale eldritch mushroom	3	decent	Last Available: "2017-03"
 9333	upside-down eldritch ichor	0		
-9334	spoiled small eldritch mushroom pizza	2	crappy	Last Available: "2017-03"
+9334	small spoiled eldritch mushroom pizza	2	crappy	Last Available: "2017-03"
 9335	squat eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	huge eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	electrified narrow eldritch rub	0		Effect: "critical.enh", Effect Duration: 36, Last Available: "2017-02"
@@ -9235,38 +9235,38 @@
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	delicious literal grasshopper	3	awesome	Last Available: "2017-03"
-9366	boozy lousy special jittery double entendre	5	decent	Effect: "Yeah, It's Just Gasoline", Effect Duration: 50, Last Available: "2017-03"
-9367	enchanted weak lousy Phlegethon	2	decent	Effect: "Fishy Fortification", Effect Duration: 15, Last Available: "2017-03"
+9366	special lousy boozy jittery double entendre	5	decent	Effect: "Yeah, It's Just Gasoline", Effect Duration: 50, Last Available: "2017-03"
+9367	weak enchanted lousy Phlegethon	2	decent	Effect: "Fishy Fortification", Effect Duration: 15, Last Available: "2017-03"
 9368	aged narrow Siberian sunrise	4	awesome	Last Available: "2017-03"
 9369	lousy cyan mentholated wine	4	decent	Last Available: "2017-03"
 9370	perfectly mixed twirling low tide martini	4	EPIC	Last Available: "2017-03"
-9371	drinkable strong shroomtini	5	good	Last Available: "2017-03"
+9371	strong drinkable shroomtini	5	good	Last Available: "2017-03"
 9372	lousy purple morning dew	3	decent	Last Available: "2017-03"
 9373	fortified delicious gray whiskey squeeze	5	awesome	Last Available: "2017-03"
 9374	hand-crafted high-proof great fashioned	6	EPIC	Last Available: "2017-03"
 9375	delicious fancy Gnomish sagngria	3	awesome	Effect: "Prideful Strut", Effect Duration: 15, Last Available: "2017-03"
 9376	bad gray blurry vodka stinger	3	decent	Last Available: "2017-03"
-9377	watered-down hand-crafted extremely slippery nipple	2	EPIC	Last Available: "2017-03"
+9377	hand-crafted watered-down extremely slippery nipple	2	EPIC	Last Available: "2017-03"
 9378	tolerable fancy piscatini	3	good	Effect: "Expert Vacationer", Effect Duration: 45, Last Available: "2017-03"
 9379	aged Churchill	3	awesome	Last Available: "2017-03"
-9380	bad special green soilzerac	4	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 35, Last Available: "2017-03"
+9380	special bad green soilzerac	4	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 35, Last Available: "2017-03"
 9381	mediocre London frog	4	decent	Last Available: "2017-03"
 9382	lousy twirling nothingtini	3	decent	Last Available: "2017-03"
-9383	bad ghostly jittery eighth plague	3	decent	Last Available: "2017-03"
+9383	bad jittery ghostly eighth plague	3	decent	Last Available: "2017-03"
 9384	delicious fuchsia single entendre	3	awesome	Last Available: "2017-03"
 9385	perfectly mixed red reverse Tantalus	4	EPIC	Last Available: "2017-03"
 9386	weak fancy bad mirror bouncing elemental caipiroska	2	decent	Effect: "Sated and Furious", Effect Duration: 20, Last Available: "2017-03"
-9387	bad weak Feliz Navidad	2	decent	Last Available: "2017-03"
+9387	weak bad Feliz Navidad	2	decent	Last Available: "2017-03"
 9388	tolerable pulsating Bloody Nora	4	good	Last Available: "2017-03"
 9389	aged skewed moreltini	3	awesome	Last Available: "2017-03"
 9390	watered-down hand-crafted hell in a bucket	2	EPIC	Last Available: "2017-03"
 9391	tolerable Newark	3	good	Last Available: "2017-03"
 9392	hand-crafted wobbly R'lyeh	3	EPIC	Last Available: "2017-03"
 9393	lousy blurry Gnollish sangria	3	decent	Last Available: "2017-03"
-9394	perfectly mixed weak blurry vodka barracuda	2	EPIC	Last Available: "2017-03"
+9394	weak perfectly mixed blurry vodka barracuda	2	EPIC	Last Available: "2017-03"
 9395	acceptable twirling Mysterious Island iced tea	4	good	Last Available: "2017-03"
-9396	tolerable triple-distilled blurry gray drive-by shooting	10	good	Last Available: "2017-03"
-9397	extra-dry drinkable gunner's daughter	5	good	Last Available: "2017-03"
+9396	triple-distilled tolerable gray blurry drive-by shooting	10	good	Last Available: "2017-03"
+9397	drinkable extra-dry gunner's daughter	5	good	Last Available: "2017-03"
 9398	drinkable practically non-alcoholic dirt julep	1	good	Last Available: "2017-03"
 9399	acceptable fancy Simepore slime	3	good	Effect: "Helping Comes Second", Effect Duration: 35, Last Available: "2017-03"
 9400	tolerable Phil Collins	4	good	Last Available: "2017-03"
@@ -9335,7 +9335,7 @@
 9463	cyan skewed Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	jittery Spacegate	0		Last Available: "2017-04"
-9466	yummy small bouncing Aldebaran sardines	2	awesome	Last Available: "2017-04"
+9466	small yummy bouncing Aldebaran sardines	2	awesome	Last Available: "2017-04"
 9467	perfectly mixed Centauri fish wine	3	EPIC	Last Available: "2017-04"
 9468	dehydrated shaking narrow oxygen	1		Last Available: "2017-04"
 9469	yellow nippy Spacegate scientist's insignia of mayonnaise	0		Cold Damage: +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-04"
@@ -9364,7 +9364,7 @@
 9492	shaking suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	chaotic wholesome wicked Kremlin's Greatest Briefcase	0		Spell Damage: +5, Maximum HP Percent: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	bad ghostly basic martini	3	decent	Last Available: "2017-06"
-9495	aged weak blinking improved martini	2	awesome	Last Available: "2017-06"
+9495	weak aged blinking improved martini	2	awesome	Last Available: "2017-06"
 9496	acceptable splendid martini	3	good	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9380,7 +9380,7 @@
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
 9510	cyan Dust bunny	0		
-9511	huge spinning Pocket Meteor Guide	0		Last Available: "2017-08"
+9511	spinning huge Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	purple wobbly Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	pulsating teal Meteorite-Ade	0		Last Available: "2017-08"
 9514	rotten meteoreo	4	crappy	Last Available: "2017-08"
@@ -9388,7 +9388,7 @@
 9516	meteoroid	0		Last Available: "2017-08"
 9517	Usain Bolt's Jim Carey's meteortarboard of the glutton	0		Monster Level: +25, Food Drop: +100, Initiative: +80, Last Available: "2017-08"
 9518	jittery blue Temple Grandin's coward's sage meteorite guard	0		Mysticality Percent: +10, Monster Level: -20, Familiar Weight: +7, Damage Reduction: 9, Last Available: "2017-08"
-9519	strapping meteorb of the sweet-tooth	0		Muscle: +5, Candy Drop: +100, Last Available: "2017-08", Lantern Element: "Hot"
+9519	strapping meteorb of the sweet-tooth	0		Muscle: +5, Candy Drop: +100, Lantern Element: "Hot", Last Available: "2017-08"
 9520	auspicious asteroid belt of Flo-Jo	0		Item Drop: +10, Initiative: +100, Single Equip, Last Available: "2017-08"
 9521	reassuring veiny meteorthopedic shoes of the cheetah	0		Maximum HP: +10, Spooky Resistance: +1, Initiative: +60, Single Equip, Last Available: "2017-08"
 9522	stanky smelly steel-toed shooting morning star	0		Damage Reduction: 9, Stench Spell Damage: 35, Single Equip, Last Available: "2017-08"
@@ -9418,7 +9418,7 @@
 9546	clever fortified mafia pinky ring	0		Damage Absorption: +60, Maximum MP: +20, Single Equip
 9547	perfectly mixed flask of port	4	EPIC	
 9548	mansplainer's contract enforcement stick of chilblains	0		Monster Level: +15, Cold Damage: +25
-9549	low-calorie decent squat Hide-rox&trade; cookie	1	good	Last Available: "2017-10"
+9549	decent low-calorie squat Hide-rox&trade; cookie	1	good	Last Available: "2017-10"
 9550	drinkable jug of booze	3	good	Last Available: "2017-10"
 9551	liquefied triple-dry purple pair of candy glasses	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 17, Last Available: "2017-10"
 9552	magnetized non-corrupted red temporary X tattoos	0		Effect: "Greasy Visage", Effect Duration: 34, Last Available: "2017-10"
@@ -9448,7 +9448,7 @@
 9576	thinker's mafia organizer badge	0		Mysticality: +10, Single Equip
 9577	mafia filofax	0		
 9578	bouncing transparent nog	1	good	Last Available: "2017-12"
-9579	stale big blinking unfinished fruitcake	5	decent	Last Available: "2017-12"
+9579	big stale blinking unfinished fruitcake	5	decent	Last Available: "2017-12"
 9580	non-altered red and cracker	0		Effect: "Hood Ridin'", Effect Duration: 43, Last Available: "2017-12"
 9581	fancy hand-crafted ghostly neg grog	3	EPIC	Effect: "For Your Brain Only", Effect Duration: 40, Last Available: "2017-12"
 9582	stale half double fruitcake	3	decent	Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	ionized wishbone	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 16, Last Available: "2017-11"
 9595	mediocre Racisto Ruidoso	4	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	yummy fancy shaking bran muffin	3	awesome	Effect: "Cock of the Walk", Effect Duration: 30
+9597	fancy yummy shaking bran muffin	3	awesome	Effect: "Cock of the Walk", Effect Duration: 30
 9598	rotten tumbling bouncing blueberry muffin	4	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	blue silent B	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	yellow warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	practically non-alcoholic artisanal stale cheer wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
-9630	flavorless miniature stale Cheer-E-Os	2	decent	Last Available: "2017-12"
+9630	miniature flavorless stale Cheer-E-Os	2	decent	Last Available: "2017-12"
 9631	blinking cheer-o-gram	0		Last Available: "2017-12"
 9632	censurious cheerful antler hat of the boozehound	0		Sleaze Resistance: +3, Booze Drop: +100, Last Available: "2017-12"
 9633	Sherlock's frosty cheerful Crimbo sweater	0		Cold Spell Damage: +10, Item Drop: +25, Last Available: "2017-12"
@@ -9517,7 +9517,7 @@
 9645	yellow The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	mirror The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	lousy watered-down gray executive mime flask	2	decent	Last Available: "2017-12"
+9648	watered-down lousy gray executive mime flask	2	decent	Last Available: "2017-12"
 9649	moldy nega-mushroom	3	crappy	Last Available: "2017-12"
 9650	hand-crafted nega-mushroom wine	4	EPIC	Last Available: "2017-12"
 9651	polarized polymerized concentrated Cheer-Up soda	0		Effect: "Well-Oiled", Effect Duration: 63, Last Available: "2017-12"
@@ -9536,22 +9536,22 @@
 9664	donated candy	0		
 9665	electrified narrow digital honeypot	0		Effect: "Piratastic", Effect Duration: 50, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	narrow tumbling Socratic mime army insignia (infantry)	0		Experience (Mysticality): +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	mime army insignia (intelligence) of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	Rosewater's mime army insignia (espionage)	0		Mysticality Percent: +30, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	narrow tumbling Socratic mime army insignia (infantry)	0		Experience (Mysticality): +1, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	mime army insignia (intelligence) of the boozehound	0		Booze Drop: +100, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	Rosewater's mime army insignia (espionage)	0		Mysticality Percent: +30, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	twirling mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
-9674	blurry olive mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
+9674	olive blurry mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	greasy smartaleck's mime army infiltration glove	0		Moxie Percent: +30, Sleaze Spell Damage: +10, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
 9677	wobbly mime army challenge coin	0		Last Available: "2017-12"
 9678	twirling cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	narrow fireproof skip lid	0		Familiar Weight: +5
-9681	snack-sized spoiled extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
-9682	watered-down drinkable wobbly mulled hobo wine	2	good	Last Available: "2018-12"
+9681	spoiled snack-sized extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
+9682	drinkable watered-down wobbly mulled hobo wine	2	good	Last Available: "2018-12"
 9683	bouncing burning newspaper	0		Last Available: "2018-12"
 9684	skewed coward's sharpshooter's burning paper hat of Leguizamo	0		Critical Hit Percent: +10, Monster Level: 0, Lasts Until Rollover, Last Available: "2018-12"
 9685	occult dance instructor's burning cape of the cheetah	0		Experience Percent (Moxie): +10, Spell Damage Percent: +25, Initiative: +60, Lasts Until Rollover, Last Available: "2018-12"
@@ -9567,7 +9567,7 @@
 9695	red executive grievous silent nightlight of Gandalf of temperance	0		Weapon Damage Percent: +50, Spell Critical Percent: +20, Sleaze Resistance: +5, Meat Drop: +40
 9696	double-improved concentrated sweetened reindeer fat	0		Effect: "El Vibrations", Effect Duration: 57
 9697	polarized mirror lime green Good 'n' Quiet	0		Effect: "Badger Underfoot", Effect Duration: 64
-9698	electrified lime green shaking hot button candy	0		Effect: "Oriental Mysticism", Effect Duration: 40
+9698	electrified shaking lime green hot button candy	0		Effect: "Oriental Mysticism", Effect Duration: 40
 9699	twirling censurious Annie Oakley's makeshift garbage shirt of the sweet-tooth	0		Critical Hit Percent: +20, Sleaze Resistance: +3, Candy Drop: +100, Last Available: "2018-01"
 9700	jittery electrified dance instructor's novelty monorail ticket	0		Experience Percent (Moxie): +10, MP Regen Min: 3, MP Regen Max: 5
 9701	twisted mirror pills	1		Effect: "Bureaucratized", Effect Duration: 20
@@ -9576,7 +9576,7 @@
 9704	altered blue twirling excitement pill	1		Effect: "Human-Human Hybrid", Effect Duration: 30
 9705	boiled jittery vitamin G pill	1		Effect: "Third Based", Effect Duration: 10
 9706	diluted tumbling lucky-ish pill	1		
-9707	twisted pulsating shaking dieting pill	1		
+9707	twisted shaking pulsating dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	green How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	olive wobbly Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
@@ -9593,9 +9593,9 @@
 9725	frightening stanky psychic's pslacks	0		Stench Spell Damage: +25, Spooky Damage: +5, Last Available: "2018-02"
 9726	twirling fortified personal trainer's psychic's amulet	0		Experience Percent (Muscle): +10, Damage Absorption: +60, Last Available: "2018-02"
 9727	stale heart-shaped candy whetstone	3	decent	Last Available: "2018-02"
-9728	half-sized rotten Swedish massage fish	2	crappy	Last Available: "2018-02"
+9728	rotten half-sized Swedish massage fish	2	crappy	Last Available: "2018-02"
 9729	artisanal blinking Third Base	4	EPIC	Last Available: "2018-02"
-9730	spirit-forward fancy delicious Bustle Hustler	5	awesome	Effect: "Concentrated Concentration", Effect Duration: 35, Last Available: "2018-02"
+9730	fancy spirit-forward delicious Bustle Hustler	5	awesome	Effect: "Concentrated Concentration", Effect Duration: 35, Last Available: "2018-02"
 9731	super-wet Fabiotion	0		Effect: "Painted-On Bikini", Effect Duration: 48, Last Available: "2018-02"
 9732	triple-unsweetened Bettie page	0		Effect: "Slimily Strong", Effect Duration: 37, Last Available: "2018-02"
 9733	tarnished unsweetened green tonic o' Banderas	0		Effect: "Human-Machine Hybrid", Effect Duration: 39, Last Available: "2018-02"
@@ -9631,7 +9631,7 @@
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	bouncing Sledgehamster	0		Last Available: "2018-03"
-9766	narrow twirling Pimpsqueak	0		Last Available: "2018-03"
+9766	twirling narrow Pimpsqueak	0		Last Available: "2018-03"
 9767	red Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	narrow Sequestrian	0		Last Available: "2018-03"
@@ -9643,7 +9643,7 @@
 9775	Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	fuchsia Aiolion	0		Last Available: "2018-03"
-9778	tumbling red Waifuton	0		Last Available: "2018-03"
+9778	red tumbling Waifuton	0		Last Available: "2018-03"
 9779	Gorillape	0		Last Available: "2018-03"
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	Snoutlet	0		Last Available: "2018-03"
@@ -9667,7 +9667,7 @@
 9799	Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	teal Vulgure	0		Last Available: "2018-03"
-9802	huge jittery Squib	0		Last Available: "2018-03"
+9802	jittery huge Squib	0		Last Available: "2018-03"
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
@@ -9687,7 +9687,7 @@
 9819	Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
-9822	maroon spinning shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9822	spinning maroon shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	fuchsia muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	fuchsia amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9712,7 +9712,7 @@
 9844	FantasyRealm key	0		Last Available: "2018-04"
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	narrow blurry tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
-9847	green mirror Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
+9847	mirror green Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	ghostly LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
 9850	bouncing My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
@@ -9730,22 +9730,22 @@
 9862	small yummy FantasyRealm turkey leg	2	awesome	Last Available: "2018-04"
 9863	watered-down tolerable FantasyRealm mead	2	good	Last Available: "2018-04"
 9864	ghostly nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
-9865	huge ghostly Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
+9865	ghostly huge Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	bouncing hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	wobbly grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	delicious super-sized druidic s'more	5	awesome	Last Available: "2018-04"
+9869	super-sized delicious druidic s'more	5	awesome	Last Available: "2018-04"
 9870	modified squat sachet of powder	1		Last Available: "2018-04"
-9871	watered-down acceptable twirling mourning wine	2	good	Last Available: "2018-04"
+9871	acceptable watered-down twirling mourning wine	2	good	Last Available: "2018-04"
 9872	upside-down sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
-9874	blurry blue map to the Mystic Wood	0		Last Available: "2018-04"
-9875	teal blinking map to the Putrid Swamp	0		Last Available: "2018-04"
+9874	blue blurry map to the Mystic Wood	0		Last Available: "2018-04"
+9875	blinking teal map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	upside-down map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless denastified haunch	3	decent	Last Available: "2018-04"
 9879	practically non-alcoholic acceptable wobbly bad rum and good cola	1	good	Last Available: "2018-04"
-9880	denatured green ghostly Potion of Heroism	0		Effect: "Wreathed in Smoke", Effect Duration: 45, Last Available: "2018-04"
+9880	denatured ghostly green Potion of Heroism	0		Effect: "Wreathed in Smoke", Effect Duration: 45, Last Available: "2018-04"
 9881	perfumed supercool leggings of the Spider Queen of the pedagogue	0		Moxie Percent: +20, Experience: +3, Stench Resistance: +5, Last Available: "2018-04"
 9882	crafty Fonzie's Herculean Master Thief's utility belt	0		Experience (Muscle): +1, Experience (Moxie): +1, Maximum MP: +10, Single Equip, Last Available: "2018-04"
 9883	lime green spinning tumbling prompt auspicious Tesla Duke Vampire's regal cloak	0		Item Drop: +10, Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	drinkable spirit-forward mirror two meat muck	5	good	
+9898	spirit-forward drinkable mirror two meat muck	5	good	
 9899	moldy chocolate Ogre Chieftain	3	crappy	
 9900	diet toothsome chocolate &quot;Phoenix&quot;	1	awesome	
 9901	normal pulsating chocolate Spider Queen	4	good	
 9902	hand-crafted weak hipster cocktail	2	EPIC	
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	bouncing wobbly God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	bouncing wobbly God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	shaking G	0		
 9910	Garland of Greatness	0		
@@ -9783,7 +9783,7 @@
 9915	super-sized stale jittery good guava	5	decent	
 9916	acceptable gin and ginger	3	good	
 9917	Thwaitgold chigger statuette	0		
-9918	pickled ghostly blinking gaseous gravy	1		Effect: "Egg-cellent Vocabulary", Effect Duration: 10
+9918	pickled blinking ghostly gaseous gravy	1		Effect: "Egg-cellent Vocabulary", Effect Duration: 10
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
@@ -9832,12 +9832,12 @@
 9964	family-friendly noticeable pumps of horror	0		Spooky Spell Damage: +25, Sleaze Resistance: +1, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
 9966	lousy pulsating everfull glass	4		Last Available: "2018-09"
-9967	gray bouncing van key	0		Last Available: "2018-09"
+9967	bouncing gray van key	0		Last Available: "2018-09"
 9968	olive jam band bootleg	0		Last Available: "2018-09"
 9969	lard-coated cool denim jacket	0		Moxie: +5, Sleaze Spell Damage: +25, Last Available: "2018-09"
 9970	wool weightlifter's ratty knitted cap	0		Muscle: +15, Cold Resistance: +1, Last Available: "2018-09"
 9972	miser's Fonzie's intimidating chainsaw	0		Experience (Moxie): +1, Meat Drop: +10, Lasts Until Rollover, Last Available: "2018-09"
-9973	fortified drinkable party beer bomb	5	good	Last Available: "2018-09"
+9973	drinkable fortified party beer bomb	5	good	Last Available: "2018-09"
 9974	rotten sweet party mix	3	crappy	Last Available: "2018-09"
 9975	mixed twirling narrow party balloon	1		Last Available: "2018-09"
 9976	healthy experienced party pants	0		Experience: +2, Maximum HP Percent: +20, Last Available: "2018-09"
@@ -9848,7 +9848,7 @@
 9981	modified Party-in-a-Can&trade;	1		Effect: "Egg-cellent Vocabulary", Effect Duration: 5, Last Available: "2018-09"
 9982	tumbling party pup	0		Last Available: "2018-09"
 9983	ruddy party crasher of the brute	0		Muscle Percent: +30, Maximum HP Percent: +40, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	blue Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	blue Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	twirling Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	fuchsia party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
@@ -9866,7 +9866,7 @@
 9999	chaotic MacGyver's slime waders of the detective	0		Maximum MP: +100, Spell Critical Percent: +10, Item Drop: +20, Last Available: "2018-11"
 10001	family-friendly wool Annie Oakley's slime fedora	0		Critical Hit Percent: +20, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2018-11"
 10002	shaking skewed blinking wicked smartaleck's slime knuckles of the early riser	0		Moxie Percent: +30, Spell Damage: +5, Adventures: +7, Last Available: "2018-11"
-10003	blurry upside-down government requisition form	0		Last Available: "2018-11"
+10003	upside-down blurry government requisition form	0		Last Available: "2018-11"
 10004	red chilly smooth weightlifter's government-issued slacks	0		Muscle: +15, Moxie: +15, Cold Damage: +5, Last Available: "2018-11"
 10005	blinking tumbling Jeselnik's stanky Sinatra's government-issued eyeshade	0		Experience (Moxie): +5, Stench Spell Damage: +25, Sleaze Damage: +25, Last Available: "2018-11"
 10006	inspector's Sinatra's beefy government-issued necktie	0		Muscle: +10, Experience (Moxie): +5, Item Drop: +15, Single Equip, Last Available: "2018-11"
@@ -9886,8 +9886,8 @@
 10020	bad distilled twice-haunted screwdriver	5	decent	Last Available: "2018-11"
 10021	small flavorless candy cane	2	decent	Last Available: "2018-12"
 10022	acceptable triple-distilled olive runny fermented egg	9	good	Last Available: "2018-12"
-10023	enchanted tiny normal cyan oldcake	1	good	Effect: "The Real Deal", Effect Duration: 25, Last Available: "2018-12"
-10024	super-sized moldy traditional Crimbo cookie	5	crappy	Last Available: "2023-06"
+10023	normal tiny enchanted cyan oldcake	1	good	Effect: "The Real Deal", Effect Duration: 25, Last Available: "2018-12"
+10024	moldy super-sized traditional Crimbo cookie	5	crappy	Last Available: "2023-06"
 10025	personal trainer's plastic wild beaver	0		Experience Percent (Muscle): +10, Last Available: "2018-12"
 10026	stylish plastic reindeer	0		Moxie: +25, Last Available: "2018-12"
 10027	smartaleck's plastic Caf&eacute; Elf	0		Moxie Percent: +30, Last Available: "2018-12"
@@ -9907,14 +9907,14 @@
 10041	family-friendly balanced antler	0		Sleaze Resistance: +1, Last Available: "2018-12"
 10042	dam of the empath	0		Familiar Weight: +5, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted practically non-alcoholic beavermouth	1	EPIC	Last Available: "2018-12"
-10044	practically non-alcoholic perfectly mixed upside-down beaver punch (papaya)	1	super ultra mega EPIC	Last Available: "2018-12"
+10044	perfectly mixed practically non-alcoholic upside-down beaver punch (papaya)	1	super ultra mega EPIC	Last Available: "2018-12"
 10045	tolerable beaver punch (peach)	4	good	Last Available: "2018-12"
 10046	perfectly mixed wobbly spinning beaver punch (cherry)	3	EPIC	Last Available: "2018-12"
 10047	lard-coated chaotic Canadian lantern	0		Spell Critical Percent: +10, Sleaze Spell Damage: +25, Last Available: "2018-12"
 10048	huge muskox-skin cap of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2018-12"
 10049	pulsating Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	rotten huge glass of raw eggs	7	crappy	Last Available: "2018-12"
-10051	bad fancy punch-drunk punch	3	decent	Effect: "Pride of the Vampire", Effect Duration: 5, Last Available: "2018-12"
+10051	fancy bad punch-drunk punch	3	decent	Effect: "Pride of the Vampire", Effect Duration: 5, Last Available: "2018-12"
 10052	diluted jittery mirror body spradium	1		Effect: "Destructive Resolve", Effect Duration: 30, Last Available: "2018-12"
 10053	jittery Samson's bauxite beret	0		Experience (Muscle): +5, Last Available: "2018-12"
 10054	bauxite boxers of courage	0		Spooky Resistance: +3, Last Available: "2018-12"
@@ -9931,9 +9931,9 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	lousy beer	4	decent	Last Available: "2018-12"
 10067	bland yule gruel	4	decent	Last Available: "2018-12"
-10068	boozy drinkable hot watered rum	5	good	Last Available: "2018-12"
-10069	delicious boozy shaking bottle of Crimbognac	5	awesome	Last Available: "2018-12"
-10070	spoiled special super-sized Crimboysters Rockefeller	5	crappy	Effect: "Healthy Blue Glow", Effect Duration: 10, Last Available: "2018-12"
+10068	drinkable boozy hot watered rum	5	good	Last Available: "2018-12"
+10069	boozy delicious shaking bottle of Crimbognac	5	awesome	Last Available: "2018-12"
+10070	special super-sized spoiled Crimboysters Rockefeller	5	crappy	Effect: "Healthy Blue Glow", Effect Duration: 10, Last Available: "2018-12"
 10071	denatured Crimbeau de toilette	1		Effect: "Irresistible Resolve", Effect Duration: 15, Last Available: "2018-12"
 10072	olive Crimbo candle	0		Last Available: "2018-12"
 10073	narrow Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -10013,7 +10013,7 @@
 10147	narrow red-and-green microcamera	0		Familiar Weight: +5
 10148	beefcake's cobbled-together Meat detector	0		Muscle: +25, Lasts Until Rollover, Last Available: "2019-12"
 10149	triple-denatured extra-tarnished teal tin thermos of chai	0		Effect: "Frost Tea", Effect Duration: 42, Last Available: "2019-12"
-10150	altered red pulsating prototype stimulant	1		Last Available: "2019-12"
+10150	altered pulsating red prototype stimulant	1		Last Available: "2019-12"
 10151	squat electrified tailored vest	0		MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-12"
 10152	blinking sew-on bandage	0		Last Available: "2019-12"
 10153	tumbling really nice net	0		Last Available: "2019-12"
@@ -10021,7 +10021,7 @@
 10155	yummy small elf army field rations	2	awesome	Last Available: "2019-12"
 10156	ghostly gingernade	0		Last Available: "2019-12"
 10157	shellacked discarded bowtie of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2019-12"
-10158	hand-crafted practically non-alcoholic martiny	1	EPIC	Last Available: "2019-12"
+10158	practically non-alcoholic hand-crafted martiny	1	EPIC	Last Available: "2019-12"
 10159	narrow tryptophan dart	0		Last Available: "2019-12"
 10160	energized unsweetened colloidal purple licorice snake	0		Effect: "Human-Horror Hybrid", Effect Duration: 28
 10161	anodized electrified blue virgin jello shot	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 60
@@ -10044,7 +10044,7 @@
 10179	flavorless plain snowcone	4	decent	
 10180	squat Booke of Vampyric Knowledge	0		
 10181	jittery money bag	0		
-10182	upside-down spinning money bag	0		
+10182	spinning upside-down money bag	0		
 10183	bouncing money bag	0		
 10184	Thwaitgold mosquito statuette	0		
 10185	bucket of Vampyre blood	0		
@@ -10065,7 +10065,7 @@
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	special aged bottle of dark rhum	4	awesome	Effect: "Red-Shirted Escort", Effect Duration: 30, Last Available: "2019-04"
 10202	weak acceptable wobbly bottle of extra-dark rhum	2	good	Last Available: "2019-04"
-10203	perfectly mixed triple-distilled fancy bottle of super-extra-dark rhum	6	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 40, Last Available: "2019-04"
+10203	triple-distilled fancy perfectly mixed bottle of super-extra-dark rhum	6	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 40, Last Available: "2019-04"
 10204	adjusted ionized fuchsia pirate shaving cream	0		Effect: "Grape Expectations", Effect Duration: 42, Last Available: "2019-04"
 10205	reassuring greasy conquistador's breastplate	0		Sleaze Spell Damage: +10, Spooky Resistance: +1, Last Available: "2019-04"
 10206	blurry pirate pantaloons of horror of temperance	0		Spooky Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2019-04"
@@ -10095,7 +10095,7 @@
 10230	pulsating flame-retardant Oprah's piratical blunderbuss	0		Maximum MP Percent: +50, Hot Resistance: +1, Last Available: "2019-04"
 10231	mirror brawny PirateRealm party hat of Calamity Jane of the empath	0		Muscle Percent: +20, Critical Hit Percent: +15, Familiar Weight: +5, Last Available: "2019-04"
 10232	perfectly mixed huge Island Landslide	3	EPIC	Last Available: "2019-04"
-10233	practically non-alcoholic smooth Island Thunderstorm	1	awesome	Last Available: "2019-04"
+10233	smooth practically non-alcoholic Island Thunderstorm	1	awesome	Last Available: "2019-04"
 10234	perfectly mixed Island Hurricane	4	EPIC	Last Available: "2019-04"
 10235	bad Skull Punch	3	decent	Last Available: "2019-04"
 10236	drinkable weak maroon Electric Punch	2	good	Last Available: "2019-04"
@@ -10132,7 +10132,7 @@
 10267	enhanced cyan seashell	0		Effect: "Insulated Trousers", Effect Duration: 28, Last Available: "2019-07"
 10268	unsweetened denatured gray seashell	0		Effect: "Memory of Attractiveness", Effect Duration: 17, Last Available: "2019-07"
 10269	oxidized seashell	0		Effect: "Happy Salamander", Effect Duration: 11, Last Available: "2019-07"
-10270	adjusted shaking pulsating seashell	0		Effect: "Tremella Tremens", Effect Duration: 68, Last Available: "2019-07"
+10270	adjusted pulsating shaking seashell	0		Effect: "Tremella Tremens", Effect Duration: 68, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
 10272	fancy hand-crafted bottle of sea wine	4	EPIC	Effect: "Influence of Sphere", Effect Duration: 5, Last Available: "2019-07"
 10273	vaporized spinning kelp	1		Effect: "The Moxie of LOV", Effect Duration: 40, Last Available: "2019-07"
@@ -10142,8 +10142,8 @@
 10277	jittery foul-smelling fortified smartaleck's waders	0		Moxie Percent: +30, Damage Absorption: +60, Stench Damage: +10, Last Available: "2019-07"
 10278	blurry purple electrified strapping spearfish fishing spear of the brazier	0		Muscle: +5, Hot Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-07"
 10279	veiny Herculean rabbitfish fin of terror	0		Experience (Muscle): +1, Maximum HP: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2019-07"
-10280	bouncing teal piece of coral	0		Last Available: "2019-07"
-10281	gray bouncing piece of driftwood	0		Last Available: "2019-07"
+10280	teal bouncing piece of coral	0		Last Available: "2019-07"
+10281	bouncing gray piece of driftwood	0		Last Available: "2019-07"
 10282	squat zippy Jack Frost's therapeutic pirate cutlass	0		Cold Spell Damage: +50, Initiative: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-07"
 10283	purple family-friendly crafty rock-hard tricorn hat	0		Damage Reduction: 5, Maximum MP: +10, Sleaze Resistance: +1, Last Available: "2019-07"
 10284	yellow inspector's manspreader's razor-sharp swash buckle	0		Weapon Damage Percent: +25, Monster Level: +10, Item Drop: +15, Single Equip, Last Available: "2019-07"
@@ -10202,9 +10202,9 @@
 10343	jittery plastic dolphin &quot;orphan&quot; of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2019-12"
 10344	huge sinister plastic Dolph Bossin	0		Spell Damage: +10, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	stale special thick mana-coated yams	5	decent	Effect: "Cruisin' for a Bruisin'", Effect Duration: 35, Last Available: "2019-11"
-10347	moldy snack-sized mana-basted tofurkey leg	2	crappy	Last Available: "2019-11"
-10348	rotten bite-sized mana-fortified cranberry sauce	1	crappy	Last Available: "2019-11"
+10346	special thick stale mana-coated yams	5	decent	Effect: "Cruisin' for a Bruisin'", Effect Duration: 35, Last Available: "2019-11"
+10347	snack-sized moldy mana-basted tofurkey leg	2	crappy	Last Available: "2019-11"
+10348	bite-sized rotten mana-fortified cranberry sauce	1	crappy	Last Available: "2019-11"
 10349	bland maroon mana-stuffed herbal stuffing	3	decent	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	pickled ionized pulsating patch of extra-warm fur	0		Effect: "Tin, Man", Effect Duration: 40, Last Available: "2019-12"
@@ -10213,16 +10213,16 @@
 10354	powdered twirling vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	diluted a bug's lymph	1		Effect: "Mushroom Moxiousness", Effect Duration: 25, Last Available: "2019-12"
 10356	super-irradiated dry organic potpourri	0		Effect: "Ogred and Oublietted", Effect Duration: 48, Last Available: "2019-12"
-10357	watered-down hand-crafted special boot flask	2	EPIC	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10, Last Available: "2019-12"
+10357	watered-down special hand-crafted boot flask	2	EPIC	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10, Last Available: "2019-12"
 10358	flattened activated galvanized infernal snowball	0		Effect: "Okee-Dokee Go!", Effect Duration: 26, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	twisted gray twirling fish sauce	1		Effect: "Sauce Monocle", Effect Duration: 20, Last Available: "2019-12"
-10361	snack-sized delicious guffin	2	awesome	Last Available: "2019-12"
+10361	delicious snack-sized guffin	2	awesome	Last Available: "2019-12"
 10362	modified Shantix&trade;	1		Effect: "Pasty", Effect Duration: 45, Last Available: "2019-12"
 10363	narrow shaking goodberry	0		Last Available: "2019-12"
 10364	distilled squat non-Euclidean angle	1		Effect: "Trash-Wrapped", Effect Duration: 5, Last Available: "2019-12"
 10365	unsweetened non-dry peppermint syrup	0		Effect: "Fireproof Lips", Effect Duration: 23, Last Available: "2019-12"
-10366	warmed chilled skewed bouncing mirror Mer-kin eyedrops	0		Effect: "Techno Bliss", Effect Duration: 43, Last Available: "2019-12"
+10366	warmed chilled bouncing mirror skewed Mer-kin eyedrops	0		Effect: "Techno Bliss", Effect Duration: 43, Last Available: "2019-12"
 10367	boiled extra-strength goo	0		Effect: "Sweet and Yellow", Effect Duration: 11, Last Available: "2019-12"
 10368	tumbling envelope full of Meat	0		Last Available: "2019-12"
 10369	boiled shaking livid energy	1		Last Available: "2019-12"
@@ -10246,15 +10246,15 @@
 10387	intact anemone spike	0		Last Available: "2019-12"
 10388	rock-hard anemoney clip	0		Damage Reduction: 5, Single Equip, Last Available: "2019-12"
 10389	runny icing	0		Last Available: "2019-12"
-10390	vaporized blinking spinning super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	vaporized spinning blinking super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	executive nasty coward's icing poncho	0		Monster Level: -20, Stench Damage: +5, Meat Drop: +40, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	tarnished diffused glob of salty molasses	0		Effect: "Winning Smile", Effect Duration: 43, Last Available: "2019-12"
 10394	personal trainer's Mer-kin rollpin	0		Experience Percent (Muscle): +10, Item Drop: +5, Last Available: "2019-12"
-10395	blinking wobbly personalizable gingerbread cookie	0		Last Available: "2019-12"
+10395	wobbly blinking personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	blinking tinsel fin	0		Familiar Weight: +5
 10397	gigantic stale gray bowl of mernudo	8	decent	Last Available: "2019-12"
-10398	practically non-alcoholic lousy fishelada	1	decent	Last Available: "2019-12"
+10398	lousy practically non-alcoholic fishelada	1	decent	Last Available: "2019-12"
 10399	spoiled ghostly ojo de pez burrito	4	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10282,7 +10282,7 @@
 10423	pulsating forbidden Herculean kelp-holly drape	0		Experience (Muscle): +1, Spell Damage Percent: +50, Last Available: "2019-12"
 10424	Usain Bolt's asbestos-lined curative Staff of the Peppermint Twist of Flo-Jo	0		Hot Resistance: +5, Initiative: 180, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10425	normal tempura and bean	4	good	Last Available: "2019-12"
-10426	lousy practically non-alcoholic salt plum sake	1	decent	Last Available: "2019-12"
+10426	practically non-alcoholic lousy salt plum sake	1	decent	Last Available: "2019-12"
 10427	tarnished deionized yellow pressurized potion of possessiveness	0		Effect: "Bread-Lined", Effect Duration: 24, Last Available: "2019-12"
 10428	tarnished quadruple-deionized squat almond	0		Effect: "OMG WTF", Effect Duration: 20
 10429	extra-energized ghostly handful of mixed nuts	0		Effect: "Serendipi Tea", Effect Duration: 59, Last Available: "2019-12"
@@ -10342,8 +10342,8 @@
 10485	gray bulky free-range mushroom	0		Last Available: "2020-03"
 10486	ghostly free-range mushroom	0		Last Available: "2020-03"
 10487	shaking gray immense free-range mushroom	0		Last Available: "2020-03"
-10488	blinking gray colossal free-range mushroom	0		Last Available: "2020-03"
-10489	tiny spoiled mushroom filet	1	crappy	Last Available: "2020-03"
+10488	gray blinking colossal free-range mushroom	0		Last Available: "2020-03"
+10489	spoiled tiny mushroom filet	1	crappy	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	diluted mushroom tea	1		Last Available: "2020-03"
 10492	mediocre spinning mushroom whiskey	4	decent	Last Available: "2020-03"
@@ -10389,16 +10389,16 @@
 10533	twirling zippy wool Guzzlr tablet	0		Cold Resistance: +1, Initiative: +20, Last Available: "2020-05"
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
-10536	bouncing squat Guzzlr hat	0		Last Available: "2020-05"
+10536	squat bouncing Guzzlr hat	0		Last Available: "2020-05"
 10537	Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	stylish Guzzlr souvenir stein	0		Moxie: +25, Last Available: "2020-05"
 10540	yellow Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	lousy lime green Ghiaccio Colada	3	decent	Last Available: "2020-05"
 10542	tolerable bouncing Sourfinger	3	good	Last Available: "2020-05"
-10543	practically non-alcoholic perfectly mixed tumbling Nog-on-the-Cob	1	super ultra mega turbo EPIC	Last Available: "2020-05"
+10543	perfectly mixed practically non-alcoholic tumbling Nog-on-the-Cob	1	super ultra mega turbo EPIC	Last Available: "2020-05"
 10544	weak perfectly mixed Steamboat	2	EPIC	Last Available: "2020-05"
-10545	artisanal blurry pulsating Buttery Boy	4	EPIC	Last Available: "2020-05"
+10545	artisanal pulsating blurry Buttery Boy	4	EPIC	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	rock-hard clown car key of the blizzard	0		Damage Reduction: 5, Cold Spell Damage: +25, Last Available: "2020-08"
 10548	censurious coward's batting cage key of the wise owl	0		Mysticality: +20, Monster Level: -20, Sleaze Resistance: +3, Last Available: "2020-08"
@@ -10425,7 +10425,7 @@
 10569	blinking shaking curative baleful discarded bike lock key	0		Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2020-08"
 10570	tumbling Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	nitrogenated enhanced blurry jittery marshroom	0		Effect: "Biologically Shocked", Effect Duration: 67
+10572	nitrogenated enhanced jittery blurry marshroom	0		Effect: "Biologically Shocked", Effect Duration: 67
 10573	bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
@@ -10458,7 +10458,7 @@
 10602	dance instructor's ert grey goo ring	0		Experience Percent (Moxie): +10
 10603	fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
-10605	narrow shaking Yeg's Motel alarm clock	0		Last Available: "2020-09"
+10605	shaking narrow Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	super-anodized extra-dry green Yeg's Motel toothbrush	0		Effect: "Boletus Swoletus", Effect Duration: 37, Last Available: "2020-09"
 10607	non-wet ionized quadruple-polymerized Yeg's Motel hand soap	0		Effect: "Flamibili Tea", Effect Duration: 57, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
@@ -10507,11 +10507,11 @@
 10651	jittery ghostly greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	deionized fortifying hot cocoa	0		Effect: "Cold Blooded", Effect Duration: 30, Last Available: "2020-12"
-10654	ionized quadruple-enhanced jittery shaking boiling hot cocoa	0		Effect: "Indescribable Flavor", Effect Duration: 48, Last Available: "2020-12"
+10654	ionized quadruple-enhanced shaking jittery boiling hot cocoa	0		Effect: "Indescribable Flavor", Effect Duration: 48, Last Available: "2020-12"
 10655	pickled cool hot cocoa	0		Effect: "Smokin'", Effect Duration: 13, Last Available: "2020-12"
 10656	cold-filtered anodized bouncing overly-fancy hot cocoa	0		Effect: "Super Accuracy", Effect Duration: 14, Last Available: "2020-12"
 10657	activated Vulcanized wobbly hot cocoa au beurre	0		Effect: "Salty Mouth", Effect Duration: 17, Last Available: "2020-12"
-10658	liquefied chilled mirror maroon hot cocoa with rainbow marshmallows	0		Effect: "Top Dog", Effect Duration: 14, Last Available: "2020-12"
+10658	liquefied chilled maroon mirror hot cocoa with rainbow marshmallows	0		Effect: "Top Dog", Effect Duration: 14, Last Available: "2020-12"
 10659	red Book of Old-Timey Carols of the bloodbag	0		Maximum HP: [+100*event(December)], Last Available: "2020-12"
 10660	spinning beefcake's Crimbo smile	0		Muscle: [+25*event(December)], Last Available: "2020-12"
 10661	experienced SalesCo sample kit	0		Experience: [+2*event(December)], Last Available: "2020-12"
@@ -10568,7 +10568,7 @@
 10712	fuchsia The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	jittery The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	snack-sized decent lime green and pepper (stale)	2	good	Last Available: "2020-12"
+10715	decent snack-sized lime green and pepper (stale)	2	good	Last Available: "2020-12"
 10716	lousy cranberry margarita (brackish)	3	decent	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
@@ -10576,7 +10576,7 @@
 10720	mediocre barrel-aged eggnog	4	decent	Last Available: "2020-12"
 10721	flavorless wobbly hand-crafted candy cane	4	decent	Last Available: "2020-12"
 10722	moldy drive-thru burger	3	crappy	Last Available: "2020-12"
-10723	weak tolerable Boulevardier cocktail	2	good	Last Available: "2020-12"
+10723	tolerable weak Boulevardier cocktail	2	good	Last Available: "2020-12"
 10724	nitrogenated ionized Hotwire&trade; brand candy rope	0		Effect: "Souper Vengeful", Effect Duration: 48, Last Available: "2020-12"
 10725	stale bowl full of jelly	3	decent	Last Available: "2020-12"
 10726	drinkable watered-down Eye and a Twist	2	good	Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	red emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	skewed spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	red emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	skewed spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	huge robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10621,17 +10621,17 @@
 10765	shaking rocket	0		Last Available: "2021-07"
 10766	skewed rocket	0		Last Available: "2021-07"
 10767	rocket	0		Last Available: "2021-07"
-10768	snack-sized stale fire crackers	2	decent	Last Available: "2021-07"
+10768	stale snack-sized fire crackers	2	decent	Last Available: "2021-07"
 10769	tumbling twirling Arr, M80	0		Last Available: "2021-07"
 10770	fuchsia narrow Catherine Wheel of wisdom of Calamity Jane	0		Mysticality: +15, Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2021-07"
 10771	lightning-fast rocket boots of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +40, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	scorching Socratic sparkler	0		Experience (Mysticality): +1, Hot Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
 10773	upside-down Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
-10774	energized magnetized colloidal cyan narrow Scent of a Human&trade; candle	0		Effect: "Eyes All Black", Effect Duration: 13, Last Available: "2021-08"
+10774	energized magnetized colloidal narrow cyan Scent of a Human&trade; candle	0		Effect: "Eyes All Black", Effect Duration: 13, Last Available: "2021-08"
 10775	magnetized non-vacuum-sealed The Beast Within&trade; candle	0		Effect: "Dreadful Fear", Effect Duration: 41, Last Available: "2021-08"
 10776	altered Salsa Caliente&trade; candle	0		Effect: "Stop and Smell the Fudge", Effect Duration: 33, Last Available: "2021-08"
 10777	extra-activated modified Smoldering Clover&trade; candle	0		Effect: "Buggy Flavor", Effect Duration: 16, Last Available: "2021-08"
-10778	nitrogenated nitrogenated huge spinning Napalm In The Morning&trade; candle	0		Effect: "Oiled Skin", Effect Duration: 16, Last Available: "2021-08"
+10778	nitrogenated nitrogenated spinning huge Napalm In The Morning&trade; candle	0		Effect: "Oiled Skin", Effect Duration: 16, Last Available: "2021-08"
 10779	extra-large utility candle of the sewer of the detective	0		Stench Damage: +25, Item Drop: +20, Lasts Until Rollover, Last Available: "2021-08"
 10780	blinking Jack Frost's cool runed taper candle	0		Moxie: +5, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 10781	Oprah's rosy-cheeked novelty sparkling candle of Calamity Jane	0		Maximum HP Percent: +30, Maximum MP Percent: +50, Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2021-08"
@@ -10640,7 +10640,7 @@
 10784	quantum natural magick candle	0		Effect: "In Vino Vires", Effect Duration: 53, Last Available: "2021-08"
 10785	boiled wobbly rainbow glitter candle	0		Effect: "In the Limelight", Effect Duration: 35, Last Available: "2021-08"
 10786	improved red squat banana candle	0		Effect: "Virgo Rising", Effect Duration: 47, Last Available: "2021-08"
-10787	polarized wobbly twirling ear candle	0		Effect: "Yes, Can Haz", Effect Duration: 52, Last Available: "2021-08"
+10787	polarized twirling wobbly ear candle	0		Effect: "Yes, Can Haz", Effect Duration: 52, Last Available: "2021-08"
 10788	galvanized tumbling mirror votive of confidence	0		Effect: "Slippery Tongue", Effect Duration: 50, Last Available: "2021-08"
 10789	auspicious water candle	0		Item Drop: +10, Water: 3, Lasts Until Rollover
 10790	sinister B. L. A. R. T.	0		Spell Damage: +10, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
@@ -10648,7 +10648,7 @@
 10792	empty nacho cheese can	0		Water: 1
 10793	literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
-10795	shaking jittery shaking pump grease	0		
+10795	shaking shaking jittery pump grease	0		
 10796	narrow packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	Jim Carey's Tesla crafty ruddy Da Vinci's weightlifter's industrial fire extinguisher	0		Muscle: +15, Experience (Mysticality): +5, Maximum HP Percent: +40, Maximum MP: +10, Monster Level: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	twirling The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
@@ -10661,7 +10661,7 @@
 10805	eggwater	1	EPIC	Last Available: "2021-12"
 10806	decent bread man	4	good	Last Available: "2021-12"
 10807	spoiled ghostly plain candy cane	4	crappy	Last Available: "2021-12"
-10808	bland maroon upside-down flour cookie	3	decent	Last Available: "2021-12"
+10808	bland upside-down maroon flour cookie	3	decent	Last Available: "2021-12"
 10809	squat wool plastic food lab	0		Cold Resistance: +1, Single Equip, Last Available: "2021-12"
 10810	wobbly thinker's plastic nog lab	0		Mysticality: +10, Single Equip, Last Available: "2021-12"
 10811	narrow extremely unsafe plastic chem lab	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2021-12"
@@ -10672,17 +10672,17 @@
 10816	inspector's dog trainer's weightlifter's ice crown	0		Muscle: +15, Experience (familiar): +1, Item Drop: +15, Lasts Until Rollover, Last Available: "2021-12"
 10817	pulsating perfumed cool jeans of the cheetah	0		Moxie: +5, Stench Resistance: +5, Initiative: +60, Lasts Until Rollover, Last Available: "2021-12"
 10818	pulsating ruddy ice wrap of Tarzan of bravery	0		Experience (Muscle): +3, Maximum HP Percent: +40, Spooky Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	low-calorie bland tofu pop	1	decent	Last Available: "2021-12"
-10820	super-sized special yummy squat bowl of prescription candy	5	awesome	Effect: "Eyes All Black", Effect Duration: 40, Last Available: "2021-12"
-10821	toothsome enchanted fishcake	3	awesome	Effect: "Ruby-ous", Effect Duration: 50, Last Available: "2021-12"
-10822	snack-sized stale bone broth	2	decent	Last Available: "2021-12"
+10819	bland low-calorie tofu pop	1	decent	Last Available: "2021-12"
+10820	yummy super-sized special squat bowl of prescription candy	5	awesome	Effect: "Eyes All Black", Effect Duration: 40, Last Available: "2021-12"
+10821	enchanted toothsome fishcake	3	awesome	Effect: "Ruby-ous", Effect Duration: 50, Last Available: "2021-12"
+10822	stale snack-sized bone broth	2	decent	Last Available: "2021-12"
 10823	snack-sized bland star pop	2	decent	Last Available: "2021-12"
-10824	practically non-alcoholic perfectly mixed Doc's Fortifying Wine	1	EPIC	Last Available: "2021-12"
+10824	perfectly mixed practically non-alcoholic Doc's Fortifying Wine	1	EPIC	Last Available: "2021-12"
 10825	distilled smooth Doc's Smartifying Wine	5	awesome	Last Available: "2021-12"
 10826	drinkable Doc's Limbering Wine	3	good	Last Available: "2021-12"
 10827	boozy acceptable pulsating Doc's Medical-Grade Wine	5	good	Last Available: "2021-12"
 10828	dried spinning Homebodyl&trade;	1		Effect: "Human-Hobo Hybrid", Effect Duration: 10, Last Available: "2021-12"
-10829	denatured jittery bouncing Extrovermectin&trade;	1		Effect: "You Drank Fish Wine", Effect Duration: 30, Last Available: "2021-12"
+10829	denatured bouncing jittery Extrovermectin&trade;	1		Effect: "You Drank Fish Wine", Effect Duration: 30, Last Available: "2021-12"
 10830	dried Breathitin&trade;	1		Last Available: "2021-12"
 10831	twisted huge Fleshazole&trade;	1		Last Available: "2021-12"
 10832	moist anti-burn cream	0		Effect: "Cold Throat", Effect Duration: 24, Last Available: "2021-12"
@@ -10691,8 +10691,8 @@
 10835	liquefied narrow ghostly anti-odor cream	0		Effect: "Cold Jellied", Effect Duration: 29, Last Available: "2021-12"
 10836	modified ionized purple anti-creep cream	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 67, Last Available: "2021-12"
 10837	wet galvanized fuchsia anti-pain cream	0		Effect: "Ooh, Salty!", Effect Duration: 56, Last Available: "2021-12"
-10838	drinkable weak blinking Doc's Special Reserve Wine	2	good	Last Available: "2021-12"
-10839	stale big bread pie	5	decent	Last Available: "2021-12"
+10838	weak drinkable blinking Doc's Special Reserve Wine	2	good	Last Available: "2021-12"
+10839	big stale bread pie	5	decent	Last Available: "2021-12"
 10840	bad irresponsibly strong clear Russian	8	decent	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10721,7 +10721,7 @@
 10865	spinning universal biscuit	0		Last Available: "2021-12"
 10866	Fonzie's yule hatchet	0		Experience (Moxie): +1, Last Available: "2021-12"
 10867	upside-down potato alarm clock	0		Last Available: "2021-12"
-10868	rotten half-sized red lab-grown meat	2	crappy	Last Available: "2021-12"
+10868	half-sized rotten red lab-grown meat	2	crappy	Last Available: "2021-12"
 10869	hardy fleece	0		Maximum HP: +50, Last Available: "2021-12"
 10870	jittery boxed gumball machine	0		Last Available: "2021-12"
 10871	jittery cloning kit	0		Last Available: "2021-12"
@@ -10729,18 +10729,18 @@
 10873	greedy lion tamer's vibrating can of mixed everything	0		Maximum MP Percent: +10, Experience (familiar): +2, Meat Drop: +20, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	flavorless snack-sized pulsating meatball	2	decent	Last Available: "2021-12"
-10877	bouncing upside-down cloned monster	0		Last Available: "2021-12"
+10876	snack-sized flavorless pulsating meatball	2	decent	Last Available: "2021-12"
+10877	upside-down bouncing cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	altered huge bouncing fried air	1		Last Available: "2021-12"
 10881	wobbly 11-leaf clover	0		
 10882	ghostly carton of astral energy drinks	0		
 10883	boiled squat astral energy drink	1		
-10884	ghostly maroon mint condition magnifying glass	0		Last Available: "2022-12"
+10884	maroon ghostly mint condition magnifying glass	0		Last Available: "2022-12"
 10885	shaking maroon sinister razor-sharp magnifying glass	0		Weapon Damage Percent: +25, Spell Damage: +10, Item Drop: +5, Last Available: "2022-12"
 10886	aged void lager	4	awesome	Last Available: "2022-12"
-10887	spoiled gigantic twirling void burger	10	crappy	Last Available: "2022-12"
+10887	gigantic spoiled twirling void burger	10	crappy	Last Available: "2022-12"
 10888	blinking void stone	0		Last Available: "2022-12"
 10889	up-at-dawn sinister Da Vinci's Socratic void shard	0		Experience (Mysticality): 6, Spell Damage: +10, Adventures: +5, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10766,9 +10766,9 @@
 10910	frozen modified single-use dust mask	0		Effect: "Stimulated Body", Effect Duration: 56, Last Available: "2022-05"
 10911	dry mirror gaffer's tape	0		Effect: "One Very Clear Eye", Effect Duration: 15, Last Available: "2022-05"
 10912	bland 20-lb can of rice and beans	4	decent	Last Available: "2022-05"
-10913	narrow lime green bar of freeze-dried water	1	crappy	Last Available: "2022-05"
+10913	lime green narrow bar of freeze-dried water	1	crappy	Last Available: "2022-05"
 10914	normal cyan expired MRE	3	good	Last Available: "2022-05"
-10915	yummy miniature wobbly cool mint precipice bar	2	awesome	Last Available: "2022-05"
+10915	miniature yummy wobbly cool mint precipice bar	2	awesome	Last Available: "2022-05"
 10916	decent carrot cake precipice bar	3	good	Last Available: "2022-05"
 10917	twirling The Big Book of Every Skill	0		
 10918	shaking Thwaitgold harvestman statuette	0		
@@ -10776,13 +10776,13 @@
 10920	mirror strapping June cleaver of Gandalf of extreme caution	0		Muscle: +5, Spell Critical Percent: +20, Monster Level: -25, Attacks Can't Miss, Last Available: "2022-06"
 10921	aged Dad's brandy	4	awesome	Last Available: "2022-06"
 10922	squat shellacked Herculean teacher's pen	0		Experience (Muscle): +1, Damage Reduction: 7, Last Available: "2022-06"
-10923	spoiled half-sized fire-roasted lake trout	2	crappy	Last Available: "2022-06"
-10924	gigantic moldy guilty sprout	10	crappy	Last Available: "2022-06"
+10923	half-sized spoiled fire-roasted lake trout	2	crappy	Last Available: "2022-06"
+10924	moldy gigantic guilty sprout	10	crappy	Last Available: "2022-06"
 10925	blue family-friendly wicked mother's necklace	0		Spell Damage: +5, Sleaze Resistance: +1, Last Available: "2022-06"
 10926	warmed trampled ticket stub	0		Effect: "Elemental Flavor", Effect Duration: 35, Last Available: "2022-06"
 10927	cold-filtered savings bond	0		Effect: "Ode to Booze", Effect Duration: 40, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	vaporized spinning sweat-ade	1		Effect: "White-boy Angst", Effect Duration: 45, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10799,7 +10799,7 @@
 10943	camouflage vest of the early riser	0		Adventures: +7
 10944	shaking Dinodollar	0		
 10945	huge valuable dinosaur droppings	0		
-10946	maroon twirling dinosaur pheromone kit	0		
+10946	twirling maroon dinosaur pheromone kit	0		
 10947	scandalous Samson's awkward dinosaur research harness of horror	0		Experience (Muscle): +5, Spooky Spell Damage: +25, Sleaze Damage: +5
 10948	mirror narrow Herculean reflective vest	0		Experience (Muscle): +1
 10949	bouncing stylish dinosaur	0		Moxie: +25
@@ -10809,7 +10809,7 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	ionized autumn leaf	0		Effect: "Icy Demeanor", Effect Duration: 61, Last Available: "2022-10"
-10956	weak artisanal AutumnFest ale	2	EPIC	Last Available: "2022-10"
+10956	artisanal weak AutumnFest ale	2	EPIC	Last Available: "2022-10"
 10957	narrow electrified personal trainer's autumn sweater-weather sweater of the cheetah	0		Experience Percent (Muscle): +10, Initiative: +60, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
 10958	blurry auspicious hale ruddy autumn debris shield of Gandalf	0		Maximum HP Percent: +40, Maximum HP: +20, Spell Critical Percent: +20, Item Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	spoiled twirling autumn-spice donut	3	crappy	Last Available: "2022-10"
@@ -10826,33 +10826,33 @@
 10970	low-calorie spoiled ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
 10971	adequate Jarlsberg's vegetable soup	4	good	Last Available: "2022-11"
 10972	moldy thick roasted vegetable of Jarlsberg	5	crappy	Last Available: "2022-11"
-10973	spoiled small St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
+10973	small spoiled St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
 10974	tasty Pete's wiley whey bar	3	awesome	Last Available: "2022-11"
-10975	bite-sized flavorless Pete's rich ricotta	1	decent	Last Available: "2022-11"
+10975	flavorless bite-sized Pete's rich ricotta	1	decent	Last Available: "2022-11"
 10976	acceptable purple Boris's beer	3	good	Last Available: "2022-11"
-10977	thick flavorless fuchsia honey bun of Boris	5	decent	Last Available: "2022-11"
+10977	flavorless thick fuchsia honey bun of Boris	5	decent	Last Available: "2022-11"
 10978	toothsome miniature upside-down Boris's bread	2	awesome	Last Available: "2022-11"
-10979	bouncing Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	blurry Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	twirling Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	blurry fuchsia Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	bouncing Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	blurry Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	twirling Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	fuchsia blurry Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	moldy low-calorie baked veggie ricotta casserole	1	crappy	Last Available: "2022-11"
-10989	special bland snack-sized twirling plain calzone	2	decent	Effect: "Antarctic Memories", Effect Duration: 45, Last Available: "2022-11"
+10989	special snack-sized bland twirling plain calzone	2	decent	Effect: "Antarctic Memories", Effect Duration: 45, Last Available: "2022-11"
 10990	low-calorie spoiled roasted vegetable focaccia	1	crappy	Last Available: "2022-11"
 10991	stale blinking Pizza of Legend	4	decent	Last Available: "2022-11"
 10992	spoiled jittery Calzone of Legend	3	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	blurry huge Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	huge blurry Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	upside-down upside-down wobbly Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	upside-down upside-down wobbly Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	stale narrow Deep Dish of Legend	4	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
@@ -10869,9 +10869,9 @@
 11013	mediocre Charleston Choo-Choo	4	decent	
 11014	acceptable fortified tumbling yellow Velvet Veil	5	good	
 11015	perfectly mixed practically non-alcoholic Marltini	1	super ultra EPIC	
-11016	mediocre blinking narrow Strong, Silent Type	3	decent	
+11016	mediocre narrow blinking Strong, Silent Type	3	decent	
 11017	hand-crafted Mysterious Stranger	3	EPIC	
-11018	lousy strong skewed twirling Champagne Shimmy	5	decent	
+11018	strong lousy skewed twirling Champagne Shimmy	5	decent	
 11019	the Sot's parcel	0		
 11020	squat shaking lightning-fast ceramic cestus of dire peril	0		Weapon Damage: +20, Initiative: +40, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
 11021	manspreader's wizardly ceramic centurion shield of the wise owl	0		Mysticality: 45, Monster Level: +10, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
@@ -10887,9 +10887,9 @@
 11031	Annie Oakley's strapping chiffon chemise of the glutton	0		Muscle: +5, Critical Hit Percent: +20, Food Drop: +100, Last Available: "2023-12"
 11032	yellow dog trainer's stylish chiffon chakram of doom	0		Moxie: +25, Experience (familiar): +1, Spooky Spell Damage: +50, Last Available: "2023-12"
 11033	frightening Jim Carey's chiffon chaps of James Dean	0		Experience (Moxie): +3, Monster Level: +25, Spooky Damage: +5, Last Available: "2023-12"
-11034	denatured skewed gray twirling chiffon carbage	1		Effect: "Fastbreaker", Effect Duration: 40, Last Available: "2023-12"
+11034	denatured gray skewed twirling chiffon carbage	1		Effect: "Fastbreaker", Effect Duration: 40, Last Available: "2023-12"
 11035	warmed chiffon lemon	0		Effect: "Bear Clawed", Effect Duration: 42
-11036	miniature normal chocomotive	2	good	Last Available: "2022-12"
+11036	normal miniature chocomotive	2	good	Last Available: "2022-12"
 11037	normal freightcake	3	good	Last Available: "2022-12"
 11038	high-proof mediocre cabooze	6	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10905,8 +10905,8 @@
 11049	pile of Trainbot parts	0		
 11050	flattened Trainbot circuitry	0		Effect: "Heightened Senses", Effect Duration: 65
 11051	improved blurry Trainbot tubing	0		Effect: "Piratastic", Effect Duration: 23
-11052	non-activated narrow lime green Trainbot plating	0		Effect: "Salamanderenity", Effect Duration: 21
-11053	modified wobbly ghostly lime green Trainbot optics	0		Effect: "Takin' It Greasy", Effect Duration: 50
+11052	non-activated lime green narrow Trainbot plating	0		Effect: "Salamanderenity", Effect Duration: 21
+11053	modified lime green ghostly wobbly Trainbot optics	0		Effect: "Takin' It Greasy", Effect Duration: 50
 11054	pressed red Trainbot servomotors	0		Effect: "World's Shortest Giant", Effect Duration: 52
 11055	unsweetened quadruple-modified Trainbot linkages	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 62
 11056	olive ping-pong paddle	0		Single Equip
@@ -10923,15 +10923,15 @@
 11067	tolerable mirror dregs of a Crimbo cocktail	4	good	
 11068	shaking lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	tiny rotten honey-drenched ham slice	1	crappy	
+11070	rotten tiny honey-drenched ham slice	1	crappy	
 11071	aged mostly-empty bottle of cookie wine	3	awesome	
 11072	flavorless Crimbo food scraps	3	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
-11076	fuchsia tumbling Trainbot slag	0		
+11076	tumbling fuchsia Trainbot slag	0		
 11077	blurry industrially-crushed ice	0		Last Available: "2022-12"
-11078	small flavorless mirror steamed oyster	2	decent	
+11078	flavorless small mirror steamed oyster	2	decent	
 11079	really nice lump of coal	0		
 11080	squat deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	blurry steam unit	0		Last Available: "2022-12"
@@ -10940,7 +10940,7 @@
 11084	bad ghostly Crimbosmopolitan	4	decent	Last Available: "2022-12"
 11085	yummy Crimbo dinner	3	awesome	Last Available: "2022-12"
 11086	squat overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
-11087	spinning olive train whistle	0		Last Available: "2022-12"
+11087	olive spinning train whistle	0		Last Available: "2022-12"
 11088	teal The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	half-height cigar	0		Familiar Weight: +5
@@ -10973,8 +10973,8 @@
 11118	alkaline mushroom	0		Effect: "Frosty the Hitman", Effect Duration: 31, Last Available: "2023-02"
 11119	Vulcanized improved five-fingered fern resin	0		Effect: "Sweet Tooth", Effect Duration: 40, Last Available: "2023-02"
 11120	flavorless huge super good fruit	4	decent	Last Available: "2023-02"
-11121	dehydrated skewed tumbling energized spores	1		Last Available: "2023-02"
-11122	hot pepper of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15, Last Available: "2023-02", Lantern Element: "Hot"
+11121	dehydrated tumbling skewed energized spores	1		Last Available: "2023-02"
+11122	hot pepper of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15, Lantern Element: "Hot", Last Available: "2023-02"
 11123	energized out-of-work circus flea	0		Effect: "In the Limelight", Effect Duration: 49, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	galvanized fire ant pheromones	0		Effect: "Cat-Alyzed", Effect Duration: 14, Last Available: "2023-02"
@@ -10997,7 +10997,7 @@
 11142	shadow brick	0		Last Available: "2023-03"
 11143	teal shadow sinew	0		Last Available: "2023-03"
 11144	artisanal spirit-forward shadow venom	5	EPIC	Last Available: "2023-03"
-11145	modified skewed wobbly shadow nectar	1		Last Available: "2023-03"
+11145	modified wobbly skewed shadow nectar	1		Last Available: "2023-03"
 11146	smelly Lo Pan's vibrating shadow stick	0		Maximum MP Percent: +10, Spell Critical Percent: +30, Stench Spell Damage: +10, Last Available: "2023-03"
 11147	chilly bat paw of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5
 11148	energetic uncursed bat paw	0		Maximum MP Percent: +20
@@ -11021,7 +11021,7 @@
 11166	Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
-11169	huge wobbly closed-circuit pay phone	0		
+11169	wobbly huge closed-circuit pay phone	0		
 11170	olive jittery shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	blurry shadow snowflake	0		
@@ -11035,7 +11035,7 @@
 11180	zippy MacGyver's stylish shadow monocle	0		Moxie: +25, Maximum MP: +100, Initiative: +20, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	spoiled diet shadow hot dog	1	crappy	
-11183	weak hand-crafted shadow martini	2	EPIC	
+11183	hand-crafted weak shadow martini	2	EPIC	
 11184	modified gray shadow pill	1		Effect: "Prideful Strut", Effect Duration: 15
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
@@ -11107,7 +11107,7 @@
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	lion tamer's quilted weightlifter's replica Cincho de Mayo of the dark arts	0		Muscle: +15, Spell Damage Percent: +100, Damage Absorption: +40, Experience (familiar): +2, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
-11255	upside-down mirror Thwaitgold splendor beetle statuette	0		
+11255	mirror upside-down Thwaitgold splendor beetle statuette	0		
 11256	spinning shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	huge aromatic flame-retardant horrifying Samson's &quot;I survived Y2K&quot; T-Shirt of the storm of the early riser	0		Experience (Muscle): +5, Maximum MP Percent: +40, Spooky Damage: +25, Hot Resistance: +1, Stench Resistance: +1, Adventures: +7, Single Equip, Last Available: "2023-06"
@@ -11117,7 +11117,7 @@
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	purple Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	Rosewater's Flash Liquidizer Ultra Dousing Accessory	0		Mysticality Percent: +30, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	rock-hard razor-sharp Socratic boxer's Amulet of Perpetual Darkness	0		Muscle Percent: +10, Experience (Mysticality): +1, Weapon Damage Percent: +25, Damage Reduction: 5, Last Available: "2023-06"
 11268	pulsating Giant monolith	0		Last Available: "2023-06"
@@ -11128,7 +11128,7 @@
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	cyan Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
-11276	modified liquefied gray skewed scroll of protection from lycanthropes	0		Effect: "Holiday Disappointment", Effect Duration: 46, Last Available: "2023-06"
+11276	modified liquefied skewed gray scroll of protection from lycanthropes	0		Effect: "Holiday Disappointment", Effect Duration: 46, Last Available: "2023-06"
 11277	wobbly Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	acceptable yellow Sexy Cosmo	3	good	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	lightning-fast forbidden strapping red-soled high heels	0		Muscle: +5, Spell Damage Percent: +50, Initiative: +40, Last Available: "2023-06"
-11285	snack-sized spoiled cyburger	2	crappy	Last Available: "2025-12"
+11285	spoiled snack-sized cyburger	2	crappy	Last Available: "2025-12"
 11286	spinning rock-hard ncle leg	0		Damage Reduction: 5
 11287	manspreader's beefy rutabuga bag	0		Muscle: +10, Monster Level: +10
 11288	mesquito proboscis of temperance	0		Sleaze Resistance: +5
@@ -11157,7 +11157,7 @@
 11302	souvenir flag	0		
 11303	name change form	0		
 11304	replica sleeping patriotic eagle	0		
-11305	twirling skewed boxed august scepter	0		Free Pull
+11305	skewed twirling boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	toothsome blue watermelon	4	awesome	
 11308	watermelon seed	0		
@@ -11174,8 +11174,8 @@
 11319	skewed medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	watered-down artisanal bottle of Cabernet Sauvignon	2	EPIC	
 11321	mirror red spinning hardened forbidden sage baywatch	0		Mysticality Percent: +10, Spell Damage Percent: +50, Damage Reduction: 3, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	blurry Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	blurry Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	blue Thwaitgold fairyfly statue	0		
@@ -11230,7 +11230,7 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	twirling housekeeping robot	0		
-11378	bland fancy narrow ghostly pickled bread	3	decent	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2023-12"
+11378	bland fancy ghostly narrow pickled bread	3	decent	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2023-12"
 11379	decent lime green salted mutton	3	good	Last Available: "2023-12"
 11380	jumbo decent twirling corned beet	5	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11268,7 +11268,7 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	Herculean stylish Elf Guard officer's sidearm	0		Moxie: +25, Experience (Muscle): +1, Last Available: "2023-12"
 11415	jittery bouncing auspicious personal trainer's Elf Guard insignia (general)	0		Experience Percent (Muscle): +10, Item Drop: +10, Single Equip, Last Available: "2023-12"
-11416	special drinkable triple-distilled Crimbow Rainbo	10	good	Effect: "Inner Dog", Effect Duration: 10, Last Available: "2023-12"
+11416	triple-distilled drinkable special Crimbow Rainbo	10	good	Effect: "Inner Dog", Effect Duration: 10, Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	prompt Elf Guard broom of vim and vigor	0		Maximum HP Percent: +50, Adventures: +3, Last Available: "2023-12"
@@ -11277,10 +11277,10 @@
 11422	bad blue old-school pirate grog	3	decent	Last Available: "2023-12"
 11423	moldy grog nuts	3	crappy	Last Available: "2023-12"
 11424	stiffened smooth sawed-off blunderbuss of Leguizamo	0		Moxie: +15, Damage Reduction: 1, Monster Level: +20, Last Available: "2023-12"
-11425	watered-down perfectly mixed officer's nog	2	EPIC	Last Available: "2023-12"
+11425	perfectly mixed watered-down officer's nog	2	EPIC	Last Available: "2023-12"
 11426	blue peppermint bomb	0		Last Available: "2023-12"
 11427	stale half-sized sundae ration	2	decent	Last Available: "2023-12"
-11428	tasty diet special jittery skewed peppermint tack	1	awesome	Effect: "Smoky Third Eye", Effect Duration: 50, Last Available: "2023-12"
+11428	tasty diet special skewed jittery peppermint tack	1	awesome	Effect: "Smoky Third Eye", Effect Duration: 50, Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	normal whalesteak	4	good	Last Available: "2023-12"
 11431	narrow Jeselnik's Lo Pan's baleful whalegun	0		Spell Damage: +25, Spell Critical Percent: +30, Sleaze Damage: +25, Last Available: "2023-12"
@@ -11308,29 +11308,29 @@
 11453	medical-grade curative Elf Guard SCUBA tank	0		HP Regen Min: 10, HP Regen Max: 15, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11455	electrified Newton's free boots	0		Experience (Mysticality): +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
-11456	mirror maroon baby rigging snake	0		Last Available: "2023-12"
+11456	maroon mirror baby rigging snake	0		Last Available: "2023-12"
 11457	blinking inspector's rosewater-soaked knitted Elvish underarmor	0		Cold Resistance: +3, Stench Resistance: +3, Item Drop: +15, Single Equip, Last Available: "2023-12"
 11458	lion tamer's deadly Crimbuccaneer bombjacket	0		Weapon Damage: +5, Experience (familiar): +2, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	rotten sugarplum ration	3	crappy	Last Available: "2023-12"
 11460	adequate gingerbread nylons	3	good	Last Available: "2023-12"
-11461	snack-sized spoiled spinning rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
+11461	spoiled snack-sized spinning rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
 11462	flavorless miniature lime	2	decent	Last Available: "2023-12"
 11463	tasty gigantic gingerbread pirate	8	awesome	Last Available: "2023-12"
-11464	normal huge enchanted teal fruit-stuffed rumcake	9	good	Effect: "Stinky Weapon", Effect Duration: 10, Last Available: "2023-12"
+11464	enchanted normal huge teal fruit-stuffed rumcake	9	good	Effect: "Stinky Weapon", Effect Duration: 10, Last Available: "2023-12"
 11465	mediocre distilled mulled wine	5	decent	Last Available: "2023-12"
 11466	perfectly mixed Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	acceptable green canteen of eggnog	4	good	Last Available: "2023-12"
-11468	lousy irresponsibly strong skewed green hot wine	6	decent	Last Available: "2023-12"
+11468	irresponsibly strong lousy green skewed hot wine	6	decent	Last Available: "2023-12"
 11469	mediocre extra-dry Jamaican coffee	5	decent	Last Available: "2023-12"
 11470	lousy upside-down mirror flask of egggrog	3	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
-11472	purple shaking Black and White Apron Meal Kit	0		Last Available: "2024-12"
+11472	shaking purple Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	wobbly pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	tolerable weak yule grog	2	good	Last Available: "2023-12"
+11474	weak tolerable yule grog	2	good	Last Available: "2023-12"
 11475	normal thick wet tack	5	good	Last Available: "2023-12"
 11476	flavorless small skewed whalecake	2	decent	Last Available: "2023-12"
 11477	upside-down chilly smooth cool gunwale whalegun	0		Moxie: 20, Cold Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	bad triple-distilled and claret	7	decent	Last Available: "2023-12"
+11478	triple-distilled bad and claret	7	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	therapeutic Elf Guard squirtgun of chilblains	0		Cold Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
@@ -11345,14 +11345,14 @@
 11490	pulsating barnacle-encrusted sweater of the brute of incineration	0		Muscle Percent: +30, Hot Spell Damage: +50, Item Drop: +5, Last Available: "2023-12"
 11491	censurious nippy Crimbuccaneer nose ring of James Dean	0		Experience (Moxie): +3, Cold Damage: +10, Sleaze Resistance: +3, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
-11493	jittery maroon Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
+11493	maroon jittery Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	ghostly Elf Guard safety bear	0		Last Available: "2023-12"
 11495	bouncing kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	squat Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	bouncing narrow Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
-11500	upside-down bouncing The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
+11500	bouncing upside-down The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	wobbly Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	wet blurry military candy cane	0		Effect: "items.enh", Effect Duration: 43
 11503	chilled activated teal groggipop	0		Effect: "Dances with Tweedles", Effect Duration: 63
@@ -11369,7 +11369,7 @@
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	narrow lime green adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
-11517	blurry ghostly adobe abaya	0		Last Available: "2024-12"
+11517	ghostly blurry adobe abaya	0		Last Available: "2024-12"
 11518	powdered skewed adobe assortment	1		Effect: "Protection from Bad Stuff", Effect Duration: 10, Last Available: "2024-12"
 11519	unsweetened unsweetened maroon adobe brittle	0		Effect: "Scrappy, Shadowy", Effect Duration: 64
 11520	zippy nasty crepe paper phrygian cap of Calamity Jane	0		Critical Hit Percent: +15, Stench Damage: +5, Initiative: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
@@ -11382,8 +11382,8 @@
 11527	vacuum-sealed twirling crepe paper peanut candy	0		Effect: "Wet Rub", Effect Duration: 12
 11528	reassuring shellacked petrified wood war pike	0		Damage Reduction: 7, Spooky Resistance: +1, Last Available: "2025-12"
 11529	chaotic crafty petrified wood waist protector	0		Maximum MP: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2025-12"
-11530	petrified wood wizard's pouch of horror of the glutton	0		Spooky Spell Damage: +25, Food Drop: +100, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	fortified stylish petrified wood water purifier	0		Moxie: +25, Damage Absorption: +60, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	petrified wood wizard's pouch of horror of the glutton	0		Spooky Spell Damage: +25, Food Drop: +100, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	fortified stylish petrified wood water purifier	0		Moxie: +25, Damage Absorption: +60, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	wobbly jittery petrified wood whoopie panama of Gandalf of the brazier	0		Spell Critical Percent: +20, Hot Spell Damage: +25, Last Available: "2025-12"
 11533	shaking Samson's supercool petrified wood walking pants	0		Moxie Percent: +20, Experience (Muscle): +5, Last Available: "2025-12"
 11534	diluted petrified wood waste parts	1		Last Available: "2025-12"
@@ -11427,11 +11427,11 @@
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	rotten yam	3	crappy	Last Available: "2024-05"
 11574	aged high-proof olive yam martini	10	awesome	Last Available: "2024-05"
-11575	weak hand-crafted sweet potato o' mine	2	EPIC	Last Available: "2024-05"
+11575	hand-crafted weak sweet potato o' mine	2	EPIC	Last Available: "2024-05"
 11576	lousy watered-down spinning lime green Southern yam	2	decent	Last Available: "2024-05"
 11577	aged watered-down sweet potato punch	2	awesome	Last Available: "2024-05"
-11578	big adequate Mayam spinach	5	good	Last Available: "2024-05"
-11579	adequate diet purple yam and swiss	1	good	Last Available: "2024-05"
+11578	adequate big Mayam spinach	5	good	Last Available: "2024-05"
+11579	diet adequate purple yam and swiss	1	good	Last Available: "2024-05"
 11580	sinister yam cannon of wisdom of the sweet-tooth	0		Mysticality: +15, Spell Damage: +10, Candy Drop: +100, Lasts Until Rollover, Last Available: "2024-05"
 11581	wobbly yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11439,22 +11439,22 @@
 11584	dangerous furry yam buckler of the storm of the boozehound	0		Weapon Damage: +10, Maximum MP Percent: +40, Booze Drop: +100, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	fireproof savvy yamtility belt of the overflowing toilet	0		Mysticality Percent: +20, Stench Spell Damage: +50, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2024-05"
-11587	jumbo bland yam slider	5	decent	Last Available: "2024-05"
+11587	bland jumbo yam slider	5	decent	Last Available: "2024-05"
 11588	normal half-sized yam mayo	2	good	Last Available: "2024-05"
-11589	bland thick wobbly yam burrito	5	decent	Last Available: "2024-05"
+11589	thick bland wobbly yam burrito	5	decent	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	teal Thwaitgold Illinigina illinoiensis model	0		
 11594	rotten gray mini kiwi	3	crappy	Last Available: "2024-06"
 11595	perfumed clever occult mini kiwi bikini	0		Spell Damage Percent: +25, Maximum MP: +20, Stench Resistance: +5, Last Available: "2024-06"
-11596	weak aged squat mini kiwitini	2	awesome	Last Available: "2024-06"
+11596	aged weak squat mini kiwitini	2	awesome	Last Available: "2024-06"
 11597	upside-down mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	wholesome arcane researcher's stylish mini kiwi silicon tiepin	0		Moxie: +25, Experience Percent (Mysticality): +10, Maximum HP Percent: +10
 11600	mini kiwi tipi	0		
 11601	decent narrow mini kiwi digitized cookies	3	good	
-11602	aged enchanted blurry mini kiwi intoxicating spirits	3	awesome	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 20
+11602	enchanted aged blurry mini kiwi intoxicating spirits	3	awesome	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 20
 11603	flattened mini kiwi antimilitaristic hippy petition	0		Effect: "Chari Tea", Effect Duration: 46
 11604	anodized polarized twirling purple mini kiwi illicit antibiotic	0		Effect: "Feeling No Pain", Effect Duration: 29
 11605	green wobbly crafty strapping mini kiwi whipping stick	0		Muscle: +5, Maximum MP: +10
@@ -11470,9 +11470,9 @@
 11615	olive perfumed horrifying energetic messenger bag RNA	0		Maximum MP Percent: +20, Spooky Damage: +25, Stench Resistance: +5
 11616	blinking squat flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	decent ghostly jittery bacteria bisque	3	good	
-11619	adequate immense ciliophora chowder	7	good	
-11620	moldy bite-sized cream of chloroplasts	1	crappy	
+11618	decent jittery ghostly bacteria bisque	3	good	
+11619	immense adequate ciliophora chowder	7	good	
+11620	bite-sized moldy cream of chloroplasts	1	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	purple flagellate soup	0		
@@ -11490,7 +11490,7 @@
 11635	delicious Colera Peste Nebbiolo	4	awesome	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
-11638	bouncing wobbly bodyguard badge	0		
+11638	wobbly bouncing bodyguard badge	0		
 11639	twirling bouncing Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	huge mirror Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	avaricious auspicious Temple Grandin's embers-only jacket	0		Familiar Weight: +7, Item Drop: +10, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-09"
 11649	manspreader's bembershoot	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2024-09"
-11650	spoiled small upside-down wheel of camembert	2	crappy	Last Available: "2024-09"
+11650	small spoiled upside-down wheel of camembert	2	crappy	Last Available: "2024-09"
 11651	prompt supercool hat of remembering	0		Moxie Percent: +20, Item Drop: +5, Adventures: +3, Lasts Until Rollover, Last Available: "2024-09"
 11652	teal upside-down throwin' ember	0		Last Available: "2024-09"
 11653	pulsating head of emberg lettuce	0		Last Available: "2024-09"
@@ -11534,7 +11534,7 @@
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
-11682	vacuum-sealed irradiated huge mirror pea brittle	0		Effect: "Hombre Muerto Caminando", Effect Duration: 59, Last Available: "2024-11"
+11682	vacuum-sealed irradiated mirror huge pea brittle	0		Effect: "Hombre Muerto Caminando", Effect Duration: 59, Last Available: "2024-11"
 11683	drinkable peasco	3	good	Last Available: "2024-11"
 11684	moldy small piece of cake	2	crappy	Last Available: "2024-11"
 11685	ghostly handful of split pea soup	0		Last Available: "2024-11"
@@ -11553,14 +11553,14 @@
 11698	governor's daughter's pearl hairpin of the wise owl	0		Mysticality: +20, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	bouncing careful chili powder cutlass	0		Monster Level: -10, Last Available: "2024-12"
-11701	decent enchanted bite-sized jittery Aztec tamale	1	good	Effect: "Sweet Incentive", Effect Duration: 50, Last Available: "2024-12"
+11701	bite-sized decent enchanted jittery Aztec tamale	1	good	Effect: "Sweet Incentive", Effect Duration: 50, Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	groggles of the empath	0		Familiar Weight: +5, Last Available: "2024-12"
 11705	pirate dinghy	0		Last Available: "2024-12"
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	nippy silky pirate drawers of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +10, Last Available: "2024-12"
-11708	pulsating upside-down profane eye patch	0		Sleaze Damage: +3
+11708	upside-down pulsating profane eye patch	0		Sleaze Damage: +3
 11709	Vulcanized ionized peppermint pegleg	0		Effect: "Square to be Hip", Effect Duration: 46, Last Available: "2024-12"
 11710	hand-crafted hard cocoa	4	EPIC	Last Available: "2024-12"
 11711	adequate salmagumdi	4	good	Last Available: "2024-12"
@@ -11574,7 +11574,7 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	gigantic moldy coney haunch	8	crappy	Last Available: "2024-12"
+11722	moldy gigantic coney haunch	8	crappy	Last Available: "2024-12"
 11723	non-vacuum-sealed chilled liquefied mirror dark chocolate egg	0		Effect: "Extra-Sharp Weapon", Effect Duration: 43, Last Available: "2024-12"
 11724	drinkable practically non-alcoholic ghostly moai toai	1	good	
 11725	olive double-paned nippy moaiball of mayonnaise	0		Cold Damage: +10, Sleaze Spell Damage: +50, Cold Resistance: +5, Last Available: "2024-12"
@@ -11609,20 +11609,20 @@
 11754	bland enchanted beef and cabbage	4	decent	Effect: "Cool Spirit", Effect Duration: 30, Last Available: "2024-12"
 11755	adequate candy rations	3	good	Last Available: "2024-12"
 11756	moldy double-candied yams	4	crappy	Last Available: "2024-12"
-11757	moldy tiny Christmas ham	1	crappy	Last Available: "2024-12"
+11757	tiny moldy Christmas ham	1	crappy	Last Available: "2024-12"
 11758	miniature flavorless skewed holiday smorgasbord	2	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bouncing bejazzled eyepatch of the cougar	0		Moxie: +20, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	narrow Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	ghostly Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	wobbly Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	narrow Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	ghostly Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	wobbly Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	nasty frosty coward's hardened egg gun	0		Damage Reduction: 3, Monster Level: -20, Cold Spell Damage: +10, Stench Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	dance instructor's Socratic army helmet of the cougar of the businessman	0		Moxie: +20, Experience (Mysticality): +1, Experience Percent (Moxie): +10, Meat Drop: +50, Last Available: "2024-12"
@@ -11666,7 +11666,7 @@
 11811	logic grenade	0		Last Available: "2025-12"
 11812	dried psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
-11814	gray narrow dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
+11814	narrow gray dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	yellow dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	huge dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
@@ -11678,7 +11678,7 @@
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
-11826	bouncing blurry lime green hashing vise	0		Last Available: "2025-12"
+11826	lime green blurry bouncing hashing vise	0		Last Available: "2025-12"
 11827	ghostly geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	huge geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
@@ -11706,9 +11706,9 @@
 11851	wobbly stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	squat phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
-11854	upside-down huge grim cellophane	0		Combat Rate: -5
+11854	huge upside-down grim cellophane	0		Combat Rate: -5
 11855	pulsating rift oculus	0		Combat Rate: +5
-11856	jittery teal sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11856	teal jittery sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	shaking glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
@@ -11716,7 +11716,7 @@
 11861	yellow Leprecondo	0		Last Available: "2025-03"
 11862	mixed twirling scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	hand-crafted strong huge mirror pint of Leprechaun Stout	5	EPIC	Last Available: "2025-03"
+11864	strong hand-crafted huge mirror pint of Leprechaun Stout	5	EPIC	Last Available: "2025-03"
 11865	boiled phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11724,24 +11724,24 @@
 11869	unironic knife	0		
 11870	squat bar dart	0		Last Available: "2025-03"
 11871	diluted skewed leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	super-sized rotten Heck ramen	5	crappy	Last Available: "2025-03"
+11872	rotten super-sized Heck ramen	5	crappy	Last Available: "2025-03"
 11873	decent burrito	4	good	Last Available: "2025-03"
-11874	normal super-sized blinking small beer brat	5	good	Last Available: "2025-03"
+11874	super-sized normal blinking small beer brat	5	good	Last Available: "2025-03"
 11875	normal peach pie	4	good	Last Available: "2025-03"
-11876	super-sized tasty incredible mini-pizza	5	awesome	Last Available: "2025-03"
+11876	tasty super-sized incredible mini-pizza	5	awesome	Last Available: "2025-03"
 11877	mediocre Divine sidecar	4	decent	Last Available: "2025-03"
 11878	mediocre tangarita sidecar	4	decent	Last Available: "2025-03"
-11879	watered-down perfectly mixed gimlet sidecar	2	EPIC	Last Available: "2025-03"
+11879	perfectly mixed watered-down gimlet sidecar	2	EPIC	Last Available: "2025-03"
 11880	acceptable vodka stratocaster sidecar	4	good	Last Available: "2025-03"
 11881	bad triple-distilled prussian cathouse sidecar	6	decent	Last Available: "2025-03"
 11882	tolerable ghostly Mon Tiki sidecar	3	good	Last Available: "2025-03"
-11883	skewed blue Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
+11883	blue skewed Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	mirror April Shower Thoughts shield of the bloodbag of horror	0		Maximum HP: +100, Spooky Spell Damage: +25, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	electrified lime green wet paper weights	0		Effect: "protect.enq", Effect Duration: 62, Last Available: "2025-04"
-11888	delicious weak squat Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
-11889	rotten super-sized pile of wet dates	5	crappy	Last Available: "2025-04"
+11888	weak delicious squat Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
+11889	super-sized rotten pile of wet dates	5	crappy	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	twirling ghostly nippy wet shower cap	0		Cold Damage: +10, Last Available: "2025-04"
@@ -11781,7 +11781,7 @@
 11926	maroon censurious Axis suspenders of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Single Equip
 11927	stolen artifact	0		
 11928	maroon jittery really expensive stolen artifact	0		
-11929	spinning ghostly priceless stolen artifact	0		
+11929	ghostly spinning priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	blue nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
@@ -11805,13 +11805,13 @@
 11950	personal trainer's time cop top hat	0		Experience Percent (Muscle): +10, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	boiled mixed berry jelly	1		Last Available: "2025-08"
-11953	half-sized normal toast with mixed berry jelly	2	good	Last Available: "2025-08"
+11953	normal half-sized toast with mixed berry jelly	2	good	Last Available: "2025-08"
 11954	yummy cup of sugar	3	awesome	Last Available: "2025-08"
 11955	immense adequate Susie's cupcake	8	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	the gun of mayonnaise of the detective of the sweet-tooth	0		Sleaze Spell Damage: +50, Item Drop: +20, Candy Drop: +100, Last Available: "2025-08"
 11958	tolerable spinning wobbly wine	4	good	Last Available: "2025-08"
-11960	green tumbling really, really nice swimming trunks	0		
+11960	tumbling green really, really nice swimming trunks	0		
 11961	twirling sand penny	0		
 11962	greasy undersea surveying goggles	0		Sleaze Spell Damage: +10, Lasts Until Rollover
 11963	lousy wobbly Ocean-Touched Rum	4	decent	
@@ -11822,7 +11822,7 @@
 11968	scroll of sea smarm	0		
 11969	spinning waterlogged scroll of healing	0		
 11970	sea gel	0		
-11971	electrified ghostly upside-down octopus ink bladder	0		Effect: "Scrappy, Shadowy", Effect Duration: 15
+11971	electrified upside-down ghostly octopus ink bladder	0		Effect: "Scrappy, Shadowy", Effect Duration: 15
 11972	durable dolphin whistle	0		
 11973	bouncing Thwaitgold lobster statuette	0		
 11974	shaking packaged Monodent of the Sea	0		Free Pull
@@ -11833,18 +11833,18 @@
 11987	Annie Oakley's clever vibrating Da Vinci's slick blood cubic zirconia of the boozehound	0		Moxie: +10, Experience (Mysticality): +5, Maximum MP Percent: +10, Maximum MP: +20, Critical Hit Percent: +20, Booze Drop: +100, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	powdered tumbling blood thinner	1		Effect: "Perception", Effect Duration: 5, Last Available: "2025-10"
 12045	acceptable pheromone cocktail	4	good	Last Available: "2025-10"
-12046	stale diet spinal tapas	1	decent	Last Available: "2025-10"
+12046	diet stale spinal tapas	1	decent	Last Available: "2025-10"
 12047	pulsating shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	executive greasy nippy shrunken head	0		Cold Damage: +10, Sleaze Spell Damage: +10, Meat Drop: +40, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	shaking small peppermint-flavored sugar walking crook	0		
 12051	wobbly knucklebone	0		
-12052	acceptable irresponsibly strong cyan Smoking Pope	8	good	
+12052	irresponsibly strong acceptable cyan Smoking Pope	8	good	
 12053	spoiled prize turkey	3	crappy	
 12054	modified medicinal gruel	1		Effect: "Nasty, Nasty Breath", Effect Duration: 45
 12055	tasty wobbly full-sized pumpkin pie	3	awesome	Last Available: "2025-11"
 12056	triple-distilled lousy vodka cranberry sauce	7	decent	Last Available: "2025-11"
-12057	quadruple-moist non-irradiated squat green yammed candy	0		Effect: "Gr8ness", Effect Duration: 52, Last Available: "2025-11"
+12057	quadruple-moist non-irradiated green squat yammed candy	0		Effect: "Gr8ness", Effect Duration: 52, Last Available: "2025-11"
 12058	yummy treasure chestnut	4	awesome	Last Available: "2025-12"
 12059	lousy fortified skewed mulled butter rum	5	decent	Last Available: "2025-12"
 12060	wet cinnamon doubloon	0		Effect: "You Know Where to Go", Effect Duration: 59, Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	banded extra-thick Crimbo sweater	0		Damage Absorption: +100, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	weak perfectly mixed squat Steve Abrams' Holiday Sampler Beer	2	EPIC	Last Available: "2025-12"
+12124	perfectly mixed weak squat Steve Abrams' Holiday Sampler Beer	2	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	watered-down mediocre bottle of prize-winning rum	2	decent	Last Available: "2025-12"
 12127	mirror prompt Santa-Slayer medal of the cougar of courage	0		Moxie: +20, Spooky Resistance: +3, Adventures: +3, Single Equip, Last Available: "2025-12"
@@ -11914,9 +11914,9 @@
 12156	wobbly Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
-12159	narrow spinning olive Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
+12159	olive narrow spinning Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12161	shaking red Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12161	red shaking Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
@@ -11955,7 +11955,7 @@
 12197	blinking double-paned arcane researcher's and dress	0		Experience Percent (Mysticality): +10, Cold Resistance: +5, Last Available: "2026-03"
 12198	yellow lion tamer's sage and dress	0		Mysticality Percent: +10, Experience (familiar): +2, Last Available: "2026-03"
 12199	alkaline dinosaur bone broth	0		Effect: "Antarctic Memories", Effect Duration: 65, Last Available: "2026-03"
-12200	upside-down huge gnawing bone	0		Last Available: "2026-03"
+12200	huge upside-down gnawing bone	0		Last Available: "2026-03"
 12201	flame-wreathed dinosaur bone club	0		Hot Spell Damage: +10, Last Available: "2026-03"
 12202	avaricious savvy dinosaur skull helmet	0		Mysticality Percent: +20, Meat Drop: +30, Last Available: "2026-03"
 12203	knitted dinosaur bone corset of wisdom of the sweet-tooth	0		Mysticality: +15, Cold Resistance: +3, Candy Drop: +100, Last Available: "2026-03"
@@ -11972,13 +11972,13 @@
 12214	mixed candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	jumbo moldy discarded hot dog	5	crappy	Last Available: "2026-04"
-12218	hand-crafted high-proof upside-down most of a beer	9	EPIC	Last Available: "2026-04"
+12217	moldy jumbo discarded hot dog	5	crappy	Last Available: "2026-04"
+12218	high-proof hand-crafted upside-down most of a beer	9	EPIC	Last Available: "2026-04"
 12222	pulsating pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	immense delicious can of tuna	9	awesome	
-12227	low-calorie stale alien salad	1	decent	
+12226	delicious immense can of tuna	9	awesome	
+12227	stale low-calorie alien salad	1	decent	
 12228	adequate jumbo ratbatatouille	5	good	
 12229	spoiled blinking onigiri	3	crappy	
 12230	moldy crudit&eacute;s	3	crappy	
@@ -11988,7 +11988,7 @@
 12234	tasty later tots	3	awesome	
 12235	stale Frutti di Scatoletta	3	decent	Last Available: "2026-05"
 12236	bite-sized normal special bouncing Pesto alla Marziano	1	good	Effect: "Guts Feeling", Effect Duration: 20, Last Available: "2026-05"
-12237	flavorless low-calorie enchanted lime green Arrattabbattabiata	1	decent	Effect: "Buggy Flavor", Effect Duration: 20, Last Available: "2026-05"
+12237	low-calorie flavorless enchanted lime green Arrattabbattabiata	1	decent	Effect: "Buggy Flavor", Effect Duration: 20, Last Available: "2026-05"
 12238	tiny bland Orzo di Riso	1	decent	Last Available: "2026-05"
 12239	normal Pasta Grimavera	3	good	Last Available: "2026-05"
 12240	thick rotten Linguini Ubriacapa	5	crappy	Last Available: "2026-05"
@@ -11997,7 +11997,7 @@
 12243	decent Gnocci Domani	4	good	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
-12246	huge bouncing yellow second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
+12246	bouncing yellow huge second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	lard-coated friendly Space Soldier Helmet	0		Familiar Weight: +3, Sleaze Spell Damage: +25
 12253	decent premium turkey leg	4	good	
@@ -12020,8 +12020,8 @@
 12270	therapeutic occult boxer's Portable Laughing Stock	0		Muscle Percent: +10, Spell Damage Percent: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	wool horrifying arcane researcher's Staff of Anachronistic Churning	0		Experience Percent (Mysticality): +10, Spooky Damage: +25, Cold Resistance: +1
 12272	adequate spinning classic banana	3	good	Last Available: "2026-07"
-12273	spoiled super-sized pulsating watermelon	5	crappy	Last Available: "2026-07"
-12274	immense moldy skewed yellow quince	10	crappy	Last Available: "2026-07"
+12273	super-sized spoiled pulsating watermelon	5	crappy	Last Available: "2026-07"
+12274	moldy immense yellow skewed quince	10	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	rotten purple classic banana pie	3	crappy	Last Available: "2026-07"
@@ -12030,16 +12030,16 @@
 12280	watered-down smooth Aesop Daiquiri	2	awesome	Last Available: "2026-07"
 12281	mediocre Monkey Congress	3	decent	Last Available: "2026-07"
 12282	spoiled snack-sized watermelon pie	2	crappy	Last Available: "2026-07"
-12283	quadruple-vacuum-sealed mirror upside-down concentrated watermelon juice	0		Effect: "Pyramid Power", Effect Duration: 41, Last Available: "2026-07"
+12283	quadruple-vacuum-sealed upside-down mirror concentrated watermelon juice	0		Effect: "Pyramid Power", Effect Duration: 41, Last Available: "2026-07"
 12284	activated Aqua Citrulanatae	0		Effect: "Berry Defensive", Effect Duration: 20, Last Available: "2026-07"
 12285	hand-crafted practically non-alcoholic Melonegroni	1	super EPIC	Last Available: "2026-07"
 12286	bad Melonade Spritz	3	decent	Last Available: "2026-07"
 12287	big bland quince pie	5	decent	Last Available: "2026-07"
 12288	liquefied purple quince quaff	0		Effect: "Beta Carotene Overdose", Effect Duration: 69, Last Available: "2026-07"
 12289	pickled gray shaking Quickquince	0		Effect: "Butt-Rock Hair", Effect Duration: 52, Last Available: "2026-07"
-12290	weak mediocre mirror Quiskey Sour	2	decent	Last Available: "2026-07"
+12290	mediocre weak mirror Quiskey Sour	2	decent	Last Available: "2026-07"
 12291	tolerable weak Quincea&ntilde;era Cooler	2	good	Last Available: "2026-07"
-12292	practically non-alcoholic acceptable spinning Roth IPA	1	good	Last Available: "2026-08"
+12292	acceptable practically non-alcoholic spinning Roth IPA	1	good	Last Available: "2026-08"
 12293	veiny underdraft protection of the boozehound	0		Maximum HP: +10, Booze Drop: +100, Last Available: "2026-08"
 12294	maroon solvent	0		Last Available: "2026-08"
 12295	bland narrow soybean futures	3	decent	Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	spinning narrow savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	diluted narrow toxic asset	1		Last Available: "2026-08"
-12311	diluted maroon blurry intangible asset	1		Last Available: "2026-08"
-12312	pickled spinning lime green shaking liquid asset	1		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 40, Last Available: "2026-08"
+12311	diluted blurry maroon intangible asset	1		Last Available: "2026-08"
+12312	pickled spinning shaking lime green liquid asset	1		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 40, Last Available: "2026-08"
 12313	yellow gross prophet chrysalis	0		Last Available: "2026-08"
 12314	skewed cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Accordion_Thief_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Platypus_cafe_booze.txt
@@ -1,4 +1,4 @@
--1	fancy watered-down perfectly mixed spinning Petite Porter	2	EPIC	
+-1	watered-down perfectly mixed fancy spinning Petite Porter	2	EPIC	
 -2	bad ghostly Scrawny Stout	4	decent	
 -3	practically non-alcoholic lousy squat spinning Infinitesimal IPA	1	decent	
 -4	smooth watered-down eggnogtini	2	awesome	
@@ -12,22 +12,22 @@
 -21	lousy hot choculate	3	decent	
 -49	bad olive Cyder	4	decent	
 -50	tolerable fancy Oil Nog	3	good	
--51	weak mediocre lime green Hi-Octane Peppermint Jet Fuel	2	decent	
+-51	mediocre weak lime green Hi-Octane Peppermint Jet Fuel	2	decent	
 -58	artisanal watered-down Grimacider	2	EPIC	
 -59	drinkable Isotope Nog	3	good	
 -60	spirit-forward lousy Mutagin 'n' Tonic	5	decent	
--70	hand-crafted practically non-alcoholic huge Gin and Herring	1	EPIC	
+-70	practically non-alcoholic hand-crafted huge Gin and Herring	1	EPIC	
 -71	aged Black and Tan and Red All Over	4	awesome	
 -72	acceptable watered-down Antarctic Ice Tea	2	good	
 -76	smooth CRIMBCO Ribbon Candy Schnapps	4	awesome	
 -77	irresponsibly strong hand-crafted CRIMBCO Egg Substitute Nog Substitute	8	EPIC	
 -78	lousy enchanted practically non-alcoholic CRIMBCO Extreme Braincracker Sour	1	decent	
 -82	artisanal Horseradish-infused Vodka	4	EPIC	
--83	bad high-proof Jerkitini	10	decent	
+-83	high-proof bad Jerkitini	10	decent	
 -84	lousy Desert Island Iced Tea	4	decent	
 -88	hand-crafted narrow Crimbo Saketini	3	EPIC	
--89	extra-dry special aged lime green Crimboku Drop	5	awesome	
+-89	special extra-dry aged lime green Crimboku Drop	5	awesome	
 -90	acceptable Flaming Crimbo Log	3	good	
--107	mediocre spinning blurry Fortified Eggnog Slurry	3	decent	
+-107	mediocre blurry spinning Fortified Eggnog Slurry	3	decent	
 -108	lousy Hot Buttered Rum	3	decent	
--109	weak artisanal Spicy Hot Chocolate	2	EPIC	
+-109	artisanal weak Spicy Hot Chocolate	2	EPIC	

--- a/data/TCRS/TCRS_Accordion_Thief_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Platypus_cafe_food.txt
@@ -1,32 +1,32 @@
--1	decent half-sized fancy spinning Peche a la Frog	2	good	
+-1	half-sized decent fancy spinning Peche a la Frog	2	good	
 -2	rotten ghostly As Jus Gezund Heit	4	crappy	
--3	spoiled diet squat spinning Bouillabaise Coucher Avec Moi	1	crappy	
+-3	diet spoiled squat spinning Bouillabaise Coucher Avec Moi	1	crappy	
 -7	miniature decent gray squat gumdrop chow mein	2	good	
 -8	stale huge candy cane pizza	7	decent	
 -9	yummy massive gingerbread stir-fry	7	awesome	
 -10	stale miniature twigs and gravel	2	decent	
 -11	bite-sized stale shoots and leaves	1	decent	
--12	enchanted moldy bowl of unidentifiable goo	3	crappy	
+-12	moldy enchanted bowl of unidentifiable goo	3	crappy	
 -13	tiny stale ghostly gingerbread massacre	1	decent	
 -14	half-sized adequate tumbling It Came From Beyond Dessert	2	good	
 -15	rotten small vampire cake	2	crappy	
--52	snack-sized decent Soylent Red and Green	2	good	
+-52	decent snack-sized Soylent Red and Green	2	good	
 -53	snack-sized toothsome Disc-Shaped Nutrition Unit	2	awesome	
--54	snack-sized delicious Gingerborg Hive	2	awesome	
+-54	delicious snack-sized Gingerborg Hive	2	awesome	
 -61	toothsome Candy Cane Surprise	3	awesome	
 -62	fancy rotten Grimdrop Chow Mein	3	crappy	
 -63	spoiled fuchsia Grimgerbread House	4	crappy	
 -67	spoiled special Caviar Carbonara	3	crappy	
 -68	stale Halibut Alfredo	4	decent	
 -69	flavorless Red Herring Velvet Cake	3	decent	
--73	immense flavorless CRIMBCO Reconstituted Gruel	8	decent	
+-73	flavorless immense CRIMBCO Reconstituted Gruel	8	decent	
 -74	bland upside-down New and Improved CRIMBCO Reconstituted Gruel	3	decent	
 -75	jumbo tasty CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	awesome	
 -79	stale diet Brussels Sprout Stir-Fry	1	decent	
--80	low-calorie moldy special cyan Carrot, Cabbage, and Kale Pizza	1	crappy	
+-80	moldy low-calorie special cyan Carrot, Cabbage, and Kale Pizza	1	crappy	
 -81	flavorless fancy Turnip and Rutabaga Pie	3	decent	
--85	toothsome special Rainbow Spider Fun Roll	3	awesome	
--86	bite-sized decent Vegas Volcano Lava Roll	1	good	
+-85	special toothsome Rainbow Spider Fun Roll	3	awesome	
+-86	decent bite-sized Vegas Volcano Lava Roll	1	good	
 -87	delicious Crazy Dragon Shogun Buddha Roll	3	awesome	
 -92	stale basic hot dog	4	decent	
 -93	half-sized enchanted normal huge savage macho dog	2	good	
@@ -36,9 +36,9 @@
 -97	rotten chilly dog	3	crappy	
 -98	adequate tumbling ghost dog	4	good	
 -99	adequate squat cyan junkyard dog	4	good	
--100	huge spoiled wet dog	6	crappy	
+-100	spoiled huge wet dog	6	crappy	
 -101	flavorless maroon sleeping dog	3	decent	
--102	special decent huge spinning optimal dog	10	good	
+-102	decent special huge spinning optimal dog	10	good	
 -103	small spoiled video games hot dog	2	crappy	
 -104	moldy Peppermint Nutrition Block	3	crappy	
 -105	spoiled Gingerbread Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Accordion_Thief_Vole.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Vole.txt
@@ -11,15 +11,15 @@
 11	squat stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	vaporized moxie weed	1		
-15	dehydrated purple ghostly strongness elixir	1		Effect: "Expert Vacationer", Effect Duration: 25
+15	dehydrated ghostly purple strongness elixir	1		Effect: "Expert Vacationer", Effect Duration: 25
 16	mixed upside-down magicalness-in-a-can	1		
-17	miniature spoiled noodles	2	crappy	
+17	spoiled miniature noodles	2	crappy	
 18	tortoise's blessing	0		
 19	asparagus knife of the scaredy-cat	0		Monster Level: -15
 20	wobbly Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
 22	huge studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
-23	jittery purple chewing gum on a string	0		
+23	purple jittery chewing gum on a string	0		
 24	ten-leaf clover	0		
 25	meat paste	0		
 26	Dolphin King's map	0		
@@ -37,7 +37,7 @@
 38	wobbly Knob Goblin pants of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, 5xPotato, cap 6"
 39	jittery pretty flower	0		
 40	cyan casino pass	0		
-41	practically non-alcoholic drinkable blurry ice-cold Sir Schlitz	1	good	
+41	drinkable practically non-alcoholic blurry ice-cold Sir Schlitz	1	good	
 42	hermit permit	0		
 43	yellow worthless trinket	0		
 44	fuchsia worthless gewgaw	0		
@@ -57,7 +57,7 @@
 58	huge stone turtle	0		
 59	ghostly slingshot	0		
 60	twirling lime green sizzling Mace of the Tortoise	0		Hot Damage: +10, Class: "Turtle Tamer"
-61	enchanted miniature stale fortune cookie	2	decent	Effect: "Crying, Dying", Effect Duration: 25
+61	stale enchanted miniature fortune cookie	2	decent	Effect: "Crying, Dying", Effect Duration: 25
 62	jittery educational oriole-feather headdress	0		Experience: +1, Familiar Effect: "atk, 3xVolley, cap 3"
 63	teal action figure body	0		
 64	blinking action figure head	0		
@@ -65,13 +65,13 @@
 66	twig	0		
 67	spaghetti with rock-balls	0		
 68	avaricious greedy Pasta Spoon of Peril	0		Meat Drop: 50, Class: "Pastamancer"
-69	gray squat Newbiesport&trade; tent	0		
+69	squat gray Newbiesport&trade; tent	0		
 70	narrow bar skin	0		
 71	double-paned stakes	0		Cold Resistance: +5
 72	ghostly wicked barskin hat	0		Spell Damage: +5, Familiar Effect: "atk, 1xVolley, cap 13"
 73	upside-down barskin tent	0		
 74	shaking Temple map	0		
-75	gray skewed sapling	0		
+75	skewed gray sapling	0		
 76	Spooky-Gro fertilizer	0		
 77	skewed stick of Tarzan	0		Experience (Muscle): +3
 78	Herculean pretty bouquet	0		Experience (Muscle): +1
@@ -161,9 +161,9 @@
 162	delicious ghuol egg quiche	3	awesome	
 163	jittery family-friendly skeleton bone	0		Sleaze Resistance: +1
 164	jittery smart skull	0		
-165	narrow maroon skewer	0		
+165	maroon narrow skewer	0		
 166	wobbly ghuol ears	0		
-167	thick toothsome ghuol-ear kabob	5	awesome	
+167	toothsome thick ghuol-ear kabob	5	awesome	
 168	huge bone rattle of chilblains	0		Cold Damage: +25
 169	tumbling bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -176,15 +176,15 @@
 177	brainy skull	0		
 178	cyan detective skull	0		
 179	yummy chorizo taco	4	awesome	
-180	delicious triple-distilled ice-cold fotie	10	awesome	
+180	triple-distilled delicious ice-cold fotie	10	awesome	
 181	baseball	0		
 182	batgut	0		
-183	twirling yellow narrow bat wing	0		
+183	yellow narrow twirling bat wing	0		
 184	briefcase	0		
 185	pulsating fat stacks of cash	0		
 186	bean	0		
 187	loose teeth	0		
-188	narrow blinking bat guano	0		
+188	blinking narrow bat guano	0		
 189	wobbly squat guano coffee cup	0		
 191	auspicious batskin belt	0		Item Drop: +10
 192	batskin belt	0		
@@ -196,10 +196,10 @@
 198	rat appendix	0		
 199	ring of the scaredy-cat	0		Monster Level: -15
 200	flavorless rat appendix kabob	3	decent	
-201	miniature moldy upside-down narrow teal bat wing kabob	2	crappy	
+201	miniature moldy teal upside-down narrow bat wing kabob	2	crappy	
 202	small bland carob chunks	2	decent	
 203	herbs	0		
-204	super-sized tasty lime green tumbling carob chunk cookies	5	awesome	
+204	super-sized tasty tumbling lime green carob chunk cookies	5	awesome	
 205	secret blend of herbs and spices	0		
 206	piercing post	0		
 207	lime green hippy herbal tea	1	good	
@@ -211,8 +211,8 @@
 213	spinning smelly smooth filthy corduroys	0		Moxie: +15, Stench Spell Damage: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	rock-hard filthy knitted dread sack	0		Damage Reduction: 5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	diet rotten carob brownies	1	crappy	
-217	miniature flavorless herb brownies	2	decent	
+216	rotten diet carob brownies	1	crappy	
+217	flavorless miniature herb brownies	2	decent	
 218	hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -220,8 +220,8 @@
 222	blinking phat turquoise bead	0		
 223	executive phat turquoise bracelet	0		Meat Drop: +40
 224	eyepatch of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "3xBarrr, cap 6"
-225	miniature adequate tofu casserole	2	good	
-226	altered skewed gray twirling can of Red Minotaur	1	EPIC	
+225	adequate miniature tofu casserole	2	good	
+226	altered twirling gray skewed can of Red Minotaur	1	EPIC	
 227	Kentucky-fried meat sword of the glutton	0		Food Drop: +100
 228	quilted Kentucky-fried meat staff	0		Damage Absorption: +40
 229	bouncing savvy Kentucky-fried meat crossbow	0		Mysticality Percent: +20
@@ -229,7 +229,7 @@
 231	Doc Galaktik's Pungent Unguent	0		
 232	Doc Galaktik's Ailment Ointment	0		
 233	blinking Doc Galaktik's Restorative Balm	0		
-234	narrow gray Doc Galaktik's Homeopathic Elixir	0		
+234	gray narrow Doc Galaktik's Homeopathic Elixir	0		
 235	stanky Temple Grandin's Bigger Bugfinder Blade	0		Familiar Weight: +7, Stench Spell Damage: +25
 236	jittery Queue Du Coq cocktailcrafting kit	0		
 237	strong hand-crafted special bottle of gin	5	EPIC	Effect: "Aided and Abetted", Effect Duration: 30
@@ -238,18 +238,18 @@
 240	huge olive stanky razor-sharp Orcish cargo shorts	0		Weapon Damage Percent: +25, Stench Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	tumbling careful Orcish frat-paddle	0		Monster Level: -10
 242	moldy	4	crappy	
-243	adequate bite-sized blinking grapefruit	1	good	
-244	spoiled massive maroon grapes	8	crappy	
-245	tasty small olive wobbly olive	2	awesome	
-246	half-sized yummy teal shaking tomato	2	awesome	
+243	bite-sized adequate blinking grapefruit	1	good	
+244	massive spoiled maroon grapes	8	crappy	
+245	tasty small wobbly olive olive	2	awesome	
+246	yummy half-sized shaking teal tomato	2	awesome	
 247	fermenting powder	0		
-248	watered-down delicious squat salty dog	2	awesome	
+248	delicious watered-down squat salty dog	2	awesome	
 249	acceptable bloody mary	3	good	
 250	practically non-alcoholic tolerable screwdriver	1	good	
 251	lousy olive martini	4	decent	
-252	hand-crafted practically non-alcoholic bloody beer	1	EPIC	
+252	practically non-alcoholic hand-crafted bloody beer	1	EPIC	
 253	artisanal pulsating shot of schnapps	3	EPIC	
-254	delicious watered-down shot of grapefruit schnapps	2	awesome	
+254	watered-down delicious shot of grapefruit schnapps	2	awesome	
 255	perfectly mixed fine wine	3	EPIC	
 256	watered-down hand-crafted shot of tomato schnapps	2	EPIC	
 257	lousy extra-spicy bloody mary	3	decent	
@@ -259,7 +259,7 @@
 261	normal blinking White Citadel burger	3	good	
 262	adequate upside-down piece of wedding cake	3	good	
 263	decent pulsating chocolate chips	3	good	
-264	delicious miniature chocolate chip cookies	2	awesome	
+264	miniature delicious chocolate chip cookies	2	awesome	
 265	shellacked satin pants	0		Damage Reduction: 7, Familiar Effect: "atk, 2xPotato, cap 10"
 266	artisanal yellow lightning	4	EPIC	
 267	family-friendly mullet wig	0		Sleaze Resistance: +1, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -295,7 +295,7 @@
 297	alkaline super-electrified denatured green tamarind-flavored chewing gum	0		Effect: "Hobo Flavor", Effect Duration: 11
 298	double-electrified colloidal lime-and-chile-flavored chewing gum	0		Effect: "Mad at Science", Effect Duration: 20
 299	colloidal quantum ghostly pickle-flavored chewing gum	0		Effect: "Morbidi Tea", Effect Duration: 27
-300	triple-diffused bouncing twirling jaba&ntilde;ero-flavored chewing gum	0		Effect: "Frisky Spirit", Effect Duration: 17
+300	triple-diffused twirling bouncing jaba&ntilde;ero-flavored chewing gum	0		Effect: "Frisky Spirit", Effect Duration: 17
 301	flat dough	0		
 302	toothsome Knob sausage	4	awesome	
 303	bland Knob mushroom	3	decent	
@@ -310,20 +310,20 @@
 312	aromatic Knob Goblin visor	0		Stench Resistance: +1, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	shaking cool Crown of the Goblin King	0		Moxie: +5, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	decent yellow bean burrito	4	good	
-315	decent fancy immense bean burrito	9	good	Effect: "Perfect Hair", Effect Duration: 10
-316	adequate miniature blinking insanely bean burrito	2	good	
+315	fancy decent immense bean burrito	9	good	Effect: "Perfect Hair", Effect Duration: 10
+316	miniature adequate blinking insanely bean burrito	2	good	
 317	moldy shaking teal bean burrito	4	crappy	
 318	spoiled bean burrito	4	crappy	
 319	low-calorie bland insanely bean burrito	1	decent	
-320	small stale bat haggis	2	decent	
-321	bland fancy menudo	3	decent	Effect: "Bone Homie", Effect Duration: 20
+320	stale small bat haggis	2	decent	
+321	fancy bland menudo	3	decent	Effect: "Bone Homie", Effect Duration: 20
 322	miniature bland teal goat cheese	2	decent	
 323	adequate miniature plain pizza	2	good	
-324	normal enchanted sausage pizza	3	good	Effect: "Coy to the Hurled", Effect Duration: 25
+324	enchanted normal sausage pizza	3	good	Effect: "Coy to the Hurled", Effect Duration: 25
 325	diet decent twirling goat cheese pizza	1	good	
 326	adequate narrow mushroom pizza	3	good	
 327	goat	0		
-328	fancy aged upside-down bottle of whiskey	3	awesome	Effect: "Shredding, Sweating", Effect Duration: 5
+328	aged fancy upside-down bottle of whiskey	3	awesome	Effect: "Shredding, Sweating", Effect Duration: 5
 329	fireproof goat beard	0		Hot Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
 331	lousy weak Canadian	2	decent	
@@ -340,7 +340,7 @@
 342	Knob Goblin stink bomb	0		
 343	alkaline aerosolized blurry Knob Goblin sharpening spray	0		Effect: "Flower Power", Effect Duration: 25
 344	mirror Knob Goblin seltzer	0		
-345	shaking jittery narrow Knob Goblin superseltzer	0		
+345	narrow jittery shaking Knob Goblin superseltzer	0		
 346	maroon blurry scrumptious reagent	0		
 347	purple Dyspepsi-Cola	0		
 348	brainy ninja mask	0		Mysticality: +5, Familiar Effect: "cold atk, 1xBarrr, cap 20"
@@ -382,14 +382,14 @@
 384	quilted chrome sword of temperance	0		Damage Absorption: +40, Sleaze Resistance: +5
 385	shellacked beefy chrome staff	0		Muscle: +10, Damage Reduction: 7
 386	perfumed occult chrome crossbow	0		Spell Damage Percent: +25, Stench Resistance: +5
-387	blinking teal fuzzy dice	0		
+387	teal blinking fuzzy dice	0		
 388	yeti fur	0		
 389	blinking Lo Pan's meaty helmet turtle	0		Spell Critical Percent: +30, Familiar Effect: "sleaze atk, 1xFairy, cap 17"
 390	supercharged asbestos helmet turtle	0		Maximum MP Percent: +30, Familiar Effect: "hot atk, 1xFairy, cap 20"
 391	Jeselnik's linoleum helmet turtle	0		Sleaze Damage: +25, Familiar Effect: "stench atk, 1xFairy, cap 25"
 392	pulsating thinker's chrome helmet turtle	0		Mysticality: +10, Familiar Effect: "cold atk, 1xFairy, cap 30"
 393	penguin skin	0		
-394	bouncing tumbling yak skin	0		
+394	tumbling bouncing yak skin	0		
 395	blinking hippopotamus skin	0		
 396	Rosewater's penguin shorts	0		Mysticality Percent: +30, Familiar Effect: "cold atk, 1xGhuol, cap 30"
 397	greasy yakskin pants	0		Sleaze Spell Damage: +10, Familiar Effect: "stench atk, 1xPotato, cap 35"
@@ -425,7 +425,7 @@
 427	fuchsia knitted box	0		Cold Resistance: +3, Wiki Name: "box"
 428	skewed nothing-in-the-box	0		
 429	beanbag chair	0		
-430	blinking huge gray acid-squirting flower	0		Single Equip
+430	huge blinking gray acid-squirting flower	0		Single Equip
 431	clown shoes of the detective	0		Item Drop: +20, Clowniness: 25
 432	razor-sharp bloody clown pants	0		Weapon Damage Percent: +25, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
 433	skinny balloon	0		
@@ -465,7 +465,7 @@
 467	moldy fancy pixel pie	3	crappy	Effect: "Weird Vibrations", Effect Duration: 35
 468	jittery ruby W	0		
 469	wussiness potion	0		
-470	mediocre practically non-alcoholic fuchsia Imp Ale	1	decent	
+470	practically non-alcoholic mediocre fuchsia Imp Ale	1	decent	
 471	flavorless hot wing	3	decent	
 472	smooth diamond-studded cane	0		Moxie: +15, Class: "Disco Bandit"
 473	bouncing electrified crutch	0		MP Regen Min: 3, MP Regen Max: 5
@@ -496,12 +496,12 @@
 498	flavorless papaya	4	decent	
 499	greasy educational denim axe	0		Experience: +1, Sleaze Spell Damage: +10
 500	olive Elf Farm Raffle ticket	0		
-501	low-calorie stale spinning Elfin shortbread	1	decent	
+501	stale low-calorie spinning Elfin shortbread	1	decent	
 502	huge jittery pagoda plans	0		
 503	decent low-calorie skewered cat appendix	1	good	
 504	evil arches	0		
 505	blue vibrating veiny gnatwing earring	0		Maximum HP: +10, Maximum MP Percent: +10
-506	thick rotten skewed blurry Hell broth	5	crappy	
+506	rotten thick skewed blurry Hell broth	5	crappy	
 507	thunderrr guitarrr of the sewer	0		Stench Damage: +25
 508	sonata	0		
 509	Hey Deze nuts	0		
@@ -509,8 +509,8 @@
 511	blinking Jarlsberg's key lime	0		
 512	skewed Sneaky Pete's key lime	0		
 513	flavorless bouncing Boris's key lime pie	3	decent	
-514	spoiled special twirling Jarlsberg's key lime pie	4	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 30
-515	small delicious Sneaky Pete's key lime pie	2	awesome	
+514	special spoiled twirling Jarlsberg's key lime pie	4	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 30
+515	delicious small Sneaky Pete's key lime pie	2	awesome	
 516	jittery olive Hey Deze map	0		
 517	wizardly bejeweled accordion strap	0		Mysticality: +25, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -552,40 +552,40 @@
 554	stale pr0n cocktail	4	decent	
 555	lion tamer's drywall axe of dire peril	0		Weapon Damage: +20, Experience (familiar): +2
 556	blinking Sinatra's Pine-Fresh air freshener	0		Experience (Moxie): +5
-557	drinkable triple-distilled whiskey and cola	8	good	
+557	triple-distilled drinkable whiskey and cola	8	good	
 558	delicious miniature papaya taco	2	awesome	
 559	razor-sharp can lid	0		
 560	gigantic adequate stalk of asparagus	7	good	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	distilled acceptable yellow Mad Train wine	5	good	
+564	acceptable distilled yellow Mad Train wine	5	good	
 565	hobo gloves of the blizzard	0		Cold Spell Damage: +25, Single Equip
 566	bum cheek of the wise owl	0		Mysticality: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	moldy Double Bacon Beelzeburger	4	crappy	
-569	massive fancy delicious Lord of the Flies-sized fries	10	awesome	Effect: "Feet of Grapefruit", Effect Duration: 5
+569	fancy massive delicious Lord of the Flies-sized fries	10	awesome	Effect: "Feet of Grapefruit", Effect Duration: 5
 570	enchanted normal Chicken Sandwich	3	good	Effect: "Wise Spirit", Effect Duration: 20
 571	enchanted Jumbo Dr. Lucifer	1	decent	Effect: "All Glory To the Toad", Effect Duration: 25
 572	bland Children's Meal of the Damned	4	decent	
-573	rotten low-calorie noodles	1	crappy	
-574	rotten blurry yellow noodles	4	crappy	
+573	low-calorie rotten noodles	1	crappy	
+574	rotten yellow blurry noodles	4	crappy	
 575	moldy painful penne pasta	3	crappy	
-576	huge adequate ravioli della hippy	8	good	
-577	flavorless snack-sized pr0n m4nic0tti	2	decent	
+576	adequate huge ravioli della hippy	8	good	
+577	snack-sized flavorless pr0n m4nic0tti	2	decent	
 578	flavorless Hell ramen	4	decent	
 579	adequate boring spaghetti	3	good	
 580	sauce of the ages	0		
 581	ghostly schmancy cheese sauce	0		
 582	cyan Himalayan Hidalgo sauce	0		
-583	enchanted small rotten fettucini Inconnu	2	crappy	Effect: "Go-Gone", Effect Duration: 5
+583	small rotten enchanted fettucini Inconnu	2	crappy	Effect: "Go-Gone", Effect Duration: 5
 584	special bland spaghetti with Skullheads	4	decent	Effect: "Salty Dogs", Effect Duration: 25
 585	super-sized flavorless gnocchetti di Nietzsche	5	decent	
 586	cyan strapping ridiculously huge sword of wisdom	0		Muscle: +5, Mysticality: +15
 587	frozen quadruple-deionized super-spiky hair gel	0		Effect: "Papowerful", Effect Duration: 33
 588	soft echo eyedrop antidote	0		
 589	moldy snack-sized cocoa eggshell fragment	2	crappy	
-590	stale fancy small cocoa eggshell fragment	2	decent	Effect: "Leo Rising", Effect Duration: 20
+590	stale small fancy cocoa eggshell fragment	2	decent	Effect: "Leo Rising", Effect Duration: 20
 591	cocoa egg	0		
 592	house	0		
 593	phonics down	0		
@@ -632,7 +632,7 @@
 634	cool whip	0		
 635	quilted paper umbrella	0		Damage Absorption: +40
 636	pulsating pulsating meat globe	0		
-637	narrow red toaster	0		
+637	red narrow toaster	0		
 638	brawny asshat of the glutton	0		Muscle Percent: +20, Food Drop: +100, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	adequate massive jittery abominable snowcone	10	good	
 640	Ent cider	1	crappy	
@@ -644,8 +644,8 @@
 646	delicious snack-sized fruitcake	2	awesome	
 647	red present	0		Last Available: "2004-11"
 648	skewed Crimbo sword of the pedagogue	0		Experience: +3, Last Available: "2004-10"
-649	rosy-cheeked Crimbo hat	0		Maximum HP Percent: +30, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	experienced Crimbo pants	0		Experience: +2, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	rosy-cheeked Crimbo hat	0		Maximum HP Percent: +30, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	experienced Crimbo pants	0		Experience: +2, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	exclusive ultra-rare item of the storm	0		Maximum MP Percent: +40
 652	quantum egg	0		
 653	pulsating intragalactic rowboat	0		
@@ -667,7 +667,7 @@
 669	bland ghuol guolash	3	decent	
 670	executive lihc face	0		Meat Drop: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	dog trainer's dangerous grave robbing shovel	0		Weapon Damage: +10, Experience (familiar): +1
-672	special miniature normal jittery gray cranberries	2	good	Effect: "Mucilaginous Muscle", Effect Duration: 30
+672	normal miniature special jittery gray cranberries	2	good	Effect: "Mucilaginous Muscle", Effect Duration: 30
 673	hand-crafted lime green vodka and cranberry	4	EPIC	
 674	weak drinkable whiskey	2	good	
 675	ruddy skull of the Bonerdagon	0		Maximum HP Percent: +40
@@ -716,11 +716,11 @@
 720	Jim Carey's clever porquoise necklace	0		Maximum MP: +20, Monster Level: +25, Single Equip
 721	knitted hardened porquoise bracelet	0		Damage Reduction: 3, Cold Resistance: +3
 722	auspicious Temple Grandin's personal trainer's porquoise ring	0		Experience Percent (Muscle): +10, Familiar Weight: +7, Item Drop: +10, Single Equip
-723	enchanted tasty Knoll mushroom	3	awesome	Effect: "Space Tripping", Effect Duration: 25
+723	tasty enchanted Knoll mushroom	3	awesome	Effect: "Space Tripping", Effect Duration: 25
 724	flavorless mushroom	4	decent	
 725	bouncing one million meat pancakes	0		
 726	vibrating huge mirror shard	0		Maximum MP Percent: +10
-727	squat teal spinning hedge maze puzzle	0		
+727	spinning squat teal hedge maze puzzle	0		
 728	blue hedge maze key	0		
 729	fishbowl	0		
 730	fishtank	0		
@@ -737,24 +737,24 @@
 741	broken skull	0		
 742	toothsome jumbo Knoll shroomkabob	5	awesome	
 743	decent gigantic mushroom	9	good	
-744	irradiated super-flattened tumbling huge hair spray	0		Effect: "Weepy, Creepy", Effect Duration: 29
+744	irradiated super-flattened huge tumbling hair spray	0		Effect: "Weepy, Creepy", Effect Duration: 29
 746	mirror stat script	0		
 747	pulsating Knob Goblin firecracker	0		
 748	purple gourd potion	0		
 749	rotten blinking blurry warm mushroom	3	crappy	
 750	delicious mushroom quesadilla	4	awesome	
 751	thick decent cool mushroom	5	good	
-752	rotten small cool mushroom casserole	2	crappy	
+752	small rotten cool mushroom casserole	2	crappy	
 753	decent pointy mushroom	3	good	
 754	delicious snack-sized tumbling cream of pointy mushroom soup	2	awesome	
 755	fancy stale mushroom	3	decent	Effect: "I See Everything Thrice!", Effect Duration: 15
-756	spoiled snack-sized mushroom	2	crappy	
+756	snack-sized spoiled mushroom	2	crappy	
 757	decent fancy bouncing mushroom	4	good	Effect: "Hyperoffended", Effect Duration: 30
 758	spoiled ghost cucumber	3	crappy	
 759	green dill	0		
 760	vinegar	0		
 761	mirror brine	0		
-762	watered-down aged especially salty dog	2	awesome	
+762	aged watered-down especially salty dog	2	awesome	
 763	bouncing ghostly pickling solution	0		
 764	decent miniature spectral pickle	2	good	
 765	briny vinegar	0		
@@ -782,7 +782,7 @@
 787	drinkable bottle of rum	3	good	
 788	mediocre strawberry daiquiri	3	decent	
 789	lousy strong rum and cola	5	decent	
-790	bad enchanted grog	4	decent	Effect: "Patent Prevention", Effect Duration: 50
+790	enchanted bad grog	4	decent	Effect: "Patent Prevention", Effect Duration: 50
 791	inspector's fireproof Mafia bow tie	0		Hot Resistance: +3, Item Drop: +15, Last Available: "2004-10"
 792	bouncing Golden Mr. Accessory of the dark arts	0		Spell Damage Percent: +100, Softcore Only
 793	electrified oil of stability	0		Effect: "Voracious Gorging", Effect Duration: 48
@@ -790,26 +790,26 @@
 795	aged Acque Luride Grezze Cabernet	4	awesome	Last Available: "2004-10"
 796	yellow narrow reassuring knitted cement shoes of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +3, Spooky Resistance: +1, Last Available: "2004-10"
 797	drinkable rockin' wagon	3	good	
-798	special delicious watered-down wobbly jittery ocean motion	2	awesome	Effect: "Strength of Ten Ettins", Effect Duration: 25
-799	fancy delicious fuzzbump	3	awesome	Effect: "White-boy Angst", Effect Duration: 40
+798	special delicious watered-down jittery wobbly ocean motion	2	awesome	Effect: "Strength of Ten Ettins", Effect Duration: 25
+799	delicious fancy fuzzbump	3	awesome	Effect: "White-boy Angst", Effect Duration: 40
 800	yummy snack-sized poutine	2	awesome	
 801	decent fuchsia Knob stir-fry	4	good	
 804	stale half-sized Knoll stir-fry	2	decent	
 805	rotten bite-sized stir-fry	1	crappy	
 806	spoiled half-sized blue asparagus stir-fry	2	crappy	
-807	huge flavorless olive stir-fry	9	decent	
+807	flavorless huge olive stir-fry	9	decent	
 808	stale thick shaking Knob sausage stir-fry	5	decent	
 809	rotten bat wing stir-fry	4	crappy	
 810	toothsome upside-down rat appendix stir-fry	3	awesome	
 811	bland blinking tofu stir-fry	3	decent	
-812	yummy small pr0n stir-fry	2	awesome	
+812	small yummy pr0n stir-fry	2	awesome	
 813	decent Knob shells	3	good	
 814	half-sized delicious b&auml;tzle	2	awesome	
 815	moldy big ratini	5	crappy	
 816	toothsome huge Knob stroganoff	9	awesome	
 817	half-sized moldy menudo ravioli	2	crappy	
 818	plus sign	0		
-819	blurry pulsating milky potion	0		
+819	pulsating blurry milky potion	0		
 820	huge swirly potion	0		
 821	bubbly potion	0		
 822	smoky potion	0		
@@ -820,20 +820,20 @@
 827	murky potion	0		
 828	wobbly baby killer bee	0		
 829	anti-anti-antidote	0		
-830	moldy super-sized royal jelly	5	crappy	
+830	super-sized moldy royal jelly	5	crappy	
 831	small box	0		
 832	ghostly twirling box	0		
 833	hardy vorpal blade	0		Maximum HP: +50
 834	yellow auspicious Van der Graaf cornuthaum	0		Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	mirror blurry ring of aggravate monster of the cheetah	0		Initiative: +60
-836	toothsome small mind flayer corpse	2	awesome	
+836	small toothsome mind flayer corpse	2	awesome	
 837	artisanal green Uovo Marcio Shiraz	4	EPIC	Last Available: "2004-10"
 838	aromatic Mafia stogie of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Last Available: "2004-10"
 839	practically non-alcoholic hand-crafted ghostly Maiali Sifilitici Pinot Noir	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 840	prompt sharpshooter's Mafia violin case	0		Critical Hit Percent: +10, Adventures: +3, Last Available: "2004-10"
 841	perfectly mixed practically non-alcoholic tomato daiquiri	1	EPIC	
 842	artisanal beertini	4	EPIC	
-843	perfectly mixed triple-distilled salty slug	7	EPIC	
+843	triple-distilled perfectly mixed salty slug	7	EPIC	
 844	hand-crafted irresponsibly strong papaya slung	7	EPIC	
 845	stiffened MAHI fez	0		Damage Reduction: 1, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	upside-down wobbly heteroerotic frat-paddle	0		
@@ -859,7 +859,7 @@
 867	dry flattened green blinking pine tar	0		Effect: "Brother Smothers's Blessing", Effect Duration: 19
 869	jittery forest tears	0		
 870	olive fetus-smashing club of bravery	0		Spooky Resistance: +5
-871	ghostly cyan meatcar model	0		Familiar Weight: +5
+871	cyan ghostly meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
 873	rolling pin	0		
 874	unrolling pin	0		
@@ -871,7 +871,7 @@
 880	pulsating disbelief suspenders of the glutton	0		Food Drop: +100
 881	grievous supportive bra	0		Weapon Damage Percent: +50
 882	spinning Blatantly Canadian	0		
-883	shaking mirror maple syrup	1	decent	
+883	mirror shaking maple syrup	1	decent	
 884	lightning-fast los chinos	0		Initiative: +40, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	miser's axe	0		Meat Drop: +10
 886	leaflet	0		
@@ -892,13 +892,13 @@
 901	squat espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	artisanal Spasmi Dolorosi Del Rene Champagne	4	EPIC	Last Available: "2004-10"
-904	maroon chilly cool school Mafia knickerbockers of Leguizamo	0		Moxie: +5, Monster Level: +20, Cold Damage: +5, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	maroon chilly cool school Mafia knickerbockers of Leguizamo	0		Moxie: +5, Monster Level: +20, Cold Damage: +5, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	quadruple-ionized galvanized Yummy Tummy bean	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 53
 906	oxidized Rock Pops	0		Effect: "Steroid Boost", Effect Duration: 57
 907	pressed deionized Mr. Mediocrebar	0		Effect: "Really Deep Breath", Effect Duration: 34
 908	denatured nitrogenated Cold Hots candy	0		Effect: "Abyssal Sweat", Effect Duration: 28
 909	activated tumbling Wint-O-Fresh mint	0		Effect: "Chilblains of the Corn", Effect Duration: 49
-910	miniature decent dwarf bread	2	good	
+910	decent miniature dwarf bread	2	good	
 911	liquefied Senior Mints	0		Effect: "Hot Hands", Effect Duration: 12
 912	moist super-dry twirling pixellated candy heart	0		Effect: "Gunky Dory", Effect Duration: 23
 913	extra-colloidal colloidal dry ghostly kobold	0		Effect: "Elron's Explosive Etude", Effect Duration: 43
@@ -906,22 +906,22 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	scorching intergalactic pom poms	0		Hot Damage: +25, Item Drop: +5
 917	Mob Penguin protection contract	0		
-918	Da Vinci's Radio Free Baseball Cap	0		Experience (Mysticality): +5, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	banded Radio Free Pants	0		Damage Absorption: +100, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	Da Vinci's Radio Free Baseball Cap	0		Experience (Mysticality): +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	banded Radio Free Pants	0		Damage Absorption: +100, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	gray Lo Pan's Radio Free Foil	0		Spell Critical Percent: +30, Last Available: "2006-07"
-921	spoiled small special radio button candy	2	crappy	Effect: "Meatwise", Effect Duration: 45
+921	special spoiled small radio button candy	2	crappy	Effect: "Meatwise", Effect Duration: 45
 922	blinking deadly severed rocking horse head	0		Weapon Damage: +5
 923	broken cellular phone	0		Last Available: "2004-01"
 924	cyan tumbling crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	chilled liquefied mirror skewed Hawking's Elixir of Brilliance	0		Effect: "Seriously Mutated", Effect Duration: 35
-927	bad weak Ferita Del Petto Zinfandel	2	decent	Last Available: "2006-12"
+927	weak bad Ferita Del Petto Zinfandel	2	decent	Last Available: "2006-12"
 928	squat nasty fuzzy bracelets	0		Stench Damage: +5
 929	flame-retardant arse-shooting crossbow	0		Hot Resistance: +1
 931	acceptable pulsating spiced rum	3	good	
 932	mediocre teal eggnog	3	decent	
 933	moldy candy cane	4	crappy	
-934	bite-sized normal gingerbread bugbear	1	good	
+934	normal bite-sized gingerbread bugbear	1	good	
 935	narrow imitation nice watch of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2004-12"
 936	ghostly skewed Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,19 +929,19 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	bowler of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	bowler of incineration	0		Hot Spell Damage: +50, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	squat grievous cool bow staff	0		Moxie: +5, Weapon Damage Percent: +50, Last Available: "2004-12"
-944	lard-coated bowlegged pants	0		Sleaze Spell Damage: +25, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	lard-coated bowlegged pants	0		Sleaze Spell Damage: +25, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	wobbly skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	perfectly mixed ghostly martini	3	super ultra EPIC	Last Available: "2004-12"
 949	aged grogtini	4	awesome	Last Available: "2004-12"
-950	delicious weak cherry bomb	2	awesome	Last Available: "2004-12"
+950	weak delicious cherry bomb	2	awesome	Last Available: "2004-12"
 951	wobbly extra special Crimbo stocking	0		Last Available: "2004-12"
 952	wobbly chaotic resourceful hockey mask	0		Maximum MP: +50, Spell Critical Percent: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
-954	upside-down jittery orphan baby yeti	0		Free Pull, Last Available: "2011-12"
+954	jittery upside-down orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	lime green fez of etymology of the cheetah	0		Initiative: +60, Familiar Effect: "1xLep, cap 30"
 956	moldy carob chunk noodles	3	crappy	
 957	spoiled immense chorizo brownies	8	crappy	
@@ -998,15 +998,15 @@
 1011	watered-down delicious monkey wrench	2	awesome	
 1012	aged tequila sunrise	4	awesome	
 1013	artisanal margarita	3	EPIC	
-1014	acceptable weak strawberry wine	2	good	
-1015	perfectly mixed weak wine spritzer	2	EPIC	
+1014	weak acceptable strawberry wine	2	good	
+1015	weak perfectly mixed wine spritzer	2	EPIC	
 1016	bad olive perpendicular hula	3	decent	
 1017	bad ducha de oro	4	decent	
 1018	hand-crafted calle de miel	3	EPIC	
-1019	hand-crafted watered-down yellow dry vodka martini	2	EPIC	
+1019	watered-down hand-crafted yellow dry vodka martini	2	EPIC	
 1020	bad old-fashioned	4	decent	
 1021	acceptable spirit-forward tequila with training wheels	5	good	
-1022	watered-down mediocre sangria	2	decent	
+1022	mediocre watered-down sangria	2	decent	
 1023	weak artisanal vesper	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1024	perfectly mixed boozy twirling bodyslam	5	EPIC	Last Available: "2004-12"
 1025	strong perfectly mixed twirling sangria del diablo	5	EPIC	Last Available: "2004-12"
@@ -1022,14 +1022,14 @@
 1035	Socratic penguin skin buckler	0		Experience (Mysticality): +1, Damage Reduction: 5
 1036	occult yakskin buckler	0		Spell Damage Percent: +25, Damage Reduction: 5
 1037	razor-sharp gnauga hide buckler	0		Weapon Damage Percent: +25, Damage Reduction: 5
-1038	ionized twirling spinning Connery's Elixir of Audacity	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 46
+1038	ionized spinning twirling Connery's Elixir of Audacity	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 46
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	perfectly mixed beer	4	EPIC	
 1042	Jack Frost's string of beads	0		Cold Spell Damage: +50
 1043	Sinatra's string of beads	0		Experience (Moxie): +5
 1044	shaking rosewater-soaked string of beads	0		Stench Resistance: +3
 1045	pulsating supercharged plastic bottle opener	0		Maximum MP Percent: +30
-1046	extremely unsafe traffic cone of doom	0		Weapon Damage Percent: +100, Spooky Spell Damage: +50, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	extremely unsafe traffic cone of doom	0		Weapon Damage Percent: +100, Spooky Spell Damage: +50, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	acceptable wobbly maroon N. O. Beer	3	good	
 1048	twisted oyster egg	1		Effect: "Extra-Thick Blood", Effect Duration: 10
 1049	compressed oyster egg	1		
@@ -1049,7 +1049,7 @@
 1063	mauve plastic oyster egg	0		
 1064	dried ghostly oyster egg	1		
 1065	vaporized oyster egg	1		
-1066	twisted fuchsia shaking oyster egg	1		Effect: "Sweet and Yellow", Effect Duration: 35
+1066	twisted shaking fuchsia oyster egg	1		Effect: "Sweet and Yellow", Effect Duration: 35
 1067	plastic oyster egg	0		
 1068	dehydrated olive jittery oyster egg	1		Effect: "Adapt to Change Eventually", Effect Duration: 25
 1069	denatured blurry cyan bouncing oyster egg	1		
@@ -1063,7 +1063,7 @@
 1077	twisted twirling wobbly ghostly oyster egg	1		Effect: "Seriously Mutated", Effect Duration: 40
 1078	boiled oyster egg	1		
 1079	tumbling plastic oyster egg	0		
-1080	jittery ghostly oyster basket	0		
+1080	ghostly jittery oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	huge gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	gray personal raindrop	0		Free Pull, Last Available: "2005-04"
@@ -1090,9 +1090,9 @@
 1104	Mountie hat	0		Familiar Weight: +5
 1105	ghostly ghostly clockwork bartender head	0		
 1106	fuchsia clockwork chef head	0		
-1107	bouncing pulsating clockwork maid head	0		
+1107	pulsating bouncing clockwork maid head	0		
 1108	clockwork detective skull	0		
-1109	ghostly purple clockwork bartender-head-in-the-box	0		
+1109	purple ghostly clockwork bartender-head-in-the-box	0		
 1110	pulsating clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
 1112	fuchsia clockwork chef-in-the-box	0		
@@ -1127,17 +1127,17 @@
 1141	mediocre watered-down olive mushroom wine	2	decent	
 1142	high-proof bad blurry pointy mushroom wine	10	decent	
 1143	tolerable flat mushroom wine	4	good	
-1144	drinkable blue bouncing cool mushroom wine	4	good	
+1144	drinkable bouncing blue cool mushroom wine	4	good	
 1145	drinkable knob mushroom wine	3	good	
 1146	perfectly mixed knoll mushroom wine	3	EPIC	
-1147	mediocre weak mushroom wine	2	decent	
+1147	weak mediocre mushroom wine	2	decent	
 1148	aged bouncing shot of flower schnapps	3	awesome	
 1149	spoiled flower petal pie	4	crappy	
 1150	watered-down drinkable special bottle of single-barrel whiskey	2	good	Effect: "Super-Mega-Charged", Effect Duration: 45
 1151	pulsating discarded plastic fork of doom of temperance	0		Spooky Spell Damage: +50, Sleaze Resistance: +5
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	decent upside-down Retenez L'Herbe Pat&eacute;	3	good	
-1154	modified ghostly fuchsia Breathetastic&trade; Premium Canned Air	1	EPIC	
+1154	modified fuchsia ghostly Breathetastic&trade; Premium Canned Air	1	EPIC	
 1155	green letter from King Ralph XI	0		
 1157	prompt wholeberd	0		Adventures: +3
 1158	concentrated Meleegra&trade; pills	0		Effect: "Army of One", Effect Duration: 40
@@ -1154,22 +1154,22 @@
 1169	exactly-three-shaped box	0		
 1170	blurry chocolate box	0		
 1171	coffin	0		
-1172	huge fuchsia asbestos box	0		
+1172	fuchsia huge asbestos box	0		
 1173	linoleum box	0		
 1174	narrow chrome box	0		
-1175	mirror squat cryptic puzzle box	0		
-1176	blurry tumbling refrigerated biohazard container	0		
+1175	squat mirror cryptic puzzle box	0		
+1176	tumbling blurry refrigerated biohazard container	0		
 1177	bouncing magnetic field	0		
 1178	potted cactus	0		
 1179	twirling daisy	0		
 1180	lime green potted fern	0		
 1181	pulsating tulip	0		
-1182	gray upside-down Venus flytrap	0		
+1182	upside-down gray Venus flytrap	0		
 1183	huge all-purpose flower	0		
 1184	upside-down exotic orchid	0		
 1185	squat long-stemmed rose	0		
 1186	skewed gilded lily	0		
-1187	blue squat deadly nightshade	0		
+1187	squat blue deadly nightshade	0		
 1188	lotus	0		
 1189	can of asparagus	0		
 1190	jittery dodecapede	0		
@@ -1183,9 +1183,9 @@
 1198	pulsating sabre-toothed lime	0		
 1199	bugbear	0		
 1200	moldy tumbling mugcake	3	crappy	
-1201	rotten bite-sized urinal cake	1	crappy	
-1202	bland big Happy Birthday, Claude! cake	5	decent	
-1203	moldy miniature olive huge personalized birthday cake	2	crappy	
+1201	bite-sized rotten urinal cake	1	crappy	
+1202	big bland Happy Birthday, Claude! cake	5	decent	
+1203	miniature moldy huge olive personalized birthday cake	2	crappy	
 1204	toothsome huge three-tiered wedding cake	4	awesome	
 1205	jumbo rotten babycakes	5	crappy	
 1206	normal green velvet cake	4	good	
@@ -1195,7 +1195,7 @@
 1210	enchanted bland birthday party jellybean cheesecake	4	decent	Effect: "Mighty Shout", Effect Duration: 50
 1211	balloon	0		
 1212	narrow wobbly balloon	0		
-1213	jittery narrow heart-shaped balloon	0		
+1213	narrow jittery heart-shaped balloon	0		
 1214	anniversary balloon	0		
 1215	Mylar balloon	0		
 1216	blinking Kevlar balloon	0		
@@ -1236,26 +1236,26 @@
 1252	decent squat gray shroomkabob	4	good	
 1253	blinking pile of jumping beans	0		
 1254	moldy small jumping bean burrito	2	crappy	
-1255	super-sized tasty olive bouncing jumping bean burrito	5	awesome	
-1256	bite-sized stale insanely jumping bean burrito	1	decent	
-1257	normal diet teal rat scrapple	1	good	
+1255	super-sized tasty bouncing olive jumping bean burrito	5	awesome	
+1256	stale bite-sized insanely jumping bean burrito	1	decent	
+1257	diet normal teal rat scrapple	1	good	
 1258	pail of pretentious paint	0		
-1259	inspector's traffic cone of the brute	0		Muscle Percent: +30, Item Drop: +15, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	inspector's traffic cone of the brute	0		Muscle Percent: +30, Item Drop: +15, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	powdered Hatorade	1		
 1262	mirror up-at-dawn off-hand balloon of vim and vigor of the businessman	0		Maximum HP Percent: +50, Meat Drop: +50, Adventures: +5
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	miniature decent gloomy mushroom	2	good	
+1266	decent miniature gloomy mushroom	2	good	
 1267	dead mimic	0		
 1268	lime green pine wand	0		
 1269	ebony wand	0		
 1270	lime green hexagonal wand	0		
-1271	bouncing bouncing jittery aluminum wand	0		
+1271	jittery bouncing bouncing aluminum wand	0		
 1272	marble wand	0		
 1273	huge careful magic lamp	0		Monster Level: -10
-1274	dried twirling purple upside-down Medicinal Herb's medicinal herbs	1		
+1274	dried twirling upside-down purple Medicinal Herb's medicinal herbs	1		
 1275	scorching basic meat skirt	0		Hot Damage: +25, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	artisanal watered-down teal jittery Otorian Battle Scar	2	EPIC	
 1277	educational basic meat kilt	0		Experience: +1, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1287,9 +1287,9 @@
 1303	fuchsia Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	red makeup kit	0		Familiar Weight: +15
-1306	nippy traffic cone of doom	0		Cold Damage: +10, Spooky Spell Damage: +50, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	nippy traffic cone of doom	0		Cold Damage: +10, Spooky Spell Damage: +50, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	squat calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
-1308	squat jittery bouncing unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
+1308	squat bouncing jittery unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
 1311	comfy blanket	0		Last Available: "2005-10"
@@ -1304,8 +1304,8 @@
 1320	spoiled questionable taco	3	crappy	
 1321	blurry Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	time helmet of the pedagogue	0		Experience: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	ribald time trousers	0		Sleaze Damage: +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	time helmet of the pedagogue	0		Experience: +3, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	ribald time trousers	0		Sleaze Damage: +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	baleful time sword	0		Spell Damage: +25, Last Available: "2005-10"
 1326	fireproof Dyspepsi-Cola helmet	0		Hot Resistance: +3, Familiar Effect: "3xFairy, cap 7"
 1327	greedy Cloaca-Cola shield	0		Meat Drop: +20, Damage Reduction: 4
@@ -1319,7 +1319,7 @@
 1335	Dyspepsi grenade	0		
 1336	jittery Cloaca grenade	0		
 1338	narrow Dyspepsi-Cola d-rations	0		
-1339	red twirling bouncing Cloaca-Cola c-rations	0		
+1339	twirling red bouncing Cloaca-Cola c-rations	0		
 1340	blue Cloaca-Cola-issue combat knife	0		
 1341	maroon weightlifter's Dyspepsi-Cola-issue canteen	0		Muscle: +15, Single Equip
 1342	picture of a dead guy's girlfriend	0		
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	normal red bowl of oriole's nest soup	4	good	
 1356	squat bunny liver	0		
-1357	practically non-alcoholic perfectly mixed blurry Mt. Noob Pale Ale	1	EPIC	
+1357	perfectly mixed practically non-alcoholic blurry Mt. Noob Pale Ale	1	EPIC	
 1358	wobbly pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1349,7 +1349,7 @@
 1366	bland tofurkey gravy	4	decent	
 1367	delicious narrow herbal stuffing	4	awesome	
 1368	normal can-shaped gelatinous cranberry sauce	4	good	
-1369	delicious big yams	5	awesome	
+1369	big delicious yams	5	awesome	
 1370	hardy rhinestone cowboy shirt	0		Maximum HP: +50
 1371	lion tamer's gingham blouse	0		Experience (familiar): +2
 1372	blurry blurry Oprah's souvenir ski t-shirt	0		Maximum MP Percent: +50
@@ -1377,14 +1377,14 @@
 1395	twirling teddy bear	0		Last Available: "2005-12"
 1396	Tesla clever duck-on-a-string	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2005-12"
 1397	toy soldier	0		Last Available: "2005-12"
-1398	upside-down skewed doll house	0		Last Available: "2005-12"
+1398	skewed upside-down doll house	0		Last Available: "2005-12"
 1399	grievous toy train	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2005-12"
 1400	blinking supercool marionette	0		Moxie Percent: +20, Last Available: "2005-12"
 1401	experienced sock monkey	0		Experience: +2, Last Available: "2005-12"
 1402	dog trainer's rag doll	0		Experience (familiar): +1, Last Available: "2005-12"
 1403	can of fake snow of James Dean	0		Experience (Moxie): +3, Last Available: "2005-12"
 1404	miser's colored-light &quot;necklace&quot;	0		Meat Drop: +10, Last Available: "2005-12"
-1405	tree skirt of wisdom	0		Mysticality: +15, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	tree skirt of wisdom	0		Mysticality: +15, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	low-calorie stale wreath-shaped Crimbo cookie	1	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	gigantic rotten bell-shaped Crimbo cookie	8	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	flavorless half-sized tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
@@ -1399,13 +1399,13 @@
 1417	activated tumbling snowcone	0		Effect: "Icy Composition", Effect Duration: 33, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	healthy thinker's traffic cone	0		Mysticality: +10, Maximum HP Percent: +20, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	healthy thinker's traffic cone	0		Mysticality: +10, Maximum HP Percent: +20, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	shaking Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	pulsating iceberglet	0		Last Available: "2006-02"
 1424	flame-retardant ice sickle of dire peril	0		Weapon Damage: +20, Hot Resistance: +1, Softcore Only, Last Available: "2006-02"
 1425	ice baby of the bloodbag	0		Maximum HP: +100, Softcore Only, Last Available: "2006-02"
-1426	sage ice pick	0		Mysticality Percent: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	sage ice pick	0		Mysticality Percent: +10, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	shellacked fortified ice skates	0		Damage Absorption: +60, Damage Reduction: 7, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	bland grue egg omelette	3	decent	
 1429	roll of drink tickets	0		
@@ -1425,19 +1425,19 @@
 1443	polymerized triple-magnetized purple sleaze powder	0		Effect: "Squid Squint", Effect Duration: 18
 1444	pickled unsweetened narrow twinkly nuggets	0		Effect: "Like a Fish to Walter", Effect Duration: 40
 1445	polarized hot nuggets	0		Effect: "Jungle Juiced", Effect Duration: 29
-1446	electrified energized tumbling green nuggets	0		Effect: "Buff as a Baobab", Effect Duration: 38
+1446	electrified energized green tumbling nuggets	0		Effect: "Buff as a Baobab", Effect Duration: 38
 1447	boiled moist nuggets	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 48
-1448	pressed wobbly purple spinning twirling stench nuggets	0		Effect: "Wet Jaw", Effect Duration: 54
+1448	pressed spinning twirling purple wobbly stench nuggets	0		Effect: "Wet Jaw", Effect Duration: 54
 1449	alkaline improved sleaze nuggets	0		Effect: "Thought", Effect Duration: 33
-1450	twisted blinking teal twinkly wad	1		Effect: "Ooh, Sweet!", Effect Duration: 50
-1451	powdered mirror wobbly hot wad	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 40
+1450	twisted teal blinking twinkly wad	1		Effect: "Ooh, Sweet!", Effect Duration: 50
+1451	powdered wobbly mirror hot wad	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 40
 1452	boiled shaking wad	1		
 1453	denatured wad	1		
 1454	modified bouncing stench wad	1		
 1455	diluted mirror pulsating sleaze wad	1		Effect: "Neuroplastici Tea", Effect Duration: 10
 1456	double daisy	0		
-1457	mirror bouncing Goth Giant	0		
-1458	adequate small upside-down Valentine's Day cake	2	good	
+1457	bouncing mirror Goth Giant	0		
+1458	small adequate upside-down Valentine's Day cake	2	good	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1450,7 +1450,7 @@
 1468	jittery two-handed depthsword	0		
 1469	bill bec-de-bardiche glaive-guisarme	0		
 1470	lead yo-yo	0		
-1471	fuchsia narrow slightly peevedbow	0		
+1471	narrow fuchsia slightly peevedbow	0		
 1472	twirling sack of doorknobs	0		
 1473	jittery ball-and-chain	0		
 1474	automatic catapult	0		
@@ -1474,21 +1474,21 @@
 1492	ninja mop of the cougar	0		Moxie: +20
 1493	squat energetic therapeutic ridiculously overelaborate ninja weapon	0		Maximum MP Percent: +20, HP Regen Min: 5, HP Regen Max: 7
 1494	diffused denatured tumbling sugar-coated pine cone	0		Effect: "Engorged Weapon", Effect Duration: 44, Last Available: "2020-09"
-1495	spinning traffic cone of bravery of temperance	0		Spooky Resistance: +5, Sleaze Resistance: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	spinning traffic cone of bravery of temperance	0		Spooky Resistance: +5, Sleaze Resistance: +5, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	delicious irresponsibly strong gloomy mushroom wine	7	awesome	
 1497	drinkable mushroom wine	3	good	
-1498	blurry blinking McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	blinking blurry McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	cold-filtered quadruple-enhanced activated olive explosion-flavored chewing gum	0		Effect: "Winklered", Effect Duration: 63, Last Available: "2006-04"
 1502	tumbling clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	wet pressed skewed snowcone	0		Effect: "Eye of the Lihc", Effect Duration: 31, Last Available: "2006-04"
-1505	fuchsia pulsating ice cube with a fly in it	0		Last Available: "2006-04"
-1506	fortified bad calle de miel with a fly in it	5	decent	Last Available: "2006-04"
+1505	pulsating fuchsia ice cube with a fly in it	0		Last Available: "2006-04"
+1506	bad fortified calle de miel with a fly in it	5	decent	Last Available: "2006-04"
 1507	tolerable rockin' wagon with a fly in it	3	good	Last Available: "2006-04"
 1508	artisanal skewed perpendicular hula with a fly in it	4	EPIC	Last Available: "2006-04"
-1509	high-proof bad slap and tickle with a fly in it	7	decent	Last Available: "2006-04"
+1509	bad high-proof slap and tickle with a fly in it	7	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of terror	0		Spooky Spell Damage: +10, Last Available: "2006-04"
 1512	pickled blinking Knob Goblin pet-buffing spray	1		
@@ -1503,45 +1503,45 @@
 1522	occult baleful Radio Free Jersey	0		Spell Damage: +25, Spell Damage Percent: +25
 1523	bouncing bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	huge joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	huge joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	skewed diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	ghostly lion tamer's corkscrew of Calamity Jane	0		Critical Hit Percent: +15, Experience (familiar): +2, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	rock-hard grass skirt	0		Damage Reduction: 5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	pulsating groovy grass hat	0		Moxie Percent: +10, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	rock-hard grass skirt	0		Damage Reduction: 5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	pulsating groovy grass hat	0		Moxie Percent: +10, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	green shaking brainy grass blade	0		Mysticality: +5, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	mirror homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	dog trainer's sparkly engagement ring	0		Experience (familiar): +1, Single Equip
 1539	shaking Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	mirror energetic studded Grimacite goggles	0		Damage Absorption: +80, Maximum MP Percent: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	mirror energetic studded Grimacite goggles	0		Damage Absorption: +80, Maximum MP Percent: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	sizzling nippy Grimacite glaive	0		Cold Damage: +10, Hot Damage: +10, Last Available: "2008-10"
-1542	Grimacite greaves of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	Grimacite greaves of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	Jeselnik's Grimacite garter of the glutton	0		Sleaze Damage: +25, Food Drop: +100, Last Available: "2008-10"
 1544	Grimacite galoshes of the empath of the boozehound	0		Familiar Weight: +5, Booze Drop: +100, Last Available: "2008-10"
 1545	Newton's Grimacite gorget of courage	0		Experience (Mysticality): +3, Spooky Resistance: +3, Last Available: "2008-10"
 1546	Jim Carey's Grimacite guayabera	0		Monster Level: +25, Last Available: "2008-10"
 1547	fortified brainy Codex of Capsaicin Conjuration	0		Mysticality: +5, Damage Absorption: +60
 1548	reassuring Lo Pan's Gazpacho's Glacial Grimoire	0		Spell Critical Percent: +30, Spooky Resistance: +1
-1549	fuchsia jittery MSG	0		
+1549	jittery fuchsia MSG	0		
 1550	second-hand knockoff engagement ring of bravery	0		Spooky Resistance: +5, Single Equip
 1551	delicious weak bottle of Domesticated Turkey	2	awesome	
 1552	hand-crafted bottle of Definit	3	EPIC	
 1553	spirit-forward drinkable bottle of Calcutta Emerald	5	good	
-1554	weak tolerable bottle of Lieutenant Freeman	2	good	
+1554	tolerable weak bottle of Lieutenant Freeman	2	good	
 1555	drinkable bouncing bottle of Jorge Sinsonte	4	good	
 1556	lousy upside-down boxed champagne	3	decent	
 1557	decent kumquat	3	good	
 1558	spoiled huge tangerine	3	crappy	
 1559	tonic water	0		
 1560	decent thick cocktail onion	5	good	
-1561	adequate snack-sized raspberry	2	good	
-1562	fancy bland maroon kiwi	4	decent	Effect: "On a Roll", Effect Duration: 15
+1561	snack-sized adequate raspberry	2	good	
+1562	bland fancy maroon kiwi	4	decent	Effect: "On a Roll", Effect Duration: 15
 1563	artisanal whiskey bittersweet	3	EPIC	
-1564	lousy practically non-alcoholic huge mimosette	1	decent	
+1564	practically non-alcoholic lousy huge mimosette	1	decent	
 1565	spirit-forward acceptable tequila sunset	5	good	
 1566	smooth jittery zmobie	3	awesome	Wiki Name: "Zmobie (drink)"
 1567	practically non-alcoholic tolerable gin and tonic	1	good	
@@ -1554,46 +1554,46 @@
 1574	bad triple-distilled teqiwila	10	decent	
 1575	tolerable practically non-alcoholic Divine	1	good	
 1576	acceptable Gordon Bennett	3	good	
-1577	high-proof tolerable tangarita	6	good	
+1577	tolerable high-proof tangarita	6	good	
 1578	bad mandarina colada	4	decent	
-1579	hand-crafted spirit-forward gimlet	5	EPIC	
+1579	spirit-forward hand-crafted gimlet	5	EPIC	
 1580	practically non-alcoholic acceptable brick road	1	good	
 1581	tolerable cyan vodka stratocaster	4	good	
-1582	perfectly mixed fancy skewed Neuromancer	3	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
-1583	practically non-alcoholic enchanted perfectly mixed prussian cathouse	1	super ultra mega turbo EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15
+1582	fancy perfectly mixed skewed Neuromancer	3	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
+1583	perfectly mixed practically non-alcoholic enchanted prussian cathouse	1	super ultra mega turbo EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15
 1584	drinkable Mae West	3	good	
-1585	fortified tolerable spinning Mon Tiki	5	good	
-1586	perfectly mixed watered-down blinking teqiwila slammer	2	super ultra EPIC	
+1585	tolerable fortified spinning Mon Tiki	5	good	
+1586	watered-down perfectly mixed blinking teqiwila slammer	2	super ultra EPIC	
 1587	rotten narrow Knob lo mein	3	crappy	
 1588	adequate asparagus lo mein	4	good	
-1589	spoiled diet Knoll lo mein	1	crappy	
-1590	fancy toothsome twirling lo mein	4	awesome	Effect: "Wallflowering", Effect Duration: 10
+1589	diet spoiled Knoll lo mein	1	crappy	
+1590	toothsome fancy twirling lo mein	4	awesome	Effect: "Wallflowering", Effect Duration: 10
 1591	miniature normal olive lo mein	2	good	
 1592	spoiled hot hi mein	4	crappy	
 1593	half-sized stale hi mein	2	decent	
 1594	bland narrow hi mein	4	decent	
-1595	special spoiled massive hi mein	8	crappy	Effect: "Go-Gone", Effect Duration: 50
-1596	small adequate sleazy hi mein	2	good	
+1595	massive spoiled special hi mein	8	crappy	Effect: "Go-Gone", Effect Duration: 50
+1596	adequate small sleazy hi mein	2	good	
 1597	skewed Junior LAAAAME merit badge of chilblains	0		Cold Damage: +25, Last Available: "2006-05"
 1598	blue frightening Senior LAAAAME merit badge	0		Spooky Damage: +5, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	drinkable tangarita with a fly in it	4	good	
 1601	hand-crafted mandarina colada with a fly in it	4	EPIC	
 1602	lousy prussian cathouse with a fly in it	3	decent	
-1603	watered-down tolerable Mae West with a fly in it	2	good	
+1603	tolerable watered-down Mae West with a fly in it	2	good	
 1604	compressed wobbly astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	powdered cyan ultimate wad	1		
 1607	electrified huge libation of liveliness	0		Effect: "Twen Tea", Effect Duration: 19
 1608	flattened eyedrops of the ermine	0		Effect: "Booing Radly", Effect Duration: 63
-1609	warmed triple-aerosolized pulsating cyan perfume of prejudice	0		Effect: "The Sweats", Effect Duration: 60
-1610	colloidal olive jittery squat eyedrops of the ocelot	0		Effect: "Dreadful Chill", Effect Duration: 62
+1609	warmed triple-aerosolized cyan pulsating perfume of prejudice	0		Effect: "The Sweats", Effect Duration: 60
+1610	colloidal jittery squat olive eyedrops of the ocelot	0		Effect: "Dreadful Chill", Effect Duration: 62
 1611	warmed potent potion of potency	0		Effect: "Your Eyes are Peeled!", Effect Duration: 69
 1612	quadruple-deionized nitrogenated diffused concentrated cordial of concentration	0		Effect: "Emotion Sickness", Effect Duration: 25
 1613	narrow extremely unsafe coffin lid	0		Weapon Damage Percent: +100, Damage Reduction: 3
 1614	upside-down inspector's satin shield	0		Item Drop: +15, Damage Reduction: 5
-1615	wicked Cerebral Cloche	0		Spell Damage: +5, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	mansplainer's Cerebral Culottes	0		Monster Level: +15, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	wicked Cerebral Cloche	0		Spell Damage: +5, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	mansplainer's Cerebral Culottes	0		Monster Level: +15, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	tumbling spinning sizzling Cerebral Crossbow of the ox of horror	0		Muscle: +20, Hot Damage: +10, Spooky Spell Damage: +25, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	lime green munchies pill	0		Last Available: "2006-06"
@@ -1630,11 +1630,11 @@
 1650	milk of magnesium	0		
 1651	half-sized rotten foie gras	2	crappy	
 1652	tarnished activated candy brain	0		Effect: "Amorous Avarice", Effect Duration: 45, Last Available: "2020-09"
-1653	therapeutic hardened beefy jewel-eyed wizard hat	0		Muscle: +10, Damage Reduction: 3, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	therapeutic hardened beefy jewel-eyed wizard hat	0		Muscle: +10, Damage Reduction: 3, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	upside-down nippy hale wad of Crovacite	0		Maximum HP: +20, Cold Damage: +10
 1655	thinker's collar of the cougar	0		Mysticality: +10, Moxie: +20
 1656	spinning spinning White Citadel Satisfaction Satchel	0		
-1657	purple squat onion shurikens	0		
+1657	squat purple onion shurikens	0		
 1658	Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
 1660	shaking Regular Cloaca Cola	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	gray rosewater-soaked beefy sword	0		Muscle: +10, Stench Resistance: +3
 1680	frightening rosy-cheeked staff	0		Maximum HP Percent: +30, Spooky Damage: +5
 1681	teal wool Socratic bubblewrap sword	0		Experience (Mysticality): +1, Cold Resistance: +1
@@ -1674,11 +1674,11 @@
 1694	double-ionized wet Frogade	0		Effect: "Ready to Snap", Effect Duration: 37
 1695	quadruple-moist magnetized quantum papotion of papower	0		Effect: "Hammertime", Effect Duration: 37
 1696	jumbo decent royal jelly taco	5	good	
-1697	enchanted big spoiled tofu taco	5	crappy	Effect: "You Liver", Effect Duration: 30
+1697	enchanted spoiled big tofu taco	5	crappy	Effect: "You Liver", Effect Duration: 30
 1698	miniature delicious jumping bean taco	2	awesome	
-1699	super-sized tasty catgut taco	5	awesome	
+1699	tasty super-sized catgut taco	5	awesome	
 1700	flavorless goat cheese taco	3	decent	
-1701	half-sized decent skewed pr0n taco	2	good	
+1701	decent half-sized skewed pr0n taco	2	good	
 1702	super-liquefied blinking alphabet gum	0		Effect: "Human-Orc Hybrid", Effect Duration: 35
 1703	yellow Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1745,12 +1745,12 @@
 1766	jittery wobbly Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	delicious immense squat fricasseed brains	10	awesome	
+1769	immense delicious squat fricasseed brains	10	awesome	
 1770	special stale brains casserole	4	decent	Effect: "Coming Up Roses", Effect Duration: 20
 1771	brainy butcherknife	0		Mysticality: +5
 1772	blinking dangerous corn holder	0		Weapon Damage: +10
 1773	occult eggbeater	0		Spell Damage Percent: +25
-1774	special artisanal practically non-alcoholic bottle of popskull	1	EPIC	Effect: "Pharmaceutically Cool", Effect Duration: 20
+1774	practically non-alcoholic special artisanal bottle of popskull	1	EPIC	Effect: "Pharmaceutically Cool", Effect Duration: 20
 1775	Temple Grandin's dishrag	0		Familiar Weight: +7
 1776	spoiled stale baguette	3	crappy	
 1777	leftovers of indeterminate origin	0		
@@ -1768,9 +1768,9 @@
 1789	jittery Mob Penguin	0		
 1790	smooth Ram's Face Lager	4	awesome	
 1791	ram horns	0		
-1792	asbestos-lined greasy dance instructor's Travoltan trousers	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	asbestos-lined greasy dance instructor's Travoltan trousers	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	banded slick pool cue	0		Moxie: +10, Damage Absorption: +100
-1794	ionized cyan mirror handful of hand chalk	0		Effect: "Hippy Flavor", Effect Duration: 36
+1794	ionized mirror cyan handful of hand chalk	0		Effect: "Hippy Flavor", Effect Duration: 36
 1795	chilly Counterclockwise Watch	0		Cold Damage: +5, Single Equip
 1796	jittery bone collar	0		Familiar Weight: +5
 1797	spinning misshapen animal skeleton	0		
@@ -1851,7 +1851,7 @@
 1872	green left ulna	0		
 1873	upside-down right ulna	0		
 1874	left femur	0		
-1875	jittery green bouncing right femur	0		
+1875	jittery bouncing green right femur	0		
 1876	left tibia	0		
 1877	right tibia	0		
 1878	left fibula	0		
@@ -1861,7 +1861,7 @@
 1882	left first front claw	0		
 1883	tumbling left second front claw	0		
 1884	left third front claw	0		
-1885	shaking mirror left fourth front claw	0		
+1885	mirror shaking left fourth front claw	0		
 1886	right first front claw	0		
 1887	right second front claw	0		
 1888	skewed right third front claw	0		
@@ -1883,18 +1883,18 @@
 1904	toasty padded 5-ball	0		Damage Absorption: +20, Hot Damage: +5
 1905	Temple Grandin's 6-ball of vim and vigor	0		Maximum HP Percent: +50, Familiar Weight: +7
 1906	twirling dance instructor's 7-ball	0		Experience Percent (Moxie): +10
-1907	blue upside-down 8-ball	0		
+1907	upside-down blue 8-ball	0		
 1910	careful therapeutic clockwork sword of vim and vigor	0		Maximum HP Percent: +50, Monster Level: -10, HP Regen Min: 5, HP Regen Max: 7
 1911	wool healthy clockwork staff of horror	0		Maximum HP Percent: +20, Spooky Spell Damage: +25, Cold Resistance: +1
 1912	purple greedy sizzling electrified clockwork crossbow	0		Hot Damage: +10, Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5
 1913	clockwork handle	0		
 1914	green clockwork rod	0		
 1915	maroon clockwork shank	0		
-1916	wobbly purple wobbly Lord Spookyraven's spectacles	0		
+1916	wobbly wobbly purple Lord Spookyraven's spectacles	0		
 1917	wallet	0		
 1918	coin purse	0		
 1919	English to A. F. U. E. Dictionary	0		
-1920	pulsating gray bizarre illegible sheet music	0		
+1920	gray pulsating bizarre illegible sheet music	0		
 1921	bouncing steel-toed wakizashi	0		Damage Reduction: 9
 1922	gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
@@ -1923,14 +1923,14 @@
 1946	knitted flame-wreathed accordion pin	0		Hot Spell Damage: +10, Cold Resistance: +3, Class: "Accordion Thief", Single Equip
 1947	jittery therapeutic hardened worn tophat	0		Damage Reduction: 3, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	narrow Tesla MacGyver's tap shoes	0		Maximum MP: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-1949	half-sized normal Manetwich	2	good	
+1949	normal half-sized Manetwich	2	good	
 1950	shaking bottle of Vangoghbitussin	0		
 1951	perfectly mixed bouncing bottle of Pinot Renoir	3	EPIC	
-1952	moldy small tumbling upside-down desiccated apricot	2	crappy	
+1952	small moldy tumbling upside-down desiccated apricot	2	crappy	
 1953	mediocre flute of flat champagne	3	decent	
 1954	normal dehydrated caviar	3	good	
 1955	maroon styrofoam peanuts	0		
-1956	spirit-forward mediocre maroon spinning snifter of thoroughly aged brandy	5	decent	
+1956	mediocre spirit-forward spinning maroon snifter of thoroughly aged brandy	5	decent	
 1957	ghostly quill pen	0		
 1958	huge blurry inkwell	0		
 1959	tattered scrap of paper	0		
@@ -1942,7 +1942,7 @@
 1965	twirling bottle of Monsieur Bubble	0		
 1966	lime green avaricious extremely unsafe Amulet of Yendor	0		Weapon Damage Percent: +100, Meat Drop: +30, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
-1968	huge fuchsia bottle of perfume	0		Familiar Weight: +5
+1968	fuchsia huge bottle of perfume	0		Familiar Weight: +5
 1969	blue spoon!	0		Familiar Weight: +5
 1970	olive nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	wobbly plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
@@ -1995,13 +1995,13 @@
 2018	blurry club necklace	0		
 2019	cream pie	0		Free Pull
 2020	toothsome maroon cherry pie	3	awesome	
-2021	rotten thick strawberry pie	5	crappy	
+2021	thick rotten strawberry pie	5	crappy	
 2022	adequate blurry lemon meringue pie	3	good	
 2023	Genalen&trade; Bottle	1	awesome	
 2024	normal mixed wildflower greens	3	good	
 2025	moldy snack-sized handful of walnuts	2	crappy	
 2026	normal lime green bouncing nutty organic salad	4	good	
-2027	moldy special teal super salad	4	crappy	Effect: "Pwnd", Effect Duration: 10
+2027	special moldy teal super salad	4	crappy	Effect: "Pwnd", Effect Duration: 10
 2028	bland tofu wonton	3	decent	
 2029	hippy protest button	0		Single Equip
 2030	veiny Lockenstock&trade; sandals of the scaredy-cat	0		Maximum HP: +10, Monster Level: -15, Single Equip
@@ -2021,7 +2021,7 @@
 2044	upside-down your father's MacGuffin diary	0		
 2045	big flavorless brain-meltingly-hot chicken wings	5	decent	
 2046	bland frat brats	3	decent	
-2047	half-sized rotten knob ka-bobs	2	crappy	
+2047	rotten half-sized knob ka-bobs	2	crappy	
 2049	delicious can of Swiller	3	awesome	
 2050	broken wings	0		
 2051	ghostly sunken eyes	0		
@@ -2058,8 +2058,8 @@
 2082	pulsating toothbrush	0		
 2083	makeshift crane	0		
 2084	can of starch	0		
-2085	powdered huge green bottle of ultravitamins	1		
-2086	powdered pulsating spinning bottle of cough syrup	1		
+2085	powdered green huge bottle of ultravitamins	1		
+2086	powdered spinning pulsating bottle of cough syrup	1		
 2087	twisted twirling tube of hair oil	1		Effect: "Egg-cellent Vocabulary", Effect Duration: 45
 2088	diffused Daffy Taffy	0		Effect: "Jittery", Effect Duration: 34
 2089	narrow Crimboween memo	0		Last Available: "2006-10"
@@ -2077,7 +2077,7 @@
 2101	blurry bloodstained briquette	0		
 2102	red greasy dreadlock	0		
 2103	vial of pirate sweat	0		
-2104	twirling gray empty aftershave bottle	0		
+2104	gray twirling empty aftershave bottle	0		
 2105	huge coal button	0		
 2106	burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
@@ -2090,7 +2090,7 @@
 2114	yellow yo	0		Last Available: "2006-12"
 2115	mansplainer's prehistoric spear	0		Monster Level: +15, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	auspicious manspreader's fire	0		Monster Level: +10, Item Drop: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	auspicious manspreader's fire	0		Monster Level: +10, Item Drop: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	shaking Grateful Undead T-shirt of Leguizamo	0		Monster Level: +20
@@ -2107,12 +2107,12 @@
 2132	grievous incredibly marionette	0		Weapon Damage Percent: +50, Last Available: "2006-12"
 2133	lime green dress ball	0		Last Available: "2010-12"
 2134	censurious mad scientist's sock monkey	0		Sleaze Resistance: +3, Last Available: "2006-12"
-2135	ghostly tumbling alien blob	0		Last Available: "2006-12"
+2135	tumbling ghostly alien blob	0		Last Available: "2006-12"
 2136	tumbling vampire duck-on-a-string of the scaredy-cat of the glutton	0		Monster Level: -15, Food Drop: +100, Last Available: "2006-12"
 2137	smooth toy crazy train	0		Moxie: +15, Single Equip, Last Available: "2006-12"
 2138	razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	upside-down toy mercenary	0		Last Available: "2006-12"
-2140	teal shaking length of string	0		Last Available: "2011-12"
+2140	shaking teal length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
 2142	block	0		Last Available: "2011-12"
 2143	blinking felt	0		Last Available: "2011-12"
@@ -2122,36 +2122,36 @@
 2147	bouncing evil teddy bear sewing kit	0		
 2148	skewed toothsome rock	0		
 2149	stale immense frank	10	decent	Last Available: "2011-12"
-2150	small fancy adequate ghostly plate of franks and beans	2	good	Effect: "Spiky Frozen Hair", Effect Duration: 10, Last Available: "2011-12"
-2151	irresponsibly strong bad shot of blackberry schnapps	8	decent	
+2150	small adequate fancy ghostly plate of franks and beans	2	good	Effect: "Spiky Frozen Hair", Effect Duration: 10, Last Available: "2011-12"
+2151	bad irresponsibly strong shot of blackberry schnapps	8	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
-2154	pulsating yellow ion grid	0		Last Available: "2011-12"
+2154	yellow pulsating ion grid	0		Last Available: "2011-12"
 2155	blue Feynman gate	0		Last Available: "2011-12"
 2156	pulsating logic synthesizer	0		Last Available: "2011-12"
 2157	blue high-resistance ultrapolymer plating	0		Last Available: "2011-12"
-2158	purple blinking servomechanical torsion facilitator	0		Last Available: "2011-12"
+2158	blinking purple servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	squat quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
-2162	huge jittery reverse-oscillating klystron	0		Last Available: "2011-12"
+2162	jittery huge reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	narrow sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
 2165	twirling atomic vector plotter	0		Last Available: "2011-12"
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	narrow toy ray gun of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Last Available: "2006-12"
-2169	spinning avaricious dance instructor's toy space helmet	0		Experience Percent (Moxie): +10, Meat Drop: +30, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	spinning avaricious dance instructor's toy space helmet	0		Experience Percent (Moxie): +10, Meat Drop: +30, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	squat MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	arcane researcher's astronaut pants of the ox	0		Muscle: +20, Experience Percent (Mysticality): +10, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	arcane researcher's astronaut pants of the ox	0		Muscle: +20, Experience Percent (Mysticality): +10, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	narrow censurious toy jet pack	0		Sleaze Resistance: +3, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	green mossy stone sphere	0		
 2175	upside-down smooth stone sphere	0		
 2176	cracked stone sphere	0		
-2177	lime green squat squat rough stone sphere	0		
+2177	squat squat lime green rough stone sphere	0		
 2178	obsidian dagger	0		Item Drop: +5
-2179	tumbling huge archaeologist's notebook	0		
+2179	huge tumbling archaeologist's notebook	0		
 2180	amulet	0		
 2181	upside-down chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
@@ -2168,7 +2168,7 @@
 2193	flavorless thick candy stake	5	decent	Last Available: "2006-12"
 2194	acceptable practically non-alcoholic eggnog	1	good	Last Available: "2006-12"
 2195	rotten unspeakable fruitcake	3	crappy	Last Available: "2006-12"
-2196	enchanted moldy gingerbread horror	3	crappy	Effect: "Eldritch Concentration", Effect Duration: 30, Last Available: "2006-12"
+2196	moldy enchanted gingerbread horror	3	crappy	Effect: "Eldritch Concentration", Effect Duration: 30, Last Available: "2006-12"
 2197	super-warmed but probably evil chocolate	0		Effect: "Material Witness", Effect Duration: 49, Last Available: "2006-12"
 2198	yummy shaking bat-shaped Crimboween cookie	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	bland skull-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2182,19 +2182,19 @@
 2207	wobbly jittery Rosewater's Crimbo tiki necklace	0		Mysticality Percent: +30, Last Available: "2006-12"
 2208	lion tamer's sinister bobble-hip hula elf doll	0		Spell Damage: +10, Experience (familiar): +2, Last Available: "2006-12"
 2209	resourceful Crimbo ukulele	0		Maximum MP: +50, Last Available: "2006-12"
-2210	family-friendly frosty Tiki lighter	0		Cold Spell Damage: +10, Sleaze Resistance: +1, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	purple toasty chilly deck of tropical cards	0		Cold Damage: +5, Hot Damage: +5, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	twirling lion tamer's forbidden tropical paperweight	0		Spell Damage Percent: +50, Experience (familiar): +2, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	family-friendly frosty Tiki lighter	0		Cold Spell Damage: +10, Sleaze Resistance: +1, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	purple toasty chilly deck of tropical cards	0		Cold Damage: +5, Hot Damage: +5, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	twirling lion tamer's forbidden tropical paperweight	0		Spell Damage Percent: +50, Experience (familiar): +2, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	blurry tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	lime green tropical wrapping paper	0		Last Available: "2006-12"
-2215	Tropical Crimbo Hat of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	pulsating forbidden Tropical Crimbo Shorts	0		Spell Damage Percent: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	stale miniature super ka-bob	2	decent	
+2215	Tropical Crimbo Hat of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	pulsating forbidden Tropical Crimbo Shorts	0		Spell Damage Percent: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2217	miniature stale super ka-bob	2	decent	
 2218	gigantic delicious upside-down cyan beer basted brat	8	awesome	
 2219	jittery frosty Tropical Crimbo Sword	0		Cold Spell Damage: +10, Last Available: "2006-12"
 2220	adjusted concentrated and Crimboween candy	0		Effect: "Analog Drunk", Effect Duration: 57, Last Available: "2020-09"
 2221	squat Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	educational liar's pants of wisdom	0		Mysticality: +15, Experience: +1, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	educational liar's pants of wisdom	0		Mysticality: +15, Experience: +1, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	brawny thinker's juggler's balls	0		Mysticality: +10, Muscle Percent: +20, Softcore Only, Last Available: "2007-01"
 2224	clever pink shirt	0		Maximum MP: +20, Softcore Only, Last Available: "2007-01"
 2225	twirling familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2230,7 +2230,7 @@
 2256	blinking skewed beefcake's furry earmuffs	0		Muscle: +25
 2257	groovy reinforced furry underpants of the sweet-tooth	0		Moxie Percent: +10, Candy Drop: +100
 2258	green &quot;I Love Me, Vol. I&quot;	0		
-2259	twirling jittery photograph of God	0		
+2259	jittery twirling photograph of God	0		
 2260	hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
@@ -2242,13 +2242,13 @@
 2268	narrow Staff of Fats of the pedagogue	0		Experience: +3
 2269	stale sausage wonton	4	decent	
 2270	yellow healthy belt of the sweet-tooth	0		Maximum HP Percent: +20, Candy Drop: +100, Single Equip
-2271	acceptable spirit-forward bottle of Merlot	5	good	
+2271	spirit-forward acceptable bottle of Merlot	5	good	
 2272	hand-crafted bottle of Port	3	EPIC	
-2273	delicious strong bottle of Pinot Noir	5	awesome	
-2274	fortified tolerable wobbly bottle of Zinfandel	5	good	
+2273	strong delicious bottle of Pinot Noir	5	awesome	
+2274	tolerable fortified wobbly bottle of Zinfandel	5	good	
 2275	weak artisanal wobbly bottle of Marsala	2	EPIC	
 2276	perfectly mixed bottle of Muscat	3	EPIC	
-2277	twirling bouncing huge Fernswarthy's key	0		
+2277	huge bouncing twirling Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
 2279	book	0		
 2280	shaking Manual of Labor	0		
@@ -2260,7 +2260,7 @@
 2286	Eye of Ed	0		
 2287	stanky glowstick of terror	0		Stench Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
-2289	blurry twirling paperclip	0		
+2289	twirling blurry paperclip	0		
 2290	really house	0		
 2291	Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
@@ -2269,7 +2269,7 @@
 2295	squat marinated stakes	0		
 2296	knob butter	0		
 2297	blue vial of ectoplasm	0		
-2298	twirling green boock of darck magicks	0		
+2298	green twirling boock of darck magicks	0		
 2299	EZ-Play Harmonica Book	0		
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
@@ -2289,7 +2289,7 @@
 2315	candygram	0		Last Available: "2007-02"
 2316	broken carburetor	0		
 2317	skewed bronze token	0		
-2318	huge twirling bomb	0		
+2318	twirling huge bomb	0		
 2319	gray carved wheel	0		
 2320	worm-riding manual page	0		
 2321	maroon worm-riding manual page 2	0		
@@ -2309,7 +2309,7 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	blinking double-paned foul-smelling pipe	0		Stench Damage: +10, Cold Resistance: +5
 2337	horrifying reinforced beaded headband	0		Spooky Damage: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	tiny adequate fancy cyan pudding	1	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40, Wiki Name: "black pudding (food)"
+2338	fancy adequate tiny cyan pudding	1	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40, Wiki Name: "black pudding (food)"
 2339	lousy Blackfly Chardonnay	3	decent	
 2340	aged & tan	3	awesome	
 2341	pepper	0		
@@ -2322,7 +2322,7 @@
 2348	pulsating water pipe bomb	0		
 2349	gas balloon	0		
 2350	ghostly beer bomb	0		
-2351	pulsating blinking superamplified boom box	0		
+2351	blinking pulsating superamplified boom box	0		
 2352	Jeselnik's sharpshooter's fire poi	0		Critical Hit Percent: +10, Sleaze Damage: +25
 2353	blurry narrow chilly bejeweled pledge pin	0		Cold Damage: +5, Single Equip
 2354	communications windchimes	0		
@@ -2346,8 +2346,8 @@
 2372	bouncing blinking bunch of bananas	0		
 2373	flavorless banana	4	decent	
 2374	banana peel	0		
-2375	gigantic stale huge banana cream pie	6	decent	
-2376	lousy strong cyan banana daiquiri	5	decent	
+2375	stale gigantic huge banana cream pie	6	decent	
+2376	strong lousy cyan banana daiquiri	5	decent	
 2377	weak delicious spinning bungle in the jungle	2	awesome	
 2378	blinking banana spritzer	0		
 2379	modified banana smoothie	0		Effect: "Dweeby", Effect Duration: 63
@@ -2396,7 +2396,7 @@
 2422	denatured oxidized wobbly irradiated pet snacks	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 34
 2423	quadruple-diffused altered adjusted narrow Mick's IcyVapoHotness Inhaler	0		Effect: "The Smeezingtons", Effect Duration: 30
 2424	oxidized adjusted cyclops eyedrops	0		Effect: "Grrrrrrreat!", Effect Duration: 26
-2425	unsweetened teal blurry can of spinach	0		Effect: "In Tuna", Effect Duration: 27
+2425	unsweetened blurry teal can of spinach	0		Effect: "In Tuna", Effect Duration: 27
 2426	colloidal wobbly fire flower	0		Effect: "Army of One", Effect Duration: 21
 2427	frozen pickled freezerburned ice cube	0		Effect: "Itchy Trigger Finger", Effect Duration: 58
 2428	boiled magnetized fake blood	0		Effect: "Arse-a'fire", Effect Duration: 28
@@ -2417,7 +2417,7 @@
 2443	manspreader's pink glowstick of mayonnaise	0		Monster Level: +10, Sleaze Spell Damage: +50, Last Available: "2007-03"
 2444	perfectly mixed special Supernova Champagne	3	EPIC	Effect: "Salamanderenity", Effect Duration: 15
 2445	fuchsia Deactivated O. A. F.	0		Last Available: "2007-04"
-2446	jittery mirror hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
+2446	mirror jittery hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	pulsating bad penguin egg	0		Free Pull
 2448	bouncing tasteful bow tie	0		Familiar Weight: +5
 2449	six-pack of New Cloaca-Cola	0		
@@ -2434,7 +2434,7 @@
 2460	energetic yak toupee	0		Maximum MP Percent: +20, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	maroon mirror odor extractor	0		Last Available: "2019-12"
 2463	ghostly Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	small spoiled bowl of Bounty-Os	2	crappy	
+2464	spoiled small bowl of Bounty-Os	2	crappy	
 2465	bad Oreille Divis&eacute;e brandy	3	decent	
 2466	jittery pompadour'd puppy	0		
 2467	skewed suede shoes	0		Familiar Weight: +5
@@ -2491,12 +2491,12 @@
 2518	baleful sawblade shield	0		Spell Damage: +25, Damage Reduction: 11
 2519	bad enchanted ghostly huge McMillicancuddy's Special Lager	3	decent	Effect: "Weepy, Creepy", Effect Duration: 20
 2520	perfectly mixed melted Jell-o shot	4	EPIC	
-2521	tolerable fortified narrow cruelty-free wine	5	good	
+2521	fortified tolerable narrow cruelty-free wine	5	good	
 2522	drinkable thistle wine	4	good	
 2523	tumbling megatofu	0		
 2524	displaced fish	0		
 2525	rotten fish	3	crappy	
-2526	fancy immense normal fish casserole	6	good	Effect: "Hangdog", Effect Duration: 40
+2526	fancy normal immense fish casserole	6	good	Effect: "Hangdog", Effect Duration: 40
 2527	snack-sized stale upside-down fish lasagna	2	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	moldy small gnatloaf	2	crappy	
@@ -2504,13 +2504,13 @@
 2531	normal immense gnat lasagna	8	good	
 2532	wobbly pork	0		
 2533	normal bouncing pork chop sandwiches	3	good	
-2534	decent half-sized blurry blinking pork casserole	2	good	
-2535	rotten jumbo pork lasagna	5	crappy	
+2534	half-sized decent blurry blinking pork casserole	2	good	
+2535	jumbo rotten pork lasagna	5	crappy	
 2536	canopic jar	0		
 2537	huge spice	0		
 2538	fuchsia organs	0		
 2539	ruddy Ankh of Badahnkadh	0		Maximum HP Percent: +40, Single Equip
-2540	blurry twirling tomb ratchet	0		
+2540	twirling blurry tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	flattened boiled anodized lesser grodulated violet	0		Effect: "Unusual Perspective", Effect Duration: 33, Last Available: "2007-05"
 2543	adjusted energized tin magnolia	0		Effect: "Human-Constellation Hybrid", Effect Duration: 41, Last Available: "2007-05"
@@ -2518,7 +2518,7 @@
 2545	pressed upsy daisy	0		Effect: "Cake Caked", Effect Duration: 34, Last Available: "2007-05"
 2546	magnetized alkaline half-orchid	0		Effect: "Tasting the Rainbow", Effect Duration: 26, Last Available: "2007-05"
 2547	huge shaking family-friendly smartaleck's tin star	0		Moxie Percent: +30, Sleaze Resistance: +1, Last Available: "2007-05"
-2548	bouncing studded outrageous sombrero of horror	0		Damage Absorption: +80, Spooky Spell Damage: +25, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	bouncing studded outrageous sombrero of horror	0		Damage Absorption: +80, Spooky Spell Damage: +25, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	rosy-cheeked &quot;Humorous&quot; T-shirt of courage	0		Maximum HP Percent: +30, Spooky Resistance: +3, Last Available: "2007-05"
 2550	tumbling Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2549,7 +2549,7 @@
 2576	narrow honey-dipped locust	0		
 2577	hardened supercool cactus quill	0		Moxie Percent: +20, Damage Reduction: 3
 2578	family-friendly frightening Staff of the Short Order Cook of the bloodbag	0		Maximum HP: +100, Spooky Damage: +5, Sleaze Resistance: +1
-2579	stale snack-sized upside-down cactus fruit	2	decent	
+2579	snack-sized stale upside-down cactus fruit	2	decent	
 2580	educational savvy scorpion whip	0		Mysticality Percent: +20, Experience: +1
 2581	handful of sand	0		
 2582	lime green brick of sand	0		
@@ -2564,7 +2564,7 @@
 2591	thick delicious upside-down tasty tart	5	awesome	
 2592	yellow Knob Goblin lunchbox	0		
 2593	adequate Knob pasty	3	good	
-2594	hand-crafted extra-dry green shaking thermos full of Knob coffee	5	EPIC	
+2594	hand-crafted extra-dry shaking green thermos full of Knob coffee	5	EPIC	
 2595	warmed Ben-Gal&trade; Balm	0		Effect: "Mitre Cut", Effect Duration: 15
 2596	leathery cat skin	0		
 2597	green leathery bat skin	0		
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	shaking rocky raccoon	0		
 2614	mojo filter	0		
-2615	jumbo normal savoy truffle	5	good	
+2615	normal jumbo savoy truffle	5	good	
 2616	blinking spinning Magi-Wipes	0		
 2617	bouncing boom	0		
 2618	Iiti Kitty phone charm of the scaredy-cat	0		Monster Level: -15, Single Equip
@@ -2608,7 +2608,7 @@
 2635	skewed really thick bandage	0		
 2636	spinning dog trainer's mummy mask	0		Experience (familiar): +1, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	Annie Oakley's gauze shorts of terror	0		Critical Hit Percent: +20, Spooky Spell Damage: +10, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
-2638	jittery spinning gauze hammock	0		
+2638	spinning jittery gauze hammock	0		
 2639	cherry soda	0		
 2640	baleful sinister greaves	0		Spell Damage: 35, Familiar Effect: "atk, 1xBarrr, cap 40"
 2641	wobbly Da Vinci's Herculean cowboy hat	0		Experience (Muscle): +1, Experience (Mysticality): +5, Familiar Effect: "1xBarrr, 1xLep, cap 41"
@@ -2624,16 +2624,16 @@
 2651	mirror pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	low-calorie toothsome wobbly S.T.L.T.	1	awesome	Last Available: "2007-06"
 2653	moldy honey-dew	3	crappy	Last Available: "2007-06"
-2654	acceptable strong Xanadian	5	good	Last Available: "2007-06"
+2654	strong acceptable Xanadian	5	good	Last Available: "2007-06"
 2655	extra-wet bottle of absinthe	0		Effect: "Stop and Smell the Fudge", Effect Duration: 67, Last Available: "2007-06"
 2656	nasty Drowsy Sword of the early riser	0		Stench Damage: +5, Adventures: +7
 2657	decent escargotsicle	3	good	Last Available: "2007-06"
-2658	high-proof mediocre bottle of realpagne	10	decent	Last Available: "2007-06"
+2658	mediocre high-proof bottle of realpagne	10	decent	Last Available: "2007-06"
 2659	bouncing Annie Oakley's albatross necklace	0		Critical Hit Percent: +20, Single Equip, Last Available: "2007-06"
 2660	twisted purple tumbling not-a-pipe	1	good	Last Available: "2007-06"
-2661	fancy acceptable flask of Amontillado	3	good	Effect: "Mercenary", Effect Duration: 5, Last Available: "2007-06"
-2662	weightlifter's ball mask	0		Muscle: +15, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	bouncing rock-hard Can-Can skirt	0		Damage Reduction: 5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2661	acceptable fancy flask of Amontillado	3	good	Effect: "Mercenary", Effect Duration: 5, Last Available: "2007-06"
+2662	weightlifter's ball mask	0		Muscle: +15, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	bouncing rock-hard Can-Can skirt	0		Damage Reduction: 5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	quantum ionized blurry blinking sensitive poetry journal	0		Effect: "Berry Thorny", Effect Duration: 38, Last Available: "2007-06"
 2665	altered bottled inspiration	0		Effect: "Egg-stra Arm", Effect Duration: 36, Last Available: "2007-06"
 2666	denatured bellhop bell	0		Effect: "The Power of Positive Thinking", Effect Duration: 36, Last Available: "2007-06"
@@ -2694,12 +2694,12 @@
 2721	extremely unsafe sage hand-carved staff of the detective	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Item Drop: +20
 2722	healthy stiffened dangerous dance instructor's Staff of the Greasefire	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Damage Reduction: 1, Maximum HP Percent: +20
 2723	lime green prompt Rosewater's Staff of the Grand Flamb&eacute; of James Dean	0		Mysticality Percent: +30, Experience (Moxie): +3, Adventures: +3
-2724	rotten immense enchanted bowl of rye sprouts	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5
+2724	enchanted rotten immense bowl of rye sprouts	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5
 2725	bland cob of corn	3	decent	
-2726	adequate fancy juniper berries	3	good	Effect: "White-boy Angst", Effect Duration: 15
+2726	fancy adequate juniper berries	3	good	Effect: "White-boy Angst", Effect Duration: 15
 2727	bite-sized normal plum	1	good	
-2728	spoiled snack-sized pear	2	crappy	
-2729	spoiled gigantic peach	6	crappy	
+2728	snack-sized spoiled pear	2	crappy	
+2729	gigantic spoiled peach	6	crappy	
 2730	artisanal practically non-alcoholic plum wine	1	EPIC	
 2731	tolerable weak shot of pear schnapps	2	good	
 2732	delicious narrow shot of peach schnapps	4	awesome	
@@ -2712,9 +2712,9 @@
 2739	Vulcanized panty raider camouflage	0		Effect: "Flame-Retardant Trousers", Effect Duration: 48
 2740	lightning-fast censurious perfumed Staff of the Walk-In Freezer	0		Stench Resistance: +5, Sleaze Resistance: +3, Initiative: +40
 2741	watered-down tolerable boilermaker	2	good	
-2742	snack-sized normal tumbling steel lasagna	2	quest	
+2742	normal snack-sized tumbling steel lasagna	2	quest	
 2743	lousy steel margarita	3	quest	
-2744	twisted tumbling huge steel-scented air freshener	1		Effect: "Memory of Smarts", Effect Duration: 5
+2744	twisted huge tumbling steel-scented air freshener	1		Effect: "Memory of Smarts", Effect Duration: 5
 2745	quantum altered gremlin mutagen	0		Effect: "Sticky Fingers", Effect Duration: 64
 2746	energized frozen twirling extra-potent gremlin mutagen	0		Effect: "Tiki Temerity", Effect Duration: 61
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2738,14 +2738,14 @@
 2765	Harold's bell	0		
 2766	bowling ball	0		
 2767	tiny stale Crimbo pie	1	decent	
-2768	normal small skewed gray pear tart	2	good	
-2769	jumbo enchanted flavorless huge peach pie	5	decent	Effect: "The Spy Who Loved XP", Effect Duration: 45
+2768	small normal gray skewed pear tart	2	good	
+2769	flavorless jumbo enchanted huge peach pie	5	decent	Effect: "The Spy Who Loved XP", Effect Duration: 45
 2770	quadruple-wet chunk of rock salt	0		Effect: "Buggy Flavor", Effect Duration: 27
 2771	oxidized spinning handful of pine needles	0		Effect: "Pemmican't", Effect Duration: 55
 2772	steamy ruby	0		
 2773	ghostly glacial sapphire	0		
 2774	spinning unearthly onyx	0		
-2775	upside-down narrow effluvious emerald	0		
+2775	narrow upside-down effluvious emerald	0		
 2776	blinking tawdry amethyst	0		
 2777	wobbly blurry family-friendly strapping filigreed hamethyst earring	0		Muscle: +5, Sleaze Resistance: +1
 2778	sizzling Herculean experienced filigreed hamethyst necklace	0		Experience: +2, Experience (Muscle): +1, Hot Damage: +10, Single Equip
@@ -2789,9 +2789,9 @@
 2816	fuchsia Boxers of Leguizamo of courage of Flo-Jo	0		Monster Level: +20, Spooky Resistance: +3, Initiative: +100, Familiar Effect: "1xVolley, 1xLep"
 2817	medical-grade beefy Brooch of the detective	0		Muscle: +10, Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 2818	ghostly gravedigger's frosty wizardly Bracelet	0		Mysticality: +25, Cold Spell Damage: +10, Spooky Damage: +10, Single Equip
-2819	MacGyver's Rosewater's Grimacite gasmask	0		Mysticality Percent: +30, Maximum MP: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	MacGyver's Rosewater's Grimacite gasmask	0		Mysticality Percent: +30, Maximum MP: +100, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	upside-down Newton's slick Grimacite gat	0		Moxie: +10, Experience (Mysticality): +3, Last Available: "2008-11"
-2821	jittery shaking toasty Temple Grandin's Grimacite gaiters	0		Familiar Weight: +7, Hot Damage: +5, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	jittery shaking toasty Temple Grandin's Grimacite gaiters	0		Familiar Weight: +7, Hot Damage: +5, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	blue educational Grimacite gauntlets of temperance	0		Experience: +1, Sleaze Resistance: +5, Single Equip, Last Available: "2008-11"
 2823	educational Rosewater's Grimacite go-go boots	0		Mysticality Percent: +30, Experience: +1, Single Equip, Last Available: "2008-11"
 2824	savvy boxer's Grimacite girdle	0		Muscle Percent: +10, Mysticality Percent: +20, Single Equip, Last Available: "2008-11"
@@ -2803,15 +2803,15 @@
 2830	upside-down digital key lime	0		
 2831	fuchsia star key lime	0		
 2832	bite-sized rotten digital key lime pie	1	crappy	
-2833	fancy decent star key lime pie	3	good	Effect: "Shamboozled", Effect Duration: 20
-2834	executive MacGyver's bottle-rocket crossbow of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Meat Drop: +40, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2833	decent fancy star key lime pie	3	good	Effect: "Shamboozled", Effect Duration: 20
+2834	executive MacGyver's bottle-rocket crossbow of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Meat Drop: +40, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	manspreader's indie comic hipster glasses	0		Monster Level: +10, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	tumbling wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	huge mint-condition magic wand	0		Last Available: "2011-12"
 2838	prompt glowstick of courage	0		Spooky Resistance: +3, Adventures: +3, Last Available: "2007-08"
 2839	curative Periodical Paintbrush	0		HP Regen Min: 3, HP Regen Max: 5, Softcore Only
 2840	bad triple-distilled blue bottle of cooking sherry	7	decent	
-2841	low-calorie enchanted normal blurry packet of ketchup	1	good	Effect: "Patience of the Tortoise", Effect Duration: 40
+2841	enchanted low-calorie normal blurry packet of ketchup	1	good	Effect: "Patience of the Tortoise", Effect Duration: 40
 2842	high-proof hand-crafted shaking accidental cider	7	EPIC	
 2843	adequate dire fudgesicle	4	good	
 2844	pulsating friendly experienced navel ring of navel gazing of the glutton of the cheetah	0		Experience: +2, Familiar Weight: +3, Food Drop: +100, Initiative: +60, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2830,10 +2830,10 @@
 2857	super-alkaline magnetized seegar butt	0		Effect: "Cool, Catlike", Effect Duration: 46
 2858	mirror bottled swamp gas	0		
 2859	studded grievous witch wart	0		Weapon Damage Percent: +50, Damage Absorption: +80
-2860	flavorless gigantic bouncing swamp muck	9	decent	
+2860	gigantic flavorless bouncing swamp muck	9	decent	
 2861	Usain Bolt's gravedigger's educational leechknife	0		Experience: +1, Spooky Damage: +10, Initiative: +80
 2862	decomposed boot	0		
-2863	ionized magnetized teal squat dribbly candle	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 58
+2863	ionized magnetized squat teal dribbly candle	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 58
 2864	stolen meatpouch	0		
 2865	jittery medical-grade Da Vinci's beaver spear	0		Experience (Mysticality): +5, HP Regen Min: 7, HP Regen Max: 10
 2866	lion tamer's shamanic beads of the wise owl	0		Mysticality: +20, Experience (familiar): +2
@@ -2841,7 +2841,7 @@
 2868	activated wobbly pirate pamphlet	0		Effect: "OMG WTF", Effect Duration: 49
 2869	dry huge purple pirate brochure	0		Effect: "Stinkybeard", Effect Duration: 69
 2870	magnetized flattened galvanized blinking pirate tract	0		Effect: "Compensatory Cruelness", Effect Duration: 16
-2871	spinning skewed burnt flower	0		
+2871	skewed spinning burnt flower	0		
 2872	plastic Naughty Sorceress of doom of the early riser	0		Spooky Spell Damage: +50, Adventures: +7
 2873	bouncing razor-sharp plastic Ed the Undying of incineration	0		Weapon Damage Percent: +25, Hot Spell Damage: +50
 2874	family-friendly frightening plastic Lord Spookyraven	0		Spooky Damage: +5, Sleaze Resistance: +1
@@ -2912,10 +2912,10 @@
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	delicious Surprise Egg	3	awesome	
 2941	moist bouncing Steal This Candy	0		Effect: "Spore-Wreathed", Effect Duration: 67
-2942	dry boiled yellow twirling chocolate filthy lucre	0		Effect: "Electrolit Up", Effect Duration: 17
+2942	dry boiled twirling yellow chocolate filthy lucre	0		Effect: "Electrolit Up", Effect Duration: 17
 2943	ionized spinning Angry Farmer's Wife Candy	0		Effect: "Stimulated Brain", Effect Duration: 16
 2945	up-at-dawn Herculean party hat	0		Experience (Muscle): +1, Adventures: +5, Familiar Effect: "4xLep, cap 7"
-2946	V for Vivala mask of the wise owl of the cougar	0		Mysticality: +20, Moxie: +20, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	V for Vivala mask of the wise owl of the cougar	0		Mysticality: +20, Moxie: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	lousy shot of rotgut	4	decent	
 2949	ionized wobbly jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Disco Inferno", Effect Duration: 52
@@ -2924,12 +2924,12 @@
 2952	ribald glowstick	0		Sleaze Damage: +10, Item Drop: +5, Last Available: "2007-11"
 2953	cyan charrrm bracelet	0		
 2954	electrified tip jar	0		MP Regen Min: 3, MP Regen Max: 5
-2955	half-sized normal yam candy	2	good	
+2955	normal half-sized yam candy	2	good	
 2956	wobbly cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	flavorless tube of cranberry Go-Goo	4	decent	
 2959	tumbling frosty rum barrel charrrm bracelet	0		Cold Spell Damage: +10
-2960	fancy normal single-serving herbal stuffing	3	good	Effect: "Reedy Pipes", Effect Duration: 15
+2960	normal fancy single-serving herbal stuffing	3	good	Effect: "Reedy Pipes", Effect Duration: 15
 2961	stale packet of tofurkey gravy	3	decent	
 2962	moldy tofurkey nugget	3	crappy	
 2963	rigging shampoo	0		
@@ -2945,13 +2945,13 @@
 2973	baleful grumpy man charrrm bracelet	0		Spell Damage: +25, Single Equip
 2974	tarrrnish charrrm	0		
 2975	electrified stylish tarrrnished charrrm bracelet	0		Moxie: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-2976	artisanal weak pulsating bilge wine	2	EPIC	
+2976	weak artisanal pulsating bilge wine	2	EPIC	
 2977	witty rapier of Leguizamo	0		Monster Level: +20
 2978	foul-smelling hardened yohohoyo	0		Damage Reduction: 3, Stench Damage: +10
 2979	pressed enhanced fish-liver oil	0		Effect: "Hairy Palms", Effect Duration: 34
 2980	booty chest charrrm	0		
 2981	purple narrow aromatic booty chest charrrm bracelet	0		Stench Resistance: +1, Single Equip
-2982	fuchsia upside-down cannonball charrrm	0		
+2982	upside-down fuchsia cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
 2984	copper ha'penny charrrm	0		
 2985	shaking rosy-cheeked copper ha'penny charrrm bracelet	0		Maximum HP Percent: +30
@@ -2998,34 +2998,34 @@
 3026	artisanal corpsetini	3	super EPIC	
 3027	artisanal corpsedriver	3	super EPIC	
 3028	irresponsibly strong perfectly mixed narrow fuchsia Corpse Island iced tea	6	EPIC	
-3029	smooth fancy strong fuchsia squat red-headed corpse	5	awesome	Effect: "Pumped Stomach", Effect Duration: 25
-3030	perfectly mixed enchanted gray kamicorpse-ee	4	EPIC	Effect: "Ooh, Bitter!", Effect Duration: 45
+3029	fancy smooth strong squat fuchsia red-headed corpse	5	awesome	Effect: "Pumped Stomach", Effect Duration: 25
+3030	enchanted perfectly mixed gray kamicorpse-ee	4	EPIC	Effect: "Ooh, Bitter!", Effect Duration: 45
 3031	perfectly mixed corpsel	3	EPIC	
-3032	artisanal practically non-alcoholic jittery corpsebite	1	super EPIC	
+3032	practically non-alcoholic artisanal jittery corpsebite	1	super EPIC	
 3033	mirror Sinatra's pirate fledges	0		Experience (Moxie): +5
 3034	purple piece of thirteen	0		
-3035	moldy jumbo gray pearl onion	5	crappy	
+3035	jumbo moldy gray pearl onion	5	crappy	
 3036	yummy sea biscuit	3	awesome	
 3037	mediocre bouncing bottle of rum	4	decent	
-3038	hand-crafted practically non-alcoholic bottle of black-label rum	1	super EPIC	
+3038	practically non-alcoholic hand-crafted bottle of black-label rum	1	super EPIC	
 3039	cannonball	0		
 3040	purple voodoo skull	0		
-3041	lime green pulsating joke scroll	0		
+3041	pulsating lime green joke scroll	0		
 3042	shaking Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	pulsating metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	stale massive gray narrow jittery nanite-infested gingerbread bugbear	6	decent	Last Available: "2007-12"
-3046	bland half-sized shaking nanite-infested candy cane	2	decent	Last Available: "2020-09"
-3047	miniature bland nanite-infested fruitcake	2	decent	Last Available: "2007-12"
-3048	perfectly mixed watered-down pulsating nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
+3044	pulsating metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	stale massive narrow gray jittery nanite-infested gingerbread bugbear	6	decent	Last Available: "2007-12"
+3046	half-sized bland shaking nanite-infested candy cane	2	decent	Last Available: "2020-09"
+3047	bland miniature nanite-infested fruitcake	2	decent	Last Available: "2007-12"
+3048	watered-down perfectly mixed pulsating nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	toasty eyepatch	0		Hot Damage: +5, Familiar Effect: "spooky atk, 1xBarrr"
 3051	mirror arcane researcher's cutlass	0		Experience Percent (Mysticality): +10
 3052	weightlifter's breeches	0		Muscle: +15, Familiar Effect: "stench atk, 1xPotato"
-3053	pulsating teal mood ring	0		Last Available: "2007-02"
+3053	teal pulsating mood ring	0		Last Available: "2007-02"
 3054	corrupted tarnished candy heart	0		Effect: "Leash of Linguini", Effect Duration: 27, Last Available: "2007-02"
 3055	energized energized olive cymbal syrup	0		Free Pull, Effect: "Bottle in front of Me", Effect Duration: 18, Last Available: "2007-02"
-3056	metallic foil cat ears	0		Item Drop: +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	metallic foil cat ears	0		Item Drop: +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	huge nanofiber cloth	0		Last Available: "2007-12"
 3058	ghostly iGoogly	0		Last Available: "2007-12"
 3059	lime green theoretical string	0		Last Available: "2007-12"
@@ -3045,10 +3045,10 @@
 3073	tumbling set of Unobtainium straps	0		Last Available: "2007-12"
 3074	purple polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	wobbly General Assembly Module	0		Last Available: "2007-12"
-3076	pulsating huge laser targeting chip	0		Last Available: "2007-12"
+3076	huge pulsating laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	huge Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	huge Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	blinking teddy borg	0		Last Available: "2007-12"
 3081	mirror marionette collective of Tarzan	0		Experience (Muscle): +3, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3056,10 +3056,10 @@
 3084	beefy borg sock monkey	0		Muscle: +10, Last Available: "2007-12"
 3085	thinker's roboduck-on-a-string of the sewer	0		Mysticality: +10, Stench Damage: +25, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
-3087	jittery blurry teddy borg sewing kit	0		Last Available: "2007-12"
-3088	yellow upside-down wool mansplainer's biomechanical crimborg helmet	0		Monster Level: +15, Cold Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3087	blurry jittery teddy borg sewing kit	0		Last Available: "2007-12"
+3088	yellow upside-down wool mansplainer's biomechanical crimborg helmet	0		Monster Level: +15, Cold Resistance: +1, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	twirling gray forbidden brawny C.B.F.G.	0		Muscle Percent: +20, Spell Damage Percent: +50, Last Available: "2007-12"
-3090	gray beefy biomechanical crimborg leg armor of temperance	0		Muscle: +10, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	gray beefy biomechanical crimborg leg armor of temperance	0		Muscle: +10, Sleaze Resistance: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	nitrogenated vitachoconutriment capsule	0		Effect: "Ninja, Please", Effect Duration: 16, Last Available: "2007-12"
 3092	Van der Graaf handmade hobby horse	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-12"
 3093	banded ball-in-a-cup	0		Damage Absorption: +100, Last Available: "2007-12"
@@ -3100,7 +3100,7 @@
 3128	mirror marshmallow	0		
 3129	decent miniature lime green roasted marshmallow	2	good	
 3130	bouncing disc	0		Last Available: "2008-01"
-3131	jumbo yummy special pulsating tin cup of mulligan stew	5	awesome	Effect: "Brother Corsican's Blessing", Effect Duration: 20
+3131	special jumbo yummy pulsating tin cup of mulligan stew	5	awesome	Effect: "Brother Corsican's Blessing", Effect Duration: 20
 3132	dog trainer's brawny flamin' bindle	0		Muscle Percent: +20, Experience (familiar): +1
 3133	ribald lion tamer's freezin' bindle	0		Experience (familiar): +2, Sleaze Damage: +10
 3134	inspector's thinker's stinkin' bindle	0		Mysticality: +10, Item Drop: +15
@@ -3145,9 +3145,9 @@
 3173	colloidal enhanced evil vihuela	0		Effect: "Heart Aflame", Effect Duration: 48
 3174	moldy evil boring spaghetti	3	crappy	
 3175	decent evil noodles	4	good	
-3176	miniature bland evil noodles	2	decent	
-3177	snack-sized decent evil painful penne pasta	2	good	
-3178	bland enchanted diet fuchsia 3vi1 pr0n m4nic0tti	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15
+3176	bland miniature evil noodles	2	decent	
+3177	decent snack-sized evil painful penne pasta	2	good	
+3178	enchanted bland diet fuchsia 3vi1 pr0n m4nic0tti	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15
 3179	moldy evil ravioli della hippy	4	crappy	
 3180	normal evil noodles	3	good	
 3181	galvanized quantum evil potion of potency	0		Effect: "Thicker, Sicker", Effect Duration: 63
@@ -3156,9 +3156,9 @@
 3184	super-modified evil eyedrops of the ermine	0		Effect: "Tennis Elbow-wow", Effect Duration: 19
 3185	magnetized evil ointment of the occult	0		Effect: "critical.enh", Effect Duration: 58
 3186	nitrogenated fuchsia evil serum of sarcasm	0		Effect: "Mo' Hobo", Effect Duration: 27
-3187	electrified squat upside-down evil philter of phorce	0		Effect: "Thickest, Sickest", Effect Duration: 45
+3187	electrified upside-down squat evil philter of phorce	0		Effect: "Thickest, Sickest", Effect Duration: 45
 3188	hand-crafted weak an evil sump'm sump'm	2	super EPIC	
-3189	drinkable triple-distilled mirror evil ducha de oro	9	good	
+3189	triple-distilled drinkable mirror evil ducha de oro	9	good	
 3190	smooth huge evil horizontal tango	4	awesome	
 3191	mediocre weak evil roll in the hay	2	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3175,7 +3175,7 @@
 3203	upside-down dwarvish magazine	0		
 3204	jittery dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
-3206	shaking blurry dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
+3206	blurry shaking dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	upside-down dwarvish punchcard	0		
 3208	pulsating small laminated card	0		
 3209	laminated card	0		
@@ -3195,13 +3195,13 @@
 3223	sewer nuggets	0		
 3224	skewed sewer wad	0		
 3225	perfectly mixed bottle of sewage schnapps	3	EPIC	
-3226	tolerable triple-distilled bottle of Ooze-O	8	good	
+3226	triple-distilled tolerable bottle of Ooze-O	8	good	
 3227	moldy half-sized pulsating C.H.U.M. chum	2	crappy	
-3228	decent tiny skewed unfortunate dumplings	1	good	
+3228	tiny decent skewed unfortunate dumplings	1	good	
 3229	decaying goldfish liver	0		
 3230	denatured Vulcanized squat oil of oiliness	0		Effect: "Human-Elemental Hybrid", Effect Duration: 17
 3231	electrified tattered paper crown	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xSombrero, cap 15"
-3232	moldy snack-sized purple vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
+3232	snack-sized moldy purple vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	wobbly water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3240,9 +3240,9 @@
 3268	extra-adjusted jittery handful of Crotchety Pine needles	0		Effect: "Rainbow Bright", Effect Duration: 37
 3269	non-deionized alkaline spinning lump of Saccharine Maple sap	0		Effect: "Crotchety, Pining", Effect Duration: 38
 3270	irradiated blurry handful of Laughing Willow bark	0		Effect: "Prince of Seaside Town", Effect Duration: 69
-3271	greedy crotchety pants	0		Meat Drop: +20, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	greedy crotchety pants	0		Meat Drop: +20, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	lion tamer's Saccharine Maple pendant	0		Experience (familiar): +2, Conditional Skill (Equipped): "Spray Sap"
-3273	narrow hale willowy bonnet	0		Maximum HP: +20, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	narrow hale willowy bonnet	0		Maximum HP: +20, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3273,7 +3273,7 @@
 3301	jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
 3303	lime green sombrero	0		Sombrero Bonus: +10
-3304	olive twirling Argarggagarg's fang	0		
+3304	twirling olive Argarggagarg's fang	0		
 3305	ghostly Safari Jack's moustache	0		
 3306	Yakisoba's hat	0		
 3307	Heimandatz's heart	0		
@@ -3285,14 +3285,14 @@
 3313	gravedigger's marinara jug	0		Spooky Damage: +10, Class: "Sauceror"
 3314	lime green reassuring makeshift castanets	0		Spooky Resistance: +1, Class: "Disco Bandit"
 3315	censurious left-handed melodica	0		Sleaze Resistance: +3, Class: "Accordion Thief"
-3316	dried purple shaking epic wad	1	good	
+3316	dried shaking purple epic wad	1	good	
 3317	zippy bottlecap	0		Initiative: +20, Single Equip
 3318	pulsating resourceful corncob pipe	0		Maximum MP: +50, Single Equip
 3319	wobbly banded Mr. Joe's bangles	0		Damage Absorption: +100, Single Equip
 3320	ghostly lion tamer's frayed rope belt	0		Experience (familiar): +2, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	upside-down energetic mayfly bait necklace of the pedagogue	0		Experience: +3, Maximum MP Percent: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
-3323	spinning narrow Ol' Scratch's salad fork	0		
+3322	upside-down energetic mayfly bait necklace of the pedagogue	0		Experience: +3, Maximum MP Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3323	narrow spinning Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	tolerable jar of fermented pickle juice	4	good	
 3326	altered red voodoo snuff	1	good	Effect: "Bestial Sympathy", Effect Duration: 45
@@ -3325,14 +3325,14 @@
 3353	non-quantum ionized enhanced llama lama gong	0		Effect: "Cancer Rising", Effect Duration: 23, Last Available: "2008-06"
 3354	spoiled banana-frosted king cake	4	crappy	Last Available: "2008-08"
 3355	brown plastic baby of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2008-08"
-3356	ghostly tumbling plump juicy grub	0		Last Available: "2008-06"
+3356	tumbling ghostly plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	olive scrumptious ice ant	0		Last Available: "2008-06"
 3360	blinking stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	half-sized stale special mole mol&eacute;	2	decent	Effect: "Burning Hands", Effect Duration: 30, Last Available: "2008-06"
+3363	stale special half-sized mole mol&eacute;	2	decent	Effect: "Burning Hands", Effect Duration: 30, Last Available: "2008-06"
 3364	acceptable high-proof Morlock's Mark Bourbon	8	good	Last Available: "2008-06"
 3365	non-galvanized deionized tarnished Climate Colada	0		Effect: "Penguinny Flavor", Effect Duration: 66, Last Available: "2008-06"
 3366	moist digital underground potion	0		Effect: "Berry Thorny", Effect Duration: 68, Last Available: "2008-06"
@@ -3371,7 +3371,7 @@
 3399	artisanal watered-down jar of squeeze	2	super ultra mega turbo EPIC	
 3400	flavorless spinning bowl of fishysoisse	4	decent	
 3401	concentrated quantum electrified shaking deadly lampshade	0		Effect: "Tenacity of the Snapper", Effect Duration: 28
-3402	concentrated pickled moist squat gray concentrated garbage juice	0		Effect: "Saucegoggles", Effect Duration: 13
+3402	concentrated pickled moist gray squat concentrated garbage juice	0		Effect: "Saucegoggles", Effect Duration: 13
 3403	lewd playing card	0		
 3404	blinking deck of lewd playing cards of the bloodbag of the storm of the glutton	0		Maximum HP: +100, Maximum MP Percent: +40, Food Drop: +100
 3405	steel-toed Hodgman's sock	0		Damage Reduction: 9, Single Equip
@@ -3386,13 +3386,13 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	spinning hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	double-tarnished blue mirror sterno-flavored Hob-O	0		Effect: "Haunted Stomach", Effect Duration: 32
 3423	anodized spinning frostbite-flavored Hob-O	0		Effect: "Crusty Head", Effect Duration: 54
 3424	warmed fry-oil-flavored Hob-O	0		Effect: "Ninja, Please", Effect Duration: 24
 3425	electrified red garbage-juice-flavored Hob-O	0		Effect: "Alacri Tea", Effect Duration: 67
 3426	cold-filtered ionized alkaline strawberry-flavored Hob-O	0		Effect: "Nuts about Candy", Effect Duration: 68
-3427	purple blurry roll of Hob-Os	0		
+3427	blurry purple roll of Hob-Os	0		
 3428	unsweetened super-activated anodized Everlasting Deckswabber	0		Effect: "Fan-Cooled", Effect Duration: 36
 3430	bouncing bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
@@ -3404,7 +3404,7 @@
 3437	huge twirling clever curative stylish Staff of the Black Kettle	0		Moxie: +25, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5
 3438	friendly Jim Carey's weightlifter's Staff of the Well-Tempered Cauldron	0		Muscle: +15, Monster Level: +25, Familiar Weight: +3
 3439	skewed Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	dried tumbling shaking prismatic wad	1	awesome	Effect: "Tingly Elbows", Effect Duration: 45, Last Available: "2008-07"
+3440	dried shaking tumbling prismatic wad	1	awesome	Effect: "Tingly Elbows", Effect Duration: 45, Last Available: "2008-07"
 3441	wobbly ribald club of the five seasons	0		Sleaze Damage: +10, Last Available: "2008-07"
 3442	mirror rainbow crossbow of bravery	0		Spooky Resistance: +5, Last Available: "2008-07"
 3443	kitten	0		
@@ -3424,13 +3424,13 @@
 3457	slick Junior Adventurer's merit badge	0		Moxie: +10
 3458	triple-galvanized magnetized bouncing STYX deodorant body spray	0		Effect: "You Liver", Effect Duration: 21
 3459	practically non-alcoholic smooth huge white-label gin	1	awesome	
-3460	moldy miniature tin rations	2	crappy	
+3460	miniature moldy tin rations	2	crappy	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
 3463	artisanal fortified bottle of sake	5	EPIC	
 3464	dog trainer's round pebble	0		Experience (familiar): +1
-3465	stale bite-sized skewed Bash-&#332;s cereal	1	decent	Wiki Name: "Bash-Os cereal"
-3466	blurry MacGyver's Samson's haiku katana of the sewer	0		Experience (Muscle): +5, Maximum MP: +100, Stench Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3465	bite-sized stale skewed Bash-&#332;s cereal	1	decent	Wiki Name: "Bash-Os cereal"
+3466	blurry MacGyver's Samson's haiku katana of the sewer	0		Experience (Muscle): +5, Maximum MP: +100, Stench Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	ghostly bargain flash powder	0		
 3468	savvy plastic baby	0		Mysticality Percent: +20, Single Equip, Last Available: "2008-12"
 3469	rotten blueberry-frosted king cake	4	crappy	Last Available: "2008-12"
@@ -3443,12 +3443,12 @@
 3476	diffused plum lozenge	0		Effect: "Jammin'", Effect Duration: 63
 3477	electrified pear lozenge	0		Effect: "Fudge Headache", Effect Duration: 66
 3478	altered huge peach lozenge	0		Effect: "Amorous Avarice", Effect Duration: 53
-3479	gray narrow balloon shield	0		Damage Reduction: 3
+3479	narrow gray balloon shield	0		Damage Reduction: 3
 3480	spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	skewed passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
-3484	narrow blue eye 'n' horn shampoo	0		Familiar Weight: +5
+3484	blue narrow eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	altered anodized bouncing glittery mascara	0		Effect: "Dreadful Chill", Effect Duration: 13
 3486	dull fish scale	0		
 3487	jittery rough fish scale	0		
@@ -3462,11 +3462,11 @@
 3495	extra-dry ionized corrupted maroon sea salt crystal	0		Effect: "Bells in the Batfry", Effect Duration: 47
 3496	diffused tarnished colloidal maroon bazookafish bubble gum	0		Effect: "Rosewater Mark", Effect Duration: 58
 3497	perfectly mixed bottle of Pete's Sake	3	EPIC	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	narrow witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	bouncing beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	narrow witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	bouncing beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	spoiled canap&eacute;s	4	crappy	
-3502	twisted yellow skewed thermos of brew	1	EPIC	Effect: "Ichorous Intensity", Effect Duration: 5, Last Available: "2011-12"
+3502	twisted skewed yellow thermos of brew	1	EPIC	Effect: "Ichorous Intensity", Effect Duration: 5, Last Available: "2011-12"
 3503	tolerable blue glass of brandy	3	good	Last Available: "2011-12"
 3504	upside-down French slippers	0		
 3505	stiffened LWA ring	0		Damage Reduction: 1
@@ -3474,7 +3474,7 @@
 3507	spinning Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	chilly scratch 'n' sniff sword	0		Cold Damage: +5, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
-3510	shaking lime green scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
+3510	lime green shaking scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	narrow scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	huge educational slick depleted Grimacite gravy boat	0		Moxie: +10, Experience: +1, Last Available: "2011-12"
 3544	aromatic sinister depleted Grimacite weightlifting belt	0		Spell Damage: +10, Stench Resistance: +1, Single Equip, Last Available: "2011-12"
 3545	ghostly friendly therapeutic depleted Grimacite grappling hook	0		Familiar Weight: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2011-12"
-3546	zippy depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Initiative: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	upside-down dog trainer's depleted Grimacite shinguards of doom	0		Experience (familiar): +1, Spooky Spell Damage: +50, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	zippy depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Initiative: +20, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	upside-down dog trainer's depleted Grimacite shinguards of doom	0		Experience (familiar): +1, Spooky Spell Damage: +50, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	lime green asbestos-lined careful depleted Grimacite astrolabe	0		Monster Level: -10, Hot Resistance: +5, Single Equip, Last Available: "2011-12"
 3549	KoL Con Cinco Pi&ntilde;ata Bat of the detective of the cheetah	0		Item Drop: +20, Initiative: +60, Softcore Only, Last Available: "2008-09"
 3550	upside-down propeller beanie of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, cap 7"
@@ -3519,12 +3519,12 @@
 3552	censurious asbestos-lined octopus's spade of the bloodbag	0		Maximum HP: +100, Hot Resistance: +5, Sleaze Resistance: +3
 3553	soggy seed packet	0		
 3554	pulsating glob of slime	0		
-3555	snack-sized delicious sea carrot	2	awesome	
+3555	delicious snack-sized sea carrot	2	awesome	
 3556	tasty bite-sized sea cucumber	1	awesome	
 3557	gigantic decent sea avocado	7	good	
 3558	decent sea lychee	3	good	
 3559	special stale sea tangelo	3	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 5
-3560	special thick delicious sea honeydew	5	awesome	Effect: "Burnt 'n' Turnt", Effect Duration: 35
+3560	delicious thick special sea honeydew	5	awesome	Effect: "Burnt 'n' Turnt", Effect Duration: 35
 3561	polarized deionized shaking pressurized potion of puissance	0		Effect: "Flame-Retardant Trousers", Effect Duration: 49
 3562	enhanced pressurized potion of perspicacity	0		Effect: "Serendipi Tea", Effect Duration: 67
 3563	liquefied diffused pressurized potion of pulchritude	0		Effect: "Smoking like a Bandit", Effect Duration: 30
@@ -3548,15 +3548,15 @@
 3581	sushi-rolling mat	0		
 3582	enchanted normal rice	4	good	Effect: "Healthy Blue Glow", Effect Duration: 15
 3584	big moldy irradiated candy cane	5	crappy	Last Available: "2008-12"
-3585	small stale wobbly gingerbread mutant bugbear	2	decent	Last Available: "2008-12"
+3585	stale small wobbly gingerbread mutant bugbear	2	decent	Last Available: "2008-12"
 3586	delicious teal oozenog	3	awesome	Last Available: "2008-12"
 3587	enhanced tumbling tumbling sugar plum	0		Effect: "Abyssal Sweat", Effect Duration: 45, Last Available: "2008-12"
 3588	aerosolized pickled shaking sugar banana	0		Effect: "Some Cheese with Your Wine", Effect Duration: 67, Last Available: "2008-12"
 3589	non-dry tarnished sugar lime	0		Effect: "Inscrutable exoskeleton", Effect Duration: 34, Last Available: "2008-12"
-3590	colloidal pressed upside-down tumbling sugar cherry	0		Effect: "Oleaginous Soles", Effect Duration: 53, Last Available: "2008-12"
+3590	colloidal pressed tumbling upside-down sugar cherry	0		Effect: "Oleaginous Soles", Effect Duration: 53, Last Available: "2008-12"
 3591	Mer-kin hookspear of the storm of the brazier	0		Maximum MP Percent: +40, Hot Spell Damage: +25
 3592	Mer-kin takebag	0		Item Drop: +5
-3593	shaking squat Mer-kin thingpouch	0		
+3593	squat shaking Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	tarnished denatured wobbly lime green Mer-kin fastjuice	0		Effect: "Salty Dogs", Effect Duration: 12
 3596	imitation crab crate	0		
@@ -3581,15 +3581,15 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	blue pulsing flesh	0		Last Available: "2008-12"
 3617	improved chilled polarized unstable DNA	0		Effect: "Chunky", Effect Duration: 53, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	lion tamer's parasitic claw	0		Experience (familiar): +2, Last Available: "2008-12"
-3625	Usain Bolt's parasitic tentacles	0		Initiative: +80, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	squat ribald parasitic headgnawer	0		Sleaze Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	Usain Bolt's parasitic tentacles	0		Initiative: +80, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	squat ribald parasitic headgnawer	0		Sleaze Damage: +10, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	parasitic strangleworm of the empath	0		Familiar Weight: +5, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	maroon burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,11 +3598,11 @@
 3632	blurry radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	wicked elven socks of Leguizamo	0		Spell Damage: +5, Monster Level: +20, Last Available: "2008-12"
 3634	foul-smelling dance instructor's elven gloves	0		Experience Percent (Moxie): +10, Stench Damage: +10, Last Available: "2008-12"
-3635	tumbling horrifying festive holiday hat of Flo-Jo	0		Spooky Damage: +25, Initiative: +100, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	tumbling horrifying festive holiday hat of Flo-Jo	0		Spooky Damage: +25, Initiative: +100, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	horrifying coward's patent shoes	0		Monster Level: -20, Spooky Damage: +25, Last Available: "2008-12"
 3637	lime green ruddy beefcake's gray bow tie	0		Muscle: +25, Maximum HP Percent: +40, Last Available: "2008-12"
 3638	medical-grade penguin thesaurus of extreme caution	0		Monster Level: -25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2008-12"
-3639	rotten tiny blob-shaped Crimbo cookie	1	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	tiny rotten blob-shaped Crimbo cookie	1	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	narrow dragonfish caviar	0		
@@ -3613,10 +3613,10 @@
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	upside-down magic dragonfish fry	0		
 3649	ghostly map to Madness Reef	0		
-3650	normal bouncing fuchsia shaking toast with jam	3	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	normal bouncing shaking fuchsia toast with jam	3	good	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	artisanal watered-down green elven moonshine	2	EPIC	Last Available: "2008-12"
-3653	rotten immense knuckle sandwich	6	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	rotten immense knuckle sandwich	6	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	wobbly miser's hardened psycho sweater	0		Damage Reduction: 3, Meat Drop: +10, Last Available: "2008-12"
 3655	ghostly fin-bit wax	0		Familiar Weight: +5
 3656	Fonzie's plastic Mob Penguin	0		Experience (Moxie): +1, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	maroon plastic strand of DNA of the brute	0		Muscle Percent: +30, Last Available: "2008-12"
 3660	ghostly groovy plastic chunk of depleted Grimacite	0		Moxie Percent: +10, Last Available: "2008-12"
 3661	blinking container of Putty	0		Last Available: "2009-01"
-3662	nasty Putty mitre	0		Stench Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	lard-coated thinker's Putty leotard	0		Mysticality: +10, Sleaze Spell Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	nasty Putty mitre	0		Stench Damage: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	lard-coated thinker's Putty leotard	0		Mysticality: +10, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Putty ball of the bloodbag	0		Maximum HP: +100, Softcore Only, Last Available: "2009-01"
 3665	narrow Putty sheet	0		Last Available: "2009-01"
 3666	rosy-cheeked hardened Putty snake of the sewer	0		Damage Reduction: 3, Maximum HP Percent: +30, Stench Damage: +25, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	Fonzie's glow-in-the-dark burrowgrub	0		Experience (Moxie): +1, Last Available: "2009-01"
 3671	jittery Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	moldy can of franks 'n' beans	4	crappy	Last Available: "2010-12"
-3673	mediocre blurry blinking bottle of peppermint schnapps	3	decent	Last Available: "2010-12"
+3673	mediocre blinking blurry bottle of peppermint schnapps	3	decent	Last Available: "2010-12"
 3674	tumbling throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	narrow Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
@@ -3647,8 +3647,8 @@
 3681	bubbling tempura batter	0		
 3682	tumbling globe of Deep Sauce	0		
 3683	purple map to the Marinara Trench	0		
-3684	massive rotten huge tempura carrot	9	crappy	
-3685	adequate snack-sized blinking tempura cucumber	2	good	
+3684	rotten massive huge tempura carrot	9	crappy	
+3685	snack-sized adequate blinking tempura cucumber	2	good	
 3686	delicious tempura avocado	3	awesome	
 3687	flavorless sea broccoli	3	decent	
 3688	low-calorie flavorless sea cauliflower	1	decent	
@@ -3713,26 +3713,26 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	cold-filtered ionized concoction of clumsiness	0		Effect: "Heal Thy Nanoself", Effect Duration: 63
 3750	vampire pearl earring of the bloodbag	0		Maximum HP: +100, Single Equip
-3751	bite-sized decent chocolate chip brownies	1	good	
+3751	decent bite-sized chocolate chip brownies	1	good	
 3753	olive Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	ionized enhanced love song of vague ambiguity	0		Effect: "Hyphemariffic", Effect Duration: 40, Last Available: "2009-02"
 3755	warmed flattened love song of smoldering passion	0		Effect: "Concentrated Concentration", Effect Duration: 64, Last Available: "2009-02"
 3756	moist cold-filtered moist ghostly love song of icy revenge	0		Effect: "Beta Carotene Overdose", Effect Duration: 15, Last Available: "2009-02"
 3757	electrified aerosolized warmed cyan love song of sugary cuteness	0		Effect: "Sweetened and Fattened", Effect Duration: 35, Last Available: "2009-02"
-3758	boiled energized energized huge jittery love song of disturbing obsession	0		Effect: "Sizzling with Fury", Effect Duration: 44, Last Available: "2009-02"
+3758	boiled energized energized jittery huge love song of disturbing obsession	0		Effect: "Sizzling with Fury", Effect Duration: 44, Last Available: "2009-02"
 3759	activated shaking love song of naughty innuendo	0		Effect: "Remaining Alive", Effect Duration: 63, Last Available: "2009-02"
 3760	galvanized aerosolized blue breath mint	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 32
 3761	ghostly vampire pearl ring of the brazier	0		Hot Spell Damage: +25, Single Equip
 3762	curative vampire pearl necklace	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
-3763	perfectly mixed fortified lime green slug of vodka	5	EPIC	
+3763	fortified perfectly mixed lime green slug of vodka	5	EPIC	
 3764	hand-crafted slug of rum	3	EPIC	
 3765	lousy watered-down tumbling slug of shochu	2	decent	
-3766	aged weak screwdiver	2	awesome	
+3766	weak aged screwdiver	2	awesome	
 3767	aged olive dew yoana lei	4	awesome	
-3768	perfectly mixed weak huge red lychee chuhai	2	EPIC	
+3768	perfectly mixed weak red huge lychee chuhai	2	EPIC	
 3769	aged salacious screwdiver	3	awesome	
-3770	special tolerable watered-down shaking dew yoana salacious lei	2	good	Effect: "Conspiratory Eyes", Effect Duration: 40
-3771	mediocre high-proof salacious lychee chuhai	6	decent	
+3770	special watered-down tolerable shaking dew yoana salacious lei	2	good	Effect: "Conspiratory Eyes", Effect Duration: 40
+3771	high-proof mediocre salacious lychee chuhai	6	decent	
 3772	artisanal Alewife&trade; Ale	4	EPIC	
 3773	upside-down seaode	0		
 3774	map to the Dive Bar	0		
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	blurry banded Mer-kin roundshield of the wise owl of courage	0		Mysticality: +20, Damage Absorption: +100, Spooky Resistance: +3, Damage Reduction: 14
 3804	purple lion tamer's Annie Oakley's Mer-kin breastplate	0		Critical Hit Percent: +20, Experience (familiar): +2
 3805	maroon Mer-kin sneakmask of the sewer	0		Stench Damage: +25, Item Drop: +5, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3766,7 +3766,7 @@
 3811	Mer-kin stashbox	0		
 3812	spoiled tiny chocolate-frosted king cake	1	crappy	Last Available: "2009-06"
 3813	bouncing plastic baby of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2009-06"
-3815	shaking blue squat midget clownfish	0		
+3815	shaking squat blue midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
 3817	flavorless skewed sea radish	4	decent	
 3818	squat spinning spinning fireproof ruddy forbidden halibut	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Hot Resistance: +3
@@ -3782,12 +3782,12 @@
 3828	green Grandma's Map	0		
 3829	moldy blurry tempura radish	3	crappy	
 3830	water-polo cap of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xVolley, 1xBarrr"
-3831	perfectly mixed enchanted distilled Typical Tavern swill	5	EPIC	Effect: "Horrid, Torrid", Effect Duration: 45
+3831	distilled enchanted perfectly mixed Typical Tavern swill	5	EPIC	Effect: "Horrid, Torrid", Effect Duration: 45
 3832	triple-distilled mediocre tropical swill	10	decent	
 3833	mediocre bouncing fruity girl swill	3	decent	
-3834	practically non-alcoholic perfectly mixed special blended swill	1	super ultra mega turbo EPIC	Effect: "Chalk Outline", Effect Duration: 50
+3834	special practically non-alcoholic perfectly mixed blended swill	1	super ultra mega turbo EPIC	Effect: "Chalk Outline", Effect Duration: 50
 3835	costume wardrobe	0		Softcore Only
-3836	executive horrifying grievous arcane researcher's Elvish sunglasses	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Spooky Damage: +25, Meat Drop: +40, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	executive horrifying grievous arcane researcher's Elvish sunglasses	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Spooky Damage: +25, Meat Drop: +40, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	ghostly anniversary safety glass vest of extreme caution	0		Monster Level: -25
 3838	anniversary burlap belt of the overflowing toilet	0		Stench Spell Damage: +50
 3839	nippy anniversary balsa wood socks	0		Cold Damage: +10
@@ -3834,11 +3834,11 @@
 3880	bouncing hellseal disguise	0		
 3881	Jack Frost's manspreader's fouet de tortue-dressage	0		Monster Level: +10, Cold Spell Damage: +50, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
-3883	squat cyan cult memo	0		
+3883	cyan squat cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	activated super-alkaline boiled vial of slime	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 44
 3886	extra-polymerized anodized vial of slime	0		Effect: "Incensed", Effect Duration: 39
-3887	liquefied huge pulsating vial of slime	0		Effect: "Berry Critical", Effect Duration: 22
+3887	liquefied pulsating huge vial of slime	0		Effect: "Berry Critical", Effect Duration: 22
 3888	dry wobbly vial of slime	0		Effect: "Squatting and Thrusting", Effect Duration: 11
 3889	oxidized vial of slime	0		Effect: "Well-Oiled", Effect Duration: 16
 3890	dry vial of violet slime	0		Effect: "Blood-Gorged", Effect Duration: 38
@@ -3862,7 +3862,7 @@
 3910	blurry figurine of a seal	0		Class: "Seal Clubber"
 3911	wobbly figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	hand-crafted fortified cyan blended swill with a fly in it	5	EPIC	
+3913	fortified hand-crafted cyan blended swill with a fly in it	5	EPIC	
 3914	cyan turtle wax	0		
 3915	vibrating turtle wax shield	0		Maximum MP Percent: +10, Damage Reduction: 2
 3916	upside-down turtle wax helmet of Leguizamo	0		Monster Level: +20, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3950,7 +3950,7 @@
 3998	metrognome	0		Familiar Weight: +5
 3999	blurry infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	lime green string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	altered green blinking agua de vida	1	decent	Last Available: "2009-06"
+4001	altered blinking green agua de vida	1	decent	Last Available: "2009-06"
 4002	smooth tortoboggan shield of the storm	0		Moxie: +15, Maximum MP Percent: +40, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	Jim Carey's soup-chucks	0		Monster Level: +25
@@ -3964,7 +3964,7 @@
 4012	purple memory of a CG base pair	0		Last Available: "2009-06"
 4013	red memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
-4015	bouncing blinking memory of an AT base pair	0		Last Available: "2009-06"
+4015	blinking bouncing memory of an AT base pair	0		Last Available: "2009-06"
 4016	memory of a GT base pair	0		Last Available: "2009-06"
 4017	squirming Slime larva	0		
 4018	miser's greaves	0		Meat Drop: +10, Familiar Effect: "1xBarrr, cap 37"
@@ -3986,24 +3986,24 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	skewed memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	bland massive slimy sweetbreads	8	decent	
+4037	massive bland slimy sweetbreads	8	decent	
 4038	tolerable jittery slimy fermented bile bladder	3	good	
 4039	dried jittery slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	jittery scorching pig-iron helm of horror	0		Hot Damage: +25, Spooky Spell Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	wholesome studded pig-iron shinguards	0		Damage Absorption: +80, Maximum HP Percent: +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	jittery scorching pig-iron helm of horror	0		Hot Damage: +25, Spooky Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	wholesome studded pig-iron shinguards	0		Damage Absorption: +80, Maximum HP Percent: +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	bouncing manspreader's curative pig-iron bracers	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2009-06"
 4044	pulsating wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
-4046	fuchsia tumbling wumpus-hair net	0		Last Available: "2009-06"
+4046	tumbling fuchsia wumpus-hair net	0		Last Available: "2009-06"
 4047	perfumed wumpus-hair whip	0		Stench Resistance: +5, Last Available: "2009-06"
-4048	twirling yellow gravedigger's scorching electrified wumpus-hair wig	0		Hot Damage: +25, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	lightning-fast therapeutic arcane researcher's wumpus-hair loincloth	0		Experience Percent (Mysticality): +10, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	twirling yellow gravedigger's scorching electrified wumpus-hair wig	0		Hot Damage: +25, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	lightning-fast therapeutic arcane researcher's wumpus-hair loincloth	0		Experience Percent (Mysticality): +10, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	chaotic sharpshooter's wumpus-hair sweater	0		Critical Hit Percent: +10, Spell Critical Percent: +10, Last Available: "2009-06"
 4051	ring of teleportation of the brazier	0		Hot Spell Damage: +25, Single Equip
 4052	glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	banana milkshake	1	crappy	Last Available: "2009-06"
-4054	practically non-alcoholic drinkable White Hyborian	1	good	Last Available: "2009-06"
+4054	drinkable practically non-alcoholic White Hyborian	1	good	Last Available: "2009-06"
 4055	frightening goblin hunting spear	0		Spooky Damage: +5, Last Available: "2009-06"
 4056	skewed huge fireproof frightening goblin autoblowgun	0		Spooky Damage: +5, Hot Resistance: +3, Last Available: "2009-06"
 4057	narrow tribal beads of the businessman	0		Meat Drop: +50, Last Available: "2009-06"
@@ -4039,7 +4039,7 @@
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
 4089	tarnished neurostim pill	0		Effect: "Bilious Briskness", Effect Duration: 45, Last Available: "2009-06"
-4090	dry liquefied ionized skewed huge ghostly physiostim pill	0		Effect: "Sugar, Hello", Effect Duration: 61, Last Available: "2009-06"
+4090	dry liquefied ionized ghostly huge skewed physiostim pill	0		Effect: "Sugar, Hello", Effect Duration: 61, Last Available: "2009-06"
 4091	slimy cyst	0		
 4092	small slimy cyst	0		
 4093	skewed tumbling medium slimy cyst	0		
@@ -4085,7 +4085,7 @@
 4133	non-moist flattened tempura air	0		Effect: "Comic Violence", Effect Duration: 48
 4134	concentrated pressurized potion of pneumaticity	0		Effect: "Voracious Gorging", Effect Duration: 54
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	yellow auspicious greasy friendly Bag o' Tricks of the wise owl	0		Mysticality: +20, Familiar Weight: +3, Sleaze Spell Damage: +10, Item Drop: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	yellow auspicious greasy friendly Bag o' Tricks of the wise owl	0		Mysticality: +20, Familiar Weight: +3, Sleaze Spell Damage: +10, Item Drop: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4109,7 +4109,7 @@
 4157	gravel	0		Last Available: "2009-09"
 4158	upside-down rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	bad enchanted fortified pebblebr&auml;u	5	decent	Effect: "Retrograde Relaxation", Effect Duration: 50, Last Available: "2009-09"
+4160	enchanted fortified bad pebblebr&auml;u	5	decent	Effect: "Retrograde Relaxation", Effect Duration: 50, Last Available: "2009-09"
 4161	flavorless huge rocky road ice cream	3	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	pressed cold-filtered deionized children of the candy corn	0		Effect: "Less Pervious", Effect Duration: 17
@@ -4130,8 +4130,8 @@
 4178	ghostly smartaleck's sugar shotgun	0		Moxie Percent: +30, Last Available: "2009-09"
 4179	hale sugar shillelagh	0		Maximum HP: +20, Last Available: "2009-09"
 4180	studded sugar shank	0		Damage Absorption: +80, Last Available: "2009-09"
-4181	narrow mirror sugar chapeau of doom of bravery of the cheetah	0		Spooky Spell Damage: +50, Spooky Resistance: +5, Initiative: +60, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	shaking sugar shorts of James Dean	0		Experience (Moxie): +3, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	narrow mirror sugar chapeau of doom of bravery of the cheetah	0		Spooky Spell Damage: +50, Spooky Resistance: +5, Initiative: +60, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	shaking sugar shorts of James Dean	0		Experience (Moxie): +3, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	blurry sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4159,7 +4159,7 @@
 4207	twirling therapeutic dorsal fin	0		HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 13
 4208	skate skates	0		
 4209	skate skin	0		
-4210	twirling fuchsia roller skate decoy	0		
+4210	fuchsia twirling roller skate decoy	0		
 4211	mermaid's purse	0		
 4212	underwater slingshot	0		
 4213	shaking shaking skate blade of the sewer of the overflowing toilet	0		Stench Damage: +25, Stench Spell Damage: +50
@@ -4178,11 +4178,11 @@
 4226	personal trainer's Star of Bravery	0		Experience Percent (Muscle): +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	shaking amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	shaking amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	skewed ice skate decoy	0		
 4232	purple upside-down ice skate doll	0		
-4233	blinking fuchsia hacienda key	0		
+4233	fuchsia blinking hacienda key	0		
 4234	jittery extremely unsafe pat&eacute; knife	0		Weapon Damage Percent: +100
 4235	pulsating salt-shaker	0		
 4236	can of sterno	0		
@@ -4209,12 +4209,12 @@
 4257	bouncing petrified wood	0		Last Available: "2009-10"
 4258	bland chocolate-covered scarab beetle	3	decent	Last Available: "2009-10"
 4259	smooth mulled cider	3	awesome	Last Available: "2009-10"
-4260	twirling wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	narrow pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mirror mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	twirling wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	narrow pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mirror mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	huge Ax of L'rose	0		Last Available: "2009-10"
-4264	fireproof bark boxers	0		Hot Resistance: +3, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	sizzling bark beret	0		Hot Damage: +10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	fireproof bark boxers	0		Hot Resistance: +3, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	sizzling bark beret	0		Hot Damage: +10, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	baleful bark bracelet	0		Spell Damage: +25, Single Equip
 4267	knitted lard-coated Krakrox's Loincloth	0		Sleaze Spell Damage: +25, Cold Resistance: +3, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	hardy grievous Galapagosian Cuisses	0		Weapon Damage Percent: +50, Maximum HP: +50, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	toasty razor-sharp Rosewater's Ass-Stompers of Violence	0		Mysticality Percent: +30, Weapon Damage Percent: +25, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	frightening Brand of Violence of the ox of Leguizamo	0		Muscle: +20, Monster Level: +20, Spooky Damage: +5, Conditional Skill (Equipped): "Brand"
 4299	greedy perfumed Novelty Belt Buckle of Violence of the ox	0		Muscle: +20, Stench Resistance: +5, Meat Drop: +20, Single Equip
-4300	lightning-fast groovy Lens of Violence of Leguizamo	0		Moxie Percent: +10, Monster Level: +20, Initiative: +40, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	lightning-fast groovy Lens of Violence of Leguizamo	0		Moxie Percent: +10, Monster Level: +20, Initiative: +40, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	healthy grievous Samson's Pigsticker of Violence	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Maximum HP Percent: +20
-4302	energetic educational Jodhpurs of Violence of the bloodbag	0		Experience: +1, Maximum HP: +100, Maximum MP Percent: +20, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	energetic educational Jodhpurs of Violence of the bloodbag	0		Experience: +1, Maximum HP: +100, Maximum MP Percent: +20, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	Usain Bolt's MacGyver's ruddy Cold Stone of Hatred	0		Maximum HP Percent: +40, Maximum MP: +100, Initiative: +80, Conditional Skill (Equipped): "Chilling Grip"
 4304	scandalous therapeutic Girdle of Hatred of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	squat nasty chaotic Staff of Simmering Hatred of the bloodbag	0		Maximum HP: +100, Spell Critical Percent: +10, Stench Damage: +5
-4306	upside-down nasty grievous Pantaloons of Hatred of the empath	0		Weapon Damage Percent: +50, Familiar Weight: +5, Stench Damage: +5, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	upside-down nasty grievous Pantaloons of Hatred of the empath	0		Weapon Damage Percent: +50, Familiar Weight: +5, Stench Damage: +5, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	clever medical-grade Fuzzy Slippers of Hatred of the storm	0		Maximum MP Percent: +40, Maximum MP: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-4308	sharpshooter's Tesla Lens of Hatred of the overflowing toilet	0		Critical Hit Percent: +10, Stench Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	sharpshooter's Tesla Lens of Hatred of the overflowing toilet	0		Critical Hit Percent: +10, Stench Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	shellacked studded Treads of Loathing of the businessman	0		Damage Absorption: +80, Damage Reduction: 7, Meat Drop: +50, Single Equip
 4310	ghostly manspreader's MacGyver's hale Scepter of Loathing	0		Maximum HP: +20, Maximum MP: +100, Monster Level: +10
 4311	rosewater-soaked Belt of Loathing of doom of mayonnaise	0		Spooky Spell Damage: +50, Sleaze Spell Damage: +50, Stench Resistance: +3, Single Equip
@@ -4280,7 +4280,7 @@
 4328	blurry suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	blue bag of many confections	0		Last Available: "2009-12"
 4330	moldy candy kneecapping stick	4	crappy	Last Available: "2009-12"
-4331	rotten tiny squat licorice garrote	1	crappy	Last Available: "2009-12"
+4331	tiny rotten squat licorice garrote	1	crappy	Last Available: "2009-12"
 4332	candy knuckles of the glutton	0		Food Drop: +100, Last Available: "2009-12"
 4333	moldy jawbruiser	3	crappy	Last Available: "2010-12"
 4334	double-polymerized spinning chocolate car	0		Effect: "Angry like the Wolf", Effect Duration: 44, Last Available: "2009-12"
@@ -4289,7 +4289,7 @@
 4337	twirling savvy plastic stocking mimic	0		Mysticality Percent: +20, Last Available: "2009-12"
 4338	rosewater-soaked plastic Don Crimbo	0		Stench Resistance: +3, Last Available: "2009-12"
 4339	deadly plastic Crimbomination	0		Weapon Damage: +5, Last Available: "2009-12"
-4340	quadruple-warmed vacuum-sealed boiled lime green ghostly Piddles	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 55, Last Available: "2009-12"
+4340	quadruple-warmed vacuum-sealed boiled ghostly lime green Piddles	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 55, Last Available: "2009-12"
 4341	irradiated ghostly BitterSweetTarts	0		Effect: "Black Lung", Effect Duration: 22, Last Available: "2009-12"
 4342	non-deionized vacuum-sealed ghostly Polka Pop	0		Effect: "BOOsted", Effect Duration: 34, Last Available: "2009-12"
 4343	spinning Crimbuck	0		Last Available: "2009-12"
@@ -4298,18 +4298,18 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	pulsating leftover Crimbo rations	0		Last Available: "2009-12"
-4349	shaking smelly snow hat	0		Stench Spell Damage: +10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	mirror up-at-dawn snow pants	0		Adventures: +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	shaking smelly snow hat	0		Stench Spell Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	mirror up-at-dawn snow pants	0		Adventures: +5, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	skewed fireproof snow belly	0		Hot Resistance: +3, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
 4354	A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	fuchsia A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	twirling A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
-4357	shaking blurry teal A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
+4357	blurry shaking teal A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
-4359	mirror huge A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	decent snack-sized blurry expired can of franks 'n' beans	2	good	Last Available: "2009-12"
+4359	huge mirror A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+4360	snack-sized decent blurry expired can of franks 'n' beans	2	good	Last Available: "2009-12"
 4361	hand-crafted special tumbling expired bottle of peppermint schnapps	4	EPIC	Effect: "The Magical Mojomuscular Melody", Effect Duration: 40, Last Available: "2009-12"
 4362	bouncing snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
@@ -4337,21 +4337,21 @@
 4385	pocketwatch on a chain of vim and vigor of Flo-Jo	0		Maximum HP Percent: +50, Initiative: +100, Last Available: "2009-12"
 4386	censurious studded cement sandals	0		Damage Absorption: +80, Sleaze Resistance: +3, Single Equip, Last Available: "2009-12"
 4387	energetic night-vision goggles of the brute	0		Muscle Percent: +30, Maximum MP Percent: +20, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	hardened peanut brittle shield	0		Damage Reduction: 6, Last Available: "2009-12"
 4390	sharpshooter's Red Rover BB gun of the ox	0		Muscle: +20, Critical Hit Percent: +10, Last Available: "2009-12"
-4391	shellacked red-and-green sweater	0		Damage Reduction: 7, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	shellacked red-and-green sweater	0		Damage Reduction: 7, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	modified tarnished teal Crimbo peppermint bark	0		Effect: "Human-Machine Hybrid", Effect Duration: 68, Last Available: "2009-12"
 4394	quadruple-Vulcanized Crimbo fudge	0		Effect: "Hippy Flavor", Effect Duration: 17, Last Available: "2009-12"
 4395	triple-Vulcanized dry super-enhanced huge Crimbo pecan	0		Effect: "Super Vision", Effect Duration: 38, Last Available: "2009-12"
-4396	blinking blurry wobbly Jack-in-the-box	0		Last Available: "2009-12"
+4396	wobbly blurry blinking Jack-in-the-box	0		Last Available: "2009-12"
 4397	red crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	tumbling smooth cheese sword	0		Moxie: +15, Softcore Only, Last Available: "2010-01"
-4400	Van der Graaf cheese diaper	0		MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	Van der Graaf cheese diaper	0		MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	cyan strapping cheese wheel	0		Muscle: +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	padded cheese eye	0		Damage Absorption: +20, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	padded cheese eye	0		Damage Absorption: +20, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	jittery clever dance instructor's Fonzie's Staff of Queso Escusado	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Maximum MP: +20, Softcore Only, Last Available: "2010-01"
 4405	ghostly foreign box	0		
 4406	skewed The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4382,7 +4382,7 @@
 4432	pressed invisibility potion	0		Effect: "familiar.enq", Effect Duration: 42, Last Available: "2011-08"
 4433	non-tarnished spinning irresistibility potion	0		Effect: "Standard Cheer", Effect Duration: 26, Last Available: "2011-08"
 4434	quantum boiled bouncing irritability potion	0		Effect: "Clean-Shaven", Effect Duration: 64, Last Available: "2011-08"
-4436	upside-down blinking cube	0		Last Available: "2011-02"
+4436	blinking upside-down cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
 4439	ghostly hellseal claw	0		
 4440	sharpshooter's guard turtle shell	0		Critical Hit Percent: +10, Familiar Effect: "atk, 1xFairy, cap 40"
@@ -4396,7 +4396,7 @@
 4448	dried wobbly Instant Karma	1	EPIC	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	blurry map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	bouncing knitted pointy hat	0		Cold Resistance: +3, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	bouncing knitted pointy hat	0		Cold Resistance: +3, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	jittery chilly machetito	0		Cold Damage: +5, Last Available: "2010-04"
 4453	teal auspicious lawnmower blade	0		Item Drop: +10, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4408,7 +4408,7 @@
 4460	deadly sage snailmail hauberk	0		Mysticality Percent: +10, Weapon Damage: +5
 4461	colloidal skewed seal-brain elixir	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 26
 4462	wet chocolate seal-clubbing club	0		Effect: "Seriously Mutated", Effect Duration: 68
-4463	corrupted bouncing huge chocolate turtle totem	0		Effect: "Heart of White", Effect Duration: 47
+4463	corrupted huge bouncing chocolate turtle totem	0		Effect: "Heart of White", Effect Duration: 47
 4464	ionized liquefied ionized pulsating chocolate pasta spoon	0		Effect: "Pie in the Sky", Effect Duration: 17
 4465	irradiated chocolate saucepan	0		Effect: "Outer Wolf&trade;", Effect Duration: 55
 4466	ionized enhanced skewed chocolate disco ball	0		Effect: "Mercenary", Effect Duration: 60
@@ -4416,15 +4416,15 @@
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	upside-down BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	Da Vinci's BRICKO hat	0		Experience (Mysticality): +5, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	blue nasty BRICKO pants	0		Stench Damage: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	Da Vinci's BRICKO hat	0		Experience (Mysticality): +5, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	blue nasty BRICKO pants	0		Stench Damage: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	brainy BRICKO sword	0		Mysticality: +5, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	blue BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	pulsating purple BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	purple pulsating BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	pulsating BRICKO airship	0		Last Available: "2010-02"
@@ -4444,8 +4444,8 @@
 4496	spinning extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	cold-filtered nitrogenated Vulcanized recording of The Ballad of Richie Thingfinder	0		Effect: "Executive Greed", Effect Duration: 53
 4498	pressed activated recording of Benetton's Medley of Diversity	0		Effect: "Artificially Sweet", Effect Duration: 55
-4499	vacuum-sealed skewed twirling recording of Elron's Explosive Etude	0		Effect: "Fratty Flavor", Effect Duration: 27
-4500	Vulcanized quantum maroon mirror recording of Chorale of Companionship	0		Effect: "Hyperoffended", Effect Duration: 39
+4499	vacuum-sealed twirling skewed recording of Elron's Explosive Etude	0		Effect: "Fratty Flavor", Effect Duration: 27
+4500	Vulcanized quantum mirror maroon recording of Chorale of Companionship	0		Effect: "Hyperoffended", Effect Duration: 39
 4501	quantum mirror recording of Prelude of Precision	0		Effect: "Glo-Face", Effect Duration: 39
 4502	energized maroon recording of Donho's Bubbly Ballad	0		Effect: "Gonna Get You, Sucker", Effect Duration: 28
 4503	Vulcanized recording of Inigo's Incantation of Inspiration	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 55, Last Available: "2010-02"
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	flame-wreathed slick eye of the Tiger-lily	0		Moxie: +10, Hot Spell Damage: +10, Last Available: "2010-03"
-4524	careful extremely unsafe wig	0		Weapon Damage Percent: +100, Monster Level: -10, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	diet special tasty donut	1	awesome	Effect: "Always In Motion", Effect Duration: 50, Last Available: "2010-03"
-4526	rotten tiny bucket of honey	1	crappy	Last Available: "2010-03"
+4524	careful extremely unsafe wig	0		Weapon Damage Percent: +100, Monster Level: -10, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	special diet tasty donut	1	awesome	Effect: "Always In Motion", Effect Duration: 50, Last Available: "2010-03"
+4526	tiny rotten bucket of honey	1	crappy	Last Available: "2010-03"
 4527	blinking dangerous elephant stinger of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, Last Available: "2010-03"
 4528	tasty dragon snaps	3	awesome	Last Available: "2010-03"
 4529	censurious experienced snapdragon pistil	0		Experience: +2, Sleaze Resistance: +3, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	bite-sized rotten rook cookie	1	crappy	Last Available: "2010-03"
-4532	flavorless super-sized bishop cookie	5	decent	Last Available: "2010-03"
+4532	super-sized flavorless bishop cookie	5	decent	Last Available: "2010-03"
 4533	rotten bite-sized ghostly knight cookie	1	crappy	Last Available: "2010-03"
-4534	fancy super-sized bland king cookie	5	decent	Effect: "Frozen Shoulders", Effect Duration: 25, Last Available: "2010-03"
+4534	bland fancy super-sized king cookie	5	decent	Effect: "Frozen Shoulders", Effect Duration: 25, Last Available: "2010-03"
 4535	rotten thick queen cookie	5	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	gray fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	insane tophat of the sewer	0		Stench Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	beefcake's helm of the knight of Flo-Jo	0		Muscle: +25, Initiative: +100, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	insane tophat of the sewer	0		Stench Damage: +25, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	beefcake's helm of the knight of Flo-Jo	0		Muscle: +25, Initiative: +100, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	blinking Annie Oakley's brawny wristwatch of the knight	0		Muscle Percent: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2010-03"
-4540	pulsating up-at-dawn Socratic trousers of the knight	0		Experience (Mysticality): +1, Adventures: +5, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	pulsating up-at-dawn Socratic trousers of the knight	0		Experience (Mysticality): +1, Adventures: +5, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	stiffened tophat	0		Damage Reduction: 1, Familiar Effect: "1xBarrr, cap 25"
 4542	blue upside-down manspreader's tie	0		Monster Level: +10, Single Equip
 4543	tuxedo pants of James Dean	0		Experience (Moxie): +3, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4502,7 +4502,7 @@
 4554	blinking percent sign	0		
 4555	left bracket	0		
 4556	right parenthesis	0		
-4557	green ghostly dollar sign	0		
+4557	ghostly green dollar sign	0		
 4558	equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
@@ -4510,10 +4510,10 @@
 4562	narrow hair of the calf	0		Last Available: "2010-04"
 4563	bad bouncing world's most unappetizing beverage	3	decent	Last Available: "2010-04"
 4564	smooth slippery when wet shield	0		Moxie: +15, Damage Reduction: 6, Last Available: "2010-04"
-4565	flavorless bite-sized mirror raisin	1	decent	Last Available: "2010-04"
+4565	bite-sized flavorless mirror raisin	1	decent	Last Available: "2010-04"
 4566	maroon ghostly fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	skewed flame-retardant friendly flyest of shirts	0		Familiar Weight: +3, Hot Resistance: +1, Last Available: "2010-04"
-4568	stale huge mirror a dance upon the palate	6	decent	Last Available: "2010-04"
+4568	huge stale mirror a dance upon the palate	6	decent	Last Available: "2010-04"
 4569	bland pulsating prehistoric meteorite jawbreaker	4	decent	Last Available: "2010-04"
 4570	huge Crazyleg's razor	0		Last Available: "2010-04"
 4571	stale immense blinking mirror squirmy violent party snack	10	decent	Last Available: "2010-04"
@@ -4521,12 +4521,12 @@
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	oxidized liquefied enhanced narrow Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Radiant Personality", Effect Duration: 17, Last Available: "2010-04"
 4580	medical-grade school Mafi<i>a kni</i>cke&frac12;&aelig;	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-04"
-4581	gravedigger's careful T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Monster Level: -10, Spooky Damage: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	gravedigger's careful T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Monster Level: -10, Spooky Damage: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	upside-down pulsating fat bottom quark	0		Last Available: "2010-05"
 4583	twirling maroon glob of skin	0		
 4584	spoiled thick six wedges of goat cheese	5	crappy	
@@ -4546,11 +4546,11 @@
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	huge bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	practically non-alcoholic bad plastic cup of beer	1	decent	Last Available: "2010-06"
+4601	bad practically non-alcoholic plastic cup of beer	1	decent	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	narrow bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	banded beefcake's bottle of Goldschn&ouml;ckered	0		Muscle: +25, Damage Absorption: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	banded beefcake's bottle of Goldschn&ouml;ckered	0		Muscle: +25, Damage Absorption: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	bland sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	artisanal fancy soyburger juice	3	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4569,20 +4569,20 @@
 4621	huge Game Grid token	0		Last Available: "2010-06"
 4622	green Game Grid ticket	0		Last Available: "2010-06"
 4623	frozen upside-down chocolate-covered caviar	0		Effect: "Livin' Large", Effect Duration: 64, Last Available: "2020-09"
-4624	normal diet pawn cookie	1	good	Last Available: "2010-06"
+4624	diet normal pawn cookie	1	good	Last Available: "2010-06"
 4625	mixed bouncing coffee pixie stick	1	good	Last Available: "2010-06"
 4626	twirling superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	fortified plastic spider ring	0		Damage Absorption: +60, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	fortified plastic spider ring	0		Damage Absorption: +60, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	blurry wobbly Jack Frost's plastic kazoo	0		Cold Spell Damage: +50, Last Available: "2010-06"
 4631	savvy inflatable baseball bat	0		Mysticality Percent: +20, Last Available: "2010-06"
-4632	lime green family-friendly frightening googly-star hat	0		Spooky Damage: +5, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2010-06"
+4632	lime green family-friendly frightening googly-star hat	0		Spooky Damage: +5, Sleaze Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk"
 4633	hale googly-ball hat of Tarzan	0		Experience (Muscle): +3, Maximum HP: +20, Last Available: "2010-06"
 4634	sinister googly-heart hat of chilblains	0		Spell Damage: +10, Cold Damage: +25, Last Available: "2010-06"
 4635	miser's super-sweet boom box of the sewer	0		Stench Damage: +25, Meat Drop: +10, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	razor-sharp cool sinister demon mask of the glutton	0		Moxie: +5, Weapon Damage Percent: +25, Food Drop: +100, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	razor-sharp cool sinister demon mask of the glutton	0		Moxie: +5, Weapon Damage Percent: +25, Food Drop: +100, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	skewed auspicious frosty Temple Grandin's streetfighting champion's belt	0		Familiar Weight: +7, Cold Spell Damage: +10, Item Drop: +10, Single Equip, Last Available: "2010-06"
 4639	sinister brainy weightlifter's Space Trip safety headphones	0		Muscle: +15, Mysticality: +5, Spell Damage: +10, Single Equip, Last Available: "2010-06"
 4640	skewed educational LARP carp	0		Experience: +1
@@ -4594,8 +4594,8 @@
 4646	twirling aromatic Jim Carey's crafty Meteoid ice beam	0		Maximum MP: +10, Monster Level: +25, Stench Resistance: +1, Last Available: "2011-12"
 4647	veiny baleful Dungeon Fist gauntlet of the cougar	0		Moxie: +20, Spell Damage: +25, Maximum HP: +10, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	upside-down chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	upside-down chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	ghostly auspicious extremely unsafe ironic knit cap	0		Weapon Damage Percent: +100, Item Drop: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	pottery shield of the pedagogue	0		Experience: +3, Damage Reduction: 3, Last Available: "2010-09"
-4682	ghostly nasty pottery hat of wisdom	0		Mysticality: +15, Stench Damage: +5, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	skewed manspreader's MacGyver's pottery training pants	0		Maximum MP: +100, Monster Level: +10, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	ghostly nasty pottery hat of wisdom	0		Mysticality: +15, Stench Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	skewed manspreader's MacGyver's pottery training pants	0		Maximum MP: +100, Monster Level: +10, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	wizardly pottery club	0		Mysticality: +25, Last Available: "2010-09"
 4685	bouncing Tesla pottery yo-yo	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4637,11 +4637,11 @@
 4689	fossilized baboon skull	0		Last Available: "2010-09"
 4690	fossilized wyrm skull	0		Last Available: "2010-09"
 4691	huge fossilized wing	0		Last Available: "2010-09"
-4692	maroon shaking fossilized limb	0		Last Available: "2010-09"
+4692	shaking maroon fossilized limb	0		Last Available: "2010-09"
 4693	pulsating fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	zippy executive banded Greatest American Pants	0		Damage Absorption: +100, Meat Drop: +40, Initiative: +20, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	zippy executive banded Greatest American Pants	0		Damage Absorption: +100, Meat Drop: +40, Initiative: +20, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	hardy fossilized necklace	0		Maximum HP: +50, Last Available: "2010-09"
 4698	pulsating imp air	0		
 4699	bus pass	0		
@@ -4659,7 +4659,7 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	twirling GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	tiny spoiled pulsating huge lemon popsicle	1	crappy	
+4714	spoiled tiny huge pulsating lemon popsicle	1	crappy	
 4715	moldy green popsicle	3	crappy	
 4716	low-calorie spoiled strawberry popsicle	1	crappy	
 4717	adequate thick blinking liver popsicle	5	good	
@@ -4673,7 +4673,7 @@
 4725	tasty huge piping organ pie	10	awesome	Last Available: "2010-10"
 4726	adequate igloo pie	4	good	Last Available: "2010-10"
 4727	immense stale stomach turnover	6	decent	Last Available: "2010-10"
-4728	spoiled miniature bouncing dead lights pie	2	crappy	Last Available: "2010-10"
+4728	miniature spoiled bouncing dead lights pie	2	crappy	Last Available: "2010-10"
 4729	adequate throbbing organ pie	4	good	Last Available: "2010-10"
 4730	blue huge bouncing aromatic stop shield	0		Stench Resistance: +1, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4684,13 +4684,13 @@
 4736	tangle of rat tails	0		
 4737	yellow flame-retardant beer-soaked mop	0		Hot Resistance: +1
 4738	drinkable watered-down day-old beer	2	good	
-4739	aged blurry upside-down plain beer	3	awesome	
+4739	aged upside-down blurry plain beer	3	awesome	
 4740	bad strong blue overpriced &quot;imported&quot; beer	5	decent	
 4741	cyan smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	ionized PlexiPips	0		Effect: "Rage of the Reindeer", Effect Duration: 17
-4745	improved spinning blurry lime green Wax Flask	0		Effect: "Ham-Fisted", Effect Duration: 47
+4745	improved blurry lime green spinning Wax Flask	0		Effect: "Ham-Fisted", Effect Duration: 47
 4746	super-liquefied warmed non-moist gray Pain Dip	0		Effect: "Fishy", Effect Duration: 63
 4747	spoiled snack-sized bone meal	2	crappy	Last Available: "2010-10"
 4748	spirit-forward artisanal bone aperitif	5	EPIC	Last Available: "2010-10"
@@ -4699,8 +4699,8 @@
 4751	boning knife of the bloodbag	0		Maximum HP: +100, Last Available: "2010-10"
 4752	blinking ribald bone crusher	0		Sleaze Damage: +10, Last Available: "2010-10"
 4753	scorching bone spurs	0		Hot Damage: +25, Single Equip, Last Available: "2010-10"
-4754	rosy-cheeked brawny bonedanna	0		Muscle Percent: +20, Maximum HP Percent: +30, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	perfumed asbestos-lined boneana hammock	0		Hot Resistance: +5, Stench Resistance: +5, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	rosy-cheeked brawny bonedanna	0		Muscle Percent: +20, Maximum HP Percent: +30, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	perfumed asbestos-lined boneana hammock	0		Hot Resistance: +5, Stench Resistance: +5, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	magnetized candy skeleton	0		Effect: "Uncanny Shot", Effect Duration: 41, Last Available: "2020-09"
@@ -4724,7 +4724,7 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	twirling Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	olive Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	bite-sized enchanted normal narrow CRIMBCOIDS mints	1	good	Effect: "Hairless and Airless", Effect Duration: 5, Last Available: "2011-01"
+4818	normal enchanted bite-sized narrow CRIMBCOIDS mints	1	good	Effect: "Hairless and Airless", Effect Duration: 5, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	decent CRIMBCOLOAF	4	good	Last Available: "2011-01"
 4821	decent circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4733,7 +4733,7 @@
 4824	skewed plastic hobo elf of the boozehound	0		Booze Drop: +100, Last Available: "2010-12"
 4825	slick plastic Mr. Mination	0		Moxie: +10, Last Available: "2010-12"
 4826	skewed careful plastic Best Game Ever	0		Monster Level: -10, Last Available: "2010-12"
-4827	squat gray hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
+4827	gray squat hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	bouncing robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	shaking robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
@@ -4743,7 +4743,7 @@
 4834	spinning robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	tumbling robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	green spinning robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	spinning green robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	small adequate triangular CRIMBCOOKIE	2	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	normal blue square CRIMBCOOKIE	3	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
@@ -4751,9 +4751,9 @@
 4842	shaking sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	Jeselnik's Uncle Hobo's stocking cap of the early riser	0		Sleaze Damage: +25, Adventures: +7, Familiar Effect: "atk", Last Available: "2010-12"
+4845	Jeselnik's Uncle Hobo's stocking cap of the early riser	0		Sleaze Damage: +25, Adventures: +7, Last Available: "2010-12", Familiar Effect: "atk"
 4846	scorching experienced Uncle Hobo's epic beard	0		Experience: +2, Hot Damage: +25, Single Equip, Last Available: "2010-12"
-4847	mansplainer's arcane researcher's Uncle Hobo's gift baggy pants	0		Experience Percent (Mysticality): +10, Monster Level: +15, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	mansplainer's arcane researcher's Uncle Hobo's gift baggy pants	0		Experience Percent (Mysticality): +10, Monster Level: +15, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	Uncle Hobo's fingerless tinsel gloves of horror of the early riser	0		Spooky Spell Damage: +25, Adventures: +7, Single Equip, Last Available: "2010-12"
 4849	beefy Uncle Hobo's highest bough of the cougar	0		Muscle: +10, Moxie: +20, Last Available: "2010-12"
 4850	steel-toed Uncle Hobo's belt of chilblains	0		Damage Reduction: 9, Cold Damage: +25, Single Equip, Last Available: "2010-12"
@@ -4762,7 +4762,7 @@
 4853	ionized huge holly-flavored Hob-O	0		Effect: "Cold Throat", Effect Duration: 54, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
-4856	bouncing upside-down blue paperclip	0		Last Available: "2011-01"
+4856	bouncing blue upside-down paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	bouncing wizardly CRIMBCO lanyard	0		Mysticality: +25, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	gray pulsating Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	pulsating inspector's nippy hardened paperclip-on tie	0		Damage Reduction: 3, Cold Damage: +10, Item Drop: +15, Single Equip, Last Available: "2011-01"
-4869	jittery energetic paperclip pants of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	medical-grade paperclip turban of the blizzard of mayonnaise	0		Cold Spell Damage: +25, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	jittery energetic paperclip pants of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +20, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	medical-grade paperclip turban of the blizzard of mayonnaise	0		Cold Spell Damage: +25, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	paperclip cape of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4790,14 +4790,14 @@
 4881	tolerable CRIMBCO wine	3	good	Last Available: "2011-01"
 4882	shaking Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	upside-down toe jam	0		Last Available: "2011-01"
-4884	flavorless half-sized toe jam toast	2	decent	Last Available: "2011-01"
+4884	half-sized flavorless toe jam toast	2	decent	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	adequate shaking traffic jam toast	4	good	Last Available: "2011-01"
 4887	blinking space jam	0		Last Available: "2011-01"
 4888	yummy gigantic space jam toast	9	awesome	Last Available: "2011-01"
 4889	modified polarized motivational poster	0		Effect: "Berry Experiential", Effect Duration: 19, Last Available: "2011-01"
 4890	bouncing sack lunch	0		Last Available: "2011-01"
-4891	tumbling blue bath ball gift set	0		Last Available: "2011-01"
+4891	blue tumbling bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	skewed BGE shotglass	0		Last Available: "2010-12"
 4894	adequate fancy festive sausage	3	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 15, Last Available: "2011-01"
@@ -4855,7 +4855,7 @@
 4952	quantum baggie of sugar	0		Effect: "The Halls of Mysticality", Effect Duration: 48
 4953	zippy frosty whalebone corset	0		Cold Spell Damage: +10, Initiative: +20, Single Equip
 4954	wizardly oven mitts	0		Mysticality: +25, Single Equip
-4955	massive adequate overcookie	6	good	
+4955	adequate massive overcookie	6	good	
 4956	normal philosopher's scone	4	good	
 4957	non-diffused adjusted half-baked potion	0		Effect: "Sourpuss", Effect Duration: 22
 4958	skewed stylish Knob Goblin deluxe scimitar	0		Moxie: +25
@@ -4874,7 +4874,7 @@
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	narrow Alice's Army Ninja	0		Last Available: "2011-03"
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
-4974	skewed red Alice's Army Page	0		Last Available: "2011-03"
+4974	red skewed Alice's Army Page	0		Last Available: "2011-03"
 4975	cyan Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	upside-down Alice's Army Nurse	0		Last Available: "2011-03"
@@ -4889,12 +4889,12 @@
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
 4987	fuchsia Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	Alice's Army Foil Swordsman	0		Last Available: "2011-03"
-4989	narrow lime green Alice's Army Foil Spearsman	0		Last Available: "2011-03"
+4989	lime green narrow Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	twirling Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	Alice's Army Foil Ninja	0		Last Available: "2011-03"
-4994	pulsating tumbling Alice's Army Foil Alchemist	0		Last Available: "2011-03"
+4994	tumbling pulsating Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	blinking Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
 4997	Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
@@ -4913,7 +4913,7 @@
 5010	evil eye	0		
 5011	wobbly Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	enchanted decent wasabi pocky	4	good	Effect: "Once Bitten Twice Fried", Effect Duration: 30, Last Available: "2011-03"
+5013	decent enchanted wasabi pocky	4	good	Effect: "Once Bitten Twice Fried", Effect Duration: 30, Last Available: "2011-03"
 5014	stale massive tobiko pocky	10	decent	Last Available: "2011-03"
 5015	normal natto pocky	3	good	Last Available: "2011-03"
 5016	drinkable distilled wasabi-infused sake	5	good	Last Available: "2011-03"
@@ -4921,12 +4921,12 @@
 5018	watered-down drinkable blurry natto-infused sake	2	good	Last Available: "2011-03"
 5019	dry tarnished wobbly wasabi marble soda	0		Effect: "Sweetened and Fattened", Effect Duration: 12, Last Available: "2011-03"
 5020	triple-pressed flattened tobiko marble soda	0		Effect: "Ginger Snapped", Effect Duration: 50, Last Available: "2011-03"
-5021	non-ionized ghostly gray natto marble soda	0		Effect: "Blubbered Up", Effect Duration: 25, Last Available: "2011-03"
+5021	non-ionized gray ghostly natto marble soda	0		Effect: "Blubbered Up", Effect Duration: 25, Last Available: "2011-03"
 5022	blurry Alice's Army booster box	0		Last Available: "2011-03"
 5023	enhanced activated pulsating elderly jawbreaker	0		Effect: "Nut-Rition", Effect Duration: 19, Last Available: "2020-09"
 5024	tolerable shaking marshmallow flamb&eacute;	4	good	Last Available: "2011-03"
 5025	hand-crafted cranberry schnapps	3	EPIC	Last Available: "2011-03"
-5026	special perfectly mixed boozy breaded beer	5	EPIC	Effect: "Mushroom Magicalness", Effect Duration: 20, Last Available: "2011-03"
+5026	boozy perfectly mixed special breaded beer	5	EPIC	Effect: "Mushroom Magicalness", Effect Duration: 20, Last Available: "2011-03"
 5027	watered-down aged soy cordial	2	awesome	Last Available: "2011-03"
 5028	yellow blurry aromatic weightlifter's astral bludgeon	0		Muscle: +15, Stench Resistance: +1, Item Drop: +5
 5029	sinister astral shield of horror	0		Spell Damage: +10, Spooky Spell Damage: +25, Damage Reduction: 15
@@ -4943,15 +4943,15 @@
 5040	olive astral pet sweater	0		Familiar Weight: +10
 5041	narrow frosty Temple Grandin's dance instructor's astral shirt	0		Experience Percent (Moxie): +10, Familiar Weight: +7, Cold Spell Damage: +10
 5042	strapping astral belt of Leguizamo	0		Muscle: +5, Monster Level: +20
-5043	bite-sized adequate astral hot dog	1		
+5043	adequate bite-sized astral hot dog	1		
 5044	lousy astral pilsner	4		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
-5048	blurry blurry skewed shard of double-ice	0		Last Available: "2011-04"
-5049	avaricious deadly brawny double-ice cap	0		Muscle Percent: +20, Weapon Damage: +5, Meat Drop: +30, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5048	blurry skewed blurry shard of double-ice	0		Last Available: "2011-04"
+5049	avaricious deadly brawny double-ice cap	0		Muscle Percent: +20, Weapon Damage: +5, Meat Drop: +30, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	pulsating prompt Temple Grandin's double-ice box of the glutton	0		Familiar Weight: +7, Food Drop: +100, Adventures: +3, Last Available: "2011-04"
-5051	Socratic groovy double-ice britches of the early riser	0		Moxie Percent: +10, Experience (Mysticality): +1, Adventures: +7, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	Socratic groovy double-ice britches of the early riser	0		Moxie Percent: +10, Experience (Mysticality): +1, Adventures: +7, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	twirling handful of numbers	0		Last Available: "2020-09"
 5053	blue wobbly Lars the Cyberian	0		Last Available: "2011-04"
 5054	tumbling intriguing puzzle box	0		Last Available: "2011-04"
@@ -4965,26 +4965,26 @@
 5062	gray voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	normal gigantic spaghetti con calaveras	10	good	Last Available: "2011-04"
+5065	gigantic normal spaghetti con calaveras	10	good	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	flavorless immense popcorn	7	decent	Last Available: "2011-04"
-5068	gigantic normal chaos popcorn	7	good	Last Available: "2011-04"
+5067	immense flavorless popcorn	7	decent	Last Available: "2011-04"
+5068	normal gigantic chaos popcorn	7	good	Last Available: "2011-04"
 5069	scandalous toasty Jack Frost's hole	0		Cold Spell Damage: +50, Hot Damage: +5, Sleaze Damage: +5, Last Available: "2011-04"
 5070	blinking innuendo	0		Last Available: "2011-04"
 5071	rotten blurry s'more	0	crappy	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	drinkable triple-distilled Russian Ice	10	good	Last Available: "2011-04"
+5073	triple-distilled drinkable Russian Ice	10	good	Last Available: "2011-04"
 5074	savvy clay ashtray	0		Mysticality Percent: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	tumbling Jack Frost's lanyard	0		Cold Spell Damage: +50, Single Equip, Last Available: "2011-05"
-5076	friendly monster pants	0		Familiar Weight: +3, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	friendly monster pants	0		Familiar Weight: +3, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	super-frozen Pok&euml;mann band-aid	0		Effect: "Sweet, Nuts", Effect Duration: 56, Last Available: "2011-05"
-5079	strapping Van der Graaf helmet of the sewer	0		Muscle: +5, Stench Damage: +25, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	strapping Van der Graaf helmet of the sewer	0		Muscle: +5, Stench Damage: +25, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	gravedigger's crutch	0		Spooky Damage: +10, Last Available: "2011-05"
 5081	ribald shock belt	0		Sleaze Damage: +10, Single Equip, Last Available: "2011-05"
 5082	aerosolized wet Okee-Dokee soda	0		Effect: "Alchemical, Brother", Effect Duration: 18, Last Available: "2011-05"
 5083	sage rubber band gun	0		Mysticality Percent: +10, Last Available: "2011-05"
-5084	blinking scorching pin-stripe slacks	0		Hot Damage: +25, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	blinking scorching pin-stripe slacks	0		Hot Damage: +25, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	lard-coated gloves	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2011-05"
 5086	boiled deionized correction fluid	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 14, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	aged skewed Jeppson's Malort	3	awesome	Last Available: "2011-06"
 5108	twirling maroon fistful of ashes	0		
-5109	gravedigger's stress ball	0		Spooky Damage: +10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	gravedigger's stress ball	0		Spooky Damage: +10, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	purple hardy Ultracolor&trade; shirt	0		Maximum HP: +50, Last Available: "2011-05"
 5112	blurry My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	wobbly bird brain	0		
 5119	olive busted wings	0		
 5120	green Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	family-friendly flame-wreathed extremely unsafe Admiral's hat	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2011-05"
-5122	smelly scorching energetic aviator's cap	0		Maximum MP Percent: +20, Hot Damage: +25, Stench Spell Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	family-friendly flame-wreathed extremely unsafe Admiral's hat	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Sleaze Resistance: +1, Last Available: "2011-05", Familiar Effect: "atk"
+5122	smelly scorching energetic aviator's cap	0		Maximum MP Percent: +20, Hot Damage: +25, Stench Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	narrow zippy mirrored aviator shades of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +20, Single Equip, Last Available: "2011-05"
 5124	red Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	narrow Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5040,19 +5040,19 @@
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	jittery E.M.U. harness	0		Last Available: "2011-06"
 5139	fuchsia carton of astral energy drinks	0		
-5140	compressed lime green bouncing astral energy drink	1		
+5140	compressed bouncing lime green astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	huge moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	moist pickled honeypot	0		Effect: "Nigh-Invincible", Effect Duration: 48
 5146	normal lime green wild honey pie	3	good	
-5147	enchanted fortified smooth huge purple honey mead	5	awesome	Effect: "Don't Step to Your Stepmother", Effect Duration: 10
+5147	fortified smooth enchanted purple huge honey mead	5	awesome	Effect: "Don't Step to Your Stepmother", Effect Duration: 10
 5148	veiny quilted arcane researcher's honey dipper	0		Experience Percent (Mysticality): +10, Damage Absorption: +40, Maximum HP: +10
 5149	squat upside-down stanky Samson's honeybritches of the sweet-tooth	0		Experience (Muscle): +5, Stench Spell Damage: +25, Candy Drop: +100, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	smelly medical-grade rock-hard honeycap	0		Damage Reduction: 5, Stench Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, cap 43"
-5151	beefcake's Moonthril Circlet	0		Muscle: +25, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	wholesome Moonthril Greaves	0		Maximum HP Percent: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	beefcake's Moonthril Circlet	0		Muscle: +25, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	wholesome Moonthril Greaves	0		Maximum HP Percent: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	experienced Moonthril Flamberge	0		Experience: +2, Last Available: "2011-06"
 5154	friendly Moonthril Longbow	0		Familiar Weight: +3, Last Available: "2011-06"
 5155	mirror frightening Moonthril Cuirass	0		Spooky Damage: +5, Softcore Only, Last Available: "2011-06"
@@ -5076,7 +5076,7 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	lousy Saison du Lune	4	decent	Last Available: "2011-06"
 5175	hand-crafted Moonthril Schnapps	3	EPIC	Last Available: "2011-06"
-5176	practically non-alcoholic perfectly mixed jittery Wrecked Generator	1	super ultra mega turbo EPIC	Last Available: "2011-06"
+5176	perfectly mixed practically non-alcoholic jittery Wrecked Generator	1	super ultra mega turbo EPIC	Last Available: "2011-06"
 5177	rotten wobbly Spaghetti with Moonballs	3	crappy	Last Available: "2011-06"
 5178	decent green Crepes a la Lune	3	good	Last Available: "2011-06"
 5179	rotten Moon Pie	3	crappy	Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	blinking Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	polymerized aerosolized honey stick	0		Effect: "Electrolit Up", Effect Duration: 64
 5189	pickled double-ice gum	0		Effect: "Mint-Condition Breath", Effect Duration: 59, Last Available: "2011-04"
-5190	pulsating inspector's double-paned brawny Operation Patriot Shield	0		Muscle Percent: +20, Cold Resistance: +5, Item Drop: +15, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	pulsating inspector's double-paned brawny Operation Patriot Shield	0		Muscle Percent: +20, Cold Resistance: +5, Item Drop: +15, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	blurry squirming egg sac	0		Last Available: "2011-06"
 5192	aerosolized alkaline corrupted data	0		Effect: "Improprie Tea", Effect Duration: 53, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5100,7 +5100,7 @@
 5197	Newton's Marvelous Unitard	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2011-07"
 5198	dehydrated tumbling gooey paste	1	decent	Effect: "Updated", Effect Duration: 15, Last Available: "2011-08"
 5199	altered beastly paste	1	crappy	Last Available: "2011-08"
-5200	denatured skewed pulsating cyan paste	1	EPIC	Last Available: "2011-08"
+5200	denatured cyan pulsating skewed paste	1	EPIC	Last Available: "2011-08"
 5201	mixed ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	altered blue mirror greasy paste	1	awesome	Effect: "Stinkybeard", Effect Duration: 35, Last Available: "2011-08"
 5203	mixed bug paste	1	crappy	Effect: "Sleazy Jellied", Effect Duration: 40, Last Available: "2011-08"
@@ -5111,7 +5111,7 @@
 5208	boiled narrow purple paste	1	good	Last Available: "2011-08"
 5209	vaporized wobbly goblin paste	1	awesome	Last Available: "2011-08"
 5210	altered upside-down pirate paste	1	good	Last Available: "2011-08"
-5211	powdered mirror green chlorophyll paste	1	EPIC	Last Available: "2011-08"
+5211	powdered green mirror chlorophyll paste	1	EPIC	Last Available: "2011-08"
 5212	pickled lime green paste	1	awesome	Effect: "Ripping, Dripping", Effect Duration: 10, Last Available: "2011-08"
 5213	altered spinning teal Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	distilled olive upside-down slimy paste	1	decent	Last Available: "2011-08"
@@ -5127,7 +5127,7 @@
 5224	adequate Ur-Donut	4	good	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	practically non-alcoholic artisanal enchanted upside-down bucket of wine	1	super ultra mega turbo EPIC	Effect: "Ruby-ous", Effect Duration: 25, Last Available: "2011-09"
+5227	enchanted artisanal practically non-alcoholic upside-down bucket of wine	1	super ultra mega turbo EPIC	Effect: "Ruby-ous", Effect Duration: 25, Last Available: "2011-09"
 5228	moldy ultrafondue	4	crappy	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	furry halo of the early riser	0		Adventures: +7, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	frightening frosty halo	0		Spooky Damage: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of Calamity Jane	0		Critical Hit Percent: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	tolerable triple-distilled Lumineux Limnio	6	good	Last Available: "2011-09"
+5238	triple-distilled tolerable Lumineux Limnio	6	good	Last Available: "2011-09"
 5239	lousy blue Morto Moreto	3	decent	Last Available: "2011-09"
-5240	bad mirror purple Temps Tempranillo	4	decent	Last Available: "2011-09"
-5241	high-proof acceptable Bordeaux Marteaux	10	good	Last Available: "2011-09"
+5240	bad purple mirror Temps Tempranillo	4	decent	Last Available: "2011-09"
+5241	acceptable high-proof Bordeaux Marteaux	10	good	Last Available: "2011-09"
 5242	smooth practically non-alcoholic gray Fromage Pinotage	1	awesome	Last Available: "2011-09"
-5243	practically non-alcoholic bad Beignet Milgranet	1	decent	Last Available: "2011-09"
+5243	bad practically non-alcoholic Beignet Milgranet	1	decent	Last Available: "2011-09"
 5244	acceptable Muschat	4	good	Last Available: "2011-09"
 5245	decent jumbo cool jelly donut	5	good	Last Available: "2011-09"
 5246	delicious shrapnel jelly donut	3	awesome	Last Available: "2011-09"
-5247	bite-sized tasty squat occult jelly donut	1	awesome	Last Available: "2011-09"
+5247	tasty bite-sized squat occult jelly donut	1	awesome	Last Available: "2011-09"
 5248	snack-sized enchanted stale thyme jelly donut	2	decent	Last Available: "2011-09"
-5249	huge toothsome wobbly danish	6	awesome	Last Available: "2011-09"
-5250	adequate big smashed danish	5	good	Last Available: "2011-09"
+5249	toothsome huge wobbly danish	6	awesome	Last Available: "2011-09"
+5250	big adequate smashed danish	5	good	Last Available: "2011-09"
 5251	moldy diet forbidden danish	1	crappy	Last Available: "2011-09"
 5252	miniature adequate upside-down cool cat claw	2	good	Last Available: "2011-09"
 5253	rotten squat blunt cat claw	4	crappy	Last Available: "2011-09"
 5254	flavorless shadowy cat claw	3	decent	Last Available: "2011-09"
 5255	normal cheezburger	4	good	Last Available: "2011-09"
-5256	rotten thick olive shaking toasted brie	5	crappy	Last Available: "2011-09"
+5256	thick rotten olive shaking toasted brie	5	crappy	Last Available: "2011-09"
 5257	magnetized moist quantum skewed wobbly potion of the field gar	0		Effect: "Corona de la Salsa", Effect Duration: 21, Last Available: "2011-09"
 5258	pickled wobbly too legit potion	0		Effect: "Raging Animal", Effect Duration: 56, Last Available: "2011-09"
 5259	cold-filtered chilled non-ionized ghostly Bright Water	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 64, Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	squat dungeon dragon chest	0		Last Available: "2011-09"
 5298	small moldy phish stick	2	crappy	Last Available: "2011-09"
-5299	wool plastic vampire fangs of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5, Cold Resistance: +1, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	wool plastic vampire fangs of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5, Cold Resistance: +1, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5219,27 +5219,27 @@
 5316	boiled extra-anodized press-on ribs	0		Effect: "Fizzier Than Light", Effect Duration: 41, Last Available: "2011-10"
 5317	super-oxidized electrified gray Rattlin' Chains	0		Effect: "Carol of the Bones", Effect Duration: 51, Last Available: "2011-10"
 5318	activated Gummy Brains	0		Effect: "Deeply Ironic", Effect Duration: 28, Last Available: "2011-10"
-5319	vacuum-sealed colloidal tarnished squat pulsating narrow gray Blood 'n' Plenty	0		Effect: "Hennaliciousness", Effect Duration: 48, Last Available: "2011-10"
+5319	vacuum-sealed colloidal tarnished narrow pulsating gray squat Blood 'n' Plenty	0		Effect: "Hennaliciousness", Effect Duration: 48, Last Available: "2011-10"
 5320	chilled unsweetened mirror Lobos Mints	0		Effect: "Holiday Bliss", Effect Duration: 40, Last Available: "2011-10"
 5321	quantum Sweet Sword	0		Effect: "Black Lung", Effect Duration: 32, Last Available: "2011-10"
 5322	lousy Ecto-Cooler	3	decent	Last Available: "2011-10"
 5323	bad Bartles and BRAAAINS wine cooler	3	decent	Last Available: "2011-10"
-5324	high-proof hand-crafted spinning gray Blood Light	7	EPIC	Last Available: "2011-10"
+5324	hand-crafted high-proof spinning gray Blood Light	7	EPIC	Last Available: "2011-10"
 5325	bad Silver Bullet beer	4	decent	Last Available: "2011-10"
 5326	lousy Bone's Farm &quot;wine&quot;	4	decent	Last Available: "2011-10"
 5327	narrow ghost protocol	0		Last Available: "2011-10"
 5328	denatured enhanced sorority brain	0		Effect: "Superioreo", Effect Duration: 34, Last Available: "2011-10"
-5329	liquefied anodized mirror wobbly Nightstalker perfume	0		Effect: "Blackberry Politeness", Effect Duration: 30, Last Available: "2011-10"
+5329	liquefied anodized wobbly mirror Nightstalker perfume	0		Effect: "Blackberry Politeness", Effect Duration: 30, Last Available: "2011-10"
 5330	irradiated cold-filtered shaking drum of pomade	0		Effect: "20/20 Vision", Effect Duration: 28, Last Available: "2011-10"
 5331	narrow throwing bone	0		Last Available: "2011-10"
 5332	green gravedigger's extra-see-thru nightie	0		Spooky Damage: +10, Last Available: "2011-10"
-5333	blinking horrifying Temple Grandin's BRAINS shorts	0		Familiar Weight: +7, Spooky Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	blinking horrifying Temple Grandin's BRAINS shorts	0		Familiar Weight: +7, Spooky Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	supercool Mesmereyes&trade; contact lenses	0		Moxie Percent: +20, Single Equip, Last Available: "2011-10"
 5335	baleful scrunchie	0		Spell Damage: +25, Single Equip, Last Available: "2011-10"
-5336	shellacked wizardly extremely skinny jeans	0		Mysticality: +25, Damage Reduction: 7, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	blue padded personal trainer's The Necbromancer's Hat	0		Experience Percent (Muscle): +10, Damage Absorption: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	shellacked wizardly extremely skinny jeans	0		Mysticality: +25, Damage Reduction: 7, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	blue padded personal trainer's The Necbromancer's Hat	0		Experience Percent (Muscle): +10, Damage Absorption: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	aromatic thinker's The Necbromancer's Stein of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Stench Resistance: +1, Last Available: "2011-10"
-5339	Usain Bolt's ribald razor-sharp The Necbromancer's Shorts	0		Weapon Damage Percent: +25, Sleaze Damage: +10, Initiative: +80, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	Usain Bolt's ribald razor-sharp The Necbromancer's Shorts	0		Weapon Damage Percent: +25, Sleaze Damage: +10, Initiative: +80, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	aromatic energetic The Necbromancer's Wizard Staff of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Stench Resistance: +1, Last Available: "2011-10"
 5341	fuchsia The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	fortified lousy The Cooler Out of Space	5	decent	Last Available: "2011-10"
@@ -5253,14 +5253,14 @@
 5350	shaking A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	mirror A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	skewed blinking A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-5353	blinking purple jar of oil	0		
+5353	purple blinking jar of oil	0		
 5354	yellow The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	upside-down Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	olive A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-5360	blurry twirling Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
+5360	twirling blurry Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	wobbly bouncing CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
@@ -5289,15 +5289,15 @@
 5386	ridiculous belt of the pedagogue	0		Experience: +3, Last Available: "2011-11"
 5387	twirling ruddy ridiculous earring	0		Maximum HP Percent: +40, Last Available: "2011-11"
 5388	yellow ridiculous sunglasses of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-11"
-5389	spoiled low-calorie ridiculous sandwich	1	crappy	Last Available: "2011-11"
+5389	low-calorie spoiled ridiculous sandwich	1	crappy	Last Available: "2011-11"
 5390	practically non-alcoholic artisanal ridiculous cocktail	1	super ultra mega turbo EPIC	Last Available: "2011-11"
 5391	yellow tumbling inspector's lard-coated zombie monkey necklace	0		Sleaze Spell Damage: +25, Item Drop: +15
 5392	twirling Thwaitgold butterfly statuette	0		
-5393	lime green jittery scrap of paper	0		
+5393	jittery lime green scrap of paper	0		
 5394	upside-down sandpaper	0		
 5395	wobbly peppermint sprout	0		Last Available: "2011-11"
-5396	enhanced cyan upside-down peppermint twist	0		Effect: "Cold as Ice", Effect Duration: 42, Last Available: "2011-11"
-5397	decent gigantic special maroon peppermint patty	7	good	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2011-11"
+5396	enhanced upside-down cyan peppermint twist	0		Effect: "Cold as Ice", Effect Duration: 42, Last Available: "2011-11"
+5397	gigantic special decent maroon peppermint patty	7	good	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2011-11"
 5398	maroon peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5306,12 +5306,12 @@
 5403	spinning Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	purple Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	brawny beefy cane-mail shirt of the overflowing toilet	0		Muscle: +10, Muscle Percent: +20, Stench Spell Damage: +50, Last Available: "2011-12"
-5406	ghostly aromatic personal trainer's cane-mail pants of dire peril	0		Experience Percent (Muscle): +10, Weapon Damage: +20, Stench Resistance: +1, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	ghostly aromatic personal trainer's cane-mail pants of dire peril	0		Experience Percent (Muscle): +10, Weapon Damage: +20, Stench Resistance: +1, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	hand-crafted Vodka Matryoshka	3	EPIC	Last Available: "2011-12"
 5408	hand-crafted weak Gin Mint	2	EPIC	Last Available: "2011-12"
-5409	enchanted acceptable watered-down Tequiz Navidad	2	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2011-12"
+5409	watered-down enchanted acceptable Tequiz Navidad	2	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2011-12"
 5410	tolerable Mint Yulep	3	good	Last Available: "2011-12"
-5411	watered-down tolerable spinning skewed Crimbojito	2	good	Last Available: "2011-12"
+5411	tolerable watered-down skewed spinning Crimbojito	2	good	Last Available: "2011-12"
 5412	watered-down bad Sangria de Menthe	2	decent	Last Available: "2011-12"
 5413	skewed candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	thinker's kumquartz ring	0		Mysticality: +10, Single Equip, Last Available: "2011-11"
 5425	lion tamer's strawberyl necklace	0		Experience (familiar): +2, Single Equip, Last Available: "2011-11"
 5426	sucker bucket of the dark arts of the detective	0		Spell Damage Percent: +100, Item Drop: +20, Last Available: "2011-11"
-5427	wizardly sucker hakama	0		Mysticality: +25, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	grievous sucker kabuto	0		Weapon Damage Percent: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	wizardly sucker hakama	0		Mysticality: +25, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	grievous sucker kabuto	0		Weapon Damage Percent: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	sucker tachi of Leguizamo	0		Monster Level: +20, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	skewed cinnamon troll doll	0		Last Available: "2011-11"
@@ -5342,7 +5342,7 @@
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	stale blurry fudgesicle	4	decent	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
-5442	olive shaking mirror The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
+5442	olive mirror shaking The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	bouncing miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	flattened jittery devilish folio	0		Effect: "Penguinny Flavor", Effect Duration: 37, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
@@ -5352,11 +5352,11 @@
 5449	vanity stone	0		Last Available: "2012-12"
 5450	lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
-5452	spinning blinking avarice stone	0		Last Available: "2012-12"
+5452	blinking spinning avarice stone	0		Last Available: "2012-12"
 5453	skewed gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
-5456	upside-down shaking yellow gummi ingot	0		Last Available: "2011-11"
+5456	upside-down yellow shaking gummi ingot	0		Last Available: "2011-11"
 5457	flattened blurry Fudgie Roll	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 51, Last Available: "2011-11"
 5458	yummy bouncing fudge bunny	4	awesome	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
@@ -5368,10 +5368,10 @@
 5465	polarized polarized narrow resolution: be happier	0		Effect: "Virgo Rising", Effect Duration: 64, Last Available: "2012-01"
 5466	adjusted narrow resolution: be stronger	0		Effect: "Reedy Pipes", Effect Duration: 33, Last Available: "2012-01"
 5467	anodized skewed resolution: be smarter	0		Effect: "Stench Jellied", Effect Duration: 62, Last Available: "2012-01"
-5468	improved energized blinking tumbling resolution: be sexier	0		Effect: "Empathy", Effect Duration: 19, Last Available: "2012-01"
+5468	improved energized tumbling blinking resolution: be sexier	0		Effect: "Empathy", Effect Duration: 19, Last Available: "2012-01"
 5469	double-ionized tarnished moist resolution: be feistier	0		Effect: "On a Roll", Effect Duration: 65, Last Available: "2012-01"
 5470	quadruple-vacuum-sealed enhanced bouncing resolution: be kinder	0		Effect: "Well-Swabbed Ear", Effect Duration: 59, Last Available: "2012-01"
-5471	cold-filtered activated squat yellow resolution: be more adventurous	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 48, Last Available: "2012-01"
+5471	cold-filtered activated yellow squat resolution: be more adventurous	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 48, Last Available: "2012-01"
 5472	altered enhanced pulsating resolution: be luckier	0		Effect: "Tiki Toughness", Effect Duration: 39, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
@@ -5379,11 +5379,11 @@
 5476	improved denatured olive gummi salamander	0		Effect: "Hiding in Plain Sight", Effect Duration: 36, Last Available: "2011-11"
 5477	aerosolized pressed electrified shaking gummi snake	0		Effect: "Holiday Disappointment", Effect Duration: 31, Last Available: "2011-11"
 5478	concentrated oxidized bouncing gummi canary	0		Effect: "I See Everything Thrice!", Effect Duration: 26, Last Available: "2011-11"
-5479	toothsome enchanted diet gummi bear	1	awesome	Effect: "White-boy Angst", Effect Duration: 30, Last Available: "2011-11"
+5479	toothsome diet enchanted gummi bear	1	awesome	Effect: "White-boy Angst", Effect Duration: 30, Last Available: "2011-11"
 5480	stale gummi bear	4	decent	Last Available: "2011-11"
 5481	adequate tumbling gummi bear	3	good	Last Available: "2011-11"
-5482	yummy upside-down cyan drunki-bear	3	awesome	Last Available: "2011-11"
-5483	yummy miniature mirror drunki-bear	2	awesome	Last Available: "2011-11"
+5482	yummy cyan upside-down drunki-bear	3	awesome	Last Available: "2011-11"
+5483	miniature yummy mirror drunki-bear	2	awesome	Last Available: "2011-11"
 5484	adequate green drunki-bear	3	good	Last Available: "2011-11"
 5485	wizardly gummi bowtie	0		Mysticality: +25, Last Available: "2011-11"
 5486	wholesome fudge pocket square	0		Maximum HP Percent: +10, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	magnetized extra-colloidal gummi belemnite	0		Effect: "Quaaaaaaa", Effect Duration: 50, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	therapeutic Big Candy's tophat of the ox	0		Muscle: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	therapeutic Big Candy's tophat of the ox	0		Muscle: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	spinning Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	yellow blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	bland jerky coins	3	decent	Last Available: "2011-11"
-5507	lousy weak enchanted squat Go-Wassail	2	decent	Effect: "Gleaming White Teeth", Effect Duration: 35, Last Available: "2011-11"
+5507	enchanted weak lousy squat Go-Wassail	2	decent	Effect: "Gleaming White Teeth", Effect Duration: 35, Last Available: "2011-11"
 5508	triple-denatured pickled red Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Drunk With Power", Effect Duration: 53, Last Available: "2011-11"
 5509	frozen bottle of bubbles	0		Effect: "Dreadful Fear", Effect Duration: 21, Last Available: "2011-11"
 5510	dry blinking wind-up meatcar	0		Effect: "Stimulated Body", Effect Duration: 42, Last Available: "2011-11"
@@ -5445,7 +5445,7 @@
 5542	pulsating pink-belly slapper	0		Last Available: "2012-12"
 5543	skewed censurious hale Leapin' Trousers	0		Maximum HP: +20, Sleaze Resistance: +3
 5544	bad eggnog	3	decent	Last Available: "2012-12"
-5545	half-sized rotten yellow skewed hamhock	2	crappy	Last Available: "2012-12"
+5545	rotten half-sized skewed yellow hamhock	2	crappy	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5459,54 +5459,54 @@
 5556	gray Rain-Doh wings of the brazier of the early riser	0		Hot Spell Damage: +25, Adventures: +7, Softcore Only, Last Available: "2012-02"
 5557	shaking Rain-Doh agent	0		Last Available: "2012-02"
 5558	Rosewater's Rain-Doh laser gun of Leguizamo	0		Mysticality Percent: +30, Monster Level: +20, Softcore Only, Last Available: "2012-02"
-5559	Rain-Doh lantern of extreme caution	0		Monster Level: -25, Item Drop: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	Rain-Doh lantern of extreme caution	0		Monster Level: -25, Item Drop: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	tumbling Rain-Doh balls	0		Last Available: "2012-02"
 5561	twirling Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	nippy medical-grade Rain-Doh violet bo	0		Cold Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	stale PB&BP	3	decent	
-5566	decent bite-sized club sandwich	1	good	
-5567	decent spinning cyan corned-beef Reuben	3	good	
+5566	bite-sized decent club sandwich	1	good	
+5567	decent cyan spinning corned-beef Reuben	3	good	
 5568	frayed ninja rope	0		
 5569	squat dull ninja crampons	0		
 5570	ghostly loose ninja carabiner	0		
 5571	pulsating Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	artisanal Drac & Tan	4	EPIC	Last Available: "2012-03"
-5574	watered-down hand-crafted Transylvania Sling	2	EPIC	Last Available: "2012-03"
+5574	hand-crafted watered-down Transylvania Sling	2	EPIC	Last Available: "2012-03"
 5575	aged Shot of the Living Dead	4	awesome	Last Available: "2012-03"
 5576	mediocre twirling Buttery Knob	3	decent	Last Available: "2012-03"
 5577	acceptable mirror Slippery Knob	3	good	Last Available: "2012-03"
 5578	acceptable watered-down Flaming Knob	2	good	Last Available: "2012-03"
-5579	drinkable practically non-alcoholic Grasshopper	1	good	Last Available: "2012-03"
+5579	practically non-alcoholic drinkable Grasshopper	1	good	Last Available: "2012-03"
 5580	lousy bouncing Locust	3	decent	Last Available: "2012-03"
 5581	hand-crafted Plague of Locusts	3	EPIC	Last Available: "2012-03"
 5582	weak drinkable huge Red Dwarf	2	good	Last Available: "2012-03"
 5583	bad Golden Mean	3	decent	Last Available: "2012-03"
 5584	acceptable Green Giant	3	good	Last Available: "2012-03"
 5585	weak artisanal pulsating Aye Aye	2	EPIC	Last Available: "2012-03"
-5586	practically non-alcoholic tolerable enchanted ghostly Aye Aye, Captain	1	good	Effect: "Rushtacean'", Effect Duration: 40, Last Available: "2012-03"
+5586	enchanted practically non-alcoholic tolerable ghostly Aye Aye, Captain	1	good	Effect: "Rushtacean'", Effect Duration: 40, Last Available: "2012-03"
 5587	tolerable practically non-alcoholic Aye Aye, Tooth Tooth	1	good	Last Available: "2012-03"
-5588	hand-crafted watered-down enchanted Humanitini	2	EPIC	Effect: "All Is Forgiven", Effect Duration: 20, Last Available: "2012-03"
+5588	enchanted watered-down hand-crafted Humanitini	2	EPIC	Effect: "All Is Forgiven", Effect Duration: 20, Last Available: "2012-03"
 5589	hand-crafted More Humanitini than Humanitini	4	EPIC	Last Available: "2012-03"
-5590	weak aged tumbling Oh, the Humanitini	2	awesome	Last Available: "2012-03"
-5591	weak tolerable enchanted Great Older Fashioned	2	good	Effect: "Granolarrrgh", Effect Duration: 30, Last Available: "2012-03"
+5590	aged weak tumbling Oh, the Humanitini	2	awesome	Last Available: "2012-03"
+5591	tolerable enchanted weak Great Older Fashioned	2	good	Effect: "Granolarrrgh", Effect Duration: 30, Last Available: "2012-03"
 5592	fortified artisanal Fuzzy Tentacle	5	EPIC	Last Available: "2012-03"
-5593	acceptable practically non-alcoholic mirror Crazymaker	1	good	Last Available: "2012-03"
+5593	practically non-alcoholic acceptable mirror Crazymaker	1	good	Last Available: "2012-03"
 5594	lousy fancy blinking Zoodriver	3	decent	Effect: "Twenty-three Squid, Ew", Effect Duration: 20, Last Available: "2012-03"
 5595	spirit-forward special delicious Sloe Comfortable Zoo	5	awesome	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2012-03"
-5596	mediocre weak enchanted teal Sloe Comfortable Zoo on Fire	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2012-03"
-5597	lousy enchanted pulsating narrow Suffering Sinner	3	decent	Effect: "Just the Brown Ones", Effect Duration: 40, Last Available: "2012-03"
+5596	weak enchanted mediocre teal Sloe Comfortable Zoo on Fire	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2012-03"
+5597	enchanted lousy narrow pulsating Suffering Sinner	3	decent	Effect: "Just the Brown Ones", Effect Duration: 40, Last Available: "2012-03"
 5598	extra-dry lousy narrow Suppurating Sinner	5	decent	Last Available: "2012-03"
 5599	bad tumbling Sizzling Sinner	3	decent	Last Available: "2012-03"
 5600	acceptable Firewater	4	good	Last Available: "2012-03"
 5601	hand-crafted Earth and Firewater	4	EPIC	Last Available: "2012-03"
-5602	practically non-alcoholic tolerable Earth, Wind and Firewater	1	good	Last Available: "2012-03"
+5602	tolerable practically non-alcoholic Earth, Wind and Firewater	1	good	Last Available: "2012-03"
 5603	bad Slimosa	3	decent	Last Available: "2012-03"
 5604	lousy triple-distilled Extra-slimy Slimosa	6	decent	Last Available: "2012-03"
 5605	lousy blue Slimebite	3	decent	Last Available: "2012-03"
-5606	spirit-forward hand-crafted Cement Mixer	5	EPIC	Last Available: "2012-03"
+5606	hand-crafted spirit-forward Cement Mixer	5	EPIC	Last Available: "2012-03"
 5607	hand-crafted weak fuchsia Jackhammer	2	EPIC	Last Available: "2012-03"
 5608	practically non-alcoholic mediocre Dump Truck	1	decent	Last Available: "2012-03"
 5609	artisanal fancy ghostly Fauna Libre	4	EPIC	Effect: "Omphalotus Omnipresence", Effect Duration: 20, Last Available: "2012-03"
@@ -5519,14 +5519,14 @@
 5616	hand-crafted Green Muslin	4	EPIC	Last Available: "2012-03"
 5617	aged practically non-alcoholic Green Burlap	1	awesome	Last Available: "2012-03"
 5618	hand-crafted Mohobo	3	EPIC	Last Available: "2012-03"
-5619	practically non-alcoholic tolerable fuchsia mirror blinking Moonshine Mohobo	1	good	Last Available: "2012-03"
+5619	practically non-alcoholic tolerable mirror blinking fuchsia Moonshine Mohobo	1	good	Last Available: "2012-03"
 5620	drinkable blinking Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	tolerable Drunken Philosopher	3	good	Last Available: "2012-03"
-5622	artisanal watered-down Drunken Neurologist	2	EPIC	Last Available: "2012-03"
+5622	watered-down artisanal Drunken Neurologist	2	EPIC	Last Available: "2012-03"
 5623	weak lousy Drunken Astrophysicist	2	decent	Last Available: "2012-03"
 5624	perfectly mixed Dark & Starry	4	EPIC	Last Available: "2012-03"
-5625	acceptable special irresponsibly strong Black Hole	6	good	Effect: "Feet of Watermelon", Effect Duration: 50, Last Available: "2012-03"
-5626	weak hand-crafted Event Horizon	2	EPIC	Last Available: "2012-03"
+5625	special acceptable irresponsibly strong Black Hole	6	good	Effect: "Feet of Watermelon", Effect Duration: 50, Last Available: "2012-03"
+5626	hand-crafted weak Event Horizon	2	EPIC	Last Available: "2012-03"
 5627	practically non-alcoholic mediocre Herring Daiquiri	1	decent	Last Available: "2012-03"
 5628	artisanal practically non-alcoholic Herring Wallbanger	1	EPIC	Last Available: "2012-03"
 5629	delicious Herringtini	3	awesome	Last Available: "2012-03"
@@ -5541,20 +5541,20 @@
 5638	aged Haymaker	4	awesome	Last Available: "2012-03"
 5639	narrow Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	snack-sized stale fungus	2	decent	
+5641	stale snack-sized fungus	2	decent	
 5642	poisoned dart	0		
 5643	polarized galvanized stone wool	0		Effect: "Walberg's Dim Bulb", Effect Duration: 47
 5644	jittery stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	cyan razor-sharp calendar	0		Weapon Damage Percent: +25, Damage Reduction: 4
-5648	teal censurious friendly Boris's Helm	0		Familiar Weight: +3, Sleaze Resistance: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	teal censurious friendly Boris's Helm	0		Familiar Weight: +3, Sleaze Resistance: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	green fireproof extremely unsafe staph of homophones	0		Weapon Damage Percent: +100, Hot Resistance: +3
-5650	foul-smelling Socratic Boris's Helm (askew) of dire peril	0		Experience (Mysticality): +1, Weapon Damage: +20, Stench Damage: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	foul-smelling Socratic Boris's Helm (askew) of dire peril	0		Experience (Mysticality): +1, Weapon Damage: +20, Stench Damage: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	massive stale nailswurst	8	decent	
+5654	stale massive nailswurst	8	decent	
 5655	hand-crafted weak used beer	2	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	green skewed fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5571,17 +5571,17 @@
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
 5670	rotten shaking fettucini &eacute;pines Inconnu	3	crappy	
-5671	special weak bad slap and slap again	2	decent	Effect: "Turtle Power", Effect Duration: 40
+5671	bad weak special slap and slap again	2	decent	Effect: "Turtle Power", Effect Duration: 40
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	mirror &quot;L&quot;	0		
 5675	diluted narrow watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	purple occult Ze&trade; goggles	0		Spell Damage Percent: +25, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	purple occult Ze&trade; goggles	0		Spell Damage Percent: +25, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	skewed nippy Rosewater's stylish swimsuit	0		Mysticality Percent: +30, Cold Damage: +10, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	skewed nippy Rosewater's stylish swimsuit	0		Mysticality Percent: +30, Cold Damage: +10, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
-5681	tasty special P.B.L.T.	3	awesome	Effect: "Pumped Stomach", Effect Duration: 40
+5681	special tasty P.B.L.T.	3	awesome	Effect: "Pumped Stomach", Effect Duration: 40
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	handful of juicy garbage	0		
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	twirling wax bugbear	0		Last Available: "2012-06"
-5705	reassuring lion tamer's wax hat	0		Experience (familiar): +2, Spooky Resistance: +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	maroon perfumed brawny wax pants	0		Muscle Percent: +20, Stench Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	reassuring lion tamer's wax hat	0		Experience (familiar): +2, Spooky Resistance: +1, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	maroon perfumed brawny wax pants	0		Muscle Percent: +20, Stench Resistance: +5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	pressed quadruple-polymerized squat drop of water-37	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 17, Last Available: "2012-07"
-5709	savvy fireman's helmet of Leguizamo	0		Mysticality Percent: +20, Monster Level: +20, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	savvy fireman's helmet of Leguizamo	0		Mysticality Percent: +20, Monster Level: +20, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	Sherlock's fire axe	0		Item Drop: +25, Last Available: "2012-07"
 5713	resourceful fire extinguisher of the sewer of the early riser	0		Maximum MP: +50, Stench Damage: +25, Adventures: +7, Last Available: "2012-07"
 5714	skewed FDKOL tattoo	0		
@@ -5617,32 +5617,32 @@
 5716	blinking Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	yummy cyan blinking FDKOL hotcakes	4	awesome	Last Available: "2012-07"
 5718	skewed hot egg	0		Last Available: "2012-07"
-5719	blinking mirror smoking grass	0		Last Available: "2012-07"
+5719	mirror blinking smoking grass	0		Last Available: "2012-07"
 5720	adequate fiery wing	4	good	Last Available: "2012-07"
 5721	fireproof scorching wings of fire	0		Hot Damage: +25, Hot Resistance: +3, Last Available: "2012-07"
 5722	resourceful FDKOL fire hose	0		Maximum MP: +50, Last Available: "2012-07"
 5723	electrified bottle of fire	0		Effect: "Whippin' It Good", Effect Duration: 57, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	fuchsia narrow hot daub	0		Last Available: "2012-07"
-5726	healthy hot daub bun of the brazier	0		Maximum HP Percent: +20, Hot Spell Damage: +25, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	jittery electrified hot daub stand of courage	0		Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	healthy hot daub bun of the brazier	0		Maximum HP Percent: +20, Hot Spell Damage: +25, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	jittery electrified hot daub stand of courage	0		Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	tumbling baleful Herculean foot-long hot daub	0		Experience (Muscle): +1, Spell Damage: +25, Last Available: "2012-07"
 5729	ghostly ballpark hot daub	0		Last Available: "2012-07"
 5730	rotten half-sized angst burger	2	crappy	
 5731	lousy watered-down squat blinking 5-hour acrimony	2	decent	
 5732	ghostly blank note	0		
 5733	wobbly eerily silent box	0		
-5734	snack-sized bland jittery forbidden sausage	2	decent	
-5735	narrow brainy Lord Flameface's cloak	0		Mysticality: +5, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5734	bland snack-sized jittery forbidden sausage	2	decent	
+5735	narrow brainy Lord Flameface's cloak	0		Mysticality: +5, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	corrupted diffused lime green Drizzlers&trade; Black Licorice	0		Effect: "Kindly Resolve", Effect Duration: 45
 5737	moist daub-breaker	0		Effect: "The Dinsey Spirit", Effect Duration: 18, Last Available: "2020-09"
 5738	Camp Scout backpack of the overflowing toilet	0		Stench Spell Damage: +50, Softcore Only, Last Available: "2012-07"
 5739	blurry olive CSA fire-starting kit	0		Last Available: "2012-07"
 5740	decent big bag of GORP	5	good	Last Available: "2012-07"
-5741	triple-distilled hand-crafted water purification pills	8	EPIC	Last Available: "2012-07"
+5741	hand-crafted triple-distilled water purification pills	8	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	artisanal bouncing CSA scoutmaster's &quot;water&quot;	4	EPIC	Last Available: "2012-07"
-5744	special delicious bag of GORF	3	awesome	Effect: "Turtle Titters", Effect Duration: 20, Last Available: "2012-07"
+5744	delicious special bag of GORF	3	awesome	Effect: "Turtle Titters", Effect Duration: 20, Last Available: "2012-07"
 5745	jittery CSA discount card	0		Last Available: "2020-09"
 5746	toothsome gigantic bag of QWOP	9	awesome	Last Available: "2012-07"
 5747	electrified bouncing CSA bravery badge	0		Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2012-07"
@@ -5650,10 +5650,10 @@
 5749	hand-crafted CSA cheerfulness ration	4	EPIC	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	yummy diet enchanted yellow crappy brain	1	awesome	Effect: "Highland Sheen", Effect Duration: 10
+5752	yummy enchanted diet yellow crappy brain	1	awesome	Effect: "Highland Sheen", Effect Duration: 10
 5753	bland decent brain	4	decent	
 5754	super-sized rotten fancy good brain	5	crappy	Effect: "Shredding, Sweating", Effect Duration: 20
-5755	rotten half-sized boss brain	2	crappy	
+5755	half-sized rotten boss brain	2	crappy	
 5756	bland hunter brain	3	decent	
 5758	perfumed forbidden strapping Staff of Holiday Sensations	0		Muscle: +5, Spell Damage Percent: +50, Stench Resistance: +5, Last Available: "2011-11"
 5759	hale thinker's staff	0		Mysticality: +10, Maximum HP: +20
@@ -5665,11 +5665,11 @@
 5765	fuchsia Fonzie's groovy fuzzy earmuffs	0		Moxie Percent: +10, Experience (Moxie): +1, Familiar Effect: "1.5xVolley, cap 32"
 5766	bouncing mirror greedy healthy supercool fuzzy montera	0		Moxie Percent: +20, Maximum HP Percent: +20, Meat Drop: +20, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	huge gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	mirror twirling gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	huge gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	mirror twirling gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	jittery fronts	0		Familiar Weight: +5
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bouncing bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	brainy right bear arm of the bloodbag	0		Mysticality: +5, Maximum HP: +100, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	dangerous brawny left bear arm of the cougar	0		Moxie: +20, Muscle Percent: +20, Weapon Damage: +10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	brainy right bear arm of the bloodbag	0		Mysticality: +5, Maximum HP: +100, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	dangerous brawny left bear arm of the cougar	0		Moxie: +20, Muscle Percent: +20, Weapon Damage: +10, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	narrow friendly Hat O' Nine Tails	0		Familiar Weight: +3
 5794	tarnished anodized Enchanted Plunger	0		Effect: "Musky", Effect Duration: 43
 5795	vacuum-sealed dry ghostly Enchanted Flyswatter	0		Effect: "Ginger Snapped", Effect Duration: 51
@@ -5752,7 +5752,7 @@
 5853	wet stick-on gnome beard	0		Effect: "Thicker, Sicker", Effect Duration: 12
 5854	moist pickled teal narrow BRICKO stud	0		Effect: "Always In Motion", Effect Duration: 36
 5855	non-dry Osk'r Chow	0		Effect: "Educated (Sorta)", Effect Duration: 49
-5856	tarnished boiled jittery spinning Scuba Snack	0		Effect: "The Dinsey Spirit", Effect Duration: 69
+5856	tarnished boiled spinning jittery Scuba Snack	0		Effect: "The Dinsey Spirit", Effect Duration: 69
 5857	non-pickled grey cube	0		Effect: "Concentration", Effect Duration: 13
 5858	pressed huge votive candle	0		Effect: "The Dinsey Way", Effect Duration: 17
 5859	triple-quantum boiled booby trap	0		Effect: "Crimbo Flavor", Effect Duration: 39
@@ -5767,8 +5767,8 @@
 5868	zippy Jack Frost's papier-m&acirc;ch&eacute;te	0		Cold Spell Damage: +50, Initiative: +20, Last Available: "2012-09"
 5869	extremely unsafe strapping papier-m&acirc;chine gun	0		Muscle: +5, Weapon Damage Percent: +100, Last Available: "2012-09"
 5870	ghostly sizzling papier-masque of the ox	0		Muscle: +20, Hot Damage: +10, Single Equip, Last Available: "2012-09"
-5871	fireproof papier-mitre of Flo-Jo	0		Hot Resistance: +3, Initiative: +100, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	papier-m&acirc;churidars of Tarzan of bravery	0		Experience (Muscle): +3, Spooky Resistance: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	fireproof papier-mitre of Flo-Jo	0		Hot Resistance: +3, Initiative: +100, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	papier-m&acirc;churidars of Tarzan of bravery	0		Experience (Muscle): +3, Spooky Resistance: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	huge papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	narrow papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	blinking medical-grade padded skeleton skis of the cougar	0		Moxie: +20, Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2012-10"
-5883	spoiled special spinning skeleton quiche	3	crappy	Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2012-10"
+5883	special spoiled spinning skeleton quiche	3	crappy	Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2012-10"
 5884	jittery skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	Sherlock's veiny Newton's Herculean Bonestabber	0		Experience (Muscle): +1, Experience (Mysticality): +3, Maximum HP: +10, Item Drop: +25, Last Available: "2012-10"
@@ -5788,7 +5788,7 @@
 5889	smooth auxiliary backbone	0		Moxie: +15, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	huge ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
-5892	super-quantum wet skewed huge that gum you like	0		Effect: "Adorable Lookout", Effect Duration: 44
+5892	super-quantum wet huge skewed that gum you like	0		Effect: "Adorable Lookout", Effect Duration: 44
 5893	tumbling dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	huge ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	Lo Pan's brainwave-controlled unicorn horn	0		Spell Critical Percent: +30, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	Lo Pan's brainwave-controlled unicorn horn	0		Spell Critical Percent: +30, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	Jack Frost's coward's MacGyver's plastic four-shadowed mime	0		Maximum MP: +100, Monster Level: -20, Cold Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	Jack Frost's plastic Father McGruber	0		Cold Spell Damage: +50, Last Available: "2012-12"
 5961	huge plastic Hank North, Photojournalist of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2012-12"
 5962	wobbly mansplainer's plastic blazing bat	0		Monster Level: +15, Last Available: "2012-12"
-5963	electronic dulcimer pants of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	electronic dulcimer pants of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	spinning lard-coated nasty Frown Exerciser	0		Stench Damage: +5, Sleaze Spell Damage: +25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5876,10 +5876,10 @@
 5978	adequate slice of pizza	3	good	Last Available: "2013-02"
 5979	wobbly huge coin	0		Last Available: "2013-02"
 5980	skewed cartoon heart	0		Last Available: "2013-02"
-5981	yellow narrow pulsating star	0		Last Available: "2013-02"
-5982	hand-crafted watered-down tankard of ale	2	EPIC	Last Available: "2013-02"
+5981	narrow yellow pulsating star	0		Last Available: "2013-02"
+5982	watered-down hand-crafted tankard of ale	2	EPIC	Last Available: "2013-02"
 5983	skewed vial of holy water	0		Last Available: "2013-02"
-5984	Newton's cloth cap of terror of the glutton	0		Experience (Mysticality): +3, Spooky Spell Damage: +10, Food Drop: +100, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	Newton's cloth cap of terror of the glutton	0		Experience (Mysticality): +3, Spooky Spell Damage: +10, Food Drop: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	olive padded educational iron dagger of the cheetah	0		Experience: +1, Damage Absorption: +20, Initiative: +60, Last Available: "2013-02"
 5986	moldy hamburger	3	crappy	Last Available: "2013-02"
 5987	upside-down dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,7 +5887,7 @@
 5989	potion	0		Last Available: "2013-02"
 5990	delicious practically non-alcoholic pulsating bottle of wine	1	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	razor-sharp Samson's Rosewater's iron helmet	0		Mysticality Percent: +30, Experience (Muscle): +5, Weapon Damage Percent: +25, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	razor-sharp Samson's Rosewater's iron helmet	0		Mysticality Percent: +30, Experience (Muscle): +5, Weapon Damage Percent: +25, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	perfumed coward's Newton's steel sword	0		Experience (Mysticality): +3, Monster Level: -20, Stench Resistance: +5, Last Available: "2013-02"
 5994	adequate pulsating skewed whole roasted chicken	3	good	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	perfectly mixed shining goblet	3	EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	beefcake's crown of the scaredy-cat of Flo-Jo	0		Muscle: +25, Monster Level: -15, Initiative: +100, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	beefcake's crown of the scaredy-cat of Flo-Jo	0		Muscle: +25, Monster Level: -15, Initiative: +100, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	spinning chilly sharpshooter's sage sword	0		Mysticality Percent: +10, Critical Hit Percent: +10, Cold Damage: +5, Last Available: "2013-02"
-6002	flame-retardant supercool Helm of the Scream Emperor of doom	0		Moxie Percent: +20, Spooky Spell Damage: +50, Hot Resistance: +1, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	flame-retardant supercool Helm of the Scream Emperor of doom	0		Moxie Percent: +20, Spooky Spell Damage: +50, Hot Resistance: +1, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	fuchsia knitted Cloak of Dire Shadows of the pedagogue	0		Experience: +3, Cold Resistance: +3, Item Drop: +5, Last Available: "2013-02"
 6004	hale thinker's Sword of Dark Omens of horror	0		Mysticality: +10, Maximum HP: +20, Spooky Spell Damage: +25, Last Available: "2013-02"
 6005	rosewater-soaked Temple Grandin's Shield of Icy Fate of the pedagogue	0		Experience: +3, Familiar Weight: +7, Stench Resistance: +3, Damage Reduction: 7, Last Available: "2013-02"
-6006	dance instructor's arcane researcher's stylish Greaves of the Murk Lord	0		Moxie: +25, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	dance instructor's arcane researcher's stylish Greaves of the Murk Lord	0		Moxie: +25, Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	grievous personal trainer's Gauntlets of the Blood Moon of the boozehound	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Booze Drop: +100, Single Equip, Last Available: "2013-02"
 6008	family-friendly personal trainer's Sinatra's Boots of Twilight Whispers	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Sleaze Resistance: +1, Single Equip, Last Available: "2013-02"
 6009	purple mirror tumbling Oprah's wholesome personal trainer's Belt of Howling Anger	0		Experience Percent (Muscle): +10, Maximum HP Percent: +10, Maximum MP Percent: +50, Single Equip, Last Available: "2013-02"
@@ -5947,11 +5947,11 @@
 6049	inspector's savvy stylish Misty Cape	0		Moxie: +25, Mysticality Percent: +20, Item Drop: +15
 6050	woimbook	0		Familiar Weight: +5
 6051	narrow Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	stale gray huge Taco Dan's Taco Stand Taco	3	decent	Last Available: "2012-12"
-6053	artisanal enchanted distilled Taco Dan's Taco Stand Chimichangarita	5	EPIC	Effect: "La Bamba", Effect Duration: 20, Last Available: "2012-12"
+6052	stale huge gray Taco Dan's Taco Stand Taco	3	decent	Last Available: "2012-12"
+6053	artisanal distilled enchanted Taco Dan's Taco Stand Chimichangarita	5	EPIC	Effect: "La Bamba", Effect Duration: 20, Last Available: "2012-12"
 6054	vacuum-sealed boiled anodized blinking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Fastbreaker", Effect Duration: 34, Last Available: "2012-12"
 6055	wobbly psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	arcane researcher's Meatcleaver of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Last Available: "2013-12"
 6058	twirling razor-sharp Crimbo Elf bobble-head	0		Weapon Damage Percent: +25, Last Available: "2012-12"
 6059	medical-grade Crimbo stogie-scented room odorizer	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	adequate haggis-wrapped haggis-stuffed haggis	4	good	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	ruddy haggis socks	0		Maximum HP Percent: +40, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	tumbling airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	ruddy haggis socks	0		Maximum HP Percent: +40, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	tumbling airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	huge yellow Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6011,12 +6011,12 @@
 6113	zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
-6116	skewed tumbling CEO office card	0		Last Available: "2013-12"
+6116	tumbling skewed CEO office card	0		Last Available: "2013-12"
 6117	test site key	0		Last Available: "2013-12"
 6118	wobbly goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	mediocre upside-down purple Chinese beer	3	decent	Last Available: "2013-12"
+6121	mediocre purple upside-down Chinese beer	3	decent	Last Available: "2013-12"
 6122	red cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	teal furry pink pillow	0		Last Available: "2013-12"
@@ -6036,30 +6036,30 @@
 6138	great capacitor	0		Last Available: "2013-12"
 6139	upside-down red Temple Grandin's rubber gloves	0		Familiar Weight: +7, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
-6141	twirling yellow triad summoning scroll	0		Last Available: "2013-12"
-6142	fancy spoiled mirror roasted duck	4	crappy	Effect: "Standard Issue Bravery", Effect Duration: 15, Last Available: "2013-12"
+6141	yellow twirling triad summoning scroll	0		Last Available: "2013-12"
+6142	spoiled fancy mirror roasted duck	4	crappy	Effect: "Standard Issue Bravery", Effect Duration: 15, Last Available: "2013-12"
 6143	stale enchanted dead meat bun	4	decent	Effect: "Broberry Brotality", Effect Duration: 50, Last Available: "2013-12"
 6144	educational cat collar	0		Experience: +1, Single Equip, Last Available: "2013-12"
-6145	suspicious-looking fedora of terror of the sweet-tooth	0		Spooky Spell Damage: +10, Candy Drop: +100, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	suspicious-looking fedora of terror of the sweet-tooth	0		Spooky Spell Damage: +10, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	fuchsia Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	huge Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	upside-down blue carrot nose	0		Last Available: "2013-01"
-6152	tiny spoiled carrot cake	1	crappy	Last Available: "2013-01"
+6152	spoiled tiny carrot cake	1	crappy	Last Available: "2013-01"
 6153	drinkable carrot claret	4	good	Last Available: "2013-01"
 6154	pickled ghostly carrot juice	1	EPIC	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	purple chilly manspreader's Byte	0		Monster Level: +10, Cold Damage: +5, Last Available: "2013-12"
-6158	padded anger blaster	0		Damage Absorption: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	hardened doubt cannon	0		Damage Reduction: 3, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	fear condenser of horror	0		Spooky Spell Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	regret hose of the sewer	0		Stench Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	padded anger blaster	0		Damage Absorption: +20, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	hardened doubt cannon	0		Damage Reduction: 3, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	fear condenser of horror	0		Spooky Spell Damage: +25, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	regret hose of the sewer	0		Stench Damage: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
-6163	narrow blinking Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	Usain Bolt's commodore's hat of the detective	0		Item Drop: +20, Initiative: +80, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	tumbling forbidden naval trousers	0		Spell Damage Percent: +50, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6163	blinking narrow Young Man's Cargo Load	0		Last Available: "2013-12"
+6164	Usain Bolt's commodore's hat of the detective	0		Item Drop: +20, Initiative: +80, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	tumbling forbidden naval trousers	0		Spell Damage Percent: +50, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	smooth deck cannon of bravery	0		Moxie: +15, Spooky Resistance: +5, Last Available: "2013-12"
 6167	tumbling rosy-cheeked ornamental sextant	0		Maximum HP Percent: +30, Last Available: "2013-12"
 6168	scandalous Newton's Bloodbath	0		Experience (Mysticality): +3, Sleaze Damage: +5, Last Available: "2013-12"
@@ -6069,7 +6069,7 @@
 6172	anodized red candy crayons	0		Effect: "Fungal Flambé", Effect Duration: 39, Last Available: "2020-09"
 6173	maroon coward's vibrating pixel grappling hook	0		Maximum MP Percent: +10, Monster Level: -20
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
-6175	skewed ghostly huge GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
+6175	skewed huge ghostly GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	shaking cosmic egg	0		
 6177	cosmic dough	0		
 6178	cosmic vegetable	0		
@@ -6084,41 +6084,41 @@
 6187	bland shaking consummate egg salad	3	decent	
 6188	toothsome thick consummate bagel	5	awesome	
 6189	normal huge consummate sliced bread	3	good	
-6190	normal jumbo upside-down consummate hot dog bun	5	good	
+6190	jumbo normal upside-down consummate hot dog bun	5	good	
 6191	normal consummate brownie	4	good	
 6192	half-sized normal huge shaking consummate toast	2	good	
 6193	irresponsibly strong bad red passable stout	9	decent	
-6194	moldy fancy consummate soup	3	crappy	Effect: "Fudgehound", Effect Duration: 10
+6194	fancy moldy consummate soup	3	crappy	Effect: "Fudgehound", Effect Duration: 10
 6195	rotten fancy consummate corn chips	4	crappy	Effect: "Pockets of Fire", Effect Duration: 15
 6196	rotten blurry consummate salad	3	crappy	
 6197	rotten consummate salsa	4	crappy	
-6198	spoiled bite-sized squat consummate sauerkraut	1	crappy	
+6198	bite-sized spoiled squat consummate sauerkraut	1	crappy	
 6199	thick spoiled consummate cheese slice	5	crappy	
-6200	delicious tiny consummate melted cheese	1	awesome	
+6200	tiny delicious consummate melted cheese	1	awesome	
 6201	tasty ghostly consummate bacon	3	awesome	
 6202	stale immense consummate meatloaf	9	decent	
 6203	spoiled olive consummate steak	3	crappy	
-6204	gigantic moldy consummate cuts	9	crappy	
+6204	moldy gigantic consummate cuts	9	crappy	
 6205	diet stale blurry blinking consummate frankfurter	1	decent	
 6206	yummy fancy consummate french fries	4	awesome	Effect: "Over-Familiar With Dactyls", Effect Duration: 10
-6207	bland big consummate baked potato	5	decent	
+6207	big bland consummate baked potato	5	decent	
 6208	acceptable acceptable vodka	3	good	
-6209	huge flavorless consummate ice cream	8	decent	
-6210	rotten snack-sized consummate whipped cream	2	crappy	
+6209	flavorless huge consummate ice cream	8	decent	
+6210	snack-sized rotten consummate whipped cream	2	crappy	
 6211	rotten immense consummate cream	8	crappy	
 6212	jumbo special adequate purple consummate strawberries	5	good	Effect: "Oiled Skin", Effect Duration: 20
 6213	bland maroon huge consummate sorbet	3	decent	
 6214	watered-down drinkable adequate rum	2	good	
-6215	high-proof acceptable mediocre lager	6	good	
-6216	massive tasty immaculate grilled cheese	10	awesome	
+6215	acceptable high-proof mediocre lager	6	good	
+6216	tasty massive immaculate grilled cheese	10	awesome	
 6217	decent snack-sized immaculate ice cream sandwich	2	good	
 6218	spoiled blinking immaculate hot dog	3	crappy	
-6219	moldy diet blurry immaculate egg salad sandwich	1	crappy	
+6219	diet moldy blurry immaculate egg salad sandwich	1	crappy	
 6220	flavorless perfect sandwich	3	decent	
 6221	rotten perfect chef salad	4	crappy	
 6222	tasty ghostly perfect breakfast	3	awesome	
-6223	bland immense pulsating sublime deluxe hot dog	8	decent	
-6224	half-sized rotten olive sublime stew	2	crappy	
+6223	immense bland pulsating sublime deluxe hot dog	8	decent	
+6224	rotten half-sized olive sublime stew	2	crappy	
 6225	moldy sublime nachos	3	crappy	
 6226	gigantic adequate Ultimate Breakfast Sandwich	7	good	
 6227	flavorless bouncing Loaded Baked Potato	4	decent	
@@ -6129,7 +6129,7 @@
 6232	spirit-forward bad Disappointed Russian	5	decent	
 6233	drinkable Chunky Mary	3	good	
 6234	smooth Nachojito	3	awesome	
-6235	drinkable fortified Le Roi	5	good	
+6235	fortified drinkable Le Roi	5	good	
 6236	mediocre bouncing Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
 6239	anodized super-vacuum-sealed cube of ectoplasm	0		Effect: "Concentration", Effect Duration: 31
@@ -6144,7 +6144,7 @@
 6248	frozen gamer slurry	0		Effect: "Very Clean Guns", Effect Duration: 28
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	knitted careful MacGyver's banded Sinatra's numberwang of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +5, Damage Absorption: +100, Maximum MP: +100, Monster Level: -10, Cold Resistance: +3, Single Equip
-6251	vacuum-sealed super-adjusted polymerized twirling upside-down scroll of Protection from Bad Stuff	0		Effect: "Human-Hobo Hybrid", Effect Duration: 27, Last Available: "2013-02"
+6251	vacuum-sealed super-adjusted polymerized upside-down twirling scroll of Protection from Bad Stuff	0		Effect: "Human-Hobo Hybrid", Effect Duration: 27, Last Available: "2013-02"
 6252	diffused scroll of Puddingskin	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 50, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	cyan Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
@@ -6160,21 +6160,21 @@
 6264	prompt perfumed Da Vinci's Staff of Fruit Salad	0		Experience (Mysticality): +5, Stench Resistance: +5, Adventures: +3, Jiggle: "Deal Some Prismatic Damage"
 6265	dangerous stylish Staff of the Cream of the Cream of terror	0		Moxie: +25, Weapon Damage: +10, Spooky Spell Damage: +10, Jiggle: "Attune to Monster's Essence"
 6266	spinning jar of protein powder	0		
-6267	toothsome small grain of protein powder	2	awesome	
+6267	small toothsome grain of protein powder	2	awesome	
 6268	liquefied polarized green pec oil	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 15
 6269	Sherlock's gym membership card	0		Item Drop: +25
 6270	polarized galvanized blurry Squat-Thrust Magazine	0		Effect: "Happy Trails", Effect Duration: 31
 6271	massive dumbbell	0		
 6272	nasty manspreader's penguin keychain	0		Monster Level: +10, Stench Damage: +5, Damage Reduction: 10
 6273	triple-irradiated O'RLY manual	0		Effect: "Ocelot Eyes", Effect Duration: 32
-6274	acceptable triple-distilled open sauce	6	good	
+6274	triple-distilled acceptable open sauce	6	good	
 6275	zippy Jeselnik's turkey leg	0		Sleaze Damage: +25, Initiative: +20
-6276	distilled mediocre Ye Olde Meade	5	decent	
+6276	mediocre distilled Ye Olde Meade	5	decent	
 6277	nitrogenated wobbly Ye Olde Bawdy Limerick	0		Effect: "Stop the Presses!", Effect Duration: 40
 6278	fuchsia Ye Olde Medieval Insult	0		
 6279	slick pewter claymore	0		Moxie: +10
 6280	arcane researcher's artisanal rice peeler	0		Experience Percent (Mysticality): +10
-6281	snack-sized normal heirloom grape tomato	2	good	
+6281	normal snack-sized heirloom grape tomato	2	good	
 6282	twirling chipotle wasabi cilantro aioli	0		
 6283	huge ghostly veiny brown felt tophat	0		Maximum HP: +10, Familiar Effect: "1xLep, cap 37"
 6284	cyan gear	0		
@@ -6182,7 +6182,7 @@
 6286	Temple Grandin's vibrating Mark II Steam-Hat of the cougar	0		Moxie: +20, Maximum MP Percent: +10, Familiar Weight: +7, Familiar Effect: "1xLep, cap 37"
 6287	bouncing purple double-paned quilted extremely unsafe Mark III Steam-Hat of Flo-Jo	0		Weapon Damage Percent: +100, Damage Absorption: +40, Cold Resistance: +5, Initiative: +100, Familiar Effect: "1xLep, cap 37"
 6288	ghostly rosewater-soaked frosty Annie Oakley's groovy beefcake's Mark IV Steam-Hat	0		Muscle: +25, Moxie Percent: +10, Critical Hit Percent: +20, Cold Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "1xLep, cap 37"
-6289	crafty personal trainer's Socratic boxer's Mark V Steam-Hat of Calamity Jane	0		Muscle Percent: +10, Experience (Mysticality): +1, Experience Percent (Muscle): +10, Maximum MP: +10, Critical Hit Percent: +15, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	crafty personal trainer's Socratic boxer's Mark V Steam-Hat of Calamity Jane	0		Muscle Percent: +10, Experience (Mysticality): +1, Experience Percent (Muscle): +10, Maximum MP: +10, Critical Hit Percent: +15, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	tumbling hardened punk rock jacket of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 3
 6292	occult safety pin	0		Spell Damage Percent: +25, Item Drop: +5
@@ -6239,7 +6239,7 @@
 6343	non-modified huge Mer-kin lipstick	0		Effect: "Prideful Strut", Effect Duration: 23
 6344	Mer-kin mouthsoap	0		
 6345	anodized anodized spinning Mer-kin strongjuice	0		Effect: "Aries Rising", Effect Duration: 47
-6346	jittery blinking Mer-kin fitbrine	0		
+6346	blinking jittery Mer-kin fitbrine	0		
 6347	liquefied olive blurry Mer-kin ragejuice	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 61
 6348	cool Mer-kin dragbelt	0		Moxie: +5, Experience (Muscle): +20, Single Equip
 6349	huge greedy Mer-kin eyeglasses	0		Meat Drop: +20, Experience (Mysticality): +20, Single Equip
@@ -6266,7 +6266,7 @@
 6370	jittery twisted piece of wire	0		
 6371	hand-crafted can of the cheapest beer	4	EPIC	
 6372	bad weak bottle of fruity &quot;wine&quot;	2	decent	
-6373	special hand-crafted weak single swig of vodka	2	EPIC	Effect: "Remaining Alive", Effect Duration: 50
+6373	weak special hand-crafted single swig of vodka	2	EPIC	Effect: "Remaining Alive", Effect Duration: 50
 6374	angry inch	0		
 6375	jittery testy toolbox of the wise owl	0		Mysticality: +20
 6376	Jick-o-User	0		
@@ -6281,7 +6281,7 @@
 6386	balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
-6389	adjusted super-frozen skewed blinking bouncing Mer-kin rocksalt	0		Effect: "Brocolate Brostidigitation", Effect Duration: 31
+6389	adjusted super-frozen blinking bouncing skewed Mer-kin rocksalt	0		Effect: "Brocolate Brostidigitation", Effect Duration: 31
 6390	enhanced super-irradiated Mer-kin saltmint	0		Effect: "Abyssal Blood", Effect Duration: 32
 6391	extra-oxidized Mer-kin saltsquid	0		Effect: "Preternatural Greed", Effect Duration: 16
 6392	huge censurious chaotic scale-mail underwear	0		Spell Critical Percent: +10, Sleaze Resistance: +3, Familiar Effect: "2xVolley"
@@ -6307,25 +6307,25 @@
 6412	gray shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	ghostly clutch of dodecapede eggs	0		
-6415	adequate special flavorless gruel	3	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 5
+6415	special adequate flavorless gruel	3	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 5
 6416	snack-sized special spoiled tumbling mana curds	2	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 10
 6417	twist of lime	0		
 6418	blinking pencil stub	0		
 6419	double-deionized moth dust	0		Effect: "Mariachi Mood", Effect Duration: 54
 6420	extra-moist narrow glob of spoiled mayo	0		Effect: "Wise Spirit", Effect Duration: 13
 6421	skewed tonic djinn	0		
-6422	spoiled enchanted jittery vampire chowder	3	crappy	Effect: "Gyromitra Gymnastics", Effect Duration: 50
+6422	enchanted spoiled jittery vampire chowder	3	crappy	Effect: "Gyromitra Gymnastics", Effect Duration: 50
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	pulsating Official Seal of Dreadsylvania	0		
-6426	gigantic stale Dreadsylvanian stew	6	decent	
+6426	stale gigantic Dreadsylvanian stew	6	decent	
 6427	lousy Dreadsylvanian	3	decent	
 6428	concentrated chilled shaking Dreadsylvanian flask	0		Effect: "Baconstoned", Effect Duration: 28
 6429	magnetized flattened Dreadsylvanian flask	0		Effect: "Stinky Hands", Effect Duration: 50
 6430	twirling inspector's Socratic dreadful fedora	0		Experience (Mysticality): +1, Item Drop: +15, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	dreadful sweater of Tarzan	0		Experience (Muscle): +3, Kruegerand Drop: 5
 6432	narrow MacGyver's dreadful glove	0		Maximum MP: +100, Kruegerand Drop: 5
-6433	purple pulsating Freddy Kruegerand	0		
+6433	pulsating purple Freddy Kruegerand	0		
 6434	spinning Mark of the Bugbear	0		
 6435	Mark of the Werewolf	0		
 6436	blurry Mark of the Zombie	0		
@@ -6367,7 +6367,7 @@
 6472	skewed Drunkula's bell	0		
 6473	shaking miser's frightening extremely unsafe Drunkula's ring of haze	0		Weapon Damage Percent: +100, Spooky Damage: +5, Meat Drop: +10, Avoid Attack: 1, Single Equip
 6474	crafty Drunkula's wineglass	0		Maximum MP: +10
-6475	tolerable weak bottle of Bloodweiser	2	good	
+6475	weak tolerable bottle of Bloodweiser	2	good	
 6476	red zippy miser's therapeutic Unkillable Skeleton's skullcap	0		Meat Drop: +10, Initiative: +20, HP Regen Min: 5, HP Regen Max: 7, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	up-at-dawn Unkillable Skeleton's breastplate of Gandalf of Leguizamo	0		Spell Critical Percent: +20, Monster Level: +20, Adventures: +5, Class: "Turtle Tamer"
 6478	huge wholesome rock-hard razor-sharp Unkillable Skeleton's shinguards	0		Weapon Damage Percent: +25, Damage Reduction: 5, Maximum HP Percent: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	wobbly bone flour	0		
 6486	green dreadful roast	0		
 6487	stinking agaricus	0		
-6488	decent miniature Dreadsylvanian shepherd's pie	2	good	
+6488	miniature decent Dreadsylvanian shepherd's pie	2	good	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6408,7 +6408,7 @@
 6513	stanky warm fur	0		Stench Spell Damage: +25
 6514	horrifying snowstick	0		Spooky Damage: +25
 6515	pulsating aromatic eerie fetish	0		Stench Resistance: +1, Single Equip
-6516	drinkable weak blinking stinkwater	2	good	
+6516	weak drinkable blinking stinkwater	2	good	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	moldy gigantic blinking accidental mutton	10	crappy	
 6519	supercool drafty drawers of the brazier	0		Moxie Percent: +20, Hot Spell Damage: +25, Familiar Effect: "1.5xVolley"
@@ -6429,7 +6429,7 @@
 6534	dangerous remorseless knife	0		Weapon Damage: +10
 6535	Da Vinci's intimidating coiffure	0		Experience (Mysticality): +5, Familiar Effect: "hot afk, 1xPotato"
 6536	Jeselnik's Temple Grandin's cod cape	0		Familiar Weight: +7, Sleaze Damage: +25
-6537	snack-sized toothsome teal blood sausage	2	awesome	
+6537	toothsome snack-sized teal blood sausage	2	awesome	
 6538	bouncing mirror gravedigger's savvy frying brainpan	0		Mysticality Percent: +20, Spooky Damage: +10
 6539	Rosewater's ball and chain of dire peril	0		Mysticality Percent: +30, Weapon Damage: +20, Single Equip
 6540	ghostly dry bone of wisdom	0		Mysticality: +15
@@ -6455,14 +6455,14 @@
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	Newton's hand of Mr. Cards	0		Experience (Mysticality): +3, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	tiny adequate blinking Dreadsylvanian hot pocket	1	good	
+6564	adequate tiny blinking Dreadsylvanian hot pocket	1	good	
 6565	decent lime green Dreadsylvanian pocket	3	good	
 6566	moldy Dreadsylvanian pocket	3	crappy	
 6567	adequate jittery Dreadsylvanian stink pocket	3	good	
 6568	stale Dreadsylvanian sleaze pocket	3	decent	
-6569	aged weak Dreadsylvanian hot toddy	2	awesome	
-6570	hand-crafted spirit-forward Dreadsylvanian cold-fashioned	5	super EPIC	
-6571	artisanal fancy squat Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	Effect: "Altered Wavelengths", Effect Duration: 50
+6569	weak aged Dreadsylvanian hot toddy	2	awesome	
+6570	spirit-forward hand-crafted Dreadsylvanian cold-fashioned	5	super EPIC	
+6571	fancy artisanal squat Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	Effect: "Altered Wavelengths", Effect Duration: 50
 6572	perfectly mixed watered-down ghostly Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	
 6573	lousy fancy Dreadsylvanian slithery nipple	3	decent	Effect: "Ooh, Salty!", Effect Duration: 35
 6574	maroon hot clusterbomb	0		
@@ -6488,7 +6488,7 @@
 6594	twirling hot Dreadsylvanian cocoa	0		
 6595	boiled epic cluster	1	good	Effect: "Adorable Lookout", Effect Duration: 15
 6596	wobbly clockwork egg	0		
-6597	ghostly bouncing clockwork birdhouse	0		
+6597	bouncing ghostly clockwork birdhouse	0		
 6598	pulsating clockwork disc	0		
 6599	clockwork hand	0		
 6600	clockwork hand	0		
@@ -6538,13 +6538,13 @@
 6644	bouncing folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	squat slide rule of chilblains of the sweet-tooth	0		Cold Damage: +25, Candy Drop: +100
-6649	diffused activated twirling huge Ogres and Oubliettes&trade; module	0		Effect: "Coated Arms", Effect Duration: 17
+6649	diffused activated huge twirling Ogres and Oubliettes&trade; module	0		Effect: "Coated Arms", Effect Duration: 17
 6650	Mountain Stream Code Black Alert	0		
 6651	ghostly twisted-up wet towel	0		
 6652	bad stepmom's booze	3	decent	
 6653	ghostly bouncing surgical tape	0		
 6654	rock-hard band T-shirt	0		Damage Reduction: 5
-6655	delicious weak skewed fountain 'soda'	2	awesome	
+6655	weak delicious skewed fountain 'soda'	2	awesome	
 6656	illegal firecracker	0		
 6657	Usain Bolt's Temple Grandin's pickelhaube	0		Familiar Weight: +7, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	double-concentrated flattened hair oil	0		Effect: "Waxing", Effect Duration: 29
@@ -6569,7 +6569,7 @@
 6677	crude monster sculpture	0		
 6678	skewed Yearbook Club Camera of incineration	0		Hot Spell Damage: +50, Conditional Skill (Equipped): "Blinding Flash"
 6679	banded machete	0		Damage Absorption: +100
-6680	drinkable weak wobbly Cursed Punch	2	good	
+6680	weak drinkable wobbly Cursed Punch	2	good	
 6681	mediocre Bowl of Scorpions	3	decent	
 6682	artisanal fuchsia Fog Murderer	3	EPIC	
 6683	book of matches	0		
@@ -6588,10 +6588,10 @@
 6696	bowling ball	0		
 6697	blurry moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
-6699	huge blinking crackling stone sphere	0		
+6699	blinking huge crackling stone sphere	0		
 6700	scorched stone sphere	0		
 6701	narrow stone triangle	0		
-6702	green jittery bowler	0		
+6702	jittery green bowler	0		
 6703	imitation White Russian	1	decent	
 6704	frosty Socratic short-handled mop	0		Experience (Mysticality): +1, Cold Spell Damage: +10
 6705	moldy jungle floor wax	3	crappy	
@@ -6609,7 +6609,7 @@
 6717	pulsating tongue depressor	0		
 6718	huge smelly compression stocking of courage	0		Stench Spell Damage: +10, Spooky Resistance: +3
 6719	upside-down executive stanky midriff scrubs	0		Stench Spell Damage: +25, Meat Drop: +40
-6720	extra-nitrogenated red wobbly pill cup	0		Effect: "Bone Homie", Effect Duration: 50
+6720	extra-nitrogenated wobbly red pill cup	0		Effect: "Bone Homie", Effect Duration: 50
 6721	Fonzie's groovy water bottle of the storm	0		Moxie Percent: +10, Experience (Moxie): +1, Maximum MP Percent: +40, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	unsweetened warmed pygmy phone number	0		Effect: "Human-Horror Hybrid", Effect Duration: 65
 6723	Boozehounds Anonymous token	0		
@@ -6617,14 +6617,14 @@
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	tumbling dude ranch souvenir crate	0		
 6727	narrow tropical island souvenir crate	0		
-6728	twirling green ski resort souvenir crate	0		
+6728	green twirling ski resort souvenir crate	0		
 6729	ghostly UV-resistant compass	0		
 6730	funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	cigar sign	0		
-6735	spinning wobbly junk junk	0		
+6735	wobbly spinning junk junk	0		
 6736	squat Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	jagged scrap	0		
@@ -6634,8 +6634,8 @@
 6742	healthy junk band	0		Maximum HP Percent: +20
 6743	scandalous junk trunks	0		Sleaze Damage: +5, Familiar Effect: "cap 15"
 6744	Jeselnik's junk-mail shirt	0		Sleaze Damage: +25
-6745	low-calorie bland junk food	1	decent	
-6746	fortified artisanal junk yard	5	EPIC	
+6745	bland low-calorie junk food	1	decent	
+6746	artisanal fortified junk yard	5	EPIC	
 6747	tumbling manspreader's swordzall of bravery	0		Monster Level: +10, Spooky Resistance: +5
 6748	bouncing arm buzzer of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 6
 6749	family-friendly cool boilgun	0		Moxie: +5, Sleaze Resistance: +1
@@ -6653,12 +6653,12 @@
 6761	lousy bottle of Professor Beer	4	decent	Last Available: "2013-09"
 6762	drinkable bottle of Rapier Witbier	3	good	Last Available: "2013-09"
 6763	acceptable bottle of Race Car Red	4	good	Last Available: "2013-09"
-6764	drinkable watered-down bottle of Greedy Dog	2	good	Last Available: "2013-09"
-6765	drinkable special fuchsia bottle of Lambada Lambic	3	good	Effect: "Oleaginous Soles", Effect Duration: 35, Last Available: "2013-09"
+6764	watered-down drinkable bottle of Greedy Dog	2	good	Last Available: "2013-09"
+6765	special drinkable fuchsia bottle of Lambada Lambic	3	good	Effect: "Oleaginous Soles", Effect Duration: 35, Last Available: "2013-09"
 6766	spinning wobbly tin beer can	0		
 6767	jittery artisanal homebrew gift package	0		
 6768	liquid bread	1	decent	Last Available: "2013-09"
-6769	supercharged weightlifter's tin tam of the boozehound	0		Muscle: +15, Maximum MP Percent: +30, Booze Drop: +100, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	supercharged weightlifter's tin tam of the boozehound	0		Muscle: +15, Maximum MP Percent: +30, Booze Drop: +100, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	vacuum-sealed Vulcanized concentrated tin cup	0		Effect: "Muscularrr", Effect Duration: 23, Last Available: "2013-09"
 6771	spinning greasy smelly padded tin foil	0		Damage Absorption: +20, Stench Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2013-09"
 6772	coward's Oprah's fortified tin drum	0		Damage Absorption: +60, Maximum MP Percent: +50, Monster Level: -20, Last Available: "2013-09"
@@ -6746,9 +6746,9 @@
 6857	bouncing blurry MacGyver's Cajun accordion	0		Maximum MP: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	groovy quirky accordion	0		Moxie Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	supercool Skipper's accordion of courage	0		Moxie Percent: +20, Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	razor-sharp smartaleck's Pantsgiving of the pedagogue of Gandalf	0		Moxie Percent: +30, Experience: +3, Weapon Damage Percent: +25, Spell Critical Percent: +20, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	razor-sharp smartaleck's Pantsgiving of the pedagogue of Gandalf	0		Moxie Percent: +30, Experience: +3, Weapon Damage Percent: +25, Spell Critical Percent: +20, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	stale tumbling can of sardines	3	decent	Last Available: "2013-11"
-6862	adequate diet high-calorie sugar substitute	1	good	Last Available: "2013-11"
+6862	diet adequate high-calorie sugar substitute	1	good	Last Available: "2013-11"
 6863	yummy pat of butter	4	awesome	Last Available: "2013-11"
 6864	moldy dinner roll	3	crappy	Last Available: "2013-11"
 6865	moldy yellow mashed potatoes	3	crappy	Last Available: "2013-11"
@@ -6793,7 +6793,7 @@
 6904	extra-aerosolized tarnished polarized bolts	0		Effect: "Certainty", Effect Duration: 65, Last Available: "2013-12"
 6905	toothsome tiny gingerbread robot	1	awesome	Last Available: "2013-12"
 6906	rotten huge shaking petit 4.1	8	crappy	Last Available: "2013-12"
-6907	adequate miniature jittery nut-shaped Crimbo cookie	2	good	Last Available: "2023-06"
+6907	miniature adequate jittery nut-shaped Crimbo cookie	2	good	Last Available: "2023-06"
 6908	blinking Tesla plastic GORM-8	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 6909	yellow huge ribald plastic warbear	0		Sleaze Damage: +10, Last Available: "2013-12"
 6910	red Da Vinci's plastic Toybot	0		Experience (Mysticality): +5, Last Available: "2013-12"
@@ -6814,25 +6814,25 @@
 6925	acceptable warbear bearserker mead	4	good	Last Available: "2013-12"
 6926	smooth watered-down narrow warbear blizzard mead	2	awesome	Last Available: "2013-12"
 6927	tumbling warbear helm fragment	0		Last Available: "2013-12"
-6928	coward's clever warbear plain fedora of the sweet-tooth	0		Maximum MP: +20, Monster Level: -20, Candy Drop: +100, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	green warbear feathered fedora of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	careful stiffened warbear fedora of terror	0		Damage Reduction: 1, Monster Level: -10, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	aromatic frightening extremely unsafe warbear plain helm	0		Weapon Damage Percent: +100, Spooky Damage: +5, Stench Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	quilted warbear spiked helm	0		Damage Absorption: +40, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	family-friendly double-paned therapeutic warbear electro-spiked helm	0		Cold Resistance: +5, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	yellow upside-down executive nasty banded warbear plain ushanka	0		Damage Absorption: +100, Stench Damage: +5, Meat Drop: +40, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	veiny warbear lined ushanka	0		Maximum HP: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	careful warbear heated ushanka of extreme caution	0		Monster Level: -35, Item Drop: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	coward's clever warbear plain fedora of the sweet-tooth	0		Maximum MP: +20, Monster Level: -20, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	green warbear feathered fedora of James Dean	0		Experience (Moxie): +3, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	careful stiffened warbear fedora of terror	0		Damage Reduction: 1, Monster Level: -10, Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	aromatic frightening extremely unsafe warbear plain helm	0		Weapon Damage Percent: +100, Spooky Damage: +5, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	quilted warbear spiked helm	0		Damage Absorption: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	family-friendly double-paned therapeutic warbear electro-spiked helm	0		Cold Resistance: +5, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	yellow upside-down executive nasty banded warbear plain ushanka	0		Damage Absorption: +100, Stench Damage: +5, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	veiny warbear lined ushanka	0		Maximum HP: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	careful warbear heated ushanka of extreme caution	0		Monster Level: -35, Item Drop: +5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	ribald nippy wholesome warbear party pants	0		Maximum HP Percent: +10, Cold Damage: +10, Sleaze Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	dance instructor's warbear ceremonial party pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	green coward's electrified medical-grade warbear high festival pants	0		Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	Usain Bolt's executive Van der Graaf warbear battle greaves	0		Meat Drop: +40, Initiative: +80, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	careful warbear officer greaves	0		Monster Level: -10, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	ghostly healthy Sinatra's warbear bearserker greaves of the cougar	0		Moxie: +20, Experience (Moxie): +5, Maximum HP Percent: +20, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	blurry hale Rosewater's warbear johns of the brazier	0		Mysticality Percent: +30, Maximum HP: +20, Hot Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	veiny warbear fleece-lined johns	0		Maximum HP: +10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	pulsating miser's Oprah's extremely unsafe warbear johns	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Meat Drop: +10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	ribald nippy wholesome warbear party pants	0		Maximum HP Percent: +10, Cold Damage: +10, Sleaze Damage: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	dance instructor's warbear ceremonial party pants	0		Experience Percent (Moxie): +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	green coward's electrified medical-grade warbear high festival pants	0		Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	Usain Bolt's executive Van der Graaf warbear battle greaves	0		Meat Drop: +40, Initiative: +80, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	careful warbear officer greaves	0		Monster Level: -10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	ghostly healthy Sinatra's warbear bearserker greaves of the cougar	0		Moxie: +20, Experience (Moxie): +5, Maximum HP Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	blurry hale Rosewater's warbear johns of the brazier	0		Mysticality Percent: +30, Maximum HP: +20, Hot Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	veiny warbear fleece-lined johns	0		Maximum HP: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	pulsating miser's Oprah's extremely unsafe warbear johns	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Meat Drop: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	friendly occult dance instructor's warbear goggles	0		Experience Percent (Moxie): +10, Spell Damage Percent: +25, Familiar Weight: +3, Single Equip, Last Available: "2013-12"
 6949	therapeutic warbear snowblindness goggles	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	Herculean warbear warscarf of the wise owl of dire peril	0		Mysticality: +20, Experience (Muscle): +1, Weapon Damage: +20, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	blinking olive warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	jittery perfumed warbear foil hat	0		Stench Resistance: +5, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	jittery perfumed warbear foil hat	0		Stench Resistance: +5, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	skewed shaking supercharged warbear oil pan of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	skewed shaking supercharged warbear oil pan of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	squat warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	hardened warbear exhaust manifold	0		Damage Reduction: 3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6893,11 +6893,11 @@
 7004	vacuum-sealed blurry Flaskfull of Hollow	0		Effect: "Spooky Weapon", Effect Duration: 49, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	distilled upside-down handful of Smithereens	1	good	Last Available: "2013-12"
-7007	decent immense Every Day is Like This Sundae	7	good	Last Available: "2013-12"
+7007	immense decent Every Day is Like This Sundae	7	good	Last Available: "2013-12"
 7008	rotten Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	flavorless pulsating This Charming Flan	4	decent	Last Available: "2013-12"
 7010	perfectly mixed Irish Coffee, English Heart	4	EPIC	Last Available: "2013-12"
-7011	weak mediocre Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
+7011	mediocre weak Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
 7012	artisanal blinking Paint A Vulgar Pitcher	4	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	gray Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	reassuring horrifying chilly wholesome Sheila Take a Crossbow	0		Maximum HP Percent: +10, Cold Damage: +5, Spooky Damage: +25, Spooky Resistance: +1, Last Available: "2013-12"
 7019	greedy sinister Da Vinci's A Light that Never Goes Out of the boozehound	0		Experience (Mysticality): +5, Spell Damage: +10, Meat Drop: +20, Booze Drop: +100, Last Available: "2013-12"
 7020	olive ghostly vibrating hardened razor-sharp Half a Purse of the bloodbag	0		Weapon Damage Percent: +25, Damage Reduction: 3, Maximum HP: +100, Maximum MP Percent: +10, Last Available: "2013-12"
-7021	perfumed greasy Hairpiece On Fire of James Dean of mayonnaise	0		Experience (Moxie): +3, Sleaze Spell Damage: 60, Stench Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	maroon flame-wreathed rosy-cheeked Vicar's Tutu of the glutton of Flo-Jo	0		Maximum HP Percent: +30, Hot Spell Damage: +10, Food Drop: +100, Initiative: +100, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	perfumed greasy Hairpiece On Fire of James Dean of mayonnaise	0		Experience (Moxie): +3, Sleaze Spell Damage: 60, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	maroon flame-wreathed rosy-cheeked Vicar's Tutu of the glutton of Flo-Jo	0		Maximum HP Percent: +30, Hot Spell Damage: +10, Food Drop: +100, Initiative: +100, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	blinking Usain Bolt's auspicious Oprah's Hand in Glove	0		Maximum MP Percent: +50, Item Drop: +10, Initiative: +80, Single Equip, Last Available: "2013-12"
 7024	family-friendly smooth Meat Tenderizer is Murder of the pedagogue	0		Moxie: +15, Experience: +3, Sleaze Resistance: +1, Class: "Seal Clubber", Last Available: "2013-12"
 7025	narrow purple forbidden Newton's groovy Ouija Board, Ouija Board	0		Moxie Percent: +10, Experience (Mysticality): +3, Spell Damage Percent: +50, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6924,13 +6924,13 @@
 7035	skewed warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	skewed warbear LP-ROM burner	0		Last Available: "2013-12"
-7038	cyan blinking warbear gyrocopter	0		Last Available: "2013-12"
+7038	blinking cyan warbear gyrocopter	0		Last Available: "2013-12"
 7039	double-adjusted galvanized pulsating warbear robo-camouflage unit	0		Effect: "Whippin' It Good", Effect Duration: 41, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	colloidal wobbly shaking glass slipper	0		Effect: "Big Meat Big Prizes", Effect Duration: 65, Last Available: "2014-12"
+7044	colloidal shaking wobbly glass slipper	0		Effect: "Big Meat Big Prizes", Effect Duration: 65, Last Available: "2014-12"
 7045	altered ghostly antimatter wad	1	EPIC	Effect: "New Zeal", Effect Duration: 10, Last Available: "2013-12"
 7046	energized pickled extra-tarnished blinking warbear superpotion	0		Effect: "Supafly", Effect Duration: 22, Last Available: "2013-12"
 7047	super-warmed cold-filtered warbear liquid lasers	0		Effect: "Flamingly Floral", Effect Duration: 47, Last Available: "2013-12"
@@ -6948,7 +6948,7 @@
 7059	green warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	grimstone mask	0		Last Available: "2014-12"
-7062	bouncing cyan praying Grim Brother	0		Free Pull, Last Available: "2014-12"
+7062	cyan bouncing praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	diluted grim fairy tale	1	good	Last Available: "2014-12"
@@ -6964,25 +6964,25 @@
 7075	activated liquid ice pack	0		Effect: "Thaumodynamic", Effect Duration: 29, Last Available: "2014-01"
 7076	bouncing snow boards	0		Last Available: "2014-01"
 7077	stale skewed snow crab	4	decent	Last Available: "2014-01"
-7078	perfectly mixed fortified Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
+7078	fortified perfectly mixed Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	snow mobile of the wise owl	0		Mysticality: +20, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	snow mobile of the wise owl	0		Mysticality: +20, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	blinking Herculean ice bucket	0		Experience (Muscle): +1, Lasts Until Rollover, Last Available: "2014-01"
 7085	foul-smelling snow shovel of the empath	0		Familiar Weight: +5, Stench Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7086	reassuring bod-ice of chilblains of the blizzard	0		Cold Damage: +25, Cold Spell Damage: +25, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2014-01"
 7087	lime green miser's Van der Graaf supercharged snow belt of the wise owl	0		Mysticality: +20, Maximum MP Percent: +30, Meat Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	upside-down supercharged cool ice nine of the blizzard of Flo-Jo	0		Moxie: +5, Maximum MP Percent: +30, Cold Spell Damage: +25, Initiative: +100, Lasts Until Rollover, Last Available: "2014-01"
-7089	tumbling green snow fort	0		Last Available: "2014-01"
+7089	green tumbling snow fort	0		Last Available: "2014-01"
 7090	watered-down tolerable En Una Fila Tequila	2	good	
 7091	enchanted fuchsia Skully's hot chocolate	1	good	Effect: "Hair on Your Chest", Effect Duration: 25
-7092	chaotic warbear dress helmet of the detective	0		Spell Critical Percent: +10, Item Drop: +20, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	chaotic warbear dress helmet of the detective	0		Spell Critical Percent: +10, Item Drop: +20, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	mirror lime green padded warbear dress bracers of the overflowing toilet	0		Damage Absorption: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2013-12"
-7094	spinning wobbly executive warbear dress greaves of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +40, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	spinning hale dangerous sweatband	0		Weapon Damage: +10, Maximum HP: +20, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	jittery scorching gym shorts of the sweet-tooth	0		Hot Damage: +25, Candy Drop: +100, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	spinning wobbly executive warbear dress greaves of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	spinning hale dangerous sweatband	0		Weapon Damage: +10, Maximum HP: +20, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	jittery scorching gym shorts of the sweet-tooth	0		Hot Damage: +25, Candy Drop: +100, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	clever ankleweights of mayonnaise	0		Maximum MP: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7098	lard-coated dog trainer's deadly sweat socks of the overflowing toilet	0		Weapon Damage: +5, Experience (familiar): +1, Stench Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6992,10 +6992,10 @@
 7103	liquefied moist powder	0		Effect: "Bat Attitude", Effect Duration: 36, Last Available: "2014-12"
 7104	teal dangerous licorice whip	0		Weapon Damage: +10, Last Available: "2014-12"
 7105	wobbly anise-flavored venom	0		Last Available: "2014-12"
-7106	fancy drinkable snakebite	3	good	Effect: "Stickler for Promptness", Effect Duration: 45, Last Available: "2014-12"
+7106	drinkable fancy snakebite	3	good	Effect: "Stickler for Promptness", Effect Duration: 45, Last Available: "2014-12"
 7107	mirror cool candy stick of the wise owl	0		Mysticality: +20, Moxie: +5, Last Available: "2014-12"
-7108	normal gray huge pecan	3	good	Last Available: "2014-12"
-7109	huge moldy pecan pie	7	crappy	Last Available: "2014-12"
+7108	normal huge gray pecan	3	good	Last Available: "2014-12"
+7109	moldy huge pecan pie	7	crappy	Last Available: "2014-12"
 7110	jittery chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	small rotten candy mountain oyster	2	crappy	Last Available: "2014-12"
 7112	artisanal blurry chocotini	3	EPIC	Last Available: "2014-12"
@@ -7003,28 +7003,28 @@
 7114	decent candy carrot	4	good	Last Available: "2014-12"
 7115	toothsome enchanted candy carrot cake	3	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 20, Last Available: "2014-12"
 7116	carrot-on-a-stick of the dark arts of the sewer	0		Spell Damage Percent: +100, Stench Damage: +25, Last Available: "2014-12"
-7117	censurious rosy-cheeked weasel stomping pants	0		Maximum HP Percent: +30, Sleaze Resistance: +3, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	censurious rosy-cheeked weasel stomping pants	0		Maximum HP Percent: +30, Sleaze Resistance: +3, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	spoiled mulberry	3	crappy	Last Available: "2014-12"
 7119	watered-down lousy mulled berry wine	2	decent	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	forbidden lemon party hat	0		Spell Damage Percent: +50, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	forbidden lemon party hat	0		Spell Damage Percent: +50, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	lemon shirt of the pedagogue	0		Experience: +3, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of the cheetah	0		Initiative: +60, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	lemon drop trousers of the cheetah	0		Initiative: +60, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	colloidal lemonhead caviar	0		Effect: "Crotchety, Pining", Effect Duration: 64, Last Available: "2014-12"
 7125	chilly energetic gummi sword	0		Maximum MP Percent: +20, Cold Damage: +5, Last Available: "2014-12"
 7126	liquefied shaking small gummi fin	0		Effect: "Gummi-Grin", Effect Duration: 47, Last Available: "2014-12"
 7127	lime green jittery vibrating chocolate cow bone	0		Maximum MP Percent: +10, Last Available: "2014-12"
 7128	Vulcanized blurry gummi fang	0		Effect: "Bootyliciousness", Effect Duration: 54, Last Available: "2014-12"
-7129	yummy small leftover canap&eacute;s	2	awesome	Last Available: "2014-12"
-7130	strong bad magnum of champagne	5	decent	Last Available: "2014-12"
+7129	small yummy leftover canap&eacute;s	2	awesome	Last Available: "2014-12"
+7130	bad strong magnum of champagne	5	decent	Last Available: "2014-12"
 7131	upside-down studded personal trainer's cow creamer of Leguizamo	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Monster Level: +20, Last Available: "2014-12"
 7132	ionized mirror Outer Wolf&trade; cologne	0		Effect: "Shawarma Initiative", Effect Duration: 37, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	maroon wolf whistle of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	maroon wolf whistle of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	rotten small yellow witch's bread	2	crappy	Last Available: "2014-12"
 7136	polymerized blurry green witch's brew	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 16, Last Available: "2014-12"
 7137	executive toasty brainy witch's bra	0		Mysticality: +5, Hot Damage: +5, Meat Drop: +40, Last Available: "2014-12"
-7138	perfectly mixed boozy mid-level medieval mead	5	EPIC	Last Available: "2014-12"
+7138	boozy perfectly mixed mid-level medieval mead	5	EPIC	Last Available: "2014-12"
 7139	unsweetened anodized R&uuml;mpelstiltz	0		Effect: "Space Cadet", Effect Duration: 58, Last Available: "2014-12"
 7140	blue spinning wheel	0		Last Available: "2014-12"
 7141	adjusted ionized hi-octane carrot juice	0		Effect: "Serendipi Tea", Effect Duration: 61, Last Available: "2014-12"
@@ -7043,9 +7043,9 @@
 7154	pulsating filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	fuchsia spinning glass	0		Last Available: "2014-12"
-7157	narrow perfumed Rosewater's fire hose of Flo-Jo	0		Mysticality Percent: +30, Stench Resistance: +5, Initiative: +100, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	narrow perfumed Rosewater's fire hose of Flo-Jo	0		Mysticality Percent: +30, Stench Resistance: +5, Initiative: +100, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	rotten fireman's lunch	4	crappy	Last Available: "2014-12"
-7159	wobbly blue knitted crafty plain paper hat of chilblains	0		Maximum MP: +10, Cold Damage: +25, Cold Resistance: +3, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	wobbly blue knitted crafty plain paper hat of chilblains	0		Maximum MP: +10, Cold Damage: +25, Cold Resistance: +3, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	stale narrow ice cream sandwich	3	decent	Last Available: "2014-12"
 7161	Newton's supercool &quot;honey&quot; dipper of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Experience (Mysticality): +3, Last Available: "2014-12"
 7162	rotten plumber's lunch	4	crappy	Last Available: "2014-12"
@@ -7055,7 +7055,7 @@
 7166	decent can of Adultwitch&trade;	3	good	Last Available: "2014-12"
 7167	cold-filtered tumbling tumbling smudge stick	0		Effect: "Innately Truthy", Effect Duration: 15, Last Available: "2014-12"
 7168	electrified wall	0		Effect: "Pwnd", Effect Duration: 38, Last Available: "2014-12"
-7169	special drinkable tankard of ale	4	good	Effect: "Chock Full o' Nanites", Effect Duration: 10, Last Available: "2014-12"
+7169	drinkable special tankard of ale	4	good	Effect: "Chock Full o' Nanites", Effect Duration: 10, Last Available: "2014-12"
 7170	liquefied scroll case	0		Effect: "Work For Hours a Week", Effect Duration: 28, Last Available: "2014-12"
 7171	extra-dry liquefied bouncing jug of &quot;wine&quot;	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 54, Last Available: "2014-12"
 7172	green juggling ball	0		Last Available: "2014-12"
@@ -7065,7 +7065,7 @@
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	aerosolized irradiated pressed crappy waiter disguise	0		Effect: "Impregnably Delicious", Effect Duration: 66
 7178	Copperhead Charm	0		
-7179	bouncing shaking The First Pizza	0		
+7179	shaking bouncing The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7078,7 +7078,7 @@
 7189	wholesome unrequired jacket	0		Maximum HP Percent: +10
 7190	tommy gun of Gandalf	0		Spell Critical Percent: +20, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	fuchsia drum of tommy ammo	0		
-7192	upside-down shaking throwing knife	0		
+7192	shaking upside-down throwing knife	0		
 7193	lime green throwing spoon	0		
 7194	tumbling throwing fork	0		
 7195	mirror zippy stylish breadchucks	0		Moxie: +25, Initiative: +20
@@ -7092,34 +7092,34 @@
 7203	bouncing flame-retardant Saturday Night Special	0		Hot Resistance: +1
 7204	twirling pulsating lynyrd snare	0		
 7205	purple wobbly wobbly Fonzie's fleetwood chain	0		Experience (Moxie): +1
-7206	drinkable watered-down Green Manalishi	2	good	
+7206	watered-down drinkable Green Manalishi	2	good	
 7207	rosy-cheeked blade	0		Maximum HP Percent: +30
 7208	fire of unknown origin	0		
 7209	narrow eagle's milk	1	awesome	
-7210	double-dry spinning upside-down eagle feather	0		Effect: "Radium Radicality", Effect Duration: 61
+7210	double-dry upside-down spinning eagle feather	0		Effect: "Radium Radicality", Effect Duration: 61
 7211	nitrogenated one pill	0		Effect: "Nutrient-Rich", Effect Duration: 60
 7212	squat Jefferson wings of the brute	0		Muscle Percent: +30
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	miniature bland fleetwood mac 'n' cheese	2	decent	
+7215	bland miniature fleetwood mac 'n' cheese	2	decent	
 7216	green lynyrd skin	0		
 7217	rosewater-soaked lynyrdskin cap	0		Stench Resistance: +3, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	lynyrdskin tunic of courage	0		Spooky Resistance: +3
 7219	ghostly narrow mirror ribald lynyrdskin breeches	0		Sleaze Damage: +10, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	shaking cigarette lighter	0		
 7221	priceless diamond	0		
-7222	drinkable cyan jittery Flamin' Whatshisname	4	good	
+7222	drinkable jittery cyan Flamin' Whatshisname	4	good	
 7223	modified lynyrd musk	0		Effect: "Familial Ties", Effect Duration: 33
 7224	inspector's quilted Kashmir sweater	0		Damage Absorption: +40, Item Drop: +15
-7225	fancy jumbo tasty custard pie	5	awesome	Effect: "Bright!", Effect Duration: 50
+7225	jumbo tasty fancy custard pie	5	awesome	Effect: "Bright!", Effect Duration: 50
 7226	tea for one	1	good	
 7227	lousy huge bottle of Evermore	3	decent	
 7228	box	0		
 7229	delicious wine	3	awesome	
 7230	artisanal fortified mirror rum	5	EPIC	
-7231	fancy watered-down lousy Murderer's Punch	2	decent	Effect: "From Nantucket", Effect Duration: 50
+7231	lousy watered-down fancy Murderer's Punch	2	decent	Effect: "From Nantucket", Effect Duration: 50
 7232	moldy velvet cake	4	crappy	
-7233	diffused blurry blinking letter	0		Effect: "Shortened", Effect Duration: 56
+7233	diffused blinking blurry letter	0		Effect: "Shortened", Effect Duration: 56
 7234	bouncing frosty rosy-cheeked book	0		Maximum HP Percent: +30, Cold Spell Damage: +10
 7235	bouncing gravedigger's razor-sharp masque	0		Weapon Damage Percent: +25, Spooky Damage: +10, Single Equip
 7236	red-hot poker of dire peril	0		Weapon Damage: +20
@@ -7144,7 +7144,7 @@
 7255	aged mini-martini	3	awesome	
 7256	smoke grenade	0		
 7257	dried pulsating molotov soda	1	decent	
-7258	pickled improved upside-down huge pile of ashes	0		Effect: "The Wisdom... of the Future", Effect Duration: 55
+7258	pickled improved huge upside-down pile of ashes	0		Effect: "The Wisdom... of the Future", Effect Duration: 55
 7259	jittery crate of firebombs	0		
 7260	firebomb	0		
 7261	avaricious Sherlock's scorching Sneaky Pete's basket	0		Hot Damage: +25, Item Drop: +25, Meat Drop: +30
@@ -7184,9 +7184,9 @@
 7295	pulsating ghostly elevent	0		Last Available: "2014-03"
 7296	twirling lion tamer's ruddy elevenderizing hammer	0		Maximum HP Percent: +40, Experience (familiar): +2, Last Available: "2014-03"
 7297	asbestos-lined Professor What T-Shirt	0		Hot Resistance: +5
-7298	skewed cyan heavy-duty bendy straw	0		
+7298	cyan skewed heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
-7300	pulsating huge sewing kit	0		
+7300	huge pulsating sewing kit	0		
 7301	jittery Spookyraven billiards room key	0		
 7302	shaking Spookyraven library key	0		
 7303	red Lady Spookyraven's necklace	0		
@@ -7211,18 +7211,18 @@
 7322	deionized Stephen's secret formula	0		Effect: "Poker Faced", Effect Duration: 34
 7323	blinking inspector's Jacob's rung of Flo-Jo	0		Item Drop: +15, Initiative: +100
 7324	dried huge purple battery	1		Effect: "Towering Strength", Effect Duration: 20
-7325	artisanal pulsating mirror snakebite	3	EPIC	
+7325	artisanal mirror pulsating snakebite	3	EPIC	
 7326	skewed wicked Samson's rubber ribcage	0		Experience (Muscle): +5, Spell Damage: +5, Damage Reduction: 7
 7327	twisted olive shaking synthetic marrow	1		
 7328	wet Vulcanized blurry funny bone	0		Effect: "Craft Tea", Effect Duration: 49
 7329	Usain Bolt's groovy half-melted spoon	0		Moxie Percent: +10, Initiative: +80
-7330	modified pulsating jittery red the funk	1		Effect: "Arcane in the Brain", Effect Duration: 5
+7330	modified red pulsating jittery the funk	1		Effect: "Arcane in the Brain", Effect Duration: 5
 7331	rotten big gunky chicken	5	crappy	
 7332	stylish doll head	0		Moxie: +25
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	lime green resourceful paddle-ball of the businessman	0		Maximum MP: +50, Meat Drop: +50
-7336	super-galvanized boiled narrow tumbling sound effects record	0		Effect: "Pla-see-bo", Effect Duration: 60
+7336	super-galvanized boiled tumbling narrow sound effects record	0		Effect: "Pla-see-bo", Effect Duration: 60
 7337	alphabet block	0		
 7338	altered dancer	0		Effect: "The Halls of Muscularity", Effect Duration: 52
 7339	music box mechanism	0		
@@ -7234,16 +7234,16 @@
 7345	ornate picture frame	0		
 7346	ghostly doll-eye amulet	0		Single Equip
 7347	wizardly ghost toga of the cougar	0		Mysticality: +25, Moxie: +20
-7348	moldy half-sized sheet cake	2	crappy	
+7348	half-sized moldy sheet cake	2	crappy	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	Temple Grandin's Tesla sinister Staff of the Electric Range	0		Spell Damage: +10, Familiar Weight: +7, MP Regen Min: 7, MP Regen Max: 10
-7352	gigantic adequate blurry deluxe layer cake	9	good	
+7352	adequate gigantic blurry deluxe layer cake	9	good	
 7353	chunk of hot iron	0		
 7354	perfectly mixed wobbly red-hot boilermaker	4	EPIC	
 7355	squat experienced coal shovel	0		Experience: +2, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	quantum maroon hot coal	0		Effect: "Initiative and Let Die", Effect Duration: 11
-7357	triple-boiled concentrated twirling squat coal dust	0		Effect: "Frozen Shoulders", Effect Duration: 30
+7357	triple-boiled concentrated squat twirling coal dust	0		Effect: "Frozen Shoulders", Effect Duration: 30
 7358	ghostly horrifying sharpshooter's smooth Bram's choker	0		Moxie: +15, Critical Hit Percent: +10, Spooky Damage: +25, Single Equip
 7359	narrow spinning plaid swatch	0		
 7360	plaid bandage	0		
@@ -7256,7 +7256,7 @@
 7367	chilled Vulcanized spinning industrial strength starch	0		Effect: "items.enh", Effect Duration: 24, Wiki Name: "industrial strength starch"
 7368	thick bland narrow extra-flat panini	5	decent	
 7369	ionized ghostly mangled finger	0		Effect: "Gamer Rage", Effect Duration: 48
-7370	practically non-alcoholic delicious ghostly fuchsia Psychotic Train wine	1	awesome	
+7370	practically non-alcoholic delicious fuchsia ghostly Psychotic Train wine	1	awesome	
 7371	crazy hobo notebook	0		
 7372	moldy pie man was not meant to eat	3	crappy	
 7373	skewed occult sommelier's towel	0		Spell Damage Percent: +25
@@ -7282,7 +7282,7 @@
 7393	pressed alkaline double-Vulcanized Gene Tonic: Horror	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 68, Last Available: "2014-04"
 7394	corrupted tarnished yellow Gene Tonic: Fish	0		Effect: "Cancer Rising", Effect Duration: 56, Last Available: "2014-04"
 7395	ionized Gene Tonic: Goblin	0		Effect: "Boilermade", Effect Duration: 14, Last Available: "2014-04"
-7396	non-modified non-chilled non-modified blinking wobbly Gene Tonic: Pirate	0		Effect: "Super Vision", Effect Duration: 22, Last Available: "2014-04"
+7396	non-modified non-chilled non-modified wobbly blinking Gene Tonic: Pirate	0		Effect: "Super Vision", Effect Duration: 22, Last Available: "2014-04"
 7397	aerosolized dry wet bouncing Gene Tonic: Plant	0		Effect: "Chalky White Pallor", Effect Duration: 30, Last Available: "2014-04"
 7398	double-ionized polarized lime green Gene Tonic: Weird	0		Effect: "Heal Thy Nanoself", Effect Duration: 40, Last Available: "2014-04"
 7399	non-quantum Gene Tonic: Elf	0		Effect: "Blubbered Up", Effect Duration: 13, Last Available: "2014-04"
@@ -7324,37 +7324,37 @@
 7435	irradiated concentrated ghostly Stemonitis Staticus mushroom	0		Effect: "Colorful Gratitude", Effect Duration: 42, Last Available: "2014-05"
 7436	diffused wobbly Tremella Tarantella mushroom	0		Effect: "Well-Lubed", Effect Duration: 40, Last Available: "2014-05"
 7437	mirror Pastaco shell	0		Last Available: "2014-05"
-7438	big adequate blue Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
+7438	adequate big blue Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
 7439	stale Brain Food Pastaco	3	decent	Last Available: "2014-05"
-7440	normal mirror blurry Cool Brunch Pastaco	3	good	Last Available: "2014-05"
+7440	normal blurry mirror Cool Brunch Pastaco	3	good	Last Available: "2014-05"
 7441	decent twirling Medical Pastaco	3	good	Last Available: "2014-05"
 7442	stale Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	adequate Ludovico Pastaco	3	good	Last Available: "2014-05"
-7444	spirit-forward perfectly mixed mirror fuchsia overpowering mushroom wine	5	EPIC	Last Available: "2014-05"
+7444	spirit-forward perfectly mixed fuchsia mirror overpowering mushroom wine	5	EPIC	Last Available: "2014-05"
 7445	bad complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	lousy huge smooth mushroom wine	4	decent	Last Available: "2014-05"
 7447	artisanal strong blood-red mushroom wine	5	EPIC	Last Available: "2014-05"
 7448	triple-distilled mediocre buzzing mushroom wine	7	decent	Last Available: "2014-05"
 7449	acceptable swirling mushroom wine	3	good	Last Available: "2014-05"
-7450	adequate enchanted super-sized Taco Dan's Basic Taco Dan Taco	5	good	Effect: "Musky", Effect Duration: 25, Last Available: "2014-05"
+7450	enchanted super-sized adequate Taco Dan's Basic Taco Dan Taco	5	good	Effect: "Musky", Effect Duration: 25, Last Available: "2014-05"
 7451	decent thick Taco Dan's Taco Fish Fish Taco	5	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	triple-distilled perfectly mixed gray regular-size brogurt	6	EPIC	Last Available: "2014-05"
 7454	artisanal upside-down super-size brogurt	4	EPIC	Last Available: "2014-05"
-7455	artisanal special yellow broberry brogurt	3	EPIC	Effect: "Boon of the Storm Tortoise", Effect Duration: 20, Last Available: "2014-05"
+7455	special artisanal yellow broberry brogurt	3	EPIC	Effect: "Boon of the Storm Tortoise", Effect Duration: 20, Last Available: "2014-05"
 7456	fortified artisanal brocolate brogurt	5	EPIC	Last Available: "2014-05"
-7457	drinkable enchanted wobbly French bronilla brogurt	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 5, Last Available: "2014-05"
+7457	enchanted drinkable wobbly French bronilla brogurt	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 5, Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	shaking Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
-7460	tumbling huge Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
+7460	huge tumbling Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts	0		Item Drop: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Brogre brorts	0		Item Drop: +5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	slick Brogre brolo shirt	0		Moxie: +10, Last Available: "2014-05"
-7464	cyan smartaleck's Brogre bucket hat	0		Moxie Percent: +30, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	cyan smartaleck's Brogre bucket hat	0		Moxie Percent: +30, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	purple Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	family-friendly foul-smelling 8-billed baseball cap of the boozehound	0		Stench Damage: +10, Sleaze Resistance: +1, Booze Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	family-friendly foul-smelling 8-billed baseball cap of the boozehound	0		Stench Damage: +10, Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	Usain Bolt's rosewater-soaked forbidden extremely wet T-shirt	0		Spell Damage Percent: +50, Stench Resistance: +3, Initiative: +80, Last Available: "2014-05"
 7470	Oprah's hardy shrimp fork of the overflowing toilet	0		Maximum HP: +50, Maximum MP Percent: +50, Stench Spell Damage: +50, Last Available: "2014-05"
 7471	denatured quadruple-colloidal alkaline BROS Energy Drink	0		Effect: "You Liver", Effect Duration: 46, Last Available: "2014-05"
@@ -7367,9 +7367,9 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	extra-chilled altered sugar fairy	0		Effect: "Tenacity of the Snapper", Effect Duration: 55, Last Available: "2014-05"
 7480	ionized sugar bunny	0		Effect: "Low on the Hog", Effect Duration: 36, Last Available: "2014-05"
-7481	shaking sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	shaking sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	extra-dry aged Rompedores de Fantasmas	5	awesome	
-7483	practically non-alcoholic smooth La Fantasma y La Oscuridad	1	awesome	
+7483	smooth practically non-alcoholic La Fantasma y La Oscuridad	1	awesome	
 7484	smooth Fantasma en la M&aacute;quina	4	awesome	
 7485	skewed loosening powder	0		
 7486	castoreum	0		
@@ -7377,7 +7377,7 @@
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	upside-down triatomaceous dust	0		
-7491	delicious boozy bottle of Chateau de Vinegar	5	awesome	
+7491	boozy delicious bottle of Chateau de Vinegar	5	awesome	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
@@ -7415,21 +7415,21 @@
 7526	bouncing weird space book	0		Last Available: "2014-05"
 7527	pulsating alien force field disruptor bean	0		Last Available: "2014-05"
 7528	bouncing resourceful beefy government-issued night-vision goggles	0		Muscle: +10, Maximum MP: +50, Single Equip, Last Available: "2014-05"
-7529	bland fancy loaf of alien bread	4	decent	Effect: "Powdered", Effect Duration: 45, Last Available: "2014-05"
+7529	fancy bland loaf of alien bread	4	decent	Effect: "Powdered", Effect Duration: 45, Last Available: "2014-05"
 7530	moldy grilled cheese sandwich	3	crappy	Last Available: "2014-05"
 7531	compressed jittery alien protein powder	1	good	Last Available: "2014-05"
-7532	lousy watered-down pulsating rocket fuel	2	decent	Last Available: "2014-05"
+7532	watered-down lousy pulsating rocket fuel	2	decent	Last Available: "2014-05"
 7533	upside-down alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	practically non-alcoholic aged stealth bomber	1	awesome	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of the pedagogue	0		Experience: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	lard-coated space beast fur pants	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	space beast fur hat of the pedagogue	0		Experience: +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	lard-coated space beast fur pants	0		Sleaze Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	hale space beast fur whip	0		Maximum HP: +20, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	pulsating squat upside-down chilly space heater of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +5, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	pulsating squat upside-down chilly space heater of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +5, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	tumbling space bar	0		Last Available: "2014-05"
 7545	artisanal space port	3	EPIC	Last Available: "2014-05"
 7546	horrifying frightening space needle	0		Spooky Damage: 30, Last Available: "2014-05"
@@ -7444,7 +7444,7 @@
 7555	page	0		
 7556	elephant gift	0		
 7557	pressed irradiated double-unsweetened lime green huge blood cells	0		Effect: "Broberry Brotality", Effect Duration: 58
-7558	hand-crafted strong wine	5	EPIC	
+7558	strong hand-crafted wine	5	EPIC	
 7559	double-flattened nitrogenated gummi turtle	0		Effect: "Wet Willied", Effect Duration: 34
 7560	turtle-shaped rock	0		
 7561	deionized dry blinking giraffe-necked turtle	0		Effect: "Artificially Sweet", Effect Duration: 12
@@ -7476,15 +7476,15 @@
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	mirror Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	perfectly mixed tumbling glass of &quot;milk&quot;	4	EPIC	Last Available: "2014-07"
-7590	smooth watered-down cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
+7590	watered-down smooth cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
 7591	drinkable practically non-alcoholic thermos of &quot;whiskey&quot;	1	good	Last Available: "2014-07"
-7592	weak drinkable Lucky Lindy	2	good	Last Available: "2014-07"
+7592	drinkable weak Lucky Lindy	2	good	Last Available: "2014-07"
 7593	artisanal Bee's Knees	3	EPIC	Last Available: "2014-07"
 7594	practically non-alcoholic mediocre Sockdollager	1	decent	Last Available: "2014-07"
 7595	tolerable Ish Kabibble	3	good	Last Available: "2014-07"
 7596	practically non-alcoholic acceptable Hot Socks	1	good	Last Available: "2014-07"
 7597	drinkable twirling Phonus Balonus	4	good	Last Available: "2014-07"
-7598	artisanal fortified Flivver	5	EPIC	Last Available: "2014-07"
+7598	fortified artisanal Flivver	5	EPIC	Last Available: "2014-07"
 7599	tolerable Sloppy Jalopy	4	good	Last Available: "2014-07"
 7600	boiled flattened huge flame	0		Effect: "Greasy Visage", Effect Duration: 43
 7601	altered energized temporary yak tattoo	0		Effect: "Truly Gritty", Effect Duration: 29
@@ -7504,7 +7504,7 @@
 7615	aerosolized pygmy adder oil	0		Effect: "Artificially Sweet", Effect Duration: 62
 7616	polarized pygmy witchhazel	0		Effect: "Salty Mouth", Effect Duration: 30
 7617	dry gray short deposition	0		Effect: "Turtle Titters", Effect Duration: 66
-7618	corrupted improved squat green straw pole	0		Effect: "Feline Ferocity", Effect Duration: 62
+7618	corrupted improved green squat straw pole	0		Effect: "Feline Ferocity", Effect Duration: 62
 7619	denatured quantum copperhead potion	0		Effect: "Truly Gritty", Effect Duration: 41
 7620	polymerized ninja fear powder	0		Effect: "Human-Beast Hybrid", Effect Duration: 67
 7621	activated ninja eyeblack	0		Effect: "Cock of the Walk", Effect Duration: 14
@@ -7517,7 +7517,7 @@
 7628	quadruple-pressed denatured irradiated gray dancing fan	0		Effect: "Thick-Skinned", Effect Duration: 11
 7629	pressed boiled aerosolized twirling green page of the Necrohobocon	0		Effect: "Bastard!", Effect Duration: 21
 7630	quadruple-polymerized pressed mirror magic powder	0		Effect: "Dances with Tweedles", Effect Duration: 30
-7631	nitrogenated non-concentrated tarnished shaking narrow bouncing friar's tonsure	0		Effect: "Cautious Prowl", Effect Duration: 27
+7631	nitrogenated non-concentrated tarnished narrow bouncing shaking friar's tonsure	0		Effect: "Cautious Prowl", Effect Duration: 27
 7632	polarized government-issue identification badge	0		Effect: "Mathematically Precise", Effect Duration: 28
 7633	triple-galvanized non-frozen wet alien hologram projector	0		Effect: "Smokin'", Effect Duration: 62
 7634	tarnished ionized upside-down irradiated turtle	0		Effect: "Sparkly!", Effect Duration: 31
@@ -7581,21 +7581,21 @@
 7692	ruddy wicked hand whip of Gandalf	0		Spell Damage: +5, Maximum HP Percent: +40, Spell Critical Percent: +20, Last Available: "2014-08"
 7693	wool boxer's glow-in-the-dark necklace of Flo-Jo	0		Muscle Percent: +10, Cold Resistance: +1, Initiative: +100, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	lightning-fast veiny cap gun of the cougar	0		Moxie: +20, Maximum HP: +10, Initiative: +40, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	lightning-fast veiny cap gun of the cougar	0		Moxie: +20, Maximum HP: +10, Initiative: +40, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	tumbling Tesla cassette player of Leguizamo	0		Monster Level: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	spinning rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	super-polymerized dry olive confiscated comic book	0		Effect: "Sourpuss", Effect Duration: 36, Last Available: "2014-08"
 7701	denatured irradiated confiscated cell phone	0		Effect: "Helvella Health", Effect Duration: 31, Last Available: "2014-08"
-7702	concentrated galvanized mirror green confiscated love note	0		Effect: "Full of Vinegar", Effect Duration: 20, Last Available: "2014-08"
+7702	concentrated galvanized green mirror confiscated love note	0		Effect: "Full of Vinegar", Effect Duration: 20, Last Available: "2014-08"
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	green LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	ghostly purple The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	polarized denatured blue rubber nubbin	0		Effect: "Super Speed", Effect Duration: 32, Last Available: "2014-08"
 7708	hardened grievous rubber cape	0		Weapon Damage Percent: +50, Damage Reduction: 3, Last Available: "2014-08"
-7709	nasty crafty healthy slick Thor's Pliers	0		Moxie: +10, Maximum HP Percent: +20, Maximum MP: +10, Stench Damage: +5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	nasty crafty healthy slick Thor's Pliers	0		Moxie: +10, Maximum HP Percent: +20, Maximum MP: +10, Stench Damage: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	oxidized narrow candy UFOs	0		Effect: "Sweet Incentive", Effect Duration: 55
 7711	horrifying water wings for babies of the wise owl	0		Mysticality: +20, Spooky Damage: +25
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
@@ -7615,7 +7615,7 @@
 7726	ionized flattened Dennis's blessing of Minerva	0		Effect: "All Branned Up", Effect Duration: 54
 7727	polarized Burt's blessing of Bacchus	0		Effect: "Dance Interpreter", Effect Duration: 37
 7728	deionized huge Freddie's blessing of Mercury	0		Effect: "Sausage Festive", Effect Duration: 19
-7729	pulsating maroon Chroner trigger	0		
+7729	maroon pulsating Chroner trigger	0		
 7730	mirror Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
 7732	Black Bart's Booty	0		Skill: "Pirate Bellow"
@@ -7636,17 +7636,17 @@
 7747	Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	teal Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
-7750	narrow tumbling Xiblaxian 5D printer	0		Last Available: "2014-09"
+7750	tumbling narrow Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	curative Xiblaxian xeno-detection goggles	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2014-09"
-7753	foul-smelling Oprah's Xiblaxian stealth cowl	0		Maximum MP Percent: +50, Stench Damage: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	foul-smelling Oprah's Xiblaxian stealth cowl	0		Maximum MP Percent: +50, Stench Damage: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	upside-down Xiblaxian stealth trousers of dire peril	0		Weapon Damage: +20, Item Drop: +5, Last Available: "2014-09"
 7755	blinking squat healthy rock-hard Xiblaxian stealth vest	0		Damage Reduction: 5, Maximum HP Percent: +20, Last Available: "2014-09"
 7756	normal blurry Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
-7757	irresponsibly strong artisanal twirling Xiblaxian space-whiskey	8	EPIC	Last Available: "2014-09"
+7757	artisanal irresponsibly strong twirling Xiblaxian space-whiskey	8	EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	adjusted They liver	0		Effect: "The Wisdom... of the Future", Effect Duration: 34, Last Available: "2014-09"
-7760	massive toothsome They liver popsicle	6	awesome	Last Available: "2014-09"
+7760	toothsome massive They liver popsicle	6	awesome	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7665,15 +7665,15 @@
 7776	fireproof lard-coated foul-smelling Sasq&trade; watch	0		Stench Damage: +10, Sleaze Spell Damage: +25, Hot Resistance: +3, Single Equip, Last Available: "2014-10"
 7777	stanky scorching studded smoker's cloak	0		Damage Absorption: +80, Hot Damage: +25, Stench Spell Damage: +25, Last Available: "2014-10"
 7778	prompt Jim Carey's extremely unsafe camouflage T-shirt of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +100, Monster Level: +25, Adventures: +3, Last Available: "2014-10"
-7779	improved dry shaking wobbly experimental serum G-9	0		Effect: "You Know When to Walk Away", Effect Duration: 15, Last Available: "2014-10"
+7779	improved dry wobbly shaking experimental serum G-9	0		Effect: "You Know When to Walk Away", Effect Duration: 15, Last Available: "2014-10"
 7780	scandalous sharpshooter's Herculean heavy-duty clipboard	0		Experience (Muscle): +1, Critical Hit Percent: +10, Sleaze Damage: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	jittery avaricious quilted smartaleck's battery-powered drill of the cheetah	0		Moxie Percent: +30, Damage Absorption: +40, Meat Drop: +30, Initiative: +60, Last Available: "2014-10"
 7782	tasty limp broccoli	4	awesome	Last Available: "2014-10"
-7783	chaotic experienced hat of Tarzan	0		Experience: +2, Experience (Muscle): +3, Spell Critical Percent: +10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	chaotic experienced hat of Tarzan	0		Experience: +2, Experience (Muscle): +3, Spell Critical Percent: +10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	triple-nitrogenated monkey barf	0		Effect: "Liquid Courage", Effect Duration: 14, Last Available: "2014-10"
 7785	double-ionized candy	0		Effect: "Truly Gritty", Effect Duration: 20, Last Available: "2014-10"
 7786	pulsating knitted ruddy jangly bracelet of the scaredy-cat	0		Maximum HP Percent: +40, Monster Level: -15, Cold Resistance: +3, Last Available: "2014-10"
-7787	supercool cuddly teddy bear	0		Moxie Percent: +20, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	supercool cuddly teddy bear	0		Moxie Percent: +20, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	supercool first-aid pouch of vim and vigor	0		Moxie Percent: +20, Maximum HP Percent: +50, Last Available: "2014-10"
 7790	lime green khaki duffel bag	0		Last Available: "2014-10"
@@ -7685,8 +7685,8 @@
 7796	spoiled jittery warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	moldy karma shawarma	3	crappy	Last Available: "2014-10"
 7798	bad huge Jungle Juice	3	decent	Last Available: "2014-10"
-7799	bad boozy tumbling Amnesiac Ale	5	decent	Last Available: "2014-10"
-7800	weak lousy twirling Highest Bitter	2	decent	Last Available: "2014-10"
+7799	boozy bad tumbling Amnesiac Ale	5	decent	Last Available: "2014-10"
+7800	lousy weak twirling Highest Bitter	2	decent	Last Available: "2014-10"
 7801	personal trainer's mercenary pistol of vim and vigor	0		Experience Percent (Muscle): +10, Maximum HP Percent: +50, Last Available: "2014-10"
 7802	mercenary rifle of the wise owl of the brazier	0		Mysticality: +20, Hot Spell Damage: +25, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7714,7 +7714,7 @@
 7825	twirling pulsating lightning-fast flame-wreathed earbuds of Flo-Jo	0		Hot Spell Damage: +10, Initiative: 140, Single Equip
 7826	up-at-dawn Oprah's thinker's iFlail	0		Mysticality: +10, Maximum MP Percent: +50, Adventures: +5
 7827	stale olive unidentifiable dried fruit	3	decent	
-7828	enchanted artisanal flat cider	3	EPIC	Effect: "Aided and Abetted", Effect Duration: 35
+7828	artisanal enchanted flat cider	3	EPIC	Effect: "Aided and Abetted", Effect Duration: 35
 7829	Usain Bolt's educational trench lighter of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Initiative: +80, Last Available: "2014-10"
 7830	denatured flattened pulsating experimental serum P-00	0		Effect: "Wet Rub", Effect Duration: 29, Last Available: "2014-10"
 7831	upside-down blinking military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7743,10 +7743,10 @@
 7854	jittery stanky plastic Crimbot	0		Stench Spell Damage: +25, Last Available: "2014-12"
 7855	plastic Crimbomega of the detective	0		Item Drop: +20, Last Available: "2014-12"
 7856	vacuum-sealed denatured wobbly flask of mining oil	0		Effect: "Sausage Festive", Effect Duration: 19, Last Available: "2014-12"
-7857	mirror radiation-resistant helmet of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	occult servo-assisted exo-pants	0		Spell Damage Percent: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	mirror radiation-resistant helmet of terror	0		Spooky Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	occult servo-assisted exo-pants	0		Spell Damage Percent: +25, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	crafty beefcake's high-energy mining laser	0		Muscle: +25, Maximum MP: +10, Last Available: "2014-12"
-7860	cyan upside-down peppermint tailings	0		Last Available: "2014-12"
+7860	upside-down cyan peppermint tailings	0		Last Available: "2014-12"
 7861	huge nugget of Crimbonium	0		Last Available: "2014-12"
 7862	yellow cylindrical mold	0		Last Available: "2014-12"
 7863	mirror Crimbonium fuel rod	0		Last Available: "2014-12"
@@ -7797,7 +7797,7 @@
 7908	recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	recovered elf pocketwatch	0		Last Available: "2014-12"
-7911	yellow pulsating recovered elf photo album	0		Last Available: "2014-12"
+7911	pulsating yellow recovered elf photo album	0		Last Available: "2014-12"
 7912	recovered elf smartphone	0		Last Available: "2014-12"
 7913	fuchsia Jack Frost's supercharged Size XI Wizard's Robe of the wise owl	0		Mysticality: +20, Maximum MP Percent: +30, Cold Spell Damage: +50, Last Available: "2014-09"
 7914	modified Bit O' Quail Spleen	0		Effect: "BOOsted", Effect Duration: 51
@@ -7826,7 +7826,7 @@
 7944	tooth	0		
 7945	table	0		
 7946	family-friendly greasy frightening outlaw bandana	0		Spooky Damage: +5, Sleaze Spell Damage: +10, Sleaze Resistance: +1
-7947	artisanal spirit-forward whiskey in a broken glass	5	EPIC	
+7947	spirit-forward artisanal whiskey in a broken glass	5	EPIC	
 7948	acceptable yellow shot of mescal	4	good	
 7949	drinkable special tumbling yellow glass of herbal tequila	3	good	Effect: "20-20 Second Sight", Effect Duration: 40
 7950	minin' dynamite	0		
@@ -7841,7 +7841,7 @@
 7959	letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	purple jittery greedy Jeselnik's occult Staff of Ed of the empath	0		Spell Damage Percent: +25, Familiar Weight: +5, Sleaze Damage: +25, Meat Drop: +20
-7962	blurry blurry green Eye of Ed	0		
+7962	blurry green blurry Eye of Ed	0		
 7963	amulet	0		
 7964	squat occult Staff of Fats	0		Spell Damage Percent: +25
 7965	Holy MacGuffin	0		
@@ -7850,7 +7850,7 @@
 7968	pulsating twirling topiary nugglet	0		
 7969	beehive	0		
 7970	mirror boning knife	0		
-7971	purple shaking Aggressive Carrot	0		Free Pull
+7971	shaking purple Aggressive Carrot	0		Free Pull
 7972	dried mummified fig	1	good	Effect: "Lemony Goodness", Effect Duration: 35
 7973	mixed mummified loaf of bread	1	EPIC	
 7974	powdered olive mummified beef haunch	1	good	
@@ -7876,22 +7876,22 @@
 7994	pepper mill of the ox of the sewer	0		Muscle: +20, Stench Damage: +25, Last Available: "2015-12"
 7995	forbidden pelerine of the blizzard	0		Spell Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2015-12"
 7996	ruddy phantom mask of the ox	0		Muscle: +20, Maximum HP Percent: +40, Single Equip, Last Available: "2015-12"
-7997	vaporized upside-down spinning polyesterene powder	1		Last Available: "2015-12"
+7997	vaporized spinning upside-down polyesterene powder	1		Last Available: "2015-12"
 7998	twisted skewed mirror powder	1		Effect: "Lifted Spirits", Effect Duration: 20, Last Available: "2015-12"
 7999	concentrated cold-filtered cyan choco-Crimbot	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 14, Last Available: "2014-12"
 8000	denatured dry smart watch	0		Effect: "Vinegavotte", Effect Duration: 45, Last Available: "2014-12"
 8001	quantum energized squat augmented-reality shades	0		Effect: "Mushroom Melody", Effect Duration: 48, Last Available: "2014-12"
-8002	Annie Oakley's toy Crimbot mega face	0		Critical Hit Percent: +20, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	wholesome toy Crimbot power glove	0		Maximum HP Percent: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	dance instructor's toy Crimbot super fist	0		Experience Percent (Moxie): +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	skewed weightlifter's toy Crimbot rocket legs	0		Muscle: +15, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
-8006	alkaline enhanced gray ghostly ghostly Crimbot battery	0		Effect: "Jingle Jangle Jingle", Effect Duration: 36, Last Available: "2014-12"
+8002	Annie Oakley's toy Crimbot mega face	0		Critical Hit Percent: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	wholesome toy Crimbot power glove	0		Maximum HP Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	dance instructor's toy Crimbot super fist	0		Experience Percent (Moxie): +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	skewed weightlifter's toy Crimbot rocket legs	0		Muscle: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8006	alkaline enhanced ghostly ghostly gray Crimbot battery	0		Effect: "Jingle Jangle Jingle", Effect Duration: 36, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	pulsating Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	jittery jittery lard-coated thinker's Crimbomega drive chain of horror	0		Mysticality: +10, Spooky Spell Damage: +25, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	jittery jittery lard-coated thinker's Crimbomega drive chain of horror	0		Mysticality: +10, Spooky Spell Damage: +25, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7900,7 +7900,7 @@
 8018	enhanced tarnished altered and rain stick	0		Effect: "Painted-On Bikini", Effect Duration: 30
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	bland Choco-Mint patty	3	decent	Last Available: "2015-01"
-8021	practically non-alcoholic drinkable hot mint schnocolate	1	good	Last Available: "2015-01"
+8021	drinkable practically non-alcoholic hot mint schnocolate	1	good	Last Available: "2015-01"
 8022	modified wobbly homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	spinning foreign language tapes	0		Last Available: "2015-01"
@@ -7947,15 +7947,15 @@
 8066	twisted	1	EPIC	Last Available: "2015-12"
 8067	mirror nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
-8069	olive tumbling Stembridge sidearm	0		Familiar Weight: +5
+8069	tumbling olive Stembridge sidearm	0		Familiar Weight: +5
 8070	pulsating warehouse map page	0		
 8071	warehouse inventory page	0		
 8072	jittery janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	vibrating Fonzie's Spelunker's fedora of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +1, Maximum MP Percent: +10, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	vibrating Fonzie's Spelunker's fedora of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +1, Maximum MP Percent: +10, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	rosewater-soaked hardened Spelunker's whip of the boozehound	0		Damage Reduction: 3, Stench Resistance: +3, Booze Drop: +100, Last Available: "2015-12"
-8076	shellacked stylish Spelunker's khakis of the glutton	0		Moxie: +25, Damage Reduction: 7, Food Drop: +100, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
-8077	blinking blinking tumbling Spelunker's Guild prize sack	0		Last Available: "2015-12"
+8076	shellacked stylish Spelunker's khakis of the glutton	0		Moxie: +25, Damage Reduction: 7, Food Drop: +100, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8077	tumbling blinking blinking Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	red LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
@@ -7984,7 +7984,7 @@
 8109	rosy-cheeked ascot of Flo-Jo	0		Maximum HP Percent: +30, Initiative: +100, Single Equip, Last Available: "2017-12"
 8110	sharpshooter's beefy attache case	0		Muscle: +10, Critical Hit Percent: +10, Last Available: "2017-12"
 8111	blue horrifying nippy accordion	0		Cold Damage: +10, Spooky Damage: +25, Song Duration: 10, Last Available: "2017-12"
-8112	distilled tumbling blurry aerosolized	1		Last Available: "2017-12"
+8112	distilled blurry tumbling aerosolized	1		Last Available: "2017-12"
 8113	flame-retardant wig of horror	0		Spooky Spell Damage: +25, Hot Resistance: +1, Last Available: "2017-12"
 8114	flame-wreathed winch crank of the boozehound	0		Hot Spell Damage: +10, Booze Drop: +100, Single Equip, Last Available: "2017-12"
 8115	jittery forbidden wizardly widget	0		Mysticality: +25, Spell Damage Percent: +50, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	ghostly stanky garland of horror	0		Stench Spell Damage: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2018-12"
 8122	flame-retardant crafty gunnysack	0		Maximum MP: +10, Hot Resistance: +1, Last Available: "2018-12"
 8123	beefy garibaldi of Tarzan	0		Muscle: +10, Experience (Muscle): +3, Last Available: "2018-12"
-8124	tumbling knitted grievous girdle	0		Weapon Damage Percent: +50, Cold Resistance: +3, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	tumbling knitted grievous girdle	0		Weapon Damage Percent: +50, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	narrow smartaleck's gloves of Calamity Jane	0		Moxie Percent: +30, Critical Hit Percent: +15, Single Equip, Last Available: "2018-12"
 8126	twisted shaking smithereens	1		Effect: "Bat Attitude", Effect Duration: 30, Last Available: "2018-12"
 8127	frosty sharpshooter's fiberglass fetish	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Last Available: "2018-12"
@@ -8015,7 +8015,7 @@
 8141	red energetic macroplane grater	0		Maximum MP Percent: +20
 8142	bastard baster of the brute	0		Muscle Percent: +30
 8143	bouncing rosy-cheeked obsidian nutcracker	0		Maximum HP Percent: +30
-8144	squat blinking talisman of Seshat	0		Free Pull
+8144	blinking squat talisman of Seshat	0		Free Pull
 8145	blinking bouncing sizzling sage glass eye	0		Mysticality Percent: +10, Hot Damage: +10, Single Equip
 8146	galvanized liquefied invisible potion	0		Effect: "Human-Plant Hybrid", Effect Duration: 36
 8147	time shuriken	0		
@@ -8025,7 +8025,7 @@
 8151	electrified corrupted spinning upside-down Shrubble Bubble	0		Effect: "Dancing Prowess", Effect Duration: 57
 8152	improved ghostly polyeaster egg	0		Effect: "Magically Fingered", Effect Duration: 51
 8153	galvanized candy dish	0		Effect: "Phorcefullness", Effect Duration: 63
-8154	quantum anodized shaking squat skewed olive Spechunky bar	0		Effect: "Haunted Stomach", Effect Duration: 21
+8154	quantum anodized squat skewed olive shaking Spechunky bar	0		Effect: "Haunted Stomach", Effect Duration: 21
 8155	adjusted talisman of Horus	0		Effect: "Inappropriate Spirit", Effect Duration: 23
 8156	check to the Meatsmith	0		
 8157	skewed Skeleton Store office key	0		
@@ -8041,11 +8041,11 @@
 8167	normal teal twirling baguette	3	good	
 8168	bouncing glob of icing	0		
 8169	pressed aerosolized green ginger snaps	0		Effect: "Spooky Weapon", Effect Duration: 53
-8170	electrified irradiated wobbly fuchsia mostly-broken sunglasses	0		Effect: "World's Shortest Giant", Effect Duration: 28
-8171	triple-distilled artisanal unflavored wine cooler	10	EPIC	
+8170	electrified irradiated fuchsia wobbly mostly-broken sunglasses	0		Effect: "World's Shortest Giant", Effect Duration: 28
+8171	artisanal triple-distilled unflavored wine cooler	10	EPIC	
 8172	carton of snake milk	1	decent	
 8173	Usain Bolt's sewer snake	0		Initiative: +80
-8174	super-sized bland pigeon egg	5	decent	
+8174	bland super-sized pigeon egg	5	decent	
 8175	double-paned beefy jaunty feather	0		Muscle: +10, Cold Resistance: +5
 8176	lousy shaking premium malt liquor	4	decent	
 8177	rosy-cheeked extremely unsafe brown paper pants	0		Weapon Damage Percent: +100, Maximum HP Percent: +30
@@ -8056,18 +8056,18 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	family-friendly bread basket	0		Sleaze Resistance: +1
 8184	Ed the Undying exhibit crate	0		
-8185	nasty The Crown of Ed the Undying of doom	0		Spooky Spell Damage: +50, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	nasty The Crown of Ed the Undying of doom	0		Spooky Spell Damage: +50, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	tumbling Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	practically non-alcoholic aged Cherrytastrophe wine cooler	1	awesome	
 8189	artisanal skewed upside-down Radberry Rip wine cooler	4	EPIC	
 8190	hand-crafted jittery Orangemageddon wine cooler	4	EPIC	
 8191	hand-crafted Breakfast Blast wine cooler	4	EPIC	
-8192	mediocre boozy enchanted Citrus Crush wine cooler	5	decent	Effect: "Nutrient-Rich", Effect Duration: 5
+8192	enchanted boozy mediocre Citrus Crush wine cooler	5	decent	Effect: "Nutrient-Rich", Effect Duration: 5
 8193	spoiled plain bagel	3	crappy	
 8194	delicious mirror glob of cream cheese	3	awesome	
-8195	miniature rotten loaf of soda bread	2	crappy	
-8196	bite-sized normal maroon acceptable bagel	1	good	
+8195	rotten miniature loaf of soda bread	2	crappy	
+8196	normal bite-sized maroon acceptable bagel	1	good	
 8197	rotten mirror standard-issue cupcake	3	crappy	
 8198	adequate ultra-deluxe cupcake	4	good	
 8199	red hypnotic breadcrumbs	0		
@@ -8082,17 +8082,17 @@
 8208	super-denatured How to Avoid Scams	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 47, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
-8211	huge lime green bag of park garbage	0		Last Available: "2015-04"
+8211	lime green huge bag of park garbage	0		Last Available: "2015-04"
 8212	ghostly grogpagne	0		Last Available: "2021-07"
 8213	manspreader's medical-grade rigging rope	0		Monster Level: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04"
 8214	modified twirling nasty snuff	1	awesome	Last Available: "2015-04"
-8215	Oprah's sage sewage-clogged pistol	0		Mysticality Percent: +10, Maximum MP Percent: +50, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	Oprah's sage sewage-clogged pistol	0		Mysticality Percent: +10, Maximum MP Percent: +50, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	modified blurry beard incense	0		Effect: "Seeing Colors", Effect Duration: 14, Last Available: "2015-04"
 8217	perfume-soaked bandana of the cougar of the sewer	0		Moxie: +20, Stench Damage: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	small bland toxo	2	decent	Last Available: "2015-04"
+8219	bland small toxo	2	decent	Last Available: "2015-04"
 8220	acceptable bouncing mirror Lemonade-235	3	good	Last Available: "2015-04"
-8221	steel-toed isotophat of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	steel-toed isotophat of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	up-at-dawn wizardly Three Mile Island shorts	0		Mysticality: +25, Adventures: +5, Last Available: "2015-04"
 8223	vibrating sinister toxic mop	0		Spell Damage: +10, Maximum MP Percent: +10, Last Available: "2015-04"
 8224	green inert sludgepuppy	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	shaking skewed lube-shoes of bravery	0		Spooky Resistance: +5, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	jittery coward's razor-sharp Dinsey mascot mask of courage	0		Weapon Damage Percent: +25, Monster Level: -20, Spooky Resistance: +3, Last Available: "2015-04"
-8247	bland small Dinsey food-cone	2	decent	Last Available: "2015-04"
+8247	small bland Dinsey food-cone	2	decent	Last Available: "2015-04"
 8248	tolerable watered-down upside-down Dinsey Whinskey	2	good	Last Available: "2015-04"
 8249	deionized Vulcanized enhanced Dinsey face paint	0		Effect: "Standard Issue Bravery", Effect Duration: 68, Last Available: "2015-04"
 8250	supercharged fannypack of the storm	0		Maximum MP Percent: 70, Last Available: "2015-04"
@@ -8126,7 +8126,7 @@
 8252	green censurious perfumed Oprah's hazmat helmet of the empath of doom	0		Maximum MP Percent: +50, Familiar Weight: +5, Spooky Spell Damage: +50, Stench Resistance: +5, Sleaze Resistance: +3, Last Available: "2015-04"
 8253	spinning Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	shaking Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
-8255	ghostly gray twirling Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
+8255	twirling gray ghostly Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	enhanced Vulcanized nasty gum	0		Effect: "Tremella Tremens", Effect Duration: 53
 8258	jittery Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
@@ -8144,19 +8144,19 @@
 8270	bland skewed fuchsia unappetizing mayolus	3	decent	Last Available: "2015-05"
 8271	adequate huge pulsating uninteresting mayolus	7	good	Last Available: "2015-05"
 8272	bland small acceptable mayolus	2	decent	Last Available: "2015-05"
-8273	fancy half-sized toothsome blinking enticing mayolus	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2015-05"
-8274	moldy miniature upside-down mouth-watering mayolus	2	crappy	Last Available: "2015-05"
+8273	half-sized fancy toothsome blinking enticing mayolus	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2015-05"
+8274	miniature moldy upside-down mouth-watering mayolus	2	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	blue Essence of Bear	0		Skill: "Bear Essence"
-8278	practically non-alcoholic enchanted mediocre Afternoon Delight	1	decent	Effect: "Carrrsmic", Effect Duration: 50, Last Available: "2015-04"
+8278	practically non-alcoholic mediocre enchanted Afternoon Delight	1	decent	Effect: "Carrrsmic", Effect Duration: 50, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	unsweetened polarized lime green Kokomo Resort Brand Suntan Oil	0		Effect: "Video Game Hot Dog", Effect Duration: 44, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	energized green Kokomo Resort Pass	0		Effect: "Paging Betty", Effect Duration: 67, Last Available: "2023-08"
-8285	spinning ghostly Mayo Minder&trade;	0		Last Available: "2015-05"
+8285	ghostly spinning Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	flattened dry blue Mayo de Mayo&trade; mayo	0		Effect: "Ruby-ous", Effect Duration: 16
 8287	wobbly puck	0		Free Pull, Last Available: "2015-06"
 8288	twirling kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
@@ -8174,9 +8174,9 @@
 8300	alkaline bouncing power pill	0		Effect: "items.enh", Effect Duration: 25, Last Available: "2015-06"
 8301	frozen pixel star	0		Effect: "Chilblains of the Corn", Effect Duration: 33, Last Available: "2015-06"
 8302	huge rotten pixel banana	6	crappy	Last Available: "2015-06"
-8303	irresponsibly strong artisanal pixel beer	10	EPIC	Last Available: "2015-06"
+8303	artisanal irresponsibly strong pixel beer	10	EPIC	Last Available: "2015-06"
 8304	skewed puck with a bow on it	0		Free Pull, Last Available: "2015-06"
-8305	cyan bouncing wobbly pumps	0		Last Available: "2015-06"
+8305	wobbly cyan bouncing pumps	0		Last Available: "2015-06"
 8306	electrified huge sludgesicle	0		Effect: "Elemental Mastery", Effect Duration: 49
 8307	extra-boiled adjusted ionized lime green &Uuml;berraschthexengebr&auml;u	0		Effect: "Sugar, Hello", Effect Duration: 23
 8308	dry colloidal tumbling piggy tattoo	0		Effect: "Feet of Grapefruit", Effect Duration: 34
@@ -8194,7 +8194,7 @@
 8320	galvanized one glove	0		Effect: "Ocelot Eyes", Effect Duration: 13
 8321	liquefied glove	0		Effect: "Gummi-Grin", Effect Duration: 13
 8322	unsweetened wet ghostly handful of fire	0		Effect: "Oh Snap", Effect Duration: 50
-8323	corrupted narrow blinking Cracklin' Oat Bran	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 66
+8323	corrupted blinking narrow Cracklin' Oat Bran	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 66
 8324	quantum polarized disposable lighter	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 29
 8325	improved irradiated squat coal contact lenses	0		Effect: "Yuletide Sappiness", Effect Duration: 23
 8326	corrupted liquefied galvanized conjured ice cream	0		Effect: "Fishy Fortification", Effect Duration: 47
@@ -8204,11 +8204,11 @@
 8330	improved dry assassin's cheese knife	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 31
 8331	liquefied adjusted blurry filthy armor	0		Effect: "Wistfully Nostalgic", Effect Duration: 30
 8332	polymerized squat plague pie	0		Effect: "Chalk Outline", Effect Duration: 54
-8333	energized cyan pulsating batarang	0		Effect: "Hot Blooded", Effect Duration: 39
+8333	energized pulsating cyan batarang	0		Effect: "Hot Blooded", Effect Duration: 39
 8334	double-Vulcanized modified pulsating spare neck bolts	0		Effect: "Boletus Swoletus", Effect Duration: 43
 8335	dry grease trap	0		Effect: "Itchy Trigger Finger", Effect Duration: 53
 8336	dry shamanic ham	0		Effect: "Crying, Dying", Effect Duration: 12
-8337	diffused wet purple skewed tumbling porkpocket	0		Effect: "Bark of the Dog", Effect Duration: 17
+8337	diffused wet skewed tumbling purple porkpocket	0		Effect: "Bark of the Dog", Effect Duration: 17
 8338	triple-polarized non-denatured teal Leonard's glasses	0		Effect: "Okee-Dokee Computer", Effect Duration: 30
 8339	galvanized corrupted olive warehouse walkie-talkie	0		Effect: "Carrion' On", Effect Duration: 25
 8340	oxidized upside-down janitor's mop	0		Effect: "Eldritch Concentration", Effect Duration: 23
@@ -8248,9 +8248,9 @@
 8374	double-tarnished concentrated drinks tray	0		Effect: "Rage of the Reindeer", Effect Duration: 36
 8375	adjusted polarized eyebrow lifter	0		Effect: "Antibiotic Saucesphere", Effect Duration: 12
 8376	narrow submarine	0		Last Available: "2015-06"
-8377	bland ghostly narrow pixel lemon	4	decent	Last Available: "2015-06"
+8377	bland narrow ghostly pixel lemon	4	decent	Last Available: "2015-06"
 8378	bad teal pixel daiquiri	4	decent	Last Available: "2015-06"
-8379	ionized liquefied blue jittery power pill	0		Effect: "Boon of She-Who-Was", Effect Duration: 46, Last Available: "2015-06"
+8379	ionized liquefied jittery blue power pill	0		Effect: "Boon of She-Who-Was", Effect Duration: 46, Last Available: "2015-06"
 8380	unsweetened boiled pixel potion	0		Effect: "Stench Jellied", Effect Duration: 29, Last Available: "2015-06"
 8381	twirling Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	fuchsia Deck of Every Card	0		Last Available: "2015-07"
@@ -8262,7 +8262,7 @@
 8388	mana	0		Last Available: "2015-07"
 8389	spinning mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
-8391	gray huge mana	0		Last Available: "2015-07"
+8391	huge gray mana	0		Last Available: "2015-07"
 8392	red gift card	0		Last Available: "2015-07"
 8393	twirling hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
@@ -8278,17 +8278,17 @@
 8404	upside-down ghostly 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	thick adequate pestopiary	5	good	
+8407	adequate thick pestopiary	5	good	
 8408	galvanized adjusted ectoplasmic orbs	0		Effect: "Bilious Brawn", Effect Duration: 69
 8409	rotten crudles	3	crappy	
-8410	half-sized stale twirling agnolotti arboli	2	decent	
+8410	stale half-sized twirling agnolotti arboli	2	decent	
 8411	rotten spaghetti with ghost balls	3	crappy	
-8412	massive rotten lime green succulent marrow	6	crappy	
+8412	rotten massive lime green succulent marrow	6	crappy	
 8413	decent bite-sized salacious crumbs	1	good	
 8414	adequate fusilli marrownarrow	3	good	
-8415	fancy adequate mirror suggestive strozzapreti	3	good	Effect: "Super Accuracy", Effect Duration: 30
+8415	adequate fancy mirror suggestive strozzapreti	3	good	Effect: "Super Accuracy", Effect Duration: 30
 8416	skewed Mountain Stream gastrique	0		
-8417	snack-sized normal Mt. McLargeHuge oyster	2	good	
+8417	normal snack-sized Mt. McLargeHuge oyster	2	good	
 8418	oyster sauce	0		
 8419	normal ghostly linguini immondizia bianco	3	good	
 8420	stale shells a la shellfish	3	decent	
@@ -8329,30 +8329,30 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	yellow crystalline light bulb	0		Last Available: "2015-08"
 8457	jittery broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	purple blurry crafty brawny high-temperature mining mask	0		Muscle Percent: +20, Maximum MP: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	purple blurry crafty brawny high-temperature mining mask	0		Muscle Percent: +20, Maximum MP: +10, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	Jim Carey's smooth fireproof megaphone	0		Moxie: +15, Monster Level: +25, Last Available: "2015-08"
 8460	stale big tumbling mineapple	5	decent	Last Available: "2015-08"
-8461	boozy perfectly mixed Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
+8461	perfectly mixed boozy Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	crappy	Last Available: "2015-08"
-8463	stale small skewed smelted roe	2	decent	Last Available: "2015-08"
-8464	weak acceptable lavawater	2	good	Last Available: "2015-08"
+8463	small stale skewed smelted roe	2	decent	Last Available: "2015-08"
+8464	acceptable weak lavawater	2	good	Last Available: "2015-08"
 8465	cold-filtered maroon basaltamander tongue	0		Effect: "Swimming Head", Effect Duration: 65, Last Available: "2015-08"
 8466	frightening supercharged boxer's lavalarva	0		Muscle Percent: +10, Maximum MP Percent: +30, Spooky Damage: +5, Last Available: "2015-08"
 8467	perfumed asbestos-lined boxer's lava balaclava	0		Muscle Percent: +10, Hot Resistance: +5, Stench Resistance: +5, Last Available: "2015-08"
 8468	tumbling reassuring dangerous wizardly basaltamander buckler	0		Mysticality: +25, Weapon Damage: +10, Spooky Resistance: +1, Damage Reduction: 15, Last Available: "2015-08"
 8469	pickled electrified oxidized lava globs	0		Effect: "Earthen Fist", Effect Duration: 16, Last Available: "2015-08"
-8470	small spoiled gooey lava globs	2	crappy	Last Available: "2015-08"
+8470	spoiled small gooey lava globs	2	crappy	Last Available: "2015-08"
 8471	occult brainy lava-proof pants	0		Mysticality: +5, Spell Damage Percent: +25, Last Available: "2015-08"
 8472	blurry hardy heat-resistant necktie of incineration	0		Maximum HP: +50, Hot Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8473	knitted frightening Da Vinci's heat-resistant gloves	0		Experience (Mysticality): +5, Spooky Damage: +5, Cold Resistance: +3, Single Equip, Last Available: "2015-08"
 8474	stale shaking very hot lunch	4	decent	Last Available: "2015-08"
-8475	fortified bad yellow bouncing asbestos thermos	5	decent	Last Available: "2015-08"
+8475	fortified bad bouncing yellow asbestos thermos	5	decent	Last Available: "2015-08"
 8476	quadruple-chilled colloidal liquid rhinestones	0		Effect: "Dreams and Lights", Effect Duration: 69, Last Available: "2015-08"
 8477	normal disco biscuit	3	good	Last Available: "2015-08"
-8478	weak mediocre Quaatorade&trade;	2	decent	Last Available: "2015-08"
-8479	scandalous hardened slick biker's hat	0		Moxie: +10, Damage Reduction: 3, Sleaze Damage: +5, Familiar Effect: "atk", Last Available: "2015-08"
-8480	twirling greedy coward's energetic feathered headdress	0		Maximum MP Percent: +20, Monster Level: -20, Meat Drop: +20, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	up-at-dawn electrician's hardhat of Leguizamo of the empath	0		Monster Level: +20, Familiar Weight: +5, Adventures: +5, Familiar Effect: "atk", Last Available: "2015-08"
+8478	mediocre weak Quaatorade&trade;	2	decent	Last Available: "2015-08"
+8479	scandalous hardened slick biker's hat	0		Moxie: +10, Damage Reduction: 3, Sleaze Damage: +5, Last Available: "2015-08", Familiar Effect: "atk"
+8480	twirling greedy coward's energetic feathered headdress	0		Maximum MP Percent: +20, Monster Level: -20, Meat Drop: +20, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	up-at-dawn electrician's hardhat of Leguizamo of the empath	0		Monster Level: +20, Familiar Weight: +5, Adventures: +5, Last Available: "2015-08", Familiar Effect: "atk"
 8482	jittery Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	huge airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	spinning Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	bouncing wobbly New Age hurting crystal	0		Last Available: "2015-08"
-8490	bouncing thinker's smooth velvet pants	0		Mysticality: +10, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	bouncing thinker's smooth velvet pants	0		Mysticality: +10, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	mirror smooth velvet shirt of the empath	0		Familiar Weight: +5, Last Available: "2015-08"
 8492	blurry smooth velvet hat of the sewer	0		Stench Damage: +25, Last Available: "2015-08"
 8493	Fonzie's smooth velvet pocket square	0		Experience (Moxie): +1, Single Equip, Last Available: "2015-08"
@@ -8378,7 +8378,7 @@
 8504	spinning Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
-8507	denatured red twirling SMOOCH coffee cup	1	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 10, Last Available: "2015-08"
+8507	denatured twirling red SMOOCH coffee cup	1	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 10, Last Available: "2015-08"
 8508	modified squat labrador cookie	0		Effect: "Block-Rockin' Beet", Effect Duration: 28, Last Available: "2015-08"
 8509	Sherlock's Jeselnik's Mr. Cheeng's spectacles of the cougar	0		Moxie: +20, Sleaze Damage: +25, Item Drop: +25, Single Equip, Last Available: "2015-08"
 8510	green censurious grease cannon of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +3, Last Available: "2015-08"
@@ -8391,22 +8391,22 @@
 8517	mansplainer's Socratic SMOOCH bracers	0		Experience (Mysticality): +1, Monster Level: +15, Single Equip, Last Available: "2015-08"
 8518	mansplainer's SMOOCH kneepads	0		Monster Level: +15, Single Equip, Last Available: "2015-08"
 8519	ghostly SMOOCH spaulders of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
-8520	hardened SMOOCH codpiece of the blizzard	0		Damage Reduction: 3, Cold Spell Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	hardened SMOOCH codpiece of the blizzard	0		Damage Reduction: 3, Cold Spell Damage: +25, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	crafty SMOOCH breastplate	0		Maximum MP: +10, Last Available: "2015-08"
 8522	pulsating superduperheated	0		Last Available: "2015-08"
 8523	jittery fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	toothsome lava cake	4	awesome	Last Available: "2015-08"
-8526	thick rotten upside-down pink slime	5	crappy	
+8526	rotten thick upside-down pink slime	5	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	rotten miniature devil hair pasta	2	crappy	
+8529	miniature rotten devil hair pasta	2	crappy	
 8530	moldy spagecialetti	4	crappy	
 8531	wobbly Salsa Libre	0		
 8532	good gravy	0		
 8533	narrow illicit fish sauce	0		
 8534	flavorless half-sized libertagliatelle	2	decent	
-8535	flavorless bouncing ghostly turkish mostaccioli	3	decent	
+8535	flavorless ghostly bouncing turkish mostaccioli	3	decent	
 8536	toothsome miniature spinning linguini of the sea	2	awesome	
 8537	dry dry Hersey&trade; SMOOCH	0		Effect: "Spookypants", Effect Duration: 60
 8539	blue Alexy sauce	0		
@@ -8421,7 +8421,7 @@
 8548	activated shady shades	0		Effect: "You're Rubber", Effect Duration: 47
 8549	activated squeaky toy rose	0		Effect: "Frost Tea", Effect Duration: 41
 8550	thick stale tumbling weird gazelle steak	5	decent	
-8551	immense stale sausage without a cause	9	decent	
+8551	stale immense sausage without a cause	9	decent	
 8552	nitrogenated narrow face paint	0		Effect: "The Smile of Mr. A.", Effect Duration: 52
 8553	practically non-alcoholic hand-crafted emergency margarita	1	super ultra mega turbo EPIC	
 8554	lousy vintage smart drink	4	decent	
@@ -8437,22 +8437,22 @@
 8564	tumbling shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	Usain Bolt's barrel lid of the cougar of the glutton	0		Moxie: +20, Food Drop: +100, Initiative: +80, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	frightening toasty veiny barrel hoop earring	0		Maximum HP: +10, Hot Damage: +5, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2015-09"
-8567	pulsating twirling horrifying rock-hard occult bankruptcy barrel	0		Spell Damage Percent: +25, Damage Reduction: 5, Spooky Damage: +25, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	pulsating twirling horrifying rock-hard occult bankruptcy barrel	0		Spell Damage Percent: +25, Damage Reduction: 5, Spooky Damage: +25, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	blurry firkin	0		Last Available: "2015-09"
 8569	yellow normal barrel	0		Last Available: "2015-09"
 8570	skewed tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
-8572	spinning squat barrel	0		Last Available: "2015-09"
+8572	squat spinning barrel	0		Last Available: "2015-09"
 8573	barrel	0		Last Available: "2015-09"
 8574	moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	red mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	watered-down tolerable narrow bottle of Amontillado	2	good	Last Available: "2015-09"
-8579	irresponsibly strong lousy barrel-aged martini	7	decent	Last Available: "2015-09"
-8580	flavorless immense barrel pickle	6	decent	Last Available: "2015-09"
+8579	lousy irresponsibly strong barrel-aged martini	7	decent	Last Available: "2015-09"
+8580	immense flavorless barrel pickle	6	decent	Last Available: "2015-09"
 8581	decent barrel cracker	3	good	Last Available: "2015-09"
-8582	modified mirror blurry vibrating mushroom	1	decent	Effect: "Stopping to Smell the Flowers", Effect Duration: 50, Last Available: "2015-09"
+8582	modified blurry mirror vibrating mushroom	1	decent	Effect: "Stopping to Smell the Flowers", Effect Duration: 50, Last Available: "2015-09"
 8583	twisted mushroom	1	good	Effect: "Spring Training", Effect Duration: 45, Last Available: "2015-09"
 8584	blurry slick KoL Con 12-gauge	0		Moxie: +10, Last Available: "2015-09"
 8585	scandalous Golden Mr. Eh?	0		Sleaze Damage: +5, Last Available: "2015-09"
@@ -8472,14 +8472,14 @@
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	wobbly potted tea tree	0		Last Available: "2015-09"
 8601	deionized deionized skewed cuppa Flamibili tea	0		Effect: "Action", Effect Duration: 15, Last Available: "2015-09"
-8602	galvanized twirling ghostly cuppa Yet tea	0		Effect: "Meadulla Oblongota", Effect Duration: 60, Last Available: "2015-09"
+8602	galvanized ghostly twirling cuppa Yet tea	0		Effect: "Meadulla Oblongota", Effect Duration: 60, Last Available: "2015-09"
 8603	electrified ghostly cuppa Boo tea	0		Effect: "Human-Constellation Hybrid", Effect Duration: 69, Last Available: "2015-09"
 8604	frozen cuppa Nas tea	0		Effect: "Permafrosty", Effect Duration: 29, Last Available: "2015-09"
 8605	super-energized improved quantum squat maroon cuppa Improprie tea	0		Effect: "Dreams and Lights", Effect Duration: 30, Last Available: "2015-09"
 8606	non-moist tarnished ghostly cuppa Frost tea	0		Effect: "Goldentongue", Effect Duration: 65, Last Available: "2015-09"
 8607	diffused wet gray cuppa Toast tea	0		Effect: "Yet tea", Effect Duration: 47, Last Available: "2015-09"
 8608	colloidal cuppa Net tea	0		Effect: "In the Slimelight", Effect Duration: 12, Last Available: "2015-09"
-8609	diffused polymerized jittery huge pulsating cuppa Proprie tea	0		Effect: "Deadly Lampblade", Effect Duration: 20, Last Available: "2015-09"
+8609	diffused polymerized pulsating jittery huge cuppa Proprie tea	0		Effect: "Deadly Lampblade", Effect Duration: 20, Last Available: "2015-09"
 8610	frozen cuppa Morbidi tea	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 13, Last Available: "2015-09"
 8611	enhanced quadruple-dry irradiated maroon cuppa Chari tea	0		Effect: "The Two-Prong Crown", Effect Duration: 14, Last Available: "2015-09"
 8612	adjusted altered cuppa Serendipi tea	0		Effect: "Triangle, Man", Effect Duration: 33, Last Available: "2015-09"
@@ -8490,7 +8490,7 @@
 8617	quadruple-wet ionized narrow cuppa Dexteri tea	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 43, Last Available: "2015-09"
 8618	nitrogenated alkaline cuppa Flexibili tea	0		Effect: "Intimidating Mien", Effect Duration: 46, Last Available: "2015-09"
 8619	adjusted diffused pickled cuppa Impregnabili tea	0		Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2015-09"
-8620	non-dry blurry upside-down cuppa Obscuri tea	0		Effect: "Dwarven Hardiness", Effect Duration: 53, Last Available: "2015-09"
+8620	non-dry upside-down blurry cuppa Obscuri tea	0		Effect: "Dwarven Hardiness", Effect Duration: 53, Last Available: "2015-09"
 8621	dry cuppa Irritabili tea	0		Effect: "Thick-Skinned", Effect Duration: 65, Last Available: "2015-09"
 8622	liquefied wobbly ghostly cuppa Mediocri tea	0		Effect: "Rushin' Hands", Effect Duration: 37, Last Available: "2015-09"
 8623	energized polarized cuppa Loyal tea	0		Effect: "Fizzier Than Light", Effect Duration: 69, Last Available: "2015-09"
@@ -8512,8 +8512,8 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	blinking Ghost Dog Chow	0		Last Available: "2015-10"
 8641	delicious bowl of eyeballs	4	awesome	Last Available: "2015-10"
-8642	enchanted bite-sized stale bowl of mummy guts	1	decent	Effect: "Headstrong", Effect Duration: 25, Last Available: "2015-10"
-8643	jumbo moldy narrow bowl of maggots	5	crappy	Last Available: "2015-10"
+8642	enchanted stale bite-sized bowl of mummy guts	1	decent	Effect: "Headstrong", Effect Duration: 25, Last Available: "2015-10"
+8643	moldy jumbo narrow bowl of maggots	5	crappy	Last Available: "2015-10"
 8644	lousy blood and blood	3	decent	Last Available: "2015-10"
 8645	delicious huge Jack-O-Lantern beer	3	awesome	Last Available: "2015-10"
 8646	acceptable zombie	4	good	Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	ruddy shellacked hawk of the brute	0		Muscle Percent: +30, Damage Reduction: 7, Maximum HP Percent: +40
-8655	moldy enchanted massive cyan hamlet sandwich	8	crappy	Effect: "Mad at Science", Effect Duration: 45
+8655	enchanted moldy massive cyan hamlet sandwich	8	crappy	Effect: "Mad at Science", Effect Duration: 45
 8656	scorching Othello's military jacket	0		Hot Damage: +25
 8657	blue aromatic Othello's dagger	0		Stench Resistance: +1, Single Equip
 8658	blinking greasy Othello's handkerchief	0		Sleaze Spell Damage: +10, Single Equip
@@ -8558,8 +8558,8 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	spinning upside-down perfect ice cube	0		Last Available: "2015-11"
 8687	ghostly The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	Jim Carey's bellhop's hat	0		Monster Level: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	bad ice porter	3	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	Jim Carey's bellhop's hat	0		Monster Level: +25, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	bad ice porter	3	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	extra-altered alkaline exotic travel brochure	0		Effect: "Chock Full o' Nanites", Effect Duration: 61, Last Available: "2015-11"
 8691	spinning bag of foreign bribes	0		Last Available: "2015-11"
 8692	super-activated squat huge shampoo-conditioner	0		Effect: "Patience of the Tortoise", Effect Duration: 16, Last Available: "2015-11"
@@ -8571,7 +8571,7 @@
 8698	bad practically non-alcoholic teal iced plum wine	1	decent	Last Available: "2016-01"
 8699	occult training belt of the wise owl of the businessman	0		Mysticality: +20, Spell Damage Percent: +25, Meat Drop: +50, Single Equip, Last Available: "2016-01"
 8700	huge wool Jim Carey's experienced training legwarmers	0		Experience: +2, Monster Level: +25, Cold Resistance: +1, Single Equip, Last Available: "2016-01"
-8701	spinning chilly training helmet of incineration of Flo-Jo	0		Cold Damage: +5, Hot Spell Damage: +50, Initiative: +100, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	spinning chilly training helmet of incineration of Flo-Jo	0		Cold Damage: +5, Hot Spell Damage: +50, Initiative: +100, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	wobbly training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8583,13 +8583,13 @@
 8710	pickled narrow teal abstraction: sensation	1		Last Available: "2015-12"
 8711	mixed abstraction: purpose	1		Last Available: "2015-12"
 8712	powdered abstraction: category	1		Last Available: "2015-12"
-8713	dried red bouncing squat abstraction: perception	1		Effect: "Pie in the Sky", Effect Duration: 10, Last Available: "2015-12"
-8714	dried wobbly purple abstraction: motion	1		Last Available: "2015-12"
+8713	dried squat bouncing red abstraction: perception	1		Effect: "Pie in the Sky", Effect Duration: 10, Last Available: "2015-12"
+8714	dried purple wobbly abstraction: motion	1		Last Available: "2015-12"
 8715	powdered wobbly yellow abstraction: joy	1		Effect: "Impregnably Delicious", Effect Duration: 30, Last Available: "2015-12"
 8716	modified abstraction: certainty	1		Effect: "Musky", Effect Duration: 45, Last Available: "2015-12"
-8717	vaporized red spinning abstraction: comprehension	1		Last Available: "2015-12"
+8717	vaporized spinning red abstraction: comprehension	1		Last Available: "2015-12"
 8718	maroon squat modern picture frame	0		Last Available: "2015-12"
-8719	thick toothsome VYKEA meatballs	5	awesome	Last Available: "2015-11"
+8719	toothsome thick VYKEA meatballs	5	awesome	Last Available: "2015-11"
 8720	practically non-alcoholic drinkable VYKEA mead	1	good	Last Available: "2015-11"
 8721	altered VYKEA woadpaint	0		Effect: "You Know When to Walk Away", Effect Duration: 55, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8601,17 +8601,17 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	blurry asbestos-lined ribald VYKEA hex key of the early riser	0		Sleaze Damage: +10, Hot Resistance: +5, Adventures: +7, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	moldy jittery tin of submardines	3	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	moldy jittery tin of submardines	3	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	artisanal blinking bottle of norwhiskey	3	EPIC	Last Available: "2015-11"
 8733	powdered octolus oculus	1	crappy	Effect: "The Magical Mojomuscular Melody", Effect Duration: 30, Last Available: "2015-11"
 8734	bouncing mansplainer's forbidden Herculean sardine can key	0		Experience (Muscle): +1, Spell Damage Percent: +50, Monster Level: +15, Last Available: "2015-11"
-8735	electrified padded norwhal helmet of the ox	0		Muscle: +20, Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk", Last Available: "2015-11"
+8735	electrified padded norwhal helmet of the ox	0		Muscle: +20, Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11", Familiar Effect: "atk"
 8736	shaking Sherlock's foul-smelling medical-grade octolus-skin cloak	0		Stench Damage: +10, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-11"
 8737	drinkable shaking perfect cosmopolitan	3	good	Last Available: "2015-11"
-8738	fancy lousy triple-distilled squat perfect negroni	7	decent	Effect: "Hypercubed", Effect Duration: 50, Last Available: "2015-11"
+8738	fancy triple-distilled lousy squat perfect negroni	7	decent	Effect: "Hypercubed", Effect Duration: 50, Last Available: "2015-11"
 8739	artisanal watered-down perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
 8740	spirit-forward acceptable perfect mimosa	5	good	Last Available: "2015-11"
-8741	weak perfectly mixed perfect old-fashioned	2	super ultra EPIC	Last Available: "2015-11"
+8741	perfectly mixed weak perfect old-fashioned	2	super ultra EPIC	Last Available: "2015-11"
 8742	hand-crafted perfect paloma	3	EPIC	Last Available: "2015-11"
 8743	frozen wet That 70s Cologne	0		Effect: "Make Meat FA$T!", Effect Duration: 52, Last Available: "2015-11"
 8744	moist Vulcanized Wal-Mart &quot;diamond&quot; ring	0		Effect: "The Grass...  Is Blue...", Effect Duration: 37, Last Available: "2015-11"
@@ -8619,12 +8619,12 @@
 8746	dry dry green Conspiracy&trade; mascara	0		Effect: "5 Pounds Lighter", Effect Duration: 26, Last Available: "2015-11"
 8747	enhanced magnetized warmed Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Nature's Bounty", Effect Duration: 62, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
-8749	vacuum-sealed chilled jittery ghostly Deep Machine Tunnels snowglobe	0		Effect: "You Read The Manual", Effect Duration: 20, Last Available: "2015-12"
+8749	vacuum-sealed chilled ghostly jittery Deep Machine Tunnels snowglobe	0		Effect: "You Read The Manual", Effect Duration: 20, Last Available: "2015-12"
 8750	tarnished altered gray hemp candy necklace	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 40, Last Available: "2015-12"
 8751	super-dry ionized communal gobstopper	0		Effect: "Infernal Thirst", Effect Duration: 46, Last Available: "2015-12"
-8752	adequate diet Crimbo salad	1	good	Last Available: "2015-12"
+8752	diet adequate Crimbo salad	1	good	Last Available: "2015-12"
 8753	stale bread line	3	decent	Last Available: "2015-12"
-8754	boozy bad tumbling skewed bark rootbeer	5	decent	Last Available: "2015-12"
+8754	boozy bad skewed tumbling bark rootbeer	5	decent	Last Available: "2015-12"
 8755	acceptable ale	4	good	Last Available: "2015-12"
 8756	blinking plastic Tammy the Tambourine Elf of the businessman	0		Meat Drop: +50, Last Available: "2015-12"
 8757	plastic Rudolph the Red of the boozehound	0		Booze Drop: +100, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	upside-down box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	pulsating squat Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	watered-down perfectly mixed Gratitude chocolate (bourbon-filled)	2	EPIC	Last Available: "2016-02"
+8766	perfectly mixed watered-down Gratitude chocolate (bourbon-filled)	2	EPIC	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	bouncing skewed Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8655,7 +8655,7 @@
 8783	elf ploughshare of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
 8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
-8786	spinning olive faded protest sign	0		Last Available: "2015-12"
+8786	olive spinning faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
 8789	ghostly book	0		Last Available: "2015-12"
@@ -8687,16 +8687,16 @@
 8815	twirling bat-bearing	0		Last Available: "2017-01"
 8816	decent Kudzu salad	4	good	Last Available: "2016-12"
 8817	dried blinking Mansquito Serum	1		Last Available: "2016-12"
-8818	practically non-alcoholic lousy Miss Graves' vermouth	1	decent	Last Available: "2016-12"
+8818	lousy practically non-alcoholic Miss Graves' vermouth	1	decent	Last Available: "2016-12"
 8819	flavorless special The Plumber's mushroom stew	3	decent	Effect: "Preternatural Greed", Effect Duration: 25, Last Available: "2016-12"
 8820	powdered The Author's ink	1		Effect: "Arcane in the Brain", Effect Duration: 15, Last Available: "2016-02"
 8821	mediocre The Mad Liquor	4	decent	Last Available: "2016-12"
 8822	perfectly mixed boozy Doc Clock's thyme cocktail	5	EPIC	Last Available: "2016-12"
 8823	normal Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	bouncing avaricious asbestos-lined The Jokester's gun of the detective	0		Hot Resistance: +5, Item Drop: +20, Meat Drop: +30, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	bouncing lion tamer's Da Vinci's The Jokester's wig of extreme caution	0		Experience (Mysticality): +5, Monster Level: -25, Experience (familiar): +2, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	Jack Frost's occult Rosewater's The Jokester's pants	0		Mysticality Percent: +30, Spell Damage Percent: +25, Cold Spell Damage: +50, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	bouncing avaricious asbestos-lined The Jokester's gun of the detective	0		Hot Resistance: +5, Item Drop: +20, Meat Drop: +30, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	bouncing lion tamer's Da Vinci's The Jokester's wig of extreme caution	0		Experience (Mysticality): +5, Monster Level: -25, Experience (familiar): +2, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	Jack Frost's occult Rosewater's The Jokester's pants	0		Mysticality Percent: +30, Spell Damage Percent: +25, Cold Spell Damage: +50, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	frozen blurry Jokester makeup	0		Effect: "Berry Experiential", Effect Duration: 36, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	skewed battoo kit	0		Last Available: "2016-12"
@@ -8704,22 +8704,22 @@
 8832	squat domino mask	0		Familiar Weight: +5
 8833	diffused dry twirling skewed robin's egg	0		Effect: "On the Trolley", Effect Duration: 39, Last Available: "2016-12"
 8834	bland immense robin flan	9	decent	Last Available: "2016-12"
-8835	mediocre weak robin nog	2	decent	Last Available: "2016-12"
+8835	weak mediocre robin nog	2	decent	Last Available: "2016-12"
 8836	upside-down LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	tumbling exploding gum	0		
 8839	root beer barrel	0		
-8840	electrified triple-improved electrified tumbling mirror blue Kudzu slaw	0		Effect: "Quaaaaaaa", Effect Duration: 47
+8840	electrified triple-improved electrified tumbling blue mirror Kudzu slaw	0		Effect: "Quaaaaaaa", Effect Duration: 47
 8841	corrupted alkaline Mansquito's blood	0		Effect: "Rave Nirvana", Effect Duration: 56
 8842	pressed aerosolized shaking infrablack lipstick	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 40
-8843	non-boiled spinning skewed can of drain cleaner	0		Effect: "Chlorophyll Flavor", Effect Duration: 65
+8843	non-boiled skewed spinning can of drain cleaner	0		Effect: "Chlorophyll Flavor", Effect Duration: 65
 8844	adjusted denatured ghostly The Author's inkwell	0		Effect: "Inscrutable exoskeleton", Effect Duration: 45
 8845	liquefied corrupted bag of random words	0		Effect: "Helvella Health", Effect Duration: 14
 8846	triple-dry narrow tube of pendulum lube	0		Effect: "Shot in the Arse", Effect Duration: 21
 8847	polymerized denatured red-hot jawbreaker	0		Effect: "Magically Fingered", Effect Duration: 18
-8848	diffused gray blurry question juice	0		Effect: "Sweetened and Fattened", Effect Duration: 53
-8849	magnetized liquefied tumbling mirror tube of villain	0		Effect: "Sugar, Hello", Effect Duration: 65
-8850	huge inspector's your cowboy boots	0		Item Drop: +15, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8848	diffused blurry gray question juice	0		Effect: "Sweetened and Fattened", Effect Duration: 53
+8849	magnetized liquefied mirror tumbling tube of villain	0		Effect: "Sugar, Hello", Effect Duration: 65
+8850	huge inspector's your cowboy boots	0		Item Drop: +15, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	mirror inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8752,20 +8752,20 @@
 8880	snack-sized decent plate of Frigid Northern Beans	2	good	Last Available: "2016-02"
 8881	yummy bite-sized twirling plate of World's Blackest-Eyed Peas	1	awesome	Last Available: "2016-02"
 8882	immense special tasty plate of Trader Olaf's Exotic Stinkbeans	7	awesome	Effect: "Ham-Fisted", Effect Duration: 50, Last Available: "2016-02"
-8883	yummy fancy diet plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	awesome	Effect: "Jammin'", Effect Duration: 45, Last Available: "2016-02"
+8883	diet yummy fancy plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	awesome	Effect: "Jammin'", Effect Duration: 45, Last Available: "2016-02"
 8884	moldy half-sized plate of Val-U Brand Every Bean Salad	2	crappy	Last Available: "2016-02"
 8885	delicious plate of Shrub's Premium Baked Beans	4	awesome	Last Available: "2016-02"
 8886	blurry aromatic horrifying Fancy Jeff's pocket square	0		Spooky Damage: +25, Stench Resistance: +1, Last Available: "2016-02"
-8887	olive studded Socratic Daisy's unclean bloomers of Leguizamo	0		Experience (Mysticality): +1, Damage Absorption: +80, Monster Level: +20, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	olive studded Socratic Daisy's unclean bloomers of Leguizamo	0		Experience (Mysticality): +1, Damage Absorption: +80, Monster Level: +20, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	shaking upside-down baleful Amoon-Ra Cowtep's nemes of doom of the early riser	0		Spell Damage: +25, Spooky Spell Damage: +50, Adventures: +7, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	shaking upside-down baleful Amoon-Ra Cowtep's nemes of doom of the early riser	0		Spell Damage: +25, Spooky Spell Damage: +50, Adventures: +7, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	skewed inspector's frosty Lo Pan's sinister Sinatra's Former Sheriff Dan's tin star	0		Experience (Moxie): +5, Spell Damage: +10, Spell Critical Percent: +30, Cold Spell Damage: +10, Item Drop: +15, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	teal frightening hardened dangerous Granny Hackleton's Gatling gun	0		Weapon Damage: +10, Damage Reduction: 3, Spooky Damage: +5, Last Available: "2016-02"
 8895	gray buffalo dime	0		Last Available: "2016-02"
-8896	purple spinning huge cow poker	0		Last Available: "2016-02"
+8896	purple huge spinning cow poker	0		Last Available: "2016-02"
 8897	double-energized poker face paint	0		Effect: "Jammin'", Effect Duration: 42, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	enchanted tainted milk	1	EPIC	Effect: "Hyperoffended", Effect Duration: 15, Last Available: "2016-02"
@@ -8778,8 +8778,8 @@
 8906	wet energized extra-irradiated rattler gland	0		Effect: "Antarctic Memories", Effect Duration: 58, Last Available: "2016-02"
 8907	ionized vacuum-sealed upside-down half-digested coal	0		Effect: "Peppermint Bite", Effect Duration: 33, Last Available: "2016-02"
 8908	extra-moist dry tightly-wound spine	0		Effect: "Mathematically Precise", Effect Duration: 15, Last Available: "2016-02"
-8909	immense flavorless tumbling rotting beefsteak	8	decent	Last Available: "2016-02"
-8910	practically non-alcoholic acceptable narrow firemilk	1	good	Last Available: "2016-02"
+8909	flavorless immense tumbling rotting beefsteak	8	decent	Last Available: "2016-02"
+8910	acceptable practically non-alcoholic narrow firemilk	1	good	Last Available: "2016-02"
 8911	non-alkaline narrow spidercow eye-cluster	0		Effect: "Shamboozled", Effect Duration: 42, Last Available: "2016-02"
 8912	powdered moomy dust	1		Last Available: "2016-02"
 8913	Newton's western-style skinning knife of the detective	0		Experience (Mysticality): +3, Item Drop: +20, Last Available: "2016-02"
@@ -8796,9 +8796,9 @@
 8924	wobbly disc (black)	0		
 8925	green disc (red)	0		
 8926	disc (green)	0		
-8927	mirror tumbling disc (blue)	0		
+8927	tumbling mirror disc (blue)	0		
 8928	disc (yellow)	0		
-8929	fuchsia pulsating red-hot knucklebone	0		Last Available: "2016-02"
+8929	pulsating fuchsia red-hot knucklebone	0		Last Available: "2016-02"
 8930	dry liquefied demonic cow's blood	0		Effect: "Egg-headedness", Effect Duration: 57, Last Available: "2016-02"
 8931	bouncing rinky-dink sixgun	0		Last Available: "2016-02"
 8932	lime green shaking makeshift sixgun	0		Last Available: "2016-02"
@@ -8817,7 +8817,7 @@
 8945	pulsating cow skull	0		Last Available: "2016-02"
 8946	cyan jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
-8948	pulsating skewed thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
+8948	skewed pulsating thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	slicksilver spurs	0		Last Available: "2016-02"
 8951	fuchsia upside-down sicksilver spurs	0		Last Available: "2016-02"
@@ -8863,16 +8863,16 @@
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	diluted shaking armored prawn	1		Last Available: "2016-03"
 8993	spoiled jumping horseradish	3	crappy	Last Available: "2016-03"
-8994	high-proof fancy lousy twirling narrow Sacramento wine	6	decent	Effect: "High Blood Chocolate Content", Effect Duration: 50, Last Available: "2016-03"
+8994	high-proof fancy lousy narrow twirling Sacramento wine	6	decent	Effect: "High Blood Chocolate Content", Effect Duration: 50, Last Available: "2016-03"
 8995	enhanced pickled pulsating Greek fire	0		Effect: "Toothy Grin", Effect Duration: 46, Last Available: "2016-03"
 8996	gravedigger's scorching medical-grade ruddy ox-head shield	0		Maximum HP Percent: +40, Hot Damage: +25, Spooky Damage: +10, Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	spinning lard-coated frightening mansplainer's arcane researcher's dented scepter of wisdom	0		Mysticality: +15, Experience Percent (Mysticality): +10, Monster Level: +15, Spooky Damage: +5, Sleaze Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	twirling fireproof careful personal trainer's slick strapping very pointy crown	0		Muscle: +5, Moxie: +10, Experience Percent (Muscle): +10, Monster Level: -10, Hot Resistance: +3, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	twirling fireproof careful personal trainer's slick strapping very pointy crown	0		Muscle: +5, Moxie: +10, Experience Percent (Muscle): +10, Monster Level: -10, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	inspector's personal trainer's groovy battle broom of wisdom of extreme caution	0		Mysticality: +15, Moxie Percent: +10, Experience Percent (Muscle): +10, Monster Level: -25, Item Drop: +15, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	huge Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	dangerous dance instructor's Newton's carpe of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3, Experience Percent (Moxie): +10, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9002	family-friendly knitted frosty Jim Carey's codpiece	0		Monster Level: +25, Cold Spell Damage: +10, Cold Resistance: +3, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
-9003	ghostly blue Annie Oakley's resourceful troutsers of Tarzan of mayonnaise	0		Experience (Muscle): +3, Maximum MP: +50, Critical Hit Percent: +20, Sleaze Spell Damage: +50, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	ghostly blue Annie Oakley's resourceful troutsers of Tarzan of mayonnaise	0		Experience (Muscle): +3, Maximum MP: +50, Critical Hit Percent: +20, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	wobbly chilly Jim Carey's therapeutic Samson's bass clarinet	0		Experience (Muscle): +5, Monster Level: +25, Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
 9005	stanky manspreader's occult brawny fish hatchet	0		Muscle Percent: +20, Spell Damage Percent: +25, Monster Level: +10, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9006	greasy scorching supercharged groovy tunac	0		Moxie Percent: +10, Maximum MP Percent: +30, Hot Damage: +25, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	pulsating meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	immense spoiled pulsating gallon of milk	10	crappy	Last Available: "2016-05"
+9021	spoiled immense pulsating gallon of milk	10	crappy	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	fuchsia daily dungeon malware	0		Last Available: "2016-05"
@@ -8902,10 +8902,10 @@
 9030	bland ghostly star salad	3	decent	
 9031	shaking purple Thwaitgold moth statuette	0		
 9032	jumbo spoiled gray bowl of Tastee-Wheet&trade;	5	crappy	
-9033	mirror ghostly Source terminal	0		Free Pull, Last Available: "2016-06"
+9033	ghostly mirror Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	miniature rotten browser cookie	2	crappy	Last Available: "2016-06"
-9036	practically non-alcoholic perfectly mixed hacked gibson	1	super ultra mega turbo EPIC	Last Available: "2016-06"
+9035	rotten miniature browser cookie	2	crappy	Last Available: "2016-06"
+9036	perfectly mixed practically non-alcoholic hacked gibson	1	super ultra mega turbo EPIC	Last Available: "2016-06"
 9037	huge ribald Source shades	0		Sleaze Damage: +10, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	blinking missing semicolon	0		Familiar Weight: +11
@@ -8936,7 +8936,7 @@
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	olive Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
-9067	shaking fuchsia pill	0		Last Available: "2016-06"
+9067	fuchsia shaking pill	0		Last Available: "2016-06"
 9068	dog trainer's sharpshooter's educational boxer's plastic detective badge	0		Muscle Percent: +10, Experience: +1, Critical Hit Percent: +10, Experience (familiar): +1, Last Available: "2016-07"
 9069	careful crafty educational bronze detective badge of bravery	0		Experience: +1, Maximum MP: +10, Monster Level: -10, Spooky Resistance: +5, Last Available: "2016-07"
 9070	mirror ribald foul-smelling detective badge of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, Stench Damage: +10, Sleaze Damage: +10, Last Available: "2016-07"
@@ -8951,7 +8951,7 @@
 9079	fancy moldy teal hardboiled egg	3	crappy	Effect: "Tingly Elbows", Effect Duration: 35, Last Available: "2016-07"
 9080	yellow detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	flame-retardant knitted sharpshooter's groovy smooth protonic accelerator pack of Gandalf	0		Moxie: +15, Moxie Percent: +10, Critical Hit Percent: +10, Spell Critical Percent: +20, Cold Resistance: +3, Hot Resistance: +1, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	flame-retardant knitted sharpshooter's groovy smooth protonic accelerator pack of Gandalf	0		Moxie: +15, Moxie Percent: +10, Critical Hit Percent: +10, Spell Critical Percent: +20, Cold Resistance: +3, Hot Resistance: +1, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	wobbly bouncing almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	Adventurer bobblehead of Gandalf	0		Spell Critical Percent: +20, Last Available: "2016-11"
 9085	ghostly psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	stiffened Mr. Screege's spectacles	0		Damage Reduction: 1, Single Equip, Last Available: "2016-08"
 9092	stanky sharpshooter's energetic Spookyraven signet	0		Maximum MP Percent: +20, Critical Hit Percent: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2016-08"
 9093	family-friendly nasty tie-dyed fannypack	0		Stench Damage: +5, Sleaze Resistance: +1, Single Equip, Last Available: "2016-08"
-9094	shellacked Samson's burnt snowpants	0		Experience (Muscle): +5, Damage Reduction: 7, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	nippy standards and practices guide	0		Cold Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	shellacked Samson's burnt snowpants	0		Experience (Muscle): +5, Damage Reduction: 7, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	nippy standards and practices guide	0		Cold Damage: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	bouncing Jeselnik's therapeutic steel-toed Carpathian longsword	0		Damage Reduction: 9, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-08"
 9097	Tesla veiny Liam's mail of incineration	0		Maximum HP: +10, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-08"
 9098	scandalous Newton's Unfortunato's foolscap of Gandalf	0		Experience (Mysticality): +3, Spell Critical Percent: +20, Sleaze Damage: +5, Last Available: "2016-08"
@@ -8984,7 +8984,7 @@
 9112	super-adjusted EMD holo-record	0		Effect: "Be a Mind Master", Effect Duration: 18
 9113	altered mirror Superdrifter holo-record	0		Effect: "On a Roll", Effect Duration: 47
 9114	altered boiled red The Pigs holo-record	0		Effect: "Buttermilk Boogie", Effect Duration: 29
-9115	activated pickled double-chilled wobbly maroon Drunk Uncles holo-record	0		Effect: "Cinnamouth", Effect Duration: 31
+9115	activated pickled double-chilled maroon wobbly Drunk Uncles holo-record	0		Effect: "Cinnamouth", Effect Duration: 31
 9116	blinking mirror time residue	0		Last Available: "2016-09"
 9117	ruddy repaid diaper	0		Maximum HP Percent: +40
 9118	squat Riker's Search History	0		Last Available: "2016-09"
@@ -8993,7 +8993,7 @@
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	mirror Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
-9124	narrow cyan shaking baby bark scorpion	0		
+9124	cyan shaking narrow baby bark scorpion	0		
 9125	red droppable microphone	0		
 9126	acceptable unidentified drink	4	good	
 9127	wicked smooth KoL Con 13 T-shirt	0		Moxie: +15, Spell Damage: +5
@@ -9003,56 +9003,56 @@
 9131	extremely confusing manual	0		
 9132	quilted smartaleck's pistol	0		Moxie Percent: +30, Damage Absorption: +40
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	half-sized decent leftover pasty	2	good	
-9135	bad extra-dry very whiskey	5	decent	
+9134	decent half-sized leftover pasty	2	good	
+9135	extra-dry bad very whiskey	5	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	shaking li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	ghostly li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	pulsating li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	ghostly li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	pulsating li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	pickled alkaline mirror gray hoarded candy wad	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 44, Last Available: "2016-10"
 9147	anodized enhanced Prunets	0		Effect: "Sugary Tongue", Effect Duration: 49
-9148	blue spinning Twitching Television Tattoo	0		
+9148	spinning blue Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	cold-filtered ionized invisible string	0		Lasts Until Rollover, Effect: "Smelly Pants", Effect Duration: 66, Last Available: "2016-10"
 9151	moist frozen invisible seam ripper	0		Lasts Until Rollover, Effect: "Supafly", Effect Duration: 33, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	low-calorie yummy raw sweet potato	1	awesome	Last Available: "2016-11"
-9154	stale gigantic raw beans	7	decent	Last Available: "2016-11"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9153	yummy low-calorie raw sweet potato	1	awesome	Last Available: "2016-11"
+9154	gigantic stale raw beans	7	decent	Last Available: "2016-11"
 9155	big decent raw stuffing	5	good	Last Available: "2016-11"
-9156	special small flavorless raw cranberry sauce	2	decent	Effect: "Cybernetic Muscles", Effect Duration: 35, Last Available: "2016-11"
+9156	small special flavorless raw cranberry sauce	2	decent	Effect: "Cybernetic Muscles", Effect Duration: 35, Last Available: "2016-11"
 9157	rotten thick raw turkey	5	crappy	Last Available: "2016-11"
-9158	huge rotten bouncing raw mincemeat	10	crappy	Last Available: "2016-11"
+9158	rotten huge bouncing raw mincemeat	10	crappy	Last Available: "2016-11"
 9159	diet flavorless tumbling raw potato	1	decent	Last Available: "2016-11"
-9160	stale half-sized raw gravy	2	decent	Last Available: "2016-11"
-9161	bite-sized toothsome raw bread	1	awesome	Last Available: "2016-11"
+9160	half-sized stale raw gravy	2	decent	Last Available: "2016-11"
+9161	toothsome bite-sized raw bread	1	awesome	Last Available: "2016-11"
 9162	yellow Sinatra's mini-marshmallow dispenser of the cheetah	0		Experience (Moxie): +5, Initiative: +60, Last Available: "2016-11"
 9163	coward's vibrating baleful glass casserole dish	0		Spell Damage: +25, Maximum MP Percent: +10, Monster Level: -20, Last Available: "2016-11"
-9164	lime green skewed stuffing fluffer	0		Last Available: "2016-11"
+9164	skewed lime green stuffing fluffer	0		Last Available: "2016-11"
 9165	cyan curative can opener of the businessman	0		Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
 9166	pickled turkey blaster	1		Last Available: "2016-11"
 9167	reassuring weightlifter's glass pie plate	0		Muscle: +15, Spooky Resistance: +1, Damage Reduction: 7, Last Available: "2016-11"
 9168	electrified steel-toed potato masher	0		Damage Reduction: 9, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bouncing bread mold	0		Last Available: "2016-11"
-9171	jumbo adequate sweet potatoes	5	good	Last Available: "2016-11"
+9171	adequate jumbo sweet potatoes	5	good	Last Available: "2016-11"
 9172	decent bean casserole	3	good	Last Available: "2016-11"
-9173	half-sized stale baked stuffing	2	decent	Last Available: "2016-11"
+9173	stale half-sized baked stuffing	2	decent	Last Available: "2016-11"
 9174	flavorless huge cranberry cylinder	9	decent	Last Available: "2016-11"
 9175	adequate wobbly thanksgiving turkey	4	good	Last Available: "2016-11"
 9176	spoiled mince pie	4	crappy	Last Available: "2016-11"
 9177	rotten tumbling mashed potatoes	3	crappy	Last Available: "2016-11"
 9178	bland half-sized warm gravy	2	decent	Last Available: "2016-11"
-9179	tiny flavorless bread roll	1	decent	Last Available: "2016-11"
-9180	snack-sized stale mirror leftovers	2	decent	Last Available: "2016-11"
+9179	flavorless tiny bread roll	1	decent	Last Available: "2016-11"
+9180	stale snack-sized mirror leftovers	2	decent	Last Available: "2016-11"
 9181	flavorless leftovers sandwich	3	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
-9183	skewed jittery red cornucopia	0		Last Available: "2016-11"
+9183	jittery red skewed cornucopia	0		Last Available: "2016-11"
 9184	jittery megacopia	0		Last Available: "2016-11"
 9185	yellow pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
@@ -9061,7 +9061,7 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	red eldritch effluvium	0		
 9191	adjusted eldritch concentrate	0		Effect: "Tenacity of the Snapper", Effect Duration: 67, Last Available: "2016-11"
-9192	bad weak eldritch extract	2	decent	Last Available: "2016-11"
+9192	weak bad eldritch extract	2	decent	Last Available: "2016-11"
 9193	frosty Fonzie's Official Council Aide Pin	0		Experience (Moxie): +1, Cold Spell Damage: +10, Last Available: "2016-11"
 9194	watered-down aged skewed eldritch distillate	2	awesome	Last Available: "2016-11"
 9195	compressed ghostly eldritch essence	1		Last Available: "2016-11"
@@ -9089,8 +9089,8 @@
 9217	upside-down gingerbread restraining order	0		Last Available: "2016-12"
 9218	gray sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	moldy purple animal part cracker	4	crappy	Last Available: "2016-12"
-9220	mediocre special gingerbread wine	3	decent	Effect: "Highland Sheen", Effect Duration: 25, Last Available: "2016-12"
-9221	spoiled huge gingerbread mug	10	crappy	Last Available: "2016-12"
+9220	special mediocre gingerbread wine	3	decent	Effect: "Highland Sheen", Effect Duration: 25, Last Available: "2016-12"
+9221	huge spoiled gingerbread mug	10	crappy	Last Available: "2016-12"
 9222	green aromatic gingerbread mask	0		Stench Resistance: +1, Last Available: "2016-12"
 9223	pulsating scandalous manspreader's brainy gingerservo	0		Mysticality: +5, Monster Level: +10, Sleaze Damage: +5, Single Equip, Last Available: "2016-12"
 9224	boiled double-activated tainted icing	0		Effect: "Sticky Fingers", Effect Duration: 28, Last Available: "2016-12"
@@ -9108,10 +9108,10 @@
 9236	pulsating wobbly Rosewater's gingerbread gavel of Leguizamo	0		Mysticality Percent: +30, Monster Level: +20, Last Available: "2016-12"
 9237	bouncing gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	tolerable weak blinking ginger beer	2	good	Last Available: "2016-12"
+9239	weak tolerable blinking ginger beer	2	good	Last Available: "2016-12"
 9240	squat spare chocolate parts	0		Last Available: "2016-12"
-9241	nitrogenated ionized twirling yellow upside-down industrial frosting	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 36, Last Available: "2016-12"
-9242	corrupted ghostly blurry fake cocktail	0		Effect: "Healthy Blue Glow", Effect Duration: 64, Last Available: "2016-12"
+9241	nitrogenated ionized upside-down yellow twirling industrial frosting	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 36, Last Available: "2016-12"
+9242	corrupted blurry ghostly fake cocktail	0		Effect: "Healthy Blue Glow", Effect Duration: 64, Last Available: "2016-12"
 9243	bad high-end ginger wine	3	decent	Last Available: "2016-12"
 9244	ghostly plastic bad vibe of the glutton	0		Food Drop: +100, Last Available: "2016-12"
 9245	pulsating wholesome plastic angry vikings	0		Maximum HP Percent: +10, Last Available: "2016-12"
@@ -9124,7 +9124,7 @@
 9252	spoiled spiritual candy cane	3	crappy	Last Available: "2016-12"
 9253	hand-crafted weak huge spiritual eggnog	2	EPIC	Last Available: "2016-12"
 9254	tasty spinning spiritual fruitcake	3	awesome	Last Available: "2016-12"
-9255	enchanted toothsome tiny spiritual gingerbread	1	awesome	Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2016-12"
+9255	tiny enchanted toothsome spiritual gingerbread	1	awesome	Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	gray My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9135,7 +9135,7 @@
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	shaking teethpick	0		Last Available: "2016-12"
-9266	Vulcanized extra-liquefied shaking yellow rock candy	0		Effect: "Buggy Flavor", Effect Duration: 19, Last Available: "2016-12"
+9266	Vulcanized extra-liquefied yellow shaking rock candy	0		Effect: "Buggy Flavor", Effect Duration: 19, Last Available: "2016-12"
 9267	normal green-iced sweet roll	4	good	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	shaking chocolate sculpture	0		Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	delicious red chakra-mental wine	3	awesome	Last Available: "2016-12"
 9277	cold-filtered wet wobbly tumbling chakra malt	0		Effect: "Incensed", Effect Duration: 38, Last Available: "2016-12"
 9278	delicious Black Angus blackburger	3	awesome	Last Available: "2016-12"
-9279	tolerable fancy fortified brandy	5	good	Effect: "Reedy Pipes", Effect Duration: 20, Last Available: "2016-12"
+9279	fortified fancy tolerable brandy	5	good	Effect: "Reedy Pipes", Effect Duration: 20, Last Available: "2016-12"
 9280	quadruple-anodized warmed quadruple-warmed squat potion of spiritual gunkifying	0		Effect: "Pie in the Sky", Effect Duration: 15, Last Available: "2016-12"
 9281	razor-sharp sage bad vibroknife	0		Mysticality Percent: +10, Weapon Damage Percent: +25, Last Available: "2016-12"
 9282	yellow miser's strapping crystal belt buckle	0		Muscle: +5, Meat Drop: +10, Last Available: "2016-12"
@@ -9163,13 +9163,13 @@
 9291	dehydrated hot jelly	1		Last Available: "2017-01"
 9292	compressed jelly	1		Last Available: "2017-01"
 9293	distilled jelly	1		Last Available: "2017-01"
-9294	mixed tumbling blinking sleaze jelly	1		Last Available: "2017-01"
+9294	mixed blinking tumbling sleaze jelly	1		Last Available: "2017-01"
 9295	powdered stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	adequate toast with hot jelly	4	good	Last Available: "2017-01"
 9298	snack-sized stale toast with jelly	2	decent	Last Available: "2017-01"
 9299	adequate toast with jelly	4	good	Last Available: "2017-01"
-9300	adequate small toast with sleaze jelly	2	good	Last Available: "2017-01"
+9300	small adequate toast with sleaze jelly	2	good	Last Available: "2017-01"
 9301	decent bite-sized toast with stench jelly	1	good	Last Available: "2017-01"
 9302	cyan space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9180,7 +9180,7 @@
 9308	ghostly lime green prompt fortified wax face	0		Damage Absorption: +60, Adventures: +3, Last Available: "2017-01"
 9309	drinkable wax booze	3	good	Last Available: "2017-01"
 9310	purple glob of melted wax	0		Last Available: "2017-01"
-9311	compressed red twirling sea jelly	1		Last Available: "2017-01"
+9311	compressed twirling red sea jelly	1		Last Available: "2017-01"
 9312	adequate spinning sea truffle	3	good	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	tumbling crushed steamer trunk	0		Last Available: "2017-01"
@@ -9208,7 +9208,7 @@
 9336	blue eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	oxidized huge eldritch rub	0		Effect: "Work For Hours a Week", Effect Duration: 19, Last Available: "2017-02"
 9338	red HP-35 Calculator	0		
-9339	olive wobbly Silver HP-35 Calculator	0		
+9339	wobbly olive Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	huge Diamond HP-35 Calculator	0		
@@ -9235,29 +9235,29 @@
 9363	twirling slime shooter	0		Last Available: "2017-03"
 9364	pulsating imaginary lemon	0		Last Available: "2017-03"
 9365	smooth literal grasshopper	3	awesome	Last Available: "2017-03"
-9366	artisanal fancy practically non-alcoholic double entendre	1	EPIC	Effect: "Salty Mouth", Effect Duration: 35, Last Available: "2017-03"
+9366	practically non-alcoholic fancy artisanal double entendre	1	EPIC	Effect: "Salty Mouth", Effect Duration: 35, Last Available: "2017-03"
 9367	aged fancy Phlegethon	4	awesome	Effect: "One For Tea", Effect Duration: 35, Last Available: "2017-03"
 9368	artisanal extra-dry spinning Siberian sunrise	5	EPIC	Last Available: "2017-03"
 9369	strong artisanal spinning mentholated wine	5	EPIC	Last Available: "2017-03"
-9370	enchanted fortified perfectly mixed low tide martini	5	EPIC	Effect: "Brother Smothers's Blessing", Effect Duration: 20, Last Available: "2017-03"
+9370	enchanted perfectly mixed fortified low tide martini	5	EPIC	Effect: "Brother Smothers's Blessing", Effect Duration: 20, Last Available: "2017-03"
 9371	watered-down lousy shroomtini	2	decent	Last Available: "2017-03"
-9372	practically non-alcoholic delicious blinking red morning dew	1	awesome	Last Available: "2017-03"
+9372	delicious practically non-alcoholic blinking red morning dew	1	awesome	Last Available: "2017-03"
 9373	special hand-crafted whiskey squeeze	3	EPIC	Effect: "Square to be Hip", Effect Duration: 35, Last Available: "2017-03"
 9374	artisanal great fashioned	4	EPIC	Last Available: "2017-03"
 9375	aged spinning Gnomish sagngria	3	awesome	Last Available: "2017-03"
 9376	perfectly mixed vodka stinger	4	EPIC	Last Available: "2017-03"
-9377	mediocre spirit-forward extremely slippery nipple	5	decent	Last Available: "2017-03"
+9377	spirit-forward mediocre extremely slippery nipple	5	decent	Last Available: "2017-03"
 9378	acceptable blurry piscatini	3	good	Last Available: "2017-03"
 9379	tolerable Churchill	4	good	Last Available: "2017-03"
 9380	perfectly mixed extra-dry soilzerac	5	EPIC	Last Available: "2017-03"
-9381	perfectly mixed weak bouncing skewed skewed London frog	2	EPIC	Last Available: "2017-03"
-9382	perfectly mixed watered-down nothingtini	2	EPIC	Last Available: "2017-03"
-9383	boozy perfectly mixed twirling olive eighth plague	5	EPIC	Last Available: "2017-03"
-9384	drinkable weak shaking single entendre	2	good	Last Available: "2017-03"
-9385	practically non-alcoholic smooth upside-down reverse Tantalus	1	awesome	Last Available: "2017-03"
-9386	artisanal triple-distilled elemental caipiroska	6	EPIC	Last Available: "2017-03"
+9381	weak perfectly mixed skewed skewed bouncing London frog	2	EPIC	Last Available: "2017-03"
+9382	watered-down perfectly mixed nothingtini	2	EPIC	Last Available: "2017-03"
+9383	perfectly mixed boozy twirling olive eighth plague	5	EPIC	Last Available: "2017-03"
+9384	weak drinkable shaking single entendre	2	good	Last Available: "2017-03"
+9385	smooth practically non-alcoholic upside-down reverse Tantalus	1	awesome	Last Available: "2017-03"
+9386	triple-distilled artisanal elemental caipiroska	6	EPIC	Last Available: "2017-03"
 9387	hand-crafted Feliz Navidad	4	EPIC	Last Available: "2017-03"
-9388	distilled hand-crafted blinking green Bloody Nora	5	EPIC	Last Available: "2017-03"
+9388	distilled hand-crafted green blinking Bloody Nora	5	EPIC	Last Available: "2017-03"
 9389	perfectly mixed moreltini	3	EPIC	Last Available: "2017-03"
 9390	practically non-alcoholic tolerable hell in a bucket	1	good	Last Available: "2017-03"
 9391	bad spinning Newark	3	decent	Last Available: "2017-03"
@@ -9267,7 +9267,7 @@
 9395	acceptable practically non-alcoholic Mysterious Island iced tea	1	good	Last Available: "2017-03"
 9396	artisanal twirling drive-by shooting	3	EPIC	Last Available: "2017-03"
 9397	distilled tolerable gunner's daughter	5	good	Last Available: "2017-03"
-9398	lousy special watered-down fuchsia dirt julep	2	decent	Effect: "Eye of the Seal", Effect Duration: 30, Last Available: "2017-03"
+9398	lousy watered-down special fuchsia dirt julep	2	decent	Effect: "Eye of the Seal", Effect Duration: 30, Last Available: "2017-03"
 9399	distilled bad Simepore slime	5	decent	Last Available: "2017-03"
 9400	drinkable Phil Collins	3	good	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9289,10 +9289,10 @@
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	olive fascinating alien plant sample	0		Last Available: "2017-04"
-9420	denatured blinking bouncing alien plant goo	1		Last Available: "2017-04"
+9420	denatured bouncing blinking alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	super-sized stale alien meat	5	decent	Last Available: "2017-04"
+9423	stale super-sized alien meat	5	decent	Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	resourceful wicked Sinatra's murderbot mask	0		Experience (Moxie): +5, Spell Damage: +5, Maximum MP: +50, Avatar: "Murderbot", Last Available: "2017-04"
 9454	pressed quadruple-modified ghostly murderbot spring injector	0		Effect: "Butt-Rock Hair", Effect Duration: 32, Last Available: "2017-04"
 9455	supercharged personal trainer's murderbot whip	0		Experience Percent (Muscle): +10, Maximum MP Percent: +30, Last Available: "2017-04"
-9456	spinning personal trainer's murderbot plasma rifle of the empath	0		Experience Percent (Muscle): +10, Familiar Weight: +5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	spinning personal trainer's murderbot plasma rifle of the empath	0		Experience Percent (Muscle): +10, Familiar Weight: +5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9336,7 +9336,7 @@
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	skewed upside-down Spacegate	0		Last Available: "2017-04"
 9466	toothsome snack-sized Aldebaran sardines	2	awesome	Last Available: "2017-04"
-9467	tolerable fancy strong Centauri fish wine	5	good	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2017-04"
+9467	fancy tolerable strong Centauri fish wine	5	good	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2017-04"
 9468	modified upside-down maroon oxygen	1		Last Available: "2017-04"
 9469	squat boxer's Spacegate scientist's insignia of the blizzard	0		Muscle Percent: +10, Cold Spell Damage: +25, Single Equip, Last Available: "2017-04"
 9470	reassuring Rosewater's Spacegate military insignia	0		Mysticality Percent: +30, Spooky Resistance: +1, Single Equip, Last Available: "2017-04"
@@ -9345,7 +9345,7 @@
 9473	gray Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	immense decent alien sandwich	9	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
-9476	colloidal lime green jittery tumbling mirror Spant eggs	0		Effect: "Medieval Mage Mayhem", Effect Duration: 31
+9476	colloidal tumbling mirror lime green jittery Spant eggs	0		Effect: "Medieval Mage Mayhem", Effect Duration: 31
 9477	narrow Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	liquefied Daily Affirmation: Always be Collecting	0		Effect: "Sweet Tooth", Effect Duration: 25, Last Available: "2017-05"
@@ -9362,9 +9362,9 @@
 9490	tarnished tarnished Threatening Missive	0		Effect: "Hiding in Plain Sight", Effect Duration: 42
 9491	jittery Targeted Plague Vector	0		
 9492	ghostly suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	razor-sharp Herculean Kremlin's Greatest Briefcase of the bloodbag	0		Experience (Muscle): +1, Weapon Damage Percent: +25, Maximum HP: +100, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	razor-sharp Herculean Kremlin's Greatest Briefcase of the bloodbag	0		Experience (Muscle): +1, Weapon Damage Percent: +25, Maximum HP: +100, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	mediocre basic martini	3	decent	Last Available: "2017-06"
-9495	delicious special improved martini	3	awesome	Effect: "Cringle's Curative Carol", Effect Duration: 35, Last Available: "2017-06"
+9495	special delicious improved martini	3	awesome	Effect: "Cringle's Curative Carol", Effect Duration: 35, Last Available: "2017-06"
 9496	smooth fortified splendid martini	5	awesome	Last Available: "2017-06"
 9497	spinning exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	big spoiled meteoreo	5	crappy	Last Available: "2017-08"
-9515	weak artisanal jittery meadeorite	2	EPIC	Last Available: "2017-08"
+9515	artisanal weak jittery meadeorite	2	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	rosy-cheeked meteortarboard of the empath of the sewer	0		Maximum HP Percent: +30, Familiar Weight: +5, Stench Damage: +25, Last Available: "2017-08"
 9518	ribald gravedigger's meteorite guard of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Sleaze Damage: +10, Damage Reduction: 9, Last Available: "2017-08"
-9519	greasy meteorb of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +10, Lantern Element: "Hot", Last Available: "2017-08"
+9519	greasy meteorb of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2017-08", Lantern Element: "Hot"
 9520	forbidden asteroid belt of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Single Equip, Last Available: "2017-08"
 9521	coward's energetic arcane researcher's meteorthopedic shoes	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Monster Level: -20, Single Equip, Last Available: "2017-08"
 9522	stanky weightlifter's shooting morning star of the dark arts	0		Muscle: +15, Spell Damage Percent: +100, Stench Spell Damage: +25, Single Equip, Last Available: "2017-08"
@@ -9398,7 +9398,7 @@
 9526	perfectly fair coin	0		Last Available: "2017-11"
 9527	Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	gray corked genie bottle	0		Free Pull, Last Available: "2017-09"
-9529	narrow pulsating genie bottle	0		Last Available: "2017-09"
+9529	pulsating narrow genie bottle	0		Last Available: "2017-09"
 9530	resourceful blessed rustproof +2 gray dragon scale mail of dire peril of the sweet-tooth	0		Weapon Damage: +20, Maximum MP: +50, Candy Drop: +100, Last Available: "2023-09"
 9531	tumbling pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	pony: Shutterfly	0		Last Available: "2017-09"
@@ -9406,7 +9406,7 @@
 9534	jittery pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
 9536	pony: Spectrum Dash	0		Last Available: "2017-09"
-9537	fuchsia spinning pocket wish	0		Last Available: "2023-09"
+9537	spinning fuchsia pocket wish	0		Last Available: "2023-09"
 9538	shaking fuchsia dropped scrap of paper	0		
 9539	skewed hunk of granite	0		
 9540	shovelful of dirt	0		
@@ -9419,7 +9419,7 @@
 9547	weak hand-crafted teal flask of port	2	EPIC	
 9548	Jeselnik's contract enforcement stick of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Damage: +25
 9549	flavorless Hide-rox&trade; cookie	3	decent	Last Available: "2017-10"
-9550	mediocre practically non-alcoholic jug of booze	1	decent	Last Available: "2017-10"
+9550	practically non-alcoholic mediocre jug of booze	1	decent	Last Available: "2017-10"
 9551	alkaline ionized green pair of candy glasses	0		Effect: "Nightstalkin'", Effect Duration: 30, Last Available: "2017-10"
 9552	non-adjusted ionized temporary X tattoos	0		Effect: "Mad at Science", Effect Duration: 46, Last Available: "2017-10"
 9553	diluted ghostly glyph of athleticism	1		Last Available: "2017-10"
@@ -9430,7 +9430,7 @@
 9558	shaking amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
 9560	O	0		Last Available: "2017-11"
-9561	tumbling blue amorphous blob	0		Last Available: "2017-11"
+9561	blue tumbling amorphous blob	0		Last Available: "2017-11"
 9562	lime green personal trainer's protection stick of Tarzan of the dark arts of temperance	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Spell Damage Percent: +100, Sleaze Resistance: +5
 9563	triple-corrupted frozen roll of meat	0		Effect: "Rat-Faced", Effect Duration: 13
 9564	therapeutic wicked mafia thumb ring	0		Spell Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip
@@ -9448,11 +9448,11 @@
 9576	shaking toasty mafia organizer badge	0		Hot Damage: +5, Single Equip
 9577	mafia filofax	0		
 9578	upside-down transparent nog	1	decent	Last Available: "2017-12"
-9579	stale thick twirling unfinished fruitcake	5	decent	Last Available: "2017-12"
+9579	thick stale twirling unfinished fruitcake	5	decent	Last Available: "2017-12"
 9580	quantum and cracker	0		Effect: "Chalked Weapon", Effect Duration: 20, Last Available: "2017-12"
-9581	fortified hand-crafted neg grog	5	EPIC	Last Available: "2017-12"
-9582	toothsome snack-sized upside-down half double fruitcake	2	awesome	Last Available: "2017-12"
-9583	spoiled low-calorie blue hushed puppy	1	crappy	Last Available: "2017-12"
+9581	hand-crafted fortified neg grog	5	EPIC	Last Available: "2017-12"
+9582	snack-sized toothsome upside-down half double fruitcake	2	awesome	Last Available: "2017-12"
+9583	low-calorie spoiled blue hushed puppy	1	crappy	Last Available: "2017-12"
 9584	bland muffled muffuletta	3	decent	Last Available: "2017-12"
 9585	stale shushed potatoes	4	decent	Last Available: "2017-12"
 9586	supercharged plastic mime functionary	0		Maximum MP Percent: +30, Last Available: "2017-12"
@@ -9488,19 +9488,19 @@
 9616	silent R	0		Last Available: "2017-12"
 9617	skewed blurry silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
-9619	bouncing upside-down silent U	0		Last Available: "2017-12"
+9619	upside-down bouncing silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
 9621	squat silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
-9626	huge twirling anti-earplugs	0		Last Available: "2017-12"
+9626	twirling huge anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	blurry mime pocket probe	0		Last Available: "2017-12"
 9629	artisanal stale cheer wine	4	EPIC	Last Available: "2017-12"
-9630	bland huge stale Cheer-E-Os	10	decent	Last Available: "2017-12"
-9631	spinning blurry twirling cheer-o-gram	0		Last Available: "2017-12"
+9630	huge bland stale Cheer-E-Os	10	decent	Last Available: "2017-12"
+9631	spinning twirling blurry cheer-o-gram	0		Last Available: "2017-12"
 9632	nippy cheerful antler hat of bravery	0		Cold Damage: +10, Spooky Resistance: +5, Last Available: "2017-12"
 9633	medical-grade personal trainer's cheerful Crimbo sweater	0		Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-12"
 9634	blinking baleful personal trainer's cheerful pajama pants	0		Experience Percent (Muscle): +10, Spell Damage: +25, Last Available: "2017-12"
@@ -9518,7 +9518,7 @@
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	acceptable extra-dry executive mime flask	5	good	Last Available: "2017-12"
-9649	bland diet nega-mushroom	1	decent	Last Available: "2017-12"
+9649	diet bland nega-mushroom	1	decent	Last Available: "2017-12"
 9650	smooth weak bouncing jittery nega-mushroom wine	2	awesome	Last Available: "2017-12"
 9651	vacuum-sealed warmed Cheer-Up soda	0		Effect: "Scrappy, Shadowy", Effect Duration: 36, Last Available: "2017-12"
 9652	huge rotten mime army rations	7	crappy	Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	skewed donated candy	0		
 9665	unsweetened frozen olive digital honeypot	0		Effect: "Sagittarius Rising", Effect Duration: 44, Last Available: "2025-12"
 9666	spinning mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	perfumed mime army insignia (infantry)	0		Stench Resistance: +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	squat family-friendly mime army insignia (intelligence)	0		Sleaze Resistance: +1, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	tumbling Newton's mime army insignia (espionage)	0		Experience (Mysticality): +3, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	perfumed mime army insignia (infantry)	0		Stench Resistance: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	squat family-friendly mime army insignia (intelligence)	0		Sleaze Resistance: +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	tumbling Newton's mime army insignia (espionage)	0		Experience (Mysticality): +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	gray mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9552,7 +9552,7 @@
 9680	mirror fireproof skip lid	0		Familiar Weight: +5
 9681	adequate blinking extra-toasted half sandwich	4	good	Last Available: "2018-12"
 9682	hand-crafted mulled hobo wine	4	EPIC	Last Available: "2018-12"
-9683	pulsating lime green burning newspaper	0		Last Available: "2018-12"
+9683	lime green pulsating burning newspaper	0		Last Available: "2018-12"
 9684	stylish brainy burning paper hat of mayonnaise	0		Mysticality: +5, Moxie: +25, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-12"
 9685	narrow miser's Sinatra's burning cape of dire peril	0		Experience (Moxie): +5, Weapon Damage: +20, Meat Drop: +10, Lasts Until Rollover, Last Available: "2018-12"
 9686	banded studded sage burning paper slippers	0		Mysticality Percent: +10, Damage Absorption: 180, Single Equip, Lasts Until Rollover, Last Available: "2018-12"
@@ -9570,7 +9570,7 @@
 9698	alkaline unsweetened hot button candy	0		Effect: "Tiki Temerity", Effect Duration: 34
 9699	wobbly auspicious MacGyver's makeshift garbage shirt of bravery	0		Maximum MP: +100, Spooky Resistance: +5, Item Drop: +10, Last Available: "2018-01"
 9700	narrow executive slick novelty monorail ticket	0		Moxie: +10, Meat Drop: +40
-9701	diluted twirling green wobbly pills	1		
+9701	diluted wobbly twirling green pills	1		
 9702	powdered green furry pill	1		Effect: "Stickler for Promptness", Effect Duration: 15
 9703	altered upside-down beefy pill	1		Effect: "Bestial Sympathy", Effect Duration: 30
 9704	distilled mirror excitement pill	1		Effect: "Bugbear in Tooth and Claw", Effect Duration: 30
@@ -9580,8 +9580,8 @@
 9712	bouncing Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	upside-down How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	mirror Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
-9715	maroon mirror Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
-9716	pulsating blurry Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
+9715	mirror maroon Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
+9716	blurry pulsating Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	squat prompt Lo Pan's genie's turbane	0		Spell Critical Percent: +30, Adventures: +3, Last Available: "2018-02"
@@ -9592,16 +9592,16 @@
 9724	lightning-fast psychic's crystal ball of James Dean	0		Experience (Moxie): +3, Initiative: +40, Last Available: "2018-02"
 9725	purple Usain Bolt's Herculean psychic's pslacks	0		Experience (Muscle): +1, Initiative: +80, Last Available: "2018-02"
 9726	narrow yellow Da Vinci's psychic's amulet of bravery	0		Experience (Mysticality): +5, Spooky Resistance: +5, Last Available: "2018-02"
-9727	decent half-sized twirling bouncing heart-shaped candy whetstone	2	good	Last Available: "2018-02"
-9728	stale special Swedish massage fish	4	decent	Effect: "Sleazy Weapon", Effect Duration: 50, Last Available: "2018-02"
-9729	practically non-alcoholic lousy fuchsia Third Base	1	decent	Last Available: "2018-02"
+9727	decent half-sized bouncing twirling heart-shaped candy whetstone	2	good	Last Available: "2018-02"
+9728	special stale Swedish massage fish	4	decent	Effect: "Sleazy Weapon", Effect Duration: 50, Last Available: "2018-02"
+9729	lousy practically non-alcoholic fuchsia Third Base	1	decent	Last Available: "2018-02"
 9730	perfectly mixed Bustle Hustler	3	EPIC	Last Available: "2018-02"
 9731	adjusted Fabiotion	0		Effect: "Sugar High", Effect Duration: 44, Last Available: "2018-02"
 9732	enhanced Bettie page	0		Effect: "Ponderous Potency", Effect Duration: 27, Last Available: "2018-02"
 9733	moist wobbly tonic o' Banderas	0		Effect: "Memory of Resilience", Effect Duration: 41, Last Available: "2018-02"
-9734	flattened galvanized pulsating twirling heather graham cracker	0		Effect: "Mathematically Precise", Effect Duration: 54, Last Available: "2018-02"
+9734	flattened galvanized twirling pulsating heather graham cracker	0		Effect: "Mathematically Precise", Effect Duration: 54, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
-9736	wobbly squat heart cozy	0		Last Available: "2018-02"
+9736	squat wobbly heart cozy	0		Last Available: "2018-02"
 9737	skewed eaves droppers	0		Last Available: "2018-02"
 9738	personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
@@ -9647,7 +9647,7 @@
 9779	skewed Gorillape	0		Last Available: "2018-03"
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	Snoutlet	0		Last Available: "2018-03"
-9782	mirror wobbly blurry Ruffalo	0		Last Available: "2018-03"
+9782	wobbly mirror blurry Ruffalo	0		Last Available: "2018-03"
 9783	Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
 9785	skewed Straypler	0		Last Available: "2018-03"
@@ -9679,7 +9679,7 @@
 9811	purple Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
-9814	yellow squat Egnaro berry	0		Last Available: "2018-03"
+9814	squat yellow Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	upside-down Jamocha berry	0		Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	vaporized magnificent oyster egg	1		
 9829	powdered brilliant oyster egg	1		
 9830	denatured glistening oyster egg	1		
-9831	vaporized olive pulsating scintillating oyster egg	1		Effect: "Polka of Plenty", Effect Duration: 30
+9831	vaporized pulsating olive scintillating oyster egg	1		Effect: "Polka of Plenty", Effect Duration: 30
 9832	twisted pulsating pulsating pearlescent oyster egg	1		Effect: "Frozen Hands", Effect Duration: 20
 9833	boiled pulsating shaking lustrous oyster egg	1		
 9834	pickled narrow gleaming oyster egg	1		
@@ -9716,7 +9716,7 @@
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	upside-down blurry dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	blurry upside-down dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	ghostly poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	squat druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	half-sized bland denastified haunch	2	decent	Last Available: "2018-04"
-9879	high-proof perfectly mixed bad rum and good cola	8	EPIC	Last Available: "2018-04"
+9879	perfectly mixed high-proof bad rum and good cola	8	EPIC	Last Available: "2018-04"
 9880	magnetized colloidal huge Potion of Heroism	0		Effect: "Busy Bein' Delicious", Effect Duration: 39, Last Available: "2018-04"
 9881	Oprah's quilted sage leggings of the Spider Queen	0		Mysticality Percent: +10, Damage Absorption: +40, Maximum MP Percent: +50, Last Available: "2018-04"
 9882	gravedigger's crafty beefy Master Thief's utility belt	0		Muscle: +10, Maximum MP: +10, Spooky Damage: +10, Single Equip, Last Available: "2018-04"
@@ -9764,30 +9764,30 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	tolerable weak two meat muck	2	good	
-9899	snack-sized decent chocolate Ogre Chieftain	2	good	
-9900	decent small chocolate &quot;Phoenix&quot;	2	good	
+9899	decent snack-sized chocolate Ogre Chieftain	2	good	
+9900	small decent chocolate &quot;Phoenix&quot;	2	good	
 9901	adequate pulsating teal chocolate Spider Queen	3	good	
 9902	weak smooth ghostly hipster cocktail	2	awesome	
-9903	blurry God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	blurry God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	blurry God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	blurry God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	upside-down Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
 9911	gattoo	0		
 9912	upside-down A-Boo glue	0		
-9913	skewed purple glued A-Boo clue	0		
+9913	purple skewed glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	bland big spinning good guava	5	decent	
 9916	mediocre tumbling gin and ginger	3	decent	
 9917	Thwaitgold chigger statuette	0		
-9918	powdered narrow purple gaseous gravy	1		Effect: "Human-Hippy Hybrid", Effect Duration: 25
+9918	powdered purple narrow gaseous gravy	1		Effect: "Human-Hippy Hybrid", Effect Duration: 25
 9919	shaking SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	ghostly SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	mirror A Guide to Safari	0		Skill: "Experience Safari"
-9922	unsweetened ionized boiled cyan bouncing huge Shielding Potion	0		Effect: "You Know When to Walk Away", Effect Duration: 19, Last Available: "2018-06"
+9922	unsweetened ionized boiled huge bouncing cyan Shielding Potion	0		Effect: "You Know When to Walk Away", Effect Duration: 19, Last Available: "2018-06"
 9923	galvanized Vulcanized bouncing Punching Potion	0		Effect: "Super Structure", Effect Duration: 24, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
 9925	twisted olive Nightmare Fuel	1		Last Available: "2018-06"
@@ -9807,7 +9807,7 @@
 9939	kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	burglar/sleep mask	0		Last Available: "2018-07"
 9941	Thwaitgold masked hunter statuette	0		
-9942	bouncing blue Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
+9942	blue bouncing Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
 9943	Neverending Party guest pass	0		Last Available: "2018-09"
 9944	wobbly frightening dog trainer's Annie Oakley's PARTY HARD T-shirt	0		Critical Hit Percent: +20, Experience (familiar): +1, Spooky Damage: +5, Last Available: "2018-09"
 9945	Neverending Party favor	0		Last Available: "2018-09"
@@ -9817,17 +9817,17 @@
 9949	green neverending wallet chain	0		Last Available: "2018-09"
 9950	resourceful Rosewater's pentagram bandana	0		Mysticality Percent: +30, Maximum MP: +50, Last Available: "2018-09"
 9951	occult skull ring	0		Spell Damage Percent: +25, Single Equip, Last Available: "2018-09"
-9952	huge blurry electronics kit	0		Last Available: "2018-09"
-9953	half-sized spoiled PB&J with the crusts cut off	2	crappy	Last Available: "2018-09"
+9952	blurry huge electronics kit	0		Last Available: "2018-09"
+9953	spoiled half-sized PB&J with the crusts cut off	2	crappy	Last Available: "2018-09"
 9954	fuchsia jittery shaking squat dorky glasses of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9955	gray wool Newton's ponytail clip	0		Experience (Mysticality): +3, Cold Resistance: +1, Last Available: "2018-09"
-9956	huge paint palette of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	huge paint palette of vim and vigor	0		Maximum HP Percent: +50, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	twirling unremarkable duffel bag	0		Last Available: "2018-09"
 9958	powdered blue Purple Beast energy drink	1		Last Available: "2018-09"
 9959	bouncing upside-down censurious cosmetic football	0		Sleaze Resistance: +3, Last Available: "2018-09"
 9960	baleful beefy shoe ad T-shirt	0		Muscle: +10, Spell Damage: +25, Last Available: "2018-09"
 9961	supercool pump-up high-tops	0		Moxie Percent: +20, Single Equip, Last Available: "2018-09"
-9962	frozen improved ghostly bouncing runproof mascara	0		Effect: "Sparkly!", Effect Duration: 58, Last Available: "2018-09"
+9962	frozen improved bouncing ghostly runproof mascara	0		Effect: "Sparkly!", Effect Duration: 58, Last Available: "2018-09"
 9963	mirror very small dress	0		Last Available: "2018-09"
 9964	Usain Bolt's noticeable pumps of the brazier	0		Hot Spell Damage: +25, Initiative: +80, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9843,15 +9843,15 @@
 9976	mirror smartaleck's party pants of extreme caution	0		Moxie Percent: +30, Monster Level: -25, Last Available: "2018-09"
 9977	double-paned party whip of the brazier of the sweet-tooth	0		Hot Spell Damage: +25, Cold Resistance: +5, Candy Drop: +100, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	practically non-alcoholic mediocre TRIO cup of beer	1	decent	Last Available: "2018-09"
+9979	mediocre practically non-alcoholic TRIO cup of beer	1	decent	Last Available: "2018-09"
 9980	stale gray party platter for one	3	decent	Last Available: "2018-09"
 9981	diluted Party-in-a-Can&trade;	1		Effect: "Human-Beast Hybrid", Effect Duration: 35, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	fortified forbidden party crasher	0		Spell Damage Percent: +50, Damage Absorption: +60, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	fortified forbidden party crasher	0		Spell Damage Percent: +50, Damage Absorption: +60, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	twirling latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of the pedagogue	0		Experience: +3, Lasts Until Rollover, Last Available: "2018-11"
@@ -9879,13 +9879,13 @@
 10013	flavorless blurry pizza	4	decent	Last Available: "2018-11"
 10014	tolerable twirling martini	4	good	Last Available: "2018-11"
 10015	adequate snack-sized cherry pie	2	good	Last Available: "2018-11"
-10016	fancy perfectly mixed eggnog	3	EPIC	Effect: "Phairly Balanced", Effect Duration: 50, Last Available: "2018-11"
+10016	perfectly mixed fancy eggnog	3	EPIC	Effect: "Phairly Balanced", Effect Duration: 50, Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	decent Hell ramen	3	good	Last Available: "2018-11"
-10019	irresponsibly strong acceptable narrow gimlet	6	good	Last Available: "2018-11"
+10019	acceptable irresponsibly strong narrow gimlet	6	good	Last Available: "2018-11"
 10020	bad practically non-alcoholic twice-haunted screwdriver	1	decent	Last Available: "2018-11"
 10021	toothsome diet candy cane	1	awesome	Last Available: "2018-12"
-10022	acceptable special runny fermented egg	3	good	Effect: "Fruited", Effect Duration: 45, Last Available: "2018-12"
+10022	special acceptable runny fermented egg	3	good	Effect: "Fruited", Effect Duration: 45, Last Available: "2018-12"
 10023	massive adequate huge oldcake	7	good	Last Available: "2018-12"
 10024	normal teal shaking traditional Crimbo cookie	4	good	Last Available: "2023-06"
 10025	upside-down flame-retardant plastic wild beaver	0		Hot Resistance: +1, Last Available: "2018-12"
@@ -9902,11 +9902,11 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	decent small grilled mooseflank	2	good	Last Available: "2018-12"
-10040	spoiled miniature moosemeat pie	2	crappy	Last Available: "2018-12"
+10039	small decent grilled mooseflank	2	good	Last Available: "2018-12"
+10040	miniature spoiled moosemeat pie	2	crappy	Last Available: "2018-12"
 10041	mirror skewed baleful balanced antler	0		Spell Damage: +25, Last Available: "2018-12"
 10042	dam of dire peril	0		Weapon Damage: +20, Damage Reduction: 9, Last Available: "2018-12"
-10043	special aged spirit-forward beavermouth	5	awesome	Effect: "Took Eleven", Effect Duration: 10, Last Available: "2018-12"
+10043	spirit-forward special aged beavermouth	5	awesome	Effect: "Took Eleven", Effect Duration: 10, Last Available: "2018-12"
 10044	mediocre beaver punch (papaya)	3	decent	Last Available: "2018-12"
 10045	tolerable olive beaver punch (peach)	4	good	Last Available: "2018-12"
 10046	lousy beaver punch (cherry)	4	decent	Last Available: "2018-12"
@@ -9914,7 +9914,7 @@
 10048	Jack Frost's muskox-skin cap	0		Cold Spell Damage: +50, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	spoiled wobbly glass of raw eggs	3	crappy	Last Available: "2018-12"
-10051	watered-down acceptable red skewed punch-drunk punch	2	good	Last Available: "2018-12"
+10051	acceptable watered-down skewed red punch-drunk punch	2	good	Last Available: "2018-12"
 10052	modified body spradium	1		Last Available: "2018-12"
 10053	pulsating Jeselnik's bauxite beret	0		Sleaze Damage: +25, Last Available: "2018-12"
 10054	mirror crafty bauxite boxers	0		Maximum MP: +10, Last Available: "2018-12"
@@ -9929,8 +9929,8 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	watered-down tolerable ghostly beer	2	good	Last Available: "2018-12"
-10067	small normal yule gruel	2	good	Last Available: "2018-12"
+10066	tolerable watered-down ghostly beer	2	good	Last Available: "2018-12"
+10067	normal small yule gruel	2	good	Last Available: "2018-12"
 10068	triple-distilled acceptable hot watered rum	9	good	Last Available: "2018-12"
 10069	drinkable bottle of Crimbognac	3	good	Last Available: "2018-12"
 10070	decent Crimboysters Rockefeller	3	good	Last Available: "2018-12"
@@ -9961,21 +9961,21 @@
 10095	dog trainer's shellacked marble mariachi hat	0		Damage Reduction: 7, Experience (familiar): +1, Last Available: "2019-12"
 10096	distilled mirror marble molecules	1		Last Available: "2019-12"
 10097	galvanized Mallomarbles	0		Effect: "Phoenix, Right?", Effect Duration: 64
-10098	red miser's banded punching bag	0		Damage Absorption: +100, Meat Drop: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	narrow dog trainer's hardened pith helmet	0		Damage Reduction: 3, Experience (familiar): +1, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	boxer's poncho of the blizzard	0		Muscle Percent: +10, Cold Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	censurious forbidden pendant	0		Spell Damage Percent: +50, Sleaze Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	Jim Carey's studded palazzos	0		Damage Absorption: +80, Monster Level: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	aromatic curative pseudoaccordion	0		Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10104	mixed olive squat pieces	1		Last Available: "2020-12"
+10098	red miser's banded punching bag	0		Damage Absorption: +100, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	narrow dog trainer's hardened pith helmet	0		Damage Reduction: 3, Experience (familiar): +1, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	boxer's poncho of the blizzard	0		Muscle Percent: +10, Cold Spell Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	censurious forbidden pendant	0		Spell Damage Percent: +50, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	Jim Carey's studded palazzos	0		Damage Absorption: +80, Monster Level: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	aromatic curative pseudoaccordion	0		Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10104	mixed squat olive pieces	1		Last Available: "2020-12"
 10105	oxidized warmed adjusted Para-Pop	0		Effect: "Bat Attitude", Effect Duration: 61
-10106	terra cotta truss of Tarzan of bravery	0		Experience (Muscle): +3, Spooky Resistance: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	horrifying terra cotta trousers of Flo-Jo	0		Spooky Damage: +25, Initiative: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	skewed gravedigger's clever terra cotta tongs	0		Maximum MP: +20, Spooky Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	blurry careful terra cotta train of courage	0		Monster Level: -10, Spooky Resistance: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	bouncing squat Annie Oakley's grievous terra cotta tie tack	0		Weapon Damage Percent: +50, Critical Hit Percent: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	Temple Grandin's Newton's terra cotta tambourine	0		Experience (Mysticality): +3, Familiar Weight: +7, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10112	altered mirror purple twirling terra cotta tidbits	1		Last Available: "2020-12"
+10106	terra cotta truss of Tarzan of bravery	0		Experience (Muscle): +3, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	horrifying terra cotta trousers of Flo-Jo	0		Spooky Damage: +25, Initiative: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	skewed gravedigger's clever terra cotta tongs	0		Maximum MP: +20, Spooky Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	blurry careful terra cotta train of courage	0		Monster Level: -10, Spooky Resistance: +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	bouncing squat Annie Oakley's grievous terra cotta tie tack	0		Weapon Damage Percent: +50, Critical Hit Percent: +20, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	Temple Grandin's Newton's terra cotta tambourine	0		Experience (Mysticality): +3, Familiar Weight: +7, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10112	altered purple twirling mirror terra cotta tidbits	1		Last Available: "2020-12"
 10113	energized nitrogenated terra panna cotta	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 28
 10114	censurious smooth velour voulge	0		Moxie: +15, Sleaze Resistance: +3, Last Available: "2021-12"
 10115	Da Vinci's velour vambraces of the bloodbag	0		Experience (Mysticality): +5, Maximum HP: +100, Single Equip, Last Available: "2021-12"
@@ -9993,26 +9993,26 @@
 10127	Temple Grandin's personal trainer's glass serape	0		Experience Percent (Muscle): +10, Familiar Weight: +7, Last Available: "2021-12"
 10128	boiled shaking glass shards	1		Last Available: "2021-12"
 10129	enhanced extra-frozen pulsating hard candy	0		Effect: "Frisky Spirit", Effect Duration: 15
-10130	weightlifter's loofah lumberjack's hat of Calamity Jane	0		Muscle: +15, Critical Hit Percent: +15, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	censurious grievous loofah lei	0		Weapon Damage Percent: +50, Sleaze Resistance: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	family-friendly healthy loofah lederhosen	0		Maximum HP Percent: +20, Sleaze Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	blurry knitted hardy loofah ladle	0		Maximum HP: +50, Cold Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	loofah legwarmers of the glutton of Flo-Jo	0		Food Drop: +100, Initiative: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	greedy loofah lavalier of the cheetah	0		Meat Drop: +20, Initiative: +60, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	weightlifter's loofah lumberjack's hat of Calamity Jane	0		Muscle: +15, Critical Hit Percent: +15, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	censurious grievous loofah lei	0		Weapon Damage Percent: +50, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	family-friendly healthy loofah lederhosen	0		Maximum HP Percent: +20, Sleaze Resistance: +1, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	blurry knitted hardy loofah ladle	0		Maximum HP: +50, Cold Resistance: +3, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	loofah legwarmers of the glutton of Flo-Jo	0		Food Drop: +100, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	greedy loofah lavalier of the cheetah	0		Meat Drop: +20, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	powdered loofah lumps	1		Effect: "Adventurer's Best Friendship", Effect Duration: 20, Last Available: "2022-12"
 10137	double-diffused olive chocolate-covered loofah	0		Effect: "Your Favorite Flavor", Effect Duration: 49
-10138	fuchsia coward's medical-grade flagstone flag	0		Monster Level: -20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	hardy flagstone flail of the empath	0		Maximum HP: +50, Familiar Weight: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	mirror Lo Pan's flagstone flip-flops of the brute	0		Muscle Percent: +30, Spell Critical Percent: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	greasy occult flagstone fez	0		Spell Damage Percent: +25, Sleaze Spell Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	twirling asbestos-lined stiffened flagstone fleece	0		Damage Reduction: 1, Hot Resistance: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	manspreader's supercharged flagstone fringe	0		Maximum MP Percent: +30, Monster Level: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	diluted skewed jittery purple flagstone flagments	1		Effect: "Cool Spirit", Effect Duration: 50, Last Available: "2022-12"
+10138	fuchsia coward's medical-grade flagstone flag	0		Monster Level: -20, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	hardy flagstone flail of the empath	0		Maximum HP: +50, Familiar Weight: +5, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	mirror Lo Pan's flagstone flip-flops of the brute	0		Muscle Percent: +30, Spell Critical Percent: +30, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	greasy occult flagstone fez	0		Spell Damage Percent: +25, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	twirling asbestos-lined stiffened flagstone fleece	0		Damage Reduction: 1, Hot Resistance: +5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	manspreader's supercharged flagstone fringe	0		Maximum MP Percent: +30, Monster Level: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10144	diluted jittery skewed purple flagstone flagments	1		Effect: "Cool Spirit", Effect Duration: 50, Last Available: "2022-12"
 10145	chilled flattened Flag by the Foot&trade;	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 30
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	huge red-and-green microcamera	0		Familiar Weight: +5
 10148	bouncing Annie Oakley's cobbled-together Meat detector	0		Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2019-12"
-10149	super-polarized improved cyan shaking tin thermos of chai	0		Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2019-12"
+10149	super-polarized improved shaking cyan tin thermos of chai	0		Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2019-12"
 10150	denatured narrow prototype stimulant	1		Last Available: "2019-12"
 10151	hardy tailored vest	0		Maximum HP: +50, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
@@ -10029,21 +10029,21 @@
 10163	pickled government-issued candy	0		Effect: "It Didn't Kill You", Effect Duration: 27
 10164	nitrogenated diffused Pneumo bar	0		Effect: "Pharmaceutically Cool", Effect Duration: 35
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	ruddy Lil' Doctor&trade; bag of the early riser	0		Maximum HP Percent: +40, Adventures: +7, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	ruddy Lil' Doctor&trade; bag of the early riser	0		Maximum HP Percent: +40, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
-10169	rotten big bloodstick	5	crappy	
+10169	big rotten bloodstick	5	crappy	
 10170	drinkable bottle of Sanguiovese	4	good	
 10171	adequate actual blood sausage	3	good	
 10172	mediocre mirror mulled blood	4	decent	
-10173	tiny bland huge blood snowcone	1	decent	
+10173	bland tiny huge blood snowcone	1	decent	
 10174	weak perfectly mixed Red Russian	2	super ultra EPIC	
 10175	massive spoiled blood roll-up	8	crappy	
-10176	high-proof acceptable mirror bottle of blood	7	good	
-10177	big spoiled blood-soaked sponge cake	5	crappy	
+10176	acceptable high-proof mirror bottle of blood	7	good	
+10177	spoiled big blood-soaked sponge cake	5	crappy	
 10178	weak tolerable vampagne	2	good	
 10179	flavorless plain snowcone	3	decent	
 10180	Booke of Vampyric Knowledge	0		
-10181	tumbling narrow money bag	0		
+10181	narrow tumbling money bag	0		
 10182	tumbling money bag	0		
 10183	money bag	0		
 10184	blinking Thwaitgold mosquito statuette	0		
@@ -10074,8 +10074,8 @@
 10209	blinking windicle	0		Last Available: "2019-04"
 10210	narrow fuchsia Lo Pan's pirate radio ring of the sweet-tooth	0		Spell Critical Percent: +30, Candy Drop: +100, Single Equip, Last Available: "2019-04"
 10211	olive Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	stale immense pineapple slab	9	decent	Last Available: "2019-04"
-10213	rotten jumbo hibiscus petal	5	crappy	Last Available: "2019-04"
+10212	immense stale pineapple slab	9	decent	Last Available: "2019-04"
+10213	jumbo rotten hibiscus petal	5	crappy	Last Available: "2019-04"
 10214	vacuum-sealed huge mint leaf	0		Effect: "Penguinny Flavor", Effect Duration: 64, Last Available: "2019-04"
 10215	wobbly cocoa of youth	0		Last Available: "2019-04"
 10216	pickled teal ice molecule	1		Last Available: "2019-04"
@@ -10089,7 +10089,7 @@
 10224	green spinning Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	ghostly plush sea serpent of Flo-Jo	0		Initiative: +100, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	moldy small pirate fork	2		Last Available: "2019-04"
+10227	small moldy pirate fork	2		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	bouncing ring	0		Single Equip, Last Available: "2019-04"
 10230	greasy piratical blunderbuss of the sweet-tooth	0		Sleaze Spell Damage: +10, Candy Drop: +100, Last Available: "2019-04"
@@ -10097,14 +10097,14 @@
 10232	weak bad Island Landslide	2	decent	Last Available: "2019-04"
 10233	tolerable Island Thunderstorm	3	good	Last Available: "2019-04"
 10234	perfectly mixed Island Hurricane	3	EPIC	Last Available: "2019-04"
-10235	bad weak Skull Punch	2	decent	Last Available: "2019-04"
+10235	weak bad Skull Punch	2	decent	Last Available: "2019-04"
 10236	watered-down lousy Electric Punch	2	decent	Last Available: "2019-04"
-10237	practically non-alcoholic delicious ghostly Smuggler's Punch	1	awesome	Last Available: "2019-04"
+10237	delicious practically non-alcoholic ghostly Smuggler's Punch	1	awesome	Last Available: "2019-04"
 10238	mediocre Scorpion Bowl	4	decent	Last Available: "2019-04"
 10239	watered-down aged Turtle Bowl	2	awesome	Last Available: "2019-04"
-10240	boozy bad skewed Cobra Bowl	5	decent	Last Available: "2019-04"
+10240	bad boozy skewed Cobra Bowl	5	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	perfumed foul-smelling beefcake's vampyric cloake of the bloodbag of the storm	0		Muscle: +25, Maximum HP: +100, Maximum MP Percent: +40, Stench Damage: +10, Stench Resistance: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	perfumed foul-smelling beefcake's vampyric cloake of the bloodbag of the storm	0		Muscle: +25, Maximum HP: +100, Maximum MP Percent: +40, Stench Damage: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	narrow plastic pirate hat	0		Familiar Weight: +5
 10244	galvanized enhanced huge one piece of bubble gum	0		Effect: "Halloweeny", Effect Duration: 36
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	Oprah's medical-grade strapping Fourth of May Cosplay Saber	0		Muscle: +5, Maximum MP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	Oprah's medical-grade strapping Fourth of May Cosplay Saber	0		Muscle: +5, Maximum MP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	zippy avaricious ribald lion tamer's Van der Graaf medical-grade rock-hard sinister arcane researcher's cool brainy hewn moon-rune spoon	0		Mysticality: +5, Moxie: +5, Experience Percent (Mysticality): +10, Spell Damage: +10, Damage Reduction: 5, Experience (familiar): +2, Sleaze Damage: +10, Meat Drop: +30, Initiative: +20, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	zippy avaricious ribald lion tamer's Van der Graaf medical-grade rock-hard sinister arcane researcher's cool brainy hewn moon-rune spoon	0		Mysticality: +5, Moxie: +5, Experience Percent (Mysticality): +10, Spell Damage: +10, Damage Reduction: 5, Experience (familiar): +2, Sleaze Damage: +10, Meat Drop: +30, Initiative: +20, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	ghostly Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	gray Sherlock's fortified Beach Comb of incineration	0		Damage Absorption: +60, Hot Spell Damage: +50, Item Drop: +25, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	gray Sherlock's fortified Beach Comb of incineration	0		Damage Absorption: +60, Hot Spell Damage: +50, Item Drop: +25, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	wobbly small pile of sand	0		Last Available: "2019-07"
 10261	squat pile of sand	0		Last Available: "2019-07"
@@ -10151,7 +10151,7 @@
 10286	cyan gravedigger's nippy sage meteorite earring	0		Mysticality Percent: +10, Cold Damage: +10, Spooky Damage: +10, Single Equip, Last Available: "2019-07"
 10287	tumbling avaricious mansplainer's Van der Graaf meteorite necklace	0		Monster Level: +15, Meat Drop: +30, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2019-07"
 10288	miser's Jack Frost's stiffened meteorite ring	0		Damage Reduction: 1, Cold Spell Damage: +50, Meat Drop: +10, Single Equip, Last Available: "2019-07"
-10289	activated narrow bouncing Finnish Fish	0		Effect: "Pumped Stomach", Effect Duration: 11
+10289	activated bouncing narrow Finnish Fish	0		Effect: "Pumped Stomach", Effect Duration: 11
 10290	quantum quantum chilled chocolate doubloon	0		Effect: "Chief Executive Optimism", Effect Duration: 54
 10291	nasty supercharged driftwood beach comb of Flo-Jo	0		Maximum MP Percent: +30, Stench Damage: +5, Initiative: +100, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	lime green Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
@@ -10169,7 +10169,7 @@
 10304	decent campfire baked potato	4	good	Last Available: "2019-08"
 10305	toothsome blinking campfire s'more	3	awesome	Last Available: "2019-08"
 10306	spoiled miniature teal campfire beans	2	crappy	Last Available: "2019-08"
-10307	snack-sized enchanted moldy campfire stew	2	crappy	Effect: "Human-Machine Hybrid", Effect Duration: 35, Last Available: "2019-08"
+10307	moldy enchanted snack-sized campfire stew	2	crappy	Effect: "Human-Machine Hybrid", Effect Duration: 35, Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	diffused leftover chocolate bar	0		Effect: "Pecan Pied Piper", Effect Duration: 58
 10310	rare Meat isotope	0		
@@ -10179,7 +10179,7 @@
 10314	Murgatroyd diode	0		
 10315	signal receiver	0		
 10316	space shield	0		Damage Reduction: 9
-10317	spinning squat signal jammer	0		Single Equip
+10317	squat spinning signal jammer	0		Single Equip
 10318	mirror low-pressure oxygen tank	0		Single Equip
 10319	ghostly Thwaitgold bombardier beetle statuette	0		
 10320	spoiled space chowder	4	crappy	
@@ -10193,21 +10193,21 @@
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	flavorless big purple bu&ntilde;uelos Jaliscos	5	decent	Last Available: "2019-12"
+10337	big flavorless purple bu&ntilde;uelos Jaliscos	5	decent	Last Available: "2019-12"
 10338	rotten flan del mar	4	crappy	Last Available: "2019-12"
-10339	small spoiled wobbly blue Baja sopapilla	2	crappy	Last Available: "2019-12"
+10339	small spoiled blue wobbly Baja sopapilla	2	crappy	Last Available: "2019-12"
 10340	blurry plastic Mer-kin baker of Flo-Jo	0		Initiative: +100, Last Available: "2019-12"
 10341	ribald plastic sea elf	0		Sleaze Damage: +10, Last Available: "2019-12"
 10342	plastic yuleviathan of the cougar	0		Moxie: +20, Last Available: "2019-12"
 10343	personal trainer's plastic dolphin &quot;orphan&quot;	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2019-12"
 10344	smartaleck's plastic Dolph Bossin	0		Moxie Percent: +30, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	rotten small mana-coated yams	2	crappy	Last Available: "2019-11"
-10347	super-sized spoiled pulsating mana-basted tofurkey leg	5	crappy	Last Available: "2019-11"
-10348	flavorless fancy mana-fortified cranberry sauce	3	decent	Effect: "Hobonic", Effect Duration: 10, Last Available: "2019-11"
+10346	small rotten mana-coated yams	2	crappy	Last Available: "2019-11"
+10347	spoiled super-sized pulsating mana-basted tofurkey leg	5	crappy	Last Available: "2019-11"
+10348	fancy flavorless mana-fortified cranberry sauce	3	decent	Effect: "Hobonic", Effect Duration: 10, Last Available: "2019-11"
 10349	adequate big mana-stuffed herbal stuffing	5	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
-10351	magnetized enhanced altered wobbly huge upside-down patch of extra-warm fur	0		Effect: "One For Tea", Effect Duration: 47, Last Available: "2019-12"
+10351	magnetized enhanced altered huge upside-down wobbly patch of extra-warm fur	0		Effect: "One For Tea", Effect Duration: 47, Last Available: "2019-12"
 10352	boiled blinking industrial lubricant	1		Effect: "Incredibly Hulking", Effect Duration: 15, Last Available: "2019-12"
 10353	modified tarnished unfinished pleasure	0		Effect: "Can Has Cyborger", Effect Duration: 69, Last Available: "2019-12"
 10354	twisted spinning vial of humanoid growth hormone	1		Last Available: "2019-12"
@@ -10220,7 +10220,7 @@
 10361	adequate guffin	3	good	Last Available: "2019-12"
 10362	altered twirling Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	denatured twirling fuchsia mirror non-Euclidean angle	1		Last Available: "2019-12"
+10364	denatured fuchsia mirror twirling non-Euclidean angle	1		Last Available: "2019-12"
 10365	chilled peppermint syrup	0		Effect: "The Moxie of LOV", Effect Duration: 18, Last Available: "2019-12"
 10366	moist upside-down Mer-kin eyedrops	0		Effect: "Elemental Flavor", Effect Duration: 15, Last Available: "2019-12"
 10367	warmed blinking extra-strength goo	0		Effect: "Leash of Linguini", Effect Duration: 53, Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	bouncing The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	pressed blurry skewed salty gumdrop	0		Effect: "Blubbered Up", Effect Duration: 46, Last Available: "2019-12"
+10384	pressed skewed blurry salty gumdrop	0		Effect: "Blubbered Up", Effect Duration: 46, Last Available: "2019-12"
 10385	spinning horrifying ribbon candy ascot of doom	0		Spooky Damage: +25, Spooky Spell Damage: +50, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	bouncing intact anemone spike	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	upside-down nutcracker figurine	0		Last Available: "2019-12"
 10415	fancy yummy salt plum	3	awesome	Effect: "Angry Bone", Effect Duration: 15, Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	toothsome gigantic and bean	7	awesome	Last Available: "2019-12"
+10417	gigantic toothsome and bean	7	awesome	Last Available: "2019-12"
 10418	miser's rosy-cheeked kelp-holly gun of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Meat Drop: +10, Last Available: "2019-12"
 10419	stiffened experienced Yuleviathan necklace	0		Experience: +2, Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10420	miser's peppermint spine of Flo-Jo	0		Meat Drop: +10, Initiative: +100, Last Available: "2019-12"
@@ -10284,23 +10284,23 @@
 10425	adequate tempura and bean	3	good	Last Available: "2019-12"
 10426	mediocre teal pulsating salt plum sake	4	decent	Last Available: "2019-12"
 10427	aerosolized colloidal pressurized potion of possessiveness	0		Effect: "Phoenix, Right?", Effect Duration: 48, Last Available: "2019-12"
-10428	adjusted adjusted pulsating upside-down almond	0		Effect: "Clyde's Blessing", Effect Duration: 53
+10428	adjusted adjusted upside-down pulsating almond	0		Effect: "Clyde's Blessing", Effect Duration: 53
 10429	super-altered cold-filtered handful of mixed nuts	0		Effect: "Deadly Lampblade", Effect Duration: 44, Last Available: "2019-12"
 10430	skewed nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	upside-down manspreader's quilted educational Retrospecs	0		Experience: +1, Damage Absorption: +40, Monster Level: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	upside-down manspreader's quilted educational Retrospecs	0		Experience: +1, Damage Absorption: +40, Monster Level: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
-10437	blue wobbly mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	toasty beefcake's beefy Powerful Glove of Tarzan of vim and vigor	0		Muscle: 35, Experience (Muscle): +3, Maximum HP Percent: +50, Hot Damage: +5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10437	wobbly blue mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
+10438	toasty beefcake's beefy Powerful Glove of Tarzan of vim and vigor	0		Muscle: 35, Experience (Muscle): +3, Maximum HP Percent: +50, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	toasty razor-sharp groovy Drip harness	0		Moxie Percent: +10, Weapon Damage Percent: +25, Hot Damage: +5
 10442	upside-down red dog trainer's drippy truncheon	0		Experience (familiar): +1, Single Equip
 10443	huge Driplet	0		
 10444	shaking drippy snail shell	0		
-10445	tiny toothsome drippy nugget	1	drippy	
-10446	drinkable triple-distilled glass of drippy wine	7	drippy	
+10445	toothsome tiny drippy nugget	1	drippy	
+10446	triple-distilled drinkable glass of drippy wine	7	drippy	
 10447	decent squat drippy caviar	3	drippy	
 10448	rotten drippy plum(?)	4	drippy	
 10449	pulsating stanky drippy stake	0		Stench Spell Damage: +25, Single Equip
@@ -10352,7 +10352,7 @@
 10495	executive sinister mushroom pants of the ox of temperance	0		Muscle: +20, Spell Damage: +10, Sleaze Resistance: +5, Meat Drop: +40, Last Available: "2020-03"
 10496	auspicious horrifying wicked mushroom badge of the ox	0		Muscle: +20, Spell Damage: +5, Spooky Damage: +25, Item Drop: +10, Single Equip, Last Available: "2020-03"
 10497	house-sized mushroom	0		Last Available: "2020-03"
-10498	yellow mirror pristine piranha seed	0		Last Available: "2020-03"
+10498	mirror yellow pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	energized piranha pollen	0		Effect: "Wit Tea", Effect Duration: 44, Last Available: "2020-03"
 10501	maroon huge plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
@@ -10369,17 +10369,17 @@
 10512	maroon miser's chipped coffee mug of the glutton	0		Meat Drop: +10, Food Drop: +100, Last Available: "2020-04"
 10513	bouncing stylish Left-Hand Man action figure	0		Moxie: +25, Last Available: "2020-04"
 10514	drippy seed	0		
-10515	lime green ghostly drippy grub	0		
+10515	ghostly lime green drippy grub	0		
 10516	fuchsia drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	drippy ichor	0		
 10519	drippy enzyme	0		
-10520	green blurry drippy salt	0		
+10520	blurry green drippy salt	0		
 10521	green drippy pigment	0		
 10522	drippy bromide	0		
 10523	cyan drippy flux	0		
 10524	tumbling drippy stein	0		
-10525	aged weak drippy pilsner	2	drippy	
+10525	weak aged drippy pilsner	2	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	red drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10396,7 +10396,7 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	mediocre Ghiaccio Colada	3	decent	Last Available: "2020-05"
 10542	delicious jittery upside-down Sourfinger	3	awesome	Last Available: "2020-05"
-10543	practically non-alcoholic tolerable ghostly Nog-on-the-Cob	1	good	Last Available: "2020-05"
+10543	tolerable practically non-alcoholic ghostly Nog-on-the-Cob	1	good	Last Available: "2020-05"
 10544	watered-down bad Steamboat	2	decent	Last Available: "2020-05"
 10545	smooth watered-down Buttery Boy	2	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10428,7 +10428,7 @@
 10572	deionized marshroom	0		Effect: "Stands Alone", Effect Duration: 35
 10573	bag of Iunion stones	0		Free Pull
 10574	blinking Iunion Crown	0		Last Available: "2020-06"
-10575	cyan ghostly huge drippy candy bar	0		
+10575	ghostly huge cyan drippy candy bar	0		
 10576	energized deionized blue salty drippy candy bar	0		Effect: "Saucegoggles", Effect Duration: 28
 10577	pressed enhanced writhing drippy candy bar	0		Effect: "Extra Backbone", Effect Duration: 53
 10578	pressed ghostly gooey drippy candy bar	0		Effect: "Lit Up", Effect Duration: 58
@@ -10438,9 +10438,9 @@
 10582	teal SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	fuchsia blinking Jim Carey's birch battery of extreme caution	0		Monster Level: 0, Lasts Until Rollover, Last Available: "2020-08"
-10585	personal trainer's smooth ebony epee of incineration	0		Moxie: +15, Experience Percent (Muscle): +10, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	narrow cyan experienced supercool weeping willow wand of the ox	0		Muscle: +20, Moxie Percent: +20, Experience: +2, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	upside-down shaking nasty Jack Frost's beechwood blowgun of the ox	0		Muscle: +20, Cold Spell Damage: +50, Stench Damage: +5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	personal trainer's smooth ebony epee of incineration	0		Moxie: +15, Experience Percent (Muscle): +10, Hot Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	narrow cyan experienced supercool weeping willow wand of the ox	0		Muscle: +20, Moxie Percent: +20, Experience: +2, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	upside-down shaking nasty Jack Frost's beechwood blowgun of the ox	0		Muscle: +20, Cold Spell Damage: +50, Stench Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	blinking executive inspector's Sinatra's maple magnet	0		Experience (Moxie): +5, Item Drop: +15, Meat Drop: +40, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	gravedigger's supercharged studded hemlock helm	0		Damage Absorption: +80, Maximum MP Percent: +30, Spooky Damage: +10, Last Available: "2020-08"
@@ -10462,7 +10462,7 @@
 10606	chilled polymerized huge Yeg's Motel toothbrush	0		Effect: "Expert Vacationer", Effect Duration: 50, Last Available: "2020-09"
 10607	vacuum-sealed jittery Yeg's Motel hand soap	0		Effect: "Pumped Stomach", Effect Duration: 47, Last Available: "2020-09"
 10608	pulsating cyan Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	diet toothsome upside-down Yeg's Motel pillow mint	1	awesome	Last Available: "2020-09"
+10609	toothsome diet upside-down Yeg's Motel pillow mint	1	awesome	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	liquefied denatured Yeg's Motel mouthwash	0		Effect: "Human-Constellation Hybrid", Effect Duration: 56, Last Available: "2020-09"
 10612	Tesla rock-hard Yeg's Motel shower cap	0		Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-09"
@@ -10496,7 +10496,7 @@
 10640	tumbling Universal Seasoning	0		
 10641	ionized activated modified null-day exploit	0		Effect: "On the Shoulders of Giants", Effect Duration: 24, Last Available: "2025-12"
 10642	lime green flame orb	0		Last Available: "2020-09"
-10643	half-sized toothsome huge chocolate chip muffin	2	awesome	
+10643	toothsome half-sized huge chocolate chip muffin	2	awesome	
 10644	wobbly Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	shaking Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10558,7 +10558,7 @@
 10702	dangerous poncho de azucar	0		Weapon Damage: +10, Item Drop: +5, Class: "Accordion Thief", Last Available: "2020-12"
 10703	The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	blurry The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
-10705	yellow tumbling twirling The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+10705	yellow twirling tumbling The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10706	green The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	olive The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
@@ -10568,23 +10568,23 @@
 10712	ghostly The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	miniature toothsome and pepper (stale)	2	awesome	Last Available: "2020-12"
-10716	mediocre weak cranberry margarita (brackish)	2	decent	Last Available: "2020-12"
+10715	toothsome miniature and pepper (stale)	2	awesome	Last Available: "2020-12"
+10716	weak mediocre cranberry margarita (brackish)	2	decent	Last Available: "2020-12"
 10717	red fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	blinking nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	hand-crafted bouncing barrel-aged eggnog	3	EPIC	Last Available: "2020-12"
 10721	tasty lime green hand-crafted candy cane	3	awesome	Last Available: "2020-12"
-10722	enchanted diet stale drive-thru burger	1	decent	Effect: "Human-Undead Hybrid", Effect Duration: 35, Last Available: "2020-12"
-10723	aged bouncing blinking Boulevardier cocktail	3	awesome	Last Available: "2020-12"
+10722	enchanted stale diet drive-thru burger	1	decent	Effect: "Human-Undead Hybrid", Effect Duration: 35, Last Available: "2020-12"
+10723	aged blinking bouncing Boulevardier cocktail	3	awesome	Last Available: "2020-12"
 10724	diffused electrified red Hotwire&trade; brand candy rope	0		Effect: "Fan-Cooled", Effect Duration: 19, Last Available: "2020-12"
-10725	half-sized stale skewed bowl full of jelly	2	decent	Last Available: "2020-12"
+10725	stale half-sized skewed bowl full of jelly	2	decent	Last Available: "2020-12"
 10726	practically non-alcoholic delicious Eye and a Twist	1	awesome	Last Available: "2020-12"
 10727	boiled pulsating Chubby and Plump bar	0		Effect: "Aries Rising", Effect Duration: 32, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	mirror packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	jittery crystal ball	0		Initiative: +50, Last Available: "2021-01"
-10731	jittery maroon fresh can of paint	0		Free Pull, Last Available: "2021-12"
+10731	maroon jittery fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 10734	pulsating spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
@@ -10602,7 +10602,7 @@
 10746	marshmallow	0		
 10747	hand-crafted mirror marshmallow bomb	3	EPIC	Last Available: "2021-03"
 10748	twirling shaking packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	chilled skewed short beer	0		Effect: "Inscrutable exoskeleton", Effect Duration: 39, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	colloidal polarized short	0		Effect: "Abyssal Sweat", Effect Duration: 54, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	blurry quantum of familiar	0		
-10759	red Van der Graaf smartaleck's familiar scrapbook	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	red Van der Graaf smartaleck's familiar scrapbook	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	lime green clan underground fireworks shop	0		Last Available: "2021-07"
 10762	prompt energetic padded fedora-mounted fountain	0		Damage Absorption: +20, Maximum MP Percent: +20, Adventures: +3, Lasts Until Rollover, Last Available: "2021-07"
@@ -10646,21 +10646,21 @@
 10790	flame-retardant B. L. A. R. T.	0		Hot Resistance: +1, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	skewed maroon Thwaitgold fire beetle statuette	0		
 10792	empty nacho cheese can	0		Water: 1
-10793	yellow twirling literal bucket hat	0		Water: 5
+10793	twirling yellow literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	squat tumbling packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	baleful industrial fire extinguisher of Tarzan of the scaredy-cat of incineration of the boozehound of the cheetah	0		Experience (Muscle): +3, Spell Damage: +25, Monster Level: -15, Hot Spell Damage: +50, Booze Drop: +100, Initiative: +60, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
-10798	narrow fuchsia The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
+10797	baleful industrial fire extinguisher of Tarzan of the scaredy-cat of incineration of the boozehound of the cheetah	0		Experience (Muscle): +3, Spell Damage: +25, Monster Level: -15, Hot Spell Damage: +50, Booze Drop: +100, Initiative: +60, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10798	fuchsia narrow The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
 10802	French-Transylvanian Dictionary	0		Familiar Weight: +5
-10803	squat wobbly packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
+10803	wobbly squat packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	friendly Daylight Shavings Helmet of the wise owl of bravery	0		Mysticality: +20, Familiar Weight: +3, Spooky Resistance: +5, Last Available: "2021-11"
 10805	spinning eggwater	1	awesome	Last Available: "2021-12"
 10806	decent shaking bread man	4	good	Last Available: "2021-12"
-10807	spoiled pulsating maroon squat plain candy cane	3	crappy	Last Available: "2021-12"
+10807	spoiled pulsating squat maroon plain candy cane	3	crappy	Last Available: "2021-12"
 10808	decent flour cookie	4	good	Last Available: "2021-12"
 10809	skewed frosty plastic food lab	0		Cold Spell Damage: +10, Single Equip, Last Available: "2021-12"
 10810	sharpshooter's plastic nog lab	0		Critical Hit Percent: +10, Single Equip, Last Available: "2021-12"
@@ -10676,9 +10676,9 @@
 10820	spoiled bowl of prescription candy	4	crappy	Last Available: "2021-12"
 10821	adequate blinking fishcake	3	good	Last Available: "2021-12"
 10822	big yummy bone broth	5	awesome	Last Available: "2021-12"
-10823	snack-sized yummy star pop	2	awesome	Last Available: "2021-12"
+10823	yummy snack-sized star pop	2	awesome	Last Available: "2021-12"
 10824	weak tolerable Doc's Fortifying Wine	2	good	Last Available: "2021-12"
-10825	drinkable weak Doc's Smartifying Wine	2	good	Last Available: "2021-12"
+10825	weak drinkable Doc's Smartifying Wine	2	good	Last Available: "2021-12"
 10826	weak perfectly mixed Doc's Limbering Wine	2	EPIC	Last Available: "2021-12"
 10827	tolerable practically non-alcoholic Doc's Medical-Grade Wine	1	good	Last Available: "2021-12"
 10828	twisted Homebodyl&trade;	1		Last Available: "2021-12"
@@ -10692,12 +10692,12 @@
 10836	unsweetened frozen upside-down anti-creep cream	0		Effect: "White Blooded", Effect Duration: 68, Last Available: "2021-12"
 10837	concentrated energized anti-pain cream	0		Effect: "Sludgesick", Effect Duration: 67, Last Available: "2021-12"
 10838	hand-crafted squat Doc's Special Reserve Wine	4	EPIC	Last Available: "2021-12"
-10839	thick yummy bread pie	5	awesome	Last Available: "2021-12"
-10840	hand-crafted special irresponsibly strong clear Russian	10	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 25, Last Available: "2021-12"
+10839	yummy thick bread pie	5	awesome	Last Available: "2021-12"
+10840	special irresponsibly strong hand-crafted clear Russian	10	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 25, Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
-10843	tumbling twirling Crimbo ball	0		Last Available: "2021-12"
-10844	wobbly red gooified animal matter	0		Last Available: "2021-12"
+10843	twirling tumbling Crimbo ball	0		Last Available: "2021-12"
+10844	red wobbly gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10709,7 +10709,7 @@
 10853	double-polymerized fleshy putty	0		Effect: "Serendipi Tea", Effect Duration: 28, Last Available: "2021-12"
 10854	nippy third ear	0		Cold Damage: +10, Single Equip, Last Available: "2021-12"
 10855	yellow festive egg sac	0		Last Available: "2021-12"
-10856	cyan huge poisonsettia	0		Last Available: "2021-12"
+10856	huge cyan poisonsettia	0		Last Available: "2021-12"
 10857	ruddy peppermint-scented socks	0		Maximum HP Percent: +40, Last Available: "2021-12"
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
@@ -10734,7 +10734,7 @@
 10878	blinking meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	distilled fried air	1		Effect: "Gummibrain", Effect Duration: 35, Last Available: "2021-12"
-10881	narrow blue 11-leaf clover	0		
+10881	blue narrow 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	dried astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
@@ -10762,36 +10762,36 @@
 10906	toasty deadly thermal blanket of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Hot Damage: +5, Lasts Until Rollover, Last Available: "2022-05"
 10907	atlas of local maps of Calamity Jane	0		Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2022-05"
 10908	aerosolized spare battery	0		Effect: "Disco Nirvana", Effect Duration: 47, Last Available: "2022-05"
-10909	shaking huge space blanket	0		Last Available: "2022-05"
+10909	huge shaking space blanket	0		Last Available: "2022-05"
 10910	energized galvanized extra-vacuum-sealed twirling single-use dust mask	0		Effect: "Almost Cool", Effect Duration: 62, Last Available: "2022-05"
 10911	pickled jittery gaffer's tape	0		Effect: "Flame-Retardant Trousers", Effect Duration: 41, Last Available: "2022-05"
 10912	decent 20-lb can of rice and beans	3	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	half-sized special decent expired MRE	2	good	Effect: "Slightly Mutated", Effect Duration: 25, Last Available: "2022-05"
 10915	normal cool mint precipice bar	3	good	Last Available: "2022-05"
-10916	half-sized moldy carrot cake precipice bar	2	crappy	Last Available: "2022-05"
+10916	moldy half-sized carrot cake precipice bar	2	crappy	Last Available: "2022-05"
 10917	wobbly The Big Book of Every Skill	0		
 10918	jittery Thwaitgold harvestman statuette	0		
 10919	olive packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	blinking ribald sharpshooter's crafty June cleaver	0		Maximum MP: +10, Critical Hit Percent: +10, Sleaze Damage: +10, Attacks Can't Miss, Last Available: "2022-06"
-10921	hand-crafted jittery spinning Dad's brandy	3	EPIC	Last Available: "2022-06"
+10921	hand-crafted spinning jittery Dad's brandy	3	EPIC	Last Available: "2022-06"
 10922	tumbling purple smelly teacher's pen of incineration	0		Hot Spell Damage: +50, Stench Spell Damage: +10, Last Available: "2022-06"
 10923	decent fire-roasted lake trout	3	good	Last Available: "2022-06"
-10924	half-sized tasty mirror guilty sprout	2	awesome	Last Available: "2022-06"
+10924	tasty half-sized mirror guilty sprout	2	awesome	Last Available: "2022-06"
 10925	olive veiny mother's necklace of Flo-Jo	0		Maximum HP: +10, Initiative: +100, Last Available: "2022-06"
 10926	adjusted trampled ticket stub	0		Effect: "protect.enq", Effect Duration: 46, Last Available: "2022-06"
 10927	vacuum-sealed denatured savings bond	0		Effect: "Remaining Alive", Effect Duration: 48, Last Available: "2022-06"
 10928	jittery designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	narrow designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	narrow designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	twisted sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	narrow stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
-10934	lime green jittery dinosaur scale	0		
+10934	jittery lime green dinosaur scale	0		
 10935	maroon pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	mirror Oprah's pterodactyl rifle	0		Maximum MP Percent: +50, Conditional Skill (Equipped): "Snipe Pterodactyl"
-10938	ghostly shaking birdseed hat	0		
+10938	shaking ghostly birdseed hat	0		
 10939	flatusaur gasmask	0		
 10940	squat dinosaur dart	0		
 10941	quadruple-pickled pressed irradiated Dino DNAde&trade;	0		Effect: "Rave Concentration", Effect Duration: 36
@@ -10805,14 +10805,14 @@
 10949	smooth dinosaur	0		Moxie: +15
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	wobbly squat Fonzie's Jurassic Parka of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	wobbly squat Fonzie's Jurassic Parka of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	warmed non-unsweetened autumn leaf	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 25, Last Available: "2022-10"
 10956	mediocre watered-down AutumnFest ale	2	decent	Last Available: "2022-10"
 10957	smooth brainy autumn sweater-weather sweater of the ox	0		Muscle: +20, Mysticality: +5, Moxie: +15, Lasts Until Rollover, Last Available: "2022-10"
 10958	olive auspicious Oprah's wicked boxer's autumn debris shield	0		Muscle Percent: +10, Spell Damage: +5, Maximum MP Percent: +50, Item Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	half-sized adequate autumn-spice donut	2	good	Last Available: "2022-10"
+10959	adequate half-sized autumn-spice donut	2	good	Last Available: "2022-10"
 10960	concentrated super-pressed autumn dollar	0		Effect: "Berry Thorny", Effect Duration: 23, Last Available: "2022-10"
 10961	pulsating scorching Tesla autumn leaf pendant of incineration	0		Hot Damage: +25, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2022-10"
 10962	boiled yellow tumbling autumn breeze	1		Last Available: "2022-10"
@@ -10826,33 +10826,33 @@
 10970	bland ratatouille de Jarlsberg	3	decent	Last Available: "2022-11"
 10971	decent Jarlsberg's vegetable soup	3	good	Last Available: "2022-11"
 10972	normal roasted vegetable of Jarlsberg	3	good	Last Available: "2022-11"
-10973	immense delicious St. Pete's sneaky smoothie	7	awesome	Last Available: "2022-11"
+10973	delicious immense St. Pete's sneaky smoothie	7	awesome	Last Available: "2022-11"
 10974	flavorless cyan upside-down Pete's wiley whey bar	3	decent	Last Available: "2022-11"
-10975	special spoiled small twirling Pete's rich ricotta	2	crappy	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 40, Last Available: "2022-11"
-10976	watered-down lousy fuchsia Boris's beer	2	decent	Last Available: "2022-11"
-10977	bland shaking ghostly honey bun of Boris	3	decent	Last Available: "2022-11"
+10975	small spoiled special twirling Pete's rich ricotta	2	crappy	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 40, Last Available: "2022-11"
+10976	lousy watered-down fuchsia Boris's beer	2	decent	Last Available: "2022-11"
+10977	bland ghostly shaking honey bun of Boris	3	decent	Last Available: "2022-11"
 10978	stale cyan Boris's bread	3	decent	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	huge twirling Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	mirror Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	tumbling Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	twirling huge Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	mirror Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	tumbling Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	spoiled baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
 10989	flavorless pulsating purple plain calzone	4	decent	Last Available: "2022-11"
 10990	normal mirror roasted vegetable focaccia	3	good	Last Available: "2022-11"
 10991	bland super-sized teal Pizza of Legend	5	decent	Last Available: "2022-11"
-10992	flavorless big Calzone of Legend	5	decent	Last Available: "2022-11"
-10993	jittery Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	maroon Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	wobbly Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	huge Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10992	big flavorless Calzone of Legend	5	decent	Last Available: "2022-11"
+10993	jittery Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	maroon Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	wobbly Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	huge Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	blue Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	blue Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	decent squat Deep Dish of Legend	4	good	Last Available: "2022-11"
 11001	ghostly deed to Oliver's Place	0		Free Pull
 11002	blinking drink chit	0		
@@ -10866,19 +10866,19 @@
 11010	adequate enchanted massive swamp haunch	6	good	Effect: "Capricorn Rising", Effect Duration: 15
 11011	blurry gator shades of dire peril of the boozehound	0		Weapon Damage: +20, Booze Drop: +100, Single Equip
 11012	twirling milk cap	0		
-11013	mediocre practically non-alcoholic gray Charleston Choo-Choo	1	decent	
+11013	practically non-alcoholic mediocre gray Charleston Choo-Choo	1	decent	
 11014	aged fortified Velvet Veil	5	awesome	
-11015	mediocre high-proof Marltini	9	decent	
+11015	high-proof mediocre Marltini	9	decent	
 11016	aged watered-down Strong, Silent Type	2	awesome	
-11017	weak drinkable ghostly Mysterious Stranger	2	good	
-11018	practically non-alcoholic enchanted aged green Champagne Shimmy	1	awesome	Effect: "Feline Ferocity", Effect Duration: 5
+11017	drinkable weak ghostly Mysterious Stranger	2	good	
+11018	enchanted practically non-alcoholic aged green Champagne Shimmy	1	awesome	Effect: "Feline Ferocity", Effect Duration: 5
 11019	the Sot's parcel	0		
-11020	spinning Jim Carey's experienced ceramic cestus	0		Experience: +2, Monster Level: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	maroon blurry fireproof nippy stylish ceramic centurion shield	0		Moxie: +25, Cold Damage: +10, Hot Resistance: +3, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	scorching ceramic celery grater of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	twirling huge hardened Rosewater's ceramic celsiturometer of the businessman	0		Mysticality Percent: +30, Damage Reduction: 3, Meat Drop: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	pulsating greedy baleful ceramic cerecloth belt of doom	0		Spell Damage: +25, Spooky Spell Damage: +50, Meat Drop: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	gravedigger's ceramic cenobite's robe of the sweet-tooth of the cheetah	0		Spooky Damage: +10, Candy Drop: +100, Initiative: +60, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	spinning Jim Carey's experienced ceramic cestus	0		Experience: +2, Monster Level: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	maroon blurry fireproof nippy stylish ceramic centurion shield	0		Moxie: +25, Cold Damage: +10, Hot Resistance: +3, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	scorching ceramic celery grater of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +25, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	twirling huge hardened Rosewater's ceramic celsiturometer of the businessman	0		Mysticality Percent: +30, Damage Reduction: 3, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	pulsating greedy baleful ceramic cerecloth belt of doom	0		Spell Damage: +25, Spooky Spell Damage: +50, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	gravedigger's ceramic cenobite's robe of the sweet-tooth of the cheetah	0		Spooky Damage: +10, Candy Drop: +100, Initiative: +60, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	altered jittery ceramic scree	1		Last Available: "2023-12"
 11027	concentrated energized bouncing extra-hard jawbreaker	0		Effect: "Weapon of Mass Destruction", Effect Duration: 44
 11028	chilly energetic arcane researcher's chiffon chevrons	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Cold Damage: +5, Single Equip, Last Available: "2023-12"
@@ -10891,7 +10891,7 @@
 11035	alkaline squat chiffon lemon	0		Effect: "Dreadful Sheen", Effect Duration: 39
 11036	decent skewed chocomotive	4	good	Last Available: "2022-12"
 11037	normal gray freightcake	4	good	Last Available: "2022-12"
-11038	mediocre watered-down green cabooze	2	decent	Last Available: "2022-12"
+11038	watered-down mediocre green cabooze	2	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	miser's plastic passenger car	0		Meat Drop: +10, Last Available: "2022-12"
 11041	huge blurry grievous plastic dining car	0		Weapon Damage Percent: +50, Last Available: "2022-12"
@@ -10905,7 +10905,7 @@
 11049	pile of Trainbot parts	0		
 11050	frozen Trainbot circuitry	0		Effect: "Super-Charged", Effect Duration: 36
 11051	flattened chilled green Trainbot tubing	0		Effect: "Gonna Get You, Sucker", Effect Duration: 23
-11052	triple-vacuum-sealed wet non-frozen spinning tumbling Trainbot plating	0		Effect: "Bilious Briskness", Effect Duration: 60
+11052	triple-vacuum-sealed wet non-frozen tumbling spinning Trainbot plating	0		Effect: "Bilious Briskness", Effect Duration: 60
 11053	warmed Trainbot optics	0		Effect: "Mathematically Precise", Effect Duration: 65
 11054	frozen alkaline blue Trainbot servomotors	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 53
 11055	diffused huge Trainbot linkages	0		Effect: "Cool, Catlike", Effect Duration: 47
@@ -10930,14 +10930,14 @@
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	mirror Trainbot slag	0		
-11077	tumbling red industrially-crushed ice	0		Last Available: "2022-12"
-11078	bland huge steamed oyster	10	decent	
+11077	red tumbling industrially-crushed ice	0		Last Available: "2022-12"
+11078	huge bland steamed oyster	10	decent	
 11079	pulsating really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	skewed skewed steam unit	0		Last Available: "2022-12"
 11082	twirling twirling crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	spirit-forward hand-crafted Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
+11084	hand-crafted spirit-forward Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
 11085	thick yummy blue Crimbo dinner	5	awesome	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10950,7 +10950,7 @@
 11094	bouncing dance instructor's grubby wool trousers of vim and vigor of the detective	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Item Drop: +20
 11095	avaricious medical-grade banded grubby wool gloves of incineration	0		Damage Absorption: +100, Hot Spell Damage: +50, Meat Drop: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	delicious blinking bouncing nice warm beer	4	awesome	
+11097	delicious bouncing blinking nice warm beer	4	awesome	
 11098	grubby woolball	0		
 11099	blurry Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10964,7 +10964,7 @@
 11108	narrow hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	moldy fancy spinning pixel bread	3	crappy	Effect: "Papowerful", Effect Duration: 35
+11112	fancy moldy spinning pixel bread	3	crappy	Effect: "Papowerful", Effect Duration: 35
 11113	smooth pixel whiskey	3	awesome	
 11114	skewed pixel rock	0		
 11115	twirling S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10974,7 +10974,7 @@
 11119	pressed polymerized green five-fingered fern resin	0		Effect: "Sweet and Yellow", Effect Duration: 50, Last Available: "2023-02"
 11120	delicious super good fruit	3	awesome	Last Available: "2023-02"
 11121	twisted energized spores	1		Effect: "Red Around the Gills", Effect Duration: 45, Last Available: "2023-02"
-11122	pulsating energetic hot pepper of courage	0		Maximum MP Percent: +20, Spooky Resistance: +3, Lantern Element: "Hot", Last Available: "2023-02"
+11122	pulsating energetic hot pepper of courage	0		Maximum MP Percent: +20, Spooky Resistance: +3, Last Available: "2023-02", Lantern Element: "Hot"
 11123	pickled blinking out-of-work circus flea	0		Effect: "The Halls of Muscularity", Effect Duration: 16, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	warmed fire ant pheromones	0		Effect: "Bubblin' Rage", Effect Duration: 22, Last Available: "2023-02"
@@ -10983,18 +10983,18 @@
 11128	anodized altered olive filled mosquito	0		Effect: "Coated Arms", Effect Duration: 49, Last Available: "2023-02"
 11129	deionized super-pressed nitrogenated shim of shame shale	0		Effect: "Feroci Tea", Effect Duration: 15, Last Available: "2023-02"
 11130	Vulcanized unsweetened pebble of proud pyrite	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 22, Last Available: "2023-02"
-11131	flattened concentrated shaking shaking olive pile of gritty sand	0		Effect: "Frostbeard", Effect Duration: 13, Last Available: "2023-02"
+11131	flattened concentrated shaking olive shaking pile of gritty sand	0		Effect: "Frostbeard", Effect Duration: 13, Last Available: "2023-02"
 11132	blinking hollow rock	0		Last Available: "2023-02"
 11133	pressed triple-irradiated angry agate	0		Effect: "Sewer-Drenched", Effect Duration: 27, Last Available: "2023-02"
 11134	nitrogenated nitrogenated shaking lump of loyal latite	0		Effect: "Greasy Flavor", Effect Duration: 44, Last Available: "2023-02"
-11135	big flavorless shadow sausage	5	decent	Last Available: "2023-03"
+11135	flavorless big shadow sausage	5	decent	Last Available: "2023-03"
 11136	stanky Van der Graaf shadow skin	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-03"
 11137	Vulcanized super-frozen corrupted shadow flame	0		Effect: "Electrolit Up", Effect Duration: 34, Last Available: "2023-03"
-11138	small stale shadow bread	2	decent	Last Available: "2023-03"
+11138	stale small shadow bread	2	decent	Last Available: "2023-03"
 11139	spinning shadow ice	0		Last Available: "2023-03"
 11140	drinkable shadow fluid	3	good	Last Available: "2023-03"
 11141	bouncing lime green shadow glass	0		Last Available: "2023-03"
-11142	blinking red shadow brick	0		Last Available: "2023-03"
+11142	red blinking shadow brick	0		Last Available: "2023-03"
 11143	huge shadow sinew	0		Last Available: "2023-03"
 11144	perfectly mixed shadow venom	3	EPIC	Last Available: "2023-03"
 11145	twisted wobbly shadow nectar	1		Last Available: "2023-03"
@@ -11021,7 +11021,7 @@
 11166	tumbling Thwaitgold anti-moth statuette	0		
 11167	pulsating shadowy cheat sheet	0		Free Pull
 11168	huge closed-circuit phone system	0		Free Pull
-11169	blurry wobbly closed-circuit pay phone	0		
+11169	wobbly blurry closed-circuit pay phone	0		
 11170	bouncing shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	shadow snowflake	0		
@@ -11038,7 +11038,7 @@
 11183	bad shadow martini	4	decent	
 11184	compressed huge shadow pill	1		
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	wobbly monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	oxidized shadow candy	0		Effect: "It Didn't Kill You", Effect Duration: 55
 11189	replica Mr. Accessory	0		
@@ -11060,7 +11060,7 @@
 11205	replica cotton candy cocoon	0		
 11206	up-at-dawn censurious Herculean replica Elvish sunglasses of incineration	0		Experience (Muscle): +1, Hot Spell Damage: +50, Sleaze Resistance: +3, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
-11208	cyan huge skewed replica stone sphere	0		
+11208	huge skewed cyan replica stone sphere	0		
 11209	narrow twirling scandalous slick replica Greatest American Pants of the empath	0		Moxie: +10, Familiar Weight: +5, Sleaze Damage: +5
 11210	replica organ grinder	0		
 11211	lard-coated nippy replica Juju Mojo Mask	0		Cold Damage: +10, Sleaze Spell Damage: +25, Item Drop: +5, Single Equip
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	rosewater-soaked foul-smelling Cincho de Mayo of the brute of the sweet-tooth	0		Muscle Percent: +30, Stench Damage: +10, Stench Resistance: +3, Candy Drop: +100, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	rosewater-soaked foul-smelling Cincho de Mayo of the brute of the sweet-tooth	0		Muscle Percent: +30, Stench Damage: +10, Stench Resistance: +3, Candy Drop: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	green dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	narrow replica still grill	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	careful Tesla replica Jurassic Parka	0		Monster Level: -10, MP Regen Min: 7, MP Regen Max: 10
 11250	maroon replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	huge replica Ten Dollars	0		
 11254	double-paned knitted hardened personal trainer's replica Cincho de Mayo	0		Experience Percent (Muscle): +10, Damage Reduction: 3, Cold Resistance: 8, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	blue Usain Bolt's flame-retardant stanky stiffened &quot;I survived Y2K&quot; T-Shirt of the pedagogue of the sweet-tooth	0		Experience: +3, Damage Reduction: 1, Stench Spell Damage: +25, Hot Resistance: +1, Candy Drop: +100, Initiative: +80, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	gray hardened studded pro skateboard	0		Damage Absorption: +80, Damage Reduction: 3, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	gray hardened studded pro skateboard	0		Damage Absorption: +80, Damage Reduction: 3, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	blinking Mr. Accessaturday	0		Last Available: "2023-06"
 11262	green Meat Butler	0		Last Available: "2023-06"
-11263	ghostly red Loathing Idol Microphone	0		Last Available: "2023-06"
+11263	red ghostly Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	bouncing Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	savvy Flash Liquidizer Ultra Dousing Accessory	0		Mysticality Percent: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	savvy Flash Liquidizer Ultra Dousing Accessory	0		Mysticality Percent: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	squat twirling MacGyver's Socratic smartaleck's beefcake's Amulet of Perpetual Darkness	0		Muscle: +25, Moxie Percent: +30, Experience (Mysticality): +1, Maximum MP: +100, Last Available: "2023-06"
 11268	bouncing Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11142,7 +11142,7 @@
 11287	grievous rutabuga bag of the overflowing toilet	0		Weapon Damage Percent: +50, Stench Spell Damage: +50
 11288	beefy mesquito proboscis	0		Muscle: +10
 11289	shaking stylish senate fly thorax	0		Moxie: +25
-11290	pressed ghostly pulsating bug juice	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 35
+11290	pressed pulsating ghostly bug juice	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 35
 11291	prompt spider leg	0		Adventures: +3
 11292	clever beetle antenna	0		Maximum MP: +20
 11293	slick mantis skull	0		Moxie: +10
@@ -11184,7 +11184,7 @@
 11329	dried wobbly meat	1		
 11330	modified huge bouncing sparkling orb	1		Effect: "Neuromancy", Effect Duration: 30
 11331	compressed hardening cream	1		Effect: "Sweet Taste", Effect Duration: 20
-11332	dried green shaking pool shark hair oil	1		Effect: "Cybernetic Muscles", Effect Duration: 30
+11332	dried shaking green pool shark hair oil	1		Effect: "Cybernetic Muscles", Effect Duration: 30
 11333	wobbly book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11216,7 +11216,7 @@
 11361	tarnished autumnic balm	0		Effect: "Wasabi With You", Effect Duration: 67
 11362	moist adjusted coping juice	0		Effect: "Memory of Strength", Effect Duration: 46
 11363	frosty chilly candy cane sword cane of the pedagogue of the storm of doom	0		Experience: +3, Maximum MP Percent: +40, Cold Damage: +5, Cold Spell Damage: +10, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
-11364	gray jittery wrapped candy cane sword cane	0		Free Pull
+11364	jittery gray wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
@@ -11230,8 +11230,8 @@
 11375	mirror Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	stale low-calorie pickled bread	1	decent	Last Available: "2023-12"
-11379	adequate half-sized salted mutton	2	good	Last Available: "2023-12"
+11378	low-calorie stale pickled bread	1	decent	Last Available: "2023-12"
+11379	half-sized adequate salted mutton	2	good	Last Available: "2023-12"
 11380	spoiled corned beet	4	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11277,12 +11277,12 @@
 11422	lousy squat old-school pirate grog	4	decent	Last Available: "2023-12"
 11423	miniature moldy grog nuts	2	crappy	Last Available: "2023-12"
 11424	quilted slick sawed-off blunderbuss of vim and vigor	0		Moxie: +10, Damage Absorption: +40, Maximum HP Percent: +50, Last Available: "2023-12"
-11425	distilled enchanted perfectly mixed cyan officer's nog	5	EPIC	Effect: "Salty Dogs", Effect Duration: 50, Last Available: "2023-12"
+11425	enchanted perfectly mixed distilled cyan officer's nog	5	EPIC	Effect: "Salty Dogs", Effect Duration: 50, Last Available: "2023-12"
 11426	narrow peppermint bomb	0		Last Available: "2023-12"
 11427	flavorless miniature sundae ration	2	decent	Last Available: "2023-12"
 11428	moldy peppermint tack	3	crappy	Last Available: "2023-12"
 11429	shaking Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	adequate big mirror whalesteak	5	good	Last Available: "2023-12"
+11430	big adequate mirror whalesteak	5	good	Last Available: "2023-12"
 11431	teal fireproof sharpshooter's hale whalegun	0		Maximum HP: +20, Critical Hit Percent: +10, Hot Resistance: +3, Last Available: "2023-12"
 11432	shaking Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11307,18 +11307,18 @@
 11452	Lo Pan's Annie Oakley's resourceful Herculean Elf dessert spoon of the scaredy-cat of horror	0		Experience (Muscle): +1, Maximum MP: +50, Critical Hit Percent: +20, Spell Critical Percent: +30, Monster Level: -15, Spooky Spell Damage: +25, Last Available: "2023-12"
 11453	experienced Elf Guard SCUBA tank of the sewer	0		Experience: +2, Stench Damage: +25, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	inspector's toasty free boots	0		Hot Damage: +5, Item Drop: +15, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	inspector's toasty free boots	0		Hot Damage: +5, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	upside-down baby rigging snake	0		Last Available: "2023-12"
 11457	rosewater-soaked Fonzie's supercool Elvish underarmor	0		Moxie Percent: +20, Experience (Moxie): +1, Stench Resistance: +3, Single Equip, Last Available: "2023-12"
 11458	scorching smooth Crimbuccaneer bombjacket	0		Moxie: +15, Hot Damage: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	adequate massive green sugarplum ration	10	good	Last Available: "2023-12"
 11460	decent snack-sized gingerbread nylons	2	good	Last Available: "2023-12"
-11461	special spoiled snack-sized rum-soaked fruitcake	2	crappy	Effect: "Ass Over Teakettle", Effect Duration: 40, Last Available: "2023-12"
+11461	spoiled special snack-sized rum-soaked fruitcake	2	crappy	Effect: "Ass Over Teakettle", Effect Duration: 40, Last Available: "2023-12"
 11462	miniature flavorless lime	2	decent	Last Available: "2023-12"
 11463	adequate gingerbread pirate	3	good	Last Available: "2023-12"
 11464	fancy toothsome red fruit-stuffed rumcake	3	awesome	Effect: "Gummi Badass", Effect Duration: 20, Last Available: "2023-12"
 11465	drinkable weak mulled wine	2	good	Last Available: "2023-12"
-11466	weak artisanal blue Swedish coffee	2	EPIC	Last Available: "2023-12"
+11466	artisanal weak blue Swedish coffee	2	EPIC	Last Available: "2023-12"
 11467	acceptable bouncing canteen of eggnog	3	good	Last Available: "2023-12"
 11468	artisanal weak narrow hot wine	2	super EPIC	Last Available: "2023-12"
 11469	acceptable special Jamaican coffee	3	good	Effect: "Dreams and Lights", Effect Duration: 50, Last Available: "2023-12"
@@ -11326,14 +11326,14 @@
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	distilled delicious yule grog	5	awesome	Last Available: "2023-12"
-11475	gigantic enchanted rotten wet tack	10	crappy	Effect: "Cravin' for a Ravin'", Effect Duration: 50, Last Available: "2023-12"
-11476	flavorless super-sized fuchsia whalecake	5	decent	Last Available: "2023-12"
-11477	greasy Annie Oakley's rosy-cheeked gunwale whalegun	0		Maximum HP Percent: +30, Critical Hit Percent: +20, Sleaze Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	distilled perfectly mixed twirling and claret	5	EPIC	Last Available: "2023-12"
+11474	delicious distilled yule grog	5	awesome	Last Available: "2023-12"
+11475	gigantic rotten enchanted wet tack	10	crappy	Effect: "Cravin' for a Ravin'", Effect Duration: 50, Last Available: "2023-12"
+11476	super-sized flavorless fuchsia whalecake	5	decent	Last Available: "2023-12"
+11477	greasy Annie Oakley's rosy-cheeked gunwale whalegun	0		Maximum HP Percent: +30, Critical Hit Percent: +20, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	perfectly mixed distilled twirling and claret	5	EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
-11480	huge fuchsia wobbly trick coin	0		Last Available: "2023-12"
-11481	shaking dangerous Elf Guard squirtgun of horror	0		Weapon Damage: +10, Spooky Spell Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11480	wobbly fuchsia huge trick coin	0		Last Available: "2023-12"
+11481	shaking dangerous Elf Guard squirtgun of horror	0		Weapon Damage: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	squat chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	deadly sequin-encrusted sweater	0		Weapon Damage: +5, Last Available: "2023-12"
 11484	scandalous Jack Frost's wicked replica Elf Guard medal	0		Spell Damage: +5, Cold Spell Damage: +50, Sleaze Damage: +5, Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	warmed squat military candy cane	0		Effect: "Cheered Up", Effect Duration: 59
 11503	triple-flattened polymerized groggipop	0		Effect: "White Blooded", Effect Duration: 21
-11504	knitted lion tamer's moss mace	0		Experience (familiar): +2, Cold Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	reassuring baleful moss megaphone	0		Spell Damage: +25, Spooky Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	lion tamer's moss medal of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +2, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	squat Samson's moss mitre of incineration	0		Experience (Muscle): +5, Hot Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	blue chilly moss mantle of horror	0		Cold Damage: +5, Spooky Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	knitted lion tamer's moss mace	0		Experience (familiar): +2, Cold Resistance: +3, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	reassuring baleful moss megaphone	0		Spell Damage: +25, Spooky Resistance: +1, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	lion tamer's moss medal of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	squat Samson's moss mitre of incineration	0		Experience (Muscle): +5, Hot Spell Damage: +50, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	blue chilly moss mantle of horror	0		Cold Damage: +5, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	careful thinker's moss marlinspike	0		Mysticality: +10, Monster Level: -10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	boiled blue moss mulch	1		Effect: "Stick Emporium Membership", Effect Duration: 35, Last Available: "2024-12"
 11511	moist modified green moss floss	0		Effect: "Weasels Underfoot", Effect Duration: 27
@@ -11372,33 +11372,33 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	vaporized huge cyan adobe assortment	1		Effect: "Curse of the Black Pearl Onion", Effect Duration: 15, Last Available: "2024-12"
 11519	alkaline adobe brittle	0		Effect: "Some Cheese with Your Wine", Effect Duration: 20
-11520	upside-down scorching extremely unsafe crepe paper phrygian cap of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +100, Hot Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	upside-down scorching extremely unsafe crepe paper phrygian cap of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +100, Hot Damage: +25, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	flame-wreathed crepe paper parachute cape of dire peril of Gandalf	0		Weapon Damage: +20, Spell Critical Percent: +20, Hot Spell Damage: +10, Last Available: "2025-12"
-11522	blinking flame-wreathed sharpshooter's Sinatra's crepe paper pie clip	0		Experience (Moxie): +5, Critical Hit Percent: +10, Hot Spell Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	chilly clever supercool crepe paper puzzle cube	0		Moxie Percent: +20, Maximum MP: +20, Cold Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	squat hardened Herculean crepe paper plunge camisole of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Damage Reduction: 3, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	foul-smelling razor-sharp Samson's crepe paper polka charm	0		Experience (Muscle): +5, Weapon Damage Percent: +25, Stench Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	blinking flame-wreathed sharpshooter's Sinatra's crepe paper pie clip	0		Experience (Moxie): +5, Critical Hit Percent: +10, Hot Spell Damage: +10, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	chilly clever supercool crepe paper puzzle cube	0		Moxie Percent: +20, Maximum MP: +20, Cold Damage: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	squat hardened Herculean crepe paper plunge camisole of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Damage Reduction: 3, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	foul-smelling razor-sharp Samson's crepe paper polka charm	0		Experience (Muscle): +5, Weapon Damage Percent: +25, Stench Damage: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	twisted crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	magnetized quadruple-irradiated blurry crepe paper peanut candy	0		Effect: "Strong Grip", Effect Duration: 66
 11528	Tesla petrified wood war pike of terror	0		Spooky Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 11529	yellow spinning curative wholesome petrified wood waist protector	0		Maximum HP Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2025-12"
-11530	huge executive petrified wood wizard's pouch	0		Item Drop: +5, Meat Drop: +40, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	ruddy petrified wood water purifier of the businessman	0		Maximum HP Percent: +40, Meat Drop: +50, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	huge executive petrified wood wizard's pouch	0		Item Drop: +5, Meat Drop: +40, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	ruddy petrified wood water purifier of the businessman	0		Maximum HP Percent: +40, Meat Drop: +50, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	purple skewed boxer's petrified wood whoopie panama of Flo-Jo	0		Muscle Percent: +10, Initiative: +100, Last Available: "2025-12"
 11533	avaricious miser's petrified wood walking pants	0		Meat Drop: 40, Last Available: "2025-12"
 11534	powdered bouncing petrified wood waste parts	1		Last Available: "2025-12"
 11535	Vulcanized dry lime green petrified wood wafer praline	0		Effect: "Bustle Hustlin'", Effect Duration: 13
-11536	special tolerable cybeer	4	good	Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2025-12"
+11536	tolerable special cybeer	4	good	Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2025-12"
 11537	narrow ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	blurry googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	Samson's Crimbuccaneer war standard of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Last Available: "2023-12"
 11544	fortified Elf Guard war standard	0		Damage Absorption: +60, Item Drop: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	rosewater-soaked energetic padded spring shoes	0		Damage Absorption: +20, Maximum MP Percent: +20, Stench Resistance: +3, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	rosewater-soaked energetic padded spring shoes	0		Damage Absorption: +20, Maximum MP Percent: +20, Stench Resistance: +3, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	quantum oxidized denatured cyan ultra-soft ferns	0		Effect: "Pisces Rising", Effect Duration: 15, Last Available: "2024-02"
 11548	polarized moist bouncing crunchy brush	0		Effect: "Weird Flavor", Effect Duration: 19, Last Available: "2024-02"
 11549	shaking jittery smashed scientific equipment	0		
@@ -11425,12 +11425,12 @@
 11570	ghostly Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	enchanted flavorless yam	3	decent	Effect: "Comic Violence", Effect Duration: 30, Last Available: "2024-05"
-11574	irresponsibly strong drinkable pulsating yam martini	8	good	Last Available: "2024-05"
+11573	flavorless enchanted yam	3	decent	Effect: "Comic Violence", Effect Duration: 30, Last Available: "2024-05"
+11574	drinkable irresponsibly strong pulsating yam martini	8	good	Last Available: "2024-05"
 11575	mediocre sweet potato o' mine	3	decent	Last Available: "2024-05"
 11576	practically non-alcoholic acceptable Southern yam	1	good	Last Available: "2024-05"
 11577	bad watered-down sweet potato punch	2	decent	Last Available: "2024-05"
-11578	miniature bland jittery yellow Mayam spinach	2	decent	Last Available: "2024-05"
+11578	bland miniature yellow jittery Mayam spinach	2	decent	Last Available: "2024-05"
 11579	bite-sized rotten yam and swiss	1	crappy	Last Available: "2024-05"
 11580	teal flame-wreathed chilly Newton's yam cannon	0		Experience (Mysticality): +3, Cold Damage: +5, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11440,7 +11440,7 @@
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	wicked smartaleck's yamtility belt of the scaredy-cat	0		Moxie Percent: +30, Spell Damage: +5, Monster Level: -15, Lasts Until Rollover, Last Available: "2024-05"
 11587	flavorless yam slider	4	decent	Last Available: "2024-05"
-11588	normal jumbo spinning yam mayo	5	good	Last Available: "2024-05"
+11588	jumbo normal spinning yam mayo	5	good	Last Available: "2024-05"
 11589	stale yam burrito	3	decent	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11453,17 +11453,17 @@
 11598	lime green mini kiwi aioli	0		
 11599	smelly mini kiwi silicon tiepin of the scaredy-cat	0		Monster Level: -15, Stench Spell Damage: +10, Item Drop: +5
 11600	mini kiwi tipi	0		
-11601	fancy spoiled mini kiwi digitized cookies	3	crappy	Effect: "Provocative Perkiness", Effect Duration: 20
-11602	strong perfectly mixed mini kiwi intoxicating spirits	5	EPIC	
+11601	spoiled fancy mini kiwi digitized cookies	3	crappy	Effect: "Provocative Perkiness", Effect Duration: 20
+11602	perfectly mixed strong mini kiwi intoxicating spirits	5	EPIC	
 11603	quantum pulsating mini kiwi antimilitaristic hippy petition	0		Effect: "Heart of White", Effect Duration: 17
 11604	electrified blue mini kiwi illicit antibiotic	0		Effect: "Yes, Can Haz", Effect Duration: 26
 11605	cyan veiny mini kiwi whipping stick of the ox	0		Muscle: +20, Maximum HP: +10
 11606	mini kiwi icepick of Calamity Jane	0		Critical Hit Percent: +15
 11607	corrupted adjusted mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Saucegoggles", Effect Duration: 15
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
-11611	pulsating skewed protogenetic chunklet (muscle)	0		
+11611	skewed pulsating protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
 11613	protogenetic chunklet (elbow)	0		
 11614	protogenetic chunklet (lips)	0		
@@ -11497,7 +11497,7 @@
 11642	spinning Sept-Ember Censer	0		Last Available: "2024-09"
 11643	manspreader's blade of dismemberment	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
-11645	bouncing tumbling narrow Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
+11645	bouncing narrow tumbling Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
 11646	Septapus summoning charm	0		Last Available: "2024-09"
 11647	structural ember	0		Last Available: "2024-09"
 11648	squat bouncing Newton's brainy embers-only jacket of wisdom	0		Mysticality: 20, Experience (Mysticality): +3, Lasts Until Rollover, Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	yellow blinking photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	mansplainer's Newton's bat wings of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Monster Level: +15, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	mansplainer's Newton's bat wings of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Monster Level: +15, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	tumbling hardy monocle on a stick of terror	0		Maximum HP: +50, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	red studded Sheriff badge of the overflowing toilet	0		Damage Absorption: +80, Stench Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	chaotic sharpshooter's Sheriff pistol	0		Critical Hit Percent: +10, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-10"
 11670	olive veiny Sheriff moustache of the blizzard	0		Maximum HP: +10, Cold Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	rock-hard experienced photo booth supply list	0		Experience: +2, Damage Reduction: 5, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	rock-hard experienced photo booth supply list	0		Experience: +2, Damage Reduction: 5, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	blurry tie-dye headband	0		
 11674	adequate whirled peas	3	good	Last Available: "2024-11"
@@ -11535,13 +11535,13 @@
 11680	skewed quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	electrified gray pea brittle	0		Effect: "Elemental Saucesphere", Effect Duration: 53, Last Available: "2024-11"
-11683	drinkable practically non-alcoholic peasco	1	good	Last Available: "2024-11"
+11683	practically non-alcoholic drinkable peasco	1	good	Last Available: "2024-11"
 11684	bland small piece of cake	2	decent	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	bouncing TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	mirror clever cool deft pirate hook	0		Moxie: +5, Maximum MP: +20, Lasts Until Rollover, Last Available: "2024-12"
-11689	squat pulsating strapping iron tricorn hat of the sewer	0		Muscle: +5, Stench Damage: +25, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	squat pulsating strapping iron tricorn hat of the sewer	0		Muscle: +5, Stench Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	friendly jolly roger flag	0		Familiar Weight: +3, Lasts Until Rollover, Last Available: "2024-12"
 11691	tumbling sleeping profane parrot	0		Last Available: "2024-12"
 11692	mirror pirrrate's currrse	0		Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	foul-smelling governor's daughter's pearl hairpin	0		Stench Damage: +10, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	chili powder cutlass of courage	0		Spooky Resistance: +3, Last Available: "2024-12"
-11701	delicious thick pulsating Aztec tamale	5	awesome	Last Available: "2024-12"
+11701	thick delicious pulsating Aztec tamale	5	awesome	Last Available: "2024-12"
 11702	blue jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	rosewater-soaked groggles	0		Stench Resistance: +3, Last Available: "2024-12"
@@ -11561,9 +11561,9 @@
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	up-at-dawn coward's silky pirate drawers	0		Monster Level: -20, Adventures: +5, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
-11709	activated ghostly cyan bouncing peppermint pegleg	0		Effect: "Wet Jaw", Effect Duration: 64, Last Available: "2024-12"
+11709	activated cyan bouncing ghostly peppermint pegleg	0		Effect: "Wet Jaw", Effect Duration: 64, Last Available: "2024-12"
 11710	acceptable red hard cocoa	3	good	Last Available: "2024-12"
-11711	stale super-sized salmagumdi	5	decent	Last Available: "2024-12"
+11711	super-sized stale salmagumdi	5	decent	Last Available: "2024-12"
 11712	plastic Easter Island Bunny of the pedagogue	0		Experience: +3, Last Available: "2024-12"
 11713	spinning sizzling plastic St. Patrick	0		Hot Damage: +10, Last Available: "2024-12"
 11714	educational plastic Colonel Brando of James Dean	0		Experience: +1, Experience (Moxie): +3, Last Available: "2024-12"
@@ -11582,8 +11582,8 @@
 11727	frozen non-modified blurry four-leaf potato sprout	0		Effect: "Strong Grip", Effect Duration: 12, Last Available: "2024-12"
 11728	narrow mansplainer's padded potato jacket of the glutton	0		Damage Absorption: +20, Monster Level: +15, Food Drop: +100, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
-11730	blurry pulsating Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Sherlock's occult military orb	0		Spell Damage Percent: +25, Item Drop: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11730	pulsating blurry Brandonian footlocker key	0		Last Available: "2024-12"
+11731	Sherlock's occult military orb	0		Spell Damage Percent: +25, Item Drop: +25, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	pickled rum ball	0		Effect: "Nuts about Candy", Effect Duration: 15
 11733	gravy skin	0		Last Available: "2024-12"
 11734	ruddy gravyskin hat of the glutton	0		Maximum HP Percent: +40, Food Drop: +100, Last Available: "2024-12"
@@ -11591,20 +11591,20 @@
 11736	gravyskin skirt of the sweet-tooth	0		Item Drop: +5, Candy Drop: +100, Last Available: "2024-12"
 11737	blurry foul-smelling Rosewater's gravyskin pants	0		Mysticality Percent: +30, Stench Damage: +10, Last Available: "2024-12"
 11738	quantum crystallized pumpkin spice	0		Effect: "Christmessy", Effect Duration: 14, Last Available: "2024-12"
-11739	jumbo flavorless blinking room scale bean casserole	5	decent	Last Available: "2024-12"
+11739	flavorless jumbo blinking room scale bean casserole	5	decent	Last Available: "2024-12"
 11740	purple fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	foul-smelling mansplainer's perfect Christmas scarf of the sewer	0		Monster Level: [+15*event(December)], Stench Damage: [35*event(December)], Single Equip, Last Available: "2024-12"
-11743	mirror lard-coated snowman-enchanting tophat of vim and vigor	0		Maximum HP Percent: +50, Sleaze Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	mirror lard-coated snowman-enchanting tophat of vim and vigor	0		Maximum HP Percent: +50, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	enhanced LIDAR candle	0		Effect: "Mo' Hobo", Effect Duration: 57, Last Available: "2024-12"
 11745	Congressional Medal of Insanity of Tarzan of the scaredy-cat of Flo-Jo	0		Experience (Muscle): +3, Monster Level: -15, Initiative: +100, Last Available: "2024-12"
 11746	green pumpkin spice whorl	0		Last Available: "2024-12"
-11747	hand-crafted special practically non-alcoholic Easter grasshopper	1	super ultra mega turbo EPIC	Effect: "Can't Smell Nothin'", Effect Duration: 25, Last Available: "2024-12"
+11747	special practically non-alcoholic hand-crafted Easter grasshopper	1	super ultra mega turbo EPIC	Effect: "Can't Smell Nothin'", Effect Duration: 25, Last Available: "2024-12"
 11748	perfectly mixed Irish eggnog	3	EPIC	Last Available: "2024-12"
 11749	tolerable upside-down canteen of jungle juice	4	good	Last Available: "2024-12"
 11750	lousy boozy turchucken	5	decent	Last Available: "2024-12"
 11751	special tolerable mechanically-mulled cider	3	good	Effect: "Stogied", Effect Duration: 5, Last Available: "2024-12"
-11752	acceptable enchanted distilled holiday trip around the world	5	good	Effect: "On the Trolley", Effect Duration: 50, Last Available: "2024-12"
+11752	enchanted distilled acceptable holiday trip around the world	5	good	Effect: "On the Trolley", Effect Duration: 50, Last Available: "2024-12"
 11753	normal miniature spinning chocolate ostrich egg	2	good	Last Available: "2024-12"
 11754	normal spinning beef and cabbage	4	good	Last Available: "2024-12"
 11755	toothsome diet upside-down candy rations	1	awesome	Last Available: "2024-12"
@@ -11616,7 +11616,7 @@
 11761	skewed Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11762	blurry Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11763	jittery How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	huge red How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	red huge How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
@@ -11624,11 +11624,11 @@
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11770	twirling Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	teal scorching crafty steel-toed egg gun of horror	0		Damage Reduction: 9, Maximum MP: +10, Hot Damage: +25, Spooky Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	teal scorching crafty steel-toed egg gun of horror	0		Damage Reduction: 9, Maximum MP: +10, Hot Damage: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	friendly chaotic curative Fonzie's army helmet	0		Experience (Moxie): +1, Spell Critical Percent: +10, Familiar Weight: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-12"
-11774	bouncing jittery candy egg deviler	0		Last Available: "2024-12"
+11774	jittery bouncing candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
-11776	diet flavorless Thanksgiving ration	1	decent	Last Available: "2024-12"
+11776	flavorless diet Thanksgiving ration	1	decent	Last Available: "2024-12"
 11777	drinkable Easter eggnog	4	good	Last Available: "2024-12"
 11778	distilled upside-down clovermint	1		Effect: "Dreadful Smell", Effect Duration: 50, Last Available: "2024-12"
 11779	inspector's horrifying chilly careful nylon Christmas stockings	0		Monster Level: -10, Cold Damage: +5, Spooky Damage: +25, Item Drop: +15, Single Equip, Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	extra-adjusted deviled candy egg	0		Effect: "Whitened Teeth", Effect Duration: 46, Last Available: "2024-12"
 11782	narrow McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	resourceful Rosewater's McHugeLarge duffel bag	0		Mysticality Percent: +30, Maximum MP: +50, Last Available: "2025-01"
-11784	Herculean beefy McHugeLarge left pole of the overflowing toilet	0		Muscle: +10, Experience (Muscle): +1, Stench Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	spinning greedy wholesome banded McHugeLarge right pole	0		Damage Absorption: +100, Maximum HP Percent: +10, Meat Drop: +20, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	energetic McHugeLarge left ski of temperance	0		Maximum MP Percent: +20, Sleaze Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	McHugeLarge right ski of the ox of the cougar	0		Muscle: +20, Moxie: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	Herculean beefy McHugeLarge left pole of the overflowing toilet	0		Muscle: +10, Experience (Muscle): +1, Stench Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	spinning greedy wholesome banded McHugeLarge right pole	0		Damage Absorption: +100, Maximum HP Percent: +10, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	energetic McHugeLarge left ski of temperance	0		Maximum MP Percent: +20, Sleaze Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	McHugeLarge right ski of the ox of the cougar	0		Muscle: +20, Moxie: +20, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	denatured spinning eXpand	1		Last Available: "2025-12"
-11791	jittery brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	jittery brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	jittery datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	maroon malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	maroon malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	twirling server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11679,16 +11679,16 @@
 11824	squat insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	jittery mirror geofencing shield	0		Last Available: "2025-12"
-11829	narrow teal virtual cybertattoo	0		Last Available: "2025-12"
+11829	teal narrow virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	pulsating ninja crampons	0		
 11832	ninja carabiner	0		
 11833	extra-tarnished synthetic coffee	0		Effect: "Butt-Rock Hair", Effect Duration: 25
 11834	modified double-polymerized squat teal iDrops	0		Effect: "Shawarma Warm War", Effect Duration: 32
 11835	shame coil	0		
-11836	cyan tumbling new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
+11836	tumbling cyan new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	spinning toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	narrow heat arc	0		
 11839	scrape	0		
@@ -11724,7 +11724,7 @@
 11869	unironic knife	0		
 11870	gray bar dart	0		Last Available: "2025-03"
 11871	vaporized cyan huge leprechaun antidepressant pill	1		Effect: "Liquid Courage", Effect Duration: 35, Last Available: "2025-03"
-11872	thick rotten Heck ramen	5	crappy	Last Available: "2025-03"
+11872	rotten thick Heck ramen	5	crappy	Last Available: "2025-03"
 11873	jumbo moldy burrito	5	crappy	Last Available: "2025-03"
 11874	stale miniature narrow small beer brat	2	decent	Last Available: "2025-03"
 11875	decent immense peach pie	9	good	Last Available: "2025-03"
@@ -11737,7 +11737,7 @@
 11882	perfectly mixed Mon Tiki sidecar	4	EPIC	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	miser's April Shower Thoughts shield of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +10, Damage Reduction: 6, Last Available: "2025-04"
-11885	maroon bouncing glob of wet paper	0		Last Available: "2025-04"
+11885	bouncing maroon glob of wet paper	0		Last Available: "2025-04"
 11886	yellow spitball	0		Last Available: "2025-04"
 11887	polarized quadruple-liquefied wet paper weights	0		Effect: "Sugar Smacks", Effect Duration: 30, Last Available: "2025-04"
 11888	acceptable Three Sheets to the Wind	4	good	Last Available: "2025-04"
@@ -11767,11 +11767,11 @@
 11912	wholesome tin foil hat	0		Maximum HP Percent: +10
 11913	arcane researcher's construction hardhat	0		Experience Percent (Mysticality): +10
 11914	olive gravedigger's imposing pilgrim's hat	0		Spooky Damage: +10
-11915	spinning mirror crown of thorns	0		
+11915	mirror spinning crown of thorns	0		
 11916	maroon fortified stylish bycocket	0		Damage Absorption: +60
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	blurry yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,12 +11789,12 @@
 11934	jittery orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	ghostly confetti grenade	0		
-11937	jumbo spoiled maroon blinking Skeleton Wars rations	5	crappy	
-11938	practically non-alcoholic delicious skeleton war fuel can	1	awesome	
+11937	spoiled jumbo maroon blinking Skeleton Wars rations	5	crappy	
+11938	delicious practically non-alcoholic skeleton war fuel can	1	awesome	
 11939	wobbly skeleton war grenade	0		
-11940	wobbly teal bouncing chocolate and nylons detector	0		
+11940	teal wobbly bouncing chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
-11942	twirling huge M&ouml;bius ring	0		Last Available: "2025-08"
+11942	huge twirling M&ouml;bius ring	0		Last Available: "2025-08"
 11943	bone pacifier	0		Familiar Weight: +5
 11944	blinking stanky Sinatra's Allied Forces insignia of Gandalf	0		Experience (Moxie): +5, Spell Critical Percent: +20, Stench Spell Damage: +25, Single Equip
 11945	Allied Tattoo Kit	0		
@@ -11805,7 +11805,7 @@
 11950	shaking coward's time cop top hat	0		Monster Level: -20, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	boiled skewed mixed berry jelly	1		Last Available: "2025-08"
-11953	half-sized moldy upside-down toast with mixed berry jelly	2	crappy	Last Available: "2025-08"
+11953	moldy half-sized upside-down toast with mixed berry jelly	2	crappy	Last Available: "2025-08"
 11954	rotten cup of sugar	3	crappy	Last Available: "2025-08"
 11955	moldy ghostly Susie's cupcake	4	crappy	Last Available: "2025-08"
 11956	mirror clock	0		Last Available: "2025-08"
@@ -11826,16 +11826,16 @@
 11972	huge durable dolphin whistle	0		
 11973	red Thwaitgold lobster statuette	0		
 11974	blinking wobbly packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	gravedigger's dentadent	0		Spooky Damage: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	ribald sizzling chilly curative experienced blood cubic zirconia of Leguizamo	0		Experience: +2, Monster Level: +20, Cold Damage: +5, Hot Damage: +10, Sleaze Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	ribald sizzling chilly curative experienced blood cubic zirconia of Leguizamo	0		Experience: +2, Monster Level: +20, Cold Damage: +5, Hot Damage: +10, Sleaze Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	modified blood thinner	1		Last Available: "2025-10"
 12045	lousy pheromone cocktail	3	decent	Last Available: "2025-10"
-12046	decent small yellow spinal tapas	2	good	Last Available: "2025-10"
+12046	small decent yellow spinal tapas	2	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	censurious wool banded shrunken head	0		Damage Absorption: +100, Cold Resistance: +1, Sleaze Resistance: +3, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	censurious wool banded shrunken head	0		Damage Absorption: +100, Cold Resistance: +1, Sleaze Resistance: +3, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	tumbling stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
@@ -11846,7 +11846,7 @@
 12056	perfectly mixed spinning vodka cranberry sauce	4	EPIC	Last Available: "2025-11"
 12057	extra-chilled twirling yammed candy	0		Effect: "Jawin'", Effect Duration: 13, Last Available: "2025-11"
 12058	normal treasure chestnut	3	good	Last Available: "2025-12"
-12059	perfectly mixed red blinking mulled butter rum	3	EPIC	Last Available: "2025-12"
+12059	perfectly mixed blinking red mulled butter rum	3	EPIC	Last Available: "2025-12"
 12060	colloidal non-corrupted mirror cinnamon doubloon	0		Effect: "Warm Shoulders", Effect Duration: 27, Last Available: "2025-12"
 12061	green Sherlock's plastic left skeleton arm	0		Item Drop: +25, Last Available: "2025-12"
 12062	narrow sinister plastic left skeleton leg	0		Spell Damage: +10, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	pickled boiling synovial fluid	0		Effect: "You Liver", Effect Duration: 48, Last Available: "2025-12"
 12132	Sherlock's arcane researcher's Socratic smoldering vertebra	0		Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Item Drop: +25, Single Equip, Last Available: "2025-12"
 12133	ghostly seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	skewed smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	veiny steel-toed hot boning knife of James Dean	0		Experience (Moxie): +3, Damage Reduction: 9, Maximum HP: +10, Single Equip, Last Available: "2025-12"
 12138	green blurry perfumed lion tamer's Annie Oakley's fistbone	0		Critical Hit Percent: +20, Experience (familiar): +2, Stench Resistance: +5, Last Available: "2025-12"
 12139	Tesla stiffened burnt bone belt of temperance	0		Damage Reduction: 1, Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2025-12"
 12140	gray scorched skull trophy of the detective	0		Item Drop: +20, Last Available: "2025-12"
-12141	adequate snack-sized wing bone	2	good	Last Available: "2025-12"
+12141	snack-sized adequate wing bone	2	good	Last Available: "2025-12"
 12142	lousy weak skeleton venom	3	decent	Last Available: "2025-12"
 12143	pickled twirling twirling baked bone meal	1		Last Available: "2025-12"
 12144	spinning plastic skeleton rib cage of horror	0		Spooky Spell Damage: +25, Last Available: "2025-12"
@@ -11928,15 +11928,15 @@
 12170	MacGyver's crafty heat-resistant harpoon pistol	0		Maximum MP: 110, Last Available: "2025-12"
 12171	super-sized flavorless traditional gingerloaf	5	decent	Last Available: "2025-12"
 12172	hand-crafted weak upside-down Scotch and eggnog	2	super ultra EPIC	Last Available: "2025-12"
-12173	polymerized jittery shaking shaking counterskeleton elixir	0		Effect: "Hobonic", Effect Duration: 42, Last Available: "2025-12"
+12173	polymerized shaking jittery shaking counterskeleton elixir	0		Effect: "Hobonic", Effect Duration: 42, Last Available: "2025-12"
 12174	delicious spinning &quot;salvaged&quot; wine	3	awesome	Last Available: "2025-12"
-12175	jittery huge The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12175	huge jittery The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	decent wedge of prize-winning cheese	3	good	Last Available: "2025-12"
 12178	quadruple-electrified double-polymerized gummi fingerbone	0		Effect: "Hammertime", Effect Duration: 66
 12179	flame-retardant chilly glimmering crystal	0		Cold Damage: +5, Hot Resistance: +1, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	squat purple Thwaitgold meat bee statuette	0		
 12183	wobbly loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11972,27 +11972,27 @@
 12214	compressed candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	special super-sized rotten discarded hot dog	5	crappy	Effect: "Omphalotus Omnipresence", Effect Duration: 20, Last Available: "2026-04"
+12217	super-sized special rotten discarded hot dog	5	crappy	Effect: "Omphalotus Omnipresence", Effect Duration: 20, Last Available: "2026-04"
 12218	bad narrow most of a beer	4	decent	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	cyan legendary noodles	0		Last Available: "2026-05"
 12226	super-sized adequate blinking maroon can of tuna	5	good	
-12227	flavorless small spinning alien salad	2	decent	
+12227	small flavorless spinning alien salad	2	decent	
 12228	stale half-sized twirling tumbling ratbatatouille	2	decent	
 12229	rotten snack-sized onigiri	2	crappy	
 12230	adequate tiny blue crudit&eacute;s	1	good	
 12231	decent sauced mutton	4	good	
 12232	rotten hot honey ant	4	crappy	
-12233	small yummy blue tomb aspic	2	awesome	
+12233	yummy small blue tomb aspic	2	awesome	
 12234	normal later tots	3	good	
 12235	decent Frutti di Scatoletta	3	good	Last Available: "2026-05"
-12236	delicious diet Pesto alla Marziano	1	awesome	Last Available: "2026-05"
-12237	decent jumbo Arrattabbattabiata	5	good	Last Available: "2026-05"
+12236	diet delicious Pesto alla Marziano	1	awesome	Last Available: "2026-05"
+12237	jumbo decent Arrattabbattabiata	5	good	Last Available: "2026-05"
 12238	tasty jumbo Orzo di Riso	5	awesome	Last Available: "2026-05"
-12239	yummy snack-sized Pasta Grimavera	2	awesome	Last Available: "2026-05"
+12239	snack-sized yummy Pasta Grimavera	2	awesome	Last Available: "2026-05"
 12240	rotten Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
-12241	tiny normal cyan twirling Formica e Pepe	1	good	Last Available: "2026-05"
+12241	normal tiny twirling cyan Formica e Pepe	1	good	Last Available: "2026-05"
 12242	stale Tubetto Gelatto	3	decent	Last Available: "2026-05"
 12243	moldy Gnocci Domani	3	crappy	Last Available: "2026-05"
 12244	jittery Thwaitgold wallet moth statuette	0		
@@ -12001,7 +12001,7 @@
 12248	blinking mega helmet	0		
 12252	Usain Bolt's Space Soldier Helmet of Gandalf	0		Spell Critical Percent: +20, Initiative: +80
 12253	normal olive premium turkey leg	4	good	
-12254	bad spirit-forward styrofoam cup of mead	5	decent	
+12254	spirit-forward bad styrofoam cup of mead	5	decent	
 12255	knitted sword	0		Cold Resistance: +3
 12256	extremely unsafe staff	0		Weapon Damage Percent: +100
 12257	Jim Carey's lute	0		Monster Level: +25
@@ -12017,20 +12017,20 @@
 12267	clever flimsy plastic breastplate	0		Maximum MP: +20
 12268	perfumed flimsy plastic shield	0		Stench Resistance: +5, Damage Reduction: 3
 12269	lime green packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	perfumed double-paned Portable Laughing Stock of the cougar	0		Moxie: +20, Cold Resistance: +5, Stench Resistance: +5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	perfumed double-paned Portable Laughing Stock of the cougar	0		Moxie: +20, Cold Resistance: +5, Stench Resistance: +5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	spinning twirling smelly rosy-cheeked Staff of Anachronistic Churning of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Stench Spell Damage: +10
 12272	flavorless classic banana	4	decent	Last Available: "2026-07"
 12273	spoiled gigantic mirror watermelon	8	crappy	Last Available: "2026-07"
 12274	flavorless quince	3	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	delicious miniature classic banana pie	2	awesome	Last Available: "2026-07"
+12277	miniature delicious classic banana pie	2	awesome	Last Available: "2026-07"
 12278	ionized oxidized essential banana decoction	0		Effect: "Uncanny Shot", Effect Duration: 26, Last Available: "2026-07"
 12279	pickled bouncing banana quintessence	0		Effect: "Blessing of Charcoatl", Effect Duration: 46, Last Available: "2026-07"
 12280	smooth special Aesop Daiquiri	4	awesome	Effect: "Demonic Flavor", Effect Duration: 20, Last Available: "2026-07"
 12281	artisanal Monkey Congress	4	EPIC	Last Available: "2026-07"
 12282	normal special watermelon pie	3	good	Effect: "Material Witness", Effect Duration: 20, Last Available: "2026-07"
-12283	oxidized blinking pulsating concentrated watermelon juice	0		Effect: "Smelly Pants", Effect Duration: 42, Last Available: "2026-07"
+12283	oxidized pulsating blinking concentrated watermelon juice	0		Effect: "Smelly Pants", Effect Duration: 42, Last Available: "2026-07"
 12284	aerosolized blurry Aqua Citrulanatae	0		Effect: "Healthy Red Glow", Effect Duration: 36, Last Available: "2026-07"
 12285	weak perfectly mixed Melonegroni	2	EPIC	Last Available: "2026-07"
 12286	hand-crafted Melonade Spritz	3	EPIC	Last Available: "2026-07"
@@ -12039,10 +12039,10 @@
 12289	magnetized activated shaking Quickquince	0		Effect: "Shredding, Sweating", Effect Duration: 13, Last Available: "2026-07"
 12290	lousy Quiskey Sour	3	decent	Last Available: "2026-07"
 12291	practically non-alcoholic mediocre Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
-12292	practically non-alcoholic delicious Roth IPA	1	awesome	Last Available: "2026-08"
+12292	delicious practically non-alcoholic Roth IPA	1	awesome	Last Available: "2026-08"
 12293	nasty padded underdraft protection	0		Damage Absorption: +20, Stench Damage: +5, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	enchanted rotten soybean futures	4	crappy	Effect: "Chalky White Pallor", Effect Duration: 45, Last Available: "2026-08"
+12295	rotten enchanted soybean futures	4	crappy	Effect: "Chalky White Pallor", Effect Duration: 45, Last Available: "2026-08"
 12296	diffused colloidal upside-down housing bubble	0		Effect: "Squirming Like a Toad", Effect Duration: 66, Last Available: "2026-08"
 12297	unsweetened Pixie-Swordz	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 11
 12298	upside-down maroon resourceful quilted financial instrument	0		Damage Absorption: +40, Maximum MP: +50, Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	savings bondo	0		Last Available: "2026-08"
 12309	wobbly homeowner's loam	0		Last Available: "2026-08"
 12310	twisted cyan toxic asset	1		Last Available: "2026-08"
-12311	vaporized maroon huge intangible asset	1		Last Available: "2026-08"
+12311	vaporized huge maroon intangible asset	1		Last Available: "2026-08"
 12312	diluted narrow liquid asset	1		Last Available: "2026-08"
 12313	spinning gross prophet chrysalis	0		Last Available: "2026-08"
 12314	upside-down cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Accordion_Thief_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Vole_cafe_booze.txt
@@ -6,9 +6,9 @@
 -6	mediocre high-proof braincracker sweet	8	decent	
 -16	mediocre mirror fermented honey	3	decent	
 -17	lousy watered-down moons-shine	2	decent	
--18	tolerable triple-distilled gin	6	good	
+-18	triple-distilled tolerable gin	6	good	
 -19	watered-down lousy ecto-nog	2	decent	
--20	lousy skewed blinking hot toady	3	decent	
+-20	lousy blinking skewed hot toady	3	decent	
 -21	artisanal hot choculate	3	EPIC	
 -49	delicious Cyder	3	awesome	
 -50	mediocre twirling Oil Nog	4	decent	
@@ -16,18 +16,18 @@
 -58	hand-crafted practically non-alcoholic skewed Grimacider	1	EPIC	
 -59	spirit-forward hand-crafted Isotope Nog	5	EPIC	
 -60	bad Mutagin 'n' Tonic	3	decent	
--70	fancy lousy blurry Gin and Herring	4	decent	
--71	drinkable practically non-alcoholic Black and Tan and Red All Over	1	good	
+-70	lousy fancy blurry Gin and Herring	4	decent	
+-71	practically non-alcoholic drinkable Black and Tan and Red All Over	1	good	
 -72	practically non-alcoholic artisanal Antarctic Ice Tea	1	EPIC	
--76	bad jittery wobbly CRIMBCO Ribbon Candy Schnapps	4	decent	
+-76	bad wobbly jittery CRIMBCO Ribbon Candy Schnapps	4	decent	
 -77	tolerable gray CRIMBCO Egg Substitute Nog Substitute	4	good	
 -78	acceptable CRIMBCO Extreme Braincracker Sour	4	good	
 -82	tolerable Horseradish-infused Vodka	4	good	
--83	delicious triple-distilled Jerkitini	6	awesome	
+-83	triple-distilled delicious Jerkitini	6	awesome	
 -84	tolerable high-proof Desert Island Iced Tea	10	good	
 -88	lousy Crimbo Saketini	4	decent	
 -89	drinkable Crimboku Drop	3	good	
--90	drinkable high-proof squat Flaming Crimbo Log	10	good	
--107	acceptable weak Fortified Eggnog Slurry	2	good	
+-90	high-proof drinkable squat Flaming Crimbo Log	10	good	
+-107	weak acceptable Fortified Eggnog Slurry	2	good	
 -108	acceptable twirling Hot Buttered Rum	3	good	
 -109	artisanal Spicy Hot Chocolate	4	EPIC	

--- a/data/TCRS/TCRS_Accordion_Thief_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Vole_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	spoiled tumbling tumbling Peche a la Frog	4	crappy	
 -2	moldy As Jus Gezund Heit	3	crappy	
 -3	spoiled Bouillabaise Coucher Avec Moi	3	crappy	
--7	snack-sized fancy flavorless gumdrop chow mein	2	decent	
+-7	flavorless snack-sized fancy gumdrop chow mein	2	decent	
 -8	stale candy cane pizza	4	decent	
 -9	adequate purple gingerbread stir-fry	4	good	
--10	enchanted adequate cyan twigs and gravel	4	good	
+-10	adequate enchanted cyan twigs and gravel	4	good	
 -11	bland mirror shoots and leaves	4	decent	
 -12	fancy moldy bowl of unidentifiable goo	4	crappy	
--13	gigantic moldy gingerbread massacre	7	crappy	
+-13	moldy gigantic gingerbread massacre	7	crappy	
 -14	stale thick huge It Came From Beyond Dessert	5	decent	
 -15	super-sized yummy spinning vampire cake	5	awesome	
--52	gigantic rotten Soylent Red and Green	6	crappy	
--53	normal gigantic Disc-Shaped Nutrition Unit	10	good	
+-52	rotten gigantic Soylent Red and Green	6	crappy	
+-53	gigantic normal Disc-Shaped Nutrition Unit	10	good	
 -54	normal blurry Gingerborg Hive	4	good	
--61	huge stale enchanted Candy Cane Surprise	9	decent	
--62	moldy tiny Grimdrop Chow Mein	1	crappy	
+-61	enchanted stale huge Candy Cane Surprise	9	decent	
+-62	tiny moldy Grimdrop Chow Mein	1	crappy	
 -63	adequate Grimgerbread House	3	good	
 -67	normal Caviar Carbonara	4	good	
 -68	moldy Halibut Alfredo	4	crappy	
 -69	normal spinning jittery Red Herring Velvet Cake	4	good	
--73	super-sized spoiled CRIMBCO Reconstituted Gruel	5	crappy	
--74	big enchanted delicious lime green New and Improved CRIMBCO Reconstituted Gruel	5	awesome	
+-73	spoiled super-sized CRIMBCO Reconstituted Gruel	5	crappy	
+-74	enchanted delicious big lime green New and Improved CRIMBCO Reconstituted Gruel	5	awesome	
 -75	stale CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
 -79	rotten Brussels Sprout Stir-Fry	4	crappy	
 -80	adequate Carrot, Cabbage, and Kale Pizza	3	good	
 -81	decent spinning Turnip and Rutabaga Pie	4	good	
 -85	rotten massive Rainbow Spider Fun Roll	9	crappy	
--86	decent thick bouncing Vegas Volcano Lava Roll	5	good	
+-86	thick decent bouncing Vegas Volcano Lava Roll	5	good	
 -87	spoiled Crazy Dragon Shogun Buddha Roll	4	crappy	
--92	jumbo bland narrow basic hot dog	5	decent	
+-92	bland jumbo narrow basic hot dog	5	decent	
 -93	normal squat savage macho dog	3	good	
 -94	delicious one with everything	3	awesome	
 -95	flavorless sly dog	4	decent	
 -96	stale devil dog	3	decent	
--97	bland super-sized narrow chilly dog	5	decent	
+-97	super-sized bland narrow chilly dog	5	decent	
 -98	rotten ghost dog	3	crappy	
--99	bland super-sized bouncing junkyard dog	5	decent	
+-99	super-sized bland bouncing junkyard dog	5	decent	
 -100	moldy thick wet dog	5	crappy	
 -101	delicious sleeping dog	3	awesome	
--102	adequate low-calorie optimal dog	1	good	
--103	enchanted flavorless bite-sized video games hot dog	1	decent	
+-102	low-calorie adequate optimal dog	1	good	
+-103	enchanted bite-sized flavorless video games hot dog	1	decent	
 -104	moldy special Peppermint Nutrition Block	4	crappy	
 -105	adequate Gingerbread Nutrition Block	4	good	
 -106	immense adequate Cinnamon Nutrition Block	10	good	

--- a/data/TCRS/TCRS_Accordion_Thief_Wallaby.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wallaby.txt
@@ -13,7 +13,7 @@
 14	altered fuchsia moxie weed	1		Effect: "Bustle Hustlin'", Effect Duration: 30
 15	boiled strongness elixir	1		
 16	twisted magicalness-in-a-can	1		
-17	special bland noodles	4	decent	Effect: "Mushroom Samba", Effect Duration: 30
+17	bland special noodles	4	decent	Effect: "Mushroom Samba", Effect Duration: 30
 18	tortoise's blessing	0		
 19	pulsating asparagus knife	0		Item Drop: +5
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -25,7 +25,7 @@
 26	Dolphin King's map	0		
 27	spider web	0		
 28	pulsating really spider web	0		
-29	skewed pulsating really really spider web	0		
+29	pulsating skewed really really spider web	0		
 30	rock	0		
 31	seal-toothed rock	0		
 32	padded Bjorn's Hammer	0		Damage Absorption: +20, Class: "Seal Clubber"
@@ -55,7 +55,7 @@
 56	hot sauce	0		
 57	dog trainer's 5-Alarm Saucepan	0		Experience (familiar): +1, Class: "Sauceror"
 58	stone turtle	0		
-59	huge jittery slingshot	0		
+59	jittery huge slingshot	0		
 60	shellacked Mace of the Tortoise	0		Damage Reduction: 7, Class: "Turtle Tamer"
 61	stale fortune cookie	3	decent	
 62	hardened oriole-feather headdress	0		Damage Reduction: 3, Familiar Effect: "atk, 3xVolley, cap 3"
@@ -77,7 +77,7 @@
 78	brainy pretty bouquet	0		Mysticality: +5
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	weak mediocre ice-cold Willer	2	decent	
+81	mediocre weak ice-cold Willer	2	decent	
 82	ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
@@ -158,16 +158,16 @@
 159	purple wad of dough	0		
 160	pie crust	0		
 161	decent ghuol egg	4	good	
-162	half-sized rotten ghuol egg quiche	2	crappy	
+162	rotten half-sized ghuol egg quiche	2	crappy	
 163	nasty skeleton bone	0		Stench Damage: +5
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
 167	spoiled ghuol-ear kabob	3	crappy	
 168	cool bone rattle	0		Moxie: +5
-169	red jittery bugbear beanie	0		Familiar Effect: "atk, cap 7"
+169	jittery red bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	special massive decent lihc eye pie	7	good	Effect: "Gummiskin", Effect Duration: 20
+171	decent special massive lihc eye pie	7	good	Effect: "Gummiskin", Effect Duration: 20
 172	mirror gnoll lips	0		
 173	yellow taco shell	0		
 174	Gnollish casserole dish	0		
@@ -181,7 +181,7 @@
 182	batgut	0		
 183	bat wing	0		
 184	briefcase	0		
-185	pulsating gray fat stacks of cash	0		
+185	gray pulsating fat stacks of cash	0		
 186	bean	0		
 187	blurry blurry loose teeth	0		
 188	upside-down wobbly bat guano	0		
@@ -196,10 +196,10 @@
 198	rat appendix	0		
 199	purple blinking greedy ring	0		Meat Drop: +20
 200	jumbo bland rat appendix kabob	5	decent	
-201	decent gigantic upside-down wobbly bat wing kabob	6	good	
+201	gigantic decent wobbly upside-down bat wing kabob	6	good	
 202	bland huge carob chunks	3	decent	
 203	pulsating herbs	0		
-204	normal special small green carob chunk cookies	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40
+204	special normal small green carob chunk cookies	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40
 205	secret blend of herbs and spices	0		
 206	ghostly piercing post	0		
 207	enchanted hippy herbal tea	1	EPIC	Effect: "Techno Bliss", Effect Duration: 40
@@ -215,7 +215,7 @@
 217	bland upside-down blurry herb brownies	4	decent	
 218	spinning hemp string	0		
 219	necklace chain	0		
-220	red shaking gnoll teeth	0		
+220	shaking red gnoll teeth	0		
 221	gnoll-tooth necklace of the businessman	0		Meat Drop: +50
 222	phat turquoise bead	0		
 223	spinning groovy phat turquoise bracelet	0		Moxie Percent: +10
@@ -233,47 +233,47 @@
 235	banded groovy Bigger Bugfinder Blade	0		Moxie Percent: +10, Damage Absorption: +100
 236	huge Queue Du Coq cocktailcrafting kit	0		
 237	acceptable bottle of gin	3	good	
-238	perfectly mixed practically non-alcoholic bottle of vodka	1	EPIC	
+238	practically non-alcoholic perfectly mixed bottle of vodka	1	EPIC	
 239	fuchsia zippy Annie Oakley's Orcish baseball cap	0		Critical Hit Percent: +20, Initiative: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	grievous Orcish cargo shorts of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	teal Orcish frat-paddle of Flo-Jo	0		Initiative: +100
 242	toothsome diet	1	awesome	
 243	rotten grapefruit	4	crappy	
-244	tasty miniature grapes	2	awesome	
+244	miniature tasty grapes	2	awesome	
 245	decent ghostly olive	3	good	
 246	moldy tomato	4	crappy	
 247	fermenting powder	0		
 248	watered-down lousy purple salty dog	2	decent	
-249	spirit-forward smooth bloody mary	5	awesome	
-250	weak drinkable screwdriver	2	good	
+249	smooth spirit-forward bloody mary	5	awesome	
+250	drinkable weak screwdriver	2	good	
 251	lousy weak martini	2	decent	
-252	boozy enchanted acceptable ghostly bloody beer	5	good	Effect: "Vital", Effect Duration: 45
-253	artisanal spirit-forward wobbly shot of schnapps	5	EPIC	
+252	enchanted boozy acceptable ghostly bloody beer	5	good	Effect: "Vital", Effect Duration: 45
+253	spirit-forward artisanal wobbly shot of schnapps	5	EPIC	
 254	tolerable shot of grapefruit schnapps	4	good	
-255	aged irresponsibly strong fine wine	6	awesome	
+255	irresponsibly strong aged fine wine	6	awesome	
 256	acceptable narrow shot of tomato schnapps	4	good	
-257	weak acceptable enchanted extra-spicy bloody mary	2	good	Effect: "Leash of Linguini", Effect Duration: 10
+257	acceptable enchanted weak extra-spicy bloody mary	2	good	Effect: "Leash of Linguini", Effect Duration: 10
 258	teal dense meat stack	0		
 259	snake skin	0		
-260	stale twirling jittery White Citadel fries	4	decent	
+260	stale jittery twirling White Citadel fries	4	decent	
 261	decent White Citadel burger	3	good	
-262	moldy half-sized piece of wedding cake	2	crappy	
-263	miniature enchanted bland chocolate chips	2	decent	Effect: "Chari Tea", Effect Duration: 50
-264	immense tasty special chocolate chip cookies	8	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 5
+262	half-sized moldy piece of wedding cake	2	crappy	
+263	enchanted miniature bland chocolate chips	2	decent	Effect: "Chari Tea", Effect Duration: 50
+264	special immense tasty chocolate chip cookies	8	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 5
 265	narrow satin pants of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 2xPotato, cap 10"
 266	bad lightning	4	decent	
 267	olive mullet wig of the glutton	0		Food Drop: +100, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	yellow wool meat cowboy hat	0		Cold Resistance: +1, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	lard-coated sword	0		Sleaze Spell Damage: +25
 270	picket fence	0		
-271	twisted maroon tumbling ghostly barbell	1		
+271	twisted ghostly maroon tumbling barbell	1		
 272	diluted skewed concentrated magicalness pill	1		Effect: "Going Ape", Effect Duration: 50
-273	mixed blinking bouncing moxie weed	1		Effect: "Seal Clubbing Frenzy", Effect Duration: 15
+273	mixed bouncing blinking moxie weed	1		Effect: "Seal Clubbing Frenzy", Effect Duration: 15
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
 277	denatured squat blurry extra-strength strongness elixir	1		
-278	twisted wobbly cyan jug-o-magicalness	1		
+278	twisted cyan wobbly jug-o-magicalness	1		
 279	dehydrated gray blurry suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	jittery gasmask of courage	0		Spooky Resistance: +3, Familiar Effect: "1xBarrr, cap 12"
@@ -309,24 +309,24 @@
 311	hill of beans	0		
 312	twirling chilly Knob Goblin visor	0		Cold Damage: +5, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	veiny Crown of the Goblin King	0		Maximum HP: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	diet spoiled bean burrito	1	crappy	
+314	spoiled diet bean burrito	1	crappy	
 315	normal huge bean burrito	3	good	
 316	spoiled miniature insanely bean burrito	2	crappy	
-317	low-calorie adequate bean burrito	1	good	
+317	adequate low-calorie bean burrito	1	good	
 318	normal cyan bean burrito	3	good	
 319	normal huge insanely bean burrito	10	good	
 320	flavorless lime green bat haggis	3	decent	
-321	spoiled twirling squat twirling menudo	4	crappy	
-322	half-sized bland goat cheese	2	decent	
+321	spoiled squat twirling twirling menudo	4	crappy	
+322	bland half-sized goat cheese	2	decent	
 323	adequate upside-down plain pizza	4	good	
-324	tiny toothsome sausage pizza	1	awesome	
+324	toothsome tiny sausage pizza	1	awesome	
 325	bland goat cheese pizza	3	decent	
 326	stale mushroom pizza	3	decent	
 327	goat	0		
 328	acceptable narrow bottle of whiskey	4	good	
 329	goat beard of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	decent	
-331	watered-down hand-crafted blue Canadian	2	EPIC	
+331	hand-crafted watered-down blue Canadian	2	EPIC	
 332	decent lemon	4	good	
 333	rotten lime	3	crappy	
 334	skewed sabre teeth of extreme caution	0		Monster Level: -25
@@ -336,13 +336,13 @@
 338	tenderizing hammer	0		
 339	yellow Cobb's Knob lab key	0		
 340	pressed dry Knob Goblin steroids	0		Effect: "Coy to the Hurled", Effect Duration: 28
-341	nitrogenated energized ghostly pulsating Knob Goblin love potion	0		Effect: "Resilient Spirit", Effect Duration: 30
+341	nitrogenated energized pulsating ghostly Knob Goblin love potion	0		Effect: "Resilient Spirit", Effect Duration: 30
 342	Knob Goblin stink bomb	0		
 343	corrupted Knob Goblin sharpening spray	0		Effect: "Mortarfied", Effect Duration: 29
 344	Knob Goblin seltzer	0		
 345	skewed Knob Goblin superseltzer	0		
 346	purple scrumptious reagent	0		
-347	tumbling blue Dyspepsi-Cola	0		
+347	blue tumbling Dyspepsi-Cola	0		
 348	gray Jeselnik's ninja mask	0		Sleaze Damage: +25, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
 350	green hot katana blade	0		
@@ -354,7 +354,7 @@
 356	lime green dog trainer's snowboarder pants	0		Experience (familiar): +1, Familiar Effect: "1xPotato, cap 25"
 357	twirling Mountain Stream soda	0		
 358	huge spoiled gr8ps	7	crappy	
-359	normal small t8r tots	2	good	
+359	small normal t8r tots	2	good	
 360	clever miner's helmet	0		Maximum MP: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	twirling Fonzie's miner's pants	0		Experience (Moxie): +1, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	squat nasty 7-Foot Dwarven mattock	0		Stench Damage: +5
@@ -418,7 +418,7 @@
 420	non-wet tomato juice of powerful power	0		Effect: "Hairless and Airless", Effect Duration: 47
 421	enhanced philter of phorce	0		Effect: "Familial Ties", Effect Duration: 33
 422	modified ionized potion of potency	0		Effect: "Granolarrrgh", Effect Duration: 37
-423	electrified double-dry super-boiled blue blinking cordial of concentration	0		Effect: "Bandersnatched", Effect Duration: 47
+423	electrified double-dry super-boiled blinking blue cordial of concentration	0		Effect: "Bandersnatched", Effect Duration: 47
 424	magnetized ionized yellow ointment of the occult	0		Effect: "Neutered Nostrils", Effect Duration: 64
 425	vacuum-sealed olive oil of expertise	0		Effect: "All Glory To the Toad", Effect Duration: 58
 426	energized enhanced shaking potion of temporary gr8ness	0		Effect: "Okee-Dokee Go!", Effect Duration: 59
@@ -436,7 +436,7 @@
 438	shaking chef-in-the-box	0		
 439	bartender skull	0		
 440	bartender-in-the-box	0		
-441	upside-down jittery chef-skull-in-the-box	0		
+441	jittery upside-down chef-skull-in-the-box	0		
 442	bartender-skull-in-the-box	0		
 443	mirror beer lens	0		
 444	beer goggles	0		
@@ -448,10 +448,10 @@
 450	pretentious paintbrush	0		
 451	mirror pretentious palette	0		
 452	disease	0		
-453	jittery huge tumbling sober pill	0		
+453	jittery tumbling huge sober pill	0		
 454	screwdriver	0		
 455	flavorless cyan jumbo olive	4	decent	
-456	hand-crafted practically non-alcoholic special dry martini	1	super EPIC	Effect: "Egg Burps", Effect Duration: 35
+456	practically non-alcoholic special hand-crafted dry martini	1	super EPIC	Effect: "Egg Burps", Effect Duration: 35
 457	blue vibrating ye olde golde frontes	0		Maximum MP Percent: +10, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
@@ -501,19 +501,19 @@
 503	bland skewered cat appendix	3	decent	
 504	evil arches	0		
 505	wobbly lightning-fast studded gnatwing earring	0		Damage Absorption: +80, Initiative: +40
-506	huge moldy Hell broth	9	crappy	
+506	moldy huge Hell broth	9	crappy	
 507	tumbling blurry thunderrr guitarrr of the overflowing toilet	0		Stench Spell Damage: +50
 508	sonata	0		
-509	spinning mirror Hey Deze nuts	0		
+509	mirror spinning Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	shaking Sneaky Pete's key lime	0		
 513	rotten Boris's key lime pie	4	crappy	
-514	adequate half-sized Jarlsberg's key lime pie	2	good	
+514	half-sized adequate Jarlsberg's key lime pie	2	good	
 515	normal upside-down Sneaky Pete's key lime pie	3	good	
 516	blinking Hey Deze map	0		
 517	bejeweled accordion strap of the wise owl	0		Mysticality: +20, Class: "Accordion Thief"
-518	jittery ghostly mystery juice	0		
+518	ghostly jittery mystery juice	0		
 519	cyan moxie magnet	0		
 520	leaflet	0		
 521	hardened kickback cookbook	0		Damage Reduction: 3
@@ -552,7 +552,7 @@
 554	miniature rotten pr0n cocktail	2	crappy	
 555	reassuring drywall axe of the sewer	0		Stench Damage: +25, Spooky Resistance: +1
 556	twirling twirling chilly Pine-Fresh air freshener	0		Cold Damage: +5
-557	practically non-alcoholic perfectly mixed skewed whiskey and cola	1	EPIC	
+557	perfectly mixed practically non-alcoholic skewed whiskey and cola	1	EPIC	
 558	tasty snack-sized squat papaya taco	2	awesome	
 559	razor-sharp can lid	0		
 560	adequate stalk of asparagus	3	good	
@@ -565,14 +565,14 @@
 567	bouncing hermit script	0		
 568	spoiled shaking Double Bacon Beelzeburger	3	crappy	
 569	yummy huge Lord of the Flies-sized fries	3	awesome	
-570	bland miniature Chicken Sandwich	2	decent	
+570	miniature bland Chicken Sandwich	2	decent	
 571	blurry Jumbo Dr. Lucifer	1	good	
-572	spoiled enchanted Children's Meal of the Damned	4	crappy	Effect: "Ten out of Ten", Effect Duration: 40
-573	spoiled half-sized blurry noodles	2	crappy	
-574	rotten diet maroon noodles	1	crappy	
+572	enchanted spoiled Children's Meal of the Damned	4	crappy	Effect: "Ten out of Ten", Effect Duration: 40
+573	half-sized spoiled blurry noodles	2	crappy	
+574	diet rotten maroon noodles	1	crappy	
 575	bland painful penne pasta	3	decent	
 576	adequate ravioli della hippy	3	good	
-577	moldy miniature huge pr0n m4nic0tti	2	crappy	
+577	miniature moldy huge pr0n m4nic0tti	2	crappy	
 578	tasty Hell ramen	4	awesome	
 579	flavorless miniature boring spaghetti	2	decent	
 580	sauce of the ages	0		
@@ -584,7 +584,7 @@
 586	twirling gravedigger's ridiculously huge sword of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10
 587	moist bouncing super-spiky hair gel	0		Effect: "Patent Avarice", Effect Duration: 16
 588	soft echo eyedrop antidote	0		
-589	stale small enchanted squat cocoa eggshell fragment	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45
+589	stale enchanted small squat cocoa eggshell fragment	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45
 590	decent cocoa eggshell fragment	3	good	
 591	cocoa egg	0		
 592	house	0		
@@ -601,9 +601,9 @@
 603	maroon jittery Item #13	0		
 604	red Penultimate Fantasy chest	0		
 605	mirror Tissue Paper Immateria	0		
-606	squat gray Tin Foil Immateria	0		
+606	gray squat Tin Foil Immateria	0		
 607	Gauze Immateria	0		
-608	narrow huge Plastic Wrap Immateria	0		
+608	huge narrow Plastic Wrap Immateria	0		
 609	red wobbly S.O.C.K.	0		
 610	huge procrastination potion	0		
 611	D	0		
@@ -634,18 +634,18 @@
 636	meat globe	0		
 637	wobbly toaster	0		
 638	Usain Bolt's executive asshat	0		Meat Drop: +40, Initiative: +80, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	thick flavorless abominable snowcone	5	decent	
+639	flavorless thick abominable snowcone	5	decent	
 640	purple Ent cider	1	crappy	
 641	decent huge toast	3	good	
 642	skeleton key	0		
 643	ghostly skeleton key ring	0		
 644	fuchsia Crimbo pressie	0		Last Available: "2003-12"
 645	huge wrapping paper	0		Last Available: "2003-12"
-646	low-calorie moldy fruitcake	1	crappy	
+646	moldy low-calorie fruitcake	1	crappy	
 647	present	0		Last Available: "2004-11"
 648	fireproof Crimbo sword	0		Hot Resistance: +3, Last Available: "2004-10"
-649	shaking Fonzie's Crimbo hat	0		Experience (Moxie): +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	wobbly Annie Oakley's Crimbo pants	0		Critical Hit Percent: +20, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	shaking Fonzie's Crimbo hat	0		Experience (Moxie): +1, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	wobbly Annie Oakley's Crimbo pants	0		Critical Hit Percent: +20, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	ghostly lion tamer's exclusive ultra-rare item	0		Experience (familiar): +2
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,7 +664,7 @@
 666	vibrating studded steaming evil of the brute	0		Muscle Percent: +30, Damage Absorption: +80, Maximum MP Percent: +10
 667	castle map	0		
 668	banded spiked femur	0		Damage Absorption: +100
-669	enchanted miniature rotten ghuol guolash	2	crappy	Effect: "Spiky Hair", Effect Duration: 40
+669	miniature rotten enchanted ghuol guolash	2	crappy	Effect: "Spiky Hair", Effect Duration: 40
 670	ribald lihc face	0		Sleaze Damage: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	therapeutic extremely unsafe grave robbing shovel	0		Weapon Damage Percent: +100, HP Regen Min: 5, HP Regen Max: 7
 672	moldy cranberries	4	crappy	
@@ -675,11 +675,11 @@
 677	badass belt of Gandalf	0		Spell Critical Percent: +20
 678	spinning chest of the Bonerdagon	0		
 679	drinkable blue roll in the hay	4	good	
-680	tolerable weak slap and tickle	2	good	
-681	lousy boozy slip 'n' slide	5	decent	
+680	weak tolerable slap and tickle	2	good	
+681	boozy lousy slip 'n' slide	5	decent	
 682	artisanal twirling a sump'm sump'm	3	EPIC	
-683	delicious enchanted mirror horizontal tango	3	awesome	Effect: "Egg-stortionary Tactics", Effect Duration: 10
-684	triple-distilled mediocre pink pony	6	decent	
+683	enchanted delicious mirror horizontal tango	3	awesome	Effect: "Egg-stortionary Tactics", Effect Duration: 10
+684	mediocre triple-distilled pink pony	6	decent	
 685	Temple Grandin's crafty Herculean Mr. Shirt	0		Experience (Muscle): +1, Maximum MP: +10, Familiar Weight: +7
 686	electrified knuckles	0		MP Regen Min: 3, MP Regen Max: 5
 687	non-wet blood of the Wereseal	0		Effect: "Spooky Flavor", Effect Duration: 41
@@ -726,7 +726,7 @@
 730	jittery fishtank	0		
 731	fish hose	0		
 732	teal hosed tank	0		
-733	skewed narrow hosed fishbowl	0		
+733	narrow skewed hosed fishbowl	0		
 734	shaking greasy careful makeshift SCUBA gear of Flo-Jo	0		Monster Level: -10, Sleaze Spell Damage: +10, Initiative: +100, Adventure Underwater
 735	strapping easter egg balloon	0		Muscle: +5
 736	stone tablet (Sinister Strumming)	0		
@@ -736,25 +736,25 @@
 740	tambourine of Calamity Jane	0		Critical Hit Percent: +15
 741	broken skull	0		
 742	normal Knoll shroomkabob	4	good	
-743	small spoiled mushroom	2	crappy	
+743	spoiled small mushroom	2	crappy	
 744	dry boiled wobbly hair spray	0		Effect: "Surreally Buff", Effect Duration: 22
 746	stat script	0		
 747	ghostly Knob Goblin firecracker	0		
 748	mirror gourd potion	0		
 749	spoiled warm mushroom	3	crappy	
-750	half-sized decent mushroom quesadilla	2	good	
+750	decent half-sized mushroom quesadilla	2	good	
 751	tasty fancy cool mushroom	4	awesome	Effect: "Gr8ness", Effect Duration: 20
-752	low-calorie spoiled lime green cool mushroom casserole	1	crappy	
+752	spoiled low-calorie lime green cool mushroom casserole	1	crappy	
 753	decent small pointy mushroom	2	good	
 754	rotten cream of pointy mushroom soup	4	crappy	
 755	snack-sized yummy mushroom	2	awesome	
-756	half-sized bland spinning mushroom	2	decent	
+756	bland half-sized spinning mushroom	2	decent	
 757	flavorless pulsating mushroom	3	decent	
 758	stale fancy ghost cucumber	4	decent	Effect: "Chilblains of the Corn", Effect Duration: 40
 759	dill	0		
 760	narrow vinegar	0		
-761	squat cyan brine	0		
-762	weak perfectly mixed especially salty dog	2	EPIC	
+761	cyan squat brine	0		
+762	perfectly mixed weak especially salty dog	2	EPIC	
 763	ghostly pickling solution	0		
 764	stale spectral pickle	3	decent	
 765	briny vinegar	0		
@@ -767,7 +767,7 @@
 772	curative foon	0		HP Regen Min: 3, HP Regen Max: 5
 773	skewed Usain Bolt's careful basic meat spork	0		Monster Level: -10, Initiative: +80
 774	Sherlock's basic meat foon of the empath	0		Familiar Weight: +5, Item Drop: +25
-775	twirling maroon Yeti Protest Sign	0		
+775	maroon twirling Yeti Protest Sign	0		
 776	jittery Oprah's kneecapping stick	0		Maximum MP Percent: +50
 777	MacGyver's iron pasta spoon	0		Maximum MP: +100
 778	careful support cummerbund	0		Monster Level: -10
@@ -778,15 +778,15 @@
 783	'Villa' document	0		
 784	perfectly mixed Acqua Del Piatto Merlot	4	EPIC	Last Available: "2004-10"
 785	upside-down raffle ticket	0		
-786	adequate half-sized strawberry	2	good	
+786	half-sized adequate strawberry	2	good	
 787	hand-crafted weak bottle of rum	2	EPIC	
 788	lousy strawberry daiquiri	4	decent	
-789	hand-crafted distilled rum and cola	5	EPIC	
+789	distilled hand-crafted rum and cola	5	EPIC	
 790	fortified bad grog	5	decent	
 791	pulsating sinister Mafia bow tie of the scaredy-cat	0		Spell Damage: +10, Monster Level: -15, Last Available: "2004-10"
 792	jittery Golden Mr. Accessory of vim and vigor	0		Maximum HP Percent: +50, Softcore Only
 793	dry skewed oil of stability	0		Effect: "Flexibili Tea", Effect Duration: 11
-794	irradiated huge skewed oil of slipperiness	0		Effect: "The Moxie of LOV", Effect Duration: 32
+794	irradiated skewed huge oil of slipperiness	0		Effect: "The Moxie of LOV", Effect Duration: 32
 795	watered-down tolerable Acque Luride Grezze Cabernet	2	good	Last Available: "2004-10"
 796	prompt Sinatra's cement shoes of the sewer	0		Experience (Moxie): +5, Stench Damage: +25, Adventures: +3, Last Available: "2004-10"
 797	fancy mediocre upside-down rockin' wagon	3	decent	Effect: "Ocelot Eyes", Effect Duration: 30
@@ -794,18 +794,18 @@
 799	boozy smooth fuzzbump	5	awesome	
 800	bland poutine	3	decent	
 801	thick enchanted flavorless purple Knob stir-fry	5	decent	Effect: "Memory of Strength", Effect Duration: 40
-804	fancy bite-sized flavorless Knoll stir-fry	1	decent	Effect: "Haunted Liver", Effect Duration: 45
+804	flavorless fancy bite-sized Knoll stir-fry	1	decent	Effect: "Haunted Liver", Effect Duration: 45
 805	decent blurry stir-fry	4	good	
 806	bland asparagus stir-fry	3	decent	
 807	tiny yummy olive stir-fry	1	awesome	
-808	decent snack-sized Knob sausage stir-fry	2	good	
-809	spoiled special skewed bat wing stir-fry	4	crappy	Effect: "Danish Cunning", Effect Duration: 35
-810	flavorless fancy wobbly rat appendix stir-fry	4	decent	Effect: "Cinnamouth", Effect Duration: 5
+808	snack-sized decent Knob sausage stir-fry	2	good	
+809	special spoiled skewed bat wing stir-fry	4	crappy	Effect: "Danish Cunning", Effect Duration: 35
+810	fancy flavorless wobbly rat appendix stir-fry	4	decent	Effect: "Cinnamouth", Effect Duration: 5
 811	thick flavorless narrow tofu stir-fry	5	decent	
 812	normal yellow pr0n stir-fry	3	good	
 813	miniature decent Knob shells	2	good	
 814	gigantic flavorless b&auml;tzle	7	decent	
-815	low-calorie stale ratini	1	decent	
+815	stale low-calorie ratini	1	decent	
 816	rotten Knob stroganoff	3	crappy	
 817	bland skewed menudo ravioli	4	decent	
 818	squat plus sign	0		
@@ -820,20 +820,20 @@
 827	squat murky potion	0		
 828	green baby killer bee	0		
 829	blinking jittery anti-anti-antidote	0		
-830	bite-sized rotten blinking royal jelly	1	crappy	
+830	rotten bite-sized blinking royal jelly	1	crappy	
 831	purple small box	0		
 832	box	0		
 833	cool vorpal blade	0		Moxie: +5
 834	bouncing dog trainer's cornuthaum of the businessman	0		Experience (familiar): +1, Meat Drop: +50, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	dog trainer's ring of aggravate monster	0		Experience (familiar): +1
-836	bland huge mirror wobbly mind flayer corpse	6	decent	
+836	huge bland mirror wobbly mind flayer corpse	6	decent	
 837	fortified perfectly mixed purple Uovo Marcio Shiraz	5	EPIC	Last Available: "2004-10"
 838	supercharged thinker's Mafia stogie	0		Mysticality: +10, Maximum MP Percent: +30, Last Available: "2004-10"
 839	bad weak Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
 840	friendly manspreader's Mafia violin case	0		Monster Level: +10, Familiar Weight: +3, Last Available: "2004-10"
 841	watered-down tolerable tomato daiquiri	2	good	
-842	aged watered-down wobbly beertini	2	awesome	
-843	weak smooth salty slug	2	awesome	
+842	watered-down aged wobbly beertini	2	awesome	
+843	smooth weak salty slug	2	awesome	
 844	hand-crafted blurry papaya slung	3	EPIC	
 845	Tesla MAHI fez	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -856,7 +856,7 @@
 864	stinger	0		Familiar Weight: +5
 865	jittery lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
-867	triple-modified warmed diffused cyan tumbling pine tar	0		Effect: "Orc Chops", Effect Duration: 22
+867	triple-modified warmed diffused tumbling cyan pine tar	0		Effect: "Orc Chops", Effect Duration: 22
 869	forest tears	0		
 870	skewed MacGyver's fetus-smashing club	0		Maximum MP: +100
 871	spinning meatcar model	0		Familiar Weight: +5
@@ -878,7 +878,7 @@
 887	leaf	0		
 888	tumbling maple leaf	0		
 889	balaclava of the brute	0		Muscle Percent: +30, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	flavorless big balaclava baklava	5	decent	
+890	big flavorless balaclava baklava	5	decent	
 891	Van der Graaf Warehouse 23 bling	0		MP Regen Min: 5, MP Regen Max: 7
 892	tumbling Usain Bolt's horrifying foul-smelling bugbear-smiting sword	0		Stench Damage: +10, Spooky Damage: +25, Initiative: +80
 893	delicious spinning lumbering jack	3	awesome	
@@ -892,7 +892,7 @@
 901	upside-down espresso maker	0		Familiar Weight: +5
 902	pulsating 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	mediocre watered-down tumbling Spasmi Dolorosi Del Rene Champagne	2	decent	Last Available: "2004-10"
-904	veiny occult school Mafia knickerbockers of the businessman	0		Spell Damage Percent: +25, Maximum HP: +10, Meat Drop: +50, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	veiny occult school Mafia knickerbockers of the businessman	0		Spell Damage Percent: +25, Maximum HP: +10, Meat Drop: +50, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	aerosolized Yummy Tummy bean	0		Effect: "Waxing", Effect Duration: 38
 906	adjusted alkaline Rock Pops	0		Effect: "Mighty Shout", Effect Duration: 21
 907	ionized nitrogenated bouncing Mr. Mediocrebar	0		Effect: "Creepin' Up on You", Effect Duration: 13
@@ -906,21 +906,21 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	tumbling gray intergalactic pom poms of the empath of incineration	0		Familiar Weight: +5, Hot Spell Damage: +50
 917	squat Mob Penguin protection contract	0		
-918	yellow slick Radio Free Baseball Cap	0		Moxie: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	teal bouncing toasty Radio Free Pants	0		Hot Damage: +5, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	yellow slick Radio Free Baseball Cap	0		Moxie: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	teal bouncing toasty Radio Free Pants	0		Hot Damage: +5, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	Sherlock's Radio Free Foil	0		Item Drop: +25, Last Available: "2006-07"
 921	decent radio button candy	4	good	
 922	zippy severed rocking horse head	0		Initiative: +20
 923	shaking broken cellular phone	0		Last Available: "2004-01"
 924	upside-down crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
-926	concentrated warmed jittery tumbling Hawking's Elixir of Brilliance	0		Effect: "Down With Chow", Effect Duration: 38
-927	mediocre blinking huge Ferita Del Petto Zinfandel	3	decent	Last Available: "2006-12"
+926	concentrated warmed tumbling jittery Hawking's Elixir of Brilliance	0		Effect: "Down With Chow", Effect Duration: 38
+927	mediocre huge blinking Ferita Del Petto Zinfandel	3	decent	Last Available: "2006-12"
 928	nasty fuzzy bracelets	0		Stench Damage: +5
 929	brawny arse-shooting crossbow	0		Muscle Percent: +20
 931	mediocre practically non-alcoholic spiced rum	1	decent	
 932	tolerable eggnog	4	good	
-933	tasty snack-sized candy cane	2	awesome	
+933	snack-sized tasty candy cane	2	awesome	
 934	decent twirling gingerbread bugbear	3	good	
 935	beefcake's imitation nice watch	0		Muscle: +25, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	wobbly bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	occult bowler	0		Spell Damage Percent: +25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	occult bowler	0		Spell Damage Percent: +25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	shaking padded sage bow staff	0		Mysticality Percent: +10, Damage Absorption: +20, Last Available: "2004-12"
-944	squat beefcake's bowlegged pants	0		Muscle: +25, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	squat beefcake's bowlegged pants	0		Muscle: +25, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	shaking skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -943,7 +943,7 @@
 953	shaking penguin-smacking club	0		Familiar Damage: +15
 954	blinking orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	fez of etymology of the wise owl	0		Mysticality: +20, Familiar Effect: "1xLep, cap 30"
-956	immense tasty red carob chunk noodles	8	awesome	
+956	tasty immense red carob chunk noodles	8	awesome	
 957	rotten super-sized skewed chorizo brownies	5	crappy	
 958	bland bouncing chocolate and tomato pizza	3	decent	
 959	flange	0		
@@ -989,20 +989,20 @@
 1002	sinister Xlyinia's notebook	0		Spell Damage: +10
 1003	soda water	0		
 1004	artisanal triple-distilled bottle of tequila	10	EPIC	
-1005	distilled tolerable boxed wine	5	good	
+1005	tolerable distilled boxed wine	5	good	
 1006	tasty spinning cherry	3	awesome	
 1007	fireproof coconut shell	0		Hot Resistance: +3, Familiar Effect: "1xFairy, cap 7"
 1008	green razor-sharp ice cubes	0		Weapon Damage Percent: +25
-1009	artisanal practically non-alcoholic purple vodka martini	1	EPIC	
+1009	practically non-alcoholic artisanal purple vodka martini	1	EPIC	
 1010	acceptable narrow whiskey and soda	3	good	
 1011	acceptable boozy spinning monkey wrench	5	good	
-1012	special watered-down tolerable skewed tequila sunrise	2	good	Effect: "Impregnably Delicious", Effect Duration: 40
+1012	watered-down tolerable special skewed tequila sunrise	2	good	Effect: "Impregnably Delicious", Effect Duration: 40
 1013	irresponsibly strong lousy enchanted margarita	9	decent	Effect: "On a Roll", Effect Duration: 10
-1014	weak special perfectly mixed strawberry wine	2	EPIC	Effect: "Spooky Flavor", Effect Duration: 40
-1015	strong perfectly mixed olive wine spritzer	5	EPIC	
+1014	weak perfectly mixed special strawberry wine	2	EPIC	Effect: "Spooky Flavor", Effect Duration: 40
+1015	perfectly mixed strong olive wine spritzer	5	EPIC	
 1016	tolerable blue perpendicular hula	3	good	
 1017	acceptable ducha de oro	3	good	
-1018	distilled acceptable calle de miel	5	good	
+1018	acceptable distilled calle de miel	5	good	
 1019	aged fuchsia blurry jittery dry vodka martini	3	awesome	
 1020	mediocre old-fashioned	3	decent	
 1021	mediocre watered-down tequila with training wheels	2	decent	
@@ -1029,11 +1029,11 @@
 1043	mirror string of beads of vim and vigor	0		Maximum HP Percent: +50
 1044	string of beads of James Dean	0		Experience (Moxie): +3
 1045	ribald plastic bottle opener	0		Sleaze Damage: +10
-1046	spinning electrified wicked traffic cone	0		Spell Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	drinkable weak spinning N. O. Beer	2	good	
+1046	spinning electrified wicked traffic cone	0		Spell Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2005-03", Familiar Effect: "cap 15"
+1047	weak drinkable spinning N. O. Beer	2	good	
 1048	mixed cyan shaking oyster egg	1		Effect: "Insulated Trousers", Effect Duration: 45
 1049	distilled oyster egg	1		
-1050	modified wobbly bouncing oyster egg	1		Effect: "Powdered", Effect Duration: 40
+1050	modified bouncing wobbly oyster egg	1		Effect: "Powdered", Effect Duration: 40
 1051	plastic oyster egg	0		
 1052	dried oyster egg	1		
 1053	altered oyster egg	1		
@@ -1055,16 +1055,16 @@
 1069	mixed lime green ghostly oyster egg	1		
 1070	twisted oyster egg	1		Effect: "Hot Hands", Effect Duration: 20
 1071	lime green plastic oyster egg	0		
-1072	altered yellow mirror mirror off-white oyster egg	1		
+1072	altered mirror yellow mirror off-white oyster egg	1		
 1073	diluted teal twirling off-white oyster egg	1		
-1074	vaporized tumbling upside-down red off-white oyster egg	1		
+1074	vaporized red tumbling upside-down off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	vaporized oyster egg	1		
 1077	distilled wobbly bouncing spinning oyster egg	1		Effect: "Trivia Master", Effect Duration: 50
 1078	dried oyster egg	1		
 1079	upside-down plastic oyster egg	0		
 1080	spinning oyster basket	0		
-1081	spinning pulsating emo roe	0		Free Pull, Last Available: "2005-04"
+1081	pulsating spinning emo roe	0		Free Pull, Last Available: "2005-04"
 1082	red gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -1101,7 +1101,7 @@
 1115	tasket	0		
 1116	annoying pitchfork	0		Monster Level: +5
 1117	family-friendly vibrating Stupid University Diploma of the wise owl	0		Mysticality: +20, Maximum MP Percent: +10, Sleaze Resistance: +1
-1118	yellow jittery pregnant mushroom	0		
+1118	jittery yellow pregnant mushroom	0		
 1119	pregnant mushroom	0		
 1120	mirror pregnant mushroom	0		
 1121	shaking ghostly inexplicably rock	0		
@@ -1133,7 +1133,7 @@
 1147	mediocre fancy mushroom wine	4	decent	Effect: "Pyromania", Effect Duration: 20
 1148	drinkable narrow green shot of flower schnapps	3	good	
 1149	stale fancy flower petal pie	3	decent	Effect: "Permanent Halloween", Effect Duration: 20
-1150	strong bad bottle of single-barrel whiskey	5	decent	
+1150	bad strong bottle of single-barrel whiskey	5	decent	
 1151	teal mirror rosewater-soaked discarded plastic fork of the sewer	0		Stench Damage: +25, Stench Resistance: +3
 1152	bouncing gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	enchanted spoiled Retenez L'Herbe Pat&eacute;	4	crappy	Effect: "Tea-hee", Effect Duration: 10
@@ -1157,7 +1157,7 @@
 1172	blue asbestos box	0		
 1173	linoleum box	0		
 1174	jittery chrome box	0		
-1175	narrow spinning cryptic puzzle box	0		
+1175	spinning narrow cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	ghostly magnetic field	0		
 1178	potted cactus	0		
@@ -1182,16 +1182,16 @@
 1197	Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
-1200	stale small mugcake	2	decent	
+1200	small stale mugcake	2	decent	
 1201	flavorless urinal cake	4	decent	
 1202	stale Happy Birthday, Claude! cake	4	decent	
 1203	moldy personalized birthday cake	4	crappy	
 1204	normal gray three-tiered wedding cake	3	good	
-1205	adequate thick babycakes	5	good	
+1205	thick adequate babycakes	5	good	
 1206	decent velvet cake	4	good	
 1207	small moldy maroon congratulatory cake	2	crappy	
 1208	decent angel-food cake	3	good	
-1209	spoiled tiny devil's-food cake	1	crappy	
+1209	tiny spoiled devil's-food cake	1	crappy	
 1210	flavorless birthday party jellybean cheesecake	3	decent	
 1211	balloon	0		
 1212	balloon	0		
@@ -1237,12 +1237,12 @@
 1253	pulsating pile of jumping beans	0		
 1254	fancy spoiled red jumping bean burrito	3	crappy	Effect: "Human-Horror Hybrid", Effect Duration: 10
 1255	adequate jumping bean burrito	4	good	
-1256	bite-sized enchanted decent insanely jumping bean burrito	1	good	Effect: "Liquid Courage", Effect Duration: 25
-1257	decent bite-sized rat scrapple	1	good	
+1256	enchanted decent bite-sized insanely jumping bean burrito	1	good	Effect: "Liquid Courage", Effect Duration: 25
+1257	bite-sized decent rat scrapple	1	good	
 1258	pail of pretentious paint	0		
-1259	asbestos-lined dangerous traffic cone	0		Weapon Damage: +10, Hot Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	asbestos-lined dangerous traffic cone	0		Weapon Damage: +10, Hot Resistance: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	blurry wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	powdered blinking gray Hatorade	1		
+1261	powdered gray blinking Hatorade	1		
 1262	blinking razor-sharp beefcake's off-hand balloon	0		Muscle: +25, Weapon Damage Percent: +25, Item Drop: +5
 1263	red pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
@@ -1287,7 +1287,7 @@
 1303	gray Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	wobbly makeup kit	0		Familiar Weight: +15
-1306	knitted scorching traffic cone	0		Hot Damage: +25, Cold Resistance: +3, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	knitted scorching traffic cone	0		Hot Damage: +25, Cold Resistance: +3, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	shaking calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	spinning unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	ghostly blood flower	0		
 1318	blurry lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	bland low-calorie questionable taco	1	decent	
+1320	low-calorie bland questionable taco	1	decent	
 1321	jittery Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	mirror petrified time	0		Last Available: "2005-10"
-1323	time helmet of the sewer	0		Stench Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	huge gravedigger's time trousers	0		Spooky Damage: +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	time helmet of the sewer	0		Stench Damage: +25, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	huge gravedigger's time trousers	0		Spooky Damage: +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	horrifying time sword	0		Spooky Damage: +25, Last Available: "2005-10"
 1326	strapping Dyspepsi-Cola helmet	0		Muscle: +5, Familiar Effect: "3xFairy, cap 7"
 1327	Cloaca-Cola shield of Gandalf	0		Spell Critical Percent: +20, Damage Reduction: 4
@@ -1324,7 +1324,7 @@
 1341	skewed Dyspepsi-Cola-issue canteen of dire peril	0		Weapon Damage: +20, Single Equip
 1342	picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
-1344	enhanced blue jittery Gummi-Gnauga	0		Effect: "Block-Rockin' Beet", Effect Duration: 61
+1344	enhanced jittery blue Gummi-Gnauga	0		Effect: "Block-Rockin' Beet", Effect Duration: 61
 1345	boiled Now and Earlier	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 13, Last Available: "2020-09"
 1346	quantum denatured non-frozen Sugar Cog	0		Effect: "[800]Chocolate Reign", Effect Duration: 24
 1347	loaded serum blowgun	0		Last Available: "2005-11"
@@ -1332,24 +1332,24 @@
 1349	spinning olive miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	blurry 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	wizardly pinky ring	0		Mysticality: +25, Single Equip
-1352	triple-distilled perfectly mixed pulsating redrum	9	EPIC	
+1352	perfectly mixed triple-distilled pulsating redrum	9	EPIC	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	rotten super-sized tumbling bowl of oriole's nest soup	5	crappy	
 1356	fuchsia bunny liver	0		
-1357	smooth practically non-alcoholic special Mt. Noob Pale Ale	1	awesome	Effect: "Strong Grip", Effect Duration: 50
+1357	special practically non-alcoholic smooth Mt. Noob Pale Ale	1	awesome	Effect: "Strong Grip", Effect Duration: 50
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	skewed ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	dangerous disembodied smile	0		Weapon Damage: +10, Single Equip
 1362	sausage	0		
 1363	red clockwork pirate skull	0		
-1364	blue pulsating rhesus monkey	0		Familiar Weight: +5
+1364	pulsating blue rhesus monkey	0		Familiar Weight: +5
 1365	gigantic spoiled tofurkey leg	7	crappy	
-1366	tasty low-calorie tofurkey gravy	1	awesome	
+1366	low-calorie tasty tofurkey gravy	1	awesome	
 1367	stale herbal stuffing	3	decent	
 1368	normal can-shaped gelatinous cranberry sauce	3	good	
-1369	special stale diet yams	1	decent	Effect: "The Wisdom... of the Future", Effect Duration: 30
+1369	special diet stale yams	1	decent	Effect: "The Wisdom... of the Future", Effect Duration: 30
 1370	twirling rhinestone cowboy shirt of Calamity Jane	0		Critical Hit Percent: +15
 1371	scorching gingham blouse	0		Hot Damage: +25
 1372	ghostly scandalous souvenir ski t-shirt	0		Sleaze Damage: +5
@@ -1384,28 +1384,28 @@
 1402	up-at-dawn rag doll	0		Adventures: +5, Last Available: "2005-12"
 1403	manspreader's can of fake snow	0		Monster Level: +10, Last Available: "2005-12"
 1404	shellacked colored-light &quot;necklace&quot;	0		Damage Reduction: 7, Last Available: "2005-12"
-1405	tree skirt of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	tree skirt of the scaredy-cat	0		Monster Level: -15, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	rotten blinking wreath-shaped Crimbo cookie	4	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	half-sized tasty bell-shaped Crimbo cookie	2	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	tasty half-sized bell-shaped Crimbo cookie	2	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	adequate tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	inspector's Unionize The Elves sign	0		Item Drop: +15, Last Available: "2005-12"
 1410	bouncing sleeping snowy owl	0		Last Available: "2005-12"
-1411	blurry wobbly Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	wobbly blurry Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	colloidal extra-improved squat snowcone	0		Effect: "Bubblin' Rage", Effect Duration: 16, Last Available: "2006-01"
 1413	energized improved twirling squat snowcone	0		Effect: "Super-Charged", Effect Duration: 63, Last Available: "2006-01"
-1414	Vulcanized squat blinking snowcone	0		Effect: "Muddled", Effect Duration: 55, Last Available: "2006-01"
+1414	Vulcanized blinking squat snowcone	0		Effect: "Muddled", Effect Duration: 55, Last Available: "2006-01"
 1415	irradiated jittery snowcone	0		Effect: "Blubbered Up", Effect Duration: 56, Last Available: "2006-01"
 1416	deionized dry snowcone	0		Effect: "Sewer-Drenched", Effect Duration: 38, Last Available: "2006-01"
 1417	liquefied nitrogenated snowcone	0		Effect: "Devil Inside", Effect Duration: 11, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	blurry teddy bear sewing kit	0		Last Available: "2006-01"
-1420	aromatic toasty traffic cone	0		Hot Damage: +5, Stench Resistance: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	aromatic toasty traffic cone	0		Hot Damage: +5, Stench Resistance: +1, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	lime green Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	skewed Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	prompt lion tamer's ice sickle	0		Experience (familiar): +2, Adventures: +3, Softcore Only, Last Available: "2006-02"
 1425	weightlifter's ice baby	0		Muscle: +15, Softcore Only, Last Available: "2006-02"
-1426	narrow ice pick of incineration	0		Hot Spell Damage: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	narrow ice pick of incineration	0		Hot Spell Damage: +50, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	flame-wreathed ice skates of chilblains	0		Cold Damage: +25, Hot Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	huge moldy grue egg omelette	7	crappy	
 1429	spinning spinning roll of drink tickets	0		
@@ -1474,8 +1474,8 @@
 1492	stiffened ninja mop	0		Damage Reduction: 1
 1493	ridiculously overelaborate ninja weapon of the boozehound of the early riser	0		Booze Drop: +100, Adventures: +7
 1494	non-quantum non-unsweetened twirling sugar-coated pine cone	0		Effect: "Joyful Resolve", Effect Duration: 36, Last Available: "2020-09"
-1495	wool nasty traffic cone	0		Stench Damage: +5, Cold Resistance: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	watered-down hand-crafted jittery gloomy mushroom wine	2	super EPIC	
+1495	wool nasty traffic cone	0		Stench Damage: +5, Cold Resistance: +1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1496	hand-crafted watered-down jittery gloomy mushroom wine	2	super EPIC	
 1497	smooth bouncing mushroom wine	3	awesome	
 1498	squat McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1485,15 +1485,15 @@
 1503	fuchsia rubber emo roe	0		Last Available: "2006-04"
 1504	tarnished snowcone	0		Effect: "All Is Forgiven", Effect Duration: 30, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	irresponsibly strong lousy calle de miel with a fly in it	6	decent	Last Available: "2006-04"
+1506	lousy irresponsibly strong calle de miel with a fly in it	6	decent	Last Available: "2006-04"
 1507	lousy rockin' wagon with a fly in it	3	decent	Last Available: "2006-04"
 1508	practically non-alcoholic bad lime green perpendicular hula with a fly in it	1	decent	Last Available: "2006-04"
 1509	spirit-forward lousy slap and tickle with a fly in it	5	decent	Last Available: "2006-04"
-1510	squat fuchsia wobbly bag of airline peanuts	0		Last Available: "2006-04"
+1510	wobbly squat fuchsia bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of the dark arts	0		Spell Damage Percent: +100, Last Available: "2006-04"
 1512	boiled wobbly Knob Goblin pet-buffing spray	1		
 1513	powdered Knob Goblin learning pill	1		Effect: "Winning Smile", Effect Duration: 35
-1514	compressed squat gray Knob Goblin eyedrops	1		Effect: "Disco Neuropathy", Effect Duration: 35
+1514	compressed gray squat Knob Goblin eyedrops	1		Effect: "Disco Neuropathy", Effect Duration: 35
 1515	compressed Knob Goblin nasal spray	1		Effect: "Chock Full o' Nanites", Effect Duration: 20
 1516	KWE-brand transistor radio	0		
 1518	vampire heart	0		
@@ -1501,25 +1501,25 @@
 1520	executive curative Radio KoL Coffee Mug	0		Meat Drop: +40, HP Regen Min: 3, HP Regen Max: 5
 1521	Frank Gorshin trophy	0		
 1522	Temple Grandin's quilted Radio Free Jersey	0		Damage Absorption: +40, Familiar Weight: +7
-1523	tumbling spinning bottle of used blood	0		
+1523	spinning tumbling bottle of used blood	0		
 1524	skewed wind-up chattering teeth	0		Last Available: "2006-04"
 1525	jittery joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	skewed pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
-1527	skewed pulsating diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
+1526	skewed pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1527	pulsating skewed diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	dog trainer's corkscrew of horror	0		Experience (familiar): +1, Spooky Spell Damage: +25, Last Available: "2006-04"
 1529	twirling St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	mirror reassuring grass skirt	0		Spooky Resistance: +1, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	wobbly lard-coated grass hat	0		Sleaze Spell Damage: +25, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	mirror reassuring grass skirt	0		Spooky Resistance: +1, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	wobbly lard-coated grass hat	0		Sleaze Spell Damage: +25, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	personal trainer's grass blade	0		Experience Percent (Muscle): +10, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	squat sparkly engagement ring of the empath	0		Familiar Weight: +5, Single Equip
 1539	green Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	greedy Grimacite goggles of the pedagogue	0		Experience: +3, Meat Drop: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	greedy Grimacite goggles of the pedagogue	0		Experience: +3, Meat Drop: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	huge fireproof Grimacite glaive of the sweet-tooth	0		Hot Resistance: +3, Candy Drop: +100, Last Available: "2008-10"
-1542	Grimacite greaves of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	Grimacite greaves of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	greasy Grimacite garter of the dark arts	0		Spell Damage Percent: +100, Sleaze Spell Damage: +10, Last Available: "2008-10"
 1544	mirror perfumed Grimacite galoshes of courage	0		Spooky Resistance: +3, Stench Resistance: +5, Last Available: "2008-10"
 1545	Socratic beefcake's Grimacite gorget	0		Muscle: +25, Experience (Mysticality): +1, Last Available: "2008-10"
@@ -1528,72 +1528,72 @@
 1548	flame-retardant scorching Gazpacho's Glacial Grimoire	0		Hot Damage: +25, Hot Resistance: +1
 1549	squat MSG	0		
 1550	boxer's second-hand knockoff engagement ring	0		Muscle Percent: +10, Single Equip
-1551	acceptable weak bottle of Domesticated Turkey	2	good	
-1552	aged fortified bottle of Definit	5	awesome	
+1551	weak acceptable bottle of Domesticated Turkey	2	good	
+1552	fortified aged bottle of Definit	5	awesome	
 1553	tolerable bottle of Calcutta Emerald	4	good	
 1554	acceptable narrow bottle of Lieutenant Freeman	3	good	
-1555	lousy practically non-alcoholic bottle of Jorge Sinsonte	1	decent	
+1555	practically non-alcoholic lousy bottle of Jorge Sinsonte	1	decent	
 1556	delicious boxed champagne	3	awesome	
 1557	bland bouncing kumquat	3	decent	
 1558	yummy tangerine	3	awesome	
 1559	twirling tonic water	0		
 1560	stale cocktail onion	3	decent	
 1561	moldy half-sized raspberry	2	crappy	
-1562	toothsome miniature kiwi	2	awesome	
+1562	miniature toothsome kiwi	2	awesome	
 1563	lousy whiskey bittersweet	4	decent	
-1564	fancy lousy mimosette	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 35
-1565	practically non-alcoholic lousy enchanted tequila sunset	1	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 50
-1566	mediocre special zmobie	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Wiki Name: "Zmobie (drink)"
-1567	irresponsibly strong artisanal blinking gin and tonic	8	EPIC	
-1568	smooth special vodka and tonic	3	awesome	Effect: "Antarctic Memories", Effect Duration: 10
+1564	lousy fancy mimosette	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 35
+1565	lousy enchanted practically non-alcoholic tequila sunset	1	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 50
+1566	special mediocre zmobie	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Wiki Name: "Zmobie (drink)"
+1567	artisanal irresponsibly strong blinking gin and tonic	8	EPIC	
+1568	special smooth vodka and tonic	3	awesome	Effect: "Antarctic Memories", Effect Duration: 10
 1569	artisanal practically non-alcoholic vodka gibson	1	super EPIC	
 1570	acceptable gibson	3	good	
-1571	enchanted perfectly mixed mirror parisian cathouse	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 10
+1571	perfectly mixed enchanted mirror parisian cathouse	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 10
 1572	acceptable rabbit punch	4	good	
 1573	artisanal lime green wobbly jittery caipifruta	3	EPIC	
 1574	bad teqiwila	3	decent	
-1575	acceptable fortified spinning tumbling Divine	5	good	
-1576	acceptable watered-down Gordon Bennett	2	good	
+1575	fortified acceptable tumbling spinning Divine	5	good	
+1576	watered-down acceptable Gordon Bennett	2	good	
 1577	bad tangarita	4	decent	
-1578	artisanal special triple-distilled mandarina colada	6	EPIC	Effect: "Mana Tea", Effect Duration: 30
+1578	special triple-distilled artisanal mandarina colada	6	EPIC	Effect: "Mana Tea", Effect Duration: 30
 1579	practically non-alcoholic hand-crafted squat gimlet	1	super ultra mega turbo EPIC	
-1580	fortified perfectly mixed enchanted brick road	5	EPIC	Effect: "Heart of White", Effect Duration: 20
+1580	fortified enchanted perfectly mixed brick road	5	EPIC	Effect: "Heart of White", Effect Duration: 20
 1581	hand-crafted vodka stratocaster	3	EPIC	
 1582	drinkable Neuromancer	3	good	
-1583	watered-down aged prussian cathouse	2	awesome	
+1583	aged watered-down prussian cathouse	2	awesome	
 1584	strong artisanal Mae West	5	EPIC	
-1585	drinkable watered-down upside-down Mon Tiki	2	good	
-1586	perfectly mixed high-proof teqiwila slammer	7	EPIC	
-1587	jumbo spoiled Knob lo mein	5	crappy	
-1588	special flavorless asparagus lo mein	4	decent	Effect: "Discomfited", Effect Duration: 30
+1585	watered-down drinkable upside-down Mon Tiki	2	good	
+1586	high-proof perfectly mixed teqiwila slammer	7	EPIC	
+1587	spoiled jumbo Knob lo mein	5	crappy	
+1588	flavorless special asparagus lo mein	4	decent	Effect: "Discomfited", Effect Duration: 30
 1589	moldy Knoll lo mein	3	crappy	
 1590	adequate lo mein	4	good	
 1591	flavorless olive lo mein	4	decent	
-1592	tiny spoiled squat hot hi mein	1	crappy	
+1592	spoiled tiny squat hot hi mein	1	crappy	
 1593	moldy hi mein	3	crappy	
-1594	super-sized decent hi mein	5	good	
+1594	decent super-sized hi mein	5	good	
 1595	decent hi mein	3	good	
-1596	normal small special blurry pulsating sleazy hi mein	2	good	Effect: "Oh Snap", Effect Duration: 50
+1596	small normal special blurry pulsating sleazy hi mein	2	good	Effect: "Oh Snap", Effect Duration: 50
 1597	blue Rosewater's Junior LAAAAME merit badge	0		Mysticality Percent: +30, Last Available: "2006-05"
 1598	teal Senior LAAAAME merit badge of the sewer	0		Stench Damage: +25, Last Available: "2006-05"
 1599	huge jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	drinkable tumbling tangarita with a fly in it	3	good	
 1601	acceptable high-proof mandarina colada with a fly in it	6	good	
 1602	perfectly mixed prussian cathouse with a fly in it	4	EPIC	
-1603	artisanal practically non-alcoholic Mae West with a fly in it	1	EPIC	
+1603	practically non-alcoholic artisanal Mae West with a fly in it	1	EPIC	
 1604	powdered skewed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
-1606	vaporized narrow twirling huge ultimate wad	1		
+1606	vaporized twirling huge narrow ultimate wad	1		
 1607	dry shaking libation of liveliness	0		Effect: "The Halls of Moxiousness", Effect Duration: 63
 1608	liquefied non-anodized eyedrops of the ermine	0		Effect: "Berry Elemental", Effect Duration: 43
 1609	super-energized perfume of prejudice	0		Effect: "Egg on your Face", Effect Duration: 27
 1610	flattened moist blurry eyedrops of the ocelot	0		Effect: "Demonic Flavor", Effect Duration: 12
-1611	magnetized spinning bouncing squat potent potion of potency	0		Effect: "Extra-Thick Blood", Effect Duration: 61
+1611	magnetized squat bouncing spinning potent potion of potency	0		Effect: "Extra-Thick Blood", Effect Duration: 61
 1612	cold-filtered modified concentrated cordial of concentration	0		Effect: "Ooh, Bitter!", Effect Duration: 64
 1613	pulsating Sinatra's coffin lid	0		Experience (Moxie): +5, Damage Reduction: 3
 1614	grievous satin shield	0		Weapon Damage Percent: +50, Damage Reduction: 5
-1615	Cerebral Cloche of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	yellow prompt Cerebral Culottes	0		Adventures: +3, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	Cerebral Cloche of the brazier	0		Hot Spell Damage: +25, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	yellow prompt Cerebral Culottes	0		Adventures: +3, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	gray ruddy personal trainer's smartaleck's Cerebral Crossbow	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Maximum HP Percent: +40, Last Available: "2006-06"
 1618	wobbly ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1630,7 +1630,7 @@
 1650	wobbly narrow milk of magnesium	0		
 1651	big spoiled bouncing foie gras	5	crappy	
 1652	dry boiled jittery candy brain	0		Effect: "Texas Elegance", Effect Duration: 17, Last Available: "2020-09"
-1653	flame-wreathed banded Herculean jewel-eyed wizard hat	0		Experience (Muscle): +1, Damage Absorption: +100, Hot Spell Damage: +10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	flame-wreathed banded Herculean jewel-eyed wizard hat	0		Experience (Muscle): +1, Damage Absorption: +100, Hot Spell Damage: +10, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	rosy-cheeked wad of Crovacite of temperance	0		Maximum HP Percent: +30, Sleaze Resistance: +5
 1655	wobbly gravedigger's boxer's collar	0		Muscle Percent: +10, Spooky Damage: +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	skewed ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	twirling pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	twirling pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	spinning miser's beefcake's sword	0		Muscle: +25, Meat Drop: +10
 1680	huge sage staff of Calamity Jane	0		Mysticality Percent: +10, Critical Hit Percent: +15
 1681	Rosewater's bubblewrap sword of the wise owl	0		Mysticality: +20, Mysticality Percent: +30
@@ -1664,12 +1664,12 @@
 1684	boxer's beefcake's styrofoam sword	0		Muscle: +25, Muscle Percent: +10
 1685	tumbling maroon flame-wreathed scorching styrofoam staff	0		Hot Damage: +25, Hot Spell Damage: +10
 1686	extremely unsafe sage styrofoam crossbow	0		Mysticality Percent: +10, Weapon Damage Percent: +100
-1687	blinking purple Platinum Yendorian Express Card	0		
+1687	purple blinking Platinum Yendorian Express Card	0		
 1688	Oprah's personal trainer's crossbow	0		Experience Percent (Muscle): +10, Maximum MP Percent: +50
 1689	tumbling fireproof ribbon	0		Hot Resistance: +3, Last Available: "2006-07"
 1690	Usain Bolt's sizzling discarded bottlecap	0		Hot Damage: +10, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	wobbly reassuring discarded torn-up glove of the sewer	0		Stench Damage: +25, Spooky Resistance: +1, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	Vulcanized chilled huge jittery salamander slurry	0		Effect: "Shoesauce", Effect Duration: 57
+1692	Vulcanized chilled jittery huge salamander slurry	0		Effect: "Shoesauce", Effect Duration: 57
 1693	nitrogenated irradiated dry eyedrops of newt	0		Effect: "Material Witness", Effect Duration: 26
 1694	polarized gray Frogade	0		Effect: "So You Can Work More...", Effect Duration: 32
 1695	dry ionized pulsating papotion of papower	0		Effect: "Big Flaming Whip", Effect Duration: 64
@@ -1725,7 +1725,7 @@
 1746	flame-wreathed Lo Pan's grievous Super Magic Power Sword X	0		Weapon Damage Percent: +50, Spell Critical Percent: +30, Hot Spell Damage: +10
 1747	hardened sage soylent staff	0		Mysticality Percent: +10, Damage Reduction: 3
 1748	inspector's goulauncher of doom	0		Spooky Spell Damage: +50, Item Drop: +15
-1749	olive huge defective skull	0		Last Available: "2011-12"
+1749	huge olive defective skull	0		Last Available: "2011-12"
 1750	ghostly Da Vinci's Gnollish pie server	0		Experience (Mysticality): +5
 1751	sharpshooter's Gnollish slotted spoon	0		Critical Hit Percent: +10
 1752	manspreader's Knob Goblin spatula	0		Monster Level: +10
@@ -1750,10 +1750,10 @@
 1771	weightlifter's butcherknife	0		Muscle: +15
 1772	spinning executive corn holder	0		Meat Drop: +40
 1773	huge eggbeater of chilblains	0		Cold Damage: +25
-1774	aged watered-down bottle of popskull	2	awesome	
+1774	watered-down aged bottle of popskull	2	awesome	
 1775	wobbly spinning executive dishrag	0		Meat Drop: +40
-1776	normal snack-sized stale baguette	2	good	
-1777	purple blinking leftovers of indeterminate origin	0		
+1776	snack-sized normal stale baguette	2	good	
+1777	blinking purple leftovers of indeterminate origin	0		
 1778	stale wobbly dinner	3	decent	
 1779	katana of the dark arts	0		Spell Damage Percent: +100
 1780	quilted ram stick	0		Damage Absorption: +40
@@ -1768,12 +1768,12 @@
 1789	Mob Penguin	0		
 1790	drinkable Ram's Face Lager	3	good	
 1791	ram horns	0		
-1792	jittery double-paned friendly hale Travoltan trousers	0		Maximum HP: +20, Familiar Weight: +3, Cold Resistance: +5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	jittery double-paned friendly hale Travoltan trousers	0		Maximum HP: +20, Familiar Weight: +3, Cold Resistance: +5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	careful pool cue of the sewer	0		Monster Level: -10, Stench Damage: +25
 1794	colloidal anodized ghostly handful of hand chalk	0		Effect: "Mental A-cue-ity", Effect Duration: 67
 1795	Newton's Counterclockwise Watch	0		Experience (Mysticality): +3, Single Equip
 1796	bone collar	0		Familiar Weight: +5
-1797	bouncing gray misshapen animal skeleton	0		
+1797	gray bouncing misshapen animal skeleton	0		
 1798	pile of animal bones	0		
 1799	upside-down animal skull	0		
 1800	animal cranium	0		
@@ -1805,7 +1805,7 @@
 1826	sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
 1828	gray sacral vertebrae	0		
-1829	olive narrow first caudal vertebra	0		
+1829	narrow olive first caudal vertebra	0		
 1830	mirror upside-down second caudal vertebra	0		
 1831	third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
@@ -1815,7 +1815,7 @@
 1836	eighth caudal vertebra	0		
 1837	ghostly ninth caudal vertebra	0		
 1838	ghostly tenth caudal vertebra	0		
-1839	upside-down wobbly left first rib	0		
+1839	wobbly upside-down left first rib	0		
 1840	left second rib	0		
 1841	left third rib	0		
 1842	left fourth rib	0		
@@ -1830,7 +1830,7 @@
 1851	right first rib	0		
 1852	right second rib	0		
 1853	upside-down right third rib	0		
-1854	blinking fuchsia right fourth rib	0		
+1854	fuchsia blinking right fourth rib	0		
 1855	right fifth rib	0		
 1856	right sixth rib	0		
 1857	right seventh rib	0		
@@ -1846,7 +1846,7 @@
 1867	right clavicle	0		
 1868	left humerus	0		
 1869	pulsating right humerus	0		
-1870	blinking blurry left radius	0		
+1870	blurry blinking left radius	0		
 1871	olive right radius	0		
 1872	squat left ulna	0		
 1873	right ulna	0		
@@ -1864,7 +1864,7 @@
 1885	narrow left fourth front claw	0		
 1886	right first front claw	0		
 1887	right second front claw	0		
-1888	ghostly shaking right third front claw	0		
+1888	shaking ghostly right third front claw	0		
 1889	twirling twirling right fourth front claw	0		
 1890	left thumb	0		
 1891	right thumb	0		
@@ -1925,8 +1925,8 @@
 1948	pulsating fireproof tap shoes of courage	0		Hot Resistance: +3, Spooky Resistance: +3, Single Equip
 1949	adequate Manetwich	3	good	
 1950	bottle of Vangoghbitussin	0		
-1951	bad special bottle of Pinot Renoir	4	decent	Effect: "Hobonic", Effect Duration: 25
-1952	rotten big desiccated apricot	5	crappy	
+1951	special bad bottle of Pinot Renoir	4	decent	Effect: "Hobonic", Effect Duration: 25
+1952	big rotten desiccated apricot	5	crappy	
 1953	drinkable skewed flute of flat champagne	3	good	
 1954	big normal pulsating dehydrated caviar	5	good	
 1955	shaking styrofoam peanuts	0		
@@ -1970,7 +1970,7 @@
 1993	rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	blue heart necklace	0		Free Pull
-1996	lime green tumbling pulsating right half of a heart necklace	0		
+1996	tumbling lime green pulsating right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	olive pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
@@ -1994,10 +1994,10 @@
 2017	mirror spade necklace	0		
 2018	tumbling club necklace	0		
 2019	cream pie	0		Free Pull
-2020	big rotten spinning cherry pie	5	crappy	
+2020	rotten big spinning cherry pie	5	crappy	
 2021	big stale strawberry pie	5	decent	
 2022	yummy green lemon meringue pie	3	awesome	
-2023	ghostly cyan Genalen&trade; Bottle	1	decent	
+2023	cyan ghostly Genalen&trade; Bottle	1	decent	
 2024	normal mixed wildflower greens	3	good	
 2025	flavorless enchanted handful of walnuts	3	decent	Effect: "Yeah, It's Just Gasoline", Effect Duration: 20
 2026	toothsome squat nutty organic salad	3	awesome	
@@ -2011,11 +2011,11 @@
 2034	shaking avaricious wicker shield	0		Meat Drop: +30, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
 2036	oxidized squat radium-flavored potato chips	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 39
-2037	flattened squat blurry wintergreen-flavored potato chips	0		Effect: "Eyes of the Dragon", Effect Duration: 49
+2037	flattened blurry squat wintergreen-flavored potato chips	0		Effect: "Eyes of the Dragon", Effect Duration: 49
 2038	non-corrupted magnetized ennui-flavored potato chips	0		Effect: "Hood Ridin'", Effect Duration: 31
 2039	mirror x-ray specs	0		Last Available: "2011-12"
-2040	skewed fuchsia patchouli oil bomb	0		
-2041	tumbling pulsating ferret bait	0		
+2040	fuchsia skewed patchouli oil bomb	0		
+2041	pulsating tumbling ferret bait	0		
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
@@ -2067,7 +2067,7 @@
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	hors d'oeuvre tray of the blizzard	0		Cold Spell Damage: +25, Damage Reduction: 5
-2094	small rotten huge ballroom blintz	2	crappy	
+2094	rotten small huge ballroom blintz	2	crappy	
 2095	shaking towel	0		
 2096	dehydrated guy made of bee pollen	1		Effect: "Corruption of Wretched Wally", Effect Duration: 20
 2097	tumbling horrifying 17-ball	0		Spooky Damage: +25
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	sharpshooter's prehistoric spear	0		Critical Hit Percent: +10, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	censurious mansplainer's fire	0		Monster Level: +15, Sleaze Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	censurious mansplainer's fire	0		Monster Level: +15, Sleaze Resistance: +3, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	manspreader's Grateful Undead T-shirt	0		Monster Level: +10
@@ -2121,9 +2121,9 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	bouncing evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	diet rotten shaking frank	1	crappy	Last Available: "2011-12"
+2149	rotten diet shaking frank	1	crappy	Last Available: "2011-12"
 2150	big yummy mirror plate of franks and beans	5	awesome	Last Available: "2011-12"
-2151	weak mediocre shot of blackberry schnapps	2	decent	
+2151	mediocre weak shot of blackberry schnapps	2	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	jittery ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	bouncing hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	veiny beefcake's toy ray gun	0		Muscle: +25, Maximum HP: +10, Last Available: "2006-12"
-2169	hardy baleful toy space helmet	0		Spell Damage: +25, Maximum HP: +50, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	hardy baleful toy space helmet	0		Spell Damage: +25, Maximum HP: +50, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	narrow MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	Sherlock's astronaut pants of the bloodbag	0		Maximum HP: +100, Item Drop: +25, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	Sherlock's astronaut pants of the bloodbag	0		Maximum HP: +100, Item Drop: +25, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	toy jet pack of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2151,7 +2151,7 @@
 2176	ghostly cracked stone sphere	0		
 2177	skewed rough stone sphere	0		
 2178	gray coward's obsidian dagger	0		Monster Level: -20
-2179	skewed spinning blinking archaeologist's notebook	0		
+2179	spinning blinking skewed archaeologist's notebook	0		
 2180	amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
@@ -2170,7 +2170,7 @@
 2195	stale unspeakable fruitcake	3	decent	Last Available: "2006-12"
 2196	flavorless gingerbread horror	3	decent	Last Available: "2006-12"
 2197	electrified but probably evil chocolate	0		Effect: "Ripping, Dripping", Effect Duration: 45, Last Available: "2006-12"
-2198	bite-sized decent bat-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	decent bite-sized bat-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	delicious twirling skull-shaped Crimboween cookie	4	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	huge bland tombstone-shaped Crimboween cookie	9	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	brainy plastic gift-wrapping vampire	0		Mysticality: +5, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	Tesla Crimbo tiki necklace	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2006-12"
 2208	Annie Oakley's bobble-hip hula elf doll of Calamity Jane	0		Critical Hit Percent: 35, Last Available: "2006-12"
 2209	educational Crimbo ukulele	0		Experience: +1, Last Available: "2006-12"
-2210	razor-sharp Tiki lighter of the dark arts	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	Lo Pan's stiffened deck of tropical cards	0		Damage Reduction: 1, Spell Critical Percent: +30, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	pulsating manspreader's tropical paperweight of the dark arts	0		Spell Damage Percent: +100, Monster Level: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	razor-sharp Tiki lighter of the dark arts	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	Lo Pan's stiffened deck of tropical cards	0		Damage Reduction: 1, Spell Critical Percent: +30, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	pulsating manspreader's tropical paperweight of the dark arts	0		Spell Damage Percent: +100, Monster Level: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	blinking tropical wrapping paper	0		Last Available: "2006-12"
-2215	extremely unsafe Tropical Crimbo Hat	0		Weapon Damage Percent: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	mirror resourceful Tropical Crimbo Shorts	0		Maximum MP: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	extremely unsafe Tropical Crimbo Hat	0		Weapon Damage Percent: +100, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	mirror resourceful Tropical Crimbo Shorts	0		Maximum MP: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	bland super ka-bob	3	decent	
-2218	rotten big beer basted brat	5	crappy	
+2218	big rotten beer basted brat	5	crappy	
 2219	vibrating Tropical Crimbo Sword	0		Maximum MP Percent: +10, Last Available: "2006-12"
 2220	colloidal polarized concentrated upside-down and Crimboween candy	0		Effect: "Whippin' It Good", Effect Duration: 54, Last Available: "2020-09"
-2221	ghostly lime green Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	reassuring sage liar's pants	0		Mysticality Percent: +10, Spooky Resistance: +1, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2221	lime green ghostly Great Ball of Frozen Fire	0		Last Available: "2007-01"
+2222	reassuring sage liar's pants	0		Mysticality Percent: +10, Spooky Resistance: +1, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	baleful juggler's balls of the scaredy-cat	0		Spell Damage: +25, Monster Level: -15, Softcore Only, Last Available: "2007-01"
 2224	spinning yellow narrow wholesome pink shirt	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2007-01"
 2225	bouncing familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2208,7 +2208,7 @@
 2233	perfumed bow tie	0		Stench Resistance: +5, Clowniness: 75
 2234	mansplainer's calavera concertina	0		Monster Level: +15, Song Duration: 7
 2235	beefcake's ratarang of the pedagogue	0		Muscle: +25, Experience: +3
-2236	pressed teal wobbly turtle pheromones	0		Effect: "Magically Fingered", Effect Duration: 65
+2236	pressed wobbly teal turtle pheromones	0		Effect: "Magically Fingered", Effect Duration: 65
 2237	pygmy blowgun	0		
 2238	lightning-fast pygmy nose-bone	0		Initiative: +40, Single Equip
 2239	hardy bad voodoo mask of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
@@ -2231,27 +2231,27 @@
 2257	flame-retardant reinforced furry underpants of the businessman	0		Hot Resistance: +1, Meat Drop: +50
 2258	&quot;I Love Me, Vol. I&quot;	0		
 2259	purple photograph of God	0		
-2260	squat yellow hard rock candy	0		
+2260	yellow squat hard rock candy	0		
 2261	twirling hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	teal lion oil	0		
 2264	stale stunt nuts	3	decent	
-2265	tiny bland wet stew	1	decent	
+2265	bland tiny wet stew	1	decent	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	lard-coated Staff of Fats	0		Sleaze Spell Damage: +25
 2269	flavorless sausage wonton	3	decent	
 2270	bouncing stiffened fortified belt	0		Damage Absorption: +60, Damage Reduction: 1, Single Equip
 2271	drinkable skewed bottle of Merlot	3	good	
-2272	weak drinkable bottle of Port	2	good	
-2273	watered-down drinkable bottle of Pinot Noir	2	good	
+2272	drinkable weak bottle of Port	2	good	
+2273	drinkable watered-down bottle of Pinot Noir	2	good	
 2274	smooth bottle of Zinfandel	3	awesome	
 2275	irresponsibly strong delicious bottle of Marsala	9	awesome	
 2276	mediocre bottle of Muscat	3	decent	
 2277	skewed Fernswarthy's key	0		
 2278	red Fernswarthy's letter	0		
 2279	book	0		
-2280	ghostly huge Manual of Labor	0		
+2280	huge ghostly Manual of Labor	0		
 2281	Manual of Transmission	0		
 2282	upside-down Manual of Dexterity	0		
 2283	ghostly red seal-skull helmet of the storm	0		Maximum MP Percent: +40, Familiar Effect: "atk, cap 2"
@@ -2309,7 +2309,7 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	electrified pipe of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 3, MP Regen Max: 5
 2337	greasy reinforced beaded headband	0		Sleaze Spell Damage: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	massive stale pudding	8	decent	Wiki Name: "black pudding (food)"
+2338	stale massive pudding	8	decent	Wiki Name: "black pudding (food)"
 2339	smooth Blackfly Chardonnay	3	awesome	
 2340	tolerable lime green & tan	3	good	
 2341	pepper	0		
@@ -2331,7 +2331,7 @@
 2357	greedy inspector's Gaia beads	0		Item Drop: +15, Meat Drop: +20
 2358	pink clay bead	0		
 2359	clay bead	0		
-2360	jittery twirling clay bead	0		
+2360	twirling jittery clay bead	0		
 2361	blinking family-friendly quilted hippy medical kit	0		Damage Absorption: +40, Sleaze Resistance: +1, Single Equip
 2362	hale Slow Talkin' Elliot's dogtags of the detective	0		Maximum HP: +20, Item Drop: +20
 2363	chaotic longhaired hippy wig of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +10, Familiar Effect: "1xPotato, 1xGhuol"
@@ -2347,7 +2347,7 @@
 2373	adequate banana	3	good	
 2374	blurry banana peel	0		
 2375	stale tumbling banana cream pie	3	decent	
-2376	fancy tolerable distilled banana daiquiri	5	good	Effect: "Tiki Temerity", Effect Duration: 20
+2376	fancy distilled tolerable banana daiquiri	5	good	Effect: "Tiki Temerity", Effect Duration: 20
 2377	tolerable bungle in the jungle	3	good	
 2378	lime green banana spritzer	0		
 2379	polymerized wet olive banana smoothie	0		Effect: "Saucemastery", Effect Duration: 46
@@ -2396,7 +2396,7 @@
 2422	super-corrupted chilled irradiated pet snacks	0		Effect: "Comprehensively Nourished", Effect Duration: 52
 2423	dry concentrated oxidized skewed Mick's IcyVapoHotness Inhaler	0		Effect: "Leisurely Amblin'", Effect Duration: 60
 2424	galvanized ionized cyclops eyedrops	0		Effect: "Boschface", Effect Duration: 38
-2425	denatured chilled narrow blurry can of spinach	0		Effect: "Dreadful Sheen", Effect Duration: 20
+2425	denatured chilled blurry narrow can of spinach	0		Effect: "Dreadful Sheen", Effect Duration: 20
 2426	quadruple-cold-filtered fire flower	0		Effect: "Medieval Mage Mayhem", Effect Duration: 35
 2427	dry freezerburned ice cube	0		Effect: "Piratastic", Effect Duration: 12
 2428	improved nitrogenated jittery upside-down fake blood	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 39
@@ -2415,7 +2415,7 @@
 2441	spinning Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	healthy pink glowstick of the overflowing toilet	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Last Available: "2007-03"
-2444	high-proof mediocre Supernova Champagne	9	decent	
+2444	mediocre high-proof Supernova Champagne	9	decent	
 2445	mirror Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2442,8 +2442,8 @@
 2469	jittery bundle of receipts	0		
 2470	mirror cork	0		
 2471	stardust	0		
-2472	spinning twirling wilted lettuce	0		
-2473	teal jittery empty greasepaint tube	0		
+2472	twirling spinning wilted lettuce	0		
+2473	jittery teal empty greasepaint tube	0		
 2474	clown skin	0		
 2475	flame-wreathed beefy clown wig	0		Muscle: +10, Hot Spell Damage: +10, Clowniness: 50, Familiar Effect: "chromatic atk, 1xPotato, cap 12"
 2476	prompt clownskin belt	0		Adventures: +3, Clowniness: 50
@@ -2492,11 +2492,11 @@
 2519	drinkable McMillicancuddy's Special Lager	4	good	
 2520	acceptable melted Jell-o shot	4	good	
 2521	tolerable jittery cruelty-free wine	3	good	
-2522	perfectly mixed distilled olive mirror thistle wine	5	EPIC	
+2522	distilled perfectly mixed mirror olive thistle wine	5	EPIC	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	enchanted adequate green fish	3	good	Effect: "Electrolit Up", Effect Duration: 15
-2526	stale half-sized fish casserole	2	decent	
+2526	half-sized stale fish casserole	2	decent	
 2527	decent fish lasagna	3	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	low-calorie bland gnatloaf	1	decent	
@@ -2504,9 +2504,9 @@
 2531	moldy gnat lasagna	3	crappy	
 2532	mirror pork	0		
 2533	miniature stale pork chop sandwiches	2	decent	
-2534	fancy spoiled pork casserole	4	crappy	Effect: "Amplified Fabulousness", Effect Duration: 15
+2534	spoiled fancy pork casserole	4	crappy	Effect: "Amplified Fabulousness", Effect Duration: 15
 2535	enchanted yummy pork lasagna	4	awesome	Effect: "Disco State of Mind", Effect Duration: 30
-2536	twirling yellow blinking canopic jar	0		
+2536	blinking twirling yellow canopic jar	0		
 2537	spice	0		
 2538	organs	0		
 2539	occult Ankh of Badahnkadh	0		Spell Damage Percent: +25, Single Equip
@@ -2518,7 +2518,7 @@
 2545	anodized adjusted chilled upsy daisy	0		Effect: "Buttermilk Boogie", Effect Duration: 58, Last Available: "2007-05"
 2546	liquefied denatured half-orchid	0		Effect: "Fudge Headache", Effect Duration: 61, Last Available: "2007-05"
 2547	ribald smartaleck's tin star	0		Moxie Percent: +30, Sleaze Damage: +10, Last Available: "2007-05"
-2548	tumbling double-paned sage outrageous sombrero	0		Mysticality Percent: +10, Cold Resistance: +5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	tumbling double-paned sage outrageous sombrero	0		Mysticality Percent: +10, Cold Resistance: +5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	manspreader's cool &quot;Humorous&quot; T-shirt	0		Moxie: +5, Monster Level: +10, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2539,7 +2539,7 @@
 2566	maroon squat Azazel's unicorn	0		
 2567	ghostly Azazel's lollipop	0		
 2568	Azazel's tutu	0		
-2569	deionized irradiated upside-down maroon ant agonist	0		Effect: "Memory of Resilience", Effect Duration: 43
+2569	deionized irradiated maroon upside-down ant agonist	0		Effect: "Memory of Resilience", Effect Duration: 43
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
@@ -2609,7 +2609,7 @@
 2636	hale mummy mask	0		Maximum HP: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	spinning brawny gauze shorts of Tarzan	0		Muscle Percent: +20, Experience (Muscle): +3, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
 2638	fuchsia gauze hammock	0		
-2639	upside-down twirling cherry soda	0		
+2639	twirling upside-down cherry soda	0		
 2640	manspreader's supercool greaves	0		Moxie Percent: +20, Monster Level: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 2641	spinning asbestos-lined electrified cowboy hat	0		Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xBarrr, 1xLep, cap 41"
 2642	Jim Carey's Maxwell's Silver Hammer of courage	0		Monster Level: +25, Spooky Resistance: +3
@@ -2624,7 +2624,7 @@
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	spoiled fuchsia twirling S.T.L.T.	3	crappy	Last Available: "2007-06"
 2653	flavorless mirror honey-dew	4	decent	Last Available: "2007-06"
-2654	acceptable irresponsibly strong Xanadian	7	good	Last Available: "2007-06"
+2654	irresponsibly strong acceptable Xanadian	7	good	Last Available: "2007-06"
 2655	deionized fuchsia bottle of absinthe	0		Effect: "Patent Avarice", Effect Duration: 52, Last Available: "2007-06"
 2656	nippy coward's Drowsy Sword	0		Monster Level: -20, Cold Damage: +10
 2657	normal fancy escargotsicle	3	good	Effect: "Slimily Sagacious", Effect Duration: 35, Last Available: "2007-06"
@@ -2632,8 +2632,8 @@
 2659	lime green tumbling albatross necklace of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2007-06"
 2660	powdered not-a-pipe	1	EPIC	Last Available: "2007-06"
 2661	smooth flask of Amontillado	3	awesome	Last Available: "2007-06"
-2662	Van der Graaf ball mask	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	narrow careful Can-Can skirt	0		Monster Level: -10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	Van der Graaf ball mask	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	narrow careful Can-Can skirt	0		Monster Level: -10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	denatured non-dry sensitive poetry journal	0		Effect: "The Style... of the Future", Effect Duration: 36, Last Available: "2007-06"
 2665	non-warmed flattened jittery bottled inspiration	0		Effect: "Big", Effect Duration: 40, Last Available: "2007-06"
 2666	modified ionized twirling bellhop bell	0		Effect: "Disco Inferno", Effect Duration: 30, Last Available: "2007-06"
@@ -2682,7 +2682,7 @@
 2709	bouncing exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
 2711	dry boiled facepaint	0		Effect: "The Real Deal", Effect Duration: 68
-2712	concentrated narrow blinking sheepskin diploma	0		Effect: "Musky", Effect Duration: 66
+2712	concentrated blinking narrow sheepskin diploma	0		Effect: "Musky", Effect Duration: 66
 2713	colloidal Black Body&trade; spray	0		Effect: "Pie in the Sky", Effect Duration: 58
 2714	shaking floorboard cruft	0		
 2715	sausage bomb	0		
@@ -2696,15 +2696,15 @@
 2723	sharpshooter's Herculean Staff of the Grand Flamb&eacute; of the dark arts	0		Experience (Muscle): +1, Spell Damage Percent: +100, Critical Hit Percent: +10
 2724	spoiled bowl of rye sprouts	4	crappy	
 2725	rotten cyan cob of corn	3	crappy	
-2726	diet yummy juniper berries	1	awesome	
+2726	yummy diet juniper berries	1	awesome	
 2727	delicious massive plum	9	awesome	
-2728	big spoiled pear	5	crappy	
+2728	spoiled big pear	5	crappy	
 2729	stale peach	4	decent	
 2730	delicious distilled plum wine	5	awesome	
-2731	weak acceptable lime green shot of pear schnapps	2	good	
+2731	acceptable weak lime green shot of pear schnapps	2	good	
 2732	smooth weak green twirling shot of peach schnapps	2	awesome	
 2733	rotten spinning bunch of square grapes	3	crappy	
-2734	special decent jumbo brown sugar cane	5	good	Effect: "The Power of Positive Thinking", Effect Duration: 25
+2734	jumbo decent special brown sugar cane	5	good	Effect: "The Power of Positive Thinking", Effect Duration: 25
 2735	normal sandwich of the gods	3	good	
 2736	artisanal Pan-Dimensional Gargle Blaster	4	EPIC	
 2737	vaporized yellow leopard-print barbell	1	decent	
@@ -2712,7 +2712,7 @@
 2739	galvanized gray panty raider camouflage	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 67
 2740	Staff of the Walk-In Freezer of the overflowing toilet of the businessman of Flo-Jo	0		Stench Spell Damage: +50, Meat Drop: +50, Initiative: +100
 2741	lousy strong boilermaker	5	decent	
-2742	rotten super-sized enchanted wobbly steel lasagna	5	quest	Effect: "Slippery Tongue", Effect Duration: 35
+2742	rotten enchanted super-sized wobbly steel lasagna	5	quest	Effect: "Slippery Tongue", Effect Duration: 35
 2743	perfectly mixed steel margarita	4	quest	
 2744	twisted skewed steel-scented air freshener	1		Effect: "Notably Lovely", Effect Duration: 10
 2745	polymerized diffused triple-dry gremlin mutagen	0		Effect: "Held Closer", Effect Duration: 16
@@ -2738,7 +2738,7 @@
 2765	twirling Harold's bell	0		
 2766	upside-down bowling ball	0		
 2767	immense adequate Crimbo pie	8	good	
-2768	small adequate shaking pear tart	2	good	
+2768	adequate small shaking pear tart	2	good	
 2769	adequate peach pie	4	good	
 2770	concentrated double-improved huge squat chunk of rock salt	0		Effect: "Empathy", Effect Duration: 25
 2771	polymerized handful of pine needles	0		Effect: "Blood-Gorged", Effect Duration: 39
@@ -2789,9 +2789,9 @@
 2816	family-friendly manspreader's resourceful Boxers	0		Maximum MP: +50, Monster Level: +10, Sleaze Resistance: +1, Familiar Effect: "1xVolley, 1xLep"
 2817	dance instructor's supercool Brooch of the blizzard	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Cold Spell Damage: +25, Single Equip
 2818	miser's ruddy dangerous Bracelet	0		Weapon Damage: +10, Maximum HP Percent: +40, Meat Drop: +10, Single Equip
-2819	Newton's sage Grimacite gasmask	0		Mysticality Percent: +10, Experience (Mysticality): +3, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	Newton's sage Grimacite gasmask	0		Mysticality Percent: +10, Experience (Mysticality): +3, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	fuchsia ruddy Grimacite gat of mayonnaise	0		Maximum HP Percent: +40, Sleaze Spell Damage: +50, Last Available: "2008-11"
-2821	upside-down ribald Grimacite gaiters of the glutton	0		Sleaze Damage: +10, Food Drop: +100, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	upside-down ribald Grimacite gaiters of the glutton	0		Sleaze Damage: +10, Food Drop: +100, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	blinking forbidden stylish Grimacite gauntlets	0		Moxie: +25, Spell Damage Percent: +50, Single Equip, Last Available: "2008-11"
 2823	blinking curative Grimacite go-go boots of James Dean	0		Experience (Moxie): +3, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2008-11"
 2824	narrow deadly Grimacite girdle of the empath	0		Weapon Damage: +5, Familiar Weight: +5, Single Equip, Last Available: "2008-11"
@@ -2799,7 +2799,7 @@
 2826	mirror flame-retardant Tesla Da Vinci's Staff of the Kitchen Floor	0		Experience (Mysticality): +5, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10
 2827	shaking anniversary gift box	0		
 2828	loaded dice	0		
-2829	teal shaking really dense meat stack	0		
+2829	shaking teal really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	rotten digital key lime pie	4	crappy	
@@ -2810,7 +2810,7 @@
 2837	mirror mint-condition magic wand	0		Last Available: "2011-12"
 2838	pulsating jittery friendly glowstick of terror	0		Familiar Weight: +3, Spooky Spell Damage: +10, Last Available: "2007-08"
 2839	stanky Periodical Paintbrush	0		Stench Spell Damage: +25, Softcore Only
-2840	practically non-alcoholic bad bottle of cooking sherry	1	decent	
+2840	bad practically non-alcoholic bottle of cooking sherry	1	decent	
 2841	moldy packet of ketchup	4	crappy	
 2842	mediocre accidental cider	4	decent	
 2843	tasty wobbly upside-down dire fudgesicle	3	awesome	
@@ -2823,14 +2823,14 @@
 2850	delicious watered-down moonberry wine cooler	2	awesome	
 2851	moldy fine aged cheddarwurst	4	crappy	
 2852	branch from the Great Tree	0		
-2853	ghostly jittery Phil Bunion's axe	0		
-2854	pulsating blurry bouquet of swamp roses	0		
+2853	jittery ghostly Phil Bunion's axe	0		
+2854	blurry pulsating bouquet of swamp roses	0		
 2855	Annie Oakley's sinister huge mosquito proboscis	0		Spell Damage: +10, Critical Hit Percent: +20
 2856	extra-oxidized blurry swamp lolly	0		Effect: "You Know Where to Go", Effect Duration: 39
 2857	pressed activated wet seegar butt	0		Effect: "Rave Nirvana", Effect Duration: 47
 2858	bottled swamp gas	0		
 2859	jittery hardy witch wart of the cougar	0		Moxie: +20, Maximum HP: +50
-2860	enchanted delicious bouncing swamp muck	3	awesome	Effect: "Is This Your Card?", Effect Duration: 40
+2860	delicious enchanted bouncing swamp muck	3	awesome	Effect: "Is This Your Card?", Effect Duration: 40
 2861	hardy padded leechknife of the storm	0		Damage Absorption: +20, Maximum HP: +50, Maximum MP Percent: +40
 2862	shaking decomposed boot	0		
 2863	colloidal warmed dribbly candle	0		Effect: "Nightlit", Effect Duration: 35
@@ -2841,7 +2841,7 @@
 2868	quantum electrified pirate pamphlet	0		Effect: "Dirge of Dreadfulness", Effect Duration: 48
 2869	electrified non-colloidal squat pirate brochure	0		Effect: "The Halls of Mysticality", Effect Duration: 64
 2870	chilled ionized tarnished ghostly pirate tract	0		Effect: "Phairly Balanced", Effect Duration: 39
-2871	blue huge burnt flower	0		
+2871	huge blue burnt flower	0		
 2872	padded deadly plastic Naughty Sorceress	0		Weapon Damage: +5, Damage Absorption: +20
 2873	wobbly rosewater-soaked smelly plastic Ed the Undying	0		Stench Spell Damage: +10, Stench Resistance: +3
 2874	blurry electrified plastic Lord Spookyraven of the dark arts	0		Spell Damage Percent: +100, MP Regen Min: 3, MP Regen Max: 5
@@ -2910,7 +2910,7 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	blurry unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	stale small Surprise Egg	2	decent	
+2940	small stale Surprise Egg	2	decent	
 2941	modified Steal This Candy	0		Effect: "Rainbow Bright", Effect Duration: 53
 2942	anodized mirror chocolate filthy lucre	0		Effect: "Using Protection", Effect Duration: 14
 2943	diffused liquefied Angry Farmer's Wife Candy	0		Effect: "Mucilaginous Mentalism", Effect Duration: 20
@@ -2929,7 +2929,7 @@
 2957	pulsating rum barrel charrrm	0		
 2958	fancy normal tube of cranberry Go-Goo	4	good	Effect: "Strong Spirit", Effect Duration: 15
 2959	Sherlock's rum barrel charrrm bracelet	0		Item Drop: +25
-2960	small flavorless fancy single-serving herbal stuffing	2	decent	Effect: "Super-Mega-Charged", Effect Duration: 50
+2960	flavorless small fancy single-serving herbal stuffing	2	decent	Effect: "Super-Mega-Charged", Effect Duration: 50
 2961	decent tumbling mirror packet of tofurkey gravy	3	good	
 2962	normal tofurkey nugget	3	good	
 2963	ghostly rigging shampoo	0		
@@ -2938,14 +2938,14 @@
 2966	blurry Tom's of the Spanish Main Toothpaste	0		
 2967	unsweetened improved Swabbie&trade; swab	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 43
 2968	adjusted Oil of Parrrlay	0		Effect: "Slimily Sagacious", Effect Duration: 32
-2969	snack-sized yummy creamsicle	2	awesome	
+2969	yummy snack-sized creamsicle	2	awesome	
 2970	artisanal cream stout	3	EPIC	
 2971	twirling Jack Frost's rosy-cheeked curmudgel	0		Maximum HP Percent: +30, Cold Spell Damage: +50
 2972	twirling squat grumpy man charrrm	0		
 2973	grumpy man charrrm bracelet of Leguizamo	0		Monster Level: +20, Single Equip
 2974	blurry tarrrnish charrrm	0		
 2975	gray electrified weightlifter's tarrrnished charrrm bracelet	0		Muscle: +15, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-2976	boozy tolerable wobbly bilge wine	5	good	
+2976	tolerable boozy wobbly bilge wine	5	good	
 2977	fortified witty rapier	0		Damage Absorption: +60
 2978	inspector's rosy-cheeked yohohoyo	0		Maximum HP Percent: +30, Item Drop: +15
 2979	improved extra-Vulcanized quadruple-galvanized bouncing red fish-liver oil	0		Effect: "Human-Slime Hybrid", Effect Duration: 59
@@ -2986,7 +2986,7 @@
 3014	mirror ornate key	0		
 3015	wobbly gilded key	0		
 3016	foot locker	0		
-3017	red huge ornate chest	0		
+3017	huge red ornate chest	0		
 3018	gilded chest	0		
 3019	gray all-purpose cleaner	0		
 3020	handful of sawdust	0		
@@ -2994,26 +2994,26 @@
 3022	medium stone triangle	0		
 3023	jittery small stone triangle	0		
 3024	stone pyramid	0		
-3025	practically non-alcoholic perfectly mixed pulsating corpse on the beach	1	super ultra mega turbo EPIC	
+3025	perfectly mixed practically non-alcoholic pulsating corpse on the beach	1	super ultra mega turbo EPIC	
 3026	drinkable lime green corpsetini	4	good	
 3027	lousy corpsedriver	4	decent	
-3028	irresponsibly strong drinkable Corpse Island iced tea	10	good	
+3028	drinkable irresponsibly strong Corpse Island iced tea	10	good	
 3029	weak artisanal red-headed corpse	2	EPIC	
 3030	mediocre kamicorpse-ee	4	decent	
 3031	aged corpsel	3	awesome	
-3032	smooth special tumbling corpsebite	3	awesome	Effect: "Leisurely Amblin'", Effect Duration: 10
+3032	special smooth tumbling corpsebite	3	awesome	Effect: "Leisurely Amblin'", Effect Duration: 10
 3033	toasty pirate fledges	0		Hot Damage: +5
-3034	shaking narrow maroon piece of thirteen	0		
-3035	toothsome jumbo mirror pearl onion	5	awesome	
+3034	narrow maroon shaking piece of thirteen	0		
+3035	jumbo toothsome mirror pearl onion	5	awesome	
 3036	normal sea biscuit	3	good	
 3037	hand-crafted practically non-alcoholic bottle of rum	1	EPIC	
-3038	watered-down hand-crafted mirror lime green bottle of black-label rum	2	EPIC	
+3038	hand-crafted watered-down lime green mirror bottle of black-label rum	2	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
 3042	green Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	gray metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	blinking jittery teal metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	teal blinking jittery metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	yummy jittery nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
 3046	moldy mirror nanite-infested candy cane	3	crappy	Last Available: "2020-09"
 3047	moldy gigantic nanite-infested fruitcake	8	crappy	Last Available: "2007-12"
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	non-cold-filtered red candy heart	0		Effect: "Tiki Temerity", Effect Duration: 34, Last Available: "2007-02"
 3055	nitrogenated blurry cymbal syrup	0		Free Pull, Effect: "Slimily Speedy", Effect Duration: 14, Last Available: "2007-02"
-3056	squat crafty metallic foil cat ears	0		Maximum MP: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	squat crafty metallic foil cat ears	0		Maximum MP: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	teal nanofiber cloth	0		Last Available: "2007-12"
 3058	spinning iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,18 +3048,18 @@
 3076	narrow laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	ghostly wobbly lime green marionette collective of Leguizamo	0		Monster Level: +20, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
 3083	gray blob	0		Last Available: "2007-12"
 3084	spinning ribald borg sock monkey	0		Sleaze Damage: +10, Last Available: "2007-12"
 3085	dog trainer's deadly roboduck-on-a-string	0		Weapon Damage: +5, Experience (familiar): +1, Last Available: "2007-12"
-3086	ghostly twirling mylar scout drone	0		Last Available: "2007-12"
+3086	twirling ghostly mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	pulsating flame-wreathed stiffened biomechanical crimborg helmet	0		Damage Reduction: 1, Hot Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	pulsating flame-wreathed stiffened biomechanical crimborg helmet	0		Damage Reduction: 1, Hot Spell Damage: +10, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	smartaleck's C.B.F.G. of bravery	0		Moxie Percent: +30, Spooky Resistance: +5, Last Available: "2007-12"
-3090	dog trainer's occult biomechanical crimborg leg armor	0		Spell Damage Percent: +25, Experience (familiar): +1, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	dog trainer's occult biomechanical crimborg leg armor	0		Spell Damage Percent: +25, Experience (familiar): +1, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	frozen aerosolized vitachoconutriment capsule	0		Effect: "Dragged Through the Coals", Effect Duration: 41, Last Available: "2007-12"
 3092	skewed tumbling prompt handmade hobby horse	0		Adventures: +3, Last Available: "2007-12"
 3093	careful ball-in-a-cup	0		Monster Level: -10, Last Available: "2007-12"
@@ -3092,7 +3092,7 @@
 3120	gray jittery divine blowout	0		Last Available: "2008-01"
 3121	green divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
-3123	pulsating mirror blinking divine champagne flute	0		Last Available: "2008-01"
+3123	mirror pulsating blinking divine champagne flute	0		Last Available: "2008-01"
 3124	warmed jittery fruitfilm	0		Effect: "Nano-juiced", Effect Duration: 66
 3125	improved triple-electrified shaking piece of after eight	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 58
 3126	hobo nickel	0		
@@ -3147,7 +3147,7 @@
 3175	stale evil noodles	3	decent	
 3176	moldy jittery evil noodles	4	crappy	
 3177	half-sized flavorless evil painful penne pasta	2	decent	
-3178	half-sized rotten bouncing shaking 3vi1 pr0n m4nic0tti	2	crappy	
+3178	rotten half-sized shaking bouncing 3vi1 pr0n m4nic0tti	2	crappy	
 3179	bland evil ravioli della hippy	3	decent	
 3180	decent miniature blurry blinking evil noodles	2	good	
 3181	unsweetened evil potion of potency	0		Effect: "Drenched With Filth", Effect Duration: 29
@@ -3195,7 +3195,7 @@
 3223	yellow sewer nuggets	0		
 3224	green ghostly sewer wad	0		
 3225	watered-down artisanal lime green bottle of sewage schnapps	2	EPIC	
-3226	watered-down tolerable bottle of Ooze-O	2	good	
+3226	tolerable watered-down bottle of Ooze-O	2	good	
 3227	tasty C.H.U.M. chum	3	awesome	
 3228	tasty unfortunate dumplings	3	awesome	
 3229	decaying goldfish liver	0		
@@ -3269,7 +3269,7 @@
 3297	stray chihuahua	0		
 3298	pretty pink bow	0		
 3299	smiley-face sticker	0		
-3300	twirling mirror cyan farfalle bow tie	0		
+3300	mirror cyan twirling farfalle bow tie	0		
 3301	jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
 3303	jittery sombrero	0		Sombrero Bonus: +10
@@ -3295,7 +3295,7 @@
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	smooth jar of fermented pickle juice	3	awesome	
-3326	diluted skewed squat voodoo snuff	1	decent	
+3326	diluted squat skewed voodoo snuff	1	decent	
 3327	stale extra-greasy slider	3	decent	
 3328	censurious crumpled felt fedora of Flo-Jo	0		Sleaze Resistance: +3, Initiative: +100, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	Sherlock's grievous battered top-hat	0		Weapon Damage Percent: +50, Item Drop: +25, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3303,23 +3303,23 @@
 3331	miser's foul-smelling mostly rat-hide leggings	0		Stench Damage: +10, Meat Drop: +10, Familiar Effect: "stench atk, 1xPotato"
 3332	supercharged hobo dungarees of the sweet-tooth	0		Maximum MP Percent: +30, Candy Drop: +100, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	shaking clever groovy patched suit-pants	0		Moxie Percent: +10, Maximum MP: +20, Familiar Effect: "1xPotato, 0.5xFairy"
-3334	squat blurry blue hobo stogie	0		Single Equip
+3334	blurry blue squat hobo stogie	0		Single Equip
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	knitted stanky dead guy's memento	0		Stench Spell Damage: +25, Cold Resistance: +3, Single Equip
 3338	toothsome banquet	4	awesome	
 3339	sharpened hubcap	0		
 3340	very caltrop	0		
-3341	wobbly blinking The Six-Pack of Pain	0		
+3341	blinking wobbly The Six-Pack of Pain	0		
 3342	green hobo monkey	0		
 3343	squat bindle	0		Familiar Weight: +5
-3344	upside-down blinking bed of coals	0		
+3344	blinking upside-down bed of coals	0		
 3345	air mattress	0		
 3346	purple filth-encrusted futon	0		
 3347	comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
-3350	weak special bad ghostly Ralph IX cognac	2	decent	Effect: "Just the Brown Ones", Effect Duration: 35
+3350	weak bad special ghostly Ralph IX cognac	2	decent	Effect: "Just the Brown Ones", Effect Duration: 35
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	boiled ionized llama lama gong	0		Effect: "Wit Tea", Effect Duration: 23, Last Available: "2008-06"
@@ -3332,16 +3332,16 @@
 3360	fuchsia stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	adequate massive mole mol&eacute;	6	good	Last Available: "2008-06"
+3363	massive adequate mole mol&eacute;	6	good	Last Available: "2008-06"
 3364	bad Morlock's Mark Bourbon	3	decent	Last Available: "2008-06"
-3365	deionized pickled pulsating tumbling Climate Colada	0		Effect: "Witch's Brood", Effect Duration: 19, Last Available: "2008-06"
+3365	deionized pickled tumbling pulsating Climate Colada	0		Effect: "Witch's Brood", Effect Duration: 19, Last Available: "2008-06"
 3366	polarized unsweetened digital underground potion	0		Effect: "Weasels Underfoot", Effect Duration: 65, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	distilled glimmering roc feather	1	crappy	Last Available: "2008-06"
 3369	vaporized spinning glimmering phoenix feather	1		Effect: "Marbles in Your Mouth", Effect Duration: 25, Last Available: "2008-06"
-3370	pickled mirror huge glimmering penguin feather	1		Last Available: "2008-06"
+3370	pickled huge mirror glimmering penguin feather	1		Last Available: "2008-06"
 3371	pickled glimmering buzzard feather	1		Last Available: "2008-06"
-3372	diluted twirling teal tumbling glimmering raven feather	1		Last Available: "2008-06"
+3372	diluted teal tumbling twirling glimmering raven feather	1		Last Available: "2008-06"
 3373	powdered glimmering great tit feather	1		Effect: "Mutated", Effect Duration: 30, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3391,7 +3391,7 @@
 3423	magnetized galvanized frostbite-flavored Hob-O	0		Effect: "The Living Hitpoints", Effect Duration: 37
 3424	energized wobbly fry-oil-flavored Hob-O	0		Effect: "Waxing", Effect Duration: 36
 3425	cold-filtered super-cold-filtered yellow garbage-juice-flavored Hob-O	0		Effect: "Man's Worst Enemy", Effect Duration: 35
-3426	tarnished ghostly shaking strawberry-flavored Hob-O	0		Effect: "Human-Pirate Hybrid", Effect Duration: 51
+3426	tarnished shaking ghostly strawberry-flavored Hob-O	0		Effect: "Human-Pirate Hybrid", Effect Duration: 51
 3427	roll of Hob-Os	0		
 3428	polymerized spinning Everlasting Deckswabber	0		Effect: "Berry Thorny", Effect Duration: 45
 3430	bindle of joy	0		
@@ -3419,17 +3419,17 @@
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
 3454	narrow cotton candy pillow	0		Last Available: "2008-08"
-3455	cyan blinking cotton candy bale	0		Last Available: "2008-08"
+3455	blinking cyan cotton candy bale	0		Last Available: "2008-08"
 3456	trusty torch of doom	0		Spooky Spell Damage: +50, Last Available: "2011-12"
 3457	rosy-cheeked Junior Adventurer's merit badge	0		Maximum HP Percent: +30
 3458	oxidized wobbly STYX deodorant body spray	0		Effect: "Spooky Weapon", Effect Duration: 31
 3459	mediocre white-label gin	3	decent	
-3460	decent bite-sized tin rations	1	good	
+3460	bite-sized decent tin rations	1	good	
 3461	upside-down haiku challenge map	0		
 3462	terrible poem	0		
-3463	weak bad cyan twirling bottle of sake	2	decent	
+3463	weak bad twirling cyan bottle of sake	2	decent	
 3464	blinking brainy round pebble	0		Mysticality: +5
-3465	super-sized spoiled Bash-&#332;s cereal	5	crappy	Wiki Name: "Bash-Os cereal"
+3465	spoiled super-sized Bash-&#332;s cereal	5	crappy	Wiki Name: "Bash-Os cereal"
 3466	skewed spinning gravedigger's Annie Oakley's Oprah's haiku katana	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Spooky Damage: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	squat bargain flash powder	0		
 3468	olive savvy plastic baby	0		Mysticality Percent: +20, Single Equip, Last Available: "2008-12"
@@ -3455,19 +3455,19 @@
 3488	pristine fish scale	0		
 3489	rotten snack-sized beefy fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3490	spoiled glistening fish meat	4	crappy	Effect: "Fishy", Effect Duration: 5
-3491	decent small slick fish meat	2	good	Effect: "Fishy", Effect Duration: 5
+3491	small decent slick fish meat	2	good	Effect: "Fishy", Effect Duration: 5
 3492	fuchsia mirror wholesome razor-sharp fish scimitar	0		Weapon Damage Percent: +25, Maximum HP Percent: +10
 3493	banded fish stick of temperance	0		Damage Absorption: +100, Sleaze Resistance: +5
 3494	mirror fish bazooka of Calamity Jane of chilblains	0		Critical Hit Percent: +15, Cold Damage: +25
 3495	vacuum-sealed sea salt crystal	0		Effect: "Alacri Tea", Effect Duration: 59
-3496	double-wet denatured squat blurry bazookafish bubble gum	0		Effect: "Low on the Hog", Effect Duration: 42
+3496	double-wet denatured blurry squat bazookafish bubble gum	0		Effect: "Low on the Hog", Effect Duration: 42
 3497	high-proof perfectly mixed bottle of Pete's Sake	6	EPIC	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	flavorless canap&eacute;s	3	decent	
 3502	pickled thermos of brew	1	decent	Effect: "Tiki Temerity", Effect Duration: 30, Last Available: "2011-12"
-3503	practically non-alcoholic mediocre pulsating glass of brandy	1	decent	Last Available: "2011-12"
+3503	mediocre practically non-alcoholic pulsating glass of brandy	1	decent	Last Available: "2011-12"
 3504	French slippers	0		
 3505	up-at-dawn LWA ring	0		Adventures: +5
 3506	LARP membership card	0		Last Available: "2008-10"
@@ -3498,7 +3498,7 @@
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	mirror ant antidepressant	0		Familiar Weight: +5
 3533	mirror cactus monocle	0		Familiar Weight: +5
-3534	cyan mirror Jawmaster 2000&trade;	0		Familiar Weight: +5
+3534	mirror cyan Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	tumbling plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
@@ -3510,8 +3510,8 @@
 3543	foul-smelling depleted Grimacite gravy boat of the detective	0		Stench Damage: +10, Item Drop: +20, Last Available: "2011-12"
 3544	twirling family-friendly depleted Grimacite weightlifting belt of extreme caution	0		Monster Level: -25, Sleaze Resistance: +1, Single Equip, Last Available: "2011-12"
 3545	tumbling groovy boxer's depleted Grimacite grappling hook	0		Muscle Percent: +10, Moxie Percent: +10, Single Equip, Last Available: "2011-12"
-3546	blurry lard-coated depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	lard-coated Herculean depleted Grimacite shinguards	0		Experience (Muscle): +1, Sleaze Spell Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	blurry lard-coated depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	lard-coated Herculean depleted Grimacite shinguards	0		Experience (Muscle): +1, Sleaze Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	greedy beefcake's depleted Grimacite astrolabe	0		Muscle: +25, Meat Drop: +20, Single Equip, Last Available: "2011-12"
 3549	avaricious supercool KoL Con Cinco Pi&ntilde;ata Bat	0		Moxie Percent: +20, Meat Drop: +30, Softcore Only, Last Available: "2008-09"
 3550	inspector's propeller beanie	0		Item Drop: +15, Familiar Effect: "atk, cap 7"
@@ -3521,14 +3521,14 @@
 3554	glob of slime	0		
 3555	tasty sea carrot	4	awesome	
 3556	fancy bland sea cucumber	3	decent	Effect: "Graham Crackling", Effect Duration: 10
-3557	flavorless tiny sea avocado	1	decent	
+3557	tiny flavorless sea avocado	1	decent	
 3558	normal sea lychee	4	good	
-3559	tiny yummy sea tangelo	1	awesome	
+3559	yummy tiny sea tangelo	1	awesome	
 3560	tasty sea honeydew	4	awesome	
 3561	wet quantum huge wobbly pressurized potion of puissance	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 54
 3562	liquefied pressurized potion of perspicacity	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 51
 3563	anodized tarnished pressed pressurized potion of pulchritude	0		Effect: "Magically Delicious", Effect Duration: 45
-3564	delicious watered-down berry-infused sake	2	awesome	
+3564	watered-down delicious berry-infused sake	2	awesome	
 3565	smooth citrus-infused sake	3	awesome	
 3566	bad melon-infused sake	3	decent	
 3567	gray slab of sponge	0		
@@ -3538,7 +3538,7 @@
 3571	flytrap pellet	0		
 3572	shaking baby cuddlefish	0		
 3573	squat six-armed sweater	0		Familiar Weight: +5
-3574	green skewed slimy chest	0		
+3574	skewed green slimy chest	0		
 3575	gray sand dollar	0		
 3576	bouncing flytrap bezoar	0		
 3577	bezoar ring	0		
@@ -3546,8 +3546,8 @@
 3579	jittery ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	squat cyan shaking sushi-rolling mat	0		
-3582	normal tiny rice	1	good	
-3584	diet bland blinking irradiated candy cane	1	decent	Last Available: "2008-12"
+3582	tiny normal rice	1	good	
+3584	bland diet blinking irradiated candy cane	1	decent	Last Available: "2008-12"
 3585	stale gingerbread mutant bugbear	4	decent	Last Available: "2008-12"
 3586	lousy oozenog	4	decent	Last Available: "2008-12"
 3587	flattened corrupted sugar plum	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 59, Last Available: "2008-12"
@@ -3580,7 +3580,7 @@
 3614	twitching claw	0		Last Available: "2008-12"
 3615	twirling rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
-3617	pickled anodized skewed squat blue unstable DNA	0		Effect: "Whitened Teeth", Effect Duration: 15, Last Available: "2008-12"
+3617	pickled anodized blue skewed squat unstable DNA	0		Effect: "Whitened Teeth", Effect Duration: 15, Last Available: "2008-12"
 3618	lime green twirling The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	teal wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
@@ -3588,17 +3588,17 @@
 3622	fuchsia gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	cyan savvy parasitic claw	0		Mysticality Percent: +20, Last Available: "2008-12"
-3625	crafty parasitic tentacles	0		Maximum MP: +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	yellow energetic parasitic headgnawer	0		Maximum MP Percent: +20, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	crafty parasitic tentacles	0		Maximum MP: +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	yellow energetic parasitic headgnawer	0		Maximum MP Percent: +20, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	upside-down brawny parasitic strangleworm	0		Muscle Percent: +20, Last Available: "2008-12"
-3628	wobbly jittery pair of ragged claws	0		Last Available: "2008-12"
+3628	jittery wobbly pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
 3630	Crimbo crate	0		Last Available: "2008-12"
 3631	moist triple-adjusted squat Gummi-DNA	0		Effect: "Ichorous Intensity", Effect Duration: 40, Last Available: "2020-09"
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	squat up-at-dawn Van der Graaf elven socks	0		Adventures: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-12"
 3634	blinking foul-smelling supercharged elven gloves	0		Maximum MP Percent: +30, Stench Damage: +10, Last Available: "2008-12"
-3635	tumbling nippy hale festive holiday hat	0		Maximum HP: +20, Cold Damage: +10, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	tumbling nippy hale festive holiday hat	0		Maximum HP: +20, Cold Damage: +10, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	frightening patent shoes of incineration	0		Hot Spell Damage: +50, Spooky Damage: +5, Last Available: "2008-12"
 3637	blinking Sherlock's Tesla gray bow tie	0		Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2008-12"
 3638	Annie Oakley's penguin thesaurus of chilblains	0		Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2008-12"
@@ -3609,14 +3609,14 @@
 3643	pufferfish spine	0		
 3644	careful depleted Grimacite kneecapping stick	0		Monster Level: -10, Last Available: "2007-06"
 3645	drinkable high-proof canteen of wine	6	good	Last Available: "2008-12"
-3646	tiny rotten elven <i>limbos</i> gingerbread	1	crappy	Last Available: "2008-12"
+3646	rotten tiny elven <i>limbos</i> gingerbread	1	crappy	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	gigantic spoiled toast with jam	7	crappy	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	delicious practically non-alcoholic elven moonshine	1	awesome	Last Available: "2008-12"
-3653	huge moldy green knuckle sandwich	10	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	practically non-alcoholic delicious elven moonshine	1	awesome	Last Available: "2008-12"
+3653	huge moldy green knuckle sandwich	10	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	squat prompt psycho sweater of the sewer	0		Stench Damage: +25, Adventures: +3, Last Available: "2008-12"
 3655	upside-down fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of the scaredy-cat	0		Monster Level: -15, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	yellow plastic strand of DNA of Tarzan	0		Experience (Muscle): +3, Last Available: "2008-12"
 3660	teal plastic chunk of depleted Grimacite of the ox	0		Muscle: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	ghostly upside-down quilted Putty mitre	0		Damage Absorption: +40, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	savvy Putty leotard of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	ghostly upside-down quilted Putty mitre	0		Damage Absorption: +40, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	savvy Putty leotard of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	deadly Putty ball	0		Weapon Damage: +5, Softcore Only, Last Available: "2009-01"
 3665	blinking gray Putty sheet	0		Last Available: "2009-01"
 3666	stylish weightlifter's Putty snake of the brazier	0		Muscle: +15, Moxie: +25, Hot Spell Damage: +25, Softcore Only, Last Available: "2009-01"
@@ -3635,8 +3635,8 @@
 3669	blurry glow-in-the-dark dart gun of the glutton	0		Food Drop: +100, Last Available: "2009-01"
 3670	Samson's glow-in-the-dark burrowgrub	0		Experience (Muscle): +5, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	snack-sized rotten red can of franks 'n' beans	2	crappy	Last Available: "2010-12"
-3673	distilled delicious spinning bottle of peppermint schnapps	5	awesome	Last Available: "2010-12"
+3672	rotten snack-sized red can of franks 'n' beans	2	crappy	Last Available: "2010-12"
+3673	delicious distilled spinning bottle of peppermint schnapps	5	awesome	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	gray Mer-kin pressureglobe	0		
 3676	pulsating upside-down Mer-kin foodbucket	0		
@@ -3648,14 +3648,14 @@
 3682	globe of Deep Sauce	0		
 3683	twirling map to the Marinara Trench	0		
 3684	stale tempura carrot	4	decent	
-3685	low-calorie decent tempura cucumber	1	good	
+3685	decent low-calorie tempura cucumber	1	good	
 3686	rotten tempura avocado	3	crappy	
-3687	rotten half-sized teal sea broccoli	2	crappy	
+3687	half-sized rotten teal sea broccoli	2	crappy	
 3688	spoiled sea cauliflower	4	crappy	
 3689	stale tempura broccoli	3	decent	
-3690	small spoiled narrow tempura cauliflower	2	crappy	
-3691	stale miniature sea blueberry	2	decent	
-3692	moldy gigantic sea persimmon	8	crappy	
+3690	spoiled small narrow tempura cauliflower	2	crappy	
+3691	miniature stale sea blueberry	2	decent	
+3692	gigantic moldy sea persimmon	8	crappy	
 3693	triple-wet moist pressurized potion of perception	0		Effect: "Night of the Nachos", Effect Duration: 54
 3694	denatured flattened pressurized potion of proficiency	0		Effect: "Locks Like the Raven", Effect Duration: 33
 3695	Samson's Mer-kin digpick	0		Experience (Muscle): +5
@@ -3690,7 +3690,7 @@
 3724	brittle plastic handle	0		
 3725	squat foggy glass globe	0		
 3726	possessed tomato	0		
-3727	narrow upside-down Nardz energy beverage	0		
+3727	upside-down narrow Nardz energy beverage	0		
 3728	pile of coins	0		
 3729	upside-down teal hand grenegg	0		
 3730	caret	0		
@@ -3713,10 +3713,10 @@
 3747	olive mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	irradiated concoction of clumsiness	0		Effect: "Black Lung", Effect Duration: 15
 3750	censurious vampire pearl earring	0		Sleaze Resistance: +3, Single Equip
-3751	immense enchanted rotten chocolate chip brownies	6	crappy	Effect: "Fire Inside", Effect Duration: 50
+3751	enchanted rotten immense chocolate chip brownies	6	crappy	Effect: "Fire Inside", Effect Duration: 50
 3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	oxidized shaking love song of vague ambiguity	0		Effect: "Tremella Tremens", Effect Duration: 67, Last Available: "2009-02"
-3755	diffused fuchsia tumbling love song of smoldering passion	0		Effect: "Burning Ears", Effect Duration: 55, Last Available: "2009-02"
+3755	diffused tumbling fuchsia love song of smoldering passion	0		Effect: "Burning Ears", Effect Duration: 55, Last Available: "2009-02"
 3756	irradiated extra-ionized olive love song of icy revenge	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 64, Last Available: "2009-02"
 3757	galvanized improved boiled love song of sugary cuteness	0		Effect: "PERL of Great Price", Effect Duration: 11, Last Available: "2009-02"
 3758	Vulcanized bouncing love song of disturbing obsession	0		Effect: "Busy Bein' Delicious", Effect Duration: 36, Last Available: "2009-02"
@@ -3725,12 +3725,12 @@
 3761	hardy vampire pearl ring	0		Maximum HP: +50, Single Equip
 3762	wobbly twirling vampire pearl necklace of the bloodbag	0		Maximum HP: +100, Single Equip
 3763	artisanal weak yellow slug of vodka	2	EPIC	
-3764	weak delicious slug of rum	2	awesome	
+3764	delicious weak slug of rum	2	awesome	
 3765	weak delicious wobbly slug of shochu	2	awesome	
 3766	hand-crafted screwdiver	4	EPIC	
 3767	irresponsibly strong mediocre maroon dew yoana lei	8	decent	
-3768	enchanted smooth lychee chuhai	4	awesome	Effect: "Human-Elemental Hybrid", Effect Duration: 45
-3769	weak perfectly mixed salacious screwdiver	2	EPIC	
+3768	smooth enchanted lychee chuhai	4	awesome	Effect: "Human-Elemental Hybrid", Effect Duration: 45
+3769	perfectly mixed weak salacious screwdiver	2	EPIC	
 3770	hand-crafted skewed dew yoana salacious lei	4	EPIC	
 3771	delicious salacious lychee chuhai	4	awesome	
 3772	acceptable Alewife&trade; Ale	3	good	
@@ -3742,8 +3742,8 @@
 3778	pulsating nasty energetic supercool amber aviator shades	0		Moxie Percent: +20, Maximum MP Percent: +20, Stench Damage: +5, Single Equip
 3779	non-pickled hair of the fish	0		Effect: "Mystic Circle", Effect Duration: 65
 3780	lightning-fast nurse's hat of the brute of Gandalf	0		Muscle Percent: +30, Spell Critical Percent: +20, Initiative: +40, Familiar Effect: "atk"
-3781	cyan twirling blank prescription sheet	0		
-3782	vaporized bouncing upside-down bottle of melodramamine	1		
+3781	twirling cyan blank prescription sheet	0		
+3782	vaporized upside-down bouncing bottle of melodramamine	1		
 3783	vaporized maroon jittery bottle of extra-strength melodramamine	1		
 3784	squat paranormal ricotta	0		Class: "Pastamancer"
 3785	wobbly smoking talon	0		Class: "Pastamancer"
@@ -3753,13 +3753,13 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	shaking aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	shaking crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	shaking crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	jittery rock-hard groovy Mer-kin roundshield of the scaredy-cat	0		Moxie Percent: +10, Damage Reduction: 19, Monster Level: -15
 3804	spinning Jack Frost's curative Mer-kin breastplate	0		Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 3805	jittery vibrating Mer-kin sneakmask of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
-3807	tarnished narrow yellow Mer-kin hidepaint	0		Effect: "Human-Beast Hybrid", Effect Duration: 59
+3807	tarnished yellow narrow Mer-kin hidepaint	0		Effect: "Human-Beast Hybrid", Effect Duration: 59
 3808	bouncing Mer-kin trailmap	0		
 3809	wobbly Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
@@ -3768,7 +3768,7 @@
 3813	plastic baby of the early riser	0		Adventures: +7, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	enchanted stale sea radish	4	decent	Effect: "Armored Innards", Effect Duration: 10
+3817	stale enchanted sea radish	4	decent	Effect: "Armored Innards", Effect Duration: 10
 3818	auspicious careful healthy halibut	0		Maximum HP Percent: +20, Monster Level: -10, Item Drop: +10
 3819	jittery eel sauce	0		
 3820	forbidden water-polo mitt	0		Spell Damage Percent: +50, Single Equip
@@ -3782,9 +3782,9 @@
 3828	Grandma's Map	0		
 3829	adequate tempura radish	3	good	
 3830	asbestos-lined water-polo cap	0		Hot Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr"
-3831	irresponsibly strong lousy blue Typical Tavern swill	9	decent	
+3831	lousy irresponsibly strong blue Typical Tavern swill	9	decent	
 3832	bad tropical swill	4	decent	
-3833	watered-down lousy green fruity girl swill	2	decent	
+3833	lousy watered-down green fruity girl swill	2	decent	
 3834	acceptable blended swill	3	good	
 3835	costume wardrobe	0		Softcore Only
 3836	scorching dog trainer's hardy Elvish sunglasses of the brute	0		Muscle Percent: +30, Maximum HP: +50, Experience (familiar): +1, Hot Damage: +25, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3831,7 +3831,7 @@
 3877	blurry burst hellseal brain	0		
 3878	hellseal sinew	0		
 3879	torn hellseal sinew	0		
-3880	blinking tumbling hellseal disguise	0		
+3880	tumbling blinking hellseal disguise	0		
 3881	padded dangerous fouet de tortue-dressage	0		Weapon Damage: +10, Damage Absorption: +20, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	mirror encoded cult documents	0		
 3883	blurry cult memo	0		
@@ -3895,7 +3895,7 @@
 3943	personal trainer's infernal toilet brush of dire peril	0		Experience Percent (Muscle): +10, Weapon Damage: +20, Class: "Seal Clubber"
 3944	tumbling Usain Bolt's Rosewater's shadowy seal eye	0		Mysticality Percent: +30, Initiative: +80, Class: "Seal Clubber"
 3945	squat lime green oyster egg balloon of chilblains	0		Cold Damage: +25
-3946	jittery blinking Clan VIP Lounge invitation	0		Free Pull
+3946	blinking jittery Clan VIP Lounge invitation	0		Free Pull
 3947	jittery Clan VIP Lounge key	0		Free Pull
 3948	Meat	0		
 3949	treasure chest	0		
@@ -3963,7 +3963,7 @@
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	memory of a CG base pair	0		Last Available: "2009-06"
 4013	tumbling memory of a CT base pair	0		Last Available: "2009-06"
-4014	jittery yellow jittery memory of an AG base pair	0		Last Available: "2009-06"
+4014	jittery jittery yellow memory of an AG base pair	0		Last Available: "2009-06"
 4015	blinking memory of an AT base pair	0		Last Available: "2009-06"
 4016	memory of a GT base pair	0		Last Available: "2009-06"
 4017	squirming Slime larva	0		
@@ -3981,29 +3981,29 @@
 4029	memory of a grappling hook	0		Last Available: "2009-06"
 4030	memory of a small stone block	0		Last Available: "2009-06"
 4031	blurry memory of a stone block	0		Last Available: "2009-06"
-4032	yellow blinking memory of half a stone circle	0		Last Available: "2009-06"
+4032	blinking yellow memory of half a stone circle	0		Last Available: "2009-06"
 4033	blurry memory of a stone half-circle	0		Last Available: "2009-06"
 4034	squat memory of an iron key	0		Last Available: "2009-06"
 4035	mirror memory of a crystal	0		Last Available: "2009-06"
 4036	bouncing caustic slime nodule	0		
-4037	jumbo normal slimy sweetbreads	5	good	
-4038	artisanal watered-down slimy fermented bile bladder	2	EPIC	
-4039	vaporized red tumbling slimy alveolus	1		Effect: "Kissed By Fire", Effect Duration: 35
+4037	normal jumbo slimy sweetbreads	5	good	
+4038	watered-down artisanal slimy fermented bile bladder	2	EPIC	
+4039	vaporized tumbling red slimy alveolus	1		Effect: "Kissed By Fire", Effect Duration: 35
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	twirling grievous educational pig-iron helm	0		Experience: +1, Weapon Damage Percent: +50, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	banded educational pig-iron shinguards	0		Experience: +1, Damage Absorption: +100, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	twirling grievous educational pig-iron helm	0		Experience: +1, Weapon Damage Percent: +50, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	banded educational pig-iron shinguards	0		Experience: +1, Damage Absorption: +100, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	cyan lightning-fast steel-toed pig-iron bracers	0		Damage Reduction: 9, Initiative: +40, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	cyan savvy wumpus-hair whip	0		Mysticality Percent: +20, Last Available: "2009-06"
-4048	mirror healthy occult wumpus-hair wig of bravery	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Spooky Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	aromatic shellacked wumpus-hair loincloth of mayonnaise	0		Damage Reduction: 7, Sleaze Spell Damage: +50, Stench Resistance: +1, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	mirror healthy occult wumpus-hair wig of bravery	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Spooky Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	aromatic shellacked wumpus-hair loincloth of mayonnaise	0		Damage Reduction: 7, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	olive narrow Socratic wumpus-hair sweater of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Last Available: "2009-06"
 4051	yellow asbestos-lined ring of teleportation	0		Hot Resistance: +5, Single Equip
 4052	glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	banana milkshake	1	awesome	Last Available: "2009-06"
-4054	drinkable special tumbling White Hyborian	4	good	Effect: "Cold Blooded", Effect Duration: 25, Last Available: "2009-06"
+4054	special drinkable tumbling White Hyborian	4	good	Effect: "Cold Blooded", Effect Duration: 25, Last Available: "2009-06"
 4055	goblin hunting spear of the cheetah	0		Initiative: +60, Last Available: "2009-06"
 4056	banded goblin autoblowgun of Leguizamo	0		Damage Absorption: +100, Monster Level: +20, Last Available: "2009-06"
 4057	mirror tribal beads of the detective	0		Item Drop: +20, Last Available: "2009-06"
@@ -4019,7 +4019,7 @@
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
-4070	shaking gray blinking ghostly essence of stench	0		Last Available: "2009-06"
+4070	shaking ghostly gray blinking essence of stench	0		Last Available: "2009-06"
 4071	lime green essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
@@ -4081,7 +4081,7 @@
 4129	twirling nasty medical-grade hardened slime belt of the glutton	0		Stench Damage: +5, Food Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4130	blinking empty agua de vida bottle	0		Last Available: "2009-06"
 4131	mixed huge boot plant	1	decent	Last Available: "2009-06"
-4132	drinkable strong blue sham champagne	5	good	Last Available: "2009-06"
+4132	strong drinkable blue sham champagne	5	good	Last Available: "2009-06"
 4133	diffused tempura air	0		Effect: "Bloody-minded", Effect Duration: 38
 4134	galvanized diffused blinking pressurized potion of pneumaticity	0		Effect: "Lubed", Effect Duration: 65
 4135	purple moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4093,9 +4093,9 @@
 4141	a crinkled paper strip	0		
 4142	bouncing a crumpled paper strip	0		
 4143	a ragged paper strip	0		
-4144	olive ghostly a ripped paper strip	0		
+4144	ghostly olive a ripped paper strip	0		
 4145	spinning shellacked funny paper hat	0		Damage Reduction: 7, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	corrupted blurry wobbly sand	0		Effect: "Whippin' It Good", Effect Duration: 68
+4146	corrupted wobbly blurry sand	0		Effect: "Whippin' It Good", Effect Duration: 68
 4147	squat rosewater-soaked curative charged magnet	0		Stench Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09"
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
@@ -4130,8 +4130,8 @@
 4178	vibrating sugar shotgun	0		Maximum MP Percent: +10, Last Available: "2009-09"
 4179	blinking groovy sugar shillelagh	0		Moxie Percent: +10, Last Available: "2009-09"
 4180	rosewater-soaked sugar shank	0		Stench Resistance: +3, Last Available: "2009-09"
-4181	ghostly Da Vinci's beefcake's sugar chapeau of the bloodbag	0		Muscle: +25, Experience (Mysticality): +5, Maximum HP: +100, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	careful sugar shorts	0		Monster Level: -10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	ghostly Da Vinci's beefcake's sugar chapeau of the bloodbag	0		Muscle: +25, Experience (Mysticality): +5, Maximum HP: +100, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	careful sugar shorts	0		Monster Level: -10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	mirror sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	twirling slime convention flyers	0		
@@ -4169,7 +4169,7 @@
 4217	ghostly red groupie bra	0		
 4218	adjusted boiled groupie spangles	0		Effect: "Creepypasted", Effect Duration: 53
 4219	miser's rock-hard skate board	0		Damage Reduction: 5, Meat Drop: +10
-4220	skewed upside-down S.A.V.E. flyer	0		
+4220	upside-down skewed S.A.V.E. flyer	0		
 4221	hale yield shield	0		Maximum HP: +20, Damage Reduction: 6, Last Available: "2009-09"
 4222	skewed map to the Skate Park	0		
 4223	lime green squamous polyp	0		Free Pull, Last Available: "2011-12"
@@ -4178,7 +4178,7 @@
 4226	beefy Star of Bravery	0		Muscle: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4208,13 +4208,13 @@
 4256	concentrated ionized gray sap	0		Effect: "Piratey Flavor", Effect Duration: 54, Last Available: "2009-10"
 4257	shaking petrified wood	0		Last Available: "2009-10"
 4258	half-sized normal chocolate-covered scarab beetle	2	good	Last Available: "2009-10"
-4259	perfectly mixed fancy tumbling teal mulled cider	3	EPIC	Effect: "The Dinsey Way", Effect Duration: 20, Last Available: "2009-10"
-4260	wobbly wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	olive pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4259	perfectly mixed fancy teal tumbling mulled cider	3	EPIC	Effect: "The Dinsey Way", Effect Duration: 20, Last Available: "2009-10"
+4260	wobbly wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	olive pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	narrow sinister bark boxers	0		Spell Damage: +10, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	Tesla bark beret	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	narrow sinister bark boxers	0		Spell Damage: +10, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	Tesla bark beret	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	bark bracelet of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 4267	sinister Krakrox's Loincloth of the boozehound	0		Spell Damage: +10, Booze Drop: +100, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	skewed fortified Galapagosian Cuisses of doom	0		Damage Absorption: +60, Spooky Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4282,7 +4282,7 @@
 4330	stale candy kneecapping stick	3	decent	Last Available: "2009-12"
 4331	flavorless teal licorice garrote	3	decent	Last Available: "2009-12"
 4332	smelly candy knuckles	0		Stench Spell Damage: +10, Last Available: "2009-12"
-4333	spoiled fancy jawbruiser	3	crappy	Effect: "Milk Studly", Effect Duration: 25, Last Available: "2010-12"
+4333	fancy spoiled jawbruiser	3	crappy	Effect: "Milk Studly", Effect Duration: 25, Last Available: "2010-12"
 4334	magnetized activated ionized huge chocolate car	0		Effect: "Human-Goblin Hybrid", Effect Duration: 50, Last Available: "2009-12"
 4335	sharpshooter's plastic 11 Dealer	0		Critical Hit Percent: +10, Last Available: "2009-12"
 4336	mirror zippy plastic Crimbo Casino	0		Initiative: +20, Last Available: "2009-12"
@@ -4298,14 +4298,14 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	huge gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	pulsating medical-grade snow hat	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	lime green bouncing wizardly snow pants	0		Mysticality: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	pulsating medical-grade snow hat	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	lime green bouncing wizardly snow pants	0		Mysticality: +25, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	reassuring snow belly	0		Spooky Resistance: +1, Single Equip, Last Available: "2009-12"
 4352	skewed pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
 4354	purple A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	narrow A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
-4356	mirror lime green A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
+4356	lime green mirror A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	maroon A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	chilly sinister pocketwatch on a chain	0		Spell Damage: +10, Cold Damage: +5, Last Available: "2009-12"
 4386	grievous Samson's cement sandals	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Single Equip, Last Available: "2009-12"
 4387	yellow chilly night-vision goggles of the overflowing toilet	0		Cold Damage: +5, Stench Spell Damage: +50, Single Equip, Last Available: "2009-12"
-4388	huge passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	huge passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	peanut brittle shield of the pedagogue	0		Experience: +3, Damage Reduction: 3, Last Available: "2009-12"
 4390	yellow Jeselnik's Red Rover BB gun of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +25, Last Available: "2009-12"
 4391	crafty red-and-green sweater	0		Maximum MP: +10, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	cheese sword of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2010-01"
-4400	Samson's cheese diaper	0		Experience (Muscle): +5, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	Samson's cheese diaper	0		Experience (Muscle): +5, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	hale cheese wheel	0		Maximum HP: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	lion tamer's cheese eye	0		Experience (familiar): +2, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	squat Tesla Staff of Queso Escusado of Calamity Jane of the early riser	0		Critical Hit Percent: +15, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2010-01"
@@ -4360,8 +4360,8 @@
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	adequate jumbo quantum taco	0		Last Available: "2010-10"
-4413	lousy weak Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	jumbo adequate quantum taco	0		Last Available: "2010-10"
+4413	weak lousy Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	sealhide hood of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	up-at-dawn sealhide leggings	0		Adventures: +5, Familiar Effect: "1xVolley, cap 40"
@@ -4396,7 +4396,7 @@
 4448	dehydrated Instant Karma	1	good	
 4449	green painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	twirling lard-coated pointy hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	twirling lard-coated pointy hat	0		Sleaze Spell Damage: +25, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	lime green machetito of bravery	0		Spooky Resistance: +5, Last Available: "2010-04"
 4453	hale lawnmower blade	0		Maximum HP: +20, Last Available: "2010-04"
 4454	blinking grass clippings	0		Last Available: "2023-12"
@@ -4410,21 +4410,21 @@
 4462	diffused non-liquefied chocolate seal-clubbing club	0		Effect: "Well-Oiled", Effect Duration: 25
 4463	polymerized ionized chocolate turtle totem	0		Effect: "Polka Face", Effect Duration: 51
 4464	energized wobbly chocolate pasta spoon	0		Effect: "The Dinsey Way", Effect Duration: 13
-4465	non-aerosolized activated narrow mirror blurry chocolate saucepan	0		Effect: "Rage of the Reindeer", Effect Duration: 24
+4465	non-aerosolized activated narrow blurry mirror chocolate saucepan	0		Effect: "Rage of the Reindeer", Effect Duration: 24
 4466	galvanized wobbly chocolate disco ball	0		Effect: "Antarctic Memories", Effect Duration: 47
 4467	adjusted double-alkaline chocolate stolen accordion	0		Effect: "Penguinny Flavor", Effect Duration: 23
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	ruddy BRICKO hat	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	blinking spinning dance instructor's BRICKO pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	ruddy BRICKO hat	0		Maximum HP Percent: +40, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	blinking spinning dance instructor's BRICKO pants	0		Experience Percent (Moxie): +10, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	red BRICKO sword of the bloodbag	0		Maximum HP: +100, Last Available: "2010-02"
 4474	blurry BRICKO ooze	0		Last Available: "2010-02"
 4475	twirling BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	upside-down BRICKO elephant	0		Last Available: "2010-02"
-4479	jittery BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	jittery BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	mirror BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	bouncing BRICKO airship	0		Last Available: "2010-02"
@@ -4442,23 +4442,23 @@
 4494	ghostly BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	upside-down extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
-4497	ionized jittery gray recording of The Ballad of Richie Thingfinder	0		Effect: "Gonna Get You, Sucker", Effect Duration: 37
+4497	ionized gray jittery recording of The Ballad of Richie Thingfinder	0		Effect: "Gonna Get You, Sucker", Effect Duration: 37
 4498	boiled oxidized upside-down recording of Benetton's Medley of Diversity	0		Effect: "Weird Vibrations", Effect Duration: 35
 4499	wet energized unsweetened recording of Elron's Explosive Etude	0		Effect: "Boilermade", Effect Duration: 11
 4500	dry recording of Chorale of Companionship	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 68
 4501	cold-filtered Vulcanized recording of Prelude of Precision	0		Effect: "Afternoon Insight", Effect Duration: 47
 4502	Vulcanized vacuum-sealed jittery recording of Donho's Bubbly Ballad	0		Effect: "Bread Burps", Effect Duration: 34
-4503	denatured upside-down mirror recording of Inigo's Incantation of Inspiration	0		Effect: "Blood-Rich", Effect Duration: 38, Last Available: "2010-02"
+4503	denatured mirror upside-down recording of Inigo's Incantation of Inspiration	0		Effect: "Blood-Rich", Effect Duration: 38, Last Available: "2010-02"
 4504	ghostly ghostly shaking supercharged personal trainer's heart of the volcano	0		Experience Percent (Muscle): +10, Maximum MP Percent: +30
 4505	altered altered mirror Northern pemmican	0		Effect: "Metal Speed", Effect Duration: 52
 4506	maroon puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	double-enhanced &quot;DRINK ME&quot; potion	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 36, Last Available: "2010-03"
 4509	green reflection of a map	0		Last Available: "2010-03"
-4510	enchanted toothsome small walrus ice cream	2	awesome	Effect: "Serenity", Effect Duration: 25, Last Available: "2010-03"
-4511	miniature spoiled beautiful soup	2	crappy	Last Available: "2010-03"
+4510	small toothsome enchanted walrus ice cream	2	awesome	Effect: "Serenity", Effect Duration: 25, Last Available: "2010-03"
+4511	spoiled miniature beautiful soup	2	crappy	Last Available: "2010-03"
 4512	narrow eggman noodles	0		Last Available: "2010-03"
-4513	spinning wobbly Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
+4513	wobbly spinning Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	bland spinning Humpty Dumplings	3	decent	Last Available: "2010-03"
 4515	normal Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
 4516	aged triple-distilled missing wine	7	awesome	Last Available: "2010-03"
@@ -4469,7 +4469,7 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	bouncing Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	zippy hardy eye of the Tiger-lily	0		Maximum HP: +50, Initiative: +20, Last Available: "2010-03"
-4524	green perfumed gravedigger's wig	0		Spooky Damage: +10, Stench Resistance: +5, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	green perfumed gravedigger's wig	0		Spooky Damage: +10, Stench Resistance: +5, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	rotten donut	4	crappy	Last Available: "2010-03"
 4526	moldy upside-down bucket of honey	4	crappy	Last Available: "2010-03"
 4527	censurious elephant stinger of the ox	0		Muscle: +20, Sleaze Resistance: +3, Last Available: "2010-03"
@@ -4482,10 +4482,10 @@
 4534	tasty bite-sized gray king cookie	1	awesome	Last Available: "2010-03"
 4535	fancy bland fuchsia queen cookie	4	decent	Effect: "Towering Strength", Effect Duration: 35, Last Available: "2010-03"
 4536	blinking fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	lime green shaking groovy insane tophat	0		Moxie Percent: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	lime green bouncing wobbly Tesla hardy helm of the knight	0		Maximum HP: +50, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	lime green shaking groovy insane tophat	0		Moxie Percent: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	lime green bouncing wobbly Tesla hardy helm of the knight	0		Maximum HP: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	spinning ghostly stanky experienced wristwatch of the knight	0		Experience: +2, Stench Spell Damage: +25, Single Equip, Last Available: "2010-03"
-4540	Lo Pan's trousers of the knight of the pedagogue	0		Experience: +3, Spell Critical Percent: +30, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	Lo Pan's trousers of the knight of the pedagogue	0		Experience: +3, Spell Critical Percent: +30, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	healthy tophat	0		Maximum HP Percent: +20, Familiar Effect: "1xBarrr, cap 25"
 4542	spinning tie of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip
 4543	zippy tuxedo pants	0		Initiative: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4503,7 +4503,7 @@
 4555	blurry left bracket	0		
 4556	right parenthesis	0		
 4557	dollar sign	0		
-4558	narrow mirror equal sign	0		
+4558	mirror narrow equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
@@ -4514,19 +4514,19 @@
 4566	wobbly fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	fuchsia smelly flyest of shirts of Tarzan	0		Experience (Muscle): +3, Stench Spell Damage: +10, Last Available: "2010-04"
 4568	moldy a dance upon the palate	3	crappy	Last Available: "2010-04"
-4569	thick adequate prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
+4569	adequate thick prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
 4570	pulsating Crazyleg's razor	0		Last Available: "2010-04"
 4571	decent squirmy violent party snack	3	good	Last Available: "2010-04"
 4572	squat sizzling can-you-dig-it?	0		Hot Damage: +10, Last Available: "2010-04"
-4573	narrow lime green The Legendary Beat	0		Last Available: "2010-04"
+4573	lime green narrow The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4578	jittery fuchsia meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4578	fuchsia jittery meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	flattened Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Artificially Sweet", Effect Duration: 28, Last Available: "2010-04"
 4580	Newton's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Experience (Mysticality): +3, Last Available: "2010-04"
-4581	healthy dance instructor's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience Percent (Moxie): +10, Maximum HP Percent: +20, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	healthy dance instructor's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience Percent (Moxie): +10, Maximum HP Percent: +20, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	upside-down fat bottom quark	0		Last Available: "2010-05"
 4583	mirror glob of skin	0		
 4584	tasty blurry six wedges of goat cheese	4	awesome	
@@ -4538,7 +4538,7 @@
 4590	beefy pixel chain whip	0		Muscle: +10, Last Available: "2010-07"
 4591	lard-coated pixel morning star	0		Sleaze Spell Damage: +25, Last Available: "2010-07"
 4592	spinning pixel orb	0		Last Available: "2010-07"
-4593	huge gray pixellated moneybag	0		Last Available: "2010-07"
+4593	gray huge pixellated moneybag	0		Last Available: "2010-07"
 4594	bouncing pixel cross	0		
 4595	blurry pixel holy water	0		Last Available: "2010-07"
 4596	twirling map to Vanya's Castle	0		Last Available: "2010-07"
@@ -4552,15 +4552,15 @@
 4604	keg	0		Last Available: "2010-06"
 4605	frosty bottle of Goldschn&ouml;ckered of the sweet-tooth	0		Cold Spell Damage: +10, Candy Drop: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	bland sun-dried tofu	4	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	watered-down acceptable soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	acceptable watered-down soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	spinning jittery essential tofu	0		Last Available: "2010-08"
 4610	oxidized essential soy	0		Effect: "The Power of Positive Thinking", Effect Duration: 22, Last Available: "2010-08"
 4611	modified colloidal warmed blurry spinning essential cameraderie	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2010-08"
-4612	skewed huge souvenir drawing	0		Last Available: "2010-08"
+4612	huge skewed souvenir drawing	0		Last Available: "2010-08"
 4613	yellow map to the Magic Commune	0		Last Available: "2010-08"
 4614	tumbling Crown of Thrones of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Last Available: "2010-05"
-4615	spirit-forward bad special Cinco Mayo Lager	5	decent	Effect: "Rainbow Bright", Effect Duration: 15, Last Available: "2010-05"
+4615	special spirit-forward bad Cinco Mayo Lager	5	decent	Effect: "Rainbow Bright", Effect Duration: 15, Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	skewed pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4571,18 +4571,18 @@
 4623	activated quadruple-dry skewed chocolate-covered caviar	0		Effect: "Unusual Perspective", Effect Duration: 64, Last Available: "2020-09"
 4624	rotten green pawn cookie	3	crappy	Last Available: "2010-06"
 4625	pickled coffee pixie stick	1	EPIC	Effect: "Sweet Tooth", Effect Duration: 20, Last Available: "2010-06"
-4626	mirror squat superduperball	0		Last Available: "2010-06"
+4626	squat mirror superduperball	0		Last Available: "2010-06"
 4627	teal finger cuffs	0		Last Available: "2010-06"
 4628	blue parachute guy	0		Last Available: "2010-06"
 4629	Annie Oakley's plastic spider ring	0		Critical Hit Percent: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	plastic kazoo of Leguizamo	0		Monster Level: +20, Last Available: "2010-06"
 4631	smelly inflatable baseball bat	0		Stench Spell Damage: +10, Last Available: "2010-06"
-4632	Sherlock's wholesome googly-star hat	0		Maximum HP Percent: +10, Item Drop: +25, Familiar Effect: "atk", Last Available: "2010-06"
+4632	Sherlock's wholesome googly-star hat	0		Maximum HP Percent: +10, Item Drop: +25, Last Available: "2010-06", Familiar Effect: "atk"
 4633	Socratic googly-ball hat	0		Experience (Mysticality): +1, Item Drop: +5, Last Available: "2010-06"
 4634	boxer's googly-heart hat of terror	0		Muscle Percent: +10, Spooky Spell Damage: +10, Last Available: "2010-06"
 4635	gravedigger's sinister super-sweet boom box	0		Spell Damage: +10, Spooky Damage: +10, Four Songs, Last Available: "2010-06"
 4636	gray Game Grid valued membership card	0		Last Available: "2010-06"
-4637	blinking Van der Graaf sinister demon mask of the empath of horror	0		Familiar Weight: +5, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	blinking Van der Graaf sinister demon mask of the empath of horror	0		Familiar Weight: +5, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	maroon censurious scandalous razor-sharp streetfighting champion's belt	0		Weapon Damage Percent: +25, Sleaze Damage: +5, Sleaze Resistance: +3, Single Equip, Last Available: "2010-06"
 4639	chaotic experienced Space Trip safety headphones of the glutton	0		Experience: +2, Spell Critical Percent: +10, Food Drop: +100, Single Equip, Last Available: "2010-06"
 4640	squat dance instructor's LARP carp	0		Experience Percent (Moxie): +10
@@ -4594,8 +4594,8 @@
 4646	cyan Jeselnik's groovy Meteoid ice beam of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50, Sleaze Damage: +25, Last Available: "2011-12"
 4647	toasty extremely unsafe arcane researcher's Dungeon Fist gauntlet	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +100, Hot Damage: +5, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	spinning chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	spinning chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	perfumed ironic knit cap of the cheetah	0		Stench Resistance: +5, Initiative: +60, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4607,7 +4607,7 @@
 4659	dog trainer's blackberry galoshes	0		Experience (familiar): +1, Single Equip
 4660	narrow cool trout fang of the glutton	0		Moxie: +5, Food Drop: +100, Last Available: "2010-09"
 4661	stale poisonous caviar	4	decent	Last Available: "2010-09"
-4662	concentrated extra-quantum pulsating blurry wet venom duct	0		Effect: "Wings of the Grasshopper", Effect Duration: 54, Last Available: "2010-09"
+4662	concentrated extra-quantum blurry pulsating wet venom duct	0		Effect: "Wings of the Grasshopper", Effect Duration: 54, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	blurry censurious clever Ellsbury's skull	0		Maximum MP: +20, Sleaze Resistance: +3, Last Available: "2010-09"
 4665	flame-wreathed hot plate	0		Hot Spell Damage: +10, Damage Reduction: 3
@@ -4616,9 +4616,9 @@
 4668	baleful observational glasses	0		Spell Damage: +25
 4669	narrow prompt hilarious comedy prop	0		Adventures: +3
 4670	tumbling beer-scented teddy bear	0		
-4671	strong lousy booze-soaked cherry	5	decent	
+4671	lousy strong booze-soaked cherry	5	decent	
 4672	wobbly comfy pillow	0		
-4673	tasty diet marshmallow	1	awesome	
+4673	diet tasty marshmallow	1	awesome	
 4674	decent wobbly sponge cake	3	good	
 4675	weak artisanal gin-soaked blotter paper	2	EPIC	
 4676	tree-holed coin	0		
@@ -4627,8 +4627,8 @@
 4679	blinking volcanic ash	0		
 4680	smoked potsherd	0		
 4681	wizardly pottery shield	0		Mysticality: +25, Damage Reduction: 3, Last Available: "2010-09"
-4682	wobbly veiny educational pottery hat	0		Experience: +1, Maximum HP: +10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	pulsating stanky Van der Graaf pottery training pants	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	wobbly veiny educational pottery hat	0		Experience: +1, Maximum HP: +10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	pulsating stanky Van der Graaf pottery training pants	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	flame-wreathed pottery club	0		Hot Spell Damage: +10, Last Available: "2010-09"
 4685	smooth pottery yo-yo	0		Moxie: +15, Last Available: "2010-09"
 4686	skewed pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4640,8 +4640,8 @@
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
-4695	skewed tumbling affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	greasy curative Herculean Greatest American Pants	0		Experience (Muscle): +1, Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4695	tumbling skewed affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
+4696	greasy curative Herculean Greatest American Pants	0		Experience (Muscle): +1, Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	banded fossilized necklace	0		Damage Absorption: +100, Last Available: "2010-09"
 4698	squat imp air	0		
 4699	bus pass	0		
@@ -4660,27 +4660,27 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	snack-sized tasty lemon popsicle	2	awesome	
-4715	immense delicious fuchsia spinning popsicle	10	awesome	
+4715	delicious immense fuchsia spinning popsicle	10	awesome	
 4716	flavorless strawberry popsicle	3	decent	
 4717	stale liver popsicle	3	decent	
 4718	supercool mariachi hat	0		Moxie Percent: +20, Familiar Effect: "atk, cap 2"
 4719	perfumed Hollandaise helmet	0		Stench Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	bland bite-sized upside-down blue liver and let pie	1	decent	Last Available: "2010-10"
+4722	bite-sized bland upside-down blue liver and let pie	1	decent	Last Available: "2010-10"
 4723	moldy purple badass pie	4	crappy	Last Available: "2010-10"
 4724	normal huge shoo-fish pie	3	good	Last Available: "2010-10"
 4725	rotten diet fuchsia twirling piping organ pie	1	crappy	Last Available: "2010-10"
-4726	half-sized special rotten blue igloo pie	2	crappy	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2010-10"
+4726	special half-sized rotten blue igloo pie	2	crappy	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2010-10"
 4727	decent red jittery stomach turnover	3	good	Last Available: "2010-10"
-4728	half-sized decent wobbly dead lights pie	2	good	Last Available: "2010-10"
+4728	decent half-sized wobbly dead lights pie	2	good	Last Available: "2010-10"
 4729	spoiled throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	deadly stop shield	0		Weapon Damage: +5, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	kitty sheet music	0		Familiar Weight: +5
 4734	mirror rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
-4735	tumbling green prop sword	0		Familiar Weight: +5
+4735	green tumbling prop sword	0		Familiar Weight: +5
 4736	jittery tangle of rat tails	0		
 4737	bouncing lime green hardy beer-soaked mop	0		Maximum HP: +50
 4738	weak tolerable blurry day-old beer	2	good	
@@ -4692,15 +4692,15 @@
 4744	alkaline vacuum-sealed squat PlexiPips	0		Effect: "Yet tea", Effect Duration: 65
 4745	pressed upside-down Wax Flask	0		Effect: "Sludgesick", Effect Duration: 34
 4746	corrupted dry unsweetened Pain Dip	0		Effect: "Stop the Presses!", Effect Duration: 67
-4747	special stale ghostly bone meal	4	decent	Effect: "Metal Speed", Effect Duration: 30, Last Available: "2010-10"
+4747	stale special ghostly bone meal	4	decent	Effect: "Metal Speed", Effect Duration: 30, Last Available: "2010-10"
 4748	aged bone aperitif	4	awesome	Last Available: "2010-10"
 4749	rock-hard bonerang	0		Damage Reduction: 5, Last Available: "2010-10"
 4750	tumbling arcane researcher's bone and arrows	0		Experience Percent (Mysticality): +10, Last Available: "2010-10"
 4751	wholesome boning knife	0		Maximum HP Percent: +10, Last Available: "2010-10"
 4752	boxer's bone crusher	0		Muscle Percent: +10, Last Available: "2010-10"
 4753	avaricious bone spurs	0		Meat Drop: +30, Single Equip, Last Available: "2010-10"
-4754	fortified deadly bonedanna	0		Weapon Damage: +5, Damage Absorption: +60, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	skewed mirror experienced boneana hammock of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	fortified deadly bonedanna	0		Weapon Damage: +5, Damage Absorption: +60, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	skewed mirror experienced boneana hammock of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	concentrated candy skeleton	0		Effect: "Crying, Dying", Effect Duration: 69, Last Available: "2020-09"
@@ -4722,7 +4722,7 @@
 4806	twirling green Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	tumbling Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	cyan mirror Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	mirror cyan Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	decent mirror CRIMBCOIDS mints	3	good	Last Available: "2011-01"
 4819	maroon can of CRIMBCOLA	0		Last Available: "2010-12"
@@ -4746,20 +4746,20 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	jittery robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	delicious diet triangular CRIMBCOOKIE	1	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	gigantic yummy square CRIMBCOOKIE	6	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	yummy gigantic square CRIMBCOOKIE	6	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	twirling lion tamer's Annie Oakley's wizardly bindlestocking	0		Mysticality: +25, Critical Hit Percent: +20, Experience (familiar): +2, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	squat Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	purple The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	red smartaleck's Uncle Hobo's stocking cap of Leguizamo	0		Moxie Percent: +30, Monster Level: +20, Familiar Effect: "atk", Last Available: "2010-12"
+4845	red smartaleck's Uncle Hobo's stocking cap of Leguizamo	0		Moxie Percent: +30, Monster Level: +20, Last Available: "2010-12", Familiar Effect: "atk"
 4846	skewed electrified forbidden Uncle Hobo's epic beard	0		Spell Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2010-12"
-4847	veiny ruddy Uncle Hobo's gift baggy pants	0		Maximum HP Percent: +40, Maximum HP: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	veiny ruddy Uncle Hobo's gift baggy pants	0		Maximum HP Percent: +40, Maximum HP: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	executive clever Uncle Hobo's fingerless tinsel gloves	0		Maximum MP: +20, Meat Drop: +40, Single Equip, Last Available: "2010-12"
 4849	friendly stylish Uncle Hobo's highest bough	0		Moxie: +25, Familiar Weight: +3, Last Available: "2010-12"
 4850	narrow teal quilted wicked Uncle Hobo's belt	0		Spell Damage: +5, Damage Absorption: +40, Single Equip, Last Available: "2010-12"
 4851	concentrated chocolate cigar	0		Effect: "Cancer Rising", Effect Duration: 58, Last Available: "2010-12"
 4852	bouncing gift-a-pult of the ox	0		Muscle: +20, Last Available: "2010-12"
-4853	vacuum-sealed squat maroon narrow holly-flavored Hob-O	0		Effect: "Stuck-Up Hair", Effect Duration: 58, Last Available: "2020-09"
+4853	vacuum-sealed maroon narrow squat holly-flavored Hob-O	0		Effect: "Stuck-Up Hair", Effect Duration: 58, Last Available: "2020-09"
 4854	mirror CRIMBCO scrip	0		Last Available: "2011-01"
 4855	spinning Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
@@ -4767,7 +4767,7 @@
 4858	wobbly careful CRIMBCO lanyard	0		Monster Level: -10, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-4861	jittery spinning CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
+4861	spinning jittery CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	photocopier	0		Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	electrified studded beefy paperclip-on tie	0		Muscle: +10, Damage Absorption: +80, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-01"
-4869	savvy paperclip pants of extreme caution	0		Mysticality Percent: +20, Monster Level: -25, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	bouncing stanky paperclip turban of Calamity Jane of terror	0		Critical Hit Percent: +15, Stench Spell Damage: +25, Spooky Spell Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	savvy paperclip pants of extreme caution	0		Mysticality Percent: +20, Monster Level: -25, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	bouncing stanky paperclip turban of Calamity Jane of terror	0		Critical Hit Percent: +15, Stench Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	wool paperclip cape	0		Cold Resistance: +1, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	tarnished double-flattened incense bath ball	0		Effect: "Mint-Condition Breath", Effect Duration: 40, Last Available: "2011-01"
 4879	adjusted upside-down purple myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 38, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	acceptable weak CRIMBCO wine	2	good	Last Available: "2011-01"
+4881	weak acceptable CRIMBCO wine	2	good	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	decent toe jam toast	3	good	Last Available: "2011-01"
@@ -4880,14 +4880,14 @@
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
-4980	red tumbling Alice's Army Lanceman	0		Last Available: "2011-03"
+4980	tumbling red Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	tumbling Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
 4983	ghostly Alice's Army Cleric	0		Last Available: "2011-03"
 4984	Alice's Army Sniper	0		Last Available: "2011-03"
 4985	Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
-4987	jittery green Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
+4987	green jittery Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	cyan Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
@@ -4897,7 +4897,7 @@
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	gray Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	twirling Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
-4997	maroon jittery Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
+4997	jittery maroon Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	Alice's Army Foil Bowman	0		Last Available: "2011-03"
@@ -4907,14 +4907,14 @@
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
-5007	blurry squat Alice's Army Foil Martyr	0		Last Available: "2011-03"
+5007	squat blurry Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	reassuring card sleeve	0		Spooky Resistance: +1, Last Available: "2011-03"
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	upside-down Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	spoiled narrow wasabi pocky	3	crappy	Last Available: "2011-03"
-5014	delicious gigantic tobiko pocky	7	awesome	Last Available: "2011-03"
+5014	gigantic delicious tobiko pocky	7	awesome	Last Available: "2011-03"
 5015	bland teal natto pocky	4	decent	Last Available: "2011-03"
 5016	perfectly mixed wasabi-infused sake	4	EPIC	Last Available: "2011-03"
 5017	perfectly mixed tobiko-infused sake	4	EPIC	Last Available: "2011-03"
@@ -4949,9 +4949,9 @@
 5046	shaking astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	double-paned gravedigger's double-ice cap of doom	0		Spooky Damage: +10, Spooky Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	double-paned gravedigger's double-ice cap of doom	0		Spooky Damage: +10, Spooky Spell Damage: +50, Cold Resistance: +5, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	teal Van der Graaf wholesome thinker's double-ice box	0		Mysticality: +10, Maximum HP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-04"
-5051	gravedigger's frosty double-ice britches of James Dean	0		Experience (Moxie): +3, Cold Spell Damage: +10, Spooky Damage: +10, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	gravedigger's frosty double-ice britches of James Dean	0		Experience (Moxie): +3, Cold Spell Damage: +10, Spooky Damage: +10, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	shaking handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4967,24 +4967,24 @@
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
 5065	rotten spaghetti con calaveras	4	crappy	Last Available: "2011-04"
 5066	squat s'more gun	0		Last Available: "2011-04"
-5067	decent narrow gray popcorn	3	good	Last Available: "2011-04"
+5067	decent gray narrow popcorn	3	good	Last Available: "2011-04"
 5068	yummy miniature chaos popcorn	2	awesome	Last Available: "2011-04"
 5069	Jim Carey's supercool smooth hole	0		Moxie: +15, Moxie Percent: +20, Monster Level: +25, Last Available: "2011-04"
 5070	pulsating innuendo	0		Last Available: "2011-04"
 5071	rotten s'more	0	crappy	Last Available: "2011-04"
 5072	blurry diamond ring	0		Last Available: "2011-04"
-5073	weak hand-crafted Russian Ice	2	EPIC	Last Available: "2011-04"
+5073	hand-crafted weak Russian Ice	2	EPIC	Last Available: "2011-04"
 5074	clay ashtray of the boozehound	0		Booze Drop: +100, Damage Reduction: 3, Last Available: "2011-05"
 5075	shaking mirror groovy lanyard	0		Moxie Percent: +10, Single Equip, Last Available: "2011-05"
-5076	bouncing monster pants of Flo-Jo	0		Initiative: +100, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	bouncing monster pants of Flo-Jo	0		Initiative: +100, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	diffused tarnished Pok&euml;mann band-aid	0		Effect: "Flame-Retardant Trousers", Effect Duration: 32, Last Available: "2011-05"
-5079	shellacked Van der Graaf helmet of incineration	0		Damage Reduction: 7, Hot Spell Damage: +50, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	shellacked Van der Graaf helmet of incineration	0		Damage Reduction: 7, Hot Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	Van der Graaf crutch	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-05"
 5081	shock belt of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2011-05"
 5082	warmed Okee-Dokee soda	0		Effect: "Reedy Pipes", Effect Duration: 45, Last Available: "2011-05"
 5083	extremely unsafe rubber band gun	0		Weapon Damage Percent: +100, Last Available: "2011-05"
-5084	upside-down Newton's pin-stripe slacks	0		Experience (Mysticality): +3, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	upside-down Newton's pin-stripe slacks	0		Experience (Mysticality): +3, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	squat narrow occult gloves	0		Spell Damage Percent: +25, Single Equip, Last Available: "2011-05"
 5086	pickled correction fluid	0		Effect: "Crying, Dying", Effect Duration: 34, Last Available: "2011-05"
 5087	pulsating bouncing Annie Oakley's Pok&euml;mann figurine: Porkachu	0		Critical Hit Percent: +20, Single Equip, Last Available: "2011-05"
@@ -5002,9 +5002,9 @@
 5099	Socratic Pok&euml;mann figurine: Shoggoth	0		Experience (Mysticality): +1, Single Equip, Last Available: "2011-05"
 5100	Pok&euml;mann figurine: Frank of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2011-05"
 5101	twirling Pok&euml;mann figurine: Moog of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2011-05"
-5102	triple-dry pickled blinking blurry willyweed	0		Effect: "Funky Coal Patina", Effect Duration: 63, Last Available: "2011-05"
+5102	triple-dry pickled blurry blinking willyweed	0		Effect: "Funky Coal Patina", Effect Duration: 63, Last Available: "2011-05"
 5103	magnetized Nuclear Blastball	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 57, Last Available: "2011-05"
-5104	vacuum-sealed altered boiled wobbly purple blurry upside-down fish juice box	0		Effect: "Filled with Magic", Effect Duration: 15, Last Available: "2011-05"
+5104	vacuum-sealed altered boiled purple blurry wobbly upside-down fish juice box	0		Effect: "Filled with Magic", Effect Duration: 15, Last Available: "2011-05"
 5105	bouncing paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
 5107	artisanal tumbling Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
@@ -5015,14 +5015,14 @@
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
 5114	red stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
-5115	jittery mirror hedge trimmers	0		
+5115	mirror jittery hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	fuchsia reconstituted crow	0		Last Available: "2011-05"
-5118	skewed pulsating bird brain	0		
+5118	pulsating skewed bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	hardened grievous Admiral's hat of the businessman	0		Weapon Damage Percent: +50, Damage Reduction: 3, Meat Drop: +50, Familiar Effect: "atk", Last Available: "2011-05"
-5122	upside-down supercharged smooth aviator's cap of the sewer	0		Moxie: +15, Maximum MP Percent: +30, Stench Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	hardened grievous Admiral's hat of the businessman	0		Weapon Damage Percent: +50, Damage Reduction: 3, Meat Drop: +50, Last Available: "2011-05", Familiar Effect: "atk"
+5122	upside-down supercharged smooth aviator's cap of the sewer	0		Moxie: +15, Maximum MP Percent: +30, Stench Damage: +25, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	extremely unsafe slick mirrored aviator shades	0		Moxie: +10, Weapon Damage Percent: +100, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	ghostly clever veiny thinker's honey dipper	0		Mysticality: +10, Maximum HP: +10, Maximum MP: +20
 5149	flame-retardant baleful beefcake's honeybritches	0		Muscle: +25, Spell Damage: +25, Hot Resistance: +1, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	boxer's cool honeycap of the sweet-tooth	0		Moxie: +5, Muscle Percent: +10, Candy Drop: +100, Familiar Effect: "1xPotato, cap 43"
-5151	clever Moonthril Circlet	0		Maximum MP: +20, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	blurry sizzling Moonthril Greaves	0		Hot Damage: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	clever Moonthril Circlet	0		Maximum MP: +20, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	blurry sizzling Moonthril Greaves	0		Hot Damage: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	blinking boxer's Moonthril Flamberge	0		Muscle Percent: +10, Last Available: "2011-06"
 5154	hale Moonthril Longbow	0		Maximum HP: +20, Last Available: "2011-06"
 5155	sharpshooter's Moonthril Cuirass	0		Critical Hit Percent: +10, Softcore Only, Last Available: "2011-06"
@@ -5099,23 +5099,23 @@
 5196	narrow jittery Great S-Cape of the cougar	0		Moxie: +20, Softcore Only, Last Available: "2011-07"
 5197	ghostly Marvelous Unitard of Flo-Jo	0		Initiative: +100, Softcore Only, Last Available: "2011-07"
 5198	dried maroon spinning gooey paste	1	crappy	Last Available: "2011-08"
-5199	boiled squat huge wobbly beastly paste	1	good	Last Available: "2011-08"
+5199	boiled wobbly huge squat beastly paste	1	good	Last Available: "2011-08"
 5200	denatured paste	1	good	Effect: "Yes, Can Haz", Effect Duration: 30, Last Available: "2011-08"
 5201	dried bouncing ectoplasmic paste	1	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2011-08"
 5202	mixed red greasy paste	1	good	Last Available: "2011-08"
-5203	diluted squat teal bug paste	1	decent	Effect: "Bells in the Batfry", Effect Duration: 20, Last Available: "2011-08"
+5203	diluted teal squat bug paste	1	decent	Effect: "Bells in the Batfry", Effect Duration: 20, Last Available: "2011-08"
 5204	dried hippy paste	1	awesome	Last Available: "2011-08"
-5205	altered bouncing shaking orc paste	1	decent	Last Available: "2011-08"
+5205	altered shaking bouncing orc paste	1	decent	Last Available: "2011-08"
 5206	compressed blinking demonic paste	1	EPIC	Effect: "Alchemical, Brother", Effect Duration: 45, Last Available: "2011-08"
 5207	boiled blurry indescribably horrible paste	1	crappy	Effect: "Gemini Rising", Effect Duration: 5, Last Available: "2011-08"
 5208	pickled twirling spinning paste	1	good	Last Available: "2011-08"
-5209	denatured bouncing fuchsia upside-down goblin paste	1	decent	Effect: "Stemonitis Storm", Effect Duration: 20, Last Available: "2011-08"
+5209	denatured fuchsia bouncing upside-down goblin paste	1	decent	Effect: "Stemonitis Storm", Effect Duration: 20, Last Available: "2011-08"
 5210	mixed pirate paste	1	decent	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2011-08"
-5211	powdered olive spinning blurry chlorophyll paste	1	awesome	Last Available: "2011-08"
+5211	powdered blurry olive spinning chlorophyll paste	1	awesome	Last Available: "2011-08"
 5212	distilled paste	1	decent	Last Available: "2011-08"
 5213	dehydrated Mer-kin paste	1	good	Effect: "Mushroom Magicalness", Effect Duration: 40, Last Available: "2011-08"
 5214	distilled olive blurry twirling slimy paste	1	good	Last Available: "2011-08"
-5215	distilled olive narrow penguin paste	1	crappy	Effect: "Astral Shell", Effect Duration: 35, Last Available: "2011-08"
+5215	distilled narrow olive penguin paste	1	crappy	Effect: "Astral Shell", Effect Duration: 35, Last Available: "2011-08"
 5216	mixed blurry elemental paste	1	decent	Last Available: "2011-08"
 5217	dehydrated cosmic paste	1	awesome	Last Available: "2011-08"
 5218	pickled teal wobbly hobo paste	1	decent	Last Available: "2011-08"
@@ -5128,7 +5128,7 @@
 5225	The Bomb	0		Last Available: "2011-09"
 5226	blurry box of Familiar Jacks	0		Last Available: "2011-09"
 5227	delicious spirit-forward bucket of wine	5	awesome	Last Available: "2011-09"
-5228	enchanted stale small wobbly ultrafondue	2	decent	Effect: "Turtle Power", Effect Duration: 25, Last Available: "2011-09"
+5228	stale enchanted small wobbly ultrafondue	2	decent	Effect: "Turtle Power", Effect Duration: 25, Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5138,19 +5138,19 @@
 5235	skewed padded furry halo	0		Damage Absorption: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	blurry inspector's frosty halo	0		Item Drop: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	spinning green ghostly time halo of the glutton	0		Food Drop: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	practically non-alcoholic hand-crafted enchanted tumbling Lumineux Limnio	1	EPIC	Effect: "Boo Tea", Effect Duration: 25, Last Available: "2011-09"
-5239	special strong perfectly mixed Morto Moreto	5	EPIC	Effect: "Blessing of the Hot Linguine", Effect Duration: 25, Last Available: "2011-09"
+5238	hand-crafted enchanted practically non-alcoholic tumbling Lumineux Limnio	1	EPIC	Effect: "Boo Tea", Effect Duration: 25, Last Available: "2011-09"
+5239	special perfectly mixed strong Morto Moreto	5	EPIC	Effect: "Blessing of the Hot Linguine", Effect Duration: 25, Last Available: "2011-09"
 5240	perfectly mixed weak Temps Tempranillo	2	EPIC	Last Available: "2011-09"
-5241	tolerable distilled Bordeaux Marteaux	5	good	Last Available: "2011-09"
-5242	perfectly mixed practically non-alcoholic blue Fromage Pinotage	1	EPIC	Last Available: "2011-09"
+5241	distilled tolerable Bordeaux Marteaux	5	good	Last Available: "2011-09"
+5242	practically non-alcoholic perfectly mixed blue Fromage Pinotage	1	EPIC	Last Available: "2011-09"
 5243	lousy Beignet Milgranet	4	decent	Last Available: "2011-09"
 5244	acceptable maroon Muschat	3	good	Last Available: "2011-09"
 5245	low-calorie moldy cool jelly donut	1	crappy	Last Available: "2011-09"
 5246	gigantic decent pulsating shrapnel jelly donut	8	good	Last Available: "2011-09"
-5247	miniature fancy flavorless occult jelly donut	2	decent	Effect: "Deep-Seated Rage", Effect Duration: 30, Last Available: "2011-09"
+5247	flavorless fancy miniature occult jelly donut	2	decent	Effect: "Deep-Seated Rage", Effect Duration: 30, Last Available: "2011-09"
 5248	normal thyme jelly donut	3	good	Last Available: "2011-09"
 5249	normal fuchsia danish	3	good	Last Available: "2011-09"
-5250	flavorless immense spinning mirror smashed danish	6	decent	Last Available: "2011-09"
+5250	immense flavorless spinning mirror smashed danish	6	decent	Last Available: "2011-09"
 5251	diet spoiled forbidden danish	1	crappy	Last Available: "2011-09"
 5252	rotten cool cat claw	4	crappy	Last Available: "2011-09"
 5253	fancy decent blunt cat claw	3	good	Effect: "Always In Motion", Effect Duration: 20, Last Available: "2011-09"
@@ -5166,10 +5166,10 @@
 5263	double-concentrated modified fuchsia potion of the captain's hammer	0		Effect: "Trivia Master", Effect Duration: 30, Last Available: "2011-09"
 5264	colloidal potion of X-ray vision	0		Effect: "Oiled Skin", Effect Duration: 64, Last Available: "2011-09"
 5265	extra-alkaline oxidized blinking potion of the litterbox	0		Effect: "Fastbreaker", Effect Duration: 65, Last Available: "2011-09"
-5266	boiled yellow squat potion of animal rage	0		Effect: "Perfect Hair", Effect Duration: 25, Last Available: "2011-09"
+5266	boiled squat yellow potion of animal rage	0		Effect: "Perfect Hair", Effect Duration: 25, Last Available: "2011-09"
 5267	adjusted spinning olive potion of punctual companionship	0		Effect: "Spiky Frozen Hair", Effect Duration: 59, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
-5269	red ghostly bobcat grenade	0		Last Available: "2011-09"
+5269	ghostly red bobcat grenade	0		Last Available: "2011-09"
 5270	teal chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
@@ -5185,7 +5185,7 @@
 5282	wobbly rosewater-soaked dethklok	0		Stench Resistance: +3, Last Available: "2011-09"
 5283	blurry manspreader's glacial clock	0		Monster Level: +10, Last Available: "2011-09"
 5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
-5285	blinking upside-down d4	0		Last Available: "2011-09"
+5285	upside-down blinking d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	pulsating d8	0		Last Available: "2011-09"
 5288	upside-down d10	0		Last Available: "2011-09"
@@ -5194,15 +5194,15 @@
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
 5293	generic restorative potion	0		Last Available: "2011-09"
-5294	bouncing mirror narrow kobold treasure hoard	0		Last Available: "2011-09"
+5294	narrow bouncing mirror kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
-5296	upside-down spinning slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
+5296	spinning upside-down slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	tumbling dungeon dragon chest	0		Last Available: "2011-09"
-5298	thick tasty phish stick	5	awesome	Last Available: "2011-09"
+5298	tasty thick phish stick	5	awesome	Last Available: "2011-09"
 5299	narrow dog trainer's plastic vampire fangs of extreme caution of mayonnaise	0		Monster Level: -25, Experience (familiar): +1, Sleaze Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	green Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
-5302	mirror mirror maroon your own heart	0		Last Available: "2011-10"
+5302	mirror maroon mirror your own heart	0		Last Available: "2011-10"
 5303	purple Sword of the Brouhaha Prince of James Dean	0		Experience (Moxie): +3, Last Available: "2011-10"
 5304	reassuring wool electrified Chalice of the Malkovich Prince	0		Cold Resistance: +1, Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-10"
 5305	pulsating groovy Sceptre of the Torremolinos Prince	0		Moxie Percent: +10, Last Available: "2011-10"
@@ -5215,31 +5215,31 @@
 5312	cold-filtered quadruple-ionized super-ionized ghostly body paint	0		Effect: "Ass Over Teakettle", Effect Duration: 39, Last Available: "2011-10"
 5313	pressed cold-filtered necrotizing body spray	0		Effect: "Red Misty-Eyed", Effect Duration: 52, Last Available: "2011-10"
 5314	moist liquefied aerosolized gray bite-me-red lipstick	0		Effect: "Wistfully Nostalgic", Effect Duration: 14, Last Available: "2011-10"
-5315	diffused narrow squat whisker pencil	0		Effect: "Techno Bliss", Effect Duration: 68, Last Available: "2011-10"
+5315	diffused squat narrow whisker pencil	0		Effect: "Techno Bliss", Effect Duration: 68, Last Available: "2011-10"
 5316	quadruple-irradiated press-on ribs	0		Effect: "Super-Electrified", Effect Duration: 21, Last Available: "2011-10"
 5317	warmed irradiated Rattlin' Chains	0		Effect: "Human-Insect Hybrid", Effect Duration: 23, Last Available: "2011-10"
 5318	nitrogenated energized Gummy Brains	0		Effect: "Wasabi With You", Effect Duration: 59, Last Available: "2011-10"
 5319	warmed Blood 'n' Plenty	0		Effect: "Dance Interpreter", Effect Duration: 36, Last Available: "2011-10"
 5320	enhanced double-activated alkaline Lobos Mints	0		Effect: "Truly Gritty", Effect Duration: 23, Last Available: "2011-10"
 5321	quantum pulsating Sweet Sword	0		Effect: "Riboflavin'", Effect Duration: 69, Last Available: "2011-10"
-5322	perfectly mixed weak Ecto-Cooler	2	EPIC	Last Available: "2011-10"
-5323	perfectly mixed spirit-forward Bartles and BRAAAINS wine cooler	5	EPIC	Last Available: "2011-10"
+5322	weak perfectly mixed Ecto-Cooler	2	EPIC	Last Available: "2011-10"
+5323	spirit-forward perfectly mixed Bartles and BRAAAINS wine cooler	5	EPIC	Last Available: "2011-10"
 5324	acceptable Blood Light	3	good	Last Available: "2011-10"
 5325	drinkable twirling Silver Bullet beer	4	good	Last Available: "2011-10"
 5326	weak acceptable Bone's Farm &quot;wine&quot;	2	good	Last Available: "2011-10"
 5327	tumbling ghost protocol	0		Last Available: "2011-10"
 5328	aerosolized quadruple-moist twirling lime green sorority brain	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 46, Last Available: "2011-10"
-5329	super-electrified narrow maroon Nightstalker perfume	0		Effect: "From Nantucket", Effect Duration: 33, Last Available: "2011-10"
+5329	super-electrified maroon narrow Nightstalker perfume	0		Effect: "From Nantucket", Effect Duration: 33, Last Available: "2011-10"
 5330	quantum olive drum of pomade	0		Effect: "Healthy Bronze Glow", Effect Duration: 39, Last Available: "2011-10"
 5331	purple throwing bone	0		Last Available: "2011-10"
 5332	horrifying extra-see-thru nightie	0		Spooky Damage: +25, Last Available: "2011-10"
-5333	double-paned BRAINS shorts of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +5, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	double-paned BRAINS shorts of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +5, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	bouncing sage Mesmereyes&trade; contact lenses	0		Mysticality Percent: +10, Single Equip, Last Available: "2011-10"
 5335	blurry Newton's scrunchie	0		Experience (Mysticality): +3, Single Equip, Last Available: "2011-10"
-5336	Sinatra's smartaleck's extremely skinny jeans	0		Moxie Percent: +30, Experience (Moxie): +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	resourceful The Necbromancer's Hat of Gandalf	0		Maximum MP: +50, Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	Sinatra's smartaleck's extremely skinny jeans	0		Moxie Percent: +30, Experience (Moxie): +5, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	resourceful The Necbromancer's Hat of Gandalf	0		Maximum MP: +50, Spell Critical Percent: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	wholesome The Necbromancer's Stein of the wise owl of bravery	0		Mysticality: +20, Maximum HP Percent: +10, Spooky Resistance: +5, Last Available: "2011-10"
-5339	careful crafty experienced The Necbromancer's Shorts	0		Experience: +2, Maximum MP: +10, Monster Level: -10, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	careful crafty experienced The Necbromancer's Shorts	0		Experience: +2, Maximum MP: +10, Monster Level: -10, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	mansplainer's therapeutic brawny The Necbromancer's Wizard Staff	0		Muscle Percent: +20, Monster Level: +15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	drinkable green The Cooler Out of Space	4	good	Last Available: "2011-10"
@@ -5277,7 +5277,7 @@
 5374	aromatic plastic abominable fudgeman	0		Stench Resistance: +1, Last Available: "2011-12"
 5375	scandalous plastic colollilossus	0		Sleaze Damage: +5, Last Available: "2011-12"
 5376	skewed flame-retardant Rosewater's plastic Big Candy	0		Mysticality Percent: +30, Hot Resistance: +1, Last Available: "2011-12"
-5377	blurry purple The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
+5377	purple blurry The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	distilled pulsating groose grease	1	good	Effect: "L'instinct F&eacute;lin", Effect Duration: 40, Last Available: "2012-12"
 5380	ghostly lollipop stick	0		Last Available: "2011-11"
@@ -5298,7 +5298,7 @@
 5395	peppermint sprout	0		Last Available: "2011-11"
 5396	polymerized enhanced peppermint twist	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 30, Last Available: "2011-11"
 5397	stale peppermint patty	3	decent	Last Available: "2011-11"
-5398	green huge peppermint crook	0		Last Available: "2011-11"
+5398	huge green peppermint crook	0		Last Available: "2011-11"
 5399	blurry peppermint rhino baby	0		Last Available: "2011-11"
 5400	skewed lime green candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
@@ -5306,14 +5306,14 @@
 5403	pulsating Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	tumbling olive chaotic curative brainy cane-mail shirt	0		Mysticality: +5, Spell Critical Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-12"
-5406	manspreader's Sinatra's slick cane-mail pants	0		Moxie: +10, Experience (Moxie): +5, Monster Level: +10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	manspreader's Sinatra's slick cane-mail pants	0		Moxie: +10, Experience (Moxie): +5, Monster Level: +10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	mediocre wobbly Vodka Matryoshka	4	decent	Last Available: "2011-12"
 5408	artisanal shaking blinking Gin Mint	3	EPIC	Last Available: "2011-12"
 5409	smooth Tequiz Navidad	3	awesome	Last Available: "2011-12"
 5410	hand-crafted Mint Yulep	4	EPIC	Last Available: "2011-12"
 5411	lousy high-proof Crimbojito	8	decent	Last Available: "2011-12"
 5412	perfectly mixed triple-distilled gray Sangria de Menthe	8	EPIC	Last Available: "2011-12"
-5413	wobbly skewed wobbly candycaine powder	0		Last Available: "2011-12"
+5413	wobbly wobbly skewed candycaine powder	0		Last Available: "2011-12"
 5414	pulsating squat licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	frozen ghostly licorice root	0		Effect: "Cold Jellied", Effect Duration: 35, Last Available: "2011-12"
 5416	cold-filtered diffused blurry banana supersucker	0		Effect: "There Is A Spoon", Effect Duration: 54, Last Available: "2011-11"
@@ -5327,15 +5327,15 @@
 5424	greedy kumquartz ring	0		Meat Drop: +20, Single Equip, Last Available: "2011-11"
 5425	zippy strawberyl necklace	0		Initiative: +20, Single Equip, Last Available: "2011-11"
 5426	blinking sucker bucket of horror of bravery	0		Spooky Spell Damage: +25, Spooky Resistance: +5, Last Available: "2011-11"
-5427	upside-down sucker hakama of the ox	0		Muscle: +20, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	sucker kabuto	0		Item Drop: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	upside-down sucker hakama of the ox	0		Muscle: +20, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	sucker kabuto	0		Item Drop: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	sucker tachi of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
 5432	wobbly grape troll doll	0		Last Available: "2011-11"
 5433	gray raspberry troll doll	0		Last Available: "2011-11"
 5434	DNOTC Box	0		Last Available: "2017-12"
-5435	tumbling ghostly fudgecule	0		Last Available: "2011-11"
+5435	ghostly tumbling fudgecule	0		Last Available: "2011-11"
 5436	diffused fudge lily	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 12, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	flattened bouncing fluid of fudge-finding	0		Effect: "I See Everything Thrice!", Effect Duration: 66, Last Available: "2011-11"
@@ -5344,7 +5344,7 @@
 5441	squat wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
-5444	polymerized diffused twirling lime green mirror devilish folio	0		Effect: "Turtle Titters", Effect Duration: 57, Last Available: "2012-12"
+5444	polymerized diffused lime green mirror twirling devilish folio	0		Effect: "Turtle Titters", Effect Duration: 57, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	blurry jar full of wind	0		Last Available: "2012-12"
 5447	spinning dangerous jerkcicle	0		Last Available: "2012-12"
@@ -5356,17 +5356,17 @@
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
-5456	jittery huge gummi ingot	0		Last Available: "2011-11"
+5456	huge jittery gummi ingot	0		Last Available: "2011-11"
 5457	super-flattened dry yellow skewed Fudgie Roll	0		Effect: "Pie in the Sky", Effect Duration: 33, Last Available: "2011-11"
 5458	moldy miniature fudge bunny	2	crappy	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	curative fudgecycle of the scaredy-cat of the sweet-tooth	0		Monster Level: -15, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-11"
-5461	tumbling yellow fudge cube	0		Last Available: "2011-11"
+5461	yellow tumbling fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	spinning Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	Vulcanized moist resolution: be wealthier	0		Effect: "Graham Crackling", Effect Duration: 49, Last Available: "2012-01"
 5465	chilled extra-activated resolution: be happier	0		Effect: "Boo Tea", Effect Duration: 42, Last Available: "2012-01"
-5466	nitrogenated spinning twirling resolution: be stronger	0		Effect: "Once Bitten Twice Fried", Effect Duration: 37, Last Available: "2012-01"
+5466	nitrogenated twirling spinning resolution: be stronger	0		Effect: "Once Bitten Twice Fried", Effect Duration: 37, Last Available: "2012-01"
 5467	modified upside-down resolution: be smarter	0		Effect: "Spooky Jellied", Effect Duration: 55, Last Available: "2012-01"
 5468	non-corrupted denatured resolution: be sexier	0		Effect: "Icy Demeanor", Effect Duration: 17, Last Available: "2012-01"
 5469	double-ionized fuchsia resolution: be feistier	0		Effect: "Perfect Hair", Effect Duration: 23, Last Available: "2012-01"
@@ -5383,7 +5383,7 @@
 5480	small moldy gummi bear	2	crappy	Last Available: "2011-11"
 5481	thick bland blinking gummi bear	5	decent	Last Available: "2011-11"
 5482	miniature normal twirling drunki-bear	2	good	Last Available: "2011-11"
-5483	bland enchanted drunki-bear	4	decent	Effect: "Pronounced Potency", Effect Duration: 20, Last Available: "2011-11"
+5483	enchanted bland drunki-bear	4	decent	Effect: "Pronounced Potency", Effect Duration: 20, Last Available: "2011-11"
 5484	tiny normal wobbly drunki-bear	1	good	Last Available: "2011-11"
 5485	gummi bowtie of the businessman	0		Meat Drop: +50, Last Available: "2011-11"
 5486	hale fudge pocket square	0		Maximum HP: +20, Last Available: "2011-11"
@@ -5398,17 +5398,17 @@
 5495	electrified bouncing gummi ammonite	0		Effect: "Stuck-Up Hair", Effect Duration: 55, Last Available: "2011-11"
 5496	aerosolized double-frozen extra-polarized ghostly gummi belemnite	0		Effect: "Wreathed in Merriment", Effect Duration: 21, Last Available: "2011-11"
 5497	twirling jittery all-year sucker	0		Last Available: "2011-11"
-5498	huge tumbling heart of dark chocolate	0		Last Available: "2011-11"
-5499	spinning executive Big Candy's tophat of the detective	0		Item Drop: +20, Meat Drop: +40, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5498	tumbling huge heart of dark chocolate	0		Last Available: "2011-11"
+5499	spinning executive Big Candy's tophat of the detective	0		Item Drop: +20, Meat Drop: +40, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	mirror Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	spinning squat Jackass Plumber home game	0		Last Available: "2011-11"
-5502	squat twirling Trivial Avocations board game	0		Last Available: "2011-11"
+5502	twirling squat Trivial Avocations board game	0		Last Available: "2011-11"
 5503	purple Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	narrow blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	adequate bite-sized jerky coins	1	good	Last Available: "2011-11"
+5506	bite-sized adequate jerky coins	1	good	Last Available: "2011-11"
 5507	lousy Go-Wassail	4	decent	Last Available: "2011-11"
-5508	nitrogenated wet jittery olive Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Okee-Dokee Computer", Effect Duration: 27, Last Available: "2011-11"
+5508	nitrogenated wet olive jittery Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Okee-Dokee Computer", Effect Duration: 27, Last Available: "2011-11"
 5509	diffused bottle of bubbles	0		Effect: "Red Around the Gills", Effect Duration: 37, Last Available: "2011-11"
 5510	ionized super-moist wind-up meatcar	0		Effect: "Mighty Shout", Effect Duration: 56, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
@@ -5421,7 +5421,7 @@
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
-5521	gray narrow pog #07 (orcish frat boy)	0		Last Available: "2011-11"
+5521	narrow gray pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	skewed pog #08 (hellion)	0		Last Available: "2011-11"
 5523	olive pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	polymerized boiled liquefied Atomic Pop	0		Effect: "Cool Spirit", Effect Duration: 39, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	red whimpering willow bark	0		Last Available: "2012-12"
-5529	bland jumbo berries of suffering	5	decent	Last Available: "2012-12"
+5529	jumbo bland berries of suffering	5	decent	Last Available: "2012-12"
 5530	activated liquefied super-adjusted baobab sap	0		Effect: "Larger", Effect Duration: 15, Last Available: "2012-12"
 5531	spinning cup of hickory chicory	0		Last Available: "2012-12"
 5532	mirror magnolia blossom	0		Last Available: "2012-12"
@@ -5453,17 +5453,17 @@
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	curative Trusty	0		HP Regen Min: 3, HP Regen Max: 5
-5553	squat skewed blue can of Rain-Doh	0		Last Available: "2012-02"
+5553	blue squat skewed can of Rain-Doh	0		Last Available: "2012-02"
 5554	mirror empty Rain-Doh can	0		Last Available: "2012-02"
 5555	enhanced galvanized fireclutch	0		Effect: "Just Aged Enough", Effect Duration: 49
 5556	upside-down dog trainer's Rain-Doh wings of Gandalf	0		Spell Critical Percent: +20, Experience (familiar): +1, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	greasy Rain-Doh laser gun	0		Sleaze Spell Damage: +10, Item Drop: +5, Softcore Only, Last Available: "2012-02"
-5559	family-friendly Rain-Doh lantern of the brazier	0		Hot Spell Damage: +25, Sleaze Resistance: +1, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
-5560	pulsating blinking Rain-Doh balls	0		Last Available: "2012-02"
+5559	family-friendly Rain-Doh lantern of the brazier	0		Hot Spell Damage: +25, Sleaze Resistance: +1, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5560	blinking pulsating Rain-Doh balls	0		Last Available: "2012-02"
 5561	lime green Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	pulsating squat ribald Rain-Doh violet bo of mayonnaise	0		Sleaze Damage: +10, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2012-02"
-5563	green twirling Rain-Doh box	0		Last Available: "2012-02"
+5563	twirling green Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	toothsome huge PB&BP	3	awesome	
 5566	small rotten club sandwich	2	crappy	
@@ -5480,38 +5480,38 @@
 5577	aged Slippery Knob	3	awesome	Last Available: "2012-03"
 5578	artisanal special blurry Flaming Knob	4	EPIC	Effect: "Sharp Weapon", Effect Duration: 25, Last Available: "2012-03"
 5579	bad Grasshopper	3	decent	Last Available: "2012-03"
-5580	practically non-alcoholic bad Locust	1	decent	Last Available: "2012-03"
+5580	bad practically non-alcoholic Locust	1	decent	Last Available: "2012-03"
 5581	mediocre Plague of Locusts	3	decent	Last Available: "2012-03"
-5582	weak delicious Red Dwarf	2	awesome	Last Available: "2012-03"
+5582	delicious weak Red Dwarf	2	awesome	Last Available: "2012-03"
 5583	bad Golden Mean	3	decent	Last Available: "2012-03"
 5584	practically non-alcoholic bad Green Giant	1	decent	Last Available: "2012-03"
 5585	hand-crafted Aye Aye	3	EPIC	Last Available: "2012-03"
 5586	fancy hand-crafted bouncing Aye Aye, Captain	4	EPIC	Effect: "Amorous Avarice", Effect Duration: 5, Last Available: "2012-03"
 5587	tolerable Aye Aye, Tooth Tooth	4	good	Last Available: "2012-03"
 5588	delicious Humanitini	3	awesome	Last Available: "2012-03"
-5589	triple-distilled hand-crafted More Humanitini than Humanitini	7	EPIC	Last Available: "2012-03"
-5590	fortified enchanted lousy Oh, the Humanitini	5	decent	Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2012-03"
+5589	hand-crafted triple-distilled More Humanitini than Humanitini	7	EPIC	Last Available: "2012-03"
+5590	enchanted fortified lousy Oh, the Humanitini	5	decent	Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2012-03"
 5591	mediocre Great Older Fashioned	3	decent	Last Available: "2012-03"
-5592	aged high-proof Fuzzy Tentacle	6	awesome	Last Available: "2012-03"
+5592	high-proof aged Fuzzy Tentacle	6	awesome	Last Available: "2012-03"
 5593	aged irresponsibly strong Crazymaker	7	awesome	Last Available: "2012-03"
 5594	smooth Zoodriver	4	awesome	Last Available: "2012-03"
-5595	weak lousy fancy Sloe Comfortable Zoo	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2012-03"
-5596	watered-down mediocre Sloe Comfortable Zoo on Fire	2	decent	Last Available: "2012-03"
+5595	lousy weak fancy Sloe Comfortable Zoo	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2012-03"
+5596	mediocre watered-down Sloe Comfortable Zoo on Fire	2	decent	Last Available: "2012-03"
 5597	acceptable boozy Suffering Sinner	5	good	Last Available: "2012-03"
 5598	delicious Suppurating Sinner	4	awesome	Last Available: "2012-03"
 5599	hand-crafted fuchsia Sizzling Sinner	3	EPIC	Last Available: "2012-03"
-5600	aged shaking narrow Firewater	3	awesome	Last Available: "2012-03"
-5601	weak enchanted smooth Earth and Firewater	2	awesome	Effect: "Orc Chops", Effect Duration: 50, Last Available: "2012-03"
-5602	strong tolerable Earth, Wind and Firewater	5	good	Last Available: "2012-03"
+5600	aged narrow shaking Firewater	3	awesome	Last Available: "2012-03"
+5601	smooth weak enchanted Earth and Firewater	2	awesome	Effect: "Orc Chops", Effect Duration: 50, Last Available: "2012-03"
+5602	tolerable strong Earth, Wind and Firewater	5	good	Last Available: "2012-03"
 5603	artisanal Slimosa	4	EPIC	Last Available: "2012-03"
-5604	practically non-alcoholic mediocre twirling Extra-slimy Slimosa	1	decent	Last Available: "2012-03"
+5604	mediocre practically non-alcoholic twirling Extra-slimy Slimosa	1	decent	Last Available: "2012-03"
 5605	perfectly mixed Slimebite	3	EPIC	Last Available: "2012-03"
 5606	bad weak spinning Cement Mixer	2	decent	Last Available: "2012-03"
-5607	fancy artisanal Jackhammer	3	EPIC	Effect: "Bolts about Candy", Effect Duration: 20, Last Available: "2012-03"
+5607	artisanal fancy Jackhammer	3	EPIC	Effect: "Bolts about Candy", Effect Duration: 20, Last Available: "2012-03"
 5608	drinkable Dump Truck	3	good	Last Available: "2012-03"
 5609	hand-crafted irresponsibly strong squat Fauna Libre	9	EPIC	Last Available: "2012-03"
-5610	weak perfectly mixed Chakra Libre	2	EPIC	Last Available: "2012-03"
-5611	practically non-alcoholic aged Aura Libre	1	awesome	Last Available: "2012-03"
+5610	perfectly mixed weak Chakra Libre	2	EPIC	Last Available: "2012-03"
+5611	aged practically non-alcoholic Aura Libre	1	awesome	Last Available: "2012-03"
 5612	aged irresponsibly strong Sazerorc	10	awesome	Last Available: "2012-03"
 5613	bad Sazuruk-hai	4	decent	Last Available: "2012-03"
 5614	lousy extra-dry Flaming Sazerorc	5	decent	Last Available: "2012-03"
@@ -5521,9 +5521,9 @@
 5618	artisanal green Mohobo	4	EPIC	Last Available: "2012-03"
 5619	drinkable Moonshine Mohobo	3	good	Last Available: "2012-03"
 5620	delicious high-proof Flaming Mohobo	8	awesome	Last Available: "2012-03"
-5621	extra-dry delicious Drunken Philosopher	5	awesome	Last Available: "2012-03"
+5621	delicious extra-dry Drunken Philosopher	5	awesome	Last Available: "2012-03"
 5622	hand-crafted twirling Drunken Neurologist	3	EPIC	Last Available: "2012-03"
-5623	watered-down tolerable upside-down Drunken Astrophysicist	2	good	Last Available: "2012-03"
+5623	tolerable watered-down upside-down Drunken Astrophysicist	2	good	Last Available: "2012-03"
 5624	delicious Dark & Starry	3	awesome	Last Available: "2012-03"
 5625	artisanal green Black Hole	3	EPIC	Last Available: "2012-03"
 5626	tolerable wobbly spinning Event Horizon	4	good	Last Available: "2012-03"
@@ -5531,7 +5531,7 @@
 5628	artisanal Herring Wallbanger	3	EPIC	Last Available: "2012-03"
 5629	tolerable teal Herringtini	4	good	Last Available: "2012-03"
 5630	artisanal Lollipop Drop	4	EPIC	Last Available: "2012-03"
-5631	fancy irresponsibly strong acceptable blurry Candy Alexander	8	good	Effect: "Frozen Shoulders", Effect Duration: 50, Last Available: "2012-03"
+5631	acceptable irresponsibly strong fancy blurry Candy Alexander	8	good	Effect: "Frozen Shoulders", Effect Duration: 50, Last Available: "2012-03"
 5632	weak acceptable Candicaine	2	good	Last Available: "2012-03"
 5633	perfectly mixed pulsating Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	perfectly mixed Flying Caipiranha	4	EPIC	Last Available: "2012-03"
@@ -5548,14 +5548,14 @@
 5645	the Nostril of the Serpent	0		
 5646	teal calendar fragment	0		
 5647	red calendar of the pedagogue	0		Experience: +3, Damage Reduction: 4
-5648	jittery sinister Boris's Helm of the brute	0		Muscle Percent: +30, Spell Damage: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	jittery sinister Boris's Helm of the brute	0		Muscle Percent: +30, Spell Damage: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	huge tumbling stanky studded staph of homophones	0		Damage Absorption: +80, Stench Spell Damage: +25
-5650	flame-retardant hale banded Boris's Helm (askew)	0		Damage Absorption: +100, Maximum HP: +20, Hot Resistance: +1, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	flame-retardant hale banded Boris's Helm (askew)	0		Damage Absorption: +100, Maximum HP: +20, Hot Resistance: +1, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	moldy nailswurst	4	crappy	
-5655	acceptable jittery fuchsia used beer	4	good	
+5655	acceptable fuchsia jittery used beer	4	good	
 5656	olive Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5569,17 +5569,17 @@
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	tumbling lime green puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
-5669	jittery upside-down club	0		
+5669	upside-down jittery club	0		
 5670	special stale half-sized fettucini &eacute;pines Inconnu	2	decent	Effect: "Cool Spirit", Effect Duration: 15
 5671	delicious fuchsia slap and slap again	4	awesome	
 5672	gunpowder burrito	2	good	
 5673	purple twirling beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	compressed maroon watered-down Red Minotaur	1		
-5676	gray spinning pool torpedo	0		Last Available: "2012-05"
-5677	twirling dog trainer's Ze&trade; goggles	0		Experience (familiar): +1, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5676	spinning gray pool torpedo	0		Last Available: "2012-05"
+5677	twirling dog trainer's Ze&trade; goggles	0		Experience (familiar): +1, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	manspreader's stylish swimsuit of horror	0		Monster Level: +10, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	manspreader's stylish swimsuit of horror	0		Monster Level: +10, Spooky Spell Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	wobbly lost key	0		Last Available: "2012-05"
 5681	adequate tumbling P.B.L.T.	3	good	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5589,7 +5589,7 @@
 5686	quantum nanopolymer spider web	0		
 5687	shaking bugbear autopsy tweezers	0		
 5688	pulsating Sinatra's UV monocular	0		Experience (Moxie): +5, Single Equip
-5689	tumbling skewed drone self-destruct chip	0		
+5689	skewed tumbling drone self-destruct chip	0		
 5690	bouncing Jeff Goldblum larva	0		
 5691	blurry pacification grenade	0		
 5692	foul-smelling quantum disintegrator pistol	0		Stench Damage: +10
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	squat crayon shavings	0		Last Available: "2012-06"
 5704	narrow wax bugbear	0		Last Available: "2012-06"
-5705	blurry shaking beefcake's wax hat of the cougar	0		Muscle: +25, Moxie: +20, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	nasty electrified wax pants	0		Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	blurry shaking beefcake's wax hat of the cougar	0		Muscle: +25, Moxie: +20, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	nasty electrified wax pants	0		Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	blue FDKOL commendation	0		Last Available: "2012-07"
 5708	activated deionized pulsating drop of water-37	0		Effect: "Aquarius Rising", Effect Duration: 15, Last Available: "2012-07"
-5709	jittery lime green lightning-fast energetic fireman's helmet	0		Maximum MP Percent: +20, Initiative: +40, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	jittery lime green lightning-fast energetic fireman's helmet	0		Maximum MP Percent: +20, Initiative: +40, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	upside-down fire axe	0		Item Drop: +5, Last Available: "2012-07"
 5713	jittery knitted healthy fire extinguisher of extreme caution	0		Maximum HP Percent: +20, Monster Level: -25, Cold Resistance: +3, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5624,11 +5624,11 @@
 5723	quantum energized bottle of fire	0		Effect: "Neuromancy", Effect Duration: 55, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	wobbly hot daub	0		Last Available: "2012-07"
-5726	stiffened hot daub bun of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	double-paned Socratic hot daub stand	0		Experience (Mysticality): +1, Cold Resistance: +5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	stiffened hot daub bun of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	double-paned Socratic hot daub stand	0		Experience (Mysticality): +1, Cold Resistance: +5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	teal gravedigger's foot-long hot daub of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	adequate miniature angst burger	2	good	
+5730	miniature adequate angst burger	2	good	
 5731	enchanted tolerable practically non-alcoholic 5-hour acrimony	1	good	Effect: "Mortarfied", Effect Duration: 30
 5732	blank note	0		
 5733	eerily silent box	0		
@@ -5638,22 +5638,22 @@
 5737	cold-filtered ionized daub-breaker	0		Effect: "Painted-On Bikini", Effect Duration: 35, Last Available: "2020-09"
 5738	red brawny Camp Scout backpack	0		Muscle Percent: +20, Softcore Only, Last Available: "2012-07"
 5739	jittery CSA fire-starting kit	0		Last Available: "2012-07"
-5740	adequate snack-sized blurry bag of GORP	2	good	Last Available: "2012-07"
+5740	snack-sized adequate blurry bag of GORP	2	good	Last Available: "2012-07"
 5741	practically non-alcoholic bad water purification pills	1	decent	Last Available: "2012-07"
 5742	tumbling Camp Scout pup tent	0		Last Available: "2012-07"
 5743	artisanal CSA scoutmaster's &quot;water&quot;	4	EPIC	Last Available: "2012-07"
-5744	delicious jumbo bag of GORF	5	awesome	Last Available: "2012-07"
+5744	jumbo delicious bag of GORF	5	awesome	Last Available: "2012-07"
 5745	wobbly CSA discount card	0		Last Available: "2020-09"
 5746	rotten bag of QWOP	4	crappy	Last Available: "2012-07"
 5747	tarnished ghostly CSA bravery badge	0		Effect: "Jacked In", Effect Duration: 48, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	practically non-alcoholic artisanal CSA cheerfulness ration	1	EPIC	Last Available: "2012-07"
+5749	artisanal practically non-alcoholic CSA cheerfulness ration	1	EPIC	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	flavorless snack-sized crappy brain	2	decent	
 5753	decent decent brain	4	good	
 5754	enchanted tasty shaking olive good brain	3	awesome	Effect: "Cranberry Cordiality", Effect Duration: 10
-5755	flavorless big boss brain	5	decent	
+5755	big flavorless boss brain	5	decent	
 5756	delicious red hunter brain	4	awesome	
 5758	lion tamer's MacGyver's Staff of Holiday Sensations of Gandalf	0		Maximum MP: +100, Spell Critical Percent: +20, Experience (familiar): +2, Last Available: "2011-11"
 5759	mansplainer's dangerous staff	0		Weapon Damage: +10, Monster Level: +15
@@ -5665,16 +5665,16 @@
 5765	ruddy fuzzy earmuffs	0		Maximum HP Percent: +40, Item Drop: +5, Familiar Effect: "1.5xVolley, cap 32"
 5766	smartaleck's fuzzy montera of Leguizamo of the blizzard	0		Moxie Percent: +30, Monster Level: +20, Cold Spell Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	tumbling narrow gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	narrow tumbling gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	narrow Thwaitgold maggot statuette	0		
 5774	pulsating talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	Barney's rake of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +5
-5778	spoiled diet maroon idiot brain	1	crappy	
+5778	diet spoiled maroon idiot brain	1	crappy	
 5779	padded keel-haulin' knife	0		Damage Absorption: +20
 5780	ice cream scoop of incineration	0		Hot Spell Damage: +50
 5781	bad green narrow soft echo eyedrop antidote martini	3	decent	
@@ -5710,7 +5710,7 @@
 5811	modified pulsating ghostly tube of lipstick	0		Effect: "Slimed Stomach", Effect Duration: 46
 5812	dry cold-filtered nitrogenated shaking skelelton spine	0		Effect: "Inebriate Pride", Effect Duration: 14
 5813	chilled polarized cyan smut orc sunglasses	0		Effect: "Gummi Badass", Effect Duration: 42
-5814	unsweetened corrupted green ghostly narrow blob of acid	0		Effect: "Feline Ferocity", Effect Duration: 20
+5814	unsweetened corrupted ghostly narrow green blob of acid	0		Effect: "Feline Ferocity", Effect Duration: 20
 5815	Vulcanized spinning flayed mind	0		Effect: "Salamander In Your Stomach", Effect Duration: 54
 5816	activated deionized ionized kobold kibble	0		Effect: "Warm Shoulders", Effect Duration: 37
 5817	anodized cyan forest spirit rattle	0		Effect: "Oleaginous Soles", Effect Duration: 55
@@ -5725,18 +5725,18 @@
 5826	moist ghostly zombie hollandaise	0		Effect: "Red Misty-Eyed", Effect Duration: 49
 5827	electrified Vulcanized gray skeletal banana	0		Effect: "Cancer Rising", Effect Duration: 26
 5828	altered Vulcanized wet gilt perfume bottle	0		Effect: "Punchy, Murdery", Effect Duration: 63
-5829	corrupted ghostly pulsating janglin' bones	0		Effect: "Berry Elemental", Effect Duration: 54
-5830	pickled activated ghostly purple pygmy papers	0		Effect: "Mo' Hobo", Effect Duration: 38
+5829	corrupted pulsating ghostly janglin' bones	0		Effect: "Berry Elemental", Effect Duration: 54
+5830	pickled activated purple ghostly pygmy papers	0		Effect: "Mo' Hobo", Effect Duration: 38
 5831	denatured altered tumbling pygmy dart	0		Effect: "Just Aged Enough", Effect Duration: 60
 5832	activated diffused secret mummy herbs and spices	0		Effect: "Hood Ridin'", Effect Duration: 69
-5833	ionized altered ghostly huge brigand brittle	0		Effect: "Strange Mental Acuity", Effect Duration: 39
+5833	ionized altered huge ghostly brigand brittle	0		Effect: "Strange Mental Acuity", Effect Duration: 39
 5834	non-vacuum-sealed holistic headache remedy	0		Effect: "Faboooo", Effect Duration: 43
 5835	dry yellow scrunchie tourniquet	0		Effect: "Jerky, Boy", Effect Duration: 55
 5836	activated ghostly embezzler's oil	0		Effect: "Fan-Cooled", Effect Duration: 39
 5837	ionized unsweetened jittery Fu Manchu Wax	0		Effect: "Mighty Shout", Effect Duration: 16
 5838	corrupted electrified Iiti Kitty Gumdrop	0		Effect: "Floundering", Effect Duration: 13
 5839	boiled dry pulsating ravenous eye	0		Effect: "The Style... of the Future", Effect Duration: 45
-5840	alkaline skewed huge gray Rogue Windmill Rouge	0		Effect: "Third Based", Effect Duration: 62
+5840	alkaline gray huge skewed Rogue Windmill Rouge	0		Effect: "Third Based", Effect Duration: 62
 5841	colloidal tarnished polarized A muse-bouche	0		Effect: "Elemental Mastery", Effect Duration: 26
 5842	double-warmed liquefied narrow toothbrush	0		Effect: "The Living Hitpoints", Effect Duration: 42
 5843	anodized cold-filtered pirate cream pie	0		Effect: "Dreadful Fear", Effect Duration: 25
@@ -5752,7 +5752,7 @@
 5853	enhanced stick-on gnome beard	0		Effect: "Magically Delicious", Effect Duration: 46
 5854	tarnished double-colloidal BRICKO stud	0		Effect: "Ichorous Intensity", Effect Duration: 48
 5855	flattened green Osk'r Chow	0		Effect: "Demonic Flavor", Effect Duration: 44
-5856	improved jittery spinning tumbling Scuba Snack	0		Effect: "Yuletide Sappiness", Effect Duration: 37
+5856	improved tumbling spinning jittery Scuba Snack	0		Effect: "Yuletide Sappiness", Effect Duration: 37
 5857	alkaline adjusted jittery grey cube	0		Effect: "Ooh, Salty!", Effect Duration: 61
 5858	frozen non-pressed teal votive candle	0		Effect: "Okee-Dokee Go!", Effect Duration: 16
 5859	anodized booby trap	0		Effect: "Ermine Eyes", Effect Duration: 36
@@ -5767,8 +5767,8 @@
 5868	perfumed coward's papier-m&acirc;ch&eacute;te	0		Monster Level: -20, Stench Resistance: +5, Last Available: "2012-09"
 5869	spinning electrified forbidden papier-m&acirc;chine gun	0		Spell Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-09"
 5870	mansplainer's wicked papier-masque	0		Spell Damage: +5, Monster Level: +15, Single Equip, Last Available: "2012-09"
-5871	pulsating papier-mitre of the storm of the sewer	0		Maximum MP Percent: +40, Stench Damage: +25, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	prompt papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Adventures: +3, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	pulsating papier-mitre of the storm of the sewer	0		Maximum MP Percent: +40, Stench Damage: +25, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	prompt papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Adventures: +3, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	tumbling papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	jittery miser's grievous skeleton skis of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Meat Drop: +10, Single Equip, Last Available: "2012-10"
-5883	toothsome small spinning skeleton quiche	2	awesome	Last Available: "2012-10"
+5883	small toothsome spinning skeleton quiche	2	awesome	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	knitted coward's MacGyver's Bonestabber of doom	0		Maximum MP: +100, Monster Level: -20, Spooky Spell Damage: +50, Cold Resistance: +3, Last Available: "2012-10"
@@ -5796,7 +5796,7 @@
 5897	twisted Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	cyan jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
-5900	maroon blinking tumbling jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
+5900	maroon tumbling blinking jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	pulsating jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	green jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	red ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	squat energetic brainwave-controlled unicorn horn	0		Maximum MP Percent: +20, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	squat energetic brainwave-controlled unicorn horn	0		Maximum MP Percent: +20, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	bouncing reassuring sizzling studded plastic four-shadowed mime	0		Damage Absorption: +80, Hot Damage: +10, Spooky Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	mirror shaking olive double-paned plastic Father McGruber	0		Cold Resistance: +5, Last Available: "2012-12"
 5961	twirling plastic Hank North, Photojournalist of terror	0		Spooky Spell Damage: +10, Last Available: "2012-12"
 5962	cyan skewed stylish plastic blazing bat	0		Moxie: +25, Last Available: "2012-12"
-5963	skewed rosewater-soaked quilted electronic dulcimer pants	0		Damage Absorption: +40, Stench Resistance: +3, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	skewed rosewater-soaked quilted electronic dulcimer pants	0		Damage Absorption: +40, Stench Resistance: +3, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	avaricious sage Frown Exerciser	0		Mysticality Percent: +10, Meat Drop: +30, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5873,13 +5873,13 @@
 5975	narrow huge record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	scorching Lo Pan's healthy silent beret	0		Maximum HP Percent: +20, Spell Critical Percent: +30, Hot Damage: +25, Familiar Effect: "1xVolley, cap 3"
-5978	toothsome small huge slice of pizza	2	awesome	Last Available: "2013-02"
+5978	small toothsome huge slice of pizza	2	awesome	Last Available: "2013-02"
 5979	ghostly huge coin	0		Last Available: "2013-02"
 5980	skewed cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	watered-down drinkable tankard of ale	2	good	Last Available: "2013-02"
+5982	drinkable watered-down tankard of ale	2	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	shellacked cloth cap of wisdom of the sewer	0		Mysticality: +15, Damage Reduction: 7, Stench Damage: +25, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	shellacked cloth cap of wisdom of the sewer	0		Mysticality: +15, Damage Reduction: 7, Stench Damage: +25, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	greasy iron dagger of chilblains of the sewer	0		Cold Damage: +25, Stench Damage: +25, Sleaze Spell Damage: +10, Last Available: "2013-02"
 5986	moldy hamburger	3	crappy	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	potion	0		Last Available: "2013-02"
 5990	drinkable jittery bottle of wine	4	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	perfumed sharpshooter's Newton's iron helmet	0		Experience (Mysticality): +3, Critical Hit Percent: +10, Stench Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	perfumed sharpshooter's Newton's iron helmet	0		Experience (Mysticality): +3, Critical Hit Percent: +10, Stench Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	sinister dance instructor's steel sword of the wise owl	0		Mysticality: +20, Experience Percent (Moxie): +10, Spell Damage: +10, Last Available: "2013-02"
 5994	fancy adequate whole roasted chicken	4	good	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 30, Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	blurry extra-strength potion	0		Last Available: "2013-02"
 5997	bouncing potion	0		Last Available: "2013-02"
-5998	practically non-alcoholic bad shining goblet	1	decent	Last Available: "2013-02"
+5998	bad practically non-alcoholic shining goblet	1	decent	Last Available: "2013-02"
 5999	huge fireball	0		Last Available: "2013-02"
-6000	olive up-at-dawn zippy weightlifter's crown	0		Muscle: +15, Initiative: +20, Adventures: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	olive up-at-dawn zippy weightlifter's crown	0		Muscle: +15, Initiative: +20, Adventures: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	horrifying padded sword of the overflowing toilet	0		Damage Absorption: +20, Stench Spell Damage: +50, Spooky Damage: +25, Last Available: "2013-02"
-6002	quilted Helm of the Scream Emperor of James Dean of the sewer	0		Experience (Moxie): +3, Damage Absorption: +40, Stench Damage: +25, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	quilted Helm of the Scream Emperor of James Dean of the sewer	0		Experience (Moxie): +3, Damage Absorption: +40, Stench Damage: +25, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	squat horrifying extremely unsafe Cloak of Dire Shadows of the overflowing toilet	0		Weapon Damage Percent: +100, Stench Spell Damage: +50, Spooky Damage: +25, Last Available: "2013-02"
 6004	Sherlock's hardened Socratic Sword of Dark Omens	0		Experience (Mysticality): +1, Damage Reduction: 3, Item Drop: +25, Last Available: "2013-02"
 6005	educational Shield of Icy Fate of the ox of horror	0		Muscle: +20, Experience: +1, Spooky Spell Damage: +25, Damage Reduction: 7, Last Available: "2013-02"
-6006	frosty wicked savvy Greaves of the Murk Lord	0		Mysticality Percent: +20, Spell Damage: +5, Cold Spell Damage: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	frosty wicked savvy Greaves of the Murk Lord	0		Mysticality Percent: +20, Spell Damage: +5, Cold Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	double-paned stylish Gauntlets of the Blood Moon of the ox	0		Muscle: +20, Moxie: +25, Cold Resistance: +5, Single Equip, Last Available: "2013-02"
 6008	lightning-fast Boots of Twilight Whispers of the overflowing toilet of horror	0		Stench Spell Damage: +50, Spooky Spell Damage: +25, Initiative: +40, Single Equip, Last Available: "2013-02"
 6009	Belt of Howling Anger of the brute of the dark arts of the storm	0		Muscle Percent: +30, Spell Damage Percent: +100, Maximum MP Percent: +40, Single Equip, Last Available: "2013-02"
@@ -5951,7 +5951,7 @@
 6053	irresponsibly strong smooth Taco Dan's Taco Stand Chimichangarita	8	awesome	Last Available: "2012-12"
 6054	frozen polarized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Mercenary", Effect Duration: 61, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	red The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	red The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	upside-down stanky lion tamer's Meatcleaver	0		Experience (familiar): +2, Stench Spell Damage: +25, Last Available: "2013-12"
 6058	pulsating stylish Crimbo Elf bobble-head	0		Moxie: +25, Last Available: "2012-12"
 6059	Annie Oakley's Crimbo stogie-scented room odorizer	0		Critical Hit Percent: +20, Last Available: "2012-12"
@@ -6040,14 +6040,14 @@
 6142	immense spoiled bouncing roasted duck	8	crappy	Last Available: "2013-12"
 6143	bite-sized delicious dead meat bun	1	awesome	Last Available: "2013-12"
 6144	twirling cat collar of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2013-12"
-6145	purple electrified suspicious-looking fedora of the businessman	0		Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	purple electrified suspicious-looking fedora of the businessman	0		Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	ghostly Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	wobbly Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	thick spoiled carrot cake	5	crappy	Last Available: "2013-01"
-6153	drinkable triple-distilled special carrot claret	6	good	Effect: "Smoky Third Eye", Effect Duration: 10, Last Available: "2013-01"
+6153	triple-distilled special drinkable carrot claret	6	good	Effect: "Smoky Third Eye", Effect Duration: 10, Last Available: "2013-01"
 6154	dehydrated carrot juice	1	crappy	Last Available: "2013-01"
 6155	blurry pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
@@ -6058,19 +6058,19 @@
 6161	weightlifter's regret hose	0		Muscle: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	stanky dance instructor's commodore's hat	0		Experience Percent (Moxie): +10, Stench Spell Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	Herculean naval trousers	0		Experience (Muscle): +1, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	stanky dance instructor's commodore's hat	0		Experience Percent (Moxie): +10, Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	Herculean naval trousers	0		Experience (Muscle): +1, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	clever medical-grade deck cannon	0		Maximum MP: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12"
 6167	ornamental sextant of the sweet-tooth	0		Candy Drop: +100, Last Available: "2013-12"
 6168	flame-wreathed scorching Bloodbath	0		Hot Damage: +25, Hot Spell Damage: +10, Last Available: "2013-12"
 6169	practically non-alcoholic perfectly mixed Hundred Headed IPA	1	super ultra mega EPIC	Last Available: "2013-12"
-6170	small moldy chum	2	crappy	Last Available: "2013-12"
+6170	moldy small chum	2	crappy	Last Available: "2013-12"
 6171	deionized crude crudit&eacute;s	0		Effect: "Hiding in Plain Sight", Effect Duration: 45
 6172	energized warmed blinking candy crayons	0		Effect: "Night Vision", Effect Duration: 25, Last Available: "2020-09"
 6173	red greasy hale pixel grappling hook	0		Maximum HP: +20, Sleaze Spell Damage: +10
 6174	gray tumbling GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
-6176	shaking blinking olive cosmic egg	0		
+6176	blinking shaking olive cosmic egg	0		
 6177	cosmic dough	0		
 6178	cosmic vegetable	0		
 6179	mirror cosmic cheese	0		
@@ -6079,56 +6079,56 @@
 6182	gray cosmic cream	0		
 6183	twirling cosmic fruit	0		
 6184	banded Jarlsberg's hat of the scaredy-cat of the glutton	0		Damage Absorption: +100, Monster Level: -15, Food Drop: +100
-6185	big decent red consummate hard-boiled egg	5	good	
+6185	decent big red consummate hard-boiled egg	5	good	
 6186	toothsome olive consummate fried egg	3	awesome	
 6187	moldy consummate egg salad	4	crappy	
-6188	super-sized tasty consummate bagel	5	awesome	
+6188	tasty super-sized consummate bagel	5	awesome	
 6189	decent mirror consummate sliced bread	3	good	
 6190	adequate consummate hot dog bun	4	good	
 6191	flavorless consummate brownie	4	decent	
-6192	stale small consummate toast	2	decent	
-6193	tolerable lime green twirling passable stout	4	good	
+6192	small stale consummate toast	2	decent	
+6193	tolerable twirling lime green passable stout	4	good	
 6194	stale purple consummate soup	3	decent	
 6195	rotten consummate corn chips	3	crappy	
 6196	normal consummate salad	3	good	
 6197	tasty half-sized tumbling twirling consummate salsa	2	awesome	
-6198	normal bite-sized consummate sauerkraut	1	good	
+6198	bite-sized normal consummate sauerkraut	1	good	
 6199	adequate enchanted consummate cheese slice	3	good	Effect: "Boletus Swoletus", Effect Duration: 35
 6200	miniature bland consummate melted cheese	2	decent	
 6201	tasty squat consummate bacon	4	awesome	
-6202	bland shaking wobbly consummate meatloaf	3	decent	
+6202	bland wobbly shaking consummate meatloaf	3	decent	
 6203	decent purple consummate steak	4	good	
 6204	bland half-sized consummate cuts	2	decent	
 6205	snack-sized adequate green consummate frankfurter	2	good	
-6206	jumbo spoiled red consummate french fries	5	crappy	
+6206	spoiled jumbo red consummate french fries	5	crappy	
 6207	rotten consummate baked potato	3	crappy	
-6208	practically non-alcoholic mediocre jittery acceptable vodka	1	decent	
+6208	mediocre practically non-alcoholic jittery acceptable vodka	1	decent	
 6209	bland tumbling consummate ice cream	3	decent	
 6210	tasty consummate whipped cream	4	awesome	
-6211	snack-sized adequate consummate cream	2	good	
+6211	adequate snack-sized consummate cream	2	good	
 6212	decent consummate strawberries	3	good	
 6213	moldy wobbly consummate sorbet	3	crappy	
 6214	tolerable weak blinking adequate rum	2	good	
 6215	aged mediocre lager	3	awesome	
-6216	tiny normal squat immaculate grilled cheese	1	good	
-6217	bland gigantic shaking immaculate ice cream sandwich	9	decent	
+6216	normal tiny squat immaculate grilled cheese	1	good	
+6217	gigantic bland shaking immaculate ice cream sandwich	9	decent	
 6218	diet delicious immaculate hot dog	1	awesome	
 6219	decent immaculate egg salad sandwich	4	good	
 6220	spoiled maroon perfect sandwich	3	crappy	
 6221	snack-sized delicious perfect chef salad	2	awesome	
-6222	super-sized stale perfect breakfast	5	decent	
+6222	stale super-sized perfect breakfast	5	decent	
 6223	spoiled bite-sized sublime deluxe hot dog	1	crappy	
 6224	toothsome sublime stew	4	awesome	
 6225	moldy blurry sublime nachos	3	crappy	
-6226	big decent Ultimate Breakfast Sandwich	5	good	
+6226	decent big Ultimate Breakfast Sandwich	5	good	
 6227	flavorless Loaded Baked Potato	3	decent	
-6228	bite-sized delicious upside-down green Omega Sundae	1	awesome	
-6229	mediocre high-proof Das Sauerlager	9	decent	
+6228	delicious bite-sized upside-down green Omega Sundae	1	awesome	
+6229	high-proof mediocre Das Sauerlager	9	decent	
 6230	perfectly mixed distilled Bologna Lambic	5	EPIC	
-6231	acceptable olive twirling Vodka Dog	3	good	
+6231	acceptable twirling olive Vodka Dog	3	good	
 6232	tolerable weak upside-down Disappointed Russian	2	good	
-6233	fortified drinkable Chunky Mary	5	good	
-6234	acceptable strong Nachojito	5	good	
+6233	drinkable fortified Chunky Mary	5	good	
+6234	strong acceptable Nachojito	5	good	
 6235	mediocre Le Roi	3	decent	
 6236	smooth practically non-alcoholic Over Easy Rider	1	awesome	
 6237	cosmic six-pack	0		
@@ -6142,7 +6142,7 @@
 6246	extra-anodized super-ionized mirror demonic surgical gloves	0		Effect: "Blood-Gorged", Effect Duration: 48
 6247	energized tumbling fuchsia clip-on ninja tie	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 28
 6248	super-diffused frozen ghostly gamer slurry	0		Effect: "Amorphous Cheer", Effect Duration: 63
-6249	shaking purple dungeoneering kit	0		Last Available: "2013-02"
+6249	purple shaking dungeoneering kit	0		Last Available: "2013-02"
 6250	foul-smelling lion tamer's mansplainer's rock-hard numberwang of the detective of the businessman	0		Damage Reduction: 5, Monster Level: +15, Experience (familiar): +2, Stench Damage: +10, Item Drop: +20, Meat Drop: +50, Single Equip
 6251	wet electrified scroll of Protection from Bad Stuff	0		Effect: "Block-Rockin' Beet", Effect Duration: 40, Last Available: "2013-02"
 6252	corrupted polarized scroll of Puddingskin	0		Effect: "Loyal Tea", Effect Duration: 38, Last Available: "2013-02"
@@ -6160,7 +6160,7 @@
 6264	narrow smelly Staff of Fruit Salad of the sweet-tooth of the early riser	0		Stench Spell Damage: +10, Candy Drop: +100, Adventures: +7, Jiggle: "Deal Some Prismatic Damage"
 6265	bouncing prompt Annie Oakley's Staff of the Cream of the Cream of the boozehound	0		Critical Hit Percent: +20, Booze Drop: +100, Adventures: +3, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	small delicious squat grain of protein powder	2	awesome	
+6267	delicious small squat grain of protein powder	2	awesome	
 6268	boiled pec oil	0		Effect: "Sourpuss", Effect Duration: 62
 6269	huge frosty gym membership card	0		Cold Spell Damage: +10
 6270	alkaline adjusted Squat-Thrust Magazine	0		Effect: "A View to Some Meat", Effect Duration: 28
@@ -6174,7 +6174,7 @@
 6278	shaking Ye Olde Medieval Insult	0		
 6279	teal medical-grade pewter claymore	0		HP Regen Min: 7, HP Regen Max: 10
 6280	ghostly dog trainer's artisanal rice peeler	0		Experience (familiar): +1
-6281	rotten thick gray blurry upside-down heirloom grape tomato	5	crappy	
+6281	rotten thick upside-down gray blurry heirloom grape tomato	5	crappy	
 6282	yellow chipotle wasabi cilantro aioli	0		
 6283	blue spinning asbestos-lined brown felt tophat	0		Hot Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6186,7 +6186,7 @@
 6290	bouncing steam-powered model rocketship	0		
 6291	upside-down pulsating scandalous punk rock jacket of the brazier	0		Hot Spell Damage: +25, Sleaze Damage: +5
 6292	beefy safety pin of mayonnaise	0		Muscle: +10, Sleaze Spell Damage: +50
-6293	normal diet stolen sushi	1	good	
+6293	diet normal stolen sushi	1	good	
 6294	pulsating very overdue library book	0		
 6295	jittery drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6222,7 +6222,7 @@
 6326	blue Socratic pearl diver's ring of Gandalf	0		Experience (Mysticality): +1, Spell Critical Percent: +20, Single Equip
 6327	scandalous pearl diver's necklace of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +5, Single Equip
 6328	purple sushi doily	0		
-6329	bouncing upside-down scimitar cozy	0		
+6329	upside-down bouncing scimitar cozy	0		
 6330	pulsating lime green fish stick cozy	0		
 6331	bazooka cozy	0		
 6332	blinking smelly forbidden wicked cozy scimitar	0		Spell Damage: +5, Spell Damage Percent: +50, Stench Spell Damage: +10
@@ -6240,7 +6240,7 @@
 6344	Mer-kin mouthsoap	0		
 6345	oxidized adjusted Mer-kin strongjuice	0		Effect: "Grumpy and Ornery", Effect Duration: 38
 6346	Mer-kin fitbrine	0		
-6347	altered quadruple-nitrogenated teal shaking Mer-kin ragejuice	0		Effect: "Mystically Oiled", Effect Duration: 33
+6347	altered quadruple-nitrogenated shaking teal Mer-kin ragejuice	0		Effect: "Mystically Oiled", Effect Duration: 33
 6348	blurry Mer-kin dragbelt of the dark arts	0		Spell Damage Percent: +100, Experience (Muscle): +20, Single Equip
 6349	pulsating medical-grade Mer-kin eyeglasses	0		HP Regen Min: 7, HP Regen Max: 10, Experience (Mysticality): +20, Single Equip
 6350	squat Mer-kin gutgirdle of bravery	0		Spooky Resistance: +5, Experience (Moxie): +20, Single Equip
@@ -6265,7 +6265,7 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	hand-crafted distilled shaking can of the cheapest beer	5	EPIC	
-6372	aged boozy bottle of fruity &quot;wine&quot;	5	awesome	
+6372	boozy aged bottle of fruity &quot;wine&quot;	5	awesome	
 6373	extra-dry mediocre single swig of vodka	5	decent	
 6374	angry inch	0		
 6375	maroon quilted testy toolbox	0		Damage Absorption: +40
@@ -6277,7 +6277,7 @@
 6382	squat nugget of sodium	0		
 6383	root beer	1	decent	
 6384	jigsaw blade	0		
-6385	tumbling fuchsia wood screw	0		
+6385	fuchsia tumbling wood screw	0		
 6386	balsa plank	0		
 6387	blinking blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
@@ -6314,18 +6314,18 @@
 6419	diffused moth dust	0		Effect: "Sticky Hands", Effect Duration: 27
 6420	ionized vacuum-sealed glob of spoiled mayo	0		Effect: "Thick, Sick", Effect Duration: 63
 6421	blue tonic djinn	0		
-6422	normal cyan tumbling vampire chowder	3	good	
-6423	olive pulsating Tales of Dread	0		Free Pull
+6422	normal tumbling cyan vampire chowder	3	good	
+6423	pulsating olive Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	moldy Dreadsylvanian stew	3	crappy	
-6427	lousy fancy olive Dreadsylvanian	3	decent	Effect: "Frog In Your Throat", Effect Duration: 25
+6427	fancy lousy olive Dreadsylvanian	3	decent	Effect: "Frog In Your Throat", Effect Duration: 25
 6428	extra-magnetized nitrogenated wobbly Dreadsylvanian flask	0		Effect: "The Halls of Moxiousness", Effect Duration: 16
 6429	super-activated Dreadsylvanian flask	0		Effect: "Norwhalloped", Effect Duration: 28
 6430	aromatic hardened dreadful fedora	0		Damage Reduction: 3, Stench Resistance: +1, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	dreadful sweater of dire peril	0		Weapon Damage: +20, Kruegerand Drop: 5
 6432	ghostly executive dreadful glove	0		Meat Drop: +40, Kruegerand Drop: 5
-6433	maroon spinning Freddy Kruegerand	0		
+6433	spinning maroon Freddy Kruegerand	0		
 6434	cyan Mark of the Bugbear	0		
 6435	twirling Mark of the Werewolf	0		
 6436	squat Mark of the Zombie	0		
@@ -6338,7 +6338,7 @@
 6443	executive Oprah's Helps-You-Sleep	0		Maximum MP Percent: +50, Meat Drop: +40, Single Equip
 6444	upside-down upside-down grievous personal trainer's Quiets-Your-Steps of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Single Equip
 6445	Jim Carey's groovy Protects-Your-Junk	0		Moxie Percent: +10, Monster Level: +25, Single Equip
-6446	practically non-alcoholic tolerable Gets-You-Drunk	1	good	
+6446	tolerable practically non-alcoholic Gets-You-Drunk	1	good	
 6447	greasy foul-smelling chaotic Great Wolf's headband	0		Spell Critical Percent: +10, Stench Damage: +10, Sleaze Spell Damage: +10, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	tumbling prompt Great Wolf's left paw of Tarzan of temperance	0		Experience (Muscle): +3, Sleaze Resistance: +5, Adventures: +3, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	rosy-cheeked wholesome Great Wolf's right paw of temperance	0		Maximum HP Percent: 40, Sleaze Resistance: +5, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6383,14 +6383,14 @@
 6488	immense adequate narrow Dreadsylvanian shepherd's pie	9	good	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
-6491	blinking bouncing fuchsia tailfeathers	0		Familiar Weight: +5
+6491	bouncing fuchsia blinking tailfeathers	0		Familiar Weight: +5
 6492	upside-down wax banana	0		
 6493	complicated lock impression	0		
 6494	replica key	0		
 6495	padded Dreadsylvania Auditor's badge	0		Damage Absorption: +20, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
-6498	artisanal watered-down yellow bloody kiwitini	2	super EPIC	
+6498	watered-down artisanal yellow bloody kiwitini	2	super EPIC	
 6499	moon-amber	0		
 6500	maroon polished moon-amber	0		
 6501	flame-wreathed brawny moon-amber necklace of temperance	0		Muscle Percent: +20, Hot Spell Damage: +10, Sleaze Resistance: +5, Single Equip
@@ -6455,7 +6455,7 @@
 6561	huge adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	shaking beefy hand of Mr. Cards	0		Muscle: +10, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	snack-sized stale Dreadsylvanian hot pocket	2	decent	
+6564	stale snack-sized Dreadsylvanian hot pocket	2	decent	
 6565	rotten spinning Dreadsylvanian pocket	3	crappy	
 6566	spoiled diet Dreadsylvanian pocket	1	crappy	
 6567	tasty Dreadsylvanian stink pocket	4	awesome	
@@ -6469,7 +6469,7 @@
 6575	clusterbomb	0		
 6576	clusterbomb	0		
 6577	wobbly stench clusterbomb	0		
-6578	squat tumbling sleaze clusterbomb	0		
+6578	tumbling squat sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	blinking dreadful box	0		
@@ -6506,7 +6506,7 @@
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	perfectly mixed special spinning Cold One	3	???	Effect: "Comic Violence", Effect Duration: 50
+6615	special perfectly mixed spinning Cold One	3	???	Effect: "Comic Violence", Effect Duration: 50
 6616	adequate spaghetti breakfast	3	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6523,13 +6523,13 @@
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	spinning folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
-6632	ghostly maroon folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
+6632	maroon ghostly folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	squat folder (barbarian)	0		Last Available: "2013-08"
 6634	skewed folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
-6638	twirling wobbly folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
+6638	wobbly twirling folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	folder (owl)	0		Last Available: "2013-08"
 6640	folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	narrow folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
@@ -6588,16 +6588,16 @@
 6696	bowling ball	0		
 6697	moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
-6699	maroon jittery crackling stone sphere	0		
+6699	jittery maroon crackling stone sphere	0		
 6700	upside-down yellow scorched stone sphere	0		
 6701	stone triangle	0		
 6702	pulsating bowler	0		
 6703	imitation White Russian	1	awesome	
 6704	skewed Jim Carey's Socratic short-handled mop	0		Experience (Mysticality): +1, Monster Level: +25
 6705	bland jungle floor wax	4	decent	
-6706	bouncing pulsating smirking shrunken head	0		
+6706	pulsating bouncing smirking shrunken head	0		
 6707	electrified wobbly colorful toad	0		Effect: "Nas Tea", Effect Duration: 67
-6708	upside-down upside-down fuchsia crude voodoo doll	0		
+6708	upside-down fuchsia upside-down crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
 6710	blurry greedy gravedigger's pygmy briefs	0		Spooky Damage: +10, Meat Drop: +20, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	tumbling short writ of habeas corpus	0		
@@ -6605,7 +6605,7 @@
 6713	adder	0		
 6714	short calculator	0		
 6715	squat cool sphygmomanometer of the dark arts	0		Moxie: +5, Spell Damage Percent: +100
-6716	boiled tarnished cyan skewed bag of pygmy blood	0		Effect: "Brother Corsican's Blessing", Effect Duration: 41
+6716	boiled tarnished skewed cyan bag of pygmy blood	0		Effect: "Brother Corsican's Blessing", Effect Duration: 41
 6717	blurry tongue depressor	0		
 6718	blue tumbling perfumed ribald compression stocking	0		Sleaze Damage: +10, Stench Resistance: +5
 6719	narrow perfumed shellacked midriff scrubs	0		Damage Reduction: 7, Stench Resistance: +5
@@ -6614,7 +6614,7 @@
 6722	energized galvanized upside-down pygmy phone number	0		Effect: "Fungal Flambé", Effect Duration: 30
 6723	gray Boozehounds Anonymous token	0		
 6724	yummy half-sized exotic jungle fruit	2	awesome	
-6725	maroon upside-down squat Shore Inc. Ship Trip Scrip	0		
+6725	squat upside-down maroon Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	wobbly ski resort souvenir crate	0		
@@ -6629,12 +6629,12 @@
 6737	wobbly tangle of copper wire	0		
 6738	blue jagged scrap	0		
 6739	quantum double-polymerized cyan bent scrap	0		Effect: "Bat Attitude", Effect Duration: 47
-6740	teal bouncing molten scrap	0		
+6740	bouncing teal molten scrap	0		
 6741	shaking eternal car battery	0		
 6742	green Herculean junk band	0		Experience (Muscle): +1
 6743	spinning double-paned junk trunks	0		Cold Resistance: +5, Familiar Effect: "cap 15"
 6744	electrified junk-mail shirt	0		MP Regen Min: 3, MP Regen Max: 5
-6745	adequate bite-sized junk food	1	good	
+6745	bite-sized adequate junk food	1	good	
 6746	mediocre junk yard	3	decent	
 6747	toasty hardened swordzall	0		Damage Reduction: 3, Hot Damage: +5
 6748	mirror fireproof arm buzzer	0		Hot Resistance: +3, Damage Reduction: 6
@@ -6646,7 +6646,7 @@
 6754	beer bottle	0		
 6755	squat beer label	0		
 6756	skewed artisanal homebrew sampler	0		
-6757	perfectly mixed weak can of Br&uuml;talbr&auml;u	2	EPIC	Last Available: "2013-09"
+6757	weak perfectly mixed can of Br&uuml;talbr&auml;u	2	EPIC	Last Available: "2013-09"
 6758	high-proof lousy twirling can of Drooling Monk	7	decent	Last Available: "2013-09"
 6759	weak artisanal blinking can of Impetuous Scofflaw	2	EPIC	Last Available: "2013-09"
 6760	smooth bottle of Old Pugilist	3	awesome	Last Available: "2013-09"
@@ -6658,7 +6658,7 @@
 6766	olive tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	blue liquid bread	1	good	Last Available: "2013-09"
-6769	family-friendly Oprah's hardened tin tam	0		Damage Reduction: 3, Maximum MP Percent: +50, Sleaze Resistance: +1, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	family-friendly Oprah's hardened tin tam	0		Damage Reduction: 3, Maximum MP Percent: +50, Sleaze Resistance: +1, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	non-frozen tin cup	0		Effect: "Ninja, Please", Effect Duration: 66, Last Available: "2013-09"
 6771	arcane researcher's stylish cool tin foil	0		Moxie: 30, Experience Percent (Mysticality): +10, Last Available: "2013-09"
 6772	groovy sage tin drum of Calamity Jane	0		Mysticality Percent: +10, Moxie Percent: +10, Critical Hit Percent: +15, Last Available: "2013-09"
@@ -6684,7 +6684,7 @@
 6795	polarized narrow disco horoscope (Aquarius)	0		Effect: "Funky Coal Patina", Effect Duration: 33
 6796	vacuum-sealed disco horoscope (Pisces)	0		Effect: "Human-Pirate Hybrid", Effect Duration: 69
 6797	dry vacuum-sealed bouncing disco horoscope (Aries)	0		Effect: "The Halls of Mysticality", Effect Duration: 25
-6798	improved triple-polymerized squat fuchsia disco horoscope (Taurus)	0		Effect: "Oleaginous Soles", Effect Duration: 20
+6798	improved triple-polymerized fuchsia squat disco horoscope (Taurus)	0		Effect: "Oleaginous Soles", Effect Duration: 20
 6799	vacuum-sealed pickled tumbling disco horoscope (Gemini)	0		Effect: "Faboooo", Effect Duration: 66
 6800	pickled skewed disco horoscope (Cancer)	0		Effect: "Disco Nirvana", Effect Duration: 20
 6801	alkaline vacuum-sealed disco horoscope (Leo)	0		Effect: "Marco Polarity", Effect Duration: 33
@@ -6746,15 +6746,15 @@
 6857	medical-grade Cajun accordion	0		HP Regen Min: 7, HP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	slick quirky accordion	0		Moxie: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	olive fortified forbidden Skipper's accordion	0		Spell Damage Percent: +50, Damage Absorption: +60, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	upside-down blue wool dangerous dance instructor's Pantsgiving of the detective	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Cold Resistance: +1, Item Drop: +20, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	bland special can of sardines	3	decent	Effect: "Fustulent", Effect Duration: 10, Last Available: "2013-11"
-6862	normal low-calorie special high-calorie sugar substitute	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 15, Last Available: "2013-11"
-6863	normal enchanted pat of butter	3	good	Effect: "Incensed", Effect Duration: 20, Last Available: "2013-11"
+6860	upside-down blue wool dangerous dance instructor's Pantsgiving of the detective	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Cold Resistance: +1, Item Drop: +20, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6861	special bland can of sardines	3	decent	Effect: "Fustulent", Effect Duration: 10, Last Available: "2013-11"
+6862	special low-calorie normal high-calorie sugar substitute	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 15, Last Available: "2013-11"
+6863	enchanted normal pat of butter	3	good	Effect: "Incensed", Effect Duration: 20, Last Available: "2013-11"
 6864	huge stale dinner roll	10	decent	Last Available: "2013-11"
-6865	small adequate jittery fuchsia mashed potatoes	2	good	Last Available: "2013-11"
+6865	adequate small jittery fuchsia mashed potatoes	2	good	Last Available: "2013-11"
 6866	flavorless whole turkey leg	3	decent	Last Available: "2013-11"
 6867	spoiled deviled egg	3	crappy	Last Available: "2013-11"
-6868	double-chilled bouncing tumbling finger exerciser	0		Effect: "So You Can Work More...", Effect Duration: 23, Last Available: "2013-11"
+6868	double-chilled tumbling bouncing finger exerciser	0		Effect: "So You Can Work More...", Effect Duration: 23, Last Available: "2013-11"
 6869	liquefied non-pressed dented spoon	0		Effect: "Fudge Headache", Effect Duration: 33, Last Available: "2013-11"
 6870	extra-liquefied blinking love note	0		Effect: "The Strength...  of the Future", Effect Duration: 20, Last Available: "2013-11"
 6871	red school beer pull tab	0		Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	galvanized bouncing mirror nuts	0		Effect: "Prince of Seaside Town", Effect Duration: 34, Last Available: "2013-12"
 6904	enhanced polymerized mirror bolts	0		Effect: "Sweet Incentive", Effect Duration: 61, Last Available: "2013-12"
 6905	normal gingerbread robot	3	good	Last Available: "2013-12"
-6906	jumbo normal petit 4.1	5	good	Last Available: "2013-12"
+6906	normal jumbo petit 4.1	5	good	Last Available: "2013-12"
 6907	normal nut-shaped Crimbo cookie	3	good	Last Available: "2023-06"
 6908	toasty plastic GORM-8	0		Hot Damage: +5, Last Available: "2013-12"
 6909	flame-retardant plastic warbear	0		Hot Resistance: +1, Last Available: "2013-12"
@@ -6807,32 +6807,32 @@
 6918	ionized chilled warbear wardance potion	0		Effect: "Sweet Tooth", Effect Duration: 40, Last Available: "2013-12"
 6919	super-quantum alkaline warbear bearserker potion	0		Effect: "Halloweeny", Effect Duration: 41, Last Available: "2013-12"
 6920	quantum anodized warbear liquid overcoat	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 36, Last Available: "2013-12"
-6921	spoiled snack-sized warbear feasting bread	2	crappy	Last Available: "2013-12"
+6921	snack-sized spoiled warbear feasting bread	2	crappy	Last Available: "2013-12"
 6922	moldy bite-sized warbear warrior bread	1	crappy	Last Available: "2013-12"
 6923	moldy cyan warbear thermoregulator bread	3	crappy	Last Available: "2013-12"
-6924	acceptable yellow blinking warbear feasting mead	4	good	Last Available: "2013-12"
+6924	acceptable blinking yellow warbear feasting mead	4	good	Last Available: "2013-12"
 6925	tolerable weak warbear bearserker mead	2	good	Last Available: "2013-12"
-6926	hand-crafted weak warbear blizzard mead	2	super EPIC	Last Available: "2013-12"
+6926	weak hand-crafted warbear blizzard mead	2	super EPIC	Last Available: "2013-12"
 6927	twirling warbear helm fragment	0		Last Available: "2013-12"
-6928	knitted sizzling warbear plain fedora of the empath	0		Familiar Weight: +5, Hot Damage: +10, Cold Resistance: +3, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	warbear feathered fedora of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	lightning-fast extremely unsafe warbear fedora of the ox	0		Muscle: +20, Weapon Damage Percent: +100, Initiative: +40, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	blue vibrating hardened groovy warbear plain helm	0		Moxie Percent: +10, Damage Reduction: 3, Maximum MP Percent: +10, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	stylish warbear spiked helm	0		Moxie: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	rosewater-soaked frosty arcane researcher's warbear electro-spiked helm	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	ghostly prompt horrifying vibrating warbear plain ushanka	0		Maximum MP Percent: +10, Spooky Damage: +25, Adventures: +3, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	gray warbear lined ushanka	0		Item Drop: +5, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	supercharged slick warbear heated ushanka of bravery	0		Moxie: +10, Maximum MP Percent: +30, Spooky Resistance: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	knitted sizzling warbear plain fedora of the empath	0		Familiar Weight: +5, Hot Damage: +10, Cold Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	warbear feathered fedora of the sewer	0		Stench Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	lightning-fast extremely unsafe warbear fedora of the ox	0		Muscle: +20, Weapon Damage Percent: +100, Initiative: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	blue vibrating hardened groovy warbear plain helm	0		Moxie Percent: +10, Damage Reduction: 3, Maximum MP Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	stylish warbear spiked helm	0		Moxie: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	rosewater-soaked frosty arcane researcher's warbear electro-spiked helm	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +10, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	ghostly prompt horrifying vibrating warbear plain ushanka	0		Maximum MP Percent: +10, Spooky Damage: +25, Adventures: +3, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	gray warbear lined ushanka	0		Item Drop: +5, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	supercharged slick warbear heated ushanka of bravery	0		Moxie: +10, Maximum MP Percent: +30, Spooky Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	blinking warbear trouser fragment	0		Last Available: "2013-12"
-6938	sizzling sinister warbear party pants of the cheetah	0		Spell Damage: +10, Hot Damage: +10, Initiative: +60, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	mirror warbear ceremonial party pants of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	red aromatic warbear high festival pants of the cougar of courage	0		Moxie: +20, Spooky Resistance: +3, Stench Resistance: +1, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	smelly mansplainer's cool warbear battle greaves	0		Moxie: +5, Monster Level: +15, Stench Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	fuchsia Samson's warbear officer greaves	0		Experience (Muscle): +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	nippy dog trainer's Tesla warbear bearserker greaves	0		Experience (familiar): +1, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	reassuring wool curative warbear johns	0		Cold Resistance: +1, Spooky Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	savvy warbear fleece-lined johns	0		Mysticality Percent: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	inspector's fortified warbear johns of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Item Drop: +15, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	sizzling sinister warbear party pants of the cheetah	0		Spell Damage: +10, Hot Damage: +10, Initiative: +60, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	mirror warbear ceremonial party pants of incineration	0		Hot Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	red aromatic warbear high festival pants of the cougar of courage	0		Moxie: +20, Spooky Resistance: +3, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	smelly mansplainer's cool warbear battle greaves	0		Moxie: +5, Monster Level: +15, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	fuchsia Samson's warbear officer greaves	0		Experience (Muscle): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	nippy dog trainer's Tesla warbear bearserker greaves	0		Experience (familiar): +1, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	reassuring wool curative warbear johns	0		Cold Resistance: +1, Spooky Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	savvy warbear fleece-lined johns	0		Mysticality Percent: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	inspector's fortified warbear johns of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	Usain Bolt's healthy warbear goggles of Leguizamo	0		Maximum HP Percent: +20, Monster Level: +20, Initiative: +80, Single Equip, Last Available: "2013-12"
 6949	Annie Oakley's warbear snowblindness goggles	0		Critical Hit Percent: +20, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	twirling flame-wreathed toasty warbear warscarf of Flo-Jo	0		Hot Damage: +5, Hot Spell Damage: +10, Initiative: +100, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	dog trainer's warbear foil hat	0		Experience (familiar): +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	dog trainer's warbear foil hat	0		Experience (familiar): +1, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	arcane researcher's warbear oil pan of bravery	0		Experience Percent (Mysticality): +10, Spooky Resistance: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	mirror warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6892,10 +6892,10 @@
 7003	squat The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	activated fuchsia Flaskfull of Hollow	0		Effect: "Mad at Science", Effect Duration: 56, Last Available: "2013-12"
 7005	olive lump of Brituminous coal	0		Last Available: "2013-12"
-7006	dried ghostly bouncing handful of Smithereens	1	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 50, Last Available: "2013-12"
-7007	small bland spinning Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
+7006	dried bouncing ghostly handful of Smithereens	1	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 50, Last Available: "2013-12"
+7007	bland small spinning Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
 7008	moldy Miserable Pie	3	crappy	Last Available: "2013-12"
-7009	enchanted yummy This Charming Flan	3	awesome	Effect: "Chalky Hand", Effect Duration: 45, Last Available: "2013-12"
+7009	yummy enchanted This Charming Flan	3	awesome	Effect: "Chalky Hand", Effect Duration: 45, Last Available: "2013-12"
 7010	bad watered-down bouncing Irish Coffee, English Heart	2	decent	Last Available: "2013-12"
 7011	drinkable Strikes Again Bigmouth	3	good	Last Available: "2013-12"
 7012	weak lousy Paint A Vulgar Pitcher	2	decent	Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	squat nasty quilted brainy Sheila Take a Crossbow of incineration	0		Mysticality: +5, Damage Absorption: +40, Hot Spell Damage: +50, Stench Damage: +5, Last Available: "2013-12"
 7019	twirling twirling frightening sizzling thinker's A Light that Never Goes Out of the early riser	0		Mysticality: +10, Hot Damage: +10, Spooky Damage: +5, Adventures: +7, Last Available: "2013-12"
 7020	curative Samson's slick Half a Purse of doom	0		Moxie: +10, Experience (Muscle): +5, Spooky Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
-7021	bouncing avaricious greedy scandalous Hairpiece On Fire of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Meat Drop: 50, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	censurious knitted Vicar's Tutu of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Cold Resistance: +3, Sleaze Resistance: +3, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	bouncing avaricious greedy scandalous Hairpiece On Fire of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Meat Drop: 50, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	censurious knitted Vicar's Tutu of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Cold Resistance: +3, Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	energetic smartaleck's brawny Hand in Glove	0		Muscle Percent: +20, Moxie Percent: +30, Maximum MP Percent: +20, Single Equip, Last Available: "2013-12"
 7024	yellow sizzling chaotic Meat Tenderizer is Murder of the ox	0		Muscle: +20, Spell Critical Percent: +10, Hot Damage: +10, Class: "Seal Clubber", Last Available: "2013-12"
 7025	miser's veiny slick Ouija Board, Ouija Board	0		Moxie: +10, Maximum HP: +10, Meat Drop: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	veiny shellacked quilted Shakespeare's Sister's Accordion	0		Damage Absorption: +40, Damage Reduction: 7, Maximum HP: +10, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	third-hand lantern of the bloodbag	0		Maximum HP: +100
 7031	loose purse strings	0		
-7032	miniature moldy fuchsia pickled egg	2	crappy	
+7032	moldy miniature fuchsia pickled egg	2	crappy	
 7033	cup of lukewarm tea	1	good	
 7034	huge warbear soda machine assembler	0		Last Available: "2013-12"
 7035	blinking warbear box	0		Last Available: "2013-12"
@@ -6930,10 +6930,10 @@
 7041	fuchsia warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	pulsating warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	boiled nitrogenated maroon narrow glass slipper	0		Effect: "In a Lather", Effect Duration: 59, Last Available: "2014-12"
+7044	boiled nitrogenated narrow maroon glass slipper	0		Effect: "In a Lather", Effect Duration: 59, Last Available: "2014-12"
 7045	dehydrated blinking jittery antimatter wad	1	awesome	Last Available: "2013-12"
-7046	warmed vacuum-sealed skewed narrow warbear superpotion	0		Effect: "Eye of the Lihc", Effect Duration: 34, Last Available: "2013-12"
-7047	wet teal skewed warbear liquid lasers	0		Effect: "Buggy Flavor", Effect Duration: 32, Last Available: "2013-12"
+7046	warmed vacuum-sealed narrow skewed warbear superpotion	0		Effect: "Eye of the Lihc", Effect Duration: 34, Last Available: "2013-12"
+7047	wet skewed teal warbear liquid lasers	0		Effect: "Buggy Flavor", Effect Duration: 32, Last Available: "2013-12"
 7048	moist extra-ionized warbear rejuvenation potion	0		Effect: "Quaaaaaaa", Effect Duration: 39, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	yummy ghostly warbear gyro	3	awesome	Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	jittery warbear drone codes	0		Last Available: "2013-12"
-7055	tasty miniature blurry breakfast mess	2	awesome	Last Available: "2013-12"
+7055	miniature tasty blurry breakfast mess	2	awesome	Last Available: "2013-12"
 7056	upside-down warbear breakfast machine	0		Last Available: "2013-12"
 7057	moldy mirror breakfast miracle	3	crappy	Last Available: "2013-12"
 7058	boiled squat narrow Cloaca Cola Polar	0		Effect: "Hoity Toity", Effect Duration: 47, Last Available: "2013-12"
@@ -6957,7 +6957,7 @@
 7068	irradiated extra-polymerized frozen shaking single of Donho's Bubbly Ballad	0		Effect: "Inebriate Pride", Effect Duration: 20
 7069	pulsating Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	rotten huge snow berries	10	crappy	Last Available: "2014-01"
+7071	huge rotten snow berries	10	crappy	Last Available: "2014-01"
 7072	bland lime green skewed ice harvest	4	decent	Last Available: "2014-01"
 7073	wet cold-filtered mirror pulsating frost flower	0		Effect: "Capricorn Rising", Effect Duration: 22, Last Available: "2014-01"
 7074	enhanced magnetized snow cleats	0		Effect: "Jawin'", Effect Duration: 35, Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	purple ice house	0		Last Available: "2014-01"
 7082	wobbly bouncing snow machine	0		Last Available: "2014-01"
-7083	squat Herculean snow mobile	0		Experience (Muscle): +1, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	squat Herculean snow mobile	0		Experience (Muscle): +1, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	hale ice bucket	0		Maximum HP: +20, Lasts Until Rollover, Last Available: "2014-01"
 7085	jittery family-friendly rosy-cheeked snow shovel	0		Maximum HP Percent: +30, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2014-01"
 7086	banded arcane researcher's bod-ice of Tarzan	0		Experience (Muscle): +3, Experience Percent (Mysticality): +10, Damage Absorption: +100, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	smooth En Una Fila Tequila	3	awesome	
 7091	jittery Skully's hot chocolate	1	awesome	
-7092	rosewater-soaked Samson's warbear dress helmet	0		Experience (Muscle): +5, Stench Resistance: +3, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	rosewater-soaked Samson's warbear dress helmet	0		Experience (Muscle): +5, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	lime green Sinatra's warbear dress bracers of the early riser	0		Experience (Moxie): +5, Adventures: +7, Single Equip, Last Available: "2013-12"
-7094	manspreader's warbear dress greaves of the sweet-tooth	0		Monster Level: +10, Candy Drop: +100, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	sizzling beefcake's sweatband	0		Muscle: +25, Hot Damage: +10, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	avaricious wicked gym shorts	0		Spell Damage: +5, Meat Drop: +30, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	manspreader's warbear dress greaves of the sweet-tooth	0		Monster Level: +10, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	sizzling beefcake's sweatband	0		Muscle: +25, Hot Damage: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	avaricious wicked gym shorts	0		Spell Damage: +5, Meat Drop: +30, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	ankleweights of the cougar of Gandalf	0		Moxie: +20, Spell Critical Percent: +20, Single Equip, Last Available: "2014-12"
 7098	fireproof frosty extremely unsafe wizardly sweat socks	0		Mysticality: +25, Weapon Damage Percent: +100, Cold Spell Damage: +10, Hot Resistance: +3, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -7001,22 +7001,22 @@
 7112	special bad green chocotini	4	decent	Effect: "Lit Up", Effect Duration: 20, Last Available: "2014-12"
 7113	double-paned flame-wreathed wizardly chocolate rabbit's foot	0		Mysticality: +25, Hot Spell Damage: +10, Cold Resistance: +5, Last Available: "2014-12"
 7114	low-calorie decent candy carrot	1	good	Last Available: "2014-12"
-7115	enchanted delicious big candy carrot cake	5	awesome	Effect: "Fastbreaker", Effect Duration: 35, Last Available: "2014-12"
+7115	big delicious enchanted candy carrot cake	5	awesome	Effect: "Fastbreaker", Effect Duration: 35, Last Available: "2014-12"
 7116	Jack Frost's ruddy carrot-on-a-stick	0		Maximum HP Percent: +40, Cold Spell Damage: +50, Last Available: "2014-12"
-7117	shaking lightning-fast Rosewater's weasel stomping pants	0		Mysticality Percent: +30, Initiative: +40, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	shaking lightning-fast Rosewater's weasel stomping pants	0		Mysticality Percent: +30, Initiative: +40, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	normal blue mulberry	4	good	Last Available: "2014-12"
 7119	weak lousy mulled berry wine	2	decent	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	flame-retardant lemon party hat	0		Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	flame-retardant lemon party hat	0		Hot Resistance: +1, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	chilly lemon shirt	0		Cold Damage: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	blue narrow ghostly lemon drop trousers of the cougar	0		Moxie: +20, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	blue narrow ghostly lemon drop trousers of the cougar	0		Moxie: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	galvanized electrified lemonhead caviar	0		Effect: "Hagg-ard", Effect Duration: 25, Last Available: "2014-12"
 7125	experienced educational gummi sword	0		Experience: 3, Last Available: "2014-12"
 7126	activated small gummi fin	0		Effect: "Seriously Mutated", Effect Duration: 49, Last Available: "2014-12"
 7127	jittery Jack Frost's chocolate cow bone	0		Cold Spell Damage: +50, Last Available: "2014-12"
 7128	Vulcanized gummi fang	0		Effect: "Heart of Orange", Effect Duration: 19, Last Available: "2014-12"
 7129	yummy narrow leftover canap&eacute;s	3	awesome	Last Available: "2014-12"
-7130	fortified mediocre magnum of champagne	5	decent	Last Available: "2014-12"
+7130	mediocre fortified magnum of champagne	5	decent	Last Available: "2014-12"
 7131	electrified hardy Newton's cow creamer	0		Experience (Mysticality): +3, Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7132	frozen dry shaking Outer Wolf&trade; cologne	0		Effect: "Booooooze", Effect Duration: 12, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
@@ -7025,7 +7025,7 @@
 7136	activated witch's brew	0		Effect: "Alpine Mintiness", Effect Duration: 11, Last Available: "2014-12"
 7137	hale padded arcane researcher's witch's bra	0		Experience Percent (Mysticality): +10, Damage Absorption: +20, Maximum HP: +20, Last Available: "2014-12"
 7138	aged mid-level medieval mead	4	awesome	Last Available: "2014-12"
-7139	tarnished ionized squat blue R&uuml;mpelstiltz	0		Effect: "Mint-Condition Breath", Effect Duration: 56, Last Available: "2014-12"
+7139	tarnished ionized blue squat R&uuml;mpelstiltz	0		Effect: "Mint-Condition Breath", Effect Duration: 56, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	extra-flattened triple-deionized tumbling hi-octane carrot juice	0		Effect: "Is This Your Card?", Effect Duration: 50, Last Available: "2014-12"
 7142	adjusted wobbly hare brush	0		Effect: "Metal Speed", Effect Duration: 51, Last Available: "2014-12"
@@ -7041,18 +7041,18 @@
 7152		0		Last Available: "2014-12"
 7153	clay	0		Last Available: "2014-12"
 7154	skewed filling	0		Last Available: "2014-12"
-7155	tumbling wobbly parchment	0		Last Available: "2014-12"
+7155	wobbly tumbling parchment	0		Last Available: "2014-12"
 7156	jittery glass	0		Last Available: "2014-12"
-7157	horrifying clever shellacked fire hose	0		Damage Reduction: 7, Maximum MP: +20, Spooky Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	horrifying clever shellacked fire hose	0		Damage Reduction: 7, Maximum MP: +20, Spooky Damage: +25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	normal tumbling fireman's lunch	3	good	Last Available: "2014-12"
-7159	green Annie Oakley's vibrating savvy plain paper hat	0		Mysticality Percent: +20, Maximum MP Percent: +10, Critical Hit Percent: +20, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	green Annie Oakley's vibrating savvy plain paper hat	0		Mysticality Percent: +20, Maximum MP Percent: +10, Critical Hit Percent: +20, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	rotten diet ice cream sandwich	1	crappy	Last Available: "2014-12"
 7161	aromatic lion tamer's &quot;honey&quot; dipper of the wise owl	0		Mysticality: +20, Experience (familiar): +2, Stench Resistance: +1, Last Available: "2014-12"
 7162	fancy normal plumber's lunch	3	good	Effect: "Fit To Be Tide", Effect Duration: 50, Last Available: "2014-12"
 7163	double-paned dangerous Rosewater's skull gearshift knob	0		Mysticality Percent: +30, Weapon Damage: +10, Cold Resistance: +5, Last Available: "2014-12"
 7164	massive adequate nachos of the night	9	good	Last Available: "2014-12"
 7165	knitted crafty supercool Sketcherz&trade;	0		Moxie Percent: +20, Maximum MP: +10, Cold Resistance: +3, Last Available: "2014-12"
-7166	gigantic normal special can of Adultwitch&trade;	8	good	Effect: "Hella Smart", Effect Duration: 5, Last Available: "2014-12"
+7166	gigantic special normal can of Adultwitch&trade;	8	good	Effect: "Hella Smart", Effect Duration: 5, Last Available: "2014-12"
 7167	non-polarized vacuum-sealed corrupted smudge stick	0		Effect: "World's Shortest Giant", Effect Duration: 19, Last Available: "2014-12"
 7168	boiled wall	0		Effect: "Fungal Fortification", Effect Duration: 12, Last Available: "2014-12"
 7169	acceptable upside-down tankard of ale	4	good	Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	activated dry squat jug of &quot;wine&quot;	0		Effect: "BOOsted", Effect Duration: 21, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	huge crappy camera	0		Last Available: "2014-12"
-7174	tiny moldy huge humble pie	1	crappy	Last Available: "2014-12"
+7174	moldy tiny huge humble pie	1	crappy	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	triple-irradiated bouncing blinking crappy waiter disguise	0		Effect: "Greased-Up Familiar", Effect Duration: 16
@@ -7069,11 +7069,11 @@
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
-7183	purple tumbling Murphy's Rancid Black Flag	0		
+7183	tumbling purple Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
 7185	twirling Red Zeppelin ticket	0		
 7186	squat teal Copperhead Charm (rampant)	0		
-7187	acceptable irresponsibly strong unnamed cocktail	7	good	
+7187	irresponsibly strong acceptable unnamed cocktail	7	good	
 7188	skewed handful of tips	0		
 7189	huge Annie Oakley's unrequired jacket	0		Critical Hit Percent: +20
 7190	green stanky tommy gun	0		Stench Spell Damage: +25, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7097,7 +7097,7 @@
 7208	fire of unknown origin	0		
 7209	skewed eagle's milk	1	crappy	
 7210	vacuum-sealed adjusted eagle feather	0		Effect: "Castaway Physique", Effect Duration: 38
-7211	colloidal unsweetened wobbly green one pill	0		Effect: "Stemonitis Storm", Effect Duration: 35
+7211	colloidal unsweetened green wobbly one pill	0		Effect: "Stemonitis Storm", Effect Duration: 35
 7212	veiny Jefferson wings	0		Maximum HP: +10
 7213	fleetwood macaroni	0		
 7214	skewed cheesy eagle sauce	0		
@@ -7108,7 +7108,7 @@
 7219	ghostly lynyrdskin breeches of the sewer	0		Stench Damage: +25, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	hand-crafted fortified twirling Flamin' Whatshisname	5	EPIC	
+7222	fortified hand-crafted twirling Flamin' Whatshisname	5	EPIC	
 7223	altered lynyrd musk	0		Effect: "The Power of Negative Thinking", Effect Duration: 34
 7224	wicked Kashmir sweater of the brazier	0		Spell Damage: +5, Hot Spell Damage: +25
 7225	stale custard pie	3	decent	
@@ -7117,9 +7117,9 @@
 7228	box	0		
 7229	aged watered-down wine	2	awesome	
 7230	drinkable skewed rum	3	good	
-7231	tolerable high-proof bouncing Murderer's Punch	10	good	
-7232	rotten gigantic velvet cake	10	crappy	
-7233	wet moist olive ghostly letter	0		Effect: "Faboooo", Effect Duration: 66
+7231	high-proof tolerable bouncing Murderer's Punch	10	good	
+7232	gigantic rotten velvet cake	10	crappy	
+7233	wet moist ghostly olive letter	0		Effect: "Faboooo", Effect Duration: 66
 7234	knitted book of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +3
 7235	miser's masque of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Single Equip
 7236	tumbling red-hot poker of extreme caution	0		Monster Level: -25
@@ -7131,26 +7131,26 @@
 7242	button	0		
 7243	red skewed button	0		
 7244	non-tarnished blood cells	0		Effect: "Afternoon Insight", Effect Duration: 27
-7245	activated polarized pulsating shaking eye	0		Effect: "Wallflowering", Effect Duration: 43
+7245	activated polarized shaking pulsating eye	0		Effect: "Wallflowering", Effect Duration: 43
 7246	ghostly glark cable	0		
 7247	mirror nasty forbidden Red Fox glove	0		Spell Damage Percent: +50, Stench Damage: +5, Attacks Can't Miss, Single Equip
 7248	adjusted bouncing foxglove	0		Effect: "Well Owl Be!", Effect Duration: 19
 7249	Thwaitgold dragonfly statuette	0		
 7250	zippy double-paned Sneaky Pete's jacket of Gandalf of temperance	0		Spell Critical Percent: +20, Cold Resistance: +5, Sleaze Resistance: +5, Initiative: +20, Softcore Only, Free Pull, Last Available: "2014-03"
-7251	bouncing tumbling jug of Sneaky Pete's Mojo	0		Free Pull
+7251	tumbling bouncing jug of Sneaky Pete's Mojo	0		Free Pull
 7252	wobbly shot of Sneaky Pete's Mojo	0		Free Pull
 7253	wobbly Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
 7255	tolerable mini-martini	3	good	
 7256	skewed smoke grenade	0		
 7257	compressed huge molotov soda	1	decent	
-7258	wet Vulcanized spinning huge pile of ashes	0		Effect: "Rave Concentration", Effect Duration: 14
+7258	wet Vulcanized huge spinning pile of ashes	0		Effect: "Rave Concentration", Effect Duration: 14
 7259	crate of firebombs	0		
 7260	firebomb	0		
 7261	lion tamer's slick Sneaky Pete's basket of the sweet-tooth	0		Moxie: +10, Experience (familiar): +2, Candy Drop: +100
 7262	twirling &quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
-7264	spinning mirror teal photograph of a nugget	0		
+7264	mirror teal spinning photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
 7266	huge disposable instant camera	0		
 7267	rosewater-soaked quilted Sneaky Pete's jacket (collar popped) of Gandalf of the sweet-tooth	0		Damage Absorption: +40, Spell Critical Percent: +20, Stench Resistance: +3, Candy Drop: +100, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7210,13 +7210,13 @@
 7321	purple brainy Stephen's lab coat of the storm	0		Mysticality: +5, Maximum MP Percent: +40
 7322	boiled activated Stephen's secret formula	0		Effect: "Frigid Weapon", Effect Duration: 13
 7323	resourceful shellacked Jacob's rung	0		Damage Reduction: 7, Maximum MP: +50
-7324	compressed twirling skewed fuchsia battery	1		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 5
+7324	compressed skewed twirling fuchsia battery	1		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 5
 7325	drinkable snakebite	4	good	
 7326	mirror wicked rubber ribcage of the pedagogue	0		Experience: +3, Spell Damage: +5, Damage Reduction: 7
 7327	denatured mirror gray synthetic marrow	1		Effect: "Fangs and Pangs", Effect Duration: 50
 7328	oxidized super-diffused funny bone	0		Effect: "Alacri Tea", Effect Duration: 68
 7329	forbidden baleful half-melted spoon	0		Spell Damage: +25, Spell Damage Percent: +50
-7330	modified blinking maroon the funk	1		
+7330	modified maroon blinking the funk	1		
 7331	huge rotten shaking gunky chicken	10	crappy	
 7332	gray rosewater-soaked doll head	0		Stench Resistance: +3
 7333	skewed droopy doll eye	0		
@@ -7228,7 +7228,7 @@
 7339	skewed music box mechanism	0		
 7340	ghostly moose antlers of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, 1xLep, cap 27"
 7341	boiled cyan moose thought	0		Effect: "X-Ray Vision", Effect Duration: 65
-7342	diet spoiled moose chocolate	1	crappy	
+7342	spoiled diet moose chocolate	1	crappy	
 7343	artisanal huge painting of a glass of wine	3	EPIC	
 7344	mirror oil painting of yourself	0		
 7345	skewed ornate picture frame	0		
@@ -7250,11 +7250,11 @@
 7361	plaid pocket square of the detective	0		Item Drop: +20
 7362	olive blurry miser's smooth plaid skirt	0		Moxie: +15, Meat Drop: +10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	colloidal super-ionized bloodstain stick	0		Effect: "No Vertigo", Effect Duration: 13
-7364	squat skewed fabric softener	0		
+7364	skewed squat fabric softener	0		
 7365	vacuum-sealed fabric hardener	0		Effect: "Space Cowboy", Effect Duration: 34
 7366	fancy artisanal strong bottle of laundry sherry	5	EPIC	Effect: "Human-Slime Hybrid", Effect Duration: 20
 7367	dry wet blurry wobbly industrial strength starch	0		Effect: "Spiritually Awake", Effect Duration: 34, Wiki Name: "industrial strength starch"
-7368	adequate special blurry extra-flat panini	4	good	Effect: "Moon-Eyed", Effect Duration: 50
+7368	special adequate blurry extra-flat panini	4	good	Effect: "Moon-Eyed", Effect Duration: 50
 7369	unsweetened jittery mangled finger	0		Effect: "Angry like the Wolf", Effect Duration: 45
 7370	drinkable Psychotic Train wine	4	good	
 7371	crazy hobo notebook	0		
@@ -7277,7 +7277,7 @@
 7388	unsweetened deionized Gene Tonic: Humanoid	0		Effect: "Human-Beast Hybrid", Effect Duration: 67, Last Available: "2014-04"
 7389	anodized improved ionized Gene Tonic: Insect	0		Effect: "Oth-Jeal-O", Effect Duration: 31, Last Available: "2014-04"
 7390	chilled Gene Tonic: Hippy	0		Effect: "Cheered Up", Effect Duration: 11, Last Available: "2014-04"
-7391	concentrated polymerized skewed jittery Gene Tonic: Orc	0		Effect: "Quiet 'n' Good", Effect Duration: 60, Last Available: "2014-04"
+7391	concentrated polymerized jittery skewed Gene Tonic: Orc	0		Effect: "Quiet 'n' Good", Effect Duration: 60, Last Available: "2014-04"
 7392	diffused diffused huge Gene Tonic: Demon	0		Effect: "Full of Vinegar", Effect Duration: 20, Last Available: "2014-04"
 7393	aerosolized tarnished Gene Tonic: Horror	0		Effect: "Sausage Festive", Effect Duration: 55, Last Available: "2014-04"
 7394	triple-boiled nitrogenated tarnished Gene Tonic: Fish	0		Effect: "Abyssal Sweat", Effect Duration: 46, Last Available: "2014-04"
@@ -7288,7 +7288,7 @@
 7399	diffused boiled maroon Gene Tonic: Elf	0		Effect: "Strawberry Alarm", Effect Duration: 57, Last Available: "2014-04"
 7400	pickled dry squat Gene Tonic: Mer-kin	0		Effect: "Gunky Dory", Effect Duration: 42, Last Available: "2014-04"
 7401	super-frozen polymerized twirling Gene Tonic: Slime	0		Effect: "Impregnably Delicious", Effect Duration: 48, Last Available: "2014-04"
-7402	dry spinning ghostly Gene Tonic: Penguin	0		Effect: "Incredibly Hulking", Effect Duration: 23, Last Available: "2014-04"
+7402	dry ghostly spinning Gene Tonic: Penguin	0		Effect: "Incredibly Hulking", Effect Duration: 23, Last Available: "2014-04"
 7403	enhanced dry squat Gene Tonic: Elemental	0		Effect: "Mad at Science", Effect Duration: 40, Last Available: "2014-04"
 7404	flattened frozen Gene Tonic: Constellation	0		Effect: "Analog Drunk", Effect Duration: 17, Last Available: "2014-04"
 7405	irradiated nitrogenated Gene Tonic: Hobo	0		Effect: "Banono", Effect Duration: 30, Last Available: "2014-04"
@@ -7325,13 +7325,13 @@
 7436	ionized improved quadruple-deionized tumbling Tremella Tarantella mushroom	0		Effect: "Sourpuss", Effect Duration: 51, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	spoiled cyan wobbly Beefy Crunch Pastaco	3	crappy	Last Available: "2014-05"
-7439	miniature adequate Brain Food Pastaco	2	good	Last Available: "2014-05"
+7439	adequate miniature Brain Food Pastaco	2	good	Last Available: "2014-05"
 7440	gigantic rotten Cool Brunch Pastaco	7	crappy	Last Available: "2014-05"
 7441	gigantic normal Medical Pastaco	10	good	Last Available: "2014-05"
 7442	spoiled pulsating Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
 7443	bland Ludovico Pastaco	4	decent	Last Available: "2014-05"
-7444	aged high-proof squat overpowering mushroom wine	9	awesome	Last Available: "2014-05"
-7445	weak lousy blinking complex mushroom wine	2	decent	Last Available: "2014-05"
+7444	high-proof aged squat overpowering mushroom wine	9	awesome	Last Available: "2014-05"
+7445	lousy weak blinking complex mushroom wine	2	decent	Last Available: "2014-05"
 7446	watered-down tolerable smooth mushroom wine	2	good	Last Available: "2014-05"
 7447	acceptable tumbling blood-red mushroom wine	3	good	Last Available: "2014-05"
 7448	lousy practically non-alcoholic buzzing mushroom wine	1	decent	Last Available: "2014-05"
@@ -7342,19 +7342,19 @@
 7453	artisanal huge regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	hand-crafted super-size brogurt	3	EPIC	Last Available: "2014-05"
 7455	artisanal blinking broberry brogurt	3	EPIC	Last Available: "2014-05"
-7456	mediocre high-proof huge olive brocolate brogurt	9	decent	Last Available: "2014-05"
+7456	mediocre high-proof olive huge brocolate brogurt	9	decent	Last Available: "2014-05"
 7457	artisanal watered-down French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7458	narrow twirling History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
+7458	twirling narrow History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Fonzie's Brogre brorts	0		Experience (Moxie): +1, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Fonzie's Brogre brorts	0		Experience (Moxie): +1, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	wobbly veiny Brogre brolo shirt	0		Maximum HP: +10, Last Available: "2014-05"
-7464	flame-retardant Brogre bucket hat	0		Hot Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	flame-retardant Brogre bucket hat	0		Hot Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	mirror Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	prompt lion tamer's Da Vinci's 8-billed baseball cap	0		Experience (Mysticality): +5, Experience (familiar): +2, Adventures: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	prompt lion tamer's Da Vinci's 8-billed baseball cap	0		Experience (Mysticality): +5, Experience (familiar): +2, Adventures: +3, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	blurry healthy cool beefy extremely wet T-shirt	0		Muscle: +10, Moxie: +5, Maximum HP Percent: +20, Last Available: "2014-05"
 7470	blurry chaotic clever groovy shrimp fork	0		Moxie Percent: +10, Maximum MP: +20, Spell Critical Percent: +10, Last Available: "2014-05"
 7471	moist mirror BROS Energy Drink	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 58, Last Available: "2014-05"
@@ -7367,8 +7367,8 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	polymerized adjusted sugar fairy	0		Effect: "Okee-Dokee Go!", Effect Duration: 64, Last Available: "2014-05"
 7480	non-adjusted improved magnetized ghostly mirror sugar bunny	0		Effect: "Block-Rockin' Beet", Effect Duration: 12, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	bad practically non-alcoholic Rompedores de Fantasmas	1	decent	
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	practically non-alcoholic bad Rompedores de Fantasmas	1	decent	
 7483	lousy spirit-forward blinking La Fantasma y La Oscuridad	5	decent	
 7484	watered-down acceptable spinning Fantasma en la M&aacute;quina	2	good	
 7485	upside-down loosening powder	0		
@@ -7378,13 +7378,13 @@
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
 7491	acceptable fancy gray bottle of Chateau de Vinegar	3	good	Effect: "Oth-Jeal-O", Effect Duration: 20
-7492	blue blinking blasting soda	0		
+7492	blinking blue blasting soda	0		
 7493	tumbling unstable fulminate	0		
-7494	jittery narrow wine bomb	0		
+7494	narrow jittery wine bomb	0		
 7495	yellow recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
-7498	narrow ghostly Thwaitgold wheel bug statuette	0		
+7498	ghostly narrow Thwaitgold wheel bug statuette	0		
 7499	adjusted ghostly Hot 'n' Scarys	0		Effect: "There Is A Spoon", Effect Duration: 39
 7500	mirror mirror map	0		
 7501		0		
@@ -7394,8 +7394,8 @@
 7505	squat studded dark porquoise ring	0		Damage Absorption: +80
 7506	squat rosewater-soaked energetic book	0		Maximum MP Percent: +20, Stench Resistance: +3
 7507	jittery cloak of the sewer	0		Stench Damage: +25
-7508	jittery green label	0		
-7509	bland enchanted low-calorie pulsating spinning Mornington crescent roll	1	decent	Effect: "How to Scam Tourists", Effect Duration: 10
+7508	green jittery label	0		
+7509	bland low-calorie enchanted pulsating spinning Mornington crescent roll	1	decent	Effect: "How to Scam Tourists", Effect Duration: 10
 7510	quantum enhanced eye shadow	0		Effect: "Tiki Thoughtfulness", Effect Duration: 34
 7511	crumbling wheel	0		
 7512	double-warmed colloidal poppy	0		Effect: "Witch's Brood", Effect Duration: 39
@@ -7405,7 +7405,7 @@
 7516	witch's spare house key	0		
 7517	rosewater-soaked spider leg of the sewer	0		Stench Damage: +25, Stench Resistance: +3
 7518	wand of pigification	0		
-7519	acceptable boozy glass of bourbon	5	good	
+7519	boozy acceptable glass of bourbon	5	good	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	spoiled government cheese	3	crappy	Last Available: "2014-05"
 7522	lime green narrow up-at-dawn pair of government shades	0		Adventures: +5, Single Equip, Last Available: "2014-05"
@@ -7416,29 +7416,29 @@
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	shellacked government-issued night-vision goggles of dire peril	0		Weapon Damage: +20, Damage Reduction: 7, Single Equip, Last Available: "2014-05"
 7529	decent loaf of alien bread	4	good	Last Available: "2014-05"
-7530	adequate jumbo special blurry yellow grilled cheese sandwich	5	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2014-05"
+7530	jumbo special adequate blurry yellow grilled cheese sandwich	5	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2014-05"
 7531	diluted alien protein powder	1	good	Last Available: "2014-05"
 7532	fortified hand-crafted blue rocket fuel	5	EPIC	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	practically non-alcoholic drinkable stealth bomber	1	good	Last Available: "2014-05"
+7535	drinkable practically non-alcoholic stealth bomber	1	good	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	jittery twitching space egg	0		Last Available: "2014-05"
 7538	lime green ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	blurry squat banded space beast fur hat	0		Damage Absorption: +100, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	tumbling groovy space beast fur pants	0		Moxie Percent: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	blurry squat banded space beast fur hat	0		Damage Absorption: +100, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	tumbling groovy space beast fur pants	0		Moxie Percent: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	space beast fur whip of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2014-05"
 7542	maroon space invader	0		Last Available: "2014-05"
 7543	family-friendly rock-hard space heater	0		Damage Reduction: 5, Sleaze Resistance: +1, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
-7545	perfectly mixed practically non-alcoholic space port	1	EPIC	Last Available: "2014-05"
+7545	practically non-alcoholic perfectly mixed space port	1	EPIC	Last Available: "2014-05"
 7546	rock-hard groovy space needle	0		Moxie Percent: +10, Damage Reduction: 5, Last Available: "2014-05"
 7547	colloidal red buffed alien drugs	0		Effect: "I See Everything Thrice!", Effect Duration: 19, Last Available: "2014-05"
 7548	bouncing hot ashes	0		Last Available: "2014-06"
 7549	quadruple-altered skewed ash soda	0		Effect: "Unusual Fashion Sense", Effect Duration: 27, Last Available: "2014-06"
-7550	irradiated pressed shaking purple liquid smoke	0		Effect: "Creepin' Up on You", Effect Duration: 51, Last Available: "2014-06"
+7550	irradiated pressed purple shaking liquid smoke	0		Effect: "Creepin' Up on You", Effect Duration: 51, Last Available: "2014-06"
 7551	super-polarized oxidized jittery dollop of barbecue sauce	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 45, Last Available: "2014-06"
-7552	polymerized quadruple-liquefied bouncing mirror cyan spinning bowl of marinade	0		Effect: "Broken Fast", Effect Duration: 55, Last Available: "2014-06"
+7552	polymerized quadruple-liquefied mirror bouncing cyan spinning bowl of marinade	0		Effect: "Broken Fast", Effect Duration: 55, Last Available: "2014-06"
 7553	narrow shaker of dry rub	0		Last Available: "2014-06"
 7554	irradiated ionized dry bottle of lighter fluid	0		Effect: "Human-Demon Hybrid", Effect Duration: 22, Last Available: "2014-06"
 7555	page	0		
@@ -7458,7 +7458,7 @@
 7569	ribald groovy Time Bandit Badge of Courage of Flo-Jo	0		Moxie Percent: +10, Sleaze Damage: +10, Initiative: +100
 7570	double-denatured modified Friendliness Beverage	0		Effect: "Familial Ties", Effect Duration: 31
 7571	fireproof extremely unsafe silent pea shooter	0		Weapon Damage Percent: +100, Hot Resistance: +3
-7572	jumbo stale D roll	5	decent	
+7572	stale jumbo D roll	5	decent	
 7573	blurry hale beefy kiwi beak	0		Muscle: +10, Maximum HP: +20
 7574	weak bad New Zealand iced tea	2	decent	
 7575	tumbling lightning-fast double-paned droll monocle	0		Cold Resistance: +5, Initiative: +40, Single Equip
@@ -7477,15 +7477,15 @@
 7588	pulsating Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	artisanal glass of &quot;milk&quot;	3	EPIC	Last Available: "2014-07"
 7590	hand-crafted irresponsibly strong cup of &quot;tea&quot;	7	EPIC	Last Available: "2014-07"
-7591	watered-down bad thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
+7591	bad watered-down thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
 7592	irresponsibly strong acceptable Lucky Lindy	6	good	Last Available: "2014-07"
 7593	drinkable Bee's Knees	4	good	Last Available: "2014-07"
 7594	artisanal Sockdollager	4	EPIC	Last Available: "2014-07"
-7595	irresponsibly strong lousy huge Ish Kabibble	7	decent	Last Available: "2014-07"
+7595	lousy irresponsibly strong huge Ish Kabibble	7	decent	Last Available: "2014-07"
 7596	tolerable Hot Socks	3	good	Last Available: "2014-07"
 7597	perfectly mixed Phonus Balonus	3	EPIC	Last Available: "2014-07"
 7598	bad Flivver	3	decent	Last Available: "2014-07"
-7599	perfectly mixed practically non-alcoholic Sloppy Jalopy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
+7599	practically non-alcoholic perfectly mixed Sloppy Jalopy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7600	corrupted upside-down huge flame	0		Effect: "Hare-o-dynamic", Effect Duration: 69
 7601	altered moist temporary yak tattoo	0		Effect: "Big Meat Big Prizes", Effect Duration: 37
 7602	liquefied alkaline alkaline jittery Fitspiration&trade; poster	0		Effect: "Rave Nirvana", Effect Duration: 62
@@ -7519,7 +7519,7 @@
 7630	super-Vulcanized mirror magic powder	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 61
 7631	warmed friar's tonsure	0		Effect: "Medieval Mage Mayhem", Effect Duration: 12
 7632	quadruple-wet boiled government-issue identification badge	0		Effect: "Gamer Rage", Effect Duration: 20
-7633	double-ionized moist magnetized green wobbly ghostly alien hologram projector	0		Effect: "Halloweeny", Effect Duration: 16
+7633	double-ionized moist magnetized green ghostly wobbly alien hologram projector	0		Effect: "Halloweeny", Effect Duration: 16
 7634	chilled aerosolized irradiated turtle	0		Effect: "Dirty Pear", Effect Duration: 22
 7635	dry quantum cigar box turtle	0		Effect: "Ooh, Salty!", Effect Duration: 30
 7636	thinker's shellacked shell of the cougar	0		Mysticality: +10, Moxie: +20, Class: "Turtle Tamer"
@@ -7534,7 +7534,7 @@
 7645	life preserver	0		
 7646	lightning milk	0		
 7647	wobbly aquaconda brain	0		
-7648	spinning blurry thunder thigh	0		
+7648	blurry spinning thunder thigh	0		
 7649	ionized anodized gourmet gourami oil	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 40
 7650	nitrogenated magnetized catfish whiskers	0		Effect: "Sewer-Drenched", Effect Duration: 44
 7651	freshwater fishbone	0		
@@ -7548,7 +7548,7 @@
 7659	quilted neoprene skullcap	0		Damage Absorption: +40, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	alkaline polarized tumbling goblin water	0		Effect: "Pockets of Fire", Effect Duration: 11
 7661	dumb mud	0		
-7662	fancy tasty big Sogg-Os	5	awesome	Effect: "20-20 Second Sight", Effect Duration: 25
+7662	tasty big fancy Sogg-Os	5	awesome	Effect: "20-20 Second Sight", Effect Duration: 25
 7663	Usain Bolt's zippy therapeutic Lord Soggyraven's Slippers	0		Initiative: 100, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 7664	chilled corrupted twirling Ancient Protector Soda	0		Effect: "Incensed", Effect Duration: 18
 7665	ionized blue liquid ice	0		Effect: "Techno Bliss", Effect Duration: 11
@@ -7601,7 +7601,7 @@
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	rotten Strix stix	4	crappy	
 7714	teal Tesla vampire pellet of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10
-7715	high-proof aged wobbly non-aged vinegar	10	awesome	
+7715	aged high-proof wobbly non-aged vinegar	10	awesome	
 7716	maroon dance instructor's unsanitized scalpel	0		Experience Percent (Moxie): +10
 7717	Sinatra's gladiator tunica	0		Experience (Moxie): +5
 7718	personal trainer's Roman sadnals	0		Experience Percent (Muscle): +10, Single Equip
@@ -7639,10 +7639,10 @@
 7750	mirror Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	yellow Xiblaxian xeno-detection goggles of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2014-09"
-7753	hale rock-hard Xiblaxian stealth cowl	0		Damage Reduction: 5, Maximum HP: +20, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	hale rock-hard Xiblaxian stealth cowl	0		Damage Reduction: 5, Maximum HP: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	Van der Graaf Newton's Xiblaxian stealth trousers	0		Experience (Mysticality): +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-09"
 7755	upside-down greedy Xiblaxian stealth vest of the cheetah	0		Meat Drop: +20, Initiative: +60, Last Available: "2014-09"
-7756	miniature moldy Xiblaxian ultraburrito	2	crappy	Last Available: "2014-09"
+7756	moldy miniature Xiblaxian ultraburrito	2	crappy	Last Available: "2014-09"
 7757	perfectly mixed Xiblaxian space-whiskey	3	super EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	polarized They liver	0		Effect: "Arcane in the Brain", Effect Duration: 17, Last Available: "2014-09"
@@ -7668,16 +7668,16 @@
 7779	liquefied irradiated twirling twirling experimental serum G-9	0		Effect: "Poker Faced", Effect Duration: 21, Last Available: "2014-10"
 7780	Lo Pan's banded heavy-duty clipboard of the overflowing toilet	0		Damage Absorption: +100, Spell Critical Percent: +30, Stench Spell Damage: +50, Damage Reduction: 8, Last Available: "2014-10"
 7781	red nasty Van der Graaf groovy Rosewater's battery-powered drill	0		Mysticality Percent: +30, Moxie Percent: +10, Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-10"
-7782	super-sized moldy limp broccoli	5	crappy	Last Available: "2014-10"
-7783	mirror careful forbidden Newton's hat	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Monster Level: -10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
-7784	double-corrupted blinking spinning monkey barf	0		Effect: "Whitened Teeth", Effect Duration: 24, Last Available: "2014-10"
+7782	moldy super-sized limp broccoli	5	crappy	Last Available: "2014-10"
+7783	mirror careful forbidden Newton's hat	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Monster Level: -10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7784	double-corrupted spinning blinking monkey barf	0		Effect: "Whitened Teeth", Effect Duration: 24, Last Available: "2014-10"
 7785	corrupted cold-filtered candy	0		Effect: "Swordholder", Effect Duration: 14, Last Available: "2014-10"
 7786	blurry banded Sinatra's strapping jangly bracelet	0		Muscle: +5, Experience (Moxie): +5, Damage Absorption: +100, Last Available: "2014-10"
 7787	hardy cuddly teddy bear	0		Maximum HP: +50, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	Lo Pan's curative first-aid pouch	0		Spell Critical Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-10"
 7790	upside-down khaki duffel bag	0		Last Available: "2014-10"
-7791	nitrogenated altered skewed teal airborne mutagen	0		Effect: "The Power of LOV", Effect Duration: 64, Last Available: "2014-10"
+7791	nitrogenated altered teal skewed airborne mutagen	0		Effect: "The Power of LOV", Effect Duration: 64, Last Available: "2014-10"
 7792	narrow SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
@@ -7685,8 +7685,8 @@
 7796	bland warm war shawarma	3	decent	Last Available: "2014-10"
 7797	decent karma shawarma	3	good	Last Available: "2014-10"
 7798	lousy Jungle Juice	4	decent	Last Available: "2014-10"
-7799	fancy hand-crafted watered-down upside-down Amnesiac Ale	2	EPIC	Effect: "Milk Studly", Effect Duration: 35, Last Available: "2014-10"
-7800	lousy weak Highest Bitter	2	decent	Last Available: "2014-10"
+7799	hand-crafted watered-down fancy upside-down Amnesiac Ale	2	EPIC	Effect: "Milk Studly", Effect Duration: 35, Last Available: "2014-10"
+7800	weak lousy Highest Bitter	2	decent	Last Available: "2014-10"
 7801	clever wholesome mercenary pistol	0		Maximum HP Percent: +10, Maximum MP: +20, Last Available: "2014-10"
 7802	upside-down rock-hard mercenary rifle of horror	0		Damage Reduction: 5, Spooky Spell Damage: +25, Last Available: "2014-10"
 7803	squat Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7696,11 +7696,11 @@
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
 7809	impure gasoline	0		
-7810	ghostly lime green Z-Bone steak	0		
+7810	lime green ghostly Z-Bone steak	0		
 7811	squat blinking viral DNA	0		
-7812	pulsating jittery tarnished bottlecap	0		
-7813	big spoiled seared dino steak	5	crappy	
-7814	perfectly mixed irresponsibly strong bottle of drinkin' gas	8	EPIC	
+7812	jittery pulsating tarnished bottlecap	0		
+7813	spoiled big seared dino steak	5	crappy	
+7814	irresponsibly strong perfectly mixed bottle of drinkin' gas	8	EPIC	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	narrow spinning gelatinous meat mass	0		
@@ -7736,15 +7736,15 @@
 7847	denatured dry aerosolized ruby on canes	0		Effect: "Eyes Wide Propped", Effect Duration: 52, Last Available: "2014-12"
 7848	decent big petit fortran	5	good	Last Available: "2014-12"
 7849	flavorless huge java cookie	4	decent	Last Available: "2014-12"
-7850	immense flavorless olive cookie cookie	9	decent	Last Available: "2014-12"
+7850	flavorless immense olive cookie cookie	9	decent	Last Available: "2014-12"
 7851	skewed steel-toed plastic exo-suited miner	0		Damage Reduction: 9, Last Available: "2014-12"
 7852	plastic semi-autonomous drill unit of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2014-12"
 7853	cyan huge scandalous plastic ambulatory robo-minecart	0		Sleaze Damage: +5, Last Available: "2014-12"
 7854	plastic Crimbot of the early riser	0		Adventures: +7, Last Available: "2014-12"
 7855	squat zippy plastic Crimbomega	0		Initiative: +20, Last Available: "2014-12"
 7856	quadruple-modified ghostly flask of mining oil	0		Effect: "Material Witness", Effect Duration: 35, Last Available: "2014-12"
-7857	narrow frightening radiation-resistant helmet	0		Spooky Damage: +5, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	slick servo-assisted exo-pants	0		Moxie: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	narrow frightening radiation-resistant helmet	0		Spooky Damage: +5, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	slick servo-assisted exo-pants	0		Moxie: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	experienced high-energy mining laser of Leguizamo	0		Experience: +2, Monster Level: +20, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7780,7 +7780,7 @@
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	mirror Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
-7894	squat red mirror Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
+7894	red mirror squat Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	jittery Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
@@ -7808,10 +7808,10 @@
 7919	diffused pulsating Big Punk	0		Effect: "Thick, Sick", Effect Duration: 22
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	enchanted drinkable Friendly Turkey	3	good	Effect: "Super Vision", Effect Duration: 40, Last Available: "2014-11"
+7922	drinkable enchanted Friendly Turkey	3	good	Effect: "Super Vision", Effect Duration: 40, Last Available: "2014-11"
 7923	artisanal huge Agitated Turkey	3	EPIC	Last Available: "2014-11"
-7924	hand-crafted weak spinning skewed Ambitious Turkey	2	EPIC	Last Available: "2014-11"
-7925	small delicious neutron lollipop	2	awesome	Last Available: "2014-12"
+7924	weak hand-crafted skewed spinning Ambitious Turkey	2	EPIC	Last Available: "2014-11"
+7925	delicious small neutron lollipop	2	awesome	Last Available: "2014-12"
 7926	hand-crafted weak gamma nog	2	EPIC	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7827,18 +7827,18 @@
 7945	huge table	0		
 7946	gravedigger's outlaw bandana of the sweet-tooth of Flo-Jo	0		Spooky Damage: +10, Candy Drop: +100, Initiative: +100
 7947	drinkable whiskey in a broken glass	4	good	
-7948	special high-proof tolerable pulsating shot of mescal	8	good	Effect: "Dance Interpreter", Effect Duration: 15
-7949	watered-down perfectly mixed glass of herbal tequila	2	EPIC	
+7948	high-proof special tolerable pulsating shot of mescal	8	good	Effect: "Dance Interpreter", Effect Duration: 15
+7949	perfectly mixed watered-down glass of herbal tequila	2	EPIC	
 7950	tumbling green minin' dynamite	0		
 7951	smelly plaid cowboy hat of the blizzard	0		Cold Spell Damage: +25, Stench Spell Damage: +10, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	fuchsia lasso	0		
 7953	greedy dance instructor's Fonzie's rusted-out shootin' iron	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Meat Drop: +20
-7954	green huge rattler rattle	0		
+7954	huge green rattler rattle	0		
 7955	huge bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	cyan even more tinsel	0		Familiar Weight: +5
 7958	blurry box of Crimbo decorations	0		
-7959	squat bouncing letter to Ed the Undying	0		
+7959	bouncing squat letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	double-paned foul-smelling steel-toed grievous Staff of Ed	0		Weapon Damage Percent: +50, Damage Reduction: 9, Stench Damage: +10, Cold Resistance: +5
 7962	Eye of Ed	0		
@@ -7847,11 +7847,11 @@
 7965	Holy MacGuffin	0		
 7966	Ka coin	0		
 7967	clever World's Best Adventurer sash	0		Maximum MP: +20
-7968	tumbling blurry topiary nugglet	0		
+7968	blurry tumbling topiary nugglet	0		
 7969	beehive	0		
 7970	boning knife	0		
 7971	squat Aggressive Carrot	0		Free Pull
-7972	compressed blue spinning mummified fig	1	EPIC	
+7972	compressed spinning blue mummified fig	1	EPIC	
 7973	powdered wobbly mummified loaf of bread	1	crappy	
 7974	boiled maroon mummified beef haunch	1	EPIC	
 7975	pulsating linen bandages	0		
@@ -7881,7 +7881,7 @@
 7999	enhanced anodized red skewed tumbling choco-Crimbot	0		Effect: "Cranberry Cordiality", Effect Duration: 68, Last Available: "2014-12"
 8000	colloidal smart watch	0		Effect: "Charrrming", Effect Duration: 63, Last Available: "2014-12"
 8001	irradiated augmented-reality shades	0		Effect: "Eye of the Seal", Effect Duration: 63, Last Available: "2014-12"
-8002	huge manspreader's toy Crimbot mega face	0		Monster Level: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8002	huge manspreader's toy Crimbot mega face	0		Monster Level: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
 8003	supercharged toy Crimbot power glove	0		Maximum MP Percent: +30, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	spinning fuchsia toy Crimbot super fist of the cougar	0		Moxie: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	double-paned toy Crimbot rocket legs	0		Cold Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
@@ -7895,11 +7895,11 @@
 8013	upside-down Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8016	corrupted mirror skewed fitness wristband	0		Effect: "Crimbo Flavor", Effect Duration: 32, Last Available: "2014-12"
+8016	corrupted skewed mirror fitness wristband	0		Effect: "Crimbo Flavor", Effect Duration: 32, Last Available: "2014-12"
 8017	nitrogenated blinking huge flask of tainted mining oil	0		Effect: "Moose Wisdom", Effect Duration: 31, Last Available: "2014-12"
 8018	pickled chilled diffused mirror and rain stick	0		Effect: "Spell Transfer Complete", Effect Duration: 48
 8019	upside-down teal Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	super-sized flavorless Choco-Mint patty	5	decent	Last Available: "2015-01"
+8020	flavorless super-sized Choco-Mint patty	5	decent	Last Available: "2015-01"
 8021	lousy hot mint schnocolate	4	decent	Last Available: "2015-01"
 8022	modified gray homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	red muscle stimulator	0		Last Available: "2015-01"
@@ -7932,7 +7932,7 @@
 8051	rosewater-soaked cape	0		Stench Resistance: +3
 8052	bouncing stanky jetpack	0		Stench Spell Damage: +25
 8053	spring boots	0		
-8054	skewed fuchsia spiked boots	0		
+8054	fuchsia skewed spiked boots	0		
 8055	pickaxe of the wise owl	0		Mysticality: +20
 8056	torch	0		
 8057	sizzling thinker's [spelunking test kit]	0		Mysticality: +10, Hot Damage: +10
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	blurry janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	reassuring studded arcane researcher's Spelunker's fedora	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Spooky Resistance: +1, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	reassuring studded arcane researcher's Spelunker's fedora	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Spooky Resistance: +1, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	careful hardened dangerous Spelunker's whip	0		Weapon Damage: +10, Damage Reduction: 3, Monster Level: -10, Last Available: "2015-12"
-8076	Jeselnik's foul-smelling mansplainer's Spelunker's khakis	0		Monster Level: +15, Stench Damage: +10, Sleaze Damage: +25, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	Jeselnik's foul-smelling mansplainer's Spelunker's khakis	0		Monster Level: +15, Stench Damage: +10, Sleaze Damage: +25, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	tumbling Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	cyan LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7991,7 +7991,7 @@
 8116	toasty beefy whisk	0		Muscle: +10, Hot Damage: +5, Last Available: "2017-12"
 8117	stanky Sinatra's walker	0		Experience (Moxie): +5, Stench Spell Damage: +25, Single Equip, Last Available: "2017-12"
 8118	twirling ghostly miser's waders of Leguizamo	0		Monster Level: +20, Meat Drop: +10, Last Available: "2017-12"
-8119	dehydrated maroon squat flakes	1		Effect: "Hot Blooded", Effect Duration: 15, Last Available: "2017-12"
+8119	dehydrated squat maroon flakes	1		Effect: "Hot Blooded", Effect Duration: 15, Last Available: "2017-12"
 8120	Samson's gaiters of vim and vigor	0		Experience (Muscle): +5, Maximum HP Percent: +50, Last Available: "2018-12"
 8121	narrow lightning-fast toasty garland	0		Hot Damage: +5, Initiative: +40, Single Equip, Last Available: "2018-12"
 8122	electrified Herculean gunnysack	0		Experience (Muscle): +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-12"
@@ -8056,20 +8056,20 @@
 8182	gray Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	tumbling jittery stylish bread basket	0		Moxie: +25
 8184	blue Ed the Undying exhibit crate	0		
-8185	spinning greedy rosewater-soaked The Crown of Ed the Undying	0		Stench Resistance: +3, Meat Drop: +20, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
-8186	purple tumbling Doc Galaktik's Invigorating Tonic	0		
+8185	spinning greedy rosewater-soaked The Crown of Ed the Undying	0		Stench Resistance: +3, Meat Drop: +20, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8186	tumbling purple Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	lousy weak Cherrytastrophe wine cooler	2	decent	
+8188	weak lousy Cherrytastrophe wine cooler	2	decent	
 8189	hand-crafted narrow Radberry Rip wine cooler	3	EPIC	
 8190	practically non-alcoholic acceptable Orangemageddon wine cooler	1	good	
 8191	tolerable fancy fuchsia Breakfast Blast wine cooler	3	good	Effect: "Super-Mega-Charged", Effect Duration: 15
 8192	tolerable Citrus Crush wine cooler	4	good	
-8193	gigantic flavorless purple plain bagel	7	decent	
+8193	flavorless gigantic purple plain bagel	7	decent	
 8194	bland big glob of cream cheese	5	decent	
 8195	bland loaf of soda bread	4	decent	
 8196	adequate acceptable bagel	4	good	
 8197	normal standard-issue cupcake	3	good	
-8198	bite-sized adequate ultra-deluxe cupcake	1	good	
+8198	adequate bite-sized ultra-deluxe cupcake	1	good	
 8199	hypnotic breadcrumbs	0		
 8200	normal popular tart	3	good	
 8201	no-handed pie	0		
@@ -8091,8 +8091,8 @@
 8217	arcane researcher's perfume-soaked bandana of wisdom	0		Mysticality: +15, Experience Percent (Mysticality): +10, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	flavorless toxo	4	decent	Last Available: "2015-04"
-8220	practically non-alcoholic acceptable Lemonade-235	1	good	Last Available: "2015-04"
-8221	double-paned isotophat of James Dean	0		Experience (Moxie): +3, Cold Resistance: +5, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	acceptable practically non-alcoholic Lemonade-235	1	good	Last Available: "2015-04"
+8221	double-paned isotophat of James Dean	0		Experience (Moxie): +3, Cold Resistance: +5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	upside-down perfumed Three Mile Island shorts of the sewer	0		Stench Damage: +25, Stench Resistance: +5, Last Available: "2015-04"
 8223	red censurious cool toxic mop	0		Moxie: +5, Sleaze Resistance: +3, Last Available: "2015-04"
 8224	teal inert sludgepuppy	0		Last Available: "2015-04"
@@ -8118,20 +8118,20 @@
 8244	olive lube-shoes of the early riser	0		Adventures: +7, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	sage Dinsey mascot mask of the scaredy-cat of bravery	0		Mysticality Percent: +10, Monster Level: -15, Spooky Resistance: +5, Last Available: "2015-04"
-8247	small adequate Dinsey food-cone	2	good	Last Available: "2015-04"
-8248	watered-down tolerable Dinsey Whinskey	2	good	Last Available: "2015-04"
+8247	adequate small Dinsey food-cone	2	good	Last Available: "2015-04"
+8248	tolerable watered-down Dinsey Whinskey	2	good	Last Available: "2015-04"
 8249	adjusted pulsating Dinsey face paint	0		Effect: "Dragged Through the Coals", Effect Duration: 39, Last Available: "2015-04"
 8250	cyan aromatic razor-sharp fannypack	0		Weapon Damage Percent: +25, Stench Resistance: +1, Last Available: "2015-04"
 8251	upside-down Sherlock's Jack Frost's ruddy sinister Samson's garbage sticker of wisdom	0		Mysticality: +15, Experience (Muscle): +5, Spell Damage: +10, Maximum HP Percent: +40, Cold Spell Damage: +50, Item Drop: +25, Last Available: "2015-04"
 8252	Tesla steel-toed stiffened hazmat helmet of the brute of the empath	0		Muscle Percent: +30, Damage Reduction: 20, Familiar Weight: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-04"
-8253	jittery red huge bouncing Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
+8253	red jittery bouncing huge Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	pulsating Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	pressed triple-dry nasty gum	0		Effect: "Spookypants", Effect Duration: 13
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	ghostly teal friendly The Lot's engagement ring	0		Familiar Weight: +3, Conditional Skill (Equipped): "Propose To Your Opponent"
-8260	tumbling spinning Mayo Clinic	0		Last Available: "2015-05"
+8260	spinning tumbling Mayo Clinic	0		Last Available: "2015-05"
 8261	spinning Mayonex	0		Last Available: "2015-05"
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	huge Mayostat	0		Last Available: "2015-05"
@@ -8141,18 +8141,18 @@
 8267	narrow Fonzie's sphygmayomanometer	0		Experience (Moxie): +1, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	moldy purple blinking unappetizing mayolus	4	crappy	Last Available: "2015-05"
+8270	moldy blinking purple unappetizing mayolus	4	crappy	Last Available: "2015-05"
 8271	flavorless twirling twirling uninteresting mayolus	3	decent	Last Available: "2015-05"
 8272	spoiled acceptable mayolus	4	crappy	Last Available: "2015-05"
 8273	rotten tiny enticing mayolus	1	crappy	Last Available: "2015-05"
 8274	flavorless twirling mouth-watering mayolus	4	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
-8277	blinking tumbling Essence of Bear	0		Skill: "Bear Essence"
+8277	tumbling blinking Essence of Bear	0		Skill: "Bear Essence"
 8278	aged Afternoon Delight	3	awesome	Last Available: "2015-04"
 8279	cyan Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
-8281	irradiated quantum altered blurry gray Kokomo Resort Brand Suntan Oil	0		Effect: "Space Tripping", Effect Duration: 20, Last Available: "2015-04"
+8281	irradiated quantum altered gray blurry Kokomo Resort Brand Suntan Oil	0		Effect: "Space Tripping", Effect Duration: 20, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	non-cold-filtered spinning Kokomo Resort Pass	0		Effect: "Floundering", Effect Duration: 37, Last Available: "2023-08"
@@ -8193,7 +8193,7 @@
 8319	anodized pulsating jazzy cigarette holder	0		Effect: "Cranberry Cordiality", Effect Duration: 47
 8320	improved mirror one glove	0		Effect: "Bloody-minded", Effect Duration: 44
 8321	corrupted non-moist gray glove	0		Effect: "Your Eyes are Peeled!", Effect Duration: 21
-8322	polarized ionized teal mirror handful of fire	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 49
+8322	polarized ionized mirror teal handful of fire	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 49
 8323	quantum quadruple-chilled tumbling Cracklin' Oat Bran	0		Effect: "Purpose", Effect Duration: 18
 8324	polarized wobbly disposable lighter	0		Effect: "Cold Throat", Effect Duration: 59
 8325	enhanced twirling coal contact lenses	0		Effect: "Wet Willied", Effect Duration: 49
@@ -8212,7 +8212,7 @@
 8338	non-frozen warmed shaking Leonard's glasses	0		Effect: "Sagittarius Rising", Effect Duration: 39
 8339	colloidal yellow warehouse walkie-talkie	0		Effect: "Eagle Eyes", Effect Duration: 30
 8340	quantum tumbling blue janitor's mop	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 18
-8341	enhanced adjusted green twirling warehouse clerk's glasses	0		Effect: "Barbecue Saucy", Effect Duration: 64
+8341	enhanced adjusted twirling green warehouse clerk's glasses	0		Effect: "Barbecue Saucy", Effect Duration: 64
 8342	tarnished Vulcanized jittery baloney rotgut	0		Effect: "Al Dente Inferno", Effect Duration: 26
 8343	chilled magnetized squat carton of gaspers	0		Effect: "Flashing Eyes", Effect Duration: 32
 8344	super-activated pulsating bronze polish	0		Effect: "Bone Homie", Effect Duration: 15
@@ -8235,21 +8235,21 @@
 8361	extra-Vulcanized fuchsia child-sized dracula cloak	0		Effect: "Slimy Hands", Effect Duration: 62
 8362	vacuum-sealed quadruple-warmed galvanized devil-summoning hat	0		Effect: "Cool Spirit", Effect Duration: 50
 8363	super-deionized shopkeeper beard	0		Effect: "Omphalotus Omnipresence", Effect Duration: 36
-8364	quadruple-quantum boiled pulsating lime green alien autoautopsy kit	0		Effect: "Chorale of Companionship", Effect Duration: 15
+8364	quadruple-quantum boiled lime green pulsating alien autoautopsy kit	0		Effect: "Chorale of Companionship", Effect Duration: 15
 8365	cold-filtered nitrogenated novelty fruit hat	0		Effect: "Incensed", Effect Duration: 41
 8366	cold-filtered chilled skewed invisibility cream	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 35
 8367	chilled blurry handful of stubble	0		Effect: "Industrial Strength Starch", Effect Duration: 29
-8368	dry altered bouncing maroon garbage juice slurpee	0		Effect: "Analog Drunk", Effect Duration: 64
+8368	dry altered maroon bouncing garbage juice slurpee	0		Effect: "Analog Drunk", Effect Duration: 64
 8369	modified shaking plunge-leg	0		Effect: "Okee-Dokee Computer", Effect Duration: 68
 8370	modified non-warmed ghostly funky eyepatch	0		Effect: "In a Lather", Effect Duration: 57
 8371	concentrated magnetized blinking bucket of fish juice	0		Effect: "Wasabi With You", Effect Duration: 55
-8372	Vulcanized maroon wobbly flashy pirate dreadlocks	0		Effect: "Pumped Up", Effect Duration: 44
+8372	Vulcanized wobbly maroon flashy pirate dreadlocks	0		Effect: "Pumped Up", Effect Duration: 44
 8373	double-anodized denatured chilled captured boozles	0		Effect: "Innately Wise", Effect Duration: 45
 8374	triple-galvanized alkaline skewed huge drinks tray	0		Effect: "Demonic Flavor", Effect Duration: 52
 8375	galvanized purple eyebrow lifter	0		Effect: "Slippery Tongue", Effect Duration: 35
 8376	ghostly submarine	0		Last Available: "2015-06"
 8377	decent pixel lemon	4	good	Last Available: "2015-06"
-8378	high-proof artisanal pixel daiquiri	9	EPIC	Last Available: "2015-06"
+8378	artisanal high-proof pixel daiquiri	9	EPIC	Last Available: "2015-06"
 8379	nitrogenated oxidized power pill	0		Effect: "Items Are Forever", Effect Duration: 16, Last Available: "2015-06"
 8380	colloidal lime green pixel potion	0		Effect: "Oleaginous Soles", Effect Duration: 51, Last Available: "2015-06"
 8381	squat Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8264,7 +8264,7 @@
 8390	lime green mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	ghostly gift card	0		Last Available: "2015-07"
-8393	huge lime green hermit factoid	0		Last Available: "2015-07"
+8393	lime green huge hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	The Emperor's new hat of the storm	0		Maximum MP Percent: +40, Last Available: "2015-07"
 8396	narrow scorching The Emperor's new shirt	0		Hot Damage: +25, Last Available: "2015-07"
@@ -8278,30 +8278,30 @@
 8404	purple 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	mirror skewed savory dry noodles	0		
-8407	super-sized adequate bouncing pestopiary	5	good	
+8407	adequate super-sized bouncing pestopiary	5	good	
 8408	double-altered altered ectoplasmic orbs	0		Effect: "Toothy Grin", Effect Duration: 28
-8409	massive delicious red crudles	10	awesome	
-8410	small spoiled tumbling agnolotti arboli	2	crappy	
+8409	delicious massive red crudles	10	awesome	
+8410	spoiled small tumbling agnolotti arboli	2	crappy	
 8411	stale spaghetti with ghost balls	3	decent	
 8412	spoiled succulent marrow	3	crappy	
-8413	decent snack-sized salacious crumbs	2	good	
+8413	snack-sized decent salacious crumbs	2	good	
 8414	spoiled fusilli marrownarrow	4	crappy	
 8415	bland immense suggestive strozzapreti	10	decent	
 8416	Mountain Stream gastrique	0		
-8417	special normal miniature Mt. McLargeHuge oyster	2	good	Effect: "Ninja, Please", Effect Duration: 20
-8418	twirling ghostly oyster sauce	0		
+8417	miniature normal special Mt. McLargeHuge oyster	2	good	Effect: "Ninja, Please", Effect Duration: 20
+8418	ghostly twirling oyster sauce	0		
 8419	rotten linguini immondizia bianco	4	crappy	
 8420	spoiled shells a la shellfish	3	crappy	
 8421	Jick's autograph	0		
 8422	olive high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
-8425	narrow fuchsia New Age healing crystal	0		Last Available: "2015-08"
+8425	fuchsia narrow New Age healing crystal	0		Last Available: "2015-08"
 8426	Volcoino	0		Last Available: "2015-08"
 8427	yellow fizzing spore pod	0		
 8428	squat spore pod	0		
 8429	veiny spore pod	0		
-8430	jittery skewed hard spore pod	0		
+8430	skewed jittery hard spore pod	0		
 8431	spore pod	0		
 8432	hot spore pod	0		
 8433	cool spore pod	0		
@@ -8313,7 +8313,7 @@
 8439	insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
-8442	gray huge viscous lava globs	0		Last Available: "2015-08"
+8442	huge gray viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
 8444	lava globs	0		Last Available: "2015-08"
 8445	lava globs	0		Last Available: "2015-08"
@@ -8323,20 +8323,20 @@
 8449	uncapped lava bottle	0		Last Available: "2015-08"
 8450	capped lava bottle	0		Last Available: "2015-08"
 8451	bouncing capped lava bottle	0		Last Available: "2015-08"
-8452	blue blurry capped lava bottle	0		Last Available: "2015-08"
+8452	blurry blue capped lava bottle	0		Last Available: "2015-08"
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	blurry maroon spinning wholesome high-temperature mining mask of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	blurry maroon spinning wholesome high-temperature mining mask of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	Usain Bolt's reassuring fireproof megaphone	0		Spooky Resistance: +1, Initiative: +80, Last Available: "2015-08"
 8460	adequate mineapple	3	good	Last Available: "2015-08"
-8461	fortified tolerable red Gold Velvet&trade; whiskey	5	good	Last Available: "2015-08"
+8461	tolerable fortified red Gold Velvet&trade; whiskey	5	good	Last Available: "2015-08"
 8462	bouncing SMOOCH soda	1	awesome	Last Available: "2015-08"
 8463	rotten smelted roe	3	crappy	Last Available: "2015-08"
 8464	lousy lavawater	3	decent	Last Available: "2015-08"
-8465	non-alkaline spinning blue basaltamander tongue	0		Effect: "Litterboxing", Effect Duration: 30, Last Available: "2015-08"
+8465	non-alkaline blue spinning basaltamander tongue	0		Effect: "Litterboxing", Effect Duration: 30, Last Available: "2015-08"
 8466	nippy slick weightlifter's lavalarva	0		Muscle: +15, Moxie: +10, Cold Damage: +10, Last Available: "2015-08"
 8467	lard-coated hardy lava balaclava of James Dean	0		Experience (Moxie): +3, Maximum HP: +50, Sleaze Spell Damage: +25, Last Available: "2015-08"
 8468	nasty therapeutic cool basaltamander buckler	0		Moxie: +5, Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 15, Last Available: "2015-08"
@@ -8346,13 +8346,13 @@
 8472	tumbling shellacked Samson's heat-resistant necktie	0		Experience (Muscle): +5, Damage Reduction: 7, Single Equip, Last Available: "2015-08"
 8473	censurious chaotic brainy heat-resistant gloves	0		Mysticality: +5, Spell Critical Percent: +10, Sleaze Resistance: +3, Single Equip, Last Available: "2015-08"
 8474	normal pulsating very hot lunch	4	good	Last Available: "2015-08"
-8475	perfectly mixed high-proof fancy asbestos thermos	7	EPIC	Effect: "Executive Greed", Effect Duration: 35, Last Available: "2015-08"
+8475	perfectly mixed fancy high-proof asbestos thermos	7	EPIC	Effect: "Executive Greed", Effect Duration: 35, Last Available: "2015-08"
 8476	moist yellow upside-down liquid rhinestones	0		Effect: "The Moxie of LOV", Effect Duration: 56, Last Available: "2015-08"
 8477	normal green disco biscuit	4	good	Last Available: "2015-08"
 8478	delicious Quaatorade&trade;	4	awesome	Last Available: "2015-08"
-8479	skewed censurious resourceful biker's hat of chilblains	0		Maximum MP: +50, Cold Damage: +25, Sleaze Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
-8480	cyan jittery Jim Carey's wholesome beefcake's feathered headdress	0		Muscle: +25, Maximum HP Percent: +10, Monster Level: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	mansplainer's energetic electrician's hardhat of the empath	0		Maximum MP Percent: +20, Monster Level: +15, Familiar Weight: +5, Familiar Effect: "atk", Last Available: "2015-08"
+8479	skewed censurious resourceful biker's hat of chilblains	0		Maximum MP: +50, Cold Damage: +25, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
+8480	cyan jittery Jim Carey's wholesome beefcake's feathered headdress	0		Muscle: +25, Maximum HP Percent: +10, Monster Level: +25, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	mansplainer's energetic electrician's hardhat of the empath	0		Maximum MP Percent: +20, Monster Level: +15, Familiar Weight: +5, Last Available: "2015-08", Familiar Effect: "atk"
 8482	bouncing Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	spinning The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8360,8 +8360,8 @@
 8486	red huge one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	pulsating airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
-8489	green blinking New Age hurting crystal	0		Last Available: "2015-08"
-8490	blurry huge dance instructor's smooth velvet pants	0		Experience Percent (Moxie): +10, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8489	blinking green New Age hurting crystal	0		Last Available: "2015-08"
+8490	blurry huge dance instructor's smooth velvet pants	0		Experience Percent (Moxie): +10, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	wicked smooth velvet shirt	0		Spell Damage: +5, Last Available: "2015-08"
 8492	sage smooth velvet hat	0		Mysticality Percent: +10, Last Available: "2015-08"
 8493	blue skewed smooth velvet pocket square of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	red wobbly inspector's coward's SMOOCH bracers	0		Monster Level: -20, Item Drop: +15, Single Equip, Last Available: "2015-08"
 8518	careful SMOOCH kneepads	0		Monster Level: -10, Single Equip, Last Available: "2015-08"
 8519	sizzling SMOOCH spaulders	0		Hot Damage: +10, Single Equip, Last Available: "2015-08"
-8520	frightening personal trainer's SMOOCH codpiece	0		Experience Percent (Muscle): +10, Spooky Damage: +5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	frightening personal trainer's SMOOCH codpiece	0		Experience Percent (Muscle): +10, Spooky Damage: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	medical-grade SMOOCH breastplate	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	purple fused fuse	0		Last Available: "2015-08"
@@ -8400,14 +8400,14 @@
 8526	tasty pink slime	3	awesome	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	big enchanted tasty devil hair pasta	5	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25
+8529	enchanted tasty big devil hair pasta	5	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25
 8530	enchanted adequate teal spagecialetti	4	good	Effect: "Booing Radly", Effect Duration: 5
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	flavorless half-sized teal libertagliatelle	2	decent	
 8535	rotten jittery turkish mostaccioli	3	crappy	
-8536	adequate fancy green linguini of the sea	3	good	Effect: "In the Slimelight", Effect Duration: 40
+8536	fancy adequate green linguini of the sea	3	good	Effect: "In the Slimelight", Effect Duration: 40
 8537	wet polarized blurry Hersey&trade; SMOOCH	0		Effect: "Bandersnatched", Effect Duration: 39
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
@@ -8420,11 +8420,11 @@
 8547	double-magnetized magnetized pocket maze	0		Effect: "Reptilian Fortitude", Effect Duration: 42
 8548	extra-quantum oxidized ghostly shady shades	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 33
 8549	wet dry squeaky toy rose	0		Effect: "Larger", Effect Duration: 18
-8550	bite-sized rotten weird gazelle steak	1	crappy	
+8550	rotten bite-sized weird gazelle steak	1	crappy	
 8551	adequate sausage without a cause	3	good	
 8552	denatured lime green narrow face paint	0		Effect: "Chorale of Companionship", Effect Duration: 32
 8553	hand-crafted emergency margarita	3	super ultra mega turbo EPIC	
-8554	fancy artisanal spirit-forward bouncing vintage smart drink	5	super ultra EPIC	Effect: "[1609]Dancin' Fool", Effect Duration: 15
+8554	spirit-forward fancy artisanal bouncing vintage smart drink	5	super ultra EPIC	Effect: "[1609]Dancin' Fool", Effect Duration: 15
 8555	tumbling a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8437,7 +8437,7 @@
 8564	tumbling upside-down shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	flame-retardant Oprah's barrel lid of the brazier	0		Maximum MP Percent: +50, Hot Spell Damage: +25, Hot Resistance: +1, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	squat blue deadly barrel hoop earring of the bloodbag of the glutton	0		Weapon Damage: +5, Maximum HP: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2015-09"
-8567	blurry red lightning-fast educational bankruptcy barrel of mayonnaise	0		Experience: +1, Sleaze Spell Damage: +50, Initiative: +40, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	blurry red lightning-fast educational bankruptcy barrel of mayonnaise	0		Experience: +1, Sleaze Spell Damage: +50, Initiative: +40, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	fuchsia firkin	0		Last Available: "2015-09"
 8569	blurry normal barrel	0		Last Available: "2015-09"
 8570	bouncing tun	0		Last Available: "2015-09"
@@ -8451,7 +8451,7 @@
 8578	delicious spinning bottle of Amontillado	4	awesome	Last Available: "2015-09"
 8579	drinkable barrel-aged martini	3	good	Last Available: "2015-09"
 8580	bland barrel pickle	4	decent	Last Available: "2015-09"
-8581	bland gigantic lime green barrel cracker	8	decent	Last Available: "2015-09"
+8581	gigantic bland lime green barrel cracker	8	decent	Last Available: "2015-09"
 8582	altered bouncing vibrating mushroom	1	EPIC	Effect: "You Can Really Taste the Dormouse", Effect Duration: 35, Last Available: "2015-09"
 8583	twisted mushroom	1	good	Last Available: "2015-09"
 8584	hardened KoL Con 12-gauge	0		Damage Reduction: 3, Last Available: "2015-09"
@@ -8483,20 +8483,20 @@
 8610	deionized spinning cuppa Morbidi tea	0		Effect: "Alchemical, Brother", Effect Duration: 59, Last Available: "2015-09"
 8611	galvanized narrow cuppa Chari tea	0		Effect: "Hobo Flavor", Effect Duration: 58, Last Available: "2015-09"
 8612	super-activated spinning cuppa Serendipi tea	0		Effect: "Action", Effect Duration: 14, Last Available: "2015-09"
-8613	irradiated shaking pulsating cuppa Feroci tea	0		Effect: "Mariachi Mood", Effect Duration: 58, Last Available: "2015-09"
-8614	cold-filtered fuchsia spinning cuppa Physicali tea	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 58, Last Available: "2015-09"
+8613	irradiated pulsating shaking cuppa Feroci tea	0		Effect: "Mariachi Mood", Effect Duration: 58, Last Available: "2015-09"
+8614	cold-filtered spinning fuchsia cuppa Physicali tea	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 58, Last Available: "2015-09"
 8615	diffused yellow cuppa Wit tea	0		Effect: "Thanksgot", Effect Duration: 55, Last Available: "2015-09"
 8616	modified ionized cuppa Neuroplastici tea	0		Effect: "Omphalotus Omnipresence", Effect Duration: 58, Last Available: "2015-09"
 8617	tarnished cuppa Dexteri tea	0		Effect: "Prelude of Precision", Effect Duration: 30, Last Available: "2015-09"
 8618	modified improved pulsating cuppa Flexibili tea	0		Effect: "Waxing", Effect Duration: 69, Last Available: "2015-09"
 8619	corrupted purple cuppa Impregnabili tea	0		Effect: "Memory of Attractiveness", Effect Duration: 47, Last Available: "2015-09"
-8620	galvanized diffused purple upside-down cuppa Obscuri tea	0		Effect: "Sweet Taste", Effect Duration: 13, Last Available: "2015-09"
+8620	galvanized diffused upside-down purple cuppa Obscuri tea	0		Effect: "Sweet Taste", Effect Duration: 13, Last Available: "2015-09"
 8621	pressed magnetized cuppa Irritabili tea	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 55, Last Available: "2015-09"
 8622	quadruple-nitrogenated dry cuppa Mediocri tea	0		Effect: "Slimily Strong", Effect Duration: 31, Last Available: "2015-09"
 8623	dry cold-filtered cuppa Loyal tea	0		Effect: "Eyes Wide Propped", Effect Duration: 13, Last Available: "2015-09"
 8624	compressed purple cuppa Activi tea	1	awesome	Effect: "You Drank Fish Wine", Effect Duration: 50, Last Available: "2015-09"
-8625	boiled pulsating narrow cuppa Cruel tea	1		Last Available: "2015-09"
-8626	adjusted narrow green cuppa Alacri tea	0		Effect: "Jammin'", Effect Duration: 33, Last Available: "2015-09"
+8625	boiled narrow pulsating cuppa Cruel tea	1		Last Available: "2015-09"
+8626	adjusted green narrow cuppa Alacri tea	0		Effect: "Jammin'", Effect Duration: 33, Last Available: "2015-09"
 8627	pressed nitrogenated twirling cuppa Vitali tea	0		Effect: "Ogred and Oublietted", Effect Duration: 49, Last Available: "2015-09"
 8628	ionized cuppa Mana tea	0		Effect: "Human-Hippy Hybrid", Effect Duration: 57, Last Available: "2015-09"
 8629	vacuum-sealed cuppa Monstrosi tea	0		Effect: "Mystic Circle", Effect Duration: 64, Last Available: "2015-09"
@@ -8512,7 +8512,7 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	rotten super-sized skewed bowl of eyeballs	5	crappy	Last Available: "2015-10"
-8642	snack-sized decent bowl of mummy guts	2	good	Last Available: "2015-10"
+8642	decent snack-sized bowl of mummy guts	2	good	Last Available: "2015-10"
 8643	half-sized rotten bowl of maggots	2	crappy	Last Available: "2015-10"
 8644	high-proof aged blood and blood	6	awesome	Last Available: "2015-10"
 8645	bad olive Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
@@ -8522,7 +8522,7 @@
 8649	plastic nightmare troll	0		Last Available: "2015-10"
 8650	tennis ball	0		Last Available: "2015-10"
 8651	auspicious horrifying supercharged crown	0		Maximum MP Percent: +30, Spooky Damage: +25, Item Drop: +10, Familiar Effect: "atk, 1xGhuol, cap 27"
-8652	lime green skewed ear poison	0		
+8652	skewed lime green ear poison	0		
 8653	stink-penny	0		
 8654	dance instructor's hawk of the blizzard of temperance	0		Experience Percent (Moxie): +10, Cold Spell Damage: +25, Sleaze Resistance: +5
 8655	huge stale hamlet sandwich	9	decent	
@@ -8547,19 +8547,19 @@
 8674	narrow airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	liquefied non-moist wobbly squat shoulder-warming lotion	0		Effect: "Big", Effect Duration: 42, Last Available: "2015-11"
-8677	bland small huge jittery iceberg lettuce	2	decent	Last Available: "2015-11"
-8678	aged fancy practically non-alcoholic ice wine	1	awesome	Effect: "Ginger Snapped", Effect Duration: 35, Last Available: "2015-11"
+8677	bland small jittery huge iceberg lettuce	2	decent	Last Available: "2015-11"
+8678	aged practically non-alcoholic fancy ice wine	1	awesome	Effect: "Ginger Snapped", Effect Duration: 35, Last Available: "2015-11"
 8679	wobbly sizzling brainy Wal-Mart snowglobe of the cheetah	0		Mysticality: +5, Hot Damage: +10, Initiative: +60, Last Available: "2015-11"
 8680	Annie Oakley's ruddy Samson's Wal-Mart nametag	0		Experience (Muscle): +5, Maximum HP Percent: +40, Critical Hit Percent: +20, Last Available: "2015-11"
 8681	bouncing flame-retardant deadly Wal-Mart overalls of the overflowing toilet	0		Weapon Damage: +5, Stench Spell Damage: +50, Hot Resistance: +1, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	wobbly The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	ghostly Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
-8685	blue huge pulsating Wal-Mart tattoo kit	0		Last Available: "2015-11"
+8685	pulsating huge blue Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	supercharged bellhop's hat	0		Maximum MP Percent: +30, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	delicious ice porter	4	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	supercharged bellhop's hat	0		Maximum MP Percent: +30, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	delicious ice porter	4	awesome	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	moist quadruple-polymerized exotic travel brochure	0		Effect: "The Moxious Madrigal", Effect Duration: 39, Last Available: "2015-11"
 8691	wobbly bag of foreign bribes	0		Last Available: "2015-11"
 8692	extra-magnetized polarized pulsating shampoo-conditioner	0		Effect: "Big Meat Big Prizes", Effect Duration: 51, Last Available: "2015-11"
@@ -8567,11 +8567,11 @@
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	boiled ghostly medicinal herbs	1		Last Available: "2016-01"
-8697	snack-sized rotten ice rice	2	crappy	Last Available: "2016-01"
+8697	rotten snack-sized ice rice	2	crappy	Last Available: "2016-01"
 8698	perfectly mixed iced plum wine	4	EPIC	Last Available: "2016-01"
 8699	maroon censurious Jack Frost's careful training belt	0		Monster Level: -10, Cold Spell Damage: +50, Sleaze Resistance: +3, Single Equip, Last Available: "2016-01"
 8700	gray supercharged groovy brawny training legwarmers	0		Muscle Percent: +20, Moxie Percent: +10, Maximum MP Percent: +30, Single Equip, Last Available: "2016-01"
-8701	horrifying rock-hard training helmet of chilblains	0		Damage Reduction: 5, Cold Damage: +25, Spooky Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	horrifying rock-hard training helmet of chilblains	0		Damage Reduction: 5, Cold Damage: +25, Spooky Damage: +25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8580,19 +8580,19 @@
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	modified upside-down upside-down abstraction: action	1		Effect: "Well-Oiled", Effect Duration: 15, Last Available: "2015-12"
 8709	dried abstraction: thought	1		Effect: "The Best a Pirate Can Get", Effect Duration: 30, Last Available: "2015-12"
-8710	diluted shaking jittery blue blinking abstraction: sensation	1		Effect: "Fudgehound", Effect Duration: 50, Last Available: "2015-12"
+8710	diluted blue blinking shaking jittery abstraction: sensation	1		Effect: "Fudgehound", Effect Duration: 50, Last Available: "2015-12"
 8711	twisted abstraction: purpose	1		Last Available: "2015-12"
 8712	mixed blinking abstraction: category	1		Last Available: "2015-12"
 8713	diluted abstraction: perception	1		Last Available: "2015-12"
 8714	vaporized skewed abstraction: motion	1		Effect: "Yuletide Sappiness", Effect Duration: 5, Last Available: "2015-12"
 8715	distilled abstraction: joy	1		Effect: "Cancer Rising", Effect Duration: 20, Last Available: "2015-12"
-8716	boiled upside-down spinning abstraction: certainty	1		Effect: "The Spy Who Loved XP", Effect Duration: 35, Last Available: "2015-12"
+8716	boiled spinning upside-down abstraction: certainty	1		Effect: "The Spy Who Loved XP", Effect Duration: 35, Last Available: "2015-12"
 8717	mixed abstraction: comprehension	1		Effect: "Human-Elf Hybrid", Effect Duration: 15, Last Available: "2015-12"
 8718	twirling modern picture frame	0		Last Available: "2015-12"
 8719	stale huge VYKEA meatballs	3	decent	Last Available: "2015-11"
 8720	practically non-alcoholic perfectly mixed VYKEA mead	1	super ultra EPIC	Last Available: "2015-11"
 8721	double-nitrogenated VYKEA woadpaint	0		Effect: "Human-Pirate Hybrid", Effect Duration: 40, Last Available: "2015-11"
-8722	pulsating lime green bouncing VYKEA frenzy rune	0		Last Available: "2015-11"
+8722	lime green bouncing pulsating VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	mirror VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	skewed VYKEA plank	0		Last Available: "2015-11"
@@ -8601,14 +8601,14 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	blurry family-friendly quilted Samson's VYKEA hex key	0		Experience (Muscle): +5, Damage Absorption: +40, Sleaze Resistance: +1, Last Available: "2015-11"
 8730	twirling VYKEA instructions	0		Last Available: "2015-11"
-8731	stale tin of submardines	3	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	stale tin of submardines	3	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	aged bottle of norwhiskey	3	awesome	Last Available: "2015-11"
 8733	dried wobbly octolus oculus	1	EPIC	Last Available: "2015-11"
 8734	narrow greasy horrifying Samson's sardine can key	0		Experience (Muscle): +5, Spooky Damage: +25, Sleaze Spell Damage: +10, Last Available: "2015-11"
-8735	maroon skewed auspicious studded norwhal helmet of Calamity Jane	0		Damage Absorption: +80, Critical Hit Percent: +15, Item Drop: +10, Familiar Effect: "atk", Last Available: "2015-11"
+8735	maroon skewed auspicious studded norwhal helmet of Calamity Jane	0		Damage Absorption: +80, Critical Hit Percent: +15, Item Drop: +10, Last Available: "2015-11", Familiar Effect: "atk"
 8736	spinning occult smartaleck's smooth octolus-skin cloak	0		Moxie: +15, Moxie Percent: +30, Spell Damage Percent: +25, Last Available: "2015-11"
 8737	aged weak perfect cosmopolitan	2	awesome	Last Available: "2015-11"
-8738	artisanal practically non-alcoholic perfect negroni	1	super ultra mega turbo EPIC	Last Available: "2015-11"
+8738	practically non-alcoholic artisanal perfect negroni	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8739	hand-crafted perfect dark and stormy	4	EPIC	Last Available: "2015-11"
 8740	bad perfect mimosa	4	decent	Last Available: "2015-11"
 8741	acceptable high-proof olive perfect old-fashioned	9	good	Last Available: "2015-11"
@@ -8622,7 +8622,7 @@
 8749	vacuum-sealed skewed blurry Deep Machine Tunnels snowglobe	0		Effect: "protect.enq", Effect Duration: 19, Last Available: "2015-12"
 8750	modified upside-down hemp candy necklace	0		Effect: "Salty Mouth", Effect Duration: 25, Last Available: "2015-12"
 8751	super-vacuum-sealed colloidal communal gobstopper	0		Effect: "Kindly Resolve", Effect Duration: 27, Last Available: "2015-12"
-8752	spoiled low-calorie Crimbo salad	1	crappy	Last Available: "2015-12"
+8752	low-calorie spoiled Crimbo salad	1	crappy	Last Available: "2015-12"
 8753	decent bouncing bread line	3	good	Last Available: "2015-12"
 8754	tolerable bark rootbeer	3	good	Last Available: "2015-12"
 8755	mediocre upside-down ale	4	decent	Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	huge BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	drinkable watered-down pulsating Gratitude chocolate (bourbon-filled)	2	good	Last Available: "2016-02"
+8766	watered-down drinkable pulsating Gratitude chocolate (bourbon-filled)	2	good	Last Available: "2016-02"
 8767	huge Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8648,7 +8648,7 @@
 8776	hale armband	0		Maximum HP: +20, Single Equip, Last Available: "2015-12"
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	twirling nuclear stockpile	0		Last Available: "2015-12"
-8779	bouncing blinking pine cone	0		Last Available: "2015-12"
+8779	blinking bouncing pine cone	0		Last Available: "2015-12"
 8780	upside-down iron chain	0		Last Available: "2015-12"
 8781	prompt pine cone necklace	0		Adventures: +3, Last Available: "2015-12"
 8782	wicked reindeer hammer	0		Spell Damage: +5, Last Available: "2015-12"
@@ -8682,20 +8682,20 @@
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	upside-down confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
-8813	shaking bouncing glob of Bat-Glue	0		Last Available: "2017-01"
+8813	bouncing shaking glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	normal super-sized Kudzu salad	5	good	Last Available: "2016-12"
-8817	diluted twirling narrow huge Mansquito Serum	1		Effect: "Demonic Taint", Effect Duration: 25, Last Available: "2016-12"
+8816	super-sized normal Kudzu salad	5	good	Last Available: "2016-12"
+8817	diluted narrow huge twirling Mansquito Serum	1		Effect: "Demonic Taint", Effect Duration: 25, Last Available: "2016-12"
 8818	hand-crafted Miss Graves' vermouth	4	EPIC	Last Available: "2016-12"
-8819	decent pulsating shaking The Plumber's mushroom stew	3	good	Last Available: "2016-12"
-8820	powdered shaking spinning The Author's ink	1		Last Available: "2016-02"
-8821	smooth triple-distilled The Mad Liquor	10	awesome	Last Available: "2016-12"
-8822	spirit-forward acceptable mirror Doc Clock's thyme cocktail	5	good	Last Available: "2016-12"
+8819	decent shaking pulsating The Plumber's mushroom stew	3	good	Last Available: "2016-12"
+8820	powdered spinning shaking The Author's ink	1		Last Available: "2016-02"
+8821	triple-distilled smooth The Mad Liquor	10	awesome	Last Available: "2016-12"
+8822	acceptable spirit-forward mirror Doc Clock's thyme cocktail	5	good	Last Available: "2016-12"
 8823	rotten Mr. Burnsger	3	crappy	Last Available: "2016-12"
 8824	powdered The Inquisitor's unidentifiable object	1		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 5, Last Available: "2016-12"
 8825	gray dog trainer's beefcake's The Jokester's gun of mayonnaise	0		Muscle: +25, Experience (familiar): +1, Sleaze Spell Damage: +50, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	MacGyver's forbidden The Jokester's wig of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Maximum MP: +100, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8826	MacGyver's forbidden The Jokester's wig of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Maximum MP: +100, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	frosty healthy experienced The Jokester's pants	0		Experience: +2, Maximum HP Percent: +20, Cold Spell Damage: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	anodized moist anodized bouncing Jokester makeup	0		Effect: "Booooooze", Effect Duration: 27, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
@@ -8703,7 +8703,7 @@
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	activated red robin's egg	0		Effect: "Biologically Shocked", Effect Duration: 21, Last Available: "2016-12"
-8834	jumbo spoiled bouncing robin flan	5	crappy	Last Available: "2016-12"
+8834	spoiled jumbo bouncing robin flan	5	crappy	Last Available: "2016-12"
 8835	hand-crafted robin nog	3	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
@@ -8713,7 +8713,7 @@
 8841	improved Mansquito's blood	0		Effect: "Coal-Powered", Effect Duration: 42
 8842	alkaline infrablack lipstick	0		Effect: "Purity of Spirit", Effect Duration: 68
 8843	quadruple-adjusted corrupted can of drain cleaner	0		Effect: "A Few Extra Pounds", Effect Duration: 51
-8844	liquefied dry skewed blinking The Author's inkwell	0		Effect: "Comprehensively Nourished", Effect Duration: 64
+8844	liquefied dry blinking skewed The Author's inkwell	0		Effect: "Comprehensively Nourished", Effect Duration: 64
 8845	unsweetened quantum olive bag of random words	0		Effect: "The Power of Negative Thinking", Effect Duration: 32
 8846	wet tube of pendulum lube	0		Effect: "Tiki Temerity", Effect Duration: 48
 8847	boiled red-hot jawbreaker	0		Effect: "Twinkly Weapon", Effect Duration: 15
@@ -8721,7 +8721,7 @@
 8849	modified energized narrow tube of villain	0		Effect: "Adorable Lookout", Effect Duration: 14
 8850	spinning your cowboy boots of the early riser	0		Adventures: +7, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	cyan inflatable LT&T telegraph office	0		Last Available: "2016-02"
-8852	shaking tumbling nugget of quicksilver	0		Last Available: "2016-02"
+8852	tumbling shaking nugget of quicksilver	0		Last Available: "2016-02"
 8853	bouncing squat nugget of thicksilver	0		Last Available: "2016-02"
 8854	nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
@@ -8750,15 +8750,15 @@
 8878	spoiled plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
 8879	bland plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	rotten plate of Frigid Northern Beans	3	crappy	Last Available: "2016-02"
-8881	massive flavorless plate of World's Blackest-Eyed Peas	9	decent	Last Available: "2016-02"
+8881	flavorless massive plate of World's Blackest-Eyed Peas	9	decent	Last Available: "2016-02"
 8882	bland plate of Trader Olaf's Exotic Stinkbeans	4	decent	Last Available: "2016-02"
 8883	flavorless ghostly plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Last Available: "2016-02"
 8884	half-sized bland skewed plate of Val-U Brand Every Bean Salad	2	decent	Last Available: "2016-02"
 8885	moldy plate of Shrub's Premium Baked Beans	3	crappy	Last Available: "2016-02"
 8886	stiffened Fancy Jeff's pocket square of the businessman	0		Damage Reduction: 1, Meat Drop: +50, Last Available: "2016-02"
-8887	greedy veiny Daisy's unclean bloomers of the brazier	0		Maximum HP: +10, Hot Spell Damage: +25, Meat Drop: +20, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	greedy veiny Daisy's unclean bloomers of the brazier	0		Maximum HP: +10, Hot Spell Damage: +25, Meat Drop: +20, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	squat Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	upside-down ruddy weightlifter's Amoon-Ra Cowtep's nemes of mayonnaise	0		Muscle: +15, Maximum HP Percent: +40, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	upside-down ruddy weightlifter's Amoon-Ra Cowtep's nemes of mayonnaise	0		Muscle: +15, Maximum HP Percent: +40, Sleaze Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	mirror maroon MacGyver's Fonzie's smartaleck's Former Sheriff Dan's tin star of extreme caution of Flo-Jo	0		Moxie Percent: +30, Experience (Moxie): +1, Maximum MP: +100, Monster Level: -25, Initiative: +100, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	enhanced upside-down rattler gland	0		Effect: "Amorous", Effect Duration: 59, Last Available: "2016-02"
 8907	super-ionized half-digested coal	0		Effect: "Stuck-Up Hair", Effect Duration: 41, Last Available: "2016-02"
 8908	energized tightly-wound spine	0		Effect: "Sweet Incentive", Effect Duration: 49, Last Available: "2016-02"
-8909	enchanted rotten rotting beefsteak	4	crappy	Effect: "Wet Rub", Effect Duration: 45, Last Available: "2016-02"
+8909	rotten enchanted rotting beefsteak	4	crappy	Effect: "Wet Rub", Effect Duration: 45, Last Available: "2016-02"
 8910	mediocre firemilk	3	decent	Last Available: "2016-02"
 8911	galvanized oxidized tumbling spidercow eye-cluster	0		Effect: "Feroci Tea", Effect Duration: 52, Last Available: "2016-02"
 8912	pickled blinking moomy dust	1		Effect: "Piratey Flavor", Effect Duration: 5, Last Available: "2016-02"
@@ -8821,7 +8821,7 @@
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	twirling slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
-8952	shaking spinning skewed nicksilver spurs	0		Last Available: "2016-02"
+8952	spinning shaking skewed nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
 8954	jittery special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
@@ -8846,7 +8846,7 @@
 8974	corrupted Vulcanized bouncing ghostly eldritch oil	0		Effect: "Stop and Smell the Fudge", Effect Duration: 21
 8975	exclusive club	0		
 8976	enhanced patent preventative tonic	0		Effect: "Vitali Tea", Effect Duration: 56
-8977	adjusted pressed altered cyan pulsating patent invisibility tonic	0		Effect: "New Zeal", Effect Duration: 50
+8977	adjusted pressed altered pulsating cyan patent invisibility tonic	0		Effect: "New Zeal", Effect Duration: 50
 8978	polarized moist patent aggression tonic	0		Effect: "[1609]Dancin' Fool", Effect Duration: 54
 8979	modified patent sallowness tonic	0		Effect: "Bilious Brains", Effect Duration: 18
 8980	oxidized super-flattened patent avarice tonic	0		Effect: "Radiated and Grodiated", Effect Duration: 69
@@ -8863,21 +8863,21 @@
 8991	olive do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	diluted spinning armored prawn	1		Effect: "Just Aged Enough", Effect Duration: 20, Last Available: "2016-03"
 8993	normal jumping horseradish	4	good	Last Available: "2016-03"
-8994	triple-distilled drinkable Sacramento wine	7	good	Last Available: "2016-03"
+8994	drinkable triple-distilled Sacramento wine	7	good	Last Available: "2016-03"
 8995	enhanced corrupted Vulcanized blurry Greek fire	0		Effect: "Deep-Seated Rage", Effect Duration: 44, Last Available: "2016-03"
 8996	asbestos-lined smelly dangerous cool ox-head shield of the blizzard	0		Moxie: +5, Weapon Damage: +10, Cold Spell Damage: +25, Stench Spell Damage: +10, Hot Resistance: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	purple shellacked Herculean dented scepter of the storm of horror of temperance	0		Experience (Muscle): +1, Damage Reduction: 7, Maximum MP Percent: +40, Spooky Spell Damage: +25, Sleaze Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	shaking Sherlock's chaotic steel-toed padded Da Vinci's very pointy crown	0		Experience (Mysticality): +5, Damage Absorption: +20, Damage Reduction: 9, Spell Critical Percent: +10, Item Drop: +25, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	shaking Sherlock's chaotic steel-toed padded Da Vinci's very pointy crown	0		Experience (Mysticality): +5, Damage Absorption: +20, Damage Reduction: 9, Spell Critical Percent: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	huge prompt careful mansplainer's chaotic Fonzie's battle broom	0		Experience (Moxie): +1, Spell Critical Percent: +10, Monster Level: 5, Adventures: +3, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	flame-retardant dog trainer's curative ruddy carpe	0		Maximum HP Percent: +40, Experience (familiar): +1, Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
 9002	zippy hardened wizardly codpiece of the brute	0		Mysticality: +25, Muscle Percent: +30, Damage Reduction: 3, Initiative: +20, Lasts Until Rollover, Last Available: "2016-04"
-9003	inspector's grievous smartaleck's troutsers of the glutton	0		Moxie Percent: +30, Weapon Damage Percent: +50, Item Drop: +15, Food Drop: +100, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	inspector's grievous smartaleck's troutsers of the glutton	0		Moxie Percent: +30, Weapon Damage Percent: +50, Item Drop: +15, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	greasy crafty extremely unsafe Herculean bass clarinet	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Maximum MP: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9005	Usain Bolt's greedy Jim Carey's fish hatchet of James Dean	0		Experience (Moxie): +3, Monster Level: +25, Meat Drop: +20, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04"
 9006	tumbling huge nippy chaotic tunac of the scaredy-cat of chilblains	0		Spell Critical Percent: +10, Monster Level: -15, Cold Damage: 35, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
-9008	adjusted squat pulsating wriggling worm	0		Effect: "Tearful, Fearful", Effect Duration: 25, Last Available: "2016-04"
+9008	adjusted pulsating squat wriggling worm	0		Effect: "Tearful, Fearful", Effect Duration: 25, Last Available: "2016-04"
 9009	mediocre irresponsibly strong bottle of Fishhead 900-Day IPA	8	decent	Last Available: "2016-04"
 9010	magnetized flattened tumbling high-test fishing line	0		Effect: "Eye of the Seal", Effect Duration: 11, Last Available: "2016-04"
 9011	squat vibrating fishin' hat	0		Maximum MP Percent: +10, Last Available: "2016-04"
@@ -8899,13 +8899,13 @@
 9027	auspicious toasty First Post shirt - Cir Senam of the sewer	0		Hot Damage: +5, Stench Damage: +25, Item Drop: +10, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	big flavorless star salad	5	decent	
+9030	flavorless big star salad	5	decent	
 9031	narrow Thwaitgold moth statuette	0		
 9032	normal bowl of Tastee-Wheet&trade;	4	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	shaking Source essence	0		Last Available: "2016-06"
 9035	miniature toothsome olive browser cookie	2	awesome	Last Available: "2016-06"
-9036	practically non-alcoholic lousy narrow hacked gibson	1	decent	Last Available: "2016-06"
+9036	lousy practically non-alcoholic narrow hacked gibson	1	decent	Last Available: "2016-06"
 9037	Source shades of Flo-Jo	0		Initiative: +100, Last Available: "2016-06"
 9038	maroon software bug	0		Last Available: "2016-06"
 9039	blinking missing semicolon	0		Familiar Weight: +11
@@ -8922,7 +8922,7 @@
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
-9053	jittery mirror Source terminal file: critical.enh	0		Last Available: "2016-06"
+9053	mirror jittery Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	mirror blurry Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	tumbling Source terminal file: compress.edu	0		Last Available: "2016-06"
@@ -8947,7 +8947,7 @@
 9075	dry shoe gum	0		Effect: "Granolarrrgh", Effect Duration: 55, Last Available: "2016-07"
 9076	Socratic thinker's noir fedora of courage	0		Mysticality: +10, Experience (Mysticality): +1, Spooky Resistance: +3, Last Available: "2016-07"
 9077	narrow quilted supercool trench coat of doom	0		Moxie Percent: +20, Damage Absorption: +40, Spooky Spell Damage: +50, Last Available: "2016-07"
-9078	weak drinkable fuchsia ghostly Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
+9078	weak drinkable ghostly fuchsia Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
 9079	moldy hardboiled egg	3	crappy	Last Available: "2016-07"
 9080	jittery detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	blinking greasy Mr. Screege's spectacles	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2016-08"
 9092	narrow executive fortified extremely unsafe Spookyraven signet	0		Weapon Damage Percent: +100, Damage Absorption: +60, Meat Drop: +40, Single Equip, Last Available: "2016-08"
 9093	upside-down ghostly flame-retardant tie-dyed fannypack of horror	0		Spooky Spell Damage: +25, Hot Resistance: +1, Single Equip, Last Available: "2016-08"
-9094	ribald wizardly burnt snowpants	0		Mysticality: +25, Sleaze Damage: +10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	ribald wizardly burnt snowpants	0		Mysticality: +25, Sleaze Damage: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	Rosewater's standards and practices guide	0		Mysticality Percent: +30, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	tumbling fireproof lard-coated Carpathian longsword of the sewer	0		Stench Damage: +25, Sleaze Spell Damage: +25, Hot Resistance: +3, Last Available: "2016-08"
 9097	blurry MacGyver's Newton's Liam's mail of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Maximum MP: +100, Last Available: "2016-08"
@@ -8983,19 +8983,19 @@
 9111	triple-ionized Lucky Strikes holo-record	0		Effect: "Gummi Badass", Effect Duration: 67
 9112	nitrogenated frozen EMD holo-record	0		Effect: "Stinky Hands", Effect Duration: 22
 9113	extra-moist Superdrifter holo-record	0		Effect: "A Few Extra Pounds", Effect Duration: 31
-9114	nitrogenated improved lime green blurry upside-down The Pigs holo-record	0		Effect: "Ghostly Shell", Effect Duration: 18
+9114	nitrogenated improved blurry lime green upside-down The Pigs holo-record	0		Effect: "Ghostly Shell", Effect Duration: 18
 9115	aerosolized Vulcanized huge Drunk Uncles holo-record	0		Effect: "Paging Betty", Effect Duration: 67
 9116	tumbling time residue	0		Last Available: "2016-09"
 9117	blue ghostly groovy repaid diaper	0		Moxie Percent: +10
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	acceptable weak Shot of Kardashian Gin	2	good	Last Available: "2016-09"
+9119	weak acceptable Shot of Kardashian Gin	2	good	Last Available: "2016-09"
 9120	blurry flame-wreathed Unstable Pointy Ears	0		Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-09"
 9121	yellow Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	crappy	Last Available: "2016-09"
 9123	shaking School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	high-proof tolerable unidentified drink	6	good	
+9126	tolerable high-proof unidentified drink	6	good	
 9127	bouncing lion tamer's Temple Grandin's KoL Con 13 T-shirt	0		Familiar Weight: +7, Experience (familiar): +2
 9128	wobbly hardy stiffened brainy discarded swimming trunks	0		Mysticality: +5, Damage Reduction: 1, Maximum HP: +50
 9129	dry activated skewed diluted makeup	0		Effect: "Trufflin'", Effect Duration: 30
@@ -9007,25 +9007,25 @@
 9135	acceptable very whiskey	4	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	narrow li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	huge li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	huge li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	olive wobbly li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	spinning li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	mirror li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	narrow li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	huge li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	huge li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	olive wobbly li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	spinning li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	mirror li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	energized improved hoarded candy wad	0		Effect: "Twen Tea", Effect Duration: 27, Last Available: "2016-10"
 9147	improved deionized Prunets	0		Effect: "Pisces Rising", Effect Duration: 57
 9148	squat Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	extra-dry pickled cold-filtered invisible string	0		Lasts Until Rollover, Effect: "Livin' Large", Effect Duration: 56, Last Available: "2016-10"
 9151	deionized improved invisible seam ripper	0		Lasts Until Rollover, Effect: "Memory of Speed", Effect Duration: 33, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	stale raw sweet potato	3	decent	Last Available: "2016-11"
 9154	decent raw beans	4	good	Last Available: "2016-11"
 9155	fancy stale blurry raw stuffing	3	decent	Effect: "I See Everything Thrice!", Effect Duration: 10, Last Available: "2016-11"
-9156	thick moldy raw cranberry sauce	5	crappy	Last Available: "2016-11"
+9156	moldy thick raw cranberry sauce	5	crappy	Last Available: "2016-11"
 9157	decent snack-sized raw turkey	2	good	Last Available: "2016-11"
 9158	rotten raw mincemeat	4	crappy	Last Available: "2016-11"
 9159	spoiled raw potato	3	crappy	Last Available: "2016-11"
@@ -9035,20 +9035,20 @@
 9163	blurry slick glass casserole dish of the blizzard	0		Moxie: +10, Cold Spell Damage: +25, Item Drop: +5, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	tumbling extremely unsafe can opener of the cheetah	0		Weapon Damage Percent: +100, Initiative: +60, Last Available: "2016-11"
-9166	altered green shaking turkey blaster	1		Last Available: "2016-11"
+9166	altered shaking green turkey blaster	1		Last Available: "2016-11"
 9167	Oprah's wicked glass pie plate	0		Spell Damage: +5, Maximum MP Percent: +50, Damage Reduction: 7, Last Available: "2016-11"
 9168	Sherlock's educational potato masher	0		Experience: +1, Item Drop: +25, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	normal thick sweet potatoes	5	good	Last Available: "2016-11"
+9171	thick normal sweet potatoes	5	good	Last Available: "2016-11"
 9172	stale bean casserole	3	decent	Last Available: "2016-11"
 9173	stale pulsating baked stuffing	3	decent	Last Available: "2016-11"
 9174	spoiled cranberry cylinder	3	crappy	Last Available: "2016-11"
 9175	bland thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	decent lime green mince pie	3	good	Last Available: "2016-11"
-9177	fancy rotten big fuchsia mashed potatoes	5	crappy	Effect: "Sweet and Yellow", Effect Duration: 15, Last Available: "2016-11"
+9177	big fancy rotten fuchsia mashed potatoes	5	crappy	Effect: "Sweet and Yellow", Effect Duration: 15, Last Available: "2016-11"
 9178	immense bland red spinning warm gravy	7	decent	Last Available: "2016-11"
-9179	bland super-sized bread roll	5	decent	Last Available: "2016-11"
+9179	super-sized bland bread roll	5	decent	Last Available: "2016-11"
 9180	normal ghostly leftovers	4	good	Last Available: "2016-11"
 9181	stale cyan leftovers sandwich	4	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9061,7 +9061,7 @@
 9189	bouncing Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	quantum teal eldritch concentrate	0		Effect: "Ancient Protected", Effect Duration: 42, Last Available: "2016-11"
-9192	acceptable watered-down special eldritch extract	2	good	Effect: "Livin' Large", Effect Duration: 30, Last Available: "2016-11"
+9192	acceptable special watered-down eldritch extract	2	good	Effect: "Livin' Large", Effect Duration: 30, Last Available: "2016-11"
 9193	Jack Frost's personal trainer's Official Council Aide Pin	0		Experience Percent (Muscle): +10, Cold Spell Damage: +50, Last Available: "2016-11"
 9194	lousy watered-down eldritch distillate	2	decent	Last Available: "2016-11"
 9195	mixed jittery eldritch essence	1		Effect: "Spookyravin'", Effect Duration: 20, Last Available: "2016-11"
@@ -9084,11 +9084,11 @@
 9212	zippy chaotic candy dress shoes of the scaredy-cat	0		Spell Critical Percent: +10, Monster Level: -15, Initiative: +20, Single Equip, Last Available: "2016-12"
 9213	horrifying Jack Frost's lion tamer's candy necktie	0		Experience (familiar): +2, Cold Spell Damage: +50, Spooky Damage: +25, Single Equip, Last Available: "2016-12"
 9214	blurry scandalous mansplainer's forbidden chocolate pocketwatch	0		Spell Damage Percent: +50, Monster Level: +15, Sleaze Damage: +5, Single Equip, Last Available: "2016-12"
-9215	blurry red broken chocolate pocketwatch	0		Last Available: "2016-12"
+9215	red blurry broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	ghostly sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	bland special cyan blurry animal part cracker	4	decent	Effect: "Wintergreen Warmongery", Effect Duration: 20, Last Available: "2016-12"
+9219	special bland blurry cyan animal part cracker	4	decent	Effect: "Wintergreen Warmongery", Effect Duration: 20, Last Available: "2016-12"
 9220	practically non-alcoholic perfectly mixed gingerbread wine	1	super ultra EPIC	Last Available: "2016-12"
 9221	rotten gingerbread mug	3	crappy	Last Available: "2016-12"
 9222	perfumed gingerbread mask	0		Stench Resistance: +5, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	squat green double-paned Oprah's gingerbread gavel	0		Maximum MP Percent: +50, Cold Resistance: +5, Last Available: "2016-12"
 9237	spinning gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	acceptable extra-dry blurry ginger beer	5	good	Last Available: "2016-12"
+9239	extra-dry acceptable blurry ginger beer	5	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	quantum industrial frosting	0		Effect: "Bonelording", Effect Duration: 31, Last Available: "2016-12"
 9242	corrupted purple fake cocktail	0		Effect: "In the Saucestream", Effect Duration: 68, Last Available: "2016-12"
@@ -9122,13 +9122,13 @@
 9250	dry tarnished Inner Strength	0		Effect: "Arresistible", Effect Duration: 60, Last Available: "2016-12"
 9251	dry deionized Inner Truth	0		Effect: "Dragged Through the Coals", Effect Duration: 39, Last Available: "2016-12"
 9252	tasty spiritual candy cane	3	awesome	Last Available: "2016-12"
-9253	smooth practically non-alcoholic huge spiritual eggnog	1	awesome	Last Available: "2016-12"
-9254	huge rotten upside-down spiritual fruitcake	7	crappy	Last Available: "2016-12"
-9255	miniature yummy lime green spiritual gingerbread	2	awesome	Last Available: "2016-12"
-9256	blurry gray chocolate puppy	0		Last Available: "2016-12"
+9253	practically non-alcoholic smooth huge spiritual eggnog	1	awesome	Last Available: "2016-12"
+9254	rotten huge upside-down spiritual fruitcake	7	crappy	Last Available: "2016-12"
+9255	yummy miniature lime green spiritual gingerbread	2	awesome	Last Available: "2016-12"
+9256	gray blurry chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
-9259	green bouncing Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
+9259	bouncing green Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	ghostly fruit-leather negatives	0		Last Available: "2016-12"
@@ -9167,8 +9167,8 @@
 9295	modified maroon stench jelly	1		Last Available: "2017-01"
 9296	blue space planula	0		Free Pull, Last Available: "2017-01"
 9297	miniature moldy toast with hot jelly	2	crappy	Last Available: "2017-01"
-9298	stale immense maroon toast with jelly	6	decent	Last Available: "2017-01"
-9299	super-sized flavorless toast with jelly	5	decent	Last Available: "2017-01"
+9298	immense stale maroon toast with jelly	6	decent	Last Available: "2017-01"
+9299	flavorless super-sized toast with jelly	5	decent	Last Available: "2017-01"
 9300	moldy yellow toast with sleaze jelly	3	crappy	Last Available: "2017-01"
 9301	immense moldy toast with stench jelly	10	crappy	Last Available: "2017-01"
 9302	green space jellybicycle	0		Familiar Weight: +5
@@ -9240,35 +9240,35 @@
 9368	bad Siberian sunrise	3	decent	Last Available: "2017-03"
 9369	tolerable mentholated wine	4	good	Last Available: "2017-03"
 9370	lousy extra-dry ghostly low tide martini	5	decent	Last Available: "2017-03"
-9371	watered-down smooth shroomtini	2	awesome	Last Available: "2017-03"
+9371	smooth watered-down shroomtini	2	awesome	Last Available: "2017-03"
 9372	hand-crafted huge morning dew	4	EPIC	Last Available: "2017-03"
 9373	spirit-forward hand-crafted twirling whiskey squeeze	5	EPIC	Last Available: "2017-03"
 9374	delicious skewed great fashioned	3	awesome	Last Available: "2017-03"
 9375	tolerable Gnomish sagngria	4	good	Last Available: "2017-03"
 9376	drinkable strong vodka stinger	5	good	Last Available: "2017-03"
-9377	fancy drinkable extremely slippery nipple	4	good	Effect: "One Very Clear Eye", Effect Duration: 20, Last Available: "2017-03"
-9378	lousy distilled piscatini	5	decent	Last Available: "2017-03"
+9377	drinkable fancy extremely slippery nipple	4	good	Effect: "One Very Clear Eye", Effect Duration: 20, Last Available: "2017-03"
+9378	distilled lousy piscatini	5	decent	Last Available: "2017-03"
 9379	bad upside-down Churchill	3	decent	Last Available: "2017-03"
-9380	artisanal watered-down ghostly soilzerac	2	EPIC	Last Available: "2017-03"
+9380	watered-down artisanal ghostly soilzerac	2	EPIC	Last Available: "2017-03"
 9381	practically non-alcoholic drinkable London frog	1	good	Last Available: "2017-03"
 9382	tolerable jittery nothingtini	3	good	Last Available: "2017-03"
 9383	mediocre eighth plague	3	decent	Last Available: "2017-03"
 9384	tolerable blurry single entendre	3	good	Last Available: "2017-03"
-9385	practically non-alcoholic acceptable reverse Tantalus	1	good	Last Available: "2017-03"
-9386	weak hand-crafted elemental caipiroska	2	EPIC	Last Available: "2017-03"
-9387	lousy distilled Feliz Navidad	5	decent	Last Available: "2017-03"
-9388	mediocre high-proof Bloody Nora	7	decent	Last Available: "2017-03"
-9389	hand-crafted watered-down wobbly moreltini	2	EPIC	Last Available: "2017-03"
+9385	acceptable practically non-alcoholic reverse Tantalus	1	good	Last Available: "2017-03"
+9386	hand-crafted weak elemental caipiroska	2	EPIC	Last Available: "2017-03"
+9387	distilled lousy Feliz Navidad	5	decent	Last Available: "2017-03"
+9388	high-proof mediocre Bloody Nora	7	decent	Last Available: "2017-03"
+9389	watered-down hand-crafted wobbly moreltini	2	EPIC	Last Available: "2017-03"
 9390	mediocre gray hell in a bucket	3	decent	Last Available: "2017-03"
 9391	lousy Newark	4	decent	Last Available: "2017-03"
 9392	drinkable R'lyeh	3	good	Last Available: "2017-03"
 9393	delicious distilled pulsating Gnollish sangria	5	awesome	Last Available: "2017-03"
 9394	drinkable vodka barracuda	4	good	Last Available: "2017-03"
 9395	lousy red Mysterious Island iced tea	4	decent	Last Available: "2017-03"
-9396	watered-down delicious drive-by shooting	2	awesome	Last Available: "2017-03"
+9396	delicious watered-down drive-by shooting	2	awesome	Last Available: "2017-03"
 9397	hand-crafted blurry gunner's daughter	3	EPIC	Last Available: "2017-03"
 9398	hand-crafted narrow dirt julep	3	EPIC	Last Available: "2017-03"
-9399	tolerable enchanted watered-down Simepore slime	2	good	Effect: "Simulation Stimulation", Effect Duration: 5, Last Available: "2017-03"
+9399	watered-down enchanted tolerable Simepore slime	2	good	Effect: "Simulation Stimulation", Effect Duration: 5, Last Available: "2017-03"
 9400	drinkable huge Phil Collins	3	good	Last Available: "2017-03"
 9401	tumbling unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9277,7 +9277,7 @@
 9405	skewed filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	lime green huge exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
-9408	tumbling jittery gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9408	jittery tumbling gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
 9411	shaking alien rock sample	0		Last Available: "2017-04"
@@ -9328,16 +9328,16 @@
 9456	ghostly Jack Frost's murderbot plasma rifle	0		Cold Spell Damage: +50, Item Drop: +5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
-9459	blurry bouncing Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
+9459	bouncing blurry Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	ghostly Space Baby bawbaw	0		Last Available: "2017-04"
 9465	lime green Spacegate	0		Last Available: "2017-04"
-9466	tiny decent Aldebaran sardines	1	good	Last Available: "2017-04"
+9466	decent tiny Aldebaran sardines	1	good	Last Available: "2017-04"
 9467	practically non-alcoholic mediocre twirling Centauri fish wine	1	decent	Last Available: "2017-04"
-9468	powdered shaking blurry olive oxygen	1		Effect: "Vital", Effect Duration: 50, Last Available: "2017-04"
+9468	powdered blurry olive shaking oxygen	1		Effect: "Vital", Effect Duration: 50, Last Available: "2017-04"
 9469	Sherlock's sinister Spacegate scientist's insignia	0		Spell Damage: +10, Item Drop: +25, Single Equip, Last Available: "2017-04"
 9470	savvy Spacegate military insignia of the blizzard	0		Mysticality Percent: +20, Cold Spell Damage: +25, Single Equip, Last Available: "2017-04"
 9471	squat zippy Van der Graaf medical-grade Spacegate diplomat's insignia	0		Initiative: +20, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-04"
@@ -9349,7 +9349,7 @@
 9477	blinking Spacegate (open)	0		Lasts Until Rollover
 9478	green New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	super-enhanced activated cyan Daily Affirmation: Always be Collecting	0		Effect: "Serenity", Effect Duration: 24, Last Available: "2017-05"
-9480	tarnished yellow blinking Daily Affirmation: Think Win-Lose	0		Effect: "Sugar High", Effect Duration: 19, Last Available: "2017-05"
+9480	tarnished blinking yellow Daily Affirmation: Think Win-Lose	0		Effect: "Sugar High", Effect Duration: 19, Last Available: "2017-05"
 9481	Vulcanized Daily Affirmation: Be Superficially interested	0		Effect: "Blood-Gorged", Effect Duration: 12, Last Available: "2017-05"
 9482	altered denatured blue Daily Affirmation: Adapt to Change Eventually	0		Effect: "Stuck That Way", Effect Duration: 58, Last Available: "2017-05"
 9483	polymerized polarized Daily Affirmation: Be a Mind Master	0		Effect: "Buttermilk Boogie", Effect Duration: 32, Last Available: "2017-05"
@@ -9359,7 +9359,7 @@
 9487	tumbling License To Kill	0		
 9488	squat Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
-9490	quadruple-dry skewed narrow Threatening Missive	0		Effect: "Big Flaming Whip", Effect Duration: 53
+9490	quadruple-dry narrow skewed Threatening Missive	0		Effect: "Big Flaming Whip", Effect Duration: 53
 9491	ghostly Targeted Plague Vector	0		
 9492	bouncing suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	twirling Sinatra's slick Kremlin's Greatest Briefcase of chilblains	0		Moxie: +10, Experience (Moxie): +5, Cold Damage: +25, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
@@ -9388,7 +9388,7 @@
 9516	meteoroid	0		Last Available: "2017-08"
 9517	resourceful energetic meteortarboard of Calamity Jane	0		Maximum MP Percent: +20, Maximum MP: +50, Critical Hit Percent: +15, Last Available: "2017-08"
 9518	sizzling chilly meteorite guard of the ox	0		Muscle: +20, Cold Damage: +5, Hot Damage: +10, Damage Reduction: 9, Last Available: "2017-08"
-9519	upside-down asbestos-lined Lo Pan's meteorb	0		Spell Critical Percent: +30, Hot Resistance: +5, Lantern Element: "Hot", Last Available: "2017-08"
+9519	upside-down asbestos-lined Lo Pan's meteorb	0		Spell Critical Percent: +30, Hot Resistance: +5, Last Available: "2017-08", Lantern Element: "Hot"
 9520	groovy beefcake's asteroid belt	0		Muscle: +25, Moxie Percent: +10, Single Equip, Last Available: "2017-08"
 9521	mirror maroon extremely unsafe meteorthopedic shoes of the blizzard of the detective	0		Weapon Damage Percent: +100, Cold Spell Damage: +25, Item Drop: +20, Single Equip, Last Available: "2017-08"
 9522	skewed toasty Oprah's shooting morning star of the cougar	0		Moxie: +20, Maximum MP Percent: +50, Hot Damage: +5, Single Equip, Last Available: "2017-08"
@@ -9414,9 +9414,9 @@
 9542	blue exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	irresponsibly strong artisanal DUFRESNE Suds	6	EPIC	Last Available: "2017-09"
+9545	artisanal irresponsibly strong DUFRESNE Suds	6	EPIC	Last Available: "2017-09"
 9546	spinning narrow thinker's mafia pinky ring of Leguizamo	0		Mysticality: +10, Monster Level: +20, Single Equip
-9547	high-proof lousy skewed flask of port	9	decent	
+9547	lousy high-proof skewed flask of port	9	decent	
 9548	wobbly lime green mansplainer's grievous contract enforcement stick	0		Weapon Damage Percent: +50, Monster Level: +15
 9549	stale ghostly Hide-rox&trade; cookie	4	decent	Last Available: "2017-10"
 9550	acceptable jug of booze	4	good	Last Available: "2017-10"
@@ -9434,7 +9434,7 @@
 9562	wobbly flame-retardant frightening scorching protection stick of the scaredy-cat	0		Monster Level: -15, Hot Damage: +25, Spooky Damage: +5, Hot Resistance: +1
 9563	triple-wet deionized roll of meat	0		Effect: "New Zeal", Effect Duration: 62
 9564	curative fortified mafia thumb ring	0		Damage Absorption: +60, HP Regen Min: 3, HP Regen Max: 5, Single Equip
-9565	extra-energized squat blinking cocoa chondrule	0		Effect: "Eagle Eyes", Effect Duration: 24, Last Available: "2020-09"
+9565	extra-energized blinking squat cocoa chondrule	0		Effect: "Eagle Eyes", Effect Duration: 24, Last Available: "2020-09"
 9566	ghostly prompt beefy mafia middle finger ring	0		Muscle: +10, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	dog trainer's dangerous steel drivin' hammer of the cougar of temperance	0		Moxie: +20, Weapon Damage: +10, Experience (familiar): +1, Sleaze Resistance: +5
 9568	olive piece of steel	0		
@@ -9449,7 +9449,7 @@
 9577	twirling mafia filofax	0		
 9578	transparent nog	1	awesome	Last Available: "2017-12"
 9579	special flavorless half-sized red unfinished fruitcake	2	decent	Effect: "Industrial Strength Starch", Effect Duration: 30, Last Available: "2017-12"
-9580	double-wet double-cold-filtered blinking yellow and cracker	0		Effect: "Pla-see-bo", Effect Duration: 42, Last Available: "2017-12"
+9580	double-wet double-cold-filtered yellow blinking and cracker	0		Effect: "Pla-see-bo", Effect Duration: 42, Last Available: "2017-12"
 9581	lousy spinning neg grog	4	decent	Last Available: "2017-12"
 9582	adequate half double fruitcake	4	good	Last Available: "2017-12"
 9583	toothsome hushed puppy	3	awesome	Last Available: "2017-12"
@@ -9467,7 +9467,7 @@
 9595	perfectly mixed Racisto Ruidoso	3	super ultra mega turbo EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	moldy green narrow bran muffin	3	crappy	
-9598	enchanted moldy squat blueberry muffin	3	crappy	Effect: "Frigid Weapon", Effect Duration: 5
+9598	moldy enchanted squat blueberry muffin	3	crappy	Effect: "Frigid Weapon", Effect Duration: 5
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	green silent C	0		Last Available: "2017-12"
@@ -9498,9 +9498,9 @@
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	tumbling warehouse key	0		Last Available: "2017-12"
 9628	shaking mime pocket probe	0		Last Available: "2017-12"
-9629	bad fancy stale cheer wine	3	decent	Effect: "Neuromancy", Effect Duration: 25, Last Available: "2017-12"
-9630	decent jumbo stale Cheer-E-Os	5	good	Last Available: "2017-12"
-9631	tumbling jittery cheer-o-gram	0		Last Available: "2017-12"
+9629	fancy bad stale cheer wine	3	decent	Effect: "Neuromancy", Effect Duration: 25, Last Available: "2017-12"
+9630	jumbo decent stale Cheer-E-Os	5	good	Last Available: "2017-12"
+9631	jittery tumbling cheer-o-gram	0		Last Available: "2017-12"
 9632	cyan arcane researcher's cheerful antler hat of the blizzard	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +25, Last Available: "2017-12"
 9633	asbestos-lined weightlifter's cheerful Crimbo sweater	0		Muscle: +15, Hot Resistance: +5, Last Available: "2017-12"
 9634	rosy-cheeked cheerful pajama pants of the bloodbag	0		Maximum HP Percent: +30, Maximum HP: +100, Last Available: "2017-12"
@@ -9517,13 +9517,13 @@
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	strong lousy executive mime flask	5	decent	Last Available: "2017-12"
+9648	lousy strong executive mime flask	5	decent	Last Available: "2017-12"
 9649	bland nega-mushroom	3	decent	Last Available: "2017-12"
 9650	practically non-alcoholic aged nega-mushroom wine	1	awesome	Last Available: "2017-12"
 9651	anodized improved olive Cheer-Up soda	0		Effect: "Chalky Hand", Effect Duration: 36, Last Available: "2017-12"
-9652	miniature bland twirling mime army rations	2	decent	Last Available: "2017-12"
+9652	bland miniature twirling mime army rations	2	decent	Last Available: "2017-12"
 9653	aged practically non-alcoholic mime army wine	1	awesome	Last Available: "2017-12"
-9654	mixed huge lime green mime army superserum	1		Last Available: "2017-12"
+9654	mixed lime green huge mime army superserum	1		Last Available: "2017-12"
 9655	modified bouncing mime army camouflage kit	0		Effect: "Bloodstain-Resistant", Effect Duration: 13, Last Available: "2017-12"
 9656	twirling lard-coated savvy miming beret	0		Mysticality Percent: +20, Sleaze Spell Damage: +25, Last Available: "2017-12"
 9657	twirling frosty Tesla miming shirt	0		Cold Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	non-flattened dry digital honeypot	0		Effect: "Human-Undead Hybrid", Effect Duration: 31, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	shaking olive shaking mime army insignia (infantry) of horror	0		Spooky Spell Damage: +25, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	manspreader's mime army insignia (intelligence)	0		Monster Level: +10, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	smooth mime army insignia (espionage)	0		Moxie: +15, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	shaking olive shaking mime army insignia (infantry) of horror	0		Spooky Spell Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	manspreader's mime army insignia (intelligence)	0		Monster Level: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	smooth mime army insignia (espionage)	0		Moxie: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9565,7 +9565,7 @@
 9693	Rosewater's strapping tinsel tights	0		Muscle: +5, Mysticality Percent: +30, Last Available: "2018-01"
 9694	ruddy wad of used tape of incineration of the sweet-tooth	0		Maximum HP Percent: +40, Hot Spell Damage: +50, Candy Drop: +100, Last Available: "2018-01"
 9695	tumbling scandalous Van der Graaf razor-sharp experienced silent nightlight	0		Experience: +2, Weapon Damage Percent: +25, Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7
-9696	extra-improved squat green sweetened reindeer fat	0		Effect: "Ancestral Disapproval", Effect Duration: 48
+9696	extra-improved green squat sweetened reindeer fat	0		Effect: "Ancestral Disapproval", Effect Duration: 48
 9697	polymerized quadruple-warmed squat Good 'n' Quiet	0		Effect: "New Zeal", Effect Duration: 59
 9698	Vulcanized ionized galvanized spinning hot button candy	0		Effect: "Loco Motives", Effect Duration: 54
 9699	medical-grade veiny banded makeshift garbage shirt	0		Damage Absorption: +100, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-01"
@@ -9573,14 +9573,14 @@
 9701	vaporized bouncing skewed pills	1		
 9702	twisted furry pill	1		Effect: "Boletus Swoletus", Effect Duration: 15
 9703	mixed beefy pill	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
-9704	dried skewed cyan excitement pill	1		Effect: "Livin' Large", Effect Duration: 20
+9704	dried cyan skewed excitement pill	1		Effect: "Livin' Large", Effect Duration: 20
 9705	powdered huge narrow vitamin G pill	1		Effect: "Hagg-ard", Effect Duration: 40
 9706	diluted lucky-ish pill	1		Effect: "Itchy Trigger Finger", Effect Duration: 5
-9707	mixed huge blurry dieting pill	1		Effect: "Mayeaugh", Effect Duration: 30
+9707	mixed blurry huge dieting pill	1		Effect: "Mayeaugh", Effect Duration: 30
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
-9715	shaking blue Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
+9715	blue shaking Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
@@ -9595,7 +9595,7 @@
 9727	spoiled half-sized heart-shaped candy whetstone	2	crappy	Last Available: "2018-02"
 9728	enchanted toothsome blurry Swedish massage fish	3	awesome	Effect: "Twenty-three Squid, Ew", Effect Duration: 50, Last Available: "2018-02"
 9729	practically non-alcoholic hand-crafted twirling squat Third Base	1	EPIC	Last Available: "2018-02"
-9730	smooth lime green skewed Bustle Hustler	4	awesome	Last Available: "2018-02"
+9730	smooth skewed lime green Bustle Hustler	4	awesome	Last Available: "2018-02"
 9731	double-boiled Fabiotion	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 56, Last Available: "2018-02"
 9732	improved jittery Bettie page	0		Effect: "Stinky Hands", Effect Duration: 59, Last Available: "2018-02"
 9733	warmed tonic o' Banderas	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 53, Last Available: "2018-02"
@@ -9614,7 +9614,7 @@
 9746	adjusted quadruple-diffused rhinestone	0		Effect: "Dance Interpreter", Effect Duration: 42
 9747	twirling 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
-9749	purple huge riboflavin	0		
+9749	huge purple riboflavin	0		
 9750	bronze	0		
 9751	piracetam	0		
 9752	ultracalcium	0		
@@ -9640,7 +9640,7 @@
 9772	Morphan	0		Last Available: "2018-03"
 9773	squat Cycloney	0		Last Available: "2018-03"
 9774	wobbly Peaclock	0		Last Available: "2018-03"
-9775	twirling red Turtive	0		Last Available: "2018-03"
+9775	red twirling Turtive	0		Last Available: "2018-03"
 9776	fuchsia Lepardner	0		Last Available: "2018-03"
 9777	narrow Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
@@ -9693,12 +9693,12 @@
 9825	blinking razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
-9828	dehydrated wobbly upside-down magnificent oyster egg	1		
+9828	dehydrated upside-down wobbly magnificent oyster egg	1		
 9829	boiled brilliant oyster egg	1		
 9830	twisted glistening oyster egg	1		
 9831	pickled blinking scintillating oyster egg	1		
 9832	pickled wobbly pearlescent oyster egg	1		
-9833	compressed tumbling blinking lustrous oyster egg	1		Effect: "Scorpio Rising", Effect Duration: 20
+9833	compressed blinking tumbling lustrous oyster egg	1		Effect: "Scorpio Rising", Effect Duration: 20
 9834	altered tumbling gleaming oyster egg	1		Effect: "Bread Burps", Effect Duration: 40
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	skewed FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9727,7 +9727,7 @@
 9859	upside-down LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	purple skewed FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	shaking LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	adequate massive FantasyRealm turkey leg	9	good	Last Available: "2018-04"
+9862	massive adequate FantasyRealm turkey leg	9	good	Last Available: "2018-04"
 9863	delicious watered-down pulsating FantasyRealm mead	2	awesome	Last Available: "2018-04"
 9864	skewed nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	skewed shaking charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	blurry notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	bad practically non-alcoholic two meat muck	1	decent	
+9898	practically non-alcoholic bad two meat muck	1	decent	
 9899	normal chocolate Ogre Chieftain	4	good	
 9900	bland chocolate &quot;Phoenix&quot;	4	decent	
 9901	immense spoiled chocolate Spider Queen	9	crappy	
-9902	artisanal weak spinning hipster cocktail	2	EPIC	
-9903	ghostly God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	narrow God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9902	weak artisanal spinning hipster cocktail	2	EPIC	
+9903	ghostly God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	narrow God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	huge G	0		
 9910	Garland of Greatness	0		
@@ -9781,7 +9781,7 @@
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	adequate blurry good guava	3	good	
-9916	acceptable practically non-alcoholic gin and ginger	1	good	
+9916	practically non-alcoholic acceptable gin and ginger	1	good	
 9917	Thwaitgold chigger statuette	0		
 9918	mixed gray gaseous gravy	1		Effect: "Certainty", Effect Duration: 45
 9919	tumbling SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9793,7 +9793,7 @@
 9925	denatured ghostly Nightmare Fuel	1		Last Available: "2018-06"
 9926	huge Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	olive Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
-9928	pulsating huge Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
+9928	huge pulsating Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	mansplainer's hale personal trainer's Brutal brogues of the brute	0		Muscle Percent: +30, Experience Percent (Muscle): +10, Maximum HP: +20, Monster Level: +15, Lasts Until Rollover, Last Available: "2018-07"
 9930	Oprah's deadly educational Draftsman's driving gloves of Tarzan	0		Experience: +1, Experience (Muscle): +3, Weapon Damage: +5, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2018-07"
 9931	supercharged Nouveau nosering of vim and vigor of the blizzard of the sweet-tooth	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Cold Spell Damage: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2018-07"
@@ -9811,14 +9811,14 @@
 9943	Neverending Party guest pass	0		Last Available: "2018-09"
 9944	narrow executive quilted baleful PARTY HARD T-shirt	0		Spell Damage: +25, Damage Absorption: +40, Meat Drop: +40, Last Available: "2018-09"
 9945	huge Neverending Party favor	0		Last Available: "2018-09"
-9946	tumbling red deluxe Neverending Party favor	0		Last Available: "2018-09"
+9946	red tumbling deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	weak mediocre Middle of the Road&trade; brand whiskey	2	decent	Last Available: "2018-09"
+9948	mediocre weak Middle of the Road&trade; brand whiskey	2	decent	Last Available: "2018-09"
 9949	squat neverending wallet chain	0		Last Available: "2018-09"
 9950	avaricious pentagram bandana of the glutton	0		Meat Drop: +30, Food Drop: +100, Last Available: "2018-09"
 9951	manspreader's skull ring	0		Monster Level: +10, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	stale low-calorie fancy huge PB&J with the crusts cut off	1	decent	Effect: "Guts Feeling", Effect Duration: 15, Last Available: "2018-09"
+9953	stale fancy low-calorie huge PB&J with the crusts cut off	1	decent	Effect: "Guts Feeling", Effect Duration: 15, Last Available: "2018-09"
 9954	coward's Newton's dorky glasses	0		Experience (Mysticality): +3, Monster Level: -20, Single Equip, Last Available: "2018-09"
 9955	skewed quilted ponytail clip of the pedagogue	0		Experience: +3, Damage Absorption: +40, Last Available: "2018-09"
 9956	stanky paint palette	0		Stench Spell Damage: +25, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
@@ -9873,21 +9873,21 @@
 10007	blurry aromatic energetic supercool mutant arm	0		Moxie Percent: +20, Maximum MP Percent: +20, Stench Resistance: +1, Last Available: "2018-11"
 10008	tumbling asbestos-lined electrified mutant legs of the pedagogue	0		Experience: +3, Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-11"
 10009	twirling careful beefcake's mutant crown of dire peril	0		Muscle: +25, Weapon Damage: +20, Monster Level: -10, Last Available: "2018-11"
-10010	normal low-calorie jittery red ghostly ectoplasm	1	good	Last Available: "2018-11"
+10010	normal low-calorie red jittery ghostly ectoplasm	1	good	Last Available: "2018-11"
 10011	stale	3	decent	Last Available: "2018-11"
 10012	perfectly mixed bottle of vodka	3	EPIC	Last Available: "2018-11"
 10013	delicious shaking pizza	3	awesome	Last Available: "2018-11"
 10014	lousy practically non-alcoholic narrow martini	1	decent	Last Available: "2018-11"
-10015	gigantic adequate shaking cherry pie	7	good	Last Available: "2018-11"
-10016	acceptable enchanted blinking eggnog	3	good	Effect: "Sleazy Hands", Effect Duration: 20, Last Available: "2018-11"
+10015	adequate gigantic shaking cherry pie	7	good	Last Available: "2018-11"
+10016	enchanted acceptable blinking eggnog	3	good	Effect: "Sleazy Hands", Effect Duration: 20, Last Available: "2018-11"
 10017	upside-down glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	bland Hell ramen	4	decent	Last Available: "2018-11"
 10019	perfectly mixed gimlet	3	EPIC	Last Available: "2018-11"
-10020	acceptable shaking twirling twice-haunted screwdriver	4	good	Last Available: "2018-11"
+10020	acceptable twirling shaking twice-haunted screwdriver	4	good	Last Available: "2018-11"
 10021	special decent candy cane	3	good	Effect: "Sucrose-Colored Glasses", Effect Duration: 25, Last Available: "2018-12"
-10022	triple-distilled bad runny fermented egg	6	decent	Last Available: "2018-12"
-10023	stale super-sized oldcake	5	decent	Last Available: "2018-12"
-10024	small spoiled traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
+10022	bad triple-distilled runny fermented egg	6	decent	Last Available: "2018-12"
+10023	super-sized stale oldcake	5	decent	Last Available: "2018-12"
+10024	spoiled small traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
 10025	Rosewater's plastic wild beaver	0		Mysticality Percent: +30, Last Available: "2018-12"
 10026	plastic reindeer of terror	0		Spooky Spell Damage: +10, Last Available: "2018-12"
 10027	crafty plastic Caf&eacute; Elf	0		Maximum MP: +10, Last Available: "2018-12"
@@ -9906,7 +9906,7 @@
 10040	bland moosemeat pie	3	decent	Last Available: "2018-12"
 10041	executive balanced antler	0		Meat Drop: +40, Last Available: "2018-12"
 10042	spinning hale dam	0		Maximum HP: +20, Damage Reduction: 9, Last Available: "2018-12"
-10043	hand-crafted high-proof beavermouth	8	EPIC	Last Available: "2018-12"
+10043	high-proof hand-crafted beavermouth	8	EPIC	Last Available: "2018-12"
 10044	delicious shaking beaver punch (papaya)	3	awesome	Last Available: "2018-12"
 10045	perfectly mixed beaver punch (peach)	4	EPIC	Last Available: "2018-12"
 10046	practically non-alcoholic delicious beaver punch (cherry)	1	awesome	Last Available: "2018-12"
@@ -9960,7 +9960,7 @@
 10094	Jeselnik's Jim Carey's marble medallion	0		Monster Level: +25, Sleaze Damage: +25, Single Equip, Last Available: "2019-12"
 10095	gravedigger's marble mariachi hat of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Last Available: "2019-12"
 10096	vaporized marble molecules	1		Last Available: "2019-12"
-10097	ionized warmed narrow jittery Mallomarbles	0		Effect: "Sticks and Stones", Effect Duration: 35
+10097	ionized warmed jittery narrow Mallomarbles	0		Effect: "Sticks and Stones", Effect Duration: 35
 10098	shaking maroon gravedigger's Rosewater's punching bag	0		Mysticality Percent: +30, Spooky Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10099	Lo Pan's grievous pith helmet	0		Weapon Damage Percent: +50, Spell Critical Percent: +30, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10100	shaking purple rosewater-soaked arcane researcher's poncho	0		Experience Percent (Mysticality): +10, Stench Resistance: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
@@ -9992,7 +9992,7 @@
 10126	flame-wreathed hardy glass shiv	0		Maximum HP: +50, Hot Spell Damage: +10, Last Available: "2021-12"
 10127	Fonzie's glass serape of the brute	0		Muscle Percent: +30, Experience (Moxie): +1, Last Available: "2021-12"
 10128	compressed glass shards	1		Last Available: "2021-12"
-10129	deionized skewed olive hard candy	0		Effect: "Pride of the Vampire", Effect Duration: 37
+10129	deionized olive skewed hard candy	0		Effect: "Pride of the Vampire", Effect Duration: 37
 10130	blinking Socratic loofah lumberjack's hat of Leguizamo	0		Experience (Mysticality): +1, Monster Level: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
 10131	prompt scandalous loofah lei	0		Sleaze Damage: +5, Adventures: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
 10132	supercool loofah lederhosen of the detective	0		Moxie Percent: +20, Item Drop: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
@@ -10007,7 +10007,7 @@
 10141	blinking purple chilly padded flagstone fez	0		Damage Absorption: +20, Cold Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
 10142	personal trainer's flagstone fleece of Leguizamo	0		Experience Percent (Muscle): +10, Monster Level: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
 10143	quilted beefcake's flagstone fringe	0		Muscle: +25, Damage Absorption: +40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	pickled huge twirling squat flagstone flagments	1		Last Available: "2022-12"
+10144	pickled twirling squat huge flagstone flagments	1		Last Available: "2022-12"
 10145	irradiated non-denatured Flag by the Foot&trade;	0		Effect: "Spookyravin'", Effect Duration: 56
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	upside-down red-and-green microcamera	0		Familiar Weight: +5
@@ -10032,9 +10032,9 @@
 10166	Sinatra's savvy Lil' Doctor&trade; bag	0		Mysticality Percent: +20, Experience (Moxie): +5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	spinning blood bag	0		
 10169	rotten ghostly bloodstick	4	crappy	
-10170	weak perfectly mixed pulsating bottle of Sanguiovese	2	EPIC	
-10171	snack-sized bland actual blood sausage	2	decent	
-10172	mediocre practically non-alcoholic mulled blood	1	decent	
+10170	perfectly mixed weak pulsating bottle of Sanguiovese	2	EPIC	
+10171	bland snack-sized actual blood sausage	2	decent	
+10172	practically non-alcoholic mediocre mulled blood	1	decent	
 10173	spoiled snack-sized yellow blood snowcone	2	crappy	
 10174	hand-crafted Red Russian	4	EPIC	
 10175	adequate blood roll-up	3	good	
@@ -10048,7 +10048,7 @@
 10183	squat money bag	0		
 10184	blinking Thwaitgold mosquito statuette	0		
 10185	wobbly bucket of Vampyre blood	0		
-10186	ghostly red blood knife	0		Lasts Until Rollover
+10186	red ghostly blood knife	0		Lasts Until Rollover
 10187	blurry PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
 10188	PirateRealm guest pass	0		Last Available: "2019-04"
 10189	greasy chilly PirateRealm eyepatch of Flo-Jo	0		Cold Damage: +5, Sleaze Spell Damage: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2019-04"
@@ -10063,9 +10063,9 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	moldy crabsicle	4	crappy	Last Available: "2019-04"
 10200	spinning melty plastic grenade	0		Last Available: "2019-04"
-10201	acceptable practically non-alcoholic pulsating bottle of dark rhum	1	good	Last Available: "2019-04"
+10201	practically non-alcoholic acceptable pulsating bottle of dark rhum	1	good	Last Available: "2019-04"
 10202	mediocre bottle of extra-dark rhum	3	decent	Last Available: "2019-04"
-10203	extra-dry tolerable bottle of super-extra-dark rhum	5	good	Last Available: "2019-04"
+10203	tolerable extra-dry bottle of super-extra-dark rhum	5	good	Last Available: "2019-04"
 10204	wet wet pirate shaving cream	0		Effect: "Reptilian Fortitude", Effect Duration: 30, Last Available: "2019-04"
 10205	cyan MacGyver's conquistador's breastplate of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Last Available: "2019-04"
 10206	tumbling lime green pirate pantaloons of doom of the boozehound	0		Spooky Spell Damage: +50, Booze Drop: +100, Last Available: "2019-04"
@@ -10082,14 +10082,14 @@
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	squat Red Roger's left hand	0		Last Available: "2019-04"
-10220	jittery squat Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10220	squat jittery Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	twisted blue pewter shavings	1		Last Available: "2019-04"
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	plush sea serpent of the wise owl	0		Mysticality: +20, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	big rotten maroon bouncing pirate fork	5		Last Available: "2019-04"
+10227	rotten big maroon bouncing pirate fork	5		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	wobbly up-at-dawn flame-wreathed piratical blunderbuss	0		Hot Spell Damage: +10, Adventures: +5, Last Available: "2019-04"
@@ -10099,7 +10099,7 @@
 10234	lousy high-proof purple Island Hurricane	6	decent	Last Available: "2019-04"
 10235	perfectly mixed cyan Skull Punch	4	EPIC	Last Available: "2019-04"
 10236	artisanal Electric Punch	4	EPIC	Last Available: "2019-04"
-10237	weak lousy Smuggler's Punch	2	decent	Last Available: "2019-04"
+10237	lousy weak Smuggler's Punch	2	decent	Last Available: "2019-04"
 10238	mediocre Scorpion Bowl	4	decent	Last Available: "2019-04"
 10239	artisanal watered-down mirror Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10240	perfectly mixed irresponsibly strong shaking Cobra Bowl	10	EPIC	Last Available: "2019-04"
@@ -10111,7 +10111,7 @@
 10246	red intact medium-wave antenna	0		
 10247	18-picohertz resonator crystal	0		
 10248	blown-out speaker cone	0		
-10249	upside-down shaking overloaded short-pulse transistor	0		
+10249	shaking upside-down overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
 10251	huge pulsating avaricious lard-coated savvy Fourth of May Cosplay Saber	0		Mysticality Percent: +20, Sleaze Spell Damage: +25, Meat Drop: +30, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
@@ -10165,11 +10165,11 @@
 10300	arcane researcher's whittled owl figurine of James Dean of the storm	0		Experience (Moxie): +3, Experience Percent (Mysticality): +10, Maximum MP Percent: +40, Single Equip, Last Available: "2019-08"
 10301	executive inspector's whittled fox figurine of the sweet-tooth	0		Item Drop: +15, Meat Drop: +40, Candy Drop: +100, Single Equip, Last Available: "2019-08"
 10302	upside-down steel-toed whittled walking stick of the scaredy-cat of horror of the cheetah	0		Damage Reduction: 9, Monster Level: -15, Spooky Spell Damage: +25, Initiative: +60, Last Available: "2019-08"
-10303	spoiled miniature campfire hot dog	2	crappy	Last Available: "2019-08"
+10303	miniature spoiled campfire hot dog	2	crappy	Last Available: "2019-08"
 10304	flavorless tiny campfire baked potato	1	decent	Last Available: "2019-08"
-10305	miniature normal campfire s'more	2	good	Last Available: "2019-08"
-10306	tiny spoiled campfire beans	1	crappy	Last Available: "2019-08"
-10307	spoiled small campfire stew	2	crappy	Last Available: "2019-08"
+10305	normal miniature campfire s'more	2	good	Last Available: "2019-08"
+10306	spoiled tiny campfire beans	1	crappy	Last Available: "2019-08"
+10307	small spoiled campfire stew	2	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	improved red leftover chocolate bar	0		Effect: "Always be Collecting", Effect Duration: 68
 10310	rare Meat isotope	0		
@@ -10191,7 +10191,7 @@
 10332	shaking Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	teal foul-smelling rosy-cheeked quilted Eight Days a Week Pill Keeper	0		Damage Absorption: +40, Maximum HP Percent: +30, Stench Damage: +10, Last Available: "2019-10"
 10334	squat unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
-10335	bouncing huge diabolic pizza cube	0		Last Available: "2019-11"
+10335	huge bouncing diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	moldy bu&ntilde;uelos Jaliscos	3	crappy	Last Available: "2019-12"
 10338	spoiled flan del mar	4	crappy	Last Available: "2019-12"
@@ -10205,15 +10205,15 @@
 10346	stale massive mana-coated yams	10	decent	Last Available: "2019-11"
 10347	moldy tiny mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
 10348	massive flavorless mana-fortified cranberry sauce	10	decent	Last Available: "2019-11"
-10349	spoiled tiny mana-stuffed herbal stuffing	1	crappy	Last Available: "2019-11"
+10349	tiny spoiled mana-stuffed herbal stuffing	1	crappy	Last Available: "2019-11"
 10350	pulsating human musk	0		Last Available: "2019-12"
 10351	activated liquefied irradiated skewed patch of extra-warm fur	0		Effect: "Ghost Finger", Effect Duration: 35, Last Available: "2019-12"
 10352	pickled industrial lubricant	1		Last Available: "2019-12"
 10353	ionized boiled unfinished pleasure	0		Effect: "Orchid Blood", Effect Duration: 49, Last Available: "2019-12"
-10354	distilled squat ghostly vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	distilled ghostly squat vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	pickled a bug's lymph	1		Effect: "Booing Radly", Effect Duration: 50, Last Available: "2019-12"
 10356	anodized flattened organic potpourri	0		Effect: "Papowerful", Effect Duration: 45, Last Available: "2019-12"
-10357	high-proof aged boot flask	7	awesome	Last Available: "2019-12"
+10357	aged high-proof boot flask	7	awesome	Last Available: "2019-12"
 10358	energized spinning infernal snowball	0		Effect: "Tingly Wrists", Effect Duration: 39, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	pickled fish sauce	1		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	upside-down nutcracker figurine	0		Last Available: "2019-12"
 10415	normal salt plum	4	good	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	snack-sized adequate and bean	2	good	Last Available: "2019-12"
+10417	adequate snack-sized and bean	2	good	Last Available: "2019-12"
 10418	resourceful energetic thinker's kelp-holly gun	0		Mysticality: +10, Maximum MP Percent: +20, Maximum MP: +50, Last Available: "2019-12"
 10419	narrow careful Yuleviathan necklace of the scaredy-cat	0		Monster Level: -25, Single Equip, Last Available: "2019-12"
 10420	sizzling Herculean peppermint spine	0		Experience (Muscle): +1, Hot Damage: +10, Last Available: "2019-12"
@@ -10300,8 +10300,8 @@
 10443	Driplet	0		
 10444	gray drippy snail shell	0		
 10445	spoiled drippy nugget	3	drippy	
-10446	perfectly mixed watered-down glass of drippy wine	2	drippy	
-10447	miniature flavorless drippy caviar	2	drippy	
+10446	watered-down perfectly mixed glass of drippy wine	2	drippy	
+10447	flavorless miniature drippy caviar	2	drippy	
 10448	yummy drippy plum(?)	3	drippy	
 10449	blurry forbidden drippy stake	0		Spell Damage Percent: +50, Single Equip
 10450	green The Eye of the Thing in the Basement	0		
@@ -10332,12 +10332,12 @@
 10475	blue coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
-10478	teal bouncing plastic doll arms	0		
+10478	bouncing teal plastic doll arms	0		
 10479	plastic doll legs	0		
 10480	rubber baby doll	0		
 10481	wobbly Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	fuchsia packet of mushroom spores	0		Last Available: "2020-03"
-10483	jittery blurry free-range mushroom	0		Last Available: "2020-03"
+10483	blurry jittery free-range mushroom	0		Last Available: "2020-03"
 10484	teal plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	blue free-range mushroom	0		Last Available: "2020-03"
@@ -10346,17 +10346,17 @@
 10489	stale mushroom filet	3	decent	Last Available: "2020-03"
 10490	olive mushroom slab	0		Last Available: "2020-03"
 10491	diluted mushroom tea	1		Effect: "Deadly Lampblade", Effect Duration: 50, Last Available: "2020-03"
-10492	mediocre high-proof mushroom whiskey	8	decent	Last Available: "2020-03"
+10492	high-proof mediocre mushroom whiskey	8	decent	Last Available: "2020-03"
 10493	wool grievous beefcake's mushroom cap	0		Muscle: +25, Weapon Damage Percent: +50, Cold Resistance: +1, Last Available: "2020-03"
 10494	lion tamer's studded personal trainer's brawny mushroom shield	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Damage Absorption: +80, Experience (familiar): +2, Damage Reduction: 6, Last Available: "2020-03"
 10495	narrow fireproof frightening electrified mushroom pants of extreme caution	0		Monster Level: -25, Spooky Damage: +5, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-03"
 10496	skewed wool Annie Oakley's mushroom badge of the wise owl of the empath	0		Mysticality: +20, Critical Hit Percent: +20, Familiar Weight: +5, Cold Resistance: +1, Single Equip, Last Available: "2020-03"
 10497	house-sized mushroom	0		Last Available: "2020-03"
-10498	narrow mirror pristine piranha seed	0		Last Available: "2020-03"
+10498	mirror narrow pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	quantum super-frozen blue piranha pollen	0		Effect: "Hombre Muerto Caminando", Effect Duration: 39, Last Available: "2020-03"
 10501	plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
-10502	red bouncing sinistral homunculus	0		Free Pull, Last Available: "2020-04"
+10502	bouncing red sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	dog trainer's kettle bell	0		Experience (familiar): +1, Last Available: "2020-04"
 10504	glued-together crystal ball of the boozehound	0		Booze Drop: +100, Last Available: "2020-04"
 10505	narrow horrifying martini dregs	0		Spooky Damage: +25, Last Available: "2020-04"
@@ -10379,7 +10379,7 @@
 10522	drippy bromide	0		
 10523	narrow drippy flux	0		
 10524	blurry drippy stein	0		
-10525	perfectly mixed watered-down drippy pilsner	2	drippy	
+10525	watered-down perfectly mixed drippy pilsner	2	drippy	
 10526	narrow drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	lime green drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10395,10 +10395,10 @@
 10539	energetic Guzzlr souvenir stein	0		Maximum MP Percent: +20, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	practically non-alcoholic perfectly mixed Ghiaccio Colada	1	super ultra mega turbo EPIC	Last Available: "2020-05"
-10542	mediocre triple-distilled jittery pulsating Sourfinger	6	decent	Last Available: "2020-05"
-10543	irresponsibly strong drinkable Nog-on-the-Cob	7	good	Last Available: "2020-05"
-10544	watered-down bad Steamboat	2	decent	Last Available: "2020-05"
-10545	weak hand-crafted Buttery Boy	2	EPIC	Last Available: "2020-05"
+10542	triple-distilled mediocre jittery pulsating Sourfinger	6	decent	Last Available: "2020-05"
+10543	drinkable irresponsibly strong Nog-on-the-Cob	7	good	Last Available: "2020-05"
+10544	bad watered-down Steamboat	2	decent	Last Available: "2020-05"
+10545	hand-crafted weak Buttery Boy	2	EPIC	Last Available: "2020-05"
 10546	jittery Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	zippy clown car key of the early riser	0		Initiative: +20, Adventures: +7, Last Available: "2020-08"
 10548	double-paned therapeutic healthy batting cage key	0		Maximum HP Percent: +20, Cold Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-08"
@@ -10482,8 +10482,8 @@
 10626	onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
 10628	shaking onyx pawn	0		Last Available: "2020-09"
-10629	huge olive alabaster king	0		Last Available: "2020-09"
-10630	tumbling olive alabaster queen	0		Last Available: "2020-09"
+10629	olive huge alabaster king	0		Last Available: "2020-09"
+10630	olive tumbling alabaster queen	0		Last Available: "2020-09"
 10631	shaking pulsating alabaster rook	0		Last Available: "2020-09"
 10632	huge alabaster bishop	0		Last Available: "2020-09"
 10633	alabaster knight	0		Last Available: "2020-09"
@@ -10494,14 +10494,14 @@
 10638	smooth watered-down flask of moonshine	2	awesome	Last Available: "2020-09"
 10639	asbestos-lined beefy sea-worn candlestick of the cougar	0		Muscle: +10, Moxie: +20, Hot Resistance: +5, Last Available: "2020-09"
 10640	Universal Seasoning	0		
-10641	ionized vacuum-sealed irradiated wobbly yellow null-day exploit	0		Effect: "Rage of the Reindeer", Effect Duration: 16, Last Available: "2025-12"
+10641	ionized vacuum-sealed irradiated yellow wobbly null-day exploit	0		Effect: "Rage of the Reindeer", Effect Duration: 16, Last Available: "2025-12"
 10642	cyan flame orb	0		Last Available: "2020-09"
-10643	rotten thick chocolate chip muffin	5	crappy	
+10643	thick rotten chocolate chip muffin	5	crappy	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	blurry Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	twirling packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
-10648	tumbling olive box o' ghosts	0		Free Pull, Last Available: "2020-12"
+10648	olive tumbling box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	cyan grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	huge greedy ghostling	0		Free Pull, Last Available: "2020-12"
@@ -10568,17 +10568,17 @@
 10712	olive The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	huge spoiled and pepper (stale)	7	crappy	Last Available: "2020-12"
-10716	triple-distilled lousy cranberry margarita (brackish)	6	decent	Last Available: "2020-12"
-10717	spinning purple fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
+10715	spoiled huge and pepper (stale)	7	crappy	Last Available: "2020-12"
+10716	lousy triple-distilled cranberry margarita (brackish)	6	decent	Last Available: "2020-12"
+10717	purple spinning fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	acceptable barrel-aged eggnog	3	good	Last Available: "2020-12"
 10721	yummy pulsating hand-crafted candy cane	4	awesome	Last Available: "2020-12"
 10722	stale skewed drive-thru burger	4	decent	Last Available: "2020-12"
 10723	drinkable narrow Boulevardier cocktail	4	good	Last Available: "2020-12"
-10724	aerosolized dry deionized huge pulsating Hotwire&trade; brand candy rope	0		Effect: "Smoky Third Eye", Effect Duration: 64, Last Available: "2020-12"
-10725	normal jumbo olive bowl full of jelly	5	good	Last Available: "2020-12"
+10724	aerosolized dry deionized pulsating huge Hotwire&trade; brand candy rope	0		Effect: "Smoky Third Eye", Effect Duration: 64, Last Available: "2020-12"
+10725	jumbo normal olive bowl full of jelly	5	good	Last Available: "2020-12"
 10726	acceptable Eye and a Twist	4	good	Last Available: "2020-12"
 10727	activated spinning Chubby and Plump bar	0		Effect: "Outer Wolf&trade;", Effect Duration: 29, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
@@ -10600,7 +10600,7 @@
 10744	electrified vacuum-sealed battery (car)	0		Effect: "Comprehensively Nourished", Effect Duration: 19, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	skewed marshmallow	0		
-10747	artisanal boozy tumbling spinning marshmallow bomb	5	EPIC	Last Available: "2021-03"
+10747	boozy artisanal tumbling spinning marshmallow bomb	5	EPIC	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10651,7 +10651,7 @@
 10795	narrow pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	coward's vibrating therapeutic banded industrial fire extinguisher of the blizzard of Flo-Jo	0		Damage Absorption: +100, Maximum MP Percent: +10, Monster Level: -20, Cold Spell Damage: +25, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
-10798	pulsating huge The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
+10798	huge pulsating The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
@@ -10673,14 +10673,14 @@
 10817	upside-down coward's steel-toed rock-hard jeans	0		Damage Reduction: 28, Monster Level: -20, Lasts Until Rollover, Last Available: "2021-12"
 10818	lightning-fast Lo Pan's ice wrap of Flo-Jo	0		Spell Critical Percent: +30, Initiative: 140, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	stale tofu pop	4	decent	Last Available: "2021-12"
-10820	immense spoiled bowl of prescription candy	7	crappy	Last Available: "2021-12"
-10821	fancy flavorless gigantic fishcake	9	decent	Effect: "Thick-Skinned", Effect Duration: 20, Last Available: "2021-12"
+10820	spoiled immense bowl of prescription candy	7	crappy	Last Available: "2021-12"
+10821	flavorless fancy gigantic fishcake	9	decent	Effect: "Thick-Skinned", Effect Duration: 20, Last Available: "2021-12"
 10822	toothsome wobbly bone broth	3	awesome	Last Available: "2021-12"
-10823	stale miniature narrow blue star pop	2	decent	Last Available: "2021-12"
-10824	mediocre upside-down narrow Doc's Fortifying Wine	4	decent	Last Available: "2021-12"
+10823	miniature stale blue narrow star pop	2	decent	Last Available: "2021-12"
+10824	mediocre narrow upside-down Doc's Fortifying Wine	4	decent	Last Available: "2021-12"
 10825	bad Doc's Smartifying Wine	3	decent	Last Available: "2021-12"
-10826	watered-down bad lime green Doc's Limbering Wine	2	decent	Last Available: "2021-12"
-10827	high-proof tolerable wobbly Doc's Medical-Grade Wine	9	good	Last Available: "2021-12"
+10826	bad watered-down lime green Doc's Limbering Wine	2	decent	Last Available: "2021-12"
+10827	tolerable high-proof wobbly Doc's Medical-Grade Wine	9	good	Last Available: "2021-12"
 10828	mixed Homebodyl&trade;	1		Last Available: "2021-12"
 10829	diluted narrow Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	distilled olive Breathitin&trade;	1		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	healthy depleted Crimbonium football helmet	0		Maximum HP Percent: +20, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	rotten small &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
+10862	small rotten &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
 10863	scandalous self-repairing earmuffs	0		Sleaze Damage: +5, Last Available: "2021-12"
 10864	shaking carnivorous potted plant of terror	0		Spooky Spell Damage: +10, Last Available: "2021-12"
 10865	green universal biscuit	0		Last Available: "2021-12"
 10866	squat Van der Graaf yule hatchet	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	miniature stale lab-grown meat	2	decent	Last Available: "2021-12"
+10868	stale miniature lab-grown meat	2	decent	Last Available: "2021-12"
 10869	friendly fleece	0		Familiar Weight: +3, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10732,7 +10732,7 @@
 10876	flavorless wobbly meatball	3	decent	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	huge meatball machine	0		Last Available: "2021-12"
-10879	yellow pulsating blurry refurbished air fryer	0		Last Available: "2021-12"
+10879	blurry pulsating yellow refurbished air fryer	0		Last Available: "2021-12"
 10880	vaporized blinking twirling fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
@@ -10741,7 +10741,7 @@
 10885	smooth magnifying glass of the bloodbag of bravery	0		Moxie: +15, Maximum HP: +100, Spooky Resistance: +5, Last Available: "2022-12"
 10886	smooth void lager	4	awesome	Last Available: "2022-12"
 10887	bland gigantic pulsating void burger	7	decent	Last Available: "2022-12"
-10888	blurry twirling void stone	0		Last Available: "2022-12"
+10888	twirling blurry void stone	0		Last Available: "2022-12"
 10889	therapeutic ruddy void shard of the wise owl of the glutton	0		Mysticality: +20, Maximum HP Percent: +40, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	cosmic bowling ball	0		Last Available: "2022-01"
@@ -10751,10 +10751,10 @@
 10895	grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	jittery grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
-10898	mirror huge undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
+10898	huge mirror undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	blinking censurious nasty padded savvy unbreakable umbrella (broken)	0		Mysticality Percent: +20, Damage Absorption: +20, Stench Damage: +5, Sleaze Resistance: +3
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
-10901	wobbly mirror olive MayDay&trade; supply package	0		Last Available: "2022-05"
+10901	olive mirror wobbly MayDay&trade; supply package	0		Last Available: "2022-05"
 10902	triple-improved emergency glowstick	0		Effect: "Orchid Blood", Effect Duration: 63, Last Available: "2022-05"
 10903	upside-down lightning-fast survival knife	0		Initiative: +40, Lasts Until Rollover, Last Available: "2022-05"
 10904	jittery Samson's crank-powered radio on a lanyard	0		Experience (Muscle): +5, Lasts Until Rollover, Last Available: "2022-05"
@@ -10763,13 +10763,13 @@
 10907	cyan hardy atlas of local maps	0		Maximum HP: +50, Lasts Until Rollover, Last Available: "2022-05"
 10908	flattened narrow spare battery	0		Effect: "Make Meat FA$T!", Effect Duration: 23, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
-10910	alkaline squat olive pulsating single-use dust mask	0		Effect: "Hairy Palms", Effect Duration: 39, Last Available: "2022-05"
-10911	non-ionized olive upside-down gaffer's tape	0		Effect: "Colorful Gratitude", Effect Duration: 38, Last Available: "2022-05"
-10912	super-sized yummy 20-lb can of rice and beans	5	awesome	Last Available: "2022-05"
+10910	alkaline olive pulsating squat single-use dust mask	0		Effect: "Hairy Palms", Effect Duration: 39, Last Available: "2022-05"
+10911	non-ionized upside-down olive gaffer's tape	0		Effect: "Colorful Gratitude", Effect Duration: 38, Last Available: "2022-05"
+10912	yummy super-sized 20-lb can of rice and beans	5	awesome	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	decent expired MRE	3	good	Last Available: "2022-05"
-10915	super-sized decent special squat blurry cool mint precipice bar	5	good	Effect: "Red Misty-Eyed", Effect Duration: 50, Last Available: "2022-05"
-10916	half-sized flavorless carrot cake precipice bar	2	decent	Last Available: "2022-05"
+10915	special super-sized decent blurry squat cool mint precipice bar	5	good	Effect: "Red Misty-Eyed", Effect Duration: 50, Last Available: "2022-05"
+10916	flavorless half-sized carrot cake precipice bar	2	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	mirror Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	colloidal trampled ticket stub	0		Effect: "Lubed", Effect Duration: 25, Last Available: "2022-06"
 10927	cold-filtered unsweetened deionized mirror savings bond	0		Effect: "protect.enq", Effect Duration: 60, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	mixed sweat-ade	1		Effect: "Blubbered Up", Effect Duration: 30, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	skewed stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10809,7 +10809,7 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	dry quadruple-irradiated autumn leaf	0		Effect: "Twen Tea", Effect Duration: 49, Last Available: "2022-10"
-10956	artisanal bouncing wobbly AutumnFest ale	3	EPIC	Last Available: "2022-10"
+10956	artisanal wobbly bouncing AutumnFest ale	3	EPIC	Last Available: "2022-10"
 10957	nasty healthy cool autumn sweater-weather sweater	0		Moxie: +5, Maximum HP Percent: +20, Stench Damage: +5, Lasts Until Rollover, Last Available: "2022-10"
 10958	blinking smelly shellacked dance instructor's autumn debris shield of temperance	0		Experience Percent (Moxie): +10, Damage Reduction: 16, Stench Spell Damage: +10, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2022-10"
 10959	moldy autumn-spice donut	4	crappy	Last Available: "2022-10"
@@ -10825,34 +10825,34 @@
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	decent ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
 10971	flavorless Jarlsberg's vegetable soup	3	decent	Last Available: "2022-11"
-10972	small stale roasted vegetable of Jarlsberg	2	decent	Last Available: "2022-11"
+10972	stale small roasted vegetable of Jarlsberg	2	decent	Last Available: "2022-11"
 10973	flavorless St. Pete's sneaky smoothie	4	decent	Last Available: "2022-11"
-10974	normal small Pete's wiley whey bar	2	good	Last Available: "2022-11"
+10974	small normal Pete's wiley whey bar	2	good	Last Available: "2022-11"
 10975	flavorless Pete's rich ricotta	4	decent	Last Available: "2022-11"
 10976	smooth Boris's beer	3	awesome	Last Available: "2022-11"
 10977	flavorless small narrow honey bun of Boris	2	decent	Last Available: "2022-11"
 10978	stale Boris's bread	3	decent	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	lime green Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	squat Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	squat Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	narrow Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	lime green Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	squat Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	squat Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	narrow Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	normal bite-sized olive baked veggie ricotta casserole	1	good	Last Available: "2022-11"
 10989	adequate plain calzone	4	good	Last Available: "2022-11"
 10990	spoiled roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	decent Pizza of Legend	3	good	Last Available: "2022-11"
 10992	stale super-sized Calzone of Legend	5	decent	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	wobbly Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	jittery Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	wobbly Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	jittery Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	mirror blinking Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	blinking mirror Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	spoiled huge Deep Dish of Legend	9	crappy	Last Available: "2022-11"
 11001	pulsating deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
@@ -10867,11 +10867,11 @@
 11011	huge nippy gator shades of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +10, Single Equip
 11012	milk cap	0		
 11013	watered-down bad Charleston Choo-Choo	2	decent	
-11014	watered-down drinkable blue Velvet Veil	2	good	
-11015	practically non-alcoholic smooth Marltini	1	awesome	
+11014	drinkable watered-down blue Velvet Veil	2	good	
+11015	smooth practically non-alcoholic Marltini	1	awesome	
 11016	delicious bouncing Strong, Silent Type	3	awesome	
 11017	aged maroon Mysterious Stranger	4	awesome	
-11018	aged blinking olive Champagne Shimmy	4	awesome	
+11018	aged olive blinking Champagne Shimmy	4	awesome	
 11019	fuchsia the Sot's parcel	0		
 11020	purple ceramic cestus of incineration of the overflowing toilet	0		Hot Spell Damage: +50, Stench Spell Damage: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
 11021	blinking miser's Tesla rock-hard ceramic centurion shield	0		Damage Reduction: 14, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
@@ -10879,7 +10879,7 @@
 11023	tumbling greedy censurious scorching ceramic celsiturometer	0		Hot Damage: +25, Sleaze Resistance: +3, Meat Drop: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
 11024	ghostly huge crafty vibrating ceramic cerecloth belt of Flo-Jo	0		Maximum MP Percent: +10, Maximum MP: +10, Initiative: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
 11025	coward's ceramic cenobite's robe of the bloodbag of the businessman	0		Maximum HP: +100, Monster Level: -20, Meat Drop: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
-11026	diluted mirror gray ceramic scree	1		Last Available: "2023-12"
+11026	diluted gray mirror ceramic scree	1		Last Available: "2023-12"
 11027	magnetized olive extra-hard jawbreaker	0		Effect: "Cat Class, Cat Style", Effect Duration: 28
 11028	grievous chiffon chevrons of the pedagogue of the dark arts	0		Experience: +3, Weapon Damage Percent: +50, Spell Damage Percent: +100, Single Equip, Last Available: "2023-12"
 11029	asbestos-lined friendly chiffon chapeau of the empath	0		Familiar Weight: 8, Hot Resistance: +5, Last Available: "2023-12"
@@ -10887,11 +10887,11 @@
 11031	Usain Bolt's greasy dance instructor's chiffon chemise	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +10, Initiative: +80, Last Available: "2023-12"
 11032	lightning-fast cool chiffon chakram of the cougar	0		Moxie: 25, Initiative: +40, Last Available: "2023-12"
 11033	gray rock-hard chiffon chaps of the brute of Tarzan	0		Muscle Percent: +30, Experience (Muscle): +3, Damage Reduction: 5, Last Available: "2023-12"
-11034	denatured narrow blurry chiffon carbage	1		Effect: "Don't Step to Your Stepmother", Effect Duration: 15, Last Available: "2023-12"
+11034	denatured blurry narrow chiffon carbage	1		Effect: "Don't Step to Your Stepmother", Effect Duration: 15, Last Available: "2023-12"
 11035	non-liquefied chiffon lemon	0		Effect: "Old School Pompadour", Effect Duration: 53
 11036	bland chocomotive	3	decent	Last Available: "2022-12"
 11037	enchanted moldy freightcake	3	crappy	Effect: "Old School Pompadour", Effect Duration: 35, Last Available: "2022-12"
-11038	artisanal triple-distilled ghostly cabooze	10	EPIC	Last Available: "2022-12"
+11038	triple-distilled artisanal ghostly cabooze	10	EPIC	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	plastic passenger car of the blizzard	0		Cold Spell Damage: +25, Last Available: "2022-12"
 11041	avaricious plastic dining car	0		Meat Drop: +30, Last Available: "2022-12"
@@ -10904,7 +10904,7 @@
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
 11050	warmed narrow Trainbot circuitry	0		Effect: "Cock of the Walk", Effect Duration: 14
-11051	ionized non-irradiated cyan ghostly Trainbot tubing	0		Effect: "Very Clean Guns", Effect Duration: 67
+11051	ionized non-irradiated ghostly cyan Trainbot tubing	0		Effect: "Very Clean Guns", Effect Duration: 67
 11052	pressed chilled blue Trainbot plating	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 58
 11053	anodized super-liquefied triple-boiled jittery Trainbot optics	0		Effect: "Truly Gritty", Effect Duration: 48
 11054	anodized Trainbot servomotors	0		Effect: "PERL of Great Price", Effect Duration: 28
@@ -10931,7 +10931,7 @@
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	rotten enchanted mirror ghostly steamed oyster	3	crappy	Effect: "Sauce Monocle", Effect Duration: 30
+11078	rotten enchanted ghostly mirror steamed oyster	3	crappy	Effect: "Sauce Monocle", Effect Duration: 30
 11079	jittery really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	skewed steam unit	0		Last Available: "2022-12"
@@ -10950,7 +10950,7 @@
 11094	Usain Bolt's grubby wool trousers of the ox of temperance	0		Muscle: +20, Sleaze Resistance: +5, Initiative: +80
 11095	maroon coward's Van der Graaf grubby wool gloves of wisdom of the early riser	0		Mysticality: +15, Monster Level: -20, Adventures: +7, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	bad distilled purple nice warm beer	5	decent	
+11097	distilled bad purple nice warm beer	5	decent	
 11098	wobbly grubby woolball	0		
 11099	shaking Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10964,17 +10964,17 @@
 11108	red hard rock	0		Last Available: "2023-01"
 11109	shaking stalagmite	0		Last Available: "2023-01"
 11110	tumbling chocolate covered ping-pong ball	0		
-11112	adequate twirling purple pixel bread	3	good	
+11112	adequate purple twirling pixel bread	3	good	
 11113	practically non-alcoholic acceptable pixel whiskey	1	good	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
-11116	gray jittery S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
+11116	jittery gray S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	polarized glob of extra-green chlorophyll	0		Effect: "Inner Dog", Effect Duration: 61, Last Available: "2023-02"
 11118	alkaline double-altered mushroom	0		Effect: "Dexteri Tea", Effect Duration: 61, Last Available: "2023-02"
 11119	alkaline chilled adjusted five-fingered fern resin	0		Effect: "Uncucumbered", Effect Duration: 52, Last Available: "2023-02"
-11120	decent small super good fruit	2	good	Last Available: "2023-02"
+11120	small decent super good fruit	2	good	Last Available: "2023-02"
 11121	modified cyan energized spores	1		Last Available: "2023-02"
-11122	padded hot pepper of the overflowing toilet	0		Damage Absorption: +20, Stench Spell Damage: +50, Lantern Element: "Hot", Last Available: "2023-02"
+11122	padded hot pepper of the overflowing toilet	0		Damage Absorption: +20, Stench Spell Damage: +50, Last Available: "2023-02", Lantern Element: "Hot"
 11123	frozen out-of-work circus flea	0		Effect: "Cock of the Walk", Effect Duration: 36, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	quantum narrow fuchsia fire ant pheromones	0		Effect: "Mad at Science", Effect Duration: 30, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	bouncing hollow rock	0		Last Available: "2023-02"
 11133	modified pickled angry agate	0		Effect: "Ack!  Barred!", Effect Duration: 30, Last Available: "2023-02"
 11134	quadruple-activated lump of loyal latite	0		Effect: "Tiki Toughness", Effect Duration: 56, Last Available: "2023-02"
-11135	adequate bite-sized tumbling blinking shadow sausage	1	good	Last Available: "2023-03"
+11135	bite-sized adequate blinking tumbling shadow sausage	1	good	Last Available: "2023-03"
 11136	Sherlock's shadow skin of terror	0		Spooky Spell Damage: +10, Item Drop: +25, Last Available: "2023-03"
 11137	cold-filtered chilled polarized spinning shadow flame	0		Effect: "Bootyliciousness", Effect Duration: 45, Last Available: "2023-03"
 11138	moldy half-sized ghostly shadow bread	2	crappy	Last Available: "2023-03"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	hand-crafted special twirling shadow venom	3	EPIC	Effect: "Intimidating Mien", Effect Duration: 10, Last Available: "2023-03"
+11144	special hand-crafted twirling shadow venom	3	EPIC	Effect: "Intimidating Mien", Effect Duration: 10, Last Available: "2023-03"
 11145	powdered wobbly shadow nectar	1		Last Available: "2023-03"
 11146	Van der Graaf studded Rosewater's shadow stick	0		Mysticality Percent: +30, Damage Absorption: +80, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-03"
 11147	avaricious clever bat paw	0		Maximum MP: +20, Meat Drop: +30
@@ -11035,13 +11035,13 @@
 11180	red rock-hard dangerous Sinatra's shadow monocle	0		Experience (Moxie): +5, Weapon Damage: +10, Damage Reduction: 5, Single Equip
 11181	wobbly shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	adequate shadow hot dog	4	good	
-11183	weak enchanted drinkable shadow martini	2	good	Effect: "Twenty-three Squid, Ew", Effect Duration: 30
+11183	enchanted drinkable weak shadow martini	2	good	Effect: "Twenty-three Squid, Ew", Effect Duration: 30
 11184	boiled shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	quadruple-nitrogenated magnetized lime green shadow candy	0		Effect: "damage.enh", Effect Duration: 30
-11189	mirror green spinning replica Mr. Accessory	0		
+11189	green mirror spinning replica Mr. Accessory	0		
 11190	bouncing replica Dark Jill-O-Lantern	0		
 11191	purple replica hand turkey outline	0		
 11192	olive replica crimbo elfling	0		
@@ -11074,7 +11074,7 @@
 11219	replica Smith's Tome	0		
 11220	wobbly replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
-11222	upside-down blurry shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
+11222	blurry upside-down shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	therapeutic boxer's weightlifter's Cincho de Mayo of the cougar	0		Muscle: +15, Moxie: +20, Muscle Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	blurry dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	shaking replica Little Geneticist DNA-Splicing Lab	0		
@@ -11117,7 +11117,7 @@
 11262	olive Meat Butler	0		Last Available: "2023-06"
 11263	jittery Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	shaking mirror yellow twirling Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11265	mirror shaking twirling yellow Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	blinking Flash Liquidizer Ultra Dousing Accessory of Gandalf	0		Spell Critical Percent: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	Newton's smartaleck's Rosewater's Amulet of Perpetual Darkness of Tarzan	0		Mysticality Percent: +30, Moxie Percent: +30, Experience (Muscle): +3, Experience (Mysticality): +3, Last Available: "2023-06"
 11268	olive Giant monolith	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	hand-crafted twirling Sexy Cosmo	3	EPIC	Last Available: "2023-06"
 11283	huge Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	padded dangerous red-soled high heels of the early riser	0		Weapon Damage: +10, Damage Absorption: +20, Adventures: +7, Last Available: "2023-06"
-11285	rotten massive tumbling pulsating cyburger	8	crappy	Last Available: "2025-12"
+11285	massive rotten tumbling pulsating cyburger	8	crappy	Last Available: "2025-12"
 11286	jittery frightening ncle leg	0		Spooky Damage: +5
 11287	tumbling up-at-dawn studded rutabuga bag	0		Damage Absorption: +80, Adventures: +5
 11288	dangerous mesquito proboscis	0		Weapon Damage: +10
@@ -11168,7 +11168,7 @@
 11313	cat o' nine teeth of the storm	0		Maximum MP Percent: +40, Item Drop: +5
 11314	Oprah's experienced tooth cap	0		Experience: +2, Maximum MP Percent: +50
 11315	Annie Oakley's toothy trousers of incineration	0		Critical Hit Percent: +20, Hot Spell Damage: +50
-11316	fancy bland banana split	3	decent	Effect: "Hiding in Plain Sight", Effect Duration: 45
+11316	bland fancy banana split	3	decent	Effect: "Hiding in Plain Sight", Effect Duration: 45
 11317	tumbling handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
@@ -11183,7 +11183,7 @@
 11328	dehydrated mirror concentrated cooking	1		Effect: "Pyramid Power", Effect Duration: 45
 11329	twisted cyan meat	1		
 11330	dehydrated purple sparkling orb	1		Effect: "Filled with Magic", Effect Duration: 35
-11331	dried maroon blinking hardening cream	1		
+11331	dried blinking maroon hardening cream	1		
 11332	dried squat pool shark hair oil	1		Effect: "Electrolit Up", Effect Duration: 5
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11240,7 +11240,7 @@
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
-11388	huge bouncing pirate encryption key charlie	0		Last Available: "2023-12"
+11388	bouncing huge pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
 11390	wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
@@ -11253,7 +11253,7 @@
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	bouncing Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	mirror Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	bad practically non-alcoholic Crimbuccaneer mologrog cocktail	1	decent	Last Available: "2023-12"
+11401	practically non-alcoholic bad Crimbuccaneer mologrog cocktail	1	decent	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	rosewater-soaked Jack Frost's sinister Crimbuccaneer lantern	0		Spell Damage: +10, Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2023-12"
@@ -11282,7 +11282,7 @@
 11427	stale shaking sundae ration	4	decent	Last Available: "2023-12"
 11428	yummy low-calorie peppermint tack	1	awesome	Last Available: "2023-12"
 11429	spinning Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	flavorless snack-sized whalesteak	2	decent	Last Available: "2023-12"
+11430	snack-sized flavorless whalesteak	2	decent	Last Available: "2023-12"
 11431	healthy banded whalegun of Gandalf	0		Damage Absorption: +100, Maximum HP Percent: +20, Spell Critical Percent: +20, Last Available: "2023-12"
 11432	fuchsia pulsating Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	purple Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11295,7 +11295,7 @@
 11440	prompt brawny Kelflar vest of Flo-Jo	0		Muscle Percent: +20, Initiative: +100, Adventures: +3, Last Available: "2023-12"
 11441	polarized whale cerebrospinal fluid	0		Effect: "Weather, Man", Effect Duration: 17, Last Available: "2023-12"
 11442	vibrating beefy Crimbuccaneer runebone	0		Muscle: +10, Maximum MP Percent: +10, Single Equip, Last Available: "2023-12"
-11443	blue tumbling cannonbomb	0		Last Available: "2023-12"
+11443	tumbling blue cannonbomb	0		Last Available: "2023-12"
 11444	ghostly wool lard-coated Elf Guard mouthknife	0		Sleaze Spell Damage: +25, Cold Resistance: +1, Last Available: "2023-12"
 11445	frosty personal trainer's Crimbuccaneer fledges (disintegrating)	0		Experience Percent (Muscle): +10, Cold Spell Damage: +10, Single Equip, Last Available: "2023-12"
 11446	Elf Guard fuel tank of bravery	0		Spooky Resistance: +5, Last Available: "2023-12"
@@ -11312,12 +11312,12 @@
 11457	yellow chilly studded Elvish underarmor of the pedagogue	0		Experience: +3, Damage Absorption: +80, Cold Damage: +5, Single Equip, Last Available: "2023-12"
 11458	spinning jittery narrow slick Crimbuccaneer bombjacket of vim and vigor	0		Moxie: +10, Maximum HP Percent: +50, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	stale twirling sugarplum ration	4	decent	Last Available: "2023-12"
-11460	big stale gingerbread nylons	5	decent	Last Available: "2023-12"
+11460	stale big gingerbread nylons	5	decent	Last Available: "2023-12"
 11461	spoiled blinking rum-soaked fruitcake	3	crappy	Last Available: "2023-12"
 11462	adequate huge lime	6	good	Last Available: "2023-12"
 11463	moldy blinking gingerbread pirate	3	crappy	Last Available: "2023-12"
 11464	rotten fruit-stuffed rumcake	4	crappy	Last Available: "2023-12"
-11465	perfectly mixed watered-down mulled wine	2	EPIC	Last Available: "2023-12"
+11465	watered-down perfectly mixed mulled wine	2	EPIC	Last Available: "2023-12"
 11466	hand-crafted Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	artisanal canteen of eggnog	3	super EPIC	Last Available: "2023-12"
 11468	bad weak spinning hot wine	2	decent	Last Available: "2023-12"
@@ -11330,7 +11330,7 @@
 11475	spoiled wet tack	3	crappy	Last Available: "2023-12"
 11476	normal whalecake	3	good	Last Available: "2023-12"
 11477	gravedigger's Tesla ruddy gunwale whalegun	0		Maximum HP Percent: +40, Spooky Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	perfectly mixed practically non-alcoholic and claret	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11478	practically non-alcoholic perfectly mixed and claret	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	pulsating trick coin	0		Last Available: "2023-12"
 11481	wobbly ghostly squat boxer's Elf Guard squirtgun of the bloodbag	0		Muscle Percent: +10, Maximum HP: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
@@ -11382,13 +11382,13 @@
 11527	denatured extra-aerosolized crepe paper peanut candy	0		Effect: "Stogied", Effect Duration: 35
 11528	wobbly avaricious beefcake's petrified wood war pike	0		Muscle: +25, Meat Drop: +30, Last Available: "2025-12"
 11529	wobbly greedy extremely unsafe petrified wood waist protector	0		Weapon Damage Percent: +100, Meat Drop: +20, Single Equip, Last Available: "2025-12"
-11530	pulsating greasy Annie Oakley's petrified wood wizard's pouch	0		Critical Hit Percent: +20, Sleaze Spell Damage: +10, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	curative padded petrified wood water purifier	0		Damage Absorption: +20, HP Regen Min: 3, HP Regen Max: 5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	pulsating greasy Annie Oakley's petrified wood wizard's pouch	0		Critical Hit Percent: +20, Sleaze Spell Damage: +10, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	curative padded petrified wood water purifier	0		Damage Absorption: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	brawny petrified wood whoopie panama of the early riser	0		Muscle Percent: +20, Adventures: +7, Last Available: "2025-12"
 11533	yellow blinking rosy-cheeked beefcake's petrified wood walking pants	0		Muscle: +25, Maximum HP Percent: +30, Last Available: "2025-12"
 11534	twisted petrified wood waste parts	1		Effect: "Disco State of Mind", Effect Duration: 15, Last Available: "2025-12"
 11535	adjusted pulsating petrified wood wafer praline	0		Effect: "The Magic of Sharing", Effect Duration: 18
-11536	watered-down artisanal blinking cybeer	2	super EPIC	Last Available: "2025-12"
+11536	artisanal watered-down blinking cybeer	2	super EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	skewed wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
 11539	huge encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
@@ -11427,8 +11427,8 @@
 11572	blurry blinking Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	decent yam	3	good	Last Available: "2024-05"
 11574	hand-crafted distilled yam martini	5	EPIC	Last Available: "2024-05"
-11575	high-proof bad blinking sweet potato o' mine	8	decent	Last Available: "2024-05"
-11576	weak mediocre Southern yam	2	decent	Last Available: "2024-05"
+11575	bad high-proof blinking sweet potato o' mine	8	decent	Last Available: "2024-05"
+11576	mediocre weak Southern yam	2	decent	Last Available: "2024-05"
 11577	drinkable sweet potato punch	3	good	Last Available: "2024-05"
 11578	huge flavorless purple Mayam spinach	10	decent	Last Available: "2024-05"
 11579	immense toothsome purple yam and swiss	6	awesome	Last Available: "2024-05"
@@ -11441,7 +11441,7 @@
 11586	tumbling up-at-dawn lion tamer's therapeutic yamtility belt	0		Experience (familiar): +2, Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-05"
 11587	small tasty pulsating yam slider	2	awesome	Last Available: "2024-05"
 11588	spoiled yam mayo	4	crappy	Last Available: "2024-05"
-11589	miniature moldy yam burrito	2	crappy	Last Available: "2024-05"
+11589	moldy miniature yam burrito	2	crappy	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	squat aviator goggles	0		
@@ -11453,8 +11453,8 @@
 11598	mini kiwi aioli	0		
 11599	spinning friendly sinister mini kiwi silicon tiepin of the cougar	0		Moxie: +20, Spell Damage: +10, Familiar Weight: +3
 11600	mini kiwi tipi	0		
-11601	fancy spoiled half-sized mini kiwi digitized cookies	2	crappy	Effect: "Gummiskin", Effect Duration: 5
-11602	extra-dry tolerable mini kiwi intoxicating spirits	5	good	
+11601	spoiled half-sized fancy mini kiwi digitized cookies	2	crappy	Effect: "Gummiskin", Effect Duration: 5
+11602	tolerable extra-dry mini kiwi intoxicating spirits	5	good	
 11603	activated ionized mini kiwi antimilitaristic hippy petition	0		Effect: "Icy Composition", Effect Duration: 14
 11604	improved warmed enhanced pulsating mini kiwi illicit antibiotic	0		Effect: "Hairy Palms", Effect Duration: 33
 11605	vibrating banded mini kiwi whipping stick	0		Damage Absorption: +100, Maximum MP Percent: +10
@@ -11471,7 +11471,7 @@
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	normal super-sized narrow bacteria bisque	5	good	
-11619	small special moldy ciliophora chowder	2	crappy	Effect: "Electrolit Up", Effect Duration: 40
+11619	moldy small special ciliophora chowder	2	crappy	Effect: "Electrolit Up", Effect Duration: 40
 11620	normal red cream of chloroplasts	3	good	
 11621	synaptic soup	0		
 11622	bouncing muscular soup	0		
@@ -11506,7 +11506,7 @@
 11651	flame-retardant hat of remembering of the scaredy-cat of horror	0		Monster Level: -15, Spooky Spell Damage: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	spinning head of emberg lettuce	0		Last Available: "2024-09"
-11654	ghostly yellow pulsating embering hunk	0		Last Available: "2024-09"
+11654	ghostly pulsating yellow embering hunk	0		Last Available: "2024-09"
 11655	pulsating soft cap of diminishing returns	0		
 11656	yellow photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
@@ -11526,7 +11526,7 @@
 11671	blurry dog trainer's photo booth supply list of doom	0		Experience (familiar): +1, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	blinking tie-dye headband	0		
-11674	bland small whirled peas	2	decent	Last Available: "2024-11"
+11674	small bland whirled peas	2	decent	Last Available: "2024-11"
 11675	moldy peaza	3	crappy	Last Available: "2024-11"
 11676	ghostly peace shooter	0		Last Available: "2024-11"
 11677	altered purple drenchrome 2.0	1		Last Available: "2025-12"
@@ -11536,7 +11536,7 @@
 11681	quantized familiar experience	0		
 11682	quantum Vulcanized yellow bouncing pea brittle	0		Effect: "Al Dente Inferno", Effect Duration: 22, Last Available: "2024-11"
 11683	weak artisanal peasco	2	EPIC	Last Available: "2024-11"
-11684	delicious enchanted skewed piece of cake	3	awesome	Effect: "Tremella Tremens", Effect Duration: 20, Last Available: "2024-11"
+11684	enchanted delicious skewed piece of cake	3	awesome	Effect: "Tremella Tremens", Effect Duration: 20, Last Available: "2024-11"
 11685	mirror handful of split pea soup	0		Last Available: "2024-11"
 11686	teal Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	tumbling profane eye patch	0		Sleaze Damage: +3
 11709	moist anodized modified spinning cyan peppermint pegleg	0		Effect: "Mmmmmelon", Effect Duration: 53, Last Available: "2024-12"
 11710	mediocre hard cocoa	4	decent	Last Available: "2024-12"
-11711	big rotten bouncing maroon salmagumdi	5	crappy	Last Available: "2024-12"
+11711	rotten big maroon bouncing salmagumdi	5	crappy	Last Available: "2024-12"
 11712	frightening plastic Easter Island Bunny	0		Spooky Damage: +5, Last Available: "2024-12"
 11713	bouncing greedy plastic St. Patrick	0		Meat Drop: +20, Last Available: "2024-12"
 11714	manspreader's experienced plastic Colonel Brando	0		Experience: +2, Monster Level: +10, Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	upside-down supercharged gravyskin skirt of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25, Last Available: "2024-12"
 11737	toasty shellacked gravyskin pants	0		Damage Reduction: 7, Hot Damage: +5, Last Available: "2024-12"
 11738	pickled warmed spinning crystallized pumpkin spice	0		Effect: "Cravin' for a Ravin'", Effect Duration: 48, Last Available: "2024-12"
-11739	delicious big room scale bean casserole	5	awesome	Last Available: "2024-12"
+11739	big delicious room scale bean casserole	5	awesome	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	Van der Graaf strapping perfect Christmas scarf of the detective	0		Muscle: [+5*event(December)], Item Drop: [+20*event(December)], MP Regen Min: [5*event(December)], MP Regen Max: [7*event(December)], Single Equip, Last Available: "2024-12"
@@ -11606,10 +11606,10 @@
 11751	perfectly mixed wobbly mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
 11752	fancy hand-crafted holiday trip around the world	3	super ultra EPIC	Effect: "Egg on your Face", Effect Duration: 50, Last Available: "2024-12"
 11753	jumbo bland chocolate ostrich egg	5	decent	Last Available: "2024-12"
-11754	spoiled skewed twirling beef and cabbage	4	crappy	Last Available: "2024-12"
-11755	massive toothsome candy rations	6	awesome	Last Available: "2024-12"
+11754	spoiled twirling skewed beef and cabbage	4	crappy	Last Available: "2024-12"
+11755	toothsome massive candy rations	6	awesome	Last Available: "2024-12"
 11756	toothsome wobbly double-candied yams	3	awesome	Last Available: "2024-12"
-11757	decent fancy Christmas ham	3	good	Effect: "Grape Expectations", Effect Duration: 45, Last Available: "2024-12"
+11757	fancy decent Christmas ham	3	good	Effect: "Grape Expectations", Effect Duration: 45, Last Available: "2024-12"
 11758	delicious holiday smorgasbord	3	awesome	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	gray Usain Bolt's bejazzled eyepatch	0		Initiative: +80, Last Available: "2024-12"
@@ -11643,7 +11643,7 @@
 11788	1	0		Last Available: "2025-12"
 11789	gray 0	0		Last Available: "2025-12"
 11790	vaporized twirling twirling eXpand	1		Effect: "Berry Experiential", Effect Duration: 10, Last Available: "2025-12"
-11791	blinking bouncing brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	bouncing blinking brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	cyan dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11653,7 +11653,7 @@
 11798	dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
-11801	yellow pulsating dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
+11801	pulsating yellow dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	cybervisor	0		Last Available: "2025-12"
 11804	jittery purple retro floppy disk	0		Last Available: "2025-12"
@@ -11662,7 +11662,7 @@
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
-11810	olive mirror dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
+11810	mirror olive dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	skewed logic grenade	0		Last Available: "2025-12"
 11812	dried psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
@@ -11686,9 +11686,9 @@
 11831	skewed ninja crampons	0		
 11832	blurry ninja carabiner	0		
 11833	non-modified colloidal synthetic coffee	0		Effect: "Hennaliciousness", Effect Duration: 35
-11834	magnetized aerosolized jittery wobbly fuchsia iDrops	0		Effect: "Intimidating Mien", Effect Duration: 59
-11835	lime green shaking shame coil	0		
-11836	teal blurry new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
+11834	magnetized aerosolized wobbly jittery fuchsia iDrops	0		Effect: "Intimidating Mien", Effect Duration: 59
+11835	shaking lime green shame coil	0		
+11836	blurry teal new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
 11839	scrape	0		
@@ -11716,24 +11716,24 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	mixed scoop of pre-workout powder	1		Effect: "Arse-a'fire", Effect Duration: 30, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	perfectly mixed watered-down skewed pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
+11864	watered-down perfectly mixed skewed pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
 11865	diluted phosphor traces	1		Effect: "Sewer-Drenched", Effect Duration: 40, Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
-11868	tumbling yellow spoon	0		
+11868	yellow tumbling spoon	0		
 11869	narrow unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	pickled shaking leprechaun antidepressant pill	1		Effect: "critical.enh", Effect Duration: 30, Last Available: "2025-03"
-11872	enchanted adequate small tumbling Heck ramen	2	good	Effect: "Always In Motion", Effect Duration: 20, Last Available: "2025-03"
-11873	half-sized flavorless bouncing burrito	2	decent	Last Available: "2025-03"
+11872	adequate enchanted small tumbling Heck ramen	2	good	Effect: "Always In Motion", Effect Duration: 20, Last Available: "2025-03"
+11873	flavorless half-sized bouncing burrito	2	decent	Last Available: "2025-03"
 11874	stale huge small beer brat	8	decent	Last Available: "2025-03"
-11875	normal small peach pie	2	good	Last Available: "2025-03"
-11876	bite-sized normal incredible mini-pizza	1	good	Last Available: "2025-03"
+11875	small normal peach pie	2	good	Last Available: "2025-03"
+11876	normal bite-sized incredible mini-pizza	1	good	Last Available: "2025-03"
 11877	tolerable enchanted Divine sidecar	4	good	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2025-03"
 11878	tolerable tangarita sidecar	4	good	Last Available: "2025-03"
 11879	hand-crafted gimlet sidecar	4	EPIC	Last Available: "2025-03"
-11880	practically non-alcoholic acceptable teal huge vodka stratocaster sidecar	1	good	Last Available: "2025-03"
-11881	enchanted practically non-alcoholic tolerable prussian cathouse sidecar	1	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5, Last Available: "2025-03"
+11880	practically non-alcoholic acceptable huge teal vodka stratocaster sidecar	1	good	Last Available: "2025-03"
+11881	enchanted tolerable practically non-alcoholic prussian cathouse sidecar	1	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5, Last Available: "2025-03"
 11882	hand-crafted Mon Tiki sidecar	3	EPIC	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	shaking Jeselnik's April Shower Thoughts shield of the businessman	0		Sleaze Damage: +25, Meat Drop: +50, Damage Reduction: 6, Last Available: "2025-04"
@@ -11769,8 +11769,8 @@
 11914	squat sage imposing pilgrim's hat	0		Mysticality Percent: +10
 11915	maroon crown of thorns	0		
 11916	teal shaking stylish bycocket of vim and vigor	0		Maximum HP Percent: +50
-11917	pulsating tumbling Thwaitgold mad hatterpillar statuette	0		
-11918	twirling teal packaged prismatic beret	0		Free Pull
+11917	tumbling pulsating Thwaitgold mad hatterpillar statuette	0		
+11918	teal twirling packaged prismatic beret	0		Free Pull
 11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	gray flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
@@ -11788,9 +11788,9 @@
 11933	shaking baleful beefy Allied Radio Backpack of mayonnaise	0		Muscle: +10, Spell Damage: +25, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
 11935	spinning ordnance magnet	0		Single Equip
-11936	spinning squat confetti grenade	0		
+11936	squat spinning confetti grenade	0		
 11937	yummy huge Skeleton Wars rations	10	awesome	
-11938	acceptable high-proof ghostly skeleton war fuel can	9	good	
+11938	high-proof acceptable ghostly skeleton war fuel can	9	good	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	huge M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11805,18 +11805,18 @@
 11950	nasty time cop top hat	0		Stench Damage: +5, Last Available: "2025-08"
 11951	twirling Stock Certificate	0		Last Available: "2025-08"
 11952	dried mixed berry jelly	1		Last Available: "2025-08"
-11953	normal small toast with mixed berry jelly	2	good	Last Available: "2025-08"
-11954	bland special squat olive mirror cup of sugar	4	decent	Effect: "Fancy Feasted", Effect Duration: 50, Last Available: "2025-08"
+11953	small normal toast with mixed berry jelly	2	good	Last Available: "2025-08"
+11954	bland special olive mirror squat cup of sugar	4	decent	Effect: "Fancy Feasted", Effect Duration: 50, Last Available: "2025-08"
 11955	bland snack-sized Susie's cupcake	2	decent	Last Available: "2025-08"
 11956	ghostly clock	0		Last Available: "2025-08"
 11957	MacGyver's medical-grade the gun	0		Maximum MP: +100, Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-08"
-11958	spirit-forward drinkable wine	5	good	Last Available: "2025-08"
+11958	drinkable spirit-forward wine	5	good	Last Available: "2025-08"
 11960	gray really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	narrow blurry scandalous undersea surveying goggles	0		Sleaze Damage: +5, Lasts Until Rollover
-11963	acceptable watered-down Ocean-Touched Rum	2	good	
+11963	watered-down acceptable Ocean-Touched Rum	2	good	
 11964	compressed water-logged pill	1		Effect: "Very Clean Guns", Effect Duration: 30
-11965	bland gigantic kelp puck	9	decent	
+11965	gigantic bland kelp puck	9	decent	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	upside-down blinking scroll of sea smarm	0		
@@ -11833,13 +11833,13 @@
 11987	miser's stanky Annie Oakley's MacGyver's deadly blood cubic zirconia of the empath	0		Weapon Damage: +5, Maximum MP: +100, Critical Hit Percent: +20, Familiar Weight: +5, Stench Spell Damage: +25, Meat Drop: +10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	diluted blood thinner	1		Last Available: "2025-10"
 12045	drinkable pheromone cocktail	3	good	Last Available: "2025-10"
-12046	diet stale spinal tapas	1	decent	Last Available: "2025-10"
+12046	stale diet spinal tapas	1	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	arcane researcher's brawny shrunken head of the cougar	0		Moxie: +20, Muscle Percent: +20, Experience Percent (Mysticality): +10, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	upside-down stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	blurry small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	fortified smooth Smoking Pope	5	awesome	
+12052	smooth fortified Smoking Pope	5	awesome	
 12053	immense bland prize turkey	7	decent	
 12054	compressed wobbly medicinal gruel	1		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 5
 12055	stale full-sized pumpkin pie	3	decent	Last Available: "2025-11"
@@ -11880,12 +11880,12 @@
 12122	aromatic extra-thick Crimbo sweater	0		Stench Resistance: +1, Last Available: "2025-12"
 12123	jittery The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	tolerable practically non-alcoholic twirling Steve Abrams' Holiday Sampler Beer	1	good	Last Available: "2025-12"
-12125	blinking skewed crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
+12125	skewed blinking crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	acceptable weak bottle of prize-winning rum	2	good	Last Available: "2025-12"
 12127	Usain Bolt's inspector's medical-grade Santa-Slayer medal	0		Item Drop: +15, Initiative: +80, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	quadruple-altered quadruple-deionized boiling bone marrow	0		Effect: "Industrial Strength Starch", Effect Duration: 60, Last Available: "2025-12"
-12130	wet lime green bouncing boiling cerebrospinal fluid	0		Effect: "Turtle Power", Effect Duration: 13, Last Available: "2025-12"
+12130	wet bouncing lime green boiling cerebrospinal fluid	0		Effect: "Turtle Power", Effect Duration: 13, Last Available: "2025-12"
 12131	irradiated narrow blinking boiling synovial fluid	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 16, Last Available: "2025-12"
 12132	Socratic thinker's smoldering vertebra of bravery	0		Mysticality: +10, Experience (Mysticality): +1, Spooky Resistance: +5, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
@@ -11898,7 +11898,7 @@
 12140	skewed healthy scorched skull trophy	0		Maximum HP Percent: +20, Last Available: "2025-12"
 12141	normal wing bone	4	good	Last Available: "2025-12"
 12142	delicious spinning blurry weak skeleton venom	4	awesome	Last Available: "2025-12"
-12143	dried wobbly huge shaking baked bone meal	1		Last Available: "2025-12"
+12143	dried shaking huge wobbly baked bone meal	1		Last Available: "2025-12"
 12144	red plastic skeleton rib cage of bravery	0		Spooky Resistance: +5, Last Available: "2025-12"
 12145	supercool plastic skeleton skull	0		Moxie Percent: +20, Last Available: "2025-12"
 12146	Jim Carey's plastic skeleton Crimbo hat	0		Monster Level: +25, Last Available: "2025-12"
@@ -11914,7 +11914,7 @@
 12156	pulsating Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	pulsating Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
-12159	upside-down green Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
+12159	green upside-down Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	shaking Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	blurry Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	mirror Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
@@ -11932,7 +11932,7 @@
 12174	bad &quot;salvaged&quot; wine	3	decent	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	toothsome miniature blurry wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
+12177	miniature toothsome blurry wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
 12178	tarnished ionized gummi fingerbone	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 18
 12179	stanky medical-grade glimmering crystal	0		Stench Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11964,16 +11964,16 @@
 12206	mirror Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	maroon Pork Elf sink	0		Last Available: "2026-03"
 12208	tumbling bouncing Pork Elf toilet	0		Last Available: "2026-03"
-12209	delicious half-sized rat pizza	2	awesome	Last Available: "2026-03"
+12209	half-sized delicious rat pizza	2	awesome	Last Available: "2026-03"
 12210	mirror Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	huge purple steel-toed rock-hard wizardly hoverboard	0		Mysticality: +25, Damage Reduction: 28, Single Equip, Last Available: "2026-03"
 12212	Jack Frost's curative Herculean left shark fin	0		Experience (Muscle): +1, Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2026-03"
 12213	cool fitness tracking bracelet	0		Moxie: +5, Single Equip, Last Available: "2026-03"
-12214	distilled twirling green candy bone	1		
-12215	gray wobbly blurry wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
+12214	distilled green twirling candy bone	1		
+12215	wobbly gray blurry wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	bland discarded hot dog	4	decent	Last Available: "2026-04"
-12218	fortified artisanal blinking blinking narrow most of a beer	5	EPIC	Last Available: "2026-04"
+12218	artisanal fortified blinking narrow blinking most of a beer	5	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
@@ -11983,10 +11983,10 @@
 12229	spoiled onigiri	3	crappy	
 12230	flavorless low-calorie crudit&eacute;s	1	decent	
 12231	flavorless sauced mutton	4	decent	
-12232	moldy enchanted half-sized blue bouncing hot honey ant	2	crappy	Effect: "Old Time Hydration", Effect Duration: 50
+12232	enchanted half-sized moldy blue bouncing hot honey ant	2	crappy	Effect: "Old Time Hydration", Effect Duration: 50
 12233	half-sized adequate wobbly tomb aspic	2	good	
 12234	decent later tots	3	good	
-12235	gigantic spoiled Frutti di Scatoletta	7	crappy	Last Available: "2026-05"
+12235	spoiled gigantic Frutti di Scatoletta	7	crappy	Last Available: "2026-05"
 12236	enchanted miniature moldy Pesto alla Marziano	2	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2026-05"
 12237	adequate jittery Arrattabbattabiata	3	good	Last Available: "2026-05"
 12238	jumbo moldy Orzo di Riso	5	crappy	Last Available: "2026-05"
@@ -12011,7 +12011,7 @@
 12261	wobbly flash paperwad	0		
 12262	juggling ball	0		
 12263	executive tactical jester's cap of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +40, Combat Item Damage Percent: 50
-12264	jittery cyan single-use sword	0		
+12264	cyan jittery single-use sword	0		
 12265	shaking flimsy plastic helmet of the businessman	0		Meat Drop: +50
 12266	flimsy plastic greaves of the early riser	0		Adventures: +7
 12267	pulsating Van der Graaf flimsy plastic breastplate	0		MP Regen Min: 5, MP Regen Max: 7
@@ -12039,12 +12039,12 @@
 12289	oxidized enhanced corrupted Quickquince	0		Effect: "In the Slimelight", Effect Duration: 40, Last Available: "2026-07"
 12290	delicious blinking Quiskey Sour	4	awesome	Last Available: "2026-07"
 12291	perfectly mixed twirling squat Quincea&ntilde;era Cooler	3	EPIC	Last Available: "2026-07"
-12292	watered-down drinkable Roth IPA	2	good	Last Available: "2026-08"
+12292	drinkable watered-down Roth IPA	2	good	Last Available: "2026-08"
 12293	educational underdraft protection of the ox	0		Muscle: +20, Experience: +1, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	stale snack-sized soybean futures	2	decent	Last Available: "2026-08"
+12295	snack-sized stale soybean futures	2	decent	Last Available: "2026-08"
 12296	non-polymerized diffused housing bubble	0		Effect: "You Read The Manual", Effect Duration: 67, Last Available: "2026-08"
-12297	modified warmed ionized cyan wobbly Pixie-Swordz	0		Effect: "You Know What's Up", Effect Duration: 44
+12297	modified warmed ionized wobbly cyan Pixie-Swordz	0		Effect: "You Know What's Up", Effect Duration: 44
 12298	nippy Temple Grandin's financial instrument	0		Familiar Weight: +7, Cold Damage: +10, Last Available: "2026-08"
 12299	flame-retardant hedge fund clippers of the wise owl	0		Mysticality: +20, Hot Resistance: +1, Last Available: "2026-08"
 12300	extremely unsafe selling shorts	0		Weapon Damage Percent: +100, Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	narrow savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	dehydrated tumbling tumbling fuchsia toxic asset	1		Last Available: "2026-08"
-12311	pickled narrow huge intangible asset	1		Effect: "Banono", Effect Duration: 25, Last Available: "2026-08"
+12311	pickled huge narrow intangible asset	1		Effect: "Banono", Effect Duration: 25, Last Available: "2026-08"
 12312	dehydrated blurry liquid asset	1		Last Available: "2026-08"
 12313	teal gross prophet chrysalis	0		Last Available: "2026-08"
 12314	wobbly cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Accordion_Thief_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wallaby_cafe_booze.txt
@@ -1,11 +1,11 @@
--1	weak lousy jittery Petite Porter	2	decent	
+-1	lousy weak jittery Petite Porter	2	decent	
 -2	delicious watered-down Scrawny Stout	2	awesome	
 -3	drinkable strong Infinitesimal IPA	5	good	
 -4	tolerable irresponsibly strong cyan eggnogtini	9	good	
 -5	artisanal candycaine	4	EPIC	
 -6	acceptable maroon braincracker sweet	4	good	
 -16	acceptable fermented honey	3	good	
--17	triple-distilled bad moons-shine	8	decent	
+-17	bad triple-distilled moons-shine	8	decent	
 -18	perfectly mixed gin	4	EPIC	
 -19	extra-dry acceptable ecto-nog	5	good	
 -20	artisanal bouncing hot toady	4	EPIC	
@@ -18,14 +18,14 @@
 -60	high-proof artisanal Mutagin 'n' Tonic	10	EPIC	
 -70	special mediocre watered-down Gin and Herring	2	decent	
 -71	smooth watered-down Black and Tan and Red All Over	2	awesome	
--72	practically non-alcoholic perfectly mixed olive Antarctic Ice Tea	1	EPIC	
+-72	perfectly mixed practically non-alcoholic olive Antarctic Ice Tea	1	EPIC	
 -76	artisanal ghostly CRIMBCO Ribbon Candy Schnapps	4	EPIC	
 -77	perfectly mixed tumbling CRIMBCO Egg Substitute Nog Substitute	3	EPIC	
--78	acceptable boozy CRIMBCO Extreme Braincracker Sour	5	good	
+-78	boozy acceptable CRIMBCO Extreme Braincracker Sour	5	good	
 -82	practically non-alcoholic artisanal yellow Horseradish-infused Vodka	1	EPIC	
 -83	acceptable Jerkitini	4	good	
--84	practically non-alcoholic artisanal Desert Island Iced Tea	1	EPIC	
--88	triple-distilled bad jittery Crimbo Saketini	7	decent	
+-84	artisanal practically non-alcoholic Desert Island Iced Tea	1	EPIC	
+-88	bad triple-distilled jittery Crimbo Saketini	7	decent	
 -89	perfectly mixed weak ghostly Crimboku Drop	2	EPIC	
 -90	smooth blurry Flaming Crimbo Log	3	awesome	
 -107	smooth high-proof pulsating Fortified Eggnog Slurry	10	awesome	

--- a/data/TCRS/TCRS_Accordion_Thief_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wallaby_cafe_food.txt
@@ -3,35 +3,35 @@
 -3	stale big Bouillabaise Coucher Avec Moi	5	decent	
 -7	moldy gumdrop chow mein	3	crappy	
 -8	delicious red candy cane pizza	3	awesome	
--9	miniature moldy gingerbread stir-fry	2	crappy	
+-9	moldy miniature gingerbread stir-fry	2	crappy	
 -10	spoiled jittery twigs and gravel	4	crappy	
 -11	flavorless wobbly shoots and leaves	4	decent	
--12	moldy thick bouncing bowl of unidentifiable goo	5	crappy	
+-12	thick moldy bouncing bowl of unidentifiable goo	5	crappy	
 -13	thick bland gingerbread massacre	5	decent	
--14	rotten immense It Came From Beyond Dessert	8	crappy	
+-14	immense rotten It Came From Beyond Dessert	8	crappy	
 -15	decent vampire cake	4	good	
 -52	half-sized stale ghostly Soylent Red and Green	2	decent	
 -53	adequate Disc-Shaped Nutrition Unit	3	good	
 -54	snack-sized decent Gingerborg Hive	2	good	
--61	fancy toothsome spinning Candy Cane Surprise	3	awesome	
--62	gigantic decent Grimdrop Chow Mein	9	good	
+-61	toothsome fancy spinning Candy Cane Surprise	3	awesome	
+-62	decent gigantic Grimdrop Chow Mein	9	good	
 -63	tasty Grimgerbread House	3	awesome	
 -67	decent small Caviar Carbonara	2	good	
 -68	decent Halibut Alfredo	3	good	
 -69	stale Red Herring Velvet Cake	3	decent	
 -73	toothsome CRIMBCO Reconstituted Gruel	3	awesome	
--74	flavorless jumbo New and Improved CRIMBCO Reconstituted Gruel	5	decent	
+-74	jumbo flavorless New and Improved CRIMBCO Reconstituted Gruel	5	decent	
 -75	normal blue jittery CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
--79	diet decent Brussels Sprout Stir-Fry	1	good	
--80	spoiled super-sized Carrot, Cabbage, and Kale Pizza	5	crappy	
+-79	decent diet Brussels Sprout Stir-Fry	1	good	
+-80	super-sized spoiled Carrot, Cabbage, and Kale Pizza	5	crappy	
 -81	normal Turnip and Rutabaga Pie	3	good	
 -85	yummy Rainbow Spider Fun Roll	3	awesome	
 -86	jumbo decent Vegas Volcano Lava Roll	5	good	
 -87	adequate spinning Crazy Dragon Shogun Buddha Roll	3	good	
 -92	moldy basic hot dog	3	crappy	
--93	flavorless enchanted savage macho dog	4	decent	
+-93	enchanted flavorless savage macho dog	4	decent	
 -94	moldy one with everything	3	crappy	
--95	jumbo stale sly dog	5	decent	
+-95	stale jumbo sly dog	5	decent	
 -96	moldy bouncing devil dog	3	crappy	
 -97	decent chilly dog	4	good	
 -98	flavorless diet ghost dog	1	decent	
@@ -40,6 +40,6 @@
 -101	delicious sleeping dog	3	awesome	
 -102	yummy optimal dog	3	awesome	
 -103	decent huge video games hot dog	3	good	
--104	miniature decent Peppermint Nutrition Block	2	good	
+-104	decent miniature Peppermint Nutrition Block	2	good	
 -105	delicious Gingerbread Nutrition Block	3	awesome	
 -106	tasty Cinnamon Nutrition Block	3	awesome	

--- a/data/TCRS/TCRS_Accordion_Thief_Wombat.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wombat.txt
@@ -10,11 +10,11 @@
 10	disco ball	0		
 11	stolen accordion	0		Song Duration: 5
 12	twirling mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	compressed gray spinning skewed moxie weed	1		Effect: "Wolf's Bane", Effect Duration: 20
+14	compressed skewed spinning gray moxie weed	1		Effect: "Wolf's Bane", Effect Duration: 20
 15	dehydrated purple strongness elixir	1		
 16	altered magicalness-in-a-can	1		Effect: "Cringle's Curative Carol", Effect Duration: 20
-17	bland spinning mirror noodles	4	decent	
-18	lime green blurry tortoise's blessing	0		
+17	bland mirror spinning noodles	4	decent	
+18	blurry lime green tortoise's blessing	0		
 19	twirling reassuring asparagus knife	0		Spooky Resistance: +1
 20	mirror Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
@@ -42,7 +42,7 @@
 43	worthless trinket	0		
 44	worthless gewgaw	0		
 45	blinking worthless knick-knack	0		
-46	shaking mirror figurine	0		
+46	mirror shaking figurine	0		
 47	rotten jittery skewed hot buttered roll	4	crappy	
 48	jittery heart of rock and roll	0		
 49	adequate twirling bowl of cottage cheese	3	good	
@@ -55,11 +55,11 @@
 56	hot sauce	0		
 57	stylish 5-Alarm Saucepan	0		Moxie: +25, Class: "Sauceror"
 58	stone turtle	0		
-59	blinking blue slingshot	0		
+59	blue blinking slingshot	0		
 60	greedy Mace of the Tortoise	0		Meat Drop: +20, Class: "Turtle Tamer"
 61	bland super-sized fortune cookie	5	decent	
 62	stiffened oriole-feather headdress	0		Damage Reduction: 1, Familiar Effect: "atk, 3xVolley, cap 3"
-63	squat tumbling action figure body	0		
+63	tumbling squat action figure body	0		
 64	action figure head	0		
 65	Mighty Bjorn action figure	0		
 66	olive twig	0		
@@ -77,8 +77,8 @@
 78	shellacked pretty bouquet	0		Damage Reduction: 7
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	bad high-proof ghostly ice-cold Willer	8	decent	
-82	wobbly purple ring	0		
+81	high-proof bad ghostly ice-cold Willer	8	decent	
+82	purple wobbly ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
 85	unlocked meat locker	0		
@@ -86,7 +86,7 @@
 87	purple meat from yesterday	0		
 88	mirror meat stack	0		
 89	blue sword hilt	0		
-90	huge yellow twirling helmet recipe	0		
+90	twirling huge yellow helmet recipe	0		
 91	twirling pants kit	0		
 92	meatsmithing guide	0		
 93	basic meat sword of courage	0		Spooky Resistance: +3
@@ -105,7 +105,7 @@
 106	upside-down ketchup	1	decent	
 107	catsup	1	decent	
 108	ghostly stick	0		
-109	gray spinning jittery crossbow string	0		
+109	spinning jittery gray crossbow string	0		
 110	avaricious basic meat staff	0		Meat Drop: +30
 111	huge bouncing basic meat crossbow of chilblains	0		Cold Damage: +25
 112	savvy sage meatloaf helmet	0		Mysticality Percent: 30, Familiar Effect: "1xBarrr, 1.5xFairy, cap 13"
@@ -127,7 +127,7 @@
 128	Newton's meat pants	0		Experience (Mysticality): +3, Familiar Effect: "2xPotato, cap 11"
 129	Fonzie's third-hand nunchaku	0		Experience (Moxie): +1
 130	toasty eyepatch	0		Hot Damage: +5, Familiar Effect: "4xBarrr, cap 8"
-131	green mirror frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
+131	mirror green frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
 133	Certificate of Participation	0		
 134	bitchin' meatcar	0		
@@ -140,7 +140,7 @@
 141	teal dingy dinghy	0		
 142	anticheese	0		
 143	green cottage	0		
-144	jittery narrow stone of eXtreme power	0		
+144	narrow jittery stone of eXtreme power	0		
 145	green barbed-wire fence	0		
 146	upside-down dinghy plans	0		
 147	blinking eXtreme meat sword of the sweet-tooth	0		Candy Drop: +100
@@ -157,8 +157,8 @@
 158	yellow Gnollish pie tin	0		
 159	pulsating wad of dough	0		
 160	pie crust	0		
-161	adequate miniature upside-down ghuol egg	2	good	
-162	adequate bite-sized upside-down ghuol egg quiche	1	good	
+161	miniature adequate upside-down ghuol egg	2	good	
+162	bite-sized adequate upside-down ghuol egg quiche	1	good	
 163	squat sinister skeleton bone	0		Spell Damage: +10
 164	smart skull	0		
 165	pulsating skewer	0		
@@ -167,11 +167,11 @@
 168	jittery deadly bone rattle	0		Weapon Damage: +5
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	blue lihc eye	0		
-171	moldy snack-sized lihc eye pie	2	crappy	
+171	snack-sized moldy lihc eye pie	2	crappy	
 172	gnoll lips	0		
 173	wobbly taco shell	0		
 174	blinking Gnollish casserole dish	0		
-175	normal tiny uncooked chorizo	1	good	
+175	tiny normal uncooked chorizo	1	good	
 176	disembodied brain	0		
 177	narrow brainy skull	0		
 178	detective skull	0		
@@ -197,7 +197,7 @@
 199	ring of James Dean	0		Experience (Moxie): +3
 200	special stale squat rat appendix kabob	4	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 45
 201	bland bat wing kabob	3	decent	
-202	gigantic adequate carob chunks	6	good	
+202	adequate gigantic carob chunks	6	good	
 203	herbs	0		
 204	stale carob chunk cookies	3	decent	
 205	secret blend of herbs and spices	0		
@@ -211,8 +211,8 @@
 213	greedy nasty filthy corduroys	0		Stench Damage: +5, Meat Drop: +20, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	shaking Fonzie's filthy knitted dread sack	0		Experience (Moxie): +1, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	normal thick gray carob brownies	5	good	
-217	special stale big herb brownies	5	decent	Effect: "damage.enh", Effect Duration: 40
+216	thick normal gray carob brownies	5	good	
+217	big stale special herb brownies	5	decent	Effect: "damage.enh", Effect Duration: 40
 218	hemp string	0		
 219	necklace chain	0		
 220	ghostly gnoll teeth	0		
@@ -233,7 +233,7 @@
 235	Van der Graaf Bigger Bugfinder Blade of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 5, MP Regen Max: 7
 236	Queue Du Coq cocktailcrafting kit	0		
 237	perfectly mixed skewed bottle of gin	3	EPIC	
-238	acceptable extra-dry bottle of vodka	5	good	
+238	extra-dry acceptable bottle of vodka	5	good	
 239	blue dangerous deadly Orcish baseball cap	0		Weapon Damage: 15, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	ribald Orcish cargo shorts of the ox	0		Muscle: +20, Sleaze Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	curative Orcish frat-paddle	0		HP Regen Min: 3, HP Regen Max: 5
@@ -244,24 +244,24 @@
 246	stale tomato	4	decent	
 247	maroon fermenting powder	0		
 248	hand-crafted salty dog	3	EPIC	
-249	fortified artisanal bloody mary	5	EPIC	
-250	artisanal watered-down squat jittery maroon screwdriver	2	EPIC	
-251	lousy watered-down martini	2	decent	
+249	artisanal fortified bloody mary	5	EPIC	
+250	artisanal watered-down squat maroon jittery screwdriver	2	EPIC	
+251	watered-down lousy martini	2	decent	
 252	tolerable jittery bloody beer	4	good	
-253	mediocre weak shot of schnapps	2	decent	
+253	weak mediocre shot of schnapps	2	decent	
 254	drinkable shot of grapefruit schnapps	4	good	
 255	hand-crafted fine wine	3	EPIC	
-256	tolerable watered-down teal shot of tomato schnapps	2	good	
+256	watered-down tolerable teal shot of tomato schnapps	2	good	
 257	tolerable twirling maroon extra-spicy bloody mary	4	good	
 258	narrow dense meat stack	0		
 259	jittery snake skin	0		
 260	enchanted normal White Citadel fries	3	good	Effect: "You Know When to Walk Away", Effect Duration: 25
 261	tasty tumbling White Citadel burger	3	awesome	
-262	snack-sized flavorless piece of wedding cake	2	decent	
+262	flavorless snack-sized piece of wedding cake	2	decent	
 263	spoiled chocolate chips	4	crappy	
-264	bland miniature chocolate chip cookies	2	decent	
+264	miniature bland chocolate chip cookies	2	decent	
 265	brawny satin pants	0		Muscle Percent: +20, Familiar Effect: "atk, 2xPotato, cap 10"
-266	tolerable weak lightning	2	good	
+266	weak tolerable lightning	2	good	
 267	manspreader's mullet wig	0		Monster Level: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	huge asbestos-lined meat cowboy hat	0		Hot Resistance: +5, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	sword of the ox	0		Muscle: +20
@@ -310,33 +310,33 @@
 312	greasy Knob Goblin visor	0		Sleaze Spell Damage: +10, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	upside-down upside-down Crown of the Goblin King of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	decent bean burrito	3	good	
-315	stale immense bean burrito	8	decent	
-316	diet bland shaking insanely bean burrito	1	decent	
+315	immense stale bean burrito	8	decent	
+316	bland diet shaking insanely bean burrito	1	decent	
 317	tiny stale yellow bean burrito	1	decent	
 318	rotten gigantic bean burrito	9	crappy	
 319	moldy half-sized mirror insanely bean burrito	2	crappy	
-320	thick decent mirror bat haggis	5	good	
-321	immense rotten menudo	8	crappy	
+320	decent thick mirror bat haggis	5	good	
+321	rotten immense menudo	8	crappy	
 322	rotten goat cheese	3	crappy	
-323	fancy moldy plain pizza	3	crappy	Effect: "Broken Bone Nubs", Effect Duration: 5
+323	moldy fancy plain pizza	3	crappy	Effect: "Broken Bone Nubs", Effect Duration: 5
 324	low-calorie rotten mirror sausage pizza	1	crappy	
-325	stale thick goat cheese pizza	5	decent	
+325	thick stale goat cheese pizza	5	decent	
 326	massive bland narrow mushroom pizza	6	decent	
 327	jittery goat	0		
-328	weak aged bottle of whiskey	2	awesome	
+328	aged weak bottle of whiskey	2	awesome	
 329	resourceful goat beard	0		Maximum MP: +50, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	crappy	
 331	acceptable tumbling Canadian	3	good	
 332	rotten lemon	3	crappy	
 333	stale tumbling lime	3	decent	
 334	fortified sabre teeth	0		Damage Absorption: +60
-335	mirror fuchsia sabre-toothed lime cub	0		
+335	fuchsia mirror sabre-toothed lime cub	0		
 336	flame-retardant consolation ribbon	0		Hot Resistance: +1
 337	ol' trophy	0		
 338	ghostly tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
 340	ionized triple-oxidized shaking Knob Goblin steroids	0		Effect: "Scorpio Rising", Effect Duration: 19
-341	corrupted maroon ghostly bouncing Knob Goblin love potion	0		Effect: "Crimbo Flavor", Effect Duration: 31
+341	corrupted maroon bouncing ghostly Knob Goblin love potion	0		Effect: "Crimbo Flavor", Effect Duration: 31
 342	twirling Knob Goblin stink bomb	0		
 343	ionized Knob Goblin sharpening spray	0		Effect: "Goldentongue", Effect Duration: 33
 344	lime green Knob Goblin seltzer	0		
@@ -353,13 +353,13 @@
 355	gray sage eXtreme scarf	0		Mysticality Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	green groovy snowboarder pants	0		Moxie Percent: +10, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	adequate green squat gr8ps	4	good	
-359	stale gigantic t8r tots	6	decent	
+358	adequate squat green gr8ps	4	good	
+359	gigantic stale t8r tots	6	decent	
 360	tumbling shaking slick miner's helmet	0		Moxie: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	aromatic miner's pants	0		Stench Resistance: +1, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	7-Foot Dwarven mattock of doom	0		Spooky Spell Damage: +50
 363	linoleum ore	0		
-364	jittery ghostly asbestos ore	0		
+364	ghostly jittery asbestos ore	0		
 365	upside-down chrome ore	0		
 366	huge linoleum sword hilt	0		
 367	linoleum stick	0		
@@ -496,7 +496,7 @@
 498	snack-sized bland bouncing papaya	2	decent	
 499	asbestos-lined denim axe of the storm	0		Maximum MP Percent: +40, Hot Resistance: +5
 500	narrow Elf Farm Raffle ticket	0		
-501	adequate immense Elfin shortbread	6	good	
+501	immense adequate Elfin shortbread	6	good	
 502	red pagoda plans	0		
 503	flavorless blurry skewered cat appendix	3	decent	
 504	spinning evil arches	0		
@@ -538,9 +538,9 @@
 540	alkaline unsweetened nitrogenated red Tasty Fun Good rice candy	0		Effect: "Hagnk's Gratitude", Effect Duration: 23
 541	bouncing prompt draggin' ball hat of the sewer	0		Stench Damage: +25, Adventures: +3, Familiar Effect: "atk, 1xVolley, cap 25"
 542	aromatic ribald 1337 7r0uZ0RZ	0		Sleaze Damage: +10, Stench Resistance: +1, Familiar Effect: "2xPotato, cap 27"
-543	delicious fancy Trollhouse cookies	4	awesome	Effect: "Super Vision", Effect Duration: 15
+543	fancy delicious Trollhouse cookies	4	awesome	Effect: "Super Vision", Effect Duration: 15
 544	mirror grievous talons of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20
-545	moldy fancy Spam Witch sammich	3	crappy	Effect: "Pwnd", Effect Duration: 25
+545	fancy moldy Spam Witch sammich	3	crappy	Effect: "Pwnd", Effect Duration: 25
 546	jittery olive meat vortex	0		
 547	334 scroll	0		
 548	pulsating yellow 668 scroll	0		
@@ -553,7 +553,7 @@
 555	stiffened drywall axe of the sewer	0		Damage Reduction: 1, Stench Damage: +25
 556	wobbly horrifying Pine-Fresh air freshener	0		Spooky Damage: +25
 557	perfectly mixed tumbling whiskey and cola	4	EPIC	
-558	super-sized fancy decent papaya taco	5	good	Effect: "Eye of the Seal", Effect Duration: 5
+558	fancy super-sized decent papaya taco	5	good	Effect: "Eye of the Seal", Effect Duration: 5
 559	razor-sharp can lid	0		
 560	moldy stalk of asparagus	4	crappy	
 561	pregnant mushroom	0		
@@ -563,14 +563,14 @@
 565	healthy hobo gloves	0		Maximum HP Percent: +20, Single Equip
 566	jittery blue bum cheek of courage	0		Spooky Resistance: +3, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	pulsating hermit script	0		
-568	snack-sized bland Double Bacon Beelzeburger	2	decent	
+568	bland snack-sized Double Bacon Beelzeburger	2	decent	
 569	normal thick squat Lord of the Flies-sized fries	5	good	
 570	enchanted normal Chicken Sandwich	4	good	Effect: "For Your Brain Only", Effect Duration: 45
 571	wobbly Jumbo Dr. Lucifer	1	decent	
 572	stale Children's Meal of the Damned	3	decent	
-573	thick stale noodles	5	decent	
+573	stale thick noodles	5	decent	
 574	moldy noodles	4	crappy	
-575	bite-sized flavorless painful penne pasta	1	decent	
+575	flavorless bite-sized painful penne pasta	1	decent	
 576	miniature adequate ghostly ravioli della hippy	2	good	
 577	miniature spoiled pr0n m4nic0tti	2	crappy	
 578	bland narrow Hell ramen	3	decent	
@@ -579,13 +579,13 @@
 581	blinking schmancy cheese sauce	0		
 582	pulsating pulsating Himalayan Hidalgo sauce	0		
 583	rotten fettucini Inconnu	3	crappy	
-584	snack-sized normal spaghetti with Skullheads	2	good	
+584	normal snack-sized spaghetti with Skullheads	2	good	
 585	flavorless gnocchetti di Nietzsche	3	decent	
 586	executive hale ridiculously huge sword	0		Maximum HP: +20, Meat Drop: +40
 587	non-enhanced magnetized upside-down super-spiky hair gel	0		Effect: "Nature's Bounty", Effect Duration: 24
 588	soft echo eyedrop antidote	0		
-589	bite-sized adequate ghostly cocoa eggshell fragment	1	good	
-590	jumbo flavorless cocoa eggshell fragment	5	decent	
+589	adequate bite-sized ghostly cocoa eggshell fragment	1	good	
+590	flavorless jumbo cocoa eggshell fragment	5	decent	
 591	cocoa egg	0		
 592	house	0		
 593	jittery phonics down	0		
@@ -636,7 +636,7 @@
 638	perfumed deadly asshat	0		Weapon Damage: +5, Stench Resistance: +5, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	stale abominable snowcone	3	decent	
 640	Ent cider	1	crappy	
-641	spoiled enchanted toast	3	crappy	Effect: "Hopped Up on Goofballs", Effect Duration: 45
+641	enchanted spoiled toast	3	crappy	Effect: "Hopped Up on Goofballs", Effect Duration: 45
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	skewed Crimbo pressie	0		Last Available: "2003-12"
@@ -644,8 +644,8 @@
 646	stale narrow fruitcake	3	decent	
 647	present	0		Last Available: "2004-11"
 648	stiffened Crimbo sword	0		Damage Reduction: 1, Last Available: "2004-10"
-649	red squat lard-coated Crimbo hat	0		Sleaze Spell Damage: +25, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	shaking cyan Crimbo pants of the scaredy-cat	0		Monster Level: -15, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	red squat lard-coated Crimbo hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	shaking cyan Crimbo pants of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	tumbling gravedigger's exclusive ultra-rare item	0		Spooky Damage: +10
 652	quantum egg	0		
 653	narrow intragalactic rowboat	0		
@@ -679,7 +679,7 @@
 681	artisanal slip 'n' slide	3	EPIC	
 682	drinkable narrow a sump'm sump'm	3	good	
 683	tolerable horizontal tango	3	good	
-684	hand-crafted strong upside-down pink pony	5	EPIC	
+684	strong hand-crafted upside-down pink pony	5	EPIC	
 685	medical-grade healthy Newton's Mr. Shirt	0		Experience (Mysticality): +3, Maximum HP Percent: +20, HP Regen Min: 7, HP Regen Max: 10
 686	hale knuckles	0		Maximum HP: +20
 687	nitrogenated dry upside-down blood of the Wereseal	0		Effect: "Greedy Resolve", Effect Duration: 13
@@ -699,7 +699,7 @@
 702	coconut bikini top of the businessman	0		Meat Drop: +50
 703	skewed blinking sharpshooter's goth kid t-shirt	0		Critical Hit Percent: +10
 704	hamethyst	0		
-705	ghostly jittery lime green baconstone	0		
+705	lime green ghostly jittery baconstone	0		
 706	porquoise	0		
 707	pork elf goodies sack	0		
 708	yellow ring setting	0		
@@ -716,7 +716,7 @@
 720	executive fireproof porquoise necklace	0		Hot Resistance: +3, Meat Drop: +40, Single Equip
 721	gravedigger's therapeutic porquoise bracelet	0		Spooky Damage: +10, HP Regen Min: 5, HP Regen Max: 7
 722	stiffened stylish beefy porquoise ring	0		Muscle: +10, Moxie: +25, Damage Reduction: 1, Single Equip
-723	moldy big Knoll mushroom	5	crappy	
+723	big moldy Knoll mushroom	5	crappy	
 724	stale spinning bouncing mushroom	3	decent	
 725	one million meat pancakes	0		
 726	zippy huge mirror shard	0		Initiative: +20
@@ -724,7 +724,7 @@
 728	wobbly hedge maze key	0		
 729	shaking fishbowl	0		
 730	fishtank	0		
-731	squat huge fish hose	0		
+731	huge squat fish hose	0		
 732	bouncing hosed tank	0		
 733	hosed fishbowl	0		
 734	upside-down auspicious rosy-cheeked makeshift SCUBA gear of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +30, Item Drop: +10, Adventure Underwater
@@ -741,21 +741,21 @@
 746	stat script	0		
 747	shaking shaking Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	thick stale bouncing warm mushroom	5	decent	
+749	stale thick bouncing warm mushroom	5	decent	
 750	bland mushroom quesadilla	3	decent	
 751	enchanted stale wobbly cool mushroom	3	decent	Effect: "Shot in the Arse", Effect Duration: 40
 752	adequate cool mushroom casserole	4	good	
-753	stale snack-sized fancy pointy mushroom	2	decent	Effect: "Squirming Like a Toad", Effect Duration: 10
+753	fancy snack-sized stale pointy mushroom	2	decent	Effect: "Squirming Like a Toad", Effect Duration: 10
 754	tasty cream of pointy mushroom soup	3	awesome	
-755	half-sized delicious mushroom	2	awesome	
-756	thick rotten mushroom	5	crappy	
+755	delicious half-sized mushroom	2	awesome	
+756	rotten thick mushroom	5	crappy	
 757	normal mushroom	3	good	
 758	decent immense ghost cucumber	6	good	
 759	dill	0		
 760	squat vinegar	0		
 761	brine	0		
-762	smooth weak especially salty dog	2	awesome	
-763	wobbly mirror lime green ghostly pickling solution	0		
+762	weak smooth especially salty dog	2	awesome	
+763	mirror wobbly lime green ghostly pickling solution	0		
 764	flavorless spectral pickle	4	decent	
 765	olive briny vinegar	0		
 766	shaking ghost pickle on a stick	0		
@@ -778,7 +778,7 @@
 783	'Villa' document	0		
 784	perfectly mixed lime green Acqua Del Piatto Merlot	4	EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
-786	diet decent strawberry	1	good	
+786	decent diet strawberry	1	good	
 787	artisanal extra-dry bottle of rum	5	EPIC	
 788	mediocre strawberry daiquiri	3	decent	
 789	fortified aged rum and cola	5	awesome	
@@ -787,27 +787,27 @@
 792	wholesome Golden Mr. Accessory	0		Maximum HP Percent: +10, Softcore Only
 793	Vulcanized oil of stability	0		Effect: "Dirge of Dreadfulness", Effect Duration: 16
 794	modified quadruple-tarnished altered skewed oil of slipperiness	0		Effect: "Tennis Elbow-wow", Effect Duration: 68
-795	lousy watered-down jittery Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
+795	watered-down lousy jittery Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
 796	friendly extremely unsafe cement shoes of the ox	0		Muscle: +20, Weapon Damage Percent: +100, Familiar Weight: +3, Last Available: "2004-10"
 797	triple-distilled bad bouncing rockin' wagon	7	decent	
 798	artisanal ocean motion	3	EPIC	
 799	drinkable fuzzbump	4	good	
-800	bite-sized spoiled poutine	1	crappy	
+800	spoiled bite-sized poutine	1	crappy	
 801	rotten huge Knob stir-fry	4	crappy	
-804	stale bite-sized upside-down blue Knoll stir-fry	1	decent	
+804	bite-sized stale upside-down blue Knoll stir-fry	1	decent	
 805	flavorless gigantic stir-fry	8	decent	
-806	decent half-sized spinning asparagus stir-fry	2	good	
+806	half-sized decent spinning asparagus stir-fry	2	good	
 807	delicious tumbling olive stir-fry	3	awesome	
 808	decent green Knob sausage stir-fry	3	good	
-809	adequate bite-sized wobbly bat wing stir-fry	1	good	
+809	bite-sized adequate wobbly bat wing stir-fry	1	good	
 810	flavorless upside-down rat appendix stir-fry	3	decent	
 811	moldy tofu stir-fry	4	crappy	
 812	spoiled jittery pr0n stir-fry	4	crappy	
-813	gigantic decent narrow Knob shells	7	good	
+813	decent gigantic narrow Knob shells	7	good	
 814	adequate maroon b&auml;tzle	3	good	
 815	decent yellow ratini	4	good	
 816	bland shaking Knob stroganoff	4	decent	
-817	massive flavorless lime green menudo ravioli	9	decent	
+817	flavorless massive lime green menudo ravioli	9	decent	
 818	plus sign	0		
 819	milky potion	0		
 820	squat swirly potion	0		
@@ -829,12 +829,12 @@
 836	adequate big mind flayer corpse	5	good	
 837	hand-crafted Uovo Marcio Shiraz	4	EPIC	Last Available: "2004-10"
 838	frightening chaotic Mafia stogie	0		Spell Critical Percent: +10, Spooky Damage: +5, Last Available: "2004-10"
-839	triple-distilled aged Maiali Sifilitici Pinot Noir	7	awesome	Last Available: "2004-10"
+839	aged triple-distilled Maiali Sifilitici Pinot Noir	7	awesome	Last Available: "2004-10"
 840	twirling Van der Graaf savvy Mafia violin case	0		Mysticality Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2004-10"
 841	watered-down acceptable tomato daiquiri	2	good	
-842	hand-crafted practically non-alcoholic narrow red beertini	1	EPIC	
+842	practically non-alcoholic hand-crafted narrow red beertini	1	EPIC	
 843	lousy salty slug	3	decent	
-844	practically non-alcoholic lousy papaya slung	1	decent	
+844	lousy practically non-alcoholic papaya slung	1	decent	
 845	MAHI fez of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	spinning ghostly hypodermic needle	0		Familiar Weight: +5
@@ -843,7 +843,7 @@
 851	mirror prosthetic forehead	0		Familiar Weight: +5
 852	olive shaker of salt	0		Familiar Weight: +5
 853	tumbling blundarrrbus	0		Familiar Weight: +5
-854	upside-down squat sucky decal	0		Familiar Weight: +5
+854	squat upside-down sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
 857	moonglasses	0		
@@ -859,7 +859,7 @@
 867	anodized pine tar	0		Effect: "Wet Rub", Effect Duration: 36
 869	forest tears	0		
 870	cyan spinning shellacked fetus-smashing club	0		Damage Reduction: 7
-871	wobbly ghostly meatcar model	0		Familiar Weight: +5
+871	ghostly wobbly meatcar model	0		Familiar Weight: +5
 872	skewed Time Juice	0		Last Available: "2004-01"
 873	rolling pin	0		
 874	unrolling pin	0		
@@ -892,7 +892,7 @@
 901	espresso maker	0		Familiar Weight: +5
 902	fuchsia 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	weak hand-crafted skewed Spasmi Dolorosi Del Rene Champagne	2	super ultra mega EPIC	Last Available: "2004-10"
-904	shaking quilted beefy school Mafia knickerbockers of mayonnaise	0		Muscle: +10, Damage Absorption: +40, Sleaze Spell Damage: +50, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	shaking quilted beefy school Mafia knickerbockers of mayonnaise	0		Muscle: +10, Damage Absorption: +40, Sleaze Spell Damage: +50, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	unsweetened galvanized spinning Yummy Tummy bean	0		Effect: "Fruited", Effect Duration: 27
 906	anodized jittery Rock Pops	0		Effect: "Hella Smart", Effect Duration: 28
 907	electrified improved corrupted teal Mr. Mediocrebar	0		Effect: "Briny Blood", Effect Duration: 27
@@ -906,20 +906,20 @@
 915	bouncing yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fuchsia huge nasty intergalactic pom poms of doom	0		Stench Damage: +5, Spooky Spell Damage: +50
 917	Mob Penguin protection contract	0		
-918	blue Radio Free Baseball Cap of temperance	0		Sleaze Resistance: +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	thinker's Radio Free Pants	0		Mysticality: +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	blue Radio Free Baseball Cap of temperance	0		Sleaze Resistance: +5, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	thinker's Radio Free Pants	0		Mysticality: +10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	olive skewed Oprah's Radio Free Foil	0		Maximum MP Percent: +50, Last Available: "2006-07"
-921	flavorless special radio button candy	4	decent	Effect: "Newt Gets In Your Eyes", Effect Duration: 5
+921	special flavorless radio button candy	4	decent	Effect: "Newt Gets In Your Eyes", Effect Duration: 5
 922	squat resourceful severed rocking horse head	0		Maximum MP: +50
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	cyan dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	flattened oxidized mirror Hawking's Elixir of Brilliance	0		Effect: "Brain Freeze", Effect Duration: 13
-927	irresponsibly strong lousy special Ferita Del Petto Zinfandel	9	decent	Effect: "Cold Blooded", Effect Duration: 30, Last Available: "2006-12"
+927	irresponsibly strong special lousy Ferita Del Petto Zinfandel	9	decent	Effect: "Cold Blooded", Effect Duration: 30, Last Available: "2006-12"
 928	dangerous fuzzy bracelets	0		Weapon Damage: +10
 929	arse-shooting crossbow of the early riser	0		Adventures: +7
-931	perfectly mixed watered-down yellow wobbly spiced rum	2	EPIC	
-932	hand-crafted practically non-alcoholic eggnog	1	super EPIC	
+931	watered-down perfectly mixed wobbly yellow spiced rum	2	EPIC	
+932	practically non-alcoholic hand-crafted eggnog	1	super EPIC	
 933	bland tumbling candy cane	4	decent	
 934	flavorless huge gingerbread bugbear	4	decent	
 935	inspector's imitation nice watch	0		Item Drop: +15, Single Equip, Last Available: "2004-12"
@@ -929,13 +929,13 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	mirror beefcake's bowler	0		Muscle: +25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	mirror beefcake's bowler	0		Muscle: +25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	Temple Grandin's baleful bow staff	0		Spell Damage: +25, Familiar Weight: +7, Last Available: "2004-12"
-944	tumbling rock-hard bowlegged pants	0		Damage Reduction: 5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	tumbling rock-hard bowlegged pants	0		Damage Reduction: 5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	ghostly skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	enchanted artisanal irresponsibly strong purple martini	9	EPIC	Effect: "Fury of the Bells", Effect Duration: 20, Last Available: "2004-12"
+948	enchanted irresponsibly strong artisanal purple martini	9	EPIC	Effect: "Fury of the Bells", Effect Duration: 20, Last Available: "2004-12"
 949	tolerable weak grogtini	2	good	Last Available: "2004-12"
 950	tolerable cherry bomb	4	good	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -982,7 +982,7 @@
 992	scorching curative hardened plastic Jarlsberg	0		Damage Reduction: 3, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5
 993	plastic Sneaky Pete of extreme caution of the empath of the detective	0		Monster Level: -25, Familiar Weight: +5, Item Drop: +20
 994	blurry family-friendly plastic Susie	0		Sleaze Resistance: +1
-995	tasty small Lucky Surprise Egg	2	awesome	
+995	small tasty Lucky Surprise Egg	2	awesome	
 998	upside-down maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	narrow maid head	0		
 1000	blurry Meat maid	0		
@@ -993,22 +993,22 @@
 1006	decent small upside-down cherry	2	good	
 1007	reassuring coconut shell	0		Spooky Resistance: +1, Familiar Effect: "1xFairy, cap 7"
 1008	Rosewater's ice cubes	0		Mysticality Percent: +30
-1009	hand-crafted practically non-alcoholic blurry vodka martini	1	EPIC	
+1009	practically non-alcoholic hand-crafted blurry vodka martini	1	EPIC	
 1010	acceptable whiskey and soda	3	good	
 1011	perfectly mixed watered-down monkey wrench	2	EPIC	
-1012	artisanal triple-distilled tequila sunrise	9	EPIC	
-1013	distilled mediocre margarita	5	decent	
+1012	triple-distilled artisanal tequila sunrise	9	EPIC	
+1013	mediocre distilled margarita	5	decent	
 1014	mediocre strawberry wine	3	decent	
-1015	triple-distilled mediocre bouncing wine spritzer	9	decent	
+1015	mediocre triple-distilled bouncing wine spritzer	9	decent	
 1016	lousy perpendicular hula	3	decent	
 1017	bad ducha de oro	3	decent	
-1018	artisanal mirror lime green calle de miel	3	EPIC	
+1018	artisanal lime green mirror calle de miel	3	EPIC	
 1019	watered-down tolerable dry vodka martini	2	good	
 1020	acceptable practically non-alcoholic old-fashioned	1	good	
 1021	artisanal pulsating tequila with training wheels	3	EPIC	
-1022	enchanted mediocre sangria	4	decent	Effect: "Phoenix, Right?", Effect Duration: 25
-1023	smooth triple-distilled vesper	7	awesome	Last Available: "2004-12"
-1024	hand-crafted spirit-forward bodyslam	5	EPIC	Last Available: "2004-12"
+1022	mediocre enchanted sangria	4	decent	Effect: "Phoenix, Right?", Effect Duration: 25
+1023	triple-distilled smooth vesper	7	awesome	Last Available: "2004-12"
+1024	spirit-forward hand-crafted bodyslam	5	EPIC	Last Available: "2004-12"
 1025	spirit-forward tolerable sangria del diablo	5	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	pulsating whip kit	0		
@@ -1029,21 +1029,21 @@
 1043	string of beads of the empath	0		Familiar Weight: +5
 1044	Jeselnik's string of beads	0		Sleaze Damage: +25
 1045	wool plastic bottle opener	0		Cold Resistance: +1
-1046	mirror Usain Bolt's Da Vinci's traffic cone	0		Experience (Mysticality): +5, Initiative: +80, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	watered-down acceptable N. O. Beer	2	good	
+1046	mirror Usain Bolt's Da Vinci's traffic cone	0		Experience (Mysticality): +5, Initiative: +80, Familiar Effect: "cap 15", Last Available: "2005-03"
+1047	acceptable watered-down N. O. Beer	2	good	
 1048	diluted spinning oyster egg	1		Effect: "Pronounced Potency", Effect Duration: 20
 1049	diluted squat yellow oyster egg	1		
 1050	dried blinking oyster egg	1		
 1051	plastic oyster egg	0		
 1052	distilled oyster egg	1		Effect: "Eagle Eyes", Effect Duration: 20
-1053	boiled yellow shaking mirror oyster egg	1		
-1054	altered jittery bouncing oyster egg	1		Effect: "Human-Constellation Hybrid", Effect Duration: 35
+1053	boiled mirror yellow shaking oyster egg	1		
+1054	altered bouncing jittery oyster egg	1		Effect: "Human-Constellation Hybrid", Effect Duration: 35
 1055	blurry shaking plastic oyster egg	0		
 1056	dried bouncing shaking puce oyster egg	1		Effect: "Hairless and Airless", Effect Duration: 20
 1057	modified puce oyster egg	1		
 1058	modified puce oyster egg	1		
 1059	puce plastic oyster egg	0		
-1060	diluted ghostly wobbly mauve oyster egg	1		
+1060	diluted wobbly ghostly mauve oyster egg	1		
 1061	boiled pulsating mauve oyster egg	1		
 1062	denatured mauve oyster egg	1		Effect: "Overstimulated", Effect Duration: 5
 1063	mauve plastic oyster egg	0		
@@ -1055,17 +1055,17 @@
 1069	twisted narrow twirling oyster egg	1		Effect: "Action", Effect Duration: 40
 1070	modified blurry oyster egg	1		
 1071	tumbling plastic oyster egg	0		
-1072	altered huge ghostly off-white oyster egg	1		
-1073	distilled ghostly blue off-white oyster egg	1		Effect: "5 Pounds Lighter", Effect Duration: 50
-1074	dehydrated blurry squat off-white oyster egg	1		
+1072	altered ghostly huge off-white oyster egg	1		
+1073	distilled blue ghostly off-white oyster egg	1		Effect: "5 Pounds Lighter", Effect Duration: 50
+1074	dehydrated squat blurry off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	boiled squat spinning oyster egg	1		Effect: "Just the Brown Ones", Effect Duration: 10
+1076	boiled spinning squat oyster egg	1		Effect: "Just the Brown Ones", Effect Duration: 10
 1077	altered blinking oyster egg	1		
-1078	denatured huge cyan wobbly oyster egg	1		
+1078	denatured wobbly huge cyan oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
-1082	upside-down tumbling gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
+1082	tumbling upside-down gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	blurry clockwork widget	0		
@@ -1073,7 +1073,7 @@
 1087	clockwork doohickey	0		
 1088	clockwork clockwise dome	0		
 1089	clockwork spine	0		
-1090	jittery gray clockwork rings	0		
+1090	gray jittery clockwork rings	0		
 1091	clockwork claws	0		
 1092	spinning clockwork sheet	0		
 1093	blinking clockwork counterclockwise dome	0		
@@ -1095,7 +1095,7 @@
 1109	twirling teal clockwork bartender-head-in-the-box	0		
 1110	clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
-1112	huge twirling clockwork chef-in-the-box	0		
+1112	twirling huge clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
 1114	tisket	0		
 1115	lime green tasket	0		
@@ -1123,17 +1123,17 @@
 1137	bicycle chain of the empath of chilblains	0		Familiar Weight: +5, Cold Damage: +25
 1138	bouncing skewed mushroom fermenting solution	0		
 1139	weak perfectly mixed mushroom wine	2	EPIC	
-1140	delicious practically non-alcoholic icy mushroom wine	1	awesome	
+1140	practically non-alcoholic delicious icy mushroom wine	1	awesome	
 1141	lousy mushroom wine	3	decent	
-1142	practically non-alcoholic lousy pointy mushroom wine	1	decent	
-1143	aged practically non-alcoholic flat mushroom wine	1	awesome	
+1142	lousy practically non-alcoholic pointy mushroom wine	1	decent	
+1143	practically non-alcoholic aged flat mushroom wine	1	awesome	
 1144	mediocre cool mushroom wine	4	decent	
 1145	drinkable practically non-alcoholic knob mushroom wine	1	good	
 1146	acceptable knoll mushroom wine	4	good	
 1147	hand-crafted bouncing mushroom wine	3	EPIC	
 1148	high-proof artisanal blurry shot of flower schnapps	7	EPIC	
 1149	half-sized normal flower petal pie	2	good	
-1150	enchanted perfectly mixed weak bottle of single-barrel whiskey	2	super ultra mega EPIC	Effect: "Compensatory Cruelness", Effect Duration: 20
+1150	perfectly mixed weak enchanted bottle of single-barrel whiskey	2	super ultra mega EPIC	Effect: "Compensatory Cruelness", Effect Duration: 20
 1151	skewed executive quilted discarded plastic fork	0		Damage Absorption: +40, Meat Drop: +40
 1152	teal gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	moldy lime green Retenez L'Herbe Pat&eacute;	3	crappy	
@@ -1182,17 +1182,17 @@
 1197	Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	blurry bugbear	0		
-1200	super-sized rotten mugcake	5	crappy	
+1200	rotten super-sized mugcake	5	crappy	
 1201	bland half-sized squat urinal cake	2	decent	
-1202	massive moldy Happy Birthday, Claude! cake	6	crappy	
+1202	moldy massive Happy Birthday, Claude! cake	6	crappy	
 1203	tasty personalized birthday cake	3	awesome	
 1204	bland huge three-tiered wedding cake	7	decent	
 1205	half-sized bland tumbling babycakes	2	decent	
-1206	yummy small olive velvet cake	2	awesome	
-1207	decent big congratulatory cake	5	good	
-1208	spoiled snack-sized ghostly angel-food cake	2	crappy	
+1206	small yummy olive velvet cake	2	awesome	
+1207	big decent congratulatory cake	5	good	
+1208	snack-sized spoiled ghostly angel-food cake	2	crappy	
 1209	rotten devil's-food cake	3	crappy	
-1210	gigantic stale birthday party jellybean cheesecake	10	decent	
+1210	stale gigantic birthday party jellybean cheesecake	10	decent	
 1211	red balloon	0		
 1212	maroon balloon	0		
 1213	heart-shaped balloon	0		
@@ -1235,12 +1235,12 @@
 1251	decent Knob shroomkabob	3	good	
 1252	decent shroomkabob	3	good	
 1253	pile of jumping beans	0		
-1254	normal huge olive jumping bean burrito	3	good	
+1254	normal olive huge jumping bean burrito	3	good	
 1255	flavorless diet jumping bean burrito	1	decent	
 1256	stale skewed insanely jumping bean burrito	4	decent	
 1257	yummy tiny skewed rat scrapple	1	awesome	
 1258	pail of pretentious paint	0		
-1259	nasty Sinatra's traffic cone	0		Experience (Moxie): +5, Stench Damage: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	nasty Sinatra's traffic cone	0		Experience (Moxie): +5, Stench Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	powdered huge huge Hatorade	1		
 1262	careful razor-sharp off-hand balloon of the early riser	0		Weapon Damage Percent: +25, Monster Level: -10, Adventures: +7
@@ -1287,7 +1287,7 @@
 1303	twirling Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	up-at-dawn shellacked traffic cone	0		Damage Reduction: 7, Adventures: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	up-at-dawn shellacked traffic cone	0		Damage Reduction: 7, Adventures: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	red unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	jittery attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	big delicious questionable taco	5	awesome	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	cyan petrified time	0		Last Available: "2005-10"
-1323	wholesome time helmet	0		Maximum HP Percent: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	gray ghostly Tesla time trousers	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	wholesome time helmet	0		Maximum HP Percent: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	gray ghostly Tesla time trousers	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	up-at-dawn time sword	0		Adventures: +5, Last Available: "2005-10"
 1326	Dyspepsi-Cola helmet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "3xFairy, cap 7"
 1327	purple Cloaca-Cola shield of incineration	0		Hot Spell Damage: +50, Damage Reduction: 4
@@ -1353,7 +1353,7 @@
 1370	wizardly rhinestone cowboy shirt	0		Mysticality: +25
 1371	twirling sharpshooter's gingham blouse	0		Critical Hit Percent: +10
 1372	skewed therapeutic souvenir ski t-shirt	0		HP Regen Min: 5, HP Regen Max: 7
-1373	green wobbly sweet nutcracker	0		Free Pull, Last Available: "2005-12"
+1373	wobbly green sweet nutcracker	0		Free Pull, Last Available: "2005-12"
 1374	tumbling mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	plastic Crimbo wreath of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2005-12"
 1376	plastic Uncle Crimbo of the cougar	0		Moxie: +20, Last Available: "2005-12"
@@ -1384,13 +1384,13 @@
 1402	Usain Bolt's rag doll	0		Initiative: +80, Last Available: "2005-12"
 1403	mirror can of fake snow of extreme caution	0		Monster Level: -25, Last Available: "2005-12"
 1404	wobbly ribald colored-light &quot;necklace&quot;	0		Sleaze Damage: +10, Last Available: "2005-12"
-1405	tree skirt of horror	0		Spooky Spell Damage: +25, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	tree skirt of horror	0		Spooky Spell Damage: +25, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	stale purple wreath-shaped Crimbo cookie	4	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	decent bell-shaped Crimbo cookie	3	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	decent snack-sized teal tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	sage Unionize The Elves sign	0		Mysticality Percent: +10, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	diffused teal snowcone	0		Effect: "Comic Violence", Effect Duration: 47, Last Available: "2006-01"
 1413	Vulcanized blue snowcone	0		Effect: "Celestial Vision", Effect Duration: 51, Last Available: "2006-01"
 1414	vacuum-sealed triple-vacuum-sealed snowcone	0		Effect: "Down With Chow", Effect Duration: 40, Last Available: "2006-01"
@@ -1399,24 +1399,24 @@
 1417	quantum shaking snowcone	0		Effect: "Slimily Sagacious", Effect Duration: 68, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	blurry teddy bear sewing kit	0		Last Available: "2006-01"
-1420	stiffened traffic cone of Flo-Jo	0		Damage Reduction: 1, Initiative: +100, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	stiffened traffic cone of Flo-Jo	0		Damage Reduction: 1, Initiative: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	pulsating Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	reassuring scandalous ice sickle	0		Sleaze Damage: +5, Spooky Resistance: +1, Softcore Only, Last Available: "2006-02"
 1425	blurry lime green ice baby of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2006-02"
-1426	bouncing friendly ice pick	0		Familiar Weight: +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	bouncing friendly ice pick	0		Familiar Weight: +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	Van der Graaf forbidden ice skates	0		Spell Damage Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	decent green jittery grue egg omelette	4	good	
 1429	roll of drink tickets	0		
 1430	blurry pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	big stale mushroom	5	decent	
+1432	stale big mushroom	5	decent	
 1433	green fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	jittery hot stuffing	0		
-1437	blurry wobbly useless powder	0		
+1437	wobbly blurry useless powder	0		
 1438	quantum twinkly powder	0		Effect: "The Dinsey Way", Effect Duration: 15
 1439	diffused chilled aerosolized hot powder	0		Effect: "The Real Deal", Effect Duration: 15
 1440	pressed double-magnetized skewed powder	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 42
@@ -1424,7 +1424,7 @@
 1442	diffused skewed stench powder	0		Effect: "Halloweeny", Effect Duration: 16
 1443	electrified deionized red mirror sleaze powder	0		Effect: "Orc Chops", Effect Duration: 14
 1444	Vulcanized twinkly nuggets	0		Effect: "Berry Experiential", Effect Duration: 26
-1445	vacuum-sealed purple narrow hot nuggets	0		Effect: "Memory of Smarts", Effect Duration: 27
+1445	vacuum-sealed narrow purple hot nuggets	0		Effect: "Memory of Smarts", Effect Duration: 27
 1446	activated narrow nuggets	0		Effect: "Elemental Flavor", Effect Duration: 35
 1447	corrupted wet cold-filtered upside-down nuggets	0		Effect: "Perfect Hair", Effect Duration: 62
 1448	polarized liquefied stench nuggets	0		Effect: "Florid Cheeks", Effect Duration: 21
@@ -1440,7 +1440,7 @@
 1458	half-sized normal Valentine's Day cake	2	good	
 1459	twirling arrow'd heart balloon	0		
 1460	spinning velvet box	0		
-1461	twirling fuchsia squashed frog	0		
+1461	fuchsia twirling squashed frog	0		
 1462	skewed eye of newt	0		
 1463	squat salamander spleen	0		
 1464	blue sleazy fairy gravy	0		
@@ -1474,10 +1474,10 @@
 1492	Temple Grandin's ninja mop	0		Familiar Weight: +7
 1493	resourceful cool ridiculously overelaborate ninja weapon	0		Moxie: +5, Maximum MP: +50
 1494	adjusted Vulcanized sugar-coated pine cone	0		Effect: "Ooh, Sweet!", Effect Duration: 47, Last Available: "2020-09"
-1495	stiffened wizardly traffic cone	0		Mysticality: +25, Damage Reduction: 1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	stiffened wizardly traffic cone	0		Mysticality: +25, Damage Reduction: 1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	acceptable gloomy mushroom wine	4	good	
-1497	perfectly mixed triple-distilled olive mushroom wine	6	EPIC	
-1498	olive McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1497	triple-distilled perfectly mixed olive mushroom wine	6	EPIC	
+1498	olive McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	bouncing whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	quadruple-adjusted explosion-flavored chewing gum	0		Effect: "You're Not Cooking", Effect Duration: 25, Last Available: "2006-04"
@@ -1509,17 +1509,17 @@
 1528	flame-wreathed beefcake's corkscrew	0		Muscle: +25, Hot Spell Damage: +10, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	wobbly fake plastic grass	0		Last Available: "2011-01"
-1531	gray padded grass skirt	0		Damage Absorption: +20, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	reassuring grass hat	0		Spooky Resistance: +1, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	gray padded grass skirt	0		Damage Absorption: +20, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	reassuring grass hat	0		Spooky Resistance: +1, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	pulsating Usain Bolt's grass blade	0		Initiative: +80, Last Available: "2011-01"
 1534	bouncing twirling raffle prize box	0		
 1536	shaking homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	yellow sparkly engagement ring of courage	0		Spooky Resistance: +3, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	strapping Grimacite goggles of Leguizamo	0		Muscle: +5, Monster Level: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	strapping Grimacite goggles of Leguizamo	0		Muscle: +5, Monster Level: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	jittery careful Grimacite glaive of the dark arts	0		Spell Damage Percent: +100, Monster Level: -10, Last Available: "2008-10"
-1542	frosty lion tamer's Grimacite greaves	0		Experience (familiar): +2, Cold Spell Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	frosty lion tamer's Grimacite greaves	0		Experience (familiar): +2, Cold Spell Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	blurry twirling prompt thinker's Grimacite garter	0		Mysticality: +10, Adventures: +3, Last Available: "2008-10"
 1544	gravedigger's Grimacite galoshes of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Last Available: "2008-10"
 1545	personal trainer's educational Grimacite gorget	0		Experience: +1, Experience Percent (Muscle): +10, Last Available: "2008-10"
@@ -1531,30 +1531,30 @@
 1551	tolerable teal bottle of Domesticated Turkey	3	good	
 1552	hand-crafted bottle of Definit	4	EPIC	
 1553	drinkable bottle of Calcutta Emerald	4	good	
-1554	special lousy bottle of Lieutenant Freeman	3	decent	Effect: "Sugar, Hello", Effect Duration: 45
+1554	lousy special bottle of Lieutenant Freeman	3	decent	Effect: "Sugar, Hello", Effect Duration: 45
 1555	lousy blurry bottle of Jorge Sinsonte	3	decent	
-1556	weak tolerable special boxed champagne	2	good	Effect: "Red Door Syndrome", Effect Duration: 35
+1556	tolerable special weak boxed champagne	2	good	Effect: "Red Door Syndrome", Effect Duration: 35
 1557	special flavorless kumquat	3	decent	Effect: "Pisces in the Skyces", Effect Duration: 10
 1558	thick decent tangerine	5	good	
 1559	narrow tonic water	0		
 1560	decent cocktail onion	4	good	
-1561	big enchanted adequate raspberry	5	good	Effect: "The Halls of Moxiousness", Effect Duration: 5
+1561	big adequate enchanted raspberry	5	good	Effect: "The Halls of Moxiousness", Effect Duration: 5
 1562	decent kiwi	4	good	
 1563	bad ghostly whiskey bittersweet	3	decent	
-1564	high-proof smooth narrow mimosette	6	awesome	
+1564	smooth high-proof narrow mimosette	6	awesome	
 1565	hand-crafted tequila sunset	3	EPIC	
-1566	smooth pulsating blinking zmobie	4	awesome	Wiki Name: "Zmobie (drink)"
-1567	distilled aged gin and tonic	5	awesome	
+1566	smooth blinking pulsating zmobie	4	awesome	Wiki Name: "Zmobie (drink)"
+1567	aged distilled gin and tonic	5	awesome	
 1568	hand-crafted vodka and tonic	4	EPIC	
-1569	fortified artisanal vodka gibson	5	EPIC	
+1569	artisanal fortified vodka gibson	5	EPIC	
 1570	tolerable irresponsibly strong gibson	10	good	
 1571	watered-down perfectly mixed parisian cathouse	2	EPIC	
-1572	weak artisanal rabbit punch	2	EPIC	
+1572	artisanal weak rabbit punch	2	EPIC	
 1573	hand-crafted caipifruta	4	EPIC	
 1574	irresponsibly strong lousy fuchsia teqiwila	10	decent	
 1575	artisanal blinking Divine	3	EPIC	
 1576	delicious Gordon Bennett	3	awesome	
-1577	practically non-alcoholic mediocre tumbling tangarita	1	decent	
+1577	mediocre practically non-alcoholic tumbling tangarita	1	decent	
 1578	artisanal mandarina colada	4	EPIC	
 1579	drinkable gimlet	4	good	
 1580	bad spinning brick road	3	decent	
@@ -1564,14 +1564,14 @@
 1584	artisanal high-proof Mae West	7	EPIC	
 1585	distilled lousy skewed Mon Tiki	5	decent	
 1586	perfectly mixed huge teqiwila slammer	3	EPIC	
-1587	rotten fancy Knob lo mein	4	crappy	Effect: "The Dinsey Way", Effect Duration: 10
-1588	moldy low-calorie asparagus lo mein	1	crappy	
+1587	fancy rotten Knob lo mein	4	crappy	Effect: "The Dinsey Way", Effect Duration: 10
+1588	low-calorie moldy asparagus lo mein	1	crappy	
 1589	immense bland Knoll lo mein	9	decent	
-1590	bland olive shaking lo mein	4	decent	
+1590	bland shaking olive lo mein	4	decent	
 1591	half-sized bland olive lo mein	2	decent	
 1592	snack-sized decent hot hi mein	2	good	
 1593	adequate hi mein	4	good	
-1594	normal bite-sized hi mein	1	good	
+1594	bite-sized normal hi mein	1	good	
 1595	normal skewed hi mein	3	good	
 1596	rotten sleazy hi mein	4	crappy	
 1597	supercharged Junior LAAAAME merit badge	0		Maximum MP Percent: +30, Last Available: "2006-05"
@@ -1592,10 +1592,10 @@
 1612	aerosolized concentrated cordial of concentration	0		Effect: "Thunderspell", Effect Duration: 55
 1613	Usain Bolt's coffin lid	0		Initiative: +80, Damage Reduction: 3
 1614	clever satin shield	0		Maximum MP: +20, Damage Reduction: 5
-1615	groovy Cerebral Cloche	0		Moxie Percent: +10, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	mirror chaotic Cerebral Culottes	0		Spell Critical Percent: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	groovy Cerebral Cloche	0		Moxie Percent: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	mirror chaotic Cerebral Culottes	0		Spell Critical Percent: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	Jeselnik's wizardly Cerebral Crossbow of incineration	0		Mysticality: +25, Hot Spell Damage: +50, Sleaze Damage: +25, Last Available: "2006-06"
-1618	huge huge pulsating ice stein	0		Last Available: "2006-06"
+1618	pulsating huge huge ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
 1620	blurry homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
@@ -1619,7 +1619,7 @@
 1639	ionized wobbly lotion of spookiness	0		Effect: "Fruited", Effect Duration: 56
 1640	improved deionized lotion of stench	0		Effect: "Hyperoffended", Effect Duration: 46
 1641	adjusted lotion of sleaziness	0		Effect: "Concentrated Concentration", Effect Duration: 64
-1642	weak acceptable shaking Grimacite Bock	2	good	Last Available: "2008-11"
+1642	acceptable weak shaking Grimacite Bock	2	good	Last Available: "2008-11"
 1643	gigantic stale wedge of gray cheese	8	decent	Last Available: "2008-11"
 1644	narrow hot and sauce	0		
 1645	and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	adequate foie gras	4	good	
 1652	denatured candy brain	0		Effect: "Cold Blooded", Effect Duration: 39, Last Available: "2020-09"
-1653	wobbly veiny jewel-eyed wizard hat of the bloodbag of the boozehound	0		Maximum HP: 110, Booze Drop: +100, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	wobbly veiny jewel-eyed wizard hat of the bloodbag of the boozehound	0		Maximum HP: 110, Booze Drop: +100, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
 1654	fireproof groovy wad of Crovacite	0		Moxie Percent: +10, Hot Resistance: +3
 1655	beefy collar of extreme caution	0		Muscle: +10, Monster Level: -25
 1656	White Citadel Satisfaction Satchel	0		
@@ -1674,9 +1674,9 @@
 1694	wet pulsating Frogade	0		Effect: "Neutered Nostrils", Effect Duration: 26
 1695	anodized denatured tumbling papotion of papower	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 21
 1696	stale bite-sized royal jelly taco	1	decent	
-1697	bite-sized rotten tofu taco	1	crappy	
+1697	rotten bite-sized tofu taco	1	crappy	
 1698	decent pulsating jumping bean taco	3	good	
-1699	half-sized stale catgut taco	2	decent	
+1699	stale half-sized catgut taco	2	decent	
 1700	flavorless goat cheese taco	4	decent	
 1701	diet normal pr0n taco	1	good	
 1702	pickled denatured upside-down alphabet gum	0		Effect: "Tiki Temerity", Effect Duration: 31
@@ -1740,7 +1740,7 @@
 1761	pulsating hardy dance instructor's foon of foulness	0		Experience Percent (Moxie): +10, Maximum HP: +50
 1762	double-paned coward's foon of fearfulness	0		Monster Level: -20, Cold Resistance: +5
 1763	chaotic foon of fleshiness of the overflowing toilet	0		Spell Critical Percent: +10, Stench Spell Damage: +50
-1764	huge pulsating Spookyraven library key	0		
+1764	pulsating huge Spookyraven library key	0		
 1765	twirling Spookyraven gallery key	0		
 1766	blinking skewed Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
@@ -1754,12 +1754,12 @@
 1775	reassuring dishrag	0		Spooky Resistance: +1
 1776	flavorless stale baguette	4	decent	
 1777	cyan leftovers of indeterminate origin	0		
-1778	thick bland dinner	5	decent	
+1778	bland thick dinner	5	decent	
 1779	katana of wisdom	0		Mysticality: +15
 1780	knitted ram stick	0		Cold Resistance: +3
 1781	tumbling padded enchantlers	0		Damage Absorption: +20, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	gray weightlifter's ram-battering staff of Tarzan	0		Muscle: +15, Experience (Muscle): +3
-1783	small rotten crazy Turkish delight	2	crappy	
+1783	rotten small crazy Turkish delight	2	crappy	
 1784	purple vibrating Newton's Snow Queen Crown	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	manspreader's chaotic banded ga-ga radio	0		Damage Absorption: +100, Spell Critical Percent: +10, Monster Level: +10
 1786	six pack of Mountain Stream	0		
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	perfectly mixed Ram's Face Lager	3	EPIC	
 1791	ram horns	0		
-1792	ruddy wicked Sinatra's Travoltan trousers	0		Experience (Moxie): +5, Spell Damage: +5, Maximum HP Percent: +40, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	ruddy wicked Sinatra's Travoltan trousers	0		Experience (Moxie): +5, Spell Damage: +5, Maximum HP Percent: +40, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	Samson's pool cue of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100
 1794	colloidal non-pickled upside-down handful of hand chalk	0		Effect: "Dreadful Sheen", Effect Duration: 58
 1795	double-paned Counterclockwise Watch	0		Cold Resistance: +5, Single Equip
@@ -1798,8 +1798,8 @@
 1819	eleventh thoracic vertebra	0		
 1820	twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
-1822	bouncing jittery second lumbar vertebra	0		
-1823	fuchsia spinning squat third lumbar vertebra	0		
+1822	jittery bouncing second lumbar vertebra	0		
+1823	fuchsia squat spinning third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
 1825	fifth lumbar vertebra	0		
 1826	red sixth lumbar vertebra	0		
@@ -1808,7 +1808,7 @@
 1829	first caudal vertebra	0		
 1830	second caudal vertebra	0		
 1831	third caudal vertebra	0		
-1832	teal ghostly fourth caudal vertebra	0		
+1832	ghostly teal fourth caudal vertebra	0		
 1833	jittery fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
 1835	ghostly seventh caudal vertebra	0		
@@ -1822,7 +1822,7 @@
 1843	left fifth rib	0		
 1844	left sixth rib	0		
 1845	twirling skewed left seventh rib	0		
-1846	twirling teal left eighth rib	0		
+1846	teal twirling left eighth rib	0		
 1847	left ninth rib	0		
 1848	cyan left tenth rib	0		
 1849	squat left eleventh rib	0		
@@ -1836,7 +1836,7 @@
 1857	right seventh rib	0		
 1858	right eighth rib	0		
 1859	maroon right ninth rib	0		
-1860	blurry mirror right tenth rib	0		
+1860	mirror blurry right tenth rib	0		
 1861	right eleventh rib	0		
 1862	right twelfth rib	0		
 1863	animal pelvis	0		
@@ -1871,7 +1871,7 @@
 1892	blinking left first rear claw	0		
 1893	mirror teal left second rear claw	0		
 1894	shaking left third rear claw	0		
-1895	shaking wobbly left fourth rear claw	0		
+1895	wobbly shaking left fourth rear claw	0		
 1896	green right first rear claw	0		
 1897	narrow right second rear claw	0		
 1898	right third rear claw	0		
@@ -1883,7 +1883,7 @@
 1904	deadly 5-ball of terror	0		Weapon Damage: +5, Spooky Spell Damage: +10
 1905	wobbly reassuring 6-ball of the ox	0		Muscle: +20, Spooky Resistance: +1
 1906	pulsating rock-hard 7-ball	0		Damage Reduction: 5
-1907	tumbling red 8-ball	0		
+1907	red tumbling 8-ball	0		
 1910	hardened Rosewater's clockwork sword of terror	0		Mysticality Percent: +30, Damage Reduction: 3, Spooky Spell Damage: +10
 1911	mansplainer's Sinatra's Herculean clockwork staff	0		Experience (Muscle): +1, Experience (Moxie): +5, Monster Level: +15
 1912	sharpshooter's clockwork crossbow of the sewer of the glutton	0		Critical Hit Percent: +10, Stench Damage: +25, Food Drop: +100
@@ -1896,7 +1896,7 @@
 1919	pulsating English to A. F. U. E. Dictionary	0		
 1920	bouncing bizarre illegible sheet music	0		
 1921	wakizashi of the sewer	0		Stench Damage: +25
-1922	narrow purple gob of wet hair	0		
+1922	purple narrow gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
 1924	bouncing tattered wolf standard	0		
 1925	tattered snake standard	0		
@@ -1923,14 +1923,14 @@
 1946	tumbling smelly cool accordion pin	0		Moxie: +5, Stench Spell Damage: +10, Class: "Accordion Thief", Single Equip
 1947	blinking gray perfumed veiny worn tophat	0		Maximum HP: +10, Stench Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	zippy asbestos-lined tap shoes	0		Hot Resistance: +5, Initiative: +20, Single Equip
-1949	half-sized spoiled Manetwich	2	crappy	
+1949	spoiled half-sized Manetwich	2	crappy	
 1950	mirror bottle of Vangoghbitussin	0		
 1951	lousy shaking bottle of Pinot Renoir	4	decent	
 1952	toothsome desiccated apricot	3	awesome	
 1953	aged flute of flat champagne	3	awesome	
 1954	flavorless jittery dehydrated caviar	4	decent	
 1955	maroon styrofoam peanuts	0		
-1956	practically non-alcoholic lousy snifter of thoroughly aged brandy	1	decent	
+1956	lousy practically non-alcoholic snifter of thoroughly aged brandy	1	decent	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	pulsating tattered scrap of paper	0		
@@ -1950,7 +1950,7 @@
 1973	half of a memo	0		
 1974	ghostly cocoabo	0		
 1975	shaking baby gravy fairy	0		
-1976	skewed blurry lime green narrow gravy fairy	0		
+1976	lime green narrow blurry skewed gravy fairy	0		
 1977	gravy fairy	0		
 1978	gravy fairy	0		
 1979	teal gravy fairy	0		
@@ -1959,7 +1959,7 @@
 1982	MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	ghostly snowy owl	0		
-1985	skewed ghostly scary death orb	0		
+1985	ghostly skewed scary death orb	0		
 1986	narrow mind flayer	0		
 1987	undead elbow macaroni	0		
 1988	maroon angry cow	0		
@@ -2032,11 +2032,11 @@
 2056	cold-filtered adder bladder	0		Effect: "Well-Swabbed Ear", Effect Duration: 26
 2057	pension check	0		
 2058	picnic basket	0		
-2059	cold-filtered squat narrow Black No. 2	0		Effect: "Super Accuracy", Effect Duration: 11
+2059	cold-filtered narrow squat Black No. 2	0		Effect: "Super Accuracy", Effect Duration: 11
 2060	sword of James Dean of the glutton	0		Experience (Moxie): +3, Food Drop: +100
 2061	occult helmet	0		Spell Damage Percent: +25, Familiar Effect: "1xFairy, cap 40"
 2062	Usain Bolt's chaotic shield	0		Spell Critical Percent: +10, Initiative: +80, Damage Reduction: 10
-2063	normal snack-sized blackberry	2	good	
+2063	snack-sized normal blackberry	2	good	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	educational kick-ass kicks of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Single Equip
@@ -2064,12 +2064,12 @@
 2088	chilled pickled blinking Daffy Taffy	0		Effect: "Items Are Forever", Effect Duration: 65
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	frightening foul-smelling resourceful steel-toed forbidden pilgrim shield	0		Spell Damage Percent: +50, Damage Reduction: 10, Maximum MP: +50, Stench Damage: +10, Spooky Damage: +5, Softcore Only, Last Available: "2006-11"
-2091	ghostly bouncing bath salts	0		
+2091	bouncing ghostly bath salts	0		
 2092	blue hand mirror	0		
 2093	greedy hors d'oeuvre tray	0		Meat Drop: +20, Damage Reduction: 5
 2094	flavorless ballroom blintz	4	decent	
 2095	towel	0		
-2096	twisted blurry mirror guy made of bee pollen	1		
+2096	twisted mirror blurry guy made of bee pollen	1		
 2097	17-ball of the pedagogue	0		Experience: +3
 2098	narrow filthy lucre	0		
 2099	hobo gristle	0		
@@ -2079,7 +2079,7 @@
 2103	vial of pirate sweat	0		
 2104	empty aftershave bottle	0		
 2105	mirror coal button	0		
-2106	narrow skewed burned-out arcanodiode	0		
+2106	skewed narrow burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
 2108	rock	0		
 2109	huge stringy sinew	0		Last Available: "2011-12"
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	quilted prehistoric spear	0		Damage Absorption: +40, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	mirror steel-toed deadly fire	0		Weapon Damage: +5, Damage Reduction: 9, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	mirror steel-toed deadly fire	0		Weapon Damage: +5, Damage Reduction: 9, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	sage Grateful Undead T-shirt	0		Mysticality Percent: +10
@@ -2107,13 +2107,13 @@
 2132	beefy incredibly marionette	0		Muscle: +10, Last Available: "2006-12"
 2133	dress ball	0		Last Available: "2010-12"
 2134	spinning grievous mad scientist's sock monkey	0		Weapon Damage Percent: +50, Last Available: "2006-12"
-2135	cyan shaking alien blob	0		Last Available: "2006-12"
+2135	shaking cyan alien blob	0		Last Available: "2006-12"
 2136	greasy electrified vampire duck-on-a-string	0		Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12"
 2137	bouncing up-at-dawn toy crazy train	0		Adventures: +5, Single Equip, Last Available: "2006-12"
 2138	blue razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	toy mercenary	0		Last Available: "2006-12"
 2140	length of string	0		Last Available: "2011-12"
-2141	olive squat toy wheel	0		Last Available: "2011-12"
+2141	squat olive toy wheel	0		Last Available: "2011-12"
 2142	bouncing block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
 2144	evil googly eye	0		Last Available: "2011-12"
@@ -2122,7 +2122,7 @@
 2147	evil teddy bear sewing kit	0		
 2148	upside-down toothsome rock	0		
 2149	super-sized spoiled jittery frank	5	crappy	Last Available: "2011-12"
-2150	super-sized enchanted flavorless plate of franks and beans	5	decent	Effect: "Phoenix, Right?", Effect Duration: 15, Last Available: "2011-12"
+2150	flavorless super-sized enchanted plate of franks and beans	5	decent	Effect: "Phoenix, Right?", Effect Duration: 15, Last Available: "2011-12"
 2151	spirit-forward delicious shot of blackberry schnapps	5	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2133,7 +2133,7 @@
 2158	purple servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	wobbly bi-lateral logic compressor	0		Last Available: "2011-12"
-2161	pulsating fuchsia computronic processing unit	0		Last Available: "2011-12"
+2161	fuchsia pulsating computronic processing unit	0		Last Available: "2011-12"
 2162	skewed tumbling reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	green sub-molecular interocitor	0		Last Available: "2011-12"
 2164	blue recursive spline reticulator	0		Last Available: "2011-12"
@@ -2141,15 +2141,15 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	yellow wicked boxer's toy ray gun	0		Muscle Percent: +10, Spell Damage: +5, Last Available: "2006-12"
-2169	squat fuchsia manspreader's therapeutic toy space helmet	0		Monster Level: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	squat fuchsia manspreader's therapeutic toy space helmet	0		Monster Level: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	squat MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	sizzling astronaut pants of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	sizzling astronaut pants of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	up-at-dawn toy jet pack	0		Adventures: +5, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	blurry mossy stone sphere	0		
-2175	gray wobbly skewed smooth stone sphere	0		
+2175	skewed gray wobbly smooth stone sphere	0		
 2176	cracked stone sphere	0		
-2177	tumbling green rough stone sphere	0		
+2177	green tumbling rough stone sphere	0		
 2178	purple ruddy obsidian dagger	0		Maximum HP Percent: +40
 2179	archaeologist's notebook	0		
 2180	amulet	0		
@@ -2165,36 +2165,36 @@
 2190	squat yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	tumbling book of carols	0		Last Available: "2006-12"
 2192	twirling sheet music	0		Last Available: "2006-12"
-2193	jumbo bland candy stake	5	decent	Last Available: "2006-12"
+2193	bland jumbo candy stake	5	decent	Last Available: "2006-12"
 2194	hand-crafted triple-distilled eggnog	10	EPIC	Last Available: "2006-12"
-2195	delicious immense fancy unspeakable fruitcake	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35, Last Available: "2006-12"
+2195	delicious fancy immense unspeakable fruitcake	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35, Last Available: "2006-12"
 2196	flavorless gingerbread horror	3	decent	Last Available: "2006-12"
 2197	ionized moist squat but probably evil chocolate	0		Effect: "Human-Orc Hybrid", Effect Duration: 21, Last Available: "2006-12"
 2198	huge decent bat-shaped Crimboween cookie	7	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	flavorless fancy skull-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2199	fancy flavorless skull-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	stale huge tombstone-shaped Crimboween cookie	3	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	fuchsia boxer's plastic gift-wrapping vampire	0		Muscle Percent: +10, Last Available: "2006-12"
 2202	plastic yuletide troll of the boozehound	0		Booze Drop: +100, Last Available: "2006-12"
 2203	yellow avaricious plastic skeletal reindeer	0		Meat Drop: +30, Single Equip, Last Available: "2006-12"
 2204	experienced plastic Crimboween pentagram	0		Experience: +2, Single Equip, Last Available: "2006-12"
 2205	deadly plastic Scream Queen	0		Weapon Damage: +5, Last Available: "2006-12"
-2206	ghostly squat time sleigh	0		Free Pull, Last Available: "2006-12"
+2206	squat ghostly time sleigh	0		Free Pull, Last Available: "2006-12"
 2207	Crimbo tiki necklace	0		Item Drop: +5, Last Available: "2006-12"
 2208	blurry prompt bobble-hip hula elf doll of incineration	0		Hot Spell Damage: +50, Adventures: +3, Last Available: "2006-12"
 2209	ghostly Crimbo ukulele of chilblains	0		Cold Damage: +25, Last Available: "2006-12"
-2210	tumbling cool Tiki lighter of the pedagogue	0		Moxie: +5, Experience: +3, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	fuchsia nasty studded deck of tropical cards	0		Damage Absorption: +80, Stench Damage: +5, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	blinking cyan perfumed lard-coated tropical paperweight	0		Sleaze Spell Damage: +25, Stench Resistance: +5, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	tumbling cool Tiki lighter of the pedagogue	0		Moxie: +5, Experience: +3, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	fuchsia nasty studded deck of tropical cards	0		Damage Absorption: +80, Stench Damage: +5, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	blinking cyan perfumed lard-coated tropical paperweight	0		Sleaze Spell Damage: +25, Stench Resistance: +5, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	huge tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	baleful Tropical Crimbo Hat	0		Spell Damage: +25, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	rosewater-soaked Tropical Crimbo Shorts	0		Stench Resistance: +3, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
-2217	bland diet super ka-bob	1	decent	
-2218	yummy immense beer basted brat	6	awesome	
+2215	baleful Tropical Crimbo Hat	0		Spell Damage: +25, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	rosewater-soaked Tropical Crimbo Shorts	0		Stench Resistance: +3, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2217	diet bland super ka-bob	1	decent	
+2218	immense yummy beer basted brat	6	awesome	
 2219	cyan Tropical Crimbo Sword of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-12"
 2220	denatured and Crimboween candy	0		Effect: "Tasting the Rainbow", Effect Duration: 22, Last Available: "2020-09"
 2221	twirling Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	tumbling frightening flame-wreathed liar's pants	0		Hot Spell Damage: +10, Spooky Damage: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	tumbling frightening flame-wreathed liar's pants	0		Hot Spell Damage: +10, Spooky Damage: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	executive groovy juggler's balls	0		Moxie Percent: +10, Meat Drop: +40, Softcore Only, Last Available: "2007-01"
 2224	pink shirt of the ox	0		Muscle: +20, Softcore Only, Last Available: "2007-01"
 2225	twirling familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2229,7 +2229,7 @@
 2255	furry turtle of doom	0		Spooky Spell Damage: +50, Familiar Effect: "2xPotato, 2xFairy, cap 11"
 2256	wizardly furry earmuffs	0		Mysticality: +25
 2257	shellacked banded reinforced furry underpants	0		Damage Absorption: +100, Damage Reduction: 7
-2258	huge blurry &quot;I Love Me, Vol. I&quot;	0		
+2258	blurry huge &quot;I Love Me, Vol. I&quot;	0		
 2259	blurry photograph of God	0		
 2260	hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
@@ -2240,14 +2240,14 @@
 2266	wet stunt nut stew	0		
 2267	squat spinning Mega Gem	0		
 2268	brawny Staff of Fats	0		Muscle Percent: +20
-2269	adequate huge sausage wonton	8	good	
+2269	huge adequate sausage wonton	8	good	
 2270	blurry Usain Bolt's experienced belt	0		Experience: +2, Initiative: +80, Single Equip
 2271	bad skewed bottle of Merlot	4	decent	
-2272	drinkable watered-down bottle of Port	2	good	
-2273	tolerable triple-distilled huge wobbly bottle of Pinot Noir	9	good	
+2272	watered-down drinkable bottle of Port	2	good	
+2273	triple-distilled tolerable huge wobbly bottle of Pinot Noir	9	good	
 2274	fancy tolerable bottle of Zinfandel	3	good	Effect: "Badger Underfoot", Effect Duration: 30
-2275	watered-down enchanted hand-crafted blinking bottle of Marsala	2	EPIC	Effect: "Magically Fingered", Effect Duration: 45
-2276	tolerable high-proof bottle of Muscat	7	good	
+2275	hand-crafted enchanted watered-down blinking bottle of Marsala	2	EPIC	Effect: "Magically Fingered", Effect Duration: 45
+2276	high-proof tolerable bottle of Muscat	7	good	
 2277	pulsating Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
 2279	skewed book	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	non-deionized quadruple-flattened candy heart	0		Effect: "Sepia Tan", Effect Duration: 35, Last Available: "2007-02"
 2305	deionized galvanized cyan pink candy heart	0		Effect: "Savage Beast Inside", Effect Duration: 14, Last Available: "2007-02"
 2306	quantum candy heart	0		Effect: "Mana Tea", Effect Duration: 28, Last Available: "2007-02"
@@ -2298,7 +2298,7 @@
 2324	huge Staff of Ed, almost	0		
 2325	Staff of Ed	0		
 2326	green stone rose	0		
-2327	ionized narrow upside-down can of paint	0		Effect: "Physicali Tea", Effect Duration: 23
+2327	ionized upside-down narrow can of paint	0		Effect: "Physicali Tea", Effect Duration: 23
 2328	drum machine	0		
 2329	handful of confetti	0		
 2330	yellow chocolate-covered diamond-studded roses	0		
@@ -2310,7 +2310,7 @@
 2336	shaking skewed brawny stylish pipe	0		Moxie: +25, Muscle Percent: +20
 2337	Van der Graaf reinforced beaded headband	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	diet bland pudding	1	decent	Wiki Name: "black pudding (food)"
-2339	practically non-alcoholic acceptable skewed Blackfly Chardonnay	1	good	
+2339	acceptable practically non-alcoholic skewed Blackfly Chardonnay	1	good	
 2340	bad teal & tan	3	decent	
 2341	pepper	0		
 2342	decent forest cake	3	good	
@@ -2320,7 +2320,7 @@
 2346	magnetized dry filthworm royal guard scent gland	0		Effect: "Smoking like a Bandit", Effect Duration: 66
 2347	upside-down heart of the filthworm queen	0		
 2348	blue water pipe bomb	0		
-2349	cyan pulsating shaking gas balloon	0		
+2349	shaking cyan pulsating gas balloon	0		
 2350	beer bomb	0		
 2351	gray superamplified boom box	0		
 2352	twirling hardy beefcake's fire poi	0		Muscle: +25, Maximum HP: +50
@@ -2348,7 +2348,7 @@
 2374	banana peel	0		
 2375	adequate banana cream pie	3	good	
 2376	watered-down perfectly mixed banana daiquiri	2	EPIC	
-2377	practically non-alcoholic mediocre bungle in the jungle	1	decent	
+2377	mediocre practically non-alcoholic bungle in the jungle	1	decent	
 2378	banana spritzer	0		
 2379	aerosolized polarized non-modified narrow banana smoothie	0		Effect: "Chlorophyll Flavor", Effect Duration: 57
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2385,7 +2385,7 @@
 2411	blinking broken petri dish	0		
 2412	sammich crust	0		
 2413	triffid bark	0		
-2414	pulsating skewed lint	0		
+2414	skewed pulsating lint	0		
 2415	discarded pacifier	0		
 2416	jittery bounty-hunting helmet of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1.5xFairy, cap 25"
 2417	sizzling bounty-hunting rifle	0		Hot Damage: +10
@@ -2402,20 +2402,20 @@
 2428	boiled irradiated narrow fake blood	0		Effect: "Larger", Effect Duration: 48
 2429	pressed Eau de Guaneau	0		Effect: "Frozen Shoulders", Effect Duration: 29
 2430	flattened bag of lard	0		Effect: "Helping Comes Second", Effect Duration: 68
-2431	chilled mirror blinking bottle of Mystic Shell	0		Effect: "Funky Coal Patina", Effect Duration: 50
+2431	chilled blinking mirror bottle of Mystic Shell	0		Effect: "Funky Coal Patina", Effect Duration: 50
 2432	unsweetened bouncing SPF 451 lip balm	0		Effect: "The Solution", Effect Duration: 55
 2433	colloidal bottle of antifreeze	0		Effect: "Shortened", Effect Duration: 57
-2434	boiled bouncing upside-down blurry eyedrops	0		Effect: "Arresistible", Effect Duration: 68
+2434	boiled bouncing blurry upside-down eyedrops	0		Effect: "Arresistible", Effect Duration: 68
 2435	deionized dry wobbly Dogsgotnonoz pills	0		Effect: "Spooky Blur", Effect Duration: 53
 2436	corrupted altered double-ionized squat donkey flipbook	0		Effect: "Deep-Seated Rage", Effect Duration: 68
 2437	New Cloaca-Cola	0		
 2438	scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
-2441	skewed olive Knob Goblin Encryption Key	0		
+2441	olive skewed Knob Goblin Encryption Key	0		
 2442	jittery Cobb's Knob map	0		
 2443	lime green up-at-dawn smelly pink glowstick	0		Stench Spell Damage: +10, Adventures: +5, Last Available: "2007-03"
-2444	drinkable narrow gray Supernova Champagne	3	good	
+2444	drinkable gray narrow Supernova Champagne	3	good	
 2445	squat Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2474,7 +2474,7 @@
 2501	fuchsia molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
-2504	skewed ghostly gray precious piercing post	0		
+2504	skewed gray ghostly precious piercing post	0		
 2505	huge necklace chain	0		
 2506	maroon beach glass bead	0		
 2507	clay peace-sign bead	0		
@@ -2489,10 +2489,10 @@
 2516	Jack Frost's supercool wrench bracelet	0		Moxie Percent: +20, Cold Spell Damage: +50
 2517	chain necklace of the wise owl of the brazier	0		Mysticality: +20, Hot Spell Damage: +25
 2518	mirror sawblade shield of wisdom	0		Mysticality: +15, Damage Reduction: 11
-2519	weak bad McMillicancuddy's Special Lager	2	decent	
+2519	bad weak McMillicancuddy's Special Lager	2	decent	
 2520	perfectly mixed bouncing melted Jell-o shot	4	EPIC	
 2521	hand-crafted cruelty-free wine	3	EPIC	
-2522	fortified lousy thistle wine	5	decent	
+2522	lousy fortified thistle wine	5	decent	
 2523	tumbling bouncing pulsating megatofu	0		
 2524	displaced fish	0		
 2525	adequate gigantic fish	10	good	
@@ -2504,7 +2504,7 @@
 2531	thick normal gnat lasagna	5	good	
 2532	wobbly pork	0		
 2533	normal pork chop sandwiches	3	good	
-2534	bland jumbo pork casserole	5	decent	
+2534	jumbo bland pork casserole	5	decent	
 2535	adequate pork lasagna	3	good	
 2536	canopic jar	0		
 2537	spice	0		
@@ -2516,15 +2516,15 @@
 2543	aerosolized altered huge tin magnolia	0		Effect: "Red Around the Gills", Effect Duration: 17, Last Available: "2007-05"
 2544	denatured oxidized begpwnia	0		Effect: "No Vertigo", Effect Duration: 39, Last Available: "2007-05"
 2545	improved alkaline cyan upsy daisy	0		Effect: "Macho, Macho Dog", Effect Duration: 17, Last Available: "2007-05"
-2546	unsweetened corrupted blue tumbling half-orchid	0		Effect: "Altered Wavelengths", Effect Duration: 23, Last Available: "2007-05"
+2546	unsweetened corrupted tumbling blue half-orchid	0		Effect: "Altered Wavelengths", Effect Duration: 23, Last Available: "2007-05"
 2547	Herculean educational tin star	0		Experience: +1, Experience (Muscle): +1, Last Available: "2007-05"
-2548	scandalous chaotic outrageous sombrero	0		Spell Critical Percent: +10, Sleaze Damage: +5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	scandalous chaotic outrageous sombrero	0		Spell Critical Percent: +10, Sleaze Damage: +5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	aromatic &quot;Humorous&quot; T-shirt of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +1, Last Available: "2007-05"
 2550	spinning Peppercorns of Power	0		
 2551	upside-down vial of mojo	0		
 2552	reeds	0		
 2553	turtle chain	0		
-2554	maroon shaking distilled seal blood	0		
+2554	shaking maroon distilled seal blood	0		
 2555	narrow high-octane olive oil	0		
 2556	skewed fuchsia sizzling smartaleck's savvy Shagadelic Disco Banjo	0		Mysticality Percent: +20, Moxie Percent: +30, Hot Damage: +10, Class: "Disco Bandit"
 2557	chilly Squeezebox of the Ages of the wise owl	0		Mysticality: +20, Cold Damage: +5, Class: "Accordion Thief", Song Duration: 15
@@ -2559,8 +2559,8 @@
 2586	vibrating General Sage's Lonely Diamonds Club Jacket	0		Maximum MP Percent: +10
 2587	upside-down cool Corporal Fennel's Lonely Clubs Club Jacket	0		Moxie: +5
 2588	smartaleck's Private Pepper's Lonely Hearts Club Jacket	0		Moxie Percent: +30
-2589	massive spoiled hot date	10	crappy	
-2590	drinkable high-proof distilled fortified wine	9	good	
+2589	spoiled massive hot date	10	crappy	
+2590	high-proof drinkable distilled fortified wine	9	good	
 2591	flavorless tasty tart	3	decent	
 2592	Knob Goblin lunchbox	0		
 2593	bland Knob pasty	4	decent	
@@ -2576,7 +2576,7 @@
 2603	shaking smoldering box	0		
 2604	Da Vinci's Tuesday's ruby	0		Experience (Mysticality): +5
 2605	palm frond	0		
-2606	yellow tumbling palm-frond fan	0		
+2606	tumbling yellow palm-frond fan	0		
 2607	palm-frond whip of the wise owl	0		Mysticality: +20
 2608	green palm-frond net	0		
 2609	dangerous palm-frond capris of the storm	0		Weapon Damage: +10, Maximum MP Percent: +40, Familiar Effect: "1.5xGhuol, cap 35"
@@ -2632,8 +2632,8 @@
 2659	family-friendly albatross necklace	0		Sleaze Resistance: +1, Single Equip, Last Available: "2007-06"
 2660	mixed not-a-pipe	1	awesome	Effect: "Musky", Effect Duration: 20, Last Available: "2007-06"
 2661	lousy narrow flask of Amontillado	4	decent	Last Available: "2007-06"
-2662	ball mask of the sewer	0		Stench Damage: +25, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	brawny Can-Can skirt	0		Muscle Percent: +20, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	ball mask of the sewer	0		Stench Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	brawny Can-Can skirt	0		Muscle Percent: +20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	galvanized wobbly sensitive poetry journal	0		Effect: "Employee of the Month", Effect Duration: 18, Last Available: "2007-06"
 2665	polarized irradiated huge spinning bottled inspiration	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 49, Last Available: "2007-06"
 2666	chilled bellhop bell	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 69, Last Available: "2007-06"
@@ -2645,14 +2645,14 @@
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	improved unsweetened bottle of cat tonic	0		Effect: "Gummi Badass", Effect Duration: 11, Last Available: "2007-06"
-2675	twisted narrow tumbling jittery handful of moss	1		
+2675	twisted jittery narrow tumbling handful of moss	1		
 2676	vaporized bit-o-cactus	1		
 2677	mixed spinning protein powder	1		
 2678	huge spectre scepter	0		
 2679	quadruple-moist chilled energized sparkler	0		Effect: "Stinky Hands", Effect Duration: 23
 2680	concentrated snake	0		Effect: "Bustle Hustlin'", Effect Duration: 44, Wiki Name: "snake"
 2681	electrified M-242	0		Effect: "Object Detection", Effect Duration: 34
-2682	lime green pulsating detuned radio	0		
+2682	pulsating lime green detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	skewed Jack Frost's sharpshooter's armgun	0		Critical Hit Percent: +10, Cold Spell Damage: +50
 2685	seashell necklace	0		
@@ -2682,7 +2682,7 @@
 2709	shaking exotic parrot egg	0		
 2710	skewed cracker	0		Familiar Weight: +15
 2711	boiled huge facepaint	0		Effect: "Gummiheart", Effect Duration: 42
-2712	tarnished extra-chilled squat upside-down sheepskin diploma	0		Effect: "Bananas!", Effect Duration: 27
+2712	tarnished extra-chilled upside-down squat sheepskin diploma	0		Effect: "Bananas!", Effect Duration: 27
 2713	double-colloidal Black Body&trade; spray	0		Effect: "Inner Warmth", Effect Duration: 28
 2714	floorboard cruft	0		
 2715	sausage bomb	0		
@@ -2702,9 +2702,9 @@
 2729	spoiled jittery peach	4	crappy	
 2730	bad pulsating plum wine	3	decent	
 2731	bad shot of pear schnapps	4	decent	
-2732	watered-down delicious shot of peach schnapps	2	awesome	
+2732	delicious watered-down shot of peach schnapps	2	awesome	
 2733	stale bunch of square grapes	3	decent	
-2734	miniature rotten huge brown sugar cane	2	crappy	
+2734	rotten miniature huge brown sugar cane	2	crappy	
 2735	bland sandwich of the gods	4	decent	
 2736	smooth watered-down Pan-Dimensional Gargle Blaster	2	awesome	
 2737	compressed shaking leopard-print barbell	1	good	
@@ -2738,10 +2738,10 @@
 2765	Harold's bell	0		
 2766	bowling ball	0		
 2767	moldy Crimbo pie	4	crappy	
-2768	bland diet pear tart	1	decent	
-2769	decent thick peach pie	5	good	
+2768	diet bland pear tart	1	decent	
+2769	thick decent peach pie	5	good	
 2770	polymerized tumbling chunk of rock salt	0		Effect: "Barbecue Saucy", Effect Duration: 41
-2771	cold-filtered cold-filtered wobbly teal handful of pine needles	0		Effect: "Indescribable Flavor", Effect Duration: 13
+2771	cold-filtered cold-filtered teal wobbly handful of pine needles	0		Effect: "Indescribable Flavor", Effect Duration: 13
 2772	steamy ruby	0		
 2773	pulsating glacial sapphire	0		
 2774	unearthly onyx	0		
@@ -2775,10 +2775,10 @@
 2802	flask of Gnomochloric acid	0		
 2803	tumbling jug of Gnomochloric acid	0		
 2804	wet vial of hamethyst juice	0		Effect: "Feeling No Pain", Effect Duration: 15
-2805	adjusted diffused twirling yellow vial of baconstone juice	0		Effect: "Well-preserved", Effect Duration: 66
+2805	adjusted diffused yellow twirling vial of baconstone juice	0		Effect: "Well-preserved", Effect Duration: 66
 2806	pressed frozen vial of porquoise juice	0		Effect: "Tremella Tremens", Effect Duration: 54
 2807	alkaline energized tumbling flask of hamethyst juice	0		Effect: "Moon'd", Effect Duration: 51
-2808	ionized concentrated lime green narrow flask of baconstone juice	0		Effect: "Hopped Up on Goofballs", Effect Duration: 45
+2808	ionized concentrated narrow lime green flask of baconstone juice	0		Effect: "Hopped Up on Goofballs", Effect Duration: 45
 2809	cold-filtered non-cold-filtered flask of porquoise juice	0		Effect: "Sharp Weapon", Effect Duration: 42
 2810	diffused quantum upside-down jug of hamethyst juice	0		Effect: "Stinky Weapon", Effect Duration: 60
 2811	polarized Vulcanized jug of baconstone juice	0		Effect: "What's That Smell?", Effect Duration: 54
@@ -2789,9 +2789,9 @@
 2816	family-friendly Rosewater's Boxers of the sweet-tooth	0		Mysticality Percent: +30, Sleaze Resistance: +1, Candy Drop: +100, Familiar Effect: "1xVolley, 1xLep"
 2817	ghostly Sherlock's dog trainer's grievous Brooch	0		Weapon Damage Percent: +50, Experience (familiar): +1, Item Drop: +25, Single Equip
 2818	Jim Carey's Bracelet of the dark arts of vim and vigor	0		Spell Damage Percent: +100, Maximum HP Percent: +50, Monster Level: +25, Single Equip
-2819	beefy Grimacite gasmask of the wise owl	0		Muscle: +10, Mysticality: +20, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	beefy Grimacite gasmask of the wise owl	0		Muscle: +10, Mysticality: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	narrow wool Grimacite gat of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +1, Last Available: "2008-11"
-2821	tumbling energetic experienced Grimacite gaiters	0		Experience: +2, Maximum MP Percent: +20, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	tumbling energetic experienced Grimacite gaiters	0		Experience: +2, Maximum MP Percent: +20, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	mirror Van der Graaf padded Grimacite gauntlets	0		Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2008-11"
 2823	Grimacite go-go boots of the cougar of courage	0		Moxie: +20, Spooky Resistance: +3, Single Equip, Last Available: "2008-11"
 2824	scorching padded Grimacite girdle	0		Damage Absorption: +20, Hot Damage: +25, Single Equip, Last Available: "2008-11"
@@ -2806,14 +2806,14 @@
 2833	decent star key lime pie	4	good	
 2834	shaking horrifying occult bottle-rocket crossbow of the scaredy-cat	0		Spell Damage Percent: +25, Monster Level: -15, Spooky Damage: +25, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	indie comic hipster glasses of the pedagogue	0		Experience: +3, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
-2836	upside-down mirror wizard action figure	0		Free Pull, Last Available: "2011-12"
+2836	mirror upside-down wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	wobbly ghostly clever wholesome glowstick	0		Maximum HP Percent: +10, Maximum MP: +20, Last Available: "2007-08"
 2839	fireproof Periodical Paintbrush	0		Hot Resistance: +3, Softcore Only
 2840	delicious triple-distilled bottle of cooking sherry	9	awesome	
 2841	spoiled packet of ketchup	4	crappy	
 2842	irresponsibly strong artisanal accidental cider	7	EPIC	
-2843	jumbo flavorless dire fudgesicle	5	decent	
+2843	flavorless jumbo dire fudgesicle	5	decent	
 2844	knitted sharpshooter's navel ring of navel gazing of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, Critical Hit Percent: +10, Cold Resistance: +3, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	pulsating class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2827,7 +2827,7 @@
 2854	bouquet of swamp roses	0		
 2855	shaking Van der Graaf MacGyver's huge mosquito proboscis	0		Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7
 2856	energized diffused swamp lolly	0		Effect: "Disco Concentration", Effect Duration: 43
-2857	nitrogenated irradiated skewed wobbly seegar butt	0		Effect: "Gr8ness", Effect Duration: 34
+2857	nitrogenated irradiated wobbly skewed seegar butt	0		Effect: "Gr8ness", Effect Duration: 34
 2858	bouncing bottled swamp gas	0		
 2859	jittery supercharged sage witch wart	0		Mysticality Percent: +10, Maximum MP Percent: +30
 2860	stale swamp muck	3	decent	
@@ -2917,20 +2917,20 @@
 2945	shaking quilted Da Vinci's party hat	0		Experience (Mysticality): +5, Damage Absorption: +40, Familiar Effect: "4xLep, cap 7"
 2946	blue arcane researcher's supercool V for Vivala mask	0		Moxie Percent: +20, Experience Percent (Mysticality): +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	ghostly The Big Book of Pirate Insults	0		
-2948	enchanted hand-crafted shot of rotgut	3	EPIC	Effect: "BOOsted", Effect Duration: 30
+2948	hand-crafted enchanted shot of rotgut	3	EPIC	Effect: "BOOsted", Effect Duration: 30
 2949	double-frozen jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Horrid, Torrid", Effect Duration: 32
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
 2952	mirror crafty stylish glowstick	0		Moxie: +25, Maximum MP: +10, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	gray huge avaricious tip jar	0		Meat Drop: +30
-2955	bland gigantic huge yam candy	10	decent	
+2955	gigantic bland huge yam candy	10	decent	
 2956	red cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	immense bland tube of cranberry Go-Goo	6	decent	
+2958	bland immense tube of cranberry Go-Goo	6	decent	
 2959	Lo Pan's rum barrel charrrm bracelet	0		Spell Critical Percent: +30
 2960	yummy single-serving herbal stuffing	4	awesome	
-2961	special snack-sized bland bouncing packet of tofurkey gravy	2	decent	Effect: "Hippy Flavor", Effect Duration: 45
+2961	snack-sized bland special bouncing packet of tofurkey gravy	2	decent	Effect: "Hippy Flavor", Effect Duration: 45
 2962	flavorless shaking tofurkey nugget	4	decent	
 2963	blurry rigging shampoo	0		
 2964	ball polish	0		
@@ -2957,7 +2957,7 @@
 2985	double-paned copper ha'penny charrrm bracelet	0		Cold Resistance: +5
 2986	tongue charrrm	0		
 2987	narrow baleful educational tongue charrrm bracelet	0		Experience: +1, Spell Damage: +25, Single Equip
-2988	spinning pulsating bit of clingfilm	0		
+2988	pulsating spinning bit of clingfilm	0		
 2989	clingfilm trousers of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
 2990	ghostly asbestos-lined groovy clingfilm cap	0		Moxie Percent: +10, Hot Resistance: +5, Familiar Effect: "1xVolley, cap 37"
 2991	Sherlock's clingfilm slippers	0		Item Drop: +25, Single Equip
@@ -2986,7 +2986,7 @@
 3014	ornate key	0		
 3015	gilded key	0		
 3016	foot locker	0		
-3017	upside-down spinning ornate chest	0		
+3017	spinning upside-down ornate chest	0		
 3018	gilded chest	0		
 3019	all-purpose cleaner	0		
 3020	pulsating handful of sawdust	0		
@@ -2996,10 +2996,10 @@
 3024	stone pyramid	0		
 3025	enchanted aged corpse on the beach	4	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 20
 3026	acceptable weak cyan corpsetini	2	good	
-3027	high-proof acceptable corpsedriver	7	good	
-3028	lousy weak Corpse Island iced tea	2	decent	
+3027	acceptable high-proof corpsedriver	7	good	
+3028	weak lousy Corpse Island iced tea	2	decent	
 3029	acceptable red-headed corpse	3	good	
-3030	enchanted bad kamicorpse-ee	3	decent	Effect: "Memory of Resilience", Effect Duration: 25
+3030	bad enchanted kamicorpse-ee	3	decent	Effect: "Memory of Resilience", Effect Duration: 25
 3031	mediocre corpsel	3	decent	
 3032	aged corpsebite	4	awesome	
 3033	mirror pirate fledges of James Dean	0		Experience (Moxie): +3
@@ -3025,7 +3025,7 @@
 3053	narrow mood ring	0		Last Available: "2007-02"
 3054	moist magnetized candy heart	0		Effect: "Neutered Nostrils", Effect Duration: 59, Last Available: "2007-02"
 3055	activated corrupted upside-down cymbal syrup	0		Free Pull, Effect: "Inebriate Pride", Effect Duration: 64, Last Available: "2007-02"
-3056	metallic foil cat ears of terror	0		Spooky Spell Damage: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	metallic foil cat ears of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	bouncing iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3057,14 +3057,14 @@
 3085	miser's nippy roboduck-on-a-string	0		Cold Damage: +10, Meat Drop: +10, Last Available: "2007-12"
 3086	teal ghostly mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	smelly experienced biomechanical crimborg helmet	0		Experience: +2, Stench Spell Damage: +10, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	smelly experienced biomechanical crimborg helmet	0		Experience: +2, Stench Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	forbidden C.B.F.G. of Tarzan	0		Experience (Muscle): +3, Spell Damage Percent: +50, Last Available: "2007-12"
-3090	tumbling flame-wreathed biomechanical crimborg leg armor of the scaredy-cat	0		Monster Level: -15, Hot Spell Damage: +10, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	tumbling flame-wreathed biomechanical crimborg leg armor of the scaredy-cat	0		Monster Level: -15, Hot Spell Damage: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	quadruple-unsweetened electrified vitachoconutriment capsule	0		Effect: "Analog Drunk", Effect Duration: 24, Last Available: "2007-12"
 3092	maroon flame-wreathed handmade hobby horse	0		Hot Spell Damage: +10, Last Available: "2007-12"
 3093	scorching ball-in-a-cup	0		Hot Damage: +25, Last Available: "2007-12"
 3094	pulsating Temple Grandin's set of jacks	0		Familiar Weight: +7, Last Available: "2007-12"
-3095	tasty snack-sized fancy laser-broiled pear	2	awesome	Effect: "X-Ray Vision", Effect Duration: 25, Last Available: "2007-12"
+3095	tasty fancy snack-sized laser-broiled pear	2	awesome	Effect: "X-Ray Vision", Effect Duration: 25, Last Available: "2007-12"
 3096	narrow blurry resourceful polyalloy shield of the cheetah	0		Maximum MP: +50, Initiative: +60, Damage Reduction: 9, Last Available: "2007-12"
 3097	cyan fish scaler	0		Last Available: "2007-12"
 3098	purple killing feather	0		Last Available: "2007-12"
@@ -3077,7 +3077,7 @@
 3105	green wool Oprah's immense cyborg hand	0		Maximum MP Percent: +50, Cold Resistance: +1, Last Available: "2007-12"
 3106	blinking Jeselnik's frosty educational cyborg stompin' boot	0		Experience: +1, Cold Spell Damage: +10, Sleaze Damage: +25, Single Equip, Last Available: "2007-12"
 3107	blurry deactivated RoboGoose	0		Last Available: "2007-12"
-3108	blurry mirror overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
+3108	mirror blurry overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
 3111	fuchsia Miniborg laser	0		Last Available: "2007-12"
@@ -3086,9 +3086,9 @@
 3114	wobbly Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	red old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	jittery divine noisemaker	0		Last Available: "2008-01"
-3119	huge jittery divine can of silly string	0		Last Available: "2008-01"
+3119	jittery huge divine can of silly string	0		Last Available: "2008-01"
 3120	narrow divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
@@ -3098,7 +3098,7 @@
 3126	huge hobo nickel	0		
 3127	blue sandcastle	0		
 3128	marshmallow	0		
-3129	super-sized enchanted flavorless roasted marshmallow	5	decent	Effect: "You Know What's Up", Effect Duration: 35
+3129	enchanted super-sized flavorless roasted marshmallow	5	decent	Effect: "You Know What's Up", Effect Duration: 35
 3130	blinking disc	0		Last Available: "2008-01"
 3131	thick adequate tin cup of mulligan stew	5	good	
 3132	energetic fortified flamin' bindle	0		Damage Absorption: +60, Maximum MP Percent: +20
@@ -3129,7 +3129,7 @@
 3157	spinning El Vibrato drone	0		
 3158	twirling sparking El Vibrato drone	0		
 3159	double-diffused tumbling warm El Vibrato drone	0		Effect: "Human-Plant Hybrid", Effect Duration: 59
-3160	electrified enhanced energized ghostly maroon humming El Vibrato drone	0		Effect: "The Q Is Talking To You", Effect Duration: 44
+3160	electrified enhanced energized maroon ghostly humming El Vibrato drone	0		Effect: "The Q Is Talking To You", Effect Duration: 44
 3161	activated narrow mirror El Vibrato drone	0		Effect: "Initiative and Let Die", Effect Duration: 13
 3162	pulsating El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
@@ -3143,7 +3143,7 @@
 3171	nauseating reagent	0		
 3172	evil paper umbrella of horror	0		Spooky Spell Damage: +25
 3173	pickled huge evil vihuela	0		Effect: "Raging Animal", Effect Duration: 68
-3174	low-calorie spoiled special evil boring spaghetti	1	crappy	Effect: "You're Rubber", Effect Duration: 30
+3174	spoiled special low-calorie evil boring spaghetti	1	crappy	Effect: "You're Rubber", Effect Duration: 30
 3175	adequate evil noodles	3	good	
 3176	flavorless evil noodles	3	decent	
 3177	delicious half-sized evil painful penne pasta	2	awesome	
@@ -3152,7 +3152,7 @@
 3180	spoiled maroon evil noodles	3	crappy	
 3181	dry extra-polymerized bouncing evil potion of potency	0		Effect: "Familial Ties", Effect Duration: 28
 3182	irradiated denatured deionized evil libation of liveliness	0		Effect: "Proprie Tea", Effect Duration: 48
-3183	cold-filtered unsweetened pulsating ghostly evil tomato juice of powerful power	0		Effect: "Butt-Rock Hair", Effect Duration: 30
+3183	cold-filtered unsweetened ghostly pulsating evil tomato juice of powerful power	0		Effect: "Butt-Rock Hair", Effect Duration: 30
 3184	quantum evil eyedrops of the ermine	0		Effect: "Coy to the Hurled", Effect Duration: 69
 3185	denatured wobbly evil ointment of the occult	0		Effect: "Patent Alacrity", Effect Duration: 50
 3186	super-colloidal colloidal tumbling evil serum of sarcasm	0		Effect: "The Moxious Madrigal", Effect Duration: 16
@@ -3160,9 +3160,9 @@
 3188	tolerable an evil sump'm sump'm	3	good	
 3189	watered-down lousy evil ducha de oro	2	decent	
 3190	triple-distilled drinkable evil horizontal tango	7	good	
-3191	practically non-alcoholic acceptable shaking evil roll in the hay	1	good	
+3191	acceptable practically non-alcoholic shaking evil roll in the hay	1	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
-3193	skewed blue naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
+3193	blue skewed naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	tumbling yellow origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	wobbly boxer's origami pasties	0		Muscle Percent: +10, Softcore Only, Last Available: "2008-02"
@@ -3196,7 +3196,7 @@
 3224	upside-down sewer wad	0		
 3225	hand-crafted bottle of sewage schnapps	3	EPIC	
 3226	mediocre blurry bottle of Ooze-O	3	decent	
-3227	gigantic moldy C.H.U.M. chum	8	crappy	
+3227	moldy gigantic C.H.U.M. chum	8	crappy	
 3228	delicious unfortunate dumplings	3	awesome	
 3229	gray decaying goldfish liver	0		
 3230	chilled chilled oil of oiliness	0		Effect: "Jungle Juiced", Effect Duration: 30
@@ -3206,7 +3206,7 @@
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
 3236	skewed Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
-3237	red narrow Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
+3237	narrow red Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	skewed Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
@@ -3232,7 +3232,7 @@
 3260	inspector's perfumed Jim Carey's Chester's moustache	0		Monster Level: +25, Stench Resistance: +5, Item Drop: +15, Class: "Disco Bandit", Single Equip
 3261	twirling olive chilly sage Chester's bag of candy	0		Mysticality Percent: +10, Cold Damage: +5, Class: "Disco Bandit"
 3262	supercool Chester's cutoffs of Flo-Jo	0		Moxie Percent: +20, Initiative: +100, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	blinking yellow candygram	0		Last Available: "2008-04"
 3265	fuchsia bag of Crotchety Pine saplings	0		
 3266	wobbly bag of Saccharine Maple saplings	0		
@@ -3240,10 +3240,10 @@
 3268	denatured vacuum-sealed handful of Crotchety Pine needles	0		Effect: "Eyes for Miles", Effect Duration: 60
 3269	vacuum-sealed lump of Saccharine Maple sap	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 46
 3270	activated energized handful of Laughing Willow bark	0		Effect: "Peppermint Bite", Effect Duration: 67
-3271	skewed sizzling crotchety pants	0		Hot Damage: +10, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	skewed sizzling crotchety pants	0		Hot Damage: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	lime green manspreader's Saccharine Maple pendant	0		Monster Level: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	Socratic willowy bonnet	0		Experience (Mysticality): +1, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
-3274	purple blinking flavored foot massage oil	0		Last Available: "2008-04"
+3273	Socratic willowy bonnet	0		Experience (Mysticality): +1, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3274	blinking purple flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
 3277	bouncing Loudmouth Larry Lamprey	0		Last Available: "2008-04"
@@ -3270,7 +3270,7 @@
 3298	olive pretty pink bow	0		
 3299	smiley-face sticker	0		
 3300	farfalle bow tie	0		
-3301	red upside-down jalape&ntilde;o slices	0		
+3301	upside-down red jalape&ntilde;o slices	0		
 3302	skewed stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
 3304	squat Argarggagarg's fang	0		
@@ -3294,7 +3294,7 @@
 3322	green razor-sharp smartaleck's mayfly bait necklace	0		Moxie Percent: +30, Weapon Damage Percent: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	bouncing Frosty's frosty mug	0		
-3325	hand-crafted weak jar of fermented pickle juice	2	super ultra mega turbo EPIC	
+3325	weak hand-crafted jar of fermented pickle juice	2	super ultra mega turbo EPIC	
 3326	distilled squat voodoo snuff	1	EPIC	Effect: "Fireproof Lips", Effect Duration: 45
 3327	stale extra-greasy slider	3	decent	
 3328	teal shaking extremely unsafe stylish crumpled felt fedora	0		Moxie: +25, Weapon Damage Percent: +100, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3303,7 +3303,7 @@
 3331	inspector's lard-coated mostly rat-hide leggings	0		Sleaze Spell Damage: +25, Item Drop: +15, Familiar Effect: "stench atk, 1xPotato"
 3332	coward's quilted hobo dungarees	0		Damage Absorption: +40, Monster Level: -20, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	asbestos-lined patched suit-pants of the pedagogue	0		Experience: +3, Hot Resistance: +5, Familiar Effect: "1xPotato, 0.5xFairy"
-3334	narrow squat hobo stogie	0		Single Equip
+3334	squat narrow hobo stogie	0		Single Equip
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	blurry dead guy's piece of double-sided tape	0		
 3337	mansplainer's dead guy's memento of James Dean	0		Experience (Moxie): +3, Monster Level: +15, Single Equip
@@ -3319,7 +3319,7 @@
 3347	comfy coffin	0		
 3348	blurry mattress	0		
 3349	tumbling dinged-up triangle	0		
-3350	watered-down tolerable Ralph IX cognac	2	good	
+3350	tolerable watered-down Ralph IX cognac	2	good	
 3351	purple llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	green zen motorcycle	0		Last Available: "2008-06"
 3353	nitrogenated llama lama gong	0		Effect: "Ice Packed", Effect Duration: 56, Last Available: "2008-06"
@@ -3367,7 +3367,7 @@
 3395	mirror flame-wreathed Hodgman's porkpie hat of incineration	0		Hot Spell Damage: 60, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	family-friendly slick Hodgman's lobsterskin pants	0		Moxie: +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xPotato"
 3397	studded Hodgman's bow tie of doom	0		Damage Absorption: +80, Spooky Spell Damage: +50, Single Equip
-3398	aged triple-distilled Hodgman's blanket	8	awesome	
+3398	triple-distilled aged Hodgman's blanket	8	awesome	
 3399	bad jar of squeeze	4	decent	
 3400	delicious bowl of fishysoisse	4	awesome	
 3401	pickled deadly lampshade	0		Effect: "Infernal Thirst", Effect Duration: 63
@@ -3382,7 +3382,7 @@
 3410	supercharged Hodgman's detector	0		Maximum MP Percent: +30
 3411	lime green gravedigger's Hodgman's cane	0		Spooky Damage: +10
 3412	upside-down Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
-3413	green mirror mirror Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
+3413	mirror green mirror Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	blinking Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	blinking Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
@@ -3423,7 +3423,7 @@
 3456	fuchsia thinker's trusty torch	0		Mysticality: +10, Last Available: "2011-12"
 3457	Junior Adventurer's merit badge of Gandalf	0		Spell Critical Percent: +20
 3458	quadruple-corrupted electrified wobbly STYX deodorant body spray	0		Effect: "Crimbo Nostalgia", Effect Duration: 12
-3459	lousy bouncing upside-down white-label gin	4	decent	
+3459	lousy upside-down bouncing white-label gin	4	decent	
 3460	flavorless massive tin rations	6	decent	
 3461	squat squat haiku challenge map	0		
 3462	ghostly terrible poem	0		
@@ -3433,7 +3433,7 @@
 3466	Tesla supercharged arcane researcher's haiku katana	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	jittery rosewater-soaked plastic baby	0		Stench Resistance: +3, Single Equip, Last Available: "2008-12"
-3469	moldy massive upside-down blueberry-frosted king cake	7	crappy	Last Available: "2008-12"
+3469	massive moldy upside-down blueberry-frosted king cake	7	crappy	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	prompt asbestos-lined dance instructor's Seasonal Beret	0		Experience Percent (Moxie): +10, Hot Resistance: +5, Adventures: +3, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3453,7 +3453,7 @@
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	huge skewed pristine fish scale	0		
-3489	spoiled special beefy fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
+3489	special spoiled beefy fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
 3490	huge decent glistening fish meat	8	good	Effect: "Fishy", Effect Duration: 5
 3491	miniature bland slick fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3492	lightning-fast flame-retardant fish scimitar	0		Hot Resistance: +1, Initiative: +40
@@ -3461,20 +3461,20 @@
 3494	jittery smartaleck's fish bazooka of the wise owl	0		Mysticality: +20, Moxie Percent: +30
 3495	moist unsweetened sea salt crystal	0		Effect: "Pride of the Vampire", Effect Duration: 14
 3496	improved blurry ghostly bazookafish bubble gum	0		Effect: "Partially Ghosted", Effect Duration: 22
-3497	drinkable practically non-alcoholic bottle of Pete's Sake	1	good	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	mirror witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3501	flavorless enchanted half-sized wobbly canap&eacute;s	2	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 10
+3497	practically non-alcoholic drinkable bottle of Pete's Sake	1	good	
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	mirror witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3501	half-sized flavorless enchanted wobbly canap&eacute;s	2	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 10
 3502	modified blue thermos of brew	1	good	Last Available: "2011-12"
 3503	perfectly mixed glass of brandy	4	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	Jack Frost's LWA ring	0		Cold Spell Damage: +50
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	family-friendly scratch 'n' sniff sword	0		Sleaze Resistance: +1, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
-3510	cyan spinning scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
+3510	spinning cyan scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	wobbly scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	wobbly scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	fuchsia forbidden depleted Grimacite gravy boat of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Last Available: "2011-12"
 3544	flame-wreathed hardened depleted Grimacite weightlifting belt	0		Damage Reduction: 3, Hot Spell Damage: +10, Single Equip, Last Available: "2011-12"
 3545	depleted Grimacite grappling hook of the brazier of the businessman	0		Hot Spell Damage: +25, Meat Drop: +50, Single Equip, Last Available: "2011-12"
-3546	clever smartaleck's depleted Grimacite ninja mask	0		Moxie Percent: +30, Maximum MP: +20, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	sharpshooter's educational depleted Grimacite shinguards	0		Experience: +1, Critical Hit Percent: +10, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	clever smartaleck's depleted Grimacite ninja mask	0		Moxie Percent: +30, Maximum MP: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	sharpshooter's educational depleted Grimacite shinguards	0		Experience: +1, Critical Hit Percent: +10, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	educational cool depleted Grimacite astrolabe	0		Moxie: +5, Experience: +1, Single Equip, Last Available: "2011-12"
 3549	reassuring electrified KoL Con Cinco Pi&ntilde;ata Bat	0		Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2008-09"
 3550	yellow gravedigger's propeller beanie	0		Spooky Damage: +10, Familiar Effect: "atk, cap 7"
@@ -3523,12 +3523,12 @@
 3556	decent fancy sea cucumber	4	good	Effect: "Cancer Rising", Effect Duration: 35
 3557	adequate sea avocado	4	good	
 3558	bland sea lychee	4	decent	
-3559	rotten super-sized sea tangelo	5	crappy	
+3559	super-sized rotten sea tangelo	5	crappy	
 3560	flavorless sea honeydew	3	decent	
-3561	triple-magnetized twirling shaking pressurized potion of puissance	0		Effect: "Pork Power", Effect Duration: 51
+3561	triple-magnetized shaking twirling pressurized potion of puissance	0		Effect: "Pork Power", Effect Duration: 51
 3562	polymerized dry pressurized potion of perspicacity	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 55
 3563	dry teal pressurized potion of pulchritude	0		Effect: "Gyromitra Gymnastics", Effect Duration: 59
-3564	aged extra-dry berry-infused sake	5	awesome	
+3564	extra-dry aged berry-infused sake	5	awesome	
 3565	drinkable yellow citrus-infused sake	4	good	
 3566	bad melon-infused sake	3	decent	
 3567	slab of sponge	0		
@@ -3546,10 +3546,10 @@
 3579	blurry ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	small rotten rice	2	crappy	
-3584	stale jumbo irradiated candy cane	5	decent	Last Available: "2008-12"
+3582	rotten small rice	2	crappy	
+3584	jumbo stale irradiated candy cane	5	decent	Last Available: "2008-12"
 3585	moldy gingerbread mutant bugbear	4	crappy	Last Available: "2008-12"
-3586	perfectly mixed watered-down red oozenog	2	EPIC	Last Available: "2008-12"
+3586	watered-down perfectly mixed red oozenog	2	EPIC	Last Available: "2008-12"
 3587	anodized unsweetened red sugar plum	0		Effect: "Dilated Pupils", Effect Duration: 54, Last Available: "2008-12"
 3588	boiled tumbling sugar banana	0		Effect: "Gummi Badass", Effect Duration: 13, Last Available: "2008-12"
 3589	quadruple-diffused fuchsia sugar lime	0		Effect: "Impregnabili Tea", Effect Duration: 41, Last Available: "2008-12"
@@ -3568,7 +3568,7 @@
 3602	broken diving helmet	0		
 3603	porthole	0		
 3604	rivet	0		
-3605	maroon mirror bubblin' stone	0		
+3605	mirror maroon bubblin' stone	0		
 3606	teal medical-grade wholesome dangerous diving helmet	0		Weapon Damage: +10, Maximum HP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "0.5xPotato"
 3607	clever stiffened aerated diving helmet of the storm	0		Damage Reduction: 1, Maximum MP Percent: +40, Maximum MP: +20, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	upside-down live nautical mine	0		
@@ -3588,8 +3588,8 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	gray chitinous pod	0		Last Available: "2008-12"
 3624	parasitic claw of the bloodbag	0		Maximum HP: +100, Last Available: "2008-12"
-3625	mirror parasitic tentacles of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	parasitic headgnawer of Leguizamo	0		Monster Level: +20, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	mirror parasitic tentacles of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	parasitic headgnawer of Leguizamo	0		Monster Level: +20, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	pulsating wicked parasitic strangleworm	0		Spell Damage: +5, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	mirror olive ribald supercharged elven socks	0		Maximum MP Percent: +30, Sleaze Damage: +10, Last Available: "2008-12"
 3634	narrow zippy aromatic elven gloves	0		Stench Resistance: +1, Initiative: +20, Last Available: "2008-12"
-3635	wobbly toasty curative festive holiday hat	0		Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	wobbly toasty curative festive holiday hat	0		Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	healthy patent shoes of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +20, Last Available: "2008-12"
 3637	skewed Jeselnik's gray bow tie of Leguizamo	0		Monster Level: +20, Sleaze Damage: +25, Last Available: "2008-12"
 3638	experienced penguin thesaurus of the bloodbag	0		Experience: +2, Maximum HP: +100, Last Available: "2008-12"
@@ -3614,19 +3614,19 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	fancy rotten spinning toast with jam	4	crappy	Effect: "Cancer Rising", Effect Duration: 30, Last Available: "2008-12"
-3651	cyan antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	cyan antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	perfectly mixed elven moonshine	4	EPIC	Last Available: "2008-12"
-3653	jumbo rotten knuckle sandwich	5	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	rotten jumbo knuckle sandwich	5	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	sage psycho sweater of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Last Available: "2008-12"
-3655	spinning lime green fin-bit wax	0		Familiar Weight: +5
+3655	lime green spinning fin-bit wax	0		Familiar Weight: +5
 3656	Socratic plastic Mob Penguin	0		Experience (Mysticality): +1, Last Available: "2008-12"
 3657	padded plastic mutant elf	0		Damage Absorption: +20, Last Available: "2008-12"
 3658	flame-retardant plastic fat stack of cash	0		Hot Resistance: +1, Last Available: "2008-12"
 3659	plastic strand of DNA of the wise owl	0		Mysticality: +20, Last Available: "2008-12"
 3660	therapeutic plastic chunk of depleted Grimacite	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-12"
 3661	maroon container of Putty	0		Last Available: "2009-01"
-3662	brawny Putty mitre	0		Muscle Percent: +20, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	perfumed dance instructor's Putty leotard	0		Experience Percent (Moxie): +10, Stench Resistance: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	brawny Putty mitre	0		Muscle Percent: +20, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	perfumed dance instructor's Putty leotard	0		Experience Percent (Moxie): +10, Stench Resistance: +5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	Putty ball of the dark arts	0		Spell Damage Percent: +100, Softcore Only, Last Available: "2009-01"
 3665	wobbly red Putty sheet	0		Last Available: "2009-01"
 3666	huge lime green up-at-dawn crafty Putty snake of horror	0		Maximum MP: +10, Spooky Spell Damage: +25, Adventures: +5, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	jittery therapeutic glow-in-the-dark burrowgrub	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	delicious can of franks 'n' beans	3	awesome	Last Available: "2010-12"
-3673	enchanted weak perfectly mixed bottle of peppermint schnapps	2	EPIC	Effect: "Flagrantly Fragrant", Effect Duration: 10, Last Available: "2010-12"
+3673	perfectly mixed enchanted weak bottle of peppermint schnapps	2	EPIC	Effect: "Flagrantly Fragrant", Effect Duration: 10, Last Available: "2010-12"
 3674	jittery throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	spinning Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
@@ -3650,7 +3650,7 @@
 3684	flavorless tempura carrot	3	decent	
 3685	decent tiny lime green tempura cucumber	1	good	
 3686	spoiled wobbly tempura avocado	3	crappy	
-3687	fancy rotten jumbo upside-down sea broccoli	5	crappy	Effect: "Cheered Up", Effect Duration: 45
+3687	rotten jumbo fancy upside-down sea broccoli	5	crappy	Effect: "Cheered Up", Effect Duration: 45
 3688	rotten bouncing sea cauliflower	3	crappy	
 3689	stale squat tempura broccoli	3	decent	
 3690	flavorless tempura cauliflower	4	decent	
@@ -3711,10 +3711,10 @@
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	mirror vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
-3749	extra-tarnished moist ghostly shaking concoction of clumsiness	0		Effect: "Scarysauce", Effect Duration: 64
+3749	extra-tarnished moist shaking ghostly concoction of clumsiness	0		Effect: "Scarysauce", Effect Duration: 64
 3750	Annie Oakley's vampire pearl earring	0		Critical Hit Percent: +20, Single Equip
 3751	delicious chocolate chip brownies	3	awesome	
-3753	pulsating Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	pulsating Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	flattened quadruple-oxidized squat love song of vague ambiguity	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 57, Last Available: "2009-02"
 3755	boiled spinning love song of smoldering passion	0		Effect: "Memory of Attractiveness", Effect Duration: 41, Last Available: "2009-02"
 3756	double-wet narrow love song of icy revenge	0		Effect: "Superheroic", Effect Duration: 37, Last Available: "2009-02"
@@ -3725,7 +3725,7 @@
 3761	blinking savvy vampire pearl ring	0		Mysticality Percent: +20, Single Equip
 3762	Rosewater's vampire pearl necklace	0		Mysticality Percent: +30, Single Equip
 3763	perfectly mixed irresponsibly strong bouncing slug of vodka	8	EPIC	
-3764	hand-crafted practically non-alcoholic slug of rum	1	EPIC	
+3764	practically non-alcoholic hand-crafted slug of rum	1	EPIC	
 3765	hand-crafted upside-down slug of shochu	4	EPIC	
 3766	mediocre irresponsibly strong screwdiver	7	decent	
 3767	bad dew yoana lei	3	decent	
@@ -3733,10 +3733,10 @@
 3769	artisanal salacious screwdiver	4	EPIC	
 3770	bad dew yoana salacious lei	4	decent	
 3771	drinkable salacious lychee chuhai	3	good	
-3772	triple-distilled artisanal shaking ghostly Alewife&trade; Ale	10	EPIC	
+3772	artisanal triple-distilled shaking ghostly Alewife&trade; Ale	10	EPIC	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
-3775	pulsating lime green Mer-kin pinkslip	0		
+3775	lime green pulsating Mer-kin pinkslip	0		
 3776	ruddy wicked pink pinkslip slip	0		Spell Damage: +5, Maximum HP Percent: +40, Familiar Effect: "1xVolley, 1xBarrr"
 3777	scorching sea salt scrubs of Leguizamo	0		Monster Level: +20, Hot Damage: +25
 3778	Jeselnik's hardened savvy amber aviator shades	0		Mysticality Percent: +20, Damage Reduction: 3, Sleaze Damage: +25, Single Equip
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	jittery Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	lard-coated Mer-kin roundshield of James Dean	0		Experience (Moxie): +3, Sleaze Spell Damage: +25, Item Drop: +5, Damage Reduction: 14
 3804	sizzling energetic Mer-kin breastplate	0		Maximum MP Percent: +20, Hot Damage: +10
 3805	nippy Tesla Mer-kin sneakmask	0		Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3764,11 +3764,11 @@
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	teal Mer-kin stashbox	0		
-3812	small normal spinning chocolate-frosted king cake	2	good	Last Available: "2009-06"
+3812	normal small spinning chocolate-frosted king cake	2	good	Last Available: "2009-06"
 3813	horrifying plastic baby	0		Spooky Damage: +25, Single Equip, Last Available: "2009-06"
 3815	narrow midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	half-sized normal fancy sea radish	2	good	Effect: "Cold as Ice", Effect Duration: 25
+3817	fancy half-sized normal sea radish	2	good	Effect: "Cold as Ice", Effect Duration: 25
 3818	twirling reassuring therapeutic padded halibut	0		Damage Absorption: +20, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 3819	eel sauce	0		
 3820	Usain Bolt's water-polo mitt	0		Initiative: +80, Single Equip
@@ -3782,8 +3782,8 @@
 3828	Grandma's Map	0		
 3829	moldy tempura radish	3	crappy	
 3830	water-polo cap of wisdom	0		Mysticality: +15, Familiar Effect: "1xVolley, 1xBarrr"
-3831	perfectly mixed watered-down Typical Tavern swill	2	EPIC	
-3832	weak drinkable tropical swill	2	good	
+3831	watered-down perfectly mixed Typical Tavern swill	2	EPIC	
+3832	drinkable weak tropical swill	2	good	
 3833	tolerable wobbly fruity girl swill	3	good	
 3834	drinkable blended swill	4	good	
 3835	costume wardrobe	0		Softcore Only
@@ -3812,7 +3812,7 @@
 3858	rock-hard bone flute	0		Damage Reduction: 5
 3859	infernal fife of incineration	0		Hot Spell Damage: +50
 3860	maroon scandalous charming flute	0		Sleaze Damage: +5
-3861	maroon upside-down pulsating leaf of grass	0		
+3861	upside-down maroon pulsating leaf of grass	0		
 3862	Temple Grandin's therapeutic grass whistle	0		Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7
 3863	green vibrating quilted plastic guitar	0		Damage Absorption: +40, Maximum MP Percent: +10
 3864	fuchsia finger cymbals of wisdom	0		Mysticality: +15
@@ -3833,7 +3833,7 @@
 3879	torn hellseal sinew	0		
 3880	hellseal disguise	0		
 3881	censurious beefcake's fouet de tortue-dressage	0		Muscle: +25, Sleaze Resistance: +3, Conditional Skill (Equipped): "Apprivoisez la tortue"
-3882	spinning bouncing encoded cult documents	0		
+3882	bouncing spinning encoded cult documents	0		
 3883	cult memo	0		
 3884	tumbling decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	non-chilled improved vial of slime	0		Effect: "Bottle in front of Me", Effect Duration: 22
@@ -3862,7 +3862,7 @@
 3910	shaking figurine of a seal	0		Class: "Seal Clubber"
 3911	twirling figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	mediocre watered-down blended swill with a fly in it	2	decent	
+3913	watered-down mediocre blended swill with a fly in it	2	decent	
 3914	squat turtle wax	0		
 3915	blue sinister turtle wax shield	0		Spell Damage: +10, Damage Reduction: 2
 3916	turtle wax helmet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3902,8 +3902,8 @@
 3950	key	0		
 3951	Baron von Ratsworth	0		
 3952	monocle	0		
-3953	ghostly spinning mink	0		
-3954	shaking blue teddy butler	0		
+3953	spinning ghostly mink	0		
+3954	blue shaking teddy butler	0		
 3955	martini	0		
 3956	crazy bastard sword	0		
 3957	shaking tin of caviar	0		
@@ -3948,7 +3948,7 @@
 3996	boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	metrognome	0		Familiar Weight: +5
-3999	blue twirling infant sandworm	0		Free Pull, Last Available: "2011-12"
+3999	twirling blue infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	modified mirror agua de vida	1	good	Effect: "Chalk Outline", Effect Duration: 30, Last Available: "2009-06"
 4002	narrow frosty Van der Graaf tortoboggan shield	0		Cold Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 6
@@ -3990,15 +3990,15 @@
 4038	practically non-alcoholic tolerable wobbly slimy fermented bile bladder	1	good	
 4039	mixed green slimy alveolus	1		Effect: "Serendipi Tea", Effect Duration: 10
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	skewed pig-iron helm of James Dean of temperance	0		Experience (Moxie): +3, Sleaze Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	Usain Bolt's pig-iron shinguards of extreme caution	0		Monster Level: -25, Initiative: +80, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	skewed pig-iron helm of James Dean of temperance	0		Experience (Moxie): +3, Sleaze Resistance: +5, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	Usain Bolt's pig-iron shinguards of extreme caution	0		Monster Level: -25, Initiative: +80, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	rosewater-soaked pig-iron bracers of chilblains	0		Cold Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2009-06"
 4044	mirror wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	narrow wumpus-hair whip of the cheetah	0		Initiative: +60, Last Available: "2009-06"
-4048	greasy smelly beefy wumpus-hair wig	0		Muscle: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	savvy wumpus-hair loincloth of the brazier of terror	0		Mysticality Percent: +20, Hot Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	greasy smelly beefy wumpus-hair wig	0		Muscle: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	savvy wumpus-hair loincloth of the brazier of terror	0		Mysticality Percent: +20, Hot Spell Damage: +25, Spooky Spell Damage: +10, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	jittery baleful sinister wumpus-hair sweater	0		Spell Damage: 35, Last Available: "2009-06"
 4051	therapeutic ring of teleportation	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
 4052	glass of baboon milk	1	decent	Last Available: "2009-06"
@@ -4011,7 +4011,7 @@
 4059	spinning beefcake's stone head	0		Muscle: +25, Damage Reduction: 5, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	skewed Violet Hunt Invitation	0		Last Available: "2009-06"
-4062	pulsating shaking Blue Milk Club Card	0		Last Available: "2009-06"
+4062	shaking pulsating Blue Milk Club Card	0		Last Available: "2009-06"
 4063	squat Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	spinning Spacefleet Communicator Badge	0		Last Available: "2009-06"
@@ -4023,7 +4023,7 @@
 4071	essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	jittery Supreme Being Glossary	0		Last Available: "2009-06"
-4074	ghostly red multi-pass	0		Last Available: "2009-06"
+4074	red ghostly multi-pass	0		Last Available: "2009-06"
 4075	mansplainer's Fonzie's villainous scythe	0		Experience (Moxie): +1, Monster Level: +15, Slime Hates It: +2
 4076	baneful bandolier of Calamity Jane of chilblains	0		Critical Hit Percent: +15, Cold Damage: +25, Slime Hates It: +1
 4077	crafty diabolical crossbow of the brazier	0		Maximum MP: +10, Hot Spell Damage: +25, Slime Hates It: +1
@@ -4084,7 +4084,7 @@
 4132	triple-distilled mediocre sham champagne	9	decent	Last Available: "2009-06"
 4133	frozen tempura air	0		Effect: "Human-Beast Hybrid", Effect Duration: 14
 4134	non-nitrogenated extra-concentrated huge pressurized potion of pneumaticity	0		Effect: "Egg on your Face", Effect Duration: 26
-4135	narrow skewed moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
+4135	skewed narrow moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	gray frightening stanky Tesla dangerous Bag o' Tricks	0		Weapon Damage: +10, Stench Spell Damage: +25, Spooky Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	maroon slime stack	0		
 4138	blue a rumpled paper strip	0		
@@ -4130,8 +4130,8 @@
 4178	squat Sherlock's sugar shotgun	0		Item Drop: +25, Last Available: "2009-09"
 4179	educational sugar shillelagh	0		Experience: +1, Last Available: "2009-09"
 4180	Sinatra's sugar shank	0		Experience (Moxie): +5, Last Available: "2009-09"
-4181	cyan skewed miser's ruddy studded sugar chapeau	0		Damage Absorption: +80, Maximum HP Percent: +40, Meat Drop: +10, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	twirling pulsating shellacked sugar shorts	0		Damage Reduction: 7, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	cyan skewed miser's ruddy studded sugar chapeau	0		Damage Absorption: +80, Maximum HP Percent: +40, Meat Drop: +10, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	twirling pulsating shellacked sugar shorts	0		Damage Reduction: 7, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	fuchsia slime convention swag bag	0		
 4185	skewed slime convention flyers	0		
@@ -4166,22 +4166,22 @@
 4214	spangly unitard	0		
 4215	blurry Jack Frost's collapsible baton of the cougar	0		Moxie: +20, Cold Spell Damage: +50
 4216	groupie lipstick	0		
-4217	twirling blurry purple groupie bra	0		
+4217	blurry purple twirling groupie bra	0		
 4218	pressed mirror groupie spangles	0		Effect: "You Drank Fish Wine", Effect Duration: 12
 4219	horrifying Lo Pan's skate board	0		Spell Critical Percent: +30, Spooky Damage: +25
 4220	twirling S.A.V.E. flyer	0		
 4221	lime green baleful yield shield	0		Spell Damage: +25, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
-4223	cyan wobbly tumbling squamous polyp	0		Free Pull, Last Available: "2011-12"
+4223	cyan tumbling wobbly squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	roller skate doll	0		
 4226	shaking Star of Bravery of terror	0		Spooky Spell Damage: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	narrow olive amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	narrow olive amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	spinning upside-down ice skate decoy	0		
-4232	narrow jittery blurry ice skate doll	0		
+4232	jittery blurry narrow ice skate doll	0		
 4233	huge hacienda key	0		
 4234	spinning resourceful pat&eacute; knife	0		Maximum MP: +50
 4235	salt-shaker	0		
@@ -4197,7 +4197,7 @@
 4245	narrow bookmark	0		
 4246	blurry Lo Pan's ivory cue ball	0		Spell Critical Percent: +30
 4247	hand-crafted purple decanter of fine Scotch	3	super EPIC	
-4248	pickled blinking upside-down expensive cigar	1		Effect: "Meatwise", Effect Duration: 25
+4248	pickled upside-down blinking expensive cigar	1		Effect: "Meatwise", Effect Duration: 25
 4249	twirling tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
@@ -4207,14 +4207,14 @@
 4255	gray Wolfman Nardz	0		Last Available: "2009-10"
 4256	corrupted dry activated lime green sap	0		Effect: "Chorale of Companionship", Effect Duration: 62, Last Available: "2009-10"
 4257	bouncing petrified wood	0		Last Available: "2009-10"
-4258	toothsome small chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
-4259	special weak delicious spinning mulled cider	2	awesome	Effect: "Squirming Like a Toad", Effect Duration: 30, Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4258	small toothsome chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
+4259	weak delicious special spinning mulled cider	2	awesome	Effect: "Squirming Like a Toad", Effect Duration: 30, Last Available: "2009-10"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	bouncing bark boxers of the detective	0		Item Drop: +20, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	pulsating MacGyver's bark beret	0		Maximum MP: +100, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	bouncing bark boxers of the detective	0		Item Drop: +20, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	pulsating MacGyver's bark beret	0		Maximum MP: +100, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	mirror nippy bark bracelet	0		Cold Damage: +10, Single Equip
 4267	jittery knitted hale Krakrox's Loincloth	0		Maximum HP: +20, Cold Resistance: +3, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	shaking scorching Galapagosian Cuisses of incineration	0		Hot Damage: +25, Hot Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	skewed dog trainer's Ass-Stompers of Violence of the pedagogue of the blizzard	0		Experience: +3, Experience (familiar): +1, Cold Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	avaricious Rosewater's beefcake's Brand of Violence	0		Muscle: +25, Mysticality Percent: +30, Meat Drop: +30, Conditional Skill (Equipped): "Brand"
 4299	blinking gravedigger's extremely unsafe Novelty Belt Buckle of Violence of the brazier	0		Weapon Damage Percent: +100, Hot Spell Damage: +25, Spooky Damage: +10, Single Equip
-4300	knitted Da Vinci's Lens of Violence of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5, Cold Resistance: +3, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	knitted Da Vinci's Lens of Violence of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5, Cold Resistance: +3, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	teal family-friendly therapeutic Pigsticker of Violence of chilblains	0		Cold Damage: +25, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
-4302	wobbly spinning clever steel-toed brawny Jodhpurs of Violence	0		Muscle Percent: +20, Damage Reduction: 9, Maximum MP: +20, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	wobbly spinning clever steel-toed brawny Jodhpurs of Violence	0		Muscle Percent: +20, Damage Reduction: 9, Maximum MP: +20, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	avaricious supercool groovy Cold Stone of Hatred	0		Moxie Percent: 30, Meat Drop: +30, Conditional Skill (Equipped): "Chilling Grip"
 4304	fireproof dance instructor's Girdle of Hatred of the brute	0		Muscle Percent: +30, Experience Percent (Moxie): +10, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	bouncing frightening baleful strapping Staff of Simmering Hatred	0		Muscle: +5, Spell Damage: +25, Spooky Damage: +5
-4306	Lo Pan's Pantaloons of Hatred of incineration of the businessman	0		Spell Critical Percent: +30, Hot Spell Damage: +50, Meat Drop: +50, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	Lo Pan's Pantaloons of Hatred of incineration of the businessman	0		Spell Critical Percent: +30, Hot Spell Damage: +50, Meat Drop: +50, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	chaotic clever shellacked Fuzzy Slippers of Hatred	0		Damage Reduction: 7, Maximum MP: +20, Spell Critical Percent: +10, Single Equip
-4308	twirling rosy-cheeked brawny Lens of Hatred of the ox	0		Muscle: +20, Muscle Percent: +20, Maximum HP Percent: +30, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	twirling rosy-cheeked brawny Lens of Hatred of the ox	0		Muscle: +20, Muscle Percent: +20, Maximum HP Percent: +30, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	prompt educational Treads of Loathing	0		Experience: +1, Item Drop: +5, Adventures: +3, Single Equip
 4310	stanky shellacked Scepter of Loathing of the ox	0		Muscle: +20, Damage Reduction: 7, Stench Spell Damage: +25
 4311	MacGyver's rock-hard Belt of Loathing of doom	0		Damage Reduction: 5, Maximum MP: +100, Spooky Spell Damage: +50, Single Equip
@@ -4298,8 +4298,8 @@
 4346	skewed plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	personal trainer's snow hat	0		Experience Percent (Muscle): +10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	scorching snow pants	0		Hot Damage: +25, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	personal trainer's snow hat	0		Experience Percent (Muscle): +10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	scorching snow pants	0		Hot Damage: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	grievous snow belly	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2009-12"
 4352	maroon pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4310,18 +4310,18 @@
 4358	squat A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	tasty expired can of franks 'n' beans	3	awesome	Last Available: "2009-12"
-4361	practically non-alcoholic perfectly mixed expired bottle of peppermint schnapps	1	super ultra mega EPIC	Last Available: "2009-12"
+4361	perfectly mixed practically non-alcoholic expired bottle of peppermint schnapps	1	super ultra mega EPIC	Last Available: "2009-12"
 4362	spinning snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	narrow elf resistance button	0		Last Available: "2009-12"
 4364	deionized maroon elven suicide capsule	0		Effect: "Disco State of Mind", Effect Duration: 59, Last Available: "2009-12"
-4365	snack-sized rotten penguin focaccia bread	2	crappy	Last Available: "2009-12"
-4366	irresponsibly strong drinkable herringcello	10	good	Last Available: "2009-12"
-4367	acceptable weak elven cellocello	2	good	Last Available: "2009-12"
+4365	rotten snack-sized penguin focaccia bread	2	crappy	Last Available: "2009-12"
+4366	drinkable irresponsibly strong herringcello	10	good	Last Available: "2009-12"
+4367	weak acceptable elven cellocello	2	good	Last Available: "2009-12"
 4368	blurry wrench handle	0		Last Available: "2009-12"
 4369	jittery handful of headless bolts	0		Last Available: "2009-12"
 4370	narrow bottle of agitprop ink	0		Last Available: "2009-12"
 4371	gray handful of wires	0		Last Available: "2009-12"
-4372	maroon tumbling chunk of cement	0		Last Available: "2009-12"
+4372	tumbling maroon chunk of cement	0		Last Available: "2009-12"
 4373	twirling grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
@@ -4337,19 +4337,19 @@
 4385	twirling fortified pocketwatch on a chain of the cheetah	0		Damage Absorption: +60, Initiative: +60, Last Available: "2009-12"
 4386	sharpshooter's cement sandals of the cheetah	0		Critical Hit Percent: +10, Initiative: +60, Single Equip, Last Available: "2009-12"
 4387	skewed medical-grade night-vision goggles of the boozehound	0		Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	jittery electrified peanut brittle shield	0		MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 3, Last Available: "2009-12"
 4390	up-at-dawn Herculean Red Rover BB gun	0		Experience (Muscle): +1, Adventures: +5, Last Available: "2009-12"
 4391	dangerous red-and-green sweater	0		Weapon Damage: +10, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
-4393	triple-adjusted skewed maroon Crimbo peppermint bark	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2009-12"
+4393	triple-adjusted maroon skewed Crimbo peppermint bark	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2009-12"
 4394	ionized altered bouncing Crimbo fudge	0		Effect: "Unusual Fashion Sense", Effect Duration: 45, Last Available: "2009-12"
 4395	ionized deionized Crimbo pecan	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 33, Last Available: "2009-12"
 4396	narrow Jack-in-the-box	0		Last Available: "2009-12"
 4397	blinking crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	zippy cheese sword	0		Initiative: +20, Softcore Only, Last Available: "2010-01"
-4400	sinister cheese diaper	0		Spell Damage: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	sinister cheese diaper	0		Spell Damage: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	cheese wheel of the cougar	0		Moxie: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	huge squat wholesome cheese eye	0		Maximum HP Percent: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	blinking tumbling censurious chaotic Staff of Queso Escusado of the ox	0		Muscle: +20, Spell Critical Percent: +10, Sleaze Resistance: +3, Softcore Only, Last Available: "2010-01"
@@ -4360,8 +4360,8 @@
 4409	green Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	massive tasty quantum taco	0		Last Available: "2010-10"
-4413	drinkable spirit-forward Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	tasty massive quantum taco	0		Last Available: "2010-10"
+4413	spirit-forward drinkable Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	dog trainer's sealhide hood	0		Experience (familiar): +1, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	sealhide leggings of the businessman	0		Meat Drop: +50, Familiar Effect: "1xVolley, cap 40"
@@ -4396,7 +4396,7 @@
 4448	dried Instant Karma	1	good	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	blurry map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	pointy hat of the bloodbag	0		Maximum HP: +100, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	pointy hat of the bloodbag	0		Maximum HP: +100, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	machetito of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-04"
 4453	tumbling nippy lawnmower blade	0		Cold Damage: +10, Last Available: "2010-04"
 4454	upside-down grass clippings	0		Last Available: "2023-12"
@@ -4413,17 +4413,17 @@
 4465	double-energized twirling chocolate saucepan	0		Effect: "Fancy Feasted", Effect Duration: 34
 4466	quantum chocolate disco ball	0		Effect: "Berry Statistical", Effect Duration: 41
 4467	liquefied chocolate stolen accordion	0		Effect: "Medieval Mage Mayhem", Effect Duration: 17
-4468	blinking Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	blinking Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	BRICKO hat of the blizzard	0		Cold Spell Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	fuchsia aromatic BRICKO pants	0		Stench Resistance: +1, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	BRICKO hat of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	fuchsia aromatic BRICKO pants	0		Stench Resistance: +1, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	Oprah's BRICKO sword	0		Maximum MP Percent: +50, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
-4478	fuchsia spinning BRICKO elephant	0		Last Available: "2010-02"
+4478	spinning fuchsia BRICKO elephant	0		Last Available: "2010-02"
 4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
@@ -4441,12 +4441,12 @@
 4493	broken BRICKO brick	0		Last Available: "2010-02"
 4494	BRICKO reactor	0		Last Available: "2010-02"
 4495	huge BRICKO egg	0		Last Available: "2010-02"
-4496	upside-down olive ghostly extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
+4496	ghostly olive upside-down extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	concentrated modified recording of The Ballad of Richie Thingfinder	0		Effect: "Ancestral Disapproval", Effect Duration: 32
 4498	colloidal extra-pressed recording of Benetton's Medley of Diversity	0		Effect: "X-Ray Vision", Effect Duration: 55
 4499	chilled recording of Elron's Explosive Etude	0		Effect: "Space Tripping", Effect Duration: 40
 4500	electrified nitrogenated spinning recording of Chorale of Companionship	0		Effect: "Transcendental Wind", Effect Duration: 57
-4501	tarnished anodized maroon skewed recording of Prelude of Precision	0		Effect: "Neuroplastici Tea", Effect Duration: 32
+4501	tarnished anodized skewed maroon recording of Prelude of Precision	0		Effect: "Neuroplastici Tea", Effect Duration: 32
 4502	vacuum-sealed pickled recording of Donho's Bubbly Ballad	0		Effect: "Rage of the Reindeer", Effect Duration: 13
 4503	tarnished recording of Inigo's Incantation of Inspiration	0		Effect: "Holiday Disappointment", Effect Duration: 11, Last Available: "2010-02"
 4504	Van der Graaf beefcake's heart of the volcano	0		Muscle: +25, MP Regen Min: 5, MP Regen Max: 7
@@ -4456,36 +4456,36 @@
 4508	deionized unsweetened warmed &quot;DRINK ME&quot; potion	0		Effect: "Haunted Liver", Effect Duration: 45, Last Available: "2010-03"
 4509	yellow reflection of a map	0		Last Available: "2010-03"
 4510	moldy special walrus ice cream	4	crappy	Effect: "Sleazy Jellied", Effect Duration: 20, Last Available: "2010-03"
-4511	miniature rotten beautiful soup	2	crappy	Last Available: "2010-03"
+4511	rotten miniature beautiful soup	2	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	upside-down Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	stale big Humpty Dumplings	5	decent	Last Available: "2010-03"
+4514	big stale Humpty Dumplings	5	decent	Last Available: "2010-03"
 4515	adequate Lobster <i>qua</i> Grill	4	good	Last Available: "2010-03"
-4516	strong drinkable missing wine	5	good	Last Available: "2010-03"
-4517	stale half-sized blue matter custard	2	decent	Last Available: "2010-03"
+4516	drinkable strong missing wine	5	good	Last Available: "2010-03"
+4517	half-sized stale blue matter custard	2	decent	Last Available: "2010-03"
 4518	quadruple-deionized dry huge squat comfit?	0		Effect: "Turkey-Agitated", Effect Duration: 20, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	Lo Pan's vibrating flamingo mallet	0		Maximum MP Percent: +10, Spell Critical Percent: +30, Last Available: "2010-03"
 4521	pulsating croquet hedgehog	0		Last Available: "2010-03"
 4522	special Tiger-lily's milk	1	good	Effect: "Sleazy Jellied", Effect Duration: 35, Last Available: "2010-03"
 4523	experienced stylish eye of the Tiger-lily	0		Moxie: +25, Experience: +2, Last Available: "2010-03"
-4524	banded wig of Calamity Jane	0		Damage Absorption: +100, Critical Hit Percent: +15, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	banded wig of Calamity Jane	0		Damage Absorption: +100, Critical Hit Percent: +15, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	adequate donut	3	good	Last Available: "2010-03"
 4526	adequate bucket of honey	3	good	Last Available: "2010-03"
 4527	prompt savvy elephant stinger	0		Mysticality Percent: +20, Adventures: +3, Last Available: "2010-03"
-4528	spoiled miniature dragon snaps	2	crappy	Last Available: "2010-03"
+4528	miniature spoiled dragon snaps	2	crappy	Last Available: "2010-03"
 4529	olive Temple Grandin's Oprah's snapdragon pistil	0		Maximum MP Percent: +50, Familiar Weight: +7, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	fancy gigantic decent rook cookie	8	good	Effect: "Memory of Attractiveness", Effect Duration: 30, Last Available: "2010-03"
+4531	gigantic fancy decent rook cookie	8	good	Effect: "Memory of Attractiveness", Effect Duration: 30, Last Available: "2010-03"
 4532	decent narrow bishop cookie	3	good	Last Available: "2010-03"
 4533	bland mirror knight cookie	3	decent	Last Available: "2010-03"
 4534	thick stale king cookie	5	decent	Last Available: "2010-03"
 4535	bland queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
-4536	twirling teal fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	Van der Graaf insane tophat	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	tumbling vibrating quilted helm of the knight	0		Damage Absorption: +40, Maximum MP Percent: +10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4536	teal twirling fairy-worn boots	0		Free Pull, Last Available: "2011-08"
+4537	Van der Graaf insane tophat	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	tumbling vibrating quilted helm of the knight	0		Damage Absorption: +40, Maximum MP Percent: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	teal wristwatch of the knight of Tarzan of the early riser	0		Experience (Muscle): +3, Adventures: +7, Single Equip, Last Available: "2010-03"
-4540	ghostly baleful trousers of the knight of the brazier	0		Spell Damage: +25, Hot Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	ghostly baleful trousers of the knight of the brazier	0		Spell Damage: +25, Hot Spell Damage: +25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	upside-down tophat of the glutton	0		Food Drop: +100, Familiar Effect: "1xBarrr, cap 25"
 4542	zippy tie	0		Initiative: +20, Single Equip
 4543	tuxedo pants of the storm	0		Maximum MP Percent: +40, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4503,8 +4503,8 @@
 4555	left bracket	0		
 4556	right parenthesis	0		
 4557	dollar sign	0		
-4558	mirror ghostly equal sign	0		
-4559	skewed blue record album	0		Last Available: "2010-04"
+4558	ghostly mirror equal sign	0		
+4559	blue skewed record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	mirror hair of the calf	0		Last Available: "2010-04"
@@ -4513,13 +4513,13 @@
 4565	toothsome raisin	3	awesome	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	rosewater-soaked lion tamer's flyest of shirts	0		Experience (familiar): +2, Stench Resistance: +3, Last Available: "2010-04"
-4568	adequate super-sized wobbly a dance upon the palate	5	good	Last Available: "2010-04"
+4568	super-sized adequate wobbly a dance upon the palate	5	good	Last Available: "2010-04"
 4569	spoiled prehistoric meteorite jawbreaker	4	crappy	Last Available: "2010-04"
-4570	tumbling mirror Crazyleg's razor	0		Last Available: "2010-04"
-4571	tiny stale shaking squirmy violent party snack	1	decent	Last Available: "2010-04"
+4570	mirror tumbling Crazyleg's razor	0		Last Available: "2010-04"
+4571	stale tiny shaking squirmy violent party snack	1	decent	Last Available: "2010-04"
 4572	groovy can-you-dig-it?	0		Moxie Percent: +10, Last Available: "2010-04"
 4573	yellow The Legendary Beat	0		Last Available: "2010-04"
-4574	pulsating teal ghostly panicked kernel	0		Free Pull, Last Available: "2010-04"
+4574	teal ghostly pulsating panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
@@ -4546,13 +4546,13 @@
 4598	shaking pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	fancy watered-down hand-crafted plastic cup of beer	2	EPIC	Effect: "Armor-Plated", Effect Duration: 10, Last Available: "2010-06"
+4601	hand-crafted fancy watered-down plastic cup of beer	2	EPIC	Effect: "Armor-Plated", Effect Duration: 10, Last Available: "2010-06"
 4602	spinning orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	squat spinning keg	0		Last Available: "2010-06"
 4605	ghostly Jeselnik's electrified bottle of Goldschn&ouml;ckered	0		Sleaze Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	rotten half-sized sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	practically non-alcoholic tolerable soyburger juice	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	half-sized rotten sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	tolerable practically non-alcoholic soyburger juice	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	cyan respected companion biscuit	0		Last Available: "2010-08"
 4609	lime green essential tofu	0		Last Available: "2010-08"
 4610	extra-dry upside-down essential soy	0		Effect: "Happy Trails", Effect Duration: 36, Last Available: "2010-08"
@@ -4569,7 +4569,7 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	improved magnetized shaking chocolate-covered caviar	0		Effect: "Meatwise", Effect Duration: 55, Last Available: "2020-09"
-4624	moldy blinking cyan pawn cookie	3	crappy	Last Available: "2010-06"
+4624	moldy cyan blinking pawn cookie	3	crappy	Last Available: "2010-06"
 4625	compressed squat olive coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	maroon finger cuffs	0		Last Available: "2010-06"
@@ -4577,12 +4577,12 @@
 4629	coward's plastic spider ring	0		Monster Level: -20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	strapping plastic kazoo	0		Muscle: +5, Last Available: "2010-06"
 4631	prompt inflatable baseball bat	0		Adventures: +3, Last Available: "2010-06"
-4632	Rosewater's boxer's googly-star hat	0		Muscle Percent: +10, Mysticality Percent: +30, Last Available: "2010-06", Familiar Effect: "atk"
+4632	Rosewater's boxer's googly-star hat	0		Muscle Percent: +10, Mysticality Percent: +30, Familiar Effect: "atk", Last Available: "2010-06"
 4633	shaking googly-ball hat of wisdom of the businessman	0		Mysticality: +15, Meat Drop: +50, Last Available: "2010-06"
 4634	greasy horrifying googly-heart hat	0		Spooky Damage: +25, Sleaze Spell Damage: +10, Last Available: "2010-06"
 4635	chilly super-sweet boom box of the empath	0		Familiar Weight: +5, Cold Damage: +5, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	twirling asbestos-lined sinister demon mask of wisdom of doom	0		Mysticality: +15, Spooky Spell Damage: +50, Hot Resistance: +5, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	twirling asbestos-lined sinister demon mask of wisdom of doom	0		Mysticality: +15, Spooky Spell Damage: +50, Hot Resistance: +5, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	blinking wobbly stanky dance instructor's Samson's streetfighting champion's belt	0		Experience (Muscle): +5, Experience Percent (Moxie): +10, Stench Spell Damage: +25, Single Equip, Last Available: "2010-06"
 4639	gravedigger's Space Trip safety headphones of wisdom of temperance	0		Mysticality: +15, Spooky Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2010-06"
 4640	wobbly dog trainer's LARP carp	0		Experience (familiar): +1
@@ -4594,8 +4594,8 @@
 4646	mirror aromatic brawny Meteoid ice beam of Calamity Jane	0		Muscle Percent: +20, Critical Hit Percent: +15, Stench Resistance: +1, Last Available: "2011-12"
 4647	double-paned mansplainer's Socratic Dungeon Fist gauntlet	0		Experience (Mysticality): +1, Monster Level: +15, Cold Resistance: +5, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	twirling fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	twirling fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	bouncing asbestos-lined razor-sharp ironic knit cap	0		Weapon Damage Percent: +25, Hot Resistance: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	blurry ironic sunglasses	0		Single Equip
@@ -4616,7 +4616,7 @@
 4668	pulsating green lard-coated observational glasses	0		Sleaze Spell Damage: +25
 4669	hilarious comedy prop of the dark arts	0		Spell Damage Percent: +100
 4670	beer-scented teddy bear	0		
-4671	enchanted acceptable pulsating booze-soaked cherry	3	good	Effect: "Elemental Flavor", Effect Duration: 15
+4671	acceptable enchanted pulsating booze-soaked cherry	3	good	Effect: "Elemental Flavor", Effect Duration: 15
 4672	comfy pillow	0		
 4673	moldy mirror marshmallow	4	crappy	
 4674	immense normal sponge cake	6	good	
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	skewed smoked potsherd	0		
 4681	careful pottery shield	0		Monster Level: -10, Damage Reduction: 3, Last Available: "2010-09"
-4682	Tesla pottery hat of temperance	0		Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	gray huge pottery training pants of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	Tesla pottery hat of temperance	0		Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	gray huge pottery training pants of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	up-at-dawn pottery club	0		Adventures: +5, Last Available: "2010-09"
 4685	mirror pottery yo-yo of the brazier	0		Hot Spell Damage: +25, Last Available: "2010-09"
 4686	upside-down pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	tumbling fossilized torso	0		Last Available: "2010-09"
 4694	bouncing fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	pulsating frosty forbidden Greatest American Pants of the detective	0		Spell Damage Percent: +50, Cold Spell Damage: +10, Item Drop: +20, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	pulsating frosty forbidden Greatest American Pants of the detective	0		Spell Damage Percent: +50, Cold Spell Damage: +10, Item Drop: +20, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	fossilized necklace of the empath	0		Familiar Weight: +5, Last Available: "2010-09"
 4698	blinking imp air	0		
 4699	bus pass	0		
@@ -4660,20 +4660,20 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	blue pulsating popsicle stick	0		
 4714	moldy lemon popsicle	3	crappy	
-4715	flavorless small popsicle	2	decent	
+4715	small flavorless popsicle	2	decent	
 4716	stale strawberry popsicle	3	decent	
 4717	spoiled bite-sized blurry liver popsicle	1	crappy	
 4718	ghostly beefcake's mariachi hat	0		Muscle: +25, Familiar Effect: "atk, cap 2"
 4719	brainy Hollandaise helmet	0		Mysticality: +5, Familiar Effect: "atk, cap 2"
 4720	maroon organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	fancy moldy liver and let pie	3	crappy	Effect: "Sweet and Yellow", Effect Duration: 25, Last Available: "2010-10"
-4723	flavorless gray pulsating badass pie	3	decent	Last Available: "2010-10"
+4722	moldy fancy liver and let pie	3	crappy	Effect: "Sweet and Yellow", Effect Duration: 25, Last Available: "2010-10"
+4723	flavorless pulsating gray badass pie	3	decent	Last Available: "2010-10"
 4724	massive spoiled shoo-fish pie	8	crappy	Last Available: "2010-10"
 4725	rotten pulsating piping organ pie	4	crappy	Last Available: "2010-10"
 4726	jumbo adequate igloo pie	5	good	Last Available: "2010-10"
 4727	rotten pulsating stomach turnover	4	crappy	Last Available: "2010-10"
-4728	special snack-sized toothsome dead lights pie	2	awesome	Effect: "The Halls of Moxiousness", Effect Duration: 35, Last Available: "2010-10"
+4728	toothsome special snack-sized dead lights pie	2	awesome	Effect: "The Halls of Moxiousness", Effect Duration: 35, Last Available: "2010-10"
 4729	spoiled purple throbbing organ pie	4	crappy	Last Available: "2010-10"
 4730	Lo Pan's stop shield	0		Spell Critical Percent: +30, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4684,7 +4684,7 @@
 4736	tangle of rat tails	0		
 4737	grievous beer-soaked mop	0		Weapon Damage Percent: +50
 4738	hand-crafted day-old beer	4	EPIC	
-4739	delicious triple-distilled wobbly plain beer	7	awesome	
+4739	triple-distilled delicious wobbly plain beer	7	awesome	
 4740	hand-crafted overpriced &quot;imported&quot; beer	3	EPIC	
 4741	wobbly smiling rat	0		
 4742	blurry rat tooth polish	0		Familiar Weight: +5
@@ -4692,15 +4692,15 @@
 4744	Vulcanized cold-filtered PlexiPips	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 43
 4745	super-diffused denatured frozen Wax Flask	0		Effect: "Pumped Up", Effect Duration: 62
 4746	dry modified denatured spinning Pain Dip	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 37
-4747	decent thick bone meal	5	good	Last Available: "2010-10"
+4747	thick decent bone meal	5	good	Last Available: "2010-10"
 4748	hand-crafted bone aperitif	3	EPIC	Last Available: "2010-10"
 4749	jittery bonerang of the ox	0		Muscle: +20, Last Available: "2010-10"
 4750	smelly bone and arrows	0		Stench Spell Damage: +10, Last Available: "2010-10"
 4751	ghostly extremely unsafe boning knife	0		Weapon Damage Percent: +100, Last Available: "2010-10"
 4752	wobbly Temple Grandin's bone crusher	0		Familiar Weight: +7, Last Available: "2010-10"
 4753	maroon asbestos-lined bone spurs	0		Hot Resistance: +5, Single Equip, Last Available: "2010-10"
-4754	ribald bonedanna of the cougar	0		Moxie: +20, Sleaze Damage: +10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	electrified padded boneana hammock	0		Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	ribald bonedanna of the cougar	0		Moxie: +20, Sleaze Damage: +10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	electrified padded boneana hammock	0		Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	altered candy skeleton	0		Effect: "Big Flaming Whip", Effect Duration: 45, Last Available: "2020-09"
@@ -4708,9 +4708,9 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	wobbly pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	half-sized tasty skewed lime green pumpkin pie	2	awesome	Last Available: "2010-11"
+4763	tasty half-sized skewed lime green pumpkin pie	2	awesome	Last Available: "2010-11"
 4764	perfectly mixed pumpkin beer	3	EPIC	Last Available: "2010-11"
-4765	deionized tarnished pickled huge mirror pumpkin juice	0		Effect: "Elemental Mastery", Effect Duration: 27, Last Available: "2010-11"
+4765	deionized tarnished pickled mirror huge pumpkin juice	0		Effect: "Elemental Mastery", Effect Duration: 27, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	narrow Annie Oakley's shin gourds of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2010-11"
 4768	narrow Jack Frost's Tesla Van der Graaf Staff of the November Jack-O-Lantern	0		Cold Spell Damage: +50, MP Regen Min: 12, MP Regen Max: 17, Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	pulsating Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	delicious massive spinning blurry CRIMBCOIDS mints	8	awesome	Last Available: "2011-01"
+4818	massive delicious blurry spinning CRIMBCOIDS mints	8	awesome	Last Available: "2011-01"
 4819	tumbling can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	adequate CRIMBCOLOAF	3	good	Last Available: "2011-01"
 4821	decent circular CRIMBCOOKIE	4	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4751,9 +4751,9 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	Uncle Hobo's stocking cap of the scaredy-cat of the sewer	0		Monster Level: -15, Stench Damage: +25, Last Available: "2010-12", Familiar Effect: "atk"
+4845	Uncle Hobo's stocking cap of the scaredy-cat of the sewer	0		Monster Level: -15, Stench Damage: +25, Familiar Effect: "atk", Last Available: "2010-12"
 4846	teal smartaleck's Uncle Hobo's epic beard of wisdom	0		Mysticality: +15, Moxie Percent: +30, Single Equip, Last Available: "2010-12"
-4847	shaking ribald horrifying Uncle Hobo's gift baggy pants	0		Spooky Damage: +25, Sleaze Damage: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	shaking ribald horrifying Uncle Hobo's gift baggy pants	0		Spooky Damage: +25, Sleaze Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	lard-coated manspreader's Uncle Hobo's fingerless tinsel gloves	0		Monster Level: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2010-12"
 4849	dog trainer's fortified Uncle Hobo's highest bough	0		Damage Absorption: +60, Experience (familiar): +1, Last Available: "2010-12"
 4850	wobbly auspicious Lo Pan's Uncle Hobo's belt	0		Spell Critical Percent: +30, Item Drop: +10, Single Equip, Last Available: "2010-12"
@@ -4766,7 +4766,7 @@
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	pulsating CRIMBCO lanyard of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2011-01"
 4859	tumbling CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
-4860	pulsating spinning CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
+4860	spinning pulsating CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	spinning paperclip sproinger	0		Last Available: "2011-01"
 4868	sinister stylish paperclip-on tie of the cheetah	0		Moxie: +25, Spell Damage: +10, Initiative: +60, Single Equip, Last Available: "2011-01"
-4869	friendly paperclip pants of the detective	0		Familiar Weight: +3, Item Drop: +20, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	family-friendly Rosewater's paperclip turban of the overflowing toilet	0		Mysticality Percent: +30, Stench Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	friendly paperclip pants of the detective	0		Familiar Weight: +3, Item Drop: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	family-friendly Rosewater's paperclip turban of the overflowing toilet	0		Mysticality Percent: +30, Stench Spell Damage: +50, Sleaze Resistance: +1, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	twirling Lo Pan's paperclip cape	0		Spell Critical Percent: +30, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4785,7 +4785,7 @@
 4876	liquefied chocolate bath ball	0		Effect: "Vinegavotte", Effect Duration: 67, Last Available: "2011-01"
 4877	oxidized oxidized bacon bath ball	0		Effect: "Inappropriate Spirit", Effect Duration: 44, Last Available: "2011-01"
 4878	adjusted incense bath ball	0		Effect: "Browbeaten", Effect Duration: 48, Last Available: "2011-01"
-4879	quadruple-galvanized ionized olive pulsating tumbling myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Dreadful Heat", Effect Duration: 33, Last Available: "2011-01"
+4879	quadruple-galvanized ionized pulsating olive tumbling myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Dreadful Heat", Effect Duration: 33, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
 4881	hand-crafted jittery CRIMBCO wine	3	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
@@ -4879,7 +4879,7 @@
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	blinking Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
-4979	ghostly blurry Alice's Army Bowman	0		Last Available: "2011-03"
+4979	blurry ghostly Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	green ghostly Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
@@ -4925,9 +4925,9 @@
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	oxidized dry elderly jawbreaker	0		Effect: "Phorcefullness", Effect Duration: 49, Last Available: "2020-09"
 5024	bad marshmallow flamb&eacute;	3	decent	Last Available: "2011-03"
-5025	boozy acceptable teal cranberry schnapps	5	good	Last Available: "2011-03"
+5025	acceptable boozy teal cranberry schnapps	5	good	Last Available: "2011-03"
 5026	mediocre special breaded beer	3	decent	Effect: "Gr8ness", Effect Duration: 10, Last Available: "2011-03"
-5027	delicious high-proof jittery soy cordial	10	awesome	Last Available: "2011-03"
+5027	high-proof delicious jittery soy cordial	10	awesome	Last Available: "2011-03"
 5028	cyan ribald sharpshooter's rock-hard astral bludgeon	0		Damage Reduction: 5, Critical Hit Percent: +10, Sleaze Damage: +10
 5029	miser's sizzling astral shield	0		Hot Damage: +10, Meat Drop: +10, Damage Reduction: 15
 5030	tumbling scorching thinker's astral chapeau of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Hot Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4943,22 +4943,22 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	wholesome rock-hard deadly astral shirt	0		Weapon Damage: +5, Damage Reduction: 5, Maximum HP Percent: +10
 5042	aromatic wizardly astral belt	0		Mysticality: +25, Stench Resistance: +1
-5043	flavorless small blurry astral hot dog	2		
+5043	small flavorless blurry astral hot dog	2		
 5044	artisanal blinking astral pilsner	3		
 5045	teal astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	wool supercool double-ice cap of wisdom	0		Mysticality: +15, Moxie Percent: +20, Cold Resistance: +1, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	wool supercool double-ice cap of wisdom	0		Mysticality: +15, Moxie Percent: +20, Cold Resistance: +1, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	double-ice box of Gandalf of the empath of incineration	0		Spell Critical Percent: +20, Familiar Weight: +5, Hot Spell Damage: +50, Last Available: "2011-04"
-5051	Jim Carey's double-ice britches of wisdom of the cheetah	0		Mysticality: +15, Monster Level: +25, Initiative: +60, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	Jim Carey's double-ice britches of wisdom of the cheetah	0		Mysticality: +15, Monster Level: +25, Initiative: +60, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	yellow handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	shaking intriguing puzzle box	0		Last Available: "2011-04"
 5055	mirror obnoxious riddle	0		Last Available: "2011-04"
 5056	maroon best joke ever	0		Last Available: "2011-04"
 5057	moist concentrated Atomic Comic	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 55, Last Available: "2011-04"
-5058	polarized improved blue wobbly Red Pill	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 20, Last Available: "2011-04"
+5058	polarized improved wobbly blue Red Pill	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 20, Last Available: "2011-04"
 5059	tumbling Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
 5061	bouncing boxing-glove-in-a-box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	mediocre irresponsibly strong Russian Ice	9	decent	Last Available: "2011-04"
 5074	clay ashtray of temperance	0		Sleaze Resistance: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	Socratic lanyard	0		Experience (Mysticality): +1, Single Equip, Last Available: "2011-05"
-5076	upside-down banded monster pants	0		Damage Absorption: +100, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	upside-down banded monster pants	0		Damage Absorption: +100, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	chilled frozen ionized spinning Pok&euml;mann band-aid	0		Effect: "Pretending to Pretend", Effect Duration: 63, Last Available: "2011-05"
-5079	twirling pulsating nasty thinker's Van der Graaf helmet	0		Mysticality: +10, Stench Damage: +5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	twirling pulsating nasty thinker's Van der Graaf helmet	0		Mysticality: +10, Stench Damage: +5, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	upside-down maroon grievous crutch	0		Weapon Damage Percent: +50, Last Available: "2011-05"
 5081	executive shock belt	0		Meat Drop: +40, Single Equip, Last Available: "2011-05"
 5082	frozen Okee-Dokee soda	0		Effect: "Highland Sheen", Effect Duration: 68, Last Available: "2011-05"
 5083	mirror personal trainer's rubber band gun	0		Experience Percent (Muscle): +10, Last Available: "2011-05"
-5084	yellow flame-wreathed pin-stripe slacks	0		Hot Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	yellow flame-wreathed pin-stripe slacks	0		Hot Spell Damage: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	green up-at-dawn gloves	0		Adventures: +5, Single Equip, Last Available: "2011-05"
 5086	diffused flattened yellow correction fluid	0		Effect: "Clean-Shaven", Effect Duration: 49, Last Available: "2011-05"
 5087	boxer's Pok&euml;mann figurine: Porkachu	0		Muscle Percent: +10, Single Equip, Last Available: "2011-05"
@@ -5005,7 +5005,7 @@
 5102	quadruple-alkaline willyweed	0		Effect: "Slippery Tongue", Effect Duration: 17, Last Available: "2011-05"
 5103	alkaline Nuclear Blastball	0		Effect: "Saucemastery", Effect Duration: 20, Last Available: "2011-05"
 5104	quadruple-dry activated fish juice box	0		Effect: "Weasels Underfoot", Effect Duration: 48, Last Available: "2011-05"
-5105	skewed blurry paint bomb	0		Last Available: "2011-05"
+5105	blurry skewed paint bomb	0		Last Available: "2011-05"
 5106	blurry hideous egg	0		Last Available: "2011-05"
 5107	perfectly mixed weak Jeppson's Malort	2	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	pulsating Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	Socratic Samson's smartaleck's Admiral's hat	0		Moxie Percent: +30, Experience (Muscle): +5, Experience (Mysticality): +1, Last Available: "2011-05", Familiar Effect: "atk"
-5122	Tesla supercool aviator's cap of the bloodbag	0		Moxie Percent: +20, Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	Socratic Samson's smartaleck's Admiral's hat	0		Moxie Percent: +30, Experience (Muscle): +5, Experience (Mysticality): +1, Familiar Effect: "atk", Last Available: "2011-05"
+5122	Tesla supercool aviator's cap of the bloodbag	0		Moxie Percent: +20, Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	friendly dance instructor's mirrored aviator shades	0		Experience Percent (Moxie): +10, Familiar Weight: +3, Single Equip, Last Available: "2011-05"
 5124	blurry Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	wobbly Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	red healthy honey dipper of bravery of the detective	0		Maximum HP Percent: +20, Spooky Resistance: +5, Item Drop: +20
 5149	huge sharpshooter's shellacked arcane researcher's honeybritches	0		Experience Percent (Mysticality): +10, Damage Reduction: 7, Critical Hit Percent: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	family-friendly curative educational honeycap	0		Experience: +1, Sleaze Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, cap 43"
-5151	Moonthril Circlet of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	twirling green manspreader's Moonthril Greaves	0		Monster Level: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	Moonthril Circlet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	twirling green manspreader's Moonthril Greaves	0		Monster Level: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	Jeselnik's Moonthril Flamberge	0		Sleaze Damage: +25, Last Available: "2011-06"
 5154	miser's Moonthril Longbow	0		Meat Drop: +10, Last Available: "2011-06"
 5155	hardy Moonthril Cuirass	0		Maximum HP: +50, Softcore Only, Last Available: "2011-06"
@@ -5081,8 +5081,8 @@
 5178	adequate Crepes a la Lune	3	good	Last Available: "2011-06"
 5179	stale Moon Pie	4	decent	Last Available: "2011-06"
 5180	denatured flattened purple squat Comet Pop	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 15, Last Available: "2011-06"
-5181	denatured denatured skewed twirling Flan in the Moon	0		Effect: "So You Can Work More...", Effect Duration: 21, Last Available: "2011-06"
-5182	alkaline energized aerosolized gray skewed 1/6th Pound Cake	0		Effect: "Spooky Weapon", Effect Duration: 63, Last Available: "2011-06"
+5181	denatured denatured twirling skewed Flan in the Moon	0		Effect: "So You Can Work More...", Effect Duration: 21, Last Available: "2011-06"
+5182	alkaline energized aerosolized skewed gray 1/6th Pound Cake	0		Effect: "Spooky Weapon", Effect Duration: 63, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
@@ -5109,9 +5109,9 @@
 5206	denatured demonic paste	1	awesome	Last Available: "2011-08"
 5207	compressed shaking indescribably horrible paste	1	awesome	Last Available: "2011-08"
 5208	boiled upside-down paste	1	crappy	Last Available: "2011-08"
-5209	mixed shaking spinning goblin paste	1	EPIC	Last Available: "2011-08"
+5209	mixed spinning shaking goblin paste	1	EPIC	Last Available: "2011-08"
 5210	distilled pirate paste	1	decent	Last Available: "2011-08"
-5211	modified squat teal narrow chlorophyll paste	1	crappy	Last Available: "2011-08"
+5211	modified teal squat narrow chlorophyll paste	1	crappy	Last Available: "2011-08"
 5212	denatured huge paste	1	good	Last Available: "2011-08"
 5213	altered huge Mer-kin paste	1	good	Effect: "Tightly-Wound Spine", Effect Duration: 5, Last Available: "2011-08"
 5214	denatured ghostly slimy paste	1	decent	Last Available: "2011-08"
@@ -5119,15 +5119,15 @@
 5216	diluted squat elemental paste	1	good	Last Available: "2011-08"
 5217	powdered olive cosmic paste	1	decent	Last Available: "2011-08"
 5218	vaporized tumbling hobo paste	1	decent	Last Available: "2011-08"
-5219	distilled maroon ghostly Crimbo paste	1	EPIC	Effect: "Berry Elemental", Effect Duration: 25, Last Available: "2011-08"
+5219	distilled ghostly maroon Crimbo paste	1	EPIC	Effect: "Berry Elemental", Effect Duration: 25, Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	squat Thwaitgold grasshopper statuette	0		
-5223	cyan Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	cyan Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	spoiled snack-sized mirror Ur-Donut	2	crappy	Last Available: "2011-09"
 5225	ghostly The Bomb	0		Last Available: "2011-09"
 5226	skewed box of Familiar Jacks	0		Last Available: "2011-09"
-5227	strong delicious bucket of wine	5	awesome	Last Available: "2011-09"
+5227	delicious strong bucket of wine	5	awesome	Last Available: "2011-09"
 5228	flavorless upside-down ultrafondue	3	decent	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	squat snowflake	0		Last Available: "2011-09"
@@ -5139,29 +5139,29 @@
 5236	Herculean frosty halo	0		Experience (Muscle): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	asbestos-lined time halo	0		Hot Resistance: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	drinkable Lumineux Limnio	3	good	Last Available: "2011-09"
-5239	fancy artisanal Morto Moreto	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 15, Last Available: "2011-09"
+5239	artisanal fancy Morto Moreto	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 15, Last Available: "2011-09"
 5240	acceptable Temps Tempranillo	3	good	Last Available: "2011-09"
 5241	perfectly mixed Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
 5242	high-proof perfectly mixed Fromage Pinotage	9	EPIC	Last Available: "2011-09"
 5243	perfectly mixed Beignet Milgranet	4	EPIC	Last Available: "2011-09"
 5244	bad Muschat	4	decent	Last Available: "2011-09"
-5245	diet rotten cool jelly donut	1	crappy	Last Available: "2011-09"
+5245	rotten diet cool jelly donut	1	crappy	Last Available: "2011-09"
 5246	flavorless spinning shrapnel jelly donut	3	decent	Last Available: "2011-09"
 5247	normal occult jelly donut	3	good	Last Available: "2011-09"
-5248	huge flavorless squat thyme jelly donut	6	decent	Last Available: "2011-09"
+5248	flavorless huge squat thyme jelly donut	6	decent	Last Available: "2011-09"
 5249	half-sized flavorless danish	2	decent	Last Available: "2011-09"
-5250	diet spoiled gray smashed danish	1	crappy	Last Available: "2011-09"
-5251	moldy bouncing narrow forbidden danish	3	crappy	Last Available: "2011-09"
-5252	normal gigantic mirror cool cat claw	8	good	Last Available: "2011-09"
-5253	decent half-sized blunt cat claw	2	good	Last Available: "2011-09"
-5254	moldy bite-sized shadowy cat claw	1	crappy	Last Available: "2011-09"
-5255	toothsome small wobbly cheezburger	2	awesome	Last Available: "2011-09"
+5250	spoiled diet gray smashed danish	1	crappy	Last Available: "2011-09"
+5251	moldy narrow bouncing forbidden danish	3	crappy	Last Available: "2011-09"
+5252	gigantic normal mirror cool cat claw	8	good	Last Available: "2011-09"
+5253	half-sized decent blunt cat claw	2	good	Last Available: "2011-09"
+5254	bite-sized moldy shadowy cat claw	1	crappy	Last Available: "2011-09"
+5255	small toothsome wobbly cheezburger	2	awesome	Last Available: "2011-09"
 5256	normal toasted brie	3	good	Last Available: "2011-09"
 5257	deionized teal potion of the field gar	0		Effect: "Petit Force", Effect Duration: 59, Last Available: "2011-09"
 5258	chilled ionized jittery too legit potion	0		Effect: "Craft Tea", Effect Duration: 43, Last Available: "2011-09"
 5259	boiled bouncing Bright Water	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 38, Last Available: "2011-09"
 5260	altered magnetized upside-down cold-filtered water	0		Effect: "Three Days Slow", Effect Duration: 30, Last Available: "2011-09"
-5261	frozen olive narrow graveyard snowglobe	0		Effect: "Wistfully Nostalgic", Effect Duration: 57, Last Available: "2011-09"
+5261	frozen narrow olive graveyard snowglobe	0		Effect: "Wistfully Nostalgic", Effect Duration: 57, Last Available: "2011-09"
 5262	pressed moist fuchsia pulsating cool cat elixir	0		Effect: "Vented Spleen", Effect Duration: 16, Last Available: "2011-09"
 5263	tarnished jittery potion of the captain's hammer	0		Effect: "Jittery", Effect Duration: 30, Last Available: "2011-09"
 5264	extra-enhanced flattened squat potion of X-ray vision	0		Effect: "Reptilian Fortitude", Effect Duration: 24, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-09"
 5282	skewed ruddy dethklok	0		Maximum HP Percent: +40, Last Available: "2011-09"
 5283	glacial clock of chilblains	0		Cold Damage: +25, Last Available: "2011-09"
-5284	squat Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	squat Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	twirling d4	0		Last Available: "2011-09"
 5286	cyan d6	0		Last Available: "2011-09"
 5287	jittery d8	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	maroon newborn kobold	0		Last Available: "2011-09"
 5296	spinning wobbly slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	enchanted spoiled phish stick	3	crappy	Effect: "Helvella Health", Effect Duration: 5, Last Available: "2011-09"
+5298	spoiled enchanted phish stick	3	crappy	Effect: "Helvella Health", Effect Duration: 5, Last Available: "2011-09"
 5299	fortified occult plastic vampire fangs of Gandalf	0		Spell Damage Percent: +25, Damage Absorption: +60, Spell Critical Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	shaking upside-down squat Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5226,28 +5226,28 @@
 5323	perfectly mixed Bartles and BRAAAINS wine cooler	4	EPIC	Last Available: "2011-10"
 5324	drinkable huge Blood Light	4	good	Last Available: "2011-10"
 5325	perfectly mixed huge Silver Bullet beer	4	EPIC	Last Available: "2011-10"
-5326	weak lousy Bone's Farm &quot;wine&quot;	2	decent	Last Available: "2011-10"
-5327	blue pulsating ghost protocol	0		Last Available: "2011-10"
+5326	lousy weak Bone's Farm &quot;wine&quot;	2	decent	Last Available: "2011-10"
+5327	pulsating blue ghost protocol	0		Last Available: "2011-10"
 5328	tarnished ionized ghostly teal sorority brain	0		Effect: "Feroci Tea", Effect Duration: 33, Last Available: "2011-10"
 5329	aerosolized Nightstalker perfume	0		Effect: "Eagle Eyes", Effect Duration: 40, Last Available: "2011-10"
 5330	irradiated drum of pomade	0		Effect: "Hangdog", Effect Duration: 63, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	skewed sharpshooter's extra-see-thru nightie	0		Critical Hit Percent: +10, Last Available: "2011-10"
-5333	padded BRAINS shorts of chilblains	0		Damage Absorption: +20, Cold Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	padded BRAINS shorts of chilblains	0		Damage Absorption: +20, Cold Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	wobbly pulsating padded Mesmereyes&trade; contact lenses	0		Damage Absorption: +20, Single Equip, Last Available: "2011-10"
 5335	scrunchie of the detective	0		Item Drop: +20, Single Equip, Last Available: "2011-10"
-5336	horrifying extremely skinny jeans of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	healthy Sinatra's The Necbromancer's Hat	0		Experience (Moxie): +5, Maximum HP Percent: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	horrifying extremely skinny jeans of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	healthy Sinatra's The Necbromancer's Hat	0		Experience (Moxie): +5, Maximum HP Percent: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	spinning tumbling red nasty resourceful quilted The Necbromancer's Stein	0		Damage Absorption: +40, Maximum MP: +50, Stench Damage: +5, Last Available: "2011-10"
-5339	medical-grade cool The Necbromancer's Shorts of the businessman	0		Moxie: +5, Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	medical-grade cool The Necbromancer's Shorts of the businessman	0		Moxie: +5, Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	wobbly tumbling MacGyver's slick The Necbromancer's Wizard Staff of the bloodbag	0		Moxie: +10, Maximum HP: +100, Maximum MP: +100, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	perfectly mixed boozy The Cooler Out of Space	5	EPIC	Last Available: "2011-10"
+5342	boozy perfectly mixed The Cooler Out of Space	5	EPIC	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	non-boiled extra-concentrated narrow Necbro wafers	0		Effect: "Chalky Hand", Effect Duration: 31, Last Available: "2020-09"
 5346	squat death blossom	0		
-5347	pulsating huge tumbling A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+5347	tumbling pulsating huge A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	bouncing A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	twirling A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
@@ -5266,7 +5266,7 @@
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	twirling CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-5366	blue ghostly CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+5366	ghostly blue CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5368	Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	mirror baleful KoL Con 8-Bit power bracelet	0		Spell Damage: +25, Last Available: "2011-09"
@@ -5289,7 +5289,7 @@
 5386	double-paned ridiculous belt	0		Cold Resistance: +5, Last Available: "2011-11"
 5387	flame-wreathed ridiculous earring	0		Hot Spell Damage: +10, Last Available: "2011-11"
 5388	tumbling ridiculous sunglasses of Tarzan	0		Experience (Muscle): +3, Last Available: "2011-11"
-5389	gigantic normal ridiculous sandwich	7	good	Last Available: "2011-11"
+5389	normal gigantic ridiculous sandwich	7	good	Last Available: "2011-11"
 5390	bad ridiculous cocktail	3	decent	Last Available: "2011-11"
 5391	miser's horrifying zombie monkey necklace	0		Spooky Damage: +25, Meat Drop: +10
 5392	Thwaitgold butterfly statuette	0		
@@ -5301,18 +5301,18 @@
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	huge candy cane candygram	0		Last Available: "2011-12"
-5401	maroon ghostly mirror peppermint parasol	0		Last Available: "2011-11"
+5401	mirror maroon ghostly peppermint parasol	0		Last Available: "2011-11"
 5402	candy cane of the cougar	0		Moxie: +20, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	blinking scorching Newton's beefcake's cane-mail shirt	0		Muscle: +25, Experience (Mysticality): +3, Hot Damage: +25, Last Available: "2011-12"
-5406	blue Jack Frost's therapeutic smooth cane-mail pants	0		Moxie: +15, Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	blue Jack Frost's therapeutic smooth cane-mail pants	0		Moxie: +15, Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	special mediocre Vodka Matryoshka	4	decent	Effect: "Innately Strong", Effect Duration: 45, Last Available: "2011-12"
 5408	watered-down artisanal Gin Mint	2	EPIC	Last Available: "2011-12"
 5409	perfectly mixed practically non-alcoholic tumbling Tequiz Navidad	1	super ultra mega turbo EPIC	Last Available: "2011-12"
 5410	drinkable Mint Yulep	3	good	Last Available: "2011-12"
 5411	perfectly mixed purple pulsating Crimbojito	3	EPIC	Last Available: "2011-12"
-5412	special weak artisanal Sangria de Menthe	2	EPIC	Effect: "Egged On", Effect Duration: 10, Last Available: "2011-12"
+5412	weak special artisanal Sangria de Menthe	2	EPIC	Effect: "Egged On", Effect Duration: 10, Last Available: "2011-12"
 5413	narrow candycaine powder	0		Last Available: "2011-12"
 5414	red licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	denatured quadruple-corrupted polarized licorice root	0		Effect: "Metal Speed", Effect Duration: 20, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	fireproof kumquartz ring	0		Hot Resistance: +3, Single Equip, Last Available: "2011-11"
 5425	lightning-fast strawberyl necklace	0		Initiative: +40, Single Equip, Last Available: "2011-11"
 5426	purple prompt knitted sucker bucket	0		Cold Resistance: +3, Adventures: +3, Last Available: "2011-11"
-5427	stiffened sucker hakama	0		Damage Reduction: 1, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	wobbly arcane researcher's sucker kabuto	0		Experience Percent (Mysticality): +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	stiffened sucker hakama	0		Damage Reduction: 1, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	wobbly arcane researcher's sucker kabuto	0		Experience Percent (Mysticality): +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	mirror Oprah's sucker tachi	0		Maximum MP Percent: +50, Last Available: "2011-11"
 5430	jittery sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	ionized jittery fluid of fudge-finding	0		Effect: "Bastard!", Effect Duration: 40, Last Available: "2011-11"
 5439	narrow fudgepuck	0		Last Available: "2011-11"
-5440	decent super-sized fudgesicle	5	good	Last Available: "2011-11"
+5440	super-sized decent fudgesicle	5	good	Last Available: "2011-11"
 5441	narrow wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	squat upside-down miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5350,7 +5350,7 @@
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
 5449	blinking vanity stone	0		Last Available: "2012-12"
-5450	squat red lecherous stone	0		Last Available: "2012-12"
+5450	red squat lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
@@ -5363,7 +5363,7 @@
 5460	squat crafty sage fudgecycle of vim and vigor	0		Mysticality Percent: +10, Maximum HP Percent: +50, Maximum MP: +10, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	cyan Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	cyan Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	dry wet spinning resolution: be wealthier	0		Effect: "Helping Comes Second", Effect Duration: 55, Last Available: "2012-01"
 5465	altered ionized blinking resolution: be happier	0		Effect: "Filled with Magic", Effect Duration: 47, Last Available: "2012-01"
 5466	moist alkaline resolution: be stronger	0		Effect: "Dreams and Lights", Effect Duration: 58, Last Available: "2012-01"
@@ -5382,7 +5382,7 @@
 5479	moldy miniature gummi bear	2	crappy	Last Available: "2011-11"
 5480	adequate gummi bear	3	good	Last Available: "2011-11"
 5481	decent gummi bear	4	good	Last Available: "2011-11"
-5482	huge moldy drunki-bear	7	crappy	Last Available: "2011-11"
+5482	moldy huge drunki-bear	7	crappy	Last Available: "2011-11"
 5483	toothsome squat drunki-bear	3	awesome	Last Available: "2011-11"
 5484	moldy drunki-bear	4	crappy	Last Available: "2011-11"
 5485	upside-down zippy gummi bowtie	0		Initiative: +20, Last Available: "2011-11"
@@ -5393,24 +5393,24 @@
 5490	blurry belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	tumbling ammonite candy mold	0		Last Available: "2011-11"
-5493	blurry blurry red belemnite candy mold	0		Last Available: "2011-11"
+5493	blurry red blurry belemnite candy mold	0		Last Available: "2011-11"
 5494	ionized warmed twirling gummi trilobite	0		Effect: "Ready to Snap", Effect Duration: 14, Last Available: "2011-11"
 5495	activated improved cyan upside-down gummi ammonite	0		Effect: "Super Structure", Effect Duration: 43, Last Available: "2011-11"
 5496	dry concentrated upside-down gummi belemnite	0		Effect: "The Halls of Muscularity", Effect Duration: 25, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	ruddy Big Candy's tophat of Gandalf	0		Maximum HP Percent: +40, Spell Critical Percent: +20, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	ruddy Big Candy's tophat of Gandalf	0		Maximum HP Percent: +40, Spell Critical Percent: +20, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	enchanted miniature spoiled purple jerky coins	2	crappy	Effect: "Good with the Ladies", Effect Duration: 40, Last Available: "2011-11"
+5506	miniature spoiled enchanted purple jerky coins	2	crappy	Effect: "Good with the Ladies", Effect Duration: 40, Last Available: "2011-11"
 5507	bad narrow Go-Wassail	4	decent	Last Available: "2011-11"
 5508	triple-adjusted Uncle Greenspan's Bathroom Finance Guide	0		Effect: "[1609]Dancin' Fool", Effect Duration: 26, Last Available: "2011-11"
 5509	liquefied tarnished bottle of bubbles	0		Effect: "Hare-o-dynamic", Effect Duration: 15, Last Available: "2011-11"
-5510	adjusted skewed skewed lime green wind-up meatcar	0		Effect: "Psalm of Pointiness", Effect Duration: 41, Last Available: "2011-11"
+5510	adjusted lime green skewed skewed wind-up meatcar	0		Effect: "Psalm of Pointiness", Effect Duration: 41, Last Available: "2011-11"
 5511	purple Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	olive twirling Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5418,7 +5418,7 @@
 5515	pog #01 (spider)	0		Last Available: "2011-11"
 5516	narrow pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	shaking pog #03 (warwelf)	0		Last Available: "2011-11"
-5518	huge pulsating pog #04 (skleleton)	0		Last Available: "2011-11"
+5518	pulsating huge pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	twirling pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	narrow pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
@@ -5434,8 +5434,8 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	denatured warmed olive Mortimer's nostrum	0		Effect: "Sludgesick", Effect Duration: 28, Last Available: "2012-12"
-5534	tolerable watered-down Barulio's bottle	2	good	Last Available: "2012-12"
-5535	tarnished irradiated ghostly tumbling Marvin's marvelous pill	0		Effect: "Magically Delicious", Effect Duration: 46, Last Available: "2012-12"
+5534	watered-down tolerable Barulio's bottle	2	good	Last Available: "2012-12"
+5535	tarnished irradiated tumbling ghostly Marvin's marvelous pill	0		Effect: "Magically Delicious", Effect Duration: 46, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	tumbling half-empty carton of milk	0		Last Available: "2012-12"
@@ -5444,7 +5444,7 @@
 5541	tumbling Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	rosewater-soaked gravedigger's Leapin' Trousers	0		Spooky Damage: +10, Stench Resistance: +3
-5544	watered-down drinkable tumbling eggnog	2	good	Last Available: "2012-12"
+5544	drinkable watered-down tumbling eggnog	2	good	Last Available: "2012-12"
 5545	stale hamhock	3	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	blurry Clancy's sackbut	0		Last Available: "2012-12"
@@ -5459,78 +5459,78 @@
 5556	coward's Rain-Doh wings of vim and vigor	0		Maximum HP Percent: +50, Monster Level: -20, Softcore Only, Last Available: "2012-02"
 5557	upside-down yellow Rain-Doh agent	0		Last Available: "2012-02"
 5558	careful stylish Rain-Doh laser gun	0		Moxie: +25, Monster Level: -10, Softcore Only, Last Available: "2012-02"
-5559	Tesla thinker's Rain-Doh lantern	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	Tesla thinker's Rain-Doh lantern	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	fuchsia Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	wobbly ghostly rosy-cheeked Rain-Doh violet bo of extreme caution	0		Maximum HP Percent: +30, Monster Level: -25, Softcore Only, Last Available: "2012-02"
 5563	blurry Rain-Doh box	0		Last Available: "2012-02"
 5564	pulsating Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	stale super-sized PB&BP	5	decent	
+5565	super-sized stale PB&BP	5	decent	
 5566	decent fancy club sandwich	3	good	Effect: "Ichorous Eyesight", Effect Duration: 10
-5567	toothsome tiny corned-beef Reuben	1	awesome	
+5567	tiny toothsome corned-beef Reuben	1	awesome	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	weak bad blinking Drac & Tan	2	decent	Last Available: "2012-03"
-5574	weak hand-crafted cyan Transylvania Sling	2	EPIC	Last Available: "2012-03"
+5573	bad weak blinking Drac & Tan	2	decent	Last Available: "2012-03"
+5574	hand-crafted weak cyan Transylvania Sling	2	EPIC	Last Available: "2012-03"
 5575	irresponsibly strong artisanal Shot of the Living Dead	10	EPIC	Last Available: "2012-03"
-5576	delicious special Buttery Knob	4	awesome	Effect: "Fishy Fortification", Effect Duration: 35, Last Available: "2012-03"
+5576	special delicious Buttery Knob	4	awesome	Effect: "Fishy Fortification", Effect Duration: 35, Last Available: "2012-03"
 5577	hand-crafted wobbly Slippery Knob	4	EPIC	Last Available: "2012-03"
 5578	practically non-alcoholic acceptable Flaming Knob	1	good	Last Available: "2012-03"
 5579	tolerable Grasshopper	3	good	Last Available: "2012-03"
-5580	hand-crafted fortified Locust	5	EPIC	Last Available: "2012-03"
-5581	strong smooth Plague of Locusts	5	awesome	Last Available: "2012-03"
+5580	fortified hand-crafted Locust	5	EPIC	Last Available: "2012-03"
+5581	smooth strong Plague of Locusts	5	awesome	Last Available: "2012-03"
 5582	tolerable Red Dwarf	4	good	Last Available: "2012-03"
 5583	acceptable irresponsibly strong Golden Mean	6	good	Last Available: "2012-03"
-5584	acceptable extra-dry Green Giant	5	good	Last Available: "2012-03"
+5584	extra-dry acceptable Green Giant	5	good	Last Available: "2012-03"
 5585	delicious high-proof teal Aye Aye	9	awesome	Last Available: "2012-03"
 5586	mediocre Aye Aye, Captain	3	decent	Last Available: "2012-03"
-5587	acceptable weak mirror Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
+5587	weak acceptable mirror Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
 5588	tolerable Humanitini	4	good	Last Available: "2012-03"
-5589	special delicious bouncing More Humanitini than Humanitini	3	awesome	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2012-03"
+5589	delicious special bouncing More Humanitini than Humanitini	3	awesome	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2012-03"
 5590	drinkable watered-down blurry Oh, the Humanitini	2	good	Last Available: "2012-03"
-5591	weak perfectly mixed Great Older Fashioned	2	EPIC	Last Available: "2012-03"
+5591	perfectly mixed weak Great Older Fashioned	2	EPIC	Last Available: "2012-03"
 5592	perfectly mixed watered-down huge blurry Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	perfectly mixed Crazymaker	4	EPIC	Last Available: "2012-03"
-5594	bad irresponsibly strong Zoodriver	7	decent	Last Available: "2012-03"
-5595	triple-distilled acceptable skewed Sloe Comfortable Zoo	10	good	Last Available: "2012-03"
+5594	irresponsibly strong bad Zoodriver	7	decent	Last Available: "2012-03"
+5595	acceptable triple-distilled skewed Sloe Comfortable Zoo	10	good	Last Available: "2012-03"
 5596	hand-crafted bouncing Sloe Comfortable Zoo on Fire	3	EPIC	Last Available: "2012-03"
 5597	hand-crafted Suffering Sinner	4	EPIC	Last Available: "2012-03"
 5598	tolerable blinking Suppurating Sinner	4	good	Last Available: "2012-03"
-5599	delicious fancy weak Sizzling Sinner	2	awesome	Effect: "You Know Where to Go", Effect Duration: 25, Last Available: "2012-03"
+5599	weak fancy delicious Sizzling Sinner	2	awesome	Effect: "You Know Where to Go", Effect Duration: 25, Last Available: "2012-03"
 5600	aged Firewater	3	awesome	Last Available: "2012-03"
-5601	extra-dry bad wobbly Earth and Firewater	5	decent	Last Available: "2012-03"
+5601	bad extra-dry wobbly Earth and Firewater	5	decent	Last Available: "2012-03"
 5602	artisanal Earth, Wind and Firewater	3	EPIC	Last Available: "2012-03"
 5603	delicious ghostly Slimosa	3	awesome	Last Available: "2012-03"
-5604	artisanal watered-down Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
+5604	watered-down artisanal Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
 5605	perfectly mixed Slimebite	3	EPIC	Last Available: "2012-03"
 5606	acceptable Cement Mixer	3	good	Last Available: "2012-03"
 5607	drinkable Jackhammer	4	good	Last Available: "2012-03"
-5608	practically non-alcoholic bad skewed Dump Truck	1	decent	Last Available: "2012-03"
+5608	bad practically non-alcoholic skewed Dump Truck	1	decent	Last Available: "2012-03"
 5609	tolerable irresponsibly strong upside-down Fauna Libre	10	good	Last Available: "2012-03"
 5610	mediocre weak Chakra Libre	2	decent	Last Available: "2012-03"
-5611	high-proof acceptable spinning mirror Aura Libre	10	good	Last Available: "2012-03"
-5612	practically non-alcoholic smooth Sazerorc	1	awesome	Last Available: "2012-03"
-5613	special practically non-alcoholic perfectly mixed Sazuruk-hai	1	EPIC	Effect: "Wet Willied", Effect Duration: 35, Last Available: "2012-03"
+5611	acceptable high-proof spinning mirror Aura Libre	10	good	Last Available: "2012-03"
+5612	smooth practically non-alcoholic Sazerorc	1	awesome	Last Available: "2012-03"
+5613	perfectly mixed practically non-alcoholic special Sazuruk-hai	1	EPIC	Effect: "Wet Willied", Effect Duration: 35, Last Available: "2012-03"
 5614	tolerable Flaming Sazerorc	3	good	Last Available: "2012-03"
 5615	mediocre Green Velvet	4	decent	Last Available: "2012-03"
-5616	weak bad spinning Green Muslin	2	decent	Last Available: "2012-03"
+5616	bad weak spinning Green Muslin	2	decent	Last Available: "2012-03"
 5617	artisanal Green Burlap	4	EPIC	Last Available: "2012-03"
-5618	boozy mediocre Mohobo	5	decent	Last Available: "2012-03"
+5618	mediocre boozy Mohobo	5	decent	Last Available: "2012-03"
 5619	perfectly mixed Moonshine Mohobo	3	EPIC	Last Available: "2012-03"
 5620	drinkable blurry Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	lousy yellow shaking Drunken Philosopher	4	decent	Last Available: "2012-03"
-5622	practically non-alcoholic drinkable blurry Drunken Neurologist	1	good	Last Available: "2012-03"
-5623	artisanal weak squat Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
+5622	drinkable practically non-alcoholic blurry Drunken Neurologist	1	good	Last Available: "2012-03"
+5623	weak artisanal squat Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
 5624	mediocre Dark & Starry	3	decent	Last Available: "2012-03"
 5625	artisanal Black Hole	3	EPIC	Last Available: "2012-03"
 5626	tolerable Event Horizon	3	good	Last Available: "2012-03"
-5627	acceptable watered-down jittery Herring Daiquiri	2	good	Last Available: "2012-03"
-5628	practically non-alcoholic aged ghostly Herring Wallbanger	1	awesome	Last Available: "2012-03"
+5627	watered-down acceptable jittery Herring Daiquiri	2	good	Last Available: "2012-03"
+5628	aged practically non-alcoholic ghostly Herring Wallbanger	1	awesome	Last Available: "2012-03"
 5629	lousy Herringtini	3	decent	Last Available: "2012-03"
-5630	drinkable watered-down Lollipop Drop	2	good	Last Available: "2012-03"
+5630	watered-down drinkable Lollipop Drop	2	good	Last Available: "2012-03"
 5631	artisanal Candy Alexander	3	EPIC	Last Available: "2012-03"
 5632	lousy Candicaine	3	decent	Last Available: "2012-03"
 5633	lousy practically non-alcoholic spinning Caipiranha	1	decent	Last Available: "2012-03"
@@ -5538,23 +5538,23 @@
 5635	lousy ghostly Flaming Caipiranha	3	decent	Last Available: "2012-03"
 5636	tolerable watered-down skewed Punchplanter	2	good	Last Available: "2012-03"
 5637	drinkable spinning Doublepunchplanter	3	good	Last Available: "2012-03"
-5638	special smooth Haymaker	3	awesome	Effect: "Cat Class, Cat Style", Effect Duration: 20, Last Available: "2012-03"
+5638	smooth special Haymaker	3	awesome	Effect: "Cat Class, Cat Style", Effect Duration: 20, Last Available: "2012-03"
 5639	huge Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	shaking crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	adequate fungus	3	good	
 5642	poisoned dart	0		
-5643	pressed wet teal skewed stone wool	0		Effect: "Bananas!", Effect Duration: 17
+5643	pressed wet skewed teal stone wool	0		Effect: "Bananas!", Effect Duration: 17
 5644	skewed stones	0		
 5645	narrow the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	calendar of the sewer	0		Stench Damage: +25, Damage Reduction: 4
-5648	ghostly coward's Socratic Boris's Helm	0		Experience (Mysticality): +1, Monster Level: -20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	ghostly coward's Socratic Boris's Helm	0		Experience (Mysticality): +1, Monster Level: -20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	skewed tumbling wool smooth staph of homophones	0		Moxie: +15, Cold Resistance: +1
-5650	yellow sizzling brainy Boris's Helm (askew) of the wise owl	0		Mysticality: 25, Hot Damage: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	yellow sizzling brainy Boris's Helm (askew) of the wise owl	0		Mysticality: 25, Hot Damage: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	shaking mime soul fragment	0		Last Available: "2012-04"
 5652	jittery maroon Monster Manuel	0		Free Pull
 5653	tumbling blinking key-o-tron	0		
-5654	snack-sized special bland nailswurst	2	decent	Effect: "Cat Class, Cat Style", Effect Duration: 35
+5654	snack-sized bland special nailswurst	2	decent	Effect: "Cat Class, Cat Style", Effect Duration: 35
 5655	artisanal used beer	4	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	wobbly fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5577,9 +5577,9 @@
 5674	wobbly &quot;L&quot;	0		
 5675	compressed watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	medical-grade Ze&trade; goggles	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	medical-grade Ze&trade; goggles	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	tumbling soggy used band-aid	0		Last Available: "2012-05"
-5679	inspector's steel-toed stylish swimsuit	0		Damage Reduction: 9, Item Drop: +15, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	inspector's steel-toed stylish swimsuit	0		Damage Reduction: 9, Item Drop: +15, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	spinning lost key	0		Last Available: "2012-05"
 5681	snack-sized moldy P.B.L.T.	2	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5587,7 +5587,7 @@
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	blinking upside-down bugbear autopsy tweezers	0		
+5687	upside-down blinking bugbear autopsy tweezers	0		
 5688	jittery vibrating UV monocular	0		Maximum MP Percent: +10, Single Equip
 5689	drone self-destruct chip	0		
 5690	Jeff Goldblum larva	0		
@@ -5605,17 +5605,17 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	shaking crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	healthy wax hat of courage	0		Maximum HP Percent: +20, Spooky Resistance: +3, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	strapping wax pants of doom	0		Muscle: +5, Spooky Spell Damage: +50, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	healthy wax hat of courage	0		Maximum HP Percent: +20, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	strapping wax pants of doom	0		Muscle: +5, Spooky Spell Damage: +50, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	oxidized drop of water-37	0		Effect: "A Contender", Effect Duration: 41, Last Available: "2012-07"
-5709	perfumed asbestos-lined fireman's helmet	0		Hot Resistance: +5, Stench Resistance: +5, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	perfumed asbestos-lined fireman's helmet	0		Hot Resistance: +5, Stench Resistance: +5, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	perfumed fire axe	0		Stench Resistance: +5, Last Available: "2012-07"
 5713	Sherlock's Tesla Herculean fire extinguisher	0		Experience (Muscle): +1, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	maroon Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	adequate half-sized FDKOL hotcakes	2	good	Last Available: "2012-07"
+5717	half-sized adequate FDKOL hotcakes	2	good	Last Available: "2012-07"
 5718	huge hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	rotten gigantic fiery wing	10	crappy	Last Available: "2012-07"
@@ -5624,13 +5624,13 @@
 5723	quantum extra-ionized bottle of fire	0		Effect: "Cat-Alyzed", Effect Duration: 21, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	upside-down greedy medical-grade hot daub bun	0		Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	electrified hot daub stand of dire peril	0		Weapon Damage: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	upside-down greedy medical-grade hot daub bun	0		Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	electrified hot daub stand of dire peril	0		Weapon Damage: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	spinning censurious foot-long hot daub of the blizzard	0		Cold Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	normal angst burger	3	good	
 5731	practically non-alcoholic perfectly mixed 5-hour acrimony	1	EPIC	
-5732	pulsating fuchsia blank note	0		
+5732	fuchsia pulsating blank note	0		
 5733	eerily silent box	0		
 5734	adequate small forbidden sausage	2	good	
 5735	pulsating Jeselnik's Lord Flameface's cloak	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
@@ -5638,23 +5638,23 @@
 5737	Vulcanized quantum daub-breaker	0		Effect: "Sensation", Effect Duration: 56, Last Available: "2020-09"
 5738	Camp Scout backpack of incineration	0		Hot Spell Damage: +50, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	big rotten bag of GORP	5	crappy	Last Available: "2012-07"
-5741	aged practically non-alcoholic special narrow teal water purification pills	1	awesome	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2012-07"
+5740	rotten big bag of GORP	5	crappy	Last Available: "2012-07"
+5741	practically non-alcoholic aged special teal narrow water purification pills	1	awesome	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2012-07"
 5742	bouncing Camp Scout pup tent	0		Last Available: "2012-07"
-5743	practically non-alcoholic perfectly mixed teal CSA scoutmaster's &quot;water&quot;	1	super ultra EPIC	Last Available: "2012-07"
+5743	perfectly mixed practically non-alcoholic teal CSA scoutmaster's &quot;water&quot;	1	super ultra EPIC	Last Available: "2012-07"
 5744	gigantic toothsome bag of GORF	9	awesome	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	normal miniature bag of QWOP	2	good	Last Available: "2012-07"
+5746	miniature normal bag of QWOP	2	good	Last Available: "2012-07"
 5747	galvanized CSA bravery badge	0		Effect: "Healthy Bronze Glow", Effect Duration: 48, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	enchanted tolerable CSA cheerfulness ration	4	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2012-07"
+5749	tolerable enchanted CSA cheerfulness ration	4	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	jumbo spoiled crappy brain	5	crappy	
 5753	rotten ghostly decent brain	4	crappy	
 5754	moldy good brain	4	crappy	
 5755	diet spoiled boss brain	1	crappy	
-5756	massive rotten hunter brain	8	crappy	
+5756	rotten massive hunter brain	8	crappy	
 5758	studded Sinatra's Staff of Holiday Sensations of James Dean	0		Experience (Moxie): 8, Damage Absorption: +80, Last Available: "2011-11"
 5759	brainy staff of Tarzan	0		Mysticality: +5, Experience (Muscle): +3
 5760	friendly grievous razor-sharp staff	0		Weapon Damage Percent: 75, Familiar Weight: +3
@@ -5665,11 +5665,11 @@
 5765	savvy fuzzy earmuffs of the scaredy-cat	0		Mysticality Percent: +20, Monster Level: -15, Familiar Effect: "1.5xVolley, cap 32"
 5766	blurry steel-toed rock-hard deadly fuzzy montera	0		Weapon Damage: +5, Damage Reduction: 28, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	pulsating gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	yellow gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5770	pulsating gnomish tennis elbow	0		Familiar Effect: "damage", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5772	yellow gnomish athlete's foot	0		Familiar Effect: "delevel", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
 5773	blurry Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5700,12 +5700,12 @@
 5801	activated Smart Bone Dust	0		Effect: "Musky", Effect Duration: 66
 5802	ionized perpendicular guano	0		Effect: "Stenchtastic", Effect Duration: 55
 5803	triple-moist dry pulsating White Chocolate Golem Seeds	0		Effect: "Serendipi Tea", Effect Duration: 26
-5804	chilled blue blinking wobbly Shivering Ch&egrave;vre	0		Effect: "Takin' It Greasy", Effect Duration: 58
+5804	chilled wobbly blue blinking Shivering Ch&egrave;vre	0		Effect: "Takin' It Greasy", Effect Duration: 58
 5805	colloidal colloidal mirror breath mint	0		Effect: "The Magic of Sharing", Effect Duration: 20
 5806	liquefied energized wet wobbly muesli	0		Effect: "Ninja, Please", Effect Duration: 40
 5807	magnetized magnetized wobbly glass of warm milk	0		Effect: "Bottle in front of Me", Effect Duration: 36
 5808	oxidized spinning glass of gnat milk	0		Effect: "Uncaged Power", Effect Duration: 38
-5809	polarized spinning ghostly Knob Goblin Mutagen	0		Effect: "Prelude of Precision", Effect Duration: 69
+5809	polarized ghostly spinning Knob Goblin Mutagen	0		Effect: "Prelude of Precision", Effect Duration: 69
 5810	double-energized Tears of the Quiet Healer	0		Effect: "Big Meat Big Prizes", Effect Duration: 11
 5811	vacuum-sealed twirling tube of lipstick	0		Effect: "Carrrsmic", Effect Duration: 65
 5812	oxidized skewed skelelton spine	0		Effect: "Buff as a Baobab", Effect Duration: 66
@@ -5715,27 +5715,27 @@
 5816	dry kobold kibble	0		Effect: "Human-Undead Hybrid", Effect Duration: 21
 5817	concentrated forest spirit rattle	0		Effect: "Memory of Strength", Effect Duration: 16
 5818	galvanized dry Stone Golem pebbles	0		Effect: "Fustulent", Effect Duration: 65
-5819	concentrated ionized boiled maroon narrow gravy fairy warlock hat	0		Effect: "Vitamin-Maxed", Effect Duration: 11
+5819	concentrated ionized boiled narrow maroon gravy fairy warlock hat	0		Effect: "Vitamin-Maxed", Effect Duration: 11
 5820	diffused mirror bull blubber	0		Effect: "Painted-On Bikini", Effect Duration: 22
 5821	non-enhanced altered triple-flattened red frog lip-print	0		Effect: "Smugness", Effect Duration: 46
-5822	unsweetened concentrated blue bouncing ghostly gazely stare	0		Effect: "Abyssal Tears", Effect Duration: 21
+5822	unsweetened concentrated blue ghostly bouncing gazely stare	0		Effect: "Abyssal Tears", Effect Duration: 21
 5823	corrupted vacuum-sealed narrow canopic jar	0		Effect: "Dreams and Lights", Effect Duration: 61
 5824	vacuum-sealed twirling clove-flavored lip balm	0		Effect: "In the Slimelight", Effect Duration: 27
 5825	non-dry concentrated Skullery Maid's Knee	0		Effect: "The Q Is Talking To You", Effect Duration: 12
 5826	super-electrified zombie hollandaise	0		Effect: "Astral Shell", Effect Duration: 41
 5827	moist anodized yellow skeletal banana	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 11
-5828	warmed concentrated corrupted upside-down shaking gilt perfume bottle	0		Effect: "Heart of Orange", Effect Duration: 28
+5828	warmed concentrated corrupted shaking upside-down gilt perfume bottle	0		Effect: "Heart of Orange", Effect Duration: 28
 5829	deionized twirling purple janglin' bones	0		Effect: "White-boy Angst", Effect Duration: 21
 5830	activated pygmy papers	0		Effect: "Mental A-cue-ity", Effect Duration: 51
 5831	magnetized flattened olive pygmy dart	0		Effect: "Standard Cheer", Effect Duration: 57
 5832	concentrated diffused dry secret mummy herbs and spices	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 12
 5833	altered quantum bouncing brigand brittle	0		Effect: "Hammertime", Effect Duration: 62
-5834	diffused aerosolized fuchsia bouncing holistic headache remedy	0		Effect: "Arabian Knighthood", Effect Duration: 49
+5834	diffused aerosolized bouncing fuchsia holistic headache remedy	0		Effect: "Arabian Knighthood", Effect Duration: 49
 5835	altered scrunchie tourniquet	0		Effect: "Crimbo Epiphany", Effect Duration: 11
 5836	electrified wet vacuum-sealed upside-down embezzler's oil	0		Effect: "Toothy Grin", Effect Duration: 24
 5837	extra-improved alkaline pulsating Fu Manchu Wax	0		Effect: "Kindly Resolve", Effect Duration: 48
 5838	nitrogenated Iiti Kitty Gumdrop	0		Effect: "Make Meat FA$T!", Effect Duration: 14
-5839	triple-boiled pickled olive blurry ravenous eye	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 32
+5839	triple-boiled pickled blurry olive ravenous eye	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 32
 5840	dry aerosolized pickled cyan Rogue Windmill Rouge	0		Effect: "Tiki Toughness", Effect Duration: 41
 5841	diffused deionized bouncing A muse-bouche	0		Effect: "Arcane in the Brain", Effect Duration: 57
 5842	flattened double-Vulcanized yellow toothbrush	0		Effect: "Shamboozled", Effect Duration: 12
@@ -5754,11 +5754,11 @@
 5855	super-frozen irradiated Osk'r Chow	0		Effect: "Bread-Lined", Effect Duration: 67
 5856	moist Scuba Snack	0		Effect: "Top Dog", Effect Duration: 44
 5857	moist pickled grey cube	0		Effect: "Purpose", Effect Duration: 57
-5858	Vulcanized tumbling jittery votive candle	0		Effect: "Blood-Rich", Effect Duration: 42
+5858	Vulcanized jittery tumbling votive candle	0		Effect: "Blood-Rich", Effect Duration: 42
 5859	double-wet non-chilled jittery booby trap	0		Effect: "Hyperoxygenated Blood", Effect Duration: 32
 5860	enhanced altered huge Agent Corrigan's cigarette	0		Effect: "Butt-Rock Hair", Effect Duration: 41
 5861	anodized narrow good ash	0		Effect: "meat.enh", Effect Duration: 56
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	skewed papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	adjusted papier-mochi	0		Effect: "Rampage!", Effect Duration: 14, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	arcane researcher's sage papier-m&acirc;ch&eacute;te	0		Mysticality Percent: +10, Experience Percent (Mysticality): +10, Last Available: "2012-09"
 5869	MacGyver's papier-m&acirc;chine gun of wisdom	0		Mysticality: +15, Maximum MP: +100, Last Available: "2012-09"
 5870	wobbly blue up-at-dawn nippy papier-masque	0		Cold Damage: +10, Adventures: +5, Single Equip, Last Available: "2012-09"
-5871	quilted papier-mitre of wisdom	0		Mysticality: +15, Damage Absorption: +40, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	wobbly perfumed papier-m&acirc;churidars of the sewer	0		Stench Damage: +25, Stench Resistance: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	quilted papier-mitre of wisdom	0		Mysticality: +15, Damage Absorption: +40, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	wobbly perfumed papier-m&acirc;churidars of the sewer	0		Stench Damage: +25, Stench Resistance: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	green papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	narrow papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5797,7 +5797,7 @@
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	wobbly jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
-5901	narrow olive jar of psychoses (The Old Man)	0		Last Available: "2013-12"
+5901	olive narrow jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	bouncing bouncing jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	wobbly jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jittery jar of psychoses (Jick)	0		Last Available: "2013-12"
@@ -5809,8 +5809,8 @@
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	Da Vinci's Solstice Shield of the scaredy-cat	0		Experience (Mysticality): +5, Monster Level: -15
 5913	moist activated blurry tumbling candy sushi set	0		Effect: "Think Win-Lose", Effect Duration: 47, Last Available: "2012-12"
-5914	extra-anodized spinning narrow sweet mochi ball	0		Effect: "Staying Frosty", Effect Duration: 28, Last Available: "2012-12"
-5915	flattened teal squat beet-flavored Mr. Mediocrebar	0		Effect: "Sepia Tan", Effect Duration: 13, Last Available: "2012-12"
+5914	extra-anodized narrow spinning sweet mochi ball	0		Effect: "Staying Frosty", Effect Duration: 28, Last Available: "2012-12"
+5915	flattened squat teal beet-flavored Mr. Mediocrebar	0		Effect: "Sepia Tan", Effect Duration: 13, Last Available: "2012-12"
 5916	pickled sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Human-Insect Hybrid", Effect Duration: 20, Last Available: "2012-12"
 5917	triple-corrupted galvanized blurry cabbage-flavored Mr. Mediocrebar	0		Effect: "Chlorophyll Flavor", Effect Duration: 16, Last Available: "2012-12"
 5918	purple smooth plastic animelf	0		Moxie: +15, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	fuchsia BittyCar HotCar	0		Last Available: "2012-12"
-5928	huge brainwave-controlled unicorn horn of mayonnaise	0		Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	huge brainwave-controlled unicorn horn of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
 5929	wobbly bubble-wrap simulator	0		Last Available: "2012-12"
 5930	huge blind-packed capsule toy	0		Last Available: "2012-12"
 5931	sinister plastic four-shadowed mime of dire peril of chilblains	0		Weapon Damage: +20, Spell Damage: +10, Cold Damage: +25, Single Equip, Last Available: "2012-12"
@@ -5858,8 +5858,8 @@
 5960	blinking plastic Father McGruber of bravery	0		Spooky Resistance: +5, Last Available: "2012-12"
 5961	sinister plastic Hank North, Photojournalist	0		Spell Damage: +10, Last Available: "2012-12"
 5962	dance instructor's plastic blazing bat	0		Experience Percent (Moxie): +10, Last Available: "2012-12"
-5963	beefy electronic dulcimer pants of Leguizamo	0		Muscle: +10, Monster Level: +20, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
-5964	upside-down mirror A-Boo clue	0		
+5963	beefy electronic dulcimer pants of Leguizamo	0		Muscle: +10, Monster Level: +20, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
+5964	mirror upside-down A-Boo clue	0		
 5965	rock-hard Frown Exerciser of the cheetah	0		Damage Reduction: 5, Initiative: +60, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	squat soul doorbell	0		
@@ -5877,9 +5877,9 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	maroon star	0		Last Available: "2013-02"
-5982	tolerable practically non-alcoholic tankard of ale	1	good	Last Available: "2013-02"
+5982	practically non-alcoholic tolerable tankard of ale	1	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	scandalous personal trainer's cloth cap of the scaredy-cat	0		Experience Percent (Muscle): +10, Monster Level: -15, Sleaze Damage: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	scandalous personal trainer's cloth cap of the scaredy-cat	0		Experience Percent (Muscle): +10, Monster Level: -15, Sleaze Damage: +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	sinister Rosewater's iron dagger of the sewer	0		Mysticality Percent: +30, Spell Damage: +10, Stench Damage: +25, Last Available: "2013-02"
 5986	adequate snack-sized hamburger	2	good	Last Available: "2013-02"
 5987	pulsating dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,7 +5887,7 @@
 5989	purple potion	0		Last Available: "2013-02"
 5990	artisanal bottle of wine	3	EPIC	Last Available: "2013-02"
 5991	squat round bomb	0		Last Available: "2013-02"
-5992	executive lion tamer's grievous iron helmet	0		Weapon Damage Percent: +50, Experience (familiar): +2, Meat Drop: +40, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	executive lion tamer's grievous iron helmet	0		Weapon Damage Percent: +50, Experience (familiar): +2, Meat Drop: +40, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	spinning resourceful razor-sharp educational steel sword	0		Experience: +1, Weapon Damage Percent: +25, Maximum MP: +50, Last Available: "2013-02"
 5994	rotten small whole roasted chicken	2	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	smooth shining goblet	4	awesome	Last Available: "2013-02"
 5999	twirling fireball	0		Last Available: "2013-02"
-6000	mirror inspector's ruddy thinker's crown	0		Mysticality: +10, Maximum HP Percent: +40, Item Drop: +15, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	mirror inspector's ruddy thinker's crown	0		Mysticality: +10, Maximum HP Percent: +40, Item Drop: +15, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	purple chilly ruddy sword of the boozehound	0		Maximum HP Percent: +40, Cold Damage: +5, Booze Drop: +100, Last Available: "2013-02"
-6002	green blurry Usain Bolt's Jack Frost's Helm of the Scream Emperor of the brute	0		Muscle Percent: +30, Cold Spell Damage: +50, Initiative: +80, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	green blurry Usain Bolt's Jack Frost's Helm of the Scream Emperor of the brute	0		Muscle Percent: +30, Cold Spell Damage: +50, Initiative: +80, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	Annie Oakley's sinister Cloak of Dire Shadows of the wise owl	0		Mysticality: +20, Spell Damage: +10, Critical Hit Percent: +20, Last Available: "2013-02"
 6004	blue executive friendly energetic Sword of Dark Omens	0		Maximum MP Percent: +20, Familiar Weight: +3, Meat Drop: +40, Last Available: "2013-02"
 6005	skewed sharpshooter's Shield of Icy Fate of James Dean of incineration	0		Experience (Moxie): +3, Critical Hit Percent: +10, Hot Spell Damage: +50, Damage Reduction: 7, Last Available: "2013-02"
-6006	ghostly gravedigger's chilly boxer's Greaves of the Murk Lord	0		Muscle Percent: +10, Cold Damage: +5, Spooky Damage: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	ghostly gravedigger's chilly boxer's Greaves of the Murk Lord	0		Muscle Percent: +10, Cold Damage: +5, Spooky Damage: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	wool steel-toed experienced Gauntlets of the Blood Moon	0		Experience: +2, Damage Reduction: 9, Cold Resistance: +1, Single Equip, Last Available: "2013-02"
 6008	tumbling tumbling lard-coated steel-toed smartaleck's Boots of Twilight Whispers	0		Moxie Percent: +30, Damage Reduction: 9, Sleaze Spell Damage: +25, Single Equip, Last Available: "2013-02"
 6009	spinning Belt of Howling Anger of the brute of Gandalf of doom	0		Muscle Percent: +30, Spell Critical Percent: +20, Spooky Spell Damage: +50, Single Equip, Last Available: "2013-02"
@@ -5931,9 +5931,9 @@
 6033	Fonzie's beefcake's stolen necklace	0		Muscle: +25, Experience (Moxie): +1
 6034	manspreader's smartaleck's troll britches	0		Moxie Percent: +30, Monster Level: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	vacuum-sealed super-improved diffused vial of The Glistening	0		Effect: "Graham Crackling", Effect Duration: 24
-6036	practically non-alcoholic acceptable artisanal limoncello	1	good	
+6036	acceptable practically non-alcoholic artisanal limoncello	1	good	
 6037	ginger ale	0		
-6038	enchanted miniature normal red wobbly incredible pizza	2	good	Effect: "Frog In Your Throat", Effect Duration: 20
+6038	normal miniature enchanted wobbly red incredible pizza	2	good	Effect: "Frog In Your Throat", Effect Duration: 20
 6039	stanky oil cap	0		Stench Spell Damage: +25, Item Drop: +5, Familiar Effect: "cap 28"
 6040	dance instructor's oil lamp of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50
 6041	skewed stylish oil slacks	0		Moxie: +25, Familiar Effect: "1xPotato, cap 30"
@@ -5966,13 +5966,13 @@
 6068	loose blade	0		
 6069	cyan goblin bone hilt	0		
 6070	sword blade	0		
-6071	bouncing Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	bouncing Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	chilled skewed haggis-infused soap	0		Effect: "Crud&eacute;", Effect Duration: 50, Last Available: "2012-12"
 6074	super-improved super-altered pickled squat twirling magicberry tablets	0		Effect: "Cold Jellied", Effect Duration: 29, Last Available: "2012-12"
-6075	activated narrow bouncing 37x37x37 puzzle cube	0		Effect: "Eye of the Seal", Effect Duration: 14, Last Available: "2012-12"
+6075	activated bouncing narrow 37x37x37 puzzle cube	0		Effect: "Eye of the Seal", Effect Duration: 14, Last Available: "2012-12"
 6076	mediocre practically non-alcoholic McLeod's Hard Haggis-Ade	1	decent	Last Available: "2012-12"
-6077	adequate enchanted haggis-wrapped haggis-stuffed haggis	4	good	Effect: "Fishy", Effect Duration: 45, Last Available: "2012-12"
+6077	enchanted adequate haggis-wrapped haggis-stuffed haggis	4	good	Effect: "Fishy", Effect Duration: 45, Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	twirling blue haggis socks of the boozehound	0		Booze Drop: +100, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
@@ -6016,11 +6016,11 @@
 6118	jittery goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	acceptable triple-distilled skewed Chinese beer	9	good	Last Available: "2013-12"
+6121	triple-distilled acceptable skewed Chinese beer	9	good	Last Available: "2013-12"
 6122	twirling cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	skewed furry pink pillow	0		Last Available: "2013-12"
-6125	super-modified dry blinking spinning bottle of limeade	0		Effect: "La Bamba", Effect Duration: 35, Last Available: "2013-12"
+6125	super-modified dry spinning blinking bottle of limeade	0		Effect: "La Bamba", Effect Duration: 35, Last Available: "2013-12"
 6126	Samson's slick novelty tattoo sleeves	0		Moxie: +10, Experience (Muscle): +5, Single Equip, Last Available: "2013-12"
 6127	upside-down pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	huge furry brown pillow	0		Last Available: "2013-12"
@@ -6038,18 +6038,18 @@
 6140	skewed Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	delicious roasted duck	3	awesome	Last Available: "2013-12"
-6143	bite-sized stale huge dead meat bun	1	decent	Last Available: "2013-12"
+6143	stale bite-sized huge dead meat bun	1	decent	Last Available: "2013-12"
 6144	careful cat collar	0		Monster Level: -10, Single Equip, Last Available: "2013-12"
-6145	suspicious-looking fedora of the overflowing toilet of the businessman	0		Stench Spell Damage: +50, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	suspicious-looking fedora of the overflowing toilet of the businessman	0		Stench Spell Damage: +50, Meat Drop: +50, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	jittery MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	decent carrot cake	4	good	Last Available: "2013-01"
-6153	hand-crafted blinking spinning carrot claret	3	EPIC	Last Available: "2013-01"
+6153	hand-crafted spinning blinking carrot claret	3	EPIC	Last Available: "2013-01"
 6154	compressed blue upside-down carrot juice	1	EPIC	Effect: "Spring Training", Effect Duration: 15, Last Available: "2013-01"
-6155	purple narrow pixel power cell	0		Last Available: "2013-12"
+6155	narrow purple pixel power cell	0		Last Available: "2013-12"
 6156	blinking flickering pixel	0		Last Available: "2013-12"
 6157	bouncing spinning scandalous Byte of the businessman	0		Sleaze Damage: +5, Meat Drop: +50, Last Available: "2013-12"
 6158	jittery dance instructor's anger blaster	0		Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
@@ -6058,13 +6058,13 @@
 6161	frightening regret hose	0		Spooky Damage: +5, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	teal Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	red Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	Lo Pan's therapeutic commodore's hat	0		Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	naval trousers of Flo-Jo	0		Initiative: +100, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	Lo Pan's therapeutic commodore's hat	0		Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	naval trousers of Flo-Jo	0		Initiative: +100, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	baleful Da Vinci's deck cannon	0		Experience (Mysticality): +5, Spell Damage: +25, Last Available: "2013-12"
 6167	fuchsia wool ornamental sextant	0		Cold Resistance: +1, Last Available: "2013-12"
 6168	Usain Bolt's auspicious Bloodbath	0		Item Drop: +10, Initiative: +80, Last Available: "2013-12"
 6169	smooth Hundred Headed IPA	4	awesome	Last Available: "2013-12"
-6170	moldy half-sized chum	2	crappy	Last Available: "2013-12"
+6170	half-sized moldy chum	2	crappy	Last Available: "2013-12"
 6171	nitrogenated chilled crude crudit&eacute;s	0		Effect: "Stenchtastic", Effect Duration: 61
 6172	triple-magnetized improved blurry candy crayons	0		Effect: "Stench Jellied", Effect Duration: 69, Last Available: "2020-09"
 6173	smooth pixel grappling hook of the pedagogue	0		Moxie: +15, Experience: +3
@@ -6089,57 +6089,57 @@
 6192	flavorless pulsating consummate toast	3	decent	
 6193	delicious upside-down passable stout	3	awesome	
 6194	stale consummate soup	4	decent	
-6195	tiny bland mirror consummate corn chips	1	decent	
+6195	bland tiny mirror consummate corn chips	1	decent	
 6196	big stale enchanted yellow consummate salad	5	decent	Effect: "Physicali Tea", Effect Duration: 45
-6197	stale tiny yellow upside-down consummate salsa	1	decent	
-6198	rotten huge blurry consummate sauerkraut	3	crappy	
-6199	rotten low-calorie squat consummate cheese slice	1	crappy	
+6197	tiny stale upside-down yellow consummate salsa	1	decent	
+6198	rotten blurry huge consummate sauerkraut	3	crappy	
+6199	low-calorie rotten squat consummate cheese slice	1	crappy	
 6200	miniature adequate consummate melted cheese	2	good	
-6201	delicious jumbo consummate bacon	5	awesome	
+6201	jumbo delicious consummate bacon	5	awesome	
 6202	spoiled consummate meatloaf	4	crappy	
 6203	rotten consummate steak	3	crappy	
 6204	toothsome consummate cuts	3	awesome	
 6205	massive flavorless consummate frankfurter	10	decent	
-6206	snack-sized rotten consummate french fries	2	crappy	
+6206	rotten snack-sized consummate french fries	2	crappy	
 6207	adequate consummate baked potato	3	good	
-6208	practically non-alcoholic tolerable acceptable vodka	1	good	
-6209	moldy small special tumbling wobbly consummate ice cream	2	crappy	Effect: "Chalk Outline", Effect Duration: 15
+6208	tolerable practically non-alcoholic acceptable vodka	1	good	
+6209	small special moldy tumbling wobbly consummate ice cream	2	crappy	Effect: "Chalk Outline", Effect Duration: 15
 6210	thick spoiled consummate whipped cream	5	crappy	
-6211	small delicious tumbling consummate cream	2	awesome	
-6212	bland massive spinning consummate strawberries	6	decent	
+6211	delicious small tumbling consummate cream	2	awesome	
+6212	massive bland spinning consummate strawberries	6	decent	
 6213	normal consummate sorbet	4	good	
 6214	acceptable wobbly adequate rum	3	good	
 6215	mediocre narrow mediocre lager	4	decent	
 6216	stale immaculate grilled cheese	4	decent	
-6217	adequate big immaculate ice cream sandwich	5	good	
+6217	big adequate immaculate ice cream sandwich	5	good	
 6218	spoiled immaculate hot dog	4	crappy	
 6219	spoiled ghostly teal immaculate egg salad sandwich	4	crappy	
-6220	small delicious green huge perfect sandwich	2	awesome	
+6220	small delicious huge green perfect sandwich	2	awesome	
 6221	rotten cyan perfect chef salad	4	crappy	
 6222	flavorless tumbling perfect breakfast	3	decent	
 6223	fancy flavorless sublime deluxe hot dog	3	decent	Effect: "Human-Penguin Hybrid", Effect Duration: 10
-6224	enchanted immense yummy narrow sublime stew	9	awesome	Effect: "Dirty Pear", Effect Duration: 50
-6225	massive decent fancy sublime nachos	7	good	Effect: "Happy Trails", Effect Duration: 50
+6224	enchanted yummy immense narrow sublime stew	9	awesome	Effect: "Dirty Pear", Effect Duration: 50
+6225	fancy decent massive sublime nachos	7	good	Effect: "Happy Trails", Effect Duration: 50
 6226	normal thick cyan Ultimate Breakfast Sandwich	5	good	
-6227	immense moldy huge Loaded Baked Potato	9	crappy	
+6227	moldy immense huge Loaded Baked Potato	9	crappy	
 6228	stale Omega Sundae	3	decent	
 6229	artisanal Das Sauerlager	4	EPIC	
 6230	strong tolerable mirror Bologna Lambic	5	good	
 6231	artisanal Vodka Dog	3	EPIC	
 6232	lousy wobbly Disappointed Russian	4	decent	
-6233	watered-down artisanal cyan Chunky Mary	2	EPIC	
-6234	watered-down artisanal Nachojito	2	EPIC	
+6233	artisanal watered-down cyan Chunky Mary	2	EPIC	
+6234	artisanal watered-down Nachojito	2	EPIC	
 6235	boozy hand-crafted Le Roi	5	EPIC	
 6236	artisanal high-proof Over Easy Rider	7	EPIC	
 6237	cosmic six-pack	0		
 6239	denatured tarnished cube of ectoplasm	0		Effect: "Fit To Be Tide", Effect Duration: 51
 6240	Vulcanized energized Illuminati earpiece	0		Effect: "The Power of LOV", Effect Duration: 45
 6241	anodized censored can label	0		Effect: "Spirit of Alph", Effect Duration: 68
-6242	extra-dry fuchsia skewed ectoplasm <i>au jus</i>	0		Effect: "Springy Fusilli", Effect Duration: 53
+6242	extra-dry skewed fuchsia ectoplasm <i>au jus</i>	0		Effect: "Springy Fusilli", Effect Duration: 53
 6243	polymerized tumbling the kindest cut	0		Effect: "Innately Wise", Effect Duration: 56
 6244	polymerized corrupted cat's paw	0		Effect: "Musky", Effect Duration: 40
 6245	Vulcanized squat ASCII fu manchu	0		Effect: "Rat-Faced", Effect Duration: 51
-6246	electrified polarized squat yellow demonic surgical gloves	0		Effect: "Stinky Weapon", Effect Duration: 63
+6246	electrified polarized yellow squat demonic surgical gloves	0		Effect: "Stinky Weapon", Effect Duration: 63
 6247	energized altered wobbly clip-on ninja tie	0		Effect: "Smokin'", Effect Duration: 54
 6248	tarnished skewed gamer slurry	0		Effect: "Aided and Abetted", Effect Duration: 25
 6249	dungeoneering kit	0		Last Available: "2013-02"
@@ -6169,7 +6169,7 @@
 6273	electrified bouncing O'RLY manual	0		Effect: "Berry Experiential", Effect Duration: 67
 6274	bad practically non-alcoholic pulsating open sauce	1	decent	
 6275	tumbling tumbling green foul-smelling Van der Graaf turkey leg	0		Stench Damage: +10, MP Regen Min: 5, MP Regen Max: 7
-6276	weak smooth cyan Ye Olde Meade	2	awesome	
+6276	smooth weak cyan Ye Olde Meade	2	awesome	
 6277	tarnished improved lime green Ye Olde Bawdy Limerick	0		Effect: "Vitali Tea", Effect Duration: 13
 6278	Ye Olde Medieval Insult	0		
 6279	jittery arcane researcher's pewter claymore	0		Experience Percent (Mysticality): +10
@@ -6182,7 +6182,7 @@
 6286	frightening studded forbidden Mark II Steam-Hat	0		Spell Damage Percent: +50, Damage Absorption: +80, Spooky Damage: +5, Familiar Effect: "1xLep, cap 37"
 6287	auspicious mansplainer's Mark III Steam-Hat of James Dean of courage	0		Experience (Moxie): +3, Monster Level: +15, Spooky Resistance: +3, Item Drop: +10, Familiar Effect: "1xLep, cap 37"
 6288	squat Oprah's quilted Samson's supercool Mark IV Steam-Hat of Tarzan	0		Moxie Percent: +20, Experience (Muscle): 8, Damage Absorption: +40, Maximum MP Percent: +50, Familiar Effect: "1xLep, cap 37"
-6289	scorching Oprah's banded sinister Mark V Steam-Hat of the sewer	0		Spell Damage: +10, Damage Absorption: +100, Maximum MP Percent: +50, Hot Damage: +25, Stench Damage: +25, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	scorching Oprah's banded sinister Mark V Steam-Hat of the sewer	0		Spell Damage: +10, Damage Absorption: +100, Maximum MP Percent: +50, Hot Damage: +25, Stench Damage: +25, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	steam-powered model rocketship	0		
 6291	Jeselnik's healthy punk rock jacket	0		Maximum HP Percent: +20, Sleaze Damage: +25
 6292	up-at-dawn scandalous safety pin	0		Sleaze Damage: +5, Adventures: +5
@@ -6194,7 +6194,7 @@
 6298	blinking Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	boiled fuchsia Super Weight-Gain 9000	0		Effect: "Become Intensely interested", Effect Duration: 24
-6301	corrupted energized spinning narrow possibility potion	0		Effect: "Human-Machine Hybrid", Effect Duration: 44
+6301	corrupted energized narrow spinning possibility potion	0		Effect: "Human-Machine Hybrid", Effect Duration: 44
 6302	eleven-foot pole	0		
 6303	ring of Detect Boring Doors	0		
 6304	upside-down narrow lightning-fast miser's forbidden arcane researcher's thinker's Jarlsberg's pan (Cosmic portal mode)	0		Mysticality: +10, Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Meat Drop: +10, Initiative: +40, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6238,7 +6238,7 @@
 6342	Usain Bolt's studded super-strong air freshener	0		Damage Absorption: +80, Initiative: +80
 6343	Vulcanized dry alkaline Mer-kin lipstick	0		Effect: "Orchid Blood", Effect Duration: 63
 6344	Mer-kin mouthsoap	0		
-6345	enhanced lime green twirling Mer-kin strongjuice	0		Effect: "Proprie Tea", Effect Duration: 57
+6345	enhanced twirling lime green Mer-kin strongjuice	0		Effect: "Proprie Tea", Effect Duration: 57
 6346	skewed Mer-kin fitbrine	0		
 6347	super-activated activated Mer-kin ragejuice	0		Effect: "Steroid Boost", Effect Duration: 30
 6348	scorching Mer-kin dragbelt	0		Hot Damage: +25, Experience (Muscle): +20, Single Equip
@@ -6253,7 +6253,7 @@
 6357	blinking Mer-kin knucklebone	0		
 6358	narrow Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	huge Newton's Mer-kin begsign	0		Experience (Mysticality): +3, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	liquefied pulled taffy	0		Effect: "Influence of Sphere", Effect Duration: 54, Last Available: "2013-04"
 6362	frozen pulled indigo taffy	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 59, Last Available: "2013-04"
 6363	modified altered wet pulled taffy	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 17, Last Available: "2013-04"
@@ -6262,10 +6262,10 @@
 6366	tarnished triple-quantum wet pulled violet taffy	0		Effect: "Okee-Dokee Computer", Effect Duration: 25, Last Available: "2013-04"
 6367	oxidized activated energized pulled taffy	0		Effect: "Human-Elf Hybrid", Effect Duration: 13, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
-6369	ghostly skewed lump of clay	0		
+6369	skewed ghostly lump of clay	0		
 6370	twisted piece of wire	0		
 6371	artisanal can of the cheapest beer	3	EPIC	
-6372	tolerable practically non-alcoholic bottle of fruity &quot;wine&quot;	1	good	
+6372	practically non-alcoholic tolerable bottle of fruity &quot;wine&quot;	1	good	
 6373	hand-crafted single swig of vodka	3	EPIC	
 6374	angry inch	0		
 6375	teal razor-sharp testy toolbox	0		Weapon Damage Percent: +25
@@ -6314,7 +6314,7 @@
 6419	quadruple-irradiated blinking moth dust	0		Effect: "Extra Terrestrial", Effect Duration: 45
 6420	tarnished tarnished concentrated huge glob of spoiled mayo	0		Effect: "Nature's Bounty", Effect Duration: 38
 6421	blinking tonic djinn	0		
-6422	spoiled super-sized teal vampire chowder	5	crappy	
+6422	super-sized spoiled teal vampire chowder	5	crappy	
 6423	blinking Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6429,7 +6429,7 @@
 6534	zippy remorseless knife	0		Initiative: +20
 6535	hardened intimidating coiffure	0		Damage Reduction: 3, Familiar Effect: "hot afk, 1xPotato"
 6536	narrow veiny Rosewater's cod cape	0		Mysticality Percent: +30, Maximum HP: +10
-6537	tiny flavorless blood sausage	1	decent	
+6537	flavorless tiny blood sausage	1	decent	
 6538	Annie Oakley's therapeutic frying brainpan	0		Critical Hit Percent: +20, HP Regen Min: 5, HP Regen Max: 7
 6539	up-at-dawn ball and chain of the cougar	0		Moxie: +20, Adventures: +5, Single Equip
 6540	supercool dry bone	0		Moxie Percent: +20
@@ -6440,7 +6440,7 @@
 6546	blinking greedy pants of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +20, Familiar Effect: "atk"
 6547	fuchsia Thwaitgold Goliath beetle statuette	0		
 6548	cooling iron helmet	0		
-6549	ghostly shaking cooling iron breastplate	0		
+6549	shaking ghostly cooling iron breastplate	0		
 6550	wobbly cooling iron greaves	0		
 6551	hot cluster	0		
 6552	cluster	0		
@@ -6455,16 +6455,16 @@
 6561	twirling adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	shaking wizardly hand of Mr. Cards	0		Mysticality: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	yummy tiny Dreadsylvanian hot pocket	1	awesome	
+6564	tiny yummy Dreadsylvanian hot pocket	1	awesome	
 6565	moldy Dreadsylvanian pocket	3	crappy	
 6566	spoiled Dreadsylvanian pocket	4	crappy	
-6567	snack-sized normal Dreadsylvanian stink pocket	2	good	
+6567	normal snack-sized Dreadsylvanian stink pocket	2	good	
 6568	flavorless small Dreadsylvanian sleaze pocket	2	decent	
-6569	practically non-alcoholic mediocre Dreadsylvanian hot toddy	1	decent	
-6570	acceptable irresponsibly strong Dreadsylvanian cold-fashioned	6	good	
-6571	hand-crafted enchanted Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	Effect: "Chalk Outline", Effect Duration: 40
+6569	mediocre practically non-alcoholic Dreadsylvanian hot toddy	1	decent	
+6570	irresponsibly strong acceptable Dreadsylvanian cold-fashioned	6	good	
+6571	enchanted hand-crafted Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	Effect: "Chalk Outline", Effect Duration: 40
 6572	enchanted acceptable Dreadsylvanian dank and stormy	3	good	Effect: "Cotton Mouthed", Effect Duration: 10
-6573	drinkable watered-down Dreadsylvanian slithery nipple	2	good	
+6573	watered-down drinkable Dreadsylvanian slithery nipple	2	good	
 6574	teal hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	twirling clusterbomb	0		
@@ -6472,7 +6472,7 @@
 6578	sleaze clusterbomb	0		
 6579	blinking Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
-6581	jittery mirror lime green dreadful box	0		
+6581	mirror lime green jittery dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	mirror vicious spiked collar	0		Familiar Damage: +20
 6584	beefcake's hot dog wrapper	0		Muscle: +25
@@ -6495,7 +6495,7 @@
 6601	clockwork numeral I	0		
 6602	mirror clockwork numeral II	0		
 6603	clockwork numeral III	0		
-6604	shaking blinking clockwork numeral IV	0		
+6604	blinking shaking clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
@@ -6513,7 +6513,7 @@
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	bouncing jittery folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
-6622	maroon shaking skewed folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
+6622	maroon skewed shaking folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
@@ -6541,14 +6541,14 @@
 6649	quantum concentrated pulsating Ogres and Oubliettes&trade; module	0		Effect: "Sugar High", Effect Duration: 58
 6650	wobbly teal Mountain Stream Code Black Alert	0		
 6651	blinking twisted-up wet towel	0		
-6652	weak bad shaking stepmom's booze	2	decent	
+6652	bad weak shaking stepmom's booze	2	decent	
 6653	surgical tape	0		
 6654	miser's band T-shirt	0		Meat Drop: +10
-6655	watered-down drinkable fountain 'soda'	2	good	
+6655	drinkable watered-down fountain 'soda'	2	good	
 6656	pulsating illegal firecracker	0		
 6657	fuchsia greedy crafty pickelhaube	0		Maximum MP: +10, Meat Drop: +20, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	energized frozen mirror hair oil	0		Effect: "Paging Betty", Effect Duration: 14
-6659	boiled ionized ionized skewed purple scrap	0		Effect: "Strange Mental Acuity", Effect Duration: 27
+6659	boiled ionized ionized purple skewed scrap	0		Effect: "Strange Mental Acuity", Effect Duration: 27
 6660	cyan school spirit socket set	0		
 6661	mirror suspension bridge	0		
 6662	pulsating aromatic fireproof mansplainer's Sinatra's Staff of the Lunch Lady	0		Experience (Moxie): +5, Monster Level: +15, Hot Resistance: +3, Stench Resistance: +1
@@ -6566,12 +6566,12 @@
 6674	red stinkbomb	0		
 6675	quadruple-deionized squat superwater	0		Effect: "Square to be Hip", Effect Duration: 30
 6676	spinning Thwaitgold bookworm statuette	0		
-6677	twirling ghostly crude monster sculpture	0		
+6677	ghostly twirling crude monster sculpture	0		
 6678	energetic Yearbook Club Camera	0		Maximum MP Percent: +20, Conditional Skill (Equipped): "Blinding Flash"
 6679	cyan skewed gravedigger's machete	0		Spooky Damage: +10
-6680	weak artisanal Cursed Punch	2	EPIC	
-6681	extra-dry lousy fancy twirling Bowl of Scorpions	5	decent	Effect: "The Two-Prong Crown", Effect Duration: 50
-6682	drinkable watered-down bouncing Fog Murderer	2	good	
+6680	artisanal weak Cursed Punch	2	EPIC	
+6681	lousy extra-dry fancy twirling Bowl of Scorpions	5	decent	Effect: "The Two-Prong Crown", Effect Duration: 50
+6682	watered-down drinkable bouncing Fog Murderer	2	good	
 6683	book of matches	0		
 6684	Tesla surgical mask	0		MP Regen Min: 7, MP Regen Max: 10, Surgeonosity: +1
 6685	Annie Oakley's head mirror	0		Critical Hit Percent: +20, Surgeonosity: +1
@@ -6623,7 +6623,7 @@
 6731	fuchsia Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	pulsating clothesline pole	0		
-6734	skewed cyan cigar sign	0		
+6734	cyan skewed cigar sign	0		
 6735	junk junk	0		
 6736	blurry Junk-Bond	0		
 6737	tangle of copper wire	0		
@@ -6635,7 +6635,7 @@
 6743	clever junk trunks	0		Maximum MP: +20, Familiar Effect: "cap 15"
 6744	lime green junk-mail shirt of the detective	0		Item Drop: +20
 6745	big fancy stale blinking skewed junk food	5	decent	Effect: "Emotion Sickness", Effect Duration: 50
-6746	artisanal weak olive junk yard	2	EPIC	
+6746	weak artisanal olive junk yard	2	EPIC	
 6747	careful medical-grade swordzall	0		Monster Level: -10, HP Regen Min: 7, HP Regen Max: 10
 6748	ghostly quilted arm buzzer	0		Damage Absorption: +40, Damage Reduction: 6
 6749	yellow sinister strapping boilgun	0		Muscle: +5, Spell Damage: +10
@@ -6647,18 +6647,18 @@
 6755	beer label	0		
 6756	blurry artisanal homebrew sampler	0		
 6757	hand-crafted can of Br&uuml;talbr&auml;u	3	EPIC	Last Available: "2013-09"
-6758	watered-down perfectly mixed can of Drooling Monk	2	EPIC	Last Available: "2013-09"
-6759	lousy lime green pulsating can of Impetuous Scofflaw	4	decent	Last Available: "2013-09"
+6758	perfectly mixed watered-down can of Drooling Monk	2	EPIC	Last Available: "2013-09"
+6759	lousy pulsating lime green can of Impetuous Scofflaw	4	decent	Last Available: "2013-09"
 6760	lousy bottle of Old Pugilist	3	decent	Last Available: "2013-09"
 6761	perfectly mixed narrow bottle of Professor Beer	4	EPIC	Last Available: "2013-09"
-6762	acceptable triple-distilled bottle of Rapier Witbier	10	good	Last Available: "2013-09"
+6762	triple-distilled acceptable bottle of Rapier Witbier	10	good	Last Available: "2013-09"
 6763	hand-crafted bottle of Race Car Red	3	EPIC	Last Available: "2013-09"
-6764	bad spirit-forward bottle of Greedy Dog	5	decent	Last Available: "2013-09"
+6764	spirit-forward bad bottle of Greedy Dog	5	decent	Last Available: "2013-09"
 6765	mediocre fortified bottle of Lambada Lambic	5	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	teal artisanal homebrew gift package	0		
 6768	liquid bread	1	EPIC	Last Available: "2013-09"
-6769	chaotic Oprah's tin tam of Gandalf	0		Maximum MP Percent: +50, Spell Critical Percent: 30, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	chaotic Oprah's tin tam of Gandalf	0		Maximum MP Percent: +50, Spell Critical Percent: 30, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	Vulcanized nitrogenated tin cup	0		Effect: "For Your Brain Only", Effect Duration: 67, Last Available: "2013-09"
 6771	greedy inspector's aromatic tin foil	0		Stench Resistance: +1, Item Drop: +15, Meat Drop: +20, Last Available: "2013-09"
 6772	sizzling Lo Pan's tin drum of the detective	0		Spell Critical Percent: +30, Hot Damage: +10, Item Drop: +20, Last Available: "2013-09"
@@ -6667,13 +6667,13 @@
 6775	gray tin lizzie	0		Last Available: "2013-09"
 6776	super-colloidal liquefied narrow foetid seal tear	0		Effect: "Disdain of She-Who-Was", Effect Duration: 45
 6777	moist seal sweat	0		Effect: "Unusual Perspective", Effect Duration: 49
-6778	wet activated skewed maroon boiling seal blood	0		Effect: "Creepin' Up on You", Effect Duration: 57
+6778	wet activated maroon skewed boiling seal blood	0		Effect: "Creepin' Up on You", Effect Duration: 57
 6779	crystalline seal eye	0		Single Equip
 6780	reassuring boxer's studded sealhide shield	0		Muscle Percent: +10, Spooky Resistance: +1, Damage Reduction: 7
 6781	sinister scabrous seal epaulets of Leguizamo	0		Spell Damage: +10, Monster Level: +20, Single Equip
 6782	huge abyssal battle plans	0		
 6783	aromatic chilly smartaleck's seal medal	0		Moxie Percent: +30, Cold Damage: +5, Stench Resistance: +1
-6784	pulsating tumbling deanimated reanimator's coffin	0		Free Pull
+6784	tumbling pulsating deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
 6788	blank diary	0		
 6789	fuchsia boot knife	0		
@@ -6690,7 +6690,7 @@
 6801	anodized pressed pulsating narrow disco horoscope (Leo)	0		Effect: "Neuromancy", Effect Duration: 22
 6802	improved disco horoscope (Virgo)	0		Effect: "Electrolit Up", Effect Duration: 59
 6803	dry moist wobbly disco horoscope (Libra)	0		Effect: "Unusual Perspective", Effect Duration: 36
-6804	anodized blinking spinning disco horoscope (Scorpio)	0		Effect: "Wintry Breath", Effect Duration: 30
+6804	anodized spinning blinking disco horoscope (Scorpio)	0		Effect: "Wintry Breath", Effect Duration: 30
 6805	deionized disco horoscope (Sagittarius)	0		Effect: "Coated Arms", Effect Duration: 57
 6806	activated improved twirling disco horoscope (Capricorn)	0		Effect: "Sparkling Consciousness", Effect Duration: 62
 6807	hardened The Sagittarian's leisure pants of the cheetah	0		Damage Reduction: 3, Initiative: +60, Familiar Effect: "atk, cap 18"
@@ -6714,13 +6714,13 @@
 6825	toasty curative alarm accordion	0		Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Class: "Accordion Thief", Song Duration: 20
 6826	wobbly asbestos-lined careful smooth All-Hallow's Steve's fright wig	0		Moxie: +15, Monster Level: -10, Hot Resistance: +5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	reassuring studded KoL Con X Treasure Map	0		Damage Absorption: +80, Spooky Resistance: +1
-6828	practically non-alcoholic hand-crafted special jittery purple discocktail	1	super ultra EPIC	Effect: "Wet and Greedy", Effect Duration: 5
+6828	special hand-crafted practically non-alcoholic purple jittery discocktail	1	super ultra EPIC	Effect: "Wet and Greedy", Effect Duration: 5
 6829	twirling Temple Grandin's KoL Con X Bingo Card	0		Familiar Weight: +7
 6830	cyan razor-sharp Temporal Tempera Tube	0		Weapon Damage Percent: +25
 6831	double-polymerized pulsating Tallowcreme Halloween Pumpkin	0		Effect: "Cheered Up", Effect Duration: 16
-6832	olive shaking Way More Tears&trade; pepper spray	0		
+6832	shaking olive Way More Tears&trade; pepper spray	0		
 6833	enhanced pressed Milk Studs	0		Effect: "Squirming Like a Toad", Effect Duration: 42
-6834	enhanced squat jittery red box of Dweebs	0		Effect: "Boilermade", Effect Duration: 43
+6834	enhanced jittery squat red box of Dweebs	0		Effect: "Boilermade", Effect Duration: 43
 6835	activated bag of W&Ws	0		Effect: "Intimidating Mien", Effect Duration: 59
 6836	concentrated unsweetened PEEZ dispenser	0		Effect: "Egg-stra Arm", Effect Duration: 33
 6837	dry tumbling Swizzler	0		Effect: "Human-Slime Hybrid", Effect Duration: 37
@@ -6746,11 +6746,11 @@
 6857	pulsating Cajun accordion of dire peril	0		Weapon Damage: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	rock-hard quirky accordion	0		Damage Reduction: 5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	experienced Skipper's accordion of terror	0		Experience: +2, Spooky Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	zippy strapping Pantsgiving of dire peril of the detective	0		Muscle: +5, Weapon Damage: +20, Item Drop: +20, Initiative: +20, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6860	zippy strapping Pantsgiving of dire peril of the detective	0		Muscle: +5, Weapon Damage: +20, Item Drop: +20, Initiative: +20, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
 6861	flavorless can of sardines	3	decent	Last Available: "2013-11"
 6862	miniature stale high-calorie sugar substitute	2	decent	Last Available: "2013-11"
 6863	rotten pat of butter	3	crappy	Last Available: "2013-11"
-6864	special yummy wobbly dinner roll	3	awesome	Effect: "Oh Snap", Effect Duration: 35, Last Available: "2013-11"
+6864	yummy special wobbly dinner roll	3	awesome	Effect: "Oh Snap", Effect Duration: 35, Last Available: "2013-11"
 6865	normal mashed potatoes	3	good	Last Available: "2013-11"
 6866	stale bite-sized whole turkey leg	1	decent	Last Available: "2013-11"
 6867	normal deviled egg	3	good	Last Available: "2013-11"
@@ -6789,8 +6789,8 @@
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	arcane researcher's smooth flask flops	0		Moxie: +15, Experience Percent (Mysticality): +10, Single Equip
-6903	pickled teal shaking nuts	0		Effect: "Wintergreen Warmongery", Effect Duration: 28, Last Available: "2013-12"
-6904	wet dry cyan spinning bolts	0		Effect: "Human-Slime Hybrid", Effect Duration: 69, Last Available: "2013-12"
+6903	pickled shaking teal nuts	0		Effect: "Wintergreen Warmongery", Effect Duration: 28, Last Available: "2013-12"
+6904	wet dry spinning cyan bolts	0		Effect: "Human-Slime Hybrid", Effect Duration: 69, Last Available: "2013-12"
 6905	decent gingerbread robot	4	good	Last Available: "2013-12"
 6906	rotten petit 4.1	4	crappy	Last Available: "2013-12"
 6907	moldy nut-shaped Crimbo cookie	4	crappy	Last Available: "2023-06"
@@ -6802,7 +6802,7 @@
 6913	warbear whosit	0		Last Available: "2013-12"
 6914	warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	executive Tesla warbear hoverbelt of the cougar	0		Moxie: +20, Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-12"
-6916	blinking red huge warbear battery	0		Last Available: "2013-12"
+6916	huge red blinking warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
 6918	pickled adjusted huge warbear wardance potion	0		Effect: "Cheered Up", Effect Duration: 40, Last Available: "2013-12"
 6919	modified warbear bearserker potion	0		Effect: "Stimulated Body", Effect Duration: 48, Last Available: "2013-12"
@@ -6810,29 +6810,29 @@
 6921	normal warbear feasting bread	4	good	Last Available: "2013-12"
 6922	flavorless warbear warrior bread	3	decent	Last Available: "2013-12"
 6923	decent fuchsia warbear thermoregulator bread	4	good	Last Available: "2013-12"
-6924	spirit-forward acceptable jittery yellow warbear feasting mead	5	good	Last Available: "2013-12"
-6925	lousy mirror teal warbear bearserker mead	3	decent	Last Available: "2013-12"
-6926	acceptable mirror pulsating warbear blizzard mead	3	good	Last Available: "2013-12"
+6924	acceptable spirit-forward yellow jittery warbear feasting mead	5	good	Last Available: "2013-12"
+6925	lousy teal mirror warbear bearserker mead	3	decent	Last Available: "2013-12"
+6926	acceptable pulsating mirror warbear blizzard mead	3	good	Last Available: "2013-12"
 6927	blinking warbear helm fragment	0		Last Available: "2013-12"
-6928	blinking lightning-fast Jack Frost's strapping warbear plain fedora	0		Muscle: +5, Cold Spell Damage: +50, Initiative: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	teal stanky warbear feathered fedora	0		Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	mirror stiffened warbear fedora of Calamity Jane of the detective	0		Damage Reduction: 1, Critical Hit Percent: +15, Item Drop: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	healthy groovy wizardly warbear plain helm	0		Mysticality: +25, Moxie Percent: +10, Maximum HP Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	wobbly baleful warbear spiked helm	0		Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	yellow perfumed nasty quilted warbear electro-spiked helm	0		Damage Absorption: +40, Stench Damage: +5, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	steel-toed beefcake's warbear plain ushanka of Flo-Jo	0		Muscle: +25, Damage Reduction: 9, Initiative: +100, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	huge lightning-fast warbear lined ushanka	0		Initiative: +40, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	hardy warbear heated ushanka of mayonnaise of the cheetah	0		Maximum HP: +50, Sleaze Spell Damage: +50, Initiative: +60, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	blinking lightning-fast Jack Frost's strapping warbear plain fedora	0		Muscle: +5, Cold Spell Damage: +50, Initiative: +40, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	teal stanky warbear feathered fedora	0		Stench Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	mirror stiffened warbear fedora of Calamity Jane of the detective	0		Damage Reduction: 1, Critical Hit Percent: +15, Item Drop: +20, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	healthy groovy wizardly warbear plain helm	0		Mysticality: +25, Moxie Percent: +10, Maximum HP Percent: +20, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	wobbly baleful warbear spiked helm	0		Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	yellow perfumed nasty quilted warbear electro-spiked helm	0		Damage Absorption: +40, Stench Damage: +5, Stench Resistance: +5, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	steel-toed beefcake's warbear plain ushanka of Flo-Jo	0		Muscle: +25, Damage Reduction: 9, Initiative: +100, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	huge lightning-fast warbear lined ushanka	0		Initiative: +40, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	hardy warbear heated ushanka of mayonnaise of the cheetah	0		Maximum HP: +50, Sleaze Spell Damage: +50, Initiative: +60, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	ghostly warbear trouser fragment	0		Last Available: "2013-12"
-6938	mirror padded smartaleck's warbear party pants of terror	0		Moxie Percent: +30, Damage Absorption: +20, Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	bouncing teal warbear ceremonial party pants of the sweet-tooth	0		Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	jittery scorching fortified sage warbear high festival pants	0		Mysticality Percent: +10, Damage Absorption: +60, Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	cool warbear battle greaves of the blizzard of the overflowing toilet	0		Moxie: +5, Cold Spell Damage: +25, Stench Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	blurry hardened warbear officer greaves	0		Damage Reduction: 3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	greedy sage warbear bearserker greaves of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Meat Drop: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	sizzling studded Fonzie's warbear johns	0		Experience (Moxie): +1, Damage Absorption: +80, Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	narrow pulsating narrow warbear fleece-lined johns of Leguizamo	0		Monster Level: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	curative deadly wizardly warbear johns	0		Mysticality: +25, Weapon Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	mirror padded smartaleck's warbear party pants of terror	0		Moxie Percent: +30, Damage Absorption: +20, Spooky Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	bouncing teal warbear ceremonial party pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	jittery scorching fortified sage warbear high festival pants	0		Mysticality Percent: +10, Damage Absorption: +60, Hot Damage: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	cool warbear battle greaves of the blizzard of the overflowing toilet	0		Moxie: +5, Cold Spell Damage: +25, Stench Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	blurry hardened warbear officer greaves	0		Damage Reduction: 3, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	greedy sage warbear bearserker greaves of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Meat Drop: +20, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	sizzling studded Fonzie's warbear johns	0		Experience (Moxie): +1, Damage Absorption: +80, Hot Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	narrow pulsating narrow warbear fleece-lined johns of Leguizamo	0		Monster Level: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	curative deadly wizardly warbear johns	0		Mysticality: +25, Weapon Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	nippy chilly razor-sharp warbear goggles	0		Weapon Damage Percent: +25, Cold Damage: 15, Single Equip, Last Available: "2013-12"
 6949	sage warbear snowblindness goggles	0		Mysticality Percent: +10, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	wool curative stiffened warbear warscarf	0		Damage Reduction: 1, Cold Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-12"
 6957	jittery warbear requisition box	0		Last Available: "2013-12"
 6958	red warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	toasty warbear foil hat	0		Hot Damage: +5, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	toasty warbear foil hat	0		Hot Damage: +5, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	narrow warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	skewed rosewater-soaked Van der Graaf warbear oil pan	0		Stench Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	shaking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	lime green bouncing ruddy die-cast Don Crimbo of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +40, Last Available: "2013-12"
 7001	Usain Bolt's beefcake's die-cast Uncle Hobo	0		Muscle: +25, Initiative: +80, Last Available: "2013-12"
 7002	strapping die-cast Father Crimbo of dire peril	0		Muscle: +5, Weapon Damage: +20, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	magnetized improved Flaskfull of Hollow	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 37, Last Available: "2013-12"
 7005	skewed lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered handful of Smithereens	1	good	Last Available: "2013-12"
-7007	stale special Every Day is Like This Sundae	3	decent	Effect: "Comic Violence", Effect Duration: 20, Last Available: "2013-12"
+7007	special stale Every Day is Like This Sundae	3	decent	Effect: "Comic Violence", Effect Duration: 20, Last Available: "2013-12"
 7008	tasty Miserable Pie	4	awesome	Last Available: "2013-12"
 7009	decent This Charming Flan	3	good	Last Available: "2013-12"
 7010	artisanal Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
-7011	enchanted acceptable weak Strikes Again Bigmouth	2	good	Effect: "Hood Ridin'", Effect Duration: 25, Last Available: "2013-12"
-7012	artisanal fortified Paint A Vulgar Pitcher	5	EPIC	Last Available: "2013-12"
+7011	enchanted weak acceptable Strikes Again Bigmouth	2	good	Effect: "Hood Ridin'", Effect Duration: 25, Last Available: "2013-12"
+7012	fortified artisanal Paint A Vulgar Pitcher	5	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	pulsating Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	lard-coated electrified Sheila Take a Crossbow of horror of temperance	0		Spooky Spell Damage: +25, Sleaze Spell Damage: +25, Sleaze Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 7019	prompt therapeutic healthy Socratic A Light that Never Goes Out	0		Experience (Mysticality): +1, Maximum HP Percent: +20, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12"
 7020	twirling stanky brainy weightlifter's Half a Purse of the sweet-tooth	0		Muscle: +15, Mysticality: +5, Stench Spell Damage: +25, Candy Drop: +100, Last Available: "2013-12"
-7021	purple lard-coated veiny stiffened occult Hairpiece On Fire	0		Spell Damage Percent: +25, Damage Reduction: 1, Maximum HP: +10, Sleaze Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	scorching sizzling energetic slick Vicar's Tutu	0		Moxie: +10, Maximum MP Percent: +20, Hot Damage: 35, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	purple lard-coated veiny stiffened occult Hairpiece On Fire	0		Spell Damage Percent: +25, Damage Reduction: 1, Maximum HP: +10, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	scorching sizzling energetic slick Vicar's Tutu	0		Moxie: +10, Maximum MP Percent: +20, Hot Damage: 35, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	nippy chaotic wizardly Hand in Glove	0		Mysticality: +25, Spell Critical Percent: +10, Cold Damage: +10, Single Equip, Last Available: "2013-12"
 7024	squat teal Usain Bolt's razor-sharp smartaleck's Meat Tenderizer is Murder	0		Moxie Percent: +30, Weapon Damage Percent: +25, Initiative: +80, Class: "Seal Clubber", Last Available: "2013-12"
 7025	cyan up-at-dawn Fonzie's experienced Ouija Board, Ouija Board	0		Experience: +2, Experience (Moxie): +1, Adventures: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	green warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	triple-aerosolized aerosolized glass slipper	0		Effect: "Scarysauce", Effect Duration: 52, Last Available: "2014-12"
-7045	pickled olive mirror antimatter wad	1	good	Last Available: "2013-12"
+7045	pickled mirror olive antimatter wad	1	good	Last Available: "2013-12"
 7046	unsweetened cold-filtered warbear superpotion	0		Effect: "Bats in the Belfry", Effect Duration: 22, Last Available: "2013-12"
 7047	quantum extra-wet warbear liquid lasers	0		Effect: "Sauce Monocle", Effect Duration: 66, Last Available: "2013-12"
 7048	anodized ionized triple-electrified skewed warbear rejuvenation potion	0		Effect: "Gleaming White Teeth", Effect Duration: 19, Last Available: "2013-12"
@@ -6943,7 +6943,7 @@
 7054	upside-down warbear drone codes	0		Last Available: "2013-12"
 7055	decent breakfast mess	4	good	Last Available: "2013-12"
 7056	upside-down warbear breakfast machine	0		Last Available: "2013-12"
-7057	fancy half-sized toothsome fuchsia upside-down breakfast miracle	2	awesome	Effect: "Simulation Stimulation", Effect Duration: 40, Last Available: "2013-12"
+7057	toothsome fancy half-sized upside-down fuchsia breakfast miracle	2	awesome	Effect: "Simulation Stimulation", Effect Duration: 40, Last Available: "2013-12"
 7058	unsweetened galvanized Cloaca Cola Polar	0		Effect: "Smoky Third Eye", Effect Duration: 32, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	skewed festive warbear bank	0		Last Available: "2013-12"
@@ -6957,8 +6957,8 @@
 7068	moist wet yellow single of Donho's Bubbly Ballad	0		Effect: "Comprehensively Nourished", Effect Duration: 15
 7069	jittery Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	maroon packet of winter seeds	0		Last Available: "2014-01"
-7071	bland snack-sized snow berries	2	decent	Last Available: "2014-01"
-7072	bite-sized rotten jittery ice harvest	1	crappy	Last Available: "2014-01"
+7071	snack-sized bland snow berries	2	decent	Last Available: "2014-01"
+7072	rotten bite-sized jittery ice harvest	1	crappy	Last Available: "2014-01"
 7073	colloidal pulsating frost flower	0		Effect: "5 Pounds Lighter", Effect Duration: 38, Last Available: "2014-01"
 7074	warmed spinning tumbling snow cleats	0		Effect: "Human-Plant Hybrid", Effect Duration: 12, Last Available: "2014-01"
 7075	deionized deionized bouncing liquid ice pack	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 48, Last Available: "2014-01"
@@ -6969,20 +6969,20 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	squat ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	jittery rosy-cheeked snow mobile	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	jittery rosy-cheeked snow mobile	0		Maximum HP Percent: +30, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	huge fuchsia miser's ice bucket	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	snow shovel of the brute of Gandalf	0		Muscle Percent: +30, Spell Critical Percent: +20, Lasts Until Rollover, Last Available: "2014-01"
 7086	greedy smelly supercool bod-ice	0		Moxie Percent: +20, Stench Spell Damage: +10, Meat Drop: +20, Lasts Until Rollover, Last Available: "2014-01"
 7087	tumbling up-at-dawn censurious Jim Carey's thinker's snow belt	0		Mysticality: +10, Monster Level: +25, Sleaze Resistance: +3, Adventures: +5, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	gray aromatic extremely unsafe beefy ice nine of the sewer	0		Muscle: +10, Weapon Damage Percent: +100, Stench Damage: +25, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2014-01"
-7089	spinning maroon snow fort	0		Last Available: "2014-01"
+7089	maroon spinning snow fort	0		Last Available: "2014-01"
 7090	practically non-alcoholic bad En Una Fila Tequila	1	decent	
 7091	skewed Skully's hot chocolate	1	crappy	
-7092	twirling smelly stylish warbear dress helmet	0		Moxie: +25, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	twirling smelly stylish warbear dress helmet	0		Moxie: +25, Stench Spell Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	executive stanky warbear dress bracers	0		Stench Spell Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2013-12"
-7094	olive Usain Bolt's banded warbear dress greaves	0		Damage Absorption: +100, Initiative: +80, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	extremely unsafe sweatband	0		Weapon Damage Percent: +100, Item Drop: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	Sherlock's foul-smelling gym shorts	0		Stench Damage: +10, Item Drop: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	olive Usain Bolt's banded warbear dress greaves	0		Damage Absorption: +100, Initiative: +80, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	extremely unsafe sweatband	0		Weapon Damage Percent: +100, Item Drop: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	Sherlock's foul-smelling gym shorts	0		Stench Damage: +10, Item Drop: +25, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	jittery jittery Jeselnik's manspreader's ankleweights	0		Monster Level: +10, Sleaze Damage: +25, Single Equip, Last Available: "2014-12"
 7098	ghostly coward's Annie Oakley's sharpshooter's sweat socks of the overflowing toilet	0		Critical Hit Percent: 30, Monster Level: -20, Stench Spell Damage: +50, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6992,24 +6992,24 @@
 7103	warmed warmed mirror powder	0		Effect: "Spiritually Awake", Effect Duration: 39, Last Available: "2014-12"
 7104	MacGyver's licorice whip	0		Maximum MP: +100, Last Available: "2014-12"
 7105	ghostly anise-flavored venom	0		Last Available: "2014-12"
-7106	mediocre weak snakebite	2	decent	Last Available: "2014-12"
+7106	weak mediocre snakebite	2	decent	Last Available: "2014-12"
 7107	Jeselnik's horrifying candy stick	0		Spooky Damage: +25, Sleaze Damage: +25, Last Available: "2014-12"
-7108	half-sized stale lime green pecan	2	decent	Last Available: "2014-12"
-7109	low-calorie special tasty blinking cyan pecan pie	1	awesome	Effect: "Just the Brown Ones", Effect Duration: 15, Last Available: "2014-12"
+7108	stale half-sized lime green pecan	2	decent	Last Available: "2014-12"
+7109	low-calorie special tasty cyan blinking pecan pie	1	awesome	Effect: "Just the Brown Ones", Effect Duration: 15, Last Available: "2014-12"
 7110	squat chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	moldy candy mountain oyster	3	crappy	Last Available: "2014-12"
-7112	weak lousy chocotini	2	decent	Last Available: "2014-12"
+7112	lousy weak chocotini	2	decent	Last Available: "2014-12"
 7113	tumbling auspicious fireproof chocolate rabbit's foot of the brute	0		Muscle Percent: +30, Hot Resistance: +3, Item Drop: +10, Last Available: "2014-12"
 7114	adequate candy carrot	3	good	Last Available: "2014-12"
-7115	jumbo flavorless candy carrot cake	5	decent	Last Available: "2014-12"
+7115	flavorless jumbo candy carrot cake	5	decent	Last Available: "2014-12"
 7116	chilly therapeutic carrot-on-a-stick	0		Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
-7117	cyan blinking stanky occult weasel stomping pants	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	decent fancy half-sized mulberry	2	good	Effect: "Sweet and Red", Effect Duration: 20, Last Available: "2014-12"
+7117	cyan blinking stanky occult weasel stomping pants	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7118	half-sized decent fancy mulberry	2	good	Effect: "Sweet and Red", Effect Duration: 20, Last Available: "2014-12"
 7119	bad special skewed mulled berry wine	3	decent	Effect: "Fustulent", Effect Duration: 45, Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	miser's lemon party hat	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	miser's lemon party hat	0		Meat Drop: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	wicked lemon shirt	0		Spell Damage: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	spinning cool lemon drop trousers	0		Moxie: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	spinning cool lemon drop trousers	0		Moxie: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	galvanized electrified maroon jittery lemonhead caviar	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 15, Last Available: "2014-12"
 7125	wholesome Fonzie's gummi sword	0		Experience (Moxie): +1, Maximum HP Percent: +10, Last Available: "2014-12"
 7126	pressed small gummi fin	0		Effect: "Rad-ish", Effect Duration: 37, Last Available: "2014-12"
@@ -7021,31 +7021,31 @@
 7132	polarized anodized bouncing Outer Wolf&trade; cologne	0		Effect: "Improved Candy Vision", Effect Duration: 11, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	red twirling fireproof knitted wolf whistle	0		Cold Resistance: +3, Hot Resistance: +3, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	normal special witch's bread	4	good	Effect: "Hobonic", Effect Duration: 5, Last Available: "2014-12"
+7135	special normal witch's bread	4	good	Effect: "Hobonic", Effect Duration: 5, Last Available: "2014-12"
 7136	liquefied witch's brew	0		Effect: "Stuck-Up Hair", Effect Duration: 53, Last Available: "2014-12"
 7137	Sherlock's ruddy Newton's witch's bra	0		Experience (Mysticality): +3, Maximum HP Percent: +40, Item Drop: +25, Last Available: "2014-12"
 7138	artisanal mid-level medieval mead	3	EPIC	Last Available: "2014-12"
-7139	ionized electrified blinking bouncing pulsating R&uuml;mpelstiltz	0		Effect: "Squirming Like a Toad", Effect Duration: 58, Last Available: "2014-12"
+7139	ionized electrified bouncing pulsating blinking R&uuml;mpelstiltz	0		Effect: "Squirming Like a Toad", Effect Duration: 58, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
-7141	pressed boiled pulsating fuchsia hi-octane carrot juice	0		Effect: "Nature's Bounty", Effect Duration: 46, Last Available: "2014-12"
-7142	chilled ionized upside-down squat hare brush	0		Effect: "Square to be Hip", Effect Duration: 69, Last Available: "2014-12"
+7141	pressed boiled fuchsia pulsating hi-octane carrot juice	0		Effect: "Nature's Bounty", Effect Duration: 46, Last Available: "2014-12"
+7142	chilled ionized squat upside-down hare brush	0		Effect: "Square to be Hip", Effect Duration: 69, Last Available: "2014-12"
 7143	pulsating frosty dance instructor's hare pin	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Single Equip, Last Available: "2014-12"
 7144	spinning odd coin	0		Last Available: "2014-12"
 7145	flavorless half-sized cinnamon cannoli	2	decent	Last Available: "2014-12"
 7146	aged expensive champagne	3	awesome	Last Available: "2014-12"
 7147	flattened deionized green polo trophy	0		Effect: "Going Ape", Effect Duration: 15, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
-7149	blinking twirling maroon rosary	0		Last Available: "2014-12"
+7149	maroon twirling blinking rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	mirror straw	0		Last Available: "2014-12"
 7152	pulsating	0		Last Available: "2014-12"
-7153	twirling bouncing clay	0		Last Available: "2014-12"
+7153	bouncing twirling clay	0		Last Available: "2014-12"
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	Lo Pan's Newton's fire hose of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Spell Critical Percent: +30, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	Lo Pan's Newton's fire hose of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Spell Critical Percent: +30, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	rotten purple fireman's lunch	4	crappy	Last Available: "2014-12"
-7159	blinking blue aromatic Jack Frost's supercool plain paper hat	0		Moxie Percent: +20, Cold Spell Damage: +50, Stench Resistance: +1, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	blinking blue aromatic Jack Frost's supercool plain paper hat	0		Moxie Percent: +20, Cold Spell Damage: +50, Stench Resistance: +1, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	flavorless ice cream sandwich	3	decent	Last Available: "2014-12"
 7161	upside-down miser's stanky Oprah's &quot;honey&quot; dipper	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Meat Drop: +10, Last Available: "2014-12"
 7162	adequate plumber's lunch	3	good	Last Available: "2014-12"
@@ -7056,7 +7056,7 @@
 7167	warmed shaking smudge stick	0		Effect: "Highland Sheen", Effect Duration: 21, Last Available: "2014-12"
 7168	ionized wall	0		Effect: "Employee of the Month", Effect Duration: 53, Last Available: "2014-12"
 7169	acceptable tankard of ale	3	good	Last Available: "2014-12"
-7170	vacuum-sealed gray spinning scroll case	0		Effect: "Boon of the War Snapper", Effect Duration: 49, Last Available: "2014-12"
+7170	vacuum-sealed spinning gray scroll case	0		Effect: "Boon of the War Snapper", Effect Duration: 49, Last Available: "2014-12"
 7171	quadruple-modified ionized jug of &quot;wine&quot;	0		Effect: "License to Punch", Effect Duration: 47, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	lime green mirror crappy camera	0		Last Available: "2014-12"
@@ -7101,7 +7101,7 @@
 7212	narrow energetic Jefferson wings	0		Maximum MP Percent: +20
 7213	huge fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	decent small fleetwood mac 'n' cheese	2	good	
+7215	small decent fleetwood mac 'n' cheese	2	good	
 7216	lynyrd skin	0		
 7217	lynyrdskin cap of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	blurry lynyrdskin tunic of mayonnaise	0		Sleaze Spell Damage: +50
@@ -7113,7 +7113,7 @@
 7224	friendly Kashmir sweater of the brazier	0		Familiar Weight: +3, Hot Spell Damage: +25
 7225	rotten green custard pie	3	crappy	
 7226	tea for one	1	decent	
-7227	distilled artisanal blurry bottle of Evermore	5	EPIC	
+7227	artisanal distilled blurry bottle of Evermore	5	EPIC	
 7228	box	0		
 7229	lousy wine	3	decent	
 7230	artisanal rum	3	EPIC	
@@ -7141,7 +7141,7 @@
 7252	fuchsia shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	practically non-alcoholic drinkable pulsating mini-martini	1	good	
+7255	drinkable practically non-alcoholic pulsating mini-martini	1	good	
 7256	spinning smoke grenade	0		
 7257	dehydrated upside-down molotov soda	1	decent	Effect: "Trivia Master", Effect Duration: 35
 7258	double-pressed adjusted pile of ashes	0		Effect: "Buttermilk Boogie", Effect Duration: 56
@@ -7202,13 +7202,13 @@
 7313	box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	purple rickety rocking horse	0		
-7316	tumbling blinking jack-in-the-box	0		
-7317	squat skewed jar of baby ghosts	0		
+7316	blinking tumbling jack-in-the-box	0		
+7317	skewed squat jar of baby ghosts	0		
 7318	knitted careful rosy-cheeked ghost of a necklace	0		Maximum HP Percent: +30, Monster Level: -10, Cold Resistance: +3
 7319	knitted healthy Elizabeth's Dollie	0		Maximum HP Percent: +20, Cold Resistance: +3
 7320	activated twirling Elizabeth's paintbrush	0		Effect: "Adorable Lookout", Effect Duration: 62
 7321	MacGyver's baleful Stephen's lab coat	0		Spell Damage: +25, Maximum MP: +100
-7322	double-ionized olive pulsating Stephen's secret formula	0		Effect: "Haunted Stomach", Effect Duration: 41
+7322	double-ionized pulsating olive Stephen's secret formula	0		Effect: "Haunted Stomach", Effect Duration: 41
 7323	yellow supercharged strapping Jacob's rung	0		Muscle: +5, Maximum MP Percent: +30
 7324	mixed battery	1		
 7325	mediocre snakebite	4	decent	
@@ -7228,13 +7228,13 @@
 7339	music box mechanism	0		
 7340	pulsating moose antlers of extreme caution	0		Monster Level: -25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	ionized narrow moose thought	0		Effect: "The Halls of Moxiousness", Effect Duration: 33
-7342	snack-sized spoiled moose chocolate	2	crappy	
+7342	spoiled snack-sized moose chocolate	2	crappy	
 7343	smooth painting of a glass of wine	3	awesome	
 7344	oil painting of yourself	0		
-7345	yellow spinning ornate picture frame	0		
+7345	spinning yellow ornate picture frame	0		
 7346	purple doll-eye amulet	0		Single Equip
 7347	baleful ghost toga of Flo-Jo	0		Spell Damage: +25, Initiative: +100
-7348	snack-sized spoiled enchanted sheet cake	2	crappy	Effect: "Morninja", Effect Duration: 30
+7348	spoiled enchanted snack-sized sheet cake	2	crappy	Effect: "Morninja", Effect Duration: 30
 7349	ghost key	0		
 7350	maroon picture of you	0		
 7351	ribald scandalous beefcake's Staff of the Electric Range	0		Muscle: +25, Sleaze Damage: 15
@@ -7252,13 +7252,13 @@
 7363	quadruple-electrified bloodstain stick	0		Effect: "Fungal Flambé", Effect Duration: 16
 7364	pulsating fabric softener	0		
 7365	irradiated dry altered fabric hardener	0		Effect: "Slimily Speedy", Effect Duration: 63
-7366	boozy mediocre wobbly bottle of laundry sherry	5	decent	
+7366	mediocre boozy wobbly bottle of laundry sherry	5	decent	
 7367	tarnished alkaline industrial strength starch	0		Effect: "Ichorous Eyesight", Effect Duration: 42, Wiki Name: "industrial strength starch"
-7368	toothsome ghostly jittery extra-flat panini	3	awesome	
+7368	toothsome jittery ghostly extra-flat panini	3	awesome	
 7369	ionized dry quadruple-polymerized mangled finger	0		Effect: "Human-Orc Hybrid", Effect Duration: 21
 7370	mediocre jittery Psychotic Train wine	4	decent	
 7371	cyan crazy hobo notebook	0		
-7372	snack-sized delicious blinking pulsating pie man was not meant to eat	2	awesome	
+7372	delicious snack-sized blinking pulsating pie man was not meant to eat	2	awesome	
 7373	beefy sommelier's towel	0		Muscle: +10
 7374	bouncing MacGyver's tarnished tastevin	0		Maximum MP: +100, Single Equip
 7375	thick bland actual tapas	5	decent	
@@ -7271,7 +7271,7 @@
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	DNA extraction syringe	0		Last Available: "2014-04"
 7384	deionized bouncing Gene Tonic: Dude	0		Effect: "Saucemastery", Effect Duration: 49, Last Available: "2014-04"
-7385	nitrogenated double-anodized gray upside-down Gene Tonic: Beast	0		Effect: "Shamboozled", Effect Duration: 54, Last Available: "2014-04"
+7385	nitrogenated double-anodized upside-down gray Gene Tonic: Beast	0		Effect: "Shamboozled", Effect Duration: 54, Last Available: "2014-04"
 7386	denatured magnetized Gene Tonic: Construct	0		Effect: "Fungal Flambé", Effect Duration: 33, Last Available: "2014-04"
 7387	electrified Gene Tonic: Undead	0		Effect: "Items Are Forever", Effect Duration: 61, Last Available: "2014-04"
 7388	boiled Gene Tonic: Humanoid	0		Effect: "Moon'd", Effect Duration: 66, Last Available: "2014-04"
@@ -7296,7 +7296,7 @@
 7407	gray Steam Card: Dungeon Fist (#2)	0		
 7408	jittery Steam Card: Dungeon Fist (#3)	0		
 7409	Steam Card: Space Trip (#1)	0		
-7410	narrow jittery Steam Card: Space Trip (#2)	0		
+7410	jittery narrow Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
 7413	Steam Card: Meteoid (#2)	0		
@@ -7329,7 +7329,7 @@
 7440	tiny normal Cool Brunch Pastaco	1	good	Last Available: "2014-05"
 7441	flavorless upside-down Medical Pastaco	4	decent	Last Available: "2014-05"
 7442	spoiled Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
-7443	toothsome thick blinking Ludovico Pastaco	5	awesome	Last Available: "2014-05"
+7443	thick toothsome blinking Ludovico Pastaco	5	awesome	Last Available: "2014-05"
 7444	mediocre green overpowering mushroom wine	4	decent	Last Available: "2014-05"
 7445	mediocre narrow complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	artisanal smooth mushroom wine	4	EPIC	Last Available: "2014-05"
@@ -7341,20 +7341,20 @@
 7452	blurry Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	acceptable practically non-alcoholic wobbly regular-size brogurt	1	good	Last Available: "2014-05"
 7454	perfectly mixed super-size brogurt	4	EPIC	Last Available: "2014-05"
-7455	enchanted tolerable red wobbly broberry brogurt	3	good	Effect: "Night Vision", Effect Duration: 40, Last Available: "2014-05"
+7455	tolerable enchanted wobbly red broberry brogurt	3	good	Effect: "Night Vision", Effect Duration: 40, Last Available: "2014-05"
 7456	bad fortified blurry brocolate brogurt	5	decent	Last Available: "2014-05"
-7457	fancy lousy maroon French bronilla brogurt	4	decent	Effect: "Carrion' On", Effect Duration: 45, Last Available: "2014-05"
+7457	lousy fancy maroon French bronilla brogurt	4	decent	Effect: "Carrion' On", Effect Duration: 45, Last Available: "2014-05"
 7458	olive History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	wobbly chilly Brogre brorts	0		Cold Damage: +5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	wobbly chilly Brogre brorts	0		Cold Damage: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	Brogre brolo shirt of the businessman	0		Meat Drop: +50, Last Available: "2014-05"
-7464	fuchsia educational Brogre bucket hat	0		Experience: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	fuchsia educational Brogre bucket hat	0		Experience: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	maroon airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	rosy-cheeked wizardly 8-billed baseball cap of the detective	0		Mysticality: +25, Maximum HP Percent: +30, Item Drop: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	rosy-cheeked wizardly 8-billed baseball cap of the detective	0		Mysticality: +25, Maximum HP Percent: +30, Item Drop: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	razor-sharp brainy extremely wet T-shirt of the early riser	0		Mysticality: +5, Weapon Damage Percent: +25, Adventures: +7, Last Available: "2014-05"
 7470	knitted shrimp fork of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Cold Resistance: +3, Last Available: "2014-05"
 7471	denatured blurry BROS Energy Drink	0		Effect: "Cinnamouth", Effect Duration: 39, Last Available: "2014-05"
@@ -7368,16 +7368,16 @@
 7479	polarized quadruple-enhanced tumbling sugar fairy	0		Effect: "Salty Dogs", Effect Duration: 12, Last Available: "2014-05"
 7480	ionized colloidal bouncing sugar bunny	0		Effect: "Abyssal Tears", Effect Duration: 64, Last Available: "2014-05"
 7481	ghostly sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	weak lousy Rompedores de Fantasmas	2	decent	
-7483	strong mediocre La Fantasma y La Oscuridad	5	decent	
-7484	special perfectly mixed Fantasma en la M&aacute;quina	3	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 10
+7482	lousy weak Rompedores de Fantasmas	2	decent	
+7483	mediocre strong La Fantasma y La Oscuridad	5	decent	
+7484	perfectly mixed special Fantasma en la M&aacute;quina	3	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 10
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	mirror drain dissolver	0		
 7488	squat triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	blinking triatomaceous dust	0		
-7491	watered-down tolerable jittery bottle of Chateau de Vinegar	2	good	
+7491	tolerable watered-down jittery bottle of Chateau de Vinegar	2	good	
 7492	tumbling twirling blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
@@ -7421,12 +7421,12 @@
 7532	watered-down delicious rocket fuel	2	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	gray alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	tolerable weak fancy tumbling stealth bomber	2	good	Effect: "Hella Tough", Effect Duration: 20, Last Available: "2014-05"
+7535	weak tolerable fancy tumbling stealth bomber	2	good	Effect: "Hella Tough", Effect Duration: 20, Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	electrified space beast fur hat	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	Sherlock's space beast fur pants	0		Item Drop: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	electrified space beast fur hat	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	Sherlock's space beast fur pants	0		Item Drop: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	rosy-cheeked space beast fur whip	0		Maximum HP Percent: +30, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	blurry sinister space heater of chilblains	0		Spell Damage: +10, Cold Damage: +25, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7443,7 +7443,7 @@
 7554	diffused bottle of lighter fluid	0		Effect: "Heart of Yellow", Effect Duration: 19, Last Available: "2014-06"
 7555	jittery page	0		
 7556	elephant gift	0		
-7557	triple-vacuum-sealed tumbling jittery blood cells	0		Effect: "Wings of the Grasshopper", Effect Duration: 67
+7557	triple-vacuum-sealed jittery tumbling blood cells	0		Effect: "Wings of the Grasshopper", Effect Duration: 67
 7558	artisanal wine	4	EPIC	
 7559	frozen pulsating gummi turtle	0		Effect: "Nightstalkin'", Effect Duration: 11
 7560	turtle-shaped rock	0		
@@ -7451,7 +7451,7 @@
 7562	super-nitrogenated musk turtle	0		Effect: "White Blooded", Effect Duration: 24
 7563	ionized double-unsweetened maroon huge programmable turtle	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
 7564	galvanized mocking turtle	0		Effect: "Peppermint Bite", Effect Duration: 43
-7565	decent jumbo fancy ham steak	5	good	Effect: "Phairly Pheromonal", Effect Duration: 45
+7565	jumbo fancy decent ham steak	5	good	Effect: "Phairly Pheromonal", Effect Duration: 45
 7566	time-twitching toolbelt of extreme caution	0		Monster Level: -25, Single Equip, Free Pull
 7567	green Chroner	0		
 7568	greedy forbidden Time Lord Badge of Honor of extreme caution	0		Spell Damage Percent: +50, Monster Level: -25, Meat Drop: +20
@@ -7475,22 +7475,22 @@
 7586	wobbly helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	triple-distilled hand-crafted cyan glass of &quot;milk&quot;	7	EPIC	Last Available: "2014-07"
-7590	perfectly mixed enchanted green cup of &quot;tea&quot;	3	EPIC	Effect: "Bright!", Effect Duration: 25, Last Available: "2014-07"
+7589	hand-crafted triple-distilled cyan glass of &quot;milk&quot;	7	EPIC	Last Available: "2014-07"
+7590	enchanted perfectly mixed green cup of &quot;tea&quot;	3	EPIC	Effect: "Bright!", Effect Duration: 25, Last Available: "2014-07"
 7591	tolerable practically non-alcoholic ghostly thermos of &quot;whiskey&quot;	1	good	Last Available: "2014-07"
-7592	artisanal weak Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
+7592	weak artisanal Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	boozy delicious Bee's Knees	5	awesome	Last Available: "2014-07"
-7594	fortified smooth Sockdollager	5	awesome	Last Available: "2014-07"
-7595	tolerable practically non-alcoholic Ish Kabibble	1	good	Last Available: "2014-07"
+7594	smooth fortified Sockdollager	5	awesome	Last Available: "2014-07"
+7595	practically non-alcoholic tolerable Ish Kabibble	1	good	Last Available: "2014-07"
 7596	irresponsibly strong acceptable Hot Socks	7	good	Last Available: "2014-07"
-7597	practically non-alcoholic mediocre cyan Phonus Balonus	1	decent	Last Available: "2014-07"
-7598	practically non-alcoholic bad Flivver	1	decent	Last Available: "2014-07"
+7597	mediocre practically non-alcoholic cyan Phonus Balonus	1	decent	Last Available: "2014-07"
+7598	bad practically non-alcoholic Flivver	1	decent	Last Available: "2014-07"
 7599	tolerable Sloppy Jalopy	4	good	Last Available: "2014-07"
 7600	magnetized liquefied Vulcanized tumbling flame	0		Effect: "Well-Lubed", Effect Duration: 61
 7601	oxidized tumbling temporary yak tattoo	0		Effect: "Covetous Robbery", Effect Duration: 22
 7602	flattened tumbling Fitspiration&trade; poster	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 22
 7603	denatured polarized flattened huge neckbeard	0		Effect: "Hot Buttoned", Effect Duration: 20
-7604	corrupted pickled skewed huge lime green artisanal hand-squeezed wheatgrass juice	0		Effect: "Sealed Brain", Effect Duration: 55
+7604	corrupted pickled lime green skewed huge artisanal hand-squeezed wheatgrass juice	0		Effect: "Sealed Brain", Effect Duration: 55
 7605	deionized bouncing punk patch	0		Effect: "Alacri Tea", Effect Duration: 17
 7606	corrupted modified steampunk potion	0		Effect: "Ancient Protected", Effect Duration: 65
 7607	unsweetened vial of swamp vapors	0		Effect: "Morbidi Tea", Effect Duration: 68
@@ -7510,7 +7510,7 @@
 7621	oxidized pickled skewed ninja eyeblack	0		Effect: "Superveiny 9000", Effect Duration: 46
 7622	liquefied button rouge	0		Effect: "Bananas!", Effect Duration: 33
 7623	dry skewed yellow Red Army camouflage kit	0		Effect: "Red Door Syndrome", Effect Duration: 62
-7624	triple-adjusted shaking wobbly lynyrd skinner toothblack	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 36
+7624	triple-adjusted wobbly shaking lynyrd skinner toothblack	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 36
 7625	colloidal concentrated bouncing flask of rainwater	0		Effect: "Strong Grip", Effect Duration: 38
 7626	oxidized nitrogenated oyster badge	0		Effect: "Broberry Brotality", Effect Duration: 36
 7627	moist ghostly plastic Jefferson wings	0		Effect: "Spirit of Alph", Effect Duration: 13
@@ -7531,7 +7531,7 @@
 7642	upside-down ingot turtle	0		
 7643	jittery duty umbrella	0		
 7644	pool skimmer	0		
-7645	blurry skewed lime green life preserver	0		
+7645	lime green skewed blurry life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
 7648	skewed thunder thigh	0		
@@ -7548,13 +7548,13 @@
 7659	lard-coated neoprene skullcap	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	denatured ghostly goblin water	0		Effect: "Cake Caked", Effect Duration: 59
 7661	dumb mud	0		
-7662	super-sized moldy Sogg-Os	5	crappy	
+7662	moldy super-sized Sogg-Os	5	crappy	
 7663	dog trainer's careful extremely unsafe Lord Soggyraven's Slippers	0		Weapon Damage Percent: +100, Monster Level: -10, Experience (familiar): +1, Single Equip
 7664	adjusted Ancient Protector Soda	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 34
 7665	ionized activated liquid ice	0		Effect: "Headstrong", Effect Duration: 12
 7666	triple-distilled delicious wobbly Wet Russian	8	awesome	
 7667	moldy small filet of The Fish	2	crappy	
-7668	narrow twirling Thwaitgold spider statuette	0		
+7668	twirling narrow Thwaitgold spider statuette	0		
 7669	toasty Oprah's studded thunder down underwear	0		Damage Absorption: +80, Maximum MP Percent: +50, Hot Damage: +5, Lasts Until Rollover
 7670	hale forbidden famous raincoat of the sewer	0		Spell Damage Percent: +50, Maximum HP: +20, Stench Damage: +25, Lasts Until Rollover
 7671	veiny sinister lightning rod of the bloodbag	0		Spell Damage: +10, Maximum HP: 110, Lasts Until Rollover
@@ -7592,14 +7592,14 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	huge huge The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	huge huge The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	liquefied adjusted chilled rubber nubbin	0		Effect: "Red Door Syndrome", Effect Duration: 49, Last Available: "2014-08"
 7708	frightening rubber cape of Tarzan	0		Experience (Muscle): +3, Spooky Damage: +5, Last Available: "2014-08"
 7709	shaking Temple Grandin's experienced Thor's Pliers of dire peril of vim and vigor	0		Experience: +2, Weapon Damage: +20, Maximum HP Percent: +50, Familiar Weight: +7, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	non-vacuum-sealed candy UFOs	0		Effect: "Reedy Pipes", Effect Duration: 43
 7711	Sherlock's rosewater-soaked water wings for babies	0		Stench Resistance: +3, Item Drop: +25
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	snack-sized tasty Strix stix	2	awesome	
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7713	tasty snack-sized Strix stix	2	awesome	
 7714	Annie Oakley's medical-grade wizardly vampire pellet	0		Mysticality: +25, Critical Hit Percent: +20, HP Regen Min: 7, HP Regen Max: 10
 7715	fancy hand-crafted non-aged vinegar	4	EPIC	Effect: "Ass Over Teakettle", Effect Duration: 10
 7716	Lo Pan's unsanitized scalpel	0		Spell Critical Percent: +30
@@ -7611,7 +7611,7 @@
 7722	jittery Jack Frost's centurion helmet	0		Cold Spell Damage: +50, Familiar Effect: "1xFairy, atk, cap 25"
 7723	Chroner cross	0		
 7724	pteruges of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xFairy, atk, cap 25"
-7725	frozen activated pulsating cyan Bruno's blessing of Mars	0		Effect: "Broberry Brotality", Effect Duration: 56
+7725	frozen activated cyan pulsating Bruno's blessing of Mars	0		Effect: "Broberry Brotality", Effect Duration: 56
 7726	pressed dry Dennis's blessing of Minerva	0		Effect: "Barking Mad", Effect Duration: 47
 7727	warmed concentrated lime green Burt's blessing of Bacchus	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 49
 7728	ionized triple-vacuum-sealed skewed Freddie's blessing of Mercury	0		Effect: "Disdain of She-Who-Was", Effect Duration: 26
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	purple Xiblaxian xeno-detection goggles of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-09"
-7753	ghostly lightning-fast scandalous Xiblaxian stealth cowl	0		Sleaze Damage: +5, Initiative: +40, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	ghostly lightning-fast scandalous Xiblaxian stealth cowl	0		Sleaze Damage: +5, Initiative: +40, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	blurry miser's energetic Xiblaxian stealth trousers	0		Maximum MP Percent: +20, Meat Drop: +10, Last Available: "2014-09"
 7755	twirling frightening Xiblaxian stealth vest of the wise owl	0		Mysticality: +20, Spooky Damage: +5, Last Available: "2014-09"
-7756	moldy thick Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
+7756	thick moldy Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
 7757	bad weak Xiblaxian space-whiskey	2	decent	Last Available: "2014-09"
 7758	shaking Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	extra-galvanized They liver	0		Effect: "Flamibili Tea", Effect Duration: 32, Last Available: "2014-09"
-7760	enchanted stale blurry They liver popsicle	4	decent	Effect: "Prideful Strut", Effect Duration: 45, Last Available: "2014-09"
+7760	stale enchanted blurry They liver popsicle	4	decent	Effect: "Prideful Strut", Effect Duration: 45, Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7668,20 +7668,20 @@
 7779	concentrated energized experimental serum G-9	0		Effect: "Disco Concentration", Effect Duration: 64, Last Available: "2014-10"
 7780	knitted Newton's heavy-duty clipboard of temperance	0		Experience (Mysticality): +3, Cold Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	bouncing up-at-dawn aromatic wholesome shellacked battery-powered drill	0		Damage Reduction: 7, Maximum HP Percent: +10, Stench Resistance: +1, Adventures: +5, Last Available: "2014-10"
-7782	super-sized decent limp broccoli	5	good	Last Available: "2014-10"
-7783	executive supercharged hat of the early riser	0		Maximum MP Percent: +30, Meat Drop: +40, Adventures: +7, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	decent super-sized limp broccoli	5	good	Last Available: "2014-10"
+7783	executive supercharged hat of the early riser	0		Maximum MP Percent: +30, Meat Drop: +40, Adventures: +7, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	corrupted unsweetened bouncing monkey barf	0		Effect: "All Fired Up", Effect Duration: 58, Last Available: "2014-10"
 7785	wet wobbly candy	0		Effect: "Bread-Lined", Effect Duration: 38, Last Available: "2014-10"
 7786	veiny jangly bracelet of doom of the boozehound	0		Maximum HP: +10, Spooky Spell Damage: +50, Booze Drop: +100, Last Available: "2014-10"
 7787	brawny cuddly teddy bear	0		Muscle Percent: +20, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	bouncing ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	pulsating miser's wicked first-aid pouch	0		Spell Damage: +5, Meat Drop: +10, Last Available: "2014-10"
-7790	skewed maroon khaki duffel bag	0		Last Available: "2014-10"
+7790	maroon skewed khaki duffel bag	0		Last Available: "2014-10"
 7791	unsweetened boiled airborne mutagen	0		Effect: "Fiery Spirit", Effect Duration: 55, Last Available: "2014-10"
 7792	bouncing SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	gray bottle-opener keycard	0		Last Available: "2014-10"
 7794	huge Armory keycard	0		Last Available: "2014-10"
-7795	bite-sized stale initiative shawarma	1	decent	Last Available: "2014-10"
+7795	stale bite-sized initiative shawarma	1	decent	Last Available: "2014-10"
 7796	bland tiny warm war shawarma	1	decent	Last Available: "2014-10"
 7797	spoiled karma shawarma	3	crappy	Last Available: "2014-10"
 7798	artisanal shaking Jungle Juice	3	EPIC	Last Available: "2014-10"
@@ -7697,7 +7697,7 @@
 7808	unused soap	0		
 7809	wobbly impure gasoline	0		
 7810	Z-Bone steak	0		
-7811	narrow huge viral DNA	0		
+7811	huge narrow viral DNA	0		
 7812	mirror tarnished bottlecap	0		
 7813	bland bouncing seared dino steak	3	decent	
 7814	lousy bottle of drinkin' gas	3	decent	
@@ -7705,7 +7705,7 @@
 7816	twirling dove DNA	0		
 7817	upside-down gelatinous meat mass	0		
 7818	fuchsia 99.44% pure math	0		
-7819	pulsating bouncing simple AI	0		
+7819	bouncing pulsating simple AI	0		
 7820	corrupted bird DNA	0		
 7821	ghostly sentient meat mass	0		
 7822	zombie dinosaur egg	0		
@@ -7714,7 +7714,7 @@
 7825	miser's occult earbuds of the detective	0		Spell Damage Percent: +25, Item Drop: +20, Meat Drop: +10, Single Equip
 7826	bouncing beefy iFlail of the wise owl of terror	0		Muscle: +10, Mysticality: +20, Spooky Spell Damage: +10
 7827	miniature toothsome tumbling unidentifiable dried fruit	2	awesome	
-7828	acceptable watered-down flat cider	2	good	
+7828	watered-down acceptable flat cider	2	good	
 7829	miser's hardy strapping trench lighter	0		Muscle: +5, Maximum HP: +50, Meat Drop: +10, Last Available: "2014-10"
 7830	magnetized double-electrified nitrogenated cyan experimental serum P-00	0		Effect: "Executive Greed", Effect Duration: 32, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	enhanced alkaline blurry perl necklace	0		Effect: "Swordholder", Effect Duration: 28, Last Available: "2014-12"
 7846	double-alkaline activated cyan Fudge Fiber Armor Plating	0		Effect: "Lifted Spirits", Effect Duration: 57, Last Available: "2014-12"
 7847	unsweetened vacuum-sealed ruby on canes	0		Effect: "Human-Goblin Hybrid", Effect Duration: 46, Last Available: "2014-12"
-7848	decent low-calorie petit fortran	1	good	Last Available: "2014-12"
+7848	low-calorie decent petit fortran	1	good	Last Available: "2014-12"
 7849	rotten java cookie	3	crappy	Last Available: "2014-12"
 7850	adequate cookie cookie	3	good	Last Available: "2014-12"
 7851	blinking hardy plastic exo-suited miner	0		Maximum HP: +50, Last Available: "2014-12"
@@ -7743,10 +7743,10 @@
 7854	padded plastic Crimbot	0		Damage Absorption: +20, Last Available: "2014-12"
 7855	weightlifter's plastic Crimbomega	0		Muscle: +15, Last Available: "2014-12"
 7856	deionized tarnished flask of mining oil	0		Effect: "Fruited", Effect Duration: 46, Last Available: "2014-12"
-7857	Rosewater's radiation-resistant helmet	0		Mysticality Percent: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	gray servo-assisted exo-pants of wisdom	0		Mysticality: +15, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	Rosewater's radiation-resistant helmet	0		Mysticality Percent: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	gray servo-assisted exo-pants of wisdom	0		Mysticality: +15, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	up-at-dawn curative high-energy mining laser	0		Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12"
-7860	huge ghostly peppermint tailings	0		Last Available: "2014-12"
+7860	ghostly huge peppermint tailings	0		Last Available: "2014-12"
 7861	huge teal nugget of Crimbonium	0		Last Available: "2014-12"
 7862	cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
@@ -7761,7 +7761,7 @@
 7872	blinking Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
-7875	shaking gray Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
+7875	gray shaking Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	blue Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
@@ -7795,7 +7795,7 @@
 7906	narrow recovered elf toothbrush	0		Last Available: "2014-12"
 7907	recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	recovered elf underpants	0		Last Available: "2014-12"
-7909	blinking bouncing lime green recovered elf wallet	0		Last Available: "2014-12"
+7909	bouncing lime green blinking recovered elf wallet	0		Last Available: "2014-12"
 7910	recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	recovered elf photo album	0		Last Available: "2014-12"
 7912	recovered elf smartphone	0		Last Available: "2014-12"
@@ -7808,26 +7808,26 @@
 7919	energized oxidized purple Big Punk	0		Effect: "Hennaliciousness", Effect Duration: 61
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	smooth practically non-alcoholic fuchsia Friendly Turkey	1	awesome	Last Available: "2014-11"
+7922	practically non-alcoholic smooth fuchsia Friendly Turkey	1	awesome	Last Available: "2014-11"
 7923	mediocre fuchsia Agitated Turkey	3	decent	Last Available: "2014-11"
 7924	tolerable triple-distilled ghostly Ambitious Turkey	7	good	Last Available: "2014-11"
-7925	half-sized rotten neutron lollipop	2	crappy	Last Available: "2014-12"
-7926	practically non-alcoholic acceptable gamma nog	1	good	Last Available: "2014-12"
-7934	upside-down blurry tumbling sneaky wrapping paper	0		Last Available: "2014-12"
-7935	narrow mirror bouncing Thwaitgold nit statuette	0		
+7925	rotten half-sized neutron lollipop	2	crappy	Last Available: "2014-12"
+7926	acceptable practically non-alcoholic gamma nog	1	good	Last Available: "2014-12"
+7934	blurry tumbling upside-down sneaky wrapping paper	0		Last Available: "2014-12"
+7935	mirror narrow bouncing Thwaitgold nit statuette	0		
 7936	tumbling picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
 7938	modified jittery single atom	1	decent	Effect: "Transcendental Wind", Effect Duration: 35, Last Available: "2015-02"
 7939	squat Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
-7941	teal mirror sleeve deuce	0		
-7942	blinking jittery pocket ace	0		
+7941	mirror teal sleeve deuce	0		
+7942	jittery blinking pocket ace	0		
 7943	nastygeist	0		
 7944	tooth	0		
 7945	mirror table	0		
 7946	smelly outlaw bandana of Leguizamo of Flo-Jo	0		Monster Level: +20, Stench Spell Damage: +10, Initiative: +100
 7947	enchanted tolerable practically non-alcoholic whiskey in a broken glass	1	good	Effect: "Elron's Explosive Etude", Effect Duration: 45
-7948	artisanal extra-dry shot of mescal	5	EPIC	
+7948	extra-dry artisanal shot of mescal	5	EPIC	
 7949	distilled drinkable gray glass of herbal tequila	5	good	
 7950	minin' dynamite	0		
 7951	sage plaid cowboy hat of temperance	0		Mysticality Percent: +10, Sleaze Resistance: +5, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7841,7 +7841,7 @@
 7959	yellow squat letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	auspicious lard-coated frightening Samson's Staff of Ed	0		Experience (Muscle): +5, Spooky Damage: +5, Sleaze Spell Damage: +25, Item Drop: +10
-7962	huge blue Eye of Ed	0		
+7962	blue huge Eye of Ed	0		
 7963	yellow amulet	0		
 7964	medical-grade Staff of Fats	0		HP Regen Min: 7, HP Regen Max: 10
 7965	Holy MacGuffin	0		
@@ -7880,8 +7880,8 @@
 7998	vaporized spinning powder	1		Last Available: "2015-12"
 7999	dry choco-Crimbot	0		Effect: "Greasy Flavor", Effect Duration: 47, Last Available: "2014-12"
 8000	pickled dry concentrated smart watch	0		Effect: "Bricked-In", Effect Duration: 63, Last Available: "2014-12"
-8001	denatured polarized blurry shaking augmented-reality shades	0		Effect: "Tiki Toughness", Effect Duration: 53, Last Available: "2014-12"
-8002	greasy toy Crimbot mega face	0		Sleaze Spell Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8001	denatured polarized shaking blurry augmented-reality shades	0		Effect: "Tiki Toughness", Effect Duration: 53, Last Available: "2014-12"
+8002	greasy toy Crimbot mega face	0		Sleaze Spell Damage: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
 8003	toasty toy Crimbot power glove	0		Hot Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	twirling miser's toy Crimbot super fist	0		Meat Drop: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	quilted toy Crimbot rocket legs	0		Damage Absorption: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7897,10 +7897,10 @@
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	polymerized triple-unsweetened fitness wristband	0		Effect: "Helvella Health", Effect Duration: 59, Last Available: "2014-12"
 8017	activated purple flask of tainted mining oil	0		Effect: "Retrograde Relaxation", Effect Duration: 12, Last Available: "2014-12"
-8018	pressed pickled purple tumbling and rain stick	0		Effect: "Category", Effect Duration: 60
+8018	pressed pickled tumbling purple and rain stick	0		Effect: "Category", Effect Duration: 60
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	rotten Choco-Mint patty	3	crappy	Last Available: "2015-01"
-8021	triple-distilled mediocre hot mint schnocolate	6	decent	Last Available: "2015-01"
+8021	mediocre triple-distilled hot mint schnocolate	6	decent	Last Available: "2015-01"
 8022	denatured ghostly homeopathic mint tea	1	crappy	Effect: "Nuts about Candy", Effect Duration: 50, Last Available: "2015-01"
 8023	blurry muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
@@ -7908,7 +7908,7 @@
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
 8028	ghostly artificial skylight	0		Last Available: "2015-01"
-8029	gray mirror Swiss piggy bank	0		Last Available: "2015-01"
+8029	mirror gray Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	upside-down stationery set	0		Last Available: "2015-01"
 8032	bouncing huge calligraphy pen	0		Free Pull, Last Available: "2015-01"
@@ -7937,13 +7937,13 @@
 8056	torch	0		
 8057	chilly therapeutic [spelunking test kit]	0		Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7
 8058	toasty plasma rifle	0		Hot Damage: +5
-8059	olive upside-down Bananubis's Staff	0		Luck: -6
+8059	upside-down olive Bananubis's Staff	0		Luck: -6
 8060	Temple Grandin's stiffened The Joke Book of the Dead	0		Damage Reduction: 1, Familiar Weight: +7, Luck: -6
 8061	pulsating The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	upside-down mirror Tales of Spelunking	0		Last Available: "2015-12"
+8063	mirror upside-down Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
-8065	skewed blurry pulsating banana	0		Familiar Weight: +5
+8065	skewed pulsating blurry banana	0		Familiar Weight: +5
 8066	powdered	1	crappy	Last Available: "2015-12"
 8067	green nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	wobbly janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	blinking studded Spelunker's fedora of Leguizamo of the sewer	0		Damage Absorption: +80, Monster Level: +20, Stench Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	blinking studded Spelunker's fedora of Leguizamo of the sewer	0		Damage Absorption: +80, Monster Level: +20, Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	supercharged vibrating Spelunker's whip of the brute	0		Muscle Percent: +30, Maximum MP Percent: 40, Last Available: "2015-12"
-8076	perfumed deadly sage Spelunker's khakis	0		Mysticality Percent: +10, Weapon Damage: +5, Stench Resistance: +5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	perfumed deadly sage Spelunker's khakis	0		Mysticality Percent: +10, Weapon Damage: +5, Stench Resistance: +5, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	squat Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8015,21 +8015,21 @@
 8141	greasy macroplane grater	0		Sleaze Spell Damage: +10
 8142	upside-down prompt bastard baster	0		Adventures: +3
 8143	steel-toed obsidian nutcracker	0		Damage Reduction: 9
-8144	squat lime green talisman of Seshat	0		Free Pull
+8144	lime green squat talisman of Seshat	0		Free Pull
 8145	Socratic groovy glass eye	0		Moxie Percent: +10, Experience (Mysticality): +1, Single Equip
 8146	colloidal frozen invisible potion	0		Effect: "Protection from Bad Stuff", Effect Duration: 58
 8147	pulsating time shuriken	0		
 8148	frightening hale cool ninjammies	0		Moxie: +5, Maximum HP: +20, Spooky Damage: +5, Familiar Effect: "atk, 0.5xPotato, cap 25"
 8149	polarized extra-pressed Glo-Pop	0		Effect: "Flamibili Tea", Effect Duration: 19
 8150	vacuum-sealed tumbling sugar sphere	0		Effect: "Techno Bliss", Effect Duration: 24
-8151	Vulcanized colloidal narrow olive Shrubble Bubble	0		Effect: "Minerva's Zen", Effect Duration: 40
+8151	Vulcanized colloidal olive narrow Shrubble Bubble	0		Effect: "Minerva's Zen", Effect Duration: 40
 8152	corrupted polyeaster egg	0		Effect: "Superhuman Sarcasm", Effect Duration: 33
 8153	tarnished colloidal candy dish	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 47
 8154	non-moist quadruple-activated Spechunky bar	0		Effect: "Riboflavin'", Effect Duration: 51
 8155	super-alkaline deionized blurry talisman of Horus	0		Effect: "Tenacity of the Snapper", Effect Duration: 66
 8156	check to the Meatsmith	0		
 8157	mirror Skeleton Store office key	0		
-8158	wobbly green bone with a price tag on it	0		
+8158	green wobbly bone with a price tag on it	0		
 8159	red half of a tooth	0		
 8160	anodized mouse skull	0		Effect: "Uncaged Power", Effect Duration: 42
 8161	super-energized polarized really thick spine	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 61
@@ -8045,7 +8045,7 @@
 8171	smooth skewed unflavored wine cooler	3	awesome	
 8172	carton of snake milk	1	good	
 8173	wicked sewer snake	0		Spell Damage: +5
-8174	small flavorless tumbling pigeon egg	2	decent	
+8174	flavorless small tumbling pigeon egg	2	decent	
 8175	fuchsia knitted jaunty feather of temperance	0		Cold Resistance: +3, Sleaze Resistance: +5
 8176	tolerable huge premium malt liquor	4	good	
 8177	flame-wreathed savvy brown paper pants	0		Mysticality Percent: +20, Hot Spell Damage: +10
@@ -8056,7 +8056,7 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	rosewater-soaked bread basket	0		Stench Resistance: +3
 8184	Ed the Undying exhibit crate	0		
-8185	red chilly hale The Crown of Ed the Undying	0		Maximum HP: +20, Cold Damage: +5, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	red chilly hale The Crown of Ed the Undying	0		Maximum HP: +20, Cold Damage: +5, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	ghostly map to a hidden booze cache	0		
 8188	perfectly mixed Cherrytastrophe wine cooler	4	EPIC	
@@ -8064,11 +8064,11 @@
 8190	hand-crafted olive Orangemageddon wine cooler	3	EPIC	
 8191	artisanal Breakfast Blast wine cooler	4	EPIC	
 8192	watered-down hand-crafted Citrus Crush wine cooler	2	EPIC	
-8193	big bland plain bagel	5	decent	
+8193	bland big plain bagel	5	decent	
 8194	adequate glob of cream cheese	3	good	
 8195	decent skewed loaf of soda bread	4	good	
 8196	huge tasty acceptable bagel	7	awesome	
-8197	bland super-sized standard-issue cupcake	5	decent	
+8197	super-sized bland standard-issue cupcake	5	decent	
 8198	normal ultra-deluxe cupcake	3	good	
 8199	hypnotic breadcrumbs	0		
 8200	adequate popular tart	4	good	
@@ -8091,8 +8091,8 @@
 8217	blinking Jack Frost's perfume-soaked bandana of the brute	0		Muscle Percent: +30, Cold Spell Damage: +50, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	tiny decent pulsating toxo	1	good	Last Available: "2015-04"
-8220	bad fancy Lemonade-235	4	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2015-04"
-8221	rosy-cheeked weightlifter's isotophat	0		Muscle: +15, Maximum HP Percent: +30, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8220	fancy bad Lemonade-235	4	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2015-04"
+8221	rosy-cheeked weightlifter's isotophat	0		Muscle: +15, Maximum HP Percent: +30, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	grievous Three Mile Island shorts of Calamity Jane	0		Weapon Damage Percent: +50, Critical Hit Percent: +15, Last Available: "2015-04"
 8223	aromatic toxic mop of the cougar	0		Moxie: +20, Stench Resistance: +1, Last Available: "2015-04"
 8224	skewed inert sludgepuppy	0		Last Available: "2015-04"
@@ -8129,7 +8129,7 @@
 8255	green Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	double-chilled diffused nasty gum	0		Effect: "How to Scam Tourists", Effect Duration: 54
-8258	spinning jittery Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
+8258	jittery spinning Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	rock-hard The Lot's engagement ring	0		Damage Reduction: 5, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	Mayo Clinic	0		Last Available: "2015-05"
 8261	shaking Mayonex	0		Last Available: "2015-05"
@@ -8182,7 +8182,7 @@
 8308	altered double-Vulcanized piggy tattoo	0		Effect: "Haunted Stomach", Effect Duration: 14
 8309	frozen modified fuchsia baggie of regular-sized tardigrades	0		Effect: "Patched In", Effect Duration: 34
 8310	dry narrow .epub file	0		Effect: "Fangs and Pangs", Effect Duration: 18
-8311	double-electrified blue squat BUBBLE GUM	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 33
+8311	double-electrified squat blue BUBBLE GUM	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 33
 8312	liquefied super-ionized squat hustler shades	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 11
 8313	oxidized polymerized blue jerky stick	0		Effect: "Far Out", Effect Duration: 50
 8314	ionized diffused tumbling costume rental shop	0		Effect: "The Living Hitpoints", Effect Duration: 25
@@ -8216,8 +8216,8 @@
 8342	frozen jittery baloney rotgut	0		Effect: "The Power of LOV", Effect Duration: 36
 8343	magnetized carton of gaspers	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 25
 8344	polymerized non-chilled cyan bronze polish	0		Effect: "Peppermint Bite", Effect Duration: 60
-8345	dry concentrated blinking upside-down crident	0		Effect: "Space Tripping", Effect Duration: 51
-8346	polarized squat red totally sweet mohawk helmet	0		Effect: "Magically Fingered", Effect Duration: 41
+8345	dry concentrated upside-down blinking crident	0		Effect: "Space Tripping", Effect Duration: 51
+8346	polarized red squat totally sweet mohawk helmet	0		Effect: "Magically Fingered", Effect Duration: 41
 8347	polymerized oxidized red spray chrome	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 38
 8348	vacuum-sealed tarnished filthy monkey head	0		Effect: "Winklered", Effect Duration: 29
 8349	corrupted hand of cards	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 29
@@ -8229,18 +8229,18 @@
 8355	alkaline dry blue iron torso box	0		Effect: "Soles of Glass", Effect Duration: 68
 8356	adjusted tumbling mercenary headband	0		Effect: "Cool Spirit", Effect Duration: 31
 8357	wet double-ionized twirling radioactive spider venom	0		Effect: "Empathy", Effect Duration: 46
-8358	denatured ionized squat skewed x-ray mirror	0		Effect: "Craft Tea", Effect Duration: 59
+8358	denatured ionized skewed squat x-ray mirror	0		Effect: "Craft Tea", Effect Duration: 59
 8359	denatured chilled wrestling mask	0		Effect: "Can't Smell Nothin'", Effect Duration: 55
 8360	colloidal hawkface potion	0		Effect: "Fishy Fortification", Effect Duration: 47
 8361	pickled concentrated child-sized dracula cloak	0		Effect: "Insulated Trousers", Effect Duration: 31
 8362	cold-filtered yellow devil-summoning hat	0		Effect: "Eyes Wide Propped", Effect Duration: 27
-8363	polymerized jittery red shopkeeper beard	0		Effect: "Boon of She-Who-Was", Effect Duration: 28
+8363	polymerized red jittery shopkeeper beard	0		Effect: "Boon of She-Who-Was", Effect Duration: 28
 8364	pressed alien autoautopsy kit	0		Effect: "Mushroom Samba", Effect Duration: 30
 8365	wet super-corrupted wet novelty fruit hat	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 43
 8366	boiled fuchsia invisibility cream	0		Effect: "Shamboozled", Effect Duration: 52
 8367	non-nitrogenated spinning handful of stubble	0		Effect: "Muscularrr", Effect Duration: 31
 8368	improved corrupted fuchsia garbage juice slurpee	0		Effect: "Ooh, Bitter!", Effect Duration: 48
-8369	adjusted tumbling yellow plunge-leg	0		Effect: "Material Witness", Effect Duration: 51
+8369	adjusted yellow tumbling plunge-leg	0		Effect: "Material Witness", Effect Duration: 51
 8370	electrified funky eyepatch	0		Effect: "Witch's Brood", Effect Duration: 41
 8371	activated spinning bucket of fish juice	0		Effect: "Frosty the Hitman", Effect Duration: 27
 8372	aerosolized lime green flashy pirate dreadlocks	0		Effect: "Extra Terrestrial", Effect Duration: 63
@@ -8256,11 +8256,11 @@
 8382	narrow Deck of Every Card	0		Last Available: "2015-07"
 8383	blinking popular part	0		
 8384	squat bubblegum heart	0		Last Available: "2015-07"
-8385	blinking jittery purple cubic zirconia	0		Last Available: "2015-07"
+8385	jittery purple blinking cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	narrow mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
-8389	upside-down squat mana	0		Last Available: "2015-07"
+8389	squat upside-down mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	blurry mana	0		Last Available: "2015-07"
 8392	blurry gift card	0		Last Available: "2015-07"
@@ -8275,17 +8275,17 @@
 8401	chaotic wicked candlestick	0		Spell Damage: +5, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2015-07"
 8402	medical-grade knife of the scaredy-cat	0		Monster Level: -15, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-07"
 8403	strapping revolver of the businessman	0		Muscle: +5, Meat Drop: +50, Lasts Until Rollover, Last Available: "2015-07"
-8404	spinning bouncing 1952 Mickey Mantle card	0		Last Available: "2015-07"
+8404	bouncing spinning 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
 8407	big normal pestopiary	5	good	
 8408	diffused altered ectoplasmic orbs	0		Effect: "Educated (Kinda)", Effect Duration: 57
-8409	bite-sized tasty shaking crudles	1	awesome	
+8409	tasty bite-sized shaking crudles	1	awesome	
 8410	spoiled big agnolotti arboli	5	crappy	
 8411	normal spaghetti with ghost balls	3	good	
 8412	spoiled succulent marrow	4	crappy	
 8413	bland salacious crumbs	4	decent	
-8414	rotten small fusilli marrownarrow	2	crappy	
+8414	small rotten fusilli marrownarrow	2	crappy	
 8415	flavorless diet suggestive strozzapreti	1	decent	
 8416	Mountain Stream gastrique	0		
 8417	stale low-calorie Mt. McLargeHuge oyster	1	decent	
@@ -8309,7 +8309,7 @@
 8435	lard-coated Socratic LavaCo Lamp&trade;	0		Experience (Mysticality): +1, Sleaze Spell Damage: +25, Last Available: "2015-08"
 8436	olive narrow rosy-cheeked LavaCo Lamp&trade; of the sewer	0		Maximum HP Percent: +30, Stench Damage: +25, Last Available: "2015-08"
 8437	Temple Grandin's LavaCo Lamp&trade; of the dark arts	0		Spell Damage Percent: +100, Familiar Weight: +7, Last Available: "2015-08"
-8438	green squat thin wire	0		Last Available: "2015-08"
+8438	squat green thin wire	0		Last Available: "2015-08"
 8439	blinking spinning narrow insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
 8441	jittery full lava bottle	0		Last Available: "2015-08"
@@ -8329,13 +8329,13 @@
 8455	narrow New Age crystal	0		Last Available: "2015-08"
 8456	purple crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	reassuring mansplainer's high-temperature mining mask	0		Monster Level: +15, Spooky Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	reassuring mansplainer's high-temperature mining mask	0		Monster Level: +15, Spooky Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	purple frosty fireproof megaphone of the storm	0		Maximum MP Percent: +40, Cold Spell Damage: +10, Last Available: "2015-08"
 8460	adequate snack-sized mineapple	2	good	Last Available: "2015-08"
-8461	triple-distilled acceptable narrow tumbling mirror Gold Velvet&trade; whiskey	10	good	Last Available: "2015-08"
+8461	triple-distilled acceptable tumbling narrow mirror Gold Velvet&trade; whiskey	10	good	Last Available: "2015-08"
 8462	fancy SMOOCH soda	1	crappy	Effect: "Puzzle Fury", Effect Duration: 25, Last Available: "2015-08"
 8463	normal smelted roe	3	good	Last Available: "2015-08"
-8464	drinkable triple-distilled lavawater	9	good	Last Available: "2015-08"
+8464	triple-distilled drinkable lavawater	9	good	Last Available: "2015-08"
 8465	polymerized Vulcanized basaltamander tongue	0		Effect: "Muscle Unbound", Effect Duration: 29, Last Available: "2015-08"
 8466	fortified Herculean smooth lavalarva	0		Moxie: +15, Experience (Muscle): +1, Damage Absorption: +60, Last Available: "2015-08"
 8467	rosewater-soaked Socratic lava balaclava of terror	0		Experience (Mysticality): +1, Spooky Spell Damage: +10, Stench Resistance: +3, Last Available: "2015-08"
@@ -8350,9 +8350,9 @@
 8476	extra-galvanized double-enhanced liquid rhinestones	0		Effect: "Broberry Brotality", Effect Duration: 15, Last Available: "2015-08"
 8477	stale blurry disco biscuit	4	decent	Last Available: "2015-08"
 8478	extra-dry lousy Quaatorade&trade;	5	decent	Last Available: "2015-08"
-8479	scandalous Annie Oakley's groovy biker's hat	0		Moxie Percent: +10, Critical Hit Percent: +20, Sleaze Damage: +5, Last Available: "2015-08", Familiar Effect: "atk"
-8480	jittery greasy wholesome feathered headdress of the pedagogue	0		Experience: +3, Maximum HP Percent: +10, Sleaze Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	hale personal trainer's electrician's hardhat of temperance	0		Experience Percent (Muscle): +10, Maximum HP: +20, Sleaze Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk"
+8479	scandalous Annie Oakley's groovy biker's hat	0		Moxie Percent: +10, Critical Hit Percent: +20, Sleaze Damage: +5, Familiar Effect: "atk", Last Available: "2015-08"
+8480	jittery greasy wholesome feathered headdress of the pedagogue	0		Experience: +3, Maximum HP Percent: +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	hale personal trainer's electrician's hardhat of temperance	0		Experience Percent (Muscle): +10, Maximum HP: +20, Sleaze Resistance: +5, Familiar Effect: "atk", Last Available: "2015-08"
 8482	tumbling Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	blinking airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	olive New Age hurting crystal	0		Last Available: "2015-08"
-8490	smooth velvet pants of the brute	0		Muscle Percent: +30, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	smooth velvet pants of the brute	0		Muscle Percent: +30, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	narrow scorching smooth velvet shirt	0		Hot Damage: +25, Last Available: "2015-08"
 8492	zippy smooth velvet hat	0		Initiative: +20, Last Available: "2015-08"
 8493	smooth smooth velvet pocket square	0		Moxie: +15, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	horrifying SMOOCH bracers of the detective	0		Spooky Damage: +25, Item Drop: +20, Single Equip, Last Available: "2015-08"
 8518	MacGyver's SMOOCH kneepads	0		Maximum MP: +100, Single Equip, Last Available: "2015-08"
 8519	rosy-cheeked SMOOCH spaulders	0		Maximum HP Percent: +30, Single Equip, Last Available: "2015-08"
-8520	electrified Da Vinci's SMOOCH codpiece	0		Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	electrified Da Vinci's SMOOCH codpiece	0		Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	SMOOCH breastplate of incineration	0		Hot Spell Damage: +50, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8400,8 +8400,8 @@
 8526	spoiled tumbling pink slime	3	crappy	
 8527	narrow Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	massive normal devil hair pasta	10	good	
-8530	flavorless super-sized spagecialetti	5	decent	
+8529	normal massive devil hair pasta	10	good	
+8530	super-sized flavorless spagecialetti	5	decent	
 8531	pulsating Salsa Libre	0		
 8532	teal good gravy	0		
 8533	illicit fish sauce	0		
@@ -8419,7 +8419,7 @@
 8546	super-ionized bag of grain	0		Effect: "Bolts about Candy", Effect Duration: 56
 8547	cold-filtered blurry green pocket maze	0		Effect: "Bilious Briskness", Effect Duration: 22
 8548	unsweetened ionized pulsating shady shades	0		Effect: "Elemental Flavor", Effect Duration: 18
-8549	boiled blurry spinning squeaky toy rose	0		Effect: "Prideful Strut", Effect Duration: 13
+8549	boiled spinning blurry squeaky toy rose	0		Effect: "Prideful Strut", Effect Duration: 13
 8550	immense stale maroon weird gazelle steak	10	decent	
 8551	flavorless diet sausage without a cause	1	decent	
 8552	pickled vacuum-sealed jittery face paint	0		Effect: "Hairless and Airless", Effect Duration: 57
@@ -8437,10 +8437,10 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	careful Rosewater's savvy barrel lid	0		Mysticality Percent: 50, Monster Level: -10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	twirling rosewater-soaked wool veiny barrel hoop earring	0		Maximum HP: +10, Cold Resistance: +1, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2015-09"
-8567	resourceful crafty banded bankruptcy barrel	0		Damage Absorption: +100, Maximum MP: 60, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	resourceful crafty banded bankruptcy barrel	0		Damage Absorption: +100, Maximum MP: 60, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	firkin	0		Last Available: "2015-09"
 8569	mirror normal barrel	0		Last Available: "2015-09"
-8570	blurry blurry huge tun	0		Last Available: "2015-09"
+8570	blurry huge blurry tun	0		Last Available: "2015-09"
 8571	teal weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
 8573	barrel	0		Last Available: "2015-09"
@@ -8448,12 +8448,12 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	hand-crafted triple-distilled bottle of Amontillado	7	EPIC	Last Available: "2015-09"
-8579	smooth maroon upside-down barrel-aged martini	3	awesome	Last Available: "2015-09"
+8578	triple-distilled hand-crafted bottle of Amontillado	7	EPIC	Last Available: "2015-09"
+8579	smooth upside-down maroon barrel-aged martini	3	awesome	Last Available: "2015-09"
 8580	adequate half-sized barrel pickle	2	good	Last Available: "2015-09"
 8581	delicious huge barrel cracker	4	awesome	Last Available: "2015-09"
 8582	modified twirling vibrating mushroom	1	EPIC	Last Available: "2015-09"
-8583	mixed blue blinking mushroom	1	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2015-09"
+8583	mixed blinking blue mushroom	1	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2015-09"
 8584	KoL Con 12-gauge of chilblains	0		Cold Damage: +25, Last Available: "2015-09"
 8585	Golden Mr. Eh? of incineration	0		Hot Spell Damage: +50, Last Available: "2015-09"
 8586	rosy-cheeked barrel gun	0		Maximum HP Percent: +30, Last Available: "2015-09"
@@ -8490,14 +8490,14 @@
 8617	super-moist polarized cuppa Dexteri tea	0		Effect: "Ready to Snap", Effect Duration: 21, Last Available: "2015-09"
 8618	chilled frozen cuppa Flexibili tea	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 48, Last Available: "2015-09"
 8619	concentrated cyan cuppa Impregnabili tea	0		Effect: "Capricorn Rising", Effect Duration: 36, Last Available: "2015-09"
-8620	adjusted cyan tumbling wobbly cuppa Obscuri tea	0		Effect: "Optimist Primal", Effect Duration: 28, Last Available: "2015-09"
+8620	adjusted wobbly tumbling cyan cuppa Obscuri tea	0		Effect: "Optimist Primal", Effect Duration: 28, Last Available: "2015-09"
 8621	irradiated polymerized energized olive cuppa Irritabili tea	0		Effect: "Impregnably Delicious", Effect Duration: 47, Last Available: "2015-09"
 8622	polarized green jittery cuppa Mediocri tea	0		Effect: "Glittering Eyelashes", Effect Duration: 40, Last Available: "2015-09"
 8623	boiled cuppa Loyal tea	0		Effect: "Ichorous Eyesight", Effect Duration: 31, Last Available: "2015-09"
 8624	dehydrated cuppa Activi tea	1	crappy	Last Available: "2015-09"
 8625	dried cyan tumbling cuppa Cruel tea	1		Last Available: "2015-09"
 8626	ionized warmed denatured cuppa Alacri tea	0		Effect: "Whole Latte Love", Effect Duration: 67, Last Available: "2015-09"
-8627	super-magnetized colloidal skewed gray cuppa Vitali tea	0		Effect: "One Very Clear Eye", Effect Duration: 43, Last Available: "2015-09"
+8627	super-magnetized colloidal gray skewed cuppa Vitali tea	0		Effect: "One Very Clear Eye", Effect Duration: 43, Last Available: "2015-09"
 8628	altered cuppa Mana tea	0		Effect: "No Vertigo", Effect Duration: 43, Last Available: "2015-09"
 8629	Vulcanized non-altered cuppa Monstrosi tea	0		Effect: "Bells in the Batfry", Effect Duration: 33, Last Available: "2015-09"
 8630	quantum vacuum-sealed cuppa Twen tea	0		Effect: "Phairly Balanced", Effect Duration: 50, Last Available: "2015-09"
@@ -8514,7 +8514,7 @@
 8641	adequate bowl of eyeballs	4	good	Last Available: "2015-10"
 8642	yummy pulsating bowl of mummy guts	4	awesome	Last Available: "2015-10"
 8643	normal upside-down bowl of maggots	3	good	Last Available: "2015-10"
-8644	watered-down special drinkable blurry blood and blood	2	good	Effect: "The Power of Negative Thinking", Effect Duration: 35, Last Available: "2015-10"
+8644	special watered-down drinkable blurry blood and blood	2	good	Effect: "The Power of Negative Thinking", Effect Duration: 35, Last Available: "2015-10"
 8645	drinkable Jack-O-Lantern beer	4	good	Last Available: "2015-10"
 8646	practically non-alcoholic aged zombie	1	awesome	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	olive How to Play Othello	0		
 8662	personal trainer's slick ghostly dagger of Gandalf	0		Moxie: +10, Experience Percent (Muscle): +10, Spell Critical Percent: +20
-8663	special mediocre weak ghost beer	2	decent	Effect: "Bored Stiff", Effect Duration: 50
+8663	mediocre weak special ghost beer	2	decent	Effect: "Bored Stiff", Effect Duration: 50
 8664	narrow Rosewater's Othello set	0		Mysticality Percent: +30
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8548,7 +8548,7 @@
 8675	squat one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	alkaline warmed squat shoulder-warming lotion	0		Effect: "Souper Vengeful", Effect Duration: 23, Last Available: "2015-11"
 8677	low-calorie toothsome teal iceberg lettuce	1	awesome	Last Available: "2015-11"
-8678	drinkable triple-distilled ice wine	7	good	Last Available: "2015-11"
+8678	triple-distilled drinkable ice wine	7	good	Last Available: "2015-11"
 8679	flame-retardant shellacked quilted Wal-Mart snowglobe	0		Damage Absorption: +40, Damage Reduction: 7, Hot Resistance: +1, Last Available: "2015-11"
 8680	ghostly up-at-dawn inspector's Sinatra's Wal-Mart nametag	0		Experience (Moxie): +5, Item Drop: +15, Adventures: +5, Last Available: "2015-11"
 8681	gray perfumed wizardly Wal-Mart overalls of the storm	0		Mysticality: +25, Maximum MP Percent: +40, Stench Resistance: +5, Last Available: "2015-11"
@@ -8558,30 +8558,30 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	fuchsia boxer's bellhop's hat	0		Muscle Percent: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	acceptable weak enchanted ice porter	2	good	Effect: "Full of Vinegar", Effect Duration: 40, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	fuchsia boxer's bellhop's hat	0		Muscle Percent: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	weak enchanted acceptable ice porter	2	good	Effect: "Full of Vinegar", Effect Duration: 40, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	unsweetened exotic travel brochure	0		Effect: "Ass Over Teakettle", Effect Duration: 45, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
-8692	liquefied colloidal blinking maroon shampoo-conditioner	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 37, Last Available: "2015-11"
+8692	liquefied colloidal maroon blinking shampoo-conditioner	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 37, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	blue Martialest Arts trophy	0		Last Available: "2016-01"
 8696	boiled blinking medicinal herbs	1		Effect: "Yeah, It's Just Gasoline", Effect Duration: 40, Last Available: "2016-01"
 8697	delicious ice rice	3	awesome	Last Available: "2016-01"
-8698	weak artisanal shaking twirling iced plum wine	2	EPIC	Last Available: "2016-01"
+8698	artisanal weak shaking twirling iced plum wine	2	EPIC	Last Available: "2016-01"
 8699	careful MacGyver's boxer's training belt	0		Muscle Percent: +10, Maximum MP: +100, Monster Level: -10, Single Equip, Last Available: "2016-01"
 8700	narrow flame-wreathed resourceful stylish training legwarmers	0		Moxie: +25, Maximum MP: +50, Hot Spell Damage: +10, Single Equip, Last Available: "2016-01"
-8701	Sherlock's Sinatra's training helmet of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10, Item Drop: +25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	Sherlock's Sinatra's training helmet of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10, Item Drop: +25, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	blurry training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
-8706	spinning huge machine elf capsule	0		Free Pull, Last Available: "2015-12"
+8706	huge spinning machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	powdered shaking upside-down abstraction: action	1		Effect: "Badger Underfoot", Effect Duration: 15, Last Available: "2015-12"
 8709	modified maroon abstraction: thought	1		Last Available: "2015-12"
-8710	dried purple blurry abstraction: sensation	1		Last Available: "2015-12"
-8711	vaporized upside-down spinning abstraction: purpose	1		Last Available: "2015-12"
+8710	dried blurry purple abstraction: sensation	1		Last Available: "2015-12"
+8711	vaporized spinning upside-down abstraction: purpose	1		Last Available: "2015-12"
 8712	twisted cyan blurry abstraction: category	1		Effect: "Soles of Glass", Effect Duration: 35, Last Available: "2015-12"
 8713	twisted blinking abstraction: perception	1		Last Available: "2015-12"
 8714	diluted abstraction: motion	1		Effect: "Provocative Perkiness", Effect Duration: 25, Last Available: "2015-12"
@@ -8589,7 +8589,7 @@
 8716	distilled yellow ghostly abstraction: certainty	1		Last Available: "2015-12"
 8717	vaporized abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	gigantic adequate VYKEA meatballs	8	good	Last Available: "2015-11"
+8719	adequate gigantic VYKEA meatballs	8	good	Last Available: "2015-11"
 8720	drinkable gray VYKEA mead	4	good	Last Available: "2015-11"
 8721	oxidized VYKEA woadpaint	0		Effect: "It's Soporiffic!", Effect Duration: 27, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8605,14 +8605,14 @@
 8732	delicious skewed bottle of norwhiskey	3	awesome	Last Available: "2015-11"
 8733	twisted ghostly octolus oculus	1	EPIC	Last Available: "2015-11"
 8734	asbestos-lined arcane researcher's sardine can key of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Hot Resistance: +5, Last Available: "2015-11"
-8735	fuchsia chaotic savvy norwhal helmet of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Spell Critical Percent: +10, Last Available: "2015-11", Familiar Effect: "atk"
+8735	fuchsia chaotic savvy norwhal helmet of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Spell Critical Percent: +10, Familiar Effect: "atk", Last Available: "2015-11"
 8736	shaking ghostly family-friendly wicked dance instructor's octolus-skin cloak	0		Experience Percent (Moxie): +10, Spell Damage: +5, Sleaze Resistance: +1, Last Available: "2015-11"
-8737	delicious practically non-alcoholic perfect cosmopolitan	1	awesome	Last Available: "2015-11"
-8738	smooth fancy twirling perfect negroni	3	awesome	Effect: "Mutated", Effect Duration: 15, Last Available: "2015-11"
+8737	practically non-alcoholic delicious perfect cosmopolitan	1	awesome	Last Available: "2015-11"
+8738	fancy smooth twirling perfect negroni	3	awesome	Effect: "Mutated", Effect Duration: 15, Last Available: "2015-11"
 8739	perfectly mixed perfect dark and stormy	4	EPIC	Last Available: "2015-11"
-8740	spirit-forward artisanal perfect mimosa	5	EPIC	Last Available: "2015-11"
+8740	artisanal spirit-forward perfect mimosa	5	EPIC	Last Available: "2015-11"
 8741	perfectly mixed perfect old-fashioned	3	EPIC	Last Available: "2015-11"
-8742	triple-distilled bad perfect paloma	8	decent	Last Available: "2015-11"
+8742	bad triple-distilled perfect paloma	8	decent	Last Available: "2015-11"
 8743	Vulcanized activated lime green That 70s Cologne	0		Effect: "Liquidy Smoky", Effect Duration: 60, Last Available: "2015-11"
 8744	modified Wal-Mart &quot;diamond&quot; ring	0		Effect: "Chalky Hand", Effect Duration: 22, Last Available: "2015-11"
 8745	liquefied pickled Puffstone cigar	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 55, Last Available: "2015-11"
@@ -8636,7 +8636,7 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	extra-dry special drinkable Gratitude chocolate (bourbon-filled)	5	good	Effect: "Cinnamouth", Effect Duration: 45, Last Available: "2016-02"
+8766	extra-dry drinkable special Gratitude chocolate (bourbon-filled)	5	good	Effect: "Cinnamouth", Effect Duration: 45, Last Available: "2016-02"
 8767	blurry Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8654,15 +8654,15 @@
 8782	Jeselnik's reindeer hammer	0		Sleaze Damage: +25, Last Available: "2015-12"
 8783	quilted elf ploughshare	0		Damage Absorption: +40, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	tumbling faded protest sign	0		Last Available: "2015-12"
 8788	shaking teal nasty-smelling moss	0		Last Available: "2015-12"
 8789	narrow book	0		Last Available: "2015-12"
 8790	veiny elven tambourine	0		Maximum HP: +10, Last Available: "2015-12"
 8791	mirror reindeer sickle of dire peril	0		Weapon Damage: +20, Last Available: "2015-12"
-8792	blurry blinking olive face paint	0		Free Pull, Last Available: "2015-12"
-8793	green twirling face paint	0		Free Pull, Last Available: "2015-12"
+8792	blinking blurry olive face paint	0		Free Pull, Last Available: "2015-12"
+8793	twirling green face paint	0		Free Pull, Last Available: "2015-12"
 8794	wobbly The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
@@ -8677,7 +8677,7 @@
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	blurry high-grade explosives	0		Last Available: "2017-01"
 8807	experimental gene therapy	0		Last Available: "2017-01"
-8808	bouncing olive ultracoagulator	0		Last Available: "2017-01"
+8808	olive bouncing ultracoagulator	0		Last Available: "2017-01"
 8809	wobbly self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	confidence-building hug	0		Last Available: "2017-01"
@@ -8687,15 +8687,15 @@
 8815	spinning bat-bearing	0		Last Available: "2017-01"
 8816	moldy ghostly Kudzu salad	4	crappy	Last Available: "2016-12"
 8817	distilled wobbly Mansquito Serum	1		Last Available: "2016-12"
-8818	practically non-alcoholic aged fancy wobbly Miss Graves' vermouth	1	awesome	Effect: "Quantum of Moxie", Effect Duration: 30, Last Available: "2016-12"
-8819	thick special adequate wobbly The Plumber's mushroom stew	5	good	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2016-12"
+8818	fancy practically non-alcoholic aged wobbly Miss Graves' vermouth	1	awesome	Effect: "Quantum of Moxie", Effect Duration: 30, Last Available: "2016-12"
+8819	special adequate thick wobbly The Plumber's mushroom stew	5	good	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2016-12"
 8820	dried The Author's ink	1		Effect: "Become Superficially interested", Effect Duration: 5, Last Available: "2016-02"
-8821	tolerable fortified The Mad Liquor	5	good	Last Available: "2016-12"
+8821	fortified tolerable The Mad Liquor	5	good	Last Available: "2016-12"
 8822	acceptable enchanted Doc Clock's thyme cocktail	3	good	Effect: "Extra-Thick Blood", Effect Duration: 10, Last Available: "2016-12"
 8823	spoiled small red Mr. Burnsger	2	crappy	Last Available: "2016-12"
-8824	mixed jittery squat The Inquisitor's unidentifiable object	1		Effect: "Holiday Disappointment", Effect Duration: 30, Last Available: "2016-12"
+8824	mixed squat jittery The Inquisitor's unidentifiable object	1		Effect: "Holiday Disappointment", Effect Duration: 30, Last Available: "2016-12"
 8825	purple pulsating executive reassuring nasty The Jokester's gun	0		Stench Damage: +5, Spooky Resistance: +1, Meat Drop: +40, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	blue twirling perfumed forbidden The Jokester's wig of the cheetah	0		Spell Damage Percent: +50, Stench Resistance: +5, Initiative: +60, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8826	blue twirling perfumed forbidden The Jokester's wig of the cheetah	0		Spell Damage Percent: +50, Stench Resistance: +5, Initiative: +60, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
 8827	twirling up-at-dawn dog trainer's energetic The Jokester's pants	0		Maximum MP Percent: +20, Experience (familiar): +1, Adventures: +5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	quantum polarized Jokester makeup	0		Effect: "Lubed", Effect Duration: 32, Last Available: "2016-12"
 8829	squat replica bat-oomerang	0		Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	narrow cyan domino mask	0		Familiar Weight: +5
 8833	pressed ghostly robin's egg	0		Effect: "High Blood Chocolate Content", Effect Duration: 13, Last Available: "2016-12"
 8834	delicious teal robin flan	3	awesome	Last Available: "2016-12"
-8835	practically non-alcoholic hand-crafted enchanted fuchsia robin nog	1	super ultra EPIC	Effect: "Okee-Dokee, Smokee", Effect Duration: 10, Last Available: "2016-12"
+8835	hand-crafted enchanted practically non-alcoholic fuchsia robin nog	1	super ultra EPIC	Effect: "Okee-Dokee, Smokee", Effect Duration: 10, Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	blinking plaintive telegram	0		Last Available: "2016-02"
 8838	maroon exploding gum	0		
@@ -8717,12 +8717,12 @@
 8845	liquefied quadruple-improved bag of random words	0		Effect: "Deadly Flashing Blade", Effect Duration: 69
 8846	activated tumbling tube of pendulum lube	0		Effect: "Intimidating Mien", Effect Duration: 52
 8847	aerosolized tarnished green red-hot jawbreaker	0		Effect: "Beastly Flavor", Effect Duration: 25
-8848	dry ionized spinning maroon question juice	0		Effect: "The Living Hitpoints", Effect Duration: 52
+8848	dry ionized maroon spinning question juice	0		Effect: "The Living Hitpoints", Effect Duration: 52
 8849	improved blue tube of villain	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 39
 8850	bouncing your cowboy boots of Gandalf	0		Spell Critical Percent: +20, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	bouncing inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
-8853	jittery wobbly nugget of thicksilver	0		Last Available: "2016-02"
+8853	wobbly jittery nugget of thicksilver	0		Last Available: "2016-02"
 8854	nugget of wicksilver	0		Last Available: "2016-02"
 8855	green nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
@@ -8747,18 +8747,18 @@
 8875	Sherlock's hardened beefcake's Shrub's Premium Baked Beans	0		Muscle: +25, Damage Reduction: 3, Item Drop: +25, Last Available: "2016-02"
 8876	normal plate of Heimz Fortified Kidney Beans	4	good	Last Available: "2016-02"
 8877	spoiled plate of Tesla's Electroplated Beans	4	crappy	Last Available: "2016-02"
-8878	tiny rotten plate of Mixed Garbanzos and Chickpeas	1	crappy	Last Available: "2016-02"
-8879	normal thick plate of Hellfire Spicy Beans	5	good	Last Available: "2016-02"
+8878	rotten tiny plate of Mixed Garbanzos and Chickpeas	1	crappy	Last Available: "2016-02"
+8879	thick normal plate of Hellfire Spicy Beans	5	good	Last Available: "2016-02"
 8880	yummy plate of Frigid Northern Beans	3	awesome	Last Available: "2016-02"
 8881	normal plate of World's Blackest-Eyed Peas	4	good	Last Available: "2016-02"
-8882	rotten enchanted plate of Trader Olaf's Exotic Stinkbeans	4	crappy	Effect: "Go Get 'Em, Tiger!", Effect Duration: 50, Last Available: "2016-02"
+8882	enchanted rotten plate of Trader Olaf's Exotic Stinkbeans	4	crappy	Effect: "Go Get 'Em, Tiger!", Effect Duration: 50, Last Available: "2016-02"
 8883	immense stale plate of Pork 'n' Pork 'n' Pork 'n' Beans	9	decent	Last Available: "2016-02"
 8884	adequate plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
 8885	diet decent plate of Shrub's Premium Baked Beans	1	good	Last Available: "2016-02"
 8886	dog trainer's sage Fancy Jeff's pocket square	0		Mysticality Percent: +10, Experience (familiar): +1, Last Available: "2016-02"
-8887	wicked extremely unsafe Daisy's unclean bloomers of the early riser	0		Weapon Damage Percent: +100, Spell Damage: +5, Adventures: +7, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	wicked extremely unsafe Daisy's unclean bloomers of the early riser	0		Weapon Damage Percent: +100, Spell Damage: +5, Adventures: +7, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	squat Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	greedy Van der Graaf stiffened Amoon-Ra Cowtep's nemes	0		Damage Reduction: 1, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	greedy Van der Graaf stiffened Amoon-Ra Cowtep's nemes	0		Damage Reduction: 1, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	spinning knitted baleful stylish Former Sheriff Dan's tin star of the cougar of chilblains	0		Moxie: 45, Spell Damage: +25, Cold Damage: +25, Cold Resistance: +3, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8774,10 +8774,10 @@
 8902	extra-modified gray ghost bit	0		Effect: "In the Slimelight", Effect Duration: 38, Last Available: "2016-02"
 8903	pickled buzzard feather	0		Effect: "Crying, Dying", Effect Duration: 15, Last Available: "2016-02"
 8904	nitrogenated quadruple-denatured upside-down lion musk	0		Effect: "Scorpio Rising", Effect Duration: 46, Last Available: "2016-02"
-8905	special tiny bland pulsating bear claw	1	decent	Effect: "Pasty", Effect Duration: 15, Last Available: "2016-02"
+8905	special bland tiny pulsating bear claw	1	decent	Effect: "Pasty", Effect Duration: 15, Last Available: "2016-02"
 8906	aerosolized ghostly rattler gland	0		Effect: "Magically Fingered", Effect Duration: 30, Last Available: "2016-02"
 8907	moist huge half-digested coal	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 54, Last Available: "2016-02"
-8908	dry spinning twirling tightly-wound spine	0		Effect: "Ham-Fisted", Effect Duration: 45, Last Available: "2016-02"
+8908	dry twirling spinning tightly-wound spine	0		Effect: "Ham-Fisted", Effect Duration: 45, Last Available: "2016-02"
 8909	normal rotting beefsteak	3	good	Last Available: "2016-02"
 8910	drinkable yellow firemilk	3	good	Last Available: "2016-02"
 8911	super-modified colloidal spidercow eye-cluster	0		Effect: "Haunted Stomach", Effect Duration: 14, Last Available: "2016-02"
@@ -8817,7 +8817,7 @@
 8945	ghostly cow skull	0		Last Available: "2016-02"
 8946	twirling jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
-8948	shaking wobbly thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
+8948	wobbly shaking thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	shaking slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
@@ -8862,23 +8862,23 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	shaking do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	vaporized spinning armored prawn	1		Last Available: "2016-03"
-8993	immense rotten jittery blinking jumping horseradish	9	crappy	Last Available: "2016-03"
+8993	rotten immense blinking jittery jumping horseradish	9	crappy	Last Available: "2016-03"
 8994	artisanal bouncing Sacramento wine	3	EPIC	Last Available: "2016-03"
 8995	oxidized Greek fire	0		Effect: "Prince of Seaside Town", Effect Duration: 18, Last Available: "2016-03"
 8996	blurry up-at-dawn studded ox-head shield of Tarzan of chilblains of terror	0		Experience (Muscle): +3, Damage Absorption: +80, Cold Damage: +25, Spooky Spell Damage: +10, Adventures: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	blinking knitted Jeselnik's sharpshooter's brainy dented scepter of the early riser	0		Mysticality: +5, Critical Hit Percent: +10, Sleaze Damage: +25, Cold Resistance: +3, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	asbestos-lined toasty very pointy crown of the cougar of the detective of the early riser	0		Moxie: +20, Hot Damage: +5, Hot Resistance: +5, Item Drop: +20, Adventures: +7, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	asbestos-lined toasty very pointy crown of the cougar of the detective of the early riser	0		Moxie: +20, Hot Damage: +5, Hot Resistance: +5, Item Drop: +20, Adventures: +7, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	aromatic horrifying Jim Carey's rosy-cheeked studded battle broom	0		Damage Absorption: +80, Maximum HP Percent: +30, Monster Level: +25, Spooky Damage: +25, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	lard-coated sizzling Lo Pan's forbidden carpe	0		Spell Damage Percent: +50, Spell Critical Percent: +30, Hot Damage: +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9002	huge wool Jim Carey's Socratic codpiece of the brute	0		Muscle Percent: +30, Experience (Mysticality): +1, Monster Level: +25, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
-9003	perfumed nasty hardy beefy troutsers	0		Muscle: +10, Maximum HP: +50, Stench Damage: +5, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	perfumed nasty hardy beefy troutsers	0		Muscle: +10, Maximum HP: +50, Stench Damage: +5, Stench Resistance: +5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	olive horrifying Annie Oakley's razor-sharp smartaleck's bass clarinet	0		Moxie Percent: +30, Weapon Damage Percent: +25, Critical Hit Percent: +20, Spooky Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9005	foul-smelling supercool smooth fish hatchet of the wise owl	0		Mysticality: +20, Moxie: +15, Moxie Percent: +20, Stench Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	clever hardened tunac of the scaredy-cat of extreme caution	0		Damage Reduction: 3, Maximum MP: +20, Monster Level: -40, Lasts Until Rollover, Last Available: "2016-04"
 9007	squat fishin' pole	0		Last Available: "2016-04"
-9008	non-altered electrified narrow mirror red wriggling worm	0		Effect: "Tearful, Fearful", Effect Duration: 53, Last Available: "2016-04"
-9009	lousy practically non-alcoholic bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
+9008	non-altered electrified narrow red mirror wriggling worm	0		Effect: "Tearful, Fearful", Effect Duration: 53, Last Available: "2016-04"
+9009	practically non-alcoholic lousy bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
 9010	warmed ionized purple high-test fishing line	0		Effect: "Well-preserved", Effect Duration: 50, Last Available: "2016-04"
 9011	energetic fishin' hat	0		Maximum MP Percent: +20, Last Available: "2016-04"
 9012	yellow Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8892,19 +8892,19 @@
 9020	squat plus one	0		Last Available: "2016-05"
 9021	rotten gallon of milk	3	crappy	Last Available: "2016-05"
 9022	skewed print screen button	0		Last Available: "2016-05"
-9023	pulsating tumbling screencapped monster	0		Last Available: "2016-05"
+9023	tumbling pulsating screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
 9025	infinite BACON machine	0		Last Available: "2016-05"
-9026	twirling fuchsia First Post shirt package	0		Last Available: "2016-05"
+9026	fuchsia twirling First Post shirt package	0		Last Available: "2016-05"
 9027	dangerous First Post shirt - Cir Senam of the ox of the empath	0		Muscle: +20, Weapon Damage: +10, Familiar Weight: +5, Last Available: "2016-05"
-9028	blurry wobbly high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
+9028	wobbly blurry high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
 9030	stale star salad	3	decent	
 9031	Thwaitgold moth statuette	0		
-9032	low-calorie bland bowl of Tastee-Wheet&trade;	1	decent	
+9032	bland low-calorie bowl of Tastee-Wheet&trade;	1	decent	
 9033	tumbling Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	normal immense blue browser cookie	6	good	Last Available: "2016-06"
+9035	immense normal blue browser cookie	6	good	Last Available: "2016-06"
 9036	acceptable hacked gibson	3	good	Last Available: "2016-06"
 9037	medical-grade Source shades	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	Mr. Screege's spectacles of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2016-08"
 9092	crafty Spookyraven signet of the storm of extreme caution	0		Maximum MP Percent: +40, Maximum MP: +10, Monster Level: -25, Single Equip, Last Available: "2016-08"
 9093	Tesla tie-dyed fannypack of the cougar	0		Moxie: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2016-08"
-9094	mirror yellow upside-down Da Vinci's burnt snowpants of the businessman	0		Experience (Mysticality): +5, Meat Drop: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9094	mirror yellow upside-down Da Vinci's burnt snowpants of the businessman	0		Experience (Mysticality): +5, Meat Drop: +50, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
 9095	bouncing wicked standards and practices guide	0		Spell Damage: +5, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	yellow shellacked wizardly Carpathian longsword of the boozehound	0		Mysticality: +25, Damage Reduction: 7, Booze Drop: +100, Last Available: "2016-08"
 9097	pulsating tumbling coward's Liam's mail of extreme caution of incineration	0		Monster Level: -45, Hot Spell Damage: +50, Last Available: "2016-08"
@@ -8984,7 +8984,7 @@
 9112	tarnished tarnished squat EMD holo-record	0		Effect: "Oily Flavor", Effect Duration: 47
 9113	vacuum-sealed frozen wobbly Superdrifter holo-record	0		Effect: "Hair on Your Chest", Effect Duration: 36
 9114	super-boiled magnetized alkaline The Pigs holo-record	0		Effect: "Egg-stortionary Tactics", Effect Duration: 37
-9115	non-anodized upside-down blinking Drunk Uncles holo-record	0		Effect: "Human-Penguin Hybrid", Effect Duration: 32
+9115	non-anodized blinking upside-down Drunk Uncles holo-record	0		Effect: "Human-Penguin Hybrid", Effect Duration: 32
 9116	time residue	0		Last Available: "2016-09"
 9117	Van der Graaf repaid diaper	0		MP Regen Min: 5, MP Regen Max: 7
 9118	Riker's Search History	0		Last Available: "2016-09"
@@ -9007,7 +9007,7 @@
 9135	perfectly mixed mirror very whiskey	3	EPIC	
 9136	ghostly purple li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	mirror li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	narrow ghostly li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	ghostly narrow li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9141	ghostly li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9025,10 +9025,10 @@
 9153	spoiled tiny raw sweet potato	1	crappy	Last Available: "2016-11"
 9154	decent raw beans	4	good	Last Available: "2016-11"
 9155	thick spoiled raw stuffing	5	crappy	Last Available: "2016-11"
-9156	massive rotten raw cranberry sauce	8	crappy	Last Available: "2016-11"
+9156	rotten massive raw cranberry sauce	8	crappy	Last Available: "2016-11"
 9157	stale green raw turkey	4	decent	Last Available: "2016-11"
 9158	special delicious diet raw mincemeat	1	awesome	Effect: "Man's Worst Enemy", Effect Duration: 10, Last Available: "2016-11"
-9159	big flavorless raw potato	5	decent	Last Available: "2016-11"
+9159	flavorless big raw potato	5	decent	Last Available: "2016-11"
 9160	delicious huge raw gravy	3	awesome	Last Available: "2016-11"
 9161	adequate huge tumbling raw bread	9	good	Last Available: "2016-11"
 9162	jittery Jeselnik's quilted mini-marshmallow dispenser	0		Damage Absorption: +40, Sleaze Damage: +25, Last Available: "2016-11"
@@ -9039,16 +9039,16 @@
 9167	vibrating Herculean glass pie plate	0		Experience (Muscle): +1, Maximum MP Percent: +10, Damage Reduction: 7, Last Available: "2016-11"
 9168	bouncing pulsating fireproof potato masher of extreme caution	0		Monster Level: -25, Hot Resistance: +3, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
-9170	ghostly cyan bread mold	0		Last Available: "2016-11"
+9170	cyan ghostly bread mold	0		Last Available: "2016-11"
 9171	decent sweet potatoes	4	good	Last Available: "2016-11"
 9172	decent miniature pulsating bean casserole	2	good	Last Available: "2016-11"
-9173	small toothsome baked stuffing	2	awesome	Last Available: "2016-11"
-9174	super-sized spoiled cranberry cylinder	5	crappy	Last Available: "2016-11"
-9175	immense stale thanksgiving turkey	7	decent	Last Available: "2016-11"
+9173	toothsome small baked stuffing	2	awesome	Last Available: "2016-11"
+9174	spoiled super-sized cranberry cylinder	5	crappy	Last Available: "2016-11"
+9175	stale immense thanksgiving turkey	7	decent	Last Available: "2016-11"
 9176	moldy mince pie	3	crappy	Last Available: "2016-11"
-9177	massive adequate mashed potatoes	10	good	Last Available: "2016-11"
+9177	adequate massive mashed potatoes	10	good	Last Available: "2016-11"
 9178	adequate warm gravy	4	good	Last Available: "2016-11"
-9179	half-sized yummy bread roll	2	awesome	Last Available: "2016-11"
+9179	yummy half-sized bread roll	2	awesome	Last Available: "2016-11"
 9180	bland leftovers	3	decent	Last Available: "2016-11"
 9181	miniature moldy narrow leftovers sandwich	2	crappy	Last Available: "2016-11"
 9182	ghostly Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9090,7 +9090,7 @@
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	bland bouncing animal part cracker	4	decent	Last Available: "2016-12"
 9220	drinkable gingerbread wine	3	good	Last Available: "2016-12"
-9221	half-sized toothsome gingerbread mug	2	awesome	Last Available: "2016-12"
+9221	toothsome half-sized gingerbread mug	2	awesome	Last Available: "2016-12"
 9222	ghostly miser's gingerbread mask	0		Meat Drop: +10, Last Available: "2016-12"
 9223	curative hale gingerservo of horror	0		Maximum HP: +20, Spooky Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2016-12"
 9224	electrified triple-denatured improved tainted icing	0		Effect: "Permafrosty", Effect Duration: 62, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	lard-coated hardened gingerbread gavel	0		Damage Reduction: 3, Sleaze Spell Damage: +25, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	pulsating gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	practically non-alcoholic artisanal ginger beer	1	super ultra mega turbo EPIC	Last Available: "2016-12"
+9239	artisanal practically non-alcoholic ginger beer	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	denatured squat industrial frosting	0		Effect: "Strong Spirit", Effect Duration: 25, Last Available: "2016-12"
 9242	liquefied fake cocktail	0		Effect: "Egg-stortionary Tactics", Effect Duration: 14, Last Available: "2016-12"
@@ -9122,12 +9122,12 @@
 9250	galvanized moist Inner Strength	0		Effect: "Seeing Colors", Effect Duration: 41, Last Available: "2016-12"
 9251	extra-vacuum-sealed Inner Truth	0		Effect: "Optimist Primal", Effect Duration: 68, Last Available: "2016-12"
 9252	low-calorie special adequate spiritual candy cane	1	good	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2016-12"
-9253	perfectly mixed practically non-alcoholic enchanted spiritual eggnog	1	super EPIC	Effect: "Slimily Strong", Effect Duration: 40, Last Available: "2016-12"
+9253	perfectly mixed enchanted practically non-alcoholic spiritual eggnog	1	super EPIC	Effect: "Slimily Strong", Effect Duration: 40, Last Available: "2016-12"
 9254	bland spiritual fruitcake	3	decent	Last Available: "2016-12"
-9255	normal snack-sized purple upside-down pulsating spiritual gingerbread	2	good	Last Available: "2016-12"
+9255	snack-sized normal upside-down purple pulsating spiritual gingerbread	2	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
-9258	skewed mirror My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
+9258	mirror skewed My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	tumbling Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
@@ -9135,8 +9135,8 @@
 9263	upside-down gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
-9266	nitrogenated squat gray shaking rock candy	0		Effect: "Yuletide Industry", Effect Duration: 47, Last Available: "2016-12"
-9267	adequate thick shaking green-iced sweet roll	5	good	Last Available: "2016-12"
+9266	nitrogenated gray shaking squat rock candy	0		Effect: "Yuletide Industry", Effect Duration: 47, Last Available: "2016-12"
+9267	thick adequate shaking green-iced sweet roll	5	good	Last Available: "2016-12"
 9268	tumbling sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9144,7 +9144,7 @@
 9272	negative lump	0		
 9273	flame-wreathed Third Eye of the glutton	0		Hot Spell Damage: +10, Food Drop: +100, Last Available: "2016-12"
 9274	bouncing asbestos-lined Krampus Horn of the cheetah	0		Hot Resistance: +5, Initiative: +60, Single Equip, Last Available: "2016-12"
-9275	spoiled spinning narrow hambrosier	4	crappy	Last Available: "2016-12"
+9275	spoiled narrow spinning hambrosier	4	crappy	Last Available: "2016-12"
 9276	extra-dry perfectly mixed chakra-mental wine	5	EPIC	Last Available: "2016-12"
 9277	quantum deionized tumbling chakra malt	0		Effect: "Thickest, Sickest", Effect Duration: 55, Last Available: "2016-12"
 9278	bland Black Angus blackburger	3	decent	Last Available: "2016-12"
@@ -9154,7 +9154,7 @@
 9282	Lo Pan's crystal belt buckle of doom	0		Spell Critical Percent: +30, Spooky Spell Damage: +50, Last Available: "2016-12"
 9283	medical-grade extremely unsafe saffron antaravasaka	0		Weapon Damage Percent: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12"
 9284	blinking dance instructor's saffron uttarasanga of the cheetah	0		Experience Percent (Moxie): +10, Initiative: +60, Last Available: "2016-12"
-9285	blinking jittery Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
+9285	jittery blinking Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
 9286	spinning eternal knot tattoo	0		Last Available: "2016-12"
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	blinking gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
@@ -9162,13 +9162,13 @@
 9290	immense bland Eldritch snap	10	decent	Last Available: "2017-01"
 9291	denatured tumbling hot jelly	1		Last Available: "2017-01"
 9292	altered jelly	1		Effect: "You Drank Fish Wine", Effect Duration: 5, Last Available: "2017-01"
-9293	compressed olive pulsating jelly	1		Effect: "Bread-Lined", Effect Duration: 35, Last Available: "2017-01"
-9294	denatured red blurry sleaze jelly	1		Effect: "The Power of LOV", Effect Duration: 35, Last Available: "2017-01"
+9293	compressed pulsating olive jelly	1		Effect: "Bread-Lined", Effect Duration: 35, Last Available: "2017-01"
+9294	denatured blurry red sleaze jelly	1		Effect: "The Power of LOV", Effect Duration: 35, Last Available: "2017-01"
 9295	boiled stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal toast with hot jelly	3	good	Last Available: "2017-01"
 9298	bland toast with jelly	3	decent	Last Available: "2017-01"
-9299	tasty bite-sized fancy blurry toast with jelly	1	awesome	Effect: "Super Structure", Effect Duration: 35, Last Available: "2017-01"
+9299	fancy bite-sized tasty blurry toast with jelly	1	awesome	Effect: "Super Structure", Effect Duration: 35, Last Available: "2017-01"
 9300	bland toast with sleaze jelly	3	decent	Last Available: "2017-01"
 9301	rotten toast with stench jelly	4	crappy	Last Available: "2017-01"
 9302	squat space jellybicycle	0		Familiar Weight: +5
@@ -9178,9 +9178,9 @@
 9306	blinking occult candle of the glutton	0		Spell Damage Percent: +25, Food Drop: +100, Lasts Until Rollover, Last Available: "2017-01"
 9307	miniature adequate wax pancake	2	good	Last Available: "2017-01"
 9308	manspreader's studded wax face	0		Damage Absorption: +80, Monster Level: +10, Last Available: "2017-01"
-9309	fancy practically non-alcoholic aged mirror wax booze	1	awesome	Effect: "Hot Buttoned", Effect Duration: 30, Last Available: "2017-01"
+9309	practically non-alcoholic aged fancy mirror wax booze	1	awesome	Effect: "Hot Buttoned", Effect Duration: 30, Last Available: "2017-01"
 9310	mirror glob of melted wax	0		Last Available: "2017-01"
-9311	denatured blurry pulsating sea jelly	1		Last Available: "2017-01"
+9311	denatured pulsating blurry sea jelly	1		Last Available: "2017-01"
 9312	spoiled upside-down sea truffle	3	crappy	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
@@ -9239,36 +9239,36 @@
 9367	delicious shaking Phlegethon	4	awesome	Last Available: "2017-03"
 9368	perfectly mixed Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	drinkable mentholated wine	3	good	Last Available: "2017-03"
-9370	drinkable irresponsibly strong ghostly lime green low tide martini	7	good	Last Available: "2017-03"
+9370	drinkable irresponsibly strong lime green ghostly low tide martini	7	good	Last Available: "2017-03"
 9371	acceptable shroomtini	3	good	Last Available: "2017-03"
-9372	acceptable spirit-forward fuchsia morning dew	5	good	Last Available: "2017-03"
-9373	weak drinkable shaking whiskey squeeze	2	good	Last Available: "2017-03"
+9372	spirit-forward acceptable fuchsia morning dew	5	good	Last Available: "2017-03"
+9373	drinkable weak shaking whiskey squeeze	2	good	Last Available: "2017-03"
 9374	artisanal great fashioned	4	EPIC	Last Available: "2017-03"
 9375	practically non-alcoholic mediocre skewed Gnomish sagngria	1	decent	Last Available: "2017-03"
 9376	watered-down delicious vodka stinger	2	awesome	Last Available: "2017-03"
 9377	perfectly mixed extremely slippery nipple	3	EPIC	Last Available: "2017-03"
-9378	watered-down bad bouncing piscatini	2	decent	Last Available: "2017-03"
+9378	bad watered-down bouncing piscatini	2	decent	Last Available: "2017-03"
 9379	special artisanal gray Churchill	4	EPIC	Effect: "Al Dente Inferno", Effect Duration: 45, Last Available: "2017-03"
 9380	bad soilzerac	4	decent	Last Available: "2017-03"
 9381	delicious practically non-alcoholic London frog	1	awesome	Last Available: "2017-03"
 9382	bad practically non-alcoholic nothingtini	1	decent	Last Available: "2017-03"
 9383	delicious spinning eighth plague	3	awesome	Last Available: "2017-03"
-9384	high-proof delicious olive single entendre	6	awesome	Last Available: "2017-03"
+9384	delicious high-proof olive single entendre	6	awesome	Last Available: "2017-03"
 9385	perfectly mixed twirling reverse Tantalus	3	EPIC	Last Available: "2017-03"
-9386	acceptable enchanted elemental caipiroska	3	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 50, Last Available: "2017-03"
+9386	enchanted acceptable elemental caipiroska	3	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 50, Last Available: "2017-03"
 9387	aged distilled Feliz Navidad	5	awesome	Last Available: "2017-03"
-9388	weak mediocre tumbling Bloody Nora	2	decent	Last Available: "2017-03"
+9388	mediocre weak tumbling Bloody Nora	2	decent	Last Available: "2017-03"
 9389	spirit-forward perfectly mixed moreltini	5	EPIC	Last Available: "2017-03"
-9390	bad weak hell in a bucket	2	decent	Last Available: "2017-03"
+9390	weak bad hell in a bucket	2	decent	Last Available: "2017-03"
 9391	practically non-alcoholic smooth Newark	1	awesome	Last Available: "2017-03"
 9392	aged jittery R'lyeh	3	awesome	Last Available: "2017-03"
 9393	artisanal Gnollish sangria	3	EPIC	Last Available: "2017-03"
-9394	weak drinkable blurry vodka barracuda	2	good	Last Available: "2017-03"
+9394	drinkable weak blurry vodka barracuda	2	good	Last Available: "2017-03"
 9395	lousy weak Mysterious Island iced tea	2	decent	Last Available: "2017-03"
 9396	smooth drive-by shooting	4	awesome	Last Available: "2017-03"
 9397	smooth mirror gunner's daughter	4	awesome	Last Available: "2017-03"
 9398	hand-crafted dirt julep	3	EPIC	Last Available: "2017-03"
-9399	bad spirit-forward Simepore slime	5	decent	Last Available: "2017-03"
+9399	spirit-forward bad Simepore slime	5	decent	Last Available: "2017-03"
 9400	bad practically non-alcoholic Phil Collins	1	decent	Last Available: "2017-03"
 9401	twirling unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	blurry toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9289,10 +9289,10 @@
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	twirling complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	altered bouncing narrow alien plant goo	1		Last Available: "2017-04"
+9420	altered narrow bouncing alien plant goo	1		Last Available: "2017-04"
 9421	wobbly alien plant pod	0		Last Available: "2017-04"
 9422	jittery mirror zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	spoiled thick alien meat	5	crappy	Last Available: "2017-04"
+9423	thick spoiled alien meat	5	crappy	Last Available: "2017-04"
 9424	lime green alien toenails	0		Last Available: "2017-04"
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9323,7 +9323,7 @@
 9451	alkaline triple-corrupted huge murderbot shield unit	0		Effect: "Chalked Weapon", Effect Duration: 56, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	blinking lard-coated Annie Oakley's Newton's murderbot mask	0		Experience (Mysticality): +3, Critical Hit Percent: +20, Sleaze Spell Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
-9454	frozen liquefied spinning upside-down murderbot spring injector	0		Effect: "Celestial Sheen", Effect Duration: 64, Last Available: "2017-04"
+9454	frozen liquefied upside-down spinning murderbot spring injector	0		Effect: "Celestial Sheen", Effect Duration: 64, Last Available: "2017-04"
 9455	frightening studded murderbot whip	0		Damage Absorption: +80, Spooky Damage: +5, Last Available: "2017-04"
 9456	frosty murderbot plasma rifle	0		Cold Spell Damage: +10, Item Drop: +5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
@@ -9343,7 +9343,7 @@
 9471	purple twirling weightlifter's Spacegate diplomat's insignia of incineration of terror	0		Muscle: +15, Hot Spell Damage: +50, Spooky Spell Damage: +10, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	tumbling Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	half-sized stale twirling alien sandwich	2	decent	Last Available: "2017-04"
+9474	stale half-sized twirling alien sandwich	2	decent	Last Available: "2017-04"
 9475	pulsating shaking pulsating glitched malware	0		Last Available: "2025-12"
 9476	colloidal jittery Spant eggs	0		Effect: "Hare-o-dynamic", Effect Duration: 48
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9364,7 +9364,7 @@
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	wool wicked Kremlin's Greatest Briefcase of the glutton	0		Spell Damage: +5, Cold Resistance: +1, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	acceptable mirror teal basic martini	3	good	Last Available: "2017-06"
-9495	watered-down aged shaking improved martini	2	awesome	Last Available: "2017-06"
+9495	aged watered-down shaking improved martini	2	awesome	Last Available: "2017-06"
 9496	hand-crafted splendid martini	4	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	spoiled meteoreo	4	crappy	Last Available: "2017-08"
-9515	irresponsibly strong bad meadeorite	9	decent	Last Available: "2017-08"
+9515	bad irresponsibly strong meadeorite	9	decent	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	vibrating forbidden arcane researcher's meteortarboard	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Maximum MP Percent: +10, Last Available: "2017-08"
 9518	baleful meteorite guard of the wise owl of the blizzard	0		Mysticality: +20, Spell Damage: +25, Cold Spell Damage: +25, Damage Reduction: 9, Last Available: "2017-08"
-9519	bouncing baleful meteorb of extreme caution	0		Spell Damage: +25, Monster Level: -25, Last Available: "2017-08", Lantern Element: "Hot"
+9519	bouncing baleful meteorb of extreme caution	0		Spell Damage: +25, Monster Level: -25, Lantern Element: "Hot", Last Available: "2017-08"
 9520	up-at-dawn banded asteroid belt	0		Damage Absorption: +100, Adventures: +5, Single Equip, Last Available: "2017-08"
 9521	foul-smelling Rosewater's savvy meteorthopedic shoes	0		Mysticality Percent: 50, Stench Damage: +10, Single Equip, Last Available: "2017-08"
 9522	twirling mansplainer's veiny Newton's shooting morning star	0		Experience (Mysticality): +3, Maximum HP: +10, Monster Level: +15, Single Equip, Last Available: "2017-08"
@@ -9397,7 +9397,7 @@
 9525	Thwaitgold time fly statuette	0		
 9526	purple perfectly fair coin	0		Last Available: "2017-11"
 9527	Horsery contract	0		Free Pull, Last Available: "2018-08"
-9528	wobbly spinning corked genie bottle	0		Free Pull, Last Available: "2017-09"
+9528	spinning wobbly corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	teal genie bottle	0		Last Available: "2017-09"
 9530	rosewater-soaked boxer's blessed rustproof +2 gray dragon scale mail of the detective	0		Muscle Percent: +10, Stench Resistance: +3, Item Drop: +20, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
@@ -9418,8 +9418,8 @@
 9546	chilly coward's mafia pinky ring	0		Monster Level: -20, Cold Damage: +5, Single Equip
 9547	drinkable weak cyan flask of port	2	good	
 9548	knitted contract enforcement stick of extreme caution	0		Monster Level: -25, Cold Resistance: +3
-9549	jumbo decent fancy Hide-rox&trade; cookie	5	good	Effect: "Cold, Dead Hands", Effect Duration: 25, Last Available: "2017-10"
-9550	weak tolerable narrow jug of booze	2	good	Last Available: "2017-10"
+9549	decent fancy jumbo Hide-rox&trade; cookie	5	good	Effect: "Cold, Dead Hands", Effect Duration: 25, Last Available: "2017-10"
+9550	tolerable weak narrow jug of booze	2	good	Last Available: "2017-10"
 9551	frozen colloidal improved twirling pair of candy glasses	0		Effect: "Dreams and Lights", Effect Duration: 51, Last Available: "2017-10"
 9552	deionized temporary X tattoos	0		Effect: "Burning Ears", Effect Duration: 11, Last Available: "2017-10"
 9553	twisted spinning glyph of athleticism	1		Effect: "Robocamo", Effect Duration: 10, Last Available: "2017-10"
@@ -9450,11 +9450,11 @@
 9578	transparent nog	1	crappy	Last Available: "2017-12"
 9579	flavorless unfinished fruitcake	4	decent	Last Available: "2017-12"
 9580	diffused polarized wobbly teal pulsating and cracker	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 66, Last Available: "2017-12"
-9581	watered-down lousy pulsating neg grog	2	decent	Last Available: "2017-12"
-9582	tasty upside-down shaking half double fruitcake	3	awesome	Last Available: "2017-12"
+9581	lousy watered-down pulsating neg grog	2	decent	Last Available: "2017-12"
+9582	tasty shaking upside-down half double fruitcake	3	awesome	Last Available: "2017-12"
 9583	flavorless mirror hushed puppy	3	decent	Last Available: "2017-12"
 9584	tiny adequate cyan muffled muffuletta	1	good	Last Available: "2017-12"
-9585	decent enchanted massive shushed potatoes	8	good	Effect: "Heart of Lavender", Effect Duration: 40, Last Available: "2017-12"
+9585	massive enchanted decent shushed potatoes	8	good	Effect: "Heart of Lavender", Effect Duration: 40, Last Available: "2017-12"
 9586	red plastic mime functionary of the businessman	0		Meat Drop: +50, Last Available: "2017-12"
 9587	jittery plastic mime scientist of the bloodbag	0		Maximum HP: +100, Last Available: "2017-12"
 9588	plastic mime soldier of courage	0		Spooky Resistance: +3, Last Available: "2017-12"
@@ -9466,8 +9466,8 @@
 9594	alkaline deionized super-unsweetened spinning wishbone	0		Effect: "Berry Thorny", Effect Duration: 56, Last Available: "2017-11"
 9595	hand-crafted pulsating Racisto Ruidoso	4	super ultra EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	special rotten purple bran muffin	4	crappy	Effect: "Pisces in the Skyces", Effect Duration: 50
-9598	special snack-sized delicious blueberry muffin	2	awesome	Effect: "On the Shoulders of Giants", Effect Duration: 50
+9597	rotten special purple bran muffin	4	crappy	Effect: "Pisces in the Skyces", Effect Duration: 50
+9598	delicious special snack-sized blueberry muffin	2	awesome	Effect: "On the Shoulders of Giants", Effect Duration: 50
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9477,14 +9477,14 @@
 9605	pulsating silent G	0		Last Available: "2017-12"
 9606	silent H	0		Last Available: "2017-12"
 9607	silent I	0		Last Available: "2017-12"
-9608	teal jittery silent J	0		Last Available: "2017-12"
+9608	jittery teal silent J	0		Last Available: "2017-12"
 9609	tumbling silent K	0		Last Available: "2017-12"
 9610	bouncing silent L	0		Last Available: "2017-12"
 9611	silent M	0		Last Available: "2017-12"
 9612	silent N	0		Last Available: "2017-12"
 9613	silent O	0		Last Available: "2017-12"
 9614	spinning silent P	0		Last Available: "2017-12"
-9615	blue upside-down silent Q	0		Last Available: "2017-12"
+9615	upside-down blue silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	jittery silent T	0		Last Available: "2017-12"
@@ -9517,11 +9517,11 @@
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	blinking mime eraser	0		Last Available: "2017-12"
-9648	watered-down drinkable executive mime flask	2	good	Last Available: "2017-12"
+9648	drinkable watered-down executive mime flask	2	good	Last Available: "2017-12"
 9649	rotten small nega-mushroom	2	crappy	Last Available: "2017-12"
 9650	smooth nega-mushroom wine	4	awesome	Last Available: "2017-12"
 9651	quantum non-vacuum-sealed extra-colloidal wobbly Cheer-Up soda	0		Effect: "Dreadful Smell", Effect Duration: 30, Last Available: "2017-12"
-9652	super-sized flavorless mime army rations	5	decent	Last Available: "2017-12"
+9652	flavorless super-sized mime army rations	5	decent	Last Available: "2017-12"
 9653	drinkable mime army wine	3	good	Last Available: "2017-12"
 9654	denatured mime army superserum	1		Effect: "Fiery Spirit", Effect Duration: 40, Last Available: "2017-12"
 9655	liquefied denatured activated jittery mime army camouflage kit	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 58, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	moist digital honeypot	0		Effect: "Neutered Nostrils", Effect Duration: 38, Last Available: "2025-12"
 9666	purple mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	olive mime army insignia (infantry) of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	jittery inspector's mime army insignia (intelligence)	0		Item Drop: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	spinning dangerous mime army insignia (espionage)	0		Weapon Damage: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	olive mime army insignia (infantry) of the pedagogue	0		Experience: +3, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	jittery inspector's mime army insignia (intelligence)	0		Item Drop: +15, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	spinning dangerous mime army insignia (espionage)	0		Weapon Damage: +10, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	ghostly mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9593,16 +9593,16 @@
 9725	green auspicious psychic's pslacks of the scaredy-cat	0		Monster Level: -15, Item Drop: +10, Last Available: "2018-02"
 9726	electrified psychic's amulet of the empath	0		Familiar Weight: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-02"
 9727	normal heart-shaped candy whetstone	3	good	Last Available: "2018-02"
-9728	small moldy Swedish massage fish	2	crappy	Last Available: "2018-02"
+9728	moldy small Swedish massage fish	2	crappy	Last Available: "2018-02"
 9729	artisanal lime green squat shaking Third Base	4	EPIC	Last Available: "2018-02"
-9730	fortified aged Bustle Hustler	5	awesome	Last Available: "2018-02"
+9730	aged fortified Bustle Hustler	5	awesome	Last Available: "2018-02"
 9731	liquefied oxidized jittery Fabiotion	0		Effect: "The Dinsey Way", Effect Duration: 21, Last Available: "2018-02"
 9732	concentrated Bettie page	0		Effect: "Sepia Tan", Effect Duration: 32, Last Available: "2018-02"
 9733	anodized energized tonic o' Banderas	0		Effect: "Ode to Booze", Effect Duration: 58, Last Available: "2018-02"
 9734	oxidized super-denatured pickled heather graham cracker	0		Effect: "Army of One", Effect Duration: 40, Last Available: "2018-02"
 9735	yellow Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
-9737	wobbly twirling eaves droppers	0		Last Available: "2018-02"
+9737	twirling wobbly eaves droppers	0		Last Available: "2018-02"
 9738	personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
@@ -9623,14 +9623,14 @@
 9755	Samson's Team Sloth cap	0		Experience (Muscle): +5, Combat Rate: -15
 9756	stanky Team Wrath cap	0		Stench Spell Damage: +25
 9757	wobbly greedy Mu cap	0		Meat Drop: +20
-9758	blinking wobbly Thwaitgold metabug statuette	0		
+9758	wobbly blinking Thwaitgold metabug statuette	0		
 9759	Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
 9760	yellow twirling packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	huge Bluzzard	0		Last Available: "2018-03"
 9764	huge Faux	0		Last Available: "2018-03"
-9765	blurry blue Sledgehamster	0		Last Available: "2018-03"
+9765	blue blurry Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	squat Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
@@ -9639,7 +9639,7 @@
 9771	twirling Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
-9774	huge wobbly Peaclock	0		Last Available: "2018-03"
+9774	wobbly huge Peaclock	0		Last Available: "2018-03"
 9775	cyan Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	pulsating Aiolion	0		Last Available: "2018-03"
@@ -9659,7 +9659,7 @@
 9791	Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
-9794	shaking lime green Nursine	0		Last Available: "2018-03"
+9794	lime green shaking Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
@@ -9671,7 +9671,7 @@
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	blinking Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
-9806	upside-down huge Glamare	0		Last Available: "2018-03"
+9806	huge upside-down Glamare	0		Last Available: "2018-03"
 9807	jittery Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
@@ -9679,7 +9679,7 @@
 9811	skewed Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
-9814	wobbly upside-down Egnaro berry	0		Last Available: "2018-03"
+9814	upside-down wobbly Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	narrow Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
@@ -9693,7 +9693,7 @@
 9825	yellow razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
-9828	vaporized mirror green magnificent oyster egg	1		Effect: "Dilated Pupils", Effect Duration: 10
+9828	vaporized green mirror magnificent oyster egg	1		Effect: "Dilated Pupils", Effect Duration: 10
 9829	mixed olive brilliant oyster egg	1		Effect: "Ocelot Eyes", Effect Duration: 20
 9830	boiled glistening oyster egg	1		
 9831	twisted scintillating oyster egg	1		Effect: "Coy to the Hurled", Effect Duration: 35
@@ -9716,12 +9716,12 @@
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	tumbling jittery dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	jittery tumbling dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	red druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	narrow to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	skewed lime green flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9856	lime green skewed flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	moist vacuum-sealed twirling universal antivenin	0		Lasts Until Rollover, Effect: "Mutated", Effect Duration: 33, Last Available: "2018-04"
 9858	jittery LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	upside-down LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
@@ -9743,8 +9743,8 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	ghostly map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	special rotten denastified haunch	3	crappy	Effect: "Joyful Resolve", Effect Duration: 45, Last Available: "2018-04"
-9879	hand-crafted watered-down bad rum and good cola	2	EPIC	Last Available: "2018-04"
+9878	rotten special denastified haunch	3	crappy	Effect: "Joyful Resolve", Effect Duration: 45, Last Available: "2018-04"
+9879	watered-down hand-crafted bad rum and good cola	2	EPIC	Last Available: "2018-04"
 9880	anodized tarnished Potion of Heroism	0		Effect: "Cautious Prowl", Effect Duration: 51, Last Available: "2018-04"
 9881	huge skewed wobbly family-friendly knitted steel-toed leggings of the Spider Queen	0		Damage Reduction: 9, Cold Resistance: +3, Sleaze Resistance: +1, Last Available: "2018-04"
 9882	frightening brainy Master Thief's utility belt of mayonnaise	0		Mysticality: +5, Spooky Damage: +5, Sleaze Spell Damage: +50, Single Equip, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	shaking charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	extra-dry hand-crafted two meat muck	5	EPIC	
-9899	half-sized decent chocolate Ogre Chieftain	2	good	
-9900	stale massive chocolate &quot;Phoenix&quot;	6	decent	
+9898	hand-crafted extra-dry two meat muck	5	EPIC	
+9899	decent half-sized chocolate Ogre Chieftain	2	good	
+9900	massive stale chocolate &quot;Phoenix&quot;	6	decent	
 9901	bland tumbling chocolate Spider Queen	4	decent	
-9902	hand-crafted weak enchanted hipster cocktail	2	EPIC	Effect: "Ninja, Please", Effect Duration: 15
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9902	enchanted hand-crafted weak hipster cocktail	2	EPIC	Effect: "Ninja, Please", Effect Duration: 15
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Last Available: "2018-05", Equips On: "God Lobster"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Last Available: "2018-05", Equips On: "God Lobster"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Last Available: "2018-05", Equips On: "God Lobster"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Last Available: "2018-05", Equips On: "God Lobster"
 9908	blinking Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	spinning G	0		
 9910	Garland of Greatness	0		
@@ -9782,8 +9782,8 @@
 9914	tumbling crude oil congealer	0		
 9915	decent good guava	4	good	
 9916	tolerable gin and ginger	4	good	
-9917	ghostly wobbly Thwaitgold chigger statuette	0		
-9918	boiled maroon jittery spinning gaseous gravy	1		
+9917	wobbly ghostly Thwaitgold chigger statuette	0		
+9918	boiled spinning maroon jittery gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
@@ -9792,7 +9792,7 @@
 9924	Special Seasoning	0		Last Available: "2018-06"
 9925	dried shaking Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
-9927	wobbly squat Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
+9927	squat wobbly Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	auspicious stanky brawny Brutal brogues of extreme caution	0		Muscle Percent: +20, Monster Level: -25, Stench Spell Damage: +25, Item Drop: +10, Lasts Until Rollover, Last Available: "2018-07"
 9930	skewed lion tamer's personal trainer's Fonzie's slick Draftsman's driving gloves	0		Moxie: +10, Experience (Moxie): +1, Experience Percent (Muscle): +10, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2018-07"
@@ -9837,18 +9837,18 @@
 9969	scandalous denim jacket of Gandalf	0		Spell Critical Percent: +20, Sleaze Damage: +5, Last Available: "2018-09"
 9970	upside-down squat mansplainer's razor-sharp ratty knitted cap	0		Weapon Damage Percent: +25, Monster Level: +15, Last Available: "2018-09"
 9972	skewed slick intimidating chainsaw of the bloodbag	0		Moxie: +10, Maximum HP: +100, Lasts Until Rollover, Last Available: "2018-09"
-9973	drinkable triple-distilled party beer bomb	7	good	Last Available: "2018-09"
+9973	triple-distilled drinkable party beer bomb	7	good	Last Available: "2018-09"
 9974	moldy sweet party mix	3	crappy	Last Available: "2018-09"
 9975	diluted party balloon	1		Last Available: "2018-09"
 9976	aromatic party pants of James Dean	0		Experience (Moxie): +3, Stench Resistance: +1, Last Available: "2018-09"
 9977	grievous Herculean party whip of the storm	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Maximum MP Percent: +40, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	special tolerable practically non-alcoholic TRIO cup of beer	1	good	Effect: "Tearful, Fearful", Effect Duration: 35, Last Available: "2018-09"
-9980	flavorless snack-sized party platter for one	2	decent	Last Available: "2018-09"
+9980	snack-sized flavorless party platter for one	2	decent	Last Available: "2018-09"
 9981	mixed squat shaking Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	olive deadly party crasher of the cheetah	0		Weapon Damage: +5, Initiative: +60, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	blurry Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	blurry Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	tumbling Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9876,7 +9876,7 @@
 10010	flavorless ghostly ectoplasm	4	decent	Last Available: "2018-11"
 10011	moldy	3	crappy	Last Available: "2018-11"
 10012	artisanal bottle of vodka	4	EPIC	Last Available: "2018-11"
-10013	special moldy big pizza	5	crappy	Effect: "Cold as Ice", Effect Duration: 15, Last Available: "2018-11"
+10013	moldy big special pizza	5	crappy	Effect: "Cold as Ice", Effect Duration: 15, Last Available: "2018-11"
 10014	acceptable martini	3	good	Last Available: "2018-11"
 10015	half-sized flavorless pulsating cherry pie	2	decent	Last Available: "2018-11"
 10016	hand-crafted eggnog	3	EPIC	Last Available: "2018-11"
@@ -9884,10 +9884,10 @@
 10018	flavorless Hell ramen	3	decent	Last Available: "2018-11"
 10019	aged yellow gimlet	3	awesome	Last Available: "2018-11"
 10020	mediocre high-proof twice-haunted screwdriver	8	decent	Last Available: "2018-11"
-10021	bland thick candy cane	5	decent	Last Available: "2018-12"
+10021	thick bland candy cane	5	decent	Last Available: "2018-12"
 10022	perfectly mixed mirror runny fermented egg	4	EPIC	Last Available: "2018-12"
-10023	low-calorie adequate oldcake	1	good	Last Available: "2018-12"
-10024	flavorless big traditional Crimbo cookie	5	decent	Last Available: "2023-06"
+10023	adequate low-calorie oldcake	1	good	Last Available: "2018-12"
+10024	big flavorless traditional Crimbo cookie	5	decent	Last Available: "2023-06"
 10025	friendly plastic wild beaver	0		Familiar Weight: +3, Last Available: "2018-12"
 10026	savvy plastic reindeer	0		Mysticality Percent: +20, Last Available: "2018-12"
 10027	savvy plastic Caf&eacute; Elf	0		Mysticality Percent: +20, Last Available: "2018-12"
@@ -9899,16 +9899,16 @@
 10033	reassuring wizardly pristine walrus tusk	0		Mysticality: +25, Spooky Resistance: +1, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	upside-down spinning ghostly coward's Herculean slick Staff of Frozen Lard of dire peril	0		Moxie: +10, Experience (Muscle): +1, Weapon Damage: +20, Monster Level: -20, Last Available: "2018-12"
-10036	bouncing spinning bomb	0		Last Available: "2018-12"
-10037	maroon blinking plastic bazooka	0		Last Available: "2018-12"
+10036	spinning bouncing bomb	0		Last Available: "2018-12"
+10037	blinking maroon plastic bazooka	0		Last Available: "2018-12"
 10038	cyan mooseflank	0		Last Available: "2018-12"
 10039	moldy grilled mooseflank	3	crappy	Last Available: "2018-12"
 10040	decent moosemeat pie	3	good	Last Available: "2018-12"
 10041	maroon grievous balanced antler	0		Weapon Damage Percent: +50, Last Available: "2018-12"
 10042	razor-sharp dam	0		Weapon Damage Percent: +25, Damage Reduction: 9, Last Available: "2018-12"
-10043	perfectly mixed practically non-alcoholic beavermouth	1	EPIC	Last Available: "2018-12"
+10043	practically non-alcoholic perfectly mixed beavermouth	1	EPIC	Last Available: "2018-12"
 10044	hand-crafted beaver punch (papaya)	4	EPIC	Last Available: "2018-12"
-10045	mediocre skewed ghostly beaver punch (peach)	3	decent	Last Available: "2018-12"
+10045	mediocre ghostly skewed beaver punch (peach)	3	decent	Last Available: "2018-12"
 10046	watered-down aged beaver punch (cherry)	2	awesome	Last Available: "2018-12"
 10047	yellow Fonzie's Canadian lantern of James Dean	0		Experience (Moxie): 4, Last Available: "2018-12"
 10048	beefy muskox-skin cap	0		Muscle: +10, Last Available: "2018-12"
@@ -9923,7 +9923,7 @@
 10057	ghostly Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	greedy greasy therapeutic wholesome wicked Kramco Sausage-o-Matic&trade;	0		Spell Damage: +5, Maximum HP Percent: +10, Sleaze Spell Damage: +10, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-01"
 10059	jittery sausage casing	0		Last Available: "2019-01"
-10060	huge spoiled sausage	9	crappy	Last Available: "2019-01"
+10060	spoiled huge sausage	9	crappy	Last Available: "2019-01"
 10061	Oprah's red-hot sausage fork of the overflowing toilet	0		Maximum MP Percent: +50, Stench Spell Damage: +50, Last Available: "2019-01"
 10062	blurry bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
@@ -9932,7 +9932,7 @@
 10066	acceptable practically non-alcoholic beer	1	good	Last Available: "2018-12"
 10067	tasty jumbo fuchsia yule gruel	5	awesome	Last Available: "2018-12"
 10068	perfectly mixed hot watered rum	4	EPIC	Last Available: "2018-12"
-10069	watered-down tolerable special huge bottle of Crimbognac	2	good	Effect: "Poker Faced", Effect Duration: 5, Last Available: "2018-12"
+10069	tolerable watered-down special huge bottle of Crimbognac	2	good	Effect: "Poker Faced", Effect Duration: 5, Last Available: "2018-12"
 10070	snack-sized normal upside-down Crimboysters Rockefeller	2	good	Last Available: "2018-12"
 10071	modified fuchsia Crimbeau de toilette	1		Last Available: "2018-12"
 10072	skewed Crimbo candle	0		Last Available: "2018-12"
@@ -9952,7 +9952,7 @@
 10086	Samson's stylish chalk chapeau	0		Moxie: +25, Experience (Muscle): +5, Last Available: "2019-12"
 10087	red chaotic chalk choker of the pedagogue	0		Experience: +3, Spell Critical Percent: +10, Single Equip, Last Available: "2019-12"
 10088	twisted narrow chalk chunks	1		Effect: "Artificially Sweet", Effect Duration: 5, Last Available: "2019-12"
-10089	anodized shaking huge candy chalk	0		Effect: "The Real Deal", Effect Duration: 68
+10089	anodized huge shaking candy chalk	0		Effect: "The Real Deal", Effect Duration: 68
 10090	curative cool marble maebari	0		Moxie: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10091	flame-retardant marble mantle of Gandalf	0		Spell Critical Percent: +20, Hot Resistance: +1, Last Available: "2019-12"
 10092	ghostly marble magnet of the brute of the detective	0		Muscle Percent: +30, Item Drop: +20, Single Equip, Last Available: "2019-12"
@@ -9976,7 +9976,7 @@
 10110	maroon sinister terra cotta tie tack of horror	0		Spell Damage: +10, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10111	narrow arcane researcher's terra cotta tambourine of doom	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	pickled yellow terra cotta tidbits	1		Effect: "The Magic of LOV", Effect Duration: 50, Last Available: "2020-12"
-10113	tarnished wet narrow squat terra panna cotta	0		Effect: "Robocamo", Effect Duration: 50
+10113	tarnished wet squat narrow terra panna cotta	0		Effect: "Robocamo", Effect Duration: 50
 10114	lightning-fast Rosewater's velour voulge	0		Mysticality Percent: +30, Initiative: +40, Last Available: "2021-12"
 10115	quilted velour vambraces of the early riser	0		Damage Absorption: +40, Adventures: +7, Single Equip, Last Available: "2021-12"
 10116	occult velour veil of the detective	0		Spell Damage Percent: +25, Item Drop: +20, Single Equip, Last Available: "2021-12"
@@ -10016,14 +10016,14 @@
 10150	altered prototype stimulant	1		Last Available: "2019-12"
 10151	electrified tailored vest	0		MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-12"
 10152	twirling sew-on bandage	0		Last Available: "2019-12"
-10153	blinking squat really nice net	0		Last Available: "2019-12"
+10153	squat blinking really nice net	0		Last Available: "2019-12"
 10154	lime green elf army poncho of chilblains	0		Cold Damage: +25, Lasts Until Rollover, Last Available: "2019-12"
-10155	decent fuchsia blurry elf army field rations	4	good	Last Available: "2019-12"
+10155	decent blurry fuchsia elf army field rations	4	good	Last Available: "2019-12"
 10156	jittery pulsating gingernade	0		Last Available: "2019-12"
 10157	ghostly sizzling discarded bowtie of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
 10158	aged martiny	3	awesome	Last Available: "2019-12"
 10159	yellow tryptophan dart	0		Last Available: "2019-12"
-10160	chilled huge tumbling licorice snake	0		Effect: "Eye of the Seal", Effect Duration: 53
+10160	chilled tumbling huge licorice snake	0		Effect: "Eye of the Seal", Effect Duration: 53
 10161	diffused virgin jello shot	0		Effect: "Hombre Muerto Caminando", Effect Duration: 19
 10162	warmed olive mutated candy lump	0		Effect: "Stenchtastic", Effect Duration: 32
 10163	concentrated government-issued candy	0		Effect: "Inebriate Pride", Effect Duration: 19
@@ -10031,15 +10031,15 @@
 10165	cyan mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	energetic smartaleck's Lil' Doctor&trade; bag	0		Moxie Percent: +30, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
-10169	fancy rotten wobbly bloodstick	4	crappy	Effect: "Bustle Hustlin'", Effect Duration: 10
+10169	rotten fancy wobbly bloodstick	4	crappy	Effect: "Bustle Hustlin'", Effect Duration: 10
 10170	watered-down mediocre bottle of Sanguiovese	2	decent	
-10171	snack-sized flavorless actual blood sausage	2	decent	
+10171	flavorless snack-sized actual blood sausage	2	decent	
 10172	hand-crafted mulled blood	4	EPIC	
 10173	decent blood snowcone	4	good	
 10174	hand-crafted shaking Red Russian	3	EPIC	
 10175	immense bland blood roll-up	8	decent	
 10176	practically non-alcoholic tolerable bottle of blood	1	good	
-10177	moldy snack-sized blood-soaked sponge cake	2	crappy	
+10177	snack-sized moldy blood-soaked sponge cake	2	crappy	
 10178	lousy vampagne	3	decent	
 10179	yummy plain snowcone	3	awesome	
 10180	Booke of Vampyric Knowledge	0		
@@ -10063,19 +10063,19 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	stale crabsicle	3	decent	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	extra-dry tolerable bottle of dark rhum	5	good	Last Available: "2019-04"
+10201	tolerable extra-dry bottle of dark rhum	5	good	Last Available: "2019-04"
 10202	drinkable bottle of extra-dark rhum	3	good	Last Available: "2019-04"
-10203	hand-crafted weak bottle of super-extra-dark rhum	2	EPIC	Last Available: "2019-04"
+10203	weak hand-crafted bottle of super-extra-dark rhum	2	EPIC	Last Available: "2019-04"
 10204	colloidal skewed pirate shaving cream	0		Effect: "World's Shortest Giant", Effect Duration: 51, Last Available: "2019-04"
 10205	fireproof Jeselnik's conquistador's breastplate	0		Sleaze Damage: +25, Hot Resistance: +3, Last Available: "2019-04"
 10206	Oprah's energetic pirate pantaloons	0		Maximum MP Percent: 70, Last Available: "2019-04"
 10207	purple [glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
-10209	tumbling narrow tumbling windicle	0		Last Available: "2019-04"
+10209	narrow tumbling tumbling windicle	0		Last Available: "2019-04"
 10210	jittery bouncing personal trainer's Rosewater's pirate radio ring	0		Mysticality Percent: +30, Experience Percent (Muscle): +10, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	spoiled immense pineapple slab	10	crappy	Last Available: "2019-04"
-10213	gigantic yummy spinning hibiscus petal	8	awesome	Last Available: "2019-04"
+10213	yummy gigantic spinning hibiscus petal	8	awesome	Last Available: "2019-04"
 10214	extra-irradiated huge mint leaf	0		Effect: "Cautious Prowl", Effect Duration: 35, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	vaporized ice molecule	1		Effect: "Twen Tea", Effect Duration: 15, Last Available: "2019-04"
@@ -10090,7 +10090,7 @@
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	fuchsia mirror stylish plush sea serpent	0		Moxie: +25, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	rotten big pirate fork	5		Last Available: "2019-04"
-10228	upside-down cyan Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
+10228	cyan upside-down Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	olive ring	0		Single Equip, Last Available: "2019-04"
 10230	nasty supercool piratical blunderbuss	0		Moxie Percent: +20, Stench Damage: +5, Last Available: "2019-04"
 10231	mirror avaricious PirateRealm party hat of the dark arts of the boozehound	0		Spell Damage Percent: +100, Meat Drop: +30, Booze Drop: +100, Last Available: "2019-04"
@@ -10121,7 +10121,7 @@
 10256	spinning maroon rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	spinning Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	knitted brainy Beach Comb of James Dean	0		Mysticality: +5, Experience (Moxie): +3, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
-10259	jittery fuchsia grain of sand	0		Last Available: "2019-07"
+10259	fuchsia jittery grain of sand	0		Last Available: "2019-07"
 10260	narrow small pile of sand	0		Last Available: "2019-07"
 10261	pulsating pile of sand	0		Last Available: "2019-07"
 10262	spinning pile of sand	0		Last Available: "2019-07"
@@ -10129,13 +10129,13 @@
 10264	hourglass	0		Last Available: "2019-07"
 10265	etched hourglass	0		Last Available: "2019-07"
 10266	warmed narrow twirling magenta seashell	0		Effect: "Chilblains of the Corn", Effect Duration: 47, Last Available: "2019-07"
-10267	dry alkaline maroon tumbling tumbling cyan seashell	0		Effect: "Thick-Skinned", Effect Duration: 52, Last Available: "2019-07"
+10267	dry alkaline tumbling tumbling maroon cyan seashell	0		Effect: "Thick-Skinned", Effect Duration: 52, Last Available: "2019-07"
 10268	pickled corrupted squat gray seashell	0		Effect: "The Rich Get Richer", Effect Duration: 67, Last Available: "2019-07"
 10269	wet seashell	0		Effect: "Improprie Tea", Effect Duration: 55, Last Available: "2019-07"
 10270	super-flattened seashell	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 45, Last Available: "2019-07"
 10271	gray bunch of sea grapes	0		Last Available: "2019-07"
-10272	watered-down lousy bottle of sea wine	2	decent	Last Available: "2019-07"
-10273	dehydrated olive bouncing kelp	1		Last Available: "2019-07"
+10272	lousy watered-down bottle of sea wine	2	decent	Last Available: "2019-07"
+10273	dehydrated bouncing olive kelp	1		Last Available: "2019-07"
 10274	fireproof nippy Jim Carey's sinister Da Vinci's Samson's driftwood hat of doom of the sweet-tooth of the glutton	0		Experience (Muscle): +5, Experience (Mysticality): +5, Spell Damage: +10, Monster Level: +25, Cold Damage: +10, Spooky Spell Damage: +50, Hot Resistance: +3, Candy Drop: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2019-07"
 10275	spinning gray zippy fireproof Jim Carey's hale veiny educational sage beefcake's driftwood pants of the sweet-tooth	0		Muscle: +25, Mysticality Percent: +10, Experience: +1, Maximum HP: 30, Monster Level: +25, Hot Resistance: +3, Candy Drop: +100, Initiative: +20, Lasts Until Rollover, Last Available: "2019-07"
 10276	zippy fireproof chaotic Van der Graaf educational savvy driftwood bracelet of the empath of chilblains of bravery	0		Mysticality Percent: +20, Experience: +1, Spell Critical Percent: +10, Familiar Weight: +5, Cold Damage: +25, Hot Resistance: +3, Spooky Resistance: +5, Initiative: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10165,20 +10165,20 @@
 10300	lion tamer's resourceful clever whittled owl figurine	0		Maximum MP: 70, Experience (familiar): +2, Single Equip, Last Available: "2019-08"
 10301	sizzling Tesla rosy-cheeked whittled fox figurine	0		Maximum HP Percent: +30, Hot Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-08"
 10302	ghostly stanky crafty Rosewater's whittled walking stick of the storm	0		Mysticality Percent: +30, Maximum MP Percent: +40, Maximum MP: +10, Stench Spell Damage: +25, Last Available: "2019-08"
-10303	rotten tiny campfire hot dog	1	crappy	Last Available: "2019-08"
-10304	small bland enchanted campfire baked potato	2	decent	Effect: "Chain Chain Chains", Effect Duration: 10, Last Available: "2019-08"
+10303	tiny rotten campfire hot dog	1	crappy	Last Available: "2019-08"
+10304	enchanted small bland campfire baked potato	2	decent	Effect: "Chain Chain Chains", Effect Duration: 10, Last Available: "2019-08"
 10305	spoiled campfire s'more	4	crappy	Last Available: "2019-08"
 10306	moldy spinning campfire beans	3	crappy	Last Available: "2019-08"
 10307	normal campfire stew	3	good	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
-10309	pressed pulsating shaking leftover chocolate bar	0		Effect: "Corona de la Salsa", Effect Duration: 22
+10309	pressed shaking pulsating leftover chocolate bar	0		Effect: "Corona de la Salsa", Effect Duration: 22
 10310	rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
 10313	campfire smoke	0		
 10314	blue Murgatroyd diode	0		
 10315	signal receiver	0		
-10316	spinning blinking space shield	0		Damage Reduction: 9
+10316	blinking spinning space shield	0		Damage Reduction: 9
 10317	signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
@@ -10204,7 +10204,7 @@
 10345	lime green red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	stale miniature mana-coated yams	2	decent	Last Available: "2019-11"
 10347	flavorless jumbo mirror mana-basted tofurkey leg	5	decent	Last Available: "2019-11"
-10348	decent big mana-fortified cranberry sauce	5	good	Last Available: "2019-11"
+10348	big decent mana-fortified cranberry sauce	5	good	Last Available: "2019-11"
 10349	moldy mana-stuffed herbal stuffing	3	crappy	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	quadruple-frozen alkaline jittery teal patch of extra-warm fur	0		Effect: "Compensatory Cruelness", Effect Duration: 18, Last Available: "2019-12"
@@ -10217,17 +10217,17 @@
 10358	quadruple-colloidal squat infernal snowball	0		Effect: "Old School Pompadour", Effect Duration: 26, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	denatured blurry shaking fish sauce	1		Effect: "Nigh-Invincible", Effect Duration: 35, Last Available: "2019-12"
-10361	flavorless big blinking guffin	5	decent	Last Available: "2019-12"
+10361	big flavorless blinking guffin	5	decent	Last Available: "2019-12"
 10362	distilled green Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	pickled huge non-Euclidean angle	1		Last Available: "2019-12"
-10365	diffused unsweetened red spinning peppermint syrup	0		Effect: "Full-Body Tan", Effect Duration: 45, Last Available: "2019-12"
+10365	diffused unsweetened spinning red peppermint syrup	0		Effect: "Full-Body Tan", Effect Duration: 45, Last Available: "2019-12"
 10366	double-aerosolized upside-down Mer-kin eyedrops	0		Effect: "Remaining Alive", Effect Duration: 13, Last Available: "2019-12"
 10367	non-anodized extra-strength goo	0		Effect: "Lemony Goodness", Effect Duration: 52, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	dehydrated livid energy	1		Effect: "Gummiskin", Effect Duration: 50, Last Available: "2019-12"
 10370	blinking micronova	0		Last Available: "2019-12"
-10371	vaporized spinning narrow beggin' cologne	1		Effect: "Tremella Tremens", Effect Duration: 20, Last Available: "2019-12"
+10371	vaporized narrow spinning beggin' cologne	1		Effect: "Tremella Tremens", Effect Duration: 20, Last Available: "2019-12"
 10372	Tesla oxygenated eggnog helmet of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 7, MP Regen Max: 10, Adventure Underwater, Last Available: "2019-12"
 10373	hand-knitted diving booties	0		Last Available: "2019-12"
 10374	squat peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	adequate skewed salt plum	3	good	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	half-sized moldy and bean	2	crappy	Last Available: "2019-12"
+10417	moldy half-sized and bean	2	crappy	Last Available: "2019-12"
 10418	jittery chaotic baleful kelp-holly gun of the empath	0		Spell Damage: +25, Spell Critical Percent: +10, Familiar Weight: +5, Last Available: "2019-12"
 10419	jittery Da Vinci's stylish Yuleviathan necklace	0		Moxie: +25, Experience (Mysticality): +5, Single Equip, Last Available: "2019-12"
 10420	mirror family-friendly scandalous peppermint spine	0		Sleaze Damage: +5, Sleaze Resistance: +1, Last Available: "2019-12"
@@ -10301,7 +10301,7 @@
 10444	drippy snail shell	0		
 10445	diet rotten drippy nugget	1	drippy	
 10446	acceptable glass of drippy wine	4	drippy	
-10447	jumbo stale drippy caviar	5	drippy	
+10447	stale jumbo drippy caviar	5	drippy	
 10448	bland drippy plum(?)	3	drippy	
 10449	drippy stake of Flo-Jo	0		Initiative: +100, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10324,7 +10324,7 @@
 10467	jittery smartaleck's cool back shell	0		Moxie: +5, Moxie Percent: +30
 10468	spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
-10470	mirror pulsating Thwaitgold buzzy beetle statuette	0		
+10470	pulsating mirror Thwaitgold buzzy beetle statuette	0		
 10471	fuchsia Plumber's Union Handbook	0		
 10472	bony back shell of doom	0		Spooky Spell Damage: +50
 10473	frosty button	0		Single Equip
@@ -10394,8 +10394,8 @@
 10538	lime green Guzzlr pants	0		Last Available: "2020-05"
 10539	maroon Guzzlr souvenir stein of the glutton	0		Food Drop: +100, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	perfectly mixed bouncing squat Ghiaccio Colada	3	EPIC	Last Available: "2020-05"
-10542	fancy perfectly mixed watered-down Sourfinger	2	EPIC	Effect: "Corruption of Wretched Wally", Effect Duration: 15, Last Available: "2020-05"
+10541	perfectly mixed squat bouncing Ghiaccio Colada	3	EPIC	Last Available: "2020-05"
+10542	watered-down fancy perfectly mixed Sourfinger	2	EPIC	Effect: "Corruption of Wretched Wally", Effect Duration: 15, Last Available: "2020-05"
 10543	lousy Nog-on-the-Cob	3	decent	Last Available: "2020-05"
 10544	aged teal Steamboat	4	awesome	Last Available: "2020-05"
 10545	bad jittery Buttery Boy	3	decent	Last Available: "2020-05"
@@ -10468,7 +10468,7 @@
 10612	stanky razor-sharp Yeg's Motel shower cap	0		Weapon Damage Percent: +25, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-09"
 10613	twirling frosty hardy Yeg's Motel bathrobe	0		Maximum HP: +50, Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-09"
 10614	shaking stanky Yeg's Motel slippers of the early riser	0		Stench Spell Damage: +25, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
-10615	purple blinking Yeg's Motel stationery	0		Last Available: "2020-09"
+10615	blinking purple Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	blinking sizzling desk bell	0		Last Available: "2020-09"
 10618	blurry frost-rimed desk bell	0		Last Available: "2020-09"
@@ -10491,12 +10491,12 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	electrified healthy Rosewater's Cargo Cultist Shorts of terror	0		Mysticality Percent: +30, Maximum HP Percent: +20, Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	acceptable watered-down flask of moonshine	2	good	Last Available: "2020-09"
+10638	watered-down acceptable flask of moonshine	2	good	Last Available: "2020-09"
 10639	wobbly inspector's fireproof frosty sea-worn candlestick	0		Cold Spell Damage: +10, Hot Resistance: +3, Item Drop: +15, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	flattened boiled altered narrow null-day exploit	0		Effect: "Wet Rub", Effect Duration: 26, Last Available: "2025-12"
 10642	skewed blinking flame orb	0		Last Available: "2020-09"
-10643	stale small chocolate chip muffin	2	decent	
+10643	small stale chocolate chip muffin	2	decent	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10509,14 +10509,14 @@
 10653	super-ionized fortifying hot cocoa	0		Effect: "Executive Greed", Effect Duration: 63, Last Available: "2020-12"
 10654	alkaline boiling hot cocoa	0		Effect: "Mmmmmelon", Effect Duration: 39, Last Available: "2020-12"
 10655	energized cool hot cocoa	0		Effect: "Wit Tea", Effect Duration: 13, Last Available: "2020-12"
-10656	flattened tumbling purple overly-fancy hot cocoa	0		Effect: "Square to be Hip", Effect Duration: 24, Last Available: "2020-12"
+10656	flattened purple tumbling overly-fancy hot cocoa	0		Effect: "Square to be Hip", Effect Duration: 24, Last Available: "2020-12"
 10657	warmed hot cocoa au beurre	0		Effect: "Fire Inside", Effect Duration: 66, Last Available: "2020-12"
 10658	extra-frozen hot cocoa with rainbow marshmallows	0		Effect: "Slightly Larger Than Usual", Effect Duration: 17, Last Available: "2020-12"
 10659	Van der Graaf Book of Old-Timey Carols	0		MP Regen Min: [5*event(December)], MP Regen Max: [7*event(December)], Last Available: "2020-12"
 10660	blinking Temple Grandin's Crimbo smile	0		Familiar Weight: [+7*event(December)], Last Available: "2020-12"
 10661	friendly SalesCo sample kit	0		Familiar Weight: [+3*event(December)], Last Available: "2020-12"
 10662	galvanized liquefied candy harmonica	0		Effect: "Berry Experiential", Effect Duration: 61, Last Available: "2020-12"
-10663	wet ionized olive blinking sugar	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 59, Last Available: "2020-12"
+10663	wet ionized blinking olive sugar	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 59, Last Available: "2020-12"
 10664	corrupted multi-level marzipan	0		Effect: "Orchid Blood", Effect Duration: 69, Last Available: "2020-12"
 10665	plastic Crimbo caroler of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2020-12"
 10666	spinning blurry Lo Pan's plastic multi-level marketer	0		Spell Critical Percent: +30, Last Available: "2020-12"
@@ -10556,7 +10556,7 @@
 10700	knitted Satan hat of the brazier	0		Hot Spell Damage: +25, Cold Resistance: +3, Class: "Sauceror", Last Available: "2020-12"
 10701	yellow nasty Crimbo stockings of the overflowing toilet	0		Stench Damage: +5, Stench Spell Damage: +50, Class: "Disco Bandit", Last Available: "2020-12"
 10702	Lo Pan's MacGyver's poncho de azucar	0		Maximum MP: +100, Spell Critical Percent: +30, Class: "Accordion Thief", Last Available: "2020-12"
-10703	shaking jittery jittery The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
+10703	jittery shaking jittery The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	wobbly The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10705	The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10706	The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
@@ -10566,15 +10566,15 @@
 10710	The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
-10713	huge teal The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
+10713	teal huge The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	green The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	half-sized yummy and pepper (stale)	2	awesome	Last Available: "2020-12"
-10716	hand-crafted fancy fortified cranberry margarita (brackish)	5	EPIC	Effect: "Amorous Avarice", Effect Duration: 50, Last Available: "2020-12"
+10715	yummy half-sized and pepper (stale)	2	awesome	Last Available: "2020-12"
+10716	fortified fancy hand-crafted cranberry margarita (brackish)	5	EPIC	Effect: "Amorous Avarice", Effect Duration: 50, Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	delicious barrel-aged eggnog	3	awesome	Last Available: "2020-12"
-10721	adequate gigantic hand-crafted candy cane	9	good	Last Available: "2020-12"
+10721	gigantic adequate hand-crafted candy cane	9	good	Last Available: "2020-12"
 10722	delicious drive-thru burger	4	awesome	Last Available: "2020-12"
 10723	lousy ghostly Boulevardier cocktail	4	decent	Last Available: "2020-12"
 10724	alkaline modified Hotwire&trade; brand candy rope	0		Effect: "Ooh, Bitter!", Effect Duration: 65, Last Available: "2020-12"
@@ -10583,11 +10583,11 @@
 10727	liquefied wet Chubby and Plump bar	0		Effect: "Mystic Circle", Effect Duration: 34, Last Available: "2020-12"
 10728	shaking digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
-10730	bouncing spinning crystal ball	0		Initiative: +50, Last Available: "2021-01"
+10730	spinning bouncing crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	jittery power seed	0		Free Pull, Last Available: "2021-03"
@@ -10660,7 +10660,7 @@
 10804	squat Jeselnik's occult Daylight Shavings Helmet of the businessman	0		Spell Damage Percent: +25, Sleaze Damage: +25, Meat Drop: +50, Last Available: "2021-11"
 10805	eggwater	1	decent	Last Available: "2021-12"
 10806	decent bread man	3	good	Last Available: "2021-12"
-10807	big adequate plain candy cane	5	good	Last Available: "2021-12"
+10807	adequate big plain candy cane	5	good	Last Available: "2021-12"
 10808	adequate flour cookie	3	good	Last Available: "2021-12"
 10809	Rosewater's plastic food lab	0		Mysticality Percent: +30, Single Equip, Last Available: "2021-12"
 10810	Da Vinci's plastic nog lab	0		Experience (Mysticality): +5, Single Equip, Last Available: "2021-12"
@@ -10677,9 +10677,9 @@
 10821	delicious cyan fishcake	3	awesome	Last Available: "2021-12"
 10822	toothsome bone broth	3	awesome	Last Available: "2021-12"
 10823	flavorless star pop	4	decent	Last Available: "2021-12"
-10824	triple-distilled drinkable Doc's Fortifying Wine	10	good	Last Available: "2021-12"
+10824	drinkable triple-distilled Doc's Fortifying Wine	10	good	Last Available: "2021-12"
 10825	aged gray Doc's Smartifying Wine	3	awesome	Last Available: "2021-12"
-10826	boozy bad tumbling Doc's Limbering Wine	5	decent	Last Available: "2021-12"
+10826	bad boozy tumbling Doc's Limbering Wine	5	decent	Last Available: "2021-12"
 10827	watered-down perfectly mixed Doc's Medical-Grade Wine	2	EPIC	Last Available: "2021-12"
 10828	distilled spinning Homebodyl&trade;	1		Last Available: "2021-12"
 10829	twisted ghostly Extrovermectin&trade;	1		Last Available: "2021-12"
@@ -10690,8 +10690,8 @@
 10834	energized corrupted purple anti-goosebump cream	0		Effect: "Super-Charged", Effect Duration: 48, Last Available: "2021-12"
 10835	polymerized anti-odor cream	0		Effect: "Cancer Rising", Effect Duration: 45, Last Available: "2021-12"
 10836	warmed anti-creep cream	0		Effect: "High Blood Chocolate Content", Effect Duration: 33, Last Available: "2021-12"
-10837	double-flattened upside-down blinking red anti-pain cream	0		Effect: "Wallflowering", Effect Duration: 36, Last Available: "2021-12"
-10838	lousy watered-down shaking bouncing Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
+10837	double-flattened red upside-down blinking anti-pain cream	0		Effect: "Wallflowering", Effect Duration: 36, Last Available: "2021-12"
+10838	watered-down lousy bouncing shaking Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
 10839	normal blinking bread pie	3	good	Last Available: "2021-12"
 10840	smooth upside-down clear Russian	3	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
@@ -10721,7 +10721,7 @@
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	yule hatchet of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2021-12"
 10867	blue potato alarm clock	0		Last Available: "2021-12"
-10868	delicious snack-sized lab-grown meat	2	awesome	Last Available: "2021-12"
+10868	snack-sized delicious lab-grown meat	2	awesome	Last Available: "2021-12"
 10869	yellow fleece of the storm	0		Maximum MP Percent: +40, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	narrow cloning kit	0		Last Available: "2021-12"
@@ -10733,7 +10733,7 @@
 10877	shaking cloned monster	0		Last Available: "2021-12"
 10878	cyan meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
-10880	powdered jittery pulsating fried air	1		Effect: "Jawin'", Effect Duration: 5, Last Available: "2021-12"
+10880	powdered pulsating jittery fried air	1		Effect: "Jawin'", Effect Duration: 5, Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	mirror carton of astral energy drinks	0		
 10883	denatured narrow astral energy drink	1		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 50
@@ -10761,7 +10761,7 @@
 10905	sinister headlamp	0		Spell Damage: +10, Lasts Until Rollover, Last Available: "2022-05"
 10906	reassuring frightening Samson's thermal blanket	0		Experience (Muscle): +5, Spooky Damage: +5, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2022-05"
 10907	skewed hardy atlas of local maps	0		Maximum HP: +50, Lasts Until Rollover, Last Available: "2022-05"
-10908	aerosolized skewed blurry spare battery	0		Effect: "Haunted Stomach", Effect Duration: 55, Last Available: "2022-05"
+10908	aerosolized blurry skewed spare battery	0		Effect: "Haunted Stomach", Effect Duration: 55, Last Available: "2022-05"
 10909	fuchsia space blanket	0		Last Available: "2022-05"
 10910	magnetized quadruple-deionized twirling single-use dust mask	0		Effect: "Rootin' Around", Effect Duration: 64, Last Available: "2022-05"
 10911	concentrated quadruple-aerosolized maroon gaffer's tape	0		Effect: "World's Shortest Giant", Effect Duration: 54, Last Available: "2022-05"
@@ -10774,15 +10774,15 @@
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	Lo Pan's dangerous June cleaver of the cheetah	0		Weapon Damage: +10, Spell Critical Percent: +30, Initiative: +60, Attacks Can't Miss, Last Available: "2022-06"
-10921	mediocre weak Dad's brandy	2	decent	Last Available: "2022-06"
+10921	weak mediocre Dad's brandy	2	decent	Last Available: "2022-06"
 10922	huge Van der Graaf veiny teacher's pen	0		Maximum HP: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-06"
-10923	super-sized special rotten fire-roasted lake trout	5	crappy	Effect: "Happy Trails", Effect Duration: 10, Last Available: "2022-06"
+10923	special super-sized rotten fire-roasted lake trout	5	crappy	Effect: "Happy Trails", Effect Duration: 10, Last Available: "2022-06"
 10924	flavorless guilty sprout	3	decent	Last Available: "2022-06"
 10925	weightlifter's mother's necklace	0		Muscle: +15, Item Drop: +5, Last Available: "2022-06"
 10926	dry warmed trampled ticket stub	0		Effect: "Hair on Your Chest", Effect Duration: 16, Last Available: "2022-06"
 10927	galvanized mirror savings bond	0		Effect: "Aquarius Rising", Effect Duration: 40, Last Available: "2022-06"
 10928	tumbling designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	yellow designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	yellow designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
 10930	powdered pulsating sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	spinning stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10798,7 +10798,7 @@
 10942	dinosaur repellent	0		
 10943	sizzling camouflage vest	0		Hot Damage: +10
 10944	Dinodollar	0		
-10945	mirror upside-down valuable dinosaur droppings	0		
+10945	upside-down mirror valuable dinosaur droppings	0		
 10946	dinosaur pheromone kit	0		
 10947	flame-wreathed medical-grade ruddy awkward dinosaur research harness	0		Maximum HP Percent: +40, Hot Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10
 10948	yellow reflective vest of terror	0		Spooky Spell Damage: +10
@@ -10807,7 +10807,7 @@
 10951	squat packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
 10952	strapping Jurassic Parka of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	shaking gray boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
-10954	cyan pulsating autumn-aton	0		Last Available: "2022-10"
+10954	pulsating cyan autumn-aton	0		Last Available: "2022-10"
 10955	deionized deionized skewed huge autumn leaf	0		Effect: "Hella Smart", Effect Duration: 34, Last Available: "2022-10"
 10956	hand-crafted AutumnFest ale	4	EPIC	Last Available: "2022-10"
 10957	greasy wicked cool autumn sweater-weather sweater	0		Moxie: +5, Spell Damage: +5, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
@@ -10818,7 +10818,7 @@
 10962	vaporized blurry narrow fuchsia autumn breeze	1		Last Available: "2022-10"
 10963	diffused autumn years wisdom	0		Effect: "Liquid Courage", Effect Duration: 63, Last Available: "2022-10"
 10964	upside-down familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	fancy high-proof delicious Oopsie IPA	10	awesome	Effect: "Smelly Pants", Effect Duration: 15, Last Available: "2022-10"
+10965	delicious high-proof fancy Oopsie IPA	10	awesome	Effect: "Smelly Pants", Effect Duration: 15, Last Available: "2022-10"
 10966	bouncing mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	huge Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10828,32 +10828,32 @@
 10972	spoiled roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
 10973	decent St. Pete's sneaky smoothie	3	good	Last Available: "2022-11"
 10974	moldy shaking Pete's wiley whey bar	4	crappy	Last Available: "2022-11"
-10975	snack-sized spoiled red Pete's rich ricotta	2	crappy	Last Available: "2022-11"
+10975	spoiled snack-sized red Pete's rich ricotta	2	crappy	Last Available: "2022-11"
 10976	mediocre Boris's beer	3	decent	Last Available: "2022-11"
 10977	decent miniature lime green shaking honey bun of Boris	2	good	Last Available: "2022-11"
 10978	adequate small wobbly Boris's bread	2	good	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	red Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	blinking Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	bouncing Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	tumbling Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	red Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	blinking Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	bouncing Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	tumbling Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	delicious squat baked veggie ricotta casserole	4	awesome	Last Available: "2022-11"
-10989	bland enchanted green upside-down plain calzone	4	decent	Effect: "Radiant Personality", Effect Duration: 25, Last Available: "2022-11"
+10989	bland enchanted upside-down green plain calzone	4	decent	Effect: "Radiant Personality", Effect Duration: 25, Last Available: "2022-11"
 10990	moldy roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	moldy Pizza of Legend	3	crappy	Last Available: "2022-11"
-10992	snack-sized spoiled Calzone of Legend	2	crappy	Last Available: "2022-11"
-10993	maroon blurry Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	spinning Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10992	spoiled snack-sized Calzone of Legend	2	crappy	Last Available: "2022-11"
+10993	blurry maroon Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	spinning Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	low-calorie stale Deep Dish of Legend	1	decent	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	stale low-calorie Deep Dish of Legend	1	decent	Last Available: "2022-11"
 11001	bouncing lime green deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10867,7 +10867,7 @@
 11011	shaking gator shades of doom of the detective	0		Spooky Spell Damage: +50, Item Drop: +20, Single Equip
 11012	upside-down shaking milk cap	0		
 11013	hand-crafted jittery Charleston Choo-Choo	3	EPIC	
-11014	mediocre spirit-forward narrow Velvet Veil	5	decent	
+11014	spirit-forward mediocre narrow Velvet Veil	5	decent	
 11015	practically non-alcoholic tolerable enchanted Marltini	1	good	Effect: "Slimily Sagacious", Effect Duration: 50
 11016	mediocre watered-down Strong, Silent Type	2	decent	
 11017	mediocre green Mysterious Stranger	3	decent	
@@ -10889,7 +10889,7 @@
 11033	rosewater-soaked chaotic chiffon chaps of the brute	0		Muscle Percent: +30, Spell Critical Percent: +10, Stench Resistance: +3, Last Available: "2023-12"
 11034	powdered lime green chiffon carbage	1		Last Available: "2023-12"
 11035	chilled spinning chiffon lemon	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 59
-11036	adequate immense chocomotive	7	good	Last Available: "2022-12"
+11036	immense adequate chocomotive	7	good	Last Available: "2022-12"
 11037	flavorless teal freightcake	3	decent	Last Available: "2022-12"
 11038	watered-down smooth yellow cabooze	2	awesome	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10901,7 +10901,7 @@
 11045	model train set	0		Last Available: "2022-12"
 11046	Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
-11048	ghostly ghostly skewed Trainbot radar monocle	0		Single Equip
+11048	ghostly skewed ghostly Trainbot radar monocle	0		Single Equip
 11049	lime green pile of Trainbot parts	0		
 11050	improved galvanized Trainbot circuitry	0		Effect: "Stemonitis Storm", Effect Duration: 30
 11051	activated irradiated Trainbot tubing	0		Effect: "Woad Warrior", Effect Duration: 39
@@ -10914,13 +10914,13 @@
 11058	yellow personal trainer's Trainbot harness	0		Experience Percent (Muscle): +10
 11059	purple ping-pong table	0		
 11060	upside-down Crimbo train emergency brake	0		
-11061	huge blurry Trainbot autoassembly module	0		
+11061	blurry huge Trainbot autoassembly module	0		
 11062	friendly grievous wizardly head-mounted Trainbot	0		Mysticality: +25, Weapon Damage Percent: +50, Familiar Weight: +3, Last Available: "2022-12"
 11063	mirror inspector's sizzling strapping leg-mounted Trainbots	0		Muscle: +5, Hot Damage: +10, Item Drop: +15, Last Available: "2022-12"
 11064	sizzling thinker's shoulder-mounted Trainbot of incineration	0		Mysticality: +10, Hot Damage: +10, Hot Spell Damage: +50, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	wobbly Crimbo crystal shards	0		
-11067	high-proof mediocre blurry dregs of a Crimbo cocktail	9	decent	
+11067	mediocre high-proof blurry dregs of a Crimbo cocktail	9	decent	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	adequate honey-drenched ham slice	3	good	
@@ -10935,9 +10935,9 @@
 11079	spinning narrow really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
-11082	pulsating ghostly crystal Crimbo goblet	0		
+11082	ghostly pulsating crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	lousy watered-down Crimbosmopolitan	2	decent	Last Available: "2022-12"
+11084	watered-down lousy Crimbosmopolitan	2	decent	Last Available: "2022-12"
 11085	flavorless Crimbo dinner	4	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10950,7 +10950,7 @@
 11094	occult grievous beefcake's grubby wool trousers	0		Muscle: +25, Weapon Damage Percent: +50, Spell Damage Percent: +25
 11095	greedy razor-sharp Da Vinci's brainy grubby wool gloves	0		Mysticality: +5, Experience (Mysticality): +5, Weapon Damage Percent: +25, Meat Drop: +20, Single Equip
 11096	jittery grubby wool beerwarmer	0		
-11097	bad irresponsibly strong wobbly nice warm beer	6	decent	
+11097	irresponsibly strong bad wobbly nice warm beer	6	decent	
 11098	narrow grubby woolball	0		
 11099	ghostly Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	lime green packet of rock seeds	0		Last Available: "2023-01"
@@ -10965,8 +10965,8 @@
 11109	upside-down stalagmite	0		Last Available: "2023-01"
 11110	cyan chocolate covered ping-pong ball	0		
 11112	spoiled olive pixel bread	4	crappy	
-11113	acceptable irresponsibly strong pixel whiskey	9	good	
-11114	bouncing narrow pixel rock	0		
+11113	irresponsibly strong acceptable pixel whiskey	9	good	
+11114	narrow bouncing pixel rock	0		
 11115	purple squat S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	triple-unsweetened boiled glob of extra-green chlorophyll	0		Effect: "Winklered", Effect Duration: 56, Last Available: "2023-02"
@@ -10974,12 +10974,12 @@
 11119	galvanized cyan wobbly five-fingered fern resin	0		Effect: "Boo Tea", Effect Duration: 42, Last Available: "2023-02"
 11120	immense adequate super good fruit	10	good	Last Available: "2023-02"
 11121	diluted twirling tumbling ghostly energized spores	1		Effect: "Tenacity of the Snapper", Effect Duration: 25, Last Available: "2023-02"
-11122	green flame-retardant hot pepper of the sweet-tooth	0		Hot Resistance: +1, Candy Drop: +100, Last Available: "2023-02", Lantern Element: "Hot"
+11122	green flame-retardant hot pepper of the sweet-tooth	0		Hot Resistance: +1, Candy Drop: +100, Lantern Element: "Hot", Last Available: "2023-02"
 11123	magnetized out-of-work circus flea	0		Effect: "Slimy Flavor", Effect Duration: 39, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	quantum enhanced frozen fuchsia fire ant pheromones	0		Effect: "Crusty Head", Effect Duration: 30, Last Available: "2023-02"
 11126	anodized flapper fly	0		Effect: "The Two-Prong Crown", Effect Duration: 52, Last Available: "2023-02"
-11127	bad high-proof twirling shot of wasp venom	9	decent	Last Available: "2023-02"
+11127	high-proof bad twirling shot of wasp venom	9	decent	Last Available: "2023-02"
 11128	deionized filled mosquito	0		Effect: "Aquarius Rising", Effect Duration: 25, Last Available: "2023-02"
 11129	ionized galvanized shim of shame shale	0		Effect: "Serendipi Tea", Effect Duration: 16, Last Available: "2023-02"
 11130	ionized pebble of proud pyrite	0		Effect: "Well Owl Be!", Effect Duration: 33, Last Available: "2023-02"
@@ -10992,11 +10992,11 @@
 11137	moist energized shadow flame	0		Effect: "Oiled Skin", Effect Duration: 37, Last Available: "2023-03"
 11138	tasty maroon shadow bread	3	awesome	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	practically non-alcoholic artisanal shadow fluid	1	super ultra mega EPIC	Last Available: "2023-03"
-11141	squat bouncing shadow glass	0		Last Available: "2023-03"
+11140	artisanal practically non-alcoholic shadow fluid	1	super ultra mega EPIC	Last Available: "2023-03"
+11141	bouncing squat shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	lousy high-proof pulsating shadow venom	7	decent	Last Available: "2023-03"
+11144	high-proof lousy pulsating shadow venom	7	decent	Last Available: "2023-03"
 11145	pickled green shadow nectar	1		Last Available: "2023-03"
 11146	squat scorching studded shadow stick of horror	0		Damage Absorption: +80, Hot Damage: +25, Spooky Spell Damage: +25, Last Available: "2023-03"
 11147	tumbling savvy bat paw of vim and vigor	0		Mysticality Percent: +20, Maximum HP Percent: +50
@@ -11016,7 +11016,7 @@
 11161	upside-down sharpshooter's deadly medallion of Leguizamo	0		Weapon Damage: +5, Critical Hit Percent: +10, Monster Level: +20
 11162	uncursed medallion of Leguizamo	0		Monster Level: +20
 11163	blue Advanced Pig Skinning	0		
-11164	lime green mirror The Cheese Wizard's Companion	0		
+11164	mirror lime green The Cheese Wizard's Companion	0		
 11165	Jazz Agent sheet music	0		
 11166	Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
@@ -11027,7 +11027,7 @@
 11172	gray shadow snowflake	0		
 11173	shadow heart	0		
 11174	shadow bucket	0		
-11175	twirling upside-down shadow wave	0		
+11175	upside-down twirling shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	veiny Newton's shadow chef's hat of the boozehound	0		Experience (Mysticality): +3, Maximum HP: +10, Booze Drop: +100
 11178	huge asbestos-lined energetic shadow trousers of Leguizamo	0		Maximum MP Percent: +20, Monster Level: +20, Hot Resistance: +5
@@ -11037,7 +11037,7 @@
 11182	snack-sized moldy shadow hot dog	2	crappy	
 11183	mediocre blinking shadow martini	3	decent	
 11184	denatured shadow pill	1		
-11185	narrow teal tumbling shadow needle	0		
+11185	narrow tumbling teal shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	electrified teal twirling shadow candy	0		Effect: "Good with the Ladies", Effect Duration: 45
@@ -11095,7 +11095,7 @@
 11240	bouncing greedy careful Da Vinci's replica Fourth of May Cosplay Saber	0		Experience (Mysticality): +5, Monster Level: -10, Meat Drop: +20, Conditional Skill (Equipped): "Use the Force"
 11241	gravedigger's resourceful curative veiny replica Kramco Sausage-o-Matic&trade; of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +10, Maximum MP: +50, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 11242	purple miser's lion tamer's manspreader's wholesome sinister arcane researcher's Herculean replica hewn moon-rune spoon of the ox of the storm of the scaredy-cat of the sewer	0		Muscle: +20, Experience (Muscle): +1, Experience Percent (Mysticality): +10, Spell Damage: +10, Maximum HP Percent: +10, Maximum MP Percent: +40, Monster Level: -5, Experience (familiar): +2, Stench Damage: +25, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
-11243	blue spinning replica baby camelCalf	0		
+11243	spinning blue replica baby camelCalf	0		
 11244	smelly mansplainer's energetic replica Powerful Glove of the ox of the brazier	0		Muscle: +20, Maximum MP Percent: +20, Monster Level: +15, Hot Spell Damage: +25, Stench Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 11245	medical-grade smooth replica Cargo Cultist Shorts of James Dean of the sewer	0		Moxie: +15, Experience (Moxie): +3, Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10
 11246	asbestos-lined sizzling healthy experienced wizardly replica industrial fire extinguisher of the ox	0		Muscle: +20, Mysticality: +25, Experience: +2, Maximum HP Percent: +20, Hot Damage: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	huge red rosewater-soaked boxer's replica Jurassic Parka	0		Muscle Percent: +10, Stench Resistance: +3
 11250	purple replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	aromatic friendly MacGyver's replica Cincho de Mayo of the businessman	0		Maximum MP: +100, Familiar Weight: +3, Stench Resistance: +1, Meat Drop: +50, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11117,7 +11117,7 @@
 11262	blinking Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	purple Charter: Nellyville	0		Last Available: "2023-06"
-11265	spinning Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11265	spinning Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	Annie Oakley's Flash Liquidizer Ultra Dousing Accessory	0		Critical Hit Percent: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	greedy banded personal trainer's Amulet of Perpetual Darkness of the early riser	0		Experience Percent (Muscle): +10, Damage Absorption: +100, Meat Drop: +20, Adventures: +7, Last Available: "2023-06"
 11268	spinning Giant monolith	0		Last Available: "2023-06"
@@ -11172,19 +11172,19 @@
 11317	handful of toilet paper	0		
 11318	blue Mrs. Rush	0		
 11319	jittery medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	strong acceptable bottle of Cabernet Sauvignon	5	good	
+11320	acceptable strong bottle of Cabernet Sauvignon	5	good	
 11321	green bouncing Tesla smooth baywatch of doom	0		Moxie: +15, Spooky Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover
-11322	shaking Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	shaking Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11326	skewed blue Thwaitgold fairyfly statue	0		
+11326	blue skewed Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	denatured jittery concentrated cooking	1		
 11329	altered meat	1		Effect: "Elemental Mastery", Effect Duration: 45
 11330	modified fuchsia sparkling orb	1		Effect: "Raging Animal", Effect Duration: 10
 11331	pickled ghostly hardening cream	1		Effect: "Lemon Enlightenment", Effect Duration: 45
-11332	dried twirling olive pulsating pool shark hair oil	1		
+11332	dried olive twirling pulsating pool shark hair oil	1		
 11333	cyan book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11205,7 +11205,7 @@
 11350	super-heated leaf	0		
 11351	lit leaf lasso	0		
 11352	teal tied-up leaflet	0		
-11353	skewed tumbling tied-up monstera	0		
+11353	tumbling skewed tied-up monstera	0		
 11354	shaking tied-up leaviathan	0		
 11355	blue ribald horrifying impromptu torch	0		Spooky Damage: +25, Sleaze Damage: +10, Lasts Until Rollover
 11356	Jim Carey's fig leaf of Flo-Jo	0		Monster Level: +25, Initiative: +100, Lasts Until Rollover
@@ -11220,7 +11220,7 @@
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
-11368	huge spinning Crimbuccaneer breeches	0		Last Available: "2023-12"
+11368	spinning huge Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	automa-bot parts	0		
 11370	blurry huge security automa-core	0		
 11371	clerical automa-core	0		
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	moldy diet peppermint donut	1	crappy	
+11395	diet moldy peppermint donut	1	crappy	
 11396	toasty Elf Guard insignia (private)	0		Hot Damage: +5, Last Available: "2023-12"
 11397	Crimbuccaneer fledges (mint) of the dark arts	0		Spell Damage Percent: +100, Last Available: "2023-12"
 11398	tumbling military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11275,12 +11275,12 @@
 11420	ghostly zippy lion tamer's manspreader's Crimbuccaneer tavern swab	0		Monster Level: +10, Experience (familiar): +2, Initiative: +20, Last Available: "2023-12"
 11421	maroon Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	acceptable cyan old-school pirate grog	3	good	Last Available: "2023-12"
-11423	huge bland special grog nuts	6	decent	Effect: "Pyromania", Effect Duration: 50, Last Available: "2023-12"
+11423	special bland huge grog nuts	6	decent	Effect: "Pyromania", Effect Duration: 50, Last Available: "2023-12"
 11424	executive grievous sawed-off blunderbuss of chilblains	0		Weapon Damage Percent: +50, Cold Damage: +25, Meat Drop: +40, Last Available: "2023-12"
-11425	triple-distilled tolerable shaking officer's nog	6	good	Last Available: "2023-12"
+11425	tolerable triple-distilled shaking officer's nog	6	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	half-sized adequate sundae ration	2	good	Last Available: "2023-12"
-11428	small toothsome tumbling peppermint tack	2	awesome	Last Available: "2023-12"
+11428	toothsome small tumbling peppermint tack	2	awesome	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten whalesteak	4	crappy	Last Available: "2023-12"
 11431	tumbling Annie Oakley's sharpshooter's weightlifter's whalegun	0		Muscle: +15, Critical Hit Percent: 30, Last Available: "2023-12"
@@ -11306,7 +11306,7 @@
 11451	mirror punching mirror	0		Last Available: "2023-12"
 11452	squat ribald flame-wreathed dog trainer's healthy Elf dessert spoon of the storm of the businessman	0		Maximum HP Percent: +20, Maximum MP Percent: +40, Experience (familiar): +1, Hot Spell Damage: +10, Sleaze Damage: +10, Meat Drop: +50, Last Available: "2023-12"
 11453	bouncing mirror gray perfumed Sinatra's Elf Guard SCUBA tank	0		Experience (Moxie): +5, Stench Resistance: +5, Last Available: "2023-12"
-11454	bouncing blurry Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
+11454	blurry bouncing Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11455	bouncing maroon steel-toed savvy free boots	0		Mysticality Percent: +20, Damage Reduction: 9, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	horrifying MacGyver's Elvish underarmor of Calamity Jane	0		Maximum MP: +100, Critical Hit Percent: +15, Spooky Damage: +25, Single Equip, Last Available: "2023-12"
@@ -11314,11 +11314,11 @@
 11459	spoiled huge sugarplum ration	3	crappy	Last Available: "2023-12"
 11460	rotten gingerbread nylons	3	crappy	Last Available: "2023-12"
 11461	tiny tasty rum-soaked fruitcake	1	awesome	Last Available: "2023-12"
-11462	snack-sized stale lime	2	decent	Last Available: "2023-12"
+11462	stale snack-sized lime	2	decent	Last Available: "2023-12"
 11463	decent gingerbread pirate	3	good	Last Available: "2023-12"
 11464	rotten fuchsia fruit-stuffed rumcake	4	crappy	Last Available: "2023-12"
 11465	hand-crafted mulled wine	4	EPIC	Last Available: "2023-12"
-11466	triple-distilled hand-crafted blinking Swedish coffee	9	EPIC	Last Available: "2023-12"
+11466	hand-crafted triple-distilled blinking Swedish coffee	9	EPIC	Last Available: "2023-12"
 11467	bad canteen of eggnog	4	decent	Last Available: "2023-12"
 11468	high-proof bad hot wine	8	decent	Last Available: "2023-12"
 11469	perfectly mixed watered-down Jamaican coffee	2	EPIC	Last Available: "2023-12"
@@ -11327,14 +11327,14 @@
 11472	jittery Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	perfectly mixed mirror yule grog	4	EPIC	Last Available: "2023-12"
-11475	massive fancy flavorless wet tack	10	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 25, Last Available: "2023-12"
+11475	flavorless fancy massive wet tack	10	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 25, Last Available: "2023-12"
 11476	stale blue whalecake	4	decent	Last Available: "2023-12"
 11477	narrow olive reassuring nippy forbidden gunwale whalegun	0		Spell Damage Percent: +50, Cold Damage: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	mediocre watered-down jittery and claret	2	decent	Last Available: "2023-12"
 11479	fuchsia rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	tumbling nasty experienced Elf Guard squirtgun	0		Experience: +2, Stench Damage: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
-11482	lime green mirror chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
+11482	mirror lime green chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	smooth sequin-encrusted sweater	0		Moxie: +15, Last Available: "2023-12"
 11484	wool sizzling weightlifter's replica Elf Guard medal	0		Muscle: +15, Hot Damage: +10, Cold Resistance: +1, Last Available: "2023-12"
 11485	ghostly blinking Lil' Snowball Factory	0		Last Available: "2023-12"
@@ -11365,12 +11365,12 @@
 11510	dried moss mulch	1		Effect: "Weather, Man", Effect Duration: 45, Last Available: "2024-12"
 11511	nitrogenated tarnished blue moss floss	0		Effect: "Optimist Primal", Effect Duration: 40
 11512	adobe arsecover	0		Last Available: "2024-12"
-11513	wobbly shaking adobe adze	0		Single Equip, Last Available: "2024-12"
+11513	shaking wobbly adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	adobe ayam	0		Last Available: "2024-12"
 11516	mirror huge adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
-11518	altered fuchsia twirling huge adobe assortment	1		Last Available: "2024-12"
+11518	altered huge fuchsia twirling adobe assortment	1		Last Available: "2024-12"
 11519	pickled oxidized adobe brittle	0		Effect: "All Is Forgiven", Effect Duration: 16
 11520	zippy coward's dance instructor's crepe paper phrygian cap	0		Experience Percent (Moxie): +10, Monster Level: -20, Initiative: +20, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	arcane researcher's crepe paper parachute cape of Calamity Jane of the early riser	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +15, Adventures: +7, Last Available: "2025-12"
@@ -11382,13 +11382,13 @@
 11527	quantum ionized ghostly crepe paper peanut candy	0		Effect: "Weepy, Creepy", Effect Duration: 58
 11528	hardy petrified wood war pike of Flo-Jo	0		Maximum HP: +50, Initiative: +100, Last Available: "2025-12"
 11529	frosty petrified wood waist protector of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
-11530	chilly petrified wood wizard's pouch of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	smelly petrified wood water purifier of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	chilly petrified wood wizard's pouch of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	smelly petrified wood water purifier of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	ribald fortified petrified wood whoopie panama	0		Damage Absorption: +60, Sleaze Damage: +10, Last Available: "2025-12"
 11533	manspreader's deadly petrified wood walking pants	0		Weapon Damage: +5, Monster Level: +10, Last Available: "2025-12"
 11534	compressed petrified wood waste parts	1		Last Available: "2025-12"
 11535	chilled Vulcanized wobbly petrified wood wafer praline	0		Effect: "Healthy Red Glow", Effect Duration: 37
-11536	perfectly mixed enchanted boozy cybeer	5	EPIC	Effect: "Your Interest is Peaked", Effect Duration: 45, Last Available: "2025-12"
+11536	boozy perfectly mixed enchanted cybeer	5	EPIC	Effect: "Your Interest is Peaked", Effect Duration: 45, Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	jittery encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
@@ -11399,7 +11399,7 @@
 11544	extremely unsafe arcane researcher's Elf Guard war standard	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +100, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	sinister spring shoes of incineration of the businessman	0		Spell Damage: +10, Hot Spell Damage: +50, Meat Drop: +50, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
-11547	moist blinking ghostly ultra-soft ferns	0		Effect: "Slimy Flavor", Effect Duration: 55, Last Available: "2024-02"
+11547	moist ghostly blinking ultra-soft ferns	0		Effect: "Slimy Flavor", Effect Duration: 55, Last Available: "2024-02"
 11548	vacuum-sealed non-irradiated crunchy brush	0		Effect: "The Strength...  of the Future", Effect Duration: 34, Last Available: "2024-02"
 11549	teal smashed scientific equipment	0		
 11550	wobbly biphasic molecular oculus	0		No Pull
@@ -11425,11 +11425,11 @@
 11570	bouncing Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	stale huge purple yam	3	decent	Last Available: "2024-05"
+11573	stale purple huge yam	3	decent	Last Available: "2024-05"
 11574	perfectly mixed yam martini	4	EPIC	Last Available: "2024-05"
 11575	lousy enchanted watered-down sweet potato o' mine	2	decent	Effect: "Quiet 'n' Good", Effect Duration: 50, Last Available: "2024-05"
 11576	bad boozy mirror Southern yam	5	decent	Last Available: "2024-05"
-11577	practically non-alcoholic enchanted perfectly mixed pulsating sweet potato punch	1	super ultra mega turbo EPIC	Effect: "Badger Underfoot", Effect Duration: 40, Last Available: "2024-05"
+11577	practically non-alcoholic perfectly mixed enchanted pulsating sweet potato punch	1	super ultra mega turbo EPIC	Effect: "Badger Underfoot", Effect Duration: 40, Last Available: "2024-05"
 11578	rotten Mayam spinach	4	crappy	Last Available: "2024-05"
 11579	rotten yam and swiss	3	crappy	Last Available: "2024-05"
 11580	shaking grievous brainy yam cannon of horror	0		Mysticality: +5, Weapon Damage Percent: +50, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-05"
@@ -11441,20 +11441,20 @@
 11586	tumbling bouncing executive studded slick yamtility belt	0		Moxie: +10, Damage Absorption: +80, Meat Drop: +40, Lasts Until Rollover, Last Available: "2024-05"
 11587	stale twirling yam slider	3	decent	Last Available: "2024-05"
 11588	half-sized toothsome yam mayo	2	awesome	Last Available: "2024-05"
-11589	decent shaking fuchsia upside-down yam burrito	4	good	Last Available: "2024-05"
+11589	decent shaking upside-down fuchsia yam burrito	4	good	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	huge mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	adequate half-sized mirror mini kiwi	2	good	Last Available: "2024-06"
+11594	half-sized adequate mirror mini kiwi	2	good	Last Available: "2024-06"
 11595	ghostly ghostly frosty supercharged razor-sharp mini kiwi bikini	0		Weapon Damage Percent: +25, Maximum MP Percent: +30, Cold Spell Damage: +10, Last Available: "2024-06"
 11596	weak mediocre mini kiwitini	2	decent	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	hale wizardly mini kiwi silicon tiepin of incineration	0		Mysticality: +25, Maximum HP: +20, Hot Spell Damage: +50
 11600	mini kiwi tipi	0		
-11601	adequate narrow pulsating mini kiwi digitized cookies	4	good	
-11602	watered-down lousy mini kiwi intoxicating spirits	2	decent	
+11601	adequate pulsating narrow mini kiwi digitized cookies	4	good	
+11602	lousy watered-down mini kiwi intoxicating spirits	2	decent	
 11603	ionized polarized mini kiwi antimilitaristic hippy petition	0		Effect: "The Dinsey Way", Effect Duration: 16
 11604	oxidized mini kiwi illicit antibiotic	0		Effect: "Hennaliciousness", Effect Duration: 32
 11605	sinister mini kiwi whipping stick of wisdom	0		Mysticality: +15, Spell Damage: +10
@@ -11468,11 +11468,11 @@
 11613	protogenetic chunklet (elbow)	0		
 11614	protogenetic chunklet (lips)	0		
 11615	Newton's messenger bag RNA of the ox of the empath	0		Muscle: +20, Experience (Mysticality): +3, Familiar Weight: +5
-11616	blinking ghostly flagellate flagon	0		
+11616	ghostly blinking flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	tasty blue bacteria bisque	3	awesome	
-11619	decent miniature ciliophora chowder	2	good	
-11620	normal tiny tumbling fuchsia cream of chloroplasts	1	good	
+11619	miniature decent ciliophora chowder	2	good	
+11620	normal tiny fuchsia tumbling cream of chloroplasts	1	good	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	pulsating flagellate soup	0		
@@ -11484,9 +11484,9 @@
 11629	untorn tearaway pants package	0		Free Pull
 11630	blinking frosty medical-grade experienced sage tearaway pants of mayonnaise	0		Mysticality Percent: +10, Experience: +2, Cold Spell Damage: +10, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	squat baby bodyguard	0		
-11632	maroon twirling Doll Moll violin case	0		
+11632	twirling maroon Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
-11634	skewed jittery tattoo gun	0		
+11634	jittery skewed tattoo gun	0		
 11635	practically non-alcoholic drinkable Colera Peste Nebbiolo	1	good	
 11636	twirling longbox of Batfellow comics	0		
 11637	wobbly Thwaitgold shield bug statuette	0		
@@ -11504,7 +11504,7 @@
 11649	ruddy bembershoot	0		Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2024-09"
 11650	stale wheel of camembert	3	decent	Last Available: "2024-09"
 11651	censurious frightening toasty hat of remembering	0		Hot Damage: +5, Spooky Damage: +5, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-09"
-11652	lime green jittery throwin' ember	0		Last Available: "2024-09"
+11652	jittery lime green throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
 11654	embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
@@ -11526,8 +11526,8 @@
 11671	coward's photo booth supply list of the scaredy-cat	0		Monster Level: -35, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	yellow peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	spinning tie-dye headband	0		
-11674	half-sized spoiled bouncing whirled peas	2	crappy	Last Available: "2024-11"
-11675	flavorless massive peaza	6	decent	Last Available: "2024-11"
+11674	spoiled half-sized bouncing whirled peas	2	crappy	Last Available: "2024-11"
+11675	massive flavorless peaza	6	decent	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	dried drenchrome 2.0	1		Last Available: "2025-12"
 11678	twisted spinning gray Synapse Blaster	1		Effect: "Buzzard Breath", Effect Duration: 10, Last Available: "2025-12"
@@ -11535,8 +11535,8 @@
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	vacuum-sealed pea brittle	0		Effect: "Gummi-Grin", Effect Duration: 65, Last Available: "2024-11"
-11683	drinkable watered-down lime green peasco	2	good	Last Available: "2024-11"
-11684	thick delicious blurry upside-down piece of cake	5	awesome	Last Available: "2024-11"
+11683	watered-down drinkable lime green peasco	2	good	Last Available: "2024-11"
+11684	thick delicious upside-down blurry piece of cake	5	awesome	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	blurry Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	skewed TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	shaking occult governor's daughter's pearl hairpin	0		Spell Damage Percent: +25, Last Available: "2024-12"
 11699	upside-down harpoon	0		Last Available: "2024-12"
 11700	lion tamer's chili powder cutlass	0		Experience (familiar): +2, Last Available: "2024-12"
-11701	jumbo normal Aztec tamale	5	good	Last Available: "2024-12"
+11701	normal jumbo Aztec tamale	5	good	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	tumbling pet rock	0		Last Available: "2024-12"
 11704	groggles of horror	0		Spooky Spell Damage: +25, Last Available: "2024-12"
@@ -11574,7 +11574,7 @@
 11719	spinning Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	decent miniature blinking coney haunch	2	good	Last Available: "2024-12"
+11722	miniature decent blinking coney haunch	2	good	Last Available: "2024-12"
 11723	chilled denatured dark chocolate egg	0		Effect: "Tiki Toughness", Effect Duration: 19, Last Available: "2024-12"
 11724	perfectly mixed moai toai	3	EPIC	
 11725	wobbly supercharged personal trainer's stylish moaiball	0		Moxie: +25, Experience Percent (Muscle): +10, Maximum MP Percent: +30, Last Available: "2024-12"
@@ -11585,7 +11585,7 @@
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
 11731	stylish military orb of bravery	0		Moxie: +25, Spooky Resistance: +5, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	quadruple-quantum bouncing tumbling rum ball	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 19
-11733	skewed maroon gravy skin	0		Last Available: "2024-12"
+11733	maroon skewed gravy skin	0		Last Available: "2024-12"
 11734	beefy gravyskin hat of the brute	0		Muscle: +10, Muscle Percent: +30, Last Available: "2024-12"
 11735	rosy-cheeked brawny gravyskin buckler	0		Muscle Percent: +20, Maximum HP Percent: +30, Damage Reduction: 7, Last Available: "2024-12"
 11736	purple chilly boxer's gravyskin skirt	0		Muscle Percent: +10, Cold Damage: +5, Last Available: "2024-12"
@@ -11603,38 +11603,38 @@
 11748	drinkable fortified Irish eggnog	5	good	Last Available: "2024-12"
 11749	hand-crafted watered-down canteen of jungle juice	2	EPIC	Last Available: "2024-12"
 11750	drinkable turchucken	3	good	Last Available: "2024-12"
-11751	perfectly mixed boozy green mechanically-mulled cider	5	EPIC	Last Available: "2024-12"
-11752	fancy drinkable fortified holiday trip around the world	5	good	Effect: "Dirge of Dreadfulness", Effect Duration: 30, Last Available: "2024-12"
-11753	enchanted bland maroon chocolate ostrich egg	4	decent	Effect: "Wallflowering", Effect Duration: 30, Last Available: "2024-12"
-11754	half-sized spoiled beef and cabbage	2	crappy	Last Available: "2024-12"
+11751	boozy perfectly mixed green mechanically-mulled cider	5	EPIC	Last Available: "2024-12"
+11752	drinkable fortified fancy holiday trip around the world	5	good	Effect: "Dirge of Dreadfulness", Effect Duration: 30, Last Available: "2024-12"
+11753	bland enchanted maroon chocolate ostrich egg	4	decent	Effect: "Wallflowering", Effect Duration: 30, Last Available: "2024-12"
+11754	spoiled half-sized beef and cabbage	2	crappy	Last Available: "2024-12"
 11755	immense stale candy rations	8	decent	Last Available: "2024-12"
-11756	diet flavorless double-candied yams	1	decent	Last Available: "2024-12"
+11756	flavorless diet double-candied yams	1	decent	Last Available: "2024-12"
 11757	stale Christmas ham	4	decent	Last Available: "2024-12"
 11758	stale holiday smorgasbord	4	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	Temple Grandin's bejazzled eyepatch	0		Familiar Weight: +7, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	upside-down ghostly How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	huge Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	purple Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	mirror Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	ghostly upside-down How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	huge Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	purple Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	mirror Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	padded dangerous brawny egg gun of Tarzan	0		Muscle Percent: +20, Experience (Muscle): +3, Weapon Damage: +10, Damage Absorption: +20, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	fireproof sharpshooter's wholesome sinister army helmet	0		Spell Damage: +10, Maximum HP Percent: +10, Critical Hit Percent: +10, Hot Resistance: +3, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	blinking napkin	0		Last Available: "2024-12"
 11776	moldy yellow Thanksgiving ration	3	crappy	Last Available: "2024-12"
-11777	delicious high-proof Easter eggnog	8	awesome	Last Available: "2024-12"
+11777	high-proof delicious Easter eggnog	8	awesome	Last Available: "2024-12"
 11778	compressed clovermint	1		Effect: "Thunderheart", Effect Duration: 50, Last Available: "2024-12"
 11779	nasty dance instructor's thinker's nylon Christmas stockings of incineration	0		Mysticality: +10, Experience Percent (Moxie): +10, Hot Spell Damage: +50, Stench Damage: +5, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	adjusted skewed deviled candy egg	0		Effect: "Purpose", Effect Duration: 59, Last Available: "2024-12"
-11782	bouncing yellow McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
+11782	yellow bouncing McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	wobbly censurious McHugeLarge duffel bag of vim and vigor	0		Maximum HP Percent: +50, Sleaze Resistance: +3, Last Available: "2025-01"
 11784	reassuring Annie Oakley's McHugeLarge left pole of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +20, Spooky Resistance: +1, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
 11785	strapping McHugeLarge right pole of bravery of the sweet-tooth	0		Muscle: +5, Spooky Resistance: +5, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
@@ -11642,7 +11642,7 @@
 11787	sinister McHugeLarge right ski of the blizzard	0		Spell Damage: +10, Cold Spell Damage: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	cyan 0	0		Last Available: "2025-12"
-11790	pickled wobbly twirling green eXpand	1		Last Available: "2025-12"
+11790	pickled green wobbly twirling eXpand	1		Last Available: "2025-12"
 11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
@@ -11690,7 +11690,7 @@
 11835	maroon shame coil	0		
 11836	jittery spinning new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
-11838	jittery gray heat arc	0		
+11838	gray jittery heat arc	0		
 11839	scrape	0		
 11840	phantom digit	0		
 11841	foul line	0		
@@ -11718,7 +11718,7 @@
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	tolerable pint of Leprechaun Stout	3	good	Last Available: "2025-03"
 11865	vaporized skewed huge olive phosphor traces	1		Effect: "Ghostly Shell", Effect Duration: 50, Last Available: "2025-03"
-11866	fuchsia huge crafting plans	0		Last Available: "2025-03"
+11866	huge fuchsia crafting plans	0		Last Available: "2025-03"
 11867	purple Book of Irony	0		Skill: "Generate Irony"
 11868	squat spoon	0		
 11869	unironic knife	0		
@@ -11729,7 +11729,7 @@
 11874	stale super-sized small beer brat	5	decent	Last Available: "2025-03"
 11875	diet moldy fuchsia peach pie	1	crappy	Last Available: "2025-03"
 11876	miniature moldy incredible mini-pizza	2	crappy	Last Available: "2025-03"
-11877	artisanal boozy ghostly Divine sidecar	5	EPIC	Last Available: "2025-03"
+11877	boozy artisanal ghostly Divine sidecar	5	EPIC	Last Available: "2025-03"
 11878	artisanal upside-down gray tangarita sidecar	4	EPIC	Last Available: "2025-03"
 11879	weak tolerable gimlet sidecar	2	good	Last Available: "2025-03"
 11880	triple-distilled hand-crafted vodka stratocaster sidecar	7	EPIC	Last Available: "2025-03"
@@ -11774,7 +11774,7 @@
 11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	wobbly flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
-11922	bouncing olive yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
+11922	olive bouncing yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
 11923	exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
 11924	resourceful quilted Axis helmet	0		Damage Absorption: +40, Maximum MP: +50
 11925	ghostly gravedigger's Axis fatigues of the early riser	0		Spooky Damage: +10, Adventures: +7
@@ -11783,13 +11783,13 @@
 11928	really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	shaking chocolate rations	0		
-11931	cyan spinning nice nylon stockings	0		
+11931	spinning cyan nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	sizzling beefcake's Allied Radio Backpack of chilblains	0		Muscle: +25, Cold Damage: +25, Hot Damage: +10, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	tumbling orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	moldy diet Skeleton Wars rations	1	crappy	
+11937	diet moldy Skeleton Wars rations	1	crappy	
 11938	perfectly mixed skeleton war fuel can	3	EPIC	
 11939	shaking skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11805,7 +11805,7 @@
 11950	zippy time cop top hat	0		Initiative: +20, Last Available: "2025-08"
 11951	blurry Stock Certificate	0		Last Available: "2025-08"
 11952	twisted mixed berry jelly	1		Last Available: "2025-08"
-11953	immense bland skewed toast with mixed berry jelly	6	decent	Last Available: "2025-08"
+11953	bland immense skewed toast with mixed berry jelly	6	decent	Last Available: "2025-08"
 11954	decent cup of sugar	3	good	Last Available: "2025-08"
 11955	delicious Susie's cupcake	3	awesome	Last Available: "2025-08"
 11956	skewed clock	0		Last Available: "2025-08"
@@ -11841,7 +11841,7 @@
 12051	tumbling knucklebone	0		
 12052	acceptable Smoking Pope	3	good	
 12053	spoiled prize turkey	4	crappy	
-12054	compressed bouncing blue tumbling medicinal gruel	1		
+12054	compressed blue tumbling bouncing medicinal gruel	1		
 12055	yummy snack-sized blurry full-sized pumpkin pie	2	awesome	Last Available: "2025-11"
 12056	weak drinkable green vodka cranberry sauce	2	good	Last Available: "2025-11"
 12057	flattened gray yammed candy	0		Effect: "Here's Mud in Your Eye", Effect Duration: 59, Last Available: "2025-11"
@@ -11879,7 +11879,7 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	spinning extra-thick Crimbo sweater of Leguizamo	0		Monster Level: +20, Last Available: "2025-12"
 12123	huge The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	mediocre irresponsibly strong spinning blinking Steve Abrams' Holiday Sampler Beer	10	decent	Last Available: "2025-12"
+12124	mediocre irresponsibly strong blinking spinning Steve Abrams' Holiday Sampler Beer	10	decent	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	tolerable bottle of prize-winning rum	3	good	Last Available: "2025-12"
 12127	Sherlock's lion tamer's extremely unsafe Santa-Slayer medal	0		Weapon Damage Percent: +100, Experience (familiar): +2, Item Drop: +25, Single Equip, Last Available: "2025-12"
@@ -11896,9 +11896,9 @@
 12138	fistbone of Calamity Jane of doom of the sweet-tooth	0		Critical Hit Percent: +15, Spooky Spell Damage: +50, Candy Drop: +100, Last Available: "2025-12"
 12139	beefcake's burnt bone belt of horror of the glutton	0		Muscle: +25, Spooky Spell Damage: +25, Food Drop: +100, Single Equip, Last Available: "2025-12"
 12140	aromatic scorched skull trophy	0		Stench Resistance: +1, Last Available: "2025-12"
-12141	spoiled immense wing bone	8	crappy	Last Available: "2025-12"
-12142	watered-down hand-crafted special gray weak skeleton venom	2	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2025-12"
-12143	modified olive spinning baked bone meal	1		Effect: "Oleaginous Soles", Effect Duration: 40, Last Available: "2025-12"
+12141	immense spoiled wing bone	8	crappy	Last Available: "2025-12"
+12142	watered-down special hand-crafted gray weak skeleton venom	2	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2025-12"
+12143	modified spinning olive baked bone meal	1		Effect: "Oleaginous Soles", Effect Duration: 40, Last Available: "2025-12"
 12144	stylish plastic skeleton rib cage	0		Moxie: +25, Last Available: "2025-12"
 12145	mirror plastic skeleton skull of the pedagogue	0		Experience: +3, Last Available: "2025-12"
 12146	energetic plastic skeleton Crimbo hat	0		Maximum MP Percent: +20, Last Available: "2025-12"
@@ -11926,16 +11926,16 @@
 12168	pulsating tumbling deadly Rosewater's vermiculite shield	0		Mysticality Percent: +30, Weapon Damage: +5, Damage Reduction: 9, Last Available: "2025-12"
 12169	wicked ship's lantern	0		Spell Damage: +5, Last Available: "2025-12"
 12170	lightning-fast Socratic heat-resistant harpoon pistol	0		Experience (Mysticality): +1, Initiative: +40, Last Available: "2025-12"
-12171	half-sized stale traditional gingerloaf	2	decent	Last Available: "2025-12"
+12171	stale half-sized traditional gingerloaf	2	decent	Last Available: "2025-12"
 12172	bad Scotch and eggnog	3	decent	Last Available: "2025-12"
 12173	denatured counterskeleton elixir	0		Effect: "Saucefingers", Effect Duration: 66, Last Available: "2025-12"
 12174	lousy &quot;salvaged&quot; wine	4	decent	Last Available: "2025-12"
 12175	upside-down The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	delicious snack-sized wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
+12177	snack-sized delicious wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
 12178	polarized blurry gummi fingerbone	0		Effect: "Bonelording", Effect Duration: 50
 12179	miser's scandalous glimmering crystal	0		Sleaze Damage: +5, Meat Drop: +10, Last Available: "2025-12"
-12180	green twirling mirror boxed Heartstone	0		Free Pull, Last Available: "2026-02"
+12180	mirror twirling green boxed Heartstone	0		Free Pull, Last Available: "2026-02"
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
@@ -11979,29 +11979,29 @@
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	moldy tiny can of tuna	1	crappy	
 12227	rotten alien salad	3	crappy	
-12228	huge spoiled ratbatatouille	9	crappy	
+12228	spoiled huge ratbatatouille	9	crappy	
 12229	super-sized rotten onigiri	5	crappy	
 12230	moldy crudit&eacute;s	3	crappy	
 12231	spoiled sauced mutton	3	crappy	
 12232	moldy red mirror hot honey ant	4	crappy	
 12233	normal yellow tomb aspic	4	good	
 12234	decent lime green later tots	4	good	
-12235	bite-sized normal Frutti di Scatoletta	1	good	Last Available: "2026-05"
-12236	jumbo fancy flavorless Pesto alla Marziano	5	decent	Effect: "Ancient Protected", Effect Duration: 20, Last Available: "2026-05"
-12237	snack-sized stale twirling Arrattabbattabiata	2	decent	Last Available: "2026-05"
+12235	normal bite-sized Frutti di Scatoletta	1	good	Last Available: "2026-05"
+12236	fancy jumbo flavorless Pesto alla Marziano	5	decent	Effect: "Ancient Protected", Effect Duration: 20, Last Available: "2026-05"
+12237	stale snack-sized twirling Arrattabbattabiata	2	decent	Last Available: "2026-05"
 12238	rotten Orzo di Riso	3	crappy	Last Available: "2026-05"
 12239	flavorless Pasta Grimavera	3	decent	Last Available: "2026-05"
 12240	tasty upside-down Linguini Ubriacapa	3	awesome	Last Available: "2026-05"
 12241	delicious Formica e Pepe	3	awesome	Last Available: "2026-05"
-12242	stale low-calorie Tubetto Gelatto	1	decent	Last Available: "2026-05"
+12242	low-calorie stale Tubetto Gelatto	1	decent	Last Available: "2026-05"
 12243	tasty teal Gnocci Domani	3	awesome	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	tumbling scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	executive boxer's Space Soldier Helmet	0		Muscle Percent: +10, Meat Drop: +40
-12253	tiny stale fancy premium turkey leg	1	decent	Effect: "Tingly Elbows", Effect Duration: 10
-12254	irresponsibly strong delicious lime green styrofoam cup of mead	8	awesome	
+12253	tiny fancy stale premium turkey leg	1	decent	Effect: "Tingly Elbows", Effect Duration: 10
+12254	delicious irresponsibly strong lime green styrofoam cup of mead	8	awesome	
 12255	fireproof sword	0		Hot Resistance: +3
 12256	staff of the empath	0		Familiar Weight: +5
 12257	blinking Jim Carey's lute	0		Monster Level: +25
@@ -12020,23 +12020,23 @@
 12270	flame-retardant smooth Portable Laughing Stock of extreme caution	0		Moxie: +15, Monster Level: -25, Hot Resistance: +1, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	wobbly fireproof gravedigger's studded Staff of Anachronistic Churning	0		Damage Absorption: +80, Spooky Damage: +10, Hot Resistance: +3
 12272	spoiled jumbo classic banana	5	crappy	Last Available: "2026-07"
-12273	fancy huge normal watermelon	7	good	Effect: "Empathy", Effect Duration: 25, Last Available: "2026-07"
+12273	normal fancy huge watermelon	7	good	Effect: "Empathy", Effect Duration: 25, Last Available: "2026-07"
 12274	decent quince	3	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	spoiled classic banana pie	3	crappy	Last Available: "2026-07"
 12278	unsweetened diffused essential banana decoction	0		Effect: "Happy Trails", Effect Duration: 62, Last Available: "2026-07"
 12279	frozen alkaline cold-filtered wobbly banana quintessence	0		Effect: "Spore-Wreathed", Effect Duration: 49, Last Available: "2026-07"
-12280	aged irresponsibly strong Aesop Daiquiri	8	awesome	Last Available: "2026-07"
+12280	irresponsibly strong aged Aesop Daiquiri	8	awesome	Last Available: "2026-07"
 12281	perfectly mixed watered-down Monkey Congress	2	super EPIC	Last Available: "2026-07"
 12282	normal watermelon pie	4	good	Last Available: "2026-07"
 12283	polarized narrow concentrated watermelon juice	0		Effect: "Techno Bliss", Effect Duration: 33, Last Available: "2026-07"
 12284	adjusted jittery Aqua Citrulanatae	0		Effect: "Human-Penguin Hybrid", Effect Duration: 43, Last Available: "2026-07"
 12285	drinkable Melonegroni	4	good	Last Available: "2026-07"
 12286	acceptable practically non-alcoholic yellow Melonade Spritz	1	good	Last Available: "2026-07"
-12287	rotten gigantic blue quince pie	7	crappy	Last Available: "2026-07"
+12287	gigantic rotten blue quince pie	7	crappy	Last Available: "2026-07"
 12288	deionized blinking quince quaff	0		Effect: "Your Favorite Flavor", Effect Duration: 45, Last Available: "2026-07"
-12289	alkaline improved purple skewed Quickquince	0		Effect: "Bark of the Dog", Effect Duration: 56, Last Available: "2026-07"
+12289	alkaline improved skewed purple Quickquince	0		Effect: "Bark of the Dog", Effect Duration: 56, Last Available: "2026-07"
 12290	hand-crafted Quiskey Sour	4	EPIC	Last Available: "2026-07"
 12291	artisanal Quincea&ntilde;era Cooler	3	EPIC	Last Available: "2026-07"
 12292	practically non-alcoholic hand-crafted Roth IPA	1	EPIC	Last Available: "2026-08"
@@ -12052,13 +12052,13 @@
 12302	olive bull tattoo	0		Last Available: "2026-08"
 12303	spinning blinking upside-down purple MacGyver's rock-hard 401k ring	0		Damage Reduction: 5, Maximum MP: +100, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
-12305	ionized aerosolized quantum squat pulsating invisible hand	0		Effect: "Mystic Circle", Effect Duration: 41, Last Available: "2026-08"
+12305	ionized aerosolized quantum pulsating squat invisible hand	0		Effect: "Mystic Circle", Effect Duration: 41, Last Available: "2026-08"
 12306	enhanced magnetized circle of overdraft protection scroll	0		Effect: "Permafrosty", Effect Duration: 20, Last Available: "2026-08"
 12307	irradiated polarized maroon mint	0		Effect: "Heart of Yellow", Effect Duration: 47, Last Available: "2026-08"
-12308	blinking cyan savings bondo	0		Last Available: "2026-08"
+12308	cyan blinking savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	dehydrated maroon toxic asset	1		Effect: "Gummibrain", Effect Duration: 30, Last Available: "2026-08"
 12311	compressed intangible asset	1		Last Available: "2026-08"
 12312	vaporized liquid asset	1		Last Available: "2026-08"
 12313	bouncing shaking gross prophet chrysalis	0		Last Available: "2026-08"
-12314	green huge cast entrails	0		Familiar Weight: +5
+12314	huge green cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Accordion_Thief_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wombat_cafe_booze.txt
@@ -1,13 +1,13 @@
 -1	lousy Petite Porter	4	decent	
 -2	bad Scrawny Stout	4	decent	
--3	distilled artisanal ghostly Infinitesimal IPA	5	EPIC	
+-3	artisanal distilled ghostly Infinitesimal IPA	5	EPIC	
 -4	perfectly mixed eggnogtini	3	EPIC	
 -5	lousy candycaine	3	decent	
--6	aged weak enchanted fuchsia braincracker sweet	2	awesome	
--16	triple-distilled smooth purple shaking fermented honey	6	awesome	
+-6	enchanted aged weak fuchsia braincracker sweet	2	awesome	
+-16	triple-distilled smooth shaking purple fermented honey	6	awesome	
 -17	artisanal moons-shine	4	EPIC	
 -18	watered-down smooth gin	2	awesome	
--19	lousy triple-distilled ecto-nog	8	decent	
+-19	triple-distilled lousy ecto-nog	8	decent	
 -20	drinkable cyan hot toady	4	good	
 -21	practically non-alcoholic artisanal twirling hot choculate	1	EPIC	
 -49	bad fuchsia Cyder	4	decent	
@@ -20,14 +20,14 @@
 -71	tolerable spirit-forward Black and Tan and Red All Over	5	good	
 -72	tolerable Antarctic Ice Tea	3	good	
 -76	tolerable blurry CRIMBCO Ribbon Candy Schnapps	3	good	
--77	practically non-alcoholic smooth CRIMBCO Egg Substitute Nog Substitute	1	awesome	
+-77	smooth practically non-alcoholic CRIMBCO Egg Substitute Nog Substitute	1	awesome	
 -78	irresponsibly strong hand-crafted CRIMBCO Extreme Braincracker Sour	7	EPIC	
--82	mediocre fancy Horseradish-infused Vodka	3	decent	
+-82	fancy mediocre Horseradish-infused Vodka	3	decent	
 -83	artisanal Jerkitini	3	EPIC	
 -84	hand-crafted yellow Desert Island Iced Tea	3	EPIC	
--88	acceptable watered-down tumbling purple Crimbo Saketini	2	good	
+-88	watered-down acceptable tumbling purple Crimbo Saketini	2	good	
 -89	acceptable Crimboku Drop	4	good	
--90	practically non-alcoholic artisanal spinning Flaming Crimbo Log	1	EPIC	
+-90	artisanal practically non-alcoholic spinning Flaming Crimbo Log	1	EPIC	
 -107	high-proof lousy gray Fortified Eggnog Slurry	10	decent	
 -108	hand-crafted squat Hot Buttered Rum	3	EPIC	
--109	triple-distilled delicious Spicy Hot Chocolate	9	awesome	
+-109	delicious triple-distilled Spicy Hot Chocolate	9	awesome	

--- a/data/TCRS/TCRS_Accordion_Thief_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Accordion_Thief_Wombat_cafe_food.txt
@@ -6,35 +6,35 @@
 -9	normal half-sized gingerbread stir-fry	2	good	
 -10	adequate miniature twigs and gravel	2	good	
 -11	flavorless shoots and leaves	3	decent	
--12	delicious special twirling bowl of unidentifiable goo	3	awesome	
+-12	special delicious twirling bowl of unidentifiable goo	3	awesome	
 -13	half-sized moldy skewed gingerbread massacre	2	crappy	
 -14	spoiled It Came From Beyond Dessert	3	crappy	
 -15	stale vampire cake	3	decent	
 -52	spoiled thick bouncing Soylent Red and Green	5	crappy	
 -53	moldy Disc-Shaped Nutrition Unit	3	crappy	
 -54	moldy Gingerborg Hive	3	crappy	
--61	moldy shaking wobbly Candy Cane Surprise	4	crappy	
--62	enchanted big decent Grimdrop Chow Mein	5	good	
+-61	moldy wobbly shaking Candy Cane Surprise	4	crappy	
+-62	big decent enchanted Grimdrop Chow Mein	5	good	
 -63	toothsome teal Grimgerbread House	4	awesome	
 -67	huge normal Caviar Carbonara	7	good	
 -68	rotten Halibut Alfredo	4	crappy	
--69	snack-sized normal ghostly red Red Herring Velvet Cake	2	good	
+-69	snack-sized normal red ghostly Red Herring Velvet Cake	2	good	
 -73	bite-sized rotten fancy CRIMBCO Reconstituted Gruel	1	crappy	
--74	decent half-sized fuchsia bouncing New and Improved CRIMBCO Reconstituted Gruel	2	good	
+-74	half-sized decent bouncing fuchsia New and Improved CRIMBCO Reconstituted Gruel	2	good	
 -75	normal twirling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	good	
 -79	decent half-sized Brussels Sprout Stir-Fry	2	good	
 -80	adequate Carrot, Cabbage, and Kale Pizza	4	good	
 -81	adequate Turnip and Rutabaga Pie	4	good	
 -85	flavorless Rainbow Spider Fun Roll	4	decent	
--86	delicious small Vegas Volcano Lava Roll	2	awesome	
--87	thick spoiled Crazy Dragon Shogun Buddha Roll	5	crappy	
--92	spoiled low-calorie basic hot dog	1	crappy	
+-86	small delicious Vegas Volcano Lava Roll	2	awesome	
+-87	spoiled thick Crazy Dragon Shogun Buddha Roll	5	crappy	
+-92	low-calorie spoiled basic hot dog	1	crappy	
 -93	bland savage macho dog	4	decent	
 -94	bland one with everything	3	decent	
 -95	yummy teal sly dog	4	awesome	
 -96	bland devil dog	4	decent	
--97	spoiled fancy chilly dog	3	crappy	
--98	stale enchanted tumbling ghost dog	3	decent	
+-97	fancy spoiled chilly dog	3	crappy	
+-98	enchanted stale tumbling ghost dog	3	decent	
 -99	moldy big green junkyard dog	5	crappy	
 -100	bland wet dog	3	decent	
 -101	special adequate sleeping dog	4	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Blender.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Blender.txt
@@ -24,7 +24,7 @@
 25	green meat paste	0		
 26	Dolphin King's map	0		
 27	spider web	0		
-28	bouncing green blinking really spider web	0		
+28	green blinking bouncing really spider web	0		
 29	really really spider web	0		
 30	rock	0		
 31	seal-toothed rock	0		
@@ -57,7 +57,7 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	huge flame-wreathed Mace of the Tortoise	0		Hot Spell Damage: +10, Class: "Turtle Tamer"
-61	adequate special blue fortune cookie	4	good	Effect: "Stemonitis Storm", Effect Duration: 45
+61	special adequate blue fortune cookie	4	good	Effect: "Stemonitis Storm", Effect Duration: 45
 62	skewed flame-wreathed oriole-feather headdress	0		Hot Spell Damage: +10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -120,7 +120,7 @@
 121	shaking sprocket assembly	0		
 122	cog and sprocket assembly	0		
 123	mirror Gnollish flyswatter	0		
-124	ghostly wobbly empty meat tank	0		
+124	wobbly ghostly empty meat tank	0		
 125	full meat tank	0		
 126	jittery meat engine	0		
 127	blinking ribald Gnollish autoplunger	0		Sleaze Damage: +10
@@ -135,7 +135,7 @@
 136	tires	0		
 137	green dope wheels	0		
 138	ice-cold six-pack	0		
-139	spinning bouncing valuable trinket	0		
+139	bouncing spinning valuable trinket	0		
 140	wobbly dingy planks	0		
 141	dingy dinghy	0		
 142	tumbling anticheese	0		
@@ -157,7 +157,7 @@
 158	Gnollish pie tin	0		
 159	jittery wad of dough	0		
 160	pie crust	0		
-161	miniature stale ghuol egg	2	decent	
+161	stale miniature ghuol egg	2	decent	
 162	moldy teal ghuol egg quiche	3	crappy	
 163	tumbling steel-toed skeleton bone	0		Damage Reduction: 9
 164	smart skull	0		
@@ -176,23 +176,23 @@
 177	fuchsia brainy skull	0		
 178	detective skull	0		
 179	normal chorizo taco	4	good	
-180	acceptable practically non-alcoholic ice-cold fotie	1	good	
+180	practically non-alcoholic acceptable ice-cold fotie	1	good	
 181	upside-down baseball	0		
 182	green batgut	0		
 183	bat wing	0		
 184	wobbly briefcase	0		
 185	fat stacks of cash	0		
 186	bean	0		
-187	red tumbling loose teeth	0		
+187	tumbling red loose teeth	0		
 188	pulsating bat guano	0		
 189	guano coffee cup	0		
 191	squat hardy batskin belt	0		Maximum HP: +50
 192	batskin belt	0		
-193	ghostly narrow birthday candle	0		
+193	narrow ghostly birthday candle	0		
 194	wobbly dog trainer's Mr. Accessory	0		Experience (familiar): +1, Softcore Only
 195	jittery razor-sharp eXtreme nose ring	0		Weapon Damage Percent: +25
 196	bouncing disassembled clover	0		
-197	tumbling maroon rat whisker	0		
+197	maroon tumbling rat whisker	0		
 198	jittery rat appendix	0		
 199	ring of Tarzan	0		Experience (Muscle): +3
 200	stale rat appendix kabob	4	decent	
@@ -201,7 +201,7 @@
 203	herbs	0		
 204	flavorless carob chunk cookies	3	decent	
 205	mirror secret blend of herbs and spices	0		
-206	jittery blurry piercing post	0		
+206	blurry jittery piercing post	0		
 207	hippy herbal tea	1	good	
 208	patchouli incense stick	0		
 209	wad of tofu	0		
@@ -232,8 +232,8 @@
 234	maroon mirror Doc Galaktik's Homeopathic Elixir	0		
 235	upside-down lard-coated baleful Bigger Bugfinder Blade	0		Spell Damage: +25, Sleaze Spell Damage: +25
 236	huge Queue Du Coq cocktailcrafting kit	0		
-237	acceptable practically non-alcoholic bottle of gin	1	good	
-238	artisanal fancy weak bottle of vodka	2	EPIC	Effect: "Inscrutable exoskeleton", Effect Duration: 35
+237	practically non-alcoholic acceptable bottle of gin	1	good	
+238	weak fancy artisanal bottle of vodka	2	EPIC	Effect: "Inscrutable exoskeleton", Effect Duration: 35
 239	grievous brainy Orcish baseball cap	0		Mysticality: +5, Weapon Damage Percent: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	electrified Orcish cargo shorts of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	curative Orcish frat-paddle	0		HP Regen Min: 3, HP Regen Max: 5
@@ -244,35 +244,35 @@
 246	moldy tomato	3	crappy	
 247	shaking fermenting powder	0		
 248	smooth tumbling salty dog	4	awesome	
-249	smooth weak bloody mary	2	awesome	
+249	weak smooth bloody mary	2	awesome	
 250	lousy screwdriver	3	decent	
-251	artisanal extra-dry martini	5	EPIC	
-252	watered-down perfectly mixed red bloody beer	2	EPIC	
+251	extra-dry artisanal martini	5	EPIC	
+252	perfectly mixed watered-down red bloody beer	2	EPIC	
 253	mediocre shot of schnapps	3	decent	
 254	distilled aged jittery shot of grapefruit schnapps	5	awesome	
 255	lousy watered-down fine wine	2	decent	
 256	artisanal shot of tomato schnapps	3	EPIC	
-257	mediocre special watered-down extra-spicy bloody mary	2	decent	Effect: "Mighty Shout", Effect Duration: 35
+257	watered-down special mediocre extra-spicy bloody mary	2	decent	Effect: "Mighty Shout", Effect Duration: 35
 258	dense meat stack	0		
 259	snake skin	0		
 260	moldy miniature White Citadel fries	2	crappy	
-261	low-calorie toothsome White Citadel burger	1	awesome	
+261	toothsome low-calorie White Citadel burger	1	awesome	
 262	rotten narrow piece of wedding cake	4	crappy	
 263	stale chocolate chips	3	decent	
 264	spoiled chocolate chip cookies	3	crappy	
 265	ghostly huge cool satin pants	0		Moxie: +5, Familiar Effect: "atk, 2xPotato, cap 10"
-266	distilled drinkable spinning lightning	5	good	
+266	drinkable distilled spinning lightning	5	good	
 267	narrow dog trainer's mullet wig	0		Experience (familiar): +1, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	meat cowboy hat of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	forbidden sword	0		Spell Damage Percent: +50
 270	picket fence	0		
 271	compressed twirling barbell	1		Effect: "Creepin' Up on You", Effect Duration: 20
-272	mixed purple jittery skewed concentrated magicalness pill	1		
+272	mixed jittery purple skewed concentrated magicalness pill	1		
 273	twisted skewed moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	pickled blinking twirling extra-strength strongness elixir	1		
+277	pickled twirling blinking extra-strength strongness elixir	1		
 278	mixed jug-o-magicalness	1		Effect: "Norwhalloped", Effect Duration: 35
 279	vaporized lime green suntan lotion of moxiousness	1		
 280	wobbly Pick-O-Matic lockpicks	0		
@@ -297,8 +297,8 @@
 299	improved pickle-flavored chewing gum	0		Effect: "Texas Elegance", Effect Duration: 40
 300	denatured spinning jaba&ntilde;ero-flavored chewing gum	0		Effect: "Very Clean Teeth", Effect Duration: 34
 301	flat dough	0		
-302	moldy fancy Knob sausage	3	crappy	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 15
-303	small rotten skewed Knob mushroom	2	crappy	
+302	fancy moldy Knob sausage	3	crappy	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 15
+303	rotten small skewed Knob mushroom	2	crappy	
 304	yellow huge dry noodles	0		
 305	greasy Knob Goblin harem pants	0		Sleaze Spell Damage: +10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	dog trainer's Knob Goblin harem veil	0		Experience (familiar): +1, Familiar Effect: "5xLep, cap 2"
@@ -310,25 +310,25 @@
 312	smelly Knob Goblin visor	0		Stench Spell Damage: +10, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	wobbly boxer's Crown of the Goblin King	0		Muscle Percent: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	immense bland bean burrito	10	decent	
-315	half-sized spoiled bean burrito	2	crappy	
+315	spoiled half-sized bean burrito	2	crappy	
 316	half-sized delicious blue blurry insanely bean burrito	2	awesome	
 317	decent low-calorie bean burrito	1	good	
 318	spoiled bean burrito	4	crappy	
 319	huge moldy pulsating insanely bean burrito	8	crappy	
 320	decent bat haggis	3	good	
-321	enchanted adequate menudo	3	good	Effect: "Disco Inferno", Effect Duration: 50
-322	normal half-sized goat cheese	2	good	
-323	miniature enchanted bland upside-down plain pizza	2	decent	Effect: "Vented Spleen", Effect Duration: 5
+321	adequate enchanted menudo	3	good	Effect: "Disco Inferno", Effect Duration: 50
+322	half-sized normal goat cheese	2	good	
+323	enchanted bland miniature upside-down plain pizza	2	decent	Effect: "Vented Spleen", Effect Duration: 5
 324	rotten small blinking sausage pizza	2	crappy	
-325	enchanted flavorless small blue goat cheese pizza	2	decent	Effect: "Adventurer's Best Friendship", Effect Duration: 5
+325	small enchanted flavorless blue goat cheese pizza	2	decent	Effect: "Adventurer's Best Friendship", Effect Duration: 5
 326	decent mushroom pizza	3	good	
 327	goat	0		
-328	perfectly mixed triple-distilled olive bottle of whiskey	10	EPIC	
+328	triple-distilled perfectly mixed olive bottle of whiskey	10	EPIC	
 329	dangerous goat beard	0		Weapon Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	spinning glass of goat's milk	1	decent	
-331	spirit-forward hand-crafted fancy Canadian	5	EPIC	Effect: "Muscle Unbound", Effect Duration: 10
+331	spirit-forward fancy hand-crafted Canadian	5	EPIC	Effect: "Muscle Unbound", Effect Duration: 10
 332	delicious low-calorie ghostly lemon	1	awesome	
-333	toothsome tiny narrow lime	1	awesome	
+333	tiny toothsome narrow lime	1	awesome	
 334	maroon sabre teeth of temperance	0		Sleaze Resistance: +5
 335	sabre-toothed lime cub	0		
 336	double-paned consolation ribbon	0		Cold Resistance: +5
@@ -342,7 +342,7 @@
 344	Knob Goblin seltzer	0		
 345	narrow Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
-347	olive twirling Dyspepsi-Cola	0		
+347	twirling olive Dyspepsi-Cola	0		
 348	teal ninja mask of the detective	0		Item Drop: +20, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
 350	hot katana blade	0		
@@ -368,7 +368,7 @@
 370	asbestos stick	0		
 371	red asbestos crossbow string	0		
 372	chrome sword hilt	0		
-373	ghostly spinning chrome stick	0		
+373	spinning ghostly chrome stick	0		
 374	chrome crossbow string	0		
 375	linoleum meat stack	0		
 376	asbestos meat stack	0		
@@ -383,7 +383,7 @@
 385	chrome staff of James Dean of doom	0		Experience (Moxie): +3, Spooky Spell Damage: +50
 386	spinning knitted chrome crossbow of bravery	0		Cold Resistance: +3, Spooky Resistance: +5
 387	fuzzy dice	0		
-388	blue blurry yeti fur	0		
+388	blurry blue yeti fur	0		
 389	jittery meaty helmet turtle of the boozehound	0		Booze Drop: +100, Familiar Effect: "sleaze atk, 1xFairy, cap 17"
 390	green chaotic asbestos helmet turtle	0		Spell Critical Percent: +10, Familiar Effect: "hot atk, 1xFairy, cap 20"
 391	bouncing brawny linoleum helmet turtle	0		Muscle Percent: +20, Familiar Effect: "stench atk, 1xFairy, cap 25"
@@ -414,7 +414,7 @@
 416	teal safarrri hat of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "2xVolley, cap 22"
 417	ionized electrified narrow henna tattoo	0		Effect: "Eyes for Miles", Effect Duration: 18
 418	enhanced Ferrigno's Elixir of Power	0		Effect: "Innately Truthy", Effect Duration: 30
-419	warmed super-liquefied yellow blurry ghostly serum of sarcasm	0		Effect: "Sweet Taste", Effect Duration: 20
+419	warmed super-liquefied blurry yellow ghostly serum of sarcasm	0		Effect: "Sweet Taste", Effect Duration: 20
 420	concentrated blurry tomato juice of powerful power	0		Effect: "Booing Radly", Effect Duration: 29
 421	deionized extra-oxidized philter of phorce	0		Effect: "For Your Brain Only", Effect Duration: 24
 422	frozen flattened potion of potency	0		Effect: "Coated Arms", Effect Duration: 32
@@ -451,7 +451,7 @@
 453	sober pill	0		
 454	screwdriver	0		
 455	stale jumbo olive	3	decent	
-456	triple-distilled drinkable upside-down cyan dry martini	6	good	
+456	drinkable triple-distilled cyan upside-down dry martini	6	good	
 457	shaking ye olde golde frontes of incineration	0		Hot Spell Damage: +50, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
@@ -466,14 +466,14 @@
 468	tumbling ruby W	0		
 469	wussiness potion	0		
 470	hand-crafted Imp Ale	4	EPIC	
-471	special normal hot wing	3	good	Effect: "You Drank Fish Wine", Effect Duration: 15
+471	normal special hot wing	3	good	Effect: "You Drank Fish Wine", Effect Duration: 15
 472	diamond-studded cane of extreme caution	0		Monster Level: -25, Class: "Disco Bandit"
 473	crutch of the boozehound	0		Booze Drop: +100
 474	upside-down cast	0		
 475	yellow zippy mask of courage	0		Spooky Resistance: +3, Initiative: +20, Familiar Effect: "sleaze atk, 1xBarrr, cap 15"
-476	shaking fuchsia hellion cube	0		
+476	fuchsia shaking hellion cube	0		
 477	asbestos-lined Da Vinci's infernal insoles	0		Experience (Mysticality): +5, Hot Resistance: +5
-478	teal wobbly upside-down evil arch	0		
+478	wobbly teal upside-down evil arch	0		
 479	pulsating maroon dodecagram	0		
 480	box of birthday candles	0		
 481	lime green eldritch butterknife	0		
@@ -492,8 +492,8 @@
 494	spinning auspicious batblade	0		Item Drop: +10
 495	catgut	0		
 496	blue cat appendix	0		
-497	gray ghostly gnatwing	0		
-498	tiny delicious blinking skewed papaya	1	awesome	
+497	ghostly gray gnatwing	0		
+498	delicious tiny skewed blinking papaya	1	awesome	
 499	huge family-friendly denim axe of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +1
 500	shaking lime green Elf Farm Raffle ticket	0		
 501	small decent narrow Elfin shortbread	2	good	
@@ -524,7 +524,7 @@
 526	spinning Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
-529	blinking maroon fertilized ghuol egg	0		
+529	maroon blinking fertilized ghuol egg	0		
 530	magnetized spray paint	0		Effect: "Big Meat Big Prizes", Effect Duration: 52
 531	yellow nasty special sauce glove	0		Stench Damage: +5, Class: "Sauceror", Single Equip
 532	squat ladle of mystery of the sewer	0		Stench Damage: +25, Class: "Sauceror"
@@ -541,7 +541,7 @@
 543	bland skewed Trollhouse cookies	3	decent	
 544	baleful weightlifter's talons	0		Muscle: +15, Spell Damage: +25
 545	super-sized stale Spam Witch sammich	5	decent	
-546	upside-down teal meat vortex	0		
+546	teal upside-down meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
 549	30669 scroll	0		
@@ -549,7 +549,7 @@
 551	skewed 64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	adequate bite-sized pr0n cocktail	1	good	
+554	bite-sized adequate pr0n cocktail	1	good	
 555	Jeselnik's scorching drywall axe	0		Hot Damage: +25, Sleaze Damage: +25
 556	Pine-Fresh air freshener of the overflowing toilet	0		Stench Spell Damage: +50
 557	delicious whiskey and cola	3	awesome	
@@ -564,8 +564,8 @@
 566	squat teal studded bum cheek	0		Damage Absorption: +80, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	ghostly hermit script	0		
 568	stale Double Bacon Beelzeburger	3	decent	
-569	special small adequate Lord of the Flies-sized fries	2	good	Effect: "Corona de la Salsa", Effect Duration: 40
-570	small spoiled special Chicken Sandwich	2	crappy	Effect: "Mer-kindliness", Effect Duration: 40
+569	small special adequate Lord of the Flies-sized fries	2	good	Effect: "Corona de la Salsa", Effect Duration: 40
+570	small special spoiled Chicken Sandwich	2	crappy	Effect: "Mer-kindliness", Effect Duration: 40
 571	Jumbo Dr. Lucifer	1	EPIC	
 572	bland Children's Meal of the Damned	4	decent	
 573	normal noodles	4	good	
@@ -575,11 +575,11 @@
 577	rotten skewed pr0n m4nic0tti	3	crappy	
 578	toothsome Hell ramen	3	awesome	
 579	stale mirror boring spaghetti	3	decent	
-580	shaking blinking sauce of the ages	0		
+580	blinking shaking sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	upside-down Himalayan Hidalgo sauce	0		
 583	normal bite-sized fettucini Inconnu	1	good	
-584	tiny normal spaghetti with Skullheads	1	good	
+584	normal tiny spaghetti with Skullheads	1	good	
 585	bland twirling gnocchetti di Nietzsche	3	decent	
 586	energetic Samson's ridiculously huge sword	0		Experience (Muscle): +5, Maximum MP Percent: +20
 587	modified energized super-spiky hair gel	0		Effect: "Turtle Power", Effect Duration: 27
@@ -647,7 +647,7 @@
 649	jittery Crimbo hat of James Dean	0		Experience (Moxie): +3, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
 650	tumbling Oprah's Crimbo pants	0		Maximum MP Percent: +50, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	spinning exclusive ultra-rare item	0		Item Drop: +5
-652	upside-down fuchsia quantum egg	0		
+652	fuchsia upside-down quantum egg	0		
 653	intragalactic rowboat	0		
 654	star	0		
 655	wobbly line	0		
@@ -667,7 +667,7 @@
 669	bland ghuol guolash	3	decent	
 670	mansplainer's lihc face	0		Monster Level: +15, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	flame-retardant arcane researcher's grave robbing shovel	0		Experience Percent (Mysticality): +10, Hot Resistance: +1
-672	moldy jumbo mirror cranberries	5	crappy	
+672	jumbo moldy mirror cranberries	5	crappy	
 673	lousy upside-down vodka and cranberry	3	decent	
 674	delicious mirror teal whiskey	3	awesome	
 675	skull of the Bonerdagon of the bloodbag	0		Maximum HP: +100
@@ -676,9 +676,9 @@
 678	chest of the Bonerdagon	0		
 679	lousy ghostly roll in the hay	3	decent	
 680	bad blurry slap and tickle	4	decent	
-681	practically non-alcoholic artisanal slip 'n' slide	1	super ultra mega turbo EPIC	
+681	artisanal practically non-alcoholic slip 'n' slide	1	super ultra mega turbo EPIC	
 682	hand-crafted a sump'm sump'm	4	EPIC	
-683	aged special huge pulsating horizontal tango	3	awesome	Effect: "Clean-Shaven", Effect Duration: 10
+683	special aged huge pulsating horizontal tango	3	awesome	Effect: "Clean-Shaven", Effect Duration: 10
 684	artisanal pulsating pink pony	4	EPIC	
 685	yellow hardy brawny strapping Mr. Shirt	0		Muscle: +5, Muscle Percent: +20, Maximum HP: +50
 686	olive rock-hard knuckles	0		Damage Reduction: 5
@@ -716,11 +716,11 @@
 720	blinking Newton's porquoise necklace of doom	0		Experience (Mysticality): +3, Spooky Spell Damage: +50, Single Equip
 721	yellow deadly savvy porquoise bracelet	0		Mysticality Percent: +20, Weapon Damage: +5
 722	energetic medical-grade strapping porquoise ring	0		Muscle: +5, Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-723	adequate snack-sized Knoll mushroom	2	good	
+723	snack-sized adequate Knoll mushroom	2	good	
 724	tasty mushroom	3	awesome	
 725	one million meat pancakes	0		
 726	lard-coated huge mirror shard	0		Sleaze Spell Damage: +25
-727	bouncing blinking hedge maze puzzle	0		
+727	blinking bouncing hedge maze puzzle	0		
 728	hedge maze key	0		
 729	huge fishbowl	0		
 730	fishtank	0		
@@ -741,20 +741,20 @@
 746	stat script	0		
 747	red Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	flavorless thick fuchsia warm mushroom	5	decent	
+749	thick flavorless fuchsia warm mushroom	5	decent	
 750	decent miniature mushroom quesadilla	2	good	
 751	normal mirror cool mushroom	3	good	
 752	adequate cool mushroom casserole	4	good	
 753	bite-sized stale pointy mushroom	1	decent	
 754	decent pulsating cream of pointy mushroom soup	3	good	
-755	toothsome olive jittery mushroom	3	awesome	
-756	rotten miniature mushroom	2	crappy	
+755	toothsome jittery olive mushroom	3	awesome	
+756	miniature rotten mushroom	2	crappy	
 757	rotten upside-down wobbly mushroom	3	crappy	
-758	diet rotten ghost cucumber	1	crappy	
+758	rotten diet ghost cucumber	1	crappy	
 759	squat dill	0		
 760	mirror vinegar	0		
 761	brine	0		
-762	aged irresponsibly strong bouncing blinking especially salty dog	8	awesome	
+762	aged irresponsibly strong blinking bouncing especially salty dog	8	awesome	
 763	ghostly pickling solution	0		
 764	decent special spectral pickle	3	good	Effect: "You're High as a Crow, Marty", Effect Duration: 30
 765	purple briny vinegar	0		
@@ -778,33 +778,33 @@
 783	skewed 'Villa' document	0		
 784	artisanal Acqua Del Piatto Merlot	4	EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
-786	moldy super-sized strawberry	5	crappy	
+786	super-sized moldy strawberry	5	crappy	
 787	bad gray bottle of rum	3	decent	
 788	mediocre strawberry daiquiri	4	decent	
-789	fancy fortified drinkable rum and cola	5	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
+789	drinkable fancy fortified rum and cola	5	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
 790	aged blurry grog	3	awesome	
 791	prompt electrified Mafia bow tie	0		Adventures: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-10"
 792	blurry vibrating Golden Mr. Accessory	0		Maximum MP Percent: +10, Softcore Only
-793	aerosolized moist spinning blinking oil of stability	0		Effect: "Berry Experiential", Effect Duration: 54
-794	super-altered ghostly upside-down squat oil of slipperiness	0		Effect: "Slimily Sagacious", Effect Duration: 57
+793	aerosolized moist blinking spinning oil of stability	0		Effect: "Berry Experiential", Effect Duration: 54
+794	super-altered squat upside-down ghostly oil of slipperiness	0		Effect: "Slimily Sagacious", Effect Duration: 57
 795	perfectly mixed yellow Acque Luride Grezze Cabernet	3	super EPIC	Last Available: "2004-10"
 796	yellow family-friendly manspreader's sharpshooter's cement shoes	0		Critical Hit Percent: +10, Monster Level: +10, Sleaze Resistance: +1, Last Available: "2004-10"
 797	tolerable rockin' wagon	4	good	
 798	acceptable ocean motion	4	good	
-799	tolerable triple-distilled tumbling cyan fuzzbump	6	good	
-800	tasty low-calorie fuchsia poutine	1	awesome	
-801	fancy miniature normal Knob stir-fry	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 30
+799	triple-distilled tolerable tumbling cyan fuzzbump	6	good	
+800	low-calorie tasty fuchsia poutine	1	awesome	
+801	miniature normal fancy Knob stir-fry	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 30
 804	huge spoiled Knoll stir-fry	8	crappy	
 805	bland massive stir-fry	7	decent	
 806	adequate asparagus stir-fry	4	good	
 807	rotten olive stir-fry	3	crappy	
 808	moldy wobbly Knob sausage stir-fry	3	crappy	
 809	decent bat wing stir-fry	4	good	
-810	massive rotten rat appendix stir-fry	9	crappy	
+810	rotten massive rat appendix stir-fry	9	crappy	
 811	decent red tofu stir-fry	4	good	
-812	stale snack-sized special pr0n stir-fry	2	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 20
+812	snack-sized special stale pr0n stir-fry	2	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 20
 813	adequate Knob shells	4	good	
-814	thick rotten narrow b&auml;tzle	5	crappy	
+814	rotten thick narrow b&auml;tzle	5	crappy	
 815	normal gigantic ratini	9	good	
 816	flavorless snack-sized Knob stroganoff	2	decent	
 817	spoiled cyan menudo ravioli	3	crappy	
@@ -816,9 +816,9 @@
 823	cloudy potion	0		
 824	squat effervescent potion	0		
 825	blinking fizzy potion	0		
-826	upside-down pulsating dark potion	0		
+826	pulsating upside-down dark potion	0		
 827	green murky potion	0		
-828	twirling cyan baby killer bee	0		
+828	cyan twirling baby killer bee	0		
 829	olive anti-anti-antidote	0		
 830	bland royal jelly	3	decent	
 831	small box	0		
@@ -829,11 +829,11 @@
 836	bland mind flayer corpse	4	decent	
 837	hand-crafted Uovo Marcio Shiraz	3	super EPIC	Last Available: "2004-10"
 838	forbidden arcane researcher's Mafia stogie	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Last Available: "2004-10"
-839	tolerable boozy ghostly Maiali Sifilitici Pinot Noir	5	good	Last Available: "2004-10"
+839	boozy tolerable ghostly Maiali Sifilitici Pinot Noir	5	good	Last Available: "2004-10"
 840	twirling perfumed Mafia violin case of the businessman	0		Stench Resistance: +5, Meat Drop: +50, Last Available: "2004-10"
 841	lousy fancy huge tomato daiquiri	3	decent	Effect: "Go-Gone", Effect Duration: 10
-842	boozy bad purple beertini	5	decent	
-843	drinkable spirit-forward salty slug	5	good	
+842	bad boozy purple beertini	5	decent	
+843	spirit-forward drinkable salty slug	5	good	
 844	fortified perfectly mixed narrow papaya slung	5	EPIC	
 845	jittery Sherlock's MAHI fez	0		Item Drop: +25, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -871,14 +871,14 @@
 880	blurry disbelief suspenders of bravery	0		Spooky Resistance: +5
 881	lard-coated supportive bra	0		Sleaze Spell Damage: +25
 882	shaking Blatantly Canadian	0		
-883	spinning wobbly maple syrup	1	good	
+883	wobbly spinning maple syrup	1	good	
 884	sinister los chinos	0		Spell Damage: +10, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	skewed friendly axe	0		Familiar Weight: +3
 886	skewed leaflet	0		
 887	leaf	0		
 888	bouncing maple leaf	0		
 889	quilted balaclava	0		Damage Absorption: +40, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	flavorless snack-sized wobbly balaclava baklava	2	decent	
+890	snack-sized flavorless wobbly balaclava baklava	2	decent	
 891	thinker's Warehouse 23 bling	0		Mysticality: +10
 892	gray rosewater-soaked coward's Fonzie's bugbear-smiting sword	0		Experience (Moxie): +1, Monster Level: -20, Stench Resistance: +3
 893	artisanal jittery lumbering jack	4	EPIC	
@@ -887,11 +887,11 @@
 896	hardy supercool Mr. Accessory Jr.	0		Moxie Percent: +20, Maximum HP: +50, Softcore Only
 897	pulsating coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
-899	olive huge custom avatar form	0		Free Pull
+899	huge olive custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	strong mediocre huge Spasmi Dolorosi Del Rene Champagne	5	decent	Last Available: "2004-10"
+903	mediocre strong huge Spasmi Dolorosi Del Rene Champagne	5	decent	Last Available: "2004-10"
 904	miser's school Mafia knickerbockers of Gandalf of chilblains	0		Spell Critical Percent: +20, Cold Damage: +25, Meat Drop: +10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	warmed quantum Yummy Tummy bean	0		Effect: "Tremella Tremens", Effect Duration: 21
 906	cold-filtered wobbly Rock Pops	0		Effect: "Ghostly Shell", Effect Duration: 39
@@ -909,7 +909,7 @@
 918	knitted Radio Free Baseball Cap	0		Cold Resistance: +3, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	MacGyver's Radio Free Pants	0		Maximum MP: +100, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	dog trainer's Radio Free Foil	0		Experience (familiar): +1, Last Available: "2006-07"
-921	diet moldy radio button candy	1	crappy	
+921	moldy diet radio button candy	1	crappy	
 922	pulsating stiffened severed rocking horse head	0		Damage Reduction: 1
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -936,14 +936,14 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	mediocre tumbling martini	3	decent	Last Available: "2004-12"
-949	hand-crafted weak grogtini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
+949	weak hand-crafted grogtini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 950	drinkable cherry bomb	4	good	Last Available: "2004-12"
-951	green squat extra special Crimbo stocking	0		Last Available: "2004-12"
+951	squat green extra special Crimbo stocking	0		Last Available: "2004-12"
 952	skewed rosewater-soaked reassuring hockey mask	0		Spooky Resistance: +1, Stench Resistance: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	ruddy fez of etymology	0		Maximum HP Percent: +40, Familiar Effect: "1xLep, cap 30"
-956	rotten diet huge carob chunk noodles	1	crappy	
+956	diet rotten huge carob chunk noodles	1	crappy	
 957	adequate chorizo brownies	3	good	
 958	rotten huge chocolate and tomato pizza	8	crappy	
 959	tumbling skewed flange	0		
@@ -988,22 +988,22 @@
 1000	Meat maid	0		
 1002	skewed asbestos-lined Xlyinia's notebook	0		Hot Resistance: +5
 1003	blurry soda water	0		
-1004	weak drinkable bottle of tequila	2	good	
+1004	drinkable weak bottle of tequila	2	good	
 1005	perfectly mixed upside-down boxed wine	4	EPIC	
 1006	stale half-sized cherry	2	decent	
 1007	spinning hale coconut shell	0		Maximum HP: +20, Familiar Effect: "1xFairy, cap 7"
 1008	pulsating ice cubes of the ox	0		Muscle: +20
 1009	drinkable vodka martini	3	good	
-1010	fancy artisanal whiskey and soda	3	EPIC	Effect: "Quantum of Moxie", Effect Duration: 45
-1011	lousy practically non-alcoholic monkey wrench	1	decent	
-1012	bad triple-distilled tequila sunrise	6	decent	
-1013	weak bad margarita	2	decent	
-1014	tolerable irresponsibly strong strawberry wine	8	good	
+1010	artisanal fancy whiskey and soda	3	EPIC	Effect: "Quantum of Moxie", Effect Duration: 45
+1011	practically non-alcoholic lousy monkey wrench	1	decent	
+1012	triple-distilled bad tequila sunrise	6	decent	
+1013	bad weak margarita	2	decent	
+1014	irresponsibly strong tolerable strawberry wine	8	good	
 1015	weak drinkable spinning wine spritzer	2	good	
-1016	drinkable weak perpendicular hula	2	good	
-1017	delicious high-proof bouncing ducha de oro	6	awesome	
+1016	weak drinkable perpendicular hula	2	good	
+1017	high-proof delicious bouncing ducha de oro	6	awesome	
 1018	acceptable mirror calle de miel	3	good	
-1019	lousy special dry vodka martini	4	decent	Effect: "Blessing of the Hot Linguine", Effect Duration: 20
+1019	special lousy dry vodka martini	4	decent	Effect: "Blessing of the Hot Linguine", Effect Duration: 20
 1020	artisanal triple-distilled old-fashioned	8	EPIC	
 1021	high-proof hand-crafted tequila with training wheels	10	EPIC	
 1022	perfectly mixed tumbling sangria	3	EPIC	
@@ -1022,7 +1022,7 @@
 1035	baleful penguin skin buckler	0		Spell Damage: +25, Damage Reduction: 5
 1036	medical-grade yakskin buckler	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 5
 1037	gnauga hide buckler of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 5
-1038	polarized denatured ionized tumbling blinking Connery's Elixir of Audacity	0		Effect: "Big Flaming Whip", Effect Duration: 29
+1038	polarized denatured ionized blinking tumbling Connery's Elixir of Audacity	0		Effect: "Big Flaming Whip", Effect Duration: 29
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	mediocre twirling beer	4	decent	
 1042	shaking string of beads of the empath	0		Familiar Weight: +5
@@ -1057,7 +1057,7 @@
 1071	plastic oyster egg	0		
 1072	denatured off-white oyster egg	1		Effect: "Wise Spirit", Effect Duration: 20
 1073	boiled off-white oyster egg	1		
-1074	mixed olive huge off-white oyster egg	1		
+1074	mixed huge olive off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	modified shaking oyster egg	1		
 1077	altered oyster egg	1		Effect: "Lemon Enlightenment", Effect Duration: 5
@@ -1079,7 +1079,7 @@
 1093	clockwork counterclockwise dome	0		
 1094	fuchsia mirror clockwork sphere	0		
 1095	deactivated MicroMechaMech	0		
-1096	wobbly spinning clockwork endoskeleton	0		
+1096	spinning wobbly clockwork endoskeleton	0		
 1097	Samson's clockwork hat	0		Experience (Muscle): +5, Familiar Effect: "atk, 1xVolley, cap 20"
 1098	gray asbestos-lined clockwork trench coat	0		Hot Resistance: +5
 1099	grievous clockwork pants	0		Weapon Damage Percent: +50, Familiar Effect: "3xPotato, 1.5xGhuol, cap 20"
@@ -1101,7 +1101,7 @@
 1115	tasket	0		
 1116	huge annoying pitchfork	0		Monster Level: +5
 1117	avaricious frosty Stupid University Diploma of the pedagogue	0		Experience: +3, Cold Spell Damage: +10, Meat Drop: +30
-1118	jittery maroon shaking pregnant mushroom	0		
+1118	shaking maroon jittery pregnant mushroom	0		
 1119	blinking blinking pregnant mushroom	0		
 1120	twirling pregnant mushroom	0		
 1121	tumbling inexplicably rock	0		
@@ -1115,17 +1115,17 @@
 1129	up-at-dawn sequined fez	0		Adventures: +5, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
 1131	wobbly beet	0		Last Available: "2005-12"
-1132	bouncing upside-down Totally Gay Claymore	0		
+1132	upside-down bouncing Totally Gay Claymore	0		
 1133	blue shaking wobbly censurious star shirt	0		Sleaze Resistance: +3
 1134	cosmetics bag	0		
-1135	deionized ghostly spinning eyeliner	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 34
+1135	deionized spinning ghostly eyeliner	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 34
 1136	polymerized altered lipstick	0		Effect: "Strength of Ten Ettins", Effect Duration: 59
 1137	jittery weightlifter's bicycle chain of the sewer	0		Muscle: +15, Stench Damage: +25
-1138	fuchsia shaking mushroom fermenting solution	0		
+1138	shaking fuchsia mushroom fermenting solution	0		
 1139	perfectly mixed weak mushroom wine	2	EPIC	
-1140	tolerable watered-down icy mushroom wine	2	good	
+1140	watered-down tolerable icy mushroom wine	2	good	
 1141	drinkable shaking mushroom wine	3	good	
-1142	drinkable high-proof tumbling jittery pointy mushroom wine	6	good	
+1142	high-proof drinkable tumbling jittery pointy mushroom wine	6	good	
 1143	practically non-alcoholic bad flat mushroom wine	1	decent	
 1144	tolerable cool mushroom wine	4	good	
 1145	mediocre high-proof knob mushroom wine	7	decent	
@@ -1148,9 +1148,9 @@
 1163	frozen super-concentrated jittery marzipan skull	0		Effect: "Chalk Outline", Effect Duration: 40
 1164	poultrygeist	0		
 1165	hovering sombrero	0		
-1166	blurry shaking maracas	0		Familiar Weight: +5
+1166	shaking blurry maracas	0		Familiar Weight: +5
 1167	wobbly plain brown wrapper	0		
-1168	squat ghostly shaking less-than-three-shaped box	0		
+1168	ghostly shaking squat less-than-three-shaped box	0		
 1169	twirling gray exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	coffin	0		
@@ -1164,11 +1164,11 @@
 1179	mirror daisy	0		
 1180	potted fern	0		
 1181	tulip	0		
-1182	tumbling maroon Venus flytrap	0		
+1182	maroon tumbling Venus flytrap	0		
 1183	all-purpose flower	0		
 1184	huge exotic orchid	0		
 1185	cyan long-stemmed rose	0		
-1186	blurry spinning gilded lily	0		
+1186	spinning blurry gilded lily	0		
 1187	deadly nightshade	0		
 1188	lotus	0		
 1189	can of asparagus	0		
@@ -1185,13 +1185,13 @@
 1200	huge bland mugcake	6	decent	
 1201	jumbo toothsome urinal cake	5	awesome	
 1202	yummy Happy Birthday, Claude! cake	4	awesome	
-1203	adequate half-sized personalized birthday cake	2	good	
+1203	half-sized adequate personalized birthday cake	2	good	
 1204	adequate three-tiered wedding cake	4	good	
-1205	tiny fancy adequate babycakes	1	good	Effect: "Human-Demon Hybrid", Effect Duration: 35
+1205	fancy adequate tiny babycakes	1	good	Effect: "Human-Demon Hybrid", Effect Duration: 35
 1206	spoiled upside-down velvet cake	3	crappy	
 1207	snack-sized decent congratulatory cake	2	good	
 1208	half-sized moldy shaking angel-food cake	2	crappy	
-1209	big decent devil's-food cake	5	good	
+1209	decent big devil's-food cake	5	good	
 1210	moldy low-calorie birthday party jellybean cheesecake	1	crappy	
 1211	balloon	0		
 1212	mirror pulsating balloon	0		
@@ -1223,7 +1223,7 @@
 1239	iced-out bling	0		Familiar Weight: +5
 1240	limburger biker boots	0		Familiar Weight: +5
 1241	huge huge carton of clove cigarettes	0		Familiar Weight: +5
-1242	twirling wobbly twirling deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
+1242	wobbly twirling twirling deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
 1243	upside-down toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
 1244	Glass Balls of the Goblin King of Tarzan	0		Experience (Muscle): +3
 1245	medical-grade Codpiece of the Goblin King	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip
@@ -1232,16 +1232,16 @@
 1248	Van der Graaf resourceful hardy Bonerdagon necklace	0		Maximum HP: +50, Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 7
 1249	horrifying Boss Bat britches	0		Spooky Damage: +25, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	executive aromatic Boss Bat bling	0		Stench Resistance: +1, Meat Drop: +40
-1251	tasty big Knob shroomkabob	5	awesome	
+1251	big tasty Knob shroomkabob	5	awesome	
 1252	adequate shroomkabob	3	good	
 1253	pile of jumping beans	0		
 1254	moldy jumping bean burrito	3	crappy	
-1255	bland super-sized cyan spinning squat jumping bean burrito	5	decent	
+1255	bland super-sized squat spinning cyan jumping bean burrito	5	decent	
 1256	decent insanely jumping bean burrito	3	good	
-1257	super-sized moldy yellow tumbling rat scrapple	5	crappy	
+1257	moldy super-sized yellow tumbling rat scrapple	5	crappy	
 1258	pail of pretentious paint	0		
 1259	smartaleck's strapping traffic cone	0		Muscle: +5, Moxie Percent: +30, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
-1260	yellow pulsating wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
+1260	pulsating yellow wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	mixed Hatorade	1		Effect: "Coming Up Roses", Effect Duration: 5
 1262	huge baleful extremely unsafe off-hand balloon of terror	0		Weapon Damage Percent: +100, Spell Damage: +25, Spooky Spell Damage: +10
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
@@ -1252,7 +1252,7 @@
 1268	skewed pine wand	0		
 1269	huge ebony wand	0		
 1270	hexagonal wand	0		
-1271	gray jittery ghostly aluminum wand	0		
+1271	jittery ghostly gray aluminum wand	0		
 1272	jittery marble wand	0		
 1273	magic lamp of the bloodbag	0		Maximum HP: +100
 1274	diluted Medicinal Herb's medicinal herbs	1		
@@ -1323,7 +1323,7 @@
 1340	Cloaca-Cola-issue combat knife	0		
 1341	dog trainer's Dyspepsi-Cola-issue canteen	0		Experience (familiar): +1, Single Equip
 1342	picture of a dead guy's girlfriend	0		
-1343	wobbly jittery zombie pineal gland	0		Last Available: "2005-11"
+1343	jittery wobbly zombie pineal gland	0		Last Available: "2005-11"
 1344	unsweetened Gummi-Gnauga	0		Effect: "Optimist Primal", Effect Duration: 63
 1345	diffused denatured quantum twirling Now and Earlier	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 47, Last Available: "2020-09"
 1346	frozen Sugar Cog	0		Effect: "Spooky Demeanor", Effect Duration: 46
@@ -1332,9 +1332,9 @@
 1349	narrow squat miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	auspicious pinky ring	0		Item Drop: +10, Single Equip
-1352	fancy bad watered-down redrum	2	decent	Effect: "Drenched With Filth", Effect Duration: 25
+1352	fancy watered-down bad redrum	2	decent	Effect: "Drenched With Filth", Effect Duration: 25
 1353	ninja pirate zombie robot	0		
-1354	jittery gray pile of pebbles	0		
+1354	gray jittery pile of pebbles	0		
 1355	spoiled bowl of oriole's nest soup	3	crappy	
 1356	bunny liver	0		
 1357	practically non-alcoholic acceptable Mt. Noob Pale Ale	1	good	
@@ -1345,11 +1345,11 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	skewed rhesus monkey	0		Familiar Weight: +5
-1365	small enchanted rotten blue tofurkey leg	2	crappy	Effect: "Memento Moir&eacute;", Effect Duration: 30
-1366	adequate miniature tofurkey gravy	2	good	
+1365	rotten small enchanted blue tofurkey leg	2	crappy	Effect: "Memento Moir&eacute;", Effect Duration: 30
+1366	miniature adequate tofurkey gravy	2	good	
 1367	moldy narrow herbal stuffing	3	crappy	
 1368	normal huge can-shaped gelatinous cranberry sauce	3	good	
-1369	diet decent blurry blurry yams	1	good	
+1369	decent diet blurry blurry yams	1	good	
 1370	sage rhinestone cowboy shirt	0		Mysticality Percent: +10
 1371	rosewater-soaked gingham blouse	0		Stench Resistance: +3
 1372	olive cool souvenir ski t-shirt	0		Moxie: +5
@@ -1364,11 +1364,11 @@
 1382	quantum oxidized pulsating chocolate	0		Effect: "Superheroic", Effect Duration: 46, Last Available: "2015-11"
 1383	fuchsia length of string	0		
 1384	googly eye	0		
-1385	mirror blue stuffing	0		
+1385	blue mirror stuffing	0		
 1386	felt	0		
 1387	block	0		
 1388	toy wheel	0		
-1389	bouncing twirling yo-yo	0		Last Available: "2010-12"
+1389	twirling bouncing yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
 1392	kite	0		Last Available: "2005-12"
@@ -1377,7 +1377,7 @@
 1395	spinning teddy bear	0		Last Available: "2005-12"
 1396	scorching careful duck-on-a-string	0		Monster Level: -10, Hot Damage: +25, Last Available: "2005-12"
 1397	toy soldier	0		Last Available: "2005-12"
-1398	wobbly red doll house	0		Last Available: "2005-12"
+1398	red wobbly doll house	0		Last Available: "2005-12"
 1399	blurry tumbling clever toy train	0		Maximum MP: +20, Single Equip, Last Available: "2005-12"
 1400	fuchsia Jim Carey's marionette	0		Monster Level: +25, Last Available: "2005-12"
 1401	asbestos-lined sock monkey	0		Hot Resistance: +5, Last Available: "2005-12"
@@ -1385,14 +1385,14 @@
 1403	skewed can of fake snow of Leguizamo	0		Monster Level: +20, Last Available: "2005-12"
 1404	cyan mirror colored-light &quot;necklace&quot; of Gandalf	0		Spell Critical Percent: +20, Last Available: "2005-12"
 1405	mansplainer's tree skirt	0		Monster Level: +15, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	normal tiny blinking wreath-shaped Crimbo cookie	1	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	tiny normal blinking wreath-shaped Crimbo cookie	1	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	huge yummy bell-shaped Crimbo cookie	7	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	decent special tree-shaped Crimbo cookie	4	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	twirling Jim Carey's Unionize The Elves sign	0		Monster Level: +25, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
 1411	wobbly Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	modified electrified deionized snowcone	0		Effect: "Rainbow Bright", Effect Duration: 52, Last Available: "2006-01"
-1413	modified olive mirror shaking snowcone	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 65, Last Available: "2006-01"
+1413	modified mirror olive shaking snowcone	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 65, Last Available: "2006-01"
 1414	activated super-aerosolized snowcone	0		Effect: "New Zeal", Effect Duration: 65, Last Available: "2006-01"
 1415	corrupted twirling snowcone	0		Effect: "Feelin' Philosophical", Effect Duration: 64, Last Available: "2006-01"
 1416	polarized snowcone	0		Effect: "All Fired Up", Effect Duration: 14, Last Available: "2006-01"
@@ -1407,17 +1407,17 @@
 1425	spinning frightening ice baby	0		Spooky Damage: +5, Softcore Only, Last Available: "2006-02"
 1426	ice pick of Tarzan	0		Experience (Muscle): +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	purple extremely unsafe ice skates of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	spoiled low-calorie grue egg omelette	1	crappy	
-1429	mirror huge yellow roll of drink tickets	0		
+1428	low-calorie spoiled grue egg omelette	1	crappy	
+1429	huge mirror yellow roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	toothsome bite-sized mushroom	1	awesome	
+1432	bite-sized toothsome mushroom	1	awesome	
 1433	blinking fruit bowl	0		
 1434	fruit basket	0		
-1435	pulsating cyan hot pink lipstick	0		Familiar Weight: +5
-1436	mirror bouncing hot stuffing	0		
+1435	cyan pulsating hot pink lipstick	0		Familiar Weight: +5
+1436	bouncing mirror hot stuffing	0		
 1437	blurry useless powder	0		
-1438	improved narrow pulsating mirror twinkly powder	0		Effect: "Tenacity of the Snapper", Effect Duration: 39
+1438	improved mirror pulsating narrow twinkly powder	0		Effect: "Tenacity of the Snapper", Effect Duration: 39
 1439	denatured improved ghostly hot powder	0		Effect: "Worth Your Salt", Effect Duration: 50
 1440	triple-oxidized powder	0		Effect: "Wings of the Grasshopper", Effect Duration: 65
 1441	deionized chilled upside-down powder	0		Effect: "Holiday Bliss", Effect Duration: 60
@@ -1434,15 +1434,15 @@
 1452	dehydrated upside-down wad	1		
 1453	powdered squat wad	1		
 1454	twisted stench wad	1		
-1455	dried squat jittery fuchsia sleaze wad	1		
+1455	dried fuchsia squat jittery sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
 1458	adequate half-sized blurry Valentine's Day cake	2	good	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
-1461	gray blinking squashed frog	0		
+1461	blinking gray squashed frog	0		
 1462	eye of newt	0		
-1463	wobbly ghostly salamander spleen	0		
+1463	ghostly wobbly salamander spleen	0		
 1464	sleazy fairy gravy	0		
 1465	suede shortsword	0		
 1466	bamboo bokuto	0		
@@ -1475,14 +1475,14 @@
 1493	clever medical-grade ridiculously overelaborate ninja weapon	0		Maximum MP: +20, HP Regen Min: 7, HP Regen Max: 10
 1494	warmed sugar-coated pine cone	0		Effect: "Celestial Body", Effect Duration: 23, Last Available: "2020-09"
 1495	huge knitted hale traffic cone	0		Maximum HP: +20, Cold Resistance: +3, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	bad high-proof gloomy mushroom wine	10	decent	
+1496	high-proof bad gloomy mushroom wine	10	decent	
 1497	triple-distilled delicious mushroom wine	10	awesome	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	lime green blurry fake fake vomit	0		Last Available: "2006-04"
 1501	warmed polymerized explosion-flavored chewing gum	0		Effect: "Ready to Snap", Effect Duration: 54, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
-1503	upside-down jittery rubber emo roe	0		Last Available: "2006-04"
+1503	jittery upside-down rubber emo roe	0		Last Available: "2006-04"
 1504	wet bouncing snowcone	0		Effect: "Heart Aflame", Effect Duration: 31, Last Available: "2006-04"
 1505	purple ice cube with a fly in it	0		Last Available: "2006-04"
 1506	mediocre calle de miel with a fly in it	3	decent	Last Available: "2006-04"
@@ -1494,7 +1494,7 @@
 1512	twisted pulsating Knob Goblin pet-buffing spray	1		Effect: "Dances with Tweedles", Effect Duration: 25
 1513	diluted twirling Knob Goblin learning pill	1		
 1514	vaporized Knob Goblin eyedrops	1		Effect: "Gummiskin", Effect Duration: 35
-1515	powdered huge jittery Knob Goblin nasal spray	1		Effect: "Braaaains Over Braaaawwn", Effect Duration: 30
+1515	powdered jittery huge Knob Goblin nasal spray	1		Effect: "Braaaains Over Braaaawwn", Effect Duration: 30
 1516	pulsating KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	twirling Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1531,57 +1531,57 @@
 1551	hand-crafted mirror spinning bottle of Domesticated Turkey	3	EPIC	
 1552	delicious bottle of Definit	3	awesome	
 1553	perfectly mixed bottle of Calcutta Emerald	3	EPIC	
-1554	perfectly mixed high-proof green bottle of Lieutenant Freeman	7	EPIC	
+1554	high-proof perfectly mixed green bottle of Lieutenant Freeman	7	EPIC	
 1555	perfectly mixed bottle of Jorge Sinsonte	4	EPIC	
 1556	mediocre jittery boxed champagne	3	decent	
 1557	moldy kumquat	3	crappy	
 1558	stale red tangerine	4	decent	
 1559	bouncing tonic water	0		
 1560	bland cocktail onion	3	decent	
-1561	adequate snack-sized raspberry	2	good	
-1562	half-sized normal kiwi	2	good	
+1561	snack-sized adequate raspberry	2	good	
+1562	normal half-sized kiwi	2	good	
 1563	hand-crafted whiskey bittersweet	3	EPIC	
 1564	bad mimosette	3	decent	
 1565	acceptable triple-distilled tequila sunset	6	good	
 1566	aged practically non-alcoholic huge zmobie	1	awesome	Wiki Name: "Zmobie (drink)"
-1567	fancy tolerable gray gin and tonic	4	good	Effect: "On a Roll", Effect Duration: 30
+1567	tolerable fancy gray gin and tonic	4	good	Effect: "On a Roll", Effect Duration: 30
 1568	tolerable vodka and tonic	3	good	
 1569	bad vodka gibson	4	decent	
-1570	bad watered-down mirror tumbling gibson	2	decent	
-1571	strong bad tumbling wobbly parisian cathouse	5	decent	
+1570	watered-down bad mirror tumbling gibson	2	decent	
+1571	bad strong tumbling wobbly parisian cathouse	5	decent	
 1572	artisanal rabbit punch	3	EPIC	
 1573	mediocre fortified twirling caipifruta	5	decent	
 1574	mediocre practically non-alcoholic teqiwila	1	decent	
 1575	drinkable blinking Divine	3	good	
 1576	fancy bad wobbly Gordon Bennett	3	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 15
-1577	tolerable watered-down tangarita	2	good	
+1577	watered-down tolerable tangarita	2	good	
 1578	drinkable mandarina colada	3	good	
 1579	strong perfectly mixed gimlet	5	EPIC	
 1580	irresponsibly strong hand-crafted brick road	9	EPIC	
-1581	lousy distilled bouncing vodka stratocaster	5	decent	
-1582	mediocre weak Neuromancer	2	decent	
+1581	distilled lousy bouncing vodka stratocaster	5	decent	
+1582	weak mediocre Neuromancer	2	decent	
 1583	artisanal practically non-alcoholic lime green spinning prussian cathouse	1	super ultra mega turbo EPIC	
 1584	triple-distilled acceptable huge Mae West	7	good	
-1585	weak drinkable Mon Tiki	2	good	
+1585	drinkable weak Mon Tiki	2	good	
 1586	drinkable teqiwila slammer	4	good	
 1587	flavorless upside-down Knob lo mein	3	decent	
 1588	bland pulsating asparagus lo mein	3	decent	
-1589	yummy immense fancy Knoll lo mein	8	awesome	Effect: "Unusual Fashion Sense", Effect Duration: 25
-1590	snack-sized enchanted spoiled narrow lo mein	2	crappy	Effect: "Oriental Mysticism", Effect Duration: 10
+1589	fancy yummy immense Knoll lo mein	8	awesome	Effect: "Unusual Fashion Sense", Effect Duration: 25
+1590	snack-sized spoiled enchanted narrow lo mein	2	crappy	Effect: "Oriental Mysticism", Effect Duration: 10
 1591	normal low-calorie shaking yellow olive lo mein	1	good	
-1592	thick fancy moldy hot hi mein	5	crappy	Effect: "Toast Tea", Effect Duration: 35
+1592	moldy thick fancy hot hi mein	5	crappy	Effect: "Toast Tea", Effect Duration: 35
 1593	normal blurry hi mein	4	good	
 1594	stale blue spinning hi mein	4	decent	
 1595	bland hi mein	4	decent	
-1596	flavorless fancy sleazy hi mein	4	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 5
+1596	fancy flavorless sleazy hi mein	4	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 5
 1597	Temple Grandin's Junior LAAAAME merit badge	0		Familiar Weight: +7, Last Available: "2006-05"
 1598	ghostly Sherlock's Senior LAAAAME merit badge	0		Item Drop: +25, Last Available: "2006-05"
 1599	teal jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	delicious tangarita with a fly in it	3	awesome	
-1601	practically non-alcoholic tolerable mandarina colada with a fly in it	1	good	
+1601	tolerable practically non-alcoholic mandarina colada with a fly in it	1	good	
 1602	perfectly mixed prussian cathouse with a fly in it	3	EPIC	
 1603	smooth Mae West with a fly in it	4	awesome	
-1604	denatured olive mirror tumbling squat astronaut ice-cream	1		Effect: "Void Between the Stars", Effect Duration: 30, Last Available: "2006-05"
+1604	denatured mirror squat olive tumbling astronaut ice-cream	1		Effect: "Void Between the Stars", Effect Duration: 30, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	vaporized ultimate wad	1		Effect: "Ooh, Sweet!", Effect Duration: 45
 1607	polarized libation of liveliness	0		Effect: "Mortarfied", Effect Duration: 58
@@ -1605,21 +1605,21 @@
 1625	polarized galvanized green-frosted astral cupcake	0		Effect: "In the Saucestream", Effect Duration: 22, Last Available: "2006-06"
 1626	vacuum-sealed lime green orange-frosted astral cupcake	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 30, Last Available: "2006-06"
 1627	moist purple skewed purple-frosted astral cupcake	0		Effect: "Twen Tea", Effect Duration: 48, Last Available: "2006-06"
-1628	pressed green ghostly pink-frosted astral cupcake	0		Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2006-06"
+1628	pressed ghostly green pink-frosted astral cupcake	0		Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2006-06"
 1629	wobbly lard-coated raspberry beret	0		Sleaze Spell Damage: +25, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	maroon pixel shield of the businessman	0		Meat Drop: +50, Damage Reduction: 3
 1631	skewed beer cartilage	0		
 1632	Spanish fly trap	0		
-1633	bouncing yellow Spanish fly	0		
+1633	yellow bouncing Spanish fly	0		
 1634	hand-crafted around the world	4	EPIC	
 1635	pulsating pulsating scrumdiddlyumptious solution	0		
 1636	squat Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	dry galvanized lotion of hotness	0		Effect: "Squirming Like a Toad", Effect Duration: 27
 1638	aerosolized polymerized denatured lotion of coldness	0		Effect: "Vanity Rage", Effect Duration: 54
-1639	concentrated dry narrow upside-down teal lotion of spookiness	0		Effect: "Amorphous Cheer", Effect Duration: 61
+1639	concentrated dry teal upside-down narrow lotion of spookiness	0		Effect: "Amorphous Cheer", Effect Duration: 61
 1640	modified wobbly lotion of stench	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 40
 1641	flattened lotion of sleaziness	0		Effect: "Broken Fast", Effect Duration: 46
-1642	lousy watered-down Grimacite Bock	2	decent	Last Available: "2008-11"
+1642	watered-down lousy Grimacite Bock	2	decent	Last Available: "2008-11"
 1643	bland wobbly wedge of gray cheese	4	decent	Last Available: "2008-11"
 1644	bouncing hot and sauce	0		
 1645	twirling and sauce	0		
@@ -1628,7 +1628,7 @@
 1648	sleazy and sauce	0		
 1649	purple brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	miniature flavorless foie gras	2	decent	
+1651	flavorless miniature foie gras	2	decent	
 1652	colloidal olive candy brain	0		Effect: "The Smeezingtons", Effect Duration: 52, Last Available: "2020-09"
 1653	baleful jewel-eyed wizard hat of wisdom of courage	0		Mysticality: +15, Spell Damage: +25, Spooky Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	tumbling lion tamer's wad of Crovacite of bravery	0		Experience (familiar): +2, Spooky Resistance: +5
@@ -1672,12 +1672,12 @@
 1692	diffused deionized triple-Vulcanized tumbling salamander slurry	0		Effect: "Hobo Flavor", Effect Duration: 67
 1693	double-improved blinking eyedrops of newt	0		Effect: "Feline Ferocity", Effect Duration: 21
 1694	altered green Frogade	0		Effect: "Blackberry Politeness", Effect Duration: 24
-1695	modified ionized shaking green papotion of papower	0		Effect: "Burning Tongue", Effect Duration: 15
-1696	enchanted snack-sized stale royal jelly taco	2	decent	Effect: "Eldritch Concentration", Effect Duration: 30
+1695	modified ionized green shaking papotion of papower	0		Effect: "Burning Tongue", Effect Duration: 15
+1696	snack-sized stale enchanted royal jelly taco	2	decent	Effect: "Eldritch Concentration", Effect Duration: 30
 1697	spoiled diet pulsating tofu taco	1	crappy	
-1698	super-sized toothsome jumping bean taco	5	awesome	
+1698	toothsome super-sized jumping bean taco	5	awesome	
 1699	adequate catgut taco	3	good	
-1700	big normal goat cheese taco	5	good	
+1700	normal big goat cheese taco	5	good	
 1701	jumbo normal ghostly pr0n taco	5	good	
 1702	tarnished irradiated pulsating alphabet gum	0		Effect: "Neuroplastici Tea", Effect Duration: 25
 1703	wobbly Comma Chameleon egg	0		Free Pull
@@ -1745,8 +1745,8 @@
 1766	Spookyraven ballroom key	0		
 1767	tumbling pack of chewing gum	0		
 1768	huge Gnomish toolbox	0		
-1769	immense yummy huge fricasseed brains	8	awesome	
-1770	decent diet blinking brains casserole	1	good	
+1769	yummy immense huge fricasseed brains	8	awesome	
+1770	diet decent blinking brains casserole	1	good	
 1771	butcherknife of the cougar	0		Moxie: +20
 1772	ghostly corn holder of the wise owl	0		Mysticality: +20
 1773	squat eggbeater of Flo-Jo	0		Initiative: +100
@@ -1754,7 +1754,7 @@
 1775	supercharged dishrag	0		Maximum MP Percent: +30
 1776	normal stale baguette	3	good	
 1777	squat leftovers of indeterminate origin	0		
-1778	half-sized fancy decent shaking dinner	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
+1778	fancy half-sized decent shaking dinner	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
 1779	blurry mansplainer's katana	0		Monster Level: +15
 1780	miser's ram stick	0		Meat Drop: +10
 1781	dangerous enchantlers	0		Weapon Damage: +10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1765,7 +1765,7 @@
 1786	six pack of Mountain Stream	0		
 1787	polymerized blinking bag of Cheat-Os	0		Effect: "Wallflowering", Effect Duration: 27
 1788	maroon blurry unrefined Mountain Stream syrup	0		
-1789	spinning cyan Mob Penguin	0		
+1789	cyan spinning Mob Penguin	0		
 1790	bad Ram's Face Lager	4	decent	
 1791	ram horns	0		
 1792	MacGyver's quilted Travoltan trousers of the blizzard	0		Damage Absorption: +40, Maximum MP: +100, Cold Spell Damage: +25, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
@@ -1791,7 +1791,7 @@
 1812	fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
-1815	tumbling blurry seventh thoracic vertebra	0		
+1815	blurry tumbling seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	blurry tenth thoracic vertebra	0		
@@ -1801,8 +1801,8 @@
 1822	huge tumbling second lumbar vertebra	0		
 1823	ghostly third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
-1825	ghostly fuchsia fifth lumbar vertebra	0		
-1826	ghostly mirror sixth lumbar vertebra	0		
+1825	fuchsia ghostly fifth lumbar vertebra	0		
+1826	mirror ghostly sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
 1829	first caudal vertebra	0		
@@ -1839,7 +1839,7 @@
 1860	right tenth rib	0		
 1861	red right eleventh rib	0		
 1862	right twelfth rib	0		
-1863	shaking purple animal pelvis	0		
+1863	purple shaking animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
 1866	left clavicle	0		
@@ -1858,20 +1858,20 @@
 1879	pulsating right fibula	0		
 1880	blurry maroon left kneecap	0		
 1881	right kneecap	0		
-1882	upside-down wobbly left first front claw	0		
+1882	wobbly upside-down left first front claw	0		
 1883	left second front claw	0		
 1884	squat left third front claw	0		
 1885	spinning left fourth front claw	0		
 1886	right first front claw	0		
-1887	shaking jittery right second front claw	0		
+1887	jittery shaking right second front claw	0		
 1888	narrow right third front claw	0		
-1889	wobbly jittery right fourth front claw	0		
+1889	jittery wobbly right fourth front claw	0		
 1890	narrow left thumb	0		
 1891	right thumb	0		
 1892	bouncing fuchsia left first rear claw	0		
 1893	jittery left second rear claw	0		
 1894	left third rear claw	0		
-1895	ghostly maroon left fourth rear claw	0		
+1895	maroon ghostly left fourth rear claw	0		
 1896	squat right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
@@ -1898,7 +1898,7 @@
 1921	blinking beefy wakizashi	0		Muscle: +10
 1922	maroon gob of wet hair	0		
 1923	wobbly roll of toilet paper	0		Free Pull
-1924	lime green blinking tattered wolf standard	0		
+1924	blinking lime green tattered wolf standard	0		
 1925	tattered snake standard	0		
 1926	KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
@@ -1925,12 +1925,12 @@
 1948	dog trainer's Jim Carey's tap shoes	0		Monster Level: +25, Experience (familiar): +1, Single Equip
 1949	rotten tiny Manetwich	1	crappy	
 1950	skewed bottle of Vangoghbitussin	0		
-1951	weak lousy bottle of Pinot Renoir	2	decent	
-1952	adequate super-sized desiccated apricot	5	good	
-1953	artisanal practically non-alcoholic flute of flat champagne	1	EPIC	
+1951	lousy weak bottle of Pinot Renoir	2	decent	
+1952	super-sized adequate desiccated apricot	5	good	
+1953	practically non-alcoholic artisanal flute of flat champagne	1	EPIC	
 1954	adequate huge dehydrated caviar	4	good	
 1955	squat styrofoam peanuts	0		
-1956	delicious practically non-alcoholic snifter of thoroughly aged brandy	1	awesome	
+1956	practically non-alcoholic delicious snifter of thoroughly aged brandy	1	awesome	
 1957	quill pen	0		
 1958	spinning inkwell	0		
 1959	squat tattered scrap of paper	0		
@@ -1971,7 +1971,7 @@
 1994	rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
 1996	narrow right half of a heart necklace	0		
-1997	maroon spinning left half of a heart necklace	0		
+1997	spinning maroon left half of a heart necklace	0		
 1998	pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
@@ -1987,7 +1987,7 @@
 2010	The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
 2012	Arrrmetia trading card	0		
-2013	squat shaking Serenity trading card	0		
+2013	shaking squat Serenity trading card	0		
 2014	Inndya trading card	0		
 2015	bouncing Kitty the Zmobie Basher trading card	0		
 2016	ghostly diamond necklace	0		
@@ -1996,13 +1996,13 @@
 2019	cream pie	0		Free Pull
 2020	spoiled shaking cherry pie	3	crappy	
 2021	moldy half-sized blue strawberry pie	2	crappy	
-2022	rotten jumbo lemon meringue pie	5	crappy	
+2022	jumbo rotten lemon meringue pie	5	crappy	
 2023	Genalen&trade; Bottle	1	good	
-2024	decent jumbo mixed wildflower greens	5	good	
+2024	jumbo decent mixed wildflower greens	5	good	
 2025	gigantic yummy handful of walnuts	10	awesome	
 2026	moldy nutty organic salad	4	crappy	
 2027	diet stale super salad	1	decent	
-2028	adequate special tofu wonton	3	good	Effect: "Bats in the Belfry", Effect Duration: 50
+2028	special adequate tofu wonton	3	good	Effect: "Bats in the Belfry", Effect Duration: 50
 2029	shaking hippy protest button	0		Single Equip
 2030	nippy curative Lockenstock&trade; sandals	0		Cold Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 2031	narrow spinning didgeridooka of Gandalf	0		Spell Critical Percent: +20
@@ -2020,7 +2020,7 @@
 2043	hemp net	0		
 2044	green your father's MacGuffin diary	0		
 2045	adequate wobbly brain-meltingly-hot chicken wings	3	good	
-2046	thick normal frat brats	5	good	
+2046	normal thick frat brats	5	good	
 2047	flavorless miniature knob ka-bobs	2	decent	
 2049	high-proof smooth can of Swiller	6	awesome	
 2050	green broken wings	0		
@@ -2031,7 +2031,7 @@
 2055	snake skin	0		
 2056	alkaline denatured adder bladder	0		Effect: "Lit Up", Effect Duration: 62
 2057	pension check	0		
-2058	cyan skewed picnic basket	0		
+2058	skewed cyan picnic basket	0		
 2059	tarnished red Black No. 2	0		Effect: "Powder Power", Effect Duration: 59
 2060	careful Annie Oakley's sword	0		Critical Hit Percent: +20, Monster Level: -10
 2061	jittery Temple Grandin's helmet	0		Familiar Weight: +7, Familiar Effect: "1xFairy, cap 40"
@@ -2060,7 +2060,7 @@
 2084	can of starch	0		
 2085	distilled squat bottle of ultravitamins	1		Effect: "Mushroom Melody", Effect Duration: 30
 2086	powdered bottle of cough syrup	1		
-2087	diluted wobbly purple tube of hair oil	1		
+2087	diluted purple wobbly tube of hair oil	1		
 2088	alkaline irradiated alkaline Daffy Taffy	0		Effect: "Buzzard Breath", Effect Duration: 53
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	tumbling greasy friendly extremely unsafe pilgrim shield of the blizzard of the cheetah	0		Weapon Damage Percent: +100, Familiar Weight: +3, Cold Spell Damage: +25, Sleaze Spell Damage: +10, Initiative: +60, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
@@ -2085,7 +2085,7 @@
 2109	blinking stringy sinew	0		Last Available: "2011-12"
 2110	stick	0		Last Available: "2011-12"
 2111	bouncing tooth	0		
-2112	spinning blurry leaf	0		Last Available: "2011-12"
+2112	blurry spinning leaf	0		Last Available: "2011-12"
 2113	wheel of the ox	0		Muscle: +20, Last Available: "2006-12"
 2114	yo	0		Last Available: "2006-12"
 2115	crafty prehistoric spear	0		Maximum MP: +10, Last Available: "2006-12"
@@ -2117,7 +2117,7 @@
 2142	block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
 2144	bouncing evil googly eye	0		Last Available: "2011-12"
-2145	jittery spinning stuffing	0		Last Available: "2011-12"
+2145	spinning jittery stuffing	0		Last Available: "2011-12"
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
@@ -2136,7 +2136,7 @@
 2161	blinking computronic processing unit	0		Last Available: "2011-12"
 2162	wobbly reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	skewed sub-molecular interocitor	0		Last Available: "2011-12"
-2164	cyan squat recursive spline reticulator	0		Last Available: "2011-12"
+2164	squat cyan recursive spline reticulator	0		Last Available: "2011-12"
 2165	atomic vector plotter	0		Last Available: "2011-12"
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
@@ -2155,7 +2155,7 @@
 2180	amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	fuchsia twirling Harold's hammer handle	0		
+2183	twirling fuchsia Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	squat Kiss the Knob apron of the scaredy-cat	0		Monster Level: -15
 2186	unlit birthday cake	0		
@@ -2165,14 +2165,14 @@
 2190	wobbly yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	upside-down narrow book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	stale low-calorie candy stake	1	decent	Last Available: "2006-12"
+2193	low-calorie stale candy stake	1	decent	Last Available: "2006-12"
 2194	drinkable high-proof eggnog	9	good	Last Available: "2006-12"
 2195	adequate green unspeakable fruitcake	4	good	Last Available: "2006-12"
 2196	stale blue gingerbread horror	4	decent	Last Available: "2006-12"
 2197	dry pressed ionized shaking but probably evil chocolate	0		Effect: "Cybernetic Muscles", Effect Duration: 23, Last Available: "2006-12"
-2198	fancy miniature bland bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	fancy bland miniature bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	tasty skull-shaped Crimboween cookie	4	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	half-sized adequate jittery jittery tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	adequate half-sized jittery jittery tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	nippy plastic gift-wrapping vampire	0		Cold Damage: +10, Last Available: "2006-12"
 2202	bouncing Annie Oakley's plastic yuletide troll	0		Critical Hit Percent: +20, Last Available: "2006-12"
 2203	mansplainer's plastic skeletal reindeer	0		Monster Level: +15, Single Equip, Last Available: "2006-12"
@@ -2189,7 +2189,7 @@
 2214	spinning tropical wrapping paper	0		Last Available: "2006-12"
 2215	squat lion tamer's Tropical Crimbo Hat	0		Experience (familiar): +2, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
 2216	asbestos-lined Tropical Crimbo Shorts	0		Hot Resistance: +5, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
-2217	half-sized tasty mirror yellow super ka-bob	2	awesome	
+2217	tasty half-sized mirror yellow super ka-bob	2	awesome	
 2218	spoiled shaking beer basted brat	3	crappy	
 2219	quilted Tropical Crimbo Sword	0		Damage Absorption: +40, Last Available: "2006-12"
 2220	quantum and Crimboween candy	0		Effect: "Rain Dancin'", Effect Duration: 50, Last Available: "2020-09"
@@ -2246,7 +2246,7 @@
 2272	tolerable bottle of Port	4	good	
 2273	acceptable spinning bottle of Pinot Noir	4	good	
 2274	watered-down delicious narrow bottle of Zinfandel	2	awesome	
-2275	fancy mediocre bottle of Marsala	3	decent	Effect: "Dreadful Sheen", Effect Duration: 5
+2275	mediocre fancy bottle of Marsala	3	decent	Effect: "Dreadful Sheen", Effect Duration: 5
 2276	tolerable bottle of Muscat	3	good	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2256,14 +2256,14 @@
 2282	Manual of Dexterity	0		
 2283	hardy seal-skull helmet	0		Maximum HP: +50, Familiar Effect: "atk, cap 2"
 2284	blurry petrified noodles	0		
-2285	upside-down blurry chisel	0		
+2285	blurry upside-down chisel	0		
 2286	jittery Eye of Ed	0		
 2287	frosty glowstick of horror	0		Cold Spell Damage: +10, Spooky Spell Damage: +25, Last Available: "2007-01"
 2288	skewed encoder ring	0		Single Equip
 2289	paperclip	0		
 2290	really house	0		
 2291	Non-Essential Amulet	0		
-2292	spinning red wine vinaigrette	0		
+2292	red spinning wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
 2294	Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	jittery marinated stakes	0		
@@ -2278,7 +2278,7 @@
 2304	frozen corrupted twirling candy heart	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 21, Last Available: "2007-02"
 2305	liquefied skewed pink candy heart	0		Effect: "The Smeezingtons", Effect Duration: 52, Last Available: "2007-02"
 2306	deionized triple-warmed candy heart	0		Effect: "Sinuses For Miles", Effect Duration: 50, Last Available: "2007-02"
-2307	alkaline upside-down wobbly candy heart	0		Effect: "Gyromitra Gymnastics", Effect Duration: 61, Last Available: "2007-02"
+2307	alkaline wobbly upside-down candy heart	0		Effect: "Gyromitra Gymnastics", Effect Duration: 61, Last Available: "2007-02"
 2308	concentrated squat candy heart	0		Effect: "Partially Ghosted", Effect Duration: 12, Last Available: "2007-02"
 2309	magnetized candy heart	0		Effect: "Chalk Outline", Effect Duration: 16, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
@@ -2293,7 +2293,7 @@
 2319	red carved wheel	0		
 2320	skewed worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
-2322	bouncing skewed worm-riding manual pages 3-15	0		
+2322	skewed bouncing worm-riding manual pages 3-15	0		
 2323	upside-down headpiece of the Staff of Ed	0		
 2324	Staff of Ed, almost	0		
 2325	Staff of Ed	0		
@@ -2303,7 +2303,7 @@
 2329	handful of confetti	0		
 2330	narrow green chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	enchanted spoiled Better Than Cuddling Cake	3	crappy	Effect: "Tightly-Wound Spine", Effect Duration: 5
+2332	spoiled enchanted Better Than Cuddling Cake	3	crappy	Effect: "Tightly-Wound Spine", Effect Duration: 5
 2333	green ninja snowman	0		
 2334	wobbly jittery Holy MacGuffin	0		
 2335	squat rubber WWBBDD? bracelet	0		
@@ -2316,7 +2316,7 @@
 2342	bland small forest cake	2	decent	
 2343	decent half-sized upside-down forest ham	2	good	
 2344	diffused tarnished deionized filthworm hatchling scent gland	0		Effect: "Quadrilled", Effect Duration: 14
-2345	boiled green blinking filthworm drone scent gland	0		Effect: "Hopped Up on Goofballs", Effect Duration: 34
+2345	boiled blinking green filthworm drone scent gland	0		Effect: "Hopped Up on Goofballs", Effect Duration: 34
 2346	quantum mirror filthworm royal guard scent gland	0		Effect: "Vitamin-Maxed", Effect Duration: 60
 2347	squat heart of the filthworm queen	0		
 2348	water pipe bomb	0		
@@ -2346,7 +2346,7 @@
 2372	bunch of bananas	0		
 2373	toothsome banana	3	awesome	
 2374	banana peel	0		
-2375	thick spoiled tumbling banana cream pie	5	crappy	
+2375	spoiled thick tumbling banana cream pie	5	crappy	
 2376	perfectly mixed banana daiquiri	3	EPIC	
 2377	tolerable bungle in the jungle	4	good	
 2378	banana spritzer	0		
@@ -2374,7 +2374,7 @@
 2400	upside-down molotov cocktail cocktail	0		
 2401	mirror mirror blinking Rosewater's beer bong of the cougar	0		Moxie: +20, Mysticality Percent: +30
 2402	gauze garter	0		
-2403	wobbly ghostly barrel of gunpowder	0		
+2403	ghostly wobbly barrel of gunpowder	0		
 2404	jam band flyers	0		
 2405	skewed rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
@@ -2390,7 +2390,7 @@
 2416	lime green censurious bounty-hunting helmet	0		Sleaze Resistance: +3, Familiar Effect: "1.5xFairy, cap 25"
 2417	twirling executive bounty-hunting rifle	0		Meat Drop: +40
 2418	squat lard-coated bounty-hunting pants	0		Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	triple-Vulcanized quantum green mirror bottle of rhinoceros hormones	0		Effect: "Chain Chain Chains", Effect Duration: 29
+2419	triple-Vulcanized quantum mirror green bottle of rhinoceros hormones	0		Effect: "Chain Chain Chains", Effect Duration: 29
 2420	adjusted electrified upside-down teeny-tiny magic scroll	0		Effect: "Mushroom Might", Effect Duration: 48
 2421	cold-filtered bottle of pirate juice	0		Effect: "Mushroom Moxiousness", Effect Duration: 25
 2422	double-aerosolized boiled irradiated pet snacks	0		Effect: "Aquarius Rising", Effect Duration: 53
@@ -2398,7 +2398,7 @@
 2424	wet cyan cyclops eyedrops	0		Effect: "Red Around the Gills", Effect Duration: 17
 2425	alkaline maroon can of spinach	0		Effect: "Memory of Resilience", Effect Duration: 38
 2426	pickled shaking fire flower	0		Effect: "Greedy Resolve", Effect Duration: 19
-2427	energized upside-down skewed freezerburned ice cube	0		Effect: "Provocative Perkiness", Effect Duration: 64
+2427	energized skewed upside-down freezerburned ice cube	0		Effect: "Provocative Perkiness", Effect Duration: 64
 2428	polarized ionized bouncing fake blood	0		Effect: "Shot in the Arse", Effect Duration: 16
 2429	flattened cold-filtered Eau de Guaneau	0		Effect: "Tennis Elbow-wow", Effect Duration: 54
 2430	quadruple-cold-filtered unsweetened bag of lard	0		Effect: "Held Closer", Effect Duration: 29
@@ -2410,8 +2410,8 @@
 2436	deionized donkey flipbook	0		Effect: "Cold as Ice", Effect Duration: 29
 2437	New Cloaca-Cola	0		
 2438	mirror scented massage oil	0		
-2439	spinning yellow poltergeist-in-the-jar-o	0		
-2440	cyan upside-down unnatural gas	0		
+2439	yellow spinning poltergeist-in-the-jar-o	0		
+2440	upside-down cyan unnatural gas	0		
 2441	lime green Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	frosty dangerous pink glowstick	0		Weapon Damage: +10, Cold Spell Damage: +10, Last Available: "2007-03"
@@ -2449,7 +2449,7 @@
 2476	lion tamer's clownskin belt	0		Experience (familiar): +2, Clowniness: 50
 2477	clownskin buckler of the cougar	0		Moxie: +20, Clowniness: 50, Damage Reduction: 3
 2478	twirling Samson's clown whip	0		Experience (Muscle): +5, Clowniness: 50
-2479	blinking pulsating demon skin	0		
+2479	pulsating blinking demon skin	0		
 2480	blurry spinning greedy demon-horned hat	0		Meat Drop: +20, Familiar Effect: "hot atk, 1xLep, cap 17"
 2481	twirling occult demon buckler	0		Spell Damage Percent: +25, Damage Reduction: 5
 2482	deadly demon whip of Calamity Jane of incineration	0		Weapon Damage: +5, Critical Hit Percent: +15, Hot Spell Damage: +50
@@ -2462,7 +2462,7 @@
 2489	reassuring tuxedo shirt	0		Spooky Resistance: +1
 2490	Jeselnik's cool gnauga hide vest	0		Moxie: +5, Sleaze Damage: +25
 2491	twirling shirt kit	0		
-2492	upside-down lime green tropical orchid	0		
+2492	lime green upside-down tropical orchid	0		
 2493	stick of dynamite	0		
 2494	skewed clever Necrotelicomnicon of the overflowing toilet	0		Maximum MP: +20, Stench Spell Damage: +50
 2495	fortified Cookbook of the Damned	0		Damage Absorption: +60, Item Drop: +5
@@ -2470,7 +2470,7 @@
 2497	lime green molybdenum magnet	0		
 2498	molybdenum hammer	0		
 2499	molybdenum screwdriver	0		
-2500	huge blinking molybdenum pliers	0		
+2500	blinking huge molybdenum pliers	0		
 2501	mirror molybdenum crescent wrench	0		
 2502	shaking Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	squat extra-fancy ring setting	0		
@@ -2489,22 +2489,22 @@
 2516	banded smartaleck's wrench bracelet	0		Moxie Percent: +30, Damage Absorption: +100
 2517	zippy auspicious chain necklace	0		Item Drop: +10, Initiative: +20
 2518	energetic sawblade shield	0		Maximum MP Percent: +20, Damage Reduction: 11
-2519	artisanal ghostly lime green McMillicancuddy's Special Lager	4	EPIC	
+2519	artisanal lime green ghostly McMillicancuddy's Special Lager	4	EPIC	
 2520	bad green melted Jell-o shot	3	decent	
-2521	perfectly mixed strong blinking cruelty-free wine	5	EPIC	
+2521	strong perfectly mixed blinking cruelty-free wine	5	EPIC	
 2522	triple-distilled bad thistle wine	7	decent	
 2523	upside-down megatofu	0		
 2524	displaced fish	0		
-2525	adequate thick blue twirling fish	5	good	
+2525	adequate thick twirling blue fish	5	good	
 2526	miniature bland fish casserole	2	decent	
 2527	flavorless purple fish lasagna	3	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	decent gnatloaf	3	good	
-2530	bland half-sized twirling gnatloaf casserole	2	decent	
+2530	half-sized bland twirling gnatloaf casserole	2	decent	
 2531	moldy snack-sized squat gnat lasagna	2	crappy	
 2532	pork	0		
-2533	super-sized yummy pork chop sandwiches	5	awesome	
-2534	gigantic rotten skewed skewed pork casserole	7	crappy	
+2533	yummy super-sized pork chop sandwiches	5	awesome	
+2534	rotten gigantic skewed skewed pork casserole	7	crappy	
 2535	flavorless pork lasagna	3	decent	
 2536	mirror canopic jar	0		
 2537	spice	0		
@@ -2512,7 +2512,7 @@
 2539	blinking beefy Ankh of Badahnkadh	0		Muscle: +10, Single Equip
 2540	tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
-2542	pressed lime green bouncing lesser grodulated violet	0		Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2007-05"
+2542	pressed bouncing lime green lesser grodulated violet	0		Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2007-05"
 2543	pickled spinning upside-down tin magnolia	0		Effect: "Ready to Snap", Effect Duration: 22, Last Available: "2007-05"
 2544	enhanced moist Vulcanized begpwnia	0		Effect: "Piratastic", Effect Duration: 61, Last Available: "2007-05"
 2545	galvanized anodized cold-filtered huge upsy daisy	0		Effect: "Corona de la Salsa", Effect Duration: 60, Last Available: "2007-05"
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	rock-hard cactus quill of James Dean	0		Experience (Moxie): +3, Damage Reduction: 5
 2578	wobbly knitted stanky baleful Staff of the Short Order Cook	0		Spell Damage: +25, Stench Spell Damage: +25, Cold Resistance: +3
-2579	toothsome jumbo cactus fruit	5	awesome	
+2579	jumbo toothsome cactus fruit	5	awesome	
 2580	Temple Grandin's Herculean scorpion whip	0		Experience (Muscle): +1, Familiar Weight: +7
 2581	upside-down handful of sand	0		
 2582	skewed blurry brick of sand	0		
@@ -2561,10 +2561,10 @@
 2588	aromatic Private Pepper's Lonely Hearts Club Jacket	0		Stench Resistance: +1
 2589	half-sized normal hot date	2	good	
 2590	acceptable distilled fortified wine	4	good	
-2591	gigantic adequate blue tasty tart	8	good	
+2591	adequate gigantic blue tasty tart	8	good	
 2592	Knob Goblin lunchbox	0		
 2593	delicious gigantic olive Knob pasty	9	awesome	
-2594	weak tolerable ghostly thermos full of Knob coffee	2	good	
+2594	tolerable weak ghostly thermos full of Knob coffee	2	good	
 2595	wet electrified Ben-Gal&trade; Balm	0		Effect: "Woad Warrior", Effect Duration: 37
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2589,8 +2589,8 @@
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	spinning mirror Jim Carey's Iiti Kitty phone charm	0		Monster Level: +25, Single Equip
-2619	teal spinning jar of swamp gas	0		Last Available: "2007-05"
-2620	bland jumbo unidentified jerky	5	decent	
+2619	spinning teal jar of swamp gas	0		Last Available: "2007-05"
+2620	jumbo bland unidentified jerky	5	decent	
 2621	curative nasty rat mask of James Dean	0		Experience (Moxie): +3, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	wicked cool ratskin belt	0		Moxie: +5, Spell Damage: +5, Single Equip
 2623	vibrating wizardly rattail whip	0		Mysticality: +25, Maximum MP Percent: +10
@@ -2624,7 +2624,7 @@
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	thick adequate fancy S.T.L.T.	5	good	Effect: "Crud&eacute;", Effect Duration: 15, Last Available: "2007-06"
 2653	spoiled honey-dew	3	crappy	Last Available: "2007-06"
-2654	smooth practically non-alcoholic Xanadian	1	awesome	Last Available: "2007-06"
+2654	practically non-alcoholic smooth Xanadian	1	awesome	Last Available: "2007-06"
 2655	alkaline triple-anodized bottle of absinthe	0		Effect: "The Halls of Moxiousness", Effect Duration: 18, Last Available: "2007-06"
 2656	squat family-friendly arcane researcher's Drowsy Sword	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +1
 2657	spoiled super-sized escargotsicle	5	crappy	Last Available: "2007-06"
@@ -2640,8 +2640,8 @@
 2667	colloidal spiky collar	0		Effect: "Bored Stiff", Effect Duration: 59, Last Available: "2007-06"
 2668	powdered can-can-in-a-can	1		Effect: "Woad Warrior", Effect Duration: 50, Last Available: "2007-06"
 2669	dehydrated patent antipsychotics	1		Last Available: "2007-06"
-2670	twisted blinking mirror Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	drinkable practically non-alcoholic shot of nepenthe schnapps	1	good	Last Available: "2007-06"
+2670	twisted mirror blinking Mariner's Friend cough drops	1		Last Available: "2007-06"
+2671	practically non-alcoholic drinkable shot of nepenthe schnapps	1	good	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	oxidized bottle of cat tonic	0		Effect: "Witch's Brood", Effect Duration: 30, Last Available: "2007-06"
@@ -2661,7 +2661,7 @@
 2688	huge Jeselnik's dreadlock whip of wisdom of chilblains	0		Mysticality: +15, Cold Damage: +25, Sleaze Damage: +25
 2689	fireproof smelly beer-a-pult	0		Stench Spell Damage: +10, Hot Resistance: +3
 2690	foul-smelling banded cast-iron legacy paddle	0		Damage Absorption: +100, Stench Damage: +10
-2691	adequate half-sized handful of nuts and berries	2	good	
+2691	half-sized adequate handful of nuts and berries	2	good	
 2692	teal experienced driftwood sculpture of vim and vigor	0		Experience: +2, Maximum HP Percent: +50
 2693	shaking veiny massive sitar of the sewer	0		Maximum HP: +10, Stench Damage: +25
 2694	lard-coated coward's wicked stone baseball cap	0		Spell Damage: +5, Monster Level: -20, Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, cap 48"
@@ -2695,24 +2695,24 @@
 2722	Usain Bolt's nasty Staff of the Greasefire of the pedagogue of the boozehound	0		Experience: +3, Stench Damage: +5, Booze Drop: +100, Initiative: +80
 2723	ghostly Lo Pan's groovy Staff of the Grand Flamb&eacute; of incineration	0		Moxie Percent: +10, Spell Critical Percent: +30, Hot Spell Damage: +50
 2724	bland bowl of rye sprouts	3	decent	
-2725	diet normal cob of corn	1	good	
+2725	normal diet cob of corn	1	good	
 2726	normal skewed juniper berries	4	good	
-2727	moldy massive purple blurry plum	6	crappy	
-2728	snack-sized bland pear	2	decent	
+2727	massive moldy blurry purple plum	6	crappy	
+2728	bland snack-sized pear	2	decent	
 2729	moldy upside-down peach	4	crappy	
-2730	high-proof aged plum wine	6	awesome	
-2731	mediocre pulsating jittery shot of pear schnapps	3	decent	
-2732	artisanal practically non-alcoholic shot of peach schnapps	1	EPIC	
-2733	toothsome wobbly jittery bunch of square grapes	3	awesome	
+2730	aged high-proof plum wine	6	awesome	
+2731	mediocre jittery pulsating shot of pear schnapps	3	decent	
+2732	practically non-alcoholic artisanal shot of peach schnapps	1	EPIC	
+2733	toothsome jittery wobbly bunch of square grapes	3	awesome	
 2734	big adequate brown sugar cane	5	good	
 2735	flavorless twirling sandwich of the gods	3	decent	
 2736	artisanal twirling Pan-Dimensional Gargle Blaster	3	super ultra EPIC	
-2737	boiled lime green upside-down leopard-print barbell	1	decent	
+2737	boiled upside-down lime green leopard-print barbell	1	decent	
 2738	pile of smoking rags	0		
 2739	Vulcanized bouncing panty raider camouflage	0		Effect: "Vitamin-Maxed", Effect Duration: 38
 2740	Van der Graaf Staff of the Walk-In Freezer of Gandalf of temperance	0		Spell Critical Percent: +20, Sleaze Resistance: +5, MP Regen Min: 5, MP Regen Max: 7
-2741	watered-down smooth boilermaker	2	awesome	
-2742	jumbo flavorless spinning steel lasagna	5	quest	
+2741	smooth watered-down boilermaker	2	awesome	
+2742	flavorless jumbo spinning steel lasagna	5	quest	
 2743	bad weak steel margarita	2	quest	
 2744	diluted spinning wobbly steel-scented air freshener	1		
 2745	irradiated upside-down gremlin mutagen	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 34
@@ -2737,7 +2737,7 @@
 2764	greedy aromatic Order of the Silver Wossname of temperance	0		Stench Resistance: +1, Sleaze Resistance: +5, Meat Drop: +20, Single Equip
 2765	ghostly Harold's bell	0		
 2766	blinking bowling ball	0		
-2767	spoiled half-sized Crimbo pie	2	crappy	
+2767	half-sized spoiled Crimbo pie	2	crappy	
 2768	gigantic spoiled pear tart	7	crappy	
 2769	toothsome peach pie	3	awesome	
 2770	activated energized chunk of rock salt	0		Effect: "Human-Machine Hybrid", Effect Duration: 69
@@ -2771,7 +2771,7 @@
 2798	green bouncing blinking scandalous frosty Mudflap-Girl Earring	0		Cold Spell Damage: +10, Sleaze Damage: +5, Single Equip
 2799	blinking chilly rock-hard Mudflap-Girl Necklace	0		Damage Reduction: 5, Cold Damage: +5, Single Equip
 2800	ghostly scandalous smartaleck's Mudflap-Girl Ring	0		Moxie Percent: +30, Sleaze Damage: +5, Single Equip
-2801	twirling green vial of Gnomochloric acid	0		
+2801	green twirling vial of Gnomochloric acid	0		
 2802	flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	dry warmed ghostly vial of hamethyst juice	0		Effect: "Berry Elemental", Effect Duration: 35
@@ -2813,7 +2813,7 @@
 2840	delicious practically non-alcoholic jittery bottle of cooking sherry	1	awesome	
 2841	massive stale packet of ketchup	7	decent	
 2842	mediocre accidental cider	3	decent	
-2843	normal miniature skewed dire fudgesicle	2	good	
+2843	miniature normal skewed dire fudgesicle	2	good	
 2844	fireproof occult navel ring of navel gazing of the ox of chilblains	0		Muscle: +20, Spell Damage Percent: +25, Cold Damage: +25, Hot Resistance: +3, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	ghostly class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2826,7 +2826,7 @@
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	tumbling mirror censurious padded huge mosquito proboscis	0		Damage Absorption: +20, Sleaze Resistance: +3
-2856	colloidal pulsating ghostly swamp lolly	0		Effect: "Brocolate Brostidigitation", Effect Duration: 54
+2856	colloidal ghostly pulsating swamp lolly	0		Effect: "Brocolate Brostidigitation", Effect Duration: 54
 2857	alkaline diffused huge seegar butt	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 69
 2858	squat bottled swamp gas	0		
 2859	Lo Pan's Fonzie's witch wart	0		Experience (Moxie): +1, Spell Critical Percent: +30
@@ -2910,10 +2910,10 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	bouncing Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	flavorless immense Surprise Egg	10	decent	
+2940	immense flavorless Surprise Egg	10	decent	
 2941	activated corrupted blurry olive Steal This Candy	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 40
 2942	electrified chocolate filthy lucre	0		Effect: "Cat Class, Cat Style", Effect Duration: 59
-2943	nitrogenated warmed anodized blurry skewed Angry Farmer's Wife Candy	0		Effect: "Thanksgot", Effect Duration: 11
+2943	nitrogenated warmed anodized skewed blurry Angry Farmer's Wife Candy	0		Effect: "Thanksgot", Effect Duration: 11
 2945	Jack Frost's therapeutic party hat	0		Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "4xLep, cap 7"
 2946	scorching occult V for Vivala mask	0		Spell Damage Percent: +25, Hot Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	huge The Big Book of Pirate Insults	0		
@@ -2929,9 +2929,9 @@
 2957	rum barrel charrrm	0		
 2958	rotten ghostly tube of cranberry Go-Goo	4	crappy	
 2959	hardy rum barrel charrrm bracelet	0		Maximum HP: +50
-2960	super-sized bland huge single-serving herbal stuffing	5	decent	
+2960	bland super-sized huge single-serving herbal stuffing	5	decent	
 2961	stale blinking packet of tofurkey gravy	4	decent	
-2962	delicious super-sized tofurkey nugget	5	awesome	
+2962	super-sized delicious tofurkey nugget	5	awesome	
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	mizzenmast mop	0		
@@ -2957,12 +2957,12 @@
 2985	copper ha'penny charrrm bracelet of the empath	0		Familiar Weight: +5
 2986	yellow tongue charrrm	0		
 2987	gravedigger's strapping tongue charrrm bracelet	0		Muscle: +5, Spooky Damage: +10, Single Equip
-2988	narrow maroon bit of clingfilm	0		
+2988	maroon narrow bit of clingfilm	0		
 2989	supercharged clingfilm trousers	0		Maximum MP Percent: +30, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
 2990	therapeutic clingfilm cap of the pedagogue	0		Experience: +3, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, cap 37"
 2991	upside-down hale clingfilm slippers	0		Maximum HP: +20, Single Equip
 2992	pulsating clingfilm tangle	0		
-2993	flavorless big vinegar-soaked lemon slice	5	decent	
+2993	big flavorless vinegar-soaked lemon slice	5	decent	
 2994	non-modified blurry true grit	0		Effect: "Stop and Smell the Fudge", Effect Duration: 69
 2995	purple executive buoybottoms of the dark arts of the detective	0		Spell Damage Percent: +100, Item Drop: +20, Meat Drop: +40, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	upside-down double-paned grungy flannel shirt	0		Cold Resistance: +5
@@ -2995,28 +2995,28 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	delicious corpse on the beach	3	awesome	
-3026	artisanal distilled mirror corpsetini	5	EPIC	
-3027	weak perfectly mixed twirling corpsedriver	2	super ultra mega EPIC	
-3028	drinkable practically non-alcoholic twirling Corpse Island iced tea	1	good	
+3026	distilled artisanal mirror corpsetini	5	EPIC	
+3027	perfectly mixed weak twirling corpsedriver	2	super ultra mega EPIC	
+3028	practically non-alcoholic drinkable twirling Corpse Island iced tea	1	good	
 3029	drinkable bouncing red-headed corpse	3	good	
 3030	tolerable kamicorpse-ee	3	good	
-3031	drinkable fancy weak corpsel	2	good	Effect: "Heavily Breathing", Effect Duration: 15
+3031	drinkable weak fancy corpsel	2	good	Effect: "Heavily Breathing", Effect Duration: 15
 3032	smooth high-proof corpsebite	8	awesome	
 3033	upside-down huge steel-toed pirate fledges	0		Damage Reduction: 9
 3034	pulsating piece of thirteen	0		
 3035	snack-sized adequate pearl onion	2	good	
 3036	bland jittery sea biscuit	4	decent	
-3037	spirit-forward hand-crafted bottle of rum	5	EPIC	
+3037	hand-crafted spirit-forward bottle of rum	5	EPIC	
 3038	watered-down hand-crafted bottle of black-label rum	2	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	twirling joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	shaking metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	shaking ghostly metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	ghostly shaking metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	bland nanite-infested gingerbread bugbear	3	decent	Last Available: "2007-12"
 3046	bland enchanted nanite-infested candy cane	3	decent	Effect: "Fudgehound", Effect Duration: 45, Last Available: "2020-09"
-3047	enchanted normal immense nanite-infested fruitcake	10	good	Effect: "Phairly Balanced", Effect Duration: 10, Last Available: "2007-12"
+3047	normal immense enchanted nanite-infested fruitcake	10	good	Effect: "Phairly Balanced", Effect Duration: 10, Last Available: "2007-12"
 3048	fortified acceptable nanite-infested eggnog	5	good	Last Available: "2007-12"
 3049	squat El Vibrato power sphere	0		
 3050	hardy eyepatch	0		Maximum HP: +50, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3024,7 +3024,7 @@
 3052	huge rosewater-soaked breeches	0		Stench Resistance: +3, Familiar Effect: "stench atk, 1xPotato"
 3053	mood ring	0		Last Available: "2007-02"
 3054	warmed nitrogenated candy heart	0		Effect: "Bonelording", Effect Duration: 30, Last Available: "2007-02"
-3055	deionized olive spinning cymbal syrup	0		Free Pull, Effect: "Mystically Oiled", Effect Duration: 61, Last Available: "2007-02"
+3055	deionized spinning olive cymbal syrup	0		Free Pull, Effect: "Mystically Oiled", Effect Duration: 61, Last Available: "2007-02"
 3056	huge savvy metallic foil cat ears	0		Mysticality Percent: +20, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	blurry nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
@@ -3149,7 +3149,7 @@
 3177	delicious evil painful penne pasta	3	awesome	
 3178	immense flavorless twirling 3vi1 pr0n m4nic0tti	9	decent	
 3179	huge adequate shaking evil ravioli della hippy	6	good	
-3180	delicious diet evil noodles	1	awesome	
+3180	diet delicious evil noodles	1	awesome	
 3181	extra-concentrated dry extra-enhanced narrow evil potion of potency	0		Effect: "Heart of Pink", Effect Duration: 42
 3182	flattened diffused boiled spinning evil libation of liveliness	0		Effect: "The Power of LOV", Effect Duration: 31
 3183	frozen wet evil tomato juice of powerful power	0		Effect: "Remaining Alive", Effect Duration: 66
@@ -3158,7 +3158,7 @@
 3186	deionized deionized upside-down evil serum of sarcasm	0		Effect: "Abominably Slippery", Effect Duration: 63
 3187	anodized oxidized evil philter of phorce	0		Effect: "Turtle Titters", Effect Duration: 40
 3188	smooth jittery an evil sump'm sump'm	3	awesome	
-3189	practically non-alcoholic special bad olive evil ducha de oro	1	decent	Effect: "Heart of White", Effect Duration: 40
+3189	practically non-alcoholic bad special olive evil ducha de oro	1	decent	Effect: "Heart of White", Effect Duration: 40
 3190	extra-dry hand-crafted spinning red evil horizontal tango	5	EPIC	
 3191	hand-crafted tumbling evil roll in the hay	4	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3176,13 +3176,13 @@
 3204	blurry dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	upside-down dwarvish war mattock	0		
 3206	wobbly dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
-3207	wobbly green dwarvish punchcard	0		
+3207	green wobbly dwarvish punchcard	0		
 3208	small laminated card	0		
 3209	laminated card	0		
 3210	notbig laminated card	0		
 3211	unlarge laminated card	0		
 3212	dwarvish document	0		
-3213	yellow pulsating dwarvish paper	0		
+3213	pulsating yellow dwarvish paper	0		
 3214	dwarvish parchment	0		
 3215	jittery overcharged El Vibrato power sphere	0		
 3216	lime green Fly-By-Knight Heraldry form	0		Free Pull
@@ -3195,13 +3195,13 @@
 3223	sewer nuggets	0		
 3224	olive sewer wad	0		
 3225	perfectly mixed shaking bottle of sewage schnapps	4	EPIC	
-3226	mediocre practically non-alcoholic spinning bottle of Ooze-O	1	decent	
+3226	practically non-alcoholic mediocre spinning bottle of Ooze-O	1	decent	
 3227	rotten C.H.U.M. chum	3	crappy	
 3228	big stale unfortunate dumplings	5	decent	
 3229	blinking decaying goldfish liver	0		
 3230	quantum oil of oiliness	0		Effect: "Tearful, Fearful", Effect Duration: 15
 3231	tattered paper crown of temperance	0		Sleaze Resistance: +5, Familiar Effect: "1xSombrero, cap 15"
-3232	half-sized flavorless vanilla-frosted king cake	2	decent	Last Available: "2008-03"
+3232	flavorless half-sized vanilla-frosted king cake	2	decent	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3212,7 +3212,7 @@
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	Travels with Jerry	0		Skill: "Mudbath"
 3242	tumbling Let Me Be!	0		Skill: "Raise Backup Dancer"
-3243	yellow skewed Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
+3243	skewed yellow Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	huge Summer Nights	0		Skill: "Grease Lightning"
 3245	Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	blurry fortified Ol' Scratch's ol' britches of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
@@ -3294,9 +3294,9 @@
 3322	frightening padded mayfly bait necklace	0		Damage Absorption: +20, Spooky Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	mediocre skewed spinning jar of fermented pickle juice	4	decent	
+3325	mediocre spinning skewed jar of fermented pickle juice	4	decent	
 3326	dehydrated voodoo snuff	1	awesome	
-3327	flavorless immense extra-greasy slider	10	decent	
+3327	immense flavorless extra-greasy slider	10	decent	
 3328	narrow lightning-fast crumpled felt fedora of doom	0		Spooky Spell Damage: +50, Initiative: +40, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	prompt Jim Carey's battered top-hat	0		Monster Level: +25, Adventures: +3, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	wobbly pulsating Sinatra's boxer's shapeless wide-brimmed hat	0		Muscle Percent: +10, Experience (Moxie): +5, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3322,7 +3322,7 @@
 3350	lousy shaking Ralph IX cognac	4	decent	
 3351	blurry spinning llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	maroon zen motorcycle	0		Last Available: "2008-06"
-3353	non-dry polarized tumbling blue llama lama gong	0		Effect: "Tiki Thoughtfulness", Effect Duration: 56, Last Available: "2008-06"
+3353	non-dry polarized blue tumbling llama lama gong	0		Effect: "Tiki Thoughtfulness", Effect Duration: 56, Last Available: "2008-06"
 3354	flavorless banana-frosted king cake	4	decent	Last Available: "2008-08"
 3355	chilly brown plastic baby	0		Cold Damage: +5, Single Equip, Last Available: "2008-08"
 3356	blinking plump juicy grub	0		Last Available: "2008-06"
@@ -3332,20 +3332,20 @@
 3360	blinking stinkbug	0		Last Available: "2008-06"
 3361	pulsating yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	half-sized normal mirror mole mol&eacute;	2	good	Last Available: "2008-06"
+3363	normal half-sized mirror mole mol&eacute;	2	good	Last Available: "2008-06"
 3364	tolerable Morlock's Mark Bourbon	3	good	Last Available: "2008-06"
 3365	quadruple-modified corrupted tarnished Climate Colada	0		Effect: "Stench Jellied", Effect Duration: 60, Last Available: "2008-06"
 3366	diffused digital underground potion	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 26, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	boiled glimmering roc feather	1	crappy	Last Available: "2008-06"
-3369	dried green huge wobbly glimmering phoenix feather	1		Last Available: "2008-06"
+3369	dried wobbly green huge glimmering phoenix feather	1		Last Available: "2008-06"
 3370	diluted shaking glimmering penguin feather	1		Last Available: "2008-06"
 3371	twisted shaking glimmering buzzard feather	1		Effect: "Scrappy, Shadowy", Effect Duration: 10, Last Available: "2008-06"
 3372	modified tumbling spinning glimmering raven feather	1		Effect: "Buggy Flavor", Effect Duration: 5, Last Available: "2008-06"
 3373	twisted jittery glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	lime green The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
-3376	upside-down cyan twirling Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
+3376	twirling upside-down cyan Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	Chorale of Companionship	0		Skill: "Chorale of Companionship"
 3379	tumbling Prelude of Precision	0		Skill: "Prelude of Precision"
@@ -3393,7 +3393,7 @@
 3425	enhanced modified tumbling garbage-juice-flavored Hob-O	0		Effect: "Big Meat Big Prizes", Effect Duration: 52
 3426	tarnished jittery strawberry-flavored Hob-O	0		Effect: "You Know When to Walk Away", Effect Duration: 13
 3427	roll of Hob-Os	0		
-3428	non-chilled upside-down pulsating Everlasting Deckswabber	0		Effect: "Memory of Strength", Effect Duration: 16
+3428	non-chilled pulsating upside-down Everlasting Deckswabber	0		Effect: "Memory of Strength", Effect Duration: 16
 3430	squat bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
@@ -3423,8 +3423,8 @@
 3456	slick trusty torch	0		Moxie: +10, Last Available: "2011-12"
 3457	rosy-cheeked Junior Adventurer's merit badge	0		Maximum HP Percent: +30
 3458	pressed STYX deodorant body spray	0		Effect: "Livin' Large", Effect Duration: 42
-3459	strong acceptable white-label gin	5	good	
-3460	stale special low-calorie tin rations	1	decent	Effect: "Three Days Slow", Effect Duration: 10
+3459	acceptable strong white-label gin	5	good	
+3460	low-calorie special stale tin rations	1	decent	Effect: "Three Days Slow", Effect Duration: 10
 3461	ghostly haiku challenge map	0		
 3462	terrible poem	0		
 3463	aged blue bottle of sake	4	awesome	
@@ -3437,7 +3437,7 @@
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	huge chilly Fonzie's Seasonal Beret of dire peril	0		Experience (Moxie): +1, Weapon Damage: +20, Cold Damage: +5, Familiar Effect: "1xPotato, 1xFairy, cap 25"
-3473	cyan mirror Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
+3473	mirror cyan Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	oxidized quadruple-deionized cranberry cordial	0		Effect: "French Bronilla Brogueishness", Effect Duration: 66
 3475	dry blackberry polite	0		Effect: "Berry Elemental", Effect Duration: 66
 3476	polymerized plum lozenge	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 33
@@ -3454,8 +3454,8 @@
 3487	olive rough fish scale	0		
 3488	pristine fish scale	0		
 3489	moldy twirling mirror beefy fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
-3490	massive normal glistening fish meat	6	good	Effect: "Fishy", Effect Duration: 5
-3491	huge flavorless lime green slick fish meat	8	decent	Effect: "Fishy", Effect Duration: 5
+3490	normal massive glistening fish meat	6	good	Effect: "Fishy", Effect Duration: 5
+3491	flavorless huge lime green slick fish meat	8	decent	Effect: "Fishy", Effect Duration: 5
 3492	narrow brawny fish scimitar of the blizzard	0		Muscle Percent: +20, Cold Spell Damage: +25
 3493	experienced fish stick of the brazier	0		Experience: +2, Hot Spell Damage: +25
 3494	fish bazooka of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5
@@ -3470,10 +3470,10 @@
 3503	acceptable weak glass of brandy	2	good	Last Available: "2011-12"
 3504	French slippers	0		
 3505	blinking LWA ring of the scaredy-cat	0		Monster Level: -15
-3506	upside-down tumbling LARP membership card	0		Last Available: "2008-10"
+3506	tumbling upside-down LARP membership card	0		Last Available: "2008-10"
 3507	purple Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	tumbling groovy scratch 'n' sniff sword	0		Moxie Percent: +10, Last Available: "2008-11"
-3509	pulsating blurry spinning scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
+3509	blurry pulsating spinning scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	bouncing scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	mirror scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
@@ -3489,7 +3489,7 @@
 3522	upside-down up-at-dawn miser's shark jumper	0		Meat Drop: +10, Adventures: +5
 3523	extra-oxidized deionized electrified narrow olive shark cartilage	0		Effect: "Muscularrr", Effect Duration: 64
 3524	polarized anodized mirror eel battery	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 36
-3525	vacuum-sealed extra-dry yellow shaking temporary teardrop tattoo	0		Effect: "Fancy Feasted", Effect Duration: 22
+3525	vacuum-sealed extra-dry shaking yellow temporary teardrop tattoo	0		Effect: "Fancy Feasted", Effect Duration: 22
 3526	brainy scratch 'n' sniff crossbow	0		Mysticality: +5, Last Available: "2008-11"
 3527	pulsating mutant rattlesnake egg	0		
 3528	huge mutant fire ant egg	0		
@@ -3519,24 +3519,24 @@
 3552	fuchsia scandalous sage octopus's spade of extreme caution	0		Mysticality Percent: +10, Monster Level: -25, Sleaze Damage: +5
 3553	spinning soggy seed packet	0		
 3554	glob of slime	0		
-3555	tiny moldy ghostly yellow wobbly sea carrot	1	crappy	
+3555	moldy tiny wobbly ghostly yellow sea carrot	1	crappy	
 3556	snack-sized adequate sea cucumber	2	good	
-3557	special bland blurry sea avocado	4	decent	Effect: "Warm Belly", Effect Duration: 50
-3558	moldy half-sized sea lychee	2	crappy	
-3559	half-sized moldy sea tangelo	2	crappy	
-3560	immense stale skewed sea honeydew	7	decent	
-3561	anodized bouncing cyan pressurized potion of puissance	0		Effect: "familiar.enq", Effect Duration: 61
+3557	bland special blurry sea avocado	4	decent	Effect: "Warm Belly", Effect Duration: 50
+3558	half-sized moldy sea lychee	2	crappy	
+3559	moldy half-sized sea tangelo	2	crappy	
+3560	stale immense skewed sea honeydew	7	decent	
+3561	anodized cyan bouncing pressurized potion of puissance	0		Effect: "familiar.enq", Effect Duration: 61
 3562	super-adjusted flattened non-moist pressurized potion of perspicacity	0		Effect: "Chlorophyll Flavor", Effect Duration: 14
 3563	unsweetened energized skewed pressurized potion of pulchritude	0		Effect: "Gemini Rising", Effect Duration: 61
 3564	acceptable berry-infused sake	4	good	
-3565	aged practically non-alcoholic bouncing citrus-infused sake	1	awesome	
+3565	practically non-alcoholic aged bouncing citrus-infused sake	1	awesome	
 3566	smooth melon-infused sake	3	awesome	
 3567	slab of sponge	0		
 3568	chaotic MacGyver's dance instructor's sponge helmet	0		Experience Percent (Moxie): +10, Maximum MP: +100, Spell Critical Percent: +10, Familiar Effect: "atk, 1xFairy"
 3569	Sherlock's stiffened spongy shield of the sweet-tooth	0		Damage Reduction: 15, Item Drop: +25, Candy Drop: +100
 3570	spinning blinking wicked Rosewater's square sponge pants of Leguizamo	0		Mysticality Percent: +30, Spell Damage: +5, Monster Level: +20, Familiar Effect: "hot atk, 1xPotato"
 3571	mirror flytrap pellet	0		
-3572	squat olive baby cuddlefish	0		
+3572	olive squat baby cuddlefish	0		
 3573	upside-down six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	sand dollar	0		
@@ -3553,7 +3553,7 @@
 3587	chilled spinning squat sugar plum	0		Effect: "Hypercubed", Effect Duration: 19, Last Available: "2008-12"
 3588	polymerized sugar banana	0		Effect: "Sweet Taste", Effect Duration: 56, Last Available: "2008-12"
 3589	moist pulsating sugar lime	0		Effect: "Black Eyes", Effect Duration: 12, Last Available: "2008-12"
-3590	dry frozen blinking red sugar cherry	0		Effect: "Memories of Puppy Love", Effect Duration: 26, Last Available: "2008-12"
+3590	dry frozen red blinking sugar cherry	0		Effect: "Memories of Puppy Love", Effect Duration: 26, Last Available: "2008-12"
 3591	smelly curative Mer-kin hookspear	0		Stench Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	narrow Mer-kin thingpouch	0		
@@ -3573,7 +3573,7 @@
 3607	fireproof gravedigger's beefcake's aerated diving helmet	0		Muscle: +25, Spooky Damage: +10, Hot Resistance: +3, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	twirling blurry live nautical mine	0		
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
-3610	ghostly upside-down green imitation whetstone	0		
+3610	upside-down ghostly green imitation whetstone	0		
 3611	enhanced sea grease	0		Effect: "Greasy Flavor", Effect Duration: 20
 3612	pulsating huge blue sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	battered Crimbo Crate	0		Last Available: "2008-12"
@@ -3593,7 +3593,7 @@
 3627	blue blurry ribald parasitic strangleworm	0		Sleaze Damage: +10, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	bouncing burrowgrub hive	0		Last Available: "2008-12"
-3630	cyan blinking Crimbo crate	0		Last Available: "2008-12"
+3630	blinking cyan Crimbo crate	0		Last Available: "2008-12"
 3631	diffused ionized blinking Gummi-DNA	0		Effect: "Egg-stra Arm", Effect Duration: 31, Last Available: "2020-09"
 3632	ghostly radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	scorching banded elven socks	0		Damage Absorption: +100, Hot Damage: +25, Last Available: "2008-12"
@@ -3609,13 +3609,13 @@
 3643	spinning pufferfish spine	0		
 3644	depleted Grimacite kneecapping stick of extreme caution	0		Monster Level: -25, Last Available: "2007-06"
 3645	fortified bad canteen of wine	5	decent	Last Available: "2008-12"
-3646	half-sized normal elven <i>limbos</i> gingerbread	2	good	Last Available: "2008-12"
+3646	normal half-sized elven <i>limbos</i> gingerbread	2	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	toothsome special bite-sized blinking toast with jam	1	awesome	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	mediocre spirit-forward blinking elven moonshine	5	decent	Last Available: "2008-12"
+3650	bite-sized toothsome special blinking toast with jam	1	awesome	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	spirit-forward mediocre blinking elven moonshine	5	decent	Last Available: "2008-12"
 3653	rotten knuckle sandwich	4	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	asbestos-lined hale psycho sweater	0		Maximum HP: +20, Hot Resistance: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
@@ -3624,11 +3624,11 @@
 3658	banded plastic fat stack of cash	0		Damage Absorption: +100, Last Available: "2008-12"
 3659	deadly plastic strand of DNA	0		Weapon Damage: +5, Last Available: "2008-12"
 3660	stylish plastic chunk of depleted Grimacite	0		Moxie: +25, Last Available: "2008-12"
-3661	teal twirling container of Putty	0		Last Available: "2009-01"
+3661	twirling teal container of Putty	0		Last Available: "2009-01"
 3662	forbidden Putty mitre	0		Spell Damage Percent: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 3663	family-friendly Socratic Putty leotard	0		Experience (Mysticality): +1, Sleaze Resistance: +1, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Putty ball of chilblains	0		Cold Damage: +25, Softcore Only, Last Available: "2009-01"
-3665	tumbling fuchsia Putty sheet	0		Last Available: "2009-01"
+3665	fuchsia tumbling Putty sheet	0		Last Available: "2009-01"
 3666	toasty Jim Carey's extremely unsafe Putty snake	0		Weapon Damage Percent: +100, Monster Level: +25, Hot Damage: +5, Softcore Only, Last Available: "2009-01"
 3667	upside-down Putty monster	0		Last Available: "2009-01"
 3668	careful glow-in-the-dark wristwatch of the businessman	0		Monster Level: -10, Meat Drop: +50, Single Equip, Last Available: "2009-01"
@@ -3644,15 +3644,15 @@
 3678	bad salinated mint julep	4	decent	
 3679	ink bladder	0		
 3680	esca	0		
-3681	red huge bubbling tempura batter	0		
+3681	huge red bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	purple map to the Marinara Trench	0		
-3684	small flavorless tempura carrot	2	decent	
+3684	flavorless small tempura carrot	2	decent	
 3685	spoiled low-calorie tempura cucumber	1	crappy	
-3686	stale low-calorie ghostly bouncing tempura avocado	1	decent	
+3686	low-calorie stale bouncing ghostly tempura avocado	1	decent	
 3687	adequate sea broccoli	4	good	
-3688	moldy miniature tumbling sea cauliflower	2	crappy	
-3689	miniature stale skewed olive tempura broccoli	2	decent	
+3688	miniature moldy tumbling sea cauliflower	2	crappy	
+3689	stale miniature olive skewed tempura broccoli	2	decent	
 3690	rotten blurry tempura cauliflower	3	crappy	
 3691	spoiled spinning sea blueberry	4	crappy	
 3692	decent sea persimmon	3	good	
@@ -3693,7 +3693,7 @@
 3727	narrow Nardz energy beverage	0		
 3728	mirror pile of coins	0		
 3729	hand grenegg	0		
-3730	olive skewed caret	0		
+3730	skewed olive caret	0		
 3731	wholesome glass gnoll eye	0		Maximum HP Percent: +10
 3732	dry cigar butt	0		Effect: "Spell Transfer Complete", Effect Duration: 14
 3733	lightning-fast thinker's manly bloomers	0		Mysticality: +10, Initiative: +40, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	frosty dance instructor's handwarmer	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Single Equip
 3737	tumbling stanky razor-sharp lighter	0		Weapon Damage Percent: +25, Stench Spell Damage: +25
-3738	stale fancy gigantic packet of beer nuts	10	decent	Effect: "Jittery", Effect Duration: 20
+3738	gigantic stale fancy packet of beer nuts	10	decent	Effect: "Jittery", Effect Duration: 20
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,7 +3713,7 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	irradiated polarized concoction of clumsiness	0		Effect: "Locks Like the Raven", Effect Duration: 48
 3750	scandalous vampire pearl earring	0		Sleaze Damage: +5, Single Equip
-3751	decent enchanted immense chocolate chip brownies	8	good	Effect: "Spooky Hands", Effect Duration: 50
+3751	immense enchanted decent chocolate chip brownies	8	good	Effect: "Spooky Hands", Effect Duration: 50
 3753	skewed Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	alkaline quadruple-dry maroon love song of vague ambiguity	0		Effect: "Can't Smell Nothin'", Effect Duration: 32, Last Available: "2009-02"
 3755	super-ionized irradiated love song of smoldering passion	0		Effect: "Indescribable Flavor", Effect Duration: 51, Last Available: "2009-02"
@@ -3727,13 +3727,13 @@
 3763	aged twirling slug of vodka	4	awesome	
 3764	lousy watered-down slug of rum	2	decent	
 3765	drinkable slug of shochu	3	good	
-3766	drinkable weak screwdiver	2	good	
-3767	drinkable boozy narrow dew yoana lei	5	good	
-3768	triple-distilled aged mirror lychee chuhai	7	awesome	
+3766	weak drinkable screwdiver	2	good	
+3767	boozy drinkable narrow dew yoana lei	5	good	
+3768	aged triple-distilled mirror lychee chuhai	7	awesome	
 3769	tolerable salacious screwdiver	4	good	
-3770	practically non-alcoholic drinkable fancy dew yoana salacious lei	1	good	Effect: "Elemental Mastery", Effect Duration: 25
-3771	fortified drinkable salacious lychee chuhai	5	good	
-3772	acceptable weak Alewife&trade; Ale	2	good	
+3770	fancy drinkable practically non-alcoholic dew yoana salacious lei	1	good	Effect: "Elemental Mastery", Effect Duration: 25
+3771	drinkable fortified salacious lychee chuhai	5	good	
+3772	weak acceptable Alewife&trade; Ale	2	good	
 3773	tumbling seaode	0		
 3774	bouncing map to the Dive Bar	0		
 3775	spinning Mer-kin pinkslip	0		
@@ -3758,7 +3758,7 @@
 3803	upside-down knitted energetic therapeutic Mer-kin roundshield	0		Maximum MP Percent: +20, Cold Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 14
 3804	pulsating lard-coated Mer-kin breastplate of the sewer	0		Stench Damage: +25, Sleaze Spell Damage: +25
 3805	fortified Mer-kin sneakmask of the boozehound	0		Damage Absorption: +60, Booze Drop: +100, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
-3806	olive blinking Mer-kin prayerbeads	0		
+3806	blinking olive Mer-kin prayerbeads	0		
 3807	improved chilled polarized bouncing Mer-kin hidepaint	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 32
 3808	Mer-kin trailmap	0		
 3809	pulsating Mer-kin healscroll	0		
@@ -3768,7 +3768,7 @@
 3813	red squat Herculean plastic baby	0		Experience (Muscle): +1, Single Equip, Last Available: "2009-06"
 3815	skewed midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	normal huge sea radish	8	good	
+3817	huge normal sea radish	8	good	
 3818	mirror inspector's foul-smelling halibut of the storm	0		Maximum MP Percent: +40, Stench Damage: +10, Item Drop: +15
 3819	teal eel sauce	0		
 3820	crafty water-polo mitt	0		Maximum MP: +10, Single Equip
@@ -3791,7 +3791,7 @@
 3837	cyan Van der Graaf anniversary safety glass vest	0		MP Regen Min: 5, MP Regen Max: 7
 3838	Socratic anniversary burlap belt	0		Experience (Mysticality): +1
 3839	careful anniversary balsa wood socks	0		Monster Level: -10
-3840	fuchsia huge anniversary latex mask	0		Familiar Weight: +1
+3840	huge fuchsia anniversary latex mask	0		Familiar Weight: +1
 3841	anniversary pewter cape of the ox	0		Muscle: +20
 3842	mirror wholesome out-of-tune biwa	0		Maximum HP Percent: +10
 3843	Socratic dented harmonica	0		Experience (Mysticality): +1
@@ -3828,7 +3828,7 @@
 3874	hellseal hide	0		
 3875	wobbly shredded hellseal hide	0		
 3876	hellseal brain	0		
-3877	mirror tumbling burst hellseal brain	0		
+3877	tumbling mirror burst hellseal brain	0		
 3878	fuchsia pulsating hellseal sinew	0		
 3879	torn hellseal sinew	0		
 3880	hellseal disguise	0		
@@ -3837,14 +3837,14 @@
 3883	cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	altered quantum jittery vial of slime	0		Effect: "So You Can Work More...", Effect Duration: 21
-3886	moist polymerized jittery blinking vial of slime	0		Effect: "Spookyravin'", Effect Duration: 17
+3886	moist polymerized blinking jittery vial of slime	0		Effect: "Spookyravin'", Effect Duration: 17
 3887	flattened vial of slime	0		Effect: "Nasty, Nasty Breath", Effect Duration: 54
 3888	diffused corrupted blinking vial of slime	0		Effect: "Pla-see-bo", Effect Duration: 50
 3889	irradiated ionized vial of slime	0		Effect: "Big Meat Big Prizes", Effect Duration: 44
 3890	tarnished enhanced pulsating vial of violet slime	0		Effect: "Night Vision", Effect Duration: 33
 3891	frozen boiled colloidal mirror blurry vial of vermilion slime	0		Effect: "Lobos Fresh", Effect Duration: 46
 3892	oxidized upside-down twirling vial of amber slime	0		Effect: "Disco Concentration", Effect Duration: 62
-3893	corrupted wobbly ghostly vial of chartreuse slime	0		Effect: "Cravin' for a Ravin'", Effect Duration: 22
+3893	corrupted ghostly wobbly vial of chartreuse slime	0		Effect: "Cravin' for a Ravin'", Effect Duration: 22
 3894	dry vial of teal slime	0		Effect: "[800]Chocolate Reign", Effect Duration: 57
 3895	adjusted polarized purple vial of indigo slime	0		Effect: "Baconstoned", Effect Duration: 26
 3896	Vulcanized colloidal ghostly vial of slime	0		Effect: "Medieval Mage Mayhem", Effect Duration: 17
@@ -3896,7 +3896,7 @@
 3944	foul-smelling shadowy seal eye of horror	0		Stench Damage: +10, Spooky Spell Damage: +25, Class: "Seal Clubber"
 3945	razor-sharp oyster egg balloon	0		Weapon Damage Percent: +25
 3946	Clan VIP Lounge invitation	0		Free Pull
-3947	twirling purple Clan VIP Lounge key	0		Free Pull
+3947	purple twirling Clan VIP Lounge key	0		Free Pull
 3948	squat Meat	0		
 3949	tumbling treasure chest	0		
 3950	key	0		
@@ -3986,7 +3986,7 @@
 4034	cyan mirror memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	low-calorie spoiled olive huge narrow slimy sweetbreads	1	crappy	
+4037	low-calorie spoiled huge narrow olive slimy sweetbreads	1	crappy	
 4038	hand-crafted slimy fermented bile bladder	3	EPIC	
 4039	denatured ghostly slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	perfumed ring of teleportation	0		Stench Resistance: +5, Single Equip
 4052	glass of baboon milk	1	awesome	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	watered-down bad White Hyborian	2	decent	Last Available: "2009-06"
+4054	bad watered-down White Hyborian	2	decent	Last Available: "2009-06"
 4055	chilly goblin hunting spear	0		Cold Damage: +5, Last Available: "2009-06"
 4056	ghostly quilted goblin autoblowgun of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +40, Last Available: "2009-06"
 4057	twirling steel-toed tribal beads	0		Damage Reduction: 9, Last Available: "2009-06"
@@ -4011,7 +4011,7 @@
 4059	coward's stone head	0		Monster Level: -20, Damage Reduction: 5, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	upside-down cyan Violet Hunt Invitation	0		Last Available: "2009-06"
-4062	squat pulsating Blue Milk Club Card	0		Last Available: "2009-06"
+4062	pulsating squat Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	tumbling extremely unsafe grisly shield of Leguizamo	0		Weapon Damage Percent: +100, Monster Level: +20, Slime Hates It: +1, Damage Reduction: 13
 4081	bouncing wicked beefcake's corroded breeches	0		Muscle: +25, Spell Damage: +5, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	lion tamer's pernicious cudgel of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Slime Hates It: +1
-4083	toothsome half-sized yellow cupcake-in-a-cup	2	awesome	Last Available: "2009-06"
+4083	half-sized toothsome yellow cupcake-in-a-cup	2	awesome	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	flavorless protein paste	4	decent	Last Available: "2009-06"
 4086	Fonzie's beefcake's cyber-mattock	0		Muscle: +25, Experience (Moxie): +1, Last Available: "2009-06"
@@ -4081,7 +4081,7 @@
 4129	lightning-fast double-paned electrified hardened slime belt	0		Cold Resistance: +5, Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	diluted blurry boot plant	1	awesome	Effect: "Well-Oiled", Effect Duration: 25, Last Available: "2009-06"
-4132	perfectly mixed irresponsibly strong sham champagne	7	EPIC	Last Available: "2009-06"
+4132	irresponsibly strong perfectly mixed sham champagne	7	EPIC	Last Available: "2009-06"
 4133	deionized modified tempura air	0		Effect: "The Halls of Moxiousness", Effect Duration: 22
 4134	chilled tumbling squat pressurized potion of pneumaticity	0		Effect: "Well Owl Be!", Effect Duration: 58
 4135	squat moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4091,7 +4091,7 @@
 4139	green a creased paper strip	0		
 4140	a folded paper strip	0		
 4141	a crinkled paper strip	0		
-4142	teal blinking a crumpled paper strip	0		
+4142	blinking teal a crumpled paper strip	0		
 4143	a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	Sinatra's funny paper hat	0		Experience (Moxie): +5, Familiar Effect: "1xVolley, 1xLep, cap 2"
@@ -4104,12 +4104,12 @@
 4152	denatured Elvish delight	0		Effect: "Human-Elemental Hybrid", Effect Duration: 43
 4153	teal rockfish stomach	0		Last Available: "2009-09"
 4154	red live lobster	0		Last Available: "2011-12"
-4155	yellow tumbling wok lobster	0		Last Available: "2011-12"
+4155	tumbling yellow wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
 4157	gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	blinking rock lobster	0		Last Available: "2009-09"
-4160	mediocre weak pebblebr&auml;u	2	decent	Last Available: "2009-09"
+4160	weak mediocre pebblebr&auml;u	2	decent	Last Available: "2009-09"
 4161	normal twirling rocky road ice cream	3	good	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	polymerized children of the candy corn	0		Effect: "Nuts about Candy", Effect Duration: 28
@@ -4132,7 +4132,7 @@
 4180	shaking savvy sugar shank	0		Mysticality Percent: +20, Last Available: "2009-09"
 4181	shaking teal lard-coated gravedigger's sugar chapeau of bravery	0		Spooky Damage: +10, Sleaze Spell Damage: +25, Spooky Resistance: +5, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
 4182	sugar shorts of the sweet-tooth	0		Candy Drop: +100, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
-4183	ghostly pulsating sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4183	pulsating ghostly sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	mirror slime convention flyers	0		
 4186	slime convention coupons	0		
@@ -4207,7 +4207,7 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	concentrated galvanized squat sap	0		Effect: "Liquid Luck", Effect Duration: 26, Last Available: "2009-10"
 4257	bouncing petrified wood	0		Last Available: "2009-10"
-4258	rotten olive shaking chocolate-covered scarab beetle	3	crappy	Last Available: "2009-10"
+4258	rotten shaking olive chocolate-covered scarab beetle	3	crappy	Last Available: "2009-10"
 4259	tolerable mulled cider	4	good	Last Available: "2009-10"
 4260	skewed wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	spinning pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4279,7 +4279,7 @@
 4327	mirror blinking double-paned dangerous smooth La Hebilla del Cintur&oacute;n de Lopez	0		Moxie: +15, Weapon Damage: +10, Cold Resistance: +5, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	rotten immense special narrow candy kneecapping stick	9	crappy	Effect: "Night of the Nachos", Effect Duration: 20, Last Available: "2009-12"
+4330	rotten special immense narrow candy kneecapping stick	9	crappy	Effect: "Night of the Nachos", Effect Duration: 20, Last Available: "2009-12"
 4331	spoiled immense wobbly licorice garrote	10	crappy	Last Available: "2009-12"
 4332	squat knitted candy knuckles	0		Cold Resistance: +3, Last Available: "2009-12"
 4333	decent jawbruiser	3	good	Last Available: "2010-12"
@@ -4291,7 +4291,7 @@
 4339	twirling olive slick plastic Crimbomination	0		Moxie: +10, Last Available: "2009-12"
 4340	diffused red Piddles	0		Effect: "Carol of the Bones", Effect Duration: 17, Last Available: "2009-12"
 4341	dry BitterSweetTarts	0		Effect: "Broken Bone Nubs", Effect Duration: 37, Last Available: "2009-12"
-4342	deionized pressed cyan blurry skewed Polka Pop	0		Effect: "Using Protection", Effect Duration: 60, Last Available: "2009-12"
+4342	deionized pressed cyan skewed blurry Polka Pop	0		Effect: "Using Protection", Effect Duration: 60, Last Available: "2009-12"
 4343	yellow Crimbuck	0		Last Available: "2009-12"
 4344	pulsating Crimbo wreath	0		Last Available: "2009-12"
 4345	string of Crimbo lights	0		Last Available: "2009-12"
@@ -4309,12 +4309,12 @@
 4357	shaking shaking A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	skewed A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	big normal special expired can of franks 'n' beans	5	good	Effect: "Cock of the Walk", Effect Duration: 25, Last Available: "2009-12"
-4361	hand-crafted extra-dry jittery expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
+4360	big special normal expired can of franks 'n' beans	5	good	Effect: "Cock of the Walk", Effect Duration: 25, Last Available: "2009-12"
+4361	extra-dry hand-crafted jittery expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	unsweetened quadruple-energized elven suicide capsule	0		Effect: "Destructive Resolve", Effect Duration: 41, Last Available: "2009-12"
-4365	spoiled half-sized upside-down penguin focaccia bread	2	crappy	Last Available: "2009-12"
+4365	half-sized spoiled upside-down penguin focaccia bread	2	crappy	Last Available: "2009-12"
 4366	triple-distilled drinkable herringcello	9	good	Last Available: "2009-12"
 4367	bad elven cellocello	3	decent	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
@@ -4420,7 +4420,7 @@
 4472	BRICKO pants of chilblains	0		Cold Damage: +25, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	electrified BRICKO sword	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
-4475	huge yellow BRICKO bat	0		Last Available: "2010-02"
+4475	yellow huge BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	spinning bouncing BRICKO turtle	0		Last Available: "2010-02"
 4478	squat BRICKO elephant	0		Last Available: "2010-02"
@@ -4437,7 +4437,7 @@
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	tumbling gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	wobbly BRICKO brick	0		Last Available: "2010-02"
-4492	tumbling skewed BRICKO brick	0		Last Available: "2010-02"
+4492	skewed tumbling BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
 4494	blurry blue BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
@@ -4453,9 +4453,9 @@
 4505	irradiated unsweetened Northern pemmican	0		Effect: "Elemental Saucesphere", Effect Duration: 39
 4506	cyan puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	polarized maroon squat &quot;DRINK ME&quot; potion	0		Effect: "It Didn't Kill You", Effect Duration: 59, Last Available: "2010-03"
+4508	polarized squat maroon &quot;DRINK ME&quot; potion	0		Effect: "It Didn't Kill You", Effect Duration: 59, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	small flavorless special walrus ice cream	2	decent	Effect: "Human-Pirate Hybrid", Effect Duration: 35, Last Available: "2010-03"
+4510	flavorless small special walrus ice cream	2	decent	Effect: "Human-Pirate Hybrid", Effect Duration: 35, Last Available: "2010-03"
 4511	half-sized rotten beautiful soup	2	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	wobbly Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
@@ -4476,11 +4476,11 @@
 4528	stale dragon snaps	4	decent	Last Available: "2010-03"
 4529	green auspicious horrifying snapdragon pistil	0		Spooky Damage: +25, Item Drop: +10, Last Available: "2010-03"
 4530	upside-down bouncing puff of smoke	0		Last Available: "2010-03"
-4531	moldy snack-sized rook cookie	2	crappy	Last Available: "2010-03"
+4531	snack-sized moldy rook cookie	2	crappy	Last Available: "2010-03"
 4532	normal bishop cookie	3	good	Last Available: "2010-03"
 4533	decent thick knight cookie	5	good	Last Available: "2010-03"
 4534	bland king cookie	4	decent	Last Available: "2010-03"
-4535	tasty miniature spinning narrow queen cookie	2	awesome	Effect: "Towering Strength", Last Available: "2010-03"
+4535	miniature tasty spinning narrow queen cookie	2	awesome	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	sinister insane tophat	0		Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 4538	bouncing veiny wholesome helm of the knight	0		Maximum HP Percent: +10, Maximum HP: +10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
@@ -4495,7 +4495,7 @@
 4547	pulsating caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
-4550	ghostly purple dodo	0		Last Available: "2010-03"
+4550	purple ghostly dodo	0		Last Available: "2010-03"
 4551	bouncing MacGyver's detour shield	0		Maximum MP: +100, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
 4553	bouncing lowercase a	0		
@@ -4510,7 +4510,7 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	drinkable world's most unappetizing beverage	4	good	Last Available: "2010-04"
 4564	family-friendly slippery when wet shield	0		Sleaze Resistance: +1, Damage Reduction: 6, Last Available: "2010-04"
-4565	thick rotten raisin	5	crappy	Last Available: "2010-04"
+4565	rotten thick raisin	5	crappy	Last Available: "2010-04"
 4566	wobbly fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	sizzling flyest of shirts of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50, Last Available: "2010-04"
 4568	moldy a dance upon the palate	3	crappy	Last Available: "2010-04"
@@ -4521,7 +4521,7 @@
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	bouncing panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	huge fuchsia bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	fuchsia huge bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	ionized tumbling Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Space Cadet", Effect Duration: 21, Last Available: "2010-04"
@@ -4529,7 +4529,7 @@
 4581	chilly T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of horror	0		Cold Damage: +5, Spooky Spell Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	normal diet six wedges of goat cheese	1	good	
+4584	diet normal six wedges of goat cheese	1	good	
 4585	olive collection of objects	0		
 4586	boulder	0		
 4587	blue goth	0		
@@ -4552,7 +4552,7 @@
 4604	keg	0		Last Available: "2010-06"
 4605	Sinatra's bottle of Goldschn&ouml;ckered of vim and vigor	0		Experience (Moxie): +5, Maximum HP Percent: +50, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	adequate thick sun-dried tofu	5	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	distilled mediocre squat tumbling soyburger juice	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	mediocre distilled squat tumbling soyburger juice	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	mirror respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	alkaline alkaline essential soy	0		Effect: "You're Rubber", Effect Duration: 24, Last Available: "2010-08"
@@ -4566,7 +4566,7 @@
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
 4620	squat motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
-4621	twirling blurry Game Grid token	0		Last Available: "2010-06"
+4621	blurry twirling Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	liquefied magnetized ionized chocolate-covered caviar	0		Effect: "Natural 20", Effect Duration: 39, Last Available: "2020-09"
 4624	bland pawn cookie	3	decent	Last Available: "2010-06"
@@ -4607,7 +4607,7 @@
 4659	beefy blackberry galoshes	0		Muscle: +10, Single Equip
 4660	green greasy Jack Frost's trout fang	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2010-09"
 4661	low-calorie bland poisonous caviar	1	decent	Last Available: "2010-09"
-4662	modified extra-denatured blinking huge wet venom duct	0		Effect: "From Nantucket", Effect Duration: 26, Last Available: "2010-09"
+4662	modified extra-denatured huge blinking wet venom duct	0		Effect: "From Nantucket", Effect Duration: 26, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	scandalous Ellsbury's skull of the boozehound	0		Sleaze Damage: +5, Booze Drop: +100, Last Available: "2010-09"
 4665	Newton's hot plate	0		Experience (Mysticality): +3, Damage Reduction: 3
@@ -4618,7 +4618,7 @@
 4670	jittery green beer-scented teddy bear	0		
 4671	mediocre weak purple booze-soaked cherry	2	decent	
 4672	green comfy pillow	0		
-4673	jumbo spoiled narrow marshmallow	5	crappy	
+4673	spoiled jumbo narrow marshmallow	5	crappy	
 4674	delicious sponge cake	3	awesome	
 4675	acceptable gin-soaked blotter paper	4	good	
 4676	tree-holed coin	0		
@@ -4661,16 +4661,16 @@
 4713	bouncing popsicle stick	0		
 4714	spoiled narrow lemon popsicle	3	crappy	
 4715	big normal popsicle	5	good	
-4716	miniature tasty squat strawberry popsicle	2	awesome	
-4717	decent jumbo liver popsicle	5	good	
+4716	tasty miniature squat strawberry popsicle	2	awesome	
+4717	jumbo decent liver popsicle	5	good	
 4718	squat beefy mariachi hat	0		Muscle: +10, Familiar Effect: "atk, cap 2"
 4719	pulsating maroon Hollandaise helmet of the wise owl	0		Mysticality: +20, Familiar Effect: "atk, cap 2"
-4720	blinking twirling organ grinder	0		Free Pull, Last Available: "2011-12"
+4720	twirling blinking organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	moldy shaking liver and let pie	4	crappy	Last Available: "2010-10"
 4723	stale badass pie	3	decent	Last Available: "2010-10"
 4724	flavorless miniature blue shoo-fish pie	2	decent	Last Available: "2010-10"
-4725	half-sized bland piping organ pie	2	decent	Last Available: "2010-10"
+4725	bland half-sized piping organ pie	2	decent	Last Available: "2010-10"
 4726	rotten igloo pie	3	crappy	Last Available: "2010-10"
 4727	rotten half-sized blurry gray stomach turnover	2	crappy	Last Available: "2010-10"
 4728	enchanted delicious olive dead lights pie	3	awesome	Effect: "Hair on Your Chest", Effect Duration: 45, Last Available: "2010-10"
@@ -4683,8 +4683,8 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	maroon tangle of rat tails	0		
 4737	Jim Carey's beer-soaked mop	0		Monster Level: +25
-4738	fancy smooth wobbly day-old beer	3	awesome	Effect: "Busy Bein' Delicious", Effect Duration: 40
-4739	special weak artisanal spinning plain beer	2	EPIC	Effect: "Billiards Belligerence", Effect Duration: 5
+4738	smooth fancy wobbly day-old beer	3	awesome	Effect: "Busy Bein' Delicious", Effect Duration: 40
+4739	special artisanal weak spinning plain beer	2	EPIC	Effect: "Billiards Belligerence", Effect Duration: 5
 4740	weak bad overpriced &quot;imported&quot; beer	2	decent	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
@@ -4692,7 +4692,7 @@
 4744	colloidal flattened PlexiPips	0		Effect: "Rad-ish", Effect Duration: 25
 4745	nitrogenated enhanced Wax Flask	0		Effect: "White-boy Angst", Effect Duration: 41
 4746	liquefied non-polarized blurry Pain Dip	0		Effect: "Big Meat Big Prizes", Effect Duration: 23
-4747	flavorless diet bone meal	1	decent	Last Available: "2010-10"
+4747	diet flavorless bone meal	1	decent	Last Available: "2010-10"
 4748	lousy upside-down bone aperitif	4	decent	Last Available: "2010-10"
 4749	bonerang of the bloodbag	0		Maximum HP: +100, Last Available: "2010-10"
 4750	rosy-cheeked bone and arrows	0		Maximum HP Percent: +30, Last Available: "2010-10"
@@ -4709,9 +4709,9 @@
 4761	teal pumpkin	0		Last Available: "2010-11"
 4762	narrow red huge pumpkin	0		Last Available: "2010-11"
 4763	adequate pumpkin pie	4	good	Last Available: "2010-11"
-4764	aged high-proof gray pumpkin beer	8	awesome	Last Available: "2010-11"
+4764	high-proof aged gray pumpkin beer	8	awesome	Last Available: "2010-11"
 4765	diffused tumbling pumpkin juice	0		Effect: "Eagle Eyes", Effect Duration: 43, Last Available: "2010-11"
-4766	maroon huge upside-down jittery pumpkin bomb	0		Last Available: "2010-11"
+4766	huge upside-down jittery maroon pumpkin bomb	0		Last Available: "2010-11"
 4767	ghostly up-at-dawn hardy shin gourds	0		Maximum HP: +50, Adventures: +5, Single Equip, Last Available: "2010-11"
 4768	scandalous rosy-cheeked Staff of the November Jack-O-Lantern of bravery	0		Maximum HP Percent: +30, Sleaze Damage: +5, Spooky Resistance: +5, Last Available: "2010-11"
 4769	pumpkin carriage	0		Last Available: "2010-11"
@@ -4720,11 +4720,11 @@
 4804	ghostly Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	wobbly Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
-4807	blinking upside-down tumbling Unmotivator: Crashed Meat Car	0		Free Pull
+4807	upside-down blinking tumbling Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	stale jumbo pulsating CRIMBCOIDS mints	5	decent	Last Available: "2011-01"
+4818	jumbo stale pulsating CRIMBCOIDS mints	5	decent	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	rotten maroon CRIMBCOLOAF	3	crappy	Last Available: "2011-01"
 4821	moldy circular CRIMBCOOKIE	3	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4739,7 +4739,7 @@
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	skewed robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
-4833	yellow skewed robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
+4833	skewed yellow robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	huge robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
@@ -4779,7 +4779,7 @@
 4870	gray family-friendly Samson's paperclip turban of Flo-Jo	0		Experience (Muscle): +5, Sleaze Resistance: +1, Initiative: +100, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	paperclip cape of courage	0		Spooky Resistance: +3, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
-4873	maroon mirror photocopied monster	0		Last Available: "2011-01"
+4873	mirror maroon photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	ionized diffused chocolate bath ball	0		Effect: "Mushroom Magicalness", Effect Duration: 63, Last Available: "2011-01"
@@ -4864,13 +4864,13 @@
 4961	Subject 37 file	0		
 4962	gray energetic rosy-cheeked mysterious lapel pin	0		Maximum HP Percent: +30, Maximum MP Percent: +20, Single Equip
 4963	narrow state loom	0		Familiar Weight: +10
-4964	mirror blue Evilometer	0		
+4964	blue mirror Evilometer	0		
 4965	Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	narrow Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	upside-down Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
-4970	jittery huge Alice's Army Guard	0		Last Available: "2011-03"
+4970	huge jittery Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	mirror upside-down Alice's Army Ninja	0		Last Available: "2011-03"
 4973	spinning Alice's Army Alchemist	0		Last Available: "2011-03"
@@ -4916,16 +4916,16 @@
 5013	stale skewed wasabi pocky	4	decent	Last Available: "2011-03"
 5014	adequate tobiko pocky	4	good	Last Available: "2011-03"
 5015	flavorless upside-down natto pocky	4	decent	Last Available: "2011-03"
-5016	practically non-alcoholic tolerable narrow wasabi-infused sake	1	good	Last Available: "2011-03"
-5017	acceptable huge twirling tobiko-infused sake	3	good	Last Available: "2011-03"
-5018	weak bad narrow natto-infused sake	2	decent	Last Available: "2011-03"
+5016	tolerable practically non-alcoholic narrow wasabi-infused sake	1	good	Last Available: "2011-03"
+5017	acceptable twirling huge tobiko-infused sake	3	good	Last Available: "2011-03"
+5018	bad weak narrow natto-infused sake	2	decent	Last Available: "2011-03"
 5019	double-frozen spinning wasabi marble soda	0		Effect: "Earthen Fist", Effect Duration: 67, Last Available: "2011-03"
 5020	colloidal vacuum-sealed polarized tobiko marble soda	0		Effect: "Stemonitis Storm", Effect Duration: 69, Last Available: "2011-03"
 5021	frozen activated natto marble soda	0		Effect: "Riboflavin'", Effect Duration: 59, Last Available: "2011-03"
-5022	ghostly wobbly Alice's Army booster box	0		Last Available: "2011-03"
+5022	wobbly ghostly Alice's Army booster box	0		Last Available: "2011-03"
 5023	alkaline elderly jawbreaker	0		Effect: "Wet Jaw", Effect Duration: 45, Last Available: "2020-09"
 5024	smooth marshmallow flamb&eacute;	3	awesome	Last Available: "2011-03"
-5025	drinkable upside-down gray cranberry schnapps	4	good	Last Available: "2011-03"
+5025	drinkable gray upside-down cranberry schnapps	4	good	Last Available: "2011-03"
 5026	practically non-alcoholic artisanal breaded beer	1	super ultra mega turbo EPIC	Last Available: "2011-03"
 5027	mediocre soy cordial	4	decent	Last Available: "2011-03"
 5028	horrifying Temple Grandin's astral bludgeon of the dark arts	0		Spell Damage Percent: +100, Familiar Weight: +7, Spooky Damage: +25
@@ -4960,14 +4960,14 @@
 5057	deionized wobbly Atomic Comic	0		Effect: "Slime Time", Effect Duration: 31, Last Available: "2011-04"
 5058	extra-liquefied warmed Red Pill	0		Effect: "Healthy Blue Glow", Effect Duration: 17, Last Available: "2011-04"
 5059	tumbling maroon Skullhead's Screw	0		Last Available: "2011-04"
-5060	twirling huge mysterious present	0		Last Available: "2011-04"
+5060	huge twirling mysterious present	0		Last Available: "2011-04"
 5061	huge boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
-5064	fuchsia pulsating Salsa de las Epocas	0		Last Available: "2011-04"
-5065	moldy miniature spaghetti con calaveras	2	crappy	Last Available: "2011-04"
+5064	pulsating fuchsia Salsa de las Epocas	0		Last Available: "2011-04"
+5065	miniature moldy spaghetti con calaveras	2	crappy	Last Available: "2011-04"
 5066	huge s'more gun	0		Last Available: "2011-04"
-5067	super-sized spoiled cyan upside-down popcorn	5	crappy	Last Available: "2011-04"
+5067	spoiled super-sized cyan upside-down popcorn	5	crappy	Last Available: "2011-04"
 5068	snack-sized decent chaos popcorn	2	good	Last Available: "2011-04"
 5069	up-at-dawn Fonzie's hole of the blizzard	0		Experience (Moxie): +1, Cold Spell Damage: +25, Adventures: +5, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
@@ -5004,9 +5004,9 @@
 5101	lion tamer's Pok&euml;mann figurine: Moog	0		Experience (familiar): +2, Single Equip, Last Available: "2011-05"
 5102	super-vacuum-sealed frozen willyweed	0		Effect: "Mariachi Mood", Effect Duration: 69, Last Available: "2011-05"
 5103	extra-warmed non-pickled Nuclear Blastball	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 14, Last Available: "2011-05"
-5104	unsweetened adjusted blinking ghostly fish juice box	0		Effect: "Wings of the Grasshopper", Effect Duration: 41, Last Available: "2011-05"
+5104	unsweetened adjusted ghostly blinking fish juice box	0		Effect: "Wings of the Grasshopper", Effect Duration: 41, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
-5106	twirling blue hideous egg	0		Last Available: "2011-05"
+5106	blue twirling hideous egg	0		Last Available: "2011-05"
 5107	bad Jeppson's Malort	3	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	lard-coated stress ball	0		Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
@@ -5016,7 +5016,7 @@
 5113	packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	hedge trimmers	0		
-5116	red huge A. W. O. L. commendation	0		Last Available: "2011-05"
+5116	huge red A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
 5119	busted wings	0		
@@ -5033,7 +5033,7 @@
 5130	skewed Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	diffused double-corrupted teal Ultrasoldier Serum	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 57, Last Available: "2011-06"
 5132	moldy elven hardtack	3	crappy	Last Available: "2011-06"
-5133	watered-down drinkable special elven squeeze	2	good	Effect: "Sludgesick", Effect Duration: 15, Last Available: "2011-06"
+5133	watered-down special drinkable elven squeeze	2	good	Effect: "Sludgesick", Effect Duration: 15, Last Available: "2011-06"
 5134	wobbly lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5046,7 +5046,7 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	dry super-dry shaking honeypot	0		Effect: "Impregnabili Tea", Effect Duration: 26
-5146	rotten gigantic wild honey pie	9	crappy	
+5146	gigantic rotten wild honey pie	9	crappy	
 5147	drinkable high-proof honey mead	9	good	
 5148	Temple Grandin's hardy beefy honey dipper	0		Muscle: +10, Maximum HP: +50, Familiar Weight: +7
 5149	foul-smelling baleful honeybritches of Gandalf	0		Spell Damage: +25, Spell Critical Percent: +20, Stench Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5076,18 +5076,18 @@
 5173	spinning blinking elven magi-pack	0		Last Available: "2011-06"
 5174	acceptable weak Saison du Lune	2	good	Last Available: "2011-06"
 5175	practically non-alcoholic mediocre Moonthril Schnapps	1	decent	Last Available: "2011-06"
-5176	practically non-alcoholic drinkable maroon Wrecked Generator	1	good	Last Available: "2011-06"
+5176	drinkable practically non-alcoholic maroon Wrecked Generator	1	good	Last Available: "2011-06"
 5177	small stale Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
 5178	adequate Crepes a la Lune	3	good	Last Available: "2011-06"
 5179	massive adequate Moon Pie	9	good	Last Available: "2011-06"
-5180	quadruple-adjusted alkaline fuchsia skewed Comet Pop	0		Effect: "Coldfinger", Effect Duration: 61, Last Available: "2011-06"
+5180	quadruple-adjusted alkaline skewed fuchsia Comet Pop	0		Effect: "Coldfinger", Effect Duration: 61, Last Available: "2011-06"
 5181	altered boiled wobbly Flan in the Moon	0		Effect: "Filled with Magic", Effect Duration: 62, Last Available: "2011-06"
 5182	extra-adjusted 1/6th Pound Cake	0		Effect: "Permanent Halloween", Effect Duration: 39, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	tumbling shaking wobbly Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
-5185	jittery blurry Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
+5185	blurry jittery Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
-5187	bouncing wobbly Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
+5187	wobbly bouncing Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	polarized aerosolized wet honey stick	0		Effect: "Antsy in your Pantsy", Effect Duration: 40
 5189	warmed unsweetened mirror pulsating double-ice gum	0		Effect: "Ruby-ous", Effect Duration: 55, Last Available: "2011-04"
 5190	flame-wreathed quilted groovy Operation Patriot Shield	0		Moxie Percent: +10, Damage Absorption: +40, Hot Spell Damage: +10, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
@@ -5105,21 +5105,21 @@
 5202	boiled greasy paste	1	EPIC	Last Available: "2011-08"
 5203	distilled blinking bug paste	1	EPIC	Last Available: "2011-08"
 5204	altered hippy paste	1	good	Last Available: "2011-08"
-5205	boiled twirling bouncing orc paste	1	crappy	Effect: "protect.enq", Effect Duration: 10, Last Available: "2011-08"
+5205	boiled bouncing twirling orc paste	1	crappy	Effect: "protect.enq", Effect Duration: 10, Last Available: "2011-08"
 5206	dried jittery demonic paste	1	EPIC	Last Available: "2011-08"
 5207	powdered indescribably horrible paste	1	crappy	Last Available: "2011-08"
 5208	mixed squat upside-down paste	1	awesome	Last Available: "2011-08"
 5209	dried shaking goblin paste	1	good	Effect: "Simulation Stimulation", Effect Duration: 15, Last Available: "2011-08"
 5210	pickled purple pirate paste	1	awesome	Effect: "Crimbo Epiphany", Effect Duration: 50, Last Available: "2011-08"
-5211	vaporized ghostly blinking chlorophyll paste	1	decent	Effect: "Nut-Rition", Effect Duration: 25, Last Available: "2011-08"
+5211	vaporized blinking ghostly chlorophyll paste	1	decent	Effect: "Nut-Rition", Effect Duration: 25, Last Available: "2011-08"
 5212	dehydrated paste	1	decent	Last Available: "2011-08"
 5213	pickled narrow tumbling Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	dried slimy paste	1	awesome	Last Available: "2011-08"
-5215	boiled shaking narrow penguin paste	1	decent	Last Available: "2011-08"
+5215	boiled narrow shaking penguin paste	1	decent	Last Available: "2011-08"
 5216	dried elemental paste	1	decent	Effect: "[1701]Hip to the Jive", Effect Duration: 20, Last Available: "2011-08"
 5217	diluted spinning cosmic paste	1	decent	Last Available: "2011-08"
 5218	compressed pulsating mirror hobo paste	1	good	Last Available: "2011-08"
-5219	powdered spinning red Crimbo paste	1	awesome	Effect: "Corona de la Salsa", Effect Duration: 5, Last Available: "2011-08"
+5219	powdered red spinning Crimbo paste	1	awesome	Effect: "Corona de la Salsa", Effect Duration: 5, Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	pulsating fat loot token	0		No Pull
 5222	bouncing Thwaitgold grasshopper statuette	0		
@@ -5140,22 +5140,22 @@
 5237	time halo of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	boozy drinkable tumbling Lumineux Limnio	5	good	Last Available: "2011-09"
 5239	irresponsibly strong aged Morto Moreto	8	awesome	Last Available: "2011-09"
-5240	bad special Temps Tempranillo	3	decent	Last Available: "2011-09"
+5240	special bad Temps Tempranillo	3	decent	Last Available: "2011-09"
 5241	lousy weak Bordeaux Marteaux	2	decent	Last Available: "2011-09"
 5242	artisanal practically non-alcoholic Fromage Pinotage	1	EPIC	Last Available: "2011-09"
-5243	spirit-forward hand-crafted Beignet Milgranet	5	EPIC	Last Available: "2011-09"
+5243	hand-crafted spirit-forward Beignet Milgranet	5	EPIC	Last Available: "2011-09"
 5244	distilled bad Muschat	5	decent	Last Available: "2011-09"
 5245	super-sized adequate cool jelly donut	5	good	Last Available: "2011-09"
 5246	bland small shrapnel jelly donut	2	decent	Last Available: "2011-09"
 5247	rotten miniature narrow occult jelly donut	2	crappy	Last Available: "2011-09"
 5248	decent small thyme jelly donut	2	good	Last Available: "2011-09"
 5249	spoiled danish	4	crappy	Last Available: "2011-09"
-5250	half-sized tasty fuchsia smashed danish	2	awesome	Last Available: "2011-09"
+5250	tasty half-sized fuchsia smashed danish	2	awesome	Last Available: "2011-09"
 5251	normal special forbidden danish	3	good	Effect: "Larger", Effect Duration: 20, Last Available: "2011-09"
 5252	rotten cool cat claw	4	crappy	Last Available: "2011-09"
 5253	delicious super-sized blunt cat claw	5	awesome	Last Available: "2011-09"
-5254	half-sized fancy decent shadowy cat claw	2	good	Effect: "Egg Burps", Effect Duration: 15, Last Available: "2011-09"
-5255	immense spoiled cheezburger	8	crappy	Last Available: "2011-09"
+5254	fancy half-sized decent shadowy cat claw	2	good	Effect: "Egg Burps", Effect Duration: 15, Last Available: "2011-09"
+5255	spoiled immense cheezburger	8	crappy	Last Available: "2011-09"
 5256	spoiled blinking toasted brie	3	crappy	Last Available: "2011-09"
 5257	extra-modified activated potion of the field gar	0		Effect: "Cranberry Cordiality", Effect Duration: 68, Last Available: "2011-09"
 5258	ionized teal too legit potion	0		Effect: "Heart of White", Effect Duration: 49, Last Available: "2011-09"
@@ -5163,14 +5163,14 @@
 5260	galvanized moist cold-filtered water	0		Effect: "Slimy Flavor", Effect Duration: 56, Last Available: "2011-09"
 5261	alkaline graveyard snowglobe	0		Effect: "Greasy Flavor", Effect Duration: 50, Last Available: "2011-09"
 5262	quadruple-polymerized moist shaking red cool cat elixir	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 58, Last Available: "2011-09"
-5263	liquefied dry blinking red potion of the captain's hammer	0		Effect: "Heart of Orange", Effect Duration: 11, Last Available: "2011-09"
+5263	liquefied dry red blinking potion of the captain's hammer	0		Effect: "Heart of Orange", Effect Duration: 11, Last Available: "2011-09"
 5264	flattened alkaline red potion of X-ray vision	0		Effect: "Remaining Alive", Effect Duration: 39, Last Available: "2011-09"
 5265	energized potion of the litterbox	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 30, Last Available: "2011-09"
 5266	double-tarnished twirling spinning potion of animal rage	0		Effect: "Broberry Brotality", Effect Duration: 65, Last Available: "2011-09"
 5267	dry potion of punctual companionship	0		Effect: "How to Scam Tourists", Effect Duration: 28, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	narrow bobcat grenade	0		Last Available: "2011-09"
-5270	mirror squat chocolate frosted sugar bomb	0		Last Available: "2011-09"
+5270	squat mirror chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
 5272	tumbling noxious gas grenade	0		Last Available: "2011-09"
 5273	pulsating skull with a fuse in it	0		Last Available: "2011-09"
@@ -5180,7 +5180,7 @@
 5277	wobbly skewed avaricious fluorescent lightbulb	0		Meat Drop: +30, Last Available: "2011-09"
 5278	nasty slick blammer	0		Moxie: +10, Stench Damage: +5, Last Available: "2011-09"
 5279	fuchsia clock-cleaning hammer of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-09"
-5280	maroon pulsating 4:20 bomb	0		Last Available: "2011-09"
+5280	pulsating maroon 4:20 bomb	0		Last Available: "2011-09"
 5281	sharpshooter's broken clock	0		Critical Hit Percent: +10, Last Available: "2011-09"
 5282	bouncing wizardly dethklok	0		Mysticality: +25, Last Available: "2011-09"
 5283	upside-down glacial clock of temperance	0		Sleaze Resistance: +5, Last Available: "2011-09"
@@ -5190,7 +5190,7 @@
 5287	d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
 5289	d12	0		Last Available: "2011-09"
-5290	ghostly narrow d20	0		Last Available: "2011-09"
+5290	narrow ghostly d20	0		Last Available: "2011-09"
 5291	green generic healing potion	0		Last Available: "2011-09"
 5292	lime green generic mana potion	0		Last Available: "2011-09"
 5293	huge squat generic restorative potion	0		Last Available: "2011-09"
@@ -5217,7 +5217,7 @@
 5314	flattened dry shaking bite-me-red lipstick	0		Effect: "Army of One", Effect Duration: 43, Last Available: "2011-10"
 5315	improved denatured whisker pencil	0		Effect: "Coal-Powered", Effect Duration: 32, Last Available: "2011-10"
 5316	activated triple-flattened upside-down press-on ribs	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 59, Last Available: "2011-10"
-5317	electrified blurry twirling Rattlin' Chains	0		Effect: "Boletus Swoletus", Effect Duration: 48, Last Available: "2011-10"
+5317	electrified twirling blurry Rattlin' Chains	0		Effect: "Boletus Swoletus", Effect Duration: 48, Last Available: "2011-10"
 5318	diffused ghostly Gummy Brains	0		Effect: "Block-Rockin' Beet", Effect Duration: 39, Last Available: "2011-10"
 5319	pickled Vulcanized electrified Blood 'n' Plenty	0		Effect: "Dexteri Tea", Effect Duration: 47, Last Available: "2011-10"
 5320	magnetized huge Lobos Mints	0		Effect: "Spring Training", Effect Duration: 21, Last Available: "2011-10"
@@ -5289,7 +5289,7 @@
 5386	ridiculous belt of courage	0		Spooky Resistance: +3, Last Available: "2011-11"
 5387	nasty ridiculous earring	0		Stench Damage: +5, Last Available: "2011-11"
 5388	banded ridiculous sunglasses	0		Damage Absorption: +100, Last Available: "2011-11"
-5389	yummy miniature ridiculous sandwich	2	awesome	Last Available: "2011-11"
+5389	miniature yummy ridiculous sandwich	2	awesome	Last Available: "2011-11"
 5390	lousy ridiculous cocktail	3	decent	Last Available: "2011-11"
 5391	chaotic MacGyver's zombie monkey necklace	0		Maximum MP: +100, Spell Critical Percent: +10
 5392	tumbling tumbling Thwaitgold butterfly statuette	0		
@@ -5303,15 +5303,15 @@
 5400	candy cane candygram	0		Last Available: "2011-12"
 5401	olive wobbly peppermint parasol	0		Last Available: "2011-11"
 5402	ghostly candy cane of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2011-12"
-5403	pulsating huge Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
+5403	huge pulsating Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	therapeutic brainy cane-mail shirt of the detective	0		Mysticality: +5, Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-12"
 5406	tumbling clever hardy cane-mail pants of the sewer	0		Maximum HP: +50, Maximum MP: +20, Stench Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	watered-down acceptable narrow Vodka Matryoshka	2	good	Last Available: "2011-12"
 5408	fortified lousy Gin Mint	5	decent	Last Available: "2011-12"
 5409	acceptable ghostly Tequiz Navidad	4	good	Last Available: "2011-12"
-5410	triple-distilled tolerable Mint Yulep	10	good	Last Available: "2011-12"
-5411	acceptable weak fuchsia mirror Crimbojito	2	good	Last Available: "2011-12"
+5410	tolerable triple-distilled Mint Yulep	10	good	Last Available: "2011-12"
+5411	weak acceptable fuchsia mirror Crimbojito	2	good	Last Available: "2011-12"
 5412	perfectly mixed Sangria de Menthe	3	EPIC	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5344,7 +5344,7 @@
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	blinking The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
-5444	liquefied upside-down twirling devilish folio	0		Effect: "Tearful, Fearful", Effect Duration: 25, Last Available: "2012-12"
+5444	liquefied twirling upside-down devilish folio	0		Effect: "Tearful, Fearful", Effect Duration: 25, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
@@ -5358,8 +5358,8 @@
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	twirling gummi ingot	0		Last Available: "2011-11"
 5457	liquefied upside-down Fudgie Roll	0		Effect: "Filled with Magic", Effect Duration: 32, Last Available: "2011-11"
-5458	thick spoiled fudge bunny	5	crappy	Last Available: "2011-11"
-5459	shaking huge fudge spork	0		Last Available: "2011-11"
+5458	spoiled thick fudge bunny	5	crappy	Last Available: "2011-11"
+5459	huge shaking fudge spork	0		Last Available: "2011-11"
 5460	lime green scandalous healthy fudgecycle of the wise owl	0		Mysticality: +20, Maximum HP Percent: +20, Sleaze Damage: +5, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
@@ -5381,10 +5381,10 @@
 5478	triple-tarnished gummi canary	0		Effect: "Sagittarius Rising", Effect Duration: 60, Last Available: "2011-11"
 5479	spoiled blinking gummi bear	4	crappy	Last Available: "2011-11"
 5480	stale gray gummi bear	3	decent	Last Available: "2011-11"
-5481	moldy half-sized gummi bear	2	crappy	Last Available: "2011-11"
+5481	half-sized moldy gummi bear	2	crappy	Last Available: "2011-11"
 5482	delicious narrow drunki-bear	3	awesome	Last Available: "2011-11"
 5483	miniature decent drunki-bear	2	good	Last Available: "2011-11"
-5484	small normal wobbly drunki-bear	2	good	Last Available: "2011-11"
+5484	normal small wobbly drunki-bear	2	good	Last Available: "2011-11"
 5485	spinning arcane researcher's gummi bowtie	0		Experience Percent (Mysticality): +10, Last Available: "2011-11"
 5486	bouncing cool fudge pocket square	0		Moxie: +5, Last Available: "2011-11"
 5487	huge lollipop cufflinks of extreme caution	0		Monster Level: -25, Last Available: "2011-11"
@@ -5407,8 +5407,8 @@
 5504	red blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	normal bite-sized shaking jerky coins	1	good	Last Available: "2011-11"
-5507	mediocre spirit-forward upside-down Go-Wassail	5	decent	Last Available: "2011-11"
-5508	deionized wobbly fuchsia Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Third Based", Effect Duration: 34, Last Available: "2011-11"
+5507	spirit-forward mediocre upside-down Go-Wassail	5	decent	Last Available: "2011-11"
+5508	deionized fuchsia wobbly Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Third Based", Effect Duration: 34, Last Available: "2011-11"
 5509	altered bottle of bubbles	0		Effect: "Perfect Hair", Effect Duration: 60, Last Available: "2011-11"
 5510	anodized wind-up meatcar	0		Effect: "Tennis Elbow-wow", Effect Duration: 57, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
@@ -5426,7 +5426,7 @@
 5523	narrow pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
 5525	blinking pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
-5526	improved red blurry Atomic Pop	0		Effect: "Ticking Clock", Effect Duration: 30, Last Available: "2020-09"
+5526	improved blurry red Atomic Pop	0		Effect: "Ticking Clock", Effect Duration: 30, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	blurry purple whimpering willow bark	0		Last Available: "2012-12"
 5529	flavorless miniature berries of suffering	2	decent	Last Available: "2012-12"
@@ -5434,9 +5434,9 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	Vulcanized enhanced extra-liquefied narrow Mortimer's nostrum	0		Effect: "Quadrilled", Effect Duration: 68, Last Available: "2012-12"
-5534	weak acceptable Barulio's bottle	2	good	Last Available: "2012-12"
-5535	galvanized triple-moist jittery maroon Marvin's marvelous pill	0		Effect: "Disco Concentration", Effect Duration: 44, Last Available: "2012-12"
-5536	wobbly bouncing Winifred's whistle	0		Last Available: "2012-12"
+5534	acceptable weak Barulio's bottle	2	good	Last Available: "2012-12"
+5535	galvanized triple-moist maroon jittery Marvin's marvelous pill	0		Effect: "Disco Concentration", Effect Duration: 44, Last Available: "2012-12"
+5536	bouncing wobbly Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	shaking half-empty carton of milk	0		Last Available: "2012-12"
 5539	glass of warm water	0		Free Pull
@@ -5453,7 +5453,7 @@
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	spinning skewed blurry sizzling Trusty	0		Hot Damage: +10
-5553	jittery huge can of Rain-Doh	0		Last Available: "2012-02"
+5553	huge jittery can of Rain-Doh	0		Last Available: "2012-02"
 5554	empty Rain-Doh can	0		Last Available: "2012-02"
 5555	polarized fireclutch	0		Effect: "Grrrrrrreat!", Effect Duration: 53
 5556	resourceful sage Rain-Doh wings	0		Mysticality Percent: +10, Maximum MP: +50, Softcore Only, Last Available: "2012-02"
@@ -5465,7 +5465,7 @@
 5562	shaking huge Rain-Doh violet bo of Calamity Jane of the glutton	0		Critical Hit Percent: +15, Food Drop: +100, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	red Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	special tasty shaking PB&BP	3	awesome	Effect: "Expert Vacationer", Effect Duration: 20
+5565	tasty special shaking PB&BP	3	awesome	Effect: "Expert Vacationer", Effect Duration: 20
 5566	decent club sandwich	3	good	
 5567	flavorless corned-beef Reuben	3	decent	
 5568	huge frayed ninja rope	0		
@@ -5477,68 +5477,68 @@
 5574	delicious Transylvania Sling	4	awesome	Last Available: "2012-03"
 5575	irresponsibly strong delicious mirror Shot of the Living Dead	7	awesome	Last Available: "2012-03"
 5576	hand-crafted Buttery Knob	4	EPIC	Last Available: "2012-03"
-5577	practically non-alcoholic artisanal Slippery Knob	1	EPIC	Last Available: "2012-03"
+5577	artisanal practically non-alcoholic Slippery Knob	1	EPIC	Last Available: "2012-03"
 5578	irresponsibly strong lousy skewed narrow Flaming Knob	10	decent	Last Available: "2012-03"
 5579	hand-crafted twirling Grasshopper	3	EPIC	Last Available: "2012-03"
 5580	acceptable Locust	3	good	Last Available: "2012-03"
 5581	artisanal Plague of Locusts	3	EPIC	Last Available: "2012-03"
 5582	artisanal Red Dwarf	4	EPIC	Last Available: "2012-03"
-5583	mediocre narrow yellow Golden Mean	4	decent	Last Available: "2012-03"
+5583	mediocre yellow narrow Golden Mean	4	decent	Last Available: "2012-03"
 5584	weak tolerable Green Giant	2	good	Last Available: "2012-03"
 5585	artisanal watered-down Aye Aye	2	EPIC	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	4	decent	Last Available: "2012-03"
-5587	bad watered-down Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
+5587	watered-down bad Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
 5588	artisanal practically non-alcoholic Humanitini	1	EPIC	Last Available: "2012-03"
 5589	spirit-forward drinkable More Humanitini than Humanitini	5	good	Last Available: "2012-03"
 5590	artisanal cyan Oh, the Humanitini	4	EPIC	Last Available: "2012-03"
 5591	hand-crafted Great Older Fashioned	3	EPIC	Last Available: "2012-03"
 5592	mediocre Fuzzy Tentacle	3	decent	Last Available: "2012-03"
 5593	artisanal Crazymaker	4	EPIC	Last Available: "2012-03"
-5594	irresponsibly strong smooth Zoodriver	10	awesome	Last Available: "2012-03"
+5594	smooth irresponsibly strong Zoodriver	10	awesome	Last Available: "2012-03"
 5595	practically non-alcoholic drinkable Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
 5596	tolerable pulsating Sloe Comfortable Zoo on Fire	3	good	Last Available: "2012-03"
 5597	tolerable Suffering Sinner	3	good	Last Available: "2012-03"
 5598	mediocre teal Suppurating Sinner	3	decent	Last Available: "2012-03"
 5599	bad Sizzling Sinner	3	decent	Last Available: "2012-03"
-5600	triple-distilled mediocre bouncing Firewater	8	decent	Last Available: "2012-03"
+5600	mediocre triple-distilled bouncing Firewater	8	decent	Last Available: "2012-03"
 5601	acceptable watered-down Earth and Firewater	2	good	Last Available: "2012-03"
-5602	hand-crafted watered-down Earth, Wind and Firewater	2	EPIC	Last Available: "2012-03"
-5603	irresponsibly strong special lousy Slimosa	9	decent	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2012-03"
-5604	weak artisanal Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
+5602	watered-down hand-crafted Earth, Wind and Firewater	2	EPIC	Last Available: "2012-03"
+5603	special lousy irresponsibly strong Slimosa	9	decent	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2012-03"
+5604	artisanal weak Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
 5605	lousy Slimebite	3	decent	Last Available: "2012-03"
 5606	drinkable Cement Mixer	3	good	Last Available: "2012-03"
 5607	hand-crafted practically non-alcoholic Jackhammer	1	EPIC	Last Available: "2012-03"
-5608	triple-distilled acceptable special mirror Dump Truck	7	good	Effect: "Painted-On Bikini", Effect Duration: 40, Last Available: "2012-03"
+5608	triple-distilled special acceptable mirror Dump Truck	7	good	Effect: "Painted-On Bikini", Effect Duration: 40, Last Available: "2012-03"
 5609	perfectly mixed Fauna Libre	3	EPIC	Last Available: "2012-03"
 5610	mediocre teal Chakra Libre	3	decent	Last Available: "2012-03"
 5611	distilled lousy olive Aura Libre	5	decent	Last Available: "2012-03"
 5612	drinkable high-proof Sazerorc	9	good	Last Available: "2012-03"
 5613	bad strong Sazuruk-hai	5	decent	Last Available: "2012-03"
-5614	mediocre weak squat blinking Flaming Sazerorc	2	decent	Last Available: "2012-03"
+5614	weak mediocre blinking squat Flaming Sazerorc	2	decent	Last Available: "2012-03"
 5615	tolerable Green Velvet	4	good	Last Available: "2012-03"
-5616	lousy high-proof Green Muslin	6	decent	Last Available: "2012-03"
-5617	practically non-alcoholic drinkable Green Burlap	1	good	Last Available: "2012-03"
+5616	high-proof lousy Green Muslin	6	decent	Last Available: "2012-03"
+5617	drinkable practically non-alcoholic Green Burlap	1	good	Last Available: "2012-03"
 5618	lousy extra-dry Mohobo	5	decent	Last Available: "2012-03"
 5619	acceptable Moonshine Mohobo	4	good	Last Available: "2012-03"
-5620	mediocre blinking narrow Flaming Mohobo	4	decent	Last Available: "2012-03"
+5620	mediocre narrow blinking Flaming Mohobo	4	decent	Last Available: "2012-03"
 5621	smooth practically non-alcoholic Drunken Philosopher	1	awesome	Last Available: "2012-03"
-5622	aged special Drunken Neurologist	4	awesome	Effect: "Fancy Feasted", Effect Duration: 40, Last Available: "2012-03"
+5622	special aged Drunken Neurologist	4	awesome	Effect: "Fancy Feasted", Effect Duration: 40, Last Available: "2012-03"
 5623	acceptable high-proof upside-down spinning Drunken Astrophysicist	6	good	Last Available: "2012-03"
 5624	bad irresponsibly strong Dark & Starry	10	decent	Last Available: "2012-03"
 5625	aged green Black Hole	3	awesome	Last Available: "2012-03"
-5626	aged weak twirling Event Horizon	2	awesome	Last Available: "2012-03"
+5626	weak aged twirling Event Horizon	2	awesome	Last Available: "2012-03"
 5627	artisanal spinning Herring Daiquiri	3	EPIC	Last Available: "2012-03"
 5628	acceptable weak Herring Wallbanger	2	good	Last Available: "2012-03"
 5629	lousy lime green Herringtini	4	decent	Last Available: "2012-03"
 5630	delicious Lollipop Drop	3	awesome	Last Available: "2012-03"
 5631	delicious watered-down Candy Alexander	2	awesome	Last Available: "2012-03"
-5632	strong tolerable twirling Candicaine	5	good	Last Available: "2012-03"
-5633	enchanted watered-down tolerable Caipiranha	2	good	Effect: "Hammered", Effect Duration: 30, Last Available: "2012-03"
+5632	tolerable strong twirling Candicaine	5	good	Last Available: "2012-03"
+5633	tolerable watered-down enchanted Caipiranha	2	good	Effect: "Hammered", Effect Duration: 30, Last Available: "2012-03"
 5634	perfectly mixed squat squat Flying Caipiranha	3	EPIC	Last Available: "2012-03"
-5635	mediocre watered-down Flaming Caipiranha	2	decent	Last Available: "2012-03"
+5635	watered-down mediocre Flaming Caipiranha	2	decent	Last Available: "2012-03"
 5636	weak perfectly mixed Punchplanter	2	EPIC	Last Available: "2012-03"
 5637	spirit-forward drinkable shaking Doublepunchplanter	5	good	Last Available: "2012-03"
-5638	lousy weak shaking twirling Haymaker	2	decent	Last Available: "2012-03"
+5638	weak lousy shaking twirling Haymaker	2	decent	Last Available: "2012-03"
 5639	olive Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	normal fungus	3	good	
@@ -5551,11 +5551,11 @@
 5648	dog trainer's wizardly Boris's Helm	0		Mysticality: +25, Experience (familiar): +1, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	clever staph of homophones of the boozehound	0		Maximum MP: +20, Booze Drop: +100
 5650	MacGyver's slick Boris's Helm (askew) of the empath	0		Moxie: +10, Maximum MP: +100, Familiar Weight: +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
-5651	upside-down bouncing mime soul fragment	0		Last Available: "2012-04"
+5651	bouncing upside-down mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	low-calorie normal nailswurst	1	good	
-5655	mediocre irresponsibly strong used beer	7	decent	
+5654	normal low-calorie nailswurst	1	good	
+5655	irresponsibly strong mediocre used beer	7	decent	
 5656	Huggler Radio	0		Free Pull
 5657	wobbly fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5565,16 +5565,16 @@
 5662	Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	wobbly microwave	0		Free Pull
 5664	pony keg	0		Free Pull
-5665	blue narrow How to Tolerate Jerks	0		Skill: "Thick-Skinned"
+5665	narrow blue How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
-5670	half-sized moldy fettucini &eacute;pines Inconnu	2	crappy	
-5671	watered-down acceptable slap and slap again	2	good	
+5670	moldy half-sized fettucini &eacute;pines Inconnu	2	crappy	
+5671	acceptable watered-down slap and slap again	2	good	
 5672	jittery gunpowder burrito	2	good	
 5673	beery blood	2	good	
-5674	ghostly blinking &quot;L&quot;	0		
+5674	blinking ghostly &quot;L&quot;	0		
 5675	mixed watered-down Red Minotaur	1		Effect: "Orchid Blood", Effect Duration: 40
 5676	pool torpedo	0		Last Available: "2012-05"
 5677	wholesome Ze&trade; goggles	0		Maximum HP Percent: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
@@ -5599,7 +5599,7 @@
 5696	bugbear purification pill	0		
 5697	cyan 1 Meat	0		
 5698	squat executive Jim Carey's The Lost Glasses	0		Monster Level: +25, Meat Drop: +40, Single Equip
-5699	lime green jittery The Lost Pill Bottle	0		Last Available: "2012-05"
+5699	jittery lime green The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	mannequin	0		Familiar Weight: +5
@@ -5618,7 +5618,7 @@
 5717	tasty FDKOL hotcakes	4	awesome	Last Available: "2012-07"
 5718	mirror hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	huge rotten fiery wing	7	crappy	Last Available: "2012-07"
+5720	rotten huge fiery wing	7	crappy	Last Available: "2012-07"
 5721	skewed curative occult wings of fire	0		Spell Damage Percent: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-07"
 5722	teal Herculean FDKOL fire hose	0		Experience (Muscle): +1, Last Available: "2012-07"
 5723	triple-polymerized chilled lime green bottle of fire	0		Effect: "Thunderheart", Effect Duration: 23, Last Available: "2012-07"
@@ -5629,7 +5629,7 @@
 5728	Tesla electrified foot-long hot daub	0		MP Regen Min: 10, MP Regen Max: 15, Last Available: "2012-07"
 5729	mirror ballpark hot daub	0		Last Available: "2012-07"
 5730	stale super-sized angst burger	5	decent	
-5731	irresponsibly strong acceptable 5-hour acrimony	8	good	
+5731	acceptable irresponsibly strong 5-hour acrimony	8	good	
 5732	ghostly blank note	0		
 5733	eerily silent box	0		
 5734	normal forbidden sausage	4	good	
@@ -5642,7 +5642,7 @@
 5741	mediocre ghostly water purification pills	3	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	bad distilled CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
-5744	normal thick special bag of GORF	5	good	Effect: "Techno Bliss", Effect Duration: 20, Last Available: "2012-07"
+5744	thick normal special bag of GORF	5	good	Effect: "Techno Bliss", Effect Duration: 20, Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	flavorless bag of QWOP	4	decent	Last Available: "2012-07"
 5747	vacuum-sealed extra-concentrated shaking CSA bravery badge	0		Effect: "Springy Fusilli", Effect Duration: 55, Last Available: "2012-07"
@@ -5653,7 +5653,7 @@
 5752	delicious cyan crappy brain	3	awesome	
 5753	adequate decent brain	4	good	
 5754	flavorless good brain	3	decent	
-5755	toothsome huge boss brain	8	awesome	
+5755	huge toothsome boss brain	8	awesome	
 5756	moldy blurry hunter brain	3	crappy	
 5758	electrified strapping Staff of Holiday Sensations of courage	0		Muscle: +5, Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
 5759	olive manspreader's staff of wisdom	0		Mysticality: +15, Monster Level: +10
@@ -5678,7 +5678,7 @@
 5779	foul-smelling keel-haulin' knife	0		Stench Damage: +10
 5780	curative ice cream scoop	0		HP Regen Min: 3, HP Regen Max: 5
 5781	tolerable green soft echo eyedrop antidote martini	4	good	
-5782	lime green tumbling pulsating morningwood plank	0		
+5782	pulsating tumbling lime green morningwood plank	0		
 5783	blinking raging hardwood plank	0		
 5784	weirdwood plank	0		
 5785	thick caulk	0		
@@ -5709,7 +5709,7 @@
 5810	frozen triple-enhanced bouncing Tears of the Quiet Healer	0		Effect: "Video Game Hot Dog", Effect Duration: 19
 5811	deionized altered olive tube of lipstick	0		Effect: "Comprehensively Nourished", Effect Duration: 28
 5812	boiled skelelton spine	0		Effect: "Hair on Your Chest", Effect Duration: 19
-5813	pressed upside-down blinking smut orc sunglasses	0		Effect: "Night Vision", Effect Duration: 29
+5813	pressed blinking upside-down smut orc sunglasses	0		Effect: "Night Vision", Effect Duration: 29
 5814	polymerized blob of acid	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 24
 5815	tarnished flayed mind	0		Effect: "Engorged Weapon", Effect Duration: 11
 5816	corrupted activated kobold kibble	0		Effect: "Alchemical, Brother", Effect Duration: 13
@@ -5719,7 +5719,7 @@
 5820	modified bull blubber	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 45
 5821	extra-concentrated double-anodized frog lip-print	0		Effect: "Balls of Ectoplasm", Effect Duration: 61
 5822	adjusted concentrated pulsating gazely stare	0		Effect: "Sweet, Nuts", Effect Duration: 36
-5823	frozen twirling mirror canopic jar	0		Effect: "Physicali Tea", Effect Duration: 23
+5823	frozen mirror twirling canopic jar	0		Effect: "Physicali Tea", Effect Duration: 23
 5824	Vulcanized clove-flavored lip balm	0		Effect: "Minerva's Zen", Effect Duration: 14
 5825	cold-filtered dry Skullery Maid's Knee	0		Effect: "Crocodile Tear", Effect Duration: 54
 5826	Vulcanized nitrogenated blue zombie hollandaise	0		Effect: "In the Limelight", Effect Duration: 48
@@ -5732,14 +5732,14 @@
 5833	moist diffused brigand brittle	0		Effect: "Al Dente Inferno", Effect Duration: 60
 5834	alkaline anodized holistic headache remedy	0		Effect: "Robocamo", Effect Duration: 17
 5835	warmed scrunchie tourniquet	0		Effect: "Chalk Outline", Effect Duration: 13
-5836	flattened ghostly red embezzler's oil	0		Effect: "Salty Mouth", Effect Duration: 39
+5836	flattened red ghostly embezzler's oil	0		Effect: "Salty Mouth", Effect Duration: 39
 5837	irradiated Fu Manchu Wax	0		Effect: "Flexibili Tea", Effect Duration: 20
 5838	flattened blurry Iiti Kitty Gumdrop	0		Effect: "Dweeby", Effect Duration: 28
 5839	adjusted ravenous eye	0		Effect: "Nas Tea", Effect Duration: 16
 5840	deionized diffused Rogue Windmill Rouge	0		Effect: "Preternatural Greed", Effect Duration: 52
 5841	double-vacuum-sealed wet spinning blurry A muse-bouche	0		Effect: "Snobby", Effect Duration: 39
 5842	dry alkaline toothbrush	0		Effect: "Abyssal Tears", Effect Duration: 52
-5843	electrified upside-down teal pirate cream pie	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 51
+5843	electrified teal upside-down pirate cream pie	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 51
 5844	altered ionized una poca de gracia	0		Effect: "Oleaginous Soles", Effect Duration: 37
 5845	triple-polarized oxidized aerosolized compressed air canister	0		Effect: "Dreadful Chill", Effect Duration: 55
 5846	moist triple-corrupted pressed blinking salt water taffy	0		Effect: "Well-Lubed", Effect Duration: 37
@@ -5793,7 +5793,7 @@
 5894	mirror Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	olive canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
-5897	dehydrated bouncing tumbling red Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
+5897	dehydrated red bouncing tumbling Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
@@ -5801,7 +5801,7 @@
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	narrow squat jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
-5906	mirror skewed teal pixel pill	0		
+5906	mirror teal skewed pixel pill	0		
 5907	wobbly pixel energy tank	0		
 5908	ghostly ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	fuchsia manspreader's medical-grade wedding ring	0		Monster Level: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip
@@ -5809,10 +5809,10 @@
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	blinking Lo Pan's slick Solstice Shield	0		Moxie: +10, Spell Critical Percent: +30
 5913	enhanced candy sushi set	0		Effect: "Impregnably Delicious", Effect Duration: 18, Last Available: "2012-12"
-5914	improved mirror mirror pulsating sweet mochi ball	0		Effect: "Barbecue Saucy", Effect Duration: 56, Last Available: "2012-12"
+5914	improved mirror pulsating mirror sweet mochi ball	0		Effect: "Barbecue Saucy", Effect Duration: 56, Last Available: "2012-12"
 5915	tarnished blinking beet-flavored Mr. Mediocrebar	0		Effect: "Tiki Temerity", Effect Duration: 43, Last Available: "2012-12"
 5916	extra-colloidal bouncing sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Corona de la Salsa", Effect Duration: 51, Last Available: "2012-12"
-5917	warmed blurry olive cabbage-flavored Mr. Mediocrebar	0		Effect: "Crusty Head", Effect Duration: 40, Last Available: "2012-12"
+5917	warmed olive blurry cabbage-flavored Mr. Mediocrebar	0		Effect: "Crusty Head", Effect Duration: 40, Last Available: "2012-12"
 5918	zippy plastic animelf	0		Initiative: +20, Last Available: "2012-12"
 5919	beefy plastic ChibiBuddy&trade;	0		Muscle: +10, Last Available: "2012-12"
 5920	huge blinking sinister plastic taco-clad Crimbo elf	0		Spell Damage: +10, Last Available: "2012-12"
@@ -5820,7 +5820,7 @@
 5922	skewed shaking steel-toed plastic MechaElf	0		Damage Reduction: 9, Last Available: "2012-12"
 5923	plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
-5925	skewed maroon ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
+5925	maroon skewed ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	squat BittyCar HotCar	0		Last Available: "2012-12"
 5928	brainwave-controlled unicorn horn of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
@@ -5877,7 +5877,7 @@
 5979	squat huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	bad practically non-alcoholic tankard of ale	1	decent	Last Available: "2013-02"
+5982	practically non-alcoholic bad tankard of ale	1	decent	Last Available: "2013-02"
 5983	olive vial of holy water	0		Last Available: "2013-02"
 5984	tumbling auspicious Temple Grandin's cloth cap of the wise owl	0		Mysticality: +20, Familiar Weight: +7, Item Drop: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	mirror therapeutic forbidden iron dagger of Gandalf	0		Spell Damage Percent: +50, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02"
@@ -5885,11 +5885,11 @@
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	lousy weak tumbling huge bottle of wine	2	decent	Last Available: "2013-02"
+5990	lousy weak huge tumbling bottle of wine	2	decent	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
 5992	foul-smelling forbidden stylish iron helmet	0		Moxie: +25, Spell Damage Percent: +50, Stench Damage: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	rosy-cheeked Samson's steel sword of bravery	0		Experience (Muscle): +5, Maximum HP Percent: +30, Spooky Resistance: +5, Last Available: "2013-02"
-5994	yummy special huge whole roasted chicken	3	awesome	Effect: "Standard Issue Bravery", Effect Duration: 25, Last Available: "2013-02"
+5994	special yummy huge whole roasted chicken	3	awesome	Effect: "Standard Issue Bravery", Effect Duration: 25, Last Available: "2013-02"
 5995	yellow massive gemstone	0		Last Available: "2013-02"
 5996	gray extra-strength potion	0		Last Available: "2013-02"
 5997	blinking potion	0		Last Available: "2013-02"
@@ -5941,7 +5941,7 @@
 6043	narrow jittery boid	0		
 6044	woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	ghostly teal BittyCar SoulCar	0		Last Available: "2012-12"
+6046	teal ghostly BittyCar SoulCar	0		Last Available: "2012-12"
 6047	blue wobbly auspicious banded Misty Cloak	0		Damage Absorption: +100, Item Drop: +10
 6048	Jeselnik's Misty Robe of the detective	0		Sleaze Damage: +25, Item Drop: +20
 6049	shaking censurious lion tamer's friendly Misty Cape	0		Familiar Weight: +3, Experience (familiar): +2, Sleaze Resistance: +3
@@ -5971,7 +5971,7 @@
 6073	modified tumbling haggis-infused soap	0		Effect: "Penguinny Flavor", Effect Duration: 47, Last Available: "2012-12"
 6074	wet dry pressed magicberry tablets	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 11, Last Available: "2012-12"
 6075	modified 37x37x37 puzzle cube	0		Effect: "Coal-Powered", Effect Duration: 18, Last Available: "2012-12"
-6076	artisanal distilled spinning squat McLeod's Hard Haggis-Ade	5	EPIC	Last Available: "2012-12"
+6076	distilled artisanal spinning squat McLeod's Hard Haggis-Ade	5	EPIC	Last Available: "2012-12"
 6077	rotten shaking haggis-wrapped haggis-stuffed haggis	4	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	mirror school calculator watch	0		Last Available: "2012-12"
@@ -5992,7 +5992,7 @@
 6094	hale Microplushie: Dorkonide	0		Maximum HP: +20, Last Available: "2012-12"
 6095	Microplushie: Fauxnerditide of James Dean	0		Experience (Moxie): +3, Last Available: "2012-12"
 6096	wobbly Microplushie: Hipsterine of Flo-Jo	0		Initiative: +100, Last Available: "2012-12"
-6097	green tumbling classy monkey	0		Last Available: "2012-12"
+6097	tumbling green classy monkey	0		Last Available: "2012-12"
 6098	blinking gourd potion	0		Last Available: "2013-12"
 6099	energetic Thinknerd T-Shirt	0		Maximum MP Percent: +20, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
@@ -6046,7 +6046,7 @@
 6149	jittery MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	olive carrot nose	0		Last Available: "2013-01"
-6152	miniature yummy shaking green carrot cake	2	awesome	Last Available: "2013-01"
+6152	yummy miniature shaking green carrot cake	2	awesome	Last Available: "2013-01"
 6153	weak artisanal carrot claret	2	EPIC	Last Available: "2013-01"
 6154	mixed carrot juice	1	decent	Last Available: "2013-01"
 6155	squat squat pixel power cell	0		Last Available: "2013-12"
@@ -6064,7 +6064,7 @@
 6167	blinking huge energetic ornamental sextant	0		Maximum MP Percent: +20, Last Available: "2013-12"
 6168	Tesla Socratic Bloodbath	0		Experience (Mysticality): +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 6169	triple-distilled perfectly mixed Hundred Headed IPA	6	EPIC	Last Available: "2013-12"
-6170	snack-sized bland chum	2	decent	Last Available: "2013-12"
+6170	bland snack-sized chum	2	decent	Last Available: "2013-12"
 6171	enhanced pickled frozen huge crude crudit&eacute;s	0		Effect: "Red Misty-Eyed", Effect Duration: 22
 6172	electrified chilled green candy crayons	0		Effect: "Frisky Spirit", Effect Duration: 41, Last Available: "2020-09"
 6173	deadly pixel grappling hook of the ox	0		Muscle: +20, Weapon Damage: +5
@@ -6084,65 +6084,65 @@
 6187	enchanted tiny moldy consummate egg salad	1	crappy	Effect: "Vanity Rage", Effect Duration: 20
 6188	spoiled consummate bagel	4	crappy	
 6189	spoiled squat consummate sliced bread	3	crappy	
-6190	small flavorless consummate hot dog bun	2	decent	
+6190	flavorless small consummate hot dog bun	2	decent	
 6191	bland squat consummate brownie	3	decent	
-6192	bland special consummate toast	3	decent	Effect: "Baconstoned", Effect Duration: 20
+6192	special bland consummate toast	3	decent	Effect: "Baconstoned", Effect Duration: 20
 6193	hand-crafted passable stout	3	EPIC	
-6194	small spoiled tumbling consummate soup	2	crappy	
+6194	spoiled small tumbling consummate soup	2	crappy	
 6195	bland squat upside-down consummate corn chips	3	decent	
 6196	spoiled consummate salad	4	crappy	
-6197	miniature toothsome mirror consummate salsa	2	awesome	
+6197	toothsome miniature mirror consummate salsa	2	awesome	
 6198	flavorless red blurry consummate sauerkraut	3	decent	
 6199	spoiled consummate cheese slice	4	crappy	
-6200	bland snack-sized tumbling consummate melted cheese	2	decent	
+6200	snack-sized bland tumbling consummate melted cheese	2	decent	
 6201	gigantic flavorless consummate bacon	9	decent	
 6202	decent spinning consummate meatloaf	3	good	
 6203	stale huge blinking shaking consummate steak	10	decent	
-6204	thick rotten skewed consummate cuts	5	crappy	
+6204	rotten thick skewed consummate cuts	5	crappy	
 6205	stale consummate frankfurter	3	decent	
-6206	spoiled big consummate french fries	5	crappy	
+6206	big spoiled consummate french fries	5	crappy	
 6207	yummy fancy thick red consummate baked potato	5	awesome	Effect: "Oth-Jeal-O", Effect Duration: 45
 6208	perfectly mixed acceptable vodka	4	EPIC	
-6209	half-sized normal skewed consummate ice cream	2	good	
+6209	normal half-sized skewed consummate ice cream	2	good	
 6210	adequate maroon consummate whipped cream	3	good	
 6211	tiny flavorless consummate cream	1	decent	
-6212	normal huge consummate strawberries	9	good	
+6212	huge normal consummate strawberries	9	good	
 6213	flavorless half-sized bouncing consummate sorbet	2	decent	
 6214	tolerable watered-down adequate rum	2	good	
-6215	perfectly mixed weak mediocre lager	2	EPIC	
-6216	adequate gigantic immaculate grilled cheese	8	good	
+6215	weak perfectly mixed mediocre lager	2	EPIC	
+6216	gigantic adequate immaculate grilled cheese	8	good	
 6217	rotten immaculate ice cream sandwich	3	crappy	
 6218	decent immaculate hot dog	3	good	
-6219	decent spinning maroon immaculate egg salad sandwich	3	good	
+6219	decent maroon spinning immaculate egg salad sandwich	3	good	
 6220	decent perfect sandwich	3	good	
 6221	yummy perfect chef salad	3	awesome	
 6222	low-calorie decent perfect breakfast	1	good	
 6223	adequate sublime deluxe hot dog	4	good	
 6224	moldy special sublime stew	3	crappy	Effect: "Experimental Effect G-9", Effect Duration: 50
 6225	immense adequate sublime nachos	8	good	
-6226	stale thick pulsating olive Ultimate Breakfast Sandwich	5	decent	
-6227	yummy small shaking Loaded Baked Potato	2	awesome	
+6226	thick stale pulsating olive Ultimate Breakfast Sandwich	5	decent	
+6227	small yummy shaking Loaded Baked Potato	2	awesome	
 6228	normal huge tumbling Omega Sundae	8	good	
 6229	mediocre boozy purple Das Sauerlager	5	decent	
 6230	artisanal extra-dry Bologna Lambic	5	EPIC	
-6231	acceptable practically non-alcoholic Vodka Dog	1	good	
-6232	weak drinkable Disappointed Russian	2	good	
-6233	bad fancy spirit-forward Chunky Mary	5	decent	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 15
+6231	practically non-alcoholic acceptable Vodka Dog	1	good	
+6232	drinkable weak Disappointed Russian	2	good	
+6233	bad spirit-forward fancy Chunky Mary	5	decent	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 15
 6234	enchanted drinkable Nachojito	4	good	Effect: "Extra-Wet", Effect Duration: 45
-6235	artisanal practically non-alcoholic jittery Le Roi	1	super ultra EPIC	
+6235	practically non-alcoholic artisanal jittery Le Roi	1	super ultra EPIC	
 6236	bad Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
 6239	aerosolized colloidal bouncing blinking cube of ectoplasm	0		Effect: "Halloweeny", Effect Duration: 15
 6240	electrified Illuminati earpiece	0		Effect: "Antarctic Memories", Effect Duration: 65
 6241	deionized triple-enhanced censored can label	0		Effect: "Cold, Dead Hands", Effect Duration: 30
-6242	double-flattened ghostly wobbly ectoplasm <i>au jus</i>	0		Effect: "Concentration", Effect Duration: 46
+6242	double-flattened wobbly ghostly ectoplasm <i>au jus</i>	0		Effect: "Concentration", Effect Duration: 46
 6243	dry magnetized the kindest cut	0		Effect: "Coming Up Roses", Effect Duration: 53
 6244	electrified flattened cat's paw	0		Effect: "The Real Deal", Effect Duration: 66
 6245	boiled mirror ASCII fu manchu	0		Effect: "Oleaginous Soles", Effect Duration: 63
 6246	quantum mirror demonic surgical gloves	0		Effect: "Cancer Rising", Effect Duration: 47
 6247	galvanized shaking clip-on ninja tie	0		Effect: "Feline Ferocity", Effect Duration: 29
 6248	chilled unsweetened gamer slurry	0		Effect: "Top Dog", Effect Duration: 66
-6249	ghostly fuchsia dungeoneering kit	0		Last Available: "2013-02"
+6249	fuchsia ghostly dungeoneering kit	0		Last Available: "2013-02"
 6250	yellow prompt Annie Oakley's deadly educational numberwang of the scaredy-cat of bravery	0		Experience: +1, Weapon Damage: +5, Critical Hit Percent: +20, Monster Level: -15, Spooky Resistance: +5, Adventures: +3, Single Equip
 6251	magnetized squat scroll of Protection from Bad Stuff	0		Effect: "Artificially Sweet", Effect Duration: 14, Last Available: "2013-02"
 6252	deionized irradiated upside-down scroll of Puddingskin	0		Effect: "Well-Swabbed Ear", Effect Duration: 68, Last Available: "2013-02"
@@ -6170,11 +6170,11 @@
 6274	drinkable open sauce	4	good	
 6275	deadly brawny turkey leg	0		Muscle Percent: +20, Weapon Damage: +5
 6276	mediocre strong squat Ye Olde Meade	5	decent	
-6277	pressed bouncing huge Ye Olde Bawdy Limerick	0		Effect: "Serendipi Tea", Effect Duration: 15
+6277	pressed huge bouncing Ye Olde Bawdy Limerick	0		Effect: "Serendipi Tea", Effect Duration: 15
 6278	shaking Ye Olde Medieval Insult	0		
 6279	Temple Grandin's pewter claymore	0		Familiar Weight: +7
 6280	tumbling artisanal rice peeler	0		Item Drop: +5
-6281	half-sized bland heirloom grape tomato	2	decent	
+6281	bland half-sized heirloom grape tomato	2	decent	
 6282	chipotle wasabi cilantro aioli	0		
 6283	lime green spinning brown felt tophat of the wise owl	0		Mysticality: +20, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6264,7 +6264,7 @@
 6368	Mer-kin hallpass	0		
 6369	mirror lump of clay	0		
 6370	twisted piece of wire	0		
-6371	aged triple-distilled lime green shaking can of the cheapest beer	10	awesome	
+6371	aged triple-distilled shaking lime green can of the cheapest beer	10	awesome	
 6372	perfectly mixed bottle of fruity &quot;wine&quot;	4	EPIC	
 6373	delicious single swig of vodka	4	awesome	
 6374	angry inch	0		
@@ -6287,8 +6287,8 @@
 6392	wholesome dance instructor's scale-mail underwear	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Familiar Effect: "2xVolley"
 6393	alkaline dry yellow comb jelly	0		Effect: "One For Tea", Effect Duration: 23
 6394	anemone sauce	0		
-6395	shaking yellow inky squid sauce	0		
-6396	wobbly red upside-down Mer-kin weaksauce	0		
+6395	yellow shaking inky squid sauce	0		
+6396	red upside-down wobbly Mer-kin weaksauce	0		
 6397	peanut sauce	0		
 6398	glass	0		
 6399	improved warmed tumbling wobbly Boss Drops	0		Effect: "Industrial Strength Starch", Effect Duration: 22
@@ -6360,14 +6360,14 @@
 6465	occult dance instructor's Mayor Ghost's gavel of the cougar	0		Moxie: +20, Experience Percent (Moxie): +10, Spell Damage Percent: +25, Conditional Skill (Equipped): "Hammer Ghost"
 6466	groovy thinker's Mayor Ghost's sash of the empath	0		Mysticality: +10, Moxie Percent: +10, Familiar Weight: +5, Single Equip
 6467	spinning Mayor Ghost's scissors	0		
-6468	stale maroon huge ghost pepper	3	decent	
+6468	stale huge maroon ghost pepper	3	decent	
 6469	gravedigger's sharpshooter's supercool Thunkula's drinking cap	0		Moxie Percent: +20, Critical Hit Percent: +10, Spooky Damage: +10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	shaking pulsating lightning-fast chilly careful Drunkula's cape	0		Monster Level: -10, Cold Damage: +5, Initiative: +40, Class: "Sauceror"
 6471	steel-toed Drunkula's silky pants of Gandalf of the scaredy-cat	0		Damage Reduction: 9, Spell Critical Percent: +20, Monster Level: -15, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 6472	Drunkula's bell	0		
 6473	zippy gravedigger's vibrating Drunkula's ring of haze	0		Maximum MP Percent: +10, Spooky Damage: +10, Initiative: +20, Avoid Attack: 1, Single Equip
 6474	lime green razor-sharp Drunkula's wineglass	0		Weapon Damage Percent: +25
-6475	fortified artisanal bottle of Bloodweiser	5	EPIC	
+6475	artisanal fortified bottle of Bloodweiser	5	EPIC	
 6476	smooth Unkillable Skeleton's skullcap of the pedagogue	0		Moxie: +15, Experience: +3, Item Drop: +5, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	arcane researcher's weightlifter's Unkillable Skeleton's breastplate of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Experience Percent (Mysticality): +10, Class: "Turtle Tamer"
 6478	family-friendly banded slick Unkillable Skeleton's shinguards	0		Moxie: +10, Damage Absorption: +100, Sleaze Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6408,9 +6408,9 @@
 6513	wobbly family-friendly warm fur	0		Sleaze Resistance: +1
 6514	scandalous snowstick	0		Sleaze Damage: +5
 6515	zippy eerie fetish	0		Initiative: +20, Single Equip
-6516	tolerable practically non-alcoholic fancy narrow stinkwater	1	good	Effect: "Mystic Circle", Effect Duration: 40
+6516	practically non-alcoholic fancy tolerable narrow stinkwater	1	good	Effect: "Mystic Circle", Effect Duration: 40
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	bland miniature accidental mutton	2	decent	
+6518	miniature bland accidental mutton	2	decent	
 6519	Van der Graaf smartaleck's drafty drawers	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xVolley"
 6520	shaking fireproof double-paned wolfskull mask	0		Cold Resistance: +5, Hot Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr"
 6521	twirling lion tamer's guts necklace	0		Experience (familiar): +2, Single Equip
@@ -6421,7 +6421,7 @@
 6526	frosty Herculean bag of unfinished business	0		Experience (Muscle): +1, Cold Spell Damage: +10
 6527	bouncing steel-toed fortified transparent pants	0		Damage Absorption: +60, Damage Reduction: 9, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of vim and vigor	0		Maximum HP Percent: +50
-6529	acceptable special weak squat Thriller Ice	2	good	Effect: "The Halls of Mysticality", Effect Duration: 45
+6529	acceptable weak special squat Thriller Ice	2	good	Effect: "The Halls of Mysticality", Effect Duration: 45
 6530	ghostly Sinatra's grandfather watch	0		Experience (Moxie): +5, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	blue wobbly reassuring quilted spyglass	0		Damage Absorption: +40, Spooky Resistance: +1
@@ -6448,7 +6448,7 @@
 6554	stench cluster	0		
 6555	yellow sleaze cluster	0		
 6556	ionized modified triple-nitrogenated phial of hotness	0		Effect: "Highland Sheen", Effect Duration: 69
-6557	adjusted nitrogenated enhanced mirror shaking phial of coldness	0		Effect: "Here's Mud in Your Eye", Effect Duration: 28
+6557	adjusted nitrogenated enhanced shaking mirror phial of coldness	0		Effect: "Here's Mud in Your Eye", Effect Duration: 28
 6558	enhanced phial of spookiness	0		Effect: "Bloodstain-Resistant", Effect Duration: 44
 6559	ionized phial of stench	0		Effect: "Drenched With Filth", Effect Duration: 52
 6560	unsweetened purple phial of sleaziness	0		Effect: "Using Protection", Effect Duration: 65
@@ -6456,7 +6456,7 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	squat manspreader's hand of Mr. Cards	0		Monster Level: +10, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	yummy thick Dreadsylvanian hot pocket	5	awesome	
-6565	adequate special Dreadsylvanian pocket	3	good	Effect: "Goldentongue", Effect Duration: 20
+6565	special adequate Dreadsylvanian pocket	3	good	Effect: "Goldentongue", Effect Duration: 20
 6566	yummy Dreadsylvanian pocket	3	awesome	
 6567	stale Dreadsylvanian stink pocket	3	decent	
 6568	normal snack-sized Dreadsylvanian sleaze pocket	2	good	
@@ -6538,13 +6538,13 @@
 6644	folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	maroon Oprah's Fonzie's slide rule	0		Experience (Moxie): +1, Maximum MP Percent: +50
-6649	wet ionized blinking tumbling Ogres and Oubliettes&trade; module	0		Effect: "Fury of the Bells", Effect Duration: 14
+6649	wet ionized tumbling blinking Ogres and Oubliettes&trade; module	0		Effect: "Fury of the Bells", Effect Duration: 14
 6650	mirror mirror Mountain Stream Code Black Alert	0		
 6651	blurry twisted-up wet towel	0		
 6652	artisanal enchanted stepmom's booze	4	EPIC	Effect: "Leo Rising", Effect Duration: 10
 6653	surgical tape	0		
 6654	jittery band T-shirt of temperance	0		Sleaze Resistance: +5
-6655	enchanted bad practically non-alcoholic fountain 'soda'	1	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 30
+6655	practically non-alcoholic bad enchanted fountain 'soda'	1	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 30
 6656	illegal firecracker	0		
 6657	reassuring Oprah's pickelhaube	0		Maximum MP Percent: +50, Spooky Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	altered blinking hair oil	0		Effect: "It Didn't Kill You", Effect Duration: 61
@@ -6613,7 +6613,7 @@
 6721	flame-retardant studded strapping water bottle	0		Muscle: +5, Damage Absorption: +80, Hot Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	nitrogenated purple pygmy phone number	0		Effect: "Yuletide Mutations", Effect Duration: 50
 6723	Boozehounds Anonymous token	0		
-6724	spoiled immense wobbly jittery exotic jungle fruit	6	crappy	
+6724	immense spoiled jittery wobbly exotic jungle fruit	6	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	squat dude ranch souvenir crate	0		
 6727	blinking tropical island souvenir crate	0		
@@ -6621,7 +6621,7 @@
 6729	tumbling UV-resistant compass	0		
 6730	squat funky junk key	0		
 6731	Worse Homes and Gardens	0		
-6732	twirling wobbly claw-foot bathtub	0		
+6732	wobbly twirling claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	cigar sign	0		
 6735	junk junk	0		
@@ -6667,7 +6667,7 @@
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	boiled bouncing tumbling foetid seal tear	0		Effect: "White Blooded", Effect Duration: 23
 6777	chilled seal sweat	0		Effect: "Ancestral Disapproval", Effect Duration: 35
-6778	alkaline gray jittery blinking boiling seal blood	0		Effect: "Fitter, Happier", Effect Duration: 52
+6778	alkaline jittery gray blinking boiling seal blood	0		Effect: "Fitter, Happier", Effect Duration: 52
 6779	lime green crystalline seal eye	0		Single Equip
 6780	chilly studded sealhide shield of wisdom	0		Mysticality: +15, Cold Damage: +5, Damage Reduction: 7
 6781	smelly scabrous seal epaulets of Gandalf	0		Spell Critical Percent: +20, Stench Spell Damage: +10, Single Equip
@@ -6683,7 +6683,7 @@
 6793	pulsating soap knife	0		
 6795	non-liquefied disco horoscope (Aquarius)	0		Effect: "Ancient Protected", Effect Duration: 18
 6796	deionized disco horoscope (Pisces)	0		Effect: "Ogred and Oublietted", Effect Duration: 21
-6797	liquefied shaking tumbling disco horoscope (Aries)	0		Effect: "Musky", Effect Duration: 15
+6797	liquefied tumbling shaking disco horoscope (Aries)	0		Effect: "Musky", Effect Duration: 15
 6798	quantum jittery jittery disco horoscope (Taurus)	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 60
 6799	chilled chilled disco horoscope (Gemini)	0		Effect: "Low on the Hog", Effect Duration: 64
 6800	electrified moist disco horoscope (Cancer)	0		Effect: "Headstrong", Effect Duration: 24
@@ -6694,7 +6694,7 @@
 6805	altered disco horoscope (Sagittarius)	0		Effect: "Memory of Smarts", Effect Duration: 32
 6806	aerosolized disco horoscope (Capricorn)	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 27
 6807	skewed personal trainer's The Sagittarian's leisure pants of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Familiar Effect: "atk, cap 18"
-6808	ghostly huge ghostly cyan toy accordion	0		Song Duration: 5
+6808	huge cyan ghostly ghostly toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
 6810	beer-battered accordion of vim and vigor	0		Maximum HP Percent: +50, Class: "Accordion Thief", Song Duration: 6
 6811	wobbly scorching baritone accordion	0		Hot Damage: +25, Class: "Accordion Thief", Song Duration: 7
@@ -6727,9 +6727,9 @@
 6838	liquefied liquefied Bugbearclaw Donut	0		Effect: "This Is Where You're a Viking", Effect Duration: 60
 6839	ionized jam	0		Effect: "Tiki Temerity", Effect Duration: 34
 6840	irradiated altered Whenchamacallit bar	0		Effect: "Chlorophyll Flavor", Effect Duration: 39
-6841	pressed corrupted shaking yellow 8-bit banana	0		Effect: "Sweet and Yellow", Effect Duration: 25
+6841	pressed corrupted yellow shaking 8-bit banana	0		Effect: "Sweet and Yellow", Effect Duration: 25
 6842	pressed adjusted vial of blood simple syrup	0		Effect: "Frozen Hands", Effect Duration: 60
-6843	dry super-anodized jittery squat bone bons	0		Effect: "Cold Hard Skin", Effect Duration: 25
+6843	dry super-anodized squat jittery bone bons	0		Effect: "Cold Hard Skin", Effect Duration: 25
 6844	cold-filtered dry spinning ironic mint	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 26
 6845	unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
@@ -6740,7 +6740,7 @@
 6851	huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
-6854	tumbling cyan desert sightseeing pamphlet	0		
+6854	cyan tumbling desert sightseeing pamphlet	0		
 6855	a suspicious address	0		
 6856	narrow miser's Bal-musette accordion	0		Meat Drop: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	maroon Cajun accordion of the boozehound	0		Booze Drop: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
@@ -6751,15 +6751,15 @@
 6862	immense delicious skewed high-calorie sugar substitute	10	awesome	Last Available: "2013-11"
 6863	normal pat of butter	3	good	Last Available: "2013-11"
 6864	adequate fancy dinner roll	3	good	Effect: "Educated (Kinda)", Effect Duration: 45, Last Available: "2013-11"
-6865	decent fancy mashed potatoes	3	good	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2013-11"
-6866	bland half-sized whole turkey leg	2	decent	Last Available: "2013-11"
-6867	stale massive upside-down deviled egg	7	decent	Last Available: "2013-11"
+6865	fancy decent mashed potatoes	3	good	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2013-11"
+6866	half-sized bland whole turkey leg	2	decent	Last Available: "2013-11"
+6867	massive stale upside-down deviled egg	7	decent	Last Available: "2013-11"
 6868	activated nitrogenated finger exerciser	0		Effect: "Big Meat Big Prizes", Effect Duration: 28, Last Available: "2013-11"
 6869	unsweetened ionized pulsating dented spoon	0		Effect: "Busy Bein' Delicious", Effect Duration: 22, Last Available: "2013-11"
 6870	alkaline love note	0		Effect: "Burning Tongue", Effect Duration: 32, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	chilled mirror nail file	0		Effect: "Rave Nirvana", Effect Duration: 40, Last Available: "2013-11"
-6873	chilled squat upside-down candy wrapper	0		Effect: "Mer-kindliness", Effect Duration: 27, Last Available: "2013-11"
+6873	chilled upside-down squat candy wrapper	0		Effect: "Mer-kindliness", Effect Duration: 27, Last Available: "2013-11"
 6874	tumbling gym membership card	0		Last Available: "2013-11"
 6875	deionized polymerized shaking cyan ghostly post-holiday sale coupon	0		Effect: "Tennis Elbow-wow", Effect Duration: 45, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
@@ -6780,7 +6780,7 @@
 6891	shaking greasy educational wizardly spirit bell	0		Mysticality: +25, Experience: +1, Sleaze Spell Damage: +10, Class: "Turtle Tamer"
 6892	altered denatured purple spoonful of Linguine-Os	0		Effect: "Feroci Tea", Effect Duration: 16, Last Available: "2013-11"
 6893	pickled freezer-burned frost-bitten tortellini	0		Effect: "Limber as Mortimer", Effect Duration: 49, Last Available: "2013-11"
-6894	oxidized flattened diffused blinking bouncing blob of Alphredo&trade;	0		Effect: "Ginger Snapped", Effect Duration: 50, Last Available: "2013-11"
+6894	oxidized flattened diffused bouncing blinking blob of Alphredo&trade;	0		Effect: "Ginger Snapped", Effect Duration: 50, Last Available: "2013-11"
 6895	tarnished pickled twirling handful of crafty noodles	0		Effect: "Memory of Strength", Effect Duration: 54, Last Available: "2013-11"
 6896	colloidal galvanized tumbling tangled mass of pasta	0		Effect: "Phorcefullness", Effect Duration: 58, Last Available: "2013-11"
 6897	tarnished yellow Can of Spaghetto	0		Effect: "Greasy Visage", Effect Duration: 20, Last Available: "2013-11"
@@ -6895,7 +6895,7 @@
 7006	diluted yellow handful of Smithereens	1	EPIC	Last Available: "2013-12"
 7007	adequate thick upside-down Every Day is Like This Sundae	5	good	Last Available: "2013-12"
 7008	moldy Miserable Pie	3	crappy	Last Available: "2013-12"
-7009	gigantic decent This Charming Flan	6	good	Last Available: "2013-12"
+7009	decent gigantic This Charming Flan	6	good	Last Available: "2013-12"
 7010	acceptable maroon Irish Coffee, English Heart	3	good	Last Available: "2013-12"
 7011	mediocre spinning Strikes Again Bigmouth	3	decent	Last Available: "2013-12"
 7012	perfectly mixed shaking Paint A Vulgar Pitcher	3	EPIC	Last Available: "2013-12"
@@ -6924,7 +6924,7 @@
 7035	warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	mirror warbear LP-ROM burner	0		Last Available: "2013-12"
-7038	twirling cyan warbear gyrocopter	0		Last Available: "2013-12"
+7038	cyan twirling warbear gyrocopter	0		Last Available: "2013-12"
 7039	ionized boiled skewed warbear robo-camouflage unit	0		Effect: "Human-Goblin Hybrid", Effect Duration: 65, Last Available: "2013-12"
 7040	lime green warbear beeping telegram	0		Last Available: "2013-12"
 7041	blurry warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
@@ -6936,7 +6936,7 @@
 7047	vacuum-sealed electrified warbear liquid lasers	0		Effect: "Broken Fast", Effect Duration: 56, Last Available: "2013-12"
 7048	quantum modified ionized warbear rejuvenation potion	0		Effect: "critical.enh", Effect Duration: 67, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	adequate fancy tiny blinking warbear gyro	1	good	Effect: "Mer-kindliness", Effect Duration: 30, Last Available: "2013-12"
+7050	tiny adequate fancy blinking warbear gyro	1	good	Effect: "Mer-kindliness", Effect Duration: 30, Last Available: "2013-12"
 7051	aerosolized recording of Rolando's Rondo of Resisto	0		Effect: "Block-Rockin' Beet", Effect Duration: 48, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6957,14 +6957,14 @@
 7068	Vulcanized boiled wobbly single of Donho's Bubbly Ballad	0		Effect: "Creepypasted", Effect Duration: 63
 7069	blurry Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	spoiled low-calorie bouncing snow berries	1	crappy	Last Available: "2014-01"
+7071	low-calorie spoiled bouncing snow berries	1	crappy	Last Available: "2014-01"
 7072	decent ice harvest	3	good	Last Available: "2014-01"
 7073	altered pulsating bouncing frost flower	0		Effect: "Musky", Effect Duration: 53, Last Available: "2014-01"
 7074	non-galvanized snow cleats	0		Effect: "Antibiotic Saucesphere", Effect Duration: 46, Last Available: "2014-01"
 7075	magnetized non-diffused liquid ice pack	0		Effect: "Strong Grip", Effect Duration: 36, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	rotten fancy snow crab	3	crappy	Effect: "Vented Spleen", Effect Duration: 35, Last Available: "2014-01"
-7078	weak artisanal huge Ice Island Long Tea	2	super ultra mega EPIC	Last Available: "2014-01"
+7077	fancy rotten snow crab	3	crappy	Effect: "Vented Spleen", Effect Duration: 35, Last Available: "2014-01"
+7078	artisanal weak huge Ice Island Long Tea	2	super ultra mega EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6991,14 +6991,14 @@
 7102	cyan narrow pixie axie	0		Last Available: "2014-12"
 7103	nitrogenated powder	0		Effect: "Hypercubed", Effect Duration: 44, Last Available: "2014-12"
 7104	vibrating licorice whip	0		Maximum MP Percent: +10, Last Available: "2014-12"
-7105	bouncing purple anise-flavored venom	0		Last Available: "2014-12"
+7105	purple bouncing anise-flavored venom	0		Last Available: "2014-12"
 7106	acceptable pulsating snakebite	4	good	Last Available: "2014-12"
 7107	blinking healthy candy stick of the blizzard	0		Maximum HP Percent: +20, Cold Spell Damage: +25, Last Available: "2014-12"
 7108	moldy pecan	4	crappy	Last Available: "2014-12"
 7109	stale blinking pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	normal low-calorie candy mountain oyster	1	good	Last Available: "2014-12"
-7112	perfectly mixed boozy spinning tumbling chocotini	5	EPIC	Last Available: "2014-12"
+7112	perfectly mixed boozy tumbling spinning chocotini	5	EPIC	Last Available: "2014-12"
 7113	auspicious dangerous Socratic chocolate rabbit's foot	0		Experience (Mysticality): +1, Weapon Damage: +10, Item Drop: +10, Last Available: "2014-12"
 7114	decent bite-sized candy carrot	1	good	Last Available: "2014-12"
 7115	bland squat candy carrot cake	3	decent	Last Available: "2014-12"
@@ -7046,18 +7046,18 @@
 7157	red Sherlock's hardy personal trainer's fire hose	0		Experience Percent (Muscle): +10, Maximum HP: +50, Item Drop: +25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	rotten pulsating fireman's lunch	3	crappy	Last Available: "2014-12"
 7159	blinking coward's Annie Oakley's personal trainer's plain paper hat	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Monster Level: -20, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	rotten miniature ice cream sandwich	2	crappy	Last Available: "2014-12"
+7160	miniature rotten ice cream sandwich	2	crappy	Last Available: "2014-12"
 7161	yellow twirling Usain Bolt's studded &quot;honey&quot; dipper of the cougar	0		Moxie: +20, Damage Absorption: +80, Initiative: +80, Last Available: "2014-12"
 7162	spoiled plumber's lunch	3	crappy	Last Available: "2014-12"
 7163	knitted supercharged skull gearshift knob of mayonnaise	0		Maximum MP Percent: +30, Sleaze Spell Damage: +50, Cold Resistance: +3, Last Available: "2014-12"
-7164	rotten huge nachos of the night	6	crappy	Last Available: "2014-12"
+7164	huge rotten nachos of the night	6	crappy	Last Available: "2014-12"
 7165	scorching Sketcherz&trade; of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Hot Damage: +25, Last Available: "2014-12"
-7166	small adequate fancy can of Adultwitch&trade;	2	good	Effect: "Twen Tea", Effect Duration: 10, Last Available: "2014-12"
-7167	modified lime green blinking smudge stick	0		Effect: "Al Dente Inferno", Effect Duration: 55, Last Available: "2014-12"
+7166	fancy small adequate can of Adultwitch&trade;	2	good	Effect: "Twen Tea", Effect Duration: 10, Last Available: "2014-12"
+7167	modified blinking lime green smudge stick	0		Effect: "Al Dente Inferno", Effect Duration: 55, Last Available: "2014-12"
 7168	double-adjusted oxidized activated wobbly wall	0		Effect: "Lemony Goodness", Effect Duration: 65, Last Available: "2014-12"
 7169	hand-crafted spinning tankard of ale	4	EPIC	Last Available: "2014-12"
 7170	liquefied corrupted scroll case	0		Effect: "Bear Clawed", Effect Duration: 42, Last Available: "2014-12"
-7171	unsweetened tumbling bouncing spinning jug of &quot;wine&quot;	0		Effect: "Ocelot Eyes", Effect Duration: 15, Last Available: "2014-12"
+7171	unsweetened spinning bouncing tumbling jug of &quot;wine&quot;	0		Effect: "Ocelot Eyes", Effect Duration: 15, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	fuchsia crappy camera	0		Last Available: "2014-12"
 7174	adequate special jittery humble pie	3	good	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2014-12"
@@ -7078,7 +7078,7 @@
 7189	upside-down squat extremely unsafe unrequired jacket	0		Weapon Damage Percent: +100
 7190	greasy tommy gun	0		Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	drum of tommy ammo	0		
-7192	twirling shaking throwing knife	0		
+7192	shaking twirling throwing knife	0		
 7193	throwing spoon	0		
 7194	throwing fork	0		
 7195	gravedigger's extremely unsafe breadchucks	0		Weapon Damage Percent: +100, Spooky Damage: +10
@@ -7101,25 +7101,25 @@
 7212	mirror ghostly medical-grade Jefferson wings	0		HP Regen Min: 7, HP Regen Max: 10
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	toothsome immense wobbly fleetwood mac 'n' cheese	9	awesome	
+7215	immense toothsome wobbly fleetwood mac 'n' cheese	9	awesome	
 7216	huge lynyrd skin	0		
 7217	beefcake's lynyrdskin cap	0		Muscle: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	ghostly Annie Oakley's lynyrdskin tunic	0		Critical Hit Percent: +20
 7219	Oprah's lynyrdskin breeches	0		Maximum MP Percent: +50, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	narrow cigarette lighter	0		
-7221	purple upside-down priceless diamond	0		
+7221	upside-down purple priceless diamond	0		
 7222	bad Flamin' Whatshisname	3	decent	
 7223	electrified pressed tumbling lynyrd musk	0		Effect: "The Wisdom... of the Future", Effect Duration: 56
 7224	teal greasy flame-wreathed Kashmir sweater	0		Hot Spell Damage: +10, Sleaze Spell Damage: +10
 7225	bland custard pie	3	decent	
 7226	squat tea for one	1	good	
-7227	triple-distilled mediocre bottle of Evermore	10	decent	
+7227	mediocre triple-distilled bottle of Evermore	10	decent	
 7228	box	0		
 7229	acceptable wine	4	good	
 7230	watered-down tolerable mirror rum	2	good	
 7231	acceptable Murderer's Punch	3	good	
 7232	half-sized stale wobbly velvet cake	2	decent	
-7233	unsweetened quadruple-oxidized upside-down blurry letter	0		Effect: "What's That Smell?", Effect Duration: 33
+7233	unsweetened quadruple-oxidized blurry upside-down letter	0		Effect: "What's That Smell?", Effect Duration: 33
 7234	inspector's book of the cougar	0		Moxie: +20, Item Drop: +15
 7235	dog trainer's crafty masque	0		Maximum MP: +10, Experience (familiar): +1, Single Equip
 7236	maroon blurry red-hot poker	0		Item Drop: +5
@@ -7138,7 +7138,7 @@
 7249	Thwaitgold dragonfly statuette	0		
 7250	gray extremely unsafe Newton's Sneaky Pete's jacket of vim and vigor of the storm	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Maximum HP Percent: +50, Maximum MP Percent: +40, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	pulsating pulsating jug of Sneaky Pete's Mojo	0		Free Pull
-7252	blue mirror shot of Sneaky Pete's Mojo	0		Free Pull
+7252	mirror blue shot of Sneaky Pete's Mojo	0		Free Pull
 7253	olive Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
 7255	lousy extra-dry mini-martini	5	decent	
@@ -7156,7 +7156,7 @@
 7267	coward's chaotic Sneaky Pete's jacket (collar popped) of bravery of the glutton	0		Spell Critical Percent: +10, Monster Level: -20, Spooky Resistance: +5, Food Drop: +100, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	wobbly Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
-7270	fuchsia ghostly huge &quot;2 Love Me, Vol. 2&quot;	0		
+7270	huge ghostly fuchsia &quot;2 Love Me, Vol. 2&quot;	0		
 7271	wobbly Thinknerd Blind-Packed Toy	0		
 7272	plastic Professor What of the blizzard	0		Cold Spell Damage: +25
 7273	brawny plastic Jared the Duskwalker	0		Muscle Percent: +20
@@ -7199,7 +7199,7 @@
 7310	Vulcanized quantum upside-down bronzer	0		Effect: "Square to be Hip", Effect Duration: 13
 7311	rock-hard slick elegant nightstick	0		Moxie: +10, Damage Reduction: 5
 7312	mirror still grill	0		Free Pull, Last Available: "2014-06"
-7313	blinking teal box of hickory chips	0		Familiar Weight: +5
+7313	teal blinking box of hickory chips	0		Familiar Weight: +5
 7314	ghostly poppet	0		
 7315	rickety rocking horse	0		
 7316	jack-in-the-box	0		
@@ -7214,7 +7214,7 @@
 7325	bad snakebite	3	decent	
 7326	blurry friendly Sinatra's rubber ribcage	0		Experience (Moxie): +5, Familiar Weight: +3, Damage Reduction: 7
 7327	altered synthetic marrow	1		
-7328	non-denatured galvanized mirror shaking funny bone	0		Effect: "Icy Composition", Effect Duration: 27
+7328	non-denatured galvanized shaking mirror funny bone	0		Effect: "Icy Composition", Effect Duration: 27
 7329	cyan sizzling half-melted spoon of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50
 7330	dried twirling the funk	1		
 7331	decent gunky chicken	3	good	
@@ -7228,8 +7228,8 @@
 7339	music box mechanism	0		
 7340	ruddy moose antlers	0		Maximum HP Percent: +40, Familiar Effect: "atk, 1xLep, cap 27"
 7341	modified enhanced dry jittery moose thought	0		Effect: "Feroci Tea", Effect Duration: 51
-7342	stale diet moose chocolate	1	decent	
-7343	strong mediocre painting of a glass of wine	5	decent	
+7342	diet stale moose chocolate	1	decent	
+7343	mediocre strong painting of a glass of wine	5	decent	
 7344	green oil painting of yourself	0		
 7345	jittery ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7262,7 +7262,7 @@
 7373	Tesla sommelier's towel	0		MP Regen Min: 7, MP Regen Max: 10
 7374	beefcake's tarnished tastevin	0		Muscle: +25, Single Equip
 7375	bite-sized tasty actual tapas	1	awesome	
-7376	lime green jittery ghast iron ingot	0		
+7376	jittery lime green ghast iron ingot	0		
 7377	nippy Lo Pan's ghast iron cleaver	0		Spell Critical Percent: +30, Cold Damage: +10
 7378	family-friendly ghast iron Garibaldi of chilblains	0		Cold Damage: +25, Sleaze Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 14"
 7379	scorching Temple Grandin's ghast iron heater shield	0		Familiar Weight: +7, Hot Damage: +25, Damage Reduction: 11
@@ -7286,11 +7286,11 @@
 7397	modified Gene Tonic: Plant	0		Effect: "Uncaged Power", Effect Duration: 19, Last Available: "2014-04"
 7398	magnetized dry pickled Gene Tonic: Weird	0		Effect: "Weasels Underfoot", Effect Duration: 13, Last Available: "2014-04"
 7399	modified enhanced Gene Tonic: Elf	0		Effect: "Hustlin'", Effect Duration: 53, Last Available: "2014-04"
-7400	frozen colloidal squat gray mirror Gene Tonic: Mer-kin	0		Effect: "Tea-hee", Effect Duration: 25, Last Available: "2014-04"
+7400	frozen colloidal mirror gray squat Gene Tonic: Mer-kin	0		Effect: "Tea-hee", Effect Duration: 25, Last Available: "2014-04"
 7401	denatured denatured Gene Tonic: Slime	0		Effect: "Peppermint Bite", Effect Duration: 36, Last Available: "2014-04"
 7402	corrupted extra-polarized Gene Tonic: Penguin	0		Effect: "Robocamo", Effect Duration: 52, Last Available: "2014-04"
 7403	pickled double-diffused Gene Tonic: Elemental	0		Effect: "Motion", Effect Duration: 47, Last Available: "2014-04"
-7404	ionized denatured upside-down shaking Gene Tonic: Constellation	0		Effect: "Winklered", Effect Duration: 22, Last Available: "2014-04"
+7404	ionized denatured shaking upside-down Gene Tonic: Constellation	0		Effect: "Winklered", Effect Duration: 22, Last Available: "2014-04"
 7405	chilled double-liquefied Gene Tonic: Hobo	0		Effect: "Well-Oiled", Effect Duration: 66, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	teal Steam Card: Dungeon Fist (#2)	0		
@@ -7314,7 +7314,7 @@
 7425	blurry Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	shaking sprinkle shaker	0		Last Available: "2014-05"
 7427	liquefied sleight-of-hand mushroom	0		Effect: "You're Not Cooking", Effect Duration: 44, Last Available: "2014-05"
-7428	shaking blinking Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
+7428	blinking shaking Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	Beach Buck	0		Last Available: "2014-05"
 7430	aerosolized Fun-Guy spore	0		Effect: "Inner Dog", Effect Duration: 45, Last Available: "2014-05"
 7431	non-moist triple-electrified pickled Boletus Broletus mushroom	0		Effect: "Strong Grip", Effect Duration: 63, Last Available: "2014-05"
@@ -7324,11 +7324,11 @@
 7435	oxidized upside-down Stemonitis Staticus mushroom	0		Effect: "Fortunate Resolve", Effect Duration: 34, Last Available: "2014-05"
 7436	electrified Tremella Tarantella mushroom	0		Effect: "Coldfinger", Effect Duration: 45, Last Available: "2014-05"
 7437	ghostly Pastaco shell	0		Last Available: "2014-05"
-7438	normal diet Beefy Crunch Pastaco	1	good	Last Available: "2014-05"
+7438	diet normal Beefy Crunch Pastaco	1	good	Last Available: "2014-05"
 7439	jumbo bland Brain Food Pastaco	5	decent	Last Available: "2014-05"
 7440	gigantic normal pulsating Cool Brunch Pastaco	9	good	Last Available: "2014-05"
 7441	yummy olive narrow Medical Pastaco	4	awesome	Last Available: "2014-05"
-7442	half-sized moldy Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
+7442	moldy half-sized Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
 7443	decent low-calorie Ludovico Pastaco	1	good	Last Available: "2014-05"
 7444	perfectly mixed weak tumbling maroon overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7445	tolerable complex mushroom wine	3	good	Last Available: "2014-05"
@@ -7336,12 +7336,12 @@
 7447	watered-down lousy skewed blood-red mushroom wine	2	decent	Last Available: "2014-05"
 7448	boozy tolerable buzzing mushroom wine	5	good	Last Available: "2014-05"
 7449	drinkable blinking swirling mushroom wine	3	good	Last Available: "2014-05"
-7450	big flavorless Taco Dan's Basic Taco Dan Taco	5	decent	Last Available: "2014-05"
+7450	flavorless big Taco Dan's Basic Taco Dan Taco	5	decent	Last Available: "2014-05"
 7451	diet spoiled Taco Dan's Taco Fish Fish Taco	1	crappy	Last Available: "2014-05"
 7452	blurry Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	hand-crafted regular-size brogurt	4	EPIC	Last Available: "2014-05"
 7454	watered-down lousy squat super-size brogurt	2	decent	Last Available: "2014-05"
-7455	practically non-alcoholic bad fancy broberry brogurt	1	decent	Effect: "Can't Be a Chooser", Effect Duration: 5, Last Available: "2014-05"
+7455	fancy practically non-alcoholic bad broberry brogurt	1	decent	Effect: "Can't Be a Chooser", Effect Duration: 5, Last Available: "2014-05"
 7456	hand-crafted brocolate brogurt	4	EPIC	Last Available: "2014-05"
 7457	delicious wobbly French bronilla brogurt	3	awesome	Last Available: "2014-05"
 7458	upside-down History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
@@ -7382,7 +7382,7 @@
 7493	squat unstable fulminate	0		
 7494	jittery wine bomb	0		
 7495	green recipe: mortar-dissolving solution	0		
-7496	teal twirling bottled day	0		
+7496	twirling teal bottled day	0		
 7497	ghost formula	0		
 7498	narrow Thwaitgold wheel bug statuette	0		
 7499	irradiated adjusted pulsating pulsating Hot 'n' Scarys	0		Effect: "Quadrilled", Effect Duration: 68
@@ -7407,7 +7407,7 @@
 7518	wand of pigification	0		
 7519	artisanal glass of bourbon	4	EPIC	
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	gigantic adequate huge government cheese	10	good	Last Available: "2014-05"
+7521	adequate gigantic huge government cheese	10	good	Last Available: "2014-05"
 7522	pair of government shades of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	wet warmed huge yellow bouncing government	0		Effect: "Gobliny Flavor", Effect Duration: 51, Last Available: "2014-05"
@@ -7416,9 +7416,9 @@
 7527	red alien force field disruptor bean	0		Last Available: "2014-05"
 7528	electrified government-issued night-vision goggles of the bloodbag	0		Maximum HP: +100, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2014-05"
 7529	bite-sized moldy bouncing loaf of alien bread	1	crappy	Last Available: "2014-05"
-7530	half-sized stale twirling wobbly grilled cheese sandwich	2	decent	Last Available: "2014-05"
+7530	half-sized stale wobbly twirling grilled cheese sandwich	2	decent	Last Available: "2014-05"
 7531	denatured alien protein powder	1	awesome	Last Available: "2014-05"
-7532	weak acceptable shaking olive rocket fuel	2	good	Last Available: "2014-05"
+7532	weak acceptable olive shaking rocket fuel	2	good	Last Available: "2014-05"
 7533	upside-down alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	aged gray stealth bomber	4	awesome	Last Available: "2014-05"
@@ -7444,7 +7444,7 @@
 7555	upside-down page	0		
 7556	elephant gift	0		
 7557	cold-filtered blood cells	0		Effect: "Stogied", Effect Duration: 26
-7558	high-proof smooth purple wine	8	awesome	
+7558	smooth high-proof purple wine	8	awesome	
 7559	chilled green gummi turtle	0		Effect: "Crud&eacute;", Effect Duration: 51
 7560	ghostly turtle-shaped rock	0		
 7561	altered giraffe-necked turtle	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20
@@ -7475,11 +7475,11 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	upside-down Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	lousy triple-distilled glass of &quot;milk&quot;	10	decent	Last Available: "2014-07"
+7589	triple-distilled lousy glass of &quot;milk&quot;	10	decent	Last Available: "2014-07"
 7590	mediocre cup of &quot;tea&quot;	4	decent	Last Available: "2014-07"
 7591	tolerable watered-down cyan thermos of &quot;whiskey&quot;	2	good	Last Available: "2014-07"
-7592	irresponsibly strong mediocre Lucky Lindy	8	decent	Last Available: "2014-07"
-7593	fortified lousy enchanted Bee's Knees	5	decent	Effect: "Standard Cheer", Effect Duration: 35, Last Available: "2014-07"
+7592	mediocre irresponsibly strong Lucky Lindy	8	decent	Last Available: "2014-07"
+7593	enchanted lousy fortified Bee's Knees	5	decent	Effect: "Standard Cheer", Effect Duration: 35, Last Available: "2014-07"
 7594	aged fancy blinking Sockdollager	3	awesome	Effect: "Hustlin'", Effect Duration: 15, Last Available: "2014-07"
 7595	tolerable Ish Kabibble	3	good	Last Available: "2014-07"
 7596	artisanal Hot Socks	4	EPIC	Last Available: "2014-07"
@@ -7517,7 +7517,7 @@
 7628	frozen aerosolized dancing fan	0		Effect: "Egg-stra Arm", Effect Duration: 19
 7629	adjusted aerosolized spinning page of the Necrohobocon	0		Effect: "Wit Tea", Effect Duration: 62
 7630	extra-polarized bouncing magic powder	0		Effect: "Fishy Fortification", Effect Duration: 32
-7631	polarized irradiated super-quantum yellow narrow friar's tonsure	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 17
+7631	polarized irradiated super-quantum narrow yellow friar's tonsure	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 17
 7632	polymerized unsweetened government-issue identification badge	0		Effect: "The Moxie of LOV", Effect Duration: 12
 7633	alkaline squat blinking alien hologram projector	0		Effect: "Sugar Smacks", Effect Duration: 28
 7634	colloidal irradiated turtle	0		Effect: "Hobonic", Effect Duration: 17
@@ -7552,7 +7552,7 @@
 7663	clever supercharged Lord Soggyraven's Slippers of the empath	0		Maximum MP Percent: +30, Maximum MP: +20, Familiar Weight: +5, Single Equip
 7664	frozen blurry Ancient Protector Soda	0		Effect: "Sweetened and Fattened", Effect Duration: 32
 7665	pressed unsweetened liquid ice	0		Effect: "Super Structure", Effect Duration: 46
-7666	weak lousy Wet Russian	2	decent	
+7666	lousy weak Wet Russian	2	decent	
 7667	yummy filet of The Fish	3	awesome	
 7668	Thwaitgold spider statuette	0		
 7669	prompt dog trainer's thunder down underwear of the storm	0		Maximum MP Percent: +40, Experience (familiar): +1, Adventures: +3, Lasts Until Rollover
@@ -7592,11 +7592,11 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	spinning maroon The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	maroon spinning The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	polarized aerosolized rubber nubbin	0		Effect: "Stands Alone", Effect Duration: 13, Last Available: "2014-08"
 7708	horrifying rubber cape of Tarzan	0		Experience (Muscle): +3, Spooky Damage: +25, Last Available: "2014-08"
 7709	ruddy sage Thor's Pliers of Calamity Jane of the boozehound	0		Mysticality Percent: +10, Maximum HP Percent: +40, Critical Hit Percent: +15, Booze Drop: +100, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
-7710	pickled irradiated skewed maroon candy UFOs	0		Effect: "Triangle, Man", Effect Duration: 11
+7710	pickled irradiated maroon skewed candy UFOs	0		Effect: "Triangle, Man", Effect Duration: 11
 7711	blinking jittery fireproof stylish water wings for babies	0		Moxie: +25, Hot Resistance: +3
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	massive spoiled Strix stix	7	crappy	
@@ -7616,11 +7616,11 @@
 7727	chilled ghostly Burt's blessing of Bacchus	0		Effect: "Pyramid Power", Effect Duration: 67
 7728	double-enhanced dry shaking Freddie's blessing of Mercury	0		Effect: "Bloodstain-Resistant", Effect Duration: 50
 7729	Chroner trigger	0		
-7730	ghostly squat Xi Receiver Unit	0		Last Available: "2014-09"
+7730	squat ghostly Xi Receiver Unit	0		Last Available: "2014-09"
 7731	shaking transmission from planet Xi	0		Last Available: "2014-09"
 7732	wobbly Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	Xiblaxian circuitry	0		Last Available: "2014-09"
-7734	jittery fuchsia narrow Xiblaxian polymer	0		Last Available: "2014-09"
+7734	narrow fuchsia jittery Xiblaxian polymer	0		Last Available: "2014-09"
 7735	skewed Xiblaxian alloy	0		Last Available: "2014-09"
 7736	Xiblaxian crystal	0		Last Available: "2014-09"
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
@@ -7629,10 +7629,10 @@
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	bouncing yellow Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
-7743	blinking wobbly pulsating Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
+7743	wobbly blinking pulsating Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
 7744	Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
-7746	wobbly twirling Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
+7746	twirling wobbly Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
 7747	Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
@@ -7643,10 +7643,10 @@
 7754	dog trainer's supercharged Xiblaxian stealth trousers	0		Maximum MP Percent: +30, Experience (familiar): +1, Last Available: "2014-09"
 7755	rosy-cheeked Xiblaxian stealth vest of the boozehound	0		Maximum HP Percent: +30, Booze Drop: +100, Last Available: "2014-09"
 7756	stale Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
-7757	artisanal fortified tumbling Xiblaxian space-whiskey	5	EPIC	Last Available: "2014-09"
+7757	fortified artisanal tumbling Xiblaxian space-whiskey	5	EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	triple-irradiated They liver	0		Effect: "Magically Fingered", Effect Duration: 62, Last Available: "2014-09"
-7760	decent big They liver popsicle	5	good	Last Available: "2014-09"
+7760	big decent They liver popsicle	5	good	Last Available: "2014-09"
 7761	green holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	blurry holo-platoon	0		Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	fuchsia twirling frosty Rosewater's sage Personal Ventilation Unit	0		Mysticality Percent: 40, Cold Spell Damage: +10, Single Equip, Last Available: "2014-10"
 7771	ionized corrupted the most dangerous bait	0		Effect: "Tapped In", Effect Duration: 37, Last Available: "2014-10"
-7772	fancy snack-sized decent &quot;meat&quot; stick	2	good	Effect: "Human-Elemental Hybrid", Effect Duration: 10, Last Available: "2014-10"
+7772	fancy decent snack-sized &quot;meat&quot; stick	2	good	Effect: "Human-Elemental Hybrid", Effect Duration: 10, Last Available: "2014-10"
 7773	powdered transdermal smoke patch	1	awesome	Effect: "Powder Power", Effect Duration: 35, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	double-paned Jim Carey's pair of plants of Leguizamo	0		Monster Level: 45, Cold Resistance: +5, Last Available: "2014-10"
@@ -7668,7 +7668,7 @@
 7779	liquefied aerosolized experimental serum G-9	0		Effect: "Certainty", Effect Duration: 41, Last Available: "2014-10"
 7780	olive miser's wholesome brawny heavy-duty clipboard	0		Muscle Percent: +20, Maximum HP Percent: +10, Meat Drop: +10, Damage Reduction: 8, Last Available: "2014-10"
 7781	fireproof MacGyver's studded experienced battery-powered drill	0		Experience: +2, Damage Absorption: +80, Maximum MP: +100, Hot Resistance: +3, Last Available: "2014-10"
-7782	thick enchanted normal limp broccoli	5	good	Effect: "Arcane in the Brain", Effect Duration: 5, Last Available: "2014-10"
+7782	normal enchanted thick limp broccoli	5	good	Effect: "Arcane in the Brain", Effect Duration: 5, Last Available: "2014-10"
 7783	stanky hardy hat of horror	0		Maximum HP: +50, Stench Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	ionized fuchsia monkey barf	0		Effect: "Beta Carotene Overdose", Effect Duration: 22, Last Available: "2014-10"
 7785	frozen activated jittery candy	0		Effect: "Gummibrain", Effect Duration: 64, Last Available: "2014-10"
@@ -7681,9 +7681,9 @@
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	maroon Armory keycard	0		Last Available: "2014-10"
-7795	stale special gigantic initiative shawarma	8	decent	Effect: "On Pins and Needles", Effect Duration: 45, Last Available: "2014-10"
-7796	low-calorie decent warm war shawarma	1	good	Last Available: "2014-10"
-7797	normal fancy squat shaking karma shawarma	3	good	Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2014-10"
+7795	special gigantic stale initiative shawarma	8	decent	Effect: "On Pins and Needles", Effect Duration: 45, Last Available: "2014-10"
+7796	decent low-calorie warm war shawarma	1	good	Last Available: "2014-10"
+7797	normal fancy shaking squat karma shawarma	3	good	Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2014-10"
 7798	hand-crafted Jungle Juice	3	EPIC	Last Available: "2014-10"
 7799	artisanal spinning Amnesiac Ale	3	EPIC	Last Available: "2014-10"
 7800	watered-down tolerable green Highest Bitter	2	good	Last Available: "2014-10"
@@ -7694,13 +7694,13 @@
 7805	twirling Merc Core challenge coin	0		Last Available: "2014-10"
 7806	wobbly jittery Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
-7808	blinking narrow unused soap	0		
+7808	narrow blinking unused soap	0		
 7809	lime green impure gasoline	0		
 7810	wobbly lime green Z-Bone steak	0		
 7811	skewed viral DNA	0		
 7812	purple tarnished bottlecap	0		
 7813	decent seared dino steak	4	good	
-7814	smooth extra-dry jittery bottle of drinkin' gas	5	awesome	
+7814	extra-dry smooth jittery bottle of drinkin' gas	5	awesome	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7714,7 +7714,7 @@
 7825	vibrating groovy earbuds of Calamity Jane	0		Moxie Percent: +10, Maximum MP Percent: +10, Critical Hit Percent: +15, Single Equip
 7826	aromatic dog trainer's supercool iFlail	0		Moxie Percent: +20, Experience (familiar): +1, Stench Resistance: +1
 7827	stale teal unidentifiable dried fruit	3	decent	
-7828	bad extra-dry skewed tumbling flat cider	5	decent	
+7828	bad extra-dry tumbling skewed flat cider	5	decent	
 7829	inspector's smelly nippy trench lighter	0		Cold Damage: +10, Stench Spell Damage: +10, Item Drop: +15, Last Available: "2014-10"
 7830	wet triple-pickled blurry experimental serum P-00	0		Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2014-10"
 7831	green military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7729,14 +7729,14 @@
 7840	special clip: wailers	0		Last Available: "2014-10"
 7841	jittery special clip: squelchers	0		Last Available: "2014-10"
 7842	olive special clip: splatterers	0		Last Available: "2014-10"
-7843	upside-down maroon special clip: boneburners	0		Last Available: "2014-10"
+7843	maroon upside-down special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
-7845	alkaline pickled jittery blue spinning perl necklace	0		Effect: "Cheered Up", Effect Duration: 27, Last Available: "2014-12"
+7845	alkaline pickled spinning blue jittery perl necklace	0		Effect: "Cheered Up", Effect Duration: 27, Last Available: "2014-12"
 7846	nitrogenated blinking Fudge Fiber Armor Plating	0		Effect: "init.enh", Effect Duration: 68, Last Available: "2014-12"
-7847	dry spinning blurry yellow ruby on canes	0		Effect: "Flambé-a-thon", Effect Duration: 15, Last Available: "2014-12"
+7847	dry yellow blurry spinning ruby on canes	0		Effect: "Flambé-a-thon", Effect Duration: 15, Last Available: "2014-12"
 7848	low-calorie stale petit fortran	1	decent	Last Available: "2014-12"
 7849	bland ghostly java cookie	4	decent	Last Available: "2014-12"
-7850	massive adequate cookie cookie	7	good	Last Available: "2014-12"
+7850	adequate massive cookie cookie	7	good	Last Available: "2014-12"
 7851	MacGyver's plastic exo-suited miner	0		Maximum MP: +100, Last Available: "2014-12"
 7852	plastic semi-autonomous drill unit of the scaredy-cat	0		Monster Level: -15, Last Available: "2014-12"
 7853	plastic ambulatory robo-minecart of the detective	0		Item Drop: +20, Last Available: "2014-12"
@@ -7759,7 +7759,7 @@
 7870	wobbly teal Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	twirling Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
-7873	blinking narrow Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
+7873	narrow blinking Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
@@ -7808,12 +7808,12 @@
 7919	concentrated Vulcanized pulsating Big Punk	0		Effect: "Black Eyes", Effect Duration: 19
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	special delicious green Friendly Turkey	4	awesome	Effect: "Dweeby", Effect Duration: 15, Last Available: "2014-11"
-7923	bad weak ghostly Agitated Turkey	2	decent	Last Available: "2014-11"
-7924	hand-crafted irresponsibly strong teal Ambitious Turkey	10	EPIC	Last Available: "2014-11"
+7922	delicious special green Friendly Turkey	4	awesome	Effect: "Dweeby", Effect Duration: 15, Last Available: "2014-11"
+7923	weak bad ghostly Agitated Turkey	2	decent	Last Available: "2014-11"
+7924	irresponsibly strong hand-crafted teal Ambitious Turkey	10	EPIC	Last Available: "2014-11"
 7925	thick adequate gray neutron lollipop	5	good	Last Available: "2014-12"
 7926	spirit-forward artisanal narrow gamma nog	5	EPIC	Last Available: "2014-12"
-7934	ghostly cyan sneaky wrapping paper	0		Last Available: "2014-12"
+7934	cyan ghostly sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	skewed Crimbo Credit	0		
@@ -7851,7 +7851,7 @@
 7969	beehive	0		
 7970	boning knife	0		
 7971	skewed Aggressive Carrot	0		Free Pull
-7972	modified tumbling shaking narrow fuchsia mummified fig	1	decent	
+7972	modified fuchsia shaking tumbling narrow mummified fig	1	decent	
 7973	powdered blurry olive mummified loaf of bread	1	good	
 7974	distilled mummified beef haunch	1	decent	Effect: "Bandersnatched", Effect Duration: 5
 7975	linen bandages	0		
@@ -7861,7 +7861,7 @@
 7979	ghostly spirit beer	0		
 7980	sacramental wine	0		
 7981	talisman of Thoth	0		
-7982	tumbling squat cure-all	0		
+7982	squat tumbling cure-all	0		
 7983	beefy Sister Accessory of the overflowing toilet	0		Muscle: +10, Stench Spell Damage: +50, Softcore Only
 7984	polarized oxidized Boosty Juice	0		Effect: "Spring Training", Effect Duration: 69
 7985	jittery mirror executive fortified parachute	0		Damage Absorption: +60, Meat Drop: +40, Last Available: "2015-12"
@@ -7877,7 +7877,7 @@
 7995	Samson's pelerine of the storm	0		Experience (Muscle): +5, Maximum MP Percent: +40, Last Available: "2015-12"
 7996	therapeutic beefy phantom mask	0		Muscle: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2015-12"
 7997	modified blurry cyan blurry polyesterene powder	1		Effect: "Drunk With Power", Effect Duration: 15, Last Available: "2015-12"
-7998	twisted blurry twirling powder	1		Effect: "What's That Smell?", Effect Duration: 45, Last Available: "2015-12"
+7998	twisted twirling blurry powder	1		Effect: "What's That Smell?", Effect Duration: 45, Last Available: "2015-12"
 7999	unsweetened choco-Crimbot	0		Effect: "Mmmmmelon", Effect Duration: 45, Last Available: "2014-12"
 8000	dry huge smart watch	0		Effect: "Analog Drunk", Effect Duration: 55, Last Available: "2014-12"
 8001	tarnished warmed augmented-reality shades	0		Effect: "Halloweeny", Effect Duration: 39, Last Available: "2014-12"
@@ -7900,7 +7900,7 @@
 8018	enhanced spinning tumbling and rain stick	0		Effect: "Elemental Saucesphere", Effect Duration: 52
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	normal tumbling Choco-Mint patty	3	good	Last Available: "2015-01"
-8021	acceptable extra-dry hot mint schnocolate	5	good	Last Available: "2015-01"
+8021	extra-dry acceptable hot mint schnocolate	5	good	Last Available: "2015-01"
 8022	pickled homeopathic mint tea	1	decent	Effect: "Less Pervious", Effect Duration: 10, Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	huge foreign language tapes	0		Last Available: "2015-01"
@@ -7932,7 +7932,7 @@
 8051	cape of chilblains	0		Cold Damage: +25
 8052	steel-toed jetpack	0		Damage Reduction: 9
 8053	pulsating spring boots	0		
-8054	olive wobbly spiked boots	0		
+8054	wobbly olive spiked boots	0		
 8055	blurry baleful pickaxe	0		Spell Damage: +25
 8056	torch	0		
 8057	[spelunking test kit] of the scaredy-cat of mayonnaise	0		Monster Level: -15, Sleaze Spell Damage: +50
@@ -7949,9 +7949,9 @@
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	green Stembridge sidearm	0		Familiar Weight: +5
 8070	twirling twirling warehouse map page	0		
-8071	blinking huge warehouse inventory page	0		
+8071	huge blinking warehouse inventory page	0		
 8072	janitor sponge	0		
-8073	upside-down tumbling Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
+8073	tumbling upside-down Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
 8074	narrow inspector's Socratic Spelunker's fedora of the early riser	0		Experience (Mysticality): +1, Item Drop: +15, Adventures: +7, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	Tesla rock-hard brawny Spelunker's whip	0		Muscle Percent: +20, Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
 8076	rock-hard Spelunker's khakis of the cougar of the businessman	0		Moxie: +20, Damage Reduction: 5, Meat Drop: +50, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
@@ -7977,14 +7977,14 @@
 8102	toasty Jack Frost's brooch	0		Cold Spell Damage: +50, Hot Damage: +5, Single Equip, Last Available: "2016-12"
 8103	rosy-cheeked breeches of temperance	0		Maximum HP Percent: +30, Sleaze Resistance: +5, Last Available: "2016-12"
 8104	zippy backpack of horror	0		Spooky Spell Damage: +25, Initiative: +20, Last Available: "2016-12"
-8105	twisted twirling cyan bits	1		Last Available: "2016-12"
+8105	twisted cyan twirling bits	1		Last Available: "2016-12"
 8106	wobbly aromatic groovy anvil	0		Moxie Percent: +10, Stench Resistance: +1, Single Equip, Last Available: "2017-12"
 8107	frightening akubra of the early riser	0		Spooky Damage: +5, Adventures: +7, Last Available: "2017-12"
 8108	therapeutic sage apron	0		Mysticality Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2017-12"
 8109	brainy ascot of the wise owl	0		Mysticality: 25, Single Equip, Last Available: "2017-12"
 8110	family-friendly clever attache case	0		Maximum MP: +20, Sleaze Resistance: +1, Last Available: "2017-12"
 8111	upside-down wobbly hardened savvy accordion	0		Mysticality Percent: +20, Damage Reduction: 3, Song Duration: 10, Last Available: "2017-12"
-8112	denatured blinking ghostly lime green aerosolized	1		Last Available: "2017-12"
+8112	denatured lime green blinking ghostly aerosolized	1		Last Available: "2017-12"
 8113	blinking stiffened wig of extreme caution	0		Damage Reduction: 1, Monster Level: -25, Last Available: "2017-12"
 8114	boxer's winch crank of the brazier	0		Muscle Percent: +10, Hot Spell Damage: +25, Single Equip, Last Available: "2017-12"
 8115	maroon careful wholesome widget	0		Maximum HP Percent: +10, Monster Level: -10, Single Equip, Last Available: "2017-12"
@@ -7998,7 +7998,7 @@
 8123	greasy Herculean garibaldi	0		Experience (Muscle): +1, Sleaze Spell Damage: +10, Last Available: "2018-12"
 8124	blinking wicked girdle of the cheetah	0		Spell Damage: +5, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	maroon friendly Rosewater's gloves	0		Mysticality Percent: +30, Familiar Weight: +3, Single Equip, Last Available: "2018-12"
-8126	altered gray shaking smithereens	1		Effect: "Hella Tough", Effect Duration: 45, Last Available: "2018-12"
+8126	altered shaking gray smithereens	1		Effect: "Hella Tough", Effect Duration: 45, Last Available: "2018-12"
 8127	gravedigger's forbidden fiberglass fetish	0		Spell Damage Percent: +50, Spooky Damage: +10, Last Available: "2018-12"
 8128	upside-down stanky fiberglass foil of dire peril	0		Weapon Damage: +20, Stench Spell Damage: +25, Last Available: "2018-12"
 8129	ghostly friendly wholesome fiberglass fannypack	0		Maximum HP Percent: +10, Familiar Weight: +3, Single Equip, Last Available: "2018-12"
@@ -8032,17 +8032,17 @@
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
 8160	polarized mouse skull	0		Effect: "Salad Days", Effect Duration: 66
-8161	Vulcanized double-improved huge ghostly really thick spine	0		Effect: "Ghostly Shell", Effect Duration: 62
+8161	Vulcanized double-improved ghostly huge really thick spine	0		Effect: "Ghostly Shell", Effect Duration: 62
 8162	ribald stiffened skullcap	0		Damage Reduction: 1, Sleaze Damage: +10, Familiar Effect: "1xVolley,cap 5"
 8163	Fonzie's three-legged pants of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Familiar Effect: "hot atk, cap 25"
 8164	narrow gray nippy wicked remaindered axe	0		Spell Damage: +5, Cold Damage: +10
 8165	wobbly low-budget shield	0		Damage Reduction: 3
 8166	teal ribald stanky cr&ecirc;epy mask	0		Stench Spell Damage: +25, Sleaze Damage: +10, Familiar Effect: "spooky atk, cap 5"
-8167	decent tiny baguette	1	good	
-8168	ghostly skewed glob of icing	0		
+8167	tiny decent baguette	1	good	
+8168	skewed ghostly glob of icing	0		
 8169	quantum narrow ginger snaps	0		Effect: "Patent Avarice", Effect Duration: 16
-8170	dry energized huge maroon mostly-broken sunglasses	0		Effect: "Mushroom Moxiousness", Effect Duration: 26
-8171	weak special artisanal spinning unflavored wine cooler	2	EPIC	Effect: "Hood Ridin'", Effect Duration: 10
+8170	dry energized maroon huge mostly-broken sunglasses	0		Effect: "Mushroom Moxiousness", Effect Duration: 26
+8171	special artisanal weak spinning unflavored wine cooler	2	EPIC	Effect: "Hood Ridin'", Effect Duration: 10
 8172	upside-down carton of snake milk	1	decent	
 8173	Jeselnik's sewer snake	0		Sleaze Damage: +25
 8174	moldy pigeon egg	3	crappy	
@@ -8060,8 +8060,8 @@
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	olive map to a hidden booze cache	0		
 8188	perfectly mixed fancy fortified narrow Cherrytastrophe wine cooler	5	EPIC	Effect: "Egg Burps", Effect Duration: 45
-8189	triple-distilled bad teal Radberry Rip wine cooler	9	decent	
-8190	bad watered-down Orangemageddon wine cooler	2	decent	
+8189	bad triple-distilled teal Radberry Rip wine cooler	9	decent	
+8190	watered-down bad Orangemageddon wine cooler	2	decent	
 8191	bad Breakfast Blast wine cooler	3	decent	
 8192	aged practically non-alcoholic Citrus Crush wine cooler	1	awesome	
 8193	miniature decent blurry plain bagel	2	good	
@@ -8071,7 +8071,7 @@
 8197	rotten standard-issue cupcake	3	crappy	
 8198	flavorless jumbo ultra-deluxe cupcake	5	decent	
 8199	hypnotic breadcrumbs	0		
-8200	miniature decent popular tart	2	good	
+8200	decent miniature popular tart	2	good	
 8201	no-handed pie	0		
 8202	liquefied tarnished shaking Doc Galaktik's Vitality Serum	0		Effect: "White Blooded", Effect Duration: 23
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8091,7 +8091,7 @@
 8217	jittery Jeselnik's perfume-soaked bandana of dire peril	0		Weapon Damage: +20, Sleaze Damage: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	stale toxo	4	decent	Last Available: "2015-04"
-8220	aged weak Lemonade-235	2	awesome	Last Available: "2015-04"
+8220	weak aged Lemonade-235	2	awesome	Last Available: "2015-04"
 8221	banded Samson's isotophat	0		Experience (Muscle): +5, Damage Absorption: +100, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Oprah's smooth Three Mile Island shorts	0		Moxie: +15, Maximum MP Percent: +50, Last Available: "2015-04"
 8223	Usain Bolt's flame-retardant toxic mop	0		Hot Resistance: +1, Initiative: +80, Last Available: "2015-04"
@@ -8110,7 +8110,7 @@
 8236	Usain Bolt's ruddy Dinsey's glove	0		Maximum HP Percent: +40, Initiative: +80, Single Equip, Last Available: "2015-04"
 8237	purple asbestos-lined chaotic Dinsey's pants	0		Spell Critical Percent: +10, Hot Resistance: +5, Last Available: "2015-04"
 8238	jittery brain preservation fluid	0		Last Available: "2015-04"
-8239	bouncing shaking keycard &alpha;	0		Last Available: "2015-04"
+8239	shaking bouncing keycard &alpha;	0		Last Available: "2015-04"
 8240	gray keycard &beta;	0		Last Available: "2015-04"
 8241	keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	hardened lube-shoes	0		Damage Reduction: 3, Last Available: "2015-04"
 8245	squat trash net	0		Last Available: "2015-04"
 8246	mirror Jeselnik's grievous Herculean Dinsey mascot mask	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Sleaze Damage: +25, Last Available: "2015-04"
-8247	huge flavorless Dinsey food-cone	7	decent	Last Available: "2015-04"
+8247	flavorless huge Dinsey food-cone	7	decent	Last Available: "2015-04"
 8248	weak mediocre shaking Dinsey Whinskey	2	decent	Last Available: "2015-04"
 8249	oxidized non-frozen huge Dinsey face paint	0		Effect: "Jammin'", Effect Duration: 23, Last Available: "2015-04"
 8250	healthy fannypack of Leguizamo	0		Maximum HP Percent: +20, Monster Level: +20, Last Available: "2015-04"
@@ -8126,7 +8126,7 @@
 8252	cyan knitted flame-wreathed coward's dangerous hazmat helmet of the early riser	0		Weapon Damage: +10, Monster Level: -20, Hot Spell Damage: +10, Cold Resistance: +3, Adventures: +7, Last Available: "2015-04"
 8253	Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
-8255	gray skewed Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
+8255	skewed gray Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	colloidal nasty gum	0		Effect: "Capricorn Rising", Effect Duration: 14
 8258	mirror Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
@@ -8176,7 +8176,7 @@
 8302	miniature toothsome enchanted pixel banana	2	awesome	Effect: "Purity of Spirit", Effect Duration: 15, Last Available: "2015-06"
 8303	lousy ghostly pixel beer	3	decent	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
-8305	skewed squat pumps	0		Last Available: "2015-06"
+8305	squat skewed pumps	0		Last Available: "2015-06"
 8306	deionized dry sludgesicle	0		Effect: "In a Lather", Effect Duration: 46
 8307	quadruple-electrified quantum &Uuml;berraschthexengebr&auml;u	0		Effect: "Total Protonic Reversal", Effect Duration: 59
 8308	moist dry ghostly piggy tattoo	0		Effect: "Mana Tea", Effect Duration: 34
@@ -8190,7 +8190,7 @@
 8316	ionized modified deionized huge bottle of Red-Out	0		Effect: "Covetous Robbery", Effect Duration: 15
 8317	energized red pickpocket protector	0		Effect: "You Liver", Effect Duration: 21
 8318	triple-vacuum-sealed non-warmed pulsating ghostly sinister-looking cat	0		Effect: "Bustle Hustlin'", Effect Duration: 18
-8319	cold-filtered shaking blurry jazzy cigarette holder	0		Effect: "The Dinsey Way", Effect Duration: 59
+8319	cold-filtered blurry shaking jazzy cigarette holder	0		Effect: "The Dinsey Way", Effect Duration: 59
 8320	chilled triple-activated one glove	0		Effect: "Liquidy Smoky", Effect Duration: 68
 8321	alkaline energized glove	0		Effect: "Lubed", Effect Duration: 60
 8322	alkaline handful of fire	0		Effect: "Stone-Faced", Effect Duration: 27
@@ -8200,11 +8200,11 @@
 8326	corrupted energized conjured ice cream	0		Effect: "Booing Radly", Effect Duration: 52
 8327	super-altered tumbling Iceberglar scarf	0		Effect: "Wise Spirit", Effect Duration: 52
 8328	electrified adjusted icy hairspray	0		Effect: "Seriously Mutated", Effect Duration: 29
-8329	altered dry aerosolized mirror upside-down smellbook	0		Effect: "Loco Motives", Effect Duration: 25
+8329	altered dry aerosolized upside-down mirror smellbook	0		Effect: "Loco Motives", Effect Duration: 25
 8330	deionized twirling assassin's cheese knife	0		Effect: "The Power of Positive Thinking", Effect Duration: 35
 8331	tarnished Vulcanized filthy armor	0		Effect: "Purpose", Effect Duration: 24
-8332	cold-filtered squat tumbling plague pie	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 36
-8333	enhanced adjusted teal spinning batarang	0		Effect: "Chari Tea", Effect Duration: 39
+8332	cold-filtered tumbling squat plague pie	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 36
+8333	enhanced adjusted spinning teal batarang	0		Effect: "Chari Tea", Effect Duration: 39
 8334	dry spare neck bolts	0		Effect: "Perception", Effect Duration: 14
 8335	chilled corrupted aerosolized grease trap	0		Effect: "All Branned Up", Effect Duration: 67
 8336	irradiated shamanic ham	0		Effect: "PERL of Great Price", Effect Duration: 61
@@ -8214,22 +8214,22 @@
 8340	improved squat janitor's mop	0		Effect: "Bats in the Belfry", Effect Duration: 44
 8341	pressed pickled warehouse clerk's glasses	0		Effect: "Gummiheart", Effect Duration: 40
 8342	tarnished polymerized blinking baloney rotgut	0		Effect: "The Moxious Madrigal", Effect Duration: 45
-8343	adjusted red shaking carton of gaspers	0		Effect: "Space Cowboy", Effect Duration: 65
+8343	adjusted shaking red carton of gaspers	0		Effect: "Space Cowboy", Effect Duration: 65
 8344	boiled bronze polish	0		Effect: "Super Vision", Effect Duration: 16
 8345	energized electrified crident	0		Effect: "[1609]Dancin' Fool", Effect Duration: 25
-8346	flattened teal skewed totally sweet mohawk helmet	0		Effect: "Heightened Senses", Effect Duration: 59
+8346	flattened skewed teal totally sweet mohawk helmet	0		Effect: "Heightened Senses", Effect Duration: 59
 8347	concentrated concentrated improved olive spray chrome	0		Effect: "Transcendental Wind", Effect Duration: 33
 8348	triple-liquefied adjusted purple filthy monkey head	0		Effect: "Tenacity of the Snapper", Effect Duration: 58
 8349	dry diffused bouncing hand of cards	0		Effect: "Weather, Man", Effect Duration: 57
 8350	adjusted oxidized damp bar rag	0		Effect: "Almost Cool", Effect Duration: 45
 8351	polymerized frozen Vulcanized wobbly lump of goofball ore	0		Effect: "Whole Latte Love", Effect Duration: 21
 8352	moist jittery skeleton beans	0		Effect: "Object Detection", Effect Duration: 31
-8353	double-altered gray shaking grimy lab coat	0		Effect: "Boon of She-Who-Was", Effect Duration: 41
+8353	double-altered shaking gray grimy lab coat	0		Effect: "Boon of She-Who-Was", Effect Duration: 41
 8354	energized magnetized nursery rhyme	0		Effect: "Petit Force", Effect Duration: 66
 8355	anodized tumbling iron torso box	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 60
 8356	flattened polymerized shaking mercenary headband	0		Effect: "Arcane in the Brain", Effect Duration: 20
 8357	frozen galvanized radioactive spider venom	0		Effect: "Blood-Gorged", Effect Duration: 50
-8358	anodized blinking ghostly x-ray mirror	0		Effect: "Faboooo", Effect Duration: 13
+8358	anodized ghostly blinking x-ray mirror	0		Effect: "Faboooo", Effect Duration: 13
 8359	pressed wrestling mask	0		Effect: "Swimming with Sharks", Effect Duration: 26
 8360	altered wet hawkface potion	0		Effect: "Updated", Effect Duration: 28
 8361	activated child-sized dracula cloak	0		Effect: "Disco State of Mind", Effect Duration: 49
@@ -8249,7 +8249,7 @@
 8375	super-adjusted twirling eyebrow lifter	0		Effect: "Human-Penguin Hybrid", Effect Duration: 56
 8376	blinking submarine	0		Last Available: "2015-06"
 8377	spoiled ghostly pixel lemon	4	crappy	Last Available: "2015-06"
-8378	practically non-alcoholic delicious jittery pixel daiquiri	1	awesome	Last Available: "2015-06"
+8378	delicious practically non-alcoholic jittery pixel daiquiri	1	awesome	Last Available: "2015-06"
 8379	warmed deionized blue power pill	0		Effect: "Lifted Spirits", Effect Duration: 54, Last Available: "2015-06"
 8380	dry vacuum-sealed olive pixel potion	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 45, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8286,11 +8286,11 @@
 8412	adequate small succulent marrow	2	good	
 8413	spoiled jumbo salacious crumbs	5	crappy	
 8414	decent fusilli marrownarrow	4	good	
-8415	half-sized decent mirror suggestive strozzapreti	2	good	
+8415	decent half-sized mirror suggestive strozzapreti	2	good	
 8416	skewed Mountain Stream gastrique	0		
 8417	bland Mt. McLargeHuge oyster	3	decent	
 8418	oyster sauce	0		
-8419	small bland bouncing linguini immondizia bianco	2	decent	
+8419	bland small bouncing linguini immondizia bianco	2	decent	
 8420	adequate shells a la shellfish	3	good	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8315,7 +8315,7 @@
 8441	huge full lava bottle	0		Last Available: "2015-08"
 8442	huge viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
-8444	bouncing pulsating lava globs	0		Last Available: "2015-08"
+8444	pulsating bouncing lava globs	0		Last Available: "2015-08"
 8445	jittery lava globs	0		Last Available: "2015-08"
 8446	shaking SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8323,7 +8323,7 @@
 8449	uncapped lava bottle	0		Last Available: "2015-08"
 8450	huge capped lava bottle	0		Last Available: "2015-08"
 8451	skewed capped lava bottle	0		Last Available: "2015-08"
-8452	ghostly huge capped lava bottle	0		Last Available: "2015-08"
+8452	huge ghostly capped lava bottle	0		Last Available: "2015-08"
 8453	gray heat-resistant sheet	0		Last Available: "2015-08"
 8454	cyan LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	shaking New Age crystal	0		Last Available: "2015-08"
@@ -8332,9 +8332,9 @@
 8458	jittery twirling electrified high-temperature mining mask of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	upside-down extremely unsafe fireproof megaphone of doom	0		Weapon Damage Percent: +100, Spooky Spell Damage: +50, Last Available: "2015-08"
 8460	yummy mineapple	4	awesome	Last Available: "2015-08"
-8461	mediocre irresponsibly strong Gold Velvet&trade; whiskey	10	decent	Last Available: "2015-08"
+8461	irresponsibly strong mediocre Gold Velvet&trade; whiskey	10	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	EPIC	Last Available: "2015-08"
-8463	small bland smelted roe	2	decent	Last Available: "2015-08"
+8463	bland small smelted roe	2	decent	Last Available: "2015-08"
 8464	practically non-alcoholic drinkable blurry lavawater	1	good	Last Available: "2015-08"
 8465	tarnished energized mirror narrow basaltamander tongue	0		Effect: "Buttermilk Boogie", Effect Duration: 66, Last Available: "2015-08"
 8466	extremely unsafe cool lavalarva of doom	0		Moxie: +5, Weapon Damage Percent: +100, Spooky Spell Damage: +50, Last Available: "2015-08"
@@ -8346,10 +8346,10 @@
 8472	skewed hale savvy heat-resistant necktie	0		Mysticality Percent: +20, Maximum HP: +20, Single Equip, Last Available: "2015-08"
 8473	Samson's smartaleck's heat-resistant gloves of bravery	0		Moxie Percent: +30, Experience (Muscle): +5, Spooky Resistance: +5, Single Equip, Last Available: "2015-08"
 8474	adequate very hot lunch	4	good	Last Available: "2015-08"
-8475	acceptable watered-down asbestos thermos	2	good	Last Available: "2015-08"
+8475	watered-down acceptable asbestos thermos	2	good	Last Available: "2015-08"
 8476	diffused boiled shaking liquid rhinestones	0		Effect: "Super Skill", Effect Duration: 34, Last Available: "2015-08"
-8477	tasty small bouncing disco biscuit	2	awesome	Last Available: "2015-08"
-8478	spirit-forward delicious Quaatorade&trade;	5	awesome	Last Available: "2015-08"
+8477	small tasty bouncing disco biscuit	2	awesome	Last Available: "2015-08"
+8478	delicious spirit-forward Quaatorade&trade;	5	awesome	Last Available: "2015-08"
 8479	censurious Jeselnik's quilted biker's hat	0		Damage Absorption: +40, Sleaze Damage: +25, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
 8480	healthy feathered headdress of the sewer of the early riser	0		Maximum HP Percent: +20, Stench Damage: +25, Adventures: +7, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	electrified Sinatra's stylish electrician's hardhat	0		Moxie: +25, Experience (Moxie): +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8397,7 +8397,7 @@
 8523	huge fused fuse	0		Last Available: "2015-08"
 8524	twirling superheated	0		Last Available: "2015-08"
 8525	spoiled lava cake	3	crappy	Last Available: "2015-08"
-8526	snack-sized bland pink slime	2	decent	
+8526	bland snack-sized pink slime	2	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	rotten half-sized devil hair pasta	2	crappy	
@@ -8405,23 +8405,23 @@
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	gray illicit fish sauce	0		
-8534	decent enchanted snack-sized skewed libertagliatelle	2	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
+8534	snack-sized decent enchanted skewed libertagliatelle	2	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
 8535	toothsome bite-sized turkish mostaccioli	1	awesome	
 8536	decent immense linguini of the sea	7	good	
 8537	cold-filtered oxidized Hersey&trade; SMOOCH	0		Effect: "Chain Chain Chains", Effect Duration: 38
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	stale big Fettris	5	decent	
+8542	big stale Fettris	5	decent	
 8543	special spoiled fusillocybin	3	crappy	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 45
-8544	big decent prescription noodles	5	good	
+8544	decent big prescription noodles	5	good	
 8545	mixed spinning red blood-drive sticker	1	good	
 8546	double-polarized olive bag of grain	0		Effect: "Cute Vision", Effect Duration: 37
 8547	triple-dry super-anodized ghostly pocket maze	0		Effect: "Adapt to Change Eventually", Effect Duration: 65
 8548	double-tarnished extra-wet squat shady shades	0		Effect: "Frigid Weapon", Effect Duration: 19
-8549	corrupted diffused upside-down shaking squeaky toy rose	0		Effect: "Greedy Resolve", Effect Duration: 57
+8549	corrupted diffused shaking upside-down squeaky toy rose	0		Effect: "Greedy Resolve", Effect Duration: 57
 8550	bland wobbly weird gazelle steak	3	decent	
-8551	immense stale sausage without a cause	9	decent	
+8551	stale immense sausage without a cause	9	decent	
 8552	anodized super-frozen face paint	0		Effect: "Updated", Effect Duration: 37
 8553	perfectly mixed emergency margarita	3	super ultra mega turbo EPIC	
 8554	tolerable green vintage smart drink	4	good	
@@ -8449,11 +8449,11 @@
 8576	mirror mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	hand-crafted bottle of Amontillado	4	EPIC	Last Available: "2015-09"
-8579	lousy extra-dry spinning barrel-aged martini	5	decent	Last Available: "2015-09"
+8579	extra-dry lousy spinning barrel-aged martini	5	decent	Last Available: "2015-09"
 8580	stale barrel pickle	3	decent	Last Available: "2015-09"
 8581	decent barrel cracker	4	good	Last Available: "2015-09"
 8582	dehydrated huge vibrating mushroom	1	good	Last Available: "2015-09"
-8583	twisted olive pulsating mirror narrow mushroom	1	decent	Last Available: "2015-09"
+8583	twisted olive pulsating narrow mirror mushroom	1	decent	Last Available: "2015-09"
 8584	KoL Con 12-gauge of the detective	0		Item Drop: +20, Last Available: "2015-09"
 8585	Golden Mr. Eh? of the businessman	0		Meat Drop: +50, Last Available: "2015-09"
 8586	barrel gun of doom	0		Spooky Spell Damage: +50, Last Available: "2015-09"
@@ -8478,7 +8478,7 @@
 8605	denatured activated cuppa Improprie tea	0		Effect: "Bat Attitude", Effect Duration: 61, Last Available: "2015-09"
 8606	enhanced aerosolized blue cuppa Frost tea	0		Effect: "Shot in the Arse", Effect Duration: 24, Last Available: "2015-09"
 8607	dry frozen cuppa Toast tea	0		Effect: "The Halls of Mysticality", Effect Duration: 64, Last Available: "2015-09"
-8608	activated tumbling olive cuppa Net tea	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 58, Last Available: "2015-09"
+8608	activated olive tumbling cuppa Net tea	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 58, Last Available: "2015-09"
 8609	corrupted cuppa Proprie tea	0		Effect: "Salamander In Your Stomach", Effect Duration: 50, Last Available: "2015-09"
 8610	flattened cuppa Morbidi tea	0		Effect: "Thunderspell", Effect Duration: 56, Last Available: "2015-09"
 8611	dry squat cuppa Chari tea	0		Effect: "Carol of the Bones", Effect Duration: 18, Last Available: "2015-09"
@@ -8487,35 +8487,35 @@
 8614	galvanized oxidized cuppa Physicali tea	0		Effect: "Demonic Flavor", Effect Duration: 32, Last Available: "2015-09"
 8615	Vulcanized mirror cuppa Wit tea	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 27, Last Available: "2015-09"
 8616	triple-cold-filtered cuppa Neuroplastici tea	0		Effect: "Sweetened and Fattened", Effect Duration: 61, Last Available: "2015-09"
-8617	denatured irradiated green pulsating cuppa Dexteri tea	0		Effect: "Radiant Personality", Effect Duration: 46, Last Available: "2015-09"
+8617	denatured irradiated pulsating green cuppa Dexteri tea	0		Effect: "Radiant Personality", Effect Duration: 46, Last Available: "2015-09"
 8618	diffused frozen cuppa Flexibili tea	0		Effect: "Rushtacean'", Effect Duration: 65, Last Available: "2015-09"
 8619	irradiated deionized bouncing cuppa Impregnabili tea	0		Effect: "Ermine Eyes", Effect Duration: 28, Last Available: "2015-09"
 8620	denatured concentrated blurry cuppa Obscuri tea	0		Effect: "Ruby-ous", Effect Duration: 23, Last Available: "2015-09"
 8621	extra-cold-filtered bouncing cuppa Irritabili tea	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 42, Last Available: "2015-09"
 8622	extra-diffused mirror cuppa Mediocri tea	0		Effect: "Hustlin'", Effect Duration: 48, Last Available: "2015-09"
 8623	alkaline cuppa Loyal tea	0		Effect: "Angry like the Wolf", Effect Duration: 32, Last Available: "2015-09"
-8624	vaporized bouncing blinking cuppa Activi tea	1	good	Last Available: "2015-09"
-8625	twisted twirling bouncing cuppa Cruel tea	1		Effect: "No Worries", Effect Duration: 25, Last Available: "2015-09"
+8624	vaporized blinking bouncing cuppa Activi tea	1	good	Last Available: "2015-09"
+8625	twisted bouncing twirling cuppa Cruel tea	1		Effect: "No Worries", Effect Duration: 25, Last Available: "2015-09"
 8626	alkaline cuppa Alacri tea	0		Effect: "Inappropriate Spirit", Effect Duration: 50, Last Available: "2015-09"
-8627	warmed adjusted shaking skewed cuppa Vitali tea	0		Effect: "The Solution", Effect Duration: 55, Last Available: "2015-09"
+8627	warmed adjusted skewed shaking cuppa Vitali tea	0		Effect: "The Solution", Effect Duration: 55, Last Available: "2015-09"
 8628	polymerized concentrated skewed cuppa Mana tea	0		Effect: "Flexibili Tea", Effect Duration: 36, Last Available: "2015-09"
 8629	chilled cuppa Monstrosi tea	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 44, Last Available: "2015-09"
 8630	moist aerosolized ghostly blue cuppa Twen tea	0		Effect: "Shawarma Initiative", Effect Duration: 34, Last Available: "2015-09"
-8631	extra-anodized flattened lime green bouncing cuppa Gill tea	0		Effect: "Hippy Flavor", Effect Duration: 41, Last Available: "2015-09"
+8631	extra-anodized flattened bouncing lime green cuppa Gill tea	0		Effect: "Hippy Flavor", Effect Duration: 41, Last Available: "2015-09"
 8632	Vulcanized energized cuppa Uncertain tea	0		Effect: "Eau de Tortue", Effect Duration: 45, Last Available: "2015-09"
 8633	skewed cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
-8635	blue jittery cuppa Royal tea	0		Last Available: "2015-09"
+8635	jittery blue cuppa Royal tea	0		Last Available: "2015-09"
 8636	pickled cuppa Craft tea	0		Effect: "Industrial Strength Starch", Effect Duration: 16, Last Available: "2015-09"
 8637	ionized corrupted cuppa Insani tea	0		Effect: "Guts Feeling", Effect Duration: 48, Last Available: "2015-09"
 8638	tumbling family-friendly double-paned Tesla Royal scepter	0		Cold Resistance: +5, Sleaze Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	spoiled enchanted snack-sized bowl of eyeballs	2	crappy	Effect: "Thicker, Sicker", Effect Duration: 40, Last Available: "2015-10"
+8641	enchanted spoiled snack-sized bowl of eyeballs	2	crappy	Effect: "Thicker, Sicker", Effect Duration: 40, Last Available: "2015-10"
 8642	adequate small huge bowl of mummy guts	2	good	Last Available: "2015-10"
 8643	stale bowl of maggots	3	decent	Last Available: "2015-10"
-8644	extra-dry smooth fancy blood and blood	5	awesome	Effect: "Discomfited", Effect Duration: 35, Last Available: "2015-10"
-8645	practically non-alcoholic artisanal Jack-O-Lantern beer	1	super ultra EPIC	Last Available: "2015-10"
+8644	smooth extra-dry fancy blood and blood	5	awesome	Effect: "Discomfited", Effect Duration: 35, Last Available: "2015-10"
+8645	artisanal practically non-alcoholic Jack-O-Lantern beer	1	super ultra EPIC	Last Available: "2015-10"
 8646	enchanted acceptable zombie	4	good	Effect: "Extra-Thick Blood", Effect Duration: 5, Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wobbly wind-up spider	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	knitted smartaleck's hawk of the businessman	0		Moxie Percent: +30, Cold Resistance: +3, Meat Drop: +50
-8655	normal thick blinking squat hamlet sandwich	5	good	
+8655	normal thick squat blinking hamlet sandwich	5	good	
 8656	shaking arcane researcher's Othello's military jacket	0		Experience Percent (Mysticality): +10
 8657	ghostly teal rock-hard Othello's dagger	0		Damage Reduction: 5, Single Equip
 8658	Sherlock's Othello's handkerchief	0		Item Drop: +25, Single Equip
@@ -8544,10 +8544,10 @@
 8671	tulip	0		
 8672	Walford's bucket	0		Last Available: "2015-11"
 8673	green Wal-Mart gift certificate	0		Last Available: "2015-11"
-8674	blue wobbly airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
+8674	wobbly blue airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	twirling one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	deionized shoulder-warming lotion	0		Effect: "Abominably Slippery", Effect Duration: 32, Last Available: "2015-11"
-8677	bland tiny iceberg lettuce	1	decent	Last Available: "2015-11"
+8677	tiny bland iceberg lettuce	1	decent	Last Available: "2015-11"
 8678	perfectly mixed lime green ice wine	4	EPIC	Last Available: "2015-11"
 8679	family-friendly wholesome Wal-Mart snowglobe of the boozehound	0		Maximum HP Percent: +10, Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2015-11"
 8680	blinking rosewater-soaked Lo Pan's supercharged Wal-Mart nametag	0		Maximum MP Percent: +30, Spell Critical Percent: +30, Stench Resistance: +3, Last Available: "2015-11"
@@ -8568,29 +8568,29 @@
 8695	upside-down Martialest Arts trophy	0		Last Available: "2016-01"
 8696	dried bouncing medicinal herbs	1		Last Available: "2016-01"
 8697	rotten ice rice	3	crappy	Last Available: "2016-01"
-8698	fancy weak hand-crafted iced plum wine	2	EPIC	Effect: "Mucilaginous Mentalism", Effect Duration: 15, Last Available: "2016-01"
+8698	fancy hand-crafted weak iced plum wine	2	EPIC	Effect: "Mucilaginous Mentalism", Effect Duration: 15, Last Available: "2016-01"
 8699	squat up-at-dawn avaricious rosy-cheeked training belt	0		Maximum HP Percent: +30, Meat Drop: +30, Adventures: +5, Single Equip, Last Available: "2016-01"
 8700	lightning-fast auspicious Newton's training legwarmers	0		Experience (Mysticality): +3, Item Drop: +10, Initiative: +40, Single Equip, Last Available: "2016-01"
 8701	upside-down Jim Carey's curative shellacked training helmet	0		Damage Reduction: 7, Monster Level: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	wobbly training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
-8705	narrow upside-down X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
+8705	upside-down narrow X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	tumbling machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	dehydrated abstraction: action	1		Last Available: "2015-12"
-8709	boiled lime green shaking pulsating abstraction: thought	1		Last Available: "2015-12"
+8709	boiled pulsating lime green shaking abstraction: thought	1		Last Available: "2015-12"
 8710	dried ghostly abstraction: sensation	1		Effect: "Powdered", Effect Duration: 40, Last Available: "2015-12"
 8711	compressed upside-down abstraction: purpose	1		Effect: "Mystic Circle", Effect Duration: 35, Last Available: "2015-12"
 8712	modified abstraction: category	1		Effect: "The Halls of Mysticality", Effect Duration: 50, Last Available: "2015-12"
 8713	diluted abstraction: perception	1		Last Available: "2015-12"
 8714	boiled abstraction: motion	1		Last Available: "2015-12"
 8715	distilled mirror abstraction: joy	1		Effect: "Berry Experiential", Effect Duration: 10, Last Available: "2015-12"
-8716	altered spinning upside-down huge fuchsia abstraction: certainty	1		Last Available: "2015-12"
+8716	altered upside-down fuchsia huge spinning abstraction: certainty	1		Last Available: "2015-12"
 8717	compressed squat abstraction: comprehension	1		Effect: "Egg-headedness", Effect Duration: 30, Last Available: "2015-12"
 8718	ghostly modern picture frame	0		Last Available: "2015-12"
 8719	rotten VYKEA meatballs	4	crappy	Last Available: "2015-11"
-8720	triple-distilled lousy VYKEA mead	8	decent	Last Available: "2015-11"
+8720	lousy triple-distilled VYKEA mead	8	decent	Last Available: "2015-11"
 8721	adjusted quadruple-diffused blue VYKEA woadpaint	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 45, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,7 +8601,7 @@
 8728	ghostly VYKEA dowel	0		Last Available: "2015-11"
 8729	stanky VYKEA hex key of the sewer of doom	0		Stench Damage: +25, Stench Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2015-11"
 8730	red VYKEA instructions	0		Last Available: "2015-11"
-8731	tasty fancy tin of submardines	3	awesome	Effect: "Castaway Physique", Effect Duration: 5, Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	fancy tasty tin of submardines	3	awesome	Effect: "Castaway Physique", Effect Duration: 5, Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	practically non-alcoholic tolerable bottle of norwhiskey	1	good	Last Available: "2015-11"
 8733	pickled octolus oculus	1	awesome	Last Available: "2015-11"
 8734	wool steel-toed sardine can key of Flo-Jo	0		Damage Reduction: 9, Cold Resistance: +1, Initiative: +100, Last Available: "2015-11"
@@ -8623,9 +8623,9 @@
 8750	aerosolized shaking shaking hemp candy necklace	0		Effect: "Eagle Eyes", Effect Duration: 64, Last Available: "2015-12"
 8751	Vulcanized blue communal gobstopper	0		Effect: "Crying, Dying", Effect Duration: 32, Last Available: "2015-12"
 8752	decent Crimbo salad	4	good	Last Available: "2015-12"
-8753	snack-sized yummy blue narrow bread line	2	awesome	Last Available: "2015-12"
+8753	yummy snack-sized blue narrow bread line	2	awesome	Last Available: "2015-12"
 8754	tolerable bark rootbeer	3	good	Last Available: "2015-12"
-8755	artisanal fancy ale	3	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 50, Last Available: "2015-12"
+8755	fancy artisanal ale	3	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 50, Last Available: "2015-12"
 8756	occult plastic Tammy the Tambourine Elf	0		Spell Damage Percent: +25, Last Available: "2015-12"
 8757	blinking hardy plastic Rudolph the Red	0		Maximum HP: +50, Last Available: "2015-12"
 8758	zippy plastic Gaia'ajh-dsli Ak'lwej	0		Initiative: +20, Last Available: "2015-12"
@@ -8646,7 +8646,7 @@
 8773	blue vibrating slick reusable shopping bag of incineration	0		Moxie: +10, Maximum MP Percent: +10, Hot Spell Damage: +50, Last Available: "2015-12"
 8775	upside-down teal bouncing hardy coarse hemp socks	0		Maximum HP: +50, Single Equip, Last Available: "2015-12"
 8776	Annie Oakley's armband	0		Critical Hit Percent: +20, Single Equip, Last Available: "2015-12"
-8777	maroon shaking spinning bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
+8777	spinning shaking maroon bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
@@ -8671,7 +8671,7 @@
 8799	bat-o-mite	0		Last Available: "2017-01"
 8800	cyan ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	incriminating evidence	0		Last Available: "2017-01"
-8802	maroon shaking dangerous chemicals	0		Last Available: "2017-01"
+8802	shaking maroon dangerous chemicals	0		Last Available: "2017-01"
 8803	ghostly kidnapped orphan	0		Last Available: "2017-01"
 8804	high-grade	0		Last Available: "2017-01"
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
@@ -8685,15 +8685,15 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	green bat-bearing	0		Last Available: "2017-01"
-8816	normal half-sized Kudzu salad	2	good	Last Available: "2016-12"
+8816	half-sized normal Kudzu salad	2	good	Last Available: "2016-12"
 8817	powdered Mansquito Serum	1		Last Available: "2016-12"
 8818	practically non-alcoholic acceptable Miss Graves' vermouth	1	good	Last Available: "2016-12"
 8819	bite-sized moldy The Plumber's mushroom stew	1	crappy	Last Available: "2016-12"
 8820	distilled The Author's ink	1		Last Available: "2016-02"
-8821	tolerable spirit-forward pulsating The Mad Liquor	5	good	Last Available: "2016-12"
+8821	spirit-forward tolerable pulsating The Mad Liquor	5	good	Last Available: "2016-12"
 8822	delicious practically non-alcoholic Doc Clock's thyme cocktail	1	awesome	Last Available: "2016-12"
 8823	decent Mr. Burnsger	3	good	Last Available: "2016-12"
-8824	boiled upside-down lime green The Inquisitor's unidentifiable object	1		Effect: "Jawin'", Effect Duration: 45, Last Available: "2016-12"
+8824	boiled lime green upside-down The Inquisitor's unidentifiable object	1		Effect: "Jawin'", Effect Duration: 45, Last Available: "2016-12"
 8825	upside-down ghostly knitted The Jokester's gun of extreme caution of the empath	0		Monster Level: -25, Familiar Weight: +5, Cold Resistance: +3, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
 8826	fuchsia smartaleck's stylish The Jokester's wig of bravery	0		Moxie: +25, Moxie Percent: +30, Spooky Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	flame-retardant dance instructor's wizardly The Jokester's pants	0		Mysticality: +25, Experience Percent (Moxie): +10, Hot Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	modified quadruple-wet maroon robin's egg	0		Effect: "Rain Dancin'", Effect Duration: 13, Last Available: "2016-12"
 8834	delicious mirror robin flan	3	awesome	Last Available: "2016-12"
-8835	watered-down artisanal robin nog	2	EPIC	Last Available: "2016-12"
+8835	artisanal watered-down robin nog	2	EPIC	Last Available: "2016-12"
 8836	jittery LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8746,8 +8746,8 @@
 8874	foul-smelling Temple Grandin's therapeutic beefcake's Val-U Brand Every Bean Salad of vim and vigor	0		Muscle: +25, Maximum HP Percent: +50, Familiar Weight: +7, Stench Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02"
 8875	Usain Bolt's veiny Shrub's Premium Baked Beans of the wise owl	0		Mysticality: +20, Maximum HP: +10, Initiative: +80, Last Available: "2016-02"
 8876	toothsome plate of Heimz Fortified Kidney Beans	3	awesome	Last Available: "2016-02"
-8877	low-calorie special normal plate of Tesla's Electroplated Beans	1	good	Effect: "Adapt to Change Eventually", Effect Duration: 15, Last Available: "2016-02"
-8878	yummy low-calorie enchanted plate of Mixed Garbanzos and Chickpeas	1	awesome	Effect: "Thick, Sick", Effect Duration: 35, Last Available: "2016-02"
+8877	special normal low-calorie plate of Tesla's Electroplated Beans	1	good	Effect: "Adapt to Change Eventually", Effect Duration: 15, Last Available: "2016-02"
+8878	enchanted yummy low-calorie plate of Mixed Garbanzos and Chickpeas	1	awesome	Effect: "Thick, Sick", Effect Duration: 35, Last Available: "2016-02"
 8879	flavorless jumbo plate of Hellfire Spicy Beans	5	decent	Last Available: "2016-02"
 8880	flavorless mirror plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
 8881	bland snack-sized plate of World's Blackest-Eyed Peas	2	decent	Last Available: "2016-02"
@@ -8764,7 +8764,7 @@
 8892	blinking El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	blinking stylish weightlifter's Granny Hackleton's Gatling gun of the storm	0		Muscle: +15, Moxie: +25, Maximum MP Percent: +40, Last Available: "2016-02"
-8895	green tumbling buffalo dime	0		Last Available: "2016-02"
+8895	tumbling green buffalo dime	0		Last Available: "2016-02"
 8896	fuchsia cow poker	0		Last Available: "2016-02"
 8897	vacuum-sealed poker face paint	0		Effect: "Protection from Bad Stuff", Effect Duration: 60, Last Available: "2016-02"
 8898	gray realistic cap gun	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	double-irradiated rattler gland	0		Effect: "Phoenix, Right?", Effect Duration: 57, Last Available: "2016-02"
 8907	liquefied quadruple-irradiated half-digested coal	0		Effect: "Mushroom Moxiousness", Effect Duration: 26, Last Available: "2016-02"
 8908	diffused cold-filtered tightly-wound spine	0		Effect: "Block-Rockin' Beet", Effect Duration: 67, Last Available: "2016-02"
-8909	decent special rotting beefsteak	4	good	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2016-02"
+8909	special decent rotting beefsteak	4	good	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2016-02"
 8910	lousy wobbly firemilk	4	decent	Last Available: "2016-02"
 8911	denatured spidercow eye-cluster	0		Effect: "Frosty the Hitman", Effect Duration: 27, Last Available: "2016-02"
 8912	denatured moomy dust	1		Last Available: "2016-02"
@@ -8793,7 +8793,7 @@
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
-8924	mirror huge disc (black)	0		
+8924	huge mirror disc (black)	0		
 8925	disc (red)	0		
 8926	disc (green)	0		
 8927	disc (blue)	0		
@@ -8820,12 +8820,12 @@
 8948	shaking fuchsia thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	jittery wicksilver spurs	0		Last Available: "2016-02"
 8950	huge slicksilver spurs	0		Last Available: "2016-02"
-8951	red ghostly sicksilver spurs	0		Last Available: "2016-02"
+8951	ghostly red sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
 8953	ghostly ticksilver spurs	0		Last Available: "2016-02"
 8954	upside-down blinking special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	lime green Tales of the West: Cow Punching	0		
-8956	mirror fuchsia Tales of the West: Beanslinging	0		
+8956	fuchsia mirror Tales of the West: Beanslinging	0		
 8957	Tales of the West: Snake Oiling	0		
 8958	briefcase full of snakes	0		
 8959	red sizzling vibrating one-gallon hat	0		Maximum MP Percent: +10, Hot Damage: +10
@@ -8846,23 +8846,23 @@
 8974	altered improved double-improved yellow bouncing eldritch oil	0		Effect: "Sticks and Stones", Effect Duration: 47
 8975	exclusive club	0		
 8976	pressed triple-unsweetened patent preventative tonic	0		Effect: "Rushin' Hands", Effect Duration: 19
-8977	energized twirling jittery patent invisibility tonic	0		Effect: "Spooky Demeanor", Effect Duration: 17
-8978	activated wobbly ghostly patent aggression tonic	0		Effect: "Sharp Weapon", Effect Duration: 27
+8977	energized jittery twirling patent invisibility tonic	0		Effect: "Spooky Demeanor", Effect Duration: 17
+8978	activated ghostly wobbly patent aggression tonic	0		Effect: "Sharp Weapon", Effect Duration: 27
 8979	ionized patent sallowness tonic	0		Effect: "Faboooo", Effect Duration: 33
 8980	chilled diffused spinning patent avarice tonic	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 44
-8981	dry mirror spinning upside-down patent alacrity tonic	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24
+8981	dry spinning upside-down mirror patent alacrity tonic	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24
 8982	warmed pickled corrupted marrow	0		Effect: "Gutterminded", Effect Duration: 51
-8983	smooth watered-down rodeo whiskey	2	awesome	
-8984	pulsating huge Thwaitgold scorpion statuette	0		
+8983	watered-down smooth rodeo whiskey	2	awesome	
+8984	huge pulsating Thwaitgold scorpion statuette	0		
 8985	ghostly real cowboy hat of the dark arts	0		Spell Damage Percent: +100
 8986	twirling Memories of Cow Punching	0		Free Pull
-8987	spinning green Memories of Beanslinging	0		Free Pull
+8987	green spinning Memories of Beanslinging	0		Free Pull
 8988	squat Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	twirling electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	diluted huge armored prawn	1		Last Available: "2016-03"
-8993	rotten small jittery jumping horseradish	2	crappy	Last Available: "2016-03"
+8993	small rotten jittery jumping horseradish	2	crappy	Last Available: "2016-03"
 8994	tolerable pulsating Sacramento wine	3	good	Last Available: "2016-03"
 8995	pressed polymerized Greek fire	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 14, Last Available: "2016-03"
 8996	gray executive Sherlock's ox-head shield of the pedagogue of Tarzan of doom	0		Experience: +3, Experience (Muscle): +3, Spooky Spell Damage: +50, Item Drop: +25, Meat Drop: +40, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
@@ -8898,13 +8898,13 @@
 9026	twirling gray First Post shirt package	0		Last Available: "2016-05"
 9027	Jim Carey's smooth First Post shirt - Cir Senam of wisdom	0		Mysticality: +15, Moxie: +15, Monster Level: +25, Last Available: "2016-05"
 9028	pulsating high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
-9029	upside-down huge no spoon	0		
+9029	huge upside-down no spoon	0		
 9030	spoiled star salad	3	crappy	
 9031	spinning Thwaitgold moth statuette	0		
-9032	enchanted miniature stale skewed bowl of Tastee-Wheet&trade;	2	decent	Effect: "Partially Ghosted", Effect Duration: 35
+9032	enchanted stale miniature skewed bowl of Tastee-Wheet&trade;	2	decent	Effect: "Partially Ghosted", Effect Duration: 35
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	flavorless half-sized bouncing browser cookie	2	decent	Last Available: "2016-06"
+9035	half-sized flavorless bouncing browser cookie	2	decent	Last Available: "2016-06"
 9036	weak tolerable hacked gibson	2	good	Last Available: "2016-06"
 9037	purple friendly Source shades	0		Familiar Weight: +3, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8913,7 +8913,7 @@
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
-9044	ghostly squat Source terminal DRAM chip	0		Last Available: "2016-06"
+9044	squat ghostly Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	blue Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	green Source terminal DIAGRAM chip	0		Last Available: "2016-06"
@@ -8947,8 +8947,8 @@
 9075	warmed adjusted jittery shoe gum	0		Effect: "Toast Tea", Effect Duration: 62, Last Available: "2016-07"
 9076	upside-down maroon foul-smelling occult noir fedora of the brazier	0		Spell Damage Percent: +25, Hot Spell Damage: +25, Stench Damage: +10, Last Available: "2016-07"
 9077	perfumed Jack Frost's trench coat of the blizzard	0		Cold Spell Damage: 75, Stench Resistance: +5, Last Available: "2016-07"
-9078	triple-distilled hand-crafted ghostly Falcon&trade; Maltese Liquor	6	EPIC	Last Available: "2016-07"
-9079	small yummy tumbling hardboiled egg	2	awesome	Last Available: "2016-07"
+9078	hand-crafted triple-distilled ghostly Falcon&trade; Maltese Liquor	6	EPIC	Last Available: "2016-07"
+9079	yummy small tumbling hardboiled egg	2	awesome	Last Available: "2016-07"
 9080	blinking detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	auspicious quilted baleful experienced beefy protonic accelerator pack of the cheetah	0		Muscle: +10, Experience: +2, Spell Damage: +25, Damage Absorption: +40, Item Drop: +10, Initiative: +60, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
@@ -8973,12 +8973,12 @@
 9101	purification tablet	0		
 9102	blurry Van der Graaf Wrist-Boy	0		MP Regen Min: 5, MP Regen Max: 7
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
-9104	bouncing shaking Time-Spinner	0		Last Available: "2016-09"
+9104	shaking bouncing Time-Spinner	0		Last Available: "2016-09"
 9105	gray compounded experience	0		Last Available: "2016-09"
 9106	Rad-B-Gone (1 lb.)	0		
 9107	dry improved blinking Rad-Pro (1 oz.)	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 62
 9108	upside-down lead umbrella	0		
-9109	ionized mirror squat Shrieking Weasel holo-record	0		Effect: "20/20 Vision", Effect Duration: 48
+9109	ionized squat mirror Shrieking Weasel holo-record	0		Effect: "20/20 Vision", Effect Duration: 48
 9110	dry Power-Guy 2000 holo-record	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 12
 9111	energized extra-galvanized Lucky Strikes holo-record	0		Effect: "Strange Mental Acuity", Effect Duration: 23
 9112	extra-warmed energized pulsating EMD holo-record	0		Effect: "Sleazy Weapon", Effect Duration: 59
@@ -9025,7 +9025,7 @@
 9153	adequate half-sized maroon ghostly raw sweet potato	2	good	Last Available: "2016-11"
 9154	stale special raw beans	4	decent	Effect: "Got Your Boots On", Effect Duration: 10, Last Available: "2016-11"
 9155	decent raw stuffing	3	good	Last Available: "2016-11"
-9156	diet stale blurry squat narrow raw cranberry sauce	1	decent	Last Available: "2016-11"
+9156	diet stale squat blurry narrow raw cranberry sauce	1	decent	Last Available: "2016-11"
 9157	half-sized stale raw turkey	2	decent	Last Available: "2016-11"
 9158	rotten huge ghostly raw mincemeat	6	crappy	Last Available: "2016-11"
 9159	big stale green raw potato	5	decent	Last Available: "2016-11"
@@ -9048,7 +9048,7 @@
 9176	flavorless mince pie	4	decent	Last Available: "2016-11"
 9177	super-sized spoiled mashed potatoes	5	crappy	Last Available: "2016-11"
 9178	bite-sized adequate warm gravy	1	good	Last Available: "2016-11"
-9179	bland thick bread roll	5	decent	Last Available: "2016-11"
+9179	thick bland bread roll	5	decent	Last Available: "2016-11"
 9180	flavorless leftovers	3	decent	Last Available: "2016-11"
 9181	flavorless ghostly leftovers sandwich	4	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9061,7 +9061,7 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	corrupted eldritch concentrate	0		Effect: "Dances with Tweedles", Effect Duration: 23, Last Available: "2016-11"
-9192	aged watered-down eldritch extract	2	awesome	Last Available: "2016-11"
+9192	watered-down aged eldritch extract	2	awesome	Last Available: "2016-11"
 9193	curative Official Council Aide Pin of terror	0		Spooky Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
 9194	perfectly mixed eldritch distillate	3	EPIC	Last Available: "2016-11"
 9195	compressed blurry eldritch essence	1		Last Available: "2016-11"
@@ -9072,7 +9072,7 @@
 9200	supercool Quartet of Flare Masters Jacket of Tarzan	0		Moxie Percent: +20, Experience (Muscle): +3, Last Available: "2016-11"
 9201	narrow lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	spinning skewed Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	skewed spinning Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
 9205	fuchsia sprinkles	0		Last Available: "2016-12"
 9206	yellow The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
@@ -9107,7 +9107,7 @@
 9235	extra-polarized denatured double-deionized huge gingerbread spice latte	0		Effect: "Spell Transfer Complete", Effect Duration: 48, Last Available: "2016-12"
 9236	frosty gingerbread gavel of extreme caution	0		Monster Level: -25, Cold Spell Damage: +10, Last Available: "2016-12"
 9237	fuchsia gingerbread cigarette	0		Last Available: "2016-12"
-9238	teal tumbling gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
+9238	tumbling teal gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	acceptable ginger beer	4	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	adjusted galvanized galvanized industrial frosting	0		Effect: "Alacri Tea", Effect Duration: 65, Last Available: "2016-12"
@@ -9118,13 +9118,13 @@
 9246	nasty plastic Knows About Chakras	0		Stench Damage: +5, Last Available: "2016-12"
 9247	Usain Bolt's plastic Your Brain	0		Initiative: +80, Last Available: "2016-12"
 9248	coward's plastic Krampus	0		Monster Level: -20, Last Available: "2016-12"
-9249	tarnished tumbling spinning Inner Wisdom	0		Effect: "Amorous", Effect Duration: 45, Last Available: "2016-12"
+9249	tarnished spinning tumbling Inner Wisdom	0		Effect: "Amorous", Effect Duration: 45, Last Available: "2016-12"
 9250	vacuum-sealed bouncing Inner Strength	0		Effect: "Healthy Bronze Glow", Effect Duration: 30, Last Available: "2016-12"
 9251	cold-filtered Inner Truth	0		Effect: "Marbles in Your Mouth", Effect Duration: 58, Last Available: "2016-12"
 9252	half-sized flavorless spiritual candy cane	2	decent	Last Available: "2016-12"
 9253	weak bad spiritual eggnog	2	decent	Last Available: "2016-12"
 9254	half-sized rotten spiritual fruitcake	2	crappy	Last Available: "2016-12"
-9255	stale snack-sized spiritual gingerbread	2	decent	Last Available: "2016-12"
+9255	snack-sized stale spiritual gingerbread	2	decent	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	negative lump	0		
 9273	narrow careful grievous Third Eye	0		Weapon Damage Percent: +50, Monster Level: -10, Last Available: "2016-12"
 9274	miser's hardy Krampus Horn	0		Maximum HP: +50, Meat Drop: +10, Single Equip, Last Available: "2016-12"
-9275	adequate upside-down blurry maroon hambrosier	3	good	Last Available: "2016-12"
+9275	adequate maroon upside-down blurry hambrosier	3	good	Last Available: "2016-12"
 9276	artisanal pulsating chakra-mental wine	4	EPIC	Last Available: "2016-12"
 9277	polarized polarized chakra malt	0		Effect: "Third Based", Effect Duration: 54, Last Available: "2016-12"
 9278	decent Black Angus blackburger	3	good	Last Available: "2016-12"
-9279	practically non-alcoholic aged blinking gray shaking brandy	1	awesome	Last Available: "2016-12"
+9279	aged practically non-alcoholic gray blinking shaking brandy	1	awesome	Last Available: "2016-12"
 9280	chilled potion of spiritual gunkifying	0		Effect: "Impregnably Delicious", Effect Duration: 69, Last Available: "2016-12"
 9281	supercharged baleful bad vibroknife	0		Spell Damage: +25, Maximum MP Percent: +30, Last Available: "2016-12"
 9282	toasty Fonzie's crystal belt buckle	0		Experience (Moxie): +1, Hot Damage: +5, Last Available: "2016-12"
@@ -9159,18 +9159,18 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	curative dance instructor's boxer's Uncle Crimbo's hat	0		Muscle Percent: +10, Experience Percent (Moxie): +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-12"
-9290	fancy rotten Eldritch snap	3	crappy	Effect: "Buttermilk Boogie", Effect Duration: 35, Last Available: "2017-01"
+9290	rotten fancy Eldritch snap	3	crappy	Effect: "Buttermilk Boogie", Effect Duration: 35, Last Available: "2017-01"
 9291	boiled hot jelly	1		Last Available: "2017-01"
-9292	diluted maroon pulsating jelly	1		Last Available: "2017-01"
+9292	diluted pulsating maroon jelly	1		Last Available: "2017-01"
 9293	boiled yellow spinning jelly	1		Effect: "Thicker, Sicker", Effect Duration: 20, Last Available: "2017-01"
 9294	modified sleaze jelly	1		Last Available: "2017-01"
-9295	powdered tumbling ghostly stench jelly	1		Last Available: "2017-01"
+9295	powdered ghostly tumbling stench jelly	1		Last Available: "2017-01"
 9296	jittery space planula	0		Free Pull, Last Available: "2017-01"
 9297	big bland fancy toast with hot jelly	5	decent	Effect: "You're Rubber", Effect Duration: 25, Last Available: "2017-01"
 9298	stale toast with jelly	3	decent	Last Available: "2017-01"
 9299	spoiled toast with jelly	3	crappy	Last Available: "2017-01"
 9300	tasty bite-sized toast with sleaze jelly	1	awesome	Last Available: "2017-01"
-9301	diet moldy skewed toast with stench jelly	1	crappy	Last Available: "2017-01"
+9301	moldy diet skewed toast with stench jelly	1	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	tumbling hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9179,14 +9179,14 @@
 9307	adequate red wax pancake	3	good	Last Available: "2017-01"
 9308	gravedigger's smartaleck's wax face	0		Moxie Percent: +30, Spooky Damage: +10, Last Available: "2017-01"
 9309	delicious wax booze	4	awesome	Last Available: "2017-01"
-9310	yellow spinning glob of melted wax	0		Last Available: "2017-01"
+9310	spinning yellow glob of melted wax	0		Last Available: "2017-01"
 9311	dehydrated tumbling sea jelly	1		Effect: "Ready to Snap", Effect Duration: 5, Last Available: "2017-01"
-9312	toothsome super-sized pulsating upside-down sea truffle	5	awesome	Last Available: "2017-01"
+9312	super-sized toothsome upside-down pulsating sea truffle	5	awesome	Last Available: "2017-01"
 9313	purple tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	grievous recovered cufflinks	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2017-01"
 9316	heart-shaped crate	0		Free Pull, Last Available: "2017-02"
-9317	quadruple-pressed teal mirror LOV Elixir #3	0		Effect: "Turkey-Friendly", Effect Duration: 65, Last Available: "2017-02"
+9317	quadruple-pressed mirror teal LOV Elixir #3	0		Effect: "Turkey-Friendly", Effect Duration: 65, Last Available: "2017-02"
 9318	enhanced alkaline LOV Elixir #6	0		Effect: "Thicker, Sicker", Effect Duration: 24, Last Available: "2017-02"
 9319	enhanced red LOV Elixir #9	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 66, Last Available: "2017-02"
 9320	maroon toasty grievous groovy LOV Eardigan	0		Moxie Percent: +10, Weapon Damage Percent: +50, Hot Damage: +5, Lasts Until Rollover, Last Available: "2017-02"
@@ -9218,7 +9218,7 @@
 9346	Thwaitgold amoeba statuette	0		
 9347	pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
-9349	ghostly shaking bottle of novelty hot sauce	0		Last Available: "2017-03"
+9349	shaking ghostly bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	elemental sugarcube	0		Last Available: "2017-03"
 9351	lime green peppermint sprig	0		Last Available: "2017-03"
 9352	bottle of clam juice	0		Last Available: "2017-03"
@@ -9232,42 +9232,42 @@
 9360	fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
 9362	pile of dirt	0		Last Available: "2017-03"
-9363	pulsating maroon blinking slime shooter	0		Last Available: "2017-03"
+9363	pulsating blinking maroon slime shooter	0		Last Available: "2017-03"
 9364	pulsating imaginary lemon	0		Last Available: "2017-03"
 9365	smooth literal grasshopper	3	awesome	Last Available: "2017-03"
-9366	acceptable weak double entendre	2	good	Last Available: "2017-03"
-9367	weak drinkable huge Phlegethon	2	good	Last Available: "2017-03"
+9366	weak acceptable double entendre	2	good	Last Available: "2017-03"
+9367	drinkable weak huge Phlegethon	2	good	Last Available: "2017-03"
 9368	perfectly mixed ghostly Siberian sunrise	4	EPIC	Last Available: "2017-03"
 9369	bad blurry mentholated wine	3	decent	Last Available: "2017-03"
 9370	tolerable low tide martini	3	good	Last Available: "2017-03"
-9371	bad fancy shroomtini	3	decent	Effect: "Outer Wolf&trade;", Effect Duration: 5, Last Available: "2017-03"
+9371	fancy bad shroomtini	3	decent	Effect: "Outer Wolf&trade;", Effect Duration: 5, Last Available: "2017-03"
 9372	tolerable morning dew	4	good	Last Available: "2017-03"
 9373	mediocre whiskey squeeze	4	decent	Last Available: "2017-03"
 9374	perfectly mixed great fashioned	3	EPIC	Last Available: "2017-03"
 9375	drinkable Gnomish sagngria	3	good	Last Available: "2017-03"
-9376	mediocre watered-down vodka stinger	2	decent	Last Available: "2017-03"
+9376	watered-down mediocre vodka stinger	2	decent	Last Available: "2017-03"
 9377	acceptable extremely slippery nipple	3	good	Last Available: "2017-03"
-9378	fortified perfectly mixed shaking piscatini	5	EPIC	Last Available: "2017-03"
+9378	perfectly mixed fortified shaking piscatini	5	EPIC	Last Available: "2017-03"
 9379	artisanal Churchill	4	EPIC	Last Available: "2017-03"
 9380	bad soilzerac	4	decent	Last Available: "2017-03"
 9381	tolerable London frog	3	good	Last Available: "2017-03"
 9382	lousy nothingtini	3	decent	Last Available: "2017-03"
 9383	artisanal eighth plague	3	EPIC	Last Available: "2017-03"
 9384	lousy pulsating single entendre	3	decent	Last Available: "2017-03"
-9385	high-proof tolerable twirling reverse Tantalus	9	good	Last Available: "2017-03"
+9385	tolerable high-proof twirling reverse Tantalus	9	good	Last Available: "2017-03"
 9386	acceptable boozy elemental caipiroska	5	good	Last Available: "2017-03"
-9387	bad fuchsia squat Feliz Navidad	4	decent	Last Available: "2017-03"
+9387	bad squat fuchsia Feliz Navidad	4	decent	Last Available: "2017-03"
 9388	hand-crafted strong huge Bloody Nora	5	EPIC	Last Available: "2017-03"
 9389	acceptable moreltini	4	good	Last Available: "2017-03"
-9390	mediocre irresponsibly strong fancy shaking hell in a bucket	9	decent	Effect: "Rushin' Hands", Effect Duration: 5, Last Available: "2017-03"
+9390	irresponsibly strong fancy mediocre shaking hell in a bucket	9	decent	Effect: "Rushin' Hands", Effect Duration: 5, Last Available: "2017-03"
 9391	hand-crafted watered-down tumbling Newark	2	EPIC	Last Available: "2017-03"
 9392	boozy acceptable R'lyeh	5	good	Last Available: "2017-03"
 9393	enchanted drinkable Gnollish sangria	4	good	Effect: "Meatwise", Effect Duration: 50, Last Available: "2017-03"
-9394	special delicious red vodka barracuda	3	awesome	Effect: "Blackberry Politeness", Effect Duration: 10, Last Available: "2017-03"
-9395	drinkable triple-distilled Mysterious Island iced tea	7	good	Last Available: "2017-03"
-9396	watered-down delicious drive-by shooting	2	awesome	Last Available: "2017-03"
+9394	delicious special red vodka barracuda	3	awesome	Effect: "Blackberry Politeness", Effect Duration: 10, Last Available: "2017-03"
+9395	triple-distilled drinkable Mysterious Island iced tea	7	good	Last Available: "2017-03"
+9396	delicious watered-down drive-by shooting	2	awesome	Last Available: "2017-03"
 9397	acceptable gunner's daughter	4	good	Last Available: "2017-03"
-9398	watered-down delicious dirt julep	2	awesome	Last Available: "2017-03"
+9398	delicious watered-down dirt julep	2	awesome	Last Available: "2017-03"
 9399	artisanal blurry Simepore slime	4	EPIC	Last Available: "2017-03"
 9400	irresponsibly strong perfectly mixed twirling Phil Collins	9	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9275,7 +9275,7 @@
 9403	wobbly toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
-9406	bouncing pulsating exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
+9406	pulsating bouncing exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	blinking rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	skewed high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9292,7 +9292,7 @@
 9420	twisted huge narrow alien plant goo	1		Last Available: "2017-04"
 9421	twirling teal alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	special stale super-sized alien meat	5	decent	Effect: "Items Are Forever", Effect Duration: 10, Last Available: "2017-04"
+9423	super-sized stale special alien meat	5	decent	Effect: "Items Are Forever", Effect Duration: 10, Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	blurry alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9303,7 +9303,7 @@
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	quantum upside-down alien medicine	0		Effect: "Stop the Presses!", Effect Duration: 33, Last Available: "2017-04"
 9433	bite-sized spoiled shaking alien salad	1	crappy	Last Available: "2017-04"
-9434	bad boozy alien booze	5	decent	Last Available: "2017-04"
+9434	boozy bad alien booze	5	decent	Last Available: "2017-04"
 9435	wobbly frightening sizzling resourceful alien mask	0		Maximum MP: +50, Hot Damage: +10, Spooky Damage: +5, Last Available: "2017-04"
 9436	asbestos-lined shellacked stylish alien spear	0		Moxie: +25, Damage Reduction: 7, Hot Resistance: +5, Last Available: "2017-04"
 9437	nippy alien blowgun of James Dean of the sewer	0		Experience (Moxie): +3, Cold Damage: +10, Stench Damage: +25, Last Available: "2017-04"
@@ -9320,7 +9320,7 @@
 9448	murderbot power cell	0		Last Available: "2017-04"
 9449	murderbot component casing	0		Last Available: "2017-04"
 9450	murderbot monofilament	0		Last Available: "2017-04"
-9451	magnetized pulsating spinning murderbot shield unit	0		Effect: "Voracious Gorging", Effect Duration: 15, Last Available: "2017-04"
+9451	magnetized spinning pulsating murderbot shield unit	0		Effect: "Voracious Gorging", Effect Duration: 15, Last Available: "2017-04"
 9452	bouncing gray murderbot live wire	0		Last Available: "2017-04"
 9453	scandalous smelly murderbot mask of the businessman	0		Stench Spell Damage: +10, Sleaze Damage: +5, Meat Drop: +50, Avatar: "Murderbot", Last Available: "2017-04"
 9454	Vulcanized yellow murderbot spring injector	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 46, Last Available: "2017-04"
@@ -9343,19 +9343,19 @@
 9471	lard-coated wizardly Spacegate diplomat's insignia of Gandalf	0		Mysticality: +25, Spell Critical Percent: +20, Sleaze Spell Damage: +25, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	special bite-sized toothsome alien sandwich	1	awesome	Effect: "All Is Forgiven", Effect Duration: 50, Last Available: "2017-04"
+9474	special toothsome bite-sized alien sandwich	1	awesome	Effect: "All Is Forgiven", Effect Duration: 50, Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	double-frozen dry olive Spant eggs	0		Effect: "Quantum of Moxie", Effect Duration: 15
 9477	pulsating Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	flattened upside-down blurry Daily Affirmation: Always be Collecting	0		Effect: "One For Tea", Effect Duration: 26, Last Available: "2017-05"
+9479	flattened blurry upside-down Daily Affirmation: Always be Collecting	0		Effect: "One For Tea", Effect Duration: 26, Last Available: "2017-05"
 9480	energized cold-filtered quantum shaking Daily Affirmation: Think Win-Lose	0		Effect: "Afternoon Insight", Effect Duration: 54, Last Available: "2017-05"
 9481	warmed mirror Daily Affirmation: Be Superficially interested	0		Effect: "Red Door Syndrome", Effect Duration: 40, Last Available: "2017-05"
 9482	concentrated Daily Affirmation: Adapt to Change Eventually	0		Effect: "Drenched With Filth", Effect Duration: 60, Last Available: "2017-05"
 9483	quantum adjusted concentrated wobbly Daily Affirmation: Be a Mind Master	0		Effect: "Mana Tea", Effect Duration: 68, Last Available: "2017-05"
 9484	triple-colloidal adjusted narrow Daily Affirmation: Work For Hours a Week	0		Effect: "Moon-Eyed", Effect Duration: 67, Last Available: "2017-05"
 9485	dry dry yellow spinning Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Mathematically Precise", Effect Duration: 21, Last Available: "2017-05"
-9486	snack-sized flavorless Affirmation Cookie	2	decent	Last Available: "2017-05"
+9486	flavorless snack-sized Affirmation Cookie	2	decent	Last Available: "2017-05"
 9487	blinking License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
@@ -9364,7 +9364,7 @@
 9492	twirling suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	knitted mansplainer's Kremlin's Greatest Briefcase of mayonnaise	0		Monster Level: +15, Sleaze Spell Damage: +50, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	perfectly mixed basic martini	3	EPIC	Last Available: "2017-06"
-9495	fortified acceptable improved martini	5	good	Last Available: "2017-06"
+9495	acceptable fortified improved martini	5	good	Last Available: "2017-06"
 9496	bad blue splendid martini	4	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	jittery can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,7 +9384,7 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	fuchsia Meteorite-Ade	0		Last Available: "2017-08"
 9514	adequate meteoreo	3	good	Last Available: "2017-08"
-9515	lousy fancy teal meadeorite	3	decent	Effect: "Moon-Eyed", Effect Duration: 30, Last Available: "2017-08"
+9515	fancy lousy teal meadeorite	3	decent	Effect: "Moon-Eyed", Effect Duration: 30, Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	mirror scandalous healthy slick meteortarboard	0		Moxie: +10, Maximum HP Percent: +20, Sleaze Damage: +5, Last Available: "2017-08"
 9518	Newton's groovy meteorite guard of the early riser	0		Moxie Percent: +10, Experience (Mysticality): +3, Adventures: +7, Damage Reduction: 9, Last Available: "2017-08"
@@ -9416,7 +9416,7 @@
 9544	O	0		Last Available: "2017-10"
 9545	hand-crafted DUFRESNE Suds	4	EPIC	Last Available: "2017-09"
 9546	horrifying mafia pinky ring of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +25, Single Equip
-9547	mediocre spirit-forward fancy narrow flask of port	5	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 40
+9547	mediocre fancy spirit-forward narrow flask of port	5	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 40
 9548	pulsating energetic groovy contract enforcement stick	0		Moxie Percent: +10, Maximum MP Percent: +20
 9549	toothsome Hide-rox&trade; cookie	4	awesome	Last Available: "2017-10"
 9550	lousy high-proof jug of booze	9	decent	Last Available: "2017-10"
@@ -9434,7 +9434,7 @@
 9562	jittery prompt Socratic protection stick of courage of the businessman	0		Experience (Mysticality): +1, Spooky Resistance: +3, Meat Drop: +50, Adventures: +3
 9563	wet roll of meat	0		Effect: "Tiki Temerity", Effect Duration: 69
 9564	spinning grievous brainy mafia thumb ring	0		Mysticality: +5, Weapon Damage Percent: +50, Single Equip
-9565	energized oxidized olive bouncing cocoa chondrule	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 60, Last Available: "2020-09"
+9565	energized oxidized bouncing olive cocoa chondrule	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 60, Last Available: "2020-09"
 9566	fortified experienced mafia middle finger ring	0		Experience: +2, Damage Absorption: +60, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	gravedigger's quilted Newton's steel drivin' hammer of horror	0		Experience (Mysticality): +3, Damage Absorption: +40, Spooky Damage: +10, Spooky Spell Damage: +25
 9568	piece of steel	0		
@@ -9464,10 +9464,10 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	enchanted green temperance whiskey	1	crappy	Effect: "Pwnd", Effect Duration: 10, Last Available: "2017-11"
 9594	irradiated wishbone	0		Effect: "Mortarfied", Effect Duration: 18, Last Available: "2017-11"
-9595	bad extra-dry Racisto Ruidoso	5	decent	Last Available: "2017-11"
+9595	extra-dry bad Racisto Ruidoso	5	decent	Last Available: "2017-11"
 9596	blurry earthenware muffin tin	0		
-9597	small moldy bran muffin	2	crappy	
-9598	stale special blueberry muffin	4	decent	Effect: "Weather, Man", Effect Duration: 35
+9597	moldy small bran muffin	2	crappy	
+9598	special stale blueberry muffin	4	decent	Effect: "Weather, Man", Effect Duration: 35
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9486,7 +9486,7 @@
 9614	jittery silent P	0		Last Available: "2017-12"
 9615	teal silent Q	0		Last Available: "2017-12"
 9616	ghostly mirror silent R	0		Last Available: "2017-12"
-9617	ghostly jittery jittery silent S	0		Last Available: "2017-12"
+9617	jittery jittery ghostly silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
@@ -9505,12 +9505,12 @@
 9633	blurry rock-hard stylish cheerful Crimbo sweater	0		Moxie: +25, Damage Reduction: 5, Last Available: "2017-12"
 9634	forbidden dangerous cheerful pajama pants	0		Weapon Damage: +10, Spell Damage Percent: +50, Last Available: "2017-12"
 9635	mirror The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
-9636	squat cyan spinning The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9636	cyan squat spinning The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	tumbling The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
-9641	bouncing shaking The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9641	shaking bouncing The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9642	The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
@@ -9518,11 +9518,11 @@
 9646	huge The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	acceptable fortified shaking executive mime flask	5	good	Last Available: "2017-12"
-9649	moldy tiny squat nega-mushroom	1	crappy	Last Available: "2017-12"
+9649	tiny moldy squat nega-mushroom	1	crappy	Last Available: "2017-12"
 9650	bad nega-mushroom wine	4	decent	Last Available: "2017-12"
 9651	double-galvanized frozen jittery shaking Cheer-Up soda	0		Effect: "Penguinny Flavor", Effect Duration: 68, Last Available: "2017-12"
 9652	bland mime army rations	3	decent	Last Available: "2017-12"
-9653	lousy watered-down enchanted mime army wine	2	decent	Effect: "It's Soporiffic!", Effect Duration: 40, Last Available: "2017-12"
+9653	enchanted watered-down lousy mime army wine	2	decent	Effect: "It's Soporiffic!", Effect Duration: 40, Last Available: "2017-12"
 9654	vaporized mime army superserum	1		Effect: "Devil Inside", Effect Duration: 45, Last Available: "2017-12"
 9655	quadruple-dry mime army camouflage kit	0		Effect: "Altered Wavelengths", Effect Duration: 61, Last Available: "2017-12"
 9656	fireproof miming beret of the sweet-tooth	0		Hot Resistance: +3, Candy Drop: +100, Last Available: "2017-12"
@@ -9542,8 +9542,8 @@
 9670	teal mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	tumbling mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
-9673	fuchsia huge mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
-9674	ghostly bouncing mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
+9673	huge fuchsia mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
+9674	bouncing ghostly mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	scorching Oprah's mime army infiltration glove	0		Maximum MP Percent: +50, Hot Damage: +25, Single Equip, Last Available: "2017-12"
 9676	olive mime army shotglass	0		Last Available: "2017-12"
 9677	bouncing mime army challenge coin	0		Last Available: "2017-12"
@@ -9572,7 +9572,7 @@
 9700	ruddy novelty monorail ticket of the scaredy-cat	0		Maximum HP Percent: +40, Monster Level: -15
 9701	powdered pills	1		
 9702	dried purple twirling furry pill	1		
-9703	altered bouncing maroon beefy pill	1		Effect: "There Is A Spoon", Effect Duration: 25
+9703	altered maroon bouncing beefy pill	1		Effect: "There Is A Spoon", Effect Duration: 25
 9704	altered skewed blinking excitement pill	1		Effect: "Creepypasted", Effect Duration: 50
 9705	vaporized huge tumbling vitamin G pill	1		Effect: "Ooh, Salty!", Effect Duration: 30
 9706	powdered jittery lucky-ish pill	1		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30
@@ -9593,7 +9593,7 @@
 9725	flame-retardant forbidden psychic's pslacks	0		Spell Damage Percent: +50, Hot Resistance: +1, Last Available: "2018-02"
 9726	gray rosewater-soaked rock-hard psychic's amulet	0		Damage Reduction: 5, Stench Resistance: +3, Last Available: "2018-02"
 9727	massive adequate heart-shaped candy whetstone	6	good	Last Available: "2018-02"
-9728	jumbo toothsome jittery Swedish massage fish	5	awesome	Last Available: "2018-02"
+9728	toothsome jumbo jittery Swedish massage fish	5	awesome	Last Available: "2018-02"
 9729	watered-down mediocre Third Base	2	decent	Last Available: "2018-02"
 9730	bad irresponsibly strong wobbly Bustle Hustler	7	decent	Last Available: "2018-02"
 9731	diffused Fabiotion	0		Effect: "Heart Aflame", Effect Duration: 57, Last Available: "2018-02"
@@ -9655,12 +9655,12 @@
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
-9790	narrow pulsating squat Mechamelion	0		Last Available: "2018-03"
+9790	narrow squat pulsating Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	tumbling Wullabye	0		Last Available: "2018-03"
 9794	twirling Nursine	0		Last Available: "2018-03"
-9795	ghostly bouncing Cantelope	0		Last Available: "2018-03"
+9795	bouncing ghostly Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
@@ -9670,7 +9670,7 @@
 9802	Squib	0		Last Available: "2018-03"
 9803	shaking Trafikoan	0		Last Available: "2018-03"
 9804	spinning Slotter	0		Last Available: "2018-03"
-9805	squat blurry Shudder	0		Last Available: "2018-03"
+9805	blurry squat Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
 9807	skewed Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
@@ -9696,10 +9696,10 @@
 9828	pickled gray magnificent oyster egg	1		
 9829	diluted brilliant oyster egg	1		
 9830	vaporized ghostly glistening oyster egg	1		Effect: "Scrappy, Shadowy", Effect Duration: 35
-9831	mixed teal narrow squat scintillating oyster egg	1		
+9831	mixed squat teal narrow scintillating oyster egg	1		
 9832	powdered pearlescent oyster egg	1		Effect: "Blessing of the Pervy Noodles", Effect Duration: 25
 9833	pickled lustrous oyster egg	1		
-9834	dried green shaking jittery gleaming oyster egg	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
+9834	dried shaking green jittery gleaming oyster egg	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	blurry FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	teal dance instructor's Sinatra's FantasyRealm G. E. M. of the sweet-tooth	0		Experience (Moxie): +5, Experience Percent (Moxie): +10, Candy Drop: +100, Lasts Until Rollover, Last Available: "2018-04"
@@ -9711,10 +9711,10 @@
 9843	greedy savvy cool &quot;Remember the Trees&quot; Shirt	0		Moxie: +5, Mysticality Percent: +20, Meat Drop: +20
 9844	blinking FantasyRealm key	0		Last Available: "2018-04"
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
-9846	bouncing olive pulsating tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
+9846	olive pulsating bouncing tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
-9849	spinning yellow LyleCo premium rope	0		Last Available: "2018-04"
+9849	yellow spinning LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	fuchsia dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9732,7 +9732,7 @@
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	narrow Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	tumbling arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9867	green squat hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
+9867	squat green hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	bland snack-sized druidic s'more	2	decent	Last Available: "2018-04"
 9870	denatured olive skewed sachet of powder	1		Last Available: "2018-04"
@@ -9766,21 +9766,21 @@
 9898	special acceptable olive two meat muck	4	good	Effect: "Berry Defensive", Effect Duration: 20
 9899	adequate bite-sized maroon chocolate Ogre Chieftain	1	good	
 9900	thick bland blinking chocolate &quot;Phoenix&quot;	5	decent	
-9901	stale low-calorie chocolate Spider Queen	1	decent	
+9901	low-calorie stale chocolate Spider Queen	1	decent	
 9902	watered-down lousy squat hipster cocktail	2	decent	
 9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
 9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
 9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
-9908	upside-down jittery Dish of Clarified Butter	0		Last Available: "2018-05"
+9908	jittery upside-down Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
 9911	gray gattoo	0		
 9912	blue A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	ghostly crude oil congealer	0		
-9915	spoiled bite-sized good guava	1	crappy	
+9915	bite-sized spoiled good guava	1	crappy	
 9916	aged green gin and ginger	3	awesome	
 9917	huge Thwaitgold chigger statuette	0		
 9918	dried twirling gaseous gravy	1		
@@ -9789,8 +9789,8 @@
 9921	A Guide to Safari	0		Skill: "Experience Safari"
 9922	polarized blurry wobbly Shielding Potion	0		Effect: "Transcendental Wind", Effect Duration: 14, Last Available: "2018-06"
 9923	alkaline quadruple-quantum Punching Potion	0		Effect: "Concentration", Effect Duration: 25, Last Available: "2018-06"
-9924	skewed shaking Special Seasoning	0		Last Available: "2018-06"
-9925	mixed skewed blue Nightmare Fuel	1		Effect: "Dreadful Fear", Effect Duration: 40, Last Available: "2018-06"
+9924	shaking skewed Special Seasoning	0		Last Available: "2018-06"
+9925	mixed blue skewed Nightmare Fuel	1		Effect: "Dreadful Fear", Effect Duration: 40, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	skewed Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	purple huge twirling Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9838,13 +9838,13 @@
 9970	ghostly ratty knitted cap of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5, Last Available: "2018-09"
 9972	jittery foul-smelling stylish intimidating chainsaw	0		Moxie: +25, Stench Damage: +10, Lasts Until Rollover, Last Available: "2018-09"
 9973	drinkable blue party beer bomb	4	good	Last Available: "2018-09"
-9974	adequate big sweet party mix	5	good	Last Available: "2018-09"
+9974	big adequate sweet party mix	5	good	Last Available: "2018-09"
 9975	diluted party balloon	1		Effect: "Favored by Lyle", Effect Duration: 10, Last Available: "2018-09"
 9976	twirling reassuring supercharged party pants	0		Maximum MP Percent: +30, Spooky Resistance: +1, Last Available: "2018-09"
 9977	censurious friendly therapeutic party whip	0		Familiar Weight: +3, Sleaze Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-09"
 9978	tumbling Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	artisanal mirror TRIO cup of beer	3	EPIC	Last Available: "2018-09"
-9980	bite-sized adequate yellow party platter for one	1	good	Last Available: "2018-09"
+9980	adequate bite-sized yellow party platter for one	1	good	Last Available: "2018-09"
 9981	denatured ghostly Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	skewed party pup	0		Last Available: "2018-09"
 9983	maroon party crasher of James Dean of the early riser	0		Experience (Moxie): +3, Adventures: +7, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
@@ -9875,10 +9875,10 @@
 10009	olive perfumed stylish mutant crown of incineration	0		Moxie: +25, Hot Spell Damage: +50, Stench Resistance: +5, Last Available: "2018-11"
 10010	adequate bite-sized tumbling ghostly ectoplasm	1	good	Last Available: "2018-11"
 10011	moldy shaking	3	crappy	Last Available: "2018-11"
-10012	watered-down lousy bottle of vodka	2	decent	Last Available: "2018-11"
-10013	flavorless snack-sized pizza	2	decent	Last Available: "2018-11"
+10012	lousy watered-down bottle of vodka	2	decent	Last Available: "2018-11"
+10013	snack-sized flavorless pizza	2	decent	Last Available: "2018-11"
 10014	perfectly mixed tumbling martini	4	EPIC	Last Available: "2018-11"
-10015	small flavorless shaking blinking cherry pie	2	decent	Last Available: "2018-11"
+10015	flavorless small shaking blinking cherry pie	2	decent	Last Available: "2018-11"
 10016	fancy artisanal eggnog	4	EPIC	Effect: "Aries Rising", Effect Duration: 40, Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	adequate Hell ramen	4	good	Last Available: "2018-11"
@@ -9908,11 +9908,11 @@
 10042	Socratic dam	0		Experience (Mysticality): +1, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable weak wobbly beavermouth	2	good	Last Available: "2018-12"
 10044	perfectly mixed triple-distilled beaver punch (papaya)	7	EPIC	Last Available: "2018-12"
-10045	mediocre tumbling jittery beaver punch (peach)	3	decent	Last Available: "2018-12"
+10045	mediocre jittery tumbling beaver punch (peach)	3	decent	Last Available: "2018-12"
 10046	acceptable bouncing beaver punch (cherry)	3	good	Last Available: "2018-12"
 10047	inspector's gravedigger's Canadian lantern	0		Spooky Damage: +10, Item Drop: +15, Last Available: "2018-12"
 10048	spinning muskox-skin cap of chilblains	0		Cold Damage: +25, Last Available: "2018-12"
-10049	pulsating spinning Boxing Day care package	0		Free Pull, Last Available: "2018-12"
+10049	spinning pulsating Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	spoiled glass of raw eggs	4	crappy	Last Available: "2018-12"
 10051	delicious shaking punch-drunk punch	3	awesome	Last Available: "2018-12"
 10052	modified maroon body spradium	1		Last Available: "2018-12"
@@ -9923,7 +9923,7 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	Sinatra's Rosewater's Kramco Sausage-o-Matic&trade; of the ox of the dark arts of the brazier	0		Muscle: +20, Mysticality Percent: +30, Experience (Moxie): +5, Spell Damage Percent: +100, Hot Spell Damage: +25, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	thick adequate huge sausage	5	good	Last Available: "2019-01"
+10060	adequate thick huge sausage	5	good	Last Available: "2019-01"
 10061	jittery therapeutic red-hot sausage fork of temperance	0		Sleaze Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-01"
 10062	spinning bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
@@ -9931,15 +9931,15 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	high-proof bad beer	7	decent	Last Available: "2018-12"
 10067	bland lime green yule gruel	3	decent	Last Available: "2018-12"
-10068	delicious fancy hot watered rum	4	awesome	Effect: "Nutrient-Rich", Effect Duration: 45, Last Available: "2018-12"
-10069	hand-crafted watered-down bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
+10068	fancy delicious hot watered rum	4	awesome	Effect: "Nutrient-Rich", Effect Duration: 45, Last Available: "2018-12"
+10069	watered-down hand-crafted bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
 10070	moldy Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
 10071	powdered blinking narrow Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	blinking blinking Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	ghostly Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10076	spinning gray Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10076	gray spinning Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	gray Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	lime green chaotic Crimbolex watch of chilblains of incineration	0		Spell Critical Percent: +10, Cold Damage: +25, Hot Spell Damage: +50, Single Equip, Last Available: "2018-12"
@@ -10007,7 +10007,7 @@
 10141	bouncing hardened flagstone fez of the businessman	0		Damage Reduction: 3, Meat Drop: +50, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	reassuring razor-sharp flagstone fleece	0		Weapon Damage Percent: +25, Spooky Resistance: +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	mirror zippy smooth flagstone fringe	0		Moxie: +15, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	diluted ghostly maroon flagstone flagments	1		Last Available: "2022-12"
+10144	diluted maroon ghostly flagstone flagments	1		Last Available: "2022-12"
 10145	warmed Flag by the Foot&trade;	0		Effect: "Egged On", Effect Duration: 23
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
@@ -10015,7 +10015,7 @@
 10149	anodized ghostly tin thermos of chai	0		Effect: "Egged On", Effect Duration: 25, Last Available: "2019-12"
 10150	denatured prototype stimulant	1		Last Available: "2019-12"
 10151	careful tailored vest	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2019-12"
-10152	twirling pulsating sew-on bandage	0		Last Available: "2019-12"
+10152	pulsating twirling sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	knitted elf army poncho	0		Cold Resistance: +3, Lasts Until Rollover, Last Available: "2019-12"
 10155	spoiled upside-down elf army field rations	4	crappy	Last Available: "2019-12"
@@ -10032,16 +10032,16 @@
 10166	jittery sharpshooter's smooth Lil' Doctor&trade; bag	0		Moxie: +15, Critical Hit Percent: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	mirror blood bag	0		
 10169	yummy immense bloodstick	7	awesome	
-10170	watered-down tolerable olive bottle of Sanguiovese	2	good	
-10171	flavorless huge skewed blinking actual blood sausage	10	decent	
-10172	acceptable triple-distilled mulled blood	8	good	
-10173	small adequate blood snowcone	2	good	
+10170	tolerable watered-down olive bottle of Sanguiovese	2	good	
+10171	huge flavorless skewed blinking actual blood sausage	10	decent	
+10172	triple-distilled acceptable mulled blood	8	good	
+10173	adequate small blood snowcone	2	good	
 10174	drinkable Red Russian	3	good	
 10175	toothsome blood roll-up	4	awesome	
 10176	hand-crafted blurry bottle of blood	4	EPIC	
 10177	miniature decent spinning blood-soaked sponge cake	2	good	
 10178	special smooth vampagne	4	awesome	Effect: "In the Limelight", Effect Duration: 40
-10179	rotten tiny plain snowcone	1	crappy	
+10179	tiny rotten plain snowcone	1	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	yellow skewed money bag	0		
@@ -10049,7 +10049,7 @@
 10184	Thwaitgold mosquito statuette	0		
 10185	pulsating bucket of Vampyre blood	0		
 10186	huge blood knife	0		Lasts Until Rollover
-10187	squat gray narrow PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
+10187	narrow squat gray PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
 10188	PirateRealm guest pass	0		Last Available: "2019-04"
 10189	shaking stanky banded Sinatra's PirateRealm eyepatch	0		Experience (Moxie): +5, Damage Absorption: +100, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2019-04"
 10190	skewed bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
@@ -10061,11 +10061,11 @@
 10196	shaking recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	moldy wobbly gray jittery crabsicle	3	crappy	Last Available: "2019-04"
+10199	moldy wobbly jittery gray crabsicle	3	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	tolerable narrow bottle of dark rhum	3	good	Last Available: "2019-04"
 10202	lousy bottle of extra-dark rhum	4	decent	Last Available: "2019-04"
-10203	perfectly mixed boozy upside-down bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
+10203	boozy perfectly mixed upside-down bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
 10204	ionized pirate shaving cream	0		Effect: "Alchemical, Brother", Effect Duration: 42, Last Available: "2019-04"
 10205	double-paned frightening conquistador's breastplate	0		Spooky Damage: +5, Cold Resistance: +5, Last Available: "2019-04"
 10206	censurious forbidden pirate pantaloons	0		Spell Damage Percent: +50, Sleaze Resistance: +3, Last Available: "2019-04"
@@ -10076,9 +10076,9 @@
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	decent immense pineapple slab	6	good	Last Available: "2019-04"
 10213	moldy shaking hibiscus petal	3	crappy	Last Available: "2019-04"
-10214	altered vacuum-sealed narrow green huge mint leaf	0		Effect: "Thick-Skinned", Effect Duration: 61, Last Available: "2019-04"
+10214	altered vacuum-sealed green narrow huge mint leaf	0		Effect: "Thick-Skinned", Effect Duration: 61, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
-10216	denatured jittery blinking ice molecule	1		Effect: "In Tuna", Effect Duration: 20, Last Available: "2019-04"
+10216	denatured blinking jittery ice molecule	1		Effect: "In Tuna", Effect Duration: 20, Last Available: "2019-04"
 10217	huge Red Roger's reliquary	0		Last Available: "2019-04"
 10218	ghostly Red Roger's right hand	0		Last Available: "2019-04"
 10219	shaking Red Roger's left hand	0		Last Available: "2019-04"
@@ -10097,9 +10097,9 @@
 10232	delicious weak narrow Island Landslide	2	awesome	Last Available: "2019-04"
 10233	irresponsibly strong tolerable Island Thunderstorm	6	good	Last Available: "2019-04"
 10234	artisanal red Island Hurricane	3	EPIC	Last Available: "2019-04"
-10235	artisanal spirit-forward Skull Punch	5	EPIC	Last Available: "2019-04"
+10235	spirit-forward artisanal Skull Punch	5	EPIC	Last Available: "2019-04"
 10236	artisanal twirling olive Electric Punch	4	EPIC	Last Available: "2019-04"
-10237	strong acceptable huge Smuggler's Punch	5	good	Last Available: "2019-04"
+10237	acceptable strong huge Smuggler's Punch	5	good	Last Available: "2019-04"
 10238	bad shaking Scorpion Bowl	3	decent	Last Available: "2019-04"
 10239	lousy green Turtle Bowl	3	decent	Last Available: "2019-04"
 10240	tolerable Cobra Bowl	4	good	Last Available: "2019-04"
@@ -10131,11 +10131,11 @@
 10266	super-electrified magenta seashell	0		Effect: "Deadly Flashing Blade", Effect Duration: 38, Last Available: "2019-07"
 10267	concentrated cyan seashell	0		Effect: "Night of the Nachos", Effect Duration: 16, Last Available: "2019-07"
 10268	magnetized frozen gray gray seashell	0		Effect: "Bloody-minded", Effect Duration: 30, Last Available: "2019-07"
-10269	quantum pickled quadruple-galvanized squat huge seashell	0		Effect: "You're Not Cooking", Effect Duration: 64, Last Available: "2019-07"
+10269	quantum pickled quadruple-galvanized huge squat seashell	0		Effect: "You're Not Cooking", Effect Duration: 64, Last Available: "2019-07"
 10270	energized quantum seashell	0		Effect: "Spooky Flavor", Effect Duration: 40, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	drinkable high-proof bottle of sea wine	10	good	Last Available: "2019-07"
-10273	pickled spinning blinking red kelp	1		Last Available: "2019-07"
+10272	high-proof drinkable bottle of sea wine	10	good	Last Available: "2019-07"
+10273	pickled red spinning blinking kelp	1		Last Available: "2019-07"
 10274	flame-retardant horrifying curative banded sinister stylish driftwood hat of James Dean of the storm of the businessman	0		Moxie: +25, Experience (Moxie): +3, Spell Damage: +10, Damage Absorption: +100, Maximum MP Percent: +40, Spooky Damage: +25, Hot Resistance: +1, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-07"
 10275	scandalous careful mansplainer's Tesla wicked arcane researcher's driftwood pants of wisdom of the scaredy-cat of the overflowing toilet	0		Mysticality: +15, Experience Percent (Mysticality): +10, Spell Damage: +5, Monster Level: -10, Stench Spell Damage: +50, Sleaze Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10276	purple avaricious Sherlock's perfumed smelly vibrating healthy hardened supercool driftwood bracelet of the wise owl	0		Mysticality: +20, Moxie Percent: +20, Damage Reduction: 3, Maximum HP Percent: +20, Maximum MP Percent: +10, Stench Spell Damage: +10, Stench Resistance: +5, Item Drop: +25, Meat Drop: +30, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10143,7 +10143,7 @@
 10278	olive chaotic Sinatra's spearfish fishing spear of horror	0		Experience (Moxie): +5, Spell Critical Percent: +10, Spooky Spell Damage: +25, Last Available: "2019-07"
 10279	toasty Sinatra's rabbitfish fin of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Hot Damage: +5, Single Equip, Last Available: "2019-07"
 10280	tumbling piece of coral	0		Last Available: "2019-07"
-10281	upside-down pulsating piece of driftwood	0		Last Available: "2019-07"
+10281	pulsating upside-down piece of driftwood	0		Last Available: "2019-07"
 10282	aromatic pirate cutlass of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Stench Resistance: +1, Initiative: +100, Single Equip, Last Available: "2019-07"
 10283	experienced tricorn hat of Gandalf of the cheetah	0		Experience: +2, Spell Critical Percent: +20, Initiative: +60, Last Available: "2019-07"
 10284	shaking arcane researcher's experienced swash buckle of the brazier	0		Experience: +2, Experience Percent (Mysticality): +10, Hot Spell Damage: +25, Single Equip, Last Available: "2019-07"
@@ -10165,11 +10165,11 @@
 10300	Lo Pan's experienced savvy whittled owl figurine	0		Mysticality Percent: +20, Experience: +2, Spell Critical Percent: +30, Single Equip, Last Available: "2019-08"
 10301	gravedigger's whittled fox figurine of Leguizamo of the early riser	0		Monster Level: +20, Spooky Damage: +10, Adventures: +7, Single Equip, Last Available: "2019-08"
 10302	electrified clever sinister whittled walking stick of the scaredy-cat	0		Spell Damage: +10, Maximum MP: +20, Monster Level: -15, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-08"
-10303	super-sized delicious campfire hot dog	5	awesome	Last Available: "2019-08"
+10303	delicious super-sized campfire hot dog	5	awesome	Last Available: "2019-08"
 10304	decent blinking campfire baked potato	4	good	Last Available: "2019-08"
-10305	diet bland huge campfire s'more	1	decent	Last Available: "2019-08"
+10305	bland diet huge campfire s'more	1	decent	Last Available: "2019-08"
 10306	small decent campfire beans	2	good	Last Available: "2019-08"
-10307	stale massive campfire stew	8	decent	Last Available: "2019-08"
+10307	massive stale campfire stew	8	decent	Last Available: "2019-08"
 10308	squat jittery campfire coffee	1	EPIC	Last Available: "2019-08"
 10309	super-energized galvanized leftover chocolate bar	0		Effect: "Gemini Rising", Effect Duration: 69
 10310	rare Meat isotope	0		
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	twirling Thwaitgold bombardier beetle statuette	0		
 10320	bland space chowder	4	decent	
-10321	acceptable boozy space wine	5	good	
+10321	boozy acceptable space wine	5	good	
 10322	twirling The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	blurry Pocket Professor memory chip	0		
@@ -10193,8 +10193,8 @@
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	tumbling diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	decent miniature bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
-10338	flavorless miniature flan del mar	2	decent	Last Available: "2019-12"
+10337	miniature decent bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
+10338	miniature flavorless flan del mar	2	decent	Last Available: "2019-12"
 10339	moldy Baja sopapilla	4	crappy	Last Available: "2019-12"
 10340	plastic Mer-kin baker of courage	0		Spooky Resistance: +3, Last Available: "2019-12"
 10341	deadly plastic sea elf	0		Weapon Damage: +5, Last Available: "2019-12"
@@ -10202,9 +10202,9 @@
 10343	plastic dolphin &quot;orphan&quot; of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2019-12"
 10344	skewed stylish plastic Dolph Bossin	0		Moxie: +25, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	normal thick mana-coated yams	5	good	Last Available: "2019-11"
-10347	super-sized fancy bland twirling mana-basted tofurkey leg	5	decent	Effect: "Booooooze", Effect Duration: 30, Last Available: "2019-11"
-10348	decent bite-sized mana-fortified cranberry sauce	1	good	Last Available: "2019-11"
+10346	thick normal mana-coated yams	5	good	Last Available: "2019-11"
+10347	bland fancy super-sized twirling mana-basted tofurkey leg	5	decent	Effect: "Booooooze", Effect Duration: 30, Last Available: "2019-11"
+10348	bite-sized decent mana-fortified cranberry sauce	1	good	Last Available: "2019-11"
 10349	yummy super-sized mana-stuffed herbal stuffing	5	awesome	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	ionized frozen lime green patch of extra-warm fur	0		Effect: "Savage Beast Inside", Effect Duration: 41, Last Available: "2019-12"
@@ -10246,19 +10246,19 @@
 10387	tumbling intact anemone spike	0		Last Available: "2019-12"
 10388	blurry gravedigger's anemoney clip	0		Spooky Damage: +10, Single Equip, Last Available: "2019-12"
 10389	fuchsia runny icing	0		Last Available: "2019-12"
-10390	twisted jittery shaking super-sweet fish goo (spoiled)	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 40, Last Available: "2019-12"
+10390	twisted shaking jittery super-sweet fish goo (spoiled)	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 40, Last Available: "2019-12"
 10391	twirling purple Annie Oakley's arcane researcher's icing poncho of the dark arts	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +100, Critical Hit Percent: +20, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	colloidal anodized glob of salty molasses	0		Effect: "Grape Expectations", Effect Duration: 63, Last Available: "2019-12"
 10394	skewed spinning careful banded Mer-kin rollpin	0		Damage Absorption: +100, Monster Level: -10, Last Available: "2019-12"
 10395	lime green personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	cyan tinsel fin	0		Familiar Weight: +5
-10397	toothsome miniature bowl of mernudo	2	awesome	Last Available: "2019-12"
-10398	watered-down smooth pulsating fishelada	2	awesome	Last Available: "2019-12"
+10397	miniature toothsome bowl of mernudo	2	awesome	Last Available: "2019-12"
+10398	smooth watered-down pulsating fishelada	2	awesome	Last Available: "2019-12"
 10399	immense flavorless ojo de pez burrito	8	decent	Last Available: "2019-12"
 10400	bouncing waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
-10402	lime green twirling waterlogged stuffing	0		Last Available: "2019-12"
+10402	twirling lime green waterlogged stuffing	0		Last Available: "2019-12"
 10403	squat olive waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
 10405	blinking friendly extremely unsafe nutcracker hat	0		Weapon Damage Percent: +100, Familiar Weight: +3, Last Available: "2019-12"
@@ -10281,8 +10281,8 @@
 10422	scorching savvy Crimbylow-rise jeans	0		Mysticality Percent: +20, Hot Damage: +25, Last Available: "2019-12"
 10423	extremely unsafe razor-sharp kelp-holly drape	0		Weapon Damage Percent: 125, Last Available: "2019-12"
 10424	chilly chaotic Oprah's stiffened Staff of the Peppermint Twist	0		Damage Reduction: 1, Maximum MP Percent: +50, Spell Critical Percent: +10, Cold Damage: +5, Last Available: "2019-12"
-10425	rotten small tempura and bean	2	crappy	Last Available: "2019-12"
-10426	lousy weak blinking salt plum sake	2	decent	Last Available: "2019-12"
+10425	small rotten tempura and bean	2	crappy	Last Available: "2019-12"
+10426	weak lousy blinking salt plum sake	2	decent	Last Available: "2019-12"
 10427	adjusted pressurized potion of possessiveness	0		Effect: "Black Eyes", Effect Duration: 49, Last Available: "2019-12"
 10428	liquefied magnetized almond	0		Effect: "Filled with Magic", Effect Duration: 13
 10429	extra-denatured handful of mixed nuts	0		Effect: "Sharp Weapon", Effect Duration: 52, Last Available: "2019-12"
@@ -10299,10 +10299,10 @@
 10442	twirling wicked drippy truncheon	0		Spell Damage: +5, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
-10445	miniature tasty drippy nugget	2	drippy	
+10445	tasty miniature drippy nugget	2	drippy	
 10446	drinkable shaking glass of drippy wine	3	drippy	
 10447	spoiled tiny drippy caviar	1	drippy	
-10448	huge rotten drippy plum(?)	8	drippy	
+10448	rotten huge drippy plum(?)	8	drippy	
 10449	skewed Jim Carey's drippy stake	0		Monster Level: +25, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10325,14 +10325,14 @@
 10468	blinking spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
 10470	Thwaitgold buzzy beetle statuette	0		
-10471	huge cyan Plumber's Union Handbook	0		
+10471	cyan huge Plumber's Union Handbook	0		
 10472	avaricious bony back shell	0		Meat Drop: +30
 10473	frosty button	0		Single Equip
 10474	deionized anodized double-moist jittery blooper ink	0		Effect: "Sealed Brain", Effect Duration: 48
 10475	coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
-10478	blinking upside-down plastic doll arms	0		
+10478	upside-down blinking plastic doll arms	0		
 10479	plastic doll legs	0		
 10480	fuchsia rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
@@ -10345,8 +10345,8 @@
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
 10489	bland mushroom filet	4	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
-10491	vaporized spinning yellow mushroom tea	1		Effect: "Superveiny 9000", Effect Duration: 15, Last Available: "2020-03"
-10492	triple-distilled acceptable mushroom whiskey	7	good	Last Available: "2020-03"
+10491	vaporized yellow spinning mushroom tea	1		Effect: "Superveiny 9000", Effect Duration: 15, Last Available: "2020-03"
+10492	acceptable triple-distilled mushroom whiskey	7	good	Last Available: "2020-03"
 10493	blurry Herculean beefy mushroom cap of the sweet-tooth	0		Muscle: +10, Experience (Muscle): +1, Candy Drop: +100, Last Available: "2020-03"
 10494	inspector's studded mushroom shield of the pedagogue of temperance	0		Experience: +3, Damage Absorption: +80, Sleaze Resistance: +5, Item Drop: +15, Damage Reduction: 6, Last Available: "2020-03"
 10495	foul-smelling mushroom pants of the storm of the blizzard of the detective	0		Maximum MP Percent: +40, Cold Spell Damage: +25, Stench Damage: +10, Item Drop: +20, Last Available: "2020-03"
@@ -10382,7 +10382,7 @@
 10525	smooth drippy pilsner	3	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
-10529	cyan bouncing lustrous drippy orb	0		
+10529	bouncing cyan lustrous drippy orb	0		
 10530	huge beefy gory drippy orb	0		Muscle: +10
 10531	annealed drippy orb	0		
 10532	Guzzlr application	0		Free Pull
@@ -10431,7 +10431,7 @@
 10575	blurry drippy candy bar	0		
 10576	extra-colloidal salty drippy candy bar	0		Effect: "Ten out of Ten", Effect Duration: 60
 10577	nitrogenated activated writhing drippy candy bar	0		Effect: "The Halls of Mysticality", Effect Duration: 43
-10578	modified twirling blue gooey drippy candy bar	0		Effect: "Lobos Fresh", Effect Duration: 11
+10578	modified blue twirling gooey drippy candy bar	0		Effect: "Lobos Fresh", Effect Duration: 11
 10579	blurry baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	spinning packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
@@ -10450,7 +10450,7 @@
 10594	vacuum-sealed warmed huge redwood rain stick	0		Effect: "Always be Collecting", Effect Duration: 20, Last Available: "2020-08"
 10595	purpleheart logs	0		Last Available: "2020-08"
 10596	gravedigger's smelly Jim Carey's purpleheart &quot;pants&quot;	0		Monster Level: +25, Stench Spell Damage: +10, Spooky Damage: +10, Last Available: "2020-08"
-10597	ghostly upside-down wormwood stick	0		Last Available: "2020-08"
+10597	upside-down ghostly wormwood stick	0		Last Available: "2020-08"
 10598	ghostly greasy baleful dance instructor's wormwood wedding ring of Calamity Jane of Leguizamo	0		Experience Percent (Moxie): +10, Spell Damage: +25, Critical Hit Percent: +15, Monster Level: +20, Sleaze Spell Damage: +10, Single Equip, Last Available: "2020-08"
 10599	Dripwood slab	0		Last Available: "2020-08"
 10600	bouncing drippy diadem	0		Last Available: "2020-08"
@@ -10471,7 +10471,7 @@
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
-10618	blinking purple frost-rimed desk bell	0		Last Available: "2020-09"
+10618	purple blinking frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	skewed nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
@@ -10496,7 +10496,7 @@
 10640	pulsating Universal Seasoning	0		
 10641	pickled null-day exploit	0		Effect: "Alchemical, Brother", Effect Duration: 26, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	gigantic normal chocolate chip muffin	10	good	
+10643	normal gigantic chocolate chip muffin	10	good	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10509,7 +10509,7 @@
 10653	pressed fortifying hot cocoa	0		Effect: "Analog Drunk", Effect Duration: 19, Last Available: "2020-12"
 10654	dry upside-down boiling hot cocoa	0		Effect: "Riboflavin'", Effect Duration: 12, Last Available: "2020-12"
 10655	frozen jittery cool hot cocoa	0		Effect: "Biologically Shocked", Effect Duration: 28, Last Available: "2020-12"
-10656	boiled pickled ghostly mirror overly-fancy hot cocoa	0		Effect: "Hardened Fabric", Effect Duration: 61, Last Available: "2020-12"
+10656	boiled pickled mirror ghostly overly-fancy hot cocoa	0		Effect: "Hardened Fabric", Effect Duration: 61, Last Available: "2020-12"
 10657	polymerized irradiated wobbly hot cocoa au beurre	0		Effect: "Boletus Swoletus", Effect Duration: 25, Last Available: "2020-12"
 10658	electrified non-galvanized spinning hot cocoa with rainbow marshmallows	0		Effect: "All Is Forgiven", Effect Duration: 28, Last Available: "2020-12"
 10659	Book of Old-Timey Carols of the ox	0		Muscle: [+20*event(December)], Last Available: "2020-12"
@@ -10568,18 +10568,18 @@
 10712	skewed The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	bouncing The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	tasty gigantic and pepper (stale)	8	awesome	Last Available: "2020-12"
+10715	gigantic tasty and pepper (stale)	8	awesome	Last Available: "2020-12"
 10716	mediocre cranberry margarita (brackish)	3	decent	Last Available: "2020-12"
 10717	skewed fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	spinning goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	high-proof artisanal blue barrel-aged eggnog	10	EPIC	Last Available: "2020-12"
+10720	artisanal high-proof blue barrel-aged eggnog	10	EPIC	Last Available: "2020-12"
 10721	spoiled hand-crafted candy cane	4	crappy	Last Available: "2020-12"
 10722	yummy yellow drive-thru burger	4	awesome	Last Available: "2020-12"
-10723	bad practically non-alcoholic Boulevardier cocktail	1	decent	Last Available: "2020-12"
+10723	practically non-alcoholic bad Boulevardier cocktail	1	decent	Last Available: "2020-12"
 10724	Vulcanized Hotwire&trade; brand candy rope	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 12, Last Available: "2020-12"
 10725	adequate bowl full of jelly	3	good	Last Available: "2020-12"
-10726	watered-down bad teal Eye and a Twist	2	decent	Last Available: "2020-12"
+10726	bad watered-down teal Eye and a Twist	2	decent	Last Available: "2020-12"
 10727	pickled chilled Chubby and Plump bar	0		Effect: "Saucefingers", Effect Duration: 40, Last Available: "2020-12"
 10728	spinning digibritches	0		Last Available: "2025-12"
 10729	narrow twirling packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10600,7 +10600,7 @@
 10744	super-warmed adjusted battery (car)	0		Effect: "Bilious Brains", Effect Duration: 12, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	purple marshmallow	0		
-10747	watered-down bad marshmallow bomb	2	decent	Last Available: "2021-03"
+10747	bad watered-down marshmallow bomb	2	decent	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	tumbling shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10630,7 +10630,7 @@
 10774	galvanized concentrated skewed upside-down Scent of a Human&trade; candle	0		Effect: "Vitamin-Maxed", Effect Duration: 44, Last Available: "2021-08"
 10775	enhanced warmed The Beast Within&trade; candle	0		Effect: "Hairy Palms", Effect Duration: 55, Last Available: "2021-08"
 10776	pickled triple-wet quadruple-galvanized Salsa Caliente&trade; candle	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 25, Last Available: "2021-08"
-10777	super-vacuum-sealed cyan blurry Smoldering Clover&trade; candle	0		Effect: "Chalky Hand", Effect Duration: 63, Last Available: "2021-08"
+10777	super-vacuum-sealed blurry cyan Smoldering Clover&trade; candle	0		Effect: "Chalky Hand", Effect Duration: 63, Last Available: "2021-08"
 10778	liquefied Napalm In The Morning&trade; candle	0		Effect: "Feline Ferocity", Effect Duration: 39, Last Available: "2021-08"
 10779	blurry supercool stylish extra-large utility candle	0		Moxie: +25, Moxie Percent: +20, Lasts Until Rollover, Last Available: "2021-08"
 10780	coward's quilted runed taper candle	0		Damage Absorption: +40, Monster Level: -20, Lasts Until Rollover, Last Available: "2021-08"
@@ -10676,7 +10676,7 @@
 10820	rotten blurry bowl of prescription candy	4	crappy	Last Available: "2021-12"
 10821	tasty fishcake	3	awesome	Last Available: "2021-12"
 10822	rotten gigantic wobbly bone broth	10	crappy	Last Available: "2021-12"
-10823	spoiled big skewed pulsating upside-down star pop	5	crappy	Last Available: "2021-12"
+10823	spoiled big pulsating upside-down skewed star pop	5	crappy	Last Available: "2021-12"
 10824	perfectly mixed Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
 10825	lousy Doc's Smartifying Wine	3	decent	Last Available: "2021-12"
 10826	lousy Doc's Limbering Wine	4	decent	Last Available: "2021-12"
@@ -10690,10 +10690,10 @@
 10834	diffused polymerized anti-goosebump cream	0		Effect: "Antibiotic Saucesphere", Effect Duration: 46, Last Available: "2021-12"
 10835	electrified corrupted narrow anti-odor cream	0		Effect: "Twinkly Weapon", Effect Duration: 17, Last Available: "2021-12"
 10836	frozen lime green anti-creep cream	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 40, Last Available: "2021-12"
-10837	oxidized spinning blurry anti-pain cream	0		Effect: "Hot Buttoned", Effect Duration: 42, Last Available: "2021-12"
+10837	oxidized blurry spinning anti-pain cream	0		Effect: "Hot Buttoned", Effect Duration: 42, Last Available: "2021-12"
 10838	aged Doc's Special Reserve Wine	3	awesome	Last Available: "2021-12"
-10839	moldy huge bread pie	10	crappy	Last Available: "2021-12"
-10840	acceptable weak clear Russian	2	good	Last Available: "2021-12"
+10839	huge moldy bread pie	10	crappy	Last Available: "2021-12"
+10840	weak acceptable clear Russian	2	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	tumbling Crimbo ball	0		Last Available: "2021-12"
@@ -10709,7 +10709,7 @@
 10853	tarnished shaking fleshy putty	0		Effect: "Dance Interpreter", Effect Duration: 38, Last Available: "2021-12"
 10854	ghostly healthy third ear	0		Maximum HP Percent: +20, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
-10856	narrow blinking poisonsettia	0		Last Available: "2021-12"
+10856	blinking narrow poisonsettia	0		Last Available: "2021-12"
 10857	smooth peppermint-scented socks	0		Moxie: +15, Last Available: "2021-12"
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
@@ -10721,7 +10721,7 @@
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	prompt yule hatchet	0		Adventures: +3, Last Available: "2021-12"
 10867	blinking potato alarm clock	0		Last Available: "2021-12"
-10868	immense normal blurry lab-grown meat	8	good	Last Available: "2021-12"
+10868	normal immense blurry lab-grown meat	8	good	Last Available: "2021-12"
 10869	savvy fleece	0		Mysticality Percent: +20, Last Available: "2021-12"
 10870	upside-down boxed gumball machine	0		Last Available: "2021-12"
 10871	mirror cloning kit	0		Last Available: "2021-12"
@@ -10729,14 +10729,14 @@
 10873	up-at-dawn executive nippy can of mixed everything	0		Cold Damage: +10, Meat Drop: +40, Adventures: +5, Last Available: "2021-12"
 10874	squat Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	enchanted miniature moldy narrow meatball	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2021-12"
+10876	miniature moldy enchanted narrow meatball	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	spinning meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
-10880	dehydrated pulsating ghostly fried air	1		Last Available: "2021-12"
+10880	dehydrated ghostly pulsating fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	bouncing carton of astral energy drinks	0		
-10883	powdered spinning tumbling lime green astral energy drink	1		
+10883	powdered lime green tumbling spinning astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	stiffened razor-sharp magnifying glass of the cheetah	0		Weapon Damage Percent: +25, Damage Reduction: 1, Initiative: +60, Last Available: "2022-12"
 10886	lousy void lager	3	decent	Last Available: "2022-12"
@@ -10776,7 +10776,7 @@
 10920	wholesome occult June cleaver of the wise owl	0		Mysticality: +20, Spell Damage Percent: +25, Maximum HP Percent: +10, Attacks Can't Miss, Last Available: "2022-06"
 10921	acceptable spirit-forward Dad's brandy	5	good	Last Available: "2022-06"
 10922	teacher's pen of the pedagogue of terror	0		Experience: +3, Spooky Spell Damage: +10, Last Available: "2022-06"
-10923	miniature adequate fire-roasted lake trout	2	good	Last Available: "2022-06"
+10923	adequate miniature fire-roasted lake trout	2	good	Last Available: "2022-06"
 10924	stale tumbling guilty sprout	4	decent	Last Available: "2022-06"
 10925	bouncing sizzling mother's necklace of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +10, Last Available: "2022-06"
 10926	wet quadruple-altered trampled ticket stub	0		Effect: "Mer-kindliness", Effect Duration: 42, Last Available: "2022-06"
@@ -10812,7 +10812,7 @@
 10956	high-proof lousy AutumnFest ale	8	decent	Last Available: "2022-10"
 10957	tumbling blinking olive foul-smelling autumn sweater-weather sweater of chilblains of the sweet-tooth	0		Cold Damage: +25, Stench Damage: +10, Candy Drop: +100, Lasts Until Rollover, Last Available: "2022-10"
 10958	pulsating lightning-fast gravedigger's razor-sharp autumn debris shield of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Spooky Damage: +10, Initiative: +40, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	adequate fancy purple autumn-spice donut	4	good	Effect: "Hiding in Plain Sight", Effect Duration: 10, Last Available: "2022-10"
+10959	fancy adequate purple autumn-spice donut	4	good	Effect: "Hiding in Plain Sight", Effect Duration: 10, Last Available: "2022-10"
 10960	aerosolized ionized autumn dollar	0		Effect: "Full Bottle in front of Me", Effect Duration: 56, Last Available: "2022-10"
 10961	nippy autumn leaf pendant of James Dean of vim and vigor	0		Experience (Moxie): +3, Maximum HP Percent: +50, Cold Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
 10962	vaporized autumn breeze	1		Last Available: "2022-10"
@@ -10821,16 +10821,16 @@
 10965	weak aged Oopsie IPA	2	awesome	Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
-10968	purple wobbly St. Sneaky Pete's Whey	0		Last Available: "2022-11"
+10968	wobbly purple St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	super-sized adequate ratatouille de Jarlsberg	5	good	Last Available: "2022-11"
+10970	adequate super-sized ratatouille de Jarlsberg	5	good	Last Available: "2022-11"
 10971	spoiled Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
-10972	tiny special bland pulsating yellow roasted vegetable of Jarlsberg	1	decent	Effect: "Human-Machine Hybrid", Effect Duration: 50, Last Available: "2022-11"
-10973	flavorless massive St. Pete's sneaky smoothie	10	decent	Last Available: "2022-11"
+10972	bland special tiny pulsating yellow roasted vegetable of Jarlsberg	1	decent	Effect: "Human-Machine Hybrid", Effect Duration: 50, Last Available: "2022-11"
+10973	massive flavorless St. Pete's sneaky smoothie	10	decent	Last Available: "2022-11"
 10974	spoiled Pete's wiley whey bar	4	crappy	Last Available: "2022-11"
 10975	adequate Pete's rich ricotta	4	good	Last Available: "2022-11"
 10976	boozy acceptable Boris's beer	5	good	Last Available: "2022-11"
-10977	stale jumbo gray honey bun of Boris	5	decent	Last Available: "2022-11"
+10977	jumbo stale gray honey bun of Boris	5	decent	Last Available: "2022-11"
 10978	flavorless small Boris's bread	2	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	spinning Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
@@ -10841,7 +10841,7 @@
 10985	skewed Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
-10988	spoiled miniature baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
+10988	miniature spoiled baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
 10989	flavorless enchanted maroon plain calzone	3	decent	Effect: "Fury of the Bells", Effect Duration: 35, Last Available: "2022-11"
 10990	tiny bland roasted vegetable focaccia	1	decent	Last Available: "2022-11"
 10991	bland Pizza of Legend	3	decent	Last Available: "2022-11"
@@ -10849,11 +10849,11 @@
 10993	olive Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	narrow bouncing Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10996	bouncing narrow Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	teal Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	rotten fancy small Deep Dish of Legend	2	crappy	Effect: "The Moxie of LOV", Effect Duration: 40, Last Available: "2022-11"
+11000	small fancy rotten Deep Dish of Legend	2	crappy	Effect: "The Moxie of LOV", Effect Duration: 40, Last Available: "2022-11"
 11001	blinking red deed to Oliver's Place	0		Free Pull
 11002	upside-down drink chit	0		
 11003	government per-diem	0		
@@ -10868,7 +10868,7 @@
 11012	milk cap	0		
 11013	weak aged jittery Charleston Choo-Choo	2	awesome	
 11014	boozy acceptable Velvet Veil	5	good	
-11015	bad watered-down Marltini	2	decent	
+11015	watered-down bad Marltini	2	decent	
 11016	bad jittery Strong, Silent Type	4	decent	
 11017	perfectly mixed Mysterious Stranger	3	EPIC	
 11018	bad mirror Champagne Shimmy	4	decent	
@@ -10889,10 +10889,10 @@
 11033	perfumed wholesome chiffon chaps of the glutton	0		Maximum HP Percent: +10, Stench Resistance: +5, Food Drop: +100, Last Available: "2023-12"
 11034	mixed maroon chiffon carbage	1		Last Available: "2023-12"
 11035	adjusted narrow chiffon lemon	0		Effect: "Smoking like a Bandit", Effect Duration: 56
-11036	normal half-sized chocomotive	2	good	Last Available: "2022-12"
+11036	half-sized normal chocomotive	2	good	Last Available: "2022-12"
 11037	half-sized delicious freightcake	2	awesome	Last Available: "2022-12"
 11038	tolerable cabooze	3	good	Last Available: "2022-12"
-11039	bouncing jittery plastic caboose	0		Last Available: "2022-12"
+11039	jittery bouncing plastic caboose	0		Last Available: "2022-12"
 11040	fuchsia plastic passenger car of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2022-12"
 11041	ghostly Usain Bolt's plastic dining car	0		Initiative: +80, Last Available: "2022-12"
 11042	auspicious plastic coal car of the glutton	0		Item Drop: +10, Food Drop: +100, Last Available: "2022-12"
@@ -10900,8 +10900,8 @@
 11044	packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	lime green model train set	0		Last Available: "2022-12"
 11046	Crimbo training manual	0		
-11047	cyan jittery Abuela Crimbo's special magnet	0		
-11048	gray jittery Trainbot radar monocle	0		Single Equip
+11047	jittery cyan Abuela Crimbo's special magnet	0		
+11048	jittery gray Trainbot radar monocle	0		Single Equip
 11049	squat pile of Trainbot parts	0		
 11050	polymerized pickled yellow Trainbot circuitry	0		Effect: "Memory of Attractiveness", Effect Duration: 27
 11051	pressed Trainbot tubing	0		Effect: "Bustle Hustlin'", Effect Duration: 34
@@ -10914,7 +10914,7 @@
 11058	wobbly ghostly censurious Trainbot harness	0		Sleaze Resistance: +3
 11059	ping-pong table	0		
 11060	wobbly Crimbo train emergency brake	0		
-11061	ghostly tumbling Trainbot autoassembly module	0		
+11061	tumbling ghostly Trainbot autoassembly module	0		
 11062	jittery cyan shaking ribald Sinatra's beefy head-mounted Trainbot	0		Muscle: +10, Experience (Moxie): +5, Sleaze Damage: +10, Last Available: "2022-12"
 11063	asbestos-lined sizzling mansplainer's leg-mounted Trainbots	0		Monster Level: +15, Hot Damage: +10, Hot Resistance: +5, Last Available: "2022-12"
 11064	cyan executive Herculean shoulder-mounted Trainbot of incineration	0		Experience (Muscle): +1, Hot Spell Damage: +50, Meat Drop: +40, Single Equip, Last Available: "2022-12"
@@ -10931,12 +10931,12 @@
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	shaking industrially-crushed ice	0		Last Available: "2022-12"
-11078	super-sized adequate upside-down steamed oyster	5	good	
+11078	adequate super-sized upside-down steamed oyster	5	good	
 11079	really nice lump of coal	0		
 11080	pulsating deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	upside-down crystal Crimbo goblet	0		
-11083	red pulsating mirror crystal Crimbo platter	0		
+11083	pulsating red mirror crystal Crimbo platter	0		
 11084	lousy Crimbosmopolitan	4	decent	Last Available: "2022-12"
 11085	enchanted rotten Crimbo dinner	3	crappy	Effect: "Go Get 'Em, Tiger!", Effect Duration: 35, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
@@ -10950,8 +10950,8 @@
 11094	huge inspector's nippy shellacked grubby wool trousers	0		Damage Reduction: 7, Cold Damage: +10, Item Drop: +15
 11095	pulsating flame-wreathed sizzling rosy-cheeked Newton's grubby wool gloves	0		Experience (Mysticality): +3, Maximum HP Percent: +30, Hot Damage: +10, Hot Spell Damage: +10, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	mediocre practically non-alcoholic pulsating nice warm beer	1	decent	
-11098	blinking teal grubby woolball	0		
+11097	practically non-alcoholic mediocre pulsating nice warm beer	1	decent	
+11098	teal blinking grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
@@ -10959,7 +10959,7 @@
 11103	spinning lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
-11106	upside-down olive molehill mountain	0		Last Available: "2023-01"
+11106	olive upside-down molehill mountain	0		Last Available: "2023-01"
 11107	tumbling whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
@@ -10992,7 +10992,7 @@
 11137	dry squat shadow flame	0		Effect: "Quadrilled", Effect Duration: 20, Last Available: "2023-03"
 11138	normal shadow bread	3	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	boozy aged spinning shadow fluid	5	awesome	Last Available: "2023-03"
+11140	aged boozy spinning shadow fluid	5	awesome	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	spinning shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11026,7 +11026,7 @@
 11171	shadow heptahedron	0		
 11172	shadow snowflake	0		
 11173	pulsating shadow heart	0		
-11174	ghostly purple shadow bucket	0		
+11174	purple ghostly shadow bucket	0		
 11175	shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	educational strapping shadow chef's hat of Gandalf	0		Muscle: +5, Experience: +1, Spell Critical Percent: +20
@@ -11034,13 +11034,13 @@
 11179	vibrating Samson's shadow hammer	0		Experience (Muscle): +5, Maximum MP Percent: +10
 11180	perfumed asbestos-lined sharpshooter's shadow monocle	0		Critical Hit Percent: +10, Hot Resistance: +5, Stench Resistance: +5, Single Equip
 11181	red shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	adequate gigantic shadow hot dog	6	good	
+11182	gigantic adequate shadow hot dog	6	good	
 11183	artisanal practically non-alcoholic shadow martini	1	EPIC	
 11184	modified shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	huge monkey glove	0		Free Pull, Last Available: "2023-04"
-11188	enhanced teal skewed shadow candy	0		Effect: "Ooh, Sour!", Effect Duration: 56
+11188	enhanced skewed teal shadow candy	0		Effect: "Ooh, Sour!", Effect Duration: 56
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
@@ -11088,7 +11088,7 @@
 11233	tumbling replica Witchess Set	0		
 11234	yellow replica genie bottle	0		
 11235	replica space planula	0		
-11236	mirror narrow replica unpowered Robortender	0		
+11236	narrow mirror replica unpowered Robortender	0		
 11237	wobbly replica Neverending Party invitation envelope	0		
 11238	blue replica January's Garbage Tote	0		
 11239	red replica God Lobster Egg	0		
@@ -11105,7 +11105,7 @@
 11250	replica grey gosling	0		
 11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
-11253	squat blurry replica Ten Dollars	0		
+11253	blurry squat replica Ten Dollars	0		
 11254	double-paned sizzling sage replica Cincho de Mayo of Calamity Jane	0		Mysticality Percent: +10, Critical Hit Percent: +15, Hot Damage: +10, Cold Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11255	Thwaitgold splendor beetle statuette	0		
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
@@ -11159,7 +11159,7 @@
 11304	wobbly replica sleeping patriotic eagle	0		
 11305	blurry boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	immense flavorless watermelon	7	decent	
+11307	flavorless immense watermelon	7	decent	
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
@@ -11182,8 +11182,8 @@
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	modified huge concentrated cooking	1		Effect: "Sweet and Yellow", Effect Duration: 40
 11329	vaporized bouncing meat	1		Effect: "Dreadful Sheen", Effect Duration: 5
-11330	denatured blinking spinning sparkling orb	1		
-11331	distilled red wobbly hardening cream	1		
+11330	denatured spinning blinking sparkling orb	1		
+11331	distilled wobbly red hardening cream	1		
 11332	pickled jittery pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	skewed book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11196,7 +11196,7 @@
 11341	inflammable leaf	0		
 11342	rake	0		Item Drop: +1
 11343	Socratic rake	0		Experience (Mysticality): +1
-11344	yellow twirling autumnic bomb	0		
+11344	twirling yellow autumnic bomb	0		
 11345	forest canopy bed	0		
 11346	day shortener	0		
 11347	twirling extra time	0		
@@ -11213,7 +11213,7 @@
 11358	smoldering leafcutter ant egg	0		
 11359	skewed foul-smelling dog trainer's ruddy deadly brainy leaf crown of chilblains	0		Mysticality: +5, Weapon Damage: +5, Maximum HP Percent: +40, Experience (familiar): +1, Cold Damage: +25, Stench Damage: +10
 11360	rotten cyan leafy browns	3	crappy	
-11361	double-polarized super-aerosolized huge gray autumnic balm	0		Effect: "Mathematically Precise", Effect Duration: 14
+11361	double-polarized super-aerosolized gray huge autumnic balm	0		Effect: "Mathematically Precise", Effect Duration: 14
 11362	boiled moist yellow coping juice	0		Effect: "Fiery Spirit", Effect Duration: 47
 11363	careful electrified candy cane sword cane of dire peril of the dark arts of the storm	0		Weapon Damage: +20, Spell Damage Percent: +100, Maximum MP Percent: +40, Monster Level: -10, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
@@ -11230,7 +11230,7 @@
 11375	Boltsmann ID badge	0		
 11376	ghostly housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	toothsome special pickled bread	3	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 40, Last Available: "2023-12"
+11378	special toothsome pickled bread	3	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 40, Last Available: "2023-12"
 11379	spoiled salted mutton	4	crappy	Last Available: "2023-12"
 11380	bland corned beet	4	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	snack-sized moldy peppermint donut	2	crappy	
+11395	moldy snack-sized peppermint donut	2	crappy	
 11396	spinning aromatic Elf Guard insignia (private)	0		Stench Resistance: +1, Last Available: "2023-12"
 11397	reassuring Crimbuccaneer fledges (mint)	0		Spooky Resistance: +1, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11260,7 +11260,7 @@
 11405	upside-down Crimbuccaneer flotsam	0		Last Available: "2023-12"
 11406	mirror Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	knitted Crimbuccaneer shirt	0		Cold Resistance: [+3*event(December)], Last Available: "2023-12"
-11408	pulsating yellow Elf Guard MPC	0		Last Available: "2023-12"
+11408	yellow pulsating Elf Guard MPC	0		Last Available: "2023-12"
 11409	blurry Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	censurious Elf Guard commandeering gloves	0		Sleaze Resistance: +3, Single Equip, Last Available: "2023-12"
 11411	anodized yellow jittery Elf Guard eyedrops	0		Effect: "Adrenaline Rush", Effect Duration: 29, Last Available: "2023-12"
@@ -11275,7 +11275,7 @@
 11420	aromatic dance instructor's Crimbuccaneer tavern swab of the storm	0		Experience Percent (Moxie): +10, Maximum MP Percent: +40, Stench Resistance: +1, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	watered-down mediocre old-school pirate grog	2	decent	Last Available: "2023-12"
-11423	stale special grog nuts	4	decent	Effect: "Heart of Yellow", Effect Duration: 50, Last Available: "2023-12"
+11423	special stale grog nuts	4	decent	Effect: "Heart of Yellow", Effect Duration: 50, Last Available: "2023-12"
 11424	knitted banded sawed-off blunderbuss of the brazier	0		Damage Absorption: +100, Hot Spell Damage: +25, Cold Resistance: +3, Last Available: "2023-12"
 11425	mediocre officer's nog	3	decent	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
@@ -11293,7 +11293,7 @@
 11438	pulsating boxer's beefcake's shipwright's hammer of bravery	0		Muscle: +25, Muscle Percent: +10, Spooky Resistance: +5, Last Available: "2023-12"
 11439	coward's chaotic crafty gunwale	0		Maximum MP: +10, Spell Critical Percent: +10, Monster Level: -20, Damage Reduction: 9, Last Available: "2023-12"
 11440	upside-down Rosewater's Kelflar vest of the dark arts of Calamity Jane	0		Mysticality Percent: +30, Spell Damage Percent: +100, Critical Hit Percent: +15, Last Available: "2023-12"
-11441	dry diffused galvanized shaking green whale cerebrospinal fluid	0		Effect: "What's That Smell?", Effect Duration: 11, Last Available: "2023-12"
+11441	dry diffused galvanized green shaking whale cerebrospinal fluid	0		Effect: "What's That Smell?", Effect Duration: 11, Last Available: "2023-12"
 11442	upside-down toasty manspreader's Crimbuccaneer runebone	0		Monster Level: +10, Hot Damage: +5, Single Equip, Last Available: "2023-12"
 11443	cannonbomb	0		Last Available: "2023-12"
 11444	knitted Elf Guard mouthknife of the ox	0		Muscle: +20, Cold Resistance: +3, Last Available: "2023-12"
@@ -11317,17 +11317,17 @@
 11462	decent gigantic blurry lime	9	good	Last Available: "2023-12"
 11463	rotten gingerbread pirate	3	crappy	Last Available: "2023-12"
 11464	small moldy enchanted fruit-stuffed rumcake	2	crappy	Effect: "Flashing Eyes", Effect Duration: 5, Last Available: "2023-12"
-11465	enchanted acceptable skewed mulled wine	4	good	Effect: "Lemony Goodness", Effect Duration: 25, Last Available: "2023-12"
+11465	acceptable enchanted skewed mulled wine	4	good	Effect: "Lemony Goodness", Effect Duration: 25, Last Available: "2023-12"
 11466	artisanal Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	perfectly mixed twirling canteen of eggnog	3	super EPIC	Last Available: "2023-12"
 11468	mediocre strong blurry hot wine	5	decent	Last Available: "2023-12"
 11469	tolerable blurry Jamaican coffee	3	good	Last Available: "2023-12"
 11470	bad flask of egggrog	4	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
-11472	squat olive Black and White Apron Meal Kit	0		Last Available: "2024-12"
+11472	olive squat Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	fancy drinkable yule grog	3	good	Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2023-12"
-11475	miniature moldy wet tack	2	crappy	Last Available: "2023-12"
+11474	drinkable fancy yule grog	3	good	Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2023-12"
+11475	moldy miniature wet tack	2	crappy	Last Available: "2023-12"
 11476	moldy whalecake	3	crappy	Last Available: "2023-12"
 11477	toasty mansplainer's curative gunwale whalegun	0		Monster Level: +15, Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	hand-crafted teal and claret	3	super EPIC	Last Available: "2023-12"
@@ -11364,9 +11364,9 @@
 11509	twirling spinning auspicious fortified moss marlinspike	0		Damage Absorption: +60, Item Drop: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	diluted moss mulch	1		Last Available: "2024-12"
 11511	double-quantum deionized moss floss	0		Effect: "Wings of the Grasshopper", Effect Duration: 44
-11512	jittery squat adobe arsecover	0		Last Available: "2024-12"
+11512	squat jittery adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
-11514	jittery narrow adobe abacus	0		Last Available: "2024-12"
+11514	narrow jittery adobe abacus	0		Last Available: "2024-12"
 11515	upside-down adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
@@ -11407,7 +11407,7 @@
 11552	teal high-tension exoskeleton	0		
 11553	purple ultra-high-tension exoskeleton	0		
 11554	twirling irresponsible-tension exoskeleton	0		
-11555	jittery bouncing quick-release belt pouch	0		Single Equip
+11555	bouncing jittery quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
 11557	quick-release utility belt	0		Single Equip
 11558	blinking spinning motion sensor of the early riser	0		Adventures: +7, Single Equip
@@ -11423,12 +11423,12 @@
 11568	Jim Carey's experienced Apriling band tuba of the pedagogue of Tarzan of James Dean	0		Experience: 5, Experience (Muscle): +3, Experience (Moxie): +3, Monster Level: +25, Lasts Until Rollover
 11569	aromatic clever medical-grade hardened experienced Apriling band staff of courage	0		Experience: +2, Damage Reduction: 3, Maximum MP: +20, Spooky Resistance: +3, Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
-11571	tumbling twirling boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
+11571	twirling tumbling boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	skewed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	half-sized stale yam	2	decent	Last Available: "2024-05"
+11573	stale half-sized yam	2	decent	Last Available: "2024-05"
 11574	hand-crafted yam martini	3	EPIC	Last Available: "2024-05"
 11575	bad practically non-alcoholic sweet potato o' mine	1	decent	Last Available: "2024-05"
-11576	acceptable irresponsibly strong spinning Southern yam	10	good	Last Available: "2024-05"
+11576	irresponsibly strong acceptable spinning Southern yam	10	good	Last Available: "2024-05"
 11577	perfectly mixed sweet potato punch	4	EPIC	Last Available: "2024-05"
 11578	spoiled special shaking Mayam spinach	3	crappy	Effect: "Yuletide Sappiness", Effect Duration: 45, Last Available: "2024-05"
 11579	bland enchanted yam and swiss	4	decent	Effect: "Ichorous Intensity", Effect Duration: 10, Last Available: "2024-05"
@@ -11444,22 +11444,22 @@
 11589	small bland yam burrito	2	decent	Last Available: "2024-05"
 11590	lime green visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
-11592	pulsating blinking green aviator goggles	0		
+11592	blinking pulsating green aviator goggles	0		
 11593	huge Thwaitgold Illinigina illinoiensis model	0		
-11594	snack-sized decent mirror mini kiwi	2	good	Last Available: "2024-06"
+11594	decent snack-sized mirror mini kiwi	2	good	Last Available: "2024-06"
 11595	nippy personal trainer's mini kiwi bikini of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10, Cold Damage: +10, Last Available: "2024-06"
 11596	perfectly mixed watered-down mini kiwitini	2	EPIC	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	teal mini kiwi aioli	0		
 11599	bouncing supercharged curative mini kiwi silicon tiepin of the scaredy-cat	0		Maximum MP Percent: +30, Monster Level: -15, HP Regen Min: 3, HP Regen Max: 5
 11600	mini kiwi tipi	0		
-11601	bite-sized enchanted moldy mini kiwi digitized cookies	1	crappy	Effect: "It Didn't Kill You", Effect Duration: 40
+11601	bite-sized moldy enchanted mini kiwi digitized cookies	1	crappy	Effect: "It Didn't Kill You", Effect Duration: 40
 11602	aged mirror mini kiwi intoxicating spirits	3	awesome	
 11603	aerosolized shaking mini kiwi antimilitaristic hippy petition	0		Effect: "Libra Rising", Effect Duration: 42
 11604	anodized twirling mini kiwi illicit antibiotic	0		Effect: "Super-Electrified", Effect Duration: 34
 11605	mini kiwi whipping stick of the dark arts of the detective	0		Spell Damage Percent: +100, Item Drop: +20
 11606	hale mini kiwi icepick	0		Maximum HP: +20
-11607	aerosolized upside-down spinning mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Human-Hippy Hybrid", Effect Duration: 27
+11607	aerosolized spinning upside-down mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Human-Hippy Hybrid", Effect Duration: 27
 11608	packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	fuchsia bouncing protogenetic chunklet (synapse)	0		
@@ -11494,7 +11494,7 @@
 11639	Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	blurry Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
-11642	jittery huge Sept-Ember Censer	0		Last Available: "2024-09"
+11642	huge jittery Sept-Ember Censer	0		Last Available: "2024-09"
 11643	ribald blade of dismemberment	0		Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
 11645	Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	double-paned wholesome grievous embers-only jacket	0		Weapon Damage Percent: +50, Maximum HP Percent: +10, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2024-09"
 11649	jittery ruddy bembershoot	0		Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2024-09"
-11650	half-sized spoiled mirror wheel of camembert	2	crappy	Last Available: "2024-09"
+11650	spoiled half-sized mirror wheel of camembert	2	crappy	Last Available: "2024-09"
 11651	Tesla dance instructor's hat of remembering	0		Experience Percent (Moxie): +10, Item Drop: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-09"
 11652	gray throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11533,7 +11533,7 @@
 11678	dried Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	blurry quantum watch	0		Adventures: +2
-11681	spinning narrow quantized familiar experience	0		
+11681	narrow spinning quantized familiar experience	0		
 11682	irradiated cold-filtered upside-down pea brittle	0		Effect: "Insulated Trousers", Effect Duration: 18, Last Available: "2024-11"
 11683	high-proof bad ghostly peasco	7	decent	Last Available: "2024-11"
 11684	big adequate piece of cake	5	good	Last Available: "2024-11"
@@ -11553,12 +11553,12 @@
 11698	supercharged governor's daughter's pearl hairpin	0		Maximum MP Percent: +30, Last Available: "2024-12"
 11699	upside-down harpoon	0		Last Available: "2024-12"
 11700	scorching chili powder cutlass	0		Hot Damage: +25, Last Available: "2024-12"
-11701	diet bland Aztec tamale	1	decent	Last Available: "2024-12"
+11701	bland diet Aztec tamale	1	decent	Last Available: "2024-12"
 11702	spinning jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	medical-grade groggles	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11705	huge pirate dinghy	0		Last Available: "2024-12"
-11706	tumbling red anchor bomb	0		Last Available: "2024-12"
+11706	red tumbling anchor bomb	0		Last Available: "2024-12"
 11707	silky pirate drawers of the scaredy-cat of the overflowing toilet	0		Monster Level: -15, Stench Spell Damage: +50, Last Available: "2024-12"
 11708	twirling profane eye patch	0		Sleaze Damage: +3
 11709	diffused gray peppermint pegleg	0		Effect: "PERL of Great Price", Effect Duration: 66, Last Available: "2024-12"
@@ -11574,7 +11574,7 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	pulsating Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	spinning Spirit of Christmas	0		Last Available: "2024-12"
-11722	spoiled big coney haunch	5	crappy	Last Available: "2024-12"
+11722	big spoiled coney haunch	5	crappy	Last Available: "2024-12"
 11723	pressed flattened spinning dark chocolate egg	0		Effect: "Painted-On Bikini", Effect Duration: 32, Last Available: "2024-12"
 11724	bad weak upside-down moai toai	2	decent	
 11725	greedy MacGyver's moaiball of mayonnaise	0		Maximum MP: +100, Sleaze Spell Damage: +50, Meat Drop: +20, Last Available: "2024-12"
@@ -11601,15 +11601,15 @@
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	bad Easter grasshopper	4	decent	Last Available: "2024-12"
 11748	lousy Irish eggnog	3	decent	Last Available: "2024-12"
-11749	fancy hand-crafted canteen of jungle juice	3	EPIC	Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2024-12"
+11749	hand-crafted fancy canteen of jungle juice	3	EPIC	Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2024-12"
 11750	practically non-alcoholic mediocre blinking spinning turchucken	1	decent	Last Available: "2024-12"
 11751	tolerable mechanically-mulled cider	4	good	Last Available: "2024-12"
 11752	perfectly mixed holiday trip around the world	3	super ultra EPIC	Last Available: "2024-12"
 11753	bland yellow chocolate ostrich egg	4	decent	Last Available: "2024-12"
 11754	flavorless beef and cabbage	3	decent	Last Available: "2024-12"
 11755	bland candy rations	3	decent	Last Available: "2024-12"
-11756	big bland double-candied yams	5	decent	Last Available: "2024-12"
-11757	low-calorie flavorless Christmas ham	1	decent	Last Available: "2024-12"
+11756	bland big double-candied yams	5	decent	Last Available: "2024-12"
+11757	flavorless low-calorie Christmas ham	1	decent	Last Available: "2024-12"
 11758	stale holiday smorgasbord	4	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	padded bejazzled eyepatch	0		Damage Absorption: +20, Last Available: "2024-12"
@@ -11650,7 +11650,7 @@
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
-11798	pulsating gray wobbly dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
+11798	wobbly gray pulsating dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	bouncing dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
@@ -11658,10 +11658,10 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	huge retro floppy disk	0		Last Available: "2025-12"
 11805	shaking pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	ghostly pulsating malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	pulsating ghostly malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
-11809	blinking tumbling 3d printed server room key	0		Last Available: "2025-12"
+11809	tumbling blinking 3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	dehydrated spinning psilocyber mushroom	1		Last Available: "2025-12"
@@ -11673,11 +11673,11 @@
 11818	blurry dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	shaking dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
-11821	green skewed SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
+11821	skewed green SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	upside-down STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
-11825	pulsating blurry parity bit	0		Familiar Weight: +5
+11825	blurry pulsating parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
 11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
@@ -11688,21 +11688,21 @@
 11833	triple-polymerized synthetic coffee	0		Effect: "Loco Motives", Effect Duration: 56
 11834	enhanced iDrops	0		Effect: "Big", Effect Duration: 55
 11835	blinking shame coil	0		
-11836	mirror cyan shaking new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
-11837	blinking skewed cyan toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
+11836	shaking cyan mirror new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
+11837	blinking cyan skewed toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
 11839	scrape	0		
 11840	narrow phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
-11844	blinking maroon upside-down chill gherkin	0		
+11844	upside-down blinking maroon chill gherkin	0		
 11845	squat childrens' stapler	0		
 11846	plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
-11850	pulsating skewed sore	0		Cold Damage: +10, Cold Spell Damage: +10
+11850	skewed pulsating sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
@@ -11716,20 +11716,20 @@
 11861	bouncing Leprecondo	0		Last Available: "2025-03"
 11862	twisted olive scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	mediocre weak cyan twirling pint of Leprechaun Stout	2	decent	Last Available: "2025-03"
+11864	mediocre weak twirling cyan pint of Leprechaun Stout	2	decent	Last Available: "2025-03"
 11865	dried phosphor traces	1		Last Available: "2025-03"
 11866	upside-down crafting plans	0		Last Available: "2025-03"
 11867	twirling Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
-11869	upside-down maroon unironic knife	0		
+11869	maroon upside-down unironic knife	0		
 11870	twirling bar dart	0		Last Available: "2025-03"
 11871	distilled leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	rotten Heck ramen	4	crappy	Last Available: "2025-03"
 11873	flavorless small burrito	2	decent	Last Available: "2025-03"
-11874	thick stale small beer brat	5	decent	Last Available: "2025-03"
+11874	stale thick small beer brat	5	decent	Last Available: "2025-03"
 11875	flavorless huge peach pie	4	decent	Last Available: "2025-03"
 11876	tiny yummy gray incredible mini-pizza	1	awesome	Last Available: "2025-03"
-11877	perfectly mixed extra-dry shaking Divine sidecar	5	EPIC	Last Available: "2025-03"
+11877	extra-dry perfectly mixed shaking Divine sidecar	5	EPIC	Last Available: "2025-03"
 11878	hand-crafted watered-down tangarita sidecar	2	EPIC	Last Available: "2025-03"
 11879	hand-crafted gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	artisanal weak blurry vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
@@ -11737,7 +11737,7 @@
 11882	mediocre ghostly Mon Tiki sidecar	3	decent	Last Available: "2025-03"
 11883	upside-down Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	healthy occult April Shower Thoughts shield	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Damage Reduction: 6, Last Available: "2025-04"
-11885	yellow mirror glob of wet paper	0		Last Available: "2025-04"
+11885	mirror yellow glob of wet paper	0		Last Available: "2025-04"
 11886	mirror spitball	0		Last Available: "2025-04"
 11887	deionized wet paper weights	0		Effect: "New Zeal", Effect Duration: 11, Last Available: "2025-04"
 11888	special acceptable Three Sheets to the Wind	4	good	Effect: "Bats in the Belfry", Effect Duration: 25, Last Available: "2025-04"
@@ -11751,7 +11751,7 @@
 11896	wet paper eye	0		Familiar Weight: +15
 11897	pulsating wet shower curtain	0		Last Available: "2025-04"
 11898	dry improved wet paper cup	0		Effect: "Thicker, Sicker", Effect Duration: 22, Last Available: "2025-04"
-11899	quadruple-frozen non-oxidized jittery narrow wet paperback	0		Effect: "Sinuses For Miles", Effect Duration: 67, Last Available: "2025-04"
+11899	quadruple-frozen non-oxidized narrow jittery wet paperback	0		Effect: "Sinuses For Miles", Effect Duration: 67, Last Available: "2025-04"
 11900	mirror supercool wet shower radio	0		Moxie Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	lime green wet shower stamp	0		Last Available: "2025-04"
 11902	wholesome birthday bloon	0		Maximum HP Percent: +10
@@ -11804,7 +11804,7 @@
 11949	bully badge of the overflowing toilet	0		Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2025-08"
 11950	wicked time cop top hat	0		Spell Damage: +5, Last Available: "2025-08"
 11951	red Stock Certificate	0		Last Available: "2025-08"
-11952	boiled yellow narrow narrow mixed berry jelly	1		Last Available: "2025-08"
+11952	boiled narrow narrow yellow mixed berry jelly	1		Last Available: "2025-08"
 11953	flavorless purple toast with mixed berry jelly	3	decent	Last Available: "2025-08"
 11954	toothsome ghostly cup of sugar	4	awesome	Last Available: "2025-08"
 11955	delicious half-sized Susie's cupcake	2	awesome	Last Available: "2025-08"
@@ -11816,7 +11816,7 @@
 11962	therapeutic undersea surveying goggles	0		HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover
 11963	drinkable tumbling Ocean-Touched Rum	3	good	
 11964	mixed wobbly water-logged pill	1		
-11965	bite-sized moldy kelp puck	1	crappy	
+11965	moldy bite-sized kelp puck	1	crappy	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	jittery scroll of sea smarm	0		
@@ -11839,15 +11839,15 @@
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	tumbling small peppermint-flavored sugar walking crook	0		
 12051	squat knucklebone	0		
-12052	artisanal olive narrow Smoking Pope	4	EPIC	
+12052	artisanal narrow olive Smoking Pope	4	EPIC	
 12053	adequate half-sized mirror prize turkey	2	good	
 12054	dehydrated medicinal gruel	1		
-12055	immense tasty squat full-sized pumpkin pie	6	awesome	Last Available: "2025-11"
-12056	weak mediocre blurry vodka cranberry sauce	2	decent	Last Available: "2025-11"
+12055	tasty immense squat full-sized pumpkin pie	6	awesome	Last Available: "2025-11"
+12056	mediocre weak blurry vodka cranberry sauce	2	decent	Last Available: "2025-11"
 12057	double-polymerized polymerized yammed candy	0		Effect: "Chain Chain Chains", Effect Duration: 66, Last Available: "2025-11"
 12058	super-sized normal treasure chestnut	5	good	Last Available: "2025-12"
-12059	artisanal practically non-alcoholic mulled butter rum	1	super ultra mega EPIC	Last Available: "2025-12"
-12060	anodized tumbling wobbly cinnamon doubloon	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 50, Last Available: "2025-12"
+12059	practically non-alcoholic artisanal mulled butter rum	1	super ultra mega EPIC	Last Available: "2025-12"
+12060	anodized wobbly tumbling cinnamon doubloon	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 50, Last Available: "2025-12"
 12061	cyan sharpshooter's plastic left skeleton arm	0		Critical Hit Percent: +10, Last Available: "2025-12"
 12062	skewed jittery Usain Bolt's plastic left skeleton leg	0		Initiative: +80, Last Available: "2025-12"
 12063	blurry slick plastic right skeleton arm	0		Moxie: +10, Last Available: "2025-12"
@@ -11879,13 +11879,13 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	lard-coated extra-thick Crimbo sweater	0		Sleaze Spell Damage: +25, Last Available: "2025-12"
 12123	maroon The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	practically non-alcoholic perfectly mixed Steve Abrams' Holiday Sampler Beer	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12124	perfectly mixed practically non-alcoholic Steve Abrams' Holiday Sampler Beer	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	bad practically non-alcoholic spinning bottle of prize-winning rum	1	decent	Last Available: "2025-12"
 12127	reassuring Tesla dangerous Santa-Slayer medal	0		Weapon Damage: +10, Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2025-12"
 12128	blurry Skull of Claus	0		Last Available: "2025-12"
 12129	corrupted frozen quadruple-dry boiling bone marrow	0		Effect: "Orc Chops", Effect Duration: 66, Last Available: "2025-12"
-12130	frozen unsweetened narrow olive boiling cerebrospinal fluid	0		Effect: "Bootyliciousness", Effect Duration: 57, Last Available: "2025-12"
+12130	frozen unsweetened olive narrow boiling cerebrospinal fluid	0		Effect: "Bootyliciousness", Effect Duration: 57, Last Available: "2025-12"
 12131	non-boiled boiling synovial fluid	0		Effect: "Ninja, Please", Effect Duration: 51, Last Available: "2025-12"
 12132	ribald Fonzie's smoldering vertebra of James Dean	0		Experience (Moxie): 4, Sleaze Damage: +10, Single Equip, Last Available: "2025-12"
 12133	blurry seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
@@ -11896,8 +11896,8 @@
 12138	blinking zippy educational fistbone of the bloodbag	0		Experience: +1, Maximum HP: +100, Initiative: +20, Last Available: "2025-12"
 12139	chilly burnt bone belt of dire peril of doom	0		Weapon Damage: +20, Cold Damage: +5, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12140	smooth scorched skull trophy	0		Moxie: +15, Last Available: "2025-12"
-12141	bland special blurry red narrow wing bone	3	decent	Effect: "Deeply Ironic", Effect Duration: 20, Last Available: "2025-12"
-12142	fancy delicious watered-down weak skeleton venom	2	awesome	Effect: "Winklered", Effect Duration: 35, Last Available: "2025-12"
+12141	special bland red blurry narrow wing bone	3	decent	Effect: "Deeply Ironic", Effect Duration: 20, Last Available: "2025-12"
+12142	watered-down delicious fancy weak skeleton venom	2	awesome	Effect: "Winklered", Effect Duration: 35, Last Available: "2025-12"
 12143	compressed pulsating baked bone meal	1		Last Available: "2025-12"
 12144	yellow squat sinister plastic skeleton rib cage	0		Spell Damage: +10, Last Available: "2025-12"
 12145	perfumed plastic skeleton skull	0		Stench Resistance: +5, Last Available: "2025-12"
@@ -11912,11 +11912,11 @@
 12154	messenger parrot egg	0		Last Available: "2025-12"
 12155	buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
-12157	twirling tumbling Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
+12157	tumbling twirling Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	wobbly tumbling Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12161	purple shaking Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12161	shaking purple Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
@@ -11926,13 +11926,13 @@
 12168	squat shaking supercharged dangerous vermiculite shield	0		Weapon Damage: +10, Maximum MP Percent: +30, Damage Reduction: 9, Last Available: "2025-12"
 12169	cool ship's lantern	0		Moxie: +5, Last Available: "2025-12"
 12170	baleful heat-resistant harpoon pistol of the sewer	0		Spell Damage: +25, Stench Damage: +25, Last Available: "2025-12"
-12171	snack-sized enchanted delicious traditional gingerloaf	2	awesome	Effect: "Ooh, Sweet!", Effect Duration: 45, Last Available: "2025-12"
+12171	enchanted snack-sized delicious traditional gingerloaf	2	awesome	Effect: "Ooh, Sweet!", Effect Duration: 45, Last Available: "2025-12"
 12172	artisanal Scotch and eggnog	3	EPIC	Last Available: "2025-12"
 12173	denatured quadruple-electrified counterskeleton elixir	0		Effect: "Salty Mouth", Effect Duration: 16, Last Available: "2025-12"
 12174	practically non-alcoholic artisanal &quot;salvaged&quot; wine	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	tumbling crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	moldy small wobbly wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
+12177	small moldy wobbly wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
 12178	oxidized gummi fingerbone	0		Effect: "Balls of Ectoplasm", Effect Duration: 12
 12179	yellow crafty Rosewater's glimmering crystal	0		Mysticality Percent: +30, Maximum MP: +10, Last Available: "2025-12"
 12180	teal ghostly boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11964,32 +11964,32 @@
 12206	wobbly Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	flavorless fancy rat pizza	4	decent	Effect: "Coated Arms", Effect Duration: 10, Last Available: "2026-03"
-12210	fuchsia jittery tumbling Fleek&trade; mascara	0		Last Available: "2026-03"
+12209	fancy flavorless rat pizza	4	decent	Effect: "Coated Arms", Effect Duration: 10, Last Available: "2026-03"
+12210	fuchsia tumbling jittery Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	bouncing Temple Grandin's wholesome boxer's hoverboard	0		Muscle Percent: +10, Maximum HP Percent: +10, Familiar Weight: +7, Single Equip, Last Available: "2026-03"
 12212	up-at-dawn medical-grade left shark fin of Calamity Jane	0		Critical Hit Percent: +15, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2026-03"
 12213	shaking bouncing aromatic fitness tracking bracelet	0		Stench Resistance: +1, Single Equip, Last Available: "2026-03"
 12214	distilled candy bone	1		Effect: "Memory of Smarts", Effect Duration: 45
 12215	gray wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	bland snack-sized discarded hot dog	2	decent	Last Available: "2026-04"
+12217	snack-sized bland discarded hot dog	2	decent	Last Available: "2026-04"
 12218	extra-dry hand-crafted most of a beer	5	EPIC	Last Available: "2026-04"
-12222	cyan blurry pasta wand loot box	0		Free Pull, Last Available: "2026-05"
+12222	blurry cyan pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	pulsating legendary noodles	0		Last Available: "2026-05"
-12226	thick decent fancy can of tuna	5	good	Effect: "Takin' It Greasy", Effect Duration: 20
+12226	fancy decent thick can of tuna	5	good	Effect: "Takin' It Greasy", Effect Duration: 20
 12227	moldy alien salad	3	crappy	
 12228	bland thick maroon ratbatatouille	5	decent	
 12229	bland gigantic onigiri	8	decent	
 12230	flavorless gigantic twirling crudit&eacute;s	6	decent	
-12231	massive toothsome spinning sauced mutton	6	awesome	
+12231	toothsome massive spinning sauced mutton	6	awesome	
 12232	bland hot honey ant	4	decent	
 12233	spoiled half-sized red tomb aspic	2	crappy	
-12234	snack-sized bland later tots	2	decent	
+12234	bland snack-sized later tots	2	decent	
 12235	decent fuchsia twirling Frutti di Scatoletta	3	good	Last Available: "2026-05"
 12236	normal Pesto alla Marziano	3	good	Last Available: "2026-05"
 12237	gigantic rotten Arrattabbattabiata	9	crappy	Last Available: "2026-05"
-12238	adequate miniature ghostly Orzo di Riso	2	good	Last Available: "2026-05"
+12238	miniature adequate ghostly Orzo di Riso	2	good	Last Available: "2026-05"
 12239	stale Pasta Grimavera	4	decent	Last Available: "2026-05"
 12240	flavorless super-sized gray Linguini Ubriacapa	5	decent	Last Available: "2026-05"
 12241	yummy blurry Formica e Pepe	3	awesome	Last Available: "2026-05"
@@ -12000,8 +12000,8 @@
 12246	ghostly green second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	flame-wreathed shellacked Space Soldier Helmet	0		Damage Reduction: 7, Hot Spell Damage: +10
-12253	moldy fancy diet huge premium turkey leg	1	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 20
-12254	boozy artisanal bouncing styrofoam cup of mead	5	EPIC	
+12253	diet fancy moldy huge premium turkey leg	1	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 20
+12254	artisanal boozy bouncing styrofoam cup of mead	5	EPIC	
 12255	spinning quilted sword	0		Damage Absorption: +40
 12256	greasy staff	0		Sleaze Spell Damage: +10
 12257	greedy lute	0		Meat Drop: +20
@@ -12020,7 +12020,7 @@
 12270	chaotic quilted Portable Laughing Stock of horror	0		Damage Absorption: +40, Spell Critical Percent: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	executive razor-sharp Staff of Anachronistic Churning of bravery	0		Weapon Damage Percent: +25, Spooky Resistance: +5, Meat Drop: +40
 12272	decent blue bouncing classic banana	3	good	Last Available: "2026-07"
-12273	toothsome diet bouncing watermelon	1	awesome	Last Available: "2026-07"
+12273	diet toothsome bouncing watermelon	1	awesome	Last Available: "2026-07"
 12274	spoiled quince	3	crappy	Last Available: "2026-07"
 12275	mirror Interesting Coin	0		Last Available: "2026-08"
 12276	jittery Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
@@ -12032,12 +12032,12 @@
 12282	stale jumbo watermelon pie	5	decent	Last Available: "2026-07"
 12283	activated concentrated watermelon juice	0		Effect: "Phoenix, Right?", Effect Duration: 57, Last Available: "2026-07"
 12284	non-diffused tarnished Aqua Citrulanatae	0		Effect: "Standard Cheer", Effect Duration: 41, Last Available: "2026-07"
-12285	triple-distilled hand-crafted Melonegroni	6	EPIC	Last Available: "2026-07"
-12286	mediocre spirit-forward Melonade Spritz	5	decent	Last Available: "2026-07"
+12285	hand-crafted triple-distilled Melonegroni	6	EPIC	Last Available: "2026-07"
+12286	spirit-forward mediocre Melonade Spritz	5	decent	Last Available: "2026-07"
 12287	bland bouncing quince pie	4	decent	Last Available: "2026-07"
 12288	anodized energized spinning quince quaff	0		Effect: "Coming Up Roses", Effect Duration: 54, Last Available: "2026-07"
 12289	pickled frozen teal Quickquince	0		Effect: "Litterboxing", Effect Duration: 66, Last Available: "2026-07"
-12290	special lousy jittery Quiskey Sour	3	decent	Effect: "Spookypants", Effect Duration: 5, Last Available: "2026-07"
+12290	lousy special jittery Quiskey Sour	3	decent	Effect: "Spookypants", Effect Duration: 5, Last Available: "2026-07"
 12291	lousy Quincea&ntilde;era Cooler	4	decent	Last Available: "2026-07"
 12292	spirit-forward acceptable Roth IPA	5	good	Last Available: "2026-08"
 12293	underdraft protection of vim and vigor of the empath	0		Maximum HP Percent: +50, Familiar Weight: +5, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Blender_cafe_booze.txt
@@ -1,21 +1,21 @@
 -1	mediocre wobbly bouncing Petite Porter	4	decent	
 -2	strong perfectly mixed bouncing Scrawny Stout	5	EPIC	
--3	high-proof enchanted drinkable Infinitesimal IPA	8	good	
--4	mediocre weak eggnogtini	2	decent	
+-3	high-proof drinkable enchanted Infinitesimal IPA	8	good	
+-4	weak mediocre eggnogtini	2	decent	
 -5	weak hand-crafted candycaine	2	EPIC	
--6	acceptable irresponsibly strong upside-down green narrow braincracker sweet	6	good	
--16	tolerable weak fermented honey	2	good	
--17	irresponsibly strong hand-crafted moons-shine	10	EPIC	
+-6	irresponsibly strong acceptable upside-down green narrow braincracker sweet	6	good	
+-16	weak tolerable fermented honey	2	good	
+-17	hand-crafted irresponsibly strong moons-shine	10	EPIC	
 -18	bad tumbling gin	4	decent	
 -19	high-proof mediocre ecto-nog	7	decent	
 -20	weak drinkable hot toady	2	good	
 -21	drinkable hot choculate	4	good	
--49	acceptable strong shaking Cyder	5	good	
+-49	strong acceptable shaking Cyder	5	good	
 -50	acceptable practically non-alcoholic maroon Oil Nog	1	good	
 -51	mediocre Hi-Octane Peppermint Jet Fuel	4	decent	
--58	enchanted watered-down perfectly mixed Grimacider	2	EPIC	
+-58	watered-down enchanted perfectly mixed Grimacider	2	EPIC	
 -59	lousy ghostly Isotope Nog	4	decent	
--60	bad weak Mutagin 'n' Tonic	2	decent	
+-60	weak bad Mutagin 'n' Tonic	2	decent	
 -70	lousy upside-down Gin and Herring	4	decent	
 -71	perfectly mixed Black and Tan and Red All Over	4	EPIC	
 -72	mediocre high-proof Antarctic Ice Tea	8	decent	
@@ -23,11 +23,11 @@
 -77	hand-crafted jittery CRIMBCO Egg Substitute Nog Substitute	3	EPIC	
 -78	aged CRIMBCO Extreme Braincracker Sour	3	awesome	
 -82	lousy Horseradish-infused Vodka	3	decent	
--83	artisanal weak Jerkitini	2	EPIC	
+-83	weak artisanal Jerkitini	2	EPIC	
 -84	tolerable Desert Island Iced Tea	4	good	
--88	distilled lousy Crimbo Saketini	5	decent	
+-88	lousy distilled Crimbo Saketini	5	decent	
 -89	perfectly mixed Crimboku Drop	4	EPIC	
--90	weak bad Flaming Crimbo Log	2	decent	
+-90	bad weak Flaming Crimbo Log	2	decent	
 -107	mediocre Fortified Eggnog Slurry	3	decent	
 -108	perfectly mixed olive Hot Buttered Rum	3	EPIC	
 -109	lousy Spicy Hot Chocolate	3	decent	

--- a/data/TCRS/TCRS_Disco_Bandit_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Blender_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	moldy wobbly bouncing Peche a la Frog	4	crappy	
--2	decent big bouncing As Jus Gezund Heit	5	good	
+-2	big decent bouncing As Jus Gezund Heit	5	good	
 -3	gigantic stale enchanted Bouillabaise Coucher Avec Moi	8	decent	
 -7	adequate low-calorie gumdrop chow mein	1	good	
 -8	delicious snack-sized fuchsia candy cane pizza	2	awesome	
--9	snack-sized flavorless fancy gingerbread stir-fry	2	decent	
--10	immense flavorless twigs and gravel	7	decent	
+-9	snack-sized fancy flavorless gingerbread stir-fry	2	decent	
+-10	flavorless immense twigs and gravel	7	decent	
 -11	low-calorie stale shoots and leaves	1	decent	
 -12	stale bowl of unidentifiable goo	3	decent	
--13	rotten pulsating purple gingerbread massacre	3	crappy	
+-13	rotten purple pulsating gingerbread massacre	3	crappy	
 -14	adequate green It Came From Beyond Dessert	4	good	
--15	special spoiled skewed vampire cake	3	crappy	
+-15	spoiled special skewed vampire cake	3	crappy	
 -52	decent Soylent Red and Green	4	good	
--53	spoiled miniature fancy Disc-Shaped Nutrition Unit	2	crappy	
+-53	fancy miniature spoiled Disc-Shaped Nutrition Unit	2	crappy	
 -54	bland massive Gingerborg Hive	8	decent	
 -61	toothsome Candy Cane Surprise	3	awesome	
--62	stale small Grimdrop Chow Mein	2	decent	
--63	small stale upside-down skewed Grimgerbread House	2	decent	
+-62	small stale Grimdrop Chow Mein	2	decent	
+-63	stale small upside-down skewed Grimgerbread House	2	decent	
 -67	normal Caviar Carbonara	4	good	
 -68	rotten Halibut Alfredo	4	crappy	
--69	massive rotten Red Herring Velvet Cake	6	crappy	
--73	diet moldy CRIMBCO Reconstituted Gruel	1	crappy	
+-69	rotten massive Red Herring Velvet Cake	6	crappy	
+-73	moldy diet CRIMBCO Reconstituted Gruel	1	crappy	
 -74	tasty New and Improved CRIMBCO Reconstituted Gruel	3	awesome	
--75	bite-sized moldy spinning twirling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	crappy	
+-75	bite-sized moldy twirling spinning CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	crappy	
 -79	rotten Brussels Sprout Stir-Fry	4	crappy	
 -80	miniature yummy Carrot, Cabbage, and Kale Pizza	2	awesome	
 -81	big moldy Turnip and Rutabaga Pie	5	crappy	
 -85	fancy delicious blurry Rainbow Spider Fun Roll	3	awesome	
 -86	rotten enchanted Vegas Volcano Lava Roll	4	crappy	
--87	super-sized stale mirror Crazy Dragon Shogun Buddha Roll	5	decent	
--92	big flavorless basic hot dog	5	decent	
+-87	stale super-sized mirror Crazy Dragon Shogun Buddha Roll	5	decent	
+-92	flavorless big basic hot dog	5	decent	
 -93	rotten bite-sized savage macho dog	1	crappy	
--94	big adequate one with everything	5	good	
--95	half-sized enchanted bland sly dog	2	decent	
+-94	adequate big one with everything	5	good	
+-95	bland half-sized enchanted sly dog	2	decent	
 -96	massive moldy devil dog	6	crappy	
 -97	decent skewed chilly dog	4	good	
 -98	bite-sized moldy skewed ghost dog	1	crappy	
--99	gigantic flavorless junkyard dog	7	decent	
+-99	flavorless gigantic junkyard dog	7	decent	
 -100	huge adequate wet dog	7	good	
 -101	toothsome sleeping dog	4	awesome	
--102	special immense bland upside-down optimal dog	10	decent	
+-102	special bland immense upside-down optimal dog	10	decent	
 -103	adequate pulsating video games hot dog	3	good	
 -104	moldy Peppermint Nutrition Block	3	crappy	
 -105	decent fuchsia Gingerbread Nutrition Block	4	good	
--106	snack-sized spoiled skewed Cinnamon Nutrition Block	2	crappy	
+-106	spoiled snack-sized skewed Cinnamon Nutrition Block	2	crappy	

--- a/data/TCRS/TCRS_Disco_Bandit_Marmot.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Marmot.txt
@@ -11,7 +11,7 @@
 11	stolen accordion	0		Song Duration: 5
 12	mirror mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	compressed moxie weed	1		
-15	altered ghostly gray spinning strongness elixir	1		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 5
+15	altered spinning gray ghostly strongness elixir	1		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 5
 16	mixed blue magicalness-in-a-can	1		Effect: "Arabian Knighthood", Effect Duration: 40
 17	moldy spinning noodles	3	crappy	
 18	tortoise's blessing	0		
@@ -22,7 +22,7 @@
 23	fuchsia chewing gum on a string	0		
 24	huge ten-leaf clover	0		
 25	meat paste	0		
-26	blinking green Dolphin King's map	0		
+26	green blinking Dolphin King's map	0		
 27	squat spider web	0		
 28	really spider web	0		
 29	blinking really really spider web	0		
@@ -39,13 +39,13 @@
 40	jittery casino pass	0		
 41	tolerable ice-cold Sir Schlitz	3	good	
 42	ghostly hermit permit	0		
-43	blurry narrow worthless trinket	0		
+43	narrow blurry worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	cyan figurine	0		
-47	stale big hot buttered roll	5	decent	
+47	big stale hot buttered roll	5	decent	
 48	heart of rock and roll	0		
-49	big yummy pulsating bowl of cottage cheese	5	awesome	
+49	yummy big pulsating bowl of cottage cheese	5	awesome	
 50	dog trainer's Rock and Roll Legend	0		Experience (familiar): +1, Class: "Accordion Thief", Song Duration: 10
 51	squat experienced Knob Goblin Uberpants	0		Experience: +2, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	wobbly banjo strings	0		
@@ -72,12 +72,12 @@
 73	blinking barskin tent	0		
 74	blinking Temple map	0		
 75	sapling	0		
-76	bouncing tumbling Spooky-Gro fertilizer	0		
+76	tumbling bouncing Spooky-Gro fertilizer	0		
 77	jittery lightning-fast stick	0		Initiative: +40
 78	squat occult pretty bouquet	0		Spell Damage Percent: +25
 79	shaking bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	practically non-alcoholic aged gray ice-cold Willer	1	awesome	
+81	aged practically non-alcoholic gray ice-cold Willer	1	awesome	
 82	teal ring	0		
 83	upside-down shaft	0		
 84	lime green upside-down Orcish meat locker	0		
@@ -104,7 +104,7 @@
 105	bland bowl of charms	3	decent	
 106	twirling ketchup	1	EPIC	
 107	catsup	1	decent	
-108	lime green bouncing stick	0		
+108	bouncing lime green stick	0		
 109	crossbow string	0		
 110	basic meat staff of the sweet-tooth	0		Candy Drop: +100
 111	gravedigger's basic meat crossbow	0		Spooky Damage: +10
@@ -120,7 +120,7 @@
 121	sprocket assembly	0		
 122	cog and sprocket assembly	0		
 123	teal Gnollish flyswatter	0		
-124	teal skewed empty meat tank	0		
+124	skewed teal empty meat tank	0		
 125	full meat tank	0		
 126	meat engine	0		
 127	supercharged Gnollish autoplunger	0		Maximum MP Percent: +30
@@ -163,7 +163,7 @@
 164	ghostly smart skull	0		
 165	pulsating skewer	0		
 166	ghuol ears	0		
-167	rotten maroon upside-down ghuol-ear kabob	3	crappy	
+167	rotten upside-down maroon ghuol-ear kabob	3	crappy	
 168	skewed lightning-fast bone rattle	0		Initiative: +40
 169	ghostly bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -199,7 +199,7 @@
 201	half-sized adequate bat wing kabob	2	good	
 202	spoiled purple carob chunks	3	crappy	
 203	herbs	0		
-204	flavorless enchanted snack-sized carob chunk cookies	2	decent	Effect: "Funky Coal Patina", Effect Duration: 45
+204	flavorless snack-sized enchanted carob chunk cookies	2	decent	Effect: "Funky Coal Patina", Effect Duration: 45
 205	secret blend of herbs and spices	0		
 206	piercing post	0		
 207	upside-down hippy herbal tea	1	awesome	
@@ -232,32 +232,32 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	fuchsia tumbling horrifying curative Bigger Bugfinder Blade	0		Spooky Damage: +25, HP Regen Min: 3, HP Regen Max: 5
 236	Queue Du Coq cocktailcrafting kit	0		
-237	watered-down enchanted lousy bottle of gin	2	decent	Effect: "Rain Dancin'", Effect Duration: 25
-238	hand-crafted weak bottle of vodka	2	EPIC	
+237	watered-down lousy enchanted bottle of gin	2	decent	Effect: "Rain Dancin'", Effect Duration: 25
+238	weak hand-crafted bottle of vodka	2	EPIC	
 239	upside-down lard-coated arcane researcher's Orcish baseball cap	0		Experience Percent (Mysticality): +10, Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	blue Oprah's dangerous Orcish cargo shorts	0		Weapon Damage: +10, Maximum MP Percent: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	blinking narrow supercool Orcish frat-paddle	0		Moxie Percent: +20
-242	normal snack-sized cyan upside-down	2	good	
-243	snack-sized bland blue grapefruit	2	decent	
-244	immense adequate enchanted grapes	10	good	Effect: "Quadrilled", Effect Duration: 40
-245	tiny tasty skewed olive	1	awesome	
+242	snack-sized normal upside-down cyan	2	good	
+243	bland snack-sized blue grapefruit	2	decent	
+244	immense enchanted adequate grapes	10	good	Effect: "Quadrilled", Effect Duration: 40
+245	tasty tiny skewed olive	1	awesome	
 246	normal snack-sized tomato	2	good	
 247	fermenting powder	0		
 248	hand-crafted salty dog	4	EPIC	
-249	artisanal watered-down spinning bloody mary	2	EPIC	
+249	watered-down artisanal spinning bloody mary	2	EPIC	
 250	bad skewed screwdriver	3	decent	
-251	bad practically non-alcoholic fancy teal martini	1	decent	Effect: "Gamer Rage", Effect Duration: 45
+251	practically non-alcoholic bad fancy teal martini	1	decent	Effect: "Gamer Rage", Effect Duration: 45
 252	acceptable bloody beer	4	good	
 253	drinkable shot of schnapps	4	good	
 254	artisanal shot of grapefruit schnapps	3	EPIC	
 255	perfectly mixed fine wine	3	EPIC	
 256	bad skewed shot of tomato schnapps	4	decent	
-257	drinkable weak extra-spicy bloody mary	2	good	
+257	weak drinkable extra-spicy bloody mary	2	good	
 258	dense meat stack	0		
 259	narrow snake skin	0		
-260	special bite-sized spoiled White Citadel fries	1	crappy	Effect: "Filled with Magic", Effect Duration: 15
+260	spoiled special bite-sized White Citadel fries	1	crappy	Effect: "Filled with Magic", Effect Duration: 15
 261	massive moldy green White Citadel burger	10	crappy	
-262	delicious huge piece of wedding cake	6	awesome	
+262	huge delicious piece of wedding cake	6	awesome	
 263	flavorless chocolate chips	4	decent	
 264	moldy narrow chocolate chip cookies	3	crappy	
 265	lion tamer's satin pants	0		Experience (familiar): +2, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -294,10 +294,10 @@
 296	olive dungeoneer's dungarees of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "stench atk, 4xPotato, cap 7"
 297	super-flattened flattened tamarind-flavored chewing gum	0		Effect: "Bureaucratized", Effect Duration: 55
 298	unsweetened maroon lime-and-chile-flavored chewing gum	0		Effect: "Human-Constellation Hybrid", Effect Duration: 67
-299	quadruple-oxidized ionized mirror bouncing blinking pickle-flavored chewing gum	0		Effect: "Coming Up Roses", Effect Duration: 65
+299	quadruple-oxidized ionized blinking mirror bouncing pickle-flavored chewing gum	0		Effect: "Coming Up Roses", Effect Duration: 65
 300	non-corrupted non-galvanized pulsating jaba&ntilde;ero-flavored chewing gum	0		Effect: "Starry-Eyed", Effect Duration: 15
 301	lime green flat dough	0		
-302	miniature stale special Knob sausage	2	decent	Effect: "substats.enh", Effect Duration: 25
+302	stale special miniature Knob sausage	2	decent	Effect: "substats.enh", Effect Duration: 25
 303	spoiled diet yellow Knob mushroom	1	crappy	
 304	dry noodles	0		
 305	greasy Knob Goblin harem pants	0		Sleaze Spell Damage: +10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -309,25 +309,25 @@
 311	blinking hill of beans	0		
 312	Rosewater's Knob Goblin visor	0		Mysticality Percent: +30, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	savvy Crown of the Goblin King	0		Mysticality Percent: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	bite-sized decent bean burrito	1	good	
+314	decent bite-sized bean burrito	1	good	
 315	spoiled half-sized huge bean burrito	2	crappy	
 316	normal insanely bean burrito	3	good	
 317	flavorless bean burrito	3	decent	
 318	flavorless jittery bean burrito	3	decent	
 319	small delicious blinking insanely bean burrito	2	awesome	
 320	delicious cyan bat haggis	3	awesome	
-321	tiny yummy menudo	1	awesome	
+321	yummy tiny menudo	1	awesome	
 322	spoiled goat cheese	3	crappy	
 323	adequate super-sized spinning plain pizza	5	good	
 324	normal super-sized spinning sausage pizza	5	good	
 325	bland goat cheese pizza	3	decent	
 326	stale mushroom pizza	3	decent	
 327	goat	0		
-328	aged weak green bottle of whiskey	2	awesome	
+328	weak aged green bottle of whiskey	2	awesome	
 329	blurry double-paned goat beard	0		Cold Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 15"
 330	maroon glass of goat's milk	1	decent	
-331	special hand-crafted practically non-alcoholic Canadian	1	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 10
-332	stale diet lemon	1	decent	
+331	practically non-alcoholic hand-crafted special Canadian	1	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 10
+332	diet stale lemon	1	decent	
 333	spoiled snack-sized lime	2	crappy	
 334	tumbling ribald sabre teeth	0		Sleaze Damage: +10
 335	maroon sabre-toothed lime cub	0		
@@ -389,7 +389,7 @@
 391	linoleum helmet turtle of doom	0		Spooky Spell Damage: +50, Familiar Effect: "stench atk, 1xFairy, cap 25"
 392	chrome helmet turtle of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "cold atk, 1xFairy, cap 30"
 393	pulsating penguin skin	0		
-394	cyan squat yak skin	0		
+394	squat cyan yak skin	0		
 395	hippopotamus skin	0		
 396	lime green resourceful penguin shorts	0		Maximum MP: +50, Familiar Effect: "cold atk, 1xGhuol, cap 30"
 397	blurry shellacked yakskin pants	0		Damage Reduction: 7, Familiar Effect: "stench atk, 1xPotato, cap 35"
@@ -447,7 +447,7 @@
 449	jittery friendly clown nose	0		Familiar Weight: +3, Clowniness: 25
 450	huge pretentious paintbrush	0		
 451	bouncing pretentious palette	0		
-452	cyan blinking bouncing disease	0		
+452	blinking cyan bouncing disease	0		
 453	sober pill	0		
 454	mirror screwdriver	0		
 455	adequate jumbo olive	3	good	
@@ -465,13 +465,13 @@
 467	flavorless pixel pie	3	decent	
 468	huge ruby W	0		
 469	wussiness potion	0		
-470	artisanal fancy wobbly jittery Imp Ale	3	EPIC	Effect: "Drunk With Power", Effect Duration: 45
+470	artisanal fancy jittery wobbly Imp Ale	3	EPIC	Effect: "Drunk With Power", Effect Duration: 45
 471	normal hot wing	3	good	
 472	family-friendly diamond-studded cane	0		Sleaze Resistance: +1, Class: "Disco Bandit"
 473	smartaleck's crutch	0		Moxie Percent: +30
 474	cast	0		
 475	fuchsia MacGyver's mask of the businessman	0		Maximum MP: +100, Meat Drop: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 15"
-476	shaking tumbling hellion cube	0		
+476	tumbling shaking hellion cube	0		
 477	fuchsia curative infernal insoles of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5
 478	pulsating evil arch	0		
 479	yellow dodecagram	0		
@@ -480,7 +480,7 @@
 482	pulsating Tesla Mr. Container	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2004-12"
 483	mirror narrow Newbiesport&trade; backpack of the sewer	0		Stench Damage: +25, Last Available: "2004-12"
 484	scandalous hemp backpack	0		Sleaze Damage: +5, Last Available: "2004-12"
-485	huge huge shaking snakehead charrrm	0		
+485	huge shaking huge snakehead charrrm	0		
 486	huge mansplainer's Talisman o' Namsilat	0		Monster Level: +15, Single Equip
 487	resourceful arrrgyle socks	0		Maximum MP: +50
 488	guitar pick	0		
@@ -493,12 +493,12 @@
 495	catgut	0		
 496	green cat appendix	0		
 497	gnatwing	0		
-498	massive decent spinning papaya	9	good	
+498	decent massive spinning papaya	9	good	
 499	skewed gravedigger's denim axe of chilblains	0		Cold Damage: +25, Spooky Damage: +10
 500	ghostly bouncing Elf Farm Raffle ticket	0		
 501	rotten half-sized blue Elfin shortbread	2	crappy	
 502	pagoda plans	0		
-503	tiny decent skewered cat appendix	1	good	
+503	decent tiny skewered cat appendix	1	good	
 504	purple evil arches	0		
 505	auspicious censurious gnatwing earring	0		Sleaze Resistance: +3, Item Drop: +10
 506	adequate tumbling Hell broth	4	good	
@@ -538,7 +538,7 @@
 540	liquefied wet pulsating Tasty Fun Good rice candy	0		Effect: "Extra Terrestrial", Effect Duration: 38
 541	MacGyver's arcane researcher's draggin' ball hat	0		Experience Percent (Mysticality): +10, Maximum MP: +100, Familiar Effect: "atk, 1xVolley, cap 25"
 542	careful experienced 1337 7r0uZ0RZ	0		Experience: +2, Monster Level: -10, Familiar Effect: "2xPotato, cap 27"
-543	spoiled snack-sized narrow purple Trollhouse cookies	2	crappy	
+543	spoiled snack-sized purple narrow Trollhouse cookies	2	crappy	
 544	lime green foul-smelling studded talons	0		Damage Absorption: +80, Stench Damage: +10
 545	rotten Spam Witch sammich	3	crappy	
 546	shaking tumbling green meat vortex	0		
@@ -553,7 +553,7 @@
 555	sizzling drywall axe of the early riser	0		Hot Damage: +10, Adventures: +7
 556	Pine-Fresh air freshener of the sweet-tooth	0		Candy Drop: +100
 557	irresponsibly strong tolerable whiskey and cola	8	good	
-558	immense bland papaya taco	10	decent	
+558	bland immense papaya taco	10	decent	
 559	blurry razor-sharp can lid	0		
 560	jumbo stale stalk of asparagus	5	decent	
 561	mirror pregnant mushroom	0		
@@ -565,9 +565,9 @@
 567	hermit script	0		
 568	immense adequate Double Bacon Beelzeburger	6	good	
 569	rotten Lord of the Flies-sized fries	3	crappy	
-570	moldy tiny Chicken Sandwich	1	crappy	
+570	tiny moldy Chicken Sandwich	1	crappy	
 571	Jumbo Dr. Lucifer	1	decent	
-572	fancy tasty jittery Children's Meal of the Damned	3	awesome	Effect: "Heart of Green", Effect Duration: 10
+572	tasty fancy jittery Children's Meal of the Damned	3	awesome	Effect: "Heart of Green", Effect Duration: 10
 573	bland noodles	3	decent	
 574	tasty spinning noodles	3	awesome	
 575	flavorless painful penne pasta	3	decent	
@@ -580,11 +580,11 @@
 582	Himalayan Hidalgo sauce	0		
 583	stale blinking fettucini Inconnu	3	decent	
 584	stale spaghetti with Skullheads	3	decent	
-585	decent red squat gnocchetti di Nietzsche	3	good	
+585	decent squat red gnocchetti di Nietzsche	3	good	
 586	fortified ridiculously huge sword of the cheetah	0		Damage Absorption: +60, Initiative: +60
 587	non-activated moist polarized super-spiky hair gel	0		Effect: "Familial Ties", Effect Duration: 34
 588	pulsating soft echo eyedrop antidote	0		
-589	fancy adequate mirror mirror cocoa eggshell fragment	3	good	Effect: "Ode to Booze", Effect Duration: 45
+589	adequate fancy mirror mirror cocoa eggshell fragment	3	good	Effect: "Ode to Booze", Effect Duration: 45
 590	rotten cocoa eggshell fragment	4	crappy	
 591	cocoa egg	0		
 592	green house	0		
@@ -634,9 +634,9 @@
 636	meat globe	0		
 637	squat toaster	0		
 638	maroon rosewater-soaked asshat of terror	0		Spooky Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	diet adequate abominable snowcone	1	good	
+639	adequate diet abominable snowcone	1	good	
 640	shaking blue Ent cider	1	awesome	
-641	bite-sized rotten huge toast	1	crappy	
+641	rotten bite-sized huge toast	1	crappy	
 642	jittery skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
@@ -649,7 +649,7 @@
 651	purple exclusive ultra-rare item of mayonnaise	0		Sleaze Spell Damage: +50
 652	mirror quantum egg	0		
 653	intragalactic rowboat	0		
-654	blurry wobbly star	0		
+654	wobbly blurry star	0		
 655	pulsating line	0		
 656	star chart	0		
 657	miser's star sword	0		Meat Drop: +10
@@ -669,7 +669,7 @@
 671	rock-hard personal trainer's grave robbing shovel	0		Experience Percent (Muscle): +10, Damage Reduction: 5
 672	big tasty cranberries	5	awesome	
 673	drinkable vodka and cranberry	3	good	
-674	enchanted weak lousy whiskey	2	decent	Effect: "Fudgehound", Effect Duration: 25
+674	lousy weak enchanted whiskey	2	decent	Effect: "Fudgehound", Effect Duration: 25
 675	Van der Graaf skull of the Bonerdagon	0		MP Regen Min: 5, MP Regen Max: 7
 676	dragonbone belt buckle	0		
 677	maroon Tesla badass belt	0		MP Regen Min: 7, MP Regen Max: 10
@@ -682,7 +682,7 @@
 684	irresponsibly strong delicious pink pony	7	awesome	
 685	wholesome dangerous Mr. Shirt of temperance	0		Weapon Damage: +10, Maximum HP Percent: +10, Sleaze Resistance: +5
 686	red knuckles of the cheetah	0		Initiative: +60
-687	extra-aerosolized blurry pulsating red blood of the Wereseal	0		Effect: "Polar Express", Effect Duration: 14
+687	extra-aerosolized pulsating red blurry blood of the Wereseal	0		Effect: "Polar Express", Effect Duration: 14
 688	pixel hat of the cougar	0		Moxie: +20, Familiar Effect: "atk, 2xVolley, cap 12"
 689	studded pixel pants	0		Damage Absorption: +80, Familiar Effect: "atk, 4xPotato, cap 12"
 690	pixel sword of the brute	0		Muscle Percent: +30
@@ -699,7 +699,7 @@
 702	narrow lion tamer's coconut bikini top	0		Experience (familiar): +2
 703	teal Herculean goth kid t-shirt	0		Experience (Muscle): +1
 704	hamethyst	0		
-705	fuchsia wobbly baconstone	0		
+705	wobbly fuchsia baconstone	0		
 706	porquoise	0		
 707	narrow pork elf goodies sack	0		
 708	ring setting	0		
@@ -716,7 +716,7 @@
 720	olive lightning-fast forbidden porquoise necklace	0		Spell Damage Percent: +50, Initiative: +40, Single Equip
 721	huge huge aromatic porquoise bracelet	0		Stench Resistance: +1, Item Drop: +5
 722	toasty stiffened Rosewater's porquoise ring	0		Mysticality Percent: +30, Damage Reduction: 1, Hot Damage: +5, Single Equip
-723	miniature normal fancy Knoll mushroom	2	good	Effect: "All Is Forgiven", Effect Duration: 30
+723	normal fancy miniature Knoll mushroom	2	good	Effect: "All Is Forgiven", Effect Duration: 30
 724	tasty small mushroom	2	awesome	
 725	one million meat pancakes	0		
 726	greedy huge mirror shard	0		Meat Drop: +20
@@ -726,7 +726,7 @@
 730	wobbly fishtank	0		
 731	fish hose	0		
 732	upside-down hosed tank	0		
-733	blue wobbly hosed fishbowl	0		
+733	wobbly blue hosed fishbowl	0		
 734	mansplainer's razor-sharp makeshift SCUBA gear of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +25, Monster Level: +15, Adventure Underwater
 735	curative easter egg balloon	0		HP Regen Min: 3, HP Regen Max: 5
 736	stone tablet (Sinister Strumming)	0		
@@ -741,20 +741,20 @@
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	decent bite-sized warm mushroom	1	good	
+749	bite-sized decent warm mushroom	1	good	
 750	bland mushroom quesadilla	3	decent	
 751	spoiled cool mushroom	3	crappy	
 752	diet flavorless gray cool mushroom casserole	1	decent	
 753	adequate lime green pointy mushroom	4	good	
 754	moldy cream of pointy mushroom soup	4	crappy	
-755	special decent pulsating upside-down mushroom	3	good	Effect: "Tiki Temerity", Effect Duration: 15
-756	spoiled massive mushroom	10	crappy	
+755	special decent upside-down pulsating mushroom	3	good	Effect: "Tiki Temerity", Effect Duration: 15
+756	massive spoiled mushroom	10	crappy	
 757	decent blurry mushroom	3	good	
-758	bland small ghost cucumber	2	decent	
-759	blue blinking dill	0		
+758	small bland ghost cucumber	2	decent	
+759	blinking blue dill	0		
 760	vinegar	0		
 761	brine	0		
-762	perfectly mixed practically non-alcoholic especially salty dog	1	super ultra mega turbo EPIC	
+762	practically non-alcoholic perfectly mixed especially salty dog	1	super ultra mega turbo EPIC	
 763	ghostly pickling solution	0		
 764	toothsome squat spectral pickle	3	awesome	
 765	briny vinegar	0		
@@ -776,37 +776,37 @@
 781	energized tarnished ionized mafia aria	0		Effect: "Bandersnatched", Effect Duration: 39
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	distilled lousy spinning upside-down spinning Acqua Del Piatto Merlot	5	decent	Last Available: "2004-10"
+784	distilled lousy upside-down spinning spinning Acqua Del Piatto Merlot	5	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	flavorless strawberry	3	decent	
 787	tolerable watered-down lime green bottle of rum	2	good	
-788	weak perfectly mixed special strawberry daiquiri	2	EPIC	Effect: "Dragged Through the Coals", Effect Duration: 45
+788	special perfectly mixed weak strawberry daiquiri	2	EPIC	Effect: "Dragged Through the Coals", Effect Duration: 45
 789	acceptable lime green rum and cola	3	good	
 790	mediocre jittery grog	3	decent	
 791	skewed blinking crafty Mafia bow tie of courage	0		Maximum MP: +10, Spooky Resistance: +3, Last Available: "2004-10"
 792	twirling Sinatra's Golden Mr. Accessory	0		Experience (Moxie): +5, Softcore Only
-793	denatured mirror olive oil of stability	0		Effect: "Floundering", Effect Duration: 57
+793	denatured olive mirror oil of stability	0		Effect: "Floundering", Effect Duration: 57
 794	concentrated chilled quantum blinking oil of slipperiness	0		Effect: "Discomfited", Effect Duration: 29
 795	tolerable yellow Acque Luride Grezze Cabernet	3	good	Last Available: "2004-10"
 796	lime green huge Usain Bolt's lard-coated curative cement shoes	0		Sleaze Spell Damage: +25, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10"
-797	hand-crafted upside-down ghostly rockin' wagon	3	EPIC	
-798	perfectly mixed spirit-forward blinking ocean motion	5	EPIC	
-799	fancy high-proof lousy narrow fuzzbump	6	decent	Effect: "Trash-Wrapped", Effect Duration: 25
+797	hand-crafted ghostly upside-down rockin' wagon	3	EPIC	
+798	spirit-forward perfectly mixed blinking ocean motion	5	EPIC	
+799	fancy lousy high-proof narrow fuzzbump	6	decent	Effect: "Trash-Wrapped", Effect Duration: 25
 800	bite-sized decent poutine	1	good	
 801	normal huge Knob stir-fry	6	good	
 804	spoiled snack-sized Knoll stir-fry	2	crappy	
 805	spoiled stir-fry	3	crappy	
 806	stale squat asparagus stir-fry	3	decent	
-807	fancy snack-sized stale cyan olive stir-fry	2	decent	Effect: "Fizzier Than Light", Effect Duration: 20
+807	snack-sized stale fancy cyan olive stir-fry	2	decent	Effect: "Fizzier Than Light", Effect Duration: 20
 808	spoiled Knob sausage stir-fry	3	crappy	
 809	decent bat wing stir-fry	3	good	
 810	rotten maroon rat appendix stir-fry	3	crappy	
-811	snack-sized spoiled tofu stir-fry	2	crappy	
-812	big decent pr0n stir-fry	5	good	
+811	spoiled snack-sized tofu stir-fry	2	crappy	
+812	decent big pr0n stir-fry	5	good	
 813	bland Knob shells	4	decent	
 814	decent half-sized olive b&auml;tzle	2	good	
-815	massive rotten ratini	10	crappy	
-816	flavorless small Knob stroganoff	2	decent	
+815	rotten massive ratini	10	crappy	
+816	small flavorless Knob stroganoff	2	decent	
 817	flavorless menudo ravioli	4	decent	
 818	plus sign	0		
 819	twirling milky potion	0		
@@ -820,7 +820,7 @@
 827	murky potion	0		
 828	twirling baby killer bee	0		
 829	anti-anti-antidote	0		
-830	super-sized adequate royal jelly	5	good	
+830	adequate super-sized royal jelly	5	good	
 831	gray small box	0		
 832	olive upside-down box	0		
 833	deadly vorpal blade	0		Weapon Damage: +5
@@ -834,7 +834,7 @@
 841	hand-crafted tomato daiquiri	4	EPIC	
 842	drinkable beertini	4	good	
 843	high-proof mediocre green salty slug	10	decent	
-844	aged weak squat papaya slung	2	awesome	
+844	weak aged squat papaya slung	2	awesome	
 845	gray MAHI fez of the empath	0		Familiar Weight: +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	spinning heteroerotic frat-paddle	0		
 848	twirling hypodermic needle	0		Familiar Weight: +5
@@ -857,7 +857,7 @@
 865	twirling lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	liquefied pine tar	0		Effect: "Cold, Dead Hands", Effect Duration: 25
-869	pulsating huge forest tears	0		
+869	huge pulsating forest tears	0		
 870	wobbly Fonzie's fetus-smashing club	0		Experience (Moxie): +1
 871	meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
@@ -893,13 +893,13 @@
 902	wobbly 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	smooth Spasmi Dolorosi Del Rene Champagne	4	awesome	Last Available: "2004-10"
 904	supercool beefy school Mafia knickerbockers of the cheetah	0		Muscle: +10, Moxie Percent: +20, Initiative: +60, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
-905	altered dry fuchsia tumbling ghostly squat Yummy Tummy bean	0		Effect: "Inappropriate Spirit", Effect Duration: 57
+905	altered dry fuchsia tumbling squat ghostly Yummy Tummy bean	0		Effect: "Inappropriate Spirit", Effect Duration: 57
 906	boiled Rock Pops	0		Effect: "Pyramid Power", Effect Duration: 54
 907	activated vacuum-sealed Mr. Mediocrebar	0		Effect: "Vitamin-Maxed", Effect Duration: 16
 908	chilled quantum energized pulsating Cold Hots candy	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 15
 909	non-pressed Wint-O-Fresh mint	0		Effect: "Piratey Flavor", Effect Duration: 16
 910	normal small huge dwarf bread	2	good	
-911	flattened blinking maroon Senior Mints	0		Effect: "Wreathed in Smoke", Effect Duration: 56
+911	flattened maroon blinking Senior Mints	0		Effect: "Wreathed in Smoke", Effect Duration: 56
 912	concentrated pixellated candy heart	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 39
 913	cold-filtered adjusted olive kobold	0		Effect: "Hare-o-dynamic", Effect Duration: 55
 914	maroon hand turkey outline	0		Free Pull, Last Available: "2004-11"
@@ -909,7 +909,7 @@
 918	pulsating stanky Radio Free Baseball Cap	0		Stench Spell Damage: +25, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	manspreader's Radio Free Pants	0		Monster Level: +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	maroon personal trainer's Radio Free Foil	0		Experience Percent (Muscle): +10, Last Available: "2006-07"
-921	rotten snack-sized radio button candy	2	crappy	
+921	snack-sized rotten radio button candy	2	crappy	
 922	groovy severed rocking horse head	0		Moxie Percent: +10
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -918,7 +918,7 @@
 927	smooth Ferita Del Petto Zinfandel	4	awesome	Last Available: "2006-12"
 928	extremely unsafe fuzzy bracelets	0		Weapon Damage Percent: +100
 929	arse-shooting crossbow of courage	0		Spooky Resistance: +3
-931	spirit-forward smooth spiced rum	5	awesome	
+931	smooth spirit-forward spiced rum	5	awesome	
 932	drinkable practically non-alcoholic eggnog	1	good	
 933	enchanted rotten small candy cane	2	crappy	Effect: "Pie in the Sky", Effect Duration: 25
 934	stale bouncing gingerbread bugbear	4	decent	
@@ -936,15 +936,15 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	delicious high-proof martini	9	awesome	Last Available: "2004-12"
-949	bad weak grogtini	2	decent	Last Available: "2004-12"
-950	fortified tolerable red jittery cherry bomb	5	good	Last Available: "2004-12"
+949	weak bad grogtini	2	decent	Last Available: "2004-12"
+950	fortified tolerable jittery red cherry bomb	5	good	Last Available: "2004-12"
 951	bouncing extra special Crimbo stocking	0		Last Available: "2004-12"
 952	knitted foul-smelling hockey mask	0		Stench Damage: +10, Cold Resistance: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	cyan upside-down mirror orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	hardy fez of etymology	0		Maximum HP: +50, Familiar Effect: "1xLep, cap 30"
 956	spoiled carob chunk noodles	4	crappy	
-957	bland massive skewed chorizo brownies	8	decent	
+957	massive bland skewed chorizo brownies	8	decent	
 958	spoiled chocolate and tomato pizza	3	crappy	
 959	squat flange	0		
 960	cyan clockwork key	0		
@@ -983,32 +983,32 @@
 993	fortified plastic Sneaky Pete of extreme caution of the glutton	0		Damage Absorption: +60, Monster Level: -25, Food Drop: +100
 994	quilted plastic Susie	0		Damage Absorption: +40
 995	adequate Lucky Surprise Egg	3	good	
-998	mirror wobbly maiden wig	0		Familiar Effect: "2xPotato, cap 8"
+998	wobbly mirror maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	gray maid head	0		
 1000	green Meat maid	0		
 1002	tumbling Oprah's Xlyinia's notebook	0		Maximum MP Percent: +50
 1003	soda water	0		
-1004	acceptable practically non-alcoholic maroon bottle of tequila	1	good	
+1004	practically non-alcoholic acceptable maroon bottle of tequila	1	good	
 1005	perfectly mixed boxed wine	3	EPIC	
 1006	moldy maroon cherry	3	crappy	
 1007	curative coconut shell	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xFairy, cap 7"
 1008	wicked ice cubes	0		Spell Damage: +5
 1009	lousy vodka martini	3	decent	
 1010	weak mediocre whiskey and soda	2	decent	
-1011	triple-distilled perfectly mixed monkey wrench	6	EPIC	
+1011	perfectly mixed triple-distilled monkey wrench	6	EPIC	
 1012	smooth tequila sunrise	4	awesome	
 1013	strong mediocre bouncing margarita	5	decent	
 1014	acceptable strawberry wine	4	good	
 1015	artisanal wine spritzer	3	EPIC	
-1016	watered-down mediocre perpendicular hula	2	decent	
-1017	hand-crafted fancy ducha de oro	3	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 20
+1016	mediocre watered-down perpendicular hula	2	decent	
+1017	fancy hand-crafted ducha de oro	3	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 20
 1018	bad maroon calle de miel	3	decent	
-1019	mediocre watered-down blurry dry vodka martini	2	decent	
-1020	artisanal enchanted old-fashioned	3	EPIC	Effect: "Mer-kinny Flavor", Effect Duration: 50
+1019	watered-down mediocre blurry dry vodka martini	2	decent	
+1020	enchanted artisanal old-fashioned	3	EPIC	Effect: "Mer-kinny Flavor", Effect Duration: 50
 1021	drinkable jittery tequila with training wheels	4	good	
 1022	practically non-alcoholic delicious sangria	1	awesome	
 1023	smooth vesper	3	awesome	Last Available: "2004-12"
-1024	irresponsibly strong delicious bodyslam	8	awesome	Last Available: "2004-12"
+1024	delicious irresponsibly strong bodyslam	8	awesome	Last Available: "2004-12"
 1025	artisanal sangria del diablo	3	super ultra EPIC	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
@@ -1024,7 +1024,7 @@
 1037	perfumed gnauga hide buckler	0		Stench Resistance: +5, Damage Reduction: 5
 1038	extra-concentrated super-deionized bouncing Connery's Elixir of Audacity	0		Effect: "Spookyravin'", Effect Duration: 49
 1040	mirror Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	triple-distilled acceptable jittery beer	7	good	
+1041	acceptable triple-distilled jittery beer	7	good	
 1042	huge shaking blue steel-toed string of beads	0		Damage Reduction: 9
 1043	pulsating grievous string of beads	0		Weapon Damage Percent: +50
 1044	shellacked string of beads	0		Damage Reduction: 7
@@ -1033,10 +1033,10 @@
 1047	spirit-forward drinkable N. O. Beer	5	good	
 1048	boiled oyster egg	1		Effect: "Alacri Tea", Effect Duration: 45
 1049	pickled fuchsia oyster egg	1		
-1050	diluted upside-down tumbling oyster egg	1		
+1050	diluted tumbling upside-down oyster egg	1		
 1051	jittery teal plastic oyster egg	0		
 1052	distilled oyster egg	1		
-1053	compressed narrow gray shaking oyster egg	1		
+1053	compressed shaking narrow gray oyster egg	1		
 1054	compressed spinning oyster egg	1		
 1055	plastic oyster egg	0		
 1056	vaporized mirror puce oyster egg	1		
@@ -1048,7 +1048,7 @@
 1062	dehydrated mauve oyster egg	1		
 1063	purple mauve plastic oyster egg	0		
 1064	compressed oyster egg	1		
-1065	vaporized purple blurry spinning oyster egg	1		
+1065	vaporized purple spinning blurry oyster egg	1		
 1066	dried maroon oyster egg	1		Effect: "Employee of the Month", Effect Duration: 35
 1067	plastic oyster egg	0		
 1068	altered huge oyster egg	1		
@@ -1057,9 +1057,9 @@
 1071	blinking plastic oyster egg	0		
 1072	dried off-white oyster egg	1		Effect: "Heart of White", Effect Duration: 50
 1073	dehydrated jittery narrow off-white oyster egg	1		Effect: "Super-Mega-Charged", Effect Duration: 25
-1074	dehydrated bouncing ghostly maroon off-white oyster egg	1		Effect: "Altered Wavelengths", Effect Duration: 35
+1074	dehydrated bouncing maroon ghostly off-white oyster egg	1		Effect: "Altered Wavelengths", Effect Duration: 35
 1075	off-white plastic oyster egg	0		
-1076	dried cyan blinking squat oyster egg	1		
+1076	dried blinking squat cyan oyster egg	1		
 1077	compressed mirror oyster egg	1		
 1078	dried blue tumbling oyster egg	1		
 1079	plastic oyster egg	0		
@@ -1089,7 +1089,7 @@
 1103	bouncing unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
-1106	yellow huge clockwork chef head	0		
+1106	huge yellow clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	clockwork detective skull	0		
 1109	squat red clockwork bartender-head-in-the-box	0		
@@ -1121,7 +1121,7 @@
 1135	electrified colloidal diffused eyeliner	0		Effect: "Healthy Blue Glow", Effect Duration: 15
 1136	denatured lipstick	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 15
 1137	banded bicycle chain of the pedagogue	0		Experience: +3, Damage Absorption: +100
-1138	blinking jittery bouncing lime green mushroom fermenting solution	0		
+1138	bouncing blinking lime green jittery mushroom fermenting solution	0		
 1139	drinkable mushroom wine	3	good	
 1140	hand-crafted upside-down icy mushroom wine	3	EPIC	
 1141	perfectly mixed extra-dry mushroom wine	5	EPIC	
@@ -1129,10 +1129,10 @@
 1143	tolerable mirror flat mushroom wine	3	good	
 1144	fortified mediocre upside-down cool mushroom wine	5	decent	
 1145	drinkable triple-distilled knob mushroom wine	9	good	
-1146	artisanal watered-down knoll mushroom wine	2	EPIC	
-1147	fancy hand-crafted irresponsibly strong teal mushroom wine	9	EPIC	Effect: "Virgo Rising", Effect Duration: 30
-1148	artisanal spirit-forward shot of flower schnapps	5	EPIC	
-1149	tasty miniature flower petal pie	2	awesome	
+1146	watered-down artisanal knoll mushroom wine	2	EPIC	
+1147	hand-crafted fancy irresponsibly strong teal mushroom wine	9	EPIC	Effect: "Virgo Rising", Effect Duration: 30
+1148	spirit-forward artisanal shot of flower schnapps	5	EPIC	
+1149	miniature tasty flower petal pie	2	awesome	
 1150	mediocre special cyan bottle of single-barrel whiskey	3	decent	Effect: "Good with the Ladies", Effect Duration: 5
 1151	sharpshooter's discarded plastic fork of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +10
 1152	narrow gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1149,7 +1149,7 @@
 1164	poultrygeist	0		
 1165	hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
-1167	blurry fuchsia plain brown wrapper	0		
+1167	fuchsia blurry plain brown wrapper	0		
 1168	ghostly less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
 1170	chocolate box	0		
@@ -1184,11 +1184,11 @@
 1199	bugbear	0		
 1200	spoiled mugcake	3	crappy	
 1201	flavorless urinal cake	4	decent	
-1202	thick adequate Happy Birthday, Claude! cake	5	good	
+1202	adequate thick Happy Birthday, Claude! cake	5	good	
 1203	bland personalized birthday cake	4	decent	
 1204	adequate small three-tiered wedding cake	2	good	
 1205	bland babycakes	3	decent	
-1206	decent small mirror velvet cake	2	good	
+1206	small decent mirror velvet cake	2	good	
 1207	flavorless shaking congratulatory cake	3	decent	
 1208	normal angel-food cake	4	good	
 1209	tasty devil's-food cake	4	awesome	
@@ -1199,7 +1199,7 @@
 1214	blurry ghostly anniversary balloon	0		
 1215	lime green Mylar balloon	0		
 1216	ghostly Kevlar balloon	0		
-1217	skewed ghostly squat thought balloon	0		
+1217	skewed squat ghostly thought balloon	0		
 1218	skewed spinning rat head balloon	0		Familiar Weight: -3
 1219	skewed mini-zeppelin	0		
 1220	supercool Mr. Balloon	0		Moxie Percent: +20
@@ -1232,8 +1232,8 @@
 1248	narrow sizzling crafty rock-hard Bonerdagon necklace	0		Damage Reduction: 5, Maximum MP: +10, Hot Damage: +10
 1249	medical-grade Boss Bat britches	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	frosty careful Boss Bat bling	0		Monster Level: -10, Cold Spell Damage: +10
-1251	tiny spoiled Knob shroomkabob	1	crappy	
-1252	tiny delicious shroomkabob	1	awesome	
+1251	spoiled tiny Knob shroomkabob	1	crappy	
+1252	delicious tiny shroomkabob	1	awesome	
 1253	bouncing pile of jumping beans	0		
 1254	spoiled jumping bean burrito	3	crappy	
 1255	half-sized adequate blinking jumping bean burrito	2	good	
@@ -1247,7 +1247,7 @@
 1263	blurry pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	enchanted bite-sized stale gloomy mushroom	1	decent	Effect: "Hood Ridin'", Effect Duration: 20
+1266	enchanted stale bite-sized gloomy mushroom	1	decent	Effect: "Hood Ridin'", Effect Duration: 20
 1267	pulsating dead mimic	0		
 1268	pine wand	0		
 1269	pulsating ebony wand	0		
@@ -1255,7 +1255,7 @@
 1271	aluminum wand	0		
 1272	marble wand	0		
 1273	spinning therapeutic magic lamp	0		HP Regen Min: 5, HP Regen Max: 7
-1274	denatured huge spinning Medicinal Herb's medicinal herbs	1		
+1274	denatured spinning huge Medicinal Herb's medicinal herbs	1		
 1275	electrified basic meat skirt	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	acceptable Otorian Battle Scar	4	good	
 1277	educational basic meat kilt	0		Experience: +1, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1301,7 +1301,7 @@
 1317	blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	moldy special diet questionable taco	1	crappy	Effect: "You Read The Manual", Effect Duration: 30
+1320	diet moldy special questionable taco	1	crappy	Effect: "You Read The Manual", Effect Duration: 30
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	auspicious time helmet	0		Item Drop: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
@@ -1332,12 +1332,12 @@
 1349	fuchsia miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	purple 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	grievous pinky ring	0		Weapon Damage Percent: +50, Single Equip
-1352	irresponsibly strong drinkable redrum	6	good	
+1352	drinkable irresponsibly strong redrum	6	good	
 1353	ninja pirate zombie robot	0		
-1354	blinking maroon pile of pebbles	0		
-1355	spoiled half-sized bowl of oriole's nest soup	2	crappy	
+1354	maroon blinking pile of pebbles	0		
+1355	half-sized spoiled bowl of oriole's nest soup	2	crappy	
 1356	bunny liver	0		
-1357	lousy irresponsibly strong squat wobbly Mt. Noob Pale Ale	8	decent	
+1357	irresponsibly strong lousy wobbly squat Mt. Noob Pale Ale	8	decent	
 1358	squat pirate zombie head	0		Last Available: "2005-11"
 1359	bouncing ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1363,8 +1363,8 @@
 1381	aspirin	0		Last Available: "2005-12"
 1382	extra-galvanized cold-filtered chocolate	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 51, Last Available: "2015-11"
 1383	length of string	0		
-1384	squat fuchsia googly eye	0		
-1385	yellow narrow stuffing	0		
+1384	fuchsia squat googly eye	0		
+1385	narrow yellow stuffing	0		
 1386	lime green felt	0		
 1387	block	0		
 1388	toy wheel	0		
@@ -1377,7 +1377,7 @@
 1395	teddy bear	0		Last Available: "2005-12"
 1396	pulsating Jim Carey's brawny duck-on-a-string	0		Muscle Percent: +20, Monster Level: +25, Last Available: "2005-12"
 1397	toy soldier	0		Last Available: "2005-12"
-1398	wobbly ghostly doll house	0		Last Available: "2005-12"
+1398	ghostly wobbly doll house	0		Last Available: "2005-12"
 1399	Lo Pan's toy train	0		Spell Critical Percent: +30, Single Equip, Last Available: "2005-12"
 1400	bouncing wizardly marionette	0		Mysticality: +25, Last Available: "2005-12"
 1401	sock monkey of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2005-12"
@@ -1387,7 +1387,7 @@
 1405	cool tree skirt	0		Moxie: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	normal diet wreath-shaped Crimbo cookie	1	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	delicious spinning bell-shaped Crimbo cookie	4	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	low-calorie decent twirling tree-shaped Crimbo cookie	1	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	decent low-calorie twirling tree-shaped Crimbo cookie	1	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	zippy Unionize The Elves sign	0		Initiative: +20, Last Available: "2005-12"
 1410	ghostly sleeping snowy owl	0		Last Available: "2005-12"
 1411	pulsating Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
@@ -1400,7 +1400,7 @@
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
 1420	Sinatra's traffic cone of James Dean	0		Experience (Moxie): 8, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1421	blinking mirror red Scandalously Skimpy Bikini	0		Four Songs, Single Equip
+1421	mirror red blinking Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	executive quilted ice sickle	0		Damage Absorption: +40, Meat Drop: +40, Softcore Only, Last Available: "2006-02"
@@ -1411,7 +1411,7 @@
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	fancy bland mushroom	4	decent	Effect: "Filled with Magic", Effect Duration: 30
+1432	bland fancy mushroom	4	decent	Effect: "Filled with Magic", Effect Duration: 30
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1424,7 +1424,7 @@
 1442	enhanced extra-energized maroon stench powder	0		Effect: "Adventurer's Best Friendship", Effect Duration: 51
 1443	moist teal sleaze powder	0		Effect: "The Magic of Sharing", Effect Duration: 46
 1444	alkaline green twinkly nuggets	0		Effect: "You Can Taste the Darkness", Effect Duration: 37
-1445	colloidal cold-filtered energized jittery cyan hot nuggets	0		Effect: "Livin' Large", Effect Duration: 54
+1445	colloidal cold-filtered energized cyan jittery hot nuggets	0		Effect: "Livin' Large", Effect Duration: 54
 1446	modified colloidal squat nuggets	0		Effect: "Crotchety, Pining", Effect Duration: 69
 1447	polarized super-magnetized boiled twirling nuggets	0		Effect: "Billiards Belligerence", Effect Duration: 42
 1448	vacuum-sealed extra-wet upside-down stench nuggets	0		Effect: "Ham-Fisted", Effect Duration: 15
@@ -1437,7 +1437,7 @@
 1455	distilled squat blurry skewed sleaze wad	1		
 1456	huge double daisy	0		
 1457	Goth Giant	0		
-1458	decent diet Valentine's Day cake	1	good	
+1458	diet decent Valentine's Day cake	1	good	
 1459	shaking arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1486,16 +1486,16 @@
 1504	improved improved skewed snowcone	0		Effect: "Slimed Stomach", Effect Duration: 34, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	aged calle de miel with a fly in it	3	awesome	Last Available: "2006-04"
-1507	hand-crafted weak rockin' wagon with a fly in it	2	EPIC	Last Available: "2006-04"
+1507	weak hand-crafted rockin' wagon with a fly in it	2	EPIC	Last Available: "2006-04"
 1508	perfectly mixed perpendicular hula with a fly in it	3	EPIC	Last Available: "2006-04"
-1509	drinkable practically non-alcoholic slap and tickle with a fly in it	1	good	Last Available: "2006-04"
+1509	practically non-alcoholic drinkable slap and tickle with a fly in it	1	good	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of Leguizamo	0		Monster Level: +20, Last Available: "2006-04"
 1512	compressed olive wobbly ghostly Knob Goblin pet-buffing spray	1		Effect: "Egg on your Face", Effect Duration: 35
 1513	dehydrated tumbling lime green Knob Goblin learning pill	1		
 1514	compressed Knob Goblin eyedrops	1		Effect: "The Power of Negative Thinking", Effect Duration: 40
 1515	vaporized blurry Knob Goblin nasal spray	1		
-1516	gray skewed KWE-brand transistor radio	0		
+1516	skewed gray KWE-brand transistor radio	0		
 1518	mirror vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	deadly Radio KoL Coffee Mug of extreme caution	0		Weapon Damage: +5, Monster Level: -25
@@ -1503,8 +1503,8 @@
 1522	narrow lard-coated nippy Radio Free Jersey	0		Cold Damage: +10, Sleaze Spell Damage: +25
 1523	green bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	wobbly joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	mirror pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1525	wobbly joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1526	mirror pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Oprah's Herculean corkscrew	0		Experience (Muscle): +1, Maximum MP Percent: +50, Last Available: "2006-04"
 1529	twirling St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
@@ -1528,22 +1528,22 @@
 1548	Jack Frost's curative Gazpacho's Glacial Grimoire	0		Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 1549	MSG	0		
 1550	huge Socratic second-hand knockoff engagement ring	0		Experience (Mysticality): +1, Single Equip
-1551	triple-distilled hand-crafted shaking bottle of Domesticated Turkey	6	EPIC	
+1551	hand-crafted triple-distilled shaking bottle of Domesticated Turkey	6	EPIC	
 1552	mediocre bottle of Definit	3	decent	
-1553	mediocre weak twirling bottle of Calcutta Emerald	2	decent	
+1553	weak mediocre twirling bottle of Calcutta Emerald	2	decent	
 1554	artisanal bottle of Lieutenant Freeman	3	EPIC	
 1555	artisanal weak bottle of Jorge Sinsonte	2	EPIC	
-1556	drinkable practically non-alcoholic boxed champagne	1	good	
+1556	practically non-alcoholic drinkable boxed champagne	1	good	
 1557	moldy kumquat	3	crappy	
 1558	decent tiny huge tangerine	1	good	
 1559	tonic water	0		
 1560	low-calorie normal cocktail onion	1	good	
 1561	normal raspberry	4	good	
-1562	flavorless fuchsia blinking kiwi	3	decent	
+1562	flavorless blinking fuchsia kiwi	3	decent	
 1563	drinkable whiskey bittersweet	4	good	
 1564	bad mimosette	3	decent	
-1565	watered-down artisanal spinning tequila sunset	2	EPIC	
-1566	smooth weak zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
+1565	artisanal watered-down spinning tequila sunset	2	EPIC	
+1566	weak smooth zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
 1567	bad watered-down blinking gin and tonic	2	decent	
 1568	practically non-alcoholic aged wobbly cyan vodka and tonic	1	awesome	
 1569	high-proof drinkable vodka gibson	6	good	
@@ -1551,41 +1551,41 @@
 1571	smooth tumbling parisian cathouse	4	awesome	
 1572	perfectly mixed olive rabbit punch	3	EPIC	
 1573	artisanal caipifruta	4	EPIC	
-1574	practically non-alcoholic hand-crafted teqiwila	1	super EPIC	
+1574	hand-crafted practically non-alcoholic teqiwila	1	super EPIC	
 1575	drinkable Divine	3	good	
 1576	special mediocre huge Gordon Bennett	3	decent	Effect: "Quiet 'n' Good", Effect Duration: 50
 1577	tolerable tangarita	3	good	
 1578	artisanal huge mandarina colada	4	EPIC	
-1579	boozy bad gimlet	5	decent	
+1579	bad boozy gimlet	5	decent	
 1580	acceptable green brick road	4	good	
-1581	watered-down hand-crafted vodka stratocaster	2	super ultra EPIC	
+1581	hand-crafted watered-down vodka stratocaster	2	super ultra EPIC	
 1582	aged ghostly Neuromancer	4	awesome	
 1583	irresponsibly strong delicious huge prussian cathouse	8	awesome	
-1584	delicious practically non-alcoholic narrow Mae West	1	awesome	
+1584	practically non-alcoholic delicious narrow Mae West	1	awesome	
 1585	practically non-alcoholic acceptable Mon Tiki	1	good	
 1586	tolerable wobbly teqiwila slammer	3	good	
-1587	miniature rotten green pulsating Knob lo mein	2	crappy	
+1587	miniature rotten pulsating green Knob lo mein	2	crappy	
 1588	rotten asparagus lo mein	4	crappy	
-1589	tasty snack-sized upside-down Knoll lo mein	2	awesome	
+1589	snack-sized tasty upside-down Knoll lo mein	2	awesome	
 1590	half-sized normal lo mein	2	good	
-1591	flavorless big olive lo mein	5	decent	
-1592	normal small tumbling hot hi mein	2	good	
+1591	big flavorless olive lo mein	5	decent	
+1592	small normal tumbling hot hi mein	2	good	
 1593	normal narrow hi mein	4	good	
 1594	bland skewed maroon hi mein	3	decent	
-1595	tiny bland hi mein	1	decent	
+1595	bland tiny hi mein	1	decent	
 1596	adequate sleazy hi mein	4	good	
 1597	brainy Junior LAAAAME merit badge	0		Mysticality: +5, Last Available: "2006-05"
 1598	green Herculean Senior LAAAAME merit badge	0		Experience (Muscle): +1, Last Available: "2006-05"
 1599	blurry jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	practically non-alcoholic lousy tangarita with a fly in it	1	decent	
-1601	hand-crafted extra-dry mandarina colada with a fly in it	5	EPIC	
+1600	lousy practically non-alcoholic tangarita with a fly in it	1	decent	
+1601	extra-dry hand-crafted mandarina colada with a fly in it	5	EPIC	
 1602	bad prussian cathouse with a fly in it	3	decent	
 1603	aged Mae West with a fly in it	3	awesome	
 1604	compressed pulsating teal astronaut ice-cream	1		Effect: "High Blood Chocolate Content", Effect Duration: 20, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	mixed mirror ultimate wad	1		
-1607	extra-concentrated moist squat ghostly libation of liveliness	0		Effect: "Shredding, Sweating", Effect Duration: 50
-1608	non-improved denatured spinning huge eyedrops of the ermine	0		Effect: "Cotton Mouthed", Effect Duration: 66
+1607	extra-concentrated moist ghostly squat libation of liveliness	0		Effect: "Shredding, Sweating", Effect Duration: 50
+1608	non-improved denatured huge spinning eyedrops of the ermine	0		Effect: "Cotton Mouthed", Effect Duration: 66
 1609	warmed perfume of prejudice	0		Effect: "Oxygenated Blood", Effect Duration: 35
 1610	oxidized maroon eyedrops of the ocelot	0		Effect: "Hustlin'", Effect Duration: 33
 1611	nitrogenated aerosolized potent potion of potency	0		Effect: "Superheroic", Effect Duration: 22
@@ -1599,7 +1599,7 @@
 1619	munchies pill	0		Last Available: "2006-06"
 1620	homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
-1622	double-dry tarnished pulsating fuchsia astral mushroom	0		Effect: "Square to be Hip", Effect Duration: 59, Last Available: "2006-06"
+1622	double-dry tarnished fuchsia pulsating astral mushroom	0		Effect: "Square to be Hip", Effect Duration: 59, Last Available: "2006-06"
 1623	badger badge	0		Last Available: "2006-06"
 1624	polarized huge blue-frosted astral cupcake	0		Effect: "Tingly Biceps", Effect Duration: 60, Last Available: "2006-06"
 1625	irradiated green-frosted astral cupcake	0		Effect: "Badger Underfoot", Effect Duration: 37, Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	red beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	Spanish fly	0		
-1634	delicious practically non-alcoholic squat around the world	1	awesome	
+1634	practically non-alcoholic delicious squat around the world	1	awesome	
 1635	blinking blinking scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	dry adjusted quadruple-activated spinning blurry lotion of hotness	0		Effect: "Thanksgot", Effect Duration: 26
@@ -1625,12 +1625,12 @@
 1645	and sauce	0		
 1646	blinking and sauce	0		
 1647	stench and sauce	0		
-1648	ghostly twirling sleazy and sauce	0		
+1648	twirling ghostly sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	snack-sized decent foie gras	2	good	
+1651	decent snack-sized foie gras	2	good	
 1652	nitrogenated improved candy brain	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 23, Last Available: "2020-09"
-1653	Tesla ruddy steel-toed jewel-eyed wizard hat	0		Damage Reduction: 9, Maximum HP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	Tesla ruddy steel-toed jewel-eyed wizard hat	0		Damage Reduction: 9, Maximum HP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	blinking greedy brawny wad of Crovacite	0		Muscle Percent: +20, Meat Drop: +20
 1655	huge fuchsia dance instructor's beefy collar	0		Muscle: +10, Experience Percent (Moxie): +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	pulsating styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	blinking pulsating pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pulsating blinking pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	coward's Oprah's sword	0		Maximum MP Percent: +50, Monster Level: -20
 1680	strapping staff of the wise owl	0		Muscle: +5, Mysticality: +20
 1681	greedy beefy bubblewrap sword	0		Muscle: +10, Meat Drop: +20
@@ -1675,7 +1675,7 @@
 1695	modified mirror blue papotion of papower	0		Effect: "Gunky Dory", Effect Duration: 32
 1696	spoiled yellow royal jelly taco	4	crappy	
 1697	diet decent tofu taco	1	good	
-1698	bite-sized bland jumping bean taco	1	decent	
+1698	bland bite-sized jumping bean taco	1	decent	
 1699	yummy catgut taco	3	awesome	
 1700	super-sized bland goat cheese taco	5	decent	
 1701	normal pr0n taco	3	good	
@@ -1752,7 +1752,7 @@
 1773	purple chaotic eggbeater	0		Spell Critical Percent: +10
 1774	tolerable bottle of popskull	4	good	
 1775	teal dishrag of the empath	0		Familiar Weight: +5
-1776	rotten immense squat stale baguette	8	crappy	
+1776	immense rotten squat stale baguette	8	crappy	
 1777	leftovers of indeterminate origin	0		
 1778	small flavorless jittery ghostly dinner	2	decent	
 1779	katana of Flo-Jo	0		Initiative: +100
@@ -1766,7 +1766,7 @@
 1787	dry tumbling bag of Cheat-Os	0		Effect: "Bananas!", Effect Duration: 63
 1788	mirror jittery unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	watered-down aged Ram's Face Lager	2	awesome	
+1790	aged watered-down Ram's Face Lager	2	awesome	
 1791	blue ram horns	0		
 1792	cyan ghostly Lo Pan's Travoltan trousers of temperance of the early riser	0		Spell Critical Percent: +30, Sleaze Resistance: +5, Adventures: +7, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	MacGyver's pool cue of wisdom	0		Mysticality: +15, Maximum MP: +100
@@ -1775,7 +1775,7 @@
 1796	bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
 1798	pile of animal bones	0		
-1799	gray bouncing animal skull	0		
+1799	bouncing gray animal skull	0		
 1800	animal cranium	0		
 1801	huge animal jawbone	0		
 1802	twirling first cervical vertebra	0		
@@ -1817,9 +1817,9 @@
 1838	tenth caudal vertebra	0		
 1839	left first rib	0		
 1840	left second rib	0		
-1841	huge purple left third rib	0		
+1841	purple huge left third rib	0		
 1842	left fourth rib	0		
-1843	blue squat left fifth rib	0		
+1843	squat blue left fifth rib	0		
 1844	left sixth rib	0		
 1845	left seventh rib	0		
 1846	tumbling left eighth rib	0		
@@ -1867,7 +1867,7 @@
 1888	right third front claw	0		
 1889	right fourth front claw	0		
 1890	skewed left thumb	0		
-1891	maroon huge right thumb	0		
+1891	huge maroon right thumb	0		
 1892	left first rear claw	0		
 1893	left second rear claw	0		
 1894	left third rear claw	0		
@@ -1923,14 +1923,14 @@
 1946	accordion pin of the cougar of the scaredy-cat	0		Moxie: +20, Monster Level: -15, Class: "Accordion Thief", Single Equip
 1947	pulsating scorching rosy-cheeked worn tophat	0		Maximum HP Percent: +30, Hot Damage: +25, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	shaking gravedigger's weightlifter's tap shoes	0		Muscle: +15, Spooky Damage: +10, Single Equip
-1949	tasty gigantic Manetwich	8	awesome	
+1949	gigantic tasty Manetwich	8	awesome	
 1950	bottle of Vangoghbitussin	0		
 1951	bad bottle of Pinot Renoir	3	decent	
 1952	flavorless desiccated apricot	4	decent	
 1953	bad flute of flat champagne	4	decent	
 1954	toothsome dehydrated caviar	4	awesome	
 1955	styrofoam peanuts	0		
-1956	watered-down hand-crafted snifter of thoroughly aged brandy	2	EPIC	
+1956	hand-crafted watered-down snifter of thoroughly aged brandy	2	EPIC	
 1957	quill pen	0		
 1958	skewed inkwell	0		
 1959	wobbly tattered scrap of paper	0		
@@ -1954,7 +1954,7 @@
 1977	gravy fairy	0		
 1978	shaking gravy fairy	0		
 1979	gravy fairy	0		
-1980	mirror huge sleazy gravy fairy	0		
+1980	huge mirror sleazy gravy fairy	0		
 1981	astral badger	0		
 1982	MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
@@ -1966,7 +1966,7 @@
 1989	Cheshire bitten	0		
 1990	ghostly yo-yo	0		
 1991	rubber WWJD? bracelet	0		
-1992	blurry shaking rubber WWBD? bracelet	0		
+1992	shaking blurry rubber WWBD? bracelet	0		
 1993	mirror rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
@@ -1993,16 +1993,16 @@
 2016	diamond necklace	0		
 2017	ghostly spade necklace	0		
 2018	club necklace	0		
-2019	maroon twirling cream pie	0		Free Pull
+2019	twirling maroon cream pie	0		Free Pull
 2020	stale jittery cherry pie	3	decent	
 2021	snack-sized rotten strawberry pie	2	crappy	
 2022	adequate snack-sized teal lemon meringue pie	2	good	
 2023	Genalen&trade; Bottle	1	good	
-2024	decent thick mixed wildflower greens	5	good	
+2024	thick decent mixed wildflower greens	5	good	
 2025	bland narrow handful of walnuts	3	decent	
 2026	decent miniature nutty organic salad	2	good	
-2027	flavorless bite-sized skewed lime green super salad	1	decent	
-2028	bland small pulsating narrow tofu wonton	2	decent	
+2027	flavorless bite-sized lime green skewed super salad	1	decent	
+2028	small bland pulsating narrow tofu wonton	2	decent	
 2029	hippy protest button	0		Single Equip
 2030	mirror lime green lard-coated sinister Lockenstock&trade; sandals	0		Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip
 2031	wobbly friendly didgeridooka	0		Familiar Weight: +3
@@ -2022,7 +2022,7 @@
 2045	snack-sized yummy squat brain-meltingly-hot chicken wings	2	awesome	
 2046	moldy half-sized frat brats	2	crappy	
 2047	decent tumbling knob ka-bobs	4	good	
-2049	irresponsibly strong smooth can of Swiller	7	awesome	
+2049	smooth irresponsibly strong can of Swiller	7	awesome	
 2050	teal twirling broken wings	0		
 2051	blurry sunken eyes	0		
 2052	mirror reassembled blackbird	0		
@@ -2067,7 +2067,7 @@
 2091	skewed bath salts	0		
 2092	hand mirror	0		
 2093	bouncing narrow hors d'oeuvre tray of extreme caution	0		Monster Level: -25, Damage Reduction: 5
-2094	yummy immense ballroom blintz	6	awesome	
+2094	immense yummy ballroom blintz	6	awesome	
 2095	narrow towel	0		
 2096	compressed guy made of bee pollen	1		
 2097	chilly 17-ball	0		Cold Damage: +5
@@ -2121,7 +2121,7 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	twirling evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	gigantic flavorless frank	9	decent	Last Available: "2011-12"
+2149	flavorless gigantic frank	9	decent	Last Available: "2011-12"
 2150	spoiled immense jittery plate of franks and beans	6	crappy	Last Available: "2011-12"
 2151	bad fuchsia shot of blackberry schnapps	4	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
@@ -2159,18 +2159,18 @@
 2184	blinking Harold's hammer	0		
 2185	teal mansplainer's Kiss the Knob apron	0		Monster Level: +15
 2186	unlit birthday cake	0		
-2187	skewed shaking lit birthday cake	0		
+2187	shaking skewed lit birthday cake	0		
 2188	bouncing flask of peppermint oil	1	EPIC	Last Available: "2006-12"
 2189	hand-crafted red ghostly flask of peppermint schnapps	3	EPIC	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	twirling sheet music	0		Last Available: "2006-12"
-2193	miniature stale candy stake	2	decent	Last Available: "2006-12"
+2193	stale miniature candy stake	2	decent	Last Available: "2006-12"
 2194	bad watered-down eggnog	2	decent	Last Available: "2006-12"
 2195	adequate huge unspeakable fruitcake	4	good	Last Available: "2006-12"
 2196	flavorless gigantic cyan gingerbread horror	6	decent	Last Available: "2006-12"
 2197	activated mirror but probably evil chocolate	0		Effect: "Weird Vibrations", Effect Duration: 11, Last Available: "2006-12"
-2198	gigantic yummy blurry bat-shaped Crimboween cookie	10	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	yummy gigantic blurry bat-shaped Crimboween cookie	10	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	spoiled skull-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	small delicious tombstone-shaped Crimboween cookie	2	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	pulsating stylish plastic gift-wrapping vampire	0		Moxie: +25, Last Available: "2006-12"
@@ -2186,11 +2186,11 @@
 2211	fireproof baleful deck of tropical cards	0		Spell Damage: +25, Hot Resistance: +3, Last Available: "2006-12", Stat Tuning: "Mysticality"
 2212	flame-wreathed tropical paperweight of the brazier	0		Hot Spell Damage: 35, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
-2214	tumbling lime green jittery tropical wrapping paper	0		Last Available: "2006-12"
+2214	lime green jittery tumbling tropical wrapping paper	0		Last Available: "2006-12"
 2215	boxer's Tropical Crimbo Hat	0		Muscle Percent: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
 2216	narrow foul-smelling Tropical Crimbo Shorts	0		Stench Damage: +10, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	bland lime green super ka-bob	3	decent	
-2218	snack-sized flavorless beer basted brat	2	decent	
+2218	flavorless snack-sized beer basted brat	2	decent	
 2219	Tropical Crimbo Sword of the ox	0		Muscle: +20, Last Available: "2006-12"
 2220	wet and Crimboween candy	0		Effect: "Elemental Mastery", Effect Duration: 48, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2199,7 +2199,7 @@
 2224	narrow zippy pink shirt	0		Initiative: +20, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	narrow crafty boxer's evil eyeball pendant	0		Muscle Percent: +10, Maximum MP: +10, Single Equip, Softcore Only, Last Available: "2007-01"
-2227	vacuum-sealed warmed activated red blurry arse-a'fire elixir	0		Effect: "Gobliny Flavor", Effect Duration: 17, Last Available: "2007-01"
+2227	vacuum-sealed warmed activated blurry red arse-a'fire elixir	0		Effect: "Gobliny Flavor", Effect Duration: 17, Last Available: "2007-01"
 2228	activated polarized cosmic lemonade	0		Effect: "Bilious Brains", Effect Duration: 29, Last Available: "2007-01"
 2229	anodized toad horn	0		Effect: "Gr8ness", Effect Duration: 59, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
@@ -2247,7 +2247,7 @@
 2273	artisanal bottle of Pinot Noir	3	EPIC	
 2274	aged shaking bottle of Zinfandel	3	awesome	
 2275	watered-down bad twirling bottle of Marsala	2	decent	
-2276	mediocre boozy bottle of Muscat	5	decent	
+2276	boozy mediocre bottle of Muscat	5	decent	
 2277	wobbly Fernswarthy's key	0		
 2278	twirling Fernswarthy's letter	0		
 2279	book	0		
@@ -2256,7 +2256,7 @@
 2282	blinking Manual of Dexterity	0		
 2283	Annie Oakley's seal-skull helmet	0		Critical Hit Percent: +20, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
-2285	blue skewed chisel	0		
+2285	skewed blue chisel	0		
 2286	wobbly Eye of Ed	0		
 2287	cyan supercharged Herculean glowstick	0		Experience (Muscle): +1, Maximum MP Percent: +30, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
@@ -2286,7 +2286,7 @@
 2312	candygram	0		Last Available: "2007-02"
 2313	teal candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
-2315	upside-down bouncing candygram	0		Last Available: "2007-02"
+2315	bouncing upside-down candygram	0		Last Available: "2007-02"
 2316	broken carburetor	0		
 2317	bronze token	0		
 2318	bomb	0		
@@ -2314,7 +2314,7 @@
 2340	artisanal high-proof & tan	9	EPIC	
 2341	pepper	0		
 2342	tasty huge forest cake	3	awesome	
-2343	half-sized adequate forest ham	2	good	
+2343	adequate half-sized forest ham	2	good	
 2344	ionized wobbly filthworm hatchling scent gland	0		Effect: "Compensatory Cruelness", Effect Duration: 32
 2345	frozen enhanced filthworm drone scent gland	0		Effect: "Resilient Spirit", Effect Duration: 66
 2346	electrified double-improved shaking twirling filthworm royal guard scent gland	0		Effect: "Purity of Spirit", Effect Duration: 44
@@ -2348,7 +2348,7 @@
 2374	banana peel	0		
 2375	moldy skewed banana cream pie	4	crappy	
 2376	smooth watered-down banana daiquiri	2	awesome	
-2377	weak fancy smooth skewed bungle in the jungle	2	awesome	Effect: "Seriously Mutated", Effect Duration: 45
+2377	fancy weak smooth skewed bungle in the jungle	2	awesome	Effect: "Seriously Mutated", Effect Duration: 45
 2378	banana spritzer	0		
 2379	extra-energized tarnished shaking banana smoothie	0		Effect: "Nano-juiced", Effect Duration: 12
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2377,7 +2377,7 @@
 2403	barrel of gunpowder	0		
 2404	jam band flyers	0		
 2405	rock band flyers	0		
-2406	blurry red Panda outfit	0		Familiar Weight: +5, Item Drop: +5
+2406	red blurry Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	pink bat eye	0		
 2408	tumbling worthless piece of glass	0		
 2409	gray billy idol	0		
@@ -2391,7 +2391,7 @@
 2417	Tesla bounty-hunting rifle	0		MP Regen Min: 7, MP Regen Max: 10
 2418	executive bounty-hunting pants	0		Meat Drop: +40, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	pressed double-modified bottle of rhinoceros hormones	0		Effect: "Adventurer's Best Friendship", Effect Duration: 39
-2420	boiled non-polarized maroon skewed teeny-tiny magic scroll	0		Effect: "Spooky Jellied", Effect Duration: 40
+2420	boiled non-polarized skewed maroon teeny-tiny magic scroll	0		Effect: "Spooky Jellied", Effect Duration: 40
 2421	cold-filtered denatured galvanized bottle of pirate juice	0		Effect: "Stemonitis Storm", Effect Duration: 42
 2422	quantum anodized shaking irradiated pet snacks	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 13
 2423	anodized Mick's IcyVapoHotness Inhaler	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 62
@@ -2404,7 +2404,7 @@
 2430	colloidal non-pickled bag of lard	0		Effect: "Dexteri Tea", Effect Duration: 48
 2431	vacuum-sealed bottle of Mystic Shell	0		Effect: "Hippy Flavor", Effect Duration: 41
 2432	electrified double-energized mirror bouncing SPF 451 lip balm	0		Effect: "Concentrated Concentration", Effect Duration: 69
-2433	enhanced spinning red shaking bottle of antifreeze	0		Effect: "Stuck-Up Hair", Effect Duration: 39
+2433	enhanced shaking red spinning bottle of antifreeze	0		Effect: "Stuck-Up Hair", Effect Duration: 39
 2434	ionized wobbly eyedrops	0		Effect: "Material Witness", Effect Duration: 23
 2435	anodized cold-filtered ghostly blue Dogsgotnonoz pills	0		Effect: "Blood-Gorged", Effect Duration: 18
 2436	improved donkey flipbook	0		Effect: "Towering Strength", Effect Duration: 67
@@ -2440,7 +2440,7 @@
 2467	tumbling suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	bundle of receipts	0		
-2470	huge twirling cork	0		
+2470	twirling huge cork	0		
 2471	spinning stardust	0		
 2472	wilted lettuce	0		
 2473	empty greasepaint tube	0		
@@ -2476,7 +2476,7 @@
 2503	extra-fancy ring setting	0		
 2504	green precious piercing post	0		
 2505	necklace chain	0		
-2506	tumbling bouncing beach glass bead	0		
+2506	bouncing tumbling beach glass bead	0		
 2507	clay peace-sign bead	0		
 2508	Sinatra's beach glass necklace	0		Experience (Moxie): +5
 2509	nasty peace-sign necklace	0		Stench Damage: +5
@@ -2491,28 +2491,28 @@
 2518	huge Annie Oakley's sawblade shield	0		Critical Hit Percent: +20, Damage Reduction: 11
 2519	watered-down mediocre spinning McMillicancuddy's Special Lager	2	decent	
 2520	drinkable melted Jell-o shot	3	good	
-2521	hand-crafted watered-down narrow cruelty-free wine	2	EPIC	
+2521	watered-down hand-crafted narrow cruelty-free wine	2	EPIC	
 2522	hand-crafted thistle wine	3	EPIC	
 2523	megatofu	0		
 2524	blinking displaced fish	0		
-2525	stale thick fish	5	decent	
-2526	rotten low-calorie fish casserole	1	crappy	
+2525	thick stale fish	5	decent	
+2526	low-calorie rotten fish casserole	1	crappy	
 2527	normal fish lasagna	4	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	miniature spoiled gnatloaf	2	crappy	
-2530	adequate fancy gray gnatloaf casserole	4	good	Effect: "Tapped In", Effect Duration: 50
-2531	toothsome tumbling olive jittery gnat lasagna	4	awesome	
+2529	spoiled miniature gnatloaf	2	crappy	
+2530	fancy adequate gray gnatloaf casserole	4	good	Effect: "Tapped In", Effect Duration: 50
+2531	toothsome jittery tumbling olive gnat lasagna	4	awesome	
 2532	pork	0		
 2533	moldy pork chop sandwiches	3	crappy	
-2534	low-calorie rotten pork casserole	1	crappy	
+2534	rotten low-calorie pork casserole	1	crappy	
 2535	bland pork lasagna	4	decent	
 2536	canopic jar	0		
-2537	wobbly shaking spice	0		
+2537	shaking wobbly spice	0		
 2538	shaking organs	0		
 2539	frightening Ankh of Badahnkadh	0		Spooky Damage: +5, Single Equip
 2540	tomb ratchet	0		
 2541	olive Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
-2542	chilled spinning blurry lesser grodulated violet	0		Effect: "Nightstalkin'", Effect Duration: 23, Last Available: "2007-05"
+2542	chilled blurry spinning lesser grodulated violet	0		Effect: "Nightstalkin'", Effect Duration: 23, Last Available: "2007-05"
 2543	moist tin magnolia	0		Effect: "Gummi-Grin", Effect Duration: 59, Last Available: "2007-05"
 2544	dry dry mirror begpwnia	0		Effect: "Polka of Plenty", Effect Duration: 41, Last Available: "2007-05"
 2545	concentrated flattened spinning upsy daisy	0		Effect: "Amplified Fabulousness", Effect Duration: 40, Last Available: "2007-05"
@@ -2538,7 +2538,7 @@
 2565	tumbling can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
-2568	huge yellow Azazel's tutu	0		
+2568	yellow huge Azazel's tutu	0		
 2569	liquefied adjusted ghostly ant agonist	0		Effect: "Orc Chops", Effect Duration: 17
 2570	pulsating ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	huge ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2549,18 +2549,18 @@
 2576	honey-dipped locust	0		
 2577	lion tamer's cactus quill of the wise owl	0		Mysticality: +20, Experience (familiar): +2
 2578	red sizzling supercharged padded Staff of the Short Order Cook	0		Damage Absorption: +20, Maximum MP Percent: +30, Hot Damage: +10
-2579	rotten special diet cactus fruit	1	crappy	Effect: "Booooooze", Effect Duration: 5
+2579	diet rotten special cactus fruit	1	crappy	Effect: "Booooooze", Effect Duration: 5
 2580	huge censurious Van der Graaf scorpion whip	0		Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	stale enchanted diet centipede eggs	1	decent	Effect: "Cringle's Curative Carol", Effect Duration: 10
+2583	enchanted stale diet centipede eggs	1	decent	Effect: "Cringle's Curative Carol", Effect Duration: 10
 2584	personal trainer's wonderwall shield	0		Experience Percent (Muscle): +10, Damage Reduction: 12
 2585	teal gravedigger's Colonel Mustard's Lonely Spades Club Jacket	0		Spooky Damage: +10
 2586	family-friendly General Sage's Lonely Diamonds Club Jacket	0		Sleaze Resistance: +1
 2587	blurry sharpshooter's Corporal Fennel's Lonely Clubs Club Jacket	0		Critical Hit Percent: +10
 2588	wobbly bouncing Private Pepper's Lonely Hearts Club Jacket of the pedagogue	0		Experience: +3
-2589	stale miniature hot date	2	decent	
-2590	hand-crafted high-proof bouncing distilled fortified wine	8	EPIC	
+2589	miniature stale hot date	2	decent	
+2590	high-proof hand-crafted bouncing distilled fortified wine	8	EPIC	
 2591	decent maroon tasty tart	4	good	
 2592	Knob Goblin lunchbox	0		
 2593	delicious green Knob pasty	3	awesome	
@@ -2590,7 +2590,7 @@
 2617	boom	0		
 2618	purple cool Iiti Kitty phone charm	0		Moxie: +5, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	bite-sized moldy gray unidentified jerky	1	crappy	
+2620	moldy bite-sized gray unidentified jerky	1	crappy	
 2621	skewed purple vibrating nasty rat mask of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	ratskin belt of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Single Equip
 2623	horrifying steel-toed rattail whip	0		Damage Reduction: 9, Spooky Damage: +25
@@ -2636,7 +2636,7 @@
 2663	jittery Can-Can skirt of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	polarized diffused sensitive poetry journal	0		Effect: "critical.enh", Effect Duration: 17, Last Available: "2007-06"
 2665	vacuum-sealed energized pulsating upside-down bottled inspiration	0		Effect: "Shamboozled", Effect Duration: 11, Last Available: "2007-06"
-2666	wet concentrated gray blurry bellhop bell	0		Effect: "Itchy Trigger Finger", Effect Duration: 41, Last Available: "2007-06"
+2666	wet concentrated blurry gray bellhop bell	0		Effect: "Itchy Trigger Finger", Effect Duration: 41, Last Available: "2007-06"
 2667	extra-wet blurry spiky collar	0		Effect: "Balls of Ectoplasm", Effect Duration: 63, Last Available: "2007-06"
 2668	mixed upside-down can-can-in-a-can	1		Effect: "Dance Interpreter", Effect Duration: 10, Last Available: "2007-06"
 2669	altered huge patent antipsychotics	1		Last Available: "2007-06"
@@ -2661,7 +2661,7 @@
 2688	spinning ribald smartaleck's dreadlock whip	0		Moxie Percent: +30, Sleaze Damage: +10, Item Drop: +5
 2689	bouncing bouncing beer-a-pult of the dark arts of bravery	0		Spell Damage Percent: +100, Spooky Resistance: +5
 2690	bouncing gray Annie Oakley's Van der Graaf cast-iron legacy paddle	0		Critical Hit Percent: +20, MP Regen Min: 5, MP Regen Max: 7
-2691	adequate tiny fancy bouncing mirror lime green handful of nuts and berries	1	good	Effect: "Ironclad", Effect Duration: 30
+2691	fancy tiny adequate bouncing lime green mirror handful of nuts and berries	1	good	Effect: "Ironclad", Effect Duration: 30
 2692	frightening Lo Pan's driftwood sculpture	0		Spell Critical Percent: +30, Spooky Damage: +5
 2693	blinking smelly razor-sharp massive sitar	0		Weapon Damage Percent: +25, Stench Spell Damage: +10
 2694	Sherlock's frightening groovy stone baseball cap	0		Moxie Percent: +10, Spooky Damage: +5, Item Drop: +25, Familiar Effect: "1xVolley, cap 48"
@@ -2684,7 +2684,7 @@
 2711	electrified squat facepaint	0		Effect: "Taurus Rising", Effect Duration: 45
 2712	tarnished concentrated sheepskin diploma	0		Effect: "Human-Penguin Hybrid", Effect Duration: 19
 2713	dry super-ionized ionized tumbling Black Body&trade; spray	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 13
-2714	jittery upside-down floorboard cruft	0		
+2714	upside-down jittery floorboard cruft	0		
 2715	sausage bomb	0		
 2716	blinking lion tamer's stiffened banded battered hubcap	0		Damage Absorption: +100, Damage Reduction: 15, Experience (familiar): +2
 2717	wool therapeutic stylish hood ornament	0		Moxie: +25, Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
@@ -2705,17 +2705,17 @@
 2732	bad huge shot of peach schnapps	4	decent	
 2733	moldy skewed bunch of square grapes	3	crappy	
 2734	miniature delicious red brown sugar cane	2	awesome	
-2735	half-sized normal ghostly sandwich of the gods	2	good	
+2735	normal half-sized ghostly sandwich of the gods	2	good	
 2736	acceptable jittery Pan-Dimensional Gargle Blaster	3	good	
-2737	mixed twirling mirror shaking leopard-print barbell	1	decent	
+2737	mixed shaking mirror twirling leopard-print barbell	1	decent	
 2738	pile of smoking rags	0		
 2739	altered panty raider camouflage	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 31
 2740	ghostly ribald padded Staff of the Walk-In Freezer of the scaredy-cat	0		Damage Absorption: +20, Monster Level: -15, Sleaze Damage: +10
 2741	lousy boilermaker	4	decent	
 2742	yummy steel lasagna	4	quest	
-2743	artisanal spirit-forward green steel margarita	5	quest	
-2744	compressed pulsating twirling jittery steel-scented air freshener	1		
-2745	magnetized cold-filtered twirling blinking gremlin mutagen	0		Effect: "Tightly-Wound Spine", Effect Duration: 23
+2743	spirit-forward artisanal green steel margarita	5	quest	
+2744	compressed twirling pulsating jittery steel-scented air freshener	1		
+2745	magnetized cold-filtered blinking twirling gremlin mutagen	0		Effect: "Tightly-Wound Spine", Effect Duration: 23
 2746	chilled spinning extra-potent gremlin mutagen	0		Effect: "Snobby", Effect Duration: 47
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of bravery	0		Spooky Resistance: +5, Single Equip
@@ -2739,7 +2739,7 @@
 2766	bowling ball	0		
 2767	moldy olive Crimbo pie	4	crappy	
 2768	moldy big pear tart	5	crappy	
-2769	jumbo stale upside-down peach pie	5	decent	
+2769	stale jumbo upside-down peach pie	5	decent	
 2770	unsweetened chunk of rock salt	0		Effect: "Adrenaline Rush", Effect Duration: 45
 2771	activated colloidal handful of pine needles	0		Effect: "Chalked-Up Teeth", Effect Duration: 60
 2772	ghostly steamy ruby	0		
@@ -2803,8 +2803,8 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	bland bouncing narrow digital key lime pie	3	decent	
-2833	enchanted adequate miniature star key lime pie	2	good	Effect: "Je Ne Sais Porquoise", Effect Duration: 15
-2834	dangerous smartaleck's savvy bottle-rocket crossbow	0		Mysticality Percent: +20, Moxie Percent: +30, Weapon Damage: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2833	miniature adequate enchanted star key lime pie	2	good	Effect: "Je Ne Sais Porquoise", Effect Duration: 15
+2834	dangerous smartaleck's savvy bottle-rocket crossbow	0		Mysticality Percent: +20, Moxie Percent: +30, Weapon Damage: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	Jeselnik's indie comic hipster glasses	0		Sleaze Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	upside-down mint-condition magic wand	0		Last Available: "2011-12"
@@ -2813,7 +2813,7 @@
 2840	mediocre bottle of cooking sherry	3	decent	
 2841	decent packet of ketchup	4	good	
 2842	acceptable fortified accidental cider	5	good	
-2843	bland half-sized blinking dire fudgesicle	2	decent	
+2843	half-sized bland blinking dire fudgesicle	2	decent	
 2844	Annie Oakley's energetic stiffened Herculean navel ring of navel gazing	0		Experience (Muscle): +1, Damage Reduction: 1, Maximum MP Percent: +20, Critical Hit Percent: +20, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	narrow class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2823,7 +2823,7 @@
 2850	bad moonberry wine cooler	4	decent	
 2851	big yummy jittery fine aged cheddarwurst	5	awesome	
 2852	branch from the Great Tree	0		
-2853	purple shaking Phil Bunion's axe	0		
+2853	shaking purple Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	rosy-cheeked huge mosquito proboscis of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50
 2856	ionized swamp lolly	0		Effect: "Coldfinger", Effect Duration: 45
@@ -2915,12 +2915,12 @@
 2942	double-Vulcanized super-modified green chocolate filthy lucre	0		Effect: "Protection from Bad Stuff", Effect Duration: 18
 2943	unsweetened Angry Farmer's Wife Candy	0		Effect: "Ocelot Eyes", Effect Duration: 20
 2945	skewed red groovy weightlifter's party hat	0		Muscle: +15, Moxie Percent: +10, Familiar Effect: "4xLep, cap 7"
-2946	ghostly rosy-cheeked V for Vivala mask of bravery	0		Maximum HP Percent: +30, Spooky Resistance: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	ghostly rosy-cheeked V for Vivala mask of bravery	0		Maximum HP Percent: +30, Spooky Resistance: +5, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
-2948	lousy watered-down enchanted shot of rotgut	2	decent	Effect: "Al Dente Inferno", Effect Duration: 10
+2948	watered-down lousy enchanted shot of rotgut	2	decent	Effect: "Al Dente Inferno", Effect Duration: 10
 2949	improved jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Extra-Wet", Effect Duration: 30
 2950	Cap'm Caronch's Map	0		
-2951	tumbling purple Orcish Frat House blueprints	0		
+2951	purple tumbling Orcish Frat House blueprints	0		
 2952	blinking glowstick of Gandalf of the cheetah	0		Spell Critical Percent: +20, Initiative: +60, Last Available: "2007-11"
 2953	squat charrrm bracelet	0		
 2954	wobbly padded tip jar	0		Damage Absorption: +20
@@ -2945,7 +2945,7 @@
 2973	ghostly dance instructor's grumpy man charrrm bracelet	0		Experience Percent (Moxie): +10, Single Equip
 2974	wobbly tarrrnish charrrm	0		
 2975	squat banded beefy tarrrnished charrrm bracelet	0		Muscle: +10, Damage Absorption: +100, Single Equip
-2976	weak hand-crafted ghostly bilge wine	2	EPIC	
+2976	hand-crafted weak ghostly bilge wine	2	EPIC	
 2977	witty rapier of mayonnaise	0		Sleaze Spell Damage: +50
 2978	yohohoyo of dire peril of the sewer	0		Weapon Damage: +20, Stench Damage: +25
 2979	unsweetened altered fish-liver oil	0		Effect: "Well-Swabbed Ear", Effect Duration: 49
@@ -2998,12 +2998,12 @@
 3026	weak drinkable maroon corpsetini	2	good	
 3027	tolerable narrow corpsedriver	3	good	
 3028	acceptable Corpse Island iced tea	3	good	
-3029	triple-distilled mediocre red-headed corpse	8	decent	
+3029	mediocre triple-distilled red-headed corpse	8	decent	
 3030	delicious blinking kamicorpse-ee	3	awesome	
 3031	acceptable watered-down corpsel	2	good	
 3032	triple-distilled artisanal corpsebite	6	EPIC	
 3033	wobbly yellow pirate fledges of terror	0		Spooky Spell Damage: +10
-3034	fuchsia blurry piece of thirteen	0		
+3034	blurry fuchsia piece of thirteen	0		
 3035	spoiled pearl onion	3	crappy	
 3036	huge stale sea biscuit	6	decent	
 3037	smooth practically non-alcoholic bottle of rum	1	awesome	
@@ -3013,7 +3013,7 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	lime green metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	bland nanite-infested gingerbread bugbear	3	decent	Last Available: "2007-12"
 3046	spoiled nanite-infested candy cane	3	crappy	Last Available: "2020-09"
 3047	delicious nanite-infested fruitcake	4	awesome	Last Available: "2007-12"
@@ -3044,18 +3044,18 @@
 3072	shaking carbonite visor	0		Last Available: "2007-12"
 3073	ghostly set of Unobtainium straps	0		Last Available: "2007-12"
 3074	polymorphic fastening apparatus	0		Last Available: "2007-12"
-3075	blinking blurry General Assembly Module	0		Last Available: "2007-12"
+3075	blurry blinking General Assembly Module	0		Last Available: "2007-12"
 3076	bouncing pulsating maroon laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	mirror kevlateflocite helmet	0		Last Available: "2007-12"
-3079	blurry Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	blurry Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	huge foul-smelling marionette collective	0		Stench Damage: +10, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
 3083	gray blob	0		Last Available: "2007-12"
 3084	steel-toed borg sock monkey	0		Damage Reduction: 9, Last Available: "2007-12"
 3085	fuchsia Socratic boxer's roboduck-on-a-string	0		Muscle Percent: +10, Experience (Mysticality): +1, Last Available: "2007-12"
-3086	ghostly narrow mylar scout drone	0		Last Available: "2007-12"
+3086	narrow ghostly mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
 3088	cyan biomechanical crimborg helmet of Gandalf of extreme caution	0		Spell Critical Percent: +20, Monster Level: -25, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	Lo Pan's Van der Graaf C.B.F.G.	0		Spell Critical Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-12"
@@ -3066,9 +3066,9 @@
 3094	pulsating Newton's set of jacks	0		Experience (Mysticality): +3, Last Available: "2007-12"
 3095	moldy laser-broiled pear	3	crappy	Last Available: "2007-12"
 3096	Jeselnik's curative polyalloy shield	0		Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 9, Last Available: "2007-12"
-3097	gray jittery fish scaler	0		Last Available: "2007-12"
+3097	jittery gray fish scaler	0		Last Available: "2007-12"
 3098	green killing feather	0		Last Available: "2007-12"
-3099	twirling spinning ring	0		Last Available: "2007-12"
+3099	spinning twirling ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	tumbling narrow rogue swarmer	0		Last Available: "2007-12"
 3102	sawblade fragment	0		Last Available: "2007-12"
@@ -3138,18 +3138,18 @@
 3166	blinking repaired El Vibrato drone	0		
 3167	spinning augmented El Vibrato drone	0		
 3168	diffused Vulcanized seal eyeball	0		Effect: "Stick Emporium Membership", Effect Duration: 43
-3169	gigantic normal turtle soup	6	good	Effect: "[598]A Little Bit Evil"
+3169	normal gigantic turtle soup	6	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	banded evil paper umbrella	0		Damage Absorption: +100
-3173	denatured shaking pulsating evil vihuela	0		Effect: "Metal Speed", Effect Duration: 19
+3173	denatured pulsating shaking evil vihuela	0		Effect: "Metal Speed", Effect Duration: 19
 3174	normal evil boring spaghetti	3	good	
-3175	half-sized delicious evil noodles	2	awesome	
-3176	stale super-sized evil noodles	5	decent	
+3175	delicious half-sized evil noodles	2	awesome	
+3176	super-sized stale evil noodles	5	decent	
 3177	normal spinning evil painful penne pasta	3	good	
 3178	miniature normal narrow jittery 3vi1 pr0n m4nic0tti	2	good	
 3179	flavorless purple evil ravioli della hippy	3	decent	
-3180	rotten jittery maroon evil noodles	3	crappy	
+3180	rotten maroon jittery evil noodles	3	crappy	
 3181	dry Vulcanized dry tumbling evil potion of potency	0		Effect: "Pretending to Pretend", Effect Duration: 69
 3182	diffused evil libation of liveliness	0		Effect: "Bilious Brains", Effect Duration: 17
 3183	galvanized pulsating evil tomato juice of powerful power	0		Effect: "Shoesauce", Effect Duration: 16
@@ -3160,7 +3160,7 @@
 3188	artisanal an evil sump'm sump'm	3	EPIC	
 3189	artisanal weak cyan evil ducha de oro	2	super EPIC	
 3190	perfectly mixed fortified evil horizontal tango	5	EPIC	
-3191	practically non-alcoholic drinkable evil roll in the hay	1	good	
+3191	drinkable practically non-alcoholic evil roll in the hay	1	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	blurry origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3193,11 +3193,11 @@
 3221	gator skin	0		
 3222	shaking mansplainer's gatorskin umbrella of wisdom	0		Mysticality: +15, Monster Level: +15
 3223	blue sewer nuggets	0		
-3224	blurry purple sewer wad	0		
+3224	purple blurry sewer wad	0		
 3225	artisanal tumbling bottle of sewage schnapps	3	EPIC	
 3226	tolerable bottle of Ooze-O	4	good	
 3227	moldy tiny blurry C.H.U.M. chum	1	crappy	
-3228	normal spinning squat unfortunate dumplings	4	good	
+3228	normal squat spinning unfortunate dumplings	4	good	
 3229	decaying goldfish liver	0		
 3230	anodized diffused oil of oiliness	0		Effect: "Flower Power", Effect Duration: 46
 3231	tumbling tattered paper crown of the early riser	0		Adventures: +7, Familiar Effect: "1xSombrero, cap 15"
@@ -3291,10 +3291,10 @@
 3319	sharpshooter's Mr. Joe's bangles	0		Critical Hit Percent: +10, Single Equip
 3320	mansplainer's frayed rope belt	0		Monster Level: +15, Single Equip
 3321	jittery packet of mayfly bait	0		Last Available: "2008-05"
-3322	Oprah's mayfly bait necklace of Leguizamo	0		Maximum MP Percent: +50, Monster Level: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	Oprah's mayfly bait necklace of Leguizamo	0		Maximum MP Percent: +50, Monster Level: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	wobbly Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	special tolerable jar of fermented pickle juice	3	good	Effect: "Barking Mad", Effect Duration: 40
+3325	tolerable special jar of fermented pickle juice	3	good	Effect: "Barking Mad", Effect Duration: 40
 3326	vaporized upside-down voodoo snuff	1	good	
 3327	bland tiny extra-greasy slider	1	decent	
 3328	miser's crumpled felt fedora of doom	0		Spooky Spell Damage: +50, Meat Drop: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3316,10 +3316,10 @@
 3344	bed of coals	0		
 3345	shaking air mattress	0		
 3346	wobbly filth-encrusted futon	0		
-3347	tumbling blinking twirling comfy coffin	0		
-3348	tumbling jittery mattress	0		
+3347	blinking twirling tumbling comfy coffin	0		
+3348	jittery tumbling mattress	0		
 3349	green dinged-up triangle	0		
-3350	drinkable squat upside-down tumbling Ralph IX cognac	3	good	
+3350	drinkable tumbling squat upside-down Ralph IX cognac	3	good	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	anodized llama lama gong	0		Effect: "Macho Profundo", Effect Duration: 55, Last Available: "2008-06"
@@ -3333,7 +3333,7 @@
 3361	teal yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	spoiled mole mol&eacute;	3	crappy	Last Available: "2008-06"
-3364	bad practically non-alcoholic Morlock's Mark Bourbon	1	decent	Last Available: "2008-06"
+3364	practically non-alcoholic bad Morlock's Mark Bourbon	1	decent	Last Available: "2008-06"
 3365	non-dry blurry Climate Colada	0		Effect: "Appeteyes", Effect Duration: 31, Last Available: "2008-06"
 3366	pickled corrupted digital underground potion	0		Effect: "I See Everything Thrice!", Effect Duration: 29, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3343,7 +3343,7 @@
 3371	vaporized shaking narrow glimmering buzzard feather	1		Last Available: "2008-06"
 3372	compressed fuchsia glimmering raven feather	1		Last Available: "2008-06"
 3373	distilled glimmering great tit feather	1		Last Available: "2008-06"
-3374	mirror bouncing house of twigs and spit	0		Last Available: "2008-06"
+3374	bouncing mirror house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
@@ -3371,7 +3371,7 @@
 3399	mediocre jar of squeeze	3	decent	
 3400	normal miniature bowl of fishysoisse	2	good	
 3401	unsweetened pressed warmed tumbling pulsating bouncing deadly lampshade	0		Effect: "Coming Up Roses", Effect Duration: 63
-3402	altered blue blinking concentrated garbage juice	0		Effect: "Less Pervious", Effect Duration: 57
+3402	altered blinking blue concentrated garbage juice	0		Effect: "Less Pervious", Effect Duration: 57
 3403	blurry lewd playing card	0		
 3404	greasy deck of lewd playing cards of the bloodbag of the cheetah	0		Maximum HP: +100, Sleaze Spell Damage: +10, Initiative: +60
 3405	Hodgman's sock of the wise owl	0		Mysticality: +20, Single Equip
@@ -3386,7 +3386,7 @@
 3414	yellow Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	jittery Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	shaking box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	shaking box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	quadruple-chilled sterno-flavored Hob-O	0		Effect: "Toast Tea", Effect Duration: 60
 3423	warmed narrow frostbite-flavored Hob-O	0		Effect: "The Power of LOV", Effect Duration: 44
 3424	activated blinking fry-oil-flavored Hob-O	0		Effect: "Memories of Puppy Love", Effect Duration: 40
@@ -3404,7 +3404,7 @@
 3437	Temple Grandin's smartaleck's Staff of the Black Kettle of bravery	0		Moxie Percent: +30, Familiar Weight: +7, Spooky Resistance: +5
 3438	fireproof Staff of the Well-Tempered Cauldron of chilblains of Flo-Jo	0		Cold Damage: +25, Hot Resistance: +3, Initiative: +100
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	compressed huge fuchsia prismatic wad	1	EPIC	Last Available: "2008-07"
+3440	compressed fuchsia huge prismatic wad	1	EPIC	Last Available: "2008-07"
 3441	cyan Oprah's club of the five seasons	0		Maximum MP Percent: +50, Last Available: "2008-07"
 3442	brawny rainbow crossbow	0		Muscle Percent: +20, Last Available: "2008-07"
 3443	jittery kitten	0		
@@ -3427,10 +3427,10 @@
 3460	delicious fancy tin rations	4	awesome	Effect: "All Branned Up", Effect Duration: 10
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	hand-crafted weak lime green bottle of sake	2	EPIC	
+3463	weak hand-crafted lime green bottle of sake	2	EPIC	
 3464	round pebble of Calamity Jane	0		Critical Hit Percent: +15
 3465	toothsome Bash-&#332;s cereal	3	awesome	Wiki Name: "Bash-Os cereal"
-3466	wicked beefy haiku katana of the blizzard	0		Muscle: +10, Spell Damage: +5, Cold Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	wicked beefy haiku katana of the blizzard	0		Muscle: +10, Spell Damage: +5, Cold Spell Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	wobbly bargain flash powder	0		
 3468	jittery energetic plastic baby	0		Maximum MP Percent: +20, Single Equip, Last Available: "2008-12"
 3469	bland upside-down blueberry-frosted king cake	3	decent	Last Available: "2008-12"
@@ -3444,7 +3444,7 @@
 3477	non-dry quadruple-altered teal pear lozenge	0		Effect: "Afternoon Insight", Effect Duration: 19
 3478	electrified diffused peach lozenge	0		Effect: "Human-Elemental Hybrid", Effect Duration: 24
 3479	balloon shield	0		Damage Reduction: 3
-3480	lime green skewed spot	0		
+3480	skewed lime green spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
@@ -3452,8 +3452,8 @@
 3485	irradiated glittery mascara	0		Effect: "Executive Greed", Effect Duration: 56
 3486	dull fish scale	0		
 3487	squat rough fish scale	0		
-3488	mirror red pristine fish scale	0		
-3489	small flavorless beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3488	red mirror pristine fish scale	0		
+3489	flavorless small beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3490	rotten skewed glistening fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
 3491	stale slick fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
 3492	beefy fish scimitar of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15
@@ -3461,11 +3461,11 @@
 3494	lime green wobbly inspector's fish bazooka of Flo-Jo	0		Item Drop: +15, Initiative: +100
 3495	pressed warmed sea salt crystal	0		Effect: "Inebriate Pride", Effect Duration: 59
 3496	liquefied deionized bazookafish bubble gum	0		Effect: "Weepy, Creepy", Effect Duration: 49
-3497	hand-crafted watered-down bottle of Pete's Sake	2	EPIC	
+3497	watered-down hand-crafted bottle of Pete's Sake	2	EPIC	
 3498	blinking invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3501	miniature tasty canap&eacute;s	2	awesome	
+3501	tasty miniature canap&eacute;s	2	awesome	
 3502	distilled bouncing thermos of brew	1	good	Last Available: "2011-12"
 3503	artisanal watered-down glass of brandy	2	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
@@ -3488,7 +3488,7 @@
 3521	maroon deadly shark tooth necklace of terror	0		Weapon Damage: +5, Spooky Spell Damage: +10, Single Equip
 3522	twirling greasy shark jumper of the sewer	0		Stench Damage: +25, Sleaze Spell Damage: +10
 3523	improved shark cartilage	0		Effect: "Memory of Smarts", Effect Duration: 51
-3524	improved oxidized shaking mirror eel battery	0		Effect: "World's Shortest Giant", Effect Duration: 17
+3524	improved oxidized mirror shaking eel battery	0		Effect: "World's Shortest Giant", Effect Duration: 17
 3525	activated tarnished wobbly temporary teardrop tattoo	0		Effect: "Aided and Abetted", Effect Duration: 44
 3526	red skewed energetic scratch 'n' sniff crossbow	0		Maximum MP Percent: +20, Last Available: "2008-11"
 3527	blurry huge mutant rattlesnake egg	0		
@@ -3519,7 +3519,7 @@
 3552	avaricious censurious sinister octopus's spade	0		Spell Damage: +10, Sleaze Resistance: +3, Meat Drop: +30
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	small bland tumbling sea carrot	2	decent	
+3555	bland small tumbling sea carrot	2	decent	
 3556	immense delicious sea cucumber	7	awesome	
 3557	stale huge shaking huge sea avocado	7	decent	
 3558	bland sea lychee	3	decent	
@@ -3544,7 +3544,7 @@
 3577	gray bezoar ring	0		
 3578	mirror candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	pulsating narrow ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
-3580	shaking huge wriggling flytrap pellet	0		
+3580	huge shaking wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	normal rice	3	good	
 3584	normal irradiated candy cane	3	good	Last Available: "2008-12"
@@ -3581,7 +3581,7 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	Vulcanized irradiated blue unstable DNA	0		Effect: "Ooh, Bitter!", Effect Duration: 50, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	shaking mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	ghostly pair of twitching claws	0		Last Available: "2008-12"
@@ -3613,10 +3613,10 @@
 3647	lime green elven whittling knife	0		Last Available: "2008-12"
 3648	upside-down magic dragonfish fry	0		
 3649	spinning map to Madness Reef	0		
-3650	decent massive toast with jam	7	good	Last Available: "2008-12"
-3651	twirling antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	massive decent toast with jam	7	good	Last Available: "2008-12"
+3651	twirling antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	aged elven moonshine	3	awesome	Last Available: "2008-12"
-3653	flavorless huge knuckle sandwich	6	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	huge flavorless knuckle sandwich	6	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	electrified psycho sweater of the pedagogue	0		Experience: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-12"
 3655	bouncing fin-bit wax	0		Familiar Weight: +5
 3656	rosy-cheeked plastic Mob Penguin	0		Maximum HP Percent: +30, Last Available: "2008-12"
@@ -3641,7 +3641,7 @@
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	gray horrifying diving muff	0		Spooky Damage: +25, Single Equip
-3678	irresponsibly strong acceptable salinated mint julep	6	good	
+3678	acceptable irresponsibly strong salinated mint julep	6	good	
 3679	red ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
@@ -3651,11 +3651,11 @@
 3685	super-sized rotten tempura cucumber	5	crappy	
 3686	tasty tempura avocado	3	awesome	
 3687	spoiled blue sea broccoli	4	crappy	
-3688	enchanted stale olive sea cauliflower	4	decent	Effect: "Red-Shirted Escort", Effect Duration: 35
-3689	miniature enchanted delicious tempura broccoli	2	awesome	Effect: "Voracious Gorging", Effect Duration: 5
+3688	stale enchanted olive sea cauliflower	4	decent	Effect: "Red-Shirted Escort", Effect Duration: 35
+3689	delicious enchanted miniature tempura broccoli	2	awesome	Effect: "Voracious Gorging", Effect Duration: 5
 3690	super-sized stale tempura cauliflower	5	decent	
 3691	delicious sea blueberry	4	awesome	
-3692	thick flavorless enchanted blinking mirror sea persimmon	5	decent	Effect: "Whippin' It Good", Effect Duration: 50
+3692	flavorless thick enchanted mirror blinking sea persimmon	5	decent	Effect: "Whippin' It Good", Effect Duration: 50
 3693	polymerized aerosolized pressurized potion of perception	0		Effect: "Human-Demon Hybrid", Effect Duration: 43
 3694	anodized pressurized potion of proficiency	0		Effect: "Egged On", Effect Duration: 27
 3695	hale Mer-kin digpick	0		Maximum HP: +20
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	pulsating lard-coated deadly handwarmer	0		Weapon Damage: +5, Sleaze Spell Damage: +25, Single Equip
 3737	gravedigger's sizzling lighter	0		Hot Damage: +10, Spooky Damage: +10
-3738	immense rotten packet of beer nuts	7	crappy	
+3738	rotten immense packet of beer nuts	7	crappy	
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	skewed spectral jelly	0		
@@ -3711,29 +3711,29 @@
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	cyan vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
-3749	colloidal quantum dry gray ghostly concoction of clumsiness	0		Effect: "On a Roll", Effect Duration: 38
+3749	colloidal quantum dry ghostly gray concoction of clumsiness	0		Effect: "On a Roll", Effect Duration: 38
 3750	blue medical-grade vampire pearl earring	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip
-3751	immense adequate chocolate chip brownies	9	good	
+3751	adequate immense chocolate chip brownies	9	good	
 3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	alkaline cyan love song of vague ambiguity	0		Effect: "Tightly-Wound Spine", Effect Duration: 32, Last Available: "2009-02"
 3755	dry modified wet love song of smoldering passion	0		Effect: "Milk Studly", Effect Duration: 49, Last Available: "2009-02"
 3756	nitrogenated purple love song of icy revenge	0		Effect: "Muscle Unbound", Effect Duration: 40, Last Available: "2009-02"
-3757	denatured magnetized fuchsia bouncing love song of sugary cuteness	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2009-02"
+3757	denatured magnetized bouncing fuchsia love song of sugary cuteness	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2009-02"
 3758	energized love song of disturbing obsession	0		Effect: "Big Meat Big Prizes", Effect Duration: 55, Last Available: "2009-02"
 3759	galvanized altered extra-flattened pulsating love song of naughty innuendo	0		Effect: "Dirge of Dreadfulness", Effect Duration: 26, Last Available: "2009-02"
 3760	dry blinking breath mint	0		Effect: "Egg Burps", Effect Duration: 29
 3761	Samson's vampire pearl ring	0		Experience (Muscle): +5, Single Equip
 3762	shaking Oprah's vampire pearl necklace	0		Maximum MP Percent: +50, Single Equip
 3763	lousy skewed narrow slug of vodka	3	decent	
-3764	bad strong slug of rum	5	decent	
+3764	strong bad slug of rum	5	decent	
 3765	triple-distilled drinkable slug of shochu	7	good	
-3766	weak tolerable screwdiver	2	good	
+3766	tolerable weak screwdiver	2	good	
 3767	mediocre dew yoana lei	3	decent	
 3768	acceptable lychee chuhai	4	good	
 3769	acceptable salacious screwdiver	4	good	
 3770	mediocre dew yoana salacious lei	4	decent	
 3771	watered-down aged fancy spinning salacious lychee chuhai	2	awesome	Effect: "Truly Gritty", Effect Duration: 20
-3772	watered-down delicious ghostly fuchsia Alewife&trade; Ale	2	awesome	
+3772	watered-down delicious fuchsia ghostly Alewife&trade; Ale	2	awesome	
 3773	lime green seaode	0		
 3774	map to the Dive Bar	0		
 3775	skewed huge Mer-kin pinkslip	0		
@@ -3768,11 +3768,11 @@
 3813	grievous plastic baby	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	moldy twirling blurry sea radish	3	crappy	
+3817	moldy blurry twirling sea radish	3	crappy	
 3818	flame-wreathed grievous groovy halibut	0		Moxie Percent: +10, Weapon Damage Percent: +50, Hot Spell Damage: +10
 3819	jittery eel sauce	0		
 3820	squat upside-down nippy water-polo mitt	0		Cold Damage: +10, Single Equip
-3821	vacuum-sealed unsweetened gray wobbly blinking syringe	0		Effect: "Icy Demeanor", Effect Duration: 51
+3821	vacuum-sealed unsweetened blinking gray wobbly syringe	0		Effect: "Icy Demeanor", Effect Duration: 51
 3822	blue wand	0		Familiar Effect: "fishy spells"
 3823	aerosolized altered teal wad of cotton	0		Effect: "Optimist Primal", Effect Duration: 37
 3824	spinning Grandma's Note	0		
@@ -3780,14 +3780,14 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	small normal tempura radish	2	good	
+3829	normal small tempura radish	2	good	
 3830	ghostly teal occult water-polo cap	0		Spell Damage Percent: +25, Familiar Effect: "1xVolley, 1xBarrr"
-3831	delicious weak Typical Tavern swill	2	awesome	
-3832	drinkable irresponsibly strong tumbling shaking tropical swill	7	good	
+3831	weak delicious Typical Tavern swill	2	awesome	
+3832	irresponsibly strong drinkable shaking tumbling tropical swill	7	good	
 3833	bad fruity girl swill	4	decent	
 3834	hand-crafted blended swill	3	EPIC	
 3835	costume wardrobe	0		Softcore Only
-3836	pulsating lard-coated resourceful hale wholesome Elvish sunglasses	0		Maximum HP Percent: +10, Maximum HP: +20, Maximum MP: +50, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	pulsating lard-coated resourceful hale wholesome Elvish sunglasses	0		Maximum HP Percent: +10, Maximum HP: +20, Maximum MP: +50, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	blinking shaking ruddy anniversary safety glass vest	0		Maximum HP Percent: +40
 3838	anniversary burlap belt	0		Item Drop: +5
 3839	bouncing tumbling careful anniversary balsa wood socks	0		Monster Level: -10
@@ -3831,7 +3831,7 @@
 3877	burst hellseal brain	0		
 3878	hellseal sinew	0		
 3879	spinning torn hellseal sinew	0		
-3880	bouncing fuchsia hellseal disguise	0		
+3880	fuchsia bouncing hellseal disguise	0		
 3881	upside-down horrifying lion tamer's fouet de tortue-dressage	0		Experience (familiar): +2, Spooky Damage: +25, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	upside-down encoded cult documents	0		
 3883	cult memo	0		
@@ -3928,8 +3928,8 @@
 3976	lightning-fast ruddy tortoboggan	0		Maximum HP Percent: +40, Initiative: +40, Single Equip
 3977	painted turtle	0		
 3978	huge miser's smooth painted shield	0		Moxie: +15, Meat Drop: +10, Damage Reduction: 7
-3979	purple pulsating sleeping wereturtle	0		
-3980	twirling blue shell	0		
+3979	pulsating purple sleeping wereturtle	0		
+3980	blue twirling shell	0		
 3981	mirror torquoise	0		
 3982	strapping torquoise ring of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Single Equip
 3983	dueling turtle	0		
@@ -4003,7 +4003,7 @@
 4051	blurry ring of teleportation of temperance	0		Sleaze Resistance: +5, Single Equip
 4052	glass of baboon milk	1	good	Last Available: "2009-06"
 4053	banana milkshake	1	decent	Last Available: "2009-06"
-4054	spirit-forward tolerable yellow squat White Hyborian	5	good	Last Available: "2009-06"
+4054	tolerable spirit-forward squat yellow White Hyborian	5	good	Last Available: "2009-06"
 4055	goblin hunting spear of courage	0		Spooky Resistance: +3, Last Available: "2009-06"
 4056	blinking yellow flame-retardant smartaleck's goblin autoblowgun	0		Moxie Percent: +30, Hot Resistance: +1, Last Available: "2009-06"
 4057	squat gray tribal beads of extreme caution	0		Monster Level: -25, Last Available: "2009-06"
@@ -4063,7 +4063,7 @@
 4111	scandalous brainy brazen bracelet	0		Mysticality: +5, Sleaze Damage: +5, Last Available: "2009-06"
 4112	wicked Sinatra's bitter bowtie	0		Experience (Moxie): +5, Spell Damage: +5, Last Available: "2009-06"
 4113	Rosewater's bewitching boots	0		Mysticality Percent: +30, Last Available: "2009-06"
-4114	wobbly skewed secret from the future	0		Last Available: "2009-06"
+4114	skewed wobbly secret from the future	0		Last Available: "2009-06"
 4115	jittery moist sack	0		
 4116	narrow inspector's hardened rickety unicycle of the overflowing toilet	0		Damage Reduction: 3, Stench Spell Damage: +50, Item Drop: +15, Single Equip
 4117	resourceful boxer's crusty hula hoop of the storm	0		Muscle Percent: +10, Maximum MP Percent: +40, Maximum MP: +50, Single Equip
@@ -4085,9 +4085,9 @@
 4133	Vulcanized flattened blue tempura air	0		Effect: "Gr8ness", Effect Duration: 41
 4134	super-dry pressurized potion of pneumaticity	0		Effect: "Coming Up Roses", Effect Duration: 61
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	blue rosy-cheeked baleful wizardly Bag o' Tricks of Leguizamo	0		Mysticality: +25, Spell Damage: +25, Maximum HP Percent: +30, Monster Level: +20, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	blue rosy-cheeked baleful wizardly Bag o' Tricks of Leguizamo	0		Mysticality: +25, Spell Damage: +25, Maximum HP Percent: +30, Monster Level: +20, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	slime stack	0		
-4138	twirling mirror a rumpled paper strip	0		
+4138	mirror twirling a rumpled paper strip	0		
 4139	a creased paper strip	0		
 4140	a folded paper strip	0		
 4141	a crinkled paper strip	0		
@@ -4103,13 +4103,13 @@
 4151	concentrated dubious peppermint	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25, Last Available: "2020-09"
 4152	extra-galvanized Elvish delight	0		Effect: "Ichorous Eyesight", Effect Duration: 24
 4153	blinking twirling rockfish stomach	0		Last Available: "2009-09"
-4154	bouncing teal live lobster	0		Last Available: "2011-12"
+4154	teal bouncing live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
 4156	spinning ghostly pebbles	0		Last Available: "2009-09"
 4157	gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	high-proof hand-crafted twirling pebblebr&auml;u	7	EPIC	Last Available: "2009-09"
+4160	hand-crafted high-proof twirling pebblebr&auml;u	7	EPIC	Last Available: "2009-09"
 4161	bland rocky road ice cream	3	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	tarnished enhanced tumbling children of the candy corn	0		Effect: "La Bamba", Effect Duration: 68
@@ -4138,7 +4138,7 @@
 4186	pulsating olive slime convention coupons	0		
 4187	Van der Graaf slime convention pin	0		MP Regen Min: 5, MP Regen Max: 7
 4188	slime convention t-shirt	0		
-4189	bouncing jittery inverse geode	0		
+4189	jittery bouncing inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	blue sugar shirt of the storm	0		Maximum MP Percent: +40, Last Available: "2009-09"
 4192	sugar shard	0		Last Available: "2009-09"
@@ -4154,7 +4154,7 @@
 4202	urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
 4204	Mer-kin cheatsheet	0		
-4205	jittery spinning Mer-kin wordquiz	0		
+4205	spinning jittery Mer-kin wordquiz	0		
 4206	upside-down family-friendly smooth brand new key	0		Moxie: +15, Sleaze Resistance: +1
 4207	purple narrow boxer's dorsal fin	0		Muscle Percent: +10, Damage Reduction: 13
 4208	skate skates	0		
@@ -4171,7 +4171,7 @@
 4219	gravedigger's steel-toed skate board	0		Damage Reduction: 9, Spooky Damage: +10
 4220	huge S.A.V.E. flyer	0		
 4221	jittery Temple Grandin's yield shield	0		Familiar Weight: +7, Damage Reduction: 6, Last Available: "2009-09"
-4222	red skewed map to the Skate Park	0		
+4222	skewed red map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	wobbly roller skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	olive salt-shaker	0		
 4236	can of sterno	0		
 4237	aromatic cheese-slicer	0		Stench Resistance: +1
-4238	spoiled half-sized pulsating red bouncing beef jerky	2	crappy	
+4238	half-sized spoiled red pulsating bouncing beef jerky	2	crappy	
 4239	clever pipe wrench	0		Maximum MP: +20
 4240	triple-energized improved tumbling gun cleaning kit	0		Effect: "Mad at Science", Effect Duration: 48
 4241	sinister sleep mask	0		Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4204,11 +4204,11 @@
 4252	aerosolized dry vial of squid ink	0		Effect: "The Magic of Sharing", Effect Duration: 50
 4253	double-liquefied huge upside-down potion of speed	0		Effect: "What's That Smell?", Effect Duration: 36
 4254	blue blinking bark	0		Last Available: "2009-10"
-4255	spinning blurry Wolfman Nardz	0		Last Available: "2009-10"
+4255	blurry spinning Wolfman Nardz	0		Last Available: "2009-10"
 4256	irradiated liquefied sap	0		Effect: "Serenity", Effect Duration: 50, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	rotten jumbo chocolate-covered scarab beetle	5	crappy	Last Available: "2009-10"
-4259	high-proof mediocre skewed mulled cider	6	decent	Last Available: "2009-10"
+4259	mediocre high-proof skewed mulled cider	6	decent	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	bouncing mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4291,7 +4291,7 @@
 4339	wobbly knitted plastic Crimbomination	0		Cold Resistance: +3, Last Available: "2009-12"
 4340	moist quadruple-flattened twirling Piddles	0		Effect: "PERL of Great Price", Effect Duration: 18, Last Available: "2009-12"
 4341	pickled BitterSweetTarts	0		Effect: "Flower Power", Effect Duration: 43, Last Available: "2009-12"
-4342	dry vacuum-sealed vacuum-sealed olive huge skewed Polka Pop	0		Effect: "Wintry Breath", Effect Duration: 56, Last Available: "2009-12"
+4342	dry vacuum-sealed vacuum-sealed skewed huge olive Polka Pop	0		Effect: "Wintry Breath", Effect Duration: 56, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
 4345	blinking ghostly string of Crimbo lights	0		Last Available: "2009-12"
@@ -4310,12 +4310,12 @@
 4358	maroon A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	adequate expired can of franks 'n' beans	3	good	Last Available: "2009-12"
-4361	weak delicious expired bottle of peppermint schnapps	2	awesome	Last Available: "2009-12"
+4361	delicious weak expired bottle of peppermint schnapps	2	awesome	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	mirror elf resistance button	0		Last Available: "2009-12"
 4364	aerosolized cyan elven suicide capsule	0		Effect: "Taurus Rising", Effect Duration: 35, Last Available: "2009-12"
-4365	spoiled low-calorie upside-down penguin focaccia bread	1	crappy	Last Available: "2009-12"
-4366	acceptable watered-down bouncing fuchsia herringcello	2	good	Last Available: "2009-12"
+4365	low-calorie spoiled upside-down penguin focaccia bread	1	crappy	Last Available: "2009-12"
+4366	acceptable watered-down fuchsia bouncing herringcello	2	good	Last Available: "2009-12"
 4367	lousy watered-down huge elven cellocello	2	decent	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
@@ -4340,9 +4340,9 @@
 4388	shaking passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	peanut brittle shield of the detective	0		Item Drop: +20, Damage Reduction: 3, Last Available: "2009-12"
 4390	wobbly curative brainy Red Rover BB gun	0		Mysticality: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-12"
-4391	rock-hard red-and-green sweater	0		Damage Reduction: 5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	rock-hard red-and-green sweater	0		Damage Reduction: 5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	bouncing wobbly Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
-4393	galvanized extra-aerosolized Vulcanized mirror blue Crimbo peppermint bark	0		Effect: "Blackberry Politeness", Effect Duration: 48, Last Available: "2009-12"
+4393	galvanized extra-aerosolized Vulcanized blue mirror Crimbo peppermint bark	0		Effect: "Blackberry Politeness", Effect Duration: 48, Last Available: "2009-12"
 4394	super-moist altered liquefied pulsating pulsating Crimbo fudge	0		Effect: "Dreadful Chill", Effect Duration: 45, Last Available: "2009-12"
 4395	triple-oxidized skewed Crimbo pecan	0		Effect: "Eau de Tortue", Effect Duration: 29, Last Available: "2009-12"
 4396	Jack-in-the-box	0		Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	upside-down Da Vinci's cheese sword	0		Experience (Mysticality): +5, Softcore Only, Last Available: "2010-01"
 4400	Lo Pan's cheese diaper	0		Spell Critical Percent: +30, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	rosy-cheeked cheese wheel	0		Maximum HP Percent: +30, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	shaking prompt cheese eye	0		Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	shaking prompt cheese eye	0		Adventures: +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	blurry flame-retardant Van der Graaf clever Staff of Queso Escusado	0		Maximum MP: +20, Hot Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	spinning The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4379,8 +4379,8 @@
 4429	shellacked candy necklace	0		Damage Reduction: 7, Single Equip
 4430	shellacked teddybear backpack	0		Damage Reduction: 7
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	anodized modified twirling red invisibility potion	0		Effect: "Taurus Rising", Effect Duration: 41, Last Available: "2011-08"
-4433	altered quadruple-flattened bouncing squat irresistibility potion	0		Effect: "You Liver", Effect Duration: 15, Last Available: "2011-08"
+4432	anodized modified red twirling invisibility potion	0		Effect: "Taurus Rising", Effect Duration: 41, Last Available: "2011-08"
+4433	altered quadruple-flattened squat bouncing irresistibility potion	0		Effect: "You Liver", Effect Duration: 15, Last Available: "2011-08"
 4434	frozen red irritability potion	0		Effect: "Once Bitten Twice Fried", Effect Duration: 61, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	huge hellseal whisker	0		
@@ -4408,14 +4408,14 @@
 4460	upside-down boxer's snailmail hauberk of doom	0		Muscle Percent: +10, Spooky Spell Damage: +50
 4461	quantum frozen pulsating seal-brain elixir	0		Effect: "Stands Alone", Effect Duration: 51
 4462	deionized vacuum-sealed cyan huge chocolate seal-clubbing club	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 21
-4463	cold-filtered quantum cyan jittery chocolate turtle totem	0		Effect: "Quantum of Moxie", Effect Duration: 12
+4463	cold-filtered quantum jittery cyan chocolate turtle totem	0		Effect: "Quantum of Moxie", Effect Duration: 12
 4464	super-dry energized double-diffused blurry chocolate pasta spoon	0		Effect: "Jelly Combed", Effect Duration: 62
 4465	irradiated non-deionized bouncing chocolate saucepan	0		Effect: "Weasels Underfoot", Effect Duration: 42
 4466	flattened gray chocolate disco ball	0		Effect: "Musky", Effect Duration: 13
 4467	unsweetened shaking wobbly chocolate stolen accordion	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 54
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
-4470	jittery squat BRICKO eye brick	0		Last Available: "2010-02"
+4470	squat jittery BRICKO eye brick	0		Last Available: "2010-02"
 4471	pulsating beefcake's BRICKO hat	0		Muscle: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
 4472	upside-down careful BRICKO pants	0		Monster Level: -10, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	BRICKO sword of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-02"
@@ -4424,7 +4424,7 @@
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	tumbling BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	tumbling BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4451,8 +4451,8 @@
 4503	deionized purple recording of Inigo's Incantation of Inspiration	0		Effect: "Horrid, Torrid", Effect Duration: 19, Last Available: "2010-02"
 4504	Sinatra's heart of the volcano of the cheetah	0		Experience (Moxie): +5, Initiative: +60
 4505	ionized chilled Northern pemmican	0		Effect: "Fizzier Than Light", Effect Duration: 62
-4506	squat red puzzling ribbon	0		
-4507	huge tumbling Clan looking glass	0		Free Pull, Last Available: "2010-03"
+4506	red squat puzzling ribbon	0		
+4507	tumbling huge Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	double-colloidal cold-filtered &quot;DRINK ME&quot; potion	0		Effect: "Moon'd", Effect Duration: 20, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	stale immense walrus ice cream	7	decent	Last Available: "2010-03"
@@ -4461,8 +4461,8 @@
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	bland Humpty Dumplings	3	decent	Last Available: "2010-03"
 4515	adequate Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
-4516	fancy drinkable practically non-alcoholic missing wine	1	good	Effect: "Happy Salamander", Effect Duration: 30, Last Available: "2010-03"
-4517	moldy tiny matter custard	1	crappy	Last Available: "2010-03"
+4516	practically non-alcoholic fancy drinkable missing wine	1	good	Effect: "Happy Salamander", Effect Duration: 30, Last Available: "2010-03"
+4517	tiny moldy matter custard	1	crappy	Last Available: "2010-03"
 4518	triple-denatured deionized lime green upside-down comfit?	0		Effect: "Gummiheart", Effect Duration: 25, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	studded Herculean flamingo mallet	0		Experience (Muscle): +1, Damage Absorption: +80, Last Available: "2010-03"
@@ -4470,15 +4470,15 @@
 4522	Tiger-lily's milk	1	EPIC	Last Available: "2010-03"
 4523	greasy rosy-cheeked eye of the Tiger-lily	0		Maximum HP Percent: +30, Sleaze Spell Damage: +10, Last Available: "2010-03"
 4524	asbestos-lined healthy wig	0		Maximum HP Percent: +20, Hot Resistance: +5, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	rotten spinning cyan spinning donut	3	crappy	Last Available: "2010-03"
+4525	rotten spinning spinning cyan donut	3	crappy	Last Available: "2010-03"
 4526	bland bucket of honey	3	decent	Last Available: "2010-03"
 4527	Sherlock's dance instructor's elephant stinger	0		Experience Percent (Moxie): +10, Item Drop: +25, Last Available: "2010-03"
 4528	snack-sized moldy yellow dragon snaps	2	crappy	Last Available: "2010-03"
 4529	nasty snapdragon pistil of the sewer	0		Stench Damage: 30, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	flavorless rook cookie	3	decent	Last Available: "2010-03"
-4532	moldy small bishop cookie	2	crappy	Last Available: "2010-03"
-4533	moldy fancy miniature knight cookie	2	crappy	Effect: "Sated and Furious", Effect Duration: 40, Last Available: "2010-03"
+4532	small moldy bishop cookie	2	crappy	Last Available: "2010-03"
+4533	fancy miniature moldy knight cookie	2	crappy	Effect: "Sated and Furious", Effect Duration: 40, Last Available: "2010-03"
 4534	moldy king cookie	4	crappy	Last Available: "2010-03"
 4535	decent fancy yellow queen cookie	4	good	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4508,9 +4508,9 @@
 4560	jittery map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	practically non-alcoholic delicious upside-down world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
+4563	delicious practically non-alcoholic upside-down world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
 4564	slippery when wet shield of the brute	0		Muscle Percent: +30, Damage Reduction: 6, Last Available: "2010-04"
-4565	low-calorie adequate maroon raisin	1	good	Last Available: "2010-04"
+4565	adequate low-calorie maroon raisin	1	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	wholesome flyest of shirts of Gandalf	0		Maximum HP Percent: +10, Spell Critical Percent: +20, Last Available: "2010-04"
 4568	flavorless gigantic a dance upon the palate	8	decent	Last Available: "2010-04"
@@ -4521,12 +4521,12 @@
 4573	jittery The Legendary Beat	0		Last Available: "2010-04"
 4574	tumbling panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	oxidized bouncing Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Oxygenated Blood", Effect Duration: 58, Last Available: "2010-04"
 4580	Newton's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Experience (Mysticality): +3, Last Available: "2010-04"
-4581	personal trainer's Newton's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	personal trainer's Newton's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	half-sized moldy teal six wedges of goat cheese	2	crappy	
@@ -4546,11 +4546,11 @@
 4598	blurry pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	twirling map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	acceptable weak plastic cup of beer	2	good	Last Available: "2010-06"
+4601	weak acceptable plastic cup of beer	2	good	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	miser's bottle of Goldschn&ouml;ckered of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	miser's bottle of Goldschn&ouml;ckered of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	decent sun-dried tofu	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	artisanal soyburger juice	3	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4569,12 +4569,12 @@
 4621	cyan Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	chilled upside-down shaking chocolate-covered caviar	0		Effect: "The Halls of Mysticality", Effect Duration: 33, Last Available: "2020-09"
-4624	half-sized normal shaking pawn cookie	2	good	Last Available: "2010-06"
+4624	normal half-sized shaking pawn cookie	2	good	Last Available: "2010-06"
 4625	modified shaking coffee pixie stick	1	good	Effect: "Just Aged Enough", Effect Duration: 45, Last Available: "2010-06"
 4626	shaking superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	executive plastic spider ring	0		Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	executive plastic spider ring	0		Meat Drop: +40, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	spinning Lo Pan's plastic kazoo	0		Spell Critical Percent: +30, Last Available: "2010-06"
 4631	inflatable baseball bat of the brute	0		Muscle Percent: +30, Last Available: "2010-06"
 4632	healthy googly-star hat of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5, Last Available: "2010-06", Familiar Effect: "atk"
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	stiffened blackberry galoshes	0		Damage Reduction: 1, Single Equip
 4660	perfumed hale trout fang	0		Maximum HP: +20, Stench Resistance: +5, Last Available: "2010-09"
-4661	rotten snack-sized poisonous caviar	2	crappy	Last Available: "2010-09"
+4661	snack-sized rotten poisonous caviar	2	crappy	Last Available: "2010-09"
 4662	pressed twirling wet venom duct	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 63, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	rock-hard experienced Ellsbury's skull	0		Experience: +2, Damage Reduction: 5, Last Available: "2010-09"
@@ -4645,7 +4645,7 @@
 4697	fossilized necklace of the early riser	0		Adventures: +7, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
-4700	green blurry fossilized spike	0		Last Available: "2010-09"
+4700	blurry green fossilized spike	0		Last Available: "2010-09"
 4701	waterlogged crate	0		Last Available: "2011-12"
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	upside-down reassuring red-hot medallion	0		Spooky Resistance: +1, Single Equip, Last Available: "2010-09"
@@ -4667,12 +4667,12 @@
 4719	Temple Grandin's Hollandaise helmet	0		Familiar Weight: +7, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	massive rotten liver and let pie	7	crappy	Last Available: "2010-10"
-4723	delicious big badass pie	5	awesome	Last Available: "2010-10"
+4722	rotten massive liver and let pie	7	crappy	Last Available: "2010-10"
+4723	big delicious badass pie	5	awesome	Last Available: "2010-10"
 4724	massive normal ghostly shoo-fish pie	7	good	Last Available: "2010-10"
 4725	rotten piping organ pie	3	crappy	Last Available: "2010-10"
 4726	moldy jittery igloo pie	3	crappy	Last Available: "2010-10"
-4727	snack-sized adequate stomach turnover	2	good	Last Available: "2010-10"
+4727	adequate snack-sized stomach turnover	2	good	Last Available: "2010-10"
 4728	rotten immense squat dead lights pie	10	crappy	Last Available: "2010-10"
 4729	small rotten yellow throbbing organ pie	2	crappy	Last Available: "2010-10"
 4730	sharpshooter's stop shield	0		Critical Hit Percent: +10, Damage Reduction: 6, Last Available: "2009-12"
@@ -4688,7 +4688,7 @@
 4740	practically non-alcoholic hand-crafted overpriced &quot;imported&quot; beer	1	EPIC	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
-4743	narrow huge bone chips	0		Last Available: "2011-12"
+4743	huge narrow bone chips	0		Last Available: "2011-12"
 4744	quadruple-alkaline PlexiPips	0		Effect: "Amorphous Cheer", Effect Duration: 63
 4745	Vulcanized Wax Flask	0		Effect: "There Wolf", Effect Duration: 66
 4746	unsweetened bouncing Pain Dip	0		Effect: "Tiki Temerity", Effect Duration: 14
@@ -4724,7 +4724,7 @@
 4810	blurry Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	twirling Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	spoiled fancy big CRIMBCOIDS mints	5	crappy	Effect: "Stimulated Brain", Effect Duration: 30, Last Available: "2011-01"
+4818	fancy spoiled big CRIMBCOIDS mints	5	crappy	Effect: "Stimulated Brain", Effect Duration: 30, Last Available: "2011-01"
 4819	olive can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	moldy snack-sized CRIMBCOLOAF	2	crappy	Last Available: "2011-01"
 4821	flavorless half-sized circular CRIMBCOOKIE	2	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,12 +4745,12 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	twirling teal robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	diet moldy triangular CRIMBCOOKIE	1	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	moldy diet triangular CRIMBCOOKIE	1	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	decent square CRIMBCOOKIE	3	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	ghostly spinning auspicious Jeselnik's nasty bindlestocking	0		Stench Damage: +5, Sleaze Damage: +25, Item Drop: +10, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
-4844	spinning purple The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
+4844	purple spinning The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
 4845	Fonzie's Uncle Hobo's stocking cap of the glutton	0		Experience (Moxie): +1, Food Drop: +100, Last Available: "2010-12", Familiar Effect: "atk"
 4846	cyan dance instructor's strapping Uncle Hobo's epic beard	0		Muscle: +5, Experience Percent (Moxie): +10, Single Equip, Last Available: "2010-12"
 4847	twirling friendly Jim Carey's Uncle Hobo's gift baggy pants	0		Monster Level: +25, Familiar Weight: +3, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
@@ -4769,7 +4769,7 @@
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	squat CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-4863	pulsating huge CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+4863	huge pulsating CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	twirling photocopier	0		Last Available: "2011-01"
 4865	cyan deluxe fax machine	0		Last Available: "2011-01"
 4866	blue Workytime Tea	0		Last Available: "2011-01"
@@ -4778,16 +4778,16 @@
 4869	shaking asbestos-lined paperclip pants of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
 4870	scandalous paperclip turban of extreme caution of horror	0		Monster Level: -25, Spooky Spell Damage: +25, Sleaze Damage: +5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	paperclip cape of wisdom	0		Mysticality: +15, Last Available: "2011-01"
-4872	teal squat glob of Blank-Out	0		Last Available: "2011-01"
+4872	squat teal glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
 4875	blurry tumbling BGE merchandise order form	0		Last Available: "2010-12"
-4876	ionized energized deionized ghostly purple chocolate bath ball	0		Effect: "Sizzling with Fury", Effect Duration: 67, Last Available: "2011-01"
+4876	ionized energized deionized purple ghostly chocolate bath ball	0		Effect: "Sizzling with Fury", Effect Duration: 67, Last Available: "2011-01"
 4877	tarnished tarnished skewed bacon bath ball	0		Effect: "Whippin' It Good", Effect Duration: 18, Last Available: "2011-01"
 4878	flattened blinking incense bath ball	0		Effect: "init.enh", Effect Duration: 62, Last Available: "2011-01"
 4879	non-denatured myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Stone-Faced", Effect Duration: 26, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	practically non-alcoholic mediocre CRIMBCO wine	1	decent	Last Available: "2011-01"
+4881	mediocre practically non-alcoholic CRIMBCO wine	1	decent	Last Available: "2011-01"
 4882	lime green narrow Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	moldy miniature toe jam toast	2	crappy	Last Available: "2011-01"
@@ -4824,7 +4824,7 @@
 4915	up-at-dawn medical-grade Loathing Legion chainsaw	0		Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2011-01"
 4916	Loathing Legion rollerblades of bravery	0		Spooky Resistance: +5, Single Equip, Softcore Only, Last Available: "2011-01"
 4917	smelly Loathing Legion flamethrower	0		Stench Spell Damage: +10, Softcore Only, Last Available: "2011-01"
-4918	ghostly wobbly Loathing Legion tattoo needle	0		Last Available: "2011-01"
+4918	wobbly ghostly Loathing Legion tattoo needle	0		Last Available: "2011-01"
 4919	gray hardened Loathing Legion defibrillator	0		Damage Reduction: 3, Softcore Only, Last Available: "2011-01"
 4920	deadly Loathing Legion double prism	0		Weapon Damage: +5, Softcore Only, Last Available: "2011-01"
 4921	jittery Loathing Legion tape measure of temperance	0		Sleaze Resistance: +5, Softcore Only, Last Available: "2011-01"
@@ -4855,12 +4855,12 @@
 4952	triple-pickled yellow blinking baggie of sugar	0		Effect: "So Fresh and So Clean", Effect Duration: 49
 4953	blurry whalebone corset of the storm of Leguizamo	0		Maximum MP Percent: +40, Monster Level: +20, Single Equip
 4954	skewed Van der Graaf oven mitts	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip
-4955	adequate small overcookie	2	good	
+4955	small adequate overcookie	2	good	
 4956	tasty small philosopher's scone	2	awesome	
 4957	corrupted blurry half-baked potion	0		Effect: "Gemini Rising", Effect Duration: 65
 4958	red blinking occult Knob Goblin deluxe scimitar	0		Spell Damage Percent: +25
 4959	stale bite-sized Knob nuts	1	decent	
-4960	practically non-alcoholic lousy Cobb's Knob Wurstbrau	1	decent	
+4960	lousy practically non-alcoholic Cobb's Knob Wurstbrau	1	decent	
 4961	Subject 37 file	0		
 4962	green auspicious padded mysterious lapel pin	0		Damage Absorption: +20, Item Drop: +10, Single Equip
 4963	tumbling state loom	0		Familiar Weight: +10
@@ -4897,7 +4897,7 @@
 4994	cyan Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	spinning Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
-4997	shaking fuchsia blinking Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
+4997	blinking fuchsia shaking Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	jittery Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	tumbling Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	Alice's Army Foil Bowman	0		Last Available: "2011-03"
@@ -4913,7 +4913,7 @@
 5010	yellow evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	tiny bland mirror wasabi pocky	1	decent	Last Available: "2011-03"
+5013	bland tiny mirror wasabi pocky	1	decent	Last Available: "2011-03"
 5014	toothsome tobiko pocky	3	awesome	Last Available: "2011-03"
 5015	bland natto pocky	3	decent	Last Available: "2011-03"
 5016	lousy irresponsibly strong tumbling wasabi-infused sake	8	decent	Last Available: "2011-03"
@@ -4943,7 +4943,7 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	twirling teal Usain Bolt's weightlifter's astral shirt of the businessman	0		Muscle: +15, Meat Drop: +50, Initiative: +80
 5042	dance instructor's astral belt of doom	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +50
-5043	super-sized stale lime green narrow astral hot dog	5		
+5043	stale super-sized narrow lime green astral hot dog	5		
 5044	artisanal astral pilsner	4		
 5045	squat astral hot dog dinner	0		
 5046	astral six-pack	0		
@@ -4973,11 +4973,11 @@
 5070	innuendo	0		Last Available: "2011-04"
 5071	stale s'more	0	decent	Last Available: "2011-04"
 5072	purple diamond ring	0		Last Available: "2011-04"
-5073	mediocre watered-down Russian Ice	2	decent	Last Available: "2011-04"
+5073	watered-down mediocre Russian Ice	2	decent	Last Available: "2011-04"
 5074	ribald clay ashtray	0		Sleaze Damage: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	gray lanyard of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2011-05"
 5076	groovy monster pants	0		Moxie Percent: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
-5077	tumbling blinking box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
+5077	blinking tumbling box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	frozen energized spinning Pok&euml;mann band-aid	0		Effect: "Frisky Spirit", Effect Duration: 65, Last Available: "2011-05"
 5079	hardened slick Van der Graaf helmet	0		Moxie: +10, Damage Reduction: 3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	skewed wool crutch	0		Cold Resistance: +1, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	watered-down hand-crafted Jeppson's Malort	2	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	pulsating fistful of ashes	0		
-5109	shaking Fonzie's stress ball	0		Experience (Moxie): +1, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	shaking Fonzie's stress ball	0		Experience (Moxie): +1, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	mirror Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	purple supercool Ultracolor&trade; shirt	0		Moxie Percent: +20, Last Available: "2011-05"
 5112	tumbling My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5033,13 +5033,13 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	electrified liquefied huge Ultrasoldier Serum	0		Effect: "Human-Undead Hybrid", Effect Duration: 31, Last Available: "2011-06"
 5132	tasty olive elven hardtack	3	awesome	Last Available: "2011-06"
-5133	irresponsibly strong acceptable elven squeeze	10	good	Last Available: "2011-06"
+5133	acceptable irresponsibly strong elven squeeze	10	good	Last Available: "2011-06"
 5134	blurry lunar isotope	0		Last Available: "2011-06"
 5135	twirling E.M.U. joystick	0		Last Available: "2011-06"
-5136	shaking twirling E.M.U. rocket thrusters	0		Last Available: "2011-06"
+5136	twirling shaking E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	narrow E.M.U. harness	0		Last Available: "2011-06"
-5139	pulsating upside-down carton of astral energy drinks	0		
+5139	upside-down pulsating carton of astral energy drinks	0		
 5140	boiled jittery astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
@@ -5075,7 +5075,7 @@
 5172	ghostly Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	fancy irresponsibly strong delicious Saison du Lune	9	awesome	Effect: "Coated Arms", Effect Duration: 15, Last Available: "2011-06"
-5175	tolerable strong Moonthril Schnapps	5	good	Last Available: "2011-06"
+5175	strong tolerable Moonthril Schnapps	5	good	Last Available: "2011-06"
 5176	smooth Wrecked Generator	3	awesome	Last Available: "2011-06"
 5177	normal Spaghetti with Moonballs	3	good	Last Available: "2011-06"
 5178	spoiled Crepes a la Lune	4	crappy	Last Available: "2011-06"
@@ -5088,9 +5088,9 @@
 5185	blinking Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
-5188	galvanized spinning wobbly honey stick	0		Effect: "Mistified", Effect Duration: 69
+5188	galvanized wobbly spinning honey stick	0		Effect: "Mistified", Effect Duration: 69
 5189	corrupted double-concentrated double-ice gum	0		Effect: "Memories of Puppy Love", Effect Duration: 19, Last Available: "2011-04"
-5190	foul-smelling stiffened forbidden Operation Patriot Shield	0		Spell Damage Percent: +50, Damage Reduction: 2, Stench Damage: +10, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	foul-smelling stiffened forbidden Operation Patriot Shield	0		Spell Damage Percent: +50, Damage Reduction: 2, Stench Damage: +10, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	flattened spinning corrupted data	0		Effect: "Pumped Stomach", Effect Duration: 22, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5101,21 +5101,21 @@
 5198	denatured gooey paste	1	good	Last Available: "2011-08"
 5199	pickled wobbly beastly paste	1	good	Last Available: "2011-08"
 5200	denatured paste	1	good	Last Available: "2011-08"
-5201	mixed ghostly cyan skewed ectoplasmic paste	1	awesome	Effect: "No Worries", Effect Duration: 10, Last Available: "2011-08"
+5201	mixed cyan skewed ghostly ectoplasmic paste	1	awesome	Effect: "No Worries", Effect Duration: 10, Last Available: "2011-08"
 5202	twisted huge greasy paste	1	crappy	Last Available: "2011-08"
 5203	boiled bug paste	1	EPIC	Last Available: "2011-08"
 5204	denatured hippy paste	1	awesome	Effect: "Remaining Alive", Effect Duration: 25, Last Available: "2011-08"
-5205	pickled blinking ghostly orc paste	1	awesome	Last Available: "2011-08"
+5205	pickled ghostly blinking orc paste	1	awesome	Last Available: "2011-08"
 5206	mixed demonic paste	1	EPIC	Last Available: "2011-08"
-5207	diluted maroon skewed indescribably horrible paste	1	decent	Last Available: "2011-08"
-5208	modified maroon bouncing paste	1	EPIC	Last Available: "2011-08"
+5207	diluted skewed maroon indescribably horrible paste	1	decent	Last Available: "2011-08"
+5208	modified bouncing maroon paste	1	EPIC	Last Available: "2011-08"
 5209	compressed shaking goblin paste	1	decent	Effect: "Poker Faced", Effect Duration: 50, Last Available: "2011-08"
 5210	pickled pirate paste	1	decent	Last Available: "2011-08"
 5211	denatured green pulsating chlorophyll paste	1	decent	Last Available: "2011-08"
 5212	powdered red paste	1	crappy	Last Available: "2011-08"
 5213	mixed cyan Mer-kin paste	1	EPIC	Last Available: "2011-08"
 5214	twisted slimy paste	1	decent	Last Available: "2011-08"
-5215	altered cyan shaking penguin paste	1	decent	Last Available: "2011-08"
+5215	altered shaking cyan penguin paste	1	decent	Last Available: "2011-08"
 5216	mixed twirling elemental paste	1	EPIC	Effect: "Slimily Speedy", Effect Duration: 15, Last Available: "2011-08"
 5217	dehydrated cosmic paste	1	EPIC	Effect: "Analog Drunk", Effect Duration: 20, Last Available: "2011-08"
 5218	mixed purple ghostly hobo paste	1	good	Effect: "Total Protonic Reversal", Effect Duration: 10, Last Available: "2011-08"
@@ -5138,25 +5138,25 @@
 5235	furry halo of the dark arts	0		Spell Damage Percent: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	banded frosty halo	0		Damage Absorption: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of the overflowing toilet	0		Stench Spell Damage: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	fancy tolerable Lumineux Limnio	3	good	Effect: "A View to Some Meat", Effect Duration: 40, Last Available: "2011-09"
+5238	tolerable fancy Lumineux Limnio	3	good	Effect: "A View to Some Meat", Effect Duration: 40, Last Available: "2011-09"
 5239	lousy upside-down Morto Moreto	3	decent	Last Available: "2011-09"
 5240	practically non-alcoholic hand-crafted Temps Tempranillo	1	EPIC	Last Available: "2011-09"
 5241	practically non-alcoholic lousy Bordeaux Marteaux	1	decent	Last Available: "2011-09"
-5242	strong drinkable Fromage Pinotage	5	good	Last Available: "2011-09"
-5243	enchanted tolerable Beignet Milgranet	4	good	Effect: "Patent Alacrity", Effect Duration: 10, Last Available: "2011-09"
-5244	hand-crafted spirit-forward Muschat	5	EPIC	Last Available: "2011-09"
-5245	miniature stale cool jelly donut	2	decent	Last Available: "2011-09"
+5242	drinkable strong Fromage Pinotage	5	good	Last Available: "2011-09"
+5243	tolerable enchanted Beignet Milgranet	4	good	Effect: "Patent Alacrity", Effect Duration: 10, Last Available: "2011-09"
+5244	spirit-forward hand-crafted Muschat	5	EPIC	Last Available: "2011-09"
+5245	stale miniature cool jelly donut	2	decent	Last Available: "2011-09"
 5246	bland diet shrapnel jelly donut	1	decent	Last Available: "2011-09"
 5247	stale super-sized occult jelly donut	5	decent	Last Available: "2011-09"
 5248	huge decent thyme jelly donut	10	good	Last Available: "2011-09"
-5249	snack-sized moldy danish	2	crappy	Last Available: "2011-09"
-5250	massive decent smashed danish	7	good	Last Available: "2011-09"
+5249	moldy snack-sized danish	2	crappy	Last Available: "2011-09"
+5250	decent massive smashed danish	7	good	Last Available: "2011-09"
 5251	adequate upside-down shaking forbidden danish	4	good	Last Available: "2011-09"
-5252	half-sized rotten cool cat claw	2	crappy	Last Available: "2011-09"
-5253	spoiled huge cyan blunt cat claw	7	crappy	Last Available: "2011-09"
+5252	rotten half-sized cool cat claw	2	crappy	Last Available: "2011-09"
+5253	huge spoiled cyan blunt cat claw	7	crappy	Last Available: "2011-09"
 5254	rotten shadowy cat claw	4	crappy	Last Available: "2011-09"
-5255	special normal diet tumbling cheezburger	1	good	Effect: "Smelly Pants", Effect Duration: 50, Last Available: "2011-09"
-5256	jumbo special delicious toasted brie	5	awesome	Effect: "Quadrilled", Effect Duration: 50, Last Available: "2011-09"
+5255	diet special normal tumbling cheezburger	1	good	Effect: "Smelly Pants", Effect Duration: 50, Last Available: "2011-09"
+5256	special delicious jumbo toasted brie	5	awesome	Effect: "Quadrilled", Effect Duration: 50, Last Available: "2011-09"
 5257	triple-liquefied quadruple-magnetized potion of the field gar	0		Effect: "Smoky Third Eye", Effect Duration: 25, Last Available: "2011-09"
 5258	modified triple-pressed too legit potion	0		Effect: "Big Flaming Whip", Effect Duration: 39, Last Available: "2011-09"
 5259	quadruple-ionized upside-down Bright Water	0		Effect: "Celestial Vision", Effect Duration: 29, Last Available: "2011-09"
@@ -5192,14 +5192,14 @@
 5289	d12	0		Last Available: "2011-09"
 5290	huge d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
-5292	blinking red generic mana potion	0		Last Available: "2011-09"
+5292	red blinking generic mana potion	0		Last Available: "2011-09"
 5293	gray generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
 5295	red newborn kobold	0		Last Available: "2011-09"
 5296	gray slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	decent tiny phish stick	1	good	Last Available: "2011-09"
-5299	ghostly lion tamer's plastic vampire fangs of the blizzard of the cheetah	0		Experience (familiar): +2, Cold Spell Damage: +25, Initiative: +60, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	ghostly lion tamer's plastic vampire fangs of the blizzard of the cheetah	0		Experience (familiar): +2, Cold Spell Damage: +25, Initiative: +60, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	maroon Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	purple Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5213,20 +5213,20 @@
 5310	shotgun shell	0		Last Available: "2011-10"
 5311	funhouse mirror	0		Last Available: "2011-10"
 5312	ionized ghostly body paint	0		Effect: "Stone-Faced", Effect Duration: 37, Last Available: "2011-10"
-5313	pressed mirror mirror blue necrotizing body spray	0		Effect: "X-Ray Vision", Effect Duration: 52, Last Available: "2011-10"
-5314	diffused super-liquefied concentrated narrow skewed bite-me-red lipstick	0		Effect: "Corruption of Wretched Wally", Effect Duration: 16, Last Available: "2011-10"
+5313	pressed blue mirror mirror necrotizing body spray	0		Effect: "X-Ray Vision", Effect Duration: 52, Last Available: "2011-10"
+5314	diffused super-liquefied concentrated skewed narrow bite-me-red lipstick	0		Effect: "Corruption of Wretched Wally", Effect Duration: 16, Last Available: "2011-10"
 5315	dry huge whisker pencil	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 65, Last Available: "2011-10"
 5316	triple-nitrogenated enhanced press-on ribs	0		Effect: "Chilblains of the Corn", Effect Duration: 58, Last Available: "2011-10"
 5317	extra-aerosolized spinning Rattlin' Chains	0		Effect: "Patched In", Effect Duration: 13, Last Available: "2011-10"
 5318	denatured colloidal aerosolized Gummy Brains	0		Effect: "Heart of Orange", Effect Duration: 42, Last Available: "2011-10"
 5319	aerosolized liquefied adjusted tumbling Blood 'n' Plenty	0		Effect: "Sagittarius Rising", Effect Duration: 27, Last Available: "2011-10"
-5320	double-deionized shaking mirror Lobos Mints	0		Effect: "Crud&eacute;", Effect Duration: 23, Last Available: "2011-10"
+5320	double-deionized mirror shaking Lobos Mints	0		Effect: "Crud&eacute;", Effect Duration: 23, Last Available: "2011-10"
 5321	electrified wobbly Sweet Sword	0		Effect: "Feline Ferocity", Effect Duration: 20, Last Available: "2011-10"
 5322	artisanal upside-down Ecto-Cooler	3	EPIC	Last Available: "2011-10"
 5323	special lousy Bartles and BRAAAINS wine cooler	3	decent	Effect: "Frost Tea", Effect Duration: 35, Last Available: "2011-10"
 5324	artisanal spirit-forward Blood Light	5	EPIC	Last Available: "2011-10"
-5325	hand-crafted weak skewed Silver Bullet beer	2	EPIC	Last Available: "2011-10"
-5326	hand-crafted watered-down pulsating Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
+5325	weak hand-crafted skewed Silver Bullet beer	2	EPIC	Last Available: "2011-10"
+5326	watered-down hand-crafted pulsating Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	triple-warmed vacuum-sealed spinning twirling sorority brain	0		Effect: "Venomous Weapon", Effect Duration: 50, Last Available: "2011-10"
 5329	polarized squat Nightstalker perfume	0		Effect: "Got Your Boots On", Effect Duration: 27, Last Available: "2011-10"
@@ -5248,7 +5248,7 @@
 5345	vacuum-sealed lime green Necbro wafers	0		Effect: "Puzzle Fury", Effect Duration: 62, Last Available: "2020-09"
 5346	death blossom	0		
 5347	olive A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
-5348	blurry huge A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
+5348	huge blurry A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	jittery A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
@@ -5260,7 +5260,7 @@
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-5360	shaking yellow Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
+5360	yellow shaking Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	blue CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	wobbly CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
@@ -5279,11 +5279,11 @@
 5376	teal medical-grade plastic Big Candy of the empath	0		Familiar Weight: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-12"
 5377	The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	diluted shaking pulsating upside-down groose grease	1	EPIC	Effect: "Rat-Faced", Effect Duration: 20, Last Available: "2012-12"
+5379	diluted upside-down shaking pulsating groose grease	1	EPIC	Effect: "Rat-Faced", Effect Duration: 20, Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
-5383	wobbly spinning tourmalime	0		Last Available: "2011-11"
+5383	spinning wobbly tourmalime	0		Last Available: "2011-11"
 5384	kumquartz	0		Last Available: "2011-11"
 5385	strawberyl	0		Last Available: "2011-11"
 5386	huge stiffened ridiculous belt	0		Damage Reduction: 1, Last Available: "2011-11"
@@ -5296,7 +5296,7 @@
 5393	scrap of paper	0		
 5394	sandpaper	0		
 5395	peppermint sprout	0		Last Available: "2011-11"
-5396	super-polymerized moist pulsating lime green peppermint twist	0		Effect: "Gemini Rising", Effect Duration: 63, Last Available: "2011-11"
+5396	super-polymerized moist lime green pulsating peppermint twist	0		Effect: "Gemini Rising", Effect Duration: 63, Last Available: "2011-11"
 5397	spoiled huge blue peppermint patty	4	crappy	Last Available: "2011-11"
 5398	huge peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
@@ -5308,15 +5308,15 @@
 5405	foul-smelling lion tamer's deadly cane-mail shirt	0		Weapon Damage: +5, Experience (familiar): +2, Stench Damage: +10, Last Available: "2011-12"
 5406	purple squat narrow horrifying Lo Pan's cane-mail pants of the brute	0		Muscle Percent: +30, Spell Critical Percent: +30, Spooky Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	perfectly mixed watered-down Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
-5408	high-proof perfectly mixed enchanted red Gin Mint	9	EPIC	Effect: "Broken Bone Nubs", Effect Duration: 25, Last Available: "2011-12"
+5408	perfectly mixed high-proof enchanted red Gin Mint	9	EPIC	Effect: "Broken Bone Nubs", Effect Duration: 25, Last Available: "2011-12"
 5409	bad strong huge Tequiz Navidad	5	decent	Last Available: "2011-12"
-5410	delicious practically non-alcoholic bouncing Mint Yulep	1	awesome	Last Available: "2011-12"
+5410	practically non-alcoholic delicious bouncing Mint Yulep	1	awesome	Last Available: "2011-12"
 5411	perfectly mixed Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	acceptable tumbling Sangria de Menthe	3	good	Last Available: "2011-12"
 5413	blinking candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
-5415	diffused red huge licorice root	0		Effect: "Rootin' Around", Effect Duration: 54, Last Available: "2011-12"
-5416	anodized ghostly skewed banana supersucker	0		Effect: "Frisky Spirit", Effect Duration: 48, Last Available: "2011-11"
+5415	diffused huge red licorice root	0		Effect: "Rootin' Around", Effect Duration: 54, Last Available: "2011-12"
+5416	anodized skewed ghostly banana supersucker	0		Effect: "Frisky Spirit", Effect Duration: 48, Last Available: "2011-11"
 5417	boiled pear supersucker	0		Effect: "Cat-Alyzed", Effect Duration: 25, Last Available: "2011-11"
 5418	electrified blurry lime supersucker	0		Effect: "Eyes for Miles", Effect Duration: 37, Last Available: "2011-11"
 5419	deionized frozen kumquat supersucker	0		Effect: "Gummiskin", Effect Duration: 59, Last Available: "2011-11"
@@ -5333,20 +5333,20 @@
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	upside-down cinnamon troll doll	0		Last Available: "2011-11"
 5432	grape troll doll	0		Last Available: "2011-11"
-5433	fuchsia tumbling raspberry troll doll	0		Last Available: "2011-11"
+5433	tumbling fuchsia raspberry troll doll	0		Last Available: "2011-11"
 5434	blurry DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
-5436	dry cyan tumbling fudge lily	0		Effect: "Hood Ridin'", Effect Duration: 34, Last Available: "2011-11"
-5437	blurry teal superheated fudge	0		Last Available: "2011-11"
+5436	dry tumbling cyan fudge lily	0		Effect: "Hood Ridin'", Effect Duration: 34, Last Available: "2011-11"
+5437	teal blurry superheated fudge	0		Last Available: "2011-11"
 5438	Vulcanized fuchsia fluid of fudge-finding	0		Effect: "Updated", Effect Duration: 65, Last Available: "2011-11"
 5439	blinking fudgepuck	0		Last Available: "2011-11"
-5440	decent snack-sized bouncing fudgesicle	2	good	Last Available: "2011-11"
+5440	snack-sized decent bouncing fudgesicle	2	good	Last Available: "2011-11"
 5441	tumbling wand of fudge control	0		Last Available: "2011-11"
 5442	bouncing The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	huge miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	altered tarnished double-adjusted shaking devilish folio	0		Effect: "Healthy Bronze Glow", Effect Duration: 42, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
-5446	teal huge jar full of wind	0		Last Available: "2012-12"
+5446	huge teal jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
 5449	mirror vanity stone	0		Last Available: "2012-12"
@@ -5379,11 +5379,11 @@
 5476	polymerized gummi salamander	0		Effect: "Cold Hands", Effect Duration: 11, Last Available: "2011-11"
 5477	wet modified gummi snake	0		Effect: "Mmmmmelon", Effect Duration: 14, Last Available: "2011-11"
 5478	extra-adjusted gummi canary	0		Effect: "The Power of Positive Thinking", Effect Duration: 69, Last Available: "2011-11"
-5479	adequate huge gummi bear	7	good	Last Available: "2011-11"
+5479	huge adequate gummi bear	7	good	Last Available: "2011-11"
 5480	stale gummi bear	4	decent	Last Available: "2011-11"
 5481	immense spoiled gummi bear	10	crappy	Last Available: "2011-11"
 5482	diet moldy upside-down drunki-bear	1	crappy	Last Available: "2011-11"
-5483	massive moldy drunki-bear	9	crappy	Last Available: "2011-11"
+5483	moldy massive drunki-bear	9	crappy	Last Available: "2011-11"
 5484	small toothsome drunki-bear	2	awesome	Last Available: "2011-11"
 5485	vibrating gummi bowtie	0		Maximum MP Percent: +10, Last Available: "2011-11"
 5486	shaking hale fudge pocket square	0		Maximum HP: +20, Last Available: "2011-11"
@@ -5405,7 +5405,7 @@
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	squat blessed box	0		
-5505	wobbly jittery maroon pack of pogs	0		Last Available: "2011-11"
+5505	maroon jittery wobbly pack of pogs	0		Last Available: "2011-11"
 5506	adequate jerky coins	3	good	Last Available: "2011-11"
 5507	fancy hand-crafted Go-Wassail	3	EPIC	Effect: "Castaway Physique", Effect Duration: 20, Last Available: "2011-11"
 5508	flattened skewed Uncle Greenspan's Bathroom Finance Guide	0		Effect: "The Style... of the Future", Effect Duration: 54, Last Available: "2011-11"
@@ -5459,13 +5459,13 @@
 5556	Samson's Rain-Doh wings of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50, Softcore Only, Last Available: "2012-02"
 5557	tumbling Rain-Doh agent	0		Last Available: "2012-02"
 5558	mansplainer's Rain-Doh laser gun of the overflowing toilet	0		Monster Level: +15, Stench Spell Damage: +50, Softcore Only, Last Available: "2012-02"
-5559	spinning smelly Rain-Doh lantern of bravery	0		Stench Spell Damage: +10, Spooky Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	spinning smelly Rain-Doh lantern of bravery	0		Stench Spell Damage: +10, Spooky Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	spinning Rain-Doh balls	0		Last Available: "2012-02"
 5561	spinning Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	reassuring padded Rain-Doh violet bo	0		Damage Absorption: +20, Spooky Resistance: +1, Softcore Only, Last Available: "2012-02"
 5563	cyan Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	decent low-calorie fancy PB&BP	1	good	Effect: "Nano-juiced", Effect Duration: 40
+5565	fancy decent low-calorie PB&BP	1	good	Effect: "Nano-juiced", Effect Duration: 40
 5566	yummy club sandwich	3	awesome	
 5567	gigantic moldy corned-beef Reuben	6	crappy	
 5568	tumbling green frayed ninja rope	0		
@@ -5476,66 +5476,66 @@
 5573	perfectly mixed Drac & Tan	4	EPIC	Last Available: "2012-03"
 5574	artisanal teal Transylvania Sling	3	EPIC	Last Available: "2012-03"
 5575	perfectly mixed yellow Shot of the Living Dead	3	EPIC	Last Available: "2012-03"
-5576	perfectly mixed watered-down Buttery Knob	2	EPIC	Last Available: "2012-03"
+5576	watered-down perfectly mixed Buttery Knob	2	EPIC	Last Available: "2012-03"
 5577	mediocre maroon Slippery Knob	3	decent	Last Available: "2012-03"
 5578	weak smooth Flaming Knob	2	awesome	Last Available: "2012-03"
 5579	hand-crafted Grasshopper	4	EPIC	Last Available: "2012-03"
-5580	watered-down acceptable Locust	2	good	Last Available: "2012-03"
+5580	acceptable watered-down Locust	2	good	Last Available: "2012-03"
 5581	smooth distilled Plague of Locusts	5	awesome	Last Available: "2012-03"
 5582	bad spinning Red Dwarf	4	decent	Last Available: "2012-03"
-5583	artisanal irresponsibly strong Golden Mean	8	EPIC	Last Available: "2012-03"
-5584	tolerable watered-down wobbly Green Giant	2	good	Last Available: "2012-03"
+5583	irresponsibly strong artisanal Golden Mean	8	EPIC	Last Available: "2012-03"
+5584	watered-down tolerable wobbly Green Giant	2	good	Last Available: "2012-03"
 5585	drinkable blinking Aye Aye	3	good	Last Available: "2012-03"
 5586	fortified artisanal Aye Aye, Captain	5	EPIC	Last Available: "2012-03"
 5587	practically non-alcoholic acceptable Aye Aye, Tooth Tooth	1	good	Last Available: "2012-03"
 5588	tolerable jittery Humanitini	3	good	Last Available: "2012-03"
-5589	aged spirit-forward More Humanitini than Humanitini	5	awesome	Last Available: "2012-03"
-5590	delicious strong Oh, the Humanitini	5	awesome	Last Available: "2012-03"
+5589	spirit-forward aged More Humanitini than Humanitini	5	awesome	Last Available: "2012-03"
+5590	strong delicious Oh, the Humanitini	5	awesome	Last Available: "2012-03"
 5591	tolerable Great Older Fashioned	4	good	Last Available: "2012-03"
 5592	smooth Fuzzy Tentacle	4	awesome	Last Available: "2012-03"
 5593	tolerable Crazymaker	4	good	Last Available: "2012-03"
 5594	aged wobbly Zoodriver	3	awesome	Last Available: "2012-03"
 5595	triple-distilled hand-crafted ghostly Sloe Comfortable Zoo	8	EPIC	Last Available: "2012-03"
 5596	lousy Sloe Comfortable Zoo on Fire	4	decent	Last Available: "2012-03"
-5597	smooth irresponsibly strong pulsating Suffering Sinner	7	awesome	Last Available: "2012-03"
+5597	irresponsibly strong smooth pulsating Suffering Sinner	7	awesome	Last Available: "2012-03"
 5598	artisanal watered-down Suppurating Sinner	2	EPIC	Last Available: "2012-03"
 5599	watered-down lousy Sizzling Sinner	2	decent	Last Available: "2012-03"
 5600	drinkable weak Firewater	2	good	Last Available: "2012-03"
-5601	high-proof drinkable Earth and Firewater	9	good	Last Available: "2012-03"
+5601	drinkable high-proof Earth and Firewater	9	good	Last Available: "2012-03"
 5602	weak delicious Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
 5603	enchanted drinkable jittery Slimosa	3	good	Effect: "Oiled Skin", Effect Duration: 10, Last Available: "2012-03"
 5604	acceptable Extra-slimy Slimosa	3	good	Last Available: "2012-03"
-5605	weak smooth wobbly Slimebite	2	awesome	Last Available: "2012-03"
+5605	smooth weak wobbly Slimebite	2	awesome	Last Available: "2012-03"
 5606	bad green Cement Mixer	3	decent	Last Available: "2012-03"
-5607	acceptable distilled twirling Jackhammer	5	good	Last Available: "2012-03"
+5607	distilled acceptable twirling Jackhammer	5	good	Last Available: "2012-03"
 5608	acceptable watered-down Dump Truck	2	good	Last Available: "2012-03"
-5609	drinkable blue bouncing Fauna Libre	3	good	Last Available: "2012-03"
+5609	drinkable bouncing blue Fauna Libre	3	good	Last Available: "2012-03"
 5610	practically non-alcoholic bad Chakra Libre	1	decent	Last Available: "2012-03"
 5611	hand-crafted skewed Aura Libre	3	EPIC	Last Available: "2012-03"
 5612	smooth triple-distilled spinning Sazerorc	7	awesome	Last Available: "2012-03"
 5613	acceptable irresponsibly strong Sazuruk-hai	10	good	Last Available: "2012-03"
 5614	perfectly mixed Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	acceptable spirit-forward narrow Green Velvet	5	good	Last Available: "2012-03"
-5616	special boozy tolerable twirling Green Muslin	5	good	Effect: "The Dinsey Spirit", Effect Duration: 25, Last Available: "2012-03"
+5616	boozy tolerable special twirling Green Muslin	5	good	Effect: "The Dinsey Spirit", Effect Duration: 25, Last Available: "2012-03"
 5617	hand-crafted blurry Green Burlap	4	EPIC	Last Available: "2012-03"
-5618	practically non-alcoholic bad shaking Mohobo	1	decent	Last Available: "2012-03"
+5618	bad practically non-alcoholic shaking Mohobo	1	decent	Last Available: "2012-03"
 5619	fancy spirit-forward artisanal Moonshine Mohobo	5	EPIC	Effect: "You Can Taste the Darkness", Effect Duration: 5, Last Available: "2012-03"
 5620	tolerable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	delicious watered-down Drunken Philosopher	2	awesome	Last Available: "2012-03"
 5622	perfectly mixed skewed Drunken Neurologist	4	EPIC	Last Available: "2012-03"
 5623	hand-crafted ghostly Drunken Astrophysicist	4	EPIC	Last Available: "2012-03"
-5624	practically non-alcoholic aged Dark & Starry	1	awesome	Last Available: "2012-03"
-5625	hand-crafted spinning green Black Hole	3	EPIC	Last Available: "2012-03"
+5624	aged practically non-alcoholic Dark & Starry	1	awesome	Last Available: "2012-03"
+5625	hand-crafted green spinning Black Hole	3	EPIC	Last Available: "2012-03"
 5626	enchanted lousy Event Horizon	3	decent	Effect: "Night of the Nachos", Effect Duration: 40, Last Available: "2012-03"
-5627	lousy weak Herring Daiquiri	2	decent	Last Available: "2012-03"
+5627	weak lousy Herring Daiquiri	2	decent	Last Available: "2012-03"
 5628	lousy yellow Herring Wallbanger	4	decent	Last Available: "2012-03"
 5629	artisanal Herringtini	3	EPIC	Last Available: "2012-03"
 5630	artisanal Lollipop Drop	3	EPIC	Last Available: "2012-03"
 5631	drinkable shaking Candy Alexander	3	good	Last Available: "2012-03"
 5632	artisanal Candicaine	4	EPIC	Last Available: "2012-03"
 5633	perfectly mixed narrow Caipiranha	3	EPIC	Last Available: "2012-03"
-5634	watered-down perfectly mixed Flying Caipiranha	2	EPIC	Last Available: "2012-03"
-5635	practically non-alcoholic hand-crafted fancy gray Flaming Caipiranha	1	super ultra EPIC	Effect: "Melancholy Burden", Effect Duration: 10, Last Available: "2012-03"
+5634	perfectly mixed watered-down Flying Caipiranha	2	EPIC	Last Available: "2012-03"
+5635	fancy hand-crafted practically non-alcoholic gray Flaming Caipiranha	1	super ultra EPIC	Effect: "Melancholy Burden", Effect Duration: 10, Last Available: "2012-03"
 5636	bad Punchplanter	3	decent	Last Available: "2012-03"
 5637	artisanal Doublepunchplanter	3	EPIC	Last Available: "2012-03"
 5638	perfectly mixed Haymaker	3	EPIC	Last Available: "2012-03"
@@ -5571,7 +5571,7 @@
 5668	bagged &quot;L&quot;	0		
 5669	blinking club	0		
 5670	stale fettucini &eacute;pines Inconnu	3	decent	
-5671	watered-down bad slap and slap again	2	decent	
+5671	bad watered-down slap and slap again	2	decent	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
@@ -5581,7 +5581,7 @@
 5678	soggy used band-aid	0		Last Available: "2012-05"
 5679	stylish swimsuit of vim and vigor of Flo-Jo	0		Maximum HP Percent: +50, Initiative: +100, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
-5681	diet moldy pulsating P.B.L.T.	1	crappy	
+5681	moldy diet pulsating P.B.L.T.	1	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	skewed BURT	0		
 5684	handful of juicy garbage	0		
@@ -5633,7 +5633,7 @@
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	special normal forbidden sausage	4	good	Effect: "Buttermilk Boogie", Effect Duration: 50
-5735	sage Lord Flameface's cloak	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5735	sage Lord Flameface's cloak	0		Mysticality Percent: +10, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	corrupted Drizzlers&trade; Black Licorice	0		Effect: "Spell Transfer Complete", Effect Duration: 31
 5737	moist daub-breaker	0		Effect: "Ack!  Barred!", Effect Duration: 68, Last Available: "2020-09"
 5738	Fonzie's Camp Scout backpack	0		Experience (Moxie): +1, Softcore Only, Last Available: "2012-07"
@@ -5644,7 +5644,7 @@
 5743	smooth CSA scoutmaster's &quot;water&quot;	4	awesome	Last Available: "2012-07"
 5744	rotten shaking bag of GORF	3	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	jumbo moldy bag of QWOP	5	crappy	Last Available: "2012-07"
+5746	moldy jumbo bag of QWOP	5	crappy	Last Available: "2012-07"
 5747	anodized concentrated narrow pulsating red CSA bravery badge	0		Effect: "Drunk With Power", Effect Duration: 35, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	perfectly mixed fancy green CSA cheerfulness ration	3	EPIC	Effect: "Holiday Disappointment", Effect Duration: 35, Last Available: "2012-07"
@@ -5665,11 +5665,11 @@
 5765	lion tamer's experienced fuzzy earmuffs	0		Experience: +2, Experience (familiar): +2, Familiar Effect: "1.5xVolley, cap 32"
 5766	shellacked hardened fuzzy montera of temperance	0		Damage Reduction: 20, Sleaze Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	huge gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "gain advs"
+5772	huge gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	jittery talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5683,18 +5683,18 @@
 5784	ghostly weirdwood plank	0		
 5785	skewed thick caulk	0		
 5786	hard screw	0		
-5787	huge cyan tumbling messy butt joint	0		
+5787	cyan huge tumbling messy butt joint	0		
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	blinking twirling hardy right bear arm of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	prompt greedy Jeselnik's left bear arm	0		Sleaze Damage: +25, Meat Drop: +20, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	blinking twirling hardy right bear arm of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	prompt greedy Jeselnik's left bear arm	0		Sleaze Damage: +25, Meat Drop: +20, Adventures: +3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	frightening Hat O' Nine Tails	0		Spooky Damage: +5
 5794	cold-filtered denatured skewed Enchanted Plunger	0		Effect: "Fishy", Effect Duration: 48
 5795	non-warmed Enchanted Flyswatter	0		Effect: "Innately Wise", Effect Duration: 54
 5796	oxidized mirror Gearhead Goo	0		Effect: "Chalk Outline", Effect Duration: 61
 5797	flattened upside-down Missing Eye Simulation Device	0		Effect: "Ironclad", Effect Duration: 41
-5798	energized corrupted blinking shaking Gnollish Crossdress	0		Effect: "Night of the Nachos", Effect Duration: 25
+5798	energized corrupted shaking blinking Gnollish Crossdress	0		Effect: "Night of the Nachos", Effect Duration: 25
 5799	corrupted adjusted pulsating eldritch dough	0		Effect: "Neuromancy", Effect Duration: 27
 5800	cold-filtered narrow Charity's choker	0		Effect: "Turkey-Ambitious", Effect Duration: 36
 5801	diffused ghostly Smart Bone Dust	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 16
@@ -5713,8 +5713,8 @@
 5814	enhanced skewed blob of acid	0		Effect: "[1609]Dancin' Fool", Effect Duration: 42
 5815	altered maroon flayed mind	0		Effect: "Booing Radly", Effect Duration: 58
 5816	dry lime green kobold kibble	0		Effect: "Ocelot Eyes", Effect Duration: 17
-5817	extra-unsweetened electrified jittery shaking forest spirit rattle	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 54
-5818	deionized ghostly twirling spinning purple Stone Golem pebbles	0		Effect: "Larger", Effect Duration: 12
+5817	extra-unsweetened electrified shaking jittery forest spirit rattle	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 54
+5818	deionized purple twirling spinning ghostly Stone Golem pebbles	0		Effect: "Larger", Effect Duration: 12
 5819	triple-magnetized narrow gravy fairy warlock hat	0		Effect: "Marco Polarity", Effect Duration: 14
 5820	diffused chilled bull blubber	0		Effect: "No Vertigo", Effect Duration: 51
 5821	super-cold-filtered aerosolized frog lip-print	0		Effect: "Bone Chilling", Effect Duration: 48
@@ -5731,7 +5731,7 @@
 5832	Vulcanized ionized shaking secret mummy herbs and spices	0		Effect: "Stuck That Way", Effect Duration: 57
 5833	enhanced brigand brittle	0		Effect: "Full of Vinegar", Effect Duration: 37
 5834	irradiated holistic headache remedy	0		Effect: "Permafrosty", Effect Duration: 62
-5835	altered cold-filtered skewed green scrunchie tourniquet	0		Effect: "Sweet Nostalgia", Effect Duration: 42
+5835	altered cold-filtered green skewed scrunchie tourniquet	0		Effect: "Sweet Nostalgia", Effect Duration: 42
 5836	polymerized pressed embezzler's oil	0		Effect: "Cancer Rising", Effect Duration: 22
 5837	quantum cold-filtered wobbly Fu Manchu Wax	0		Effect: "A Contender", Effect Duration: 21
 5838	altered Iiti Kitty Gumdrop	0		Effect: "Hagg-ard", Effect Duration: 58
@@ -5745,7 +5745,7 @@
 5846	chilled upside-down salt water taffy	0		Effect: "Whippin' It Good", Effect Duration: 26
 5847	energized polymerized unholy water	0		Effect: "Spell Transfer Complete", Effect Duration: 39
 5848	improved non-enhanced pulsating Bangyomaman battle juice	0		Effect: "Adapt to Change Eventually", Effect Duration: 31
-5849	tarnished triple-ionized skewed shaking handyman &quot;hand soap&quot;	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 56
+5849	tarnished triple-ionized shaking skewed handyman &quot;hand soap&quot;	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 56
 5850	magnetized space marine flash grenade	0		Effect: "Stogied", Effect Duration: 59
 5851	aerosolized dry temporary tribal tattoo	0		Effect: "Gleaming White Teeth", Effect Duration: 35
 5852	polymerized aerosolized oil-filled donut	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 62
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	greasy personal trainer's skeleton skis of courage	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +10, Spooky Resistance: +3, Single Equip, Last Available: "2012-10"
-5883	special toothsome snack-sized upside-down skeleton quiche	2	awesome	Effect: "Tiki Temerity", Effect Duration: 50, Last Available: "2012-10"
+5883	special snack-sized toothsome upside-down skeleton quiche	2	awesome	Effect: "Tiki Temerity", Effect Duration: 50, Last Available: "2012-10"
 5884	blurry skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	twirling therapeutic educational slick wizardly Bonestabber	0		Mysticality: +25, Moxie: +10, Experience: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-10"
@@ -5798,7 +5798,7 @@
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	twirling jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	squat jar of psychoses (The Old Man)	0		Last Available: "2013-12"
-5902	green squat jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
+5902	squat green jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	pixel pill	0		
@@ -5808,7 +5808,7 @@
 5910	deactivated nanobots	0		Free Pull, Last Available: "2012-11"
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	Solstice Shield of James Dean of chilblains	0		Experience (Moxie): +3, Cold Damage: +25
-5913	adjusted skewed huge squat candy sushi set	0		Effect: "Ham-Fisted", Effect Duration: 27, Last Available: "2012-12"
+5913	adjusted huge squat skewed candy sushi set	0		Effect: "Ham-Fisted", Effect Duration: 27, Last Available: "2012-12"
 5914	deionized pressed chilled mirror sweet mochi ball	0		Effect: "Seriously Mutated", Effect Duration: 48, Last Available: "2012-12"
 5915	vacuum-sealed wobbly beet-flavored Mr. Mediocrebar	0		Effect: "Hyperoffended", Effect Duration: 24, Last Available: "2012-12"
 5916	improved sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Mo' Hobo", Effect Duration: 36, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	narrow ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	olive BittyCar MeatCar	0		Last Available: "2012-12"
 5927	narrow BittyCar HotCar	0		Last Available: "2012-12"
-5928	sage brainwave-controlled unicorn horn	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	sage brainwave-controlled unicorn horn	0		Mysticality Percent: +10, Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	huge bubble-wrap simulator	0		Last Available: "2012-12"
 5930	jittery blind-packed capsule toy	0		Last Available: "2012-12"
 5931	mirror double-paned plastic four-shadowed mime of Leguizamo of mayonnaise	0		Monster Level: +20, Sleaze Spell Damage: +50, Cold Resistance: +5, Single Equip, Last Available: "2012-12"
@@ -5858,10 +5858,10 @@
 5960	wobbly scandalous plastic Father McGruber	0		Sleaze Damage: +5, Last Available: "2012-12"
 5961	Herculean plastic Hank North, Photojournalist	0		Experience (Muscle): +1, Last Available: "2012-12"
 5962	olive careful plastic blazing bat	0		Monster Level: -10, Last Available: "2012-12"
-5963	manspreader's therapeutic electronic dulcimer pants	0		Monster Level: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	manspreader's therapeutic electronic dulcimer pants	0		Monster Level: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	experienced Frown Exerciser of Calamity Jane	0		Experience: +2, Critical Hit Percent: +15, Single Equip, Last Available: "2012-12"
-5966	twirling squat soul monocle	0		Single Equip
+5966	squat twirling soul monocle	0		Single Equip
 5967	soul doorbell	0		
 5968	soul coin	0		
 5969	soul knife	0		
@@ -5871,7 +5871,7 @@
 5973	record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	ghostly record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
-5976	pulsating yellow record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
+5976	yellow pulsating record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	jittery lion tamer's resourceful occult silent beret	0		Spell Damage Percent: +25, Maximum MP: +50, Experience (familiar): +2, Familiar Effect: "1xVolley, cap 3"
 5978	normal huge slice of pizza	3	good	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
@@ -5881,19 +5881,19 @@
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	spinning family-friendly perfumed flame-retardant cloth cap	0		Hot Resistance: +1, Stench Resistance: +5, Sleaze Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	dog trainer's cool iron dagger of the ox	0		Muscle: +20, Moxie: +5, Experience (familiar): +1, Last Available: "2013-02"
-5986	flavorless gigantic bouncing ghostly hamburger	10	decent	Last Available: "2013-02"
+5986	gigantic flavorless ghostly bouncing hamburger	10	decent	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	shaking potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	artisanal spirit-forward fuchsia blurry bottle of wine	5	EPIC	Last Available: "2013-02"
-5991	mirror lime green round bomb	0		Last Available: "2013-02"
+5990	spirit-forward artisanal blurry fuchsia bottle of wine	5	EPIC	Last Available: "2013-02"
+5991	lime green mirror round bomb	0		Last Available: "2013-02"
 5992	rosewater-soaked iron helmet of extreme caution of the boozehound	0		Monster Level: -25, Stench Resistance: +3, Booze Drop: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	horrifying flame-wreathed razor-sharp steel sword	0		Weapon Damage Percent: +25, Hot Spell Damage: +10, Spooky Damage: +25, Last Available: "2013-02"
 5994	moldy whole roasted chicken	3	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	green potion	0		Last Available: "2013-02"
-5998	practically non-alcoholic perfectly mixed tumbling shining goblet	1	super ultra mega turbo EPIC	Last Available: "2013-02"
+5998	perfectly mixed practically non-alcoholic tumbling shining goblet	1	super ultra mega turbo EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
 6000	Tesla padded strapping crown	0		Muscle: +5, Damage Absorption: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	mirror friendly medical-grade sword of the early riser	0		Familiar Weight: +3, Adventures: +7, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02"
@@ -5947,11 +5947,11 @@
 6049	auspicious Misty Cape of doom	0		Spooky Spell Damage: +50, Item Drop: 15
 6050	woimbook	0		Familiar Weight: +5
 6051	wobbly Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	spoiled jumbo wobbly Taco Dan's Taco Stand Taco	5	crappy	Last Available: "2012-12"
-6053	watered-down drinkable Taco Dan's Taco Stand Chimichangarita	2	good	Last Available: "2012-12"
+6052	jumbo spoiled wobbly Taco Dan's Taco Stand Taco	5	crappy	Last Available: "2012-12"
+6053	drinkable watered-down Taco Dan's Taco Stand Chimichangarita	2	good	Last Available: "2012-12"
 6054	triple-modified cold-filtered Taco Dan's Taco Stand Chillacious Churro	0		Effect: "[1701]Hip to the Jive", Effect Duration: 67, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	bouncing The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	bouncing The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	maroon Meatcleaver of horror of the detective	0		Spooky Spell Damage: +25, Item Drop: +20, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head	0		Item Drop: +5, Last Available: "2012-12"
 6059	skewed Jeselnik's Crimbo stogie-scented room odorizer	0		Sleaze Damage: +25, Last Available: "2012-12"
@@ -5959,7 +5959,7 @@
 6061	blue shaking Crimbo tree flocker of the pedagogue	0		Experience: +3, Last Available: "2012-12"
 6062	miser's Crimbo light-up Rudolph doll	0		Meat Drop: +10, Last Available: "2012-12"
 6063	Super Crimboman Ultra Mega Hypersword	0		Item Drop: +5, Last Available: "2012-12"
-6064	jittery yellow sharp tin strip	0		
+6064	yellow jittery sharp tin strip	0		
 6065	squat wad of spider silk	0		
 6066	goblin collarbone	0		
 6067	horrifying hardened Truthsayer	0		Damage Reduction: 3, Spooky Damage: +25, Last Available: "2013-12"
@@ -5971,14 +5971,14 @@
 6073	quantum fuchsia pulsating haggis-infused soap	0		Effect: "A Few Extra Pounds", Effect Duration: 50, Last Available: "2012-12"
 6074	vacuum-sealed activated super-wet ghostly magicberry tablets	0		Effect: "Impregnabili Tea", Effect Duration: 32, Last Available: "2012-12"
 6075	alkaline warmed 37x37x37 puzzle cube	0		Effect: "Eldritch Concentration", Effect Duration: 62, Last Available: "2012-12"
-6076	watered-down mediocre cyan wobbly McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
-6077	fancy bland haggis-wrapped haggis-stuffed haggis	4	decent	Effect: "Trufflin'", Effect Duration: 30, Last Available: "2012-12"
+6076	mediocre watered-down wobbly cyan McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
+6077	bland fancy haggis-wrapped haggis-stuffed haggis	4	decent	Effect: "Trufflin'", Effect Duration: 30, Last Available: "2012-12"
 6078	shaking home robotics kit	0		Last Available: "2012-12"
 6079	tumbling school calculator watch	0		Last Available: "2012-12"
-6080	haggis socks of chilblains	0		Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	haggis socks of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	skewed Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
-6083	lime green narrow actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
+6083	narrow lime green actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	mirror Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
 6086	red greasy Microplushie: Otakulone	0		Sleaze Spell Damage: +10, Last Available: "2012-12"
@@ -6014,13 +6014,13 @@
 6116	CEO office card	0		Last Available: "2013-12"
 6117	test site key	0		Last Available: "2013-12"
 6118	pulsating goggles	0		Last Available: "2013-12"
-6119	purple blurry abacus	0		Last Available: "2013-12"
+6119	blurry purple abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
 6121	watered-down artisanal Chinese beer	2	EPIC	Last Available: "2013-12"
 6122	bouncing cat statue	0		Last Available: "2013-12"
 6123	fuchsia rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
-6125	enhanced dry bouncing upside-down bottle of limeade	0		Effect: "Frozen Shoulders", Effect Duration: 40, Last Available: "2013-12"
+6125	enhanced dry upside-down bouncing bottle of limeade	0		Effect: "Frozen Shoulders", Effect Duration: 40, Last Available: "2013-12"
 6126	Usain Bolt's wholesome novelty tattoo sleeves	0		Maximum HP Percent: +10, Initiative: +80, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	upside-down furry brown pillow	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	jittery wicked rubber gloves	0		Spell Damage: +5, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	cyan triad summoning scroll	0		Last Available: "2013-12"
-6142	stale fancy huge squat roasted duck	3	decent	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2013-12"
+6142	fancy stale squat huge roasted duck	3	decent	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2013-12"
 6143	stale dead meat bun	3	decent	Last Available: "2013-12"
 6144	therapeutic cat collar	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
 6145	chilly beefy suspicious-looking fedora	0		Muscle: +10, Cold Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
@@ -6052,10 +6052,10 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	pulsating friendly deadly Byte	0		Weapon Damage: +5, Familiar Weight: +3, Last Available: "2013-12"
-6158	fuchsia spinning anger blaster of Flo-Jo	0		Initiative: +100, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	squat knitted doubt cannon	0		Cold Resistance: +3, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	quilted fear condenser	0		Damage Absorption: +40, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	Sherlock's regret hose	0		Item Drop: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	fuchsia spinning anger blaster of Flo-Jo	0		Initiative: +100, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	squat knitted doubt cannon	0		Cold Resistance: +3, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	quilted fear condenser	0		Damage Absorption: +40, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	Sherlock's regret hose	0		Item Drop: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	maroon Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	Tesla commodore's hat of bravery	0		Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
@@ -6063,13 +6063,13 @@
 6166	blue sage deck cannon of the ox	0		Muscle: +20, Mysticality Percent: +10, Last Available: "2013-12"
 6167	narrow Herculean ornamental sextant	0		Experience (Muscle): +1, Last Available: "2013-12"
 6168	greasy Bloodbath of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Last Available: "2013-12"
-6169	smooth watered-down Hundred Headed IPA	2	awesome	Last Available: "2013-12"
+6169	watered-down smooth Hundred Headed IPA	2	awesome	Last Available: "2013-12"
 6170	big spoiled narrow chum	5	crappy	Last Available: "2013-12"
 6171	quantum electrified crude crudit&eacute;s	0		Effect: "Afternoon Insight", Effect Duration: 58
 6172	boiled double-galvanized maroon candy crayons	0		Effect: "Prince of Seaside Town", Effect Duration: 69, Last Available: "2020-09"
 6173	blinking greedy strapping pixel grappling hook	0		Muscle: +5, Meat Drop: +20
 6174	pulsating GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
-6175	maroon tumbling GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
+6175	tumbling maroon GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	cosmic dough	0		
 6178	cosmic vegetable	0		
@@ -6085,8 +6085,8 @@
 6188	rotten consummate bagel	3	crappy	
 6189	spoiled snack-sized consummate sliced bread	2	crappy	
 6190	rotten consummate hot dog bun	3	crappy	
-6191	tasty miniature narrow consummate brownie	2	awesome	
-6192	normal enchanted consummate toast	4	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 50
+6191	miniature tasty narrow consummate brownie	2	awesome	
+6192	enchanted normal consummate toast	4	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 50
 6193	smooth pulsating passable stout	4	awesome	
 6194	snack-sized moldy consummate soup	2	crappy	
 6195	stale miniature consummate corn chips	2	decent	
@@ -6095,37 +6095,37 @@
 6198	decent consummate sauerkraut	4	good	
 6199	flavorless wobbly consummate cheese slice	3	decent	
 6200	bland consummate melted cheese	4	decent	
-6201	half-sized bland consummate bacon	2	decent	
-6202	moldy miniature consummate meatloaf	2	crappy	
+6201	bland half-sized consummate bacon	2	decent	
+6202	miniature moldy consummate meatloaf	2	crappy	
 6203	rotten consummate steak	3	crappy	
 6204	flavorless consummate cuts	4	decent	
 6205	toothsome consummate frankfurter	4	awesome	
 6206	spoiled shaking consummate french fries	3	crappy	
 6207	bland consummate baked potato	3	decent	
-6208	watered-down special hand-crafted acceptable vodka	2	EPIC	Effect: "Stopping to Smell the Flowers", Effect Duration: 5
-6209	stale bite-sized consummate ice cream	1	decent	
-6210	moldy miniature bouncing consummate whipped cream	2	crappy	
+6208	hand-crafted watered-down special acceptable vodka	2	EPIC	Effect: "Stopping to Smell the Flowers", Effect Duration: 5
+6209	bite-sized stale consummate ice cream	1	decent	
+6210	miniature moldy bouncing consummate whipped cream	2	crappy	
 6211	bland fancy consummate cream	4	decent	Effect: "damage.enh", Effect Duration: 20
-6212	super-sized stale consummate strawberries	5	decent	
+6212	stale super-sized consummate strawberries	5	decent	
 6213	moldy huge consummate sorbet	3	crappy	
 6214	mediocre adequate rum	3	decent	
 6215	lousy fancy ghostly mediocre lager	3	decent	Effect: "Eyes All Black", Effect Duration: 45
 6216	delicious immaculate grilled cheese	3	awesome	
 6217	tasty small mirror immaculate ice cream sandwich	2	awesome	
 6218	moldy pulsating immaculate hot dog	4	crappy	
-6219	bland snack-sized ghostly immaculate egg salad sandwich	2	decent	
+6219	snack-sized bland ghostly immaculate egg salad sandwich	2	decent	
 6220	rotten perfect sandwich	3	crappy	
 6221	stale special perfect chef salad	4	decent	Effect: "Mad at Science", Effect Duration: 50
-6222	bland miniature huge ghostly perfect breakfast	2	decent	
-6223	toothsome low-calorie sublime deluxe hot dog	1	awesome	
-6224	adequate olive squat sublime stew	4	good	
-6225	super-sized bland squat sublime nachos	5	decent	
-6226	moldy jumbo Ultimate Breakfast Sandwich	5	crappy	
+6222	miniature bland huge ghostly perfect breakfast	2	decent	
+6223	low-calorie toothsome sublime deluxe hot dog	1	awesome	
+6224	adequate squat olive sublime stew	4	good	
+6225	bland super-sized squat sublime nachos	5	decent	
+6226	jumbo moldy Ultimate Breakfast Sandwich	5	crappy	
 6227	normal Loaded Baked Potato	4	good	
 6228	flavorless Omega Sundae	3	decent	
 6229	acceptable twirling Das Sauerlager	4	good	
 6230	drinkable Bologna Lambic	4	good	
-6231	drinkable practically non-alcoholic olive Vodka Dog	1	good	
+6231	practically non-alcoholic drinkable olive Vodka Dog	1	good	
 6232	lousy Disappointed Russian	3	decent	
 6233	bad fancy huge Chunky Mary	3	decent	Effect: "Blessing of Pikachutlotal", Effect Duration: 10
 6234	lousy Nachojito	4	decent	
@@ -6150,7 +6150,7 @@
 6254	wobbly shaking Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	wobbly Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	bouncing dried gelatinous cube	0		
-6257	lime green blurry pile of dungeon junk	0		Familiar Weight: +5
+6257	blurry lime green pile of dungeon junk	0		Familiar Weight: +5
 6258	flame-retardant Tesla slick Staff of the Healthy Breakfast of the businessman	0		Moxie: +10, Hot Resistance: +1, Meat Drop: +50, MP Regen Min: 7, MP Regen Max: 10, Jiggle: "Recover Some HP"
 6259	hale banded arcane researcher's Staff of the Staff of Life of chilblains	0		Experience Percent (Mysticality): +10, Damage Absorption: +100, Maximum HP: +20, Cold Damage: +25, Jiggle: "Full HP Recovery"
 6260	gray chaotic energetic Staff of the Light Lunch of the ox	0		Muscle: +20, Maximum MP Percent: +20, Spell Critical Percent: +10, Jiggle: "Deal Some Cold Damage"
@@ -6194,13 +6194,13 @@
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	dry moist Super Weight-Gain 9000	0		Effect: "Stenchtastic", Effect Duration: 55
-6301	electrified Vulcanized ghostly yellow possibility potion	0		Effect: "World's Shortest Giant", Effect Duration: 53
+6301	electrified Vulcanized yellow ghostly possibility potion	0		Effect: "World's Shortest Giant", Effect Duration: 53
 6302	squat blurry eleven-foot pole	0		
 6303	skewed ring of Detect Boring Doors	0		
 6304	flame-retardant gravedigger's baleful Jarlsberg's pan (Cosmic portal mode) of the storm of the sewer	0		Spell Damage: +25, Maximum MP Percent: +40, Stench Damage: +25, Spooky Damage: +10, Hot Resistance: +1, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	fuchsia up-at-dawn wool dog trainer's arcane researcher's Jarlsberg's pan of the wise owl	0		Mysticality: +20, Experience Percent (Mysticality): +10, Experience (familiar): +1, Cold Resistance: +1, Adventures: +5, Softcore Only, Free Pull, Last Available: "2013-03"
 6306	Cosmic Calorie	0		Last Available: "2013-03"
-6307	non-chilled ionized spinning shaking celestial olive oil	0		Effect: "A View to Some Meat", Effect Duration: 28, Last Available: "2013-03"
+6307	non-chilled ionized shaking spinning celestial olive oil	0		Effect: "A View to Some Meat", Effect Duration: 28, Last Available: "2013-03"
 6308	warmed squat maroon celestial carrot juice	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 59, Last Available: "2013-03"
 6309	extra-galvanized altered celestial au jus	0		Effect: "Granolarrrgh", Effect Duration: 49, Last Available: "2013-03"
 6310	electrified deionized celestial squid ink	0		Effect: "Pemmican't", Effect Duration: 17, Last Available: "2013-03"
@@ -6221,7 +6221,7 @@
 6325	teal tumbling miser's knitted Rosewater's aquamariner's necklace	0		Mysticality Percent: +30, Cold Resistance: +3, Meat Drop: +10, Single Equip
 6326	bouncing padded pearl diver's ring of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Single Equip
 6327	Temple Grandin's stiffened pearl diver's necklace	0		Damage Reduction: 1, Familiar Weight: +7, Single Equip
-6328	olive tumbling sushi doily	0		
+6328	tumbling olive sushi doily	0		
 6329	scimitar cozy	0		
 6330	skewed fish stick cozy	0		
 6331	pulsating bazooka cozy	0		
@@ -6238,7 +6238,7 @@
 6342	baleful Sinatra's super-strong air freshener	0		Experience (Moxie): +5, Spell Damage: +25
 6343	energized nitrogenated purple Mer-kin lipstick	0		Effect: "Inscrutable exoskeleton", Effect Duration: 19
 6344	mirror Mer-kin mouthsoap	0		
-6345	quadruple-altered mirror wobbly Mer-kin strongjuice	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
+6345	quadruple-altered wobbly mirror Mer-kin strongjuice	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
 6346	Mer-kin fitbrine	0		
 6347	tarnished dry Mer-kin ragejuice	0		Effect: "Net Tea", Effect Duration: 22
 6348	padded Mer-kin dragbelt	0		Damage Absorption: +20, Experience (Muscle): +20, Single Equip
@@ -6247,7 +6247,7 @@
 6351	wobbly smartaleck's Mer-kin finpaddle	0		Moxie Percent: +30
 6352	Mer-kin stopwatch of the pedagogue	0		Experience: +3, Initiative: +50
 6353	Mer-kin dreadscroll	0		
-6354	liquefied super-liquefied jittery olive huge Mer-kin smartjuice	0		Effect: "Spooky Flavor", Effect Duration: 43
+6354	liquefied super-liquefied olive huge jittery Mer-kin smartjuice	0		Effect: "Spooky Flavor", Effect Duration: 43
 6355	non-quantum deionized Mer-kin cooljuice	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 36
 6356	twirling Mer-kin worktea	0		
 6357	twirling Mer-kin knucklebone	0		
@@ -6265,9 +6265,9 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	acceptable teal can of the cheapest beer	3	good	
-6372	smooth boozy lime green bottle of fruity &quot;wine&quot;	5	awesome	
+6372	boozy smooth lime green bottle of fruity &quot;wine&quot;	5	awesome	
 6373	acceptable single swig of vodka	4	good	
-6374	narrow yellow angry inch	0		
+6374	yellow narrow angry inch	0		
 6375	mirror auspicious testy toolbox	0		Item Drop: +10
 6376	Jick-o-User	0		
 6378	wobbly eraser nubbin	0		
@@ -6295,7 +6295,7 @@
 6400	Mer-kin lunchbox	0		
 6401	oxidized tumbling tear	0		Effect: "Feet of Watermelon", Effect Duration: 61
 6402	unsweetened polymerized jagged tooth	0		Effect: "Gyromitra Gymnastics", Effect Duration: 63
-6403	modified mirror wobbly squat grisly shell fragment	0		Effect: "Bilious Brains", Effect Duration: 64
+6403	modified mirror squat wobbly grisly shell fragment	0		Effect: "Bilious Brains", Effect Duration: 64
 6404	magnetized liquefied wet violent pastilles	0		Effect: "Raging Animal", Effect Duration: 34
 6405	vacuum-sealed green worst candy	0		Effect: "Joy", Effect Duration: 15
 6406	corrupted fudge-shaped hole in space-time	0		Effect: "Healthy Blue Glow", Effect Duration: 20
@@ -6308,7 +6308,7 @@
 6413	jittery cyan Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	huge bland fuchsia flavorless gruel	7	decent	
-6416	moldy snack-sized mana curds	2	crappy	
+6416	snack-sized moldy mana curds	2	crappy	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	ionized corrupted triple-frozen mirror moth dust	0		Effect: "The Style... of the Future", Effect Duration: 25
@@ -6367,7 +6367,7 @@
 6472	teal bouncing Drunkula's bell	0		
 6473	Van der Graaf Drunkula's ring of haze of Tarzan of chilblains	0		Experience (Muscle): +3, Cold Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Avoid Attack: 1, Single Equip
 6474	Drunkula's wineglass of the ox	0		Muscle: +20
-6475	weak tolerable blue bottle of Bloodweiser	2	good	
+6475	tolerable weak blue bottle of Bloodweiser	2	good	
 6476	groovy cool weightlifter's Unkillable Skeleton's skullcap	0		Muscle: +15, Moxie: +5, Moxie Percent: +10, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	nippy extremely unsafe Unkillable Skeleton's breastplate of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Cold Damage: +10, Class: "Turtle Tamer"
 6478	Temple Grandin's slick Unkillable Skeleton's shinguards of Gandalf	0		Moxie: +10, Spell Critical Percent: +20, Familiar Weight: +7, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6390,7 +6390,7 @@
 6495	vibrating Dreadsylvania Auditor's badge	0		Maximum MP Percent: +10, Kruegerand Drop: 5, Single Equip
 6496	ghostly blood kiwi	0		
 6497	eau de mort	0		
-6498	bad boozy huge bloody kiwitini	5	decent	
+6498	boozy bad huge bloody kiwitini	5	decent	
 6499	moon-amber	0		
 6500	blurry pulsating polished moon-amber	0		
 6501	double-paned steel-toed rock-hard moon-amber necklace	0		Damage Reduction: 28, Cold Resistance: +5, Single Equip
@@ -6421,7 +6421,7 @@
 6526	mansplainer's energetic bag of unfinished business	0		Maximum MP Percent: +20, Monster Level: +15
 6527	shaking MacGyver's transparent pants of the empath	0		Maximum MP: +100, Familiar Weight: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of doom	0		Spooky Spell Damage: +50
-6529	aged practically non-alcoholic skewed Thriller Ice	1	awesome	
+6529	practically non-alcoholic aged skewed Thriller Ice	1	awesome	
 6530	prompt grandfather watch	0		Adventures: +3, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	huge arcane researcher's spyglass	0		Experience Percent (Mysticality): +10, Item Drop: +5
@@ -6443,7 +6443,7 @@
 6549	cooling iron breastplate	0		
 6550	cooling iron greaves	0		
 6551	hot cluster	0		
-6552	red bouncing jittery cluster	0		
+6552	jittery bouncing red cluster	0		
 6553	purple cluster	0		
 6554	blue stench cluster	0		
 6555	blinking sleaze cluster	0		
@@ -6458,11 +6458,11 @@
 6564	special yummy Dreadsylvanian hot pocket	3	awesome	Effect: "Burning Tongue", Effect Duration: 50
 6565	decent Dreadsylvanian pocket	4	good	
 6566	yummy shaking Dreadsylvanian pocket	4	awesome	
-6567	yummy miniature Dreadsylvanian stink pocket	2	awesome	
+6567	miniature yummy Dreadsylvanian stink pocket	2	awesome	
 6568	decent lime green Dreadsylvanian sleaze pocket	3	good	
-6569	delicious extra-dry spinning teal Dreadsylvanian hot toddy	5	awesome	
-6570	acceptable special Dreadsylvanian cold-fashioned	3	good	Effect: "Purity of Spirit", Effect Duration: 15
-6571	perfectly mixed watered-down Dreadsylvanian grimlet	2	super ultra mega turbo EPIC	
+6569	extra-dry delicious teal spinning Dreadsylvanian hot toddy	5	awesome	
+6570	special acceptable Dreadsylvanian cold-fashioned	3	good	Effect: "Purity of Spirit", Effect Duration: 15
+6571	watered-down perfectly mixed Dreadsylvanian grimlet	2	super ultra mega turbo EPIC	
 6572	weak tolerable Dreadsylvanian dank and stormy	2	good	
 6573	smooth squat Dreadsylvanian slithery nipple	3	awesome	
 6574	hot clusterbomb	0		
@@ -6477,7 +6477,7 @@
 6583	mirror vicious spiked collar	0		Familiar Damage: +20
 6584	hale hot dog wrapper	0		Maximum HP: +20
 6585	upside-down Jeselnik's debonair deboner of the sweet-tooth	0		Sleaze Damage: +25, Candy Drop: +100
-6586	dry squat fuchsia chicle de salchicha	0		Effect: "Jungle Juiced", Effect Duration: 27
+6586	dry fuchsia squat chicle de salchicha	0		Effect: "Jungle Juiced", Effect Duration: 27
 6587	narrow cyan jar of frostigkraut of the bloodbag	0		Maximum HP: +100
 6588	vibrating quilted gnawed-up dog bone	0		Damage Absorption: +40, Maximum MP Percent: +10
 6589	blurry padded Grey Guanon	0		Damage Absorption: +20
@@ -6491,7 +6491,7 @@
 6597	clockwork birdhouse	0		
 6598	narrow clockwork disc	0		
 6599	clockwork hand	0		
-6600	ghostly spinning clockwork hand	0		
+6600	spinning ghostly clockwork hand	0		
 6601	pulsating clockwork numeral I	0		
 6602	green clockwork numeral II	0		
 6603	wobbly clockwork numeral III	0		
@@ -6522,9 +6522,9 @@
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	jittery folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
-6631	bouncing purple folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
+6631	purple bouncing folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
-6633	blinking blurry folder (barbarian)	0		Last Available: "2013-08"
+6633	blurry blinking folder (barbarian)	0		Last Available: "2013-08"
 6634	wobbly folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
 6636	ghostly folder (dancing dolphins)	0		Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	unsweetened narrow Ogres and Oubliettes&trade; module	0		Effect: "Voracious Gorging", Effect Duration: 52
 6650	spinning Mountain Stream Code Black Alert	0		
 6651	upside-down twisted-up wet towel	0		
-6652	triple-distilled drinkable blurry gray stepmom's booze	9	good	
+6652	drinkable triple-distilled blurry gray stepmom's booze	9	good	
 6653	pulsating surgical tape	0		
 6654	wobbly frightening band T-shirt	0		Spooky Damage: +5
 6655	mediocre fountain 'soda'	4	decent	
@@ -6569,7 +6569,7 @@
 6677	narrow crude monster sculpture	0		
 6678	wicked Yearbook Club Camera	0		Spell Damage: +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	narrow machete of the boozehound	0		Booze Drop: +100
-6680	strong smooth Cursed Punch	5	awesome	
+6680	smooth strong Cursed Punch	5	awesome	
 6681	bad Bowl of Scorpions	4	decent	
 6682	aged Fog Murderer	3	awesome	
 6683	shaking book of matches	0		
@@ -6581,7 +6581,7 @@
 6689	spinning McClusky file (page 1)	0		
 6690	blinking McClusky file (page 2)	0		
 6691	McClusky file (page 3)	0		
-6692	bouncing tumbling McClusky file (page 4)	0		
+6692	tumbling bouncing McClusky file (page 4)	0		
 6693	McClusky file (page 5)	0		
 6694	boring binder clip	0		
 6695	McClusky file (complete)	0		
@@ -6597,7 +6597,7 @@
 6705	massive flavorless jungle floor wax	8	decent	
 6706	jittery smirking shrunken head	0		
 6707	super-warmed gray colorful toad	0		Effect: "Gummibrain", Effect Duration: 61
-6708	red shaking crude voodoo doll	0		
+6708	shaking red crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
 6710	perfumed gravedigger's pygmy briefs	0		Spooky Damage: +10, Stench Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
@@ -6612,7 +6612,7 @@
 6720	diffused improved pill cup	0		Effect: "Night Vision", Effect Duration: 32
 6721	bouncing Newton's cool water bottle of the ox	0		Muscle: +20, Moxie: +5, Experience (Mysticality): +3, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	vacuum-sealed pygmy phone number	0		Effect: "Wintry Breath", Effect Duration: 58
-6723	shaking huge Boozehounds Anonymous token	0		
+6723	huge shaking Boozehounds Anonymous token	0		
 6724	rotten shaking exotic jungle fruit	4	crappy	
 6725	lime green Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
@@ -6643,10 +6643,10 @@
 6751	skewed packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
 6753	yellow cluster of hops	0		
-6754	mirror huge beer bottle	0		
+6754	huge mirror beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	delicious red blurry narrow can of Br&uuml;talbr&auml;u	3	awesome	Last Available: "2013-09"
+6757	delicious blurry narrow red can of Br&uuml;talbr&auml;u	3	awesome	Last Available: "2013-09"
 6758	weak perfectly mixed can of Drooling Monk	2	EPIC	Last Available: "2013-09"
 6759	acceptable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	perfectly mixed red twirling bottle of Old Pugilist	4	EPIC	Last Available: "2013-09"
@@ -6657,7 +6657,7 @@
 6765	watered-down acceptable bottle of Lambada Lambic	2	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
-6768	bouncing olive liquid bread	1	good	Last Available: "2013-09"
+6768	olive bouncing liquid bread	1	good	Last Available: "2013-09"
 6769	blue aromatic vibrating educational tin tam	0		Experience: +1, Maximum MP Percent: +10, Stench Resistance: +1, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	oxidized squat tin cup	0		Effect: "Moose Wisdom", Effect Duration: 44, Last Available: "2013-09"
 6771	teal greasy smelly nippy tin foil	0		Cold Damage: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2013-09"
@@ -6675,13 +6675,13 @@
 6783	shaking miser's ribald seal medal of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10, Meat Drop: +10
 6784	deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
-6788	blue wobbly blank diary	0		
+6788	wobbly blue blank diary	0		
 6789	boot knife	0		
 6790	twirling broken beer bottle	0		
 6791	sharpened spoon	0		
 6792	candy knife	0		
 6793	soap knife	0		
-6795	liquefied flattened shaking olive disco horoscope (Aquarius)	0		Effect: "Scavengers Scavenging", Effect Duration: 42
+6795	liquefied flattened olive shaking disco horoscope (Aquarius)	0		Effect: "Scavengers Scavenging", Effect Duration: 42
 6796	pickled boiled bouncing disco horoscope (Pisces)	0		Effect: "Heart of White", Effect Duration: 18
 6797	adjusted fuchsia disco horoscope (Aries)	0		Effect: "Dirty Pear", Effect Duration: 24
 6798	adjusted adjusted disco horoscope (Taurus)	0		Effect: "Analog Drunk", Effect Duration: 48
@@ -6690,7 +6690,7 @@
 6801	magnetized red wobbly disco horoscope (Leo)	0		Effect: "Berry Berry Cold", Effect Duration: 54
 6802	enhanced oxidized upside-down yellow disco horoscope (Virgo)	0		Effect: "Scarysauce", Effect Duration: 39
 6803	colloidal double-liquefied ghostly lime green disco horoscope (Libra)	0		Effect: "20/20 Vision", Effect Duration: 34
-6804	improved vacuum-sealed ghostly blue disco horoscope (Scorpio)	0		Effect: "Tiki Temerity", Effect Duration: 48
+6804	improved vacuum-sealed blue ghostly disco horoscope (Scorpio)	0		Effect: "Tiki Temerity", Effect Duration: 48
 6805	pickled twirling disco horoscope (Sagittarius)	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 51
 6806	extra-frozen flattened disco horoscope (Capricorn)	0		Effect: "Old Time Hydration", Effect Duration: 63
 6807	gravedigger's The Sagittarian's leisure pants of the storm	0		Maximum MP Percent: +40, Spooky Damage: +10, Familiar Effect: "atk, cap 18"
@@ -6722,20 +6722,20 @@
 6833	denatured magnetized Milk Studs	0		Effect: "Wintry Breath", Effect Duration: 64
 6834	quantum extra-frozen triple-galvanized tumbling box of Dweebs	0		Effect: "[1609]Dancin' Fool", Effect Duration: 32
 6835	anodized irradiated mirror bag of W&Ws	0		Effect: "Slimy Flavor", Effect Duration: 11
-6836	quadruple-energized dry teal mirror PEEZ dispenser	0		Effect: "Tenacity of the Snapper", Effect Duration: 52
+6836	quadruple-energized dry mirror teal PEEZ dispenser	0		Effect: "Tenacity of the Snapper", Effect Duration: 52
 6837	nitrogenated adjusted Swizzler	0		Effect: "Musky", Effect Duration: 27
 6838	improved lime green Bugbearclaw Donut	0		Effect: "Mushroom Melody", Effect Duration: 22
 6839	adjusted jam	0		Effect: "Very Clean Guns", Effect Duration: 35
 6840	altered cold-filtered Whenchamacallit bar	0		Effect: "Once Bitten Twice Fried", Effect Duration: 62
 6841	boiled non-activated shaking 8-bit banana	0		Effect: "Thaumodynamic", Effect Duration: 57
-6842	aerosolized tumbling maroon vial of blood simple syrup	0		Effect: "Bandersnatched", Effect Duration: 17
+6842	aerosolized maroon tumbling vial of blood simple syrup	0		Effect: "Bandersnatched", Effect Duration: 17
 6843	aerosolized aerosolized huge bone bons	0		Effect: "Orchid Blood", Effect Duration: 40
 6844	polymerized polymerized wet ironic mint	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 26
 6845	unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
 6847	jittery killing jar	0		
 6848	electrified security flashlight	0		MP Regen Min: 3, MP Regen Max: 5
-6849	chilled aerosolized tumbling pulsating Effermint&trade; tablets	0		Effect: "Tremella Tremens", Effect Duration: 39
+6849	chilled aerosolized pulsating tumbling Effermint&trade; tablets	0		Effect: "Tremella Tremens", Effect Duration: 39
 6850	stanky thinker's sturdy cane of the boozehound	0		Mysticality: +10, Stench Spell Damage: +25, Booze Drop: +100
 6851	huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
@@ -6746,20 +6746,20 @@
 6857	electrified Cajun accordion	0		MP Regen Min: 3, MP Regen Max: 5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	pulsating quirky accordion of the early riser	0		Adventures: +7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	gravedigger's veiny Skipper's accordion	0		Maximum HP: +10, Spooky Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	executive chaotic vibrating thinker's Pantsgiving	0		Mysticality: +10, Maximum MP Percent: +10, Spell Critical Percent: +10, Meat Drop: +40, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
-6861	spoiled half-sized yellow wobbly can of sardines	2	crappy	Last Available: "2013-11"
+6860	executive chaotic vibrating thinker's Pantsgiving	0		Mysticality: +10, Maximum MP Percent: +10, Spell Critical Percent: +10, Meat Drop: +40, Softcore Only, Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25"
+6861	spoiled half-sized wobbly yellow can of sardines	2	crappy	Last Available: "2013-11"
 6862	rotten high-calorie sugar substitute	4	crappy	Last Available: "2013-11"
-6863	flavorless small pat of butter	2	decent	Last Available: "2013-11"
+6863	small flavorless pat of butter	2	decent	Last Available: "2013-11"
 6864	decent wobbly dinner roll	4	good	Last Available: "2013-11"
 6865	normal mashed potatoes	3	good	Last Available: "2013-11"
 6866	moldy whole turkey leg	4	crappy	Last Available: "2013-11"
-6867	immense bland deviled egg	10	decent	Last Available: "2013-11"
+6867	bland immense deviled egg	10	decent	Last Available: "2013-11"
 6868	pressed deionized finger exerciser	0		Effect: "Vitamin-Maxed", Effect Duration: 54, Last Available: "2013-11"
 6869	cold-filtered dented spoon	0		Effect: "You Know When to Walk Away", Effect Duration: 22, Last Available: "2013-11"
 6870	activated wet anodized love note	0		Effect: "Milk Studly", Effect Duration: 41, Last Available: "2013-11"
 6871	tumbling school beer pull tab	0		Last Available: "2013-11"
-6872	polarized super-magnetized frozen maroon jittery nail file	0		Effect: "Pumped Up", Effect Duration: 45, Last Available: "2013-11"
-6873	denatured twirling shaking candy wrapper	0		Effect: "Broberry Brotality", Effect Duration: 61, Last Available: "2013-11"
+6872	polarized super-magnetized frozen jittery maroon nail file	0		Effect: "Pumped Up", Effect Duration: 45, Last Available: "2013-11"
+6873	denatured shaking twirling candy wrapper	0		Effect: "Broberry Brotality", Effect Duration: 61, Last Available: "2013-11"
 6874	fuchsia gym membership card	0		Last Available: "2013-11"
 6875	diffused anodized post-holiday sale coupon	0		Effect: "Dreadful Heat", Effect Duration: 22, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
@@ -6791,9 +6791,9 @@
 6902	censurious friendly flask flops	0		Familiar Weight: +3, Sleaze Resistance: +3, Single Equip
 6903	pickled nuts	0		Effect: "Sweet and Green", Effect Duration: 57, Last Available: "2013-12"
 6904	pressed blurry bolts	0		Effect: "Gamer Rage", Effect Duration: 64, Last Available: "2013-12"
-6905	big bland fancy gingerbread robot	5	decent	Effect: "Larger", Effect Duration: 30, Last Available: "2013-12"
-6906	adequate tiny petit 4.1	1	good	Last Available: "2013-12"
-6907	diet stale nut-shaped Crimbo cookie	1	decent	Last Available: "2023-06"
+6905	big fancy bland gingerbread robot	5	decent	Effect: "Larger", Effect Duration: 30, Last Available: "2013-12"
+6906	tiny adequate petit 4.1	1	good	Last Available: "2013-12"
+6907	stale diet nut-shaped Crimbo cookie	1	decent	Last Available: "2023-06"
 6908	clever plastic GORM-8	0		Maximum MP: +20, Last Available: "2013-12"
 6909	plastic warbear of the cheetah	0		Initiative: +60, Last Available: "2013-12"
 6910	tumbling spinning frosty plastic Toybot	0		Cold Spell Damage: +10, Last Available: "2013-12"
@@ -6807,12 +6807,12 @@
 6918	unsweetened dry colloidal upside-down warbear wardance potion	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 23, Last Available: "2013-12"
 6919	electrified warbear bearserker potion	0		Effect: "Sweet, Nuts", Effect Duration: 67, Last Available: "2013-12"
 6920	dry purple warbear liquid overcoat	0		Effect: "Colorful Gratitude", Effect Duration: 57, Last Available: "2013-12"
-6921	flavorless low-calorie warbear feasting bread	1	decent	Last Available: "2013-12"
-6922	snack-sized flavorless warbear warrior bread	2	decent	Last Available: "2013-12"
+6921	low-calorie flavorless warbear feasting bread	1	decent	Last Available: "2013-12"
+6922	flavorless snack-sized warbear warrior bread	2	decent	Last Available: "2013-12"
 6923	snack-sized moldy warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
 6924	irresponsibly strong tolerable warbear feasting mead	10	good	Last Available: "2013-12"
-6925	enchanted perfectly mixed warbear bearserker mead	4	EPIC	Effect: "Wax On Your Shoes", Effect Duration: 10, Last Available: "2013-12"
-6926	mediocre irresponsibly strong warbear blizzard mead	10	decent	Last Available: "2013-12"
+6925	perfectly mixed enchanted warbear bearserker mead	4	EPIC	Effect: "Wax On Your Shoes", Effect Duration: 10, Last Available: "2013-12"
+6926	irresponsibly strong mediocre warbear blizzard mead	10	decent	Last Available: "2013-12"
 6927	fuchsia warbear helm fragment	0		Last Available: "2013-12"
 6928	healthy warbear plain fedora of the sweet-tooth of the early riser	0		Maximum HP Percent: +20, Candy Drop: +100, Adventures: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	narrow groovy warbear feathered fedora	0		Moxie Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6846,8 +6846,8 @@
 6957	spinning warbear requisition box	0		Last Available: "2013-12"
 6958	huge warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	hardy warbear foil hat	0		Maximum HP: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
-6960	maroon wobbly warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	extremely unsafe warbear oil pan of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: +40, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6960	wobbly maroon warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
+6961	extremely unsafe warbear oil pan of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: +40, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	warbear exhaust manifold of Calamity Jane	0		Critical Hit Percent: +15, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6894,13 +6894,13 @@
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	twisted huge handful of Smithereens	1	awesome	Effect: "Tiki Thoughtfulness", Effect Duration: 35, Last Available: "2013-12"
 7007	adequate squat Every Day is Like This Sundae	4	good	Last Available: "2013-12"
-7008	stale jumbo Miserable Pie	5	decent	Last Available: "2013-12"
+7008	jumbo stale Miserable Pie	5	decent	Last Available: "2013-12"
 7009	small bland spinning This Charming Flan	2	decent	Last Available: "2013-12"
 7010	acceptable Irish Coffee, English Heart	3	good	Last Available: "2013-12"
-7011	extra-dry tolerable blinking narrow Strikes Again Bigmouth	5	good	Last Available: "2013-12"
-7012	special perfectly mixed Paint A Vulgar Pitcher	3	EPIC	Effect: "Irresistible Resolve", Effect Duration: 15, Last Available: "2013-12"
+7011	tolerable extra-dry narrow blinking Strikes Again Bigmouth	5	good	Last Available: "2013-12"
+7012	perfectly mixed special Paint A Vulgar Pitcher	3	EPIC	Effect: "Irresistible Resolve", Effect Duration: 15, Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
-7014	tumbling pulsating Louder Than Bomb	0		Last Available: "2013-12"
+7014	pulsating tumbling Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
 7016	huge chaotic quilted Da Vinci's experienced Work is a Four Letter Sword	0		Experience: +2, Experience (Mysticality): +5, Damage Absorption: +40, Spell Critical Percent: +10, Last Available: "2013-12"
 7017	sizzling ruddy brawny Staff of the Headmaster's Victuals of incineration	0		Muscle Percent: +20, Maximum HP Percent: +40, Hot Damage: +10, Hot Spell Damage: +50, Last Available: "2013-12"
@@ -6936,19 +6936,19 @@
 7047	chilled warbear liquid lasers	0		Effect: "Yet tea", Effect Duration: 37, Last Available: "2013-12"
 7048	activated nitrogenated adjusted warbear rejuvenation potion	0		Effect: "Cold Blooded", Effect Duration: 66, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	flavorless half-sized warbear gyro	2	decent	Last Available: "2013-12"
+7050	half-sized flavorless warbear gyro	2	decent	Last Available: "2013-12"
 7051	pressed deionized blurry recording of Rolando's Rondo of Resisto	0		Effect: "Thick-Skinned", Effect Duration: 39, Last Available: "2013-12"
-7052	jittery twirling warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
+7052	twirling jittery warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	decent massive breakfast mess	9	good	Last Available: "2013-12"
+7055	massive decent breakfast mess	9	good	Last Available: "2013-12"
 7056	blue warbear breakfast machine	0		Last Available: "2013-12"
 7057	normal breakfast miracle	4	good	Last Available: "2013-12"
 7058	pickled Cloaca Cola Polar	0		Effect: "Nasty, Nasty Breath", Effect Duration: 34, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	grimstone mask	0		Last Available: "2014-12"
-7062	twirling yellow praying Grim Brother	0		Free Pull, Last Available: "2014-12"
+7062	yellow twirling praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	narrow hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	diluted wobbly teal grim fairy tale	1	decent	Effect: "Compensatory Cruelness", Effect Duration: 35, Last Available: "2014-12"
@@ -6958,7 +6958,7 @@
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
 7071	rotten snow berries	3	crappy	Last Available: "2014-01"
-7072	fancy delicious cyan ice harvest	3	awesome	Effect: "Become Intensely interested", Effect Duration: 15, Last Available: "2014-01"
+7072	delicious fancy cyan ice harvest	3	awesome	Effect: "Become Intensely interested", Effect Duration: 15, Last Available: "2014-01"
 7073	non-adjusted squat frost flower	0		Effect: "The Magic of LOV", Effect Duration: 41, Last Available: "2014-01"
 7074	vacuum-sealed warmed snow cleats	0		Effect: "Trufflin'", Effect Duration: 54, Last Available: "2014-01"
 7075	non-tarnished colloidal blurry liquid ice pack	0		Effect: "Meat the Flintstones", Effect Duration: 19, Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	gray ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	red ghostly vibrating snow mobile	0		Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	red ghostly vibrating snow mobile	0		Maximum MP Percent: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	ice bucket of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-01"
 7085	narrow cyan mansplainer's healthy snow shovel	0		Maximum HP Percent: +20, Monster Level: +15, Lasts Until Rollover, Last Available: "2014-01"
 7086	squat miser's careful bod-ice of the scaredy-cat	0		Monster Level: -25, Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
@@ -6994,7 +6994,7 @@
 7105	narrow anise-flavored venom	0		Last Available: "2014-12"
 7106	mediocre boozy snakebite	5	decent	Last Available: "2014-12"
 7107	Annie Oakley's studded candy stick	0		Damage Absorption: +80, Critical Hit Percent: +20, Last Available: "2014-12"
-7108	moldy half-sized pecan	2	crappy	Last Available: "2014-12"
+7108	half-sized moldy pecan	2	crappy	Last Available: "2014-12"
 7109	bland huge pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	moldy blue candy mountain oyster	4	crappy	Last Available: "2014-12"
@@ -7004,8 +7004,8 @@
 7115	stale upside-down candy carrot cake	3	decent	Last Available: "2014-12"
 7116	supercharged stiffened carrot-on-a-stick	0		Damage Reduction: 1, Maximum MP Percent: +30, Last Available: "2014-12"
 7117	Jeselnik's personal trainer's weasel stomping pants	0		Experience Percent (Muscle): +10, Sleaze Damage: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	spoiled immense mulberry	7	crappy	Last Available: "2014-12"
-7119	tolerable high-proof mulled berry wine	8	good	Last Available: "2014-12"
+7118	immense spoiled mulberry	7	crappy	Last Available: "2014-12"
+7119	high-proof tolerable mulled berry wine	8	good	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	skewed slick lemon party hat	0		Moxie: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	lemon shirt of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-12"
@@ -7016,15 +7016,15 @@
 7127	tumbling gray chocolate cow bone of the sweet-tooth	0		Candy Drop: +100, Last Available: "2014-12"
 7128	oxidized anodized improved gummi fang	0		Effect: "Cosmic Flavor", Effect Duration: 62, Last Available: "2014-12"
 7129	miniature rotten leftover canap&eacute;s	2	crappy	Last Available: "2014-12"
-7130	fancy artisanal weak magnum of champagne	2	super ultra mega turbo EPIC	Effect: "Ghostly Shell", Effect Duration: 50, Last Available: "2014-12"
+7130	fancy weak artisanal magnum of champagne	2	super ultra mega turbo EPIC	Effect: "Ghostly Shell", Effect Duration: 50, Last Available: "2014-12"
 7131	blinking greedy smelly wizardly cow creamer	0		Mysticality: +25, Stench Spell Damage: +10, Meat Drop: +20, Last Available: "2014-12"
 7132	diffused frozen huge Outer Wolf&trade; cologne	0		Effect: "Gingerbread Robust", Effect Duration: 28, Last Available: "2014-12"
-7133	skewed cyan lupine appetite hormones	0		Last Available: "2014-12"
-7134	ghostly stylish wolf whistle of horror	0		Moxie: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	half-sized flavorless spinning witch's bread	2	decent	Last Available: "2014-12"
+7133	cyan skewed lupine appetite hormones	0		Last Available: "2014-12"
+7134	ghostly stylish wolf whistle of horror	0		Moxie: +25, Spooky Spell Damage: +25, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7135	flavorless half-sized spinning witch's bread	2	decent	Last Available: "2014-12"
 7136	triple-alkaline activated frozen witch's brew	0		Effect: "Fratty Flavor", Effect Duration: 67, Last Available: "2014-12"
 7137	maroon inspector's hardened sinister witch's bra	0		Spell Damage: +10, Damage Reduction: 3, Item Drop: +15, Last Available: "2014-12"
-7138	bad practically non-alcoholic shaking mid-level medieval mead	1	decent	Last Available: "2014-12"
+7138	practically non-alcoholic bad shaking mid-level medieval mead	1	decent	Last Available: "2014-12"
 7139	boiled extra-quantum fuchsia R&uuml;mpelstiltz	0		Effect: "Here to Kick Ass", Effect Duration: 13, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	triple-diffused narrow hi-octane carrot juice	0		Effect: "Hangdog", Effect Duration: 16, Last Available: "2014-12"
@@ -7032,8 +7032,8 @@
 7143	fireproof hare pin of terror	0		Spooky Spell Damage: +10, Hot Resistance: +3, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
 7145	flavorless cinnamon cannoli	4	decent	Last Available: "2014-12"
-7146	mediocre practically non-alcoholic shaking expensive champagne	1	decent	Last Available: "2014-12"
-7147	super-dry maroon blurry polo trophy	0		Effect: "Strawberry Alarm", Effect Duration: 17, Last Available: "2014-12"
+7146	practically non-alcoholic mediocre shaking expensive champagne	1	decent	Last Available: "2014-12"
+7147	super-dry blurry maroon polo trophy	0		Effect: "Strawberry Alarm", Effect Duration: 17, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	cyan rosary	0		Last Available: "2014-12"
 7150	squat ornate dowsing rod	0		Last Available: "2014-12"
@@ -7050,7 +7050,7 @@
 7161	olive horrifying &quot;honey&quot; dipper of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Spell Damage: +50, Spooky Damage: +25, Last Available: "2014-12"
 7162	flavorless plumber's lunch	4	decent	Last Available: "2014-12"
 7163	spinning stanky smelly Fonzie's skull gearshift knob	0		Experience (Moxie): +1, Stench Spell Damage: 35, Last Available: "2014-12"
-7164	miniature adequate nachos of the night	2	good	Last Available: "2014-12"
+7164	adequate miniature nachos of the night	2	good	Last Available: "2014-12"
 7165	teal perfumed sage stylish Sketcherz&trade;	0		Moxie: +25, Mysticality Percent: +10, Stench Resistance: +5, Last Available: "2014-12"
 7166	half-sized stale can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
 7167	super-nitrogenated smudge stick	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 62, Last Available: "2014-12"
@@ -7058,10 +7058,10 @@
 7169	acceptable tankard of ale	3	good	Last Available: "2014-12"
 7170	moist moist cold-filtered scroll case	0		Effect: "Gyromitra Gymnastics", Effect Duration: 29, Last Available: "2014-12"
 7171	dry jug of &quot;wine&quot;	0		Effect: "Piratastic", Effect Duration: 13, Last Available: "2014-12"
-7172	yellow upside-down juggling ball	0		Last Available: "2014-12"
+7172	upside-down yellow juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
 7174	decent snack-sized shaking humble pie	2	good	Last Available: "2014-12"
-7175	red shaking small golem	0		Last Available: "2014-12"
+7175	shaking red small golem	0		Last Available: "2014-12"
 7176	gray shaking crappy camera	0		Last Available: "2014-12"
 7177	modified triple-boiled crappy waiter disguise	0		Effect: "Headstrong", Effect Duration: 54
 7178	lime green Copperhead Charm	0		
@@ -7096,7 +7096,7 @@
 7207	huge Jim Carey's blade	0		Monster Level: +25
 7208	fire of unknown origin	0		
 7209	eagle's milk	1	decent	
-7210	galvanized adjusted bouncing lime green eagle feather	0		Effect: "Bark of the Dog", Effect Duration: 31
+7210	galvanized adjusted lime green bouncing eagle feather	0		Effect: "Bark of the Dog", Effect Duration: 31
 7211	extra-altered one pill	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 63
 7212	bouncing brainy Jefferson wings	0		Mysticality: +5
 7213	fleetwood macaroni	0		
@@ -7111,14 +7111,14 @@
 7222	drinkable practically non-alcoholic Flamin' Whatshisname	1	good	
 7223	deionized moist jittery lynyrd musk	0		Effect: "Vital", Effect Duration: 49
 7224	upside-down greedy auspicious Kashmir sweater	0		Item Drop: +10, Meat Drop: +20
-7225	decent thick skewed mirror custard pie	5	good	
+7225	thick decent skewed mirror custard pie	5	good	
 7226	fancy ghostly tea for one	1	decent	Effect: "Polar Express", Effect Duration: 15
 7227	watered-down perfectly mixed bottle of Evermore	2	EPIC	
 7228	mirror box	0		
 7229	drinkable wine	3	good	
 7230	tolerable rum	4	good	
-7231	mediocre practically non-alcoholic Murderer's Punch	1	decent	
-7232	bland miniature velvet cake	2	decent	
+7231	practically non-alcoholic mediocre Murderer's Punch	1	decent	
+7232	miniature bland velvet cake	2	decent	
 7233	cold-filtered oxidized letter	0		Effect: "Pop-eyed", Effect Duration: 19
 7234	flame-retardant book of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5
 7235	Sherlock's stanky masque	0		Stench Spell Damage: +25, Item Drop: +25, Single Equip
@@ -7157,7 +7157,7 @@
 7268	huge Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
 7270	&quot;2 Love Me, Vol. 2&quot;	0		
-7271	mirror ghostly Thinknerd Blind-Packed Toy	0		
+7271	ghostly mirror Thinknerd Blind-Packed Toy	0		
 7272	plastic Professor What of the sewer	0		Stench Damage: +25
 7273	blinking supercool plastic Jared the Duskwalker	0		Moxie Percent: +20
 7274	tumbling twirling rock-hard plastic Duke Starkiller	0		Damage Reduction: 5
@@ -7167,7 +7167,7 @@
 7278	blinking returned Thinknerd package	0		
 7279	adjusted dry liquefied wind-up Whatsian robot	0		Effect: "Cool Spirit", Effect Duration: 38
 7280	altered wind-up vampire teeth	0		Effect: "Can Has Cyborger", Effect Duration: 59
-7281	pickled ionized ghostly huge wind-up navigation droid	0		Effect: "Radiated and Grodiated", Effect Duration: 11
+7281	pickled ionized huge ghostly wind-up navigation droid	0		Effect: "Radiated and Grodiated", Effect Duration: 11
 7282	Vulcanized wind-up owl	0		Effect: "Scrappy, Shadowy", Effect Duration: 50
 7283	vacuum-sealed concentrated wind-up ensign	0		Effect: "The Two-Prong Crown", Effect Duration: 19
 7284	extremely unsafe experienced crying statue earrings	0		Experience: +2, Weapon Damage Percent: +100, Single Equip, Lasts Until Rollover
@@ -7216,7 +7216,7 @@
 7327	denatured synthetic marrow	1		
 7328	ionized blurry funny bone	0		Effect: "Bread-Lined", Effect Duration: 38
 7329	tumbling Oprah's curative half-melted spoon	0		Maximum MP Percent: +50, HP Regen Min: 3, HP Regen Max: 5
-7330	dehydrated skewed blue the funk	1		
+7330	dehydrated blue skewed the funk	1		
 7331	adequate gunky chicken	4	good	
 7332	energetic doll head	0		Maximum MP Percent: +20
 7333	droopy doll eye	0		
@@ -7229,7 +7229,7 @@
 7340	wizardly moose antlers	0		Mysticality: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	non-irradiated bouncing moose thought	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 12
 7342	low-calorie decent moose chocolate	1	good	
-7343	perfectly mixed watered-down painting of a glass of wine	2	EPIC	
+7343	watered-down perfectly mixed painting of a glass of wine	2	EPIC	
 7344	huge oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	wobbly doll-eye amulet	0		Single Equip
@@ -7238,7 +7238,7 @@
 7349	ghost key	0		
 7350	picture of you	0		
 7351	ruddy Staff of the Electric Range of the brazier of the detective	0		Maximum HP Percent: +40, Hot Spell Damage: +25, Item Drop: +20
-7352	bland super-sized special blue deluxe layer cake	5	decent	Effect: "Standard Cheer", Effect Duration: 25
+7352	special super-sized bland blue deluxe layer cake	5	decent	Effect: "Standard Cheer", Effect Duration: 25
 7353	teal chunk of hot iron	0		
 7354	bad red-hot boilermaker	4	decent	
 7355	shaking horrifying coal shovel	0		Spooky Damage: +25, Conditional Skill (Equipped): "Shovel Hot Coal"
@@ -7254,11 +7254,11 @@
 7365	dry fabric hardener	0		Effect: "X-Ray Vision", Effect Duration: 59
 7366	hand-crafted bottle of laundry sherry	4	EPIC	
 7367	super-oxidized galvanized squat industrial strength starch	0		Effect: "Scorpio Rising", Effect Duration: 24, Wiki Name: "industrial strength starch"
-7368	low-calorie tasty twirling extra-flat panini	1	awesome	
+7368	tasty low-calorie twirling extra-flat panini	1	awesome	
 7369	vacuum-sealed denatured frozen mangled finger	0		Effect: "Holiday Bliss", Effect Duration: 52
 7370	mediocre lime green Psychotic Train wine	3	decent	
 7371	crazy hobo notebook	0		
-7372	small bland shaking pie man was not meant to eat	2	decent	
+7372	bland small shaking pie man was not meant to eat	2	decent	
 7373	huge greasy sommelier's towel	0		Sleaze Spell Damage: +10
 7374	personal trainer's tarnished tastevin	0		Experience Percent (Muscle): +10, Single Equip
 7375	bland narrow actual tapas	3	decent	
@@ -7286,15 +7286,15 @@
 7397	activated teal Gene Tonic: Plant	0		Effect: "Slimy Flavor", Effect Duration: 24, Last Available: "2014-04"
 7398	oxidized pressed shaking Gene Tonic: Weird	0		Effect: "Just Aged Enough", Effect Duration: 62, Last Available: "2014-04"
 7399	unsweetened polymerized Gene Tonic: Elf	0		Effect: "Sauce Monocle", Effect Duration: 38, Last Available: "2014-04"
-7400	tarnished magnetized spinning teal Gene Tonic: Mer-kin	0		Effect: "Heart of Lavender", Effect Duration: 43, Last Available: "2014-04"
+7400	tarnished magnetized teal spinning Gene Tonic: Mer-kin	0		Effect: "Heart of Lavender", Effect Duration: 43, Last Available: "2014-04"
 7401	oxidized electrified upside-down Gene Tonic: Slime	0		Effect: "Icy Demeanor", Effect Duration: 24, Last Available: "2014-04"
 7402	altered shaking Gene Tonic: Penguin	0		Effect: "Mana Tea", Effect Duration: 37, Last Available: "2014-04"
 7403	dry Gene Tonic: Elemental	0		Effect: "Cat-Alyzed", Effect Duration: 29, Last Available: "2014-04"
-7404	double-aerosolized tumbling spinning huge Gene Tonic: Constellation	0		Effect: "Alpine Mintiness", Effect Duration: 41, Last Available: "2014-04"
+7404	double-aerosolized spinning tumbling huge Gene Tonic: Constellation	0		Effect: "Alpine Mintiness", Effect Duration: 41, Last Available: "2014-04"
 7405	flattened blinking ghostly Gene Tonic: Hobo	0		Effect: "Penguinny Flavor", Effect Duration: 39, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
-7408	huge squat Steam Card: Dungeon Fist (#3)	0		
+7408	squat huge Steam Card: Dungeon Fist (#3)	0		
 7409	blurry Steam Card: Space Trip (#1)	0		
 7410	Steam Card: Space Trip (#2)	0		
 7411	ghostly Steam Card: Space Trip (#3)	0		
@@ -7308,7 +7308,7 @@
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	pencil thin mushroom	0		Last Available: "2014-05"
-7422	spinning yellow Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
+7422	yellow spinning Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	wobbly salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
 7425	Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
@@ -7324,7 +7324,7 @@
 7435	quadruple-irradiated pulsating Stemonitis Staticus mushroom	0		Effect: "Heart of White", Effect Duration: 67, Last Available: "2014-05"
 7436	enhanced Tremella Tarantella mushroom	0		Effect: "Human-Penguin Hybrid", Effect Duration: 45, Last Available: "2014-05"
 7437	twirling Pastaco shell	0		Last Available: "2014-05"
-7438	adequate thick bouncing bouncing purple Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
+7438	thick adequate bouncing purple bouncing Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
 7439	massive bland Brain Food Pastaco	10	decent	Last Available: "2014-05"
 7440	super-sized moldy twirling Cool Brunch Pastaco	5	crappy	Last Available: "2014-05"
 7441	delicious teal Medical Pastaco	4	awesome	Last Available: "2014-05"
@@ -7343,7 +7343,7 @@
 7454	acceptable super-size brogurt	4	good	Last Available: "2014-05"
 7455	practically non-alcoholic aged maroon broberry brogurt	1	awesome	Last Available: "2014-05"
 7456	weak perfectly mixed brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7457	practically non-alcoholic bad squat French bronilla brogurt	1	decent	Last Available: "2014-05"
+7457	bad practically non-alcoholic squat French bronilla brogurt	1	decent	Last Available: "2014-05"
 7458	red History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	maroon Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7367,11 +7367,11 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	irradiated vacuum-sealed extra-anodized sugar fairy	0		Effect: "Video Game Hot Dog", Effect Duration: 29, Last Available: "2014-05"
 7480	flattened blurry sugar bunny	0		Effect: "Ancestral Disapproval", Effect Duration: 13, Last Available: "2014-05"
-7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	tolerable blue Rompedores de Fantasmas	4	good	
 7483	perfectly mixed fancy pulsating La Fantasma y La Oscuridad	3	EPIC	Effect: "Optimist Primal", Effect Duration: 25
 7484	mediocre fuchsia Fantasma en la M&aacute;quina	4	decent	
-7485	squat tumbling loosening powder	0		
+7485	tumbling squat loosening powder	0		
 7486	shaking castoreum	0		
 7487	drain dissolver	0		
 7488	triple-distilled turpentine	0		
@@ -7396,7 +7396,7 @@
 7507	huge shellacked cloak	0		Damage Reduction: 7
 7508	label	0		
 7509	moldy Mornington crescent roll	4	crappy	
-7510	double-enhanced cold-filtered twirling cyan eye shadow	0		Effect: "Salamander In Your Stomach", Effect Duration: 34
+7510	double-enhanced cold-filtered cyan twirling eye shadow	0		Effect: "Salamander In Your Stomach", Effect Duration: 34
 7511	cyan shaking crumbling wheel	0		
 7512	pressed ionized deionized poppy	0		Effect: "Scrappy, Shadowy", Effect Duration: 25
 7513	shaking opium grenade	0		
@@ -7407,7 +7407,7 @@
 7518	gray wand of pigification	0		
 7519	aged glass of bourbon	3	awesome	
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	flavorless huge blinking government cheese	6	decent	Last Available: "2014-05"
+7521	huge flavorless blinking government cheese	6	decent	Last Available: "2014-05"
 7522	lime green flame-wreathed pair of government shades	0		Hot Spell Damage: +10, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	anodized activated government	0		Effect: "Springy Fusilli", Effect Duration: 64, Last Available: "2014-05"
@@ -7418,7 +7418,7 @@
 7529	rotten loaf of alien bread	3	crappy	Last Available: "2014-05"
 7530	adequate fuchsia grilled cheese sandwich	3	good	Last Available: "2014-05"
 7531	vaporized alien protein powder	1	EPIC	Last Available: "2014-05"
-7532	practically non-alcoholic delicious teal rocket fuel	1	awesome	Last Available: "2014-05"
+7532	delicious practically non-alcoholic teal rocket fuel	1	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	distilled mediocre stealth bomber	5	decent	Last Available: "2014-05"
@@ -7429,7 +7429,7 @@
 7540	blue space beast fur pants of the brute	0		Muscle Percent: +30, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	ribald space beast fur whip	0		Sleaze Damage: +10, Last Available: "2014-05"
 7542	teal space invader	0		Last Available: "2014-05"
-7543	blue prompt hardened space heater	0		Damage Reduction: 3, Adventures: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	blue prompt hardened space heater	0		Damage Reduction: 3, Adventures: +3, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	fuchsia space bar	0		Last Available: "2014-05"
 7545	aged watered-down space port	2	awesome	Last Available: "2014-05"
 7546	blurry miser's hardened space needle	0		Damage Reduction: 3, Meat Drop: +10, Last Available: "2014-05"
@@ -7444,7 +7444,7 @@
 7555	shaking page	0		
 7556	elephant gift	0		
 7557	anodized concentrated blood cells	0		Effect: "Burnt 'n' Turnt", Effect Duration: 55
-7558	acceptable practically non-alcoholic wine	1	good	
+7558	practically non-alcoholic acceptable wine	1	good	
 7559	double-dry cold-filtered ghostly olive gummi turtle	0		Effect: "Salad Days", Effect Duration: 13
 7560	turtle-shaped rock	0		
 7561	deionized magnetized giraffe-necked turtle	0		Effect: "Grrrrrrreat!", Effect Duration: 45
@@ -7460,7 +7460,7 @@
 7571	huge horrifying steel-toed silent pea shooter	0		Damage Reduction: 9, Spooky Damage: +25
 7572	flavorless jumbo D roll	5	decent	
 7573	blue aromatic kiwi beak of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +1
-7574	drinkable watered-down bouncing New Zealand iced tea	2	good	
+7574	watered-down drinkable bouncing New Zealand iced tea	2	good	
 7575	steel-toed personal trainer's droll monocle	0		Experience Percent (Muscle): +10, Damage Reduction: 9, Single Equip
 7576	pickled future drug: Muscularactum	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 36
 7577	ionized future drug: Smartinex	0		Effect: "Cold as Ice", Effect Duration: 63
@@ -7469,21 +7469,21 @@
 7580	twisted pulsating liquid shifting time weirdness	1		Effect: "Weapon of Mass Destruction", Effect Duration: 15
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	small rotten rack of dinosaur ribs	2	crappy	
-7583	watered-down artisanal scotch on the rocks	2	super ultra EPIC	
+7583	artisanal watered-down scotch on the rocks	2	super ultra EPIC	
 7584	upside-down censurious supercool yabba dabba doo rag	0		Moxie Percent: +20, Sleaze Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	Van der Graaf wooly loincloth of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	huge pulsating helix fossil	0		
-7587	cyan upside-down S.S. Ticket	0		Familiar Weight: +5
+7587	upside-down cyan S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	bad practically non-alcoholic glass of &quot;milk&quot;	1	decent	Last Available: "2014-07"
+7589	practically non-alcoholic bad glass of &quot;milk&quot;	1	decent	Last Available: "2014-07"
 7590	drinkable yellow cup of &quot;tea&quot;	4	good	Last Available: "2014-07"
 7591	lousy thermos of &quot;whiskey&quot;	4	decent	Last Available: "2014-07"
 7592	mediocre high-proof huge Lucky Lindy	9	decent	Last Available: "2014-07"
-7593	tolerable irresponsibly strong Bee's Knees	6	good	Last Available: "2014-07"
-7594	special smooth Sockdollager	3	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 15, Last Available: "2014-07"
-7595	special fortified lousy spinning Ish Kabibble	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2014-07"
+7593	irresponsibly strong tolerable Bee's Knees	6	good	Last Available: "2014-07"
+7594	smooth special Sockdollager	3	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 15, Last Available: "2014-07"
+7595	fortified special lousy spinning Ish Kabibble	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2014-07"
 7596	aged red Hot Socks	3	awesome	Last Available: "2014-07"
-7597	artisanal practically non-alcoholic Phonus Balonus	1	super ultra mega turbo EPIC	Last Available: "2014-07"
+7597	practically non-alcoholic artisanal Phonus Balonus	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7598	drinkable Flivver	4	good	Last Available: "2014-07"
 7599	artisanal watered-down huge Sloppy Jalopy	2	super ultra mega EPIC	Last Available: "2014-07"
 7600	liquefied flame	0		Effect: "Tenacity of the Snapper", Effect Duration: 23
@@ -7552,7 +7552,7 @@
 7663	shaking cool thinker's Lord Soggyraven's Slippers of the boozehound	0		Mysticality: +10, Moxie: +5, Booze Drop: +100, Single Equip
 7664	adjusted nitrogenated pulsating fuchsia Ancient Protector Soda	0		Effect: "Wit Tea", Effect Duration: 60
 7665	deionized denatured liquid ice	0		Effect: "Hella Smooth", Effect Duration: 33
-7666	fortified perfectly mixed blurry Wet Russian	5	EPIC	
+7666	perfectly mixed fortified blurry Wet Russian	5	EPIC	
 7667	low-calorie flavorless blurry filet of The Fish	1	decent	
 7668	gray narrow Thwaitgold spider statuette	0		
 7669	greedy greasy boxer's thunder down underwear	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Meat Drop: +20, Lasts Until Rollover
@@ -7581,7 +7581,7 @@
 7692	blue censurious flame-wreathed hand whip of the boozehound	0		Hot Spell Damage: +10, Sleaze Resistance: +3, Booze Drop: +100, Last Available: "2014-08"
 7693	hardened dance instructor's Herculean glow-in-the-dark necklace	0		Experience (Muscle): +1, Experience Percent (Moxie): +10, Damage Reduction: 3, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	Newton's supercool cap gun of the cheetah	0		Moxie Percent: +20, Experience (Mysticality): +3, Initiative: +60, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	Newton's supercool cap gun of the cheetah	0		Moxie Percent: +20, Experience (Mysticality): +3, Initiative: +60, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	spinning Temple Grandin's Newton's cassette player	0		Experience (Mysticality): +3, Familiar Weight: +7, Single Equip, Last Available: "2014-08"
 7697	skewed chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	bouncing rubber spider	0		Last Available: "2014-08"
@@ -7592,10 +7592,10 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	squat LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	wobbly huge The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	huge wobbly The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	colloidal diffused rubber nubbin	0		Effect: "Banono", Effect Duration: 30, Last Available: "2014-08"
 7708	narrow MacGyver's rubber cape of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100, Last Available: "2014-08"
-7709	nasty MacGyver's curative beefy Thor's Pliers	0		Muscle: +10, Maximum MP: +100, Stench Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	nasty MacGyver's curative beefy Thor's Pliers	0		Muscle: +10, Maximum MP: +100, Stench Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	diffused candy UFOs	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 17
 7711	blue energetic weightlifter's water wings for babies	0		Muscle: +15, Maximum MP Percent: +20
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
@@ -7673,7 +7673,7 @@
 7784	anodized dry monkey barf	0		Effect: "Mushroom Samba", Effect Duration: 61, Last Available: "2014-10"
 7785	triple-ionized denatured candy	0		Effect: "Sugary Tongue", Effect Duration: 56, Last Available: "2014-10"
 7786	perfumed MacGyver's jangly bracelet of the detective	0		Maximum MP: +100, Stench Resistance: +5, Item Drop: +20, Last Available: "2014-10"
-7787	quilted cuddly teddy bear	0		Damage Absorption: +40, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	quilted cuddly teddy bear	0		Damage Absorption: +40, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	huge Tesla crafty first-aid pouch	0		Maximum MP: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7684,8 +7684,8 @@
 7795	moldy initiative shawarma	4	crappy	Last Available: "2014-10"
 7796	spoiled fuchsia warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	enchanted spoiled karma shawarma	4	crappy	Effect: "Ancient Protected", Effect Duration: 20, Last Available: "2014-10"
-7798	practically non-alcoholic fancy hand-crafted Jungle Juice	1	EPIC	Effect: "Wet Rub", Effect Duration: 35, Last Available: "2014-10"
-7799	artisanal practically non-alcoholic blinking blurry Amnesiac Ale	1	super ultra EPIC	Last Available: "2014-10"
+7798	fancy practically non-alcoholic hand-crafted Jungle Juice	1	EPIC	Effect: "Wet Rub", Effect Duration: 35, Last Available: "2014-10"
+7799	artisanal practically non-alcoholic blurry blinking Amnesiac Ale	1	super ultra EPIC	Last Available: "2014-10"
 7800	artisanal Highest Bitter	3	EPIC	Last Available: "2014-10"
 7801	vibrating mercenary pistol of the brazier	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Last Available: "2014-10"
 7802	Tesla mercenary rifle of the storm	0		Maximum MP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
@@ -7696,14 +7696,14 @@
 7807	TI-9000 calculator	0		
 7808	squat unused soap	0		
 7809	impure gasoline	0		
-7810	red ghostly Z-Bone steak	0		
+7810	ghostly red Z-Bone steak	0		
 7811	tumbling viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	miniature rotten tumbling seared dino steak	2	crappy	
-7814	bad weak bottle of drinkin' gas	2	decent	
+7814	weak bad bottle of drinkin' gas	2	decent	
 7815	handful of napalm	0		
 7816	dove DNA	0		
-7817	green ghostly gelatinous meat mass	0		
+7817	ghostly green gelatinous meat mass	0		
 7818	mirror 99.44% pure math	0		
 7819	simple AI	0		
 7820	corrupted bird DNA	0		
@@ -7713,7 +7713,7 @@
 7824	mirror skewed chilly grievous Rosewater's iShield	0		Mysticality Percent: +30, Weapon Damage Percent: +50, Cold Damage: +5, Damage Reduction: 6
 7825	energetic earbuds of Tarzan of bravery	0		Experience (Muscle): +3, Maximum MP Percent: +20, Spooky Resistance: +5, Single Equip
 7826	reassuring dance instructor's iFlail of the brute	0		Muscle Percent: +30, Experience Percent (Moxie): +10, Spooky Resistance: +1
-7827	enchanted small stale unidentifiable dried fruit	2	decent	Effect: "Mad at Science", Effect Duration: 40
+7827	stale small enchanted unidentifiable dried fruit	2	decent	Effect: "Mad at Science", Effect Duration: 40
 7828	weak acceptable flat cider	2	good	
 7829	auspicious hardened trench lighter of the cougar	0		Moxie: +20, Damage Reduction: 3, Item Drop: +10, Last Available: "2014-10"
 7830	Vulcanized ionized experimental serum P-00	0		Effect: "Preternatural Greed", Effect Duration: 56, Last Available: "2014-10"
@@ -7731,11 +7731,11 @@
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
-7845	quantum enhanced teal narrow perl necklace	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 42, Last Available: "2014-12"
+7845	quantum enhanced narrow teal perl necklace	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 42, Last Available: "2014-12"
 7846	extra-altered Fudge Fiber Armor Plating	0		Effect: "Wallflowering", Effect Duration: 62, Last Available: "2014-12"
 7847	extra-unsweetened yellow spinning ruby on canes	0		Effect: "Loyal Tea", Effect Duration: 19, Last Available: "2014-12"
-7848	flavorless miniature petit fortran	2	decent	Last Available: "2014-12"
-7849	jumbo toothsome java cookie	5	awesome	Last Available: "2014-12"
+7848	miniature flavorless petit fortran	2	decent	Last Available: "2014-12"
+7849	toothsome jumbo java cookie	5	awesome	Last Available: "2014-12"
 7850	toothsome cookie cookie	3	awesome	Last Available: "2014-12"
 7851	brawny plastic exo-suited miner	0		Muscle Percent: +20, Last Available: "2014-12"
 7852	yellow plastic semi-autonomous drill unit of the sweet-tooth	0		Candy Drop: +100, Last Available: "2014-12"
@@ -7780,12 +7780,12 @@
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
-7894	spinning huge Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
+7894	huge spinning Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	jittery Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	olive Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
-7899	squat bouncing Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
+7899	bouncing squat Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	spinning Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	ghostly Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
@@ -7802,7 +7802,7 @@
 7913	frosty smartaleck's Size XI Wizard's Robe of the cougar	0		Moxie: +20, Moxie Percent: +30, Cold Spell Damage: +10, Last Available: "2014-09"
 7914	quadruple-anodized Vulcanized yellow Bit O' Quail Spleen	0		Effect: "Well-Lubed", Effect Duration: 26
 7915	electrified modified dry Take Eleven Bar	0		Effect: "Earthen Fist", Effect Duration: 53
-7916	shaking bouncing jittery mimeplasm	0		
+7916	jittery bouncing shaking mimeplasm	0		
 7917	wet dry pressed maroon BOOterfinger	0		Effect: "Scorpio Rising", Effect Duration: 51
 7918	Vulcanized wobbly Moonds	0		Effect: "Held Closer", Effect Duration: 65
 7919	tarnished denatured enhanced upside-down ghostly Big Punk	0		Effect: "Concentrated Concentration", Effect Duration: 65
@@ -7810,7 +7810,7 @@
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	practically non-alcoholic delicious Friendly Turkey	1	awesome	Last Available: "2014-11"
 7923	acceptable blurry Agitated Turkey	3	good	Last Available: "2014-11"
-7924	weak acceptable mirror Ambitious Turkey	2	good	Last Available: "2014-11"
+7924	acceptable weak mirror Ambitious Turkey	2	good	Last Available: "2014-11"
 7925	adequate small neutron lollipop	2	good	Last Available: "2014-12"
 7926	mediocre gamma nog	3	decent	Last Available: "2014-12"
 7934	huge sneaky wrapping paper	0		Last Available: "2014-12"
@@ -7822,11 +7822,11 @@
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
 7942	pocket ace	0		
-7943	mirror teal nastygeist	0		
+7943	teal mirror nastygeist	0		
 7944	tooth	0		
 7945	olive table	0		
 7946	wholesome banded cool outlaw bandana	0		Moxie: +5, Damage Absorption: +100, Maximum HP Percent: +10
-7947	fortified smooth whiskey in a broken glass	5	awesome	
+7947	smooth fortified whiskey in a broken glass	5	awesome	
 7948	spirit-forward drinkable shot of mescal	5	good	
 7949	mediocre upside-down glass of herbal tequila	4	decent	
 7950	minin' dynamite	0		
@@ -7838,7 +7838,7 @@
 7956	wobbly Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
-7959	jittery narrow letter to Ed the Undying	0		
+7959	narrow jittery letter to Ed the Undying	0		
 7960	teal copy of a jerk adventurer's father's diary	0		
 7961	squat chaotic slick Staff of Ed of the brute of Tarzan	0		Moxie: +10, Muscle Percent: +30, Experience (Muscle): +3, Spell Critical Percent: +10
 7962	Eye of Ed	0		
@@ -7851,9 +7851,9 @@
 7969	blurry beehive	0		
 7970	boning knife	0		
 7971	red Aggressive Carrot	0		Free Pull
-7972	mixed red jittery mummified fig	1	good	Effect: "Heal Thy Nanoself", Effect Duration: 10
+7972	mixed jittery red mummified fig	1	good	Effect: "Heal Thy Nanoself", Effect Duration: 10
 7973	distilled olive mummified loaf of bread	1	decent	Effect: "Bananas!", Effect Duration: 20
-7974	mixed teal pulsating bouncing mummified beef haunch	1	good	Effect: "Sweetened and Fattened", Effect Duration: 50
+7974	mixed bouncing teal pulsating mummified beef haunch	1	good	Effect: "Sweetened and Fattened", Effect Duration: 50
 7975	purple linen bandages	0		
 7976	red cotton bandages	0		
 7977	squat wobbly silk bandages	0		
@@ -7876,30 +7876,30 @@
 7994	pulsating censurious groovy pepper mill	0		Moxie Percent: +10, Sleaze Resistance: +3, Last Available: "2015-12"
 7995	Rosewater's beefy pelerine	0		Muscle: +10, Mysticality Percent: +30, Last Available: "2015-12"
 7996	chaotic baleful phantom mask	0		Spell Damage: +25, Spell Critical Percent: +10, Single Equip, Last Available: "2015-12"
-7997	vaporized squat fuchsia polyesterene powder	1		Effect: "Human-Constellation Hybrid", Effect Duration: 5, Last Available: "2015-12"
-7998	pickled red skewed powder	1		Last Available: "2015-12"
+7997	vaporized fuchsia squat polyesterene powder	1		Effect: "Human-Constellation Hybrid", Effect Duration: 5, Last Available: "2015-12"
+7998	pickled skewed red powder	1		Last Available: "2015-12"
 7999	quadruple-pickled choco-Crimbot	0		Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2014-12"
 8000	enhanced smart watch	0		Effect: "Can't Be a Chooser", Effect Duration: 32, Last Available: "2014-12"
 8001	colloidal vacuum-sealed huge augmented-reality shades	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 12, Last Available: "2014-12"
-8002	lion tamer's toy Crimbot mega face	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
-8003	red blinking lion tamer's toy Crimbot power glove	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	yellow lightning-fast toy Crimbot super fist	0		Initiative: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	lime green scandalous toy Crimbot rocket legs	0		Sleaze Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	lion tamer's toy Crimbot mega face	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12"
+8003	red blinking lion tamer's toy Crimbot power glove	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	yellow lightning-fast toy Crimbot super fist	0		Initiative: +40, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	lime green scandalous toy Crimbot rocket legs	0		Sleaze Damage: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	improved cold-filtered skewed Crimbot battery	0		Effect: "Concentrated Concentration", Effect Duration: 57, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	narrow Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8009	cyan twirling Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8009	twirling cyan Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	wobbly heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	lard-coated strapping Crimbomega drive chain of vim and vigor	0		Muscle: +5, Maximum HP Percent: +50, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	lard-coated strapping Crimbomega drive chain of vim and vigor	0		Muscle: +5, Maximum HP Percent: +50, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	super-irradiated anodized fitness wristband	0		Effect: "Sausage Festive", Effect Duration: 65, Last Available: "2014-12"
-8017	improved denatured squat skewed flask of tainted mining oil	0		Effect: "Sagittarius Rising", Effect Duration: 17, Last Available: "2014-12"
+8017	improved denatured skewed squat flask of tainted mining oil	0		Effect: "Sagittarius Rising", Effect Duration: 17, Last Available: "2014-12"
 8018	triple-tarnished pressed and rain stick	0		Effect: "Fizzier Than Light", Effect Duration: 22
 8019	tumbling Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	snack-sized bland Choco-Mint patty	2	decent	Last Available: "2015-01"
+8020	bland snack-sized Choco-Mint patty	2	decent	Last Available: "2015-01"
 8021	hand-crafted hot mint schnocolate	4	EPIC	Last Available: "2015-01"
 8022	compressed homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
@@ -7941,10 +7941,10 @@
 8060	hardy beefy The Joke Book of the Dead	0		Muscle: +10, Maximum HP: +50, Luck: -6
 8061	The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	spinning squat Tales of Spelunking	0		Last Available: "2015-12"
+8063	squat spinning Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	upside-down banana	0		Familiar Weight: +5
-8066	modified blinking green	1	decent	Effect: "Arse-a'fire", Effect Duration: 20, Last Available: "2015-12"
+8066	modified green blinking	1	decent	Effect: "Arse-a'fire", Effect Duration: 20, Last Available: "2015-12"
 8067	nuggets	0		
 8068	purple Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
@@ -7996,17 +7996,17 @@
 8121	ghostly lard-coated gravedigger's garland	0		Spooky Damage: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2018-12"
 8122	blinking Sherlock's scorching gunnysack	0		Hot Damage: +25, Item Drop: +25, Last Available: "2018-12"
 8123	shaking foul-smelling curative garibaldi	0		Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
-8124	Newton's girdle of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	Newton's girdle of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	vibrating brainy gloves	0		Mysticality: +5, Maximum MP Percent: +10, Single Equip, Last Available: "2018-12"
-8126	boiled upside-down purple smithereens	1		Last Available: "2018-12"
+8126	boiled purple upside-down smithereens	1		Last Available: "2018-12"
 8127	clever boxer's fiberglass fetish	0		Muscle Percent: +10, Maximum MP: +20, Last Available: "2018-12"
 8128	fiberglass foil of the blizzard of doom	0		Cold Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2018-12"
 8129	fiberglass fannypack of the dark arts of Flo-Jo	0		Spell Damage Percent: +100, Initiative: +100, Single Equip, Last Available: "2018-12"
 8130	blinking fiberglass frock of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Last Available: "2018-12"
 8131	fiberglass fingerguard of Tarzan of James Dean	0		Experience (Muscle): +3, Experience (Moxie): +3, Single Equip, Last Available: "2018-12"
 8132	sinister stylish fiberglass fedora	0		Moxie: +25, Spell Damage: +10, Last Available: "2018-12"
-8133	dehydrated skewed red fiberglass fibers	1		Last Available: "2018-12"
-8134	huge cyan spinning bottle of lovebug pheromones	0		Free Pull
+8133	dehydrated red skewed fiberglass fibers	1		Last Available: "2018-12"
+8134	huge spinning cyan bottle of lovebug pheromones	0		Free Pull
 8135	blinking jittery winged yeti fur	0		
 8136	blurry talisman of Renenutet	0		
 8138	olive rubber spatula of the sweet-tooth	0		Candy Drop: +100
@@ -8047,7 +8047,7 @@
 8173	sewer snake of the early riser	0		Adventures: +7
 8174	jumbo toothsome skewed pigeon egg	5	awesome	
 8175	flame-retardant grievous jaunty feather	0		Weapon Damage Percent: +50, Hot Resistance: +1
-8176	spirit-forward artisanal premium malt liquor	5	EPIC	
+8176	artisanal spirit-forward premium malt liquor	5	EPIC	
 8177	bouncing teal wholesome smooth brown paper pants	0		Moxie: +15, Maximum HP Percent: +10
 8178	energetic brawny brown paper bag mask	0		Muscle Percent: +20, Maximum MP Percent: +20
 8179	lime green ring of telling skeletons what to do of incineration	0		Hot Spell Damage: +50, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8065,7 +8065,7 @@
 8191	mediocre Breakfast Blast wine cooler	4	decent	
 8192	perfectly mixed Citrus Crush wine cooler	4	EPIC	
 8193	moldy huge plain bagel	3	crappy	
-8194	tasty diet glob of cream cheese	1	awesome	
+8194	diet tasty glob of cream cheese	1	awesome	
 8195	small spoiled loaf of soda bread	2	crappy	
 8196	rotten yellow acceptable bagel	4	crappy	
 8197	decent immense teal standard-issue cupcake	6	good	
@@ -8081,12 +8081,12 @@
 8207	twirling sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	concentrated How to Avoid Scams	0		Effect: "Warm Shoulders", Effect Duration: 19, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
-8210	squat jittery bag of gross foreign snacks	0		Last Available: "2015-04"
+8210	jittery squat bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	energetic sinister rigging rope	0		Spell Damage: +10, Maximum MP Percent: +20, Last Available: "2015-04"
 8214	altered nasty snuff	1	good	Last Available: "2015-04"
-8215	fireproof veiny sewage-clogged pistol	0		Maximum HP: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8215	fireproof veiny sewage-clogged pistol	0		Maximum HP: +10, Hot Resistance: +3, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	warmed alkaline tumbling beard incense	0		Effect: "Lemony Goodness", Effect Duration: 24, Last Available: "2015-04"
 8217	tumbling double-paned gravedigger's perfume-soaked bandana	0		Spooky Damage: +10, Cold Resistance: +5, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
@@ -8113,7 +8113,7 @@
 8239	keycard &alpha;	0		Last Available: "2015-04"
 8240	keycard &beta;	0		Last Available: "2015-04"
 8241	mirror keycard &gamma;	0		Last Available: "2015-04"
-8242	narrow twirling keycard &delta;	0		Last Available: "2015-04"
+8242	twirling narrow keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	huge lube-shoes of dire peril	0		Weapon Damage: +20, Last Available: "2015-04"
 8245	upside-down trash net	0		Last Available: "2015-04"
@@ -8141,15 +8141,15 @@
 8267	tumbling olive weightlifter's sphygmayomanometer	0		Muscle: +15, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	fuchsia mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	miniature rotten unappetizing mayolus	2	crappy	Last Available: "2015-05"
-8271	diet normal uninteresting mayolus	1	good	Last Available: "2015-05"
-8272	moldy snack-sized acceptable mayolus	2	crappy	Last Available: "2015-05"
-8273	special bland enticing mayolus	3	decent	Effect: "Swimming Head", Effect Duration: 10, Last Available: "2015-05"
+8270	rotten miniature unappetizing mayolus	2	crappy	Last Available: "2015-05"
+8271	normal diet uninteresting mayolus	1	good	Last Available: "2015-05"
+8272	snack-sized moldy acceptable mayolus	2	crappy	Last Available: "2015-05"
+8273	bland special enticing mayolus	3	decent	Effect: "Swimming Head", Effect Duration: 10, Last Available: "2015-05"
 8274	bland diet mouth-watering mayolus	1	decent	Last Available: "2015-05"
 8275	huge newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
-8276	upside-down tumbling mayo pump	0		Familiar Weight: +5
+8276	tumbling upside-down mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	mediocre high-proof Afternoon Delight	8	decent	Last Available: "2015-04"
+8278	high-proof mediocre Afternoon Delight	8	decent	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	purple Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	polymerized dry concentrated Kokomo Resort Brand Suntan Oil	0		Effect: "Permanent Halloween", Effect Duration: 47, Last Available: "2015-04"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	aerosolized adjusted power pill	0		Effect: "Greased-Up Familiar", Effect Duration: 45, Last Available: "2015-06"
 8301	non-adjusted ionized squat pixel star	0		Effect: "Flaming Weapon", Effect Duration: 58, Last Available: "2015-06"
-8302	super-sized decent pixel banana	5	good	Last Available: "2015-06"
+8302	decent super-sized pixel banana	5	good	Last Available: "2015-06"
 8303	hand-crafted practically non-alcoholic pixel beer	1	super ultra mega EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	narrow pumps	0		Last Available: "2015-06"
@@ -8194,9 +8194,9 @@
 8320	enhanced one glove	0		Effect: "Bark of the Dog", Effect Duration: 44
 8321	wet glove	0		Effect: "Expert Vacationer", Effect Duration: 39
 8322	boiled handful of fire	0		Effect: "Buttermilk Boogie", Effect Duration: 26
-8323	irradiated galvanized anodized ghostly huge Cracklin' Oat Bran	0		Effect: "So Fresh and So Clean", Effect Duration: 41
+8323	irradiated galvanized anodized huge ghostly Cracklin' Oat Bran	0		Effect: "So Fresh and So Clean", Effect Duration: 41
 8324	anodized dry disposable lighter	0		Effect: "Rampage!", Effect Duration: 62
-8325	polymerized alkaline pulsating teal huge coal contact lenses	0		Effect: "The Best a Pirate Can Get", Effect Duration: 44
+8325	polymerized alkaline pulsating huge teal coal contact lenses	0		Effect: "The Best a Pirate Can Get", Effect Duration: 44
 8326	altered corrupted blinking blue conjured ice cream	0		Effect: "Nutrient-Rich", Effect Duration: 49
 8327	extra-liquefied pickled Iceberglar scarf	0		Effect: "Thanksgot", Effect Duration: 50
 8328	moist oxidized mirror icy hairspray	0		Effect: "Dragged Through the Coals", Effect Duration: 31
@@ -8244,7 +8244,7 @@
 8370	modified huge funky eyepatch	0		Effect: "Stinkybeard", Effect Duration: 50
 8371	magnetized moist quadruple-quantum mirror spinning bucket of fish juice	0		Effect: "Frozen Shoulders", Effect Duration: 52
 8372	warmed lime green flashy pirate dreadlocks	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 38
-8373	boiled ghostly fuchsia narrow captured boozles	0		Effect: "Egg-headedness", Effect Duration: 25
+8373	boiled narrow ghostly fuchsia captured boozles	0		Effect: "Egg-headedness", Effect Duration: 25
 8374	cold-filtered squat drinks tray	0		Effect: "Nas Tea", Effect Duration: 34
 8375	unsweetened wobbly eyebrow lifter	0		Effect: "Human-Slime Hybrid", Effect Duration: 31
 8376	squat submarine	0		Last Available: "2015-06"
@@ -8255,7 +8255,7 @@
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	shaking Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
-8384	blinking huge bubblegum heart	0		Last Available: "2015-07"
+8384	huge blinking bubblegum heart	0		Last Available: "2015-07"
 8385	skewed cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
@@ -8283,7 +8283,7 @@
 8409	bland wobbly crudles	4	decent	
 8410	stale agnolotti arboli	3	decent	
 8411	normal twirling spaghetti with ghost balls	4	good	
-8412	bland small blurry succulent marrow	2	decent	
+8412	small bland blurry succulent marrow	2	decent	
 8413	tasty mirror salacious crumbs	3	awesome	
 8414	toothsome fusilli marrownarrow	3	awesome	
 8415	adequate suggestive strozzapreti	4	good	
@@ -8291,7 +8291,7 @@
 8417	normal Mt. McLargeHuge oyster	3	good	
 8418	oyster sauce	0		
 8419	decent linguini immondizia bianco	3	good	
-8420	super-sized yummy maroon shells a la shellfish	5	awesome	
+8420	yummy super-sized maroon shells a la shellfish	5	awesome	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8310,7 +8310,7 @@
 8436	pulsating blue lard-coated friendly LavaCo Lamp&trade;	0		Familiar Weight: +3, Sleaze Spell Damage: +25, Last Available: "2015-08"
 8437	LavaCo Lamp&trade; of extreme caution of incineration	0		Monster Level: -25, Hot Spell Damage: +50, Last Available: "2015-08"
 8438	blinking pulsating thin wire	0		Last Available: "2015-08"
-8439	jittery green insulated wire	0		Last Available: "2015-08"
+8439	green jittery insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	narrow viscous lava globs	0		Last Available: "2015-08"
@@ -8348,7 +8348,7 @@
 8474	decent very hot lunch	3	good	Last Available: "2015-08"
 8475	drinkable asbestos thermos	4	good	Last Available: "2015-08"
 8476	non-enhanced energized liquid rhinestones	0		Effect: "Salt Rockin'", Effect Duration: 48, Last Available: "2015-08"
-8477	rotten bite-sized tumbling disco biscuit	1	crappy	Last Available: "2015-08"
+8477	bite-sized rotten tumbling disco biscuit	1	crappy	Last Available: "2015-08"
 8478	spirit-forward lousy Quaatorade&trade;	5	decent	Last Available: "2015-08"
 8479	pulsating olive chaotic energetic brawny biker's hat	0		Muscle Percent: +20, Maximum MP Percent: +20, Spell Critical Percent: +10, Last Available: "2015-08", Familiar Effect: "atk"
 8480	Usain Bolt's double-paned feathered headdress of the cougar	0		Moxie: +20, Cold Resistance: +5, Initiative: +80, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
@@ -8397,7 +8397,7 @@
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	bland lava cake	3	decent	Last Available: "2015-08"
-8526	special bland snack-sized pink slime	2	decent	Effect: "Dancing Prowess", Effect Duration: 30
+8526	special snack-sized bland pink slime	2	decent	Effect: "Dancing Prowess", Effect Duration: 30
 8527	Devil's Elbow Hot Sauce	0		
 8528	blinking Special&trade; Sauce	0		
 8529	spoiled narrow devil hair pasta	3	crappy	
@@ -8405,18 +8405,18 @@
 8531	Salsa Libre	0		
 8532	bouncing good gravy	0		
 8533	illicit fish sauce	0		
-8534	gigantic toothsome huge tumbling gray libertagliatelle	10	awesome	
+8534	gigantic toothsome huge gray tumbling libertagliatelle	10	awesome	
 8535	moldy turkish mostaccioli	4	crappy	
 8536	decent linguini of the sea	4	good	
 8537	wet shaking Hersey&trade; SMOOCH	0		Effect: "Outer Wolf&trade;", Effect Duration: 60
-8539	teal squat Alexy sauce	0		
+8539	squat teal Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	adequate Fettris	4	good	
 8543	massive flavorless squat huge fusillocybin	10	decent	
 8544	spoiled prescription noodles	4	crappy	
 8545	boiled blood-drive sticker	1	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 35
-8546	quadruple-corrupted narrow huge bag of grain	0		Effect: "Liquid Luck", Effect Duration: 23
+8546	quadruple-corrupted huge narrow bag of grain	0		Effect: "Liquid Luck", Effect Duration: 23
 8547	electrified electrified pocket maze	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 19
 8548	enhanced Vulcanized ionized narrow shady shades	0		Effect: "Transcendental Wind", Effect Duration: 42
 8549	oxidized Vulcanized squeaky toy rose	0		Effect: "Dances with Tweedles", Effect Duration: 11
@@ -8424,7 +8424,7 @@
 8551	adequate sausage without a cause	3	good	
 8552	irradiated face paint	0		Effect: "Net Tea", Effect Duration: 46
 8553	aged maroon emergency margarita	3	awesome	
-8554	distilled aged vintage smart drink	5	awesome	
+8554	aged distilled vintage smart drink	5	awesome	
 8555	a ten-percent bonus	0		
 8556	blurry Thwaitgold termite statuette	0		
 8557	shaking The Emperor's new cookie	0		
@@ -8444,11 +8444,11 @@
 8571	weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
 8573	cyan barrel	0		Last Available: "2015-09"
-8574	pulsating blue moist barrel	0		Last Available: "2015-09"
+8574	blue pulsating moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	spirit-forward aged blurry bottle of Amontillado	5	awesome	Last Available: "2015-09"
+8578	aged spirit-forward blurry bottle of Amontillado	5	awesome	Last Available: "2015-09"
 8579	watered-down smooth shaking barrel-aged martini	2	awesome	Last Available: "2015-09"
 8580	half-sized flavorless barrel pickle	2	decent	Last Available: "2015-09"
 8581	moldy teal barrel cracker	4	crappy	Last Available: "2015-09"
@@ -8476,7 +8476,7 @@
 8603	non-anodized quadruple-dry ionized yellow cuppa Boo tea	0		Effect: "Leash of Linguini", Effect Duration: 37, Last Available: "2015-09"
 8604	wet quantum teal cuppa Nas tea	0		Effect: "White Knuckles", Effect Duration: 55, Last Available: "2015-09"
 8605	anodized cyan ghostly cuppa Improprie tea	0		Effect: "Moon-Eyed", Effect Duration: 18, Last Available: "2015-09"
-8606	frozen blinking skewed cuppa Frost tea	0		Effect: "For Your Brain Only", Effect Duration: 62, Last Available: "2015-09"
+8606	frozen skewed blinking cuppa Frost tea	0		Effect: "For Your Brain Only", Effect Duration: 62, Last Available: "2015-09"
 8607	polymerized irradiated cuppa Toast tea	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 31, Last Available: "2015-09"
 8608	anodized quantum maroon skewed cuppa Net tea	0		Effect: "Metal Speed", Effect Duration: 63, Last Available: "2015-09"
 8609	magnetized oxidized magnetized ghostly blurry cuppa Proprie tea	0		Effect: "Chalky Hand", Effect Duration: 44, Last Available: "2015-09"
@@ -8486,7 +8486,7 @@
 8613	activated flattened tumbling cuppa Feroci tea	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 12, Last Available: "2015-09"
 8614	unsweetened cuppa Physicali tea	0		Effect: "Optimist Primal", Effect Duration: 59, Last Available: "2015-09"
 8615	double-adjusted cuppa Wit tea	0		Effect: "Flambé-a-thon", Effect Duration: 28, Last Available: "2015-09"
-8616	triple-chilled improved teal twirling cuppa Neuroplastici tea	0		Effect: "Scavengers Scavenging", Effect Duration: 31, Last Available: "2015-09"
+8616	triple-chilled improved twirling teal cuppa Neuroplastici tea	0		Effect: "Scavengers Scavenging", Effect Duration: 31, Last Available: "2015-09"
 8617	diffused cuppa Dexteri tea	0		Effect: "Disdain of the War Snapper", Effect Duration: 45, Last Available: "2015-09"
 8618	enhanced deionized anodized twirling cuppa Flexibili tea	0		Effect: "Rushin' Hands", Effect Duration: 31, Last Available: "2015-09"
 8619	energized cuppa Impregnabili tea	0		Effect: "Barbecue Saucy", Effect Duration: 69, Last Available: "2015-09"
@@ -8511,11 +8511,11 @@
 8638	upside-down hale Da Vinci's Royal scepter of the pedagogue	0		Experience: +3, Experience (Mysticality): +5, Maximum HP: +20, Last Available: "2015-09"
 8639	huge doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	miniature special adequate jittery bowl of eyeballs	2	good	Effect: "Spooky Hands", Effect Duration: 20, Last Available: "2015-10"
+8641	special miniature adequate jittery bowl of eyeballs	2	good	Effect: "Spooky Hands", Effect Duration: 20, Last Available: "2015-10"
 8642	rotten bowl of mummy guts	3	crappy	Last Available: "2015-10"
 8643	tasty bowl of maggots	3	awesome	Last Available: "2015-10"
 8644	lousy blood and blood	3	decent	Last Available: "2015-10"
-8645	practically non-alcoholic hand-crafted mirror fuchsia Jack-O-Lantern beer	1	super ultra EPIC	Last Available: "2015-10"
+8645	hand-crafted practically non-alcoholic mirror fuchsia Jack-O-Lantern beer	1	super ultra EPIC	Last Available: "2015-10"
 8646	lousy zombie	3	decent	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8525,15 +8525,15 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	Herculean strapping hawk of the dark arts	0		Muscle: +5, Experience (Muscle): +1, Spell Damage Percent: +100
-8655	spoiled olive spinning narrow hamlet sandwich	4	crappy	
+8655	spoiled spinning narrow olive hamlet sandwich	4	crappy	
 8656	twirling Othello's military jacket of the detective	0		Item Drop: +20
 8657	Othello's dagger of Flo-Jo	0		Initiative: +100, Single Equip
 8658	Newton's Othello's handkerchief	0		Experience (Mysticality): +3, Single Equip
 8659	concentrated bowl of Jeal-O	0		Effect: "Bear Clawed", Effect Duration: 63
-8660	spinning gray grip key	0		
+8660	gray spinning grip key	0		
 8661	How to Play Othello	0		
 8662	tumbling resourceful energetic thinker's ghostly dagger	0		Mysticality: +10, Maximum MP Percent: +20, Maximum MP: +50
-8663	hand-crafted triple-distilled ghost beer	10	EPIC	
+8663	triple-distilled hand-crafted ghost beer	10	EPIC	
 8664	bouncing baleful Othello set	0		Spell Damage: +25
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8546,29 +8546,29 @@
 8673	gray Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	twirling airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	ionized huge jittery shoulder-warming lotion	0		Effect: "Stickler for Promptness", Effect Duration: 54, Last Available: "2015-11"
+8676	ionized jittery huge shoulder-warming lotion	0		Effect: "Stickler for Promptness", Effect Duration: 54, Last Available: "2015-11"
 8677	flavorless upside-down iceberg lettuce	3	decent	Last Available: "2015-11"
 8678	tolerable skewed ice wine	4	good	Last Available: "2015-11"
 8679	Usain Bolt's double-paned Wal-Mart snowglobe of chilblains	0		Cold Damage: +25, Cold Resistance: +5, Initiative: +80, Last Available: "2015-11"
 8680	fuchsia fireproof smelly Jack Frost's Wal-Mart nametag	0		Cold Spell Damage: +50, Stench Spell Damage: +10, Hot Resistance: +3, Last Available: "2015-11"
 8681	up-at-dawn cool Wal-Mart overalls of the sweet-tooth	0		Moxie: +5, Candy Drop: +100, Adventures: +5, Last Available: "2015-11"
-8682	skewed mirror To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
+8682	mirror skewed To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	twirling Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	bouncing perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	upside-down Temple Grandin's bellhop's hat	0		Familiar Weight: +7, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	strong hand-crafted tumbling ice porter	5	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
-8690	wet dry blinking olive exotic travel brochure	0		Effect: "Liquidy Smoky", Effect Duration: 58, Last Available: "2015-11"
+8689	strong hand-crafted tumbling ice porter	5	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8690	wet dry olive blinking exotic travel brochure	0		Effect: "Liquidy Smoky", Effect Duration: 58, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	Vulcanized twirling blue shampoo-conditioner	0		Effect: "Hammertime", Effect Duration: 11, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	denatured medicinal herbs	1		Last Available: "2016-01"
-8697	rotten low-calorie ice rice	1	crappy	Last Available: "2016-01"
-8698	high-proof drinkable fancy iced plum wine	9	good	Effect: "Psalm of Pointiness", Effect Duration: 50, Last Available: "2016-01"
+8697	low-calorie rotten ice rice	1	crappy	Last Available: "2016-01"
+8698	drinkable high-proof fancy iced plum wine	9	good	Effect: "Psalm of Pointiness", Effect Duration: 50, Last Available: "2016-01"
 8699	ruddy stylish training belt of the cougar	0		Moxie: 45, Maximum HP Percent: +40, Single Equip, Last Available: "2016-01"
 8700	lime green Annie Oakley's energetic boxer's training legwarmers	0		Muscle Percent: +10, Maximum MP Percent: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2016-01"
 8701	tumbling smelly crafty training helmet of the boozehound	0		Maximum MP: +10, Stench Spell Damage: +10, Booze Drop: +100, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
@@ -8580,20 +8580,20 @@
 8707	tumbling self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	vaporized ghostly abstraction: action	1		Effect: "Cold as Ice", Effect Duration: 50, Last Available: "2015-12"
 8709	vaporized abstraction: thought	1		Last Available: "2015-12"
-8710	denatured gray blinking abstraction: sensation	1		Last Available: "2015-12"
-8711	modified twirling squat purple ghostly abstraction: purpose	1		Effect: "Improprie Tea", Effect Duration: 50, Last Available: "2015-12"
+8710	denatured blinking gray abstraction: sensation	1		Last Available: "2015-12"
+8711	modified squat ghostly purple twirling abstraction: purpose	1		Effect: "Improprie Tea", Effect Duration: 50, Last Available: "2015-12"
 8712	mixed gray abstraction: category	1		Last Available: "2015-12"
 8713	denatured huge abstraction: perception	1		Effect: "Pasty", Effect Duration: 25, Last Available: "2015-12"
 8714	diluted teal abstraction: motion	1		Last Available: "2015-12"
 8715	twisted fuchsia abstraction: joy	1		Last Available: "2015-12"
-8716	vaporized jittery green abstraction: certainty	1		Last Available: "2015-12"
-8717	boiled green twirling wobbly abstraction: comprehension	1		Effect: "Updated", Effect Duration: 15, Last Available: "2015-12"
+8716	vaporized green jittery abstraction: certainty	1		Last Available: "2015-12"
+8717	boiled green wobbly twirling abstraction: comprehension	1		Effect: "Updated", Effect Duration: 15, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	delicious yellow VYKEA meatballs	3	awesome	Last Available: "2015-11"
-8720	watered-down drinkable huge spinning VYKEA mead	2	good	Last Available: "2015-11"
+8720	watered-down drinkable spinning huge VYKEA mead	2	good	Last Available: "2015-11"
 8721	Vulcanized moist VYKEA woadpaint	0		Effect: "Penguinny Flavor", Effect Duration: 32, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
-8723	huge purple VYKEA blood rune	0		Last Available: "2015-11"
+8723	purple huge VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	upside-down VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
@@ -8601,21 +8601,21 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	blurry upside-down mansplainer's quilted boxer's VYKEA hex key	0		Muscle Percent: +10, Damage Absorption: +40, Monster Level: +15, Last Available: "2015-11"
 8730	blurry VYKEA instructions	0		Last Available: "2015-11"
-8731	stale tin of submardines	3	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	perfectly mixed special bottle of norwhiskey	4	EPIC	Effect: "Reptilian Fortitude", Effect Duration: 40, Last Available: "2015-11"
+8731	stale tin of submardines	3	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8732	special perfectly mixed bottle of norwhiskey	4	EPIC	Effect: "Reptilian Fortitude", Effect Duration: 40, Last Available: "2015-11"
 8733	dried tumbling blurry octolus oculus	1	good	Last Available: "2015-11"
 8734	friendly sardine can key of doom	0		Familiar Weight: +3, Spooky Spell Damage: +50, Item Drop: +5, Last Available: "2015-11"
 8735	ghostly Jeselnik's fortified experienced norwhal helmet	0		Experience: +2, Damage Absorption: +60, Sleaze Damage: +25, Last Available: "2015-11", Familiar Effect: "atk"
 8736	skewed toasty studded octolus-skin cloak of the storm	0		Damage Absorption: +80, Maximum MP Percent: +40, Hot Damage: +5, Last Available: "2015-11"
 8737	triple-distilled lousy perfect cosmopolitan	6	decent	Last Available: "2015-11"
-8738	weak hand-crafted perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
+8738	hand-crafted weak perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
 8739	drinkable olive perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	fancy tolerable practically non-alcoholic perfect mimosa	1	good	Effect: "From Nantucket", Effect Duration: 5, Last Available: "2015-11"
 8741	artisanal perfect old-fashioned	4	EPIC	Last Available: "2015-11"
-8742	special delicious perfect paloma	3	awesome	Effect: "Indescribable Flavor", Effect Duration: 45, Last Available: "2015-11"
+8742	delicious special perfect paloma	3	awesome	Effect: "Indescribable Flavor", Effect Duration: 45, Last Available: "2015-11"
 8743	electrified bouncing That 70s Cologne	0		Effect: "Human-Beast Hybrid", Effect Duration: 25, Last Available: "2015-11"
 8744	cold-filtered Wal-Mart &quot;diamond&quot; ring	0		Effect: "Jacked In", Effect Duration: 18, Last Available: "2015-11"
-8745	dry super-adjusted bouncing cyan Puffstone cigar	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 51, Last Available: "2015-11"
+8745	dry super-adjusted cyan bouncing Puffstone cigar	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 51, Last Available: "2015-11"
 8746	vacuum-sealed oxidized narrow Conspiracy&trade; mascara	0		Effect: "Morninja", Effect Duration: 51, Last Available: "2015-11"
 8747	altered dry Spring Break Beach &quot;swimsuit&quot;	0		Effect: "The Dinsey Way", Effect Duration: 36, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
@@ -8631,7 +8631,7 @@
 8758	narrow Socratic plastic Gaia'ajh-dsli Ak'lwej	0		Experience (Mysticality): +1, Last Available: "2015-12"
 8759	plastic Crimborgatron of horror	0		Spooky Spell Damage: +25, Last Available: "2015-12"
 8760	twirling plastic Crimbodhisattva of the bloodbag	0		Maximum HP: +100, Last Available: "2015-12"
-8761	shaking narrow bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
+8761	narrow shaking bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
 8763	BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
@@ -8688,19 +8688,19 @@
 8816	delicious pulsating Kudzu salad	3	awesome	Last Available: "2016-12"
 8817	powdered lime green Mansquito Serum	1		Last Available: "2016-12"
 8818	mediocre irresponsibly strong Miss Graves' vermouth	9	decent	Last Available: "2016-12"
-8819	fancy jumbo bland gray The Plumber's mushroom stew	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 20, Last Available: "2016-12"
+8819	bland fancy jumbo gray The Plumber's mushroom stew	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 20, Last Available: "2016-12"
 8820	mixed jittery The Author's ink	1		Effect: "Disco Concentration", Effect Duration: 30, Last Available: "2016-02"
-8821	extra-dry drinkable lime green The Mad Liquor	5	good	Last Available: "2016-12"
-8822	artisanal weak Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
-8823	normal miniature Mr. Burnsger	2	good	Last Available: "2016-12"
+8821	drinkable extra-dry lime green The Mad Liquor	5	good	Last Available: "2016-12"
+8822	weak artisanal Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
+8823	miniature normal Mr. Burnsger	2	good	Last Available: "2016-12"
 8824	dehydrated The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	upside-down jittery squat scorching careful The Jokester's gun of the detective	0		Monster Level: -10, Hot Damage: +25, Item Drop: +20, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	auspicious scorching dance instructor's The Jokester's wig	0		Experience Percent (Moxie): +10, Hot Damage: +25, Item Drop: +10, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
-8827	Socratic savvy The Jokester's pants of the scaredy-cat	0		Mysticality Percent: +20, Experience (Mysticality): +1, Monster Level: -15, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	upside-down jittery squat scorching careful The Jokester's gun of the detective	0		Monster Level: -10, Hot Damage: +25, Item Drop: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	auspicious scorching dance instructor's The Jokester's wig	0		Experience Percent (Moxie): +10, Hot Damage: +25, Item Drop: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol"
+8827	Socratic savvy The Jokester's pants of the scaredy-cat	0		Mysticality Percent: +20, Experience (Mysticality): +1, Monster Level: -15, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	liquefied vacuum-sealed Jokester makeup	0		Effect: "Sweetened and Fattened", Effect Duration: 56, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
-8831	squat fuchsia basking robin	0		Free Pull, Last Available: "2016-12"
+8831	fuchsia squat basking robin	0		Free Pull, Last Available: "2016-12"
 8832	blue domino mask	0		Familiar Weight: +5
 8833	warmed dry robin's egg	0		Effect: "Alchemical, Brother", Effect Duration: 19, Last Available: "2016-12"
 8834	normal robin flan	4	good	Last Available: "2016-12"
@@ -8714,12 +8714,12 @@
 8842	modified pulsating infrablack lipstick	0		Effect: "Bear Clawed", Effect Duration: 21
 8843	activated galvanized flattened can of drain cleaner	0		Effect: "Stregngth of the Gnome", Effect Duration: 23
 8844	altered super-activated jittery The Author's inkwell	0		Effect: "Shortened", Effect Duration: 45
-8845	super-diffused colloidal narrow mirror bag of random words	0		Effect: "Frog In Your Throat", Effect Duration: 51
+8845	super-diffused colloidal mirror narrow bag of random words	0		Effect: "Frog In Your Throat", Effect Duration: 51
 8846	polarized tube of pendulum lube	0		Effect: "On the Trolley", Effect Duration: 50
 8847	tarnished polarized red-hot jawbreaker	0		Effect: "Hyphemariffic", Effect Duration: 56
 8848	warmed concentrated blurry question juice	0		Effect: "Quantum of Moxie", Effect Duration: 43
 8849	deionized triple-pickled tube of villain	0		Effect: "Weird Flavor", Effect Duration: 26
-8850	upside-down occult your cowboy boots	0		Spell Damage Percent: +25, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	upside-down occult your cowboy boots	0		Spell Damage Percent: +25, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	squat inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8745,7 +8745,7 @@
 8873	flame-retardant Pork 'n' Pork 'n' Pork 'n' Beans	0		Hot Resistance: +1, Last Available: "2016-02"
 8874	blinking auspicious electrified healthy Newton's Val-U Brand Every Bean Salad of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3, Maximum HP Percent: +20, Item Drop: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-02"
 8875	jittery tumbling inspector's veiny Shrub's Premium Baked Beans of chilblains	0		Maximum HP: +10, Cold Damage: +25, Item Drop: +15, Last Available: "2016-02"
-8876	bland super-sized huge plate of Heimz Fortified Kidney Beans	5	decent	Last Available: "2016-02"
+8876	super-sized bland huge plate of Heimz Fortified Kidney Beans	5	decent	Last Available: "2016-02"
 8877	rotten blurry plate of Tesla's Electroplated Beans	4	crappy	Last Available: "2016-02"
 8878	spoiled pulsating plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
 8879	bland small ghostly plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
@@ -8753,8 +8753,8 @@
 8881	normal ghostly plate of World's Blackest-Eyed Peas	3	good	Last Available: "2016-02"
 8882	stale small plate of Trader Olaf's Exotic Stinkbeans	2	decent	Last Available: "2016-02"
 8883	stale twirling plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Last Available: "2016-02"
-8884	delicious small plate of Val-U Brand Every Bean Salad	2	awesome	Last Available: "2016-02"
-8885	spoiled big pulsating plate of Shrub's Premium Baked Beans	5	crappy	Last Available: "2016-02"
+8884	small delicious plate of Val-U Brand Every Bean Salad	2	awesome	Last Available: "2016-02"
+8885	big spoiled pulsating plate of Shrub's Premium Baked Beans	5	crappy	Last Available: "2016-02"
 8886	razor-sharp Fancy Jeff's pocket square of the cheetah	0		Weapon Damage Percent: +25, Initiative: +60, Last Available: "2016-02"
 8887	baleful Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Spell Damage: +25, Item Drop: +5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8794,7 +8794,7 @@
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	mirror disc (white)	0		
 8924	disc (black)	0		
-8925	ghostly blurry disc (red)	0		
+8925	blurry ghostly disc (red)	0		
 8926	disc (green)	0		
 8927	huge disc (blue)	0		
 8928	disc (yellow)	0		
@@ -8844,10 +8844,10 @@
 8972	improved skin oil	0		Effect: "Sweet and Green", Effect Duration: 45
 8973	aerosolized extra-liquefied ghostly lime green unusual oil	0		Effect: "Wise Spirit", Effect Duration: 44
 8974	deionized unsweetened eldritch oil	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 36
-8975	pulsating purple exclusive club	0		
-8976	vacuum-sealed flattened red mirror bouncing patent preventative tonic	0		Effect: "Liquidy Smoky", Effect Duration: 24
+8975	purple pulsating exclusive club	0		
+8976	vacuum-sealed flattened mirror red bouncing patent preventative tonic	0		Effect: "Liquidy Smoky", Effect Duration: 24
 8977	activated blue pulsating patent invisibility tonic	0		Effect: "Rainbow Bright", Effect Duration: 25
-8978	polymerized nitrogenated bouncing upside-down patent aggression tonic	0		Effect: "Sealed Brain", Effect Duration: 20
+8978	polymerized nitrogenated upside-down bouncing patent aggression tonic	0		Effect: "Sealed Brain", Effect Duration: 20
 8979	corrupted patent sallowness tonic	0		Effect: "License to Punch", Effect Duration: 33
 8980	adjusted aerosolized green patent avarice tonic	0		Effect: "Punch Another Day", Effect Duration: 33
 8981	polarized patent alacrity tonic	0		Effect: "Berry Thorny", Effect Duration: 45
@@ -8862,7 +8862,7 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	denatured armored prawn	1		Last Available: "2016-03"
-8993	normal small jumping horseradish	2	good	Last Available: "2016-03"
+8993	small normal jumping horseradish	2	good	Last Available: "2016-03"
 8994	bad tumbling Sacramento wine	3	decent	Last Available: "2016-03"
 8995	double-warmed blinking Greek fire	0		Effect: "Sinuses For Miles", Effect Duration: 26, Last Available: "2016-03"
 8996	greasy resourceful energetic ox-head shield of horror of the businessman	0		Maximum MP Percent: +20, Maximum MP: +50, Spooky Spell Damage: +25, Sleaze Spell Damage: +10, Meat Drop: +50, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
@@ -8901,11 +8901,11 @@
 9029	no spoon	0		
 9030	flavorless star salad	4	decent	
 9031	Thwaitgold moth statuette	0		
-9032	massive toothsome tumbling bowl of Tastee-Wheet&trade;	6	awesome	
+9032	toothsome massive tumbling bowl of Tastee-Wheet&trade;	6	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	lime green Source essence	0		Last Available: "2016-06"
-9035	immense stale browser cookie	9	decent	Last Available: "2016-06"
-9036	weak enchanted lousy hacked gibson	2	decent	Effect: "Aided and Abetted", Effect Duration: 50, Last Available: "2016-06"
+9035	stale immense browser cookie	9	decent	Last Available: "2016-06"
+9036	enchanted lousy weak hacked gibson	2	decent	Effect: "Aided and Abetted", Effect Duration: 50, Last Available: "2016-06"
 9037	friendly Source shades	0		Familiar Weight: +3, Last Available: "2016-06"
 9038	blurry software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8919,7 +8919,7 @@
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	bouncing green Source terminal SCRAM chip	0		Last Available: "2016-06"
-9050	bouncing wobbly Source terminal TRIGRAM chip	0		Last Available: "2016-06"
+9050	wobbly bouncing Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	twirling Source terminal file: critical.enh	0		Last Available: "2016-06"
@@ -8951,7 +8951,7 @@
 9079	normal big hardboiled egg	5	good	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	Usain Bolt's perfumed knitted Jeselnik's savvy protonic accelerator pack of the cheetah	0		Mysticality Percent: +20, Sleaze Damage: +25, Cold Resistance: +3, Stench Resistance: +5, Initiative: 140, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	Usain Bolt's perfumed knitted Jeselnik's savvy protonic accelerator pack of the cheetah	0		Mysticality Percent: +20, Sleaze Damage: +25, Cold Resistance: +3, Stench Resistance: +5, Initiative: 140, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	lion tamer's Adventurer bobblehead	0		Experience (familiar): +2, Last Available: "2016-11"
 9085	bouncing psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	blurry up-at-dawn sharpshooter's quilted Spookyraven signet	0		Damage Absorption: +40, Critical Hit Percent: +10, Adventures: +5, Single Equip, Last Available: "2016-08"
 9093	squat maroon blinking thinker's tie-dyed fannypack of dire peril	0		Mysticality: +10, Weapon Damage: +20, Single Equip, Last Available: "2016-08"
 9094	upside-down inspector's burnt snowpants of Tarzan	0		Experience (Muscle): +3, Item Drop: +15, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	jittery friendly standards and practices guide	0		Familiar Weight: +3, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9095	jittery friendly standards and practices guide	0		Familiar Weight: +3, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	blinking electrified wicked cool Carpathian longsword	0		Moxie: +5, Spell Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-08"
 9097	squat Sherlock's supercool weightlifter's Liam's mail	0		Muscle: +15, Moxie Percent: +20, Item Drop: +25, Last Available: "2016-08"
 9098	wholesome slick Unfortunato's foolscap of courage	0		Moxie: +10, Maximum HP Percent: +10, Spooky Resistance: +3, Last Available: "2016-08"
@@ -8984,7 +8984,7 @@
 9112	boiled bouncing purple EMD holo-record	0		Effect: "Spooky Jellied", Effect Duration: 66
 9113	polarized maroon Superdrifter holo-record	0		Effect: "Holiday Bliss", Effect Duration: 16
 9114	wet vacuum-sealed concentrated The Pigs holo-record	0		Effect: "Slimed Stomach", Effect Duration: 29
-9115	energized huge pulsating Drunk Uncles holo-record	0		Effect: "Moon'd", Effect Duration: 55
+9115	energized pulsating huge Drunk Uncles holo-record	0		Effect: "Moon'd", Effect Duration: 55
 9116	time residue	0		Last Available: "2016-09"
 9117	repaid diaper of wisdom	0		Mysticality: +15
 9118	bouncing Riker's Search History	0		Last Available: "2016-09"
@@ -8995,7 +8995,7 @@
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	olive droppable microphone	0		
-9126	lousy enchanted unidentified drink	4	decent	Effect: "Snobby", Effect Duration: 45
+9126	enchanted lousy unidentified drink	4	decent	Effect: "Snobby", Effect Duration: 45
 9127	auspicious KoL Con 13 T-shirt of the sewer	0		Stench Damage: +25, Item Drop: +10
 9128	narrow ruddy Socratic discarded swimming trunks of mayonnaise	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Sleaze Spell Damage: +50
 9129	dry diluted makeup	0		Effect: "Oleaginous Soles", Effect Duration: 39
@@ -9007,49 +9007,49 @@
 9135	weak aged mirror very whiskey	2	awesome	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	upside-down li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	narrow li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	mirror shaking li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	bouncing li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	bouncing li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	narrow li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	mirror shaking li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	bouncing li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	bouncing li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	double-ionized hoarded candy wad	0		Effect: "It's Soporiffic!", Effect Duration: 41, Last Available: "2016-10"
 9147	flattened vacuum-sealed Prunets	0		Effect: "Grape Expectations", Effect Duration: 21
 9148	twirling Twitching Television Tattoo	0		
 9149	jittery baby scorpion	0		Familiar Weight: +10
 9150	frozen energized invisible string	0		Lasts Until Rollover, Effect: "Mucilaginous Moxiousness", Effect Duration: 48, Last Available: "2016-10"
 9151	moist invisible seam ripper	0		Lasts Until Rollover, Effect: "Drenched With Filth", Effect Duration: 55, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9153	bland miniature raw sweet potato	2	decent	Last Available: "2016-11"
+9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9153	miniature bland raw sweet potato	2	decent	Last Available: "2016-11"
 9154	rotten small skewed raw beans	2	crappy	Last Available: "2016-11"
 9155	delicious raw stuffing	4	awesome	Last Available: "2016-11"
-9156	normal huge raw cranberry sauce	10	good	Last Available: "2016-11"
+9156	huge normal raw cranberry sauce	10	good	Last Available: "2016-11"
 9157	normal raw turkey	3	good	Last Available: "2016-11"
 9158	small rotten twirling raw mincemeat	2	crappy	Last Available: "2016-11"
-9159	flavorless small olive raw potato	2	decent	Last Available: "2016-11"
+9159	small flavorless olive raw potato	2	decent	Last Available: "2016-11"
 9160	special bland wobbly raw gravy	3	decent	Effect: "Mushroom Moxiousness", Effect Duration: 50, Last Available: "2016-11"
 9161	thick bland raw bread	5	decent	Last Available: "2016-11"
 9162	shaking ghostly clever quilted mini-marshmallow dispenser	0		Damage Absorption: +40, Maximum MP: +20, Last Available: "2016-11"
 9163	fortified Sinatra's glass casserole dish of the sewer	0		Experience (Moxie): +5, Damage Absorption: +60, Stench Damage: +25, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	pulsating auspicious steel-toed can opener	0		Damage Reduction: 9, Item Drop: +10, Last Available: "2016-11"
-9166	mixed squat skewed jittery turkey blaster	1		Last Available: "2016-11"
+9166	mixed skewed squat jittery turkey blaster	1		Last Available: "2016-11"
 9167	pulsating tumbling stylish glass pie plate of Gandalf	0		Moxie: +25, Spell Critical Percent: +20, Damage Reduction: 7, Last Available: "2016-11"
 9168	ghostly toasty therapeutic potato masher	0		Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
-9170	blinking maroon bread mold	0		Last Available: "2016-11"
+9170	maroon blinking bread mold	0		Last Available: "2016-11"
 9171	decent sweet potatoes	3	good	Last Available: "2016-11"
-9172	decent snack-sized huge bean casserole	2	good	Last Available: "2016-11"
-9173	big rotten baked stuffing	5	crappy	Last Available: "2016-11"
+9172	snack-sized decent huge bean casserole	2	good	Last Available: "2016-11"
+9173	rotten big baked stuffing	5	crappy	Last Available: "2016-11"
 9174	bland cranberry cylinder	3	decent	Last Available: "2016-11"
 9175	flavorless thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	bland mince pie	3	decent	Last Available: "2016-11"
 9177	flavorless mashed potatoes	4	decent	Last Available: "2016-11"
-9178	flavorless snack-sized fancy warm gravy	2	decent	Effect: "You Know What's Up", Effect Duration: 40, Last Available: "2016-11"
+9178	flavorless fancy snack-sized warm gravy	2	decent	Effect: "You Know What's Up", Effect Duration: 40, Last Available: "2016-11"
 9179	spoiled bread roll	3	crappy	Last Available: "2016-11"
-9180	yummy gigantic leftovers	7	awesome	Last Available: "2016-11"
+9180	gigantic yummy leftovers	7	awesome	Last Available: "2016-11"
 9181	decent pulsating leftovers sandwich	3	good	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	bouncing cornucopia	0		Last Available: "2016-11"
@@ -9063,19 +9063,19 @@
 9191	non-magnetized quadruple-unsweetened narrow eldritch concentrate	0		Effect: "Black Lung", Effect Duration: 22, Last Available: "2016-11"
 9192	artisanal eldritch extract	4	EPIC	Last Available: "2016-11"
 9193	shaking careful dance instructor's Official Council Aide Pin	0		Experience Percent (Moxie): +10, Monster Level: -10, Last Available: "2016-11"
-9194	smooth triple-distilled huge eldritch distillate	7	awesome	Last Available: "2016-11"
+9194	triple-distilled smooth huge eldritch distillate	7	awesome	Last Available: "2016-11"
 9195	diluted pulsating eldritch essence	1		Last Available: "2016-11"
 9196	twirling curative Science Notebook	0		HP Regen Min: 3, HP Regen Max: 5
 9197	greedy toasty curative eldritch hat	0		Hot Damage: +5, Meat Drop: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
 9198	twirling lard-coated frosty eldritch pants of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +10, Sleaze Spell Damage: +25, Last Available: "2016-11"
-9199	practically non-alcoholic aged jittery eldritch elixir	1	awesome	Last Available: "2016-11"
+9199	aged practically non-alcoholic jittery eldritch elixir	1	awesome	Last Available: "2016-11"
 9200	wobbly studded beefcake's Quartet of Flare Masters Jacket	0		Muscle: +25, Damage Absorption: +80, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	narrow Adventurer's Kit	0		
 9203	blinking Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	skewed counterfeit city	0		Last Available: "2016-12"
 9205	sprinkles	0		Last Available: "2016-12"
-9206	pulsating wobbly The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
+9206	wobbly pulsating The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	blurry ball and chain of the brute	0		Muscle Percent: +30, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	jittery candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9209	shaking chilly gingerbread tophat	0		Cold Damage: +5, Last Available: "2016-12"
@@ -9088,7 +9088,7 @@
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	blurry sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	adequate special shaking animal part cracker	4	good	Effect: "Permafrosty", Effect Duration: 25, Last Available: "2016-12"
+9219	special adequate shaking animal part cracker	4	good	Effect: "Permafrosty", Effect Duration: 25, Last Available: "2016-12"
 9220	tolerable cyan gingerbread wine	3	good	Last Available: "2016-12"
 9221	massive normal gingerbread mug	10	good	Last Available: "2016-12"
 9222	gingerbread mask of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2016-12"
@@ -9108,11 +9108,11 @@
 9236	executive chaotic gingerbread gavel	0		Spell Critical Percent: +10, Meat Drop: +40, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	upside-down gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	high-proof hand-crafted ginger beer	8	EPIC	Last Available: "2016-12"
+9239	hand-crafted high-proof ginger beer	8	EPIC	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	dry bouncing tumbling industrial frosting	0		Effect: "Can't Smell Nothin'", Effect Duration: 44, Last Available: "2016-12"
 9242	colloidal double-liquefied tarnished fake cocktail	0		Effect: "Tingly Biceps", Effect Duration: 17, Last Available: "2016-12"
-9243	special tolerable practically non-alcoholic high-end ginger wine	1	good	Effect: "Make Meat FA$T!", Effect Duration: 35, Last Available: "2016-12"
+9243	practically non-alcoholic tolerable special high-end ginger wine	1	good	Effect: "Make Meat FA$T!", Effect Duration: 35, Last Available: "2016-12"
 9244	reassuring plastic bad vibe	0		Spooky Resistance: +1, Last Available: "2016-12"
 9245	pulsating wool plastic angry vikings	0		Cold Resistance: +1, Last Available: "2016-12"
 9246	plastic Knows About Chakras of dire peril	0		Weapon Damage: +20, Last Available: "2016-12"
@@ -9121,10 +9121,10 @@
 9249	aerosolized non-tarnished Inner Wisdom	0		Effect: "Speed of the Internet", Effect Duration: 20, Last Available: "2016-12"
 9250	denatured chilled flattened jittery Inner Strength	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 11, Last Available: "2016-12"
 9251	cold-filtered Inner Truth	0		Effect: "Less Pervious", Effect Duration: 63, Last Available: "2016-12"
-9252	bland massive spiritual candy cane	9	decent	Last Available: "2016-12"
-9253	special tolerable blinking spiritual eggnog	3	good	Effect: "In Vino Vires", Effect Duration: 25, Last Available: "2016-12"
+9252	massive bland spiritual candy cane	9	decent	Last Available: "2016-12"
+9253	tolerable special blinking spiritual eggnog	3	good	Effect: "In Vino Vires", Effect Duration: 25, Last Available: "2016-12"
 9254	spoiled spiritual fruitcake	3	crappy	Last Available: "2016-12"
-9255	moldy half-sized bouncing spiritual gingerbread	2	crappy	Last Available: "2016-12"
+9255	half-sized moldy bouncing spiritual gingerbread	2	crappy	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	tumbling chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9141,15 +9141,15 @@
 9269	narrow chocolate sculpture	0		Last Available: "2016-12"
 9270	bouncing no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	chakra sludge	0		
-9272	blinking teal negative lump	0		
+9272	teal blinking negative lump	0		
 9273	cyan hardy veiny Third Eye	0		Maximum HP: 60, Last Available: "2016-12"
 9274	prompt boxer's Krampus Horn	0		Muscle Percent: +10, Adventures: +3, Single Equip, Last Available: "2016-12"
-9275	snack-sized normal spinning hambrosier	2	good	Last Available: "2016-12"
-9276	weak acceptable chakra-mental wine	2	good	Last Available: "2016-12"
+9275	normal snack-sized spinning hambrosier	2	good	Last Available: "2016-12"
+9276	acceptable weak chakra-mental wine	2	good	Last Available: "2016-12"
 9277	pickled jittery chakra malt	0		Effect: "Towering Strength", Effect Duration: 62, Last Available: "2016-12"
-9278	rotten thick pulsating Black Angus blackburger	5	crappy	Last Available: "2016-12"
+9278	thick rotten pulsating Black Angus blackburger	5	crappy	Last Available: "2016-12"
 9279	artisanal distilled brandy	5	EPIC	Last Available: "2016-12"
-9280	energized magnetized adjusted tumbling gray potion of spiritual gunkifying	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 20, Last Available: "2016-12"
+9280	energized magnetized adjusted gray tumbling potion of spiritual gunkifying	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 20, Last Available: "2016-12"
 9281	bad vibroknife of incineration of temperance	0		Hot Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2016-12"
 9282	family-friendly smartaleck's crystal belt buckle	0		Moxie Percent: +30, Sleaze Resistance: +1, Last Available: "2016-12"
 9283	gravedigger's Herculean saffron antaravasaka	0		Experience (Muscle): +1, Spooky Damage: +10, Last Available: "2016-12"
@@ -9160,10 +9160,10 @@
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	Usain Bolt's thinker's beefy Uncle Crimbo's hat	0		Muscle: +10, Mysticality: +10, Initiative: +80, Last Available: "2016-12"
 9290	bland tiny fuchsia Eldritch snap	1	decent	Last Available: "2017-01"
-9291	diluted jittery huge hot jelly	1		Last Available: "2017-01"
+9291	diluted huge jittery hot jelly	1		Last Available: "2017-01"
 9292	dried ghostly ghostly jelly	1		Last Available: "2017-01"
 9293	denatured jelly	1		Last Available: "2017-01"
-9294	denatured bouncing yellow sleaze jelly	1		Last Available: "2017-01"
+9294	denatured yellow bouncing sleaze jelly	1		Last Available: "2017-01"
 9295	dried huge stench jelly	1		Effect: "Cautious Prowl", Effect Duration: 25, Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	stale toast with hot jelly	3	decent	Last Available: "2017-01"
@@ -9176,7 +9176,7 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	asbestos-lined savvy wax hand	0		Mysticality Percent: +20, Hot Resistance: +5, Last Available: "2017-01"
 9306	wool horrifying candle	0		Spooky Damage: +25, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2017-01"
-9307	moldy snack-sized wax pancake	2	crappy	Last Available: "2017-01"
+9307	snack-sized moldy wax pancake	2	crappy	Last Available: "2017-01"
 9308	narrow resourceful smartaleck's wax face	0		Moxie Percent: +30, Maximum MP: +50, Last Available: "2017-01"
 9309	drinkable wax booze	3	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
@@ -9185,10 +9185,10 @@
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	teal crushed steamer trunk	0		Last Available: "2017-01"
 9315	ghostly wool recovered cufflinks	0		Cold Resistance: +1, Single Equip, Last Available: "2017-01"
-9316	twirling yellow heart-shaped crate	0		Free Pull, Last Available: "2017-02"
+9316	yellow twirling heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	activated activated LOV Elixir #3	0		Effect: "Eyes All Black", Effect Duration: 47, Last Available: "2017-02"
 9318	Vulcanized irradiated LOV Elixir #6	0		Effect: "This Is Where You're a Viking", Effect Duration: 62, Last Available: "2017-02"
-9319	frozen activated blurry skewed LOV Elixir #9	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 15, Last Available: "2017-02"
+9319	frozen activated skewed blurry LOV Elixir #9	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 15, Last Available: "2017-02"
 9320	nippy shellacked razor-sharp LOV Eardigan	0		Weapon Damage Percent: +25, Damage Reduction: 7, Cold Damage: +10, Lasts Until Rollover, Last Available: "2017-02"
 9321	avaricious frightening nasty LOV Epaulettes	0		Stench Damage: +5, Spooky Damage: +5, Meat Drop: +30, Lasts Until Rollover, Last Available: "2017-02"
 9322	foul-smelling Jack Frost's rock-hard LOV Earrings	0		Damage Reduction: 5, Cold Spell Damage: +50, Stench Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
@@ -9198,7 +9198,7 @@
 9326	dried LOV Echinacea Bouquet	1		Effect: "Cool Spirit", Effect Duration: 10, Last Available: "2017-02"
 9327	skewed LOV Elephant of mayonnaise	0		Sleaze Spell Damage: +50, Damage Reduction: 6, Last Available: "2017-02"
 9328	narrow groovy eldritch scanner	0		Moxie Percent: +10, Last Available: "2017-02"
-9329	moist chilled narrow squat eldritch alignment spray	0		Effect: "Kindly Resolve", Effect Duration: 42, Last Available: "2017-02"
+9329	moist chilled squat narrow eldritch alignment spray	0		Effect: "Kindly Resolve", Effect Duration: 42, Last Available: "2017-02"
 9330	blinking LOV Entrance Pass	0		Last Available: "2017-02"
 9331	spinning medical-grade Rosewater's smooth eldritch hammer	0		Moxie: +15, Mysticality Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-01"
 9332	tasty bouncing olive eldritch mushroom	3	awesome	Last Available: "2017-03"
@@ -9212,7 +9212,7 @@
 9340	tumbling Golden HP-35 Calculator	0		
 9341	jittery Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
-9343	squat twirling bottlecap	0		
+9343	twirling squat bottlecap	0		
 9344	discarded button	0		
 9345	Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
@@ -9234,29 +9234,29 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
-9365	hand-crafted blinking ghostly literal grasshopper	3	EPIC	Last Available: "2017-03"
+9365	hand-crafted ghostly blinking literal grasshopper	3	EPIC	Last Available: "2017-03"
 9366	delicious huge double entendre	4	awesome	Last Available: "2017-03"
 9367	hand-crafted skewed Phlegethon	3	EPIC	Last Available: "2017-03"
 9368	practically non-alcoholic lousy Siberian sunrise	1	decent	Last Available: "2017-03"
 9369	acceptable enchanted mentholated wine	3	good	Effect: "Whippin' It Good", Effect Duration: 50, Last Available: "2017-03"
 9370	delicious cyan low tide martini	4	awesome	Last Available: "2017-03"
 9371	aged weak shroomtini	2	awesome	Last Available: "2017-03"
-9372	special hand-crafted irresponsibly strong morning dew	10	EPIC	Effect: "Venomous Weapon", Effect Duration: 35, Last Available: "2017-03"
+9372	special irresponsibly strong hand-crafted morning dew	10	EPIC	Effect: "Venomous Weapon", Effect Duration: 35, Last Available: "2017-03"
 9373	mediocre whiskey squeeze	3	decent	Last Available: "2017-03"
 9374	artisanal irresponsibly strong great fashioned	8	EPIC	Last Available: "2017-03"
-9375	high-proof drinkable bouncing Gnomish sagngria	9	good	Last Available: "2017-03"
-9376	irresponsibly strong drinkable vodka stinger	10	good	Last Available: "2017-03"
-9377	spirit-forward smooth squat fuchsia extremely slippery nipple	5	awesome	Last Available: "2017-03"
+9375	drinkable high-proof bouncing Gnomish sagngria	9	good	Last Available: "2017-03"
+9376	drinkable irresponsibly strong vodka stinger	10	good	Last Available: "2017-03"
+9377	smooth spirit-forward squat fuchsia extremely slippery nipple	5	awesome	Last Available: "2017-03"
 9378	bad shaking piscatini	4	decent	Last Available: "2017-03"
-9379	practically non-alcoholic tolerable Churchill	1	good	Last Available: "2017-03"
+9379	tolerable practically non-alcoholic Churchill	1	good	Last Available: "2017-03"
 9380	hand-crafted olive soilzerac	3	EPIC	Last Available: "2017-03"
-9381	tolerable huge tumbling London frog	4	good	Last Available: "2017-03"
+9381	tolerable tumbling huge London frog	4	good	Last Available: "2017-03"
 9382	hand-crafted nothingtini	4	EPIC	Last Available: "2017-03"
 9383	delicious eighth plague	4	awesome	Last Available: "2017-03"
-9384	weak bad single entendre	2	decent	Last Available: "2017-03"
+9384	bad weak single entendre	2	decent	Last Available: "2017-03"
 9385	drinkable boozy purple reverse Tantalus	5	good	Last Available: "2017-03"
-9386	high-proof enchanted drinkable elemental caipiroska	10	good	Effect: "Red-Shirted Escort", Effect Duration: 40, Last Available: "2017-03"
-9387	weak fancy acceptable huge Feliz Navidad	2	good	Effect: "Bloodstain-Resistant", Effect Duration: 20, Last Available: "2017-03"
+9386	drinkable high-proof enchanted elemental caipiroska	10	good	Effect: "Red-Shirted Escort", Effect Duration: 40, Last Available: "2017-03"
+9387	acceptable fancy weak huge Feliz Navidad	2	good	Effect: "Bloodstain-Resistant", Effect Duration: 20, Last Available: "2017-03"
 9388	acceptable watered-down twirling Bloody Nora	2	good	Last Available: "2017-03"
 9389	mediocre moreltini	4	decent	Last Available: "2017-03"
 9390	acceptable bouncing hell in a bucket	4	good	Last Available: "2017-03"
@@ -9264,12 +9264,12 @@
 9392	enchanted hand-crafted R'lyeh	4	EPIC	Effect: "Witch's Brood", Effect Duration: 5, Last Available: "2017-03"
 9393	watered-down perfectly mixed Gnollish sangria	2	EPIC	Last Available: "2017-03"
 9394	mediocre vodka barracuda	3	decent	Last Available: "2017-03"
-9395	practically non-alcoholic artisanal Mysterious Island iced tea	1	EPIC	Last Available: "2017-03"
-9396	weak hand-crafted tumbling drive-by shooting	2	EPIC	Last Available: "2017-03"
-9397	smooth high-proof gunner's daughter	7	awesome	Last Available: "2017-03"
-9398	delicious practically non-alcoholic dirt julep	1	awesome	Last Available: "2017-03"
-9399	fancy tolerable watered-down ghostly Simepore slime	2	good	Effect: "Really Deep Breath", Effect Duration: 30, Last Available: "2017-03"
-9400	tolerable irresponsibly strong red Phil Collins	9	good	Last Available: "2017-03"
+9395	artisanal practically non-alcoholic Mysterious Island iced tea	1	EPIC	Last Available: "2017-03"
+9396	hand-crafted weak tumbling drive-by shooting	2	EPIC	Last Available: "2017-03"
+9397	high-proof smooth gunner's daughter	7	awesome	Last Available: "2017-03"
+9398	practically non-alcoholic delicious dirt julep	1	awesome	Last Available: "2017-03"
+9399	tolerable watered-down fancy ghostly Simepore slime	2	good	Effect: "Really Deep Breath", Effect Duration: 30, Last Available: "2017-03"
+9400	irresponsibly strong tolerable red Phil Collins	9	good	Last Available: "2017-03"
 9401	blinking pulsating unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	blinking toggle switch (Bartend)	0		Familiar Weight: +5
 9403	ghostly toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	blurry geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	flavorless thick special edible alien plant bit	5	decent	Effect: "Almost Cool", Effect Duration: 45, Last Available: "2017-04"
+9415	thick flavorless special edible alien plant bit	5	decent	Effect: "Almost Cool", Effect Duration: 45, Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	narrow alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	reassuring studded experienced murderbot mask	0		Experience: +2, Damage Absorption: +80, Spooky Resistance: +1, Avatar: "Murderbot", Last Available: "2017-04"
 9454	alkaline irradiated jittery murderbot spring injector	0		Effect: "Moose Wisdom", Effect Duration: 43, Last Available: "2017-04"
 9455	lightning-fast coward's murderbot whip	0		Monster Level: -20, Initiative: +40, Last Available: "2017-04"
-9456	blurry murderbot plasma rifle of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Initiative: +100, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	blurry murderbot plasma rifle of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Initiative: +100, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	squat murderbot memory chip	0		Last Available: "2017-04"
 9458	twirling squat space pirate treasure map	0		Last Available: "2017-04"
 9459	red Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9343,7 +9343,7 @@
 9471	gray shaking frosty Herculean Spacegate diplomat's insignia of temperance	0		Experience (Muscle): +1, Cold Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2017-04"
 9472	shaking Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	thick adequate ghostly alien sandwich	5	good	Last Available: "2017-04"
+9474	adequate thick ghostly alien sandwich	5	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	electrified Spant eggs	0		Effect: "Chorale of Companionship", Effect Duration: 15
 9477	shaking green Spacegate (open)	0		Lasts Until Rollover
@@ -9351,7 +9351,7 @@
 9479	galvanized Daily Affirmation: Always be Collecting	0		Effect: "Faboooo", Effect Duration: 23, Last Available: "2017-05"
 9480	moist tumbling tumbling Daily Affirmation: Think Win-Lose	0		Effect: "Puddingskin", Effect Duration: 55, Last Available: "2017-05"
 9481	nitrogenated tarnished squat Daily Affirmation: Be Superficially interested	0		Effect: "You Can Taste the Darkness", Effect Duration: 11, Last Available: "2017-05"
-9482	Vulcanized ghostly wobbly Daily Affirmation: Adapt to Change Eventually	0		Effect: "Educated (Kinda)", Effect Duration: 62, Last Available: "2017-05"
+9482	Vulcanized wobbly ghostly Daily Affirmation: Adapt to Change Eventually	0		Effect: "Educated (Kinda)", Effect Duration: 62, Last Available: "2017-05"
 9483	colloidal boiled blurry Daily Affirmation: Be a Mind Master	0		Effect: "Twinklebritches", Effect Duration: 39, Last Available: "2017-05"
 9484	vacuum-sealed narrow Daily Affirmation: Work For Hours a Week	0		Effect: "Human-Elemental Hybrid", Effect Duration: 36, Last Available: "2017-05"
 9485	liquefied spinning Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 32, Last Available: "2017-05"
@@ -9362,8 +9362,8 @@
 9490	modified Threatening Missive	0		Effect: "Deeply Ironic", Effect Duration: 15
 9491	squat Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	veiny wholesome Kremlin's Greatest Briefcase of terror	0		Maximum HP Percent: +10, Maximum HP: +10, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	mediocre watered-down blue basic martini	2	decent	Last Available: "2017-06"
+9493	veiny wholesome Kremlin's Greatest Briefcase of terror	0		Maximum HP Percent: +10, Maximum HP: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9494	watered-down mediocre blue basic martini	2	decent	Last Available: "2017-06"
 9495	perfectly mixed improved martini	4	EPIC	Last Available: "2017-06"
 9496	fancy weak acceptable squat splendid martini	2	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 35, Last Available: "2017-06"
 9497	shaking exploding cigar	0		Last Available: "2017-06"
@@ -9388,7 +9388,7 @@
 9516	bouncing meteoroid	0		Last Available: "2017-08"
 9517	upside-down rosewater-soaked Jack Frost's meteortarboard of Tarzan	0		Experience (Muscle): +3, Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2017-08"
 9518	wobbly Tesla meteorite guard of the wise owl of the businessman	0		Mysticality: +20, Meat Drop: +50, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 9, Last Available: "2017-08"
-9519	blue meteorb of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Last Available: "2017-08", Lantern Element: "Hot"
+9519	blue meteorb of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Lantern Element: "Hot", Last Available: "2017-08"
 9520	ruddy asteroid belt of the empath	0		Maximum HP Percent: +40, Familiar Weight: +5, Single Equip, Last Available: "2017-08"
 9521	reassuring meteorthopedic shoes of extreme caution of the early riser	0		Monster Level: -25, Spooky Resistance: +1, Adventures: +7, Single Equip, Last Available: "2017-08"
 9522	mirror blurry crafty baleful shooting morning star of bravery	0		Spell Damage: +25, Maximum MP: +10, Spooky Resistance: +5, Single Equip, Last Available: "2017-08"
@@ -9418,7 +9418,7 @@
 9546	razor-sharp mafia pinky ring of the empath	0		Weapon Damage Percent: +25, Familiar Weight: +5, Single Equip
 9547	artisanal flask of port	3	EPIC	
 9548	upside-down hardy personal trainer's contract enforcement stick	0		Experience Percent (Muscle): +10, Maximum HP: +50
-9549	moldy bite-sized jittery huge Hide-rox&trade; cookie	1	crappy	Last Available: "2017-10"
+9549	bite-sized moldy jittery huge Hide-rox&trade; cookie	1	crappy	Last Available: "2017-10"
 9550	smooth watered-down spinning jug of booze	2	awesome	Last Available: "2017-10"
 9551	frozen pair of candy glasses	0		Effect: "Hyphemariffic", Effect Duration: 62, Last Available: "2017-10"
 9552	triple-dry polymerized wobbly temporary X tattoos	0		Effect: "Human-Pirate Hybrid", Effect Duration: 25, Last Available: "2017-10"
@@ -9441,7 +9441,7 @@
 9569	purple mansplainer's mafia pointer finger ring of wisdom	0		Mysticality: +15, Monster Level: +15, Single Equip
 9570	tumbling worksite credentials of Flo-Jo	0		Initiative: +100, Single Equip
 9571	wobbly family-friendly Temple Grandin's clever sage negotiatin' hammer	0		Mysticality Percent: +10, Maximum MP: +20, Familiar Weight: +7, Sleaze Resistance: +1
-9572	squat green pantogram	0		Free Pull, Last Available: "2017-11"
+9572	green squat pantogram	0		Free Pull, Last Available: "2017-11"
 9573	pantogram	0		Last Available: "2017-11"
 9574	pantogram pants	0		Lasts Until Rollover, Last Available: "2017-11"
 9575	spinning medical-grade rock-hard mafia wedding ring	0		Damage Reduction: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip
@@ -9453,7 +9453,7 @@
 9581	tolerable neg grog	3	good	Last Available: "2017-12"
 9582	bland half double fruitcake	4	decent	Last Available: "2017-12"
 9583	rotten hushed puppy	4	crappy	Last Available: "2017-12"
-9584	spoiled huge narrow spinning muffled muffuletta	9	crappy	Last Available: "2017-12"
+9584	huge spoiled spinning narrow muffled muffuletta	9	crappy	Last Available: "2017-12"
 9585	flavorless shushed potatoes	3	decent	Last Available: "2017-12"
 9586	plastic mime functionary of Flo-Jo	0		Initiative: +100, Last Available: "2017-12"
 9587	Oprah's plastic mime scientist	0		Maximum MP Percent: +50, Last Available: "2017-12"
@@ -9464,7 +9464,7 @@
 9592	tumbling mumming trunk	0		Last Available: "2017-12"
 9593	tumbling temperance whiskey	1	good	Last Available: "2017-11"
 9594	magnetized vacuum-sealed wishbone	0		Effect: "Liquidy Smoky", Effect Duration: 49, Last Available: "2017-11"
-9595	acceptable extra-dry special blurry Racisto Ruidoso	5	good	Effect: "Purity of Spirit", Effect Duration: 5, Last Available: "2017-11"
+9595	extra-dry special acceptable blurry Racisto Ruidoso	5	good	Effect: "Purity of Spirit", Effect Duration: 5, Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	bland red bran muffin	3	decent	
 9598	half-sized adequate skewed blueberry muffin	2	good	
@@ -9489,7 +9489,7 @@
 9617	purple silent S	0		Last Available: "2017-12"
 9618	bouncing silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
-9620	olive narrow silent V	0		Last Available: "2017-12"
+9620	narrow olive silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
@@ -9523,7 +9523,7 @@
 9651	dry Cheer-Up soda	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 38, Last Available: "2017-12"
 9652	rotten mime army rations	3	crappy	Last Available: "2017-12"
 9653	artisanal mime army wine	4	super ultra EPIC	Last Available: "2017-12"
-9654	modified upside-down red twirling mime army superserum	1		Effect: "Smoky Third Eye", Effect Duration: 35, Last Available: "2017-12"
+9654	modified upside-down twirling red mime army superserum	1		Effect: "Smoky Third Eye", Effect Duration: 35, Last Available: "2017-12"
 9655	unsweetened mime army camouflage kit	0		Effect: "Squatting and Thrusting", Effect Duration: 47, Last Available: "2017-12"
 9656	careful dangerous miming beret	0		Weapon Damage: +10, Monster Level: -10, Last Available: "2017-12"
 9657	miming shirt of Leguizamo of bravery	0		Monster Level: +20, Spooky Resistance: +5, Last Available: "2017-12"
@@ -9549,9 +9549,9 @@
 9677	mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	skewed kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
-9680	blinking upside-down fireproof skip lid	0		Familiar Weight: +5
+9680	upside-down blinking fireproof skip lid	0		Familiar Weight: +5
 9681	gigantic rotten extra-toasted half sandwich	9	crappy	Last Available: "2018-12"
-9682	watered-down drinkable olive mulled hobo wine	2	good	Last Available: "2018-12"
+9682	drinkable watered-down olive mulled hobo wine	2	good	Last Available: "2018-12"
 9683	teal burning newspaper	0		Last Available: "2018-12"
 9684	squat Sherlock's frightening burning paper hat of the detective	0		Spooky Damage: +5, Item Drop: 45, Lasts Until Rollover, Last Available: "2018-12"
 9685	rosewater-soaked Jim Carey's fortified burning cape	0		Damage Absorption: +60, Monster Level: +25, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2018-12"
@@ -9559,13 +9559,13 @@
 9687	auspicious rosy-cheeked personal trainer's burning paper jorts	0		Experience Percent (Muscle): +10, Maximum HP Percent: +30, Item Drop: +10, Lasts Until Rollover, Last Available: "2018-12"
 9688	lard-coated dance instructor's smooth burning paper crane	0		Moxie: +15, Experience Percent (Moxie): +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
 9689	spinning January's Garbage Tote (unopened)	0		Free Pull, Last Available: "2018-01"
-9690	shaking upside-down January's Garbage Tote	0		Last Available: "2018-01"
+9690	upside-down shaking January's Garbage Tote	0		Last Available: "2018-01"
 9691	deceased crimbo tree	0		Last Available: "2018-01"
 9692	clever broken champagne bottle of bravery	0		Maximum MP: +20, Spooky Resistance: +5, Last Available: "2018-01"
 9693	yellow educational tinsel tights of the glutton	0		Experience: +1, Food Drop: +100, Last Available: "2018-01"
 9694	censurious Jeselnik's beefcake's wad of used tape	0		Muscle: +25, Sleaze Damage: +25, Sleaze Resistance: +3, Last Available: "2018-01"
 9695	olive spinning auspicious banded smartaleck's silent nightlight of incineration	0		Moxie Percent: +30, Damage Absorption: +100, Hot Spell Damage: +50, Item Drop: +10
-9696	activated bouncing tumbling sweetened reindeer fat	0		Effect: "Liquid Luck", Effect Duration: 60
+9696	activated tumbling bouncing sweetened reindeer fat	0		Effect: "Liquid Luck", Effect Duration: 60
 9697	aerosolized activated blurry Good 'n' Quiet	0		Effect: "Dirge of Dreadfulness", Effect Duration: 32
 9698	quadruple-alkaline hot button candy	0		Effect: "Mana Tea", Effect Duration: 22
 9699	smelly cool makeshift garbage shirt of the empath	0		Moxie: +5, Familiar Weight: +5, Stench Spell Damage: +10, Last Available: "2018-01"
@@ -9573,7 +9573,7 @@
 9701	dehydrated pills	1		
 9702	diluted tumbling furry pill	1		
 9703	denatured beefy pill	1		
-9704	mixed narrow green excitement pill	1		Effect: "Discomfited", Effect Duration: 20
+9704	mixed green narrow excitement pill	1		Effect: "Discomfited", Effect Duration: 20
 9705	dehydrated vitamin G pill	1		
 9706	dehydrated mirror lucky-ish pill	1		
 9707	diluted dieting pill	1		
@@ -9583,7 +9583,7 @@
 9715	jittery wobbly Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	blurry Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	blinking squat They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
-9718	narrow skewed Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
+9718	skewed narrow Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	dog trainer's genie's turbane of the brazier	0		Experience (familiar): +1, Hot Spell Damage: +25, Last Available: "2018-02"
 9720	executive manspreader's genie's scimitar	0		Monster Level: +10, Meat Drop: +40, Last Available: "2018-02"
 9721	skewed genie's pants of Leguizamo of the sewer	0		Monster Level: +20, Stench Damage: +25, Last Available: "2018-02"
@@ -9661,7 +9661,7 @@
 9793	Wullabye	0		Last Available: "2018-03"
 9794	narrow Nursine	0		Last Available: "2018-03"
 9795	skewed Cantelope	0		Last Available: "2018-03"
-9796	tumbling fuchsia Ungulant	0		Last Available: "2018-03"
+9796	fuchsia tumbling Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	tumbling Oppossum	0		Last Available: "2018-03"
 9799	jittery Amanitee	0		Last Available: "2018-03"
@@ -9729,22 +9729,22 @@
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	flavorless FantasyRealm turkey leg	4	decent	Last Available: "2018-04"
 9863	perfectly mixed bouncing FantasyRealm mead	3	EPIC	Last Available: "2018-04"
-9864	huge bouncing nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
+9864	bouncing huge nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	squat Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	ghostly arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	ghostly hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	twirling grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	super-sized stale druidic s'more	5	decent	Last Available: "2018-04"
+9869	stale super-sized druidic s'more	5	decent	Last Available: "2018-04"
 9870	distilled spinning sachet of powder	1		Effect: "Gr8ness", Effect Duration: 35, Last Available: "2018-04"
 9871	bad mourning wine	3	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
-9875	narrow jittery map to the Putrid Swamp	0		Last Available: "2018-04"
+9875	jittery narrow map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	tumbling shaking map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	stale immense denastified haunch	7	decent	Last Available: "2018-04"
-9879	high-proof acceptable bad rum and good cola	6	good	Last Available: "2018-04"
+9879	acceptable high-proof bad rum and good cola	6	good	Last Available: "2018-04"
 9880	chilled diffused Potion of Heroism	0		Effect: "Bootyliciousness", Effect Duration: 60, Last Available: "2018-04"
 9881	teal frosty Lo Pan's deadly leggings of the Spider Queen	0		Weapon Damage: +5, Spell Critical Percent: +30, Cold Spell Damage: +10, Last Available: "2018-04"
 9882	executive frosty Master Thief's utility belt of the dark arts	0		Spell Damage Percent: +100, Cold Spell Damage: +10, Meat Drop: +40, Single Equip, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	fuchsia notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	weak acceptable two meat muck	2	good	
+9898	acceptable weak two meat muck	2	good	
 9899	bland chocolate Ogre Chieftain	3	decent	
 9900	flavorless chocolate &quot;Phoenix&quot;	3	decent	
 9901	adequate half-sized chocolate Spider Queen	2	good	
 9902	tolerable spirit-forward hipster cocktail	5	good	
-9903	jittery God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	jittery God Lobster's Scepter	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "fairy"
 9908	mirror Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9785,7 +9785,7 @@
 9917	Thwaitgold chigger statuette	0		
 9918	vaporized upside-down gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
-9920	green bouncing SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
+9920	bouncing green SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	purple A Guide to Safari	0		Skill: "Experience Safari"
 9922	cold-filtered moist Shielding Potion	0		Effect: "Liquidy Smoky", Effect Duration: 44, Last Available: "2018-06"
 9923	non-corrupted diffused purple Punching Potion	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 48, Last Available: "2018-06"
@@ -9813,15 +9813,15 @@
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	olive gas can	0		Last Available: "2018-09"
-9948	fancy delicious weak huge Middle of the Road&trade; brand whiskey	2	awesome	Effect: "Bilious Brains", Effect Duration: 5, Last Available: "2018-09"
+9948	weak delicious fancy huge Middle of the Road&trade; brand whiskey	2	awesome	Effect: "Bilious Brains", Effect Duration: 5, Last Available: "2018-09"
 9949	gray neverending wallet chain	0		Last Available: "2018-09"
 9950	greasy pentagram bandana of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +10, Last Available: "2018-09"
 9951	zippy skull ring	0		Initiative: +20, Single Equip, Last Available: "2018-09"
-9952	pulsating green electronics kit	0		Last Available: "2018-09"
+9952	green pulsating electronics kit	0		Last Available: "2018-09"
 9953	decent PB&J with the crusts cut off	3	good	Last Available: "2018-09"
 9954	tumbling coward's Van der Graaf dorky glasses	0		Monster Level: -20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2018-09"
 9955	scorching ponytail clip of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +25, Last Available: "2018-09"
-9956	paint palette of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	paint palette of terror	0		Spooky Spell Damage: +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	ghostly unremarkable duffel bag	0		Last Available: "2018-09"
 9958	twisted mirror Purple Beast energy drink	1		Effect: "Buzzard Breath", Effect Duration: 35, Last Available: "2018-09"
 9959	energetic cosmetic football	0		Maximum MP Percent: +20, Last Available: "2018-09"
@@ -9830,28 +9830,28 @@
 9962	denatured extra-pickled runproof mascara	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 47, Last Available: "2018-09"
 9963	shaking very small dress	0		Last Available: "2018-09"
 9964	miser's crafty noticeable pumps	0		Maximum MP: +10, Meat Drop: +10, Single Equip, Last Available: "2018-09"
-9965	skewed gray surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	weak lousy spinning everfull glass	2		Last Available: "2018-09"
+9965	gray skewed surprisingly capacious handbag	0		Last Available: "2018-09"
+9966	lousy weak spinning everfull glass	2		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
 9968	jam band bootleg	0		Last Available: "2018-09"
 9969	pulsating savvy denim jacket of mayonnaise	0		Mysticality Percent: +20, Sleaze Spell Damage: +50, Last Available: "2018-09"
 9970	spinning Tesla Da Vinci's ratty knitted cap	0		Experience (Mysticality): +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-09"
 9972	avaricious Lo Pan's intimidating chainsaw	0		Spell Critical Percent: +30, Meat Drop: +30, Lasts Until Rollover, Last Available: "2018-09"
 9973	drinkable party beer bomb	4	good	Last Available: "2018-09"
-9974	snack-sized fancy rotten skewed sweet party mix	2	crappy	Effect: "Bootyliciousness", Effect Duration: 10, Last Available: "2018-09"
+9974	fancy rotten snack-sized skewed sweet party mix	2	crappy	Effect: "Bootyliciousness", Effect Duration: 10, Last Available: "2018-09"
 9975	modified wobbly party balloon	1		Last Available: "2018-09"
 9976	maroon mansplainer's rosy-cheeked party pants	0		Maximum HP Percent: +30, Monster Level: +15, Last Available: "2018-09"
 9977	foul-smelling Herculean party whip of the glutton	0		Experience (Muscle): +1, Stench Damage: +10, Food Drop: +100, Last Available: "2018-09"
 9978	maroon Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	acceptable high-proof squat TRIO cup of beer	8	good	Last Available: "2018-09"
+9979	high-proof acceptable squat TRIO cup of beer	8	good	Last Available: "2018-09"
 9980	spoiled party platter for one	3	crappy	Last Available: "2018-09"
 9981	altered blurry Party-in-a-Can&trade;	1		Last Available: "2018-09"
-9982	squat wobbly fuchsia party pup	0		Last Available: "2018-09"
-9983	wobbly party crasher of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9982	squat fuchsia wobbly party pup	0		Last Available: "2018-09"
+9983	wobbly party crasher of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
-9985	huge fuchsia Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
+9985	fuchsia huge Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	pulsating latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	upside-down &quot;I Voted!&quot; sticker of mayonnaise	0		Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-11"
@@ -9875,7 +9875,7 @@
 10009	blinking skewed maroon frightening Annie Oakley's Socratic mutant crown	0		Experience (Mysticality): +1, Critical Hit Percent: +20, Spooky Damage: +5, Last Available: "2018-11"
 10010	half-sized rotten ghostly ectoplasm	2	crappy	Last Available: "2018-11"
 10011	bland	3	decent	Last Available: "2018-11"
-10012	artisanal triple-distilled bottle of vodka	7	EPIC	Last Available: "2018-11"
+10012	triple-distilled artisanal bottle of vodka	7	EPIC	Last Available: "2018-11"
 10013	adequate tiny pizza	1	good	Last Available: "2018-11"
 10014	bad yellow martini	3	decent	Last Available: "2018-11"
 10015	bite-sized bland cherry pie	1	decent	Last Available: "2018-11"
@@ -9886,7 +9886,7 @@
 10020	tolerable twice-haunted screwdriver	3	good	Last Available: "2018-11"
 10021	half-sized moldy candy cane	2	crappy	Last Available: "2018-12"
 10022	smooth runny fermented egg	3	awesome	Last Available: "2018-12"
-10023	massive stale oldcake	6	decent	Last Available: "2018-12"
+10023	stale massive oldcake	6	decent	Last Available: "2018-12"
 10024	spoiled spinning mirror traditional Crimbo cookie	3	crappy	Last Available: "2023-06"
 10025	wobbly yellow plastic wild beaver of the empath	0		Familiar Weight: +5, Last Available: "2018-12"
 10026	plastic reindeer of temperance	0		Sleaze Resistance: +5, Last Available: "2018-12"
@@ -9907,7 +9907,7 @@
 10041	balanced antler of the brute	0		Muscle Percent: +30, Last Available: "2018-12"
 10042	Annie Oakley's dam	0		Critical Hit Percent: +20, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted beavermouth	3	EPIC	Last Available: "2018-12"
-10044	bad enchanted beaver punch (papaya)	3	decent	Effect: "Inappropriate Spirit", Effect Duration: 50, Last Available: "2018-12"
+10044	enchanted bad beaver punch (papaya)	3	decent	Effect: "Inappropriate Spirit", Effect Duration: 50, Last Available: "2018-12"
 10045	smooth beaver punch (peach)	4	awesome	Last Available: "2018-12"
 10046	hand-crafted beaver punch (cherry)	4	EPIC	Last Available: "2018-12"
 10047	flame-retardant Canadian lantern of the cheetah	0		Hot Resistance: +1, Initiative: +60, Last Available: "2018-12"
@@ -9929,18 +9929,18 @@
 10063	gray sausage golem	0		Last Available: "2019-01"
 10064	squat wobbly jar of relish	0		Familiar Weight: +5
 10065	lime green Toyleporter	0		Last Available: "2018-12"
-10066	perfectly mixed irresponsibly strong ghostly narrow skewed beer	10	EPIC	Last Available: "2018-12"
+10066	perfectly mixed irresponsibly strong ghostly skewed narrow beer	10	EPIC	Last Available: "2018-12"
 10067	bland snack-sized yule gruel	2	decent	Last Available: "2018-12"
-10068	practically non-alcoholic acceptable hot watered rum	1	good	Last Available: "2018-12"
-10069	weak artisanal bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
-10070	spoiled enchanted small Crimboysters Rockefeller	2	crappy	Effect: "Mutated", Effect Duration: 50, Last Available: "2018-12"
+10068	acceptable practically non-alcoholic hot watered rum	1	good	Last Available: "2018-12"
+10069	artisanal weak bottle of Crimbognac	2	super ultra mega EPIC	Last Available: "2018-12"
+10070	small spoiled enchanted Crimboysters Rockefeller	2	crappy	Effect: "Mutated", Effect Duration: 50, Last Available: "2018-12"
 10071	modified Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10077	tumbling blue Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
+10077	blue tumbling Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	inspector's rosewater-soaked wizardly Crimbolex watch	0		Mysticality: +25, Stench Resistance: +3, Item Drop: +15, Single Equip, Last Available: "2018-12"
 10080	Crimbo tattoo kit	0		Last Available: "2018-12"
@@ -9961,21 +9961,21 @@
 10095	ghostly vibrating marble mariachi hat of the businessman	0		Maximum MP Percent: +10, Meat Drop: +50, Last Available: "2019-12"
 10096	dehydrated cyan marble molecules	1		Last Available: "2019-12"
 10097	quadruple-magnetized skewed Mallomarbles	0		Effect: "Amorous", Effect Duration: 41
-10098	dog trainer's extremely unsafe punching bag	0		Weapon Damage Percent: +100, Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	jittery mansplainer's wicked pith helmet	0		Spell Damage: +5, Monster Level: +15, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	sizzling fortified poncho	0		Damage Absorption: +60, Hot Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	flame-retardant beefcake's pendant	0		Muscle: +25, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	palazzos of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	red banded arcane researcher's pseudoaccordion	0		Experience Percent (Mysticality): +10, Damage Absorption: +100, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	dog trainer's extremely unsafe punching bag	0		Weapon Damage Percent: +100, Experience (familiar): +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	jittery mansplainer's wicked pith helmet	0		Spell Damage: +5, Monster Level: +15, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	sizzling fortified poncho	0		Damage Absorption: +60, Hot Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	flame-retardant beefcake's pendant	0		Muscle: +25, Hot Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	palazzos of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	red banded arcane researcher's pseudoaccordion	0		Experience Percent (Mysticality): +10, Damage Absorption: +100, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	dried narrow pieces	1		Last Available: "2020-12"
 10105	oxidized Para-Pop	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 36
-10106	Annie Oakley's terra cotta truss of incineration	0		Critical Hit Percent: +20, Hot Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	narrow electrified ruddy terra cotta trousers	0		Maximum HP Percent: +40, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	inspector's grievous terra cotta tongs	0		Weapon Damage Percent: +50, Item Drop: +15, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	blurry ghostly asbestos-lined ribald terra cotta train	0		Sleaze Damage: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	blurry gravedigger's personal trainer's terra cotta tie tack	0		Experience Percent (Muscle): +10, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	green coward's mansplainer's terra cotta tambourine	0		Monster Level: -5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10112	dehydrated squat gray terra cotta tidbits	1		Last Available: "2020-12"
+10106	Annie Oakley's terra cotta truss of incineration	0		Critical Hit Percent: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	narrow electrified ruddy terra cotta trousers	0		Maximum HP Percent: +40, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	inspector's grievous terra cotta tongs	0		Weapon Damage Percent: +50, Item Drop: +15, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	blurry ghostly asbestos-lined ribald terra cotta train	0		Sleaze Damage: +10, Hot Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	blurry gravedigger's personal trainer's terra cotta tie tack	0		Experience Percent (Muscle): +10, Spooky Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	green coward's mansplainer's terra cotta tambourine	0		Monster Level: -5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10112	dehydrated gray squat terra cotta tidbits	1		Last Available: "2020-12"
 10113	tarnished terra panna cotta	0		Effect: "Here's Mud in Your Eye", Effect Duration: 45
 10114	huge jittery velour voulge of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Last Available: "2021-12"
 10115	gravedigger's occult velour vambraces	0		Spell Damage Percent: +25, Spooky Damage: +10, Single Equip, Last Available: "2021-12"
@@ -9993,21 +9993,21 @@
 10127	wobbly stanky groovy glass serape	0		Moxie Percent: +10, Stench Spell Damage: +25, Last Available: "2021-12"
 10128	pickled wobbly glass shards	1		Effect: "Coldfinger", Effect Duration: 10, Last Available: "2021-12"
 10129	enhanced polarized hard candy	0		Effect: "Twen Tea", Effect Duration: 41
-10130	friendly resourceful loofah lumberjack's hat	0		Maximum MP: +50, Familiar Weight: +3, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	double-paned Tesla loofah lei	0		Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	lime green loofah lederhosen of chilblains of the sweet-tooth	0		Cold Damage: +25, Candy Drop: +100, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	maroon lion tamer's crafty loofah ladle	0		Maximum MP: +10, Experience (familiar): +2, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	wool smelly loofah legwarmers	0		Stench Spell Damage: +10, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	electrified loofah lavalier of temperance	0		Sleaze Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	friendly resourceful loofah lumberjack's hat	0		Maximum MP: +50, Familiar Weight: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	double-paned Tesla loofah lei	0		Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	lime green loofah lederhosen of chilblains of the sweet-tooth	0		Cold Damage: +25, Candy Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	maroon lion tamer's crafty loofah ladle	0		Maximum MP: +10, Experience (familiar): +2, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	wool smelly loofah legwarmers	0		Stench Spell Damage: +10, Cold Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	electrified loofah lavalier of temperance	0		Sleaze Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	vaporized spinning loofah lumps	1		Effect: "Coming Up Roses", Effect Duration: 30, Last Available: "2022-12"
 10137	electrified shaking chocolate-covered loofah	0		Effect: "Sourpuss", Effect Duration: 50
-10138	huge lightning-fast flame-retardant flagstone flag	0		Hot Resistance: +1, Initiative: +40, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	tumbling rock-hard flagstone flail of the glutton	0		Damage Reduction: 5, Food Drop: +100, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	teal blinking miser's Fonzie's flagstone flip-flops	0		Experience (Moxie): +1, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	manspreader's Rosewater's flagstone fez	0		Mysticality Percent: +30, Monster Level: +10, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	extremely unsafe flagstone fleece of the blizzard	0		Weapon Damage Percent: +100, Cold Spell Damage: +25, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	wobbly foul-smelling smartaleck's flagstone fringe	0		Moxie Percent: +30, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	twisted cyan bouncing flagstone flagments	1		Last Available: "2022-12"
+10138	huge lightning-fast flame-retardant flagstone flag	0		Hot Resistance: +1, Initiative: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	tumbling rock-hard flagstone flail of the glutton	0		Damage Reduction: 5, Food Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	teal blinking miser's Fonzie's flagstone flip-flops	0		Experience (Moxie): +1, Meat Drop: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	manspreader's Rosewater's flagstone fez	0		Mysticality Percent: +30, Monster Level: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	extremely unsafe flagstone fleece of the blizzard	0		Weapon Damage Percent: +100, Cold Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	wobbly foul-smelling smartaleck's flagstone fringe	0		Moxie Percent: +30, Stench Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10144	twisted bouncing cyan flagstone flagments	1		Last Available: "2022-12"
 10145	super-magnetized chilled Flag by the Foot&trade;	0		Effect: "Unusual Fashion Sense", Effect Duration: 13
 10146	green elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	shaking red-and-green microcamera	0		Familiar Weight: +5
@@ -10029,18 +10029,18 @@
 10163	non-electrified dry government-issued candy	0		Effect: "Greased-Up Familiar", Effect Duration: 20
 10164	unsweetened quantum colloidal Pneumo bar	0		Effect: "Physicali Tea", Effect Duration: 33
 10165	tumbling mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	healthy strapping Lil' Doctor&trade; bag	0		Muscle: +5, Maximum HP Percent: +20, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
-10168	huge skewed blood bag	0		
+10166	healthy strapping Lil' Doctor&trade; bag	0		Muscle: +5, Maximum HP Percent: +20, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10168	skewed huge blood bag	0		
 10169	flavorless fuchsia bloodstick	3	decent	
 10170	lousy bottle of Sanguiovese	4	decent	
-10171	stale immense actual blood sausage	8	decent	
+10171	immense stale actual blood sausage	8	decent	
 10172	artisanal blue mulled blood	4	EPIC	
-10173	massive tasty twirling blood snowcone	7	awesome	
+10173	tasty massive twirling blood snowcone	7	awesome	
 10174	hand-crafted Red Russian	4	EPIC	
 10175	stale blood roll-up	4	decent	
-10176	bad fortified bottle of blood	5	decent	
+10176	fortified bad bottle of blood	5	decent	
 10177	huge adequate blood-soaked sponge cake	7	good	
-10178	acceptable weak vampagne	2	good	
+10178	weak acceptable vampagne	2	good	
 10179	normal plain snowcone	4	good	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
@@ -10076,8 +10076,8 @@
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	stale narrow pineapple slab	3	decent	Last Available: "2019-04"
 10213	normal hibiscus petal	3	good	Last Available: "2019-04"
-10214	quadruple-improved gray blinking narrow huge mint leaf	0		Effect: "Hagnk's Gratitude", Effect Duration: 36, Last Available: "2019-04"
-10215	olive ghostly cocoa of youth	0		Last Available: "2019-04"
+10214	quadruple-improved gray narrow blinking huge mint leaf	0		Effect: "Hagnk's Gratitude", Effect Duration: 36, Last Available: "2019-04"
+10215	ghostly olive cocoa of youth	0		Last Available: "2019-04"
 10216	dehydrated ice molecule	1		Last Available: "2019-04"
 10217	huge Red Roger's reliquary	0		Last Available: "2019-04"
 10218	blinking Red Roger's right hand	0		Last Available: "2019-04"
@@ -10098,13 +10098,13 @@
 10233	drinkable weak bouncing Island Thunderstorm	2	good	Last Available: "2019-04"
 10234	smooth squat Island Hurricane	4	awesome	Last Available: "2019-04"
 10235	lousy tumbling Skull Punch	4	decent	Last Available: "2019-04"
-10236	tolerable high-proof Electric Punch	8	good	Last Available: "2019-04"
+10236	high-proof tolerable Electric Punch	8	good	Last Available: "2019-04"
 10237	enchanted mediocre Smuggler's Punch	3	decent	Effect: "Well-preserved", Effect Duration: 15, Last Available: "2019-04"
-10238	bad special jittery Scorpion Bowl	3	decent	Effect: "Grape Expectations", Effect Duration: 30, Last Available: "2019-04"
+10238	special bad jittery Scorpion Bowl	3	decent	Effect: "Grape Expectations", Effect Duration: 30, Last Available: "2019-04"
 10239	lousy cyan Turtle Bowl	3	decent	Last Available: "2019-04"
 10240	mediocre Cobra Bowl	4	decent	Last Available: "2019-04"
 10241	tumbling vampyric cloake pattern	0		Free Pull
-10242	greasy ruddy arcane researcher's vampyric cloake of the brazier of incineration	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, Hot Spell Damage: 75, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	greasy ruddy arcane researcher's vampyric cloake of the brazier of incineration	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, Hot Spell Damage: 75, Sleaze Spell Damage: +10, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	warmed wet gray one piece of bubble gum	0		Effect: "Optimist Primal", Effect Duration: 41
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	mirror blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	Oprah's slick Fourth of May Cosplay Saber	0		Moxie: +10, Maximum MP Percent: +50, Item Drop: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	Oprah's slick Fourth of May Cosplay Saber	0		Moxie: +10, Maximum MP Percent: +50, Item Drop: +5, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	executive inspector's flame-wreathed hardy studded padded razor-sharp hewn moon-rune spoon of the cougar of horror of the detective of the early riser	0		Moxie: +20, Weapon Damage Percent: +25, Damage Absorption: 100, Maximum HP: +50, Hot Spell Damage: +10, Spooky Spell Damage: +25, Item Drop: 35, Meat Drop: +40, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	executive inspector's flame-wreathed hardy studded padded razor-sharp hewn moon-rune spoon of the cougar of horror of the detective of the early riser	0		Moxie: +20, Weapon Damage Percent: +25, Damage Absorption: 100, Maximum HP: +50, Hot Spell Damage: +10, Spooky Spell Damage: +25, Item Drop: 35, Meat Drop: +40, Adventures: +7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	lime green rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	Jeselnik's Lo Pan's hardy Beach Comb	0		Maximum HP: +50, Spell Critical Percent: +30, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	Jeselnik's Lo Pan's hardy Beach Comb	0		Maximum HP: +50, Spell Critical Percent: +30, Sleaze Damage: +25, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	triple-polarized unsweetened seashell	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 54, Last Available: "2019-07"
 10270	polymerized squat seashell	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 28, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	bad watered-down bottle of sea wine	2	decent	Last Available: "2019-07"
+10272	watered-down bad bottle of sea wine	2	decent	Last Available: "2019-07"
 10273	pickled tumbling wobbly kelp	1		Last Available: "2019-07"
 10274	jittery Sherlock's wool stanky MacGyver's shellacked padded boxer's driftwood hat of the brute of horror	0		Muscle Percent: 40, Damage Absorption: +20, Damage Reduction: 7, Maximum MP: +100, Stench Spell Damage: +25, Spooky Spell Damage: +25, Cold Resistance: +1, Item Drop: +25, Lasts Until Rollover, Last Available: "2019-07"
 10275	up-at-dawn greedy inspector's greasy toasty Tesla wicked Fonzie's driftwood pants of Gandalf	0		Experience (Moxie): +1, Spell Damage: +5, Spell Critical Percent: +20, Hot Damage: +5, Sleaze Spell Damage: +10, Item Drop: +15, Meat Drop: +20, Adventures: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
@@ -10167,7 +10167,7 @@
 10302	twirling double-paned fortified Fonzie's whittled walking stick of Flo-Jo	0		Experience (Moxie): +1, Damage Absorption: +60, Cold Resistance: +5, Initiative: +100, Last Available: "2019-08"
 10303	half-sized normal twirling campfire hot dog	2	good	Last Available: "2019-08"
 10304	yummy campfire baked potato	3	awesome	Last Available: "2019-08"
-10305	toothsome special twirling campfire s'more	3	awesome	Effect: "Turtle Power", Effect Duration: 35, Last Available: "2019-08"
+10305	special toothsome twirling campfire s'more	3	awesome	Effect: "Turtle Power", Effect Duration: 35, Last Available: "2019-08"
 10306	thick yummy campfire beans	5	awesome	Last Available: "2019-08"
 10307	stale campfire stew	3	decent	Last Available: "2019-08"
 10308	fancy campfire coffee	1	good	Effect: "20-20 Second Sight", Effect Duration: 50, Last Available: "2019-08"
@@ -10194,7 +10194,7 @@
 10335	twirling diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	rotten bu&ntilde;uelos Jaliscos	3	crappy	Last Available: "2019-12"
-10338	huge stale blurry flan del mar	9	decent	Last Available: "2019-12"
+10338	stale huge blurry flan del mar	9	decent	Last Available: "2019-12"
 10339	adequate yellow Baja sopapilla	4	good	Last Available: "2019-12"
 10340	censurious plastic Mer-kin baker	0		Sleaze Resistance: +3, Last Available: "2019-12"
 10341	fuchsia plastic sea elf of the brute	0		Muscle Percent: +30, Last Available: "2019-12"
@@ -10214,13 +10214,13 @@
 10355	denatured squat a bug's lymph	1		Effect: "Newt Gets In Your Eyes", Effect Duration: 15, Last Available: "2019-12"
 10356	polymerized frozen organic potpourri	0		Effect: "Celestial Sheen", Effect Duration: 52, Last Available: "2019-12"
 10357	mediocre blinking boot flask	3	decent	Last Available: "2019-12"
-10358	concentrated unsweetened yellow twirling infernal snowball	0		Effect: "Red Misty-Eyed", Effect Duration: 54, Last Available: "2019-12"
+10358	concentrated unsweetened twirling yellow infernal snowball	0		Effect: "Red Misty-Eyed", Effect Duration: 54, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	dehydrated purple ghostly fish sauce	1		Effect: "Full of Wist", Effect Duration: 20, Last Available: "2019-12"
-10361	fancy bland diet guffin	1	decent	Effect: "Nigh-Invincible", Effect Duration: 15, Last Available: "2019-12"
+10361	diet bland fancy guffin	1	decent	Effect: "Nigh-Invincible", Effect Duration: 15, Last Available: "2019-12"
 10362	dehydrated green Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	denatured lime green shaking non-Euclidean angle	1		Effect: "Bark of the Dog", Effect Duration: 35, Last Available: "2019-12"
+10364	denatured shaking lime green non-Euclidean angle	1		Effect: "Bark of the Dog", Effect Duration: 35, Last Available: "2019-12"
 10365	tarnished improved ionized peppermint syrup	0		Effect: "Crotchety, Pining", Effect Duration: 47, Last Available: "2019-12"
 10366	pressed boiled gray Mer-kin eyedrops	0		Effect: "Hardened Fabric", Effect Duration: 61, Last Available: "2019-12"
 10367	galvanized frozen blue extra-strength goo	0		Effect: "Okee-Dokee Go!", Effect Duration: 40, Last Available: "2019-12"
@@ -10234,9 +10234,9 @@
 10375	magnetized double-polarized concentrated fish broth	0		Effect: "Ass Over Teakettle", Effect Duration: 12, Last Available: "2019-12"
 10376	triple-pickled polymerized gray liquid SONAR	0		Effect: "Tiki Toughness", Effect Duration: 14, Last Available: "2019-12"
 10377	blurry map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
-10378	narrow pulsating Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
+10378	pulsating narrow Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	pulsating inspector's beefcake's Dolph Bossin's Crimbo hat of dire peril	0		Muscle: +25, Weapon Damage: +20, Item Drop: +15, Last Available: "2019-12"
-10380	skewed bouncing The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
+10380	bouncing skewed The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	yellow Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	upside-down ghostly soggy gingerbread chunk	0		Last Available: "2019-12"
@@ -10253,14 +10253,14 @@
 10394	smooth Mer-kin rollpin of James Dean	0		Moxie: +15, Experience (Moxie): +3, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	twirling tinsel fin	0		Familiar Weight: +5
-10397	rotten gigantic bowl of mernudo	8	crappy	Last Available: "2019-12"
+10397	gigantic rotten bowl of mernudo	8	crappy	Last Available: "2019-12"
 10398	bad fishelada	4	decent	Last Available: "2019-12"
-10399	bland red twirling ojo de pez burrito	3	decent	Last Available: "2019-12"
+10399	bland twirling red ojo de pez burrito	3	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
-10404	blinking squat jittery teal waterlogged	0		Last Available: "2019-12"
+10404	teal jittery squat blinking waterlogged	0		Last Available: "2019-12"
 10405	narrow auspicious dog trainer's nutcracker hat	0		Experience (familiar): +1, Item Drop: +10, Last Available: "2019-12"
 10406	friendly stiffened nutcracker waistcoat	0		Damage Reduction: 1, Familiar Weight: +3, Last Available: "2019-12"
 10407	upside-down chilly Tesla nutcracker pants	0		Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	gray nutcracker figurine	0		Last Available: "2019-12"
 10415	moldy salt plum	3	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	delicious half-sized mirror and bean	2	awesome	Last Available: "2019-12"
+10417	half-sized delicious mirror and bean	2	awesome	Last Available: "2019-12"
 10418	knitted rock-hard kelp-holly gun of the sewer	0		Damage Reduction: 5, Stench Damage: +25, Cold Resistance: +3, Last Available: "2019-12"
 10419	yellow avaricious Yuleviathan necklace of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +30, Single Equip, Last Available: "2019-12"
 10420	stanky Oprah's peppermint spine	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	chilly Crimbylow-rise jeans of the brazier	0		Cold Damage: +5, Hot Spell Damage: +25, Last Available: "2019-12"
 10423	perfumed resourceful kelp-holly drape	0		Maximum MP: +50, Stench Resistance: +5, Last Available: "2019-12"
 10424	maroon aromatic vibrating hardened extremely unsafe Staff of the Peppermint Twist	0		Weapon Damage Percent: +100, Damage Reduction: 3, Maximum MP Percent: +10, Stench Resistance: +1, Last Available: "2019-12"
-10425	snack-sized rotten upside-down tempura and bean	2	crappy	Last Available: "2019-12"
+10425	rotten snack-sized upside-down tempura and bean	2	crappy	Last Available: "2019-12"
 10426	artisanal salt plum sake	3	EPIC	Last Available: "2019-12"
 10427	moist dry pressurized potion of possessiveness	0		Effect: "Wintry Breath", Effect Duration: 43, Last Available: "2019-12"
 10428	flattened nitrogenated electrified almond	0		Effect: "Thaumodynamic", Effect Duration: 21
 10429	energized anodized deionized handful of mixed nuts	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 22, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	wobbly Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	dangerous smooth Retrospecs of temperance	0		Moxie: +15, Weapon Damage: +10, Sleaze Resistance: +5, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	dangerous smooth Retrospecs of temperance	0		Moxie: +15, Weapon Damage: +10, Sleaze Resistance: +5, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	blurry mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	bouncing fireproof clever padded groovy Powerful Glove of the businessman	0		Moxie Percent: +10, Damage Absorption: +20, Maximum MP: +20, Hot Resistance: +3, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	bouncing fireproof clever padded groovy Powerful Glove of the businessman	0		Moxie Percent: +10, Damage Absorption: +20, Maximum MP: +20, Hot Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	cyan enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	blinking ribald banded brainy Drip harness	0		Mysticality: +5, Damage Absorption: +100, Sleaze Damage: +10
@@ -10334,7 +10334,7 @@
 10477	rubber doll body	0		
 10478	plastic doll arms	0		
 10479	plastic doll legs	0		
-10480	huge maroon rubber baby doll	0		
+10480	maroon huge rubber baby doll	0		
 10481	blinking Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
@@ -10379,7 +10379,7 @@
 10522	mirror drippy bromide	0		
 10523	drippy flux	0		
 10524	blinking drippy stein	0		
-10525	triple-distilled artisanal enchanted spinning drippy pilsner	8	drippy	Effect: "Berry Elemental", Effect Duration: 50
+10525	artisanal enchanted triple-distilled spinning drippy pilsner	8	drippy	Effect: "Berry Elemental", Effect Duration: 50
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	ghostly purple drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10398,7 +10398,7 @@
 10542	acceptable Sourfinger	4	good	Last Available: "2020-05"
 10543	hand-crafted Nog-on-the-Cob	4	EPIC	Last Available: "2020-05"
 10544	artisanal Steamboat	3	EPIC	Last Available: "2020-05"
-10545	triple-distilled enchanted artisanal green Buttery Boy	6	EPIC	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2020-05"
+10545	enchanted triple-distilled artisanal green Buttery Boy	6	EPIC	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2020-05"
 10546	narrow purple Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	narrow Newton's clown car key of chilblains	0		Experience (Mysticality): +3, Cold Damage: +25, Last Available: "2020-08"
 10548	foul-smelling Herculean batting cage key of mayonnaise	0		Experience (Muscle): +1, Stench Damage: +10, Sleaze Spell Damage: +50, Last Available: "2020-08"
@@ -10430,7 +10430,7 @@
 10574	blue Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	altered alkaline salty drippy candy bar	0		Effect: "Shawarma Warm War", Effect Duration: 24
-10577	deionized huge maroon writhing drippy candy bar	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 55
+10577	deionized maroon huge writhing drippy candy bar	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 55
 10578	chilled flattened gooey drippy candy bar	0		Effect: "Drunk With Power", Effect Duration: 58
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	lime green dromedary drinking helmet	0		
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	upside-down flame-retardant stylish birch battery	0		Moxie: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2020-08"
-10585	sage beefcake's weightlifter's ebony epee	0		Muscle: 40, Mysticality Percent: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	censurious curative Newton's weeping willow wand	0		Experience (Mysticality): +3, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	greedy greasy experienced beechwood blowgun	0		Experience: +2, Sleaze Spell Damage: +10, Meat Drop: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	sage beefcake's weightlifter's ebony epee	0		Muscle: 40, Mysticality Percent: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	censurious curative Newton's weeping willow wand	0		Experience (Mysticality): +3, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	greedy greasy experienced beechwood blowgun	0		Experience: +2, Sleaze Spell Damage: +10, Meat Drop: +20, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	censurious wool Samson's maple magnet	0		Experience (Muscle): +5, Cold Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2020-08"
 10589	purple Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	lion tamer's dance instructor's Da Vinci's hemlock helm	0		Experience (Mysticality): +5, Experience Percent (Moxie): +10, Experience (familiar): +2, Last Available: "2020-08"
@@ -10491,12 +10491,12 @@
 10635	cyan bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	upside-down prompt Fonzie's Cargo Cultist Shorts of the bloodbag of extreme caution	0		Experience (Moxie): +1, Maximum HP: +100, Monster Level: -25, Adventures: +3, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	practically non-alcoholic bad flask of moonshine	1	decent	Last Available: "2020-09"
+10638	bad practically non-alcoholic flask of moonshine	1	decent	Last Available: "2020-09"
 10639	purple ribald sea-worn candlestick of the storm of Gandalf	0		Maximum MP Percent: +40, Spell Critical Percent: +20, Sleaze Damage: +10, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	non-polarized spinning null-day exploit	0		Effect: "Turtle Power", Effect Duration: 29, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	snack-sized rotten chocolate chip muffin	2	crappy	
+10643	rotten snack-sized chocolate chip muffin	2	crappy	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10511,7 +10511,7 @@
 10655	ionized super-polarized huge blurry cool hot cocoa	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 59, Last Available: "2020-12"
 10656	denatured overly-fancy hot cocoa	0		Effect: "Buggy Flavor", Effect Duration: 67, Last Available: "2020-12"
 10657	electrified pickled hot cocoa au beurre	0		Effect: "Buff as a Baobab", Effect Duration: 31, Last Available: "2020-12"
-10658	electrified jittery squat cyan hot cocoa with rainbow marshmallows	0		Effect: "Bats in the Belfry", Effect Duration: 42, Last Available: "2020-12"
+10658	electrified cyan squat jittery hot cocoa with rainbow marshmallows	0		Effect: "Bats in the Belfry", Effect Duration: 42, Last Available: "2020-12"
 10659	Book of Old-Timey Carols of Tarzan	0		Experience (Muscle): [+3*event(December)], Last Available: "2020-12"
 10660	Annie Oakley's Crimbo smile	0		Critical Hit Percent: [+20*event(December)], Last Available: "2020-12"
 10661	gravedigger's SalesCo sample kit	0		Spooky Damage: [+10*event(December)], Last Available: "2020-12"
@@ -10569,17 +10569,17 @@
 10713	fuchsia jittery The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	rotten skewed and pepper (stale)	4	crappy	Last Available: "2020-12"
-10716	mediocre special cranberry margarita (brackish)	3	decent	Effect: "Broken Bone Nubs", Effect Duration: 5, Last Available: "2020-12"
+10716	special mediocre cranberry margarita (brackish)	3	decent	Effect: "Broken Bone Nubs", Effect Duration: 5, Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
-10718	jittery narrow nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
+10718	narrow jittery nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	weak perfectly mixed barrel-aged eggnog	2	super ultra EPIC	Last Available: "2020-12"
-10721	bland enchanted hand-crafted candy cane	4	decent	Effect: "Ready to Snap", Effect Duration: 20, Last Available: "2020-12"
+10721	enchanted bland hand-crafted candy cane	4	decent	Effect: "Ready to Snap", Effect Duration: 20, Last Available: "2020-12"
 10722	stale blinking drive-thru burger	3	decent	Last Available: "2020-12"
 10723	watered-down perfectly mixed Boulevardier cocktail	2	EPIC	Last Available: "2020-12"
 10724	electrified narrow Hotwire&trade; brand candy rope	0		Effect: "Human-Goblin Hybrid", Effect Duration: 68, Last Available: "2020-12"
 10725	moldy bowl full of jelly	3	crappy	Last Available: "2020-12"
-10726	watered-down lousy fancy Eye and a Twist	2	decent	Effect: "Sugar, Hello", Effect Duration: 20, Last Available: "2020-12"
+10726	lousy fancy watered-down Eye and a Twist	2	decent	Effect: "Sugar, Hello", Effect Duration: 20, Last Available: "2020-12"
 10727	galvanized quantum maroon Chubby and Plump bar	0		Effect: "Empathy", Effect Duration: 42, Last Available: "2020-12"
 10728	ghostly teal digibritches	0		Last Available: "2025-12"
 10729	skewed packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10602,17 +10602,17 @@
 10746	marshmallow	0		
 10747	mediocre enchanted marshmallow bomb	3	decent	Effect: "Eldritch Concentration", Effect Duration: 50, Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	squat olive plate	0		Familiar Weight: +5
 10752	chilled red short beer	0		Effect: "Castaway Physique", Effect Duration: 35, Last Available: "2021-05"
 10753	quantum energized short stack of pancakes	0		Effect: "Gummiheart", Effect Duration: 64, Last Available: "2021-05"
 10754	ionized liquefied short stick of butter	0		Effect: "Minerva's Zen", Effect Duration: 13, Last Available: "2021-05"
 10755	aerosolized short glass of water	0		Effect: "protect.enq", Effect Duration: 57, Last Available: "2021-05"
-10756	deionized polymerized maroon mirror pulsating short	0		Effect: "Pill Power", Effect Duration: 59, Last Available: "2021-05"
+10756	deionized polymerized mirror pulsating maroon short	0		Effect: "Pill Power", Effect Duration: 59, Last Available: "2021-05"
 10757	narrow Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	pulsating frightening familiar scrapbook of the cougar	0		Moxie: +20, Spooky Damage: +5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	pulsating frightening familiar scrapbook of the cougar	0		Moxie: +20, Spooky Damage: +5, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	cyan packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	upside-down clan underground fireworks shop	0		Last Available: "2021-07"
 10762	skewed miser's curative fedora-mounted fountain of the brazier	0		Hot Spell Damage: +25, Meat Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2021-07"
@@ -10627,11 +10627,11 @@
 10771	sharpshooter's occult rocket boots	0		Spell Damage Percent: +25, Critical Hit Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	blue Van der Graaf razor-sharp sparkler	0		Weapon Damage Percent: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2021-07"
 10773	Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
-10774	improved modified upside-down wobbly maroon Scent of a Human&trade; candle	0		Effect: "Purity of Spirit", Effect Duration: 41, Last Available: "2021-08"
+10774	improved modified wobbly upside-down maroon Scent of a Human&trade; candle	0		Effect: "Purity of Spirit", Effect Duration: 41, Last Available: "2021-08"
 10775	diffused blurry The Beast Within&trade; candle	0		Effect: "Limber as Mortimer", Effect Duration: 27, Last Available: "2021-08"
 10776	unsweetened Salsa Caliente&trade; candle	0		Effect: "Spirit Bubble", Effect Duration: 66, Last Available: "2021-08"
 10777	triple-corrupted narrow Smoldering Clover&trade; candle	0		Effect: "Elemental Saucesphere", Effect Duration: 33, Last Available: "2021-08"
-10778	triple-improved bouncing blue Napalm In The Morning&trade; candle	0		Effect: "Colorful Gratitude", Effect Duration: 11, Last Available: "2021-08"
+10778	triple-improved blue bouncing Napalm In The Morning&trade; candle	0		Effect: "Colorful Gratitude", Effect Duration: 11, Last Available: "2021-08"
 10779	huge inspector's nippy extra-large utility candle	0		Cold Damage: +10, Item Drop: +15, Lasts Until Rollover, Last Available: "2021-08"
 10780	studded slick runed taper candle	0		Moxie: +10, Damage Absorption: +80, Lasts Until Rollover, Last Available: "2021-08"
 10781	narrow dance instructor's Newton's novelty sparkling candle of terror	0		Experience (Mysticality): +3, Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	narrow rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	lard-coated foul-smelling Socratic smartaleck's industrial fire extinguisher of wisdom of the wise owl	0		Mysticality: 35, Moxie Percent: +30, Experience (Mysticality): +1, Stench Damage: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	lard-coated foul-smelling Socratic smartaleck's industrial fire extinguisher of wisdom of the wise owl	0		Mysticality: 35, Moxie Percent: +30, Experience (Mysticality): +1, Stench Damage: +10, Sleaze Spell Damage: +25, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	teal The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,7 +10660,7 @@
 10804	bouncing family-friendly nippy Daylight Shavings Helmet of the cougar	0		Moxie: +20, Cold Damage: +10, Sleaze Resistance: +1, Last Available: "2021-11"
 10805	purple eggwater	1	decent	Last Available: "2021-12"
 10806	delicious bread man	3	awesome	Last Available: "2021-12"
-10807	rotten tumbling narrow plain candy cane	4	crappy	Last Available: "2021-12"
+10807	rotten narrow tumbling plain candy cane	4	crappy	Last Available: "2021-12"
 10808	adequate upside-down flour cookie	3	good	Last Available: "2021-12"
 10809	medical-grade plastic food lab	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2021-12"
 10810	inspector's plastic nog lab	0		Item Drop: +15, Single Equip, Last Available: "2021-12"
@@ -10673,16 +10673,16 @@
 10817	ruddy forbidden thinker's jeans	0		Mysticality: +10, Spell Damage Percent: +50, Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2021-12"
 10818	lard-coated curative ice wrap of the boozehound	0		Sleaze Spell Damage: +25, Booze Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	rotten ghostly tofu pop	3	crappy	Last Available: "2021-12"
-10820	diet adequate blinking bowl of prescription candy	1	good	Last Available: "2021-12"
+10820	adequate diet blinking bowl of prescription candy	1	good	Last Available: "2021-12"
 10821	moldy jumbo twirling fishcake	5	crappy	Last Available: "2021-12"
 10822	normal bone broth	3	good	Last Available: "2021-12"
-10823	bite-sized moldy pulsating star pop	1	crappy	Last Available: "2021-12"
-10824	strong mediocre Doc's Fortifying Wine	5	decent	Last Available: "2021-12"
+10823	moldy bite-sized pulsating star pop	1	crappy	Last Available: "2021-12"
+10824	mediocre strong Doc's Fortifying Wine	5	decent	Last Available: "2021-12"
 10825	perfectly mixed Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
-10826	bad enchanted mirror Doc's Limbering Wine	4	decent	Effect: "Brocolate Brostidigitation", Effect Duration: 20, Last Available: "2021-12"
+10826	enchanted bad mirror Doc's Limbering Wine	4	decent	Effect: "Brocolate Brostidigitation", Effect Duration: 20, Last Available: "2021-12"
 10827	lousy Doc's Medical-Grade Wine	3	decent	Last Available: "2021-12"
 10828	twisted fuchsia Homebodyl&trade;	1		Last Available: "2021-12"
-10829	diluted olive mirror Extrovermectin&trade;	1		Last Available: "2021-12"
+10829	diluted mirror olive Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	denatured Breathitin&trade;	1		Effect: "Icy Demeanor", Effect Duration: 30, Last Available: "2021-12"
 10831	distilled Fleshazole&trade;	1		Effect: "Buttermilk Boogie", Effect Duration: 30, Last Available: "2021-12"
 10832	oxidized tarnished narrow anti-burn cream	0		Effect: "Bloodstain-Resistant", Effect Duration: 34, Last Available: "2021-12"
@@ -10692,12 +10692,12 @@
 10836	improved altered anti-creep cream	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 17, Last Available: "2021-12"
 10837	non-altered spinning blinking anti-pain cream	0		Effect: "Resilient Spirit", Effect Duration: 12, Last Available: "2021-12"
 10838	special fortified perfectly mixed yellow Doc's Special Reserve Wine	5	EPIC	Effect: "Polka of Plenty", Effect Duration: 45, Last Available: "2021-12"
-10839	flavorless fancy big bread pie	5	decent	Effect: "Helvella Health", Effect Duration: 35, Last Available: "2021-12"
+10839	fancy flavorless big bread pie	5	decent	Effect: "Helvella Health", Effect Duration: 35, Last Available: "2021-12"
 10840	delicious weak clear Russian	2	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
-10843	shaking twirling Crimbo ball	0		Last Available: "2021-12"
-10844	teal narrow gooified animal matter	0		Last Available: "2021-12"
+10843	twirling shaking Crimbo ball	0		Last Available: "2021-12"
+10844	narrow teal gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10706,12 +10706,12 @@
 10850	goo magnet	0		Last Available: "2021-12"
 10851	twirling wholesome cozy scarf	0		Maximum HP Percent: +10, Last Available: "2021-12"
 10852	spoiled huge Crimbo cookie	3	crappy	Last Available: "2023-06"
-10853	chilled tumbling spinning upside-down fleshy putty	0		Effect: "Elvish", Effect Duration: 61, Last Available: "2021-12"
+10853	chilled tumbling upside-down spinning fleshy putty	0		Effect: "Elvish", Effect Duration: 61, Last Available: "2021-12"
 10854	frightening third ear	0		Spooky Damage: +5, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
 10857	clever peppermint-scented socks	0		Maximum MP: +20, Last Available: "2021-12"
-10858	upside-down olive the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10858	olive upside-down the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	blinking projectile chemistry set	0		Last Available: "2021-12"
 10860	Tesla depleted Crimbonium football helmet	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2021-12"
 10861	fuchsia synthetic rock	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	perfumed coward's beefcake's can of mixed everything	0		Muscle: +25, Monster Level: -20, Stench Resistance: +5, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	huge bland meatball	9	decent	Last Available: "2021-12"
+10876	bland huge meatball	9	decent	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	squat shaking meatball machine	0		Last Available: "2021-12"
 10879	tumbling blinking refurbished air fryer	0		Last Available: "2021-12"
@@ -10753,7 +10753,7 @@
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	upside-down undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	stanky Temple Grandin's forbidden unbreakable umbrella (broken) of terror	0		Spell Damage Percent: +50, Familiar Weight: +7, Stench Spell Damage: +25, Spooky Spell Damage: +10
-10900	skewed spinning MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
+10900	spinning skewed MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
 10901	MayDay&trade; supply package	0		Last Available: "2022-05"
 10902	corrupted emergency glowstick	0		Effect: "Stone-Faced", Effect Duration: 29, Last Available: "2022-05"
 10903	friendly survival knife	0		Familiar Weight: +3, Lasts Until Rollover, Last Available: "2022-05"
@@ -10777,18 +10777,18 @@
 10921	bad Dad's brandy	3	decent	Last Available: "2022-06"
 10922	upside-down reassuring medical-grade teacher's pen	0		Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2022-06"
 10923	bland fire-roasted lake trout	3	decent	Last Available: "2022-06"
-10924	bite-sized moldy guilty sprout	1	crappy	Last Available: "2022-06"
+10924	moldy bite-sized guilty sprout	1	crappy	Last Available: "2022-06"
 10925	MacGyver's mother's necklace of doom	0		Maximum MP: +100, Spooky Spell Damage: +50, Last Available: "2022-06"
-10926	adjusted shaking mirror yellow trampled ticket stub	0		Effect: "Neutered Nostrils", Effect Duration: 30, Last Available: "2022-06"
+10926	adjusted mirror shaking yellow trampled ticket stub	0		Effect: "Neutered Nostrils", Effect Duration: 30, Last Available: "2022-06"
 10927	vacuum-sealed quadruple-dry savings bond	0		Effect: "Meadulla Oblongota", Effect Duration: 45, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	narrow designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	narrow designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	compressed sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	pulsating dinosaur scale	0		
-10935	blurry shaking pristine dinosaur feather	0		
+10935	shaking blurry pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	bouncing squat pterodactyl rifle of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
@@ -10805,9 +10805,9 @@
 10949	dinosaur of the bloodbag	0		Maximum HP: +100
 10950	pulsating Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	manspreader's savvy Jurassic Parka	0		Mysticality Percent: +20, Monster Level: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	manspreader's savvy Jurassic Parka	0		Mysticality Percent: +20, Monster Level: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
-10954	spinning huge autumn-aton	0		Last Available: "2022-10"
+10954	huge spinning autumn-aton	0		Last Available: "2022-10"
 10955	double-flattened anodized chilled fuchsia autumn leaf	0		Effect: "Radium Radicality", Effect Duration: 38, Last Available: "2022-10"
 10956	mediocre fortified AutumnFest ale	5	decent	Last Available: "2022-10"
 10957	ghostly therapeutic banded autumn sweater-weather sweater of the overflowing toilet	0		Damage Absorption: +100, Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2022-10"
@@ -10832,27 +10832,27 @@
 10976	drinkable Boris's beer	4	good	Last Available: "2022-11"
 10977	rotten honey bun of Boris	3	crappy	Last Available: "2022-11"
 10978	adequate miniature Boris's bread	2	good	Last Available: "2022-11"
-10979	huge Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	tumbling Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	mirror Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	narrow Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	huge Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	tumbling Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	mirror Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	narrow Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	small decent baked veggie ricotta casserole	2	good	Last Available: "2022-11"
 10989	normal plain calzone	3	good	Last Available: "2022-11"
-10990	spoiled huge enchanted roasted vegetable focaccia	10	crappy	Effect: "The Solution", Effect Duration: 45, Last Available: "2022-11"
-10991	rotten jittery narrow Pizza of Legend	3	crappy	Last Available: "2022-11"
+10990	huge enchanted spoiled roasted vegetable focaccia	10	crappy	Effect: "The Solution", Effect Duration: 45, Last Available: "2022-11"
+10991	rotten narrow jittery Pizza of Legend	3	crappy	Last Available: "2022-11"
 10992	decent Calzone of Legend	4	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	pulsating Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	pulsating Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	purple cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	rotten Deep Dish of Legend	3	crappy	Last Available: "2022-11"
 11001	yellow deed to Oliver's Place	0		Free Pull
 11002	upside-down drink chit	0		
@@ -10865,21 +10865,21 @@
 11009	wobbly crafty supercool bullet necklace	0		Moxie Percent: +20, Maximum MP: +10, Single Equip
 11010	bland pulsating swamp haunch	4	decent	
 11011	Sherlock's electrified gator shades	0		Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-11012	huge teal milk cap	0		
+11012	teal huge milk cap	0		
 11013	tolerable Charleston Choo-Choo	4	good	
 11014	aged twirling Velvet Veil	3	awesome	
-11015	tolerable wobbly twirling Marltini	4	good	
+11015	tolerable twirling wobbly Marltini	4	good	
 11016	delicious Strong, Silent Type	4	awesome	
-11017	perfectly mixed triple-distilled Mysterious Stranger	8	EPIC	
-11018	weak drinkable Champagne Shimmy	2	good	
+11017	triple-distilled perfectly mixed Mysterious Stranger	8	EPIC	
+11018	drinkable weak Champagne Shimmy	2	good	
 11019	lime green the Sot's parcel	0		
-11020	lion tamer's baleful ceramic cestus	0		Spell Damage: +25, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	hardy boxer's slick ceramic centurion shield	0		Moxie: +10, Muscle Percent: +10, Maximum HP: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	careful forbidden ceramic celery grater	0		Spell Damage Percent: +50, Monster Level: -10, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	Sherlock's weightlifter's ceramic celsiturometer of the businessman	0		Muscle: +15, Item Drop: +25, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	cyan nippy ceramic cerecloth belt of the dark arts of the businessman	0		Spell Damage Percent: +100, Cold Damage: +10, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	executive Jack Frost's therapeutic ceramic cenobite's robe	0		Cold Spell Damage: +50, Meat Drop: +40, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
-11026	boiled pulsating skewed ceramic scree	1		Effect: "Amorous Avarice", Effect Duration: 15, Last Available: "2023-12"
+11020	lion tamer's baleful ceramic cestus	0		Spell Damage: +25, Experience (familiar): +2, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	hardy boxer's slick ceramic centurion shield	0		Moxie: +10, Muscle Percent: +10, Maximum HP: +50, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	careful forbidden ceramic celery grater	0		Spell Damage Percent: +50, Monster Level: -10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	Sherlock's weightlifter's ceramic celsiturometer of the businessman	0		Muscle: +15, Item Drop: +25, Meat Drop: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	cyan nippy ceramic cerecloth belt of the dark arts of the businessman	0		Spell Damage Percent: +100, Cold Damage: +10, Meat Drop: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	executive Jack Frost's therapeutic ceramic cenobite's robe	0		Cold Spell Damage: +50, Meat Drop: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11026	boiled skewed pulsating ceramic scree	1		Effect: "Amorous Avarice", Effect Duration: 15, Last Available: "2023-12"
 11027	unsweetened squat extra-hard jawbreaker	0		Effect: "Old Time Hydration", Effect Duration: 48
 11028	wholesome chiffon chevrons of the storm	0		Maximum HP Percent: +10, Maximum MP Percent: +40, Item Drop: +5, Single Equip, Last Available: "2023-12"
 11029	knitted Lo Pan's shellacked chiffon chapeau	0		Damage Reduction: 7, Spell Critical Percent: +30, Cold Resistance: +3, Last Available: "2023-12"
@@ -10891,7 +10891,7 @@
 11035	chilled chiffon lemon	0		Effect: "Hangdog", Effect Duration: 65
 11036	stale small chocomotive	2	decent	Last Available: "2022-12"
 11037	bland narrow freightcake	3	decent	Last Available: "2022-12"
-11038	hand-crafted fortified cabooze	5	EPIC	Last Available: "2022-12"
+11038	fortified hand-crafted cabooze	5	EPIC	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	tumbling chilly plastic passenger car	0		Cold Damage: +5, Last Available: "2022-12"
 11041	plastic dining car of James Dean	0		Experience (Moxie): +3, Last Available: "2022-12"
@@ -10903,7 +10903,7 @@
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	huge pile of Trainbot parts	0		
-11050	flattened warmed super-Vulcanized bouncing spinning Trainbot circuitry	0		Effect: "Fishy", Effect Duration: 49
+11050	flattened warmed super-Vulcanized spinning bouncing Trainbot circuitry	0		Effect: "Fishy", Effect Duration: 49
 11051	dry liquefied mirror Trainbot tubing	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 48
 11052	irradiated blurry Trainbot plating	0		Effect: "Crimbo Flavor", Effect Duration: 40
 11053	electrified concentrated skewed Trainbot optics	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 62
@@ -10924,14 +10924,14 @@
 11068	twirling twirling lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	normal honey-drenched ham slice	3	good	
-11071	lousy triple-distilled fancy mostly-empty bottle of cookie wine	9	decent	Effect: "Trufflin'", Effect Duration: 15
+11071	triple-distilled lousy fancy mostly-empty bottle of cookie wine	9	decent	Effect: "Trufflin'", Effect Duration: 15
 11072	stale red Crimbo food scraps	3	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	upside-down automatic wine thief	0		Single Equip
 11075	narrow table-scraper	0		Single Equip
 11076	tumbling Trainbot slag	0		
 11077	olive industrially-crushed ice	0		Last Available: "2022-12"
-11078	spoiled miniature ghostly olive steamed oyster	2	crappy	
+11078	miniature spoiled ghostly olive steamed oyster	2	crappy	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
@@ -10941,7 +10941,7 @@
 11085	snack-sized normal Crimbo dinner	2	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
-11088	olive upside-down The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
+11088	upside-down olive The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	half-height cigar	0		Familiar Weight: +5
 11091	grubby wool	0		
@@ -10970,33 +10970,33 @@
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	activated ionized narrow glob of extra-green chlorophyll	0		Effect: "Flamingly Floral", Effect Duration: 61, Last Available: "2023-02"
-11118	ionized nitrogenated twirling squat mushroom	0		Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2023-02"
+11118	ionized nitrogenated squat twirling mushroom	0		Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2023-02"
 11119	activated nitrogenated five-fingered fern resin	0		Effect: "The Halls of Mysticality", Effect Duration: 25, Last Available: "2023-02"
 11120	rotten super good fruit	3	crappy	Last Available: "2023-02"
 11121	mixed teal energized spores	1		Last Available: "2023-02"
-11122	mirror savvy hot pepper of vim and vigor	0		Mysticality Percent: +20, Maximum HP Percent: +50, Last Available: "2023-02", Lantern Element: "Hot"
+11122	mirror savvy hot pepper of vim and vigor	0		Mysticality Percent: +20, Maximum HP Percent: +50, Lantern Element: "Hot", Last Available: "2023-02"
 11123	modified colloidal narrow out-of-work circus flea	0		Effect: "Patent Avarice", Effect Duration: 61, Last Available: "2023-02"
-11124	blurry yellow extra-grubby grub	0		Last Available: "2023-02"
+11124	yellow blurry extra-grubby grub	0		Last Available: "2023-02"
 11125	cold-filtered gray fire ant pheromones	0		Effect: "Big", Effect Duration: 37, Last Available: "2023-02"
 11126	Vulcanized quantum flapper fly	0		Effect: "Disco Neuropathy", Effect Duration: 69, Last Available: "2023-02"
 11127	smooth teal shot of wasp venom	4	awesome	Last Available: "2023-02"
 11128	nitrogenated alkaline filled mosquito	0		Effect: "Orchid Blood", Effect Duration: 56, Last Available: "2023-02"
-11129	deionized polarized shaking red shim of shame shale	0		Effect: "Muscularrr", Effect Duration: 23, Last Available: "2023-02"
+11129	deionized polarized red shaking shim of shame shale	0		Effect: "Muscularrr", Effect Duration: 23, Last Available: "2023-02"
 11130	irradiated purple pebble of proud pyrite	0		Effect: "Devil Inside", Effect Duration: 29, Last Available: "2023-02"
 11131	pressed ghostly pile of gritty sand	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 16, Last Available: "2023-02"
-11132	mirror wobbly hollow rock	0		Last Available: "2023-02"
+11132	wobbly mirror hollow rock	0		Last Available: "2023-02"
 11133	boiled angry agate	0		Effect: "Dreadful Fear", Effect Duration: 18, Last Available: "2023-02"
 11134	moist diffused wet cyan lump of loyal latite	0		Effect: "You Liver", Effect Duration: 46, Last Available: "2023-02"
-11135	half-sized rotten shadow sausage	2	crappy	Last Available: "2023-03"
+11135	rotten half-sized shadow sausage	2	crappy	Last Available: "2023-03"
 11136	jittery family-friendly clever shadow skin	0		Maximum MP: +20, Sleaze Resistance: +1, Last Available: "2023-03"
 11137	liquefied shadow flame	0		Effect: "Butt-Rock Hair", Effect Duration: 40, Last Available: "2023-03"
 11138	delicious shadow bread	3	awesome	Last Available: "2023-03"
 11139	yellow shadow ice	0		Last Available: "2023-03"
-11140	extra-dry perfectly mixed shadow fluid	5	EPIC	Last Available: "2023-03"
+11140	perfectly mixed extra-dry shadow fluid	5	EPIC	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	huge shadow sinew	0		Last Available: "2023-03"
-11144	perfectly mixed watered-down shadow venom	2	EPIC	Last Available: "2023-03"
+11144	watered-down perfectly mixed shadow venom	2	EPIC	Last Available: "2023-03"
 11145	diluted blue ghostly shadow nectar	1		Last Available: "2023-03"
 11146	wool frosty shadow stick of dire peril	0		Weapon Damage: +20, Cold Spell Damage: +10, Cold Resistance: +1, Last Available: "2023-03"
 11147	cyan mansplainer's slick bat paw	0		Moxie: +10, Monster Level: +15
@@ -11035,10 +11035,10 @@
 11180	gray asbestos-lined careful shadow monocle of chilblains	0		Monster Level: -10, Cold Damage: +25, Hot Resistance: +5, Single Equip
 11181	fuchsia shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	moldy small narrow mirror shadow hot dog	2	crappy	
-11183	fancy mediocre watered-down shadow martini	2	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 50
+11183	mediocre watered-down fancy shadow martini	2	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 50
 11184	compressed shadow pill	1		Effect: "Aided and Abetted", Effect Duration: 15
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	unsweetened pressed adjusted wobbly shadow candy	0		Effect: "Souper Vengeful", Effect Duration: 14
 11189	replica Mr. Accessory	0		
@@ -11049,7 +11049,7 @@
 11194	upside-down dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	replica wax lips	0		Experience: +3
-11197	ghostly olive replica Tome of Snowcone Summoning	0		
+11197	olive ghostly replica Tome of Snowcone Summoning	0		
 11198	mirror dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	blurry prompt reassuring resourceful replica jewel-eyed wizard hat	0		Maximum MP: +50, Spooky Resistance: +1, Adventures: +3, Conditional Skill (Equipped): "Magic Missile"
 11200	inspector's friendly veiny replica bottle-rocket crossbow	0		Maximum HP: +10, Familiar Weight: +3, Item Drop: +15, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	squat sharpshooter's hardy savvy beefcake's Cincho de Mayo	0		Muscle: +25, Mysticality Percent: +20, Maximum HP: +50, Critical Hit Percent: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	squat sharpshooter's hardy savvy beefcake's Cincho de Mayo	0		Muscle: +25, Mysticality Percent: +20, Maximum HP: +50, Critical Hit Percent: +10, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	greasy curative grievous groovy &quot;I survived Y2K&quot; T-Shirt of the ox of the bloodbag	0		Muscle: +20, Moxie Percent: +10, Weapon Damage Percent: +50, Maximum HP: +100, Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	fireproof hale pro skateboard	0		Maximum HP: +20, Hot Resistance: +3, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	fireproof hale pro skateboard	0		Maximum HP: +20, Hot Resistance: +3, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
-11264	purple bouncing Charter: Nellyville	0		Last Available: "2023-06"
+11264	bouncing purple Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	sharpshooter's Flash Liquidizer Ultra Dousing Accessory	0		Critical Hit Percent: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	sharpshooter's Flash Liquidizer Ultra Dousing Accessory	0		Critical Hit Percent: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	wobbly wool ribald Amulet of Perpetual Darkness of vim and vigor of the sewer	0		Maximum HP Percent: +50, Stench Damage: +25, Sleaze Damage: +10, Cold Resistance: +1, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11184,7 +11184,7 @@
 11329	denatured mirror meat	1		
 11330	compressed lime green mirror sparkling orb	1		Effect: "Amorous", Effect Duration: 15
 11331	pickled huge purple hardening cream	1		
-11332	twisted jittery huge pool shark hair oil	1		
+11332	twisted huge jittery pool shark hair oil	1		
 11333	teal book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	ghostly Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11198,7 +11198,7 @@
 11343	censurious rake	0		Sleaze Resistance: +3
 11344	squat autumnic bomb	0		
 11345	forest canopy bed	0		
-11346	shaking tumbling day shortener	0		
+11346	tumbling shaking day shortener	0		
 11347	twirling ghostly extra time	0		
 11348	lion tamer's smartaleck's autumnal aegis	0		Moxie Percent: +30, Experience (familiar): +2, Damage Reduction: 9
 11349	corrupted activated deionized red distilled resin	0		Effect: "Pisces Rising", Effect Duration: 45
@@ -11220,7 +11220,7 @@
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	mirror upside-down Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
-11368	spinning purple Crimbuccaneer breeches	0		Last Available: "2023-12"
+11368	purple spinning Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	automa-bot parts	0		
 11370	security automa-core	0		
 11371	bouncing clerical automa-core	0		
@@ -11231,8 +11231,8 @@
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	rotten pickled bread	3	crappy	Last Available: "2023-12"
-11379	decent snack-sized salted mutton	2	good	Last Available: "2023-12"
-11380	half-sized flavorless fancy corned beet	2	decent	Effect: "Sweet and Red", Effect Duration: 15, Last Available: "2023-12"
+11379	snack-sized decent salted mutton	2	good	Last Available: "2023-12"
+11380	flavorless half-sized fancy corned beet	2	decent	Effect: "Sweet and Red", Effect Duration: 15, Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11252,8 +11252,8 @@
 11397	hale Crimbuccaneer fledges (mint)	0		Maximum HP: +20, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
-11400	ghostly blue huge Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	bad triple-distilled upside-down Crimbuccaneer mologrog cocktail	8	decent	Last Available: "2023-12"
+11400	huge ghostly blue Elf Guard tinsel grenade	0		Last Available: "2023-12"
+11401	triple-distilled bad upside-down Crimbuccaneer mologrog cocktail	8	decent	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	friendly vibrating hardened Crimbuccaneer lantern	0		Damage Reduction: 3, Maximum MP Percent: +10, Familiar Weight: +3, Last Available: "2023-12"
@@ -11282,7 +11282,7 @@
 11427	toothsome maroon sundae ration	3	awesome	Last Available: "2023-12"
 11428	normal tumbling peppermint tack	3	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	spoiled small whalesteak	2	crappy	Last Available: "2023-12"
+11430	small spoiled whalesteak	2	crappy	Last Available: "2023-12"
 11431	tumbling lightning-fast deadly wizardly whalegun	0		Mysticality: +25, Weapon Damage: +5, Initiative: +40, Last Available: "2023-12"
 11432	shaking Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11307,19 +11307,19 @@
 11452	teal squat executive flame-retardant quilted Rosewater's cool Elf dessert spoon of the wise owl	0		Mysticality: +20, Moxie: +5, Mysticality Percent: +30, Damage Absorption: +40, Hot Resistance: +1, Meat Drop: +40, Last Available: "2023-12"
 11453	mirror Elf Guard SCUBA tank of incineration of bravery	0		Hot Spell Damage: +50, Spooky Resistance: +5, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	squat wool free boots of the empath	0		Familiar Weight: +5, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	squat wool free boots of the empath	0		Familiar Weight: +5, Cold Resistance: +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	jittery baby rigging snake	0		Last Available: "2023-12"
 11457	mirror gray nasty Temple Grandin's healthy Elvish underarmor	0		Maximum HP Percent: +20, Familiar Weight: +7, Stench Damage: +5, Single Equip, Last Available: "2023-12"
 11458	tumbling foul-smelling friendly Crimbuccaneer bombjacket	0		Familiar Weight: +3, Stench Damage: +10, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	yummy big sugarplum ration	5	awesome	Last Available: "2023-12"
-11460	half-sized toothsome gingerbread nylons	2	awesome	Last Available: "2023-12"
-11461	adequate small yellow rum-soaked fruitcake	2	good	Last Available: "2023-12"
+11459	big yummy sugarplum ration	5	awesome	Last Available: "2023-12"
+11460	toothsome half-sized gingerbread nylons	2	awesome	Last Available: "2023-12"
+11461	small adequate yellow rum-soaked fruitcake	2	good	Last Available: "2023-12"
 11462	adequate snack-sized lime	2	good	Last Available: "2023-12"
 11463	rotten gingerbread pirate	4	crappy	Last Available: "2023-12"
-11464	moldy diet fruit-stuffed rumcake	1	crappy	Last Available: "2023-12"
+11464	diet moldy fruit-stuffed rumcake	1	crappy	Last Available: "2023-12"
 11465	hand-crafted mulled wine	3	EPIC	Last Available: "2023-12"
 11466	artisanal spinning Swedish coffee	3	EPIC	Last Available: "2023-12"
-11467	irresponsibly strong mediocre spinning tumbling canteen of eggnog	7	decent	Last Available: "2023-12"
+11467	mediocre irresponsibly strong tumbling spinning canteen of eggnog	7	decent	Last Available: "2023-12"
 11468	acceptable weak hot wine	2	good	Last Available: "2023-12"
 11469	weak artisanal spinning Jamaican coffee	2	EPIC	Last Available: "2023-12"
 11470	tolerable flask of egggrog	3	good	Last Available: "2023-12"
@@ -11329,11 +11329,11 @@
 11474	smooth yule grog	4	awesome	Last Available: "2023-12"
 11475	tasty yellow wet tack	4	awesome	Last Available: "2023-12"
 11476	tasty huge narrow whalecake	10	awesome	Last Available: "2023-12"
-11477	inspector's Rosewater's slick gunwale whalegun	0		Moxie: +10, Mysticality Percent: +30, Item Drop: +15, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
-11478	spirit-forward bad and claret	5	decent	Last Available: "2023-12"
+11477	inspector's Rosewater's slick gunwale whalegun	0		Moxie: +10, Mysticality Percent: +30, Item Drop: +15, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11478	bad spirit-forward and claret	5	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	bouncing trick coin	0		Last Available: "2023-12"
-11481	prompt supercool Elf Guard squirtgun	0		Moxie Percent: +20, Adventures: +3, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	prompt supercool Elf Guard squirtgun	0		Moxie Percent: +20, Adventures: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	skewed chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	greedy sequin-encrusted sweater	0		Meat Drop: +20, Last Available: "2023-12"
 11484	brainy replica Elf Guard medal of the empath of chilblains	0		Mysticality: +5, Familiar Weight: +5, Cold Damage: +25, Last Available: "2023-12"
@@ -11352,15 +11352,15 @@
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	squat jittery Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	pulsating Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
-11500	shaking wobbly The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
+11500	wobbly shaking The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	mirror Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	denatured huge military candy cane	0		Effect: "Salty Dogs", Effect Duration: 65
 11503	wet ionized oxidized huge groggipop	0		Effect: "Some Cheese with Your Wine", Effect Duration: 13
-11504	Jim Carey's supercharged moss mace	0		Maximum MP Percent: +30, Monster Level: +25, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	inspector's Jim Carey's moss megaphone	0		Monster Level: +25, Item Drop: +15, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	banded moss medal of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	Sherlock's sinister moss mitre	0		Spell Damage: +10, Item Drop: +25, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	dangerous brainy moss mantle	0		Mysticality: +5, Weapon Damage: +10, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	Jim Carey's supercharged moss mace	0		Maximum MP Percent: +30, Monster Level: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	inspector's Jim Carey's moss megaphone	0		Monster Level: +25, Item Drop: +15, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	banded moss medal of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	Sherlock's sinister moss mitre	0		Spell Damage: +10, Item Drop: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	dangerous brainy moss mantle	0		Mysticality: +5, Weapon Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	wool moss marlinspike of the boozehound	0		Cold Resistance: +1, Booze Drop: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	modified moss mulch	1		Last Available: "2024-12"
 11511	warmed gray moss floss	0		Effect: "Mutated", Effect Duration: 22
@@ -11372,33 +11372,33 @@
 11517	purple adobe abaya	0		Last Available: "2024-12"
 11518	modified blurry upside-down adobe assortment	1		Effect: "Bilious Brains", Effect Duration: 25, Last Available: "2024-12"
 11519	irradiated aerosolized shaking upside-down adobe brittle	0		Effect: "Innately Wise", Effect Duration: 41
-11520	baleful Fonzie's sage crepe paper phrygian cap	0		Mysticality Percent: +10, Experience (Moxie): +1, Spell Damage: +25, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	baleful Fonzie's sage crepe paper phrygian cap	0		Mysticality Percent: +10, Experience (Moxie): +1, Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	purple Temple Grandin's crepe paper parachute cape of James Dean of the empath	0		Experience (Moxie): +3, Familiar Weight: 12, Last Available: "2025-12"
-11522	blurry lion tamer's thinker's crepe paper pie clip of the blizzard	0		Mysticality: +10, Experience (familiar): +2, Cold Spell Damage: +25, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	flame-retardant grievous crepe paper puzzle cube of horror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +25, Hot Resistance: +1, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	lion tamer's shellacked crepe paper plunge camisole of the overflowing toilet	0		Damage Reduction: 7, Experience (familiar): +2, Stench Spell Damage: +50, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	frosty nippy crepe paper polka charm of extreme caution	0		Monster Level: -25, Cold Damage: +10, Cold Spell Damage: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	blurry lion tamer's thinker's crepe paper pie clip of the blizzard	0		Mysticality: +10, Experience (familiar): +2, Cold Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	flame-retardant grievous crepe paper puzzle cube of horror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +25, Hot Resistance: +1, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	lion tamer's shellacked crepe paper plunge camisole of the overflowing toilet	0		Damage Reduction: 7, Experience (familiar): +2, Stench Spell Damage: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	frosty nippy crepe paper polka charm of extreme caution	0		Monster Level: -25, Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	mixed crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	alkaline colloidal crepe paper peanut candy	0		Effect: "Mucilaginous Muscle", Effect Duration: 33
 11528	blinking perfumed cool petrified wood war pike	0		Moxie: +5, Stench Resistance: +5, Last Available: "2025-12"
 11529	tumbling weightlifter's petrified wood waist protector of the empath	0		Muscle: +15, Familiar Weight: +5, Single Equip, Last Available: "2025-12"
-11530	inspector's petrified wood wizard's pouch of the ox	0		Muscle: +20, Item Drop: +15, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	wool arcane researcher's petrified wood water purifier	0		Experience Percent (Mysticality): +10, Cold Resistance: +1, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	inspector's petrified wood wizard's pouch of the ox	0		Muscle: +20, Item Drop: +15, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	wool arcane researcher's petrified wood water purifier	0		Experience Percent (Mysticality): +10, Cold Resistance: +1, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	purple family-friendly brawny petrified wood whoopie panama	0		Muscle Percent: +20, Sleaze Resistance: +1, Last Available: "2025-12"
 11533	supercool petrified wood walking pants of the boozehound	0		Moxie Percent: +20, Booze Drop: +100, Last Available: "2025-12"
 11534	pickled petrified wood waste parts	1		Last Available: "2025-12"
 11535	chilled shaking petrified wood wafer praline	0		Effect: "A Taste of Rainbow", Effect Duration: 19
 11536	lousy practically non-alcoholic tumbling cybeer	1	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	cyan blinking encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	blinking cyan encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	narrow olive baby chest mimic	0		Free Pull
 11541	spinning googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	spinning chilly dangerous Crimbuccaneer war standard	0		Weapon Damage: +10, Cold Damage: +5, Last Available: "2023-12"
 11544	green resourceful supercharged Elf Guard war standard	0		Maximum MP Percent: +30, Maximum MP: +50, Last Available: "2023-12"
-11545	wobbly skewed in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	Da Vinci's smartaleck's spring shoes of the scaredy-cat	0		Moxie Percent: +30, Experience (Mysticality): +5, Monster Level: -15, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11545	skewed wobbly in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
+11546	Da Vinci's smartaleck's spring shoes of the scaredy-cat	0		Moxie Percent: +30, Experience (Mysticality): +5, Monster Level: -15, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	colloidal blurry ultra-soft ferns	0		Effect: "Bear Clawed", Effect Duration: 17, Last Available: "2024-02"
 11548	alkaline crunchy brush	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 35, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11425,9 +11425,9 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	small spoiled enchanted yam	2	crappy	Effect: "Pride of the Vampire", Effect Duration: 20, Last Available: "2024-05"
+11573	spoiled small enchanted yam	2	crappy	Effect: "Pride of the Vampire", Effect Duration: 20, Last Available: "2024-05"
 11574	artisanal watered-down yam martini	2	EPIC	Last Available: "2024-05"
-11575	practically non-alcoholic perfectly mixed sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
+11575	perfectly mixed practically non-alcoholic sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
 11576	delicious mirror Southern yam	4	awesome	Last Available: "2024-05"
 11577	extra-dry perfectly mixed sweet potato punch	5	EPIC	Last Available: "2024-05"
 11578	stale Mayam spinach	3	decent	Last Available: "2024-05"
@@ -11440,12 +11440,12 @@
 11585	blue thanksgiving bomb	0		Last Available: "2024-05"
 11586	olive Temple Grandin's steel-toed smooth yamtility belt	0		Moxie: +15, Damage Reduction: 9, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2024-05"
 11587	toothsome yam slider	4	awesome	Last Available: "2024-05"
-11588	rotten half-sized pulsating yam mayo	2	crappy	Last Available: "2024-05"
+11588	half-sized rotten pulsating yam mayo	2	crappy	Last Available: "2024-05"
 11589	flavorless yam burrito	3	decent	Last Available: "2024-05"
 11590	huge visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	blurry aviator goggles	0		
-11593	ghostly blurry lime green Thwaitgold Illinigina illinoiensis model	0		
+11593	lime green blurry ghostly Thwaitgold Illinigina illinoiensis model	0		
 11594	diet adequate red mini kiwi	1	good	Last Available: "2024-06"
 11595	ghostly lightning-fast Tesla electrified mini kiwi bikini	0		Initiative: +40, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2024-06"
 11596	fortified drinkable mini kiwitini	5	good	Last Available: "2024-06"
@@ -11453,15 +11453,15 @@
 11598	mini kiwi aioli	0		
 11599	fireproof stanky coward's mini kiwi silicon tiepin	0		Monster Level: -20, Stench Spell Damage: +25, Hot Resistance: +3
 11600	mini kiwi tipi	0		
-11601	bite-sized spoiled mini kiwi digitized cookies	1	crappy	
-11602	perfectly mixed huge bouncing mini kiwi intoxicating spirits	4	EPIC	
+11601	spoiled bite-sized mini kiwi digitized cookies	1	crappy	
+11602	perfectly mixed bouncing huge mini kiwi intoxicating spirits	4	EPIC	
 11603	frozen non-adjusted mini kiwi antimilitaristic hippy petition	0		Effect: "Mushroom Moxiousness", Effect Duration: 67
 11604	quadruple-magnetized quantum double-frozen mini kiwi illicit antibiotic	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 48
 11605	perfumed brainy mini kiwi whipping stick	0		Mysticality: +5, Stench Resistance: +5
 11606	supercharged mini kiwi icepick	0		Maximum MP Percent: +30
 11607	unsweetened huge mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Cold Hard Skin", Effect Duration: 16
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	huge protogenetic chunklet (flagellum)	0		
@@ -11470,14 +11470,14 @@
 11615	Oprah's supercharged therapeutic messenger bag RNA	0		Maximum MP Percent: 80, HP Regen Min: 5, HP Regen Max: 7
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	moldy super-sized bacteria bisque	5	crappy	
-11619	stale bite-sized ciliophora chowder	1	decent	
+11618	super-sized moldy bacteria bisque	5	crappy	
+11619	bite-sized stale ciliophora chowder	1	decent	
 11620	moldy blurry cream of chloroplasts	3	crappy	
 11621	synaptic soup	0		
 11622	spinning muscular soup	0		
-11623	green upside-down tumbling flagellate soup	0		
+11623	upside-down tumbling green flagellate soup	0		
 11624	blinking elbow soup	0		
-11625	squat purple lip soup	0		
+11625	purple squat lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	squat extra ooze	0		
 11628	extra DNA	0		Experience (familiar): +1
@@ -11510,9 +11510,9 @@
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	lightning-fast resourceful razor-sharp bat wings	0		Weapon Damage Percent: +25, Maximum MP: +50, Initiative: +40, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	lightning-fast resourceful razor-sharp bat wings	0		Weapon Damage Percent: +25, Maximum MP: +50, Initiative: +40, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	teal ember egg	0		Last Available: "2024-09"
-11660	yellow bouncing ember	0		Cold Resistance: +1
+11660	bouncing yellow ember	0		Cold Resistance: +1
 11661	flame-wreathed sizzling monocle on a stick	0		Hot Damage: +10, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
 11662	Temple Grandin's plastic pipe of doom	0		Familiar Weight: +7, Spooky Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11663	veiny dangerous fake arrow-through-the-head	0		Weapon Damage: +10, Maximum HP: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,11 +11523,11 @@
 11668	Jeselnik's Sheriff badge of terror	0		Spooky Spell Damage: +10, Sleaze Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	huge grievous Sheriff pistol of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +50, Lasts Until Rollover, Last Available: "2024-10"
 11670	pulsating extremely unsafe Sheriff moustache of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	censurious vibrating photo booth supply list	0		Maximum MP Percent: +10, Sleaze Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	censurious vibrating photo booth supply list	0		Maximum MP Percent: +10, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	rotten snack-sized whirled peas	2	crappy	Last Available: "2024-11"
-11675	tiny delicious peaza	1	awesome	Last Available: "2024-11"
+11674	snack-sized rotten whirled peas	2	crappy	Last Available: "2024-11"
+11675	delicious tiny peaza	1	awesome	Last Available: "2024-11"
 11676	cyan peace shooter	0		Last Available: "2024-11"
 11677	dried red drenchrome 2.0	1		Last Available: "2025-12"
 11678	mixed Synapse Blaster	1		Effect: "Souper Vengeful", Effect Duration: 10, Last Available: "2025-12"
@@ -11535,25 +11535,25 @@
 11680	green quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	super-denatured ionized pea brittle	0		Effect: "Improved Candy Vision", Effect Duration: 16, Last Available: "2024-11"
-11683	practically non-alcoholic perfectly mixed peasco	1	super ultra mega turbo EPIC	Last Available: "2024-11"
+11683	perfectly mixed practically non-alcoholic peasco	1	super ultra mega turbo EPIC	Last Available: "2024-11"
 11684	normal piece of cake	3	good	Last Available: "2024-11"
 11685	mirror handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	fortified deft pirate hook of James Dean	0		Experience (Moxie): +3, Damage Absorption: +60, Lasts Until Rollover, Last Available: "2024-12"
-11689	therapeutic iron tricorn hat of the early riser	0		Adventures: +7, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	therapeutic iron tricorn hat of the early riser	0		Adventures: +7, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	pulsating coward's jolly roger flag	0		Monster Level: -20, Lasts Until Rollover, Last Available: "2024-12"
 11691	mirror sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	spirit-forward bad bouncing tankard of spiced rum	5	decent	Last Available: "2024-12"
+11693	bad spirit-forward bouncing tankard of spiced rum	5	decent	Last Available: "2024-12"
 11694	drinkable lime green tankard of spiced Goldschlepper	3	good	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	hardy governor's daughter's lace collar	0		Maximum HP: +50, Last Available: "2024-12"
 11697	upside-down greasy governor's daughter's petticoats	0		Sleaze Spell Damage: +10, Last Available: "2024-12"
 11698	governor's daughter's pearl hairpin of the businessman	0		Meat Drop: +50, Last Available: "2024-12"
-11699	blinking mirror harpoon	0		Last Available: "2024-12"
+11699	mirror blinking harpoon	0		Last Available: "2024-12"
 11700	pulsating chili powder cutlass of the cougar	0		Moxie: +20, Last Available: "2024-12"
-11701	adequate tiny cyan Aztec tamale	1	good	Last Available: "2024-12"
+11701	tiny adequate cyan Aztec tamale	1	good	Last Available: "2024-12"
 11702	maroon jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	gray pet rock	0		Last Available: "2024-12"
 11704	blurry fuchsia spinning sinister groggles	0		Spell Damage: +10, Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	Sherlock's wizardly silky pirate drawers	0		Mysticality: +25, Item Drop: +25, Last Available: "2024-12"
 11708	blue profane eye patch	0		Sleaze Damage: +3
 11709	warmed pickled purple peppermint pegleg	0		Effect: "Coal-Powered", Effect Duration: 27, Last Available: "2024-12"
-11710	hand-crafted ghostly bouncing hard cocoa	3	EPIC	Last Available: "2024-12"
+11710	hand-crafted bouncing ghostly hard cocoa	3	EPIC	Last Available: "2024-12"
 11711	spoiled spinning salmagumdi	3	crappy	Last Available: "2024-12"
 11712	blurry wicked plastic Easter Island Bunny	0		Spell Damage: +5, Last Available: "2024-12"
 11713	gray plastic St. Patrick of the wise owl	0		Mysticality: +20, Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	frightening Temple Grandin's thinker's potato jacket	0		Mysticality: +10, Familiar Weight: +7, Spooky Damage: +5, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	fireproof nippy military orb	0		Cold Damage: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	fireproof nippy military orb	0		Cold Damage: +10, Hot Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	ionized boiled rum ball	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 63
 11733	mirror gravy skin	0		Last Available: "2024-12"
 11734	medical-grade gravyskin hat of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
@@ -11595,28 +11595,28 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	huge ragged wool yarn	0		Last Available: "2024-12"
 11742	gravedigger's clever hardy perfect Christmas scarf	0		Maximum HP: [+50*event(December)], Maximum MP: [+20*event(December)], Spooky Damage: [+10*event(December)], Single Equip, Last Available: "2024-12"
-11743	twirling Tesla snowman-enchanting tophat of the glutton	0		Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	twirling Tesla snowman-enchanting tophat of the glutton	0		Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	vacuum-sealed LIDAR candle	0		Effect: "Hangdog", Effect Duration: 62, Last Available: "2024-12"
 11745	inspector's stanky healthy Congressional Medal of Insanity	0		Maximum HP Percent: +20, Stench Spell Damage: +25, Item Drop: +15, Last Available: "2024-12"
 11746	cyan pumpkin spice whorl	0		Last Available: "2024-12"
 11747	acceptable watered-down twirling Easter grasshopper	2	good	Last Available: "2024-12"
-11748	perfectly mixed distilled Irish eggnog	5	EPIC	Last Available: "2024-12"
-11749	special bad canteen of jungle juice	4	decent	Effect: "New Zeal", Effect Duration: 50, Last Available: "2024-12"
+11748	distilled perfectly mixed Irish eggnog	5	EPIC	Last Available: "2024-12"
+11749	bad special canteen of jungle juice	4	decent	Effect: "New Zeal", Effect Duration: 50, Last Available: "2024-12"
 11750	watered-down hand-crafted turchucken	2	EPIC	Last Available: "2024-12"
-11751	perfectly mixed practically non-alcoholic blue spinning mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11751	practically non-alcoholic perfectly mixed blue spinning mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11752	mediocre weak holiday trip around the world	2	decent	Last Available: "2024-12"
-11753	decent half-sized bouncing chocolate ostrich egg	2	good	Last Available: "2024-12"
+11753	half-sized decent bouncing chocolate ostrich egg	2	good	Last Available: "2024-12"
 11754	spoiled beef and cabbage	4	crappy	Last Available: "2024-12"
 11755	big toothsome candy rations	5	awesome	Last Available: "2024-12"
 11756	yummy half-sized double-candied yams	2	awesome	Last Available: "2024-12"
 11757	rotten Christmas ham	3	crappy	Last Available: "2024-12"
-11758	flavorless half-sized holiday smorgasbord	2	decent	Last Available: "2024-12"
+11758	half-sized flavorless holiday smorgasbord	2	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	smartaleck's bejazzled eyepatch	0		Moxie Percent: +30, Last Available: "2024-12"
-11761	wobbly teal Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11761	teal wobbly Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	tumbling wobbly How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	wobbly tumbling How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
@@ -11624,7 +11624,7 @@
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11770	wobbly Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	cyan moai statuette	0		Last Available: "2024-12"
-11772	skewed ribald Van der Graaf curative egg gun of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +10, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	skewed ribald Van der Graaf curative egg gun of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +10, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	huge fireproof cool beefy army helmet of extreme caution	0		Muscle: +10, Moxie: +5, Monster Level: -25, Hot Resistance: +3, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	magnetized non-altered deviled candy egg	0		Effect: "Yet tea", Effect Duration: 37, Last Available: "2024-12"
 11782	maroon McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	supercool McHugeLarge duffel bag of the scaredy-cat	0		Moxie Percent: +20, Monster Level: -15, Last Available: "2025-01"
-11784	yellow tumbling scorching sinister wizardly McHugeLarge left pole	0		Mysticality: +25, Spell Damage: +10, Hot Damage: +25, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	curative Sinatra's McHugeLarge right pole of the businessman	0		Experience (Moxie): +5, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	bouncing savvy McHugeLarge left ski of Calamity Jane	0		Mysticality Percent: +20, Critical Hit Percent: +15, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	blurry Jack Frost's clever McHugeLarge right ski	0		Maximum MP: +20, Cold Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	yellow tumbling scorching sinister wizardly McHugeLarge left pole	0		Mysticality: +25, Spell Damage: +10, Hot Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	curative Sinatra's McHugeLarge right pole of the businessman	0		Experience (Moxie): +5, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	bouncing savvy McHugeLarge left ski of Calamity Jane	0		Mysticality Percent: +20, Critical Hit Percent: +15, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	blurry Jack Frost's clever McHugeLarge right ski	0		Maximum MP: +20, Cold Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	1	0		Last Available: "2025-12"
 11789	fuchsia 0	0		Last Available: "2025-12"
-11790	modified green bouncing skewed eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11790	modified bouncing skewed green eXpand	1		Last Available: "2025-12"
+11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,12 +11658,12 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pulsating pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	bouncing CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
-11811	huge tumbling wobbly logic grenade	0		Last Available: "2025-12"
+11811	wobbly huge tumbling logic grenade	0		Last Available: "2025-12"
 11812	pickled psilocyber mushroom	1		Effect: "Strong Grip", Effect Duration: 35, Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	purple insignificant bit	0		Last Available: "2025-12"
 11825	pulsating parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	tumbling ninja rope	0		
@@ -11697,44 +11697,44 @@
 11842	spinning dark manioc	0		
 11843	Observer source code	0		
 11844	chill gherkin	0		
-11845	maroon mirror childrens' stapler	0		
+11845	mirror maroon childrens' stapler	0		
 11846	plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	mirror heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	wobbly sore	0		Cold Damage: +10, Cold Spell Damage: +10
-11851	upside-down jittery stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
+11851	jittery upside-down stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	purple phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	blue skewed grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
-11856	cyan skewed sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
-11857	upside-down purple carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
+11856	skewed cyan sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11857	purple upside-down carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
 11860	blinking assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	denatured scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	special acceptable weak pint of Leprechaun Stout	2	good	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2025-03"
+11864	special weak acceptable pint of Leprechaun Stout	2	good	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2025-03"
 11865	powdered mirror phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	unironic knife	0		
-11870	pulsating cyan bar dart	0		Last Available: "2025-03"
+11870	cyan pulsating bar dart	0		Last Available: "2025-03"
 11871	powdered leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	half-sized adequate Heck ramen	2	good	Last Available: "2025-03"
 11873	adequate diet burrito	1	good	Last Available: "2025-03"
 11874	bland small beer brat	4	decent	Last Available: "2025-03"
 11875	stale snack-sized peach pie	2	decent	Last Available: "2025-03"
 11876	normal incredible mini-pizza	3	good	Last Available: "2025-03"
-11877	fancy practically non-alcoholic acceptable wobbly Divine sidecar	1	good	Effect: "Category", Effect Duration: 40, Last Available: "2025-03"
-11878	tolerable weak huge tangarita sidecar	2	good	Last Available: "2025-03"
-11879	watered-down acceptable gimlet sidecar	2	good	Last Available: "2025-03"
-11880	aged high-proof tumbling vodka stratocaster sidecar	9	awesome	Last Available: "2025-03"
-11881	drinkable enchanted triple-distilled tumbling prussian cathouse sidecar	8	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 45, Last Available: "2025-03"
-11882	mediocre triple-distilled pulsating Mon Tiki sidecar	7	decent	Last Available: "2025-03"
+11877	fancy acceptable practically non-alcoholic wobbly Divine sidecar	1	good	Effect: "Category", Effect Duration: 40, Last Available: "2025-03"
+11878	weak tolerable huge tangarita sidecar	2	good	Last Available: "2025-03"
+11879	acceptable watered-down gimlet sidecar	2	good	Last Available: "2025-03"
+11880	high-proof aged tumbling vodka stratocaster sidecar	9	awesome	Last Available: "2025-03"
+11881	enchanted drinkable triple-distilled tumbling prussian cathouse sidecar	8	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 45, Last Available: "2025-03"
+11882	triple-distilled mediocre pulsating Mon Tiki sidecar	7	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	supercharged stylish April Shower Thoughts shield	0		Moxie: +25, Maximum MP Percent: +30, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
@@ -11751,7 +11751,7 @@
 11896	wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
 11898	galvanized pickled spinning wet paper cup	0		Effect: "Trash-Wrapped", Effect Duration: 20, Last Available: "2025-04"
-11899	super-energized bouncing cyan wet paperback	0		Effect: "Blessing of Charcoatl", Effect Duration: 22, Last Available: "2025-04"
+11899	super-energized cyan bouncing wet paperback	0		Effect: "Blessing of Charcoatl", Effect Duration: 22, Last Available: "2025-04"
 11900	blinking energetic wet shower radio	0		Maximum MP Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	upside-down wet shower stamp	0		Last Available: "2025-04"
 11902	Jack Frost's birthday bloon	0		Cold Spell Damage: +50
@@ -11771,7 +11771,7 @@
 11916	pulsating razor-sharp stylish bycocket	0		Weapon Damage Percent: +25
 11917	blurry wobbly Thwaitgold mad hatterpillar statuette	0		
 11918	pulsating packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11816,7 +11816,7 @@
 11962	hardy undersea surveying goggles	0		Maximum HP: +50, Lasts Until Rollover
 11963	artisanal practically non-alcoholic Ocean-Touched Rum	1	EPIC	
 11964	distilled water-logged pill	1		
-11965	small rotten shaking kelp puck	2	crappy	
+11965	rotten small shaking kelp puck	2	crappy	
 11966	scroll of sea strength	0		
 11967	cyan scroll of sea smarts	0		
 11968	huge scroll of sea smarm	0		
@@ -11826,27 +11826,27 @@
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	sage dentadent	0		Mysticality Percent: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	nasty friendly Annie Oakley's dance instructor's brawny blood cubic zirconia of incineration	0		Muscle Percent: +20, Experience Percent (Moxie): +10, Critical Hit Percent: +20, Familiar Weight: +3, Hot Spell Damage: +50, Stench Damage: +5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	nasty friendly Annie Oakley's dance instructor's brawny blood cubic zirconia of incineration	0		Muscle Percent: +20, Experience Percent (Moxie): +10, Critical Hit Percent: +20, Familiar Weight: +3, Hot Spell Damage: +50, Stench Damage: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	denatured squat blinking blood thinner	1		Last Available: "2025-10"
-12045	practically non-alcoholic drinkable pheromone cocktail	1	good	Last Available: "2025-10"
+12045	drinkable practically non-alcoholic pheromone cocktail	1	good	Last Available: "2025-10"
 12046	decent spinning spinal tapas	3	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	upside-down Oprah's Socratic shrunken head of Gandalf	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Spell Critical Percent: +20, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	upside-down Oprah's Socratic shrunken head of Gandalf	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Spell Critical Percent: +20, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	pulsating stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	skewed small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	weak hand-crafted Smoking Pope	2	EPIC	
 12053	normal prize turkey	4	good	
 12054	denatured medicinal gruel	1		Effect: "Yet tea", Effect Duration: 10
-12055	stale tiny full-sized pumpkin pie	1	decent	Last Available: "2025-11"
-12056	high-proof perfectly mixed vodka cranberry sauce	7	EPIC	Last Available: "2025-11"
+12055	tiny stale full-sized pumpkin pie	1	decent	Last Available: "2025-11"
+12056	perfectly mixed high-proof vodka cranberry sauce	7	EPIC	Last Available: "2025-11"
 12057	warmed cold-filtered yammed candy	0		Effect: "Slimy Flavor", Effect Duration: 50, Last Available: "2025-11"
 12058	spoiled spinning treasure chestnut	3	crappy	Last Available: "2025-12"
-12059	weak perfectly mixed mulled butter rum	2	EPIC	Last Available: "2025-12"
+12059	perfectly mixed weak mulled butter rum	2	EPIC	Last Available: "2025-12"
 12060	colloidal cinnamon doubloon	0		Effect: "Florid Cheeks", Effect Duration: 14, Last Available: "2025-12"
 12061	steel-toed plastic left skeleton arm	0		Damage Reduction: 9, Last Available: "2025-12"
 12062	upside-down Annie Oakley's plastic left skeleton leg	0		Critical Hit Percent: +20, Last Available: "2025-12"
@@ -11879,9 +11879,9 @@
 12121	wobbly Crymbocurrency	0		Last Available: "2025-12"
 12122	squat upside-down executive extra-thick Crimbo sweater	0		Meat Drop: +40, Last Available: "2025-12"
 12123	olive The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	watered-down acceptable Steve Abrams' Holiday Sampler Beer	2	good	Last Available: "2025-12"
+12124	acceptable watered-down Steve Abrams' Holiday Sampler Beer	2	good	Last Available: "2025-12"
 12125	ghostly crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	drinkable practically non-alcoholic skewed shaking bottle of prize-winning rum	1	good	Last Available: "2025-12"
+12126	practically non-alcoholic drinkable shaking skewed bottle of prize-winning rum	1	good	Last Available: "2025-12"
 12127	lard-coated Santa-Slayer medal of Tarzan of the boozehound	0		Experience (Muscle): +3, Sleaze Spell Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2025-12"
 12128	blue Skull of Claus	0		Last Available: "2025-12"
 12129	dry green boiling bone marrow	0		Effect: "Quaaaaaaa", Effect Duration: 27, Last Available: "2025-12"
@@ -11889,16 +11889,16 @@
 12131	galvanized boiling synovial fluid	0		Effect: "Greased-Up Familiar", Effect Duration: 64, Last Available: "2025-12"
 12132	lard-coated sizzling smoldering vertebra of terror	0		Hot Damage: +10, Spooky Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2025-12"
 12133	blurry seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	ghostly smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	up-at-dawn baleful wizardly hot boning knife	0		Mysticality: +25, Spell Damage: +25, Adventures: +5, Single Equip, Last Available: "2025-12"
 12138	olive Herculean boxer's fistbone of the sweet-tooth	0		Muscle Percent: +10, Experience (Muscle): +1, Candy Drop: +100, Last Available: "2025-12"
 12139	healthy sinister grievous burnt bone belt	0		Weapon Damage Percent: +50, Spell Damage: +10, Maximum HP Percent: +20, Single Equip, Last Available: "2025-12"
 12140	scorched skull trophy of the dark arts	0		Spell Damage Percent: +100, Last Available: "2025-12"
-12141	rotten low-calorie wobbly red wing bone	1	crappy	Last Available: "2025-12"
+12141	rotten low-calorie red wobbly wing bone	1	crappy	Last Available: "2025-12"
 12142	lousy ghostly weak skeleton venom	3	decent	Last Available: "2025-12"
-12143	vaporized pulsating wobbly baked bone meal	1		Effect: "Reptilian Fortitude", Effect Duration: 20, Last Available: "2025-12"
+12143	vaporized wobbly pulsating baked bone meal	1		Effect: "Reptilian Fortitude", Effect Duration: 20, Last Available: "2025-12"
 12144	jittery plastic skeleton rib cage of extreme caution	0		Monster Level: -25, Last Available: "2025-12"
 12145	red friendly plastic skeleton skull	0		Familiar Weight: +3, Last Available: "2025-12"
 12146	jittery frightening plastic skeleton Crimbo hat	0		Spooky Damage: +5, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	blinking blinking Da Vinci's ship's lantern	0		Experience (Mysticality): +5, Last Available: "2025-12"
 12170	rosewater-soaked crafty heat-resistant harpoon pistol	0		Maximum MP: +10, Stench Resistance: +3, Last Available: "2025-12"
 12171	flavorless traditional gingerloaf	3	decent	Last Available: "2025-12"
-12172	watered-down acceptable Scotch and eggnog	2	good	Last Available: "2025-12"
+12172	acceptable watered-down Scotch and eggnog	2	good	Last Available: "2025-12"
 12173	adjusted colloidal counterskeleton elixir	0		Effect: "Broken Fast", Effect Duration: 20, Last Available: "2025-12"
 12174	tolerable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
 12175	twirling The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	triple-oxidized gummi fingerbone	0		Effect: "Bread Burps", Effect Duration: 21
 12179	shaking mansplainer's Fonzie's glimmering crystal	0		Experience (Moxie): +1, Monster Level: +15, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	jittery loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11959,7 +11959,7 @@
 12201	Usain Bolt's dinosaur bone club	0		Initiative: +80, Last Available: "2026-03"
 12202	stanky dog trainer's dinosaur skull helmet	0		Experience (familiar): +1, Stench Spell Damage: +25, Last Available: "2026-03"
 12203	shaking ribald flame-wreathed dance instructor's dinosaur bone corset	0		Experience Percent (Moxie): +10, Hot Spell Damage: +10, Sleaze Damage: +10, Last Available: "2026-03"
-12204	lousy boozy upside-down Pork Elf cough syrup	5	decent	Last Available: "2026-03"
+12204	boozy lousy upside-down Pork Elf cough syrup	5	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
@@ -11972,7 +11972,7 @@
 12214	denatured olive candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	spoiled fancy low-calorie discarded hot dog	1	crappy	Effect: "Ham-Fisted", Effect Duration: 40, Last Available: "2026-04"
+12217	low-calorie spoiled fancy discarded hot dog	1	crappy	Effect: "Ham-Fisted", Effect Duration: 40, Last Available: "2026-04"
 12218	bad special skewed most of a beer	3	decent	Effect: "substats.enh", Effect Duration: 25, Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
@@ -11984,10 +11984,10 @@
 12230	bland half-sized crudit&eacute;s	2	decent	
 12231	bland sauced mutton	3	decent	
 12232	adequate massive hot honey ant	7	good	
-12233	normal special tomb aspic	3	good	Effect: "Almost Cool", Effect Duration: 50
+12233	special normal tomb aspic	3	good	Effect: "Almost Cool", Effect Duration: 50
 12234	adequate huge olive later tots	6	good	
 12235	normal Frutti di Scatoletta	3	good	Last Available: "2026-05"
-12236	small delicious Pesto alla Marziano	2	awesome	Last Available: "2026-05"
+12236	delicious small Pesto alla Marziano	2	awesome	Last Available: "2026-05"
 12237	moldy purple Arrattabbattabiata	3	crappy	Last Available: "2026-05"
 12238	normal tiny Orzo di Riso	1	good	Last Available: "2026-05"
 12239	gigantic normal purple tumbling Pasta Grimavera	6	good	Last Available: "2026-05"
@@ -12008,33 +12008,33 @@
 12258	huge shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	foul-smelling Fonzie's sage The Wizard's Android	0		Mysticality Percent: +10, Experience (Moxie): +1, Stench Damage: +10
-12261	narrow olive flash paperwad	0		
+12261	olive narrow flash paperwad	0		
 12262	twirling juggling ball	0		
 12263	family-friendly tactical jester's cap of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +1, Combat Item Damage Percent: 50
-12264	shaking fuchsia single-use sword	0		
+12264	fuchsia shaking single-use sword	0		
 12265	maroon knitted flimsy plastic helmet	0		Cold Resistance: +3
 12266	pulsating flame-retardant flimsy plastic greaves	0		Hot Resistance: +1
 12267	ghostly pulsating shaking mansplainer's flimsy plastic breastplate	0		Monster Level: +15
 12268	yellow flimsy plastic shield of Flo-Jo	0		Initiative: +100, Damage Reduction: 3
 12269	twirling packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	blurry red avaricious Portable Laughing Stock of the brute of dire peril	0		Muscle Percent: +30, Weapon Damage: +20, Meat Drop: +30, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	blurry red avaricious Portable Laughing Stock of the brute of dire peril	0		Muscle Percent: +30, Weapon Damage: +20, Meat Drop: +30, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	dance instructor's Staff of Anachronistic Churning of the scaredy-cat of the glutton	0		Experience Percent (Moxie): +10, Monster Level: -15, Food Drop: +100
 12272	bland classic banana	3	decent	Last Available: "2026-07"
-12273	bland snack-sized special watermelon	2	decent	Effect: "Butt-Rock Hair", Effect Duration: 50, Last Available: "2026-07"
+12273	snack-sized bland special watermelon	2	decent	Effect: "Butt-Rock Hair", Effect Duration: 50, Last Available: "2026-07"
 12274	bland snack-sized squat quince	2	decent	Last Available: "2026-07"
 12275	wobbly skewed Interesting Coin	0		Last Available: "2026-08"
 12276	wobbly mirror Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	normal tiny classic banana pie	1	good	Last Available: "2026-07"
-12278	super-magnetized polymerized lime green blurry essential banana decoction	0		Effect: "Uncanny Shot", Effect Duration: 14, Last Available: "2026-07"
+12278	super-magnetized polymerized blurry lime green essential banana decoction	0		Effect: "Uncanny Shot", Effect Duration: 14, Last Available: "2026-07"
 12279	oxidized huge banana quintessence	0		Effect: "Superheroic", Effect Duration: 33, Last Available: "2026-07"
 12280	delicious Aesop Daiquiri	3	awesome	Last Available: "2026-07"
 12281	perfectly mixed yellow Monkey Congress	3	EPIC	Last Available: "2026-07"
-12282	yummy low-calorie blurry watermelon pie	1	awesome	Last Available: "2026-07"
+12282	low-calorie yummy blurry watermelon pie	1	awesome	Last Available: "2026-07"
 12283	boiled quadruple-warmed gray concentrated watermelon juice	0		Effect: "Psalm of Pointiness", Effect Duration: 39, Last Available: "2026-07"
-12284	vacuum-sealed blue upside-down Aqua Citrulanatae	0		Effect: "Pwnd", Effect Duration: 28, Last Available: "2026-07"
+12284	vacuum-sealed upside-down blue Aqua Citrulanatae	0		Effect: "Pwnd", Effect Duration: 28, Last Available: "2026-07"
 12285	mediocre teal Melonegroni	4	decent	Last Available: "2026-07"
 12286	drinkable Melonade Spritz	3	good	Last Available: "2026-07"
-12287	yummy tiny pulsating upside-down quince pie	1	awesome	Last Available: "2026-07"
+12287	yummy tiny upside-down pulsating quince pie	1	awesome	Last Available: "2026-07"
 12288	denatured dry cyan quince quaff	0		Effect: "Haunted Stomach", Effect Duration: 55, Last Available: "2026-07"
 12289	non-Vulcanized wobbly Quickquince	0		Effect: "Your Favorite Flavor", Effect Duration: 53, Last Available: "2026-07"
 12290	perfectly mixed shaking Quiskey Sour	4	EPIC	Last Available: "2026-07"
@@ -12043,8 +12043,8 @@
 12293	bouncing cyan reassuring extremely unsafe underdraft protection	0		Weapon Damage Percent: +100, Spooky Resistance: +1, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	immense tasty soybean futures	8	awesome	Last Available: "2026-08"
-12296	quadruple-vacuum-sealed tarnished yellow ghostly upside-down housing bubble	0		Effect: "Space Cadet", Effect Duration: 55, Last Available: "2026-08"
-12297	unsweetened twirling wobbly Pixie-Swordz	0		Effect: "Greasy Visage", Effect Duration: 67
+12296	quadruple-vacuum-sealed tarnished upside-down ghostly yellow housing bubble	0		Effect: "Space Cadet", Effect Duration: 55, Last Available: "2026-08"
+12297	unsweetened wobbly twirling Pixie-Swordz	0		Effect: "Greasy Visage", Effect Duration: 67
 12298	family-friendly financial instrument of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2026-08"
 12299	manspreader's hedge fund clippers of the glutton	0		Monster Level: +10, Food Drop: +100, Last Available: "2026-08"
 12300	fuchsia smelly selling shorts	0		Stench Spell Damage: +10, Last Available: "2026-08"
@@ -12052,12 +12052,12 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	twirling resourceful stylish 401k ring	0		Moxie: +25, Maximum MP: +50, Last Available: "2026-08"
 12304	fuchsia balance sheet	0		Last Available: "2026-08"
-12305	frozen pulsating blue invisible hand	0		Effect: "Ichorous Eyesight", Effect Duration: 22, Last Available: "2026-08"
+12305	frozen blue pulsating invisible hand	0		Effect: "Ichorous Eyesight", Effect Duration: 22, Last Available: "2026-08"
 12306	altered circle of overdraft protection scroll	0		Effect: "Egg-stortionary Tactics", Effect Duration: 21, Last Available: "2026-08"
 12307	ionized energized mint	0		Effect: "Shawarma Warm War", Effect Duration: 31, Last Available: "2026-08"
 12308	blurry savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
-12310	compressed pulsating ghostly lime green toxic asset	1		Last Available: "2026-08"
+12310	compressed ghostly pulsating lime green toxic asset	1		Last Available: "2026-08"
 12311	twisted purple intangible asset	1		Last Available: "2026-08"
 12312	denatured liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Marmot_cafe_booze.txt
@@ -1,22 +1,22 @@
--1	mediocre distilled blinking Petite Porter	5	decent	
--2	tolerable watered-down Scrawny Stout	2	good	
+-1	distilled mediocre blinking Petite Porter	5	decent	
+-2	watered-down tolerable Scrawny Stout	2	good	
 -3	acceptable shaking Infinitesimal IPA	4	good	
 -4	drinkable eggnogtini	4	good	
 -5	bad candycaine	3	decent	
 -6	enchanted bad braincracker sweet	4	decent	
 -16	bad fermented honey	4	decent	
--17	boozy bad moons-shine	5	decent	
--18	fancy acceptable gin	4	good	
+-17	bad boozy moons-shine	5	decent	
+-18	acceptable fancy gin	4	good	
 -19	tolerable ecto-nog	3	good	
--20	mediocre extra-dry twirling hot toady	5	decent	
--21	artisanal extra-dry mirror hot choculate	5	EPIC	
--49	acceptable extra-dry purple Cyder	5	good	
--50	mediocre weak twirling Oil Nog	2	decent	
+-20	extra-dry mediocre twirling hot toady	5	decent	
+-21	extra-dry artisanal mirror hot choculate	5	EPIC	
+-49	extra-dry acceptable purple Cyder	5	good	
+-50	weak mediocre twirling Oil Nog	2	decent	
 -51	hand-crafted Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	practically non-alcoholic bad Grimacider	1	decent	
 -59	lousy fuchsia Isotope Nog	3	decent	
 -60	weak acceptable teal blinking Mutagin 'n' Tonic	2	good	
--70	practically non-alcoholic drinkable squat huge Gin and Herring	1	good	
+-70	drinkable practically non-alcoholic squat huge Gin and Herring	1	good	
 -71	irresponsibly strong fancy drinkable Black and Tan and Red All Over	7	good	
 -72	hand-crafted special Antarctic Ice Tea	4	EPIC	
 -76	artisanal CRIMBCO Ribbon Candy Schnapps	4	EPIC	
@@ -25,9 +25,9 @@
 -82	mediocre Horseradish-infused Vodka	3	decent	
 -83	smooth purple Jerkitini	4	awesome	
 -84	triple-distilled bad Desert Island Iced Tea	9	decent	
--88	high-proof lousy Crimbo Saketini	8	decent	
+-88	lousy high-proof Crimbo Saketini	8	decent	
 -89	practically non-alcoholic aged cyan Crimboku Drop	1	awesome	
--90	weak hand-crafted squat Flaming Crimbo Log	2	EPIC	
--107	fortified artisanal Fortified Eggnog Slurry	5	EPIC	
+-90	hand-crafted weak squat Flaming Crimbo Log	2	EPIC	
+-107	artisanal fortified Fortified Eggnog Slurry	5	EPIC	
 -108	delicious Hot Buttered Rum	4	awesome	
 -109	perfectly mixed bouncing Spicy Hot Chocolate	3	EPIC	

--- a/data/TCRS/TCRS_Disco_Bandit_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Marmot_cafe_food.txt
@@ -4,42 +4,42 @@
 -7	stale gumdrop chow mein	3	decent	
 -8	stale candy cane pizza	4	decent	
 -9	moldy half-sized gingerbread stir-fry	2	crappy	
--10	thick decent lime green twigs and gravel	5	good	
+-10	decent thick lime green twigs and gravel	5	good	
 -11	bland special lime green shoots and leaves	4	decent	
 -12	adequate jittery bowl of unidentifiable goo	4	good	
--13	small adequate gingerbread massacre	2	good	
--14	delicious half-sized It Came From Beyond Dessert	2	awesome	
+-13	adequate small gingerbread massacre	2	good	
+-14	half-sized delicious It Came From Beyond Dessert	2	awesome	
 -15	spoiled blinking vampire cake	3	crappy	
 -52	flavorless Soylent Red and Green	4	decent	
 -53	moldy Disc-Shaped Nutrition Unit	3	crappy	
 -54	adequate immense red Gingerborg Hive	9	good	
 -61	adequate Candy Cane Surprise	3	good	
 -62	bland Grimdrop Chow Mein	3	decent	
--63	special normal low-calorie Grimgerbread House	1	good	
+-63	low-calorie special normal Grimgerbread House	1	good	
 -67	rotten bouncing Caviar Carbonara	4	crappy	
 -68	adequate gray Halibut Alfredo	3	good	
 -69	immense stale Red Herring Velvet Cake	7	decent	
 -73	flavorless bouncing CRIMBCO Reconstituted Gruel	4	decent	
--74	spoiled bite-sized jittery New and Improved CRIMBCO Reconstituted Gruel	1	crappy	
--75	rotten enchanted bouncing tumbling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	crappy	
--79	moldy small Brussels Sprout Stir-Fry	2	crappy	
+-74	bite-sized spoiled jittery New and Improved CRIMBCO Reconstituted Gruel	1	crappy	
+-75	enchanted rotten bouncing tumbling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	crappy	
+-79	small moldy Brussels Sprout Stir-Fry	2	crappy	
 -80	toothsome gigantic Carrot, Cabbage, and Kale Pizza	8	awesome	
 -81	bland half-sized narrow Turnip and Rutabaga Pie	2	decent	
 -85	normal Rainbow Spider Fun Roll	3	good	
--86	normal blurry twirling Vegas Volcano Lava Roll	3	good	
+-86	normal twirling blurry Vegas Volcano Lava Roll	3	good	
 -87	rotten Crazy Dragon Shogun Buddha Roll	3	crappy	
--92	bland thick twirling basic hot dog	5	decent	
--93	stale super-sized savage macho dog	5	decent	
+-92	thick bland twirling basic hot dog	5	decent	
+-93	super-sized stale savage macho dog	5	decent	
 -94	rotten maroon mirror one with everything	3	crappy	
 -95	rotten immense sly dog	8	crappy	
--96	normal low-calorie fancy red devil dog	1	good	
+-96	fancy normal low-calorie red devil dog	1	good	
 -97	stale chilly dog	3	decent	
 -98	big stale ghost dog	5	decent	
 -99	flavorless junkyard dog	3	decent	
--100	small moldy upside-down wet dog	2	crappy	
+-100	moldy small upside-down wet dog	2	crappy	
 -101	spoiled miniature sleeping dog	2	crappy	
 -102	yummy optimal dog	4	awesome	
 -103	rotten pulsating video games hot dog	3	crappy	
 -104	spoiled low-calorie Peppermint Nutrition Block	1	crappy	
 -105	bland Gingerbread Nutrition Block	3	decent	
--106	big moldy Cinnamon Nutrition Block	5	crappy	
+-106	moldy big Cinnamon Nutrition Block	5	crappy	

--- a/data/TCRS/TCRS_Disco_Bandit_Mongoose.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Mongoose.txt
@@ -12,8 +12,8 @@
 12	jittery mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	vaporized huge tumbling moxie weed	1		Effect: "Poker Faced", Effect Duration: 30
 15	denatured strongness elixir	1		
-16	twisted shaking fuchsia magicalness-in-a-can	1		
-17	half-sized decent noodles	2	good	
+16	twisted fuchsia shaking magicalness-in-a-can	1		
+17	decent half-sized noodles	2	good	
 18	mirror tortoise's blessing	0		
 19	vibrating asparagus knife	0		Maximum MP Percent: +10
 20	spinning Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -26,10 +26,10 @@
 27	gray blinking spider web	0		
 28	really spider web	0		
 29	really really spider web	0		
-30	cyan mirror rock	0		
+30	mirror cyan rock	0		
 31	seal-toothed rock	0		
 32	Bjorn's Hammer of the detective	0		Item Drop: +20, Class: "Seal Clubber"
-33	wobbly blurry snorkel	0		Familiar Effect: "atk, cap 2"
+33	blurry wobbly snorkel	0		Familiar Effect: "atk, cap 2"
 34	Dolphin King's crown of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, 2xGhuol, cap 8"
 35	wobbly blinking Knob Goblin scimitar of incineration	0		Hot Spell Damage: +50
 36	olive horrifying Knob Goblin tongs	0		Spooky Damage: +25
@@ -38,14 +38,14 @@
 39	pretty flower	0		
 40	casino pass	0		
 41	lousy ice-cold Sir Schlitz	3	decent	
-42	spinning ghostly hermit permit	0		
+42	ghostly spinning hermit permit	0		
 43	worthless trinket	0		
 44	spinning worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	figurine	0		
 47	flavorless immense hot buttered roll	8	decent	
 48	teal heart of rock and roll	0		
-49	toothsome wobbly mirror bowl of cottage cheese	3	awesome	
+49	toothsome mirror wobbly bowl of cottage cheese	3	awesome	
 50	Tesla Rock and Roll Legend	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10
 51	squat Knob Goblin Uberpants of temperance	0		Sleaze Resistance: +5, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -55,11 +55,11 @@
 56	skewed hot sauce	0		
 57	scorching 5-Alarm Saucepan	0		Hot Damage: +25, Class: "Sauceror"
 58	stone turtle	0		
-59	narrow teal upside-down slingshot	0		
+59	upside-down teal narrow slingshot	0		
 60	pulsating narrow fuchsia Mace of the Tortoise of the early riser	0		Adventures: +7, Class: "Turtle Tamer"
 61	spoiled green fortune cookie	4	crappy	
 62	blurry oriole-feather headdress of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "atk, 3xVolley, cap 3"
-63	narrow upside-down action figure body	0		
+63	upside-down narrow action figure body	0		
 64	upside-down action figure head	0		
 65	Mighty Bjorn action figure	0		
 66	twig	0		
@@ -80,7 +80,7 @@
 81	mediocre practically non-alcoholic ice-cold Willer	1	decent	
 82	ring	0		
 83	shaft	0		
-84	mirror lime green Orcish meat locker	0		
+84	lime green mirror Orcish meat locker	0		
 85	unlocked meat locker	0		
 86	key	0		
 87	meat from yesterday	0		
@@ -163,7 +163,7 @@
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	delicious super-sized ghuol-ear kabob	5	awesome	
+167	super-sized delicious ghuol-ear kabob	5	awesome	
 168	Lo Pan's bone rattle	0		Spell Critical Percent: +30
 169	pulsating bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -171,7 +171,7 @@
 172	gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
-175	bland massive uncooked chorizo	6	decent	
+175	massive bland uncooked chorizo	6	decent	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
@@ -212,12 +212,12 @@
 214	Fonzie's filthy knitted dread sack	0		Experience (Moxie): +1, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
 216	small stale shaking carob brownies	2	decent	
-217	stale snack-sized squat herb brownies	2	decent	
+217	snack-sized stale squat herb brownies	2	decent	
 218	fuchsia hemp string	0		
 219	pulsating necklace chain	0		
 220	gnoll teeth	0		
 221	skewed clever gnoll-tooth necklace	0		Maximum MP: +20
-222	skewed red phat turquoise bead	0		
+222	red skewed phat turquoise bead	0		
 223	Van der Graaf phat turquoise bracelet	0		MP Regen Min: 5, MP Regen Max: 7
 224	blue frightening eyepatch	0		Spooky Damage: +5, Familiar Effect: "3xBarrr, cap 6"
 225	stale tofu casserole	3	decent	
@@ -242,24 +242,24 @@
 244	moldy grapes	4	crappy	
 245	moldy olive	4	crappy	
 246	adequate bouncing tomato	4	good	
-247	shaking blurry fermenting powder	0		
+247	blurry shaking fermenting powder	0		
 248	aged salty dog	4	awesome	
 249	lousy bloody mary	3	decent	
-250	drinkable distilled screwdriver	5	good	
+250	distilled drinkable screwdriver	5	good	
 251	practically non-alcoholic acceptable maroon martini	1	good	
 252	special bad bloody beer	4	decent	Effect: "Burning Hands", Effect Duration: 25
-253	perfectly mixed weak shot of schnapps	2	EPIC	
+253	weak perfectly mixed shot of schnapps	2	EPIC	
 254	bad shot of grapefruit schnapps	3	decent	
-255	delicious triple-distilled fine wine	8	awesome	
-256	smooth high-proof shot of tomato schnapps	8	awesome	
+255	triple-distilled delicious fine wine	8	awesome	
+256	high-proof smooth shot of tomato schnapps	8	awesome	
 257	triple-distilled aged blinking extra-spicy bloody mary	8	awesome	
 258	dense meat stack	0		
 259	snake skin	0		
 260	bland huge White Citadel fries	3	decent	
 261	half-sized spoiled White Citadel burger	2	crappy	
-262	half-sized bland piece of wedding cake	2	decent	
+262	bland half-sized piece of wedding cake	2	decent	
 263	tasty chocolate chips	3	awesome	
-264	miniature rotten bouncing chocolate chip cookies	2	crappy	
+264	rotten miniature bouncing chocolate chip cookies	2	crappy	
 265	twirling up-at-dawn satin pants	0		Adventures: +5, Familiar Effect: "atk, 2xPotato, cap 10"
 266	delicious extra-dry enchanted lightning	5	awesome	Effect: "You Know What's Up", Effect Duration: 25
 267	fireproof mullet wig	0		Hot Resistance: +3, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -270,9 +270,9 @@
 272	modified concentrated magicalness pill	1		
 273	modified twirling moxie weed	1		Effect: "Nas Tea", Effect Duration: 45
 274	Familiar-Gro&trade; Terrarium	0		
-275	wobbly spinning mosquito larva	0		
-276	spinning jittery leprechaun hatchling	0		
-277	distilled tumbling tumbling olive extra-strength strongness elixir	1		Effect: "Moon'd", Effect Duration: 45
+275	spinning wobbly mosquito larva	0		
+276	jittery spinning leprechaun hatchling	0		
+277	distilled tumbling olive tumbling extra-strength strongness elixir	1		Effect: "Moon'd", Effect Duration: 45
 278	twisted wobbly jug-o-magicalness	1		
 279	twisted suntan lotion of moxiousness	1		Effect: "Strong Grip", Effect Duration: 10
 280	Pick-O-Matic lockpicks	0		
@@ -306,29 +306,29 @@
 308	Annie Oakley's Knob Goblin elite helm	0		Critical Hit Percent: +20, Familiar Effect: "2xFairy, cap 15"
 309	Knob Goblin elite pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xBarrr, cap 15"
 310	pulsating padded Knob Goblin elite polearm	0		Damage Absorption: +20
-311	ghostly lime green hill of beans	0		
+311	lime green ghostly hill of beans	0		
 312	curative Knob Goblin visor	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	shaking hardy Crown of the Goblin King	0		Maximum HP: +50, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	small adequate bean burrito	2	good	
+314	adequate small bean burrito	2	good	
 315	yummy bean burrito	4	awesome	
-316	decent snack-sized fuchsia insanely bean burrito	2	good	
-317	decent miniature bean burrito	2	good	
+316	snack-sized decent fuchsia insanely bean burrito	2	good	
+317	miniature decent bean burrito	2	good	
 318	stale bean burrito	3	decent	
-319	bland low-calorie enchanted huge insanely bean burrito	1	decent	Effect: "Big Punkin'", Effect Duration: 25
+319	enchanted low-calorie bland huge insanely bean burrito	1	decent	Effect: "Big Punkin'", Effect Duration: 25
 320	bland special bat haggis	4	decent	Effect: "Bilious Brawn", Effect Duration: 50
-321	immense rotten menudo	9	crappy	
+321	rotten immense menudo	9	crappy	
 322	rotten goat cheese	3	crappy	
 323	normal squat plain pizza	4	good	
-324	tasty gigantic blue sausage pizza	6	awesome	
+324	gigantic tasty blue sausage pizza	6	awesome	
 325	flavorless goat cheese pizza	4	decent	
 326	bland ghostly mushroom pizza	4	decent	
 327	lime green goat	0		
 328	bad bottle of whiskey	3	decent	
 329	censurious goat beard	0		Sleaze Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 15"
 330	enchanted glass of goat's milk	1	good	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 50
-331	delicious watered-down jittery Canadian	2	awesome	
-332	fancy adequate super-sized huge lime green lemon	5	good	Effect: "Elemental Flavor", Effect Duration: 45
-333	normal bite-sized lime	1	good	
+331	watered-down delicious jittery Canadian	2	awesome	
+332	super-sized adequate fancy lime green huge lemon	5	good	Effect: "Elemental Flavor", Effect Duration: 45
+333	bite-sized normal lime	1	good	
 334	sabre teeth of the businessman	0		Meat Drop: +50
 335	cyan sabre-toothed lime cub	0		
 336	upside-down shellacked consolation ribbon	0		Damage Reduction: 7
@@ -339,7 +339,7 @@
 341	double-boiled deionized pulsating Knob Goblin love potion	0		Effect: "Berry Critical", Effect Duration: 32
 342	maroon Knob Goblin stink bomb	0		
 343	super-polarized Knob Goblin sharpening spray	0		Effect: "Superioreo", Effect Duration: 15
-344	squat green tumbling Knob Goblin seltzer	0		
+344	green tumbling squat Knob Goblin seltzer	0		
 345	mirror Knob Goblin superseltzer	0		
 346	spinning scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
@@ -353,14 +353,14 @@
 355	tumbling eXtreme scarf of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	Usain Bolt's snowboarder pants	0		Initiative: +80, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	special normal wobbly gr8ps	4	good	Effect: "Shredding, Sweating", Effect Duration: 40
+358	normal special wobbly gr8ps	4	good	Effect: "Shredding, Sweating", Effect Duration: 40
 359	spoiled ghostly squat t8r tots	4	crappy	
 360	huge dangerous miner's helmet	0		Weapon Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	blinking sage miner's pants	0		Mysticality Percent: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	tumbling stanky 7-Foot Dwarven mattock	0		Stench Spell Damage: +25
 363	linoleum ore	0		
-364	blinking bouncing asbestos ore	0		
-365	mirror wobbly chrome ore	0		
+364	bouncing blinking asbestos ore	0		
+365	wobbly mirror chrome ore	0		
 366	linoleum sword hilt	0		
 367	bouncing linoleum stick	0		
 368	linoleum crossbow string	0		
@@ -401,7 +401,7 @@
 403	skewed therapeutic shoulder parrot	0		HP Regen Min: 5, HP Regen Max: 7
 404	blurry mansplainer's acoustic guitarrr	0		Monster Level: +15
 405	huge sunken chest	0		
-406	narrow cyan pirate pelvis	0		
+406	cyan narrow pirate pelvis	0		
 407	pirate skull	0		
 408	bouncing pirate skeleton	0		
 409	mirror vial of patchouli oil	0		
@@ -420,7 +420,7 @@
 422	dry wet twirling potion of potency	0		Effect: "Unusual Perspective", Effect Duration: 13
 423	warmed galvanized wobbly cordial of concentration	0		Effect: "Cat Class, Cat Style", Effect Duration: 22
 424	Vulcanized ointment of the occult	0		Effect: "Become Superficially interested", Effect Duration: 51
-425	magnetized diffused red upside-down oil of expertise	0		Effect: "It's Soporiffic!", Effect Duration: 20
+425	magnetized diffused upside-down red oil of expertise	0		Effect: "It's Soporiffic!", Effect Duration: 20
 426	corrupted galvanized narrow potion of temporary gr8ness	0		Effect: "Twinklebritches", Effect Duration: 39
 427	experienced box	0		Experience: +2, Wiki Name: "box"
 428	blinking nothing-in-the-box	0		
@@ -439,7 +439,7 @@
 441	chef-skull-in-the-box	0		
 442	red bartender-skull-in-the-box	0		
 443	lime green beer lens	0		
-444	upside-down blue beer goggles	0		
+444	blue upside-down beer goggles	0		
 445	Socratic box-in-the-box	0		Experience (Mysticality): +1
 446	nothing-in-the-box-in-the-box	0		
 447	flame-wreathed box-in-the-box-in-the-box	0		Hot Spell Damage: +10
@@ -462,7 +462,7 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	decent massive blinking pixel pie	6	good	
+467	massive decent blinking pixel pie	6	good	
 468	ruby W	0		
 469	wobbly wussiness potion	0		
 470	bad Imp Ale	3	decent	
@@ -493,7 +493,7 @@
 495	twirling catgut	0		
 496	cat appendix	0		
 497	lime green gnatwing	0		
-498	snack-sized rotten skewed papaya	2	crappy	
+498	rotten snack-sized skewed papaya	2	crappy	
 499	olive reassuring Temple Grandin's denim axe	0		Familiar Weight: +7, Spooky Resistance: +1
 500	Elf Farm Raffle ticket	0		
 501	moldy big Elfin shortbread	5	crappy	
@@ -508,8 +508,8 @@
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	half-sized moldy upside-down blue Boris's key lime pie	2	crappy	
-514	snack-sized bland bouncing jittery Jarlsberg's key lime pie	2	decent	
+513	moldy half-sized blue upside-down Boris's key lime pie	2	crappy	
+514	bland snack-sized jittery bouncing Jarlsberg's key lime pie	2	decent	
 515	yummy Sneaky Pete's key lime pie	3	awesome	
 516	Hey Deze map	0		
 517	crafty bejeweled accordion strap	0		Maximum MP: +10, Class: "Accordion Thief"
@@ -520,7 +520,7 @@
 522	twirling one-winged stab bat	0		
 523	rewinged stab bat	0		
 524	acceptable high-proof squat papaya sling	6	good	
-525	red shaking grue egg	0		
+525	shaking red grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	lime green volleyball	0		
 528	narrow blood-faced volleyball	0		
@@ -538,14 +538,14 @@
 540	unsweetened tarnished Tasty Fun Good rice candy	0		Effect: "Influence of Sphere", Effect Duration: 25
 541	draggin' ball hat of vim and vigor of extreme caution	0		Maximum HP Percent: +50, Monster Level: -25, Familiar Effect: "atk, 1xVolley, cap 25"
 542	squat experienced brawny 1337 7r0uZ0RZ	0		Muscle Percent: +20, Experience: +2, Familiar Effect: "2xPotato, cap 27"
-543	diet flavorless Trollhouse cookies	1	decent	
+543	flavorless diet Trollhouse cookies	1	decent	
 544	lightning-fast horrifying talons	0		Spooky Damage: +25, Initiative: +40
-545	moldy gigantic tumbling Spam Witch sammich	6	crappy	
+545	gigantic moldy tumbling Spam Witch sammich	6	crappy	
 546	meat vortex	0		
-547	purple shaking 334 scroll	0		
+547	shaking purple 334 scroll	0		
 548	yellow 668 scroll	0		
 549	upside-down 30669 scroll	0		
-550	pulsating twirling 33398 scroll	0		
+550	twirling pulsating 33398 scroll	0		
 551	blurry 64067 scroll	0		
 552	64735 scroll	0		
 553	skewed blurry 31337 scroll	0		
@@ -559,22 +559,22 @@
 561	olive pregnant mushroom	0		
 562	jittery ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	strong drinkable Mad Train wine	5	good	
+564	drinkable strong Mad Train wine	5	good	
 565	steel-toed hobo gloves	0		Damage Reduction: 9, Single Equip
 566	bum cheek of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	miniature toothsome cyan Double Bacon Beelzeburger	2	awesome	
-569	flavorless jumbo Lord of the Flies-sized fries	5	decent	
+568	toothsome miniature cyan Double Bacon Beelzeburger	2	awesome	
+569	jumbo flavorless Lord of the Flies-sized fries	5	decent	
 570	tasty small blurry Chicken Sandwich	2	awesome	
 571	Jumbo Dr. Lucifer	1	good	
 572	spoiled Children's Meal of the Damned	3	crappy	
 573	miniature stale green noodles	2	decent	
 574	flavorless noodles	3	decent	
 575	adequate painful penne pasta	4	good	
-576	flavorless fancy tumbling ravioli della hippy	3	decent	Effect: "Ooh, Sour!", Effect Duration: 20
+576	fancy flavorless tumbling ravioli della hippy	3	decent	Effect: "Ooh, Sour!", Effect Duration: 20
 577	spoiled jumbo bouncing pr0n m4nic0tti	5	crappy	
 578	spoiled Hell ramen	4	crappy	
-579	decent huge olive twirling boring spaghetti	6	good	
+579	huge decent twirling olive boring spaghetti	6	good	
 580	sauce of the ages	0		
 581	upside-down schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
@@ -582,7 +582,7 @@
 584	normal gray spaghetti with Skullheads	4	good	
 585	bland lime green gnocchetti di Nietzsche	3	decent	
 586	crafty ridiculously huge sword of Flo-Jo	0		Maximum MP: +10, Initiative: +100
-587	adjusted maroon shaking squat super-spiky hair gel	0		Effect: "Carrion' On", Effect Duration: 15
+587	adjusted shaking maroon squat super-spiky hair gel	0		Effect: "Carrion' On", Effect Duration: 15
 588	soft echo eyedrop antidote	0		
 589	moldy cocoa eggshell fragment	4	crappy	
 590	normal upside-down cocoa eggshell fragment	3	good	
@@ -590,7 +590,7 @@
 592	house	0		
 593	bouncing phonics down	0		
 594	steel-toed amulet of extreme plot significance	0		Damage Reduction: 9
-595	ghostly olive scroll of drastic healing	0		
+595	olive ghostly scroll of drastic healing	0		
 596	narrow titanium assault umbrella of extreme caution	0		Monster Level: -25
 597	Mohawk wig of the brute	0		Muscle Percent: +30, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
 598	the Slug Lord's map	0		
@@ -609,7 +609,7 @@
 611	D	0		
 612	gray original G	0		
 613	plot hole	0		
-614	dry maroon upside-down probability potion	0		Effect: "Tremella Tremens", Effect Duration: 33
+614	dry upside-down maroon probability potion	0		Effect: "Tremella Tremens", Effect Duration: 33
 615	pulsating chaos butterfly	0		
 616	furry fur	0		
 617	magnetized Angry Farmer candy	0		Effect: "Burning Tongue", Effect Duration: 67
@@ -623,7 +623,7 @@
 625	wang	0		
 626	narrow Wand of Nagamar	0		
 627	shaking ND	0		
-628	spinning wobbly squat maroon metallic A	0		
+628	maroon squat spinning wobbly metallic A	0		
 629	blurry eye of the boozehound	0		Booze Drop: +100
 630	lime green photoprotoneutron torpedo	0		
 631	vibrating furry pants	0		Maximum MP Percent: +10, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
@@ -660,22 +660,22 @@
 662	tumbling lime green Temple Grandin's star buckler	0		Familiar Weight: +7, Damage Reduction: 10
 663	pulsating star throwing star	0		
 664	yellow star starfish	0		
-665	red huge Richard's star key	0		
+665	huge red Richard's star key	0		
 666	mirror nasty shellacked steaming evil of extreme caution	0		Damage Reduction: 7, Monster Level: -25, Stench Damage: +5
 667	pulsating castle map	0		
 668	sinister spiked femur	0		Spell Damage: +10
 669	flavorless ghuol guolash	3	decent	
 670	olive lihc face of the glutton	0		Food Drop: +100, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	up-at-dawn grave robbing shovel of mayonnaise	0		Sleaze Spell Damage: +50, Adventures: +5
-672	moldy immense fuchsia cranberries	10	crappy	
+672	immense moldy fuchsia cranberries	10	crappy	
 673	delicious vodka and cranberry	3	awesome	
-674	lousy weak mirror whiskey	2	decent	
+674	weak lousy mirror whiskey	2	decent	
 675	blurry gravedigger's skull of the Bonerdagon	0		Spooky Damage: +10
 676	maroon dragonbone belt buckle	0		
 677	jittery badass belt of extreme caution	0		Monster Level: -25
 678	twirling chest of the Bonerdagon	0		
 679	lousy roll in the hay	3	decent	
-680	weak artisanal slap and tickle	2	EPIC	
+680	artisanal weak slap and tickle	2	EPIC	
 681	mediocre slip 'n' slide	4	decent	
 682	lousy a sump'm sump'm	4	decent	
 683	aged horizontal tango	3	awesome	
@@ -716,8 +716,8 @@
 720	Lo Pan's fortified porquoise necklace	0		Damage Absorption: +60, Spell Critical Percent: +30, Single Equip
 721	vibrating medical-grade porquoise bracelet	0		Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10
 722	scorching porquoise ring of extreme caution of mayonnaise	0		Monster Level: -25, Hot Damage: +25, Sleaze Spell Damage: +50, Single Equip
-723	thick rotten narrow Knoll mushroom	5	crappy	
-724	stale upside-down olive mushroom	3	decent	
+723	rotten thick narrow Knoll mushroom	5	crappy	
+724	stale olive upside-down mushroom	3	decent	
 725	huge one million meat pancakes	0		
 726	mirror jittery foul-smelling huge mirror shard	0		Stench Damage: +10
 727	hedge maze puzzle	0		
@@ -736,7 +736,7 @@
 740	sharpshooter's tambourine	0		Critical Hit Percent: +10
 741	blinking broken skull	0		
 742	stale Knoll shroomkabob	4	decent	
-743	super-sized rotten mushroom	5	crappy	
+743	rotten super-sized mushroom	5	crappy	
 744	energized unsweetened ionized hair spray	0		Effect: "Object Detection", Effect Duration: 47
 746	stat script	0		
 747	tumbling olive Knob Goblin firecracker	0		
@@ -746,9 +746,9 @@
 751	flavorless cool mushroom	3	decent	
 752	toothsome cool mushroom casserole	3	awesome	
 753	moldy pointy mushroom	3	crappy	
-754	big rotten skewed cream of pointy mushroom soup	5	crappy	
+754	rotten big skewed cream of pointy mushroom soup	5	crappy	
 755	normal snack-sized mirror mushroom	2	good	
-756	massive spoiled mushroom	9	crappy	
+756	spoiled massive mushroom	9	crappy	
 757	spoiled mushroom	3	crappy	
 758	decent bouncing ghost cucumber	4	good	
 759	dill	0		
@@ -776,24 +776,24 @@
 781	non-energized mafia aria	0		Effect: "Rotten Memories", Effect Duration: 57
 782	purple Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	watered-down drinkable spinning squat Acqua Del Piatto Merlot	2	good	Last Available: "2004-10"
+784	drinkable watered-down squat spinning Acqua Del Piatto Merlot	2	good	Last Available: "2004-10"
 785	upside-down raffle ticket	0		
 786	flavorless spinning strawberry	4	decent	
-787	enchanted artisanal bottle of rum	3	EPIC	Effect: "I See Everything Thrice!", Effect Duration: 45
-788	bad practically non-alcoholic strawberry daiquiri	1	decent	
+787	artisanal enchanted bottle of rum	3	EPIC	Effect: "I See Everything Thrice!", Effect Duration: 45
+788	practically non-alcoholic bad strawberry daiquiri	1	decent	
 789	perfectly mixed practically non-alcoholic rum and cola	1	EPIC	
-790	strong drinkable skewed grog	5	good	
+790	drinkable strong skewed grog	5	good	
 791	flame-retardant Mafia bow tie of Calamity Jane	0		Critical Hit Percent: +15, Hot Resistance: +1, Last Available: "2004-10"
 792	Golden Mr. Accessory of the sewer	0		Stench Damage: +25, Softcore Only
 793	concentrated vacuum-sealed oil of stability	0		Effect: "Vital", Effect Duration: 22
 794	oxidized tarnished oil of slipperiness	0		Effect: "Voracious Gorging", Effect Duration: 53
-795	practically non-alcoholic hand-crafted narrow Acque Luride Grezze Cabernet	1	super ultra mega turbo EPIC	Last Available: "2004-10"
+795	hand-crafted practically non-alcoholic narrow Acque Luride Grezze Cabernet	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 796	frosty rock-hard slick cement shoes	0		Moxie: +10, Damage Reduction: 5, Cold Spell Damage: +10, Last Available: "2004-10"
 797	hand-crafted pulsating twirling rockin' wagon	4	EPIC	
 798	artisanal ocean motion	3	EPIC	
-799	enchanted mediocre practically non-alcoholic blurry fuzzbump	1	decent	Effect: "Black Eyes", Effect Duration: 30
+799	practically non-alcoholic mediocre enchanted blurry fuzzbump	1	decent	Effect: "Black Eyes", Effect Duration: 30
 800	stale half-sized poutine	2	decent	
-801	spoiled snack-sized Knob stir-fry	2	crappy	
+801	snack-sized spoiled Knob stir-fry	2	crappy	
 804	stale massive spinning Knoll stir-fry	9	decent	
 805	decent stir-fry	3	good	
 806	decent asparagus stir-fry	3	good	
@@ -803,11 +803,11 @@
 810	spoiled rat appendix stir-fry	3	crappy	
 811	decent squat tofu stir-fry	4	good	
 812	moldy miniature pr0n stir-fry	2	crappy	
-813	bite-sized spoiled special twirling Knob shells	1	crappy	Effect: "Bats in the Belfry", Effect Duration: 25
-814	special flavorless spinning b&auml;tzle	3	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 50
+813	special spoiled bite-sized twirling Knob shells	1	crappy	Effect: "Bats in the Belfry", Effect Duration: 25
+814	flavorless special spinning b&auml;tzle	3	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 50
 815	bland ratini	3	decent	
 816	moldy Knob stroganoff	3	crappy	
-817	adequate tumbling fuchsia narrow menudo ravioli	3	good	
+817	adequate narrow fuchsia tumbling menudo ravioli	3	good	
 818	plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
@@ -817,7 +817,7 @@
 824	huge effervescent potion	0		
 825	fizzy potion	0		
 826	pulsating dark potion	0		
-827	blue shaking murky potion	0		
+827	shaking blue murky potion	0		
 828	tumbling baby killer bee	0		
 829	anti-anti-antidote	0		
 830	flavorless royal jelly	3	decent	
@@ -827,12 +827,12 @@
 834	narrow shellacked cornuthaum	0		Damage Reduction: 7, Item Drop: +5, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	knitted ring of aggravate monster	0		Cold Resistance: +3
 836	toothsome mind flayer corpse	3	awesome	
-837	aged narrow purple Uovo Marcio Shiraz	4	awesome	Last Available: "2004-10"
+837	aged purple narrow Uovo Marcio Shiraz	4	awesome	Last Available: "2004-10"
 838	Usain Bolt's knitted Mafia stogie	0		Cold Resistance: +3, Initiative: +80, Last Available: "2004-10"
 839	lousy cyan Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
 840	wobbly miser's friendly Mafia violin case	0		Familiar Weight: +3, Meat Drop: +10, Last Available: "2004-10"
 841	aged tomato daiquiri	3	awesome	
-842	hand-crafted fortified green beertini	5	EPIC	
+842	fortified hand-crafted green beertini	5	EPIC	
 843	delicious blinking salty slug	3	awesome	
 844	perfectly mixed papaya slung	3	EPIC	
 845	purple Herculean MAHI fez	0		Experience (Muscle): +1, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -899,7 +899,7 @@
 908	quantum double-corrupted concentrated pulsating Cold Hots candy	0		Effect: "Venomous Weapon", Effect Duration: 19
 909	quadruple-nitrogenated energized maroon Wint-O-Fresh mint	0		Effect: "Chari Tea", Effect Duration: 30
 910	bland dwarf bread	4	decent	
-911	aerosolized altered bouncing red Senior Mints	0		Effect: "Starry-Eyed", Effect Duration: 30
+911	aerosolized altered red bouncing Senior Mints	0		Effect: "Starry-Eyed", Effect Duration: 30
 912	activated enhanced pixellated candy heart	0		Effect: "Mucilaginous Muscle", Effect Duration: 50
 913	enhanced kobold	0		Effect: "Motion", Effect Duration: 23
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
@@ -911,16 +911,16 @@
 920	manspreader's Radio Free Foil	0		Monster Level: +10, Last Available: "2006-07"
 921	bland small radio button candy	2	decent	
 922	stanky severed rocking horse head	0		Stench Spell Damage: +25
-923	narrow spinning teal broken cellular phone	0		Last Available: "2004-01"
+923	teal narrow spinning broken cellular phone	0		Last Available: "2004-01"
 924	blurry crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	nitrogenated purple upside-down Hawking's Elixir of Brilliance	0		Effect: "Savage Beast Inside", Effect Duration: 63
-927	practically non-alcoholic bad Ferita Del Petto Zinfandel	1	decent	Last Available: "2006-12"
+927	bad practically non-alcoholic Ferita Del Petto Zinfandel	1	decent	Last Available: "2006-12"
 928	nippy fuzzy bracelets	0		Cold Damage: +10
 929	red arse-shooting crossbow of Leguizamo	0		Monster Level: +20
 931	mediocre spiced rum	3	decent	
-932	fortified acceptable special fuchsia eggnog	5	good	Effect: "Hippy Flavor", Effect Duration: 50
-933	half-sized special stale ghostly candy cane	2	decent	Effect: "Cold as Ice", Effect Duration: 30
+932	acceptable fortified special fuchsia eggnog	5	good	Effect: "Hippy Flavor", Effect Duration: 50
+933	stale special half-sized ghostly candy cane	2	decent	Effect: "Cold as Ice", Effect Duration: 30
 934	adequate gingerbread bugbear	4	good	
 935	skewed imitation nice watch of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2004-12"
 936	squat Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -936,16 +936,16 @@
 946	gray skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	bad martini	3	decent	Last Available: "2004-12"
-949	perfectly mixed high-proof grogtini	10	EPIC	Last Available: "2004-12"
-950	drinkable spinning narrow cherry bomb	4	good	Last Available: "2004-12"
+949	high-proof perfectly mixed grogtini	10	EPIC	Last Available: "2004-12"
+950	drinkable narrow spinning cherry bomb	4	good	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	Socratic hockey mask of mayonnaise	0		Experience (Mysticality): +1, Sleaze Spell Damage: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	bouncing penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	censurious fez of etymology	0		Sleaze Resistance: +3, Familiar Effect: "1xLep, cap 30"
-956	bite-sized bland carob chunk noodles	1	decent	
-957	fancy decent jittery chorizo brownies	3	good	Effect: "Omphalotus Omnipresence", Effect Duration: 25
-958	normal half-sized chocolate and tomato pizza	2	good	
+956	bland bite-sized carob chunk noodles	1	decent	
+957	decent fancy jittery chorizo brownies	3	good	Effect: "Omphalotus Omnipresence", Effect Duration: 25
+958	half-sized normal chocolate and tomato pizza	2	good	
 959	red flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -996,20 +996,20 @@
 1009	fortified hand-crafted vodka martini	5	EPIC	
 1010	lousy whiskey and soda	4	decent	
 1011	bad monkey wrench	4	decent	
-1012	hand-crafted triple-distilled red tequila sunrise	6	EPIC	
-1013	practically non-alcoholic tolerable blurry green margarita	1	good	
+1012	triple-distilled hand-crafted red tequila sunrise	6	EPIC	
+1013	tolerable practically non-alcoholic green blurry margarita	1	good	
 1014	bad wobbly strawberry wine	4	decent	
-1015	weak artisanal wine spritzer	2	EPIC	
+1015	artisanal weak wine spritzer	2	EPIC	
 1016	tolerable perpendicular hula	3	good	
-1017	boozy enchanted acceptable fuchsia ducha de oro	5	good	Effect: "Cat Class, Cat Style", Effect Duration: 30
+1017	acceptable boozy enchanted fuchsia ducha de oro	5	good	Effect: "Cat Class, Cat Style", Effect Duration: 30
 1018	hand-crafted weak lime green calle de miel	2	EPIC	
 1019	smooth dry vodka martini	4	awesome	
-1020	weak acceptable old-fashioned	2	good	
-1021	watered-down drinkable tequila with training wheels	2	good	
+1020	acceptable weak old-fashioned	2	good	
+1021	drinkable watered-down tequila with training wheels	2	good	
 1022	acceptable squat sangria	4	good	
 1023	artisanal vesper	3	super ultra EPIC	Last Available: "2004-12"
 1024	enchanted tolerable bodyslam	4	good	Effect: "In the Slimelight", Effect Duration: 15, Last Available: "2004-12"
-1025	weak perfectly mixed sangria del diablo	2	super ultra mega turbo EPIC	Last Available: "2004-12"
+1025	perfectly mixed weak sangria del diablo	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	ghostly buckler buckle	0		
@@ -1030,10 +1030,10 @@
 1044	string of beads of the early riser	0		Adventures: +7
 1045	blinking Annie Oakley's plastic bottle opener	0		Critical Hit Percent: +20
 1046	shaking Oprah's cool traffic cone	0		Moxie: +5, Maximum MP Percent: +50, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	acceptable skewed green N. O. Beer	3	good	
-1048	mixed skewed fuchsia oyster egg	1		
+1047	acceptable green skewed N. O. Beer	3	good	
+1048	mixed fuchsia skewed oyster egg	1		
 1049	pickled jittery oyster egg	1		
-1050	pickled bouncing twirling oyster egg	1		Effect: "Lifted Spirits", Effect Duration: 25
+1050	pickled twirling bouncing oyster egg	1		Effect: "Lifted Spirits", Effect Duration: 25
 1051	blurry plastic oyster egg	0		
 1052	boiled ghostly oyster egg	1		Effect: "Transcendental Wind", Effect Duration: 25
 1053	diluted red tumbling oyster egg	1		
@@ -1051,10 +1051,10 @@
 1065	pickled tumbling ghostly oyster egg	1		
 1066	twisted oyster egg	1		
 1067	upside-down plastic oyster egg	0		
-1068	dehydrated mirror olive oyster egg	1		
-1069	modified blinking wobbly oyster egg	1		
+1068	dehydrated olive mirror oyster egg	1		
+1069	modified wobbly blinking oyster egg	1		
 1070	dried spinning oyster egg	1		
-1071	red tumbling plastic oyster egg	0		
+1071	tumbling red plastic oyster egg	0		
 1072	mixed blurry off-white oyster egg	1		Effect: "Peppermint Bite", Effect Duration: 15
 1073	boiled off-white oyster egg	1		Effect: "Super-Mega-Charged", Effect Duration: 10
 1074	altered tumbling off-white oyster egg	1		
@@ -1123,7 +1123,7 @@
 1137	bicycle chain of the wise owl of Calamity Jane	0		Mysticality: +20, Critical Hit Percent: +15
 1138	skewed mushroom fermenting solution	0		
 1139	weak bad mushroom wine	2	decent	
-1140	artisanal weak icy mushroom wine	2	EPIC	
+1140	weak artisanal icy mushroom wine	2	EPIC	
 1141	triple-distilled aged mushroom wine	6	awesome	
 1142	artisanal weak pointy mushroom wine	2	EPIC	
 1143	tolerable twirling flat mushroom wine	4	good	
@@ -1131,7 +1131,7 @@
 1145	perfectly mixed knob mushroom wine	4	EPIC	
 1146	watered-down smooth blurry knoll mushroom wine	2	awesome	
 1147	bad mushroom wine	3	decent	
-1148	practically non-alcoholic hand-crafted bouncing shot of flower schnapps	1	EPIC	
+1148	hand-crafted practically non-alcoholic bouncing shot of flower schnapps	1	EPIC	
 1149	bland flower petal pie	3	decent	
 1150	acceptable blurry bottle of single-barrel whiskey	3	good	
 1151	hale discarded plastic fork of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +20
@@ -1148,7 +1148,7 @@
 1163	boiled deionized marzipan skull	0		Effect: "Spooky Blur", Effect Duration: 33
 1164	poultrygeist	0		
 1165	hovering sombrero	0		
-1166	spinning skewed blinking maracas	0		Familiar Weight: +5
+1166	blinking spinning skewed maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	less-than-three-shaped box	0		
 1169	spinning exactly-three-shaped box	0		
@@ -1157,7 +1157,7 @@
 1172	narrow asbestos box	0		
 1173	spinning linoleum box	0		
 1174	chrome box	0		
-1175	maroon jittery cryptic puzzle box	0		
+1175	jittery maroon cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	spinning magnetic field	0		
 1178	twirling maroon potted cactus	0		
@@ -1166,7 +1166,7 @@
 1181	tulip	0		
 1182	Venus flytrap	0		
 1183	all-purpose flower	0		
-1184	jittery ghostly exotic orchid	0		
+1184	ghostly jittery exotic orchid	0		
 1185	long-stemmed rose	0		
 1186	gilded lily	0		
 1187	deadly nightshade	0		
@@ -1182,16 +1182,16 @@
 1197	Mob Penguin	0		
 1198	mirror sabre-toothed lime	0		
 1199	bugbear	0		
-1200	small moldy wobbly pulsating mugcake	2	crappy	
+1200	moldy small wobbly pulsating mugcake	2	crappy	
 1201	decent spinning urinal cake	4	good	
 1202	moldy Happy Birthday, Claude! cake	3	crappy	
 1203	adequate immense upside-down personalized birthday cake	8	good	
-1204	rotten fancy shaking three-tiered wedding cake	3	crappy	Effect: "Crocodile Tear", Effect Duration: 5
-1205	flavorless pulsating jittery babycakes	4	decent	
+1204	fancy rotten shaking three-tiered wedding cake	3	crappy	Effect: "Crocodile Tear", Effect Duration: 5
+1205	flavorless jittery pulsating babycakes	4	decent	
 1206	toothsome olive velvet cake	4	awesome	
 1207	adequate congratulatory cake	3	good	
-1208	bland bite-sized angel-food cake	1	decent	
-1209	tiny tasty devil's-food cake	1	awesome	
+1208	bite-sized bland angel-food cake	1	decent	
+1209	tasty tiny devil's-food cake	1	awesome	
 1210	bland birthday party jellybean cheesecake	4	decent	
 1211	balloon	0		
 1212	balloon	0		
@@ -1228,11 +1228,11 @@
 1244	Glass Balls of the Goblin King of the scaredy-cat	0		Monster Level: -15
 1245	wizardly Codpiece of the Goblin King	0		Mysticality: +25, Single Equip
 1246	scandalous baleful grievous rib of the Bonerdagon	0		Weapon Damage Percent: +50, Spell Damage: +25, Sleaze Damage: +5
-1247	shaking blurry vertebra of the Bonerdagon	0		
+1247	blurry shaking vertebra of the Bonerdagon	0		
 1248	squat inspector's Bonerdagon necklace of the wise owl of the blizzard	0		Mysticality: +20, Cold Spell Damage: +25, Item Drop: +15
 1249	Usain Bolt's Boss Bat britches	0		Initiative: +80, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	Boss Bat bling of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Stench Spell Damage: +50
-1251	delicious big fancy skewed Knob shroomkabob	5	awesome	Effect: "Infernal Thirst", Effect Duration: 15
+1251	big fancy delicious skewed Knob shroomkabob	5	awesome	Effect: "Infernal Thirst", Effect Duration: 15
 1252	moldy small shroomkabob	2	crappy	
 1253	pile of jumping beans	0		
 1254	small moldy jumping bean burrito	2	crappy	
@@ -1242,12 +1242,12 @@
 1258	pail of pretentious paint	0		
 1259	upside-down flame-wreathed beefy traffic cone	0		Muscle: +10, Hot Spell Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	spinning bouncing wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	twisted narrow jittery Hatorade	1		
+1261	twisted jittery narrow Hatorade	1		
 1262	Usain Bolt's razor-sharp deadly off-hand balloon	0		Weapon Damage: +5, Weapon Damage Percent: +25, Initiative: +80
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	blurry gray nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	thick moldy gloomy mushroom	5	crappy	
+1266	moldy thick gloomy mushroom	5	crappy	
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	ebony wand	0		
@@ -1302,7 +1302,7 @@
 1318	spinning lovecat tail	0		
 1319	plastic passion fruit	0		
 1320	rotten questionable taco	4	crappy	
-1321	spinning blinking mirror Doc's Miracle Cure	0		Last Available: "2011-12"
+1321	mirror blinking spinning Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	dangerous time helmet	0		Weapon Damage: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
 1324	mirror tumbling executive time trousers	0		Meat Drop: +40, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
@@ -1313,7 +1313,7 @@
 1329	squat Sinatra's Dyspepsi-Cola shield	0		Experience (Moxie): +5, Damage Reduction: 4
 1330	electrified Dyspepsi-Cola fatigues	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "3.5xPotato, 3xVolley, cap 7"
 1331	Rosewater's Cloaca-Cola helmet	0		Mysticality Percent: +30, Familiar Effect: "3xFairy, cap 7"
-1332	lime green shaking Cloaca-Cola knapsack	0		
+1332	shaking lime green Cloaca-Cola knapsack	0		
 1333	mirror Dyspepsi-Cola knapsack	0		
 1334	Cloaca-Cola	0		
 1335	Dyspepsi grenade	0		
@@ -1324,7 +1324,7 @@
 1341	hardened Dyspepsi-Cola-issue canteen	0		Damage Reduction: 3, Single Equip
 1342	picture of a dead guy's girlfriend	0		
 1343	twirling twirling zombie pineal gland	0		Last Available: "2005-11"
-1344	energized maroon upside-down Gummi-Gnauga	0		Effect: "White Knuckles", Effect Duration: 13
+1344	energized upside-down maroon Gummi-Gnauga	0		Effect: "White Knuckles", Effect Duration: 13
 1345	galvanized Now and Earlier	0		Effect: "Dragged Through the Coals", Effect Duration: 67, Last Available: "2020-09"
 1346	ionized squat Sugar Cog	0		Effect: "Cosmic Flavor", Effect Duration: 28
 1347	loaded serum blowgun	0		Last Available: "2005-11"
@@ -1334,7 +1334,7 @@
 1351	groovy pinky ring	0		Moxie Percent: +10, Single Equip
 1352	drinkable distilled jittery redrum	5	good	
 1353	ninja pirate zombie robot	0		
-1354	blurry twirling pile of pebbles	0		
+1354	twirling blurry pile of pebbles	0		
 1355	bland diet bowl of oriole's nest soup	1	decent	
 1356	bunny liver	0		
 1357	mediocre Mt. Noob Pale Ale	3	decent	
@@ -1346,7 +1346,7 @@
 1363	spinning clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	bland squat tofurkey leg	3	decent	
-1366	stale low-calorie tofurkey gravy	1	decent	
+1366	low-calorie stale tofurkey gravy	1	decent	
 1367	flavorless herbal stuffing	3	decent	
 1368	normal narrow can-shaped gelatinous cranberry sauce	3	good	
 1369	half-sized bland huge yams	2	decent	
@@ -1385,9 +1385,9 @@
 1403	Van der Graaf can of fake snow	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2005-12"
 1404	blurry auspicious colored-light &quot;necklace&quot;	0		Item Drop: +10, Last Available: "2005-12"
 1405	rosewater-soaked tree skirt	0		Stench Resistance: +3, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	delicious small wreath-shaped Crimbo cookie	2	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	small delicious wreath-shaped Crimbo cookie	2	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	jumbo rotten wobbly bell-shaped Crimbo cookie	5	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	immense spoiled tree-shaped Crimbo cookie	7	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	spoiled immense tree-shaped Crimbo cookie	7	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	therapeutic Unionize The Elves sign	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
@@ -1409,7 +1409,7 @@
 1427	groovy ice skates of James Dean	0		Moxie Percent: +10, Experience (Moxie): +3, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	moldy big spinning grue egg omelette	5	crappy	
 1429	huge roll of drink tickets	0		
-1430	huge blinking lime green pregnant gloomy mushroom	0		
+1430	blinking huge lime green pregnant gloomy mushroom	0		
 1431	upside-down pregnant mushroom	0		
 1432	adequate mushroom	3	good	
 1433	tumbling fruit bowl	0		
@@ -1434,7 +1434,7 @@
 1452	mixed tumbling narrow red wad	1		
 1453	boiled wad	1		Effect: "Quiet 'n' Good", Effect Duration: 10
 1454	powdered stench wad	1		
-1455	diluted tumbling maroon sleaze wad	1		
+1455	diluted maroon tumbling sleaze wad	1		
 1456	double daisy	0		
 1457	upside-down skewed Goth Giant	0		
 1458	normal Valentine's Day cake	3	good	
@@ -1443,7 +1443,7 @@
 1461	squashed frog	0		
 1462	mirror eye of newt	0		
 1463	tumbling salamander spleen	0		
-1464	huge yellow sleazy fairy gravy	0		
+1464	yellow huge sleazy fairy gravy	0		
 1465	suede shortsword	0		
 1466	bamboo bokuto	0		
 1467	25-meat staff	0		
@@ -1475,7 +1475,7 @@
 1493	supercool ridiculously overelaborate ninja weapon of Gandalf	0		Moxie Percent: +20, Spell Critical Percent: +20
 1494	deionized sugar-coated pine cone	0		Effect: "Superheroic", Effect Duration: 66, Last Available: "2020-09"
 1495	family-friendly fireproof traffic cone	0		Hot Resistance: +3, Sleaze Resistance: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	triple-distilled bad wobbly gloomy mushroom wine	7	decent	
+1496	bad triple-distilled wobbly gloomy mushroom wine	7	decent	
 1497	smooth mushroom wine	3	awesome	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1486,24 +1486,24 @@
 1504	double-adjusted super-magnetized extra-nitrogenated snowcone	0		Effect: "Good Motivator", Effect Duration: 17, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	hand-crafted calle de miel with a fly in it	4	EPIC	Last Available: "2006-04"
-1507	acceptable pulsating tumbling rockin' wagon with a fly in it	4	good	Last Available: "2006-04"
+1507	acceptable tumbling pulsating rockin' wagon with a fly in it	4	good	Last Available: "2006-04"
 1508	bad perpendicular hula with a fly in it	3	decent	Last Available: "2006-04"
 1509	smooth slap and tickle with a fly in it	4	awesome	Last Available: "2006-04"
 1510	shaking bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of the scaredy-cat	0		Monster Level: -15, Last Available: "2006-04"
-1512	distilled mirror ghostly Knob Goblin pet-buffing spray	1		
+1512	distilled ghostly mirror Knob Goblin pet-buffing spray	1		
 1513	mixed green tumbling Knob Goblin learning pill	1		
 1514	altered Knob Goblin eyedrops	1		Effect: "You Ate Some Hemp Candy", Effect Duration: 50
 1515	denatured mirror red Knob Goblin nasal spray	1		
-1516	wobbly ghostly KWE-brand transistor radio	0		
+1516	ghostly wobbly KWE-brand transistor radio	0		
 1518	vampire heart	0		
-1519	tumbling bouncing Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
+1519	bouncing tumbling Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	lightning-fast beefcake's Radio KoL Coffee Mug	0		Muscle: +25, Initiative: +40
 1521	Frank Gorshin trophy	0		
 1522	crafty extremely unsafe Radio Free Jersey	0		Weapon Damage Percent: +100, Maximum MP: +10
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	wobbly pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	blue censurious corkscrew of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3, Last Available: "2006-04"
@@ -1530,10 +1530,10 @@
 1550	foul-smelling second-hand knockoff engagement ring	0		Stench Damage: +10, Single Equip
 1551	artisanal bottle of Domesticated Turkey	3	EPIC	
 1552	perfectly mixed bottle of Definit	4	EPIC	
-1553	tolerable practically non-alcoholic gray bottle of Calcutta Emerald	1	good	
+1553	practically non-alcoholic tolerable gray bottle of Calcutta Emerald	1	good	
 1554	lousy blurry bottle of Lieutenant Freeman	3	decent	
 1555	lousy fuchsia bottle of Jorge Sinsonte	4	decent	
-1556	practically non-alcoholic drinkable blinking boxed champagne	1	good	
+1556	drinkable practically non-alcoholic blinking boxed champagne	1	good	
 1557	decent super-sized twirling kumquat	5	good	
 1558	adequate half-sized tangerine	2	good	
 1559	tonic water	0		
@@ -1542,38 +1542,38 @@
 1562	rotten kiwi	3	crappy	
 1563	mediocre whiskey bittersweet	3	decent	
 1564	perfectly mixed ghostly mimosette	4	EPIC	
-1565	special practically non-alcoholic bad teal tequila sunset	1	decent	Effect: "Hot Jellied", Effect Duration: 20
+1565	special bad practically non-alcoholic teal tequila sunset	1	decent	Effect: "Hot Jellied", Effect Duration: 20
 1566	weak delicious zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
 1567	bad gin and tonic	4	decent	
 1568	hand-crafted vodka and tonic	3	EPIC	
 1569	tolerable tumbling vodka gibson	3	good	
 1570	acceptable wobbly gibson	4	good	
-1571	drinkable practically non-alcoholic parisian cathouse	1	good	
-1572	acceptable fancy watered-down mirror rabbit punch	2	good	Effect: "Baconstoned", Effect Duration: 5
+1571	practically non-alcoholic drinkable parisian cathouse	1	good	
+1572	watered-down acceptable fancy mirror rabbit punch	2	good	Effect: "Baconstoned", Effect Duration: 5
 1573	aged caipifruta	3	awesome	
 1574	perfectly mixed enchanted teqiwila	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50
-1575	hand-crafted watered-down Divine	2	super ultra EPIC	
+1575	watered-down hand-crafted Divine	2	super ultra EPIC	
 1576	tolerable Gordon Bennett	4	good	
-1577	practically non-alcoholic lousy tangarita	1	decent	
+1577	lousy practically non-alcoholic tangarita	1	decent	
 1578	perfectly mixed practically non-alcoholic mandarina colada	1	super ultra mega turbo EPIC	
 1579	artisanal shaking gimlet	3	EPIC	
-1580	artisanal watered-down fancy brick road	2	super ultra EPIC	Effect: "One For Tea", Effect Duration: 40
-1581	boozy hand-crafted shaking vodka stratocaster	5	EPIC	
+1580	watered-down artisanal fancy brick road	2	super ultra EPIC	Effect: "One For Tea", Effect Duration: 40
+1581	hand-crafted boozy shaking vodka stratocaster	5	EPIC	
 1582	tolerable watered-down Neuromancer	2	good	
 1583	hand-crafted practically non-alcoholic prussian cathouse	1	super ultra mega turbo EPIC	
 1584	lousy Mae West	3	decent	
-1585	drinkable triple-distilled olive Mon Tiki	6	good	
-1586	bad high-proof teqiwila slammer	6	decent	
-1587	bite-sized moldy wobbly Knob lo mein	1	crappy	
+1585	triple-distilled drinkable olive Mon Tiki	6	good	
+1586	high-proof bad teqiwila slammer	6	decent	
+1587	moldy bite-sized wobbly Knob lo mein	1	crappy	
 1588	bland asparagus lo mein	4	decent	
-1589	bite-sized stale Knoll lo mein	1	decent	
+1589	stale bite-sized Knoll lo mein	1	decent	
 1590	rotten small lo mein	2	crappy	
 1591	moldy miniature olive lo mein	2	crappy	
-1592	toothsome tiny hot hi mein	1	awesome	
+1592	tiny toothsome hot hi mein	1	awesome	
 1593	super-sized moldy hi mein	5	crappy	
 1594	decent hi mein	3	good	
 1595	moldy hi mein	3	crappy	
-1596	thick toothsome sleazy hi mein	5	awesome	
+1596	toothsome thick sleazy hi mein	5	awesome	
 1597	jittery yellow Junior LAAAAME merit badge of the pedagogue	0		Experience: +3, Last Available: "2006-05"
 1598	aromatic Senior LAAAAME merit badge	0		Stench Resistance: +1, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
@@ -1604,13 +1604,13 @@
 1624	cold-filtered blue-frosted astral cupcake	0		Effect: "Nightstalkin'", Effect Duration: 27, Last Available: "2006-06"
 1625	super-vacuum-sealed green-frosted astral cupcake	0		Effect: "Twinkly Weapon", Effect Duration: 51, Last Available: "2006-06"
 1626	irradiated orange-frosted astral cupcake	0		Effect: "Floundering", Effect Duration: 54, Last Available: "2006-06"
-1627	non-cold-filtered teal skewed purple-frosted astral cupcake	0		Effect: "Celestial Sheen", Effect Duration: 57, Last Available: "2006-06"
+1627	non-cold-filtered skewed teal purple-frosted astral cupcake	0		Effect: "Celestial Sheen", Effect Duration: 57, Last Available: "2006-06"
 1628	liquefied extra-galvanized pink-frosted astral cupcake	0		Effect: "Pill Power", Effect Duration: 18, Last Available: "2006-06"
 1629	Lo Pan's raspberry beret	0		Spell Critical Percent: +30, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	Oprah's pixel shield	0		Maximum MP Percent: +50, Damage Reduction: 3
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
-1633	shaking jittery Spanish fly	0		
+1633	jittery shaking Spanish fly	0		
 1634	bad around the world	4	decent	
 1635	squat scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
@@ -1619,18 +1619,18 @@
 1639	concentrated dry blue lotion of spookiness	0		Effect: "Nas Tea", Effect Duration: 19
 1640	aerosolized bouncing lotion of stench	0		Effect: "Dancing Prowess", Effect Duration: 37
 1641	non-polymerized enhanced squat lotion of sleaziness	0		Effect: "Proprie Tea", Effect Duration: 26
-1642	perfectly mixed weak gray Grimacite Bock	2	EPIC	Last Available: "2008-11"
+1642	weak perfectly mixed gray Grimacite Bock	2	EPIC	Last Available: "2008-11"
 1643	normal wedge of gray cheese	3	good	Last Available: "2008-11"
-1644	squat gray hot and sauce	0		
+1644	gray squat hot and sauce	0		
 1645	upside-down and sauce	0		
 1646	ghostly and sauce	0		
 1647	stench and sauce	0		
-1648	spinning huge sleazy and sauce	0		
+1648	huge spinning sleazy and sauce	0		
 1649	ghostly brick	0		Free Pull
 1650	milk of magnesium	0		
 1651	moldy half-sized mirror foie gras	2	crappy	
 1652	super-tarnished yellow narrow tumbling candy brain	0		Effect: "OMG WTF", Effect Duration: 62, Last Available: "2020-09"
-1653	stiffened jewel-eyed wizard hat of Gandalf of the blizzard	0		Damage Reduction: 1, Spell Critical Percent: +20, Cold Spell Damage: +25, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	stiffened jewel-eyed wizard hat of Gandalf of the blizzard	0		Damage Reduction: 1, Spell Critical Percent: +20, Cold Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	healthy baleful wad of Crovacite	0		Spell Damage: +25, Maximum HP Percent: +20
 1655	asbestos-lined groovy collar	0		Moxie Percent: +10, Hot Resistance: +5
 1656	White Citadel Satisfaction Satchel	0		
@@ -1673,10 +1673,10 @@
 1693	triple-dry eyedrops of newt	0		Effect: "Ermine Eyes", Effect Duration: 21
 1694	adjusted quantum Frogade	0		Effect: "Ack!  Barred!", Effect Duration: 15
 1695	extra-anodized adjusted blurry papotion of papower	0		Effect: "Drenched With Filth", Effect Duration: 61
-1696	jumbo rotten royal jelly taco	5	crappy	
+1696	rotten jumbo royal jelly taco	5	crappy	
 1697	rotten tofu taco	4	crappy	
 1698	stale jumping bean taco	3	decent	
-1699	bland bite-sized catgut taco	1	decent	
+1699	bite-sized bland catgut taco	1	decent	
 1700	normal miniature jittery goat cheese taco	2	good	
 1701	decent big blue pr0n taco	5	good	
 1702	magnetized teal alphabet gum	0		Effect: "Disdain of the War Snapper", Effect Duration: 63
@@ -1754,7 +1754,7 @@
 1775	squat grievous dishrag	0		Weapon Damage Percent: +50
 1776	spoiled big stale baguette	5	crappy	
 1777	leftovers of indeterminate origin	0		
-1778	toothsome miniature dinner	2	awesome	
+1778	miniature toothsome dinner	2	awesome	
 1779	teal squat energetic katana	0		Maximum MP Percent: +20
 1780	jittery coward's ram stick	0		Monster Level: -20
 1781	occult enchantlers	0		Spell Damage Percent: +25, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1766,7 +1766,7 @@
 1787	deionized polarized vacuum-sealed lime green bag of Cheat-Os	0		Effect: "Spiro Gyro", Effect Duration: 55
 1788	unrefined Mountain Stream syrup	0		
 1789	blinking Mob Penguin	0		
-1790	watered-down smooth Ram's Face Lager	2	awesome	
+1790	smooth watered-down Ram's Face Lager	2	awesome	
 1791	wobbly ram horns	0		
 1792	pulsating arcane researcher's Travoltan trousers of Leguizamo of the cheetah	0		Experience Percent (Mysticality): +10, Monster Level: +20, Initiative: +60, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	ghostly hale pool cue of chilblains	0		Maximum HP: +20, Cold Damage: +25
@@ -1827,7 +1827,7 @@
 1848	left tenth rib	0		
 1849	left eleventh rib	0		
 1850	left twelfth rib	0		
-1851	jittery skewed right first rib	0		
+1851	skewed jittery right first rib	0		
 1852	squat right second rib	0		
 1853	right third rib	0		
 1854	right fourth rib	0		
@@ -1843,7 +1843,7 @@
 1864	left scapula	0		
 1865	narrow right scapula	0		
 1866	left clavicle	0		
-1867	ghostly blinking right clavicle	0		
+1867	blinking ghostly right clavicle	0		
 1868	left humerus	0		
 1869	right humerus	0		
 1870	left radius	0		
@@ -1883,7 +1883,7 @@
 1904	up-at-dawn executive 5-ball	0		Meat Drop: +40, Adventures: +5
 1905	lightning-fast Socratic 6-ball	0		Experience (Mysticality): +1, Initiative: +40
 1906	7-ball of courage	0		Spooky Resistance: +3
-1907	huge narrow 8-ball	0		
+1907	narrow huge 8-ball	0		
 1910	aromatic clockwork sword of the brute of the businessman	0		Muscle Percent: +30, Stench Resistance: +1, Meat Drop: +50
 1911	knitted Oprah's clockwork staff of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Cold Resistance: +3
 1912	mirror Jack Frost's smartaleck's slick clockwork crossbow	0		Moxie: +10, Moxie Percent: +30, Cold Spell Damage: +50
@@ -1901,7 +1901,7 @@
 1924	shaking tattered wolf standard	0		
 1925	blue tattered snake standard	0		
 1926	KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
-1927	tumbling jittery narrow scary death orb	0		
+1927	jittery tumbling narrow scary death orb	0		
 1928	red tuning fork	0		
 1929	greaves of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xBarrr"
 1930	bouncing asbestos-lined helmet of courage	0		Hot Resistance: +5, Spooky Resistance: +3, Familiar Effect: "0.5xPotato, 0.5xFairy"
@@ -1923,15 +1923,15 @@
 1946	Rosewater's accordion pin of the ox	0		Muscle: +20, Mysticality Percent: +30, Class: "Accordion Thief", Single Equip
 1947	maroon ribald horrifying worn tophat	0		Spooky Damage: +25, Sleaze Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	horrifying medical-grade tap shoes	0		Spooky Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-1949	big rotten ghostly Manetwich	5	crappy	
+1949	rotten big ghostly Manetwich	5	crappy	
 1950	lime green bottle of Vangoghbitussin	0		
-1951	acceptable practically non-alcoholic ghostly bottle of Pinot Renoir	1	good	
+1951	practically non-alcoholic acceptable ghostly bottle of Pinot Renoir	1	good	
 1952	small normal desiccated apricot	2	good	
 1953	smooth flute of flat champagne	3	awesome	
 1954	rotten enchanted dehydrated caviar	4	crappy	Effect: "Inappropriate Spirit", Effect Duration: 30
 1955	styrofoam peanuts	0		
 1956	bad snifter of thoroughly aged brandy	3	decent	
-1957	blurry teal blinking quill pen	0		
+1957	blurry blinking teal quill pen	0		
 1958	inkwell	0		
 1959	mirror tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
@@ -1943,7 +1943,7 @@
 1966	squat perfumed Annie Oakley's Amulet of Yendor	0		Critical Hit Percent: +20, Stench Resistance: +5, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	mirror bottle of perfume	0		Familiar Weight: +5
-1969	ghostly skewed mirror spoon!	0		Familiar Weight: +5
+1969	skewed mirror ghostly spoon!	0		Familiar Weight: +5
 1970	nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	flame-retardant shrimp fork of the boozehound	0		Hot Resistance: +1, Booze Drop: +100
@@ -1994,15 +1994,15 @@
 2017	jittery spade necklace	0		
 2018	twirling club necklace	0		
 2019	cream pie	0		Free Pull
-2020	tasty thick cherry pie	5	awesome	
+2020	thick tasty cherry pie	5	awesome	
 2021	half-sized adequate strawberry pie	2	good	
-2022	jumbo tasty lemon meringue pie	5	awesome	
+2022	tasty jumbo lemon meringue pie	5	awesome	
 2023	Genalen&trade; Bottle	1	good	
-2024	massive normal bouncing mixed wildflower greens	10	good	
+2024	normal massive bouncing mixed wildflower greens	10	good	
 2025	adequate handful of walnuts	4	good	
-2026	massive stale nutty organic salad	9	decent	
+2026	stale massive nutty organic salad	9	decent	
 2027	decent super salad	4	good	
-2028	adequate pulsating green tofu wonton	4	good	
+2028	adequate green pulsating tofu wonton	4	good	
 2029	hippy protest button	0		Single Equip
 2030	Lockenstock&trade; sandals of the dark arts of Gandalf	0		Spell Damage Percent: +100, Spell Critical Percent: +20, Single Equip
 2031	extremely unsafe didgeridooka	0		Weapon Damage Percent: +100
@@ -2021,7 +2021,7 @@
 2044	blurry your father's MacGuffin diary	0		
 2045	snack-sized tasty pulsating skewed brain-meltingly-hot chicken wings	2	awesome	
 2046	normal blue frat brats	3	good	
-2047	spoiled miniature knob ka-bobs	2	crappy	
+2047	miniature spoiled knob ka-bobs	2	crappy	
 2049	acceptable extra-dry bouncing can of Swiller	5	good	
 2050	broken wings	0		
 2051	sunken eyes	0		
@@ -2061,7 +2061,7 @@
 2085	vaporized skewed bottle of ultravitamins	1		
 2086	powdered huge bottle of cough syrup	1		Effect: "Big", Effect Duration: 30
 2087	compressed tumbling tube of hair oil	1		
-2088	wet Vulcanized bouncing purple pulsating Daffy Taffy	0		Effect: "Cold Throat", Effect Duration: 20
+2088	wet Vulcanized bouncing pulsating purple Daffy Taffy	0		Effect: "Cold Throat", Effect Duration: 20
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	purple Usain Bolt's stanky extremely unsafe thinker's pilgrim shield of the glutton	0		Mysticality: +10, Weapon Damage Percent: +100, Stench Spell Damage: +25, Food Drop: +100, Initiative: +80, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
@@ -2072,16 +2072,16 @@
 2096	diluted twirling guy made of bee pollen	1		
 2097	Jack Frost's 17-ball	0		Cold Spell Damage: +50
 2098	filthy lucre	0		
-2099	blue narrow hobo gristle	0		
+2099	narrow blue hobo gristle	0		
 2100	squat shredded can label	0		
 2101	blinking bloodstained briquette	0		
 2102	ghostly greasy dreadlock	0		
 2103	vial of pirate sweat	0		
 2104	yellow empty aftershave bottle	0		
 2105	blinking coal button	0		
-2106	jittery tumbling burned-out arcanodiode	0		
+2106	tumbling jittery burned-out arcanodiode	0		
 2107	bouncing non-Euclidean hoof	0		
-2108	huge bouncing rock	0		
+2108	bouncing huge rock	0		
 2109	stringy sinew	0		Last Available: "2011-12"
 2110	stick	0		Last Available: "2011-12"
 2111	tumbling tooth	0		
@@ -2137,7 +2137,7 @@
 2162	tumbling reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
-2165	tumbling gray atomic vector plotter	0		Last Available: "2011-12"
+2165	gray tumbling atomic vector plotter	0		Last Available: "2011-12"
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	pulsating huge hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	thinker's toy ray gun of terror	0		Mysticality: +10, Spooky Spell Damage: +10, Last Available: "2006-12"
@@ -2165,14 +2165,14 @@
 2190	tumbling yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	small adequate wobbly candy stake	2	good	Last Available: "2006-12"
+2193	adequate small wobbly candy stake	2	good	Last Available: "2006-12"
 2194	bad eggnog	4	decent	Last Available: "2006-12"
 2195	decent unspeakable fruitcake	3	good	Last Available: "2006-12"
 2196	enchanted stale gingerbread horror	4	decent	Effect: "Flambé-a-thon", Effect Duration: 40, Last Available: "2006-12"
 2197	dry Vulcanized tumbling but probably evil chocolate	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 36, Last Available: "2006-12"
 2198	spoiled bat-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	small bland ghostly skull-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	jumbo bland tombstone-shaped Crimboween cookie	5	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	bland jumbo tombstone-shaped Crimboween cookie	5	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	frightening plastic gift-wrapping vampire	0		Spooky Damage: +5, Last Available: "2006-12"
 2202	smartaleck's plastic yuletide troll	0		Moxie Percent: +30, Last Available: "2006-12"
 2203	huge rosewater-soaked plastic skeletal reindeer	0		Stench Resistance: +3, Single Equip, Last Available: "2006-12"
@@ -2190,7 +2190,7 @@
 2215	blurry Lo Pan's Tropical Crimbo Hat	0		Spell Critical Percent: +30, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	hardy Tropical Crimbo Shorts	0		Maximum HP: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	yummy snack-sized super ka-bob	2	awesome	
-2218	snack-sized fancy normal spinning beer basted brat	2	good	Effect: "Locks Like the Raven", Effect Duration: 30
+2218	normal fancy snack-sized spinning beer basted brat	2	good	Effect: "Locks Like the Raven", Effect Duration: 30
 2219	rock-hard Tropical Crimbo Sword	0		Damage Reduction: 5, Last Available: "2006-12"
 2220	altered super-dry and Crimboween candy	0		Effect: "Marco Polarity", Effect Duration: 34, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2208,7 +2208,7 @@
 2233	wobbly mirror nasty bow tie	0		Stench Damage: +5, Clowniness: 75
 2234	jittery bouncing fortified calavera concertina	0		Damage Absorption: +60, Song Duration: 7
 2235	cyan hardened baleful ratarang	0		Spell Damage: +25, Damage Reduction: 3
-2236	altered nitrogenated blurry maroon turtle pheromones	0		Effect: "Polka Face", Effect Duration: 57
+2236	altered nitrogenated maroon blurry turtle pheromones	0		Effect: "Polka Face", Effect Duration: 57
 2237	pygmy blowgun	0		
 2238	bouncing aromatic pygmy nose-bone	0		Stench Resistance: +1, Single Equip
 2239	perfumed supercool bad voodoo mask	0		Moxie Percent: +20, Stench Resistance: +5, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
@@ -2243,9 +2243,9 @@
 2269	yummy sausage wonton	3	awesome	
 2270	upside-down nasty belt of extreme caution	0		Monster Level: -25, Stench Damage: +5, Single Equip
 2271	mediocre irresponsibly strong spinning bottle of Merlot	10	decent	
-2272	perfectly mixed enchanted blurry bottle of Port	4	EPIC	Effect: "Mariachi Mood", Effect Duration: 45
+2272	enchanted perfectly mixed blurry bottle of Port	4	EPIC	Effect: "Mariachi Mood", Effect Duration: 45
 2273	delicious bottle of Pinot Noir	3	awesome	
-2274	watered-down bad bottle of Zinfandel	2	decent	
+2274	bad watered-down bottle of Zinfandel	2	decent	
 2275	aged bottle of Marsala	4	awesome	
 2276	weak mediocre huge bottle of Muscat	2	decent	
 2277	mirror Fernswarthy's key	0		
@@ -2294,17 +2294,17 @@
 2320	worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
 2322	teal worm-riding manual pages 3-15	0		
-2323	jittery maroon headpiece of the Staff of Ed	0		
+2323	maroon jittery headpiece of the Staff of Ed	0		
 2324	Staff of Ed, almost	0		
 2325	Staff of Ed	0		
 2326	stone rose	0		
-2327	extra-chilled irradiated shaking green can of paint	0		Effect: "Shawarma Warm War", Effect Duration: 53
+2327	extra-chilled irradiated green shaking can of paint	0		Effect: "Shawarma Warm War", Effect Duration: 53
 2328	mirror drum machine	0		
 2329	handful of confetti	0		
 2330	teal chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
 2332	massive rotten Better Than Cuddling Cake	10	crappy	
-2333	tumbling ghostly ninja snowman	0		
+2333	ghostly tumbling ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	wobbly rubber WWBBDD? bracelet	0		
 2336	auspicious Fonzie's pipe	0		Experience (Moxie): +1, Item Drop: +10
@@ -2314,7 +2314,7 @@
 2340	perfectly mixed weak blurry & tan	2	EPIC	
 2341	pepper	0		
 2342	moldy forest cake	3	crappy	
-2343	adequate gigantic forest ham	6	good	
+2343	gigantic adequate forest ham	6	good	
 2344	electrified filthworm hatchling scent gland	0		Effect: "Stinkybeard", Effect Duration: 66
 2345	warmed filthworm drone scent gland	0		Effect: "Squirming Like a Toad", Effect Duration: 33
 2346	boiled polarized filthworm royal guard scent gland	0		Effect: "Stop the Presses!", Effect Duration: 17
@@ -2325,9 +2325,9 @@
 2351	superamplified boom box	0		
 2352	hardy stiffened fire poi	0		Damage Reduction: 1, Maximum HP: +50
 2353	bejeweled pledge pin of bravery	0		Spooky Resistance: +5, Single Equip
-2354	maroon bouncing communications windchimes	0		
+2354	bouncing maroon communications windchimes	0		
 2355	oxidized improved henna face paint	0		Effect: "Ruthlessly Efficient", Effect Duration: 65
-2356	oxidized non-wet squat cyan tube of dread wax	0		Effect: "On the Shoulders of Giants", Effect Duration: 47
+2356	oxidized non-wet cyan squat tube of dread wax	0		Effect: "On the Shoulders of Giants", Effect Duration: 47
 2357	fireproof Da Vinci's Gaia beads	0		Experience (Mysticality): +5, Hot Resistance: +3
 2358	pink clay bead	0		
 2359	fuchsia tumbling clay bead	0		
@@ -2347,8 +2347,8 @@
 2373	tasty bouncing banana	3	awesome	
 2374	banana peel	0		
 2375	adequate banana cream pie	4	good	
-2376	perfectly mixed twirling narrow banana daiquiri	4	EPIC	
-2377	practically non-alcoholic smooth pulsating bungle in the jungle	1	awesome	
+2376	perfectly mixed narrow twirling banana daiquiri	4	EPIC	
+2377	smooth practically non-alcoholic pulsating bungle in the jungle	1	awesome	
 2378	blinking banana spritzer	0		
 2379	frozen banana smoothie	0		Effect: "Mistified", Effect Duration: 40
 2380	blinking dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2368,7 +2368,7 @@
 2394	purple Tesla Newton's Danglin' Chad's loincloth	0		Experience (Mysticality): +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "stench atk, 0.5xVolley"
 2395	blinking gravedigger's tube sock	0		Spooky Damage: +10, Single Equip
 2396	chloroform rag	0		
-2397	green wobbly depantsing bomb	0		
+2397	wobbly green depantsing bomb	0		
 2398	blinking Newton's energy drink IV	0		Experience (Mysticality): +3, Single Equip
 2399	squat Fonzie's brainy Elmley shades	0		Mysticality: +5, Experience (Moxie): +1, Single Equip
 2400	blurry molotov cocktail cocktail	0		
@@ -2378,7 +2378,7 @@
 2404	squat jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
-2407	purple narrow pink bat eye	0		
+2407	narrow purple pink bat eye	0		
 2408	shaking worthless piece of glass	0		
 2409	blinking billy idol	0		
 2410	blurry rag	0		
@@ -2403,7 +2403,7 @@
 2429	wet Eau de Guaneau	0		Effect: "Cat Class, Cat Style", Effect Duration: 46
 2430	energized bag of lard	0		Effect: "Crying, Dying", Effect Duration: 18
 2431	improved non-dry blue bottle of Mystic Shell	0		Effect: "Less Pervious", Effect Duration: 67
-2432	unsweetened red mirror skewed SPF 451 lip balm	0		Effect: "Grrrrrrreat!", Effect Duration: 46
+2432	unsweetened red skewed mirror SPF 451 lip balm	0		Effect: "Grrrrrrreat!", Effect Duration: 46
 2433	pressed squat bottle of antifreeze	0		Effect: "Gummi Badass", Effect Duration: 17
 2434	warmed corrupted upside-down eyedrops	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 50
 2435	unsweetened activated Dogsgotnonoz pills	0		Effect: "Human-Undead Hybrid", Effect Duration: 63
@@ -2415,7 +2415,7 @@
 2441	teal Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	Newton's pink glowstick of mayonnaise	0		Experience (Mysticality): +3, Sleaze Spell Damage: +50, Last Available: "2007-03"
-2444	watered-down artisanal Supernova Champagne	2	EPIC	
+2444	artisanal watered-down Supernova Champagne	2	EPIC	
 2445	pulsating Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	ghostly fuchsia bad penguin egg	0		Free Pull
@@ -2474,8 +2474,8 @@
 2501	molybdenum crescent wrench	0		
 2502	cyan Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	maroon extra-fancy ring setting	0		
-2504	narrow bouncing precious piercing post	0		
-2505	gray pulsating necklace chain	0		
+2504	bouncing narrow precious piercing post	0		
+2505	pulsating gray necklace chain	0		
 2506	beach glass bead	0		
 2507	clay peace-sign bead	0		
 2508	skewed purple hardened beach glass necklace	0		Damage Reduction: 3
@@ -2492,14 +2492,14 @@
 2519	practically non-alcoholic bad jittery McMillicancuddy's Special Lager	1	decent	
 2520	lousy upside-down melted Jell-o shot	3	decent	
 2521	mediocre cruelty-free wine	4	decent	
-2522	fancy delicious irresponsibly strong thistle wine	8	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 50
+2522	fancy irresponsibly strong delicious thistle wine	8	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 50
 2523	green megatofu	0		
 2524	displaced fish	0		
 2525	bland fish	4	decent	
 2526	spoiled lime green bouncing fish casserole	3	crappy	
 2527	spoiled miniature wobbly fish lasagna	2	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	tasty thick gnatloaf	5	awesome	
+2529	thick tasty gnatloaf	5	awesome	
 2530	gigantic adequate teal gnatloaf casserole	9	good	
 2531	toothsome gnat lasagna	4	awesome	
 2532	pork	0		
@@ -2514,7 +2514,7 @@
 2541	wobbly wobbly Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	liquefied lesser grodulated violet	0		Effect: "Analog Drunk", Effect Duration: 38, Last Available: "2007-05"
 2543	diffused tin magnolia	0		Effect: "One For Tea", Effect Duration: 66, Last Available: "2007-05"
-2544	polarized dry twirling fuchsia begpwnia	0		Effect: "Meadulla Oblongota", Effect Duration: 41, Last Available: "2007-05"
+2544	polarized dry fuchsia twirling begpwnia	0		Effect: "Meadulla Oblongota", Effect Duration: 41, Last Available: "2007-05"
 2545	electrified dry upsy daisy	0		Effect: "Chunky", Effect Duration: 11, Last Available: "2007-05"
 2546	super-activated half-orchid	0		Effect: "Glittering Eyelashes", Effect Duration: 21, Last Available: "2007-05"
 2547	Jeselnik's hardened tin star	0		Damage Reduction: 3, Sleaze Damage: +25, Last Available: "2007-05"
@@ -2538,7 +2538,7 @@
 2565	can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	cyan Azazel's lollipop	0		
-2568	tumbling bouncing Azazel's tutu	0		
+2568	bouncing tumbling Azazel's tutu	0		
 2569	moist deionized ghostly ant agonist	0		Effect: "Smoking like a Bandit", Effect Duration: 44
 2570	jittery ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2546,14 +2546,14 @@
 2573	green ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
-2576	narrow teal upside-down honey-dipped locust	0		
+2576	upside-down narrow teal honey-dipped locust	0		
 2577	Sherlock's friendly cactus quill	0		Familiar Weight: +3, Item Drop: +25
 2578	Da Vinci's Staff of the Short Order Cook of the scaredy-cat of the detective	0		Experience (Mysticality): +5, Monster Level: -15, Item Drop: +20
-2579	big toothsome cactus fruit	5	awesome	
+2579	toothsome big cactus fruit	5	awesome	
 2580	reassuring grievous scorpion whip	0		Weapon Damage Percent: +50, Spooky Resistance: +1
 2581	handful of sand	0		
-2582	olive skewed brick of sand	0		
-2583	moldy super-sized skewed centipede eggs	5	crappy	
+2582	skewed olive brick of sand	0		
+2583	super-sized moldy skewed centipede eggs	5	crappy	
 2584	extremely unsafe wonderwall shield	0		Weapon Damage Percent: +100, Damage Reduction: 12
 2585	aromatic Colonel Mustard's Lonely Spades Club Jacket	0		Stench Resistance: +1
 2586	auspicious General Sage's Lonely Diamonds Club Jacket	0		Item Drop: +10
@@ -2561,9 +2561,9 @@
 2588	olive dangerous Private Pepper's Lonely Hearts Club Jacket	0		Weapon Damage: +10
 2589	bland tiny ghostly hot date	1	decent	
 2590	artisanal fancy distilled fortified wine	4	EPIC	Effect: "Also Schmeckt Zarathustra", Effect Duration: 25
-2591	decent snack-sized tasty tart	2	good	
+2591	snack-sized decent tasty tart	2	good	
 2592	Knob Goblin lunchbox	0		
-2593	moldy low-calorie Knob pasty	1	crappy	
+2593	low-calorie moldy Knob pasty	1	crappy	
 2594	weak bad thermos full of Knob coffee	2	decent	
 2595	aerosolized colloidal Ben-Gal&trade; Balm	0		Effect: "Omphalotus Omnipresence", Effect Duration: 30
 2596	blurry leathery cat skin	0		
@@ -2578,15 +2578,15 @@
 2605	pulsating palm frond	0		
 2606	palm-frond fan	0		
 2607	stanky palm-frond whip	0		Stench Spell Damage: +25
-2608	squat gray palm-frond net	0		
+2608	gray squat palm-frond net	0		
 2609	mirror scandalous energetic palm-frond capris	0		Maximum MP Percent: +20, Sleaze Damage: +5, Familiar Effect: "1.5xGhuol, cap 35"
 2610	skewed reassuring extra-large palm-frond toupee	0		Spooky Resistance: +1, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 2611	squat Tesla palm-frond cloak	0		MP Regen Min: 7, MP Regen Max: 10
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	cyan mojo filter	0		
-2615	rotten tiny pulsating green savoy truffle	1	crappy	
-2616	maroon twirling Magi-Wipes	0		
+2615	tiny rotten green pulsating savoy truffle	1	crappy	
+2616	twirling maroon Magi-Wipes	0		
 2617	boom	0		
 2618	auspicious Iiti Kitty phone charm	0		Item Drop: +10, Single Equip
 2619	bouncing jar of swamp gas	0		Last Available: "2007-05"
@@ -2624,14 +2624,14 @@
 2651	tumbling cyan pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	moldy squat S.T.L.T.	3	crappy	Last Available: "2007-06"
 2653	decent honey-dew	3	good	Last Available: "2007-06"
-2654	aged practically non-alcoholic Xanadian	1	awesome	Last Available: "2007-06"
-2655	galvanized enhanced purple blinking bottle of absinthe	0		Effect: "Stinking Cloud", Effect Duration: 37, Last Available: "2007-06"
+2654	practically non-alcoholic aged Xanadian	1	awesome	Last Available: "2007-06"
+2655	galvanized enhanced blinking purple bottle of absinthe	0		Effect: "Stinking Cloud", Effect Duration: 37, Last Available: "2007-06"
 2656	medical-grade slick Drowsy Sword	0		Moxie: +10, HP Regen Min: 7, HP Regen Max: 10
 2657	spoiled escargotsicle	3	crappy	Last Available: "2007-06"
 2658	perfectly mixed bottle of realpagne	4	EPIC	Last Available: "2007-06"
 2659	albatross necklace of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2007-06"
 2660	compressed jittery bouncing not-a-pipe	1	good	Effect: "Loco Motives", Effect Duration: 5, Last Available: "2007-06"
-2661	lousy extra-dry squat flask of Amontillado	5	decent	Last Available: "2007-06"
+2661	extra-dry lousy squat flask of Amontillado	5	decent	Last Available: "2007-06"
 2662	skewed Jeselnik's ball mask	0		Sleaze Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	Can-Can skirt of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	liquefied frozen sensitive poetry journal	0		Effect: "Meadulla Oblongota", Effect Duration: 30, Last Available: "2007-06"
@@ -2640,14 +2640,14 @@
 2667	pressed spiky collar	0		Effect: "Bananas!", Effect Duration: 49, Last Available: "2007-06"
 2668	altered can-can-in-a-can	1		Effect: "Arcane in the Brain", Effect Duration: 15, Last Available: "2007-06"
 2669	powdered lime green patent antipsychotics	1		Last Available: "2007-06"
-2670	distilled skewed wobbly Mariner's Friend cough drops	1		Last Available: "2007-06"
+2670	distilled wobbly skewed Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	drinkable narrow shot of nepenthe schnapps	3	good	Last Available: "2007-06"
 2672	mirror library card	0		Last Available: "2007-06"
 2673	bouncing Bohemian rhapsody	0		Last Available: "2007-06"
 2674	polarized bottle of cat tonic	0		Effect: "Rain Dancin'", Effect Duration: 35, Last Available: "2007-06"
 2675	dehydrated handful of moss	1		
 2676	modified wobbly bit-o-cactus	1		
-2677	dried jittery shaking huge protein powder	1		Effect: "Feline Ferocity", Effect Duration: 25
+2677	dried shaking jittery huge protein powder	1		Effect: "Feline Ferocity", Effect Duration: 25
 2678	spectre scepter	0		
 2679	oxidized denatured narrow sparkler	0		Effect: "Vented Spleen", Effect Duration: 12
 2680	modified ionized pulsating snake	0		Effect: "Here's Mud in Your Eye", Effect Duration: 33, Wiki Name: "snake"
@@ -2698,25 +2698,25 @@
 2725	normal cob of corn	4	good	
 2726	toothsome gray juniper berries	3	awesome	
 2727	rotten upside-down skewed plum	4	crappy	
-2728	rotten thick pear	5	crappy	
+2728	thick rotten pear	5	crappy	
 2729	huge normal red peach	6	good	
-2730	lousy wobbly tumbling plum wine	4	decent	
+2730	lousy tumbling wobbly plum wine	4	decent	
 2731	tolerable practically non-alcoholic shot of pear schnapps	1	good	
 2732	lousy squat shot of peach schnapps	4	decent	
 2733	moldy bunch of square grapes	3	crappy	
 2734	moldy brown sugar cane	4	crappy	
-2735	gigantic rotten mirror upside-down pulsating sandwich of the gods	9	crappy	
+2735	gigantic rotten upside-down pulsating mirror sandwich of the gods	9	crappy	
 2736	drinkable Pan-Dimensional Gargle Blaster	3	good	
-2737	altered olive blurry blurry leopard-print barbell	1	crappy	Effect: "Grrrrrrreat!", Effect Duration: 10
+2737	altered blurry blurry olive leopard-print barbell	1	crappy	Effect: "Grrrrrrreat!", Effect Duration: 10
 2738	pile of smoking rags	0		
 2739	quantum quadruple-flattened panty raider camouflage	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 22
 2740	rosewater-soaked asbestos-lined slick Staff of the Walk-In Freezer	0		Moxie: +10, Hot Resistance: +5, Stench Resistance: +3
 2741	perfectly mixed boilermaker	4	EPIC	
 2742	flavorless steel lasagna	4	quest	
-2743	special bad weak wobbly blue steel margarita	2	quest	Effect: "Mer-kinny Flavor", Effect Duration: 15
+2743	weak special bad wobbly blue steel margarita	2	quest	Effect: "Mer-kinny Flavor", Effect Duration: 15
 2744	compressed steel-scented air freshener	1		Effect: "Stench Jellied", Effect Duration: 5
 2745	quadruple-moist gremlin mutagen	0		Effect: "Pronounced Potency", Effect Duration: 11
-2746	energized altered skewed wobbly extra-potent gremlin mutagen	0		Effect: "Crimbo Nostalgia", Effect Duration: 48
+2746	energized altered wobbly skewed extra-potent gremlin mutagen	0		Effect: "Crimbo Nostalgia", Effect Duration: 48
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	bouncing furniture dolly of James Dean	0		Experience (Moxie): +3, Single Equip
 2749	teal family-friendly dog trainer's Staff of the Grease Trap of the wise owl	0		Mysticality: +20, Experience (familiar): +1, Sleaze Resistance: +1
@@ -2737,7 +2737,7 @@
 2764	ghostly scorching dance instructor's Order of the Silver Wossname of extreme caution	0		Experience Percent (Moxie): +10, Monster Level: -25, Hot Damage: +25, Single Equip
 2765	blurry Harold's bell	0		
 2766	bowling ball	0		
-2767	toothsome miniature Crimbo pie	2	awesome	
+2767	miniature toothsome Crimbo pie	2	awesome	
 2768	moldy fancy pear tart	4	crappy	Effect: "Okee-Dokee Computer", Effect Duration: 45
 2769	bland narrow peach pie	3	decent	
 2770	Vulcanized altered chunk of rock salt	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 37
@@ -2782,7 +2782,7 @@
 2809	energized enhanced anodized wobbly flask of porquoise juice	0		Effect: "Tomato Power", Effect Duration: 47
 2810	altered jug of hamethyst juice	0		Effect: "Bestial Sympathy", Effect Duration: 11
 2811	non-pressed polymerized red upside-down jug of baconstone juice	0		Effect: "Dreadful Heat", Effect Duration: 34
-2812	super-altered polarized unsweetened tumbling jittery jug of porquoise juice	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 19
+2812	super-altered polarized unsweetened jittery tumbling jug of porquoise juice	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 19
 2813	Oprah's Beret of the sweet-tooth	0		Maximum MP Percent: +50, Candy Drop: +100, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	wobbly knitted lard-coated wicked Bludgeon	0		Spell Damage: +5, Sleaze Spell Damage: +25, Cold Resistance: +3
 2815	bouncing wobbly stiffened Bunker of the storm of Leguizamo	0		Damage Reduction: 16, Maximum MP Percent: +40, Monster Level: +20
@@ -2802,16 +2802,16 @@
 2829	blurry really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
-2832	decent small digital key lime pie	2	good	
+2832	small decent digital key lime pie	2	good	
 2833	bland star key lime pie	4	decent	
-2834	upside-down double-paned electrified steel-toed bottle-rocket crossbow	0		Damage Reduction: 9, Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	upside-down double-paned electrified steel-toed bottle-rocket crossbow	0		Damage Reduction: 9, Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	yellow curative indie comic hipster glasses	0		HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	narrow wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	blue curative beefcake's glowstick	0		Muscle: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2007-08"
 2839	aromatic Periodical Paintbrush	0		Stench Resistance: +1, Softcore Only
 2840	perfectly mixed green bottle of cooking sherry	4	EPIC	
-2841	special toothsome packet of ketchup	3	awesome	Effect: "Pumped Stomach", Effect Duration: 45
+2841	toothsome special packet of ketchup	3	awesome	Effect: "Pumped Stomach", Effect Duration: 45
 2842	artisanal olive accidental cider	3	EPIC	
 2843	yummy gigantic dire fudgesicle	10	awesome	
 2844	Jack Frost's clever grievous experienced navel ring of navel gazing	0		Experience: +2, Weapon Damage Percent: +50, Maximum MP: +20, Cold Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2821,12 +2821,12 @@
 2848	upside-down lime green Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	mediocre moonberry wine cooler	3	decent	
-2851	half-sized normal fine aged cheddarwurst	2	good	
+2851	normal half-sized fine aged cheddarwurst	2	good	
 2852	purple branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	pulsating bouquet of swamp roses	0		
 2855	green auspicious censurious huge mosquito proboscis	0		Sleaze Resistance: +3, Item Drop: +10
-2856	alkaline lime green shaking swamp lolly	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 61
+2856	alkaline shaking lime green swamp lolly	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 61
 2857	diffused Vulcanized seegar butt	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 57
 2858	bottled swamp gas	0		
 2859	gray scandalous smartaleck's witch wart	0		Moxie Percent: +30, Sleaze Damage: +5
@@ -2910,12 +2910,12 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	small decent tumbling Surprise Egg	2	good	
+2940	decent small tumbling Surprise Egg	2	good	
 2941	quadruple-enhanced concentrated polymerized gray Steal This Candy	0		Effect: "Turkey-Agitated", Effect Duration: 42
 2942	triple-unsweetened spinning chocolate filthy lucre	0		Effect: "Mer-kinny Flavor", Effect Duration: 47
 2943	colloidal purple narrow Angry Farmer's Wife Candy	0		Effect: "Slimy Flavor", Effect Duration: 47
 2945	executive inspector's party hat	0		Item Drop: +15, Meat Drop: +40, Familiar Effect: "4xLep, cap 7"
-2946	rosewater-soaked arcane researcher's V for Vivala mask	0		Experience Percent (Mysticality): +10, Stench Resistance: +3, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	rosewater-soaked arcane researcher's V for Vivala mask	0		Experience Percent (Mysticality): +10, Stench Resistance: +3, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	drinkable weak shot of rotgut	2	good	
 2949	quantum tarnished tumbling jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Covetous Robbery", Effect Duration: 24
@@ -2924,14 +2924,14 @@
 2952	chaotic glowstick of the early riser	0		Spell Critical Percent: +10, Adventures: +7, Last Available: "2007-11"
 2953	fuchsia charrrm bracelet	0		
 2954	shaking tip jar of the pedagogue	0		Experience: +3
-2955	tasty snack-sized yam candy	2	awesome	
+2955	snack-sized tasty yam candy	2	awesome	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	normal blurry tube of cranberry Go-Goo	3	good	
 2959	tumbling blue rum barrel charrrm bracelet of dire peril	0		Weapon Damage: +20
 2960	adequate squat single-serving herbal stuffing	4	good	
-2961	snack-sized moldy packet of tofurkey gravy	2	crappy	
-2962	immense spoiled tofurkey nugget	10	crappy	
+2961	moldy snack-sized packet of tofurkey gravy	2	crappy	
+2962	spoiled immense tofurkey nugget	10	crappy	
 2963	rigging shampoo	0		
 2964	upside-down ball polish	0		
 2965	spinning mizzenmast mop	0		
@@ -2939,7 +2939,7 @@
 2967	corrupted Swabbie&trade; swab	0		Effect: "Witch's Brood", Effect Duration: 59
 2968	ionized boiled skewed Oil of Parrrlay	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 23
 2969	moldy miniature creamsicle	2	crappy	
-2970	practically non-alcoholic bad spinning maroon cream stout	1	decent	
+2970	bad practically non-alcoholic maroon spinning cream stout	1	decent	
 2971	weightlifter's curmudgel of the storm	0		Muscle: +15, Maximum MP Percent: +40
 2972	grumpy man charrrm	0		
 2973	yellow baleful grumpy man charrrm bracelet	0		Spell Damage: +25, Single Equip
@@ -2951,7 +2951,7 @@
 2979	pickled red narrow fish-liver oil	0		Effect: "Grumpy and Ornery", Effect Duration: 42
 2980	booty chest charrrm	0		
 2981	Tesla booty chest charrrm bracelet	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
-2982	jittery twirling cannonball charrrm	0		
+2982	twirling jittery cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
 2984	blurry copper ha'penny charrrm	0		
 2985	red sinister copper ha'penny charrrm bracelet	0		Spell Damage: +10
@@ -2995,10 +2995,10 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	mediocre fancy corpse on the beach	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 30
-3026	practically non-alcoholic fancy delicious corpsetini	1	awesome	Effect: "Optimist Primal", Effect Duration: 15
+3026	delicious fancy practically non-alcoholic corpsetini	1	awesome	Effect: "Optimist Primal", Effect Duration: 15
 3027	lousy twirling corpsedriver	3	decent	
 3028	artisanal fortified skewed Corpse Island iced tea	5	EPIC	
-3029	watered-down lousy blinking red-headed corpse	2	decent	
+3029	lousy watered-down blinking red-headed corpse	2	decent	
 3030	artisanal kamicorpse-ee	4	EPIC	
 3031	perfectly mixed teal corpsel	4	EPIC	
 3032	hand-crafted triple-distilled corpsebite	10	EPIC	
@@ -3015,8 +3015,8 @@
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	pulsating metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	fancy spoiled nanite-infested gingerbread bugbear	4	crappy	Effect: "Thunderspell", Effect Duration: 25, Last Available: "2007-12"
-3046	miniature bland nanite-infested candy cane	2	decent	Last Available: "2020-09"
-3047	moldy fancy tumbling nanite-infested fruitcake	4	crappy	Effect: "Broken Fast", Effect Duration: 25, Last Available: "2007-12"
+3046	bland miniature nanite-infested candy cane	2	decent	Last Available: "2020-09"
+3047	fancy moldy tumbling nanite-infested fruitcake	4	crappy	Effect: "Broken Fast", Effect Duration: 25, Last Available: "2007-12"
 3048	artisanal nanite-infested eggnog	3	EPIC	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	reassuring eyepatch	0		Spooky Resistance: +1, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	marionette collective of incineration	0		Hot Spell Damage: +50, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3092,7 +3092,7 @@
 3120	divine blowout	0		Last Available: "2008-01"
 3121	shaking red divine champagne popper	0		Last Available: "2008-01"
 3122	narrow divine cracker	0		Last Available: "2008-01"
-3123	fuchsia pulsating divine champagne flute	0		Last Available: "2008-01"
+3123	pulsating fuchsia divine champagne flute	0		Last Available: "2008-01"
 3124	colloidal polymerized twirling fruitfilm	0		Effect: "Phairly Pheromonal", Effect Duration: 55
 3125	irradiated piece of after eight	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 11
 3126	hobo nickel	0		
@@ -3129,7 +3129,7 @@
 3157	El Vibrato drone	0		
 3158	sparking El Vibrato drone	0		
 3159	unsweetened irradiated mirror warm El Vibrato drone	0		Effect: "Hot Hands", Effect Duration: 27
-3160	adjusted liquefied upside-down pulsating blue humming El Vibrato drone	0		Effect: "Meadulla Oblongota", Effect Duration: 54
+3160	adjusted liquefied pulsating blue upside-down humming El Vibrato drone	0		Effect: "Meadulla Oblongota", Effect Duration: 54
 3161	alkaline El Vibrato drone	0		Effect: "Berry Thorny", Effect Duration: 18
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	gray El Vibrato energy spear	0		
@@ -3145,11 +3145,11 @@
 3173	colloidal ionized evil vihuela	0		Effect: "Healthy Red Glow", Effect Duration: 68
 3174	bite-sized flavorless evil boring spaghetti	1	decent	
 3175	adequate snack-sized evil noodles	2	good	
-3176	bland special diet evil noodles	1	decent	Effect: "Bright!", Effect Duration: 50
+3176	special bland diet evil noodles	1	decent	Effect: "Bright!", Effect Duration: 50
 3177	rotten evil painful penne pasta	4	crappy	
-3178	special stale low-calorie purple 3vi1 pr0n m4nic0tti	1	decent	Effect: "Resilient Spirit", Effect Duration: 10
-3179	spoiled half-sized twirling gray bouncing evil ravioli della hippy	2	crappy	
-3180	decent low-calorie twirling evil noodles	1	good	
+3178	low-calorie stale special purple 3vi1 pr0n m4nic0tti	1	decent	Effect: "Resilient Spirit", Effect Duration: 10
+3179	spoiled half-sized bouncing gray twirling evil ravioli della hippy	2	crappy	
+3180	low-calorie decent twirling evil noodles	1	good	
 3181	aerosolized double-enhanced triple-nitrogenated evil potion of potency	0		Effect: "The Strength...  of the Future", Effect Duration: 43
 3182	galvanized evil libation of liveliness	0		Effect: "Mathematically Precise", Effect Duration: 68
 3183	dry denatured galvanized evil tomato juice of powerful power	0		Effect: "Liquidy Smoky", Effect Duration: 18
@@ -3157,7 +3157,7 @@
 3185	extra-modified enhanced warmed pulsating evil ointment of the occult	0		Effect: "Antibiotic Saucesphere", Effect Duration: 61
 3186	pickled evil serum of sarcasm	0		Effect: "Jingle Jangle Jingle", Effect Duration: 40
 3187	wet evil philter of phorce	0		Effect: "Polar Express", Effect Duration: 68
-3188	smooth practically non-alcoholic lime green an evil sump'm sump'm	1	awesome	
+3188	practically non-alcoholic smooth lime green an evil sump'm sump'm	1	awesome	
 3189	tolerable spirit-forward mirror evil ducha de oro	5	good	
 3190	perfectly mixed practically non-alcoholic evil horizontal tango	1	super ultra mega turbo EPIC	
 3191	acceptable olive evil roll in the hay	4	good	
@@ -3185,8 +3185,8 @@
 3213	dwarvish paper	0		
 3214	wobbly narrow dwarvish parchment	0		
 3215	overcharged El Vibrato power sphere	0		
-3216	blurry upside-down Fly-By-Knight Heraldry form	0		Free Pull
-3217	twirling squat El Vibrato Megadrone	0		
+3216	upside-down blurry Fly-By-Knight Heraldry form	0		Free Pull
+3217	squat twirling El Vibrato Megadrone	0		
 3218	censurious baleful glowstick	0		Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2008-02"
 3219	sane hatrack	0		Free Pull, Last Available: "2011-12"
 3220	upside-down hobo code binder	0		Free Pull
@@ -3209,7 +3209,7 @@
 3237	tumbling Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
-3240	huge squat Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
+3240	squat huge Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	Travels with Jerry	0		Skill: "Mudbath"
 3242	huge Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	purple Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
@@ -3240,9 +3240,9 @@
 3268	dry handful of Crotchety Pine needles	0		Effect: "Wet Willied", Effect Duration: 21
 3269	corrupted bouncing lump of Saccharine Maple sap	0		Effect: "Punch Another Day", Effect Duration: 24
 3270	boiled ghostly handful of Laughing Willow bark	0		Effect: "Cock of the Walk", Effect Duration: 26
-3271	skewed lard-coated crotchety pants	0		Sleaze Spell Damage: +25, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	skewed lard-coated crotchety pants	0		Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	avaricious Saccharine Maple pendant	0		Meat Drop: +30, Conditional Skill (Equipped): "Spray Sap"
-3273	forbidden willowy bonnet	0		Spell Damage Percent: +50, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	forbidden willowy bonnet	0		Spell Damage Percent: +50, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	jittery flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	fuchsia pulsating personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	up-at-dawn stick-on eyebrow piercing	0		Adventures: +5, Last Available: "2008-04"
-3283	tiny normal salad	1	good	
+3283	normal tiny salad	1	good	
 3284	tumbling brainy C.H.U.M. lantern of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25
 3285	jittery cool C.H.U.M. knife	0		Moxie: +5
 3286	jittery wobbly brawny Frosty's snowball sack	0		Muscle Percent: +20
@@ -3291,10 +3291,10 @@
 3319	blinking prompt Mr. Joe's bangles	0		Adventures: +3, Single Equip
 3320	tumbling aromatic frayed rope belt	0		Stench Resistance: +1, Single Equip
 3321	lime green packet of mayfly bait	0		Last Available: "2008-05"
-3322	pulsating blue rosy-cheeked mayfly bait necklace of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +30, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	pulsating blue rosy-cheeked mayfly bait necklace of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	smooth practically non-alcoholic fancy jar of fermented pickle juice	1	awesome	Effect: "Frozen Hands", Effect Duration: 20
+3325	practically non-alcoholic fancy smooth jar of fermented pickle juice	1	awesome	Effect: "Frozen Hands", Effect Duration: 20
 3326	dehydrated narrow voodoo snuff	1	EPIC	
 3327	miniature delicious extra-greasy slider	2	awesome	
 3328	manspreader's experienced crumpled felt fedora	0		Experience: +2, Monster Level: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3323,7 +3323,7 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	shaking zen motorcycle	0		Last Available: "2008-06"
 3353	cold-filtered modified narrow llama lama gong	0		Effect: "Provocative Perkiness", Effect Duration: 63, Last Available: "2008-06"
-3354	tasty miniature banana-frosted king cake	2	awesome	Last Available: "2008-08"
+3354	miniature tasty banana-frosted king cake	2	awesome	Last Available: "2008-08"
 3355	auspicious brown plastic baby	0		Item Drop: +10, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	wobbly ghostly shimmering moth	0		Last Available: "2008-06"
@@ -3332,13 +3332,13 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	cyan tasty louse	0		Last Available: "2008-06"
-3363	normal jumbo mole mol&eacute;	5	good	Last Available: "2008-06"
+3363	jumbo normal mole mol&eacute;	5	good	Last Available: "2008-06"
 3364	artisanal Morlock's Mark Bourbon	4	EPIC	Last Available: "2008-06"
 3365	non-tarnished vacuum-sealed Climate Colada	0		Effect: "For Your Brain Only", Effect Duration: 39, Last Available: "2008-06"
 3366	double-chilled adjusted digital underground potion	0		Effect: "Phairly Pheromonal", Effect Duration: 45, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	dried yellow squat glimmering roc feather	1	awesome	Last Available: "2008-06"
-3369	diluted pulsating mirror glimmering phoenix feather	1		Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2008-06"
+3368	dried squat yellow glimmering roc feather	1	awesome	Last Available: "2008-06"
+3369	diluted mirror pulsating glimmering phoenix feather	1		Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2008-06"
 3370	vaporized glimmering penguin feather	1		Last Available: "2008-06"
 3371	mixed glimmering buzzard feather	1		Last Available: "2008-06"
 3372	diluted twirling glimmering raven feather	1		Last Available: "2008-06"
@@ -3386,7 +3386,7 @@
 3414	shaking Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	shaking Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	mirror box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	mirror box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	polymerized activated tumbling sterno-flavored Hob-O	0		Effect: "Memory of Resilience", Effect Duration: 46
 3423	unsweetened pulsating frostbite-flavored Hob-O	0		Effect: "Gunky Dory", Effect Duration: 41
 3424	deionized double-polarized modified fry-oil-flavored Hob-O	0		Effect: "Tingly Biceps", Effect Duration: 16
@@ -3427,10 +3427,10 @@
 3460	stale tin rations	3	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	bad boozy bottle of sake	5	decent	
+3463	boozy bad bottle of sake	5	decent	
 3464	foul-smelling round pebble	0		Stench Damage: +10
 3465	flavorless Bash-&#332;s cereal	3	decent	Wiki Name: "Bash-Os cereal"
-3466	manspreader's brainy haiku katana of the empath	0		Mysticality: +5, Monster Level: +10, Familiar Weight: +5, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	manspreader's brainy haiku katana of the empath	0		Mysticality: +5, Monster Level: +10, Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	yellow bargain flash powder	0		
 3468	Van der Graaf plastic baby	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2008-12"
 3469	adequate blueberry-frosted king cake	4	good	Last Available: "2008-12"
@@ -3450,16 +3450,16 @@
 3483	blue psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	electrified twirling glittery mascara	0		Effect: "Glo-Face", Effect Duration: 55
-3486	gray skewed dull fish scale	0		
+3486	skewed gray dull fish scale	0		
 3487	pulsating rough fish scale	0		
 3488	pristine fish scale	0		
 3489	tasty beefy fish meat	4	awesome	Effect: "Fishy", Effect Duration: 5
-3490	thick moldy upside-down bouncing glistening fish meat	5	crappy	Effect: "Fishy", Effect Duration: 5
-3491	spoiled miniature mirror slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
+3490	moldy thick bouncing upside-down glistening fish meat	5	crappy	Effect: "Fishy", Effect Duration: 5
+3491	miniature spoiled mirror slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3492	shellacked fish scimitar of the cougar	0		Moxie: +20, Damage Reduction: 7
 3493	foul-smelling fish stick of the glutton	0		Stench Damage: +10, Food Drop: +100
 3494	upside-down blinking curative fish bazooka of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 3, HP Regen Max: 5
-3495	colloidal Vulcanized cyan shaking squat sea salt crystal	0		Effect: "Floundering", Effect Duration: 24
+3495	colloidal Vulcanized squat cyan shaking sea salt crystal	0		Effect: "Floundering", Effect Duration: 24
 3496	pickled wet blue bazookafish bubble gum	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 15
 3497	perfectly mixed bottle of Pete's Sake	4	EPIC	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
@@ -3467,7 +3467,7 @@
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	moldy massive canap&eacute;s	6	crappy	
 3502	distilled thermos of brew	1	decent	Effect: "Employee of the Month", Effect Duration: 35, Last Available: "2011-12"
-3503	artisanal fortified glass of brandy	5	EPIC	Last Available: "2011-12"
+3503	fortified artisanal glass of brandy	5	EPIC	Last Available: "2011-12"
 3504	blinking French slippers	0		
 3505	twirling Lo Pan's LWA ring	0		Spell Critical Percent: +30
 3506	bouncing LARP membership card	0		Last Available: "2008-10"
@@ -3484,7 +3484,7 @@
 3517	blurry eelskin hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk"
 3518	eelskin pants of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, MP regen"
 3519	foul-smelling eelskin shield	0		Stench Damage: +10, Damage Reduction: 13
-3520	wobbly yellow shark tooth	0		
+3520	yellow wobbly shark tooth	0		
 3521	Jeselnik's arcane researcher's shark tooth necklace	0		Experience Percent (Mysticality): +10, Sleaze Damage: +25, Single Equip
 3522	twirling horrifying shark jumper of the pedagogue	0		Experience: +3, Spooky Damage: +25
 3523	activated shark cartilage	0		Effect: "Adapt to Change Eventually", Effect Duration: 65
@@ -3497,7 +3497,7 @@
 3530	wobbly shaking mutant gila monster egg	0		
 3531	blurry rattlesnake enrager	0		Familiar Weight: +5
 3532	bouncing ant antidepressant	0		Familiar Weight: +5
-3533	twirling blue cactus monocle	0		Familiar Weight: +5
+3533	blue twirling cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	blinking plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	blinking plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
@@ -3519,10 +3519,10 @@
 3552	avaricious toasty brawny octopus's spade	0		Muscle Percent: +20, Hot Damage: +5, Meat Drop: +30
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	adequate low-calorie tumbling sea carrot	1	good	
+3555	low-calorie adequate tumbling sea carrot	1	good	
 3556	normal small purple sea cucumber	2	good	
 3557	spoiled sea avocado	3	crappy	
-3558	spoiled special jumbo sea lychee	5	crappy	Effect: "Spookyravin'", Effect Duration: 5
+3558	special jumbo spoiled sea lychee	5	crappy	Effect: "Spookyravin'", Effect Duration: 5
 3559	adequate sea tangelo	3	good	
 3560	toothsome low-calorie sea honeydew	1	awesome	
 3561	enhanced pressurized potion of puissance	0		Effect: "In Vino Vires", Effect Duration: 59
@@ -3540,14 +3540,14 @@
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	maroon sand dollar	0		
-3576	purple upside-down flytrap bezoar	0		
+3576	upside-down purple flytrap bezoar	0		
 3577	bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	yellow ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
-3581	upside-down skewed sushi-rolling mat	0		
+3581	skewed upside-down sushi-rolling mat	0		
 3582	spoiled rice	3	crappy	
-3584	tiny tasty irradiated candy cane	1	awesome	Last Available: "2008-12"
+3584	tasty tiny irradiated candy cane	1	awesome	Last Available: "2008-12"
 3585	stale fuchsia gingerbread mutant bugbear	3	decent	Last Available: "2008-12"
 3586	acceptable oozenog	4	good	Last Available: "2008-12"
 3587	denatured colloidal huge huge sugar plum	0		Effect: "Jungle Juiced", Effect Duration: 15, Last Available: "2008-12"
@@ -3574,16 +3574,16 @@
 3608	live nautical mine	0		
 3609	gray das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
-3611	concentrated corrupted bouncing ghostly sea grease	0		Effect: "Hot Jellied", Effect Duration: 51
+3611	concentrated corrupted ghostly bouncing sea grease	0		Effect: "Hot Jellied", Effect Duration: 51
 3612	narrow sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	bouncing battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	shaking pulsing flesh	0		Last Available: "2008-12"
 3617	extra-alkaline ionized modified unstable DNA	0		Effect: "Moon'd", Effect Duration: 42, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
-3620	narrow bouncing mass of wriggling tentacles	0		Last Available: "2008-12"
+3620	bouncing narrow mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	toothsome toast with jam	4	awesome	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	lousy practically non-alcoholic red elven moonshine	1	decent	Last Available: "2008-12"
-3653	rotten super-sized tumbling knuckle sandwich	5	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	practically non-alcoholic lousy red elven moonshine	1	decent	Last Available: "2008-12"
+3653	rotten super-sized tumbling knuckle sandwich	5	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	tumbling rosy-cheeked grievous psycho sweater	0		Weapon Damage Percent: +50, Maximum HP Percent: +30, Last Available: "2008-12"
 3655	yellow fin-bit wax	0		Familiar Weight: +5
 3656	sage plastic Mob Penguin	0		Mysticality Percent: +10, Last Available: "2008-12"
@@ -3635,7 +3635,7 @@
 3669	wobbly arcane researcher's glow-in-the-dark dart gun	0		Experience Percent (Mysticality): +10, Last Available: "2009-01"
 3670	narrow sage glow-in-the-dark burrowgrub	0		Mysticality Percent: +10, Last Available: "2009-01"
 3671	bouncing Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	small decent can of franks 'n' beans	2	good	Last Available: "2010-12"
+3672	decent small can of franks 'n' beans	2	good	Last Available: "2010-12"
 3673	lousy bottle of peppermint schnapps	3	decent	Last Available: "2010-12"
 3674	cyan throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3644,18 +3644,18 @@
 3678	drinkable green salinated mint julep	3	good	
 3679	ink bladder	0		
 3680	twirling esca	0		
-3681	shaking teal bubbling tempura batter	0		
+3681	teal shaking bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	tasty big red tempura carrot	5	awesome	
-3685	miniature stale gray tempura cucumber	2	decent	
+3684	big tasty red tempura carrot	5	awesome	
+3685	stale miniature gray tempura cucumber	2	decent	
 3686	stale tempura avocado	3	decent	
 3687	miniature stale cyan huge sea broccoli	2	decent	
 3688	spoiled sea cauliflower	4	crappy	
-3689	half-sized adequate tempura broccoli	2	good	
+3689	adequate half-sized tempura broccoli	2	good	
 3690	normal tempura cauliflower	4	good	
 3691	stale squat sea blueberry	3	decent	
-3692	big moldy upside-down sea persimmon	5	crappy	
+3692	moldy big upside-down sea persimmon	5	crappy	
 3693	pressed pressurized potion of perception	0		Effect: "Winklered", Effect Duration: 43
 3694	anodized enhanced pressurized potion of proficiency	0		Effect: "Beta Carotene Overdose", Effect Duration: 25
 3695	maroon greasy Mer-kin digpick	0		Sleaze Spell Damage: +10
@@ -3663,7 +3663,7 @@
 3697	narrow high-pressure seltzer bottle	0		
 3698	blurry velcro ore	0		
 3699	red huge teflon ore	0		
-3700	jittery squat vinyl ore	0		
+3700	squat jittery vinyl ore	0		
 3701	map to Anemone Mine	0		
 3702	marine aquamarine	0		
 3703	valve wheel	0		
@@ -3692,16 +3692,16 @@
 3726	possessed tomato	0		
 3727	Nardz energy beverage	0		
 3728	lime green pile of coins	0		
-3729	mirror purple hand grenegg	0		
+3729	purple mirror hand grenegg	0		
 3730	caret	0		
 3731	glass gnoll eye of Leguizamo	0		Monster Level: +20
 3732	diffused wobbly cigar butt	0		Effect: "Conspiratory Eyes", Effect Duration: 38
 3733	horrifying forbidden manly bloomers	0		Spell Damage Percent: +50, Spooky Damage: +25, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
-3734	twirling narrow Colon Annihilation Hot Sauce	0		
+3734	narrow twirling Colon Annihilation Hot Sauce	0		
 3735	blue fat wallet	0		
 3736	mirror banded handwarmer of temperance	0		Damage Absorption: +100, Sleaze Resistance: +5, Single Equip
 3737	chaotic educational lighter	0		Experience: +1, Spell Critical Percent: +10
-3738	miniature adequate packet of beer nuts	2	good	
+3738	adequate miniature packet of beer nuts	2	good	
 3739	purple Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3727,12 +3727,12 @@
 3763	artisanal slug of vodka	3	EPIC	
 3764	hand-crafted fortified slug of rum	5	EPIC	
 3765	artisanal slug of shochu	4	EPIC	
-3766	enchanted acceptable screwdiver	4	good	Effect: "Icy Demeanor", Effect Duration: 35
+3766	acceptable enchanted screwdiver	4	good	Effect: "Icy Demeanor", Effect Duration: 35
 3767	hand-crafted dew yoana lei	3	EPIC	
 3768	artisanal lychee chuhai	3	EPIC	
-3769	practically non-alcoholic lousy salacious screwdiver	1	decent	
-3770	watered-down fancy hand-crafted dew yoana salacious lei	2	EPIC	Effect: "Triangle, Man", Effect Duration: 35
-3771	delicious spirit-forward salacious lychee chuhai	5	awesome	
+3769	lousy practically non-alcoholic salacious screwdiver	1	decent	
+3770	hand-crafted watered-down fancy dew yoana salacious lei	2	EPIC	Effect: "Triangle, Man", Effect Duration: 35
+3771	spirit-forward delicious salacious lychee chuhai	5	awesome	
 3772	practically non-alcoholic lousy narrow Alewife&trade; Ale	1	decent	
 3773	cyan twirling seaode	0		
 3774	map to the Dive Bar	0		
@@ -3768,7 +3768,7 @@
 3813	ruddy plastic baby	0		Maximum HP Percent: +40, Single Equip, Last Available: "2009-06"
 3815	blue midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	flavorless snack-sized sea radish	2	decent	
+3817	snack-sized flavorless sea radish	2	decent	
 3818	coward's supercool halibut of the sweet-tooth	0		Moxie Percent: +20, Monster Level: -20, Candy Drop: +100
 3819	narrow eel sauce	0		
 3820	blinking shaking water-polo mitt of the blizzard	0		Cold Spell Damage: +25, Single Equip
@@ -3783,11 +3783,11 @@
 3829	delicious narrow tempura radish	4	awesome	
 3830	lime green lion tamer's water-polo cap	0		Experience (familiar): +2, Familiar Effect: "1xVolley, 1xBarrr"
 3831	practically non-alcoholic mediocre Typical Tavern swill	1	decent	
-3832	hand-crafted fancy tropical swill	3	EPIC	Effect: "Jungle Juiced", Effect Duration: 20
+3832	fancy hand-crafted tropical swill	3	EPIC	Effect: "Jungle Juiced", Effect Duration: 20
 3833	acceptable fruity girl swill	3	good	
 3834	drinkable blended swill	4	good	
-3835	spinning olive costume wardrobe	0		Softcore Only
-3836	bouncing skewed sharpshooter's vibrating sage Elvish sunglasses of Gandalf	0		Mysticality Percent: +10, Maximum MP Percent: +10, Critical Hit Percent: +10, Spell Critical Percent: +20, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3835	olive spinning costume wardrobe	0		Softcore Only
+3836	bouncing skewed sharpshooter's vibrating sage Elvish sunglasses of Gandalf	0		Mysticality Percent: +10, Maximum MP Percent: +10, Critical Hit Percent: +10, Spell Critical Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	friendly anniversary safety glass vest	0		Familiar Weight: +3
 3838	rock-hard anniversary burlap belt	0		Damage Reduction: 5
 3839	spinning yellow chilly anniversary balsa wood socks	0		Cold Damage: +5
@@ -3848,7 +3848,7 @@
 3894	boiled enhanced polymerized maroon vial of teal slime	0		Effect: "Chilblains of the Corn", Effect Duration: 66
 3895	double-improved aerosolized maroon vial of indigo slime	0		Effect: "Stinking Cloud", Effect Duration: 69
 3896	altered electrified huge vial of slime	0		Effect: "Employee of the Month", Effect Duration: 46
-3897	colloidal skewed spinning vial of brown slime	0		Effect: "Norwhalloped", Effect Duration: 14
+3897	colloidal spinning skewed vial of brown slime	0		Effect: "Norwhalloped", Effect Duration: 14
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	spinning figurine of a wretched-looking seal	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	maroon imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	fortified tolerable blended swill with a fly in it	5	good	
+3913	tolerable fortified blended swill with a fly in it	5	good	
 3914	jittery turtle wax	0		
 3915	Rosewater's turtle wax shield	0		Mysticality Percent: +30, Damage Reduction: 2
 3916	turtle wax helmet of the empath	0		Familiar Weight: +5, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3914,7 +3914,7 @@
 3962	designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
-3965	enhanced spinning mirror cube of billiard chalk	0		Effect: "Berry Elemental", Effect Duration: 33
+3965	enhanced mirror spinning cube of billiard chalk	0		Effect: "Berry Elemental", Effect Duration: 33
 3966	Tesla occult Da Vinci's hot-ass club	0		Experience (Mysticality): +5, Spell Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, Class: "Seal Clubber"
 3967	careful grievous stylish frigid-ass club	0		Moxie: +25, Weapon Damage Percent: +50, Monster Level: -10, Class: "Seal Clubber"
 3968	chaotic cool weightlifter's creepy-ass club	0		Muscle: +15, Moxie: +5, Spell Critical Percent: +10, Class: "Seal Clubber"
@@ -3956,7 +3956,7 @@
 4004	experienced soup-chucks	0		Experience: +2
 4005	irradiated chilled ballast turtle	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33
 4006	memory of some amino acids	0		Last Available: "2009-06"
-4007	bouncing huge memory of a C	0		Last Available: "2009-06"
+4007	huge bouncing memory of a C	0		Last Available: "2009-06"
 4008	memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
@@ -3979,15 +3979,15 @@
 4027	yellow up-at-dawn greasy greaves of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +10, Adventures: +5, Familiar Effect: "sleaze atk, 0.5xBarrr"
 4028	squat upside-down Sherlock's Temple Grandin's club of the brazier	0		Familiar Weight: +7, Hot Spell Damage: +25, Item Drop: +25
 4029	huge memory of a grappling hook	0		Last Available: "2009-06"
-4030	narrow fuchsia memory of a small stone block	0		Last Available: "2009-06"
+4030	fuchsia narrow memory of a small stone block	0		Last Available: "2009-06"
 4031	lime green memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	blue caustic slime nodule	0		
-4037	massive bland spinning upside-down slimy sweetbreads	8	decent	
-4038	weak enchanted aged slimy fermented bile bladder	2	awesome	Effect: "Leisurely Amblin'", Effect Duration: 30
+4037	bland massive upside-down spinning slimy sweetbreads	8	decent	
+4038	aged enchanted weak slimy fermented bile bladder	2	awesome	Effect: "Leisurely Amblin'", Effect Duration: 30
 4039	compressed shaking slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	Lo Pan's Tesla pig-iron helm	0		Spell Critical Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4012,7 +4012,7 @@
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
-4063	wobbly upside-down Mecha Mayhem Club Card	0		Last Available: "2009-06"
+4063	upside-down wobbly Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	blue ruddy extremely unsafe grisly shield	0		Weapon Damage Percent: +100, Maximum HP Percent: +40, Slime Hates It: +1, Damage Reduction: 13
 4081	wobbly grievous dangerous corroded breeches	0		Weapon Damage: +10, Weapon Damage Percent: +50, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	twirling studded pernicious cudgel of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Slime Hates It: +1
-4083	moldy thick cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
+4083	thick moldy cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	decent protein paste	4	good	Last Available: "2009-06"
 4086	Fonzie's cyber-mattock of the sewer	0		Experience (Moxie): +1, Stench Damage: +25, Last Available: "2009-06"
@@ -4081,11 +4081,11 @@
 4129	knitted frightening Temple Grandin's hardened slime belt	0		Familiar Weight: +7, Spooky Damage: +5, Cold Resistance: +3, Single Equip
 4130	wobbly empty agua de vida bottle	0		Last Available: "2009-06"
 4131	denatured ghostly boot plant	1	good	Last Available: "2009-06"
-4132	practically non-alcoholic aged sham champagne	1	awesome	Last Available: "2009-06"
+4132	aged practically non-alcoholic sham champagne	1	awesome	Last Available: "2009-06"
 4133	quadruple-chilled tempura air	0		Effect: "Spooky Blur", Effect Duration: 54
 4134	quantum magnetized tumbling pressurized potion of pneumaticity	0		Effect: "Butt-Rock Hair", Effect Duration: 37
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	blinking frightening lion tamer's steel-toed Newton's Bag o' Tricks	0		Experience (Mysticality): +3, Damage Reduction: 9, Experience (familiar): +2, Spooky Damage: +5, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	blinking frightening lion tamer's steel-toed Newton's Bag o' Tricks	0		Experience (Mysticality): +3, Damage Reduction: 9, Experience (familiar): +2, Spooky Damage: +5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	upside-down slime stack	0		
 4138	green a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4097,7 +4097,7 @@
 4145	jittery occult funny paper hat	0		Spell Damage Percent: +25, Familiar Effect: "1xVolley, 1xLep, cap 2"
 4146	quadruple-anodized olive sand	0		Effect: "Broken Bone Nubs", Effect Duration: 67
 4147	bouncing charged magnet of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Last Available: "2009-09"
-4148	narrow green stone sphere	0		Free Pull, Last Available: "2009-09"
+4148	green narrow stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	blinking quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	lint	0		Last Available: "2011-12"
 4151	extra-dry squat dubious peppermint	0		Effect: "Salsa Satanica", Effect Duration: 59, Last Available: "2020-09"
@@ -4154,7 +4154,7 @@
 4202	urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
 4204	shaking Mer-kin cheatsheet	0		
-4205	twirling pulsating Mer-kin wordquiz	0		
+4205	pulsating twirling Mer-kin wordquiz	0		
 4206	veiny brainy brand new key	0		Mysticality: +5, Maximum HP: +10
 4207	Annie Oakley's dorsal fin	0		Critical Hit Percent: +20, Damage Reduction: 13
 4208	skewed skate skates	0		
@@ -4163,7 +4163,7 @@
 4211	mermaid's purse	0		
 4212	pulsating underwater slingshot	0		
 4213	Van der Graaf cool skate blade	0		Moxie: +5, MP Regen Min: 5, MP Regen Max: 7
-4214	jittery squat spangly unitard	0		
+4214	squat jittery spangly unitard	0		
 4215	stanky veiny collapsible baton	0		Maximum HP: +10, Stench Spell Damage: +25
 4216	groupie lipstick	0		
 4217	groupie bra	0		
@@ -4208,7 +4208,7 @@
 4256	triple-flattened non-tarnished sap	0		Effect: "Marinated", Effect Duration: 17, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	decent chocolate-covered scarab beetle	3	good	Last Available: "2009-10"
-4259	mediocre ghostly blurry mulled cider	4	decent	Last Available: "2009-10"
+4259	mediocre blurry ghostly mulled cider	4	decent	Last Available: "2009-10"
 4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	ghostly pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	sharpshooter's Ass-Stompers of Violence of extreme caution of the empath	0		Critical Hit Percent: +10, Monster Level: -25, Familiar Weight: +5, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	wool toasty Annie Oakley's Brand of Violence	0		Critical Hit Percent: +20, Hot Damage: +5, Cold Resistance: +1, Conditional Skill (Equipped): "Brand"
 4299	fireproof nasty Novelty Belt Buckle of Violence of terror	0		Stench Damage: +5, Spooky Spell Damage: +10, Hot Resistance: +3, Single Equip
-4300	scorching curative beefcake's Lens of Violence	0		Muscle: +25, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	scorching curative beefcake's Lens of Violence	0		Muscle: +25, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	narrow flame-wreathed ruddy Socratic Pigsticker of Violence	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Hot Spell Damage: +10
-4302	flame-wreathed Fonzie's Newton's Jodhpurs of Violence	0		Experience (Mysticality): +3, Experience (Moxie): +1, Hot Spell Damage: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	flame-wreathed Fonzie's Newton's Jodhpurs of Violence	0		Experience (Mysticality): +3, Experience (Moxie): +1, Hot Spell Damage: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	padded wicked wizardly Cold Stone of Hatred	0		Mysticality: +25, Spell Damage: +5, Damage Absorption: +20, Conditional Skill (Equipped): "Chilling Grip"
 4304	knitted Girdle of Hatred of the overflowing toilet of temperance	0		Stench Spell Damage: +50, Cold Resistance: +3, Sleaze Resistance: +5, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	manspreader's chaotic Rosewater's Staff of Simmering Hatred	0		Mysticality Percent: +30, Spell Critical Percent: +10, Monster Level: +10
-4306	blue family-friendly scorching Pantaloons of Hatred of the cougar	0		Moxie: +20, Hot Damage: +25, Sleaze Resistance: +1, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	blue family-friendly scorching Pantaloons of Hatred of the cougar	0		Moxie: +20, Hot Damage: +25, Sleaze Resistance: +1, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	ruddy stiffened Fuzzy Slippers of Hatred of James Dean	0		Experience (Moxie): +3, Damage Reduction: 1, Maximum HP Percent: +40, Single Equip
-4308	rock-hard sage Lens of Hatred of the empath	0		Mysticality Percent: +10, Damage Reduction: 5, Familiar Weight: +5, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	rock-hard sage Lens of Hatred of the empath	0		Mysticality Percent: +10, Damage Reduction: 5, Familiar Weight: +5, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	smooth Treads of Loathing of incineration of the cheetah	0		Moxie: +15, Hot Spell Damage: +50, Initiative: +60, Single Equip
 4310	lion tamer's Van der Graaf Scepter of Loathing of the wise owl	0		Mysticality: +20, Experience (familiar): +2, MP Regen Min: 5, MP Regen Max: 7
 4311	cyan bouncing flame-retardant Belt of Loathing of the storm of the early riser	0		Maximum MP Percent: +40, Hot Resistance: +1, Adventures: +7, Single Equip
@@ -4280,10 +4280,10 @@
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	decent fancy candy kneecapping stick	3	good	Effect: "Musky", Effect Duration: 5, Last Available: "2009-12"
-4331	massive moldy licorice garrote	9	crappy	Last Available: "2009-12"
+4331	moldy massive licorice garrote	9	crappy	Last Available: "2009-12"
 4332	narrow perfumed candy knuckles	0		Stench Resistance: +5, Last Available: "2009-12"
 4333	stale jawbruiser	3	decent	Last Available: "2010-12"
-4334	flattened upside-down huge chocolate car	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 19, Last Available: "2009-12"
+4334	flattened huge upside-down chocolate car	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 19, Last Available: "2009-12"
 4335	wholesome plastic 11 Dealer	0		Maximum HP Percent: +10, Last Available: "2009-12"
 4336	upside-down rosewater-soaked plastic Crimbo Casino	0		Stench Resistance: +3, Last Available: "2009-12"
 4337	plastic stocking mimic of the cougar	0		Moxie: +20, Last Available: "2009-12"
@@ -4292,7 +4292,7 @@
 4340	improved Piddles	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 13, Last Available: "2009-12"
 4341	oxidized BitterSweetTarts	0		Effect: "Wise Spirit", Effect Duration: 42, Last Available: "2009-12"
 4342	pressed altered teal Polka Pop	0		Effect: "Sweet Nostalgia", Effect Duration: 65, Last Available: "2009-12"
-4343	huge twirling Crimbuck	0		Last Available: "2009-12"
+4343	twirling huge Crimbuck	0		Last Available: "2009-12"
 4344	mirror Crimbo wreath	0		Last Available: "2009-12"
 4345	gray string of Crimbo lights	0		Last Available: "2009-12"
 4346	spinning plastic Crimbo reindeer	0		Last Available: "2009-12"
@@ -4314,8 +4314,8 @@
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	upside-down elf resistance button	0		Last Available: "2009-12"
 4364	warmed aerosolized elven suicide capsule	0		Effect: "Flagrantly Fragrant", Effect Duration: 43, Last Available: "2009-12"
-4365	adequate snack-sized maroon penguin focaccia bread	2	good	Last Available: "2009-12"
-4366	bad triple-distilled herringcello	9	decent	Last Available: "2009-12"
+4365	snack-sized adequate maroon penguin focaccia bread	2	good	Last Available: "2009-12"
+4366	triple-distilled bad herringcello	9	decent	Last Available: "2009-12"
 4367	tolerable pulsating elven cellocello	4	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	skewed handful of headless bolts	0		Last Available: "2009-12"
@@ -4340,18 +4340,18 @@
 4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	banded peanut brittle shield	0		Damage Absorption: +100, Damage Reduction: 3, Last Available: "2009-12"
 4390	gravedigger's Red Rover BB gun of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Last Available: "2009-12"
-4391	twirling red-and-green sweater of the pedagogue	0		Experience: +3, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	twirling red-and-green sweater of the pedagogue	0		Experience: +3, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	diffused galvanized colloidal fuchsia Crimbo peppermint bark	0		Effect: "Super Accuracy", Effect Duration: 66, Last Available: "2009-12"
 4394	boiled wobbly Crimbo fudge	0		Effect: "Bolts about Candy", Effect Duration: 25, Last Available: "2009-12"
 4395	corrupted red Crimbo pecan	0		Effect: "Salsa Satanica", Effect Duration: 31, Last Available: "2009-12"
 4396	Jack-in-the-box	0		Last Available: "2009-12"
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
-4398	red shaking squat cheese ball	0		Last Available: "2010-01"
+4398	squat red shaking cheese ball	0		Last Available: "2010-01"
 4399	knitted cheese sword	0		Cold Resistance: +3, Softcore Only, Last Available: "2010-01"
 4400	beefcake's cheese diaper	0		Muscle: +25, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	ghostly MacGyver's cheese wheel	0		Maximum MP: +100, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	cheese eye of terror	0		Spooky Spell Damage: +10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	cheese eye of terror	0		Spooky Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	friendly vibrating Staff of Queso Escusado of the cheetah	0		Maximum MP Percent: +10, Familiar Weight: +3, Initiative: +60, Softcore Only, Last Available: "2010-01"
 4405	maroon foreign box	0		
 4406	huge The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4360,7 +4360,7 @@
 4409	shaking Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	moldy super-sized quantum taco	0		Last Available: "2010-10"
+4412	super-sized moldy quantum taco	0		Last Available: "2010-10"
 4413	tolerable Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	ghostly colorful plastic ball	0		Last Available: "2010-01"
 4415	brawny sealhide hood	0		Muscle Percent: +20, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4424,7 +4424,7 @@
 4476	shaking BRICKO oyster	0		Last Available: "2010-02"
 4477	lime green BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	bouncing BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	bouncing BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	jittery BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	spinning BRICKO airship	0		Last Available: "2010-02"
@@ -4445,7 +4445,7 @@
 4497	aerosolized squat recording of The Ballad of Richie Thingfinder	0		Effect: "Spooky Jellied", Effect Duration: 67
 4498	oxidized frozen recording of Benetton's Medley of Diversity	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 68
 4499	colloidal blurry recording of Elron's Explosive Etude	0		Effect: "Elemental Saucesphere", Effect Duration: 40
-4500	ionized dry blinking skewed recording of Chorale of Companionship	0		Effect: "Material Witness", Effect Duration: 38
+4500	ionized dry skewed blinking recording of Chorale of Companionship	0		Effect: "Material Witness", Effect Duration: 38
 4501	colloidal tumbling recording of Prelude of Precision	0		Effect: "Balls of Ectoplasm", Effect Duration: 12
 4502	magnetized activated blurry purple recording of Donho's Bubbly Ballad	0		Effect: "Sensation", Effect Duration: 36
 4503	non-diffused nitrogenated polymerized huge recording of Inigo's Incantation of Inspiration	0		Effect: "Sausage Festive", Effect Duration: 50, Last Available: "2010-02"
@@ -4456,13 +4456,13 @@
 4508	double-modified &quot;DRINK ME&quot; potion	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 26, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	normal walrus ice cream	4	good	Last Available: "2010-03"
-4511	decent miniature upside-down beautiful soup	2	good	Last Available: "2010-03"
+4511	miniature decent upside-down beautiful soup	2	good	Last Available: "2010-03"
 4512	blurry eggman noodles	0		Last Available: "2010-03"
-4513	red wobbly Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	jumbo flavorless Humpty Dumplings	5	decent	Last Available: "2010-03"
-4515	snack-sized bland upside-down Lobster <i>qua</i> Grill	2	decent	Last Available: "2010-03"
+4513	wobbly red Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
+4514	flavorless jumbo Humpty Dumplings	5	decent	Last Available: "2010-03"
+4515	bland snack-sized upside-down Lobster <i>qua</i> Grill	2	decent	Last Available: "2010-03"
 4516	extra-dry perfectly mixed missing wine	5	EPIC	Last Available: "2010-03"
-4517	small delicious tumbling matter custard	2	awesome	Last Available: "2010-03"
+4517	delicious small tumbling matter custard	2	awesome	Last Available: "2010-03"
 4518	energized teal spinning comfit?	0		Effect: "Halloweeny", Effect Duration: 61, Last Available: "2010-03"
 4519	mirror ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	teal jittery miser's nippy flamingo mallet	0		Cold Damage: +10, Meat Drop: +10, Last Available: "2010-03"
@@ -4476,11 +4476,11 @@
 4528	normal big dragon snaps	5	good	Last Available: "2010-03"
 4529	aromatic flame-retardant snapdragon pistil	0		Hot Resistance: +1, Stench Resistance: +1, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	spoiled super-sized rook cookie	5	crappy	Last Available: "2010-03"
-4532	stale huge bishop cookie	6	decent	Last Available: "2010-03"
+4531	super-sized spoiled rook cookie	5	crappy	Last Available: "2010-03"
+4532	huge stale bishop cookie	6	decent	Last Available: "2010-03"
 4533	flavorless knight cookie	3	decent	Last Available: "2010-03"
 4534	rotten king cookie	3	crappy	Last Available: "2010-03"
-4535	adequate lime green bouncing queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
+4535	adequate bouncing lime green queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	ghostly fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	pulsating Jack Frost's insane tophat	0		Cold Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
 4538	bouncing therapeutic smartaleck's helm of the knight	0		Moxie Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
@@ -4507,14 +4507,14 @@
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
-4562	narrow bouncing hair of the calf	0		Last Available: "2010-04"
-4563	triple-distilled hand-crafted world's most unappetizing beverage	8	EPIC	Last Available: "2010-04"
+4562	bouncing narrow hair of the calf	0		Last Available: "2010-04"
+4563	hand-crafted triple-distilled world's most unappetizing beverage	8	EPIC	Last Available: "2010-04"
 4564	avaricious slippery when wet shield	0		Meat Drop: +30, Damage Reduction: 6, Last Available: "2010-04"
 4565	decent raisin	3	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	blurry fortified flyest of shirts of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +60, Last Available: "2010-04"
 4568	rotten a dance upon the palate	3	crappy	Last Available: "2010-04"
-4569	fancy rotten small huge shaking prehistoric meteorite jawbreaker	2	crappy	Effect: "Hairless and Airless", Effect Duration: 35, Last Available: "2010-04"
+4569	rotten small fancy huge shaking prehistoric meteorite jawbreaker	2	crappy	Effect: "Hairless and Airless", Effect Duration: 35, Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	flavorless maroon squirmy violent party snack	3	decent	Last Available: "2010-04"
 4572	blinking rock-hard can-you-dig-it?	0		Damage Reduction: 5, Last Available: "2010-04"
@@ -4523,12 +4523,12 @@
 4575	bouncing bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4577	squat bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4578	narrow cyan meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
+4578	cyan narrow meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	moist upside-down Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Mortarfied", Effect Duration: 13, Last Available: "2010-04"
 4580	Tesla school Mafi<i>a kni</i>cke&frac12;&aelig;	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-04"
-4581	lard-coated smartaleck's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	lard-coated smartaleck's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	jittery fat bottom quark	0		Last Available: "2010-05"
-4583	blinking pulsating glob of skin	0		
+4583	pulsating blinking glob of skin	0		
 4584	decent olive six wedges of goat cheese	3	good	
 4585	collection of objects	0		
 4586	boulder	0		
@@ -4550,8 +4550,8 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	prompt padded bottle of Goldschn&ouml;ckered	0		Damage Absorption: +20, Adventures: +3, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	gigantic stale blurry spinning sun-dried tofu	9	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	prompt padded bottle of Goldschn&ouml;ckered	0		Damage Absorption: +20, Adventures: +3, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4606	gigantic stale spinning blurry sun-dried tofu	9	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	acceptable gray soyburger juice	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	cyan respected companion biscuit	0		Last Available: "2010-08"
 4609	squat essential tofu	0		Last Available: "2010-08"
@@ -4565,16 +4565,16 @@
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
-4620	twirling lime green motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
+4620	lime green twirling motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	pulsating Game Grid ticket	0		Last Available: "2010-06"
 4623	activated pressed wobbly chocolate-covered caviar	0		Effect: "Educated (Kinda)", Effect Duration: 50, Last Available: "2020-09"
-4624	spoiled enchanted half-sized pawn cookie	2	crappy	Effect: "Chorale of Companionship", Effect Duration: 40, Last Available: "2010-06"
+4624	spoiled half-sized enchanted pawn cookie	2	crappy	Effect: "Chorale of Companionship", Effect Duration: 40, Last Available: "2010-06"
 4625	denatured coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	jittery superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	cyan forbidden plastic spider ring	0		Spell Damage Percent: +50, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	cyan forbidden plastic spider ring	0		Spell Damage Percent: +50, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	red plastic kazoo of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-06"
 4631	purple boxer's inflatable baseball bat	0		Muscle Percent: +10, Last Available: "2010-06"
 4632	squat chilly googly-star hat of the empath	0		Familiar Weight: +5, Cold Damage: +5, Familiar Effect: "atk", Last Available: "2010-06"
@@ -4606,8 +4606,8 @@
 4658	spinning map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	padded blackberry galoshes	0		Damage Absorption: +20, Single Equip
 4660	auspicious double-paned trout fang	0		Cold Resistance: +5, Item Drop: +10, Last Available: "2010-09"
-4661	spoiled huge poisonous caviar	8	crappy	Last Available: "2010-09"
-4662	boiled skewed cyan wet venom duct	0		Effect: "Slimy Flavor", Effect Duration: 31, Last Available: "2010-09"
+4661	huge spoiled poisonous caviar	8	crappy	Last Available: "2010-09"
+4662	boiled cyan skewed wet venom duct	0		Effect: "Slimy Flavor", Effect Duration: 31, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	zippy Samson's Ellsbury's skull	0		Experience (Muscle): +5, Initiative: +20, Last Available: "2010-09"
 4665	dog trainer's hot plate	0		Experience (familiar): +1, Damage Reduction: 3
@@ -4615,11 +4615,11 @@
 4667	pulsating frosty Victor, the Insult Comic Hellhound Puppet	0		Cold Spell Damage: +10
 4668	tumbling yellow Van der Graaf observational glasses	0		MP Regen Min: 5, MP Regen Max: 7
 4669	hilarious comedy prop of incineration	0		Hot Spell Damage: +50
-4670	wobbly blinking olive beer-scented teddy bear	0		
+4670	olive blinking wobbly beer-scented teddy bear	0		
 4671	aged booze-soaked cherry	3	awesome	
 4672	comfy pillow	0		
-4673	miniature stale marshmallow	2	decent	
-4674	delicious jumbo sponge cake	5	awesome	
+4673	stale miniature marshmallow	2	decent	
+4674	jumbo delicious sponge cake	5	awesome	
 4675	bad gin-soaked blotter paper	4	decent	
 4676	tree-holed coin	0		
 4677	bouncing unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4645,11 +4645,11 @@
 4697	pulsating auspicious fossilized necklace	0		Item Drop: +10, Last Available: "2010-09"
 4698	red imp air	0		
 4699	bus pass	0		
-4700	jittery skewed fossilized spike	0		Last Available: "2010-09"
+4700	skewed jittery fossilized spike	0		Last Available: "2010-09"
 4701	olive waterlogged crate	0		Last Available: "2011-12"
 4702	lime green archaeologing shovel	0		Last Available: "2011-12"
 4703	wholesome red-hot medallion	0		Maximum HP Percent: +10, Single Equip, Last Available: "2010-09"
-4704	purple upside-down fossilized demon skull	0		Last Available: "2010-09"
+4704	upside-down purple fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
@@ -4659,22 +4659,22 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	snack-sized flavorless jittery lemon popsicle	2	decent	
+4714	flavorless snack-sized jittery lemon popsicle	2	decent	
 4715	normal snack-sized popsicle	2	good	
-4716	small stale strawberry popsicle	2	decent	
+4716	stale small strawberry popsicle	2	decent	
 4717	decent liver popsicle	4	good	
 4718	stanky mariachi hat	0		Stench Spell Damage: +25, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	pulsating organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	jittery microwave stogie	0		Last Available: "2011-12"
-4722	fancy bland liver and let pie	3	decent	Effect: "The Rich Get Richer", Effect Duration: 45, Last Available: "2010-10"
+4722	bland fancy liver and let pie	3	decent	Effect: "The Rich Get Richer", Effect Duration: 45, Last Available: "2010-10"
 4723	moldy badass pie	4	crappy	Last Available: "2010-10"
 4724	fancy spoiled shoo-fish pie	3	crappy	Effect: "meat.enh", Effect Duration: 50, Last Available: "2010-10"
 4725	tasty piping organ pie	4	awesome	Last Available: "2010-10"
 4726	spoiled fuchsia huge igloo pie	4	crappy	Last Available: "2010-10"
 4727	toothsome diet spinning stomach turnover	1	awesome	Last Available: "2010-10"
 4728	toothsome blue dead lights pie	3	awesome	Last Available: "2010-10"
-4729	stale special throbbing organ pie	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 40, Last Available: "2010-10"
+4729	special stale throbbing organ pie	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 40, Last Available: "2010-10"
 4730	green dance instructor's stop shield	0		Experience Percent (Moxie): +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	shaking nest egg	0		
 4732	mirror sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,17 +4683,17 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	savvy beer-soaked mop	0		Mysticality Percent: +20
-4738	aged irresponsibly strong enchanted fuchsia wobbly day-old beer	7	awesome	Effect: "Familial Ties", Effect Duration: 45
-4739	weak mediocre plain beer	2	decent	
+4738	aged enchanted irresponsibly strong fuchsia wobbly day-old beer	7	awesome	Effect: "Familial Ties", Effect Duration: 45
+4739	mediocre weak plain beer	2	decent	
 4740	delicious strong overpriced &quot;imported&quot; beer	5	awesome	
 4741	narrow smiling rat	0		
 4742	blurry rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	altered electrified oxidized PlexiPips	0		Effect: "Egg Burps", Effect Duration: 58
-4745	extra-chilled twirling jittery Wax Flask	0		Effect: "Brain Freeze", Effect Duration: 39
+4745	extra-chilled jittery twirling Wax Flask	0		Effect: "Brain Freeze", Effect Duration: 39
 4746	alkaline flattened Pain Dip	0		Effect: "Fudge Headache", Effect Duration: 69
 4747	moldy bone meal	4	crappy	Last Available: "2010-10"
-4748	tolerable watered-down bone aperitif	2	good	Last Available: "2010-10"
+4748	watered-down tolerable bone aperitif	2	good	Last Available: "2010-10"
 4749	green Herculean bonerang	0		Experience (Muscle): +1, Last Available: "2010-10"
 4750	maroon bone and arrows of the storm	0		Maximum MP Percent: +40, Last Available: "2010-10"
 4751	teal boning knife of the boozehound	0		Booze Drop: +100, Last Available: "2010-10"
@@ -4708,25 +4708,25 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	tumbling pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	rotten miniature mirror pulsating spinning pumpkin pie	2	crappy	Last Available: "2010-11"
-4764	special acceptable pumpkin beer	4	good	Effect: "Well-Oiled", Effect Duration: 5, Last Available: "2010-11"
+4763	miniature rotten spinning mirror pulsating pumpkin pie	2	crappy	Last Available: "2010-11"
+4764	acceptable special pumpkin beer	4	good	Effect: "Well-Oiled", Effect Duration: 5, Last Available: "2010-11"
 4765	ionized pumpkin juice	0		Effect: "Items Are Forever", Effect Duration: 32, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	hale shin gourds of the scaredy-cat	0		Maximum HP: +20, Monster Level: -15, Single Equip, Last Available: "2010-11"
 4768	rock-hard Herculean Staff of the November Jack-O-Lantern of wisdom	0		Mysticality: +15, Experience (Muscle): +1, Damage Reduction: 5, Last Available: "2010-11"
 4769	tumbling pumpkin carriage	0		Last Available: "2010-11"
 4770	mirror Desert Bus pass	0		
-4771	wobbly upside-down ginormous pumpkin	0		Last Available: "2010-11"
+4771	upside-down wobbly ginormous pumpkin	0		Last Available: "2010-11"
 4804	blinking Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
 4806	huge yellow Unmotivator: Success Warrior	0		Free Pull
 4807	lime green Unmotivator: Crashed Meat Car	0		Free Pull
-4810	cyan huge Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
+4810	huge cyan Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	upside-down Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	spoiled CRIMBCOIDS mints	4	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	normal huge CRIMBCOLOAF	7	good	Last Available: "2011-01"
+4820	huge normal CRIMBCOLOAF	7	good	Last Available: "2011-01"
 4821	rotten circular CRIMBCOOKIE	3	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	vibrating plastic CRIMBCO HQ	0		Maximum MP Percent: +10, Last Available: "2010-12"
 4823	jittery wholesome plastic fax machine	0		Maximum HP Percent: +10, Last Available: "2010-12"
@@ -4746,7 +4746,7 @@
 4837	tumbling robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	rotten twirling triangular CRIMBCOOKIE	4	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	moldy huge square CRIMBCOOKIE	7	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	huge moldy square CRIMBCOOKIE	7	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	lime green pulsating rosy-cheeked quilted Socratic bindlestocking	0		Experience (Mysticality): +1, Damage Absorption: +40, Maximum HP Percent: +30, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	bouncing Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4767,7 +4767,7 @@
 4858	skewed fortified CRIMBCO lanyard	0		Damage Absorption: +60, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	spinning CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-4861	blurry maroon CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
+4861	maroon blurry CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	tumbling CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	jittery CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	photocopier	0		Last Available: "2011-01"
@@ -4792,13 +4792,13 @@
 4883	toe jam	0		Last Available: "2011-01"
 4884	bland toe jam toast	3	decent	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	huge adequate traffic jam toast	9	good	Last Available: "2011-01"
+4886	adequate huge traffic jam toast	9	good	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	spoiled miniature space jam toast	2	crappy	Last Available: "2011-01"
 4889	corrupted pickled bouncing motivational poster	0		Effect: "Jingle Jangle Jingle", Effect Duration: 59, Last Available: "2011-01"
-4890	blinking bouncing green sack lunch	0		Last Available: "2011-01"
+4890	blinking green bouncing sack lunch	0		Last Available: "2011-01"
 4891	pulsating bath ball gift set	0		Last Available: "2011-01"
-4892	mirror twirling slow jam collection	0		Last Available: "2011-01"
+4892	twirling mirror slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	moldy festive sausage	3	crappy	Last Available: "2011-01"
 4895	massive stale wobbly bouncing holiday cheese log	7	decent	Last Available: "2011-01"
@@ -4860,7 +4860,7 @@
 4957	quadruple-corrupted half-baked potion	0		Effect: "Mushroom Might", Effect Duration: 59
 4958	chaotic Knob Goblin deluxe scimitar	0		Spell Critical Percent: +10
 4959	spoiled red Knob nuts	4	crappy	
-4960	watered-down acceptable Cobb's Knob Wurstbrau	2	good	
+4960	acceptable watered-down Cobb's Knob Wurstbrau	2	good	
 4961	Subject 37 file	0		
 4962	Usain Bolt's auspicious mysterious lapel pin	0		Item Drop: +10, Initiative: +80, Single Equip
 4963	maroon state loom	0		Familiar Weight: +10
@@ -4915,7 +4915,7 @@
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	stale huge wasabi pocky	3	decent	Last Available: "2011-03"
 5014	stale narrow tobiko pocky	3	decent	Last Available: "2011-03"
-5015	bland bite-sized jittery natto pocky	1	decent	Last Available: "2011-03"
+5015	bite-sized bland jittery natto pocky	1	decent	Last Available: "2011-03"
 5016	watered-down bad wasabi-infused sake	2	decent	Last Available: "2011-03"
 5017	smooth tobiko-infused sake	3	awesome	Last Available: "2011-03"
 5018	tolerable natto-infused sake	4	good	Last Available: "2011-03"
@@ -4961,11 +4961,11 @@
 5058	tarnished diffused Red Pill	0		Effect: "Army of One", Effect Duration: 61, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
-5061	squat shaking boxing-glove-in-a-box	0		Last Available: "2011-04"
+5061	shaking squat boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	shaking shaking voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	rotten gigantic spinning spaghetti con calaveras	6	crappy	Last Available: "2011-04"
+5065	gigantic rotten spinning spaghetti con calaveras	6	crappy	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	moldy mirror popcorn	3	crappy	Last Available: "2011-04"
 5068	tiny rotten chaos popcorn	1	crappy	Last Available: "2011-04"
@@ -5007,15 +5007,15 @@
 5104	electrified modified fish juice box	0		Effect: "Very Clean Guns", Effect Duration: 18, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	fancy spirit-forward acceptable Jeppson's Malort	5	good	Effect: "Your Favorite Flavor", Effect Duration: 25, Last Available: "2011-06"
+5107	fancy acceptable spirit-forward Jeppson's Malort	5	good	Effect: "Your Favorite Flavor", Effect Duration: 25, Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	stress ball of Leguizamo	0		Monster Level: +20, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	stress ball of Leguizamo	0		Monster Level: +20, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Annie Oakley's Ultracolor&trade; shirt	0		Critical Hit Percent: +20, Last Available: "2011-05"
 5112	bouncing My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	gray packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
-5115	ghostly red hedge trimmers	0		
+5115	red ghostly hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	shaking bird brain	0		
@@ -5032,8 +5032,8 @@
 5129	green Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	twirling Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	ionized colloidal squat Ultrasoldier Serum	0		Effect: "Old School Pompadour", Effect Duration: 35, Last Available: "2011-06"
-5132	normal small elven hardtack	2	good	Last Available: "2011-06"
-5133	tolerable upside-down jittery elven squeeze	4	good	Last Available: "2011-06"
+5132	small normal elven hardtack	2	good	Last Available: "2011-06"
+5133	tolerable jittery upside-down elven squeeze	4	good	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	twirling E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5075,23 +5075,23 @@
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	practically non-alcoholic hand-crafted purple spinning Saison du Lune	1	super ultra EPIC	Last Available: "2011-06"
-5175	weak tolerable Moonthril Schnapps	2	good	Last Available: "2011-06"
-5176	weak drinkable skewed Wrecked Generator	2	good	Last Available: "2011-06"
+5175	tolerable weak Moonthril Schnapps	2	good	Last Available: "2011-06"
+5176	drinkable weak skewed Wrecked Generator	2	good	Last Available: "2011-06"
 5177	rotten Spaghetti with Moonballs	3	crappy	Last Available: "2011-06"
-5178	stale bouncing lime green Crepes a la Lune	3	decent	Last Available: "2011-06"
-5179	bland huge bouncing Moon Pie	4	decent	Last Available: "2011-06"
+5178	stale lime green bouncing Crepes a la Lune	3	decent	Last Available: "2011-06"
+5179	bland bouncing huge Moon Pie	4	decent	Last Available: "2011-06"
 5180	tarnished flattened jittery Comet Pop	0		Effect: "Flexibili Tea", Effect Duration: 59, Last Available: "2011-06"
 5181	quadruple-moist Flan in the Moon	0		Effect: "Hombre Muerto Caminando", Effect Duration: 17, Last Available: "2011-06"
 5182	pressed jittery 1/6th Pound Cake	0		Effect: "Floundering", Effect Duration: 50, Last Available: "2011-06"
 5183	spinning Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
-5184	pulsating shaking Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
+5184	shaking pulsating Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	quantum extra-colloidal quantum blinking honey stick	0		Effect: "All Blued Up", Effect Duration: 34
 5189	flattened improved double-ice gum	0		Effect: "Egg Burps", Effect Duration: 49, Last Available: "2011-04"
-5190	Rosewater's Operation Patriot Shield of the dark arts of Calamity Jane	0		Mysticality Percent: +30, Spell Damage Percent: +100, Critical Hit Percent: +15, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
-5191	twirling mirror squirming egg sac	0		Last Available: "2011-06"
+5190	Rosewater's Operation Patriot Shield of the dark arts of Calamity Jane	0		Mysticality Percent: +30, Spell Damage Percent: +100, Critical Hit Percent: +15, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5191	mirror twirling squirming egg sac	0		Last Available: "2011-06"
 5192	flattened magnetized deionized corrupted data	0		Effect: "Crimbo Nostalgia", Effect Duration: 56, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
 5194	exorcised sandwich	0		
@@ -5101,7 +5101,7 @@
 5198	pickled wobbly gooey paste	1	decent	Last Available: "2011-08"
 5199	boiled blinking beastly paste	1	EPIC	Effect: "Pla-see-bo", Effect Duration: 25, Last Available: "2011-08"
 5200	modified narrow blurry paste	1	decent	Effect: "Healthy Green Glow", Effect Duration: 20, Last Available: "2011-08"
-5201	mixed jittery blue tumbling ectoplasmic paste	1	awesome	Last Available: "2011-08"
+5201	mixed blue tumbling jittery ectoplasmic paste	1	awesome	Last Available: "2011-08"
 5202	boiled greasy paste	1	decent	Last Available: "2011-08"
 5203	dried twirling bug paste	1	good	Last Available: "2011-08"
 5204	pickled upside-down hippy paste	1	good	Last Available: "2011-08"
@@ -5111,7 +5111,7 @@
 5208	compressed maroon paste	1	decent	Last Available: "2011-08"
 5209	diluted skewed twirling goblin paste	1	good	Effect: "Fury of the Bells", Effect Duration: 35, Last Available: "2011-08"
 5210	compressed pirate paste	1	awesome	Last Available: "2011-08"
-5211	twisted ghostly wobbly chlorophyll paste	1	crappy	Last Available: "2011-08"
+5211	twisted wobbly ghostly chlorophyll paste	1	crappy	Last Available: "2011-08"
 5212	compressed gray paste	1	decent	Last Available: "2011-08"
 5213	compressed Mer-kin paste	1	good	Last Available: "2011-08"
 5214	compressed twirling slimy paste	1	EPIC	Last Available: "2011-08"
@@ -5139,24 +5139,24 @@
 5236	rosy-cheeked frosty halo	0		Maximum HP Percent: +30, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of Leguizamo	0		Monster Level: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	drinkable Lumineux Limnio	4	good	Last Available: "2011-09"
-5239	acceptable extra-dry Morto Moreto	5	good	Last Available: "2011-09"
+5239	extra-dry acceptable Morto Moreto	5	good	Last Available: "2011-09"
 5240	bad watered-down Temps Tempranillo	2	decent	Last Available: "2011-09"
 5241	strong lousy upside-down Bordeaux Marteaux	5	decent	Last Available: "2011-09"
-5242	lousy irresponsibly strong Fromage Pinotage	7	decent	Last Available: "2011-09"
-5243	tolerable extra-dry Beignet Milgranet	5	good	Last Available: "2011-09"
+5242	irresponsibly strong lousy Fromage Pinotage	7	decent	Last Available: "2011-09"
+5243	extra-dry tolerable Beignet Milgranet	5	good	Last Available: "2011-09"
 5244	artisanal jittery Muschat	4	EPIC	Last Available: "2011-09"
-5245	jumbo toothsome green cool jelly donut	5	awesome	Last Available: "2011-09"
-5246	bland super-sized shrapnel jelly donut	5	decent	Last Available: "2011-09"
-5247	small stale occult jelly donut	2	decent	Last Available: "2011-09"
+5245	toothsome jumbo green cool jelly donut	5	awesome	Last Available: "2011-09"
+5246	super-sized bland shrapnel jelly donut	5	decent	Last Available: "2011-09"
+5247	stale small occult jelly donut	2	decent	Last Available: "2011-09"
 5248	stale pulsating thyme jelly donut	4	decent	Last Available: "2011-09"
 5249	stale danish	3	decent	Last Available: "2011-09"
 5250	decent smashed danish	3	good	Last Available: "2011-09"
 5251	moldy forbidden danish	3	crappy	Last Available: "2011-09"
-5252	bland half-sized wobbly cool cat claw	2	decent	Last Available: "2011-09"
-5253	adequate miniature special blunt cat claw	2	good	Effect: "Sweet Incentive", Effect Duration: 15, Last Available: "2011-09"
+5252	half-sized bland wobbly cool cat claw	2	decent	Last Available: "2011-09"
+5253	adequate special miniature blunt cat claw	2	good	Effect: "Sweet Incentive", Effect Duration: 15, Last Available: "2011-09"
 5254	decent special ghostly shadowy cat claw	3	good	Effect: "Flamingly Floral", Effect Duration: 35, Last Available: "2011-09"
 5255	tasty cheezburger	4	awesome	Last Available: "2011-09"
-5256	stale bite-sized green toasted brie	1	decent	Last Available: "2011-09"
+5256	bite-sized stale green toasted brie	1	decent	Last Available: "2011-09"
 5257	Vulcanized potion of the field gar	0		Effect: "Seeing Colors", Effect Duration: 21, Last Available: "2011-09"
 5258	pressed too legit potion	0		Effect: "Puddingface", Effect Duration: 42, Last Available: "2011-09"
 5259	frozen squat Bright Water	0		Effect: "Devil Inside", Effect Duration: 41, Last Available: "2011-09"
@@ -5172,7 +5172,7 @@
 5269	narrow bobcat grenade	0		Last Available: "2011-09"
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	teal broken glass grenade	0		Last Available: "2011-09"
-5272	purple blurry noxious gas grenade	0		Last Available: "2011-09"
+5272	blurry purple noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	lime green resourceful hammerus	0		Maximum MP: +50, Last Available: "2011-09"
@@ -5198,8 +5198,8 @@
 5295	spinning newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	shaking dungeon dragon chest	0		Last Available: "2011-09"
-5298	super-sized stale blinking phish stick	5	decent	Last Available: "2011-09"
-5299	ghostly padded groovy plastic vampire fangs of chilblains	0		Moxie Percent: +10, Damage Absorption: +20, Cold Damage: +25, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5298	stale super-sized blinking phish stick	5	decent	Last Available: "2011-09"
+5299	ghostly padded groovy plastic vampire fangs of chilblains	0		Moxie Percent: +10, Damage Absorption: +20, Cold Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5222,11 +5222,11 @@
 5319	denatured skewed Blood 'n' Plenty	0		Effect: "Souper Vengeful", Effect Duration: 17, Last Available: "2011-10"
 5320	tarnished quantum magnetized Lobos Mints	0		Effect: "Permanent Halloween", Effect Duration: 51, Last Available: "2011-10"
 5321	boiled quadruple-unsweetened Sweet Sword	0		Effect: "Intimidating Mien", Effect Duration: 30, Last Available: "2011-10"
-5322	high-proof lousy Ecto-Cooler	6	decent	Last Available: "2011-10"
+5322	lousy high-proof Ecto-Cooler	6	decent	Last Available: "2011-10"
 5323	irresponsibly strong mediocre Bartles and BRAAAINS wine cooler	6	decent	Last Available: "2011-10"
 5324	perfectly mixed watered-down Blood Light	2	EPIC	Last Available: "2011-10"
 5325	artisanal boozy Silver Bullet beer	5	EPIC	Last Available: "2011-10"
-5326	fancy lousy Bone's Farm &quot;wine&quot;	3	decent	Effect: "Wintergreen Warmongery", Effect Duration: 20, Last Available: "2011-10"
+5326	lousy fancy Bone's Farm &quot;wine&quot;	3	decent	Effect: "Wintergreen Warmongery", Effect Duration: 20, Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	super-nitrogenated irradiated triple-activated sorority brain	0		Effect: "Carol of the Bones", Effect Duration: 18, Last Available: "2011-10"
 5329	cold-filtered Nightstalker perfume	0		Effect: "Infernal Thirst", Effect Duration: 60, Last Available: "2011-10"
@@ -5245,7 +5245,7 @@
 5342	delicious The Cooler Out of Space	4	awesome	Last Available: "2011-10"
 5343	blurry The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
-5345	alkaline blurry mirror Necbro wafers	0		Effect: "Corona de la Salsa", Effect Duration: 51, Last Available: "2020-09"
+5345	alkaline mirror blurry Necbro wafers	0		Effect: "Corona de la Salsa", Effect Duration: 51, Last Available: "2020-09"
 5346	death blossom	0		
 5347	tumbling A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	narrow A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -5290,7 +5290,7 @@
 5387	prompt ridiculous earring	0		Adventures: +3, Last Available: "2011-11"
 5388	ridiculous sunglasses of the storm	0		Maximum MP Percent: +40, Last Available: "2011-11"
 5389	spoiled ridiculous sandwich	3	crappy	Last Available: "2011-11"
-5390	weak bad ridiculous cocktail	2	decent	Last Available: "2011-11"
+5390	bad weak ridiculous cocktail	2	decent	Last Available: "2011-11"
 5391	groovy zombie monkey necklace of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50
 5392	Thwaitgold butterfly statuette	0		
 5393	blinking scrap of paper	0		
@@ -5310,14 +5310,14 @@
 5407	bad green Vodka Matryoshka	4	decent	Last Available: "2011-12"
 5408	bad watered-down Gin Mint	2	decent	Last Available: "2011-12"
 5409	bad watered-down twirling Tequiz Navidad	2	decent	Last Available: "2011-12"
-5410	perfectly mixed watered-down Mint Yulep	2	EPIC	Last Available: "2011-12"
+5410	watered-down perfectly mixed Mint Yulep	2	EPIC	Last Available: "2011-12"
 5411	boozy bad Crimbojito	5	decent	Last Available: "2011-12"
 5412	mediocre Sangria de Menthe	4	decent	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	dry ghostly licorice root	0		Effect: "Sweet and Green", Effect Duration: 40, Last Available: "2011-12"
 5416	extra-ionized wet banana supersucker	0		Effect: "Pretending to Pretend", Effect Duration: 50, Last Available: "2011-11"
-5417	oxidized tumbling red pear supersucker	0		Effect: "Starry-Eyed", Effect Duration: 24, Last Available: "2011-11"
+5417	oxidized red tumbling pear supersucker	0		Effect: "Starry-Eyed", Effect Duration: 24, Last Available: "2011-11"
 5418	warmed blurry spinning spinning lime supersucker	0		Effect: "Superveiny 9000", Effect Duration: 59, Last Available: "2011-11"
 5419	energized kumquat supersucker	0		Effect: "Mushroom Moxiousness", Effect Duration: 32, Last Available: "2011-11"
 5420	wet electrified red strawberry supersucker	0		Effect: "Black Eyes", Effect Duration: 28, Last Available: "2011-11"
@@ -5331,7 +5331,7 @@
 5428	purple sucker kabuto of the detective	0		Item Drop: +20, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	blinking maroon sucker tachi of dire peril	0		Weapon Damage: +20, Last Available: "2011-11"
 5430	cyan sucker scaffold	0		Last Available: "2011-11"
-5431	green blurry cinnamon troll doll	0		Last Available: "2011-11"
+5431	blurry green cinnamon troll doll	0		Last Available: "2011-11"
 5432	grape troll doll	0		Last Available: "2011-11"
 5433	spinning raspberry troll doll	0		Last Available: "2011-11"
 5434	DNOTC Box	0		Last Available: "2017-12"
@@ -5349,7 +5349,7 @@
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
-5449	ghostly twirling vanity stone	0		Last Available: "2012-12"
+5449	twirling ghostly vanity stone	0		Last Available: "2012-12"
 5450	lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	avarice stone	0		Last Available: "2012-12"
@@ -5357,19 +5357,19 @@
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
-5457	corrupted lime green huge Fudgie Roll	0		Effect: "All Branned Up", Effect Duration: 63, Last Available: "2011-11"
+5457	corrupted huge lime green Fudgie Roll	0		Effect: "All Branned Up", Effect Duration: 63, Last Available: "2011-11"
 5458	massive delicious fudge bunny	8	awesome	Last Available: "2011-11"
 5459	spinning tumbling fudge spork	0		Last Available: "2011-11"
 5460	nasty scorching Newton's fudgecycle	0		Experience (Mysticality): +3, Hot Damage: +25, Stench Damage: +5, Single Equip, Last Available: "2011-11"
 5461	tumbling fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
-5464	nitrogenated diffused olive jittery tumbling resolution: be wealthier	0		Effect: "Jammin'", Effect Duration: 32, Last Available: "2012-01"
+5464	nitrogenated diffused jittery tumbling olive resolution: be wealthier	0		Effect: "Jammin'", Effect Duration: 32, Last Available: "2012-01"
 5465	polarized yellow resolution: be happier	0		Effect: "Oxygenated Blood", Effect Duration: 46, Last Available: "2012-01"
 5466	chilled pickled resolution: be stronger	0		Effect: "Tingling Feeling", Effect Duration: 55, Last Available: "2012-01"
 5467	unsweetened chilled upside-down resolution: be smarter	0		Effect: "Void Between the Stars", Effect Duration: 32, Last Available: "2012-01"
 5468	double-cold-filtered polymerized wobbly resolution: be sexier	0		Effect: "Burning Tongue", Effect Duration: 65, Last Available: "2012-01"
-5469	extra-energized skewed narrow resolution: be feistier	0		Effect: "Shamboozled", Effect Duration: 65, Last Available: "2012-01"
+5469	extra-energized narrow skewed resolution: be feistier	0		Effect: "Shamboozled", Effect Duration: 65, Last Available: "2012-01"
 5470	pressed twirling resolution: be kinder	0		Effect: "20/20 Vision", Effect Duration: 69, Last Available: "2012-01"
 5471	deionized polarized huge resolution: be more adventurous	0		Effect: "Meadulla Oblongota", Effect Duration: 36, Last Available: "2012-01"
 5472	non-wet twirling resolution: be luckier	0		Effect: "Perfect Hair", Effect Duration: 56, Last Available: "2012-01"
@@ -5380,10 +5380,10 @@
 5477	ionized dry blinking gummi snake	0		Effect: "Creepin' Up on You", Effect Duration: 37, Last Available: "2011-11"
 5478	triple-polarized oxidized upside-down gummi canary	0		Effect: "Nightstalkin'", Effect Duration: 41, Last Available: "2011-11"
 5479	tasty miniature gummi bear	2	awesome	Last Available: "2011-11"
-5480	snack-sized bland mirror gummi bear	2	decent	Last Available: "2011-11"
+5480	bland snack-sized mirror gummi bear	2	decent	Last Available: "2011-11"
 5481	rotten gummi bear	3	crappy	Last Available: "2011-11"
 5482	half-sized tasty drunki-bear	2	awesome	Last Available: "2011-11"
-5483	tasty snack-sized drunki-bear	2	awesome	Last Available: "2011-11"
+5483	snack-sized tasty drunki-bear	2	awesome	Last Available: "2011-11"
 5484	moldy drunki-bear	4	crappy	Last Available: "2011-11"
 5485	slick gummi bowtie	0		Moxie: +10, Last Available: "2011-11"
 5486	lard-coated fudge pocket square	0		Sleaze Spell Damage: +25, Last Available: "2011-11"
@@ -5392,7 +5392,7 @@
 5489	ammonite fossil	0		Last Available: "2011-11"
 5490	belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
-5492	blue mirror shaking tumbling ammonite candy mold	0		Last Available: "2011-11"
+5492	mirror tumbling blue shaking ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	super-chilled aerosolized narrow gummi trilobite	0		Effect: "Eye of the Seal", Effect Duration: 54, Last Available: "2011-11"
 5495	double-cold-filtered wobbly huge gummi ammonite	0		Effect: "OMG WTF", Effect Duration: 23, Last Available: "2011-11"
@@ -5415,7 +5415,7 @@
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	wobbly Trivial Avocations Card: Where?	0		Last Available: "2011-11"
-5515	twirling spinning pog #01 (spider)	0		Last Available: "2011-11"
+5515	spinning twirling pog #01 (spider)	0		Last Available: "2011-11"
 5516	red pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
@@ -5444,9 +5444,9 @@
 5541	purple Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	greedy forbidden Leapin' Trousers	0		Spell Damage Percent: +50, Meat Drop: +20
-5544	artisanal watered-down eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
+5544	watered-down artisanal eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
 5545	normal hamhock	4	good	Last Available: "2012-12"
-5546	narrow teal The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
+5546	teal narrow The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	olive Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
 5549	Clancy's crumhorn	0		Last Available: "2012-12"
@@ -5483,37 +5483,37 @@
 5580	acceptable fortified blue Locust	5	good	Last Available: "2012-03"
 5581	drinkable Plague of Locusts	4	good	Last Available: "2012-03"
 5582	drinkable irresponsibly strong Red Dwarf	9	good	Last Available: "2012-03"
-5583	acceptable triple-distilled Golden Mean	8	good	Last Available: "2012-03"
+5583	triple-distilled acceptable Golden Mean	8	good	Last Available: "2012-03"
 5584	hand-crafted Green Giant	3	EPIC	Last Available: "2012-03"
-5585	practically non-alcoholic bad Aye Aye	1	decent	Last Available: "2012-03"
-5586	tolerable upside-down blinking Aye Aye, Captain	4	good	Last Available: "2012-03"
+5585	bad practically non-alcoholic Aye Aye	1	decent	Last Available: "2012-03"
+5586	tolerable blinking upside-down Aye Aye, Captain	4	good	Last Available: "2012-03"
 5587	watered-down hand-crafted blurry Aye Aye, Tooth Tooth	2	EPIC	Last Available: "2012-03"
-5588	extra-dry enchanted bad Humanitini	5	decent	Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2012-03"
+5588	extra-dry bad enchanted Humanitini	5	decent	Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2012-03"
 5589	smooth weak More Humanitini than Humanitini	2	awesome	Last Available: "2012-03"
-5590	weak hand-crafted Oh, the Humanitini	2	EPIC	Last Available: "2012-03"
+5590	hand-crafted weak Oh, the Humanitini	2	EPIC	Last Available: "2012-03"
 5591	delicious watered-down Great Older Fashioned	2	awesome	Last Available: "2012-03"
-5592	watered-down artisanal Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5592	artisanal watered-down Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	delicious Crazymaker	3	awesome	Last Available: "2012-03"
 5594	drinkable jittery Zoodriver	4	good	Last Available: "2012-03"
-5595	drinkable irresponsibly strong Sloe Comfortable Zoo	7	good	Last Available: "2012-03"
+5595	irresponsibly strong drinkable Sloe Comfortable Zoo	7	good	Last Available: "2012-03"
 5596	hand-crafted olive Sloe Comfortable Zoo on Fire	3	EPIC	Last Available: "2012-03"
 5597	artisanal Suffering Sinner	4	EPIC	Last Available: "2012-03"
-5598	practically non-alcoholic aged upside-down Suppurating Sinner	1	awesome	Last Available: "2012-03"
+5598	aged practically non-alcoholic upside-down Suppurating Sinner	1	awesome	Last Available: "2012-03"
 5599	enchanted hand-crafted Sizzling Sinner	3	EPIC	Effect: "On the Trolley", Effect Duration: 45, Last Available: "2012-03"
 5600	tolerable olive Firewater	4	good	Last Available: "2012-03"
-5601	artisanal watered-down Earth and Firewater	2	EPIC	Last Available: "2012-03"
+5601	watered-down artisanal Earth and Firewater	2	EPIC	Last Available: "2012-03"
 5602	smooth irresponsibly strong Earth, Wind and Firewater	8	awesome	Last Available: "2012-03"
 5603	practically non-alcoholic delicious Slimosa	1	awesome	Last Available: "2012-03"
-5604	irresponsibly strong hand-crafted special Extra-slimy Slimosa	10	EPIC	Effect: "Surreally Buff", Effect Duration: 45, Last Available: "2012-03"
+5604	hand-crafted special irresponsibly strong Extra-slimy Slimosa	10	EPIC	Effect: "Surreally Buff", Effect Duration: 45, Last Available: "2012-03"
 5605	weak lousy Slimebite	2	decent	Last Available: "2012-03"
-5606	lousy watered-down ghostly Cement Mixer	2	decent	Last Available: "2012-03"
+5606	watered-down lousy ghostly Cement Mixer	2	decent	Last Available: "2012-03"
 5607	bad Jackhammer	4	decent	Last Available: "2012-03"
 5608	fancy mediocre Dump Truck	3	decent	Effect: "Spirit of Alph", Effect Duration: 35, Last Available: "2012-03"
 5609	aged Fauna Libre	4	awesome	Last Available: "2012-03"
-5610	tolerable practically non-alcoholic Chakra Libre	1	good	Last Available: "2012-03"
-5611	perfectly mixed enchanted watered-down Aura Libre	2	EPIC	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2012-03"
+5610	practically non-alcoholic tolerable Chakra Libre	1	good	Last Available: "2012-03"
+5611	perfectly mixed watered-down enchanted Aura Libre	2	EPIC	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2012-03"
 5612	lousy Sazerorc	4	decent	Last Available: "2012-03"
-5613	special acceptable irresponsibly strong skewed Sazuruk-hai	6	good	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2012-03"
+5613	special irresponsibly strong acceptable skewed Sazuruk-hai	6	good	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2012-03"
 5614	artisanal Flaming Sazerorc	4	EPIC	Last Available: "2012-03"
 5615	drinkable mirror Green Velvet	3	good	Last Available: "2012-03"
 5616	bad squat Green Muslin	3	decent	Last Available: "2012-03"
@@ -5522,7 +5522,7 @@
 5619	hand-crafted Moonshine Mohobo	3	EPIC	Last Available: "2012-03"
 5620	hand-crafted Flaming Mohobo	3	EPIC	Last Available: "2012-03"
 5621	mediocre weak Drunken Philosopher	2	decent	Last Available: "2012-03"
-5622	weak bad Drunken Neurologist	2	decent	Last Available: "2012-03"
+5622	bad weak Drunken Neurologist	2	decent	Last Available: "2012-03"
 5623	hand-crafted Drunken Astrophysicist	3	EPIC	Last Available: "2012-03"
 5624	mediocre Dark & Starry	3	decent	Last Available: "2012-03"
 5625	hand-crafted Black Hole	3	EPIC	Last Available: "2012-03"
@@ -5532,16 +5532,16 @@
 5629	drinkable Herringtini	3	good	Last Available: "2012-03"
 5630	perfectly mixed boozy Lollipop Drop	5	EPIC	Last Available: "2012-03"
 5631	delicious bouncing Candy Alexander	4	awesome	Last Available: "2012-03"
-5632	artisanal watered-down Candicaine	2	EPIC	Last Available: "2012-03"
-5633	weak artisanal spinning red Caipiranha	2	EPIC	Last Available: "2012-03"
+5632	watered-down artisanal Candicaine	2	EPIC	Last Available: "2012-03"
+5633	artisanal weak spinning red Caipiranha	2	EPIC	Last Available: "2012-03"
 5634	spirit-forward perfectly mixed Flying Caipiranha	5	EPIC	Last Available: "2012-03"
 5635	perfectly mixed lime green Flaming Caipiranha	3	EPIC	Last Available: "2012-03"
 5636	artisanal shaking huge Punchplanter	4	EPIC	Last Available: "2012-03"
-5637	practically non-alcoholic drinkable Doublepunchplanter	1	good	Last Available: "2012-03"
+5637	drinkable practically non-alcoholic Doublepunchplanter	1	good	Last Available: "2012-03"
 5638	lousy Haymaker	3	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	normal snack-sized fungus	2	good	
+5641	snack-sized normal fungus	2	good	
 5642	wobbly poisoned dart	0		
 5643	energized green stone wool	0		Effect: "Human-Elemental Hybrid", Effect Duration: 59
 5644	lime green stones	0		
@@ -5555,7 +5555,7 @@
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	normal nailswurst	4	good	
-5655	artisanal spirit-forward used beer	5	EPIC	
+5655	spirit-forward artisanal used beer	5	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	jittery fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5628,30 +5628,30 @@
 5727	resourceful therapeutic hot daub stand	0		Maximum MP: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	friendly Sinatra's foot-long hot daub	0		Experience (Moxie): +5, Familiar Weight: +3, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	special stale thick angst burger	5	decent	Effect: "Employee of the Month", Effect Duration: 20
+5730	special thick stale angst burger	5	decent	Effect: "Employee of the Month", Effect Duration: 20
 5731	bad 5-hour acrimony	4	decent	
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	bland tumbling forbidden sausage	3	decent	
-5735	knitted Lord Flameface's cloak	0		Cold Resistance: +3, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	knitted Lord Flameface's cloak	0		Cold Resistance: +3, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	warmed pickled Drizzlers&trade; Black Licorice	0		Effect: "Outer Wolf&trade;", Effect Duration: 24
 5737	cold-filtered adjusted daub-breaker	0		Effect: "Strong Spirit", Effect Duration: 64, Last Available: "2020-09"
 5738	stylish Camp Scout backpack	0		Moxie: +25, Softcore Only, Last Available: "2012-07"
 5739	maroon CSA fire-starting kit	0		Last Available: "2012-07"
 5740	spoiled bag of GORP	3	crappy	Last Available: "2012-07"
-5741	drinkable practically non-alcoholic water purification pills	1	good	Last Available: "2012-07"
+5741	practically non-alcoholic drinkable water purification pills	1	good	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	lousy practically non-alcoholic CSA scoutmaster's &quot;water&quot;	1	decent	Last Available: "2012-07"
-5744	enchanted stale wobbly lime green bag of GORF	4	decent	Effect: "Slime Time", Effect Duration: 40, Last Available: "2012-07"
+5744	stale enchanted lime green wobbly bag of GORF	4	decent	Effect: "Slime Time", Effect Duration: 40, Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	stale blurry maroon bag of QWOP	3	decent	Last Available: "2012-07"
 5747	frozen lime green CSA bravery badge	0		Effect: "Vinegavotte", Effect Duration: 19, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	bad watered-down CSA cheerfulness ration	2	decent	Last Available: "2012-07"
+5749	watered-down bad CSA cheerfulness ration	2	decent	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	blinking Tales of the Word Realms	0		
 5752	adequate crappy brain	3	good	
-5753	toothsome snack-sized decent brain	2	awesome	
+5753	snack-sized toothsome decent brain	2	awesome	
 5754	half-sized stale good brain	2	decent	
 5755	rotten boss brain	3	crappy	
 5756	jumbo spoiled bouncing hunter brain	5	crappy	
@@ -5687,8 +5687,8 @@
 5788	ghostly smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	red box of bear arms	0		Last Available: "2012-09"
-5791	family-friendly lion tamer's right bear arm	0		Experience (familiar): +2, Sleaze Resistance: +1, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	skewed blurry Jack Frost's grievous left bear arm of the businessman	0		Weapon Damage Percent: +50, Cold Spell Damage: +50, Meat Drop: +50, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	family-friendly lion tamer's right bear arm	0		Experience (familiar): +2, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	skewed blurry Jack Frost's grievous left bear arm of the businessman	0		Weapon Damage Percent: +50, Cold Spell Damage: +50, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	up-at-dawn Hat O' Nine Tails	0		Adventures: +5
 5794	cold-filtered energized spinning Enchanted Plunger	0		Effect: "Pill Power", Effect Duration: 12
 5795	deionized Enchanted Flyswatter	0		Effect: "Sparkling Consciousness", Effect Duration: 67
@@ -5711,17 +5711,17 @@
 5812	quantum twirling skelelton spine	0		Effect: "Floundering", Effect Duration: 25
 5813	ionized galvanized smut orc sunglasses	0		Effect: "Fishy", Effect Duration: 65
 5814	triple-galvanized super-oxidized blob of acid	0		Effect: "Sourpuss", Effect Duration: 17
-5815	adjusted extra-activated double-chilled shaking gray flayed mind	0		Effect: "Elvish", Effect Duration: 19
-5816	colloidal boiled blurry gray skewed kobold kibble	0		Effect: "Empathy", Effect Duration: 37
+5815	adjusted extra-activated double-chilled gray shaking flayed mind	0		Effect: "Elvish", Effect Duration: 19
+5816	colloidal boiled skewed blurry gray kobold kibble	0		Effect: "Empathy", Effect Duration: 37
 5817	polymerized forest spirit rattle	0		Effect: "Earthen Fist", Effect Duration: 22
-5818	tarnished skewed olive Stone Golem pebbles	0		Effect: "Souper Vengeful", Effect Duration: 31
+5818	tarnished olive skewed Stone Golem pebbles	0		Effect: "Souper Vengeful", Effect Duration: 31
 5819	boiled deionized altered narrow cyan blinking gravy fairy warlock hat	0		Effect: "Icy Composition", Effect Duration: 47
 5820	frozen olive ghostly bull blubber	0		Effect: "Cheered Up", Effect Duration: 39
-5821	denatured extra-vacuum-sealed super-improved blinking teal blinking frog lip-print	0		Effect: "Memento Moir&eacute;", Effect Duration: 69
+5821	denatured extra-vacuum-sealed super-improved blinking blinking teal frog lip-print	0		Effect: "Memento Moir&eacute;", Effect Duration: 69
 5822	cold-filtered wet blurry gazely stare	0		Effect: "Sealed Brain", Effect Duration: 45
 5823	polymerized tumbling canopic jar	0		Effect: "Buzzard Breath", Effect Duration: 52
 5824	modified alkaline clove-flavored lip balm	0		Effect: "New and Improved", Effect Duration: 62
-5825	tarnished quantum pulsating purple Skullery Maid's Knee	0		Effect: "Angry like the Wolf", Effect Duration: 39
+5825	tarnished quantum purple pulsating Skullery Maid's Knee	0		Effect: "Angry like the Wolf", Effect Duration: 39
 5826	quadruple-vacuum-sealed zombie hollandaise	0		Effect: "The Magic of Sharing", Effect Duration: 54
 5827	moist adjusted lime green skeletal banana	0		Effect: "Amorous", Effect Duration: 24
 5828	double-liquefied unsweetened unsweetened gilt perfume bottle	0		Effect: "Pharmaceutically Cool", Effect Duration: 27
@@ -5736,8 +5736,8 @@
 5837	quantum Fu Manchu Wax	0		Effect: "Wistfully Nostalgic", Effect Duration: 12
 5838	galvanized moist squat Iiti Kitty Gumdrop	0		Effect: "Bottle in front of Me", Effect Duration: 20
 5839	flattened ravenous eye	0		Effect: "Berry Critical", Effect Duration: 32
-5840	enhanced jittery huge Rogue Windmill Rouge	0		Effect: "Toothy Grin", Effect Duration: 30
-5841	quantum blinking maroon A muse-bouche	0		Effect: "Black Eyes", Effect Duration: 45
+5840	enhanced huge jittery Rogue Windmill Rouge	0		Effect: "Toothy Grin", Effect Duration: 30
+5841	quantum maroon blinking A muse-bouche	0		Effect: "Black Eyes", Effect Duration: 45
 5842	dry tarnished upside-down toothbrush	0		Effect: "Taurus Rising", Effect Duration: 57
 5843	non-Vulcanized tumbling pirate cream pie	0		Effect: "Mariachi Mood", Effect Duration: 20
 5844	moist pickled una poca de gracia	0		Effect: "Trivia Master", Effect Duration: 36
@@ -5755,7 +5755,7 @@
 5856	concentrated super-vacuum-sealed Scuba Snack	0		Effect: "The Strength...  of the Future", Effect Duration: 60
 5857	boiled ionized purple grey cube	0		Effect: "Taurus Rising", Effect Duration: 21
 5858	aerosolized votive candle	0		Effect: "The Living Hitpoints", Effect Duration: 21
-5859	double-cold-filtered altered non-deionized mirror ghostly booby trap	0		Effect: "Very Clean Guns", Effect Duration: 65
+5859	double-cold-filtered altered non-deionized ghostly mirror booby trap	0		Effect: "Very Clean Guns", Effect Duration: 65
 5860	ionized denatured Agent Corrigan's cigarette	0		Effect: "Celestial Sheen", Effect Duration: 47
 5861	nitrogenated bouncing good ash	0		Effect: "Bone Chilling", Effect Duration: 21
 5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
@@ -5787,7 +5787,7 @@
 5888	twirling Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	cool auxiliary backbone	0		Moxie: +5, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
-5891	blinking gray ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
+5891	gray blinking ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	electrified that gum you like	0		Effect: "20-20 Second Sight", Effect Duration: 62
 5893	green dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	squat Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
@@ -5821,9 +5821,9 @@
 5923	plastic ingot	0		Last Available: "2012-12"
 5924	yellow electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	spinning mirror BittyCar MeatCar	0		Last Available: "2012-12"
+5926	mirror spinning BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	blinking huge brainwave-controlled unicorn horn of chilblains	0		Cold Damage: +25, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	blinking huge brainwave-controlled unicorn horn of chilblains	0		Cold Damage: +25, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	narrow bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	huge jittery extremely unsafe slick plastic four-shadowed mime of the cheetah	0		Moxie: +10, Weapon Damage Percent: +100, Initiative: +60, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	fuchsia brainy plastic Father McGruber	0		Mysticality: +5, Last Available: "2012-12"
 5961	nippy plastic Hank North, Photojournalist	0		Cold Damage: +10, Last Available: "2012-12"
 5962	green plastic blazing bat of the brazier	0		Hot Spell Damage: +25, Last Available: "2012-12"
-5963	ghostly electrified beefcake's electronic dulcimer pants	0		Muscle: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	ghostly electrified beefcake's electronic dulcimer pants	0		Muscle: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	teal dangerous savvy Frown Exerciser	0		Mysticality Percent: +20, Weapon Damage: +10, Single Equip, Last Available: "2012-12"
 5966	upside-down soul monocle	0		Single Equip
@@ -5877,11 +5877,11 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	weak drinkable skewed pulsating tankard of ale	2	good	Last Available: "2013-02"
+5982	drinkable weak skewed pulsating tankard of ale	2	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	red Da Vinci's smartaleck's cloth cap of wisdom	0		Mysticality: +15, Moxie Percent: +30, Experience (Mysticality): +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	skewed ribald cool iron dagger of the dark arts	0		Moxie: +5, Spell Damage Percent: +100, Sleaze Damage: +10, Last Available: "2013-02"
-5986	jumbo bland hamburger	5	decent	Last Available: "2013-02"
+5986	bland jumbo hamburger	5	decent	Last Available: "2013-02"
 5987	fuchsia huge wobbly dollar-sign bag	0		Last Available: "2013-02"
 5988	pulsating potion	0		Last Available: "2013-02"
 5989	jittery cyan potion	0		Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	aerosolized magnetized orcish hand lotion	0		Effect: "Antibiotic Saucesphere", Effect Duration: 37
 6016	frozen blurry orcish rubber	0		Effect: "Hella Tough", Effect Duration: 43
 6017	nitrogenated activated upside-down orcish nailing lube	0		Effect: "Ass Over Teakettle", Effect Duration: 63
-6018	tolerable strong backwoods screwdriver	5	good	
+6018	strong tolerable backwoods screwdriver	5	good	
 6019	perfumed loadstone	0		Stench Resistance: +5
 6020	reassuring vibrating Claybender glasses	0		Maximum MP Percent: +10, Spooky Resistance: +1, Single Equip
 6021	supercharged therapeutic Duskwalker fangs	0		Maximum MP Percent: +30, HP Regen Min: 5, HP Regen Max: 7
@@ -5930,7 +5930,7 @@
 6032	narrow horrifying supercool motorcycle boots	0		Moxie Percent: +20, Spooky Damage: +25, Single Equip
 6033	Sherlock's Herculean stolen necklace	0		Experience (Muscle): +1, Item Drop: +25
 6034	razor-sharp Fonzie's troll britches	0		Experience (Moxie): +1, Weapon Damage Percent: +25, Familiar Effect: "1.5xPotato, cap 28"
-6035	ionized improved olive squat vial of The Glistening	0		Effect: "Black Lung", Effect Duration: 50
+6035	ionized improved squat olive vial of The Glistening	0		Effect: "Black Lung", Effect Duration: 50
 6036	lousy artisanal limoncello	3	decent	
 6037	ginger ale	0		
 6038	spoiled incredible pizza	3	crappy	
@@ -5947,11 +5947,11 @@
 6049	stiffened Samson's stylish Misty Cape	0		Moxie: +25, Experience (Muscle): +5, Damage Reduction: 1
 6050	woimbook	0		Familiar Weight: +5
 6051	pulsating Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	jumbo stale tumbling Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
+6052	stale jumbo tumbling Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
 6053	drinkable weak Taco Dan's Taco Stand Chimichangarita	2	good	Last Available: "2012-12"
-6054	colloidal super-moist wet wobbly yellow bouncing Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Hammered", Effect Duration: 44, Last Available: "2012-12"
+6054	colloidal super-moist wet yellow wobbly bouncing Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Hammered", Effect Duration: 44, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	censurious banded Meatcleaver	0		Damage Absorption: +100, Sleaze Resistance: +3, Last Available: "2013-12"
 6058	blinking Crimbo Elf bobble-head of chilblains	0		Cold Damage: +25, Last Available: "2012-12"
 6059	twirling Jack Frost's Crimbo stogie-scented room odorizer	0		Cold Spell Damage: +50, Last Available: "2012-12"
@@ -5973,10 +5973,10 @@
 6075	dry ghostly 37x37x37 puzzle cube	0		Effect: "The Moxious Madrigal", Effect Duration: 31, Last Available: "2012-12"
 6076	drinkable McLeod's Hard Haggis-Ade	4	good	Last Available: "2012-12"
 6077	decent green haggis-wrapped haggis-stuffed haggis	3	good	Last Available: "2012-12"
-6078	red ghostly home robotics kit	0		Last Available: "2012-12"
+6078	ghostly red home robotics kit	0		Last Available: "2012-12"
 6079	upside-down school calculator watch	0		Last Available: "2012-12"
-6080	tumbling chaotic haggis socks	0		Spell Critical Percent: +10, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	tumbling chaotic haggis socks	0		Spell Critical Percent: +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	skewed actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	tumbling Mr. Haggis	0		Last Available: "2012-12"
@@ -6036,26 +6036,26 @@
 6138	great capacitor	0		Last Available: "2013-12"
 6139	auspicious rubber gloves	0		Item Drop: +10, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
-6141	wobbly squat maroon shaking triad summoning scroll	0		Last Available: "2013-12"
+6141	squat maroon wobbly shaking triad summoning scroll	0		Last Available: "2013-12"
 6142	bland roasted duck	4	decent	Last Available: "2013-12"
 6143	tiny bland dead meat bun	1	decent	Last Available: "2013-12"
 6144	lime green narrow smartaleck's cat collar	0		Moxie Percent: +30, Single Equip, Last Available: "2013-12"
 6145	huge sinister thinker's suspicious-looking fedora	0		Mysticality: +10, Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	huge huge Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
-6148	tumbling squat Deactivated MiniMechaElf	0		Last Available: "2012-12"
+6148	squat tumbling Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	blinking carrot nose	0		Last Available: "2013-01"
-6152	flavorless huge blurry red carrot cake	8	decent	Last Available: "2013-01"
-6153	practically non-alcoholic tolerable carrot claret	1	good	Last Available: "2013-01"
-6154	dried narrow upside-down teal carrot juice	1	decent	Last Available: "2013-01"
+6152	huge flavorless blurry red carrot cake	8	decent	Last Available: "2013-01"
+6153	tolerable practically non-alcoholic carrot claret	1	good	Last Available: "2013-01"
+6154	dried upside-down narrow teal carrot juice	1	decent	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	miser's Byte of Tarzan	0		Experience (Muscle): +3, Meat Drop: +10, Last Available: "2013-12"
-6158	toasty anger blaster	0		Hot Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	doubt cannon of courage	0		Spooky Resistance: +3, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	green nasty fear condenser	0		Stench Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	regret hose of extreme caution	0		Monster Level: -25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	toasty anger blaster	0		Hot Damage: +5, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	doubt cannon of courage	0		Spooky Resistance: +3, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	green nasty fear condenser	0		Stench Damage: +5, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	regret hose of extreme caution	0		Monster Level: -25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	jittery Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	wobbly prompt commodore's hat of vim and vigor	0		Maximum HP Percent: +50, Adventures: +3, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
@@ -6063,7 +6063,7 @@
 6166	wicked weightlifter's deck cannon	0		Muscle: +15, Spell Damage: +5, Last Available: "2013-12"
 6167	razor-sharp ornamental sextant	0		Weapon Damage Percent: +25, Last Available: "2013-12"
 6168	gravedigger's Bloodbath of mayonnaise	0		Spooky Damage: +10, Sleaze Spell Damage: +50, Last Available: "2013-12"
-6169	enchanted tolerable Hundred Headed IPA	3	good	Effect: "Barking Mad", Effect Duration: 5, Last Available: "2013-12"
+6169	tolerable enchanted Hundred Headed IPA	3	good	Effect: "Barking Mad", Effect Duration: 5, Last Available: "2013-12"
 6170	decent diet chum	1	good	Last Available: "2013-12"
 6171	anodized boiled green crude crudit&eacute;s	0		Effect: "Pla-see-bo", Effect Duration: 44
 6172	adjusted frozen candy crayons	0		Effect: "Pyromania", Effect Duration: 32, Last Available: "2020-09"
@@ -6080,7 +6080,7 @@
 6183	cosmic fruit	0		
 6184	aromatic Jarlsberg's hat of terror of bravery	0		Spooky Spell Damage: +10, Spooky Resistance: +5, Stench Resistance: +1
 6185	toothsome miniature tumbling consummate hard-boiled egg	2	awesome	
-6186	rotten jumbo fancy consummate fried egg	5	crappy	Effect: "Wintry Breath", Effect Duration: 5
+6186	fancy jumbo rotten consummate fried egg	5	crappy	Effect: "Wintry Breath", Effect Duration: 5
 6187	bland consummate egg salad	4	decent	
 6188	special decent half-sized spinning consummate bagel	2	good	Effect: "Swimming Head", Effect Duration: 20
 6189	adequate consummate sliced bread	4	good	
@@ -6093,36 +6093,36 @@
 6196	normal jittery consummate salad	3	good	
 6197	decent consummate salsa	3	good	
 6198	tiny spoiled twirling consummate sauerkraut	1	crappy	
-6199	flavorless fancy snack-sized consummate cheese slice	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 10
-6200	gigantic decent upside-down consummate melted cheese	10	good	
+6199	snack-sized flavorless fancy consummate cheese slice	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 10
+6200	decent gigantic upside-down consummate melted cheese	10	good	
 6201	spoiled consummate bacon	4	crappy	
 6202	adequate consummate meatloaf	3	good	
 6203	bland huge consummate steak	3	decent	
 6204	flavorless consummate cuts	4	decent	
 6205	spoiled consummate frankfurter	3	crappy	
-6206	decent special consummate french fries	4	good	Effect: "Weird Flavor", Effect Duration: 35
+6206	special decent consummate french fries	4	good	Effect: "Weird Flavor", Effect Duration: 35
 6207	small toothsome mirror consummate baked potato	2	awesome	
-6208	hand-crafted high-proof enchanted maroon acceptable vodka	10	EPIC	Effect: "No Worries", Effect Duration: 45
-6209	half-sized rotten narrow consummate ice cream	2	crappy	
+6208	hand-crafted enchanted high-proof maroon acceptable vodka	10	EPIC	Effect: "No Worries", Effect Duration: 45
+6209	rotten half-sized narrow consummate ice cream	2	crappy	
 6210	rotten consummate whipped cream	3	crappy	
-6211	flavorless enchanted wobbly consummate cream	3	decent	Effect: "Saucegoggles", Effect Duration: 35
-6212	spoiled immense consummate strawberries	8	crappy	
-6213	decent half-sized enchanted consummate sorbet	2	good	Effect: "Blubbered Up", Effect Duration: 50
-6214	aged fancy adequate rum	3	awesome	Effect: "Saucemastery", Effect Duration: 30
-6215	artisanal spirit-forward ghostly mediocre lager	5	EPIC	
-6216	thick enchanted tasty immaculate grilled cheese	5	awesome	Effect: "Highland Sheen", Effect Duration: 5
+6211	enchanted flavorless wobbly consummate cream	3	decent	Effect: "Saucegoggles", Effect Duration: 35
+6212	immense spoiled consummate strawberries	8	crappy	
+6213	half-sized decent enchanted consummate sorbet	2	good	Effect: "Blubbered Up", Effect Duration: 50
+6214	fancy aged adequate rum	3	awesome	Effect: "Saucemastery", Effect Duration: 30
+6215	spirit-forward artisanal ghostly mediocre lager	5	EPIC	
+6216	tasty thick enchanted immaculate grilled cheese	5	awesome	Effect: "Highland Sheen", Effect Duration: 5
 6217	rotten immaculate ice cream sandwich	3	crappy	
-6218	flavorless super-sized immaculate hot dog	5	decent	
+6218	super-sized flavorless immaculate hot dog	5	decent	
 6219	rotten immaculate egg salad sandwich	4	crappy	
 6220	rotten perfect sandwich	3	crappy	
 6221	tasty fuchsia perfect chef salad	4	awesome	
 6222	spoiled perfect breakfast	3	crappy	
-6223	small bland blinking sublime deluxe hot dog	2	decent	
+6223	bland small blinking sublime deluxe hot dog	2	decent	
 6224	adequate sublime stew	3	good	
 6225	toothsome sublime nachos	3	awesome	
-6226	spoiled half-sized Ultimate Breakfast Sandwich	2	crappy	
-6227	jumbo special yummy cyan Loaded Baked Potato	5	awesome	Effect: "Cold Throat", Effect Duration: 5
-6228	rotten gigantic twirling Omega Sundae	9	crappy	
+6226	half-sized spoiled Ultimate Breakfast Sandwich	2	crappy	
+6227	yummy jumbo special cyan Loaded Baked Potato	5	awesome	Effect: "Cold Throat", Effect Duration: 5
+6228	gigantic rotten twirling Omega Sundae	9	crappy	
 6229	drinkable Das Sauerlager	4	good	
 6230	hand-crafted huge Bologna Lambic	3	EPIC	
 6231	triple-distilled perfectly mixed Vodka Dog	9	EPIC	
@@ -6130,7 +6130,7 @@
 6233	weak delicious Chunky Mary	2	awesome	
 6234	artisanal Nachojito	3	EPIC	
 6235	acceptable teal Le Roi	4	good	
-6236	fancy tolerable pulsating bouncing Over Easy Rider	4	good	Effect: "Bricked-In", Effect Duration: 35
+6236	tolerable fancy bouncing pulsating Over Easy Rider	4	good	Effect: "Bricked-In", Effect Duration: 35
 6237	blurry cosmic six-pack	0		
 6239	non-pressed irradiated shaking cube of ectoplasm	0		Effect: "Cold Hands", Effect Duration: 38
 6240	dry triple-ionized maroon Illuminati earpiece	0		Effect: "Ten out of Ten", Effect Duration: 60
@@ -6167,9 +6167,9 @@
 6271	wobbly massive dumbbell	0		
 6272	upside-down fireproof nippy penguin keychain	0		Cold Damage: +10, Hot Resistance: +3, Damage Reduction: 10
 6273	quadruple-vacuum-sealed ghostly O'RLY manual	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 30
-6274	high-proof drinkable open sauce	9	good	
+6274	drinkable high-proof open sauce	9	good	
 6275	wholesome personal trainer's turkey leg	0		Experience Percent (Muscle): +10, Maximum HP Percent: +10
-6276	mediocre extra-dry gray Ye Olde Meade	5	decent	
+6276	extra-dry mediocre gray Ye Olde Meade	5	decent	
 6277	alkaline Ye Olde Bawdy Limerick	0		Effect: "Feet of Watermelon", Effect Duration: 20
 6278	blinking Ye Olde Medieval Insult	0		
 6279	jittery lightning-fast pewter claymore	0		Initiative: +40
@@ -6182,7 +6182,7 @@
 6286	gray Lo Pan's electrified Mark II Steam-Hat	0		Spell Critical Percent: +30, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6287	ghostly fireproof flame-retardant Mark III Steam-Hat of horror of the glutton	0		Spooky Spell Damage: +25, Hot Resistance: 4, Food Drop: +100, Familiar Effect: "1xLep, cap 37"
 6288	upside-down ghostly perfumed flame-retardant Jim Carey's Oprah's Mark IV Steam-Hat of James Dean	0		Experience (Moxie): +3, Maximum MP Percent: +50, Monster Level: +25, Hot Resistance: +1, Stench Resistance: +5, Familiar Effect: "1xLep, cap 37"
-6289	miser's frosty banded padded grievous Mark V Steam-Hat	0		Weapon Damage Percent: +50, Damage Absorption: 120, Cold Spell Damage: +10, Meat Drop: +10, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	miser's frosty banded padded grievous Mark V Steam-Hat	0		Weapon Damage Percent: +50, Damage Absorption: 120, Cold Spell Damage: +10, Meat Drop: +10, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	teal steam-powered model rocketship	0		
 6291	yellow electrified razor-sharp punk rock jacket	0		Weapon Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5
 6292	sharpshooter's thinker's safety pin	0		Mysticality: +10, Critical Hit Percent: +10
@@ -6247,7 +6247,7 @@
 6351	deadly Mer-kin finpaddle	0		Weapon Damage: +5
 6352	studded Mer-kin stopwatch	0		Damage Absorption: +80, Initiative: +50
 6353	yellow Mer-kin dreadscroll	0		
-6354	magnetized colloidal purple squat huge Mer-kin smartjuice	0		Effect: "Hot Jellied", Effect Duration: 42
+6354	magnetized colloidal purple huge squat Mer-kin smartjuice	0		Effect: "Hot Jellied", Effect Duration: 42
 6355	unsweetened pressed twirling Mer-kin cooljuice	0		Effect: "Hyperoffended", Effect Duration: 39
 6356	Mer-kin worktea	0		
 6357	yellow Mer-kin knucklebone	0		
@@ -6307,18 +6307,18 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	enchanted decent flavorless gruel	4	good	Effect: "Hare-o-dynamic", Effect Duration: 15
+6415	decent enchanted flavorless gruel	4	good	Effect: "Hare-o-dynamic", Effect Duration: 15
 6416	tasty mana curds	4	awesome	
 6417	twist of lime	0		
 6418	mirror wobbly pencil stub	0		
 6419	ionized moth dust	0		Effect: "Sparkly!", Effect Duration: 68
 6420	nitrogenated glob of spoiled mayo	0		Effect: "Wet and Greedy", Effect Duration: 62
 6421	blurry jittery tonic djinn	0		
-6422	moldy snack-sized upside-down shaking vampire chowder	2	crappy	
+6422	snack-sized moldy shaking upside-down vampire chowder	2	crappy	
 6423	Tales of Dread	0		Free Pull
 6424	skewed Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	flavorless miniature squat Dreadsylvanian stew	2	decent	
+6426	miniature flavorless squat Dreadsylvanian stew	2	decent	
 6427	perfectly mixed Dreadsylvanian	3	EPIC	
 6428	ionized Dreadsylvanian flask	0		Effect: "Influence of Sphere", Effect Duration: 48
 6429	triple-wet quadruple-denatured tumbling Dreadsylvanian flask	0		Effect: "Slightly Larger Than Usual", Effect Duration: 66
@@ -6338,14 +6338,14 @@
 6443	Helps-You-Sleep of the scaredy-cat of chilblains	0		Monster Level: -15, Cold Damage: +25, Single Equip
 6444	upside-down blue healthy Quiets-Your-Steps of the bloodbag of chilblains	0		Maximum HP Percent: +20, Maximum HP: +100, Cold Damage: +25, Single Equip
 6445	fuchsia wool crafty Protects-Your-Junk	0		Maximum MP: +10, Cold Resistance: +1, Single Equip
-6446	smooth fancy teal Gets-You-Drunk	4	awesome	Effect: "Got Your Boots On", Effect Duration: 50
+6446	fancy smooth teal Gets-You-Drunk	4	awesome	Effect: "Got Your Boots On", Effect Duration: 50
 6447	careful beefcake's Great Wolf's headband of the storm	0		Muscle: +25, Maximum MP Percent: +40, Monster Level: -10, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	family-friendly beefy Great Wolf's left paw of the overflowing toilet	0		Muscle: +10, Stench Spell Damage: +50, Sleaze Resistance: +1, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	pulsating flame-wreathed wholesome banded Great Wolf's right paw	0		Damage Absorption: +100, Maximum HP Percent: +10, Hot Spell Damage: +10, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	Temple Grandin's Samson's Great Wolf's rocket launcher	0		Experience (Muscle): +5, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	hardy extremely unsafe Great Wolf's beastly trousers	0		Weapon Damage Percent: +100, Maximum HP: +50, Item Drop: +5, Familiar Effect: "1xPotato, 1.5xWhelp"
 6452	huge Great Wolf's lice	0		
-6453	cold-filtered non-altered ionized narrow green Hunger&trade; Sauce	0		Effect: "Twinkly Weapon", Effect Duration: 67
+6453	cold-filtered non-altered ionized green narrow Hunger&trade; Sauce	0		Effect: "Twinkly Weapon", Effect Duration: 67
 6454	wool Lo Pan's Oprah's zombie mariachi hat	0		Maximum MP Percent: +50, Spell Critical Percent: +30, Cold Resistance: +1, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	slick zombie accordion of James Dean of temperance	0		Moxie: +10, Experience (Moxie): +3, Sleaze Resistance: +5, Class: "Accordion Thief", Single Equip, Song Duration: 20
 6456	cyan grievous cool zombie mariachi pants of horror	0		Moxie: +5, Weapon Damage Percent: +50, Spooky Spell Damage: +25, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
@@ -6377,7 +6377,7 @@
 6482	executive Lo Pan's Newton's Staff of the Roaring Hearth	0		Experience (Mysticality): +3, Spell Critical Percent: +30, Meat Drop: +40
 6483	Kool-Aid	1	crappy	
 6484	dread tarragon	0		
-6485	green spinning bone flour	0		
+6485	spinning green bone flour	0		
 6486	blue dreadful roast	0		
 6487	tumbling stinking agaricus	0		
 6488	rotten immense Dreadsylvanian shepherd's pie	6	crappy	
@@ -6390,7 +6390,7 @@
 6495	forbidden Dreadsylvania Auditor's badge	0		Spell Damage Percent: +50, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	upside-down eau de mort	0		
-6498	acceptable practically non-alcoholic fancy bloody kiwitini	1	good	Effect: "Be a Mind Master", Effect Duration: 40
+6498	practically non-alcoholic fancy acceptable bloody kiwitini	1	good	Effect: "Be a Mind Master", Effect Duration: 40
 6499	bouncing moon-amber	0		
 6500	fuchsia polished moon-amber	0		
 6501	spinning occult moon-amber necklace of the cougar of the brazier	0		Moxie: +20, Spell Damage Percent: +25, Hot Spell Damage: +25, Single Equip
@@ -6410,7 +6410,7 @@
 6515	inspector's eerie fetish	0		Item Drop: +15, Single Equip
 6516	hand-crafted stinkwater	3	super ultra EPIC	
 6517	narrow dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	thick bland accidental mutton	5	decent	
+6518	bland thick accidental mutton	5	decent	
 6519	hardened drafty drawers of the sweet-tooth	0		Damage Reduction: 3, Candy Drop: +100, Familiar Effect: "1.5xVolley"
 6520	executive auspicious wolfskull mask	0		Item Drop: +10, Meat Drop: +40, Familiar Effect: "spooky atk, 1xBarrr"
 6521	Tesla guts necklace	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -6429,7 +6429,7 @@
 6534	ghostly educational remorseless knife	0		Experience: +1
 6535	narrow scandalous intimidating coiffure	0		Sleaze Damage: +5, Familiar Effect: "hot afk, 1xPotato"
 6536	studded stylish cod cape	0		Moxie: +25, Damage Absorption: +80
-6537	spoiled immense blood sausage	8	crappy	
+6537	immense spoiled blood sausage	8	crappy	
 6538	deadly frying brainpan of Gandalf	0		Weapon Damage: +5, Spell Critical Percent: +20
 6539	horrifying beefy ball and chain	0		Muscle: +10, Spooky Damage: +25, Single Equip
 6540	deadly dry bone	0		Weapon Damage: +5
@@ -6452,19 +6452,19 @@
 6558	cold-filtered double-vacuum-sealed bouncing phial of spookiness	0		Effect: "Itchy Trigger Finger", Effect Duration: 12
 6559	energized tumbling phial of stench	0		Effect: "Lit Up", Effect Duration: 21
 6560	altered vacuum-sealed olive phial of sleaziness	0		Effect: "Healthy Blue Glow", Effect Duration: 46
-6561	ghostly tumbling adventurer clone egg	0		Free Pull, Last Available: "2013-06"
+6561	tumbling ghostly adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mirror mini-Mr. Accessory	0		Familiar Weight: +5
 6563	rock-hard hand of Mr. Cards	0		Damage Reduction: 5, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	flavorless immense Dreadsylvanian hot pocket	10	decent	
-6565	half-sized tasty Dreadsylvanian pocket	2	awesome	
+6564	immense flavorless Dreadsylvanian hot pocket	10	decent	
+6565	tasty half-sized Dreadsylvanian pocket	2	awesome	
 6566	moldy Dreadsylvanian pocket	3	crappy	
 6567	adequate Dreadsylvanian stink pocket	3	good	
-6568	delicious huge blinking Dreadsylvanian sleaze pocket	7	awesome	
+6568	huge delicious blinking Dreadsylvanian sleaze pocket	7	awesome	
 6569	strong bad Dreadsylvanian hot toddy	5	decent	
 6570	mediocre Dreadsylvanian cold-fashioned	4	decent	
 6571	tolerable squat Dreadsylvanian grimlet	4	good	
 6572	drinkable Dreadsylvanian dank and stormy	4	good	
-6573	mediocre strong Dreadsylvanian slithery nipple	5	decent	
+6573	strong mediocre Dreadsylvanian slithery nipple	5	decent	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
@@ -6482,19 +6482,19 @@
 6588	stanky gnawed-up dog bone of mayonnaise	0		Stench Spell Damage: +25, Sleaze Spell Damage: +50
 6589	deadly Grey Guanon	0		Weapon Damage: +5
 6590	ruddy extremely unsafe Herculean Engorged Sausages and You	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Maximum HP Percent: +40
-6591	practically non-alcoholic artisanal dream of a dog	1	super ultra mega EPIC	
+6591	artisanal practically non-alcoholic dream of a dog	1	super ultra mega EPIC	
 6592	stanky electrified optimal spreadsheet of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
 6595	powdered gray epic cluster	1	EPIC	
-6596	blue shaking clockwork egg	0		
+6596	shaking blue clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	squat clockwork disc	0		
 6599	upside-down clockwork hand	0		
 6600	bouncing clockwork hand	0		
 6601	clockwork numeral I	0		
-6602	squat bouncing clockwork numeral II	0		
-6603	ghostly blinking clockwork numeral III	0		
+6602	bouncing squat clockwork numeral II	0		
+6603	blinking ghostly clockwork numeral III	0		
 6604	clockwork numeral IV	0		
 6605	mirror clockwork numeral V	0		
 6606	lime green clockwork numeral VI	0		
@@ -6507,7 +6507,7 @@
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	hand-crafted boozy Cold One	5	???	
-6616	snack-sized bland spaghetti breakfast	2	???	
+6616	bland snack-sized spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6515,7 +6515,7 @@
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
-6624	fuchsia shaking twirling folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
+6624	shaking twirling fuchsia folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
@@ -6527,7 +6527,7 @@
 6633	folder (barbarian)	0		Last Available: "2013-08"
 6634	folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
-6636	twirling bouncing folder (dancing dolphins)	0		Last Available: "2013-08"
+6636	bouncing twirling folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	jittery folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	folder (owl)	0		Last Available: "2013-08"
@@ -6542,7 +6542,7 @@
 6650	Mountain Stream Code Black Alert	0		
 6651	lime green twisted-up wet towel	0		
 6652	acceptable shaking stepmom's booze	3	good	
-6653	blinking shaking surgical tape	0		
+6653	shaking blinking surgical tape	0		
 6654	executive band T-shirt	0		Meat Drop: +40
 6655	drinkable fountain 'soda'	4	good	
 6656	illegal firecracker	0		
@@ -6552,14 +6552,14 @@
 6660	olive school spirit socket set	0		
 6661	suspension bridge	0		
 6662	shaking huge hardened Sinatra's Staff of the Lunch Lady of the ox of the scaredy-cat	0		Muscle: +20, Experience (Moxie): +5, Damage Reduction: 3, Monster Level: -15
-6663	blurry cyan universal key	0		
+6663	cyan blurry universal key	0		
 6664	world's most dangerous birdhouse	0		
 6665	chaotic deathchucks of Leguizamo	0		Spell Critical Percent: +10, Monster Level: +20
 6666	eraser	0		
 6667	quasireligious sculpture	0		
 6668	upside-down blurry Faraday cage	0		
 6669	purple modeling claymore	0		
-6670	blinking mirror clay homunculus	0		
+6670	mirror blinking clay homunculus	0		
 6671	modified irradiated sodium pentasomething	0		Effect: "Marinated", Effect Duration: 17
 6672	grains of salt	0		
 6673	squat yellowcake bomb	0		
@@ -6569,8 +6569,8 @@
 6677	crude monster sculpture	0		
 6678	Yearbook Club Camera of the early riser	0		Adventures: +7, Conditional Skill (Equipped): "Blinding Flash"
 6679	friendly machete	0		Familiar Weight: +3
-6680	weak drinkable Cursed Punch	2	good	
-6681	acceptable weak gray Bowl of Scorpions	2	good	
+6680	drinkable weak Cursed Punch	2	good	
+6681	weak acceptable gray Bowl of Scorpions	2	good	
 6682	lousy Fog Murderer	3	decent	
 6683	mirror book of matches	0		
 6684	tumbling hale surgical mask	0		Maximum HP: +20, Surgeonosity: +1
@@ -6589,13 +6589,13 @@
 6697	moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
 6699	crackling stone sphere	0		
-6700	pulsating jittery scorched stone sphere	0		
+6700	jittery pulsating scorched stone sphere	0		
 6701	stone triangle	0		
 6702	narrow bowler	0		
 6703	blinking imitation White Russian	1	decent	
 6704	purple short-handled mop of the brazier of doom	0		Hot Spell Damage: +25, Spooky Spell Damage: +50
 6705	bland jungle floor wax	3	decent	
-6706	tumbling maroon smirking shrunken head	0		
+6706	maroon tumbling smirking shrunken head	0		
 6707	denatured olive colorful toad	0		Effect: "Turkey-Agitated", Effect Duration: 18
 6708	crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
@@ -6611,7 +6611,7 @@
 6719	jittery avaricious midriff scrubs of James Dean	0		Experience (Moxie): +3, Meat Drop: +30
 6720	energized chilled skewed pill cup	0		Effect: "Joy", Effect Duration: 43
 6721	blurry ribald horrifying supercharged water bottle	0		Maximum MP Percent: +30, Spooky Damage: +25, Sleaze Damage: +10, Familiar Effect: "atk, 1xFairy, cap 40"
-6722	non-frozen olive twirling pygmy phone number	0		Effect: "Thaumodynamic", Effect Duration: 69
+6722	non-frozen twirling olive pygmy phone number	0		Effect: "Thaumodynamic", Effect Duration: 69
 6723	blinking Boozehounds Anonymous token	0		
 6724	spoiled exotic jungle fruit	3	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
@@ -6624,7 +6624,7 @@
 6732	claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	huge cigar sign	0		
-6735	jittery pulsating junk junk	0		
+6735	pulsating jittery junk junk	0		
 6736	Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	jagged scrap	0		
@@ -6634,7 +6634,7 @@
 6742	up-at-dawn junk band	0		Adventures: +5
 6743	ruddy junk trunks	0		Maximum HP Percent: +40, Familiar Effect: "cap 15"
 6744	red experienced junk-mail shirt	0		Experience: +2
-6745	bland huge pulsating junk food	4	decent	
+6745	bland pulsating huge junk food	4	decent	
 6746	lousy practically non-alcoholic junk yard	1	decent	
 6747	yellow miser's swordzall of the early riser	0		Meat Drop: +10, Adventures: +7
 6748	arm buzzer of temperance	0		Sleaze Resistance: +5, Damage Reduction: 6
@@ -6646,10 +6646,10 @@
 6754	beer bottle	0		
 6755	beer label	0		
 6756	blinking artisanal homebrew sampler	0		
-6757	artisanal fancy practically non-alcoholic can of Br&uuml;talbr&auml;u	1	EPIC	Effect: "Sourpuss", Effect Duration: 10, Last Available: "2013-09"
+6757	practically non-alcoholic fancy artisanal can of Br&uuml;talbr&auml;u	1	EPIC	Effect: "Sourpuss", Effect Duration: 10, Last Available: "2013-09"
 6758	bad jittery can of Drooling Monk	3	decent	Last Available: "2013-09"
 6759	bad tumbling can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
-6760	acceptable strong bottle of Old Pugilist	5	good	Last Available: "2013-09"
+6760	strong acceptable bottle of Old Pugilist	5	good	Last Available: "2013-09"
 6761	perfectly mixed extra-dry bottle of Professor Beer	5	EPIC	Last Available: "2013-09"
 6762	acceptable high-proof bottle of Rapier Witbier	8	good	Last Available: "2013-09"
 6763	tolerable bottle of Race Car Red	3	good	Last Available: "2013-09"
@@ -6746,12 +6746,12 @@
 6857	skewed rosy-cheeked Cajun accordion	0		Maximum HP Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	boxer's quirky accordion	0		Muscle Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery skewed stiffened baleful Skipper's accordion	0		Spell Damage: +25, Damage Reduction: 1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	lightning-fast chilly ruddy Pantsgiving of mayonnaise	0		Maximum HP Percent: +40, Cold Damage: +5, Sleaze Spell Damage: +50, Initiative: +40, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	decent thick can of sardines	5	good	Last Available: "2013-11"
+6860	lightning-fast chilly ruddy Pantsgiving of mayonnaise	0		Maximum HP Percent: +40, Cold Damage: +5, Sleaze Spell Damage: +50, Initiative: +40, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6861	thick decent can of sardines	5	good	Last Available: "2013-11"
 6862	toothsome blue high-calorie sugar substitute	3	awesome	Last Available: "2013-11"
 6863	stale enchanted purple pat of butter	4	decent	Effect: "Crotchety, Pining", Effect Duration: 40, Last Available: "2013-11"
 6864	super-sized spoiled dinner roll	5	crappy	Last Available: "2013-11"
-6865	snack-sized normal tumbling mashed potatoes	2	good	Last Available: "2013-11"
+6865	normal snack-sized tumbling mashed potatoes	2	good	Last Available: "2013-11"
 6866	rotten small whole turkey leg	2	crappy	Last Available: "2013-11"
 6867	stale deviled egg	4	decent	Last Available: "2013-11"
 6868	alkaline frozen tumbling finger exerciser	0		Effect: "Glo-Face", Effect Duration: 60, Last Available: "2013-11"
@@ -6779,10 +6779,10 @@
 6890	green spirit bed	0		
 6891	steel-toed shellacked spirit bell of the sweet-tooth	0		Damage Reduction: 32, Candy Drop: +100, Class: "Turtle Tamer"
 6892	enhanced spoonful of Linguine-Os	0		Effect: "Wintergreen Warmongery", Effect Duration: 31, Last Available: "2013-11"
-6893	energized deionized gray tumbling freezer-burned frost-bitten tortellini	0		Effect: "Empty Inside", Effect Duration: 17, Last Available: "2013-11"
+6893	energized deionized tumbling gray freezer-burned frost-bitten tortellini	0		Effect: "Empty Inside", Effect Duration: 17, Last Available: "2013-11"
 6894	denatured vacuum-sealed blob of Alphredo&trade;	0		Effect: "Egged On", Effect Duration: 35, Last Available: "2013-11"
 6895	deionized yellow mirror handful of crafty noodles	0		Effect: "Slimed Stomach", Effect Duration: 53, Last Available: "2013-11"
-6896	polarized triple-boiled galvanized mirror twirling tangled mass of pasta	0		Effect: "Retrograde Relaxation", Effect Duration: 45, Last Available: "2013-11"
+6896	polarized triple-boiled galvanized twirling mirror tangled mass of pasta	0		Effect: "Retrograde Relaxation", Effect Duration: 45, Last Available: "2013-11"
 6897	denatured electrified blurry spinning Can of Spaghetto	0		Effect: "Stickler for Promptness", Effect Duration: 36, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
@@ -6792,7 +6792,7 @@
 6903	flattened nuts	0		Effect: "Drenched With Filth", Effect Duration: 65, Last Available: "2013-12"
 6904	concentrated triple-warmed ghostly bolts	0		Effect: "Bilious Brawn", Effect Duration: 21, Last Available: "2013-12"
 6905	adequate pulsating gingerbread robot	4	good	Last Available: "2013-12"
-6906	decent huge petit 4.1	9	good	Last Available: "2013-12"
+6906	huge decent petit 4.1	9	good	Last Available: "2013-12"
 6907	half-sized bland nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
 6908	lime green pulsating fortified plastic GORM-8	0		Damage Absorption: +60, Last Available: "2013-12"
 6909	wobbly plastic warbear of temperance	0		Sleaze Resistance: +5, Last Available: "2013-12"
@@ -6808,9 +6808,9 @@
 6919	oxidized twirling warbear bearserker potion	0		Effect: "So You Can Work More...", Effect Duration: 26, Last Available: "2013-12"
 6920	extra-warmed warbear liquid overcoat	0		Effect: "Biologically Shocked", Effect Duration: 36, Last Available: "2013-12"
 6921	moldy massive red warbear feasting bread	6	crappy	Last Available: "2013-12"
-6922	huge spoiled warbear warrior bread	7	crappy	Last Available: "2013-12"
+6922	spoiled huge warbear warrior bread	7	crappy	Last Available: "2013-12"
 6923	rotten warbear thermoregulator bread	3	crappy	Last Available: "2013-12"
-6924	high-proof lousy squat bouncing warbear feasting mead	7	decent	Last Available: "2013-12"
+6924	high-proof lousy bouncing squat warbear feasting mead	7	decent	Last Available: "2013-12"
 6925	tolerable warbear bearserker mead	3	good	Last Available: "2013-12"
 6926	delicious tumbling warbear blizzard mead	3	awesome	Last Available: "2013-12"
 6927	purple warbear helm fragment	0		Last Available: "2013-12"
@@ -6823,7 +6823,7 @@
 6934	censurious Oprah's brainy warbear plain ushanka	0		Mysticality: +5, Maximum MP Percent: +50, Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
 6935	horrifying warbear lined ushanka	0		Spooky Damage: +25, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
 6936	ghostly scandalous beefcake's warbear heated ushanka of Gandalf	0		Muscle: +25, Spell Critical Percent: +20, Sleaze Damage: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
-6937	mirror wobbly warbear trouser fragment	0		Last Available: "2013-12"
+6937	wobbly mirror warbear trouser fragment	0		Last Available: "2013-12"
 6938	executive shellacked forbidden warbear party pants	0		Spell Damage Percent: +50, Damage Reduction: 7, Meat Drop: +40, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
 6939	skewed therapeutic warbear ceremonial party pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
 6940	dangerous warbear high festival pants of the ox of the early riser	0		Muscle: +20, Weapon Damage: +10, Adventures: +7, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
@@ -6847,11 +6847,11 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	lightning-fast warbear foil hat	0		Initiative: +40, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	narrow Usain Bolt's curative warbear oil pan	0		Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	narrow Usain Bolt's curative warbear oil pan	0		Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	jittery shaking warbear exhaust manifold of the ox	0		Muscle: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
-6965	ghostly mirror warbear auto-anvil	0		Last Available: "2013-12"
+6965	mirror ghostly warbear auto-anvil	0		Last Available: "2013-12"
 6966	warbear induction oven	0		Last Available: "2013-12"
 6967	olive warbear chemistry lab	0		Last Available: "2013-12"
 6968	yellow warbear officer requisition box	0		Last Available: "2013-12"
@@ -6893,7 +6893,7 @@
 7004	anodized Flaskfull of Hollow	0		Effect: "Loco Motives", Effect Duration: 32, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	powdered tumbling handful of Smithereens	1	crappy	Last Available: "2013-12"
-7007	flavorless massive Every Day is Like This Sundae	7	decent	Last Available: "2013-12"
+7007	massive flavorless Every Day is Like This Sundae	7	decent	Last Available: "2013-12"
 7008	moldy Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	decent fancy blinking This Charming Flan	3	good	Effect: "Elemental Saucesphere", Effect Duration: 10, Last Available: "2013-12"
 7010	artisanal shaking Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
@@ -6918,11 +6918,11 @@
 7029	huge wholesome brawny Shakespeare's Sister's Accordion of the detective	0		Muscle Percent: +20, Maximum HP Percent: +10, Item Drop: +20, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	blinking reassuring third-hand lantern	0		Spooky Resistance: +1
 7031	mirror loose purse strings	0		
-7032	stale snack-sized pickled egg	2	decent	
+7032	snack-sized stale pickled egg	2	decent	
 7033	fancy cup of lukewarm tea	1	decent	Effect: "Slippery Tongue", Effect Duration: 20
 7034	upside-down warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
-7036	bouncing wobbly warbear high-efficiency still	0		Last Available: "2013-12"
+7036	wobbly bouncing warbear high-efficiency still	0		Last Available: "2013-12"
 7037	narrow warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	warbear gyrocopter	0		Last Available: "2013-12"
 7039	unsweetened quadruple-polarized warbear robo-camouflage unit	0		Effect: "Red Misty-Eyed", Effect Duration: 58, Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	activated energized blinking narrow glass slipper	0		Effect: "Gamer Rage", Effect Duration: 51, Last Available: "2014-12"
-7045	boiled upside-down ghostly antimatter wad	1	decent	Effect: "Always In Motion", Effect Duration: 30, Last Available: "2013-12"
+7045	boiled ghostly upside-down antimatter wad	1	decent	Effect: "Always In Motion", Effect Duration: 30, Last Available: "2013-12"
 7046	double-irradiated Vulcanized warbear superpotion	0		Effect: "Hustlin'", Effect Duration: 61, Last Available: "2013-12"
 7047	dry triple-unsweetened energized skewed warbear liquid lasers	0		Effect: "Cat Class, Cat Style", Effect Duration: 63, Last Available: "2013-12"
 7048	enhanced warbear rejuvenation potion	0		Effect: "Super-Electrified", Effect Duration: 45, Last Available: "2013-12"
@@ -6943,8 +6943,8 @@
 7054	ghostly warbear drone codes	0		Last Available: "2013-12"
 7055	adequate tumbling breakfast mess	3	good	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	tasty special half-sized breakfast miracle	2	awesome	Effect: "Rage of the Reindeer", Effect Duration: 10, Last Available: "2013-12"
-7058	quadruple-ionized Vulcanized spinning cyan Cloaca Cola Polar	0		Effect: "Barking Mad", Effect Duration: 32, Last Available: "2013-12"
+7057	special half-sized tasty breakfast miracle	2	awesome	Effect: "Rage of the Reindeer", Effect Duration: 10, Last Available: "2013-12"
+7058	quadruple-ionized Vulcanized cyan spinning Cloaca Cola Polar	0		Effect: "Barking Mad", Effect Duration: 32, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	grimstone mask	0		Last Available: "2014-12"
@@ -6955,16 +6955,16 @@
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	ionized jittery tumbling jittery single of Inigo's Incantation of Inspiration	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 43, Last Available: "2010-02"
 7068	magnetized diffused single of Donho's Bubbly Ballad	0		Effect: "Marbles in Your Mouth", Effect Duration: 34
-7069	mirror gray Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
+7069	gray mirror Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	pulsating packet of winter seeds	0		Last Available: "2014-01"
-7071	adequate fancy thick olive snow berries	5	good	Effect: "Radiant Personality", Effect Duration: 35, Last Available: "2014-01"
+7071	thick fancy adequate olive snow berries	5	good	Effect: "Radiant Personality", Effect Duration: 35, Last Available: "2014-01"
 7072	rotten bite-sized ice harvest	1	crappy	Last Available: "2014-01"
 7073	dry concentrated pressed spinning teal frost flower	0		Effect: "Radium Radicality", Effect Duration: 31, Last Available: "2014-01"
 7074	diffused snow cleats	0		Effect: "Favored by Lyle", Effect Duration: 27, Last Available: "2014-01"
 7075	galvanized cold-filtered liquid ice pack	0		Effect: "Blood-Rich", Effect Duration: 22, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	spoiled enchanted snow crab	4	crappy	Effect: "Abyssal Tears", Effect Duration: 15, Last Available: "2014-01"
-7078	aged fancy Ice Island Long Tea	3	awesome	Effect: "Experimental Effect G-9", Effect Duration: 5, Last Available: "2014-01"
+7077	enchanted spoiled snow crab	4	crappy	Effect: "Abyssal Tears", Effect Duration: 15, Last Available: "2014-01"
+7078	fancy aged Ice Island Long Tea	3	awesome	Effect: "Experimental Effect G-9", Effect Duration: 5, Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	twirling ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	blinking asbestos-lined frosty MacGyver's supercool snow belt	0		Moxie Percent: +20, Maximum MP: +100, Cold Spell Damage: +10, Hot Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	bouncing ribald coward's smooth ice nine of terror	0		Moxie: +15, Monster Level: -20, Spooky Spell Damage: +10, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7089	upside-down snow fort	0		Last Available: "2014-01"
-7090	high-proof tolerable En Una Fila Tequila	7	good	
+7090	tolerable high-proof En Una Fila Tequila	7	good	
 7091	Skully's hot chocolate	1	decent	
 7092	ribald warbear dress helmet of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	rosewater-soaked warbear dress bracers of chilblains	0		Cold Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2013-12"
@@ -6986,7 +6986,7 @@
 7097	squat stanky hale ankleweights	0		Maximum HP: +20, Stench Spell Damage: +25, Single Equip, Last Available: "2014-12"
 7098	lion tamer's Lo Pan's wholesome sweat socks of the glutton	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Experience (familiar): +2, Food Drop: +100, Last Available: "2014-12"
 7099	blue pint of sweat	0		Last Available: "2014-12"
-7100	olive huge Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
+7100	huge olive Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	dehydrated Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
 7103	moist non-anodized powder	0		Effect: "Springy Fusilli", Effect Duration: 34, Last Available: "2014-12"
@@ -7001,11 +7001,11 @@
 7112	mediocre upside-down chocotini	4	decent	Last Available: "2014-12"
 7113	therapeutic chocolate rabbit's foot of the pedagogue of Flo-Jo	0		Experience: +3, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7114	yummy wobbly candy carrot	3	awesome	Last Available: "2014-12"
-7115	enchanted flavorless super-sized candy carrot cake	5	decent	Effect: "Surreally Buff", Effect Duration: 20, Last Available: "2014-12"
+7115	super-sized flavorless enchanted candy carrot cake	5	decent	Effect: "Surreally Buff", Effect Duration: 20, Last Available: "2014-12"
 7116	bouncing frosty cool carrot-on-a-stick	0		Moxie: +5, Cold Spell Damage: +10, Last Available: "2014-12"
 7117	gray weasel stomping pants of Gandalf of the brazier	0		Spell Critical Percent: +20, Hot Spell Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	rotten half-sized mulberry	2	crappy	Last Available: "2014-12"
-7119	lousy weak mulled berry wine	2	decent	Last Available: "2014-12"
+7119	weak lousy mulled berry wine	2	decent	Last Available: "2014-12"
 7120	skewed lemony scales	0		Last Available: "2014-12"
 7121	dangerous lemon party hat	0		Weapon Damage: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	rosy-cheeked lemon shirt	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2014-12"
@@ -7015,12 +7015,12 @@
 7126	ionized small gummi fin	0		Effect: "Yuletide Industry", Effect Duration: 12, Last Available: "2014-12"
 7127	rosewater-soaked chocolate cow bone	0		Stench Resistance: +3, Last Available: "2014-12"
 7128	denatured gummi fang	0		Effect: "Berry Experiential", Effect Duration: 28, Last Available: "2014-12"
-7129	decent small bouncing spinning leftover canap&eacute;s	2	good	Last Available: "2014-12"
+7129	small decent bouncing spinning leftover canap&eacute;s	2	good	Last Available: "2014-12"
 7130	strong drinkable magnum of champagne	5	good	Last Available: "2014-12"
 7131	scandalous MacGyver's cow creamer of the sweet-tooth	0		Maximum MP: +100, Sleaze Damage: +5, Candy Drop: +100, Last Available: "2014-12"
 7132	modified electrified Outer Wolf&trade; cologne	0		Effect: "Mint-Condition Breath", Effect Duration: 63, Last Available: "2014-12"
 7133	skewed ghostly lupine appetite hormones	0		Last Available: "2014-12"
-7134	Sinatra's beefy wolf whistle	0		Muscle: +10, Experience (Moxie): +5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	Sinatra's beefy wolf whistle	0		Muscle: +10, Experience (Moxie): +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	yummy huge witch's bread	9	awesome	Last Available: "2014-12"
 7136	unsweetened polymerized quadruple-wet shaking witch's brew	0		Effect: "Chalky Hand", Effect Duration: 40, Last Available: "2014-12"
 7137	shaking ghostly wicked witch's bra of the blizzard of incineration	0		Spell Damage: +5, Cold Spell Damage: +25, Hot Spell Damage: +50, Last Available: "2014-12"
@@ -7052,15 +7052,15 @@
 7163	dog trainer's hale skull gearshift knob of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +20, Experience (familiar): +1, Last Available: "2014-12"
 7164	bland nachos of the night	4	decent	Last Available: "2014-12"
 7165	spinning careful manspreader's Tesla Sketcherz&trade;	0		Monster Level: 0, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12"
-7166	half-sized delicious red can of Adultwitch&trade;	2	awesome	Last Available: "2014-12"
+7166	delicious half-sized red can of Adultwitch&trade;	2	awesome	Last Available: "2014-12"
 7167	concentrated fuchsia smudge stick	0		Effect: "Become Intensely interested", Effect Duration: 56, Last Available: "2014-12"
 7168	triple-quantum altered electrified twirling wall	0		Effect: "Flashing Eyes", Effect Duration: 27, Last Available: "2014-12"
-7169	watered-down tolerable narrow tankard of ale	2	good	Last Available: "2014-12"
+7169	tolerable watered-down narrow tankard of ale	2	good	Last Available: "2014-12"
 7170	tarnished scroll case	0		Effect: "Prelude of Precision", Effect Duration: 53, Last Available: "2014-12"
 7171	adjusted jug of &quot;wine&quot;	0		Effect: "Stickler for Promptness", Effect Duration: 65, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	snack-sized spoiled humble pie	2	crappy	Last Available: "2014-12"
+7174	spoiled snack-sized humble pie	2	crappy	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	tumbling shaking crappy camera	0		Last Available: "2014-12"
 7177	polarized moist crappy waiter disguise	0		Effect: "Trufflin'", Effect Duration: 13
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	savvy Buddy Bjorn	0		Mysticality Percent: +20, Softcore Only, Last Available: "2014-02"
 7201	lion tamer's razor-sharp brawny The Nuge's favorite crossbow	0		Muscle Percent: +20, Weapon Damage Percent: +25, Experience (familiar): +2
-7202	immense fancy adequate sweet roll Alabama	8	good	Effect: "You're High as a Crow, Marty", Effect Duration: 40
+7202	adequate fancy immense sweet roll Alabama	8	good	Effect: "You're High as a Crow, Marty", Effect Duration: 40
 7203	purple Saturday Night Special of wisdom	0		Mysticality: +15
 7204	blinking lynyrd snare	0		
 7205	ghostly fleetwood chain of the wise owl	0		Mysticality: +20
@@ -7113,9 +7113,9 @@
 7224	huge friendly Kashmir sweater of wisdom	0		Mysticality: +15, Familiar Weight: +3
 7225	normal gigantic custard pie	9	good	
 7226	tea for one	1	awesome	
-7227	tolerable fortified bottle of Evermore	5	good	
+7227	fortified tolerable bottle of Evermore	5	good	
 7228	box	0		
-7229	special mediocre wine	4	decent	Effect: "Fishy", Effect Duration: 45
+7229	mediocre special wine	4	decent	Effect: "Fishy", Effect Duration: 45
 7230	delicious rum	3	awesome	
 7231	perfectly mixed high-proof Murderer's Punch	10	EPIC	
 7232	decent miniature velvet cake	2	good	
@@ -7219,7 +7219,7 @@
 7330	distilled twirling the funk	1		
 7331	rotten gunky chicken	3	crappy	
 7332	educational doll head	0		Experience: +1
-7333	cyan pulsating twirling droopy doll eye	0		
+7333	pulsating cyan twirling droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	flame-retardant paddle-ball of chilblains	0		Cold Damage: +25, Hot Resistance: +1
 7336	diffused sound effects record	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 32
@@ -7238,7 +7238,7 @@
 7349	ghost key	0		
 7350	squat picture of you	0		
 7351	Temple Grandin's rosy-cheeked Fonzie's Staff of the Electric Range	0		Experience (Moxie): +1, Maximum HP Percent: +30, Familiar Weight: +7
-7352	tasty half-sized green deluxe layer cake	2	awesome	
+7352	half-sized tasty green deluxe layer cake	2	awesome	
 7353	red chunk of hot iron	0		
 7354	perfectly mixed red-hot boilermaker	3	EPIC	
 7355	bouncing Herculean coal shovel	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Shovel Hot Coal"
@@ -7254,14 +7254,14 @@
 7365	oxidized frozen double-pressed fabric hardener	0		Effect: "Greased-Up Familiar", Effect Duration: 11
 7366	high-proof bad bottle of laundry sherry	6	decent	
 7367	magnetized triple-altered industrial strength starch	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 19, Wiki Name: "industrial strength starch"
-7368	spoiled low-calorie extra-flat panini	1	crappy	
+7368	low-calorie spoiled extra-flat panini	1	crappy	
 7369	moist mangled finger	0		Effect: "Amorphous Cheer", Effect Duration: 25
 7370	bad Psychotic Train wine	4	decent	
 7371	crazy hobo notebook	0		
-7372	adequate enchanted pie man was not meant to eat	4	good	Effect: "Ruthlessly Efficient", Effect Duration: 50
+7372	enchanted adequate pie man was not meant to eat	4	good	Effect: "Ruthlessly Efficient", Effect Duration: 50
 7373	sommelier's towel of the overflowing toilet	0		Stench Spell Damage: +50
 7374	fuchsia huge manspreader's tarnished tastevin	0		Monster Level: +10, Single Equip
-7375	low-calorie stale tumbling actual tapas	1	decent	
+7375	stale low-calorie tumbling actual tapas	1	decent	
 7376	ghast iron ingot	0		
 7377	sizzling Oprah's ghast iron cleaver	0		Maximum MP Percent: +50, Hot Damage: +10
 7378	upside-down blue Newton's Rosewater's ghast iron Garibaldi	0		Mysticality Percent: +30, Experience (Mysticality): +3, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7277,13 +7277,13 @@
 7388	denatured frozen upside-down cyan Gene Tonic: Humanoid	0		Effect: "The Two-Prong Crown", Effect Duration: 33, Last Available: "2014-04"
 7389	deionized Gene Tonic: Insect	0		Effect: "Sweet and Green", Effect Duration: 43, Last Available: "2014-04"
 7390	magnetized concentrated Gene Tonic: Hippy	0		Effect: "Staying Frosty", Effect Duration: 51, Last Available: "2014-04"
-7391	warmed teal narrow ghostly Gene Tonic: Orc	0		Effect: "Sticky Hands", Effect Duration: 69, Last Available: "2014-04"
+7391	warmed narrow teal ghostly Gene Tonic: Orc	0		Effect: "Sticky Hands", Effect Duration: 69, Last Available: "2014-04"
 7392	improved chilled tumbling Gene Tonic: Demon	0		Effect: "You Drank Fish Wine", Effect Duration: 13, Last Available: "2014-04"
 7393	quadruple-warmed lime green Gene Tonic: Horror	0		Effect: "Improprie Tea", Effect Duration: 66, Last Available: "2014-04"
 7394	anodized unsweetened Gene Tonic: Fish	0		Effect: "Inner Warmth", Effect Duration: 56, Last Available: "2014-04"
 7395	chilled fuchsia Gene Tonic: Goblin	0		Effect: "Polka Face", Effect Duration: 37, Last Available: "2014-04"
 7396	irradiated triple-deionized boiled lime green Gene Tonic: Pirate	0		Effect: "Berry Thorny", Effect Duration: 29, Last Available: "2014-04"
-7397	electrified corrupted wobbly jittery Gene Tonic: Plant	0		Effect: "Sweet Taste", Effect Duration: 69, Last Available: "2014-04"
+7397	electrified corrupted jittery wobbly Gene Tonic: Plant	0		Effect: "Sweet Taste", Effect Duration: 69, Last Available: "2014-04"
 7398	corrupted Gene Tonic: Weird	0		Effect: "Toast Tea", Effect Duration: 19, Last Available: "2014-04"
 7399	extra-tarnished liquefied jittery Gene Tonic: Elf	0		Effect: "Patent Prevention", Effect Duration: 50, Last Available: "2014-04"
 7400	galvanized boiled Gene Tonic: Mer-kin	0		Effect: "Fangs and Pangs", Effect Duration: 33, Last Available: "2014-04"
@@ -7313,37 +7313,37 @@
 7424	cyan bike rental broupon	0		Last Available: "2014-05"
 7425	Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	shaking sprinkle shaker	0		Last Available: "2014-05"
-7427	improved maroon squat skewed sleight-of-hand mushroom	0		Effect: "Cake Caked", Effect Duration: 13, Last Available: "2014-05"
+7427	improved skewed squat maroon sleight-of-hand mushroom	0		Effect: "Cake Caked", Effect Duration: 13, Last Available: "2014-05"
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	pulsating Beach Buck	0		Last Available: "2014-05"
 7430	pickled gray Fun-Guy spore	0		Effect: "Bright!", Effect Duration: 58, Last Available: "2014-05"
 7431	Vulcanized nitrogenated Boletus Broletus mushroom	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 25, Last Available: "2014-05"
-7432	electrified upside-down blue Omphalotus Omphaloskepsis mushroom	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 34, Last Available: "2014-05"
+7432	electrified blue upside-down Omphalotus Omphaloskepsis mushroom	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 34, Last Available: "2014-05"
 7433	cold-filtered pickled pulsating cyan Gyromitra Dynomita mushroom	0		Effect: "damage.enh", Effect Duration: 61, Last Available: "2014-05"
 7434	cold-filtered ionized green Helvella Haemophilia mushroom	0		Effect: "Moose Wisdom", Effect Duration: 47, Last Available: "2014-05"
 7435	tarnished gray Stemonitis Staticus mushroom	0		Effect: "Bonelording", Effect Duration: 61, Last Available: "2014-05"
-7436	double-altered pickled lime green tumbling twirling Tremella Tarantella mushroom	0		Effect: "Cold Throat", Effect Duration: 34, Last Available: "2014-05"
+7436	double-altered pickled lime green twirling tumbling Tremella Tarantella mushroom	0		Effect: "Cold Throat", Effect Duration: 34, Last Available: "2014-05"
 7437	skewed Pastaco shell	0		Last Available: "2014-05"
-7438	super-sized spoiled Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
+7438	spoiled super-sized Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
 7439	normal Brain Food Pastaco	4	good	Last Available: "2014-05"
 7440	bland pulsating red Cool Brunch Pastaco	4	decent	Last Available: "2014-05"
-7441	gigantic decent fancy maroon Medical Pastaco	10	good	Effect: "Smoky Third Eye", Effect Duration: 50, Last Available: "2014-05"
-7442	enchanted decent snack-sized Energy Buzz Pastaco	2	good	Effect: "Bright!", Effect Duration: 10, Last Available: "2014-05"
+7441	fancy gigantic decent maroon Medical Pastaco	10	good	Effect: "Smoky Third Eye", Effect Duration: 50, Last Available: "2014-05"
+7442	decent enchanted snack-sized Energy Buzz Pastaco	2	good	Effect: "Bright!", Effect Duration: 10, Last Available: "2014-05"
 7443	flavorless Ludovico Pastaco	3	decent	Last Available: "2014-05"
-7444	practically non-alcoholic mediocre overpowering mushroom wine	1	decent	Last Available: "2014-05"
+7444	mediocre practically non-alcoholic overpowering mushroom wine	1	decent	Last Available: "2014-05"
 7445	high-proof bad red complex mushroom wine	9	decent	Last Available: "2014-05"
 7446	hand-crafted smooth mushroom wine	3	super EPIC	Last Available: "2014-05"
 7447	acceptable blood-red mushroom wine	4	good	Last Available: "2014-05"
-7448	weak lousy twirling cyan buzzing mushroom wine	2	decent	Last Available: "2014-05"
+7448	lousy weak twirling cyan buzzing mushroom wine	2	decent	Last Available: "2014-05"
 7449	smooth jittery swirling mushroom wine	4	awesome	Last Available: "2014-05"
-7450	decent tiny Taco Dan's Basic Taco Dan Taco	1	good	Last Available: "2014-05"
+7450	tiny decent Taco Dan's Basic Taco Dan Taco	1	good	Last Available: "2014-05"
 7451	delicious ghostly Taco Dan's Taco Fish Fish Taco	4	awesome	Last Available: "2014-05"
 7452	lime green Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	practically non-alcoholic bad ghostly regular-size brogurt	1	decent	Last Available: "2014-05"
+7453	bad practically non-alcoholic ghostly regular-size brogurt	1	decent	Last Available: "2014-05"
 7454	hand-crafted weak super-size brogurt	2	EPIC	Last Available: "2014-05"
 7455	practically non-alcoholic delicious broberry brogurt	1	awesome	Last Available: "2014-05"
 7456	weak lousy brocolate brogurt	2	decent	Last Available: "2014-05"
-7457	strong lousy blinking French bronilla brogurt	5	decent	Last Available: "2014-05"
+7457	lousy strong blinking French bronilla brogurt	5	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	pulsating Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7367,7 +7367,7 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	concentrated alkaline bouncing sugar fairy	0		Effect: "Full of Wist", Effect Duration: 28, Last Available: "2014-05"
 7480	corrupted modified blinking sugar bunny	0		Effect: "Less Pervious", Effect Duration: 20, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	aged high-proof Rompedores de Fantasmas	7	awesome	
 7483	lousy La Fantasma y La Oscuridad	3	decent	
 7484	perfectly mixed narrow Fantasma en la M&aacute;quina	4	EPIC	
@@ -7377,10 +7377,10 @@
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	mirror triatomaceous dust	0		
-7491	watered-down aged maroon bottle of Chateau de Vinegar	2	awesome	
+7491	aged watered-down maroon bottle of Chateau de Vinegar	2	awesome	
 7492	blasting soda	0		
 7493	fuchsia unstable fulminate	0		
-7494	spinning bouncing spinning wine bomb	0		
+7494	bouncing spinning spinning wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
@@ -7405,7 +7405,7 @@
 7516	witch's spare house key	0		
 7517	Jeselnik's spider leg of temperance	0		Sleaze Damage: +25, Sleaze Resistance: +5
 7518	wand of pigification	0		
-7519	bad fancy glass of bourbon	3	decent	Effect: "Coal-Powered", Effect Duration: 45
+7519	fancy bad glass of bourbon	3	decent	Effect: "Coal-Powered", Effect Duration: 45
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	delicious government cheese	4	awesome	Last Available: "2014-05"
 7522	twirling pair of government shades of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2014-05"
@@ -7416,9 +7416,9 @@
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	tumbling dog trainer's rock-hard government-issued night-vision goggles	0		Damage Reduction: 5, Experience (familiar): +1, Single Equip, Last Available: "2014-05"
 7529	moldy loaf of alien bread	4	crappy	Last Available: "2014-05"
-7530	normal snack-sized grilled cheese sandwich	2	good	Last Available: "2014-05"
+7530	snack-sized normal grilled cheese sandwich	2	good	Last Available: "2014-05"
 7531	boiled alien protein powder	1	good	Last Available: "2014-05"
-7532	aged practically non-alcoholic rocket fuel	1	awesome	Last Available: "2014-05"
+7532	practically non-alcoholic aged rocket fuel	1	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	tumbling alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	hand-crafted stealth bomber	3	EPIC	Last Available: "2014-05"
@@ -7429,14 +7429,14 @@
 7540	blue rosewater-soaked space beast fur pants	0		Stench Resistance: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	deadly space beast fur whip	0		Weapon Damage: +5, Last Available: "2014-05"
 7542	twirling space invader	0		Last Available: "2014-05"
-7543	Newton's space heater of incineration	0		Experience (Mysticality): +3, Hot Spell Damage: +50, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
-7544	squat maroon space bar	0		Last Available: "2014-05"
-7545	weak artisanal space port	2	EPIC	Last Available: "2014-05"
+7543	Newton's space heater of incineration	0		Experience (Mysticality): +3, Hot Spell Damage: +50, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7544	maroon squat space bar	0		Last Available: "2014-05"
+7545	artisanal weak space port	2	EPIC	Last Available: "2014-05"
 7546	narrow aromatic fireproof space needle	0		Hot Resistance: +3, Stench Resistance: +1, Last Available: "2014-05"
-7547	tarnished cold-filtered lime green huge buffed alien drugs	0		Effect: "Shawarma Warm War", Effect Duration: 58, Last Available: "2014-05"
+7547	tarnished cold-filtered huge lime green buffed alien drugs	0		Effect: "Shawarma Warm War", Effect Duration: 58, Last Available: "2014-05"
 7548	mirror hot ashes	0		Last Available: "2014-06"
 7549	super-aerosolized ash soda	0		Effect: "Fireproof Lips", Effect Duration: 14, Last Available: "2014-06"
-7550	adjusted corrupted huge teal ghostly liquid smoke	0		Effect: "Bilious Brawn", Effect Duration: 65, Last Available: "2014-06"
+7550	adjusted corrupted ghostly huge teal liquid smoke	0		Effect: "Bilious Brawn", Effect Duration: 65, Last Available: "2014-06"
 7551	energized blinking dollop of barbecue sauce	0		Effect: "Motion", Effect Duration: 35, Last Available: "2014-06"
 7552	magnetized wet shaking bowl of marinade	0		Effect: "Slightly Larger Than Usual", Effect Duration: 24, Last Available: "2014-06"
 7553	yellow shaker of dry rub	0		Last Available: "2014-06"
@@ -7444,10 +7444,10 @@
 7555	wobbly page	0		
 7556	bouncing elephant gift	0		
 7557	galvanized spinning blood cells	0		Effect: "Tremella Tremens", Effect Duration: 33
-7558	acceptable watered-down wine	2	good	
+7558	watered-down acceptable wine	2	good	
 7559	extra-irradiated yellow ghostly gummi turtle	0		Effect: "Hot Blooded", Effect Duration: 14
 7560	turtle-shaped rock	0		
-7561	diffused pressed squat mirror blue giraffe-necked turtle	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 60
+7561	diffused pressed mirror blue squat giraffe-necked turtle	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 60
 7562	Vulcanized energized huge musk turtle	0		Effect: "Dreadful Fear", Effect Duration: 53
 7563	improved corrupted yellow programmable turtle	0		Effect: "Chief Executive Optimism", Effect Duration: 36
 7564	magnetized electrified bouncing mocking turtle	0		Effect: "Chalk Outline", Effect Duration: 44
@@ -7460,10 +7460,10 @@
 7571	greasy manspreader's silent pea shooter	0		Monster Level: +10, Sleaze Spell Damage: +10
 7572	bland thick wobbly D roll	5	decent	
 7573	ghostly foul-smelling kiwi beak of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +10
-7574	acceptable enchanted watered-down New Zealand iced tea	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35
+7574	enchanted acceptable watered-down New Zealand iced tea	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35
 7575	friendly droll monocle of bravery	0		Familiar Weight: +3, Spooky Resistance: +5, Single Equip
 7576	cold-filtered quantum gray future drug: Muscularactum	0		Effect: "Net Tea", Effect Duration: 24
-7577	corrupted magnetized ghostly green tumbling future drug: Smartinex	0		Effect: "Hot Blooded", Effect Duration: 34
+7577	corrupted magnetized tumbling green ghostly future drug: Smartinex	0		Effect: "Hot Blooded", Effect Duration: 34
 7578	ionized frozen future drug: Coolscaline	0		Effect: "Neuroplastici Tea", Effect Duration: 28
 7579	twitching time capsule	0		
 7580	altered shaking pulsating liquid shifting time weirdness	1		
@@ -7475,16 +7475,16 @@
 7586	helix fossil	0		
 7587	lime green S.S. Ticket	0		Familiar Weight: +5
 7588	pulsating Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	watered-down tolerable glass of &quot;milk&quot;	2	good	Last Available: "2014-07"
-7590	watered-down tolerable cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
+7589	tolerable watered-down glass of &quot;milk&quot;	2	good	Last Available: "2014-07"
+7590	tolerable watered-down cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
 7591	mediocre high-proof thermos of &quot;whiskey&quot;	10	decent	Last Available: "2014-07"
-7592	artisanal high-proof Lucky Lindy	8	EPIC	Last Available: "2014-07"
+7592	high-proof artisanal Lucky Lindy	8	EPIC	Last Available: "2014-07"
 7593	perfectly mixed Bee's Knees	3	EPIC	Last Available: "2014-07"
 7594	drinkable boozy narrow Sockdollager	5	good	Last Available: "2014-07"
 7595	perfectly mixed ghostly jittery Ish Kabibble	3	EPIC	Last Available: "2014-07"
 7596	lousy Hot Socks	3	decent	Last Available: "2014-07"
-7597	aged practically non-alcoholic Phonus Balonus	1	awesome	Last Available: "2014-07"
-7598	practically non-alcoholic mediocre Flivver	1	decent	Last Available: "2014-07"
+7597	practically non-alcoholic aged Phonus Balonus	1	awesome	Last Available: "2014-07"
+7598	mediocre practically non-alcoholic Flivver	1	decent	Last Available: "2014-07"
 7599	triple-distilled lousy Sloppy Jalopy	8	decent	Last Available: "2014-07"
 7600	improved blurry flame	0		Effect: "Human-Goblin Hybrid", Effect Duration: 41
 7601	magnetized cold-filtered shaking temporary yak tattoo	0		Effect: "Remaining Alive", Effect Duration: 65
@@ -7494,9 +7494,9 @@
 7605	polymerized double-pressed punk patch	0		Effect: "Bright!", Effect Duration: 55
 7606	corrupted tarnished steampunk potion	0		Effect: "[1609]Dancin' Fool", Effect Duration: 67
 7607	moist diffused twirling vial of swamp vapors	0		Effect: "Orchid Blood", Effect Duration: 39
-7608	moist pulsating blurry turtle mud	0		Effect: "Hiding in Plain Sight", Effect Duration: 63
+7608	moist blurry pulsating turtle mud	0		Effect: "Hiding in Plain Sight", Effect Duration: 63
 7609	non-warmed dry Redeye&trade; Eyedrops	0		Effect: "Shot in the Arse", Effect Duration: 66
-7610	polymerized blue mirror Dweebisol&trade; inhaler	0		Effect: "Hiding in Plain Sight", Effect Duration: 44
+7610	polymerized mirror blue Dweebisol&trade; inhaler	0		Effect: "Hiding in Plain Sight", Effect Duration: 44
 7611	altered improved Lewd Lemmy Hair Oil	0		Effect: "Third Based", Effect Duration: 15
 7612	deionized tomato soup poster	0		Effect: "Unrunnable Face", Effect Duration: 68
 7613	nitrogenated bubblin' chemistry solution	0		Effect: "Rain Dancin'", Effect Duration: 53
@@ -7519,7 +7519,7 @@
 7630	double-dry quantum upside-down magic powder	0		Effect: "Healthy Bronze Glow", Effect Duration: 15
 7631	energized colloidal friar's tonsure	0		Effect: "Swordholder", Effect Duration: 57
 7632	unsweetened ionized upside-down government-issue identification badge	0		Effect: "Orc Chops", Effect Duration: 33
-7633	double-magnetized pulsating shaking alien hologram projector	0		Effect: "Work For Hours a Week", Effect Duration: 36
+7633	double-magnetized shaking pulsating alien hologram projector	0		Effect: "Work For Hours a Week", Effect Duration: 36
 7634	energized ionized irradiated turtle	0		Effect: "Space Cadet", Effect Duration: 51
 7635	Vulcanized cigar box turtle	0		Effect: "Frozen Hands", Effect Duration: 22
 7636	Jack Frost's shellacked shell of the boozehound	0		Cold Spell Damage: +50, Booze Drop: +100, Class: "Turtle Tamer"
@@ -7532,7 +7532,7 @@
 7643	jittery duty umbrella	0		
 7644	pool skimmer	0		
 7645	maroon life preserver	0		
-7646	shaking blinking lightning milk	0		
+7646	blinking shaking lightning milk	0		
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
 7649	moist vacuum-sealed gourmet gourami oil	0		Effect: "It's Electric!", Effect Duration: 67
@@ -7552,7 +7552,7 @@
 7663	cool Lord Soggyraven's Slippers of the brazier of the sweet-tooth	0		Moxie: +5, Hot Spell Damage: +25, Candy Drop: +100, Single Equip
 7664	frozen ionized ghostly Ancient Protector Soda	0		Effect: "Heart of Lavender", Effect Duration: 25
 7665	ionized non-chilled corrupted liquid ice	0		Effect: "Motion", Effect Duration: 37
-7666	watered-down smooth green Wet Russian	2	awesome	
+7666	smooth watered-down green Wet Russian	2	awesome	
 7667	immense bland filet of The Fish	8	decent	
 7668	Thwaitgold spider statuette	0		
 7669	upside-down bouncing shaking veiny weightlifter's thunder down underwear of courage	0		Muscle: +15, Maximum HP: +10, Spooky Resistance: +3, Lasts Until Rollover
@@ -7563,7 +7563,7 @@
 7674	tumbling jittery family-friendly hep waders	0		Sleaze Resistance: +1, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	rotten jive turkey leg	3	crappy	
 7676	double-paned birdbone corset	0		Cold Resistance: +5
-7677	wet blurry lime green candy cigarette	0		Effect: "Fungal Fortification", Effect Duration: 37
+7677	wet lime green blurry candy cigarette	0		Effect: "Fungal Fortification", Effect Duration: 37
 7678	bouncing twirling supercool 4-dimensional fez	0		Moxie Percent: +20, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	savvy super-absorbent tarp	0		Mysticality Percent: +20
@@ -7581,7 +7581,7 @@
 7692	maroon Lo Pan's MacGyver's hand whip of Flo-Jo	0		Maximum MP: +100, Spell Critical Percent: +30, Initiative: +100, Last Available: "2014-08"
 7693	lightning-fast healthy glow-in-the-dark necklace of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5, Initiative: +40, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	fortified Herculean cap gun of temperance	0		Experience (Muscle): +1, Damage Absorption: +60, Sleaze Resistance: +5, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	fortified Herculean cap gun of temperance	0		Experience (Muscle): +1, Damage Absorption: +60, Sleaze Resistance: +5, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	manspreader's ruddy cassette player	0		Maximum HP Percent: +40, Monster Level: +10, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	twirling rubber spider	0		Last Available: "2014-08"
@@ -7592,14 +7592,14 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	tumbling red LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	blinking spinning The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	spinning blinking The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	alkaline quantum rubber nubbin	0		Effect: "Afternoon Insight", Effect Duration: 20, Last Available: "2014-08"
 7708	supercool rubber cape of the storm	0		Moxie Percent: +20, Maximum MP Percent: +40, Last Available: "2014-08"
-7709	aromatic resourceful veiny Thor's Pliers of incineration	0		Maximum HP: +10, Maximum MP: +50, Hot Spell Damage: +50, Stench Resistance: +1, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	aromatic resourceful veiny Thor's Pliers of incineration	0		Maximum HP: +10, Maximum MP: +50, Hot Spell Damage: +50, Stench Resistance: +1, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	adjusted candy UFOs	0		Effect: "Ooh, Salty!", Effect Duration: 60
 7711	lard-coated ruddy water wings for babies	0		Maximum HP Percent: +40, Sleaze Spell Damage: +25
 7712	narrow beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	small bland yellow pulsating Strix stix	2	decent	
+7713	bland small yellow pulsating Strix stix	2	decent	
 7714	dance instructor's vampire pellet of Gandalf of horror	0		Experience Percent (Moxie): +10, Spell Critical Percent: +20, Spooky Spell Damage: +25
 7715	acceptable huge non-aged vinegar	4	good	
 7716	bouncing unsanitized scalpel of the storm	0		Maximum MP Percent: +40
@@ -7642,7 +7642,7 @@
 7753	green MacGyver's vibrating Xiblaxian stealth cowl	0		Maximum MP Percent: +10, Maximum MP: +100, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	chaotic deadly Xiblaxian stealth trousers	0		Weapon Damage: +5, Spell Critical Percent: +10, Last Available: "2014-09"
 7755	healthy Xiblaxian stealth vest of the overflowing toilet	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Last Available: "2014-09"
-7756	spoiled special small bouncing jittery Xiblaxian ultraburrito	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10, Last Available: "2014-09"
+7756	small special spoiled jittery bouncing Xiblaxian ultraburrito	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10, Last Available: "2014-09"
 7757	high-proof perfectly mixed spinning Xiblaxian space-whiskey	6	EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	quantum bouncing ghostly They liver	0		Effect: "Heart of White", Effect Duration: 27, Last Available: "2014-09"
@@ -7673,7 +7673,7 @@
 7784	nitrogenated monkey barf	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25, Last Available: "2014-10"
 7785	energized aerosolized candy	0		Effect: "Human-Elf Hybrid", Effect Duration: 47, Last Available: "2014-10"
 7786	forbidden slick jangly bracelet of the boozehound	0		Moxie: +10, Spell Damage Percent: +50, Booze Drop: +100, Last Available: "2014-10"
-7787	cuddly teddy bear of the glutton	0		Food Drop: +100, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	cuddly teddy bear of the glutton	0		Food Drop: +100, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	upside-down ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	mirror reassuring personal trainer's first-aid pouch	0		Experience Percent (Muscle): +10, Spooky Resistance: +1, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7683,10 +7683,10 @@
 7794	skewed Armory keycard	0		Last Available: "2014-10"
 7795	delicious initiative shawarma	4	awesome	Last Available: "2014-10"
 7796	yummy warm war shawarma	4	awesome	Last Available: "2014-10"
-7797	yummy low-calorie karma shawarma	1	awesome	Last Available: "2014-10"
-7798	strong drinkable red pulsating Jungle Juice	5	good	Last Available: "2014-10"
-7799	acceptable strong Amnesiac Ale	5	good	Last Available: "2014-10"
-7800	watered-down mediocre Highest Bitter	2	decent	Last Available: "2014-10"
+7797	low-calorie yummy karma shawarma	1	awesome	Last Available: "2014-10"
+7798	strong drinkable pulsating red Jungle Juice	5	good	Last Available: "2014-10"
+7799	strong acceptable Amnesiac Ale	5	good	Last Available: "2014-10"
+7800	mediocre watered-down Highest Bitter	2	decent	Last Available: "2014-10"
 7801	wobbly arcane researcher's experienced mercenary pistol	0		Experience: +2, Experience Percent (Mysticality): +10, Last Available: "2014-10"
 7802	ghostly Jack Frost's Fonzie's mercenary rifle	0		Experience (Moxie): +1, Cold Spell Damage: +50, Last Available: "2014-10"
 7803	green Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7698,7 +7698,7 @@
 7809	impure gasoline	0		
 7810	jittery Z-Bone steak	0		
 7811	viral DNA	0		
-7812	ghostly green tarnished bottlecap	0		
+7812	green ghostly tarnished bottlecap	0		
 7813	flavorless huge seared dino steak	3	decent	
 7814	mediocre bottle of drinkin' gas	4	decent	
 7815	handful of napalm	0		
@@ -7706,7 +7706,7 @@
 7817	gelatinous meat mass	0		
 7818	olive 99.44% pure math	0		
 7819	bouncing simple AI	0		
-7820	gray huge corrupted bird DNA	0		
+7820	huge gray corrupted bird DNA	0		
 7821	sentient meat mass	0		
 7822	spinning zombie dinosaur egg	0		
 7823	french-fry grabber	0		Familiar Weight: +5
@@ -7714,7 +7714,7 @@
 7825	blinking supercharged earbuds of wisdom of terror	0		Mysticality: +15, Maximum MP Percent: +30, Spooky Spell Damage: +10, Single Equip
 7826	flame-retardant supercool iFlail of Leguizamo	0		Moxie Percent: +20, Monster Level: +20, Hot Resistance: +1
 7827	bland big unidentifiable dried fruit	5	decent	
-7828	weak tolerable flat cider	2	good	
+7828	tolerable weak flat cider	2	good	
 7829	narrow frosty quilted arcane researcher's trench lighter	0		Experience Percent (Mysticality): +10, Damage Absorption: +40, Cold Spell Damage: +10, Last Available: "2014-10"
 7830	diffused experimental serum P-00	0		Effect: "Speed of the Internet", Effect Duration: 50, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7730,9 +7730,9 @@
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
-7844	twirling huge special clip: graveburpers	0		Last Available: "2014-10"
+7844	huge twirling special clip: graveburpers	0		Last Available: "2014-10"
 7845	aerosolized squat perl necklace	0		Effect: "Spooky Jellied", Effect Duration: 57, Last Available: "2014-12"
-7846	irradiated wobbly skewed purple Fudge Fiber Armor Plating	0		Effect: "Sharp Weapon", Effect Duration: 44, Last Available: "2014-12"
+7846	irradiated skewed purple wobbly Fudge Fiber Armor Plating	0		Effect: "Sharp Weapon", Effect Duration: 44, Last Available: "2014-12"
 7847	moist ruby on canes	0		Effect: "Standard Issue Bravery", Effect Duration: 25, Last Available: "2014-12"
 7848	adequate petit fortran	4	good	Last Available: "2014-12"
 7849	stale half-sized java cookie	2	decent	Last Available: "2014-12"
@@ -7742,7 +7742,7 @@
 7853	spinning plastic ambulatory robo-minecart of the boozehound	0		Booze Drop: +100, Last Available: "2014-12"
 7854	Usain Bolt's plastic Crimbot	0		Initiative: +80, Last Available: "2014-12"
 7855	therapeutic plastic Crimbomega	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
-7856	pressed quadruple-vacuum-sealed blurry mirror flask of mining oil	0		Effect: "Berry Elemental", Effect Duration: 38, Last Available: "2014-12"
+7856	pressed quadruple-vacuum-sealed mirror blurry flask of mining oil	0		Effect: "Berry Elemental", Effect Duration: 38, Last Available: "2014-12"
 7857	coward's radiation-resistant helmet	0		Monster Level: -20, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
 7858	teal occult servo-assisted exo-pants	0		Spell Damage Percent: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	ghostly wobbly purple asbestos-lined energetic high-energy mining laser	0		Maximum MP Percent: +20, Hot Resistance: +5, Last Available: "2014-12"
@@ -7754,7 +7754,7 @@
 7865	blurry Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	squat Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
-7868	pulsating red Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
+7868	red pulsating Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	huge Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
@@ -7804,12 +7804,12 @@
 7915	unsweetened Take Eleven Bar	0		Effect: "The Halls of Mysticality", Effect Duration: 22
 7916	upside-down mimeplasm	0		
 7917	unsweetened enhanced galvanized mirror BOOterfinger	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 16
-7918	non-energized bouncing purple Moonds	0		Effect: "Boo Tea", Effect Duration: 66
+7918	non-energized purple bouncing Moonds	0		Effect: "Boo Tea", Effect Duration: 66
 7919	altered oxidized huge Big Punk	0		Effect: "Lifted Spirits", Effect Duration: 27
 7920	spinning fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	cyan turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	hand-crafted practically non-alcoholic enchanted Friendly Turkey	1	EPIC	Effect: "Heavily Breathing", Effect Duration: 45, Last Available: "2014-11"
-7923	watered-down hand-crafted Agitated Turkey	2	EPIC	Last Available: "2014-11"
+7922	enchanted hand-crafted practically non-alcoholic Friendly Turkey	1	EPIC	Effect: "Heavily Breathing", Effect Duration: 45, Last Available: "2014-11"
+7923	hand-crafted watered-down Agitated Turkey	2	EPIC	Last Available: "2014-11"
 7924	aged Ambitious Turkey	4	awesome	Last Available: "2014-11"
 7925	stale neutron lollipop	4	decent	Last Available: "2014-12"
 7926	smooth gamma nog	3	awesome	Last Available: "2014-12"
@@ -7839,7 +7839,7 @@
 7957	even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
-7960	skewed green copy of a jerk adventurer's father's diary	0		
+7960	green skewed copy of a jerk adventurer's father's diary	0		
 7961	zippy perfumed double-paned hale Staff of Ed	0		Maximum HP: +20, Cold Resistance: +5, Stench Resistance: +5, Initiative: +20
 7962	Eye of Ed	0		
 7963	mirror amulet	0		
@@ -7853,7 +7853,7 @@
 7971	skewed Aggressive Carrot	0		Free Pull
 7972	modified shaking mummified fig	1	good	
 7973	vaporized blurry twirling mummified loaf of bread	1	crappy	
-7974	compressed spinning blinking mummified beef haunch	1	decent	
+7974	compressed blinking spinning mummified beef haunch	1	decent	
 7975	linen bandages	0		
 7976	skewed cotton bandages	0		
 7977	shaking silk bandages	0		
@@ -7878,20 +7878,20 @@
 7996	blinking phantom mask of the brute of the sweet-tooth	0		Muscle Percent: +30, Candy Drop: +100, Single Equip, Last Available: "2015-12"
 7997	boiled pulsating polyesterene powder	1		Last Available: "2015-12"
 7998	distilled powder	1		Last Available: "2015-12"
-7999	ionized polymerized huge upside-down choco-Crimbot	0		Effect: "You're Rubber", Effect Duration: 33, Last Available: "2014-12"
+7999	ionized polymerized upside-down huge choco-Crimbot	0		Effect: "You're Rubber", Effect Duration: 33, Last Available: "2014-12"
 8000	double-pickled smart watch	0		Effect: "Blubbered Up", Effect Duration: 19, Last Available: "2014-12"
 8001	warmed pressed alkaline augmented-reality shades	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 50, Last Available: "2014-12"
-8002	toy Crimbot mega face of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	smartaleck's toy Crimbot power glove	0		Moxie Percent: +30, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	toy Crimbot super fist of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of Calamity Jane	0		Critical Hit Percent: +15, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	toy Crimbot mega face of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8003	smartaleck's toy Crimbot power glove	0		Moxie Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	toy Crimbot super fist of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of Calamity Jane	0		Critical Hit Percent: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	unsweetened cold-filtered ghostly Crimbot battery	0		Effect: "You Liver", Effect Duration: 29, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	blue Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	sinister brawny Crimbomega drive chain of the boozehound	0		Muscle Percent: +20, Spell Damage: +10, Booze Drop: +100, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	sinister brawny Crimbomega drive chain of the boozehound	0		Muscle Percent: +20, Spell Damage: +10, Booze Drop: +100, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7916,11 +7916,11 @@
 8034	skewed experienced tope&eacute; of wisdom	0		Mysticality: +15, Experience: +2, Familiar Effect: "3xBarrr, cap 12"
 8035	olive resourceful razor-sharp topiary tights	0		Weapon Damage Percent: +25, Maximum MP: +50
 8036	ghostly cyan topiary necktie of chilblains	0		Cold Damage: +25
-8037	massive moldy blue bowl of topioca	10	crappy	
+8037	moldy massive blue bowl of topioca	10	crappy	
 8038	topiary skunk	0		
 8039	blurry topiary noseplugs	0		Familiar Weight: +5
 8040	tumbling trusty whip	0		
-8041	blurry mirror crumbling skull	0		
+8041	mirror blurry crumbling skull	0		
 8042	rock	0		
 8043	upside-down skewed lion tamer's pot	0		Experience (familiar): +2
 8044	bouncing beefy spelunking fedora	0		Muscle: +10
@@ -7946,7 +7946,7 @@
 8065	teal banana	0		Familiar Weight: +5
 8066	modified red	1	decent	Last Available: "2015-12"
 8067	nuggets	0		
-8068	narrow gray Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
+8068	gray narrow Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	squat Stembridge sidearm	0		Familiar Weight: +5
 8070	cyan warehouse map page	0		
 8071	wobbly teal warehouse inventory page	0		
@@ -7991,21 +7991,21 @@
 8116	fuchsia jittery hardy whisk of temperance	0		Maximum HP: +50, Sleaze Resistance: +5, Last Available: "2017-12"
 8117	pulsating fuchsia hardy savvy walker	0		Mysticality Percent: +20, Maximum HP: +50, Single Equip, Last Available: "2017-12"
 8118	censurious waders of the wise owl	0		Mysticality: +20, Sleaze Resistance: +3, Last Available: "2017-12"
-8119	pickled lime green twirling flakes	1		Last Available: "2017-12"
+8119	pickled twirling lime green flakes	1		Last Available: "2017-12"
 8120	Temple Grandin's energetic gaiters	0		Maximum MP Percent: +20, Familiar Weight: +7, Last Available: "2018-12"
 8121	dance instructor's Socratic garland	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Single Equip, Last Available: "2018-12"
 8122	upside-down cyan ghostly asbestos-lined quilted gunnysack	0		Damage Absorption: +40, Hot Resistance: +5, Last Available: "2018-12"
 8123	medical-grade garibaldi of the cougar	0		Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-12"
-8124	flame-wreathed Jack Frost's girdle	0		Cold Spell Damage: +50, Hot Spell Damage: +10, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	flame-wreathed Jack Frost's girdle	0		Cold Spell Damage: +50, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	green skewed resourceful gloves of the blizzard	0		Maximum MP: +50, Cold Spell Damage: +25, Single Equip, Last Available: "2018-12"
-8126	pickled teal blinking smithereens	1		Last Available: "2018-12"
+8126	pickled blinking teal smithereens	1		Last Available: "2018-12"
 8127	sizzling careful fiberglass fetish	0		Monster Level: -10, Hot Damage: +10, Last Available: "2018-12"
 8128	upside-down Samson's wizardly fiberglass foil	0		Mysticality: +25, Experience (Muscle): +5, Last Available: "2018-12"
 8129	gray nasty fiberglass fannypack of incineration	0		Hot Spell Damage: +50, Stench Damage: +5, Single Equip, Last Available: "2018-12"
 8130	olive MacGyver's boxer's fiberglass frock	0		Muscle Percent: +10, Maximum MP: +100, Last Available: "2018-12"
 8131	stanky fiberglass fingerguard of chilblains	0		Cold Damage: +25, Stench Spell Damage: +25, Single Equip, Last Available: "2018-12"
 8132	red avaricious perfumed fiberglass fedora	0		Stench Resistance: +5, Meat Drop: +30, Last Available: "2018-12"
-8133	powdered twirling bouncing fiberglass fibers	1		Effect: "One Foot Heavier", Effect Duration: 10, Last Available: "2018-12"
+8133	powdered bouncing twirling fiberglass fibers	1		Effect: "One Foot Heavier", Effect Duration: 10, Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	red winged yeti fur	0		
 8136	talisman of Renenutet	0		
@@ -8042,12 +8042,12 @@
 8168	glob of icing	0		
 8169	denatured activated aerosolized ginger snaps	0		Effect: "Thickest, Sickest", Effect Duration: 32
 8170	activated mostly-broken sunglasses	0		Effect: "Appeteyes", Effect Duration: 25
-8171	spirit-forward perfectly mixed unflavored wine cooler	5	EPIC	
+8171	perfectly mixed spirit-forward unflavored wine cooler	5	EPIC	
 8172	carton of snake milk	1	EPIC	
 8173	fireproof sewer snake	0		Hot Resistance: +3
 8174	stale pigeon egg	3	decent	
 8175	flame-wreathed mansplainer's jaunty feather	0		Monster Level: +15, Hot Spell Damage: +10
-8176	drinkable fancy practically non-alcoholic skewed premium malt liquor	1	good	Effect: "Joyful Resolve", Effect Duration: 25
+8176	practically non-alcoholic fancy drinkable skewed premium malt liquor	1	good	Effect: "Joyful Resolve", Effect Duration: 25
 8177	twirling chilly personal trainer's brown paper pants	0		Experience Percent (Muscle): +10, Cold Damage: +5
 8178	spinning supercharged brown paper bag mask of temperance	0		Maximum MP Percent: +30, Sleaze Resistance: +5
 8179	Samson's ring of telling skeletons what to do	0		Experience (Muscle): +5, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8061,32 +8061,32 @@
 8187	teal map to a hidden booze cache	0		
 8188	drinkable Cherrytastrophe wine cooler	3	good	
 8189	drinkable special Radberry Rip wine cooler	3	good	Effect: "Angry like the Wolf", Effect Duration: 15
-8190	high-proof tolerable Orangemageddon wine cooler	8	good	
+8190	tolerable high-proof Orangemageddon wine cooler	8	good	
 8191	acceptable upside-down Breakfast Blast wine cooler	3	good	
 8192	bad Citrus Crush wine cooler	3	decent	
-8193	toothsome jumbo cyan plain bagel	5	awesome	
+8193	jumbo toothsome cyan plain bagel	5	awesome	
 8194	spoiled glob of cream cheese	3	crappy	
 8195	diet normal spinning loaf of soda bread	1	good	
 8196	normal pulsating acceptable bagel	3	good	
 8197	bland standard-issue cupcake	4	decent	
 8198	toothsome bouncing ultra-deluxe cupcake	4	awesome	
 8199	wobbly hypnotic breadcrumbs	0		
-8200	massive decent jittery popular tart	6	good	
+8200	decent massive jittery popular tart	6	good	
 8201	no-handed pie	0		
 8202	liquefied super-oxidized Doc Galaktik's Vitality Serum	0		Effect: "Patent Prevention", Effect Duration: 24
 8203	teal airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
-8204	twirling huge one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
+8204	huge twirling one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	FunFunds&trade;	0		Last Available: "2015-04"
 8206	greedy expensive camera of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +20, Single Equip, Last Available: "2015-04"
 8207	sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	energized double-tarnished blurry skewed How to Avoid Scams	0		Effect: "Cat-Alyzed", Effect Duration: 36, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
-8211	narrow mirror bag of park garbage	0		Last Available: "2015-04"
+8211	mirror narrow bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	knitted wicked rigging rope	0		Spell Damage: +5, Cold Resistance: +3, Last Available: "2015-04"
 8214	powdered ghostly nasty snuff	1	crappy	Last Available: "2015-04"
-8215	twirling Jeselnik's Herculean sewage-clogged pistol	0		Experience (Muscle): +1, Sleaze Damage: +25, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	twirling Jeselnik's Herculean sewage-clogged pistol	0		Experience (Muscle): +1, Sleaze Damage: +25, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	boiled polarized beard incense	0		Effect: "Weepy, Creepy", Effect Duration: 28, Last Available: "2015-04"
 8217	pulsating hale boxer's perfume-soaked bandana	0		Muscle Percent: +10, Maximum HP: +20, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
@@ -8118,8 +8118,8 @@
 8244	chilly lube-shoes	0		Cold Damage: +5, Last Available: "2015-04"
 8245	spinning trash net	0		Last Available: "2015-04"
 8246	pulsating olive crafty beefy Dinsey mascot mask of bravery	0		Muscle: +10, Maximum MP: +10, Spooky Resistance: +5, Last Available: "2015-04"
-8247	snack-sized adequate squat blurry Dinsey food-cone	2	good	Last Available: "2015-04"
-8248	triple-distilled bad lime green Dinsey Whinskey	7	decent	Last Available: "2015-04"
+8247	adequate snack-sized squat blurry Dinsey food-cone	2	good	Last Available: "2015-04"
+8248	bad triple-distilled lime green Dinsey Whinskey	7	decent	Last Available: "2015-04"
 8249	activated unsweetened deionized skewed Dinsey face paint	0		Effect: "Cotton Mouthed", Effect Duration: 15, Last Available: "2015-04"
 8250	wizardly fannypack of Leguizamo	0		Mysticality: +25, Monster Level: +20, Last Available: "2015-04"
 8251	smelly scorching Jim Carey's experienced thinker's garbage sticker of wisdom	0		Mysticality: 25, Experience: +2, Monster Level: +25, Hot Damage: +25, Stench Spell Damage: +10, Last Available: "2015-04"
@@ -8149,7 +8149,7 @@
 8275	wobbly newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	tolerable fancy upside-down Afternoon Delight	4	good	Effect: "Human-Machine Hybrid", Effect Duration: 30, Last Available: "2015-04"
+8278	fancy tolerable upside-down Afternoon Delight	4	good	Effect: "Human-Machine Hybrid", Effect Duration: 30, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	cold-filtered irradiated magnetized tumbling Kokomo Resort Brand Suntan Oil	0		Effect: "Scarysauce", Effect Duration: 48, Last Available: "2015-04"
@@ -8193,7 +8193,7 @@
 8319	irradiated jazzy cigarette holder	0		Effect: "Sagittarius Rising", Effect Duration: 37
 8320	dry one glove	0		Effect: "Bananas!", Effect Duration: 24
 8321	magnetized super-diffused glove	0		Effect: "Sweet Incentive", Effect Duration: 65
-8322	denatured spinning squat handful of fire	0		Effect: "Healthy Green Glow", Effect Duration: 17
+8322	denatured squat spinning handful of fire	0		Effect: "Healthy Green Glow", Effect Duration: 17
 8323	triple-magnetized squat Cracklin' Oat Bran	0		Effect: "Strong Spirit", Effect Duration: 62
 8324	vacuum-sealed galvanized blue disposable lighter	0		Effect: "Tremella Tremens", Effect Duration: 63
 8325	aerosolized moist coal contact lenses	0		Effect: "Frog In Your Throat", Effect Duration: 24
@@ -8204,7 +8204,7 @@
 8330	colloidal magnetized huge assassin's cheese knife	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 29
 8331	energized super-electrified adjusted filthy armor	0		Effect: "Reedy Pipes", Effect Duration: 26
 8332	unsweetened plague pie	0		Effect: "Locks Like the Raven", Effect Duration: 19
-8333	tarnished anodized yellow mirror bouncing batarang	0		Effect: "Preemptive Medicine", Effect Duration: 64
+8333	tarnished anodized bouncing yellow mirror batarang	0		Effect: "Preemptive Medicine", Effect Duration: 64
 8334	altered extra-frozen huge spare neck bolts	0		Effect: "Sweet Tooth", Effect Duration: 22
 8335	moist frozen grease trap	0		Effect: "Yuletide Mutations", Effect Duration: 25
 8336	electrified quadruple-vacuum-sealed squat shamanic ham	0		Effect: "Human-Orc Hybrid", Effect Duration: 21
@@ -8216,12 +8216,12 @@
 8342	warmed diffused ghostly baloney rotgut	0		Effect: "Tiki Toughness", Effect Duration: 38
 8343	flattened improved carton of gaspers	0		Effect: "Bastard!", Effect Duration: 45
 8344	cold-filtered magnetized blurry bronze polish	0		Effect: "Kissed By Fire", Effect Duration: 35
-8345	altered magnetized tumbling skewed crident	0		Effect: "Square to be Hip", Effect Duration: 21
+8345	altered magnetized skewed tumbling crident	0		Effect: "Square to be Hip", Effect Duration: 21
 8346	corrupted warmed totally sweet mohawk helmet	0		Effect: "Thaumodynamic", Effect Duration: 23
 8347	triple-denatured alkaline jittery spray chrome	0		Effect: "Hiding in Plain Sight", Effect Duration: 32
 8348	dry squat filthy monkey head	0		Effect: "Well Owl Be!", Effect Duration: 14
 8349	anodized super-boiled wobbly hand of cards	0		Effect: "One Foot Heavier", Effect Duration: 23
-8350	chilled oxidized blurry shaking damp bar rag	0		Effect: "Prideful Strut", Effect Duration: 52
+8350	chilled oxidized shaking blurry damp bar rag	0		Effect: "Prideful Strut", Effect Duration: 52
 8351	aerosolized chilled lump of goofball ore	0		Effect: "Booing Radly", Effect Duration: 37
 8352	concentrated skeleton beans	0		Effect: "Hyphemariffic", Effect Duration: 50
 8353	dry frozen red grimy lab coat	0		Effect: "Sweet, Nuts", Effect Duration: 66
@@ -8234,7 +8234,7 @@
 8360	concentrated hawkface potion	0		Effect: "Space Cadet", Effect Duration: 25
 8361	improved dry narrow child-sized dracula cloak	0		Effect: "Wings of the Grasshopper", Effect Duration: 17
 8362	dry magnetized concentrated wobbly devil-summoning hat	0		Effect: "Fan-Cooled", Effect Duration: 21
-8363	diffused pressed pulsating fuchsia shopkeeper beard	0		Effect: "Stuck-Up Hair", Effect Duration: 68
+8363	diffused pressed fuchsia pulsating shopkeeper beard	0		Effect: "Stuck-Up Hair", Effect Duration: 68
 8364	ionized improved alien autoautopsy kit	0		Effect: "Aided and Abetted", Effect Duration: 19
 8365	liquefied polymerized novelty fruit hat	0		Effect: "Hypercubed", Effect Duration: 54
 8366	wet ghostly twirling invisibility cream	0		Effect: "Nuts about Candy", Effect Duration: 66
@@ -8275,22 +8275,22 @@
 8401	mirror candlestick of Gandalf of mayonnaise	0		Spell Critical Percent: +20, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2015-07"
 8402	huge knife of the brazier of temperance	0		Hot Spell Damage: +25, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2015-07"
 8403	huge toasty Temple Grandin's revolver	0		Familiar Weight: +7, Hot Damage: +5, Lasts Until Rollover, Last Available: "2015-07"
-8404	bouncing blue 1952 Mickey Mantle card	0		Last Available: "2015-07"
+8404	blue bouncing 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
 8407	rotten immense pestopiary	6	crappy	
 8408	modified nitrogenated ectoplasmic orbs	0		Effect: "Healthy Red Glow", Effect Duration: 64
-8409	small spoiled crudles	2	crappy	
+8409	spoiled small crudles	2	crappy	
 8410	rotten pulsating agnolotti arboli	3	crappy	
 8411	normal blinking spaghetti with ghost balls	3	good	
 8412	huge spoiled succulent marrow	9	crappy	
 8413	adequate salacious crumbs	4	good	
-8414	diet moldy fusilli marrownarrow	1	crappy	
+8414	moldy diet fusilli marrownarrow	1	crappy	
 8415	yummy small suggestive strozzapreti	2	awesome	
 8416	Mountain Stream gastrique	0		
 8417	stale half-sized jittery Mt. McLargeHuge oyster	2	decent	
 8418	oyster sauce	0		
-8419	rotten huge ghostly linguini immondizia bianco	7	crappy	
+8419	huge rotten ghostly linguini immondizia bianco	7	crappy	
 8420	moldy shells a la shellfish	4	crappy	
 8421	ghostly Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8335,20 +8335,20 @@
 8461	tolerable jittery Gold Velvet&trade; whiskey	4	good	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	decent super-sized blurry smelted roe	5	good	Last Available: "2015-08"
-8464	hand-crafted special lavawater	3	EPIC	Effect: "Insatiable Hunger", Effect Duration: 45, Last Available: "2015-08"
+8464	special hand-crafted lavawater	3	EPIC	Effect: "Insatiable Hunger", Effect Duration: 45, Last Available: "2015-08"
 8465	liquefied energized basaltamander tongue	0		Effect: "Oh Snap", Effect Duration: 23, Last Available: "2015-08"
 8466	crafty lavalarva of chilblains of the cheetah	0		Maximum MP: +10, Cold Damage: +25, Initiative: +60, Last Available: "2015-08"
 8467	skewed baleful dangerous Socratic lava balaclava	0		Experience (Mysticality): +1, Weapon Damage: +10, Spell Damage: +25, Last Available: "2015-08"
 8468	maroon wicked experienced basaltamander buckler of the businessman	0		Experience: +2, Spell Damage: +5, Meat Drop: +50, Damage Reduction: 15, Last Available: "2015-08"
 8469	warmed oxidized lava globs	0		Effect: "Jingle Jangle Jingle", Effect Duration: 53, Last Available: "2015-08"
-8470	immense rotten tumbling gooey lava globs	10	crappy	Last Available: "2015-08"
+8470	rotten immense tumbling gooey lava globs	10	crappy	Last Available: "2015-08"
 8471	maroon gravedigger's lava-proof pants of mayonnaise	0		Spooky Damage: +10, Sleaze Spell Damage: +50, Last Available: "2015-08"
 8472	forbidden smartaleck's heat-resistant necktie	0		Moxie Percent: +30, Spell Damage Percent: +50, Single Equip, Last Available: "2015-08"
 8473	red prompt vibrating savvy heat-resistant gloves	0		Mysticality Percent: +20, Maximum MP Percent: +10, Adventures: +3, Single Equip, Last Available: "2015-08"
-8474	tiny yummy very hot lunch	1	awesome	Last Available: "2015-08"
+8474	yummy tiny very hot lunch	1	awesome	Last Available: "2015-08"
 8475	smooth asbestos thermos	3	awesome	Last Available: "2015-08"
 8476	wet tarnished liquid rhinestones	0		Effect: "Memory of Smarts", Effect Duration: 12, Last Available: "2015-08"
-8477	immense adequate disco biscuit	10	good	Last Available: "2015-08"
+8477	adequate immense disco biscuit	10	good	Last Available: "2015-08"
 8478	perfectly mixed Quaatorade&trade;	3	EPIC	Last Available: "2015-08"
 8479	jittery blinking Usain Bolt's wholesome occult biker's hat	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Initiative: +80, Familiar Effect: "atk", Last Available: "2015-08"
 8480	Samson's smartaleck's feathered headdress of the wise owl	0		Mysticality: +20, Moxie Percent: +30, Experience (Muscle): +5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
@@ -8360,7 +8360,7 @@
 8486	one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	shaking Manual of Numberology	0		Skill: "Calculate the Universe"
-8489	fuchsia bouncing New Age hurting crystal	0		Last Available: "2015-08"
+8489	bouncing fuchsia New Age hurting crystal	0		Last Available: "2015-08"
 8490	deadly smooth velvet pants	0		Weapon Damage: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	green twirling scorching smooth velvet shirt	0		Hot Damage: +25, Last Available: "2015-08"
 8492	smooth velvet hat of the businessman	0		Meat Drop: +50, Last Available: "2015-08"
@@ -8378,7 +8378,7 @@
 8504	skewed Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
-8507	distilled skewed wobbly SMOOCH coffee cup	1	good	Last Available: "2015-08"
+8507	distilled wobbly skewed SMOOCH coffee cup	1	good	Last Available: "2015-08"
 8508	aerosolized labrador cookie	0		Effect: "Springy Fusilli", Effect Duration: 34, Last Available: "2015-08"
 8509	scorching fortified Mr. Cheeng's spectacles of the boozehound	0		Damage Absorption: +60, Hot Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2015-08"
 8510	asbestos-lined grease cannon of the ox	0		Muscle: +20, Hot Resistance: +5, Last Available: "2015-08"
@@ -8397,10 +8397,10 @@
 8523	wobbly fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	adequate lava cake	4	good	Last Available: "2015-08"
-8526	spoiled massive fuchsia skewed pink slime	7	crappy	
+8526	massive spoiled fuchsia skewed pink slime	7	crappy	
 8527	maroon Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	flavorless low-calorie pulsating devil hair pasta	1	decent	
+8529	low-calorie flavorless pulsating devil hair pasta	1	decent	
 8530	tasty spagecialetti	4	awesome	
 8531	Salsa Libre	0		
 8532	good gravy	0		
@@ -8420,10 +8420,10 @@
 8547	dry polymerized upside-down pocket maze	0		Effect: "Rain Dancin'", Effect Duration: 69
 8548	corrupted alkaline shady shades	0		Effect: "Improprie Tea", Effect Duration: 37
 8549	non-polarized energized squeaky toy rose	0		Effect: "Carol of the Bones", Effect Duration: 14
-8550	decent diet red weird gazelle steak	1	good	
+8550	diet decent red weird gazelle steak	1	good	
 8551	bland snack-sized sausage without a cause	2	decent	
 8552	dry face paint	0		Effect: "Voracious Gorging", Effect Duration: 45
-8553	tolerable fancy huge skewed emergency margarita	3	good	Effect: "Ack!  Barred!", Effect Duration: 5
+8553	fancy tolerable skewed huge emergency margarita	3	good	Effect: "Ack!  Barred!", Effect Duration: 5
 8554	smooth distilled vintage smart drink	5	awesome	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8442,8 +8442,8 @@
 8569	normal barrel	0		Last Available: "2015-09"
 8570	narrow tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
-8572	blinking wobbly barrel	0		Last Available: "2015-09"
-8573	tumbling fuchsia barrel	0		Last Available: "2015-09"
+8572	wobbly blinking barrel	0		Last Available: "2015-09"
+8573	fuchsia tumbling barrel	0		Last Available: "2015-09"
 8574	moist barrel	0		Last Available: "2015-09"
 8575	twirling rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
@@ -8451,15 +8451,15 @@
 8578	lousy bottle of Amontillado	3	decent	Last Available: "2015-09"
 8579	drinkable barrel-aged martini	4	good	Last Available: "2015-09"
 8580	decent skewed barrel pickle	3	good	Last Available: "2015-09"
-8581	tasty half-sized blurry barrel cracker	2	awesome	Last Available: "2015-09"
+8581	half-sized tasty blurry barrel cracker	2	awesome	Last Available: "2015-09"
 8582	dehydrated jittery vibrating mushroom	1	good	Last Available: "2015-09"
-8583	compressed blinking squat red upside-down mushroom	1	good	Last Available: "2015-09"
+8583	compressed red blinking upside-down squat mushroom	1	good	Last Available: "2015-09"
 8584	Oprah's KoL Con 12-gauge	0		Maximum MP Percent: +50, Last Available: "2015-09"
 8585	Golden Mr. Eh? of Tarzan	0		Experience (Muscle): +3, Last Available: "2015-09"
 8586	blinking teal inspector's barrel gun	0		Item Drop: +15, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
-8588	squat ghostly barrel beryl	0		Last Available: "2015-09"
-8589	stale diet water log	1	decent	Last Available: "2015-09"
+8588	ghostly squat barrel beryl	0		Last Available: "2015-09"
+8589	diet stale water log	1	decent	Last Available: "2015-09"
 8590	jittery narrow healthy barrelhead	0		Maximum HP Percent: +20, Item Drop: +5, Last Available: "2015-09"
 8591	maroon mansplainer's Tesla bottoms of the barrel	0		Monster Level: +15, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-09"
 8592	maroon forbidden chest barrel of the early riser	0		Spell Damage Percent: +50, Adventures: +7, Last Available: "2015-09"
@@ -8514,9 +8514,9 @@
 8641	flavorless olive bowl of eyeballs	3	decent	Last Available: "2015-10"
 8642	rotten bowl of mummy guts	4	crappy	Last Available: "2015-10"
 8643	spoiled bowl of maggots	4	crappy	Last Available: "2015-10"
-8644	bad watered-down blood and blood	2	decent	Last Available: "2015-10"
+8644	watered-down bad blood and blood	2	decent	Last Available: "2015-10"
 8645	hand-crafted Jack-O-Lantern beer	4	EPIC	Last Available: "2015-10"
-8646	perfectly mixed spirit-forward blinking zombie	5	EPIC	Last Available: "2015-10"
+8646	spirit-forward perfectly mixed blinking zombie	5	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
@@ -8543,7 +8543,7 @@
 8670	maroon tulip	0		
 8671	bouncing tulip	0		
 8672	ghostly Walford's bucket	0		Last Available: "2015-11"
-8673	skewed spinning Wal-Mart gift certificate	0		Last Available: "2015-11"
+8673	spinning skewed Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	activated shoulder-warming lotion	0		Effect: "Irresistible Resolve", Effect Duration: 17, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	brawny bellhop's hat	0		Muscle Percent: +20, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	acceptable triple-distilled ice porter	7	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	triple-distilled acceptable ice porter	7	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	extra-wet aerosolized triple-flattened huge exotic travel brochure	0		Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	flattened dry squat shampoo-conditioner	0		Effect: "Cat Class, Cat Style", Effect Duration: 68, Last Available: "2015-11"
@@ -8580,17 +8580,17 @@
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	modified skewed abstraction: action	1		Last Available: "2015-12"
 8709	twisted abstraction: thought	1		Effect: "Robocamo", Effect Duration: 20, Last Available: "2015-12"
-8710	mixed pulsating pulsating blurry abstraction: sensation	1		Last Available: "2015-12"
+8710	mixed pulsating blurry pulsating abstraction: sensation	1		Last Available: "2015-12"
 8711	modified abstraction: purpose	1		Effect: "Turkey-Agitated", Effect Duration: 30, Last Available: "2015-12"
 8712	boiled abstraction: category	1		Effect: "Mad at Science", Effect Duration: 10, Last Available: "2015-12"
 8713	pickled shaking abstraction: perception	1		Effect: "Sharp Weapon", Effect Duration: 10, Last Available: "2015-12"
 8714	twisted blinking abstraction: motion	1		Effect: "Hella Smooth", Effect Duration: 45, Last Available: "2015-12"
-8715	modified cyan blurry skewed abstraction: joy	1		Effect: "Mana Tea", Effect Duration: 5, Last Available: "2015-12"
+8715	modified skewed cyan blurry abstraction: joy	1		Effect: "Mana Tea", Effect Duration: 5, Last Available: "2015-12"
 8716	altered fuchsia abstraction: certainty	1		Last Available: "2015-12"
 8717	pickled abstraction: comprehension	1		Last Available: "2015-12"
 8718	pulsating modern picture frame	0		Last Available: "2015-12"
 8719	decent VYKEA meatballs	4	good	Last Available: "2015-11"
-8720	fancy drinkable practically non-alcoholic VYKEA mead	1	good	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2015-11"
+8720	drinkable fancy practically non-alcoholic VYKEA mead	1	good	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2015-11"
 8721	colloidal nitrogenated skewed VYKEA woadpaint	0		Effect: "Lemon Enlightenment", Effect Duration: 44, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,18 +8601,18 @@
 8728	twirling narrow VYKEA dowel	0		Last Available: "2015-11"
 8729	wobbly forbidden dance instructor's VYKEA hex key of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Spell Damage Percent: +50, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	tasty tin of submardines	3	awesome	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	practically non-alcoholic lousy cyan bottle of norwhiskey	1	decent	Last Available: "2015-11"
+8731	tasty tin of submardines	3	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	lousy practically non-alcoholic cyan bottle of norwhiskey	1	decent	Last Available: "2015-11"
 8733	denatured octolus oculus	1	decent	Last Available: "2015-11"
 8734	ghostly up-at-dawn lard-coated extremely unsafe sardine can key	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Adventures: +5, Last Available: "2015-11"
 8735	mirror family-friendly experienced norwhal helmet of vim and vigor	0		Experience: +2, Maximum HP Percent: +50, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2015-11"
 8736	knitted razor-sharp octolus-skin cloak of the overflowing toilet	0		Weapon Damage Percent: +25, Stench Spell Damage: +50, Cold Resistance: +3, Last Available: "2015-11"
 8737	bad perfect cosmopolitan	3	decent	Last Available: "2015-11"
-8738	watered-down perfectly mixed perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
+8738	perfectly mixed watered-down perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
 8739	tolerable wobbly perfect dark and stormy	4	good	Last Available: "2015-11"
-8740	watered-down drinkable perfect mimosa	2	good	Last Available: "2015-11"
+8740	drinkable watered-down perfect mimosa	2	good	Last Available: "2015-11"
 8741	aged perfect old-fashioned	4	awesome	Last Available: "2015-11"
-8742	watered-down drinkable perfect paloma	2	good	Last Available: "2015-11"
+8742	drinkable watered-down perfect paloma	2	good	Last Available: "2015-11"
 8743	warmed olive tumbling That 70s Cologne	0		Effect: "Chock Full o' Nanites", Effect Duration: 40, Last Available: "2015-11"
 8744	dry double-cold-filtered Wal-Mart &quot;diamond&quot; ring	0		Effect: "Rotten Memories", Effect Duration: 19, Last Available: "2015-11"
 8745	warmed double-galvanized skewed Puffstone cigar	0		Effect: "Tapped In", Effect Duration: 24, Last Available: "2015-11"
@@ -8647,7 +8647,7 @@
 8775	horrifying coarse hemp socks	0		Spooky Damage: +25, Single Equip, Last Available: "2015-12"
 8776	armband of the ox	0		Muscle: +20, Single Equip, Last Available: "2015-12"
 8777	spinning bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
-8778	twirling tumbling upside-down nuclear stockpile	0		Last Available: "2015-12"
+8778	tumbling upside-down twirling nuclear stockpile	0		Last Available: "2015-12"
 8779	olive pine cone	0		Last Available: "2015-12"
 8780	skewed maroon iron chain	0		Last Available: "2015-12"
 8781	lime green sinister pine cone necklace	0		Spell Damage: +10, Last Available: "2015-12"
@@ -8668,7 +8668,7 @@
 8796	plastic spoiler	0		
 8797	cyan bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
-8799	lime green twirling bat-o-mite	0		Last Available: "2017-01"
+8799	twirling lime green bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
@@ -8692,19 +8692,19 @@
 8820	compressed mirror The Author's ink	1		Effect: "All Branned Up", Effect Duration: 5, Last Available: "2016-02"
 8821	drinkable The Mad Liquor	4	good	Last Available: "2016-12"
 8822	artisanal Doc Clock's thyme cocktail	4	super EPIC	Last Available: "2016-12"
-8823	adequate diet Mr. Burnsger	1	good	Last Available: "2016-12"
+8823	diet adequate Mr. Burnsger	1	good	Last Available: "2016-12"
 8824	twisted red The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	nasty educational The Jokester's gun of Flo-Jo	0		Experience: +1, Stench Damage: +5, Initiative: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	rosewater-soaked frightening brainy The Jokester's wig	0		Mysticality: +5, Spooky Damage: +5, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	quilted The Jokester's pants of the pedagogue of bravery	0		Experience: +3, Damage Absorption: +40, Spooky Resistance: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	nasty educational The Jokester's gun of Flo-Jo	0		Experience: +1, Stench Damage: +5, Initiative: +100, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	rosewater-soaked frightening brainy The Jokester's wig	0		Mysticality: +5, Spooky Damage: +5, Stench Resistance: +3, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8827	quilted The Jokester's pants of the pedagogue of bravery	0		Experience: +3, Damage Absorption: +40, Spooky Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	chilled super-modified Jokester makeup	0		Effect: "Sweet, Nuts", Effect Duration: 39, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	shaking battoo kit	0		Last Available: "2016-12"
-8831	tumbling narrow basking robin	0		Free Pull, Last Available: "2016-12"
+8831	narrow tumbling basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	extra-wet quadruple-activated liquefied bouncing robin's egg	0		Effect: "Can Has Cyborger", Effect Duration: 29, Last Available: "2016-12"
-8834	normal miniature robin flan	2	good	Last Available: "2016-12"
-8835	perfectly mixed shaking fuchsia robin nog	3	EPIC	Last Available: "2016-12"
+8834	miniature normal robin flan	2	good	Last Available: "2016-12"
+8835	perfectly mixed fuchsia shaking robin nog	3	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	huge purple plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8718,8 +8718,8 @@
 8846	dry tube of pendulum lube	0		Effect: "Coy to the Hurled", Effect Duration: 69
 8847	double-aerosolized energized pickled red-hot jawbreaker	0		Effect: "Grape Expectations", Effect Duration: 37
 8848	denatured wobbly question juice	0		Effect: "Knightlife", Effect Duration: 20
-8849	super-nitrogenated dry adjusted mirror wobbly olive tube of villain	0		Effect: "Virgo Rising", Effect Duration: 41
-8850	banded your cowboy boots	0		Damage Absorption: +100, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8849	super-nitrogenated dry adjusted olive wobbly mirror tube of villain	0		Effect: "Virgo Rising", Effect Duration: 41
+8850	banded your cowboy boots	0		Damage Absorption: +100, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	skewed bouncing inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	fuchsia nugget of quicksilver	0		Last Available: "2016-02"
 8853	blinking nugget of thicksilver	0		Last Available: "2016-02"
@@ -8749,10 +8749,10 @@
 8877	bland super-sized huge plate of Tesla's Electroplated Beans	5	decent	Last Available: "2016-02"
 8878	adequate huge plate of Mixed Garbanzos and Chickpeas	3	good	Last Available: "2016-02"
 8879	normal plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
-8880	gigantic bland plate of Frigid Northern Beans	8	decent	Last Available: "2016-02"
+8880	bland gigantic plate of Frigid Northern Beans	8	decent	Last Available: "2016-02"
 8881	flavorless bite-sized enchanted bouncing plate of World's Blackest-Eyed Peas	1	decent	Effect: "Singer's Faithful Ocelot", Effect Duration: 10, Last Available: "2016-02"
 8882	adequate plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
-8883	diet decent bouncing plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	good	Last Available: "2016-02"
+8883	decent diet bouncing plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	good	Last Available: "2016-02"
 8884	toothsome plate of Val-U Brand Every Bean Salad	4	awesome	Last Available: "2016-02"
 8885	adequate bouncing plate of Shrub's Premium Baked Beans	4	good	Last Available: "2016-02"
 8886	olive blurry energetic studded Fancy Jeff's pocket square	0		Damage Absorption: +80, Maximum MP Percent: +20, Last Available: "2016-02"
@@ -8779,7 +8779,7 @@
 8907	magnetized pulsating half-digested coal	0		Effect: "Staying Frosty", Effect Duration: 19, Last Available: "2016-02"
 8908	ionized ghostly tightly-wound spine	0		Effect: "Trufflin'", Effect Duration: 55, Last Available: "2016-02"
 8909	spoiled pulsating rotting beefsteak	3	crappy	Last Available: "2016-02"
-8910	artisanal fancy triple-distilled firemilk	6	EPIC	Effect: "Thought", Effect Duration: 15, Last Available: "2016-02"
+8910	fancy triple-distilled artisanal firemilk	6	EPIC	Effect: "Thought", Effect Duration: 15, Last Available: "2016-02"
 8911	non-alkaline blurry spidercow eye-cluster	0		Effect: "Hyperoffended", Effect Duration: 65, Last Available: "2016-02"
 8912	modified huge moomy dust	1		Last Available: "2016-02"
 8913	cyan western-style skinning knife of the overflowing toilet	0		Stench Spell Damage: +50, Item Drop: +5, Last Available: "2016-02"
@@ -8788,7 +8788,7 @@
 8916	Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
 8918	The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
-8919	blurry mirror LT&T tattoo kit	0		Last Available: "2016-02"
+8919	mirror blurry LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	spinning pulsating Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
@@ -8801,7 +8801,7 @@
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	dry twirling demonic cow's blood	0		Effect: "Sappy Blood", Effect Duration: 65, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
-8932	green wobbly makeshift sixgun	0		Last Available: "2016-02"
+8932	wobbly green makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	blurry porquoise-handled sixgun	0		Last Available: "2016-02"
@@ -8812,7 +8812,7 @@
 8940	coal snakeskin	0		Last Available: "2016-02"
 8941	jittery frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
-8943	skewed wobbly shuddering cow skull	0		Last Available: "2016-02"
+8943	wobbly skewed shuddering cow skull	0		Last Available: "2016-02"
 8944	spinning rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
@@ -8852,7 +8852,7 @@
 8980	flattened improved wobbly patent avarice tonic	0		Effect: "The Sweats", Effect Duration: 42
 8981	electrified triple-vacuum-sealed patent alacrity tonic	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 63
 8982	altered corrupted marrow	0		Effect: "Burning Tongue", Effect Duration: 65
-8983	tolerable cyan skewed rodeo whiskey	4	good	
+8983	tolerable skewed cyan rodeo whiskey	4	good	
 8984	Thwaitgold scorpion statuette	0		
 8985	shaking lime green greedy real cowboy hat	0		Meat Drop: +20
 8986	Memories of Cow Punching	0		Free Pull
@@ -8886,7 +8886,7 @@
 9014	pulsating luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	twirling disconnected intergnat	0		Free Pull, Last Available: "2016-05"
-9017	twirling bouncing viral video	0		Last Available: "2016-05"
+9017	bouncing twirling viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
@@ -8904,7 +8904,7 @@
 9032	fancy decent narrow bowl of Tastee-Wheet&trade;	3	good	Effect: "Hyphemariffic", Effect Duration: 35
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	pulsating blue Source essence	0		Last Available: "2016-06"
-9035	bland miniature cyan browser cookie	2	decent	Last Available: "2016-06"
+9035	miniature bland cyan browser cookie	2	decent	Last Available: "2016-06"
 9036	aged hacked gibson	4	awesome	Last Available: "2016-06"
 9037	resourceful Source shades	0		Maximum MP: +50, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	improved twirling shoe gum	0		Effect: "Natural 20", Effect Duration: 19, Last Available: "2016-07"
 9076	mirror Sherlock's auspicious scandalous noir fedora	0		Sleaze Damage: +5, Item Drop: 35, Last Available: "2016-07"
 9077	bouncing rock-hard fortified trench coat of horror	0		Damage Absorption: +60, Damage Reduction: 5, Spooky Spell Damage: +25, Last Available: "2016-07"
-9078	practically non-alcoholic lousy Falcon&trade; Maltese Liquor	1	decent	Last Available: "2016-07"
-9079	flavorless small teal hardboiled egg	2	decent	Last Available: "2016-07"
+9078	lousy practically non-alcoholic Falcon&trade; Maltese Liquor	1	decent	Last Available: "2016-07"
+9079	small flavorless teal hardboiled egg	2	decent	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	narrow blue scorching Tesla electrified energetic hale protonic accelerator pack of the overflowing toilet	0		Maximum HP: +20, Maximum MP Percent: +20, Hot Damage: +25, Stench Spell Damage: +50, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	narrow blue scorching Tesla electrified energetic hale protonic accelerator pack of the overflowing toilet	0		Maximum HP: +20, Maximum MP Percent: +20, Hot Damage: +25, Stench Spell Damage: +50, MP Regen Min: 10, MP Regen Max: 15, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	huge auspicious Adventurer bobblehead	0		Item Drop: +10, Last Available: "2016-11"
 9085	red psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	bouncing up-at-dawn double-paned personal trainer's Spookyraven signet	0		Experience Percent (Muscle): +10, Cold Resistance: +5, Adventures: +5, Single Equip, Last Available: "2016-08"
 9093	bouncing hardy baleful tie-dyed fannypack	0		Spell Damage: +25, Maximum HP: +50, Single Equip, Last Available: "2016-08"
 9094	stanky nasty burnt snowpants	0		Stench Damage: +5, Stench Spell Damage: +25, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	Oprah's standards and practices guide	0		Maximum MP Percent: +50, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	Oprah's standards and practices guide	0		Maximum MP Percent: +50, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	pulsating Annie Oakley's wicked Carpathian longsword of terror	0		Spell Damage: +5, Critical Hit Percent: +20, Spooky Spell Damage: +10, Last Available: "2016-08"
 9097	aromatic wool wicked Liam's mail	0		Spell Damage: +5, Cold Resistance: +1, Stench Resistance: +1, Last Available: "2016-08"
 9098	knitted smelly razor-sharp Unfortunato's foolscap	0		Weapon Damage Percent: +25, Stench Spell Damage: +10, Cold Resistance: +3, Last Available: "2016-08"
@@ -8995,21 +8995,21 @@
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	distilled mediocre jittery skewed unidentified drink	5	decent	
+9126	distilled mediocre skewed jittery unidentified drink	5	decent	
 9127	jittery fireproof KoL Con 13 T-shirt of the empath	0		Familiar Weight: +5, Hot Resistance: +3
 9128	friendly discarded swimming trunks of the brute of the boozehound	0		Muscle Percent: +30, Familiar Weight: +3, Booze Drop: +100
 9129	dry diluted makeup	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 53
-9130	triple-polymerized twirling blurry charisma potion	0		Effect: "Drenched With Filth", Effect Duration: 59
+9130	triple-polymerized blurry twirling charisma potion	0		Effect: "Drenched With Filth", Effect Duration: 59
 9131	fuchsia extremely confusing manual	0		
 9132	asbestos-lined arcane researcher's pistol	0		Experience Percent (Mysticality): +10, Hot Resistance: +5
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	delicious immense leftover pasty	8	awesome	
+9134	immense delicious leftover pasty	8	awesome	
 9135	perfectly mixed squat very whiskey	4	EPIC	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	pulsating green li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	green pulsating li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9141	blinking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
@@ -9024,13 +9024,13 @@
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	stale raw sweet potato	4	decent	Last Available: "2016-11"
 9154	rotten raw beans	4	crappy	Last Available: "2016-11"
-9155	gigantic flavorless raw stuffing	8	decent	Last Available: "2016-11"
-9156	adequate enchanted super-sized raw cranberry sauce	5	good	Effect: "Virgo Rising", Effect Duration: 20, Last Available: "2016-11"
+9155	flavorless gigantic raw stuffing	8	decent	Last Available: "2016-11"
+9156	enchanted super-sized adequate raw cranberry sauce	5	good	Effect: "Virgo Rising", Effect Duration: 20, Last Available: "2016-11"
 9157	adequate shaking raw turkey	3	good	Last Available: "2016-11"
 9158	spoiled tumbling raw mincemeat	3	crappy	Last Available: "2016-11"
-9159	small bland purple raw potato	2	decent	Last Available: "2016-11"
+9159	bland small purple raw potato	2	decent	Last Available: "2016-11"
 9160	rotten huge raw gravy	7	crappy	Last Available: "2016-11"
-9161	bland miniature raw bread	2	decent	Last Available: "2016-11"
+9161	miniature bland raw bread	2	decent	Last Available: "2016-11"
 9162	lard-coated thinker's mini-marshmallow dispenser	0		Mysticality: +10, Sleaze Spell Damage: +25, Last Available: "2016-11"
 9163	ribald energetic personal trainer's glass casserole dish	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Sleaze Damage: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9044,13 +9044,13 @@
 9172	bland upside-down bean casserole	3	decent	Last Available: "2016-11"
 9173	normal upside-down baked stuffing	3	good	Last Available: "2016-11"
 9174	rotten cranberry cylinder	3	crappy	Last Available: "2016-11"
-9175	normal enchanted miniature jittery gray thanksgiving turkey	2	good	Effect: "Phairly Pheromonal", Effect Duration: 45, Last Available: "2016-11"
-9176	normal snack-sized mince pie	2	good	Last Available: "2016-11"
+9175	miniature normal enchanted jittery gray thanksgiving turkey	2	good	Effect: "Phairly Pheromonal", Effect Duration: 45, Last Available: "2016-11"
+9176	snack-sized normal mince pie	2	good	Last Available: "2016-11"
 9177	yummy tumbling mashed potatoes	3	awesome	Last Available: "2016-11"
 9178	bland tumbling warm gravy	4	decent	Last Available: "2016-11"
 9179	fancy snack-sized rotten shaking pulsating bread roll	2	crappy	Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2016-11"
-9180	massive spoiled narrow cyan leftovers	9	crappy	Last Available: "2016-11"
-9181	big spoiled leftovers sandwich	5	crappy	Last Available: "2016-11"
+9180	massive spoiled cyan narrow leftovers	9	crappy	Last Available: "2016-11"
+9181	spoiled big leftovers sandwich	5	crappy	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
@@ -9089,7 +9089,7 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	rotten animal part cracker	4	crappy	Last Available: "2016-12"
-9220	tolerable spirit-forward gingerbread wine	5	good	Last Available: "2016-12"
+9220	spirit-forward tolerable gingerbread wine	5	good	Last Available: "2016-12"
 9221	adequate gingerbread mug	4	good	Last Available: "2016-12"
 9222	cyan gingerbread mask of the blizzard	0		Cold Spell Damage: +25, Last Available: "2016-12"
 9223	wool Sinatra's Socratic gingerservo	0		Experience (Mysticality): +1, Experience (Moxie): +5, Cold Resistance: +1, Single Equip, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	spinning spare chocolate parts	0		Last Available: "2016-12"
 9241	colloidal dry shaking industrial frosting	0		Effect: "Sleazy Weapon", Effect Duration: 42, Last Available: "2016-12"
 9242	colloidal colloidal blinking blinking fake cocktail	0		Effect: "Holiday Disappointment", Effect Duration: 66, Last Available: "2016-12"
-9243	drinkable practically non-alcoholic high-end ginger wine	1	good	Last Available: "2016-12"
+9243	practically non-alcoholic drinkable high-end ginger wine	1	good	Last Available: "2016-12"
 9244	blue ribald plastic bad vibe	0		Sleaze Damage: +10, Last Available: "2016-12"
 9245	plastic angry vikings of the pedagogue	0		Experience: +3, Last Available: "2016-12"
 9246	beefcake's plastic Knows About Chakras	0		Muscle: +25, Last Available: "2016-12"
@@ -9121,10 +9121,10 @@
 9249	warmed Inner Wisdom	0		Effect: "Omphalotus Omnipresence", Effect Duration: 47, Last Available: "2016-12"
 9250	improved deionized Inner Strength	0		Effect: "Leo Rising", Effect Duration: 28, Last Available: "2016-12"
 9251	Vulcanized spinning Inner Truth	0		Effect: "Jittery", Effect Duration: 15, Last Available: "2016-12"
-9252	jumbo adequate spiritual candy cane	5	good	Last Available: "2016-12"
+9252	adequate jumbo spiritual candy cane	5	good	Last Available: "2016-12"
 9253	mediocre fortified spiritual eggnog	5	decent	Last Available: "2016-12"
-9254	snack-sized decent spiritual fruitcake	2	good	Last Available: "2016-12"
-9255	delicious special huge spiritual gingerbread	8	awesome	Effect: "Flame-Retardant Trousers", Effect Duration: 45, Last Available: "2016-12"
+9254	decent snack-sized spiritual fruitcake	2	good	Last Available: "2016-12"
+9255	huge delicious special spiritual gingerbread	8	awesome	Effect: "Flame-Retardant Trousers", Effect Duration: 45, Last Available: "2016-12"
 9256	pulsating chocolate puppy	0		Last Available: "2016-12"
 9257	narrow chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9145,11 +9145,11 @@
 9273	ribald supercharged Third Eye	0		Maximum MP Percent: +30, Sleaze Damage: +10, Last Available: "2016-12"
 9274	slick weightlifter's Krampus Horn	0		Muscle: +15, Moxie: +10, Single Equip, Last Available: "2016-12"
 9275	moldy upside-down hambrosier	3	crappy	Last Available: "2016-12"
-9276	lousy watered-down chakra-mental wine	2	decent	Last Available: "2016-12"
+9276	watered-down lousy chakra-mental wine	2	decent	Last Available: "2016-12"
 9277	cold-filtered spinning chakra malt	0		Effect: "Elemental Flavor", Effect Duration: 63, Last Available: "2016-12"
 9278	spoiled low-calorie blinking Black Angus blackburger	1	crappy	Last Available: "2016-12"
 9279	perfectly mixed brandy	3	EPIC	Last Available: "2016-12"
-9280	anodized upside-down pulsating potion of spiritual gunkifying	0		Effect: "OMG WTF", Effect Duration: 18, Last Available: "2016-12"
+9280	anodized pulsating upside-down potion of spiritual gunkifying	0		Effect: "OMG WTF", Effect Duration: 18, Last Available: "2016-12"
 9281	cyan friendly arcane researcher's bad vibroknife	0		Experience Percent (Mysticality): +10, Familiar Weight: +3, Last Available: "2016-12"
 9282	fuchsia tumbling crystal belt buckle of James Dean of chilblains	0		Experience (Moxie): +3, Cold Damage: +25, Last Available: "2016-12"
 9283	lightning-fast avaricious saffron antaravasaka	0		Meat Drop: +30, Initiative: +40, Last Available: "2016-12"
@@ -9162,23 +9162,23 @@
 9290	rotten pulsating Eldritch snap	3	crappy	Last Available: "2017-01"
 9291	vaporized bouncing hot jelly	1		Last Available: "2017-01"
 9292	modified blue bouncing jelly	1		Last Available: "2017-01"
-9293	diluted jittery purple jelly	1		Last Available: "2017-01"
+9293	diluted purple jittery jelly	1		Last Available: "2017-01"
 9294	dehydrated sleaze jelly	1		Effect: "Human-Goblin Hybrid", Effect Duration: 45, Last Available: "2017-01"
-9295	boiled blinking lime green stench jelly	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 25, Last Available: "2017-01"
+9295	boiled lime green blinking stench jelly	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 25, Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	miniature flavorless toast with hot jelly	2	decent	Last Available: "2017-01"
+9297	flavorless miniature toast with hot jelly	2	decent	Last Available: "2017-01"
 9298	decent toast with jelly	4	good	Last Available: "2017-01"
 9299	half-sized flavorless wobbly toast with jelly	2	decent	Last Available: "2017-01"
-9300	enchanted small normal toast with sleaze jelly	2	good	Effect: "Got Your Boots On", Effect Duration: 30, Last Available: "2017-01"
-9301	yummy tiny pulsating toast with stench jelly	1	awesome	Last Available: "2017-01"
+9300	small normal enchanted toast with sleaze jelly	2	good	Effect: "Got Your Boots On", Effect Duration: 30, Last Available: "2017-01"
+9301	tiny yummy pulsating toast with stench jelly	1	awesome	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	bouncing Newton's wax hand of extreme caution	0		Experience (Mysticality): +3, Monster Level: -25, Last Available: "2017-01"
 9306	maroon ribald padded candle	0		Damage Absorption: +20, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2017-01"
-9307	decent fancy wax pancake	4	good	Effect: "Total Protonic Reversal", Effect Duration: 25, Last Available: "2017-01"
+9307	fancy decent wax pancake	4	good	Effect: "Total Protonic Reversal", Effect Duration: 25, Last Available: "2017-01"
 9308	upside-down quilted brawny wax face	0		Muscle Percent: +20, Damage Absorption: +40, Last Available: "2017-01"
-9309	irresponsibly strong acceptable shaking wax booze	6	good	Last Available: "2017-01"
+9309	acceptable irresponsibly strong shaking wax booze	6	good	Last Available: "2017-01"
 9310	lime green glob of melted wax	0		Last Available: "2017-01"
 9311	modified sea jelly	1		Last Available: "2017-01"
 9312	half-sized bland sea truffle	2	decent	Last Available: "2017-01"
@@ -9188,7 +9188,7 @@
 9316	heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	activated magnetized spinning LOV Elixir #3	0		Effect: "Feet of Watermelon", Effect Duration: 28, Last Available: "2017-02"
 9318	wet twirling LOV Elixir #6	0		Effect: "Dreadful Smell", Effect Duration: 37, Last Available: "2017-02"
-9319	flattened extra-corrupted liquefied jittery pulsating LOV Elixir #9	0		Effect: "Full Bottle in front of Me", Effect Duration: 60, Last Available: "2017-02"
+9319	flattened extra-corrupted liquefied pulsating jittery LOV Elixir #9	0		Effect: "Full Bottle in front of Me", Effect Duration: 60, Last Available: "2017-02"
 9320	ghostly scorching hardy razor-sharp LOV Eardigan	0		Weapon Damage Percent: +25, Maximum HP: +50, Hot Damage: +25, Lasts Until Rollover, Last Available: "2017-02"
 9321	blinking twirling teal family-friendly greasy LOV Epaulettes of temperance	0		Sleaze Spell Damage: +10, Sleaze Resistance: 6, Lasts Until Rollover, Last Available: "2017-02"
 9322	veiny forbidden Herculean LOV Earrings	0		Experience (Muscle): +1, Spell Damage Percent: +50, Maximum HP: +10, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
@@ -9201,7 +9201,7 @@
 9329	corrupted blurry eldritch alignment spray	0		Effect: "Celestial Sheen", Effect Duration: 20, Last Available: "2017-02"
 9330	skewed LOV Entrance Pass	0		Last Available: "2017-02"
 9331	huge aromatic clever eldritch hammer of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +20, Stench Resistance: +1, Last Available: "2017-01"
-9332	thick normal eldritch mushroom	5	good	Last Available: "2017-03"
+9332	normal thick eldritch mushroom	5	good	Last Available: "2017-03"
 9333	mirror eldritch ichor	0		
 9334	decent eldritch mushroom pizza	3	good	Last Available: "2017-03"
 9335	pulsating eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9213,7 +9213,7 @@
 9341	maroon Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
 9343	narrow bottlecap	0		
-9344	maroon wobbly discarded button	0		
+9344	wobbly maroon discarded button	0		
 9345	Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
 9347	pickled grasshopper	0		Last Available: "2017-03"
@@ -9224,7 +9224,7 @@
 9352	blue bottle of clam juice	0		Last Available: "2017-03"
 9353	green cocktail mushroom	0		Last Available: "2017-03"
 9354	shot of granola liqueur	0		Last Available: "2017-03"
-9355	skewed wobbly can of cherry-flavored sterno	0		Last Available: "2017-03"
+9355	wobbly skewed can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
 9358	twirling bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
@@ -9240,42 +9240,42 @@
 9368	bad Siberian sunrise	3	decent	Last Available: "2017-03"
 9369	perfectly mixed mentholated wine	3	EPIC	Last Available: "2017-03"
 9370	hand-crafted low tide martini	4	EPIC	Last Available: "2017-03"
-9371	acceptable practically non-alcoholic lime green shroomtini	1	good	Last Available: "2017-03"
-9372	watered-down perfectly mixed morning dew	2	EPIC	Last Available: "2017-03"
+9371	practically non-alcoholic acceptable lime green shroomtini	1	good	Last Available: "2017-03"
+9372	perfectly mixed watered-down morning dew	2	EPIC	Last Available: "2017-03"
 9373	tolerable weak whiskey squeeze	2	good	Last Available: "2017-03"
 9374	lousy watered-down great fashioned	2	decent	Last Available: "2017-03"
 9375	acceptable watered-down Gnomish sagngria	2	good	Last Available: "2017-03"
-9376	lousy watered-down vodka stinger	2	decent	Last Available: "2017-03"
+9376	watered-down lousy vodka stinger	2	decent	Last Available: "2017-03"
 9377	hand-crafted fancy extremely slippery nipple	3	EPIC	Effect: "Eyes All Black", Effect Duration: 25, Last Available: "2017-03"
-9378	tolerable high-proof purple piscatini	9	good	Last Available: "2017-03"
-9379	bad fortified Churchill	5	decent	Last Available: "2017-03"
+9378	high-proof tolerable purple piscatini	9	good	Last Available: "2017-03"
+9379	fortified bad Churchill	5	decent	Last Available: "2017-03"
 9380	watered-down acceptable narrow soilzerac	2	good	Last Available: "2017-03"
 9381	hand-crafted London frog	3	EPIC	Last Available: "2017-03"
 9382	acceptable triple-distilled spinning nothingtini	8	good	Last Available: "2017-03"
-9383	triple-distilled bad blinking eighth plague	8	decent	Last Available: "2017-03"
+9383	bad triple-distilled blinking eighth plague	8	decent	Last Available: "2017-03"
 9384	watered-down smooth purple single entendre	2	awesome	Last Available: "2017-03"
-9385	watered-down mediocre pulsating reverse Tantalus	2	decent	Last Available: "2017-03"
+9385	mediocre watered-down pulsating reverse Tantalus	2	decent	Last Available: "2017-03"
 9386	weak acceptable elemental caipiroska	2	good	Last Available: "2017-03"
-9387	mediocre watered-down Feliz Navidad	2	decent	Last Available: "2017-03"
+9387	watered-down mediocre Feliz Navidad	2	decent	Last Available: "2017-03"
 9388	special weak tolerable Bloody Nora	2	good	Effect: "Flamibili Tea", Effect Duration: 20, Last Available: "2017-03"
 9389	lousy fortified moreltini	5	decent	Last Available: "2017-03"
-9390	hand-crafted strong hell in a bucket	5	EPIC	Last Available: "2017-03"
+9390	strong hand-crafted hell in a bucket	5	EPIC	Last Available: "2017-03"
 9391	practically non-alcoholic perfectly mixed Newark	1	EPIC	Last Available: "2017-03"
-9392	lousy twirling jittery maroon R'lyeh	3	decent	Last Available: "2017-03"
+9392	lousy maroon jittery twirling R'lyeh	3	decent	Last Available: "2017-03"
 9393	aged fortified Gnollish sangria	5	awesome	Last Available: "2017-03"
 9394	perfectly mixed skewed vodka barracuda	4	EPIC	Last Available: "2017-03"
 9395	tolerable Mysterious Island iced tea	3	good	Last Available: "2017-03"
 9396	drinkable practically non-alcoholic squat drive-by shooting	1	good	Last Available: "2017-03"
-9397	lousy squat maroon gunner's daughter	3	decent	Last Available: "2017-03"
-9398	fortified drinkable dirt julep	5	good	Last Available: "2017-03"
-9399	spirit-forward mediocre Simepore slime	5	decent	Last Available: "2017-03"
-9400	delicious weak shaking mirror Phil Collins	2	awesome	Last Available: "2017-03"
+9397	lousy maroon squat gunner's daughter	3	decent	Last Available: "2017-03"
+9398	drinkable fortified dirt julep	5	good	Last Available: "2017-03"
+9399	mediocre spirit-forward Simepore slime	5	decent	Last Available: "2017-03"
+9400	delicious weak mirror shaking Phil Collins	2	awesome	Last Available: "2017-03"
 9401	wobbly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	blurry Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	gray blinking filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
-9406	huge upside-down exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
+9406	upside-down huge exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	blinking gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	jittery high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9294,12 +9294,12 @@
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	moldy immense alien meat	10	crappy	Last Available: "2017-04"
 9424	blinking alien toenails	0		Last Available: "2017-04"
-9425	jittery teal alien zoological sample	0		Last Available: "2017-04"
+9425	teal jittery alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	vaporized alien animal goo	1		Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
-9430	skewed narrow spant egg casing	0		Last Available: "2017-04"
+9430	narrow skewed spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	alkaline super-pickled alien medicine	0		Effect: "Items Are Forever", Effect Duration: 59, Last Available: "2017-04"
 9433	moldy alien salad	3	crappy	Last Available: "2017-04"
@@ -9325,18 +9325,18 @@
 9453	Van der Graaf therapeutic grievous murderbot mask	0		Weapon Damage Percent: +50, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 5, HP Regen Max: 7, Avatar: "Murderbot", Last Available: "2017-04"
 9454	quadruple-improved Vulcanized cyan murderbot spring injector	0		Effect: "Feet of Grapefruit", Effect Duration: 54, Last Available: "2017-04"
 9455	healthy murderbot whip of the overflowing toilet	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Last Available: "2017-04"
-9456	miser's hardened murderbot plasma rifle	0		Damage Reduction: 3, Meat Drop: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	miser's hardened murderbot plasma rifle	0		Damage Reduction: 3, Meat Drop: +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	squat tumbling murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
-9462	spinning skewed Procrastinator locker key	0		Last Available: "2017-04"
+9462	skewed spinning Procrastinator locker key	0		Last Available: "2017-04"
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	tumbling Space Baby bawbaw	0		Last Available: "2017-04"
 9465	jittery Spacegate	0		Last Available: "2017-04"
 9466	jumbo rotten narrow Aldebaran sardines	5	crappy	Last Available: "2017-04"
-9467	mediocre high-proof ghostly skewed Centauri fish wine	8	decent	Last Available: "2017-04"
+9467	high-proof mediocre ghostly skewed Centauri fish wine	8	decent	Last Available: "2017-04"
 9468	vaporized pulsating oxygen	1		Last Available: "2017-04"
 9469	Oprah's grievous Spacegate scientist's insignia	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Single Equip, Last Available: "2017-04"
 9470	Spacegate military insignia of the empath of Flo-Jo	0		Familiar Weight: +5, Initiative: +100, Single Equip, Last Available: "2017-04"
@@ -9354,7 +9354,7 @@
 9482	chilled Daily Affirmation: Adapt to Change Eventually	0		Effect: "Extra-Wet", Effect Duration: 42, Last Available: "2017-05"
 9483	concentrated aerosolized energized Daily Affirmation: Be a Mind Master	0		Effect: "Cravin' for a Ravin'", Effect Duration: 19, Last Available: "2017-05"
 9484	diffused Daily Affirmation: Work For Hours a Week	0		Effect: "Heart of Orange", Effect Duration: 58, Last Available: "2017-05"
-9485	denatured gray pulsating Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Tiki Thoughtfulness", Effect Duration: 64, Last Available: "2017-05"
+9485	denatured pulsating gray Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Tiki Thoughtfulness", Effect Duration: 64, Last Available: "2017-05"
 9486	tasty gray Affirmation Cookie	3	awesome	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
@@ -9362,7 +9362,7 @@
 9490	irradiated pickled triple-polarized wobbly Threatening Missive	0		Effect: "Super Speed", Effect Duration: 19
 9491	squat Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	lion tamer's stylish wizardly Kremlin's Greatest Briefcase	0		Mysticality: +25, Moxie: +25, Experience (familiar): +2, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	lion tamer's stylish wizardly Kremlin's Greatest Briefcase	0		Mysticality: +25, Moxie: +25, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	hand-crafted weak basic martini	2	EPIC	Last Available: "2017-06"
 9495	watered-down tolerable upside-down improved martini	2	good	Last Available: "2017-06"
 9496	bad splendid martini	3	decent	Last Available: "2017-06"
@@ -9418,8 +9418,8 @@
 9546	mansplainer's mafia pinky ring of the sewer	0		Monster Level: +15, Stench Damage: +25, Single Equip
 9547	tolerable flask of port	3	good	
 9548	twirling narrow lime green smooth cool contract enforcement stick	0		Moxie: 20
-9549	immense rotten blue Hide-rox&trade; cookie	8	crappy	Last Available: "2017-10"
-9550	enchanted perfectly mixed ghostly jug of booze	3	EPIC	Effect: "Slimy Flavor", Effect Duration: 45, Last Available: "2017-10"
+9549	rotten immense blue Hide-rox&trade; cookie	8	crappy	Last Available: "2017-10"
+9550	perfectly mixed enchanted ghostly jug of booze	3	EPIC	Effect: "Slimy Flavor", Effect Duration: 45, Last Available: "2017-10"
 9551	quadruple-irradiated pair of candy glasses	0		Effect: "Milk Studly", Effect Duration: 30, Last Available: "2017-10"
 9552	denatured denatured temporary X tattoos	0		Effect: "Purpose", Effect Duration: 25, Last Available: "2017-10"
 9553	compressed upside-down bouncing glyph of athleticism	1		Last Available: "2017-10"
@@ -9450,11 +9450,11 @@
 9578	transparent nog	1	good	Last Available: "2017-12"
 9579	normal fancy unfinished fruitcake	4	good	Effect: "Fancy Feasted", Effect Duration: 35, Last Available: "2017-12"
 9580	super-frozen and cracker	0		Effect: "Vinegavotte", Effect Duration: 62, Last Available: "2017-12"
-9581	aged irresponsibly strong yellow ghostly neg grog	10	awesome	Last Available: "2017-12"
-9582	decent jumbo half double fruitcake	5	good	Last Available: "2017-12"
+9581	aged irresponsibly strong ghostly yellow neg grog	10	awesome	Last Available: "2017-12"
+9582	jumbo decent half double fruitcake	5	good	Last Available: "2017-12"
 9583	stale spinning hushed puppy	4	decent	Last Available: "2017-12"
 9584	bland muffled muffuletta	3	decent	Last Available: "2017-12"
-9585	immense spoiled shushed potatoes	6	crappy	Last Available: "2017-12"
+9585	spoiled immense shushed potatoes	6	crappy	Last Available: "2017-12"
 9586	miser's plastic mime functionary	0		Meat Drop: +10, Last Available: "2017-12"
 9587	plastic mime scientist of courage	0		Spooky Resistance: +3, Last Available: "2017-12"
 9588	wicked plastic mime soldier	0		Spell Damage: +5, Last Available: "2017-12"
@@ -9462,7 +9462,7 @@
 9590	Socratic plastic The Silent Nightmare	0		Experience (Mysticality): +1, Last Available: "2017-12"
 9591	locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	mumming trunk	0		Last Available: "2017-12"
-9593	blue mirror temperance whiskey	1	awesome	Last Available: "2017-11"
+9593	mirror blue temperance whiskey	1	awesome	Last Available: "2017-11"
 9594	tarnished lime green wishbone	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 60, Last Available: "2017-11"
 9595	mediocre Racisto Ruidoso	4	decent	Last Available: "2017-11"
 9596	pulsating earthenware muffin tin	0		
@@ -9488,18 +9488,18 @@
 9616	blinking silent R	0		Last Available: "2017-12"
 9617	upside-down silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
-9619	teal blurry silent U	0		Last Available: "2017-12"
+9619	blurry teal silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
 9621	upside-down silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	cyan silent Y	0		Last Available: "2017-12"
-9624	maroon jittery jittery silent Z	0		Last Available: "2017-12"
+9624	jittery jittery maroon silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	hand-crafted stale cheer wine	3	EPIC	Last Available: "2017-12"
-9630	small bland squat shaking stale Cheer-E-Os	2	decent	Last Available: "2017-12"
+9630	bland small squat shaking stale Cheer-E-Os	2	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	horrifying sharpshooter's cheerful antler hat	0		Critical Hit Percent: +10, Spooky Damage: +25, Last Available: "2017-12"
 9633	cyan dog trainer's hale cheerful Crimbo sweater	0		Maximum HP: +20, Experience (familiar): +1, Last Available: "2017-12"
@@ -9519,7 +9519,7 @@
 9647	skewed mime eraser	0		Last Available: "2017-12"
 9648	bad executive mime flask	4	decent	Last Available: "2017-12"
 9649	bite-sized spoiled nega-mushroom	1	crappy	Last Available: "2017-12"
-9650	delicious watered-down nega-mushroom wine	2	awesome	Last Available: "2017-12"
+9650	watered-down delicious nega-mushroom wine	2	awesome	Last Available: "2017-12"
 9651	ionized Cheer-Up soda	0		Effect: "On the Trolley", Effect Duration: 54, Last Available: "2017-12"
 9652	rotten mime army rations	3	crappy	Last Available: "2017-12"
 9653	perfectly mixed mime army wine	3	super ultra mega EPIC	Last Available: "2017-12"
@@ -9549,7 +9549,7 @@
 9677	mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	mirror purple kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
-9680	twirling olive spinning fireproof skip lid	0		Familiar Weight: +5
+9680	spinning olive twirling fireproof skip lid	0		Familiar Weight: +5
 9681	decent extra-toasted half sandwich	3	good	Last Available: "2018-12"
 9682	acceptable mulled hobo wine	3	good	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
@@ -9593,7 +9593,7 @@
 9725	prompt energetic psychic's pslacks	0		Maximum MP Percent: +20, Adventures: +3, Last Available: "2018-02"
 9726	aromatic foul-smelling psychic's amulet	0		Stench Damage: +10, Stench Resistance: +1, Last Available: "2018-02"
 9727	stale big heart-shaped candy whetstone	5	decent	Last Available: "2018-02"
-9728	yummy half-sized Swedish massage fish	2	awesome	Last Available: "2018-02"
+9728	half-sized yummy Swedish massage fish	2	awesome	Last Available: "2018-02"
 9729	lousy Third Base	3	decent	Last Available: "2018-02"
 9730	mediocre Bustle Hustler	4	decent	Last Available: "2018-02"
 9731	deionized altered pulsating Fabiotion	0		Effect: "Retrograde Relaxation", Effect Duration: 62, Last Available: "2018-02"
@@ -9693,8 +9693,8 @@
 9825	cyan razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	maroon bouncing smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	tumbling rocket	0		
-9828	twisted huge fuchsia magnificent oyster egg	1		Effect: "EVISCERATE!", Effect Duration: 10
-9829	denatured tumbling bouncing brilliant oyster egg	1		
+9828	twisted fuchsia huge magnificent oyster egg	1		Effect: "EVISCERATE!", Effect Duration: 10
+9829	denatured bouncing tumbling brilliant oyster egg	1		
 9830	twisted glistening oyster egg	1		
 9831	denatured scintillating oyster egg	1		Effect: "Orchid Blood", Effect Duration: 25
 9832	denatured pearlescent oyster egg	1		Effect: "Puddingface", Effect Duration: 45
@@ -9728,20 +9728,20 @@
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	shaking LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	spoiled FantasyRealm turkey leg	4	crappy	Last Available: "2018-04"
-9863	tolerable practically non-alcoholic FantasyRealm mead	1	good	Last Available: "2018-04"
+9863	practically non-alcoholic tolerable FantasyRealm mead	1	good	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	spinning arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	tumbling grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	snack-sized rotten druidic s'more	2	crappy	Last Available: "2018-04"
+9869	rotten snack-sized druidic s'more	2	crappy	Last Available: "2018-04"
 9870	dried maroon sachet of powder	1		Last Available: "2018-04"
-9871	bad extra-dry mourning wine	5	decent	Last Available: "2018-04"
+9871	extra-dry bad mourning wine	5	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	blurry jittery map to the Putrid Swamp	0		Last Available: "2018-04"
-9876	narrow upside-down map to the Cursed Village	0		Last Available: "2018-04"
+9876	upside-down narrow map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	rotten miniature denastified haunch	2	crappy	Last Available: "2018-04"
 9879	perfectly mixed blurry bad rum and good cola	3	EPIC	Last Available: "2018-04"
@@ -9764,7 +9764,7 @@
 9896	tumbling dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	mediocre weak bouncing two meat muck	2	decent	
-9899	moldy snack-sized chocolate Ogre Chieftain	2	crappy	
+9899	snack-sized moldy chocolate Ogre Chieftain	2	crappy	
 9900	flavorless jumbo upside-down chocolate &quot;Phoenix&quot;	5	decent	
 9901	flavorless chocolate Spider Queen	4	decent	
 9902	aged hipster cocktail	3	awesome	
@@ -9774,13 +9774,13 @@
 9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
 9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
-9909	skewed bouncing G	0		
+9909	bouncing skewed G	0		
 9910	Garland of Greatness	0		
 9911	ghostly gattoo	0		
 9912	A-Boo glue	0		
 9913	bouncing glued A-Boo clue	0		
 9914	blue crude oil congealer	0		
-9915	rotten small good guava	2	crappy	
+9915	small rotten good guava	2	crappy	
 9916	watered-down acceptable gin and ginger	2	good	
 9917	Thwaitgold chigger statuette	0		
 9918	dehydrated maroon gaseous gravy	1		
@@ -9790,7 +9790,7 @@
 9922	magnetized alkaline altered jittery Shielding Potion	0		Effect: "5 Pounds Lighter", Effect Duration: 49, Last Available: "2018-06"
 9923	corrupted Punching Potion	0		Effect: "Busy Bein' Delicious", Effect Duration: 67, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	dehydrated jittery skewed Nightmare Fuel	1		Last Available: "2018-06"
+9925	dehydrated skewed jittery Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	olive Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9813,17 +9813,17 @@
 9945	skewed Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	artisanal watered-down narrow Middle of the Road&trade; brand whiskey	2	EPIC	Last Available: "2018-09"
+9948	watered-down artisanal narrow Middle of the Road&trade; brand whiskey	2	EPIC	Last Available: "2018-09"
 9949	wobbly neverending wallet chain	0		Last Available: "2018-09"
 9950	olive upside-down slick weightlifter's pentagram bandana	0		Muscle: +15, Moxie: +10, Last Available: "2018-09"
 9951	twirling fireproof skull ring	0		Hot Resistance: +3, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	thick bland upside-down PB&J with the crusts cut off	5	decent	Last Available: "2018-09"
+9953	bland thick upside-down PB&J with the crusts cut off	5	decent	Last Available: "2018-09"
 9954	blinking dorky glasses of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2018-09"
 9955	censurious stylish ponytail clip	0		Moxie: +25, Sleaze Resistance: +3, Last Available: "2018-09"
-9956	paint palette of Tarzan	0		Experience (Muscle): +3, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	paint palette of Tarzan	0		Experience (Muscle): +3, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	olive unremarkable duffel bag	0		Last Available: "2018-09"
-9958	distilled upside-down gray Purple Beast energy drink	1		Last Available: "2018-09"
+9958	distilled gray upside-down Purple Beast energy drink	1		Last Available: "2018-09"
 9959	lightning-fast cosmetic football	0		Initiative: +40, Last Available: "2018-09"
 9960	wobbly prompt Sherlock's shoe ad T-shirt	0		Item Drop: +25, Adventures: +3, Last Available: "2018-09"
 9961	prompt pump-up high-tops	0		Adventures: +3, Single Equip, Last Available: "2018-09"
@@ -9837,21 +9837,21 @@
 9969	prompt steel-toed denim jacket	0		Damage Reduction: 9, Adventures: +3, Last Available: "2018-09"
 9970	tumbling dance instructor's personal trainer's ratty knitted cap	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Last Available: "2018-09"
 9972	quilted arcane researcher's intimidating chainsaw	0		Experience Percent (Mysticality): +10, Damage Absorption: +40, Lasts Until Rollover, Last Available: "2018-09"
-9973	high-proof acceptable party beer bomb	10	good	Last Available: "2018-09"
+9973	acceptable high-proof party beer bomb	10	good	Last Available: "2018-09"
 9974	yummy wobbly sweet party mix	3	awesome	Last Available: "2018-09"
-9975	distilled squat ghostly party balloon	1		Effect: "The Rich Get Richer", Effect Duration: 20, Last Available: "2018-09"
+9975	distilled ghostly squat party balloon	1		Effect: "The Rich Get Richer", Effect Duration: 20, Last Available: "2018-09"
 9976	padded party pants of dire peril	0		Weapon Damage: +20, Damage Absorption: +20, Last Available: "2018-09"
 9977	censurious Sinatra's party whip of the sweet-tooth	0		Experience (Moxie): +5, Sleaze Resistance: +3, Candy Drop: +100, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	practically non-alcoholic acceptable TRIO cup of beer	1	good	Last Available: "2018-09"
-9980	tasty cyan squat party platter for one	3	awesome	Last Available: "2018-09"
+9979	acceptable practically non-alcoholic TRIO cup of beer	1	good	Last Available: "2018-09"
+9980	tasty squat cyan party platter for one	3	awesome	Last Available: "2018-09"
 9981	pickled wobbly upside-down Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	upside-down party pup	0		Last Available: "2018-09"
-9983	Van der Graaf wholesome party crasher	0		Maximum HP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	Van der Graaf wholesome party crasher	0		Maximum HP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	tumbling Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	shaking party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	blurry latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	twirling voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	thinker's &quot;I Voted!&quot; sticker	0		Mysticality: +10, Lasts Until Rollover, Last Available: "2018-11"
@@ -9862,7 +9862,7 @@
 9995	pulsating horrifying snakeskin jacket of James Dean	0		Experience (Moxie): +3, Spooky Damage: +25, Last Available: "2018-11"
 9996	slime glob	0		Last Available: "2018-11"
 9997	slime glob	0		Last Available: "2018-11"
-9998	fuchsia mirror twirling slime glob	0		Last Available: "2018-11"
+9998	mirror twirling fuchsia slime glob	0		Last Available: "2018-11"
 9999	asbestos-lined flame-wreathed slime waders of Flo-Jo	0		Hot Spell Damage: +10, Hot Resistance: +5, Initiative: +100, Last Available: "2018-11"
 10001	jittery ruddy steel-toed rock-hard slime fedora	0		Damage Reduction: 28, Maximum HP Percent: +40, Last Available: "2018-11"
 10002	upside-down sinister brainy slime knuckles of the glutton	0		Mysticality: +5, Spell Damage: +10, Food Drop: +100, Last Available: "2018-11"
@@ -9884,7 +9884,7 @@
 10018	diet moldy gray Hell ramen	1	crappy	Last Available: "2018-11"
 10019	artisanal gimlet	3	EPIC	Last Available: "2018-11"
 10020	aged twice-haunted screwdriver	3	awesome	Last Available: "2018-11"
-10021	normal miniature candy cane	2	good	Last Available: "2018-12"
+10021	miniature normal candy cane	2	good	Last Available: "2018-12"
 10022	smooth runny fermented egg	3	awesome	Last Available: "2018-12"
 10023	massive moldy skewed oldcake	10	crappy	Last Available: "2018-12"
 10024	stale traditional Crimbo cookie	4	decent	Last Available: "2023-06"
@@ -9902,7 +9902,7 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	skewed plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	snack-sized bland pulsating grilled mooseflank	2	decent	Last Available: "2018-12"
+10039	bland snack-sized pulsating grilled mooseflank	2	decent	Last Available: "2018-12"
 10040	normal moosemeat pie	3	good	Last Available: "2018-12"
 10041	blurry ribald balanced antler	0		Sleaze Damage: +10, Last Available: "2018-12"
 10042	mirror olive dam of the pedagogue	0		Experience: +3, Damage Reduction: 9, Last Available: "2018-12"
@@ -9931,7 +9931,7 @@
 10065	olive Toyleporter	0		Last Available: "2018-12"
 10066	lousy twirling beer	3	decent	Last Available: "2018-12"
 10067	tasty fancy blue yule gruel	3	awesome	Effect: "Uncanny Shot", Effect Duration: 25, Last Available: "2018-12"
-10068	weak artisanal hot watered rum	2	EPIC	Last Available: "2018-12"
+10068	artisanal weak hot watered rum	2	EPIC	Last Available: "2018-12"
 10069	hand-crafted bottle of Crimbognac	3	EPIC	Last Available: "2018-12"
 10070	rotten Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
 10071	denatured skewed bouncing Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9961,21 +9961,21 @@
 10095	grievous Da Vinci's marble mariachi hat	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Last Available: "2019-12"
 10096	dried marble molecules	1		Effect: "Greasy Visage", Effect Duration: 25, Last Available: "2019-12"
 10097	frozen galvanized Mallomarbles	0		Effect: "Memory of Speed", Effect Duration: 58
-10098	mirror zippy gravedigger's punching bag	0		Spooky Damage: +10, Initiative: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	jittery occult brainy pith helmet	0		Mysticality: +5, Spell Damage Percent: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	nasty poncho of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	blurry narrow executive pendant of James Dean	0		Experience (Moxie): +3, Meat Drop: +40, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	medical-grade Herculean palazzos	0		Experience (Muscle): +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	padded pseudoaccordion of the brazier	0		Damage Absorption: +20, Hot Spell Damage: +25, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	mirror zippy gravedigger's punching bag	0		Spooky Damage: +10, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	jittery occult brainy pith helmet	0		Mysticality: +5, Spell Damage Percent: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	nasty poncho of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	blurry narrow executive pendant of James Dean	0		Experience (Moxie): +3, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	medical-grade Herculean palazzos	0		Experience (Muscle): +1, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	padded pseudoaccordion of the brazier	0		Damage Absorption: +20, Hot Spell Damage: +25, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	boiled jittery blinking blinking pieces	1		Effect: "Improprie Tea", Effect Duration: 45, Last Available: "2020-12"
 10105	improved super-diffused Para-Pop	0		Effect: "Drunk With Power", Effect Duration: 30
-10106	educational terra cotta truss of the bloodbag	0		Experience: +1, Maximum HP: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	mirror huge nippy boxer's terra cotta trousers	0		Muscle Percent: +10, Cold Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	ribald terra cotta tongs of extreme caution	0		Monster Level: -25, Sleaze Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	shellacked terra cotta train of horror	0		Damage Reduction: 7, Spooky Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	terra cotta tie tack of James Dean of the cheetah	0		Experience (Moxie): +3, Initiative: +60, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	lard-coated terra cotta tambourine of temperance	0		Sleaze Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10112	altered spinning yellow twirling terra cotta tidbits	1		Last Available: "2020-12"
+10106	educational terra cotta truss of the bloodbag	0		Experience: +1, Maximum HP: +100, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	mirror huge nippy boxer's terra cotta trousers	0		Muscle Percent: +10, Cold Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	ribald terra cotta tongs of extreme caution	0		Monster Level: -25, Sleaze Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	shellacked terra cotta train of horror	0		Damage Reduction: 7, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	terra cotta tie tack of James Dean of the cheetah	0		Experience (Moxie): +3, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	lard-coated terra cotta tambourine of temperance	0		Sleaze Spell Damage: +25, Sleaze Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10112	altered yellow twirling spinning terra cotta tidbits	1		Last Available: "2020-12"
 10113	ionized super-vacuum-sealed terra panna cotta	0		Effect: "Fancy Feasted", Effect Duration: 34
 10114	hale ruddy velour voulge	0		Maximum HP Percent: +40, Maximum HP: +20, Last Available: "2021-12"
 10115	blinking squat aromatic velour vambraces of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +1, Single Equip, Last Available: "2021-12"
@@ -9983,7 +9983,7 @@
 10117	rosy-cheeked fortified velour viscometer	0		Damage Absorption: +60, Maximum HP Percent: +30, Single Equip, Last Available: "2021-12"
 10118	manspreader's ruddy velour valise	0		Maximum HP Percent: +40, Monster Level: +10, Last Available: "2021-12"
 10119	sizzling velour vaqueros of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +10, Last Available: "2021-12"
-10120	modified maroon jittery wobbly velour veneer	1		Effect: "Destructive Resolve", Effect Duration: 20, Last Available: "2021-12"
+10120	modified jittery wobbly maroon velour veneer	1		Effect: "Destructive Resolve", Effect Duration: 20, Last Available: "2021-12"
 10121	adjusted Velougats&trade;	0		Effect: "You Read The Manual", Effect Duration: 68
 10122	mirror manspreader's hardened glass suspenders	0		Damage Reduction: 3, Monster Level: +10, Single Equip, Last Available: "2021-12"
 10123	cyan mansplainer's strapping glass shield	0		Muscle: +5, Monster Level: +15, Damage Reduction: 7, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	scandalous chaotic glass serape	0		Spell Critical Percent: +10, Sleaze Damage: +5, Last Available: "2021-12"
 10128	denatured narrow glass shards	1		Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2021-12"
 10129	pickled hard candy	0		Effect: "Wet Willied", Effect Duration: 55
-10130	miser's Jeselnik's loofah lumberjack's hat	0		Sleaze Damage: +25, Meat Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	sizzling crafty loofah lei	0		Maximum MP: +10, Hot Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	mirror hale loofah lederhosen of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	Oprah's hardy loofah ladle	0		Maximum HP: +50, Maximum MP Percent: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	shaking asbestos-lined Oprah's loofah legwarmers	0		Maximum MP Percent: +50, Hot Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	blue gravedigger's beefy loofah lavalier	0		Muscle: +10, Spooky Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	miser's Jeselnik's loofah lumberjack's hat	0		Sleaze Damage: +25, Meat Drop: +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	sizzling crafty loofah lei	0		Maximum MP: +10, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	mirror hale loofah lederhosen of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	Oprah's hardy loofah ladle	0		Maximum HP: +50, Maximum MP Percent: +50, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	shaking asbestos-lined Oprah's loofah legwarmers	0		Maximum MP Percent: +50, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	blue gravedigger's beefy loofah lavalier	0		Muscle: +10, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	modified loofah lumps	1		Last Available: "2022-12"
-10137	modified extra-deionized vacuum-sealed blurry wobbly chocolate-covered loofah	0		Effect: "Thick-Skinned", Effect Duration: 54
-10138	squat flame-retardant padded flagstone flag	0		Damage Absorption: +20, Hot Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	mirror Fonzie's flagstone flail of courage	0		Experience (Moxie): +1, Spooky Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	family-friendly dog trainer's flagstone flip-flops	0		Experience (familiar): +1, Sleaze Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	mirror clever savvy flagstone fez	0		Mysticality Percent: +20, Maximum MP: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	spinning tumbling Temple Grandin's flagstone fleece of the glutton	0		Familiar Weight: +7, Food Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	squat manspreader's sage flagstone fringe	0		Mysticality Percent: +10, Monster Level: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10137	modified extra-deionized vacuum-sealed wobbly blurry chocolate-covered loofah	0		Effect: "Thick-Skinned", Effect Duration: 54
+10138	squat flame-retardant padded flagstone flag	0		Damage Absorption: +20, Hot Resistance: +1, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	mirror Fonzie's flagstone flail of courage	0		Experience (Moxie): +1, Spooky Resistance: +3, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	family-friendly dog trainer's flagstone flip-flops	0		Experience (familiar): +1, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	mirror clever savvy flagstone fez	0		Mysticality Percent: +20, Maximum MP: +20, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	spinning tumbling Temple Grandin's flagstone fleece of the glutton	0		Familiar Weight: +7, Food Drop: +100, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	squat manspreader's sage flagstone fringe	0		Mysticality Percent: +10, Monster Level: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	pickled flagstone flagments	1		Last Available: "2022-12"
 10145	diffused polymerized Flag by the Foot&trade;	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 29
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10029,19 +10029,19 @@
 10163	extra-flattened government-issued candy	0		Effect: "Concentration", Effect Duration: 17
 10164	modified energized Pneumo bar	0		Effect: "All Fired Up", Effect Duration: 19
 10165	huge mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	foul-smelling dance instructor's Lil' Doctor&trade; bag	0		Experience Percent (Moxie): +10, Stench Damage: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	foul-smelling dance instructor's Lil' Doctor&trade; bag	0		Experience Percent (Moxie): +10, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	huge flavorless narrow bloodstick	7	decent	
 10170	artisanal wobbly bottle of Sanguiovese	3	EPIC	
 10171	spoiled actual blood sausage	3	crappy	
 10172	lousy mulled blood	4	decent	
 10173	normal blood snowcone	4	good	
-10174	tolerable practically non-alcoholic Red Russian	1	good	
-10175	flavorless bite-sized spinning blood roll-up	1	decent	
+10174	practically non-alcoholic tolerable Red Russian	1	good	
+10175	bite-sized flavorless spinning blood roll-up	1	decent	
 10176	bad maroon bottle of blood	3	decent	
 10177	rotten immense blood-soaked sponge cake	10	crappy	
-10178	triple-distilled mediocre enchanted vampagne	9	decent	Effect: "Glittering Eyelashes", Effect Duration: 30
-10179	enchanted moldy snack-sized plain snowcone	2	crappy	Effect: "Twinkly Weapon", Effect Duration: 20
+10178	enchanted triple-distilled mediocre vampagne	9	decent	Effect: "Glittering Eyelashes", Effect Duration: 30
+10179	enchanted snack-sized moldy plain snowcone	2	crappy	Effect: "Twinkly Weapon", Effect Duration: 20
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	mirror money bag	0		
@@ -10062,11 +10062,11 @@
 10197	red tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	skewed Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	yummy snack-sized crabsicle	2	awesome	Last Available: "2019-04"
-10200	upside-down jittery melty plastic grenade	0		Last Available: "2019-04"
-10201	perfectly mixed watered-down tumbling pulsating bottle of dark rhum	2	EPIC	Last Available: "2019-04"
-10202	perfectly mixed watered-down bottle of extra-dark rhum	2	EPIC	Last Available: "2019-04"
+10200	jittery upside-down melty plastic grenade	0		Last Available: "2019-04"
+10201	watered-down perfectly mixed pulsating tumbling bottle of dark rhum	2	EPIC	Last Available: "2019-04"
+10202	watered-down perfectly mixed bottle of extra-dark rhum	2	EPIC	Last Available: "2019-04"
 10203	acceptable bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
-10204	dry ionized skewed shaking pirate shaving cream	0		Effect: "Arresistible", Effect Duration: 23, Last Available: "2019-04"
+10204	dry ionized shaking skewed pirate shaving cream	0		Effect: "Arresistible", Effect Duration: 23, Last Available: "2019-04"
 10205	careful hardy conquistador's breastplate	0		Maximum HP: +50, Monster Level: -10, Last Available: "2019-04"
 10206	huge sizzling pirate pantaloons of Flo-Jo	0		Hot Damage: +10, Initiative: +100, Last Available: "2019-04"
 10207	[glitch season reward name]	0		
@@ -10096,15 +10096,15 @@
 10231	tumbling dog trainer's wizardly PirateRealm party hat of the boozehound	0		Mysticality: +25, Experience (familiar): +1, Booze Drop: +100, Last Available: "2019-04"
 10232	lousy weak Island Landslide	2	decent	Last Available: "2019-04"
 10233	delicious Island Thunderstorm	3	awesome	Last Available: "2019-04"
-10234	fortified artisanal shaking Island Hurricane	5	EPIC	Last Available: "2019-04"
+10234	artisanal fortified shaking Island Hurricane	5	EPIC	Last Available: "2019-04"
 10235	special bad Skull Punch	3	decent	Effect: "Slime Time", Effect Duration: 35, Last Available: "2019-04"
 10236	weak delicious Electric Punch	2	awesome	Last Available: "2019-04"
 10237	artisanal practically non-alcoholic Smuggler's Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
-10238	delicious extra-dry Scorpion Bowl	5	awesome	Last Available: "2019-04"
+10238	extra-dry delicious Scorpion Bowl	5	awesome	Last Available: "2019-04"
 10239	perfectly mixed narrow Turtle Bowl	3	super EPIC	Last Available: "2019-04"
-10240	fancy drinkable high-proof Cobra Bowl	10	good	Effect: "Category", Effect Duration: 20, Last Available: "2019-04"
+10240	drinkable fancy high-proof Cobra Bowl	10	good	Effect: "Category", Effect Duration: 20, Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	ghostly foul-smelling careful rosy-cheeked Rosewater's savvy vampyric cloake	0		Mysticality Percent: 50, Maximum HP Percent: +30, Monster Level: -10, Stench Damage: +10, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	ghostly foul-smelling careful rosy-cheeked Rosewater's savvy vampyric cloake	0		Mysticality Percent: 50, Maximum HP Percent: +30, Monster Level: -10, Stench Damage: +10, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	teal plastic pirate hat	0		Familiar Weight: +5
 10244	modified cyan one piece of bubble gum	0		Effect: "Leisurely Amblin'", Effect Duration: 12
 10245	blinking arcanoferric housing	0		
@@ -10113,19 +10113,19 @@
 10248	blurry blown-out speaker cone	0		
 10249	blue blinking overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	huge avaricious supercharged Fourth of May Cosplay Saber of mayonnaise	0		Maximum MP Percent: +30, Sleaze Spell Damage: +50, Meat Drop: +30, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	huge avaricious supercharged Fourth of May Cosplay Saber of mayonnaise	0		Maximum MP Percent: +30, Sleaze Spell Damage: +50, Meat Drop: +30, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	wobbly auspicious lard-coated ribald therapeutic personal trainer's experienced smartaleck's slick hewn moon-rune spoon of the wise owl of the sewer of the early riser	0		Mysticality: +20, Moxie: +10, Moxie Percent: +30, Experience: +2, Experience Percent (Muscle): +10, Stench Damage: +25, Sleaze Damage: +10, Sleaze Spell Damage: +25, Item Drop: +10, Adventures: +7, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	wobbly auspicious lard-coated ribald therapeutic personal trainer's experienced smartaleck's slick hewn moon-rune spoon of the wise owl of the sewer of the early riser	0		Mysticality: +20, Moxie: +10, Moxie Percent: +30, Experience: +2, Experience Percent (Muscle): +10, Stench Damage: +25, Sleaze Damage: +10, Sleaze Spell Damage: +25, Item Drop: +10, Adventures: +7, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	yellow cartoon harpoon	0		Last Available: "2019-06"
 10256	tumbling rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	blurry pulsating gravedigger's curative razor-sharp Beach Comb	0		Weapon Damage Percent: +25, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	blurry pulsating gravedigger's curative razor-sharp Beach Comb	0		Weapon Damage Percent: +25, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	squat spinning pile of sand	0		Last Available: "2019-07"
-10263	squat bouncing empty hourglass	0		Last Available: "2019-07"
+10263	bouncing squat empty hourglass	0		Last Available: "2019-07"
 10264	hourglass	0		Last Available: "2019-07"
 10265	jittery etched hourglass	0		Last Available: "2019-07"
 10266	quantum maroon magenta seashell	0		Effect: "Hairy Palms", Effect Duration: 62, Last Available: "2019-07"
@@ -10182,8 +10182,8 @@
 10317	signal jammer	0		Single Equip
 10318	spinning low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
-10320	special miniature normal space chowder	2	good	Effect: "Hot Hands", Effect Duration: 45
-10321	drinkable weak pulsating huge space wine	2	good	
+10320	normal miniature special space chowder	2	good	Effect: "Hot Hands", Effect Duration: 45
+10321	weak drinkable pulsating huge space wine	2	good	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	twirling Pocket Professor memory chip	0		
@@ -10203,9 +10203,9 @@
 10344	quilted plastic Dolph Bossin	0		Damage Absorption: +40, Last Available: "2019-12"
 10345	blurry red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	moldy mana-coated yams	4	crappy	Last Available: "2019-11"
-10347	half-sized bland mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
+10347	bland half-sized mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
 10348	stale immense mana-fortified cranberry sauce	6	decent	Last Available: "2019-11"
-10349	decent thick mana-stuffed herbal stuffing	5	good	Last Available: "2019-11"
+10349	thick decent mana-stuffed herbal stuffing	5	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	extra-quantum triple-denatured bouncing patch of extra-warm fur	0		Effect: "Hella Smart", Effect Duration: 37, Last Available: "2019-12"
 10352	dehydrated industrial lubricant	1		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 50, Last Available: "2019-12"
@@ -10217,7 +10217,7 @@
 10358	cold-filtered infernal snowball	0		Effect: "Abominably Slippery", Effect Duration: 65, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	mixed fish sauce	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45, Last Available: "2019-12"
-10361	adequate diet guffin	1	good	Last Available: "2019-12"
+10361	diet adequate guffin	1	good	Last Available: "2019-12"
 10362	dried skewed Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	twisted twirling non-Euclidean angle	1		Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	wobbly The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	modified shaking narrow salty gumdrop	0		Effect: "Rootin' Around", Effect Duration: 22, Last Available: "2019-12"
+10384	modified narrow shaking salty gumdrop	0		Effect: "Rootin' Around", Effect Duration: 22, Last Available: "2019-12"
 10385	MacGyver's dance instructor's ribbon candy ascot	0		Experience Percent (Moxie): +10, Maximum MP: +100, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
@@ -10272,7 +10272,7 @@
 10413	spinning asbestos-lined wholesome nutcracker epaulets	0		Maximum HP Percent: +10, Hot Resistance: +5, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	moldy salt plum	4	crappy	Last Available: "2019-12"
-10416	mirror pulsating peppermint eel sauce	0		Last Available: "2019-12"
+10416	pulsating mirror peppermint eel sauce	0		Last Available: "2019-12"
 10417	bland lime green and bean	3	decent	Last Available: "2019-12"
 10418	mansplainer's Lo Pan's kelp-holly gun of the storm	0		Maximum MP Percent: +40, Spell Critical Percent: +30, Monster Level: +15, Last Available: "2019-12"
 10419	censurious Yuleviathan necklace of temperance	0		Sleaze Resistance: 8, Single Equip, Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	perfumed Temple Grandin's Crimbylow-rise jeans	0		Familiar Weight: +7, Stench Resistance: +5, Last Available: "2019-12"
 10423	frightening kelp-holly drape of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Last Available: "2019-12"
 10424	mirror nasty scorching therapeutic extremely unsafe Staff of the Peppermint Twist	0		Weapon Damage Percent: +100, Hot Damage: +25, Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-12"
-10425	rotten tiny tempura and bean	1	crappy	Last Available: "2019-12"
-10426	tolerable enchanted salt plum sake	4	good	Effect: "Arabian Knighthood", Effect Duration: 35, Last Available: "2019-12"
+10425	tiny rotten tempura and bean	1	crappy	Last Available: "2019-12"
+10426	enchanted tolerable salt plum sake	4	good	Effect: "Arabian Knighthood", Effect Duration: 35, Last Available: "2019-12"
 10427	ionized pressurized potion of possessiveness	0		Effect: "The Strength...  of the Future", Effect Duration: 23, Last Available: "2019-12"
 10428	polymerized triple-pressed mirror almond	0		Effect: "Triangle, Man", Effect Duration: 65
 10429	non-chilled handful of mixed nuts	0		Effect: "Towering Strength", Effect Duration: 39, Last Available: "2019-12"
 10430	mirror nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	bouncing auspicious Retrospecs of the sewer of doom	0		Stench Damage: +25, Spooky Spell Damage: +50, Item Drop: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	bouncing auspicious Retrospecs of the sewer of doom	0		Stench Damage: +25, Spooky Spell Damage: +50, Item Drop: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
-10434	spinning ghostly gray skewed Bird-a-Day calendar	0		Last Available: "2020-01"
+10434	gray ghostly skewed spinning Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	yellow mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	Jack Frost's quilted sinister Powerful Glove of the pedagogue of chilblains	0		Experience: +3, Spell Damage: +10, Damage Absorption: +40, Cold Damage: +25, Cold Spell Damage: +50, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	Jack Frost's quilted sinister Powerful Glove of the pedagogue of chilblains	0		Experience: +3, Spell Damage: +10, Damage Absorption: +40, Cold Damage: +25, Cold Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	tumbling enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	spinning Samson's weightlifter's Drip harness of the overflowing toilet	0		Muscle: +15, Experience (Muscle): +5, Stench Spell Damage: +50
@@ -10395,10 +10395,10 @@
 10539	red Guzzlr souvenir stein of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	acceptable weak pulsating Ghiaccio Colada	2	good	Last Available: "2020-05"
-10542	tolerable high-proof Sourfinger	6	good	Last Available: "2020-05"
-10543	drinkable strong Nog-on-the-Cob	5	good	Last Available: "2020-05"
+10542	high-proof tolerable Sourfinger	6	good	Last Available: "2020-05"
+10543	strong drinkable Nog-on-the-Cob	5	good	Last Available: "2020-05"
 10544	aged watered-down Steamboat	2	awesome	Last Available: "2020-05"
-10545	watered-down lousy Buttery Boy	2	decent	Last Available: "2020-05"
+10545	lousy watered-down Buttery Boy	2	decent	Last Available: "2020-05"
 10546	shaking Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	teal clown car key of the ox of chilblains	0		Muscle: +20, Cold Damage: +25, Last Available: "2020-08"
 10548	olive miser's batting cage key of the ox of the cougar	0		Muscle: +20, Moxie: +20, Meat Drop: +10, Last Available: "2020-08"
@@ -10431,23 +10431,23 @@
 10575	narrow drippy candy bar	0		
 10576	vacuum-sealed salty drippy candy bar	0		Effect: "Drunk With Power", Effect Duration: 57
 10577	cold-filtered upside-down huge writhing drippy candy bar	0		Effect: "Rosewater Mark", Effect Duration: 23
-10578	liquefied cold-filtered bouncing red gooey drippy candy bar	0		Effect: "Human-Beast Hybrid", Effect Duration: 28
+10578	liquefied cold-filtered red bouncing gooey drippy candy bar	0		Effect: "Human-Beast Hybrid", Effect Duration: 28
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	blurry cyan dromedary drinking helmet	0		
 10581	tumbling packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	wobbly knitted birch battery of extreme caution	0		Monster Level: -25, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2020-08"
-10585	auspicious shellacked cool ebony epee	0		Moxie: +5, Damage Reduction: 7, Item Drop: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	wobbly reassuring medical-grade ruddy weeping willow wand	0		Maximum HP Percent: +40, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	friendly Jim Carey's experienced beechwood blowgun	0		Experience: +2, Monster Level: +25, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	auspicious shellacked cool ebony epee	0		Moxie: +5, Damage Reduction: 7, Item Drop: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	wobbly reassuring medical-grade ruddy weeping willow wand	0		Maximum HP Percent: +40, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	friendly Jim Carey's experienced beechwood blowgun	0		Experience: +2, Monster Level: +25, Familiar Weight: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	blurry olive foul-smelling careful maple magnet of the businessman	0		Monster Level: -10, Stench Damage: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	greedy healthy hemlock helm of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5, Meat Drop: +20, Last Available: "2020-08"
 10591	narrow sweaty balsam	0		Last Available: "2020-08"
 10592	ghostly pulsating thinker's strapping balsam barrel of the sweet-tooth	0		Muscle: +5, Mysticality: +10, Candy Drop: +100, Last Available: "2020-08"
 10593	redwood	0		Last Available: "2020-08"
-10594	warmed boiled huge pulsating redwood rain stick	0		Effect: "Souper Vengeful", Effect Duration: 16, Last Available: "2020-08"
+10594	warmed boiled pulsating huge redwood rain stick	0		Effect: "Souper Vengeful", Effect Duration: 16, Last Available: "2020-08"
 10595	twirling purpleheart logs	0		Last Available: "2020-08"
 10596	jittery Jim Carey's medical-grade purpleheart &quot;pants&quot; of the wise owl	0		Mysticality: +20, Monster Level: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-08"
 10597	twirling wormwood stick	0		Last Available: "2020-08"
@@ -10474,7 +10474,7 @@
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	spinning nasty desk bell	0		Last Available: "2020-09"
-10621	jittery skewed greasy desk bell	0		Last Available: "2020-09"
+10621	skewed jittery greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
@@ -10487,7 +10487,7 @@
 10631	alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
 10633	alabaster knight	0		Last Available: "2020-09"
-10634	huge upside-down alabaster pawn	0		Last Available: "2020-09"
+10634	upside-down huge alabaster pawn	0		Last Available: "2020-09"
 10635	mirror bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	lime green zippy lion tamer's groovy Cargo Cultist Shorts of Gandalf	0		Moxie Percent: +10, Spell Critical Percent: +20, Experience (familiar): +2, Initiative: +20, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
@@ -10496,7 +10496,7 @@
 10640	ghostly bouncing Universal Seasoning	0		
 10641	dry non-altered squat null-day exploit	0		Effect: "Tremella Tremens", Effect Duration: 57, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	special stale huge chocolate chip muffin	4	decent	Effect: "Mitre Cut", Effect Duration: 40
+10643	stale special huge chocolate chip muffin	4	decent	Effect: "Mitre Cut", Effect Duration: 40
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	purple Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10507,7 +10507,7 @@
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	cold-filtered fortifying hot cocoa	0		Effect: "Antibiotic Saucesphere", Effect Duration: 37, Last Available: "2020-12"
-10654	boiled unsweetened blinking bouncing boiling hot cocoa	0		Effect: "Hairless and Airless", Effect Duration: 47, Last Available: "2020-12"
+10654	boiled unsweetened bouncing blinking boiling hot cocoa	0		Effect: "Hairless and Airless", Effect Duration: 47, Last Available: "2020-12"
 10655	nitrogenated double-flattened cool hot cocoa	0		Effect: "Celestial Sheen", Effect Duration: 15, Last Available: "2020-12"
 10656	pressed aerosolized overly-fancy hot cocoa	0		Effect: "Gyromitra Gymnastics", Effect Duration: 65, Last Available: "2020-12"
 10657	oxidized twirling hot cocoa au beurre	0		Effect: "Black Eyes", Effect Duration: 68, Last Available: "2020-12"
@@ -10536,7 +10536,7 @@
 10680	jittery dance instructor's wine carrier	0		Experience Percent (Moxie): +10, Lasts Until Rollover, Last Available: "2020-12"
 10681	pulsating Sherlock's candy bucket	0		Item Drop: +25, Lasts Until Rollover, Last Available: "2020-12"
 10682	polarized prescription teeth whitener	0		Effect: "Low on the Hog", Effect Duration: 32, Last Available: "2020-12"
-10683	diffused wet red pulsating imported lemon lozenge	0		Effect: "Pork Power", Effect Duration: 26, Last Available: "2020-12"
+10683	diffused wet pulsating red imported lemon lozenge	0		Effect: "Pork Power", Effect Duration: 26, Last Available: "2020-12"
 10684	triple-enhanced magnetized polymerized hermedisiac cologne	0		Effect: "Billiards Belligerence", Effect Duration: 15, Last Available: "2020-12"
 10685	red government food shipment	0		Last Available: "2020-12"
 10686	upside-down government booze shipment	0		Last Available: "2020-12"
@@ -10567,7 +10567,7 @@
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	shaking The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10714	blurry maroon The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
+10714	maroon blurry The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	yummy half-sized jittery blurry and pepper (stale)	2	awesome	Last Available: "2020-12"
 10716	aged cranberry margarita (brackish)	3	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
@@ -10578,7 +10578,7 @@
 10722	flavorless drive-thru burger	3	decent	Last Available: "2020-12"
 10723	perfectly mixed Boulevardier cocktail	3	EPIC	Last Available: "2020-12"
 10724	Vulcanized flattened Hotwire&trade; brand candy rope	0		Effect: "Goldentongue", Effect Duration: 66, Last Available: "2020-12"
-10725	spoiled miniature tumbling bowl full of jelly	2	crappy	Last Available: "2020-12"
+10725	miniature spoiled tumbling bowl full of jelly	2	crappy	Last Available: "2020-12"
 10726	lousy Eye and a Twist	3	decent	Last Available: "2020-12"
 10727	warmed nitrogenated Chubby and Plump bar	0		Effect: "Shortened", Effect Duration: 53, Last Available: "2020-12"
 10728	shaking digibritches	0		Last Available: "2025-12"
@@ -10593,16 +10593,16 @@
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
 10739	alkaline battery (AAA)	0		Effect: "Human-Insect Hybrid", Effect Duration: 53, Last Available: "2021-03"
-10740	diffused double-chilled ghostly twirling battery (AA)	0		Effect: "Weird Flavor", Effect Duration: 69, Last Available: "2021-03"
+10740	diffused double-chilled twirling ghostly battery (AA)	0		Effect: "Weird Flavor", Effect Duration: 69, Last Available: "2021-03"
 10741	extra-nitrogenated battery (D)	0		Effect: "Sewer-Drenched", Effect Duration: 41, Last Available: "2021-03"
-10742	warmed lime green huge huge blurry battery (9-Volt)	0		Effect: "Human-Goblin Hybrid", Effect Duration: 59, Last Available: "2021-03"
+10742	warmed huge blurry lime green huge battery (9-Volt)	0		Effect: "Human-Goblin Hybrid", Effect Duration: 59, Last Available: "2021-03"
 10743	quadruple-polarized ionized battery (lantern)	0		Effect: "White Knuckles", Effect Duration: 41, Last Available: "2021-03"
 10744	triple-polymerized vacuum-sealed blurry battery (car)	0		Effect: "Jelly Combed", Effect Duration: 20, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
 10747	aged green marshmallow bomb	4	awesome	Last Available: "2021-03"
 10748	fuchsia packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	tumbling plate	0		Familiar Weight: +5
 10752	colloidal altered huge short beer	0		Effect: "Waxing", Effect Duration: 23, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	non-vacuum-sealed short	0		Effect: "Tiki Temerity", Effect Duration: 37, Last Available: "2021-05"
 10757	squat Thwaitgold quantum bug statuette	0		
 10758	tumbling quantum of familiar	0		
-10759	blue ghostly medical-grade Herculean familiar scrapbook	0		Experience (Muscle): +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	blue ghostly medical-grade Herculean familiar scrapbook	0		Experience (Muscle): +1, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	twirling clan underground fireworks shop	0		Last Available: "2021-07"
 10762	veiny wholesome forbidden fedora-mounted fountain	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Maximum HP: +10, Lasts Until Rollover, Last Available: "2021-07"
@@ -10628,7 +10628,7 @@
 10772	rock-hard stiffened sparkler	0		Damage Reduction: 12, Lasts Until Rollover, Last Available: "2021-07"
 10773	blinking spinning Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	super-flattened alkaline teal Scent of a Human&trade; candle	0		Effect: "Purpose", Effect Duration: 43, Last Available: "2021-08"
-10775	double-Vulcanized double-liquefied yellow bouncing The Beast Within&trade; candle	0		Effect: "Jelly Combed", Effect Duration: 36, Last Available: "2021-08"
+10775	double-Vulcanized double-liquefied bouncing yellow The Beast Within&trade; candle	0		Effect: "Jelly Combed", Effect Duration: 36, Last Available: "2021-08"
 10776	oxidized Salsa Caliente&trade; candle	0		Effect: "Feelin' Philosophical", Effect Duration: 36, Last Available: "2021-08"
 10777	frozen deionized Smoldering Clover&trade; candle	0		Effect: "Strong Grip", Effect Duration: 21, Last Available: "2021-08"
 10778	chilled cyan Napalm In The Morning&trade; candle	0		Effect: "Muscularrr", Effect Duration: 56, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	jittery rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	dog trainer's curative hardy grievous industrial fire extinguisher of James Dean of the sweet-tooth	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Maximum HP: +50, Experience (familiar): +1, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	dog trainer's curative hardy grievous industrial fire extinguisher of James Dean of the sweet-tooth	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Maximum HP: +50, Experience (familiar): +1, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	skewed The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10677,9 +10677,9 @@
 10821	stale bite-sized fishcake	1	decent	Last Available: "2021-12"
 10822	big fancy bland bone broth	5	decent	Effect: "Tingly Elbows", Effect Duration: 10, Last Available: "2021-12"
 10823	toothsome star pop	3	awesome	Last Available: "2021-12"
-10824	special practically non-alcoholic mediocre Doc's Fortifying Wine	1	decent	Effect: "Strawberry Alarm", Effect Duration: 10, Last Available: "2021-12"
+10824	practically non-alcoholic special mediocre Doc's Fortifying Wine	1	decent	Effect: "Strawberry Alarm", Effect Duration: 10, Last Available: "2021-12"
 10825	artisanal Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
-10826	bad weak Doc's Limbering Wine	2	decent	Last Available: "2021-12"
+10826	weak bad Doc's Limbering Wine	2	decent	Last Available: "2021-12"
 10827	artisanal blurry Doc's Medical-Grade Wine	3	EPIC	Last Available: "2021-12"
 10828	diluted wobbly Homebodyl&trade;	1		Effect: "Shot in the Arse", Effect Duration: 35, Last Available: "2021-12"
 10829	compressed spinning Extrovermectin&trade;	1		Effect: "Hot Jellied", Effect Duration: 45, Last Available: "2021-12"
@@ -10691,8 +10691,8 @@
 10835	pressed liquefied anti-odor cream	0		Effect: "It's Electric!", Effect Duration: 55, Last Available: "2021-12"
 10836	diffused anti-creep cream	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 36, Last Available: "2021-12"
 10837	tarnished anti-pain cream	0		Effect: "Savage Beast Inside", Effect Duration: 53, Last Available: "2021-12"
-10838	watered-down lousy pulsating Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
-10839	jumbo stale bread pie	5	decent	Last Available: "2021-12"
+10838	lousy watered-down pulsating Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
+10839	stale jumbo bread pie	5	decent	Last Available: "2021-12"
 10840	hand-crafted clear Russian	4	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10714,14 +10714,14 @@
 10858	fuchsia the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	bouncing jittery coward's depleted Crimbonium football helmet	0		Monster Level: -20, Last Available: "2021-12"
-10861	lime green jittery synthetic rock	0		Last Available: "2021-12"
+10861	jittery lime green synthetic rock	0		Last Available: "2021-12"
 10862	adequate &quot;caramel&quot;	4	good	Last Available: "2021-12"
 10863	teal electrified self-repairing earmuffs	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2021-12"
 10864	MacGyver's carnivorous potted plant	0		Maximum MP: +100, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	educational yule hatchet	0		Experience: +1, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	snack-sized yummy lab-grown meat	2	awesome	Last Available: "2021-12"
+10868	yummy snack-sized lab-grown meat	2	awesome	Last Available: "2021-12"
 10869	frightening fleece	0		Spooky Damage: +5, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	red bouncing wobbly cloning kit	0		Last Available: "2021-12"
@@ -10733,10 +10733,10 @@
 10877	cloned monster	0		Last Available: "2021-12"
 10878	blinking meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
-10880	compressed upside-down huge fried air	1		Last Available: "2021-12"
+10880	compressed huge upside-down fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	boiled squat narrow astral energy drink	1		
+10883	boiled narrow squat astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	skewed rosewater-soaked Oprah's rosy-cheeked magnifying glass	0		Maximum HP Percent: +30, Maximum MP Percent: +50, Stench Resistance: +3, Last Available: "2022-12"
 10886	hand-crafted void lager	3	EPIC	Last Available: "2022-12"
@@ -10765,11 +10765,11 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	pressed pickled single-use dust mask	0		Effect: "Goldentongue", Effect Duration: 65, Last Available: "2022-05"
 10911	altered liquefied ghostly gaffer's tape	0		Effect: "Peppermint Bite", Effect Duration: 17, Last Available: "2022-05"
-10912	immense decent squat 20-lb can of rice and beans	8	good	Last Available: "2022-05"
+10912	decent immense squat 20-lb can of rice and beans	8	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	good	Last Available: "2022-05"
 10914	adequate fancy expired MRE	3	good	Effect: "Magically Delicious", Effect Duration: 35, Last Available: "2022-05"
 10915	decent cool mint precipice bar	4	good	Last Available: "2022-05"
-10916	decent bite-sized bouncing carrot cake precipice bar	1	good	Last Available: "2022-05"
+10916	bite-sized decent bouncing carrot cake precipice bar	1	good	Last Available: "2022-05"
 10917	blinking The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	non-deionized quantum narrow trampled ticket stub	0		Effect: "Tiki Thoughtfulness", Effect Duration: 27, Last Available: "2022-06"
 10927	galvanized aerosolized savings bond	0		Effect: "Space Tripping", Effect Duration: 48, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	compressed sweat-ade	1		Effect: "Super-Mega-Charged", Effect Duration: 35, Last Available: "2022-07"
 10931	spinning unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10805,17 +10805,17 @@
 10949	narrow dinosaur of the bloodbag	0		Maximum HP: +100
 10950	blurry Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	knitted Tesla Jurassic Parka	0		Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	knitted Tesla Jurassic Parka	0		Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	ghostly boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
-10955	ionized modified twirling narrow autumn leaf	0		Effect: "Adrenaline Rush", Effect Duration: 29, Last Available: "2022-10"
-10956	practically non-alcoholic delicious special AutumnFest ale	1	awesome	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 40, Last Available: "2022-10"
+10955	ionized modified narrow twirling autumn leaf	0		Effect: "Adrenaline Rush", Effect Duration: 29, Last Available: "2022-10"
+10956	delicious practically non-alcoholic special AutumnFest ale	1	awesome	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 40, Last Available: "2022-10"
 10957	tumbling Jeselnik's crafty beefcake's autumn sweater-weather sweater	0		Muscle: +25, Maximum MP: +10, Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2022-10"
 10958	jittery jittery stanky foul-smelling healthy rock-hard autumn debris shield	0		Damage Reduction: 14, Maximum HP Percent: +20, Stench Damage: +10, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-10"
 10959	huge toothsome green autumn-spice donut	6	awesome	Last Available: "2022-10"
 10960	ionized blue autumn dollar	0		Effect: "Wintergreen Warmongery", Effect Duration: 53, Last Available: "2022-10"
 10961	purple twirling careful autumn leaf pendant of the brute of courage	0		Muscle Percent: +30, Monster Level: -10, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2022-10"
-10962	distilled yellow ghostly autumn breeze	1		Effect: "Patent Alacrity", Effect Duration: 45, Last Available: "2022-10"
+10962	distilled ghostly yellow autumn breeze	1		Effect: "Patent Alacrity", Effect Duration: 45, Last Available: "2022-10"
 10963	vacuum-sealed electrified lime green autumn years wisdom	0		Effect: "Surreally Buff", Effect Duration: 63, Last Available: "2022-10"
 10964	huge familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	acceptable blinking Oopsie IPA	3	good	Last Available: "2022-10"
@@ -10823,18 +10823,18 @@
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	blurry Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	normal snack-sized skewed ratatouille de Jarlsberg	2	good	Last Available: "2022-11"
+10970	snack-sized normal skewed ratatouille de Jarlsberg	2	good	Last Available: "2022-11"
 10971	stale huge blue Jarlsberg's vegetable soup	3	decent	Last Available: "2022-11"
 10972	low-calorie spoiled narrow roasted vegetable of Jarlsberg	1	crappy	Last Available: "2022-11"
 10973	gigantic bland St. Pete's sneaky smoothie	7	decent	Last Available: "2022-11"
 10974	stale Pete's wiley whey bar	3	decent	Last Available: "2022-11"
-10975	normal bite-sized skewed Pete's rich ricotta	1	good	Last Available: "2022-11"
+10975	bite-sized normal skewed Pete's rich ricotta	1	good	Last Available: "2022-11"
 10976	delicious cyan Boris's beer	4	awesome	Last Available: "2022-11"
 10977	spoiled green honey bun of Boris	3	crappy	Last Available: "2022-11"
-10978	bland snack-sized spinning Boris's bread	2	decent	Last Available: "2022-11"
+10978	snack-sized bland spinning Boris's bread	2	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	blinking bouncing yellow Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10981	bouncing yellow blinking Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
 10983	jittery Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
 10984	squat cyan Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
@@ -10866,20 +10866,20 @@
 11010	bland super-sized mirror swamp haunch	5	decent	
 11011	ruddy sage gator shades	0		Mysticality Percent: +10, Maximum HP Percent: +40, Single Equip
 11012	milk cap	0		
-11013	tolerable practically non-alcoholic Charleston Choo-Choo	1	good	
+11013	practically non-alcoholic tolerable Charleston Choo-Choo	1	good	
 11014	bad spirit-forward Velvet Veil	5	decent	
 11015	tolerable Marltini	3	good	
 11016	high-proof drinkable Strong, Silent Type	9	good	
-11017	practically non-alcoholic perfectly mixed Mysterious Stranger	1	super ultra mega turbo EPIC	
+11017	perfectly mixed practically non-alcoholic Mysterious Stranger	1	super ultra mega turbo EPIC	
 11018	tolerable Champagne Shimmy	3	good	
 11019	the Sot's parcel	0		
-11020	knitted Tesla ceramic cestus	0		Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	experienced smooth ceramic centurion shield of the glutton	0		Moxie: +15, Experience: +2, Food Drop: +100, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	twirling careful sharpshooter's ceramic celery grater	0		Critical Hit Percent: +10, Monster Level: -10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	spinning stiffened thinker's ceramic celsiturometer of the blizzard	0		Mysticality: +10, Damage Reduction: 1, Cold Spell Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	beefcake's strapping ceramic cerecloth belt	0		Muscle: 30, Item Drop: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	Jack Frost's Lo Pan's veiny ceramic cenobite's robe	0		Maximum HP: +10, Spell Critical Percent: +30, Cold Spell Damage: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
-11026	powdered skewed ghostly ceramic scree	1		Last Available: "2023-12"
+11020	knitted Tesla ceramic cestus	0		Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	experienced smooth ceramic centurion shield of the glutton	0		Moxie: +15, Experience: +2, Food Drop: +100, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	twirling careful sharpshooter's ceramic celery grater	0		Critical Hit Percent: +10, Monster Level: -10, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	spinning stiffened thinker's ceramic celsiturometer of the blizzard	0		Mysticality: +10, Damage Reduction: 1, Cold Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	beefcake's strapping ceramic cerecloth belt	0		Muscle: 30, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	Jack Frost's Lo Pan's veiny ceramic cenobite's robe	0		Maximum HP: +10, Spell Critical Percent: +30, Cold Spell Damage: +50, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11026	powdered ghostly skewed ceramic scree	1		Last Available: "2023-12"
 11027	super-irradiated energized extra-hard jawbreaker	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 69
 11028	avaricious Tesla Newton's chiffon chevrons	0		Experience (Mysticality): +3, Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12"
 11029	blinking coward's supercool beefcake's chiffon chapeau	0		Muscle: +25, Moxie Percent: +20, Monster Level: -20, Last Available: "2023-12"
@@ -10903,7 +10903,7 @@
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
-11050	nitrogenated dry jittery olive Trainbot circuitry	0		Effect: "Fury of the Bells", Effect Duration: 67
+11050	nitrogenated dry olive jittery Trainbot circuitry	0		Effect: "Fury of the Bells", Effect Duration: 67
 11051	wet mirror Trainbot tubing	0		Effect: "Blubbered Up", Effect Duration: 29
 11052	quantum Trainbot plating	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 36
 11053	wet irradiated Trainbot optics	0		Effect: "Blood-Rich", Effect Duration: 27
@@ -10920,11 +10920,11 @@
 11064	squat zippy energetic personal trainer's shoulder-mounted Trainbot	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Initiative: +20, Single Equip, Last Available: "2022-12"
 11065	cyan narrow cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	acceptable watered-down dregs of a Crimbo cocktail	2	good	
+11067	watered-down acceptable dregs of a Crimbo cocktail	2	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	bland honey-drenched ham slice	4	decent	
-11071	bad enchanted mostly-empty bottle of cookie wine	3	decent	Effect: "Stinking Cloud", Effect Duration: 5
+11071	enchanted bad mostly-empty bottle of cookie wine	3	decent	Effect: "Stinking Cloud", Effect Duration: 5
 11072	normal purple Crimbo food scraps	4	good	
 11073	pulsating arm towel	0		Last Available: "2022-12"
 11074	gray automatic wine thief	0		Single Equip
@@ -10933,11 +10933,11 @@
 11077	twirling industrially-crushed ice	0		Last Available: "2022-12"
 11078	decent teal steamed oyster	4	good	
 11079	really nice lump of coal	0		
-11080	blinking bouncing deactivated mini-Trainbot	0		Last Available: "2022-12"
+11080	bouncing blinking deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	blinking steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	hand-crafted jittery ghostly Crimbosmopolitan	4	EPIC	Last Available: "2022-12"
+11084	hand-crafted ghostly jittery Crimbosmopolitan	4	EPIC	Last Available: "2022-12"
 11085	spoiled fancy Crimbo dinner	3	crappy	Effect: "Resilient Spirit", Effect Duration: 45, Last Available: "2022-12"
 11086	spinning overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10965,7 +10965,7 @@
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
 11112	toothsome pixel bread	3	awesome	
-11113	acceptable weak pixel whiskey	2	good	
+11113	weak acceptable pixel whiskey	2	good	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	fuchsia S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10977,11 +10977,11 @@
 11122	supercharged hot pepper of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Lantern Element: "Hot", Last Available: "2023-02"
 11123	tarnished out-of-work circus flea	0		Effect: "Oily Flavor", Effect Duration: 18, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
-11125	pressed quadruple-moist gray squat fire ant pheromones	0		Effect: "Sweetened and Fattened", Effect Duration: 53, Last Available: "2023-02"
-11126	boiled warmed ghostly skewed flapper fly	0		Effect: "Rat-Faced", Effect Duration: 35, Last Available: "2023-02"
+11125	pressed quadruple-moist squat gray fire ant pheromones	0		Effect: "Sweetened and Fattened", Effect Duration: 53, Last Available: "2023-02"
+11126	boiled warmed skewed ghostly flapper fly	0		Effect: "Rat-Faced", Effect Duration: 35, Last Available: "2023-02"
 11127	artisanal shot of wasp venom	4	EPIC	Last Available: "2023-02"
 11128	extra-vacuum-sealed squat filled mosquito	0		Effect: "Sauce Monocle", Effect Duration: 65, Last Available: "2023-02"
-11129	irradiated concentrated purple upside-down blurry shim of shame shale	0		Effect: "Yet tea", Effect Duration: 14, Last Available: "2023-02"
+11129	irradiated concentrated blurry upside-down purple shim of shame shale	0		Effect: "Yet tea", Effect Duration: 14, Last Available: "2023-02"
 11130	magnetized ionized ghostly maroon pebble of proud pyrite	0		Effect: "Memento Moir&eacute;", Effect Duration: 31, Last Available: "2023-02"
 11131	polarized nitrogenated pile of gritty sand	0		Effect: "Mathematically Precise", Effect Duration: 68, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
@@ -10992,7 +10992,7 @@
 11137	extra-magnetized triple-adjusted shadow flame	0		Effect: "Far Out", Effect Duration: 35, Last Available: "2023-03"
 11138	flavorless shadow bread	4	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	extra-dry mediocre shadow fluid	5	decent	Last Available: "2023-03"
+11140	mediocre extra-dry shadow fluid	5	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	purple shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11015,7 +11015,7 @@
 11160	uncursed blanket	0		
 11161	greedy coward's Socratic medallion	0		Experience (Mysticality): +1, Monster Level: -20, Meat Drop: +20
 11162	blue uncursed medallion of mayonnaise	0		Sleaze Spell Damage: +50
-11163	blurry squat Advanced Pig Skinning	0		
+11163	squat blurry Advanced Pig Skinning	0		
 11164	blinking The Cheese Wizard's Companion	0		
 11165	Jazz Agent sheet music	0		
 11166	Thwaitgold anti-moth statuette	0		
@@ -11034,23 +11034,23 @@
 11179	avaricious aromatic shadow hammer	0		Stench Resistance: +1, Meat Drop: +30
 11180	maroon toasty shadow monocle of the wise owl of dire peril	0		Mysticality: +20, Weapon Damage: +20, Hot Damage: +5, Single Equip
 11181	blue shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	normal thick huge shadow hot dog	5	good	
-11183	lousy fancy shadow martini	4	decent	Effect: "Capricorn Rising", Effect Duration: 50
+11182	thick normal huge shadow hot dog	5	good	
+11183	fancy lousy shadow martini	4	decent	Effect: "Capricorn Rising", Effect Duration: 50
 11184	powdered spinning shadow pill	1		
-11185	squat cyan shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11185	cyan squat shadow needle	0		
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
-11188	non-magnetized twirling tumbling shadow candy	0		Effect: "In the Slimelight", Effect Duration: 65
+11188	non-magnetized tumbling twirling shadow candy	0		Effect: "In the Slimelight", Effect Duration: 65
 11189	squat replica Mr. Accessory	0		
 11190	ghostly replica Dark Jill-O-Lantern	0		
-11191	lime green skewed replica hand turkey outline	0		
+11191	skewed lime green replica hand turkey outline	0		
 11192	spinning replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	yellow replica gravy-covered maypole	0		Item Drop: +25
 11196	replica wax lips	0		Experience: +3
 11197	mirror replica Tome of Snowcone Summoning	0		
-11198	jittery twirling purple dedigitizer schematic: cybeer	0		Last Available: "2025-12"
+11198	twirling purple jittery dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	fireproof ruddy replica jewel-eyed wizard hat of vim and vigor	0		Maximum HP Percent: 90, Hot Resistance: +3, Conditional Skill (Equipped): "Magic Missile"
 11200	lime green Sherlock's replica bottle-rocket crossbow of the brazier of incineration	0		Hot Spell Damage: 75, Item Drop: +25, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 11201	censurious manspreader's Lo Pan's hardened replica navel ring of navel gazing	0		Damage Reduction: 3, Spell Critical Percent: +30, Monster Level: +10, Sleaze Resistance: +3, Single Equip
@@ -11075,14 +11075,14 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	prompt foul-smelling electrified Cincho de Mayo of extreme caution	0		Monster Level: -25, Stench Damage: +10, Adventures: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	prompt foul-smelling electrified Cincho de Mayo of extreme caution	0		Monster Level: -25, Stench Damage: +10, Adventures: +3, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	mirror dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
 11227	jittery replica Crimbo sapling	0		
 11228	maroon replica puck	0		
 11229	replica Chateau Mantegna room key	0		
-11230	lime green twirling replica Deck of Every Card	0		
+11230	twirling lime green replica Deck of Every Card	0		
 11231	replica Source terminal	0		
 11232	replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	upside-down narrow hale replica Jurassic Parka of the cheetah	0		Maximum HP: +20, Initiative: +60
 11250	blinking replica grey gosling	0		
-11251	twirling replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	twirling replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	narrow replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	twirling miser's reassuring lion tamer's banded replica Cincho de Mayo	0		Damage Absorption: +100, Experience (familiar): +2, Spooky Resistance: +1, Meat Drop: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,19 +11112,19 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	rosewater-soaked crafty ruddy shellacked wizardly &quot;I survived Y2K&quot; T-Shirt of vim and vigor	0		Mysticality: +25, Damage Reduction: 7, Maximum HP Percent: 90, Maximum MP: +10, Stench Resistance: +3, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	tumbling greasy shellacked pro skateboard	0		Damage Reduction: 7, Sleaze Spell Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	tumbling greasy shellacked pro skateboard	0		Damage Reduction: 7, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	pulsating Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	blinking teal Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	olive greasy Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Spell Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	olive greasy Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	scorching nippy steel-toed Amulet of Perpetual Darkness of the storm	0		Damage Reduction: 9, Maximum MP Percent: +40, Cold Damage: +10, Hot Damage: +25, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	squat Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
 11271	diffused scroll of minor invulnerability	0		Effect: "Superhuman Sarcasm", Effect Duration: 67, Last Available: "2023-06"
-11272	huge green Lapis Lazuli	0		Last Available: "2023-06"
+11272	green huge Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	red Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
@@ -11134,7 +11134,7 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	blinking Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	special strong bad Sexy Cosmo	5	decent	Effect: "Innately Truthy", Effect Duration: 30, Last Available: "2023-06"
+11282	bad special strong Sexy Cosmo	5	decent	Effect: "Innately Truthy", Effect Duration: 30, Last Available: "2023-06"
 11283	blinking Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	inspector's gravedigger's red-soled high heels of Gandalf	0		Spell Critical Percent: +20, Spooky Damage: +10, Item Drop: +15, Last Available: "2023-06"
 11285	yummy cyburger	4	awesome	Last Available: "2025-12"
@@ -11172,7 +11172,7 @@
 11317	narrow handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	cyan medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	drinkable fancy spirit-forward twirling bottle of Cabernet Sauvignon	5	good	Effect: "Sinuses For Miles", Effect Duration: 50
+11320	drinkable spirit-forward fancy twirling bottle of Cabernet Sauvignon	5	good	Effect: "Sinuses For Miles", Effect Duration: 50
 11321	Tesla weightlifter's baywatch of the storm	0		Muscle: +15, Maximum MP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover
 11322	blinking Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	bouncing Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
@@ -11181,12 +11181,12 @@
 11326	Thwaitgold fairyfly statue	0		
 11327	olive residual chitin paste	0		Skill: "Chitinous Soul"
 11328	compressed concentrated cooking	1		Effect: "Bilious Brains", Effect Duration: 40
-11329	diluted huge jittery skewed meat	1		Effect: "Hella Smart", Effect Duration: 10
+11329	diluted huge skewed jittery meat	1		Effect: "Hella Smart", Effect Duration: 10
 11330	compressed blurry sparkling orb	1		
 11331	powdered hardening cream	1		Effect: "Anytwo Five Elevenis?", Effect Duration: 25
 11332	dried bouncing blurry pool shark hair oil	1		
-11333	purple ghostly wobbly book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
-11334	olive jittery book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
+11333	ghostly wobbly purple book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
+11334	jittery olive book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	upside-down Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
 11337	map to a candy-rich block	0		Last Available: "2023-10"
@@ -11212,12 +11212,12 @@
 11357	banded smoldering drape of incineration	0		Damage Absorption: +100, Hot Spell Damage: +50, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	greasy medical-grade curative grievous leaf crown of the storm of courage	0		Weapon Damage Percent: +50, Maximum MP Percent: +40, Sleaze Spell Damage: +10, Spooky Resistance: +3, HP Regen Min: 10, HP Regen Max: 15
-11360	tasty immense enchanted leafy browns	6	awesome	Effect: "Ten out of Ten", Effect Duration: 30
+11360	immense tasty enchanted leafy browns	6	awesome	Effect: "Ten out of Ten", Effect Duration: 30
 11361	anodized quantum blue autumnic balm	0		Effect: "Night Vision", Effect Duration: 15
 11362	Vulcanized skewed coping juice	0		Effect: "Prideful Strut", Effect Duration: 60
 11363	gray double-paned mansplainer's supercharged savvy smooth candy cane sword cane	0		Moxie: +15, Mysticality Percent: +20, Maximum MP Percent: +30, Monster Level: +15, Cold Resistance: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
-11365	blue upside-down Elf Guard patrol cap	0		Last Available: "2023-12"
+11365	upside-down blue Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	ghostly yellow Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
@@ -11227,10 +11227,10 @@
 11372	pulsating handful of Boltsmann bearings	0		
 11373	wobbly Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
-11375	tumbling pulsating Boltsmann ID badge	0		
+11375	pulsating tumbling Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	decent immense pickled bread	7	good	Last Available: "2023-12"
+11378	immense decent pickled bread	7	good	Last Available: "2023-12"
 11379	flavorless skewed salted mutton	3	decent	Last Available: "2023-12"
 11380	adequate corned beet	4	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11252,7 +11252,7 @@
 11397	Crimbuccaneer fledges (mint) of doom	0		Spooky Spell Damage: +50, Last Available: "2023-12"
 11398	teal military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
-11400	wobbly skewed Elf Guard tinsel grenade	0		Last Available: "2023-12"
+11400	skewed wobbly Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	high-proof perfectly mixed Crimbuccaneer mologrog cocktail	6	EPIC	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
@@ -11268,18 +11268,18 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	Elf Guard officer's sidearm of terror of horror	0		Spooky Spell Damage: 35, Last Available: "2023-12"
 11415	greedy Tesla Elf Guard insignia (general)	0		Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12"
-11416	acceptable weak Crimbow Rainbo	2	good	Last Available: "2023-12"
+11416	weak acceptable Crimbow Rainbo	2	good	Last Available: "2023-12"
 11417	bouncing Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	occult sage Elf Guard broom	0		Mysticality Percent: +10, Spell Damage Percent: +25, Last Available: "2023-12"
 11420	skewed auspicious aromatic mansplainer's Crimbuccaneer tavern swab	0		Monster Level: +15, Stench Resistance: +1, Item Drop: +10, Last Available: "2023-12"
-11421	shaking olive shaking Elf Guard hangover cure	0		Last Available: "2023-12"
+11421	olive shaking shaking Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	drinkable upside-down tumbling old-school pirate grog	3	good	Last Available: "2023-12"
 11423	flavorless teal grog nuts	3	decent	Last Available: "2023-12"
 11424	Da Vinci's sawed-off blunderbuss of the brazier	0		Experience (Mysticality): +5, Hot Spell Damage: +25, Item Drop: +5, Last Available: "2023-12"
 11425	hand-crafted officer's nog	3	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	bland big sundae ration	5	decent	Last Available: "2023-12"
+11427	big bland sundae ration	5	decent	Last Available: "2023-12"
 11428	adequate peppermint tack	3	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	stale jittery wobbly whalesteak	3	decent	Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	upside-down Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	double-paned rock-hard Elf Guard clipboard of the glutton	0		Damage Reduction: 5, Cold Resistance: +5, Food Drop: +100, Last Available: "2023-12"
 11435	squat executive pegfinger	0		Meat Drop: +40, Single Equip, Last Available: "2023-12"
-11436	hand-crafted weak and claret	2	EPIC	Last Available: "2023-12"
+11436	weak hand-crafted and claret	2	EPIC	Last Available: "2023-12"
 11437	mirror squat chilly Elf Guard and beret	0		Cold Damage: [+5*event(December)], Last Available: "2023-12"
 11438	blinking greasy experienced weightlifter's shipwright's hammer	0		Muscle: +15, Experience: +2, Sleaze Spell Damage: +10, Last Available: "2023-12"
 11439	huge avaricious friendly gunwale of the overflowing toilet	0		Familiar Weight: +3, Stench Spell Damage: +50, Meat Drop: +30, Damage Reduction: 9, Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	crafty brawny boxer's stylish Elf dessert spoon of Leguizamo of courage	0		Moxie: +25, Muscle Percent: 30, Maximum MP: +10, Monster Level: +20, Spooky Resistance: +3, Last Available: "2023-12"
 11453	asbestos-lined Sinatra's Elf Guard SCUBA tank	0		Experience (Moxie): +5, Hot Resistance: +5, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	spinning free boots of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	spinning free boots of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	wholesome Elvish underarmor of the pedagogue of the storm	0		Experience: +3, Maximum HP Percent: +10, Maximum MP Percent: +40, Single Equip, Last Available: "2023-12"
 11458	healthy Crimbuccaneer bombjacket of the pedagogue	0		Experience: +3, Maximum HP Percent: +20, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	moldy sugarplum ration	3	crappy	Last Available: "2023-12"
 11460	adequate gingerbread nylons	4	good	Last Available: "2023-12"
 11461	flavorless rum-soaked fruitcake	3	decent	Last Available: "2023-12"
-11462	rotten half-sized lime	2	crappy	Last Available: "2023-12"
-11463	decent massive squat gingerbread pirate	7	good	Last Available: "2023-12"
+11462	half-sized rotten lime	2	crappy	Last Available: "2023-12"
+11463	massive decent squat gingerbread pirate	7	good	Last Available: "2023-12"
 11464	bland fruit-stuffed rumcake	4	decent	Last Available: "2023-12"
-11465	mediocre practically non-alcoholic tumbling squat mulled wine	1	decent	Last Available: "2023-12"
+11465	practically non-alcoholic mediocre tumbling squat mulled wine	1	decent	Last Available: "2023-12"
 11466	strong hand-crafted Swedish coffee	5	EPIC	Last Available: "2023-12"
 11467	drinkable olive canteen of eggnog	3	good	Last Available: "2023-12"
 11468	hand-crafted green hot wine	4	EPIC	Last Available: "2023-12"
 11469	lousy blurry Jamaican coffee	3	decent	Last Available: "2023-12"
 11470	bad weak fuchsia flask of egggrog	2	decent	Last Available: "2023-12"
-11471	ghostly cyan Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
+11471	cyan ghostly Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	lime green Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	huge pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	weak perfectly mixed yule grog	2	super EPIC	Last Available: "2023-12"
+11474	perfectly mixed weak yule grog	2	super EPIC	Last Available: "2023-12"
 11475	adequate super-sized shaking wet tack	5	good	Last Available: "2023-12"
 11476	spoiled whalecake	4	crappy	Last Available: "2023-12"
-11477	wobbly flame-retardant stanky vibrating gunwale whalegun	0		Maximum MP Percent: +10, Stench Spell Damage: +25, Hot Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	wobbly flame-retardant stanky vibrating gunwale whalegun	0		Maximum MP Percent: +10, Stench Spell Damage: +25, Hot Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	hand-crafted olive and claret	3	super EPIC	Last Available: "2023-12"
 11479	blinking rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	upside-down sharpshooter's beefy Elf Guard squirtgun	0		Muscle: +10, Critical Hit Percent: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	upside-down sharpshooter's beefy Elf Guard squirtgun	0		Muscle: +10, Critical Hit Percent: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	yellow chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	bouncing greedy sequin-encrusted sweater	0		Meat Drop: +20, Last Available: "2023-12"
 11484	wobbly executive ribald stiffened replica Elf Guard medal	0		Damage Reduction: 1, Sleaze Damage: +10, Meat Drop: +40, Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	super-liquefied military candy cane	0		Effect: "Milk Studly", Effect Duration: 20
 11503	double-improved concentrated groggipop	0		Effect: "Like a Fish to Walter", Effect Duration: 27
-11504	dog trainer's electrified moss mace	0		Experience (familiar): +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	fuchsia Samson's moss megaphone of Gandalf	0		Experience (Muscle): +5, Spell Critical Percent: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	blue weightlifter's moss medal of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	squat banded moss mitre of Leguizamo	0		Damage Absorption: +100, Monster Level: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	beefcake's moss mantle of Calamity Jane	0		Muscle: +25, Critical Hit Percent: +15, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	dog trainer's electrified moss mace	0		Experience (familiar): +1, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	fuchsia Samson's moss megaphone of Gandalf	0		Experience (Muscle): +5, Spell Critical Percent: +20, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	blue weightlifter's moss medal of Gandalf	0		Muscle: +15, Spell Critical Percent: +20, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	squat banded moss mitre of Leguizamo	0		Damage Absorption: +100, Monster Level: +20, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	beefcake's moss mantle of Calamity Jane	0		Muscle: +25, Critical Hit Percent: +15, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	mirror Sherlock's friendly moss marlinspike	0		Familiar Weight: +3, Item Drop: +25, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	vaporized wobbly blinking moss mulch	1		Last Available: "2024-12"
 11511	super-concentrated double-dry frozen tumbling moss floss	0		Effect: "Hyphemariffic", Effect Duration: 19
@@ -11372,12 +11372,12 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	twisted purple adobe assortment	1		Last Available: "2024-12"
 11519	concentrated adobe brittle	0		Effect: "Bloodstain-Resistant", Effect Duration: 22
-11520	clever personal trainer's beefy crepe paper phrygian cap	0		Muscle: +10, Experience Percent (Muscle): +10, Maximum MP: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	clever personal trainer's beefy crepe paper phrygian cap	0		Muscle: +10, Experience Percent (Muscle): +10, Maximum MP: +20, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	vibrating wizardly crepe paper parachute cape of wisdom	0		Mysticality: 40, Maximum MP Percent: +10, Last Available: "2025-12"
-11522	wobbly shaking Temple Grandin's personal trainer's slick crepe paper pie clip	0		Moxie: +10, Experience Percent (Muscle): +10, Familiar Weight: +7, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	crafty Socratic crepe paper puzzle cube of wisdom	0		Mysticality: +15, Experience (Mysticality): +1, Maximum MP: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	wobbly curative ruddy Newton's crepe paper plunge camisole	0		Experience (Mysticality): +3, Maximum HP Percent: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	shaking chilly groovy crepe paper polka charm of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50, Cold Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	wobbly shaking Temple Grandin's personal trainer's slick crepe paper pie clip	0		Moxie: +10, Experience Percent (Muscle): +10, Familiar Weight: +7, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	crafty Socratic crepe paper puzzle cube of wisdom	0		Mysticality: +15, Experience (Mysticality): +1, Maximum MP: +10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	wobbly curative ruddy Newton's crepe paper plunge camisole	0		Experience (Mysticality): +3, Maximum HP Percent: +40, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	shaking chilly groovy crepe paper polka charm of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50, Cold Damage: +5, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	modified wobbly crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	boiled chilled huge crepe paper peanut candy	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 24
 11528	smartaleck's petrified wood war pike of extreme caution	0		Moxie Percent: +30, Monster Level: -25, Last Available: "2025-12"
@@ -11390,15 +11390,15 @@
 11535	dry frozen petrified wood wafer praline	0		Effect: "Weasels Underfoot", Effect Duration: 57
 11536	mediocre cybeer	4	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	blurry wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	blurry wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	wool Crimbuccaneer war standard of temperance	0		Cold Resistance: +1, Sleaze Resistance: +5, Last Available: "2023-12"
 11544	teal nasty Oprah's Elf Guard war standard	0		Maximum MP Percent: +50, Stench Damage: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	skewed rosewater-soaked razor-sharp beefy spring shoes	0		Muscle: +10, Weapon Damage Percent: +25, Stench Resistance: +3, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	skewed rosewater-soaked razor-sharp beefy spring shoes	0		Muscle: +10, Weapon Damage Percent: +25, Stench Resistance: +3, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	super-quantum aerosolized blue ultra-soft ferns	0		Effect: "Booooooze", Effect Duration: 49, Last Available: "2024-02"
 11548	chilled double-aerosolized electrified tumbling crunchy brush	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 11, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11407,7 +11407,7 @@
 11552	high-tension exoskeleton	0		
 11553	ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
-11555	cyan mirror tumbling quick-release belt pouch	0		Single Equip
+11555	mirror tumbling cyan quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
 11557	quick-release utility belt	0		Single Equip
 11558	frosty motion sensor	0		Cold Spell Damage: +10, Single Equip
@@ -11426,12 +11426,12 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	moldy yam	4	crappy	Last Available: "2024-05"
-11574	tolerable irresponsibly strong yam martini	10	good	Last Available: "2024-05"
+11574	irresponsibly strong tolerable yam martini	10	good	Last Available: "2024-05"
 11575	lousy blue sweet potato o' mine	4	decent	Last Available: "2024-05"
 11576	bad special Southern yam	4	decent	Effect: "Towering Strength", Effect Duration: 40, Last Available: "2024-05"
 11577	bad sweet potato punch	3	decent	Last Available: "2024-05"
-11578	adequate snack-sized Mayam spinach	2	good	Last Available: "2024-05"
-11579	miniature decent yam and swiss	2	good	Last Available: "2024-05"
+11578	snack-sized adequate Mayam spinach	2	good	Last Available: "2024-05"
+11579	decent miniature yam and swiss	2	good	Last Available: "2024-05"
 11580	pulsating Usain Bolt's Annie Oakley's beefcake's yam cannon	0		Muscle: +25, Critical Hit Percent: +20, Initiative: +80, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11446,22 +11446,22 @@
 11591	red mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	small rotten mini kiwi	2	crappy	Last Available: "2024-06"
+11594	rotten small mini kiwi	2	crappy	Last Available: "2024-06"
 11595	narrow reassuring chaotic ruddy mini kiwi bikini	0		Maximum HP Percent: +40, Spell Critical Percent: +10, Spooky Resistance: +1, Last Available: "2024-06"
 11596	artisanal mini kiwitini	3	EPIC	Last Available: "2024-06"
 11597	upside-down mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	twirling mini kiwi aioli	0		
 11599	auspicious rosy-cheeked healthy mini kiwi silicon tiepin	0		Maximum HP Percent: 50, Item Drop: +10
 11600	mini kiwi tipi	0		
-11601	moldy thick mini kiwi digitized cookies	5	crappy	
-11602	practically non-alcoholic delicious mini kiwi intoxicating spirits	1	awesome	
+11601	thick moldy mini kiwi digitized cookies	5	crappy	
+11602	delicious practically non-alcoholic mini kiwi intoxicating spirits	1	awesome	
 11603	enhanced cold-filtered mini kiwi antimilitaristic hippy petition	0		Effect: "Extra Terrestrial", Effect Duration: 53
 11604	boiled modified mini kiwi illicit antibiotic	0		Effect: "Dreadful Sheen", Effect Duration: 62
 11605	wool healthy mini kiwi whipping stick	0		Maximum HP Percent: +20, Cold Resistance: +1
 11606	narrow wicked mini kiwi icepick	0		Spell Damage: +5
-11607	colloidal blurry shaking mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Dreadful Chill", Effect Duration: 44
+11607	colloidal shaking blurry mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Dreadful Chill", Effect Duration: 44
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	purple protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	huge protogenetic chunklet (flagellum)	0		
@@ -11470,14 +11470,14 @@
 11615	upside-down smelly stiffened Da Vinci's messenger bag RNA	0		Experience (Mysticality): +5, Damage Reduction: 1, Stench Spell Damage: +10
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	tiny moldy cyan skewed bacteria bisque	1	crappy	
+11618	moldy tiny cyan skewed bacteria bisque	1	crappy	
 11619	enchanted normal tiny ciliophora chowder	1	good	Effect: "Expert Vacationer", Effect Duration: 35
 11620	low-calorie decent cream of chloroplasts	1	good	
 11621	wobbly synaptic soup	0		
 11622	blinking muscular soup	0		
 11623	flagellate soup	0		
 11624	mirror elbow soup	0		
-11625	green mirror lip soup	0		
+11625	mirror green lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	extra ooze	0		
 11628	extra DNA	0		Experience (familiar): +1
@@ -11487,13 +11487,13 @@
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	bad high-proof Colera Peste Nebbiolo	7	decent	
+11635	high-proof bad Colera Peste Nebbiolo	7	decent	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	spinning Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
-11641	purple pulsating boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
+11641	pulsating purple boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	Sept-Ember Censer	0		Last Available: "2024-09"
 11643	blue blade of dismemberment of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
@@ -11509,8 +11509,8 @@
 11654	tumbling embering hunk	0		Last Available: "2024-09"
 11655	blurry soft cap of diminishing returns	0		
 11656	olive ghostly photo booth sized crate	0		Free Pull, Last Available: "2024-10"
-11657	wobbly red boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	mirror bat wings of Calamity Jane of Leguizamo of the glutton	0		Critical Hit Percent: +15, Monster Level: +20, Food Drop: +100, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11657	red wobbly boxed bat wings	0		Free Pull, Last Available: "2024-10"
+11658	mirror bat wings of Calamity Jane of Leguizamo of the glutton	0		Critical Hit Percent: +15, Monster Level: +20, Food Drop: +100, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	jittery ember	0		Cold Resistance: +1
 11661	smelly grievous monocle on a stick	0		Weapon Damage Percent: +50, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	electrified medical-grade Sheriff badge	0		MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	chaotic Sheriff pistol of courage	0		Spell Critical Percent: +10, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2024-10"
 11670	knitted fortified Sheriff moustache	0		Damage Absorption: +60, Cold Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	Da Vinci's supercool photo booth supply list	0		Moxie Percent: +20, Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	Da Vinci's supercool photo booth supply list	0		Moxie Percent: +20, Experience (Mysticality): +5, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	huge peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	spoiled whirled peas	3	crappy	Last Available: "2024-11"
@@ -11541,7 +11541,7 @@
 11686	red Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	twirling TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	sizzling experienced deft pirate hook	0		Experience: +2, Hot Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
-11689	Jack Frost's iron tricorn hat of the glutton	0		Cold Spell Damage: +50, Food Drop: +100, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	Jack Frost's iron tricorn hat of the glutton	0		Cold Spell Damage: +50, Food Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	ghostly lime green asbestos-lined jolly roger flag	0		Hot Resistance: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	narrow pirrrate's currrse	0		Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	ghostly pulsating governor's daughter's pearl hairpin of the businessman	0		Meat Drop: +50, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	upside-down chili powder cutlass of the sewer	0		Stench Damage: +25, Last Available: "2024-12"
-11701	rotten snack-sized Aztec tamale	2	crappy	Last Available: "2024-12"
+11701	snack-sized rotten Aztec tamale	2	crappy	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	wobbly pet rock	0		Last Available: "2024-12"
 11704	rosy-cheeked groggles	0		Maximum HP Percent: +30, Last Available: "2024-12"
@@ -11579,11 +11579,11 @@
 11724	fortified bad moai toai	5	decent	
 11725	green aromatic weightlifter's moaiball of the overflowing toilet	0		Muscle: +15, Stench Spell Damage: +50, Stench Resistance: +1, Last Available: "2024-12"
 11726	shaking olive half-digested rat	0		Last Available: "2024-12"
-11727	super-warmed anodized olive blurry four-leaf potato sprout	0		Effect: "Fishy", Effect Duration: 14, Last Available: "2024-12"
+11727	super-warmed anodized blurry olive four-leaf potato sprout	0		Effect: "Fishy", Effect Duration: 14, Last Available: "2024-12"
 11728	skewed mansplainer's Newton's potato jacket of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Monster Level: +15, Last Available: "2024-12"
 11729	narrow traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	careful military orb of the businessman	0		Monster Level: -10, Meat Drop: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	careful military orb of the businessman	0		Monster Level: -10, Meat Drop: +50, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	flattened diffused twirling gray rum ball	0		Effect: "Winklered", Effect Duration: 24
 11733	teal gravy skin	0		Last Available: "2024-12"
 11734	dance instructor's arcane researcher's gravyskin hat	0		Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Last Available: "2024-12"
@@ -11591,24 +11591,24 @@
 11736	careful brainy gravyskin skirt	0		Mysticality: +5, Monster Level: -10, Last Available: "2024-12"
 11737	twirling cyan horrifying healthy gravyskin pants	0		Maximum HP Percent: +20, Spooky Damage: +25, Last Available: "2024-12"
 11738	corrupted super-moist narrow crystallized pumpkin spice	0		Effect: "Oth-Jeal-O", Effect Duration: 31, Last Available: "2024-12"
-11739	snack-sized adequate wobbly room scale bean casserole	2	good	Last Available: "2024-12"
+11739	adequate snack-sized wobbly room scale bean casserole	2	good	Last Available: "2024-12"
 11740	blinking fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	Lo Pan's medical-grade hardened perfect Christmas scarf	0		Damage Reduction: [3*event(December)], Spell Critical Percent: [+30*event(December)], HP Regen Min: [7*event(December)], HP Regen Max: [10*event(December)], Single Equip, Last Available: "2024-12"
-11743	smartaleck's snowman-enchanting tophat of Tarzan	0		Moxie Percent: +30, Experience (Muscle): +3, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	smartaleck's snowman-enchanting tophat of Tarzan	0		Moxie Percent: +30, Experience (Muscle): +3, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	dry electrified shaking LIDAR candle	0		Effect: "Hennaliciousness", Effect Duration: 40, Last Available: "2024-12"
 11745	spinning smelly sage Congressional Medal of Insanity of the glutton	0		Mysticality Percent: +10, Stench Spell Damage: +10, Food Drop: +100, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	lousy red Easter grasshopper	4	decent	Last Available: "2024-12"
 11748	irresponsibly strong aged Irish eggnog	10	awesome	Last Available: "2024-12"
 11749	watered-down drinkable canteen of jungle juice	2	good	Last Available: "2024-12"
-11750	boozy enchanted aged blue turchucken	5	awesome	Effect: "Tremella Tremens", Effect Duration: 45, Last Available: "2024-12"
+11750	aged enchanted boozy blue turchucken	5	awesome	Effect: "Tremella Tremens", Effect Duration: 45, Last Available: "2024-12"
 11751	delicious red mechanically-mulled cider	3	awesome	Last Available: "2024-12"
 11752	lousy extra-dry holiday trip around the world	5	decent	Last Available: "2024-12"
 11753	flavorless chocolate ostrich egg	4	decent	Last Available: "2024-12"
 11754	half-sized normal beef and cabbage	2	good	Last Available: "2024-12"
-11755	gigantic flavorless candy rations	10	decent	Last Available: "2024-12"
-11756	huge spoiled double-candied yams	10	crappy	Last Available: "2024-12"
+11755	flavorless gigantic candy rations	10	decent	Last Available: "2024-12"
+11756	spoiled huge double-candied yams	10	crappy	Last Available: "2024-12"
 11757	tiny spoiled blinking Christmas ham	1	crappy	Last Available: "2024-12"
 11758	rotten huge holiday smorgasbord	10	crappy	Last Available: "2024-12"
 11759	fuchsia Bowl of Infinite Jelly	0		Last Available: "2024-12"
@@ -11624,33 +11624,33 @@
 11769	upside-down Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	censurious horrifying experienced savvy egg gun	0		Mysticality Percent: +20, Experience: +2, Spooky Damage: +25, Sleaze Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	censurious horrifying experienced savvy egg gun	0		Mysticality Percent: +20, Experience: +2, Spooky Damage: +25, Sleaze Resistance: +3, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	smelly lion tamer's careful army helmet of the scaredy-cat	0		Monster Level: -25, Experience (familiar): +2, Stench Spell Damage: +10, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
 11776	spoiled tumbling Thanksgiving ration	3	crappy	Last Available: "2024-12"
-11777	special drinkable weak Easter eggnog	2	good	Effect: "Sugar High", Effect Duration: 10, Last Available: "2024-12"
+11777	special weak drinkable Easter eggnog	2	good	Effect: "Sugar High", Effect Duration: 10, Last Available: "2024-12"
 11778	distilled wobbly bouncing bouncing clovermint	1		Effect: "Locks Like the Raven", Effect Duration: 20, Last Available: "2024-12"
 11779	medical-grade ruddy rock-hard nylon Christmas stockings of the pedagogue	0		Experience: +3, Damage Reduction: 5, Maximum HP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2024-12"
-11780	wobbly huge tattoo of two turkeys	0		Last Available: "2024-12"
+11780	huge wobbly tattoo of two turkeys	0		Last Available: "2024-12"
 11781	modified Vulcanized activated deviled candy egg	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 67, Last Available: "2024-12"
 11782	twirling McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	deadly McHugeLarge duffel bag of the cougar	0		Moxie: +20, Weapon Damage: +5, Last Available: "2025-01"
-11784	twirling greedy fireproof slick McHugeLarge left pole	0		Moxie: +10, Hot Resistance: +3, Meat Drop: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	perfumed sharpshooter's deadly McHugeLarge right pole	0		Weapon Damage: +5, Critical Hit Percent: +10, Stench Resistance: +5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	jittery razor-sharp beefcake's McHugeLarge left ski	0		Muscle: +25, Weapon Damage Percent: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	supercharged thinker's McHugeLarge right ski	0		Mysticality: +10, Maximum MP Percent: +30, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	twirling greedy fireproof slick McHugeLarge left pole	0		Moxie: +10, Hot Resistance: +3, Meat Drop: +20, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	perfumed sharpshooter's deadly McHugeLarge right pole	0		Weapon Damage: +5, Critical Hit Percent: +10, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	jittery razor-sharp beefcake's McHugeLarge left ski	0		Muscle: +25, Weapon Damage Percent: +25, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	supercharged thinker's McHugeLarge right ski	0		Mysticality: +10, Maximum MP Percent: +30, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	huge 0	0		Last Available: "2025-12"
 11790	boiled red narrow eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	cyan datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	mirror dedigitizer schematic: digibritches	0		Last Available: "2025-12"
-11797	huge bouncing dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
-11798	wobbly bouncing dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
+11797	bouncing huge dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
+11798	bouncing wobbly dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	narrow dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	upside-down dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
@@ -11658,14 +11658,14 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	ghostly malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	ghostly malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	blurry CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	blurry server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	ghostly huge logic grenade	0		Last Available: "2025-12"
 11812	diluted psilocyber mushroom	1		Effect: "Quiet 'n' Good", Effect Duration: 15, Last Available: "2025-12"
-11813	tumbling pulsating blurry dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
+11813	blurry pulsating tumbling dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
@@ -11675,18 +11675,18 @@
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
-11823	tumbling blurry STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
+11823	blurry tumbling STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	blinking parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	teal virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	bouncing ninja crampons	0		
 11832	huge ninja carabiner	0		
 11833	polymerized synthetic coffee	0		Effect: "Protection from Bad Stuff", Effect Duration: 12
-11834	colloidal unsweetened modified blinking blinking red iDrops	0		Effect: "Certainty", Effect Duration: 54
+11834	colloidal unsweetened modified blinking red blinking iDrops	0		Effect: "Certainty", Effect Duration: 54
 11835	twirling shame coil	0		
 11836	cyan ghostly shaking new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
@@ -11695,8 +11695,8 @@
 11840	ghostly phantom digit	0		
 11841	shaking foul line	0		
 11842	dark manioc	0		
-11843	squat ghostly Observer source code	0		
-11844	skewed red chill gherkin	0		
+11843	ghostly squat Observer source code	0		
+11844	red skewed chill gherkin	0		
 11845	narrow childrens' stapler	0		
 11846	plover's egg	0		
 11847	bouncing flyswatter	0		
@@ -11716,7 +11716,7 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	boiled scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	mirror table tennis ball	0		Last Available: "2025-03"
-11864	delicious weak pint of Leprechaun Stout	2	awesome	Last Available: "2025-03"
+11864	weak delicious pint of Leprechaun Stout	2	awesome	Last Available: "2025-03"
 11865	distilled tumbling phosphor traces	1		Last Available: "2025-03"
 11866	lime green crafting plans	0		Last Available: "2025-03"
 11867	huge Book of Irony	0		Skill: "Generate Irony"
@@ -11725,11 +11725,11 @@
 11870	bar dart	0		Last Available: "2025-03"
 11871	powdered leprechaun antidepressant pill	1		Effect: "Sweet Nostalgia", Effect Duration: 15, Last Available: "2025-03"
 11872	stale snack-sized gray Heck ramen	2	decent	Last Available: "2025-03"
-11873	snack-sized moldy burrito	2	crappy	Last Available: "2025-03"
+11873	moldy snack-sized burrito	2	crappy	Last Available: "2025-03"
 11874	normal small beer brat	4	good	Last Available: "2025-03"
 11875	decent bite-sized peach pie	1	good	Last Available: "2025-03"
 11876	adequate shaking incredible mini-pizza	4	good	Last Available: "2025-03"
-11877	drinkable watered-down Divine sidecar	2	good	Last Available: "2025-03"
+11877	watered-down drinkable Divine sidecar	2	good	Last Available: "2025-03"
 11878	drinkable weak tangarita sidecar	2	good	Last Available: "2025-03"
 11879	tolerable distilled gimlet sidecar	5	good	Last Available: "2025-03"
 11880	bad shaking vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
@@ -11741,7 +11741,7 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	concentrated energized spinning wet paper weights	0		Effect: "Eyes of the Dragon", Effect Duration: 46, Last Available: "2025-04"
 11888	drinkable triple-distilled Three Sheets to the Wind	10	good	Last Available: "2025-04"
-11889	bite-sized toothsome shaking pile of wet dates	1	awesome	Last Available: "2025-04"
+11889	toothsome bite-sized shaking pile of wet dates	1	awesome	Last Available: "2025-04"
 11890	skewed papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	twirling wet blanket	0		Last Available: "2025-04"
 11892	wet shower cap of the brute	0		Muscle Percent: +30, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	stylish bycocket of the early riser	0		Adventures: +7
 11917	narrow Thwaitgold mad hatterpillar statuette	0		
 11918	mirror packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	huge flak shield	0		Damage Reduction: 9
 11921	blue Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11779,11 +11779,11 @@
 11924	skewed manspreader's smartaleck's Axis helmet	0		Moxie Percent: +30, Monster Level: +10
 11925	deadly brawny Axis fatigues	0		Muscle Percent: +20, Weapon Damage: +5
 11926	greedy smelly Axis suspenders	0		Stench Spell Damage: +10, Meat Drop: +20, Single Equip
-11927	skewed spinning stolen artifact	0		
+11927	spinning skewed stolen artifact	0		
 11928	really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	chocolate rations	0		
-11931	tumbling wobbly nice nylon stockings	0		
+11931	wobbly tumbling nice nylon stockings	0		
 11932	ghostly Allied Radio Backpack Pack	0		Free Pull
 11933	friendly Allied Radio Backpack of wisdom of Flo-Jo	0		Mysticality: +15, Familiar Weight: +3, Initiative: +100, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
@@ -11797,7 +11797,7 @@
 11942	upside-down M&ouml;bius ring	0		Last Available: "2025-08"
 11943	jittery bone pacifier	0		Familiar Weight: +5
 11944	Temple Grandin's Van der Graaf hardy Allied Forces insignia	0		Maximum HP: +50, Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-11945	mirror lime green Allied Tattoo Kit	0		
+11945	lime green mirror Allied Tattoo Kit	0		
 11946	handheld Allied radio	0		
 11947	Axis codebook	0		
 11948	diffused nitrogenated non-energized Life Goals Pamphlet	0		Effect: "Hangdog", Effect Duration: 13, Last Available: "2025-08"
@@ -11805,12 +11805,12 @@
 11950	stanky time cop top hat	0		Stench Spell Damage: +25, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	pickled twirling shaking mixed berry jelly	1		Effect: "Chunky", Effect Duration: 5, Last Available: "2025-08"
-11953	small bland mirror toast with mixed berry jelly	2	decent	Last Available: "2025-08"
+11953	bland small mirror toast with mixed berry jelly	2	decent	Last Available: "2025-08"
 11954	moldy cup of sugar	4	crappy	Last Available: "2025-08"
 11955	massive rotten Susie's cupcake	7	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	jittery slick the gun of the bloodbag of doom	0		Moxie: +10, Maximum HP: +100, Spooky Spell Damage: +50, Last Available: "2025-08"
-11958	spirit-forward acceptable narrow wine	5	good	Last Available: "2025-08"
+11958	acceptable spirit-forward narrow wine	5	good	Last Available: "2025-08"
 11960	upside-down really, really nice swimming trunks	0		
 11961	wobbly teal sand penny	0		
 11962	sharpshooter's undersea surveying goggles	0		Critical Hit Percent: +10, Lasts Until Rollover
@@ -11823,26 +11823,26 @@
 11969	fuchsia waterlogged scroll of healing	0		
 11970	sea gel	0		
 11971	electrified yellow octopus ink bladder	0		Effect: "Human-Plant Hybrid", Effect Duration: 67
-11972	squat skewed durable dolphin whistle	0		
+11972	skewed squat durable dolphin whistle	0		
 11973	tumbling Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	tumbling unblemished pearl	0		
 11977	squat curative dentadent	0		HP Regen Min: 3, HP Regen Max: 5
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	executive greedy chilly rosy-cheeked educational blood cubic zirconia of dire peril	0		Experience: +1, Weapon Damage: +20, Maximum HP Percent: +30, Cold Damage: +5, Meat Drop: 60, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	executive greedy chilly rosy-cheeked educational blood cubic zirconia of dire peril	0		Experience: +1, Weapon Damage: +20, Maximum HP Percent: +30, Cold Damage: +5, Meat Drop: 60, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	altered blood thinner	1		Effect: "Optimist Primal", Effect Duration: 10, Last Available: "2025-10"
 12045	delicious pheromone cocktail	4	awesome	Last Available: "2025-10"
 12046	spoiled spinal tapas	4	crappy	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	dog trainer's Lo Pan's quilted shrunken head	0		Damage Absorption: +40, Spell Critical Percent: +30, Experience (familiar): +1, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	dog trainer's Lo Pan's quilted shrunken head	0		Damage Absorption: +40, Spell Critical Percent: +30, Experience (familiar): +1, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	mediocre practically non-alcoholic squat Smoking Pope	1	decent	
-12053	decent enchanted low-calorie prize turkey	1	good	Effect: "Quantum of Moxie", Effect Duration: 40
+12052	practically non-alcoholic mediocre squat Smoking Pope	1	decent	
+12053	decent low-calorie enchanted prize turkey	1	good	Effect: "Quantum of Moxie", Effect Duration: 40
 12054	modified blurry medicinal gruel	1		Effect: "Shawarma Initiative", Effect Duration: 40
-12055	small bland full-sized pumpkin pie	2	decent	Last Available: "2025-11"
+12055	bland small full-sized pumpkin pie	2	decent	Last Available: "2025-11"
 12056	tolerable tumbling vodka cranberry sauce	3	good	Last Available: "2025-11"
 12057	colloidal spinning yammed candy	0		Effect: "Hiding in Plain Sight", Effect Duration: 32, Last Available: "2025-11"
 12058	adequate treasure chestnut	3	good	Last Available: "2025-12"
@@ -11870,7 +11870,7 @@
 12080	miser's weightlifter's devilbone flute	0		Muscle: +15, Meat Drop: +10, Last Available: "2026-12"
 12081	squat fuchsia forbidden devilbone rosary	0		Spell Damage Percent: +50, Single Equip, Last Available: "2026-12"
 12082	diluted wobbly devilbone chunks	1		Effect: "Crusty Head", Effect Duration: 45, Last Available: "2026-12"
-12083	ionized tumbling jittery lime green Gehenna tattoo	0		Effect: "Oth-Jeal-O", Effect Duration: 55
+12083	ionized lime green tumbling jittery Gehenna tattoo	0		Effect: "Oth-Jeal-O", Effect Duration: 55
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	tumbling burnt phalange	0		Last Available: "2025-12"
 12118	shaking burnt radius	0		Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	electrified colloidal boiling synovial fluid	0		Effect: "You Know When to Walk Away", Effect Duration: 28, Last Available: "2025-12"
 12132	knitted Annie Oakley's Fonzie's smoldering vertebra	0		Experience (Moxie): +1, Critical Hit Percent: +20, Cold Resistance: +3, Single Equip, Last Available: "2025-12"
 12133	maroon seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	Jack Frost's hot boning knife of the brazier of the businessman	0		Cold Spell Damage: +50, Hot Spell Damage: +25, Meat Drop: +50, Single Equip, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	Tesla ship's lantern	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 12170	rosewater-soaked heat-resistant harpoon pistol of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +3, Last Available: "2025-12"
 12171	yummy traditional gingerloaf	4	awesome	Last Available: "2025-12"
-12172	hand-crafted practically non-alcoholic Scotch and eggnog	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12172	practically non-alcoholic hand-crafted Scotch and eggnog	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12173	modified bouncing counterskeleton elixir	0		Effect: "Uncucumbered", Effect Duration: 69, Last Available: "2025-12"
 12174	perfectly mixed &quot;salvaged&quot; wine	3	EPIC	Last Available: "2025-12"
 12175	narrow The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	concentrated gummi fingerbone	0		Effect: "Ancestral Disapproval", Effect Duration: 31
 12179	curative glimmering crystal of the businessman	0		Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	shaking loose Meats	0		
 12184	narrow Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11947,10 +11947,10 @@
 12189	intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
 12191	squat unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
-12192	green mirror Pork Elf toiletries kit	0		Last Available: "2026-03"
+12192	mirror green Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	nitrogenated Pork Elf mouthwash	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 49, Last Available: "2026-03"
 12194	aerosolized super-Vulcanized Pork Elf deodorant	0		Effect: "Ooh, Sour!", Effect Duration: 25, Last Available: "2026-03"
-12195	super-chilled red jittery Pork Elf toothpaste	0		Effect: "Educated (Sorta)", Effect Duration: 42, Last Available: "2026-03"
+12195	super-chilled jittery red Pork Elf toothpaste	0		Effect: "Educated (Sorta)", Effect Duration: 42, Last Available: "2026-03"
 12196	blurry bolt of fabric	0		Last Available: "2026-03"
 12197	mansplainer's sharpshooter's and dress	0		Critical Hit Percent: +10, Monster Level: +15, Last Available: "2026-03"
 12198	lime green blurry rosy-cheeked boxer's and dress	0		Muscle Percent: +10, Maximum HP Percent: +30, Last Available: "2026-03"
@@ -11969,7 +11969,7 @@
 12211	MacGyver's hoverboard of the ox of terror	0		Muscle: +20, Maximum MP: +100, Spooky Spell Damage: +10, Single Equip, Last Available: "2026-03"
 12212	stiffened wizardly left shark fin	0		Mysticality: +25, Damage Reduction: 1, Item Drop: +5, Last Available: "2026-03"
 12213	family-friendly fitness tracking bracelet	0		Sleaze Resistance: +1, Single Equip, Last Available: "2026-03"
-12214	pickled blinking gray candy bone	1		
+12214	pickled gray blinking candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	normal gigantic discarded hot dog	9	good	Last Available: "2026-04"
@@ -11977,7 +11977,7 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	huge legendary noodles	0		Last Available: "2026-05"
-12226	miniature enchanted stale can of tuna	2	decent	Effect: "Briny Blood", Effect Duration: 25
+12226	miniature stale enchanted can of tuna	2	decent	Effect: "Briny Blood", Effect Duration: 25
 12227	stale mirror alien salad	3	decent	
 12228	snack-sized rotten ratbatatouille	2	crappy	
 12229	decent onigiri	3	good	
@@ -11989,18 +11989,18 @@
 12235	flavorless upside-down Frutti di Scatoletta	3	decent	Last Available: "2026-05"
 12236	toothsome Pesto alla Marziano	3	awesome	Last Available: "2026-05"
 12237	decent super-sized Arrattabbattabiata	5	good	Last Available: "2026-05"
-12238	moldy special red Orzo di Riso	3	crappy	Effect: "Pie in the Sky", Effect Duration: 25, Last Available: "2026-05"
+12238	special moldy red Orzo di Riso	3	crappy	Effect: "Pie in the Sky", Effect Duration: 25, Last Available: "2026-05"
 12239	normal small Pasta Grimavera	2	good	Last Available: "2026-05"
-12240	bland bite-sized Linguini Ubriacapa	1	decent	Last Available: "2026-05"
+12240	bite-sized bland Linguini Ubriacapa	1	decent	Last Available: "2026-05"
 12241	normal Formica e Pepe	3	good	Last Available: "2026-05"
-12242	enchanted low-calorie bland Tubetto Gelatto	1	decent	Effect: "Booing Radly", Effect Duration: 35, Last Available: "2026-05"
-12243	yummy miniature purple Gnocci Domani	2	awesome	Last Available: "2026-05"
+12242	low-calorie enchanted bland Tubetto Gelatto	1	decent	Effect: "Booing Radly", Effect Duration: 35, Last Available: "2026-05"
+12243	miniature yummy purple Gnocci Domani	2	awesome	Last Available: "2026-05"
 12244	shaking Thwaitgold wallet moth statuette	0		
-12245	jittery bouncing scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
+12245	bouncing jittery scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	tumbling second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	Van der Graaf hardy Space Soldier Helmet	0		Maximum HP: +50, MP Regen Min: 5, MP Regen Max: 7
-12253	tasty jumbo premium turkey leg	5	awesome	
+12253	jumbo tasty premium turkey leg	5	awesome	
 12254	lousy tumbling styrofoam cup of mead	3	decent	
 12255	fortified sword	0		Damage Absorption: +60
 12256	skewed staff of the cheetah	0		Initiative: +60
@@ -12017,7 +12017,7 @@
 12267	flimsy plastic breastplate of mayonnaise	0		Sleaze Spell Damage: +50
 12268	flimsy plastic shield of terror	0		Spooky Spell Damage: +10, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	Usain Bolt's educational beefcake's Portable Laughing Stock	0		Muscle: +25, Experience: +1, Initiative: +80, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	Usain Bolt's educational beefcake's Portable Laughing Stock	0		Muscle: +25, Experience: +1, Initiative: +80, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	narrow miser's flame-wreathed Rosewater's Staff of Anachronistic Churning	0		Mysticality Percent: +30, Hot Spell Damage: +10, Meat Drop: +10
 12272	stale miniature classic banana	2	decent	Last Available: "2026-07"
 12273	bland teal watermelon	3	decent	Last Available: "2026-07"
@@ -12038,11 +12038,11 @@
 12288	denatured Vulcanized squat quince quaff	0		Effect: "Shamboozled", Effect Duration: 47, Last Available: "2026-07"
 12289	magnetized Quickquince	0		Effect: "stats.enq", Effect Duration: 36, Last Available: "2026-07"
 12290	artisanal blue Quiskey Sour	4	EPIC	Last Available: "2026-07"
-12291	practically non-alcoholic artisanal Quincea&ntilde;era Cooler	1	super ultra mega turbo EPIC	Last Available: "2026-07"
+12291	artisanal practically non-alcoholic Quincea&ntilde;era Cooler	1	super ultra mega turbo EPIC	Last Available: "2026-07"
 12292	tolerable Roth IPA	4	good	Last Available: "2026-08"
 12293	underdraft protection of the sweet-tooth of the cheetah	0		Candy Drop: +100, Initiative: +60, Last Available: "2026-08"
 12294	yellow solvent	0		Last Available: "2026-08"
-12295	adequate super-sized soybean futures	5	good	Last Available: "2026-08"
+12295	super-sized adequate soybean futures	5	good	Last Available: "2026-08"
 12296	nitrogenated modified housing bubble	0		Effect: "Florid Cheeks", Effect Duration: 14, Last Available: "2026-08"
 12297	flattened Pixie-Swordz	0		Effect: "On a Roll", Effect Duration: 48
 12298	Sherlock's financial instrument of the brute	0		Muscle Percent: +30, Item Drop: +25, Last Available: "2026-08"
@@ -12057,7 +12057,7 @@
 12307	super-quantum mint	0		Effect: "Industrial Strength Starch", Effect Duration: 56, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
-12310	modified upside-down yellow toxic asset	1		Effect: "Sharp Weapon", Effect Duration: 40, Last Available: "2026-08"
+12310	modified yellow upside-down toxic asset	1		Effect: "Sharp Weapon", Effect Duration: 40, Last Available: "2026-08"
 12311	twisted intangible asset	1		Last Available: "2026-08"
 12312	powdered jittery liquid asset	1		Effect: "Drunk With Power", Effect Duration: 5, Last Available: "2026-08"
 12313	shaking gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Mongoose_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	weak lousy Petite Porter	2	decent	
--2	mediocre narrow yellow Scrawny Stout	4	decent	
--3	weak perfectly mixed mirror spinning Infinitesimal IPA	2	EPIC	
+-1	lousy weak Petite Porter	2	decent	
+-2	mediocre yellow narrow Scrawny Stout	4	decent	
+-3	perfectly mixed weak spinning mirror Infinitesimal IPA	2	EPIC	
 -4	mediocre eggnogtini	3	decent	
--5	practically non-alcoholic drinkable candycaine	1	good	
--6	perfectly mixed watered-down braincracker sweet	2	EPIC	
+-5	drinkable practically non-alcoholic candycaine	1	good	
+-6	watered-down perfectly mixed braincracker sweet	2	EPIC	
 -16	aged fermented honey	3	awesome	
 -17	mediocre high-proof moons-shine	9	decent	
--18	watered-down hand-crafted gin	2	EPIC	
+-18	hand-crafted watered-down gin	2	EPIC	
 -19	lousy wobbly ecto-nog	4	decent	
 -20	bad high-proof hot toady	9	decent	
--21	practically non-alcoholic bad hot choculate	1	decent	
+-21	bad practically non-alcoholic hot choculate	1	decent	
 -49	perfectly mixed huge Cyder	3	EPIC	
 -50	acceptable Oil Nog	4	good	
 -51	hand-crafted spirit-forward Hi-Octane Peppermint Jet Fuel	5	EPIC	
 -58	aged Grimacider	4	awesome	
 -59	hand-crafted mirror blurry Isotope Nog	3	EPIC	
 -60	fancy hand-crafted Mutagin 'n' Tonic	4	EPIC	
--70	practically non-alcoholic aged Gin and Herring	1	awesome	
--71	special lousy Black and Tan and Red All Over	3	decent	
--72	mediocre fortified Antarctic Ice Tea	5	decent	
+-70	aged practically non-alcoholic Gin and Herring	1	awesome	
+-71	lousy special Black and Tan and Red All Over	3	decent	
+-72	fortified mediocre Antarctic Ice Tea	5	decent	
 -76	practically non-alcoholic drinkable CRIMBCO Ribbon Candy Schnapps	1	good	
--77	fortified delicious CRIMBCO Egg Substitute Nog Substitute	5	awesome	
+-77	delicious fortified CRIMBCO Egg Substitute Nog Substitute	5	awesome	
 -78	watered-down drinkable CRIMBCO Extreme Braincracker Sour	2	good	
 -82	acceptable Horseradish-infused Vodka	3	good	
 -83	mediocre Jerkitini	4	decent	
 -84	delicious teal Desert Island Iced Tea	3	awesome	
 -88	artisanal Crimbo Saketini	4	EPIC	
--89	hand-crafted fancy practically non-alcoholic shaking Crimboku Drop	1	EPIC	
+-89	fancy hand-crafted practically non-alcoholic shaking Crimboku Drop	1	EPIC	
 -90	high-proof drinkable Flaming Crimbo Log	8	good	
--107	acceptable watered-down Fortified Eggnog Slurry	2	good	
+-107	watered-down acceptable Fortified Eggnog Slurry	2	good	
 -108	mediocre Hot Buttered Rum	3	decent	
--109	practically non-alcoholic hand-crafted gray Spicy Hot Chocolate	1	EPIC	
+-109	hand-crafted practically non-alcoholic gray Spicy Hot Chocolate	1	EPIC	

--- a/data/TCRS/TCRS_Disco_Bandit_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Mongoose_cafe_food.txt
@@ -1,18 +1,18 @@
 -1	spoiled snack-sized Peche a la Frog	2	crappy	
--2	enchanted moldy narrow yellow As Jus Gezund Heit	4	crappy	
--3	small tasty mirror spinning Bouillabaise Coucher Avec Moi	2	awesome	
--7	miniature normal enchanted gumdrop chow mein	2	good	
+-2	moldy enchanted yellow narrow As Jus Gezund Heit	4	crappy	
+-3	tasty small spinning mirror Bouillabaise Coucher Avec Moi	2	awesome	
+-7	normal enchanted miniature gumdrop chow mein	2	good	
 -8	flavorless tiny candy cane pizza	1	decent	
 -9	spoiled gingerbread stir-fry	4	crappy	
--10	rotten big twigs and gravel	5	crappy	
--11	rotten gigantic shoots and leaves	10	crappy	
+-10	big rotten twigs and gravel	5	crappy	
+-11	gigantic rotten shoots and leaves	10	crappy	
 -12	flavorless tumbling fuchsia bowl of unidentifiable goo	4	decent	
--13	special jumbo decent gingerbread massacre	5	good	
+-13	jumbo decent special gingerbread massacre	5	good	
 -14	bland It Came From Beyond Dessert	4	decent	
 -15	flavorless tumbling vampire cake	3	decent	
--52	decent thick fancy skewed Soylent Red and Green	5	good	
+-52	fancy thick decent skewed Soylent Red and Green	5	good	
 -53	rotten Disc-Shaped Nutrition Unit	4	crappy	
--54	bland half-sized Gingerborg Hive	2	decent	
+-54	half-sized bland Gingerborg Hive	2	decent	
 -61	moldy Candy Cane Surprise	3	crappy	
 -62	decent shaking Grimdrop Chow Mein	3	good	
 -63	bland Grimgerbread House	4	decent	
@@ -21,25 +21,25 @@
 -69	miniature normal Red Herring Velvet Cake	2	good	
 -73	tasty gigantic CRIMBCO Reconstituted Gruel	10	awesome	
 -74	thick flavorless green New and Improved CRIMBCO Reconstituted Gruel	5	decent	
--75	massive decent CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	9	good	
+-75	decent massive CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	9	good	
 -79	thick yummy Brussels Sprout Stir-Fry	5	awesome	
 -80	normal shaking Carrot, Cabbage, and Kale Pizza	4	good	
 -81	delicious Turnip and Rutabaga Pie	3	awesome	
 -85	moldy Rainbow Spider Fun Roll	4	crappy	
--86	flavorless fancy Vegas Volcano Lava Roll	3	decent	
+-86	fancy flavorless Vegas Volcano Lava Roll	3	decent	
 -87	stale Crazy Dragon Shogun Buddha Roll	3	decent	
 -92	jumbo decent bouncing basic hot dog	5	good	
 -93	decent savage macho dog	3	good	
 -94	yummy immense one with everything	6	awesome	
--95	moldy massive shaking sly dog	10	crappy	
+-95	massive moldy shaking sly dog	10	crappy	
 -96	rotten immense devil dog	7	crappy	
 -97	flavorless chilly dog	4	decent	
 -98	bland ghost dog	4	decent	
 -99	rotten junkyard dog	4	crappy	
--100	massive moldy wet dog	6	crappy	
+-100	moldy massive wet dog	6	crappy	
 -101	fancy spoiled half-sized sleeping dog	2	crappy	
 -102	small decent cyan optimal dog	2	good	
 -103	bland bouncing video games hot dog	3	decent	
 -104	delicious Peppermint Nutrition Block	3	awesome	
--105	jumbo spoiled wobbly olive Gingerbread Nutrition Block	5	crappy	
--106	yummy fancy half-sized bouncing Cinnamon Nutrition Block	2	awesome	
+-105	jumbo spoiled olive wobbly Gingerbread Nutrition Block	5	crappy	
+-106	half-sized fancy yummy bouncing Cinnamon Nutrition Block	2	awesome	

--- a/data/TCRS/TCRS_Disco_Bandit_Opossum.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Opossum.txt
@@ -19,8 +19,8 @@
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
 22	studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
-23	yellow wobbly chewing gum on a string	0		
-24	narrow skewed ten-leaf clover	0		
+23	wobbly yellow chewing gum on a string	0		
+24	skewed narrow ten-leaf clover	0		
 25	meat paste	0		
 26	Dolphin King's map	0		
 27	spider web	0		
@@ -37,13 +37,13 @@
 38	red narrow steel-toed Knob Goblin pants	0		Damage Reduction: 9, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	casino pass	0		
-41	practically non-alcoholic lousy ice-cold Sir Schlitz	1	decent	
+41	lousy practically non-alcoholic ice-cold Sir Schlitz	1	decent	
 42	bouncing hermit permit	0		
 43	worthless trinket	0		
 44	spinning worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	figurine	0		
-47	super-sized delicious hot buttered roll	5	awesome	
+47	delicious super-sized hot buttered roll	5	awesome	
 48	blinking heart of rock and roll	0		
 49	small adequate bowl of cottage cheese	2	good	
 50	careful Rock and Roll Legend	0		Monster Level: -10, Class: "Accordion Thief", Song Duration: 10
@@ -59,7 +59,7 @@
 60	forbidden Mace of the Tortoise	0		Spell Damage Percent: +50, Class: "Turtle Tamer"
 61	miniature flavorless fortune cookie	2	decent	
 62	ruddy oriole-feather headdress	0		Maximum HP Percent: +40, Familiar Effect: "atk, 3xVolley, cap 3"
-63	pulsating blinking yellow action figure body	0		
+63	blinking pulsating yellow action figure body	0		
 64	bouncing teal action figure head	0		
 65	Mighty Bjorn action figure	0		
 66	twig	0		
@@ -70,7 +70,7 @@
 71	mirror blue boxer's stakes	0		Muscle Percent: +10
 72	barskin hat of the businessman	0		Meat Drop: +50, Familiar Effect: "atk, 1xVolley, cap 13"
 73	barskin tent	0		
-74	blinking jittery Temple map	0		
+74	jittery blinking Temple map	0		
 75	purple sapling	0		
 76	ghostly Spooky-Gro fertilizer	0		
 77	olive stick of the brute	0		Muscle Percent: +30
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	staff of James Dean of doom	0		Experience (Moxie): +3, Spooky Spell Damage: +50
 104	ghostly scarecrow	0		
-105	moldy jittery blurry bowl of charms	3	crappy	
+105	moldy blurry jittery bowl of charms	3	crappy	
 106	ketchup	1	good	
 107	skewed catsup	1	decent	
 108	stick	0		
@@ -171,12 +171,12 @@
 172	spinning gnoll lips	0		
 173	olive taco shell	0		
 174	purple Gnollish casserole dish	0		
-175	big stale uncooked chorizo	5	decent	
+175	stale big uncooked chorizo	5	decent	
 176	blurry disembodied brain	0		
 177	brainy skull	0		
 178	shaking detective skull	0		
-179	decent half-sized chorizo taco	2	good	
-180	special tolerable practically non-alcoholic ice-cold fotie	1	good	Effect: "Egged On", Effect Duration: 5
+179	half-sized decent chorizo taco	2	good	
+180	practically non-alcoholic special tolerable ice-cold fotie	1	good	Effect: "Egged On", Effect Duration: 5
 181	baseball	0		
 182	purple batgut	0		
 183	shaking bat wing	0		
@@ -195,11 +195,11 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	shaking narrow rosy-cheeked ring	0		Maximum HP Percent: +30
-200	rotten small rat appendix kabob	2	crappy	
+200	small rotten rat appendix kabob	2	crappy	
 201	decent mirror bat wing kabob	4	good	
-202	moldy snack-sized blue carob chunks	2	crappy	
+202	snack-sized moldy blue carob chunks	2	crappy	
 203	herbs	0		
-204	adequate miniature carob chunk cookies	2	good	
+204	miniature adequate carob chunk cookies	2	good	
 205	secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	EPIC	
@@ -233,7 +233,7 @@
 235	upside-down fireproof Jack Frost's Bigger Bugfinder Blade	0		Cold Spell Damage: +50, Hot Resistance: +3
 236	Queue Du Coq cocktailcrafting kit	0		
 237	tolerable bottle of gin	4	good	
-238	bad special weak bottle of vodka	2	decent	Effect: "Healthy Blue Glow", Effect Duration: 25
+238	weak bad special bottle of vodka	2	decent	Effect: "Healthy Blue Glow", Effect Duration: 25
 239	stiffened Orcish baseball cap of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 1, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	cyan beefcake's Orcish cargo shorts of dire peril	0		Muscle: +25, Weapon Damage: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	ghostly healthy Orcish frat-paddle	0		Maximum HP Percent: +20
@@ -245,20 +245,20 @@
 247	fermenting powder	0		
 248	bad spinning salty dog	3	decent	
 249	watered-down acceptable bloody mary	2	good	
-250	bad watered-down screwdriver	2	decent	
-251	hand-crafted practically non-alcoholic martini	1	EPIC	
+250	watered-down bad screwdriver	2	decent	
+251	practically non-alcoholic hand-crafted martini	1	EPIC	
 252	practically non-alcoholic mediocre bloody beer	1	decent	
-253	delicious twirling green shot of schnapps	4	awesome	
+253	delicious green twirling shot of schnapps	4	awesome	
 254	lousy shot of grapefruit schnapps	3	decent	
-255	weak lousy wobbly fine wine	2	decent	
+255	lousy weak wobbly fine wine	2	decent	
 256	drinkable skewed shot of tomato schnapps	3	good	
-257	practically non-alcoholic aged fancy extra-spicy bloody mary	1	awesome	Effect: "Stone-Faced", Effect Duration: 5
+257	fancy aged practically non-alcoholic extra-spicy bloody mary	1	awesome	Effect: "Stone-Faced", Effect Duration: 5
 258	blurry dense meat stack	0		
 259	snake skin	0		
 260	yummy White Citadel fries	3	awesome	
-261	small delicious White Citadel burger	2	awesome	
+261	delicious small White Citadel burger	2	awesome	
 262	yummy squat piece of wedding cake	3	awesome	
-263	snack-sized normal spinning blue chocolate chips	2	good	
+263	normal snack-sized blue spinning chocolate chips	2	good	
 264	flavorless chocolate chip cookies	3	decent	
 265	satin pants of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	practically non-alcoholic hand-crafted ghostly lightning	1	super EPIC	
@@ -267,13 +267,13 @@
 269	fuchsia avaricious sword	0		Meat Drop: +30
 270	picket fence	0		
 271	mixed barbell	1		
-272	compressed blue squat concentrated magicalness pill	1		
+272	compressed squat blue concentrated magicalness pill	1		
 273	twisted blinking spinning moxie weed	1		
 274	wobbly Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	pickled jittery blinking extra-strength strongness elixir	1		
-278	diluted squat upside-down olive jug-o-magicalness	1		
+277	pickled blinking jittery extra-strength strongness elixir	1		
+278	diluted squat olive upside-down jug-o-magicalness	1		
 279	boiled blurry suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	baleful gasmask	0		Spell Damage: +25, Familiar Effect: "1xBarrr, cap 12"
@@ -306,18 +306,18 @@
 308	Knob Goblin elite helm of the cheetah	0		Initiative: +60, Familiar Effect: "2xFairy, cap 15"
 309	wobbly teal perfumed Knob Goblin elite pants	0		Stench Resistance: +5, Familiar Effect: "2xBarrr, cap 15"
 310	shaking manspreader's Knob Goblin elite polearm	0		Monster Level: +10
-311	cyan squat hill of beans	0		
+311	squat cyan hill of beans	0		
 312	Knob Goblin visor of the bloodbag	0		Maximum HP: +100, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	Herculean Crown of the Goblin King	0		Experience (Muscle): +1, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	rotten bean burrito	3	crappy	
 315	small decent squat bean burrito	2	good	
-316	yummy special massive insanely bean burrito	9	awesome	Effect: "Nothing Is Impossible", Effect Duration: 50
+316	special yummy massive insanely bean burrito	9	awesome	Effect: "Nothing Is Impossible", Effect Duration: 50
 317	normal bean burrito	3	good	
-318	normal big bean burrito	5	good	
+318	big normal bean burrito	5	good	
 319	stale insanely bean burrito	4	decent	
 320	snack-sized normal bat haggis	2	good	
-321	thick moldy menudo	5	crappy	
-322	rotten miniature blinking goat cheese	2	crappy	
+321	moldy thick menudo	5	crappy	
+322	miniature rotten blinking goat cheese	2	crappy	
 323	toothsome blinking plain pizza	4	awesome	
 324	spoiled sausage pizza	3	crappy	
 325	spoiled mirror narrow goat cheese pizza	4	crappy	
@@ -326,8 +326,8 @@
 328	practically non-alcoholic tolerable bottle of whiskey	1	good	
 329	Sinatra's goat beard	0		Experience (Moxie): +5, Familiar Effect: "atk, 1xPotato, cap 15"
 330	yellow glass of goat's milk	1	good	
-331	watered-down delicious narrow Canadian	2	awesome	
-332	big bland lime green lemon	5	decent	
+331	delicious watered-down narrow Canadian	2	awesome	
+332	bland big lime green lemon	5	decent	
 333	normal lime	3	good	
 334	clever sabre teeth	0		Maximum MP: +20
 335	sabre-toothed lime cub	0		
@@ -345,7 +345,7 @@
 347	blinking Dyspepsi-Cola	0		
 348	therapeutic ninja mask	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
-350	squat blue huge hot katana blade	0		
+350	huge blue squat hot katana blade	0		
 351	careful Socratic icy-hot katana	0		Experience (Mysticality): +1, Monster Level: -10
 352	pulsating weightlifter's ninja hot pants	0		Muscle: +15, Familiar Effect: "hot atk, 3xPotato, cap 17"
 353	ninja stars	0		
@@ -353,7 +353,7 @@
 355	eXtreme scarf of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	upside-down smooth snowboarder pants	0		Moxie: +15, Familiar Effect: "1xPotato, cap 25"
 357	spinning Mountain Stream soda	0		
-358	stale small gr8ps	2	decent	
+358	small stale gr8ps	2	decent	
 359	immense bland gray t8r tots	8	decent	
 360	Socratic miner's helmet	0		Experience (Mysticality): +1, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	beefy miner's pants	0		Muscle: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -404,7 +404,7 @@
 406	pirate pelvis	0		
 407	pirate skull	0		
 408	tumbling pirate skeleton	0		
-409	ghostly spinning vial of patchouli oil	0		
+409	spinning ghostly vial of patchouli oil	0		
 410	beefcake's sk8board	0		Muscle: +25
 411	bouncing Jolly Roger charrrm	0		
 412	barrrnacle	0		
@@ -416,7 +416,7 @@
 418	aerosolized purple spinning Ferrigno's Elixir of Power	0		Effect: "Very Clean Teeth", Effect Duration: 19
 419	warmed alkaline huge serum of sarcasm	0		Effect: "Thick-Skinned", Effect Duration: 64
 420	aerosolized galvanized tomato juice of powerful power	0		Effect: "Healthy Red Glow", Effect Duration: 50
-421	warmed electrified skewed olive philter of phorce	0		Effect: "Red Door Syndrome", Effect Duration: 42
+421	warmed electrified olive skewed philter of phorce	0		Effect: "Red Door Syndrome", Effect Duration: 42
 422	flattened concentrated potion of potency	0		Effect: "Butt-Rock Hair", Effect Duration: 22
 423	liquefied spinning cordial of concentration	0		Effect: "The Q Is Talking To You", Effect Duration: 14
 424	dry vacuum-sealed gray ointment of the occult	0		Effect: "Meatwise", Effect Duration: 24
@@ -462,11 +462,11 @@
 464	blurry pixel potion	0		
 465	squat pixel potion	0		
 466	upside-down pixel potion	0		
-467	adequate jumbo green pixel pie	5	good	
+467	jumbo adequate green pixel pie	5	good	
 468	ruby W	0		
 469	wussiness potion	0		
-470	perfectly mixed enchanted watered-down Imp Ale	2	EPIC	Effect: "Spookypants", Effect Duration: 40
-471	gigantic spoiled fancy tumbling hot wing	7	crappy	Effect: "Spooky Blur", Effect Duration: 30
+470	enchanted watered-down perfectly mixed Imp Ale	2	EPIC	Effect: "Spookypants", Effect Duration: 40
+471	fancy gigantic spoiled tumbling hot wing	7	crappy	Effect: "Spooky Blur", Effect Duration: 30
 472	huge stanky diamond-studded cane	0		Stench Spell Damage: +25, Class: "Disco Bandit"
 473	tumbling lard-coated crutch	0		Sleaze Spell Damage: +25
 474	cast	0		
@@ -493,15 +493,15 @@
 495	blue catgut	0		
 496	mirror cat appendix	0		
 497	gnatwing	0		
-498	adequate half-sized skewed papaya	2	good	
+498	half-sized adequate skewed papaya	2	good	
 499	red wobbly extremely unsafe razor-sharp denim axe	0		Weapon Damage Percent: 125
 500	Elf Farm Raffle ticket	0		
-501	bland fancy miniature Elfin shortbread	2	decent	Effect: "Held Closer", Effect Duration: 25
+501	fancy bland miniature Elfin shortbread	2	decent	Effect: "Held Closer", Effect Duration: 25
 502	pagoda plans	0		
 503	bite-sized stale purple skewered cat appendix	1	decent	
 504	pulsating evil arches	0		
 505	Jeselnik's gnatwing earring of mayonnaise	0		Sleaze Damage: +25, Sleaze Spell Damage: +50
-506	stale cyan squat Hell broth	3	decent	
+506	stale squat cyan Hell broth	3	decent	
 507	hale thunderrr guitarrr	0		Maximum HP: +20
 508	sonata	0		
 509	skewed Hey Deze nuts	0		
@@ -509,9 +509,9 @@
 511	spinning Jarlsberg's key lime	0		
 512	mirror Sneaky Pete's key lime	0		
 513	bland twirling Boris's key lime pie	4	decent	
-514	decent jumbo Jarlsberg's key lime pie	5	good	
-515	stale thick pulsating blinking Sneaky Pete's key lime pie	5	decent	
-516	skewed tumbling Hey Deze map	0		
+514	jumbo decent Jarlsberg's key lime pie	5	good	
+515	stale thick blinking pulsating Sneaky Pete's key lime pie	5	decent	
+516	tumbling skewed Hey Deze map	0		
 517	ghostly Annie Oakley's bejeweled accordion strap	0		Critical Hit Percent: +20, Class: "Accordion Thief"
 518	ghostly mystery juice	0		
 519	spinning moxie magnet	0		
@@ -532,7 +532,7 @@
 534	abridged dictionary	0		
 535	bridge	0		
 536	dictionary	0		
-537	huge blinking pr0n legs	0		
+537	blinking huge pr0n legs	0		
 538	yellow zippy f3d0r4	0		Initiative: +20, Familiar Effect: "atk, 1xLep, cap 27"
 539	lowercase N	0		
 540	extra-electrified ionized Tasty Fun Good rice candy	0		Effect: "Hustlin'", Effect Duration: 28
@@ -549,17 +549,17 @@
 551	64067 scroll	0		
 552	bouncing 64735 scroll	0		
 553	31337 scroll	0		
-554	half-sized moldy pr0n cocktail	2	crappy	
+554	moldy half-sized pr0n cocktail	2	crappy	
 555	blinking lard-coated horrifying drywall axe	0		Spooky Damage: +25, Sleaze Spell Damage: +25
 556	Pine-Fresh air freshener of Gandalf	0		Spell Critical Percent: +20
 557	drinkable extra-dry narrow whiskey and cola	5	good	
 558	moldy miniature papaya taco	2	crappy	
 559	blinking razor-sharp can lid	0		
-560	massive decent stalk of asparagus	7	good	
+560	decent massive stalk of asparagus	7	good	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	acceptable watered-down Mad Train wine	2	good	
+564	watered-down acceptable Mad Train wine	2	good	
 565	bouncing lard-coated hobo gloves	0		Sleaze Spell Damage: +25, Single Equip
 566	Temple Grandin's bum cheek	0		Familiar Weight: +7, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	yellow hermit script	0		
@@ -572,10 +572,10 @@
 574	flavorless noodles	4	decent	
 575	low-calorie adequate painful penne pasta	1	good	
 576	spoiled ravioli della hippy	4	crappy	
-577	normal thick fuchsia pr0n m4nic0tti	5	good	
+577	thick normal fuchsia pr0n m4nic0tti	5	good	
 578	tasty Hell ramen	4	awesome	
-579	moldy massive boring spaghetti	8	crappy	
-580	shaking mirror huge sauce of the ages	0		
+579	massive moldy boring spaghetti	8	crappy	
+580	shaking huge mirror sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	tasty fettucini Inconnu	3	awesome	
@@ -584,7 +584,7 @@
 586	nasty wizardly ridiculously huge sword	0		Mysticality: +25, Stench Damage: +5
 587	liquefied shaking super-spiky hair gel	0		Effect: "Be a Mind Master", Effect Duration: 13
 588	soft echo eyedrop antidote	0		
-589	immense rotten cocoa eggshell fragment	10	crappy	
+589	rotten immense cocoa eggshell fragment	10	crappy	
 590	spoiled gigantic cocoa eggshell fragment	6	crappy	
 591	cocoa egg	0		
 592	house	0		
@@ -605,11 +605,11 @@
 607	bouncing Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
 609	lime green S.O.C.K.	0		
-610	cyan ghostly procrastination potion	0		
+610	ghostly cyan procrastination potion	0		
 611	lime green D	0		
 612	blurry original G	0		
 613	mirror plot hole	0		
-614	ionized jittery upside-down probability potion	0		Effect: "Red Door Syndrome", Effect Duration: 13
+614	ionized upside-down jittery probability potion	0		Effect: "Red Door Syndrome", Effect Duration: 13
 615	spinning chaos butterfly	0		
 616	twirling furry fur	0		
 617	unsweetened blurry Angry Farmer candy	0		Effect: "Neuromancy", Effect Duration: 64
@@ -668,7 +668,7 @@
 670	huge brawny lihc face	0		Muscle Percent: +20, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	spinning reassuring savvy grave robbing shovel	0		Mysticality Percent: +20, Spooky Resistance: +1
 672	bland cranberries	3	decent	
-673	mediocre watered-down special tumbling vodka and cranberry	2	decent	Effect: "Empty Inside", Effect Duration: 50
+673	special mediocre watered-down tumbling vodka and cranberry	2	decent	Effect: "Empty Inside", Effect Duration: 50
 674	artisanal whiskey	3	EPIC	
 675	skull of the Bonerdagon of the pedagogue	0		Experience: +3
 676	ghostly dragonbone belt buckle	0		
@@ -676,8 +676,8 @@
 678	cyan chest of the Bonerdagon	0		
 679	tolerable squat roll in the hay	3	good	
 680	perfectly mixed pulsating slap and tickle	3	EPIC	
-681	watered-down artisanal slip 'n' slide	2	EPIC	
-682	practically non-alcoholic bad a sump'm sump'm	1	decent	
+681	artisanal watered-down slip 'n' slide	2	EPIC	
+682	bad practically non-alcoholic a sump'm sump'm	1	decent	
 683	tolerable distilled horizontal tango	5	good	
 684	mediocre distilled pink pony	5	decent	
 685	cyan blurry knitted vibrating stylish Mr. Shirt	0		Moxie: +25, Maximum MP Percent: +10, Cold Resistance: +3
@@ -721,7 +721,7 @@
 725	blinking one million meat pancakes	0		
 726	narrow grievous huge mirror shard	0		Weapon Damage Percent: +50
 727	hedge maze puzzle	0		
-728	spinning huge bouncing hedge maze key	0		
+728	bouncing spinning huge hedge maze key	0		
 729	blue fishbowl	0		
 730	fishtank	0		
 731	mirror fish hose	0		
@@ -735,7 +735,7 @@
 739	upside-down tambourine bells	0		
 740	tambourine of Gandalf	0		Spell Critical Percent: +20
 741	broken skull	0		
-742	big flavorless Knoll shroomkabob	5	decent	
+742	flavorless big Knoll shroomkabob	5	decent	
 743	immense tasty mushroom	7	awesome	
 744	oxidized cold-filtered liquefied bouncing hair spray	0		Effect: "Sticks and Stones", Effect Duration: 33
 746	stat script	0		
@@ -744,11 +744,11 @@
 749	tasty olive warm mushroom	4	awesome	
 750	decent mushroom quesadilla	3	good	
 751	adequate cool mushroom	3	good	
-752	immense normal cool mushroom casserole	6	good	
+752	normal immense cool mushroom casserole	6	good	
 753	delicious pointy mushroom	3	awesome	
 754	rotten skewed cream of pointy mushroom soup	3	crappy	
 755	spoiled thick twirling mushroom	5	crappy	
-756	big bland blue shaking mushroom	5	decent	
+756	bland big blue shaking mushroom	5	decent	
 757	stale squat mushroom	4	decent	
 758	diet bland tumbling ghost cucumber	1	decent	
 759	dill	0		
@@ -776,12 +776,12 @@
 781	concentrated non-modified mafia aria	0		Effect: "Saucegoggles", Effect Duration: 33
 782	blinking blue wobbly Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	weak bad Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
+784	bad weak Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	rotten gray strawberry	4	crappy	
 787	artisanal red bottle of rum	3	EPIC	
 788	lousy fuchsia strawberry daiquiri	3	decent	
-789	acceptable spirit-forward rum and cola	5	good	
+789	spirit-forward acceptable rum and cola	5	good	
 790	hand-crafted grog	4	EPIC	
 791	blue medical-grade Mafia bow tie of Gandalf	0		Spell Critical Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10"
 792	frightening Golden Mr. Accessory	0		Spooky Damage: +5, Softcore Only
@@ -797,17 +797,17 @@
 804	decent big Knoll stir-fry	5	good	
 805	decent ghostly stir-fry	3	good	
 806	moldy asparagus stir-fry	4	crappy	
-807	decent thick fancy olive stir-fry	5	good	Effect: "Walberg's Dim Bulb", Effect Duration: 20
+807	decent fancy thick olive stir-fry	5	good	Effect: "Walberg's Dim Bulb", Effect Duration: 20
 808	spoiled Knob sausage stir-fry	3	crappy	
 809	decent bat wing stir-fry	3	good	
-810	normal huge rat appendix stir-fry	6	good	
+810	huge normal rat appendix stir-fry	6	good	
 811	decent tofu stir-fry	3	good	
 812	stale pr0n stir-fry	4	decent	
 813	normal Knob shells	3	good	
-814	huge moldy mirror b&auml;tzle	10	crappy	
+814	moldy huge mirror b&auml;tzle	10	crappy	
 815	immense toothsome ratini	6	awesome	
 816	rotten bite-sized Knob stroganoff	1	crappy	
-817	gigantic rotten twirling spinning menudo ravioli	10	crappy	
+817	gigantic rotten spinning twirling menudo ravioli	10	crappy	
 818	plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
@@ -826,14 +826,14 @@
 833	Jack Frost's vorpal blade	0		Cold Spell Damage: +50
 834	energetic medical-grade cornuthaum	0		Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	ring of aggravate monster of the overflowing toilet	0		Stench Spell Damage: +50
-836	adequate enchanted snack-sized mind flayer corpse	2	good	Effect: "The Rich Get Richer", Effect Duration: 20
+836	adequate snack-sized enchanted mind flayer corpse	2	good	Effect: "The Rich Get Richer", Effect Duration: 20
 837	perfectly mixed Uovo Marcio Shiraz	3	super EPIC	Last Available: "2004-10"
 838	reassuring hardy Mafia stogie	0		Maximum HP: +50, Spooky Resistance: +1, Last Available: "2004-10"
 839	drinkable weak Maiali Sifilitici Pinot Noir	2	good	Last Available: "2004-10"
 840	smelly Oprah's Mafia violin case	0		Maximum MP Percent: +50, Stench Spell Damage: +10, Last Available: "2004-10"
-841	acceptable fancy high-proof tomato daiquiri	6	good	Effect: "Heavily Breathing", Effect Duration: 20
+841	fancy acceptable high-proof tomato daiquiri	6	good	Effect: "Heavily Breathing", Effect Duration: 20
 842	tolerable beertini	3	good	
-843	drinkable practically non-alcoholic salty slug	1	good	
+843	practically non-alcoholic drinkable salty slug	1	good	
 844	mediocre weak special papaya slung	2	decent	Effect: "Gr8ness", Effect Duration: 30
 845	MAHI fez of the bloodbag	0		Maximum HP: +100, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -878,7 +878,7 @@
 887	green leaf	0		
 888	maple leaf	0		
 889	Oprah's balaclava	0		Maximum MP Percent: +50, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	half-sized moldy balaclava baklava	2	crappy	
+890	moldy half-sized balaclava baklava	2	crappy	
 891	olive fireproof Warehouse 23 bling	0		Hot Resistance: +3
 892	ghostly greasy resourceful weightlifter's bugbear-smiting sword	0		Muscle: +15, Maximum MP: +50, Sleaze Spell Damage: +10
 893	hand-crafted lumbering jack	3	EPIC	
@@ -894,7 +894,7 @@
 903	acceptable Spasmi Dolorosi Del Rene Champagne	3	good	Last Available: "2004-10"
 904	therapeutic hardy school Mafia knickerbockers of the businessman	0		Maximum HP: +50, Meat Drop: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	pickled triple-diffused moist Yummy Tummy bean	0		Effect: "Steroid Boost", Effect Duration: 61
-906	double-chilled yellow narrow tumbling Rock Pops	0		Effect: "Wet and Greedy", Effect Duration: 32
+906	double-chilled narrow tumbling yellow Rock Pops	0		Effect: "Wet and Greedy", Effect Duration: 32
 907	modified super-alkaline Mr. Mediocrebar	0		Effect: "Innately Truthy", Effect Duration: 40
 908	irradiated spinning Cold Hots candy	0		Effect: "Elbow Sauce", Effect Duration: 22
 909	galvanized Wint-O-Fresh mint	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 20
@@ -909,7 +909,7 @@
 918	Radio Free Baseball Cap of the wise owl	0		Mysticality: +20, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	Radio Free Pants of extreme caution	0		Monster Level: -25, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	wobbly inspector's Radio Free Foil	0		Item Drop: +15, Last Available: "2006-07"
-921	moldy jumbo radio button candy	5	crappy	
+921	jumbo moldy radio button candy	5	crappy	
 922	spinning huge severed rocking horse head of the ox	0		Muscle: +20
 923	pulsating broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -918,7 +918,7 @@
 927	tolerable maroon Ferita Del Petto Zinfandel	4	good	Last Available: "2006-12"
 928	fuzzy bracelets of horror	0		Spooky Spell Damage: +25
 929	arse-shooting crossbow of dire peril	0		Weapon Damage: +20
-931	hand-crafted watered-down blinking spiced rum	2	EPIC	
+931	watered-down hand-crafted blinking spiced rum	2	EPIC	
 932	aged eggnog	3	awesome	
 933	spoiled blurry candy cane	4	crappy	
 934	bland upside-down gingerbread bugbear	3	decent	
@@ -937,7 +937,7 @@
 947	spinning skewered cherry	0		Last Available: "2004-12"
 948	lousy martini	4	decent	Last Available: "2004-12"
 949	bad grogtini	4	decent	Last Available: "2004-12"
-950	spirit-forward tolerable cherry bomb	5	good	Last Available: "2004-12"
+950	tolerable spirit-forward cherry bomb	5	good	Last Available: "2004-12"
 951	twirling extra special Crimbo stocking	0		Last Available: "2004-12"
 952	shaking mansplainer's hockey mask of bravery	0		Monster Level: +15, Spooky Resistance: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	yellow penguin-smacking club	0		Familiar Damage: +15
@@ -994,21 +994,21 @@
 1007	ghostly coconut shell of the cougar	0		Moxie: +20, Familiar Effect: "1xFairy, cap 7"
 1008	ice cubes of Leguizamo	0		Monster Level: +20
 1009	artisanal vodka martini	4	EPIC	
-1010	hand-crafted triple-distilled whiskey and soda	10	EPIC	
+1010	triple-distilled hand-crafted whiskey and soda	10	EPIC	
 1011	hand-crafted monkey wrench	3	EPIC	
 1012	delicious tequila sunrise	3	awesome	
 1013	watered-down artisanal special maroon margarita	2	EPIC	Effect: "Chunky", Effect Duration: 40
 1014	artisanal strawberry wine	3	EPIC	
-1015	watered-down bad jittery wine spritzer	2	decent	
+1015	bad watered-down jittery wine spritzer	2	decent	
 1016	mediocre perpendicular hula	4	decent	
 1017	hand-crafted lime green ducha de oro	3	EPIC	
-1018	special acceptable mirror calle de miel	3	good	Effect: "Devil Inside", Effect Duration: 40
+1018	acceptable special mirror calle de miel	3	good	Effect: "Devil Inside", Effect Duration: 40
 1019	mediocre dry vodka martini	4	decent	
-1020	triple-distilled special perfectly mixed old-fashioned	6	EPIC	Effect: "Weapon of Mass Destruction", Effect Duration: 30
+1020	triple-distilled perfectly mixed special old-fashioned	6	EPIC	Effect: "Weapon of Mass Destruction", Effect Duration: 30
 1021	weak perfectly mixed bouncing tequila with training wheels	2	EPIC	
 1022	drinkable red sangria	3	good	
 1023	watered-down delicious vesper	2	awesome	Last Available: "2004-12"
-1024	weak mediocre yellow bodyslam	2	decent	Last Available: "2004-12"
+1024	mediocre weak yellow bodyslam	2	decent	Last Available: "2004-12"
 1025	hand-crafted blinking sangria del diablo	4	EPIC	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	lime green whip kit	0		
@@ -1032,7 +1032,7 @@
 1046	toasty wicked traffic cone	0		Spell Damage: +5, Hot Damage: +5, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	hand-crafted pulsating N. O. Beer	3	EPIC	
 1048	denatured mirror oyster egg	1		
-1049	denatured bouncing ghostly oyster egg	1		
+1049	denatured ghostly bouncing oyster egg	1		
 1050	twisted oyster egg	1		
 1051	plastic oyster egg	0		
 1052	mixed oyster egg	1		Effect: "Superveiny 9000", Effect Duration: 40
@@ -1041,7 +1041,7 @@
 1055	plastic oyster egg	0		
 1056	twisted skewed blinking puce oyster egg	1		
 1057	vaporized jittery puce oyster egg	1		
-1058	vaporized wobbly bouncing puce oyster egg	1		
+1058	vaporized bouncing wobbly puce oyster egg	1		
 1059	bouncing puce plastic oyster egg	0		
 1060	vaporized spinning mauve oyster egg	1		Effect: "Go-Gone", Effect Duration: 20
 1061	pickled mirror huge mauve oyster egg	1		
@@ -1088,7 +1088,7 @@
 1102	targeting chip	0		
 1103	unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
-1105	tumbling olive clockwork bartender head	0		
+1105	olive tumbling clockwork bartender head	0		
 1106	clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	clockwork detective skull	0		
@@ -1123,16 +1123,16 @@
 1137	foul-smelling hardened bicycle chain	0		Damage Reduction: 3, Stench Damage: +10
 1138	mushroom fermenting solution	0		
 1139	bad mushroom wine	4	decent	
-1140	practically non-alcoholic tolerable bouncing icy mushroom wine	1	good	
+1140	tolerable practically non-alcoholic bouncing icy mushroom wine	1	good	
 1141	drinkable watered-down purple mushroom wine	2	good	
 1142	aged wobbly pointy mushroom wine	4	awesome	
 1143	artisanal flat mushroom wine	3	EPIC	
-1144	practically non-alcoholic bad cool mushroom wine	1	decent	
+1144	bad practically non-alcoholic cool mushroom wine	1	decent	
 1145	aged gray knob mushroom wine	3	awesome	
 1146	lousy practically non-alcoholic knoll mushroom wine	1	decent	
 1147	lousy mushroom wine	3	decent	
 1148	tolerable spinning yellow shot of flower schnapps	3	good	
-1149	big spoiled enchanted flower petal pie	5	crappy	Effect: "Flower Power", Effect Duration: 15
+1149	enchanted big spoiled flower petal pie	5	crappy	Effect: "Flower Power", Effect Duration: 15
 1150	tolerable practically non-alcoholic bottle of single-barrel whiskey	1	good	
 1151	Samson's groovy discarded plastic fork	0		Moxie Percent: +10, Experience (Muscle): +5
 1152	gray gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1188,12 +1188,12 @@
 1203	stale personalized birthday cake	3	decent	
 1204	decent three-tiered wedding cake	4	good	
 1205	normal babycakes	4	good	
-1206	super-sized yummy yellow velvet cake	5	awesome	
+1206	yummy super-sized yellow velvet cake	5	awesome	
 1207	decent congratulatory cake	3	good	
 1208	decent blinking angel-food cake	3	good	
 1209	adequate fuchsia devil's-food cake	3	good	
 1210	rotten huge birthday party jellybean cheesecake	3	crappy	
-1211	blurry blinking balloon	0		
+1211	blinking blurry balloon	0		
 1212	balloon	0		
 1213	skewed heart-shaped balloon	0		
 1214	anniversary balloon	0		
@@ -1236,9 +1236,9 @@
 1252	rotten shroomkabob	3	crappy	
 1253	mirror pile of jumping beans	0		
 1254	adequate blinking jumping bean burrito	3	good	
-1255	normal immense jumping bean burrito	8	good	
+1255	immense normal jumping bean burrito	8	good	
 1256	normal insanely jumping bean burrito	3	good	
-1257	special moldy rat scrapple	3	crappy	Effect: "From Nantucket", Effect Duration: 25
+1257	moldy special rat scrapple	3	crappy	Effect: "From Nantucket", Effect Duration: 25
 1258	blue pail of pretentious paint	0		
 1259	lard-coated traffic cone of Leguizamo	0		Monster Level: +20, Sleaze Spell Damage: +25, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	upside-down fuchsia wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
@@ -1248,7 +1248,7 @@
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
 1266	flavorless gloomy mushroom	3	decent	
-1267	narrow bouncing dead mimic	0		
+1267	bouncing narrow dead mimic	0		
 1268	pine wand	0		
 1269	red ebony wand	0		
 1270	fuchsia hexagonal wand	0		
@@ -1302,7 +1302,7 @@
 1318	mirror lovecat tail	0		
 1319	jittery plastic passion fruit	0		
 1320	fancy stale questionable taco	3	decent	Effect: "Chalky White Pallor", Effect Duration: 30
-1321	upside-down squat Doc's Miracle Cure	0		Last Available: "2011-12"
+1321	squat upside-down Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	maroon time helmet of the cougar	0		Moxie: +20, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
 1324	time trousers of the bloodbag	0		Maximum HP: +100, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
@@ -1319,7 +1319,7 @@
 1335	Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
 1338	shaking maroon Dyspepsi-Cola d-rations	0		
-1339	purple shaking Cloaca-Cola c-rations	0		
+1339	shaking purple Cloaca-Cola c-rations	0		
 1340	Cloaca-Cola-issue combat knife	0		
 1341	Dyspepsi-Cola-issue canteen of the sweet-tooth	0		Candy Drop: +100, Single Equip
 1342	picture of a dead guy's girlfriend	0		
@@ -1332,12 +1332,12 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	maroon 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	supercharged pinky ring	0		Maximum MP Percent: +30, Single Equip
-1352	bad watered-down redrum	2	decent	
+1352	watered-down bad redrum	2	decent	
 1353	jittery ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	normal fancy narrow bowl of oriole's nest soup	4	good	Effect: "Greasy Peasy", Effect Duration: 20
 1356	bunny liver	0		
-1357	weak aged Mt. Noob Pale Ale	2	awesome	
+1357	aged weak Mt. Noob Pale Ale	2	awesome	
 1358	squat pirate zombie head	0		Last Available: "2005-11"
 1359	blurry ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	mirror pirate zombie robot head	0		Last Available: "2005-11"
@@ -1345,7 +1345,7 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	blurry rhesus monkey	0		Familiar Weight: +5
-1365	rotten huge special wobbly gray tofurkey leg	7	crappy	Effect: "Helping Comes Second", Effect Duration: 5
+1365	rotten special huge gray wobbly tofurkey leg	7	crappy	Effect: "Helping Comes Second", Effect Duration: 5
 1366	enchanted moldy tofurkey gravy	4	crappy	Effect: "Corona de la Salsa", Effect Duration: 10
 1367	stale snack-sized herbal stuffing	2	decent	
 1368	delicious can-shaped gelatinous cranberry sauce	4	awesome	
@@ -1385,12 +1385,12 @@
 1403	blinking bouncing tumbling groovy can of fake snow	0		Moxie Percent: +10, Last Available: "2005-12"
 1404	narrow shaking ruddy colored-light &quot;necklace&quot;	0		Maximum HP Percent: +40, Last Available: "2005-12"
 1405	skewed upside-down fortified tree skirt	0		Damage Absorption: +60, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	tasty gigantic wreath-shaped Crimbo cookie	10	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	gigantic tasty wreath-shaped Crimbo cookie	10	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	rotten bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	normal massive tree-shaped Crimbo cookie	6	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	blinking mirror executive Unionize The Elves sign	0		Meat Drop: +40, Last Available: "2005-12"
 1410	fuchsia sleeping snowy owl	0		Last Available: "2005-12"
-1411	blinking purple Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	purple blinking Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	triple-activated improved green snowcone	0		Effect: "Cat-Alyzed", Effect Duration: 61, Last Available: "2006-01"
 1413	warmed gray snowcone	0		Effect: "Berry Statistical", Effect Duration: 24, Last Available: "2006-01"
 1414	wet snowcone	0		Effect: "Empty Inside", Effect Duration: 19, Last Available: "2006-01"
@@ -1398,7 +1398,7 @@
 1416	super-concentrated cold-filtered snowcone	0		Effect: "Scavengers Scavenging", Effect Duration: 67, Last Available: "2006-01"
 1417	boiled tarnished snowcone	0		Effect: "Peppermint Bite", Effect Duration: 53, Last Available: "2006-01"
 1418	skewed Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
-1419	shaking purple teddy bear sewing kit	0		Last Available: "2006-01"
+1419	purple shaking teddy bear sewing kit	0		Last Available: "2006-01"
 1420	hardened traffic cone of Flo-Jo	0		Damage Reduction: 3, Initiative: +100, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	fuchsia Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
@@ -1416,7 +1416,7 @@
 1434	pulsating fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
-1437	blinking teal useless powder	0		
+1437	teal blinking useless powder	0		
 1438	quadruple-polarized flattened pulsating twinkly powder	0		Effect: "Halloweeny", Effect Duration: 51
 1439	pressed non-unsweetened maroon hot powder	0		Effect: "Irresistible Resolve", Effect Duration: 51
 1440	warmed powder	0		Effect: "Dance Interpreter", Effect Duration: 35
@@ -1428,7 +1428,7 @@
 1446	colloidal shaking nuggets	0		Effect: "Creepin' Up on You", Effect Duration: 64
 1447	quantum modified nuggets	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 15
 1448	liquefied moist mirror stench nuggets	0		Effect: "Big Flaming Whip", Effect Duration: 44
-1449	flattened denatured skewed narrow sleaze nuggets	0		Effect: "Dancing Prowess", Effect Duration: 19
+1449	flattened denatured narrow skewed sleaze nuggets	0		Effect: "Dancing Prowess", Effect Duration: 19
 1450	denatured twinkly wad	1		
 1451	compressed bouncing hot wad	1		Effect: "Mer-kindliness", Effect Duration: 35
 1452	distilled wad	1		Effect: "Fitter, Happier", Effect Duration: 45
@@ -1466,7 +1466,7 @@
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	Jim Carey's rabbit's foot of the dark arts	0		Spell Damage Percent: +100, Monster Level: +25
 1486	massive bag of catnip	0		
-1487	wobbly blue hang glider	0		
+1487	blue wobbly hang glider	0		
 1488	March hat	0		Free Pull
 1489	jittery dormouse	0		
 1490	maroon friendly chopsticks of bravery	0		Familiar Weight: +3, Spooky Resistance: +5
@@ -1475,9 +1475,9 @@
 1493	flame-wreathed dog trainer's ridiculously overelaborate ninja weapon	0		Experience (familiar): +1, Hot Spell Damage: +10
 1494	tarnished moist huge sugar-coated pine cone	0		Effect: "You're Not Cooking", Effect Duration: 33, Last Available: "2020-09"
 1495	blinking tumbling avaricious ribald traffic cone	0		Sleaze Damage: +10, Meat Drop: +30, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	weak artisanal gloomy mushroom wine	2	super EPIC	
+1496	artisanal weak gloomy mushroom wine	2	super EPIC	
 1497	tolerable mushroom wine	3	good	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	spinning whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	vacuum-sealed electrified enhanced explosion-flavored chewing gum	0		Effect: "Ghostly Shell", Effect Duration: 19, Last Available: "2006-04"
@@ -1485,10 +1485,10 @@
 1503	ghostly blinking rubber emo roe	0		Last Available: "2006-04"
 1504	Vulcanized snowcone	0		Effect: "Comic Violence", Effect Duration: 29, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	delicious weak enchanted calle de miel with a fly in it	2	awesome	Effect: "Pasty", Effect Duration: 5, Last Available: "2006-04"
+1506	weak enchanted delicious calle de miel with a fly in it	2	awesome	Effect: "Pasty", Effect Duration: 5, Last Available: "2006-04"
 1507	lousy blurry rockin' wagon with a fly in it	3	decent	Last Available: "2006-04"
 1508	aged fuchsia perpendicular hula with a fly in it	4	awesome	Last Available: "2006-04"
-1509	smooth narrow tumbling slap and tickle with a fly in it	4	awesome	Last Available: "2006-04"
+1509	smooth tumbling narrow slap and tickle with a fly in it	4	awesome	Last Available: "2006-04"
 1510	maroon bag of airline peanuts	0		Last Available: "2006-04"
 1511	electrified fake hand	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-04"
 1512	boiled Knob Goblin pet-buffing spray	1		Effect: "Gr8ness", Effect Duration: 10
@@ -1503,7 +1503,7 @@
 1522	huge twirling resourceful smooth Radio Free Jersey	0		Moxie: +15, Maximum MP: +50
 1523	bottle of used blood	0		
 1524	pulsating wind-up chattering teeth	0		Last Available: "2006-04"
-1525	green wobbly joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	wobbly green joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	twirling diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	green lion tamer's corkscrew of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Last Available: "2006-04"
@@ -1528,56 +1528,56 @@
 1548	careful Gazpacho's Glacial Grimoire of the glutton	0		Monster Level: -10, Food Drop: +100
 1549	MSG	0		
 1550	pulsating ghostly second-hand knockoff engagement ring of the wise owl	0		Mysticality: +20, Single Equip
-1551	watered-down delicious bottle of Domesticated Turkey	2	awesome	
+1551	delicious watered-down bottle of Domesticated Turkey	2	awesome	
 1552	artisanal bottle of Definit	3	EPIC	
 1553	artisanal jittery bottle of Calcutta Emerald	3	EPIC	
-1554	lousy distilled bottle of Lieutenant Freeman	5	decent	
-1555	artisanal mirror jittery bottle of Jorge Sinsonte	3	EPIC	
+1554	distilled lousy bottle of Lieutenant Freeman	5	decent	
+1555	artisanal jittery mirror bottle of Jorge Sinsonte	3	EPIC	
 1556	tolerable watered-down fuchsia boxed champagne	2	good	
 1557	tasty miniature kumquat	2	awesome	
 1558	normal thick fuchsia tangerine	5	good	
 1559	narrow tonic water	0		
 1560	flavorless diet cocktail onion	1	decent	
-1561	half-sized spoiled raspberry	2	crappy	
+1561	spoiled half-sized raspberry	2	crappy	
 1562	normal lime green kiwi	3	good	
 1563	practically non-alcoholic acceptable maroon whiskey bittersweet	1	good	
 1564	drinkable mimosette	4	good	
-1565	mediocre strong tequila sunset	5	decent	
+1565	strong mediocre tequila sunset	5	decent	
 1566	tolerable zmobie	3	good	Wiki Name: "Zmobie (drink)"
-1567	drinkable practically non-alcoholic spinning blinking gray gin and tonic	1	good	
+1567	drinkable practically non-alcoholic spinning gray blinking gin and tonic	1	good	
 1568	fancy drinkable vodka and tonic	3	good	Effect: "Morninja", Effect Duration: 35
 1569	bad vodka gibson	3	decent	
 1570	hand-crafted gibson	3	EPIC	
-1571	practically non-alcoholic artisanal parisian cathouse	1	super EPIC	
+1571	artisanal practically non-alcoholic parisian cathouse	1	super EPIC	
 1572	smooth rabbit punch	3	awesome	
 1573	smooth tumbling caipifruta	4	awesome	
 1574	delicious ghostly teqiwila	3	awesome	
-1575	distilled smooth Divine	5	awesome	
+1575	smooth distilled Divine	5	awesome	
 1576	hand-crafted Gordon Bennett	3	EPIC	
 1577	drinkable tangarita	4	good	
 1578	delicious weak yellow mandarina colada	2	awesome	
 1579	mediocre gimlet	4	decent	
-1580	irresponsibly strong smooth brick road	8	awesome	
-1581	acceptable practically non-alcoholic vodka stratocaster	1	good	
+1580	smooth irresponsibly strong brick road	8	awesome	
+1581	practically non-alcoholic acceptable vodka stratocaster	1	good	
 1582	drinkable Neuromancer	3	good	
-1583	acceptable weak prussian cathouse	2	good	
+1583	weak acceptable prussian cathouse	2	good	
 1584	high-proof bad Mae West	10	decent	
 1585	hand-crafted Mon Tiki	3	EPIC	
 1586	practically non-alcoholic perfectly mixed skewed teqiwila slammer	1	super ultra mega turbo EPIC	
-1587	gigantic delicious bouncing Knob lo mein	10	awesome	
+1587	delicious gigantic bouncing Knob lo mein	10	awesome	
 1588	toothsome asparagus lo mein	3	awesome	
 1589	bland green Knoll lo mein	3	decent	
-1590	half-sized spoiled enchanted lo mein	2	crappy	Effect: "Texas Elegance", Effect Duration: 30
+1590	half-sized enchanted spoiled lo mein	2	crappy	Effect: "Texas Elegance", Effect Duration: 30
 1591	spoiled olive lo mein	4	crappy	
 1592	moldy olive tumbling hot hi mein	3	crappy	
-1593	massive rotten blue hi mein	8	crappy	
+1593	rotten massive blue hi mein	8	crappy	
 1594	huge tasty yellow hi mein	9	awesome	
-1595	diet decent special hi mein	1	good	Effect: "Big Meat Big Prizes", Effect Duration: 25
+1595	diet special decent hi mein	1	good	Effect: "Big Meat Big Prizes", Effect Duration: 25
 1596	adequate sleazy hi mein	4	good	
 1597	ghostly asbestos-lined Junior LAAAAME merit badge	0		Hot Resistance: +5, Last Available: "2006-05"
 1598	wicked Senior LAAAAME merit badge	0		Spell Damage: +5, Last Available: "2006-05"
 1599	upside-down jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	bad triple-distilled twirling tangarita with a fly in it	9	decent	
+1600	triple-distilled bad twirling tangarita with a fly in it	9	decent	
 1601	mediocre mandarina colada with a fly in it	3	decent	
 1602	acceptable squat tumbling prussian cathouse with a fly in it	3	good	
 1603	delicious Mae West with a fly in it	4	awesome	
@@ -1587,7 +1587,7 @@
 1607	magnetized libation of liveliness	0		Effect: "Black Lung", Effect Duration: 47
 1608	dry eyedrops of the ermine	0		Effect: "Category", Effect Duration: 64
 1609	deionized nitrogenated pulsating perfume of prejudice	0		Effect: "Hagnk's Gratitude", Effect Duration: 22
-1610	concentrated squat squat bouncing eyedrops of the ocelot	0		Effect: "Human-Slime Hybrid", Effect Duration: 32
+1610	concentrated bouncing squat squat eyedrops of the ocelot	0		Effect: "Human-Slime Hybrid", Effect Duration: 32
 1611	improved improved fuchsia squat potent potion of potency	0		Effect: "Chain Chain Chains", Effect Duration: 61
 1612	dry pulsating concentrated cordial of concentration	0		Effect: "Executive Greed", Effect Duration: 60
 1613	red jittery smooth coffin lid	0		Moxie: +15, Damage Reduction: 3
@@ -1611,7 +1611,7 @@
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	Spanish fly	0		
-1634	distilled smooth gray huge around the world	5	awesome	
+1634	distilled smooth huge gray around the world	5	awesome	
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	oxidized non-diffused lotion of hotness	0		Effect: "Human-Goblin Hybrid", Effect Duration: 68
@@ -1628,9 +1628,9 @@
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	bland small shaking foie gras	2	decent	
-1652	denatured altered jittery fuchsia candy brain	0		Effect: "Piratey Flavor", Effect Duration: 27, Last Available: "2020-09"
-1653	shaking greedy inspector's deadly jewel-eyed wizard hat	0		Weapon Damage: +5, Item Drop: +15, Meat Drop: +20, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1651	small bland shaking foie gras	2	decent	
+1652	denatured altered fuchsia jittery candy brain	0		Effect: "Piratey Flavor", Effect Duration: 27, Last Available: "2020-09"
+1653	shaking greedy inspector's deadly jewel-eyed wizard hat	0		Weapon Damage: +5, Item Drop: +15, Meat Drop: +20, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	blinking ribald scandalous wad of Crovacite	0		Sleaze Damage: 15
 1655	bouncing fireproof studded collar	0		Damage Absorption: +80, Hot Resistance: +3
 1656	shaking White Citadel Satisfaction Satchel	0		
@@ -1675,7 +1675,7 @@
 1695	dry oxidized papotion of papower	0		Effect: "Sappy Blood", Effect Duration: 46
 1696	adequate royal jelly taco	3	good	
 1697	flavorless mirror tofu taco	4	decent	
-1698	small stale spinning jumping bean taco	2	decent	
+1698	stale small spinning jumping bean taco	2	decent	
 1699	tasty gigantic catgut taco	6	awesome	
 1700	moldy goat cheese taco	3	crappy	
 1701	normal bite-sized ghostly pr0n taco	1	good	
@@ -1752,9 +1752,9 @@
 1773	tumbling frosty eggbeater	0		Cold Spell Damage: +10
 1774	lousy bottle of popskull	3	decent	
 1775	vibrating dishrag	0		Maximum MP Percent: +10
-1776	stale thick stale baguette	5	decent	
+1776	thick stale stale baguette	5	decent	
 1777	shaking leftovers of indeterminate origin	0		
-1778	huge adequate jittery dinner	9	good	
+1778	adequate huge jittery dinner	9	good	
 1779	maroon hardy katana	0		Maximum HP: +50
 1780	ram stick of horror	0		Spooky Spell Damage: +25
 1781	fireproof enchantlers	0		Hot Resistance: +3, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1775,14 +1775,14 @@
 1796	bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
 1798	pile of animal bones	0		
-1799	wobbly narrow animal skull	0		
+1799	narrow wobbly animal skull	0		
 1800	animal cranium	0		
 1801	twirling animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
-1806	cyan squat fifth cervical vertebra	0		
+1806	squat cyan fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
 1809	blurry first thoracic vertebra	0		
@@ -1803,10 +1803,10 @@
 1824	fourth lumbar vertebra	0		
 1825	fifth lumbar vertebra	0		
 1826	huge sixth lumbar vertebra	0		
-1827	shaking olive seventh lumbar vertebra	0		
-1828	red pulsating sacral vertebrae	0		
+1827	olive shaking seventh lumbar vertebra	0		
+1828	pulsating red sacral vertebrae	0		
 1829	mirror first caudal vertebra	0		
-1830	purple tumbling second caudal vertebra	0		
+1830	tumbling purple second caudal vertebra	0		
 1831	third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
@@ -1923,12 +1923,12 @@
 1946	bouncing censurious Fonzie's accordion pin	0		Experience (Moxie): +1, Sleaze Resistance: +3, Class: "Accordion Thief", Single Equip
 1947	blue pulsating avaricious ribald worn tophat	0		Sleaze Damage: +10, Meat Drop: +30, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	blue vibrating shellacked tap shoes	0		Damage Reduction: 7, Maximum MP Percent: +10, Single Equip
-1949	stale diet Manetwich	1	decent	
+1949	diet stale Manetwich	1	decent	
 1950	bottle of Vangoghbitussin	0		
-1951	bad practically non-alcoholic bottle of Pinot Renoir	1	decent	
+1951	practically non-alcoholic bad bottle of Pinot Renoir	1	decent	
 1952	spoiled desiccated apricot	4	crappy	
-1953	practically non-alcoholic lousy flute of flat champagne	1	decent	
-1954	gigantic flavorless twirling dehydrated caviar	10	decent	
+1953	lousy practically non-alcoholic flute of flat champagne	1	decent	
+1954	flavorless gigantic twirling dehydrated caviar	10	decent	
 1955	styrofoam peanuts	0		
 1956	hand-crafted special narrow snifter of thoroughly aged brandy	4	EPIC	Effect: "Paging Betty", Effect Duration: 20
 1957	quill pen	0		
@@ -1936,7 +1936,7 @@
 1959	squat tattered scrap of paper	0		
 1960	squat scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
-1962	magnetized skewed pulsating blue wobbly Bit O' Ectoplasm	0		Effect: "Kindly Resolve", Effect Duration: 32
+1962	magnetized pulsating skewed blue wobbly Bit O' Ectoplasm	0		Effect: "Kindly Resolve", Effect Duration: 32
 1963	dance card	0		
 1964	bouncing double-paned opera mask	0		Cold Resistance: +5, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
@@ -1950,7 +1950,7 @@
 1973	half of a memo	0		
 1974	blurry cocoabo	0		
 1975	spinning baby gravy fairy	0		
-1976	teal upside-down gravy fairy	0		
+1976	upside-down teal gravy fairy	0		
 1977	spinning gravy fairy	0		
 1978	gravy fairy	0		
 1979	gravy fairy	0		
@@ -1958,10 +1958,10 @@
 1981	astral badger	0		
 1982	blinking MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
-1984	ghostly lime green squat snowy owl	0		
+1984	lime green squat ghostly snowy owl	0		
 1985	spinning maroon scary death orb	0		
 1986	mind flayer	0		
-1987	olive skewed undead elbow macaroni	0		
+1987	skewed olive undead elbow macaroni	0		
 1988	jittery angry cow	0		
 1989	Cheshire bitten	0		
 1990	squat yo-yo	0		
@@ -1999,9 +1999,9 @@
 2022	tiny rotten twirling maroon lemon meringue pie	1	crappy	
 2023	Genalen&trade; Bottle	1	good	
 2024	bland mixed wildflower greens	3	decent	
-2025	adequate huge handful of walnuts	7	good	
-2026	decent tiny nutty organic salad	1	good	
-2027	snack-sized normal gray super salad	2	good	
+2025	huge adequate handful of walnuts	7	good	
+2026	tiny decent nutty organic salad	1	good	
+2027	normal snack-sized gray super salad	2	good	
 2028	flavorless tofu wonton	3	decent	
 2029	hippy protest button	0		Single Equip
 2030	zippy lion tamer's Lockenstock&trade; sandals	0		Experience (familiar): +2, Initiative: +20, Single Equip
@@ -2020,8 +2020,8 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	moldy brain-meltingly-hot chicken wings	3	crappy	
-2046	decent thick frat brats	5	good	
-2047	spoiled immense upside-down teal knob ka-bobs	7	crappy	
+2046	thick decent frat brats	5	good	
+2047	immense spoiled teal upside-down knob ka-bobs	7	crappy	
 2049	perfectly mixed can of Swiller	3	EPIC	
 2050	broken wings	0		
 2051	wobbly sunken eyes	0		
@@ -2069,7 +2069,7 @@
 2093	dog trainer's hors d'oeuvre tray	0		Experience (familiar): +1, Damage Reduction: 5
 2094	adequate snack-sized jittery ballroom blintz	2	good	
 2095	towel	0		
-2096	diluted tumbling twirling lime green guy made of bee pollen	1		
+2096	diluted lime green tumbling twirling guy made of bee pollen	1		
 2097	hardy 17-ball	0		Maximum HP: +50
 2098	filthy lucre	0		
 2099	hobo gristle	0		
@@ -2121,13 +2121,13 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	mirror evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	miniature fancy moldy frank	2	crappy	Effect: "Liquidy Smoky", Effect Duration: 5, Last Available: "2011-12"
+2149	fancy miniature moldy frank	2	crappy	Effect: "Liquidy Smoky", Effect Duration: 5, Last Available: "2011-12"
 2150	moldy half-sized plate of franks and beans	2	crappy	Last Available: "2011-12"
 2151	bad practically non-alcoholic shot of blackberry schnapps	1	decent	
 2152	olive capacitor relay	0		Last Available: "2011-12"
 2153	spinning carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
-2155	maroon tumbling Feynman gate	0		Last Available: "2011-12"
+2155	tumbling maroon Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
@@ -2166,7 +2166,7 @@
 2191	book of carols	0		Last Available: "2006-12"
 2192	gray sheet music	0		Last Available: "2006-12"
 2193	adequate miniature candy stake	2	good	Last Available: "2006-12"
-2194	delicious irresponsibly strong eggnog	6	awesome	Last Available: "2006-12"
+2194	irresponsibly strong delicious eggnog	6	awesome	Last Available: "2006-12"
 2195	adequate unspeakable fruitcake	4	good	Last Available: "2006-12"
 2196	stale gingerbread horror	3	decent	Last Available: "2006-12"
 2197	polarized frozen but probably evil chocolate	0		Effect: "Superveiny 9000", Effect Duration: 50, Last Available: "2006-12"
@@ -2209,7 +2209,7 @@
 2234	calavera concertina of the ox	0		Muscle: +20, Song Duration: 7
 2235	yellow family-friendly razor-sharp ratarang	0		Weapon Damage Percent: +25, Sleaze Resistance: +1
 2236	unsweetened turtle pheromones	0		Effect: "Gummiskin", Effect Duration: 43
-2237	maroon spinning pygmy blowgun	0		
+2237	spinning maroon pygmy blowgun	0		
 2238	extremely unsafe pygmy nose-bone	0		Weapon Damage Percent: +100, Single Equip
 2239	executive bad voodoo mask	0		Item Drop: +5, Meat Drop: +40, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	upside-down bottle of alcohol	0		
@@ -2236,18 +2236,18 @@
 2262	bird rib	0		
 2263	lion oil	0		
 2264	normal thick stunt nuts	5	good	
-2265	fancy stale wet stew	3	decent	Effect: "Broken Fast", Effect Duration: 25
+2265	stale fancy wet stew	3	decent	Effect: "Broken Fast", Effect Duration: 25
 2266	wet stunt nut stew	0		
 2267	twirling Mega Gem	0		
 2268	Staff of Fats of courage	0		Spooky Resistance: +3
-2269	flavorless enchanted sausage wonton	3	decent	Effect: "Billiards Belligerence", Effect Duration: 40
+2269	enchanted flavorless sausage wonton	3	decent	Effect: "Billiards Belligerence", Effect Duration: 40
 2270	veiny arcane researcher's belt	0		Experience Percent (Mysticality): +10, Maximum HP: +10, Single Equip
 2271	artisanal bottle of Merlot	4	EPIC	
 2272	tolerable bottle of Port	4	good	
 2273	watered-down drinkable teal bottle of Pinot Noir	2	good	
 2274	tolerable bottle of Zinfandel	3	good	
 2275	drinkable bottle of Marsala	3	good	
-2276	practically non-alcoholic artisanal bottle of Muscat	1	EPIC	
+2276	artisanal practically non-alcoholic bottle of Muscat	1	EPIC	
 2277	Fernswarthy's key	0		
 2278	wobbly Fernswarthy's letter	0		
 2279	jittery book	0		
@@ -2257,7 +2257,7 @@
 2283	seal-skull helmet of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
 2285	olive chisel	0		
-2286	tumbling twirling Eye of Ed	0		
+2286	twirling tumbling Eye of Ed	0		
 2287	nippy glowstick of bravery	0		Cold Damage: +10, Spooky Resistance: +5, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
 2289	gray paperclip	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	olive worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	tarnished candy heart	0		Effect: "The Grass...  Is Blue...", Effect Duration: 54, Last Available: "2007-02"
 2305	double-polymerized spinning pink candy heart	0		Effect: "Destructive Resolve", Effect Duration: 56, Last Available: "2007-02"
 2306	quadruple-enhanced candy heart	0		Effect: "Wasabi With You", Effect Duration: 69, Last Available: "2007-02"
@@ -2309,14 +2309,14 @@
 2335	olive rubber WWBBDD? bracelet	0		
 2336	wizardly pipe of doom	0		Mysticality: +25, Spooky Spell Damage: +50
 2337	reinforced beaded headband of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	normal big pudding	5	good	Wiki Name: "black pudding (food)"
+2338	big normal pudding	5	good	Wiki Name: "black pudding (food)"
 2339	mediocre Blackfly Chardonnay	4	decent	
-2340	artisanal weak & tan	2	EPIC	
+2340	weak artisanal & tan	2	EPIC	
 2341	maroon pepper	0		
 2342	decent pulsating forest cake	3	good	
 2343	decent forest ham	4	good	
 2344	wet filthworm hatchling scent gland	0		Effect: "Healthy Blue Glow", Effect Duration: 64
-2345	quantum colloidal tumbling blurry blue filthworm drone scent gland	0		Effect: "Twinkly Weapon", Effect Duration: 44
+2345	quantum colloidal blurry blue tumbling filthworm drone scent gland	0		Effect: "Twinkly Weapon", Effect Duration: 44
 2346	dry wobbly filthworm royal guard scent gland	0		Effect: "Voracious Gorging", Effect Duration: 58
 2347	heart of the filthworm queen	0		
 2348	water pipe bomb	0		
@@ -2344,7 +2344,7 @@
 2370	natural fennel soda	0		
 2371	wobbly smoke bomb	0		
 2372	bunch of bananas	0		
-2373	special half-sized rotten banana	2	crappy	Effect: "Salad Days", Effect Duration: 30
+2373	half-sized special rotten banana	2	crappy	Effect: "Salad Days", Effect Duration: 30
 2374	banana peel	0		
 2375	decent big olive banana cream pie	5	good	
 2376	hand-crafted watered-down tumbling banana daiquiri	2	EPIC	
@@ -2394,8 +2394,8 @@
 2420	pressed pulsating teeny-tiny magic scroll	0		Effect: "Coal-Powered", Effect Duration: 52
 2421	moist bottle of pirate juice	0		Effect: "Fishily Speeding", Effect Duration: 23
 2422	nitrogenated blurry irradiated pet snacks	0		Effect: "Turkey-Friendly", Effect Duration: 46
-2423	colloidal quantum narrow fuchsia Mick's IcyVapoHotness Inhaler	0		Effect: "Rotten Memories", Effect Duration: 19
-2424	liquefied vacuum-sealed huge green wobbly cyclops eyedrops	0		Effect: "Comprehensively Nourished", Effect Duration: 29
+2423	colloidal quantum fuchsia narrow Mick's IcyVapoHotness Inhaler	0		Effect: "Rotten Memories", Effect Duration: 19
+2424	liquefied vacuum-sealed huge wobbly green cyclops eyedrops	0		Effect: "Comprehensively Nourished", Effect Duration: 29
 2425	improved can of spinach	0		Effect: "Musky", Effect Duration: 61
 2426	quantum blurry fire flower	0		Effect: "Hammertime", Effect Duration: 29
 2427	dry ionized shaking freezerburned ice cube	0		Effect: "Dance Interpreter", Effect Duration: 36
@@ -2469,7 +2469,7 @@
 2496	twirling wicked Sinful Desires of Gandalf	0		Spell Damage: +5, Spell Critical Percent: +20
 2497	molybdenum magnet	0		
 2498	molybdenum hammer	0		
-2499	spinning blinking molybdenum screwdriver	0		
+2499	blinking spinning molybdenum screwdriver	0		
 2500	molybdenum pliers	0		
 2501	molybdenum crescent wrench	0		
 2502	tumbling Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
@@ -2489,19 +2489,19 @@
 2516	double-paned banded wrench bracelet	0		Damage Absorption: +100, Cold Resistance: +5
 2517	wobbly sinister groovy chain necklace	0		Moxie Percent: +10, Spell Damage: +10
 2518	sinister sawblade shield	0		Spell Damage: +10, Damage Reduction: 11
-2519	fortified hand-crafted McMillicancuddy's Special Lager	5	EPIC	
+2519	hand-crafted fortified McMillicancuddy's Special Lager	5	EPIC	
 2520	weak acceptable melted Jell-o shot	2	good	
 2521	mediocre special squat cruelty-free wine	3	decent	Effect: "Dreadful Sheen", Effect Duration: 40
 2522	artisanal thistle wine	4	EPIC	
 2523	huge megatofu	0		
 2524	displaced fish	0		
 2525	spoiled fish	3	crappy	
-2526	super-sized spoiled fish casserole	5	crappy	
-2527	stale half-sized fish lasagna	2	decent	
+2526	spoiled super-sized fish casserole	5	crappy	
+2527	half-sized stale fish lasagna	2	decent	
 2528	upside-down filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	normal enchanted miniature gnatloaf	2	good	Effect: "Sealed Brain", Effect Duration: 15
+2529	enchanted normal miniature gnatloaf	2	good	Effect: "Sealed Brain", Effect Duration: 15
 2530	stale gnatloaf casserole	4	decent	
-2531	stale huge wobbly shaking gnat lasagna	8	decent	
+2531	huge stale wobbly shaking gnat lasagna	8	decent	
 2532	huge pork	0		
 2533	small tasty skewed pork chop sandwiches	2	awesome	
 2534	adequate jumbo pork casserole	5	good	
@@ -2513,15 +2513,15 @@
 2540	lime green tomb ratchet	0		
 2541	shaking Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	super-modified lesser grodulated violet	0		Effect: "Jingle Jangle Jingle", Effect Duration: 37, Last Available: "2007-05"
-2543	aerosolized anodized warmed upside-down maroon tumbling tin magnolia	0		Effect: "Stuck-Up Hair", Effect Duration: 21, Last Available: "2007-05"
+2543	aerosolized anodized warmed tumbling upside-down maroon tin magnolia	0		Effect: "Stuck-Up Hair", Effect Duration: 21, Last Available: "2007-05"
 2544	frozen begpwnia	0		Effect: "Pork Power", Effect Duration: 25, Last Available: "2007-05"
-2545	electrified mirror blurry upsy daisy	0		Effect: "Scorpio Rising", Effect Duration: 67, Last Available: "2007-05"
+2545	electrified blurry mirror upsy daisy	0		Effect: "Scorpio Rising", Effect Duration: 67, Last Available: "2007-05"
 2546	irradiated liquefied shaking half-orchid	0		Effect: "Here's Mud in Your Eye", Effect Duration: 30, Last Available: "2007-05"
 2547	wobbly Socratic groovy tin star	0		Moxie Percent: +10, Experience (Mysticality): +1, Last Available: "2007-05"
 2548	huge olive electrified boxer's outrageous sombrero	0		Muscle Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	brainy &quot;Humorous&quot; T-shirt of doom	0		Mysticality: +5, Spooky Spell Damage: +50, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
-2551	lime green wobbly vial of mojo	0		
+2551	wobbly lime green vial of mojo	0		
 2552	reeds	0		
 2553	jittery turtle chain	0		
 2554	distilled seal blood	0		
@@ -2541,7 +2541,7 @@
 2568	spinning Azazel's tutu	0		
 2569	dry irradiated ant agonist	0		Effect: "Springy Fusilli", Effect Duration: 44
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
-2571	blue skewed ant rake	0		Familiar Effect: "hot damage, meat"
+2571	skewed blue ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	mirror ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
@@ -2560,7 +2560,7 @@
 2587	huge Sherlock's Corporal Fennel's Lonely Clubs Club Jacket	0		Item Drop: +25
 2588	wool Private Pepper's Lonely Hearts Club Jacket	0		Cold Resistance: +1
 2589	super-sized flavorless hot date	5	decent	
-2590	smooth weak upside-down blinking distilled fortified wine	2	awesome	
+2590	weak smooth blinking upside-down distilled fortified wine	2	awesome	
 2591	rotten tasty tart	3	crappy	
 2592	red Knob Goblin lunchbox	0		
 2593	delicious teal skewed Knob pasty	3	awesome	
@@ -2623,14 +2623,14 @@
 2650	olive bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	rotten upside-down S.T.L.T.	3	crappy	Last Available: "2007-06"
-2653	jumbo decent honey-dew	5	good	Last Available: "2007-06"
+2653	decent jumbo honey-dew	5	good	Last Available: "2007-06"
 2654	hand-crafted teal Xanadian	3	EPIC	Last Available: "2007-06"
 2655	extra-polarized irradiated spinning bottle of absinthe	0		Effect: "Disco Concentration", Effect Duration: 37, Last Available: "2007-06"
 2656	jittery frightening Lo Pan's Drowsy Sword	0		Spell Critical Percent: +30, Spooky Damage: +5
-2657	fancy normal miniature escargotsicle	2	good	Effect: "Thunderspell", Effect Duration: 25, Last Available: "2007-06"
+2657	normal fancy miniature escargotsicle	2	good	Effect: "Thunderspell", Effect Duration: 25, Last Available: "2007-06"
 2658	perfectly mixed tumbling bottle of realpagne	3	EPIC	Last Available: "2007-06"
 2659	MacGyver's albatross necklace	0		Maximum MP: +100, Single Equip, Last Available: "2007-06"
-2660	diluted blurry purple not-a-pipe	1	decent	Last Available: "2007-06"
+2660	diluted purple blurry not-a-pipe	1	decent	Last Available: "2007-06"
 2661	acceptable flask of Amontillado	3	good	Last Available: "2007-06"
 2662	nasty ball mask	0		Stench Damage: +5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 2663	Can-Can skirt of the sewer	0		Stench Damage: +25, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
@@ -2647,7 +2647,7 @@
 2674	magnetized bottle of cat tonic	0		Effect: "Oxygenated Blood", Effect Duration: 33, Last Available: "2007-06"
 2675	diluted pulsating handful of moss	1		
 2676	powdered bit-o-cactus	1		Effect: "Tin, Man", Effect Duration: 40
-2677	pickled pulsating twirling yellow protein powder	1		Effect: "Chalky White Pallor", Effect Duration: 5
+2677	pickled twirling yellow pulsating protein powder	1		Effect: "Chalky White Pallor", Effect Duration: 5
 2678	pulsating spectre scepter	0		
 2679	magnetized bouncing jittery sparkler	0		Effect: "Moose Wisdom", Effect Duration: 62
 2680	dry snake	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 22, Wiki Name: "snake"
@@ -2698,14 +2698,14 @@
 2725	stale cob of corn	4	decent	
 2726	tasty small juniper berries	2	awesome	
 2727	rotten plum	4	crappy	
-2728	stale gigantic wobbly pear	7	decent	
+2728	gigantic stale wobbly pear	7	decent	
 2729	toothsome peach	4	awesome	
 2730	weak delicious bouncing plum wine	2	awesome	
-2731	lousy weak shot of pear schnapps	2	decent	
-2732	practically non-alcoholic bad ghostly red shot of peach schnapps	1	decent	
+2731	weak lousy shot of pear schnapps	2	decent	
+2732	bad practically non-alcoholic red ghostly shot of peach schnapps	1	decent	
 2733	moldy snack-sized bunch of square grapes	2	crappy	
 2734	decent brown sugar cane	4	good	
-2735	fancy stale gigantic sandwich of the gods	10	decent	Effect: "Flower Power", Effect Duration: 40
+2735	gigantic fancy stale sandwich of the gods	10	decent	Effect: "Flower Power", Effect Duration: 40
 2736	bad distilled shaking Pan-Dimensional Gargle Blaster	5	decent	
 2737	diluted shaking pulsating leopard-print barbell	1	good	Effect: "Ooh, Sweet!", Effect Duration: 25
 2738	pile of smoking rags	0		
@@ -2713,7 +2713,7 @@
 2740	horrifying Jack Frost's Staff of the Walk-In Freezer of the brute	0		Muscle Percent: +30, Cold Spell Damage: +50, Spooky Damage: +25
 2741	bad twirling boilermaker	4	decent	
 2742	immense moldy steel lasagna	8	quest	
-2743	practically non-alcoholic special perfectly mixed steel margarita	1	quest	Effect: "Superveiny 9000", Effect Duration: 10
+2743	perfectly mixed special practically non-alcoholic steel margarita	1	quest	Effect: "Superveiny 9000", Effect Duration: 10
 2744	compressed teal wobbly steel-scented air freshener	1		
 2745	oxidized quadruple-moist moist shaking gremlin mutagen	0		Effect: "Vital", Effect Duration: 27
 2746	pressed electrified aerosolized pulsating extra-potent gremlin mutagen	0		Effect: "Wise Spirit", Effect Duration: 54
@@ -2738,8 +2738,8 @@
 2765	purple Harold's bell	0		
 2766	tumbling bowling ball	0		
 2767	low-calorie rotten Crimbo pie	1	crappy	
-2768	flavorless half-sized pear tart	2	decent	
-2769	jumbo flavorless huge peach pie	5	decent	
+2768	half-sized flavorless pear tart	2	decent	
+2769	flavorless jumbo huge peach pie	5	decent	
 2770	ionized liquefied ionized jittery chunk of rock salt	0		Effect: "Floundering", Effect Duration: 61
 2771	dry anodized extra-dry handful of pine needles	0		Effect: "Hot Jellied", Effect Duration: 58
 2772	steamy ruby	0		
@@ -2804,7 +2804,7 @@
 2831	star key lime	0		
 2832	normal digital key lime pie	3	good	
 2833	moldy star key lime pie	3	crappy	
-2834	blurry family-friendly manspreader's smartaleck's bottle-rocket crossbow	0		Moxie Percent: +30, Monster Level: +10, Sleaze Resistance: +1, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	blurry family-friendly manspreader's smartaleck's bottle-rocket crossbow	0		Moxie Percent: +30, Monster Level: +10, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	padded indie comic hipster glasses	0		Damage Absorption: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	blurry wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	blue mint-condition magic wand	0		Last Available: "2011-12"
@@ -2821,7 +2821,7 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	olive shrunken navigator head	0		
 2850	practically non-alcoholic mediocre moonberry wine cooler	1	decent	
-2851	stale bite-sized spinning fine aged cheddarwurst	1	decent	
+2851	bite-sized stale spinning fine aged cheddarwurst	1	decent	
 2852	jittery branch from the Great Tree	0		
 2853	squat Phil Bunion's axe	0		
 2854	ghostly bouquet of swamp roses	0		
@@ -2910,28 +2910,28 @@
 2937	shaking siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	mirror Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	adequate miniature Surprise Egg	2	good	
+2940	miniature adequate Surprise Egg	2	good	
 2941	triple-polymerized spinning Steal This Candy	0		Effect: "Wet and Greedy", Effect Duration: 52
 2942	deionized liquefied chocolate filthy lucre	0		Effect: "Rainbow Bright", Effect Duration: 33
 2943	wet activated diffused Angry Farmer's Wife Candy	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 55
 2945	jittery twirling energetic Rosewater's party hat	0		Mysticality Percent: +30, Maximum MP Percent: +20, Familiar Effect: "4xLep, cap 7"
-2946	avaricious stylish V for Vivala mask	0		Moxie: +25, Meat Drop: +30, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	avaricious stylish V for Vivala mask	0		Moxie: +25, Meat Drop: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	weak lousy ghostly shot of rotgut	2	decent	
 2949	denatured jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Tightly-Wound Spine", Effect Duration: 65
 2950	Cap'm Caronch's Map	0		
-2951	wobbly teal Orcish Frat House blueprints	0		
+2951	teal wobbly Orcish Frat House blueprints	0		
 2952	narrow dangerous stylish glowstick	0		Moxie: +25, Weapon Damage: +10, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	squat groovy tip jar	0		Moxie Percent: +10
 2955	adequate half-sized twirling yam candy	2	good	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	massive adequate tube of cranberry Go-Goo	10	good	
+2958	adequate massive tube of cranberry Go-Goo	10	good	
 2959	red mansplainer's rum barrel charrrm bracelet	0		Monster Level: +15
 2960	stale single-serving herbal stuffing	3	decent	
 2961	jumbo bland packet of tofurkey gravy	5	decent	
-2962	bland special tofurkey nugget	4	decent	Effect: "Become Superficially interested", Effect Duration: 35
+2962	special bland tofurkey nugget	4	decent	Effect: "Become Superficially interested", Effect Duration: 35
 2963	yellow rigging shampoo	0		
 2964	tumbling ball polish	0		
 2965	mizzenmast mop	0		
@@ -2939,13 +2939,13 @@
 2967	frozen jittery Swabbie&trade; swab	0		Effect: "Educated (Sorta)", Effect Duration: 56
 2968	vacuum-sealed spinning Oil of Parrrlay	0		Effect: "Slime Time", Effect Duration: 31
 2969	miniature rotten creamsicle	2	crappy	
-2970	tolerable extra-dry shaking cream stout	5	good	
+2970	extra-dry tolerable shaking cream stout	5	good	
 2971	curmudgel of the empath of the early riser	0		Familiar Weight: +5, Adventures: +7
 2972	grumpy man charrrm	0		
 2973	aromatic grumpy man charrrm bracelet	0		Stench Resistance: +1, Single Equip
 2974	tarrrnish charrrm	0		
 2975	bouncing padded Herculean tarrrnished charrrm bracelet	0		Experience (Muscle): +1, Damage Absorption: +20, Single Equip
-2976	watered-down perfectly mixed bilge wine	2	EPIC	
+2976	perfectly mixed watered-down bilge wine	2	EPIC	
 2977	boxer's witty rapier	0		Muscle Percent: +10
 2978	huge curative sage yohohoyo	0		Mysticality Percent: +10, HP Regen Min: 3, HP Regen Max: 5
 2979	polymerized alkaline olive fish-liver oil	0		Effect: "Coated Arms", Effect Duration: 14
@@ -2992,20 +2992,20 @@
 3020	handful of sawdust	0		
 3021	stone triangle	0		
 3022	medium stone triangle	0		
-3023	narrow huge small stone triangle	0		
+3023	huge narrow small stone triangle	0		
 3024	stone pyramid	0		
 3025	hand-crafted upside-down corpse on the beach	3	super EPIC	
 3026	hand-crafted corpsetini	4	EPIC	
 3027	smooth corpsedriver	3	awesome	
 3028	artisanal upside-down Corpse Island iced tea	4	EPIC	
-3029	extra-dry hand-crafted red-headed corpse	5	EPIC	
+3029	hand-crafted extra-dry red-headed corpse	5	EPIC	
 3030	acceptable enchanted practically non-alcoholic jittery kamicorpse-ee	1	good	Effect: "Fireproof Lips", Effect Duration: 15
 3031	delicious watered-down corpsel	2	awesome	
-3032	tolerable spirit-forward huge corpsebite	5	good	
+3032	spirit-forward tolerable huge corpsebite	5	good	
 3033	therapeutic pirate fledges	0		HP Regen Min: 5, HP Regen Max: 7
 3034	piece of thirteen	0		
 3035	normal pearl onion	4	good	
-3036	spoiled thick sea biscuit	5	crappy	
+3036	thick spoiled sea biscuit	5	crappy	
 3037	lousy purple bottle of rum	3	decent	
 3038	lousy skewed bottle of black-label rum	3	decent	
 3039	cannonball	0		
@@ -3014,8 +3014,8 @@
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	bouncing metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	bouncing metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	stale miniature nanite-infested gingerbread bugbear	2	decent	Last Available: "2007-12"
-3046	bite-sized fancy bland nanite-infested candy cane	1	decent	Effect: "Sated and Furious", Effect Duration: 20, Last Available: "2020-09"
+3045	miniature stale nanite-infested gingerbread bugbear	2	decent	Last Available: "2007-12"
+3046	bland fancy bite-sized nanite-infested candy cane	1	decent	Effect: "Sated and Furious", Effect Duration: 20, Last Available: "2020-09"
 3047	bland nanite-infested fruitcake	3	decent	Last Available: "2007-12"
 3048	drinkable huge nanite-infested eggnog	3	good	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	blue Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	blue Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	gray marionette collective of bravery	0		Spooky Resistance: +5, Last Available: "2007-12"
 3082	gray monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3060,7 +3060,7 @@
 3088	flame-wreathed biomechanical crimborg helmet of doom	0		Hot Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	experienced wizardly C.B.F.G.	0		Mysticality: +25, Experience: +2, Last Available: "2007-12"
 3090	nasty studded biomechanical crimborg leg armor	0		Damage Absorption: +80, Stench Damage: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
-3091	activated denatured tumbling green vitachoconutriment capsule	0		Effect: "Enraged", Effect Duration: 62, Last Available: "2007-12"
+3091	activated denatured green tumbling vitachoconutriment capsule	0		Effect: "Enraged", Effect Duration: 62, Last Available: "2007-12"
 3092	red personal trainer's handmade hobby horse	0		Experience Percent (Muscle): +10, Last Available: "2007-12"
 3093	teal horrifying ball-in-a-cup	0		Spooky Damage: +25, Last Available: "2007-12"
 3094	therapeutic set of jacks	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-12"
@@ -3076,31 +3076,31 @@
 3104	ghostly shaking banded vibrating cyborg knife of the pedagogue	0		Experience: +3, Damage Absorption: +100, Last Available: "2007-12"
 3105	twirling mirror cool weightlifter's immense cyborg hand	0		Muscle: +15, Moxie: +5, Last Available: "2007-12"
 3106	nippy mansplainer's stylish cyborg stompin' boot	0		Moxie: +25, Monster Level: +15, Cold Damage: +10, Single Equip, Last Available: "2007-12"
-3107	narrow blurry deactivated RoboGoose	0		Last Available: "2007-12"
+3107	blurry narrow deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
 3111	squat Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
 3113	jittery Miniborg hiveminder	0		Last Available: "2007-12"
-3114	narrow upside-down Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
+3114	upside-down narrow Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	blurry old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	tumbling Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	jittery divine cracker	0		Last Available: "2008-01"
 3123	huge divine champagne flute	0		Last Available: "2008-01"
-3124	super-polymerized huge blue fruitfilm	0		Effect: "Sweet Taste", Effect Duration: 62
+3124	super-polymerized blue huge fruitfilm	0		Effect: "Sweet Taste", Effect Duration: 62
 3125	extra-liquefied piece of after eight	0		Effect: "Voracious Gorging", Effect Duration: 56
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	flavorless low-calorie roasted marshmallow	1	decent	
+3129	low-calorie flavorless roasted marshmallow	1	decent	
 3130	disc	0		Last Available: "2008-01"
-3131	immense bland tin cup of mulligan stew	8	decent	
+3131	bland immense tin cup of mulligan stew	8	decent	
 3132	ghostly groovy flamin' bindle of James Dean	0		Moxie Percent: +10, Experience (Moxie): +3
 3133	auspicious knitted freezin' bindle	0		Cold Resistance: +3, Item Drop: +10
 3134	avaricious stinkin' bindle of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30
@@ -3134,7 +3134,7 @@
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
-3165	narrow teal broken El Vibrato drone	0		
+3165	teal narrow broken El Vibrato drone	0		
 3166	narrow repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	ionized seal eyeball	0		Effect: "Elvish", Effect Duration: 50
@@ -3146,8 +3146,8 @@
 3174	special half-sized bland evil boring spaghetti	2	decent	Effect: "Meatwise", Effect Duration: 20
 3175	flavorless squat blurry evil noodles	3	decent	
 3176	yummy evil noodles	3	awesome	
-3177	rotten tiny yellow evil painful penne pasta	1	crappy	
-3178	rotten huge 3vi1 pr0n m4nic0tti	7	crappy	
+3177	tiny rotten yellow evil painful penne pasta	1	crappy	
+3178	huge rotten 3vi1 pr0n m4nic0tti	7	crappy	
 3179	decent bite-sized fuchsia evil ravioli della hippy	1	good	
 3180	yummy snack-sized evil noodles	2	awesome	
 3181	denatured evil potion of potency	0		Effect: "Really Deep Breath", Effect Duration: 63
@@ -3174,7 +3174,7 @@
 3202	stanky Socratic KoL Con IV Pole of incineration	0		Experience (Mysticality): +1, Hot Spell Damage: +50, Stench Spell Damage: +25, Last Available: "2007-09"
 3203	dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
-3205	tumbling mirror dwarvish war mattock	0		
+3205	mirror tumbling dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	small laminated card	0		
@@ -3195,18 +3195,18 @@
 3223	sewer nuggets	0		
 3224	mirror sewer wad	0		
 3225	special hand-crafted shaking bottle of sewage schnapps	3	EPIC	Effect: "Pumped Stomach", Effect Duration: 25
-3226	artisanal triple-distilled bottle of Ooze-O	6	EPIC	
+3226	triple-distilled artisanal bottle of Ooze-O	6	EPIC	
 3227	miniature yummy C.H.U.M. chum	2	awesome	
 3228	miniature normal olive unfortunate dumplings	2	good	
 3229	decaying goldfish liver	0		
 3230	quantum ionized oil of oiliness	0		Effect: "Muddled", Effect Duration: 37
 3231	tattered paper crown of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1xSombrero, cap 15"
-3232	immense rotten enchanted vanilla-frosted king cake	7	crappy	Effect: "Supafly", Effect Duration: 20, Last Available: "2008-03"
+3232	rotten immense enchanted vanilla-frosted king cake	7	crappy	Effect: "Supafly", Effect Duration: 20, Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	spinning water wings	0		Wiki Name: "water wings"
 3235	pulsating noodle	0		
 3236	wobbly Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
-3237	wobbly pulsating Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
+3237	pulsating wobbly Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	blurry blue huge Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	tumbling Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
@@ -3232,7 +3232,7 @@
 3260	wobbly curative razor-sharp Chester's moustache of horror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Class: "Disco Bandit", Single Equip
 3261	narrow Samson's thinker's Chester's bag of candy	0		Mysticality: +10, Experience (Muscle): +5, Class: "Disco Bandit"
 3262	blurry educational Chester's cutoffs of the dark arts	0		Experience: +1, Spell Damage Percent: +100, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	mirror green bag of Saccharine Maple saplings	0		
@@ -3240,9 +3240,9 @@
 3268	nitrogenated handful of Crotchety Pine needles	0		Effect: "Unusual Fashion Sense", Effect Duration: 23
 3269	galvanized magnetized lump of Saccharine Maple sap	0		Effect: "Super Vision", Effect Duration: 32
 3270	pickled warmed pulsating handful of Laughing Willow bark	0		Effect: "Cold as Ice", Effect Duration: 62
-3271	green sage crotchety pants	0		Mysticality Percent: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	green sage crotchety pants	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	dangerous Saccharine Maple pendant	0		Weapon Damage: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	bouncing stiffened willowy bonnet	0		Damage Reduction: 1, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	bouncing stiffened willowy bonnet	0		Damage Reduction: 1, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3257,7 +3257,7 @@
 3285	chaotic C.H.U.M. knife	0		Spell Critical Percent: +10
 3286	twirling jittery padded Frosty's snowball sack	0		Damage Absorption: +20
 3287	cyan quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
-3288	yellow jittery shimmering tendrils	0		Class: "Pastamancer"
+3288	jittery yellow shimmering tendrils	0		Class: "Pastamancer"
 3289	scintillating powder	0		Class: "Pastamancer"
 3290	abandoned candy	0		
 3291	wobbly secret tropical island volcano lair map	0		
@@ -3274,10 +3274,10 @@
 3302	stick-on mini solar panels	0		
 3303	shaking sombrero	0		Sombrero Bonus: +10
 3304	Argarggagarg's fang	0		
-3305	pulsating olive blinking Safari Jack's moustache	0		
-3306	upside-down spinning Yakisoba's hat	0		
+3305	olive blinking pulsating Safari Jack's moustache	0		
+3306	spinning upside-down Yakisoba's hat	0		
 3307	Heimandatz's heart	0		
-3308	teal tumbling Jocko Homo's head	0		
+3308	tumbling teal Jocko Homo's head	0		
 3309	The Mariachi's guitar case	0		
 3310	avaricious sealskin drum	0		Meat Drop: +30, Class: "Seal Clubber"
 3311	spinning rock-hard washboard shield	0		Damage Reduction: 15, Class: "Turtle Tamer"
@@ -3285,17 +3285,17 @@
 3313	wobbly greedy marinara jug	0		Meat Drop: +20, Class: "Sauceror"
 3314	ruddy makeshift castanets	0		Maximum HP Percent: +40, Class: "Disco Bandit"
 3315	skewed reassuring left-handed melodica	0		Spooky Resistance: +1, Class: "Accordion Thief"
-3316	denatured cyan wobbly epic wad	1	crappy	Effect: "Memento Moir&eacute;", Effect Duration: 5
+3316	denatured wobbly cyan epic wad	1	crappy	Effect: "Memento Moir&eacute;", Effect Duration: 5
 3317	manspreader's bottlecap	0		Monster Level: +10, Single Equip
 3318	mirror mirror corncob pipe of Leguizamo	0		Monster Level: +20, Single Equip
 3319	brawny Mr. Joe's bangles	0		Muscle Percent: +20, Single Equip
 3320	green hardened frayed rope belt	0		Damage Reduction: 3, Single Equip
 3321	cyan packet of mayfly bait	0		Last Available: "2008-05"
-3322	green experienced mayfly bait necklace of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	green experienced mayfly bait necklace of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	huge Frosty's frosty mug	0		
-3325	artisanal watered-down jar of fermented pickle juice	2	super ultra mega turbo EPIC	
-3326	distilled huge yellow jittery voodoo snuff	1	awesome	
+3325	watered-down artisanal jar of fermented pickle juice	2	super ultra mega turbo EPIC	
+3326	distilled huge jittery yellow voodoo snuff	1	awesome	
 3327	adequate extra-greasy slider	3	good	
 3328	nasty rosy-cheeked crumpled felt fedora	0		Maximum HP Percent: +30, Stench Damage: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	sizzling nippy battered top-hat	0		Cold Damage: +10, Hot Damage: +10, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3312,37 +3312,37 @@
 3340	bouncing very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	hobo monkey	0		
-3343	squat wobbly bindle	0		Familiar Weight: +5
+3343	wobbly squat bindle	0		Familiar Weight: +5
 3344	bed of coals	0		
 3345	air mattress	0		
 3346	filth-encrusted futon	0		
 3347	comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
-3350	aged watered-down Ralph IX cognac	2	awesome	
+3350	watered-down aged Ralph IX cognac	2	awesome	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	fuchsia zen motorcycle	0		Last Available: "2008-06"
 3353	deionized wobbly llama lama gong	0		Effect: "The Rich Get Richer", Effect Duration: 20, Last Available: "2008-06"
-3354	moldy enchanted bouncing banana-frosted king cake	3	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 15, Last Available: "2008-08"
+3354	enchanted moldy bouncing banana-frosted king cake	3	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 15, Last Available: "2008-08"
 3355	gray brown plastic baby of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	bouncing shimmering moth	0		Last Available: "2008-06"
-3358	narrow shaking green delectable fire ant	0		Last Available: "2008-06"
+3358	narrow green shaking delectable fire ant	0		Last Available: "2008-06"
 3359	jittery scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	red tasty louse	0		Last Available: "2008-06"
-3363	small toothsome mole mol&eacute;	2	awesome	Last Available: "2008-06"
+3363	toothsome small mole mol&eacute;	2	awesome	Last Available: "2008-06"
 3364	lousy fancy Morlock's Mark Bourbon	4	decent	Effect: "Bolts about Candy", Effect Duration: 10, Last Available: "2008-06"
 3365	chilled ionized Climate Colada	0		Effect: "Slimily Speedy", Effect Duration: 19, Last Available: "2008-06"
 3366	cold-filtered jittery digital underground potion	0		Effect: "Nutrient-Rich", Effect Duration: 37, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	vaporized fuchsia twirling glimmering roc feather	1	good	Last Available: "2008-06"
-3369	twisted olive narrow shaking glimmering phoenix feather	1		Effect: "Fire Inside", Effect Duration: 20, Last Available: "2008-06"
+3368	vaporized twirling fuchsia glimmering roc feather	1	good	Last Available: "2008-06"
+3369	twisted shaking narrow olive glimmering phoenix feather	1		Effect: "Fire Inside", Effect Duration: 20, Last Available: "2008-06"
 3370	dried green glimmering penguin feather	1		Last Available: "2008-06"
 3371	twisted glimmering buzzard feather	1		Last Available: "2008-06"
 3372	dehydrated glimmering raven feather	1		Last Available: "2008-06"
-3373	diluted blurry pulsating cyan glimmering great tit feather	1		Last Available: "2008-06"
+3373	diluted cyan pulsating blurry glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3368,7 +3368,7 @@
 3396	skewed avaricious frosty Hodgman's lobsterskin pants	0		Cold Spell Damage: +10, Meat Drop: +30, Familiar Effect: "atk, 1xPotato"
 3397	forbidden grievous Hodgman's bow tie	0		Weapon Damage Percent: +50, Spell Damage Percent: +50, Single Equip
 3398	artisanal skewed Hodgman's blanket	4	EPIC	
-3399	watered-down mediocre jar of squeeze	2	decent	
+3399	mediocre watered-down jar of squeeze	2	decent	
 3400	yummy massive bowl of fishysoisse	9	awesome	
 3401	concentrated quantum deadly lampshade	0		Effect: "Indescribable Flavor", Effect Duration: 30
 3402	quantum pressed concentrated garbage juice	0		Effect: "Ham-Fisted", Effect Duration: 67
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	improved sterno-flavored Hob-O	0		Effect: "Quiet 'n' Good", Effect Duration: 56
 3423	extra-diffused frostbite-flavored Hob-O	0		Effect: "Hypercubed", Effect Duration: 62
 3424	concentrated vacuum-sealed fry-oil-flavored Hob-O	0		Effect: "Sealed Brain", Effect Duration: 60
@@ -3416,21 +3416,21 @@
 3449	cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
-3452	olive bouncing cotton candy skoshe	0		Last Available: "2008-08"
+3452	bouncing olive cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
 3454	teal spinning cotton candy pillow	0		Last Available: "2008-08"
 3455	cotton candy bale	0		Last Available: "2008-08"
 3456	green Oprah's trusty torch	0		Maximum MP Percent: +50, Last Available: "2011-12"
 3457	therapeutic Junior Adventurer's merit badge	0		HP Regen Min: 5, HP Regen Max: 7
 3458	denatured twirling blinking STYX deodorant body spray	0		Effect: "Like a Fish to Walter", Effect Duration: 49
-3459	perfectly mixed weak purple white-label gin	2	EPIC	
+3459	weak perfectly mixed purple white-label gin	2	EPIC	
 3460	flavorless special tin rations	4	decent	Effect: "Some Cheese with Your Wine", Effect Duration: 45
 3461	upside-down mirror gray haiku challenge map	0		
 3462	terrible poem	0		
 3463	aged upside-down bottle of sake	4	awesome	
 3464	skewed round pebble of the pedagogue	0		Experience: +3
 3465	bland twirling Bash-&#332;s cereal	3	decent	Wiki Name: "Bash-Os cereal"
-3466	spinning flame-retardant fortified sinister haiku katana	0		Spell Damage: +10, Damage Absorption: +60, Hot Resistance: +1, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	spinning flame-retardant fortified sinister haiku katana	0		Spell Damage: +10, Damage Absorption: +60, Hot Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	sage plastic baby	0		Mysticality Percent: +10, Single Equip, Last Available: "2008-12"
 3469	rotten blueberry-frosted king cake	4	crappy	Last Available: "2008-12"
@@ -3467,11 +3467,11 @@
 3500	shaking beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	flavorless ghostly tumbling canap&eacute;s	3	decent	
 3502	twisted maroon tumbling thermos of brew	1	decent	Effect: "Buff as a Baobab", Effect Duration: 10, Last Available: "2011-12"
-3503	acceptable triple-distilled glass of brandy	8	good	Last Available: "2011-12"
+3503	triple-distilled acceptable glass of brandy	8	good	Last Available: "2011-12"
 3504	blue French slippers	0		
 3505	extremely unsafe LWA ring	0		Weapon Damage Percent: +100
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	Sinatra's scratch 'n' sniff sword	0		Experience (Moxie): +5, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3522,8 +3522,8 @@
 3555	rotten blinking sea carrot	3	crappy	
 3556	rotten maroon sea cucumber	3	crappy	
 3557	flavorless sea avocado	4	decent	
-3558	flavorless jumbo sea lychee	5	decent	
-3559	miniature normal sea tangelo	2	good	
+3558	jumbo flavorless sea lychee	5	decent	
+3559	normal miniature sea tangelo	2	good	
 3560	delicious sea honeydew	3	awesome	
 3561	boiled olive pressurized potion of puissance	0		Effect: "Castaway Physique", Effect Duration: 47
 3562	frozen alkaline tumbling pressurized potion of perspicacity	0		Effect: "Extra Terrestrial", Effect Duration: 68
@@ -3548,7 +3548,7 @@
 3581	sushi-rolling mat	0		
 3582	rotten rice	4	crappy	
 3584	spoiled huge irradiated candy cane	4	crappy	Last Available: "2008-12"
-3585	half-sized rotten cyan gingerbread mutant bugbear	2	crappy	Last Available: "2008-12"
+3585	rotten half-sized cyan gingerbread mutant bugbear	2	crappy	Last Available: "2008-12"
 3586	acceptable oozenog	3	good	Last Available: "2008-12"
 3587	polymerized twirling sugar plum	0		Effect: "Drunk With Power", Effect Duration: 60, Last Available: "2008-12"
 3588	super-ionized sugar banana	0		Effect: "Cute Vision", Effect Duration: 66, Last Available: "2008-12"
@@ -3558,9 +3558,9 @@
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
-3595	flattened galvanized tumbling huge Mer-kin fastjuice	0		Effect: "Night Vision", Effect Duration: 52
+3595	flattened galvanized huge tumbling Mer-kin fastjuice	0		Effect: "Night Vision", Effect Duration: 52
 3596	imitation crab crate	0		
-3597	squat skewed imitation crab meat	0		
+3597	skewed squat imitation crab meat	0		
 3598	ghostly imitation crab zoea	0		
 3599	lard-coated scorching stylish moist sailor's cap	0		Moxie: +25, Hot Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "stench atk"
 3600	double-paned steel-toed speargun	0		Damage Reduction: 9, Cold Resistance: +5
@@ -3581,7 +3581,7 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	huge pulsing flesh	0		Last Available: "2008-12"
 3617	polymerized unstable DNA	0		Effect: "Full Bottle in front of Me", Effect Duration: 54, Last Available: "2008-12"
-3618	mirror The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	mirror The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	bouncing mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
@@ -3611,12 +3611,12 @@
 3645	tolerable canteen of wine	3	good	Last Available: "2008-12"
 3646	moldy elven <i>limbos</i> gingerbread	3	crappy	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
-3648	fuchsia tumbling magic dragonfish fry	0		
+3648	tumbling fuchsia magic dragonfish fry	0		
 3649	bouncing map to Madness Reef	0		
-3650	snack-sized stale pulsating toast with jam	2	decent	Last Available: "2008-12"
-3651	upside-down spinning antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	stale snack-sized pulsating toast with jam	2	decent	Last Available: "2008-12"
+3651	upside-down spinning antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	perfectly mixed shaking elven moonshine	3	EPIC	Last Available: "2008-12"
-3653	miniature stale twirling knuckle sandwich	2	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	stale miniature twirling knuckle sandwich	2	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	aromatic energetic psycho sweater	0		Maximum MP Percent: +20, Stench Resistance: +1, Last Available: "2008-12"
 3655	ghostly fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of the early riser	0		Adventures: +7, Last Available: "2008-12"
@@ -3641,7 +3641,7 @@
 3675	Mer-kin pressureglobe	0		
 3676	squat Mer-kin foodbucket	0		
 3677	wool diving muff	0		Cold Resistance: +1, Single Equip
-3678	irresponsibly strong tolerable shaking salinated mint julep	9	good	
+3678	tolerable irresponsibly strong shaking salinated mint julep	9	good	
 3679	ink bladder	0		
 3680	bouncing esca	0		
 3681	squat bubbling tempura batter	0		
@@ -3650,9 +3650,9 @@
 3684	adequate tempura carrot	4	good	
 3685	adequate diet tempura cucumber	1	good	
 3686	moldy super-sized tempura avocado	5	crappy	
-3687	decent red bouncing sea broccoli	3	good	
+3687	decent bouncing red sea broccoli	3	good	
 3688	thick rotten sea cauliflower	5	crappy	
-3689	fancy miniature toothsome yellow tempura broccoli	2	awesome	Effect: "Always be Collecting", Effect Duration: 35
+3689	toothsome miniature fancy yellow tempura broccoli	2	awesome	Effect: "Always be Collecting", Effect Duration: 35
 3690	moldy miniature tempura cauliflower	2	crappy	
 3691	yummy tumbling sea blueberry	3	awesome	
 3692	adequate small sea persimmon	2	good	
@@ -3695,13 +3695,13 @@
 3729	hand grenegg	0		
 3730	caret	0		
 3731	Socratic glass gnoll eye	0		Experience (Mysticality): +1
-3732	magnetized dry ghostly shaking cigar butt	0		Effect: "Super Speed", Effect Duration: 64
+3732	magnetized dry shaking ghostly cigar butt	0		Effect: "Super Speed", Effect Duration: 64
 3733	huge lard-coated friendly manly bloomers	0		Familiar Weight: +3, Sleaze Spell Damage: +25, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
 3734	Colon Annihilation Hot Sauce	0		
 3735	mirror fat wallet	0		
 3736	twirling fortified handwarmer of Leguizamo	0		Damage Absorption: +60, Monster Level: +20, Single Equip
 3737	shaking knitted lighter of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +3
-3738	super-sized stale packet of beer nuts	5	decent	
+3738	stale super-sized packet of beer nuts	5	decent	
 3739	blinking Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,8 +3713,8 @@
 3747	bouncing mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	frozen dry blue concoction of clumsiness	0		Effect: "Ready to Snap", Effect Duration: 38
 3750	olive blurry blinking ruddy vampire pearl earring	0		Maximum HP Percent: +40, Single Equip
-3751	massive moldy chocolate chip brownies	6	crappy	
-3753	gray Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3751	moldy massive chocolate chip brownies	6	crappy	
+3753	gray Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	energized ionized tumbling love song of vague ambiguity	0		Effect: "[800]Chocolate Reign", Effect Duration: 69, Last Available: "2009-02"
 3755	adjusted deionized love song of smoldering passion	0		Effect: "Celestial Sheen", Effect Duration: 19, Last Available: "2009-02"
 3756	denatured love song of icy revenge	0		Effect: "Can't Smell Nothin'", Effect Duration: 54, Last Available: "2009-02"
@@ -3730,7 +3730,7 @@
 3766	smooth screwdiver	4	awesome	
 3767	lousy mirror purple dew yoana lei	3	decent	
 3768	mediocre lychee chuhai	3	decent	
-3769	high-proof bad salacious screwdiver	10	decent	
+3769	bad high-proof salacious screwdiver	10	decent	
 3770	lousy dew yoana salacious lei	4	decent	
 3771	bad gray salacious lychee chuhai	3	decent	
 3772	drinkable Alewife&trade; Ale	3	good	
@@ -3784,14 +3784,14 @@
 3830	scorching water-polo cap	0		Hot Damage: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	perfectly mixed Typical Tavern swill	3	EPIC	
 3832	artisanal special extra-dry spinning tropical swill	5	EPIC	Effect: "Pop-eyed", Effect Duration: 50
-3833	drinkable blue bouncing fruity girl swill	3	good	
+3833	drinkable bouncing blue fruity girl swill	3	good	
 3834	delicious blended swill	4	awesome	
 3835	costume wardrobe	0		Softcore Only
-3836	wool coward's careful Tesla Elvish sunglasses	0		Monster Level: -30, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	wool coward's careful Tesla Elvish sunglasses	0		Monster Level: -30, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	huge anniversary safety glass vest of Leguizamo	0		Monster Level: +20
 3838	lion tamer's anniversary burlap belt	0		Experience (familiar): +2
 3839	toasty anniversary balsa wood socks	0		Hot Damage: +5
-3840	huge ghostly anniversary latex mask	0		Familiar Weight: +1
+3840	ghostly huge anniversary latex mask	0		Familiar Weight: +1
 3841	chaotic anniversary pewter cape	0		Spell Critical Percent: +10
 3842	out-of-tune biwa of horror	0		Spooky Spell Damage: +25
 3843	fortified dented harmonica	0		Damage Absorption: +60
@@ -3852,7 +3852,7 @@
 3898	bottle of G&uuml;-Gone	0		
 3901	skewed cyan seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
-3903	green skewed figurine of a baby seal	0		Class: "Seal Clubber"
+3903	skewed green figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	narrow figurine of an seal	0		Class: "Seal Clubber"
 3906	skewed figurine of a sleek seal	0		Class: "Seal Clubber"
@@ -3878,7 +3878,7 @@
 3926	rosewater-soaked arcane researcher's spiky turtle shield	0		Experience Percent (Mysticality): +10, Stench Resistance: +3, Damage Reduction: 8
 3927	turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
-3929	shaking blinking grinning turtle	0		
+3929	blinking shaking grinning turtle	0		
 3930	quadruple-galvanized shaking tainted seal's blood	0		Effect: "The Two-Prong Crown", Effect Duration: 12
 3931	bouncing brainy severed flipper of Gandalf	0		Mysticality: +5, Spell Critical Percent: +20, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
@@ -3895,9 +3895,9 @@
 3943	Van der Graaf educational infernal toilet brush	0		Experience: +1, MP Regen Min: 5, MP Regen Max: 7, Class: "Seal Clubber"
 3944	squat blinking flame-retardant stylish shadowy seal eye	0		Moxie: +25, Hot Resistance: +1, Class: "Seal Clubber"
 3945	oyster egg balloon of bravery	0		Spooky Resistance: +5
-3946	red mirror Clan VIP Lounge invitation	0		Free Pull
+3946	mirror red Clan VIP Lounge invitation	0		Free Pull
 3947	Clan VIP Lounge key	0		Free Pull
-3948	spinning lime green Meat	0		
+3948	lime green spinning Meat	0		
 3949	twirling treasure chest	0		
 3950	key	0		
 3951	Baron von Ratsworth	0		
@@ -3940,7 +3940,7 @@
 3988	turtle shell	0		
 3989	turtle shell powder	0		
 3990	chilly turtle shell helmet	0		Cold Damage: +5, Familiar Effect: "hot atk, cap 8"
-3991	bouncing tumbling slime-soaked hypophysis	0		Skill: "Slimy Sinews"
+3991	tumbling bouncing slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
@@ -3987,7 +3987,7 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	shaking caustic slime nodule	0		
 4037	flavorless shaking slimy sweetbreads	3	decent	
-4038	bad boozy bouncing slimy fermented bile bladder	5	decent	
+4038	boozy bad bouncing slimy fermented bile bladder	5	decent	
 4039	altered narrow slimy alveolus	1		
 4040	shaking memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	greedy pig-iron helm of doom	0		Spooky Spell Damage: +50, Meat Drop: +20, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
@@ -4032,9 +4032,9 @@
 4080	fortified grisly shield of horror	0		Damage Absorption: +60, Spooky Spell Damage: +25, Slime Hates It: +1, Damage Reduction: 13
 4081	corroded breeches of Gandalf of the brazier	0		Spell Critical Percent: +20, Hot Spell Damage: +25, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	Jack Frost's Sinatra's pernicious cudgel	0		Experience (Moxie): +5, Cold Spell Damage: +50, Slime Hates It: +1
-4083	jumbo stale jittery twirling cupcake-in-a-cup	5	decent	Last Available: "2009-06"
+4083	jumbo stale twirling jittery cupcake-in-a-cup	5	decent	Last Available: "2009-06"
 4084	spinning pool of liquid	0		Last Available: "2009-06"
-4085	half-sized adequate mirror protein paste	2	good	Last Available: "2009-06"
+4085	adequate half-sized mirror protein paste	2	good	Last Available: "2009-06"
 4086	ribald veiny cyber-mattock	0		Maximum HP: +10, Sleaze Damage: +10, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	tumbling X-37 gun	0		Last Available: "2009-06"
@@ -4081,15 +4081,15 @@
 4129	clever curative hardened slime belt of dire peril	0		Weapon Damage: +20, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 4130	blinking empty agua de vida bottle	0		Last Available: "2009-06"
 4131	pickled boot plant	1	awesome	Last Available: "2009-06"
-4132	hand-crafted watered-down sham champagne	2	EPIC	Last Available: "2009-06"
+4132	watered-down hand-crafted sham champagne	2	EPIC	Last Available: "2009-06"
 4133	warmed magnetized tempura air	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 24
 4134	pickled shaking pressurized potion of pneumaticity	0		Effect: "Human-Machine Hybrid", Effect Duration: 23
-4135	blurry wobbly cyan moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	wobbly avaricious studded Bag o' Tricks of the blizzard of bravery	0		Damage Absorption: +80, Cold Spell Damage: +25, Spooky Resistance: +5, Meat Drop: +30, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4135	cyan wobbly blurry moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
+4136	wobbly avaricious studded Bag o' Tricks of the blizzard of bravery	0		Damage Absorption: +80, Cold Spell Damage: +25, Spooky Resistance: +5, Meat Drop: +30, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
-4140	mirror fuchsia a folded paper strip	0		
+4140	fuchsia mirror a folded paper strip	0		
 4141	a crinkled paper strip	0		
 4142	ghostly a crumpled paper strip	0		
 4143	jittery a ragged paper strip	0		
@@ -4110,7 +4110,7 @@
 4158	rock	0		Last Available: "2009-09"
 4159	jittery rock lobster	0		Last Available: "2009-09"
 4160	hand-crafted narrow pebblebr&auml;u	3	EPIC	Last Available: "2009-09"
-4161	immense special normal rocky road ice cream	8	good	Effect: "Ocelot Eyes", Effect Duration: 10, Last Available: "2009-09"
+4161	special normal immense rocky road ice cream	8	good	Effect: "Ocelot Eyes", Effect Duration: 10, Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	double-polymerized liquefied children of the candy corn	0		Effect: "Tomato Power", Effect Duration: 35
 4164	warmed wobbly Good 'n' Slimy	0		Effect: "Briny Blood", Effect Duration: 49
@@ -4158,15 +4158,15 @@
 4206	huge jittery Jeselnik's nippy brand new key	0		Cold Damage: +10, Sleaze Damage: +25
 4207	mirror dorsal fin of Calamity Jane	0		Critical Hit Percent: +15, Damage Reduction: 13
 4208	skate skates	0		
-4209	twirling skewed narrow skate skin	0		
+4209	narrow twirling skewed skate skin	0		
 4210	roller skate decoy	0		
-4211	mirror blurry mermaid's purse	0		
+4211	blurry mirror mermaid's purse	0		
 4212	underwater slingshot	0		
 4213	green rosewater-soaked skate blade of dire peril	0		Weapon Damage: +20, Stench Resistance: +3
-4214	mirror tumbling spangly unitard	0		
+4214	tumbling mirror spangly unitard	0		
 4215	mirror twirling stiffened stylish collapsible baton	0		Moxie: +25, Damage Reduction: 1
 4216	groupie lipstick	0		
-4217	olive skewed groupie bra	0		
+4217	skewed olive groupie bra	0		
 4218	corrupted shaking groupie spangles	0		Effect: "Shot in the Arse", Effect Duration: 61
 4219	shaking asbestos-lined skate board of doom	0		Spooky Spell Damage: +50, Hot Resistance: +5
 4220	olive S.A.V.E. flyer	0		
@@ -4180,7 +4180,7 @@
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
 4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
-4231	cyan squat ice skate decoy	0		
+4231	squat cyan ice skate decoy	0		
 4232	ice skate doll	0		
 4233	twirling hacienda key	0		
 4234	ghostly pat&eacute; knife of the early riser	0		Adventures: +7
@@ -4189,7 +4189,7 @@
 4237	mirror Van der Graaf cheese-slicer	0		MP Regen Min: 5, MP Regen Max: 7
 4238	stale mirror beef jerky	3	decent	
 4239	hardy pipe wrench	0		Maximum HP: +50
-4240	aerosolized wobbly wobbly tumbling gun cleaning kit	0		Effect: "Pork Power", Effect Duration: 45
+4240	aerosolized tumbling wobbly wobbly gun cleaning kit	0		Effect: "Pork Power", Effect Duration: 45
 4241	sleep mask of the cheetah	0		Initiative: +60, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	wholesome sock garters	0		Maximum HP Percent: +10, Single Equip
 4243	galvanized mariachi toothpaste	0		Effect: "Filled with Magic", Effect Duration: 46
@@ -4210,7 +4210,7 @@
 4258	toothsome super-sized spinning chocolate-covered scarab beetle	5	awesome	Last Available: "2009-10"
 4259	tolerable blinking mulled cider	4	good	Last Available: "2009-10"
 4260	narrow wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	shaking squat pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4261	squat shaking pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	upside-down mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
 4264	lime green blurry MacGyver's bark boxers	0		Maximum MP: +100, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
@@ -4249,15 +4249,15 @@
 4297	scandalous Newton's Ass-Stompers of Violence of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Sleaze Damage: +5, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	inspector's lard-coated Brand of Violence of the businessman	0		Sleaze Spell Damage: +25, Item Drop: +15, Meat Drop: +50, Conditional Skill (Equipped): "Brand"
 4299	electrified Novelty Belt Buckle of Violence of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-4300	manspreader's Fonzie's Da Vinci's Lens of Violence	0		Experience (Mysticality): +5, Experience (Moxie): +1, Monster Level: +10, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	manspreader's Fonzie's Da Vinci's Lens of Violence	0		Experience (Mysticality): +5, Experience (Moxie): +1, Monster Level: +10, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	lion tamer's Jim Carey's slick Pigsticker of Violence	0		Moxie: +10, Monster Level: +25, Experience (familiar): +2
-4302	squat supercharged wizardly Jodhpurs of Violence of terror	0		Mysticality: +25, Maximum MP Percent: +30, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	squat supercharged wizardly Jodhpurs of Violence of terror	0		Mysticality: +25, Maximum MP Percent: +30, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	upside-down narrow prompt wicked Sinatra's Cold Stone of Hatred	0		Experience (Moxie): +5, Spell Damage: +5, Adventures: +3, Conditional Skill (Equipped): "Chilling Grip"
 4304	jittery foul-smelling lion tamer's educational Girdle of Hatred	0		Experience: +1, Experience (familiar): +2, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	Annie Oakley's educational Staff of Simmering Hatred of wisdom	0		Mysticality: +15, Experience: +1, Critical Hit Percent: +20
-4306	quilted Rosewater's weightlifter's Pantaloons of Hatred	0		Muscle: +15, Mysticality Percent: +30, Damage Absorption: +40, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	quilted Rosewater's weightlifter's Pantaloons of Hatred	0		Muscle: +15, Mysticality Percent: +30, Damage Absorption: +40, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	ghostly mirror stanky brainy Fuzzy Slippers of Hatred of the brazier	0		Mysticality: +5, Hot Spell Damage: +25, Stench Spell Damage: +25, Single Equip
-4308	Jeselnik's nasty medical-grade Lens of Hatred	0		Stench Damage: +5, Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	Jeselnik's nasty medical-grade Lens of Hatred	0		Stench Damage: +5, Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	stanky Fonzie's thinker's Treads of Loathing	0		Mysticality: +10, Experience (Moxie): +1, Stench Spell Damage: +25, Single Equip
 4310	double-paned dog trainer's vibrating Scepter of Loathing	0		Maximum MP Percent: +10, Experience (familiar): +1, Cold Resistance: +5
 4311	cool Belt of Loathing of wisdom of the empath	0		Mysticality: +15, Moxie: +5, Familiar Weight: +5, Single Equip
@@ -4280,7 +4280,7 @@
 4328	squat suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	huge bag of many confections	0		Last Available: "2009-12"
 4330	normal skewed candy kneecapping stick	4	good	Last Available: "2009-12"
-4331	spoiled skewed narrow licorice garrote	4	crappy	Last Available: "2009-12"
+4331	spoiled narrow skewed licorice garrote	4	crappy	Last Available: "2009-12"
 4332	scorching candy knuckles	0		Hot Damage: +25, Last Available: "2009-12"
 4333	gigantic stale jawbruiser	8	decent	Last Available: "2010-12"
 4334	non-pressed pulsating chocolate car	0		Effect: "Lobos Fresh", Effect Duration: 32, Last Available: "2009-12"
@@ -4293,7 +4293,7 @@
 4341	extra-deionized BitterSweetTarts	0		Effect: "Insulated Trousers", Effect Duration: 48, Last Available: "2009-12"
 4342	liquefied squat skewed Polka Pop	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 33, Last Available: "2009-12"
 4343	skewed Crimbuck	0		Last Available: "2009-12"
-4344	squat teal Crimbo wreath	0		Last Available: "2009-12"
+4344	teal squat Crimbo wreath	0		Last Available: "2009-12"
 4345	string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
@@ -4309,15 +4309,15 @@
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	upside-down A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	toothsome diet expired can of franks 'n' beans	1	awesome	Last Available: "2009-12"
-4361	practically non-alcoholic acceptable fancy expired bottle of peppermint schnapps	1	good	Effect: "Burning Tongue", Effect Duration: 15, Last Available: "2009-12"
+4360	diet toothsome expired can of franks 'n' beans	1	awesome	Last Available: "2009-12"
+4361	acceptable practically non-alcoholic fancy expired bottle of peppermint schnapps	1	good	Effect: "Burning Tongue", Effect Duration: 15, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	modified unsweetened vacuum-sealed red elven suicide capsule	0		Effect: "Covetous Robbery", Effect Duration: 24, Last Available: "2009-12"
 4365	bland penguin focaccia bread	4	decent	Last Available: "2009-12"
 4366	perfectly mixed herringcello	4	EPIC	Last Available: "2009-12"
 4367	practically non-alcoholic perfectly mixed twirling pulsating elven cellocello	1	EPIC	Last Available: "2009-12"
-4368	wobbly skewed wrench handle	0		Last Available: "2009-12"
+4368	skewed wobbly wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	blinking bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	peanut brittle shield of incineration	0		Hot Spell Damage: +50, Damage Reduction: 3, Last Available: "2009-12"
 4390	savvy Red Rover BB gun of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Last Available: "2009-12"
-4391	perfumed red-and-green sweater	0		Stench Resistance: +5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	perfumed red-and-green sweater	0		Stench Resistance: +5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	blue Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	double-galvanized colloidal Crimbo peppermint bark	0		Effect: "Tea-hee", Effect Duration: 64, Last Available: "2009-12"
 4394	quadruple-irradiated activated Crimbo fudge	0		Effect: "Neuroplastici Tea", Effect Duration: 56, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	twirling sizzling cheese sword	0		Hot Damage: +10, Softcore Only, Last Available: "2010-01"
 4400	frosty cheese diaper	0		Cold Spell Damage: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	blurry frightening cheese wheel	0		Spooky Damage: +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	nasty cheese eye	0		Stench Damage: +5, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	nasty cheese eye	0		Stench Damage: +5, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	dog trainer's Staff of Queso Escusado of the brute of terror	0		Muscle Percent: +30, Experience (familiar): +1, Spooky Spell Damage: +10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	pulsating The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	spinning Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	stale half-sized quantum taco	0		Last Available: "2010-10"
-4413	drinkable cyan narrow Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	drinkable narrow cyan Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	stiffened sealhide hood	0		Damage Reduction: 1, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	deadly sealhide leggings	0		Weapon Damage: +5, Familiar Effect: "1xVolley, cap 40"
@@ -4374,7 +4374,7 @@
 4423	olive sealhide snare	0		
 4424	squat puzzling trophy	0		
 4425	polarized triple-modified extra-unsweetened upside-down sealhide seal doll	0		Effect: "Truly Gritty", Effect Duration: 64
-4426	huge green hymnal	0		Skill: "Canticle of Carboloading"
+4426	green huge hymnal	0		Skill: "Canticle of Carboloading"
 4428	teal glowstick on a string of the boozehound	0		Booze Drop: +100
 4429	candy necklace of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 4430	narrow nippy teddybear backpack	0		Cold Damage: +10
@@ -4412,8 +4412,8 @@
 4464	irradiated chocolate pasta spoon	0		Effect: "Salamander In Your Stomach", Effect Duration: 58
 4465	anodized ghostly chocolate saucepan	0		Effect: "Wasabi With You", Effect Duration: 61
 4466	energized altered chocolate disco ball	0		Effect: "Pwnd", Effect Duration: 58
-4467	liquefied galvanized squat pulsating chocolate stolen accordion	0		Effect: "Brain Freeze", Effect Duration: 34
-4468	olive Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4467	liquefied galvanized pulsating squat chocolate stolen accordion	0		Effect: "Brain Freeze", Effect Duration: 34
+4468	olive Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
 4471	wobbly yellow horrifying BRICKO hat	0		Spooky Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
@@ -4424,7 +4424,7 @@
 4476	blurry BRICKO oyster	0		Last Available: "2010-02"
 4477	green BRICKO turtle	0		Last Available: "2010-02"
 4478	fuchsia BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4462,7 +4462,7 @@
 4514	fancy rotten twirling Humpty Dumplings	3	crappy	Effect: "Crusty Head", Effect Duration: 5, Last Available: "2010-03"
 4515	moldy shaking Lobster <i>qua</i> Grill	3	crappy	Last Available: "2010-03"
 4516	tolerable practically non-alcoholic missing wine	1	good	Last Available: "2010-03"
-4517	super-sized moldy lime green matter custard	5	crappy	Last Available: "2010-03"
+4517	moldy super-sized lime green matter custard	5	crappy	Last Available: "2010-03"
 4518	deionized blurry comfit?	0		Effect: "Petit Forbearance", Effect Duration: 31, Last Available: "2010-03"
 4519	upside-down ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	squat studded flamingo mallet of courage	0		Damage Absorption: +80, Spooky Resistance: +3, Last Available: "2010-03"
@@ -4470,7 +4470,7 @@
 4522	mirror Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	toasty rosy-cheeked eye of the Tiger-lily	0		Maximum HP Percent: +30, Hot Damage: +5, Last Available: "2010-03"
 4524	veiny wig of the storm	0		Maximum HP: +10, Maximum MP Percent: +40, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	adequate super-sized donut	5	good	Last Available: "2010-03"
+4525	super-sized adequate donut	5	good	Last Available: "2010-03"
 4526	rotten bucket of honey	3	crappy	Last Available: "2010-03"
 4527	wobbly hale personal trainer's elephant stinger	0		Experience Percent (Muscle): +10, Maximum HP: +20, Last Available: "2010-03"
 4528	normal dragon snaps	4	good	Last Available: "2010-03"
@@ -4492,7 +4492,7 @@
 4544	porpoise	0		Last Available: "2010-03"
 4545	narrow pocketwatch	0		Last Available: "2010-03"
 4546	bandersnatch	0		Last Available: "2010-03"
-4547	wobbly ghostly caterpillar	0		Last Available: "2010-03"
+4547	ghostly wobbly caterpillar	0		Last Available: "2010-03"
 4548	tumbling walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
 4550	huge dodo	0		Last Available: "2010-03"
@@ -4508,15 +4508,15 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	narrow can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	bad high-proof world's most unappetizing beverage	8	decent	Last Available: "2010-04"
+4563	high-proof bad world's most unappetizing beverage	8	decent	Last Available: "2010-04"
 4564	slippery when wet shield of courage	0		Spooky Resistance: +3, Damage Reduction: 6, Last Available: "2010-04"
-4565	tiny normal bouncing raisin	1	good	Last Available: "2010-04"
+4565	normal tiny bouncing raisin	1	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	twirling flyest of shirts of James Dean of Flo-Jo	0		Experience (Moxie): +3, Initiative: +100, Last Available: "2010-04"
 4568	spoiled a dance upon the palate	3	crappy	Last Available: "2010-04"
 4569	bland prehistoric meteorite jawbreaker	3	decent	Last Available: "2010-04"
 4570	blinking Crazyleg's razor	0		Last Available: "2010-04"
-4571	super-sized normal squirmy violent party snack	5	good	Last Available: "2010-04"
+4571	normal super-sized squirmy violent party snack	5	good	Last Available: "2010-04"
 4572	huge nasty can-you-dig-it?	0		Stench Damage: +5, Last Available: "2010-04"
 4573	jittery The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4524,9 +4524,9 @@
 4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4577	teal bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	galvanized ionized mirror blue Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Spookypants", Effect Duration: 22, Last Available: "2010-04"
+4579	galvanized ionized blue mirror Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Spookypants", Effect Duration: 22, Last Available: "2010-04"
 4580	tumbling weightlifter's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Muscle: +15, Last Available: "2010-04"
-4581	fireproof T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of terror	0		Spooky Spell Damage: +10, Hot Resistance: +3, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	fireproof T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of terror	0		Spooky Spell Damage: +10, Hot Resistance: +3, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	gray fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	adequate bouncing six wedges of goat cheese	4	good	
@@ -4550,7 +4550,7 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	blinking bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	Jack Frost's slick bottle of Goldschn&ouml;ckered	0		Moxie: +10, Cold Spell Damage: +50, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	Jack Frost's slick bottle of Goldschn&ouml;ckered	0		Moxie: +10, Cold Spell Damage: +50, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	huge decent upside-down sun-dried tofu	9	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	acceptable wobbly soyburger juice	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	upside-down respected companion biscuit	0		Last Available: "2010-08"
@@ -4561,7 +4561,7 @@
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	gray twirling wizardly Crown of Thrones	0		Mysticality: +25, Softcore Only, Last Available: "2010-05"
 4615	weak artisanal Cinco Mayo Lager	2	super EPIC	Last Available: "2010-05"
-4616	spinning squat Underworld sapling	0		Last Available: "2009-10"
+4616	squat spinning Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	green frisbee	0		Free Pull, Last Available: "2011-12"
@@ -4574,7 +4574,7 @@
 4626	maroon superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	ghostly parachute guy	0		Last Available: "2010-06"
-4629	MacGyver's plastic spider ring	0		Maximum MP: +100, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	MacGyver's plastic spider ring	0		Maximum MP: +100, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	stanky plastic kazoo	0		Stench Spell Damage: +25, Last Available: "2010-06"
 4631	executive inflatable baseball bat	0		Meat Drop: +40, Last Available: "2010-06"
 4632	skewed chaotic resourceful googly-star hat	0		Maximum MP: +50, Spell Critical Percent: +10, Last Available: "2010-06", Familiar Effect: "atk"
@@ -4659,7 +4659,7 @@
 4711	lime green sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	massive decent lemon popsicle	8	good	
+4714	decent massive lemon popsicle	8	good	
 4715	bland popsicle	4	decent	
 4716	bland strawberry popsicle	4	decent	
 4717	normal half-sized liver popsicle	2	good	
@@ -4667,14 +4667,14 @@
 4719	razor-sharp Hollandaise helmet	0		Weapon Damage Percent: +25, Familiar Effect: "atk, cap 2"
 4720	mirror organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	huge microwave stogie	0		Last Available: "2011-12"
-4722	snack-sized spoiled liver and let pie	2	crappy	Last Available: "2010-10"
-4723	super-sized bland badass pie	5	decent	Last Available: "2010-10"
-4724	adequate thick upside-down bouncing shoo-fish pie	5	good	Last Available: "2010-10"
+4722	spoiled snack-sized liver and let pie	2	crappy	Last Available: "2010-10"
+4723	bland super-sized badass pie	5	decent	Last Available: "2010-10"
+4724	adequate thick bouncing upside-down shoo-fish pie	5	good	Last Available: "2010-10"
 4725	low-calorie rotten piping organ pie	1	crappy	Last Available: "2010-10"
 4726	moldy igloo pie	3	crappy	Last Available: "2010-10"
 4727	flavorless tumbling stomach turnover	3	decent	Last Available: "2010-10"
-4728	stale massive dead lights pie	7	decent	Last Available: "2010-10"
-4729	spoiled thick mirror red throbbing organ pie	5	crappy	Last Available: "2010-10"
+4728	massive stale dead lights pie	7	decent	Last Available: "2010-10"
+4729	thick spoiled mirror red throbbing organ pie	5	crappy	Last Available: "2010-10"
 4730	Usain Bolt's stop shield	0		Initiative: +80, Damage Reduction: 6, Last Available: "2009-12"
 4731	huge nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,8 +4683,8 @@
 4735	blue prop sword	0		Familiar Weight: +5
 4736	upside-down tangle of rat tails	0		
 4737	perfumed beer-soaked mop	0		Stench Resistance: +5
-4738	bad special practically non-alcoholic day-old beer	1	decent	Effect: "Worth Your Salt", Effect Duration: 45
-4739	watered-down acceptable yellow plain beer	2	good	
+4738	special practically non-alcoholic bad day-old beer	1	decent	Effect: "Worth Your Salt", Effect Duration: 45
+4739	acceptable watered-down yellow plain beer	2	good	
 4740	distilled hand-crafted overpriced &quot;imported&quot; beer	5	EPIC	
 4741	skewed smiling rat	0		
 4742	ghostly rat tooth polish	0		Familiar Weight: +5
@@ -4703,7 +4703,7 @@
 4755	auspicious Da Vinci's boneana hammock	0		Experience (Mysticality): +5, Item Drop: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	red Stabonic scroll	0		Last Available: "2010-10"
-4758	polymerized vacuum-sealed skewed cyan candy skeleton	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 49, Last Available: "2020-09"
+4758	polymerized vacuum-sealed cyan skewed candy skeleton	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 49, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	huge Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	small decent wobbly CRIMBCOIDS mints	2	good	Last Available: "2011-01"
+4818	decent small wobbly CRIMBCOIDS mints	2	good	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	moldy blinking CRIMBCOLOAF	4	crappy	Last Available: "2011-01"
 4821	massive moldy shaking circular CRIMBCOOKIE	9	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,8 +4745,8 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	flavorless enchanted triangular CRIMBCOOKIE	4	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	adequate mirror blurry square CRIMBCOOKIE	3	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4839	enchanted flavorless triangular CRIMBCOOKIE	4	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4840	adequate blurry mirror square CRIMBCOOKIE	3	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	nasty frosty dance instructor's bindlestocking	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Stench Damage: +5, Last Available: "2010-12"
 4842	shaking sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4783,11 +4783,11 @@
 4874	wobbly gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	polarized adjusted blinking chocolate bath ball	0		Effect: "Marinated", Effect Duration: 21, Last Available: "2011-01"
-4877	adjusted colloidal upside-down mirror bacon bath ball	0		Effect: "Berry Critical", Effect Duration: 38, Last Available: "2011-01"
+4877	adjusted colloidal mirror upside-down bacon bath ball	0		Effect: "Berry Critical", Effect Duration: 38, Last Available: "2011-01"
 4878	liquefied incense bath ball	0		Effect: "Stop the Presses!", Effect Duration: 42, Last Available: "2011-01"
-4879	triple-enhanced liquefied mirror pulsating green myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 67, Last Available: "2011-01"
+4879	triple-enhanced liquefied green pulsating mirror myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 67, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	hand-crafted high-proof CRIMBCO wine	6	EPIC	Last Available: "2011-01"
+4881	high-proof hand-crafted CRIMBCO wine	6	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	narrow toe jam	0		Last Available: "2011-01"
 4884	bland toe jam toast	3	decent	Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	spoiled festive sausage	4	crappy	Last Available: "2011-01"
-4895	rotten small holiday cheese log	2	crappy	Last Available: "2011-01"
+4895	small rotten holiday cheese log	2	crappy	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	therapeutic BGE 'ferocious fruit' shirt of doom	0		Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-12"
 4898	cyan fireproof hardened BGE 'cuddly critter' shirt	0		Damage Reduction: 3, Hot Resistance: +3, Last Available: "2010-12"
@@ -4833,7 +4833,7 @@
 4924	blinking Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
 4925	frosty Loathing Legion pizza stone	0		Cold Spell Damage: +10, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
 4926	skewed Loathing Legion universal screwdriver	0		Last Available: "2011-01"
-4927	narrow purple Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
+4927	purple narrow Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
 4928	cyan Loathing Legion hammer of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2011-01"
 4929	Uncle Crimbo's Sack	0		Last Available: "2011-01"
 4930	ghostly Folder Holder	0		Last Available: "2013-08"
@@ -4861,7 +4861,7 @@
 4958	dog trainer's Knob Goblin deluxe scimitar	0		Experience (familiar): +1
 4959	spoiled half-sized Knob nuts	2	crappy	
 4960	lousy skewed Cobb's Knob Wurstbrau	3	decent	
-4961	lime green narrow Subject 37 file	0		
+4961	narrow lime green Subject 37 file	0		
 4962	blinking knitted brainy mysterious lapel pin	0		Mysticality: +5, Cold Resistance: +3, Single Equip
 4963	state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
@@ -4897,8 +4897,8 @@
 4994	yellow Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
-4997	lime green huge Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
-4998	shaking blinking Alice's Army Foil Nurse	0		Last Available: "2011-03"
+4997	huge lime green Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
+4998	blinking shaking Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	huge Alice's Army Foil Lanceman	0		Last Available: "2011-03"
@@ -4913,20 +4913,20 @@
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	upside-down cyan Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	moldy jumbo wasabi pocky	5	crappy	Last Available: "2011-03"
-5014	spoiled miniature tobiko pocky	2	crappy	Last Available: "2011-03"
+5013	jumbo moldy wasabi pocky	5	crappy	Last Available: "2011-03"
+5014	miniature spoiled tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	normal natto pocky	4	good	Last Available: "2011-03"
 5016	drinkable wasabi-infused sake	3	good	Last Available: "2011-03"
 5017	hand-crafted spinning tobiko-infused sake	4	EPIC	Last Available: "2011-03"
 5018	mediocre spirit-forward wobbly natto-infused sake	5	decent	Last Available: "2011-03"
-5019	liquefied adjusted jittery blurry wasabi marble soda	0		Effect: "Smelly Pants", Effect Duration: 20, Last Available: "2011-03"
+5019	liquefied adjusted blurry jittery wasabi marble soda	0		Effect: "Smelly Pants", Effect Duration: 20, Last Available: "2011-03"
 5020	Vulcanized yellow tobiko marble soda	0		Effect: "Disco Nirvana", Effect Duration: 32, Last Available: "2011-03"
 5021	liquefied frozen wobbly natto marble soda	0		Effect: "Florid Cheeks", Effect Duration: 13, Last Available: "2011-03"
 5022	green jittery Alice's Army booster box	0		Last Available: "2011-03"
 5023	aerosolized anodized elderly jawbreaker	0		Effect: "Ooh, Sour!", Effect Duration: 50, Last Available: "2020-09"
 5024	watered-down bad marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
 5025	irresponsibly strong tolerable cranberry schnapps	7	good	Last Available: "2011-03"
-5026	watered-down mediocre breaded beer	2	decent	Last Available: "2011-03"
+5026	mediocre watered-down breaded beer	2	decent	Last Available: "2011-03"
 5027	hand-crafted soy cordial	3	super ultra mega EPIC	Last Available: "2011-03"
 5028	ghostly Oprah's curative hardened astral bludgeon	0		Damage Reduction: 3, Maximum MP Percent: +50, HP Regen Min: 3, HP Regen Max: 5
 5029	smartaleck's astral shield of the wise owl	0		Mysticality: +20, Moxie Percent: +30, Damage Reduction: 15
@@ -4967,12 +4967,12 @@
 5064	upside-down Salsa de las Epocas	0		Last Available: "2011-04"
 5065	adequate spaghetti con calaveras	4	good	Last Available: "2011-04"
 5066	gray s'more gun	0		Last Available: "2011-04"
-5067	low-calorie rotten popcorn	1	crappy	Last Available: "2011-04"
-5068	enchanted moldy chaos popcorn	4	crappy	Last Available: "2011-04"
+5067	rotten low-calorie popcorn	1	crappy	Last Available: "2011-04"
+5068	moldy enchanted chaos popcorn	4	crappy	Last Available: "2011-04"
 5069	horrifying hole of the wise owl of bravery	0		Mysticality: +20, Spooky Damage: +25, Spooky Resistance: +5, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	small spoiled shaking s'more	0	crappy	Last Available: "2011-04"
-5072	blue squat diamond ring	0		Last Available: "2011-04"
+5072	squat blue diamond ring	0		Last Available: "2011-04"
 5073	perfectly mixed Russian Ice	4	EPIC	Last Available: "2011-04"
 5074	groovy clay ashtray	0		Moxie Percent: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	blue zippy lanyard	0		Initiative: +20, Single Equip, Last Available: "2011-05"
@@ -4982,7 +4982,7 @@
 5079	toasty vibrating Van der Graaf helmet	0		Maximum MP Percent: +10, Hot Damage: +5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	blurry sharpshooter's crutch	0		Critical Hit Percent: +10, Last Available: "2011-05"
 5081	bouncing lime green banded shock belt	0		Damage Absorption: +100, Single Equip, Last Available: "2011-05"
-5082	alkaline huge fuchsia Okee-Dokee soda	0		Effect: "Arse-a'fire", Effect Duration: 67, Last Available: "2011-05"
+5082	alkaline fuchsia huge Okee-Dokee soda	0		Effect: "Arse-a'fire", Effect Duration: 67, Last Available: "2011-05"
 5083	vibrating rubber band gun	0		Maximum MP Percent: +10, Last Available: "2011-05"
 5084	spinning foul-smelling pin-stripe slacks	0		Stench Damage: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	zippy gloves	0		Initiative: +20, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	wobbly hideous egg	0		Last Available: "2011-05"
 5107	smooth jittery Jeppson's Malort	4	awesome	Last Available: "2011-06"
 5108	blurry fistful of ashes	0		
-5109	stress ball of the storm	0		Maximum MP Percent: +40, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	stress ball of the storm	0		Maximum MP Percent: +40, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	wobbly Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	frosty Ultracolor&trade; shirt	0		Cold Spell Damage: +10, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5019,7 +5019,7 @@
 5116	blinking A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
-5119	maroon blinking shaking busted wings	0		
+5119	blinking maroon shaking busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	narrow Da Vinci's smooth Admiral's hat of wisdom	0		Mysticality: +15, Moxie: +15, Experience (Mysticality): +5, Last Available: "2011-05", Familiar Effect: "atk"
 5122	up-at-dawn sage aviator's cap of the blizzard	0		Mysticality Percent: +10, Cold Spell Damage: +25, Adventures: +5, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
@@ -5031,7 +5031,7 @@
 5128	blinking Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	fuchsia Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
-5131	extra-moist huge spinning Ultrasoldier Serum	0		Effect: "Ticking Clock", Effect Duration: 65, Last Available: "2011-06"
+5131	extra-moist spinning huge Ultrasoldier Serum	0		Effect: "Ticking Clock", Effect Duration: 65, Last Available: "2011-06"
 5132	normal bite-sized elven hardtack	1	good	Last Available: "2011-06"
 5133	weak bad fuchsia elven squeeze	2	decent	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
@@ -5057,7 +5057,7 @@
 5154	squat Van der Graaf Moonthril Longbow	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-06"
 5155	Moonthril Cuirass of the empath	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-06"
 5156	weightlifter's plush alielf	0		Muscle: +15, Last Available: "2011-06"
-5157	deionized blinking blue Comet Drop	0		Effect: "Old Time Hydration", Effect Duration: 41, Last Available: "2020-09"
+5157	deionized blue blinking Comet Drop	0		Effect: "Old Time Hydration", Effect Duration: 41, Last Available: "2020-09"
 5158	boxer's plush dogcat	0		Muscle Percent: +10, Last Available: "2011-06"
 5159	plush hamsterpus of doom	0		Spooky Spell Damage: +50, Last Available: "2011-06"
 5160	sinister plush ferrelf	0		Spell Damage: +10, Last Available: "2011-06"
@@ -5070,13 +5070,13 @@
 5167	narrow synthetic dog hair pill	0		Last Available: "2011-06"
 5168	bouncing skewed distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
-5170	magnetized energized bouncing skewed transporter transponder	0		Effect: "Superhuman Sarcasm", Effect Duration: 60, Last Available: "2011-06"
+5170	magnetized energized skewed bouncing transporter transponder	0		Effect: "Superhuman Sarcasm", Effect Duration: 60, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	spinning Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	artisanal Saison du Lune	3	EPIC	Last Available: "2011-06"
 5175	lousy Moonthril Schnapps	4	decent	Last Available: "2011-06"
-5176	distilled drinkable blurry Wrecked Generator	5	good	Last Available: "2011-06"
+5176	drinkable distilled blurry Wrecked Generator	5	good	Last Available: "2011-06"
 5177	normal Spaghetti with Moonballs	3	good	Last Available: "2011-06"
 5178	moldy blue Crepes a la Lune	4	crappy	Last Available: "2011-06"
 5179	adequate Moon Pie	4	good	Last Available: "2011-06"
@@ -5086,11 +5086,11 @@
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	twirling blinking Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
-5186	teal jittery Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
+5186	jittery teal Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	electrified honey stick	0		Effect: "Flambé-a-thon", Effect Duration: 49
 5189	chilled triple-liquefied moist double-ice gum	0		Effect: "La Bamba", Effect Duration: 53, Last Available: "2011-04"
-5190	skewed asbestos-lined Lo Pan's electrified Operation Patriot Shield	0		Spell Critical Percent: +30, Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	skewed asbestos-lined Lo Pan's electrified Operation Patriot Shield	0		Spell Critical Percent: +30, Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	yellow squirming egg sac	0		Last Available: "2011-06"
 5192	nitrogenated corrupted corrupted data	0		Effect: "Healthy Green Glow", Effect Duration: 52, Last Available: "2011-06"
 5193	tumbling 11-inch knob sausage	0		
@@ -5102,10 +5102,10 @@
 5199	vaporized narrow beastly paste	1	good	Last Available: "2011-08"
 5200	dried paste	1	EPIC	Effect: "Warm Shoulders", Effect Duration: 20, Last Available: "2011-08"
 5201	dehydrated squat ectoplasmic paste	1	decent	Last Available: "2011-08"
-5202	powdered narrow skewed greasy paste	1	good	Effect: "Chunky", Effect Duration: 15, Last Available: "2011-08"
+5202	powdered skewed narrow greasy paste	1	good	Effect: "Chunky", Effect Duration: 15, Last Available: "2011-08"
 5203	vaporized pulsating bug paste	1	decent	Effect: "Armor-Plated", Effect Duration: 20, Last Available: "2011-08"
 5204	vaporized hippy paste	1	decent	Last Available: "2011-08"
-5205	denatured mirror jittery olive orc paste	1	awesome	Last Available: "2011-08"
+5205	denatured jittery olive mirror orc paste	1	awesome	Last Available: "2011-08"
 5206	twisted ghostly demonic paste	1	crappy	Last Available: "2011-08"
 5207	distilled jittery indescribably horrible paste	1	good	Effect: "Nightstalkin'", Effect Duration: 50, Last Available: "2011-08"
 5208	compressed paste	1	awesome	Last Available: "2011-08"
@@ -5116,18 +5116,18 @@
 5213	dried twirling Mer-kin paste	1	good	Effect: "Snobby", Effect Duration: 50, Last Available: "2011-08"
 5214	diluted jittery slimy paste	1	decent	Effect: "Object Detection", Effect Duration: 5, Last Available: "2011-08"
 5215	distilled penguin paste	1	EPIC	Last Available: "2011-08"
-5216	altered red skewed shaking elemental paste	1	decent	Effect: "From Nantucket", Effect Duration: 50, Last Available: "2011-08"
+5216	altered shaking red skewed elemental paste	1	decent	Effect: "From Nantucket", Effect Duration: 50, Last Available: "2011-08"
 5217	distilled pulsating cosmic paste	1	awesome	Last Available: "2011-08"
 5218	boiled huge hobo paste	1	good	Last Available: "2011-08"
 5219	altered red Crimbo paste	1	good	Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	pulsating fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	tumbling Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	tumbling Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	rotten Ur-Donut	3	crappy	Last Available: "2011-09"
 5225	fuchsia The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	practically non-alcoholic perfectly mixed special bucket of wine	1	super ultra mega turbo EPIC	Effect: "Serenity", Effect Duration: 15, Last Available: "2011-09"
+5227	perfectly mixed special practically non-alcoholic bucket of wine	1	super ultra mega turbo EPIC	Effect: "Serenity", Effect Duration: 15, Last Available: "2011-09"
 5228	bland fancy ultrafondue	4	decent	Effect: "There Wolf", Effect Duration: 45, Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	family-friendly furry halo	0		Sleaze Resistance: +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	blurry rock-hard frosty halo	0		Damage Reduction: 5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	wobbly Jim Carey's time halo	0		Monster Level: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	weak tolerable Lumineux Limnio	2	good	Last Available: "2011-09"
-5239	practically non-alcoholic drinkable ghostly Morto Moreto	1	good	Last Available: "2011-09"
+5238	tolerable weak Lumineux Limnio	2	good	Last Available: "2011-09"
+5239	drinkable practically non-alcoholic ghostly Morto Moreto	1	good	Last Available: "2011-09"
 5240	drinkable Temps Tempranillo	3	good	Last Available: "2011-09"
 5241	acceptable irresponsibly strong skewed Bordeaux Marteaux	7	good	Last Available: "2011-09"
 5242	acceptable Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	practically non-alcoholic tolerable Beignet Milgranet	1	good	Last Available: "2011-09"
-5244	artisanal fancy high-proof jittery Muschat	9	EPIC	Effect: "Ginger Snapped", Effect Duration: 5, Last Available: "2011-09"
-5245	massive normal cool jelly donut	10	good	Last Available: "2011-09"
+5244	artisanal high-proof fancy jittery Muschat	9	EPIC	Effect: "Ginger Snapped", Effect Duration: 5, Last Available: "2011-09"
+5245	normal massive cool jelly donut	10	good	Last Available: "2011-09"
 5246	flavorless shrapnel jelly donut	4	decent	Last Available: "2011-09"
 5247	moldy occult jelly donut	3	crappy	Last Available: "2011-09"
-5248	spoiled snack-sized thyme jelly donut	2	crappy	Last Available: "2011-09"
+5248	snack-sized spoiled thyme jelly donut	2	crappy	Last Available: "2011-09"
 5249	adequate danish	3	good	Last Available: "2011-09"
 5250	adequate thick blurry smashed danish	5	good	Last Available: "2011-09"
 5251	rotten forbidden danish	4	crappy	Last Available: "2011-09"
-5252	huge rotten cool cat claw	6	crappy	Last Available: "2011-09"
-5253	massive rotten squat blunt cat claw	8	crappy	Last Available: "2011-09"
+5252	rotten huge cool cat claw	6	crappy	Last Available: "2011-09"
+5253	rotten massive squat blunt cat claw	8	crappy	Last Available: "2011-09"
 5254	spoiled blurry shadowy cat claw	4	crappy	Last Available: "2011-09"
 5255	fancy normal cheezburger	3	good	Effect: "Crimbo Nostalgia", Effect Duration: 45, Last Available: "2011-09"
-5256	bland snack-sized toasted brie	2	decent	Last Available: "2011-09"
+5256	snack-sized bland toasted brie	2	decent	Last Available: "2011-09"
 5257	improved improved potion of the field gar	0		Effect: "Rotten Memories", Effect Duration: 35, Last Available: "2011-09"
 5258	electrified too legit potion	0		Effect: "Big Punkin'", Effect Duration: 40, Last Available: "2011-09"
 5259	vacuum-sealed wobbly Bright Water	0		Effect: "Always be Collecting", Effect Duration: 20, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of chilblains	0		Cold Damage: +25, Last Available: "2011-09"
 5282	bouncing sage dethklok	0		Mysticality Percent: +10, Last Available: "2011-09"
 5283	gray dog trainer's glacial clock	0		Experience (familiar): +1, Last Available: "2011-09"
-5284	wobbly Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	wobbly Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	teal slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	narrow dungeon dragon chest	0		Last Available: "2011-09"
 5298	toothsome purple phish stick	3	awesome	Last Available: "2011-09"
-5299	avaricious stanky Da Vinci's plastic vampire fangs	0		Experience (Mysticality): +5, Stench Spell Damage: +25, Meat Drop: +30, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	avaricious stanky Da Vinci's plastic vampire fangs	0		Experience (Mysticality): +5, Stench Spell Damage: +25, Meat Drop: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5222,14 +5222,14 @@
 5319	non-magnetized magnetized Blood 'n' Plenty	0		Effect: "You Know Where to Go", Effect Duration: 59, Last Available: "2011-10"
 5320	diffused Lobos Mints	0		Effect: "Human-Human Hybrid", Effect Duration: 37, Last Available: "2011-10"
 5321	super-modified modified Sweet Sword	0		Effect: "Comprehensively Nourished", Effect Duration: 44, Last Available: "2011-10"
-5322	watered-down acceptable Ecto-Cooler	2	good	Last Available: "2011-10"
-5323	artisanal special Bartles and BRAAAINS wine cooler	4	EPIC	Effect: "Cold Hard Skin", Effect Duration: 5, Last Available: "2011-10"
+5322	acceptable watered-down Ecto-Cooler	2	good	Last Available: "2011-10"
+5323	special artisanal Bartles and BRAAAINS wine cooler	4	EPIC	Effect: "Cold Hard Skin", Effect Duration: 5, Last Available: "2011-10"
 5324	drinkable Blood Light	3	good	Last Available: "2011-10"
 5325	bad weak Silver Bullet beer	2	decent	Last Available: "2011-10"
-5326	strong artisanal Bone's Farm &quot;wine&quot;	5	EPIC	Last Available: "2011-10"
+5326	artisanal strong Bone's Farm &quot;wine&quot;	5	EPIC	Last Available: "2011-10"
 5327	upside-down ghost protocol	0		Last Available: "2011-10"
 5328	triple-moist colloidal sorority brain	0		Effect: "Disdain of the War Snapper", Effect Duration: 60, Last Available: "2011-10"
-5329	wet quantum irradiated olive skewed Nightstalker perfume	0		Effect: "Horrid, Torrid", Effect Duration: 17, Last Available: "2011-10"
+5329	wet quantum irradiated skewed olive Nightstalker perfume	0		Effect: "Horrid, Torrid", Effect Duration: 17, Last Available: "2011-10"
 5330	quadruple-energized nitrogenated modified drum of pomade	0		Effect: "Lemony Goodness", Effect Duration: 50, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extra-see-thru nightie of terror	0		Spooky Spell Damage: +10, Last Available: "2011-10"
@@ -5251,7 +5251,7 @@
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	squat A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
-5351	tumbling teal tumbling twirling A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
+5351	tumbling tumbling teal twirling A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -5297,10 +5297,10 @@
 5394	sandpaper	0		
 5395	huge peppermint sprout	0		Last Available: "2011-11"
 5396	super-oxidized peppermint twist	0		Effect: "Eagle Eyes", Effect Duration: 23, Last Available: "2011-11"
-5397	flavorless big bouncing peppermint patty	5	decent	Last Available: "2011-11"
+5397	big flavorless bouncing peppermint patty	5	decent	Last Available: "2011-11"
 5398	blue peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
-5400	skewed blue candy cane candygram	0		Last Available: "2011-12"
+5400	blue skewed candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
 5402	greasy candy cane	0		Sleaze Spell Damage: +10, Last Available: "2011-12"
 5403	gray Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
@@ -5308,7 +5308,7 @@
 5405	shaking avaricious flame-retardant cool cane-mail shirt	0		Moxie: +5, Hot Resistance: +1, Meat Drop: +30, Last Available: "2011-12"
 5406	ghostly knitted cane-mail pants of doom of the boozehound	0		Spooky Spell Damage: +50, Cold Resistance: +3, Booze Drop: +100, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	drinkable Vodka Matryoshka	3	good	Last Available: "2011-12"
-5408	hand-crafted boozy Gin Mint	5	EPIC	Last Available: "2011-12"
+5408	boozy hand-crafted Gin Mint	5	EPIC	Last Available: "2011-12"
 5409	hand-crafted weak twirling Tequiz Navidad	2	EPIC	Last Available: "2011-12"
 5410	bad Mint Yulep	4	decent	Last Available: "2011-12"
 5411	lousy distilled Crimbojito	5	decent	Last Available: "2011-12"
@@ -5338,7 +5338,7 @@
 5435	fudgecule	0		Last Available: "2011-11"
 5436	improved purple narrow fudge lily	0		Effect: "Human-Slime Hybrid", Effect Duration: 64, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
-5438	modified chilled skewed upside-down fluid of fudge-finding	0		Effect: "Outer Wolf&trade;", Effect Duration: 20, Last Available: "2011-11"
+5438	modified chilled upside-down skewed fluid of fudge-finding	0		Effect: "Outer Wolf&trade;", Effect Duration: 20, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	tasty fudgesicle	4	awesome	Last Available: "2011-11"
 5441	blurry maroon wand of fudge control	0		Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	flame-retardant crafty sage fudgecycle	0		Mysticality Percent: +10, Maximum MP: +10, Hot Resistance: +1, Single Equip, Last Available: "2011-11"
 5461	ghostly fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	tumbling Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	tumbling Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	pressed wet resolution: be wealthier	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 58, Last Available: "2012-01"
 5465	Vulcanized resolution: be happier	0		Effect: "Incredibly Hulking", Effect Duration: 55, Last Available: "2012-01"
 5466	improved improved wobbly resolution: be stronger	0		Effect: "Fortunate Resolve", Effect Duration: 63, Last Available: "2012-01"
@@ -5382,7 +5382,7 @@
 5479	stale gummi bear	4	decent	Last Available: "2011-11"
 5480	toothsome gummi bear	4	awesome	Last Available: "2011-11"
 5481	normal gummi bear	4	good	Last Available: "2011-11"
-5482	small normal ghostly drunki-bear	2	good	Last Available: "2011-11"
+5482	normal small ghostly drunki-bear	2	good	Last Available: "2011-11"
 5483	adequate drunki-bear	3	good	Last Available: "2011-11"
 5484	super-sized toothsome olive drunki-bear	5	awesome	Last Available: "2011-11"
 5485	gummi bowtie of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2011-11"
@@ -5396,17 +5396,17 @@
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	liquefied jittery gummi trilobite	0		Effect: "Army of One", Effect Duration: 17, Last Available: "2011-11"
 5495	double-modified extra-modified lime green skewed gummi ammonite	0		Effect: "Reedy Pipes", Effect Duration: 27, Last Available: "2011-11"
-5496	cold-filtered pressed wobbly gray gummi belemnite	0		Effect: "Slimily Strong", Effect Duration: 67, Last Available: "2011-11"
+5496	cold-filtered pressed gray wobbly gummi belemnite	0		Effect: "Slimily Strong", Effect Duration: 67, Last Available: "2011-11"
 5497	bouncing all-year sucker	0		Last Available: "2011-11"
 5498	spinning heart of dark chocolate	0		Last Available: "2011-11"
 5499	cool Big Candy's tophat of the sewer	0		Moxie: +5, Stench Damage: +25, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
-5500	shaking upside-down Fuzzby	0		Free Pull, Last Available: "2011-11"
+5500	upside-down shaking Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	huge pack of pogs	0		Last Available: "2011-11"
-5506	rotten twirling mirror jerky coins	3	crappy	Last Available: "2011-11"
+5506	rotten mirror twirling jerky coins	3	crappy	Last Available: "2011-11"
 5507	extra-dry lousy Go-Wassail	5	decent	Last Available: "2011-11"
 5508	pickled spinning Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Almost Cool", Effect Duration: 41, Last Available: "2011-11"
 5509	wet modified mirror bottle of bubbles	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 51, Last Available: "2011-11"
@@ -5441,10 +5441,10 @@
 5538	half-empty carton of milk	0		Last Available: "2012-12"
 5539	gray glass of warm water	0		Free Pull
 5540	concentrated desktop zen garden	0		Effect: "Marinated", Effect Duration: 25, Last Available: "2012-12"
-5541	red huge Vivian's Vitamin	0		Last Available: "2012-12"
+5541	huge red Vivian's Vitamin	0		Last Available: "2012-12"
 5542	huge pink-belly slapper	0		Last Available: "2012-12"
 5543	Da Vinci's beefy Leapin' Trousers	0		Muscle: +10, Experience (Mysticality): +5
-5544	mediocre weak eggnog	2	decent	Last Available: "2012-12"
+5544	weak mediocre eggnog	2	decent	Last Available: "2012-12"
 5545	flavorless hamhock	4	decent	Last Available: "2012-12"
 5546	huge The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	tumbling Clancy's sackbut	0		Last Available: "2012-12"
@@ -5460,32 +5460,32 @@
 5557	teal Rain-Doh agent	0		Last Available: "2012-02"
 5558	experienced stylish Rain-Doh laser gun	0		Moxie: +25, Experience: +2, Softcore Only, Last Available: "2012-02"
 5559	Van der Graaf medical-grade Rain-Doh lantern	0		MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
-5560	huge lime green Rain-Doh balls	0		Last Available: "2012-02"
+5560	lime green huge Rain-Doh balls	0		Last Available: "2012-02"
 5561	squat Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	Lo Pan's Rain-Doh violet bo of the brazier	0		Spell Critical Percent: +30, Hot Spell Damage: +25, Softcore Only, Last Available: "2012-02"
 5563	pulsating Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	enchanted miniature decent PB&BP	2	good	Effect: "Riboflavin'", Effect Duration: 30
+5565	decent miniature enchanted PB&BP	2	good	Effect: "Riboflavin'", Effect Duration: 30
 5566	moldy club sandwich	3	crappy	
-5567	fancy spoiled fuchsia corned-beef Reuben	3	crappy	Effect: "Memory of Smarts", Effect Duration: 30
+5567	spoiled fancy fuchsia corned-beef Reuben	3	crappy	Effect: "Memory of Smarts", Effect Duration: 30
 5568	frayed ninja rope	0		
 5569	jittery dull ninja crampons	0		
 5570	bouncing mirror loose ninja carabiner	0		
 5571	jittery Groar's fur	0		
 5572	maroon Thwaitgold stag beetle statuette	0		
-5573	artisanal special Drac & Tan	4	EPIC	Effect: "Always In Motion", Effect Duration: 10, Last Available: "2012-03"
+5573	special artisanal Drac & Tan	4	EPIC	Effect: "Always In Motion", Effect Duration: 10, Last Available: "2012-03"
 5574	artisanal Transylvania Sling	3	EPIC	Last Available: "2012-03"
 5575	mediocre Shot of the Living Dead	3	decent	Last Available: "2012-03"
-5576	watered-down bad Buttery Knob	2	decent	Last Available: "2012-03"
+5576	bad watered-down Buttery Knob	2	decent	Last Available: "2012-03"
 5577	watered-down tolerable Slippery Knob	2	good	Last Available: "2012-03"
-5578	triple-distilled perfectly mixed Flaming Knob	6	EPIC	Last Available: "2012-03"
+5578	perfectly mixed triple-distilled Flaming Knob	6	EPIC	Last Available: "2012-03"
 5579	perfectly mixed Grasshopper	3	EPIC	Last Available: "2012-03"
 5580	hand-crafted watered-down Locust	2	EPIC	Last Available: "2012-03"
-5581	aged weak Plague of Locusts	2	awesome	Last Available: "2012-03"
-5582	tolerable boozy Red Dwarf	5	good	Last Available: "2012-03"
-5583	bad watered-down Golden Mean	2	decent	Last Available: "2012-03"
+5581	weak aged Plague of Locusts	2	awesome	Last Available: "2012-03"
+5582	boozy tolerable Red Dwarf	5	good	Last Available: "2012-03"
+5583	watered-down bad Golden Mean	2	decent	Last Available: "2012-03"
 5584	acceptable Green Giant	3	good	Last Available: "2012-03"
-5585	weak smooth Aye Aye	2	awesome	Last Available: "2012-03"
+5585	smooth weak Aye Aye	2	awesome	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	4	decent	Last Available: "2012-03"
 5587	acceptable ghostly Aye Aye, Tooth Tooth	3	good	Last Available: "2012-03"
 5588	tolerable Humanitini	3	good	Last Available: "2012-03"
@@ -5493,39 +5493,39 @@
 5590	artisanal Oh, the Humanitini	3	EPIC	Last Available: "2012-03"
 5591	mediocre skewed Great Older Fashioned	3	decent	Last Available: "2012-03"
 5592	mediocre high-proof Fuzzy Tentacle	8	decent	Last Available: "2012-03"
-5593	fancy tolerable extra-dry Crazymaker	5	good	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2012-03"
+5593	extra-dry fancy tolerable Crazymaker	5	good	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2012-03"
 5594	perfectly mixed Zoodriver	3	EPIC	Last Available: "2012-03"
 5595	mediocre Sloe Comfortable Zoo	3	decent	Last Available: "2012-03"
 5596	artisanal Sloe Comfortable Zoo on Fire	3	EPIC	Last Available: "2012-03"
 5597	bad Suffering Sinner	3	decent	Last Available: "2012-03"
-5598	acceptable watered-down mirror ghostly Suppurating Sinner	2	good	Last Available: "2012-03"
+5598	watered-down acceptable mirror ghostly Suppurating Sinner	2	good	Last Available: "2012-03"
 5599	lousy Sizzling Sinner	4	decent	Last Available: "2012-03"
 5600	tolerable blue Firewater	4	good	Last Available: "2012-03"
 5601	special hand-crafted Earth and Firewater	3	EPIC	Effect: "Cold Throat", Effect Duration: 25, Last Available: "2012-03"
 5602	tolerable boozy spinning Earth, Wind and Firewater	5	good	Last Available: "2012-03"
 5603	triple-distilled tolerable huge Slimosa	10	good	Last Available: "2012-03"
-5604	weak lousy purple Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
+5604	lousy weak purple Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
 5605	weak smooth Slimebite	2	awesome	Last Available: "2012-03"
-5606	perfectly mixed weak Cement Mixer	2	EPIC	Last Available: "2012-03"
+5606	weak perfectly mixed Cement Mixer	2	EPIC	Last Available: "2012-03"
 5607	watered-down bad Jackhammer	2	decent	Last Available: "2012-03"
 5608	practically non-alcoholic hand-crafted Dump Truck	1	super ultra EPIC	Last Available: "2012-03"
 5609	artisanal Fauna Libre	4	EPIC	Last Available: "2012-03"
-5610	smooth high-proof Chakra Libre	7	awesome	Last Available: "2012-03"
-5611	smooth practically non-alcoholic Aura Libre	1	awesome	Last Available: "2012-03"
+5610	high-proof smooth Chakra Libre	7	awesome	Last Available: "2012-03"
+5611	practically non-alcoholic smooth Aura Libre	1	awesome	Last Available: "2012-03"
 5612	acceptable Sazerorc	3	good	Last Available: "2012-03"
-5613	bad fortified Sazuruk-hai	5	decent	Last Available: "2012-03"
+5613	fortified bad Sazuruk-hai	5	decent	Last Available: "2012-03"
 5614	mediocre Flaming Sazerorc	4	decent	Last Available: "2012-03"
 5615	acceptable Green Velvet	3	good	Last Available: "2012-03"
-5616	mediocre watered-down Green Muslin	2	decent	Last Available: "2012-03"
+5616	watered-down mediocre Green Muslin	2	decent	Last Available: "2012-03"
 5617	weak aged Green Burlap	2	awesome	Last Available: "2012-03"
-5618	special mediocre Mohobo	3	decent	Effect: "Bread Burps", Effect Duration: 40, Last Available: "2012-03"
+5618	mediocre special Mohobo	3	decent	Effect: "Bread Burps", Effect Duration: 40, Last Available: "2012-03"
 5619	hand-crafted Moonshine Mohobo	3	EPIC	Last Available: "2012-03"
 5620	smooth squat Flaming Mohobo	4	awesome	Last Available: "2012-03"
 5621	perfectly mixed Drunken Philosopher	3	EPIC	Last Available: "2012-03"
 5622	lousy Drunken Neurologist	3	decent	Last Available: "2012-03"
 5623	bad Drunken Astrophysicist	3	decent	Last Available: "2012-03"
-5624	mediocre weak huge Dark & Starry	2	decent	Last Available: "2012-03"
-5625	bad distilled Black Hole	5	decent	Last Available: "2012-03"
+5624	weak mediocre huge Dark & Starry	2	decent	Last Available: "2012-03"
+5625	distilled bad Black Hole	5	decent	Last Available: "2012-03"
 5626	fancy artisanal huge Event Horizon	3	EPIC	Effect: "Oth-Jeal-O", Effect Duration: 15, Last Available: "2012-03"
 5627	tolerable Herring Daiquiri	3	good	Last Available: "2012-03"
 5628	delicious Herring Wallbanger	3	awesome	Last Available: "2012-03"
@@ -5537,11 +5537,11 @@
 5634	tolerable practically non-alcoholic Flying Caipiranha	1	good	Last Available: "2012-03"
 5635	tolerable watered-down jittery Flaming Caipiranha	2	good	Last Available: "2012-03"
 5636	extra-dry artisanal narrow Punchplanter	5	EPIC	Last Available: "2012-03"
-5637	drinkable huge purple Doublepunchplanter	3	good	Last Available: "2012-03"
+5637	drinkable purple huge Doublepunchplanter	3	good	Last Available: "2012-03"
 5638	artisanal Haymaker	4	EPIC	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	stale immense shaking fungus	10	decent	
+5641	immense stale shaking fungus	10	decent	
 5642	wobbly poisoned dart	0		
 5643	flattened stone wool	0		Effect: "Nightstalkin'", Effect Duration: 20
 5644	stones	0		
@@ -5570,8 +5570,8 @@
 5667	fuchsia puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
-5670	toothsome snack-sized huge skewed fettucini &eacute;pines Inconnu	2	awesome	
-5671	mediocre special teal slap and slap again	4	decent	Effect: "Speed of the Internet", Effect Duration: 40
+5670	snack-sized toothsome huge skewed fettucini &eacute;pines Inconnu	2	awesome	
+5671	special mediocre teal slap and slap again	4	decent	Effect: "Speed of the Internet", Effect Duration: 40
 5672	gunpowder burrito	2	good	
 5673	ghostly beery blood	2	good	
 5674	spinning &quot;L&quot;	0		
@@ -5629,16 +5629,16 @@
 5728	supercool foot-long hot daub of Leguizamo	0		Moxie Percent: +20, Monster Level: +20, Last Available: "2012-07"
 5729	pulsating lime green ballpark hot daub	0		Last Available: "2012-07"
 5730	normal skewed angst burger	3	good	
-5731	watered-down drinkable huge 5-hour acrimony	2	good	
+5731	drinkable watered-down huge 5-hour acrimony	2	good	
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	moldy special forbidden sausage	3	crappy	Effect: "Elvish", Effect Duration: 50
-5735	Herculean Lord Flameface's cloak	0		Experience (Muscle): +1, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Herculean Lord Flameface's cloak	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	aerosolized chilled spinning Drizzlers&trade; Black Licorice	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 50
 5737	triple-wet quadruple-warmed daub-breaker	0		Effect: "Well Owl Be!", Effect Duration: 41, Last Available: "2020-09"
 5738	Camp Scout backpack of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2012-07"
 5739	tumbling CSA fire-starting kit	0		Last Available: "2012-07"
-5740	special super-sized spoiled wobbly bag of GORP	5	crappy	Effect: "Serendipi Tea", Effect Duration: 15, Last Available: "2012-07"
+5740	super-sized special spoiled wobbly bag of GORP	5	crappy	Effect: "Serendipi Tea", Effect Duration: 15, Last Available: "2012-07"
 5741	smooth weak water purification pills	2	awesome	Last Available: "2012-07"
 5742	squat Camp Scout pup tent	0		Last Available: "2012-07"
 5743	hand-crafted weak pulsating CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
@@ -5670,14 +5670,14 @@
 5770	tumbling gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
 5771	green gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
 5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
-5773	red bouncing Thwaitgold maggot statuette	0		
+5773	bouncing red Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	squat Barney's rake of Tarzan of doom	0		Experience (Muscle): +3, Spooky Spell Damage: +50
 5778	miniature normal idiot brain	2	good	
 5779	keel-haulin' knife of chilblains	0		Cold Damage: +25
 5780	veiny ice cream scoop	0		Maximum HP: +10
-5781	lousy practically non-alcoholic soft echo eyedrop antidote martini	1	decent	
+5781	practically non-alcoholic lousy soft echo eyedrop antidote martini	1	decent	
 5782	morningwood plank	0		
 5783	spinning raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	fuchsia box of bear arms	0		Last Available: "2012-09"
-5791	forbidden right bear arm of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	blurry rock-hard forbidden sinister left bear arm	0		Spell Damage: +10, Spell Damage Percent: +50, Damage Reduction: 5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	forbidden right bear arm of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	blurry rock-hard forbidden sinister left bear arm	0		Spell Damage: +10, Spell Damage Percent: +50, Damage Reduction: 5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	sage Hat O' Nine Tails	0		Mysticality Percent: +10
 5794	chilled ionized mirror bouncing Enchanted Plunger	0		Effect: "Preternatural Greed", Effect Duration: 11
 5795	denatured dry double-pickled yellow Enchanted Flyswatter	0		Effect: "Human-Plant Hybrid", Effect Duration: 13
@@ -5698,15 +5698,15 @@
 5799	modified eldritch dough	0		Effect: "Phairly Pheromonal", Effect Duration: 66
 5800	super-activated altered Charity's choker	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 28
 5801	ionized Smart Bone Dust	0		Effect: "Demonic Taint", Effect Duration: 15
-5802	warmed purple huge skewed perpendicular guano	0		Effect: "Wistfully Nostalgic", Effect Duration: 16
+5802	warmed purple skewed huge perpendicular guano	0		Effect: "Wistfully Nostalgic", Effect Duration: 16
 5803	boiled irradiated narrow White Chocolate Golem Seeds	0		Effect: "Healthy Blue Glow", Effect Duration: 59
-5804	altered nitrogenated shaking blurry Shivering Ch&egrave;vre	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 65
+5804	altered nitrogenated blurry shaking Shivering Ch&egrave;vre	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 65
 5805	dry diffused cyan breath mint	0		Effect: "Rat-Faced", Effect Duration: 66
 5806	enhanced muesli	0		Effect: "Joy", Effect Duration: 45
-5807	alkaline unsweetened mirror twirling glass of warm milk	0		Effect: "The Smile of Mr. A.", Effect Duration: 35
-5808	corrupted quantum green narrow glass of gnat milk	0		Effect: "Hella Tough", Effect Duration: 28
+5807	alkaline unsweetened twirling mirror glass of warm milk	0		Effect: "The Smile of Mr. A.", Effect Duration: 35
+5808	corrupted quantum narrow green glass of gnat milk	0		Effect: "Hella Tough", Effect Duration: 28
 5809	non-chilled Knob Goblin Mutagen	0		Effect: "Puddingskin", Effect Duration: 33
-5810	moist aerosolized electrified pulsating gray blurry Tears of the Quiet Healer	0		Effect: "Frog In Your Throat", Effect Duration: 54
+5810	moist aerosolized electrified gray blurry pulsating Tears of the Quiet Healer	0		Effect: "Frog In Your Throat", Effect Duration: 54
 5811	deionized tube of lipstick	0		Effect: "Reptilian Fortitude", Effect Duration: 68
 5812	aerosolized skelelton spine	0		Effect: "Musky", Effect Duration: 56
 5813	altered energized spinning smut orc sunglasses	0		Effect: "Stickler for Promptness", Effect Duration: 24
@@ -5728,8 +5728,8 @@
 5829	energized dry janglin' bones	0		Effect: "Well-Oiled", Effect Duration: 37
 5830	tarnished oxidized pygmy papers	0		Effect: "Crud&eacute;", Effect Duration: 37
 5831	quantum pulsating pygmy dart	0		Effect: "Hairy Palms", Effect Duration: 43
-5832	improved huge teal secret mummy herbs and spices	0		Effect: "Innately Strong", Effect Duration: 65
-5833	quantum squat blurry brigand brittle	0		Effect: "Red Door Syndrome", Effect Duration: 30
+5832	improved teal huge secret mummy herbs and spices	0		Effect: "Innately Strong", Effect Duration: 65
+5833	quantum blurry squat brigand brittle	0		Effect: "Red Door Syndrome", Effect Duration: 30
 5834	chilled holistic headache remedy	0		Effect: "Gummiheart", Effect Duration: 51
 5835	modified skewed scrunchie tourniquet	0		Effect: "Sharp Weapon", Effect Duration: 64
 5836	anodized alkaline yellow embezzler's oil	0		Effect: "Antarctic Memories", Effect Duration: 58
@@ -5758,7 +5758,7 @@
 5859	galvanized deionized booby trap	0		Effect: "Dreadful Smell", Effect Duration: 36
 5860	polarized lime green Agent Corrigan's cigarette	0		Effect: "Sweetened and Fattened", Effect Duration: 50
 5861	warmed frozen squat good ash	0		Effect: "Clean-Shaven", Effect Duration: 43
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	pulsating blinking Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	dry frozen blurry papier-mochi	0		Effect: "Pork Power", Effect Duration: 30, Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	cyan coward's MacGyver's healthy Bonestabber of temperance	0		Maximum HP Percent: +20, Maximum MP: +100, Monster Level: -20, Sleaze Resistance: +5, Last Available: "2012-10"
-5887	artisanal practically non-alcoholic crystal skeleton vodka	1	super ultra mega turbo EPIC	Last Available: "2012-10"
+5887	practically non-alcoholic artisanal crystal skeleton vodka	1	super ultra mega turbo EPIC	Last Available: "2012-10"
 5888	shaking Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	tumbling auxiliary backbone of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5820,10 +5820,10 @@
 5922	sinister plastic MechaElf	0		Spell Damage: +10, Last Available: "2012-12"
 5923	plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
-5925	twirling pulsating ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
+5925	pulsating twirling ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of chilblains	0		Cold Damage: +25, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	brainwave-controlled unicorn horn of chilblains	0		Cold Damage: +25, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	mirror bubble-wrap simulator	0		Last Available: "2012-12"
 5930	gray blind-packed capsule toy	0		Last Available: "2012-12"
 5931	knitted dog trainer's plastic four-shadowed mime of the brute	0		Muscle Percent: +30, Experience (familiar): +1, Cold Resistance: +3, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	resourceful plastic Father McGruber	0		Maximum MP: +50, Last Available: "2012-12"
 5961	curative plastic Hank North, Photojournalist	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-12"
 5962	pulsating twirling weightlifter's plastic blazing bat	0		Muscle: +15, Last Available: "2012-12"
-5963	inspector's electronic dulcimer pants of the dark arts	0		Spell Damage Percent: +100, Item Drop: +15, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	inspector's electronic dulcimer pants of the dark arts	0		Spell Damage Percent: +100, Item Drop: +15, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	Lo Pan's Da Vinci's Frown Exerciser	0		Experience (Mysticality): +5, Spell Critical Percent: +30, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5881,15 +5881,15 @@
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	purple aromatic flame-retardant Jim Carey's cloth cap	0		Monster Level: +25, Hot Resistance: +1, Stench Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	rosewater-soaked educational iron dagger of incineration	0		Experience: +1, Hot Spell Damage: +50, Stench Resistance: +3, Last Available: "2013-02"
-5986	bland diet hamburger	1	decent	Last Available: "2013-02"
+5986	diet bland hamburger	1	decent	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	practically non-alcoholic tolerable bottle of wine	1	good	Last Available: "2013-02"
+5990	tolerable practically non-alcoholic bottle of wine	1	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
 5992	spinning lard-coated clever experienced iron helmet	0		Experience: +2, Maximum MP: +20, Sleaze Spell Damage: +25, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	Usain Bolt's zippy wool steel sword	0		Cold Resistance: +1, Initiative: 100, Last Available: "2013-02"
-5994	fancy adequate fuchsia whole roasted chicken	4	good	Effect: "Disco State of Mind", Effect Duration: 45, Last Available: "2013-02"
+5994	adequate fancy fuchsia whole roasted chicken	4	good	Effect: "Disco State of Mind", Effect Duration: 45, Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
@@ -5920,7 +5920,7 @@
 6022	twirling Space Tourist Phaser	0		
 6023	Whoompa Fur Pants of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Familiar Effect: "atk, cap 27"
 6024	Whatsian Ionic Pliers of Flo-Jo	0		Initiative: +100
-6025	pickled narrow huge fuchsia wobbly Polysniff Perfume	0		Effect: "Jelly Combed", Effect Duration: 59
+6025	pickled huge narrow wobbly fuchsia Polysniff Perfume	0		Effect: "Jelly Combed", Effect Duration: 59
 6026	fuchsia Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
@@ -5931,7 +5931,7 @@
 6033	upside-down thinker's stolen necklace of the brazier	0		Mysticality: +10, Hot Spell Damage: +25
 6034	mansplainer's energetic troll britches	0		Maximum MP Percent: +20, Monster Level: +15, Familiar Effect: "1.5xPotato, cap 28"
 6035	polarized non-denatured extra-enhanced vial of The Glistening	0		Effect: "Good Motivator", Effect Duration: 36
-6036	artisanal distilled red artisanal limoncello	5	EPIC	
+6036	distilled artisanal red artisanal limoncello	5	EPIC	
 6037	wobbly ginger ale	0		
 6038	miniature bland pulsating incredible pizza	2	decent	
 6039	shaking huge Temple Grandin's wicked oil cap	0		Spell Damage: +5, Familiar Weight: +7, Familiar Effect: "cap 28"
@@ -5951,7 +5951,7 @@
 6053	mediocre Taco Dan's Taco Stand Chimichangarita	4	decent	Last Available: "2012-12"
 6054	oxidized unsweetened pressed shaking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Cold Hard Skin", Effect Duration: 18, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	skewed The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	skewed The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	dance instructor's Meatcleaver of the businessman	0		Experience Percent (Moxie): +10, Meat Drop: +50, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of chilblains	0		Cold Damage: +25, Last Available: "2012-12"
 6059	vibrating Crimbo stogie-scented room odorizer	0		Maximum MP Percent: +10, Last Available: "2012-12"
@@ -5966,7 +5966,7 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	energized haggis-infused soap	0		Effect: "Thought", Effect Duration: 48, Last Available: "2012-12"
 6074	diffused colloidal magicberry tablets	0		Effect: "Radiated and Grodiated", Effect Duration: 33, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	stale tumbling haggis-wrapped haggis-stuffed haggis	3	decent	Last Available: "2012-12"
 6078	red home robotics kit	0		Last Available: "2012-12"
 6079	jittery school calculator watch	0		Last Available: "2012-12"
-6080	Tesla haggis socks	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	blinking airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	Tesla haggis socks	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	blinking airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	spinning Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	shaking actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6046,16 +6046,16 @@
 6149	blurry MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	spinning Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	small stale carrot cake	2	decent	Last Available: "2013-01"
+6152	stale small carrot cake	2	decent	Last Available: "2013-01"
 6153	tolerable irresponsibly strong maroon carrot claret	9	good	Last Available: "2013-01"
 6154	twisted blinking carrot juice	1	good	Effect: "Hot Blooded", Effect Duration: 20, Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	cyan flickering pixel	0		Last Available: "2013-12"
 6157	Usain Bolt's boxer's Byte	0		Muscle Percent: +10, Initiative: +80, Last Available: "2013-12"
-6158	wobbly hale anger blaster	0		Maximum HP: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	wholesome doubt cannon	0		Maximum HP Percent: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	stiffened fear condenser	0		Damage Reduction: 1, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	tumbling vibrating regret hose	0		Maximum MP Percent: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	wobbly hale anger blaster	0		Maximum HP: +20, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	wholesome doubt cannon	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	stiffened fear condenser	0		Damage Reduction: 1, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	tumbling vibrating regret hose	0		Maximum MP Percent: +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	green Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	jittery Rosewater's commodore's hat of doom	0		Mysticality Percent: +30, Spooky Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
@@ -6064,8 +6064,8 @@
 6167	ornamental sextant of the cheetah	0		Initiative: +60, Last Available: "2013-12"
 6168	scandalous stylish Bloodbath	0		Moxie: +25, Sleaze Damage: +5, Last Available: "2013-12"
 6169	lousy ghostly Hundred Headed IPA	4	decent	Last Available: "2013-12"
-6170	enchanted rotten massive chum	7	crappy	Effect: "Hennaliciousness", Effect Duration: 40, Last Available: "2013-12"
-6171	Vulcanized red spinning narrow crude crudit&eacute;s	0		Effect: "You Drank Fish Wine", Effect Duration: 26
+6170	rotten massive enchanted chum	7	crappy	Effect: "Hennaliciousness", Effect Duration: 40, Last Available: "2013-12"
+6171	Vulcanized narrow red spinning crude crudit&eacute;s	0		Effect: "You Drank Fish Wine", Effect Duration: 26
 6172	moist activated candy crayons	0		Effect: "Busy Bein' Delicious", Effect Duration: 18, Last Available: "2020-09"
 6173	family-friendly occult pixel grappling hook	0		Spell Damage Percent: +25, Sleaze Resistance: +1
 6174	lime green GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
@@ -6085,69 +6085,69 @@
 6188	delicious consummate bagel	4	awesome	
 6189	bland thick consummate sliced bread	5	decent	
 6190	half-sized decent consummate hot dog bun	2	good	
-6191	bland special immense consummate brownie	6	decent	Effect: "Mutated", Effect Duration: 20
+6191	immense special bland consummate brownie	6	decent	Effect: "Mutated", Effect Duration: 20
 6192	flavorless consummate toast	3	decent	
 6193	hand-crafted passable stout	3	EPIC	
 6194	snack-sized bland consummate soup	2	decent	
 6195	adequate consummate corn chips	3	good	
-6196	moldy super-sized upside-down consummate salad	5	crappy	
+6196	super-sized moldy upside-down consummate salad	5	crappy	
 6197	miniature normal consummate salsa	2	good	
 6198	flavorless consummate sauerkraut	3	decent	
 6199	yummy consummate cheese slice	4	awesome	
 6200	decent consummate melted cheese	3	good	
 6201	decent pulsating consummate bacon	3	good	
 6202	spoiled consummate meatloaf	4	crappy	
-6203	rotten immense lime green consummate steak	7	crappy	
+6203	immense rotten lime green consummate steak	7	crappy	
 6204	flavorless twirling consummate cuts	3	decent	
 6205	stale consummate frankfurter	3	decent	
-6206	moldy snack-sized consummate french fries	2	crappy	
-6207	huge bland consummate baked potato	9	decent	
+6206	snack-sized moldy consummate french fries	2	crappy	
+6207	bland huge consummate baked potato	9	decent	
 6208	acceptable acceptable vodka	3	good	
 6209	moldy consummate ice cream	4	crappy	
 6210	thick normal consummate whipped cream	5	good	
 6211	normal tumbling consummate cream	3	good	
 6212	gigantic rotten consummate strawberries	9	crappy	
 6213	stale thick consummate sorbet	5	decent	
-6214	bad watered-down adequate rum	2	decent	
+6214	watered-down bad adequate rum	2	decent	
 6215	perfectly mixed distilled jittery mediocre lager	5	EPIC	
 6216	snack-sized yummy immaculate grilled cheese	2	awesome	
 6217	bland immaculate ice cream sandwich	3	decent	
 6218	spoiled purple immaculate hot dog	4	crappy	
-6219	bite-sized normal enchanted immaculate egg salad sandwich	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 30
-6220	fancy spoiled perfect sandwich	4	crappy	Effect: "Flexibili Tea", Effect Duration: 45
+6219	enchanted bite-sized normal immaculate egg salad sandwich	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 30
+6220	spoiled fancy perfect sandwich	4	crappy	Effect: "Flexibili Tea", Effect Duration: 45
 6221	adequate tiny shaking perfect chef salad	1	good	
 6222	rotten perfect breakfast	3	crappy	
-6223	fancy rotten sublime deluxe hot dog	3	crappy	Effect: "Lit Up", Effect Duration: 35
+6223	rotten fancy sublime deluxe hot dog	3	crappy	Effect: "Lit Up", Effect Duration: 35
 6224	normal sublime stew	4	good	
 6225	spoiled sublime nachos	3	crappy	
-6226	low-calorie flavorless upside-down Ultimate Breakfast Sandwich	1	decent	
+6226	flavorless low-calorie upside-down Ultimate Breakfast Sandwich	1	decent	
 6227	adequate Loaded Baked Potato	3	good	
-6228	decent miniature bouncing Omega Sundae	2	good	
-6229	perfectly mixed weak Das Sauerlager	2	EPIC	
+6228	miniature decent bouncing Omega Sundae	2	good	
+6229	weak perfectly mixed Das Sauerlager	2	EPIC	
 6230	lousy upside-down Bologna Lambic	4	decent	
-6231	weak drinkable Vodka Dog	2	good	
-6232	artisanal watered-down Disappointed Russian	2	EPIC	
+6231	drinkable weak Vodka Dog	2	good	
+6232	watered-down artisanal Disappointed Russian	2	EPIC	
 6233	artisanal Chunky Mary	4	EPIC	
-6234	perfectly mixed triple-distilled Nachojito	7	EPIC	
-6235	drinkable skewed blinking Le Roi	3	good	
+6234	triple-distilled perfectly mixed Nachojito	7	EPIC	
+6235	drinkable blinking skewed Le Roi	3	good	
 6236	mediocre Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
 6239	anodized frozen irradiated cube of ectoplasm	0		Effect: "Limber as Mortimer", Effect Duration: 18
 6240	improved altered Illuminati earpiece	0		Effect: "Fishily Speeding", Effect Duration: 60
-6241	diffused huge twirling censored can label	0		Effect: "Egg Burps", Effect Duration: 14
+6241	diffused twirling huge censored can label	0		Effect: "Egg Burps", Effect Duration: 14
 6242	chilled ectoplasm <i>au jus</i>	0		Effect: "Vented Spleen", Effect Duration: 37
 6243	adjusted chilled upside-down the kindest cut	0		Effect: "The Smile of Mr. A.", Effect Duration: 13
 6244	extra-aerosolized super-moist jittery cat's paw	0		Effect: "Tasting the Rainbow", Effect Duration: 30
 6245	altered ASCII fu manchu	0		Effect: "Scorpio Rising", Effect Duration: 33
 6246	chilled deionized maroon demonic surgical gloves	0		Effect: "Stinky Hands", Effect Duration: 27
 6247	anodized deionized clip-on ninja tie	0		Effect: "Chorale of Companionship", Effect Duration: 29
-6248	colloidal skewed tumbling jittery gamer slurry	0		Effect: "Cat-Alyzed", Effect Duration: 63
+6248	colloidal skewed jittery tumbling gamer slurry	0		Effect: "Cat-Alyzed", Effect Duration: 63
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	pulsating perfumed supercharged steel-toed Herculean numberwang of James Dean	0		Experience (Muscle): +1, Experience (Moxie): +3, Damage Reduction: 9, Maximum MP Percent: +30, Stench Resistance: +5, Item Drop: +5, Single Equip
 6251	dry liquefied scroll of Protection from Bad Stuff	0		Effect: "Permafrosty", Effect Duration: 41, Last Available: "2013-02"
 6252	nitrogenated double-anodized scroll of Puddingskin	0		Effect: "Vanity Rage", Effect Duration: 48, Last Available: "2013-02"
 6253	twirling Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
-6254	ghostly shaking Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
+6254	shaking ghostly Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	teal Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	lime green dried gelatinous cube	0		
 6257	pile of dungeon junk	0		Familiar Weight: +5
@@ -6160,7 +6160,7 @@
 6264	Rosewater's Staff of Fruit Salad of the brute of bravery	0		Muscle Percent: +30, Mysticality Percent: +30, Spooky Resistance: +5, Jiggle: "Deal Some Prismatic Damage"
 6265	stiffened occult Staff of the Cream of the Cream of the pedagogue	0		Experience: +3, Spell Damage Percent: +25, Damage Reduction: 1, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	spoiled immense wobbly wobbly grain of protein powder	8	crappy	
+6267	immense spoiled wobbly wobbly grain of protein powder	8	crappy	
 6268	pressed jittery pec oil	0		Effect: "Mo' Hobo", Effect Duration: 17
 6269	chilly gym membership card	0		Cold Damage: +5
 6270	improved dry twirling Squat-Thrust Magazine	0		Effect: "Memory of Attractiveness", Effect Duration: 53
@@ -6170,11 +6170,11 @@
 6274	acceptable skewed skewed open sauce	4	good	
 6275	electrified smooth turkey leg	0		Moxie: +15, MP Regen Min: 3, MP Regen Max: 5
 6276	bad Ye Olde Meade	3	decent	
-6277	moist olive blurry huge Ye Olde Bawdy Limerick	0		Effect: "I See Everything Thrice!", Effect Duration: 27
+6277	moist blurry olive huge Ye Olde Bawdy Limerick	0		Effect: "I See Everything Thrice!", Effect Duration: 27
 6278	blinking Ye Olde Medieval Insult	0		
 6279	gray gravedigger's pewter claymore	0		Spooky Damage: +10
 6280	cyan artisanal rice peeler of the brazier	0		Hot Spell Damage: +25
-6281	thick adequate heirloom grape tomato	5	good	
+6281	adequate thick heirloom grape tomato	5	good	
 6282	blurry chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6182,7 +6182,7 @@
 6286	miser's perfumed lion tamer's Mark II Steam-Hat	0		Experience (familiar): +2, Stench Resistance: +5, Meat Drop: +10, Familiar Effect: "1xLep, cap 37"
 6287	ghostly censurious smelly personal trainer's slick Mark III Steam-Hat	0		Moxie: +10, Experience Percent (Muscle): +10, Stench Spell Damage: +10, Sleaze Resistance: +3, Familiar Effect: "1xLep, cap 37"
 6288	rock-hard Da Vinci's Mark IV Steam-Hat of the wise owl of the cougar of the storm	0		Mysticality: +20, Moxie: +20, Experience (Mysticality): +5, Damage Reduction: 5, Maximum MP Percent: +40, Familiar Effect: "1xLep, cap 37"
-6289	auspicious ribald veiny beefcake's Mark V Steam-Hat of horror	0		Muscle: +25, Maximum HP: +10, Spooky Spell Damage: +25, Sleaze Damage: +10, Item Drop: +10, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	auspicious ribald veiny beefcake's Mark V Steam-Hat of horror	0		Muscle: +25, Maximum HP: +10, Spooky Spell Damage: +25, Sleaze Damage: +10, Item Drop: +10, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	jittery punk rock jacket of the cheetah of Flo-Jo	0		Initiative: 160
 6292	coward's savvy safety pin	0		Mysticality Percent: +20, Monster Level: -20
@@ -6203,7 +6203,7 @@
 6307	non-pickled wobbly celestial olive oil	0		Effect: "Bricked-In", Effect Duration: 17, Last Available: "2013-03"
 6308	triple-electrified jittery celestial carrot juice	0		Effect: "Oth-Jeal-O", Effect Duration: 41, Last Available: "2013-03"
 6309	super-pressed tarnished celestial au jus	0		Effect: "The Moxie of LOV", Effect Duration: 33, Last Available: "2013-03"
-6310	non-activated upside-down wobbly celestial squid ink	0		Effect: "Cake Caked", Effect Duration: 28, Last Available: "2013-03"
+6310	non-activated wobbly upside-down celestial squid ink	0		Effect: "Cake Caked", Effect Duration: 28, Last Available: "2013-03"
 6311	blinking rosy-cheeked Uncle Buck	0		Maximum HP Percent: +30, Softcore Only
 6312	crate of fish meat	0		
 6313	damp wallet	0		
@@ -6250,14 +6250,14 @@
 6354	concentrated moist Mer-kin smartjuice	0		Effect: "Human-Slime Hybrid", Effect Duration: 34
 6355	colloidal upside-down Mer-kin cooljuice	0		Effect: "Turtle Power", Effect Duration: 59
 6356	narrow Mer-kin worktea	0		
-6357	tumbling huge Mer-kin knucklebone	0		
+6357	huge tumbling Mer-kin knucklebone	0		
 6358	teal Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	wobbly electrified Mer-kin begsign	0		MP Regen Min: 3, MP Regen Max: 5, Meat Drop: +40
-6360	blinking Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	blinking Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	enhanced gray pulled taffy	0		Effect: "Fangs and Pangs", Effect Duration: 15, Last Available: "2013-04"
 6362	chilled pulled indigo taffy	0		Effect: "Quiet 'n' Good", Effect Duration: 64, Last Available: "2013-04"
 6363	denatured pulled taffy	0		Effect: "Chlorophyll Flavor", Effect Duration: 40, Last Available: "2013-04"
-6364	pressed corrupted squat green pulled taffy	0		Effect: "Ooh, Salty!", Effect Duration: 47, Last Available: "2013-04"
+6364	pressed corrupted green squat pulled taffy	0		Effect: "Ooh, Salty!", Effect Duration: 47, Last Available: "2013-04"
 6365	galvanized pulsating pulled taffy	0		Effect: "Almost Cool", Effect Duration: 46, Last Available: "2013-04"
 6366	polymerized Vulcanized pulled violet taffy	0		Effect: "Elron's Explosive Etude", Effect Duration: 56, Last Available: "2013-04"
 6367	pickled wobbly pulled taffy	0		Effect: "Ocelot Eyes", Effect Duration: 59, Last Available: "2013-04"
@@ -6265,7 +6265,7 @@
 6369	lime green lump of clay	0		
 6370	twisted piece of wire	0		
 6371	smooth spinning can of the cheapest beer	4	awesome	
-6372	acceptable weak blinking bottle of fruity &quot;wine&quot;	2	good	
+6372	weak acceptable blinking bottle of fruity &quot;wine&quot;	2	good	
 6373	bad single swig of vodka	3	decent	
 6374	angry inch	0		
 6375	wobbly zippy testy toolbox	0		Initiative: +20
@@ -6307,19 +6307,19 @@
 6412	pulsating shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	snack-sized spoiled flavorless gruel	2	crappy	
+6415	spoiled snack-sized flavorless gruel	2	crappy	
 6416	stale upside-down mana curds	3	decent	
-6417	blinking upside-down twist of lime	0		
+6417	upside-down blinking twist of lime	0		
 6418	pencil stub	0		
 6419	dry anodized moth dust	0		Effect: "Nature's Bounty", Effect Duration: 41
 6420	electrified polarized jittery glob of spoiled mayo	0		Effect: "Nas Tea", Effect Duration: 46
 6421	tonic djinn	0		
-6422	adequate jumbo squat vampire chowder	5	good	
+6422	jumbo adequate squat vampire chowder	5	good	
 6423	Tales of Dread	0		Free Pull
 6424	blurry Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	moldy tumbling Dreadsylvanian stew	4	crappy	
-6427	aged watered-down skewed Dreadsylvanian	2	awesome	
+6427	watered-down aged skewed Dreadsylvanian	2	awesome	
 6428	triple-unsweetened polarized blurry Dreadsylvanian flask	0		Effect: "Stench Jellied", Effect Duration: 53
 6429	frozen blinking Dreadsylvanian flask	0		Effect: "Emotion Sickness", Effect Duration: 28
 6430	avaricious dreadful fedora of the bloodbag	0		Maximum HP: +100, Meat Drop: +30, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6384,7 +6384,7 @@
 6489	narrow music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
-6492	blinking jittery wax banana	0		
+6492	jittery blinking wax banana	0		
 6493	complicated lock impression	0		
 6494	spinning replica key	0		
 6495	blinking strapping Dreadsylvania Auditor's badge	0		Muscle: +5, Kruegerand Drop: 5, Single Equip
@@ -6404,7 +6404,7 @@
 6509	energetic wholesome cool iron breastplate	0		Maximum HP Percent: +10, Maximum MP Percent: +20
 6510	smartaleck's cool iron greaves of the wise owl	0		Mysticality: +20, Moxie Percent: +30, Familiar Effect: "atk, 1xBarrr"
 6511	red Van der Graaf Socratic ghost shawl	0		Experience (Mysticality): +1, MP Regen Min: 5, MP Regen Max: 7
-6512	cyan wobbly narrow blinking skull capacitor	0		
+6512	narrow wobbly blinking cyan skull capacitor	0		
 6513	warm fur of vim and vigor	0		Maximum HP Percent: +50
 6514	resourceful snowstick	0		Maximum MP: +50
 6515	narrow cool eerie fetish	0		Moxie: +5, Single Equip
@@ -6429,7 +6429,7 @@
 6534	remorseless knife of the wise owl	0		Mysticality: +20
 6535	Sinatra's intimidating coiffure	0		Experience (Moxie): +5, Familiar Effect: "hot afk, 1xPotato"
 6536	healthy cod cape of the sewer	0		Maximum HP Percent: +20, Stench Damage: +25
-6537	tasty wobbly blinking blood sausage	3	awesome	
+6537	tasty blinking wobbly blood sausage	3	awesome	
 6538	executive energetic frying brainpan	0		Maximum MP Percent: +20, Meat Drop: +40
 6539	lime green lard-coated ball and chain of the blizzard	0		Cold Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip
 6540	lime green dog trainer's dry bone	0		Experience (familiar): +1
@@ -6441,10 +6441,10 @@
 6547	skewed Thwaitgold Goliath beetle statuette	0		
 6548	cooling iron helmet	0		
 6549	cooling iron breastplate	0		
-6550	lime green blinking cooling iron greaves	0		
+6550	blinking lime green cooling iron greaves	0		
 6551	hot cluster	0		
 6552	blinking cluster	0		
-6553	gray blinking cluster	0		
+6553	blinking gray cluster	0		
 6554	stench cluster	0		
 6555	pulsating sleaze cluster	0		
 6556	flattened phial of hotness	0		Effect: "Shot in the Arse", Effect Duration: 24
@@ -6457,9 +6457,9 @@
 6563	olive hand of Mr. Cards of the ox	0		Muscle: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	adequate squat Dreadsylvanian hot pocket	3	good	
 6565	moldy Dreadsylvanian pocket	4	crappy	
-6566	toothsome gigantic Dreadsylvanian pocket	6	awesome	
+6566	gigantic toothsome Dreadsylvanian pocket	6	awesome	
 6567	spoiled half-sized Dreadsylvanian stink pocket	2	crappy	
-6568	decent half-sized red Dreadsylvanian sleaze pocket	2	good	
+6568	half-sized decent red Dreadsylvanian sleaze pocket	2	good	
 6569	triple-distilled hand-crafted Dreadsylvanian hot toddy	9	EPIC	
 6570	drinkable pulsating Dreadsylvanian cold-fashioned	4	good	
 6571	drinkable Dreadsylvanian grimlet	3	good	
@@ -6471,7 +6471,7 @@
 6577	stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	lime green jittery Dreadsylvanian Almanac page	0		
-6580	maroon wobbly length of fuse	0		
+6580	wobbly maroon length of fuse	0		
 6581	huge dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	vicious spiked collar	0		Familiar Damage: +20
@@ -6541,10 +6541,10 @@
 6649	galvanized diffused shaking Ogres and Oubliettes&trade; module	0		Effect: "Sweet and Green", Effect Duration: 37
 6650	teal Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	hand-crafted weak stepmom's booze	2	EPIC	
+6652	weak hand-crafted stepmom's booze	2	EPIC	
 6653	surgical tape	0		
 6654	band T-shirt of the scaredy-cat	0		Monster Level: -15
-6655	aged distilled olive squat fountain 'soda'	5	awesome	
+6655	aged distilled squat olive fountain 'soda'	5	awesome	
 6656	illegal firecracker	0		
 6657	electrified razor-sharp pickelhaube	0		Weapon Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	dry Vulcanized ionized hair oil	0		Effect: "There Is A Spoon", Effect Duration: 34
@@ -6559,7 +6559,7 @@
 6667	quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	huge modeling claymore	0		
-6670	skewed blue clay homunculus	0		
+6670	blue skewed clay homunculus	0		
 6671	denatured adjusted sodium pentasomething	0		Effect: "Human-Pirate Hybrid", Effect Duration: 55
 6672	blurry grains of salt	0		
 6673	yellowcake bomb	0		
@@ -6613,10 +6613,10 @@
 6721	water bottle of the wise owl of the sewer of the glutton	0		Mysticality: +20, Stench Damage: +25, Food Drop: +100, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	tarnished upside-down cyan pygmy phone number	0		Effect: "Moon'd", Effect Duration: 44
 6723	Boozehounds Anonymous token	0		
-6724	spoiled big exotic jungle fruit	5	crappy	
+6724	big spoiled exotic jungle fruit	5	crappy	
 6725	upside-down Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
-6727	fuchsia squat tropical island souvenir crate	0		
+6727	squat fuchsia tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
 6730	green funky junk key	0		
@@ -6652,9 +6652,9 @@
 6760	lousy irresponsibly strong bottle of Old Pugilist	8	decent	Last Available: "2013-09"
 6761	fortified fancy tolerable jittery bottle of Professor Beer	5	good	Effect: "Seal Clubbing Frenzy", Effect Duration: 45, Last Available: "2013-09"
 6762	hand-crafted skewed bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
-6763	drinkable weak fancy bottle of Race Car Red	2	good	Effect: "Gleaming White Teeth", Effect Duration: 45, Last Available: "2013-09"
+6763	fancy weak drinkable bottle of Race Car Red	2	good	Effect: "Gleaming White Teeth", Effect Duration: 45, Last Available: "2013-09"
 6764	artisanal squat bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
-6765	bad practically non-alcoholic bottle of Lambada Lambic	1	decent	Last Available: "2013-09"
+6765	practically non-alcoholic bad bottle of Lambada Lambic	1	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	huge liquid bread	1	decent	Last Available: "2013-09"
@@ -6714,7 +6714,7 @@
 6825	cyan Sherlock's veiny alarm accordion	0		Maximum HP: +10, Item Drop: +25, Class: "Accordion Thief", Song Duration: 20
 6826	Temple Grandin's therapeutic All-Hallow's Steve's fright wig of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	blinking rosewater-soaked dangerous KoL Con X Treasure Map	0		Weapon Damage: +10, Stench Resistance: +3
-6828	weak mediocre special shaking discocktail	2	decent	Effect: "Paging Betty", Effect Duration: 25
+6828	mediocre weak special shaking discocktail	2	decent	Effect: "Paging Betty", Effect Duration: 25
 6829	executive KoL Con X Bingo Card	0		Meat Drop: +40
 6830	weightlifter's Temporal Tempera Tube	0		Muscle: +15
 6831	activated Tallowcreme Halloween Pumpkin	0		Effect: "Fizzier Than Light", Effect Duration: 29
@@ -6746,13 +6746,13 @@
 6857	padded Cajun accordion	0		Damage Absorption: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	lime green groovy quirky accordion	0		Moxie Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	miser's Skipper's accordion of the dark arts	0		Spell Damage Percent: +100, Meat Drop: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	Van der Graaf Oprah's Pantsgiving of the ox of Tarzan	0		Muscle: +20, Experience (Muscle): +3, Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	toothsome small can of sardines	2	awesome	Last Available: "2013-11"
+6860	Van der Graaf Oprah's Pantsgiving of the ox of Tarzan	0		Muscle: +20, Experience (Muscle): +3, Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	small toothsome can of sardines	2	awesome	Last Available: "2013-11"
 6862	diet decent bouncing high-calorie sugar substitute	1	good	Last Available: "2013-11"
 6863	bland yellow pat of butter	3	decent	Last Available: "2013-11"
-6864	snack-sized tasty yellow dinner roll	2	awesome	Last Available: "2013-11"
+6864	tasty snack-sized yellow dinner roll	2	awesome	Last Available: "2013-11"
 6865	snack-sized rotten mashed potatoes	2	crappy	Last Available: "2013-11"
-6866	spoiled thick whole turkey leg	5	crappy	Last Available: "2013-11"
+6866	thick spoiled whole turkey leg	5	crappy	Last Available: "2013-11"
 6867	delicious deviled egg	4	awesome	Last Available: "2013-11"
 6868	pressed nitrogenated finger exerciser	0		Effect: "Red Door Syndrome", Effect Duration: 65, Last Available: "2013-11"
 6869	dry blurry dented spoon	0		Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2013-11"
@@ -6766,7 +6766,7 @@
 6877	narrow pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
 6879	teal pocket lint (white)	0		Last Available: "2013-11"
-6880	wobbly red huge pocket lint (orange)	0		Last Available: "2013-11"
+6880	huge wobbly red pocket lint (orange)	0		Last Available: "2013-11"
 6881	Lo Pan's curative occult bowl of petunias of the glutton	0		Spell Damage Percent: +25, Spell Critical Percent: +30, Food Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-11"
 6882	flame-retardant wool Samson's power sock of chilblains	0		Experience (Muscle): +5, Cold Damage: +25, Cold Resistance: +1, Hot Resistance: +1, Single Equip, Last Available: "2013-11"
 6883	blurry Lo Pan's wool sock of James Dean of Gandalf of horror	0		Experience (Moxie): +3, Spell Critical Percent: 50, Spooky Spell Damage: +25, Single Equip, Last Available: "2013-11"
@@ -6781,7 +6781,7 @@
 6892	triple-alkaline unsweetened dry bouncing spoonful of Linguine-Os	0		Effect: "Hennaliciousness", Effect Duration: 66, Last Available: "2013-11"
 6893	polymerized freezer-burned frost-bitten tortellini	0		Effect: "Blackberry Politeness", Effect Duration: 45, Last Available: "2013-11"
 6894	wet tumbling blob of Alphredo&trade;	0		Effect: "Truly Gritty", Effect Duration: 28, Last Available: "2013-11"
-6895	improved cold-filtered bouncing skewed gray handful of crafty noodles	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 30, Last Available: "2013-11"
+6895	improved cold-filtered gray bouncing skewed handful of crafty noodles	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 30, Last Available: "2013-11"
 6896	chilled pickled frozen tangled mass of pasta	0		Effect: "Uncaged Power", Effect Duration: 44, Last Available: "2013-11"
 6897	flattened Can of Spaghetto	0		Effect: "Neuromancy", Effect Duration: 51, Last Available: "2013-11"
 6898	huge Chef Boy, R&D's business card	0		Last Available: "2013-11"
@@ -6790,9 +6790,9 @@
 6901	mirror hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	beefcake's flask flops of mayonnaise	0		Muscle: +25, Sleaze Spell Damage: +50, Single Equip
 6903	pressed red nuts	0		Effect: "Night Vision", Effect Duration: 67, Last Available: "2013-12"
-6904	tarnished blurry squat twirling bolts	0		Effect: "Jammin'", Effect Duration: 69, Last Available: "2013-12"
+6904	tarnished blurry twirling squat bolts	0		Effect: "Jammin'", Effect Duration: 69, Last Available: "2013-12"
 6905	rotten gray gingerbread robot	4	crappy	Last Available: "2013-12"
-6906	snack-sized moldy petit 4.1	2	crappy	Last Available: "2013-12"
+6906	moldy snack-sized petit 4.1	2	crappy	Last Available: "2013-12"
 6907	bland low-calorie mirror yellow nut-shaped Crimbo cookie	1	decent	Last Available: "2023-06"
 6908	cool plastic GORM-8	0		Moxie: +5, Last Available: "2013-12"
 6909	chaotic plastic warbear	0		Spell Critical Percent: +10, Last Available: "2013-12"
@@ -6810,7 +6810,7 @@
 6921	bite-sized moldy warbear feasting bread	1	crappy	Last Available: "2013-12"
 6922	rotten warbear warrior bread	3	crappy	Last Available: "2013-12"
 6923	special normal warbear thermoregulator bread	4	good	Effect: "Purity of Spirit", Effect Duration: 30, Last Available: "2013-12"
-6924	high-proof enchanted bad warbear feasting mead	8	decent	Effect: "Weapon of Mass Destruction", Effect Duration: 30, Last Available: "2013-12"
+6924	enchanted bad high-proof warbear feasting mead	8	decent	Effect: "Weapon of Mass Destruction", Effect Duration: 30, Last Available: "2013-12"
 6925	drinkable warbear bearserker mead	3	good	Last Available: "2013-12"
 6926	smooth special warbear blizzard mead	4	awesome	Effect: "Spiky Frozen Hair", Effect Duration: 30, Last Available: "2013-12"
 6927	maroon tumbling warbear helm fragment	0		Last Available: "2013-12"
@@ -6847,7 +6847,7 @@
 6958	ghostly tumbling warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	warbear foil hat of doom	0		Spooky Spell Damage: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	asbestos-lined warbear oil pan of Leguizamo	0		Monster Level: +20, Hot Resistance: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	asbestos-lined warbear oil pan of Leguizamo	0		Monster Level: +20, Hot Resistance: +5, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	shaking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	hardy warbear exhaust manifold	0		Maximum HP: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	pulsating warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,11 +6889,11 @@
 7000	arcane researcher's die-cast Don Crimbo of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Last Available: "2013-12"
 7001	steel-toed sage die-cast Uncle Hobo	0		Mysticality Percent: +10, Damage Reduction: 9, Last Available: "2013-12"
 7002	scandalous die-cast Father Crimbo	0		Sleaze Damage: +5, Item Drop: +5, Last Available: "2013-12"
-7003	jittery The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	jittery The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	triple-dry squat shaking Flaskfull of Hollow	0		Effect: "Shot in the Arse", Effect Duration: 61, Last Available: "2013-12"
 7005	skewed lump of Brituminous coal	0		Last Available: "2013-12"
 7006	dehydrated purple handful of Smithereens	1	good	Effect: "Physicali Tea", Effect Duration: 40, Last Available: "2013-12"
-7007	adequate small Every Day is Like This Sundae	2	good	Last Available: "2013-12"
+7007	small adequate Every Day is Like This Sundae	2	good	Last Available: "2013-12"
 7008	bland narrow Miserable Pie	3	decent	Last Available: "2013-12"
 7009	moldy mirror This Charming Flan	4	crappy	Last Available: "2013-12"
 7010	acceptable Irish Coffee, English Heart	3	good	Last Available: "2013-12"
@@ -6923,7 +6923,7 @@
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	tumbling warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
-7037	narrow blurry warbear LP-ROM burner	0		Last Available: "2013-12"
+7037	blurry narrow warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	gray warbear gyrocopter	0		Last Available: "2013-12"
 7039	oxidized super-activated super-cold-filtered bouncing warbear robo-camouflage unit	0		Effect: "Sharp Weapon", Effect Duration: 29, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
@@ -6958,7 +6958,7 @@
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	shaking packet of winter seeds	0		Last Available: "2014-01"
 7071	thick tasty snow berries	5	awesome	Last Available: "2014-01"
-7072	rotten snack-sized blurry ice harvest	2	crappy	Last Available: "2014-01"
+7072	snack-sized rotten blurry ice harvest	2	crappy	Last Available: "2014-01"
 7073	Vulcanized frost flower	0		Effect: "Improprie Tea", Effect Duration: 38, Last Available: "2014-01"
 7074	tarnished non-deionized shaking snow cleats	0		Effect: "Insatiable Hunger", Effect Duration: 22, Last Available: "2014-01"
 7075	quantum enhanced blinking liquid ice pack	0		Effect: "Rushtacean'", Effect Duration: 23, Last Available: "2014-01"
@@ -6966,7 +6966,7 @@
 7077	thick decent snow crab	5	good	Last Available: "2014-01"
 7078	lousy Ice Island Long Tea	4	decent	Last Available: "2014-01"
 7079	blurry unfinished ice sculpture	0		Last Available: "2014-01"
-7080	tumbling tumbling maroon ice sculpture	0		Last Available: "2014-01"
+7080	maroon tumbling tumbling ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	teal snow machine	0		Last Available: "2014-01"
 7083	stanky snow mobile	0		Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
@@ -6976,7 +6976,7 @@
 7087	scandalous rosy-cheeked shellacked groovy snow belt	0		Moxie Percent: +10, Damage Reduction: 7, Maximum HP Percent: +30, Sleaze Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	auspicious nippy deadly ice nine of the dark arts	0		Weapon Damage: +5, Spell Damage Percent: +100, Cold Damage: +10, Item Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7089	wobbly snow fort	0		Last Available: "2014-01"
-7090	watered-down smooth En Una Fila Tequila	2	awesome	
+7090	smooth watered-down En Una Fila Tequila	2	awesome	
 7091	Skully's hot chocolate	1	good	
 7092	fireproof stylish warbear dress helmet	0		Moxie: +25, Hot Resistance: +3, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	Tesla rock-hard warbear dress bracers	0		Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-12"
@@ -6987,21 +6987,21 @@
 7098	lard-coated ribald gravedigger's friendly sweat socks	0		Familiar Weight: +3, Spooky Damage: +10, Sleaze Damage: +10, Sleaze Spell Damage: +25, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	powdered red twirling Five Second Energy&trade;	1		Effect: "Eagle Eyes", Effect Duration: 50, Last Available: "2014-12"
+7101	powdered twirling red Five Second Energy&trade;	1		Effect: "Eagle Eyes", Effect Duration: 50, Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
-7103	denatured teal pulsating powder	0		Effect: "Happy Salamander", Effect Duration: 42, Last Available: "2014-12"
+7103	denatured pulsating teal powder	0		Effect: "Happy Salamander", Effect Duration: 42, Last Available: "2014-12"
 7104	licorice whip of courage	0		Spooky Resistance: +3, Last Available: "2014-12"
 7105	wobbly anise-flavored venom	0		Last Available: "2014-12"
-7106	watered-down smooth snakebite	2	awesome	Last Available: "2014-12"
+7106	smooth watered-down snakebite	2	awesome	Last Available: "2014-12"
 7107	steel-toed educational candy stick	0		Experience: +1, Damage Reduction: 9, Last Available: "2014-12"
 7108	toothsome pecan	3	awesome	Last Available: "2014-12"
 7109	stale pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	moldy super-sized candy mountain oyster	5	crappy	Last Available: "2014-12"
+7111	super-sized moldy candy mountain oyster	5	crappy	Last Available: "2014-12"
 7112	tolerable watered-down chocotini	2	good	Last Available: "2014-12"
 7113	lightning-fast hale beefcake's chocolate rabbit's foot	0		Muscle: +25, Maximum HP: +20, Initiative: +40, Last Available: "2014-12"
 7114	flavorless narrow candy carrot	3	decent	Last Available: "2014-12"
-7115	bland huge candy carrot cake	9	decent	Last Available: "2014-12"
+7115	huge bland candy carrot cake	9	decent	Last Available: "2014-12"
 7116	tumbling Usain Bolt's supercool carrot-on-a-stick	0		Moxie Percent: +20, Initiative: +80, Last Available: "2014-12"
 7117	rosewater-soaked crafty weasel stomping pants	0		Maximum MP: +10, Stench Resistance: +3, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	half-sized rotten lime green mulberry	2	crappy	Last Available: "2014-12"
@@ -7010,9 +7010,9 @@
 7121	miser's lemon party hat	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	lemon shirt of the glutton	0		Food Drop: +100, Lasts Until Rollover, Last Available: "2014-12"
 7123	wobbly lemon drop trousers of temperance	0		Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
-7124	non-dry blinking squat purple lemonhead caviar	0		Effect: "Tiki Thoughtfulness", Effect Duration: 52, Last Available: "2014-12"
+7124	non-dry purple squat blinking lemonhead caviar	0		Effect: "Tiki Thoughtfulness", Effect Duration: 52, Last Available: "2014-12"
 7125	jittery family-friendly gummi sword of the pedagogue	0		Experience: +3, Sleaze Resistance: +1, Last Available: "2014-12"
-7126	alkaline upside-down narrow green small gummi fin	0		Effect: "Can't Be a Chooser", Effect Duration: 69, Last Available: "2014-12"
+7126	alkaline upside-down green narrow small gummi fin	0		Effect: "Can't Be a Chooser", Effect Duration: 69, Last Available: "2014-12"
 7127	tumbling double-paned chocolate cow bone	0		Cold Resistance: +5, Last Available: "2014-12"
 7128	improved galvanized blinking gummi fang	0		Effect: "Disdain of She-Who-Was", Effect Duration: 49, Last Available: "2014-12"
 7129	fancy bland squat leftover canap&eacute;s	3	decent	Effect: "Grrrrrrreat!", Effect Duration: 20, Last Available: "2014-12"
@@ -7020,21 +7020,21 @@
 7131	Jack Frost's vibrating cow creamer of the storm	0		Maximum MP Percent: 50, Cold Spell Damage: +50, Last Available: "2014-12"
 7132	electrified quantum squat Outer Wolf&trade; cologne	0		Effect: "Antibiotic Saucesphere", Effect Duration: 61, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	deadly wolf whistle of the ox	0		Muscle: +20, Weapon Damage: +5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	deadly wolf whistle of the ox	0		Muscle: +20, Weapon Damage: +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	bite-sized flavorless witch's bread	1	decent	Last Available: "2014-12"
 7136	irradiated nitrogenated modified huge witch's brew	0		Effect: "Crying, Dying", Effect Duration: 66, Last Available: "2014-12"
 7137	gray Jim Carey's ruddy witch's bra of chilblains	0		Maximum HP Percent: +40, Monster Level: +25, Cold Damage: +25, Last Available: "2014-12"
-7138	drinkable practically non-alcoholic wobbly mid-level medieval mead	1	good	Last Available: "2014-12"
+7138	practically non-alcoholic drinkable wobbly mid-level medieval mead	1	good	Last Available: "2014-12"
 7139	extra-corrupted R&uuml;mpelstiltz	0		Effect: "Colorful Gratitude", Effect Duration: 65, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	boiled corrupted hi-octane carrot juice	0		Effect: "Emotion Sickness", Effect Duration: 38, Last Available: "2014-12"
 7142	colloidal ionized hare brush	0		Effect: "Icy Demeanor", Effect Duration: 51, Last Available: "2014-12"
 7143	huge gravedigger's hare pin of vim and vigor	0		Maximum HP Percent: +50, Spooky Damage: +10, Single Equip, Last Available: "2014-12"
 7144	tumbling odd coin	0		Last Available: "2014-12"
-7145	toothsome big enchanted cinnamon cannoli	5	awesome	Effect: "Empty Inside", Effect Duration: 15, Last Available: "2014-12"
-7146	practically non-alcoholic smooth special expensive champagne	1	awesome	Effect: "Dreadful Smell", Effect Duration: 10, Last Available: "2014-12"
+7145	toothsome enchanted big cinnamon cannoli	5	awesome	Effect: "Empty Inside", Effect Duration: 15, Last Available: "2014-12"
+7146	special practically non-alcoholic smooth expensive champagne	1	awesome	Effect: "Dreadful Smell", Effect Duration: 10, Last Available: "2014-12"
 7147	adjusted unsweetened spinning narrow polo trophy	0		Effect: "Flagrantly Fragrant", Effect Duration: 21, Last Available: "2014-12"
-7148	tumbling purple oil painting	0		Last Available: "2014-12"
+7148	purple tumbling oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
@@ -7050,13 +7050,13 @@
 7161	hardened padded weightlifter's &quot;honey&quot; dipper	0		Muscle: +15, Damage Absorption: +20, Damage Reduction: 3, Last Available: "2014-12"
 7162	stale bite-sized plumber's lunch	1	decent	Last Available: "2014-12"
 7163	resourceful skull gearshift knob of the bloodbag of Calamity Jane	0		Maximum HP: +100, Maximum MP: +50, Critical Hit Percent: +15, Last Available: "2014-12"
-7164	adequate tiny nachos of the night	1	good	Last Available: "2014-12"
+7164	tiny adequate nachos of the night	1	good	Last Available: "2014-12"
 7165	skewed Jack Frost's Jim Carey's Sketcherz&trade; of the wise owl	0		Mysticality: +20, Monster Level: +25, Cold Spell Damage: +50, Last Available: "2014-12"
 7166	bland ghostly can of Adultwitch&trade;	4	decent	Last Available: "2014-12"
 7167	polymerized purple smudge stick	0		Effect: "Cranberry Cordiality", Effect Duration: 60, Last Available: "2014-12"
 7168	polymerized wobbly wall	0		Effect: "Haunted Liver", Effect Duration: 50, Last Available: "2014-12"
 7169	acceptable tankard of ale	4	good	Last Available: "2014-12"
-7170	chilled wet shaking bouncing blinking scroll case	0		Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2014-12"
+7170	chilled wet bouncing shaking blinking scroll case	0		Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2014-12"
 7171	boiled dry dry green jug of &quot;wine&quot;	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 62, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	tumbling crappy camera	0		Last Available: "2014-12"
@@ -7074,7 +7074,7 @@
 7185	Red Zeppelin ticket	0		
 7186	red Copperhead Charm (rampant)	0		
 7187	aged unnamed cocktail	3	awesome	
-7188	yellow blinking handful of tips	0		
+7188	blinking yellow handful of tips	0		
 7189	unrequired jacket of mayonnaise	0		Sleaze Spell Damage: +50
 7190	vibrating tommy gun	0		Maximum MP Percent: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	pulsating drum of tommy ammo	0		
@@ -7092,7 +7092,7 @@
 7203	upside-down weightlifter's Saturday Night Special	0		Muscle: +15
 7204	lynyrd snare	0		
 7205	fleetwood chain of James Dean	0		Experience (Moxie): +3
-7206	irresponsibly strong enchanted tolerable Green Manalishi	6	good	Effect: "Hopped Up on Goofballs", Effect Duration: 20
+7206	tolerable enchanted irresponsibly strong Green Manalishi	6	good	Effect: "Hopped Up on Goofballs", Effect Duration: 20
 7207	spinning blade of chilblains	0		Cold Damage: +25
 7208	olive fire of unknown origin	0		
 7209	cyan eagle's milk	1	good	
@@ -7115,10 +7115,10 @@
 7226	tea for one	1	awesome	
 7227	hand-crafted bottle of Evermore	4	EPIC	
 7228	box	0		
-7229	artisanal triple-distilled wine	7	EPIC	
+7229	triple-distilled artisanal wine	7	EPIC	
 7230	acceptable tumbling rum	3	good	
 7231	artisanal bouncing Murderer's Punch	3	EPIC	
-7232	normal blurry upside-down velvet cake	3	good	
+7232	normal upside-down blurry velvet cake	3	good	
 7233	magnetized non-dry letter	0		Effect: "Oxygenated Blood", Effect Duration: 25
 7234	pulsating upside-down dangerous supercool book	0		Moxie Percent: +20, Weapon Damage: +10
 7235	green auspicious masque of the sweet-tooth	0		Item Drop: +10, Candy Drop: +100, Single Equip
@@ -7168,8 +7168,8 @@
 7279	irradiated double-quantum unsweetened wind-up Whatsian robot	0		Effect: "Gr8ness", Effect Duration: 67
 7280	liquefied diffused tumbling wind-up vampire teeth	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 15
 7281	anodized cyan wind-up navigation droid	0		Effect: "Papowerful", Effect Duration: 59
-7282	dry polarized dry squat mirror wind-up owl	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 63
-7283	enhanced tarnished twirling blurry wind-up ensign	0		Effect: "Disdain of She-Who-Was", Effect Duration: 15
+7282	dry polarized dry mirror squat wind-up owl	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 63
+7283	enhanced tarnished blurry twirling wind-up ensign	0		Effect: "Disdain of She-Who-Was", Effect Duration: 15
 7284	quilted crying statue earrings of the pedagogue	0		Experience: +3, Damage Absorption: +40, Single Equip, Lasts Until Rollover
 7285	Oprah's groovy plastic Duskwalker necklace	0		Moxie Percent: +10, Maximum MP Percent: +50, Single Equip, Lasts Until Rollover
 7286	blurry green nasty plastic replica blaster pistol of the glutton	0		Stench Damage: +5, Food Drop: +100, Lasts Until Rollover
@@ -7191,7 +7191,7 @@
 7302	lime green Spookyraven library key	0		
 7303	maroon Lady Spookyraven's necklace	0		
 7304	narrow telegram from Lady Spookyraven	0		
-7305	tumbling maroon Lady Spookyraven's powder puff	0		
+7305	maroon tumbling Lady Spookyraven's powder puff	0		
 7306	Lady Spookyraven's finest gown	0		
 7307	twirling Lady Spookyraven's dancing shoes	0		
 7308	anodized skewed eyebrow pencil	0		Effect: "Dexteri Tea", Effect Duration: 51
@@ -7208,12 +7208,12 @@
 7319	smartaleck's beefcake's Elizabeth's Dollie	0		Muscle: +25, Moxie Percent: +30
 7320	electrified frozen unsweetened Elizabeth's paintbrush	0		Effect: "Arabian Knighthood", Effect Duration: 54
 7321	fuchsia friendly Stephen's lab coat of Leguizamo	0		Monster Level: +20, Familiar Weight: +3
-7322	dry improved narrow cyan Stephen's secret formula	0		Effect: "Stregngth of the Gnome", Effect Duration: 22
+7322	dry improved cyan narrow Stephen's secret formula	0		Effect: "Stregngth of the Gnome", Effect Duration: 22
 7323	blue pulsating dance instructor's smooth Jacob's rung	0		Moxie: +15, Experience Percent (Moxie): +10
-7324	pickled wobbly pulsating battery	1		Effect: "Berry Critical", Effect Duration: 25
+7324	pickled pulsating wobbly battery	1		Effect: "Berry Critical", Effect Duration: 25
 7325	acceptable snakebite	3	good	
 7326	jittery mirror Jack Frost's thinker's rubber ribcage	0		Mysticality: +10, Cold Spell Damage: +50, Damage Reduction: 7
-7327	altered twirling mirror synthetic marrow	1		
+7327	altered mirror twirling synthetic marrow	1		
 7328	boiled vacuum-sealed green funny bone	0		Effect: "Rat-Faced", Effect Duration: 22
 7329	sharpshooter's rosy-cheeked half-melted spoon	0		Maximum HP Percent: +30, Critical Hit Percent: +10
 7330	compressed mirror the funk	1		
@@ -7251,7 +7251,7 @@
 7362	healthy plaid skirt of the businessman	0		Maximum HP Percent: +20, Meat Drop: +50, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	boiled diffused bloodstain stick	0		Effect: "Resilient Spirit", Effect Duration: 53
 7364	maroon fabric softener	0		
-7365	electrified triple-nitrogenated pulsating ghostly fabric hardener	0		Effect: "Chow Downed", Effect Duration: 49
+7365	electrified triple-nitrogenated ghostly pulsating fabric hardener	0		Effect: "Chow Downed", Effect Duration: 49
 7366	hand-crafted practically non-alcoholic bottle of laundry sherry	1	super EPIC	
 7367	super-wet industrial strength starch	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 33, Wiki Name: "industrial strength starch"
 7368	jumbo rotten extra-flat panini	5	crappy	
@@ -7285,20 +7285,20 @@
 7396	Vulcanized mirror Gene Tonic: Pirate	0		Effect: "Mucilaginous Muscle", Effect Duration: 52, Last Available: "2014-04"
 7397	unsweetened polarized blurry Gene Tonic: Plant	0		Effect: "Wise Spirit", Effect Duration: 50, Last Available: "2014-04"
 7398	improved quadruple-liquefied Gene Tonic: Weird	0		Effect: "Hairless and Airless", Effect Duration: 63, Last Available: "2014-04"
-7399	tarnished adjusted flattened narrow ghostly Gene Tonic: Elf	0		Effect: "Glittering Eyelashes", Effect Duration: 12, Last Available: "2014-04"
-7400	Vulcanized frozen blurry huge Gene Tonic: Mer-kin	0		Effect: "Salamander In Your Stomach", Effect Duration: 15, Last Available: "2014-04"
-7401	frozen huge shaking Gene Tonic: Slime	0		Effect: "All Branned Up", Effect Duration: 58, Last Available: "2014-04"
+7399	tarnished adjusted flattened ghostly narrow Gene Tonic: Elf	0		Effect: "Glittering Eyelashes", Effect Duration: 12, Last Available: "2014-04"
+7400	Vulcanized frozen huge blurry Gene Tonic: Mer-kin	0		Effect: "Salamander In Your Stomach", Effect Duration: 15, Last Available: "2014-04"
+7401	frozen shaking huge Gene Tonic: Slime	0		Effect: "All Branned Up", Effect Duration: 58, Last Available: "2014-04"
 7402	corrupted maroon Gene Tonic: Penguin	0		Effect: "Provocative Perkiness", Effect Duration: 48, Last Available: "2014-04"
 7403	alkaline blurry Gene Tonic: Elemental	0		Effect: "The Moxious Madrigal", Effect Duration: 57, Last Available: "2014-04"
 7404	extra-moist squat Gene Tonic: Constellation	0		Effect: "Grrrrrrreat!", Effect Duration: 32, Last Available: "2014-04"
-7405	alkaline tumbling spinning purple Gene Tonic: Hobo	0		Effect: "Polar Express", Effect Duration: 30, Last Available: "2014-04"
+7405	alkaline tumbling purple spinning Gene Tonic: Hobo	0		Effect: "Polar Express", Effect Duration: 30, Last Available: "2014-04"
 7406	blurry Steam Card: Dungeon Fist (#1)	0		
 7407	narrow Steam Card: Dungeon Fist (#2)	0		
 7408	pulsating Steam Card: Dungeon Fist (#3)	0		
 7409	yellow Steam Card: Space Trip (#1)	0		
 7410	Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
-7412	jittery blurry Steam Card: Meteoid (#1)	0		
+7412	blurry jittery Steam Card: Meteoid (#1)	0		
 7413	Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
 7415	Steam Card: DemonStar (#1)	0		
@@ -7326,21 +7326,21 @@
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	rotten upside-down Beefy Crunch Pastaco	3	crappy	Last Available: "2014-05"
 7439	toothsome Brain Food Pastaco	3	awesome	Last Available: "2014-05"
-7440	small adequate Cool Brunch Pastaco	2	good	Last Available: "2014-05"
-7441	yummy half-sized Medical Pastaco	2	awesome	Last Available: "2014-05"
+7440	adequate small Cool Brunch Pastaco	2	good	Last Available: "2014-05"
+7441	half-sized yummy Medical Pastaco	2	awesome	Last Available: "2014-05"
 7442	adequate lime green Energy Buzz Pastaco	3	good	Last Available: "2014-05"
-7443	small rotten blinking Ludovico Pastaco	2	crappy	Last Available: "2014-05"
-7444	smooth narrow tumbling overpowering mushroom wine	3	awesome	Last Available: "2014-05"
-7445	mediocre watered-down complex mushroom wine	2	decent	Last Available: "2014-05"
-7446	mediocre practically non-alcoholic smooth mushroom wine	1	decent	Last Available: "2014-05"
+7443	rotten small blinking Ludovico Pastaco	2	crappy	Last Available: "2014-05"
+7444	smooth tumbling narrow overpowering mushroom wine	3	awesome	Last Available: "2014-05"
+7445	watered-down mediocre complex mushroom wine	2	decent	Last Available: "2014-05"
+7446	practically non-alcoholic mediocre smooth mushroom wine	1	decent	Last Available: "2014-05"
 7447	acceptable upside-down blood-red mushroom wine	4	good	Last Available: "2014-05"
-7448	lousy watered-down buzzing mushroom wine	2	decent	Last Available: "2014-05"
+7448	watered-down lousy buzzing mushroom wine	2	decent	Last Available: "2014-05"
 7449	watered-down hand-crafted fuchsia swirling mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
-7450	massive bland fancy Taco Dan's Basic Taco Dan Taco	7	decent	Effect: "Filled with Magic", Effect Duration: 5, Last Available: "2014-05"
-7451	toothsome thick special Taco Dan's Taco Fish Fish Taco	5	awesome	Effect: "Benetton's Medley of Diversity", Effect Duration: 45, Last Available: "2014-05"
+7450	fancy massive bland Taco Dan's Basic Taco Dan Taco	7	decent	Effect: "Filled with Magic", Effect Duration: 5, Last Available: "2014-05"
+7451	special toothsome thick Taco Dan's Taco Fish Fish Taco	5	awesome	Effect: "Benetton's Medley of Diversity", Effect Duration: 45, Last Available: "2014-05"
 7452	teal bouncing Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	bad regular-size brogurt	3	decent	Last Available: "2014-05"
-7454	artisanal practically non-alcoholic super-size brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7454	practically non-alcoholic artisanal super-size brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7455	drinkable distilled broberry brogurt	5	good	Last Available: "2014-05"
 7456	hand-crafted narrow brocolate brogurt	3	EPIC	Last Available: "2014-05"
 7457	mediocre spirit-forward French bronilla brogurt	5	decent	Last Available: "2014-05"
@@ -7367,7 +7367,7 @@
 7478	mirror possessed sugar cube	0		Last Available: "2014-05"
 7479	adjusted quadruple-improved upside-down sugar fairy	0		Effect: "Carrrsmic", Effect Duration: 59, Last Available: "2014-05"
 7480	ionized pulsating sugar bunny	0		Effect: "Barbecue Saucy", Effect Duration: 38, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	drinkable Rompedores de Fantasmas	3	good	
 7483	bad La Fantasma y La Oscuridad	4	decent	
 7484	lousy practically non-alcoholic Fantasma en la M&aacute;quina	1	decent	
@@ -7402,12 +7402,12 @@
 7513	wobbly opium grenade	0		
 7514	clever duonoculars of the scaredy-cat	0		Maximum MP: +20, Monster Level: -15, Single Equip
 7515	plastic rock	0		
-7516	blurry lime green jittery witch's spare house key	0		
+7516	jittery lime green blurry witch's spare house key	0		
 7517	pulsating brawny spider leg of terror	0		Muscle Percent: +20, Spooky Spell Damage: +10
 7518	wand of pigification	0		
 7519	perfectly mixed glass of bourbon	3	EPIC	
 7520	blinking burned government manual fragment	0		Last Available: "2014-05"
-7521	flavorless half-sized red government cheese	2	decent	Last Available: "2014-05"
+7521	half-sized flavorless red government cheese	2	decent	Last Available: "2014-05"
 7522	boxer's pair of government shades	0		Muscle Percent: +10, Single Equip, Last Available: "2014-05"
 7523	shaking space junk	0		Last Available: "2014-05"
 7524	corrupted wobbly government	0		Effect: "Witch's Brood", Effect Duration: 25, Last Available: "2014-05"
@@ -7416,11 +7416,11 @@
 7527	squat alien force field disruptor bean	0		Last Available: "2014-05"
 7528	aromatic sinister government-issued night-vision goggles	0		Spell Damage: +10, Stench Resistance: +1, Single Equip, Last Available: "2014-05"
 7529	flavorless loaf of alien bread	3	decent	Last Available: "2014-05"
-7530	tasty miniature teal grilled cheese sandwich	2	awesome	Last Available: "2014-05"
+7530	miniature tasty teal grilled cheese sandwich	2	awesome	Last Available: "2014-05"
 7531	twisted wobbly teal alien protein powder	1	decent	Effect: "Dweeby", Effect Duration: 50, Last Available: "2014-05"
 7532	lousy blinking rocket fuel	4	decent	Last Available: "2014-05"
-7533	yellow tumbling alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7534	ghostly lime green alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7533	tumbling yellow alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7534	lime green ghostly alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	mediocre practically non-alcoholic stealth bomber	1	decent	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
@@ -7429,7 +7429,7 @@
 7540	supercool space beast fur pants	0		Moxie Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	tumbling Temple Grandin's space beast fur whip	0		Familiar Weight: +7, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	prompt groovy space heater	0		Moxie Percent: +10, Adventures: +3, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	prompt groovy space heater	0		Moxie Percent: +10, Adventures: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
 7545	artisanal jittery squat space port	4	EPIC	Last Available: "2014-05"
 7546	blinking forbidden razor-sharp space needle	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Last Available: "2014-05"
@@ -7439,7 +7439,7 @@
 7550	moist tarnished twirling liquid smoke	0		Effect: "Holiday Bliss", Effect Duration: 17, Last Available: "2014-06"
 7551	double-magnetized spinning dollop of barbecue sauce	0		Effect: "Knightlife", Effect Duration: 66, Last Available: "2014-06"
 7552	aerosolized yellow bowl of marinade	0		Effect: "Headstrong", Effect Duration: 20, Last Available: "2014-06"
-7553	blurry red shaker of dry rub	0		Last Available: "2014-06"
+7553	red blurry shaker of dry rub	0		Last Available: "2014-06"
 7554	unsweetened diffused Vulcanized olive bottle of lighter fluid	0		Effect: "Memory of Attractiveness", Effect Duration: 27, Last Available: "2014-06"
 7555	page	0		
 7556	elephant gift	0		
@@ -7460,7 +7460,7 @@
 7571	twirling crafty hardened silent pea shooter	0		Damage Reduction: 3, Maximum MP: +10
 7572	moldy small D roll	2	crappy	
 7573	auspicious kiwi beak of the boozehound	0		Item Drop: +10, Booze Drop: +100
-7574	weak acceptable New Zealand iced tea	2	good	
+7574	acceptable weak New Zealand iced tea	2	good	
 7575	upside-down Van der Graaf droll monocle of Gandalf	0		Spell Critical Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 7576	boiled adjusted narrow future drug: Muscularactum	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 69
 7577	alkaline polymerized spinning future drug: Smartinex	0		Effect: "Spirit of Alph", Effect Duration: 68
@@ -7469,7 +7469,7 @@
 7580	dried squat liquid shifting time weirdness	1		Effect: "Cat Class, Cat Style", Effect Duration: 30
 7581	green shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	stale rack of dinosaur ribs	4	decent	
-7583	hand-crafted cyan tumbling scotch on the rocks	3	EPIC	
+7583	hand-crafted tumbling cyan scotch on the rocks	3	EPIC	
 7584	lard-coated banded yabba dabba doo rag	0		Damage Absorption: +100, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	bouncing wooly loincloth of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
@@ -7477,20 +7477,20 @@
 7588	jittery Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	artisanal blue glass of &quot;milk&quot;	4	EPIC	Last Available: "2014-07"
 7590	tolerable watered-down cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
-7591	weak hand-crafted thermos of &quot;whiskey&quot;	2	EPIC	Last Available: "2014-07"
+7591	hand-crafted weak thermos of &quot;whiskey&quot;	2	EPIC	Last Available: "2014-07"
 7592	lousy Lucky Lindy	3	decent	Last Available: "2014-07"
 7593	practically non-alcoholic artisanal Bee's Knees	1	super EPIC	Last Available: "2014-07"
-7594	watered-down mediocre shaking Sockdollager	2	decent	Last Available: "2014-07"
+7594	mediocre watered-down shaking Sockdollager	2	decent	Last Available: "2014-07"
 7595	hand-crafted triple-distilled Ish Kabibble	7	EPIC	Last Available: "2014-07"
-7596	delicious boozy Hot Socks	5	awesome	Last Available: "2014-07"
+7596	boozy delicious Hot Socks	5	awesome	Last Available: "2014-07"
 7597	drinkable Phonus Balonus	4	good	Last Available: "2014-07"
-7598	special acceptable practically non-alcoholic Flivver	1	good	Effect: "Biologically Shocked", Effect Duration: 50, Last Available: "2014-07"
+7598	special practically non-alcoholic acceptable Flivver	1	good	Effect: "Biologically Shocked", Effect Duration: 50, Last Available: "2014-07"
 7599	drinkable Sloppy Jalopy	4	good	Last Available: "2014-07"
 7600	super-enhanced deionized moist squat flame	0		Effect: "New and Improved", Effect Duration: 41
 7601	quantum temporary yak tattoo	0		Effect: "Took Eleven", Effect Duration: 49
 7602	adjusted vacuum-sealed yellow Fitspiration&trade; poster	0		Effect: "Spiky Frozen Hair", Effect Duration: 66
 7603	irradiated extra-cold-filtered neckbeard	0		Effect: "Disdain of She-Who-Was", Effect Duration: 23
-7604	dry skewed teal artisanal hand-squeezed wheatgrass juice	0		Effect: "Healthy Bronze Glow", Effect Duration: 19
+7604	dry teal skewed artisanal hand-squeezed wheatgrass juice	0		Effect: "Healthy Bronze Glow", Effect Duration: 19
 7605	nitrogenated colloidal punk patch	0		Effect: "Hombre Muerto Caminando", Effect Duration: 16
 7606	moist polarized steampunk potion	0		Effect: "Cinnamouth", Effect Duration: 68
 7607	activated non-colloidal bouncing vial of swamp vapors	0		Effect: "Emotion Sickness", Effect Duration: 21
@@ -7499,7 +7499,7 @@
 7610	pressed oxidized irradiated Dweebisol&trade; inhaler	0		Effect: "Burning Hands", Effect Duration: 68
 7611	extra-wet electrified twirling Lewd Lemmy Hair Oil	0		Effect: "Red Misty-Eyed", Effect Duration: 22
 7612	pickled triple-Vulcanized purple tomato soup poster	0		Effect: "Feroci Tea", Effect Duration: 35
-7613	magnetized upside-down green shaking bubblin' chemistry solution	0		Effect: "On the Trolley", Effect Duration: 24
+7613	magnetized green shaking upside-down bubblin' chemistry solution	0		Effect: "On the Trolley", Effect Duration: 24
 7614	wet dry mirror skewed voodoo glowskull	0		Effect: "Cold, Dead Hands", Effect Duration: 59
 7615	ionized pygmy adder oil	0		Effect: "Stimulated Body", Effect Duration: 27
 7616	unsweetened non-altered pygmy witchhazel	0		Effect: "Flame-Retardant Trousers", Effect Duration: 61
@@ -7511,9 +7511,9 @@
 7622	quadruple-activated dry button rouge	0		Effect: "A Taste of Rainbow", Effect Duration: 60
 7623	ionized skewed skewed Red Army camouflage kit	0		Effect: "Thick-Skinned", Effect Duration: 40
 7624	dry lynyrd skinner toothblack	0		Effect: "Pumped Stomach", Effect Duration: 31
-7625	deionized polarized altered blurry pulsating flask of rainwater	0		Effect: "Marco Polarity", Effect Duration: 21
+7625	deionized polarized altered pulsating blurry flask of rainwater	0		Effect: "Marco Polarity", Effect Duration: 21
 7626	quantum oyster badge	0		Effect: "Memory of Attractiveness", Effect Duration: 45
-7627	magnetized bouncing teal plastic Jefferson wings	0		Effect: "Very Clean Teeth", Effect Duration: 65
+7627	magnetized teal bouncing plastic Jefferson wings	0		Effect: "Very Clean Teeth", Effect Duration: 65
 7628	galvanized tumbling blinking dancing fan	0		Effect: "Inscrutable exoskeleton", Effect Duration: 28
 7629	polymerized dry page of the Necrohobocon	0		Effect: "All Blued Up", Effect Duration: 40
 7630	alkaline flattened blinking magic powder	0		Effect: "Disco Neuropathy", Effect Duration: 20
@@ -7521,7 +7521,7 @@
 7632	wet twirling government-issue identification badge	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 54
 7633	quadruple-cold-filtered upside-down alien hologram projector	0		Effect: "Well Owl Be!", Effect Duration: 49
 7634	electrified diffused aerosolized irradiated turtle	0		Effect: "It's Soporiffic!", Effect Duration: 25
-7635	dry blue narrow cigar box turtle	0		Effect: "Turkey-Friendly", Effect Duration: 53
+7635	dry narrow blue cigar box turtle	0		Effect: "Turkey-Friendly", Effect Duration: 53
 7636	inspector's manspreader's shellacked shell	0		Monster Level: +10, Item Drop: +15, Class: "Turtle Tamer"
 7637	teal pillow shell of the cheetah	0		Initiative: +60, Class: "Turtle Tamer"
 7638	mirror boxer's whatsit-covered turtle shell	0		Muscle Percent: +10, Class: "Turtle Tamer"
@@ -7553,7 +7553,7 @@
 7664	concentrated yellow Ancient Protector Soda	0		Effect: "Hot Buttoned", Effect Duration: 44
 7665	electrified dry diffused liquid ice	0		Effect: "Inebriate Pride", Effect Duration: 14
 7666	bad Wet Russian	3	decent	
-7667	adequate jumbo filet of The Fish	5	good	
+7667	jumbo adequate filet of The Fish	5	good	
 7668	Thwaitgold spider statuette	0		
 7669	squat sharpshooter's beefcake's thunder down underwear of the businessman	0		Muscle: +25, Critical Hit Percent: +10, Meat Drop: +50, Lasts Until Rollover
 7670	Jeselnik's veiny famous raincoat of terror	0		Maximum HP: +10, Spooky Spell Damage: +10, Sleaze Damage: +25, Lasts Until Rollover
@@ -7561,7 +7561,7 @@
 7672	steel-toed law-abiding citizen cane	0		Damage Reduction: 9, Single Equip
 7673	mediocre extra-dry legitimate business on the beach	5	decent	
 7674	hep waders	0		Item Drop: +5, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	bland half-sized jive turkey leg	2	decent	
+7675	half-sized bland jive turkey leg	2	decent	
 7676	pulsating cyan groovy birdbone corset	0		Moxie Percent: +10
 7677	magnetized oxidized teal candy cigarette	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 12
 7678	ghostly educational 4-dimensional fez	0		Experience: +1, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7581,7 +7581,7 @@
 7692	hand whip of the ox of the dark arts of the detective	0		Muscle: +20, Spell Damage Percent: +100, Item Drop: +20, Last Available: "2014-08"
 7693	frosty healthy glow-in-the-dark necklace of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Cold Spell Damage: +10, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	reassuring rosy-cheeked strapping cap gun	0		Muscle: +5, Maximum HP Percent: +30, Spooky Resistance: +1, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	reassuring rosy-cheeked strapping cap gun	0		Muscle: +5, Maximum HP Percent: +30, Spooky Resistance: +1, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	frosty nippy cassette player	0		Cold Damage: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,16 +7592,16 @@
 7703	ghostly yellow LCD game: Food Eater	0		Last Available: "2014-08"
 7704	twirling LCD game: Garbage River	0		Last Available: "2014-08"
 7705	mirror LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	unsweetened rubber nubbin	0		Effect: "init.enh", Effect Duration: 14, Last Available: "2014-08"
 7708	ghostly lime green chilly stylish rubber cape	0		Moxie: +25, Cold Damage: +5, Last Available: "2014-08"
-7709	jittery yellow zippy chaotic hale Da Vinci's Thor's Pliers	0		Experience (Mysticality): +5, Maximum HP: +20, Spell Critical Percent: +10, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	jittery yellow zippy chaotic hale Da Vinci's Thor's Pliers	0		Experience (Mysticality): +5, Maximum HP: +20, Spell Critical Percent: +10, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	polymerized narrow candy UFOs	0		Effect: "Buggy Flavor", Effect Duration: 65
 7711	dog trainer's Jim Carey's water wings for babies	0		Monster Level: +25, Experience (familiar): +1
-7712	huge beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	half-sized flavorless Strix stix	2	decent	
+7712	huge beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7713	flavorless half-sized Strix stix	2	decent	
 7714	double-paned resourceful vampire pellet of the pedagogue	0		Experience: +3, Maximum MP: +50, Cold Resistance: +5
-7715	practically non-alcoholic drinkable non-aged vinegar	1	good	
+7715	drinkable practically non-alcoholic non-aged vinegar	1	good	
 7716	chaotic unsanitized scalpel	0		Spell Critical Percent: +10
 7717	careful gladiator tunica	0		Monster Level: -10
 7718	slick Roman sadnals	0		Moxie: +10, Single Equip
@@ -7611,7 +7611,7 @@
 7722	prompt centurion helmet	0		Adventures: +3, Familiar Effect: "1xFairy, atk, cap 25"
 7723	Chroner cross	0		
 7724	pteruges of the pedagogue	0		Experience: +3, Familiar Effect: "1xFairy, atk, cap 25"
-7725	nitrogenated corrupted skewed spinning lime green mirror Bruno's blessing of Mars	0		Effect: "Dreadful Smell", Effect Duration: 34
+7725	nitrogenated corrupted skewed mirror lime green spinning Bruno's blessing of Mars	0		Effect: "Dreadful Smell", Effect Duration: 34
 7726	non-warmed improved shaking Dennis's blessing of Minerva	0		Effect: "Eau de Tortue", Effect Duration: 62
 7727	corrupted huge Burt's blessing of Bacchus	0		Effect: "Sugary World View", Effect Duration: 43
 7728	super-concentrated super-activated ghostly Freddie's blessing of Mercury	0		Effect: "Abyssal Tears", Effect Duration: 65
@@ -7642,7 +7642,7 @@
 7753	family-friendly baleful Xiblaxian stealth cowl	0		Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	weightlifter's Xiblaxian stealth trousers of the glutton	0		Muscle: +15, Food Drop: +100, Last Available: "2014-09"
 7755	sharpshooter's Xiblaxian stealth vest of the scaredy-cat	0		Critical Hit Percent: +10, Monster Level: -15, Last Available: "2014-09"
-7756	small normal Xiblaxian ultraburrito	2	good	Last Available: "2014-09"
+7756	normal small Xiblaxian ultraburrito	2	good	Last Available: "2014-09"
 7757	delicious Xiblaxian space-whiskey	3	awesome	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	pickled galvanized They liver	0		Effect: "Stench Jellied", Effect Duration: 62, Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	huge Coinspiracy	0		Last Available: "2014-10"
 7770	double-paned sharpshooter's Personal Ventilation Unit of courage	0		Critical Hit Percent: +10, Cold Resistance: +5, Spooky Resistance: +3, Single Equip, Last Available: "2014-10"
 7771	triple-anodized polarized upside-down the most dangerous bait	0		Effect: "Sleazy Jellied", Effect Duration: 40, Last Available: "2014-10"
-7772	small rotten &quot;meat&quot; stick	2	crappy	Last Available: "2014-10"
+7772	rotten small &quot;meat&quot; stick	2	crappy	Last Available: "2014-10"
 7773	dehydrated tumbling transdermal smoke patch	1	EPIC	Last Available: "2014-10"
 7774	upside-down specialty ammo bandolier	0		Last Available: "2014-10"
 7775	bouncing jittery frightening wicked brainy pair of plants	0		Mysticality: +5, Spell Damage: +5, Spooky Damage: +5, Last Available: "2014-10"
@@ -7670,23 +7670,23 @@
 7781	upside-down careful grievous brawny battery-powered drill of the cougar	0		Moxie: +20, Muscle Percent: +20, Weapon Damage Percent: +50, Monster Level: -10, Last Available: "2014-10"
 7782	bland shaking bouncing limp broccoli	3	decent	Last Available: "2014-10"
 7783	squat blue ribald hardy hat of the ox	0		Muscle: +20, Maximum HP: +50, Sleaze Damage: +10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
-7784	electrified bouncing ghostly red monkey barf	0		Effect: "Drenched With Filth", Effect Duration: 46, Last Available: "2014-10"
+7784	electrified red ghostly bouncing monkey barf	0		Effect: "Drenched With Filth", Effect Duration: 46, Last Available: "2014-10"
 7785	super-tarnished dry candy	0		Effect: "Okee-Dokee Go!", Effect Duration: 54, Last Available: "2014-10"
 7786	aromatic MacGyver's jangly bracelet of the glutton	0		Maximum MP: +100, Stench Resistance: +1, Food Drop: +100, Last Available: "2014-10"
-7787	healthy cuddly teddy bear	0		Maximum HP Percent: +20, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	healthy cuddly teddy bear	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	greedy first-aid pouch of the sewer	0		Stench Damage: +25, Meat Drop: +20, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	modified diffused huge airborne mutagen	0		Effect: "The Q Is Talking To You", Effect Duration: 24, Last Available: "2014-10"
-7792	wobbly pulsating SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
+7792	pulsating wobbly SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	red bottle-opener keycard	0		Last Available: "2014-10"
 7794	cyan Armory keycard	0		Last Available: "2014-10"
-7795	gigantic adequate jittery initiative shawarma	7	good	Last Available: "2014-10"
+7795	adequate gigantic jittery initiative shawarma	7	good	Last Available: "2014-10"
 7796	bland warm war shawarma	3	decent	Last Available: "2014-10"
 7797	adequate karma shawarma	4	good	Last Available: "2014-10"
 7798	lousy Jungle Juice	3	decent	Last Available: "2014-10"
 7799	perfectly mixed practically non-alcoholic Amnesiac Ale	1	super ultra EPIC	Last Available: "2014-10"
-7800	weak mediocre Highest Bitter	2	decent	Last Available: "2014-10"
+7800	mediocre weak Highest Bitter	2	decent	Last Available: "2014-10"
 7801	fortified groovy mercenary pistol	0		Moxie Percent: +10, Damage Absorption: +60, Last Available: "2014-10"
 7802	dangerous mercenary rifle of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7699,14 +7699,14 @@
 7810	cyan Z-Bone steak	0		
 7811	wobbly viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	enchanted rotten bouncing seared dino steak	3	crappy	Effect: "Quadrilled", Effect Duration: 10
+7813	rotten enchanted bouncing seared dino steak	3	crappy	Effect: "Quadrilled", Effect Duration: 10
 7814	artisanal jittery bottle of drinkin' gas	4	EPIC	
-7815	gray blinking tumbling handful of napalm	0		
+7815	blinking tumbling gray handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
 7818	99.44% pure math	0		
 7819	simple AI	0		
-7820	tumbling mirror corrupted bird DNA	0		
+7820	mirror tumbling corrupted bird DNA	0		
 7821	bouncing sentient meat mass	0		
 7822	zombie dinosaur egg	0		
 7823	french-fry grabber	0		Familiar Weight: +5
@@ -7734,7 +7734,7 @@
 7845	improved liquefied perl necklace	0		Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2014-12"
 7846	wet Fudge Fiber Armor Plating	0		Effect: "Incensed", Effect Duration: 68, Last Available: "2014-12"
 7847	vacuum-sealed ruby on canes	0		Effect: "Bureaucratized", Effect Duration: 21, Last Available: "2014-12"
-7848	moldy snack-sized pulsating petit fortran	2	crappy	Last Available: "2014-12"
+7848	snack-sized moldy pulsating petit fortran	2	crappy	Last Available: "2014-12"
 7849	moldy java cookie	3	crappy	Last Available: "2014-12"
 7850	decent cookie cookie	4	good	Last Available: "2014-12"
 7851	shellacked plastic exo-suited miner	0		Damage Reduction: 7, Last Available: "2014-12"
@@ -7782,7 +7782,7 @@
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	squat cyan Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	huge Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
-7896	ghostly gray Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
+7896	gray ghostly Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	skewed Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
@@ -7810,7 +7810,7 @@
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	acceptable squat Friendly Turkey	3	good	Last Available: "2014-11"
 7923	aged squat Agitated Turkey	3	awesome	Last Available: "2014-11"
-7924	aged practically non-alcoholic Ambitious Turkey	1	awesome	Last Available: "2014-11"
+7924	practically non-alcoholic aged Ambitious Turkey	1	awesome	Last Available: "2014-11"
 7925	adequate neutron lollipop	3	good	Last Available: "2014-12"
 7926	drinkable huge gamma nog	4	good	Last Available: "2014-12"
 7934	bouncing sneaky wrapping paper	0		Last Available: "2014-12"
@@ -7820,13 +7820,13 @@
 7938	boiled single atom	1	decent	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2015-02"
 7939	skewed Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
-7941	blurry wobbly sleeve deuce	0		
+7941	wobbly blurry sleeve deuce	0		
 7942	pocket ace	0		
 7943	narrow nastygeist	0		
 7944	squat tooth	0		
 7945	table	0		
 7946	lightning-fast arcane researcher's outlaw bandana of doom	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +50, Initiative: +40
-7947	drinkable watered-down whiskey in a broken glass	2	good	
+7947	watered-down drinkable whiskey in a broken glass	2	good	
 7948	perfectly mixed blurry shot of mescal	4	EPIC	
 7949	acceptable watered-down skewed glass of herbal tequila	2	good	
 7950	minin' dynamite	0		
@@ -7881,17 +7881,17 @@
 7999	dry choco-Crimbot	0		Effect: "Broberry Brotality", Effect Duration: 64, Last Available: "2014-12"
 8000	wet smart watch	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 66, Last Available: "2014-12"
 8001	triple-boiled wet wobbly augmented-reality shades	0		Effect: "Sewer-Drenched", Effect Duration: 12, Last Available: "2014-12"
-8002	wholesome toy Crimbot mega face	0		Maximum HP Percent: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
-8003	friendly toy Crimbot power glove	0		Familiar Weight: +3, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	bouncing toy Crimbot super fist of the blizzard	0		Cold Spell Damage: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	olive experienced toy Crimbot rocket legs	0		Experience: +2, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	wholesome toy Crimbot mega face	0		Maximum HP Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	friendly toy Crimbot power glove	0		Familiar Weight: +3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	bouncing toy Crimbot super fist of the blizzard	0		Cold Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	olive experienced toy Crimbot rocket legs	0		Experience: +2, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	modified Crimbot battery	0		Effect: "Pasty", Effect Duration: 38, Last Available: "2014-12"
 8007	squat Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	blurry twirling heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	prompt studded Crimbomega drive chain of the early riser	0		Damage Absorption: +80, Adventures: 10, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	prompt studded Crimbomega drive chain of the early riser	0		Damage Absorption: +80, Adventures: 10, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	blinking Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	blue Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,9 +7899,9 @@
 8017	extra-irradiated flask of tainted mining oil	0		Effect: "Wit Tea", Effect Duration: 39, Last Available: "2014-12"
 8018	aerosolized and rain stick	0		Effect: "Holiday Disappointment", Effect Duration: 12
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	decent half-sized Choco-Mint patty	2	good	Last Available: "2015-01"
+8020	half-sized decent Choco-Mint patty	2	good	Last Available: "2015-01"
 8021	irresponsibly strong lousy twirling hot mint schnocolate	10	decent	Last Available: "2015-01"
-8022	altered green upside-down homeopathic mint tea	1	awesome	Last Available: "2015-01"
+8022	altered upside-down green homeopathic mint tea	1	awesome	Last Available: "2015-01"
 8023	lime green muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	ghostly bowl of potpourri	0		Last Available: "2015-01"
@@ -7984,7 +7984,7 @@
 8109	maroon Sinatra's savvy ascot	0		Mysticality Percent: +20, Experience (Moxie): +5, Single Equip, Last Available: "2017-12"
 8110	wobbly banded wizardly attache case	0		Mysticality: +25, Damage Absorption: +100, Last Available: "2017-12"
 8111	experienced smartaleck's accordion	0		Moxie Percent: +30, Experience: +2, Song Duration: 10, Last Available: "2017-12"
-8112	twisted tumbling maroon tumbling aerosolized	1		Last Available: "2017-12"
+8112	twisted tumbling tumbling maroon aerosolized	1		Last Available: "2017-12"
 8113	bouncing hale wig of temperance	0		Maximum HP: +20, Sleaze Resistance: +5, Last Available: "2017-12"
 8114	flame-wreathed Herculean winch crank	0		Experience (Muscle): +1, Hot Spell Damage: +10, Single Equip, Last Available: "2017-12"
 8115	Fonzie's widget of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	rosewater-soaked extremely unsafe garland	0		Weapon Damage Percent: +100, Stench Resistance: +3, Single Equip, Last Available: "2018-12"
 8122	wobbly fuchsia stiffened Rosewater's gunnysack	0		Mysticality Percent: +30, Damage Reduction: 1, Last Available: "2018-12"
 8123	ghostly garibaldi of temperance of the glutton	0		Sleaze Resistance: +5, Food Drop: +100, Last Available: "2018-12"
-8124	olive chilly girdle of the sewer	0		Cold Damage: +5, Stench Damage: +25, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	olive chilly girdle of the sewer	0		Cold Damage: +5, Stench Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	manspreader's savvy gloves	0		Mysticality Percent: +20, Monster Level: +10, Single Equip, Last Available: "2018-12"
 8126	powdered shaking smithereens	1		Effect: "Dreadful Heat", Effect Duration: 25, Last Available: "2018-12"
 8127	vibrating fiberglass fetish of incineration	0		Maximum MP Percent: +10, Hot Spell Damage: +50, Last Available: "2018-12"
@@ -8029,7 +8029,7 @@
 8155	non-electrified talisman of Horus	0		Effect: "Heal Thy Nanoself", Effect Duration: 55
 8156	wobbly check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
-8158	jittery red bone with a price tag on it	0		
+8158	red jittery bone with a price tag on it	0		
 8159	half of a tooth	0		
 8160	extra-energized mouse skull	0		Effect: "Weird Flavor", Effect Duration: 61
 8161	polarized pickled upside-down really thick spine	0		Effect: "Neutered Nostrils", Effect Duration: 47
@@ -8038,7 +8038,7 @@
 8164	strapping remaindered axe of the sewer	0		Muscle: +5, Stench Damage: +25
 8165	low-budget shield	0		Damage Reduction: 3
 8166	rosy-cheeked cr&ecirc;epy mask of the cheetah	0		Maximum HP Percent: +30, Initiative: +60, Familiar Effect: "spooky atk, cap 5"
-8167	diet normal squat baguette	1	good	
+8167	normal diet squat baguette	1	good	
 8168	purple glob of icing	0		
 8169	dry lime green ginger snaps	0		Effect: "Berry Defensive", Effect Duration: 39
 8170	oxidized lime green squat mostly-broken sunglasses	0		Effect: "Retrograde Relaxation", Effect Duration: 35
@@ -8059,23 +8059,23 @@
 8185	clever steel-toed The Crown of Ed the Undying	0		Damage Reduction: 9, Maximum MP: +20, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	distilled perfectly mixed tumbling huge Cherrytastrophe wine cooler	5	EPIC	
-8189	watered-down artisanal blurry upside-down Radberry Rip wine cooler	2	EPIC	
+8188	perfectly mixed distilled tumbling huge Cherrytastrophe wine cooler	5	EPIC	
+8189	artisanal watered-down blurry upside-down Radberry Rip wine cooler	2	EPIC	
 8190	tolerable Orangemageddon wine cooler	4	good	
 8191	distilled perfectly mixed Breakfast Blast wine cooler	5	EPIC	
 8192	artisanal huge Citrus Crush wine cooler	3	EPIC	
 8193	spoiled plain bagel	3	crappy	
-8194	spoiled diet gray glob of cream cheese	1	crappy	
+8194	diet spoiled gray glob of cream cheese	1	crappy	
 8195	bland loaf of soda bread	4	decent	
 8196	yummy super-sized mirror acceptable bagel	5	awesome	
 8197	moldy standard-issue cupcake	3	crappy	
 8198	spoiled blurry ultra-deluxe cupcake	3	crappy	
 8199	hypnotic breadcrumbs	0		
-8200	special tasty popular tart	3	awesome	Effect: "Industrial Strength Starch", Effect Duration: 25
+8200	tasty special popular tart	3	awesome	Effect: "Industrial Strength Starch", Effect Duration: 25
 8201	no-handed pie	0		
 8202	double-nitrogenated Doc Galaktik's Vitality Serum	0		Effect: "stats.enq", Effect Duration: 69
 8203	green airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
-8204	yellow pulsating one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
+8204	pulsating yellow one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	mirror FunFunds&trade;	0		Last Available: "2015-04"
 8206	ghostly foul-smelling rock-hard expensive camera	0		Damage Reduction: 5, Stench Damage: +10, Single Equip, Last Available: "2015-04"
 8207	fuchsia sunglasses	0		Single Equip, Last Available: "2015-04"
@@ -8086,12 +8086,12 @@
 8212	twirling grogpagne	0		Last Available: "2021-07"
 8213	censurious rigging rope of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Last Available: "2015-04"
 8214	mixed upside-down nasty snuff	1	decent	Effect: "Patience of the Tortoise", Effect Duration: 40, Last Available: "2015-04"
-8215	baleful sewage-clogged pistol of the overflowing toilet	0		Spell Damage: +25, Stench Spell Damage: +50, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	baleful sewage-clogged pistol of the overflowing toilet	0		Spell Damage: +25, Stench Spell Damage: +50, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	warmed huge beard incense	0		Effect: "Jittery", Effect Duration: 17, Last Available: "2015-04"
 8217	manspreader's perfume-soaked bandana of the bloodbag	0		Maximum HP: +100, Monster Level: +10, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	decent toxo	3	good	Last Available: "2015-04"
-8220	bad weak pulsating Lemonade-235	2	decent	Last Available: "2015-04"
+8220	weak bad pulsating Lemonade-235	2	decent	Last Available: "2015-04"
 8221	ribald Oprah's isotophat	0		Maximum MP Percent: +50, Sleaze Damage: +10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	auspicious careful Three Mile Island shorts	0		Monster Level: -10, Item Drop: +10, Last Available: "2015-04"
 8223	aromatic vibrating toxic mop	0		Maximum MP Percent: +10, Stench Resistance: +1, Last Available: "2015-04"
@@ -8116,10 +8116,10 @@
 8242	keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	steel-toed lube-shoes	0		Damage Reduction: 9, Last Available: "2015-04"
-8245	shaking blurry gray trash net	0		Last Available: "2015-04"
+8245	blurry shaking gray trash net	0		Last Available: "2015-04"
 8246	upside-down rosewater-soaked lion tamer's Dinsey mascot mask of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Stench Resistance: +3, Last Available: "2015-04"
 8247	yummy immense Dinsey food-cone	9	awesome	Last Available: "2015-04"
-8248	drinkable irresponsibly strong mirror Dinsey Whinskey	8	good	Last Available: "2015-04"
+8248	irresponsibly strong drinkable mirror Dinsey Whinskey	8	good	Last Available: "2015-04"
 8249	anodized blurry Dinsey face paint	0		Effect: "Sweet and Green", Effect Duration: 55, Last Available: "2015-04"
 8250	occult fannypack of the brazier	0		Spell Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2015-04"
 8251	aromatic double-paned razor-sharp cool garbage sticker of the ox of the pedagogue	0		Muscle: +20, Moxie: +5, Experience: +3, Weapon Damage Percent: +25, Cold Resistance: +5, Stench Resistance: +1, Last Available: "2015-04"
@@ -8127,13 +8127,13 @@
 8253	Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
-8256	squat fuchsia wobbly Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	quadruple-moist cold-filtered frozen skewed cyan nasty gum	0		Effect: "Bestial Sympathy", Effect Duration: 35
+8256	wobbly fuchsia squat Dinsey tattoo kit	0		Last Available: "2015-04"
+8257	quadruple-moist cold-filtered frozen cyan skewed nasty gum	0		Effect: "Bestial Sympathy", Effect Duration: 35
 8258	bouncing bouncing Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	bouncing scorching The Lot's engagement ring	0		Hot Damage: +25, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	wobbly Mayo Clinic	0		Last Available: "2015-05"
 8261	Mayonex	0		Last Available: "2015-05"
-8262	skewed wobbly Mayodiol	0		Last Available: "2015-05"
+8262	wobbly skewed Mayodiol	0		Last Available: "2015-05"
 8263	narrow jittery Mayostat	0		Last Available: "2015-05"
 8264	maroon Mayozapine	0		Last Available: "2015-05"
 8265	Mayoflex	0		Last Available: "2015-05"
@@ -8141,15 +8141,15 @@
 8267	foul-smelling sphygmayomanometer	0		Stench Damage: +10, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	moldy big pulsating green unappetizing mayolus	5	crappy	Last Available: "2015-05"
+8270	big moldy pulsating green unappetizing mayolus	5	crappy	Last Available: "2015-05"
 8271	flavorless uninteresting mayolus	3	decent	Last Available: "2015-05"
 8272	massive bland acceptable mayolus	7	decent	Last Available: "2015-05"
 8273	spoiled enticing mayolus	4	crappy	Last Available: "2015-05"
 8274	spoiled super-sized mouth-watering mayolus	5	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
-8276	narrow spinning mayo pump	0		Familiar Weight: +5
+8276	spinning narrow mayo pump	0		Familiar Weight: +5
 8277	wobbly Essence of Bear	0		Skill: "Bear Essence"
-8278	watered-down aged Afternoon Delight	2	awesome	Last Available: "2015-04"
+8278	aged watered-down Afternoon Delight	2	awesome	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	triple-tarnished tumbling Kokomo Resort Brand Suntan Oil	0		Effect: "The Solution", Effect Duration: 68, Last Available: "2015-04"
@@ -8172,9 +8172,9 @@
 8298	pixel	0		Last Available: "2015-06"
 8299	blue ghostly pixel coin	0		Last Available: "2015-06"
 8300	pressed wet olive power pill	0		Effect: "One Very Clear Eye", Effect Duration: 35, Last Available: "2015-06"
-8301	modified ionized tarnished blurry blinking pixel star	0		Effect: "From Nantucket", Effect Duration: 67, Last Available: "2015-06"
+8301	modified ionized tarnished blinking blurry pixel star	0		Effect: "From Nantucket", Effect Duration: 67, Last Available: "2015-06"
 8302	decent pixel banana	4	good	Last Available: "2015-06"
-8303	special perfectly mixed pixel beer	4	EPIC	Effect: "Expert Vacationer", Effect Duration: 40, Last Available: "2015-06"
+8303	perfectly mixed special pixel beer	4	EPIC	Effect: "Expert Vacationer", Effect Duration: 40, Last Available: "2015-06"
 8304	red bouncing puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	flattened sludgesicle	0		Effect: "Wreathed in Smoke", Effect Duration: 56
@@ -8196,10 +8196,10 @@
 8322	quadruple-quantum handful of fire	0		Effect: "Stinky Hands", Effect Duration: 42
 8323	polymerized pressed Cracklin' Oat Bran	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 26
 8324	modified disposable lighter	0		Effect: "Concentration", Effect Duration: 49
-8325	enhanced activated blue narrow coal contact lenses	0		Effect: "Techno Bliss", Effect Duration: 15
+8325	enhanced activated narrow blue coal contact lenses	0		Effect: "Techno Bliss", Effect Duration: 15
 8326	unsweetened extra-concentrated shaking conjured ice cream	0		Effect: "Neutered Nostrils", Effect Duration: 20
 8327	oxidized Iceberglar scarf	0		Effect: "Memory of Smarts", Effect Duration: 61
-8328	chilled tumbling maroon icy hairspray	0		Effect: "Pop-eyed", Effect Duration: 51
+8328	chilled maroon tumbling icy hairspray	0		Effect: "Pop-eyed", Effect Duration: 51
 8329	polymerized blurry smellbook	0		Effect: "Devil Inside", Effect Duration: 15
 8330	quantum vacuum-sealed gray twirling assassin's cheese knife	0		Effect: "Clyde's Blessing", Effect Duration: 30
 8331	irradiated triple-denatured filthy armor	0		Effect: "Meadulla Oblongota", Effect Duration: 40
@@ -8228,7 +8228,7 @@
 8354	Vulcanized ghostly nursery rhyme	0		Effect: "Egg-stra Arm", Effect Duration: 11
 8355	energized ghostly iron torso box	0		Effect: "Beastly Flavor", Effect Duration: 13
 8356	unsweetened mercenary headband	0		Effect: "Wreathed in Smoke", Effect Duration: 38
-8357	vacuum-sealed enhanced frozen squat maroon radioactive spider venom	0		Effect: "Mighty Shout", Effect Duration: 34
+8357	vacuum-sealed enhanced frozen maroon squat radioactive spider venom	0		Effect: "Mighty Shout", Effect Duration: 34
 8358	alkaline huge teal x-ray mirror	0		Effect: "Starry-Eyed", Effect Duration: 62
 8359	polymerized polarized alkaline wrestling mask	0		Effect: "Sausage Festive", Effect Duration: 23
 8360	nitrogenated ionized hawkface potion	0		Effect: "Spring Training", Effect Duration: 51
@@ -8248,7 +8248,7 @@
 8374	non-corrupted deionized drinks tray	0		Effect: "Mucilaginous Mentalism", Effect Duration: 47
 8375	quadruple-polarized enhanced eyebrow lifter	0		Effect: "Disco Concentration", Effect Duration: 59
 8376	submarine	0		Last Available: "2015-06"
-8377	thick yummy pixel lemon	5	awesome	Last Available: "2015-06"
+8377	yummy thick pixel lemon	5	awesome	Last Available: "2015-06"
 8378	smooth triple-distilled pixel daiquiri	8	awesome	Last Available: "2015-06"
 8379	concentrated non-dry squat power pill	0		Effect: "Bone Homie", Effect Duration: 20, Last Available: "2015-06"
 8380	double-dry pixel potion	0		Effect: "Frisky Spirit", Effect Duration: 31, Last Available: "2015-06"
@@ -8280,12 +8280,12 @@
 8406	savory dry noodles	0		
 8407	decent ghostly pestopiary	4	good	
 8408	non-magnetized ionized ectoplasmic orbs	0		Effect: "The Dinsey Spirit", Effect Duration: 59
-8409	normal huge crudles	9	good	
+8409	huge normal crudles	9	good	
 8410	adequate agnolotti arboli	3	good	
 8411	spoiled spaghetti with ghost balls	3	crappy	
-8412	moldy bite-sized red succulent marrow	1	crappy	
+8412	bite-sized moldy red succulent marrow	1	crappy	
 8413	decent salacious crumbs	3	good	
-8414	decent bite-sized special fusilli marrownarrow	1	good	Effect: "Amorous", Effect Duration: 20
+8414	bite-sized decent special fusilli marrownarrow	1	good	Effect: "Amorous", Effect Duration: 20
 8415	rotten pulsating suggestive strozzapreti	4	crappy	
 8416	Mountain Stream gastrique	0		
 8417	small adequate Mt. McLargeHuge oyster	2	good	
@@ -8311,7 +8311,7 @@
 8437	bouncing lard-coated fortified LavaCo Lamp&trade;	0		Damage Absorption: +60, Sleaze Spell Damage: +25, Last Available: "2015-08"
 8438	thin wire	0		Last Available: "2015-08"
 8439	purple insulated wire	0		Last Available: "2015-08"
-8440	green bouncing empty lava bottle	0		Last Available: "2015-08"
+8440	bouncing green empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	cyan viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
@@ -8332,7 +8332,7 @@
 8458	huge ghostly blinking greedy energetic high-temperature mining mask	0		Maximum MP Percent: +20, Meat Drop: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	padded fireproof megaphone of the boozehound	0		Damage Absorption: +20, Booze Drop: +100, Last Available: "2015-08"
 8460	normal mineapple	4	good	Last Available: "2015-08"
-8461	practically non-alcoholic smooth Gold Velvet&trade; whiskey	1	awesome	Last Available: "2015-08"
+8461	smooth practically non-alcoholic Gold Velvet&trade; whiskey	1	awesome	Last Available: "2015-08"
 8462	bouncing SMOOCH soda	1	good	Last Available: "2015-08"
 8463	spoiled smelted roe	4	crappy	Last Available: "2015-08"
 8464	weak drinkable lavawater	2	good	Last Available: "2015-08"
@@ -8346,7 +8346,7 @@
 8472	smelly heat-resistant necktie of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8473	Usain Bolt's inspector's extremely unsafe heat-resistant gloves	0		Weapon Damage Percent: +100, Item Drop: +15, Initiative: +80, Single Equip, Last Available: "2015-08"
 8474	stale very hot lunch	3	decent	Last Available: "2015-08"
-8475	watered-down hand-crafted asbestos thermos	2	super EPIC	Last Available: "2015-08"
+8475	hand-crafted watered-down asbestos thermos	2	super EPIC	Last Available: "2015-08"
 8476	warmed irradiated blue liquid rhinestones	0		Effect: "Sludgesick", Effect Duration: 11, Last Available: "2015-08"
 8477	enchanted rotten huge bouncing disco biscuit	3	crappy	Effect: "Unrunnable Face", Effect Duration: 20, Last Available: "2015-08"
 8478	perfectly mixed Quaatorade&trade;	3	EPIC	Last Available: "2015-08"
@@ -8354,7 +8354,7 @@
 8480	reassuring electrified feathered headdress of the sweet-tooth	0		Spooky Resistance: +1, Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	upside-down censurious chilly crafty electrician's hardhat	0		Maximum MP: +10, Cold Damage: +5, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
-8483	twirling tumbling Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
+8483	tumbling twirling Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	tumbling one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
@@ -8396,23 +8396,23 @@
 8522	fuchsia superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	lime green superheated	0		Last Available: "2015-08"
-8525	spoiled small lava cake	2	crappy	Last Available: "2015-08"
-8526	flavorless snack-sized skewed spinning pink slime	2	decent	
+8525	small spoiled lava cake	2	crappy	Last Available: "2015-08"
+8526	flavorless snack-sized spinning skewed pink slime	2	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	adequate devil hair pasta	3	good	
-8530	snack-sized yummy spagecialetti	2	awesome	
+8530	yummy snack-sized spagecialetti	2	awesome	
 8531	Salsa Libre	0		
 8532	mirror good gravy	0		
 8533	green illicit fish sauce	0		
-8534	diet normal huge libertagliatelle	1	good	
+8534	normal diet huge libertagliatelle	1	good	
 8535	tasty big teal turkish mostaccioli	5	awesome	
 8536	decent gigantic pulsating linguini of the sea	6	good	
 8537	dry Hersey&trade; SMOOCH	0		Effect: "Super Skill", Effect Duration: 11
 8539	spinning Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	rotten immense fuchsia Fettris	10	crappy	
+8542	immense rotten fuchsia Fettris	10	crappy	
 8543	tasty purple fusillocybin	4	awesome	
 8544	stale blurry skewed prescription noodles	4	decent	
 8545	twisted blinking blood-drive sticker	1	EPIC	
@@ -8420,10 +8420,10 @@
 8547	quadruple-aerosolized bouncing pocket maze	0		Effect: "Gr8ness", Effect Duration: 53
 8548	Vulcanized electrified ionized shady shades	0		Effect: "Vitamin-Maxed", Effect Duration: 25
 8549	galvanized vacuum-sealed twirling squeaky toy rose	0		Effect: "On Pins and Needles", Effect Duration: 28
-8550	toothsome snack-sized weird gazelle steak	2	awesome	
+8550	snack-sized toothsome weird gazelle steak	2	awesome	
 8551	small stale sausage without a cause	2	decent	
 8552	liquefied extra-polarized blue face paint	0		Effect: "Berry Critical", Effect Duration: 25
-8553	aged watered-down emergency margarita	2	awesome	
+8553	watered-down aged emergency margarita	2	awesome	
 8554	hand-crafted practically non-alcoholic vintage smart drink	1	super ultra mega turbo EPIC	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8432,7 +8432,7 @@
 8559	boiled aerosolized concentrated bakelite-covered bacon	0		Effect: "Winklered", Effect Duration: 66
 8560	ionized adjusted teal Aerheads	0		Effect: "Muscularrr", Effect Duration: 14
 8561	pressed improved Wrotz	0		Effect: "Smelly Pants", Effect Duration: 17
-8562	warmed yellow upside-down Gabarbar	0		Effect: "Ichorous Intensity", Effect Duration: 67
+8562	warmed upside-down yellow Gabarbar	0		Effect: "Ichorous Intensity", Effect Duration: 67
 8563	altered energized fiberglass insulation	0		Effect: "Flower Power", Effect Duration: 42
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	hale barrel lid of Gandalf of the blizzard	0		Maximum HP: +20, Spell Critical Percent: +20, Cold Spell Damage: +25, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
@@ -8448,12 +8448,12 @@
 8575	upside-down rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	blurry barnacled barrel	0		Last Available: "2015-09"
-8578	lousy practically non-alcoholic bottle of Amontillado	1	decent	Last Available: "2015-09"
+8578	practically non-alcoholic lousy bottle of Amontillado	1	decent	Last Available: "2015-09"
 8579	mediocre blinking barrel-aged martini	4	decent	Last Available: "2015-09"
 8580	rotten barrel pickle	4	crappy	Last Available: "2015-09"
 8581	massive moldy barrel cracker	10	crappy	Last Available: "2015-09"
 8582	compressed vibrating mushroom	1	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 25, Last Available: "2015-09"
-8583	boiled gray upside-down mushroom	1	decent	Effect: "Neutered Nostrils", Effect Duration: 10, Last Available: "2015-09"
+8583	boiled upside-down gray mushroom	1	decent	Effect: "Neutered Nostrils", Effect Duration: 10, Last Available: "2015-09"
 8584	rosewater-soaked KoL Con 12-gauge	0		Stench Resistance: +3, Last Available: "2015-09"
 8585	twirling Golden Mr. Eh? of incineration	0		Hot Spell Damage: +50, Last Available: "2015-09"
 8586	upside-down barrel gun of courage	0		Spooky Resistance: +3, Last Available: "2015-09"
@@ -8475,7 +8475,7 @@
 8602	warmed adjusted ghostly cuppa Yet tea	0		Effect: "Fustulent", Effect Duration: 66, Last Available: "2015-09"
 8603	energized cuppa Boo tea	0		Effect: "Winklered", Effect Duration: 27, Last Available: "2015-09"
 8604	aerosolized cuppa Nas tea	0		Effect: "Chalky Hand", Effect Duration: 41, Last Available: "2015-09"
-8605	Vulcanized bouncing spinning squat cuppa Improprie tea	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 29, Last Available: "2015-09"
+8605	Vulcanized squat bouncing spinning cuppa Improprie tea	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 29, Last Available: "2015-09"
 8606	tarnished super-polymerized cuppa Frost tea	0		Effect: "Jacked In", Effect Duration: 60, Last Available: "2015-09"
 8607	super-modified cold-filtered cuppa Toast tea	0		Effect: "Beta Carotene Overdose", Effect Duration: 15, Last Available: "2015-09"
 8608	non-pickled improved extra-diffused blurry cuppa Net tea	0		Effect: "Boon of She-Who-Was", Effect Duration: 17, Last Available: "2015-09"
@@ -8486,8 +8486,8 @@
 8613	galvanized cold-filtered purple cuppa Feroci tea	0		Effect: "Boo Tea", Effect Duration: 31, Last Available: "2015-09"
 8614	super-galvanized non-energized cuppa Physicali tea	0		Effect: "[800]Chocolate Reign", Effect Duration: 60, Last Available: "2015-09"
 8615	ionized cuppa Wit tea	0		Effect: "Hot Jellied", Effect Duration: 31, Last Available: "2015-09"
-8616	corrupted irradiated jittery narrow cuppa Neuroplastici tea	0		Effect: "Cold Jellied", Effect Duration: 19, Last Available: "2015-09"
-8617	quadruple-cold-filtered wobbly green narrow cuppa Dexteri tea	0		Effect: "Permanent Halloween", Effect Duration: 17, Last Available: "2015-09"
+8616	corrupted irradiated narrow jittery cuppa Neuroplastici tea	0		Effect: "Cold Jellied", Effect Duration: 19, Last Available: "2015-09"
+8617	quadruple-cold-filtered green narrow wobbly cuppa Dexteri tea	0		Effect: "Permanent Halloween", Effect Duration: 17, Last Available: "2015-09"
 8618	concentrated cuppa Flexibili tea	0		Effect: "Poker Faced", Effect Duration: 37, Last Available: "2015-09"
 8619	galvanized diffused blinking twirling cuppa Impregnabili tea	0		Effect: "Helvella Health", Effect Duration: 23, Last Available: "2015-09"
 8620	vacuum-sealed green cuppa Obscuri tea	0		Effect: "Sweet Taste", Effect Duration: 37, Last Available: "2015-09"
@@ -8501,10 +8501,10 @@
 8628	adjusted chilled maroon cuppa Mana tea	0		Effect: "Provocative Perkiness", Effect Duration: 18, Last Available: "2015-09"
 8629	pressed non-oxidized cuppa Monstrosi tea	0		Effect: "Egg on your Face", Effect Duration: 40, Last Available: "2015-09"
 8630	liquefied shaking cuppa Twen tea	0		Effect: "Ghostly Shell", Effect Duration: 32, Last Available: "2015-09"
-8631	quantum blinking lime green cuppa Gill tea	0		Effect: "Gr8ness", Effect Duration: 52, Last Available: "2015-09"
+8631	quantum lime green blinking cuppa Gill tea	0		Effect: "Gr8ness", Effect Duration: 52, Last Available: "2015-09"
 8632	energized unsweetened yellow cuppa Uncertain tea	0		Effect: "Gemini Rising", Effect Duration: 20, Last Available: "2015-09"
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
-8634	blinking wobbly cuppa Sobrie tea	0		Last Available: "2015-09"
+8634	wobbly blinking cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
 8636	anodized cuppa Craft tea	0		Effect: "The Power of Positive Thinking", Effect Duration: 51, Last Available: "2015-09"
 8637	cold-filtered shaking cuppa Insani tea	0		Effect: "Eagle Eyes", Effect Duration: 38, Last Available: "2015-09"
@@ -8512,9 +8512,9 @@
 8639	squat doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	enchanted stale bowl of eyeballs	3	decent	Effect: "Stuck-Up Hair", Effect Duration: 30, Last Available: "2015-10"
-8642	special adequate wobbly bowl of mummy guts	4	good	Effect: "Thunderspell", Effect Duration: 10, Last Available: "2015-10"
+8642	adequate special wobbly bowl of mummy guts	4	good	Effect: "Thunderspell", Effect Duration: 10, Last Available: "2015-10"
 8643	decent bowl of maggots	3	good	Last Available: "2015-10"
-8644	lousy fortified gray blood and blood	5	decent	Last Available: "2015-10"
+8644	fortified lousy gray blood and blood	5	decent	Last Available: "2015-10"
 8645	artisanal Jack-O-Lantern beer	3	EPIC	Last Available: "2015-10"
 8646	watered-down tolerable zombie	2	good	Last Available: "2015-10"
 8647	fuchsia Telltale&trade; rubber heart	0		Last Available: "2015-10"
@@ -8525,12 +8525,12 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	twirling Temple Grandin's Van der Graaf ruddy hawk	0		Maximum HP Percent: +40, Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7
-8655	flavorless huge fancy hamlet sandwich	10	decent	Effect: "Bone Chilling", Effect Duration: 40
+8655	huge flavorless fancy hamlet sandwich	10	decent	Effect: "Bone Chilling", Effect Duration: 40
 8656	chilly Othello's military jacket	0		Cold Damage: +5
 8657	educational Othello's dagger	0		Experience: +1, Single Equip
 8658	vibrating Othello's handkerchief	0		Maximum MP Percent: +10, Single Equip
 8659	super-cold-filtered bowl of Jeal-O	0		Effect: "Thick-Skinned", Effect Duration: 19
-8660	purple squat grip key	0		
+8660	squat purple grip key	0		
 8661	How to Play Othello	0		
 8662	coward's medical-grade ruddy ghostly dagger	0		Maximum HP Percent: +40, Monster Level: -20, HP Regen Min: 7, HP Regen Max: 10
 8663	aged ghost beer	3	awesome	
@@ -8540,7 +8540,7 @@
 8667	fireproof supercharged deadly Yorick	0		Weapon Damage: +5, Maximum MP Percent: +30, Hot Resistance: +3
 8668	rose	0		
 8669	cyan tulip	0		
-8670	shaking blue tulip	0		
+8670	blue shaking tulip	0		
 8671	pulsating tulip	0		
 8672	twirling Walford's bucket	0		Last Available: "2015-11"
 8673	tumbling Wal-Mart gift certificate	0		Last Available: "2015-11"
@@ -8548,7 +8548,7 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	wet pressed shoulder-warming lotion	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 13, Last Available: "2015-11"
 8677	massive stale iceberg lettuce	10	decent	Last Available: "2015-11"
-8678	spirit-forward acceptable ice wine	5	good	Last Available: "2015-11"
+8678	acceptable spirit-forward ice wine	5	good	Last Available: "2015-11"
 8679	flame-wreathed Jack Frost's steel-toed Wal-Mart snowglobe	0		Damage Reduction: 9, Cold Spell Damage: +50, Hot Spell Damage: +10, Last Available: "2015-11"
 8680	executive Sherlock's Wal-Mart nametag of the bloodbag	0		Maximum HP: +100, Item Drop: +25, Meat Drop: +40, Last Available: "2015-11"
 8681	purple double-paned Jeselnik's curative Wal-Mart overalls	0		Sleaze Damage: +25, Cold Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	narrow perfect ice cube	0		Last Available: "2015-11"
 8687	skewed The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	wobbly bellhop's hat of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	artisanal ice porter	3	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	artisanal ice porter	3	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	corrupted cold-filtered exotic travel brochure	0		Effect: "Thought", Effect Duration: 57, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	alkaline blinking shampoo-conditioner	0		Effect: "Tenacity of the Snapper", Effect Duration: 53, Last Available: "2015-11"
@@ -8576,21 +8576,21 @@
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
-8706	pulsating blinking machine elf capsule	0		Free Pull, Last Available: "2015-12"
+8706	blinking pulsating machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
-8708	diluted jittery mirror abstraction: action	1		Last Available: "2015-12"
-8709	dehydrated blue spinning abstraction: thought	1		Last Available: "2015-12"
+8708	diluted mirror jittery abstraction: action	1		Last Available: "2015-12"
+8709	dehydrated spinning blue abstraction: thought	1		Last Available: "2015-12"
 8710	pickled pulsating abstraction: sensation	1		Last Available: "2015-12"
 8711	boiled pulsating abstraction: purpose	1		Effect: "Spooky Blur", Effect Duration: 20, Last Available: "2015-12"
 8712	compressed abstraction: category	1		Last Available: "2015-12"
-8713	altered squat mirror abstraction: perception	1		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2015-12"
+8713	altered mirror squat abstraction: perception	1		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2015-12"
 8714	compressed huge blurry abstraction: motion	1		Last Available: "2015-12"
 8715	pickled cyan abstraction: joy	1		Last Available: "2015-12"
 8716	dehydrated narrow abstraction: certainty	1		Last Available: "2015-12"
 8717	compressed gray huge abstraction: comprehension	1		Last Available: "2015-12"
 8718	squat modern picture frame	0		Last Available: "2015-12"
 8719	decent VYKEA meatballs	4	good	Last Available: "2015-11"
-8720	acceptable practically non-alcoholic VYKEA mead	1	good	Last Available: "2015-11"
+8720	practically non-alcoholic acceptable VYKEA mead	1	good	Last Available: "2015-11"
 8721	extra-activated VYKEA woadpaint	0		Effect: "Stimulated Brain", Effect Duration: 25, Last Available: "2015-11"
 8722	jittery VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	spinning VYKEA blood rune	0		Last Available: "2015-11"
@@ -8598,16 +8598,16 @@
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
 8727	maroon VYKEA bracket	0		Last Available: "2015-11"
-8728	blinking blurry VYKEA dowel	0		Last Available: "2015-11"
+8728	blurry blinking VYKEA dowel	0		Last Available: "2015-11"
 8729	up-at-dawn mansplainer's Fonzie's VYKEA hex key	0		Experience (Moxie): +1, Monster Level: +15, Adventures: +5, Last Available: "2015-11"
 8730	spinning lime green VYKEA instructions	0		Last Available: "2015-11"
-8731	decent blue tin of submardines	4	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	decent blue tin of submardines	4	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	bad bottle of norwhiskey	3	decent	Last Available: "2015-11"
 8733	boiled octolus oculus	1	good	Last Available: "2015-11"
 8734	shaking sharpshooter's sardine can key of terror of bravery	0		Critical Hit Percent: +10, Spooky Spell Damage: +10, Spooky Resistance: +5, Last Available: "2015-11"
 8735	gravedigger's boxer's smooth norwhal helmet	0		Moxie: +15, Muscle Percent: +10, Spooky Damage: +10, Last Available: "2015-11", Familiar Effect: "atk"
 8736	chaotic Annie Oakley's octolus-skin cloak of Flo-Jo	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Initiative: +100, Last Available: "2015-11"
-8737	hand-crafted spirit-forward ghostly perfect cosmopolitan	5	EPIC	Last Available: "2015-11"
+8737	spirit-forward hand-crafted ghostly perfect cosmopolitan	5	EPIC	Last Available: "2015-11"
 8738	aged high-proof perfect negroni	9	awesome	Last Available: "2015-11"
 8739	artisanal watered-down perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
 8740	high-proof drinkable perfect mimosa	10	good	Last Available: "2015-11"
@@ -8617,21 +8617,21 @@
 8744	moist purple bouncing Wal-Mart &quot;diamond&quot; ring	0		Effect: "Lemony Goodness", Effect Duration: 34, Last Available: "2015-11"
 8745	double-vacuum-sealed Puffstone cigar	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 12, Last Available: "2015-11"
 8746	extra-dry moist skewed Conspiracy&trade; mascara	0		Effect: "Familial Ties", Effect Duration: 35, Last Available: "2015-11"
-8747	deionized spinning bouncing Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Spirit of Alph", Effect Duration: 38, Last Available: "2015-11"
+8747	deionized bouncing spinning Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Spirit of Alph", Effect Duration: 38, Last Available: "2015-11"
 8748	skewed airplane tattoo	0		Last Available: "2015-11"
 8749	tarnished Deep Machine Tunnels snowglobe	0		Effect: "Armor-Plated", Effect Duration: 30, Last Available: "2015-12"
 8750	corrupted polarized huge hemp candy necklace	0		Effect: "Dreadful Chill", Effect Duration: 31, Last Available: "2015-12"
 8751	pickled double-quantum vacuum-sealed communal gobstopper	0		Effect: "You Drank Fish Wine", Effect Duration: 16, Last Available: "2015-12"
-8752	gigantic special flavorless Crimbo salad	8	decent	Effect: "Yuletide Industry", Effect Duration: 15, Last Available: "2015-12"
-8753	special decent bread line	3	good	Effect: "Stench Jellied", Effect Duration: 15, Last Available: "2015-12"
-8754	watered-down tolerable bark rootbeer	2	good	Last Available: "2015-12"
+8752	special flavorless gigantic Crimbo salad	8	decent	Effect: "Yuletide Industry", Effect Duration: 15, Last Available: "2015-12"
+8753	decent special bread line	3	good	Effect: "Stench Jellied", Effect Duration: 15, Last Available: "2015-12"
+8754	tolerable watered-down bark rootbeer	2	good	Last Available: "2015-12"
 8755	tolerable ale	3	good	Last Available: "2015-12"
 8756	spinning plastic Tammy the Tambourine Elf of the brazier	0		Hot Spell Damage: +25, Last Available: "2015-12"
 8757	pulsating nasty plastic Rudolph the Red	0		Stench Damage: +5, Last Available: "2015-12"
 8758	twirling hardy plastic Gaia'ajh-dsli Ak'lwej	0		Maximum HP: +50, Last Available: "2015-12"
 8759	flame-wreathed plastic Crimborgatron	0		Hot Spell Damage: +10, Last Available: "2015-12"
 8760	wicked plastic Crimbodhisattva	0		Spell Damage: +5, Last Available: "2015-12"
-8761	jittery narrow bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
+8761	narrow jittery bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
 8763	mirror BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
@@ -8654,7 +8654,7 @@
 8782	gravedigger's reindeer hammer	0		Spooky Damage: +10, Last Available: "2015-12"
 8783	inspector's elf ploughshare	0		Item Drop: +15, Last Available: "2015-12"
 8784	blurry circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	blurry faded protest sign	0		Last Available: "2015-12"
 8787	jittery faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8685,25 +8685,25 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	narrow bat-bearing	0		Last Available: "2017-01"
-8816	enchanted snack-sized stale gray Kudzu salad	2	decent	Effect: "Bilious Briskness", Effect Duration: 50, Last Available: "2016-12"
+8816	snack-sized enchanted stale gray Kudzu salad	2	decent	Effect: "Bilious Briskness", Effect Duration: 50, Last Available: "2016-12"
 8817	diluted huge Mansquito Serum	1		Last Available: "2016-12"
 8818	practically non-alcoholic smooth huge Miss Graves' vermouth	1	awesome	Last Available: "2016-12"
-8819	normal diet The Plumber's mushroom stew	1	good	Last Available: "2016-12"
+8819	diet normal The Plumber's mushroom stew	1	good	Last Available: "2016-12"
 8820	modified jittery The Author's ink	1		Effect: "Punchy, Murdery", Effect Duration: 5, Last Available: "2016-02"
 8821	delicious The Mad Liquor	3	awesome	Last Available: "2016-12"
 8822	drinkable Doc Clock's thyme cocktail	3	good	Last Available: "2016-12"
 8823	spoiled small Mr. Burnsger	2	crappy	Last Available: "2016-12"
 8824	pickled The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	huge wicked The Jokester's gun of horror of the glutton	0		Spell Damage: +5, Spooky Spell Damage: +25, Food Drop: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	savvy smooth The Jokester's wig of the wise owl	0		Mysticality: +20, Moxie: +15, Mysticality Percent: +20, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	Jeselnik's frosty quilted The Jokester's pants	0		Damage Absorption: +40, Cold Spell Damage: +10, Sleaze Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	huge wicked The Jokester's gun of horror of the glutton	0		Spell Damage: +5, Spooky Spell Damage: +25, Food Drop: +100, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	savvy smooth The Jokester's wig of the wise owl	0		Mysticality: +20, Moxie: +15, Mysticality Percent: +20, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	Jeselnik's frosty quilted The Jokester's pants	0		Damage Absorption: +40, Cold Spell Damage: +10, Sleaze Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	oxidized frozen Jokester makeup	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 33, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	deionized boiled robin's egg	0		Effect: "Pie in the Sky", Effect Duration: 22, Last Available: "2016-12"
-8834	bland small robin flan	2	decent	Last Available: "2016-12"
+8834	small bland robin flan	2	decent	Last Available: "2016-12"
 8835	weak lousy blurry robin nog	2	decent	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
@@ -8714,12 +8714,12 @@
 8842	triple-moist infrablack lipstick	0		Effect: "Salsa Satanica", Effect Duration: 17
 8843	flattened polymerized altered can of drain cleaner	0		Effect: "Sweet and Red", Effect Duration: 67
 8844	pickled The Author's inkwell	0		Effect: "Feeling No Pain", Effect Duration: 29
-8845	alkaline pressed spinning twirling bag of random words	0		Effect: "Vanity Rage", Effect Duration: 42
+8845	alkaline pressed twirling spinning bag of random words	0		Effect: "Vanity Rage", Effect Duration: 42
 8846	aerosolized shaking tube of pendulum lube	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 21
 8847	pickled ionized blinking red-hot jawbreaker	0		Effect: "Mushroom Melody", Effect Duration: 37
-8848	improved aerosolized colloidal huge shaking question juice	0		Effect: "Booing Radly", Effect Duration: 11
+8848	improved aerosolized colloidal shaking huge question juice	0		Effect: "Booing Radly", Effect Duration: 11
 8849	quadruple-cold-filtered tube of villain	0		Effect: "Outer Wolf&trade;", Effect Duration: 68
-8850	hardened your cowboy boots	0		Damage Reduction: 3, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	hardened your cowboy boots	0		Damage Reduction: 3, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	narrow inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8748,7 +8748,7 @@
 8876	toothsome plate of Heimz Fortified Kidney Beans	3	awesome	Last Available: "2016-02"
 8877	flavorless plate of Tesla's Electroplated Beans	3	decent	Last Available: "2016-02"
 8878	spoiled small plate of Mixed Garbanzos and Chickpeas	2	crappy	Last Available: "2016-02"
-8879	snack-sized bland plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
+8879	bland snack-sized plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
 8880	adequate tiny gray plate of Frigid Northern Beans	1	good	Last Available: "2016-02"
 8881	huge adequate plate of World's Blackest-Eyed Peas	6	good	Last Available: "2016-02"
 8882	enchanted half-sized normal plate of Trader Olaf's Exotic Stinkbeans	2	good	Effect: "Balls of Ectoplasm", Effect Duration: 45, Last Available: "2016-02"
@@ -8757,7 +8757,7 @@
 8885	small rotten plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	dance instructor's slick Fancy Jeff's pocket square	0		Moxie: +10, Experience Percent (Moxie): +10, Last Available: "2016-02"
 8887	shaking up-at-dawn chilly Van der Graaf Daisy's unclean bloomers	0		Cold Damage: +5, Adventures: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
-8888	purple twirling Pecos Dave's sixgun	0		Last Available: "2016-02"
+8888	twirling purple Pecos Dave's sixgun	0		Last Available: "2016-02"
 8889	zippy ruddy Amoon-Ra Cowtep's nemes of the brute	0		Muscle Percent: +30, Maximum HP Percent: +40, Initiative: +20, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	sizzling personal trainer's Fonzie's brainy Former Sheriff Dan's tin star of the scaredy-cat	0		Mysticality: +5, Experience (Moxie): +1, Experience Percent (Muscle): +10, Monster Level: -15, Hot Damage: +10, Last Available: "2016-02"
@@ -8772,7 +8772,7 @@
 8900	gun parts	0		Last Available: "2016-02"
 8901	pressed triggerfingerbone	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 24, Last Available: "2016-02"
 8902	double-polarized huge ghost bit	0		Effect: "Jawin'", Effect Duration: 47, Last Available: "2016-02"
-8903	polarized pulsating cyan buzzard feather	0		Effect: "Oriental Mysticism", Effect Duration: 26, Last Available: "2016-02"
+8903	polarized cyan pulsating buzzard feather	0		Effect: "Oriental Mysticism", Effect Duration: 26, Last Available: "2016-02"
 8904	concentrated narrow lion musk	0		Effect: "Chalky White Pallor", Effect Duration: 18, Last Available: "2016-02"
 8905	delicious blinking blue bear claw	3	awesome	Last Available: "2016-02"
 8906	deionized extra-alkaline rattler gland	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 55, Last Available: "2016-02"
@@ -8848,7 +8848,7 @@
 8976	tarnished ionized patent preventative tonic	0		Effect: "Booze Goozles", Effect Duration: 65
 8977	irradiated shaking patent invisibility tonic	0		Effect: "Nasty, Nasty Breath", Effect Duration: 16
 8978	dry double-frozen double-frozen patent aggression tonic	0		Effect: "Mushroom Might", Effect Duration: 21
-8979	oxidized fuchsia blinking patent sallowness tonic	0		Effect: "Greedy Resolve", Effect Duration: 50
+8979	oxidized blinking fuchsia patent sallowness tonic	0		Effect: "Greedy Resolve", Effect Duration: 50
 8980	warmed patent avarice tonic	0		Effect: "Loyal Tea", Effect Duration: 61
 8981	improved twirling patent alacrity tonic	0		Effect: "Bone Chilling", Effect Duration: 15
 8982	galvanized tarnished green ghostly corrupted marrow	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 67
@@ -8877,7 +8877,7 @@
 9005	maroon upside-down scorching careful sage fish hatchet of the empath	0		Mysticality Percent: +10, Monster Level: -10, Familiar Weight: +5, Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9006	gray Jeselnik's tunac of the empath of the boozehound of the glutton	0		Familiar Weight: +5, Sleaze Damage: +25, Booze Drop: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
-9008	unsweetened blinking olive wriggling worm	0		Effect: "stats.enq", Effect Duration: 64, Last Available: "2016-04"
+9008	unsweetened olive blinking wriggling worm	0		Effect: "stats.enq", Effect Duration: 64, Last Available: "2016-04"
 9009	tolerable practically non-alcoholic shaking bottle of Fishhead 900-Day IPA	1	good	Last Available: "2016-04"
 9010	galvanized spinning high-test fishing line	0		Effect: "Ginger Snapped", Effect Duration: 49, Last Available: "2016-04"
 9011	tumbling fishin' hat of the storm	0		Maximum MP Percent: +40, Last Available: "2016-04"
@@ -8899,20 +8899,20 @@
 9027	twirling gravedigger's Tesla studded First Post shirt - Cir Senam	0		Damage Absorption: +80, Spooky Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-05"
 9028	blinking high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	half-sized decent star salad	2	good	
+9030	decent half-sized star salad	2	good	
 9031	Thwaitgold moth statuette	0		
-9032	diet moldy bowl of Tastee-Wheet&trade;	1	crappy	
+9032	moldy diet bowl of Tastee-Wheet&trade;	1	crappy	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	decent teal browser cookie	4	good	Last Available: "2016-06"
-9036	artisanal triple-distilled hacked gibson	10	EPIC	Last Available: "2016-06"
+9036	triple-distilled artisanal hacked gibson	10	EPIC	Last Available: "2016-06"
 9037	lard-coated Source shades	0		Sleaze Spell Damage: +25, Last Available: "2016-06"
-9038	yellow blurry software bug	0		Last Available: "2016-06"
+9038	blurry yellow software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
-9040	jittery spinning Source terminal PRAM chip	0		Last Available: "2016-06"
+9040	spinning jittery Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	twirling blinking narrow Source terminal SPAM chip	0		Last Available: "2016-06"
-9043	huge tumbling Source terminal CRAM chip	0		Last Available: "2016-06"
+9043	tumbling huge Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	Source terminal INGRAM chip	0		Last Available: "2016-06"
@@ -8926,7 +8926,7 @@
 9054	Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	teal Source terminal file: compress.edu	0		Last Available: "2016-06"
-9057	blurry fuchsia Source terminal file: duplicate.edu	0		Last Available: "2016-06"
+9057	fuchsia blurry Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	green Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	shaking Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	huge Source terminal file: familiar.ext	0		Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	nitrogenated denatured red shoe gum	0		Effect: "Inappropriate Spirit", Effect Duration: 66, Last Available: "2016-07"
 9076	blue flame-retardant ribald crafty noir fedora	0		Maximum MP: +10, Sleaze Damage: +10, Hot Resistance: +1, Last Available: "2016-07"
 9077	squat narrow pulsating scorching trench coat of the ox of the blizzard	0		Muscle: +20, Cold Spell Damage: +25, Hot Damage: +25, Last Available: "2016-07"
-9078	weak mediocre special cyan Falcon&trade; Maltese Liquor	2	decent	Effect: "Biologically Shocked", Effect Duration: 15, Last Available: "2016-07"
-9079	miniature enchanted delicious narrow hardboiled egg	2	awesome	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 15, Last Available: "2016-07"
+9078	mediocre special weak cyan Falcon&trade; Maltese Liquor	2	decent	Effect: "Biologically Shocked", Effect Duration: 15, Last Available: "2016-07"
+9079	enchanted miniature delicious narrow hardboiled egg	2	awesome	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 15, Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	Jeselnik's toasty frosty stylish protonic accelerator pack of the ox of the empath	0		Muscle: +20, Moxie: +25, Familiar Weight: +5, Cold Spell Damage: +10, Hot Damage: +5, Sleaze Damage: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	Jeselnik's toasty frosty stylish protonic accelerator pack of the ox of the empath	0		Muscle: +20, Moxie: +25, Familiar Weight: +5, Cold Spell Damage: +10, Hot Damage: +5, Sleaze Damage: +25, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	Socratic Adventurer bobblehead	0		Experience (Mysticality): +1, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	squat shaking greasy extremely unsafe smooth Spookyraven signet	0		Moxie: +15, Weapon Damage Percent: +100, Sleaze Spell Damage: +10, Single Equip, Last Available: "2016-08"
 9093	stanky tie-dyed fannypack of the bloodbag	0		Maximum HP: +100, Stench Spell Damage: +25, Single Equip, Last Available: "2016-08"
 9094	spinning auspicious coward's burnt snowpants	0		Monster Level: -20, Item Drop: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	gray dog trainer's standards and practices guide	0		Experience (familiar): +1, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	gray dog trainer's standards and practices guide	0		Experience (familiar): +1, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	coward's wholesome Newton's Carpathian longsword	0		Experience (Mysticality): +3, Maximum HP Percent: +10, Monster Level: -20, Last Available: "2016-08"
 9097	up-at-dawn auspicious Liam's mail of terror	0		Spooky Spell Damage: +10, Item Drop: +10, Adventures: +5, Last Available: "2016-08"
 9098	zippy Fonzie's Unfortunato's foolscap of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Initiative: +20, Last Available: "2016-08"
@@ -8981,29 +8981,29 @@
 9109	unsweetened Shrieking Weasel holo-record	0		Effect: "Innately Wise", Effect Duration: 32
 9110	chilled frozen Power-Guy 2000 holo-record	0		Effect: "Fortunate Resolve", Effect Duration: 42
 9111	activated narrow Lucky Strikes holo-record	0		Effect: "Slimily Sagacious", Effect Duration: 69
-9112	pickled blinking wobbly EMD holo-record	0		Effect: "Cold as Ice", Effect Duration: 32
+9112	pickled wobbly blinking EMD holo-record	0		Effect: "Cold as Ice", Effect Duration: 32
 9113	alkaline quadruple-magnetized ghostly Superdrifter holo-record	0		Effect: "Brocolate Brostidigitation", Effect Duration: 50
 9114	adjusted flattened The Pigs holo-record	0		Effect: "Oiled Skin", Effect Duration: 24
 9115	improved Drunk Uncles holo-record	0		Effect: "Inner Warmth", Effect Duration: 13
 9116	time residue	0		Last Available: "2016-09"
 9117	careful repaid diaper	0		Monster Level: -10
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	hand-crafted special Shot of Kardashian Gin	3	EPIC	Effect: "Ruthlessly Efficient", Effect Duration: 15, Last Available: "2016-09"
+9119	special hand-crafted Shot of Kardashian Gin	3	EPIC	Effect: "Ruthlessly Efficient", Effect Duration: 15, Last Available: "2016-09"
 9120	smelly Unstable Pointy Ears	0		Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	yellow Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	bouncing baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	watered-down artisanal blue blinking unidentified drink	2	EPIC	
+9126	artisanal watered-down blue blinking unidentified drink	2	EPIC	
 9127	KoL Con 13 T-shirt of vim and vigor of the early riser	0		Maximum HP Percent: +50, Adventures: +7
 9128	Usain Bolt's supercharged experienced discarded swimming trunks	0		Experience: +2, Maximum MP Percent: +30, Initiative: +80
-9129	energized spinning tumbling diluted makeup	0		Effect: "Elemental Mastery", Effect Duration: 16
+9129	energized tumbling spinning diluted makeup	0		Effect: "Elemental Mastery", Effect Duration: 16
 9130	adjusted charisma potion	0		Effect: "Bastard!", Effect Duration: 44
 9131	jittery extremely confusing manual	0		
 9132	wobbly medical-grade pistol of bravery	0		Spooky Resistance: +5, HP Regen Min: 7, HP Regen Max: 10
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	adequate gigantic leftover pasty	10	good	
+9134	gigantic adequate leftover pasty	10	good	
 9135	bad blurry green very whiskey	4	decent	
 9136	skewed li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	jittery bouncing li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9019,11 +9019,11 @@
 9147	enhanced Prunets	0		Effect: "Leash of Linguini", Effect Duration: 60
 9148	Twitching Television Tattoo	0		
 9149	upside-down baby scorpion	0		Familiar Weight: +10
-9150	energized mirror tumbling lime green invisible string	0		Lasts Until Rollover, Effect: "Rad-ish", Effect Duration: 46, Last Available: "2016-10"
+9150	energized tumbling mirror lime green invisible string	0		Lasts Until Rollover, Effect: "Rad-ish", Effect Duration: 46, Last Available: "2016-10"
 9151	polymerized tarnished invisible seam ripper	0		Lasts Until Rollover, Effect: "Chow Downed", Effect Duration: 32, Last Available: "2016-10"
 9152	ghostly li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	rotten raw sweet potato	3	crappy	Last Available: "2016-11"
-9154	enchanted normal jumbo raw beans	5	good	Effect: "The Magic of Sharing", Effect Duration: 40, Last Available: "2016-11"
+9154	enchanted jumbo normal raw beans	5	good	Effect: "The Magic of Sharing", Effect Duration: 40, Last Available: "2016-11"
 9155	bland pulsating raw stuffing	3	decent	Last Available: "2016-11"
 9156	miniature adequate raw cranberry sauce	2	good	Last Available: "2016-11"
 9157	rotten raw turkey	3	crappy	Last Available: "2016-11"
@@ -9043,10 +9043,10 @@
 9171	bland sweet potatoes	3	decent	Last Available: "2016-11"
 9172	big bland twirling bean casserole	5	decent	Last Available: "2016-11"
 9173	spoiled skewed baked stuffing	4	crappy	Last Available: "2016-11"
-9174	immense normal twirling cranberry cylinder	6	good	Last Available: "2016-11"
+9174	normal immense twirling cranberry cylinder	6	good	Last Available: "2016-11"
 9175	adequate thanksgiving turkey	3	good	Last Available: "2016-11"
 9176	flavorless mince pie	4	decent	Last Available: "2016-11"
-9177	miniature delicious blue mashed potatoes	2	awesome	Last Available: "2016-11"
+9177	delicious miniature blue mashed potatoes	2	awesome	Last Available: "2016-11"
 9178	stale warm gravy	4	decent	Last Available: "2016-11"
 9179	massive rotten bread roll	8	crappy	Last Available: "2016-11"
 9180	half-sized spoiled leftovers	2	crappy	Last Available: "2016-11"
@@ -9064,7 +9064,7 @@
 9192	acceptable fortified eldritch extract	5	good	Last Available: "2016-11"
 9193	upside-down Jim Carey's beefcake's Official Council Aide Pin	0		Muscle: +25, Monster Level: +25, Last Available: "2016-11"
 9194	perfectly mixed eldritch distillate	3	EPIC	Last Available: "2016-11"
-9195	vaporized tumbling spinning eldritch essence	1		Last Available: "2016-11"
+9195	vaporized spinning tumbling eldritch essence	1		Last Available: "2016-11"
 9196	asbestos-lined Science Notebook	0		Hot Resistance: +5
 9197	baleful eldritch hat of incineration of the sewer	0		Spell Damage: +25, Hot Spell Damage: +50, Stench Damage: +25, Last Available: "2016-11"
 9198	twirling aromatic veiny eldritch pants of Tarzan	0		Experience (Muscle): +3, Maximum HP: +10, Stench Resistance: +1, Last Available: "2016-11"
@@ -9087,8 +9087,8 @@
 9215	broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
-9218	ghostly teal sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	fancy delicious jumbo animal part cracker	5	awesome	Effect: "Muscularrr", Effect Duration: 50, Last Available: "2016-12"
+9218	teal ghostly sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
+9219	fancy jumbo delicious animal part cracker	5	awesome	Effect: "Muscularrr", Effect Duration: 50, Last Available: "2016-12"
 9220	mediocre twirling gingerbread wine	3	decent	Last Available: "2016-12"
 9221	flavorless low-calorie gingerbread mug	1	decent	Last Available: "2016-12"
 9222	experienced gingerbread mask	0		Experience: +2, Last Available: "2016-12"
@@ -9106,13 +9106,13 @@
 9234	narrow wholesome pumpkin spice candle	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2016-12"
 9235	electrified colloidal gingerbread spice latte	0		Effect: "Demonic Flavor", Effect Duration: 21, Last Available: "2016-12"
 9236	blue nasty stylish gingerbread gavel	0		Moxie: +25, Stench Damage: +5, Last Available: "2016-12"
-9237	blinking narrow gingerbread cigarette	0		Last Available: "2016-12"
+9237	narrow blinking gingerbread cigarette	0		Last Available: "2016-12"
 9238	shaking gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	lousy ginger beer	4	decent	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	electrified concentrated industrial frosting	0		Effect: "Stuck That Way", Effect Duration: 49, Last Available: "2016-12"
 9242	wet upside-down fake cocktail	0		Effect: "Square to be Hip", Effect Duration: 31, Last Available: "2016-12"
-9243	hand-crafted weak high-end ginger wine	2	EPIC	Last Available: "2016-12"
+9243	weak hand-crafted high-end ginger wine	2	EPIC	Last Available: "2016-12"
 9244	red razor-sharp plastic bad vibe	0		Weapon Damage Percent: +25, Last Available: "2016-12"
 9245	shaking plastic angry vikings of the sewer	0		Stench Damage: +25, Last Available: "2016-12"
 9246	censurious plastic Knows About Chakras	0		Sleaze Resistance: +3, Last Available: "2016-12"
@@ -9123,18 +9123,18 @@
 9251	galvanized pressed extra-galvanized Inner Truth	0		Effect: "Jelly Combed", Effect Duration: 69, Last Available: "2016-12"
 9252	moldy spiritual candy cane	4	crappy	Last Available: "2016-12"
 9253	special delicious irresponsibly strong spiritual eggnog	9	awesome	Effect: "Frog In Your Throat", Effect Duration: 30, Last Available: "2016-12"
-9254	bite-sized flavorless spiritual fruitcake	1	decent	Last Available: "2016-12"
+9254	flavorless bite-sized spiritual fruitcake	1	decent	Last Available: "2016-12"
 9255	spoiled spiritual gingerbread	4	crappy	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
-9259	ghostly maroon Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
+9259	maroon ghostly Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	upside-down No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	spinning pulsating Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	jittery fruit-leather negatives	0		Last Available: "2016-12"
 9263	blinking maroon gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
-9265	purple blinking tumbling teethpick	0		Last Available: "2016-12"
+9265	blinking purple tumbling teethpick	0		Last Available: "2016-12"
 9266	ionized modified huge jittery spinning rock candy	0		Effect: "From Nantucket", Effect Duration: 17, Last Available: "2016-12"
 9267	flavorless green-iced sweet roll	3	decent	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
@@ -9159,17 +9159,17 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	jittery upside-down gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	skewed double-paned coward's padded Uncle Crimbo's hat	0		Damage Absorption: +20, Monster Level: -20, Cold Resistance: +5, Last Available: "2016-12"
-9290	moldy enchanted small spinning Eldritch snap	2	crappy	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2017-01"
+9290	enchanted moldy small spinning Eldritch snap	2	crappy	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2017-01"
 9291	dehydrated hot jelly	1		Last Available: "2017-01"
 9292	diluted jelly	1		Effect: "Cuts Like a Buttered Knife", Effect Duration: 45, Last Available: "2017-01"
 9293	boiled pulsating jelly	1		Effect: "Texas Elegance", Effect Duration: 5, Last Available: "2017-01"
 9294	twisted twirling sleaze jelly	1		Last Available: "2017-01"
 9295	pickled blue stench jelly	1		Last Available: "2017-01"
 9296	squat space planula	0		Free Pull, Last Available: "2017-01"
-9297	delicious big toast with hot jelly	5	awesome	Last Available: "2017-01"
+9297	big delicious toast with hot jelly	5	awesome	Last Available: "2017-01"
 9298	normal maroon toast with jelly	3	good	Last Available: "2017-01"
 9299	normal toast with jelly	3	good	Last Available: "2017-01"
-9300	bite-sized rotten shaking toast with sleaze jelly	1	crappy	Last Available: "2017-01"
+9300	rotten bite-sized shaking toast with sleaze jelly	1	crappy	Last Available: "2017-01"
 9301	rotten toast with stench jelly	4	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	lime green hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9232,13 +9232,13 @@
 9360	fish head	0		Last Available: "2017-03"
 9361	ghostly limepatch	0		Last Available: "2017-03"
 9362	wobbly pile of dirt	0		Last Available: "2017-03"
-9363	olive pulsating slime shooter	0		Last Available: "2017-03"
+9363	pulsating olive slime shooter	0		Last Available: "2017-03"
 9364	shaking imaginary lemon	0		Last Available: "2017-03"
 9365	lousy extra-dry literal grasshopper	5	decent	Last Available: "2017-03"
-9366	artisanal practically non-alcoholic cyan double entendre	1	EPIC	Last Available: "2017-03"
+9366	practically non-alcoholic artisanal cyan double entendre	1	EPIC	Last Available: "2017-03"
 9367	hand-crafted Phlegethon	3	EPIC	Last Available: "2017-03"
 9368	acceptable practically non-alcoholic Siberian sunrise	1	good	Last Available: "2017-03"
-9369	tolerable watered-down mentholated wine	2	good	Last Available: "2017-03"
+9369	watered-down tolerable mentholated wine	2	good	Last Available: "2017-03"
 9370	hand-crafted skewed low tide martini	4	EPIC	Last Available: "2017-03"
 9371	tolerable enchanted shroomtini	3	good	Effect: "Human-Humanoid Hybrid", Effect Duration: 25, Last Available: "2017-03"
 9372	drinkable morning dew	4	good	Last Available: "2017-03"
@@ -9246,16 +9246,16 @@
 9374	artisanal great fashioned	3	EPIC	Last Available: "2017-03"
 9375	bad Gnomish sagngria	4	decent	Last Available: "2017-03"
 9376	acceptable vodka stinger	3	good	Last Available: "2017-03"
-9377	acceptable wobbly ghostly extremely slippery nipple	3	good	Last Available: "2017-03"
+9377	acceptable ghostly wobbly extremely slippery nipple	3	good	Last Available: "2017-03"
 9378	hand-crafted pulsating piscatini	4	EPIC	Last Available: "2017-03"
 9379	lousy Churchill	4	decent	Last Available: "2017-03"
 9380	tolerable soilzerac	3	good	Last Available: "2017-03"
 9381	triple-distilled enchanted mediocre London frog	10	decent	Effect: "Rampage!", Effect Duration: 45, Last Available: "2017-03"
 9382	hand-crafted nothingtini	3	EPIC	Last Available: "2017-03"
 9383	delicious eighth plague	3	awesome	Last Available: "2017-03"
-9384	weak drinkable fancy single entendre	2	good	Effect: "Boschface", Effect Duration: 45, Last Available: "2017-03"
+9384	drinkable weak fancy single entendre	2	good	Effect: "Boschface", Effect Duration: 45, Last Available: "2017-03"
 9385	lousy ghostly reverse Tantalus	4	decent	Last Available: "2017-03"
-9386	extra-dry lousy elemental caipiroska	5	decent	Last Available: "2017-03"
+9386	lousy extra-dry elemental caipiroska	5	decent	Last Available: "2017-03"
 9387	perfectly mixed lime green Feliz Navidad	4	EPIC	Last Available: "2017-03"
 9388	watered-down smooth Bloody Nora	2	awesome	Last Available: "2017-03"
 9389	aged moreltini	3	awesome	Last Available: "2017-03"
@@ -9265,11 +9265,11 @@
 9393	hand-crafted Gnollish sangria	3	EPIC	Last Available: "2017-03"
 9394	bad vodka barracuda	4	decent	Last Available: "2017-03"
 9395	bad ghostly Mysterious Island iced tea	3	decent	Last Available: "2017-03"
-9396	triple-distilled drinkable drive-by shooting	9	good	Last Available: "2017-03"
-9397	mediocre boozy upside-down gunner's daughter	5	decent	Last Available: "2017-03"
-9398	mediocre weak special dirt julep	2	decent	Effect: "Amplified Fabulousness", Effect Duration: 10, Last Available: "2017-03"
+9396	drinkable triple-distilled drive-by shooting	9	good	Last Available: "2017-03"
+9397	boozy mediocre upside-down gunner's daughter	5	decent	Last Available: "2017-03"
+9398	special mediocre weak dirt julep	2	decent	Effect: "Amplified Fabulousness", Effect Duration: 10, Last Available: "2017-03"
 9399	tolerable Simepore slime	3	good	Last Available: "2017-03"
-9400	bad upside-down skewed Phil Collins	3	decent	Last Available: "2017-03"
+9400	bad skewed upside-down Phil Collins	3	decent	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	wobbly toggle switch (Bartend)	0		Familiar Weight: +5
 9403	blurry toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	half-sized moldy gray mirror edible alien plant bit	2	crappy	Last Available: "2017-04"
+9415	moldy half-sized gray mirror edible alien plant bit	2	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	tumbling alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	up-at-dawn executive medical-grade murderbot mask	0		Meat Drop: +40, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Avatar: "Murderbot", Last Available: "2017-04"
 9454	super-unsweetened moist cold-filtered tumbling murderbot spring injector	0		Effect: "Pride of the Vampire", Effect Duration: 61, Last Available: "2017-04"
 9455	personal trainer's supercool murderbot whip	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Last Available: "2017-04"
-9456	curative murderbot plasma rifle of Leguizamo	0		Monster Level: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	curative murderbot plasma rifle of Leguizamo	0		Monster Level: +20, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	spinning Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9336,12 +9336,12 @@
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	fuchsia Spacegate	0		Last Available: "2017-04"
 9466	flavorless small Aldebaran sardines	2	decent	Last Available: "2017-04"
-9467	artisanal practically non-alcoholic jittery Centauri fish wine	1	super ultra mega EPIC	Last Available: "2017-04"
+9467	practically non-alcoholic artisanal jittery Centauri fish wine	1	super ultra mega EPIC	Last Available: "2017-04"
 9468	powdered oxygen	1		Last Available: "2017-04"
 9469	maroon careful savvy Spacegate scientist's insignia	0		Mysticality Percent: +20, Monster Level: -10, Single Equip, Last Available: "2017-04"
 9470	double-paned scorching Spacegate military insignia	0		Hot Damage: +25, Cold Resistance: +5, Single Equip, Last Available: "2017-04"
 9471	narrow bouncing frosty deadly Socratic Spacegate diplomat's insignia	0		Experience (Mysticality): +1, Weapon Damage: +5, Cold Spell Damage: +10, Single Equip, Last Available: "2017-04"
-9472	skewed mirror Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
+9472	mirror skewed Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	spoiled alien sandwich	3	crappy	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
@@ -9362,7 +9362,7 @@
 9490	denatured Threatening Missive	0		Effect: "Top Dog", Effect Duration: 32
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	banded Kremlin's Greatest Briefcase of the cougar of doom	0		Moxie: +20, Damage Absorption: +100, Spooky Spell Damage: +50, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	banded Kremlin's Greatest Briefcase of the cougar of doom	0		Moxie: +20, Damage Absorption: +100, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	irresponsibly strong acceptable shaking basic martini	10	good	Last Available: "2017-06"
 9495	perfectly mixed cyan improved martini	3	EPIC	Last Available: "2017-06"
 9496	tolerable tumbling splendid martini	3	good	Last Available: "2017-06"
@@ -9413,16 +9413,16 @@
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
-9544	mirror twirling O	0		Last Available: "2017-10"
-9545	bad fancy DUFRESNE Suds	3	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2017-09"
+9544	twirling mirror O	0		Last Available: "2017-10"
+9545	fancy bad DUFRESNE Suds	3	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2017-09"
 9546	squat Jim Carey's Lo Pan's mafia pinky ring	0		Spell Critical Percent: +30, Monster Level: +25, Single Equip
-9547	tolerable practically non-alcoholic flask of port	1	good	
+9547	practically non-alcoholic tolerable flask of port	1	good	
 9548	cyan MacGyver's contract enforcement stick of temperance	0		Maximum MP: +100, Sleaze Resistance: +5
 9549	spoiled diet Hide-rox&trade; cookie	1	crappy	Last Available: "2017-10"
 9550	mediocre practically non-alcoholic jug of booze	1	decent	Last Available: "2017-10"
 9551	enhanced blurry pair of candy glasses	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 53, Last Available: "2017-10"
 9552	galvanized irradiated narrow temporary X tattoos	0		Effect: "On the Trolley", Effect Duration: 66, Last Available: "2017-10"
-9553	distilled skewed green glyph of athleticism	1		Last Available: "2017-10"
+9553	distilled green skewed glyph of athleticism	1		Last Available: "2017-10"
 9554	upside-down pair of scissors	0		Last Available: "2017-10"
 9555	wet nitrogenated new habit	0		Effect: "Oh Snap", Effect Duration: 56, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
@@ -9449,9 +9449,9 @@
 9577	mafia filofax	0		
 9578	blurry transparent nog	1	good	Last Available: "2017-12"
 9579	snack-sized decent spinning unfinished fruitcake	2	good	Last Available: "2017-12"
-9580	improved diffused cyan blinking twirling and cracker	0		Effect: "New and Improved", Effect Duration: 47, Last Available: "2017-12"
-9581	smooth weak olive neg grog	2	awesome	Last Available: "2017-12"
-9582	half-sized rotten upside-down jittery half double fruitcake	2	crappy	Last Available: "2017-12"
+9580	improved diffused cyan twirling blinking and cracker	0		Effect: "New and Improved", Effect Duration: 47, Last Available: "2017-12"
+9581	weak smooth olive neg grog	2	awesome	Last Available: "2017-12"
+9582	half-sized rotten jittery upside-down half double fruitcake	2	crappy	Last Available: "2017-12"
 9583	flavorless fuchsia hushed puppy	3	decent	Last Available: "2017-12"
 9584	jumbo tasty muffled muffuletta	5	awesome	Last Available: "2017-12"
 9585	rotten purple shushed potatoes	3	crappy	Last Available: "2017-12"
@@ -9464,7 +9464,7 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	good	Last Available: "2017-11"
 9594	enhanced improved diffused fuchsia wishbone	0		Effect: "White Knuckles", Effect Duration: 64, Last Available: "2017-11"
-9595	perfectly mixed high-proof twirling Racisto Ruidoso	6	EPIC	Last Available: "2017-11"
+9595	high-proof perfectly mixed twirling Racisto Ruidoso	6	EPIC	Last Available: "2017-11"
 9596	blue earthenware muffin tin	0		
 9597	stale shaking bran muffin	3	decent	
 9598	decent thick blueberry muffin	5	good	
@@ -9472,7 +9472,7 @@
 9600	red silent B	0		Last Available: "2017-12"
 9601	twirling silent C	0		Last Available: "2017-12"
 9602	upside-down silent D	0		Last Available: "2017-12"
-9603	squat gray silent E	0		Last Available: "2017-12"
+9603	gray squat silent E	0		Last Available: "2017-12"
 9604	skewed silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
 9606	silent H	0		Last Available: "2017-12"
@@ -9514,7 +9514,7 @@
 9642	The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	blinking teal The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	mirror The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
-9645	pulsating gray The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9645	gray pulsating The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	artisanal executive mime flask	4	EPIC	Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	miniature flavorless extra-toasted half sandwich	2	decent	Last Available: "2018-12"
+9681	flavorless miniature extra-toasted half sandwich	2	decent	Last Available: "2018-12"
 9682	hand-crafted mulled hobo wine	3	EPIC	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	huge zippy Da Vinci's cool burning paper hat	0		Moxie: +5, Experience (Mysticality): +5, Initiative: +20, Lasts Until Rollover, Last Available: "2018-12"
@@ -9595,7 +9595,7 @@
 9727	moldy heart-shaped candy whetstone	4	crappy	Last Available: "2018-02"
 9728	spoiled Swedish massage fish	4	crappy	Last Available: "2018-02"
 9729	tolerable extra-dry Third Base	5	good	Last Available: "2018-02"
-9730	weak artisanal lime green Bustle Hustler	2	EPIC	Last Available: "2018-02"
+9730	artisanal weak lime green Bustle Hustler	2	EPIC	Last Available: "2018-02"
 9731	galvanized triple-alkaline irradiated skewed Fabiotion	0		Effect: "Buzzard Breath", Effect Duration: 31, Last Available: "2018-02"
 9732	non-quantum pickled squat Bettie page	0		Effect: "Crocodile Tear", Effect Duration: 42, Last Available: "2018-02"
 9733	nitrogenated Vulcanized tonic o' Banderas	0		Effect: "Permanent Halloween", Effect Duration: 34, Last Available: "2018-02"
@@ -9607,7 +9607,7 @@
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
-9742	twirling tumbling Mysterious Black Box	0		Last Available: "2018-02"
+9742	tumbling twirling Mysterious Black Box	0		Last Available: "2018-02"
 9743	vacuum-sealed nitrogenated lime green rainbow jellybean	0		Effect: "Disco Nirvana", Effect Duration: 19
 9744	deionized mystery lollipop	0		Effect: "Dances with Tweedles", Effect Duration: 61
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
@@ -9629,7 +9629,7 @@
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	teal Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
-9764	wobbly cyan Faux	0		Last Available: "2018-03"
+9764	cyan wobbly Faux	0		Last Available: "2018-03"
 9765	bouncing Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	bouncing Pillowbug	0		Last Available: "2018-03"
@@ -9684,7 +9684,7 @@
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
 9818	Tapioc berry	0		Last Available: "2018-03"
-9819	blurry purple Snarf berry	0		Last Available: "2018-03"
+9819	purple blurry Snarf berry	0		Last Available: "2018-03"
 9820	blinking Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9697,11 +9697,11 @@
 9829	pickled blinking brilliant oyster egg	1		
 9830	mixed upside-down glistening oyster egg	1		Effect: "Takin' It Greasy", Effect Duration: 30
 9831	dried bouncing scintillating oyster egg	1		Effect: "Radium Radicality", Effect Duration: 45
-9832	powdered blurry teal pearlescent oyster egg	1		Effect: "Gunky Dory", Effect Duration: 35
+9832	powdered teal blurry pearlescent oyster egg	1		Effect: "Gunky Dory", Effect Duration: 35
 9833	powdered pulsating lustrous oyster egg	1		
 9834	diluted blurry gleaming oyster egg	1		Effect: "Virgo Rising", Effect Duration: 30
 9835	red FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
-9836	pulsating purple FantasyRealm guest pass	0		Last Available: "2018-04"
+9836	purple pulsating FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	miser's wholesome dangerous FantasyRealm G. E. M.	0		Weapon Damage: +10, Maximum HP Percent: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2018-04"
 9838	bouncing Rubee&trade;	0		Last Available: "2018-04"
 9839	experienced FantasyRealm Warrior's Helm	0		Experience: +2, Last Available: "2018-04"
@@ -9710,7 +9710,7 @@
 9842	lump of bauxite	0		Last Available: "2018-12"
 9843	wobbly Jack Frost's crafty occult &quot;Remember the Trees&quot; Shirt	0		Spell Damage Percent: +25, Maximum MP: +10, Cold Spell Damage: +50
 9844	FantasyRealm key	0		Last Available: "2018-04"
-9845	huge squat plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
+9845	squat huge plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
@@ -9727,7 +9727,7 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	cyan twirling FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	huge normal ghostly tumbling FantasyRealm turkey leg	8	good	Last Available: "2018-04"
+9862	normal huge tumbling ghostly FantasyRealm turkey leg	8	good	Last Available: "2018-04"
 9863	lousy narrow FantasyRealm mead	3	decent	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9766,8 +9766,8 @@
 9898	delicious olive two meat muck	3	awesome	
 9899	miniature adequate maroon chocolate Ogre Chieftain	2	good	
 9900	normal chocolate &quot;Phoenix&quot;	3	good	
-9901	flavorless cyan twirling chocolate Spider Queen	4	decent	
-9902	weak artisanal skewed hipster cocktail	2	EPIC	
+9901	flavorless twirling cyan chocolate Spider Queen	4	decent	
+9902	artisanal weak skewed hipster cocktail	2	EPIC	
 9903	blue God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	blurry God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
@@ -9780,7 +9780,7 @@
 9912	A-Boo glue	0		
 9913	narrow glued A-Boo clue	0		
 9914	upside-down crude oil congealer	0		
-9915	stale miniature good guava	2	decent	
+9915	miniature stale good guava	2	decent	
 9916	acceptable gin and ginger	3	good	
 9917	Thwaitgold chigger statuette	0		
 9918	pickled gaseous gravy	1		Effect: "Neutered Nostrils", Effect Duration: 5
@@ -9818,10 +9818,10 @@
 9950	jittery flame-retardant beefcake's pentagram bandana	0		Muscle: +25, Hot Resistance: +1, Last Available: "2018-09"
 9951	skull ring of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2018-09"
 9952	upside-down electronics kit	0		Last Available: "2018-09"
-9953	spoiled enchanted bite-sized jittery PB&J with the crusts cut off	1	crappy	Effect: "Concentration", Effect Duration: 15, Last Available: "2018-09"
+9953	enchanted bite-sized spoiled jittery PB&J with the crusts cut off	1	crappy	Effect: "Concentration", Effect Duration: 15, Last Available: "2018-09"
 9954	Jim Carey's energetic dorky glasses	0		Maximum MP Percent: +20, Monster Level: +25, Single Equip, Last Available: "2018-09"
 9955	mirror steel-toed Rosewater's ponytail clip	0		Mysticality Percent: +30, Damage Reduction: 9, Last Available: "2018-09"
-9956	reassuring paint palette	0		Spooky Resistance: +1, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	reassuring paint palette	0		Spooky Resistance: +1, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	vaporized blue Purple Beast energy drink	1		Last Available: "2018-09"
 9959	bouncing supercool cosmetic football	0		Moxie Percent: +20, Last Available: "2018-09"
@@ -9838,20 +9838,20 @@
 9970	teal brainy ratty knitted cap of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Last Available: "2018-09"
 9972	intimidating chainsaw of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP: +100, Lasts Until Rollover, Last Available: "2018-09"
 9973	smooth party beer bomb	3	awesome	Last Available: "2018-09"
-9974	rotten gigantic green squat narrow sweet party mix	9	crappy	Last Available: "2018-09"
-9975	dehydrated bouncing wobbly wobbly party balloon	1		Last Available: "2018-09"
+9974	gigantic rotten green squat narrow sweet party mix	9	crappy	Last Available: "2018-09"
+9975	dehydrated wobbly bouncing wobbly party balloon	1		Last Available: "2018-09"
 9976	huge party pants of Tarzan of the businessman	0		Experience (Muscle): +3, Meat Drop: +50, Last Available: "2018-09"
 9977	fortified razor-sharp party whip of the businessman	0		Weapon Damage Percent: +25, Damage Absorption: +60, Meat Drop: +50, Last Available: "2018-09"
 9978	skewed Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	perfectly mixed spinning TRIO cup of beer	3	EPIC	Last Available: "2018-09"
 9980	bland party platter for one	3	decent	Last Available: "2018-09"
-9981	vaporized skewed purple tumbling Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9981	vaporized skewed tumbling purple Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	executive party crasher of the glutton	0		Meat Drop: +40, Food Drop: +100, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	executive party crasher of the glutton	0		Meat Drop: +40, Food Drop: +100, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
-9986	pulsating lime green party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9986	lime green pulsating party mouse hat	0		Familiar Weight: +5
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	miser's &quot;I Voted!&quot; sticker	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2018-11"
@@ -9878,16 +9878,16 @@
 10012	perfectly mixed bottle of vodka	3	EPIC	Last Available: "2018-11"
 10013	bland miniature pizza	2	decent	Last Available: "2018-11"
 10014	aged martini	4	awesome	Last Available: "2018-11"
-10015	yummy huge skewed cherry pie	8	awesome	Last Available: "2018-11"
+10015	huge yummy skewed cherry pie	8	awesome	Last Available: "2018-11"
 10016	bad eggnog	3	decent	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	adequate snack-sized ghostly Hell ramen	2	good	Last Available: "2018-11"
+10018	snack-sized adequate ghostly Hell ramen	2	good	Last Available: "2018-11"
 10019	mediocre gimlet	4	decent	Last Available: "2018-11"
-10020	practically non-alcoholic hand-crafted twice-haunted screwdriver	1	super ultra mega turbo EPIC	Last Available: "2018-11"
+10020	hand-crafted practically non-alcoholic twice-haunted screwdriver	1	super ultra mega turbo EPIC	Last Available: "2018-11"
 10021	decent candy cane	3	good	Last Available: "2018-12"
 10022	practically non-alcoholic mediocre runny fermented egg	1	decent	Last Available: "2018-12"
 10023	adequate oldcake	3	good	Last Available: "2018-12"
-10024	flavorless bite-sized traditional Crimbo cookie	1	decent	Last Available: "2023-06"
+10024	bite-sized flavorless traditional Crimbo cookie	1	decent	Last Available: "2023-06"
 10025	ghostly plastic wild beaver of chilblains	0		Cold Damage: +25, Last Available: "2018-12"
 10026	plastic reindeer of the blizzard	0		Cold Spell Damage: +25, Last Available: "2018-12"
 10027	ghostly mansplainer's plastic Caf&eacute; Elf	0		Monster Level: +15, Last Available: "2018-12"
@@ -9902,7 +9902,7 @@
 10036	huge bomb	0		Last Available: "2018-12"
 10037	jittery plastic bazooka	0		Last Available: "2018-12"
 10038	blinking mooseflank	0		Last Available: "2018-12"
-10039	rotten big grilled mooseflank	5	crappy	Last Available: "2018-12"
+10039	big rotten grilled mooseflank	5	crappy	Last Available: "2018-12"
 10040	rotten moosemeat pie	4	crappy	Last Available: "2018-12"
 10041	balanced antler of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2018-12"
 10042	dam of temperance	0		Sleaze Resistance: +5, Damage Reduction: 9, Last Available: "2018-12"
@@ -9914,8 +9914,8 @@
 10048	spinning groovy muskox-skin cap	0		Moxie Percent: +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	moldy half-sized glass of raw eggs	2	crappy	Last Available: "2018-12"
-10051	high-proof acceptable narrow blurry punch-drunk punch	10	good	Last Available: "2018-12"
-10052	vaporized huge mirror body spradium	1		Last Available: "2018-12"
+10051	acceptable high-proof blurry narrow punch-drunk punch	10	good	Last Available: "2018-12"
+10052	vaporized mirror huge body spradium	1		Last Available: "2018-12"
 10053	knitted bauxite beret	0		Cold Resistance: +3, Last Available: "2018-12"
 10054	bauxite boxers of extreme caution	0		Monster Level: -25, Last Available: "2018-12"
 10055	reassuring bauxite bow-tie	0		Spooky Resistance: +1, Single Equip, Last Available: "2018-12"
@@ -9923,14 +9923,14 @@
 10057	olive Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	blurry narrow Jeselnik's toasty steel-toed baleful Kramco Sausage-o-Matic&trade; of the overflowing toilet	0		Spell Damage: +25, Damage Reduction: 9, Hot Damage: +5, Stench Spell Damage: +50, Sleaze Damage: +25, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	fancy normal tumbling sausage	4	good	Effect: "The Moxious Madrigal", Effect Duration: 25, Last Available: "2019-01"
+10060	normal fancy tumbling sausage	4	good	Effect: "The Moxious Madrigal", Effect Duration: 25, Last Available: "2019-01"
 10061	narrow gray dangerous cool red-hot sausage fork	0		Moxie: +5, Weapon Damage: +10, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	twirling sausage golem	0		Last Available: "2019-01"
 10064	skewed jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	lousy beer	3	decent	Last Available: "2018-12"
-10067	enchanted miniature tasty wobbly yule gruel	2	awesome	Effect: "Nutrient-Rich", Effect Duration: 30, Last Available: "2018-12"
+10067	miniature tasty enchanted wobbly yule gruel	2	awesome	Effect: "Nutrient-Rich", Effect Duration: 30, Last Available: "2018-12"
 10068	practically non-alcoholic lousy tumbling hot watered rum	1	decent	Last Available: "2018-12"
 10069	perfectly mixed bottle of Crimbognac	3	EPIC	Last Available: "2018-12"
 10070	jumbo moldy Crimboysters Rockefeller	5	crappy	Last Available: "2018-12"
@@ -9961,22 +9961,22 @@
 10095	forbidden marble mariachi hat of the ox	0		Muscle: +20, Spell Damage Percent: +50, Last Available: "2019-12"
 10096	denatured twirling marble molecules	1		Last Available: "2019-12"
 10097	magnetized Mallomarbles	0		Effect: "Horrid, Torrid", Effect Duration: 17
-10098	thinker's punching bag of the detective	0		Mysticality: +10, Item Drop: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	careful cool pith helmet	0		Moxie: +5, Monster Level: -10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	Tesla healthy poncho	0		Maximum HP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	reassuring Herculean pendant	0		Experience (Muscle): +1, Spooky Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	palazzos of terror of the early riser	0		Spooky Spell Damage: +10, Adventures: +7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	weightlifter's pseudoaccordion of the cheetah	0		Muscle: +15, Initiative: +60, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	thinker's punching bag of the detective	0		Mysticality: +10, Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	careful cool pith helmet	0		Moxie: +5, Monster Level: -10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	Tesla healthy poncho	0		Maximum HP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	reassuring Herculean pendant	0		Experience (Muscle): +1, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	palazzos of terror of the early riser	0		Spooky Spell Damage: +10, Adventures: +7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	weightlifter's pseudoaccordion of the cheetah	0		Muscle: +15, Initiative: +60, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	mixed spinning pieces	1		Last Available: "2020-12"
 10105	dry magnetized Para-Pop	0		Effect: "Deadly Flashing Blade", Effect Duration: 12
-10106	gravedigger's terra cotta truss of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	wobbly greasy gravedigger's terra cotta trousers	0		Spooky Damage: +10, Sleaze Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	Newton's thinker's terra cotta tongs	0		Mysticality: +10, Experience (Mysticality): +3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	jittery hardy groovy terra cotta train	0		Moxie Percent: +10, Maximum HP: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	blinking Jack Frost's padded terra cotta tie tack	0		Damage Absorption: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	spinning beefy terra cotta tambourine of incineration	0		Muscle: +10, Hot Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	gravedigger's terra cotta truss of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	wobbly greasy gravedigger's terra cotta trousers	0		Spooky Damage: +10, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	Newton's thinker's terra cotta tongs	0		Mysticality: +10, Experience (Mysticality): +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	jittery hardy groovy terra cotta train	0		Moxie Percent: +10, Maximum HP: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	blinking Jack Frost's padded terra cotta tie tack	0		Damage Absorption: +20, Cold Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	spinning beefy terra cotta tambourine of incineration	0		Muscle: +10, Hot Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	distilled cyan terra cotta tidbits	1		Last Available: "2020-12"
-10113	corrupted pressed blinking pulsating terra panna cotta	0		Effect: "Feline Ferocity", Effect Duration: 52
+10113	corrupted pressed pulsating blinking terra panna cotta	0		Effect: "Feline Ferocity", Effect Duration: 52
 10114	shaking Usain Bolt's shellacked velour voulge	0		Damage Reduction: 7, Initiative: +80, Last Available: "2021-12"
 10115	scandalous hardened velour vambraces	0		Damage Reduction: 3, Sleaze Damage: +5, Single Equip, Last Available: "2021-12"
 10116	shellacked velour veil of the wise owl	0		Mysticality: +20, Damage Reduction: 7, Single Equip, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	twirling jittery rosewater-soaked Fonzie's glass serape	0		Experience (Moxie): +1, Stench Resistance: +3, Last Available: "2021-12"
 10128	dehydrated shaking fuchsia glass shards	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 15, Last Available: "2021-12"
 10129	chilled hard candy	0		Effect: "Gamer Rage", Effect Duration: 27
-10130	shaking aromatic loofah lumberjack's hat of the pedagogue	0		Experience: +3, Stench Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	horrifying Herculean loofah lei	0		Experience (Muscle): +1, Spooky Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	loofah lederhosen of courage of temperance	0		Spooky Resistance: +3, Sleaze Resistance: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	blue skewed ribald smelly loofah ladle	0		Stench Spell Damage: +10, Sleaze Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	gravedigger's loofah legwarmers of Flo-Jo	0		Spooky Damage: +10, Initiative: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	mirror censurious careful loofah lavalier	0		Monster Level: -10, Sleaze Resistance: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	modified jittery pulsating olive loofah lumps	1		Last Available: "2022-12"
+10130	shaking aromatic loofah lumberjack's hat of the pedagogue	0		Experience: +3, Stench Resistance: +1, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	horrifying Herculean loofah lei	0		Experience (Muscle): +1, Spooky Damage: +25, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	loofah lederhosen of courage of temperance	0		Spooky Resistance: +3, Sleaze Resistance: +5, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	blue skewed ribald smelly loofah ladle	0		Stench Spell Damage: +10, Sleaze Damage: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	gravedigger's loofah legwarmers of Flo-Jo	0		Spooky Damage: +10, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	mirror censurious careful loofah lavalier	0		Monster Level: -10, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10136	modified olive pulsating jittery loofah lumps	1		Last Available: "2022-12"
 10137	altered chocolate-covered loofah	0		Effect: "Weapon of Mass Destruction", Effect Duration: 19
-10138	Herculean flagstone flag of vim and vigor	0		Experience (Muscle): +1, Maximum HP Percent: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	MacGyver's strapping flagstone flail	0		Muscle: +5, Maximum MP: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	crafty flagstone flip-flops of Leguizamo	0		Maximum MP: +10, Monster Level: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	blue Sherlock's sage flagstone fez	0		Mysticality Percent: +10, Item Drop: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	flagstone fleece of the brute of Tarzan	0		Muscle Percent: +30, Experience (Muscle): +3, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	bouncing red stanky quilted flagstone fringe	0		Damage Absorption: +40, Stench Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	Herculean flagstone flag of vim and vigor	0		Experience (Muscle): +1, Maximum HP Percent: +50, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	MacGyver's strapping flagstone flail	0		Muscle: +5, Maximum MP: +100, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	crafty flagstone flip-flops of Leguizamo	0		Maximum MP: +10, Monster Level: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	blue Sherlock's sage flagstone fez	0		Mysticality Percent: +10, Item Drop: +25, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	flagstone fleece of the brute of Tarzan	0		Muscle Percent: +30, Experience (Muscle): +3, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	bouncing red stanky quilted flagstone fringe	0		Damage Absorption: +40, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	diluted blurry flagstone flagments	1		Last Available: "2022-12"
 10145	moist vacuum-sealed Flag by the Foot&trade;	0		Effect: "Low on the Hog", Effect Duration: 42
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	shaking sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	elf army poncho of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-12"
-10155	adequate jumbo gray elf army field rations	5	good	Last Available: "2019-12"
+10155	jumbo adequate gray elf army field rations	5	good	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	maroon inspector's discarded bowtie of bravery	0		Spooky Resistance: +5, Item Drop: +15, Lasts Until Rollover, Last Available: "2019-12"
 10158	watered-down artisanal olive martiny	2	EPIC	Last Available: "2019-12"
@@ -10029,17 +10029,17 @@
 10163	dry flattened government-issued candy	0		Effect: "Tasting the Rainbow", Effect Duration: 61
 10164	deionized activated oxidized blurry ghostly green Pneumo bar	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 36
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	dog trainer's occult Lil' Doctor&trade; bag	0		Spell Damage Percent: +25, Experience (familiar): +1, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	dog trainer's occult Lil' Doctor&trade; bag	0		Spell Damage Percent: +25, Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
-10169	small rotten bloodstick	2	crappy	
-10170	fortified lousy bottle of Sanguiovese	5	decent	
+10169	rotten small bloodstick	2	crappy	
+10170	lousy fortified bottle of Sanguiovese	5	decent	
 10171	flavorless huge actual blood sausage	3	decent	
 10172	bad mulled blood	3	decent	
-10173	diet spoiled purple blood snowcone	1	crappy	
+10173	spoiled diet purple blood snowcone	1	crappy	
 10174	lousy Red Russian	3	decent	
 10175	spoiled spinning blood roll-up	3	crappy	
-10176	lousy weak bottle of blood	2	decent	
-10177	small special spoiled blood-soaked sponge cake	2	crappy	Effect: "Frozen Shoulders", Effect Duration: 45
+10176	weak lousy bottle of blood	2	decent	
+10177	spoiled special small blood-soaked sponge cake	2	crappy	Effect: "Frozen Shoulders", Effect Duration: 45
 10178	drinkable practically non-alcoholic spinning vampagne	1	good	
 10179	stale plain snowcone	3	decent	
 10180	Booke of Vampyric Knowledge	0		
@@ -10061,7 +10061,7 @@
 10196	spinning recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	twirling green tumbling tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	special bland snack-sized crabsicle	2	decent	Effect: "No Vertigo", Effect Duration: 45, Last Available: "2019-04"
+10199	bland snack-sized special crabsicle	2	decent	Effect: "No Vertigo", Effect Duration: 45, Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	mediocre cyan bottle of dark rhum	3	decent	Last Available: "2019-04"
 10202	weak bad bottle of extra-dark rhum	2	decent	Last Available: "2019-04"
@@ -10095,16 +10095,16 @@
 10230	avaricious personal trainer's piratical blunderbuss	0		Experience Percent (Muscle): +10, Meat Drop: +30, Last Available: "2019-04"
 10231	double-paned personal trainer's educational PirateRealm party hat	0		Experience: +1, Experience Percent (Muscle): +10, Cold Resistance: +5, Last Available: "2019-04"
 10232	extra-dry aged narrow Island Landslide	5	awesome	Last Available: "2019-04"
-10233	lousy high-proof Island Thunderstorm	8	decent	Last Available: "2019-04"
+10233	high-proof lousy Island Thunderstorm	8	decent	Last Available: "2019-04"
 10234	hand-crafted jittery Island Hurricane	4	EPIC	Last Available: "2019-04"
 10235	watered-down delicious huge Skull Punch	2	awesome	Last Available: "2019-04"
-10236	extra-dry drinkable jittery teal Electric Punch	5	good	Last Available: "2019-04"
+10236	drinkable extra-dry jittery teal Electric Punch	5	good	Last Available: "2019-04"
 10237	weak lousy maroon Smuggler's Punch	2	decent	Last Available: "2019-04"
 10238	mediocre gray Scorpion Bowl	4	decent	Last Available: "2019-04"
 10239	weak bad Turtle Bowl	2	decent	Last Available: "2019-04"
-10240	tolerable fancy blurry Cobra Bowl	4	good	Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2019-04"
+10240	fancy tolerable blurry Cobra Bowl	4	good	Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	censurious dog trainer's curative occult vampyric cloake of wisdom	0		Mysticality: +15, Spell Damage Percent: +25, Experience (familiar): +1, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	censurious dog trainer's curative occult vampyric cloake of wisdom	0		Mysticality: +15, Spell Damage Percent: +25, Experience (familiar): +1, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	activated oxidized one piece of bubble gum	0		Effect: "Weird Flavor", Effect Duration: 36
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	upside-down scandalous Fourth of May Cosplay Saber of the cougar of the dark arts	0		Moxie: +20, Spell Damage Percent: +100, Sleaze Damage: +5, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	upside-down scandalous Fourth of May Cosplay Saber of the cougar of the dark arts	0		Moxie: +20, Spell Damage Percent: +100, Sleaze Damage: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	spinning Thwaitgold nymph statuette	0		
-10254	auspicious Jeselnik's lion tamer's quilted Herculean smooth weightlifter's hewn moon-rune spoon of wisdom of the brute of bravery of Flo-Jo	0		Muscle: +15, Mysticality: +15, Moxie: +15, Muscle Percent: +30, Experience (Muscle): +1, Damage Absorption: +40, Experience (familiar): +2, Sleaze Damage: +25, Spooky Resistance: +5, Item Drop: +10, Initiative: +100, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	auspicious Jeselnik's lion tamer's quilted Herculean smooth weightlifter's hewn moon-rune spoon of wisdom of the brute of bravery of Flo-Jo	0		Muscle: +15, Mysticality: +15, Moxie: +15, Muscle Percent: +30, Experience (Muscle): +1, Damage Absorption: +40, Experience (familiar): +2, Sleaze Damage: +25, Spooky Resistance: +5, Item Drop: +10, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	blurry cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	pulsating Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	jittery Oprah's rosy-cheeked dance instructor's Beach Comb	0		Experience Percent (Moxie): +10, Maximum HP Percent: +30, Maximum MP Percent: +50, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	jittery Oprah's rosy-cheeked dance instructor's Beach Comb	0		Experience Percent (Moxie): +10, Maximum HP Percent: +30, Maximum MP Percent: +50, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	bouncing pile of sand	0		Last Available: "2019-07"
@@ -10133,9 +10133,9 @@
 10268	electrified irradiated twirling gray seashell	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 25, Last Available: "2019-07"
 10269	energized double-anodized dry seashell	0		Effect: "Banono", Effect Duration: 36, Last Available: "2019-07"
 10270	tarnished galvanized seashell	0		Effect: "Sugar High", Effect Duration: 46, Last Available: "2019-07"
-10271	huge wobbly bunch of sea grapes	0		Last Available: "2019-07"
-10272	enchanted tolerable watered-down bottle of sea wine	2	good	Effect: "Cringle's Curative Carol", Effect Duration: 15, Last Available: "2019-07"
-10273	distilled blurry yellow kelp	1		Effect: "Crimbo Epiphany", Effect Duration: 25, Last Available: "2019-07"
+10271	wobbly huge bunch of sea grapes	0		Last Available: "2019-07"
+10272	tolerable enchanted watered-down bottle of sea wine	2	good	Effect: "Cringle's Curative Carol", Effect Duration: 15, Last Available: "2019-07"
+10273	distilled yellow blurry kelp	1		Effect: "Crimbo Epiphany", Effect Duration: 25, Last Available: "2019-07"
 10274	wobbly pulsating greedy fireproof frightening scorching mansplainer's banded brainy driftwood hat of wisdom of James Dean	0		Mysticality: 20, Experience (Moxie): +3, Damage Absorption: +100, Monster Level: +15, Hot Damage: +25, Spooky Damage: +5, Hot Resistance: +3, Meat Drop: +20, Lasts Until Rollover, Last Available: "2019-07"
 10275	knitted manspreader's curative occult grievous Herculean groovy sage wizardly driftwood pants	0		Mysticality: +25, Mysticality Percent: +10, Moxie Percent: +10, Experience (Muscle): +1, Weapon Damage Percent: +50, Spell Damage Percent: +25, Monster Level: +10, Cold Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-07"
 10276	supercharged curative rosy-cheeked wholesome baleful driftwood bracelet of wisdom of the dark arts of the empath	0		Mysticality: +15, Spell Damage: +25, Spell Damage Percent: +100, Maximum HP Percent: 40, Maximum MP Percent: +30, Familiar Weight: +5, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10167,7 +10167,7 @@
 10302	medical-grade stiffened personal trainer's whittled walking stick of the storm	0		Experience Percent (Muscle): +10, Damage Reduction: 1, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-08"
 10303	bland campfire hot dog	4	decent	Last Available: "2019-08"
 10304	moldy cyan campfire baked potato	3	crappy	Last Available: "2019-08"
-10305	immense flavorless teal campfire s'more	8	decent	Last Available: "2019-08"
+10305	flavorless immense teal campfire s'more	8	decent	Last Available: "2019-08"
 10306	stale small campfire beans	2	decent	Last Available: "2019-08"
 10307	rotten wobbly campfire stew	3	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	awesome	Last Available: "2019-08"
@@ -10183,18 +10183,18 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	fuchsia Thwaitgold bombardier beetle statuette	0		
 10320	yummy huge space chowder	3	awesome	
-10321	bad weak space wine	2	decent	
+10321	weak bad space wine	2	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
-10324	green pulsating Pocket Professor memory chip	0		
-10325	shaking squat Law of Averages	0		
+10324	pulsating green Pocket Professor memory chip	0		
+10325	squat shaking Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	ruddy Eight Days a Week Pill Keeper of the empath of the detective	0		Maximum HP Percent: +40, Familiar Weight: +5, Item Drop: +20, Last Available: "2019-10"
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	rotten pulsating bu&ntilde;uelos Jaliscos	3	crappy	Last Available: "2019-12"
-10338	stale small huge flan del mar	2	decent	Last Available: "2019-12"
+10338	small stale huge flan del mar	2	decent	Last Available: "2019-12"
 10339	spoiled jittery Baja sopapilla	4	crappy	Last Available: "2019-12"
 10340	shaking ribald plastic Mer-kin baker	0		Sleaze Damage: +10, Last Available: "2019-12"
 10341	fireproof plastic sea elf	0		Hot Resistance: +3, Last Available: "2019-12"
@@ -10202,23 +10202,23 @@
 10343	nippy plastic dolphin &quot;orphan&quot;	0		Cold Damage: +10, Single Equip, Last Available: "2019-12"
 10344	Newton's plastic Dolph Bossin	0		Experience (Mysticality): +3, Last Available: "2019-12"
 10345	twirling red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	miniature flavorless mana-coated yams	2	decent	Last Available: "2019-11"
-10347	spoiled super-sized mana-basted tofurkey leg	5	crappy	Last Available: "2019-11"
+10346	flavorless miniature mana-coated yams	2	decent	Last Available: "2019-11"
+10347	super-sized spoiled mana-basted tofurkey leg	5	crappy	Last Available: "2019-11"
 10348	moldy mana-fortified cranberry sauce	4	crappy	Last Available: "2019-11"
-10349	rotten ghostly olive mana-stuffed herbal stuffing	3	crappy	Last Available: "2019-11"
+10349	rotten olive ghostly mana-stuffed herbal stuffing	3	crappy	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	liquefied enhanced olive patch of extra-warm fur	0		Effect: "Pasta Oneness", Effect Duration: 33, Last Available: "2019-12"
-10352	mixed spinning olive industrial lubricant	1		Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2019-12"
-10353	quantum adjusted cyan skewed unfinished pleasure	0		Effect: "Disco Concentration", Effect Duration: 61, Last Available: "2019-12"
+10352	mixed olive spinning industrial lubricant	1		Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2019-12"
+10353	quantum adjusted skewed cyan unfinished pleasure	0		Effect: "Disco Concentration", Effect Duration: 61, Last Available: "2019-12"
 10354	twisted vial of humanoid growth hormone	1		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 50, Last Available: "2019-12"
-10355	distilled blurry bouncing a bug's lymph	1		Last Available: "2019-12"
+10355	distilled bouncing blurry a bug's lymph	1		Last Available: "2019-12"
 10356	enhanced huge blurry organic potpourri	0		Effect: "Eyes for Miles", Effect Duration: 22, Last Available: "2019-12"
 10357	practically non-alcoholic drinkable twirling boot flask	1	good	Last Available: "2019-12"
 10358	irradiated altered infernal snowball	0		Effect: "PERL of Great Price", Effect Duration: 52, Last Available: "2019-12"
 10359	pulsating madness	0		Last Available: "2019-12"
 10360	powdered skewed fish sauce	1		Effect: "Night of the Nachos", Effect Duration: 15, Last Available: "2019-12"
 10361	normal half-sized guffin	2	good	Last Available: "2019-12"
-10362	vaporized bouncing blurry Shantix&trade;	1		Effect: "Human-Plant Hybrid", Effect Duration: 25, Last Available: "2019-12"
+10362	vaporized blurry bouncing Shantix&trade;	1		Effect: "Human-Plant Hybrid", Effect Duration: 25, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	mixed green non-Euclidean angle	1		Effect: "20-20 Second Sight", Effect Duration: 15, Last Available: "2019-12"
 10365	chilled vacuum-sealed peppermint syrup	0		Effect: "The Rich Get Richer", Effect Duration: 53, Last Available: "2019-12"
@@ -10254,7 +10254,7 @@
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	narrow tinsel fin	0		Familiar Weight: +5
 10397	tasty fuchsia bowl of mernudo	4	awesome	Last Available: "2019-12"
-10398	artisanal practically non-alcoholic enchanted shaking fishelada	1	super ultra EPIC	Effect: "Elemental Mastery", Effect Duration: 20, Last Available: "2019-12"
+10398	enchanted artisanal practically non-alcoholic shaking fishelada	1	super ultra EPIC	Effect: "Elemental Mastery", Effect Duration: 20, Last Available: "2019-12"
 10399	stale huge ojo de pez burrito	6	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	jittery waterlogged cloth	0		Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	crafty steel-toed Crimbylow-rise jeans	0		Damage Reduction: 9, Maximum MP: +10, Last Available: "2019-12"
 10423	upside-down scorching kelp-holly drape of the sweet-tooth	0		Hot Damage: +25, Candy Drop: +100, Last Available: "2019-12"
 10424	huge dangerous weightlifter's Staff of the Peppermint Twist of chilblains	0		Muscle: +15, Weapon Damage: +10, Cold Damage: +25, Item Drop: +5, Last Available: "2019-12"
-10425	stale snack-sized tempura and bean	2	decent	Last Available: "2019-12"
-10426	spirit-forward perfectly mixed salt plum sake	5	EPIC	Last Available: "2019-12"
+10425	snack-sized stale tempura and bean	2	decent	Last Available: "2019-12"
+10426	perfectly mixed spirit-forward salt plum sake	5	EPIC	Last Available: "2019-12"
 10427	extra-deionized pressurized potion of possessiveness	0		Effect: "Reptilian Fortitude", Effect Duration: 46, Last Available: "2019-12"
 10428	ionized liquefied tumbling almond	0		Effect: "Like a Fish to Walter", Effect Duration: 21
 10429	frozen mirror handful of mixed nuts	0		Effect: "Penguinny Flavor", Effect Duration: 13, Last Available: "2019-12"
-10430	narrow upside-down lime green nutcracking pliers	0		
+10430	narrow lime green upside-down nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	chaotic padded educational Retrospecs	0		Experience: +1, Damage Absorption: +20, Spell Critical Percent: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
-10433	narrow blurry unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
+10432	chaotic padded educational Retrospecs	0		Experience: +1, Damage Absorption: +20, Spell Critical Percent: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10433	blurry narrow unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	fuchsia curative cool Powerful Glove of Calamity Jane of the overflowing toilet of the early riser	0		Moxie: +5, Critical Hit Percent: +15, Stench Spell Damage: +50, Adventures: +7, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	fuchsia curative cool Powerful Glove of Calamity Jane of the overflowing toilet of the early riser	0		Moxie: +5, Critical Hit Percent: +15, Stench Spell Damage: +50, Adventures: +7, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	shaking baleful brawny thinker's Drip harness	0		Mysticality: +10, Muscle Percent: +20, Spell Damage: +25
@@ -10300,7 +10300,7 @@
 10443	blurry Driplet	0		
 10444	drippy snail shell	0		
 10445	stale special drippy nugget	3	drippy	Effect: "Holiday Bliss", Effect Duration: 5
-10446	spirit-forward enchanted aged glass of drippy wine	5	drippy	Effect: "Mathematically Precise", Effect Duration: 35
+10446	aged enchanted spirit-forward glass of drippy wine	5	drippy	Effect: "Mathematically Precise", Effect Duration: 35
 10447	spoiled drippy caviar	3	drippy	
 10448	adequate twirling drippy plum(?)	3	drippy	
 10449	blurry horrifying drippy stake	0		Spooky Damage: +25, Single Equip
@@ -10328,7 +10328,7 @@
 10471	Plumber's Union Handbook	0		
 10472	pulsating MacGyver's bony back shell	0		Maximum MP: +100
 10473	frosty button	0		Single Equip
-10474	altered pulsating mirror squat blooper ink	0		Effect: "Horrid, Torrid", Effect Duration: 67
+10474	altered pulsating squat mirror blooper ink	0		Effect: "Horrid, Torrid", Effect Duration: 67
 10475	coin	0		
 10476	fuchsia rubber doll head	0		
 10477	lime green rubber doll body	0		
@@ -10346,7 +10346,7 @@
 10489	moldy skewed mushroom filet	3	crappy	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	denatured upside-down maroon blurry mushroom tea	1		Effect: "Grrrrrrreat!", Effect Duration: 25, Last Available: "2020-03"
-10492	watered-down drinkable mushroom whiskey	2	good	Last Available: "2020-03"
+10492	drinkable watered-down mushroom whiskey	2	good	Last Available: "2020-03"
 10493	narrow avaricious Van der Graaf mushroom cap of Flo-Jo	0		Meat Drop: +30, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-03"
 10494	red up-at-dawn sharpshooter's veiny mushroom shield of bravery	0		Maximum HP: +10, Critical Hit Percent: +10, Spooky Resistance: +5, Adventures: +5, Damage Reduction: 6, Last Available: "2020-03"
 10495	twirling red flame-retardant scorching Oprah's cool mushroom pants	0		Moxie: +5, Maximum MP Percent: +50, Hot Damage: +25, Hot Resistance: +1, Last Available: "2020-03"
@@ -10379,7 +10379,7 @@
 10522	drippy bromide	0		
 10523	blue shaking drippy flux	0		
 10524	drippy stein	0		
-10525	drinkable teal tumbling skewed drippy pilsner	3	drippy	
+10525	drinkable teal skewed tumbling drippy pilsner	3	drippy	
 10526	wobbly pulsating drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	lime green drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10394,7 +10394,7 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	narrow reassuring Guzzlr souvenir stein	0		Spooky Resistance: +1, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	practically non-alcoholic drinkable Ghiaccio Colada	1	good	Last Available: "2020-05"
+10541	drinkable practically non-alcoholic Ghiaccio Colada	1	good	Last Available: "2020-05"
 10542	aged Sourfinger	3	awesome	Last Available: "2020-05"
 10543	practically non-alcoholic tolerable green Nog-on-the-Cob	1	good	Last Available: "2020-05"
 10544	practically non-alcoholic delicious squat Steamboat	1	awesome	Last Available: "2020-05"
@@ -10424,11 +10424,11 @@
 10568	purple blurry mansplainer's slick deep-fried key of the empath	0		Moxie: +10, Monster Level: +15, Familiar Weight: +5, Last Available: "2020-08"
 10569	MacGyver's healthy discarded bike lock key	0		Maximum HP Percent: +20, Maximum MP: +100, Last Available: "2020-08"
 10570	Thwaitgold keyhole spider statuette	0		
-10571	skewed red Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
+10571	red skewed Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	corrupted anodized marshroom	0		Effect: "Fangs and Pangs", Effect Duration: 38
 10573	bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
-10575	wobbly mirror drippy candy bar	0		
+10575	mirror wobbly drippy candy bar	0		
 10576	diffused salty drippy candy bar	0		Effect: "Black Lung", Effect Duration: 34
 10577	boiled magnetized liquefied writhing drippy candy bar	0		Effect: "init.enh", Effect Duration: 59
 10578	dry wet gooey drippy candy bar	0		Effect: "Jammin'", Effect Duration: 50
@@ -10438,15 +10438,15 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	gray lion tamer's forbidden birch battery	0		Spell Damage Percent: +50, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2020-08"
-10585	blurry jittery chilly hardened Newton's ebony epee	0		Experience (Mysticality): +3, Damage Reduction: 3, Cold Damage: +5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	auspicious knitted weeping willow wand of horror	0		Spooky Spell Damage: +25, Cold Resistance: +3, Item Drop: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	cyan manspreader's vibrating studded beechwood blowgun	0		Damage Absorption: +80, Maximum MP Percent: +10, Monster Level: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	blurry jittery chilly hardened Newton's ebony epee	0		Experience (Mysticality): +3, Damage Reduction: 3, Cold Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	auspicious knitted weeping willow wand of horror	0		Spooky Spell Damage: +25, Cold Resistance: +3, Item Drop: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	cyan manspreader's vibrating studded beechwood blowgun	0		Damage Absorption: +80, Maximum MP Percent: +10, Monster Level: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	miser's chilly energetic maple magnet	0		Maximum MP Percent: +20, Cold Damage: +5, Meat Drop: +10, Lasts Until Rollover, Last Available: "2020-08"
-10589	spinning tumbling Dreadsylvanian hemlock	0		Last Available: "2020-08"
+10589	tumbling spinning Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	squat up-at-dawn stiffened Sinatra's hemlock helm	0		Experience (Moxie): +5, Damage Reduction: 1, Adventures: +5, Last Available: "2020-08"
 10591	tumbling sweaty balsam	0		Last Available: "2020-08"
 10592	friendly electrified dance instructor's balsam barrel	0		Experience Percent (Moxie): +10, Familiar Weight: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-08"
-10593	green mirror redwood	0		Last Available: "2020-08"
+10593	mirror green redwood	0		Last Available: "2020-08"
 10594	altered spinning redwood rain stick	0		Effect: "Warm Belly", Effect Duration: 66, Last Available: "2020-08"
 10595	purpleheart logs	0		Last Available: "2020-08"
 10596	gray resourceful Fonzie's purpleheart &quot;pants&quot; of the early riser	0		Experience (Moxie): +1, Maximum MP: +50, Adventures: +7, Last Available: "2020-08"
@@ -10472,11 +10472,11 @@
 10616	Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	purple sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
-10619	wobbly yellow uncanny desk bell	0		Last Available: "2020-09"
+10619	yellow wobbly uncanny desk bell	0		Last Available: "2020-09"
 10620	spinning nasty desk bell	0		Last Available: "2020-09"
 10621	blue greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
-10623	green blinking onyx king	0		Last Available: "2020-09"
+10623	blinking green onyx king	0		Last Available: "2020-09"
 10624	red onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
 10626	maroon onyx bishop	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bouncing bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	squat frosty Cargo Cultist Shorts of dire peril of the dark arts of Calamity Jane	0		Weapon Damage: +20, Spell Damage Percent: +100, Critical Hit Percent: +15, Cold Spell Damage: +10, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	practically non-alcoholic hand-crafted enchanted squat flask of moonshine	1	super ultra mega EPIC	Effect: "Black Lung", Effect Duration: 45, Last Available: "2020-09"
+10638	hand-crafted practically non-alcoholic enchanted squat flask of moonshine	1	super ultra mega EPIC	Effect: "Black Lung", Effect Duration: 45, Last Available: "2020-09"
 10639	scandalous Jim Carey's Annie Oakley's sea-worn candlestick	0		Critical Hit Percent: +20, Monster Level: +25, Sleaze Damage: +5, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	improved wet null-day exploit	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 26, Last Available: "2025-12"
@@ -10537,7 +10537,7 @@
 10681	candy bucket of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2020-12"
 10682	pickled flattened prescription teeth whitener	0		Effect: "Sewer-Drenched", Effect Duration: 13, Last Available: "2020-12"
 10683	ionized enhanced imported lemon lozenge	0		Effect: "Bastard!", Effect Duration: 26, Last Available: "2020-12"
-10684	chilled pressed twirling spinning hermedisiac cologne	0		Effect: "Cold Jellied", Effect Duration: 61, Last Available: "2020-12"
+10684	chilled pressed spinning twirling hermedisiac cologne	0		Effect: "Cold Jellied", Effect Duration: 61, Last Available: "2020-12"
 10685	government food shipment	0		Last Available: "2020-12"
 10686	squat government booze shipment	0		Last Available: "2020-12"
 10687	government candy shipment	0		Last Available: "2020-12"
@@ -10569,7 +10569,7 @@
 10713	pulsating The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	jittery The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	delicious and pepper (stale)	3	awesome	Last Available: "2020-12"
-10716	enchanted watered-down mediocre cranberry margarita (brackish)	2	decent	Effect: "Ponderous Potency", Effect Duration: 30, Last Available: "2020-12"
+10716	enchanted mediocre watered-down cranberry margarita (brackish)	2	decent	Effect: "Ponderous Potency", Effect Duration: 30, Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
@@ -10579,30 +10579,30 @@
 10723	mediocre Boulevardier cocktail	3	decent	Last Available: "2020-12"
 10724	diffused wet Hotwire&trade; brand candy rope	0		Effect: "Alpine Mintiness", Effect Duration: 62, Last Available: "2020-12"
 10725	enchanted bland fuchsia bowl full of jelly	4	decent	Effect: "Amplified Fabulousness", Effect Duration: 10, Last Available: "2020-12"
-10726	perfectly mixed watered-down Eye and a Twist	2	EPIC	Last Available: "2020-12"
+10726	watered-down perfectly mixed Eye and a Twist	2	EPIC	Last Available: "2020-12"
 10727	galvanized triple-nitrogenated magnetized Chubby and Plump bar	0		Effect: "Arse-a'fire", Effect Duration: 29, Last Available: "2020-12"
 10728	bouncing digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	pulsating fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	wobbly Thwaitgold listening bug statuette	0		
 10737	huge power seed	0		Free Pull, Last Available: "2021-03"
 10738	blinking potted power plant	0		Last Available: "2021-03"
 10739	corrupted battery (AAA)	0		Effect: "Arresistible", Effect Duration: 43, Last Available: "2021-03"
 10740	extra-enhanced ionized battery (AA)	0		Effect: "Pasty", Effect Duration: 44, Last Available: "2021-03"
-10741	moist denatured altered yellow narrow battery (D)	0		Effect: "Cold Hands", Effect Duration: 32, Last Available: "2021-03"
+10741	moist denatured altered narrow yellow battery (D)	0		Effect: "Cold Hands", Effect Duration: 32, Last Available: "2021-03"
 10742	unsweetened electrified battery (9-Volt)	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 14, Last Available: "2021-03"
 10743	extra-chilled ghostly battery (lantern)	0		Effect: "Unusual Perspective", Effect Duration: 62, Last Available: "2021-03"
-10744	warmed fuchsia squat battery (car)	0		Effect: "Sweet Tooth", Effect Duration: 14, Last Available: "2021-03"
+10744	warmed squat fuchsia battery (car)	0		Effect: "Sweet Tooth", Effect Duration: 14, Last Available: "2021-03"
 10745	ghostly cryptocloak	0		Last Available: "2025-12"
 10746	wobbly marshmallow	0		
-10747	triple-distilled smooth marshmallow bomb	10	awesome	Last Available: "2021-03"
+10747	smooth triple-distilled marshmallow bomb	10	awesome	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	blinking shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	modified activated short beer	0		Effect: "Hairless and Airless", Effect Duration: 22, Last Available: "2021-05"
@@ -10612,26 +10612,26 @@
 10756	quadruple-concentrated quadruple-ionized cyan short	0		Effect: "Sappy Blood", Effect Duration: 29, Last Available: "2021-05"
 10757	jittery Thwaitgold quantum bug statuette	0		
 10758	wobbly quantum of familiar	0		
-10759	Fonzie's cool familiar scrapbook	0		Moxie: +5, Experience (Moxie): +1, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	Fonzie's cool familiar scrapbook	0		Moxie: +5, Experience (Moxie): +1, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	huge clan underground fireworks shop	0		Last Available: "2021-07"
 10762	gray Temple Grandin's rosy-cheeked fedora-mounted fountain of the empath	0		Maximum HP Percent: +30, Familiar Weight: 12, Lasts Until Rollover, Last Available: "2021-07"
 10763	mirror stanky Oprah's rosy-cheeked sombrero-mounted sparkler	0		Maximum HP Percent: +30, Maximum MP Percent: +50, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
 10764	nippy Tesla thinker's porkpie-mounted popper	0		Mysticality: +10, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2021-07"
 10765	rocket	0		Last Available: "2021-07"
-10766	skewed upside-down blue rocket	0		Last Available: "2021-07"
+10766	blue upside-down skewed rocket	0		Last Available: "2021-07"
 10767	spinning rocket	0		Last Available: "2021-07"
-10768	jumbo yummy wobbly fire crackers	5	awesome	Last Available: "2021-07"
+10768	yummy jumbo wobbly fire crackers	5	awesome	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	spinning yellow stylish Catherine Wheel of the early riser	0		Moxie: +25, Adventures: +7, Lasts Until Rollover, Last Available: "2021-07"
 10771	ghostly rocket boots of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	stanky ruddy sparkler	0		Maximum HP Percent: +40, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
 10773	mirror Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
-10774	enhanced triple-improved pickled mirror green Scent of a Human&trade; candle	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 56, Last Available: "2021-08"
+10774	enhanced triple-improved pickled green mirror Scent of a Human&trade; candle	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 56, Last Available: "2021-08"
 10775	boiled The Beast Within&trade; candle	0		Effect: "Human-Horror Hybrid", Effect Duration: 61, Last Available: "2021-08"
 10776	frozen frozen triple-colloidal skewed fuchsia Salsa Caliente&trade; candle	0		Effect: "Lobos Fresh", Effect Duration: 35, Last Available: "2021-08"
 10777	modified twirling Smoldering Clover&trade; candle	0		Effect: "Gemini Rising", Effect Duration: 48, Last Available: "2021-08"
-10778	cold-filtered extra-tarnished pulsating twirling Napalm In The Morning&trade; candle	0		Effect: "Hairy Palms", Effect Duration: 26, Last Available: "2021-08"
+10778	cold-filtered extra-tarnished twirling pulsating Napalm In The Morning&trade; candle	0		Effect: "Hairy Palms", Effect Duration: 26, Last Available: "2021-08"
 10779	green fireproof extra-large utility candle of the storm	0		Maximum MP Percent: +40, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2021-08"
 10780	tumbling miser's runed taper candle of the bloodbag	0		Maximum HP: +100, Meat Drop: +10, Lasts Until Rollover, Last Available: "2021-08"
 10781	friendly ruddy Socratic novelty sparkling candle	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2021-08"
@@ -10641,7 +10641,7 @@
 10785	corrupted huge rainbow glitter candle	0		Effect: "Chock Full o' Nanites", Effect Duration: 38, Last Available: "2021-08"
 10786	double-polymerized concentrated wet narrow banana candle	0		Effect: "Healthy Green Glow", Effect Duration: 52, Last Available: "2021-08"
 10787	nitrogenated concentrated ear candle	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 39, Last Available: "2021-08"
-10788	galvanized quadruple-frozen ghostly green votive of confidence	0		Effect: "Thunderheart", Effect Duration: 17, Last Available: "2021-08"
+10788	galvanized quadruple-frozen green ghostly votive of confidence	0		Effect: "Thunderheart", Effect Duration: 17, Last Available: "2021-08"
 10789	cool water candle	0		Moxie: +5, Water: 3, Lasts Until Rollover
 10790	educational B. L. A. R. T.	0		Experience: +1, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	Thwaitgold fire beetle statuette	0		
@@ -10650,7 +10650,7 @@
 10794	shaking green rainproof barrel caulk	0		
 10795	spinning pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	therapeutic personal trainer's smartaleck's wizardly industrial fire extinguisher of doom of the cheetah	0		Mysticality: +25, Moxie Percent: +30, Experience Percent (Muscle): +10, Spooky Spell Damage: +50, Initiative: +60, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	therapeutic personal trainer's smartaleck's wizardly industrial fire extinguisher of doom of the cheetah	0		Mysticality: +25, Moxie Percent: +30, Experience Percent (Muscle): +10, Spooky Spell Damage: +50, Initiative: +60, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	wobbly The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10678,13 +10678,13 @@
 10822	rotten bone broth	3	crappy	Last Available: "2021-12"
 10823	bland red star pop	3	decent	Last Available: "2021-12"
 10824	mediocre Doc's Fortifying Wine	4	decent	Last Available: "2021-12"
-10825	smooth special blinking Doc's Smartifying Wine	3	awesome	Effect: "Fangs and Pangs", Effect Duration: 35, Last Available: "2021-12"
+10825	special smooth blinking Doc's Smartifying Wine	3	awesome	Effect: "Fangs and Pangs", Effect Duration: 35, Last Available: "2021-12"
 10826	mediocre weak blinking Doc's Limbering Wine	2	decent	Last Available: "2021-12"
 10827	delicious Doc's Medical-Grade Wine	4	awesome	Last Available: "2021-12"
 10828	altered Homebodyl&trade;	1		Last Available: "2021-12"
 10829	denatured blinking Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	modified purple Breathitin&trade;	1		Last Available: "2021-12"
-10831	diluted tumbling squat fuchsia Fleshazole&trade;	1		Last Available: "2021-12"
+10831	diluted tumbling fuchsia squat Fleshazole&trade;	1		Last Available: "2021-12"
 10832	oxidized anodized pickled shaking anti-burn cream	0		Effect: "Weird Vibrations", Effect Duration: 54, Last Available: "2021-12"
 10833	dry wet blue anti-freeze cream	0		Effect: "Stuck That Way", Effect Duration: 65, Last Available: "2021-12"
 10834	extra-galvanized frozen mirror anti-goosebump cream	0		Effect: "Okee-Dokee Go!", Effect Duration: 39, Last Available: "2021-12"
@@ -10693,7 +10693,7 @@
 10837	altered anti-pain cream	0		Effect: "Down With Chow", Effect Duration: 28, Last Available: "2021-12"
 10838	acceptable Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
 10839	stale snack-sized bread pie	2	decent	Last Available: "2021-12"
-10840	spirit-forward tolerable clear Russian	5	good	Last Available: "2021-12"
+10840	tolerable spirit-forward clear Russian	5	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	upside-down goo magnet	0		Last Available: "2021-12"
 10851	wobbly cozy scarf of the bloodbag	0		Maximum HP: +100, Last Available: "2021-12"
-10852	yummy jumbo huge Crimbo cookie	5	awesome	Last Available: "2023-06"
+10852	jumbo yummy huge Crimbo cookie	5	awesome	Last Available: "2023-06"
 10853	super-magnetized modified fleshy putty	0		Effect: "Stogied", Effect Duration: 45, Last Available: "2021-12"
 10854	perfumed third ear	0		Stench Resistance: +5, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	tumbling projectile chemistry set	0		Last Available: "2021-12"
 10860	red depleted Crimbonium football helmet of dire peril	0		Weapon Damage: +20, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	small fancy decent spinning &quot;caramel&quot;	2	good	Effect: "Powdered", Effect Duration: 5, Last Available: "2021-12"
+10862	fancy small decent spinning &quot;caramel&quot;	2	good	Effect: "Powdered", Effect Duration: 5, Last Available: "2021-12"
 10863	blinking medical-grade self-repairing earmuffs	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-12"
 10864	sinister carnivorous potted plant	0		Spell Damage: +10, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	yule hatchet of the pedagogue	0		Experience: +3, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	yummy huge lab-grown meat	8	awesome	Last Available: "2021-12"
+10868	huge yummy lab-grown meat	8	awesome	Last Available: "2021-12"
 10869	purple dog trainer's fleece	0		Experience (familiar): +1, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	wobbly teal blinking cloning kit	0		Last Available: "2021-12"
@@ -10736,11 +10736,11 @@
 10880	vaporized fried air	1		Effect: "Hare-o-dynamic", Effect Duration: 20, Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	blue carton of astral energy drinks	0		
-10883	altered mirror lime green astral energy drink	1		Effect: "Antarctic Memories", Effect Duration: 10
+10883	altered lime green mirror astral energy drink	1		Effect: "Antarctic Memories", Effect Duration: 10
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	perfumed scorching magnifying glass of the brute	0		Muscle Percent: +30, Hot Damage: +25, Stench Resistance: +5, Last Available: "2022-12"
 10886	watered-down lousy void lager	2	decent	Last Available: "2022-12"
-10887	big fancy flavorless huge void burger	5	decent	Effect: "Warm Belly", Effect Duration: 25, Last Available: "2022-12"
+10887	big flavorless fancy huge void burger	5	decent	Effect: "Warm Belly", Effect Duration: 25, Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	wizardly void shard of the dark arts of chilblains of the glutton	0		Mysticality: +25, Spell Damage Percent: +100, Cold Damage: +25, Food Drop: +100, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10767,7 +10767,7 @@
 10911	vacuum-sealed corrupted tumbling gaffer's tape	0		Effect: "Stop the Presses!", Effect Duration: 45, Last Available: "2022-05"
 10912	low-calorie adequate 20-lb can of rice and beans	1	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	tasty wobbly narrow expired MRE	3	awesome	Last Available: "2022-05"
+10914	tasty narrow wobbly expired MRE	3	awesome	Last Available: "2022-05"
 10915	normal huge cool mint precipice bar	3	good	Last Available: "2022-05"
 10916	special moldy lime green carrot cake precipice bar	3	crappy	Effect: "Melancholy Burden", Effect Duration: 35, Last Available: "2022-05"
 10917	cyan The Big Book of Every Skill	0		
@@ -10777,12 +10777,12 @@
 10921	practically non-alcoholic delicious Dad's brandy	1	awesome	Last Available: "2022-06"
 10922	blue mirror spinning censurious scandalous teacher's pen	0		Sleaze Damage: +5, Sleaze Resistance: +3, Last Available: "2022-06"
 10923	tasty fire-roasted lake trout	3	awesome	Last Available: "2022-06"
-10924	rotten big guilty sprout	5	crappy	Last Available: "2022-06"
+10924	big rotten guilty sprout	5	crappy	Last Available: "2022-06"
 10925	lion tamer's mother's necklace of courage	0		Experience (familiar): +2, Spooky Resistance: +3, Last Available: "2022-06"
 10926	improved pressed trampled ticket stub	0		Effect: "All Is Forgiven", Effect Duration: 59, Last Available: "2022-06"
 10927	pickled wet corrupted savings bond	0		Effect: "Sensation", Effect Duration: 57, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	huge designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	huge designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	dried huge sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	squat stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10795,7 +10795,7 @@
 10939	flatusaur gasmask	0		
 10940	blinking dinosaur dart	0		
 10941	polymerized anodized Dino DNAde&trade;	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 43
-10942	tumbling mirror dinosaur repellent	0		
+10942	mirror tumbling dinosaur repellent	0		
 10943	green avaricious camouflage vest	0		Meat Drop: +30
 10944	narrow Dinodollar	0		
 10945	valuable dinosaur droppings	0		
@@ -10805,10 +10805,10 @@
 10949	steel-toed dinosaur	0		Damage Reduction: 9
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	ghostly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	clever Jurassic Parka of James Dean	0		Experience (Moxie): +3, Maximum MP: +20, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	clever Jurassic Parka of James Dean	0		Experience (Moxie): +3, Maximum MP: +20, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
-10955	aerosolized upside-down skewed autumn leaf	0		Effect: "Mayeaugh", Effect Duration: 53, Last Available: "2022-10"
+10955	aerosolized skewed upside-down autumn leaf	0		Effect: "Mayeaugh", Effect Duration: 53, Last Available: "2022-10"
 10956	perfectly mixed pulsating AutumnFest ale	3	EPIC	Last Available: "2022-10"
 10957	huge electrified razor-sharp brawny autumn sweater-weather sweater	0		Muscle Percent: +20, Weapon Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
 10958	mirror zippy wool ribald ruddy autumn debris shield	0		Maximum HP Percent: +40, Sleaze Damage: +10, Cold Resistance: +1, Initiative: +20, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
@@ -10824,14 +10824,14 @@
 10968	lime green St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	adequate ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
-10971	gigantic stale Jarlsberg's vegetable soup	9	decent	Last Available: "2022-11"
-10972	low-calorie stale roasted vegetable of Jarlsberg	1	decent	Last Available: "2022-11"
+10971	stale gigantic Jarlsberg's vegetable soup	9	decent	Last Available: "2022-11"
+10972	stale low-calorie roasted vegetable of Jarlsberg	1	decent	Last Available: "2022-11"
 10973	low-calorie bland St. Pete's sneaky smoothie	1	decent	Last Available: "2022-11"
-10974	special normal Pete's wiley whey bar	4	good	Effect: "Extra Backbone", Effect Duration: 10, Last Available: "2022-11"
+10974	normal special Pete's wiley whey bar	4	good	Effect: "Extra Backbone", Effect Duration: 10, Last Available: "2022-11"
 10975	delicious red Pete's rich ricotta	4	awesome	Last Available: "2022-11"
-10976	boozy lousy Boris's beer	5	decent	Last Available: "2022-11"
+10976	lousy boozy Boris's beer	5	decent	Last Available: "2022-11"
 10977	decent honey bun of Boris	3	good	Last Available: "2022-11"
-10978	enchanted rotten bouncing Boris's bread	3	crappy	Effect: "Quadrilled", Effect Duration: 30, Last Available: "2022-11"
+10978	rotten enchanted bouncing Boris's bread	3	crappy	Effect: "Quadrilled", Effect Duration: 30, Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	wobbly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
@@ -10842,10 +10842,10 @@
 10986	twirling Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	cyan Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	stale half-sized baked veggie ricotta casserole	2	decent	Last Available: "2022-11"
-10989	rotten small plain calzone	2	crappy	Last Available: "2022-11"
-10990	normal small roasted vegetable focaccia	2	good	Last Available: "2022-11"
+10989	small rotten plain calzone	2	crappy	Last Available: "2022-11"
+10990	small normal roasted vegetable focaccia	2	good	Last Available: "2022-11"
 10991	normal gigantic Pizza of Legend	8	good	Last Available: "2022-11"
-10992	flavorless massive Calzone of Legend	8	decent	Last Available: "2022-11"
+10992	massive flavorless Calzone of Legend	8	decent	Last Available: "2022-11"
 10993	tumbling Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
@@ -10863,22 +10863,22 @@
 11007	booze bindle	0		
 11008	spinning rare oboe of Leguizamo of terror	0		Monster Level: +20, Spooky Spell Damage: +10
 11009	ghostly thinker's bullet necklace of the scaredy-cat	0		Mysticality: +10, Monster Level: -15, Single Equip
-11010	spoiled miniature swamp haunch	2	crappy	
+11010	miniature spoiled swamp haunch	2	crappy	
 11011	coward's gator shades of chilblains	0		Monster Level: -20, Cold Damage: +25, Single Equip
 11012	milk cap	0		
 11013	lousy Charleston Choo-Choo	3	decent	
-11014	watered-down acceptable Velvet Veil	2	good	
-11015	tolerable watered-down mirror Marltini	2	good	
+11014	acceptable watered-down Velvet Veil	2	good	
+11015	watered-down tolerable mirror Marltini	2	good	
 11016	high-proof delicious twirling Strong, Silent Type	10	awesome	
 11017	weak mediocre Mysterious Stranger	2	decent	
 11018	drinkable purple Champagne Shimmy	4	good	
 11019	the Sot's parcel	0		
-11020	flame-wreathed ceramic cestus of the ox	0		Muscle: +20, Hot Spell Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	Usain Bolt's deadly ceramic centurion shield of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Initiative: +80, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	cyan scandalous ceramic celery grater of the sweet-tooth	0		Sleaze Damage: +5, Candy Drop: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	upside-down sizzling ceramic celsiturometer of James Dean of bravery	0		Experience (Moxie): +3, Hot Damage: +10, Spooky Resistance: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	steel-toed studded ceramic cerecloth belt of horror	0		Damage Absorption: +80, Damage Reduction: 9, Spooky Spell Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	horrifying lion tamer's coward's ceramic cenobite's robe	0		Monster Level: -20, Experience (familiar): +2, Spooky Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	flame-wreathed ceramic cestus of the ox	0		Muscle: +20, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	Usain Bolt's deadly ceramic centurion shield of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Initiative: +80, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	cyan scandalous ceramic celery grater of the sweet-tooth	0		Sleaze Damage: +5, Candy Drop: +100, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	upside-down sizzling ceramic celsiturometer of James Dean of bravery	0		Experience (Moxie): +3, Hot Damage: +10, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	steel-toed studded ceramic cerecloth belt of horror	0		Damage Absorption: +80, Damage Reduction: 9, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	horrifying lion tamer's coward's ceramic cenobite's robe	0		Monster Level: -20, Experience (familiar): +2, Spooky Damage: +25, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	denatured mirror spinning ceramic scree	1		Effect: "Springy Fusilli", Effect Duration: 35, Last Available: "2023-12"
 11027	polarized wobbly extra-hard jawbreaker	0		Effect: "Larger", Effect Duration: 65
 11028	horrifying ruddy smooth chiffon chevrons	0		Moxie: +15, Maximum HP Percent: +40, Spooky Damage: +25, Single Equip, Last Available: "2023-12"
@@ -10889,9 +10889,9 @@
 11033	executive educational chiffon chaps of horror	0		Experience: +1, Spooky Spell Damage: +25, Meat Drop: +40, Last Available: "2023-12"
 11034	vaporized chiffon carbage	1		Last Available: "2023-12"
 11035	super-cold-filtered bouncing chiffon lemon	0		Effect: "Spookypants", Effect Duration: 35
-11036	immense rotten chocomotive	9	crappy	Last Available: "2022-12"
-11037	massive decent freightcake	7	good	Last Available: "2022-12"
-11038	hand-crafted high-proof fuchsia cabooze	6	EPIC	Last Available: "2022-12"
+11036	rotten immense chocomotive	9	crappy	Last Available: "2022-12"
+11037	decent massive freightcake	7	good	Last Available: "2022-12"
+11038	high-proof hand-crafted fuchsia cabooze	6	EPIC	Last Available: "2022-12"
 11039	tumbling plastic caboose	0		Last Available: "2022-12"
 11040	friendly plastic passenger car	0		Familiar Weight: +3, Last Available: "2022-12"
 11041	olive sinister plastic dining car	0		Spell Damage: +10, Last Available: "2022-12"
@@ -10903,7 +10903,7 @@
 11047	skewed Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
-11050	dry cyan twirling Trainbot circuitry	0		Effect: "Executive Greed", Effect Duration: 14
+11050	dry twirling cyan Trainbot circuitry	0		Effect: "Executive Greed", Effect Duration: 14
 11051	tarnished super-aerosolized activated mirror pulsating Trainbot tubing	0		Effect: "Armor-Plated", Effect Duration: 53
 11052	super-chilled lime green Trainbot plating	0		Effect: "Salt Rockin'", Effect Duration: 51
 11053	alkaline adjusted Trainbot optics	0		Effect: "Super-Electrified", Effect Duration: 27
@@ -10920,18 +10920,18 @@
 11064	red supercharged experienced smartaleck's shoulder-mounted Trainbot	0		Moxie Percent: +30, Experience: +2, Maximum MP Percent: +30, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	squat skewed Crimbo crystal shards	0		
-11067	high-proof hand-crafted purple dregs of a Crimbo cocktail	9	EPIC	
+11067	hand-crafted high-proof purple dregs of a Crimbo cocktail	9	EPIC	
 11068	lost elf luggage	0		
 11069	bouncing Trainbot luggage hook	0		Single Equip
 11070	spoiled ghostly honey-drenched ham slice	4	crappy	
-11071	irresponsibly strong lousy mostly-empty bottle of cookie wine	7	decent	
-11072	spoiled massive ghostly wobbly Crimbo food scraps	8	crappy	
+11071	lousy irresponsibly strong mostly-empty bottle of cookie wine	7	decent	
+11072	massive spoiled wobbly ghostly Crimbo food scraps	8	crappy	
 11073	pulsating arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
-11076	blurry upside-down Trainbot slag	0		
+11076	upside-down blurry Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	special stale steamed oyster	4	decent	Effect: "No Worries", Effect Duration: 15
+11078	stale special steamed oyster	4	decent	Effect: "No Worries", Effect Duration: 15
 11079	mirror really nice lump of coal	0		
 11080	skewed deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	upside-down steam unit	0		Last Available: "2022-12"
@@ -10950,7 +10950,7 @@
 11094	fuchsia forbidden grubby wool trousers of the bloodbag of mayonnaise	0		Spell Damage Percent: +50, Maximum HP: +100, Sleaze Spell Damage: +50
 11095	squat squat prompt arcane researcher's Da Vinci's grubby wool gloves of mayonnaise	0		Experience (Mysticality): +5, Experience Percent (Mysticality): +10, Sleaze Spell Damage: +50, Adventures: +3, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	triple-distilled mediocre nice warm beer	7	decent	
+11097	mediocre triple-distilled nice warm beer	7	decent	
 11098	grubby woolball	0		
 11099	blue Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10964,8 +10964,8 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	tumbling gray chocolate covered ping-pong ball	0		
-11112	stale blinking cyan pixel bread	4	decent	
-11113	watered-down drinkable pixel whiskey	2	good	
+11112	stale cyan blinking pixel bread	4	decent	
+11113	drinkable watered-down pixel whiskey	2	good	
 11114	jittery pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10979,7 +10979,7 @@
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	boiled fire ant pheromones	0		Effect: "EVISCERATE!", Effect Duration: 48, Last Available: "2023-02"
 11126	frozen non-galvanized flapper fly	0		Effect: "Warm Belly", Effect Duration: 19, Last Available: "2023-02"
-11127	fancy bad practically non-alcoholic ghostly shot of wasp venom	1	decent	Effect: "Thunderspell", Effect Duration: 15, Last Available: "2023-02"
+11127	bad fancy practically non-alcoholic ghostly shot of wasp venom	1	decent	Effect: "Thunderspell", Effect Duration: 15, Last Available: "2023-02"
 11128	cold-filtered pressed double-moist filled mosquito	0		Effect: "Eyes Wide Propped", Effect Duration: 22, Last Available: "2023-02"
 11129	polarized improved liquefied jittery shim of shame shale	0		Effect: "Frog In Your Throat", Effect Duration: 38, Last Available: "2023-02"
 11130	non-vacuum-sealed unsweetened moist olive pebble of proud pyrite	0		Effect: "Preternatural Greed", Effect Duration: 63, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	electrified galvanized narrow angry agate	0		Effect: "Blessing of Charcoatl", Effect Duration: 34, Last Available: "2023-02"
 11134	enhanced ionized shaking lump of loyal latite	0		Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2023-02"
-11135	big stale shadow sausage	5	decent	Last Available: "2023-03"
+11135	stale big shadow sausage	5	decent	Last Available: "2023-03"
 11136	Lo Pan's shadow skin of the brazier	0		Spell Critical Percent: +30, Hot Spell Damage: +25, Last Available: "2023-03"
 11137	Vulcanized shadow flame	0		Effect: "Leisurely Amblin'", Effect Duration: 50, Last Available: "2023-03"
 11138	yummy shadow bread	3	awesome	Last Available: "2023-03"
@@ -11034,11 +11034,11 @@
 11179	blurry rock-hard shadow hammer of chilblains	0		Damage Reduction: 5, Cold Damage: +25
 11180	chaotic medical-grade smooth shadow monocle	0		Moxie: +15, Spell Critical Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 11181	shaking shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	miniature rotten gray shadow hot dog	2	crappy	
+11182	rotten miniature gray shadow hot dog	2	crappy	
 11183	drinkable twirling shadow martini	3	good	
 11184	compressed shadow pill	1		Effect: "Metal Speed", Effect Duration: 15
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	adjusted pulsating narrow shadow candy	0		Effect: "Egg-stra Arm", Effect Duration: 11
 11189	replica Mr. Accessory	0		
@@ -11075,7 +11075,7 @@
 11220	mirror replica over-the-shoulder Folder Holder	0		
 11221	spinning replica Order of the Green Thumb Order Form	0		
 11222	wobbly shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	blue mansplainer's energetic Sinatra's Cincho de Mayo of the early riser	0		Experience (Moxie): +5, Maximum MP Percent: +20, Monster Level: +15, Adventures: +7, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	blue mansplainer's energetic Sinatra's Cincho de Mayo of the early riser	0		Experience (Moxie): +5, Maximum MP Percent: +20, Monster Level: +15, Adventures: +7, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	squat red replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11084,7 +11084,7 @@
 11229	olive replica Chateau Mantegna room key	0		
 11230	shaking replica Deck of Every Card	0		
 11231	replica Source terminal	0		
-11232	spinning twirling green replica disconnected intergnat	0		
+11232	twirling spinning green replica disconnected intergnat	0		
 11233	gray replica Witchess Set	0		
 11234	replica genie bottle	0		
 11235	spinning replica space planula	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	green crafty supercool replica Jurassic Parka	0		Moxie Percent: +20, Maximum MP: +10
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	tumbling replica Ten Dollars	0		
 11254	asbestos-lined dangerous personal trainer's thinker's replica Cincho de Mayo	0		Mysticality: +10, Experience Percent (Muscle): +10, Weapon Damage: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,16 +11112,16 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	green greasy dog trainer's extremely unsafe grievous &quot;I survived Y2K&quot; T-Shirt of the overflowing toilet of the boozehound	0		Weapon Damage Percent: 150, Experience (familiar): +1, Stench Spell Damage: +50, Sleaze Spell Damage: +10, Booze Drop: +100, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	blurry fortified Socratic pro skateboard	0		Experience (Mysticality): +1, Damage Absorption: +60, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	blurry fortified Socratic pro skateboard	0		Experience (Mysticality): +1, Damage Absorption: +60, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	red Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	hale Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	hale Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	twirling scorching coward's Amulet of Perpetual Darkness of the brute of horror	0		Muscle Percent: +30, Monster Level: -20, Hot Damage: +25, Spooky Spell Damage: +25, Last Available: "2023-06"
 11268	spinning Giant monolith	0		Last Available: "2023-06"
-11269	jittery purple Crimbo cookie sheet	0		Last Available: "2023-06"
+11269	purple jittery Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
 11271	denatured magnetized dry scroll of minor invulnerability	0		Effect: "Brother Corsican's Blessing", Effect Duration: 40, Last Available: "2023-06"
 11272	Lapis Lazuli	0		Last Available: "2023-06"
@@ -11132,12 +11132,12 @@
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	fuchsia Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
-11280	spinning green narrow Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
+11280	narrow green spinning Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
 11282	drinkable practically non-alcoholic gray Sexy Cosmo	1	good	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	ghostly toasty careful Socratic red-soled high heels	0		Experience (Mysticality): +1, Monster Level: -10, Hot Damage: +5, Last Available: "2023-06"
-11285	immense normal cyburger	6	good	Last Available: "2025-12"
+11285	normal immense cyburger	6	good	Last Available: "2025-12"
 11286	pulsating chaotic ncle leg	0		Spell Critical Percent: +10
 11287	green double-paned medical-grade rutabuga bag	0		Cold Resistance: +5, HP Regen Min: 7, HP Regen Max: 10
 11288	green Van der Graaf mesquito proboscis	0		MP Regen Min: 5, MP Regen Max: 7
@@ -11174,14 +11174,14 @@
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	mediocre watered-down bottle of Cabernet Sauvignon	2	decent	
 11321	prompt executive clever baywatch	0		Maximum MP: +20, Meat Drop: +40, Adventures: +3, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	jittery Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	jittery Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	bouncing consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	teal residual chitin paste	0		Skill: "Chitinous Soul"
 11328	dehydrated ghostly concentrated cooking	1		
-11329	diluted squat skewed meat	1		Effect: "The Best a Pirate Can Get", Effect Duration: 40
+11329	diluted skewed squat meat	1		Effect: "The Best a Pirate Can Get", Effect Duration: 40
 11330	vaporized lime green sparkling orb	1		
 11331	dehydrated blurry hardening cream	1		Effect: "Patience of the Tortoise", Effect Duration: 45
 11332	dried mirror pulsating pool shark hair oil	1		
@@ -11227,12 +11227,12 @@
 11372	ghostly handful of Boltsmann bearings	0		
 11373	blurry Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
-11375	blinking blurry Boltsmann ID badge	0		
+11375	blurry blinking Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	immense adequate pickled bread	9	good	Last Available: "2023-12"
 11379	gigantic adequate tumbling salted mutton	6	good	Last Available: "2023-12"
-11380	half-sized toothsome corned beet	2	awesome	Last Available: "2023-12"
+11380	toothsome half-sized corned beet	2	awesome	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11242,7 +11242,7 @@
 11387	pulsating pulsating pirate encryption key bravo	0		Last Available: "2023-12"
 11388	pirate encryption key charlie	0		Last Available: "2023-12"
 11389	spinning wobbly pirate encryption key delta	0		Last Available: "2023-12"
-11390	maroon mirror wardrobe-o-matic	0		
+11390	mirror maroon wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
@@ -11279,7 +11279,7 @@
 11424	smelly dangerous sawed-off blunderbuss of the glutton	0		Weapon Damage: +10, Stench Spell Damage: +10, Food Drop: +100, Last Available: "2023-12"
 11425	bad watered-down squat officer's nog	2	decent	Last Available: "2023-12"
 11426	spinning peppermint bomb	0		Last Available: "2023-12"
-11427	bite-sized toothsome wobbly sundae ration	1	awesome	Last Available: "2023-12"
+11427	toothsome bite-sized wobbly sundae ration	1	awesome	Last Available: "2023-12"
 11428	decent peppermint tack	3	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	stale lime green whalesteak	3	decent	Last Available: "2023-12"
@@ -11301,40 +11301,40 @@
 11446	skewed Elf Guard fuel tank	0		Item Drop: +5, Last Available: "2023-12"
 11447	pulsating manspreader's grievous massive wrench of chilblains	0		Weapon Damage Percent: +50, Monster Level: +10, Cold Damage: +25, Last Available: "2023-12"
 11448	shaking ribald coward's brown pirate pants	0		Monster Level: -20, Sleaze Damage: +10, Last Available: "2023-12"
-11449	jittery teal Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+11449	teal jittery Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11450	huge red The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
-11451	purple blinking punching mirror	0		Last Available: "2023-12"
+11451	blinking purple punching mirror	0		Last Available: "2023-12"
 11452	tumbling flame-wreathed supercharged grievous groovy Elf dessert spoon of the bloodbag of the boozehound	0		Moxie Percent: +10, Weapon Damage Percent: +50, Maximum HP: +100, Maximum MP Percent: +30, Hot Spell Damage: +10, Booze Drop: +100, Last Available: "2023-12"
 11453	sinister wicked Elf Guard SCUBA tank	0		Spell Damage: 15, Last Available: "2023-12"
 11454	skewed Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	free boots of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	free boots of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	foul-smelling baleful Socratic Elvish underarmor	0		Experience (Mysticality): +1, Spell Damage: +25, Stench Damage: +10, Single Equip, Last Available: "2023-12"
 11458	wizardly Crimbuccaneer bombjacket of the brute	0		Mysticality: +25, Muscle Percent: +30, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	stale sugarplum ration	3	decent	Last Available: "2023-12"
-11460	stale tumbling blue upside-down narrow gingerbread nylons	3	decent	Last Available: "2023-12"
+11460	stale narrow blue tumbling upside-down gingerbread nylons	3	decent	Last Available: "2023-12"
 11461	rotten yellow rum-soaked fruitcake	3	crappy	Last Available: "2023-12"
-11462	jumbo spoiled lime	5	crappy	Last Available: "2023-12"
+11462	spoiled jumbo lime	5	crappy	Last Available: "2023-12"
 11463	fancy spoiled upside-down gingerbread pirate	3	crappy	Effect: "Elemental Mastery", Effect Duration: 50, Last Available: "2023-12"
 11464	spoiled fruit-stuffed rumcake	3	crappy	Last Available: "2023-12"
-11465	practically non-alcoholic tolerable mulled wine	1	good	Last Available: "2023-12"
+11465	tolerable practically non-alcoholic mulled wine	1	good	Last Available: "2023-12"
 11466	drinkable Swedish coffee	3	good	Last Available: "2023-12"
 11467	lousy high-proof canteen of eggnog	6	decent	Last Available: "2023-12"
-11468	hand-crafted high-proof hot wine	6	EPIC	Last Available: "2023-12"
-11469	acceptable practically non-alcoholic blinking Jamaican coffee	1	good	Last Available: "2023-12"
+11468	high-proof hand-crafted hot wine	6	EPIC	Last Available: "2023-12"
+11469	practically non-alcoholic acceptable blinking Jamaican coffee	1	good	Last Available: "2023-12"
 11470	acceptable flask of egggrog	4	good	Last Available: "2023-12"
 11471	upside-down Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	ghostly huge pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	artisanal watered-down teal yule grog	2	super EPIC	Last Available: "2023-12"
+11474	watered-down artisanal teal yule grog	2	super EPIC	Last Available: "2023-12"
 11475	adequate twirling wet tack	3	good	Last Available: "2023-12"
 11476	adequate spinning whalecake	3	good	Last Available: "2023-12"
-11477	wicked Samson's gunwale whalegun of the brazier	0		Experience (Muscle): +5, Spell Damage: +5, Hot Spell Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	wicked Samson's gunwale whalegun of the brazier	0		Experience (Muscle): +5, Spell Damage: +5, Hot Spell Damage: +25, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	watered-down mediocre and claret	2	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	blurry mirror reassuring Elf Guard squirtgun of chilblains	0		Cold Damage: +25, Spooky Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
-11482	shaking ghostly chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
+11481	blurry mirror reassuring Elf Guard squirtgun of chilblains	0		Cold Damage: +25, Spooky Resistance: +1, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11482	ghostly shaking chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	fortified sequin-encrusted sweater	0		Damage Absorption: +60, Last Available: "2023-12"
 11484	Da Vinci's sage replica Elf Guard medal of terror	0		Mysticality Percent: +10, Experience (Mysticality): +5, Spooky Spell Damage: +10, Last Available: "2023-12"
 11485	blinking Lil' Snowball Factory	0		Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	ionized super-ionized military candy cane	0		Effect: "Swordholder", Effect Duration: 68
 11503	non-denatured groggipop	0		Effect: "Fan-Cooled", Effect Duration: 50
-11504	hardy moss mace of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	zippy Socratic moss megaphone	0		Experience (Mysticality): +1, Initiative: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	mirror manspreader's resourceful moss medal	0		Maximum MP: +50, Monster Level: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	blinking flame-wreathed moss mitre of Gandalf	0		Spell Critical Percent: +20, Hot Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	lime green Rosewater's moss mantle of the boozehound	0		Mysticality Percent: +30, Booze Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	hardy moss mace of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	zippy Socratic moss megaphone	0		Experience (Mysticality): +1, Initiative: +20, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	mirror manspreader's resourceful moss medal	0		Maximum MP: +50, Monster Level: +10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	blinking flame-wreathed moss mitre of Gandalf	0		Spell Critical Percent: +20, Hot Spell Damage: +10, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	lime green Rosewater's moss mantle of the boozehound	0		Mysticality Percent: +30, Booze Drop: +100, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	miser's moss marlinspike of bravery	0		Spooky Resistance: +5, Meat Drop: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	diluted moss mulch	1		Last Available: "2024-12"
 11511	warmed moss floss	0		Effect: "Speed of the Internet", Effect Duration: 54
@@ -11372,12 +11372,12 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	dehydrated blinking adobe assortment	1		Effect: "Coy to the Hurled", Effect Duration: 15, Last Available: "2024-12"
 11519	deionized denatured adobe brittle	0		Effect: "Danish Cunning", Effect Duration: 45
-11520	therapeutic healthy crepe paper phrygian cap of incineration	0		Maximum HP Percent: +20, Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	therapeutic healthy crepe paper phrygian cap of incineration	0		Maximum HP Percent: +20, Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	pulsating inspector's Jack Frost's lion tamer's crepe paper parachute cape	0		Experience (familiar): +2, Cold Spell Damage: +50, Item Drop: +15, Last Available: "2025-12"
-11522	brainy beefy crepe paper pie clip of incineration	0		Muscle: +10, Mysticality: +5, Hot Spell Damage: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	blurry sizzling crepe paper puzzle cube of the scaredy-cat of the sewer	0		Monster Level: -15, Hot Damage: +10, Stench Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	squat lightning-fast Jack Frost's lion tamer's crepe paper plunge camisole	0		Experience (familiar): +2, Cold Spell Damage: +50, Initiative: +40, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	skewed Jack Frost's savvy crepe paper polka charm of the cougar	0		Moxie: +20, Mysticality Percent: +20, Cold Spell Damage: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	brainy beefy crepe paper pie clip of incineration	0		Muscle: +10, Mysticality: +5, Hot Spell Damage: +50, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	blurry sizzling crepe paper puzzle cube of the scaredy-cat of the sewer	0		Monster Level: -15, Hot Damage: +10, Stench Damage: +25, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	squat lightning-fast Jack Frost's lion tamer's crepe paper plunge camisole	0		Experience (familiar): +2, Cold Spell Damage: +50, Initiative: +40, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	skewed Jack Frost's savvy crepe paper polka charm of the cougar	0		Moxie: +20, Mysticality Percent: +20, Cold Spell Damage: +50, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	diluted lime green pulsating crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	dry enhanced spinning crepe paper peanut candy	0		Effect: "Lifted Spirits", Effect Duration: 38
 11528	wobbly aromatic quilted petrified wood war pike	0		Damage Absorption: +40, Stench Resistance: +1, Last Available: "2025-12"
@@ -11386,19 +11386,19 @@
 11531	arcane researcher's experienced petrified wood water purifier	0		Experience: +2, Experience Percent (Mysticality): +10, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	asbestos-lined veiny petrified wood whoopie panama	0		Maximum HP: +10, Hot Resistance: +5, Last Available: "2025-12"
 11533	rock-hard padded petrified wood walking pants	0		Damage Absorption: +20, Damage Reduction: 5, Last Available: "2025-12"
-11534	vaporized gray squat blurry petrified wood waste parts	1		Last Available: "2025-12"
+11534	vaporized squat blurry gray petrified wood waste parts	1		Last Available: "2025-12"
 11535	dry petrified wood wafer praline	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 67
 11536	artisanal spinning cybeer	3	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	blue baby chest mimic	0		Free Pull
 11541	green googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	blurry Fonzie's Crimbuccaneer war standard of the early riser	0		Experience (Moxie): +1, Adventures: +7, Last Available: "2023-12"
 11544	skewed supercool Elf Guard war standard of the dark arts	0		Moxie Percent: +20, Spell Damage Percent: +100, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	narrow curative smartaleck's strapping spring shoes	0		Muscle: +5, Moxie Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	narrow curative smartaleck's strapping spring shoes	0		Muscle: +5, Moxie Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	ionized dry corrupted tumbling ultra-soft ferns	0		Effect: "Pla-see-bo", Effect Duration: 34, Last Available: "2024-02"
 11548	irradiated dry crunchy brush	0		Effect: "Smugness", Effect Duration: 33, Last Available: "2024-02"
 11549	blinking smashed scientific equipment	0		
@@ -11431,7 +11431,7 @@
 11576	artisanal Southern yam	4	EPIC	Last Available: "2024-05"
 11577	drinkable wobbly sweet potato punch	3	good	Last Available: "2024-05"
 11578	diet bland blue Mayam spinach	1	decent	Last Available: "2024-05"
-11579	yummy super-sized yam and swiss	5	awesome	Last Available: "2024-05"
+11579	super-sized yummy yam and swiss	5	awesome	Last Available: "2024-05"
 11580	MacGyver's therapeutic yam cannon of Calamity Jane	0		Maximum MP: +100, Critical Hit Percent: +15, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	gray pulsating yam battery	0		Last Available: "2024-05"
@@ -11441,19 +11441,19 @@
 11586	curative padded yamtility belt of James Dean	0		Experience (Moxie): +3, Damage Absorption: +20, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-05"
 11587	decent yam slider	3	good	Last Available: "2024-05"
 11588	snack-sized tasty yam mayo	2	awesome	Last Available: "2024-05"
-11589	decent squat blinking yam burrito	3	good	Last Available: "2024-05"
+11589	decent blinking squat yam burrito	3	good	Last Available: "2024-05"
 11590	upside-down visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	red aviator goggles	0		
 11593	twirling Thwaitgold Illinigina illinoiensis model	0		
 11594	snack-sized decent upside-down mini kiwi	2	good	Last Available: "2024-06"
 11595	hale slick brainy mini kiwi bikini	0		Mysticality: +5, Moxie: +10, Maximum HP: +20, Last Available: "2024-06"
-11596	perfectly mixed watered-down mini kiwitini	2	EPIC	Last Available: "2024-06"
+11596	watered-down perfectly mixed mini kiwitini	2	EPIC	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	scandalous stiffened boxer's mini kiwi silicon tiepin	0		Muscle Percent: +10, Damage Reduction: 1, Sleaze Damage: +5
-11600	olive huge mini kiwi tipi	0		
-11601	snack-sized flavorless spinning fuchsia mini kiwi digitized cookies	2	decent	
+11600	huge olive mini kiwi tipi	0		
+11601	flavorless snack-sized spinning fuchsia mini kiwi digitized cookies	2	decent	
 11602	drinkable squat mini kiwi intoxicating spirits	3	good	
 11603	colloidal enhanced altered yellow mini kiwi antimilitaristic hippy petition	0		Effect: "Jacked In", Effect Duration: 64
 11604	anodized altered chilled blinking mini kiwi illicit antibiotic	0		Effect: "Mad at Science", Effect Duration: 22
@@ -11461,7 +11461,7 @@
 11606	upside-down mini kiwi icepick of extreme caution	0		Monster Level: -25
 11607	diffused colloidal mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Tingly Elbows", Effect Duration: 25
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	bouncing protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	bouncing protogenetic chunklet (flagellum)	0		
@@ -11484,10 +11484,10 @@
 11629	untorn tearaway pants package	0		Free Pull
 11630	twirling gravedigger's sizzling toasty grievous Socratic tearaway pants	0		Experience (Mysticality): +1, Weapon Damage Percent: +50, Hot Damage: 15, Spooky Damage: +10, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	blinking baby bodyguard	0		
-11632	cyan ghostly Doll Moll violin case	0		
+11632	ghostly cyan Doll Moll violin case	0		
 11633	fuchsia Tina gun	0		Familiar Weight: +5
 11634	maroon tattoo gun	0		
-11635	hand-crafted practically non-alcoholic Colera Peste Nebbiolo	1	super ultra EPIC	
+11635	practically non-alcoholic hand-crafted Colera Peste Nebbiolo	1	super ultra EPIC	
 11636	longbox of Batfellow comics	0		
 11637	maroon Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11502,7 +11502,7 @@
 11647	red structural ember	0		Last Available: "2024-09"
 11648	curative dangerous embers-only jacket of the wise owl	0		Mysticality: +20, Weapon Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-09"
 11649	mansplainer's bembershoot	0		Monster Level: +15, Lasts Until Rollover, Last Available: "2024-09"
-11650	half-sized flavorless mirror wheel of camembert	2	decent	Last Available: "2024-09"
+11650	flavorless half-sized mirror wheel of camembert	2	decent	Last Available: "2024-09"
 11651	upside-down razor-sharp stylish hat of remembering of chilblains	0		Moxie: +25, Weapon Damage Percent: +25, Cold Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
 11652	skewed throwin' ember	0		Last Available: "2024-09"
 11653	upside-down head of emberg lettuce	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	ghostly photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	wobbly boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	jittery scandalous bat wings of the dark arts of chilblains	0		Spell Damage Percent: +100, Cold Damage: +25, Sleaze Damage: +5, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	jittery scandalous bat wings of the dark arts of chilblains	0		Spell Damage Percent: +100, Cold Damage: +25, Sleaze Damage: +5, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	blue blinking ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	friendly resourceful monocle on a stick	0		Maximum MP: +50, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,14 +11523,14 @@
 11668	resourceful Sheriff badge of Calamity Jane	0		Maximum MP: +50, Critical Hit Percent: +15, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	gravedigger's Sheriff pistol of the early riser	0		Spooky Damage: +10, Adventures: +7, Lasts Until Rollover, Last Available: "2024-10"
 11670	maroon coward's Sheriff moustache of terror	0		Monster Level: -20, Spooky Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	lard-coated photo booth supply list of the cougar	0		Moxie: +20, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	lard-coated photo booth supply list of the cougar	0		Moxie: +20, Sleaze Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	blue peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	skewed skewed tie-dye headband	0		
 11674	delicious whirled peas	4	awesome	Last Available: "2024-11"
 11675	adequate peaza	4	good	Last Available: "2024-11"
 11676	squat peace shooter	0		Last Available: "2024-11"
 11677	boiled skewed drenchrome 2.0	1		Last Available: "2025-12"
-11678	powdered teal blinking blurry huge Synapse Blaster	1		Last Available: "2025-12"
+11678	powdered teal blurry huge blinking Synapse Blaster	1		Last Available: "2025-12"
 11679	gray quantized familiar	0		
 11680	skewed quantum watch	0		Adventures: +2
 11681	blinking quantized familiar experience	0		
@@ -11541,7 +11541,7 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	spinning TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	smelly sage deft pirate hook	0		Mysticality Percent: +10, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
-11689	lightning-fast clever iron tricorn hat	0		Maximum MP: +20, Initiative: +40, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	lightning-fast clever iron tricorn hat	0		Maximum MP: +20, Initiative: +40, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	Usain Bolt's jolly roger flag	0		Initiative: +80, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	narrow pirrrate's currrse	0		Last Available: "2024-12"
@@ -11576,14 +11576,14 @@
 11721	blurry pulsating Spirit of Christmas	0		Last Available: "2024-12"
 11722	normal snack-sized coney haunch	2	good	Last Available: "2024-12"
 11723	non-diffused super-moist dark chocolate egg	0		Effect: "Boilermade", Effect Duration: 13, Last Available: "2024-12"
-11724	enchanted perfectly mixed moai toai	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 40
+11724	perfectly mixed enchanted moai toai	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 40
 11725	pulsating ribald Van der Graaf strapping moaiball	0		Muscle: +5, Sleaze Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	quadruple-corrupted four-leaf potato sprout	0		Effect: "Tiki Thoughtfulness", Effect Duration: 64, Last Available: "2024-12"
 11728	spinning blinking Lo Pan's sharpshooter's potato jacket of temperance	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Sleaze Resistance: +5, Last Available: "2024-12"
 11729	narrow traumatic holiday memory	0		Last Available: "2024-12"
 11730	mirror Brandonian footlocker key	0		Last Available: "2024-12"
-11731	steel-toed razor-sharp military orb	0		Weapon Damage Percent: +25, Damage Reduction: 9, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	steel-toed razor-sharp military orb	0		Weapon Damage Percent: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	ionized cold-filtered polymerized red rum ball	0		Effect: "meat.enh", Effect Duration: 49
 11733	huge gravy skin	0		Last Available: "2024-12"
 11734	fuchsia thinker's gravyskin hat of the scaredy-cat	0		Mysticality: +10, Monster Level: -15, Last Available: "2024-12"
@@ -11591,11 +11591,11 @@
 11736	wobbly greedy shellacked gravyskin skirt	0		Damage Reduction: 7, Meat Drop: +20, Last Available: "2024-12"
 11737	squat gravyskin pants of the bloodbag of courage	0		Maximum HP: +100, Spooky Resistance: +3, Last Available: "2024-12"
 11738	non-chilled Vulcanized purple crystallized pumpkin spice	0		Effect: "Bats in the Belfry", Effect Duration: 40, Last Available: "2024-12"
-11739	snack-sized stale spinning blurry room scale bean casserole	2	decent	Last Available: "2024-12"
+11739	stale snack-sized blurry spinning room scale bean casserole	2	decent	Last Available: "2024-12"
 11740	mirror fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ghostly ragged wool yarn	0		Last Available: "2024-12"
 11742	Rosewater's boxer's perfect Christmas scarf of the businessman	0		Muscle Percent: [+10*event(December)], Mysticality Percent: [+30*event(December)], Meat Drop: [+50*event(December)], Single Equip, Last Available: "2024-12"
-11743	savvy boxer's snowman-enchanting tophat	0		Muscle Percent: +10, Mysticality Percent: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	savvy boxer's snowman-enchanting tophat	0		Muscle Percent: +10, Mysticality Percent: +20, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	moist alkaline LIDAR candle	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 54, Last Available: "2024-12"
 11745	Sinatra's Congressional Medal of Insanity of the storm of the early riser	0		Experience (Moxie): +5, Maximum MP Percent: +40, Adventures: +7, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
@@ -11610,21 +11610,21 @@
 11755	normal candy rations	3	good	Last Available: "2024-12"
 11756	flavorless double-candied yams	4	decent	Last Available: "2024-12"
 11757	rotten snack-sized Christmas ham	2	crappy	Last Available: "2024-12"
-11758	snack-sized decent holiday smorgasbord	2	good	Last Available: "2024-12"
+11758	decent snack-sized holiday smorgasbord	2	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	healthy bejazzled eyepatch	0		Maximum HP Percent: +20, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	huge blurry Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	upside-down blinking How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	shaking teal Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	mirror Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	blurry huge Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	upside-down blinking How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	teal shaking Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	mirror Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	tumbling prompt perfumed arcane researcher's boxer's egg gun	0		Muscle Percent: +10, Experience Percent (Mysticality): +10, Stench Resistance: +5, Adventures: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	tumbling prompt perfumed arcane researcher's boxer's egg gun	0		Muscle Percent: +10, Experience Percent (Mysticality): +10, Stench Resistance: +5, Adventures: +3, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	flame-retardant double-paned crafty slick army helmet	0		Moxie: +10, Maximum MP: +10, Cold Resistance: +5, Hot Resistance: +1, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	upside-down napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	extra-pickled deviled candy egg	0		Effect: "Hot Hands", Effect Duration: 30, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	squat foul-smelling toasty McHugeLarge duffel bag	0		Hot Damage: +5, Stench Damage: +10, Last Available: "2025-01"
-11784	mirror mirror gray knitted smelly veiny McHugeLarge left pole	0		Maximum HP: +10, Stench Spell Damage: +10, Cold Resistance: +3, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	sinister McHugeLarge right pole of Gandalf of mayonnaise	0		Spell Damage: +10, Spell Critical Percent: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	purple manspreader's McHugeLarge left ski of the sweet-tooth	0		Monster Level: +10, Candy Drop: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	cyan skewed skewed wicked smartaleck's McHugeLarge right ski	0		Moxie Percent: +30, Spell Damage: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	mirror mirror gray knitted smelly veiny McHugeLarge left pole	0		Maximum HP: +10, Stench Spell Damage: +10, Cold Resistance: +3, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	sinister McHugeLarge right pole of Gandalf of mayonnaise	0		Spell Damage: +10, Spell Critical Percent: +20, Sleaze Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	purple manspreader's McHugeLarge left ski of the sweet-tooth	0		Monster Level: +10, Candy Drop: +100, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	cyan skewed skewed wicked smartaleck's McHugeLarge right ski	0		Moxie Percent: +30, Spell Damage: +5, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
-11789	blurry fuchsia 0	0		Last Available: "2025-12"
+11789	fuchsia blurry 0	0		Last Available: "2025-12"
 11790	vaporized bouncing eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	purple dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11656,9 +11656,9 @@
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	mirror dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	cybervisor	0		Last Available: "2025-12"
-11804	gray spinning mirror retro floppy disk	0		Last Available: "2025-12"
+11804	gray mirror spinning retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	narrow CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	shaking 3d printed server room key	0		Last Available: "2025-12"
@@ -11670,7 +11670,7 @@
 11815	pulsating dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	spinning dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
-11818	purple twirling dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
+11818	twirling purple dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	cyan dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	maroon dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	tumbling insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	ghostly hashing vise	0		Last Available: "2025-12"
-11827	lime green geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	lime green geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	blinking virtual cybertattoo	0		Last Available: "2025-12"
 11830	lime green ninja rope	0		
@@ -11687,7 +11687,7 @@
 11832	ninja carabiner	0		
 11833	diffused synthetic coffee	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 57
 11834	magnetized concentrated iDrops	0		Effect: "Spirit Bubble", Effect Duration: 66
-11835	lime green huge shame coil	0		
+11835	huge lime green shame coil	0		
 11836	new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	blinking toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	blinking heat arc	0		
@@ -11696,9 +11696,9 @@
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
-11844	ghostly green chill gherkin	0		
+11844	green ghostly chill gherkin	0		
 11845	childrens' stapler	0		
-11846	huge squat plover's egg	0		
+11846	squat huge plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	upside-down heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11708,7 +11708,7 @@
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	wobbly grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
-11856	bouncing wobbly cyan sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11856	wobbly bouncing cyan sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	blinking huge jittery carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	glover liners	0		Pickpocket Chance: +10
 11859	ghostly mosquito speakers	0		Monster Level: +5
@@ -11717,7 +11717,7 @@
 11862	diluted ghostly scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	lime green table tennis ball	0		Last Available: "2025-03"
 11864	tolerable pint of Leprechaun Stout	3	good	Last Available: "2025-03"
-11865	vaporized jittery lime green phosphor traces	1		Last Available: "2025-03"
+11865	vaporized lime green jittery phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
@@ -11728,19 +11728,19 @@
 11873	normal burrito	3	good	Last Available: "2025-03"
 11874	moldy small beer brat	3	crappy	Last Available: "2025-03"
 11875	small normal bouncing peach pie	2	good	Last Available: "2025-03"
-11876	massive flavorless blinking incredible mini-pizza	6	decent	Last Available: "2025-03"
-11877	irresponsibly strong enchanted lousy green Divine sidecar	6	decent	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2025-03"
-11878	triple-distilled drinkable red tangarita sidecar	9	good	Last Available: "2025-03"
+11876	flavorless massive blinking incredible mini-pizza	6	decent	Last Available: "2025-03"
+11877	lousy enchanted irresponsibly strong green Divine sidecar	6	decent	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2025-03"
+11878	drinkable triple-distilled red tangarita sidecar	9	good	Last Available: "2025-03"
 11879	bad gimlet sidecar	4	decent	Last Available: "2025-03"
 11880	practically non-alcoholic acceptable huge vodka stratocaster sidecar	1	good	Last Available: "2025-03"
-11881	perfectly mixed practically non-alcoholic prussian cathouse sidecar	1	EPIC	Last Available: "2025-03"
-11882	fortified drinkable pulsating Mon Tiki sidecar	5	good	Last Available: "2025-03"
+11881	practically non-alcoholic perfectly mixed prussian cathouse sidecar	1	EPIC	Last Available: "2025-03"
+11882	drinkable fortified pulsating Mon Tiki sidecar	5	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	censurious April Shower Thoughts shield of wisdom	0		Mysticality: +15, Sleaze Resistance: +3, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	adjusted wet paper weights	0		Effect: "Pie in the Sky", Effect Duration: 36, Last Available: "2025-04"
-11888	acceptable practically non-alcoholic Three Sheets to the Wind	1	good	Last Available: "2025-04"
+11888	practically non-alcoholic acceptable Three Sheets to the Wind	1	good	Last Available: "2025-04"
 11889	yummy pile of wet dates	3	awesome	Last Available: "2025-04"
 11890	olive papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	narrow stylish bycocket of the empath	0		Familiar Weight: +5
 11917	blurry Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	adequate small Skeleton Wars rations	2	good	
+11937	small adequate Skeleton Wars rations	2	good	
 11938	lousy skeleton war fuel can	4	decent	
 11939	skeleton war grenade	0		
 11940	blinking chocolate and nylons detector	0		
@@ -11804,7 +11804,7 @@
 11949	nippy bully badge	0		Cold Damage: +10, Lasts Until Rollover, Last Available: "2025-08"
 11950	frosty time cop top hat	0		Cold Spell Damage: +10, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	compressed squat blurry mixed berry jelly	1		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 10, Last Available: "2025-08"
+11952	compressed blurry squat mixed berry jelly	1		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 10, Last Available: "2025-08"
 11953	adequate toast with mixed berry jelly	3	good	Last Available: "2025-08"
 11954	stale cup of sugar	3	decent	Last Available: "2025-08"
 11955	rotten small wobbly Susie's cupcake	2	crappy	Last Available: "2025-08"
@@ -11814,7 +11814,7 @@
 11960	shaking really, really nice swimming trunks	0		
 11961	bouncing sand penny	0		
 11962	maroon undersea surveying goggles of incineration	0		Hot Spell Damage: +50, Lasts Until Rollover
-11963	watered-down perfectly mixed Ocean-Touched Rum	2	EPIC	
+11963	perfectly mixed watered-down Ocean-Touched Rum	2	EPIC	
 11964	vaporized lime green water-logged pill	1		
 11965	adequate jittery kelp puck	4	good	
 11966	skewed scroll of sea strength	0		
@@ -11826,16 +11826,16 @@
 11972	blinking durable dolphin whistle	0		
 11973	mirror Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	nippy dentadent	0		Cold Damage: +10
 11986	pulsating lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	executive inspector's rosewater-soaked Lo Pan's grievous beefy blood cubic zirconia	0		Muscle: +10, Weapon Damage Percent: +50, Spell Critical Percent: +30, Stench Resistance: +3, Item Drop: +15, Meat Drop: +40, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	executive inspector's rosewater-soaked Lo Pan's grievous beefy blood cubic zirconia	0		Muscle: +10, Weapon Damage Percent: +50, Spell Critical Percent: +30, Stench Resistance: +3, Item Drop: +15, Meat Drop: +40, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	modified blurry skewed blood thinner	1		Effect: "Disdain of the Storm Tortoise", Effect Duration: 40, Last Available: "2025-10"
 12045	artisanal pheromone cocktail	3	EPIC	Last Available: "2025-10"
-12046	adequate tiny lime green spinal tapas	1	good	Last Available: "2025-10"
-12047	pulsating huge shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	twirling zippy miser's baleful shrunken head	0		Spell Damage: +25, Meat Drop: +10, Initiative: +20, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12046	tiny adequate lime green spinal tapas	1	good	Last Available: "2025-10"
+12047	huge pulsating shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
+12048	twirling zippy miser's baleful shrunken head	0		Spell Damage: +25, Meat Drop: +10, Initiative: +20, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
@@ -11879,7 +11879,7 @@
 12121	blurry Crymbocurrency	0		Last Available: "2025-12"
 12122	razor-sharp extra-thick Crimbo sweater	0		Weapon Damage Percent: +25, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	high-proof hand-crafted Steve Abrams' Holiday Sampler Beer	9	EPIC	Last Available: "2025-12"
+12124	hand-crafted high-proof Steve Abrams' Holiday Sampler Beer	9	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	tolerable bottle of prize-winning rum	3	good	Last Available: "2025-12"
 12127	jittery narrow stanky toasty Santa-Slayer medal of terror	0		Hot Damage: +5, Stench Spell Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	quantum boiling synovial fluid	0		Effect: "The Solution", Effect Duration: 55, Last Available: "2025-12"
 12132	Oprah's Newton's Herculean smoldering vertebra	0		Experience (Muscle): +1, Experience (Mysticality): +3, Maximum MP Percent: +50, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	narrow smoldering bone dust	0		Last Available: "2025-12"
 12136	teal jittery volatile bone bomb	0		Last Available: "2025-12"
 12137	medical-grade Da Vinci's hot boning knife of the cougar	0		Moxie: +20, Experience (Mysticality): +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2025-12"
@@ -11897,7 +11897,7 @@
 12139	upside-down Tesla hardened Fonzie's burnt bone belt	0		Experience (Moxie): +1, Damage Reduction: 3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2025-12"
 12140	experienced scorched skull trophy	0		Experience: +2, Last Available: "2025-12"
 12141	tasty pulsating wing bone	4	awesome	Last Available: "2025-12"
-12142	artisanal watered-down fancy weak skeleton venom	2	EPIC	Effect: "OMG WTF", Effect Duration: 25, Last Available: "2025-12"
+12142	artisanal fancy watered-down weak skeleton venom	2	EPIC	Effect: "OMG WTF", Effect Duration: 25, Last Available: "2025-12"
 12143	boiled tumbling baked bone meal	1		Effect: "Hyperoxygenated Blood", Effect Duration: 20, Last Available: "2025-12"
 12144	plastic skeleton rib cage of the sewer	0		Stench Damage: +25, Last Available: "2025-12"
 12145	experienced plastic skeleton skull	0		Experience: +2, Last Available: "2025-12"
@@ -11927,8 +11927,8 @@
 12169	ship's lantern of the blizzard	0		Cold Spell Damage: +25, Last Available: "2025-12"
 12170	electrified wicked heat-resistant harpoon pistol	0		Spell Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-12"
 12171	delicious traditional gingerloaf	4	awesome	Last Available: "2025-12"
-12172	high-proof aged Scotch and eggnog	10	awesome	Last Available: "2025-12"
-12173	tarnished concentrated maroon upside-down counterskeleton elixir	0		Effect: "A Taste of Rainbow", Effect Duration: 20, Last Available: "2025-12"
+12172	aged high-proof Scotch and eggnog	10	awesome	Last Available: "2025-12"
+12173	tarnished concentrated upside-down maroon counterskeleton elixir	0		Effect: "A Taste of Rainbow", Effect Duration: 20, Last Available: "2025-12"
 12174	perfectly mixed watered-down teal &quot;salvaged&quot; wine	2	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	ghostly crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	improved pickled blinking gummi fingerbone	0		Effect: "Eyes of the Dragon", Effect Duration: 53
 12179	supercool glimmering crystal of Calamity Jane	0		Moxie Percent: +20, Critical Hit Percent: +15, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	cyan Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11959,7 +11959,7 @@
 12201	twirling Da Vinci's dinosaur bone club	0		Experience (Mysticality): +5, Last Available: "2026-03"
 12202	Sherlock's boxer's dinosaur skull helmet	0		Muscle Percent: +10, Item Drop: +25, Last Available: "2026-03"
 12203	mirror gravedigger's personal trainer's dinosaur bone corset of the storm	0		Experience Percent (Muscle): +10, Maximum MP Percent: +40, Spooky Damage: +10, Last Available: "2026-03"
-12204	hand-crafted watered-down wobbly Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
+12204	watered-down hand-crafted wobbly Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	blurry Pork Elf sink	0		Last Available: "2026-03"
@@ -11977,38 +11977,38 @@
 12222	squat pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	rotten snack-sized can of tuna	2	crappy	
+12226	snack-sized rotten can of tuna	2	crappy	
 12227	flavorless alien salad	3	decent	
-12228	rotten half-sized ratbatatouille	2	crappy	
+12228	half-sized rotten ratbatatouille	2	crappy	
 12229	small bland tumbling onigiri	2	decent	
 12230	adequate huge crudit&eacute;s	9	good	
-12231	immense spoiled narrow sauced mutton	9	crappy	
+12231	spoiled immense narrow sauced mutton	9	crappy	
 12232	rotten huge purple hot honey ant	9	crappy	
 12233	bland tomb aspic	3	decent	
-12234	adequate snack-sized shaking later tots	2	good	
+12234	snack-sized adequate shaking later tots	2	good	
 12235	flavorless Frutti di Scatoletta	4	decent	Last Available: "2026-05"
 12236	adequate spinning Pesto alla Marziano	3	good	Last Available: "2026-05"
 12237	normal immense blinking Arrattabbattabiata	10	good	Last Available: "2026-05"
 12238	delicious Orzo di Riso	3	awesome	Last Available: "2026-05"
-12239	adequate snack-sized Pasta Grimavera	2	good	Last Available: "2026-05"
+12239	snack-sized adequate Pasta Grimavera	2	good	Last Available: "2026-05"
 12240	rotten blinking Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
-12241	jumbo normal Formica e Pepe	5	good	Last Available: "2026-05"
+12241	normal jumbo Formica e Pepe	5	good	Last Available: "2026-05"
 12242	delicious Tubetto Gelatto	3	awesome	Last Available: "2026-05"
-12243	enchanted moldy pulsating Gnocci Domani	3	crappy	Effect: "Cringle's Curative Carol", Effect Duration: 45, Last Available: "2026-05"
-12244	ghostly bouncing Thwaitgold wallet moth statuette	0		
+12243	moldy enchanted pulsating Gnocci Domani	3	crappy	Effect: "Cringle's Curative Carol", Effect Duration: 45, Last Available: "2026-05"
+12244	bouncing ghostly Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	lime green second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	squat mega helmet	0		
 12252	greasy smelly Space Soldier Helmet	0		Stench Spell Damage: +10, Sleaze Spell Damage: +10
-12253	jumbo spoiled premium turkey leg	5	crappy	
-12254	smooth high-proof styrofoam cup of mead	10	awesome	
+12253	spoiled jumbo premium turkey leg	5	crappy	
+12254	high-proof smooth styrofoam cup of mead	10	awesome	
 12255	ghostly deadly sword	0		Weapon Damage: +5
 12256	deadly staff	0		Weapon Damage: +5
 12257	grievous lute	0		Weapon Damage Percent: +50
 12258	shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	olive double-paned The Wizard's Android of the bloodbag of the glutton	0		Maximum HP: +100, Cold Resistance: +5, Food Drop: +100
-12261	shaking upside-down teal flash paperwad	0		
+12261	upside-down teal shaking flash paperwad	0		
 12262	gray juggling ball	0		
 12263	purple banded tactical jester's cap of the empath	0		Damage Absorption: +100, Familiar Weight: +5, Combat Item Damage Percent: 50
 12264	single-use sword	0		
@@ -12017,7 +12017,7 @@
 12267	stylish flimsy plastic breastplate	0		Moxie: +25
 12268	flimsy plastic shield of dire peril	0		Weapon Damage: +20, Damage Reduction: 3
 12269	blinking packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	squat fireproof Portable Laughing Stock of the pedagogue of the cheetah	0		Experience: +3, Hot Resistance: +3, Initiative: +60, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	squat fireproof Portable Laughing Stock of the pedagogue of the cheetah	0		Experience: +3, Hot Resistance: +3, Initiative: +60, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	slick Staff of Anachronistic Churning of the pedagogue of doom	0		Moxie: +10, Experience: +3, Spooky Spell Damage: +50
 12272	adequate maroon classic banana	4	good	Last Available: "2026-07"
 12273	immense decent watermelon	10	good	Last Available: "2026-07"
@@ -12042,7 +12042,7 @@
 12292	artisanal pulsating Roth IPA	3	EPIC	Last Available: "2026-08"
 12293	strapping underdraft protection of Leguizamo	0		Muscle: +5, Monster Level: +20, Last Available: "2026-08"
 12294	pulsating yellow solvent	0		Last Available: "2026-08"
-12295	rotten low-calorie special pulsating soybean futures	1	crappy	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 15, Last Available: "2026-08"
+12295	special rotten low-calorie pulsating soybean futures	1	crappy	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 15, Last Available: "2026-08"
 12296	galvanized housing bubble	0		Effect: "Hare-o-dynamic", Effect Duration: 63, Last Available: "2026-08"
 12297	double-pickled chilled Pixie-Swordz	0		Effect: "Dreadful Chill", Effect Duration: 39
 12298	Sinatra's stylish financial instrument	0		Moxie: +25, Experience (Moxie): +5, Last Available: "2026-08"
@@ -12052,7 +12052,7 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	zippy sizzling 401k ring	0		Hot Damage: +10, Initiative: +20, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
-12305	aerosolized huge yellow invisible hand	0		Effect: "Fit To Be Tide", Effect Duration: 42, Last Available: "2026-08"
+12305	aerosolized yellow huge invisible hand	0		Effect: "Fit To Be Tide", Effect Duration: 42, Last Available: "2026-08"
 12306	tarnished moist circle of overdraft protection scroll	0		Effect: "Patent Alacrity", Effect Duration: 51, Last Available: "2026-08"
 12307	energized mint	0		Effect: "Macho, Macho Dog", Effect Duration: 33, Last Available: "2026-08"
 12308	yellow savings bondo	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Opossum_cafe_booze.txt
@@ -1,32 +1,32 @@
--1	hand-crafted irresponsibly strong Petite Porter	8	EPIC	
--2	weak lousy Scrawny Stout	2	decent	
+-1	irresponsibly strong hand-crafted Petite Porter	8	EPIC	
+-2	lousy weak Scrawny Stout	2	decent	
 -3	artisanal Infinitesimal IPA	3	EPIC	
 -4	artisanal eggnogtini	3	EPIC	
--5	practically non-alcoholic bad skewed candycaine	1	decent	
+-5	bad practically non-alcoholic skewed candycaine	1	decent	
 -6	lousy gray narrow braincracker sweet	3	decent	
 -16	mediocre fermented honey	3	decent	
 -17	acceptable practically non-alcoholic twirling moons-shine	1	good	
 -18	fortified drinkable gin	5	good	
 -19	perfectly mixed ecto-nog	3	EPIC	
--20	enchanted high-proof perfectly mixed hot toady	6	EPIC	
+-20	perfectly mixed enchanted high-proof hot toady	6	EPIC	
 -21	fortified perfectly mixed twirling hot choculate	5	EPIC	
 -49	artisanal Cyder	4	EPIC	
--50	weak artisanal enchanted Oil Nog	2	EPIC	
--51	aged irresponsibly strong enchanted Hi-Octane Peppermint Jet Fuel	7	awesome	
--58	fancy weak acceptable blue Grimacider	2	good	
+-50	enchanted weak artisanal Oil Nog	2	EPIC	
+-51	aged enchanted irresponsibly strong Hi-Octane Peppermint Jet Fuel	7	awesome	
+-58	acceptable weak fancy blue Grimacider	2	good	
 -59	watered-down perfectly mixed Isotope Nog	2	EPIC	
 -60	drinkable Mutagin 'n' Tonic	3	good	
--70	fortified artisanal Gin and Herring	5	EPIC	
+-70	artisanal fortified Gin and Herring	5	EPIC	
 -71	hand-crafted Black and Tan and Red All Over	3	EPIC	
--72	triple-distilled mediocre Antarctic Ice Tea	6	decent	
+-72	mediocre triple-distilled Antarctic Ice Tea	6	decent	
 -76	mediocre twirling CRIMBCO Ribbon Candy Schnapps	3	decent	
 -77	mediocre CRIMBCO Egg Substitute Nog Substitute	3	decent	
 -78	bad CRIMBCO Extreme Braincracker Sour	4	decent	
--82	enchanted acceptable practically non-alcoholic Horseradish-infused Vodka	1	good	
+-82	acceptable practically non-alcoholic enchanted Horseradish-infused Vodka	1	good	
 -83	bad olive Jerkitini	4	decent	
 -84	hand-crafted Desert Island Iced Tea	4	EPIC	
 -88	tolerable practically non-alcoholic huge Crimbo Saketini	1	good	
--89	delicious strong red Crimboku Drop	5	awesome	
+-89	strong delicious red Crimboku Drop	5	awesome	
 -90	tolerable Flaming Crimbo Log	3	good	
 -107	mediocre practically non-alcoholic Fortified Eggnog Slurry	1	decent	
 -108	tolerable spinning bouncing Hot Buttered Rum	3	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Opossum_cafe_food.txt
@@ -6,16 +6,16 @@
 -9	rotten gingerbread stir-fry	3	crappy	
 -10	decent twigs and gravel	3	good	
 -11	decent yellow shoots and leaves	3	good	
--12	tiny enchanted toothsome ghostly bowl of unidentifiable goo	1	awesome	
+-12	enchanted tiny toothsome ghostly bowl of unidentifiable goo	1	awesome	
 -13	tiny flavorless twirling gingerbread massacre	1	decent	
 -14	special flavorless snack-sized It Came From Beyond Dessert	2	decent	
 -15	flavorless vampire cake	4	decent	
--52	half-sized delicious Soylent Red and Green	2	awesome	
+-52	delicious half-sized Soylent Red and Green	2	awesome	
 -53	stale gray Disc-Shaped Nutrition Unit	3	decent	
 -54	moldy Gingerborg Hive	4	crappy	
 -61	small toothsome Candy Cane Surprise	2	awesome	
 -62	thick tasty Grimdrop Chow Mein	5	awesome	
--63	stale miniature Grimgerbread House	2	decent	
+-63	miniature stale Grimgerbread House	2	decent	
 -67	moldy Caviar Carbonara	4	crappy	
 -68	bland immense Halibut Alfredo	6	decent	
 -69	moldy snack-sized Red Herring Velvet Cake	2	crappy	
@@ -23,12 +23,12 @@
 -74	rotten blue twirling New and Improved CRIMBCO Reconstituted Gruel	3	crappy	
 -75	bland CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
 -79	snack-sized delicious shaking Brussels Sprout Stir-Fry	2	awesome	
--80	adequate snack-sized Carrot, Cabbage, and Kale Pizza	2	good	
+-80	snack-sized adequate Carrot, Cabbage, and Kale Pizza	2	good	
 -81	small moldy Turnip and Rutabaga Pie	2	crappy	
 -85	rotten Rainbow Spider Fun Roll	3	crappy	
--86	stale low-calorie Vegas Volcano Lava Roll	1	decent	
--87	rotten half-sized Crazy Dragon Shogun Buddha Roll	2	crappy	
--92	small bland huge basic hot dog	2	decent	
+-86	low-calorie stale Vegas Volcano Lava Roll	1	decent	
+-87	half-sized rotten Crazy Dragon Shogun Buddha Roll	2	crappy	
+-92	bland small huge basic hot dog	2	decent	
 -93	stale savage macho dog	4	decent	
 -94	toothsome immense blinking one with everything	8	awesome	
 -95	stale sly dog	4	decent	
@@ -36,10 +36,10 @@
 -97	rotten jumbo chilly dog	5	crappy	
 -98	rotten ghost dog	4	crappy	
 -99	spoiled junkyard dog	3	crappy	
--100	enchanted spoiled miniature wet dog	2	crappy	
+-100	spoiled miniature enchanted wet dog	2	crappy	
 -101	flavorless gray blurry sleeping dog	3	decent	
 -102	moldy optimal dog	3	crappy	
--103	gigantic adequate huge video games hot dog	6	good	
--104	normal maroon blurry Peppermint Nutrition Block	4	good	
--105	enchanted bland Gingerbread Nutrition Block	4	decent	
--106	half-sized normal Cinnamon Nutrition Block	2	good	
+-103	adequate gigantic huge video games hot dog	6	good	
+-104	normal blurry maroon Peppermint Nutrition Block	4	good	
+-105	bland enchanted Gingerbread Nutrition Block	4	decent	
+-106	normal half-sized Cinnamon Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Packrat.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Packrat.txt
@@ -2,7 +2,7 @@
 2	pulsating seal tooth	0		
 3	crafty helmet turtle	0		Maximum MP: +10, Familiar Effect: "atk, cap 2"
 4	turtle totem	0		
-5	ghostly squat pasta spoon	0		
+5	squat ghostly pasta spoon	0		
 6	ravioli hat of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, cap 2"
 7	spinning saucepan	0		
 8	spices	0		
@@ -12,11 +12,11 @@
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	powdered fuchsia moxie weed	1		
 15	dehydrated strongness elixir	1		
-16	boiled mirror teal magicalness-in-a-can	1		
+16	boiled teal mirror magicalness-in-a-can	1		
 17	fancy tasty noodles	4	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 30
 18	lime green tortoise's blessing	0		
 19	reassuring asparagus knife	0		Spooky Resistance: +1
-20	squat ghostly Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
+20	ghostly squat Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	shaking sweet ninja sword	0		
 22	studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
@@ -24,7 +24,7 @@
 25	twirling meat paste	0		
 26	Dolphin King's map	0		
 27	spider web	0		
-28	spinning gray really spider web	0		
+28	gray spinning really spider web	0		
 29	skewed really really spider web	0		
 30	blinking rock	0		
 31	seal-toothed rock	0		
@@ -57,7 +57,7 @@
 58	pulsating stone turtle	0		
 59	slingshot	0		
 60	fuchsia Mace of the Tortoise of the bloodbag	0		Maximum HP: +100, Class: "Turtle Tamer"
-61	normal snack-sized fortune cookie	2	good	
+61	snack-sized normal fortune cookie	2	good	
 62	bouncing chaotic oriole-feather headdress	0		Spell Critical Percent: +10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	pulsating action figure head	0		
@@ -79,7 +79,7 @@
 80	fairy gravy boat	0		
 81	mediocre ice-cold Willer	4	decent	
 82	ring	0		
-83	olive ghostly shaft	0		
+83	ghostly olive shaft	0		
 84	Orcish meat locker	0		
 85	unlocked meat locker	0		
 86	key	0		
@@ -96,12 +96,12 @@
 97	sinister Da Vinci's pimpin' meat hat	0		Experience (Mysticality): +5, Spell Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 13"
 98	cyan dried face	0		
 99	fuchsia meat face	0		
-100	blurry upside-down lifeless meat doll	0		
+100	upside-down blurry lifeless meat doll	0		
 101	meat golem	0		
 102	shrunken head	0		
 103	bouncing frosty educational staff	0		Experience: +1, Cold Spell Damage: +10
 104	scarecrow	0		
-105	half-sized normal teal bowl of charms	2	good	
+105	normal half-sized teal bowl of charms	2	good	
 106	ketchup	1	decent	
 107	catsup	1	awesome	
 108	stick	0		
@@ -161,12 +161,12 @@
 162	stale ghuol egg quiche	3	decent	
 163	upside-down razor-sharp skeleton bone	0		Weapon Damage Percent: +25
 164	smart skull	0		
-165	narrow twirling skewer	0		
+165	twirling narrow skewer	0		
 166	blinking ghuol ears	0		
 167	special bland ghuol-ear kabob	3	decent	Effect: "Protection from Bad Stuff", Effect Duration: 45
 168	blue coward's bone rattle	0		Monster Level: -20
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
-170	blue upside-down lihc eye	0		
+170	upside-down blue lihc eye	0		
 171	normal lihc eye pie	3	good	
 172	pulsating gnoll lips	0		
 173	taco shell	0		
@@ -196,8 +196,8 @@
 198	blinking rat appendix	0		
 199	ghostly ring of the cougar	0		Moxie: +20
 200	tasty rat appendix kabob	4	awesome	
-201	massive decent bat wing kabob	6	good	
-202	enchanted miniature normal blue carob chunks	2	good	Effect: "Salt Rockin'", Effect Duration: 15
+201	decent massive bat wing kabob	6	good	
+202	miniature enchanted normal blue carob chunks	2	good	Effect: "Salt Rockin'", Effect Duration: 15
 203	yellow herbs	0		
 204	moldy carob chunk cookies	4	crappy	
 205	secret blend of herbs and spices	0		
@@ -211,7 +211,7 @@
 213	Sherlock's filthy corduroys of courage	0		Spooky Resistance: +3, Item Drop: +25, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	fuchsia filthy knitted dread sack of the glutton	0		Food Drop: +100, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	stale small carob brownies	2	decent	
+216	small stale carob brownies	2	decent	
 217	tasty herb brownies	3	awesome	
 218	upside-down hemp string	0		
 219	tumbling squat lime green necklace chain	0		
@@ -232,32 +232,32 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	Lo Pan's Herculean Bigger Bugfinder Blade	0		Experience (Muscle): +1, Spell Critical Percent: +30
 236	Queue Du Coq cocktailcrafting kit	0		
-237	practically non-alcoholic drinkable twirling teal bottle of gin	1	good	
+237	drinkable practically non-alcoholic teal twirling bottle of gin	1	good	
 238	lousy bottle of vodka	3	decent	
 239	purple MacGyver's grievous Orcish baseball cap	0		Weapon Damage Percent: +50, Maximum MP: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	thinker's Orcish cargo shorts of the overflowing toilet	0		Mysticality: +10, Stench Spell Damage: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	jittery Orcish frat-paddle of the overflowing toilet	0		Stench Spell Damage: +50
-242	tiny stale upside-down	1	decent	
-243	decent miniature grapefruit	2	good	
-244	rotten big grapes	5	crappy	
-245	snack-sized flavorless olive	2	decent	
-246	small moldy tomato	2	crappy	
+242	stale tiny upside-down	1	decent	
+243	miniature decent grapefruit	2	good	
+244	big rotten grapes	5	crappy	
+245	flavorless snack-sized olive	2	decent	
+246	moldy small tomato	2	crappy	
 247	fermenting powder	0		
 248	perfectly mixed salty dog	3	EPIC	
 249	mediocre bloody mary	3	decent	
 250	drinkable screwdriver	4	good	
 251	mediocre martini	3	decent	
 252	tolerable bloody beer	3	good	
-253	special lousy shot of schnapps	4	decent	Effect: "Infernal Thirst", Effect Duration: 40
-254	tolerable practically non-alcoholic shot of grapefruit schnapps	1	good	
+253	lousy special shot of schnapps	4	decent	Effect: "Infernal Thirst", Effect Duration: 40
+254	practically non-alcoholic tolerable shot of grapefruit schnapps	1	good	
 255	tolerable practically non-alcoholic fine wine	1	good	
-256	practically non-alcoholic hand-crafted shot of tomato schnapps	1	EPIC	
+256	hand-crafted practically non-alcoholic shot of tomato schnapps	1	EPIC	
 257	perfectly mixed extra-spicy bloody mary	4	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
-260	enchanted bland White Citadel fries	3	decent	Effect: "Hyphemariffic", Effect Duration: 35
+260	bland enchanted White Citadel fries	3	decent	Effect: "Hyphemariffic", Effect Duration: 35
 261	bland White Citadel burger	3	decent	
-262	special toothsome piece of wedding cake	3	awesome	Effect: "Heart of Green", Effect Duration: 20
+262	toothsome special piece of wedding cake	3	awesome	Effect: "Heart of Green", Effect Duration: 20
 263	special rotten chocolate chips	4	crappy	Effect: "Stimulated Brain", Effect Duration: 25
 264	tiny fancy flavorless chocolate chip cookies	1	decent	Effect: "Hip to Be Square Dancin'", Effect Duration: 50
 265	beefcake's satin pants	0		Muscle: +25, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -294,10 +294,10 @@
 296	fortified dungeoneer's dungarees	0		Damage Absorption: +60, Familiar Effect: "stench atk, 4xPotato, cap 7"
 297	deionized altered cyan tamarind-flavored chewing gum	0		Effect: "Very Clean Guns", Effect Duration: 35
 298	improved lime-and-chile-flavored chewing gum	0		Effect: "Crying, Dying", Effect Duration: 51
-299	corrupted skewed upside-down pickle-flavored chewing gum	0		Effect: "Haunted Stomach", Effect Duration: 20
+299	corrupted upside-down skewed pickle-flavored chewing gum	0		Effect: "Haunted Stomach", Effect Duration: 20
 300	ionized upside-down jaba&ntilde;ero-flavored chewing gum	0		Effect: "Booing Radly", Effect Duration: 53
 301	blinking flat dough	0		
-302	rotten massive ghostly Knob sausage	9	crappy	
+302	massive rotten ghostly Knob sausage	9	crappy	
 303	moldy Knob mushroom	4	crappy	
 304	bouncing dry noodles	0		
 305	Knob Goblin harem pants of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -309,12 +309,12 @@
 311	hill of beans	0		
 312	pulsating avaricious Knob Goblin visor	0		Meat Drop: +30, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	bouncing energetic Crown of the Goblin King	0		Maximum MP Percent: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	moldy snack-sized bean burrito	2	crappy	
+314	snack-sized moldy bean burrito	2	crappy	
 315	flavorless bean burrito	3	decent	
 316	flavorless jittery insanely bean burrito	4	decent	
 317	half-sized yummy bean burrito	2	awesome	
-318	stale gigantic blurry bean burrito	7	decent	
-319	adequate bite-sized insanely bean burrito	1	good	
+318	gigantic stale blurry bean burrito	7	decent	
+319	bite-sized adequate insanely bean burrito	1	good	
 320	spoiled super-sized squat bat haggis	5	crappy	
 321	rotten thick menudo	5	crappy	
 322	adequate miniature goat cheese	2	good	
@@ -322,12 +322,12 @@
 324	rotten upside-down fuchsia sausage pizza	3	crappy	
 325	bland goat cheese pizza	3	decent	
 326	delicious blurry mushroom pizza	4	awesome	
-327	blinking twirling goat	0		
+327	twirling blinking goat	0		
 328	lousy fancy watered-down bottle of whiskey	2	decent	Effect: "Gleaming White Teeth", Effect Duration: 35
 329	blinking avaricious goat beard	0		Meat Drop: +30, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	decent	
 331	tolerable Canadian	3	good	
-332	rotten small wobbly red lemon	2	crappy	
+332	small rotten red wobbly lemon	2	crappy	
 333	super-sized adequate lime	5	good	
 334	Newton's sabre teeth	0		Experience (Mysticality): +3
 335	sabre-toothed lime cub	0		
@@ -336,7 +336,7 @@
 338	tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
 340	frozen dry Knob Goblin steroids	0		Effect: "Gummiskin", Effect Duration: 37
-341	irradiated spinning jittery Knob Goblin love potion	0		Effect: "Vented Spleen", Effect Duration: 55
+341	irradiated jittery spinning Knob Goblin love potion	0		Effect: "Vented Spleen", Effect Duration: 55
 342	Knob Goblin stink bomb	0		
 343	activated oxidized Knob Goblin sharpening spray	0		Effect: "Experimental Effect G-9", Effect Duration: 14
 344	Knob Goblin seltzer	0		
@@ -353,8 +353,8 @@
 355	ghostly eXtreme scarf of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	skewed blinking snowboarder pants of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	small spoiled gr8ps	2	crappy	
-359	enchanted adequate thick t8r tots	5	good	Effect: "Litterboxing", Effect Duration: 10
+358	spoiled small gr8ps	2	crappy	
+359	adequate thick enchanted t8r tots	5	good	Effect: "Litterboxing", Effect Duration: 10
 360	slick miner's helmet	0		Moxie: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	Rosewater's miner's pants	0		Mysticality Percent: +30, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	Da Vinci's 7-Foot Dwarven mattock	0		Experience (Mysticality): +5
@@ -402,9 +402,9 @@
 404	acoustic guitarrr of the cheetah	0		Initiative: +60
 405	sunken chest	0		
 406	pirate pelvis	0		
-407	tumbling squat pirate skull	0		
+407	squat tumbling pirate skull	0		
 408	blurry pirate skeleton	0		
-409	shaking blurry vial of patchouli oil	0		
+409	blurry shaking vial of patchouli oil	0		
 410	sk8board of the sweet-tooth	0		Candy Drop: +100
 411	spinning Jolly Roger charrrm	0		
 412	barrrnacle	0		
@@ -420,7 +420,7 @@
 422	adjusted quantum potion of potency	0		Effect: "Ruby-ous", Effect Duration: 51
 423	triple-adjusted activated cordial of concentration	0		Effect: "Moon-Eyed", Effect Duration: 61
 424	concentrated ointment of the occult	0		Effect: "Discomfited", Effect Duration: 56
-425	polarized lime green bouncing oil of expertise	0		Effect: "Spooky Demeanor", Effect Duration: 19
+425	polarized bouncing lime green oil of expertise	0		Effect: "Spooky Demeanor", Effect Duration: 19
 426	magnetized extra-electrified blurry potion of temporary gr8ness	0		Effect: "Fire Inside", Effect Duration: 28
 427	upside-down healthy box	0		Maximum HP Percent: +20, Wiki Name: "box"
 428	ghostly nothing-in-the-box	0		
@@ -447,13 +447,13 @@
 449	teal mansplainer's clown nose	0		Monster Level: +15, Clowniness: 25
 450	pretentious paintbrush	0		
 451	pretentious palette	0		
-452	narrow bouncing disease	0		
+452	bouncing narrow disease	0		
 453	sober pill	0		
 454	screwdriver	0		
 455	normal half-sized jumbo olive	2	good	
-456	weak smooth dry martini	2	awesome	
+456	smooth weak dry martini	2	awesome	
 457	healthy ye olde golde frontes	0		Maximum HP Percent: +20, Class: "Disco Bandit", Single Equip
-458	red skewed continuum transfunctioner	0		
+458	skewed red continuum transfunctioner	0		
 459	teal pixel	0		
 460	blurry pixel	0		
 461	pixel	0		
@@ -461,12 +461,12 @@
 463	squat pixel	0		
 464	pixel potion	0		
 465	pixel potion	0		
-466	blue spinning pixel potion	0		
-467	stale huge jittery upside-down pixel pie	4	decent	
+466	spinning blue pixel potion	0		
+467	stale huge upside-down jittery pixel pie	4	decent	
 468	ruby W	0		
 469	blinking yellow wussiness potion	0		
 470	practically non-alcoholic delicious Imp Ale	1	awesome	
-471	adequate jumbo huge hot wing	5	good	
+471	jumbo adequate huge hot wing	5	good	
 472	stanky diamond-studded cane	0		Stench Spell Damage: +25, Class: "Disco Bandit"
 473	tumbling executive crutch	0		Meat Drop: +40
 474	cast	0		
@@ -508,7 +508,7 @@
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	thick moldy twirling Boris's key lime pie	5	crappy	
+513	moldy thick twirling Boris's key lime pie	5	crappy	
 514	bland Jarlsberg's key lime pie	4	decent	
 515	bland huge Sneaky Pete's key lime pie	9	decent	
 516	Hey Deze map	0		
@@ -538,7 +538,7 @@
 540	pickled skewed Tasty Fun Good rice candy	0		Effect: "Coy to the Hurled", Effect Duration: 47
 541	Annie Oakley's brawny draggin' ball hat	0		Muscle Percent: +20, Critical Hit Percent: +20, Familiar Effect: "atk, 1xVolley, cap 25"
 542	sharpshooter's dangerous 1337 7r0uZ0RZ	0		Weapon Damage: +10, Critical Hit Percent: +10, Familiar Effect: "2xPotato, cap 27"
-543	adequate diet Trollhouse cookies	1	good	
+543	diet adequate Trollhouse cookies	1	good	
 544	tumbling talons of the empath of temperance	0		Familiar Weight: +5, Sleaze Resistance: +5
 545	flavorless Spam Witch sammich	4	decent	
 546	meat vortex	0		
@@ -553,7 +553,7 @@
 555	narrow family-friendly supercharged drywall axe	0		Maximum MP Percent: +30, Sleaze Resistance: +1
 556	huge Pine-Fresh air freshener of the scaredy-cat	0		Monster Level: -15
 557	artisanal skewed tumbling whiskey and cola	4	EPIC	
-558	moldy enchanted tiny papaya taco	1	crappy	Effect: "Virgo Rising", Effect Duration: 30
+558	moldy tiny enchanted papaya taco	1	crappy	Effect: "Virgo Rising", Effect Duration: 30
 559	yellow razor-sharp can lid	0		
 560	stale twirling stalk of asparagus	3	decent	
 561	pregnant mushroom	0		
@@ -567,7 +567,7 @@
 569	bite-sized stale Lord of the Flies-sized fries	1	decent	
 570	snack-sized bland Chicken Sandwich	2	decent	
 571	Jumbo Dr. Lucifer	1	decent	
-572	snack-sized stale Children's Meal of the Damned	2	decent	
+572	stale snack-sized Children's Meal of the Damned	2	decent	
 573	toothsome gray noodles	3	awesome	
 574	stale noodles	4	decent	
 575	half-sized decent painful penne pasta	2	good	
@@ -578,9 +578,9 @@
 580	blinking sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	bouncing Himalayan Hidalgo sauce	0		
-583	special decent fettucini Inconnu	3	good	Effect: "Pharmaceutically Cool", Effect Duration: 30
+583	decent special fettucini Inconnu	3	good	Effect: "Pharmaceutically Cool", Effect Duration: 30
 584	bland spinning spaghetti with Skullheads	3	decent	
-585	delicious miniature gnocchetti di Nietzsche	2	awesome	
+585	miniature delicious gnocchetti di Nietzsche	2	awesome	
 586	tumbling Usain Bolt's Annie Oakley's ridiculously huge sword	0		Critical Hit Percent: +20, Initiative: +80
 587	polarized green blurry super-spiky hair gel	0		Effect: "Well Owl Be!", Effect Duration: 39
 588	soft echo eyedrop antidote	0		
@@ -596,7 +596,7 @@
 598	cyan the Slug Lord's map	0		
 599	Sinatra's pants of the Slug Lord	0		Experience (Moxie): +5, Familiar Effect: "stench atk, 3xPotato, cap 8"
 600	foul-smelling friendly Dr. Hobo's scalpel	0		Familiar Weight: +3, Stench Damage: +10
-601	huge jittery Dr. Hobo's map	0		
+601	jittery huge Dr. Hobo's map	0		
 602	Degrassi Knoll shopping list	0		
 603	olive Item #13	0		
 604	Penultimate Fantasy chest	0		
@@ -610,7 +610,7 @@
 612	original G	0		
 613	plot hole	0		
 614	tarnished probability potion	0		Effect: "Dweeby", Effect Duration: 59
-615	upside-down squat chaos butterfly	0		
+615	squat upside-down chaos butterfly	0		
 616	pulsating furry fur	0		
 617	anodized Angry Farmer candy	0		Effect: "Spore-Wreathed", Effect Duration: 68
 618	ionized double-alkaline frozen Mick's IcyVapoHotness Rub	0		Effect: "Spiky Hair", Effect Duration: 34
@@ -642,10 +642,10 @@
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
 646	bland fruitcake	3	decent	
-647	ghostly jittery present	0		Last Available: "2004-11"
+647	jittery ghostly present	0		Last Available: "2004-11"
 648	chaotic Crimbo sword	0		Spell Critical Percent: +10, Last Available: "2004-10"
-649	olive sharpshooter's Crimbo hat	0		Critical Hit Percent: +10, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	frightening Crimbo pants	0		Spooky Damage: +5, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	olive sharpshooter's Crimbo hat	0		Critical Hit Percent: +10, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	frightening Crimbo pants	0		Spooky Damage: +5, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	pulsating chilly exclusive ultra-rare item	0		Cold Damage: +5
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -662,23 +662,23 @@
 664	star starfish	0		
 665	Richard's star key	0		
 666	up-at-dawn chilly supercharged steaming evil	0		Maximum MP Percent: +30, Cold Damage: +5, Adventures: +5
-667	green squat castle map	0		
+667	squat green castle map	0		
 668	red blinking spiked femur of mayonnaise	0		Sleaze Spell Damage: +50
-669	flavorless enchanted massive ghuol guolash	9	decent	Effect: "I See Everything Thrice!", Effect Duration: 45
+669	flavorless massive enchanted ghuol guolash	9	decent	Effect: "I See Everything Thrice!", Effect Duration: 45
 670	beefcake's lihc face	0		Muscle: +25, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	Socratic smooth grave robbing shovel	0		Moxie: +15, Experience (Mysticality): +1
-672	stale miniature cranberries	2	decent	
+672	miniature stale cranberries	2	decent	
 673	practically non-alcoholic artisanal vodka and cranberry	1	EPIC	
-674	hand-crafted special gray whiskey	3	EPIC	Effect: "Celestial Body", Effect Duration: 5
+674	special hand-crafted gray whiskey	3	EPIC	Effect: "Celestial Body", Effect Duration: 5
 675	skull of the Bonerdagon of incineration	0		Hot Spell Damage: +50
 676	dragonbone belt buckle	0		
 677	hardy badass belt	0		Maximum HP: +50
 678	bouncing chest of the Bonerdagon	0		
-679	tolerable skewed red roll in the hay	3	good	
+679	tolerable red skewed roll in the hay	3	good	
 680	artisanal slap and tickle	3	EPIC	
-681	special tolerable slip 'n' slide	4	good	Effect: "Cool, Catlike", Effect Duration: 30
-682	weak hand-crafted a sump'm sump'm	2	EPIC	
-683	artisanal watered-down horizontal tango	2	EPIC	
+681	tolerable special slip 'n' slide	4	good	Effect: "Cool, Catlike", Effect Duration: 30
+682	hand-crafted weak a sump'm sump'm	2	EPIC	
+683	watered-down artisanal horizontal tango	2	EPIC	
 684	irresponsibly strong bad pink pony	9	decent	
 685	shaking scandalous stanky rosy-cheeked Mr. Shirt	0		Maximum HP Percent: +30, Stench Spell Damage: +25, Sleaze Damage: +5
 686	blinking lion tamer's knuckles	0		Experience (familiar): +2
@@ -742,7 +742,7 @@
 747	squat Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	adequate warm mushroom	3	good	
-750	gigantic adequate huge mushroom quesadilla	6	good	
+750	adequate gigantic huge mushroom quesadilla	6	good	
 751	flavorless cool mushroom	3	decent	
 752	bite-sized spoiled cool mushroom casserole	1	crappy	
 753	decent pointy mushroom	3	good	
@@ -750,13 +750,13 @@
 755	tasty mushroom	4	awesome	
 756	low-calorie rotten mushroom	1	crappy	
 757	massive spoiled mushroom	6	crappy	
-758	decent fancy miniature ghost cucumber	2	good	Effect: "Frostbeard", Effect Duration: 50
+758	fancy decent miniature ghost cucumber	2	good	Effect: "Frostbeard", Effect Duration: 50
 759	squat dill	0		
-760	ghostly blinking vinegar	0		
+760	blinking ghostly vinegar	0		
 761	brine	0		
 762	strong artisanal especially salty dog	5	EPIC	
 763	bouncing ghostly pickling solution	0		
-764	super-sized yummy blurry spectral pickle	5	awesome	
+764	yummy super-sized blurry spectral pickle	5	awesome	
 765	skewed briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	electrified super-modified polarized tumbling cologne of contempt	0		Effect: "Conspiratory Eyes", Effect Duration: 58
@@ -780,8 +780,8 @@
 785	raffle ticket	0		
 786	stale snack-sized upside-down strawberry	2	decent	
 787	perfectly mixed watered-down bottle of rum	2	EPIC	
-788	artisanal high-proof fancy strawberry daiquiri	8	EPIC	Effect: "Joyful Resolve", Effect Duration: 15
-789	fortified acceptable rum and cola	5	good	
+788	high-proof fancy artisanal strawberry daiquiri	8	EPIC	Effect: "Joyful Resolve", Effect Duration: 15
+789	acceptable fortified rum and cola	5	good	
 790	tolerable triple-distilled grog	7	good	
 791	forbidden extremely unsafe Mafia bow tie	0		Weapon Damage Percent: +100, Spell Damage Percent: +50, Last Available: "2004-10"
 792	yellow medical-grade Golden Mr. Accessory	0		HP Regen Min: 7, HP Regen Max: 10, Softcore Only
@@ -789,11 +789,11 @@
 794	moist wet corrupted teal oil of slipperiness	0		Effect: "Be a Mind Master", Effect Duration: 25
 795	perfectly mixed ghostly Acque Luride Grezze Cabernet	4	EPIC	Last Available: "2004-10"
 796	upside-down Oprah's Socratic savvy cement shoes	0		Mysticality Percent: +20, Experience (Mysticality): +1, Maximum MP Percent: +50, Last Available: "2004-10"
-797	practically non-alcoholic lousy mirror rockin' wagon	1	decent	
-798	watered-down fancy acceptable jittery ocean motion	2	good	Effect: "Toothy Grin", Effect Duration: 30
+797	lousy practically non-alcoholic mirror rockin' wagon	1	decent	
+798	acceptable fancy watered-down jittery ocean motion	2	good	Effect: "Toothy Grin", Effect Duration: 30
 799	lousy mirror fuzzbump	4	decent	
 800	spoiled fancy shaking poutine	4	crappy	Effect: "Far Out", Effect Duration: 25
-801	tiny stale Knob stir-fry	1	decent	
+801	stale tiny Knob stir-fry	1	decent	
 804	flavorless massive Knoll stir-fry	10	decent	
 805	rotten stir-fry	4	crappy	
 806	adequate asparagus stir-fry	3	good	
@@ -801,9 +801,9 @@
 808	normal gigantic Knob sausage stir-fry	9	good	
 809	normal cyan bat wing stir-fry	4	good	
 810	delicious rat appendix stir-fry	4	awesome	
-811	spoiled tiny huge bouncing tofu stir-fry	1	crappy	
+811	tiny spoiled bouncing huge tofu stir-fry	1	crappy	
 812	normal squat pr0n stir-fry	3	good	
-813	enchanted flavorless jittery Knob shells	4	decent	Effect: "Comprehensively Nourished", Effect Duration: 35
+813	flavorless enchanted jittery Knob shells	4	decent	Effect: "Comprehensively Nourished", Effect Duration: 35
 814	normal blue b&auml;tzle	3	good	
 815	decent half-sized ratini	2	good	
 816	spoiled Knob stroganoff	3	crappy	
@@ -831,10 +831,10 @@
 838	greedy Mafia stogie of the brute	0		Muscle Percent: +30, Meat Drop: +20, Last Available: "2004-10"
 839	hand-crafted Maiali Sifilitici Pinot Noir	3	super EPIC	Last Available: "2004-10"
 840	Mafia violin case of Tarzan of the cheetah	0		Experience (Muscle): +3, Initiative: +60, Last Available: "2004-10"
-841	special boozy drinkable tomato daiquiri	5	good	Effect: "Human-Beast Hybrid", Effect Duration: 40
+841	special drinkable boozy tomato daiquiri	5	good	Effect: "Human-Beast Hybrid", Effect Duration: 40
 842	drinkable irresponsibly strong beertini	6	good	
 843	hand-crafted salty slug	3	EPIC	
-844	hand-crafted triple-distilled blurry papaya slung	10	EPIC	
+844	triple-distilled hand-crafted blurry papaya slung	10	EPIC	
 845	yellow sharpshooter's MAHI fez	0		Critical Hit Percent: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	bouncing heteroerotic frat-paddle	0		
 848	blurry upside-down hypodermic needle	0		Familiar Weight: +5
@@ -856,7 +856,7 @@
 864	wobbly stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
 866	green shaving cream	0		
-867	alkaline aerosolized mirror skewed pine tar	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 25
+867	alkaline aerosolized skewed mirror pine tar	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 25
 869	blurry forest tears	0		
 870	huge ruddy fetus-smashing club	0		Maximum HP Percent: +40
 871	meatcar model	0		Familiar Weight: +5
@@ -881,7 +881,7 @@
 890	stale narrow balaclava baklava	4	decent	
 891	Warehouse 23 bling of horror	0		Spooky Spell Damage: +25
 892	blinking huge scorching supercharged bugbear-smiting sword of the wise owl	0		Mysticality: +20, Maximum MP Percent: +30, Hot Damage: +25
-893	practically non-alcoholic drinkable narrow blinking lumbering jack	1	good	
+893	drinkable practically non-alcoholic narrow blinking lumbering jack	1	good	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	narrow Fonzie's Ms. Accessory	0		Experience (Moxie): +1, Softcore Only
 896	Rosewater's Mr. Accessory Jr. of the dark arts	0		Mysticality Percent: +30, Spell Damage Percent: +100, Softcore Only
@@ -892,9 +892,9 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	acceptable Spasmi Dolorosi Del Rene Champagne	4	good	Last Available: "2004-10"
-904	blurry lard-coated nasty school Mafia knickerbockers of bravery	0		Stench Damage: +5, Sleaze Spell Damage: +25, Spooky Resistance: +5, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	blurry lard-coated nasty school Mafia knickerbockers of bravery	0		Stench Damage: +5, Sleaze Spell Damage: +25, Spooky Resistance: +5, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	pickled red Yummy Tummy bean	0		Effect: "Meadulla Oblongota", Effect Duration: 26
-906	corrupted squat tumbling Rock Pops	0		Effect: "Slimily Speedy", Effect Duration: 62
+906	corrupted tumbling squat Rock Pops	0		Effect: "Slimily Speedy", Effect Duration: 62
 907	polymerized narrow squat Mr. Mediocrebar	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 37
 908	deionized Cold Hots candy	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 44
 909	nitrogenated chilled dry wobbly Wint-O-Fresh mint	0		Effect: "Funky Coal Patina", Effect Duration: 65
@@ -906,8 +906,8 @@
 915	wobbly narrow yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fuchsia intergalactic pom poms of Leguizamo of incineration	0		Monster Level: +20, Hot Spell Damage: +50
 917	spinning Mob Penguin protection contract	0		
-918	bouncing smooth Radio Free Baseball Cap	0		Moxie: +15, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	pulsating sharpshooter's Radio Free Pants	0		Critical Hit Percent: +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	bouncing smooth Radio Free Baseball Cap	0		Moxie: +15, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	pulsating sharpshooter's Radio Free Pants	0		Critical Hit Percent: +10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	squat Radio Free Foil of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-07"
 921	normal radio button candy	3	good	
 922	hardened severed rocking horse head	0		Damage Reduction: 3
@@ -915,7 +915,7 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	jittery dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	irradiated teal Hawking's Elixir of Brilliance	0		Effect: "Arcane in the Brain", Effect Duration: 24
-927	weak tolerable Ferita Del Petto Zinfandel	2	good	Last Available: "2006-12"
+927	tolerable weak Ferita Del Petto Zinfandel	2	good	Last Available: "2006-12"
 928	blinking fuzzy bracelets of the storm	0		Maximum MP Percent: +40
 929	sizzling arse-shooting crossbow	0		Hot Damage: +10
 931	drinkable spiced rum	3	good	
@@ -929,22 +929,22 @@
 939	tumbling small Crimbo Pressie	0		Last Available: "2004-12"
 940	jittery bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	groovy bowler	0		Moxie Percent: +10, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	groovy bowler	0		Moxie Percent: +10, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	rosewater-soaked bow staff of Calamity Jane	0		Critical Hit Percent: +15, Stench Resistance: +3, Last Available: "2004-12"
-944	dangerous bowlegged pants	0		Weapon Damage: +10, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	dangerous bowlegged pants	0		Weapon Damage: +10, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	tumbling skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	ghostly skewered cherry	0		Last Available: "2004-12"
 948	artisanal teal martini	3	super ultra EPIC	Last Available: "2004-12"
 949	delicious grogtini	3	awesome	Last Available: "2004-12"
-950	high-proof drinkable special huge cherry bomb	8	good	Effect: "Charrrming", Effect Duration: 25, Last Available: "2004-12"
+950	drinkable high-proof special huge cherry bomb	8	good	Effect: "Charrrming", Effect Duration: 25, Last Available: "2004-12"
 951	twirling extra special Crimbo stocking	0		Last Available: "2004-12"
 952	hockey mask of the ox of temperance	0		Muscle: +20, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	yellow chilly fez of etymology	0		Cold Damage: +5, Familiar Effect: "1xLep, cap 30"
 956	adequate carob chunk noodles	3	good	
-957	special moldy diet chorizo brownies	1	crappy	Effect: "Thickest, Sickest", Effect Duration: 30
+957	diet moldy special chorizo brownies	1	crappy	Effect: "Thickest, Sickest", Effect Duration: 30
 958	thick stale chocolate and tomato pizza	5	decent	
 959	tumbling flange	0		
 960	huge clockwork key	0		
@@ -990,23 +990,23 @@
 1003	soda water	0		
 1004	aged distilled bottle of tequila	5	awesome	
 1005	hand-crafted boxed wine	3	EPIC	
-1006	half-sized rotten cherry	2	crappy	
+1006	rotten half-sized cherry	2	crappy	
 1007	spinning ghostly huge careful coconut shell	0		Monster Level: -10, Familiar Effect: "1xFairy, cap 7"
 1008	ice cubes of the cougar	0		Moxie: +20
-1009	high-proof lousy red vodka martini	9	decent	
+1009	lousy high-proof red vodka martini	9	decent	
 1010	acceptable whiskey and soda	3	good	
 1011	aged monkey wrench	4	awesome	
 1012	mediocre tequila sunrise	3	decent	
-1013	hand-crafted strong margarita	5	EPIC	
+1013	strong hand-crafted margarita	5	EPIC	
 1014	tolerable strawberry wine	3	good	
-1015	weak tolerable wine spritzer	2	good	
-1016	tolerable extra-dry shaking perpendicular hula	5	good	
+1015	tolerable weak wine spritzer	2	good	
+1016	extra-dry tolerable shaking perpendicular hula	5	good	
 1017	mediocre ducha de oro	4	decent	
 1018	artisanal strong calle de miel	5	EPIC	
 1019	delicious teal dry vodka martini	3	awesome	
-1020	drinkable watered-down old-fashioned	2	good	
-1021	irresponsibly strong mediocre shaking tequila with training wheels	8	decent	
-1022	acceptable weak sangria	2	good	
+1020	watered-down drinkable old-fashioned	2	good	
+1021	mediocre irresponsibly strong shaking tequila with training wheels	8	decent	
+1022	weak acceptable sangria	2	good	
 1023	boozy tolerable upside-down vesper	5	good	Last Available: "2004-12"
 1024	triple-distilled perfectly mixed teal bodyslam	9	EPIC	Last Available: "2004-12"
 1025	acceptable sangria del diablo	3	good	Last Available: "2004-12"
@@ -1022,22 +1022,22 @@
 1035	medical-grade penguin skin buckler	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 5
 1036	jittery flame-retardant yakskin buckler	0		Hot Resistance: +1, Damage Reduction: 5
 1037	skewed Usain Bolt's gnauga hide buckler	0		Initiative: +80, Damage Reduction: 5
-1038	double-corrupted improved narrow skewed Connery's Elixir of Audacity	0		Effect: "Craft Tea", Effect Duration: 50
+1038	double-corrupted improved skewed narrow Connery's Elixir of Audacity	0		Effect: "Craft Tea", Effect Duration: 50
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	artisanal special beer	3	EPIC	Effect: "Bureaucratized", Effect Duration: 40
 1042	lion tamer's string of beads	0		Experience (familiar): +2
 1043	teal string of beads of extreme caution	0		Monster Level: -25
 1044	miser's string of beads	0		Meat Drop: +10
 1045	plastic bottle opener of bravery	0		Spooky Resistance: +5
-1046	traffic cone of the blizzard of the detective	0		Cold Spell Damage: +25, Item Drop: +20, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	traffic cone of the blizzard of the detective	0		Cold Spell Damage: +25, Item Drop: +20, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	aged N. O. Beer	3	awesome	
 1048	altered mirror oyster egg	1		
-1049	distilled jittery red oyster egg	1		
+1049	distilled red jittery oyster egg	1		
 1050	diluted oyster egg	1		
 1051	plastic oyster egg	0		
 1052	compressed shaking narrow oyster egg	1		
 1053	twisted fuchsia oyster egg	1		
-1054	modified blurry blinking oyster egg	1		Effect: "Crocodile Tear", Effect Duration: 50
+1054	modified blinking blurry oyster egg	1		Effect: "Crocodile Tear", Effect Duration: 50
 1055	upside-down plastic oyster egg	0		
 1056	diluted wobbly wobbly puce oyster egg	1		
 1057	compressed pulsating puce oyster egg	1		
@@ -1045,7 +1045,7 @@
 1059	red puce plastic oyster egg	0		
 1060	altered mauve oyster egg	1		
 1061	twisted huge mauve oyster egg	1		
-1062	powdered tumbling skewed wobbly mauve oyster egg	1		
+1062	powdered wobbly skewed tumbling mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
 1064	vaporized jittery oyster egg	1		
 1065	modified oyster egg	1		Effect: "Flambé-a-thon", Effect Duration: 50
@@ -1128,7 +1128,7 @@
 1142	smooth jittery pointy mushroom wine	4	awesome	
 1143	smooth flat mushroom wine	3	awesome	
 1144	perfectly mixed blue cool mushroom wine	4	EPIC	
-1145	fortified mediocre special knob mushroom wine	5	decent	Effect: "Moon-Eyed", Effect Duration: 35
+1145	mediocre special fortified knob mushroom wine	5	decent	Effect: "Moon-Eyed", Effect Duration: 35
 1146	delicious knoll mushroom wine	3	awesome	
 1147	bad enchanted cyan mushroom wine	3	decent	Effect: "New and Improved", Effect Duration: 5
 1148	weak perfectly mixed shot of flower schnapps	2	EPIC	
@@ -1136,7 +1136,7 @@
 1150	distilled lousy bottle of single-barrel whiskey	5	decent	
 1151	narrow cyan bouncing executive dangerous discarded plastic fork	0		Weapon Damage: +10, Meat Drop: +40
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	small bland jittery Retenez L'Herbe Pat&eacute;	2	decent	
+1153	bland small jittery Retenez L'Herbe Pat&eacute;	2	decent	
 1154	twisted Breathetastic&trade; Premium Canned Air	1	decent	
 1155	twirling letter from King Ralph XI	0		
 1157	Van der Graaf wholeberd	0		MP Regen Min: 5, MP Regen Max: 7
@@ -1165,7 +1165,7 @@
 1180	potted fern	0		
 1181	bouncing tulip	0		
 1182	Venus flytrap	0		
-1183	bouncing spinning purple all-purpose flower	0		
+1183	purple spinning bouncing all-purpose flower	0		
 1184	exotic orchid	0		
 1185	teal wobbly long-stemmed rose	0		
 1186	gilded lily	0		
@@ -1185,11 +1185,11 @@
 1200	flavorless massive mugcake	10	decent	
 1201	yummy urinal cake	4	awesome	
 1202	spoiled shaking Happy Birthday, Claude! cake	4	crappy	
-1203	spoiled fancy blinking personalized birthday cake	3	crappy	Effect: "Sugary Tongue", Effect Duration: 15
+1203	fancy spoiled blinking personalized birthday cake	3	crappy	Effect: "Sugary Tongue", Effect Duration: 15
 1204	low-calorie special yummy ghostly three-tiered wedding cake	1	awesome	Effect: "Slimily Strong", Effect Duration: 35
 1205	big moldy babycakes	5	crappy	
 1206	tasty velvet cake	4	awesome	
-1207	enchanted stale huge congratulatory cake	3	decent	Effect: "Disco State of Mind", Effect Duration: 10
+1207	stale enchanted huge congratulatory cake	3	decent	Effect: "Disco State of Mind", Effect Duration: 10
 1208	spoiled angel-food cake	3	crappy	
 1209	spoiled devil's-food cake	4	crappy	
 1210	toothsome bouncing birthday party jellybean cheesecake	3	awesome	
@@ -1235,12 +1235,12 @@
 1251	flavorless Knob shroomkabob	4	decent	
 1252	normal shroomkabob	4	good	
 1253	pile of jumping beans	0		
-1254	miniature normal jumping bean burrito	2	good	
-1255	jumbo rotten bouncing jumping bean burrito	5	crappy	
-1256	jumbo delicious ghostly insanely jumping bean burrito	5	awesome	
+1254	normal miniature jumping bean burrito	2	good	
+1255	rotten jumbo bouncing jumping bean burrito	5	crappy	
+1256	delicious jumbo ghostly insanely jumping bean burrito	5	awesome	
 1257	rotten shaking rat scrapple	4	crappy	
 1258	pail of pretentious paint	0		
-1259	flame-wreathed traffic cone	0		Hot Spell Damage: +10, Item Drop: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	flame-wreathed traffic cone	0		Hot Spell Damage: +10, Item Drop: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	ghostly wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	distilled Hatorade	1		Effect: "Flagrantly Fragrant", Effect Duration: 20
 1262	lion tamer's off-hand balloon of the early riser	0		Experience (familiar): +2, Item Drop: +5, Adventures: +7
@@ -1252,7 +1252,7 @@
 1268	jittery pine wand	0		
 1269	ebony wand	0		
 1270	squat hexagonal wand	0		
-1271	twirling spinning aluminum wand	0		
+1271	spinning twirling aluminum wand	0		
 1272	mirror marble wand	0		
 1273	beefy magic lamp	0		Muscle: +10
 1274	vaporized skewed Medicinal Herb's medicinal herbs	1		
@@ -1283,16 +1283,16 @@
 1299	Lo Pan's pirate hook	0		Spell Critical Percent: +30
 1300	lion tamer's monster bait	0		Experience (familiar): +2, Single Equip
 1301	ionized bouncing deodorant	0		Effect: "Salty Dogs", Effect Duration: 30
-1302	pressed twirling skewed reodorant	0		Effect: "Boon of the War Snapper", Effect Duration: 49
+1302	pressed skewed twirling reodorant	0		Effect: "Boon of the War Snapper", Effect Duration: 49
 1303	Mjolnir Jr.	0		
 1304	squat ghostly doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	shaking wizardly traffic cone	0		Mysticality: +25, Item Drop: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	shaking wizardly traffic cone	0		Mysticality: +25, Item Drop: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	fuchsia attention spanner	0		Familiar Weight: +5
-1310	lime green pulsating funky fez	0		Familiar Weight: +5
-1311	ghostly yellow comfy blanket	0		Last Available: "2005-10"
+1310	pulsating lime green funky fez	0		Familiar Weight: +5
+1311	yellow ghostly comfy blanket	0		Last Available: "2005-10"
 1312	baleful Baron von Ratsworth's monocle	0		Spell Damage: +25, Single Equip
 1313	squat cyan Baron von Ratsworth's money clip of horror	0		Spooky Spell Damage: +25, Single Equip
 1314	jittery dance instructor's Baron von Ratsworth's tophat	0		Experience Percent (Moxie): +10, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
@@ -1300,12 +1300,12 @@
 1316	skewed facsimile dictionary	0		
 1317	blood flower	0		
 1318	lovecat tail	0		
-1319	spinning jittery plastic passion fruit	0		
-1320	snack-sized flavorless questionable taco	2	decent	
+1319	jittery spinning plastic passion fruit	0		
+1320	flavorless snack-sized questionable taco	2	decent	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	medical-grade time helmet	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	time trousers of Leguizamo	0		Monster Level: +20, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	medical-grade time helmet	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	time trousers of Leguizamo	0		Monster Level: +20, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	time sword of terror	0		Spooky Spell Damage: +10, Last Available: "2005-10"
 1326	blinking squat greasy Dyspepsi-Cola helmet	0		Sleaze Spell Damage: +10, Familiar Effect: "3xFairy, cap 7"
 1327	flame-wreathed Cloaca-Cola shield	0		Hot Spell Damage: +10, Damage Reduction: 4
@@ -1335,17 +1335,17 @@
 1352	bad mirror redrum	3	decent	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	stale small fancy bowl of oriole's nest soup	2	decent	Effect: "Night Vision", Effect Duration: 45
+1355	stale fancy small bowl of oriole's nest soup	2	decent	Effect: "Night Vision", Effect Duration: 45
 1356	olive bunny liver	0		
 1357	fortified bad Mt. Noob Pale Ale	5	decent	
 1358	spinning pirate zombie head	0		Last Available: "2005-11"
 1359	blinking ninja pirate zombie robot head	0		Last Available: "2005-11"
-1360	blinking cyan pirate zombie robot head	0		Last Available: "2005-11"
+1360	cyan blinking pirate zombie robot head	0		Last Available: "2005-11"
 1361	skewed shaking wobbly brawny disembodied smile	0		Muscle Percent: +20, Single Equip
 1362	sausage	0		
 1363	ghostly clockwork pirate skull	0		
 1364	fuchsia rhesus monkey	0		Familiar Weight: +5
-1365	snack-sized flavorless tofurkey leg	2	decent	
+1365	flavorless snack-sized tofurkey leg	2	decent	
 1366	half-sized yummy upside-down tofurkey gravy	2	awesome	
 1367	normal snack-sized fancy upside-down herbal stuffing	2	good	Effect: "Unrunnable Face", Effect Duration: 25
 1368	normal can-shaped gelatinous cranberry sauce	4	good	
@@ -1370,8 +1370,8 @@
 1388	blue toy wheel	0		
 1389	blinking yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
-1391	narrow narrow green ball	0		Last Available: "2010-12"
-1392	jittery gray kite	0		Last Available: "2005-12"
+1391	narrow green narrow ball	0		Last Available: "2010-12"
+1392	gray jittery kite	0		Last Available: "2005-12"
 1393	pet rock	0		Last Available: "2005-12"
 1394	upside-down doppelshifter	0		Last Available: "2005-12"
 1395	skewed teddy bear	0		Last Available: "2005-12"
@@ -1384,10 +1384,10 @@
 1402	personal trainer's rag doll	0		Experience Percent (Muscle): +10, Last Available: "2005-12"
 1403	smelly can of fake snow	0		Stench Spell Damage: +10, Last Available: "2005-12"
 1404	purple occult colored-light &quot;necklace&quot;	0		Spell Damage Percent: +25, Last Available: "2005-12"
-1405	tree skirt of extreme caution	0		Monster Level: -25, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	tree skirt of extreme caution	0		Monster Level: -25, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	bland half-sized wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	miniature normal bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	adequate cyan twirling tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	adequate twirling cyan tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	wobbly Lo Pan's Unionize The Elves sign	0		Spell Critical Percent: +30, Last Available: "2005-12"
 1410	narrow sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
@@ -1399,15 +1399,15 @@
 1417	boiled anodized twirling snowcone	0		Effect: "Human-Slime Hybrid", Effect Duration: 38, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	lime green teddy bear sewing kit	0		Last Available: "2006-01"
-1420	foul-smelling wicked traffic cone	0		Spell Damage: +5, Stench Damage: +10, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	foul-smelling wicked traffic cone	0		Spell Damage: +5, Stench Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	lion tamer's ice sickle of the bloodbag	0		Maximum HP: +100, Experience (familiar): +2, Softcore Only, Last Available: "2006-02"
 1425	shellacked ice baby	0		Damage Reduction: 7, Softcore Only, Last Available: "2006-02"
-1426	extremely unsafe ice pick	0		Weapon Damage Percent: +100, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	extremely unsafe ice pick	0		Weapon Damage Percent: +100, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	Van der Graaf ice skates of courage	0		Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	fancy super-sized rotten mirror grue egg omelette	5	crappy	Effect: "Slimily Sagacious", Effect Duration: 45
+1428	rotten fancy super-sized mirror grue egg omelette	5	crappy	Effect: "Slimily Sagacious", Effect Duration: 45
 1429	bouncing blue roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	maroon pregnant mushroom	0		
@@ -1418,13 +1418,13 @@
 1436	hot stuffing	0		
 1437	upside-down useless powder	0		
 1438	double-denatured deionized pressed twinkly powder	0		Effect: "Sticky Hands", Effect Duration: 29
-1439	polarized pickled fuchsia blinking hot powder	0		Effect: "Buggy Flavor", Effect Duration: 32
+1439	polarized pickled blinking fuchsia hot powder	0		Effect: "Buggy Flavor", Effect Duration: 32
 1440	double-activated corrupted moist powder	0		Effect: "Marbles in Your Mouth", Effect Duration: 56
 1441	extra-chilled galvanized narrow powder	0		Effect: "Ginger Snapped", Effect Duration: 48
 1442	Vulcanized super-vacuum-sealed purple stench powder	0		Effect: "Cautious Prowl", Effect Duration: 54
 1443	deionized lime green sleaze powder	0		Effect: "Carrrsmic", Effect Duration: 43
 1444	galvanized quadruple-concentrated twinkly nuggets	0		Effect: "Jingle Jangle Jingle", Effect Duration: 63
-1445	adjusted quadruple-Vulcanized cold-filtered blinking green hot nuggets	0		Effect: "Beastly Flavor", Effect Duration: 38
+1445	adjusted quadruple-Vulcanized cold-filtered green blinking hot nuggets	0		Effect: "Beastly Flavor", Effect Duration: 38
 1446	liquefied boiled nuggets	0		Effect: "Nut-Rition", Effect Duration: 14
 1447	adjusted mirror nuggets	0		Effect: "Chilblains of the Corn", Effect Duration: 14
 1448	tarnished jittery stench nuggets	0		Effect: "Greased-Up Familiar", Effect Duration: 25
@@ -1433,15 +1433,15 @@
 1451	diluted yellow hot wad	1		Effect: "Gummiskin", Effect Duration: 50
 1452	pickled wad	1		Effect: "Red-Shirted Escort", Effect Duration: 50
 1453	modified wad	1		Effect: "Creepin' Up on You", Effect Duration: 15
-1454	altered shaking blinking stench wad	1		
-1455	pickled blurry huge sleaze wad	1		Effect: "Savage Beast Inside", Effect Duration: 5
+1454	altered blinking shaking stench wad	1		
+1455	pickled huge blurry sleaze wad	1		Effect: "Savage Beast Inside", Effect Duration: 5
 1456	double daisy	0		
 1457	Goth Giant	0		
 1458	spoiled Valentine's Day cake	3	crappy	
 1459	twirling bouncing arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	purple squashed frog	0		
-1462	shaking gray eye of newt	0		
+1462	gray shaking eye of newt	0		
 1463	gray salamander spleen	0		
 1464	teal sleazy fairy gravy	0		
 1465	suede shortsword	0		
@@ -1474,8 +1474,8 @@
 1492	ninja mop of the blizzard	0		Cold Spell Damage: +25
 1493	Herculean Rosewater's ridiculously overelaborate ninja weapon	0		Mysticality Percent: +30, Experience (Muscle): +1
 1494	tarnished squat pulsating sugar-coated pine cone	0		Effect: "Itchy Trigger Finger", Effect Duration: 60, Last Available: "2020-09"
-1495	blinking careful traffic cone of the boozehound	0		Monster Level: -10, Booze Drop: +100, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	special irresponsibly strong perfectly mixed gloomy mushroom wine	6	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 30
+1495	blinking careful traffic cone of the boozehound	0		Monster Level: -10, Booze Drop: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1496	special perfectly mixed irresponsibly strong gloomy mushroom wine	6	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 30
 1497	artisanal mushroom wine	3	EPIC	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	blinking whoopie cushion	0		Last Available: "2006-04"
@@ -1503,23 +1503,23 @@
 1522	censurious Radio Free Jersey of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100
 1523	bottle of used blood	0		
 1524	green wind-up chattering teeth	0		Last Available: "2006-04"
-1525	jittery joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1525	jittery joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	teal diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	bouncing Da Vinci's corkscrew of the sewer	0		Experience (Mysticality): +5, Stench Damage: +25, Last Available: "2006-04"
 1529	wobbly St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	double-paned grass skirt	0		Cold Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	razor-sharp grass hat	0		Weapon Damage Percent: +25, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	double-paned grass skirt	0		Cold Resistance: +5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	razor-sharp grass hat	0		Weapon Damage Percent: +25, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	groovy grass blade	0		Moxie Percent: +10, Last Available: "2011-01"
 1534	jittery raffle prize box	0		
 1536	upside-down homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	deadly sparkly engagement ring	0		Weapon Damage: +5, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	huge scandalous toasty Grimacite goggles	0		Hot Damage: +5, Sleaze Damage: +5, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	huge scandalous toasty Grimacite goggles	0		Hot Damage: +5, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	executive rosy-cheeked Grimacite glaive	0		Maximum HP Percent: +30, Meat Drop: +40, Last Available: "2008-10"
-1542	knitted healthy Grimacite greaves	0		Maximum HP Percent: +20, Cold Resistance: +3, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	knitted healthy Grimacite greaves	0		Maximum HP Percent: +20, Cold Resistance: +3, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	pulsating dance instructor's personal trainer's Grimacite garter	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Last Available: "2008-10"
 1544	rosy-cheeked Grimacite galoshes of chilblains	0		Maximum HP Percent: +30, Cold Damage: +25, Last Available: "2008-10"
 1545	sharpshooter's Grimacite gorget of the cougar	0		Moxie: +20, Critical Hit Percent: +10, Last Available: "2008-10"
@@ -1529,31 +1529,31 @@
 1549	MSG	0		
 1550	Sinatra's second-hand knockoff engagement ring	0		Experience (Moxie): +5, Single Equip
 1551	strong lousy shaking bottle of Domesticated Turkey	5	decent	
-1552	drinkable watered-down bottle of Definit	2	good	
+1552	watered-down drinkable bottle of Definit	2	good	
 1553	watered-down tolerable bouncing narrow bottle of Calcutta Emerald	2	good	
 1554	drinkable bottle of Lieutenant Freeman	4	good	
-1555	triple-distilled mediocre shaking lime green bottle of Jorge Sinsonte	7	decent	
+1555	mediocre triple-distilled lime green shaking bottle of Jorge Sinsonte	7	decent	
 1556	mediocre boxed champagne	3	decent	
 1557	moldy kumquat	3	crappy	
 1558	adequate tangerine	4	good	
 1559	tonic water	0		
-1560	tiny bland cocktail onion	1	decent	
+1560	bland tiny cocktail onion	1	decent	
 1561	spoiled raspberry	3	crappy	
 1562	stale kiwi	3	decent	
 1563	lousy triple-distilled whiskey bittersweet	9	decent	
-1564	mediocre triple-distilled mimosette	8	decent	
+1564	triple-distilled mediocre mimosette	8	decent	
 1565	hand-crafted green tumbling tequila sunset	3	EPIC	
-1566	smooth weak zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
+1566	weak smooth zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
 1567	smooth bouncing gin and tonic	3	awesome	
-1568	artisanal practically non-alcoholic fancy vodka and tonic	1	super EPIC	Effect: "Blessing of Squirtlcthulli", Effect Duration: 45
-1569	special artisanal boozy vodka gibson	5	EPIC	Effect: "Shawarma Initiative", Effect Duration: 20
+1568	practically non-alcoholic artisanal fancy vodka and tonic	1	super EPIC	Effect: "Blessing of Squirtlcthulli", Effect Duration: 45
+1569	artisanal boozy special vodka gibson	5	EPIC	Effect: "Shawarma Initiative", Effect Duration: 20
 1570	fortified tolerable blurry gibson	5	good	
-1571	special mediocre shaking parisian cathouse	4	decent	Effect: "Sugar High", Effect Duration: 15
+1571	mediocre special shaking parisian cathouse	4	decent	Effect: "Sugar High", Effect Duration: 15
 1572	smooth rabbit punch	4	awesome	
 1573	special lousy caipifruta	4	decent	Effect: "Eyes of the Dragon", Effect Duration: 25
 1574	delicious teqiwila	3	awesome	
 1575	acceptable mirror Divine	4	good	
-1576	weak lousy cyan shaking Gordon Bennett	2	decent	
+1576	lousy weak cyan shaking Gordon Bennett	2	decent	
 1577	acceptable watered-down fuchsia tangarita	2	good	
 1578	perfectly mixed special mandarina colada	3	EPIC	Effect: "Impregnably Delicious", Effect Duration: 10
 1579	drinkable gimlet	4	good	
@@ -1563,16 +1563,16 @@
 1583	weak drinkable prussian cathouse	2	good	
 1584	aged blurry Mae West	3	awesome	
 1585	artisanal Mon Tiki	4	EPIC	
-1586	lousy practically non-alcoholic teqiwila slammer	1	decent	
+1586	practically non-alcoholic lousy teqiwila slammer	1	decent	
 1587	miniature spoiled Knob lo mein	2	crappy	
 1588	bite-sized delicious mirror asparagus lo mein	1	awesome	
 1589	bland immense Knoll lo mein	10	decent	
-1590	miniature rotten fancy lo mein	2	crappy	Effect: "Ripping, Dripping", Effect Duration: 40
-1591	jumbo rotten olive lo mein	5	crappy	
-1592	diet decent gray hot hi mein	1	good	
+1590	miniature fancy rotten lo mein	2	crappy	Effect: "Ripping, Dripping", Effect Duration: 40
+1591	rotten jumbo olive lo mein	5	crappy	
+1592	decent diet gray hot hi mein	1	good	
 1593	delicious hi mein	3	awesome	
 1594	immense flavorless hi mein	7	decent	
-1595	snack-sized stale hi mein	2	decent	
+1595	stale snack-sized hi mein	2	decent	
 1596	flavorless sleazy hi mein	3	decent	
 1597	shaking Annie Oakley's Junior LAAAAME merit badge	0		Critical Hit Percent: +20, Last Available: "2006-05"
 1598	pulsating Annie Oakley's Senior LAAAAME merit badge	0		Critical Hit Percent: +20, Last Available: "2006-05"
@@ -1592,16 +1592,16 @@
 1612	magnetized energized anodized concentrated cordial of concentration	0		Effect: "Mad at Science", Effect Duration: 40
 1613	upside-down coffin lid of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3
 1614	bouncing sizzling satin shield	0		Hot Damage: +10, Damage Reduction: 5
-1615	pulsating Cerebral Cloche of the brute	0		Muscle Percent: +30, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	bouncing vibrating Cerebral Culottes	0		Maximum MP Percent: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	pulsating Cerebral Cloche of the brute	0		Muscle Percent: +30, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	bouncing vibrating Cerebral Culottes	0		Maximum MP Percent: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	bouncing narrow smelly crafty Da Vinci's Cerebral Crossbow	0		Experience (Mysticality): +5, Maximum MP: +10, Stench Spell Damage: +10, Last Available: "2006-06"
 1618	shaking ice stein	0		Last Available: "2006-06"
 1619	shaking munchies pill	0		Last Available: "2006-06"
-1620	twirling tumbling homeopathic healing powder	0		Last Available: "2006-06"
+1620	tumbling twirling homeopathic healing powder	0		Last Available: "2006-06"
 1621	wobbly astral badger	0		Free Pull, Last Available: "2006-06"
 1622	aerosolized astral mushroom	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 37, Last Available: "2006-06"
 1623	jittery badger badge	0		Last Available: "2006-06"
-1624	cold-filtered bouncing ghostly blue-frosted astral cupcake	0		Effect: "Mushroom Might", Effect Duration: 33, Last Available: "2006-06"
+1624	cold-filtered ghostly bouncing blue-frosted astral cupcake	0		Effect: "Mushroom Might", Effect Duration: 33, Last Available: "2006-06"
 1625	pressed blurry green-frosted astral cupcake	0		Effect: "Heavily Breathing", Effect Duration: 47, Last Available: "2006-06"
 1626	frozen yellow twirling orange-frosted astral cupcake	0		Effect: "Billiards Belligerence", Effect Duration: 34, Last Available: "2006-06"
 1627	deionized diffused purple-frosted astral cupcake	0		Effect: "Ginger Snapped", Effect Duration: 39, Last Available: "2006-06"
@@ -1620,17 +1620,17 @@
 1640	alkaline extra-adjusted lotion of stench	0		Effect: "Livin' Large", Effect Duration: 64
 1641	pressed narrow lotion of sleaziness	0		Effect: "Brain Freeze", Effect Duration: 56
 1642	lousy Grimacite Bock	3	decent	Last Available: "2008-11"
-1643	flavorless small wedge of gray cheese	2	decent	Last Available: "2008-11"
+1643	small flavorless wedge of gray cheese	2	decent	Last Available: "2008-11"
 1644	squat hot and sauce	0		
 1645	upside-down and sauce	0		
 1646	and sauce	0		
-1647	purple bouncing stench and sauce	0		
+1647	bouncing purple stench and sauce	0		
 1648	squat sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
 1651	half-sized normal foie gras	2	good	
 1652	magnetized non-electrified mirror candy brain	0		Effect: "Human-Constellation Hybrid", Effect Duration: 50, Last Available: "2020-09"
-1653	auspicious mansplainer's weightlifter's jewel-eyed wizard hat	0		Muscle: +15, Monster Level: +15, Item Drop: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	auspicious mansplainer's weightlifter's jewel-eyed wizard hat	0		Muscle: +15, Monster Level: +15, Item Drop: +10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	rosewater-soaked wad of Crovacite of dire peril	0		Weapon Damage: +20, Stench Resistance: +3
 1655	green frosty smartaleck's collar	0		Moxie Percent: +30, Cold Spell Damage: +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	skewed ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	bouncing upside-down supercharged sword of horror	0		Maximum MP Percent: +30, Spooky Spell Damage: +25
 1680	electrified occult staff	0		Spell Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5
 1681	olive Herculean smartaleck's bubblewrap sword	0		Moxie Percent: +30, Experience (Muscle): +1
@@ -1670,14 +1670,14 @@
 1690	up-at-dawn Van der Graaf discarded bottlecap	0		Adventures: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	deadly discarded torn-up glove of the ox	0		Muscle: +20, Weapon Damage: +5, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	energized nitrogenated salamander slurry	0		Effect: "You're Rubber", Effect Duration: 26
-1693	energized galvanized huge cyan eyedrops of newt	0		Effect: "Unusual Fashion Sense", Effect Duration: 46
+1693	energized galvanized cyan huge eyedrops of newt	0		Effect: "Unusual Fashion Sense", Effect Duration: 46
 1694	non-dry quantum Frogade	0		Effect: "Spooky Weapon", Effect Duration: 49
-1695	altered tumbling cyan papotion of papower	0		Effect: "Cranberry Cordiality", Effect Duration: 53
-1696	delicious special royal jelly taco	3	awesome	Effect: "Chilblains of the Corn", Effect Duration: 15
+1695	altered cyan tumbling papotion of papower	0		Effect: "Cranberry Cordiality", Effect Duration: 53
+1696	special delicious royal jelly taco	3	awesome	Effect: "Chilblains of the Corn", Effect Duration: 15
 1697	moldy tofu taco	3	crappy	
 1698	miniature normal jumping bean taco	2	good	
-1699	snack-sized spoiled catgut taco	2	crappy	
-1700	fancy rotten goat cheese taco	3	crappy	Effect: "Heart of Yellow", Effect Duration: 40
+1699	spoiled snack-sized catgut taco	2	crappy	
+1700	rotten fancy goat cheese taco	3	crappy	Effect: "Heart of Yellow", Effect Duration: 40
 1701	fancy moldy tumbling pr0n taco	4	crappy	Effect: "Buggy Flavor", Effect Duration: 25
 1702	extra-dry activated narrow cyan alphabet gum	0		Effect: "Macho Profundo", Effect Duration: 43
 1703	purple Comma Chameleon egg	0		Free Pull
@@ -1745,7 +1745,7 @@
 1766	Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	decent super-sized fricasseed brains	5	good	
+1769	super-sized decent fricasseed brains	5	good	
 1770	moldy brains casserole	3	crappy	
 1771	squat huge Newton's butcherknife	0		Experience (Mysticality): +3
 1772	therapeutic corn holder	0		HP Regen Min: 5, HP Regen Max: 7
@@ -1754,7 +1754,7 @@
 1775	rock-hard dishrag	0		Damage Reduction: 5
 1776	flavorless stale baguette	3	decent	
 1777	leftovers of indeterminate origin	0		
-1778	small moldy wobbly dinner	2	crappy	
+1778	moldy small wobbly dinner	2	crappy	
 1779	Sherlock's katana	0		Item Drop: +25
 1780	Tesla ram stick	0		MP Regen Min: 7, MP Regen Max: 10
 1781	cyan personal trainer's enchantlers	0		Experience Percent (Muscle): +10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	artisanal red Ram's Face Lager	4	EPIC	
 1791	ram horns	0		
-1792	rosy-cheeked strapping Travoltan trousers of the cheetah	0		Muscle: +5, Maximum HP Percent: +30, Initiative: +60, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	rosy-cheeked strapping Travoltan trousers of the cheetah	0		Muscle: +5, Maximum HP Percent: +30, Initiative: +60, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	pulsating zippy pool cue of chilblains	0		Cold Damage: +25, Initiative: +20
 1794	nitrogenated tumbling handful of hand chalk	0		Effect: "Granolarrrgh", Effect Duration: 48
 1795	ruddy Counterclockwise Watch	0		Maximum HP Percent: +40, Single Equip
@@ -1841,13 +1841,13 @@
 1862	right twelfth rib	0		
 1863	animal pelvis	0		
 1864	spinning left scapula	0		
-1865	squat blurry right scapula	0		
+1865	blurry squat right scapula	0		
 1866	blinking left clavicle	0		
 1867	right clavicle	0		
 1868	jittery left humerus	0		
 1869	right humerus	0		
-1870	lime green shaking left radius	0		
-1871	tumbling olive right radius	0		
+1870	shaking lime green left radius	0		
+1871	olive tumbling right radius	0		
 1872	maroon left ulna	0		
 1873	right ulna	0		
 1874	spinning left femur	0		
@@ -1959,7 +1959,7 @@
 1982	jittery mirror MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	shaking snowy owl	0		
-1985	purple shaking scary death orb	0		
+1985	shaking purple scary death orb	0		
 1986	mind flayer	0		
 1987	jittery undead elbow macaroni	0		
 1988	narrow angry cow	0		
@@ -1967,15 +1967,15 @@
 1990	yo-yo	0		
 1991	jittery rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
-1993	upside-down mirror rubber WWSPD? bracelet	0		
+1993	mirror upside-down rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
-1996	green wobbly right half of a heart necklace	0		
+1996	wobbly green right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	skewed pack of KWE trading card	0		
 1999	squat stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
-2001	mirror cyan Vaso De Agua trading card	0		
+2001	cyan mirror Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	cyan Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
@@ -1994,8 +1994,8 @@
 2017	spade necklace	0		
 2018	spinning club necklace	0		
 2019	cream pie	0		Free Pull
-2020	enchanted toothsome diet cherry pie	1	awesome	Effect: "Yuletide Industry", Effect Duration: 40
-2021	half-sized delicious strawberry pie	2	awesome	
+2020	toothsome diet enchanted cherry pie	1	awesome	Effect: "Yuletide Industry", Effect Duration: 40
+2021	delicious half-sized strawberry pie	2	awesome	
 2022	miniature decent special lemon meringue pie	2	good	Effect: "The Grass...  Is Blue...", Effect Duration: 20
 2023	bouncing Genalen&trade; Bottle	1	good	
 2024	flavorless mixed wildflower greens	3	decent	
@@ -2017,18 +2017,18 @@
 2040	blinking patchouli oil bomb	0		
 2041	ferret bait	0		
 2042	exploding hacky-sack	0		
-2043	blinking gray jittery hemp net	0		
+2043	gray blinking jittery hemp net	0		
 2044	jittery your father's MacGuffin diary	0		
 2045	rotten brain-meltingly-hot chicken wings	3	crappy	
 2046	gigantic bland frat brats	8	decent	
-2047	spoiled massive knob ka-bobs	7	crappy	
+2047	massive spoiled knob ka-bobs	7	crappy	
 2049	delicious can of Swiller	3	awesome	
 2050	pulsating broken wings	0		
 2051	sunken eyes	0		
 2052	olive reassembled blackbird	0		
 2053	tumbling bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
-2055	yellow tumbling snake skin	0		
+2055	tumbling yellow snake skin	0		
 2056	ionized vacuum-sealed adder bladder	0		Effect: "Mmmmmelon", Effect Duration: 12
 2057	pension check	0		
 2058	picnic basket	0		
@@ -2036,7 +2036,7 @@
 2060	spinning electrified sword of the ox	0		Muscle: +20, MP Regen Min: 3, MP Regen Max: 5
 2061	gray flame-wreathed helmet	0		Hot Spell Damage: +10, Familiar Effect: "1xFairy, cap 40"
 2062	vibrating stiffened shield	0		Damage Reduction: 11, Maximum MP Percent: +10
-2063	moldy miniature blackberry	2	crappy	
+2063	miniature moldy blackberry	2	crappy	
 2064	shaking forged identification documents	0		
 2065	teal PADL Phone	0		
 2066	kick-ass kicks of the brazier of the businessman	0		Hot Spell Damage: +25, Meat Drop: +50, Single Equip
@@ -2090,7 +2090,7 @@
 2114	huge yo	0		Last Available: "2006-12"
 2115	wizardly prehistoric spear	0		Mysticality: +25, Last Available: "2006-12"
 2116	teal stick-on-a-string	0		Last Available: "2006-12"
-2117	red flame-retardant greasy fire	0		Sleaze Spell Damage: +10, Hot Resistance: +1, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	red flame-retardant greasy fire	0		Sleaze Spell Damage: +10, Hot Resistance: +1, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	blinking leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	rosy-cheeked Grateful Undead T-shirt	0		Maximum HP Percent: +30
@@ -2103,7 +2103,7 @@
 2128	vampire collar	0		Single Equip
 2129	possessed top	0		Last Available: "2010-12"
 2130	green zippy killer rag doll	0		Initiative: +20, Last Available: "2006-12"
-2131	mirror jittery tree-eating kite	0		Last Available: "2006-12"
+2131	jittery mirror tree-eating kite	0		Last Available: "2006-12"
 2132	knitted incredibly marionette	0		Cold Resistance: +3, Last Available: "2006-12"
 2133	dress ball	0		Last Available: "2010-12"
 2134	mad scientist's sock monkey of Leguizamo	0		Monster Level: +20, Last Available: "2006-12"
@@ -2131,7 +2131,7 @@
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	gray servomechanical torsion facilitator	0		Last Available: "2011-12"
-2159	maroon mirror quantum polarity inducer	0		Last Available: "2011-12"
+2159	mirror maroon quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
 2162	ghostly reverse-oscillating klystron	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	pulsating hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	Jack Frost's toy ray gun of the cougar	0		Moxie: +20, Cold Spell Damage: +50, Last Available: "2006-12"
-2169	stiffened forbidden toy space helmet	0		Spell Damage Percent: +50, Damage Reduction: 1, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	stiffened forbidden toy space helmet	0		Spell Damage Percent: +50, Damage Reduction: 1, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	spinning MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	spinning asbestos-lined foul-smelling astronaut pants	0		Stench Damage: +10, Hot Resistance: +5, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	spinning asbestos-lined foul-smelling astronaut pants	0		Stench Damage: +10, Hot Resistance: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	chaotic toy jet pack	0		Spell Critical Percent: +10, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2153,7 +2153,7 @@
 2178	rock-hard obsidian dagger	0		Damage Reduction: 5
 2179	upside-down archaeologist's notebook	0		
 2180	ghostly amulet	0		
-2181	olive bouncing chocolate lump	0		Last Available: "2011-12"
+2181	bouncing olive chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
 2183	Harold's hammer handle	0		
 2184	Harold's hammer	0		
@@ -2166,13 +2166,13 @@
 2191	blue book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	miniature stale candy stake	2	decent	Last Available: "2006-12"
-2194	fancy lousy eggnog	3	decent	Effect: "Army of One", Effect Duration: 10, Last Available: "2006-12"
+2194	lousy fancy eggnog	3	decent	Effect: "Army of One", Effect Duration: 10, Last Available: "2006-12"
 2195	huge normal unspeakable fruitcake	9	good	Last Available: "2006-12"
 2196	low-calorie normal jittery gingerbread horror	1	good	Last Available: "2006-12"
 2197	altered polymerized electrified but probably evil chocolate	0		Effect: "Stuck-Up Hair", Effect Duration: 31, Last Available: "2006-12"
 2198	decent bat-shaped Crimboween cookie	3	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	delicious skewed skull-shaped Crimboween cookie	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	spoiled jumbo fuchsia tombstone-shaped Crimboween cookie	5	crappy	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	jumbo spoiled fuchsia tombstone-shaped Crimboween cookie	5	crappy	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	huge brainy plastic gift-wrapping vampire	0		Mysticality: +5, Last Available: "2006-12"
 2202	spinning nasty plastic yuletide troll	0		Stench Damage: +5, Last Available: "2006-12"
 2203	Jack Frost's plastic skeletal reindeer	0		Cold Spell Damage: +50, Single Equip, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	shaking Crimbo tiki necklace of terror	0		Spooky Spell Damage: +10, Last Available: "2006-12"
 2208	stiffened bobble-hip hula elf doll of wisdom	0		Mysticality: +15, Damage Reduction: 1, Last Available: "2006-12"
 2209	razor-sharp Crimbo ukulele	0		Weapon Damage Percent: +25, Last Available: "2006-12"
-2210	spinning greedy studded Tiki lighter	0		Damage Absorption: +80, Meat Drop: +20, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	cyan deck of tropical cards of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	tropical paperweight of the storm of extreme caution	0		Maximum MP Percent: +40, Monster Level: -25, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	spinning greedy studded Tiki lighter	0		Damage Absorption: +80, Meat Drop: +20, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	cyan deck of tropical cards of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	tropical paperweight of the storm of extreme caution	0		Maximum MP Percent: +40, Monster Level: -25, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	wicked Tropical Crimbo Hat	0		Spell Damage: +5, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	tumbling shaking savvy Tropical Crimbo Shorts	0		Mysticality Percent: +20, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	wicked Tropical Crimbo Hat	0		Spell Damage: +5, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	tumbling shaking savvy Tropical Crimbo Shorts	0		Mysticality Percent: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	moldy spinning super ka-bob	4	crappy	
 2218	stale beer basted brat	4	decent	
 2219	energetic Tropical Crimbo Sword	0		Maximum MP Percent: +20, Last Available: "2006-12"
 2220	quantum altered blinking and Crimboween candy	0		Effect: "Improved Candy Vision", Effect Duration: 23, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	bouncing scandalous liar's pants of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	bouncing scandalous liar's pants of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	foul-smelling Socratic juggler's balls	0		Experience (Mysticality): +1, Stench Damage: +10, Softcore Only, Last Available: "2007-01"
 2224	aromatic pink shirt	0		Stench Resistance: +1, Softcore Only, Last Available: "2007-01"
 2225	olive familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2235,7 +2235,7 @@
 2261	hard-boiled ostrich egg	0		
 2262	huge bird rib	0		
 2263	lime green lion oil	0		
-2264	bite-sized bland shaking stunt nuts	1	decent	
+2264	bland bite-sized shaking stunt nuts	1	decent	
 2265	huge spoiled wet stew	8	crappy	
 2266	wet stunt nut stew	0		
 2267	upside-down upside-down Mega Gem	0		
@@ -2243,7 +2243,7 @@
 2269	diet flavorless purple sausage wonton	1	decent	
 2270	blue twirling greasy stylish belt	0		Moxie: +25, Sleaze Spell Damage: +10, Single Equip
 2271	perfectly mixed bottle of Merlot	3	EPIC	
-2272	delicious weak bottle of Port	2	awesome	
+2272	weak delicious bottle of Port	2	awesome	
 2273	bad bottle of Pinot Noir	4	decent	
 2274	bad bottle of Zinfandel	4	decent	
 2275	mediocre bottle of Marsala	3	decent	
@@ -2278,10 +2278,10 @@
 2304	improved squat candy heart	0		Effect: "Mucilaginous Mentalism", Effect Duration: 69, Last Available: "2007-02"
 2305	magnetized altered pink candy heart	0		Effect: "Wings of the Grasshopper", Effect Duration: 46, Last Available: "2007-02"
 2306	non-tarnished triple-flattened candy heart	0		Effect: "Eye of the Seal", Effect Duration: 11, Last Available: "2007-02"
-2307	deionized narrow teal candy heart	0		Effect: "Boschface", Effect Duration: 55, Last Available: "2007-02"
+2307	deionized teal narrow candy heart	0		Effect: "Boschface", Effect Duration: 55, Last Available: "2007-02"
 2308	moist cold-filtered candy heart	0		Effect: "Hot Buttoned", Effect Duration: 50, Last Available: "2007-02"
 2309	denatured liquefied candy heart	0		Effect: "Initiative and Let Die", Effect Duration: 65, Last Available: "2007-02"
-2310	twirling skewed candygram	0		Last Available: "2007-02"
+2310	skewed twirling candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
 2312	twirling candygram	0		Last Available: "2007-02"
 2313	candygram	0		Last Available: "2007-02"
@@ -2294,7 +2294,7 @@
 2320	wobbly worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
 2322	worm-riding manual pages 3-15	0		
-2323	shaking teal headpiece of the Staff of Ed	0		
+2323	teal shaking headpiece of the Staff of Ed	0		
 2324	Staff of Ed, almost	0		
 2325	Staff of Ed	0		
 2326	stone rose	0		
@@ -2303,7 +2303,7 @@
 2329	handful of confetti	0		
 2330	shaking chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	gigantic spoiled Better Than Cuddling Cake	9	crappy	
+2332	spoiled gigantic Better Than Cuddling Cake	9	crappy	
 2333	ninja snowman	0		
 2334	twirling Holy MacGuffin	0		
 2335	narrow rubber WWBBDD? bracelet	0		
@@ -2311,7 +2311,7 @@
 2337	reinforced beaded headband of horror	0		Spooky Spell Damage: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	normal pudding	3	good	Wiki Name: "black pudding (food)"
 2339	drinkable weak Blackfly Chardonnay	2	good	
-2340	artisanal practically non-alcoholic enchanted & tan	1	EPIC	Effect: "meat.enh", Effect Duration: 10
+2340	artisanal enchanted practically non-alcoholic & tan	1	EPIC	Effect: "meat.enh", Effect Duration: 10
 2341	tumbling pepper	0		
 2342	tiny stale squat forest cake	1	decent	
 2343	tasty yellow forest ham	3	awesome	
@@ -2326,7 +2326,7 @@
 2352	lightning-fast rosy-cheeked fire poi	0		Maximum HP Percent: +30, Initiative: +40
 2353	red wholesome bejeweled pledge pin	0		Maximum HP Percent: +10, Single Equip
 2354	skewed cyan communications windchimes	0		
-2355	triple-irradiated nitrogenated ghostly lime green henna face paint	0		Effect: "Scorpio Rising", Effect Duration: 48
+2355	triple-irradiated nitrogenated lime green ghostly henna face paint	0		Effect: "Scorpio Rising", Effect Duration: 48
 2356	adjusted non-diffused concentrated tube of dread wax	0		Effect: "Stinking Cloud", Effect Duration: 65
 2357	narrow rock-hard Gaia beads of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40
 2358	wobbly pink clay bead	0		
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	bunch of bananas	0		
-2373	enchanted stale banana	3	decent	Effect: "White Blooded", Effect Duration: 35
+2373	stale enchanted banana	3	decent	Effect: "White Blooded", Effect Duration: 35
 2374	red banana peel	0		
-2375	super-sized moldy special banana cream pie	5	crappy	Effect: "Cold as Ice", Effect Duration: 50
+2375	super-sized special moldy banana cream pie	5	crappy	Effect: "Cold as Ice", Effect Duration: 50
 2376	artisanal banana daiquiri	3	EPIC	
 2377	smooth high-proof blurry bungle in the jungle	6	awesome	
 2378	maroon banana spritzer	0		
@@ -2355,7 +2355,7 @@
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	class ring	0		
-2384	blurry wobbly class ring	0		
+2384	wobbly blurry class ring	0		
 2385	bottle opener belt buckle	0		Single Equip
 2386	squat Jeselnik's veiny keg shield	0		Maximum HP: +10, Sleaze Damage: +25, Damage Reduction: 11
 2387	brawny finger	0		Muscle Percent: +20
@@ -2368,7 +2368,7 @@
 2394	friendly Danglin' Chad's loincloth of terror	0		Familiar Weight: +3, Spooky Spell Damage: +10, Familiar Effect: "stench atk, 0.5xVolley"
 2395	pulsating zippy tube sock	0		Initiative: +20, Single Equip
 2396	blurry chloroform rag	0		
-2397	pulsating twirling depantsing bomb	0		
+2397	twirling pulsating depantsing bomb	0		
 2398	deadly energy drink IV	0		Weapon Damage: +5, Single Equip
 2399	yellow double-paned deadly Elmley shades	0		Weapon Damage: +5, Cold Resistance: +5, Single Equip
 2400	blue molotov cocktail cocktail	0		
@@ -2394,7 +2394,7 @@
 2420	frozen polymerized teeny-tiny magic scroll	0		Effect: "Mint-Condition Breath", Effect Duration: 46
 2421	improved bottle of pirate juice	0		Effect: "Ginger Snapped", Effect Duration: 20
 2422	improved corrupted irradiated pet snacks	0		Effect: "Big Meat Big Prizes", Effect Duration: 56
-2423	improved skewed green Mick's IcyVapoHotness Inhaler	0		Effect: "Flamibili Tea", Effect Duration: 34
+2423	improved green skewed Mick's IcyVapoHotness Inhaler	0		Effect: "Flamibili Tea", Effect Duration: 34
 2424	diffused cyclops eyedrops	0		Effect: "Disdain of the War Snapper", Effect Duration: 22
 2425	non-deionized lime green ghostly can of spinach	0		Effect: "Cringle's Curative Carol", Effect Duration: 63
 2426	alkaline energized narrow fire flower	0		Effect: "Heart of Green", Effect Duration: 49
@@ -2411,11 +2411,11 @@
 2437	ghostly New Cloaca-Cola	0		
 2438	scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
-2440	narrow teal unnatural gas	0		
+2440	teal narrow unnatural gas	0		
 2441	Knob Goblin Encryption Key	0		
 2442	jittery Cobb's Knob map	0		
 2443	Jim Carey's energetic pink glowstick	0		Maximum MP Percent: +20, Monster Level: +25, Last Available: "2007-03"
-2444	drinkable irresponsibly strong Supernova Champagne	10	good	
+2444	irresponsibly strong drinkable Supernova Champagne	10	good	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	blinking bad penguin egg	0		Free Pull
@@ -2435,9 +2435,9 @@
 2462	huge odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	delicious bowl of Bounty-Os	3	awesome	
-2465	weak lousy Oreille Divis&eacute;e brandy	2	decent	
+2465	lousy weak Oreille Divis&eacute;e brandy	2	decent	
 2466	blue pompadour'd puppy	0		
-2467	mirror olive suede shoes	0		Familiar Weight: +5
+2467	olive mirror suede shoes	0		Familiar Weight: +5
 2468	blurry callused fingerbone	0		
 2469	bundle of receipts	0		
 2470	cork	0		
@@ -2495,13 +2495,13 @@
 2522	watered-down artisanal thistle wine	2	EPIC	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	gigantic moldy fish	10	crappy	
+2525	moldy gigantic fish	10	crappy	
 2526	yummy massive twirling green fish casserole	10	awesome	
 2527	decent fish lasagna	4	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	adequate gnatloaf	3	good	
 2530	spoiled jittery gnatloaf casserole	3	crappy	
-2531	adequate miniature spinning gnat lasagna	2	good	
+2531	miniature adequate spinning gnat lasagna	2	good	
 2532	pork	0		
 2533	big decent pork chop sandwiches	5	good	
 2534	spoiled small blinking pork casserole	2	crappy	
@@ -2518,7 +2518,7 @@
 2545	adjusted triple-corrupted anodized upsy daisy	0		Effect: "Hombre Muerto Caminando", Effect Duration: 52, Last Available: "2007-05"
 2546	pressed adjusted half-orchid	0		Effect: "Sealed Brain", Effect Duration: 49, Last Available: "2007-05"
 2547	knitted electrified tin star	0		Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-05"
-2548	ribald outrageous sombrero of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	ribald outrageous sombrero of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	twirling huge scandalous wizardly &quot;Humorous&quot; T-shirt	0		Mysticality: +25, Sleaze Damage: +5, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2539,7 +2539,7 @@
 2566	Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
 2568	blinking Azazel's tutu	0		
-2569	concentrated flattened ghostly green ant agonist	0		Effect: "Ancient Protected", Effect Duration: 31
+2569	concentrated flattened green ghostly ant agonist	0		Effect: "Ancient Protected", Effect Duration: 31
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	fuchsia ant rake	0		Familiar Effect: "hot damage, meat"
 2572	wobbly ant pitchfork	0		Familiar Effect: "stench damage, meat"
@@ -2559,11 +2559,11 @@
 2586	forbidden General Sage's Lonely Diamonds Club Jacket	0		Spell Damage Percent: +50
 2587	skewed hardy Corporal Fennel's Lonely Clubs Club Jacket	0		Maximum HP: +50
 2588	energetic Private Pepper's Lonely Hearts Club Jacket	0		Maximum MP Percent: +20
-2589	flavorless snack-sized hot date	2	decent	
+2589	snack-sized flavorless hot date	2	decent	
 2590	acceptable shaking distilled fortified wine	3	good	
 2591	tasty tasty tart	3	awesome	
 2592	Knob Goblin lunchbox	0		
-2593	huge bland Knob pasty	6	decent	
+2593	bland huge Knob pasty	6	decent	
 2594	artisanal thermos full of Knob coffee	4	EPIC	
 2595	flattened upside-down Ben-Gal&trade; Balm	0		Effect: "What's That Smell?", Effect Duration: 35
 2596	tumbling leathery cat skin	0		
@@ -2601,7 +2601,7 @@
 2628	educational smartaleck's catskin buckler	0		Moxie Percent: +30, Experience: +1, Damage Reduction: 11
 2629	ghostly avaricious tail o' nine cats of the detective	0		Item Drop: +20, Meat Drop: +30
 2630	Hugo's Weaving Manual	0		
-2631	aerosolized red blurry narrow gremlin juice	0		Effect: "On a Roll", Effect Duration: 48
+2631	aerosolized narrow red blurry gremlin juice	0		Effect: "On a Roll", Effect Duration: 48
 2632	galvanized pressed mother's helper	0		Effect: "Pronounced Potency", Effect Duration: 27
 2633	tumbling executive wholesome pat-a-cake pendant	0		Maximum HP Percent: +10, Meat Drop: +40
 2634	mummy wrapping	0		
@@ -2621,51 +2621,51 @@
 2648	flirtatious feather	0		
 2649	pulsating nasty Lord Spookyraven's ear trumpet	0		Stench Damage: +5, Single Equip
 2650	bottled pixie	0		Free Pull
-2651	green spinning pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
+2651	spinning green pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	normal S.T.L.T.	3	good	Last Available: "2007-06"
 2653	decent shaking honey-dew	3	good	Last Available: "2007-06"
-2654	fortified hand-crafted jittery Xanadian	5	EPIC	Last Available: "2007-06"
+2654	hand-crafted fortified jittery Xanadian	5	EPIC	Last Available: "2007-06"
 2655	quantum triple-magnetized bottle of absinthe	0		Effect: "Stuck That Way", Effect Duration: 34, Last Available: "2007-06"
 2656	cyan dangerous cool Drowsy Sword	0		Moxie: +5, Weapon Damage: +10
 2657	rotten shaking maroon escargotsicle	4	crappy	Last Available: "2007-06"
-2658	acceptable irresponsibly strong skewed bottle of realpagne	6	good	Last Available: "2007-06"
+2658	irresponsibly strong acceptable skewed bottle of realpagne	6	good	Last Available: "2007-06"
 2659	beefy albatross necklace	0		Muscle: +10, Single Equip, Last Available: "2007-06"
 2660	distilled lime green not-a-pipe	1	good	Last Available: "2007-06"
 2661	acceptable flask of Amontillado	3	good	Last Available: "2007-06"
-2662	cyan rock-hard ball mask	0		Damage Reduction: 5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	skewed Can-Can skirt of wisdom	0		Mysticality: +15, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	cyan rock-hard ball mask	0		Damage Reduction: 5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	skewed Can-Can skirt of wisdom	0		Mysticality: +15, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	improved ionized sensitive poetry journal	0		Effect: "Soles of Glass", Effect Duration: 55, Last Available: "2007-06"
 2665	frozen spinning bottled inspiration	0		Effect: "Human-Plant Hybrid", Effect Duration: 35, Last Available: "2007-06"
 2666	polymerized bellhop bell	0		Effect: "Celestial Vision", Effect Duration: 51, Last Available: "2007-06"
 2667	quadruple-quantum twirling spiky collar	0		Effect: "Using Protection", Effect Duration: 56, Last Available: "2007-06"
 2668	compressed wobbly can-can-in-a-can	1		Effect: "Hip to Be Square Dancin'", Effect Duration: 50, Last Available: "2007-06"
-2669	mixed twirling maroon shaking patent antipsychotics	1		Last Available: "2007-06"
+2669	mixed shaking twirling maroon patent antipsychotics	1		Last Available: "2007-06"
 2670	boiled ghostly narrow Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	hand-crafted triple-distilled shot of nepenthe schnapps	8	EPIC	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	irradiated ionized bottle of cat tonic	0		Effect: "Livin' Large", Effect Duration: 39, Last Available: "2007-06"
-2675	dried blinking olive narrow handful of moss	1		Effect: "Stopping to Smell the Flowers", Effect Duration: 25
+2675	dried blinking narrow olive handful of moss	1		Effect: "Stopping to Smell the Flowers", Effect Duration: 25
 2676	mixed mirror bit-o-cactus	1		
-2677	vaporized blinking squat protein powder	1		
+2677	vaporized squat blinking protein powder	1		
 2678	narrow spectre scepter	0		
-2679	modified huge yellow sparkler	0		Effect: "Tiki Temerity", Effect Duration: 42
+2679	modified yellow huge sparkler	0		Effect: "Tiki Temerity", Effect Duration: 42
 2680	oxidized corrupted snake	0		Effect: "Human-Constellation Hybrid", Effect Duration: 28, Wiki Name: "snake"
-2681	corrupted tumbling yellow M-242	0		Effect: "Snobby", Effect Duration: 68
+2681	corrupted yellow tumbling M-242	0		Effect: "Snobby", Effect Duration: 68
 2682	detuned radio	0		
-2683	skewed green Warehouse 23 crate	0		
+2683	green skewed Warehouse 23 crate	0		
 2684	dog trainer's beefy armgun	0		Muscle: +10, Experience (familiar): +1
 2685	seashell necklace	0		
-2686	skewed spinning commemorative war stein	0		
+2686	spinning skewed commemorative war stein	0		
 2687	stone frisbee	0		
 2688	lion tamer's resourceful groovy dreadlock whip	0		Moxie Percent: +10, Maximum MP: +50, Experience (familiar): +2
 2689	auspicious asbestos-lined beer-a-pult	0		Hot Resistance: +5, Item Drop: +10
 2690	cast-iron legacy paddle of the cougar of Gandalf	0		Moxie: +20, Spell Critical Percent: +20
-2691	special small spoiled handful of nuts and berries	2	crappy	Effect: "Sucrose-Colored Glasses", Effect Duration: 45
+2691	spoiled special small handful of nuts and berries	2	crappy	Effect: "Sucrose-Colored Glasses", Effect Duration: 45
 2692	mansplainer's vibrating driftwood sculpture	0		Maximum MP Percent: +10, Monster Level: +15
 2693	bouncing bouncing stanky arcane researcher's massive sitar	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +25
 2694	dog trainer's boxer's stone baseball cap of the detective	0		Muscle Percent: +10, Experience (familiar): +1, Item Drop: +20, Familiar Effect: "1xVolley, cap 48"
-2695	high-proof artisanal cup of beer	6	EPIC	
+2695	artisanal high-proof cup of beer	6	EPIC	
 2696	ovoid thing	0		
 2697	duct tape	0		
 2698	skewed duct tape wallet	0		
@@ -2695,25 +2695,25 @@
 2722	ribald brawny Staff of the Greasefire of vim and vigor of the detective	0		Muscle Percent: +20, Maximum HP Percent: +50, Sleaze Damage: +10, Item Drop: +20
 2723	boxer's brainy Staff of the Grand Flamb&eacute; of the blizzard	0		Mysticality: +5, Muscle Percent: +10, Cold Spell Damage: +25
 2724	adequate bowl of rye sprouts	3	good	
-2725	tasty thick cob of corn	5	awesome	
-2726	snack-sized normal juniper berries	2	good	
+2725	thick tasty cob of corn	5	awesome	
+2726	normal snack-sized juniper berries	2	good	
 2727	diet yummy narrow plum	1	awesome	
-2728	fancy moldy pear	3	crappy	Effect: "Hairy Palms", Effect Duration: 40
-2729	half-sized flavorless peach	2	decent	
+2728	moldy fancy pear	3	crappy	Effect: "Hairy Palms", Effect Duration: 40
+2729	flavorless half-sized peach	2	decent	
 2730	bad enchanted blinking plum wine	4	decent	Effect: "Hennaliciousness", Effect Duration: 15
-2731	weak hand-crafted shot of pear schnapps	2	EPIC	
+2731	hand-crafted weak shot of pear schnapps	2	EPIC	
 2732	acceptable fuchsia shot of peach schnapps	3	good	
 2733	flavorless bunch of square grapes	3	decent	
 2734	small stale brown sugar cane	2	decent	
 2735	spoiled lime green sandwich of the gods	3	crappy	
-2736	artisanal practically non-alcoholic Pan-Dimensional Gargle Blaster	1	super ultra mega turbo EPIC	
+2736	practically non-alcoholic artisanal Pan-Dimensional Gargle Blaster	1	super ultra mega turbo EPIC	
 2737	distilled ghostly leopard-print barbell	1	good	Effect: "Joy", Effect Duration: 35
 2738	twirling pile of smoking rags	0		
 2739	unsweetened panty raider camouflage	0		Effect: "Radium Radicality", Effect Duration: 43
 2740	greedy Lo Pan's personal trainer's Staff of the Walk-In Freezer	0		Experience Percent (Muscle): +10, Spell Critical Percent: +30, Meat Drop: +20
 2741	fancy acceptable wobbly boilermaker	3	good	Effect: "Nuts about Candy", Effect Duration: 5
 2742	thick normal steel lasagna	5	quest	
-2743	high-proof enchanted acceptable steel margarita	6	quest	Effect: "Salty Mouth", Effect Duration: 5
+2743	acceptable high-proof enchanted steel margarita	6	quest	Effect: "Salty Mouth", Effect Duration: 5
 2744	boiled steel-scented air freshener	1		
 2745	flattened non-irradiated gremlin mutagen	0		Effect: "Fishily Speeding", Effect Duration: 51
 2746	oxidized ionized electrified gray extra-potent gremlin mutagen	0		Effect: "Fever From the Flavor", Effect Duration: 39
@@ -2780,7 +2780,7 @@
 2807	altered galvanized flask of hamethyst juice	0		Effect: "Chain Chain Chains", Effect Duration: 47
 2808	adjusted flask of baconstone juice	0		Effect: "Your Favorite Flavor", Effect Duration: 66
 2809	galvanized chilled flask of porquoise juice	0		Effect: "Rad-ish", Effect Duration: 64
-2810	extra-adjusted concentrated green blinking jug of hamethyst juice	0		Effect: "Ginger Snapped", Effect Duration: 65
+2810	extra-adjusted concentrated blinking green jug of hamethyst juice	0		Effect: "Ginger Snapped", Effect Duration: 65
 2811	deionized jug of baconstone juice	0		Effect: "Good Motivator", Effect Duration: 39
 2812	vacuum-sealed jug of porquoise juice	0		Effect: "Heart of Lavender", Effect Duration: 21
 2813	jittery baleful Beret of the businessman	0		Spell Damage: +25, Meat Drop: +50, Four Songs, Familiar Effect: "1xVolley, 1xLep"
@@ -2789,9 +2789,9 @@
 2816	rosy-cheeked hardened Boxers of terror	0		Damage Reduction: 3, Maximum HP Percent: +30, Spooky Spell Damage: +10, Familiar Effect: "1xVolley, 1xLep"
 2817	ghostly yellow friendly extremely unsafe Da Vinci's Brooch	0		Experience (Mysticality): +5, Weapon Damage Percent: +100, Familiar Weight: +3, Single Equip
 2818	foul-smelling nippy sharpshooter's Bracelet	0		Critical Hit Percent: +10, Cold Damage: +10, Stench Damage: +10, Single Equip
-2819	mirror greasy Lo Pan's Grimacite gasmask	0		Spell Critical Percent: +30, Sleaze Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	mirror greasy Lo Pan's Grimacite gasmask	0		Spell Critical Percent: +30, Sleaze Spell Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	smelly Grimacite gat	0		Stench Spell Damage: +10, Item Drop: +5, Last Available: "2008-11"
-2821	energetic Grimacite gaiters of incineration	0		Maximum MP Percent: +20, Hot Spell Damage: +50, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	energetic Grimacite gaiters of incineration	0		Maximum MP Percent: +20, Hot Spell Damage: +50, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	Annie Oakley's banded Grimacite gauntlets	0		Damage Absorption: +100, Critical Hit Percent: +20, Single Equip, Last Available: "2008-11"
 2823	jittery medical-grade Grimacite go-go boots of the sweet-tooth	0		Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2008-11"
 2824	Grimacite girdle of chilblains of temperance	0		Cold Damage: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2008-11"
@@ -2804,16 +2804,16 @@
 2831	star key lime	0		
 2832	normal digital key lime pie	3	good	
 2833	flavorless ghostly star key lime pie	4	decent	
-2834	ribald careful bottle-rocket crossbow of courage	0		Monster Level: -10, Sleaze Damage: +10, Spooky Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2834	ribald careful bottle-rocket crossbow of courage	0		Monster Level: -10, Sleaze Damage: +10, Spooky Resistance: +3, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	tumbling rosewater-soaked indie comic hipster glasses	0		Stench Resistance: +3, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	glowstick of Tarzan of the scaredy-cat	0		Experience (Muscle): +3, Monster Level: -15, Last Available: "2007-08"
 2839	shaking horrifying Periodical Paintbrush	0		Spooky Damage: +25, Softcore Only
 2840	bad enchanted bottle of cooking sherry	3	decent	Effect: "Spooky Weapon", Effect Duration: 35
-2841	rotten low-calorie packet of ketchup	1	crappy	
+2841	low-calorie rotten packet of ketchup	1	crappy	
 2842	mediocre accidental cider	3	decent	
-2843	stale super-sized dire fudgesicle	5	decent	
+2843	super-sized stale dire fudgesicle	5	decent	
 2844	reassuring slick brainy navel ring of navel gazing of the boozehound	0		Mysticality: +5, Moxie: +10, Spooky Resistance: +1, Booze Drop: +100, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	upside-down class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2821,12 +2821,12 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	spinning shrunken navigator head	0		
 2850	strong aged moonberry wine cooler	5	awesome	
-2851	moldy special fine aged cheddarwurst	3	crappy	Effect: "Fancy Feasted", Effect Duration: 20
+2851	special moldy fine aged cheddarwurst	3	crappy	Effect: "Fancy Feasted", Effect Duration: 20
 2852	jittery branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	huge asbestos-lined healthy huge mosquito proboscis	0		Maximum HP Percent: +20, Hot Resistance: +5
-2856	vacuum-sealed frozen spinning ghostly lime green swamp lolly	0		Effect: "Hammertime", Effect Duration: 35
+2856	vacuum-sealed frozen lime green ghostly spinning swamp lolly	0		Effect: "Hammertime", Effect Duration: 35
 2857	magnetized extra-flattened seegar butt	0		Effect: "Cold, Dead Hands", Effect Duration: 62
 2858	bottled swamp gas	0		
 2859	lime green avaricious manspreader's witch wart	0		Monster Level: +10, Meat Drop: +30
@@ -2839,7 +2839,7 @@
 2866	teal strapping shamanic beads of the businessman	0		Muscle: +5, Meat Drop: +50
 2867	therapeutic dilapidated wizard hat of incineration	0		Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "cap 31"
 2868	polarized super-wet spinning pirate pamphlet	0		Effect: "Weepy, Creepy", Effect Duration: 31
-2869	altered blinking shaking pirate brochure	0		Effect: "Unrunnable Face", Effect Duration: 36
+2869	altered shaking blinking pirate brochure	0		Effect: "Unrunnable Face", Effect Duration: 36
 2870	tarnished vacuum-sealed pirate tract	0		Effect: "Graham Crackling", Effect Duration: 14
 2871	burnt flower	0		
 2872	greedy flame-wreathed plastic Naughty Sorceress	0		Hot Spell Damage: +10, Meat Drop: +20
@@ -2915,7 +2915,7 @@
 2942	alkaline diffused chocolate filthy lucre	0		Effect: "Swimming Head", Effect Duration: 54
 2943	double-frozen Vulcanized jittery Angry Farmer's Wife Candy	0		Effect: "Remaining Alive", Effect Duration: 55
 2945	nasty hardened party hat	0		Damage Reduction: 3, Stench Damage: +5, Familiar Effect: "4xLep, cap 7"
-2946	maroon sinister groovy V for Vivala mask	0		Moxie Percent: +10, Spell Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	maroon sinister groovy V for Vivala mask	0		Moxie Percent: +10, Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
 2948	acceptable shot of rotgut	3	good	
 2949	deionized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 44
@@ -2927,11 +2927,11 @@
 2955	low-calorie moldy yam candy	1	crappy	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	thick moldy tube of cranberry Go-Goo	5	crappy	
+2958	moldy thick tube of cranberry Go-Goo	5	crappy	
 2959	rum barrel charrrm bracelet of the pedagogue	0		Experience: +3
 2960	huge delicious single-serving herbal stuffing	10	awesome	
 2961	bland packet of tofurkey gravy	4	decent	
-2962	tasty snack-sized shaking blurry tofurkey nugget	2	awesome	
+2962	snack-sized tasty shaking blurry tofurkey nugget	2	awesome	
 2963	spinning rigging shampoo	0		
 2964	ball polish	0		
 2965	shaking mizzenmast mop	0		
@@ -2939,7 +2939,7 @@
 2967	ionized lime green Swabbie&trade; swab	0		Effect: "Sensation", Effect Duration: 53
 2968	pickled Vulcanized pulsating Oil of Parrrlay	0		Effect: "Melancholy Burden", Effect Duration: 17
 2969	toothsome diet creamsicle	1	awesome	
-2970	weak tolerable cream stout	2	good	
+2970	tolerable weak cream stout	2	good	
 2971	cyan strapping curmudgel of mayonnaise	0		Muscle: +5, Sleaze Spell Damage: +50
 2972	grumpy man charrrm	0		
 2973	clever grumpy man charrrm bracelet	0		Maximum MP: +20, Single Equip
@@ -2952,7 +2952,7 @@
 2980	green booty chest charrrm	0		
 2981	mirror strapping booty chest charrrm bracelet	0		Muscle: +5, Single Equip
 2982	cannonball charrrm	0		
-2983	huge squat cannonball charrrm bracelet	0		Single Equip
+2983	squat huge cannonball charrrm bracelet	0		Single Equip
 2984	copper ha'penny charrrm	0		
 2985	Newton's copper ha'penny charrrm bracelet	0		Experience (Mysticality): +3
 2986	tongue charrrm	0		
@@ -2996,24 +2996,24 @@
 3024	stone pyramid	0		
 3025	tolerable ghostly corpse on the beach	3	good	
 3026	artisanal wobbly corpsetini	3	super EPIC	
-3027	drinkable weak yellow corpsedriver	2	good	
+3027	weak drinkable yellow corpsedriver	2	good	
 3028	hand-crafted fancy Corpse Island iced tea	4	EPIC	Effect: "Once Bitten Twice Fried", Effect Duration: 35
 3029	extra-dry tolerable red-headed corpse	5	good	
 3030	acceptable fortified wobbly kamicorpse-ee	5	good	
-3031	practically non-alcoholic smooth tumbling corpsel	1	awesome	
-3032	perfectly mixed irresponsibly strong corpsebite	9	EPIC	
+3031	smooth practically non-alcoholic tumbling corpsel	1	awesome	
+3032	irresponsibly strong perfectly mixed corpsebite	9	EPIC	
 3033	Temple Grandin's pirate fledges	0		Familiar Weight: +7
 3034	upside-down piece of thirteen	0		
-3035	super-sized decent pearl onion	5	good	
-3036	bland gigantic sea biscuit	7	decent	
+3035	decent super-sized pearl onion	5	good	
+3036	gigantic bland sea biscuit	7	decent	
 3037	drinkable green bottle of rum	4	good	
-3038	lousy practically non-alcoholic bottle of black-label rum	1	decent	
+3038	practically non-alcoholic lousy bottle of black-label rum	1	decent	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	spinning metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	spinning metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	gigantic rotten nanite-infested gingerbread bugbear	8	crappy	Last Available: "2007-12"
 3046	adequate big nanite-infested candy cane	5	good	Last Available: "2020-09"
 3047	half-sized flavorless huge nanite-infested fruitcake	2	decent	Last Available: "2007-12"
@@ -3025,10 +3025,10 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	non-Vulcanized lime green candy heart	0		Effect: "Familial Ties", Effect Duration: 34, Last Available: "2007-02"
 3055	double-improved jittery pulsating cymbal syrup	0		Free Pull, Effect: "Power Ballad of the Arrowsmith", Effect Duration: 66, Last Available: "2007-02"
-3056	resourceful metallic foil cat ears	0		Maximum MP: +50, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	resourceful metallic foil cat ears	0		Maximum MP: +50, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	spinning iGoogly	0		Last Available: "2007-12"
-3059	narrow olive theoretical string	0		Last Available: "2007-12"
+3059	olive narrow theoretical string	0		Last Available: "2007-12"
 3060	upside-down cyan synthetic stuffing	0		Last Available: "2007-12"
 3061	narrow toy hoverpad	0		Last Available: "2007-12"
 3062	LED block	0		Last Available: "2007-12"
@@ -3048,18 +3048,18 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	mirror teddy borg	0		Last Available: "2007-12"
 3081	foul-smelling marionette collective	0		Stench Damage: +10, Last Available: "2007-12"
 3082	blue monomolecular yo-yo	0		Last Available: "2010-12"
-3083	upside-down gray gray blob	0		Last Available: "2007-12"
+3083	gray upside-down gray blob	0		Last Available: "2007-12"
 3084	groovy borg sock monkey	0		Moxie Percent: +10, Last Available: "2007-12"
 3085	studded slick roboduck-on-a-string	0		Moxie: +10, Damage Absorption: +80, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	vibrating biomechanical crimborg helmet of horror	0		Maximum MP Percent: +10, Spooky Spell Damage: +25, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	vibrating biomechanical crimborg helmet of horror	0		Maximum MP Percent: +10, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	fireproof Sinatra's C.B.F.G.	0		Experience (Moxie): +5, Hot Resistance: +3, Last Available: "2007-12"
-3090	auspicious therapeutic biomechanical crimborg leg armor	0		Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	auspicious therapeutic biomechanical crimborg leg armor	0		Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	quantum ghostly vitachoconutriment capsule	0		Effect: "Fireproof Lips", Effect Duration: 43, Last Available: "2007-12"
 3092	ghostly friendly handmade hobby horse	0		Familiar Weight: +3, Last Available: "2007-12"
 3093	skewed stiffened ball-in-a-cup	0		Damage Reduction: 1, Last Available: "2007-12"
@@ -3079,7 +3079,7 @@
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	twirling overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	green spinning twirling Miniborg stomper	0		Last Available: "2007-12"
-3110	bouncing fuchsia Miniborg strangler	0		Last Available: "2007-12"
+3110	fuchsia bouncing Miniborg strangler	0		Last Available: "2007-12"
 3111	huge Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
@@ -3117,12 +3117,12 @@
 3145	El Vibrato translator	0		
 3146	El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
-3148	tumbling blinking El Vibrato punchcard (129 holes)	0		
+3148	blinking tumbling El Vibrato punchcard (129 holes)	0		
 3149	El Vibrato punchcard (213 holes)	0		
 3150	skewed huge El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
 3152	El Vibrato punchcard (216 holes)	0		
-3153	ghostly mirror El Vibrato punchcard (88 holes)	0		
+3153	mirror ghostly El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
 3155	El Vibrato punchcard (176 holes)	0		
 3156	El Vibrato punchcard (104 holes)	0		
@@ -3143,12 +3143,12 @@
 3171	shaking nauseating reagent	0		
 3172	deadly evil paper umbrella	0		Weapon Damage: +5
 3173	moist evil vihuela	0		Effect: "Patched In", Effect Duration: 53
-3174	adequate huge upside-down evil boring spaghetti	8	good	
+3174	huge adequate upside-down evil boring spaghetti	8	good	
 3175	diet bland evil noodles	1	decent	
 3176	rotten evil noodles	3	crappy	
 3177	yummy fuchsia evil painful penne pasta	4	awesome	
 3178	adequate 3vi1 pr0n m4nic0tti	3	good	
-3179	diet flavorless green evil ravioli della hippy	1	decent	
+3179	flavorless diet green evil ravioli della hippy	1	decent	
 3180	half-sized tasty jittery evil noodles	2	awesome	
 3181	polymerized double-irradiated shaking evil potion of potency	0		Effect: "Papowerful", Effect Duration: 62
 3182	anodized evil libation of liveliness	0		Effect: "Action", Effect Duration: 38
@@ -3156,11 +3156,11 @@
 3184	altered non-corrupted evil eyedrops of the ermine	0		Effect: "Gingerbread Robust", Effect Duration: 54
 3185	pressed galvanized evil ointment of the occult	0		Effect: "Amplified Fabulousness", Effect Duration: 64
 3186	enhanced evil serum of sarcasm	0		Effect: "Comprehensively Nourished", Effect Duration: 64
-3187	improved warmed skewed gray evil philter of phorce	0		Effect: "Reedy Pipes", Effect Duration: 12
+3187	improved warmed gray skewed evil philter of phorce	0		Effect: "Reedy Pipes", Effect Duration: 12
 3188	watered-down artisanal an evil sump'm sump'm	2	super EPIC	
 3189	acceptable evil ducha de oro	3	good	
 3190	delicious irresponsibly strong evil horizontal tango	6	awesome	
-3191	artisanal high-proof evil roll in the hay	7	EPIC	
+3191	high-proof artisanal evil roll in the hay	7	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3172,13 +3172,13 @@
 3200	red lump of diamond	0		
 3201	thick padded envelope	0		
 3202	coward's Annie Oakley's beefcake's KoL Con IV Pole	0		Muscle: +25, Critical Hit Percent: +20, Monster Level: -20, Last Available: "2007-09"
-3203	twirling upside-down bouncing dwarvish magazine	0		
+3203	twirling bouncing upside-down dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	upside-down dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	small laminated card	0		
-3209	wobbly skewed laminated card	0		
+3209	skewed wobbly laminated card	0		
 3210	notbig laminated card	0		
 3211	unlarge laminated card	0		
 3212	dwarvish document	0		
@@ -3195,13 +3195,13 @@
 3223	sewer nuggets	0		
 3224	sewer wad	0		
 3225	watered-down hand-crafted narrow spinning bottle of sewage schnapps	2	EPIC	
-3226	enchanted weak acceptable blurry bottle of Ooze-O	2	good	Effect: "Deeply Ironic", Effect Duration: 15
-3227	immense spoiled C.H.U.M. chum	6	crappy	
-3228	flavorless fancy diet unfortunate dumplings	1	decent	Effect: "Dancing Prowess", Effect Duration: 50
+3226	enchanted acceptable weak blurry bottle of Ooze-O	2	good	Effect: "Deeply Ironic", Effect Duration: 15
+3227	spoiled immense C.H.U.M. chum	6	crappy	
+3228	flavorless diet fancy unfortunate dumplings	1	decent	Effect: "Dancing Prowess", Effect Duration: 50
 3229	decaying goldfish liver	0		
 3230	modified gray oil of oiliness	0		Effect: "Mighty Shout", Effect Duration: 39
 3231	extremely unsafe tattered paper crown	0		Weapon Damage Percent: +100, Familiar Effect: "1xSombrero, cap 15"
-3232	rotten gigantic vanilla-frosted king cake	9	crappy	Last Available: "2008-03"
+3232	gigantic rotten vanilla-frosted king cake	9	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3240,9 +3240,9 @@
 3268	non-diffused moist yellow handful of Crotchety Pine needles	0		Effect: "Bricked-In", Effect Duration: 68
 3269	alkaline lump of Saccharine Maple sap	0		Effect: "Cranberry Cordiality", Effect Duration: 27
 3270	aerosolized galvanized improved handful of Laughing Willow bark	0		Effect: "Disco Nirvana", Effect Duration: 40
-3271	supercharged crotchety pants	0		Maximum MP Percent: +30, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	supercharged crotchety pants	0		Maximum MP Percent: +30, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	veiny Saccharine Maple pendant	0		Maximum HP: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	Usain Bolt's willowy bonnet	0		Initiative: +80, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	Usain Bolt's willowy bonnet	0		Initiative: +80, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	ghostly dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3257,9 +3257,9 @@
 3285	avaricious C.H.U.M. knife	0		Meat Drop: +30
 3286	inspector's Frosty's snowball sack	0		Item Drop: +15
 3287	quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
-3288	huge squat shimmering tendrils	0		Class: "Pastamancer"
+3288	squat huge shimmering tendrils	0		Class: "Pastamancer"
 3289	scintillating powder	0		Class: "Pastamancer"
-3290	spinning gray abandoned candy	0		
+3290	gray spinning abandoned candy	0		
 3291	tumbling secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
 3293	skewed gray blurry untamable turtle	0		
@@ -3291,12 +3291,12 @@
 3319	yellow Mr. Joe's bangles of the pedagogue	0		Experience: +3, Single Equip
 3320	yellow ribald frayed rope belt	0		Sleaze Damage: +10, Single Equip
 3321	blinking packet of mayfly bait	0		Last Available: "2008-05"
-3322	avaricious clever mayfly bait necklace	0		Maximum MP: +20, Meat Drop: +30, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	avaricious clever mayfly bait necklace	0		Maximum MP: +20, Meat Drop: +30, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	watered-down hand-crafted squat jar of fermented pickle juice	2	super ultra mega turbo EPIC	
-3326	vaporized red tumbling twirling voodoo snuff	1	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 30
-3327	miniature flavorless fancy tumbling extra-greasy slider	2	decent	Effect: "Gamer Rage", Effect Duration: 35
+3326	vaporized tumbling red twirling voodoo snuff	1	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 30
+3327	miniature fancy flavorless tumbling extra-greasy slider	2	decent	Effect: "Gamer Rage", Effect Duration: 35
 3328	mirror Samson's crumpled felt fedora	0		Experience (Muscle): +5, Item Drop: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	brainy strapping battered top-hat	0		Muscle: +5, Mysticality: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	banded brawny shapeless wide-brimmed hat	0		Muscle Percent: +20, Damage Absorption: +100, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3318,7 +3318,7 @@
 3346	spinning filth-encrusted futon	0		
 3347	comfy coffin	0		
 3348	mattress	0		
-3349	pulsating blurry dinged-up triangle	0		
+3349	blurry pulsating dinged-up triangle	0		
 3350	hand-crafted Ralph IX cognac	4	super ultra mega turbo EPIC	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
@@ -3338,7 +3338,7 @@
 3366	pickled digital underground potion	0		Effect: "Toothy Grin", Effect Duration: 49, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	vaporized glimmering roc feather	1	decent	Last Available: "2008-06"
-3369	compressed huge cyan glimmering phoenix feather	1		Last Available: "2008-06"
+3369	compressed cyan huge glimmering phoenix feather	1		Last Available: "2008-06"
 3370	vaporized glimmering penguin feather	1		Last Available: "2008-06"
 3371	denatured upside-down blurry glimmering buzzard feather	1		Last Available: "2008-06"
 3372	denatured glimmering raven feather	1		Last Available: "2008-06"
@@ -3367,8 +3367,8 @@
 3395	Van der Graaf Hodgman's porkpie hat of courage	0		Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	ribald razor-sharp Hodgman's lobsterskin pants	0		Weapon Damage Percent: +25, Sleaze Damage: +10, Familiar Effect: "atk, 1xPotato"
 3397	frosty Newton's Hodgman's bow tie	0		Experience (Mysticality): +3, Cold Spell Damage: +10, Single Equip
-3398	hand-crafted triple-distilled Hodgman's blanket	8	EPIC	
-3399	practically non-alcoholic artisanal bouncing lime green jar of squeeze	1	super ultra mega turbo EPIC	
+3398	triple-distilled hand-crafted Hodgman's blanket	8	EPIC	
+3399	artisanal practically non-alcoholic bouncing lime green jar of squeeze	1	super ultra mega turbo EPIC	
 3400	adequate small bowl of fishysoisse	2	good	
 3401	moist aerosolized deadly lampshade	0		Effect: "Gutterminded", Effect Duration: 62
 3402	deionized wobbly concentrated garbage juice	0		Effect: "Bandersnatched", Effect Duration: 22
@@ -3381,12 +3381,12 @@
 3409	sizzling Hodgman's garbage sticker	0		Hot Damage: +10
 3410	Jeselnik's Hodgman's detector	0		Sleaze Damage: +25
 3411	crafty Hodgman's cane	0		Maximum MP: +10
-3412	ghostly tumbling Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
+3412	tumbling ghostly Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
 3413	Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	green Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	shaking hobo fortress blueprints	0		
-3421	skewed box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	skewed box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	dry sterno-flavored Hob-O	0		Effect: "meat.enh", Effect Duration: 36
 3423	dry frostbite-flavored Hob-O	0		Effect: "Nano-juiced", Effect Duration: 32
 3424	polarized squat wobbly fry-oil-flavored Hob-O	0		Effect: "Human-Undead Hybrid", Effect Duration: 19
@@ -3424,26 +3424,26 @@
 3457	Junior Adventurer's merit badge of the boozehound	0		Booze Drop: +100
 3458	dry double-warmed STYX deodorant body spray	0		Effect: "Mental A-cue-ity", Effect Duration: 68
 3459	acceptable white-label gin	3	good	
-3460	stale super-sized fancy tin rations	5	decent	Effect: "Mad at Science", Effect Duration: 10
+3460	fancy stale super-sized tin rations	5	decent	Effect: "Mad at Science", Effect Duration: 10
 3461	mirror haiku challenge map	0		
 3462	terrible poem	0		
 3463	fortified drinkable maroon mirror bottle of sake	5	good	
 3464	round pebble of horror	0		Spooky Spell Damage: +25
-3465	jumbo flavorless Bash-&#332;s cereal	5	decent	Wiki Name: "Bash-Os cereal"
-3466	lard-coated healthy padded haiku katana	0		Damage Absorption: +20, Maximum HP Percent: +20, Sleaze Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3465	flavorless jumbo Bash-&#332;s cereal	5	decent	Wiki Name: "Bash-Os cereal"
+3466	lard-coated healthy padded haiku katana	0		Damage Absorption: +20, Maximum HP Percent: +20, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	skewed bargain flash powder	0		
 3468	fuchsia plastic baby of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2008-12"
 3469	tasty bite-sized blueberry-frosted king cake	1	awesome	Last Available: "2008-12"
-3470	skewed huge bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
+3470	huge skewed bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	wool forbidden Seasonal Beret of terror	0		Spell Damage Percent: +50, Spooky Spell Damage: +10, Cold Resistance: +1, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	narrow tumbling Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	non-enhanced cranberry cordial	0		Effect: "Bilious Briskness", Effect Duration: 35
 3475	tarnished warmed blackberry polite	0		Effect: "Pumped Up", Effect Duration: 32
-3476	aerosolized bouncing jittery plum lozenge	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
+3476	aerosolized jittery bouncing plum lozenge	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
 3477	non-concentrated altered pear lozenge	0		Effect: "Fortunate Resolve", Effect Duration: 28
-3478	aerosolized ionized tumbling bouncing blue peach lozenge	0		Effect: "Enraged", Effect Duration: 33
-3479	blurry shaking green balloon shield	0		Damage Reduction: 3
+3478	aerosolized ionized bouncing tumbling blue peach lozenge	0		Effect: "Enraged", Effect Duration: 33
+3479	green shaking blurry balloon shield	0		Damage Reduction: 3
 3480	spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
@@ -3462,11 +3462,11 @@
 3495	galvanized sea salt crystal	0		Effect: "Spooky Hands", Effect Duration: 24
 3496	ionized bazookafish bubble gum	0		Effect: "Saucemastery", Effect Duration: 69
 3497	artisanal bottle of Pete's Sake	4	EPIC	
-3498	shaking invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	tumbling beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	shaking invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	tumbling beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	rotten half-sized canap&eacute;s	2	crappy	
-3502	dried shaking huge thermos of brew	1	awesome	Last Available: "2011-12"
+3502	dried huge shaking thermos of brew	1	awesome	Last Available: "2011-12"
 3503	artisanal weak glass of brandy	2	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	studded LWA ring	0		Damage Absorption: +80
@@ -3488,7 +3488,7 @@
 3521	blinking sage shark tooth necklace of horror	0		Mysticality Percent: +10, Spooky Spell Damage: +25, Single Equip
 3522	blurry green shaking perfumed Socratic shark jumper	0		Experience (Mysticality): +1, Stench Resistance: +5
 3523	frozen shark cartilage	0		Effect: "Weasels Underfoot", Effect Duration: 19
-3524	dry polarized tumbling upside-down eel battery	0		Effect: "Patched In", Effect Duration: 36
+3524	dry polarized upside-down tumbling eel battery	0		Effect: "Patched In", Effect Duration: 36
 3525	ionized ionized temporary teardrop tattoo	0		Effect: "Vitali Tea", Effect Duration: 65
 3526	blue ribald scratch 'n' sniff crossbow	0		Sleaze Damage: +10, Last Available: "2008-11"
 3527	mutant rattlesnake egg	0		
@@ -3510,8 +3510,8 @@
 3543	manspreader's curative depleted Grimacite gravy boat	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-12"
 3544	skewed mansplainer's depleted Grimacite weightlifting belt of the pedagogue	0		Experience: +3, Monster Level: +15, Single Equip, Last Available: "2011-12"
 3545	bouncing forbidden strapping depleted Grimacite grappling hook	0		Muscle: +5, Spell Damage Percent: +50, Single Equip, Last Available: "2011-12"
-3546	upside-down stiffened slick depleted Grimacite ninja mask	0		Moxie: +10, Damage Reduction: 1, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	olive frightening nasty depleted Grimacite shinguards	0		Stench Damage: +5, Spooky Damage: +5, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	upside-down stiffened slick depleted Grimacite ninja mask	0		Moxie: +10, Damage Reduction: 1, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	olive frightening nasty depleted Grimacite shinguards	0		Stench Damage: +5, Spooky Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	knitted crafty depleted Grimacite astrolabe	0		Maximum MP: +10, Cold Resistance: +3, Single Equip, Last Available: "2011-12"
 3549	wobbly purple rosewater-soaked nasty KoL Con Cinco Pi&ntilde;ata Bat	0		Stench Damage: +5, Stench Resistance: +3, Softcore Only, Last Available: "2008-09"
 3550	twirling lightning-fast propeller beanie	0		Initiative: +40, Familiar Effect: "atk, cap 7"
@@ -3521,7 +3521,7 @@
 3554	glob of slime	0		
 3555	rotten sea carrot	3	crappy	
 3556	normal jittery sea cucumber	4	good	
-3557	special tasty sea avocado	4	awesome	Effect: "Piratastic", Effect Duration: 40
+3557	tasty special sea avocado	4	awesome	Effect: "Piratastic", Effect Duration: 40
 3558	adequate huge sea lychee	4	good	
 3559	adequate tumbling blinking sea tangelo	3	good	
 3560	delicious sea honeydew	4	awesome	
@@ -3542,24 +3542,24 @@
 3575	shaking sand dollar	0		
 3576	flytrap bezoar	0		
 3577	squat bezoar ring	0		
-3578	narrow cyan candy cornucopia	0		Free Pull, Last Available: "2011-12"
+3578	cyan narrow candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	ghostly wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	moldy twirling rice	3	crappy	
 3584	flavorless diet jittery irradiated candy cane	1	decent	Last Available: "2008-12"
-3585	special tasty jumbo gingerbread mutant bugbear	5	awesome	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2008-12"
-3586	strong tolerable oozenog	5	good	Last Available: "2008-12"
+3585	jumbo special tasty gingerbread mutant bugbear	5	awesome	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2008-12"
+3586	tolerable strong oozenog	5	good	Last Available: "2008-12"
 3587	alkaline double-deionized sugar plum	0		Effect: "Wet and Greedy", Effect Duration: 49, Last Available: "2008-12"
 3588	energized modified upside-down sugar banana	0		Effect: "Mmmmmelon", Effect Duration: 40, Last Available: "2008-12"
 3589	aerosolized narrow sugar lime	0		Effect: "Horrid, Torrid", Effect Duration: 19, Last Available: "2008-12"
-3590	denatured polarized upside-down maroon spinning sugar cherry	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 24, Last Available: "2008-12"
+3590	denatured polarized spinning upside-down maroon sugar cherry	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 24, Last Available: "2008-12"
 3591	careful sinister Mer-kin hookspear	0		Spell Damage: +10, Monster Level: -10
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	Mer-kin thingpouch	0		
-3594	ghostly fuchsia Mer-kin killscroll	0		
+3594	fuchsia ghostly Mer-kin killscroll	0		
 3595	denatured Mer-kin fastjuice	0		Effect: "Scavengers Scavenging", Effect Duration: 24
-3596	blinking yellow imitation crab crate	0		
+3596	yellow blinking imitation crab crate	0		
 3597	spinning imitation crab meat	0		
 3598	lime green imitation crab zoea	0		
 3599	asbestos-lined experienced cool moist sailor's cap	0		Moxie: +5, Experience: +2, Hot Resistance: +5, Familiar Effect: "stench atk"
@@ -3581,24 +3581,24 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	extra-liquefied diffused green unstable DNA	0		Effect: "Familial Ties", Effect Duration: 39, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	shaking pulsating pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	sizzling parasitic claw	0		Hot Damage: +10, Last Available: "2008-12"
-3625	gray studded parasitic tentacles	0		Damage Absorption: +80, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	forbidden parasitic headgnawer	0		Spell Damage Percent: +50, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	gray studded parasitic tentacles	0		Damage Absorption: +80, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	forbidden parasitic headgnawer	0		Spell Damage Percent: +50, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	jittery parasitic strangleworm of the bloodbag	0		Maximum HP: +100, Last Available: "2008-12"
 3628	pulsating pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
 3630	bouncing Crimbo crate	0		Last Available: "2008-12"
 3631	irradiated dry Gummi-DNA	0		Effect: "Barbecue Saucy", Effect Duration: 46, Last Available: "2020-09"
-3632	blurry cyan radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
+3632	cyan blurry radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	blinking hardened elven socks of the cougar	0		Moxie: +20, Damage Reduction: 3, Last Available: "2008-12"
 3634	mirror shellacked Socratic elven gloves	0		Experience (Mysticality): +1, Damage Reduction: 7, Last Available: "2008-12"
-3635	huge nasty slick festive holiday hat	0		Moxie: +10, Stench Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	huge nasty slick festive holiday hat	0		Moxie: +10, Stench Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	censurious hardy patent shoes	0		Maximum HP: +50, Sleaze Resistance: +3, Last Available: "2008-12"
 3637	spinning stanky flame-wreathed gray bow tie	0		Hot Spell Damage: +10, Stench Spell Damage: +25, Last Available: "2008-12"
 3638	Lo Pan's penguin thesaurus of horror	0		Spell Critical Percent: +30, Spooky Spell Damage: +25, Last Available: "2008-12"
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	decent toast with jam	4	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	hand-crafted high-proof elven moonshine	6	EPIC	Last Available: "2008-12"
-3653	decent olive knuckle sandwich	4	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	high-proof hand-crafted elven moonshine	6	EPIC	Last Available: "2008-12"
+3653	decent olive knuckle sandwich	4	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	auspicious double-paned psycho sweater	0		Cold Resistance: +5, Item Drop: +10, Last Available: "2008-12"
 3655	wobbly fin-bit wax	0		Familiar Weight: +5
 3656	Socratic plastic Mob Penguin	0		Experience (Mysticality): +1, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	lime green flame-wreathed plastic strand of DNA	0		Hot Spell Damage: +10, Last Available: "2008-12"
 3660	supercool plastic chunk of depleted Grimacite	0		Moxie Percent: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	auspicious Putty mitre	0		Item Drop: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	scandalous Putty leotard of chilblains	0		Cold Damage: +25, Sleaze Damage: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	auspicious Putty mitre	0		Item Drop: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	scandalous Putty leotard of chilblains	0		Cold Damage: +25, Sleaze Damage: +5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	smooth Putty ball	0		Moxie: +15, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	tumbling inspector's Van der Graaf dangerous Putty snake	0		Weapon Damage: +10, Item Drop: +15, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2009-01"
@@ -3635,7 +3635,7 @@
 3669	wizardly glow-in-the-dark dart gun	0		Mysticality: +25, Last Available: "2009-01"
 3670	ghostly red bouncing stylish glow-in-the-dark burrowgrub	0		Moxie: +25, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	decent small squat squat can of franks 'n' beans	2	good	Last Available: "2010-12"
+3672	small decent squat squat can of franks 'n' beans	2	good	Last Available: "2010-12"
 3673	practically non-alcoholic perfectly mixed bottle of peppermint schnapps	1	super ultra EPIC	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3650,7 +3650,7 @@
 3684	rotten huge tempura carrot	8	crappy	
 3685	flavorless snack-sized tempura cucumber	2	decent	
 3686	moldy tempura avocado	3	crappy	
-3687	flavorless bite-sized sea broccoli	1	decent	
+3687	bite-sized flavorless sea broccoli	1	decent	
 3688	moldy half-sized sea cauliflower	2	crappy	
 3689	stale purple tempura broccoli	3	decent	
 3690	normal tempura cauliflower	3	good	
@@ -3659,7 +3659,7 @@
 3693	dry blinking narrow pressurized potion of perception	0		Effect: "Frosty the Hitman", Effect Duration: 38
 3694	double-alkaline triple-activated pressurized potion of proficiency	0		Effect: "Bureaucratized", Effect Duration: 20
 3695	bouncing Mer-kin digpick of bravery	0		Spooky Resistance: +5
-3696	squat ghostly anemone nematocyst	0		
+3696	ghostly squat anemone nematocyst	0		
 3697	high-pressure seltzer bottle	0		
 3698	blurry velcro ore	0		
 3699	mirror teflon ore	0		
@@ -3667,7 +3667,7 @@
 3701	map to Anemone Mine	0		
 3702	marine aquamarine	0		
 3703	ghostly valve wheel	0		
-3704	red upside-down tumbling waterlogged bootstraps	0		
+3704	upside-down tumbling red waterlogged bootstraps	0		
 3705	blurry Sherlock's Herculean brainy velcro broadsword	0		Mysticality: +5, Experience (Muscle): +1, Item Drop: +25
 3706	narrow miser's rosewater-soaked velcro paddle ball of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +3, Meat Drop: +10
 3707	shaking velcro shield of the bloodbag of Leguizamo of bravery	0		Maximum HP: +100, Monster Level: +20, Spooky Resistance: +5, Damage Reduction: 14
@@ -3680,7 +3680,7 @@
 3714	knitted resourceful medical-grade PVC staff	0		Maximum MP: +50, Cold Resistance: +3, HP Regen Min: 7, HP Regen Max: 10
 3715	Usain Bolt's vinyl shield of bravery of the glutton	0		Spooky Resistance: +5, Food Drop: +100, Initiative: +80, Damage Reduction: 14
 3716	blurry careful razor-sharp experienced vinyl boots	0		Experience: +2, Weapon Damage Percent: +25, Monster Level: -10, Single Equip
-3717	mirror gray decaying oar	0		
+3717	gray mirror decaying oar	0		
 3718	ghostly fishhook	0		
 3719	lantern	0		
 3720	decaying pole	0		
@@ -3717,8 +3717,8 @@
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	denatured jittery love song of vague ambiguity	0		Effect: "Space Cadet", Effect Duration: 55, Last Available: "2009-02"
 3755	cold-filtered double-polarized galvanized love song of smoldering passion	0		Effect: "Shredding, Sweating", Effect Duration: 65, Last Available: "2009-02"
-3756	pressed shaking green tumbling love song of icy revenge	0		Effect: "Standard Issue Bravery", Effect Duration: 28, Last Available: "2009-02"
-3757	frozen squat red love song of sugary cuteness	0		Effect: "Almost Cool", Effect Duration: 31, Last Available: "2009-02"
+3756	pressed green tumbling shaking love song of icy revenge	0		Effect: "Standard Issue Bravery", Effect Duration: 28, Last Available: "2009-02"
+3757	frozen red squat love song of sugary cuteness	0		Effect: "Almost Cool", Effect Duration: 31, Last Available: "2009-02"
 3758	colloidal nitrogenated tumbling love song of disturbing obsession	0		Effect: "Locks Like the Raven", Effect Duration: 29, Last Available: "2009-02"
 3759	denatured flattened love song of naughty innuendo	0		Effect: "Hardened Fabric", Effect Duration: 24, Last Available: "2009-02"
 3760	colloidal spinning breath mint	0		Effect: "Radiant Personality", Effect Duration: 45
@@ -3729,7 +3729,7 @@
 3765	tolerable slug of shochu	4	good	
 3766	special acceptable bouncing screwdiver	4	good	Effect: "The Dinsey Spirit", Effect Duration: 50
 3767	lousy weak dew yoana lei	2	decent	
-3768	enchanted boozy acceptable lychee chuhai	5	good	Effect: "Sticky Fingers", Effect Duration: 50
+3768	enchanted acceptable boozy lychee chuhai	5	good	Effect: "Sticky Fingers", Effect Duration: 50
 3769	special mediocre salacious screwdiver	4	decent	Effect: "Stinky Hands", Effect Duration: 15
 3770	drinkable dew yoana salacious lei	3	good	
 3771	hand-crafted watered-down salacious lychee chuhai	2	EPIC	
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	squat Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	shaking huge charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	shaking huge charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	Jim Carey's Da Vinci's Mer-kin roundshield of the overflowing toilet	0		Experience (Mysticality): +5, Monster Level: +25, Stench Spell Damage: +50, Damage Reduction: 14
 3804	energetic Mer-kin breastplate of Calamity Jane	0		Maximum MP Percent: +20, Critical Hit Percent: +15
 3805	perfumed Mer-kin sneakmask of courage	0		Spooky Resistance: +3, Stench Resistance: +5, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,7 +3768,7 @@
 3813	plastic baby of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	small moldy sea radish	2	crappy	
+3817	moldy small sea radish	2	crappy	
 3818	halibut of dire peril of doom of the cheetah	0		Weapon Damage: +20, Spooky Spell Damage: +50, Initiative: +60
 3819	eel sauce	0		
 3820	narrow shellacked water-polo mitt	0		Damage Reduction: 7, Single Equip
@@ -3784,10 +3784,10 @@
 3830	ghostly mansplainer's water-polo cap	0		Monster Level: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable practically non-alcoholic Typical Tavern swill	1	good	
 3832	drinkable tropical swill	3	good	
-3833	acceptable triple-distilled upside-down lime green fruity girl swill	6	good	
-3834	high-proof smooth spinning blended swill	9	awesome	
+3833	triple-distilled acceptable upside-down lime green fruity girl swill	6	good	
+3834	smooth high-proof spinning blended swill	9	awesome	
 3835	costume wardrobe	0		Softcore Only
-3836	therapeutic fortified extremely unsafe Socratic Elvish sunglasses	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Damage Absorption: +60, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	therapeutic fortified extremely unsafe Socratic Elvish sunglasses	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Damage Absorption: +60, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	blinking hale anniversary safety glass vest	0		Maximum HP: +20
 3838	anniversary burlap belt of dire peril	0		Weapon Damage: +20
 3839	wobbly anniversary balsa wood socks of horror	0		Spooky Spell Damage: +25
@@ -3847,7 +3847,7 @@
 3893	moist oxidized extra-pickled vial of chartreuse slime	0		Effect: "Blessing of Charcoatl", Effect Duration: 17
 3894	denatured jittery vial of teal slime	0		Effect: "The Dinsey Way", Effect Duration: 36
 3895	anodized ghostly vial of indigo slime	0		Effect: "Heart of Green", Effect Duration: 15
-3896	dry altered cyan spinning vial of slime	0		Effect: "Boilermade", Effect Duration: 51
+3896	dry altered spinning cyan vial of slime	0		Effect: "Boilermade", Effect Duration: 51
 3897	pickled blurry vial of brown slime	0		Effect: "Feline Ferocity", Effect Duration: 13
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	ghostly figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	weak perfectly mixed bouncing blended swill with a fly in it	2	EPIC	
+3913	perfectly mixed weak bouncing blended swill with a fly in it	2	EPIC	
 3914	teal turtle wax	0		
 3915	supercharged turtle wax shield	0		Maximum MP Percent: +30, Damage Reduction: 2
 3916	bouncing chilly turtle wax helmet	0		Cold Damage: +5, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3900,7 +3900,7 @@
 3948	blinking olive Meat	0		
 3949	olive treasure chest	0		
 3950	narrow key	0		
-3951	pulsating jittery Baron von Ratsworth	0		
+3951	jittery pulsating Baron von Ratsworth	0		
 3952	monocle	0		
 3953	narrow mink	0		
 3954	teddy butler	0		
@@ -3918,7 +3918,7 @@
 3966	narrow lion tamer's coward's hot-ass club of the brute	0		Muscle Percent: +30, Monster Level: -20, Experience (familiar): +2, Class: "Seal Clubber"
 3967	lion tamer's quilted baleful frigid-ass club	0		Spell Damage: +25, Damage Absorption: +40, Experience (familiar): +2, Class: "Seal Clubber"
 3968	teal medical-grade wholesome creepy-ass club of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Class: "Seal Clubber"
-3969	unsweetened anodized bouncing wobbly purple sizzling seal fat	0		Effect: "Toast Tea", Effect Duration: 57
+3969	unsweetened anodized purple bouncing wobbly sizzling seal fat	0		Effect: "Toast Tea", Effect Duration: 57
 3970	squat smelly deadly Abyssal ember	0		Weapon Damage: +5, Stench Spell Damage: +10, Class: "Seal Clubber"
 3971	warmed tarnished liquefied frost-rimed seal hide	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 51
 3972	wholesome brainy seal spine	0		Mysticality: +5, Maximum HP Percent: +10, Class: "Seal Clubber"
@@ -3934,8 +3934,8 @@
 3982	reassuring fireproof torquoise ring	0		Hot Resistance: +3, Spooky Resistance: +1, Single Equip
 3983	dueling turtle	0		
 3984	boxer's brainy dueling banjo	0		Mysticality: +5, Muscle Percent: +10
-3985	purple shaking soup turtle	0		
-3986	pulsating mirror samurai turtle	0		
+3985	shaking purple soup turtle	0		
+3986	mirror pulsating samurai turtle	0		
 3987	wobbly ghostly sage samurai turtle helmet of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	turtle shell	0		
 3989	turtle shell powder	0		
@@ -3986,24 +3986,24 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	jittery memory of a crystal	0		Last Available: "2009-06"
 4036	fuchsia caustic slime nodule	0		
-4037	flavorless small jittery slimy sweetbreads	2	decent	
+4037	small flavorless jittery slimy sweetbreads	2	decent	
 4038	delicious slimy fermented bile bladder	3	awesome	
 4039	vaporized wobbly slimy alveolus	1		Effect: "Magically Delicious", Effect Duration: 10
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	gravedigger's vibrating pig-iron helm	0		Maximum MP Percent: +10, Spooky Damage: +10, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	savvy pig-iron shinguards of the overflowing toilet	0		Mysticality Percent: +20, Stench Spell Damage: +50, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	gravedigger's vibrating pig-iron helm	0		Maximum MP Percent: +10, Spooky Damage: +10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	savvy pig-iron shinguards of the overflowing toilet	0		Mysticality Percent: +20, Stench Spell Damage: +50, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	twirling double-paned beefy pig-iron bracers	0		Muscle: +10, Cold Resistance: +5, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
-4046	bouncing twirling wumpus-hair net	0		Last Available: "2009-06"
+4046	twirling bouncing wumpus-hair net	0		Last Available: "2009-06"
 4047	Temple Grandin's wumpus-hair whip	0		Familiar Weight: +7, Last Available: "2009-06"
-4048	energetic veiny baleful wumpus-hair wig	0		Spell Damage: +25, Maximum HP: +10, Maximum MP Percent: +20, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	Socratic brawny wumpus-hair loincloth of the sewer	0		Muscle Percent: +20, Experience (Mysticality): +1, Stench Damage: +25, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	energetic veiny baleful wumpus-hair wig	0		Spell Damage: +25, Maximum HP: +10, Maximum MP Percent: +20, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	Socratic brawny wumpus-hair loincloth of the sewer	0		Muscle Percent: +20, Experience (Mysticality): +1, Stench Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	experienced wumpus-hair sweater of the cheetah	0		Experience: +2, Initiative: +60, Last Available: "2009-06"
 4051	beefcake's ring of teleportation	0		Muscle: +25, Single Equip
 4052	glass of baboon milk	1	EPIC	Last Available: "2009-06"
 4053	shaking banana milkshake	1	awesome	Last Available: "2009-06"
-4054	perfectly mixed high-proof gray White Hyborian	6	EPIC	Last Available: "2009-06"
+4054	high-proof perfectly mixed gray White Hyborian	6	EPIC	Last Available: "2009-06"
 4055	bouncing yellow Van der Graaf goblin hunting spear	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2009-06"
 4056	beefy goblin autoblowgun of courage	0		Muscle: +10, Spooky Resistance: +3, Last Available: "2009-06"
 4057	tribal beads of the blizzard	0		Cold Spell Damage: +25, Last Available: "2009-06"
@@ -4011,11 +4011,11 @@
 4059	censurious stone head	0		Sleaze Resistance: +3, Damage Reduction: 5, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	squat Violet Hunt Invitation	0		Last Available: "2009-06"
-4062	shaking narrow Blue Milk Club Card	0		Last Available: "2009-06"
+4062	narrow shaking Blue Milk Club Card	0		Last Available: "2009-06"
 4063	upside-down Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
-4066	wobbly red Ruby Rod	0		Last Available: "2009-06"
+4066	red wobbly Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
@@ -4032,8 +4032,8 @@
 4080	personal trainer's grisly shield of James Dean	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Slime Hates It: +1, Damage Reduction: 13
 4081	corroded breeches of the pedagogue of the detective	0		Experience: +3, Item Drop: +20, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	pernicious cudgel of doom of temperance	0		Spooky Spell Damage: +50, Sleaze Resistance: +5, Slime Hates It: +1
-4083	big bland cupcake-in-a-cup	5	decent	Last Available: "2009-06"
-4084	mirror ghostly pool of liquid	0		Last Available: "2009-06"
+4083	bland big cupcake-in-a-cup	5	decent	Last Available: "2009-06"
+4084	ghostly mirror pool of liquid	0		Last Available: "2009-06"
 4085	decent protein paste	4	good	Last Available: "2009-06"
 4086	aromatic Annie Oakley's cyber-mattock	0		Critical Hit Percent: +20, Stench Resistance: +1, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
@@ -4079,13 +4079,13 @@
 4127	cyan forbidden hardened slime hat of the cougar of Calamity Jane	0		Moxie: +20, Spell Damage Percent: +50, Critical Hit Percent: +15, Familiar Effect: "1xFairy"
 4128	censurious curative studded hardened slime pants	0		Damage Absorption: +80, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xPotato"
 4129	narrow gravedigger's veiny hardened slime belt of horror	0		Maximum HP: +10, Spooky Damage: +10, Spooky Spell Damage: +25, Single Equip
-4130	twirling gray empty agua de vida bottle	0		Last Available: "2009-06"
-4131	boiled huge cyan boot plant	1	good	Last Available: "2009-06"
-4132	fancy drinkable wobbly jittery sham champagne	4	good	Effect: "Neutered Nostrils", Effect Duration: 45, Last Available: "2009-06"
+4130	gray twirling empty agua de vida bottle	0		Last Available: "2009-06"
+4131	boiled cyan huge boot plant	1	good	Last Available: "2009-06"
+4132	fancy drinkable jittery wobbly sham champagne	4	good	Effect: "Neutered Nostrils", Effect Duration: 45, Last Available: "2009-06"
 4133	triple-polymerized corrupted tempura air	0		Effect: "Demonic Flavor", Effect Duration: 48
 4134	energized pulsating pressurized potion of pneumaticity	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 45
 4135	yellow moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	miser's inspector's padded forbidden Bag o' Tricks	0		Spell Damage Percent: +50, Damage Absorption: +20, Item Drop: +15, Meat Drop: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	miser's inspector's padded forbidden Bag o' Tricks	0		Spell Damage Percent: +50, Damage Absorption: +20, Item Drop: +15, Meat Drop: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	squat slime stack	0		
 4138	a rumpled paper strip	0		
 4139	squat a creased paper strip	0		
@@ -4113,7 +4113,7 @@
 4161	stale rocky road ice cream	3	decent	Last Available: "2009-09"
 4162	huge extra-strength rubber bands	0		Familiar Weight: +5
 4163	nitrogenated quantum children of the candy corn	0		Effect: "Wintergreen Warmongery", Effect Duration: 69
-4164	irradiated electrified ghostly blurry Good 'n' Slimy	0		Effect: "Fishy", Effect Duration: 63
+4164	irradiated electrified blurry ghostly Good 'n' Slimy	0		Effect: "Fishy", Effect Duration: 63
 4165	inspector's fireproof forbidden Staff of the Soupbone	0		Spell Damage Percent: +50, Hot Resistance: +3, Item Drop: +15
 4166	huge curative Voluminous Radio Pants	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xGhoul, cap 37"
 4167	huge Voluminous Radio Hat of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4130,15 +4130,15 @@
 4178	upside-down jittery rosy-cheeked sugar shotgun	0		Maximum HP Percent: +30, Last Available: "2009-09"
 4179	rosewater-soaked sugar shillelagh	0		Stench Resistance: +3, Last Available: "2009-09"
 4180	sugar shank of the storm	0		Maximum MP Percent: +40, Last Available: "2009-09"
-4181	avaricious Jim Carey's mansplainer's sugar chapeau	0		Monster Level: 40, Meat Drop: +30, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	tumbling Usain Bolt's sugar shorts	0		Initiative: +80, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	avaricious Jim Carey's mansplainer's sugar chapeau	0		Monster Level: 40, Meat Drop: +30, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	tumbling Usain Bolt's sugar shorts	0		Initiative: +80, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	tumbling bouncing sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
 4186	slime convention coupons	0		
 4187	toasty slime convention pin	0		Hot Damage: +5
 4188	bouncing slime convention t-shirt	0		
-4189	wobbly olive twirling inverse geode	0		
+4189	twirling olive wobbly inverse geode	0		
 4190	mirror control crystal	0		Free Pull, Last Available: "2011-12"
 4191	blurry crafty sugar shirt	0		Maximum MP: +10, Last Available: "2009-09"
 4192	sugar shard	0		Last Available: "2009-09"
@@ -4178,7 +4178,7 @@
 4226	blinking scandalous Star of Bravery	0		Sleaze Damage: +5, Single Equip
 4227	bouncing skewed hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	narrow perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	tumbling amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	tumbling amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	squat bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	lime green ice skate doll	0		
@@ -4197,7 +4197,7 @@
 4245	maroon bookmark	0		
 4246	wobbly Van der Graaf ivory cue ball	0		MP Regen Min: 5, MP Regen Max: 7
 4247	tolerable decanter of fine Scotch	4	good	
-4248	boiled twirling tumbling expensive cigar	1		
+4248	boiled tumbling twirling expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
@@ -4207,14 +4207,14 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	double-liquefied unsweetened sap	0		Effect: "Red Misty-Eyed", Effect Duration: 50, Last Available: "2009-10"
 4257	wobbly petrified wood	0		Last Available: "2009-10"
-4258	moldy super-sized chocolate-covered scarab beetle	5	crappy	Last Available: "2009-10"
+4258	super-sized moldy chocolate-covered scarab beetle	5	crappy	Last Available: "2009-10"
 4259	artisanal blue mulled cider	3	EPIC	Last Available: "2009-10"
-4260	blurry wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	upside-down mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	blurry wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	upside-down mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	mirror Ax of L'rose	0		Last Available: "2009-10"
-4264	bark boxers of the storm	0		Maximum MP Percent: +40, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	weightlifter's bark beret	0		Muscle: +15, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	bark boxers of the storm	0		Maximum MP Percent: +40, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	weightlifter's bark beret	0		Muscle: +15, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	lime green greasy bark bracelet	0		Sleaze Spell Damage: +10, Single Equip
 4267	aromatic strapping Krakrox's Loincloth	0		Muscle: +5, Stench Resistance: +1, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	crafty razor-sharp Galapagosian Cuisses	0		Weapon Damage Percent: +25, Maximum MP: +10, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4223,7 +4223,7 @@
 4271	censurious Volartta's bellbottoms of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 4272	squat horrifying supercool Lederhosen of the Night	0		Moxie Percent: +20, Spooky Damage: +25, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
 4273	electrified frozen ribbon candy	0		Effect: "Bandersnatched", Effect Duration: 48, Last Available: "2020-09"
-4274	upside-down mirror Underworld acorn	0		Free Pull, Last Available: "2009-10"
+4274	mirror upside-down Underworld acorn	0		Free Pull, Last Available: "2009-10"
 4275	Underworld trunk	0		Last Available: "2009-10"
 4276	resourceful Herculean Underworld truncheon of incineration	0		Experience (Muscle): +1, Maximum MP: +50, Hot Spell Damage: +50, Last Available: "2009-10"
 4277	pulsating dog trainer's Van der Graaf ruddy Staff of the Woodfire	0		Maximum HP Percent: +40, Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	miser's Tesla vibrating Ass-Stompers of Violence	0		Maximum MP Percent: +10, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	shellacked smartaleck's boxer's Brand of Violence	0		Muscle Percent: +10, Moxie Percent: +30, Damage Reduction: 7, Conditional Skill (Equipped): "Brand"
 4299	huge rosewater-soaked Novelty Belt Buckle of Violence of dire peril of Flo-Jo	0		Weapon Damage: +20, Stench Resistance: +3, Initiative: +100, Single Equip
-4300	tumbling narrow prompt padded Lens of Violence of the bloodbag	0		Damage Absorption: +20, Maximum HP: +100, Adventures: +3, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	tumbling narrow prompt padded Lens of Violence of the bloodbag	0		Damage Absorption: +20, Maximum HP: +100, Adventures: +3, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	jittery aromatic Pigsticker of Violence of the storm of Calamity Jane	0		Maximum MP Percent: +40, Critical Hit Percent: +15, Stench Resistance: +1
-4302	skewed yellow executive Socratic Jodhpurs of Violence	0		Experience (Mysticality): +1, Item Drop: +5, Meat Drop: +40, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	skewed yellow executive Socratic Jodhpurs of Violence	0		Experience (Mysticality): +1, Item Drop: +5, Meat Drop: +40, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	rosy-cheeked razor-sharp Cold Stone of Hatred of the businessman	0		Weapon Damage Percent: +25, Maximum HP Percent: +30, Meat Drop: +50, Conditional Skill (Equipped): "Chilling Grip"
 4304	weightlifter's strapping Girdle of Hatred of the bloodbag	0		Muscle: 20, Maximum HP: +100, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	Usain Bolt's thinker's Staff of Simmering Hatred of vim and vigor	0		Mysticality: +10, Maximum HP Percent: +50, Initiative: +80
-4306	skewed curative slick Pantaloons of Hatred of Calamity Jane	0		Moxie: +10, Critical Hit Percent: +15, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	skewed curative slick Pantaloons of Hatred of Calamity Jane	0		Moxie: +10, Critical Hit Percent: +15, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	perfumed supercharged Fuzzy Slippers of Hatred of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25, Stench Resistance: +5, Single Equip
-4308	fireproof smooth Lens of Hatred of Flo-Jo	0		Moxie: +15, Hot Resistance: +3, Initiative: +100, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	fireproof smooth Lens of Hatred of Flo-Jo	0		Moxie: +15, Hot Resistance: +3, Initiative: +100, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	twirling Temple Grandin's supercharged beefcake's Treads of Loathing	0		Muscle: +25, Maximum MP Percent: +30, Familiar Weight: +7, Single Equip
 4310	rosewater-soaked frightening rosy-cheeked Scepter of Loathing	0		Maximum HP Percent: +30, Spooky Damage: +5, Stench Resistance: +3
 4311	wholesome fortified padded Belt of Loathing	0		Damage Absorption: 80, Maximum HP Percent: +10, Single Equip
@@ -4279,7 +4279,7 @@
 4327	resourceful Herculean boxer's La Hebilla del Cintur&oacute;n de Lopez	0		Muscle Percent: +10, Experience (Muscle): +1, Maximum MP: +50, Class: "Accordion Thief", Single Equip
 4328	skewed suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	blurry bag of many confections	0		Last Available: "2009-12"
-4330	rotten massive candy kneecapping stick	6	crappy	Last Available: "2009-12"
+4330	massive rotten candy kneecapping stick	6	crappy	Last Available: "2009-12"
 4331	adequate super-sized licorice garrote	5	good	Last Available: "2009-12"
 4332	spinning Tesla candy knuckles	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-12"
 4333	stale bite-sized jawbruiser	1	decent	Last Available: "2010-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	jittery gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	lime green rock-hard snow hat	0		Damage Reduction: 5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	red ruddy snow pants	0		Maximum HP Percent: +40, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	lime green rock-hard snow hat	0		Damage Reduction: 5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	red ruddy snow pants	0		Maximum HP Percent: +40, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	narrow extremely unsafe snow belly	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	lime green Crimbough	0		Last Available: "2009-12"
@@ -4310,11 +4310,11 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	mirror A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	half-sized rotten expired can of franks 'n' beans	2	crappy	Last Available: "2009-12"
-4361	tolerable jittery blue twirling expired bottle of peppermint schnapps	3	good	Last Available: "2009-12"
+4361	tolerable jittery twirling blue expired bottle of peppermint schnapps	3	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
-4364	super-pickled tumbling blinking elven suicide capsule	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 37, Last Available: "2009-12"
-4365	miniature bland special blinking penguin focaccia bread	2	decent	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2009-12"
+4364	super-pickled blinking tumbling elven suicide capsule	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 37, Last Available: "2009-12"
+4365	special miniature bland blinking penguin focaccia bread	2	decent	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2009-12"
 4366	drinkable twirling herringcello	3	good	Last Available: "2009-12"
 4367	artisanal elven cellocello	4	EPIC	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
@@ -4324,7 +4324,7 @@
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
-4375	mirror blurry spiraling shape	0		Last Available: "2009-12"
+4375	blurry mirror spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
 4377	prompt throwing wrench	0		Adventures: +3, Last Available: "2009-12"
 4378	pair of bolt cutters of the sewer	0		Stench Damage: +25, Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	fuchsia dance instructor's pocketwatch on a chain of the brazier	0		Experience Percent (Moxie): +10, Hot Spell Damage: +25, Last Available: "2009-12"
 4386	ghostly shellacked sage cement sandals	0		Mysticality Percent: +10, Damage Reduction: 7, Single Equip, Last Available: "2009-12"
 4387	twirling blurry Fonzie's night-vision goggles of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	fuchsia peanut brittle shield of bravery	0		Spooky Resistance: +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	Red Rover BB gun of Leguizamo of the brazier	0		Monster Level: +20, Hot Spell Damage: +25, Last Available: "2009-12"
-4391	Lo Pan's red-and-green sweater	0		Spell Critical Percent: +30, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	Lo Pan's red-and-green sweater	0		Spell Critical Percent: +30, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	tumbling Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	Vulcanized Crimbo peppermint bark	0		Effect: "Joyful Resolve", Effect Duration: 57, Last Available: "2009-12"
 4394	Vulcanized non-unsweetened dry blurry Crimbo fudge	0		Effect: "Greedy Resolve", Effect Duration: 58, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	squat crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	sinister cheese sword	0		Spell Damage: +10, Softcore Only, Last Available: "2010-01"
-4400	cheese diaper of incineration	0		Hot Spell Damage: +50, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	cheese diaper of incineration	0		Hot Spell Damage: +50, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	double-paned cheese wheel	0		Cold Resistance: +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	cheese eye of the empath	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	cheese eye of the empath	0		Familiar Weight: +5, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	spinning huge prompt Staff of Queso Escusado of Gandalf of the early riser	0		Spell Critical Percent: +20, Adventures: 10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	normal low-calorie quantum taco	0		Last Available: "2010-10"
-4413	mediocre special ghostly Schr&ouml;dinger's thermos	0		Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2010-04"
+4413	special mediocre ghostly Schr&ouml;dinger's thermos	0		Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	beefcake's sealhide hood	0		Muscle: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	upside-down wholesome sealhide leggings	0		Maximum HP Percent: +10, Familiar Effect: "1xVolley, cap 40"
@@ -4396,7 +4396,7 @@
 4448	boiled fuchsia ghostly Instant Karma	1	decent	Effect: "Mushroom Samba", Effect Duration: 45
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	lion tamer's pointy hat	0		Experience (familiar): +2, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	lion tamer's pointy hat	0		Experience (familiar): +2, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	machetito of the cougar	0		Moxie: +20, Last Available: "2010-04"
 4453	chaotic lawnmower blade	0		Spell Critical Percent: +10, Last Available: "2010-04"
 4454	shaking grass clippings	0		Last Available: "2023-12"
@@ -4410,21 +4410,21 @@
 4462	frozen vacuum-sealed quadruple-activated chocolate seal-clubbing club	0		Effect: "Inappropriate Spirit", Effect Duration: 15
 4463	deionized dry extra-warmed yellow chocolate turtle totem	0		Effect: "On the Shoulders of Giants", Effect Duration: 48
 4464	polarized skewed chocolate pasta spoon	0		Effect: "Wet Rub", Effect Duration: 23
-4465	activated skewed spinning chocolate saucepan	0		Effect: "Cockroach Scurry", Effect Duration: 12
+4465	activated spinning skewed chocolate saucepan	0		Effect: "Cockroach Scurry", Effect Duration: 12
 4466	adjusted ionized cold-filtered chocolate disco ball	0		Effect: "Moon'd", Effect Duration: 50
 4467	Vulcanized chocolate stolen accordion	0		Effect: "Whole Latte Love", Effect Duration: 56
 4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	ghostly BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	jittery Temple Grandin's BRICKO hat	0		Familiar Weight: +7, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	upside-down BRICKO pants of bravery	0		Spooky Resistance: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	jittery Temple Grandin's BRICKO hat	0		Familiar Weight: +7, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	upside-down BRICKO pants of bravery	0		Spooky Resistance: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	savvy BRICKO sword	0		Mysticality Percent: +20, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
-4475	bouncing jittery BRICKO bat	0		Last Available: "2010-02"
+4475	jittery bouncing BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	squat BRICKO elephant	0		Last Available: "2010-02"
-4479	mirror BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	mirror BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4450,16 +4450,16 @@
 4502	non-adjusted recording of Donho's Bubbly Ballad	0		Effect: "Turkey-Agitated", Effect Duration: 47
 4503	colloidal recording of Inigo's Incantation of Inspiration	0		Effect: "Hustlin'", Effect Duration: 35, Last Available: "2010-02"
 4504	Sinatra's cool heart of the volcano	0		Moxie: +5, Experience (Moxie): +5
-4505	enhanced wobbly tumbling Northern pemmican	0		Effect: "Whitened Teeth", Effect Duration: 21
+4505	enhanced tumbling wobbly Northern pemmican	0		Effect: "Whitened Teeth", Effect Duration: 21
 4506	twirling puzzling ribbon	0		
 4507	ghostly Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	pressed &quot;DRINK ME&quot; potion	0		Effect: "Natural 20", Effect Duration: 69, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	gigantic yummy walrus ice cream	6	awesome	Last Available: "2010-03"
-4511	bland small beautiful soup	2	decent	Last Available: "2010-03"
-4512	mirror jittery eggman noodles	0		Last Available: "2010-03"
+4511	small bland beautiful soup	2	decent	Last Available: "2010-03"
+4512	jittery mirror eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	special stale massive Humpty Dumplings	9	decent	Effect: "Cold Blooded", Effect Duration: 20, Last Available: "2010-03"
+4514	stale massive special Humpty Dumplings	9	decent	Effect: "Cold Blooded", Effect Duration: 20, Last Available: "2010-03"
 4515	low-calorie decent mirror Lobster <i>qua</i> Grill	1	good	Last Available: "2010-03"
 4516	drinkable missing wine	3	good	Last Available: "2010-03"
 4517	low-calorie spoiled lime green matter custard	1	crappy	Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	blinking croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	chaotic electrified eye of the Tiger-lily	0		Spell Critical Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-03"
-4524	fortified wig of courage	0		Damage Absorption: +60, Spooky Resistance: +3, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	fortified wig of courage	0		Damage Absorption: +60, Spooky Resistance: +3, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	bland donut	3	decent	Last Available: "2010-03"
 4526	rotten bucket of honey	4	crappy	Last Available: "2010-03"
 4527	healthy studded elephant stinger	0		Damage Absorption: +80, Maximum HP Percent: +20, Last Available: "2010-03"
-4528	flavorless miniature dragon snaps	2	decent	Last Available: "2010-03"
+4528	miniature flavorless dragon snaps	2	decent	Last Available: "2010-03"
 4529	blinking yellow Herculean snapdragon pistil of incineration	0		Experience (Muscle): +1, Hot Spell Damage: +50, Last Available: "2010-03"
 4530	red skewed puff of smoke	0		Last Available: "2010-03"
-4531	huge adequate fancy mirror rook cookie	6	good	Effect: "Unusual Perspective", Effect Duration: 40, Last Available: "2010-03"
+4531	adequate fancy huge mirror rook cookie	6	good	Effect: "Unusual Perspective", Effect Duration: 40, Last Available: "2010-03"
 4532	normal immense blue bishop cookie	10	good	Last Available: "2010-03"
-4533	flavorless low-calorie knight cookie	1	decent	Last Available: "2010-03"
-4534	fancy tasty king cookie	4	awesome	Effect: "Coldfinger", Effect Duration: 40, Last Available: "2010-03"
+4533	low-calorie flavorless knight cookie	1	decent	Last Available: "2010-03"
+4534	tasty fancy king cookie	4	awesome	Effect: "Coldfinger", Effect Duration: 40, Last Available: "2010-03"
 4535	snack-sized rotten teal queen cookie	2	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	insane tophat of Gandalf	0		Spell Critical Percent: +20, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	blinking clever helm of the knight of extreme caution	0		Maximum MP: +20, Monster Level: -25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	insane tophat of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	blinking clever helm of the knight of extreme caution	0		Maximum MP: +20, Monster Level: -25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	personal trainer's wristwatch of the knight of the brute	0		Muscle Percent: +30, Experience Percent (Muscle): +10, Single Equip, Last Available: "2010-03"
-4540	Tesla groovy trousers of the knight	0		Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	Tesla groovy trousers of the knight	0		Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	tophat of extreme caution	0		Monster Level: -25, Familiar Effect: "1xBarrr, cap 25"
 4542	tie of the businessman	0		Meat Drop: +50, Single Equip
 4543	bouncing wicked tuxedo pants	0		Spell Damage: +5, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4515,21 +4515,21 @@
 4567	smelly experienced flyest of shirts	0		Experience: +2, Stench Spell Damage: +10, Last Available: "2010-04"
 4568	flavorless half-sized maroon a dance upon the palate	2	decent	Last Available: "2010-04"
 4569	flavorless miniature prehistoric meteorite jawbreaker	2	decent	Last Available: "2010-04"
-4570	tumbling skewed Crazyleg's razor	0		Last Available: "2010-04"
-4571	stale super-sized squirmy violent party snack	5	decent	Last Available: "2010-04"
+4570	skewed tumbling Crazyleg's razor	0		Last Available: "2010-04"
+4571	super-sized stale squirmy violent party snack	5	decent	Last Available: "2010-04"
 4572	can-you-dig-it? of the wise owl	0		Mysticality: +20, Last Available: "2010-04"
 4573	blinking The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	electrified dry Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Gummibrain", Effect Duration: 64, Last Available: "2010-04"
 4580	mirror huge Temple Grandin's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Familiar Weight: +7, Last Available: "2010-04"
-4581	razor-sharp T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the glutton	0		Weapon Damage Percent: +25, Food Drop: +100, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	razor-sharp T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the glutton	0		Weapon Damage Percent: +25, Food Drop: +100, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	purple glob of skin	0		
-4584	gigantic delicious wobbly six wedges of goat cheese	8	awesome	
+4584	delicious gigantic wobbly six wedges of goat cheese	8	awesome	
 4585	upside-down collection of objects	0		
 4586	huge boulder	0		
 4587	goth	0		
@@ -4537,20 +4537,20 @@
 4589	lard-coated pixel whip	0		Sleaze Spell Damage: +25
 4590	huge nasty pixel chain whip	0		Stench Damage: +5, Last Available: "2010-07"
 4591	pixel morning star of the cheetah	0		Initiative: +60, Last Available: "2010-07"
-4592	spinning lime green pixel orb	0		Last Available: "2010-07"
+4592	lime green spinning pixel orb	0		Last Available: "2010-07"
 4593	pixellated moneybag	0		Last Available: "2010-07"
 4594	pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
 4597	8-Bit Power magazine	0		Last Available: "2010-07"
-4598	shaking narrow pixel stopwatch	0		Last Available: "2010-07"
+4598	narrow shaking pixel stopwatch	0		Last Available: "2010-07"
 4599	blinking bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	irresponsibly strong drinkable blue bouncing plastic cup of beer	7	good	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	blurry keg	0		Last Available: "2010-06"
-4605	blinking stylish bottle of Goldschn&ouml;ckered of temperance	0		Moxie: +25, Sleaze Resistance: +5, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	blinking stylish bottle of Goldschn&ouml;ckered of temperance	0		Moxie: +25, Sleaze Resistance: +5, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	adequate sun-dried tofu	4	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	acceptable soyburger juice	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	lion tamer's Crown of Thrones	0		Experience (familiar): +2, Softcore Only, Last Available: "2010-05"
-4615	fancy weak mediocre Cinco Mayo Lager	2	decent	Effect: "Pumped Up", Effect Duration: 35, Last Available: "2010-05"
+4615	weak fancy mediocre Cinco Mayo Lager	2	decent	Effect: "Pumped Up", Effect Duration: 35, Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	tumbling pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4574,15 +4574,15 @@
 4626	squat squat superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	jittery plastic spider ring of the ox	0		Muscle: +20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	jittery plastic spider ring of the ox	0		Muscle: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	maroon plastic kazoo of the boozehound	0		Booze Drop: +100, Last Available: "2010-06"
 4631	electrified inflatable baseball bat	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-06"
-4632	pulsating frightening scorching googly-star hat	0		Hot Damage: +25, Spooky Damage: +5, Last Available: "2010-06", Familiar Effect: "atk"
+4632	pulsating frightening scorching googly-star hat	0		Hot Damage: +25, Spooky Damage: +5, Familiar Effect: "atk", Last Available: "2010-06"
 4633	blinking padded googly-ball hat of the sweet-tooth	0		Damage Absorption: +20, Candy Drop: +100, Last Available: "2010-06"
 4634	foul-smelling frosty googly-heart hat	0		Cold Spell Damage: +10, Stench Damage: +10, Last Available: "2010-06"
 4635	zippy padded super-sweet boom box	0		Damage Absorption: +20, Initiative: +20, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	reassuring wicked Rosewater's sinister demon mask	0		Mysticality Percent: +30, Spell Damage: +5, Spooky Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	reassuring wicked Rosewater's sinister demon mask	0		Mysticality Percent: +30, Spell Damage: +5, Spooky Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	beefy streetfighting champion's belt of temperance of the sweet-tooth	0		Muscle: +10, Sleaze Resistance: +5, Candy Drop: +100, Single Equip, Last Available: "2010-06"
 4639	wool chaotic brainy Space Trip safety headphones	0		Mysticality: +5, Spell Critical Percent: +10, Cold Resistance: +1, Single Equip, Last Available: "2010-06"
 4640	friendly LARP carp	0		Familiar Weight: +3
@@ -4594,8 +4594,8 @@
 4646	flame-retardant groovy Meteoid ice beam of the empath	0		Moxie Percent: +10, Familiar Weight: +5, Hot Resistance: +1, Last Available: "2011-12"
 4647	veiny Da Vinci's Dungeon Fist gauntlet of the dark arts	0		Experience (Mysticality): +5, Spell Damage Percent: +100, Maximum HP: +10, Last Available: "2011-06"
 4648	twirling Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	mirror chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	mirror chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	ghostly vibrating rock-hard ironic knit cap	0		Damage Reduction: 5, Maximum MP Percent: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	blurry ironic sunglasses	0		Single Equip
@@ -4607,7 +4607,7 @@
 4659	bouncing pulsating rosy-cheeked blackberry galoshes	0		Maximum HP Percent: +30, Single Equip
 4660	ruddy trout fang of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +40, Last Available: "2010-09"
 4661	normal wobbly poisonous caviar	3	good	Last Available: "2010-09"
-4662	frozen blue tumbling wet venom duct	0		Effect: "Turkey-Agitated", Effect Duration: 12, Last Available: "2010-09"
+4662	frozen tumbling blue wet venom duct	0		Effect: "Turkey-Agitated", Effect Duration: 12, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	rock-hard razor-sharp Ellsbury's skull	0		Weapon Damage Percent: +25, Damage Reduction: 5, Last Available: "2010-09"
 4665	squat arcane researcher's hot plate	0		Experience Percent (Mysticality): +10, Damage Reduction: 3
@@ -4617,9 +4617,9 @@
 4669	deadly hilarious comedy prop	0		Weapon Damage: +5
 4670	blurry beer-scented teddy bear	0		
 4671	watered-down lousy blurry booze-soaked cherry	2	decent	
-4672	huge twirling comfy pillow	0		
+4672	twirling huge comfy pillow	0		
 4673	rotten marshmallow	3	crappy	
-4674	big normal sponge cake	5	good	
+4674	normal big sponge cake	5	good	
 4675	mediocre triple-distilled tumbling gin-soaked blotter paper	8	decent	
 4676	blurry ghostly tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	squat volcanic ash	0		
 4680	smoked potsherd	0		
 4681	gray ghostly Van der Graaf pottery shield	0		MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 3, Last Available: "2010-09"
-4682	aromatic double-paned pottery hat	0		Cold Resistance: +5, Stench Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	upside-down pottery training pants of the storm of Leguizamo	0		Maximum MP Percent: +40, Monster Level: +20, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	aromatic double-paned pottery hat	0		Cold Resistance: +5, Stench Resistance: +1, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	upside-down pottery training pants of the storm of Leguizamo	0		Maximum MP Percent: +40, Monster Level: +20, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	tumbling pottery club of doom	0		Spooky Spell Damage: +50, Last Available: "2010-09"
 4685	Jack Frost's pottery yo-yo	0		Cold Spell Damage: +50, Last Available: "2010-09"
 4686	jittery pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4639,9 +4639,9 @@
 4691	fossilized wing	0		Last Available: "2010-09"
 4692	red fossilized limb	0		Last Available: "2010-09"
 4693	narrow fossilized torso	0		Last Available: "2010-09"
-4694	mirror blue skewed fossilized spine	0		Last Available: "2010-09"
+4694	blue mirror skewed fossilized spine	0		Last Available: "2010-09"
 4695	mirror affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	huge flame-wreathed electrified occult Greatest American Pants	0		Spell Damage Percent: +25, Hot Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	huge flame-wreathed electrified occult Greatest American Pants	0		Spell Damage Percent: +25, Hot Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	narrow vibrating fossilized necklace	0		Maximum MP Percent: +10, Last Available: "2010-09"
 4698	mirror imp air	0		
 4699	blurry bus pass	0		
@@ -4651,7 +4651,7 @@
 4703	red-hot medallion of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2010-09"
 4704	pulsating fossilized demon skull	0		Last Available: "2010-09"
 4705	ghostly fossilized spider skull	0		Last Available: "2010-09"
-4706	blinking red sinister tablet	0		
+4706	red blinking sinister tablet	0		
 4707	spinning E-Z Cook&trade; oven	0		
 4708	purple My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
@@ -4659,7 +4659,7 @@
 4711	green sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	moldy enchanted huge lemon popsicle	8	crappy	Effect: "Sepia Tan", Effect Duration: 30
+4714	enchanted huge moldy lemon popsicle	8	crappy	Effect: "Sepia Tan", Effect Duration: 30
 4715	moldy popsicle	3	crappy	
 4716	tasty skewed strawberry popsicle	4	awesome	
 4717	moldy liver popsicle	3	crappy	
@@ -4668,12 +4668,12 @@
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	flavorless wobbly liver and let pie	4	decent	Last Available: "2010-10"
-4723	decent special badass pie	4	good	Effect: "Once Bitten Twice Fried", Effect Duration: 15, Last Available: "2010-10"
+4723	special decent badass pie	4	good	Effect: "Once Bitten Twice Fried", Effect Duration: 15, Last Available: "2010-10"
 4724	spoiled big shoo-fish pie	5	crappy	Last Available: "2010-10"
 4725	normal piping organ pie	4	good	Last Available: "2010-10"
 4726	spoiled igloo pie	4	crappy	Last Available: "2010-10"
-4727	tiny rotten stomach turnover	1	crappy	Last Available: "2010-10"
-4728	rotten huge dead lights pie	8	crappy	Last Available: "2010-10"
+4727	rotten tiny stomach turnover	1	crappy	Last Available: "2010-10"
+4728	huge rotten dead lights pie	8	crappy	Last Available: "2010-10"
 4729	moldy throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	mansplainer's stop shield	0		Monster Level: +15, Damage Reduction: 6, Last Available: "2009-12"
 4731	twirling nest egg	0		
@@ -4685,22 +4685,22 @@
 4737	ghostly savvy beer-soaked mop	0		Mysticality Percent: +20
 4738	acceptable day-old beer	3	good	
 4739	bad plain beer	3	decent	
-4740	lousy distilled overpriced &quot;imported&quot; beer	5	decent	
+4740	distilled lousy overpriced &quot;imported&quot; beer	5	decent	
 4741	wobbly lime green smiling rat	0		
 4742	jittery rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	anodized polymerized PlexiPips	0		Effect: "Bilious Briskness", Effect Duration: 35
 4745	dry super-chilled Wax Flask	0		Effect: "Spirit of Alph", Effect Duration: 42
 4746	ionized boiled polarized Pain Dip	0		Effect: "Orchid Blood", Effect Duration: 31
-4747	gigantic flavorless bone meal	8	decent	Last Available: "2010-10"
+4747	flavorless gigantic bone meal	8	decent	Last Available: "2010-10"
 4748	weak tolerable ghostly bone aperitif	2	good	Last Available: "2010-10"
 4749	careful bonerang	0		Monster Level: -10, Last Available: "2010-10"
 4750	Newton's bone and arrows	0		Experience (Mysticality): +3, Last Available: "2010-10"
 4751	blinking scorching boning knife	0		Hot Damage: +25, Last Available: "2010-10"
 4752	bone crusher of incineration	0		Hot Spell Damage: +50, Last Available: "2010-10"
 4753	groovy bone spurs	0		Moxie Percent: +10, Single Equip, Last Available: "2010-10"
-4754	sizzling Temple Grandin's bonedanna	0		Familiar Weight: +7, Hot Damage: +10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	skewed bouncing beefy boneana hammock of the glutton	0		Muscle: +10, Food Drop: +100, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	sizzling Temple Grandin's bonedanna	0		Familiar Weight: +7, Hot Damage: +10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	skewed bouncing beefy boneana hammock of the glutton	0		Muscle: +10, Food Drop: +100, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	polarized wobbly blurry candy skeleton	0		Effect: "Arse-a'fire", Effect Duration: 13, Last Available: "2020-09"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	moldy huge pumpkin pie	4	crappy	Last Available: "2010-11"
-4764	acceptable spirit-forward pumpkin beer	5	good	Last Available: "2010-11"
+4764	spirit-forward acceptable pumpkin beer	5	good	Last Available: "2010-11"
 4765	nitrogenated chilled alkaline lime green pumpkin juice	0		Effect: "Yuletide Mutations", Effect Duration: 60, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	shin gourds of the cougar of James Dean	0		Moxie: +20, Experience (Moxie): +3, Single Equip, Last Available: "2010-11"
@@ -4725,7 +4725,7 @@
 4811	bouncing twirling Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	thick bland twirling CRIMBCOIDS mints	5	decent	Last Available: "2011-01"
-4819	squat wobbly can of CRIMBCOLA	0		Last Available: "2010-12"
+4819	wobbly squat can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	spoiled CRIMBCOLOAF	4	crappy	Last Available: "2011-01"
 4821	adequate bouncing circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	veiny plastic CRIMBCO HQ	0		Maximum HP: +10, Last Available: "2010-12"
@@ -4735,7 +4735,7 @@
 4826	plastic Best Game Ever of Flo-Jo	0		Initiative: +100, Last Available: "2010-12"
 4827	hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
-4829	cyan huge robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
+4829	huge cyan robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	cyan mirror robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	gray robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	skewed robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
@@ -4745,15 +4745,15 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	fuchsia robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	small rotten triangular CRIMBCOOKIE	2	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	delicious special square CRIMBCOOKIE	3	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4839	rotten small triangular CRIMBCOOKIE	2	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4840	special delicious square CRIMBCOOKIE	3	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	perfumed strapping bindlestocking of the glutton	0		Muscle: +5, Stench Resistance: +5, Food Drop: +100, Last Available: "2010-12"
-4842	twirling lime green skewed sleeping stocking	0		Last Available: "2010-12"
+4842	skewed lime green twirling sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	huge The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	blue ghostly brainy Uncle Hobo's stocking cap of Leguizamo	0		Mysticality: +5, Monster Level: +20, Last Available: "2010-12", Familiar Effect: "atk"
+4845	blue ghostly brainy Uncle Hobo's stocking cap of Leguizamo	0		Mysticality: +5, Monster Level: +20, Familiar Effect: "atk", Last Available: "2010-12"
 4846	sizzling careful Uncle Hobo's epic beard	0		Monster Level: -10, Hot Damage: +10, Single Equip, Last Available: "2010-12"
-4847	flame-wreathed hale Uncle Hobo's gift baggy pants	0		Maximum HP: +20, Hot Spell Damage: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	flame-wreathed hale Uncle Hobo's gift baggy pants	0		Maximum HP: +20, Hot Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	supercool Uncle Hobo's fingerless tinsel gloves of the overflowing toilet	0		Moxie Percent: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2010-12"
 4849	jittery blinking censurious mansplainer's Uncle Hobo's highest bough	0		Monster Level: +15, Sleaze Resistance: +3, Last Available: "2010-12"
 4850	cyan horrifying energetic Uncle Hobo's belt	0		Maximum MP Percent: +20, Spooky Damage: +25, Single Equip, Last Available: "2010-12"
@@ -4775,8 +4775,8 @@
 4866	tumbling Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	studded Da Vinci's experienced paperclip-on tie	0		Experience: +2, Experience (Mysticality): +5, Damage Absorption: +80, Single Equip, Last Available: "2011-01"
-4869	pulsating maroon Jack Frost's paperclip pants of the sweet-tooth	0		Cold Spell Damage: +50, Candy Drop: +100, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	stylish smooth paperclip turban of the sweet-tooth	0		Moxie: 40, Candy Drop: +100, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	pulsating maroon Jack Frost's paperclip pants of the sweet-tooth	0		Cold Spell Damage: +50, Candy Drop: +100, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	stylish smooth paperclip turban of the sweet-tooth	0		Moxie: 40, Candy Drop: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	twirling purple sinister paperclip cape	0		Spell Damage: +10, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	purple photocopied monster	0		Last Available: "2011-01"
@@ -4787,12 +4787,12 @@
 4878	ionized incense bath ball	0		Effect: "Happy Salamander", Effect Duration: 11, Last Available: "2011-01"
 4879	electrified colloidal gray myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Tremella Tremens", Effect Duration: 14, Last Available: "2011-01"
 4880	blurry CRIMBCO mug	0		Last Available: "2011-01"
-4881	distilled hand-crafted tumbling CRIMBCO wine	5	EPIC	Last Available: "2011-01"
+4881	hand-crafted distilled tumbling CRIMBCO wine	5	EPIC	Last Available: "2011-01"
 4882	ghostly Dickory Farms Gift Basket	0		Last Available: "2011-01"
-4883	narrow skewed purple toe jam	0		Last Available: "2011-01"
-4884	bland immense bouncing toe jam toast	6	decent	Last Available: "2011-01"
+4883	narrow purple skewed toe jam	0		Last Available: "2011-01"
+4884	immense bland bouncing toe jam toast	6	decent	Last Available: "2011-01"
 4885	narrow traffic jam	0		Last Available: "2011-01"
-4886	flavorless low-calorie traffic jam toast	1	decent	Last Available: "2011-01"
+4886	low-calorie flavorless traffic jam toast	1	decent	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	rotten skewed space jam toast	4	crappy	Last Available: "2011-01"
 4889	irradiated motivational poster	0		Effect: "Creepin' Up on You", Effect Duration: 28, Last Available: "2011-01"
@@ -4800,8 +4800,8 @@
 4891	teal bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	ghostly BGE shotglass	0		Last Available: "2010-12"
-4894	super-sized spoiled festive sausage	5	crappy	Last Available: "2011-01"
-4895	half-sized spoiled jittery holiday cheese log	2	crappy	Last Available: "2011-01"
+4894	spoiled super-sized festive sausage	5	crappy	Last Available: "2011-01"
+4895	spoiled half-sized jittery holiday cheese log	2	crappy	Last Available: "2011-01"
 4896	twirling holiday log	0		Last Available: "2011-01"
 4897	teal toasty weightlifter's BGE 'ferocious fruit' shirt	0		Muscle: +15, Hot Damage: +5, Last Available: "2010-12"
 4898	nippy slick BGE 'cuddly critter' shirt	0		Moxie: +10, Cold Damage: +10, Last Available: "2010-12"
@@ -4832,7 +4832,7 @@
 4923	maroon hardy Loathing Legion abacus	0		Maximum HP: +50, Softcore Only, Last Available: "2011-01"
 4924	Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
 4925	wool Loathing Legion pizza stone	0		Cold Resistance: +1, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
-4926	blue bouncing Loathing Legion universal screwdriver	0		Last Available: "2011-01"
+4926	bouncing blue Loathing Legion universal screwdriver	0		Last Available: "2011-01"
 4927	Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
 4928	ghostly Newton's Loathing Legion hammer	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2011-01"
 4929	shaking Uncle Crimbo's Sack	0		Last Available: "2011-01"
@@ -4848,7 +4848,7 @@
 4945	shaking lime green Knob frosting	0		
 4946	unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
-4948	fuchsia bouncing upside-down GOTO	0		
+4948	fuchsia upside-down bouncing GOTO	0		
 4949	nitrogenated energized weremoose spit	0		Effect: "Sweet and Green", Effect Duration: 14
 4950	diffused anodized abominable blubber	0		Effect: "Aided and Abetted", Effect Duration: 34
 4951	frightening flimsy clipboard	0		Spooky Damage: +5, Damage Reduction: 3
@@ -4861,10 +4861,10 @@
 4958	energetic Knob Goblin deluxe scimitar	0		Maximum MP Percent: +20
 4959	bland tumbling Knob nuts	3	decent	
 4960	mediocre practically non-alcoholic Cobb's Knob Wurstbrau	1	decent	
-4961	pulsating purple Subject 37 file	0		
+4961	purple pulsating Subject 37 file	0		
 4962	pulsating personal trainer's mysterious lapel pin of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10, Single Equip
 4963	state loom	0		Familiar Weight: +10
-4964	huge upside-down Evilometer	0		
+4964	upside-down huge Evilometer	0		
 4965	twirling Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	purple Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	twirling Alice's Army Swordsman	0		Last Available: "2011-03"
@@ -4878,7 +4878,7 @@
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
-4978	tumbling bouncing Alice's Army Hammerman	0		Last Available: "2011-03"
+4978	bouncing tumbling Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	narrow Alice's Army Horseman	0		Last Available: "2011-03"
@@ -4900,7 +4900,7 @@
 4997	Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	green Alice's Army Foil Hammerman	0		Last Available: "2011-03"
-5000	yellow jittery Alice's Army Foil Bowman	0		Last Available: "2011-03"
+5000	jittery yellow Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	jittery Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	squat Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
@@ -4927,7 +4927,7 @@
 5024	mediocre narrow marshmallow flamb&eacute;	4	decent	Last Available: "2011-03"
 5025	mediocre cranberry schnapps	4	decent	Last Available: "2011-03"
 5026	drinkable pulsating breaded beer	4	good	Last Available: "2011-03"
-5027	practically non-alcoholic hand-crafted soy cordial	1	super ultra mega turbo EPIC	Last Available: "2011-03"
+5027	hand-crafted practically non-alcoholic soy cordial	1	super ultra mega turbo EPIC	Last Available: "2011-03"
 5028	twirling scandalous astral bludgeon of the overflowing toilet of the businessman	0		Stench Spell Damage: +50, Sleaze Damage: +5, Meat Drop: +50
 5029	personal trainer's astral shield of the sweet-tooth	0		Experience Percent (Muscle): +10, Candy Drop: +100, Damage Reduction: 15
 5030	dog trainer's stylish astral chapeau of the early riser	0		Moxie: +25, Experience (familiar): +1, Adventures: +7, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4949,9 +4949,9 @@
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	huge shard of double-ice	0		Last Available: "2011-04"
-5049	lime green padded Herculean groovy double-ice cap	0		Moxie Percent: +10, Experience (Muscle): +1, Damage Absorption: +20, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	lime green padded Herculean groovy double-ice cap	0		Moxie Percent: +10, Experience (Muscle): +1, Damage Absorption: +20, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	purple ribald banded slick double-ice box	0		Moxie: +10, Damage Absorption: +100, Sleaze Damage: +10, Last Available: "2011-04"
-5051	double-paned Temple Grandin's double-ice britches of the overflowing toilet	0		Familiar Weight: +7, Stench Spell Damage: +50, Cold Resistance: +5, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	double-paned Temple Grandin's double-ice britches of the overflowing toilet	0		Familiar Weight: +7, Stench Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	spinning Lars the Cyberian	0		Last Available: "2011-04"
 5054	blinking intriguing puzzle box	0		Last Available: "2011-04"
@@ -4971,20 +4971,20 @@
 5068	spoiled blinking chaos popcorn	3	crappy	Last Available: "2011-04"
 5069	wool educational cool hole	0		Moxie: +5, Experience: +1, Cold Resistance: +1, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	immense adequate fancy olive s'more	0	good	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2011-04"
+5071	fancy immense adequate olive s'more	0	good	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2011-04"
 5072	spinning diamond ring	0		Last Available: "2011-04"
-5073	special hand-crafted high-proof Russian Ice	6	EPIC	Effect: "Fishy Fortification", Effect Duration: 5, Last Available: "2011-04"
+5073	high-proof hand-crafted special Russian Ice	6	EPIC	Effect: "Fishy Fortification", Effect Duration: 5, Last Available: "2011-04"
 5074	Fonzie's clay ashtray	0		Experience (Moxie): +1, Damage Reduction: 3, Last Available: "2011-05"
 5075	executive lanyard	0		Meat Drop: +40, Single Equip, Last Available: "2011-05"
-5076	upside-down Socratic monster pants	0		Experience (Mysticality): +1, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	upside-down Socratic monster pants	0		Experience (Mysticality): +1, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	oxidized wobbly Pok&euml;mann band-aid	0		Effect: "Fungal Fortification", Effect Duration: 21, Last Available: "2011-05"
-5079	censurious Da Vinci's Van der Graaf helmet	0		Experience (Mysticality): +5, Sleaze Resistance: +3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	censurious Da Vinci's Van der Graaf helmet	0		Experience (Mysticality): +5, Sleaze Resistance: +3, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	jittery beefy crutch	0		Muscle: +10, Last Available: "2011-05"
 5081	pulsating hale shock belt	0		Maximum HP: +20, Single Equip, Last Available: "2011-05"
 5082	concentrated electrified upside-down Okee-Dokee soda	0		Effect: "Gummiheart", Effect Duration: 44, Last Available: "2011-05"
 5083	asbestos-lined rubber band gun	0		Hot Resistance: +5, Last Available: "2011-05"
-5084	shaking rock-hard pin-stripe slacks	0		Damage Reduction: 5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	shaking rock-hard pin-stripe slacks	0		Damage Reduction: 5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	chaotic gloves	0		Spell Critical Percent: +10, Single Equip, Last Available: "2011-05"
 5086	vacuum-sealed double-alkaline correction fluid	0		Effect: "Spirit Bubble", Effect Duration: 33, Last Available: "2011-05"
 5087	shaking family-friendly Pok&euml;mann figurine: Porkachu	0		Sleaze Resistance: +1, Single Equip, Last Available: "2011-05"
@@ -5007,9 +5007,9 @@
 5104	moist fish juice box	0		Effect: "Swordholder", Effect Duration: 57, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	spinning hideous egg	0		Last Available: "2011-05"
-5107	mediocre triple-distilled mirror Jeppson's Malort	8	decent	Last Available: "2011-06"
+5107	triple-distilled mediocre mirror Jeppson's Malort	8	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	stress ball of bravery	0		Spooky Resistance: +5, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	stress ball of bravery	0		Spooky Resistance: +5, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	maroon Ultracolor&trade; shirt of the wise owl	0		Mysticality: +20, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	twirling censurious scorching padded Admiral's hat	0		Damage Absorption: +20, Hot Damage: +25, Sleaze Resistance: +3, Last Available: "2011-05", Familiar Effect: "atk"
-5122	twirling shaking bouncing executive horrifying Samson's aviator's cap	0		Experience (Muscle): +5, Spooky Damage: +25, Meat Drop: +40, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	twirling censurious scorching padded Admiral's hat	0		Damage Absorption: +20, Hot Damage: +25, Sleaze Resistance: +3, Familiar Effect: "atk", Last Available: "2011-05"
+5122	twirling shaking bouncing executive horrifying Samson's aviator's cap	0		Experience (Muscle): +5, Spooky Damage: +25, Meat Drop: +40, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	dog trainer's steel-toed mirrored aviator shades	0		Damage Reduction: 9, Experience (familiar): +1, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5031,8 +5031,8 @@
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
-5131	ionized pickled twirling blue Ultrasoldier Serum	0		Effect: "Nano-juiced", Effect Duration: 17, Last Available: "2011-06"
-5132	stale thick elven hardtack	5	decent	Last Available: "2011-06"
+5131	ionized pickled blue twirling Ultrasoldier Serum	0		Effect: "Nano-juiced", Effect Duration: 17, Last Available: "2011-06"
+5132	thick stale elven hardtack	5	decent	Last Available: "2011-06"
 5133	lousy bouncing elven squeeze	3	decent	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	twirling E.M.U. joystick	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	reassuring brainy honey dipper of Leguizamo	0		Mysticality: +5, Monster Level: +20, Spooky Resistance: +1
 5149	therapeutic fortified honeybritches of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	huge flame-wreathed hardy weightlifter's honeycap	0		Muscle: +15, Maximum HP: +50, Hot Spell Damage: +10, Familiar Effect: "1xPotato, cap 43"
-5151	smooth Moonthril Circlet	0		Moxie: +15, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	skewed auspicious Moonthril Greaves	0		Item Drop: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	smooth Moonthril Circlet	0		Moxie: +15, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	skewed auspicious Moonthril Greaves	0		Item Drop: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	dance instructor's Moonthril Flamberge	0		Experience Percent (Moxie): +10, Last Available: "2011-06"
 5154	electrified Moonthril Longbow	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-06"
 5155	squat gravedigger's Moonthril Cuirass	0		Spooky Damage: +10, Softcore Only, Last Available: "2011-06"
@@ -5077,7 +5077,7 @@
 5174	perfectly mixed Saison du Lune	3	EPIC	Last Available: "2011-06"
 5175	mediocre spinning Moonthril Schnapps	4	decent	Last Available: "2011-06"
 5176	hand-crafted Wrecked Generator	3	super ultra mega EPIC	Last Available: "2011-06"
-5177	rotten miniature Spaghetti with Moonballs	2	crappy	Last Available: "2011-06"
+5177	miniature rotten Spaghetti with Moonballs	2	crappy	Last Available: "2011-06"
 5178	normal bouncing Crepes a la Lune	3	good	Last Available: "2011-06"
 5179	huge bland lime green Moon Pie	6	decent	Last Available: "2011-06"
 5180	quadruple-adjusted magnetized blinking Comet Pop	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 39, Last Available: "2011-06"
@@ -5090,45 +5090,45 @@
 5187	shaking Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	concentrated cyan honey stick	0		Effect: "Witch's Brood", Effect Duration: 56
 5189	cold-filtered electrified double-ice gum	0		Effect: "Perfect Hair", Effect Duration: 15, Last Available: "2011-04"
-5190	Jeselnik's nippy Operation Patriot Shield of doom	0		Cold Damage: +10, Spooky Spell Damage: +50, Sleaze Damage: +25, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	Jeselnik's nippy Operation Patriot Shield of doom	0		Cold Damage: +10, Spooky Spell Damage: +50, Sleaze Damage: +25, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	Vulcanized moist corrupted data	0		Effect: "The Halls of Moxiousness", Effect Duration: 51, Last Available: "2011-06"
-5193	huge gray 11-inch knob sausage	0		
+5193	gray huge 11-inch knob sausage	0		
 5194	exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	blurry foul-smelling Great S-Cape	0		Stench Damage: +10, Softcore Only, Last Available: "2011-07"
 5197	fuchsia jittery steel-toed Marvelous Unitard	0		Damage Reduction: 9, Softcore Only, Last Available: "2011-07"
-5198	compressed pulsating fuchsia twirling gooey paste	1	decent	Last Available: "2011-08"
+5198	compressed twirling pulsating fuchsia gooey paste	1	decent	Last Available: "2011-08"
 5199	vaporized gray blinking beastly paste	1	decent	Last Available: "2011-08"
 5200	altered paste	1	awesome	Effect: "Heart of Pink", Effect Duration: 50, Last Available: "2011-08"
-5201	compressed huge red mirror ectoplasmic paste	1	good	Last Available: "2011-08"
+5201	compressed mirror huge red ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	denatured blurry greasy paste	1	decent	Effect: "Loco Motives", Effect Duration: 20, Last Available: "2011-08"
 5203	altered mirror bug paste	1	crappy	Last Available: "2011-08"
 5204	pickled maroon hippy paste	1	decent	Last Available: "2011-08"
 5205	dehydrated orc paste	1	EPIC	Last Available: "2011-08"
 5206	powdered demonic paste	1	EPIC	Last Available: "2011-08"
 5207	dried bouncing squat yellow indescribably horrible paste	1	decent	Last Available: "2011-08"
-5208	dried mirror mirror blinking paste	1	awesome	Effect: "Insulated Trousers", Effect Duration: 10, Last Available: "2011-08"
-5209	dried blinking ghostly goblin paste	1	decent	Last Available: "2011-08"
-5210	compressed tumbling blinking spinning pirate paste	1	awesome	Last Available: "2011-08"
+5208	dried blinking mirror mirror paste	1	awesome	Effect: "Insulated Trousers", Effect Duration: 10, Last Available: "2011-08"
+5209	dried ghostly blinking goblin paste	1	decent	Last Available: "2011-08"
+5210	compressed spinning blinking tumbling pirate paste	1	awesome	Last Available: "2011-08"
 5211	twisted mirror chlorophyll paste	1	decent	Effect: "Also Schmeckt Zarathustra", Effect Duration: 30, Last Available: "2011-08"
-5212	vaporized pulsating ghostly paste	1	awesome	Last Available: "2011-08"
+5212	vaporized ghostly pulsating paste	1	awesome	Last Available: "2011-08"
 5213	diluted tumbling Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	boiled pulsating blinking slimy paste	1	decent	Effect: "Full of Wist", Effect Duration: 20, Last Available: "2011-08"
 5215	twisted penguin paste	1	EPIC	Effect: "Total Protonic Reversal", Effect Duration: 10, Last Available: "2011-08"
 5216	denatured jittery twirling green elemental paste	1	good	Last Available: "2011-08"
 5217	diluted spinning cosmic paste	1	good	Last Available: "2011-08"
 5218	dehydrated shaking hobo paste	1	EPIC	Last Available: "2011-08"
-5219	diluted tumbling spinning green Crimbo paste	1	crappy	Last Available: "2011-08"
+5219	diluted green spinning tumbling Crimbo paste	1	crappy	Last Available: "2011-08"
 5220	ghostly Teachings of the Fist	0		
 5221	narrow fat loot token	0		No Pull
 5222	skewed Thwaitgold grasshopper statuette	0		
 5223	huge Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	miniature adequate Ur-Donut	2	good	Last Available: "2011-09"
+5224	adequate miniature Ur-Donut	2	good	Last Available: "2011-09"
 5225	gray The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	mediocre extra-dry enchanted bucket of wine	5	decent	Effect: "Physicali Tea", Effect Duration: 50, Last Available: "2011-09"
-5228	immense flavorless purple ultrafondue	9	decent	Last Available: "2011-09"
+5228	flavorless immense purple ultrafondue	9	decent	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	maroon snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5138,22 +5138,22 @@
 5235	maroon squat furry halo of the scaredy-cat	0		Monster Level: -15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	pulsating careful frosty halo	0		Monster Level: -10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	mirror time halo	0		Item Drop: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	bad watered-down Lumineux Limnio	2	decent	Last Available: "2011-09"
-5239	fancy lousy practically non-alcoholic Morto Moreto	1	decent	Effect: "Like a Fish to Walter", Effect Duration: 15, Last Available: "2011-09"
+5238	watered-down bad Lumineux Limnio	2	decent	Last Available: "2011-09"
+5239	practically non-alcoholic lousy fancy Morto Moreto	1	decent	Effect: "Like a Fish to Walter", Effect Duration: 15, Last Available: "2011-09"
 5240	watered-down lousy Temps Tempranillo	2	decent	Last Available: "2011-09"
 5241	perfectly mixed Bordeaux Marteaux	4	EPIC	Last Available: "2011-09"
-5242	weak drinkable spinning Fromage Pinotage	2	good	Last Available: "2011-09"
+5242	drinkable weak spinning Fromage Pinotage	2	good	Last Available: "2011-09"
 5243	artisanal Beignet Milgranet	4	EPIC	Last Available: "2011-09"
 5244	tolerable narrow Muschat	3	good	Last Available: "2011-09"
 5245	flavorless skewed cool jelly donut	4	decent	Last Available: "2011-09"
-5246	flavorless big lime green shrapnel jelly donut	5	decent	Last Available: "2011-09"
+5246	big flavorless lime green shrapnel jelly donut	5	decent	Last Available: "2011-09"
 5247	enchanted flavorless occult jelly donut	3	decent	Effect: "Macho Profundo", Effect Duration: 30, Last Available: "2011-09"
 5248	adequate thyme jelly donut	3	good	Last Available: "2011-09"
 5249	half-sized normal danish	2	good	Last Available: "2011-09"
-5250	immense stale blinking smashed danish	8	decent	Last Available: "2011-09"
-5251	gigantic spoiled forbidden danish	9	crappy	Last Available: "2011-09"
-5252	enchanted decent miniature cool cat claw	2	good	Effect: "Squid Squint", Effect Duration: 10, Last Available: "2011-09"
-5253	tasty immense special upside-down blunt cat claw	6	awesome	Effect: "Bastard!", Effect Duration: 40, Last Available: "2011-09"
+5250	stale immense blinking smashed danish	8	decent	Last Available: "2011-09"
+5251	spoiled gigantic forbidden danish	9	crappy	Last Available: "2011-09"
+5252	decent miniature enchanted cool cat claw	2	good	Effect: "Squid Squint", Effect Duration: 10, Last Available: "2011-09"
+5253	immense tasty special upside-down blunt cat claw	6	awesome	Effect: "Bastard!", Effect Duration: 40, Last Available: "2011-09"
 5254	decent shadowy cat claw	4	good	Last Available: "2011-09"
 5255	decent blue cheezburger	4	good	Last Available: "2011-09"
 5256	rotten toasted brie	3	crappy	Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	ghostly slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	shaking dungeon dragon chest	0		Last Available: "2011-09"
 5298	flavorless massive phish stick	8	decent	Last Available: "2011-09"
-5299	blinking flame-retardant manspreader's plastic vampire fangs of the boozehound	0		Monster Level: +10, Hot Resistance: +1, Booze Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	blinking flame-retardant manspreader's plastic vampire fangs of the boozehound	0		Monster Level: +10, Hot Resistance: +1, Booze Drop: +100, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	upside-down fuchsia Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	pulsating Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5222,27 +5222,27 @@
 5319	pressed wet skewed Blood 'n' Plenty	0		Effect: "Uncucumbered", Effect Duration: 19, Last Available: "2011-10"
 5320	irradiated Lobos Mints	0		Effect: "Jittery", Effect Duration: 15, Last Available: "2011-10"
 5321	wet Sweet Sword	0		Effect: "Salsa Satanica", Effect Duration: 37, Last Available: "2011-10"
-5322	spirit-forward perfectly mixed Ecto-Cooler	5	EPIC	Last Available: "2011-10"
+5322	perfectly mixed spirit-forward Ecto-Cooler	5	EPIC	Last Available: "2011-10"
 5323	delicious Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
 5324	artisanal huge Blood Light	3	EPIC	Last Available: "2011-10"
-5325	boozy drinkable fuchsia Silver Bullet beer	5	good	Last Available: "2011-10"
+5325	drinkable boozy fuchsia Silver Bullet beer	5	good	Last Available: "2011-10"
 5326	acceptable Bone's Farm &quot;wine&quot;	4	good	Last Available: "2011-10"
 5327	mirror ghost protocol	0		Last Available: "2011-10"
 5328	triple-vacuum-sealed frozen sorority brain	0		Effect: "Izchak's Blessing", Effect Duration: 19, Last Available: "2011-10"
 5329	dry narrow narrow Nightstalker perfume	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 16, Last Available: "2011-10"
 5330	flattened ionized drum of pomade	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 62, Last Available: "2011-10"
-5331	shaking squat throwing bone	0		Last Available: "2011-10"
+5331	squat shaking throwing bone	0		Last Available: "2011-10"
 5332	stylish extra-see-thru nightie	0		Moxie: +25, Last Available: "2011-10"
-5333	twirling fuchsia savvy smooth BRAINS shorts	0		Moxie: +15, Mysticality Percent: +20, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	twirling fuchsia savvy smooth BRAINS shorts	0		Moxie: +15, Mysticality Percent: +20, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	blinking Mesmereyes&trade; contact lenses of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2011-10"
 5335	friendly scrunchie	0		Familiar Weight: +3, Single Equip, Last Available: "2011-10"
-5336	squat therapeutic extremely skinny jeans of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	shaking double-paned beefy The Necbromancer's Hat	0		Muscle: +10, Cold Resistance: +5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	squat therapeutic extremely skinny jeans of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	shaking double-paned beefy The Necbromancer's Hat	0		Muscle: +10, Cold Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	vibrating occult dangerous The Necbromancer's Stein	0		Weapon Damage: +10, Spell Damage Percent: +25, Maximum MP Percent: +10, Last Available: "2011-10"
-5339	purple stanky smelly The Necbromancer's Shorts of the glutton	0		Stench Spell Damage: 35, Food Drop: +100, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	purple stanky smelly The Necbromancer's Shorts of the glutton	0		Stench Spell Damage: 35, Food Drop: +100, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	family-friendly deadly The Necbromancer's Wizard Staff of incineration	0		Weapon Damage: +5, Hot Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2011-10"
 5341	huge The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	watered-down bad The Cooler Out of Space	2	decent	Last Available: "2011-10"
+5342	bad watered-down The Cooler Out of Space	2	decent	Last Available: "2011-10"
 5343	squat The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	purple sorority girl's box	0		Last Available: "2011-10"
 5345	adjusted anodized huge Necbro wafers	0		Effect: "Springy Fusilli", Effect Duration: 39, Last Available: "2020-09"
@@ -5262,13 +5262,13 @@
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
-5362	shaking twirling yellow CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+5362	yellow shaking twirling CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	bouncing CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	squat CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	lime green twirling CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 5366	yellow CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
-5368	blurry lime green Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
+5368	lime green blurry Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	blinking thinker's KoL Con 8-Bit power bracelet	0		Mysticality: +10, Last Available: "2011-09"
 5370	boiler	0		
 5371	upside-down stuffed-shirt scarecrow	0		Free Pull, Last Available: "2011-11"
@@ -5290,7 +5290,7 @@
 5387	ridiculous earring of dire peril	0		Weapon Damage: +20, Last Available: "2011-11"
 5388	olive blinking bouncing ridiculous sunglasses of the cheetah	0		Initiative: +60, Last Available: "2011-11"
 5389	stale mirror ridiculous sandwich	3	decent	Last Available: "2011-11"
-5390	artisanal distilled bouncing ridiculous cocktail	5	EPIC	Last Available: "2011-11"
+5390	distilled artisanal bouncing ridiculous cocktail	5	EPIC	Last Available: "2011-11"
 5391	upside-down up-at-dawn zombie monkey necklace of the boozehound	0		Booze Drop: +100, Adventures: +5
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5306,12 +5306,12 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	spinning Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	scandalous clever cane-mail shirt of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +20, Sleaze Damage: +5, Last Available: "2011-12"
-5406	pulsating ghostly ribald gravedigger's banded cane-mail pants	0		Damage Absorption: +100, Spooky Damage: +10, Sleaze Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	pulsating ghostly ribald gravedigger's banded cane-mail pants	0		Damage Absorption: +100, Spooky Damage: +10, Sleaze Damage: +10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	perfectly mixed skewed Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
-5408	fortified enchanted artisanal Gin Mint	5	EPIC	Effect: "Antsy in your Pantsy", Effect Duration: 35, Last Available: "2011-12"
+5408	artisanal enchanted fortified Gin Mint	5	EPIC	Effect: "Antsy in your Pantsy", Effect Duration: 35, Last Available: "2011-12"
 5409	lousy practically non-alcoholic Tequiz Navidad	1	decent	Last Available: "2011-12"
 5410	drinkable jittery Mint Yulep	3	good	Last Available: "2011-12"
-5411	watered-down delicious gray Crimbojito	2	awesome	Last Available: "2011-12"
+5411	delicious watered-down gray Crimbojito	2	awesome	Last Available: "2011-12"
 5412	drinkable narrow Sangria de Menthe	3	good	Last Available: "2011-12"
 5413	pulsating candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	pulsating sharpshooter's kumquartz ring	0		Critical Hit Percent: +10, Single Equip, Last Available: "2011-11"
 5425	censurious strawberyl necklace	0		Sleaze Resistance: +3, Single Equip, Last Available: "2011-11"
 5426	sucker bucket of the wise owl of vim and vigor	0		Mysticality: +20, Maximum HP Percent: +50, Last Available: "2011-11"
-5427	sucker hakama of the early riser	0		Adventures: +7, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	padded sucker kabuto	0		Damage Absorption: +20, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	sucker hakama of the early riser	0		Adventures: +7, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	padded sucker kabuto	0		Damage Absorption: +20, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	forbidden sucker tachi	0		Spell Damage Percent: +50, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	pulsating pulsating cinnamon troll doll	0		Last Available: "2011-11"
@@ -5370,7 +5370,7 @@
 5467	modified non-pressed red resolution: be smarter	0		Effect: "Heart Aflame", Effect Duration: 20, Last Available: "2012-01"
 5468	vacuum-sealed double-alkaline resolution: be sexier	0		Effect: "Ooh, Sweet!", Effect Duration: 30, Last Available: "2012-01"
 5469	flattened tumbling resolution: be feistier	0		Effect: "Chunky", Effect Duration: 57, Last Available: "2012-01"
-5470	ionized mirror huge resolution: be kinder	0		Effect: "Faboooo", Effect Duration: 66, Last Available: "2012-01"
+5470	ionized huge mirror resolution: be kinder	0		Effect: "Faboooo", Effect Duration: 66, Last Available: "2012-01"
 5471	chilled resolution: be more adventurous	0		Effect: "Insatiable Hunger", Effect Duration: 56, Last Available: "2012-01"
 5472	double-irradiated triple-tarnished spinning resolution: be luckier	0		Effect: "Boletus Swoletus", Effect Duration: 57, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
@@ -5381,9 +5381,9 @@
 5478	enhanced gummi canary	0		Effect: "Tingly Wrists", Effect Duration: 62, Last Available: "2011-11"
 5479	moldy massive gummi bear	8	crappy	Last Available: "2011-11"
 5480	spoiled gummi bear	3	crappy	Last Available: "2011-11"
-5481	diet rotten gummi bear	1	crappy	Last Available: "2011-11"
+5481	rotten diet gummi bear	1	crappy	Last Available: "2011-11"
 5482	decent drunki-bear	4	good	Last Available: "2011-11"
-5483	thick toothsome enchanted drunki-bear	5	awesome	Effect: "Macho, Macho Dog", Effect Duration: 20, Last Available: "2011-11"
+5483	enchanted thick toothsome drunki-bear	5	awesome	Effect: "Macho, Macho Dog", Effect Duration: 20, Last Available: "2011-11"
 5484	rotten drunki-bear	3	crappy	Last Available: "2011-11"
 5485	blue Rosewater's gummi bowtie	0		Mysticality Percent: +30, Last Available: "2011-11"
 5486	rosy-cheeked fudge pocket square	0		Maximum HP Percent: +30, Last Available: "2011-11"
@@ -5397,9 +5397,9 @@
 5494	unsweetened polymerized huge gummi trilobite	0		Effect: "Squatting and Thrusting", Effect Duration: 48, Last Available: "2011-11"
 5495	quadruple-tarnished quantum gummi ammonite	0		Effect: "Winklered", Effect Duration: 13, Last Available: "2011-11"
 5496	non-quantum modified bouncing gummi belemnite	0		Effect: "Sweet and Green", Effect Duration: 29, Last Available: "2011-11"
-5497	narrow pulsating all-year sucker	0		Last Available: "2011-11"
+5497	pulsating narrow all-year sucker	0		Last Available: "2011-11"
 5498	red heart of dark chocolate	0		Last Available: "2011-11"
-5499	bouncing fireproof dangerous Big Candy's tophat	0		Weapon Damage: +10, Hot Resistance: +3, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	bouncing fireproof dangerous Big Candy's tophat	0		Weapon Damage: +10, Hot Resistance: +3, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	cyan Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	ghostly Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5409,8 +5409,8 @@
 5506	bland pulsating narrow jerky coins	4	decent	Last Available: "2011-11"
 5507	irresponsibly strong artisanal Go-Wassail	7	EPIC	Last Available: "2011-11"
 5508	colloidal non-ionized twirling Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Greased-Up Familiar", Effect Duration: 29, Last Available: "2011-11"
-5509	irradiated cold-filtered huge lime green spinning bottle of bubbles	0		Effect: "Infernal Thirst", Effect Duration: 35, Last Available: "2011-11"
-5510	energized nitrogenated green jittery wind-up meatcar	0		Effect: "Three Days Slow", Effect Duration: 42, Last Available: "2011-11"
+5509	irradiated cold-filtered lime green huge spinning bottle of bubbles	0		Effect: "Infernal Thirst", Effect Duration: 35, Last Available: "2011-11"
+5510	energized nitrogenated jittery green wind-up meatcar	0		Effect: "Three Days Slow", Effect Duration: 42, Last Available: "2011-11"
 5511	jittery Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	gray Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	tarnished quadruple-ionized Atomic Pop	0		Effect: "Experimental Effect G-9", Effect Duration: 29, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	half-sized bland jittery berries of suffering	2	decent	Last Available: "2012-12"
+5529	bland half-sized jittery berries of suffering	2	decent	Last Available: "2012-12"
 5530	aerosolized baobab sap	0		Effect: "Ham-Fisted", Effect Duration: 37, Last Available: "2012-12"
 5531	tumbling cup of hickory chicory	0		Last Available: "2012-12"
 5532	huge magnolia blossom	0		Last Available: "2012-12"
@@ -5439,13 +5439,13 @@
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	half-empty carton of milk	0		Last Available: "2012-12"
-5539	upside-down mirror glass of warm water	0		Free Pull
+5539	mirror upside-down glass of warm water	0		Free Pull
 5540	double-activated Vulcanized desktop zen garden	0		Effect: "Human-Fish Hybrid", Effect Duration: 15, Last Available: "2012-12"
 5541	twirling Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	ribald energetic Leapin' Trousers	0		Maximum MP Percent: +20, Sleaze Damage: +10
 5544	watered-down perfectly mixed eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
-5545	moldy snack-sized hamhock	2	crappy	Last Available: "2012-12"
+5545	snack-sized moldy hamhock	2	crappy	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	pulsating Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5454,37 +5454,37 @@
 5551	narrow Clancy's lute	0		Last Available: "2012-12"
 5552	smartaleck's Trusty	0		Moxie Percent: +30
 5553	can of Rain-Doh	0		Last Available: "2012-02"
-5554	jittery blue mirror empty Rain-Doh can	0		Last Available: "2012-02"
+5554	mirror blue jittery empty Rain-Doh can	0		Last Available: "2012-02"
 5555	quadruple-polymerized adjusted fireclutch	0		Effect: "Polar Express", Effect Duration: 50
 5556	supercool Rain-Doh wings of Flo-Jo	0		Moxie Percent: +20, Initiative: +100, Softcore Only, Last Available: "2012-02"
 5557	bouncing Rain-Doh agent	0		Last Available: "2012-02"
 5558	ribald frightening Rain-Doh laser gun	0		Spooky Damage: +5, Sleaze Damage: +10, Softcore Only, Last Available: "2012-02"
-5559	tumbling hale wizardly Rain-Doh lantern	0		Mysticality: +25, Maximum HP: +20, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	tumbling hale wizardly Rain-Doh lantern	0		Mysticality: +25, Maximum HP: +20, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	maroon Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	asbestos-lined fortified Rain-Doh violet bo	0		Damage Absorption: +60, Hot Resistance: +5, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	rotten small mirror tumbling PB&BP	2	crappy	
-5566	adequate bite-sized mirror club sandwich	1	good	
+5565	rotten small tumbling mirror PB&BP	2	crappy	
+5566	bite-sized adequate mirror club sandwich	1	good	
 5567	flavorless super-sized corned-beef Reuben	5	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	watered-down perfectly mixed spinning Drac & Tan	2	EPIC	Last Available: "2012-03"
-5574	practically non-alcoholic hand-crafted Transylvania Sling	1	EPIC	Last Available: "2012-03"
-5575	watered-down delicious Shot of the Living Dead	2	awesome	Last Available: "2012-03"
-5576	irresponsibly strong perfectly mixed Buttery Knob	10	EPIC	Last Available: "2012-03"
+5573	perfectly mixed watered-down spinning Drac & Tan	2	EPIC	Last Available: "2012-03"
+5574	hand-crafted practically non-alcoholic Transylvania Sling	1	EPIC	Last Available: "2012-03"
+5575	delicious watered-down Shot of the Living Dead	2	awesome	Last Available: "2012-03"
+5576	perfectly mixed irresponsibly strong Buttery Knob	10	EPIC	Last Available: "2012-03"
 5577	lousy Slippery Knob	3	decent	Last Available: "2012-03"
-5578	practically non-alcoholic drinkable pulsating Flaming Knob	1	good	Last Available: "2012-03"
+5578	drinkable practically non-alcoholic pulsating Flaming Knob	1	good	Last Available: "2012-03"
 5579	weak acceptable Grasshopper	2	good	Last Available: "2012-03"
 5580	weak fancy aged Locust	2	awesome	Effect: "A Few Extra Pounds", Effect Duration: 15, Last Available: "2012-03"
 5581	acceptable gray upside-down Plague of Locusts	3	good	Last Available: "2012-03"
 5582	smooth Red Dwarf	3	awesome	Last Available: "2012-03"
 5583	acceptable Golden Mean	3	good	Last Available: "2012-03"
-5584	weak delicious Green Giant	2	awesome	Last Available: "2012-03"
+5584	delicious weak Green Giant	2	awesome	Last Available: "2012-03"
 5585	acceptable practically non-alcoholic blinking Aye Aye	1	good	Last Available: "2012-03"
 5586	artisanal Aye Aye, Captain	3	EPIC	Last Available: "2012-03"
 5587	hand-crafted jittery Aye Aye, Tooth Tooth	4	EPIC	Last Available: "2012-03"
@@ -5494,38 +5494,38 @@
 5591	bad Great Older Fashioned	3	decent	Last Available: "2012-03"
 5592	irresponsibly strong artisanal special Fuzzy Tentacle	9	EPIC	Effect: "Don't Step to Your Stepmother", Effect Duration: 10, Last Available: "2012-03"
 5593	hand-crafted Crazymaker	3	EPIC	Last Available: "2012-03"
-5594	practically non-alcoholic hand-crafted skewed Zoodriver	1	EPIC	Last Available: "2012-03"
+5594	hand-crafted practically non-alcoholic skewed Zoodriver	1	EPIC	Last Available: "2012-03"
 5595	acceptable weak Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
 5596	aged practically non-alcoholic Sloe Comfortable Zoo on Fire	1	awesome	Last Available: "2012-03"
 5597	aged watered-down Suffering Sinner	2	awesome	Last Available: "2012-03"
 5598	practically non-alcoholic delicious Suppurating Sinner	1	awesome	Last Available: "2012-03"
-5599	watered-down artisanal Sizzling Sinner	2	EPIC	Last Available: "2012-03"
-5600	drinkable fancy Firewater	3	good	Effect: "Sausage Festive", Effect Duration: 50, Last Available: "2012-03"
+5599	artisanal watered-down Sizzling Sinner	2	EPIC	Last Available: "2012-03"
+5600	fancy drinkable Firewater	3	good	Effect: "Sausage Festive", Effect Duration: 50, Last Available: "2012-03"
 5601	lousy Earth and Firewater	4	decent	Last Available: "2012-03"
-5602	enchanted watered-down lousy spinning Earth, Wind and Firewater	2	decent	Effect: "Hypercubed", Effect Duration: 25, Last Available: "2012-03"
-5603	strong artisanal special Slimosa	5	EPIC	Effect: "Heart Aflame", Effect Duration: 5, Last Available: "2012-03"
-5604	fancy aged Extra-slimy Slimosa	3	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 45, Last Available: "2012-03"
+5602	watered-down enchanted lousy spinning Earth, Wind and Firewater	2	decent	Effect: "Hypercubed", Effect Duration: 25, Last Available: "2012-03"
+5603	special strong artisanal Slimosa	5	EPIC	Effect: "Heart Aflame", Effect Duration: 5, Last Available: "2012-03"
+5604	aged fancy Extra-slimy Slimosa	3	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 45, Last Available: "2012-03"
 5605	acceptable Slimebite	4	good	Last Available: "2012-03"
-5606	hand-crafted enchanted triple-distilled jittery Cement Mixer	7	EPIC	Effect: "Fungal Fortification", Effect Duration: 45, Last Available: "2012-03"
-5607	tolerable olive huge Jackhammer	4	good	Last Available: "2012-03"
+5606	enchanted hand-crafted triple-distilled jittery Cement Mixer	7	EPIC	Effect: "Fungal Fortification", Effect Duration: 45, Last Available: "2012-03"
+5607	tolerable huge olive Jackhammer	4	good	Last Available: "2012-03"
 5608	lousy blue Dump Truck	4	decent	Last Available: "2012-03"
 5609	practically non-alcoholic drinkable red Fauna Libre	1	good	Last Available: "2012-03"
 5610	hand-crafted Chakra Libre	3	EPIC	Last Available: "2012-03"
 5611	artisanal Aura Libre	3	EPIC	Last Available: "2012-03"
 5612	artisanal weak Sazerorc	2	EPIC	Last Available: "2012-03"
-5613	watered-down aged Sazuruk-hai	2	awesome	Last Available: "2012-03"
-5614	special perfectly mixed watered-down pulsating olive Flaming Sazerorc	2	EPIC	Effect: "Stogied", Effect Duration: 35, Last Available: "2012-03"
-5615	lousy triple-distilled Green Velvet	10	decent	Last Available: "2012-03"
-5616	watered-down perfectly mixed green Green Muslin	2	EPIC	Last Available: "2012-03"
+5613	aged watered-down Sazuruk-hai	2	awesome	Last Available: "2012-03"
+5614	special watered-down perfectly mixed pulsating olive Flaming Sazerorc	2	EPIC	Effect: "Stogied", Effect Duration: 35, Last Available: "2012-03"
+5615	triple-distilled lousy Green Velvet	10	decent	Last Available: "2012-03"
+5616	perfectly mixed watered-down green Green Muslin	2	EPIC	Last Available: "2012-03"
 5617	acceptable Green Burlap	3	good	Last Available: "2012-03"
 5618	tolerable Mohobo	3	good	Last Available: "2012-03"
-5619	lousy weak Moonshine Mohobo	2	decent	Last Available: "2012-03"
+5619	weak lousy Moonshine Mohobo	2	decent	Last Available: "2012-03"
 5620	practically non-alcoholic tolerable Flaming Mohobo	1	good	Last Available: "2012-03"
 5621	perfectly mixed Drunken Philosopher	3	EPIC	Last Available: "2012-03"
-5622	perfectly mixed weak Drunken Neurologist	2	EPIC	Last Available: "2012-03"
+5622	weak perfectly mixed Drunken Neurologist	2	EPIC	Last Available: "2012-03"
 5623	tolerable Drunken Astrophysicist	3	good	Last Available: "2012-03"
 5624	acceptable triple-distilled squat Dark & Starry	6	good	Last Available: "2012-03"
-5625	hand-crafted special mirror Black Hole	3	EPIC	Effect: "Ancient Protected", Effect Duration: 40, Last Available: "2012-03"
+5625	special hand-crafted mirror Black Hole	3	EPIC	Effect: "Ancient Protected", Effect Duration: 40, Last Available: "2012-03"
 5626	hand-crafted Event Horizon	3	EPIC	Last Available: "2012-03"
 5627	fancy tolerable upside-down upside-down Herring Daiquiri	3	good	Effect: "Warm Belly", Effect Duration: 35, Last Available: "2012-03"
 5628	mediocre Herring Wallbanger	4	decent	Last Available: "2012-03"
@@ -5533,11 +5533,11 @@
 5630	delicious Lollipop Drop	3	awesome	Last Available: "2012-03"
 5631	drinkable jittery Candy Alexander	3	good	Last Available: "2012-03"
 5632	practically non-alcoholic artisanal teal Candicaine	1	super ultra EPIC	Last Available: "2012-03"
-5633	triple-distilled mediocre Caipiranha	7	decent	Last Available: "2012-03"
-5634	practically non-alcoholic perfectly mixed Flying Caipiranha	1	EPIC	Last Available: "2012-03"
+5633	mediocre triple-distilled Caipiranha	7	decent	Last Available: "2012-03"
+5634	perfectly mixed practically non-alcoholic Flying Caipiranha	1	EPIC	Last Available: "2012-03"
 5635	lousy Flaming Caipiranha	3	decent	Last Available: "2012-03"
 5636	artisanal Punchplanter	3	EPIC	Last Available: "2012-03"
-5637	drinkable irresponsibly strong blinking Doublepunchplanter	6	good	Last Available: "2012-03"
+5637	irresponsibly strong drinkable blinking Doublepunchplanter	6	good	Last Available: "2012-03"
 5638	aged extra-dry Haymaker	5	awesome	Last Available: "2012-03"
 5639	gray Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	green crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
@@ -5545,16 +5545,16 @@
 5642	poisoned dart	0		
 5643	extra-deionized aerosolized shaking stone wool	0		Effect: "Memories of Puppy Love", Effect Duration: 18
 5644	stones	0		
-5645	blurry yellow bouncing the Nostril of the Serpent	0		
+5645	yellow bouncing blurry the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	spinning avaricious calendar	0		Meat Drop: +30, Damage Reduction: 4
-5648	pulsating huge censurious resourceful Boris's Helm	0		Maximum MP: +50, Sleaze Resistance: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	pulsating huge censurious resourceful Boris's Helm	0		Maximum MP: +50, Sleaze Resistance: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	nasty chaotic staph of homophones	0		Spell Critical Percent: +10, Stench Damage: +5
-5650	tumbling Tesla Boris's Helm (askew) of the sewer of the early riser	0		Stench Damage: +25, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	tumbling Tesla Boris's Helm (askew) of the sewer of the early riser	0		Stench Damage: +25, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	bouncing Monster Manuel	0		Free Pull
 5653	purple key-o-tron	0		
-5654	massive stale nailswurst	7	decent	
+5654	stale massive nailswurst	7	decent	
 5655	artisanal used beer	3	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	lime green fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5575,19 +5575,19 @@
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	squat &quot;L&quot;	0		
-5675	diluted lime green huge watered-down Red Minotaur	1		Effect: "Ancestral Disapproval", Effect Duration: 5
+5675	diluted huge lime green watered-down Red Minotaur	1		Effect: "Ancestral Disapproval", Effect Duration: 5
 5676	tumbling pool torpedo	0		Last Available: "2012-05"
-5677	blinking Ze&trade; goggles of the sewer	0		Stench Damage: +25, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	blinking Ze&trade; goggles of the sewer	0		Stench Damage: +25, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	squat upside-down Jack Frost's Da Vinci's stylish swimsuit	0		Experience (Mysticality): +5, Cold Spell Damage: +50, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	squat upside-down Jack Frost's Da Vinci's stylish swimsuit	0		Experience (Mysticality): +5, Cold Spell Damage: +50, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
-5681	moldy half-sized mirror P.B.L.T.	2	crappy	
+5681	half-sized moldy mirror P.B.L.T.	2	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	pulsating handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	squat wobbly bugbear autopsy tweezers	0		
+5687	wobbly squat bugbear autopsy tweezers	0		
 5688	lion tamer's UV monocular	0		Experience (familiar): +2, Single Equip
 5689	shaking drone self-destruct chip	0		
 5690	squat Jeff Goldblum larva	0		
@@ -5605,18 +5605,18 @@
 5702	huge mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	tumbling wax bugbear	0		Last Available: "2012-06"
-5705	cyan supercool strapping wax hat	0		Muscle: +5, Moxie Percent: +20, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	Lo Pan's brainy wax pants	0		Mysticality: +5, Spell Critical Percent: +30, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	cyan supercool strapping wax hat	0		Muscle: +5, Moxie Percent: +20, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	Lo Pan's brainy wax pants	0		Mysticality: +5, Spell Critical Percent: +30, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	irradiated quadruple-tarnished drop of water-37	0		Effect: "Serenity", Effect Duration: 41, Last Available: "2012-07"
-5709	maroon executive fireman's helmet of the detective	0		Item Drop: +20, Meat Drop: +40, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	maroon executive fireman's helmet of the detective	0		Item Drop: +20, Meat Drop: +40, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	stiffened fire axe	0		Damage Reduction: 1, Last Available: "2012-07"
 5713	huge greedy therapeutic wizardly fire extinguisher	0		Mysticality: +25, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	twirling Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	super-sized spoiled wobbly FDKOL hotcakes	5	crappy	Last Available: "2012-07"
-5718	twirling purple ghostly hot egg	0		Last Available: "2012-07"
+5717	spoiled super-sized wobbly FDKOL hotcakes	5	crappy	Last Available: "2012-07"
+5718	ghostly twirling purple hot egg	0		Last Available: "2012-07"
 5719	cyan smoking grass	0		Last Available: "2012-07"
 5720	spoiled half-sized wobbly fiery wing	2	crappy	Last Available: "2012-07"
 5721	tumbling cyan friendly chaotic wings of fire	0		Spell Critical Percent: +10, Familiar Weight: +3, Last Available: "2012-07"
@@ -5624,8 +5624,8 @@
 5723	ionized cyan bottle of fire	0		Effect: "Spooky Hands", Effect Duration: 16, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	twirling squat hot daub	0		Last Available: "2012-07"
-5726	ghostly lime green squat chaotic rock-hard hot daub bun	0		Damage Reduction: 5, Spell Critical Percent: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	up-at-dawn therapeutic hot daub stand	0		Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	ghostly lime green squat chaotic rock-hard hot daub bun	0		Damage Reduction: 5, Spell Critical Percent: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	up-at-dawn therapeutic hot daub stand	0		Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	narrow greasy Annie Oakley's foot-long hot daub	0		Critical Hit Percent: +20, Sleaze Spell Damage: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	normal olive angst burger	3	good	
@@ -5633,7 +5633,7 @@
 5732	green blank note	0		
 5733	eerily silent box	0		
 5734	stale forbidden sausage	3	decent	
-5735	groovy Lord Flameface's cloak	0		Moxie Percent: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5735	groovy Lord Flameface's cloak	0		Moxie Percent: +10, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	pickled pressed Drizzlers&trade; Black Licorice	0		Effect: "Certainty", Effect Duration: 62
 5737	frozen mirror daub-breaker	0		Effect: "Feeling No Pain", Effect Duration: 59, Last Available: "2020-09"
 5738	tumbling bouncing yellow wool Camp Scout backpack	0		Cold Resistance: +1, Softcore Only, Last Available: "2012-07"
@@ -5642,16 +5642,16 @@
 5741	aged wobbly water purification pills	4	awesome	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	mediocre skewed CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
-5744	fancy yummy ghostly bag of GORF	3	awesome	Effect: "Piratastic", Effect Duration: 25, Last Available: "2012-07"
+5744	yummy fancy ghostly bag of GORF	3	awesome	Effect: "Piratastic", Effect Duration: 25, Last Available: "2012-07"
 5745	shaking CSA discount card	0		Last Available: "2020-09"
-5746	moldy miniature huge bag of QWOP	2	crappy	Last Available: "2012-07"
-5747	wet bouncing upside-down CSA bravery badge	0		Effect: "Twinkly Weapon", Effect Duration: 37, Last Available: "2012-07"
+5746	miniature moldy huge bag of QWOP	2	crappy	Last Available: "2012-07"
+5747	wet upside-down bouncing CSA bravery badge	0		Effect: "Twinkly Weapon", Effect Duration: 37, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	high-proof perfectly mixed wobbly CSA cheerfulness ration	7	EPIC	Last Available: "2012-07"
 5750	wobbly CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	adequate crappy brain	4	good	
-5753	delicious jumbo decent brain	5	awesome	
+5753	jumbo delicious decent brain	5	awesome	
 5754	toothsome blurry good brain	3	awesome	
 5755	bland boss brain	3	decent	
 5756	normal hunter brain	3	good	
@@ -5665,16 +5665,16 @@
 5765	blinking chilly fuzzy earmuffs	0		Cold Damage: +5, Item Drop: +5, Familiar Effect: "1.5xVolley, cap 32"
 5766	aromatic chaotic beefcake's fuzzy montera	0		Muscle: +25, Spell Critical Percent: +10, Stench Resistance: +1, Familiar Effect: "1.5xVolley, cap 32"
 5767	upside-down Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	purple spinning gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	wobbly gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	squat gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	spinning purple gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	wobbly gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	squat gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	narrow talkative skull	0		
-5775	red jittery fronts	0		Familiar Weight: +5
+5775	jittery red fronts	0		Familiar Weight: +5
 5776	gray padded wicked Barney's rake	0		Spell Damage: +5, Damage Absorption: +20
-5778	enchanted tasty diet ghostly idiot brain	1	awesome	Effect: "Happy Salamander", Effect Duration: 45
+5778	tasty diet enchanted ghostly idiot brain	1	awesome	Effect: "Happy Salamander", Effect Duration: 45
 5779	skewed keel-haulin' knife of the boozehound	0		Booze Drop: +100
 5780	razor-sharp ice cream scoop	0		Weapon Damage Percent: +25
 5781	delicious soft echo eyedrop antidote martini	4	awesome	
@@ -5687,15 +5687,15 @@
 5788	smut orc keepsake box	0		
 5789	purple bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	tumbling Usain Bolt's electrified right bear arm	0		Initiative: +80, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	avaricious wicked educational left bear arm	0		Experience: +1, Spell Damage: +5, Meat Drop: +30, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	tumbling Usain Bolt's electrified right bear arm	0		Initiative: +80, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	avaricious wicked educational left bear arm	0		Experience: +1, Spell Damage: +5, Meat Drop: +30, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	mirror boxer's Hat O' Nine Tails	0		Muscle Percent: +10
-5794	polarized mirror lime green Enchanted Plunger	0		Effect: "familiar.enq", Effect Duration: 14
+5794	polarized lime green mirror Enchanted Plunger	0		Effect: "familiar.enq", Effect Duration: 14
 5795	quadruple-wet blue jittery Enchanted Flyswatter	0		Effect: "Stuck That Way", Effect Duration: 52
 5796	activated ionized pressed yellow Gearhead Goo	0		Effect: "Impregnabili Tea", Effect Duration: 67
 5797	triple-alkaline Missing Eye Simulation Device	0		Effect: "Drunk With Power", Effect Duration: 35
 5798	oxidized Gnollish Crossdress	0		Effect: "Flamibili Tea", Effect Duration: 20
-5799	nitrogenated huge blurry shaking eldritch dough	0		Effect: "Glo-Face", Effect Duration: 45
+5799	nitrogenated shaking blurry huge eldritch dough	0		Effect: "Glo-Face", Effect Duration: 45
 5800	irradiated Vulcanized yellow Charity's choker	0		Effect: "Protection from Bad Stuff", Effect Duration: 48
 5801	cold-filtered Smart Bone Dust	0		Effect: "Transcendental Wind", Effect Duration: 22
 5802	polymerized perpendicular guano	0		Effect: "Full-Body Tan", Effect Duration: 25
@@ -5733,7 +5733,7 @@
 5834	concentrated holistic headache remedy	0		Effect: "Florid Cheeks", Effect Duration: 59
 5835	Vulcanized scrunchie tourniquet	0		Effect: "Amorous Avarice", Effect Duration: 20
 5836	super-unsweetened triple-tarnished squat embezzler's oil	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 54
-5837	polymerized blurry shaking Fu Manchu Wax	0		Effect: "Mayeaugh", Effect Duration: 14
+5837	polymerized shaking blurry Fu Manchu Wax	0		Effect: "Mayeaugh", Effect Duration: 14
 5838	enhanced improved Iiti Kitty Gumdrop	0		Effect: "Super Speed", Effect Duration: 41
 5839	Vulcanized activated ravenous eye	0		Effect: "Stickler for Promptness", Effect Duration: 23
 5840	improved alkaline ghostly Rogue Windmill Rouge	0		Effect: "Jerky, Boy", Effect Duration: 57
@@ -5741,11 +5741,11 @@
 5842	non-liquefied toothbrush	0		Effect: "Insulated Trousers", Effect Duration: 52
 5843	polymerized polymerized pirate cream pie	0		Effect: "Thunderspell", Effect Duration: 38
 5844	liquefied upside-down una poca de gracia	0		Effect: "The Smile of Mr. A.", Effect Duration: 51
-5845	aerosolized green spinning compressed air canister	0		Effect: "Human-Hobo Hybrid", Effect Duration: 35
+5845	aerosolized spinning green compressed air canister	0		Effect: "Human-Hobo Hybrid", Effect Duration: 35
 5846	improved twirling green salt water taffy	0		Effect: "Incensed", Effect Duration: 49
 5847	magnetized unholy water	0		Effect: "Memory of Speed", Effect Duration: 33
 5848	oxidized Bangyomaman battle juice	0		Effect: "Speed of the Internet", Effect Duration: 33
-5849	denatured pressed double-frozen jittery mirror handyman &quot;hand soap&quot;	0		Effect: "Disco State of Mind", Effect Duration: 28
+5849	denatured pressed double-frozen mirror jittery handyman &quot;hand soap&quot;	0		Effect: "Disco State of Mind", Effect Duration: 28
 5850	triple-unsweetened magnetized space marine flash grenade	0		Effect: "Winklered", Effect Duration: 28
 5851	chilled polarized temporary tribal tattoo	0		Effect: "Big Flaming Whip", Effect Duration: 42
 5852	extra-dry extra-corrupted squat oil-filled donut	0		Effect: "Morninja", Effect Duration: 54
@@ -5754,11 +5754,11 @@
 5855	triple-ionized enhanced Osk'r Chow	0		Effect: "Bone Homie", Effect Duration: 64
 5856	oxidized Scuba Snack	0		Effect: "Quiet 'n' Good", Effect Duration: 49
 5857	double-boiled pressed improved pulsating grey cube	0		Effect: "Prince of Seaside Town", Effect Duration: 57
-5858	chilled double-polymerized bouncing red votive candle	0		Effect: "Frog In Your Throat", Effect Duration: 11
+5858	chilled double-polymerized red bouncing votive candle	0		Effect: "Frog In Your Throat", Effect Duration: 11
 5859	activated alkaline booby trap	0		Effect: "Oth-Jeal-O", Effect Duration: 61
 5860	non-ionized ionized yellow Agent Corrigan's cigarette	0		Effect: "Limber as Mortimer", Effect Duration: 58
 5861	moist irradiated good ash	0		Effect: "Hairy Palms", Effect Duration: 26
-5862	lime green shaking Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	shaking lime green Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	anodized frozen quadruple-oxidized squat papier-mochi	0		Effect: "Material Witness", Effect Duration: 50, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	jittery stylish papier-m&acirc;ch&eacute;te	0		Moxie: +25, Item Drop: +5, Last Available: "2012-09"
 5869	spinning Usain Bolt's papier-m&acirc;chine gun of chilblains	0		Cold Damage: +25, Initiative: +80, Last Available: "2012-09"
 5870	cyan extremely unsafe Sinatra's papier-masque	0		Experience (Moxie): +5, Weapon Damage Percent: +100, Single Equip, Last Available: "2012-09"
-5871	manspreader's papier-mitre of the scaredy-cat	0		Monster Level: -5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	pulsating perfumed scandalous papier-m&acirc;churidars	0		Sleaze Damage: +5, Stench Resistance: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	manspreader's papier-mitre of the scaredy-cat	0		Monster Level: -5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	pulsating perfumed scandalous papier-m&acirc;churidars	0		Sleaze Damage: +5, Stench Resistance: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	tumbling papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	blurry papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5823,7 +5823,7 @@
 5925	teal ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	teal BittyCar HotCar	0		Last Available: "2012-12"
-5928	squat coward's brainwave-controlled unicorn horn	0		Monster Level: -20, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	squat coward's brainwave-controlled unicorn horn	0		Monster Level: -20, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	twirling sinister thinker's plastic four-shadowed mime of extreme caution	0		Mysticality: +10, Spell Damage: +10, Monster Level: -25, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	baleful plastic Father McGruber	0		Spell Damage: +25, Last Available: "2012-12"
 5961	cyan rock-hard plastic Hank North, Photojournalist	0		Damage Reduction: 5, Last Available: "2012-12"
 5962	teal mirror hardy plastic blazing bat	0		Maximum HP: +50, Last Available: "2012-12"
-5963	electrified razor-sharp electronic dulcimer pants	0		Weapon Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	electrified razor-sharp electronic dulcimer pants	0		Weapon Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	up-at-dawn forbidden Frown Exerciser	0		Spell Damage Percent: +50, Adventures: +5, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5867,7 +5867,7 @@
 5969	teal soul knife	0		
 5970	veiny soul mask	0		Maximum HP: +10, Single Equip
 5971	record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
-5972	wobbly blinking record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
+5972	blinking wobbly record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
 5973	record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	spinning record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
@@ -5877,17 +5877,17 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	blurry cartoon heart	0		Last Available: "2013-02"
 5981	teal star	0		Last Available: "2013-02"
-5982	bad triple-distilled tankard of ale	6	decent	Last Available: "2013-02"
+5982	triple-distilled bad tankard of ale	6	decent	Last Available: "2013-02"
 5983	bouncing vial of holy water	0		Last Available: "2013-02"
-5984	forbidden beefy cloth cap of bravery	0		Muscle: +10, Spell Damage Percent: +50, Spooky Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	forbidden beefy cloth cap of bravery	0		Muscle: +10, Spell Damage Percent: +50, Spooky Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	greasy experienced stylish iron dagger	0		Moxie: +25, Experience: +2, Sleaze Spell Damage: +10, Last Available: "2013-02"
-5986	half-sized stale spinning hamburger	2	decent	Last Available: "2013-02"
+5986	stale half-sized spinning hamburger	2	decent	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
 5990	strong hand-crafted wobbly bottle of wine	5	EPIC	Last Available: "2013-02"
 5991	bouncing round bomb	0		Last Available: "2013-02"
-5992	twirling twirling toasty friendly vibrating iron helmet	0		Maximum MP Percent: +10, Familiar Weight: +3, Hot Damage: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	twirling twirling toasty friendly vibrating iron helmet	0		Maximum MP Percent: +10, Familiar Weight: +3, Hot Damage: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	ribald healthy steel sword of the scaredy-cat	0		Maximum HP Percent: +20, Monster Level: -15, Sleaze Damage: +10, Last Available: "2013-02"
 5994	flavorless whole roasted chicken	3	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	delicious shining goblet	4	awesome	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	maroon squat resourceful supercool sage crown	0		Mysticality Percent: +10, Moxie Percent: +20, Maximum MP: +50, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	maroon squat resourceful supercool sage crown	0		Mysticality Percent: +10, Moxie Percent: +20, Maximum MP: +50, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	scandalous Jim Carey's clever sword	0		Maximum MP: +20, Monster Level: +25, Sleaze Damage: +5, Last Available: "2013-02"
-6002	Lo Pan's therapeutic experienced Helm of the Scream Emperor	0		Experience: +2, Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	Lo Pan's therapeutic experienced Helm of the Scream Emperor	0		Experience: +2, Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	electrified MacGyver's Cloak of Dire Shadows of the businessman	0		Maximum MP: +100, Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-02"
 6004	horrifying dangerous Sword of Dark Omens of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, Spooky Damage: +25, Last Available: "2013-02"
 6005	groovy Shield of Icy Fate of the dark arts of the blizzard	0		Moxie Percent: +10, Spell Damage Percent: +100, Cold Spell Damage: +25, Damage Reduction: 7, Last Available: "2013-02"
-6006	chaotic medical-grade occult Greaves of the Murk Lord	0		Spell Damage Percent: +25, Spell Critical Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	chaotic medical-grade occult Greaves of the Murk Lord	0		Spell Damage Percent: +25, Spell Critical Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	manspreader's supercool Gauntlets of the Blood Moon	0		Moxie Percent: +20, Monster Level: +10, Item Drop: +5, Single Equip, Last Available: "2013-02"
 6008	miser's chilly razor-sharp Boots of Twilight Whispers	0		Weapon Damage Percent: +25, Cold Damage: +5, Meat Drop: +10, Single Equip, Last Available: "2013-02"
 6009	flame-wreathed Belt of Howling Anger of the pedagogue of the brazier	0		Experience: +3, Hot Spell Damage: 35, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	nitrogenated red orcish hand lotion	0		Effect: "Rainbow Bright", Effect Duration: 40
 6016	denatured tumbling orcish rubber	0		Effect: "Sweet and Yellow", Effect Duration: 12
 6017	adjusted anodized dry orcish nailing lube	0		Effect: "Impregnabili Tea", Effect Duration: 66
-6018	tolerable watered-down backwoods screwdriver	2	good	
+6018	watered-down tolerable backwoods screwdriver	2	good	
 6019	flame-wreathed loadstone	0		Hot Spell Damage: +10
 6020	Lo Pan's Claybender glasses of bravery	0		Spell Critical Percent: +30, Spooky Resistance: +5, Single Equip
 6021	bouncing deadly groovy Duskwalker fangs	0		Moxie Percent: +10, Weapon Damage: +5
@@ -5921,7 +5921,7 @@
 6023	Temple Grandin's manspreader's Whoompa Fur Pants	0		Monster Level: +10, Familiar Weight: +7, Familiar Effect: "atk, cap 27"
 6024	shaking Whatsian Ionic Pliers of horror	0		Spooky Spell Damage: +25
 6025	pickled Polysniff Perfume	0		Effect: "Rainbow Bright", Effect Duration: 50
-6026	mirror lime green Duskwalker syringe	0		
+6026	lime green mirror Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
@@ -5931,9 +5931,9 @@
 6033	twirling perfumed stolen necklace of dire peril	0		Weapon Damage: +20, Stench Resistance: +5
 6034	greasy mansplainer's troll britches	0		Monster Level: +15, Sleaze Spell Damage: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	modified vial of The Glistening	0		Effect: "Drunk With Power", Effect Duration: 56
-6036	drinkable practically non-alcoholic upside-down artisanal limoncello	1	good	
+6036	practically non-alcoholic drinkable upside-down artisanal limoncello	1	good	
 6037	teal ginger ale	0		
-6038	delicious miniature incredible pizza	2	awesome	
+6038	miniature delicious incredible pizza	2	awesome	
 6039	rosy-cheeked beefcake's oil cap	0		Muscle: +25, Maximum HP Percent: +30, Familiar Effect: "cap 28"
 6040	shellacked oil lamp of doom	0		Damage Reduction: 7, Spooky Spell Damage: +50
 6041	Sinatra's oil slacks	0		Experience (Moxie): +5, Familiar Effect: "1xPotato, cap 30"
@@ -5951,7 +5951,7 @@
 6053	bad Taco Dan's Taco Stand Chimichangarita	3	decent	Last Available: "2012-12"
 6054	warmed ionized blue Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Wasabi With You", Effect Duration: 28, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	blinking The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	blinking The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	aromatic razor-sharp Meatcleaver	0		Weapon Damage Percent: +25, Stench Resistance: +1, Last Available: "2013-12"
 6058	huge double-paned Crimbo Elf bobble-head	0		Cold Resistance: +5, Last Available: "2012-12"
 6059	Annie Oakley's Crimbo stogie-scented room odorizer	0		Critical Hit Percent: +20, Last Available: "2012-12"
@@ -5966,7 +5966,7 @@
 6068	loose blade	0		
 6069	pulsating yellow goblin bone hilt	0		
 6070	sword blade	0		
-6071	jittery blurry Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	blurry jittery Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	bouncing confusing LED clock	0		Last Available: "2012-12"
 6073	double-polarized haggis-infused soap	0		Effect: "Serendipi Tea", Effect Duration: 17, Last Available: "2012-12"
 6074	electrified cyan magicberry tablets	0		Effect: "Frozen Shoulders", Effect Duration: 16, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	delicious haggis-wrapped haggis-stuffed haggis	4	awesome	Last Available: "2012-12"
 6078	jittery blinking home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	wizardly haggis socks	0		Mysticality: +25, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	ghostly airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	wizardly haggis socks	0		Mysticality: +25, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	ghostly airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	jittery blurry wobbly Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6040,26 +6040,26 @@
 6142	stale fancy tumbling roasted duck	4	decent	Effect: "Nightstalkin'", Effect Duration: 45, Last Available: "2013-12"
 6143	flavorless dead meat bun	4	decent	Last Available: "2013-12"
 6144	bouncing cat collar of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2013-12"
-6145	blinking pulsating suspicious-looking fedora of Leguizamo of the scaredy-cat	0		Monster Level: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	blinking pulsating suspicious-looking fedora of Leguizamo of the scaredy-cat	0		Monster Level: 5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	huge Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	tumbling Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	pulsating Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	diet bland carrot cake	1	decent	Last Available: "2013-01"
+6152	bland diet carrot cake	1	decent	Last Available: "2013-01"
 6153	lousy bouncing carrot claret	3	decent	Last Available: "2013-01"
 6154	modified huge pulsating carrot juice	1	good	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	upside-down personal trainer's Byte of the boozehound	0		Experience Percent (Muscle): +10, Booze Drop: +100, Last Available: "2013-12"
-6158	family-friendly anger blaster	0		Sleaze Resistance: +1, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	knitted doubt cannon	0		Cold Resistance: +3, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	stiffened fear condenser	0		Damage Reduction: 1, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	jittery greedy regret hose	0		Meat Drop: +20, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
-6162	blue upside-down Young Man's Crew Sequester	0		Last Available: "2013-12"
+6158	family-friendly anger blaster	0		Sleaze Resistance: +1, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	knitted doubt cannon	0		Cold Resistance: +3, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	stiffened fear condenser	0		Damage Reduction: 1, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	jittery greedy regret hose	0		Meat Drop: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6162	upside-down blue Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	scorching crafty commodore's hat	0		Maximum MP: +10, Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	skewed slick naval trousers	0		Moxie: +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	scorching crafty commodore's hat	0		Maximum MP: +10, Hot Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	skewed slick naval trousers	0		Moxie: +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	spinning Van der Graaf deck cannon of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
 6167	shaking cool ornamental sextant	0		Moxie: +5, Last Available: "2013-12"
 6168	manspreader's strapping Bloodbath	0		Muscle: +5, Monster Level: +10, Last Available: "2013-12"
@@ -6079,9 +6079,9 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	bouncing bouncing lime green foul-smelling hardy Socratic Jarlsberg's hat	0		Experience (Mysticality): +1, Maximum HP: +50, Stench Damage: +10
-6185	stale half-sized consummate hard-boiled egg	2	decent	
+6185	half-sized stale consummate hard-boiled egg	2	decent	
 6186	tasty consummate fried egg	3	awesome	
-6187	moldy diet consummate egg salad	1	crappy	
+6187	diet moldy consummate egg salad	1	crappy	
 6188	normal consummate bagel	3	good	
 6189	moldy small consummate sliced bread	2	crappy	
 6190	toothsome upside-down spinning consummate hot dog bun	4	awesome	
@@ -6089,21 +6089,21 @@
 6192	flavorless consummate toast	4	decent	
 6193	perfectly mixed passable stout	3	EPIC	
 6194	tasty consummate soup	3	awesome	
-6195	flavorless tiny consummate corn chips	1	decent	
+6195	tiny flavorless consummate corn chips	1	decent	
 6196	bite-sized tasty teal consummate salad	1	awesome	
 6197	flavorless consummate salsa	3	decent	
-6198	half-sized decent consummate sauerkraut	2	good	
+6198	decent half-sized consummate sauerkraut	2	good	
 6199	bland consummate cheese slice	3	decent	
-6200	delicious massive olive consummate melted cheese	10	awesome	
+6200	massive delicious olive consummate melted cheese	10	awesome	
 6201	spoiled shaking consummate bacon	3	crappy	
 6202	tasty super-sized spinning consummate meatloaf	5	awesome	
 6203	spoiled tumbling consummate steak	3	crappy	
-6204	adequate small consummate cuts	2	good	
+6204	small adequate consummate cuts	2	good	
 6205	rotten thick consummate frankfurter	5	crappy	
 6206	moldy miniature consummate french fries	2	crappy	
 6207	big bland consummate baked potato	5	decent	
 6208	acceptable acceptable vodka	3	good	
-6209	bite-sized decent enchanted wobbly consummate ice cream	1	good	Effect: "Blessing of Charcoatl", Effect Duration: 30
+6209	bite-sized enchanted decent wobbly consummate ice cream	1	good	Effect: "Blessing of Charcoatl", Effect Duration: 30
 6210	toothsome consummate whipped cream	3	awesome	
 6211	delicious fancy diet consummate cream	1	awesome	Effect: "Hot Jellied", Effect Duration: 20
 6212	decent consummate strawberries	3	good	
@@ -6113,23 +6113,23 @@
 6216	miniature rotten immaculate grilled cheese	2	crappy	
 6217	normal immaculate ice cream sandwich	4	good	
 6218	moldy blinking immaculate hot dog	3	crappy	
-6219	half-sized stale immaculate egg salad sandwich	2	decent	
-6220	tiny tasty perfect sandwich	1	awesome	
+6219	stale half-sized immaculate egg salad sandwich	2	decent	
+6220	tasty tiny perfect sandwich	1	awesome	
 6221	tasty perfect chef salad	4	awesome	
 6222	low-calorie flavorless shaking perfect breakfast	1	decent	
-6223	normal half-sized green sublime deluxe hot dog	2	good	
+6223	half-sized normal green sublime deluxe hot dog	2	good	
 6224	rotten snack-sized sublime stew	2	crappy	
 6225	rotten immense sublime nachos	9	crappy	
 6226	stale Ultimate Breakfast Sandwich	3	decent	
 6227	spoiled tiny Loaded Baked Potato	1	crappy	
-6228	massive stale Omega Sundae	6	decent	
+6228	stale massive Omega Sundae	6	decent	
 6229	acceptable gray Das Sauerlager	4	good	
-6230	lousy watered-down bouncing Bologna Lambic	2	decent	
+6230	watered-down lousy bouncing Bologna Lambic	2	decent	
 6231	mediocre Vodka Dog	3	decent	
-6232	practically non-alcoholic hand-crafted Disappointed Russian	1	super ultra EPIC	
+6232	hand-crafted practically non-alcoholic Disappointed Russian	1	super ultra EPIC	
 6233	tolerable high-proof Chunky Mary	7	good	
 6234	delicious practically non-alcoholic Nachojito	1	awesome	
-6235	delicious triple-distilled Le Roi	9	awesome	
+6235	triple-distilled delicious Le Roi	9	awesome	
 6236	aged gray squat Over Easy Rider	4	awesome	
 6237	cosmic six-pack	0		
 6239	anodized non-altered gray cube of ectoplasm	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 40
@@ -6147,9 +6147,9 @@
 6251	dry oxidized twirling scroll of Protection from Bad Stuff	0		Effect: "Pharmaceutically Cool", Effect Duration: 43, Last Available: "2013-02"
 6252	colloidal irradiated scroll of Puddingskin	0		Effect: "Inner Dog", Effect Duration: 24, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
-6254	squat jittery Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
+6254	jittery squat Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	lime green Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
-6256	upside-down gray huge dried gelatinous cube	0		
+6256	gray huge upside-down dried gelatinous cube	0		
 6257	pile of dungeon junk	0		Familiar Weight: +5
 6258	jittery blurry family-friendly smelly sizzling Temple Grandin's Staff of the Healthy Breakfast	0		Familiar Weight: +7, Hot Damage: +10, Stench Spell Damage: +10, Sleaze Resistance: +1, Jiggle: "Recover Some HP"
 6259	green up-at-dawn mansplainer's rosy-cheeked sage Staff of the Staff of Life	0		Mysticality Percent: +10, Maximum HP Percent: +30, Monster Level: +15, Adventures: +5, Jiggle: "Full HP Recovery"
@@ -6182,7 +6182,7 @@
 6286	skewed reassuring double-paned Mark II Steam-Hat of temperance	0		Cold Resistance: +5, Spooky Resistance: +1, Sleaze Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6287	double-paned scandalous nippy dance instructor's Mark III Steam-Hat	0		Experience Percent (Moxie): +10, Cold Damage: +10, Sleaze Damage: +5, Cold Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6288	executive smelly steel-toed forbidden Newton's Mark IV Steam-Hat	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Damage Reduction: 9, Stench Spell Damage: +10, Meat Drop: +40, Familiar Effect: "1xLep, cap 37"
-6289	narrow zippy MacGyver's sinister Mark V Steam-Hat of the sewer of the cheetah	0		Spell Damage: +10, Maximum MP: +100, Stench Damage: +25, Initiative: 80, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	narrow zippy MacGyver's sinister Mark V Steam-Hat of the sewer of the cheetah	0		Spell Damage: +10, Maximum MP: +100, Stench Damage: +25, Initiative: 80, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	steam-powered model rocketship	0		
 6291	dangerous brawny punk rock jacket	0		Muscle Percent: +20, Weapon Damage: +10
 6292	upside-down fireproof nasty safety pin	0		Stench Damage: +5, Hot Resistance: +3
@@ -6194,7 +6194,7 @@
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	quantum gray Super Weight-Gain 9000	0		Effect: "Standard Cheer", Effect Duration: 52
-6301	electrified teal wobbly twirling possibility potion	0		Effect: "Quantum of Moxie", Effect Duration: 64
+6301	electrified teal twirling wobbly possibility potion	0		Effect: "Quantum of Moxie", Effect Duration: 64
 6302	eleven-foot pole	0		
 6303	ring of Detect Boring Doors	0		
 6304	yellow prompt MacGyver's Samson's boxer's Jarlsberg's pan (Cosmic portal mode) of the glutton	0		Muscle Percent: +10, Experience (Muscle): +5, Maximum MP: +100, Food Drop: +100, Adventures: +3, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6266,10 +6266,10 @@
 6370	twisted piece of wire	0		
 6371	acceptable strong can of the cheapest beer	5	good	
 6372	bad lime green bottle of fruity &quot;wine&quot;	3	decent	
-6373	mediocre weak single swig of vodka	2	decent	
+6373	weak mediocre single swig of vodka	2	decent	
 6374	angry inch	0		
 6375	bouncing testy toolbox of the dark arts	0		Spell Damage Percent: +100
-6376	narrow blinking Jick-o-User	0		
+6376	blinking narrow Jick-o-User	0		
 6378	eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	super-polymerized deionized lime green shaking ph balancer	0		Effect: "Lit Up", Effect Duration: 52
@@ -6294,7 +6294,7 @@
 6399	boiled Boss Drops	0		Effect: "Flamingly Floral", Effect Duration: 38
 6400	huge Mer-kin lunchbox	0		
 6401	aerosolized tarnished spinning tear	0		Effect: "Ninja, Please", Effect Duration: 20
-6402	double-moist ghostly spinning jagged tooth	0		Effect: "Unrunnable Face", Effect Duration: 50
+6402	double-moist spinning ghostly jagged tooth	0		Effect: "Unrunnable Face", Effect Duration: 50
 6403	denatured mirror grisly shell fragment	0		Effect: "Dirge of Dreadfulness", Effect Duration: 62
 6404	ionized vacuum-sealed violent pastilles	0		Effect: "Favored by Lyle", Effect Duration: 54
 6405	oxidized tarnished ghostly worst candy	0		Effect: "Winklered", Effect Duration: 22
@@ -6306,20 +6306,20 @@
 6411	twirling KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
-6414	pulsating blue clutch of dodecapede eggs	0		
+6414	blue pulsating clutch of dodecapede eggs	0		
 6415	low-calorie normal flavorless gruel	1	good	
-6416	immense adequate special blurry mana curds	9	good	Effect: "Just the Brown Ones", Effect Duration: 5
+6416	immense special adequate blurry mana curds	9	good	Effect: "Just the Brown Ones", Effect Duration: 5
 6417	twist of lime	0		
 6418	skewed pencil stub	0		
 6419	denatured activated moth dust	0		Effect: "Salamander In Your Stomach", Effect Duration: 46
 6420	concentrated glob of spoiled mayo	0		Effect: "Fishy Fortification", Effect Duration: 26
 6421	tonic djinn	0		
-6422	immense bland vampire chowder	6	decent	
+6422	bland immense vampire chowder	6	decent	
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	normal jumbo Dreadsylvanian stew	5	good	
-6427	hand-crafted watered-down special Dreadsylvanian	2	EPIC	Effect: "Heart of Lavender", Effect Duration: 5
+6427	hand-crafted special watered-down Dreadsylvanian	2	EPIC	Effect: "Heart of Lavender", Effect Duration: 5
 6428	vacuum-sealed dry olive Dreadsylvanian flask	0		Effect: "Izchak's Blessing", Effect Duration: 43
 6429	double-enhanced Dreadsylvanian flask	0		Effect: "Very Clean Guns", Effect Duration: 47
 6430	steel-toed Samson's dreadful fedora	0		Experience (Muscle): +5, Damage Reduction: 9, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6390,7 +6390,7 @@
 6495	spinning auspicious Dreadsylvania Auditor's badge	0		Item Drop: +10, Kruegerand Drop: 5, Single Equip
 6496	gray blood kiwi	0		
 6497	green eau de mort	0		
-6498	irresponsibly strong drinkable bloody kiwitini	6	good	
+6498	drinkable irresponsibly strong bloody kiwitini	6	good	
 6499	moon-amber	0		
 6500	polished moon-amber	0		
 6501	nippy beefy moon-amber necklace of the blizzard	0		Muscle: +10, Cold Damage: +10, Cold Spell Damage: +25, Single Equip
@@ -6398,7 +6398,7 @@
 6503	ghost pencil	0		
 6504	huge Sherlock's banded boxer's hangman's hood	0		Muscle Percent: +10, Damage Absorption: +100, Item Drop: +25
 6505	ruddy ring finger ring of dire peril of mayonnaise	0		Weapon Damage: +20, Maximum HP Percent: +40, Sleaze Spell Damage: +50, Single Equip
-6506	skewed blurry Dreadsylvanian clockwork key	0		
+6506	blurry skewed Dreadsylvanian clockwork key	0		
 6507	cool iron ingot	0		
 6508	jittery energetic quilted cool iron helmet	0		Damage Absorption: +40, Maximum MP Percent: +20, Familiar Effect: "atk, 1xFairy"
 6509	shaking coward's Herculean cool iron breastplate	0		Experience (Muscle): +1, Monster Level: -20
@@ -6408,7 +6408,7 @@
 6513	warm fur of wisdom	0		Mysticality: +15
 6514	Van der Graaf snowstick	0		MP Regen Min: 5, MP Regen Max: 7
 6515	wobbly tumbling eerie fetish of the early riser	0		Adventures: +7, Single Equip
-6516	aged strong blurry bouncing stinkwater	5	awesome	
+6516	strong aged bouncing blurry stinkwater	5	awesome	
 6517	blurry dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	rotten mirror accidental mutton	3	crappy	
 6519	upside-down gray horrifying Jim Carey's drafty drawers	0		Monster Level: +25, Spooky Damage: +25, Familiar Effect: "1.5xVolley"
@@ -6458,10 +6458,10 @@
 6564	stale Dreadsylvanian hot pocket	4	decent	
 6565	gigantic spoiled mirror Dreadsylvanian pocket	9	crappy	
 6566	thick flavorless Dreadsylvanian pocket	5	decent	
-6567	flavorless massive twirling Dreadsylvanian stink pocket	7	decent	
+6567	massive flavorless twirling Dreadsylvanian stink pocket	7	decent	
 6568	stale bouncing Dreadsylvanian sleaze pocket	3	decent	
 6569	mediocre shaking Dreadsylvanian hot toddy	3	decent	
-6570	watered-down perfectly mixed lime green Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
+6570	perfectly mixed watered-down lime green Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
 6571	irresponsibly strong acceptable spinning Dreadsylvanian grimlet	7	good	
 6572	mediocre fancy tumbling Dreadsylvanian dank and stormy	3	decent	Effect: "Smokin'", Effect Duration: 40
 6573	mediocre extra-dry blurry Dreadsylvanian slithery nipple	5	decent	
@@ -6469,7 +6469,7 @@
 6575	clusterbomb	0		
 6576	clusterbomb	0		
 6577	stench clusterbomb	0		
-6578	huge twirling sleaze clusterbomb	0		
+6578	twirling huge sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	skewed length of fuse	0		
 6581	dreadful box	0		
@@ -6489,7 +6489,7 @@
 6595	compressed tumbling mirror epic cluster	1	good	Effect: "Buggy Flavor", Effect Duration: 35
 6596	clockwork egg	0		
 6597	wobbly clockwork birdhouse	0		
-6598	gray upside-down pulsating clockwork disc	0		
+6598	pulsating upside-down gray clockwork disc	0		
 6599	clockwork hand	0		
 6600	maroon clockwork hand	0		
 6601	clockwork numeral I	0		
@@ -6561,7 +6561,7 @@
 6669	shaking modeling claymore	0		
 6670	clay homunculus	0		
 6671	vacuum-sealed pickled sodium pentasomething	0		Effect: "Retrograde Relaxation", Effect Duration: 25
-6672	shaking lime green grains of salt	0		
+6672	lime green shaking grains of salt	0		
 6673	mirror yellowcake bomb	0		
 6674	stinkbomb	0		
 6675	deionized pulsating superwater	0		Effect: "Human-Orc Hybrid", Effect Duration: 33
@@ -6569,9 +6569,9 @@
 6677	crude monster sculpture	0		
 6678	huge Newton's Yearbook Club Camera	0		Experience (Mysticality): +3, Conditional Skill (Equipped): "Blinding Flash"
 6679	cyan jittery machete of chilblains	0		Cold Damage: +25
-6680	practically non-alcoholic perfectly mixed Cursed Punch	1	EPIC	
+6680	perfectly mixed practically non-alcoholic Cursed Punch	1	EPIC	
 6681	practically non-alcoholic acceptable Bowl of Scorpions	1	good	
-6682	delicious fortified Fog Murderer	5	awesome	
+6682	fortified delicious Fog Murderer	5	awesome	
 6683	book of matches	0		
 6684	censurious surgical mask	0		Sleaze Resistance: +3, Surgeonosity: +1
 6685	head mirror of the detective	0		Item Drop: +20, Surgeonosity: +1
@@ -6585,16 +6585,16 @@
 6693	narrow McClusky file (page 5)	0		
 6694	yellow boring binder clip	0		
 6695	teal McClusky file (complete)	0		
-6696	squat tumbling bowling ball	0		
+6696	tumbling squat bowling ball	0		
 6697	shaking moss-covered stone sphere	0		
 6698	green dripping stone sphere	0		
 6699	mirror crackling stone sphere	0		
 6700	spinning scorched stone sphere	0		
 6701	stone triangle	0		
-6702	bouncing squat bowler	0		
+6702	squat bouncing bowler	0		
 6703	fancy imitation White Russian	1	good	Effect: "Nutrient-Rich", Effect Duration: 40
 6704	friendly dance instructor's short-handled mop	0		Experience Percent (Moxie): +10, Familiar Weight: +3
-6705	rotten miniature jungle floor wax	2	crappy	
+6705	miniature rotten jungle floor wax	2	crappy	
 6706	spinning smirking shrunken head	0		
 6707	warmed jittery skewed colorful toad	0		Effect: "Insatiable Hunger", Effect Duration: 28
 6708	crude voodoo doll	0		
@@ -6602,10 +6602,10 @@
 6710	pygmy briefs of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
 6712	yellow bone abacus	0		
-6713	skewed olive bouncing adder	0		
+6713	bouncing skewed olive adder	0		
 6714	red short calculator	0		
 6715	huge smooth sphygmomanometer of extreme caution	0		Moxie: +15, Monster Level: -25
-6716	triple-liquefied pulsating blinking bag of pygmy blood	0		Effect: "Full of Vinegar", Effect Duration: 17
+6716	triple-liquefied blinking pulsating bag of pygmy blood	0		Effect: "Full of Vinegar", Effect Duration: 17
 6717	tongue depressor	0		
 6718	compression stocking of wisdom of the sweet-tooth	0		Mysticality: +15, Candy Drop: +100
 6719	asbestos-lined frightening midriff scrubs	0		Spooky Damage: +5, Hot Resistance: +5
@@ -6648,7 +6648,7 @@
 6756	artisanal homebrew sampler	0		
 6757	bad can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
 6758	acceptable can of Drooling Monk	3	good	Last Available: "2013-09"
-6759	practically non-alcoholic perfectly mixed twirling can of Impetuous Scofflaw	1	EPIC	Last Available: "2013-09"
+6759	perfectly mixed practically non-alcoholic twirling can of Impetuous Scofflaw	1	EPIC	Last Available: "2013-09"
 6760	delicious teal bottle of Old Pugilist	3	awesome	Last Available: "2013-09"
 6761	bad weak bottle of Professor Beer	2	decent	Last Available: "2013-09"
 6762	acceptable narrow bottle of Rapier Witbier	3	good	Last Available: "2013-09"
@@ -6658,7 +6658,7 @@
 6766	cyan tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	awesome	Last Available: "2013-09"
-6769	flame-retardant Lo Pan's resourceful tin tam	0		Maximum MP: +50, Spell Critical Percent: +30, Hot Resistance: +1, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	flame-retardant Lo Pan's resourceful tin tam	0		Maximum MP: +50, Spell Critical Percent: +30, Hot Resistance: +1, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	quantum purple tin cup	0		Effect: "Heart of Pink", Effect Duration: 22, Last Available: "2013-09"
 6771	coward's tin foil of the cougar of the detective	0		Moxie: +20, Monster Level: -20, Item Drop: +20, Last Available: "2013-09"
 6772	squat nasty wizardly tin drum of terror	0		Mysticality: +25, Stench Damage: +5, Spooky Spell Damage: +10, Last Available: "2013-09"
@@ -6724,12 +6724,12 @@
 6835	triple-quantum magnetized tumbling bag of W&Ws	0		Effect: "Mental A-cue-ity", Effect Duration: 18
 6836	electrified upside-down PEEZ dispenser	0		Effect: "Disdain of the War Snapper", Effect Duration: 66
 6837	warmed vacuum-sealed ghostly Swizzler	0		Effect: "Superioreo", Effect Duration: 56
-6838	pickled aerosolized cyan bouncing Bugbearclaw Donut	0		Effect: "Oriental Mysticism", Effect Duration: 25
+6838	pickled aerosolized bouncing cyan Bugbearclaw Donut	0		Effect: "Oriental Mysticism", Effect Duration: 25
 6839	altered pickled pulsating tumbling jam	0		Effect: "Shawarma Warm War", Effect Duration: 64
 6840	altered frozen tumbling Whenchamacallit bar	0		Effect: "Human-Penguin Hybrid", Effect Duration: 53
 6841	adjusted 8-bit banana	0		Effect: "Vital", Effect Duration: 31
 6842	unsweetened super-quantum spinning vial of blood simple syrup	0		Effect: "Florid Cheeks", Effect Duration: 58
-6843	quadruple-dry aerosolized denatured twirling upside-down bone bons	0		Effect: "Bottle in front of Me", Effect Duration: 26
+6843	quadruple-dry aerosolized denatured upside-down twirling bone bons	0		Effect: "Bottle in front of Me", Effect Duration: 26
 6844	triple-magnetized electrified ironic mint	0		Effect: "Super-Electrified", Effect Duration: 39
 6845	unused walkie-talkie	0		Free Pull
 6846	shaking walkie-talkie	0		Free Pull
@@ -6746,13 +6746,13 @@
 6857	blurry dance instructor's Cajun accordion	0		Experience Percent (Moxie): +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	upside-down experienced quirky accordion	0		Experience: +2, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	chaotic dangerous Skipper's accordion	0		Weapon Damage: +10, Spell Critical Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	dog trainer's Oprah's cool Pantsgiving of the scaredy-cat	0		Moxie: +5, Maximum MP Percent: +50, Monster Level: -15, Experience (familiar): +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
-6861	miniature flavorless can of sardines	2	decent	Last Available: "2013-11"
+6860	dog trainer's Oprah's cool Pantsgiving of the scaredy-cat	0		Moxie: +5, Maximum MP Percent: +50, Monster Level: -15, Experience (familiar): +1, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6861	flavorless miniature can of sardines	2	decent	Last Available: "2013-11"
 6862	rotten high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
-6863	stale red jittery pat of butter	3	decent	Last Available: "2013-11"
+6863	stale jittery red pat of butter	3	decent	Last Available: "2013-11"
 6864	moldy fancy dinner roll	3	crappy	Effect: "Heart Aflame", Effect Duration: 30, Last Available: "2013-11"
-6865	spoiled low-calorie mashed potatoes	1	crappy	Last Available: "2013-11"
-6866	enchanted rotten whole turkey leg	3	crappy	Effect: "Slippery Tongue", Effect Duration: 20, Last Available: "2013-11"
+6865	low-calorie spoiled mashed potatoes	1	crappy	Last Available: "2013-11"
+6866	rotten enchanted whole turkey leg	3	crappy	Effect: "Slippery Tongue", Effect Duration: 20, Last Available: "2013-11"
 6867	bland miniature skewed deviled egg	2	decent	Last Available: "2013-11"
 6868	cold-filtered teal finger exerciser	0		Effect: "Blubbered Up", Effect Duration: 34, Last Available: "2013-11"
 6869	quadruple-diffused dry dented spoon	0		Effect: "Bored Stiff", Effect Duration: 45, Last Available: "2013-11"
@@ -6762,9 +6762,9 @@
 6873	aerosolized candy wrapper	0		Effect: "Using Protection", Effect Duration: 44, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	wet squat blurry post-holiday sale coupon	0		Effect: "Tennis Elbow-wow", Effect Duration: 16, Last Available: "2013-11"
-6876	blurry blue dry cleaning receipt	0		Last Available: "2013-11"
+6876	blue blurry dry cleaning receipt	0		Last Available: "2013-11"
 6877	wobbly pocket lint (blue)	0		Last Available: "2013-11"
-6878	squat tumbling pocket lint (green)	0		Last Available: "2013-11"
+6878	tumbling squat pocket lint (green)	0		Last Available: "2013-11"
 6879	pocket lint (white)	0		Last Available: "2013-11"
 6880	upside-down pocket lint (orange)	0		Last Available: "2013-11"
 6881	rosewater-soaked Annie Oakley's sharpshooter's thinker's bowl of petunias	0		Mysticality: +10, Critical Hit Percent: 30, Stench Resistance: +3, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	vacuum-sealed nuts	0		Effect: "Chalked-Up Teeth", Effect Duration: 24, Last Available: "2013-12"
 6904	colloidal electrified bolts	0		Effect: "Ode to Booze", Effect Duration: 11, Last Available: "2013-12"
 6905	yummy gray gingerbread robot	4	awesome	Last Available: "2013-12"
-6906	snack-sized fancy flavorless narrow petit 4.1	2	decent	Effect: "Dreams and Lights", Effect Duration: 5, Last Available: "2013-12"
+6906	snack-sized flavorless fancy narrow petit 4.1	2	decent	Effect: "Dreams and Lights", Effect Duration: 5, Last Available: "2013-12"
 6907	stale teal nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
 6908	pulsating yellow knitted plastic GORM-8	0		Cold Resistance: +3, Last Available: "2013-12"
 6909	upside-down Tesla plastic warbear	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
@@ -6808,31 +6808,31 @@
 6919	chilled warbear bearserker potion	0		Effect: "Big Flaming Whip", Effect Duration: 65, Last Available: "2013-12"
 6920	ionized colloidal concentrated warbear liquid overcoat	0		Effect: "protect.enq", Effect Duration: 11, Last Available: "2013-12"
 6921	stale low-calorie warbear feasting bread	1	decent	Last Available: "2013-12"
-6922	adequate thick warbear warrior bread	5	good	Last Available: "2013-12"
+6922	thick adequate warbear warrior bread	5	good	Last Available: "2013-12"
 6923	flavorless warbear thermoregulator bread	3	decent	Last Available: "2013-12"
 6924	lousy warbear feasting mead	4	decent	Last Available: "2013-12"
 6925	hand-crafted warbear bearserker mead	3	EPIC	Last Available: "2013-12"
 6926	acceptable high-proof upside-down warbear blizzard mead	9	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	red Jim Carey's rock-hard warbear plain fedora of the boozehound	0		Damage Reduction: 5, Monster Level: +25, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	Oprah's warbear feathered fedora	0		Maximum MP Percent: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	sizzling energetic personal trainer's warbear fedora	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	slick warbear plain helm of wisdom of the brute	0		Mysticality: +15, Moxie: +10, Muscle Percent: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	warbear spiked helm of the wise owl	0		Mysticality: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	horrifying coward's warbear electro-spiked helm of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Spooky Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	energetic personal trainer's boxer's warbear plain ushanka	0		Muscle Percent: +10, Experience Percent (Muscle): +10, Maximum MP Percent: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	fuchsia smartaleck's warbear lined ushanka	0		Moxie Percent: +30, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	twirling purple perfumed brawny warbear heated ushanka of chilblains	0		Muscle Percent: +20, Cold Damage: +25, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	red Jim Carey's rock-hard warbear plain fedora of the boozehound	0		Damage Reduction: 5, Monster Level: +25, Booze Drop: +100, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	Oprah's warbear feathered fedora	0		Maximum MP Percent: +50, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	sizzling energetic personal trainer's warbear fedora	0		Experience Percent (Muscle): +10, Maximum MP Percent: +20, Hot Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	slick warbear plain helm of wisdom of the brute	0		Mysticality: +15, Moxie: +10, Muscle Percent: +30, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	warbear spiked helm of the wise owl	0		Mysticality: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	horrifying coward's warbear electro-spiked helm of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Spooky Damage: +25, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	energetic personal trainer's boxer's warbear plain ushanka	0		Muscle Percent: +10, Experience Percent (Muscle): +10, Maximum MP Percent: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	fuchsia smartaleck's warbear lined ushanka	0		Moxie Percent: +30, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	twirling purple perfumed brawny warbear heated ushanka of chilblains	0		Muscle Percent: +20, Cold Damage: +25, Stench Resistance: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	squat upside-down warbear trouser fragment	0		Last Available: "2013-12"
-6938	jittery smelly electrified dangerous warbear party pants	0		Weapon Damage: +10, Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	pulsating resourceful warbear ceremonial party pants	0		Maximum MP: +50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	crafty groovy beefcake's warbear high festival pants	0		Muscle: +25, Moxie Percent: +10, Maximum MP: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	blurry purple smartaleck's wizardly warbear battle greaves of the cheetah	0		Mysticality: +25, Moxie Percent: +30, Initiative: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	maroon horrifying warbear officer greaves	0		Spooky Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	greasy Annie Oakley's warbear bearserker greaves of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +20, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	fuchsia twirling greasy curative supercool warbear johns	0		Moxie Percent: +20, Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	Da Vinci's warbear fleece-lined johns	0		Experience (Mysticality): +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	rosewater-soaked stylish warbear johns of the sweet-tooth	0		Moxie: +25, Stench Resistance: +3, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	jittery smelly electrified dangerous warbear party pants	0		Weapon Damage: +10, Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	pulsating resourceful warbear ceremonial party pants	0		Maximum MP: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	crafty groovy beefcake's warbear high festival pants	0		Muscle: +25, Moxie Percent: +10, Maximum MP: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	blurry purple smartaleck's wizardly warbear battle greaves of the cheetah	0		Mysticality: +25, Moxie Percent: +30, Initiative: +60, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	maroon horrifying warbear officer greaves	0		Spooky Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	greasy Annie Oakley's warbear bearserker greaves of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +20, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	fuchsia twirling greasy curative supercool warbear johns	0		Moxie Percent: +20, Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	Da Vinci's warbear fleece-lined johns	0		Experience (Mysticality): +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	rosewater-soaked stylish warbear johns of the sweet-tooth	0		Moxie: +25, Stench Resistance: +3, Candy Drop: +100, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	vibrating occult Socratic warbear goggles	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Maximum MP Percent: +10, Single Equip, Last Available: "2013-12"
 6949	ribald warbear snowblindness goggles	0		Sleaze Damage: +10, Single Equip, Last Available: "2013-12"
@@ -6843,17 +6843,17 @@
 6954	Jeselnik's nippy Rosewater's warbear warscarf	0		Mysticality Percent: +30, Cold Damage: +10, Sleaze Damage: +25, Single Equip, Last Available: "2013-12"
 6955	banded warbear fleece-lined warscarf	0		Damage Absorption: +100, Single Equip, Last Available: "2013-12"
 6956	knitted vibrating ruddy warbear warscarf	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Cold Resistance: +3, Single Equip, Last Available: "2013-12"
-6957	gray shaking warbear requisition box	0		Last Available: "2013-12"
+6957	shaking gray warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	wobbly forbidden warbear foil hat	0		Spell Damage Percent: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	wobbly forbidden warbear foil hat	0		Spell Damage Percent: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	purple wholesome warbear oil pan of the ox	0		Muscle: +20, Maximum HP Percent: +10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	purple wholesome warbear oil pan of the ox	0		Muscle: +20, Maximum HP Percent: +10, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	pulsating blinking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	Newton's warbear exhaust manifold	0		Experience (Mysticality): +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	warbear auto-anvil	0		Last Available: "2013-12"
 6966	warbear induction oven	0		Last Available: "2013-12"
-6967	ghostly upside-down warbear chemistry lab	0		Last Available: "2013-12"
+6967	upside-down ghostly warbear chemistry lab	0		Last Available: "2013-12"
 6968	blurry warbear officer requisition box	0		Last Available: "2013-12"
 6969	spinning warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 6970	warbear drone assembler	0		Last Available: "2013-12"
@@ -6892,13 +6892,13 @@
 7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	colloidal Flaskfull of Hollow	0		Effect: "Sweet Nostalgia", Effect Duration: 49, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
-7006	vaporized skewed jittery blue handful of Smithereens	1	good	Last Available: "2013-12"
+7006	vaporized jittery skewed blue handful of Smithereens	1	good	Last Available: "2013-12"
 7007	spoiled Every Day is Like This Sundae	3	crappy	Last Available: "2013-12"
-7008	moldy immense Miserable Pie	8	crappy	Last Available: "2013-12"
+7008	immense moldy Miserable Pie	8	crappy	Last Available: "2013-12"
 7009	special flavorless gray This Charming Flan	3	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 45, Last Available: "2013-12"
 7010	lousy Irish Coffee, English Heart	4	decent	Last Available: "2013-12"
-7011	artisanal weak Strikes Again Bigmouth	2	EPIC	Last Available: "2013-12"
-7012	watered-down perfectly mixed Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
+7011	weak artisanal Strikes Again Bigmouth	2	EPIC	Last Available: "2013-12"
+7012	perfectly mixed watered-down Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	gravedigger's Newton's Sheila Take a Crossbow of terror of the early riser	0		Experience (Mysticality): +3, Spooky Damage: +10, Spooky Spell Damage: +10, Adventures: +7, Last Available: "2013-12"
 7019	pulsating spinning mirror purple flame-wreathed clever padded experienced A Light that Never Goes Out	0		Experience: +2, Damage Absorption: +20, Maximum MP: +20, Hot Spell Damage: +10, Last Available: "2013-12"
 7020	blue electrified studded Socratic boxer's Half a Purse	0		Muscle Percent: +10, Experience (Mysticality): +1, Damage Absorption: +80, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
-7021	narrow greasy Jim Carey's Fonzie's Hairpiece On Fire of the detective	0		Experience (Moxie): +1, Monster Level: +25, Sleaze Spell Damage: +10, Item Drop: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	aromatic sharpshooter's stiffened brawny Vicar's Tutu	0		Muscle Percent: +20, Damage Reduction: 1, Critical Hit Percent: +10, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	narrow greasy Jim Carey's Fonzie's Hairpiece On Fire of the detective	0		Experience (Moxie): +1, Monster Level: +25, Sleaze Spell Damage: +10, Item Drop: +20, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	aromatic sharpshooter's stiffened brawny Vicar's Tutu	0		Muscle Percent: +20, Damage Reduction: 1, Critical Hit Percent: +10, Stench Resistance: +1, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	blinking green mansplainer's ruddy dance instructor's Hand in Glove	0		Experience Percent (Moxie): +10, Maximum HP Percent: +40, Monster Level: +15, Single Equip, Last Available: "2013-12"
 7024	fireproof Oprah's extremely unsafe Meat Tenderizer is Murder	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Hot Resistance: +3, Class: "Seal Clubber", Last Available: "2013-12"
 7025	ribald medical-grade Ouija Board, Ouija Board of the pedagogue	0		Experience: +3, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	friendly hale arcane researcher's Shakespeare's Sister's Accordion	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Familiar Weight: +3, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	yellow Da Vinci's third-hand lantern	0		Experience (Mysticality): +5
 7031	shaking loose purse strings	0		
-7032	small stale pickled egg	2	decent	
+7032	stale small pickled egg	2	decent	
 7033	cup of lukewarm tea	1	good	
 7034	pulsating warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6943,33 +6943,33 @@
 7054	warbear drone codes	0		Last Available: "2013-12"
 7055	yummy breakfast mess	3	awesome	Last Available: "2013-12"
 7056	tumbling warbear breakfast machine	0		Last Available: "2013-12"
-7057	adequate miniature breakfast miracle	2	good	Last Available: "2013-12"
+7057	miniature adequate breakfast miracle	2	good	Last Available: "2013-12"
 7058	diffused super-pressed shaking Cloaca Cola Polar	0		Effect: "Bored Stiff", Effect Duration: 41, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	ghostly grimstone mask	0		Last Available: "2014-12"
 7062	mirror praying Grim Brother	0		Free Pull, Last Available: "2014-12"
-7063	huge squat narrow Grim Brothers' story book	0		Familiar Weight: +5
-7064	shaking maroon hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
+7063	narrow huge squat Grim Brothers' story book	0		Familiar Weight: +5
+7064	maroon shaking hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	boiled spinning grim fairy tale	1	good	Effect: "Heart of Lavender", Effect Duration: 40, Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
-7067	polymerized Vulcanized polarized jittery shaking single of Inigo's Incantation of Inspiration	0		Effect: "Bone Homie", Effect Duration: 46, Last Available: "2010-02"
+7067	polymerized Vulcanized polarized shaking jittery single of Inigo's Incantation of Inspiration	0		Effect: "Bone Homie", Effect Duration: 46, Last Available: "2010-02"
 7068	pickled enhanced jittery single of Donho's Bubbly Ballad	0		Effect: "Ticking Clock", Effect Duration: 35
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	rotten snack-sized snow berries	2	crappy	Last Available: "2014-01"
+7071	snack-sized rotten snow berries	2	crappy	Last Available: "2014-01"
 7072	delicious ice harvest	4	awesome	Last Available: "2014-01"
 7073	anodized wet frost flower	0		Effect: "Superheroic", Effect Duration: 32, Last Available: "2014-01"
 7074	Vulcanized double-energized shaking snow cleats	0		Effect: "Sweet Tooth", Effect Duration: 34, Last Available: "2014-01"
 7075	boiled irradiated pulsating liquid ice pack	0		Effect: "Adorable Lookout", Effect Duration: 46, Last Available: "2014-01"
 7076	huge snow boards	0		Last Available: "2014-01"
-7077	gigantic decent special blinking snow crab	6	good	Effect: "The Best a Pirate Can Get", Effect Duration: 10, Last Available: "2014-01"
+7077	special decent gigantic blinking snow crab	6	good	Effect: "The Best a Pirate Can Get", Effect Duration: 10, Last Available: "2014-01"
 7078	artisanal fortified mirror Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
 7079	pulsating unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	gray ice house	0		Last Available: "2014-01"
 7082	blurry gray snow machine	0		Last Available: "2014-01"
-7083	spinning ghostly frightening snow mobile	0		Spooky Damage: +5, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	spinning ghostly frightening snow mobile	0		Spooky Damage: +5, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	smartaleck's ice bucket	0		Moxie Percent: +30, Lasts Until Rollover, Last Available: "2014-01"
 7085	gravedigger's lion tamer's snow shovel	0		Experience (familiar): +2, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7086	upside-down lion tamer's manspreader's experienced bod-ice	0		Experience: +2, Monster Level: +10, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	irresponsibly strong drinkable spinning En Una Fila Tequila	8	good	
 7091	Skully's hot chocolate	1	good	
-7092	wobbly huge medical-grade razor-sharp warbear dress helmet	0		Weapon Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	wobbly huge medical-grade razor-sharp warbear dress helmet	0		Weapon Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	twirling shaking toasty Temple Grandin's warbear dress bracers	0		Familiar Weight: +7, Hot Damage: +5, Single Equip, Last Available: "2013-12"
-7094	family-friendly perfumed warbear dress greaves	0		Stench Resistance: +5, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	banded sweatband of the sewer	0		Damage Absorption: +100, Stench Damage: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	shellacked smartaleck's gym shorts	0		Moxie Percent: +30, Damage Reduction: 7, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	family-friendly perfumed warbear dress greaves	0		Stench Resistance: +5, Sleaze Resistance: +1, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	banded sweatband of the sewer	0		Damage Absorption: +100, Stench Damage: +25, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	shellacked smartaleck's gym shorts	0		Moxie Percent: +30, Damage Reduction: 7, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	zippy savvy ankleweights	0		Mysticality Percent: +20, Initiative: +20, Single Equip, Last Available: "2014-12"
 7098	pulsating fuchsia sizzling chaotic sinister sweat socks of vim and vigor	0		Spell Damage: +10, Maximum HP Percent: +50, Spell Critical Percent: +10, Hot Damage: +10, Last Available: "2014-12"
 7099	wobbly squat pint of sweat	0		Last Available: "2014-12"
@@ -6992,10 +6992,10 @@
 7103	flattened ghostly powder	0		Effect: "Arresistible", Effect Duration: 19, Last Available: "2014-12"
 7104	manspreader's licorice whip	0		Monster Level: +10, Last Available: "2014-12"
 7105	pulsating anise-flavored venom	0		Last Available: "2014-12"
-7106	bad practically non-alcoholic snakebite	1	decent	Last Available: "2014-12"
+7106	practically non-alcoholic bad snakebite	1	decent	Last Available: "2014-12"
 7107	tumbling fortified candy stick of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +60, Last Available: "2014-12"
-7108	miniature stale pecan	2	decent	Last Available: "2014-12"
-7109	spoiled special pecan pie	4	crappy	Effect: "Night of the Nachos", Effect Duration: 50, Last Available: "2014-12"
+7108	stale miniature pecan	2	decent	Last Available: "2014-12"
+7109	special spoiled pecan pie	4	crappy	Effect: "Night of the Nachos", Effect Duration: 50, Last Available: "2014-12"
 7110	narrow chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	spoiled maroon candy mountain oyster	4	crappy	Last Available: "2014-12"
 7112	drinkable practically non-alcoholic mirror chocotini	1	good	Last Available: "2014-12"
@@ -7003,13 +7003,13 @@
 7114	normal candy carrot	4	good	Last Available: "2014-12"
 7115	thick decent candy carrot cake	5	good	Last Available: "2014-12"
 7116	blinking friendly carrot-on-a-stick of Calamity Jane	0		Critical Hit Percent: +15, Familiar Weight: +3, Last Available: "2014-12"
-7117	Jim Carey's sharpshooter's weasel stomping pants	0		Critical Hit Percent: +10, Monster Level: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	yummy huge mulberry	10	awesome	Last Available: "2014-12"
+7117	Jim Carey's sharpshooter's weasel stomping pants	0		Critical Hit Percent: +10, Monster Level: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7118	huge yummy mulberry	10	awesome	Last Available: "2014-12"
 7119	triple-distilled delicious mulled berry wine	6	awesome	Last Available: "2014-12"
 7120	blinking lemony scales	0		Last Available: "2014-12"
-7121	blinking hardened lemon party hat	0		Damage Reduction: 3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	blinking hardened lemon party hat	0		Damage Reduction: 3, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	stanky lemon shirt	0		Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-12"
-7123	upside-down medical-grade lemon drop trousers	0		HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	upside-down medical-grade lemon drop trousers	0		HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	non-anodized magnetized irradiated lime green lemonhead caviar	0		Effect: "Cold, Dead Hands", Effect Duration: 16, Last Available: "2014-12"
 7125	narrow Lo Pan's gummi sword of the early riser	0		Spell Critical Percent: +30, Adventures: +7, Last Available: "2014-12"
 7126	pickled small gummi fin	0		Effect: "Abyssal Tears", Effect Duration: 23, Last Available: "2014-12"
@@ -7020,7 +7020,7 @@
 7131	squat executive Sherlock's Herculean cow creamer	0		Experience (Muscle): +1, Item Drop: +25, Meat Drop: +40, Last Available: "2014-12"
 7132	deionized Outer Wolf&trade; cologne	0		Effect: "Sugary World View", Effect Duration: 55, Last Available: "2014-12"
 7133	wobbly lupine appetite hormones	0		Last Available: "2014-12"
-7134	medical-grade wolf whistle of the pedagogue	0		Experience: +3, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7134	medical-grade wolf whistle of the pedagogue	0		Experience: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	normal spinning witch's bread	3	good	Last Available: "2014-12"
 7136	magnetized polarized huge witch's brew	0		Effect: "Memory of Strength", Effect Duration: 49, Last Available: "2014-12"
 7137	frightening steel-toed stylish witch's bra	0		Moxie: +25, Damage Reduction: 9, Spooky Damage: +5, Last Available: "2014-12"
@@ -7034,7 +7034,7 @@
 7145	spoiled ghostly cinnamon cannoli	3	crappy	Last Available: "2014-12"
 7146	acceptable expensive champagne	4	good	Last Available: "2014-12"
 7147	activated colloidal polo trophy	0		Effect: "Once Bitten Twice Fried", Effect Duration: 45, Last Available: "2014-12"
-7148	mirror green oil painting	0		Last Available: "2014-12"
+7148	green mirror oil painting	0		Last Available: "2014-12"
 7149	yellow rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
@@ -7043,29 +7043,29 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	squat rosewater-soaked fire hose of chilblains of terror	0		Cold Damage: +25, Spooky Spell Damage: +10, Stench Resistance: +3, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	squat rosewater-soaked fire hose of chilblains of terror	0		Cold Damage: +25, Spooky Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	normal green fireman's lunch	4	good	Last Available: "2014-12"
-7159	blurry reassuring electrified arcane researcher's plain paper hat	0		Experience Percent (Mysticality): +10, Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	blurry reassuring electrified arcane researcher's plain paper hat	0		Experience Percent (Mysticality): +10, Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	bland ice cream sandwich	3	decent	Last Available: "2014-12"
 7161	greedy brainy beefy &quot;honey&quot; dipper	0		Muscle: +10, Mysticality: +5, Meat Drop: +20, Last Available: "2014-12"
 7162	stale half-sized squat plumber's lunch	2	decent	Last Available: "2014-12"
 7163	red lard-coated baleful weightlifter's skull gearshift knob	0		Muscle: +15, Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2014-12"
 7164	adequate nachos of the night	4	good	Last Available: "2014-12"
 7165	asbestos-lined hardened thinker's Sketcherz&trade;	0		Mysticality: +10, Damage Reduction: 3, Hot Resistance: +5, Last Available: "2014-12"
-7166	bite-sized spoiled can of Adultwitch&trade;	1	crappy	Last Available: "2014-12"
-7167	extra-dry ionized blinking pulsating fuchsia smudge stick	0		Effect: "Sugar Smacks", Effect Duration: 59, Last Available: "2014-12"
+7166	spoiled bite-sized can of Adultwitch&trade;	1	crappy	Last Available: "2014-12"
+7167	extra-dry ionized blinking fuchsia pulsating smudge stick	0		Effect: "Sugar Smacks", Effect Duration: 59, Last Available: "2014-12"
 7168	deionized wall	0		Effect: "Sepia Tan", Effect Duration: 21, Last Available: "2014-12"
-7169	artisanal fancy tankard of ale	4	EPIC	Effect: "Jittery", Effect Duration: 50, Last Available: "2014-12"
+7169	fancy artisanal tankard of ale	4	EPIC	Effect: "Jittery", Effect Duration: 50, Last Available: "2014-12"
 7170	deionized boiled scroll case	0		Effect: "Jittery", Effect Duration: 66, Last Available: "2014-12"
 7171	vacuum-sealed polarized jug of &quot;wine&quot;	0		Effect: "Physicali Tea", Effect Duration: 44, Last Available: "2014-12"
 7172	bouncing juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	yummy big humble pie	5	awesome	Last Available: "2014-12"
+7174	big yummy humble pie	5	awesome	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	bouncing shaking crappy camera	0		Last Available: "2014-12"
 7177	alkaline ghostly crappy waiter disguise	0		Effect: "Inebriate Pride", Effect Duration: 18
 7178	Copperhead Charm	0		
-7179	narrow mirror The First Pizza	0		
+7179	mirror narrow The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	blinking The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7088,11 +7088,11 @@
 7199	squat blowdart	0		
 7200	Buddy Bjorn of Leguizamo	0		Monster Level: +20, Softcore Only, Last Available: "2014-02"
 7201	Samson's smooth The Nuge's favorite crossbow of the businessman	0		Moxie: +15, Experience (Muscle): +5, Meat Drop: +50
-7202	moldy diet sweet roll Alabama	1	crappy	
+7202	diet moldy sweet roll Alabama	1	crappy	
 7203	pulsating squat rosy-cheeked Saturday Night Special	0		Maximum HP Percent: +30
 7204	bouncing lynyrd snare	0		
 7205	fuchsia fleetwood chain of the sweet-tooth	0		Candy Drop: +100
-7206	mediocre weak Green Manalishi	2	decent	
+7206	weak mediocre Green Manalishi	2	decent	
 7207	olive dangerous blade	0		Weapon Damage: +10
 7208	blinking fire of unknown origin	0		
 7209	eagle's milk	1	good	
@@ -7101,22 +7101,22 @@
 7212	ghostly huge Jefferson wings of Tarzan	0		Experience (Muscle): +3
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	fancy normal spinning fleetwood mac 'n' cheese	3	good	Effect: "Net Tea", Effect Duration: 45
+7215	normal fancy spinning fleetwood mac 'n' cheese	3	good	Effect: "Net Tea", Effect Duration: 45
 7216	mirror lynyrd skin	0		
 7217	stylish lynyrdskin cap	0		Moxie: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	greasy lynyrdskin tunic	0		Sleaze Spell Damage: +10
 7219	supercool lynyrdskin breeches	0		Moxie Percent: +20, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	enchanted perfectly mixed blurry Flamin' Whatshisname	4	EPIC	Effect: "Hopped Up on Goofballs", Effect Duration: 40
-7223	warmed chilled yellow bouncing twirling lynyrd musk	0		Effect: "Slimed Stomach", Effect Duration: 20
+7222	perfectly mixed enchanted blurry Flamin' Whatshisname	4	EPIC	Effect: "Hopped Up on Goofballs", Effect Duration: 40
+7223	warmed chilled twirling bouncing yellow lynyrd musk	0		Effect: "Slimed Stomach", Effect Duration: 20
 7224	inspector's razor-sharp Kashmir sweater	0		Weapon Damage Percent: +25, Item Drop: +15
-7225	rotten huge teal custard pie	9	crappy	
+7225	huge rotten teal custard pie	9	crappy	
 7226	tea for one	1	awesome	
 7227	drinkable bottle of Evermore	3	good	
 7228	box	0		
 7229	watered-down perfectly mixed wine	2	EPIC	
-7230	practically non-alcoholic smooth enchanted rum	1	awesome	Effect: "Slimily Sagacious", Effect Duration: 35
+7230	smooth practically non-alcoholic enchanted rum	1	awesome	Effect: "Slimily Sagacious", Effect Duration: 35
 7231	fortified hand-crafted Murderer's Punch	5	EPIC	
 7232	flavorless velvet cake	4	decent	
 7233	pickled letter	0		Effect: "Thunderheart", Effect Duration: 56
@@ -7152,7 +7152,7 @@
 7263	photograph of a dog	0		
 7264	fuchsia photograph of a nugget	0		
 7265	skewed photograph of an ostrich egg	0		
-7266	blurry huge disposable instant camera	0		
+7266	huge blurry disposable instant camera	0		
 7267	asbestos-lined stiffened sage Sneaky Pete's jacket (collar popped) of the empath	0		Mysticality Percent: +10, Damage Reduction: 1, Familiar Weight: +5, Hot Resistance: +5, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
@@ -7195,7 +7195,7 @@
 7306	Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
 7308	energized alkaline squat eyebrow pencil	0		Effect: "Bone Homie", Effect Duration: 21
-7309	super-aerosolized spinning blurry rosewater cream	0		Effect: "Hot Blooded", Effect Duration: 57
+7309	super-aerosolized blurry spinning rosewater cream	0		Effect: "Hot Blooded", Effect Duration: 57
 7310	activated aerosolized bronzer	0		Effect: "Hare-o-dynamic", Effect Duration: 19
 7311	inspector's Van der Graaf elegant nightstick	0		Item Drop: +15, MP Regen Min: 5, MP Regen Max: 7
 7312	still grill	0		Free Pull, Last Available: "2014-06"
@@ -7208,12 +7208,12 @@
 7319	personal trainer's Elizabeth's Dollie of the detective	0		Experience Percent (Muscle): +10, Item Drop: +20
 7320	deionized unsweetened twirling Elizabeth's paintbrush	0		Effect: "Memento Moir&eacute;", Effect Duration: 26
 7321	wobbly Stephen's lab coat of the cougar of bravery	0		Moxie: +20, Spooky Resistance: +5
-7322	ionized tarnished upside-down huge Stephen's secret formula	0		Effect: "Dilated Pupils", Effect Duration: 60
+7322	ionized tarnished huge upside-down Stephen's secret formula	0		Effect: "Dilated Pupils", Effect Duration: 60
 7323	huge gray brawny Jacob's rung of horror	0		Muscle Percent: +20, Spooky Spell Damage: +25
-7324	mixed huge spinning cyan battery	1		
+7324	mixed huge cyan spinning battery	1		
 7325	mediocre olive upside-down snakebite	4	decent	
 7326	scandalous Herculean rubber ribcage	0		Experience (Muscle): +1, Sleaze Damage: +5, Damage Reduction: 7
-7327	dehydrated blurry jittery synthetic marrow	1		
+7327	dehydrated jittery blurry synthetic marrow	1		
 7328	activated jittery funny bone	0		Effect: "Crying, Dying", Effect Duration: 64
 7329	weightlifter's half-melted spoon of wisdom	0		Muscle: +15, Mysticality: +15
 7330	pickled yellow the funk	1		Effect: "Bloody Bloody Bloody!", Effect Duration: 25
@@ -7229,24 +7229,24 @@
 7340	groovy moose antlers	0		Moxie Percent: +10, Familiar Effect: "atk, 1xLep, cap 27"
 7341	oxidized quadruple-anodized dry moose thought	0		Effect: "Magically Delicious", Effect Duration: 32
 7342	rotten spinning moose chocolate	3	crappy	
-7343	mediocre fortified huge painting of a glass of wine	5	decent	
+7343	fortified mediocre huge painting of a glass of wine	5	decent	
 7344	narrow oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	wobbly extremely unsafe ghost toga of horror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +25
-7348	gigantic toothsome gray sheet cake	6	awesome	
+7348	toothsome gigantic gray sheet cake	6	awesome	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	reassuring Van der Graaf Staff of the Electric Range of chilblains	0		Cold Damage: +25, Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7
 7352	moldy pulsating deluxe layer cake	4	crappy	
-7353	blue ghostly chunk of hot iron	0		
-7354	delicious practically non-alcoholic red-hot boilermaker	1	awesome	
+7353	ghostly blue chunk of hot iron	0		
+7354	practically non-alcoholic delicious red-hot boilermaker	1	awesome	
 7355	groovy coal shovel	0		Moxie Percent: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	adjusted ionized huge hot coal	0		Effect: "Greasy Peasy", Effect Duration: 50
 7357	flattened coal dust	0		Effect: "Clyde's Blessing", Effect Duration: 19
 7358	Jim Carey's curative Socratic Bram's choker	0		Experience (Mysticality): +1, Monster Level: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 7359	red plaid swatch	0		
-7360	gray blinking plaid bandage	0		
+7360	blinking gray plaid bandage	0		
 7361	blurry dangerous plaid pocket square	0		Weapon Damage: +10
 7362	tumbling deadly plaid skirt of the boozehound	0		Weapon Damage: +5, Booze Drop: +100, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	triple-pressed bloodstain stick	0		Effect: "Dexteri Tea", Effect Duration: 32
@@ -7256,7 +7256,7 @@
 7367	double-electrified super-corrupted industrial strength starch	0		Effect: "The Best a Pirate Can Get", Effect Duration: 69, Wiki Name: "industrial strength starch"
 7368	tasty extra-flat panini	3	awesome	
 7369	unsweetened triple-cold-filtered mangled finger	0		Effect: "Crotchety, Pining", Effect Duration: 20
-7370	mediocre practically non-alcoholic Psychotic Train wine	1	decent	
+7370	practically non-alcoholic mediocre Psychotic Train wine	1	decent	
 7371	blinking crazy hobo notebook	0		
 7372	snack-sized rotten pie man was not meant to eat	2	crappy	
 7373	razor-sharp sommelier's towel	0		Weapon Damage Percent: +25
@@ -7285,12 +7285,12 @@
 7396	deionized chilled mirror Gene Tonic: Pirate	0		Effect: "Cosmic Flavor", Effect Duration: 46, Last Available: "2014-04"
 7397	magnetized non-irradiated corrupted narrow Gene Tonic: Plant	0		Effect: "Elvish", Effect Duration: 37, Last Available: "2014-04"
 7398	galvanized quadruple-electrified fuchsia Gene Tonic: Weird	0		Effect: "Turtle Titters", Effect Duration: 26, Last Available: "2014-04"
-7399	polarized anodized Vulcanized upside-down maroon bouncing Gene Tonic: Elf	0		Effect: "Rushtacean'", Effect Duration: 14, Last Available: "2014-04"
+7399	polarized anodized Vulcanized bouncing upside-down maroon Gene Tonic: Elf	0		Effect: "Rushtacean'", Effect Duration: 14, Last Available: "2014-04"
 7400	flattened Gene Tonic: Mer-kin	0		Effect: "Loyal Tea", Effect Duration: 19, Last Available: "2014-04"
 7401	modified quadruple-alkaline ghostly Gene Tonic: Slime	0		Effect: "Moon'd", Effect Duration: 36, Last Available: "2014-04"
 7402	magnetized Gene Tonic: Penguin	0		Effect: "Litterboxing", Effect Duration: 51, Last Available: "2014-04"
 7403	electrified corrupted Gene Tonic: Elemental	0		Effect: "Lifted Spirits", Effect Duration: 57, Last Available: "2014-04"
-7404	liquefied extra-liquefied blurry upside-down Gene Tonic: Constellation	0		Effect: "Fit To Be Tide", Effect Duration: 34, Last Available: "2014-04"
+7404	liquefied extra-liquefied upside-down blurry Gene Tonic: Constellation	0		Effect: "Fit To Be Tide", Effect Duration: 34, Last Available: "2014-04"
 7405	tarnished Gene Tonic: Hobo	0		Effect: "Pla-see-bo", Effect Duration: 55, Last Available: "2014-04"
 7406	jittery Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
@@ -7331,12 +7331,12 @@
 7442	adequate Energy Buzz Pastaco	3	good	Last Available: "2014-05"
 7443	diet delicious Ludovico Pastaco	1	awesome	Last Available: "2014-05"
 7444	lousy overpowering mushroom wine	4	decent	Last Available: "2014-05"
-7445	special weak acceptable blinking purple complex mushroom wine	2	good	Effect: "Blubbered Up", Effect Duration: 35, Last Available: "2014-05"
-7446	watered-down acceptable purple smooth mushroom wine	2	good	Last Available: "2014-05"
+7445	acceptable special weak purple blinking complex mushroom wine	2	good	Effect: "Blubbered Up", Effect Duration: 35, Last Available: "2014-05"
+7446	acceptable watered-down purple smooth mushroom wine	2	good	Last Available: "2014-05"
 7447	drinkable blood-red mushroom wine	4	good	Last Available: "2014-05"
 7448	lousy buzzing mushroom wine	3	decent	Last Available: "2014-05"
 7449	hand-crafted upside-down swirling mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
-7450	spoiled bite-sized Taco Dan's Basic Taco Dan Taco	1	crappy	Last Available: "2014-05"
+7450	bite-sized spoiled Taco Dan's Basic Taco Dan Taco	1	crappy	Last Available: "2014-05"
 7451	bland tiny Taco Dan's Taco Fish Fish Taco	1	decent	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	acceptable regular-size brogurt	3	good	Last Available: "2014-05"
@@ -7348,13 +7348,13 @@
 7459	wobbly Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	teal Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	fuchsia industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	tumbling Brogre brorts of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	tumbling Brogre brorts of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	yellow deadly Brogre brolo shirt	0		Weapon Damage: +5, Last Available: "2014-05"
-7464	mirror spinning Brogre bucket hat of the glutton	0		Food Drop: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	mirror spinning Brogre bucket hat of the glutton	0		Food Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	teal Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	gray one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	flame-retardant 8-billed baseball cap of the sewer of the sweet-tooth	0		Stench Damage: +25, Hot Resistance: +1, Candy Drop: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	flame-retardant 8-billed baseball cap of the sewer of the sweet-tooth	0		Stench Damage: +25, Hot Resistance: +1, Candy Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	lion tamer's grievous thinker's extremely wet T-shirt	0		Mysticality: +10, Weapon Damage Percent: +50, Experience (familiar): +2, Last Available: "2014-05"
 7470	blurry steel-toed experienced shrimp fork of the boozehound	0		Experience: +2, Damage Reduction: 9, Booze Drop: +100, Last Available: "2014-05"
 7471	altered moist purple BROS Energy Drink	0		Effect: "Proprie Tea", Effect Duration: 44, Last Available: "2014-05"
@@ -7367,9 +7367,9 @@
 7478	narrow squat possessed sugar cube	0		Last Available: "2014-05"
 7479	pressed magnetized upside-down mirror sugar fairy	0		Effect: "World's Shortest Giant", Effect Duration: 44, Last Available: "2014-05"
 7480	deionized frozen jittery sugar bunny	0		Effect: "Vitamin-Maxed", Effect Duration: 49, Last Available: "2014-05"
-7481	bouncing sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	bouncing sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	lousy practically non-alcoholic Rompedores de Fantasmas	1	decent	
-7483	hand-crafted watered-down special La Fantasma y La Oscuridad	2	EPIC	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 10
+7483	special watered-down hand-crafted La Fantasma y La Oscuridad	2	EPIC	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 10
 7484	tolerable blurry Fantasma en la M&aacute;quina	3	good	
 7485	loosening powder	0		
 7486	yellow castoreum	0		
@@ -7382,7 +7382,7 @@
 7493	unstable fulminate	0		
 7494	ghostly wine bomb	0		
 7495	shaking blurry recipe: mortar-dissolving solution	0		
-7496	blinking huge bottled day	0		
+7496	huge blinking bottled day	0		
 7497	ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
 7499	pressed gray Hot 'n' Scarys	0		Effect: "Your Interest is Peaked", Effect Duration: 22
@@ -7395,7 +7395,7 @@
 7506	executive veiny book	0		Maximum HP: +10, Meat Drop: +40
 7507	savvy cloak	0		Mysticality Percent: +20
 7508	label	0		
-7509	stale half-sized Mornington crescent roll	2	decent	
+7509	half-sized stale Mornington crescent roll	2	decent	
 7510	energized extra-polarized eye shadow	0		Effect: "Retrograde Relaxation", Effect Duration: 58
 7511	crumbling wheel	0		
 7512	energized ghostly jittery blue poppy	0		Effect: "Holiday Disappointment", Effect Duration: 34
@@ -7418,25 +7418,25 @@
 7529	rotten loaf of alien bread	3	crappy	Last Available: "2014-05"
 7530	toothsome grilled cheese sandwich	3	awesome	Last Available: "2014-05"
 7531	powdered wobbly alien protein powder	1	EPIC	Last Available: "2014-05"
-7532	triple-distilled fancy perfectly mixed lime green rocket fuel	8	EPIC	Effect: "Vitamin-Maxed", Effect Duration: 30, Last Available: "2014-05"
+7532	fancy perfectly mixed triple-distilled lime green rocket fuel	8	EPIC	Effect: "Vitamin-Maxed", Effect Duration: 30, Last Available: "2014-05"
 7533	purple alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7534	jittery blue alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7534	blue jittery alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	irresponsibly strong tolerable red stealth bomber	8	good	Last Available: "2014-05"
 7536	blinking space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	huge shaking ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	healthy space beast fur pants	0		Maximum HP Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	space beast fur hat of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	healthy space beast fur pants	0		Maximum HP Percent: +20, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	upside-down pulsating space beast fur whip of the cheetah	0		Initiative: +60, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	sizzling friendly space heater	0		Familiar Weight: +3, Hot Damage: +10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	sizzling friendly space heater	0		Familiar Weight: +3, Hot Damage: +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
-7545	practically non-alcoholic perfectly mixed enchanted space port	1	EPIC	Effect: "Dilated Pupils", Effect Duration: 50, Last Available: "2014-05"
+7545	perfectly mixed enchanted practically non-alcoholic space port	1	EPIC	Effect: "Dilated Pupils", Effect Duration: 50, Last Available: "2014-05"
 7546	veiny space needle of extreme caution	0		Maximum HP: +10, Monster Level: -25, Last Available: "2014-05"
 7547	dry buffed alien drugs	0		Effect: "Ooh, Sour!", Effect Duration: 16, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
 7549	chilled ash soda	0		Effect: "Video Game Hot Dog", Effect Duration: 62, Last Available: "2014-06"
-7550	pressed blinking purple liquid smoke	0		Effect: "Natural 20", Effect Duration: 35, Last Available: "2014-06"
+7550	pressed purple blinking liquid smoke	0		Effect: "Natural 20", Effect Duration: 35, Last Available: "2014-06"
 7551	Vulcanized huge dollop of barbecue sauce	0		Effect: "Magically Fingered", Effect Duration: 40, Last Available: "2014-06"
 7552	denatured ionized bowl of marinade	0		Effect: "Material Witness", Effect Duration: 28, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
@@ -7458,7 +7458,7 @@
 7569	frightening vibrating dangerous Time Bandit Badge of Courage	0		Weapon Damage: +10, Maximum MP Percent: +10, Spooky Damage: +5
 7570	boiled warmed Friendliness Beverage	0		Effect: "Spooky Demeanor", Effect Duration: 68
 7571	greedy Socratic silent pea shooter	0		Experience (Mysticality): +1, Meat Drop: +20
-7572	gigantic rotten D roll	9	crappy	
+7572	rotten gigantic D roll	9	crappy	
 7573	reassuring kiwi beak of the businessman	0		Spooky Resistance: +1, Meat Drop: +50
 7574	perfectly mixed tumbling New Zealand iced tea	4	EPIC	
 7575	prompt droll monocle of Calamity Jane	0		Critical Hit Percent: +15, Adventures: +3, Single Equip
@@ -7479,12 +7479,12 @@
 7590	aged cup of &quot;tea&quot;	4	awesome	Last Available: "2014-07"
 7591	mediocre watered-down thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
 7592	hand-crafted Lucky Lindy	3	EPIC	Last Available: "2014-07"
-7593	watered-down drinkable wobbly cyan Bee's Knees	2	good	Last Available: "2014-07"
+7593	drinkable watered-down wobbly cyan Bee's Knees	2	good	Last Available: "2014-07"
 7594	artisanal Sockdollager	3	EPIC	Last Available: "2014-07"
-7595	aged fortified huge Ish Kabibble	5	awesome	Last Available: "2014-07"
-7596	watered-down fancy artisanal Hot Socks	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2014-07"
+7595	fortified aged huge Ish Kabibble	5	awesome	Last Available: "2014-07"
+7596	fancy watered-down artisanal Hot Socks	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2014-07"
 7597	practically non-alcoholic mediocre Phonus Balonus	1	decent	Last Available: "2014-07"
-7598	weak perfectly mixed Flivver	2	EPIC	Last Available: "2014-07"
+7598	perfectly mixed weak Flivver	2	EPIC	Last Available: "2014-07"
 7599	acceptable Sloppy Jalopy	3	good	Last Available: "2014-07"
 7600	energized activated flame	0		Effect: "Oth-Jeal-O", Effect Duration: 68
 7601	dry temporary yak tattoo	0		Effect: "Tomato Power", Effect Duration: 65
@@ -7520,7 +7520,7 @@
 7631	tarnished modified friar's tonsure	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 65
 7632	pickled quadruple-warmed quadruple-nitrogenated government-issue identification badge	0		Effect: "Bandersnatched", Effect Duration: 50
 7633	nitrogenated ionized alien hologram projector	0		Effect: "Eyes All Black", Effect Duration: 15
-7634	polarized upside-down green jittery irradiated turtle	0		Effect: "Gummi-Grin", Effect Duration: 14
+7634	polarized jittery green upside-down irradiated turtle	0		Effect: "Gummi-Grin", Effect Duration: 14
 7635	energized cigar box turtle	0		Effect: "Barbecue Saucy", Effect Duration: 49
 7636	reassuring scorching shellacked shell	0		Hot Damage: +25, Spooky Resistance: +1, Class: "Turtle Tamer"
 7637	crafty pillow shell	0		Maximum MP: +10, Class: "Turtle Tamer"
@@ -7581,7 +7581,7 @@
 7692	Sherlock's greasy hand whip of bravery	0		Sleaze Spell Damage: +10, Spooky Resistance: +5, Item Drop: +25, Last Available: "2014-08"
 7693	greedy perfumed toasty glow-in-the-dark necklace	0		Hot Damage: +5, Stench Resistance: +5, Meat Drop: +20, Last Available: "2014-08"
 7694	bouncing Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	maroon wobbly aromatic stiffened cap gun of the brute	0		Muscle Percent: +30, Damage Reduction: 1, Stench Resistance: +1, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	maroon wobbly aromatic stiffened cap gun of the brute	0		Muscle Percent: +30, Damage Reduction: 1, Stench Resistance: +1, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	Van der Graaf Socratic cassette player	0		Experience (Mysticality): +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2014-08"
 7697	teal chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7595,11 +7595,11 @@
 7706	purple The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	Vulcanized warmed polymerized blinking rubber nubbin	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 63, Last Available: "2014-08"
 7708	veiny rubber cape of James Dean	0		Experience (Moxie): +3, Maximum HP: +10, Last Available: "2014-08"
-7709	zippy inspector's double-paned Thor's Pliers of the brute	0		Muscle Percent: +30, Cold Resistance: +5, Item Drop: +15, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	zippy inspector's double-paned Thor's Pliers of the brute	0		Muscle Percent: +30, Cold Resistance: +5, Item Drop: +15, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	frozen candy UFOs	0		Effect: "Perception", Effect Duration: 35
 7711	crafty rosy-cheeked water wings for babies	0		Maximum HP Percent: +30, Maximum MP: +10
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	flavorless massive skewed narrow Strix stix	10	decent	
+7713	massive flavorless skewed narrow Strix stix	10	decent	
 7714	chilly energetic medical-grade vampire pellet	0		Maximum MP Percent: +20, Cold Damage: +5, HP Regen Min: 7, HP Regen Max: 10
 7715	smooth green non-aged vinegar	4	awesome	
 7716	chilly unsanitized scalpel	0		Cold Damage: +5
@@ -7611,7 +7611,7 @@
 7722	educational centurion helmet	0		Experience: +1, Familiar Effect: "1xFairy, atk, cap 25"
 7723	gray Chroner cross	0		
 7724	pteruges of the cheetah	0		Initiative: +60, Familiar Effect: "1xFairy, atk, cap 25"
-7725	colloidal triple-modified ghostly cyan Bruno's blessing of Mars	0		Effect: "Perception", Effect Duration: 34
+7725	colloidal triple-modified cyan ghostly Bruno's blessing of Mars	0		Effect: "Perception", Effect Duration: 34
 7726	flattened aerosolized ghostly Dennis's blessing of Minerva	0		Effect: "Chief Executive Optimism", Effect Duration: 38
 7727	pickled chilled Burt's blessing of Bacchus	0		Effect: "Venomous Weapon", Effect Duration: 33
 7728	altered Freddie's blessing of Mercury	0		Effect: "Astral Shell", Effect Duration: 33
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	jittery Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	huge Xiblaxian xeno-detection goggles of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2014-09"
-7753	lime green chaotic MacGyver's Xiblaxian stealth cowl	0		Maximum MP: +100, Spell Critical Percent: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	lime green chaotic MacGyver's Xiblaxian stealth cowl	0		Maximum MP: +100, Spell Critical Percent: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	hale stiffened Xiblaxian stealth trousers	0		Damage Reduction: 1, Maximum HP: +20, Last Available: "2014-09"
 7755	chilly resourceful Xiblaxian stealth vest	0		Maximum MP: +50, Cold Damage: +5, Last Available: "2014-09"
 7756	adequate Xiblaxian ultraburrito	4	good	Last Available: "2014-09"
@@ -7658,9 +7658,9 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	ghostly narrow rosy-cheeked Personal Ventilation Unit of terror of doom	0		Maximum HP Percent: +30, Spooky Spell Damage: 60, Single Equip, Last Available: "2014-10"
 7771	pressed moist activated mirror the most dangerous bait	0		Effect: "Rootin' Around", Effect Duration: 45, Last Available: "2014-10"
-7772	rotten enchanted &quot;meat&quot; stick	4	crappy	Effect: "Armored Innards", Effect Duration: 5, Last Available: "2014-10"
-7773	twisted squat blinking transdermal smoke patch	1	crappy	Last Available: "2014-10"
-7774	blurry huge specialty ammo bandolier	0		Last Available: "2014-10"
+7772	enchanted rotten &quot;meat&quot; stick	4	crappy	Effect: "Armored Innards", Effect Duration: 5, Last Available: "2014-10"
+7773	twisted blinking squat transdermal smoke patch	1	crappy	Last Available: "2014-10"
+7774	huge blurry specialty ammo bandolier	0		Last Available: "2014-10"
 7775	censurious sizzling padded pair of plants	0		Damage Absorption: +20, Hot Damage: +10, Sleaze Resistance: +3, Last Available: "2014-10"
 7776	stiffened smartaleck's Sasq&trade; watch of doom	0		Moxie Percent: +30, Damage Reduction: 1, Spooky Spell Damage: +50, Single Equip, Last Available: "2014-10"
 7777	shaking chilly smoker's cloak of the boozehound of the glutton	0		Cold Damage: +5, Booze Drop: +100, Food Drop: +100, Last Available: "2014-10"
@@ -7669,11 +7669,11 @@
 7780	auspicious aromatic slick heavy-duty clipboard	0		Moxie: +10, Stench Resistance: +1, Item Drop: +10, Damage Reduction: 8, Last Available: "2014-10"
 7781	red perfumed manspreader's clever battery-powered drill of chilblains	0		Maximum MP: +20, Monster Level: +10, Cold Damage: +25, Stench Resistance: +5, Last Available: "2014-10"
 7782	toothsome limp broccoli	4	awesome	Last Available: "2014-10"
-7783	hardened razor-sharp hat of courage	0		Weapon Damage Percent: +25, Damage Reduction: 3, Spooky Resistance: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7783	hardened razor-sharp hat of courage	0		Weapon Damage Percent: +25, Damage Reduction: 3, Spooky Resistance: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	galvanized electrified huge monkey barf	0		Effect: "Protection from Bad Stuff", Effect Duration: 65, Last Available: "2014-10"
 7785	boiled liquefied candy	0		Effect: "Faboooo", Effect Duration: 18, Last Available: "2014-10"
 7786	olive Jeselnik's wizardly weightlifter's jangly bracelet	0		Muscle: +15, Mysticality: +25, Sleaze Damage: +25, Last Available: "2014-10"
-7787	cuddly teddy bear of the bloodbag	0		Maximum HP: +100, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	cuddly teddy bear of the bloodbag	0		Maximum HP: +100, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	wobbly wool fortified first-aid pouch	0		Damage Absorption: +60, Cold Resistance: +1, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7681,12 +7681,12 @@
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	pulsating bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	enchanted delicious jittery initiative shawarma	3	awesome	Effect: "Macho, Macho Dog", Effect Duration: 50, Last Available: "2014-10"
-7796	tasty miniature huge warm war shawarma	2	awesome	Last Available: "2014-10"
+7795	delicious enchanted jittery initiative shawarma	3	awesome	Effect: "Macho, Macho Dog", Effect Duration: 50, Last Available: "2014-10"
+7796	miniature tasty huge warm war shawarma	2	awesome	Last Available: "2014-10"
 7797	tasty karma shawarma	4	awesome	Last Available: "2014-10"
-7798	bad practically non-alcoholic Jungle Juice	1	decent	Last Available: "2014-10"
-7799	practically non-alcoholic artisanal Amnesiac Ale	1	super ultra EPIC	Last Available: "2014-10"
-7800	bad enchanted Highest Bitter	4	decent	Effect: "Hypercubed", Effect Duration: 40, Last Available: "2014-10"
+7798	practically non-alcoholic bad Jungle Juice	1	decent	Last Available: "2014-10"
+7799	artisanal practically non-alcoholic Amnesiac Ale	1	super ultra EPIC	Last Available: "2014-10"
+7800	enchanted bad Highest Bitter	4	decent	Effect: "Hypercubed", Effect Duration: 40, Last Available: "2014-10"
 7801	blurry extremely unsafe wizardly mercenary pistol	0		Mysticality: +25, Weapon Damage Percent: +100, Last Available: "2014-10"
 7802	Van der Graaf sinister mercenary rifle	0		Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7699,7 +7699,7 @@
 7810	Z-Bone steak	0		
 7811	cyan viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	flavorless fancy spinning fuchsia seared dino steak	4	decent	Effect: "Salamander In Your Stomach", Effect Duration: 45
+7813	flavorless fancy fuchsia spinning seared dino steak	4	decent	Effect: "Salamander In Your Stomach", Effect Duration: 45
 7814	extra-dry delicious bottle of drinkin' gas	5	awesome	
 7815	handful of napalm	0		
 7816	dove DNA	0		
@@ -7736,15 +7736,15 @@
 7847	unsweetened ionized ruby on canes	0		Effect: "Optimist Primal", Effect Duration: 64, Last Available: "2014-12"
 7848	flavorless petit fortran	3	decent	Last Available: "2014-12"
 7849	rotten big green java cookie	5	crappy	Last Available: "2014-12"
-7850	miniature spoiled cookie cookie	2	crappy	Last Available: "2014-12"
+7850	spoiled miniature cookie cookie	2	crappy	Last Available: "2014-12"
 7851	bouncing twirling Herculean plastic exo-suited miner	0		Experience (Muscle): +1, Last Available: "2014-12"
 7852	blurry lion tamer's plastic semi-autonomous drill unit	0		Experience (familiar): +2, Last Available: "2014-12"
 7853	skewed plastic ambulatory robo-minecart of Leguizamo	0		Monster Level: +20, Last Available: "2014-12"
 7854	sharpshooter's plastic Crimbot	0		Critical Hit Percent: +10, Last Available: "2014-12"
 7855	huge thinker's plastic Crimbomega	0		Mysticality: +10, Last Available: "2014-12"
 7856	frozen flask of mining oil	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 50, Last Available: "2014-12"
-7857	Oprah's radiation-resistant helmet	0		Maximum MP Percent: +50, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	veiny servo-assisted exo-pants	0		Maximum HP: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	Oprah's radiation-resistant helmet	0		Maximum MP Percent: +50, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	veiny servo-assisted exo-pants	0		Maximum HP: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	huge blurry fuchsia therapeutic studded high-energy mining laser	0		Damage Absorption: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	twirling nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7773,13 +7773,13 @@
 7884	Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	red Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
-7887	gray twirling Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
+7887	twirling gray Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
 7888	Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	bouncing Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
-7893	teal blurry Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
+7893	blurry teal Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	upside-down Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	olive Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
@@ -7809,8 +7809,8 @@
 7920	upside-down fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	artisanal Friendly Turkey	3	EPIC	Last Available: "2014-11"
-7923	practically non-alcoholic mediocre Agitated Turkey	1	decent	Last Available: "2014-11"
-7924	tolerable distilled Ambitious Turkey	5	good	Last Available: "2014-11"
+7923	mediocre practically non-alcoholic Agitated Turkey	1	decent	Last Available: "2014-11"
+7924	distilled tolerable Ambitious Turkey	5	good	Last Available: "2014-11"
 7925	moldy neutron lollipop	3	crappy	Last Available: "2014-12"
 7926	hand-crafted gamma nog	4	EPIC	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
@@ -7828,12 +7828,12 @@
 7946	executive greasy razor-sharp outlaw bandana	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10, Meat Drop: +40
 7947	drinkable high-proof whiskey in a broken glass	8	good	
 7948	aged shot of mescal	4	awesome	
-7949	watered-down perfectly mixed glass of herbal tequila	2	EPIC	
+7949	perfectly mixed watered-down glass of herbal tequila	2	EPIC	
 7950	minin' dynamite	0		
 7951	red beefy plaid cowboy hat of Flo-Jo	0		Muscle: +10, Initiative: +100, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	cyan lasso	0		
 7953	gravedigger's therapeutic deadly rusted-out shootin' iron	0		Weapon Damage: +5, Spooky Damage: +10, HP Regen Min: 5, HP Regen Max: 7
-7954	bouncing shaking rattler rattle	0		
+7954	shaking bouncing rattler rattle	0		
 7955	mirror bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	blurry even more tinsel	0		Familiar Weight: +5
@@ -7860,7 +7860,7 @@
 7978	blinking holy spring water	0		
 7979	spirit beer	0		
 7980	sacramental wine	0		
-7981	shaking twirling talisman of Thoth	0		
+7981	twirling shaking talisman of Thoth	0		
 7982	bouncing cure-all	0		
 7983	lightning-fast dance instructor's Sister Accessory	0		Experience Percent (Moxie): +10, Initiative: +40, Softcore Only
 7984	pickled Boosty Juice	0		Effect: "Adventurer's Best Friendship", Effect Duration: 27
@@ -7881,42 +7881,42 @@
 7999	magnetized concentrated choco-Crimbot	0		Effect: "Slimily Sagacious", Effect Duration: 31, Last Available: "2014-12"
 8000	electrified dry smart watch	0		Effect: "Updated", Effect Duration: 23, Last Available: "2014-12"
 8001	deionized wobbly augmented-reality shades	0		Effect: "Glittering Eyelashes", Effect Duration: 26, Last Available: "2014-12"
-8002	toy Crimbot mega face of the brute	0		Muscle Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
-8003	skewed up-at-dawn toy Crimbot power glove	0		Adventures: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	shaking Rosewater's toy Crimbot super fist	0		Mysticality Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	toy Crimbot rocket legs of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	toy Crimbot mega face of the brute	0		Muscle Percent: +30, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	skewed up-at-dawn toy Crimbot power glove	0		Adventures: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	shaking Rosewater's toy Crimbot super fist	0		Mysticality Percent: +30, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	toy Crimbot rocket legs of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	ionized nitrogenated frozen Crimbot battery	0		Effect: "Wintry Breath", Effect Duration: 36, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	Jack Frost's dog trainer's studded Crimbomega drive chain	0		Damage Absorption: +80, Experience (familiar): +1, Cold Spell Damage: +50, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	Jack Frost's dog trainer's studded Crimbomega drive chain	0		Damage Absorption: +80, Experience (familiar): +1, Cold Spell Damage: +50, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	blue Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8015	purple mirror Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8015	mirror purple Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	ionized narrow fitness wristband	0		Effect: "Mariachi Mood", Effect Duration: 11, Last Available: "2014-12"
 8017	nitrogenated polarized green flask of tainted mining oil	0		Effect: "Norwhalloped", Effect Duration: 57, Last Available: "2014-12"
 8018	super-energized polarized and rain stick	0		Effect: "The Style... of the Future", Effect Duration: 60
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	yummy fancy snack-sized Choco-Mint patty	2	awesome	Effect: "Make Meat FA$T!", Effect Duration: 15, Last Available: "2015-01"
-8021	perfectly mixed fancy hot mint schnocolate	3	EPIC	Effect: "Extra-Thick Blood", Effect Duration: 5, Last Available: "2015-01"
+8021	fancy perfectly mixed hot mint schnocolate	3	EPIC	Effect: "Extra-Thick Blood", Effect Duration: 5, Last Available: "2015-01"
 8022	powdered homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	narrow muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
-8028	blinking jittery artificial skylight	0		Last Available: "2015-01"
+8028	jittery blinking artificial skylight	0		Last Available: "2015-01"
 8029	shaking Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	stationery set	0		Last Available: "2015-01"
-8032	lime green jittery calligraphy pen	0		Free Pull, Last Available: "2015-01"
+8032	jittery lime green calligraphy pen	0		Free Pull, Last Available: "2015-01"
 8033	red alpine watercolor set	0		Last Available: "2015-01"
 8034	sinister tope&eacute; of the cougar	0		Moxie: +20, Spell Damage: +10, Familiar Effect: "3xBarrr, cap 12"
 8035	topiary tights of mayonnaise of bravery	0		Sleaze Spell Damage: +50, Spooky Resistance: +5
 8036	topiary necktie of James Dean	0		Experience (Moxie): +3
-8037	huge rotten enchanted mirror bowl of topioca	9	crappy	Effect: "Heart of Green", Effect Duration: 40
+8037	rotten enchanted huge mirror bowl of topioca	9	crappy	Effect: "Heart of Green", Effect Duration: 40
 8038	blinking jittery topiary skunk	0		
 8039	blinking topiary noseplugs	0		Familiar Weight: +5
 8040	tumbling trusty whip	0		
@@ -7931,7 +7931,7 @@
 8050	ghostly therapeutic X-ray goggles	0		HP Regen Min: 5, HP Regen Max: 7, Luck: +5
 8051	jittery cape of the cougar	0		Moxie: +20
 8052	narrow MacGyver's jetpack	0		Maximum MP: +100
-8053	shaking pulsating spring boots	0		
+8053	pulsating shaking spring boots	0		
 8054	pulsating spiked boots	0		
 8055	smartaleck's pickaxe	0		Moxie Percent: +30
 8056	torch	0		
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	mirror Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	skewed wobbly sage smooth Spelunker's fedora of horror	0		Moxie: +15, Mysticality Percent: +10, Spooky Spell Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	skewed wobbly sage smooth Spelunker's fedora of horror	0		Moxie: +15, Mysticality Percent: +10, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	jittery purple narrow gravedigger's educational Spelunker's whip of the wise owl	0		Mysticality: +20, Experience: +1, Spooky Damage: +10, Last Available: "2015-12"
-8076	Annie Oakley's Spelunker's khakis of vim and vigor of bravery	0		Maximum HP Percent: +50, Critical Hit Percent: +20, Spooky Resistance: +5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	Annie Oakley's Spelunker's khakis of vim and vigor of bravery	0		Maximum HP Percent: +50, Critical Hit Percent: +20, Spooky Resistance: +5, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7977,14 +7977,14 @@
 8102	brooch of the scaredy-cat of Flo-Jo	0		Monster Level: -15, Initiative: +100, Single Equip, Last Available: "2016-12"
 8103	Samson's breeches of Tarzan	0		Experience (Muscle): 8, Last Available: "2016-12"
 8104	wobbly backpack of the bloodbag of the boozehound	0		Maximum HP: +100, Booze Drop: +100, Last Available: "2016-12"
-8105	mixed blurry blurry jittery bits	1		Last Available: "2016-12"
+8105	mixed jittery blurry blurry bits	1		Last Available: "2016-12"
 8106	banded Socratic anvil	0		Experience (Mysticality): +1, Damage Absorption: +100, Single Equip, Last Available: "2017-12"
 8107	horrifying weightlifter's akubra	0		Muscle: +15, Spooky Damage: +25, Last Available: "2017-12"
 8108	ghostly coward's vibrating apron	0		Maximum MP Percent: +10, Monster Level: -20, Single Equip, Last Available: "2017-12"
 8109	wholesome steel-toed ascot	0		Damage Reduction: 9, Maximum HP Percent: +10, Single Equip, Last Available: "2017-12"
 8110	electrified Sinatra's attache case	0		Experience (Moxie): +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2017-12"
 8111	sinister accordion of the early riser	0		Spell Damage: +10, Adventures: +7, Song Duration: 10, Last Available: "2017-12"
-8112	dried blinking huge aerosolized	1		Last Available: "2017-12"
+8112	dried huge blinking aerosolized	1		Last Available: "2017-12"
 8113	therapeutic wig of James Dean	0		Experience (Moxie): +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-12"
 8114	winch crank of the sewer of bravery	0		Stench Damage: +25, Spooky Resistance: +5, Single Equip, Last Available: "2017-12"
 8115	frosty widget of the wise owl	0		Mysticality: +20, Cold Spell Damage: +10, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	chilly garland of bravery	0		Cold Damage: +5, Spooky Resistance: +5, Single Equip, Last Available: "2018-12"
 8122	skewed gravedigger's gunnysack of Tarzan	0		Experience (Muscle): +3, Spooky Damage: +10, Last Available: "2018-12"
 8123	bouncing purple cool garibaldi of Calamity Jane	0		Moxie: +5, Critical Hit Percent: +15, Last Available: "2018-12"
-8124	yellow blinking groovy wizardly girdle	0		Mysticality: +25, Moxie Percent: +10, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	yellow blinking groovy wizardly girdle	0		Mysticality: +25, Moxie Percent: +10, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	toasty Jack Frost's gloves	0		Cold Spell Damage: +50, Hot Damage: +5, Single Equip, Last Available: "2018-12"
 8126	distilled jittery smithereens	1		Last Available: "2018-12"
 8127	chilly shellacked fiberglass fetish	0		Damage Reduction: 7, Cold Damage: +5, Last Available: "2018-12"
@@ -8047,7 +8047,7 @@
 8173	twirling brainy sewer snake	0		Mysticality: +5
 8174	stale pigeon egg	3	decent	
 8175	gravedigger's Samson's jaunty feather	0		Experience (Muscle): +5, Spooky Damage: +10
-8176	smooth weak premium malt liquor	2	awesome	
+8176	weak smooth premium malt liquor	2	awesome	
 8177	red frosty Newton's brown paper pants	0		Experience (Mysticality): +3, Cold Spell Damage: +10
 8178	spinning bouncing perfumed resourceful brown paper bag mask	0		Maximum MP: +50, Stench Resistance: +5
 8179	smooth ring of telling skeletons what to do	0		Moxie: +15, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,19 +8056,19 @@
 8182	bouncing Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	ribald bread basket	0		Sleaze Damage: +10
 8184	Ed the Undying exhibit crate	0		
-8185	executive double-paned The Crown of Ed the Undying	0		Cold Resistance: +5, Meat Drop: +40, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	executive double-paned The Crown of Ed the Undying	0		Cold Resistance: +5, Meat Drop: +40, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	mirror Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	acceptable blue Cherrytastrophe wine cooler	3	good	
-8189	watered-down lousy Radberry Rip wine cooler	2	decent	
-8190	enchanted artisanal Orangemageddon wine cooler	3	EPIC	Effect: "Fire Inside", Effect Duration: 25
-8191	artisanal triple-distilled wobbly Breakfast Blast wine cooler	9	EPIC	
-8192	enchanted perfectly mixed Citrus Crush wine cooler	3	EPIC	Effect: "Fangs and Pangs", Effect Duration: 30
+8189	lousy watered-down Radberry Rip wine cooler	2	decent	
+8190	artisanal enchanted Orangemageddon wine cooler	3	EPIC	Effect: "Fire Inside", Effect Duration: 25
+8191	triple-distilled artisanal wobbly Breakfast Blast wine cooler	9	EPIC	
+8192	perfectly mixed enchanted Citrus Crush wine cooler	3	EPIC	Effect: "Fangs and Pangs", Effect Duration: 30
 8193	bland plain bagel	3	decent	
 8194	stale pulsating glob of cream cheese	3	decent	
-8195	rotten huge loaf of soda bread	8	crappy	
+8195	huge rotten loaf of soda bread	8	crappy	
 8196	bland snack-sized narrow acceptable bagel	2	decent	
-8197	adequate thick yellow standard-issue cupcake	5	good	
+8197	thick adequate yellow standard-issue cupcake	5	good	
 8198	miniature adequate ultra-deluxe cupcake	2	good	
 8199	ghostly hypnotic breadcrumbs	0		
 8200	yummy miniature popular tart	2	awesome	
@@ -8086,13 +8086,13 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	rigging rope of the empath of the early riser	0		Familiar Weight: +5, Adventures: +7, Last Available: "2015-04"
 8214	powdered twirling nasty snuff	1	good	Last Available: "2015-04"
-8215	hale studded sewage-clogged pistol	0		Damage Absorption: +80, Maximum HP: +20, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
-8216	quadruple-unsweetened pickled deionized blinking huge maroon beard incense	0		Effect: "Inner Warmth", Effect Duration: 13, Last Available: "2015-04"
+8215	hale studded sewage-clogged pistol	0		Damage Absorption: +80, Maximum HP: +20, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8216	quadruple-unsweetened pickled deionized blinking maroon huge beard incense	0		Effect: "Inner Warmth", Effect Duration: 13, Last Available: "2015-04"
 8217	tumbling stiffened perfume-soaked bandana of Leguizamo	0		Damage Reduction: 1, Monster Level: +20, Single Equip, Last Available: "2015-04"
-8218	purple narrow toxic globule	0		Last Available: "2015-04"
+8218	narrow purple toxic globule	0		Last Available: "2015-04"
 8219	moldy toxo	4	crappy	Last Available: "2015-04"
-8220	acceptable special irresponsibly strong blurry huge Lemonade-235	9	good	Effect: "Pasta Oneness", Effect Duration: 40, Last Available: "2015-04"
-8221	Sherlock's isotophat of the brazier	0		Hot Spell Damage: +25, Item Drop: +25, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8220	special acceptable irresponsibly strong huge blurry Lemonade-235	9	good	Effect: "Pasta Oneness", Effect Duration: 40, Last Available: "2015-04"
+8221	Sherlock's isotophat of the brazier	0		Hot Spell Damage: +25, Item Drop: +25, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	prompt Sherlock's Three Mile Island shorts	0		Item Drop: +25, Adventures: +3, Last Available: "2015-04"
 8223	clever toxic mop of chilblains	0		Maximum MP: +20, Cold Damage: +25, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8149,16 +8149,16 @@
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	mediocre strong yellow Afternoon Delight	5	decent	Last Available: "2015-04"
+8278	strong mediocre yellow Afternoon Delight	5	decent	Last Available: "2015-04"
 8279	purple Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	pickled dry blurry Kokomo Resort Brand Suntan Oil	0		Effect: "Cold Hands", Effect Duration: 65, Last Available: "2015-04"
-8282	jittery cyan Kokomo Resort Order Pad	0		Last Available: "2015-04"
+8282	cyan jittery Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	colloidal extra-oxidized Kokomo Resort Pass	0		Effect: "Mucilaginous Muscle", Effect Duration: 67, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	nitrogenated double-vacuum-sealed Mayo de Mayo&trade; mayo	0		Effect: "Big Punkin'", Effect Duration: 56
-8287	lime green bouncing puck	0		Free Pull, Last Available: "2015-06"
+8287	bouncing lime green puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	friendly dice ring	0		Familiar Weight: +3, Single Equip
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	diffused quantum power pill	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 62, Last Available: "2015-06"
 8301	improved improved oxidized narrow pixel star	0		Effect: "Happy Salamander", Effect Duration: 23, Last Available: "2015-06"
-8302	small flavorless pixel banana	2	decent	Last Available: "2015-06"
+8302	flavorless small pixel banana	2	decent	Last Available: "2015-06"
 8303	acceptable squat pixel beer	3	good	Last Available: "2015-06"
 8304	maroon puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	huge pumps	0		Last Available: "2015-06"
@@ -8214,7 +8214,7 @@
 8340	dry Vulcanized Vulcanized janitor's mop	0		Effect: "Well-Oiled", Effect Duration: 46
 8341	liquefied narrow warehouse clerk's glasses	0		Effect: "Less Pervious", Effect Duration: 45
 8342	adjusted polymerized baloney rotgut	0		Effect: "You're Rubber", Effect Duration: 12
-8343	boiled concentrated huge bouncing carton of gaspers	0		Effect: "It's Electric!", Effect Duration: 44
+8343	boiled concentrated bouncing huge carton of gaspers	0		Effect: "It's Electric!", Effect Duration: 44
 8344	warmed bronze polish	0		Effect: "Glo-Face", Effect Duration: 38
 8345	nitrogenated warmed crident	0		Effect: "Here to Kick Ass", Effect Duration: 41
 8346	modified adjusted totally sweet mohawk helmet	0		Effect: "Remaining Alive", Effect Duration: 52
@@ -8224,7 +8224,7 @@
 8350	galvanized cold-filtered damp bar rag	0		Effect: "Top Dog", Effect Duration: 69
 8351	flattened dry pulsating lump of goofball ore	0		Effect: "Almost Cool", Effect Duration: 20
 8352	boiled skeleton beans	0		Effect: "Memento Moir&eacute;", Effect Duration: 45
-8353	altered energized narrow teal grimy lab coat	0		Effect: "Mathematically Precise", Effect Duration: 39
+8353	altered energized teal narrow grimy lab coat	0		Effect: "Mathematically Precise", Effect Duration: 39
 8354	enhanced lime green nursery rhyme	0		Effect: "Stinky Weapon", Effect Duration: 24
 8355	polymerized polymerized iron torso box	0		Effect: "Booze Goozles", Effect Duration: 15
 8356	chilled bouncing mercenary headband	0		Effect: "Video Game Hot Dog", Effect Duration: 11
@@ -8248,7 +8248,7 @@
 8374	improved improved drinks tray	0		Effect: "Improved Candy Vision", Effect Duration: 52
 8375	Vulcanized eyebrow lifter	0		Effect: "Polka of Plenty", Effect Duration: 44
 8376	blue submarine	0		Last Available: "2015-06"
-8377	spoiled miniature pixel lemon	2	crappy	Last Available: "2015-06"
+8377	miniature spoiled pixel lemon	2	crappy	Last Available: "2015-06"
 8378	tolerable huge wobbly pixel daiquiri	3	good	Last Available: "2015-06"
 8379	colloidal oxidized power pill	0		Effect: "Disdain of the War Snapper", Effect Duration: 21, Last Available: "2015-06"
 8380	vacuum-sealed boiled green pixel potion	0		Effect: "Hare-o-dynamic", Effect Duration: 47, Last Available: "2015-06"
@@ -8265,7 +8265,7 @@
 8391	mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
-8394	tumbling olive The Emperor's dry cleaning	0		Last Available: "2015-07"
+8394	olive tumbling The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	upside-down Annie Oakley's The Emperor's new hat	0		Critical Hit Percent: +20, Last Available: "2015-07"
 8396	squat beefy The Emperor's new shirt	0		Muscle: +10, Last Available: "2015-07"
 8397	Annie Oakley's The Emperor's new pants	0		Critical Hit Percent: +20, Last Available: "2015-07"
@@ -8278,15 +8278,15 @@
 8404	shaking 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	ghostly talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	rotten fancy pestopiary	3	crappy	Effect: "Blessing of the Pervy Noodles", Effect Duration: 50
+8407	fancy rotten pestopiary	3	crappy	Effect: "Blessing of the Pervy Noodles", Effect Duration: 50
 8408	warmed electrified ectoplasmic orbs	0		Effect: "Mmmmmelon", Effect Duration: 37
-8409	jumbo rotten crudles	5	crappy	
-8410	miniature adequate twirling agnolotti arboli	2	good	
+8409	rotten jumbo crudles	5	crappy	
+8410	adequate miniature twirling agnolotti arboli	2	good	
 8411	normal spaghetti with ghost balls	4	good	
-8412	super-sized moldy succulent marrow	5	crappy	
+8412	moldy super-sized succulent marrow	5	crappy	
 8413	flavorless salacious crumbs	4	decent	
-8414	small normal red fusilli marrownarrow	2	good	
-8415	moldy massive suggestive strozzapreti	8	crappy	
+8414	normal small red fusilli marrownarrow	2	good	
+8415	massive moldy suggestive strozzapreti	8	crappy	
 8416	Mountain Stream gastrique	0		
 8417	rotten Mt. McLargeHuge oyster	3	crappy	
 8418	oyster sauce	0		
@@ -8299,8 +8299,8 @@
 8425	New Age healing crystal	0		Last Available: "2015-08"
 8426	Volcoino	0		Last Available: "2015-08"
 8427	purple fizzing spore pod	0		
-8428	twirling jittery spore pod	0		
-8429	wobbly skewed veiny spore pod	0		
+8428	jittery twirling spore pod	0		
+8429	skewed wobbly veiny spore pod	0		
 8430	jittery hard spore pod	0		
 8431	spore pod	0		
 8432	hot spore pod	0		
@@ -8329,9 +8329,9 @@
 8455	ghostly New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	skewed broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	lion tamer's grievous high-temperature mining mask	0		Weapon Damage Percent: +50, Experience (familiar): +2, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	lion tamer's grievous high-temperature mining mask	0		Weapon Damage Percent: +50, Experience (familiar): +2, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	ghostly green frightening beefcake's fireproof megaphone	0		Muscle: +25, Spooky Damage: +5, Last Available: "2015-08"
-8460	normal tiny mineapple	1	good	Last Available: "2015-08"
+8460	tiny normal mineapple	1	good	Last Available: "2015-08"
 8461	hand-crafted olive Gold Velvet&trade; whiskey	4	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	stale smelted roe	4	decent	Last Available: "2015-08"
@@ -8341,27 +8341,27 @@
 8467	olive friendly coward's sharpshooter's lava balaclava	0		Critical Hit Percent: +10, Monster Level: -20, Familiar Weight: +3, Last Available: "2015-08"
 8468	foul-smelling Newton's beefy basaltamander buckler	0		Muscle: +10, Experience (Mysticality): +3, Stench Damage: +10, Damage Reduction: 15, Last Available: "2015-08"
 8469	polarized squat lava globs	0		Effect: "Ode to Booze", Effect Duration: 62, Last Available: "2015-08"
-8470	miniature rotten gooey lava globs	2	crappy	Last Available: "2015-08"
+8470	rotten miniature gooey lava globs	2	crappy	Last Available: "2015-08"
 8471	arcane researcher's lava-proof pants of chilblains	0		Experience Percent (Mysticality): +10, Cold Damage: +25, Last Available: "2015-08"
 8472	huge fuchsia greedy heat-resistant necktie of the scaredy-cat	0		Monster Level: -15, Meat Drop: +20, Single Equip, Last Available: "2015-08"
 8473	smartaleck's heat-resistant gloves of Tarzan of courage	0		Moxie Percent: +30, Experience (Muscle): +3, Spooky Resistance: +3, Single Equip, Last Available: "2015-08"
 8474	decent wobbly very hot lunch	4	good	Last Available: "2015-08"
 8475	acceptable asbestos thermos	4	good	Last Available: "2015-08"
 8476	chilled chilled wobbly liquid rhinestones	0		Effect: "Joyful Resolve", Effect Duration: 40, Last Available: "2015-08"
-8477	toothsome bite-sized disco biscuit	1	awesome	Last Available: "2015-08"
+8477	bite-sized toothsome disco biscuit	1	awesome	Last Available: "2015-08"
 8478	tolerable Quaatorade&trade;	3	good	Last Available: "2015-08"
-8479	squat censurious sizzling biker's hat of the empath	0		Familiar Weight: +5, Hot Damage: +10, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
-8480	flame-wreathed stylish feathered headdress of Calamity Jane	0		Moxie: +25, Critical Hit Percent: +15, Hot Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	flame-retardant banded weightlifter's electrician's hardhat	0		Muscle: +15, Damage Absorption: +100, Hot Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
+8479	squat censurious sizzling biker's hat of the empath	0		Familiar Weight: +5, Hot Damage: +10, Sleaze Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8480	flame-wreathed stylish feathered headdress of Calamity Jane	0		Moxie: +25, Critical Hit Percent: +15, Hot Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	flame-retardant banded weightlifter's electrician's hardhat	0		Muscle: +15, Damage Absorption: +100, Hot Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	green narrow Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	blinking spinning The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	upside-down &quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
-8486	wobbly skewed one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
+8486	skewed wobbly one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	pulsating Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	bouncing bouncing grievous smooth velvet pants	0		Weapon Damage Percent: +50, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	bouncing bouncing grievous smooth velvet pants	0		Weapon Damage Percent: +50, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	smooth velvet shirt of the sewer	0		Stench Damage: +25, Last Available: "2015-08"
 8492	ghostly smooth velvet hat of the pedagogue	0		Experience: +3, Last Available: "2015-08"
 8493	smooth velvet pocket square of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2015-08"
@@ -8372,7 +8372,7 @@
 8498	Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	Saturday Night thermometer	0		Last Available: "2015-08"
 8500	the tongue of Smimmons	0		Last Available: "2015-08"
-8501	skewed shaking Raul's guitar pick	0		Last Available: "2015-08"
+8501	shaking skewed Raul's guitar pick	0		Last Available: "2015-08"
 8502	Pener's crisps	0		Last Available: "2015-08"
 8503	blinking signed deuce	0		Last Available: "2015-08"
 8504	Lavalos core	0		Last Available: "2015-08"
@@ -8391,21 +8391,21 @@
 8517	blue MacGyver's SMOOCH bracers of horror	0		Maximum MP: +100, Spooky Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8518	mansplainer's SMOOCH kneepads	0		Monster Level: +15, Single Equip, Last Available: "2015-08"
 8519	experienced SMOOCH spaulders	0		Experience: +2, Single Equip, Last Available: "2015-08"
-8520	greedy beefy SMOOCH codpiece	0		Muscle: +10, Meat Drop: +20, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	greedy beefy SMOOCH codpiece	0		Muscle: +10, Meat Drop: +20, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	ribald SMOOCH breastplate	0		Sleaze Damage: +10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	ghostly fused fuse	0		Last Available: "2015-08"
 8524	skewed superheated	0		Last Available: "2015-08"
 8525	toothsome snack-sized lava cake	2	awesome	Last Available: "2015-08"
-8526	miniature stale pink slime	2	decent	
+8526	stale miniature pink slime	2	decent	
 8527	maroon Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	fancy yummy devil hair pasta	4	awesome	Effect: "Dreadful Chill", Effect Duration: 50
+8529	yummy fancy devil hair pasta	4	awesome	Effect: "Dreadful Chill", Effect Duration: 50
 8530	massive spoiled upside-down spagecialetti	8	crappy	
 8531	Salsa Libre	0		
 8532	purple good gravy	0		
 8533	illicit fish sauce	0		
-8534	spoiled super-sized libertagliatelle	5	crappy	
+8534	super-sized spoiled libertagliatelle	5	crappy	
 8535	big yummy turkish mostaccioli	5	awesome	
 8536	yummy linguini of the sea	3	awesome	
 8537	polymerized Hersey&trade; SMOOCH	0		Effect: "Employee of the Month", Effect Duration: 63
@@ -8424,11 +8424,11 @@
 8551	bland mirror sausage without a cause	3	decent	
 8552	pressed non-altered face paint	0		Effect: "Polar Express", Effect Duration: 38
 8553	enchanted watered-down mediocre emergency margarita	2	decent	Effect: "Flamingly Floral", Effect Duration: 50
-8554	bad practically non-alcoholic vintage smart drink	1	decent	
+8554	practically non-alcoholic bad vintage smart drink	1	decent	
 8555	maroon a ten-percent bonus	0		
 8556	cyan Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	flattened aerosolized squat cyan Wickers bar	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 20
+8558	flattened aerosolized cyan squat Wickers bar	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 20
 8559	energized teal bakelite-covered bacon	0		Effect: "Crud&eacute;", Effect Duration: 48
 8560	double-magnetized squat Aerheads	0		Effect: "The Moxie of LOV", Effect Duration: 13
 8561	anodized dry energized Wrotz	0		Effect: "Bottle in front of Me", Effect Duration: 20
@@ -8437,9 +8437,9 @@
 8564	squat shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	inspector's flame-retardant barrel lid of wisdom	0		Mysticality: +15, Hot Resistance: +1, Item Drop: +15, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	skewed wholesome thinker's barrel hoop earring of Leguizamo	0		Mysticality: +10, Maximum HP Percent: +10, Monster Level: +20, Lasts Until Rollover, Last Available: "2015-09"
-8567	mansplainer's fortified bankruptcy barrel of wisdom	0		Mysticality: +15, Damage Absorption: +60, Monster Level: +15, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	mansplainer's fortified bankruptcy barrel of wisdom	0		Mysticality: +15, Damage Absorption: +60, Monster Level: +15, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	firkin	0		Last Available: "2015-09"
-8569	skewed wobbly normal barrel	0		Last Available: "2015-09"
+8569	wobbly skewed normal barrel	0		Last Available: "2015-09"
 8570	spinning tun	0		Last Available: "2015-09"
 8571	jittery lime green weathered barrel	0		Last Available: "2015-09"
 8572	blurry barrel	0		Last Available: "2015-09"
@@ -8448,7 +8448,7 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	blinking mouldering barrel	0		Last Available: "2015-09"
 8577	narrow jittery barnacled barrel	0		Last Available: "2015-09"
-8578	perfectly mixed watered-down narrow bottle of Amontillado	2	EPIC	Last Available: "2015-09"
+8578	watered-down perfectly mixed narrow bottle of Amontillado	2	EPIC	Last Available: "2015-09"
 8579	aged triple-distilled barrel-aged martini	9	awesome	Last Available: "2015-09"
 8580	normal cyan barrel pickle	3	good	Last Available: "2015-09"
 8581	normal barrel cracker	3	good	Last Available: "2015-09"
@@ -8476,7 +8476,7 @@
 8603	cold-filtered Vulcanized cuppa Boo tea	0		Effect: "Frosty the Hitman", Effect Duration: 34, Last Available: "2015-09"
 8604	polymerized quadruple-quantum narrow cuppa Nas tea	0		Effect: "Well-Lubed", Effect Duration: 56, Last Available: "2015-09"
 8605	boiled cuppa Improprie tea	0		Effect: "Demonic Flavor", Effect Duration: 52, Last Available: "2015-09"
-8606	moist blurry pulsating olive cuppa Frost tea	0		Effect: "Celestial Body", Effect Duration: 41, Last Available: "2015-09"
+8606	moist blurry olive pulsating cuppa Frost tea	0		Effect: "Celestial Body", Effect Duration: 41, Last Available: "2015-09"
 8607	double-colloidal unsweetened cuppa Toast tea	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 15, Last Available: "2015-09"
 8608	improved vacuum-sealed blue cuppa Net tea	0		Effect: "Sugary World View", Effect Duration: 13, Last Available: "2015-09"
 8609	quantum quantum cyan cuppa Proprie tea	0		Effect: "Red Around the Gills", Effect Duration: 63, Last Available: "2015-09"
@@ -8488,10 +8488,10 @@
 8615	unsweetened Vulcanized squat cuppa Wit tea	0		Effect: "Frostbeard", Effect Duration: 66, Last Available: "2015-09"
 8616	improved frozen activated huge cuppa Neuroplastici tea	0		Effect: "The Q Is Talking To You", Effect Duration: 18, Last Available: "2015-09"
 8617	magnetized lime green cuppa Dexteri tea	0		Effect: "Cautious Prowl", Effect Duration: 34, Last Available: "2015-09"
-8618	oxidized anodized squat shaking cuppa Flexibili tea	0		Effect: "Florid Cheeks", Effect Duration: 16, Last Available: "2015-09"
+8618	oxidized anodized shaking squat cuppa Flexibili tea	0		Effect: "Florid Cheeks", Effect Duration: 16, Last Available: "2015-09"
 8619	flattened cuppa Impregnabili tea	0		Effect: "Spiro Gyro", Effect Duration: 12, Last Available: "2015-09"
 8620	quantum corrupted cuppa Obscuri tea	0		Effect: "Melancholy Burden", Effect Duration: 22, Last Available: "2015-09"
-8621	energized dry electrified yellow tumbling jittery cuppa Irritabili tea	0		Effect: "Yuletide Mutations", Effect Duration: 21, Last Available: "2015-09"
+8621	energized dry electrified yellow jittery tumbling cuppa Irritabili tea	0		Effect: "Yuletide Mutations", Effect Duration: 21, Last Available: "2015-09"
 8622	liquefied energized cuppa Mediocri tea	0		Effect: "Sweet and Green", Effect Duration: 34, Last Available: "2015-09"
 8623	frozen wobbly cuppa Loyal tea	0		Effect: "Tiki Temerity", Effect Duration: 29, Last Available: "2015-09"
 8624	boiled cuppa Activi tea	1	awesome	Last Available: "2015-09"
@@ -8516,7 +8516,7 @@
 8643	rotten skewed bowl of maggots	4	crappy	Last Available: "2015-10"
 8644	watered-down bad blood and blood	2	decent	Last Available: "2015-10"
 8645	perfectly mixed weak blue Jack-O-Lantern beer	2	EPIC	Last Available: "2015-10"
-8646	drinkable distilled tumbling zombie	5	good	Last Available: "2015-10"
+8646	distilled drinkable tumbling zombie	5	good	Last Available: "2015-10"
 8647	tumbling Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	green wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
@@ -8548,7 +8548,7 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	quadruple-denatured ionized shoulder-warming lotion	0		Effect: "All Glory To the Toad", Effect Duration: 47, Last Available: "2015-11"
 8677	spoiled jumbo special iceberg lettuce	5	crappy	Effect: "Mercenary", Effect Duration: 45, Last Available: "2015-11"
-8678	enchanted hand-crafted irresponsibly strong huge ice wine	7	EPIC	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2015-11"
+8678	irresponsibly strong enchanted hand-crafted huge ice wine	7	EPIC	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2015-11"
 8679	wobbly yellow shaking flame-wreathed Van der Graaf Wal-Mart snowglobe of bravery	0		Hot Spell Damage: +10, Spooky Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-11"
 8680	blue twirling lion tamer's sage beefcake's Wal-Mart nametag	0		Muscle: +25, Mysticality Percent: +10, Experience (familiar): +2, Last Available: "2015-11"
 8681	avaricious Socratic boxer's Wal-Mart overalls	0		Muscle Percent: +10, Experience (Mysticality): +1, Meat Drop: +30, Last Available: "2015-11"
@@ -8558,31 +8558,31 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	huge The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	bellhop's hat of the glutton	0		Food Drop: +100, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	watered-down lousy gray ice porter	2	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	bellhop's hat of the glutton	0		Food Drop: +100, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	watered-down lousy gray ice porter	2	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	concentrated exotic travel brochure	0		Effect: "Baconstoned", Effect Duration: 12, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	deionized shampoo-conditioner	0		Effect: "Well Owl Be!", Effect Duration: 37, Last Available: "2015-11"
 8693	twirling hotel minibar key	0		Last Available: "2015-11"
 8694	jittery ice hotel bell	0		Last Available: "2015-11"
-8695	huge ghostly Martialest Arts trophy	0		Last Available: "2016-01"
+8695	ghostly huge Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered olive medicinal herbs	1		Effect: "Broken Fast", Effect Duration: 35, Last Available: "2016-01"
 8697	super-sized normal ice rice	5	good	Last Available: "2016-01"
 8698	artisanal iced plum wine	4	EPIC	Last Available: "2016-01"
 8699	narrow purple occult extremely unsafe brawny training belt	0		Muscle Percent: +20, Weapon Damage Percent: +100, Spell Damage Percent: +25, Single Equip, Last Available: "2016-01"
 8700	ribald horrifying weightlifter's training legwarmers	0		Muscle: +15, Spooky Damage: +25, Sleaze Damage: +10, Single Equip, Last Available: "2016-01"
-8701	shaking shaking banded brainy training helmet of the detective	0		Mysticality: +5, Damage Absorption: +100, Item Drop: +20, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
-8702	mirror shaking training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
+8701	shaking shaking banded brainy training helmet of the detective	0		Mysticality: +5, Damage Absorption: +100, Item Drop: +20, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8702	shaking mirror training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	squat machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	cyan self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
-8708	powdered red narrow abstraction: action	1		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 25, Last Available: "2015-12"
+8708	powdered narrow red abstraction: action	1		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 25, Last Available: "2015-12"
 8709	vaporized lime green abstraction: thought	1		Last Available: "2015-12"
 8710	compressed ghostly fuchsia abstraction: sensation	1		Last Available: "2015-12"
 8711	compressed abstraction: purpose	1		Last Available: "2015-12"
-8712	denatured narrow mirror abstraction: category	1		Last Available: "2015-12"
+8712	denatured mirror narrow abstraction: category	1		Last Available: "2015-12"
 8713	modified lime green pulsating abstraction: perception	1		Last Available: "2015-12"
 8714	modified abstraction: motion	1		Last Available: "2015-12"
 8715	denatured olive abstraction: joy	1		Effect: "Slimy Hands", Effect Duration: 45, Last Available: "2015-12"
@@ -8593,7 +8593,7 @@
 8720	drinkable watered-down VYKEA mead	2	good	Last Available: "2015-11"
 8721	nitrogenated tarnished electrified VYKEA woadpaint	0		Effect: "Squatting and Thrusting", Effect Duration: 35, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
-8723	green jittery VYKEA blood rune	0		Last Available: "2015-11"
+8723	jittery green VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	fuchsia VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
@@ -8601,16 +8601,16 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	blue wholesome VYKEA hex key of the scaredy-cat of the cheetah	0		Maximum HP Percent: +10, Monster Level: -15, Initiative: +60, Last Available: "2015-11"
 8730	spinning VYKEA instructions	0		Last Available: "2015-11"
-8731	rotten blinking tin of submardines	3	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	acceptable spirit-forward huge blinking skewed bottle of norwhiskey	5	good	Last Available: "2015-11"
+8731	rotten blinking tin of submardines	3	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8732	acceptable spirit-forward skewed blinking huge bottle of norwhiskey	5	good	Last Available: "2015-11"
 8733	modified wobbly octolus oculus	1	EPIC	Last Available: "2015-11"
 8734	shaking squat flame-wreathed lion tamer's healthy sardine can key	0		Maximum HP Percent: +20, Experience (familiar): +2, Hot Spell Damage: +10, Last Available: "2015-11"
-8735	pulsating electrified baleful Fonzie's norwhal helmet	0		Experience (Moxie): +1, Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	pulsating electrified baleful Fonzie's norwhal helmet	0		Experience (Moxie): +1, Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	shaking steel-toed brawny octolus-skin cloak of vim and vigor	0		Muscle Percent: +20, Damage Reduction: 9, Maximum HP Percent: +50, Last Available: "2015-11"
-8737	irresponsibly strong hand-crafted perfect cosmopolitan	8	EPIC	Last Available: "2015-11"
+8737	hand-crafted irresponsibly strong perfect cosmopolitan	8	EPIC	Last Available: "2015-11"
 8738	artisanal perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	aged enchanted perfect dark and stormy	4	awesome	Effect: "Crotchety, Pining", Effect Duration: 15, Last Available: "2015-11"
-8740	weak bad huge perfect mimosa	2	decent	Last Available: "2015-11"
+8739	enchanted aged perfect dark and stormy	4	awesome	Effect: "Crotchety, Pining", Effect Duration: 15, Last Available: "2015-11"
+8740	bad weak huge perfect mimosa	2	decent	Last Available: "2015-11"
 8741	mediocre purple perfect old-fashioned	4	decent	Last Available: "2015-11"
 8742	drinkable narrow shaking perfect paloma	4	good	Last Available: "2015-11"
 8743	pressed modified ghostly That 70s Cologne	0		Effect: "Strawberry Alarm", Effect Duration: 33, Last Available: "2015-11"
@@ -8622,10 +8622,10 @@
 8749	Vulcanized Deep Machine Tunnels snowglobe	0		Effect: "Pork Power", Effect Duration: 24, Last Available: "2015-12"
 8750	galvanized hemp candy necklace	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 12, Last Available: "2015-12"
 8751	aerosolized communal gobstopper	0		Effect: "Bells in the Batfry", Effect Duration: 29, Last Available: "2015-12"
-8752	tasty upside-down shaking Crimbo salad	3	awesome	Last Available: "2015-12"
+8752	tasty shaking upside-down Crimbo salad	3	awesome	Last Available: "2015-12"
 8753	adequate bread line	3	good	Last Available: "2015-12"
 8754	acceptable bark rootbeer	3	good	Last Available: "2015-12"
-8755	practically non-alcoholic artisanal squat ale	1	EPIC	Last Available: "2015-12"
+8755	artisanal practically non-alcoholic squat ale	1	EPIC	Last Available: "2015-12"
 8756	skewed crafty plastic Tammy the Tambourine Elf	0		Maximum MP: +10, Last Available: "2015-12"
 8757	tumbling plastic Rudolph the Red of the businessman	0		Meat Drop: +50, Last Available: "2015-12"
 8758	brainy plastic Gaia'ajh-dsli Ak'lwej	0		Mysticality: +5, Last Available: "2015-12"
@@ -8641,7 +8641,7 @@
 8768	narrow spinning Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
 8770	quantum quantum tumbling pitted sheet	0		Effect: "Feeling No Pain", Effect Duration: 22, Last Available: "2015-12"
-8771	blurry narrow sparking robo-battery	0		Last Available: "2015-12"
+8771	narrow blurry sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	tumbling executive sharpshooter's razor-sharp reusable shopping bag	0		Weapon Damage Percent: +25, Critical Hit Percent: +10, Meat Drop: +40, Last Available: "2015-12"
 8775	bouncing Temple Grandin's coarse hemp socks	0		Familiar Weight: +7, Single Equip, Last Available: "2015-12"
@@ -8675,7 +8675,7 @@
 8803	upside-down kidnapped orphan	0		Last Available: "2017-01"
 8804	high-grade	0		Last Available: "2017-01"
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
-8806	squat huge high-grade explosives	0		Last Available: "2017-01"
+8806	huge squat high-grade explosives	0		Last Available: "2017-01"
 8807	skewed experimental gene therapy	0		Last Available: "2017-01"
 8808	ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
@@ -8694,17 +8694,17 @@
 8822	tolerable Doc Clock's thyme cocktail	4	good	Last Available: "2016-12"
 8823	moldy Mr. Burnsger	4	crappy	Last Available: "2016-12"
 8824	mixed The Inquisitor's unidentifiable object	1		Effect: "You're Not Cooking", Effect Duration: 40, Last Available: "2016-12"
-8825	razor-sharp boxer's The Jokester's gun of the brazier	0		Muscle Percent: +10, Weapon Damage Percent: +25, Hot Spell Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	resourceful therapeutic The Jokester's wig of Flo-Jo	0		Maximum MP: +50, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
-8827	jittery The Jokester's pants of the brute of Calamity Jane of the detective	0		Muscle Percent: +30, Critical Hit Percent: +15, Item Drop: +20, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	razor-sharp boxer's The Jokester's gun of the brazier	0		Muscle Percent: +10, Weapon Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	resourceful therapeutic The Jokester's wig of Flo-Jo	0		Maximum MP: +50, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	jittery The Jokester's pants of the brute of Calamity Jane of the detective	0		Muscle Percent: +30, Critical Hit Percent: +15, Item Drop: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	aerosolized Jokester makeup	0		Effect: "Fungal Flambé", Effect Duration: 60, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
-8831	twirling yellow basking robin	0		Free Pull, Last Available: "2016-12"
+8831	yellow twirling basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	double-chilled jittery robin's egg	0		Effect: "Can't Smell Nothin'", Effect Duration: 64, Last Available: "2016-12"
 8834	toothsome tumbling robin flan	4	awesome	Last Available: "2016-12"
-8835	artisanal weak robin nog	2	EPIC	Last Available: "2016-12"
+8835	weak artisanal robin nog	2	EPIC	Last Available: "2016-12"
 8836	squat LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8719,12 +8719,12 @@
 8847	chilled oxidized extra-liquefied red-hot jawbreaker	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 18
 8848	aerosolized anodized question juice	0		Effect: "Incensed", Effect Duration: 64
 8849	quadruple-pressed deionized mirror tube of villain	0		Effect: "Compensatory Cruelness", Effect Duration: 48
-8850	supercool your cowboy boots	0		Moxie Percent: +20, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	supercool your cowboy boots	0		Moxie Percent: +20, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	pulsating nugget of thicksilver	0		Last Available: "2016-02"
 8854	upside-down nugget of wicksilver	0		Last Available: "2016-02"
-8855	yellow narrow nugget of slicksilver	0		Last Available: "2016-02"
+8855	narrow yellow nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
 8858	nugget of ticksilver	0		Last Available: "2016-02"
@@ -8746,19 +8746,19 @@
 8874	fireproof friendly Tesla Val-U Brand Every Bean Salad of Calamity Jane of Leguizamo	0		Critical Hit Percent: +15, Monster Level: +20, Familiar Weight: +3, Hot Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-02"
 8875	zippy hale educational Shrub's Premium Baked Beans	0		Experience: +1, Maximum HP: +20, Initiative: +20, Last Available: "2016-02"
 8876	flavorless plate of Heimz Fortified Kidney Beans	4	decent	Last Available: "2016-02"
-8877	miniature spoiled plate of Tesla's Electroplated Beans	2	crappy	Last Available: "2016-02"
+8877	spoiled miniature plate of Tesla's Electroplated Beans	2	crappy	Last Available: "2016-02"
 8878	moldy maroon plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
 8879	flavorless jumbo plate of Hellfire Spicy Beans	5	decent	Last Available: "2016-02"
 8880	spoiled plate of Frigid Northern Beans	4	crappy	Last Available: "2016-02"
-8881	special bland plate of World's Blackest-Eyed Peas	3	decent	Effect: "Lifted Spirits", Effect Duration: 15, Last Available: "2016-02"
-8882	decent gigantic plate of Trader Olaf's Exotic Stinkbeans	8	good	Last Available: "2016-02"
+8881	bland special plate of World's Blackest-Eyed Peas	3	decent	Effect: "Lifted Spirits", Effect Duration: 15, Last Available: "2016-02"
+8882	gigantic decent plate of Trader Olaf's Exotic Stinkbeans	8	good	Last Available: "2016-02"
 8883	normal plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	good	Last Available: "2016-02"
 8884	flavorless miniature huge plate of Val-U Brand Every Bean Salad	2	decent	Last Available: "2016-02"
 8885	spoiled plate of Shrub's Premium Baked Beans	4	crappy	Last Available: "2016-02"
 8886	twirling crafty beefcake's Fancy Jeff's pocket square	0		Muscle: +25, Maximum MP: +10, Last Available: "2016-02"
-8887	miser's smelly Newton's Daisy's unclean bloomers	0		Experience (Mysticality): +3, Stench Spell Damage: +10, Meat Drop: +10, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	miser's smelly Newton's Daisy's unclean bloomers	0		Experience (Mysticality): +3, Stench Spell Damage: +10, Meat Drop: +10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	fortified experienced thinker's Amoon-Ra Cowtep's nemes	0		Mysticality: +10, Experience: +2, Damage Absorption: +60, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	fortified experienced thinker's Amoon-Ra Cowtep's nemes	0		Mysticality: +10, Experience: +2, Damage Absorption: +60, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	olive Glenn's dice	0		Last Available: "2016-02"
 8891	nippy supercharged beefcake's Former Sheriff Dan's tin star of incineration of the boozehound	0		Muscle: +25, Maximum MP Percent: +30, Cold Damage: +10, Hot Spell Damage: +50, Booze Drop: +100, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	flattened galvanized rattler gland	0		Effect: "Fastbreaker", Effect Duration: 20, Last Available: "2016-02"
 8907	adjusted upside-down half-digested coal	0		Effect: "Hagg-ard", Effect Duration: 30, Last Available: "2016-02"
 8908	corrupted gray spinning tightly-wound spine	0		Effect: "Hyperoffended", Effect Duration: 39, Last Available: "2016-02"
-8909	half-sized flavorless rotting beefsteak	2	decent	Last Available: "2016-02"
+8909	flavorless half-sized rotting beefsteak	2	decent	Last Available: "2016-02"
 8910	perfectly mixed firemilk	3	EPIC	Last Available: "2016-02"
 8911	concentrated spidercow eye-cluster	0		Effect: "Fustulent", Effect Duration: 52, Last Available: "2016-02"
 8912	dehydrated shaking blinking moomy dust	1		Last Available: "2016-02"
@@ -8786,10 +8786,10 @@
 8914	blurry reliable sixgun	0		Last Available: "2016-02"
 8915	steel knuckles of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2016-02"
 8916	Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
-8917	huge cyan Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
+8917	cyan huge Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
 8918	blue The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
 8919	shaking LT&T tattoo kit	0		Last Available: "2016-02"
-8920	gray pulsating Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
+8920	pulsating gray Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	tumbling Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
@@ -8844,7 +8844,7 @@
 8972	modified diffused skin oil	0		Effect: "Hombre Muerto Caminando", Effect Duration: 58
 8973	wet quadruple-irradiated unusual oil	0		Effect: "Melancholy Burden", Effect Duration: 61
 8974	denatured pulsating eldritch oil	0		Effect: "Berry Statistical", Effect Duration: 61
-8975	maroon blurry exclusive club	0		
+8975	blurry maroon exclusive club	0		
 8976	alkaline adjusted tumbling patent preventative tonic	0		Effect: "Far Out", Effect Duration: 41
 8977	galvanized cold-filtered maroon patent invisibility tonic	0		Effect: "Chalky Hand", Effect Duration: 28
 8978	tarnished dry shaking patent aggression tonic	0		Effect: "Voracious Gorging", Effect Duration: 57
@@ -8852,7 +8852,7 @@
 8980	polymerized chilled twirling patent avarice tonic	0		Effect: "Innately Strong", Effect Duration: 29
 8981	adjusted anodized patent alacrity tonic	0		Effect: "Morbidi Tea", Effect Duration: 15
 8982	tarnished denatured corrupted marrow	0		Effect: "Aloofah", Effect Duration: 48
-8983	practically non-alcoholic mediocre shaking rodeo whiskey	1	decent	
+8983	mediocre practically non-alcoholic shaking rodeo whiskey	1	decent	
 8984	Thwaitgold scorpion statuette	0		
 8985	dog trainer's real cowboy hat	0		Experience (familiar): +1
 8986	Memories of Cow Punching	0		Free Pull
@@ -8862,23 +8862,23 @@
 8990	upside-down electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	pickled armored prawn	1		Last Available: "2016-03"
-8993	tasty diet red huge jumping horseradish	1	awesome	Last Available: "2016-03"
-8994	weak lousy enchanted gray Sacramento wine	2	decent	Effect: "Unusual Fashion Sense", Effect Duration: 30, Last Available: "2016-03"
+8993	diet tasty huge red jumping horseradish	1	awesome	Last Available: "2016-03"
+8994	lousy weak enchanted gray Sacramento wine	2	decent	Effect: "Unusual Fashion Sense", Effect Duration: 30, Last Available: "2016-03"
 8995	boiled Greek fire	0		Effect: "Nut-Rition", Effect Duration: 11, Last Available: "2016-03"
 8996	greasy ribald hardy educational ox-head shield of the ox	0		Muscle: +20, Experience: +1, Maximum HP: +50, Sleaze Damage: +10, Sleaze Spell Damage: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	curative grievous thinker's dented scepter of the brute of the overflowing toilet	0		Mysticality: +10, Muscle Percent: +30, Weapon Damage Percent: +50, Stench Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	executive asbestos-lined flame-wreathed frosty ruddy very pointy crown	0		Maximum HP Percent: +40, Cold Spell Damage: +10, Hot Spell Damage: +10, Hot Resistance: +5, Meat Drop: +40, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	executive asbestos-lined flame-wreathed frosty ruddy very pointy crown	0		Maximum HP Percent: +40, Cold Spell Damage: +10, Hot Spell Damage: +10, Hot Resistance: +5, Meat Drop: +40, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	greedy wizardly battle broom of the ox of vim and vigor of the bloodbag	0		Muscle: +20, Mysticality: +25, Maximum HP Percent: +50, Maximum HP: +100, Meat Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	inspector's electrified medical-grade slick carpe	0		Moxie: +10, Item Drop: +15, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9002	smelly clever codpiece of the bloodbag of the cheetah	0		Maximum HP: +100, Maximum MP: +20, Stench Spell Damage: +10, Initiative: +60, Lasts Until Rollover, Last Available: "2016-04"
-9003	narrow tumbling fuchsia fireproof troutsers of the bloodbag of the overflowing toilet of temperance	0		Maximum HP: +100, Stench Spell Damage: +50, Hot Resistance: +3, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	narrow tumbling fuchsia fireproof troutsers of the bloodbag of the overflowing toilet of temperance	0		Maximum HP: +100, Stench Spell Damage: +50, Hot Resistance: +3, Sleaze Resistance: +5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	avaricious groovy bass clarinet of the brazier of courage	0		Moxie Percent: +10, Hot Spell Damage: +25, Spooky Resistance: +3, Meat Drop: +30, Lasts Until Rollover, Last Available: "2016-04"
 9005	nasty dangerous fish hatchet of the cougar of the bloodbag	0		Moxie: +20, Weapon Damage: +10, Maximum HP: +100, Stench Damage: +5, Lasts Until Rollover, Last Available: "2016-04"
 9006	up-at-dawn executive experienced slick tunac	0		Moxie: +10, Experience: +2, Meat Drop: +40, Adventures: +5, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	electrified irradiated twirling green wriggling worm	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 49, Last Available: "2016-04"
-9009	weak lousy bottle of Fishhead 900-Day IPA	2	decent	Last Available: "2016-04"
+9009	lousy weak bottle of Fishhead 900-Day IPA	2	decent	Last Available: "2016-04"
 9010	tarnished dry high-test fishing line	0		Effect: "Human-Plant Hybrid", Effect Duration: 62, Last Available: "2016-04"
 9011	blinking sharpshooter's fishin' hat	0		Critical Hit Percent: +10, Last Available: "2016-04"
 9012	blurry Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8889,7 +8889,7 @@
 9017	upside-down viral video	0		Last Available: "2016-05"
 9018	jittery internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
-9020	bouncing green plus one	0		Last Available: "2016-05"
+9020	green bouncing plus one	0		Last Available: "2016-05"
 9021	half-sized flavorless special cyan gallon of milk	2	decent	Effect: "Chunky", Effect Duration: 5, Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
@@ -8915,7 +8915,7 @@
 9043	fuchsia blurry Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	Source terminal TRAM chip	0		Last Available: "2016-06"
-9046	red skewed Source terminal INGRAM chip	0		Last Available: "2016-06"
+9046	skewed red Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	ghostly Source terminal SCRAM chip	0		Last Available: "2016-06"
@@ -8930,7 +8930,7 @@
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	tumbling Source terminal file: familiar.ext	0		Last Available: "2016-06"
-9061	blurry red Source terminal file: pram.ext	0		Last Available: "2016-06"
+9061	red blurry Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	cyan Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	pulsating Source terminal file: cram.ext	0		Last Available: "2016-06"
@@ -8948,10 +8948,10 @@
 9076	lard-coated educational sage noir fedora	0		Mysticality Percent: +10, Experience: +1, Sleaze Spell Damage: +25, Last Available: "2016-07"
 9077	mirror lightning-fast hale trench coat of the sewer	0		Maximum HP: +20, Stench Damage: +25, Initiative: +40, Last Available: "2016-07"
 9078	bad Falcon&trade; Maltese Liquor	3	decent	Last Available: "2016-07"
-9079	moldy snack-sized hardboiled egg	2	crappy	Last Available: "2016-07"
+9079	snack-sized moldy hardboiled egg	2	crappy	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	pulsating DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	spinning Jack Frost's chaotic protonic accelerator pack of horror of doom of courage of the glutton	0		Spell Critical Percent: +10, Cold Spell Damage: +50, Spooky Spell Damage: 75, Spooky Resistance: +3, Food Drop: +100, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	spinning Jack Frost's chaotic protonic accelerator pack of horror of doom of courage of the glutton	0		Spell Critical Percent: +10, Cold Spell Damage: +50, Spooky Spell Damage: 75, Spooky Resistance: +3, Food Drop: +100, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	twirling almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	huge healthy Adventurer bobblehead	0		Maximum HP Percent: +20, Last Available: "2016-11"
 9085	twirling psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	resourceful Mr. Screege's spectacles	0		Maximum MP: +50, Single Equip, Last Available: "2016-08"
 9092	olive Sherlock's Spookyraven signet of Calamity Jane of extreme caution	0		Critical Hit Percent: +15, Monster Level: -25, Item Drop: +25, Single Equip, Last Available: "2016-08"
 9093	smartaleck's tie-dyed fannypack of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Single Equip, Last Available: "2016-08"
-9094	blurry frightening crafty burnt snowpants	0		Maximum MP: +10, Spooky Damage: +5, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	boxer's standards and practices guide	0		Muscle Percent: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9094	blurry frightening crafty burnt snowpants	0		Maximum MP: +10, Spooky Damage: +5, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	boxer's standards and practices guide	0		Muscle Percent: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	twirling forbidden stylish Carpathian longsword of the empath	0		Moxie: +25, Spell Damage Percent: +50, Familiar Weight: +5, Last Available: "2016-08"
 9097	wobbly smelly healthy baleful Liam's mail	0		Spell Damage: +25, Maximum HP Percent: +20, Stench Spell Damage: +10, Last Available: "2016-08"
 9098	perfumed occult Unfortunato's foolscap of Flo-Jo	0		Spell Damage Percent: +25, Stench Resistance: +5, Initiative: +100, Last Available: "2016-08"
@@ -8987,7 +8987,7 @@
 9115	frozen blue Drunk Uncles holo-record	0		Effect: "Human-Constellation Hybrid", Effect Duration: 21
 9116	time residue	0		Last Available: "2016-09"
 9117	energetic repaid diaper	0		Maximum MP Percent: +20
-9118	pulsating blurry Riker's Search History	0		Last Available: "2016-09"
+9118	blurry pulsating Riker's Search History	0		Last Available: "2016-09"
 9119	perfectly mixed narrow Shot of Kardashian Gin	4	EPIC	Last Available: "2016-09"
 9120	huge skewed Annie Oakley's Unstable Pointy Ears	0		Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	teal Memory Disk, Alpha	0		Last Available: "2016-09"
@@ -8999,33 +8999,33 @@
 9127	blurry Lo Pan's KoL Con 13 T-shirt of the boozehound	0		Spell Critical Percent: +30, Booze Drop: +100
 9128	aromatic beefy discarded swimming trunks of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15, Stench Resistance: +1
 9129	triple-chilled modified altered skewed diluted makeup	0		Effect: "Sizzling with Fury", Effect Duration: 22
-9130	oxidized upside-down ghostly fuchsia charisma potion	0		Effect: "Elemental Mastery", Effect Duration: 39
+9130	oxidized upside-down fuchsia ghostly charisma potion	0		Effect: "Elemental Mastery", Effect Duration: 39
 9131	extremely confusing manual	0		
 9132	frosty curative pistol	0		Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	adequate leftover pasty	3	good	
-9135	practically non-alcoholic fancy bad gray very whiskey	1	decent	Effect: "Serendipi Tea", Effect Duration: 10
+9135	practically non-alcoholic bad fancy gray very whiskey	1	decent	Effect: "Serendipi Tea", Effect Duration: 10
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	huge li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	squat li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	huge li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	squat li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	moist dry huge hoarded candy wad	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 40, Last Available: "2016-10"
 9147	polarized Prunets	0		Effect: "Strange Mental Acuity", Effect Duration: 52
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	improved denatured maroon ghostly tumbling invisible string	0		Lasts Until Rollover, Effect: "Inebriate Pride", Effect Duration: 14, Last Available: "2016-10"
 9151	dry invisible seam ripper	0		Lasts Until Rollover, Effect: "Arresistible", Effect Duration: 32, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	toothsome tiny bouncing raw sweet potato	1	awesome	Last Available: "2016-11"
-9154	enchanted flavorless pulsating raw beans	4	decent	Effect: "Dweeby", Effect Duration: 35, Last Available: "2016-11"
+9154	flavorless enchanted pulsating raw beans	4	decent	Effect: "Dweeby", Effect Duration: 35, Last Available: "2016-11"
 9155	stale bite-sized raw stuffing	1	decent	Last Available: "2016-11"
-9156	normal half-sized raw cranberry sauce	2	good	Last Available: "2016-11"
+9156	half-sized normal raw cranberry sauce	2	good	Last Available: "2016-11"
 9157	delicious raw turkey	4	awesome	Last Available: "2016-11"
 9158	rotten raw mincemeat	4	crappy	Last Available: "2016-11"
 9159	bland spinning raw potato	4	decent	Last Available: "2016-11"
@@ -9033,7 +9033,7 @@
 9161	normal bouncing raw bread	3	good	Last Available: "2016-11"
 9162	veiny smartaleck's mini-marshmallow dispenser	0		Moxie Percent: +30, Maximum HP: +10, Last Available: "2016-11"
 9163	knitted clever padded glass casserole dish	0		Damage Absorption: +20, Maximum MP: +20, Cold Resistance: +3, Last Available: "2016-11"
-9164	ghostly maroon stuffing fluffer	0		Last Available: "2016-11"
+9164	maroon ghostly stuffing fluffer	0		Last Available: "2016-11"
 9165	toasty can opener of the bloodbag	0		Maximum HP: +100, Hot Damage: +5, Last Available: "2016-11"
 9166	modified turkey blaster	1		Last Available: "2016-11"
 9167	spinning miser's rock-hard glass pie plate	0		Damage Reduction: 12, Meat Drop: +10, Last Available: "2016-11"
@@ -9041,21 +9041,21 @@
 9169	jittery gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	enchanted decent spinning sweet potatoes	3	good	Effect: "Raging Animal", Effect Duration: 25, Last Available: "2016-11"
-9172	flavorless lime green bouncing bean casserole	4	decent	Last Available: "2016-11"
+9172	flavorless bouncing lime green bean casserole	4	decent	Last Available: "2016-11"
 9173	snack-sized decent baked stuffing	2	good	Last Available: "2016-11"
 9174	bland cranberry cylinder	4	decent	Last Available: "2016-11"
-9175	small moldy olive thanksgiving turkey	2	crappy	Last Available: "2016-11"
+9175	moldy small olive thanksgiving turkey	2	crappy	Last Available: "2016-11"
 9176	rotten mince pie	4	crappy	Last Available: "2016-11"
 9177	flavorless spinning mashed potatoes	3	decent	Last Available: "2016-11"
 9178	delicious snack-sized warm gravy	2	awesome	Last Available: "2016-11"
-9179	normal diet bread roll	1	good	Last Available: "2016-11"
+9179	diet normal bread roll	1	good	Last Available: "2016-11"
 9180	adequate leftovers	4	good	Last Available: "2016-11"
 9181	flavorless pulsating leftovers sandwich	3	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	skewed cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
-9186	yellow huge packet of thanksgarden seeds	0		Last Available: "2016-11"
+9186	huge yellow packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	upside-down cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	huge Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
@@ -9075,7 +9075,7 @@
 9203	Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	blinking counterfeit city	0		Last Available: "2016-12"
 9205	sprinkles	0		Last Available: "2016-12"
-9206	blurry olive The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
+9206	olive blurry The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	sage ball and chain	0		Mysticality Percent: +10, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	skewed candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9209	narrow gingerbread tophat of incineration	0		Hot Spell Damage: +50, Last Available: "2016-12"
@@ -9089,7 +9089,7 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	stale upside-down animal part cracker	4	decent	Last Available: "2016-12"
-9220	drinkable triple-distilled gingerbread wine	9	good	Last Available: "2016-12"
+9220	triple-distilled drinkable gingerbread wine	9	good	Last Available: "2016-12"
 9221	rotten gingerbread mug	4	crappy	Last Available: "2016-12"
 9222	wicked gingerbread mask	0		Spell Damage: +5, Last Available: "2016-12"
 9223	blue miser's personal trainer's gingerservo of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10, Meat Drop: +10, Single Equip, Last Available: "2016-12"
@@ -9123,8 +9123,8 @@
 9251	tarnished warmed skewed Inner Truth	0		Effect: "Artificially Sweet", Effect Duration: 19, Last Available: "2016-12"
 9252	adequate thick spiritual candy cane	5	good	Last Available: "2016-12"
 9253	mediocre spiritual eggnog	3	decent	Last Available: "2016-12"
-9254	spoiled small spiritual fruitcake	2	crappy	Last Available: "2016-12"
-9255	flavorless small wobbly wobbly olive wobbly spiritual gingerbread	2	decent	Last Available: "2016-12"
+9254	small spoiled spiritual fruitcake	2	crappy	Last Available: "2016-12"
+9255	small flavorless wobbly wobbly olive wobbly spiritual gingerbread	2	decent	Last Available: "2016-12"
 9256	jittery chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9133,7 +9133,7 @@
 9261	mirror Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	huge fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
-9264	spinning pulsating olive briefcase full of sprinkles	0		Last Available: "2016-12"
+9264	pulsating olive spinning briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	enhanced tumbling rock candy	0		Effect: "Hyperoxygenated Blood", Effect Duration: 30, Last Available: "2016-12"
 9267	moldy green-iced sweet roll	3	crappy	Last Available: "2016-12"
@@ -9145,9 +9145,9 @@
 9273	bouncing jittery grievous Third Eye of the ox	0		Muscle: +20, Weapon Damage Percent: +50, Last Available: "2016-12"
 9274	twirling Krampus Horn of the ox of horror	0		Muscle: +20, Spooky Spell Damage: +25, Single Equip, Last Available: "2016-12"
 9275	bland hambrosier	4	decent	Last Available: "2016-12"
-9276	delicious triple-distilled bouncing chakra-mental wine	9	awesome	Last Available: "2016-12"
+9276	triple-distilled delicious bouncing chakra-mental wine	9	awesome	Last Available: "2016-12"
 9277	boiled chakra malt	0		Effect: "Thick-Skinned", Effect Duration: 54, Last Available: "2016-12"
-9278	decent jumbo maroon Black Angus blackburger	5	good	Last Available: "2016-12"
+9278	jumbo decent maroon Black Angus blackburger	5	good	Last Available: "2016-12"
 9279	mediocre irresponsibly strong brandy	6	decent	Last Available: "2016-12"
 9280	triple-pickled potion of spiritual gunkifying	0		Effect: "Sepia Tan", Effect Duration: 24, Last Available: "2016-12"
 9281	asbestos-lined thinker's bad vibroknife	0		Mysticality: +10, Hot Resistance: +5, Last Available: "2016-12"
@@ -9159,28 +9159,28 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	veiny Uncle Crimbo's hat of the brazier of courage	0		Maximum HP: +10, Hot Spell Damage: +25, Spooky Resistance: +3, Last Available: "2016-12"
-9290	decent special Eldritch snap	4	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50, Last Available: "2017-01"
+9290	special decent Eldritch snap	4	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50, Last Available: "2017-01"
 9291	pickled mirror hot jelly	1		Last Available: "2017-01"
 9292	boiled wobbly skewed jelly	1		Last Available: "2017-01"
 9293	vaporized red skewed jelly	1		Effect: "Phorcefullness", Effect Duration: 20, Last Available: "2017-01"
-9294	boiled pulsating blinking lime green sleaze jelly	1		Last Available: "2017-01"
+9294	boiled lime green blinking pulsating sleaze jelly	1		Last Available: "2017-01"
 9295	boiled pulsating stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	decent pulsating toast with hot jelly	3	good	Last Available: "2017-01"
 9298	normal special narrow olive toast with jelly	3	good	Effect: "Tiki Toughness", Effect Duration: 15, Last Available: "2017-01"
 9299	delicious toast with jelly	3	awesome	Last Available: "2017-01"
 9300	flavorless gigantic toast with sleaze jelly	9	decent	Last Available: "2017-01"
-9301	normal miniature toast with stench jelly	2	good	Last Available: "2017-01"
+9301	miniature normal toast with stench jelly	2	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	upside-down fireproof crafty wax hand	0		Maximum MP: +10, Hot Resistance: +3, Last Available: "2017-01"
 9306	lime green lightning-fast therapeutic candle	0		Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2017-01"
-9307	fancy half-sized adequate bouncing wax pancake	2	good	Effect: "You Read The Manual", Effect Duration: 10, Last Available: "2017-01"
+9307	half-sized fancy adequate bouncing wax pancake	2	good	Effect: "You Read The Manual", Effect Duration: 10, Last Available: "2017-01"
 9308	jittery wobbly rosewater-soaked medical-grade wax face	0		Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-01"
 9309	bad wax booze	3	decent	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	dehydrated squat narrow sea jelly	1		Effect: "Demonic Flavor", Effect Duration: 40, Last Available: "2017-01"
+9311	dehydrated narrow squat sea jelly	1		Effect: "Demonic Flavor", Effect Duration: 40, Last Available: "2017-01"
 9312	stale super-sized sea truffle	5	decent	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
@@ -9192,18 +9192,18 @@
 9320	Jack Frost's medical-grade therapeutic LOV Eardigan	0		Cold Spell Damage: +50, HP Regen Min: 12, HP Regen Max: 17, Lasts Until Rollover, Last Available: "2017-02"
 9321	Sherlock's horrifying wholesome LOV Epaulettes	0		Maximum HP Percent: +10, Spooky Damage: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2017-02"
 9322	tumbling lard-coated razor-sharp LOV Earrings of the sweet-tooth	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +25, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
-9323	twirling skewed teal LOV Enamorang	0		Last Available: "2017-02"
+9323	twirling teal skewed LOV Enamorang	0		Last Available: "2017-02"
 9324	yellow LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	dried mirror LOV Echinacea Bouquet	1		Effect: "The Wisdom... of the Future", Effect Duration: 15, Last Available: "2017-02"
 9327	jittery LOV Elephant of the sewer	0		Stench Damage: +25, Damage Reduction: 6, Last Available: "2017-02"
 9328	upside-down eldritch scanner of the sewer	0		Stench Damage: +25, Last Available: "2017-02"
-9329	alkaline warmed tumbling bouncing eldritch alignment spray	0		Effect: "Gemini Rising", Effect Duration: 51, Last Available: "2017-02"
+9329	alkaline warmed bouncing tumbling eldritch alignment spray	0		Effect: "Gemini Rising", Effect Duration: 51, Last Available: "2017-02"
 9330	shaking mirror LOV Entrance Pass	0		Last Available: "2017-02"
 9331	perfumed slick eldritch hammer of the bloodbag	0		Moxie: +10, Maximum HP: +100, Stench Resistance: +5, Last Available: "2017-01"
 9332	miniature decent twirling eldritch mushroom	2	good	Last Available: "2017-03"
 9333	cyan eldritch ichor	0		
-9334	yummy huge eldritch mushroom pizza	6	awesome	Last Available: "2017-03"
+9334	huge yummy eldritch mushroom pizza	6	awesome	Last Available: "2017-03"
 9335	blurry eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	frozen moist eldritch rub	0		Effect: "Quadrilled", Effect Duration: 57, Last Available: "2017-02"
@@ -9231,7 +9231,7 @@
 9359	yellow baby oil shooter	0		Last Available: "2017-03"
 9360	pulsating fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
-9362	bouncing spinning pile of dirt	0		Last Available: "2017-03"
+9362	spinning bouncing pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	bad literal grasshopper	3	decent	Last Available: "2017-03"
@@ -9239,26 +9239,26 @@
 9367	aged distilled spinning Phlegethon	5	awesome	Last Available: "2017-03"
 9368	hand-crafted Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	smooth high-proof mentholated wine	9	awesome	Last Available: "2017-03"
-9370	watered-down acceptable enchanted low tide martini	2	good	Effect: "Super Speed", Effect Duration: 20, Last Available: "2017-03"
+9370	watered-down enchanted acceptable low tide martini	2	good	Effect: "Super Speed", Effect Duration: 20, Last Available: "2017-03"
 9371	tolerable extra-dry shroomtini	5	good	Last Available: "2017-03"
 9372	mediocre watered-down morning dew	2	decent	Last Available: "2017-03"
 9373	weak acceptable whiskey squeeze	2	good	Last Available: "2017-03"
-9374	artisanal distilled great fashioned	5	EPIC	Last Available: "2017-03"
-9375	tolerable practically non-alcoholic Gnomish sagngria	1	good	Last Available: "2017-03"
+9374	distilled artisanal great fashioned	5	EPIC	Last Available: "2017-03"
+9375	practically non-alcoholic tolerable Gnomish sagngria	1	good	Last Available: "2017-03"
 9376	drinkable upside-down vodka stinger	4	good	Last Available: "2017-03"
-9377	mediocre irresponsibly strong extremely slippery nipple	6	decent	Last Available: "2017-03"
+9377	irresponsibly strong mediocre extremely slippery nipple	6	decent	Last Available: "2017-03"
 9378	artisanal piscatini	3	EPIC	Last Available: "2017-03"
 9379	artisanal spinning Churchill	3	EPIC	Last Available: "2017-03"
 9380	watered-down perfectly mixed upside-down soilzerac	2	EPIC	Last Available: "2017-03"
-9381	weak acceptable London frog	2	good	Last Available: "2017-03"
+9381	acceptable weak London frog	2	good	Last Available: "2017-03"
 9382	hand-crafted nothingtini	4	EPIC	Last Available: "2017-03"
-9383	artisanal practically non-alcoholic eighth plague	1	EPIC	Last Available: "2017-03"
-9384	artisanal watered-down pulsating single entendre	2	EPIC	Last Available: "2017-03"
+9383	practically non-alcoholic artisanal eighth plague	1	EPIC	Last Available: "2017-03"
+9384	watered-down artisanal pulsating single entendre	2	EPIC	Last Available: "2017-03"
 9385	distilled bad gray reverse Tantalus	5	decent	Last Available: "2017-03"
 9386	weak hand-crafted elemental caipiroska	2	EPIC	Last Available: "2017-03"
 9387	bad cyan jittery Feliz Navidad	4	decent	Last Available: "2017-03"
 9388	delicious purple Bloody Nora	3	awesome	Last Available: "2017-03"
-9389	mediocre triple-distilled moreltini	6	decent	Last Available: "2017-03"
+9389	triple-distilled mediocre moreltini	6	decent	Last Available: "2017-03"
 9390	tolerable distilled skewed skewed ghostly hell in a bucket	5	good	Last Available: "2017-03"
 9391	hand-crafted Newark	3	EPIC	Last Available: "2017-03"
 9392	mediocre R'lyeh	4	decent	Last Available: "2017-03"
@@ -9266,9 +9266,9 @@
 9394	delicious vodka barracuda	3	awesome	Last Available: "2017-03"
 9395	tolerable Mysterious Island iced tea	3	good	Last Available: "2017-03"
 9396	perfectly mixed drive-by shooting	4	EPIC	Last Available: "2017-03"
-9397	hand-crafted weak narrow gunner's daughter	2	EPIC	Last Available: "2017-03"
+9397	weak hand-crafted narrow gunner's daughter	2	EPIC	Last Available: "2017-03"
 9398	tolerable ghostly dirt julep	4	good	Last Available: "2017-03"
-9399	tolerable watered-down mirror blinking Simepore slime	2	good	Last Available: "2017-03"
+9399	watered-down tolerable mirror blinking Simepore slime	2	good	Last Available: "2017-03"
 9400	artisanal watered-down wobbly blurry Phil Collins	2	EPIC	Last Available: "2017-03"
 9401	bouncing unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	shaking toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9289,10 +9289,10 @@
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	ghostly fascinating alien plant sample	0		Last Available: "2017-04"
-9420	pickled purple tumbling alien plant goo	1		Last Available: "2017-04"
+9420	pickled tumbling purple alien plant goo	1		Last Available: "2017-04"
 9421	wobbly alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	jumbo fancy toothsome alien meat	5	awesome	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2017-04"
+9423	fancy jumbo toothsome alien meat	5	awesome	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2017-04"
 9424	wobbly alien toenails	0		Last Available: "2017-04"
 9425	huge alien zoological sample	0		Last Available: "2017-04"
 9426	olive complex alien zoological sample	0		Last Available: "2017-04"
@@ -9325,17 +9325,17 @@
 9453	dance instructor's murderbot mask of terror	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Item Drop: +5, Avatar: "Murderbot", Last Available: "2017-04"
 9454	triple-concentrated modified super-adjusted upside-down murderbot spring injector	0		Effect: "Mer-kindliness", Effect Duration: 25, Last Available: "2017-04"
 9455	greedy MacGyver's murderbot whip	0		Maximum MP: +100, Meat Drop: +20, Last Available: "2017-04"
-9456	smooth murderbot plasma rifle of Leguizamo	0		Moxie: +15, Monster Level: +20, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	smooth murderbot plasma rifle of Leguizamo	0		Moxie: +15, Monster Level: +20, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	squat murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	pulsating Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
-9462	bouncing shaking Procrastinator locker key	0		Last Available: "2017-04"
+9462	shaking bouncing Procrastinator locker key	0		Last Available: "2017-04"
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	maroon Spacegate	0		Last Available: "2017-04"
-9466	fancy adequate blinking Aldebaran sardines	4	good	Effect: "Arabian Knighthood", Effect Duration: 10, Last Available: "2017-04"
+9466	adequate fancy blinking Aldebaran sardines	4	good	Effect: "Arabian Knighthood", Effect Duration: 10, Last Available: "2017-04"
 9467	tolerable Centauri fish wine	4	good	Last Available: "2017-04"
 9468	dried squat oxygen	1		Effect: "Bottle in front of Me", Effect Duration: 50, Last Available: "2017-04"
 9469	upside-down tumbling wholesome Socratic Spacegate scientist's insignia	0		Experience (Mysticality): +1, Maximum HP Percent: +10, Single Equip, Last Available: "2017-04"
@@ -9343,7 +9343,7 @@
 9471	ghostly gravedigger's Spacegate diplomat's insignia of the cougar of the bloodbag	0		Moxie: +20, Maximum HP: +100, Spooky Damage: +10, Single Equip, Last Available: "2017-04"
 9472	blinking Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	bland miniature maroon ghostly alien sandwich	2	decent	Last Available: "2017-04"
+9474	bland miniature ghostly maroon alien sandwich	2	decent	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	magnetized adjusted Spant eggs	0		Effect: "Dexteri Tea", Effect Duration: 42
 9477	teal Spacegate (open)	0		Lasts Until Rollover
@@ -9362,10 +9362,10 @@
 9490	irradiated dry wobbly Threatening Missive	0		Effect: "Feet of Watermelon", Effect Duration: 44
 9491	mirror Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	wobbly Jeselnik's dog trainer's savvy Kremlin's Greatest Briefcase	0		Mysticality Percent: +20, Experience (familiar): +1, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	acceptable watered-down yellow basic martini	2	good	Last Available: "2017-06"
+9493	wobbly Jeselnik's dog trainer's savvy Kremlin's Greatest Briefcase	0		Mysticality Percent: +20, Experience (familiar): +1, Sleaze Damage: +25, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9494	watered-down acceptable yellow basic martini	2	good	Last Available: "2017-06"
 9495	acceptable mirror improved martini	3	good	Last Available: "2017-06"
-9496	watered-down tolerable narrow splendid martini	2	good	Last Available: "2017-06"
+9496	tolerable watered-down narrow splendid martini	2	good	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9383,21 +9383,21 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	upside-down Meteorite-Ade	0		Last Available: "2017-08"
-9514	rotten snack-sized meteoreo	2	crappy	Last Available: "2017-08"
+9514	snack-sized rotten meteoreo	2	crappy	Last Available: "2017-08"
 9515	hand-crafted spinning meadeorite	4	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	smelly clever meteortarboard of temperance	0		Maximum MP: +20, Stench Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2017-08"
 9518	hale wicked meteorite guard of the early riser	0		Spell Damage: +5, Maximum HP: +20, Adventures: +7, Damage Reduction: 9, Last Available: "2017-08"
-9519	Tesla Samson's meteorb	0		Experience (Muscle): +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2017-08", Lantern Element: "Hot"
+9519	Tesla Samson's meteorb	0		Experience (Muscle): +5, MP Regen Min: 7, MP Regen Max: 10, Lantern Element: "Hot", Last Available: "2017-08"
 9520	electrified asteroid belt of courage	0		Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2017-08"
 9521	blurry tumbling meteorthopedic shoes of the brute of the overflowing toilet of temperance	0		Muscle Percent: +30, Stench Spell Damage: +50, Sleaze Resistance: +5, Single Equip, Last Available: "2017-08"
 9522	asbestos-lined greasy frosty shooting morning star	0		Cold Spell Damage: +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Single Equip, Last Available: "2017-08"
 9523	meteoroid	0		Last Available: "2017-08"
-9524	mirror blue twirling meteor shower cap	0		Familiar Weight: +5
+9524	twirling blue mirror meteor shower cap	0		Familiar Weight: +5
 9525	green Thwaitgold time fly statuette	0		
 9526	twirling perfectly fair coin	0		Last Available: "2017-11"
 9527	blue Horsery contract	0		Free Pull, Last Available: "2018-08"
-9528	blurry upside-down corked genie bottle	0		Free Pull, Last Available: "2017-09"
+9528	upside-down blurry corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	jittery genie bottle	0		Last Available: "2017-09"
 9530	resourceful razor-sharp blessed rustproof +2 gray dragon scale mail of temperance	0		Weapon Damage Percent: +25, Maximum MP: +50, Sleaze Resistance: +5, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
@@ -9410,7 +9410,7 @@
 9538	dropped scrap of paper	0		
 9539	blurry hunk of granite	0		
 9540	huge shovelful of dirt	0		
-9541	mirror narrow xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
+9541	narrow mirror xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	maroon exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	skewed X	0		Last Available: "2017-10"
 9544	pulsating O	0		Last Available: "2017-10"
@@ -9450,11 +9450,11 @@
 9578	twirling transparent nog	1	decent	Last Available: "2017-12"
 9579	spoiled huge unfinished fruitcake	3	crappy	Last Available: "2017-12"
 9580	triple-colloidal and cracker	0		Effect: "Papowerful", Effect Duration: 11, Last Available: "2017-12"
-9581	weak bad teal neg grog	2	decent	Last Available: "2017-12"
+9581	bad weak teal neg grog	2	decent	Last Available: "2017-12"
 9582	stale low-calorie half double fruitcake	1	decent	Last Available: "2017-12"
 9583	spoiled hushed puppy	3	crappy	Last Available: "2017-12"
-9584	fancy spoiled teal muffled muffuletta	4	crappy	Effect: "Lifted Spirits", Effect Duration: 25, Last Available: "2017-12"
-9585	small adequate shushed potatoes	2	good	Last Available: "2017-12"
+9584	spoiled fancy teal muffled muffuletta	4	crappy	Effect: "Lifted Spirits", Effect Duration: 25, Last Available: "2017-12"
+9585	adequate small shushed potatoes	2	good	Last Available: "2017-12"
 9586	blue plastic mime functionary of the scaredy-cat	0		Monster Level: -15, Last Available: "2017-12"
 9587	banded plastic mime scientist	0		Damage Absorption: +100, Last Available: "2017-12"
 9588	plastic mime soldier of the scaredy-cat	0		Monster Level: -15, Last Available: "2017-12"
@@ -9474,9 +9474,9 @@
 9602	silent D	0		Last Available: "2017-12"
 9603	silent E	0		Last Available: "2017-12"
 9604	wobbly silent F	0		Last Available: "2017-12"
-9605	spinning narrow silent G	0		Last Available: "2017-12"
+9605	narrow spinning silent G	0		Last Available: "2017-12"
 9606	bouncing silent H	0		Last Available: "2017-12"
-9607	wobbly fuchsia silent I	0		Last Available: "2017-12"
+9607	fuchsia wobbly silent I	0		Last Available: "2017-12"
 9608	blue silent J	0		Last Available: "2017-12"
 9609	olive silent K	0		Last Available: "2017-12"
 9610	huge silent L	0		Last Available: "2017-12"
@@ -9498,7 +9498,7 @@
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	tumbling warehouse key	0		Last Available: "2017-12"
 9628	upside-down mime pocket probe	0		Last Available: "2017-12"
-9629	artisanal teal squat stale cheer wine	3	EPIC	Last Available: "2017-12"
+9629	artisanal squat teal stale cheer wine	3	EPIC	Last Available: "2017-12"
 9630	spoiled snack-sized shaking stale Cheer-E-Os	2	crappy	Last Available: "2017-12"
 9631	pulsating cheer-o-gram	0		Last Available: "2017-12"
 9632	rosewater-soaked cheerful antler hat of extreme caution	0		Monster Level: -25, Stench Resistance: +3, Last Available: "2017-12"
@@ -9509,7 +9509,7 @@
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	blinking The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
-9640	maroon blurry The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
+9640	blurry maroon The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9642	blinking The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
@@ -9519,11 +9519,11 @@
 9647	mime eraser	0		Last Available: "2017-12"
 9648	hand-crafted upside-down executive mime flask	4	EPIC	Last Available: "2017-12"
 9649	moldy mirror nega-mushroom	3	crappy	Last Available: "2017-12"
-9650	aged practically non-alcoholic nega-mushroom wine	1	awesome	Last Available: "2017-12"
+9650	practically non-alcoholic aged nega-mushroom wine	1	awesome	Last Available: "2017-12"
 9651	diffused flattened Cheer-Up soda	0		Effect: "Disco Inferno", Effect Duration: 48, Last Available: "2017-12"
 9652	big normal mirror mime army rations	5	good	Last Available: "2017-12"
-9653	bad weak mime army wine	2	decent	Last Available: "2017-12"
-9654	powdered fuchsia blinking mime army superserum	1		Last Available: "2017-12"
+9653	weak bad mime army wine	2	decent	Last Available: "2017-12"
+9654	powdered blinking fuchsia mime army superserum	1		Last Available: "2017-12"
 9655	activated mime army camouflage kit	0		Effect: "Infernal Thirst", Effect Duration: 25, Last Available: "2017-12"
 9656	wobbly twirling Jim Carey's miming beret of Flo-Jo	0		Monster Level: +25, Initiative: +100, Last Available: "2017-12"
 9657	red asbestos-lined stanky miming shirt	0		Stench Spell Damage: +25, Hot Resistance: +5, Last Available: "2017-12"
@@ -9534,11 +9534,11 @@
 9662	donated booze	0		
 9663	blinking donated food	0		
 9664	donated candy	0		
-9665	galvanized tumbling spinning digital honeypot	0		Effect: "Patience of the Tortoise", Effect Duration: 32, Last Available: "2025-12"
+9665	galvanized spinning tumbling digital honeypot	0		Effect: "Patience of the Tortoise", Effect Duration: 32, Last Available: "2025-12"
 9666	purple mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	bouncing mansplainer's mime army insignia (infantry)	0		Monster Level: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	beefcake's mime army insignia (intelligence)	0		Muscle: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	pulsating occult mime army insignia (espionage)	0		Spell Damage Percent: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	bouncing mansplainer's mime army insignia (infantry)	0		Monster Level: +15, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	beefcake's mime army insignia (intelligence)	0		Muscle: +25, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	pulsating occult mime army insignia (espionage)	0		Spell Damage Percent: +25, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	pulsating mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	skewed mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	moldy blue extra-toasted half sandwich	3	crappy	Last Available: "2018-12"
-9682	mediocre watered-down mulled hobo wine	2	decent	Last Available: "2018-12"
+9682	watered-down mediocre mulled hobo wine	2	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	Jeselnik's boxer's burning paper hat of the businessman	0		Muscle Percent: +10, Sleaze Damage: +25, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-12"
 9685	blue huge flame-retardant sage burning cape of Gandalf	0		Mysticality Percent: +10, Spell Critical Percent: +20, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2018-12"
@@ -9566,7 +9566,7 @@
 9694	smelly toasty grievous wad of used tape	0		Weapon Damage Percent: +50, Hot Damage: +5, Stench Spell Damage: +10, Last Available: "2018-01"
 9695	savvy silent nightlight of vim and vigor of the bloodbag of Calamity Jane	0		Mysticality Percent: +20, Maximum HP Percent: +50, Maximum HP: +100, Critical Hit Percent: +15
 9696	anodized sweetened reindeer fat	0		Effect: "Less Pervious", Effect Duration: 36
-9697	unsweetened modified skewed spinning Good 'n' Quiet	0		Effect: "High Blood Chocolate Content", Effect Duration: 18
+9697	unsweetened modified spinning skewed Good 'n' Quiet	0		Effect: "High Blood Chocolate Content", Effect Duration: 18
 9698	concentrated activated hot button candy	0		Effect: "Bear Clawed", Effect Duration: 31
 9699	maroon energetic smooth makeshift garbage shirt of the storm	0		Moxie: +15, Maximum MP Percent: 60, Last Available: "2018-01"
 9700	arcane researcher's novelty monorail ticket of doom	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +50
@@ -9578,7 +9578,7 @@
 9706	modified mirror lucky-ish pill	1		Effect: "Extra Backbone", Effect Duration: 30
 9707	vaporized dieting pill	1		
 9712	wobbly Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
-9713	twirling mirror How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
+9713	mirror twirling How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	skewed Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	mirror tumbling Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
@@ -9594,7 +9594,7 @@
 9726	cool psychic's amulet of the brute	0		Moxie: +5, Muscle Percent: +30, Last Available: "2018-02"
 9727	decent heart-shaped candy whetstone	3	good	Last Available: "2018-02"
 9728	bland Swedish massage fish	3	decent	Last Available: "2018-02"
-9729	weak aged Third Base	2	awesome	Last Available: "2018-02"
+9729	aged weak Third Base	2	awesome	Last Available: "2018-02"
 9730	hand-crafted Bustle Hustler	3	EPIC	Last Available: "2018-02"
 9731	Vulcanized pulsating Fabiotion	0		Effect: "Spooky Hands", Effect Duration: 26, Last Available: "2018-02"
 9732	polymerized pulsating Bettie page	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 64, Last Available: "2018-02"
@@ -9618,7 +9618,7 @@
 9750	olive bronze	0		
 9751	skewed piracetam	0		
 9752	bouncing ultracalcium	0		
-9753	narrow blurry ginseng	0		
+9753	blurry narrow ginseng	0		
 9754	scorching Team Avarice cap	0		Hot Damage: +25
 9755	asbestos-lined Team Sloth cap	0		Hot Resistance: +5, Combat Rate: -15
 9756	arcane researcher's Team Wrath cap	0		Experience Percent (Mysticality): +10
@@ -9648,7 +9648,7 @@
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	ghostly Snoutlet	0		Last Available: "2018-03"
 9782	tumbling Ruffalo	0		Last Available: "2018-03"
-9783	ghostly blue Vaporpoise	0		Last Available: "2018-03"
+9783	blue ghostly Vaporpoise	0		Last Available: "2018-03"
 9784	narrow Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
@@ -9695,7 +9695,7 @@
 9827	narrow rocket	0		
 9828	compressed blurry magnificent oyster egg	1		
 9829	pickled upside-down green brilliant oyster egg	1		
-9830	dehydrated mirror narrow glistening oyster egg	1		
+9830	dehydrated narrow mirror glistening oyster egg	1		
 9831	compressed scintillating oyster egg	1		
 9832	dried narrow pearlescent oyster egg	1		Effect: "Standard Issue Bravery", Effect Duration: 5
 9833	dehydrated mirror lustrous oyster egg	1		
@@ -9710,7 +9710,7 @@
 9842	pulsating lump of bauxite	0		Last Available: "2018-12"
 9843	skewed narrow reassuring steel-toed &quot;Remember the Trees&quot; Shirt of Leguizamo	0		Damage Reduction: 9, Monster Level: +20, Spooky Resistance: +1
 9844	FantasyRealm key	0		Last Available: "2018-04"
-9845	pulsating bouncing plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
+9845	bouncing pulsating plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
@@ -9734,16 +9734,16 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	jumbo special moldy pulsating druidic s'more	5	crappy	Effect: "The Grass...  Is Blue...", Effect Duration: 25, Last Available: "2018-04"
+9869	jumbo moldy special pulsating druidic s'more	5	crappy	Effect: "The Grass...  Is Blue...", Effect Duration: 25, Last Available: "2018-04"
 9870	dried sachet of powder	1		Last Available: "2018-04"
-9871	aged watered-down mourning wine	2	awesome	Last Available: "2018-04"
+9871	watered-down aged mourning wine	2	awesome	Last Available: "2018-04"
 9872	gray spinning sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	yellow map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	fancy bland twirling denastified haunch	4	decent	Effect: "Hot Buttoned", Effect Duration: 35, Last Available: "2018-04"
+9878	bland fancy twirling denastified haunch	4	decent	Effect: "Hot Buttoned", Effect Duration: 35, Last Available: "2018-04"
 9879	artisanal bad rum and good cola	3	EPIC	Last Available: "2018-04"
 9880	adjusted triple-wet Potion of Heroism	0		Effect: "Insatiable Hunger", Effect Duration: 66, Last Available: "2018-04"
 9881	toasty arcane researcher's leggings of the Spider Queen of Gandalf	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +20, Hot Damage: +5, Last Available: "2018-04"
@@ -9765,14 +9765,14 @@
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	perfectly mixed two meat muck	4	EPIC	
 9899	massive normal chocolate Ogre Chieftain	7	good	
-9900	half-sized delicious chocolate &quot;Phoenix&quot;	2	awesome	
-9901	big normal chocolate Spider Queen	5	good	
+9900	delicious half-sized chocolate &quot;Phoenix&quot;	2	awesome	
+9901	normal big chocolate Spider Queen	5	good	
 9902	drinkable hipster cocktail	4	good	
-9903	pulsating God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	ghostly God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	shaking God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	pulsating God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	ghostly God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	shaking God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,9 +9780,9 @@
 9912	blurry A-Boo glue	0		
 9913	blurry glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	massive stale blinking good guava	8	decent	
+9915	stale massive blinking good guava	8	decent	
 9916	acceptable tumbling gin and ginger	4	good	
-9917	cyan ghostly Thwaitgold chigger statuette	0		
+9917	ghostly cyan Thwaitgold chigger statuette	0		
 9918	altered mirror gaseous gravy	1		Effect: "Certainty", Effect Duration: 5
 9919	maroon pulsating SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	upside-down jittery skewed SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
@@ -9797,7 +9797,7 @@
 9929	ribald Brutal brogues of the wise owl of the bloodbag of Flo-Jo	0		Mysticality: +20, Maximum HP: +100, Sleaze Damage: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2018-07"
 9930	ruddy groovy Draftsman's driving gloves of chilblains of the glutton	0		Moxie Percent: +10, Maximum HP Percent: +40, Cold Damage: +25, Food Drop: +100, Lasts Until Rollover, Last Available: "2018-07"
 9931	spinning shellacked stiffened Rosewater's beefcake's Nouveau nosering	0		Muscle: +25, Mysticality Percent: +30, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2018-07"
-9932	Vulcanized spinning narrow sharkfin gumbo	0		Effect: "Spiky Frozen Hair", Effect Duration: 49, Last Available: "2018-07"
+9932	Vulcanized narrow spinning sharkfin gumbo	0		Effect: "Spiky Frozen Hair", Effect Duration: 49, Last Available: "2018-07"
 9933	ionized boiling broth	0		Effect: "Fireproof Lips", Effect Duration: 46, Last Available: "2018-07"
 9934	super-electrified jittery interrogative elixir	0		Effect: "Vinegavotte", Effect Duration: 58, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
@@ -9818,10 +9818,10 @@
 9950	spinning inspector's weightlifter's pentagram bandana	0		Muscle: +15, Item Drop: +15, Last Available: "2018-09"
 9951	skull ring of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	jumbo normal PB&J with the crusts cut off	5	good	Last Available: "2018-09"
+9953	normal jumbo PB&J with the crusts cut off	5	good	Last Available: "2018-09"
 9954	wobbly toasty MacGyver's dorky glasses	0		Maximum MP: +100, Hot Damage: +5, Single Equip, Last Available: "2018-09"
 9955	savvy ponytail clip of the blizzard	0		Mysticality Percent: +20, Cold Spell Damage: +25, Last Available: "2018-09"
-9956	maroon personal trainer's paint palette	0		Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	maroon personal trainer's paint palette	0		Experience Percent (Muscle): +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	modified mirror Purple Beast energy drink	1		Effect: "Pop-eyed", Effect Duration: 20, Last Available: "2018-09"
 9959	blurry Temple Grandin's cosmetic football	0		Familiar Weight: +7, Last Available: "2018-09"
@@ -9838,20 +9838,20 @@
 9970	skewed fortified ratty knitted cap of the bloodbag	0		Damage Absorption: +60, Maximum HP: +100, Last Available: "2018-09"
 9972	huge lightning-fast wicked intimidating chainsaw	0		Spell Damage: +5, Initiative: +40, Lasts Until Rollover, Last Available: "2018-09"
 9973	mediocre party beer bomb	4	decent	Last Available: "2018-09"
-9974	super-sized decent sweet party mix	5	good	Last Available: "2018-09"
+9974	decent super-sized sweet party mix	5	good	Last Available: "2018-09"
 9975	pickled shaking party balloon	1		Last Available: "2018-09"
 9976	olive blurry miser's party pants of terror	0		Spooky Spell Damage: +10, Meat Drop: +10, Last Available: "2018-09"
 9977	brawny party whip of the scaredy-cat of the overflowing toilet	0		Muscle Percent: +20, Monster Level: -15, Stench Spell Damage: +50, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	smooth TRIO cup of beer	3	awesome	Last Available: "2018-09"
-9980	tasty enchanted huge gray party platter for one	8	awesome	Effect: "Bandersnatched", Effect Duration: 30, Last Available: "2018-09"
+9980	huge tasty enchanted gray party platter for one	8	awesome	Effect: "Bandersnatched", Effect Duration: 30, Last Available: "2018-09"
 9981	twisted spinning Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	avaricious party crasher of the bloodbag	0		Maximum HP: +100, Meat Drop: +30, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9983	avaricious party crasher of the bloodbag	0		Maximum HP: +100, Meat Drop: +30, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	blue Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	wobbly party mouse hat	0		Familiar Weight: +5
-9987	bouncing latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	bouncing latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	narrow latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of the early riser	0		Adventures: +7, Lasts Until Rollover, Last Available: "2018-11"
@@ -9861,7 +9861,7 @@
 9994	stanky snakeskin cowboy hat of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25, Last Available: "2018-11"
 9995	snakeskin jacket of dire peril of the brazier	0		Weapon Damage: +20, Hot Spell Damage: +25, Last Available: "2018-11"
 9996	slime glob	0		Last Available: "2018-11"
-9997	upside-down skewed slime glob	0		Last Available: "2018-11"
+9997	skewed upside-down slime glob	0		Last Available: "2018-11"
 9998	squat slime glob	0		Last Available: "2018-11"
 9999	supercharged personal trainer's slime waders of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Maximum MP Percent: +30, Last Available: "2018-11"
 10001	blurry fireproof lion tamer's hardy slime fedora	0		Maximum HP: +50, Experience (familiar): +2, Hot Resistance: +3, Last Available: "2018-11"
@@ -9873,11 +9873,11 @@
 10007	flame-wreathed steel-toed mutant arm of the scaredy-cat	0		Damage Reduction: 9, Monster Level: -15, Hot Spell Damage: +10, Last Available: "2018-11"
 10008	censurious clever mutant legs of the brazier	0		Maximum MP: +20, Hot Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2018-11"
 10009	miser's Tesla clever mutant crown	0		Maximum MP: +20, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-11"
-10010	massive delicious ghostly ectoplasm	10	awesome	Last Available: "2018-11"
-10011	normal enchanted	4	good	Effect: "Wings of the Grasshopper", Effect Duration: 40, Last Available: "2018-11"
+10010	delicious massive ghostly ectoplasm	10	awesome	Last Available: "2018-11"
+10011	enchanted normal	4	good	Effect: "Wings of the Grasshopper", Effect Duration: 40, Last Available: "2018-11"
 10012	lousy watered-down purple bottle of vodka	2	decent	Last Available: "2018-11"
 10013	toothsome jittery huge pizza	3	awesome	Last Available: "2018-11"
-10014	triple-distilled delicious martini	6	awesome	Last Available: "2018-11"
+10014	delicious triple-distilled martini	6	awesome	Last Available: "2018-11"
 10015	normal cherry pie	3	good	Last Available: "2018-11"
 10016	bad eggnog	3	decent	Last Available: "2018-11"
 10017	pulsating glob of undifferentiated tissue	0		Last Available: "2018-11"
@@ -9886,7 +9886,7 @@
 10020	perfectly mixed twice-haunted screwdriver	3	EPIC	Last Available: "2018-11"
 10021	delicious squat candy cane	3	awesome	Last Available: "2018-12"
 10022	perfectly mixed runny fermented egg	3	EPIC	Last Available: "2018-12"
-10023	normal half-sized oldcake	2	good	Last Available: "2018-12"
+10023	half-sized normal oldcake	2	good	Last Available: "2018-12"
 10024	normal blue traditional Crimbo cookie	3	good	Last Available: "2023-06"
 10025	plastic wild beaver	0		Item Drop: +5, Last Available: "2018-12"
 10026	lime green toasty plastic reindeer	0		Hot Damage: +5, Last Available: "2018-12"
@@ -9907,9 +9907,9 @@
 10041	bouncing balanced antler of the businessman	0		Meat Drop: +50, Last Available: "2018-12"
 10042	double-paned dam	0		Cold Resistance: +5, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable practically non-alcoholic tumbling beavermouth	1	good	Last Available: "2018-12"
-10044	watered-down artisanal beaver punch (papaya)	2	EPIC	Last Available: "2018-12"
-10045	special triple-distilled lousy beaver punch (peach)	8	decent	Effect: "Happy Trails", Effect Duration: 15, Last Available: "2018-12"
-10046	watered-down bad beaver punch (cherry)	2	decent	Last Available: "2018-12"
+10044	artisanal watered-down beaver punch (papaya)	2	EPIC	Last Available: "2018-12"
+10045	special lousy triple-distilled beaver punch (peach)	8	decent	Effect: "Happy Trails", Effect Duration: 15, Last Available: "2018-12"
+10046	bad watered-down beaver punch (cherry)	2	decent	Last Available: "2018-12"
 10047	upside-down Canadian lantern of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Stench Spell Damage: +50, Last Available: "2018-12"
 10048	shellacked muskox-skin cap	0		Damage Reduction: 7, Last Available: "2018-12"
 10049	tumbling Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9923,7 +9923,7 @@
 10057	skewed wobbly Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	huge fireproof resourceful rock-hard stiffened beefy Kramco Sausage-o-Matic&trade;	0		Muscle: +10, Damage Reduction: 12, Maximum MP: +50, Hot Resistance: +3, Last Available: "2019-01"
 10059	huge sausage casing	0		Last Available: "2019-01"
-10060	gigantic moldy green sausage	10	crappy	Last Available: "2019-01"
+10060	moldy gigantic green sausage	10	crappy	Last Available: "2019-01"
 10061	Jim Carey's dance instructor's red-hot sausage fork	0		Experience Percent (Moxie): +10, Monster Level: +25, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	mirror sausage golem	0		Last Available: "2019-01"
@@ -9932,7 +9932,7 @@
 10066	bad watered-down beer	2	decent	Last Available: "2018-12"
 10067	decent yule gruel	4	good	Last Available: "2018-12"
 10068	irresponsibly strong smooth hot watered rum	7	awesome	Last Available: "2018-12"
-10069	perfectly mixed narrow green bottle of Crimbognac	3	EPIC	Last Available: "2018-12"
+10069	perfectly mixed green narrow bottle of Crimbognac	3	EPIC	Last Available: "2018-12"
 10070	spoiled Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
 10071	compressed twirling Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	forbidden marble mariachi hat of bravery	0		Spell Damage Percent: +50, Spooky Resistance: +5, Last Available: "2019-12"
 10096	distilled gray marble molecules	1		Last Available: "2019-12"
 10097	galvanized Mallomarbles	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 44
-10098	Jeselnik's hardy punching bag	0		Maximum HP: +50, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	wobbly squat up-at-dawn aromatic pith helmet	0		Stench Resistance: +1, Adventures: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	skewed huge manspreader's energetic poncho	0		Maximum MP Percent: +20, Monster Level: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	blurry blurry pendant of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	Sherlock's Jack Frost's palazzos	0		Cold Spell Damage: +50, Item Drop: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	personal trainer's cool pseudoaccordion	0		Moxie: +5, Experience Percent (Muscle): +10, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	Jeselnik's hardy punching bag	0		Maximum HP: +50, Sleaze Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	wobbly squat up-at-dawn aromatic pith helmet	0		Stench Resistance: +1, Adventures: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	skewed huge manspreader's energetic poncho	0		Maximum MP Percent: +20, Monster Level: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	blurry blurry pendant of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	Sherlock's Jack Frost's palazzos	0		Cold Spell Damage: +50, Item Drop: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	personal trainer's cool pseudoaccordion	0		Moxie: +5, Experience Percent (Muscle): +10, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	vaporized jittery pieces	1		Effect: "Wet and Greedy", Effect Duration: 20, Last Available: "2020-12"
 10105	warmed teal Para-Pop	0		Effect: "Raging Animal", Effect Duration: 64
-10106	Annie Oakley's crafty terra cotta truss	0		Maximum MP: +10, Critical Hit Percent: +20, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	terra cotta trousers of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	banded terra cotta tongs of dire peril	0		Weapon Damage: +20, Damage Absorption: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	Temple Grandin's smartaleck's terra cotta train	0		Moxie Percent: +30, Familiar Weight: +7, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	Lo Pan's Samson's terra cotta tie tack	0		Experience (Muscle): +5, Spell Critical Percent: +30, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	jittery Sherlock's rosewater-soaked terra cotta tambourine	0		Stench Resistance: +3, Item Drop: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	Annie Oakley's crafty terra cotta truss	0		Maximum MP: +10, Critical Hit Percent: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	terra cotta trousers of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	banded terra cotta tongs of dire peril	0		Weapon Damage: +20, Damage Absorption: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	Temple Grandin's smartaleck's terra cotta train	0		Moxie Percent: +30, Familiar Weight: +7, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	Lo Pan's Samson's terra cotta tie tack	0		Experience (Muscle): +5, Spell Critical Percent: +30, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	jittery Sherlock's rosewater-soaked terra cotta tambourine	0		Stench Resistance: +3, Item Drop: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	diluted mirror terra cotta tidbits	1		Last Available: "2020-12"
 10113	deionized jittery terra panna cotta	0		Effect: "Chalky White Pallor", Effect Duration: 63
 10114	frosty chilly velour voulge	0		Cold Damage: +5, Cold Spell Damage: +10, Last Available: "2021-12"
@@ -9992,36 +9992,36 @@
 10126	fortified glass shiv of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +60, Last Available: "2021-12"
 10127	sizzling Oprah's glass serape	0		Maximum MP Percent: +50, Hot Damage: +10, Last Available: "2021-12"
 10128	vaporized glass shards	1		Last Available: "2021-12"
-10129	polymerized blue spinning hard candy	0		Effect: "Tiki Temerity", Effect Duration: 47
-10130	stiffened loofah lumberjack's hat of courage	0		Damage Reduction: 1, Spooky Resistance: +3, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	skewed green flame-wreathed stylish loofah lei	0		Moxie: +25, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	blurry beefcake's loofah lederhosen of incineration	0		Muscle: +25, Hot Spell Damage: +50, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	sinister thinker's loofah ladle	0		Mysticality: +10, Spell Damage: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	bouncing perfumed Oprah's loofah legwarmers	0		Maximum MP Percent: +50, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	energetic loofah lavalier of the pedagogue	0		Experience: +3, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10129	polymerized spinning blue hard candy	0		Effect: "Tiki Temerity", Effect Duration: 47
+10130	stiffened loofah lumberjack's hat of courage	0		Damage Reduction: 1, Spooky Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	skewed green flame-wreathed stylish loofah lei	0		Moxie: +25, Hot Spell Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	blurry beefcake's loofah lederhosen of incineration	0		Muscle: +25, Hot Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	sinister thinker's loofah ladle	0		Mysticality: +10, Spell Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	bouncing perfumed Oprah's loofah legwarmers	0		Maximum MP Percent: +50, Stench Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	energetic loofah lavalier of the pedagogue	0		Experience: +3, Maximum MP Percent: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	denatured loofah lumps	1		Effect: "Memento Moir&eacute;", Effect Duration: 25, Last Available: "2022-12"
 10137	quantum chocolate-covered loofah	0		Effect: "Radiant Personality", Effect Duration: 44
-10138	aromatic flagstone flag of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	teal asbestos-lined resourceful flagstone flail	0		Maximum MP: +50, Hot Resistance: +5, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	flagstone flip-flops of bravery of the detective	0		Spooky Resistance: +5, Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	double-paned hardy flagstone fez	0		Maximum HP: +50, Cold Resistance: +5, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	sinister flagstone fleece of the sweet-tooth	0		Spell Damage: +10, Candy Drop: +100, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	toasty thinker's flagstone fringe	0		Mysticality: +10, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	aromatic flagstone flag of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	teal asbestos-lined resourceful flagstone flail	0		Maximum MP: +50, Hot Resistance: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	flagstone flip-flops of bravery of the detective	0		Spooky Resistance: +5, Item Drop: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	double-paned hardy flagstone fez	0		Maximum HP: +50, Cold Resistance: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	sinister flagstone fleece of the sweet-tooth	0		Spell Damage: +10, Candy Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	toasty thinker's flagstone fringe	0		Mysticality: +10, Hot Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	powdered cyan tumbling flagstone flagments	1		Last Available: "2022-12"
 10145	warmed modified moist bouncing Flag by the Foot&trade;	0		Effect: "Strange Mental Acuity", Effect Duration: 54
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	bouncing red-and-green microcamera	0		Familiar Weight: +5
 10148	spinning chaotic cobbled-together Meat detector	0		Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2019-12"
-10149	magnetized pressed tumbling skewed tin thermos of chai	0		Effect: "Fit To Be Tide", Effect Duration: 58, Last Available: "2019-12"
+10149	magnetized pressed skewed tumbling tin thermos of chai	0		Effect: "Fit To Be Tide", Effect Duration: 58, Last Available: "2019-12"
 10150	twisted twirling pulsating prototype stimulant	1		Last Available: "2019-12"
 10151	sinister tailored vest	0		Spell Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	skewed really nice net	0		Last Available: "2019-12"
 10154	chilly elf army poncho	0		Cold Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
-10155	super-sized decent fuchsia elf army field rations	5	good	Last Available: "2019-12"
+10155	decent super-sized fuchsia elf army field rations	5	good	Last Available: "2019-12"
 10156	ghostly jittery gingernade	0		Last Available: "2019-12"
 10157	hardy discarded bowtie of courage	0		Maximum HP: +50, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2019-12"
-10158	practically non-alcoholic mediocre martiny	1	decent	Last Available: "2019-12"
+10158	mediocre practically non-alcoholic martiny	1	decent	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	oxidized licorice snake	0		Effect: "On Pins and Needles", Effect Duration: 61
 10161	enhanced irradiated virgin jello shot	0		Effect: "Radiated and Grodiated", Effect Duration: 65
@@ -10029,20 +10029,20 @@
 10163	non-dry warmed galvanized government-issued candy	0		Effect: "You're Not Cooking", Effect Duration: 62
 10164	dry alkaline Pneumo bar	0		Effect: "You Read The Manual", Effect Duration: 24
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	fuchsia executive censurious Lil' Doctor&trade; bag	0		Sleaze Resistance: +3, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	fuchsia executive censurious Lil' Doctor&trade; bag	0		Sleaze Resistance: +3, Meat Drop: +40, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	super-sized spoiled bloodstick	5	crappy	
+10169	spoiled super-sized bloodstick	5	crappy	
 10170	hand-crafted irresponsibly strong bottle of Sanguiovese	8	EPIC	
 10171	bland actual blood sausage	3	decent	
 10172	drinkable gray mulled blood	3	good	
-10173	special spoiled blurry ghostly blood snowcone	4	crappy	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 15
+10173	special spoiled ghostly blurry blood snowcone	4	crappy	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 15
 10174	practically non-alcoholic hand-crafted cyan Red Russian	1	super ultra mega turbo EPIC	
 10175	toothsome yellow blood roll-up	4	awesome	
 10176	acceptable fancy bottle of blood	4	good	Effect: "Irresistible Resolve", Effect Duration: 15
 10177	enchanted flavorless blood-soaked sponge cake	4	decent	Effect: "Nature's Bounty", Effect Duration: 30
 10178	tolerable ghostly vampagne	3	good	
 10179	rotten plain snowcone	3	crappy	
-10180	wobbly narrow Booke of Vampyric Knowledge	0		
+10180	narrow wobbly Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
 10183	upside-down money bag	0		
@@ -10052,7 +10052,7 @@
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
 10188	PirateRealm guest pass	0		Last Available: "2019-04"
 10189	friendly PirateRealm eyepatch of the blizzard of doom	0		Familiar Weight: +3, Cold Spell Damage: +25, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2019-04"
-10190	squat pulsating bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
+10190	pulsating squat bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10192	skull key	0		Lasts Until Rollover, Last Available: "2019-04"
 10193	upside-down curious anemometer	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10061,10 +10061,10 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	spinning Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	half-sized bland crabsicle	2	decent	Last Available: "2019-04"
+10199	bland half-sized crabsicle	2	decent	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	lousy triple-distilled huge bottle of dark rhum	9	decent	Last Available: "2019-04"
-10202	weak hand-crafted bottle of extra-dark rhum	2	EPIC	Last Available: "2019-04"
+10202	hand-crafted weak bottle of extra-dark rhum	2	EPIC	Last Available: "2019-04"
 10203	watered-down perfectly mixed bottle of super-extra-dark rhum	2	EPIC	Last Available: "2019-04"
 10204	ionized pirate shaving cream	0		Effect: "Top Dog", Effect Duration: 20, Last Available: "2019-04"
 10205	conquistador's breastplate of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Last Available: "2019-04"
@@ -10075,7 +10075,7 @@
 10210	wobbly spinning sizzling pirate radio ring of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +10, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	normal pineapple slab	4	good	Last Available: "2019-04"
-10213	bland thick special hibiscus petal	5	decent	Effect: "Natural 20", Effect Duration: 10, Last Available: "2019-04"
+10213	special bland thick hibiscus petal	5	decent	Effect: "Natural 20", Effect Duration: 10, Last Available: "2019-04"
 10214	frozen huge mint leaf	0		Effect: "Gutterminded", Effect Duration: 31, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	twisted ice molecule	1		Last Available: "2019-04"
@@ -10095,16 +10095,16 @@
 10230	mirror scorching piratical blunderbuss of temperance	0		Hot Damage: +25, Sleaze Resistance: +5, Last Available: "2019-04"
 10231	squat gravedigger's padded PirateRealm party hat of the wise owl	0		Mysticality: +20, Damage Absorption: +20, Spooky Damage: +10, Last Available: "2019-04"
 10232	watered-down artisanal blurry Island Landslide	2	super EPIC	Last Available: "2019-04"
-10233	weak tolerable Island Thunderstorm	2	good	Last Available: "2019-04"
+10233	tolerable weak Island Thunderstorm	2	good	Last Available: "2019-04"
 10234	strong drinkable jittery Island Hurricane	5	good	Last Available: "2019-04"
-10235	special bad Skull Punch	4	decent	Effect: "Elron's Explosive Etude", Effect Duration: 30, Last Available: "2019-04"
+10235	bad special Skull Punch	4	decent	Effect: "Elron's Explosive Etude", Effect Duration: 30, Last Available: "2019-04"
 10236	acceptable Electric Punch	3	good	Last Available: "2019-04"
 10237	high-proof mediocre Smuggler's Punch	8	decent	Last Available: "2019-04"
 10238	smooth weak tumbling Scorpion Bowl	2	awesome	Last Available: "2019-04"
-10239	hand-crafted enchanted ghostly Turtle Bowl	3	super EPIC	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2019-04"
+10239	enchanted hand-crafted ghostly Turtle Bowl	3	super EPIC	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2019-04"
 10240	acceptable Cobra Bowl	3	good	Last Available: "2019-04"
-10241	purple ghostly vampyric cloake pattern	0		Free Pull
-10242	tumbling Sherlock's Da Vinci's wizardly vampyric cloake of Gandalf of the boozehound	0		Mysticality: +25, Experience (Mysticality): +5, Spell Critical Percent: +20, Item Drop: +25, Booze Drop: +100, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10241	ghostly purple vampyric cloake pattern	0		Free Pull
+10242	tumbling Sherlock's Da Vinci's wizardly vampyric cloake of Gandalf of the boozehound	0		Mysticality: +25, Experience (Mysticality): +5, Spell Critical Percent: +20, Item Drop: +25, Booze Drop: +100, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	vacuum-sealed one piece of bubble gum	0		Effect: "Cravin' for a Ravin'", Effect Duration: 43
 10245	pulsating arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	maroon twirling blurry overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	supercool Fourth of May Cosplay Saber of the wise owl of extreme caution	0		Mysticality: +20, Moxie Percent: +20, Monster Level: -25, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	supercool Fourth of May Cosplay Saber of the wise owl of extreme caution	0		Mysticality: +20, Moxie Percent: +20, Monster Level: -25, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	tumbling Thwaitgold nymph statuette	0		
-10254	tumbling reassuring Oprah's veiny healthy stiffened smooth brainy hewn moon-rune spoon of James Dean of dire peril of vim and vigor of the boozehound	0		Mysticality: +5, Moxie: +15, Experience (Moxie): +3, Weapon Damage: +20, Damage Reduction: 1, Maximum HP Percent: 70, Maximum HP: +10, Maximum MP Percent: +50, Spooky Resistance: +1, Booze Drop: +100, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	tumbling reassuring Oprah's veiny healthy stiffened smooth brainy hewn moon-rune spoon of James Dean of dire peril of vim and vigor of the boozehound	0		Mysticality: +5, Moxie: +15, Experience (Moxie): +3, Weapon Damage: +20, Damage Reduction: 1, Maximum HP Percent: 70, Maximum HP: +10, Maximum MP Percent: +50, Spooky Resistance: +1, Booze Drop: +100, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
-10256	purple spinning rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
+10256	spinning purple rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	bouncing Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	lard-coated careful Beach Comb of doom	0		Monster Level: -10, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	lard-coated careful Beach Comb of doom	0		Monster Level: -10, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	gray narrow grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10167,8 +10167,8 @@
 10302	shaking fireproof horrifying MacGyver's hardened whittled walking stick	0		Damage Reduction: 3, Maximum MP: +100, Spooky Damage: +25, Hot Resistance: +3, Last Available: "2019-08"
 10303	moldy narrow campfire hot dog	3	crappy	Last Available: "2019-08"
 10304	big decent campfire baked potato	5	good	Last Available: "2019-08"
-10305	spoiled huge campfire s'more	6	crappy	Last Available: "2019-08"
-10306	jumbo moldy campfire beans	5	crappy	Last Available: "2019-08"
+10305	huge spoiled campfire s'more	6	crappy	Last Available: "2019-08"
+10306	moldy jumbo campfire beans	5	crappy	Last Available: "2019-08"
 10307	half-sized normal fancy campfire stew	2	good	Effect: "Jittery", Effect Duration: 25, Last Available: "2019-08"
 10308	campfire coffee	1	crappy	Last Available: "2019-08"
 10309	anodized leftover chocolate bar	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 55
@@ -10183,7 +10183,7 @@
 10318	mirror low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	moldy space chowder	4	crappy	
-10321	artisanal watered-down space wine	2	super ultra mega EPIC	
+10321	watered-down artisanal space wine	2	super ultra mega EPIC	
 10322	ghostly The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10193,9 +10193,9 @@
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	fancy normal half-sized bu&ntilde;uelos Jaliscos	2	good	Effect: "Haunted Liver", Effect Duration: 5, Last Available: "2019-12"
+10337	half-sized fancy normal bu&ntilde;uelos Jaliscos	2	good	Effect: "Haunted Liver", Effect Duration: 5, Last Available: "2019-12"
 10338	diet normal flan del mar	1	good	Last Available: "2019-12"
-10339	spoiled miniature Baja sopapilla	2	crappy	Last Available: "2019-12"
+10339	miniature spoiled Baja sopapilla	2	crappy	Last Available: "2019-12"
 10340	beefcake's plastic Mer-kin baker	0		Muscle: +25, Last Available: "2019-12"
 10341	shaking mirror brainy plastic sea elf	0		Mysticality: +5, Last Available: "2019-12"
 10342	upside-down plastic yuleviathan of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2019-12"
@@ -10207,7 +10207,7 @@
 10348	adequate gigantic mana-fortified cranberry sauce	10	good	Last Available: "2019-11"
 10349	toothsome mana-stuffed herbal stuffing	4	awesome	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
-10351	adjusted pressed jittery twirling patch of extra-warm fur	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25, Last Available: "2019-12"
+10351	adjusted pressed twirling jittery patch of extra-warm fur	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25, Last Available: "2019-12"
 10352	powdered industrial lubricant	1		Last Available: "2019-12"
 10353	concentrated alkaline olive unfinished pleasure	0		Effect: "Butt-Rock Hair", Effect Duration: 34, Last Available: "2019-12"
 10354	mixed narrow vial of humanoid growth hormone	1		Last Available: "2019-12"
@@ -10216,7 +10216,7 @@
 10357	smooth wobbly boot flask	4	awesome	Last Available: "2019-12"
 10358	irradiated unsweetened infernal snowball	0		Effect: "New Zeal", Effect Duration: 52, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	twisted blurry jittery pulsating fish sauce	1		Effect: "Boschface", Effect Duration: 15, Last Available: "2019-12"
+10360	twisted blurry pulsating jittery fish sauce	1		Effect: "Boschface", Effect Duration: 15, Last Available: "2019-12"
 10361	moldy snack-sized spinning guffin	2	crappy	Last Available: "2019-12"
 10362	distilled Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
@@ -10225,7 +10225,7 @@
 10366	adjusted cyan Mer-kin eyedrops	0		Effect: "Mushroom Might", Effect Duration: 28, Last Available: "2019-12"
 10367	modified extra-strength goo	0		Effect: "Heart of Pink", Effect Duration: 21, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
-10369	vaporized purple upside-down livid energy	1		Last Available: "2019-12"
+10369	vaporized upside-down purple livid energy	1		Last Available: "2019-12"
 10370	narrow micronova	0		Last Available: "2019-12"
 10371	compressed jittery beggin' cologne	1		Effect: "Thickest, Sickest", Effect Duration: 30, Last Available: "2019-12"
 10372	quilted boxer's oxygenated eggnog helmet	0		Muscle Percent: +10, Damage Absorption: +40, Adventure Underwater, Last Available: "2019-12"
@@ -10243,7 +10243,7 @@
 10384	colloidal blurry salty gumdrop	0		Effect: "Heart of Orange", Effect Duration: 19, Last Available: "2019-12"
 10385	dance instructor's ribbon candy ascot of the brazier	0		Experience Percent (Moxie): +10, Hot Spell Damage: +25, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
-10387	shaking blurry teal intact anemone spike	0		Last Available: "2019-12"
+10387	teal shaking blurry intact anemone spike	0		Last Available: "2019-12"
 10388	teal zippy anemoney clip	0		Initiative: +20, Single Equip, Last Available: "2019-12"
 10389	runny icing	0		Last Available: "2019-12"
 10390	diluted tumbling super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
@@ -10257,7 +10257,7 @@
 10398	high-proof drinkable fishelada	10	good	Last Available: "2019-12"
 10399	yummy squat ojo de pez burrito	4	awesome	Last Available: "2019-12"
 10400	wobbly waterlogged wood	0		Last Available: "2019-12"
-10401	squat upside-down tumbling waterlogged cloth	0		Last Available: "2019-12"
+10401	tumbling upside-down squat waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
@@ -10282,26 +10282,26 @@
 10423	Da Vinci's savvy kelp-holly drape	0		Mysticality Percent: +20, Experience (Mysticality): +5, Last Available: "2019-12"
 10424	scorching dog trainer's experienced Staff of the Peppermint Twist of bravery	0		Experience: +2, Experience (familiar): +1, Hot Damage: +25, Spooky Resistance: +5, Last Available: "2019-12"
 10425	normal tempura and bean	4	good	Last Available: "2019-12"
-10426	practically non-alcoholic acceptable huge salt plum sake	1	good	Last Available: "2019-12"
+10426	acceptable practically non-alcoholic huge salt plum sake	1	good	Last Available: "2019-12"
 10427	dry super-liquefied pressurized potion of possessiveness	0		Effect: "Memories of Puppy Love", Effect Duration: 16, Last Available: "2019-12"
 10428	colloidal corrupted almond	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 66
 10429	improved handful of mixed nuts	0		Effect: "In the Limelight", Effect Duration: 55, Last Available: "2019-12"
-10430	green blurry nutcracking pliers	0		
+10430	blurry green nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	fortified extremely unsafe Rosewater's Retrospecs	0		Mysticality Percent: +30, Weapon Damage Percent: +100, Damage Absorption: +60, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	fortified extremely unsafe Rosewater's Retrospecs	0		Mysticality Percent: +30, Weapon Damage Percent: +100, Damage Absorption: +60, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	spinning unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	fuchsia Sherlock's auspicious scandalous steel-toed educational Powerful Glove	0		Experience: +1, Damage Reduction: 9, Sleaze Damage: +5, Item Drop: 35, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	fuchsia Sherlock's auspicious scandalous steel-toed educational Powerful Glove	0		Experience: +1, Damage Reduction: 9, Sleaze Damage: +5, Item Drop: 35, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
-10440	maroon mirror status cymbal	0		Last Available: "2020-02"
+10440	mirror maroon status cymbal	0		Last Available: "2020-02"
 10441	asbestos-lined Herculean weightlifter's Drip harness	0		Muscle: +15, Experience (Muscle): +1, Hot Resistance: +5
 10442	coward's drippy truncheon	0		Monster Level: -20, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	normal drippy nugget	4	drippy	
 10446	lousy glass of drippy wine	3	drippy	
-10447	yummy miniature drippy caviar	2	drippy	
+10447	miniature yummy drippy caviar	2	drippy	
 10448	huge rotten bouncing drippy plum(?)	6	drippy	
 10449	jittery Rosewater's drippy stake	0		Mysticality Percent: +30, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10333,7 +10333,7 @@
 10476	narrow rubber doll head	0		
 10477	rubber doll body	0		
 10478	plastic doll arms	0		
-10479	twirling skewed plastic doll legs	0		
+10479	skewed twirling plastic doll legs	0		
 10480	blurry rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
@@ -10343,10 +10343,10 @@
 10486	squat free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	jittery colossal free-range mushroom	0		Last Available: "2020-03"
-10489	bland low-calorie mushroom filet	1	decent	Last Available: "2020-03"
-10490	tumbling upside-down mushroom slab	0		Last Available: "2020-03"
+10489	low-calorie bland mushroom filet	1	decent	Last Available: "2020-03"
+10490	upside-down tumbling mushroom slab	0		Last Available: "2020-03"
 10491	vaporized yellow mushroom tea	1		Effect: "Poker Faced", Effect Duration: 45, Last Available: "2020-03"
-10492	tolerable squat pulsating mushroom whiskey	4	good	Last Available: "2020-03"
+10492	tolerable pulsating squat mushroom whiskey	4	good	Last Available: "2020-03"
 10493	greedy scandalous deadly mushroom cap	0		Weapon Damage: +5, Sleaze Damage: +5, Meat Drop: +20, Last Available: "2020-03"
 10494	Jim Carey's hardened Fonzie's mushroom shield of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +1, Damage Reduction: 9, Monster Level: +25, Last Available: "2020-03"
 10495	upside-down inspector's electrified deadly mushroom pants of the sweet-tooth	0		Weapon Damage: +5, Item Drop: +15, Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-03"
@@ -10371,11 +10371,11 @@
 10514	blurry drippy seed	0		
 10515	skewed drippy grub	0		
 10516	shaking drippy bezoar	0		
-10517	bouncing blinking Drip Institute petri dish	0		
+10517	blinking bouncing Drip Institute petri dish	0		
 10518	pulsating drippy ichor	0		
 10519	teal drippy enzyme	0		
 10520	huge drippy salt	0		
-10521	tumbling green blurry drippy pigment	0		
+10521	blurry green tumbling drippy pigment	0		
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
@@ -10394,8 +10394,8 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	spinning fireproof Guzzlr souvenir stein	0		Hot Resistance: +3, Last Available: "2020-05"
 10540	green Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	drinkable watered-down Ghiaccio Colada	2	good	Last Available: "2020-05"
-10542	watered-down perfectly mixed blinking Sourfinger	2	EPIC	Last Available: "2020-05"
+10541	watered-down drinkable Ghiaccio Colada	2	good	Last Available: "2020-05"
+10542	perfectly mixed watered-down blinking Sourfinger	2	EPIC	Last Available: "2020-05"
 10543	hand-crafted Nog-on-the-Cob	3	EPIC	Last Available: "2020-05"
 10544	hand-crafted tumbling Steamboat	3	EPIC	Last Available: "2020-05"
 10545	bad jittery Buttery Boy	3	decent	Last Available: "2020-05"
@@ -10438,9 +10438,9 @@
 10582	gray SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	flame-retardant foul-smelling birch battery	0		Stench Damage: +10, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2020-08"
-10585	Jack Frost's dog trainer's brawny ebony epee	0		Muscle Percent: +20, Experience (familiar): +1, Cold Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	aromatic forbidden weeping willow wand of the brazier	0		Spell Damage Percent: +50, Hot Spell Damage: +25, Stench Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	bouncing avaricious flame-retardant sharpshooter's beechwood blowgun	0		Critical Hit Percent: +10, Hot Resistance: +1, Meat Drop: +30, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	Jack Frost's dog trainer's brawny ebony epee	0		Muscle Percent: +20, Experience (familiar): +1, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	aromatic forbidden weeping willow wand of the brazier	0		Spell Damage Percent: +50, Hot Spell Damage: +25, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	bouncing avaricious flame-retardant sharpshooter's beechwood blowgun	0		Critical Hit Percent: +10, Hot Resistance: +1, Meat Drop: +30, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	censurious reassuring maple magnet of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	shaking inspector's nippy hemlock helm of the sewer	0		Cold Damage: +10, Stench Damage: +25, Item Drop: +15, Last Available: "2020-08"
@@ -10462,14 +10462,14 @@
 10606	alkaline Yeg's Motel toothbrush	0		Effect: "Mmmmmelon", Effect Duration: 19, Last Available: "2020-09"
 10607	anodized moist Yeg's Motel hand soap	0		Effect: "Peppermint Bite", Effect Duration: 48, Last Available: "2020-09"
 10608	spinning Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	big decent Yeg's Motel pillow mint	5	good	Last Available: "2020-09"
+10609	decent big Yeg's Motel pillow mint	5	good	Last Available: "2020-09"
 10610	huge Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	dry huge upside-down Yeg's Motel mouthwash	0		Effect: "Lubed", Effect Duration: 19, Last Available: "2020-09"
 10612	Sherlock's supercool Yeg's Motel shower cap	0		Moxie Percent: +20, Item Drop: +25, Lasts Until Rollover, Last Available: "2020-09"
 10613	narrow twirling gravedigger's Yeg's Motel bathrobe of wisdom	0		Mysticality: +15, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2020-09"
 10614	MacGyver's sage Yeg's Motel slippers	0		Mysticality Percent: +10, Maximum MP: +100, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
-10616	narrow huge Yeg's Motel minibar key	0		Last Available: "2020-09"
+10616	huge narrow Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	olive sizzling desk bell	0		Last Available: "2020-09"
 10618	blurry frost-rimed desk bell	0		Last Available: "2020-09"
 10619	wobbly red uncanny desk bell	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	Lo Pan's padded educational strapping Cargo Cultist Shorts	0		Muscle: +5, Experience: +1, Damage Absorption: +20, Spell Critical Percent: +30, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	boozy acceptable flask of moonshine	5	good	Last Available: "2020-09"
+10638	acceptable boozy flask of moonshine	5	good	Last Available: "2020-09"
 10639	pulsating aromatic deadly sea-worn candlestick of the dark arts	0		Weapon Damage: +5, Spell Damage Percent: +100, Stench Resistance: +1, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	altered dry wobbly narrow null-day exploit	0		Effect: "Impregnabili Tea", Effect Duration: 43, Last Available: "2025-12"
@@ -10523,7 +10523,7 @@
 10667	savvy plastic Crimbo cheer	0		Mysticality Percent: +20, Last Available: "2020-12"
 10668	wobbly spinning scandalous plastic Mirth	0		Sleaze Damage: +5, Last Available: "2020-12"
 10669	banded plastic Penny	0		Damage Absorption: +100, Last Available: "2020-12"
-10670	ghostly upside-down overflowing gift basket	0		Last Available: "2020-12"
+10670	upside-down ghostly overflowing gift basket	0		Last Available: "2020-12"
 10671	shaking teal personalized wassail stein	0		Last Available: "2020-12"
 10672	squat tabletop candy dispenser	0		Last Available: "2020-12"
 10673	neck wreath of the scaredy-cat	0		Monster Level: [-15*event(December)], Single Equip, Last Available: "2020-12"
@@ -10536,7 +10536,7 @@
 10680	Usain Bolt's wine carrier	0		Initiative: +80, Lasts Until Rollover, Last Available: "2020-12"
 10681	gravedigger's candy bucket	0		Spooky Damage: +10, Lasts Until Rollover, Last Available: "2020-12"
 10682	double-modified prescription teeth whitener	0		Effect: "Muscularrr", Effect Duration: 43, Last Available: "2020-12"
-10683	polymerized activated spinning lime green imported lemon lozenge	0		Effect: "Ponderous Potency", Effect Duration: 57, Last Available: "2020-12"
+10683	polymerized activated lime green spinning imported lemon lozenge	0		Effect: "Ponderous Potency", Effect Duration: 57, Last Available: "2020-12"
 10684	corrupted hermedisiac cologne	0		Effect: "Coming Up Roses", Effect Duration: 46, Last Available: "2020-12"
 10685	narrow government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
@@ -10569,7 +10569,7 @@
 10713	huge The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	immense flavorless and pepper (stale)	9	decent	Last Available: "2020-12"
-10716	delicious weak tumbling cranberry margarita (brackish)	2	awesome	Last Available: "2020-12"
+10716	weak delicious tumbling cranberry margarita (brackish)	2	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	jittery goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
@@ -10578,7 +10578,7 @@
 10722	moldy drive-thru burger	3	crappy	Last Available: "2020-12"
 10723	acceptable Boulevardier cocktail	4	good	Last Available: "2020-12"
 10724	magnetized shaking Hotwire&trade; brand candy rope	0		Effect: "License to Punch", Effect Duration: 60, Last Available: "2020-12"
-10725	moldy snack-sized bowl full of jelly	2	crappy	Last Available: "2020-12"
+10725	snack-sized moldy bowl full of jelly	2	crappy	Last Available: "2020-12"
 10726	lousy fancy narrow Eye and a Twist	3	decent	Effect: "Flaming Weapon", Effect Duration: 15, Last Available: "2020-12"
 10727	quadruple-flattened jittery blurry Chubby and Plump bar	0		Effect: "The Sweats", Effect Duration: 40, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
@@ -10600,9 +10600,9 @@
 10744	non-anodized corrupted battery (car)	0		Effect: "This Is Where You're a Viking", Effect Duration: 32, Last Available: "2021-03"
 10745	skewed cryptocloak	0		Last Available: "2025-12"
 10746	fuchsia marshmallow	0		
-10747	triple-distilled drinkable marshmallow bomb	9	good	Last Available: "2021-03"
+10747	drinkable triple-distilled marshmallow bomb	9	good	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	nitrogenated shaking short beer	0		Effect: "Nuts about Candy", Effect Duration: 49, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	non-altered flattened short	0		Effect: "Meat the Flintstones", Effect Duration: 61, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	huge perfumed dangerous familiar scrapbook	0		Weapon Damage: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	huge perfumed dangerous familiar scrapbook	0		Weapon Damage: +10, Stench Resistance: +5, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	huge packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	huge clan underground fireworks shop	0		Last Available: "2021-07"
 10762	spinning wobbly sharpshooter's fedora-mounted fountain of Tarzan of Flo-Jo	0		Experience (Muscle): +3, Critical Hit Percent: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,7 +10621,7 @@
 10765	skewed rocket	0		Last Available: "2021-07"
 10766	fuchsia rocket	0		Last Available: "2021-07"
 10767	blinking rocket	0		Last Available: "2021-07"
-10768	adequate narrow ghostly twirling fire crackers	3	good	Last Available: "2021-07"
+10768	adequate ghostly twirling narrow fire crackers	3	good	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	huge pulsating inspector's healthy Catherine Wheel	0		Maximum HP Percent: +20, Item Drop: +15, Lasts Until Rollover, Last Available: "2021-07"
 10771	chaotic forbidden rocket boots	0		Spell Damage Percent: +50, Spell Critical Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10630,7 +10630,7 @@
 10774	extra-Vulcanized tumbling Scent of a Human&trade; candle	0		Effect: "Human-Machine Hybrid", Effect Duration: 26, Last Available: "2021-08"
 10775	chilled shaking The Beast Within&trade; candle	0		Effect: "Feet of Watermelon", Effect Duration: 65, Last Available: "2021-08"
 10776	irradiated Salsa Caliente&trade; candle	0		Effect: "Permafrosty", Effect Duration: 19, Last Available: "2021-08"
-10777	liquefied huge shaking Smoldering Clover&trade; candle	0		Effect: "Flaming Weapon", Effect Duration: 30, Last Available: "2021-08"
+10777	liquefied shaking huge Smoldering Clover&trade; candle	0		Effect: "Flaming Weapon", Effect Duration: 30, Last Available: "2021-08"
 10778	wet corrupted Napalm In The Morning&trade; candle	0		Effect: "Poker Faced", Effect Duration: 13, Last Available: "2021-08"
 10779	narrow friendly hardened extra-large utility candle	0		Damage Reduction: 3, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2021-08"
 10780	Sherlock's runed taper candle of the pedagogue	0		Experience: +3, Item Drop: +25, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	squat rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	shaking packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	smelly MacGyver's clever educational industrial fire extinguisher of the empath of mayonnaise	0		Experience: +1, Maximum MP: 120, Familiar Weight: +5, Stench Spell Damage: +10, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	smelly MacGyver's clever educational industrial fire extinguisher of the empath of mayonnaise	0		Experience: +1, Maximum MP: 120, Familiar Weight: +5, Stench Spell Damage: +10, Sleaze Spell Damage: +50, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	squat The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	tumbling The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10661,13 +10661,13 @@
 10805	eggwater	1	EPIC	Last Available: "2021-12"
 10806	half-sized decent bread man	2	good	Last Available: "2021-12"
 10807	moldy plain candy cane	4	crappy	Last Available: "2021-12"
-10808	bland gigantic flour cookie	8	decent	Last Available: "2021-12"
+10808	gigantic bland flour cookie	8	decent	Last Available: "2021-12"
 10809	steel-toed plastic food lab	0		Damage Reduction: 9, Single Equip, Last Available: "2021-12"
 10810	wobbly dangerous plastic nog lab	0		Weapon Damage: +10, Single Equip, Last Available: "2021-12"
 10811	manspreader's plastic chem lab	0		Monster Level: +10, Single Equip, Last Available: "2021-12"
 10812	skewed quilted plastic primary lab	0		Damage Absorption: +40, Single Equip, Last Available: "2021-12"
 10813	wobbly ruddy plastic Cheer Core	0		Maximum HP Percent: +40, Single Equip, Last Available: "2021-12"
-10814	squat jittery packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
+10814	jittery squat packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
 10815	spinning medicine cabinet	0		Last Available: "2021-12"
 10816	twirling blurry baleful ice crown of wisdom of the brute	0		Mysticality: +15, Muscle Percent: +30, Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-12"
 10817	green MacGyver's steel-toed jeans of Leguizamo	0		Damage Reduction: 9, Maximum MP: +100, Monster Level: +20, Lasts Until Rollover, Last Available: "2021-12"
@@ -10677,12 +10677,12 @@
 10821	adequate fishcake	4	good	Last Available: "2021-12"
 10822	flavorless bone broth	3	decent	Last Available: "2021-12"
 10823	spoiled star pop	3	crappy	Last Available: "2021-12"
-10824	weak aged blurry skewed Doc's Fortifying Wine	2	awesome	Last Available: "2021-12"
+10824	aged weak skewed blurry Doc's Fortifying Wine	2	awesome	Last Available: "2021-12"
 10825	boozy mediocre blinking Doc's Smartifying Wine	5	decent	Last Available: "2021-12"
 10826	acceptable Doc's Limbering Wine	3	good	Last Available: "2021-12"
 10827	hand-crafted blurry Doc's Medical-Grade Wine	4	EPIC	Last Available: "2021-12"
-10828	distilled huge purple Homebodyl&trade;	1		Last Available: "2021-12"
-10829	vaporized purple spinning Extrovermectin&trade;	1		Effect: "The Dinsey Way", Effect Duration: 35, Last Available: "2021-12"
+10828	distilled purple huge Homebodyl&trade;	1		Last Available: "2021-12"
+10829	vaporized spinning purple Extrovermectin&trade;	1		Effect: "The Dinsey Way", Effect Duration: 35, Last Available: "2021-12"
 10830	powdered Breathitin&trade;	1		Last Available: "2021-12"
 10831	dehydrated Fleshazole&trade;	1		Last Available: "2021-12"
 10832	non-energized quantum anti-burn cream	0		Effect: "Purity of Spirit", Effect Duration: 30, Last Available: "2021-12"
@@ -10691,7 +10691,7 @@
 10835	colloidal non-nitrogenated anti-odor cream	0		Effect: "Burning Hands", Effect Duration: 61, Last Available: "2021-12"
 10836	deionized magnetized mirror anti-creep cream	0		Effect: "Executive Greed", Effect Duration: 15, Last Available: "2021-12"
 10837	non-activated polarized anti-pain cream	0		Effect: "Joy", Effect Duration: 48, Last Available: "2021-12"
-10838	perfectly mixed fancy wobbly Doc's Special Reserve Wine	4	EPIC	Effect: "The Chains Down In The Belly-O", Effect Duration: 45, Last Available: "2021-12"
+10838	fancy perfectly mixed wobbly Doc's Special Reserve Wine	4	EPIC	Effect: "The Chains Down In The Belly-O", Effect Duration: 45, Last Available: "2021-12"
 10839	normal bread pie	4	good	Last Available: "2021-12"
 10840	hand-crafted watered-down clear Russian	2	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
@@ -10728,8 +10728,8 @@
 10872	avaricious pants	0		Meat Drop: +30, Last Available: "2021-12"
 10873	Lo Pan's Fonzie's can of mixed everything of the glutton	0		Experience (Moxie): +1, Spell Critical Percent: +30, Food Drop: +100, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
-10875	wobbly ghostly the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	special immense yummy meatball	7	awesome	Effect: "Mana Tea", Effect Duration: 50, Last Available: "2021-12"
+10875	ghostly wobbly the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10876	yummy immense special meatball	7	awesome	Effect: "Mana Tea", Effect Duration: 50, Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	skewed refurbished air fryer	0		Last Available: "2021-12"
@@ -10782,8 +10782,8 @@
 10926	concentrated dry pickled trampled ticket stub	0		Effect: "Chalk Outline", Effect Duration: 31, Last Available: "2022-06"
 10927	liquefied improved savings bond	0		Effect: "Prelude of Precision", Effect Duration: 46, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
-10930	denatured blinking maroon blinking sweat-ade	1		Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10930	denatured blinking blinking maroon sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	yellow ghostly stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
@@ -10798,14 +10798,14 @@
 10942	dinosaur repellent	0		
 10943	cyan mirror careful camouflage vest	0		Monster Level: -10
 10944	Dinodollar	0		
-10945	yellow squat valuable dinosaur droppings	0		
+10945	squat yellow valuable dinosaur droppings	0		
 10946	huge dinosaur pheromone kit	0		
 10947	lion tamer's quilted arcane researcher's awkward dinosaur research harness	0		Experience Percent (Mysticality): +10, Damage Absorption: +40, Experience (familiar): +2
 10948	supercharged reflective vest	0		Maximum MP Percent: +30
 10949	shaking arcane researcher's dinosaur	0		Experience Percent (Mysticality): +10
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	pulsating packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	clever grievous Jurassic Parka	0		Weapon Damage Percent: +50, Maximum MP: +20, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	clever grievous Jurassic Parka	0		Weapon Damage Percent: +50, Maximum MP: +20, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	teal skewed boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	anodized narrow autumn leaf	0		Effect: "Astral Shell", Effect Duration: 56, Last Available: "2022-10"
@@ -10816,7 +10816,7 @@
 10960	unsweetened autumn dollar	0		Effect: "Mmmmmelon", Effect Duration: 66, Last Available: "2022-10"
 10961	deadly autumn leaf pendant of extreme caution of horror	0		Weapon Damage: +5, Monster Level: -25, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-10"
 10962	denatured autumn breeze	1		Effect: "Demonic Flavor", Effect Duration: 40, Last Available: "2022-10"
-10963	flattened red pulsating autumn years wisdom	0		Effect: "Tightly-Wound Spine", Effect Duration: 38, Last Available: "2022-10"
+10963	flattened pulsating red autumn years wisdom	0		Effect: "Tightly-Wound Spine", Effect Duration: 38, Last Available: "2022-10"
 10964	squat familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	artisanal triple-distilled blurry Oopsie IPA	6	EPIC	Last Available: "2022-10"
 10966	fuchsia mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
@@ -10828,32 +10828,32 @@
 10972	decent roasted vegetable of Jarlsberg	3	good	Last Available: "2022-11"
 10973	immense toothsome ghostly St. Pete's sneaky smoothie	9	awesome	Last Available: "2022-11"
 10974	decent half-sized Pete's wiley whey bar	2	good	Last Available: "2022-11"
-10975	super-sized decent Pete's rich ricotta	5	good	Last Available: "2022-11"
-10976	hand-crafted shaking pulsating Boris's beer	4	EPIC	Last Available: "2022-11"
-10977	delicious big honey bun of Boris	5	awesome	Last Available: "2022-11"
-10978	delicious huge Boris's bread	7	awesome	Last Available: "2022-11"
-10979	upside-down Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	huge Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	green Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10975	decent super-sized Pete's rich ricotta	5	good	Last Available: "2022-11"
+10976	hand-crafted pulsating shaking Boris's beer	4	EPIC	Last Available: "2022-11"
+10977	big delicious honey bun of Boris	5	awesome	Last Available: "2022-11"
+10978	huge delicious Boris's bread	7	awesome	Last Available: "2022-11"
+10979	upside-down Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	huge Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	green Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	moldy baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
-10989	rotten small blinking plain calzone	2	crappy	Last Available: "2022-11"
-10990	special adequate roasted vegetable focaccia	4	good	Effect: "Carrrsmic", Effect Duration: 40, Last Available: "2022-11"
+10989	small rotten blinking plain calzone	2	crappy	Last Available: "2022-11"
+10990	adequate special roasted vegetable focaccia	4	good	Effect: "Carrrsmic", Effect Duration: 40, Last Available: "2022-11"
 10991	small moldy Pizza of Legend	2	crappy	Last Available: "2022-11"
 10992	massive normal Calzone of Legend	10	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	gray Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	gray blinking Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	fuchsia pulsating Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	gray Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	blinking gray Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	fuchsia pulsating Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	moldy half-sized Deep Dish of Legend	2	crappy	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	half-sized moldy Deep Dish of Legend	2	crappy	Last Available: "2022-11"
 11001	huge deed to Oliver's Place	0		Free Pull
 11002	cyan drink chit	0		
 11003	upside-down huge government per-diem	0		
@@ -10866,19 +10866,19 @@
 11010	delicious swamp haunch	3	awesome	
 11011	ghostly nasty Lo Pan's gator shades	0		Spell Critical Percent: +30, Stench Damage: +5, Single Equip
 11012	milk cap	0		
-11013	watered-down artisanal maroon Charleston Choo-Choo	2	EPIC	
-11014	practically non-alcoholic aged Velvet Veil	1	awesome	
+11013	artisanal watered-down maroon Charleston Choo-Choo	2	EPIC	
+11014	aged practically non-alcoholic Velvet Veil	1	awesome	
 11015	irresponsibly strong hand-crafted Marltini	10	EPIC	
 11016	smooth Strong, Silent Type	4	awesome	
 11017	aged Mysterious Stranger	3	awesome	
 11018	enchanted hand-crafted Champagne Shimmy	3	EPIC	Effect: "Greasy Flavor", Effect Duration: 35
 11019	the Sot's parcel	0		
-11020	narrow Jeselnik's ceramic cestus of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	avaricious clever ceramic centurion shield of the brute	0		Muscle Percent: +30, Maximum MP: +20, Meat Drop: +30, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	fireproof grievous ceramic celery grater	0		Weapon Damage Percent: +50, Hot Resistance: +3, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	ceramic celsiturometer of wisdom of the dark arts of Leguizamo	0		Mysticality: +15, Spell Damage Percent: +100, Monster Level: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	Van der Graaf padded groovy ceramic cerecloth belt	0		Moxie Percent: +10, Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	fuchsia spinning scorching Samson's strapping ceramic cenobite's robe	0		Muscle: +5, Experience (Muscle): +5, Hot Damage: +25, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	narrow Jeselnik's ceramic cestus of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	avaricious clever ceramic centurion shield of the brute	0		Muscle Percent: +30, Maximum MP: +20, Meat Drop: +30, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	fireproof grievous ceramic celery grater	0		Weapon Damage Percent: +50, Hot Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	ceramic celsiturometer of wisdom of the dark arts of Leguizamo	0		Mysticality: +15, Spell Damage Percent: +100, Monster Level: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	Van der Graaf padded groovy ceramic cerecloth belt	0		Moxie Percent: +10, Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	fuchsia spinning scorching Samson's strapping ceramic cenobite's robe	0		Muscle: +5, Experience (Muscle): +5, Hot Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	modified ceramic scree	1		Effect: "Nature's Bounty", Effect Duration: 50, Last Available: "2023-12"
 11027	moist electrified skewed shaking extra-hard jawbreaker	0		Effect: "Fishily Speeding", Effect Duration: 63
 11028	maroon Newton's chiffon chevrons of the brute of James Dean	0		Muscle Percent: +30, Experience (Mysticality): +3, Experience (Moxie): +3, Single Equip, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	yellow flame-wreathed Annie Oakley's beefcake's chiffon chaps	0		Muscle: +25, Critical Hit Percent: +20, Hot Spell Damage: +10, Last Available: "2023-12"
 11034	denatured chiffon carbage	1		Last Available: "2023-12"
 11035	polarized chiffon lemon	0		Effect: "Is This Your Card?", Effect Duration: 28
-11036	tasty huge chocomotive	9	awesome	Last Available: "2022-12"
+11036	huge tasty chocomotive	9	awesome	Last Available: "2022-12"
 11037	normal upside-down freightcake	4	good	Last Available: "2022-12"
 11038	fortified aged cabooze	5	awesome	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10907,7 +10907,7 @@
 11051	super-nitrogenated Vulcanized adjusted Trainbot tubing	0		Effect: "The Power of Positive Thinking", Effect Duration: 60
 11052	enhanced warmed Trainbot plating	0		Effect: "Wings of the Grasshopper", Effect Duration: 47
 11053	galvanized Trainbot optics	0		Effect: "Frosty the Hitman", Effect Duration: 66
-11054	polymerized quantum moist squat huge Trainbot servomotors	0		Effect: "Libra Rising", Effect Duration: 26
+11054	polymerized quantum moist huge squat Trainbot servomotors	0		Effect: "Libra Rising", Effect Duration: 26
 11055	triple-ionized Trainbot linkages	0		Effect: "A Few Extra Pounds", Effect Duration: 44
 11056	blurry ping-pong paddle	0		Single Equip
 11057	tumbling ping-pong ball	0		
@@ -10937,7 +10937,7 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	skewed spinning crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	aged watered-down lime green mirror Crimbosmopolitan	2	awesome	Last Available: "2022-12"
+11084	aged watered-down mirror lime green Crimbosmopolitan	2	awesome	Last Available: "2022-12"
 11085	rotten Crimbo dinner	4	crappy	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10955,7 +10955,7 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	mixed huge blurry fruity pebble	1		Effect: "Blessing of the Creepy Pasta", Effect Duration: 15, Last Available: "2023-01"
+11102	mixed blurry huge fruity pebble	1		Effect: "Blessing of the Creepy Pasta", Effect Duration: 15, Last Available: "2023-01"
 11103	mirror lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	shaking wobbly milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
@@ -10970,27 +10970,27 @@
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	magnetized glob of extra-green chlorophyll	0		Effect: "Resilient Spirit", Effect Duration: 30, Last Available: "2023-02"
-11118	magnetized wobbly squat mushroom	0		Effect: "Fungal Fortification", Effect Duration: 53, Last Available: "2023-02"
+11118	magnetized squat wobbly mushroom	0		Effect: "Fungal Fortification", Effect Duration: 53, Last Available: "2023-02"
 11119	alkaline irradiated ghostly olive five-fingered fern resin	0		Effect: "Uncucumbered", Effect Duration: 29, Last Available: "2023-02"
 11120	yummy blurry super good fruit	3	awesome	Last Available: "2023-02"
 11121	denatured jittery energized spores	1		Last Available: "2023-02"
-11122	hot pepper of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10, Last Available: "2023-02", Lantern Element: "Hot"
+11122	hot pepper of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10, Lantern Element: "Hot", Last Available: "2023-02"
 11123	colloidal enhanced energized out-of-work circus flea	0		Effect: "Your Eyes are Peeled!", Effect Duration: 68, Last Available: "2023-02"
 11124	tumbling extra-grubby grub	0		Last Available: "2023-02"
 11125	galvanized double-corrupted pressed tumbling fire ant pheromones	0		Effect: "Wreathed in Smoke", Effect Duration: 17, Last Available: "2023-02"
 11126	ionized flapper fly	0		Effect: "Cute Vision", Effect Duration: 29, Last Available: "2023-02"
-11127	perfectly mixed special weak shot of wasp venom	2	EPIC	Effect: "Sauce Monocle", Effect Duration: 5, Last Available: "2023-02"
+11127	weak perfectly mixed special shot of wasp venom	2	EPIC	Effect: "Sauce Monocle", Effect Duration: 5, Last Available: "2023-02"
 11128	triple-cold-filtered mirror filled mosquito	0		Effect: "Rampage!", Effect Duration: 41, Last Available: "2023-02"
 11129	double-irradiated shim of shame shale	0		Effect: "Turkey-Agitated", Effect Duration: 39, Last Available: "2023-02"
 11130	modified pebble of proud pyrite	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 30, Last Available: "2023-02"
 11131	vacuum-sealed liquefied narrow pile of gritty sand	0		Effect: "items.enh", Effect Duration: 57, Last Available: "2023-02"
 11132	pulsating hollow rock	0		Last Available: "2023-02"
 11133	alkaline angry agate	0		Effect: "Stickler for Promptness", Effect Duration: 33, Last Available: "2023-02"
-11134	extra-concentrated frozen modified huge jittery lime green lump of loyal latite	0		Effect: "Toothy Grin", Effect Duration: 64, Last Available: "2023-02"
+11134	extra-concentrated frozen modified jittery lime green huge lump of loyal latite	0		Effect: "Toothy Grin", Effect Duration: 64, Last Available: "2023-02"
 11135	massive stale shadow sausage	9	decent	Last Available: "2023-03"
 11136	maroon knitted horrifying shadow skin	0		Spooky Damage: +25, Cold Resistance: +3, Last Available: "2023-03"
 11137	colloidal shadow flame	0		Effect: "Trash-Wrapped", Effect Duration: 54, Last Available: "2023-03"
-11138	half-sized spoiled shadow bread	2	crappy	Last Available: "2023-03"
+11138	spoiled half-sized shadow bread	2	crappy	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	tolerable shadow fluid	4	good	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
@@ -11033,12 +11033,12 @@
 11178	twirling careful stiffened shadow trousers of horror	0		Damage Reduction: 1, Monster Level: -10, Spooky Spell Damage: +25
 11179	twirling coward's dance instructor's shadow hammer	0		Experience Percent (Moxie): +10, Monster Level: -20
 11180	Oprah's razor-sharp shadow monocle of temperance	0		Weapon Damage Percent: +25, Maximum MP Percent: +50, Sleaze Resistance: +5, Single Equip
-11181	olive blinking shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
+11181	blinking olive shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	spoiled shadow hot dog	3	crappy	
 11183	hand-crafted shadow martini	3	EPIC	
 11184	pickled blurry shadow pill	1		Effect: "Good Motivator", Effect Duration: 50
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	narrow monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	frozen shadow candy	0		Effect: "Floundering", Effect Duration: 15
 11189	replica Mr. Accessory	0		
@@ -11067,7 +11067,7 @@
 11212	padded arcane researcher's replica Operation Patriot Shield of dire peril	0		Experience Percent (Mysticality): +10, Weapon Damage: +20, Damage Absorption: +20, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	replica Libram of Resolutions	0		
 11214	ghostly chilly electrified sinister replica plastic vampire fangs	0		Spell Damage: +10, Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Feed"
-11215	blurry spinning replica angel	0		
+11215	spinning blurry replica angel	0		
 11216	teal blurry mirror shellacked replica Camp Scout backpack	0		Damage Reduction: 7
 11217	huge replica deactivated nanobots	0		
 11218	replica Apathargic Bandersnatch	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	narrow replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	double-paned horrifying vibrating dangerous Cincho de Mayo	0		Weapon Damage: +10, Maximum MP Percent: +10, Spooky Damage: +25, Cold Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	double-paned horrifying vibrating dangerous Cincho de Mayo	0		Weapon Damage: +10, Maximum MP Percent: +10, Spooky Damage: +25, Cold Resistance: +5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	upside-down fuchsia dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11084,7 +11084,7 @@
 11229	bouncing replica Chateau Mantegna room key	0		
 11230	replica Deck of Every Card	0		
 11231	replica Source terminal	0		
-11232	lime green mirror replica disconnected intergnat	0		
+11232	mirror lime green replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
 11234	purple replica genie bottle	0		
 11235	replica space planula	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	purple jittery blinking beefcake's replica Jurassic Parka of James Dean	0		Muscle: +25, Experience (Moxie): +3
 11250	shaking replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	squat replica Ten Dollars	0		
 11254	ghostly jittery flame-retardant Jack Frost's slick replica Cincho de Mayo of temperance	0		Moxie: +10, Cold Spell Damage: +50, Hot Resistance: +1, Sleaze Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	bouncing knitted stanky Van der Graaf banded experienced &quot;I survived Y2K&quot; T-Shirt of vim and vigor	0		Experience: +2, Damage Absorption: +100, Maximum HP Percent: +50, Stench Spell Damage: +25, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	spinning razor-sharp boxer's pro skateboard	0		Muscle Percent: +10, Weapon Damage Percent: +25, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	spinning razor-sharp boxer's pro skateboard	0		Muscle Percent: +10, Weapon Damage Percent: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	huge red Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	boxer's Flash Liquidizer Ultra Dousing Accessory	0		Muscle Percent: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	boxer's Flash Liquidizer Ultra Dousing Accessory	0		Muscle Percent: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	frightening flame-wreathed lion tamer's Amulet of Perpetual Darkness of the cheetah	0		Experience (familiar): +2, Hot Spell Damage: +10, Spooky Damage: +5, Initiative: +60, Last Available: "2023-06"
 11268	jittery Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11142,7 +11142,7 @@
 11287	rosewater-soaked Samson's rutabuga bag	0		Experience (Muscle): +5, Stench Resistance: +3
 11288	skewed hardened mesquito proboscis	0		Damage Reduction: 3
 11289	cyan senate fly thorax of the brute	0		Muscle Percent: +30
-11290	anodized upside-down bouncing bug juice	0		Effect: "Ooh, Umami!", Effect Duration: 50
+11290	anodized bouncing upside-down bug juice	0		Effect: "Ooh, Umami!", Effect Duration: 50
 11291	spider leg of the overflowing toilet	0		Stench Spell Damage: +50
 11292	wool beetle antenna	0		Cold Resistance: +1
 11293	brawny mantis skull	0		Muscle Percent: +20
@@ -11152,7 +11152,7 @@
 11297	narrow bouncing dog trainer's Da Vinci's kilopede skull	0		Experience (Mysticality): +5, Experience (familiar): +1
 11298	polarized tarnished blinking haemolymphnode	0		Effect: "Mystic Circle", Effect Duration: 14
 11299	magnetized electrified ghostly chitin powder paste	0		Effect: "Jacked In", Effect Duration: 53
-11300	red pulsating sleeping patriotic eagle	0		Free Pull
+11300	pulsating red sleeping patriotic eagle	0		Free Pull
 11301	claw-held flag	0		Familiar Weight: +5
 11302	bouncing souvenir flag	0		
 11303	yellow name change form	0		
@@ -11172,7 +11172,7 @@
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	fancy practically non-alcoholic hand-crafted bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	Effect: "Bark of the Dog", Effect Duration: 35
+11320	hand-crafted practically non-alcoholic fancy bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	Effect: "Bark of the Dog", Effect Duration: 35
 11321	miser's stanky baywatch of the detective	0		Stench Spell Damage: +25, Item Drop: +20, Meat Drop: +10, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	cyan Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
@@ -11180,9 +11180,9 @@
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	wobbly residual chitin paste	0		Skill: "Chitinous Soul"
-11328	compressed mirror lime green concentrated cooking	1		
-11329	distilled tumbling olive meat	1		
-11330	boiled shaking shaking cyan sparkling orb	1		
+11328	compressed lime green mirror concentrated cooking	1		
+11329	distilled olive tumbling meat	1		
+11330	boiled cyan shaking shaking sparkling orb	1		
 11331	mixed blinking fuchsia hardening cream	1		
 11332	twisted pool shark hair oil	1		Effect: "Florid Cheeks", Effect Duration: 45
 11333	jittery book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11198,7 +11198,7 @@
 11343	greasy rake	0		Sleaze Spell Damage: +10
 11344	autumnic bomb	0		
 11345	shaking forest canopy bed	0		
-11346	twirling blinking day shortener	0		
+11346	blinking twirling day shortener	0		
 11347	maroon extra time	0		
 11348	pulsating autumnal aegis of vim and vigor of Leguizamo	0		Maximum HP Percent: +50, Monster Level: +20, Damage Reduction: 9
 11349	liquefied distilled resin	0		Effect: "Human-Elemental Hybrid", Effect Duration: 16
@@ -11258,7 +11258,7 @@
 11403	lime green shaking Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	Usain Bolt's rosy-cheeked Crimbuccaneer lantern of the storm	0		Maximum HP Percent: +30, Maximum MP Percent: +40, Initiative: +80, Last Available: "2023-12"
 11405	Crimbuccaneer flotsam	0		Last Available: "2023-12"
-11406	squat maroon Crimbuccaneer invasion map	0		Last Available: "2023-12"
+11406	maroon squat Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	red extremely unsafe Crimbuccaneer shirt	0		Weapon Damage Percent: [+100*event(December)], Last Available: "2023-12"
 11408	Elf Guard MPC	0		Last Available: "2023-12"
 11409	spinning squat Crimbuccaneer piece of 12	0		Last Available: "2023-12"
@@ -11274,13 +11274,13 @@
 11419	mirror shaking Elf Guard broom of the wise owl of Tarzan	0		Mysticality: +20, Experience (Muscle): +3, Last Available: "2023-12"
 11420	greedy strapping Crimbuccaneer tavern swab of mayonnaise	0		Muscle: +5, Sleaze Spell Damage: +50, Meat Drop: +20, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	fancy smooth practically non-alcoholic old-school pirate grog	1	awesome	Effect: "Stop the Presses!", Effect Duration: 5, Last Available: "2023-12"
+11422	practically non-alcoholic smooth fancy old-school pirate grog	1	awesome	Effect: "Stop the Presses!", Effect Duration: 5, Last Available: "2023-12"
 11423	normal small grog nuts	2	good	Last Available: "2023-12"
 11424	olive flame-retardant mansplainer's studded sawed-off blunderbuss	0		Damage Absorption: +80, Monster Level: +15, Hot Resistance: +1, Last Available: "2023-12"
-11425	strong perfectly mixed officer's nog	5	EPIC	Last Available: "2023-12"
+11425	perfectly mixed strong officer's nog	5	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	toothsome sundae ration	3	awesome	Last Available: "2023-12"
-11428	spoiled gigantic mirror shaking peppermint tack	9	crappy	Last Available: "2023-12"
+11428	spoiled gigantic shaking mirror peppermint tack	9	crappy	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	moldy whalesteak	3	crappy	Last Available: "2023-12"
 11431	stanky whalegun of wisdom of the sweet-tooth	0		Mysticality: +15, Stench Spell Damage: +25, Candy Drop: +100, Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	greasy Oprah's hale forbidden Da Vinci's Elf dessert spoon of the bloodbag	0		Experience (Mysticality): +5, Spell Damage Percent: +50, Maximum HP: 120, Maximum MP Percent: +50, Sleaze Spell Damage: +10, Last Available: "2023-12"
 11453	wicked weightlifter's Elf Guard SCUBA tank	0		Muscle: +15, Spell Damage: +5, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	narrow frightening free boots of terror	0		Spooky Damage: +5, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	narrow frightening free boots of terror	0		Spooky Damage: +5, Spooky Spell Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	bouncing baby rigging snake	0		Last Available: "2023-12"
 11457	pulsating groovy strapping Elvish underarmor of Calamity Jane	0		Muscle: +5, Moxie Percent: +10, Critical Hit Percent: +15, Single Equip, Last Available: "2023-12"
 11458	therapeutic Crimbuccaneer bombjacket of the sewer	0		Stench Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	adequate miniature twirling blinking sugarplum ration	2	good	Last Available: "2023-12"
+11459	miniature adequate blinking twirling sugarplum ration	2	good	Last Available: "2023-12"
 11460	adequate gingerbread nylons	4	good	Last Available: "2023-12"
-11461	moldy miniature blurry rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
-11462	normal enchanted jumbo tumbling jittery fuchsia lime	5	good	Effect: "Bandersnatched", Effect Duration: 30, Last Available: "2023-12"
+11461	miniature moldy blurry rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
+11462	normal enchanted jumbo fuchsia tumbling jittery lime	5	good	Effect: "Bandersnatched", Effect Duration: 30, Last Available: "2023-12"
 11463	stale pulsating gingerbread pirate	4	decent	Last Available: "2023-12"
-11464	bland small fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
+11464	small bland fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
 11465	artisanal mirror mulled wine	3	EPIC	Last Available: "2023-12"
-11466	hand-crafted spirit-forward Swedish coffee	5	EPIC	Last Available: "2023-12"
-11467	mediocre fortified canteen of eggnog	5	decent	Last Available: "2023-12"
+11466	spirit-forward hand-crafted Swedish coffee	5	EPIC	Last Available: "2023-12"
+11467	fortified mediocre canteen of eggnog	5	decent	Last Available: "2023-12"
 11468	acceptable hot wine	3	good	Last Available: "2023-12"
-11469	practically non-alcoholic special acceptable Jamaican coffee	1	good	Effect: "Super Accuracy", Effect Duration: 15, Last Available: "2023-12"
+11469	acceptable practically non-alcoholic special Jamaican coffee	1	good	Effect: "Super Accuracy", Effect Duration: 15, Last Available: "2023-12"
 11470	bad green flask of egggrog	3	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	wobbly pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	aged irresponsibly strong mirror yule grog	6	awesome	Last Available: "2023-12"
+11474	irresponsibly strong aged mirror yule grog	6	awesome	Last Available: "2023-12"
 11475	bland spinning wet tack	3	decent	Last Available: "2023-12"
 11476	thick moldy whalecake	5	crappy	Last Available: "2023-12"
-11477	twirling purple scandalous studded personal trainer's gunwale whalegun	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Sleaze Damage: +5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11477	twirling purple scandalous studded personal trainer's gunwale whalegun	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Sleaze Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	hand-crafted blue and claret	4	EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	huge twirling Jim Carey's Elf Guard squirtgun of bravery	0		Monster Level: +25, Spooky Resistance: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	huge twirling Jim Carey's Elf Guard squirtgun of bravery	0		Monster Level: +25, Spooky Resistance: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	sequin-encrusted sweater of temperance	0		Sleaze Resistance: +5, Last Available: "2023-12"
 11484	tumbling prompt greasy wicked replica Elf Guard medal	0		Spell Damage: +5, Sleaze Spell Damage: +10, Adventures: +3, Last Available: "2023-12"
@@ -11348,7 +11348,7 @@
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	yellow Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
-11496	jittery tumbling precision snowball	0		Last Available: "2023-12"
+11496	tumbling jittery precision snowball	0		Last Available: "2023-12"
 11497	jittery Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	ghostly Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
@@ -11356,60 +11356,60 @@
 11501	spinning Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	modified ghostly squat military candy cane	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 42
 11503	moist blurry groggipop	0		Effect: "Kissed By Fire", Effect Duration: 23
-11504	moss mace of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	Van der Graaf moss megaphone of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	fireproof Tesla moss medal	0		Hot Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	moss mitre of dire peril of mayonnaise	0		Weapon Damage: +20, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	ghostly miser's therapeutic moss mantle	0		Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	moss mace of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	Van der Graaf moss megaphone of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	fireproof Tesla moss medal	0		Hot Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	moss mitre of dire peril of mayonnaise	0		Weapon Damage: +20, Sleaze Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	ghostly miser's therapeutic moss mantle	0		Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	experienced Rosewater's moss marlinspike	0		Mysticality Percent: +30, Experience: +2, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	diluted moss mulch	1		Last Available: "2024-12"
 11511	frozen dry twirling moss floss	0		Effect: "Notably Lovely", Effect Duration: 62
 11512	adobe arsecover	0		Last Available: "2024-12"
-11513	fuchsia shaking adobe adze	0		Single Equip, Last Available: "2024-12"
+11513	shaking fuchsia adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	tumbling adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	vaporized narrow adobe assortment	1		Effect: "Boon of She-Who-Was", Effect Duration: 25, Last Available: "2024-12"
 11519	pressed adobe brittle	0		Effect: "Sweet Taste", Effect Duration: 62
-11520	frightening crepe paper phrygian cap of the dark arts of the detective	0		Spell Damage Percent: +100, Spooky Damage: +5, Item Drop: +20, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	frightening crepe paper phrygian cap of the dark arts of the detective	0		Spell Damage Percent: +100, Spooky Damage: +5, Item Drop: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	chaotic quilted weightlifter's crepe paper parachute cape	0		Muscle: +15, Damage Absorption: +40, Spell Critical Percent: +10, Last Available: "2025-12"
-11522	zippy clever crepe paper pie clip of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Initiative: +20, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	up-at-dawn crepe paper puzzle cube of the brazier of terror	0		Hot Spell Damage: +25, Spooky Spell Damage: +10, Adventures: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	Jim Carey's thinker's crepe paper plunge camisole of extreme caution	0		Mysticality: +10, Monster Level: 0, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	spinning Oprah's wholesome strapping crepe paper polka charm	0		Muscle: +5, Maximum HP Percent: +10, Maximum MP Percent: +50, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	zippy clever crepe paper pie clip of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Initiative: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	up-at-dawn crepe paper puzzle cube of the brazier of terror	0		Hot Spell Damage: +25, Spooky Spell Damage: +10, Adventures: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	Jim Carey's thinker's crepe paper plunge camisole of extreme caution	0		Mysticality: +10, Monster Level: 0, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	spinning Oprah's wholesome strapping crepe paper polka charm	0		Muscle: +5, Maximum HP Percent: +10, Maximum MP Percent: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	pickled crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	super-frozen energized tumbling crepe paper peanut candy	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 11
 11528	spinning Usain Bolt's petrified wood war pike	0		Item Drop: +5, Initiative: +80, Last Available: "2025-12"
 11529	chilly ruddy petrified wood waist protector	0		Maximum HP Percent: +40, Cold Damage: +5, Single Equip, Last Available: "2025-12"
-11530	crafty Rosewater's petrified wood wizard's pouch	0		Mysticality Percent: +30, Maximum MP: +10, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	Da Vinci's brawny petrified wood water purifier	0		Muscle Percent: +20, Experience (Mysticality): +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	crafty Rosewater's petrified wood wizard's pouch	0		Mysticality Percent: +30, Maximum MP: +10, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	Da Vinci's brawny petrified wood water purifier	0		Muscle Percent: +20, Experience (Mysticality): +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	bouncing inspector's Jim Carey's petrified wood whoopie panama	0		Monster Level: +25, Item Drop: +15, Last Available: "2025-12"
 11533	twirling flame-wreathed friendly petrified wood walking pants	0		Familiar Weight: +3, Hot Spell Damage: +10, Last Available: "2025-12"
 11534	denatured petrified wood waste parts	1		Effect: "Feeling No Pain", Effect Duration: 5, Last Available: "2025-12"
 11535	galvanized nitrogenated wobbly petrified wood wafer praline	0		Effect: "Stinky Hands", Effect Duration: 34
 11536	bad cybeer	3	decent	Last Available: "2025-12"
 11537	twirling ICEbox	0		Last Available: "2025-12"
-11538	bouncing wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	twirling encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	bouncing wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	twirling encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
 11541	fuchsia googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	squat aromatic lard-coated Crimbuccaneer war standard	0		Sleaze Spell Damage: +25, Stench Resistance: +1, Last Available: "2023-12"
 11544	pulsating avaricious Elf Guard war standard of Flo-Jo	0		Meat Drop: +30, Initiative: +100, Last Available: "2023-12"
-11545	twirling maroon in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	up-at-dawn flame-wreathed rock-hard spring shoes	0		Damage Reduction: 5, Hot Spell Damage: +10, Adventures: +5, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11545	maroon twirling in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
+11546	up-at-dawn flame-wreathed rock-hard spring shoes	0		Damage Reduction: 5, Hot Spell Damage: +10, Adventures: +5, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	modified triple-aerosolized skewed ultra-soft ferns	0		Effect: "In Tuna", Effect Duration: 37, Last Available: "2024-02"
 11548	irradiated shaking crunchy brush	0		Effect: "Berry Statistical", Effect Duration: 44, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	blurry biphasic molecular oculus	0		No Pull
-11551	blurry bouncing triphasic molecular oculus	0		
+11551	bouncing blurry triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
 11553	ultra-high-tension exoskeleton	0		
 11554	spinning irresponsible-tension exoskeleton	0		
 11555	maroon quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
-11557	twirling spinning quick-release utility belt	0		Single Equip
+11557	spinning twirling quick-release utility belt	0		Single Equip
 11558	wobbly cool motion sensor	0		Moxie: +5, Single Equip
 11559	focused magnetron pistol	0		Single Equip
 11560	shaking packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
@@ -11428,10 +11428,10 @@
 11573	small stale yam	2	decent	Last Available: "2024-05"
 11574	tolerable watered-down yam martini	2	good	Last Available: "2024-05"
 11575	hand-crafted sweet potato o' mine	3	EPIC	Last Available: "2024-05"
-11576	special tolerable watered-down Southern yam	2	good	Effect: "Drenched With Filth", Effect Duration: 15, Last Available: "2024-05"
+11576	special watered-down tolerable Southern yam	2	good	Effect: "Drenched With Filth", Effect Duration: 15, Last Available: "2024-05"
 11577	acceptable sweet potato punch	4	good	Last Available: "2024-05"
 11578	rotten Mayam spinach	3	crappy	Last Available: "2024-05"
-11579	moldy miniature twirling yam and swiss	2	crappy	Last Available: "2024-05"
+11579	miniature moldy twirling yam and swiss	2	crappy	Last Available: "2024-05"
 11580	maroon therapeutic supercool Rosewater's yam cannon	0		Mysticality Percent: +30, Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-05"
 11581	shaking ghostly yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	blinking yam battery	0		Last Available: "2024-05"
@@ -11439,13 +11439,13 @@
 11584	nippy furry yam buckler of the pedagogue of the businessman	0		Experience: +3, Cold Damage: +10, Meat Drop: +50, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	double-paned clever yamtility belt of the ox	0		Muscle: +20, Maximum MP: +20, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2024-05"
-11587	huge flavorless blurry yam slider	6	decent	Last Available: "2024-05"
+11587	flavorless huge blurry yam slider	6	decent	Last Available: "2024-05"
 11588	fancy spoiled shaking yam mayo	3	crappy	Effect: "Techno Bliss", Effect Duration: 35, Last Available: "2024-05"
-11589	super-sized flavorless yam burrito	5	decent	Last Available: "2024-05"
+11589	flavorless super-sized yam burrito	5	decent	Last Available: "2024-05"
 11590	skewed visual packet sniffer	0		Last Available: "2025-12"
 11591	narrow mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	jittery aviator goggles	0		
-11593	pulsating squat Thwaitgold Illinigina illinoiensis model	0		
+11593	squat pulsating Thwaitgold Illinigina illinoiensis model	0		
 11594	spoiled mini kiwi	3	crappy	Last Available: "2024-06"
 11595	therapeutic stiffened mini kiwi bikini of terror	0		Damage Reduction: 1, Spooky Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-06"
 11596	aged mini kiwitini	3	awesome	Last Available: "2024-06"
@@ -11456,12 +11456,12 @@
 11601	big normal mini kiwi digitized cookies	5	good	
 11602	artisanal skewed mini kiwi intoxicating spirits	3	EPIC	
 11603	extra-electrified colloidal activated mini kiwi antimilitaristic hippy petition	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 34
-11604	electrified mirror squat mini kiwi illicit antibiotic	0		Effect: "Inappropriate Spirit", Effect Duration: 48
+11604	electrified squat mirror mini kiwi illicit antibiotic	0		Effect: "Inappropriate Spirit", Effect Duration: 48
 11605	family-friendly slick mini kiwi whipping stick	0		Moxie: +10, Sleaze Resistance: +1
 11606	huge chilly mini kiwi icepick	0		Cold Damage: +5
-11607	unsweetened pressed adjusted spinning fuchsia mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Flamibili Tea", Effect Duration: 26
+11607	unsweetened pressed adjusted fuchsia spinning mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Flamibili Tea", Effect Duration: 26
 11608	cyan packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	cyan protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	shaking protogenetic chunklet (flagellum)	0		
@@ -11470,8 +11470,8 @@
 11615	fuchsia foul-smelling frosty messenger bag RNA of doom	0		Cold Spell Damage: +10, Stench Damage: +10, Spooky Spell Damage: +50
 11616	tumbling flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	decent low-calorie bacteria bisque	1	good	
-11619	massive rotten olive tumbling ciliophora chowder	9	crappy	
+11618	low-calorie decent bacteria bisque	1	good	
+11619	rotten massive tumbling olive ciliophora chowder	9	crappy	
 11620	spoiled cream of chloroplasts	4	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11487,7 +11487,7 @@
 11632	Doll Moll violin case	0		
 11633	ghostly Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	mediocre high-proof Colera Peste Nebbiolo	10	decent	
+11635	high-proof mediocre Colera Peste Nebbiolo	10	decent	
 11636	purple longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11496,7 +11496,7 @@
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	blue Sept-Ember Censer	0		Last Available: "2024-09"
 11643	shaking lime green smooth blade of dismemberment	0		Moxie: +15, Lasts Until Rollover, Last Available: "2024-09"
-11644	maroon twirling Embering Hulk	0		Last Available: "2024-09"
+11644	twirling maroon Embering Hulk	0		Last Available: "2024-09"
 11645	huge Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
 11646	blinking Septapus summoning charm	0		Last Available: "2024-09"
 11647	huge structural ember	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	jittery soft cap of diminishing returns	0		
 11656	shaking photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	knitted bat wings of temperance of the early riser	0		Cold Resistance: +3, Sleaze Resistance: +5, Adventures: +7, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	knitted bat wings of temperance of the early riser	0		Cold Resistance: +3, Sleaze Resistance: +5, Adventures: +7, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ghostly ember	0		Cold Resistance: +1
 11661	stiffened Newton's monocle on a stick	0		Experience (Mysticality): +3, Damage Reduction: 1, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,11 +11523,11 @@
 11668	therapeutic Sheriff badge of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	Sheriff pistol of the brazier of the overflowing toilet	0		Hot Spell Damage: +25, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-10"
 11670	lightning-fast avaricious Sheriff moustache	0		Meat Drop: +30, Initiative: +40, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	wizardly photo booth supply list of James Dean	0		Mysticality: +25, Experience (Moxie): +3, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	wizardly photo booth supply list of James Dean	0		Mysticality: +25, Experience (Moxie): +3, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	tumbling peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	upside-down tie-dye headband	0		
 11674	flavorless whirled peas	4	decent	Last Available: "2024-11"
-11675	moldy half-sized peaza	2	crappy	Last Available: "2024-11"
+11675	half-sized moldy peaza	2	crappy	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	dried shaking drenchrome 2.0	1		Last Available: "2025-12"
 11678	boiled green Synapse Blaster	1		Last Available: "2025-12"
@@ -11541,12 +11541,12 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	blue TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	pulsating smooth deft pirate hook of the brazier	0		Moxie: +15, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
-11689	sage iron tricorn hat of Gandalf	0		Mysticality Percent: +10, Spell Critical Percent: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	sage iron tricorn hat of Gandalf	0		Mysticality Percent: +10, Spell Critical Percent: +20, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	lion tamer's jolly roger flag	0		Experience (familiar): +2, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	wobbly pirrrate's currrse	0		Last Available: "2024-12"
-11693	lousy watered-down enchanted tankard of spiced rum	2	decent	Effect: "L'instinct F&eacute;lin", Effect Duration: 10, Last Available: "2024-12"
-11694	tolerable watered-down spinning tankard of spiced Goldschlepper	2	good	Last Available: "2024-12"
+11693	enchanted watered-down lousy tankard of spiced rum	2	decent	Effect: "L'instinct F&eacute;lin", Effect Duration: 10, Last Available: "2024-12"
+11694	watered-down tolerable spinning tankard of spiced Goldschlepper	2	good	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	skewed groovy governor's daughter's lace collar	0		Moxie Percent: +10, Last Available: "2024-12"
 11697	steel-toed governor's daughter's petticoats	0		Damage Reduction: 9, Last Available: "2024-12"
@@ -11576,14 +11576,14 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	low-calorie stale coney haunch	1	decent	Last Available: "2024-12"
 11723	boiled bouncing dark chocolate egg	0		Effect: "Steroid Boost", Effect Duration: 51, Last Available: "2024-12"
-11724	extra-dry smooth moai toai	5	awesome	
+11724	smooth extra-dry moai toai	5	awesome	
 11725	Annie Oakley's occult moaiball of the bloodbag	0		Spell Damage Percent: +25, Maximum HP: +100, Critical Hit Percent: +20, Last Available: "2024-12"
 11726	yellow half-digested rat	0		Last Available: "2024-12"
 11727	boiled jittery four-leaf potato sprout	0		Effect: "Wintry Breath", Effect Duration: 65, Last Available: "2024-12"
 11728	gravedigger's beefcake's potato jacket of the overflowing toilet	0		Muscle: +25, Stench Spell Damage: +50, Spooky Damage: +10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	twirling Brandonian footlocker key	0		Last Available: "2024-12"
-11731	military orb of the boozehound of the glutton	0		Booze Drop: +100, Food Drop: +100, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	military orb of the boozehound of the glutton	0		Booze Drop: +100, Food Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	frozen rum ball	0		Effect: "Litterboxing", Effect Duration: 45
 11733	spinning gravy skin	0		Last Available: "2024-12"
 11734	inspector's Tesla gravyskin hat	0		Item Drop: +15, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12"
@@ -11591,23 +11591,23 @@
 11736	family-friendly smartaleck's gravyskin skirt	0		Moxie Percent: +30, Sleaze Resistance: +1, Last Available: "2024-12"
 11737	pulsating bouncing Lo Pan's gravyskin pants of mayonnaise	0		Spell Critical Percent: +30, Sleaze Spell Damage: +50, Last Available: "2024-12"
 11738	oxidized irradiated energized blurry crystallized pumpkin spice	0		Effect: "Mortarfied", Effect Duration: 30, Last Available: "2024-12"
-11739	spoiled miniature room scale bean casserole	2	crappy	Last Available: "2024-12"
+11739	miniature spoiled room scale bean casserole	2	crappy	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	deadly Samson's perfect Christmas scarf of the pedagogue	0		Experience: [+3*event(December)], Experience (Muscle): [+5*event(December)], Weapon Damage: [+5*event(December)], Single Equip, Last Available: "2024-12"
-11743	cyan upside-down Jim Carey's snowman-enchanting tophat of the businessman	0		Monster Level: +25, Meat Drop: +50, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	cyan upside-down Jim Carey's snowman-enchanting tophat of the businessman	0		Monster Level: +25, Meat Drop: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	diffused moist LIDAR candle	0		Effect: "Afternoon Insight", Effect Duration: 41, Last Available: "2024-12"
 11745	Jeselnik's Sinatra's stylish Congressional Medal of Insanity	0		Moxie: +25, Experience (Moxie): +5, Sleaze Damage: +25, Last Available: "2024-12"
 11746	spinning pumpkin spice whorl	0		Last Available: "2024-12"
-11747	weak fancy lousy Easter grasshopper	2	decent	Effect: "Raging Animal", Effect Duration: 20, Last Available: "2024-12"
-11748	drinkable enchanted Irish eggnog	3	good	Effect: "Inner Warmth", Effect Duration: 15, Last Available: "2024-12"
+11747	lousy fancy weak Easter grasshopper	2	decent	Effect: "Raging Animal", Effect Duration: 20, Last Available: "2024-12"
+11748	enchanted drinkable Irish eggnog	3	good	Effect: "Inner Warmth", Effect Duration: 15, Last Available: "2024-12"
 11749	tolerable canteen of jungle juice	4	good	Last Available: "2024-12"
-11750	hand-crafted spinning maroon turchucken	3	EPIC	Last Available: "2024-12"
+11750	hand-crafted maroon spinning turchucken	3	EPIC	Last Available: "2024-12"
 11751	delicious wobbly ghostly mechanically-mulled cider	3	awesome	Last Available: "2024-12"
-11752	hand-crafted weak holiday trip around the world	2	super ultra mega turbo EPIC	Last Available: "2024-12"
+11752	weak hand-crafted holiday trip around the world	2	super ultra mega turbo EPIC	Last Available: "2024-12"
 11753	adequate chocolate ostrich egg	4	good	Last Available: "2024-12"
 11754	bland beef and cabbage	3	decent	Last Available: "2024-12"
-11755	super-sized rotten candy rations	5	crappy	Last Available: "2024-12"
+11755	rotten super-sized candy rations	5	crappy	Last Available: "2024-12"
 11756	moldy narrow double-candied yams	3	crappy	Last Available: "2024-12"
 11757	decent Christmas ham	3	good	Last Available: "2024-12"
 11758	spoiled holiday smorgasbord	3	crappy	Last Available: "2024-12"
@@ -11617,38 +11617,38 @@
 11762	upside-down Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	twirling tumbling Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11765	tumbling twirling Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	maroon Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	bouncing teal moai statuette	0		Last Available: "2024-12"
-11772	Jim Carey's egg gun of the ox of the wise owl of bravery	0		Muscle: +20, Mysticality: +20, Monster Level: +25, Spooky Resistance: +5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	Jim Carey's egg gun of the ox of the wise owl of bravery	0		Muscle: +20, Mysticality: +20, Monster Level: +25, Spooky Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	wobbly army helmet of the bloodbag of the sewer of courage of temperance	0		Maximum HP: +100, Stench Damage: +25, Spooky Resistance: +3, Sleaze Resistance: +5, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	squat napkin	0		Last Available: "2024-12"
 11776	rotten small twirling Thanksgiving ration	2	crappy	Last Available: "2024-12"
-11777	weak acceptable Easter eggnog	2	good	Last Available: "2024-12"
+11777	acceptable weak Easter eggnog	2	good	Last Available: "2024-12"
 11778	altered clovermint	1		Last Available: "2024-12"
 11779	Jeselnik's smartaleck's nylon Christmas stockings of chilblains of the overflowing toilet	0		Moxie Percent: +30, Cold Damage: +25, Stench Spell Damage: +50, Sleaze Damage: +25, Single Equip, Last Available: "2024-12"
 11780	mirror tattoo of two turkeys	0		Last Available: "2024-12"
-11781	chilled frozen ionized yellow upside-down deviled candy egg	0		Effect: "You Know What's Up", Effect Duration: 33, Last Available: "2024-12"
+11781	chilled frozen ionized upside-down yellow deviled candy egg	0		Effect: "You Know What's Up", Effect Duration: 33, Last Available: "2024-12"
 11782	blurry McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	bouncing aromatic Samson's McHugeLarge duffel bag	0		Experience (Muscle): +5, Stench Resistance: +1, Last Available: "2025-01"
-11784	executive smelly sizzling McHugeLarge left pole	0		Hot Damage: +10, Stench Spell Damage: +10, Meat Drop: +40, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	flame-retardant Da Vinci's McHugeLarge right pole of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	jittery wobbly ribald Lo Pan's McHugeLarge left ski	0		Spell Critical Percent: +30, Sleaze Damage: +10, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	blurry ghostly coward's arcane researcher's McHugeLarge right ski	0		Experience Percent (Mysticality): +10, Monster Level: -20, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	executive smelly sizzling McHugeLarge left pole	0		Hot Damage: +10, Stench Spell Damage: +10, Meat Drop: +40, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	flame-retardant Da Vinci's McHugeLarge right pole of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Hot Resistance: +1, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	jittery wobbly ribald Lo Pan's McHugeLarge left ski	0		Spell Critical Percent: +30, Sleaze Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	blurry ghostly coward's arcane researcher's McHugeLarge right ski	0		Experience Percent (Mysticality): +10, Monster Level: -20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	jittery 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
-11790	dried wobbly gray eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11790	dried gray wobbly eXpand	1		Last Available: "2025-12"
+11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	yellow datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	upside-down shaking dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	bouncing dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
-11796	ghostly purple dedigitizer schematic: digibritches	0		Last Available: "2025-12"
+11796	purple ghostly dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	shaking dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	huge retro floppy disk	0		Last Available: "2025-12"
 11805	squat pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	green 3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	jittery mirror hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	narrow geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	fuchsia ninja rope	0		
@@ -11706,7 +11706,7 @@
 11851	pulsating stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
-11854	mirror blinking grim cellophane	0		Combat Rate: -5
+11854	blinking mirror grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
 11856	spinning sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
@@ -11714,28 +11714,28 @@
 11859	squat mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	olive Leprecondo	0		Last Available: "2025-03"
-11862	mixed lime green tumbling jittery scoop of pre-workout powder	1		Last Available: "2025-03"
+11862	mixed tumbling jittery lime green scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	lousy weak pint of Leprechaun Stout	2	decent	Last Available: "2025-03"
-11865	pickled maroon tumbling bouncing phosphor traces	1		Last Available: "2025-03"
+11865	pickled bouncing tumbling maroon phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	gray spoon	0		
 11869	spinning blue unironic knife	0		
-11870	blurry tumbling bar dart	0		Last Available: "2025-03"
+11870	tumbling blurry bar dart	0		Last Available: "2025-03"
 11871	boiled leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	small adequate upside-down Heck ramen	2	good	Last Available: "2025-03"
+11872	adequate small upside-down Heck ramen	2	good	Last Available: "2025-03"
 11873	tasty burrito	4	awesome	Last Available: "2025-03"
 11874	decent special small beer brat	4	good	Effect: "Liquidy Smoky", Effect Duration: 45, Last Available: "2025-03"
 11875	jumbo bland peach pie	5	decent	Last Available: "2025-03"
 11876	stale mirror incredible mini-pizza	3	decent	Last Available: "2025-03"
-11877	weak special mediocre Divine sidecar	2	decent	Effect: "Crying, Dying", Effect Duration: 10, Last Available: "2025-03"
+11877	mediocre weak special Divine sidecar	2	decent	Effect: "Crying, Dying", Effect Duration: 10, Last Available: "2025-03"
 11878	weak acceptable tangarita sidecar	2	good	Last Available: "2025-03"
 11879	aged blinking gimlet sidecar	3	awesome	Last Available: "2025-03"
 11880	hand-crafted vodka stratocaster sidecar	3	EPIC	Last Available: "2025-03"
-11881	acceptable weak prussian cathouse sidecar	2	good	Last Available: "2025-03"
+11881	weak acceptable prussian cathouse sidecar	2	good	Last Available: "2025-03"
 11882	mediocre upside-down Mon Tiki sidecar	3	decent	Last Available: "2025-03"
-11883	tumbling cyan Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
+11883	cyan tumbling Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	ruddy rosy-cheeked April Shower Thoughts shield	0		Maximum HP Percent: 70, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	gray baleful stylish bycocket	0		Spell Damage: +25
 11917	maroon Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	wobbly Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11780,7 +11780,7 @@
 11925	cyan mansplainer's Axis fatigues of the overflowing toilet	0		Monster Level: +15, Stench Spell Damage: +50
 11926	supercharged Axis suspenders of temperance	0		Maximum MP Percent: +30, Sleaze Resistance: +5, Single Equip
 11927	skewed stolen artifact	0		
-11928	upside-down narrow shaking really expensive stolen artifact	0		
+11928	narrow upside-down shaking really expensive stolen artifact	0		
 11929	lime green priceless stolen artifact	0		
 11930	upside-down chocolate rations	0		
 11931	tumbling nice nylon stockings	0		
@@ -11790,7 +11790,7 @@
 11935	ordnance magnet	0		Single Equip
 11936	narrow confetti grenade	0		
 11937	bland immense Skeleton Wars rations	10	decent	
-11938	lousy watered-down skeleton war fuel can	2	decent	
+11938	watered-down lousy skeleton war fuel can	2	decent	
 11939	twirling skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	shaking M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11826,16 +11826,16 @@
 11972	durable dolphin whistle	0		
 11973	skewed Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	dentadent of wisdom	0		Mysticality: +15
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	spinning prompt miser's inspector's rock-hard padded Sinatra's blood cubic zirconia	0		Experience (Moxie): +5, Damage Absorption: +20, Damage Reduction: 5, Item Drop: +15, Meat Drop: +10, Adventures: +3, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	spinning prompt miser's inspector's rock-hard padded Sinatra's blood cubic zirconia	0		Experience (Moxie): +5, Damage Absorption: +20, Damage Reduction: 5, Item Drop: +15, Meat Drop: +10, Adventures: +3, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	powdered blood thinner	1		Last Available: "2025-10"
 12045	hand-crafted teal pheromone cocktail	3	EPIC	Last Available: "2025-10"
 12046	decent twirling spinal tapas	4	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	steel-toed shrunken head of wisdom of dire peril	0		Mysticality: +15, Weapon Damage: +20, Damage Reduction: 9, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	steel-toed shrunken head of wisdom of dire peril	0		Mysticality: +15, Weapon Damage: +20, Damage Reduction: 9, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	bouncing stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
@@ -11843,10 +11843,10 @@
 12053	moldy prize turkey	3	crappy	
 12054	twisted narrow medicinal gruel	1		
 12055	flavorless teal full-sized pumpkin pie	4	decent	Last Available: "2025-11"
-12056	irresponsibly strong bad vodka cranberry sauce	8	decent	Last Available: "2025-11"
+12056	bad irresponsibly strong vodka cranberry sauce	8	decent	Last Available: "2025-11"
 12057	nitrogenated extra-pressed yammed candy	0		Effect: "Bats in the Belfry", Effect Duration: 34, Last Available: "2025-11"
-12058	adequate jumbo treasure chestnut	5	good	Last Available: "2025-12"
-12059	lousy weak huge mulled butter rum	2	decent	Last Available: "2025-12"
+12058	jumbo adequate treasure chestnut	5	good	Last Available: "2025-12"
+12059	weak lousy huge mulled butter rum	2	decent	Last Available: "2025-12"
 12060	galvanized blurry cinnamon doubloon	0		Effect: "Fishy", Effect Duration: 14, Last Available: "2025-12"
 12061	dog trainer's plastic left skeleton arm	0		Experience (familiar): +1, Last Available: "2025-12"
 12062	fireproof plastic left skeleton leg	0		Hot Resistance: +3, Last Available: "2025-12"
@@ -11869,7 +11869,7 @@
 12079	devilbone corset of the pedagogue	0		Experience: +3, Last Available: "2026-12"
 12080	occult smartaleck's devilbone flute	0		Moxie Percent: +30, Spell Damage Percent: +25, Last Available: "2026-12"
 12081	devilbone rosary of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2026-12"
-12082	denatured pulsating spinning devilbone chunks	1		Effect: "Cold Throat", Effect Duration: 40, Last Available: "2026-12"
+12082	denatured spinning pulsating devilbone chunks	1		Effect: "Cold Throat", Effect Duration: 40, Last Available: "2026-12"
 12083	frozen Gehenna tattoo	0		Effect: "Abyssal Sweat", Effect Duration: 55
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	squat Crymbocurrency	0		Last Available: "2025-12"
 12122	Sherlock's extra-thick Crimbo sweater	0		Item Drop: +25, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	special delicious triple-distilled Steve Abrams' Holiday Sampler Beer	8	awesome	Effect: "Human-Undead Hybrid", Effect Duration: 50, Last Available: "2025-12"
+12124	special triple-distilled delicious Steve Abrams' Holiday Sampler Beer	8	awesome	Effect: "Human-Undead Hybrid", Effect Duration: 50, Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	artisanal bottle of prize-winning rum	3	EPIC	Last Available: "2025-12"
 12127	frosty veiny Rosewater's Santa-Slayer medal	0		Mysticality Percent: +30, Maximum HP: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	super-moist galvanized boiling synovial fluid	0		Effect: "Takin' It Greasy", Effect Duration: 50, Last Available: "2025-12"
 12132	olive shellacked smartaleck's smoldering vertebra of the scaredy-cat	0		Moxie Percent: +30, Damage Reduction: 7, Monster Level: -15, Single Equip, Last Available: "2025-12"
 12133	green seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	miser's Van der Graaf shellacked hot boning knife	0		Damage Reduction: 7, Meat Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
@@ -11897,7 +11897,7 @@
 12139	brawny burnt bone belt of the brute of the sewer	0		Muscle Percent: 50, Stench Damage: +25, Single Equip, Last Available: "2025-12"
 12140	prompt scorched skull trophy	0		Adventures: +3, Last Available: "2025-12"
 12141	normal red squat wing bone	4	good	Last Available: "2025-12"
-12142	weak mediocre teal pulsating weak skeleton venom	2	decent	Last Available: "2025-12"
+12142	mediocre weak teal pulsating weak skeleton venom	2	decent	Last Available: "2025-12"
 12143	twisted yellow baked bone meal	1		Effect: "Elvish", Effect Duration: 5, Last Available: "2025-12"
 12144	skewed arcane researcher's plastic skeleton rib cage	0		Experience Percent (Mysticality): +10, Last Available: "2025-12"
 12145	narrow deadly plastic skeleton skull	0		Weapon Damage: +5, Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	electrified crafty vermiculite shield	0		Maximum MP: +10, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 9, Last Available: "2025-12"
 12169	experienced ship's lantern	0		Experience: +2, Last Available: "2025-12"
 12170	fuchsia twirling wobbly foul-smelling heat-resistant harpoon pistol of terror	0		Stench Damage: +10, Spooky Spell Damage: +10, Last Available: "2025-12"
-12171	tasty miniature fancy traditional gingerloaf	2	awesome	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2025-12"
+12171	tasty fancy miniature traditional gingerloaf	2	awesome	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2025-12"
 12172	artisanal Scotch and eggnog	4	EPIC	Last Available: "2025-12"
 12173	warmed extra-corrupted squat counterskeleton elixir	0		Effect: "Phairly Pheromonal", Effect Duration: 66, Last Available: "2025-12"
 12174	irresponsibly strong tolerable &quot;salvaged&quot; wine	10	good	Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	denatured Vulcanized blurry gummi fingerbone	0		Effect: "Mutated", Effect Duration: 58
 12179	ruddy Socratic glimmering crystal	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11978,22 +11978,22 @@
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	narrow legendary noodles	0		Last Available: "2026-05"
 12226	moldy huge shaking can of tuna	10	crappy	
-12227	rotten gigantic alien salad	10	crappy	
-12228	decent special ratbatatouille	3	good	Effect: "Spell Transfer Complete", Effect Duration: 50
+12227	gigantic rotten alien salad	10	crappy	
+12228	special decent ratbatatouille	3	good	Effect: "Spell Transfer Complete", Effect Duration: 50
 12229	stale cyan onigiri	3	decent	
-12230	moldy fancy crudit&eacute;s	4	crappy	Effect: "Morninja", Effect Duration: 5
+12230	fancy moldy crudit&eacute;s	4	crappy	Effect: "Morninja", Effect Duration: 5
 12231	moldy sauced mutton	3	crappy	
 12232	delicious jittery hot honey ant	3	awesome	
 12233	adequate tomb aspic	4	good	
 12234	moldy spinning later tots	3	crappy	
-12235	adequate massive upside-down Frutti di Scatoletta	7	good	Last Available: "2026-05"
+12235	massive adequate upside-down Frutti di Scatoletta	7	good	Last Available: "2026-05"
 12236	normal Pesto alla Marziano	4	good	Last Available: "2026-05"
 12237	decent thick Arrattabbattabiata	5	good	Last Available: "2026-05"
 12238	half-sized stale Orzo di Riso	2	decent	Last Available: "2026-05"
 12239	delicious Pasta Grimavera	3	awesome	Last Available: "2026-05"
 12240	bland Linguini Ubriacapa	3	decent	Last Available: "2026-05"
 12241	moldy squat Formica e Pepe	4	crappy	Last Available: "2026-05"
-12242	super-sized toothsome Tubetto Gelatto	5	awesome	Last Available: "2026-05"
+12242	toothsome super-sized Tubetto Gelatto	5	awesome	Last Available: "2026-05"
 12243	bland Gnocci Domani	4	decent	Last Available: "2026-05"
 12244	lime green Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12017,27 +12017,27 @@
 12267	blue flimsy plastic breastplate of dire peril	0		Weapon Damage: +20
 12268	tumbling rosewater-soaked flimsy plastic shield	0		Stench Resistance: +3, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	scandalous chilly lion tamer's Portable Laughing Stock	0		Experience (familiar): +2, Cold Damage: +5, Sleaze Damage: +5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	scandalous chilly lion tamer's Portable Laughing Stock	0		Experience (familiar): +2, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	flame-wreathed Staff of Anachronistic Churning of Calamity Jane of terror	0		Critical Hit Percent: +15, Hot Spell Damage: +10, Spooky Spell Damage: +10
 12272	normal classic banana	3	good	Last Available: "2026-07"
 12273	bland purple watermelon	3	decent	Last Available: "2026-07"
-12274	stale immense blurry quince	6	decent	Last Available: "2026-07"
+12274	immense stale blurry quince	6	decent	Last Available: "2026-07"
 12275	squat Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	flavorless classic banana pie	3	decent	Last Available: "2026-07"
 12278	flattened essential banana decoction	0		Effect: "Sepia Tan", Effect Duration: 63, Last Available: "2026-07"
 12279	altered activated banana quintessence	0		Effect: "Dweeby", Effect Duration: 33, Last Available: "2026-07"
-12280	lousy lime green skewed Aesop Daiquiri	3	decent	Last Available: "2026-07"
+12280	lousy skewed lime green Aesop Daiquiri	3	decent	Last Available: "2026-07"
 12281	hand-crafted Monkey Congress	4	EPIC	Last Available: "2026-07"
 12282	moldy olive watermelon pie	4	crappy	Last Available: "2026-07"
 12283	wet irradiated teal skewed concentrated watermelon juice	0		Effect: "License to Punch", Effect Duration: 39, Last Available: "2026-07"
 12284	tarnished concentrated Aqua Citrulanatae	0		Effect: "Kernel Panic!", Effect Duration: 64, Last Available: "2026-07"
 12285	mediocre Melonegroni	3	decent	Last Available: "2026-07"
 12286	lousy huge Melonade Spritz	4	decent	Last Available: "2026-07"
-12287	snack-sized rotten spinning blinking quince pie	2	crappy	Last Available: "2026-07"
+12287	rotten snack-sized blinking spinning quince pie	2	crappy	Last Available: "2026-07"
 12288	vacuum-sealed cold-filtered green quince quaff	0		Effect: "Slippery Tongue", Effect Duration: 69, Last Available: "2026-07"
 12289	ionized green huge Quickquince	0		Effect: "Amorous", Effect Duration: 15, Last Available: "2026-07"
-12290	bad twirling lime green Quiskey Sour	4	decent	Last Available: "2026-07"
+12290	bad lime green twirling Quiskey Sour	4	decent	Last Available: "2026-07"
 12291	smooth Quincea&ntilde;era Cooler	3	awesome	Last Available: "2026-07"
 12292	drinkable Roth IPA	3	good	Last Available: "2026-08"
 12293	bouncing fuchsia foul-smelling savvy underdraft protection	0		Mysticality Percent: +20, Stench Damage: +10, Last Available: "2026-08"
@@ -12060,5 +12060,5 @@
 12310	denatured twirling toxic asset	1		Last Available: "2026-08"
 12311	boiled intangible asset	1		Last Available: "2026-08"
 12312	dehydrated jittery upside-down liquid asset	1		Last Available: "2026-08"
-12313	skewed narrow gross prophet chrysalis	0		Last Available: "2026-08"
+12313	narrow skewed gross prophet chrysalis	0		Last Available: "2026-08"
 12314	red cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Disco_Bandit_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Packrat_cafe_booze.txt
@@ -1,31 +1,31 @@
--1	enchanted perfectly mixed practically non-alcoholic purple Petite Porter	1	EPIC	
+-1	practically non-alcoholic perfectly mixed enchanted purple Petite Porter	1	EPIC	
 -2	acceptable Scrawny Stout	3	good	
 -3	drinkable Infinitesimal IPA	4	good	
 -4	drinkable eggnogtini	4	good	
 -5	bad cyan candycaine	3	decent	
 -6	bad squat braincracker sweet	3	decent	
--16	distilled enchanted artisanal narrow fermented honey	5	EPIC	
+-16	artisanal enchanted distilled narrow fermented honey	5	EPIC	
 -17	drinkable skewed moons-shine	3	good	
 -18	artisanal gin	4	EPIC	
--19	lousy practically non-alcoholic mirror ecto-nog	1	decent	
+-19	practically non-alcoholic lousy mirror ecto-nog	1	decent	
 -20	drinkable mirror hot toady	4	good	
--21	special aged high-proof purple hot choculate	9	awesome	
+-21	special high-proof aged purple hot choculate	9	awesome	
 -49	acceptable Cyder	4	good	
--50	hand-crafted practically non-alcoholic fuchsia shaking Oil Nog	1	EPIC	
+-50	hand-crafted practically non-alcoholic shaking fuchsia Oil Nog	1	EPIC	
 -51	delicious squat Hi-Octane Peppermint Jet Fuel	3	awesome	
 -58	drinkable Grimacider	3	good	
 -59	watered-down lousy Isotope Nog	2	decent	
 -60	bad watered-down spinning Mutagin 'n' Tonic	2	decent	
 -70	bad Gin and Herring	3	decent	
--71	boozy hand-crafted Black and Tan and Red All Over	5	EPIC	
+-71	hand-crafted boozy Black and Tan and Red All Over	5	EPIC	
 -72	bad Antarctic Ice Tea	3	decent	
 -76	mediocre CRIMBCO Ribbon Candy Schnapps	3	decent	
--77	perfectly mixed high-proof CRIMBCO Egg Substitute Nog Substitute	6	EPIC	
--78	smooth fortified CRIMBCO Extreme Braincracker Sour	5	awesome	
+-77	high-proof perfectly mixed CRIMBCO Egg Substitute Nog Substitute	6	EPIC	
+-78	fortified smooth CRIMBCO Extreme Braincracker Sour	5	awesome	
 -82	perfectly mixed distilled Horseradish-infused Vodka	5	EPIC	
--83	lousy watered-down squat Jerkitini	2	decent	
+-83	watered-down lousy squat Jerkitini	2	decent	
 -84	practically non-alcoholic artisanal cyan Desert Island Iced Tea	1	EPIC	
--88	acceptable high-proof blurry Crimbo Saketini	6	good	
+-88	high-proof acceptable blurry Crimbo Saketini	6	good	
 -89	tolerable Crimboku Drop	3	good	
 -90	bad Flaming Crimbo Log	3	decent	
 -107	special lousy boozy Fortified Eggnog Slurry	5	decent	

--- a/data/TCRS/TCRS_Disco_Bandit_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Packrat_cafe_food.txt
@@ -1,16 +1,16 @@
--1	decent tiny purple Peche a la Frog	1	good	
+-1	tiny decent purple Peche a la Frog	1	good	
 -2	bland As Jus Gezund Heit	3	decent	
 -3	stale Bouillabaise Coucher Avec Moi	4	decent	
 -7	decent gumdrop chow mein	4	good	
--8	spoiled half-sized huge candy cane pizza	2	crappy	
+-8	half-sized spoiled huge candy cane pizza	2	crappy	
 -9	adequate gingerbread stir-fry	4	good	
 -10	jumbo decent twigs and gravel	5	good	
 -11	moldy big upside-down shoots and leaves	5	crappy	
 -12	rotten bowl of unidentifiable goo	4	crappy	
--13	diet stale gingerbread massacre	1	decent	
+-13	stale diet gingerbread massacre	1	decent	
 -14	miniature decent ghostly maroon It Came From Beyond Dessert	2	good	
 -15	decent vampire cake	3	good	
--52	small delicious blinking Soylent Red and Green	2	awesome	
+-52	delicious small blinking Soylent Red and Green	2	awesome	
 -53	toothsome Disc-Shaped Nutrition Unit	3	awesome	
 -54	fancy delicious Gingerborg Hive	3	awesome	
 -61	rotten Candy Cane Surprise	3	crappy	
@@ -24,22 +24,22 @@
 -75	rotten CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	crappy	
 -79	normal skewed Brussels Sprout Stir-Fry	3	good	
 -80	moldy Carrot, Cabbage, and Kale Pizza	4	crappy	
--81	spoiled low-calorie ghostly Turnip and Rutabaga Pie	1	crappy	
+-81	low-calorie spoiled ghostly Turnip and Rutabaga Pie	1	crappy	
 -85	stale Rainbow Spider Fun Roll	3	decent	
 -86	gigantic decent wobbly Vegas Volcano Lava Roll	8	good	
--87	big fancy adequate Crazy Dragon Shogun Buddha Roll	5	good	
+-87	big adequate fancy Crazy Dragon Shogun Buddha Roll	5	good	
 -92	tasty low-calorie basic hot dog	1	awesome	
 -93	moldy savage macho dog	4	crappy	
 -94	moldy small wobbly one with everything	2	crappy	
 -95	yummy sly dog	3	awesome	
--96	half-sized adequate purple devil dog	2	good	
--97	flavorless immense chilly dog	9	decent	
+-96	adequate half-sized purple devil dog	2	good	
+-97	immense flavorless chilly dog	9	decent	
 -98	spoiled narrow blue ghost dog	4	crappy	
--99	flavorless fancy blinking junkyard dog	3	decent	
+-99	fancy flavorless blinking junkyard dog	3	decent	
 -100	flavorless twirling wet dog	3	decent	
 -101	special snack-sized delicious sleeping dog	2	awesome	
 -102	bland optimal dog	3	decent	
--103	rotten tiny video games hot dog	1	crappy	
+-103	tiny rotten video games hot dog	1	crappy	
 -104	immense special moldy Peppermint Nutrition Block	7	crappy	
--105	half-sized normal Gingerbread Nutrition Block	2	good	
--106	tiny normal Cinnamon Nutrition Block	1	good	
+-105	normal half-sized Gingerbread Nutrition Block	2	good	
+-106	normal tiny Cinnamon Nutrition Block	1	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Platypus.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Platypus.txt
@@ -13,7 +13,7 @@
 14	distilled moxie weed	1		
 15	modified huge strongness elixir	1		
 16	distilled blurry mirror magicalness-in-a-can	1		
-17	normal low-calorie noodles	1	good	
+17	low-calorie normal noodles	1	good	
 18	lime green tortoise's blessing	0		
 19	hardened asparagus knife	0		Damage Reduction: 3
 20	twirling green Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -23,7 +23,7 @@
 24	ten-leaf clover	0		
 25	bouncing meat paste	0		
 26	Dolphin King's map	0		
-27	upside-down blurry spider web	0		
+27	blurry upside-down spider web	0		
 28	really spider web	0		
 29	really really spider web	0		
 30	rock	0		
@@ -42,7 +42,7 @@
 43	twirling worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
-46	lime green squat figurine	0		
+46	squat lime green figurine	0		
 47	rotten special pulsating hot buttered roll	4	crappy	Effect: "Pasty", Effect Duration: 10
 48	heart of rock and roll	0		
 49	spoiled bowl of cottage cheese	4	crappy	
@@ -57,9 +57,9 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	cyan mirror Mace of the Tortoise of the blizzard	0		Cold Spell Damage: +25, Class: "Turtle Tamer"
-61	spoiled big fortune cookie	5	crappy	
+61	big spoiled fortune cookie	5	crappy	
 62	family-friendly oriole-feather headdress	0		Sleaze Resistance: +1, Familiar Effect: "atk, 3xVolley, cap 3"
-63	upside-down jittery action figure body	0		
+63	jittery upside-down action figure body	0		
 64	action figure head	0		
 65	Mighty Bjorn action figure	0		
 66	twirling twig	0		
@@ -69,7 +69,7 @@
 70	shaking bar skin	0		
 71	stakes of incineration	0		Hot Spell Damage: +50
 72	careful barskin hat	0		Monster Level: -10, Familiar Effect: "atk, 1xVolley, cap 13"
-73	narrow pulsating barskin tent	0		
+73	pulsating narrow barskin tent	0		
 74	Temple map	0		
 75	sapling	0		
 76	Spooky-Gro fertilizer	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	thinker's staff of the businessman	0		Mysticality: +10, Meat Drop: +50
 104	skewed scarecrow	0		
-105	immense rotten twirling bowl of charms	7	crappy	
+105	rotten immense twirling bowl of charms	7	crappy	
 106	ketchup	1	decent	
 107	catsup	1	decent	
 108	stick	0		
@@ -142,7 +142,7 @@
 143	lime green cottage	0		
 144	stone of eXtreme power	0		
 145	barbed-wire fence	0		
-146	teal blinking dinghy plans	0		
+146	blinking teal dinghy plans	0		
 147	eXtreme meat sword of James Dean	0		Experience (Moxie): +3
 148	eXtreme meat staff of doom	0		Spooky Spell Damage: +50
 149	greasy eXtreme meat crossbow	0		Sleaze Spell Damage: +10
@@ -161,17 +161,17 @@
 162	immense flavorless ghuol egg quiche	8	decent	
 163	MacGyver's skeleton bone	0		Maximum MP: +100
 164	smart skull	0		
-165	skewed blue skewer	0		
+165	blue skewed skewer	0		
 166	spinning ghuol ears	0		
 167	adequate ghuol-ear kabob	3	good	
 168	bone rattle of the businessman	0		Meat Drop: +50
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
-170	upside-down olive lihc eye	0		
+170	olive upside-down lihc eye	0		
 171	flavorless small blurry lihc eye pie	2	decent	
 172	blinking gnoll lips	0		
 173	spinning taco shell	0		
 174	Gnollish casserole dish	0		
-175	tasty half-sized uncooked chorizo	2	awesome	
+175	half-sized tasty uncooked chorizo	2	awesome	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	teal pulsating detective skull	0		
@@ -193,9 +193,9 @@
 195	huge arcane researcher's eXtreme nose ring	0		Experience Percent (Mysticality): +10
 196	disassembled clover	0		
 197	rat whisker	0		
-198	pulsating bouncing rat appendix	0		
+198	bouncing pulsating rat appendix	0		
 199	tumbling supercool ring	0		Moxie Percent: +20
-200	stale pulsating skewed rat appendix kabob	3	decent	
+200	stale skewed pulsating rat appendix kabob	3	decent	
 201	yummy bat wing kabob	4	awesome	
 202	stale half-sized bouncing carob chunks	2	decent	
 203	herbs	0		
@@ -212,7 +212,7 @@
 214	Jeselnik's filthy knitted dread sack	0		Sleaze Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
 216	flavorless carob brownies	3	decent	
-217	low-calorie bland herb brownies	1	decent	
+217	bland low-calorie herb brownies	1	decent	
 218	squat hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -238,26 +238,26 @@
 240	jittery savvy Orcish cargo shorts of the scaredy-cat	0		Mysticality Percent: +20, Monster Level: -15, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Lo Pan's Orcish frat-paddle	0		Spell Critical Percent: +30
 242	decent	4	good	
-243	immense spoiled cyan grapefruit	10	crappy	
+243	spoiled immense cyan grapefruit	10	crappy	
 244	spoiled twirling grapes	3	crappy	
 245	huge flavorless purple skewed olive	6	decent	
 246	yummy tomato	3	awesome	
 247	mirror fermenting powder	0		
 248	artisanal salty dog	4	EPIC	
-249	enchanted drinkable bloody mary	4	good	Effect: "The Chains Down In The Belly-O", Effect Duration: 5
-250	practically non-alcoholic lousy cyan screwdriver	1	decent	
+249	drinkable enchanted bloody mary	4	good	Effect: "The Chains Down In The Belly-O", Effect Duration: 5
+250	lousy practically non-alcoholic cyan screwdriver	1	decent	
 251	artisanal fortified blinking red martini	5	EPIC	
-252	hand-crafted fortified squat bloody beer	5	EPIC	
+252	fortified hand-crafted squat bloody beer	5	EPIC	
 253	tolerable shot of schnapps	4	good	
 254	lousy shot of grapefruit schnapps	4	decent	
-255	fancy high-proof perfectly mixed fine wine	10	EPIC	Effect: "Limber as Mortimer", Effect Duration: 5
+255	perfectly mixed fancy high-proof fine wine	10	EPIC	Effect: "Limber as Mortimer", Effect Duration: 5
 256	artisanal weak fancy shot of tomato schnapps	2	EPIC	Effect: "Browbeaten", Effect Duration: 50
 257	bad watered-down extra-spicy bloody mary	2	decent	
 258	dense meat stack	0		
 259	snake skin	0		
 260	yummy fancy White Citadel fries	3	awesome	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 50
-261	thick stale White Citadel burger	5	decent	
-262	toothsome thick piece of wedding cake	5	awesome	
+261	stale thick White Citadel burger	5	decent	
+262	thick toothsome piece of wedding cake	5	awesome	
 263	decent snack-sized chocolate chips	2	good	
 264	tasty chocolate chip cookies	4	awesome	
 265	narrow huge cool satin pants	0		Moxie: +5, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -266,7 +266,7 @@
 268	clever meat cowboy hat	0		Maximum MP: +20, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	dangerous sword	0		Weapon Damage: +10
 270	picket fence	0		
-271	altered tumbling upside-down jittery barbell	1		Effect: "Amorous Avarice", Effect Duration: 45
+271	altered upside-down jittery tumbling barbell	1		Effect: "Amorous Avarice", Effect Duration: 45
 272	denatured teal concentrated magicalness pill	1		Effect: "Strong Grip", Effect Duration: 30
 273	modified moxie weed	1		
 274	upside-down jittery Familiar-Gro&trade; Terrarium	0		
@@ -295,9 +295,9 @@
 297	colloidal tamarind-flavored chewing gum	0		Effect: "Petit Forbearance", Effect Duration: 41
 298	Vulcanized lime-and-chile-flavored chewing gum	0		Effect: "Pharmaceutically Cool", Effect Duration: 45
 299	adjusted concentrated modified wobbly pickle-flavored chewing gum	0		Effect: "Frisky Spirit", Effect Duration: 14
-300	ionized vacuum-sealed yellow mirror jaba&ntilde;ero-flavored chewing gum	0		Effect: "Heavily Breathing", Effect Duration: 55
+300	ionized vacuum-sealed mirror yellow jaba&ntilde;ero-flavored chewing gum	0		Effect: "Heavily Breathing", Effect Duration: 55
 301	cyan blurry flat dough	0		
-302	toothsome small fancy pulsating Knob sausage	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 30
+302	small toothsome fancy pulsating Knob sausage	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 30
 303	normal small wobbly Knob mushroom	2	good	
 304	dry noodles	0		
 305	mirror friendly Knob Goblin harem pants	0		Familiar Weight: +3, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -309,26 +309,26 @@
 311	bouncing hill of beans	0		
 312	Knob Goblin visor of dire peril	0		Weapon Damage: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	double-paned Crown of the Goblin King	0		Cold Resistance: +5, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	small adequate bean burrito	2	good	
+314	adequate small bean burrito	2	good	
 315	spoiled low-calorie bean burrito	1	crappy	
 316	stale massive insanely bean burrito	8	decent	
 317	bland bean burrito	4	decent	
-318	huge flavorless bean burrito	8	decent	
-319	snack-sized rotten insanely bean burrito	2	crappy	
+318	flavorless huge bean burrito	8	decent	
+319	rotten snack-sized insanely bean burrito	2	crappy	
 320	spoiled bat haggis	3	crappy	
-321	enchanted big rotten menudo	5	crappy	Effect: "Nigh-Invincible", Effect Duration: 15
+321	rotten enchanted big menudo	5	crappy	Effect: "Nigh-Invincible", Effect Duration: 15
 322	normal goat cheese	3	good	
 323	yummy bouncing plain pizza	3	awesome	
-324	spoiled thick spinning sausage pizza	5	crappy	
+324	thick spoiled spinning sausage pizza	5	crappy	
 325	stale goat cheese pizza	3	decent	
 326	adequate mushroom pizza	3	good	
 327	goat	0		
-328	practically non-alcoholic lousy mirror bottle of whiskey	1	decent	
+328	lousy practically non-alcoholic mirror bottle of whiskey	1	decent	
 329	brawny goat beard	0		Muscle Percent: +20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
-331	mediocre watered-down shaking Canadian	2	decent	
-332	flavorless miniature lemon	2	decent	
-333	adequate massive skewed lime	7	good	
+331	watered-down mediocre shaking Canadian	2	decent	
+332	miniature flavorless lemon	2	decent	
+333	massive adequate skewed lime	7	good	
 334	sabre teeth of Flo-Jo	0		Initiative: +100
 335	teal sabre-toothed lime cub	0		
 336	mirror hardy consolation ribbon	0		Maximum HP: +50
@@ -353,8 +353,8 @@
 355	wholesome eXtreme scarf	0		Maximum HP Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	snowboarder pants of James Dean	0		Experience (Moxie): +3, Familiar Effect: "1xPotato, cap 25"
 357	jittery Mountain Stream soda	0		
-358	miniature stale squat gr8ps	2	decent	
-359	special decent t8r tots	4	good	Effect: "Chalky Hand", Effect Duration: 40
+358	stale miniature squat gr8ps	2	decent	
+359	decent special t8r tots	4	good	Effect: "Chalky Hand", Effect Duration: 40
 360	shaking experienced miner's helmet	0		Experience: +2, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	huge green dance instructor's miner's pants	0		Experience Percent (Moxie): +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	narrow 7-Foot Dwarven mattock of the brute	0		Muscle Percent: +30
@@ -423,7 +423,7 @@
 425	corrupted polarized oil of expertise	0		Effect: "Browbeaten", Effect Duration: 14
 426	concentrated denatured activated purple potion of temporary gr8ness	0		Effect: "The Style... of the Future", Effect Duration: 31
 427	wicked box	0		Spell Damage: +5, Wiki Name: "box"
-428	squat narrow nothing-in-the-box	0		
+428	narrow squat nothing-in-the-box	0		
 429	beanbag chair	0		
 430	jittery acid-squirting flower	0		Single Equip
 431	mirror clown shoes of the overflowing toilet	0		Stench Spell Damage: +50, Clowniness: 25
@@ -466,7 +466,7 @@
 468	ruby W	0		
 469	blurry wussiness potion	0		
 470	lousy Imp Ale	3	decent	
-471	decent low-calorie hot wing	1	good	
+471	low-calorie decent hot wing	1	good	
 472	narrow frightening diamond-studded cane	0		Spooky Damage: +5, Class: "Disco Bandit"
 473	spinning lard-coated crutch	0		Sleaze Spell Damage: +25
 474	cast	0		
@@ -498,14 +498,14 @@
 500	Elf Farm Raffle ticket	0		
 501	toothsome Elfin shortbread	3	awesome	
 502	pagoda plans	0		
-503	snack-sized toothsome skewered cat appendix	2	awesome	
+503	toothsome snack-sized skewered cat appendix	2	awesome	
 504	evil arches	0		
 505	blinking Usain Bolt's rosewater-soaked gnatwing earring	0		Stench Resistance: +3, Initiative: +80
 506	stale miniature tumbling Hell broth	2	decent	
 507	smooth thunderrr guitarrr	0		Moxie: +15
 508	squat sonata	0		
 509	tumbling Hey Deze nuts	0		
-510	purple huge Boris's key lime	0		
+510	huge purple Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	delicious Boris's key lime pie	3	awesome	
@@ -528,19 +528,19 @@
 530	polymerized maroon spray paint	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 52
 531	Herculean special sauce glove	0		Experience (Muscle): +1, Class: "Sauceror", Single Equip
 532	dog trainer's ladle of mystery	0		Experience (familiar): +1, Class: "Sauceror"
-533	twirling tumbling Gnollish toolbox	0		
+533	tumbling twirling Gnollish toolbox	0		
 534	abridged dictionary	0		
 535	bouncing bridge	0		
 536	dictionary	0		
-537	wobbly pulsating pr0n legs	0		
+537	pulsating wobbly pr0n legs	0		
 538	flame-wreathed f3d0r4	0		Hot Spell Damage: +10, Familiar Effect: "atk, 1xLep, cap 27"
 539	lowercase N	0		
-540	nitrogenated adjusted bouncing spinning Tasty Fun Good rice candy	0		Effect: "The Moxie of LOV", Effect Duration: 63
+540	nitrogenated adjusted spinning bouncing Tasty Fun Good rice candy	0		Effect: "The Moxie of LOV", Effect Duration: 63
 541	cyan clever razor-sharp draggin' ball hat	0		Weapon Damage Percent: +25, Maximum MP: +20, Familiar Effect: "atk, 1xVolley, cap 25"
 542	Jeselnik's Da Vinci's 1337 7r0uZ0RZ	0		Experience (Mysticality): +5, Sleaze Damage: +25, Familiar Effect: "2xPotato, cap 27"
 543	small bland Trollhouse cookies	2	decent	
 544	talons of dire peril of the sweet-tooth	0		Weapon Damage: +20, Candy Drop: +100
-545	rotten fancy Spam Witch sammich	3	crappy	Effect: "Square to be Hip", Effect Duration: 20
+545	fancy rotten Spam Witch sammich	3	crappy	Effect: "Square to be Hip", Effect Duration: 20
 546	meat vortex	0		
 547	334 scroll	0		
 548	narrow 668 scroll	0		
@@ -553,26 +553,26 @@
 555	horrifying steel-toed drywall axe	0		Damage Reduction: 9, Spooky Damage: +25
 556	scandalous Pine-Fresh air freshener	0		Sleaze Damage: +5
 557	weak mediocre whiskey and cola	2	decent	
-558	moldy tiny tumbling ghostly papaya taco	1	crappy	
+558	tiny moldy ghostly tumbling papaya taco	1	crappy	
 559	razor-sharp can lid	0		
 560	rotten small stalk of asparagus	2	crappy	
 561	purple pregnant mushroom	0		
 562	spinning ratgut	0		
-563	upside-down ghostly sonar-in-a-biscuit	0		
-564	bad spinning yellow Mad Train wine	3	decent	
+563	ghostly upside-down sonar-in-a-biscuit	0		
+564	bad yellow spinning Mad Train wine	3	decent	
 565	hobo gloves of the detective	0		Item Drop: +20, Single Equip
 566	skewed lion tamer's bum cheek	0		Experience (familiar): +2, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	huge green hermit script	0		
-568	huge adequate wobbly olive narrow Double Bacon Beelzeburger	6	good	
+568	huge adequate olive narrow wobbly Double Bacon Beelzeburger	6	good	
 569	adequate Lord of the Flies-sized fries	3	good	
 570	delicious Chicken Sandwich	3	awesome	
 571	Jumbo Dr. Lucifer	1	crappy	
 572	fancy normal Children's Meal of the Damned	4	good	Effect: "Human-Pirate Hybrid", Effect Duration: 40
-573	special decent mirror noodles	3	good	Effect: "Heart of White", Effect Duration: 25
+573	decent special mirror noodles	3	good	Effect: "Heart of White", Effect Duration: 25
 574	flavorless enchanted blinking noodles	4	decent	Effect: "Hairless and Airless", Effect Duration: 10
-575	decent low-calorie painful penne pasta	1	good	
+575	low-calorie decent painful penne pasta	1	good	
 576	adequate big twirling ravioli della hippy	5	good	
-577	adequate small pr0n m4nic0tti	2	good	
+577	small adequate pr0n m4nic0tti	2	good	
 578	flavorless Hell ramen	3	decent	
 579	spoiled boring spaghetti	4	crappy	
 580	sauce of the ages	0		
@@ -585,7 +585,7 @@
 587	magnetized super-spiky hair gel	0		Effect: "A Few Extra Pounds", Effect Duration: 49
 588	soft echo eyedrop antidote	0		
 589	fancy immense moldy cocoa eggshell fragment	10	crappy	Effect: "What's That Smell?", Effect Duration: 20
-590	fancy bland bouncing pulsating cocoa eggshell fragment	4	decent	Effect: "Sagittarius Rising", Effect Duration: 15
+590	bland fancy bouncing pulsating cocoa eggshell fragment	4	decent	Effect: "Sagittarius Rising", Effect Duration: 15
 591	cocoa egg	0		
 592	house	0		
 593	phonics down	0		
@@ -634,18 +634,18 @@
 636	teal meat globe	0		
 637	toaster	0		
 638	squat lightning-fast Rosewater's asshat	0		Mysticality Percent: +30, Initiative: +40, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	flavorless thick abominable snowcone	5	decent	
+639	thick flavorless abominable snowcone	5	decent	
 640	Ent cider	1	EPIC	
 641	rotten toast	4	crappy	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	purple Crimbo pressie	0		Last Available: "2003-12"
 645	bouncing wrapping paper	0		Last Available: "2003-12"
-646	flavorless massive squat fruitcake	7	decent	
+646	massive flavorless squat fruitcake	7	decent	
 647	present	0		Last Available: "2004-11"
 648	spinning knitted Crimbo sword	0		Cold Resistance: +3, Last Available: "2004-10"
-649	pulsating tumbling sinister Crimbo hat	0		Spell Damage: +10, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	beefcake's Crimbo pants	0		Muscle: +25, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	pulsating tumbling sinister Crimbo hat	0		Spell Damage: +10, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	beefcake's Crimbo pants	0		Muscle: +25, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	weightlifter's exclusive ultra-rare item	0		Muscle: +15
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -659,10 +659,10 @@
 661	wobbly hardened star hat	0		Damage Reduction: 3, Familiar Effect: "0.5xVolley, 0.5xPotato, cap 41"
 662	upside-down energetic star buckler	0		Maximum MP Percent: +20, Damage Reduction: 10
 663	star throwing star	0		
-664	upside-down tumbling star starfish	0		
+664	tumbling upside-down star starfish	0		
 665	Richard's star key	0		
 666	purple wool flame-wreathed steaming evil of the cougar	0		Moxie: +20, Hot Spell Damage: +10, Cold Resistance: +1
-667	gray shaking castle map	0		
+667	shaking gray castle map	0		
 668	savvy spiked femur	0		Mysticality Percent: +20
 669	tasty pulsating ghuol guolash	4	awesome	
 670	ribald lihc face	0		Sleaze Damage: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
@@ -671,22 +671,22 @@
 673	artisanal purple vodka and cranberry	4	EPIC	
 674	mediocre whiskey	4	decent	
 675	lightning-fast skull of the Bonerdagon	0		Initiative: +40
-676	skewed fuchsia shaking dragonbone belt buckle	0		
+676	shaking skewed fuchsia dragonbone belt buckle	0		
 677	badass belt of the scaredy-cat	0		Monster Level: -15
 678	upside-down chest of the Bonerdagon	0		
 679	irresponsibly strong lousy roll in the hay	8	decent	
 680	drinkable ghostly slap and tickle	3	good	
 681	practically non-alcoholic smooth twirling slip 'n' slide	1	awesome	
 682	aged a sump'm sump'm	3	awesome	
-683	lousy fancy horizontal tango	3	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 30
-684	tolerable spirit-forward pink pony	5	good	
+683	fancy lousy horizontal tango	3	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 30
+684	spirit-forward tolerable pink pony	5	good	
 685	hardy Mr. Shirt of wisdom of the storm	0		Mysticality: +15, Maximum HP: +50, Maximum MP Percent: +40
 686	spinning knuckles of Tarzan	0		Experience (Muscle): +3
 687	energized wet pulsating blood of the Wereseal	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 38
 688	brainy pixel hat	0		Mysticality: +5, Familiar Effect: "atk, 2xVolley, cap 12"
 689	careful pixel pants	0		Monster Level: -10, Familiar Effect: "atk, 4xPotato, cap 12"
 690	mirror skewed toasty pixel sword	0		Hot Damage: +5
-691	mirror wobbly digital key	0		
+691	wobbly mirror digital key	0		
 692	Ascension Souvenir T-Shirt	0		
 693	forbidden harem girl t-shirt	0		Spell Damage Percent: +50
 694	rosewater-soaked Knob Goblin elite shirt	0		Stench Resistance: +3
@@ -731,11 +731,11 @@
 735	easter egg balloon of the detective	0		Item Drop: +20
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	tumbling wobbly stone tablet (Really Evil Rhythm)	0		
+738	wobbly tumbling stone tablet (Really Evil Rhythm)	0		
 739	cyan tambourine bells	0		
 740	skewed cyan flame-wreathed tambourine	0		Hot Spell Damage: +10
 741	broken skull	0		
-742	flavorless snack-sized enchanted Knoll shroomkabob	2	decent	Effect: "Takin' It Greasy", Effect Duration: 10
+742	flavorless enchanted snack-sized Knoll shroomkabob	2	decent	Effect: "Takin' It Greasy", Effect Duration: 10
 743	bland mushroom	3	decent	
 744	moist denatured hair spray	0		Effect: "Eyes for Miles", Effect Duration: 64
 746	spinning huge stat script	0		
@@ -743,11 +743,11 @@
 748	wobbly gourd potion	0		
 749	rotten huge warm mushroom	7	crappy	
 750	decent ghostly mushroom quesadilla	3	good	
-751	bite-sized adequate cool mushroom	1	good	
+751	adequate bite-sized cool mushroom	1	good	
 752	flavorless cool mushroom casserole	3	decent	
 753	yummy pointy mushroom	3	awesome	
-754	half-sized adequate mirror cream of pointy mushroom soup	2	good	
-755	jumbo flavorless narrow mushroom	5	decent	
+754	adequate half-sized mirror cream of pointy mushroom soup	2	good	
+755	flavorless jumbo narrow mushroom	5	decent	
 756	stale mushroom	4	decent	
 757	spoiled mushroom	3	crappy	
 758	spoiled shaking ghost cucumber	3	crappy	
@@ -778,34 +778,34 @@
 783	'Villa' document	0		
 784	hand-crafted Acqua Del Piatto Merlot	4	EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
-786	flavorless massive strawberry	6	decent	
+786	massive flavorless strawberry	6	decent	
 787	bad bottle of rum	3	decent	
 788	watered-down lousy strawberry daiquiri	2	decent	
-789	triple-distilled perfectly mixed ghostly rum and cola	6	EPIC	
+789	perfectly mixed triple-distilled ghostly rum and cola	6	EPIC	
 790	watered-down perfectly mixed grog	2	EPIC	
 791	gray Sherlock's Jack Frost's Mafia bow tie	0		Cold Spell Damage: +50, Item Drop: +25, Last Available: "2004-10"
 792	Golden Mr. Accessory of the wise owl	0		Mysticality: +20, Softcore Only
 793	pressed enhanced oil of stability	0		Effect: "Your Eyes are Peeled!", Effect Duration: 46
 794	unsweetened pickled narrow olive oil of slipperiness	0		Effect: "Dreadful Smell", Effect Duration: 14
-795	spirit-forward artisanal Acque Luride Grezze Cabernet	5	EPIC	Last Available: "2004-10"
+795	artisanal spirit-forward Acque Luride Grezze Cabernet	5	EPIC	Last Available: "2004-10"
 796	chilly experienced cement shoes of Tarzan	0		Experience: +2, Experience (Muscle): +3, Cold Damage: +5, Last Available: "2004-10"
 797	drinkable fancy blurry rockin' wagon	4	good	Effect: "Frosty the Hitman", Effect Duration: 45
 798	drinkable ghostly ocean motion	4	good	
 799	bad fuzzbump	3	decent	
-800	bland snack-sized poutine	2	decent	
+800	snack-sized bland poutine	2	decent	
 801	moldy Knob stir-fry	4	crappy	
-804	big flavorless Knoll stir-fry	5	decent	
+804	flavorless big Knoll stir-fry	5	decent	
 805	flavorless stir-fry	3	decent	
-806	moldy massive asparagus stir-fry	9	crappy	
+806	massive moldy asparagus stir-fry	9	crappy	
 807	miniature moldy spinning olive stir-fry	2	crappy	
 808	flavorless Knob sausage stir-fry	3	decent	
 809	spoiled bat wing stir-fry	4	crappy	
 810	adequate rat appendix stir-fry	3	good	
 811	moldy miniature tofu stir-fry	2	crappy	
-812	toothsome miniature pr0n stir-fry	2	awesome	
+812	miniature toothsome pr0n stir-fry	2	awesome	
 813	huge moldy Knob shells	7	crappy	
-814	flavorless super-sized b&auml;tzle	5	decent	
-815	massive normal teal bouncing ratini	8	good	
+814	super-sized flavorless b&auml;tzle	5	decent	
+815	massive normal bouncing teal ratini	8	good	
 816	bland snack-sized Knob stroganoff	2	decent	
 817	normal menudo ravioli	4	good	
 818	plus sign	0		
@@ -831,7 +831,7 @@
 838	electrified hardy Mafia stogie	0		Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-10"
 839	lousy twirling Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
 840	nippy Mafia violin case of the cougar	0		Moxie: +20, Cold Damage: +10, Last Available: "2004-10"
-841	acceptable weak special huge tomato daiquiri	2	good	Effect: "Rushin' Hands", Effect Duration: 50
+841	acceptable special weak huge tomato daiquiri	2	good	Effect: "Rushin' Hands", Effect Duration: 50
 842	artisanal beertini	4	EPIC	
 843	watered-down artisanal skewed salty slug	2	EPIC	
 844	drinkable ghostly papaya slung	3	good	
@@ -875,7 +875,7 @@
 884	auspicious los chinos	0		Item Drop: +10, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	ribald axe	0		Sleaze Damage: +10
 886	leaflet	0		
-887	jittery gray leaf	0		
+887	gray jittery leaf	0		
 888	maple leaf	0		
 889	wobbly Jim Carey's balaclava	0		Monster Level: +25, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 890	moldy balaclava baklava	3	crappy	
@@ -892,7 +892,7 @@
 901	narrow espresso maker	0		Familiar Weight: +5
 902	jittery 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	boozy mediocre Spasmi Dolorosi Del Rene Champagne	5	decent	Last Available: "2004-10"
-904	flame-retardant savvy wizardly school Mafia knickerbockers	0		Mysticality: +25, Mysticality Percent: +20, Hot Resistance: +1, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	flame-retardant savvy wizardly school Mafia knickerbockers	0		Mysticality: +25, Mysticality Percent: +20, Hot Resistance: +1, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	ionized diffused Yummy Tummy bean	0		Effect: "Tapped In", Effect Duration: 26
 906	boiled moist skewed Rock Pops	0		Effect: "Eyes for Miles", Effect Duration: 44
 907	concentrated skewed Mr. Mediocrebar	0		Effect: "Prelude of Precision", Effect Duration: 38
@@ -906,8 +906,8 @@
 915	mirror yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	cyan hardened educational intergalactic pom poms	0		Experience: +1, Damage Reduction: 3
 917	Mob Penguin protection contract	0		
-918	mansplainer's Radio Free Baseball Cap	0		Monster Level: +15, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	wobbly Radio Free Pants of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	mansplainer's Radio Free Baseball Cap	0		Monster Level: +15, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	wobbly Radio Free Pants of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	executive Radio Free Foil	0		Meat Drop: +40, Last Available: "2006-07"
 921	enchanted adequate skewed radio button candy	3	good	Effect: "Third Based", Effect Duration: 5
 922	huge ghostly mirror grievous severed rocking horse head	0		Weapon Damage Percent: +50
@@ -921,7 +921,7 @@
 931	hand-crafted huge spiced rum	3	EPIC	
 932	tolerable eggnog	4	good	
 933	miniature toothsome huge candy cane	2	awesome	
-934	special spoiled diet gingerbread bugbear	1	crappy	Effect: "Smugness", Effect Duration: 35
+934	special diet spoiled gingerbread bugbear	1	crappy	Effect: "Smugness", Effect Duration: 35
 935	groovy imitation nice watch	0		Moxie Percent: +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,22 +929,22 @@
 939	huge small Crimbo Pressie	0		Last Available: "2004-12"
 940	ghostly bow	0		Last Available: "2004-12"
 941	blurry Crimbo stocking	0		Last Available: "2004-12"
-942	lightning-fast bowler	0		Initiative: +40, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	lightning-fast bowler	0		Initiative: +40, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	banded bow staff of the pedagogue	0		Experience: +3, Damage Absorption: +100, Last Available: "2004-12"
-944	perfumed bowlegged pants	0		Stench Resistance: +5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	perfumed bowlegged pants	0		Stench Resistance: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	weak aged martini	2	awesome	Last Available: "2004-12"
+948	aged weak martini	2	awesome	Last Available: "2004-12"
 949	hand-crafted watered-down grogtini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 950	acceptable mirror cherry bomb	3	good	Last Available: "2004-12"
-951	shaking cyan skewed extra special Crimbo stocking	0		Last Available: "2004-12"
+951	cyan shaking skewed extra special Crimbo stocking	0		Last Available: "2004-12"
 952	fuchsia energetic veiny hockey mask	0		Maximum HP: +10, Maximum MP Percent: +20, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	upside-down penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	forbidden fez of etymology	0		Spell Damage Percent: +50, Familiar Effect: "1xLep, cap 30"
-956	stale miniature lime green carob chunk noodles	2	decent	
-957	adequate huge chorizo brownies	10	good	
+956	miniature stale lime green carob chunk noodles	2	decent	
+957	huge adequate chorizo brownies	10	good	
 958	tasty mirror chocolate and tomato pizza	4	awesome	
 959	pulsating olive flange	0		
 960	wobbly huge clockwork key	0		
@@ -993,15 +993,15 @@
 1006	moldy cherry	3	crappy	
 1007	yellow forbidden coconut shell	0		Spell Damage Percent: +50, Familiar Effect: "1xFairy, cap 7"
 1008	huge fuchsia ice cubes of the early riser	0		Adventures: +7
-1009	weak acceptable vodka martini	2	good	
-1010	acceptable special whiskey and soda	3	good	Effect: "Extra-Wet", Effect Duration: 5
+1009	acceptable weak vodka martini	2	good	
+1010	special acceptable whiskey and soda	3	good	Effect: "Extra-Wet", Effect Duration: 5
 1011	perfectly mixed monkey wrench	3	EPIC	
 1012	artisanal tequila sunrise	4	EPIC	
 1013	perfectly mixed twirling margarita	4	EPIC	
 1014	lousy watered-down strawberry wine	2	decent	
 1015	tolerable wine spritzer	3	good	
 1016	special hand-crafted perpendicular hula	3	EPIC	Effect: "Deeply Ironic", Effect Duration: 40
-1017	practically non-alcoholic drinkable ducha de oro	1	good	
+1017	drinkable practically non-alcoholic ducha de oro	1	good	
 1018	smooth calle de miel	4	awesome	
 1019	perfectly mixed extra-dry dry vodka martini	5	EPIC	
 1020	hand-crafted old-fashioned	3	EPIC	
@@ -1024,12 +1024,12 @@
 1037	manspreader's gnauga hide buckler	0		Monster Level: +10, Damage Reduction: 5
 1038	aerosolized Connery's Elixir of Audacity	0		Effect: "Vitali Tea", Effect Duration: 15
 1040	twirling Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	aged huge wobbly beer	4	awesome	
+1041	aged wobbly huge beer	4	awesome	
 1042	smartaleck's string of beads	0		Moxie Percent: +30
 1043	electrified string of beads	0		MP Regen Min: 3, MP Regen Max: 5
 1044	spinning zippy string of beads	0		Initiative: +20
 1045	gray razor-sharp plastic bottle opener	0		Weapon Damage Percent: +25
-1046	skewed jittery aromatic ruddy traffic cone	0		Maximum HP Percent: +40, Stench Resistance: +1, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	skewed jittery aromatic ruddy traffic cone	0		Maximum HP Percent: +40, Stench Resistance: +1, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	weak drinkable N. O. Beer	2	good	
 1048	pickled oyster egg	1		
 1049	denatured upside-down oyster egg	1		
@@ -1055,13 +1055,13 @@
 1069	boiled yellow oyster egg	1		Effect: "Stuck-Up Hair", Effect Duration: 50
 1070	distilled skewed oyster egg	1		Effect: "[1342]Slicked-Back Do", Effect Duration: 40
 1071	wobbly plastic oyster egg	0		
-1072	distilled red shaking off-white oyster egg	1		
+1072	distilled shaking red off-white oyster egg	1		
 1073	mixed lime green off-white oyster egg	1		
 1074	boiled bouncing off-white oyster egg	1		Effect: "Spooky Blur", Effect Duration: 20
 1075	shaking off-white plastic oyster egg	0		
 1076	powdered teal squat oyster egg	1		
 1077	altered bouncing oyster egg	1		
-1078	powdered purple bouncing oyster egg	1		
+1078	powdered bouncing purple oyster egg	1		
 1079	gray plastic oyster egg	0		
 1080	blurry oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
@@ -1117,21 +1117,21 @@
 1131	upside-down beet	0		Last Available: "2005-12"
 1132	wobbly Totally Gay Claymore	0		
 1133	MacGyver's star shirt	0		Maximum MP: +100
-1134	upside-down bouncing blurry cosmetics bag	0		
+1134	blurry bouncing upside-down cosmetics bag	0		
 1135	moist eyeliner	0		Effect: "Chorale of Companionship", Effect Duration: 21
 1136	vacuum-sealed super-flattened mirror lipstick	0		Effect: "Spookypants", Effect Duration: 46
 1137	jittery Oprah's bicycle chain of Gandalf	0		Maximum MP Percent: +50, Spell Critical Percent: +20
 1138	mushroom fermenting solution	0		
 1139	triple-distilled perfectly mixed wobbly mushroom wine	7	EPIC	
-1140	lousy watered-down icy mushroom wine	2	decent	
-1141	drinkable triple-distilled fancy mushroom wine	8	good	Effect: "Wet Jaw", Effect Duration: 50
+1140	watered-down lousy icy mushroom wine	2	decent	
+1141	fancy drinkable triple-distilled mushroom wine	8	good	Effect: "Wet Jaw", Effect Duration: 50
 1142	mediocre blurry pointy mushroom wine	3	decent	
 1143	acceptable flat mushroom wine	4	good	
 1144	smooth cool mushroom wine	3	awesome	
 1145	tolerable blinking knob mushroom wine	3	good	
 1146	bad tumbling knoll mushroom wine	3	decent	
-1147	triple-distilled acceptable gray mushroom wine	8	good	
-1148	drinkable weak shot of flower schnapps	2	good	
+1147	acceptable triple-distilled gray mushroom wine	8	good	
+1148	weak drinkable shot of flower schnapps	2	good	
 1149	normal tiny flower petal pie	1	good	
 1150	mediocre bottle of single-barrel whiskey	4	decent	
 1151	ghostly toasty thinker's discarded plastic fork	0		Mysticality: +10, Hot Damage: +5
@@ -1148,7 +1148,7 @@
 1163	improved Vulcanized marzipan skull	0		Effect: "Think Win-Lose", Effect Duration: 56
 1164	shaking poultrygeist	0		
 1165	maroon spinning hovering sombrero	0		
-1166	spinning tumbling maracas	0		Familiar Weight: +5
+1166	tumbling spinning maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	fuchsia less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
@@ -1174,7 +1174,7 @@
 1189	fuchsia can of asparagus	0		
 1190	dodecapede	0		
 1191	ghuol whelp	0		
-1192	squat maroon zmobie	0		
+1192	maroon squat zmobie	0		
 1193	Raggedy Hippy doll	0		
 1194	stab bat	0		
 1195	shaking apathetic lizardman doll	0		
@@ -1183,9 +1183,9 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	tasty big mugcake	5	awesome	
-1201	half-sized rotten green urinal cake	2	crappy	
+1201	rotten half-sized green urinal cake	2	crappy	
 1202	rotten Happy Birthday, Claude! cake	3	crappy	
-1203	spoiled red shaking personalized birthday cake	3	crappy	
+1203	spoiled shaking red personalized birthday cake	3	crappy	
 1204	spoiled pulsating three-tiered wedding cake	3	crappy	
 1205	tasty wobbly babycakes	4	awesome	
 1206	rotten velvet cake	3	crappy	
@@ -1233,14 +1233,14 @@
 1249	Boss Bat britches of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	perfumed sinister Boss Bat bling	0		Spell Damage: +10, Stench Resistance: +5
 1251	spoiled Knob shroomkabob	3	crappy	
-1252	bland blurry pulsating cyan shroomkabob	3	decent	
+1252	bland cyan blurry pulsating shroomkabob	3	decent	
 1253	spinning pile of jumping beans	0		
 1254	adequate blinking jumping bean burrito	4	good	
 1255	flavorless jumping bean burrito	4	decent	
 1256	rotten wobbly insanely jumping bean burrito	3	crappy	
 1257	delicious shaking rat scrapple	4	awesome	
 1258	ghostly shaking pail of pretentious paint	0		
-1259	bouncing Oprah's supercool traffic cone	0		Moxie Percent: +20, Maximum MP Percent: +50, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	bouncing Oprah's supercool traffic cone	0		Moxie Percent: +20, Maximum MP Percent: +50, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	denatured bouncing Hatorade	1		
 1262	blurry nippy occult off-hand balloon of the ox	0		Muscle: +20, Spell Damage Percent: +25, Cold Damage: +10
@@ -1287,7 +1287,7 @@
 1303	skewed Mjolnir Jr.	0		
 1304	purple doppelshifter egg	0		Free Pull
 1305	shaking makeup kit	0		Familiar Weight: +15
-1306	traffic cone of the wise owl of Tarzan	0		Mysticality: +20, Experience (Muscle): +3, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	traffic cone of the wise owl of Tarzan	0		Mysticality: +20, Experience (Muscle): +3, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	skewed blood flower	0		
 1318	lovecat tail	0		
 1319	lime green plastic passion fruit	0		
-1320	decent bouncing upside-down questionable taco	4	good	
+1320	decent upside-down bouncing questionable taco	4	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	huge time helmet of wisdom	0		Mysticality: +15, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	shaking cyan friendly time trousers	0		Familiar Weight: +3, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	huge time helmet of wisdom	0		Mysticality: +15, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	shaking cyan friendly time trousers	0		Familiar Weight: +3, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	blue brainy time sword	0		Mysticality: +5, Last Available: "2005-10"
 1326	green smooth Dyspepsi-Cola helmet	0		Moxie: +15, Familiar Effect: "3xFairy, cap 7"
 1327	squat Lo Pan's Cloaca-Cola shield	0		Spell Critical Percent: +30, Damage Reduction: 4
@@ -1330,7 +1330,7 @@
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	empty blowgun	0		Last Available: "2005-11"
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
-1350	jittery lime green 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
+1350	lime green jittery 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	pinky ring of the pedagogue	0		Experience: +3, Single Equip
 1352	practically non-alcoholic bad gray redrum	1	decent	
 1353	ninja pirate zombie robot	0		
@@ -1342,14 +1342,14 @@
 1359	skewed ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	bouncing ghostly groovy disembodied smile	0		Moxie Percent: +10, Single Equip
-1362	blinking purple sausage	0		
+1362	purple blinking sausage	0		
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	decent tumbling upside-down tofurkey leg	4	good	
-1366	rotten tiny huge tofurkey gravy	1	crappy	
+1366	tiny rotten huge tofurkey gravy	1	crappy	
 1367	spoiled herbal stuffing	3	crappy	
 1368	moldy can-shaped gelatinous cranberry sauce	3	crappy	
-1369	super-sized rotten yams	5	crappy	
+1369	rotten super-sized yams	5	crappy	
 1370	rhinestone cowboy shirt of courage	0		Spooky Resistance: +3
 1371	savvy gingham blouse	0		Mysticality Percent: +20
 1372	slick souvenir ski t-shirt	0		Moxie: +10
@@ -1384,8 +1384,8 @@
 1402	scandalous rag doll	0		Sleaze Damage: +5, Last Available: "2005-12"
 1403	resourceful can of fake snow	0		Maximum MP: +50, Last Available: "2005-12"
 1404	shaking chaotic colored-light &quot;necklace&quot;	0		Spell Critical Percent: +10, Last Available: "2005-12"
-1405	tree skirt of incineration	0		Hot Spell Damage: +50, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	normal tiny wreath-shaped Crimbo cookie	1	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	tree skirt of incineration	0		Hot Spell Damage: +50, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1406	tiny normal wreath-shaped Crimbo cookie	1	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	moldy jittery bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	flavorless tree-shaped Crimbo cookie	3	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of terror	0		Spooky Spell Damage: +10, Last Available: "2005-12"
@@ -1399,13 +1399,13 @@
 1417	cold-filtered snowcone	0		Effect: "In a Lather", Effect Duration: 38, Last Available: "2006-01"
 1418	jittery Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	blinking careful traffic cone of chilblains	0		Monster Level: -10, Cold Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	blinking careful traffic cone of chilblains	0		Monster Level: -10, Cold Damage: +25, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	jittery Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	ghostly Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	fuchsia lard-coated ice sickle of extreme caution	0		Monster Level: -25, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2006-02"
 1425	ice baby of the cheetah	0		Initiative: +60, Softcore Only, Last Available: "2006-02"
-1426	friendly ice pick	0		Familiar Weight: +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	friendly ice pick	0		Familiar Weight: +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	fuchsia up-at-dawn Rosewater's ice skates	0		Mysticality Percent: +30, Adventures: +5, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	stale grue egg omelette	3	decent	
 1429	roll of drink tickets	0		
@@ -1422,7 +1422,7 @@
 1440	flattened powder	0		Effect: "Gummiskin", Effect Duration: 67
 1441	quantum powder	0		Effect: "Funky Coal Patina", Effect Duration: 36
 1442	chilled stench powder	0		Effect: "Provocative Perkiness", Effect Duration: 57
-1443	galvanized deionized shaking narrow sleaze powder	0		Effect: "Weepy, Creepy", Effect Duration: 19
+1443	galvanized deionized narrow shaking sleaze powder	0		Effect: "Weepy, Creepy", Effect Duration: 19
 1444	enhanced unsweetened jittery twinkly nuggets	0		Effect: "Permafrosty", Effect Duration: 34
 1445	tarnished improved purple hot nuggets	0		Effect: "Amorous", Effect Duration: 22
 1446	polarized nuggets	0		Effect: "Dreams and Lights", Effect Duration: 29
@@ -1434,7 +1434,7 @@
 1452	dehydrated wad	1		Effect: "Strong Spirit", Effect Duration: 20
 1453	distilled pulsating wad	1		Effect: "Permanent Halloween", Effect Duration: 5
 1454	twisted pulsating stench wad	1		Effect: "Conspiratory Eyes", Effect Duration: 30
-1455	boiled pulsating olive upside-down sleaze wad	1		
+1455	boiled upside-down olive pulsating sleaze wad	1		
 1456	double daisy	0		
 1457	skewed Goth Giant	0		
 1458	delicious Valentine's Day cake	3	awesome	
@@ -1474,7 +1474,7 @@
 1492	dangerous ninja mop	0		Weapon Damage: +10
 1493	Usain Bolt's boxer's ridiculously overelaborate ninja weapon	0		Muscle Percent: +10, Initiative: +80
 1494	boiled extra-wet blue sugar-coated pine cone	0		Effect: "Drenched With Filth", Effect Duration: 39, Last Available: "2020-09"
-1495	crafty supercool traffic cone	0		Moxie Percent: +20, Maximum MP: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	crafty supercool traffic cone	0		Moxie Percent: +20, Maximum MP: +10, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	perfectly mixed watered-down gloomy mushroom wine	2	super EPIC	
 1497	bad enchanted mushroom wine	4	decent	Effect: "The Wisdom... of the Future", Effect Duration: 15
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
@@ -1494,9 +1494,9 @@
 1512	altered blue Knob Goblin pet-buffing spray	1		
 1513	vaporized Knob Goblin learning pill	1		
 1514	altered shaking Knob Goblin eyedrops	1		Effect: "init.enh", Effect Duration: 5
-1515	boiled narrow fuchsia blinking Knob Goblin nasal spray	1		
+1515	boiled narrow blinking fuchsia Knob Goblin nasal spray	1		
 1516	KWE-brand transistor radio	0		
-1518	jittery skewed vampire heart	0		
+1518	skewed jittery vampire heart	0		
 1519	narrow Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	upside-down Jack Frost's electrified Radio KoL Coffee Mug	0		Cold Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5
 1521	Frank Gorshin trophy	0		
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	purple shaking pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	shaking purple pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	narrow diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	cyan flame-wreathed energetic corkscrew	0		Maximum MP Percent: +20, Hot Spell Damage: +10, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	Herculean grass skirt	0		Experience (Muscle): +1, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	frosty grass hat	0		Cold Spell Damage: +10, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	Herculean grass skirt	0		Experience (Muscle): +1, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	frosty grass hat	0		Cold Spell Damage: +10, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	Van der Graaf grass blade	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	shaking sparkly engagement ring of temperance	0		Sleaze Resistance: +5, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	skewed pulsating zippy hardened Grimacite goggles	0		Damage Reduction: 3, Initiative: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	skewed pulsating zippy hardened Grimacite goggles	0		Damage Reduction: 3, Initiative: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	Grimacite glaive of chilblains of doom	0		Cold Damage: +25, Spooky Spell Damage: +50, Last Available: "2008-10"
-1542	banded Grimacite greaves of the bloodbag	0		Damage Absorption: +100, Maximum HP: +100, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	banded Grimacite greaves of the bloodbag	0		Damage Absorption: +100, Maximum HP: +100, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	quilted thinker's Grimacite garter	0		Mysticality: +10, Damage Absorption: +40, Last Available: "2008-10"
 1544	spinning grievous Rosewater's Grimacite galoshes	0		Mysticality Percent: +30, Weapon Damage Percent: +50, Last Available: "2008-10"
 1545	jittery frosty nippy Grimacite gorget	0		Cold Damage: +10, Cold Spell Damage: +10, Last Available: "2008-10"
@@ -1538,39 +1538,39 @@
 1558	flavorless wobbly tangerine	4	decent	
 1559	teal tonic water	0		
 1560	moldy spinning cocktail onion	3	crappy	
-1561	small fancy normal blurry raspberry	2	good	Effect: "In the Slimelight", Effect Duration: 5
+1561	normal fancy small blurry raspberry	2	good	Effect: "In the Slimelight", Effect Duration: 5
 1562	bland diet kiwi	1	decent	
 1563	drinkable twirling whiskey bittersweet	3	good	
-1564	triple-distilled hand-crafted special mimosette	10	EPIC	Effect: "Reedy Pipes", Effect Duration: 5
+1564	hand-crafted special triple-distilled mimosette	10	EPIC	Effect: "Reedy Pipes", Effect Duration: 5
 1565	bad tequila sunset	4	decent	
-1566	practically non-alcoholic bad zmobie	1	decent	Wiki Name: "Zmobie (drink)"
+1566	bad practically non-alcoholic zmobie	1	decent	Wiki Name: "Zmobie (drink)"
 1567	acceptable gin and tonic	3	good	
-1568	hand-crafted enchanted watered-down vodka and tonic	2	EPIC	Effect: "Danish Cunning", Effect Duration: 30
+1568	watered-down hand-crafted enchanted vodka and tonic	2	EPIC	Effect: "Danish Cunning", Effect Duration: 30
 1569	lousy mirror vodka gibson	4	decent	
 1570	perfectly mixed gibson	3	EPIC	
 1571	bad blue parisian cathouse	4	decent	
-1572	weak mediocre rabbit punch	2	decent	
+1572	mediocre weak rabbit punch	2	decent	
 1573	weak delicious caipifruta	2	awesome	
-1574	lousy extra-dry twirling teqiwila	5	decent	
+1574	extra-dry lousy twirling teqiwila	5	decent	
 1575	acceptable Divine	3	good	
 1576	hand-crafted Gordon Bennett	3	EPIC	
-1577	special tolerable tangarita	4	good	Effect: "Adorable Lookout", Effect Duration: 45
+1577	tolerable special tangarita	4	good	Effect: "Adorable Lookout", Effect Duration: 45
 1578	delicious mandarina colada	4	awesome	
 1579	practically non-alcoholic drinkable gimlet	1	good	
-1580	mediocre irresponsibly strong brick road	6	decent	
+1580	irresponsibly strong mediocre brick road	6	decent	
 1581	mediocre practically non-alcoholic squat vodka stratocaster	1	decent	
-1582	tolerable practically non-alcoholic Neuromancer	1	good	
+1582	practically non-alcoholic tolerable Neuromancer	1	good	
 1583	boozy delicious prussian cathouse	5	awesome	
-1584	distilled lousy Mae West	5	decent	
+1584	lousy distilled Mae West	5	decent	
 1585	artisanal Mon Tiki	4	EPIC	
 1586	perfectly mixed teqiwila slammer	4	EPIC	
 1587	adequate olive Knob lo mein	3	good	
-1588	adequate fancy asparagus lo mein	3	good	Effect: "L'instinct F&eacute;lin", Effect Duration: 30
-1589	normal small Knoll lo mein	2	good	
+1588	fancy adequate asparagus lo mein	3	good	Effect: "L'instinct F&eacute;lin", Effect Duration: 30
+1589	small normal Knoll lo mein	2	good	
 1590	delicious diet lo mein	1	awesome	
 1591	normal diet yellow olive lo mein	1	good	
 1592	normal hot hi mein	3	good	
-1593	miniature rotten hi mein	2	crappy	
+1593	rotten miniature hi mein	2	crappy	
 1594	adequate huge hi mein	7	good	
 1595	flavorless shaking hi mein	4	decent	
 1596	decent special red sleazy hi mein	3	good	Effect: "Speed of the Internet", Effect Duration: 45
@@ -1578,12 +1578,12 @@
 1598	Senior LAAAAME merit badge of the empath	0		Familiar Weight: +5, Last Available: "2006-05"
 1599	skewed jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	artisanal fuchsia tangarita with a fly in it	4	EPIC	
-1601	mediocre high-proof mandarina colada with a fly in it	9	decent	
+1601	high-proof mediocre mandarina colada with a fly in it	9	decent	
 1602	drinkable distilled prussian cathouse with a fly in it	5	good	
 1603	perfectly mixed gray Mae West with a fly in it	4	EPIC	
-1604	pickled shaking blurry astronaut ice-cream	1		Last Available: "2006-05"
+1604	pickled blurry shaking astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
-1606	pickled blurry green ultimate wad	1		Effect: "The Magic of LOV", Effect Duration: 5
+1606	pickled green blurry ultimate wad	1		Effect: "The Magic of LOV", Effect Duration: 5
 1607	wet colloidal twirling libation of liveliness	0		Effect: "Stench Jellied", Effect Duration: 21
 1608	cold-filtered oxidized eyedrops of the ermine	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 40
 1609	super-Vulcanized perfume of prejudice	0		Effect: "Pronounced Potency", Effect Duration: 49
@@ -1592,8 +1592,8 @@
 1612	Vulcanized red ghostly concentrated cordial of concentration	0		Effect: "Egg-stortionary Tactics", Effect Duration: 36
 1613	coffin lid of the sewer	0		Stench Damage: +25, Damage Reduction: 3
 1614	ribald satin shield	0		Sleaze Damage: +10, Damage Reduction: 5
-1615	thinker's Cerebral Cloche	0		Mysticality: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	rosewater-soaked Cerebral Culottes	0		Stench Resistance: +3, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	thinker's Cerebral Cloche	0		Mysticality: +10, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	rosewater-soaked Cerebral Culottes	0		Stench Resistance: +3, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	flame-retardant curative forbidden Cerebral Crossbow	0		Spell Damage Percent: +50, Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	blinking munchies pill	0		Last Available: "2006-06"
@@ -1601,11 +1601,11 @@
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
 1622	nitrogenated astral mushroom	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 57, Last Available: "2006-06"
 1623	pulsating badger badge	0		Last Available: "2006-06"
-1624	nitrogenated irradiated squat blurry blue-frosted astral cupcake	0		Effect: "Stinky Hands", Effect Duration: 47, Last Available: "2006-06"
+1624	nitrogenated irradiated blurry squat blue-frosted astral cupcake	0		Effect: "Stinky Hands", Effect Duration: 47, Last Available: "2006-06"
 1625	triple-enhanced green-frosted astral cupcake	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 15, Last Available: "2006-06"
 1626	improved adjusted jittery orange-frosted astral cupcake	0		Effect: "Glo-Face", Effect Duration: 40, Last Available: "2006-06"
 1627	tarnished blurry purple-frosted astral cupcake	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 36, Last Available: "2006-06"
-1628	triple-alkaline pressed gray twirling pink-frosted astral cupcake	0		Effect: "Hot Blooded", Effect Duration: 67, Last Available: "2006-06"
+1628	triple-alkaline pressed twirling gray pink-frosted astral cupcake	0		Effect: "Hot Blooded", Effect Duration: 67, Last Available: "2006-06"
 1629	wobbly raspberry beret of the cougar	0		Moxie: +20, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	lime green ribald pixel shield	0		Sleaze Damage: +10, Damage Reduction: 3
 1631	beer cartilage	0		
@@ -1615,7 +1615,7 @@
 1635	spinning scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	double-corrupted extra-irradiated anodized mirror lotion of hotness	0		Effect: "Stop the Presses!", Effect Duration: 39
-1638	altered skewed olive lotion of coldness	0		Effect: "Stone-Faced", Effect Duration: 49
+1638	altered olive skewed lotion of coldness	0		Effect: "Stone-Faced", Effect Duration: 49
 1639	concentrated lotion of spookiness	0		Effect: "Amorous", Effect Duration: 23
 1640	galvanized ionized upside-down lotion of stench	0		Effect: "Natural 20", Effect Duration: 38
 1641	non-dry warmed blinking lotion of sleaziness	0		Effect: "Gummi Badass", Effect Duration: 44
@@ -1630,14 +1630,14 @@
 1650	milk of magnesium	0		
 1651	moldy red foie gras	3	crappy	
 1652	moist candy brain	0		Effect: "Incensed", Effect Duration: 17, Last Available: "2020-09"
-1653	shaking Jack Frost's ruddy forbidden jewel-eyed wizard hat	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Cold Spell Damage: +50, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	shaking Jack Frost's ruddy forbidden jewel-eyed wizard hat	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Cold Spell Damage: +50, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	sinister wad of Crovacite of mayonnaise	0		Spell Damage: +10, Sleaze Spell Damage: +50
 1655	smooth collar of mayonnaise	0		Moxie: +15, Sleaze Spell Damage: +50
 1656	White Citadel Satisfaction Satchel	0		
 1657	onion shurikens	0		
 1658	Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
-1660	bouncing blurry Regular Cloaca Cola	0		
+1660	blurry bouncing Regular Cloaca Cola	0		
 1661	ghostly strapping Radio KoL Keychain	0		Muscle: +5
 1662	skewed banded Radio KoL Antenna Ball	0		Damage Absorption: +100
 1663	blurry Radio KoL Flashlight of the brute	0		Muscle Percent: +30
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	ghostly blinking pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	ghostly blinking pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	forbidden educational sword	0		Experience: +1, Spell Damage Percent: +50
 1680	beefy staff of bravery	0		Muscle: +10, Spooky Resistance: +5
 1681	electrified bubblewrap sword of the cheetah	0		Initiative: +60, MP Regen Min: 3, MP Regen Max: 5
@@ -1670,15 +1670,15 @@
 1690	lard-coated frightening discarded bottlecap	0		Spooky Damage: +5, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	energetic discarded torn-up glove of the boozehound	0		Maximum MP Percent: +20, Booze Drop: +100, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	quantum improved salamander slurry	0		Effect: "Spooky Blur", Effect Duration: 28
-1693	concentrated wet lime green huge eyedrops of newt	0		Effect: "Polar Express", Effect Duration: 31
+1693	concentrated wet huge lime green eyedrops of newt	0		Effect: "Polar Express", Effect Duration: 31
 1694	pickled cold-filtered non-frozen squat Frogade	0		Effect: "Spiky Frozen Hair", Effect Duration: 19
 1695	polymerized pulsating papotion of papower	0		Effect: "Baconstoned", Effect Duration: 43
-1696	low-calorie decent bouncing royal jelly taco	1	good	
+1696	decent low-calorie bouncing royal jelly taco	1	good	
 1697	thick moldy tofu taco	5	crappy	
-1698	half-sized flavorless mirror pulsating olive jumping bean taco	2	decent	
-1699	tiny spoiled catgut taco	1	crappy	
-1700	adequate half-sized goat cheese taco	2	good	
-1701	super-sized delicious pr0n taco	5	awesome	
+1698	flavorless half-sized olive mirror pulsating jumping bean taco	2	decent	
+1699	spoiled tiny catgut taco	1	crappy	
+1700	half-sized adequate goat cheese taco	2	good	
+1701	delicious super-sized pr0n taco	5	awesome	
 1702	colloidal oxidized alphabet gum	0		Effect: "Spirit of Alph", Effect Duration: 27
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1750,7 +1750,7 @@
 1771	pulsating butcherknife of bravery	0		Spooky Resistance: +5
 1772	corn holder of the early riser	0		Adventures: +7
 1773	blurry wizardly eggbeater	0		Mysticality: +25
-1774	weak enchanted tolerable bottle of popskull	2	good	Effect: "Castaway Physique", Effect Duration: 40
+1774	enchanted tolerable weak bottle of popskull	2	good	Effect: "Castaway Physique", Effect Duration: 40
 1775	squat dishrag of the sweet-tooth	0		Candy Drop: +100
 1776	adequate stale baguette	4	good	
 1777	lime green leftovers of indeterminate origin	0		
@@ -1768,7 +1768,7 @@
 1789	ghostly maroon Mob Penguin	0		
 1790	acceptable Ram's Face Lager	4	good	
 1791	upside-down ram horns	0		
-1792	mirror fireproof Sinatra's Herculean Travoltan trousers	0		Experience (Muscle): +1, Experience (Moxie): +5, Hot Resistance: +3, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	mirror fireproof Sinatra's Herculean Travoltan trousers	0		Experience (Muscle): +1, Experience (Moxie): +5, Hot Resistance: +3, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	teal personal trainer's pool cue of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25
 1794	quadruple-nitrogenated upside-down handful of hand chalk	0		Effect: "Baconstoned", Effect Duration: 26
 1795	resourceful Counterclockwise Watch	0		Maximum MP: +50, Single Equip
@@ -1781,7 +1781,7 @@
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
-1805	pulsating blurry fourth cervical vertebra	0		
+1805	blurry pulsating fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
@@ -1794,7 +1794,7 @@
 1815	seventh thoracic vertebra	0		
 1816	mirror eighth thoracic vertebra	0		
 1817	ghostly ninth thoracic vertebra	0		
-1818	lime green ghostly tenth thoracic vertebra	0		
+1818	ghostly lime green tenth thoracic vertebra	0		
 1819	blinking eleventh thoracic vertebra	0		
 1820	jittery twelfth thoracic vertebra	0		
 1821	shaking first lumbar vertebra	0		
@@ -1806,7 +1806,7 @@
 1827	seventh lumbar vertebra	0		
 1828	maroon sacral vertebrae	0		
 1829	green first caudal vertebra	0		
-1830	spinning pulsating second caudal vertebra	0		
+1830	pulsating spinning second caudal vertebra	0		
 1831	tumbling red third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
@@ -1835,7 +1835,7 @@
 1856	right sixth rib	0		
 1857	right seventh rib	0		
 1858	ghostly wobbly right eighth rib	0		
-1859	jittery shaking right ninth rib	0		
+1859	shaking jittery right ninth rib	0		
 1860	right tenth rib	0		
 1861	right eleventh rib	0		
 1862	jittery huge right twelfth rib	0		
@@ -1855,7 +1855,7 @@
 1876	left tibia	0		
 1877	teal right tibia	0		
 1878	wobbly left fibula	0		
-1879	jittery pulsating right fibula	0		
+1879	pulsating jittery right fibula	0		
 1880	left kneecap	0		
 1881	skewed blinking right kneecap	0		
 1882	left first front claw	0		
@@ -1937,7 +1937,7 @@
 1960	scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	warmed Bit O' Ectoplasm	0		Effect: "One Very Clear Eye", Effect Duration: 19
-1963	blurry bouncing dance card	0		
+1963	bouncing blurry dance card	0		
 1964	tumbling teal opera mask of courage	0		Spooky Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
 1966	huge supercharged brawny Amulet of Yendor	0		Muscle Percent: +20, Maximum MP Percent: +30, Single Equip, Last Available: "2011-12"
@@ -1945,10 +1945,10 @@
 1968	bottle of perfume	0		Familiar Weight: +5
 1969	spoon!	0		Familiar Weight: +5
 1970	nervous tick egg	0		Free Pull, Last Available: "2007-10"
-1971	green upside-down plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
+1971	upside-down green plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	MacGyver's slick shrimp fork	0		Moxie: +10, Maximum MP: +100
 1973	jittery half of a memo	0		
-1974	huge maroon cocoabo	0		
+1974	maroon huge cocoabo	0		
 1975	baby gravy fairy	0		
 1976	gravy fairy	0		
 1977	skewed maroon gravy fairy	0		
@@ -1967,12 +1967,12 @@
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
-1993	squat gray rubber WWSPD? bracelet	0		
+1993	gray squat rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
 1996	squat right half of a heart necklace	0		
-1997	spinning squat left half of a heart necklace	0		
-1998	ghostly blinking pack of KWE trading card	0		
+1997	squat spinning left half of a heart necklace	0		
+1998	blinking ghostly pack of KWE trading card	0		
 1999	spinning stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	skewed Vaso De Agua trading card	0		
@@ -1984,7 +1984,7 @@
 2007	huge Princess Rutabaga trading card	0		
 2008	Roo trading card	0		
 2009	Woldo trading card	0		
-2010	blue mirror The Snake trading card	0		
+2010	mirror blue The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
 2012	spinning Arrrmetia trading card	0		
 2013	Serenity trading card	0		
@@ -2000,7 +2000,7 @@
 2023	enchanted Genalen&trade; Bottle	1	decent	Effect: "Wolf's Bane", Effect Duration: 45
 2024	rotten mixed wildflower greens	3	crappy	
 2025	decent handful of walnuts	3	good	
-2026	massive spoiled enchanted shaking nutty organic salad	8	crappy	Effect: "The Grass...  Is Blue...", Effect Duration: 20
+2026	spoiled massive enchanted shaking nutty organic salad	8	crappy	Effect: "The Grass...  Is Blue...", Effect Duration: 20
 2027	decent big shaking upside-down super salad	5	good	
 2028	small stale tofu wonton	2	decent	
 2029	olive hippy protest button	0		Single Equip
@@ -2020,7 +2020,7 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	bland blurry brain-meltingly-hot chicken wings	4	decent	
-2046	huge rotten frat brats	6	crappy	
+2046	rotten huge frat brats	6	crappy	
 2047	normal knob ka-bobs	3	good	
 2049	drinkable can of Swiller	3	good	
 2050	cyan broken wings	0		
@@ -2036,12 +2036,12 @@
 2060	stanky hale sword	0		Maximum HP: +20, Stench Spell Damage: +25
 2061	perfumed helmet	0		Stench Resistance: +5, Familiar Effect: "1xFairy, cap 40"
 2062	wool Da Vinci's shield	0		Experience (Mysticality): +5, Cold Resistance: +1, Damage Reduction: 10
-2063	snack-sized moldy blackberry	2	crappy	
+2063	moldy snack-sized blackberry	2	crappy	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	jittery smelly stylish kick-ass kicks	0		Moxie: +25, Stench Spell Damage: +10, Single Equip
 2067	sake bomb	0		
-2068	olive upside-down tequila grenade	0		
+2068	upside-down olive tequila grenade	0		
 2069	ghostly crafty beer helmet	0		Maximum MP: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2070	hardy strapping distressed denim pants	0		Muscle: +5, Maximum HP: +50, Familiar Effect: "sleaze atk, 1xPotato, cap 42"
 2071	red blurry wholesome perforated battle paddle	0		Maximum HP Percent: +10
@@ -2058,7 +2058,7 @@
 2082	toothbrush	0		
 2083	squat makeshift crane	0		
 2084	can of starch	0		
-2085	powdered blue blinking bottle of ultravitamins	1		Effect: "Thick, Sick", Effect Duration: 20
+2085	powdered blinking blue bottle of ultravitamins	1		Effect: "Thick, Sick", Effect Duration: 20
 2086	denatured spinning bottle of cough syrup	1		
 2087	vaporized tube of hair oil	1		
 2088	warmed dry blurry narrow Daffy Taffy	0		Effect: "Spooky Hands", Effect Duration: 57
@@ -2067,7 +2067,7 @@
 2091	blue bath salts	0		
 2092	hand mirror	0		
 2093	hors d'oeuvre tray of bravery	0		Spooky Resistance: +5, Damage Reduction: 5
-2094	miniature bland ballroom blintz	2	decent	
+2094	bland miniature ballroom blintz	2	decent	
 2095	twirling bouncing towel	0		
 2096	boiled guy made of bee pollen	1		
 2097	ghostly 17-ball of the pedagogue	0		Experience: +3
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	prehistoric spear of the brute	0		Muscle Percent: +30, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	huge curative weightlifter's fire	0		Muscle: +15, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	huge curative weightlifter's fire	0		Muscle: +15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	Grateful Undead T-shirt of the ox	0		Muscle: +20
@@ -2112,18 +2112,18 @@
 2137	studded toy crazy train	0		Damage Absorption: +80, Single Equip, Last Available: "2006-12"
 2138	razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	toy mercenary	0		Last Available: "2006-12"
-2140	spinning shaking length of string	0		Last Available: "2011-12"
+2140	shaking spinning length of string	0		Last Available: "2011-12"
 2141	bouncing toy wheel	0		Last Available: "2011-12"
 2142	ghostly block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
-2144	blinking blue evil googly eye	0		Last Available: "2011-12"
+2144	blue blinking evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	bland twirling frank	3	decent	Last Available: "2011-12"
 2150	toothsome plate of franks and beans	3	awesome	Last Available: "2011-12"
-2151	practically non-alcoholic lousy fuchsia shot of blackberry schnapps	1	decent	
+2151	lousy practically non-alcoholic fuchsia shot of blackberry schnapps	1	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	wobbly carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2137,13 +2137,13 @@
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
-2165	green mirror atomic vector plotter	0		Last Available: "2011-12"
+2165	mirror green atomic vector plotter	0		Last Available: "2011-12"
 2166	huge blinking ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	narrow hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	rock-hard toy ray gun of the brute	0		Muscle Percent: +30, Damage Reduction: 5, Last Available: "2006-12"
-2169	beefcake's toy space helmet of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	beefcake's toy space helmet of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	huge teal MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	veiny astronaut pants of the early riser	0		Maximum HP: +10, Adventures: +7, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	veiny astronaut pants of the early riser	0		Maximum HP: +10, Adventures: +7, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	blinking shaking baleful toy jet pack	0		Spell Damage: +25, Last Available: "2006-12"
 2173	olive triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,18 +2161,18 @@
 2186	wobbly unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	good	Last Available: "2006-12"
-2189	bad boozy flask of peppermint schnapps	5	decent	Last Available: "2006-12"
+2189	boozy bad flask of peppermint schnapps	5	decent	Last Available: "2006-12"
 2190	cyan spinning yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
-2192	skewed cyan sheet music	0		Last Available: "2006-12"
-2193	half-sized spoiled candy stake	2	crappy	Last Available: "2006-12"
+2192	cyan skewed sheet music	0		Last Available: "2006-12"
+2193	spoiled half-sized candy stake	2	crappy	Last Available: "2006-12"
 2194	tolerable eggnog	4	good	Last Available: "2006-12"
 2195	flavorless miniature unspeakable fruitcake	2	decent	Last Available: "2006-12"
 2196	normal thick gingerbread horror	5	good	Last Available: "2006-12"
 2197	activated oxidized but probably evil chocolate	0		Effect: "Gonna Get You, Sucker", Effect Duration: 65, Last Available: "2006-12"
-2198	snack-sized spoiled bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	miniature tasty huge skull-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	enchanted diet stale twirling tombstone-shaped Crimboween cookie	1	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2198	spoiled snack-sized bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2199	tasty miniature huge skull-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2200	enchanted stale diet twirling tombstone-shaped Crimboween cookie	1	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	auspicious plastic gift-wrapping vampire	0		Item Drop: +10, Last Available: "2006-12"
 2202	skewed strapping plastic yuletide troll	0		Muscle: +5, Last Available: "2006-12"
 2203	gravedigger's plastic skeletal reindeer	0		Spooky Damage: +10, Single Equip, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	red mansplainer's Crimbo tiki necklace	0		Monster Level: +15, Last Available: "2006-12"
 2208	scorching sage bobble-hip hula elf doll	0		Mysticality Percent: +10, Hot Damage: +25, Last Available: "2006-12"
 2209	teal shaking mirror Crimbo ukulele of the bloodbag	0		Maximum HP: +100, Last Available: "2006-12"
-2210	wholesome Tiki lighter of extreme caution	0		Maximum HP Percent: +10, Monster Level: -25, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	huge Lo Pan's brainy deck of tropical cards	0		Mysticality: +5, Spell Critical Percent: +30, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	vibrating brawny tropical paperweight	0		Muscle Percent: +20, Maximum MP Percent: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	wholesome Tiki lighter of extreme caution	0		Maximum HP Percent: +10, Monster Level: -25, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	huge Lo Pan's brainy deck of tropical cards	0		Mysticality: +5, Spell Critical Percent: +30, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	vibrating brawny tropical paperweight	0		Muscle Percent: +20, Maximum MP Percent: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	purple shaking tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	upside-down green tropical wrapping paper	0		Last Available: "2006-12"
-2215	arcane researcher's Tropical Crimbo Hat	0		Experience Percent (Mysticality): +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	Tropical Crimbo Shorts of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	arcane researcher's Tropical Crimbo Hat	0		Experience Percent (Mysticality): +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	Tropical Crimbo Shorts of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	fancy yummy super ka-bob	3	awesome	Effect: "Arresistible", Effect Duration: 10
-2218	jumbo rotten beer basted brat	5	crappy	
+2218	rotten jumbo beer basted brat	5	crappy	
 2219	skewed Tropical Crimbo Sword of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2006-12"
 2220	alkaline teal and Crimboween candy	0		Effect: "Your Eyes are Peeled!", Effect Duration: 67, Last Available: "2020-09"
-2221	teal bouncing Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	shaking blue Sherlock's studded liar's pants	0		Damage Absorption: +80, Item Drop: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2221	bouncing teal Great Ball of Frozen Fire	0		Last Available: "2007-01"
+2222	shaking blue Sherlock's studded liar's pants	0		Damage Absorption: +80, Item Drop: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	frosty Temple Grandin's juggler's balls	0		Familiar Weight: +7, Cold Spell Damage: +10, Softcore Only, Last Available: "2007-01"
 2224	inspector's pink shirt	0		Item Drop: +15, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2204,7 +2204,7 @@
 2229	anodized toad horn	0		Effect: "El Vibrations", Effect Duration: 41, Last Available: "2007-01"
 2230	blinking icicle katana	0		Familiar Weight: +5
 2231	mote	0		
-2232	twirling squat smudged alchemical recipe	0		
+2232	squat twirling smudged alchemical recipe	0		
 2233	squat Herculean bow tie	0		Experience (Muscle): +1, Clowniness: 75
 2234	squat squat reassuring calavera concertina	0		Spooky Resistance: +1, Song Duration: 7
 2235	ghostly reassuring deadly ratarang	0		Weapon Damage: +5, Spooky Resistance: +1
@@ -2240,13 +2240,13 @@
 2266	wet stunt nut stew	0		
 2267	ghostly Mega Gem	0		
 2268	Staff of Fats of the early riser	0		Adventures: +7
-2269	bland miniature sausage wonton	2	decent	
+2269	miniature bland sausage wonton	2	decent	
 2270	pulsating purple wholesome smooth belt	0		Moxie: +15, Maximum HP Percent: +10, Single Equip
 2271	drinkable cyan bottle of Merlot	4	good	
 2272	lousy skewed bottle of Port	3	decent	
 2273	perfectly mixed shaking bottle of Pinot Noir	3	EPIC	
 2274	bad extra-dry bottle of Zinfandel	5	decent	
-2275	fancy artisanal bottle of Marsala	4	EPIC	Effect: "Some Cheese with Your Wine", Effect Duration: 30
+2275	artisanal fancy bottle of Marsala	4	EPIC	Effect: "Some Cheese with Your Wine", Effect Duration: 30
 2276	watered-down drinkable bottle of Muscat	2	good	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2256,7 +2256,7 @@
 2282	Manual of Dexterity	0		
 2283	asbestos-lined seal-skull helmet	0		Hot Resistance: +5, Familiar Effect: "atk, cap 2"
 2284	mirror petrified noodles	0		
-2285	gray shaking chisel	0		
+2285	shaking gray chisel	0		
 2286	Eye of Ed	0		
 2287	twirling glowstick of the boozehound	0		Item Drop: +5, Booze Drop: +100, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
@@ -2273,7 +2273,7 @@
 2299	EZ-Play Harmonica Book	0		
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
-2302	squat teal worm-riding hooks	0		
+2302	teal squat worm-riding hooks	0		
 2303	blinking Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	warmed gray candy heart	0		Effect: "Booing Radly", Effect Duration: 52, Last Available: "2007-02"
 2305	electrified pink candy heart	0		Effect: "Ogred and Oublietted", Effect Duration: 37, Last Available: "2007-02"
@@ -2287,7 +2287,7 @@
 2313	candygram	0		Last Available: "2007-02"
 2314	shaking candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
-2316	skewed tumbling broken carburetor	0		
+2316	tumbling skewed broken carburetor	0		
 2317	olive bronze token	0		
 2318	bomb	0		
 2319	spinning carved wheel	0		
@@ -2309,12 +2309,12 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	gray zippy weightlifter's pipe	0		Muscle: +15, Initiative: +20
 2337	strapping reinforced beaded headband	0		Muscle: +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	tiny tasty pudding	1	awesome	Wiki Name: "black pudding (food)"
-2339	artisanal special jittery skewed Blackfly Chardonnay	4	EPIC	Effect: "Fishy", Effect Duration: 45
+2338	tasty tiny pudding	1	awesome	Wiki Name: "black pudding (food)"
+2339	special artisanal skewed jittery Blackfly Chardonnay	4	EPIC	Effect: "Fishy", Effect Duration: 45
 2340	smooth watered-down & tan	2	awesome	
 2341	mirror pepper	0		
-2342	huge rotten shaking tumbling forest cake	8	crappy	
-2343	gigantic adequate enchanted forest ham	6	good	Effect: "Overstimulated", Effect Duration: 35
+2342	huge rotten tumbling shaking forest cake	8	crappy	
+2343	enchanted gigantic adequate forest ham	6	good	Effect: "Overstimulated", Effect Duration: 35
 2344	galvanized narrow filthworm hatchling scent gland	0		Effect: "Bright!", Effect Duration: 68
 2345	polarized boiled blurry filthworm drone scent gland	0		Effect: "Rotten Memories", Effect Duration: 57
 2346	cold-filtered deionized filthworm royal guard scent gland	0		Effect: "Sagittarius Rising", Effect Duration: 39
@@ -2322,7 +2322,7 @@
 2348	water pipe bomb	0		
 2349	gas balloon	0		
 2350	beer bomb	0		
-2351	pulsating jittery superamplified boom box	0		
+2351	jittery pulsating superamplified boom box	0		
 2352	mansplainer's supercool fire poi	0		Moxie Percent: +20, Monster Level: +15
 2353	wicked bejeweled pledge pin	0		Spell Damage: +5, Single Equip
 2354	communications windchimes	0		
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	squat smoke bomb	0		
 2372	shaking bunch of bananas	0		
-2373	big enchanted stale blinking banana	5	decent	Effect: "Extra-Thick Blood", Effect Duration: 20
+2373	enchanted stale big blinking banana	5	decent	Effect: "Extra-Thick Blood", Effect Duration: 20
 2374	banana peel	0		
-2375	yummy gigantic blue banana cream pie	6	awesome	
+2375	gigantic yummy blue banana cream pie	6	awesome	
 2376	weak artisanal banana daiquiri	2	EPIC	
 2377	weak perfectly mixed bungle in the jungle	2	super EPIC	
 2378	banana spritzer	0		
@@ -2407,7 +2407,7 @@
 2433	ionized bottle of antifreeze	0		Effect: "BOOsted", Effect Duration: 54
 2434	concentrated eyedrops	0		Effect: "Patent Alacrity", Effect Duration: 41
 2435	Vulcanized wobbly Dogsgotnonoz pills	0		Effect: "You Know When to Walk Away", Effect Duration: 21
-2436	quadruple-warmed flattened blurry huge donkey flipbook	0		Effect: "Ghostly Shell", Effect Duration: 59
+2436	quadruple-warmed flattened huge blurry donkey flipbook	0		Effect: "Ghostly Shell", Effect Duration: 59
 2437	New Cloaca-Cola	0		
 2438	squat scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
@@ -2433,10 +2433,10 @@
 2459	Lo Pan's tighty whiteys	0		Spell Critical Percent: +30, Familiar Effect: "sleaze atk, 3xVolley, cap 10"
 2460	cyan yak toupee of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
-2463	red huge Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
+2463	huge red Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	spoiled bowl of Bounty-Os	3	crappy	
-2465	smooth strong spinning Oreille Divis&eacute;e brandy	5	awesome	
-2466	squat spinning pompadour'd puppy	0		
+2465	strong smooth spinning Oreille Divis&eacute;e brandy	5	awesome	
+2466	spinning squat pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	tumbling callused fingerbone	0		
 2469	bundle of receipts	0		
@@ -2475,7 +2475,7 @@
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
 2504	precious piercing post	0		
-2505	green bouncing necklace chain	0		
+2505	bouncing green necklace chain	0		
 2506	huge beach glass bead	0		
 2507	tumbling clay peace-sign bead	0		
 2508	wobbly grievous beach glass necklace	0		Weapon Damage Percent: +50
@@ -2489,13 +2489,13 @@
 2516	stanky wrench bracelet of wisdom	0		Mysticality: +15, Stench Spell Damage: +25
 2517	ghostly manspreader's wizardly chain necklace	0		Mysticality: +25, Monster Level: +10
 2518	blurry rosewater-soaked sawblade shield	0		Stench Resistance: +3, Damage Reduction: 11
-2519	perfectly mixed fancy McMillicancuddy's Special Lager	3	EPIC	Effect: "Steroid Boost", Effect Duration: 15
+2519	fancy perfectly mixed McMillicancuddy's Special Lager	3	EPIC	Effect: "Steroid Boost", Effect Duration: 15
 2520	enchanted perfectly mixed melted Jell-o shot	3	EPIC	Effect: "Fan-Cooled", Effect Duration: 10
-2521	lousy practically non-alcoholic gray cruelty-free wine	1	decent	
+2521	practically non-alcoholic lousy gray cruelty-free wine	1	decent	
 2522	drinkable watered-down thistle wine	2	good	
 2523	twirling megatofu	0		
 2524	displaced fish	0		
-2525	thick tasty fish	5	awesome	
+2525	tasty thick fish	5	awesome	
 2526	rotten jumbo fish casserole	5	crappy	
 2527	stale small fish lasagna	2	decent	
 2528	blurry filet of tangy gnat (&quot;fotelif&quot;)	0		
@@ -2512,13 +2512,13 @@
 2539	censurious Ankh of Badahnkadh	0		Sleaze Resistance: +3, Single Equip
 2540	tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
-2542	concentrated super-activated fuchsia blurry lesser grodulated violet	0		Effect: "Destructive Resolve", Effect Duration: 18, Last Available: "2007-05"
+2542	concentrated super-activated blurry fuchsia lesser grodulated violet	0		Effect: "Destructive Resolve", Effect Duration: 18, Last Available: "2007-05"
 2543	irradiated tumbling tin magnolia	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 16, Last Available: "2007-05"
 2544	chilled frozen adjusted begpwnia	0		Effect: "Wit Tea", Effect Duration: 28, Last Available: "2007-05"
 2545	Vulcanized upsy daisy	0		Effect: "Buttermilk Boogie", Effect Duration: 15, Last Available: "2007-05"
 2546	anodized quantum super-nitrogenated mirror half-orchid	0		Effect: "Cold Hands", Effect Duration: 53, Last Available: "2007-05"
 2547	avaricious tin star of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +30, Last Available: "2007-05"
-2548	prompt experienced outrageous sombrero	0		Experience: +2, Adventures: +3, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	prompt experienced outrageous sombrero	0		Experience: +2, Adventures: +3, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	skewed frightening foul-smelling &quot;Humorous&quot; T-shirt	0		Stench Damage: +10, Spooky Damage: +5, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2540,7 +2540,7 @@
 2567	Azazel's lollipop	0		
 2568	huge Azazel's tutu	0		
 2569	tarnished triple-magnetized ant agonist	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 24
-2570	mirror huge ant hoe	0		Familiar Effect: "sleaze damage, meat"
+2570	huge mirror ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	spinning ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
@@ -2551,7 +2551,7 @@
 2578	fireproof chilly Staff of the Short Order Cook of the businessman	0		Cold Damage: +5, Hot Resistance: +3, Meat Drop: +50
 2579	tiny rotten cactus fruit	1	crappy	
 2580	censurious scorpion whip of Gandalf	0		Spell Critical Percent: +20, Sleaze Resistance: +3
-2581	ghostly wobbly handful of sand	0		
+2581	wobbly ghostly handful of sand	0		
 2582	mirror brick of sand	0		
 2583	special normal olive centipede eggs	3	good	Effect: "Rave Concentration", Effect Duration: 45
 2584	lard-coated wonderwall shield	0		Sleaze Spell Damage: +25, Damage Reduction: 12
@@ -2559,15 +2559,15 @@
 2586	stanky General Sage's Lonely Diamonds Club Jacket	0		Stench Spell Damage: +25
 2587	squat Corporal Fennel's Lonely Clubs Club Jacket of the blizzard	0		Cold Spell Damage: +25
 2588	maroon brainy Private Pepper's Lonely Hearts Club Jacket	0		Mysticality: +5
-2589	miniature decent hot date	2	good	
-2590	acceptable purple blurry distilled fortified wine	3	good	
-2591	small bland tasty tart	2	decent	
+2589	decent miniature hot date	2	good	
+2590	acceptable blurry purple distilled fortified wine	3	good	
+2591	bland small tasty tart	2	decent	
 2592	blurry Knob Goblin lunchbox	0		
 2593	rotten Knob pasty	3	crappy	
 2594	delicious fancy pulsating thermos full of Knob coffee	3	awesome	Effect: "Prince of Seaside Town", Effect Duration: 30
 2595	chilled blurry Ben-Gal&trade; Balm	0		Effect: "Puddingface", Effect Duration: 41
 2596	leathery cat skin	0		
-2597	mirror red leathery bat skin	0		
+2597	red mirror leathery bat skin	0		
 2598	leathery rat skin	0		
 2599	Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	maroon upside-down mojo filter	0		
-2615	flavorless half-sized blurry savoy truffle	2	decent	
+2615	half-sized flavorless blurry savoy truffle	2	decent	
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	purple Iiti Kitty phone charm of terror	0		Spooky Spell Damage: +10, Single Equip
@@ -2631,12 +2631,12 @@
 2658	perfectly mixed bottle of realpagne	3	EPIC	Last Available: "2007-06"
 2659	lard-coated albatross necklace	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2007-06"
 2660	compressed blurry upside-down not-a-pipe	1	crappy	Last Available: "2007-06"
-2661	weak tolerable blinking flask of Amontillado	2	good	Last Available: "2007-06"
-2662	upside-down Lo Pan's ball mask	0		Spell Critical Percent: +30, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	chaotic Can-Can skirt	0		Spell Critical Percent: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2661	tolerable weak blinking flask of Amontillado	2	good	Last Available: "2007-06"
+2662	upside-down Lo Pan's ball mask	0		Spell Critical Percent: +30, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	chaotic Can-Can skirt	0		Spell Critical Percent: +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	denatured adjusted sensitive poetry journal	0		Effect: "Pyromania", Effect Duration: 22, Last Available: "2007-06"
 2665	polymerized magnetized bottled inspiration	0		Effect: "Gemini Rising", Effect Duration: 69, Last Available: "2007-06"
-2666	quadruple-magnetized corrupted super-nitrogenated blue narrow blinking bellhop bell	0		Effect: "Libra Rising", Effect Duration: 40, Last Available: "2007-06"
+2666	quadruple-magnetized corrupted super-nitrogenated blue blinking narrow bellhop bell	0		Effect: "Libra Rising", Effect Duration: 40, Last Available: "2007-06"
 2667	colloidal spiky collar	0		Effect: "Uncucumbered", Effect Duration: 20, Last Available: "2007-06"
 2668	compressed narrow can-can-in-a-can	1		Last Available: "2007-06"
 2669	diluted narrow patent antipsychotics	1		Last Available: "2007-06"
@@ -2647,11 +2647,11 @@
 2674	double-warmed irradiated diffused narrow mirror bottle of cat tonic	0		Effect: "The Power of Negative Thinking", Effect Duration: 63, Last Available: "2007-06"
 2675	vaporized pulsating handful of moss	1		
 2676	distilled bit-o-cactus	1		
-2677	mixed mirror pulsating protein powder	1		
+2677	mixed pulsating mirror protein powder	1		
 2678	cyan spectre scepter	0		
 2679	tarnished mirror sparkler	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 29
 2680	non-activated energized snake	0		Effect: "Fever From the Flavor", Effect Duration: 55, Wiki Name: "snake"
-2681	liquefied dry pulsating purple M-242	0		Effect: "The Style... of the Future", Effect Duration: 21
+2681	liquefied dry purple pulsating M-242	0		Effect: "The Style... of the Future", Effect Duration: 21
 2682	detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	occult brainy armgun	0		Mysticality: +5, Spell Damage Percent: +25
@@ -2682,7 +2682,7 @@
 2709	gray exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
 2711	oxidized facepaint	0		Effect: "Sugar, Hello", Effect Duration: 50
-2712	alkaline liquefied cyan bouncing sheepskin diploma	0		Effect: "Bats in the Belfry", Effect Duration: 42
+2712	alkaline liquefied bouncing cyan sheepskin diploma	0		Effect: "Bats in the Belfry", Effect Duration: 42
 2713	alkaline gray Black Body&trade; spray	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 12
 2714	floorboard cruft	0		
 2715	blurry sausage bomb	0		
@@ -2696,22 +2696,22 @@
 2723	squat shaking Staff of the Grand Flamb&eacute; of wisdom of chilblains of temperance	0		Mysticality: +15, Cold Damage: +25, Sleaze Resistance: +5
 2724	adequate bowl of rye sprouts	3	good	
 2725	normal cob of corn	3	good	
-2726	fancy adequate juniper berries	3	good	Effect: "Guts Feeling", Effect Duration: 30
+2726	adequate fancy juniper berries	3	good	Effect: "Guts Feeling", Effect Duration: 30
 2727	adequate bite-sized plum	1	good	
-2728	snack-sized moldy mirror pear	2	crappy	
-2729	bland diet peach	1	decent	
+2728	moldy snack-sized mirror pear	2	crappy	
+2729	diet bland peach	1	decent	
 2730	lousy purple plum wine	3	decent	
 2731	tolerable shot of pear schnapps	3	good	
-2732	irresponsibly strong artisanal twirling shot of peach schnapps	6	EPIC	
+2732	artisanal irresponsibly strong twirling shot of peach schnapps	6	EPIC	
 2733	rotten blurry bunch of square grapes	4	crappy	
-2734	flavorless huge pulsating brown sugar cane	6	decent	
+2734	huge flavorless pulsating brown sugar cane	6	decent	
 2735	small spoiled bouncing sandwich of the gods	2	crappy	
 2736	drinkable Pan-Dimensional Gargle Blaster	3	good	
 2737	twisted wobbly leopard-print barbell	1	awesome	
 2738	mirror pile of smoking rags	0		
 2739	polarized purple panty raider camouflage	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 44
 2740	fireproof flame-retardant dog trainer's Staff of the Walk-In Freezer	0		Experience (familiar): +1, Hot Resistance: 4
-2741	practically non-alcoholic acceptable narrow boilermaker	1	good	
+2741	acceptable practically non-alcoholic narrow boilermaker	1	good	
 2742	moldy steel lasagna	3	quest	
 2743	mediocre steel margarita	4	quest	
 2744	distilled steel-scented air freshener	1		
@@ -2737,8 +2737,8 @@
 2764	jittery blinking family-friendly knitted MacGyver's Order of the Silver Wossname	0		Maximum MP: +100, Cold Resistance: +3, Sleaze Resistance: +1, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	stale enchanted Crimbo pie	3	decent	Effect: "New and Improved", Effect Duration: 30
-2768	delicious miniature pear tart	2	awesome	
+2767	enchanted stale Crimbo pie	3	decent	Effect: "New and Improved", Effect Duration: 30
+2768	miniature delicious pear tart	2	awesome	
 2769	spoiled peach pie	3	crappy	
 2770	altered chunk of rock salt	0		Effect: "Almost Cool", Effect Duration: 14
 2771	corrupted extra-quantum ghostly handful of pine needles	0		Effect: "Influence of Sphere", Effect Duration: 65
@@ -2789,9 +2789,9 @@
 2816	blurry prompt greedy miser's Boxers	0		Meat Drop: 30, Adventures: +3, Familiar Effect: "1xVolley, 1xLep"
 2817	horrifying stanky nasty Brooch	0		Stench Damage: +5, Stench Spell Damage: +25, Spooky Damage: +25, Single Equip
 2818	toasty curative Bracelet of James Dean	0		Experience (Moxie): +3, Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip
-2819	lime green narrow Grimacite gasmask of the pedagogue of the scaredy-cat	0		Experience: +3, Monster Level: -15, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	lime green narrow Grimacite gasmask of the pedagogue of the scaredy-cat	0		Experience: +3, Monster Level: -15, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	maroon rosewater-soaked wool Grimacite gat	0		Cold Resistance: +1, Stench Resistance: +3, Last Available: "2008-11"
-2821	frightening Grimacite gaiters of the pedagogue	0		Experience: +3, Spooky Damage: +5, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	frightening Grimacite gaiters of the pedagogue	0		Experience: +3, Spooky Damage: +5, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	sharpshooter's resourceful Grimacite gauntlets	0		Maximum MP: +50, Critical Hit Percent: +10, Single Equip, Last Available: "2008-11"
 2823	Grimacite go-go boots of the pedagogue	0		Experience: +3, Item Drop: +5, Single Equip, Last Available: "2008-11"
 2824	rosy-cheeked wholesome Grimacite girdle	0		Maximum HP Percent: 40, Single Equip, Last Available: "2008-11"
@@ -2807,7 +2807,7 @@
 2834	dog trainer's bottle-rocket crossbow of the ox of doom	0		Muscle: +20, Experience (familiar): +1, Spooky Spell Damage: +50, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	wobbly indie comic hipster glasses of courage	0		Spooky Resistance: +3, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
-2837	olive mirror mint-condition magic wand	0		Last Available: "2011-12"
+2837	mirror olive mint-condition magic wand	0		Last Available: "2011-12"
 2838	ribald glowstick of the sewer	0		Stench Damage: +25, Sleaze Damage: +10, Last Available: "2007-08"
 2839	blurry wholesome Periodical Paintbrush	0		Maximum HP Percent: +10, Softcore Only
 2840	acceptable bottle of cooking sherry	4	good	
@@ -2913,7 +2913,7 @@
 2940	rotten wobbly Surprise Egg	4	crappy	
 2941	non-vacuum-sealed huge Steal This Candy	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 65
 2942	activated diffused blinking chocolate filthy lucre	0		Effect: "Prideful Strut", Effect Duration: 35
-2943	adjusted squat teal blinking Angry Farmer's Wife Candy	0		Effect: "Horrid, Torrid", Effect Duration: 14
+2943	adjusted squat blinking teal Angry Farmer's Wife Candy	0		Effect: "Horrid, Torrid", Effect Duration: 14
 2945	blurry sage party hat of the cougar	0		Moxie: +20, Mysticality Percent: +10, Familiar Effect: "4xLep, cap 7"
 2946	manspreader's fortified V for Vivala mask	0		Damage Absorption: +60, Monster Level: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
@@ -2924,13 +2924,13 @@
 2952	miser's chaotic glowstick	0		Spell Critical Percent: +10, Meat Drop: +10, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	upside-down ruddy tip jar	0		Maximum HP Percent: +40
-2955	enchanted super-sized stale yam candy	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 35
+2955	super-sized stale enchanted yam candy	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 35
 2956	narrow cocktail napkin	0		
 2957	cyan rum barrel charrrm	0		
 2958	jumbo bland mirror tube of cranberry Go-Goo	5	decent	
 2959	rum barrel charrrm bracelet of terror	0		Spooky Spell Damage: +10
 2960	bland single-serving herbal stuffing	3	decent	
-2961	enchanted small tasty packet of tofurkey gravy	2	awesome	Effect: "Frost Tea", Effect Duration: 20
+2961	enchanted tasty small packet of tofurkey gravy	2	awesome	Effect: "Frost Tea", Effect Duration: 20
 2962	decent small tofurkey nugget	2	good	
 2963	wobbly rigging shampoo	0		
 2964	ball polish	0		
@@ -2987,7 +2987,7 @@
 3015	pulsating gilded key	0		
 3016	foot locker	0		
 3017	ornate chest	0		
-3018	twirling tumbling gilded chest	0		
+3018	tumbling twirling gilded chest	0		
 3019	lime green all-purpose cleaner	0		
 3020	narrow handful of sawdust	0		
 3021	pulsating stone triangle	0		
@@ -2995,17 +2995,17 @@
 3023	small stone triangle	0		
 3024	bouncing stone pyramid	0		
 3025	drinkable corpse on the beach	3	good	
-3026	weak delicious spinning corpsetini	2	awesome	
+3026	delicious weak spinning corpsetini	2	awesome	
 3027	tolerable corpsedriver	3	good	
 3028	bad Corpse Island iced tea	4	decent	
-3029	weak hand-crafted red-headed corpse	2	EPIC	
+3029	hand-crafted weak red-headed corpse	2	EPIC	
 3030	fancy perfectly mixed kamicorpse-ee	4	EPIC	Effect: "Dreadful Sheen", Effect Duration: 45
-3031	drinkable triple-distilled corpsel	9	good	
-3032	distilled acceptable enchanted blurry corpsebite	5	good	Effect: "Bells in the Batfry", Effect Duration: 25
+3031	triple-distilled drinkable corpsel	9	good	
+3032	enchanted distilled acceptable blurry corpsebite	5	good	Effect: "Bells in the Batfry", Effect Duration: 25
 3033	bouncing blinking rosy-cheeked pirate fledges	0		Maximum HP Percent: +30
 3034	piece of thirteen	0		
 3035	bland blurry pearl onion	4	decent	
-3036	flavorless blinking green sea biscuit	4	decent	
+3036	flavorless green blinking sea biscuit	4	decent	
 3037	perfectly mixed wobbly bottle of rum	3	EPIC	
 3038	lousy red bottle of black-label rum	4	decent	
 3039	cannonball	0		
@@ -3013,10 +3013,10 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	blinking metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	normal small nanite-infested gingerbread bugbear	2	good	Last Available: "2007-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	small normal nanite-infested gingerbread bugbear	2	good	Last Available: "2007-12"
 3046	half-sized flavorless nanite-infested candy cane	2	decent	Last Available: "2020-09"
-3047	flavorless fuchsia mirror nanite-infested fruitcake	3	decent	Last Available: "2007-12"
+3047	flavorless mirror fuchsia nanite-infested fruitcake	3	decent	Last Available: "2007-12"
 3048	lousy nanite-infested eggnog	4	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	aromatic eyepatch	0		Stench Resistance: +1, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	quantum candy heart	0		Effect: "Chorale of Companionship", Effect Duration: 29, Last Available: "2007-02"
 3055	chilled ionized cymbal syrup	0		Free Pull, Effect: "Certainty", Effect Duration: 31, Last Available: "2007-02"
-3056	censurious metallic foil cat ears	0		Sleaze Resistance: +3, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	censurious metallic foil cat ears	0		Sleaze Resistance: +3, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	ghostly theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	marionette collective of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,14 +3057,14 @@
 3085	mirror scorching roboduck-on-a-string of the glutton	0		Hot Damage: +25, Food Drop: +100, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	squat hardened biomechanical crimborg helmet of the brute	0		Muscle Percent: +30, Damage Reduction: 3, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	squat hardened biomechanical crimborg helmet of the brute	0		Muscle Percent: +30, Damage Reduction: 3, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	skewed scandalous occult C.B.F.G.	0		Spell Damage Percent: +25, Sleaze Damage: +5, Last Available: "2007-12"
-3090	spinning narrow rock-hard biomechanical crimborg leg armor of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	spinning narrow rock-hard biomechanical crimborg leg armor of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	magnetized vitachoconutriment capsule	0		Effect: "Charrrming", Effect Duration: 15, Last Available: "2007-12"
 3092	handmade hobby horse of the storm	0		Maximum MP Percent: +40, Last Available: "2007-12"
 3093	ball-in-a-cup of the brazier	0		Hot Spell Damage: +25, Last Available: "2007-12"
 3094	set of jacks of the blizzard	0		Cold Spell Damage: +25, Last Available: "2007-12"
-3095	adequate gigantic laser-broiled pear	7	good	Last Available: "2007-12"
+3095	gigantic adequate laser-broiled pear	7	good	Last Available: "2007-12"
 3096	huge polyalloy shield of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100, Damage Reduction: 9, Last Available: "2007-12"
 3097	skewed skewed fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
@@ -3092,13 +3092,13 @@
 3120	maroon divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
-3123	upside-down narrow divine champagne flute	0		Last Available: "2008-01"
+3123	narrow upside-down divine champagne flute	0		Last Available: "2008-01"
 3124	oxidized irradiated ghostly fruitfilm	0		Effect: "Hella Smooth", Effect Duration: 12
 3125	triple-unsweetened quadruple-adjusted blue piece of after eight	0		Effect: "Weapon of Mass Destruction", Effect Duration: 52
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	immense adequate blinking roasted marshmallow	6	good	
+3129	adequate immense blinking roasted marshmallow	6	good	
 3130	disc	0		Last Available: "2008-01"
 3131	spoiled tin cup of mulligan stew	3	crappy	
 3132	cyan nippy wicked flamin' bindle	0		Spell Damage: +5, Cold Damage: +10
@@ -3138,7 +3138,7 @@
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	anodized galvanized seal eyeball	0		Effect: "Mutated", Effect Duration: 28
-3169	gigantic decent turtle soup	7	good	Effect: "[598]A Little Bit Evil"
+3169	decent gigantic turtle soup	7	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	skewed nauseating reagent	0		
 3172	perfumed evil paper umbrella	0		Stench Resistance: +5
@@ -3146,7 +3146,7 @@
 3174	miniature moldy evil boring spaghetti	2	crappy	
 3175	spoiled small shaking evil noodles	2	crappy	
 3176	small stale green evil noodles	2	decent	
-3177	small spoiled pulsating evil painful penne pasta	2	crappy	
+3177	spoiled small pulsating evil painful penne pasta	2	crappy	
 3178	normal 3vi1 pr0n m4nic0tti	3	good	
 3179	flavorless tumbling evil ravioli della hippy	3	decent	
 3180	delicious evil noodles	4	awesome	
@@ -3154,7 +3154,7 @@
 3182	quantum evil libation of liveliness	0		Effect: "Healthy Red Glow", Effect Duration: 57
 3183	concentrated polarized evil tomato juice of powerful power	0		Effect: "A View to Some Meat", Effect Duration: 39
 3184	irradiated dry super-polarized bouncing evil eyedrops of the ermine	0		Effect: "The Best a Pirate Can Get", Effect Duration: 11
-3185	polymerized frozen tumbling wobbly evil ointment of the occult	0		Effect: "Chalked Weapon", Effect Duration: 23
+3185	polymerized frozen wobbly tumbling evil ointment of the occult	0		Effect: "Chalked Weapon", Effect Duration: 23
 3186	dry oxidized pulsating evil serum of sarcasm	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 45
 3187	pickled adjusted jittery evil philter of phorce	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 55
 3188	tolerable an evil sump'm sump'm	3	good	
@@ -3174,7 +3174,7 @@
 3202	reassuring double-paned dance instructor's KoL Con IV Pole	0		Experience Percent (Moxie): +10, Cold Resistance: +5, Spooky Resistance: +1, Last Available: "2007-09"
 3203	dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
-3205	jittery tumbling dwarvish war mattock	0		
+3205	tumbling jittery dwarvish war mattock	0		
 3206	mirror dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	small laminated card	0		
@@ -3194,9 +3194,9 @@
 3222	upside-down upside-down gatorskin umbrella of the brazier of the cheetah	0		Hot Spell Damage: +25, Initiative: +60
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	drinkable practically non-alcoholic bottle of sewage schnapps	1	good	
+3225	practically non-alcoholic drinkable bottle of sewage schnapps	1	good	
 3226	lousy weak skewed bottle of Ooze-O	2	decent	
-3227	bland gigantic C.H.U.M. chum	9	decent	
+3227	gigantic bland C.H.U.M. chum	9	decent	
 3228	decent snack-sized unfortunate dumplings	2	good	
 3229	upside-down decaying goldfish liver	0		
 3230	ionized moist moist oil of oiliness	0		Effect: "Eagle Eyes", Effect Duration: 31
@@ -3211,7 +3211,7 @@
 3239	jittery Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	huge Travels with Jerry	0		Skill: "Mudbath"
-3242	jittery ghostly Let Me Be!	0		Skill: "Raise Backup Dancer"
+3242	ghostly jittery Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	blue Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	Summer Nights	0		Skill: "Grease Lightning"
 3245	blue Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
@@ -3248,7 +3248,7 @@
 3276	black-and-blue light	0		Last Available: "2008-04"
 3277	squat Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	therapeutic studded belt	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-04"
-3279	blue bouncing pulsating personal massager	0		Last Available: "2008-04"
+3279	pulsating bouncing blue personal massager	0		Last Available: "2008-04"
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	stick-on eyebrow piercing of incineration	0		Hot Spell Damage: +50, Last Available: "2008-04"
@@ -3269,7 +3269,7 @@
 3297	stray chihuahua	0		
 3298	jittery pretty pink bow	0		
 3299	smiley-face sticker	0		
-3300	blurry bouncing farfalle bow tie	0		
+3300	bouncing blurry farfalle bow tie	0		
 3301	bouncing jalape&ntilde;o slices	0		
 3302	squat stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
@@ -3292,11 +3292,11 @@
 3320	brainy frayed rope belt	0		Mysticality: +5, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
 3322	huge lightning-fast quilted mayfly bait necklace	0		Damage Absorption: +40, Initiative: +40, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
-3323	tumbling teal Ol' Scratch's salad fork	0		
+3323	teal tumbling Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	lousy practically non-alcoholic mirror jar of fermented pickle juice	1	decent	
-3326	pickled squat gray voodoo snuff	1	decent	
-3327	normal immense bouncing huge extra-greasy slider	6	good	
+3326	pickled gray squat voodoo snuff	1	decent	
+3327	immense normal bouncing huge extra-greasy slider	6	good	
 3328	spinning chaotic sharpshooter's crumpled felt fedora	0		Critical Hit Percent: +10, Spell Critical Percent: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	manspreader's slick battered top-hat	0		Moxie: +10, Monster Level: +10, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	resourceful shapeless wide-brimmed hat of chilblains	0		Maximum MP: +50, Cold Damage: +25, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3309,11 +3309,11 @@
 3337	avaricious razor-sharp dead guy's memento	0		Weapon Damage Percent: +25, Meat Drop: +30, Single Equip
 3338	spoiled gigantic banquet	8	crappy	
 3339	sharpened hubcap	0		
-3340	pulsating narrow very caltrop	0		
+3340	narrow pulsating very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	hobo monkey	0		
 3343	bindle	0		Familiar Weight: +5
-3344	lime green pulsating bed of coals	0		
+3344	pulsating lime green bed of coals	0		
 3345	air mattress	0		
 3346	olive filth-encrusted futon	0		
 3347	mirror comfy coffin	0		
@@ -3328,17 +3328,17 @@
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	blurry shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
-3359	bouncing cyan scrumptious ice ant	0		Last Available: "2008-06"
+3359	cyan bouncing scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	twirling yummy death watch beetle	0		Last Available: "2008-06"
 3362	fuchsia tasty louse	0		Last Available: "2008-06"
-3363	small decent mole mol&eacute;	2	good	Last Available: "2008-06"
-3364	weak acceptable huge Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
+3363	decent small mole mol&eacute;	2	good	Last Available: "2008-06"
+3364	acceptable weak huge Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
 3365	concentrated Climate Colada	0		Effect: "Grape Expectations", Effect Duration: 32, Last Available: "2008-06"
 3366	boiled twirling maroon digital underground potion	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 45, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	compressed fuchsia glimmering roc feather	1	decent	Last Available: "2008-06"
-3369	modified maroon wobbly glimmering phoenix feather	1		Last Available: "2008-06"
+3369	modified wobbly maroon glimmering phoenix feather	1		Last Available: "2008-06"
 3370	denatured bouncing glimmering penguin feather	1		Last Available: "2008-06"
 3371	powdered narrow teal glimmering buzzard feather	1		Last Available: "2008-06"
 3372	modified glimmering raven feather	1		Last Available: "2008-06"
@@ -3367,8 +3367,8 @@
 3395	teal chaotic wholesome Hodgman's porkpie hat	0		Maximum HP Percent: +10, Spell Critical Percent: +10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	skewed scandalous Hodgman's lobsterskin pants of bravery	0		Sleaze Damage: +5, Spooky Resistance: +5, Familiar Effect: "atk, 1xPotato"
 3397	Hodgman's bow tie of courage of the early riser	0		Spooky Resistance: +3, Adventures: +7, Single Equip
-3398	spirit-forward bad Hodgman's blanket	5	decent	
-3399	weak artisanal jar of squeeze	2	super ultra mega turbo EPIC	
+3398	bad spirit-forward Hodgman's blanket	5	decent	
+3399	artisanal weak jar of squeeze	2	super ultra mega turbo EPIC	
 3400	special stale bowl of fishysoisse	4	decent	Effect: "Leo Rising", Effect Duration: 40
 3401	oxidized double-modified deadly lampshade	0		Effect: "On the Trolley", Effect Duration: 41
 3402	polymerized blinking concentrated garbage juice	0		Effect: "Patched In", Effect Duration: 15
@@ -3422,7 +3422,7 @@
 3455	squat cotton candy bale	0		Last Available: "2008-08"
 3456	toasty trusty torch	0		Hot Damage: +5, Last Available: "2011-12"
 3457	sharpshooter's Junior Adventurer's merit badge	0		Critical Hit Percent: +10
-3458	quadruple-quantum squat ghostly STYX deodorant body spray	0		Effect: "Cool Spirit", Effect Duration: 20
+3458	quadruple-quantum ghostly squat STYX deodorant body spray	0		Effect: "Cool Spirit", Effect Duration: 20
 3459	irresponsibly strong bad white-label gin	6	decent	
 3460	super-sized moldy tin rations	5	crappy	
 3461	haiku challenge map	0		
@@ -3453,19 +3453,19 @@
 3486	dull fish scale	0		
 3487	twirling rough fish scale	0		
 3488	pristine fish scale	0		
-3489	bite-sized stale twirling beefy fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
-3490	miniature bland glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3489	stale bite-sized twirling beefy fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
+3490	bland miniature glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3491	bland half-sized slick fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3492	blinking padded fish scimitar	0		Damage Absorption: +20, Item Drop: +5
 3493	purple shaking auspicious clever fish stick	0		Maximum MP: +20, Item Drop: +10
 3494	mirror scorching nippy fish bazooka	0		Cold Damage: +10, Hot Damage: +25
 3495	improved liquefied blue sea salt crystal	0		Effect: "Tingly Biceps", Effect Duration: 59
 3496	quadruple-concentrated irradiated cyan bazookafish bubble gum	0		Effect: "Patent Avarice", Effect Duration: 24
-3497	irresponsibly strong bad bottle of Pete's Sake	8	decent	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	spinning witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	small flavorless twirling lime green canap&eacute;s	2	decent	
+3497	bad irresponsibly strong bottle of Pete's Sake	8	decent	
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	spinning witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3501	flavorless small twirling lime green canap&eacute;s	2	decent	
 3502	twisted thermos of brew	1	good	Effect: "Larger", Effect Duration: 35, Last Available: "2011-12"
 3503	tolerable fuchsia glass of brandy	3	good	Last Available: "2011-12"
 3504	jittery French slippers	0		
@@ -3492,7 +3492,7 @@
 3525	deionized activated temporary teardrop tattoo	0		Effect: "Slimy Hands", Effect Duration: 14
 3526	Temple Grandin's scratch 'n' sniff crossbow	0		Familiar Weight: +7, Last Available: "2008-11"
 3527	bouncing mutant rattlesnake egg	0		
-3528	jittery cyan mutant fire ant egg	0		
+3528	cyan jittery mutant fire ant egg	0		
 3529	mutant cactus bud	0		
 3530	mutant gila monster egg	0		
 3531	rattlesnake enrager	0		Familiar Weight: +5
@@ -3510,8 +3510,8 @@
 3543	bouncing inspector's supercharged depleted Grimacite gravy boat	0		Maximum MP Percent: +30, Item Drop: +15, Last Available: "2011-12"
 3544	knitted vibrating depleted Grimacite weightlifting belt	0		Maximum MP Percent: +10, Cold Resistance: +3, Single Equip, Last Available: "2011-12"
 3545	manspreader's brainy depleted Grimacite grappling hook	0		Mysticality: +5, Monster Level: +10, Single Equip, Last Available: "2011-12"
-3546	twirling extremely unsafe wizardly depleted Grimacite ninja mask	0		Mysticality: +25, Weapon Damage Percent: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	spinning Oprah's depleted Grimacite shinguards of incineration	0		Maximum MP Percent: +50, Hot Spell Damage: +50, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	twirling extremely unsafe wizardly depleted Grimacite ninja mask	0		Mysticality: +25, Weapon Damage Percent: +100, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	spinning Oprah's depleted Grimacite shinguards of incineration	0		Maximum MP Percent: +50, Hot Spell Damage: +50, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	Van der Graaf Rosewater's depleted Grimacite astrolabe	0		Mysticality Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-12"
 3549	mansplainer's vibrating KoL Con Cinco Pi&ntilde;ata Bat	0		Maximum MP Percent: +10, Monster Level: +15, Softcore Only, Last Available: "2008-09"
 3550	propeller beanie of the detective	0		Item Drop: +20, Familiar Effect: "atk, cap 7"
@@ -3523,13 +3523,13 @@
 3556	rotten sea cucumber	4	crappy	
 3557	spoiled blurry sea avocado	3	crappy	
 3558	toothsome sea lychee	3	awesome	
-3559	bland diet sea tangelo	1	decent	
+3559	diet bland sea tangelo	1	decent	
 3560	toothsome sea honeydew	4	awesome	
 3561	activated pressurized potion of puissance	0		Effect: "Sourpuss", Effect Duration: 56
 3562	modified pressurized potion of perspicacity	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 14
 3563	extra-irradiated wet mirror pressurized potion of pulchritude	0		Effect: "Bustle Hustlin'", Effect Duration: 25
 3564	delicious berry-infused sake	3	awesome	
-3565	extra-dry perfectly mixed citrus-infused sake	5	EPIC	
+3565	perfectly mixed extra-dry citrus-infused sake	5	EPIC	
 3566	acceptable practically non-alcoholic upside-down melon-infused sake	1	good	
 3567	slab of sponge	0		
 3568	family-friendly MacGyver's sponge helmet of the pedagogue	0		Experience: +3, Maximum MP: +100, Sleaze Resistance: +1, Familiar Effect: "atk, 1xFairy"
@@ -3540,14 +3540,14 @@
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	skewed sand dollar	0		
-3576	red mirror flytrap bezoar	0		
+3576	mirror red flytrap bezoar	0		
 3577	shaking bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	stale rice	4	decent	
-3584	adequate jumbo irradiated candy cane	5	good	Last Available: "2008-12"
+3584	jumbo adequate irradiated candy cane	5	good	Last Available: "2008-12"
 3585	bland small gingerbread mutant bugbear	2	decent	Last Available: "2008-12"
 3586	tolerable oozenog	3	good	Last Available: "2008-12"
 3587	boiled ionized sugar plum	0		Effect: "Hobonic", Effect Duration: 45, Last Available: "2008-12"
@@ -3588,17 +3588,17 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	skewed parasitic claw of bravery	0		Spooky Resistance: +5, Last Available: "2008-12"
-3625	skewed razor-sharp parasitic tentacles	0		Weapon Damage Percent: +25, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	perfumed parasitic headgnawer	0		Stench Resistance: +5, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	skewed razor-sharp parasitic tentacles	0		Weapon Damage Percent: +25, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	perfumed parasitic headgnawer	0		Stench Resistance: +5, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	cyan perfumed parasitic strangleworm	0		Stench Resistance: +5, Last Available: "2008-12"
 3628	red pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
-3630	lime green blurry narrow Crimbo crate	0		Last Available: "2008-12"
+3630	blurry narrow lime green Crimbo crate	0		Last Available: "2008-12"
 3631	quadruple-pickled double-irradiated squat Gummi-DNA	0		Effect: "Ghost Finger", Effect Duration: 49, Last Available: "2020-09"
 3632	blue radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	flame-retardant elven socks of the brute	0		Muscle Percent: +30, Hot Resistance: +1, Last Available: "2008-12"
 3634	blurry blinking vibrating beefy elven gloves	0		Muscle: +10, Maximum MP Percent: +10, Last Available: "2008-12"
-3635	healthy festive holiday hat of chilblains	0		Maximum HP Percent: +20, Cold Damage: +25, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	healthy festive holiday hat of chilblains	0		Maximum HP Percent: +20, Cold Damage: +25, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	flame-retardant lard-coated patent shoes	0		Sleaze Spell Damage: +25, Hot Resistance: +1, Last Available: "2008-12"
 3637	scorching gray bow tie of the bloodbag	0		Maximum HP: +100, Hot Damage: +25, Last Available: "2008-12"
 3638	electrified hardy penguin thesaurus	0		Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-12"
@@ -3608,15 +3608,15 @@
 3642	skewed dragonfish caviar	0		
 3643	fuchsia pufferfish spine	0		
 3644	shaking extremely unsafe depleted Grimacite kneecapping stick	0		Weapon Damage Percent: +100, Last Available: "2007-06"
-3645	perfectly mixed watered-down canteen of wine	2	EPIC	Last Available: "2008-12"
+3645	watered-down perfectly mixed canteen of wine	2	EPIC	Last Available: "2008-12"
 3646	decent gigantic elven <i>limbos</i> gingerbread	8	good	Last Available: "2008-12"
 3647	narrow elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	spoiled big toast with jam	5	crappy	Last Available: "2008-12"
-3651	gray antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	big spoiled toast with jam	5	crappy	Last Available: "2008-12"
+3651	gray antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	lousy elven moonshine	4	decent	Last Available: "2008-12"
-3653	small stale tumbling knuckle sandwich	2	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	stale small tumbling knuckle sandwich	2	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	flame-wreathed psycho sweater of the detective	0		Hot Spell Damage: +10, Item Drop: +20, Last Available: "2008-12"
 3655	maroon fin-bit wax	0		Familiar Weight: +5
 3656	careful plastic Mob Penguin	0		Monster Level: -10, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	dangerous plastic strand of DNA	0		Weapon Damage: +10, Last Available: "2008-12"
 3660	blinking resourceful plastic chunk of depleted Grimacite	0		Maximum MP: +50, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	skewed Putty mitre of the businessman	0		Meat Drop: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	zippy careful Putty leotard	0		Monster Level: -10, Initiative: +20, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	skewed Putty mitre of the businessman	0		Meat Drop: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	zippy careful Putty leotard	0		Monster Level: -10, Initiative: +20, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	scorching Putty ball	0		Hot Damage: +25, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	double-paned clever Putty snake of the ox	0		Muscle: +20, Maximum MP: +20, Cold Resistance: +5, Softcore Only, Last Available: "2009-01"
@@ -3647,20 +3647,20 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	miniature stale shaking tempura carrot	2	decent	
-3685	small adequate tempura cucumber	2	good	
+3684	stale miniature shaking tempura carrot	2	decent	
+3685	adequate small tempura cucumber	2	good	
 3686	half-sized rotten tempura avocado	2	crappy	
 3687	flavorless half-sized olive sea broccoli	2	decent	
 3688	bland half-sized huge sea cauliflower	2	decent	
 3689	flavorless tempura broccoli	4	decent	
 3690	decent huge tempura cauliflower	3	good	
-3691	half-sized flavorless bouncing sea blueberry	2	decent	
+3691	flavorless half-sized bouncing sea blueberry	2	decent	
 3692	spoiled super-sized olive sea persimmon	5	crappy	
 3693	wet triple-diffused yellow pressurized potion of perception	0		Effect: "Man's Worst Enemy", Effect Duration: 16
 3694	activated activated skewed pressurized potion of proficiency	0		Effect: "20-20 Second Sight", Effect Duration: 59
 3695	Rosewater's Mer-kin digpick	0		Mysticality Percent: +30
 3696	pulsating anemone nematocyst	0		
-3697	ghostly green high-pressure seltzer bottle	0		
+3697	green ghostly high-pressure seltzer bottle	0		
 3698	velcro ore	0		
 3699	teflon ore	0		
 3700	bouncing vinyl ore	0		
@@ -3705,7 +3705,7 @@
 3739	skewed Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
-3742	electrified extra-polarized spinning bouncing jellyfish gel	0		Effect: "Filled with Magic", Effect Duration: 40
+3742	electrified extra-polarized bouncing spinning jellyfish gel	0		Effect: "Filled with Magic", Effect Duration: 40
 3743	unstable quark	0		
 3744	blue software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
@@ -3718,7 +3718,7 @@
 3754	flattened love song of vague ambiguity	0		Effect: "Wasabi With You", Effect Duration: 28, Last Available: "2009-02"
 3755	double-pressed vacuum-sealed love song of smoldering passion	0		Effect: "So Fresh and So Clean", Effect Duration: 22, Last Available: "2009-02"
 3756	adjusted quadruple-boiled love song of icy revenge	0		Effect: "Fiery Spirit", Effect Duration: 60, Last Available: "2009-02"
-3757	super-flattened narrow maroon love song of sugary cuteness	0		Effect: "Cool Spirit", Effect Duration: 27, Last Available: "2009-02"
+3757	super-flattened maroon narrow love song of sugary cuteness	0		Effect: "Cool Spirit", Effect Duration: 27, Last Available: "2009-02"
 3758	aerosolized love song of disturbing obsession	0		Effect: "Conspiratory Eyes", Effect Duration: 51, Last Available: "2009-02"
 3759	tarnished love song of naughty innuendo	0		Effect: "Spell Transfer Complete", Effect Duration: 52, Last Available: "2009-02"
 3760	activated spinning breath mint	0		Effect: "Hoity Toity", Effect Duration: 20
@@ -3732,7 +3732,7 @@
 3768	watered-down drinkable squat lychee chuhai	2	good	
 3769	perfectly mixed watered-down salacious screwdiver	2	EPIC	
 3770	artisanal dew yoana salacious lei	3	EPIC	
-3771	aged practically non-alcoholic salacious lychee chuhai	1	awesome	
+3771	practically non-alcoholic aged salacious lychee chuhai	1	awesome	
 3772	drinkable Alewife&trade; Ale	3	good	
 3773	seaode	0		
 3774	pulsating map to the Dive Bar	0		
@@ -3753,8 +3753,8 @@
 3789	narrow twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	shaking wobbly crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	wobbly shaking crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	wobbly careful Tesla vibrating Mer-kin roundshield	0		Maximum MP Percent: +10, Monster Level: -10, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 14
 3804	Mer-kin breastplate of the wise owl of Calamity Jane	0		Mysticality: +20, Critical Hit Percent: +15
 3805	mirror hardy savvy Mer-kin sneakmask	0		Mysticality Percent: +20, Maximum HP: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3775,16 +3775,16 @@
 3821	polarized quadruple-polarized blue syringe	0		Effect: "Chalked Weapon", Effect Duration: 66
 3822	wand	0		Familiar Effect: "fishy spells"
 3823	deionized super-polarized wad of cotton	0		Effect: "Arse-a'fire", Effect Duration: 31
-3824	gray squat Grandma's Note	0		
+3824	squat gray Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	wobbly Grandma's Chartreuse Yarn	0		
 3827	blue plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	delicious small tempura radish	2	awesome	
+3829	small delicious tempura radish	2	awesome	
 3830	green ribald water-polo cap	0		Sleaze Damage: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable teal Typical Tavern swill	4	good	
-3832	delicious watered-down spinning tropical swill	2	awesome	
-3833	mediocre weak fruity girl swill	2	decent	
+3832	watered-down delicious spinning tropical swill	2	awesome	
+3833	weak mediocre fruity girl swill	2	decent	
 3834	watered-down perfectly mixed blended swill	2	EPIC	
 3835	costume wardrobe	0		Softcore Only
 3836	yellow censurious chilly Elvish sunglasses of the scaredy-cat of the empath	0		Monster Level: -15, Familiar Weight: +5, Cold Damage: +5, Sleaze Resistance: +3, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3812,7 +3812,7 @@
 3858	shaking MacGyver's bone flute	0		Maximum MP: +100
 3859	twirling twirling supercharged infernal fife	0		Maximum MP Percent: +30
 3860	yellow lard-coated charming flute	0		Sleaze Spell Damage: +25
-3861	wobbly ghostly leaf of grass	0		
+3861	ghostly wobbly leaf of grass	0		
 3862	up-at-dawn electrified grass whistle	0		Adventures: +5, MP Regen Min: 3, MP Regen Max: 5
 3863	scorching plastic guitar of terror	0		Hot Damage: +25, Spooky Spell Damage: +10
 3864	squat finger cymbals of the empath	0		Familiar Weight: +5
@@ -3852,7 +3852,7 @@
 3898	pulsating bottle of G&uuml;-Gone	0		
 3901	gray seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
-3903	huge upside-down figurine of a baby seal	0		Class: "Seal Clubber"
+3903	upside-down huge figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
@@ -3861,7 +3861,7 @@
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
 3910	cyan figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
-3912	blurry cyan imbued seal-blubber candle	0		Class: "Seal Clubber"
+3912	cyan blurry imbued seal-blubber candle	0		Class: "Seal Clubber"
 3913	hand-crafted extra-dry blended swill with a fly in it	5	EPIC	
 3914	turtle wax	0		
 3915	reassuring turtle wax shield	0		Spooky Resistance: +1, Damage Reduction: 2
@@ -3872,20 +3872,20 @@
 3920	double-paned Jim Carey's turtlemail coif	0		Monster Level: +25, Cold Resistance: +5, Familiar Effect: "1xPotato, cap 20"
 3921	coward's brainy turtlemail breeches	0		Mysticality: +5, Monster Level: -20, Familiar Effect: "3xBarrr, 1.5xFairy, cap 20"
 3922	friendly educational turtlemail hauberk	0		Experience: +1, Familiar Weight: +3
-3923	blurry shaking hedgeturtle	0		
+3923	shaking blurry hedgeturtle	0		
 3924	friendly spiky turtle helmet of the blizzard	0		Familiar Weight: +3, Cold Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 32"
 3925	narrow electrified spiky turtle shoulderpads	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 3926	blinking tumbling toasty Newton's spiky turtle shield	0		Experience (Mysticality): +3, Hot Damage: +5, Damage Reduction: 8
-3927	jittery blinking turtling rod	0		Class: "Turtle Tamer"
+3927	blinking jittery turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
-3929	tumbling yellow grinning turtle	0		
+3929	yellow tumbling grinning turtle	0		
 3930	chilled tainted seal's blood	0		Effect: "Action", Effect Duration: 44
 3931	Annie Oakley's severed flipper of the blizzard	0		Critical Hit Percent: +20, Cold Spell Damage: +25, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
 3933	knitted brainy bad-ass club	0		Mysticality: +5, Cold Resistance: +3, Class: "Seal Clubber"
 3934	blue sealbone	0		
 3935	non-boiled ionized bouncing hyperinflated seal lung	0		Effect: "Buzzard Breath", Effect Duration: 38
-3936	diffused jittery shaking olive scrap of shadow	0		Effect: "Beastly Flavor", Effect Duration: 58
+3936	diffused olive jittery shaking scrap of shadow	0		Effect: "Beastly Flavor", Effect Duration: 58
 3937	improved cold-filtered fustulent seal grulch	0		Effect: "Guts Feeling", Effect Duration: 19
 3938	gray healthy club of corruption	0		Maximum HP Percent: +20, Class: "Seal Clubber"
 3939	gravedigger's corrupt club of corruption	0		Spooky Damage: +10, Class: "Seal Clubber"
@@ -3899,13 +3899,13 @@
 3947	skewed Clan VIP Lounge key	0		Free Pull
 3948	ghostly Meat	0		
 3949	treasure chest	0		
-3950	ghostly twirling key	0		
+3950	twirling ghostly key	0		
 3951	shaking Baron von Ratsworth	0		
-3952	red ghostly monocle	0		
+3952	ghostly red monocle	0		
 3953	mink	0		
 3954	teddy butler	0		
 3955	martini	0		
-3956	fuchsia tumbling huge crazy bastard sword	0		
+3956	fuchsia huge tumbling crazy bastard sword	0		
 3957	pulsating tin of caviar	0		
 3958	narrow bejeweled cufflinks of the wise owl	0		Mysticality: +20, Single Equip
 3959	blinking garish pinky ring of bravery	0		Spooky Resistance: +5
@@ -3942,7 +3942,7 @@
 3990	turtle shell helmet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
-3993	tumbling maroon slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
+3993	maroon tumbling slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
 3995	squat bundle of chamoix	0		
 3996	mirror boxcar turtle	0		
@@ -3989,21 +3989,21 @@
 4037	small normal tumbling slimy sweetbreads	2	good	
 4038	artisanal slimy fermented bile bladder	3	EPIC	
 4039	compressed slimy alveolus	1		Effect: "Leisurely Amblin'", Effect Duration: 20
-4040	wobbly purple memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	blinking squat energetic pig-iron helm of the empath	0		Maximum MP Percent: +20, Familiar Weight: +5, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	crafty pig-iron shinguards of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4040	purple wobbly memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
+4041	blinking squat energetic pig-iron helm of the empath	0		Maximum MP Percent: +20, Familiar Weight: +5, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	crafty pig-iron shinguards of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	Socratic boxer's pig-iron bracers	0		Muscle Percent: +10, Experience (Mysticality): +1, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	skewed wumpus-hair net	0		Last Available: "2009-06"
 4047	Fonzie's wumpus-hair whip	0		Experience (Moxie): +1, Last Available: "2009-06"
-4048	studded extremely unsafe beefcake's wumpus-hair wig	0		Muscle: +25, Weapon Damage Percent: +100, Damage Absorption: +80, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	Usain Bolt's flame-retardant Rosewater's wumpus-hair loincloth	0		Mysticality Percent: +30, Hot Resistance: +1, Initiative: +80, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	studded extremely unsafe beefcake's wumpus-hair wig	0		Muscle: +25, Weapon Damage Percent: +100, Damage Absorption: +80, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	Usain Bolt's flame-retardant Rosewater's wumpus-hair loincloth	0		Mysticality Percent: +30, Hot Resistance: +1, Initiative: +80, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	therapeutic quilted wumpus-hair sweater	0		Damage Absorption: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06"
 4051	Annie Oakley's ring of teleportation	0		Critical Hit Percent: +20, Single Equip
 4052	enchanted skewed squat glass of baboon milk	1	crappy	Effect: "Magically Delicious", Effect Duration: 25, Last Available: "2009-06"
 4053	spinning banana milkshake	1	super EPIC	Last Available: "2009-06"
-4054	tolerable triple-distilled White Hyborian	7	good	Last Available: "2009-06"
+4054	triple-distilled tolerable White Hyborian	7	good	Last Available: "2009-06"
 4055	wobbly goblin hunting spear of Leguizamo	0		Monster Level: +20, Last Available: "2009-06"
 4056	Sherlock's goblin autoblowgun of Flo-Jo	0		Item Drop: +25, Initiative: +100, Last Available: "2009-06"
 4057	olive chilly tribal beads	0		Cold Damage: +5, Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	shaking lion tamer's thinker's grisly shield	0		Mysticality: +10, Experience (familiar): +2, Slime Hates It: +1, Damage Reduction: 13
 4081	lime green prompt foul-smelling corroded breeches	0		Stench Damage: +10, Adventures: +3, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	teal personal trainer's educational pernicious cudgel	0		Experience: +1, Experience Percent (Muscle): +10, Slime Hates It: +1
-4083	rotten big narrow cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
+4083	big rotten narrow cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	flavorless blurry protein paste	3	decent	Last Available: "2009-06"
 4086	prompt cyber-mattock of the wise owl	0		Mysticality: +20, Adventures: +3, Last Available: "2009-06"
@@ -4080,7 +4080,7 @@
 4128	blurry banded hardened slime pants of the storm of temperance	0		Damage Absorption: +100, Maximum MP Percent: +40, Sleaze Resistance: +5, Familiar Effect: "atk, 1xPotato"
 4129	auspicious Tesla hardened slime belt of the ox	0		Muscle: +20, Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 4130	spinning empty agua de vida bottle	0		Last Available: "2009-06"
-4131	powdered purple tumbling boot plant	1	decent	Effect: "Texas Elegance", Effect Duration: 5, Last Available: "2009-06"
+4131	powdered tumbling purple boot plant	1	decent	Effect: "Texas Elegance", Effect Duration: 5, Last Available: "2009-06"
 4132	bad sham champagne	3	decent	Last Available: "2009-06"
 4133	cold-filtered tempura air	0		Effect: "Wallflowering", Effect Duration: 45
 4134	irradiated pulsating pressurized potion of pneumaticity	0		Effect: "Slightly Mutated", Effect Duration: 27
@@ -4110,7 +4110,7 @@
 4158	ghostly rock	0		Last Available: "2009-09"
 4159	mirror rock lobster	0		Last Available: "2009-09"
 4160	bad pebblebr&auml;u	3	decent	Last Available: "2009-09"
-4161	half-sized stale rocky road ice cream	2	decent	Last Available: "2009-09"
+4161	stale half-sized rocky road ice cream	2	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	adjusted jittery children of the candy corn	0		Effect: "Wax On Your Shoes", Effect Duration: 67
 4164	adjusted Good 'n' Slimy	0		Effect: "Intimidating Mien", Effect Duration: 57
@@ -4130,12 +4130,12 @@
 4178	olive smooth sugar shotgun	0		Moxie: +15, Last Available: "2009-09"
 4179	stanky sugar shillelagh	0		Stench Spell Damage: +25, Last Available: "2009-09"
 4180	sugar shank of dire peril	0		Weapon Damage: +20, Last Available: "2009-09"
-4181	nasty friendly sugar chapeau of the early riser	0		Familiar Weight: +3, Stench Damage: +5, Adventures: +7, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	wizardly sugar shorts	0		Mysticality: +25, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	nasty friendly sugar chapeau of the early riser	0		Familiar Weight: +3, Stench Damage: +5, Adventures: +7, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	wizardly sugar shorts	0		Mysticality: +25, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	blinking sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	twirling slime convention swag bag	0		
 4185	slime convention flyers	0		
-4186	pulsating upside-down slime convention coupons	0		
+4186	upside-down pulsating slime convention coupons	0		
 4187	sage slime convention pin	0		Mysticality Percent: +10
 4188	slime convention t-shirt	0		
 4189	blurry inverse geode	0		
@@ -4169,7 +4169,7 @@
 4217	groupie bra	0		
 4218	deionized ionized gray groupie spangles	0		Effect: "Stands Alone", Effect Duration: 48
 4219	shaking skate board of the blizzard of terror	0		Cold Spell Damage: +25, Spooky Spell Damage: +10
-4220	green skewed pulsating S.A.V.E. flyer	0		
+4220	skewed green pulsating S.A.V.E. flyer	0		
 4221	red miser's yield shield	0		Meat Drop: +10, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
 4223	ghostly squamous polyp	0		Free Pull, Last Available: "2011-12"
@@ -4178,7 +4178,7 @@
 4226	Star of Bravery of chilblains	0		Cold Damage: +25, Single Equip
 4227	green hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	bouncing perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	wobbly ice skate doll	0		
@@ -4196,7 +4196,7 @@
 4244	lard-coated leather-bound tome	0		Sleaze Spell Damage: +25
 4245	bookmark	0		
 4246	educational ivory cue ball	0		Experience: +1
-4247	aged weak tumbling decanter of fine Scotch	2	awesome	
+4247	weak aged tumbling decanter of fine Scotch	2	awesome	
 4248	dehydrated upside-down expensive cigar	1		
 4249	upside-down tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4207,14 +4207,14 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	diffused galvanized magnetized jittery sap	0		Effect: "Meadulla Oblongota", Effect Duration: 67, Last Available: "2009-10"
 4257	ghostly petrified wood	0		Last Available: "2009-10"
-4258	rotten half-sized chocolate-covered scarab beetle	2	crappy	Last Available: "2009-10"
+4258	half-sized rotten chocolate-covered scarab beetle	2	crappy	Last Available: "2009-10"
 4259	fancy lousy mulled cider	4	decent	Effect: "Tightly-Wound Spine", Effect Duration: 25, Last Available: "2009-10"
-4260	squat wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	pulsating mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	squat wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	pulsating mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	bark boxers of the cougar	0		Moxie: +20, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	bark beret of the pedagogue	0		Experience: +3, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	bark boxers of the cougar	0		Moxie: +20, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	bark beret of the pedagogue	0		Experience: +3, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	coward's bark bracelet	0		Monster Level: -20, Single Equip
 4267	double-paned Krakrox's Loincloth of the pedagogue	0		Experience: +3, Cold Resistance: +5, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	dog trainer's beefy Galapagosian Cuisses	0		Muscle: +10, Experience (familiar): +1, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4283,7 +4283,7 @@
 4331	normal super-sized licorice garrote	5	good	Last Available: "2009-12"
 4332	huge nippy candy knuckles	0		Cold Damage: +10, Last Available: "2009-12"
 4333	bland jawbruiser	3	decent	Last Available: "2010-12"
-4334	electrified activated blurry huge chocolate car	0		Effect: "How to Scam Tourists", Effect Duration: 27, Last Available: "2009-12"
+4334	electrified activated huge blurry chocolate car	0		Effect: "How to Scam Tourists", Effect Duration: 27, Last Available: "2009-12"
 4335	savvy plastic 11 Dealer	0		Mysticality Percent: +20, Last Available: "2009-12"
 4336	skewed Annie Oakley's plastic Crimbo Casino	0		Critical Hit Percent: +20, Last Available: "2009-12"
 4337	twirling groovy plastic stocking mimic	0		Moxie Percent: +10, Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	twirling plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	bouncing maroon sizzling snow hat	0		Hot Damage: +10, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	squat snow pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	bouncing maroon sizzling snow hat	0		Hot Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	squat snow pants of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	shaking hardy snow belly	0		Maximum HP: +50, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4308,19 +4308,19 @@
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	cyan A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	shaking gray A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
-4359	purple blurry A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+4359	blurry purple A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	rotten expired can of franks 'n' beans	3	crappy	Last Available: "2009-12"
-4361	drinkable special expired bottle of peppermint schnapps	3	good	Effect: "Riboflavin'", Effect Duration: 10, Last Available: "2009-12"
+4361	special drinkable expired bottle of peppermint schnapps	3	good	Effect: "Riboflavin'", Effect Duration: 10, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	moist elven suicide capsule	0		Effect: "Icy Demeanor", Effect Duration: 20, Last Available: "2009-12"
 4365	immense moldy penguin focaccia bread	10	crappy	Last Available: "2009-12"
 4366	aged herringcello	3	awesome	Last Available: "2009-12"
-4367	weak lousy enchanted elven cellocello	2	decent	Effect: "Ruthlessly Efficient", Effect Duration: 10, Last Available: "2009-12"
+4367	lousy weak enchanted elven cellocello	2	decent	Effect: "Ruthlessly Efficient", Effect Duration: 10, Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	maroon handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
-4371	wobbly tumbling handful of wires	0		Last Available: "2009-12"
+4371	tumbling wobbly handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	blinking grappling hook	0		Last Available: "2009-12"
 4374	teal elf ear	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	narrow stiffened beefy pocketwatch on a chain	0		Muscle: +10, Damage Reduction: 1, Last Available: "2009-12"
 4386	Tesla vibrating cement sandals	0		Maximum MP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2009-12"
 4387	zippy MacGyver's night-vision goggles	0		Maximum MP: +100, Initiative: +20, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	maroon veiny peanut brittle shield	0		Maximum HP: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	fuchsia chilly groovy Red Rover BB gun	0		Moxie Percent: +10, Cold Damage: +5, Last Available: "2009-12"
 4391	thinker's red-and-green sweater	0		Mysticality: +10, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
@@ -4349,7 +4349,7 @@
 4397	squat crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	spinning cheese ball	0		Last Available: "2010-01"
 4399	lime green up-at-dawn cheese sword	0		Adventures: +5, Softcore Only, Last Available: "2010-01"
-4400	blinking Sherlock's cheese diaper	0		Item Drop: +25, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	blinking Sherlock's cheese diaper	0		Item Drop: +25, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	Sherlock's cheese wheel	0		Item Drop: +25, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	maroon toasty cheese eye	0		Hot Damage: +5, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	arcane researcher's Sinatra's Newton's Staff of Queso Escusado	0		Experience (Mysticality): +3, Experience (Moxie): +5, Experience Percent (Mysticality): +10, Softcore Only, Last Available: "2010-01"
@@ -4373,14 +4373,14 @@
 4422	wholesome sealhide belt	0		Maximum HP Percent: +10
 4423	fuchsia sealhide snare	0		
 4424	upside-down puzzling trophy	0		
-4425	quadruple-oxidized tarnished shaking upside-down sealhide seal doll	0		Effect: "Outer Wolf&trade;", Effect Duration: 56
+4425	quadruple-oxidized tarnished upside-down shaking sealhide seal doll	0		Effect: "Outer Wolf&trade;", Effect Duration: 56
 4426	hymnal	0		Skill: "Canticle of Carboloading"
 4428	Jim Carey's glowstick on a string	0		Monster Level: +25
 4429	spinning candy necklace of temperance	0		Sleaze Resistance: +5, Single Equip
 4430	tumbling Jeselnik's teddybear backpack	0		Sleaze Damage: +25
 4431	narrow NPZR chemistry set	0		Last Available: "2011-08"
 4432	polymerized diffused invisibility potion	0		Effect: "Mayeaugh", Effect Duration: 15, Last Available: "2011-08"
-4433	oxidized denatured quadruple-modified blurry maroon irresistibility potion	0		Effect: "Fudge Headache", Effect Duration: 24, Last Available: "2011-08"
+4433	oxidized denatured quadruple-modified maroon blurry irresistibility potion	0		Effect: "Fudge Headache", Effect Duration: 24, Last Available: "2011-08"
 4434	non-unsweetened boiled irritability potion	0		Effect: "Cold as Ice", Effect Duration: 56, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	mirror hellseal whisker	0		
@@ -4396,7 +4396,7 @@
 4448	dried blinking Instant Karma	1	decent	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	pointy hat of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	pointy hat of dire peril	0		Weapon Damage: +20, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	up-at-dawn machetito	0		Adventures: +5, Last Available: "2010-04"
 4453	blurry lawnmower blade of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4407,7 +4407,7 @@
 4459	gravedigger's occult snailmail breeches	0		Spell Damage Percent: +25, Spooky Damage: +10, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
 4460	beefcake's snailmail hauberk of the storm	0		Muscle: +25, Maximum MP Percent: +40
 4461	double-nitrogenated green seal-brain elixir	0		Effect: "Rad-ish", Effect Duration: 47
-4462	aerosolized cyan spinning chocolate seal-clubbing club	0		Effect: "Mayeaugh", Effect Duration: 67
+4462	aerosolized spinning cyan chocolate seal-clubbing club	0		Effect: "Mayeaugh", Effect Duration: 67
 4463	triple-cold-filtered quantum chocolate turtle totem	0		Effect: "Amorphous Cheer", Effect Duration: 65
 4464	Vulcanized spinning huge chocolate pasta spoon	0		Effect: "Strength of Ten Ettins", Effect Duration: 47
 4465	altered tarnished olive chocolate saucepan	0		Effect: "Wit Tea", Effect Duration: 45
@@ -4416,17 +4416,17 @@
 4468	bouncing fuchsia Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	blinking BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	BRICKO hat of the pedagogue	0		Experience: +3, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	sinister BRICKO pants	0		Spell Damage: +10, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	BRICKO hat of the pedagogue	0		Experience: +3, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	sinister BRICKO pants	0		Spell Damage: +10, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	upside-down Jim Carey's BRICKO sword	0		Monster Level: +25, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	ghostly BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	ghostly BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	cyan BRICKO python	0		Last Available: "2010-02"
-4481	upside-down narrow BRICKO vacuum cleaner	0		Last Available: "2010-02"
+4481	narrow upside-down BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
 4483	fuchsia BRICKO cathedral	0		Last Available: "2010-02"
 4484	tumbling BRICKO gargantuchicken	0		Last Available: "2010-02"
@@ -4456,20 +4456,20 @@
 4508	dry &quot;DRINK ME&quot; potion	0		Effect: "Preternatural Greed", Effect Duration: 20, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	adequate walrus ice cream	4	good	Last Available: "2010-03"
-4511	bland immense special lime green beautiful soup	7	decent	Effect: "Full of Vinegar", Effect Duration: 30, Last Available: "2010-03"
+4511	special bland immense lime green beautiful soup	7	decent	Effect: "Full of Vinegar", Effect Duration: 30, Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	rotten squat Humpty Dumplings	3	crappy	Last Available: "2010-03"
-4515	special normal low-calorie Lobster <i>qua</i> Grill	1	good	Effect: "Gummiskin", Effect Duration: 50, Last Available: "2010-03"
-4516	mediocre watered-down missing wine	2	decent	Last Available: "2010-03"
+4515	normal special low-calorie Lobster <i>qua</i> Grill	1	good	Effect: "Gummiskin", Effect Duration: 50, Last Available: "2010-03"
+4516	watered-down mediocre missing wine	2	decent	Last Available: "2010-03"
 4517	rotten matter custard	3	crappy	Last Available: "2010-03"
 4518	non-enhanced ionized comfit?	0		Effect: "Sticky Fingers", Effect Duration: 27, Last Available: "2010-03"
-4519	wobbly jittery ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
+4519	jittery wobbly ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	clever Newton's flamingo mallet	0		Experience (Mysticality): +3, Maximum MP: +20, Last Available: "2010-03"
 4521	wobbly croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	chilly educational eye of the Tiger-lily	0		Experience: +1, Cold Damage: +5, Last Available: "2010-03"
-4524	prompt flame-retardant wig	0		Hot Resistance: +1, Adventures: +3, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	prompt flame-retardant wig	0		Hot Resistance: +1, Adventures: +3, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	normal snack-sized jittery donut	2	good	Last Available: "2010-03"
 4526	adequate bucket of honey	3	good	Last Available: "2010-03"
 4527	executive beefcake's elephant stinger	0		Muscle: +25, Meat Drop: +40, Last Available: "2010-03"
@@ -4478,14 +4478,14 @@
 4530	wobbly puff of smoke	0		Last Available: "2010-03"
 4531	delicious rook cookie	4	awesome	Last Available: "2010-03"
 4532	normal bishop cookie	4	good	Last Available: "2010-03"
-4533	diet decent huge knight cookie	1	good	Last Available: "2010-03"
-4534	miniature delicious king cookie	2	awesome	Last Available: "2010-03"
+4533	decent diet huge knight cookie	1	good	Last Available: "2010-03"
+4534	delicious miniature king cookie	2	awesome	Last Available: "2010-03"
 4535	bland queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	frosty insane tophat	0		Cold Spell Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	studded personal trainer's helm of the knight	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	frosty insane tophat	0		Cold Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	studded personal trainer's helm of the knight	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	wristwatch of the knight of the wise owl of the brute	0		Mysticality: +20, Muscle Percent: +30, Single Equip, Last Available: "2010-03"
-4540	toasty trousers of the knight of the boozehound	0		Hot Damage: +5, Booze Drop: +100, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	toasty trousers of the knight of the boozehound	0		Hot Damage: +5, Booze Drop: +100, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	grievous tophat	0		Weapon Damage Percent: +50, Familiar Effect: "1xBarrr, cap 25"
 4542	medical-grade tie	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4543	auspicious tuxedo pants	0		Item Drop: +10, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4510,26 +4510,26 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	acceptable world's most unappetizing beverage	3	good	Last Available: "2010-04"
 4564	scandalous slippery when wet shield	0		Sleaze Damage: +5, Damage Reduction: 6, Last Available: "2010-04"
-4565	miniature flavorless bouncing raisin	2	decent	Last Available: "2010-04"
+4565	flavorless miniature bouncing raisin	2	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	experienced flyest of shirts of the brute	0		Muscle Percent: +30, Experience: +2, Last Available: "2010-04"
 4568	normal narrow a dance upon the palate	4	good	Last Available: "2010-04"
-4569	jumbo adequate prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
+4569	adequate jumbo prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	bland twirling squirmy violent party snack	4	decent	Last Available: "2010-04"
 4572	blurry resourceful can-you-dig-it?	0		Maximum MP: +50, Last Available: "2010-04"
 4573	wobbly The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	twirling bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	pickled denatured upside-down purple ghostly Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Stinky Weapon", Effect Duration: 58, Last Available: "2010-04"
+4579	pickled denatured purple ghostly upside-down Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Stinky Weapon", Effect Duration: 58, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of Tarzan	0		Experience (Muscle): +3, Last Available: "2010-04"
-4581	jittery upside-down upside-down Tesla electrified T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		MP Regen Min: 10, MP Regen Max: 15, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	jittery upside-down upside-down Tesla electrified T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		MP Regen Min: 10, MP Regen Max: 15, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	super-sized normal fuchsia six wedges of goat cheese	5	good	
+4584	normal super-sized fuchsia six wedges of goat cheese	5	good	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	goth	0		
@@ -4560,29 +4560,29 @@
 4612	purple souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	sizzling Crown of Thrones	0		Hot Damage: +10, Softcore Only, Last Available: "2010-05"
-4615	triple-distilled mediocre Cinco Mayo Lager	10	decent	Last Available: "2010-05"
+4615	mediocre triple-distilled Cinco Mayo Lager	10	decent	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	teal pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	twirling frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
-4621	tumbling twirling Game Grid token	0		Last Available: "2010-06"
+4621	twirling tumbling Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	irradiated Vulcanized wet blinking chocolate-covered caviar	0		Effect: "Alacri Tea", Effect Duration: 62, Last Available: "2020-09"
 4624	rotten twirling pawn cookie	4	crappy	Last Available: "2010-06"
 4625	altered coffee pixie stick	1	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 35, Last Available: "2010-06"
-4626	wobbly blurry upside-down superduperball	0		Last Available: "2010-06"
+4626	upside-down wobbly blurry superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	jittery parachute guy	0		Last Available: "2010-06"
 4629	narrow plastic spider ring of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	upside-down MacGyver's plastic kazoo	0		Maximum MP: +100, Last Available: "2010-06"
 4631	inflatable baseball bat of the early riser	0		Adventures: +7, Last Available: "2010-06"
-4632	smelly dangerous googly-star hat	0		Weapon Damage: +10, Stench Spell Damage: +10, Familiar Effect: "atk", Last Available: "2010-06"
+4632	smelly dangerous googly-star hat	0		Weapon Damage: +10, Stench Spell Damage: +10, Last Available: "2010-06", Familiar Effect: "atk"
 4633	ribald smartaleck's googly-ball hat	0		Moxie Percent: +30, Sleaze Damage: +10, Last Available: "2010-06"
 4634	cyan fireproof Lo Pan's googly-heart hat	0		Spell Critical Percent: +30, Hot Resistance: +3, Last Available: "2010-06"
 4635	fireproof scorching super-sweet boom box	0		Hot Damage: +25, Hot Resistance: +3, Four Songs, Last Available: "2010-06"
 4636	ghostly Game Grid valued membership card	0		Last Available: "2010-06"
-4637	flame-wreathed lion tamer's sinister demon mask of mayonnaise	0		Experience (familiar): +2, Hot Spell Damage: +10, Sleaze Spell Damage: +50, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	flame-wreathed lion tamer's sinister demon mask of mayonnaise	0		Experience (familiar): +2, Hot Spell Damage: +10, Sleaze Spell Damage: +50, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	jittery teal grievous streetfighting champion's belt of extreme caution of horror	0		Weapon Damage Percent: +50, Monster Level: -25, Spooky Spell Damage: +25, Single Equip, Last Available: "2010-06"
 4639	gray fireproof supercool smooth Space Trip safety headphones	0		Moxie: +15, Moxie Percent: +20, Hot Resistance: +3, Single Equip, Last Available: "2010-06"
 4640	jittery wool LARP carp	0		Cold Resistance: +1
@@ -4594,8 +4594,8 @@
 4646	Rosewater's Meteoid ice beam of vim and vigor of incineration	0		Mysticality Percent: +30, Maximum HP Percent: +50, Hot Spell Damage: +50, Last Available: "2011-12"
 4647	mirror foul-smelling hardened baleful Dungeon Fist gauntlet	0		Spell Damage: +25, Damage Reduction: 3, Stench Damage: +10, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	wobbly chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	blinking fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	wobbly chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	blinking fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	teal rosewater-soaked lard-coated ironic knit cap	0		Sleaze Spell Damage: +25, Stench Resistance: +3, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	pulsating gray ironic sunglasses	0		Single Equip
@@ -4616,10 +4616,10 @@
 4668	upside-down auspicious observational glasses	0		Item Drop: +10
 4669	zippy hilarious comedy prop	0		Initiative: +20
 4670	beer-scented teddy bear	0		
-4671	weak artisanal bouncing booze-soaked cherry	2	EPIC	
+4671	artisanal weak bouncing booze-soaked cherry	2	EPIC	
 4672	comfy pillow	0		
 4673	stale miniature marshmallow	2	decent	
-4674	bland low-calorie jittery sponge cake	1	decent	
+4674	low-calorie bland jittery sponge cake	1	decent	
 4675	tolerable gin-soaked blotter paper	4	good	
 4676	tree-holed coin	0		
 4677	twirling unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,13 +4627,13 @@
 4679	ghostly volcanic ash	0		
 4680	smoked potsherd	0		
 4681	chilly pottery shield	0		Cold Damage: +5, Damage Reduction: 3, Last Available: "2010-09"
-4682	blinking jittery pottery hat of the ox of Calamity Jane	0		Muscle: +20, Critical Hit Percent: +15, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	family-friendly pottery training pants of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +1, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	blinking jittery pottery hat of the ox of Calamity Jane	0		Muscle: +20, Critical Hit Percent: +15, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	family-friendly pottery training pants of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	pottery club of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2010-09"
 4685	deadly pottery yo-yo	0		Weapon Damage: +5, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
 4687	twirling fossilized bat skull	0		Last Available: "2010-09"
-4688	jittery shaking fossilized serpent skull	0		Last Available: "2010-09"
+4688	shaking jittery fossilized serpent skull	0		Last Available: "2010-09"
 4689	teal mirror fossilized baboon skull	0		Last Available: "2010-09"
 4690	fossilized wyrm skull	0		Last Available: "2010-09"
 4691	fossilized wing	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	blinking shaking fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	yellow fireproof toasty stiffened Greatest American Pants	0		Damage Reduction: 1, Hot Damage: +5, Hot Resistance: +3, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	yellow fireproof toasty stiffened Greatest American Pants	0		Damage Reduction: 1, Hot Damage: +5, Hot Resistance: +3, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	bouncing bouncing fossilized necklace of the glutton	0		Food Drop: +100, Last Available: "2010-09"
 4698	spinning imp air	0		
 4699	jittery bus pass	0		
@@ -4671,7 +4671,7 @@
 4723	rotten bite-sized badass pie	1	crappy	Last Available: "2010-10"
 4724	adequate shoo-fish pie	4	good	Last Available: "2010-10"
 4725	bland piping organ pie	3	decent	Last Available: "2010-10"
-4726	rotten enchanted blinking narrow igloo pie	3	crappy	Effect: "Yeah, It's Just Gasoline", Effect Duration: 30, Last Available: "2010-10"
+4726	enchanted rotten blinking narrow igloo pie	3	crappy	Effect: "Yeah, It's Just Gasoline", Effect Duration: 30, Last Available: "2010-10"
 4727	decent bite-sized stomach turnover	1	good	Last Available: "2010-10"
 4728	stale dead lights pie	3	decent	Last Available: "2010-10"
 4729	moldy pulsating throbbing organ pie	3	crappy	Last Available: "2010-10"
@@ -4699,8 +4699,8 @@
 4751	ghostly fortified boning knife	0		Damage Absorption: +60, Last Available: "2010-10"
 4752	bouncing cyan miser's bone crusher	0		Meat Drop: +10, Last Available: "2010-10"
 4753	huge bone spurs of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2010-10"
-4754	shaking red Samson's bonedanna of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	wobbly boneana hammock of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	shaking red Samson's bonedanna of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	wobbly boneana hammock of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	colloidal quadruple-deionized candy skeleton	0		Effect: "Hopped Up on Goofballs", Effect Duration: 52, Last Available: "2020-09"
@@ -4715,18 +4715,18 @@
 4767	greasy careful shin gourds	0		Monster Level: -10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2010-11"
 4768	lime green wobbly wobbly razor-sharp smooth Staff of the November Jack-O-Lantern of the dark arts	0		Moxie: +15, Weapon Damage Percent: +25, Spell Damage Percent: +100, Last Available: "2010-11"
 4769	gray pumpkin carriage	0		Last Available: "2010-11"
-4770	wobbly pulsating Desert Bus pass	0		
+4770	pulsating wobbly Desert Bus pass	0		
 4771	ginormous pumpkin	0		Last Available: "2010-11"
 4804	Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
 4806	mirror Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	cyan wobbly Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	wobbly cyan Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	bland jittery CRIMBCOIDS mints	4	decent	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	special adequate skewed CRIMBCOLOAF	4	good	Effect: "Mariachi Mood", Effect Duration: 40, Last Available: "2011-01"
+4820	adequate special skewed CRIMBCOLOAF	4	good	Effect: "Mariachi Mood", Effect Duration: 40, Last Available: "2011-01"
 4821	spoiled bouncing circular CRIMBCOOKIE	4	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	huge hardened plastic CRIMBCO HQ	0		Damage Reduction: 3, Last Available: "2010-12"
 4823	plastic fax machine of the businessman	0		Meat Drop: +50, Last Available: "2010-12"
@@ -4736,7 +4736,7 @@
 4827	jittery hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	huge jittery S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
-4830	twirling maroon robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
+4830	maroon twirling robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	pulsating robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
@@ -4751,15 +4751,15 @@
 4842	jittery sleeping stocking	0		Last Available: "2010-12"
 4843	cyan Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	olive The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	bouncing resourceful boxer's Uncle Hobo's stocking cap	0		Muscle Percent: +10, Maximum MP: +50, Familiar Effect: "atk", Last Available: "2010-12"
+4845	bouncing resourceful boxer's Uncle Hobo's stocking cap	0		Muscle Percent: +10, Maximum MP: +50, Last Available: "2010-12", Familiar Effect: "atk"
 4846	prompt boxer's Uncle Hobo's epic beard	0		Muscle Percent: +10, Adventures: +3, Single Equip, Last Available: "2010-12"
-4847	greedy Uncle Hobo's gift baggy pants of bravery	0		Spooky Resistance: +5, Meat Drop: +20, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	greedy Uncle Hobo's gift baggy pants of bravery	0		Spooky Resistance: +5, Meat Drop: +20, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	tumbling razor-sharp smartaleck's Uncle Hobo's fingerless tinsel gloves	0		Moxie Percent: +30, Weapon Damage Percent: +25, Single Equip, Last Available: "2010-12"
 4849	curative stiffened Uncle Hobo's highest bough	0		Damage Reduction: 1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-12"
 4850	blinking zippy dog trainer's Uncle Hobo's belt	0		Experience (familiar): +1, Initiative: +20, Single Equip, Last Available: "2010-12"
 4851	improved chocolate cigar	0		Effect: "Optimist Primal", Effect Duration: 35, Last Available: "2010-12"
 4852	beefy gift-a-pult	0		Muscle: +10, Last Available: "2010-12"
-4853	wet concentrated jittery wobbly mirror holly-flavored Hob-O	0		Effect: "Earthen Fist", Effect Duration: 44, Last Available: "2020-09"
+4853	wet concentrated jittery mirror wobbly holly-flavored Hob-O	0		Effect: "Earthen Fist", Effect Duration: 44, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	green paperclip	0		Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	twirling Workytime Tea	0		Last Available: "2011-01"
 4867	blurry paperclip sproinger	0		Last Available: "2011-01"
 4868	gray dog trainer's curative fortified paperclip-on tie	0		Damage Absorption: +60, Experience (familiar): +1, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-01"
-4869	pulsating foul-smelling stylish paperclip pants	0		Moxie: +25, Stench Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	narrow executive wool paperclip turban of the sewer	0		Stench Damage: +25, Cold Resistance: +1, Meat Drop: +40, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	pulsating foul-smelling stylish paperclip pants	0		Moxie: +25, Stench Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	narrow executive wool paperclip turban of the sewer	0		Stench Damage: +25, Cold Resistance: +1, Meat Drop: +40, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	hardened paperclip cape	0		Damage Reduction: 3, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	boiled non-modified incense bath ball	0		Effect: "Antarctic Memories", Effect Duration: 55, Last Available: "2011-01"
 4879	liquefied warmed lime green myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Fratty Flavor", Effect Duration: 26, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	tolerable watered-down CRIMBCO wine	2	good	Last Available: "2011-01"
+4881	watered-down tolerable CRIMBCO wine	2	good	Last Available: "2011-01"
 4882	huge Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	blinking toe jam	0		Last Available: "2011-01"
 4884	delicious snack-sized toe jam toast	2	awesome	Last Available: "2011-01"
@@ -4800,7 +4800,7 @@
 4891	cyan bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	fancy adequate pulsating festive sausage	3	good	Effect: "Triangle, Man", Effect Duration: 5, Last Available: "2011-01"
+4894	adequate fancy pulsating festive sausage	3	good	Effect: "Triangle, Man", Effect Duration: 5, Last Available: "2011-01"
 4895	big normal blurry holiday cheese log	5	good	Last Available: "2011-01"
 4896	squat holiday log	0		Last Available: "2011-01"
 4897	BGE 'ferocious fruit' shirt of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Last Available: "2010-12"
@@ -4855,7 +4855,7 @@
 4952	dry electrified purple baggie of sugar	0		Effect: "Booooooze", Effect Duration: 37
 4953	fuchsia energetic hardened whalebone corset	0		Damage Reduction: 3, Maximum MP Percent: +20, Single Equip
 4954	experienced oven mitts	0		Experience: +2, Single Equip
-4955	adequate small overcookie	2	good	
+4955	small adequate overcookie	2	good	
 4956	rotten philosopher's scone	3	crappy	
 4957	alkaline boiled ghostly half-baked potion	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 47
 4958	Knob Goblin deluxe scimitar of terror	0		Spooky Spell Damage: +10
@@ -4865,7 +4865,7 @@
 4962	prompt hale mysterious lapel pin	0		Maximum HP: +20, Adventures: +3, Single Equip
 4963	blurry state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
-4965	blinking lime green Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
+4965	lime green blinking Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
@@ -4903,7 +4903,7 @@
 5000	skewed Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
-5003	shaking yellow Alice's Army Foil Coward	0		Last Available: "2011-03"
+5003	yellow shaking Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
@@ -4914,7 +4914,7 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	adequate gray wasabi pocky	3	good	Last Available: "2011-03"
-5014	stale blurry skewed tobiko pocky	3	decent	Last Available: "2011-03"
+5014	stale skewed blurry tobiko pocky	3	decent	Last Available: "2011-03"
 5015	big adequate natto pocky	5	good	Last Available: "2011-03"
 5016	tolerable wasabi-infused sake	3	good	Last Available: "2011-03"
 5017	artisanal tobiko-infused sake	3	EPIC	Last Available: "2011-03"
@@ -4924,7 +4924,7 @@
 5021	modified natto marble soda	0		Effect: "Human-Slime Hybrid", Effect Duration: 16, Last Available: "2011-03"
 5022	blurry Alice's Army booster box	0		Last Available: "2011-03"
 5023	Vulcanized quadruple-warmed polymerized elderly jawbreaker	0		Effect: "Hippy Flavor", Effect Duration: 50, Last Available: "2020-09"
-5024	artisanal weak marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
+5024	weak artisanal marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
 5025	artisanal cranberry schnapps	3	EPIC	Last Available: "2011-03"
 5026	mediocre strong breaded beer	5	decent	Last Available: "2011-03"
 5027	acceptable soy cordial	3	good	Last Available: "2011-03"
@@ -4946,12 +4946,12 @@
 5043	flavorless astral hot dog	3		
 5044	acceptable squat astral pilsner	3		
 5045	astral hot dog dinner	0		
-5046	purple blurry astral six-pack	0		
+5046	blurry purple astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	huge upside-down manspreader's double-ice cap of incineration of the cheetah	0		Monster Level: +10, Hot Spell Damage: +50, Initiative: +60, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	huge upside-down manspreader's double-ice cap of incineration of the cheetah	0		Monster Level: +10, Hot Spell Damage: +50, Initiative: +60, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	green blinking prompt reassuring brawny double-ice box	0		Muscle Percent: +20, Spooky Resistance: +1, Adventures: +3, Last Available: "2011-04"
-5051	executive strapping double-ice britches of the businessman	0		Muscle: +5, Meat Drop: 90, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	executive strapping double-ice britches of the businessman	0		Muscle: +5, Meat Drop: 90, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	blurry intriguing puzzle box	0		Last Available: "2011-04"
@@ -4967,7 +4967,7 @@
 5064	twirling Salsa de las Epocas	0		Last Available: "2011-04"
 5065	special adequate spaghetti con calaveras	3	good	Effect: "Nas Tea", Effect Duration: 45, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	bite-sized special moldy skewed popcorn	1	crappy	Effect: "Happy Salamander", Effect Duration: 10, Last Available: "2011-04"
+5067	moldy special bite-sized skewed popcorn	1	crappy	Effect: "Happy Salamander", Effect Duration: 10, Last Available: "2011-04"
 5068	stale chaos popcorn	4	decent	Last Available: "2011-04"
 5069	twirling knitted dance instructor's hole of terror	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Cold Resistance: +3, Last Available: "2011-04"
 5070	blurry innuendo	0		Last Available: "2011-04"
@@ -4976,17 +4976,17 @@
 5073	irresponsibly strong hand-crafted Russian Ice	9	EPIC	Last Available: "2011-04"
 5074	Samson's clay ashtray	0		Experience (Muscle): +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	baleful lanyard	0		Spell Damage: +25, Single Equip, Last Available: "2011-05"
-5076	wholesome monster pants	0		Maximum HP Percent: +10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	wholesome monster pants	0		Maximum HP Percent: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	aerosolized Pok&euml;mann band-aid	0		Effect: "Dreadful Chill", Effect Duration: 60, Last Available: "2011-05"
-5079	skewed censurious stanky Van der Graaf helmet	0		Stench Spell Damage: +25, Sleaze Resistance: +3, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	skewed censurious stanky Van der Graaf helmet	0		Stench Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	brainy crutch	0		Mysticality: +5, Last Available: "2011-05"
 5081	beefcake's shock belt	0		Muscle: +25, Single Equip, Last Available: "2011-05"
 5082	energized shaking Okee-Dokee soda	0		Effect: "Fishy", Effect Duration: 38, Last Available: "2011-05"
 5083	gray Sherlock's rubber band gun	0		Item Drop: +25, Last Available: "2011-05"
-5084	skewed toasty pin-stripe slacks	0		Hot Damage: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	skewed toasty pin-stripe slacks	0		Hot Damage: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	toasty gloves	0		Hot Damage: +5, Single Equip, Last Available: "2011-05"
-5086	liquefied super-altered red huge jittery correction fluid	0		Effect: "Unusual Perspective", Effect Duration: 14, Last Available: "2011-05"
+5086	liquefied super-altered huge jittery red correction fluid	0		Effect: "Unusual Perspective", Effect Duration: 14, Last Available: "2011-05"
 5087	beefy Pok&euml;mann figurine: Porkachu	0		Muscle: +10, Single Equip, Last Available: "2011-05"
 5088	gravedigger's Pok&euml;mann figurine: Magikrap	0		Spooky Damage: +10, Single Equip, Last Available: "2011-05"
 5089	sinister Pok&euml;mann figurine: Vegemite	0		Spell Damage: +10, Single Equip, Last Available: "2011-05"
@@ -5002,9 +5002,9 @@
 5099	blurry slick Pok&euml;mann figurine: Shoggoth	0		Moxie: +10, Single Equip, Last Available: "2011-05"
 5100	upside-down educational Pok&euml;mann figurine: Frank	0		Experience: +1, Single Equip, Last Available: "2011-05"
 5101	Van der Graaf Pok&euml;mann figurine: Moog	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-05"
-5102	polarized mirror squat willyweed	0		Effect: "Punchy, Murdery", Effect Duration: 34, Last Available: "2011-05"
+5102	polarized squat mirror willyweed	0		Effect: "Punchy, Murdery", Effect Duration: 34, Last Available: "2011-05"
 5103	moist upside-down Nuclear Blastball	0		Effect: "Yet tea", Effect Duration: 54, Last Available: "2011-05"
-5104	galvanized maroon blinking fish juice box	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 32, Last Available: "2011-05"
+5104	galvanized blinking maroon fish juice box	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 32, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
 5107	acceptable watered-down gray Jeppson's Malort	2	good	Last Available: "2011-06"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	blinking Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	ghostly perfumed frightening Admiral's hat of the sweet-tooth	0		Spooky Damage: +5, Stench Resistance: +5, Candy Drop: +100, Familiar Effect: "atk", Last Available: "2011-05"
-5122	huge friendly resourceful Rosewater's aviator's cap	0		Mysticality Percent: +30, Maximum MP: +50, Familiar Weight: +3, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	ghostly perfumed frightening Admiral's hat of the sweet-tooth	0		Spooky Damage: +5, Stench Resistance: +5, Candy Drop: +100, Last Available: "2011-05", Familiar Effect: "atk"
+5122	huge friendly resourceful Rosewater's aviator's cap	0		Mysticality Percent: +30, Maximum MP: +50, Familiar Weight: +3, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	banded mirrored aviator shades of the cougar	0		Moxie: +20, Damage Absorption: +100, Single Equip, Last Available: "2011-05"
 5124	pulsating Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	maroon Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5046,13 +5046,13 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	shaking handful of honey	0		
 5145	modified honeypot	0		Effect: "Souper Vengeful", Effect Duration: 49
-5146	small normal wild honey pie	2	good	
+5146	normal small wild honey pie	2	good	
 5147	perfectly mixed honey mead	3	EPIC	
 5148	red nippy rock-hard sinister honey dipper	0		Spell Damage: +10, Damage Reduction: 5, Cold Damage: +10
 5149	studded savvy honeybritches of the detective	0		Mysticality Percent: +20, Damage Absorption: +80, Item Drop: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	greasy Oprah's sage honeycap	0		Mysticality Percent: +10, Maximum MP Percent: +50, Sleaze Spell Damage: +10, Familiar Effect: "1xPotato, cap 43"
-5151	Moonthril Circlet of bravery	0		Spooky Resistance: +5, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	toasty Moonthril Greaves	0		Hot Damage: +5, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	Moonthril Circlet of bravery	0		Spooky Resistance: +5, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	toasty Moonthril Greaves	0		Hot Damage: +5, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	Sherlock's Moonthril Flamberge	0		Item Drop: +25, Last Available: "2011-06"
 5154	gray double-paned Moonthril Longbow	0		Cold Resistance: +5, Last Available: "2011-06"
 5155	olive wool Moonthril Cuirass	0		Cold Resistance: +1, Softcore Only, Last Available: "2011-06"
@@ -5068,15 +5068,15 @@
 5165	tumbling slick girl	0		Moxie: +10, Last Available: "2011-06"
 5166	top hat and cane	0		Last Available: "2011-06"
 5167	synthetic dog hair pill	0		Last Available: "2011-06"
-5168	twirling mirror distention pill	0		Last Available: "2011-06"
+5168	mirror twirling distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	extra-diffused dry magnetized transporter transponder	0		Effect: "Tiki Toughness", Effect Duration: 42, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	squat Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	blinking elven magi-pack	0		Last Available: "2011-06"
 5174	lousy Saison du Lune	3	decent	Last Available: "2011-06"
-5175	weak mediocre spinning Moonthril Schnapps	2	decent	Last Available: "2011-06"
-5176	watered-down lousy fuchsia Wrecked Generator	2	decent	Last Available: "2011-06"
+5175	mediocre weak spinning Moonthril Schnapps	2	decent	Last Available: "2011-06"
+5176	lousy watered-down fuchsia Wrecked Generator	2	decent	Last Available: "2011-06"
 5177	decent Spaghetti with Moonballs	4	good	Last Available: "2011-06"
 5178	moldy diet Crepes a la Lune	1	crappy	Last Available: "2011-06"
 5179	moldy wobbly Moon Pie	4	crappy	Last Available: "2011-06"
@@ -5116,7 +5116,7 @@
 5213	distilled ghostly huge Mer-kin paste	1	decent	Effect: "There Wolf", Effect Duration: 5, Last Available: "2011-08"
 5214	powdered upside-down ghostly slimy paste	1	good	Last Available: "2011-08"
 5215	dried teal tumbling penguin paste	1	decent	Last Available: "2011-08"
-5216	modified jittery skewed elemental paste	1	decent	Last Available: "2011-08"
+5216	modified skewed jittery elemental paste	1	decent	Last Available: "2011-08"
 5217	compressed cosmic paste	1	crappy	Last Available: "2011-08"
 5218	powdered hobo paste	1	crappy	Last Available: "2011-08"
 5219	pickled tumbling Crimbo paste	1	awesome	Effect: "Putting the Pro in Proletariat", Effect Duration: 25, Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	fat loot token	0		No Pull
 5222	mirror Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	normal skewed blurry Ur-Donut	3	good	Last Available: "2011-09"
+5224	normal blurry skewed Ur-Donut	3	good	Last Available: "2011-09"
 5225	green The Bomb	0		Last Available: "2011-09"
 5226	lime green box of Familiar Jacks	0		Last Available: "2011-09"
 5227	hand-crafted bucket of wine	3	EPIC	Last Available: "2011-09"
@@ -5147,16 +5147,16 @@
 5244	bad Muschat	4	decent	Last Available: "2011-09"
 5245	decent low-calorie wobbly cool jelly donut	1	good	Last Available: "2011-09"
 5246	spoiled shrapnel jelly donut	3	crappy	Last Available: "2011-09"
-5247	normal fancy diet occult jelly donut	1	good	Effect: "Phairly Pheromonal", Effect Duration: 25, Last Available: "2011-09"
+5247	diet normal fancy occult jelly donut	1	good	Effect: "Phairly Pheromonal", Effect Duration: 25, Last Available: "2011-09"
 5248	adequate miniature thyme jelly donut	2	good	Last Available: "2011-09"
 5249	adequate ghostly danish	3	good	Last Available: "2011-09"
 5250	toothsome smashed danish	3	awesome	Last Available: "2011-09"
 5251	normal forbidden danish	4	good	Last Available: "2011-09"
-5252	half-sized moldy cool cat claw	2	crappy	Last Available: "2011-09"
+5252	moldy half-sized cool cat claw	2	crappy	Last Available: "2011-09"
 5253	tasty low-calorie blunt cat claw	1	awesome	Last Available: "2011-09"
-5254	fancy rotten half-sized shadowy cat claw	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 15, Last Available: "2011-09"
-5255	spoiled miniature spinning cheezburger	2	crappy	Last Available: "2011-09"
-5256	special adequate toasted brie	4	good	Effect: "Vinegavotte", Effect Duration: 5, Last Available: "2011-09"
+5254	rotten fancy half-sized shadowy cat claw	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 15, Last Available: "2011-09"
+5255	miniature spoiled spinning cheezburger	2	crappy	Last Available: "2011-09"
+5256	adequate special toasted brie	4	good	Effect: "Vinegavotte", Effect Duration: 5, Last Available: "2011-09"
 5257	colloidal activated pulsating potion of the field gar	0		Effect: "Hobo Flavor", Effect Duration: 21, Last Available: "2011-09"
 5258	chilled aerosolized too legit potion	0		Effect: "Really Deep Breath", Effect Duration: 59, Last Available: "2011-09"
 5259	concentrated squat maroon Bright Water	0		Effect: "Purpose", Effect Duration: 31, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	gray strapping broken clock	0		Muscle: +5, Last Available: "2011-09"
 5282	bouncing Temple Grandin's dethklok	0		Familiar Weight: +7, Last Available: "2011-09"
 5283	glacial clock of terror	0		Spooky Spell Damage: +10, Last Available: "2011-09"
-5284	twirling upside-down Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	upside-down twirling Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	green d4	0		Last Available: "2011-09"
 5286	wobbly d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5192,7 +5192,7 @@
 5289	d12	0		Last Available: "2011-09"
 5290	d20	0		Last Available: "2011-09"
 5291	yellow generic healing potion	0		Last Available: "2011-09"
-5292	mirror purple generic mana potion	0		Last Available: "2011-09"
+5292	purple mirror generic mana potion	0		Last Available: "2011-09"
 5293	mirror generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
@@ -5215,31 +5215,31 @@
 5312	energized galvanized ghostly body paint	0		Effect: "Inner Dog", Effect Duration: 32, Last Available: "2011-10"
 5313	frozen twirling necrotizing body spray	0		Effect: "Robocamo", Effect Duration: 48, Last Available: "2011-10"
 5314	chilled aerosolized mirror bite-me-red lipstick	0		Effect: "Stimulated Body", Effect Duration: 35, Last Available: "2011-10"
-5315	warmed pulsating narrow whisker pencil	0		Effect: "substats.enh", Effect Duration: 67, Last Available: "2011-10"
+5315	warmed narrow pulsating whisker pencil	0		Effect: "substats.enh", Effect Duration: 67, Last Available: "2011-10"
 5316	modified press-on ribs	0		Effect: "Scarysauce", Effect Duration: 30, Last Available: "2011-10"
 5317	diffused Rattlin' Chains	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 34, Last Available: "2011-10"
 5318	modified improved pressed Gummy Brains	0		Effect: "Squatting and Thrusting", Effect Duration: 16, Last Available: "2011-10"
 5319	extra-chilled blurry Blood 'n' Plenty	0		Effect: "Locks Like the Raven", Effect Duration: 29, Last Available: "2011-10"
 5320	dry Lobos Mints	0		Effect: "Stands Alone", Effect Duration: 16, Last Available: "2011-10"
 5321	energized lime green Sweet Sword	0		Effect: "Pwnd", Effect Duration: 13, Last Available: "2011-10"
-5322	weak smooth Ecto-Cooler	2	awesome	Last Available: "2011-10"
-5323	irresponsibly strong hand-crafted Bartles and BRAAAINS wine cooler	6	EPIC	Last Available: "2011-10"
-5324	drinkable practically non-alcoholic Blood Light	1	good	Last Available: "2011-10"
-5325	watered-down tolerable bouncing blurry Silver Bullet beer	2	good	Last Available: "2011-10"
+5322	smooth weak Ecto-Cooler	2	awesome	Last Available: "2011-10"
+5323	hand-crafted irresponsibly strong Bartles and BRAAAINS wine cooler	6	EPIC	Last Available: "2011-10"
+5324	practically non-alcoholic drinkable Blood Light	1	good	Last Available: "2011-10"
+5325	tolerable watered-down bouncing blurry Silver Bullet beer	2	good	Last Available: "2011-10"
 5326	hand-crafted Bone's Farm &quot;wine&quot;	3	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
-5328	quadruple-concentrated skewed blurry twirling sorority brain	0		Effect: "Amorous Avarice", Effect Duration: 20, Last Available: "2011-10"
+5328	quadruple-concentrated blurry skewed twirling sorority brain	0		Effect: "Amorous Avarice", Effect Duration: 20, Last Available: "2011-10"
 5329	activated deionized yellow Nightstalker perfume	0		Effect: "Dweeby", Effect Duration: 37, Last Available: "2011-10"
 5330	super-frozen yellow drum of pomade	0		Effect: "Mushroom Melody", Effect Duration: 64, Last Available: "2011-10"
 5331	blinking throwing bone	0		Last Available: "2011-10"
 5332	bouncing extra-see-thru nightie of the pedagogue	0		Experience: +3, Last Available: "2011-10"
-5333	narrow miser's cool BRAINS shorts	0		Moxie: +5, Meat Drop: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	narrow miser's cool BRAINS shorts	0		Moxie: +5, Meat Drop: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	lime green upside-down extremely unsafe Mesmereyes&trade; contact lenses	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2011-10"
 5335	shaking banded scrunchie	0		Damage Absorption: +100, Single Equip, Last Available: "2011-10"
-5336	blurry banded extremely skinny jeans of Flo-Jo	0		Damage Absorption: +100, Initiative: +100, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	jittery lard-coated studded The Necbromancer's Hat	0		Damage Absorption: +80, Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	blurry banded extremely skinny jeans of Flo-Jo	0		Damage Absorption: +100, Initiative: +100, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	jittery lard-coated studded The Necbromancer's Hat	0		Damage Absorption: +80, Sleaze Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	narrow wobbly flame-retardant occult The Necbromancer's Stein of the brute	0		Muscle Percent: +30, Spell Damage Percent: +25, Hot Resistance: +1, Last Available: "2011-10"
-5339	greasy dangerous The Necbromancer's Shorts of temperance	0		Weapon Damage: +10, Sleaze Spell Damage: +10, Sleaze Resistance: +5, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	greasy dangerous The Necbromancer's Shorts of temperance	0		Weapon Damage: +10, Sleaze Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	foul-smelling hale arcane researcher's The Necbromancer's Wizard Staff	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Stench Damage: +10, Last Available: "2011-10"
 5341	blue The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	bad weak squat The Cooler Out of Space	2	decent	Last Available: "2011-10"
@@ -5253,7 +5253,7 @@
 5350	mirror A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	bouncing A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-5353	green wobbly jar of oil	0		
+5353	wobbly green jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
@@ -5262,7 +5262,7 @@
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
-5362	olive spinning skewed CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+5362	spinning skewed olive CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	teal CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
@@ -5279,7 +5279,7 @@
 5376	groovy plastic Big Candy of the wise owl	0		Mysticality: +20, Moxie Percent: +10, Last Available: "2011-12"
 5377	mirror The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	boiled twirling fuchsia blinking groose grease	1	decent	Last Available: "2012-12"
+5379	boiled twirling blinking fuchsia groose grease	1	decent	Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	jittery bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
@@ -5289,7 +5289,7 @@
 5386	rosewater-soaked ridiculous belt	0		Stench Resistance: +3, Last Available: "2011-11"
 5387	skewed razor-sharp ridiculous earring	0		Weapon Damage Percent: +25, Last Available: "2011-11"
 5388	dog trainer's ridiculous sunglasses	0		Experience (familiar): +1, Last Available: "2011-11"
-5389	immense adequate ridiculous sandwich	8	good	Last Available: "2011-11"
+5389	adequate immense ridiculous sandwich	8	good	Last Available: "2011-11"
 5390	drinkable ridiculous cocktail	4	good	Last Available: "2011-11"
 5391	twirling sharpshooter's zombie monkey necklace of extreme caution	0		Critical Hit Percent: +10, Monster Level: -25
 5392	narrow Thwaitgold butterfly statuette	0		
@@ -5304,9 +5304,9 @@
 5401	peppermint parasol	0		Last Available: "2011-11"
 5402	pulsating vibrating candy cane	0		Maximum MP Percent: +10, Last Available: "2011-12"
 5403	teal Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
-5404	shaking teal Peppermint Pip Packet	0		Last Available: "2011-11"
+5404	teal shaking Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	Usain Bolt's flame-wreathed Fonzie's cane-mail shirt	0		Experience (Moxie): +1, Hot Spell Damage: +10, Initiative: +80, Last Available: "2011-12"
-5406	Socratic Herculean cane-mail pants of mayonnaise	0		Experience (Muscle): +1, Experience (Mysticality): +1, Sleaze Spell Damage: +50, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	Socratic Herculean cane-mail pants of mayonnaise	0		Experience (Muscle): +1, Experience (Mysticality): +1, Sleaze Spell Damage: +50, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	perfectly mixed spinning Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
 5408	drinkable shaking Gin Mint	3	good	Last Available: "2011-12"
 5409	tolerable high-proof blinking Tequiz Navidad	7	good	Last Available: "2011-12"
@@ -5319,7 +5319,7 @@
 5416	moist maroon banana supersucker	0		Effect: "Florid Cheeks", Effect Duration: 13, Last Available: "2011-11"
 5417	colloidal cold-filtered pear supersucker	0		Effect: "Fungal Flambé", Effect Duration: 53, Last Available: "2011-11"
 5418	aerosolized lime supersucker	0		Effect: "Happy Salamander", Effect Duration: 59, Last Available: "2011-11"
-5419	adjusted ghostly skewed kumquat supersucker	0		Effect: "Locks Like the Raven", Effect Duration: 43, Last Available: "2011-11"
+5419	adjusted skewed ghostly kumquat supersucker	0		Effect: "Locks Like the Raven", Effect Duration: 43, Last Available: "2011-11"
 5420	warmed colloidal strawberry supersucker	0		Effect: "Sticky Fingers", Effect Duration: 36, Last Available: "2011-11"
 5421	ghostly greasy bananarama bangle	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2011-11"
 5422	yellow electrified pair of pearidot earrings	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	kumquartz ring of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2011-11"
 5425	Lo Pan's strawberyl necklace	0		Spell Critical Percent: +30, Single Equip, Last Available: "2011-11"
 5426	auspicious grievous sucker bucket	0		Weapon Damage Percent: +50, Item Drop: +10, Last Available: "2011-11"
-5427	scorching sucker hakama	0		Hot Damage: +25, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	steel-toed sucker kabuto	0		Damage Reduction: 9, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	scorching sucker hakama	0		Hot Damage: +25, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	steel-toed sucker kabuto	0		Damage Reduction: 9, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	jittery razor-sharp sucker tachi	0		Weapon Damage Percent: +25, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5338,10 +5338,10 @@
 5435	fudgecule	0		Last Available: "2011-11"
 5436	triple-electrified irradiated bouncing fudge lily	0		Effect: "Disco Inferno", Effect Duration: 68, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
-5438	tarnished shaking narrow fluid of fudge-finding	0		Effect: "Worth Your Salt", Effect Duration: 66, Last Available: "2011-11"
+5438	tarnished narrow shaking fluid of fudge-finding	0		Effect: "Worth Your Salt", Effect Duration: 66, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	decent mirror fudgesicle	4	good	Last Available: "2011-11"
-5441	gray upside-down wand of fudge control	0		Last Available: "2011-11"
+5441	upside-down gray wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	triple-Vulcanized devilish folio	0		Effect: "Bread Burps", Effect Duration: 37, Last Available: "2012-12"
@@ -5354,10 +5354,10 @@
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	pulsating avarice stone	0		Last Available: "2012-12"
 5453	narrow gluttonous stone	0		Last Available: "2012-12"
-5454	squat purple gummi ingot	0		Last Available: "2011-11"
+5454	purple squat gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	fuchsia gummi ingot	0		Last Available: "2011-11"
-5457	diffused huge blue Fudgie Roll	0		Effect: "Spiky Frozen Hair", Effect Duration: 15, Last Available: "2011-11"
+5457	diffused blue huge Fudgie Roll	0		Effect: "Spiky Frozen Hair", Effect Duration: 15, Last Available: "2011-11"
 5458	decent half-sized fudge bunny	2	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	pulsating jittery Temple Grandin's ruddy fudgecycle of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Familiar Weight: +7, Single Equip, Last Available: "2011-11"
@@ -5369,7 +5369,7 @@
 5466	anodized pressed resolution: be stronger	0		Effect: "Saucefingers", Effect Duration: 40, Last Available: "2012-01"
 5467	adjusted resolution: be smarter	0		Effect: "Norwhalloped", Effect Duration: 46, Last Available: "2012-01"
 5468	improved triple-denatured pulsating resolution: be sexier	0		Effect: "Jammin'", Effect Duration: 28, Last Available: "2012-01"
-5469	galvanized wobbly huge resolution: be feistier	0		Effect: "Turkey-Friendly", Effect Duration: 24, Last Available: "2012-01"
+5469	galvanized huge wobbly resolution: be feistier	0		Effect: "Turkey-Friendly", Effect Duration: 24, Last Available: "2012-01"
 5470	deionized gray twirling resolution: be kinder	0		Effect: "Altered Wavelengths", Effect Duration: 34, Last Available: "2012-01"
 5471	super-irradiated dry tumbling resolution: be more adventurous	0		Effect: "Craft Tea", Effect Duration: 69, Last Available: "2012-01"
 5472	double-moist deionized resolution: be luckier	0		Effect: "The Moxie of LOV", Effect Duration: 62, Last Available: "2012-01"
@@ -5379,12 +5379,12 @@
 5476	diffused quantum adjusted gummi salamander	0		Effect: "Gleaming White Teeth", Effect Duration: 32, Last Available: "2011-11"
 5477	liquefied enhanced gummi snake	0		Effect: "Your Favorite Flavor", Effect Duration: 17, Last Available: "2011-11"
 5478	nitrogenated gummi canary	0		Effect: "Alchemical, Brother", Effect Duration: 29, Last Available: "2011-11"
-5479	half-sized tasty gummi bear	2	awesome	Last Available: "2011-11"
-5480	small fancy flavorless gummi bear	2	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 5, Last Available: "2011-11"
+5479	tasty half-sized gummi bear	2	awesome	Last Available: "2011-11"
+5480	flavorless small fancy gummi bear	2	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 5, Last Available: "2011-11"
 5481	spoiled gummi bear	4	crappy	Last Available: "2011-11"
-5482	half-sized flavorless bouncing drunki-bear	2	decent	Last Available: "2011-11"
+5482	flavorless half-sized bouncing drunki-bear	2	decent	Last Available: "2011-11"
 5483	delicious drunki-bear	3	awesome	Last Available: "2011-11"
-5484	rotten huge drunki-bear	9	crappy	Last Available: "2011-11"
+5484	huge rotten drunki-bear	9	crappy	Last Available: "2011-11"
 5485	boxer's gummi bowtie	0		Muscle Percent: +10, Last Available: "2011-11"
 5486	twirling fudge pocket square of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-11"
 5487	double-paned lollipop cufflinks	0		Cold Resistance: +5, Last Available: "2011-11"
@@ -5399,8 +5399,8 @@
 5496	tarnished chilled twirling gummi belemnite	0		Effect: "In the Slimelight", Effect Duration: 66, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	avaricious asbestos-lined Big Candy's tophat	0		Hot Resistance: +5, Meat Drop: +30, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
-5500	purple bouncing Fuzzby	0		Free Pull, Last Available: "2011-11"
+5499	avaricious asbestos-lined Big Candy's tophat	0		Hot Resistance: +5, Meat Drop: +30, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5500	bouncing purple Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	upside-down Trivial Avocations board game	0		Last Available: "2011-11"
 5503	blinking Tickle-Me Emilio	0		Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	galvanized adjusted bouncing Atomic Pop	0		Effect: "Turkey-Friendly", Effect Duration: 21, Last Available: "2020-09"
 5527	upside-down do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	huge whimpering willow bark	0		Last Available: "2012-12"
-5529	spoiled bite-sized special berries of suffering	1	crappy	Effect: "Egg-stra Arm", Effect Duration: 15, Last Available: "2012-12"
+5529	bite-sized spoiled special berries of suffering	1	crappy	Effect: "Egg-stra Arm", Effect Duration: 15, Last Available: "2012-12"
 5530	nitrogenated polarized spinning baobab sap	0		Effect: "Orc Chops", Effect Duration: 67, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
@@ -5442,14 +5442,14 @@
 5539	skewed glass of warm water	0		Free Pull
 5540	chilled pulsating desktop zen garden	0		Effect: "Swimming Head", Effect Duration: 63, Last Available: "2012-12"
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
-5542	skewed wobbly pink-belly slapper	0		Last Available: "2012-12"
+5542	wobbly skewed pink-belly slapper	0		Last Available: "2012-12"
 5543	smelly Leapin' Trousers of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10
-5544	watered-down artisanal eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
+5544	artisanal watered-down eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
 5545	adequate purple hamhock	3	good	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	squat Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
-5549	narrow huge green Clancy's crumhorn	0		Last Available: "2012-12"
+5549	green narrow huge Clancy's crumhorn	0		Last Available: "2012-12"
 5550	lime green The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	stanky Trusty	0		Stench Spell Damage: +25
@@ -5459,7 +5459,7 @@
 5556	blurry Tesla wholesome Rain-Doh wings	0		Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-02"
 5557	tumbling Rain-Doh agent	0		Last Available: "2012-02"
 5558	veiny rosy-cheeked Rain-Doh laser gun	0		Maximum HP Percent: +30, Maximum HP: +10, Softcore Only, Last Available: "2012-02"
-5559	double-paned thinker's Rain-Doh lantern	0		Mysticality: +10, Cold Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	double-paned thinker's Rain-Doh lantern	0		Mysticality: +10, Cold Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	pulsating Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	blurry Sherlock's toasty Rain-Doh violet bo	0		Hot Damage: +5, Item Drop: +25, Softcore Only, Last Available: "2012-02"
@@ -5474,41 +5474,41 @@
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	tolerable Drac & Tan	3	good	Last Available: "2012-03"
-5574	practically non-alcoholic delicious Transylvania Sling	1	awesome	Last Available: "2012-03"
+5574	delicious practically non-alcoholic Transylvania Sling	1	awesome	Last Available: "2012-03"
 5575	drinkable Shot of the Living Dead	3	good	Last Available: "2012-03"
-5576	watered-down fancy drinkable Buttery Knob	2	good	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2012-03"
-5577	aged weak Slippery Knob	2	awesome	Last Available: "2012-03"
+5576	drinkable watered-down fancy Buttery Knob	2	good	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2012-03"
+5577	weak aged Slippery Knob	2	awesome	Last Available: "2012-03"
 5578	mediocre upside-down Flaming Knob	3	decent	Last Available: "2012-03"
 5579	irresponsibly strong mediocre Grasshopper	8	decent	Last Available: "2012-03"
-5580	artisanal watered-down Locust	2	EPIC	Last Available: "2012-03"
+5580	watered-down artisanal Locust	2	EPIC	Last Available: "2012-03"
 5581	weak drinkable Plague of Locusts	2	good	Last Available: "2012-03"
 5582	practically non-alcoholic lousy Red Dwarf	1	decent	Last Available: "2012-03"
-5583	watered-down artisanal Golden Mean	2	EPIC	Last Available: "2012-03"
+5583	artisanal watered-down Golden Mean	2	EPIC	Last Available: "2012-03"
 5584	smooth twirling Green Giant	4	awesome	Last Available: "2012-03"
 5585	hand-crafted boozy Aye Aye	5	EPIC	Last Available: "2012-03"
 5586	aged Aye Aye, Captain	4	awesome	Last Available: "2012-03"
 5587	artisanal weak Aye Aye, Tooth Tooth	2	EPIC	Last Available: "2012-03"
-5588	tolerable special watered-down Humanitini	2	good	Effect: "Hopped Up on Goofballs", Effect Duration: 30, Last Available: "2012-03"
-5589	distilled lousy More Humanitini than Humanitini	5	decent	Last Available: "2012-03"
+5588	tolerable watered-down special Humanitini	2	good	Effect: "Hopped Up on Goofballs", Effect Duration: 30, Last Available: "2012-03"
+5589	lousy distilled More Humanitini than Humanitini	5	decent	Last Available: "2012-03"
 5590	bad Oh, the Humanitini	4	decent	Last Available: "2012-03"
 5591	practically non-alcoholic bad Great Older Fashioned	1	decent	Last Available: "2012-03"
 5592	aged skewed Fuzzy Tentacle	4	awesome	Last Available: "2012-03"
 5593	practically non-alcoholic bad Crazymaker	1	decent	Last Available: "2012-03"
-5594	drinkable watered-down Zoodriver	2	good	Last Available: "2012-03"
+5594	watered-down drinkable Zoodriver	2	good	Last Available: "2012-03"
 5595	bad Sloe Comfortable Zoo	4	decent	Last Available: "2012-03"
 5596	special tolerable shaking Sloe Comfortable Zoo on Fire	3	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2012-03"
 5597	aged tumbling Suffering Sinner	4	awesome	Last Available: "2012-03"
 5598	hand-crafted green Suppurating Sinner	4	EPIC	Last Available: "2012-03"
 5599	practically non-alcoholic drinkable Sizzling Sinner	1	good	Last Available: "2012-03"
-5600	fancy drinkable Firewater	3	good	Effect: "Chalky White Pallor", Effect Duration: 35, Last Available: "2012-03"
+5600	drinkable fancy Firewater	3	good	Effect: "Chalky White Pallor", Effect Duration: 35, Last Available: "2012-03"
 5601	tolerable watered-down Earth and Firewater	2	good	Last Available: "2012-03"
 5602	artisanal weak Earth, Wind and Firewater	2	EPIC	Last Available: "2012-03"
 5603	drinkable irresponsibly strong squat Slimosa	9	good	Last Available: "2012-03"
-5604	drinkable high-proof Extra-slimy Slimosa	7	good	Last Available: "2012-03"
+5604	high-proof drinkable Extra-slimy Slimosa	7	good	Last Available: "2012-03"
 5605	weak smooth Slimebite	2	awesome	Last Available: "2012-03"
 5606	bad Cement Mixer	4	decent	Last Available: "2012-03"
 5607	aged Jackhammer	3	awesome	Last Available: "2012-03"
-5608	enchanted drinkable Dump Truck	3	good	Effect: "Sauce Monocle", Effect Duration: 10, Last Available: "2012-03"
+5608	drinkable enchanted Dump Truck	3	good	Effect: "Sauce Monocle", Effect Duration: 10, Last Available: "2012-03"
 5609	drinkable Fauna Libre	3	good	Last Available: "2012-03"
 5610	perfectly mixed Chakra Libre	3	EPIC	Last Available: "2012-03"
 5611	lousy Aura Libre	4	decent	Last Available: "2012-03"
@@ -5516,9 +5516,9 @@
 5613	perfectly mixed practically non-alcoholic Sazuruk-hai	1	EPIC	Last Available: "2012-03"
 5614	bad Flaming Sazerorc	3	decent	Last Available: "2012-03"
 5615	mediocre Green Velvet	4	decent	Last Available: "2012-03"
-5616	irresponsibly strong drinkable Green Muslin	8	good	Last Available: "2012-03"
-5617	spirit-forward hand-crafted Green Burlap	5	EPIC	Last Available: "2012-03"
-5618	triple-distilled lousy tumbling Mohobo	6	decent	Last Available: "2012-03"
+5616	drinkable irresponsibly strong Green Muslin	8	good	Last Available: "2012-03"
+5617	hand-crafted spirit-forward Green Burlap	5	EPIC	Last Available: "2012-03"
+5618	lousy triple-distilled tumbling Mohobo	6	decent	Last Available: "2012-03"
 5619	weak mediocre Moonshine Mohobo	2	decent	Last Available: "2012-03"
 5620	drinkable wobbly Flaming Mohobo	4	good	Last Available: "2012-03"
 5621	irresponsibly strong artisanal huge Drunken Philosopher	9	EPIC	Last Available: "2012-03"
@@ -5534,28 +5534,28 @@
 5631	mediocre jittery Candy Alexander	3	decent	Last Available: "2012-03"
 5632	drinkable Candicaine	4	good	Last Available: "2012-03"
 5633	mediocre Caipiranha	3	decent	Last Available: "2012-03"
-5634	lousy irresponsibly strong teal Flying Caipiranha	9	decent	Last Available: "2012-03"
+5634	irresponsibly strong lousy teal Flying Caipiranha	9	decent	Last Available: "2012-03"
 5635	artisanal wobbly Flaming Caipiranha	3	EPIC	Last Available: "2012-03"
 5636	hand-crafted Punchplanter	3	EPIC	Last Available: "2012-03"
 5637	artisanal Doublepunchplanter	4	EPIC	Last Available: "2012-03"
-5638	lousy distilled blurry Haymaker	5	decent	Last Available: "2012-03"
+5638	distilled lousy blurry Haymaker	5	decent	Last Available: "2012-03"
 5639	gray blurry Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	stale huge fungus	6	decent	
-5642	teal spinning poisoned dart	0		
+5641	huge stale fungus	6	decent	
+5642	spinning teal poisoned dart	0		
 5643	concentrated pickled stone wool	0		Effect: "The Smile of Mr. A.", Effect Duration: 50
 5644	stones	0		
 5645	the Nostril of the Serpent	0		
 5646	squat calendar fragment	0		
 5647	medical-grade calendar	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 4
-5648	Jim Carey's Boris's Helm of the bloodbag	0		Maximum HP: +100, Monster Level: +25, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	Jim Carey's Boris's Helm of the bloodbag	0		Maximum HP: +100, Monster Level: +25, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	upside-down shellacked Newton's staph of homophones	0		Experience (Mysticality): +3, Damage Reduction: 7
-5650	prompt rosewater-soaked deadly Boris's Helm (askew)	0		Weapon Damage: +5, Stench Resistance: +3, Adventures: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	prompt rosewater-soaked deadly Boris's Helm (askew)	0		Weapon Damage: +5, Stench Resistance: +3, Adventures: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	blurry mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	huge key-o-tron	0		
 5654	adequate squat nailswurst	3	good	
-5655	special smooth squat used beer	3	awesome	Effect: "Human-Hobo Hybrid", Effect Duration: 15
+5655	smooth special squat used beer	3	awesome	Effect: "Human-Hobo Hybrid", Effect Duration: 15
 5656	Huggler Radio	0		Free Pull
 5657	tumbling fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5570,16 +5570,16 @@
 5667	puppet strings	0		Free Pull
 5668	bouncing bagged &quot;L&quot;	0		
 5669	club	0		
-5670	super-sized stale fettucini &eacute;pines Inconnu	5	decent	
-5671	practically non-alcoholic smooth slap and slap again	1	awesome	
+5670	stale super-sized fettucini &eacute;pines Inconnu	5	decent	
+5671	smooth practically non-alcoholic slap and slap again	1	awesome	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	red &quot;L&quot;	0		
 5675	twisted wobbly shaking watered-down Red Minotaur	1		
 5676	squat pool torpedo	0		Last Available: "2012-05"
-5677	upside-down up-at-dawn Ze&trade; goggles	0		Adventures: +5, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	upside-down up-at-dawn Ze&trade; goggles	0		Adventures: +5, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	pulsating soggy used band-aid	0		Last Available: "2012-05"
-5679	friendly beefy stylish swimsuit	0		Muscle: +10, Familiar Weight: +3, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	friendly beefy stylish swimsuit	0		Muscle: +10, Familiar Weight: +3, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	fuchsia lost key	0		Last Available: "2012-05"
 5681	miniature decent P.B.L.T.	2	good	
 5682	teal bouncing note from Clancy	0		Skill: "Request Sandwich"
@@ -5587,7 +5587,7 @@
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	jittery lime green bugbear autopsy tweezers	0		
+5687	lime green jittery bugbear autopsy tweezers	0		
 5688	bouncing flame-retardant UV monocular	0		Hot Resistance: +1, Single Equip
 5689	mirror drone self-destruct chip	0		
 5690	jittery Jeff Goldblum larva	0		
@@ -5602,14 +5602,14 @@
 5699	tumbling The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
-5702	tumbling squat mannequin	0		Familiar Weight: +5
+5702	squat tumbling mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
-5704	spinning pulsating wax bugbear	0		Last Available: "2012-06"
-5705	lime green Temple Grandin's crafty wax hat	0		Maximum MP: +10, Familiar Weight: +7, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	coward's therapeutic wax pants	0		Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5704	pulsating spinning wax bugbear	0		Last Available: "2012-06"
+5705	lime green Temple Grandin's crafty wax hat	0		Maximum MP: +10, Familiar Weight: +7, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	coward's therapeutic wax pants	0		Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	olive shaking FDKOL commendation	0		Last Available: "2012-07"
 5708	pressed yellow drop of water-37	0		Effect: "Kissed By Fire", Effect Duration: 26, Last Available: "2012-07"
-5709	blinking huge Temple Grandin's steel-toed fireman's helmet	0		Damage Reduction: 9, Familiar Weight: +7, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	blinking huge Temple Grandin's steel-toed fireman's helmet	0		Damage Reduction: 9, Familiar Weight: +7, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	fire axe of Tarzan	0		Experience (Muscle): +3, Last Available: "2012-07"
 5713	huge horrifying nippy fire extinguisher of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +10, Spooky Damage: +25, Last Available: "2012-07"
 5714	teal FDKOL tattoo	0		
@@ -5624,13 +5624,13 @@
 5723	colloidal enhanced pickled bottle of fire	0		Effect: "All Glory To the Toad", Effect Duration: 22, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	spinning bouncing maroon nippy quilted hot daub bun	0		Damage Absorption: +40, Cold Damage: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	spinning executive veiny hot daub stand	0		Maximum HP: +10, Meat Drop: +40, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	spinning bouncing maroon nippy quilted hot daub bun	0		Damage Absorption: +40, Cold Damage: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	spinning executive veiny hot daub stand	0		Maximum HP: +10, Meat Drop: +40, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	yellow Samson's foot-long hot daub of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Last Available: "2012-07"
 5729	jittery twirling ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy angst burger	4	crappy	
 5731	aged enchanted 5-hour acrimony	4	awesome	Effect: "Pronounced Potency", Effect Duration: 15
-5732	squat mirror blank note	0		
+5732	mirror squat blank note	0		
 5733	purple eerily silent box	0		
 5734	bland huge teal forbidden sausage	3	decent	
 5735	huge Lord Flameface's cloak	0		Item Drop: +5, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
@@ -5639,13 +5639,13 @@
 5738	perfumed Camp Scout backpack	0		Stench Resistance: +5, Softcore Only, Last Available: "2012-07"
 5739	tumbling CSA fire-starting kit	0		Last Available: "2012-07"
 5740	rotten teal bag of GORP	3	crappy	Last Available: "2012-07"
-5741	watered-down lousy water purification pills	2	decent	Last Available: "2012-07"
+5741	lousy watered-down water purification pills	2	decent	Last Available: "2012-07"
 5742	squat Camp Scout pup tent	0		Last Available: "2012-07"
 5743	mediocre skewed CSA scoutmaster's &quot;water&quot;	4	decent	Last Available: "2012-07"
 5744	adequate bag of GORF	3	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	stale bag of QWOP	3	decent	Last Available: "2012-07"
-5747	triple-energized cold-filtered narrow mirror CSA bravery badge	0		Effect: "Superhuman Sarcasm", Effect Duration: 56, Last Available: "2012-07"
+5747	triple-energized cold-filtered mirror narrow CSA bravery badge	0		Effect: "Superhuman Sarcasm", Effect Duration: 56, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	smooth CSA cheerfulness ration	4	awesome	Last Available: "2012-07"
 5750	ghostly CSA obedience grenade	0		Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	stale wobbly decent brain	3	decent	
 5754	rotten half-sized wobbly spinning good brain	2	crappy	
 5755	spoiled boss brain	4	crappy	
-5756	half-sized decent hunter brain	2	good	
+5756	decent half-sized hunter brain	2	good	
 5758	Jim Carey's sharpshooter's MacGyver's Staff of Holiday Sensations	0		Maximum MP: +100, Critical Hit Percent: +10, Monster Level: +25, Last Available: "2011-11"
 5759	sage staff of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3
 5760	zippy aromatic gravedigger's staff	0		Spooky Damage: +10, Stench Resistance: +1, Initiative: +20
@@ -5665,16 +5665,16 @@
 5765	gravedigger's banded fuzzy earmuffs	0		Damage Absorption: +100, Spooky Damage: +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	lard-coated cool fuzzy montera of the glutton	0		Moxie: +5, Sleaze Spell Damage: +25, Food Drop: +100, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	purple gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	narrow gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	red gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	purple gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	narrow gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	red gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	wobbly Thwaitgold maggot statuette	0		
 5774	tumbling talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	huge savvy Barney's rake of terror	0		Mysticality Percent: +20, Spooky Spell Damage: +10
-5778	rotten bite-sized huge idiot brain	1	crappy	
+5778	bite-sized rotten huge idiot brain	1	crappy	
 5779	sizzling keel-haulin' knife	0		Hot Damage: +10
 5780	ice cream scoop of Leguizamo	0		Monster Level: +20
 5781	practically non-alcoholic drinkable soft echo eyedrop antidote martini	1	good	
@@ -5684,7 +5684,7 @@
 5785	thick caulk	0		
 5786	teal hard screw	0		
 5787	messy butt joint	0		
-5788	jittery huge shaking smut orc keepsake box	0		
+5788	huge jittery shaking smut orc keepsake box	0		
 5789	twirling bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
 5791	hardened right bear arm of the cougar	0		Moxie: +20, Damage Reduction: 3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
@@ -5706,9 +5706,9 @@
 5807	polymerized ionized ionized glass of warm milk	0		Effect: "Chlorophyll Flavor", Effect Duration: 51
 5808	energized extra-vacuum-sealed skewed glass of gnat milk	0		Effect: "Low on the Hog", Effect Duration: 50
 5809	flattened pressed squat Knob Goblin Mutagen	0		Effect: "Joy", Effect Duration: 11
-5810	denatured colloidal energized yellow squat upside-down Tears of the Quiet Healer	0		Effect: "Cat-Alyzed", Effect Duration: 40
+5810	denatured colloidal energized squat yellow upside-down Tears of the Quiet Healer	0		Effect: "Cat-Alyzed", Effect Duration: 40
 5811	boiled quadruple-tarnished tube of lipstick	0		Effect: "Crimbo Flavor", Effect Duration: 64
-5812	oxidized tumbling upside-down skelelton spine	0		Effect: "Gemini Rising", Effect Duration: 68
+5812	oxidized upside-down tumbling skelelton spine	0		Effect: "Gemini Rising", Effect Duration: 68
 5813	deionized liquefied huge smut orc sunglasses	0		Effect: "Altered Wavelengths", Effect Duration: 68
 5814	double-ionized spinning blob of acid	0		Effect: "Fiery Spirit", Effect Duration: 23
 5815	modified colloidal polarized red flayed mind	0		Effect: "Bread-Lined", Effect Duration: 19
@@ -5716,14 +5716,14 @@
 5817	denatured gray forest spirit rattle	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 11
 5818	ionized blurry Stone Golem pebbles	0		Effect: "Greasy Peasy", Effect Duration: 23
 5819	anodized ghostly gravy fairy warlock hat	0		Effect: "Fangs and Pangs", Effect Duration: 65
-5820	denatured blue spinning bull blubber	0		Effect: "One For Tea", Effect Duration: 69
+5820	denatured spinning blue bull blubber	0		Effect: "One For Tea", Effect Duration: 69
 5821	quantum ionized oxidized cyan frog lip-print	0		Effect: "Hippy Flavor", Effect Duration: 37
 5822	enhanced oxidized gazely stare	0		Effect: "Engorged Weapon", Effect Duration: 46
 5823	tarnished ionized canopic jar	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 13
 5824	non-nitrogenated flattened clove-flavored lip balm	0		Effect: "Polar Express", Effect Duration: 22
 5825	quadruple-frozen blinking Skullery Maid's Knee	0		Effect: "Virgo Rising", Effect Duration: 13
 5826	super-colloidal zombie hollandaise	0		Effect: "Filled with Magic", Effect Duration: 31
-5827	energized chilled narrow blurry skeletal banana	0		Effect: "Baconstoned", Effect Duration: 34
+5827	energized chilled blurry narrow skeletal banana	0		Effect: "Baconstoned", Effect Duration: 34
 5828	pickled squat gilt perfume bottle	0		Effect: "There Is A Spoon", Effect Duration: 22
 5829	flattened double-anodized deionized lime green janglin' bones	0		Effect: "Brother Corsican's Blessing", Effect Duration: 20
 5830	Vulcanized super-energized anodized pygmy papers	0		Effect: "Wet Willied", Effect Duration: 21
@@ -5756,19 +5756,19 @@
 5857	flattened grey cube	0		Effect: "Some Cheese with Your Wine", Effect Duration: 58
 5858	nitrogenated votive candle	0		Effect: "protect.enq", Effect Duration: 21
 5859	anodized cold-filtered ghostly booby trap	0		Effect: "A View to Some Meat", Effect Duration: 28
-5860	denatured tarnished blinking bouncing Agent Corrigan's cigarette	0		Effect: "Block-Rockin' Beet", Effect Duration: 55
+5860	denatured tarnished bouncing blinking Agent Corrigan's cigarette	0		Effect: "Block-Rockin' Beet", Effect Duration: 55
 5861	cold-filtered flattened blurry pulsating good ash	0		Effect: "Gutterminded", Effect Duration: 52
 5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	wobbly papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	boiled double-polarized cyan papier-mochi	0		Effect: "Limber as Mortimer", Effect Duration: 67, Last Available: "2012-09"
-5866	activated colloidal twirling blue papier-m&acirc;chaeranthera	0		Effect: "Gummiheart", Effect Duration: 68, Last Available: "2012-09"
+5866	activated colloidal blue twirling papier-m&acirc;chaeranthera	0		Effect: "Gummiheart", Effect Duration: 68, Last Available: "2012-09"
 5867	triple-deionized modified papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Extra Backbone", Effect Duration: 54, Last Available: "2012-09"
 5868	bouncing up-at-dawn Jim Carey's papier-m&acirc;ch&eacute;te	0		Monster Level: +25, Adventures: +5, Last Available: "2012-09"
 5869	energetic papier-m&acirc;chine gun of the brute	0		Muscle Percent: +30, Maximum MP Percent: +20, Last Available: "2012-09"
 5870	blurry Da Vinci's papier-masque of the early riser	0		Experience (Mysticality): +5, Adventures: +7, Single Equip, Last Available: "2012-09"
-5871	purple pulsating nasty wicked papier-mitre	0		Spell Damage: +5, Stench Damage: +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	skewed wicked papier-m&acirc;churidars of the sewer	0		Spell Damage: +5, Stench Damage: +25, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	purple pulsating nasty wicked papier-mitre	0		Spell Damage: +5, Stench Damage: +5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	skewed wicked papier-m&acirc;churidars of the sewer	0		Spell Damage: +5, Stench Damage: +25, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	spinning skeletal skiff	0		Last Available: "2012-10"
 5886	miser's censurious Rosewater's weightlifter's Bonestabber	0		Muscle: +15, Mysticality Percent: +30, Sleaze Resistance: +3, Meat Drop: +10, Last Available: "2012-10"
-5887	lousy irresponsibly strong teal crystal skeleton vodka	6	decent	Last Available: "2012-10"
+5887	irresponsibly strong lousy teal crystal skeleton vodka	6	decent	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	Jim Carey's auxiliary backbone	0		Monster Level: +25, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5818,12 +5818,12 @@
 5920	stanky plastic taco-clad Crimbo elf	0		Stench Spell Damage: +25, Last Available: "2012-12"
 5921	blurry Van der Graaf plastic Uncle Crimboku	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-12"
 5922	upside-down huge studded plastic MechaElf	0		Damage Absorption: +80, Last Available: "2012-12"
-5923	blurry yellow ghostly plastic ingot	0		Last Available: "2012-12"
+5923	blurry ghostly yellow plastic ingot	0		Last Available: "2012-12"
 5924	bouncing electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	teal shaking BittyCar MeatCar	0		Last Available: "2012-12"
+5926	shaking teal BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	shaking brainwave-controlled unicorn horn	0		Item Drop: +5, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	shaking brainwave-controlled unicorn horn	0		Item Drop: +5, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	purple bubble-wrap simulator	0		Last Available: "2012-12"
 5930	maroon blind-packed capsule toy	0		Last Available: "2012-12"
 5931	purple skewed double-paned Samson's plastic four-shadowed mime of the boozehound	0		Experience (Muscle): +5, Cold Resistance: +5, Booze Drop: +100, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	plastic Father McGruber of the sweet-tooth	0		Candy Drop: +100, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of the boozehound	0		Booze Drop: +100, Last Available: "2012-12"
 5962	skewed squat plastic blazing bat of the sewer	0		Stench Damage: +25, Last Available: "2012-12"
-5963	aromatic chaotic electronic dulcimer pants	0		Spell Critical Percent: +10, Stench Resistance: +1, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	aromatic chaotic electronic dulcimer pants	0		Spell Critical Percent: +10, Stench Resistance: +1, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	lime green A-Boo clue	0		
 5965	jittery educational Frown Exerciser of the cougar	0		Moxie: +20, Experience: +1, Single Equip, Last Available: "2012-12"
 5966	blinking soul monocle	0		Single Equip
@@ -5879,7 +5879,7 @@
 5981	tumbling star	0		Last Available: "2013-02"
 5982	irresponsibly strong drinkable tankard of ale	7	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	purple Jack Frost's veiny personal trainer's cloth cap	0		Experience Percent (Muscle): +10, Maximum HP: +10, Cold Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	purple Jack Frost's veiny personal trainer's cloth cap	0		Experience Percent (Muscle): +10, Maximum HP: +10, Cold Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	twirling up-at-dawn family-friendly Jack Frost's iron dagger	0		Cold Spell Damage: +50, Sleaze Resistance: +1, Adventures: +5, Last Available: "2013-02"
 5986	massive toothsome enchanted blue hamburger	10	awesome	Effect: "Spirit of Alph", Effect Duration: 50, Last Available: "2013-02"
 5987	fuchsia dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	blurry blinking potion	0		Last Available: "2013-02"
 5990	acceptable narrow bottle of wine	4	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	Van der Graaf wicked boxer's iron helmet	0		Muscle Percent: +10, Spell Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	Van der Graaf wicked boxer's iron helmet	0		Muscle Percent: +10, Spell Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	wool occult sinister steel sword	0		Spell Damage: +10, Spell Damage Percent: +25, Cold Resistance: +1, Last Available: "2013-02"
 5994	rotten whole roasted chicken	4	crappy	Last Available: "2013-02"
 5995	maroon massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	practically non-alcoholic bad shining goblet	1	decent	Last Available: "2013-02"
+5998	bad practically non-alcoholic shining goblet	1	decent	Last Available: "2013-02"
 5999	jittery fireball	0		Last Available: "2013-02"
-6000	wool Annie Oakley's crown	0		Critical Hit Percent: +20, Cold Resistance: +1, Item Drop: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	wool Annie Oakley's crown	0		Critical Hit Percent: +20, Cold Resistance: +1, Item Drop: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	lime green blurry executive energetic curative sword	0		Maximum MP Percent: +20, Meat Drop: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-02"
-6002	upside-down gravedigger's experienced brawny Helm of the Scream Emperor	0		Muscle Percent: +20, Experience: +2, Spooky Damage: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	upside-down gravedigger's experienced brawny Helm of the Scream Emperor	0		Muscle Percent: +20, Experience: +2, Spooky Damage: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	rock-hard arcane researcher's Cloak of Dire Shadows of the storm	0		Experience Percent (Mysticality): +10, Damage Reduction: 5, Maximum MP Percent: +40, Last Available: "2013-02"
 6004	twirling toasty Jack Frost's vibrating Sword of Dark Omens	0		Maximum MP Percent: +10, Cold Spell Damage: +50, Hot Damage: +5, Last Available: "2013-02"
 6005	narrow stiffened Da Vinci's Shield of Icy Fate of the blizzard	0		Experience (Mysticality): +5, Damage Reduction: 8, Cold Spell Damage: +25, Last Available: "2013-02"
-6006	blinking Temple Grandin's Greaves of the Murk Lord of James Dean of the sewer	0		Experience (Moxie): +3, Familiar Weight: +7, Stench Damage: +25, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	blinking Temple Grandin's Greaves of the Murk Lord of James Dean of the sewer	0		Experience (Moxie): +3, Familiar Weight: +7, Stench Damage: +25, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	friendly wicked Gauntlets of the Blood Moon of wisdom	0		Mysticality: +15, Spell Damage: +5, Familiar Weight: +3, Single Equip, Last Available: "2013-02"
 6008	auspicious Boots of Twilight Whispers of doom of temperance	0		Spooky Spell Damage: +50, Sleaze Resistance: +5, Item Drop: +10, Single Equip, Last Available: "2013-02"
 6009	horrifying stylish Belt of Howling Anger of incineration	0		Moxie: +25, Hot Spell Damage: +50, Spooky Damage: +25, Single Equip, Last Available: "2013-02"
@@ -5931,7 +5931,7 @@
 6033	huge ghostly scandalous resourceful stolen necklace	0		Maximum MP: +50, Sleaze Damage: +5
 6034	wobbly aromatic troll britches of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Familiar Effect: "1.5xPotato, cap 28"
 6035	polymerized vial of The Glistening	0		Effect: "Mana Tea", Effect Duration: 18
-6036	artisanal distilled artisanal limoncello	5	EPIC	
+6036	distilled artisanal artisanal limoncello	5	EPIC	
 6037	ginger ale	0		
 6038	rotten wobbly incredible pizza	3	crappy	
 6039	bouncing dance instructor's Samson's oil cap	0		Experience (Muscle): +5, Experience Percent (Moxie): +10, Familiar Effect: "cap 28"
@@ -5947,11 +5947,11 @@
 6049	greedy Jeselnik's thinker's Misty Cape	0		Mysticality: +10, Sleaze Damage: +25, Meat Drop: +20
 6050	jittery woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	jumbo adequate Taco Dan's Taco Stand Taco	5	good	Last Available: "2012-12"
-6053	practically non-alcoholic perfectly mixed Taco Dan's Taco Stand Chimichangarita	1	EPIC	Last Available: "2012-12"
+6052	adequate jumbo Taco Dan's Taco Stand Taco	5	good	Last Available: "2012-12"
+6053	perfectly mixed practically non-alcoholic Taco Dan's Taco Stand Chimichangarita	1	EPIC	Last Available: "2012-12"
 6054	cold-filtered colloidal ghostly Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Hagnk's Gratitude", Effect Duration: 20, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	skewed The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	skewed The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	narrow blue curative strapping Meatcleaver	0		Muscle: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
 6058	hardened Crimbo Elf bobble-head	0		Damage Reduction: 3, Last Available: "2012-12"
 6059	fireproof Crimbo stogie-scented room odorizer	0		Hot Resistance: +3, Last Available: "2012-12"
@@ -6038,9 +6038,9 @@
 6140	blurry Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	jumbo spoiled roasted duck	5	crappy	Last Available: "2013-12"
-6143	bland gigantic dead meat bun	9	decent	Last Available: "2013-12"
+6143	gigantic bland dead meat bun	9	decent	Last Available: "2013-12"
 6144	sage cat collar	0		Mysticality Percent: +10, Single Equip, Last Available: "2013-12"
-6145	wobbly vibrating Newton's suspicious-looking fedora	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	wobbly vibrating Newton's suspicious-looking fedora	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,8 +6058,8 @@
 6161	regret hose of Tarzan	0		Experience (Muscle): +3, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	curative slick commodore's hat	0		Moxie: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	Fonzie's naval trousers	0		Experience (Moxie): +1, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	curative slick commodore's hat	0		Moxie: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	Fonzie's naval trousers	0		Experience (Moxie): +1, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	rosy-cheeked groovy deck cannon	0		Moxie Percent: +10, Maximum HP Percent: +30, Last Available: "2013-12"
 6167	Samson's ornamental sextant	0		Experience (Muscle): +5, Last Available: "2013-12"
 6168	Bloodbath of the bloodbag of the blizzard	0		Maximum HP: +100, Cold Spell Damage: +25, Last Available: "2013-12"
@@ -6071,30 +6071,30 @@
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	upside-down GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
-6177	spinning yellow cosmic dough	0		
+6177	yellow spinning cosmic dough	0		
 6178	cosmic vegetable	0		
 6179	cosmic cheese	0		
 6180	fuchsia cosmic potted meat product	0		
 6181	cosmic potato	0		
-6182	maroon skewed cosmic cream	0		
+6182	skewed maroon cosmic cream	0		
 6183	cosmic fruit	0		
 6184	shaking sizzling rock-hard Jarlsberg's hat of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40, Hot Damage: +10
 6185	normal consummate hard-boiled egg	3	good	
 6186	thick normal consummate fried egg	5	good	
-6187	big bland consummate egg salad	5	decent	
-6188	thick spoiled narrow consummate bagel	5	crappy	
-6189	rotten bite-sized consummate sliced bread	1	crappy	
+6187	bland big consummate egg salad	5	decent	
+6188	spoiled thick narrow consummate bagel	5	crappy	
+6189	bite-sized rotten consummate sliced bread	1	crappy	
 6190	bland consummate hot dog bun	3	decent	
 6191	moldy consummate brownie	4	crappy	
 6192	bland consummate toast	3	decent	
 6193	mediocre passable stout	3	decent	
 6194	spoiled massive consummate soup	8	crappy	
 6195	flavorless consummate corn chips	3	decent	
-6196	stale tiny consummate salad	1	decent	
+6196	tiny stale consummate salad	1	decent	
 6197	bite-sized decent consummate salsa	1	good	
 6198	flavorless consummate sauerkraut	3	decent	
-6199	thick delicious consummate cheese slice	5	awesome	
-6200	bland enchanted consummate melted cheese	4	decent	Effect: "Grape Expectations", Effect Duration: 25
+6199	delicious thick consummate cheese slice	5	awesome	
+6200	enchanted bland consummate melted cheese	4	decent	Effect: "Grape Expectations", Effect Duration: 25
 6201	bland consummate bacon	4	decent	
 6202	stale consummate meatloaf	3	decent	
 6203	gigantic bland consummate steak	6	decent	
@@ -6107,36 +6107,36 @@
 6210	adequate consummate whipped cream	3	good	
 6211	rotten consummate cream	3	crappy	
 6212	bland consummate strawberries	3	decent	
-6213	spoiled gigantic consummate sorbet	8	crappy	
-6214	weak enchanted aged adequate rum	2	awesome	Effect: "Healthy Green Glow", Effect Duration: 30
-6215	perfectly mixed weak gray mediocre lager	2	EPIC	
+6213	gigantic spoiled consummate sorbet	8	crappy	
+6214	enchanted aged weak adequate rum	2	awesome	Effect: "Healthy Green Glow", Effect Duration: 30
+6215	weak perfectly mixed gray mediocre lager	2	EPIC	
 6216	normal immaculate grilled cheese	3	good	
 6217	normal immaculate ice cream sandwich	3	good	
-6218	small rotten enchanted immaculate hot dog	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 15
-6219	tasty big special immaculate egg salad sandwich	5	awesome	Effect: "Cookie Backup", Effect Duration: 30
+6218	enchanted rotten small immaculate hot dog	2	crappy	Effect: "Grumpy and Ornery", Effect Duration: 15
+6219	big special tasty immaculate egg salad sandwich	5	awesome	Effect: "Cookie Backup", Effect Duration: 30
 6220	toothsome perfect sandwich	4	awesome	
-6221	rotten enchanted spinning perfect chef salad	4	crappy	Effect: "Vitamin-Maxed", Effect Duration: 15
+6221	enchanted rotten spinning perfect chef salad	4	crappy	Effect: "Vitamin-Maxed", Effect Duration: 15
 6222	special flavorless blurry perfect breakfast	3	decent	Effect: "Colorful Gratitude", Effect Duration: 5
 6223	stale sublime deluxe hot dog	3	decent	
 6224	decent sublime stew	3	good	
 6225	delicious sublime nachos	3	awesome	
-6226	adequate small Ultimate Breakfast Sandwich	2	good	
-6227	miniature moldy Loaded Baked Potato	2	crappy	
+6226	small adequate Ultimate Breakfast Sandwich	2	good	
+6227	moldy miniature Loaded Baked Potato	2	crappy	
 6228	miniature yummy Omega Sundae	2	awesome	
 6229	lousy Das Sauerlager	3	decent	
-6230	perfectly mixed practically non-alcoholic Bologna Lambic	1	super ultra EPIC	
+6230	practically non-alcoholic perfectly mixed Bologna Lambic	1	super ultra EPIC	
 6231	lousy lime green Vodka Dog	3	decent	
 6232	drinkable pulsating Disappointed Russian	3	good	
-6233	drinkable triple-distilled Chunky Mary	7	good	
+6233	triple-distilled drinkable Chunky Mary	7	good	
 6234	smooth Nachojito	3	awesome	
 6235	spirit-forward bad Le Roi	5	decent	
-6236	drinkable watered-down Over Easy Rider	2	good	
+6236	watered-down drinkable Over Easy Rider	2	good	
 6237	jittery cosmic six-pack	0		
 6239	ionized enhanced lime green cube of ectoplasm	0		Effect: "Colorful Gratitude", Effect Duration: 38
 6240	enhanced electrified Illuminati earpiece	0		Effect: "Highland Sheen", Effect Duration: 69
 6241	unsweetened censored can label	0		Effect: "Ticking Clock", Effect Duration: 22
 6242	colloidal pressed ectoplasm <i>au jus</i>	0		Effect: "Brother Corsican's Blessing", Effect Duration: 19
-6243	quantum aerosolized blurry mirror the kindest cut	0		Effect: "Sugar, Hello", Effect Duration: 53
+6243	quantum aerosolized mirror blurry the kindest cut	0		Effect: "Sugar, Hello", Effect Duration: 53
 6244	quadruple-moist cat's paw	0		Effect: "Heart of Lavender", Effect Duration: 54
 6245	enhanced pulsating ASCII fu manchu	0		Effect: "Cookie Backup", Effect Duration: 29
 6246	irradiated deionized demonic surgical gloves	0		Effect: "Coated Arms", Effect Duration: 25
@@ -6144,7 +6144,7 @@
 6248	improved ionized quantum gamer slurry	0		Effect: "Comic Violence", Effect Duration: 63
 6249	upside-down dungeoneering kit	0		Last Available: "2013-02"
 6250	blurry horrifying Van der Graaf steel-toed numberwang of Tarzan of the businessman of the boozehound	0		Experience (Muscle): +3, Damage Reduction: 9, Spooky Damage: +25, Meat Drop: +50, Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-6251	dry upside-down skewed scroll of Protection from Bad Stuff	0		Effect: "Bolts about Candy", Effect Duration: 60, Last Available: "2013-02"
+6251	dry skewed upside-down scroll of Protection from Bad Stuff	0		Effect: "Bolts about Candy", Effect Duration: 60, Last Available: "2013-02"
 6252	tarnished scroll of Puddingskin	0		Effect: "Block-Rockin' Beet", Effect Duration: 64, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
@@ -6160,7 +6160,7 @@
 6264	upside-down frosty Staff of Fruit Salad of extreme caution of Flo-Jo	0		Monster Level: -25, Cold Spell Damage: +10, Initiative: +100, Jiggle: "Deal Some Prismatic Damage"
 6265	perfumed resourceful veiny Staff of the Cream of the Cream	0		Maximum HP: +10, Maximum MP: +50, Stench Resistance: +5, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	super-sized flavorless special grain of protein powder	5	decent	Effect: "Good Karma", Effect Duration: 15
+6267	flavorless super-sized special grain of protein powder	5	decent	Effect: "Good Karma", Effect Duration: 15
 6268	adjusted mirror pec oil	0		Effect: "Can't Smell Nothin'", Effect Duration: 29
 6269	green jittery educational gym membership card	0		Experience: +1
 6270	Vulcanized dry Squat-Thrust Magazine	0		Effect: "Greasy Flavor", Effect Duration: 33
@@ -6174,7 +6174,7 @@
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of the scaredy-cat	0		Monster Level: -15
 6280	skewed padded artisanal rice peeler	0		Damage Absorption: +20
-6281	snack-sized bland mirror heirloom grape tomato	2	decent	
+6281	bland snack-sized mirror heirloom grape tomato	2	decent	
 6282	chipotle wasabi cilantro aioli	0		
 6283	miser's brown felt tophat	0		Meat Drop: +10, Familiar Effect: "1xLep, cap 37"
 6284	wobbly gear	0		
@@ -6194,7 +6194,7 @@
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	altered Super Weight-Gain 9000	0		Effect: "Spooky Flavor", Effect Duration: 55
-6301	moist upside-down skewed possibility potion	0		Effect: "Al Dente Inferno", Effect Duration: 48
+6301	moist skewed upside-down possibility potion	0		Effect: "Al Dente Inferno", Effect Duration: 48
 6302	green eleven-foot pole	0		
 6303	mirror ring of Detect Boring Doors	0		
 6304	greasy electrified energetic deadly Jarlsberg's pan (Cosmic portal mode) of Flo-Jo	0		Weapon Damage: +5, Maximum MP Percent: +20, Sleaze Spell Damage: +10, Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6203,7 +6203,7 @@
 6307	modified blurry celestial olive oil	0		Effect: "You're Not Cooking", Effect Duration: 15, Last Available: "2013-03"
 6308	activated oxidized celestial carrot juice	0		Effect: "X-Ray Vision", Effect Duration: 48, Last Available: "2013-03"
 6309	liquefied bouncing celestial au jus	0		Effect: "Pyromania", Effect Duration: 66, Last Available: "2013-03"
-6310	galvanized galvanized wobbly shaking celestial squid ink	0		Effect: "Salad Days", Effect Duration: 18, Last Available: "2013-03"
+6310	galvanized galvanized shaking wobbly celestial squid ink	0		Effect: "Salad Days", Effect Duration: 18, Last Available: "2013-03"
 6311	lime green mirror steel-toed Uncle Buck	0		Damage Reduction: 9, Softcore Only
 6312	crate of fish meat	0		
 6313	damp wallet	0		
@@ -6255,8 +6255,8 @@
 6359	upside-down brawny Mer-kin begsign	0		Muscle Percent: +20, Meat Drop: +40
 6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	denatured pulled taffy	0		Effect: "Slippery Tongue", Effect Duration: 47, Last Available: "2013-04"
-6362	corrupted tumbling squat pulled indigo taffy	0		Effect: "Motion", Effect Duration: 50, Last Available: "2013-04"
-6363	magnetized flattened teal squat pulled taffy	0		Effect: "Extra-Thick Blood", Effect Duration: 25, Last Available: "2013-04"
+6362	corrupted squat tumbling pulled indigo taffy	0		Effect: "Motion", Effect Duration: 50, Last Available: "2013-04"
+6363	magnetized flattened squat teal pulled taffy	0		Effect: "Extra-Thick Blood", Effect Duration: 25, Last Available: "2013-04"
 6364	galvanized skewed pulled taffy	0		Effect: "Incensed", Effect Duration: 28, Last Available: "2013-04"
 6365	frozen ionized pulled taffy	0		Effect: "Memory of Speed", Effect Duration: 27, Last Available: "2013-04"
 6366	liquefied ionized frozen mirror pulled violet taffy	0		Effect: "Fury of the Bells", Effect Duration: 20, Last Available: "2013-04"
@@ -6308,7 +6308,7 @@
 6413	green spinning Order of the Green Thumb Order Form	0		Free Pull
 6414	teal clutch of dodecapede eggs	0		
 6415	spoiled flavorless gruel	3	crappy	
-6416	decent gigantic mana curds	10	good	
+6416	gigantic decent mana curds	10	good	
 6417	twist of lime	0		
 6418	blurry pencil stub	0		
 6419	nitrogenated pulsating moth dust	0		Effect: "Busy Bein' Delicious", Effect Duration: 54
@@ -6318,7 +6318,7 @@
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	bouncing Official Seal of Dreadsylvania	0		
-6426	diet moldy narrow Dreadsylvanian stew	1	crappy	
+6426	moldy diet narrow Dreadsylvanian stew	1	crappy	
 6427	drinkable Dreadsylvanian	3	good	
 6428	unsweetened tarnished galvanized Dreadsylvanian flask	0		Effect: "Hopped Up on Goofballs", Effect Duration: 50
 6429	adjusted Dreadsylvanian flask	0		Effect: "Boletus Swoletus", Effect Duration: 68
@@ -6360,7 +6360,7 @@
 6465	lion tamer's Van der Graaf hardy Mayor Ghost's gavel	0		Maximum HP: +50, Experience (familiar): +2, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Hammer Ghost"
 6466	Temple Grandin's sinister Mayor Ghost's sash of incineration	0		Spell Damage: +10, Familiar Weight: +7, Hot Spell Damage: +50, Single Equip
 6467	ghostly Mayor Ghost's scissors	0		
-6468	adequate upside-down twirling ghost pepper	4	good	
+6468	adequate twirling upside-down ghost pepper	4	good	
 6469	vibrating wicked experienced Thunkula's drinking cap	0		Experience: +2, Spell Damage: +5, Maximum MP Percent: +10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	skewed Jack Frost's wicked groovy Drunkula's cape	0		Moxie Percent: +10, Spell Damage: +5, Cold Spell Damage: +50, Class: "Sauceror"
 6471	skewed Usain Bolt's careful Socratic Drunkula's silky pants	0		Experience (Mysticality): +1, Monster Level: -10, Initiative: +80, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	rotten ghostly blinking Dreadsylvanian shepherd's pie	4	crappy	
+6488	rotten blinking ghostly Dreadsylvanian shepherd's pie	4	crappy	
 6489	upside-down music box parts	0		
 6490	tumbling unwound mechanical songbird	0		
 6491	bouncing tailfeathers	0		Familiar Weight: +5
@@ -6410,7 +6410,7 @@
 6515	padded eerie fetish	0		Damage Absorption: +20, Single Equip
 6516	distilled lousy stinkwater	5	decent	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	huge special toothsome pulsating red accidental mutton	10	awesome	Effect: "Twenty-three Squid, Ew", Effect Duration: 30
+6518	toothsome special huge red pulsating accidental mutton	10	awesome	Effect: "Twenty-three Squid, Ew", Effect Duration: 30
 6519	dangerous thinker's drafty drawers	0		Mysticality: +10, Weapon Damage: +10, Familiar Effect: "1.5xVolley"
 6520	aromatic medical-grade wolfskull mask	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, 1xBarrr"
 6521	cyan guts necklace of wisdom	0		Mysticality: +15, Single Equip
@@ -6458,12 +6458,12 @@
 6564	adequate Dreadsylvanian hot pocket	4	good	
 6565	immense decent Dreadsylvanian pocket	7	good	
 6566	bland Dreadsylvanian pocket	3	decent	
-6567	tasty thick Dreadsylvanian stink pocket	5	awesome	
+6567	thick tasty Dreadsylvanian stink pocket	5	awesome	
 6568	flavorless massive twirling huge Dreadsylvanian sleaze pocket	8	decent	
 6569	special aged Dreadsylvanian hot toddy	3	awesome	Effect: "Disco Nirvana", Effect Duration: 20
 6570	aged twirling Dreadsylvanian cold-fashioned	4	awesome	
 6571	high-proof hand-crafted wobbly Dreadsylvanian grimlet	9	EPIC	
-6572	aged practically non-alcoholic Dreadsylvanian dank and stormy	1	awesome	
+6572	practically non-alcoholic aged Dreadsylvanian dank and stormy	1	awesome	
 6573	special delicious Dreadsylvanian slithery nipple	3	awesome	Effect: "meat.enh", Effect Duration: 10
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	Annie Oakley's stylish gnawed-up dog bone	0		Moxie: +25, Critical Hit Percent: +20
 6589	Annie Oakley's Grey Guanon	0		Critical Hit Percent: +20
 6590	pulsating chaotic padded Engorged Sausages and You of the brazier	0		Damage Absorption: +20, Spell Critical Percent: +10, Hot Spell Damage: +25
-6591	practically non-alcoholic drinkable dream of a dog	1	good	
+6591	drinkable practically non-alcoholic dream of a dog	1	good	
 6592	skewed upside-down padded boxer's optimal spreadsheet of the glutton	0		Muscle Percent: +10, Damage Absorption: +20, Food Drop: +100
 6593	defective Game Grid token	0		
 6594	upside-down cyan hot Dreadsylvanian cocoa	0		
@@ -6506,8 +6506,8 @@
 6612	lime green jittery clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	perfectly mixed practically non-alcoholic Cold One	1	???	
-6616	decent snack-sized spaghetti breakfast	2	???	
+6615	practically non-alcoholic perfectly mixed Cold One	1	???	
+6616	snack-sized decent spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	blurry folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6538,7 +6538,7 @@
 6644	folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	wizardly slide rule of Leguizamo	0		Mysticality: +25, Monster Level: +20
-6649	Vulcanized diffused anodized tumbling ghostly Ogres and Oubliettes&trade; module	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 11
+6649	Vulcanized diffused anodized ghostly tumbling Ogres and Oubliettes&trade; module	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 11
 6650	Mountain Stream Code Black Alert	0		
 6651	upside-down twisted-up wet towel	0		
 6652	artisanal stepmom's booze	4	EPIC	
@@ -6569,7 +6569,7 @@
 6677	crude monster sculpture	0		
 6678	Yearbook Club Camera of the businessman	0		Meat Drop: +50, Conditional Skill (Equipped): "Blinding Flash"
 6679	strapping machete	0		Muscle: +5
-6680	bad irresponsibly strong blue Cursed Punch	8	decent	
+6680	irresponsibly strong bad blue Cursed Punch	8	decent	
 6681	perfectly mixed Bowl of Scorpions	3	EPIC	
 6682	aged Fog Murderer	3	awesome	
 6683	blurry book of matches	0		
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	fancy imitation White Russian	1	good	Effect: "Mayeaugh", Effect Duration: 5
 6704	wobbly ribald Da Vinci's short-handled mop	0		Experience (Mysticality): +5, Sleaze Damage: +10
-6705	adequate thick jungle floor wax	5	good	
+6705	thick adequate jungle floor wax	5	good	
 6706	jittery smirking shrunken head	0		
 6707	irradiated double-galvanized colorful toad	0		Effect: "Well-Oiled", Effect Duration: 47
 6708	crude voodoo doll	0		
@@ -6618,11 +6618,11 @@
 6726	pulsating dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	blurry ski resort souvenir crate	0		
-6729	upside-down gray UV-resistant compass	0		
+6729	gray upside-down UV-resistant compass	0		
 6730	funky junk key	0		
 6731	ghostly Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
-6733	fuchsia ghostly clothesline pole	0		
+6733	ghostly fuchsia clothesline pole	0		
 6734	shaking cigar sign	0		
 6735	shaking junk junk	0		
 6736	Junk-Bond	0		
@@ -6634,7 +6634,7 @@
 6742	blue junk band of the overflowing toilet	0		Stench Spell Damage: +50
 6743	junk trunks of the cougar	0		Moxie: +20, Familiar Effect: "cap 15"
 6744	arcane researcher's junk-mail shirt	0		Experience Percent (Mysticality): +10
-6745	low-calorie decent junk food	1	good	
+6745	decent low-calorie junk food	1	good	
 6746	hand-crafted practically non-alcoholic jittery junk yard	1	EPIC	
 6747	twirling cool weightlifter's swordzall	0		Muscle: +15, Moxie: +5
 6748	blurry beefcake's arm buzzer	0		Muscle: +25, Damage Reduction: 6
@@ -6648,17 +6648,17 @@
 6756	mirror artisanal homebrew sampler	0		
 6757	artisanal can of Br&uuml;talbr&auml;u	3	EPIC	Last Available: "2013-09"
 6758	mediocre can of Drooling Monk	4	decent	Last Available: "2013-09"
-6759	watered-down tolerable can of Impetuous Scofflaw	2	good	Last Available: "2013-09"
-6760	hand-crafted irresponsibly strong bottle of Old Pugilist	9	EPIC	Last Available: "2013-09"
-6761	irresponsibly strong drinkable bouncing bottle of Professor Beer	9	good	Last Available: "2013-09"
+6759	tolerable watered-down can of Impetuous Scofflaw	2	good	Last Available: "2013-09"
+6760	irresponsibly strong hand-crafted bottle of Old Pugilist	9	EPIC	Last Available: "2013-09"
+6761	drinkable irresponsibly strong bouncing bottle of Professor Beer	9	good	Last Available: "2013-09"
 6762	mediocre bottle of Rapier Witbier	4	decent	Last Available: "2013-09"
-6763	fortified perfectly mixed tumbling bottle of Race Car Red	5	EPIC	Last Available: "2013-09"
+6763	perfectly mixed fortified tumbling bottle of Race Car Red	5	EPIC	Last Available: "2013-09"
 6764	bad bottle of Greedy Dog	4	decent	Last Available: "2013-09"
 6765	aged enchanted twirling bottle of Lambada Lambic	3	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 15, Last Available: "2013-09"
 6766	green tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	mirror liquid bread	1	decent	Last Available: "2013-09"
-6769	supercharged Socratic tin tam of temperance	0		Experience (Mysticality): +1, Maximum MP Percent: +30, Sleaze Resistance: +5, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	supercharged Socratic tin tam of temperance	0		Experience (Mysticality): +1, Maximum MP Percent: +30, Sleaze Resistance: +5, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	aerosolized blinking tin cup	0		Effect: "Tearful, Fearful", Effect Duration: 57, Last Available: "2013-09"
 6771	greedy mansplainer's tin foil of horror	0		Monster Level: +15, Spooky Spell Damage: +25, Meat Drop: +20, Last Available: "2013-09"
 6772	friendly coward's tin drum of chilblains	0		Monster Level: -20, Familiar Weight: +3, Cold Damage: +25, Last Available: "2013-09"
@@ -6690,7 +6690,7 @@
 6801	anodized adjusted tumbling disco horoscope (Leo)	0		Effect: "Yet tea", Effect Duration: 56
 6802	anodized ionized irradiated disco horoscope (Virgo)	0		Effect: "Swordholder", Effect Duration: 16
 6803	diffused colloidal disco horoscope (Libra)	0		Effect: "Amplified Fabulousness", Effect Duration: 24
-6804	non-corrupted shaking skewed disco horoscope (Scorpio)	0		Effect: "Once Bitten Twice Fried", Effect Duration: 39
+6804	non-corrupted skewed shaking disco horoscope (Scorpio)	0		Effect: "Once Bitten Twice Fried", Effect Duration: 39
 6805	colloidal blue disco horoscope (Sagittarius)	0		Effect: "Fungal Fortification", Effect Duration: 67
 6806	polymerized blurry disco horoscope (Capricorn)	0		Effect: "Salsa Satanica", Effect Duration: 62
 6807	Newton's The Sagittarian's leisure pants of the empath	0		Experience (Mysticality): +3, Familiar Weight: +5, Familiar Effect: "atk, cap 18"
@@ -6724,7 +6724,7 @@
 6835	warmed Vulcanized bag of W&Ws	0		Effect: "Celestial Body", Effect Duration: 30
 6836	double-moist concentrated cyan PEEZ dispenser	0		Effect: "Browbeaten", Effect Duration: 20
 6837	improved energized Swizzler	0		Effect: "Barbecue Saucy", Effect Duration: 16
-6838	triple-concentrated squat bouncing Bugbearclaw Donut	0		Effect: "Hot Buttoned", Effect Duration: 44
+6838	triple-concentrated bouncing squat Bugbearclaw Donut	0		Effect: "Hot Buttoned", Effect Duration: 44
 6839	enhanced jam	0		Effect: "Black Lung", Effect Duration: 49
 6840	wet wet Whenchamacallit bar	0		Effect: "Hairy Palms", Effect Duration: 67
 6841	extra-liquefied frozen quadruple-improved 8-bit banana	0		Effect: "You're High as a Crow, Marty", Effect Duration: 63
@@ -6739,21 +6739,21 @@
 6850	mirror dangerous boxer's sturdy cane of doom	0		Muscle Percent: +10, Weapon Damage: +10, Spooky Spell Damage: +50
 6851	twirling huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
-6853	skewed twirling carton of rotten eggs	0		
+6853	twirling skewed carton of rotten eggs	0		
 6854	teal desert sightseeing pamphlet	0		
 6855	a suspicious address	0		
 6856	Tesla Bal-musette accordion	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	jittery jittery flame-retardant Cajun accordion	0		Hot Resistance: +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	spinning sharpshooter's quirky accordion	0		Critical Hit Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery mirror foul-smelling stylish Skipper's accordion	0		Moxie: +25, Stench Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	squat resourceful healthy savvy Pantsgiving of the overflowing toilet	0		Mysticality Percent: +20, Maximum HP Percent: +20, Maximum MP: +50, Stench Spell Damage: +50, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	squat resourceful healthy savvy Pantsgiving of the overflowing toilet	0		Mysticality Percent: +20, Maximum HP Percent: +20, Maximum MP: +50, Stench Spell Damage: +50, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	decent can of sardines	3	good	Last Available: "2013-11"
 6862	normal high-calorie sugar substitute	3	good	Last Available: "2013-11"
 6863	moldy pat of butter	4	crappy	Last Available: "2013-11"
 6864	toothsome dinner roll	3	awesome	Last Available: "2013-11"
 6865	flavorless blurry mashed potatoes	3	decent	Last Available: "2013-11"
 6866	decent enchanted whole turkey leg	3	good	Effect: "Barking Mad", Effect Duration: 40, Last Available: "2013-11"
-6867	bite-sized delicious deviled egg	1	awesome	Last Available: "2013-11"
+6867	delicious bite-sized deviled egg	1	awesome	Last Available: "2013-11"
 6868	nitrogenated modified tarnished finger exerciser	0		Effect: "Feline Ferocity", Effect Duration: 49, Last Available: "2013-11"
 6869	activated denatured magnetized huge dented spoon	0		Effect: "Banono", Effect Duration: 34, Last Available: "2013-11"
 6870	polarized love note	0		Effect: "Rad-ish", Effect Duration: 55, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	super-deionized red nuts	0		Effect: "Rootin' Around", Effect Duration: 34, Last Available: "2013-12"
 6904	tarnished double-altered narrow bolts	0		Effect: "Nature's Bounty", Effect Duration: 38, Last Available: "2013-12"
 6905	decent tiny gingerbread robot	1	good	Last Available: "2013-12"
-6906	big rotten blurry petit 4.1	5	crappy	Last Available: "2013-12"
+6906	rotten big blurry petit 4.1	5	crappy	Last Available: "2013-12"
 6907	flavorless nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
 6908	smelly plastic GORM-8	0		Stench Spell Damage: +10, Last Available: "2013-12"
 6909	wool plastic warbear	0		Cold Resistance: +1, Last Available: "2013-12"
@@ -6806,33 +6806,33 @@
 6917	warbear badge	0		Last Available: "2013-12"
 6918	dry aerosolized energized warbear wardance potion	0		Effect: "Powder Power", Effect Duration: 40, Last Available: "2013-12"
 6919	deionized magnetized warbear bearserker potion	0		Effect: "Serenity", Effect Duration: 39, Last Available: "2013-12"
-6920	nitrogenated pulsating olive warbear liquid overcoat	0		Effect: "Remaining Alive", Effect Duration: 52, Last Available: "2013-12"
+6920	nitrogenated olive pulsating warbear liquid overcoat	0		Effect: "Remaining Alive", Effect Duration: 52, Last Available: "2013-12"
 6921	rotten warbear feasting bread	4	crappy	Last Available: "2013-12"
 6922	decent big warbear warrior bread	5	good	Last Available: "2013-12"
-6923	normal small lime green warbear thermoregulator bread	2	good	Last Available: "2013-12"
+6923	small normal lime green warbear thermoregulator bread	2	good	Last Available: "2013-12"
 6924	artisanal warbear feasting mead	3	EPIC	Last Available: "2013-12"
-6925	irresponsibly strong mediocre warbear bearserker mead	8	decent	Last Available: "2013-12"
-6926	bad special warbear blizzard mead	4	decent	Effect: "Petit Forbearance", Effect Duration: 15, Last Available: "2013-12"
+6925	mediocre irresponsibly strong warbear bearserker mead	8	decent	Last Available: "2013-12"
+6926	special bad warbear blizzard mead	4	decent	Effect: "Petit Forbearance", Effect Duration: 15, Last Available: "2013-12"
 6927	blurry warbear helm fragment	0		Last Available: "2013-12"
-6928	ghostly hale baleful warbear plain fedora of the sewer	0		Spell Damage: +25, Maximum HP: +20, Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	flame-wreathed warbear feathered fedora	0		Hot Spell Damage: +10, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	Tesla wholesome warbear fedora of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	asbestos-lined dance instructor's warbear plain helm of incineration	0		Experience Percent (Moxie): +10, Hot Spell Damage: +50, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	mirror stanky warbear spiked helm	0		Stench Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	executive stylish warbear electro-spiked helm of Leguizamo	0		Moxie: +25, Monster Level: +20, Meat Drop: +40, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	Sinatra's Socratic warbear plain ushanka of the cheetah	0		Experience (Mysticality): +1, Experience (Moxie): +5, Initiative: +60, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	blue personal trainer's warbear lined ushanka	0		Experience Percent (Muscle): +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	fuchsia twirling frightening Annie Oakley's experienced warbear heated ushanka	0		Experience: +2, Critical Hit Percent: +20, Spooky Damage: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	ghostly hale baleful warbear plain fedora of the sewer	0		Spell Damage: +25, Maximum HP: +20, Stench Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	flame-wreathed warbear feathered fedora	0		Hot Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	Tesla wholesome warbear fedora of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	asbestos-lined dance instructor's warbear plain helm of incineration	0		Experience Percent (Moxie): +10, Hot Spell Damage: +50, Hot Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	mirror stanky warbear spiked helm	0		Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	executive stylish warbear electro-spiked helm of Leguizamo	0		Moxie: +25, Monster Level: +20, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	Sinatra's Socratic warbear plain ushanka of the cheetah	0		Experience (Mysticality): +1, Experience (Moxie): +5, Initiative: +60, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	blue personal trainer's warbear lined ushanka	0		Experience Percent (Muscle): +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	fuchsia twirling frightening Annie Oakley's experienced warbear heated ushanka	0		Experience: +2, Critical Hit Percent: +20, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	scandalous occult Herculean warbear party pants	0		Experience (Muscle): +1, Spell Damage Percent: +25, Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	stylish warbear ceremonial party pants	0		Moxie: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	shaking smartaleck's warbear high festival pants of Calamity Jane of extreme caution	0		Moxie Percent: +30, Critical Hit Percent: +15, Monster Level: -25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	auspicious Jim Carey's shellacked warbear battle greaves	0		Damage Reduction: 7, Monster Level: +25, Item Drop: +10, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	warbear officer greaves of the cheetah	0		Initiative: +60, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	censurious chaotic supercool warbear bearserker greaves	0		Moxie Percent: +20, Spell Critical Percent: +10, Sleaze Resistance: +3, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	gray blurry Oprah's occult grievous warbear johns	0		Weapon Damage Percent: +50, Spell Damage Percent: +25, Maximum MP Percent: +50, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	therapeutic warbear fleece-lined johns	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	bouncing zippy dance instructor's warbear johns of the sweet-tooth	0		Experience Percent (Moxie): +10, Candy Drop: +100, Initiative: +20, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	scandalous occult Herculean warbear party pants	0		Experience (Muscle): +1, Spell Damage Percent: +25, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	stylish warbear ceremonial party pants	0		Moxie: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	shaking smartaleck's warbear high festival pants of Calamity Jane of extreme caution	0		Moxie Percent: +30, Critical Hit Percent: +15, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	auspicious Jim Carey's shellacked warbear battle greaves	0		Damage Reduction: 7, Monster Level: +25, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	warbear officer greaves of the cheetah	0		Initiative: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	censurious chaotic supercool warbear bearserker greaves	0		Moxie Percent: +20, Spell Critical Percent: +10, Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	gray blurry Oprah's occult grievous warbear johns	0		Weapon Damage Percent: +50, Spell Damage Percent: +25, Maximum MP Percent: +50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	therapeutic warbear fleece-lined johns	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	bouncing zippy dance instructor's warbear johns of the sweet-tooth	0		Experience Percent (Moxie): +10, Candy Drop: +100, Initiative: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	spinning warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	wool brawny warbear goggles of the overflowing toilet	0		Muscle Percent: +20, Stench Spell Damage: +50, Cold Resistance: +1, Single Equip, Last Available: "2013-12"
 6949	aromatic warbear snowblindness goggles	0		Stench Resistance: +1, Single Equip, Last Available: "2013-12"
@@ -6845,10 +6845,10 @@
 6956	gravedigger's warbear warscarf of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Spooky Damage: +10, Single Equip, Last Available: "2013-12"
 6957	jittery warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	Jack Frost's warbear foil hat	0		Cold Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	Jack Frost's warbear foil hat	0		Cold Spell Damage: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	miser's Oprah's warbear oil pan	0		Maximum MP Percent: +50, Meat Drop: +10, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
-6962	shaking jittery warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
+6962	jittery shaking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	brawny warbear exhaust manifold	0		Muscle Percent: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	olive narrow warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	warbear auto-anvil	0		Last Available: "2013-12"
@@ -6858,7 +6858,7 @@
 6969	warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 6970	warbear drone assembler	0		Last Available: "2013-12"
 6971	purple warbear breakfast machine assembler	0		Last Available: "2013-12"
-6972	narrow wobbly blind-packed die-cast toy	0		Last Available: "2013-12"
+6972	wobbly narrow blind-packed die-cast toy	0		Last Available: "2013-12"
 6973	blinking die-cast Bashful the Reindeer of the businessman	0		Meat Drop: +50, Last Available: "2013-12"
 6974	wobbly purple occult die-cast Doc the Reindeer	0		Spell Damage Percent: +25, Last Available: "2013-12"
 6975	savvy die-cast Dopey the Reindeer	0		Mysticality Percent: +20, Last Available: "2013-12"
@@ -6893,11 +6893,11 @@
 7004	Vulcanized chilled Flaskfull of Hollow	0		Effect: "Sparkling Consciousness", Effect Duration: 34, Last Available: "2013-12"
 7005	red lump of Brituminous coal	0		Last Available: "2013-12"
 7006	twisted narrow handful of Smithereens	1	good	Effect: "The Power of Negative Thinking", Effect Duration: 15, Last Available: "2013-12"
-7007	moldy snack-sized narrow Every Day is Like This Sundae	2	crappy	Last Available: "2013-12"
+7007	snack-sized moldy narrow Every Day is Like This Sundae	2	crappy	Last Available: "2013-12"
 7008	small spoiled Miserable Pie	2	crappy	Last Available: "2013-12"
 7009	flavorless This Charming Flan	4	decent	Last Available: "2013-12"
-7010	smooth practically non-alcoholic fancy Irish Coffee, English Heart	1	awesome	Effect: "Afternoon Insight", Effect Duration: 35, Last Available: "2013-12"
-7011	mediocre extra-dry Strikes Again Bigmouth	5	decent	Last Available: "2013-12"
+7010	fancy practically non-alcoholic smooth Irish Coffee, English Heart	1	awesome	Effect: "Afternoon Insight", Effect Duration: 35, Last Available: "2013-12"
+7011	extra-dry mediocre Strikes Again Bigmouth	5	decent	Last Available: "2013-12"
 7012	aged Paint A Vulgar Pitcher	3	awesome	Last Available: "2013-12"
 7013	twirling Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	Jeselnik's dog trainer's wicked Sheila Take a Crossbow of the scaredy-cat	0		Spell Damage: +5, Monster Level: -15, Experience (familiar): +1, Sleaze Damage: +25, Last Available: "2013-12"
 7019	upside-down inspector's dance instructor's weightlifter's A Light that Never Goes Out of mayonnaise	0		Muscle: +15, Experience Percent (Moxie): +10, Sleaze Spell Damage: +50, Item Drop: +15, Last Available: "2013-12"
 7020	shaking mirror inspector's coward's studded experienced Half a Purse	0		Experience: +2, Damage Absorption: +80, Monster Level: -20, Item Drop: +15, Last Available: "2013-12"
-7021	blurry toasty rock-hard forbidden Hairpiece On Fire of the early riser	0		Spell Damage Percent: +50, Damage Reduction: 5, Hot Damage: +5, Adventures: +7, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	gravedigger's boxer's Vicar's Tutu of the dark arts of the cheetah	0		Muscle Percent: +10, Spell Damage Percent: +100, Spooky Damage: +10, Initiative: +60, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	blurry toasty rock-hard forbidden Hairpiece On Fire of the early riser	0		Spell Damage Percent: +50, Damage Reduction: 5, Hot Damage: +5, Adventures: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	gravedigger's boxer's Vicar's Tutu of the dark arts of the cheetah	0		Muscle Percent: +10, Spell Damage Percent: +100, Spooky Damage: +10, Initiative: +60, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	mirror boxer's smooth Hand in Glove of the early riser	0		Moxie: +15, Muscle Percent: +10, Adventures: +7, Single Equip, Last Available: "2013-12"
 7024	spinning Sherlock's Jim Carey's Meat Tenderizer is Murder of the cheetah	0		Monster Level: +25, Item Drop: +25, Initiative: +60, Class: "Seal Clubber", Last Available: "2013-12"
 7025	reassuring Ouija Board, Ouija Board of the bloodbag of the brazier	0		Maximum HP: +100, Hot Spell Damage: +25, Spooky Resistance: +1, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6919,7 +6919,7 @@
 7030	wobbly third-hand lantern of Leguizamo	0		Monster Level: +20
 7031	loose purse strings	0		
 7032	snack-sized spoiled pickled egg	2	crappy	
-7033	twirling shaking cup of lukewarm tea	1	awesome	
+7033	shaking twirling cup of lukewarm tea	1	awesome	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
 7036	bouncing warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6933,7 +6933,7 @@
 7044	vacuum-sealed aerosolized skewed glass slipper	0		Effect: "Cold Throat", Effect Duration: 28, Last Available: "2014-12"
 7045	mixed antimatter wad	1	EPIC	Last Available: "2013-12"
 7046	ionized energized jittery skewed warbear superpotion	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 57, Last Available: "2013-12"
-7047	ionized double-pressed bouncing lime green warbear liquid lasers	0		Effect: "Total Protonic Reversal", Effect Duration: 19, Last Available: "2013-12"
+7047	ionized double-pressed lime green bouncing warbear liquid lasers	0		Effect: "Total Protonic Reversal", Effect Duration: 19, Last Available: "2013-12"
 7048	energized twirling warbear rejuvenation potion	0		Effect: "Memory of Resilience", Effect Duration: 28, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	stale warbear gyro	3	decent	Last Available: "2013-12"
@@ -6957,19 +6957,19 @@
 7068	corrupted dry oxidized teal single of Donho's Bubbly Ballad	0		Effect: "Human-Machine Hybrid", Effect Duration: 32
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	pulsating narrow packet of winter seeds	0		Last Available: "2014-01"
-7071	diet adequate snow berries	1	good	Last Available: "2014-01"
+7071	adequate diet snow berries	1	good	Last Available: "2014-01"
 7072	adequate ice harvest	4	good	Last Available: "2014-01"
 7073	deionized frozen liquefied tumbling frost flower	0		Effect: "Medieval Mage Mayhem", Effect Duration: 14, Last Available: "2014-01"
 7074	galvanized oxidized yellow snow cleats	0		Effect: "Dirge of Dreadfulness", Effect Duration: 46, Last Available: "2014-01"
 7075	ionized liquid ice pack	0		Effect: "Human-Horror Hybrid", Effect Duration: 50, Last Available: "2014-01"
 7076	spinning mirror mirror snow boards	0		Last Available: "2014-01"
-7077	adequate snack-sized blinking snow crab	2	good	Last Available: "2014-01"
+7077	snack-sized adequate blinking snow crab	2	good	Last Available: "2014-01"
 7078	smooth Ice Island Long Tea	4	awesome	Last Available: "2014-01"
 7079	lime green unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ghostly ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	mirror snow machine	0		Last Available: "2014-01"
-7083	bouncing snow mobile of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	bouncing snow mobile of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	studded ice bucket	0		Damage Absorption: +80, Lasts Until Rollover, Last Available: "2014-01"
 7085	Usain Bolt's frosty snow shovel	0		Cold Spell Damage: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2014-01"
 7086	bouncing resourceful cool brainy bod-ice	0		Mysticality: +5, Moxie: +5, Maximum MP: +50, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,18 +6978,18 @@
 7089	jittery snow fort	0		Last Available: "2014-01"
 7090	bad practically non-alcoholic narrow En Una Fila Tequila	1	decent	
 7091	Skully's hot chocolate	1	EPIC	
-7092	miser's groovy warbear dress helmet	0		Moxie Percent: +10, Meat Drop: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	miser's groovy warbear dress helmet	0		Moxie Percent: +10, Meat Drop: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	fortified forbidden warbear dress bracers	0		Spell Damage Percent: +50, Damage Absorption: +60, Single Equip, Last Available: "2013-12"
-7094	horrifying chilly warbear dress greaves	0		Cold Damage: +5, Spooky Damage: +25, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	smartaleck's sweatband of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	narrow occult sage gym shorts	0		Mysticality Percent: +10, Spell Damage Percent: +25, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	horrifying chilly warbear dress greaves	0		Cold Damage: +5, Spooky Damage: +25, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	smartaleck's sweatband of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	narrow occult sage gym shorts	0		Mysticality Percent: +10, Spell Damage Percent: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	lightning-fast supercharged ankleweights	0		Maximum MP Percent: +30, Initiative: +40, Single Equip, Last Available: "2014-12"
 7098	squat inspector's scorching wicked brainy sweat socks	0		Mysticality: +5, Spell Damage: +5, Hot Damage: +25, Item Drop: +15, Last Available: "2014-12"
 7099	wobbly pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	vaporized tumbling jittery Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	narrow pixie axie	0		Last Available: "2014-12"
-7103	ionized lime green upside-down powder	0		Effect: "Rad-ish", Effect Duration: 53, Last Available: "2014-12"
+7103	ionized upside-down lime green powder	0		Effect: "Rad-ish", Effect Duration: 53, Last Available: "2014-12"
 7104	jittery rock-hard licorice whip	0		Damage Reduction: 5, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	smooth bouncing snakebite	3	awesome	Last Available: "2014-12"
@@ -6998,25 +6998,25 @@
 7109	bland mirror pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	fancy decent mirror candy mountain oyster	3	good	Effect: "Mo' Hobo", Effect Duration: 10, Last Available: "2014-12"
-7112	artisanal fortified chocotini	5	EPIC	Last Available: "2014-12"
+7112	fortified artisanal chocotini	5	EPIC	Last Available: "2014-12"
 7113	lard-coated hardened chocolate rabbit's foot of the storm	0		Damage Reduction: 3, Maximum MP Percent: +40, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7114	immense stale candy carrot	8	decent	Last Available: "2014-12"
+7114	stale immense candy carrot	8	decent	Last Available: "2014-12"
 7115	rotten candy carrot cake	3	crappy	Last Available: "2014-12"
 7116	up-at-dawn carrot-on-a-stick of the overflowing toilet	0		Stench Spell Damage: +50, Adventures: +5, Last Available: "2014-12"
-7117	blurry pulsating greedy lion tamer's weasel stomping pants	0		Experience (familiar): +2, Meat Drop: +20, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	blurry pulsating greedy lion tamer's weasel stomping pants	0		Experience (familiar): +2, Meat Drop: +20, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	yummy upside-down mulberry	3	awesome	Last Available: "2014-12"
-7119	irresponsibly strong acceptable mulled berry wine	6	good	Last Available: "2014-12"
+7119	acceptable irresponsibly strong mulled berry wine	6	good	Last Available: "2014-12"
 7120	skewed lemony scales	0		Last Available: "2014-12"
-7121	chilly lemon party hat	0		Cold Damage: +5, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	chilly lemon party hat	0		Cold Damage: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	savvy lemon shirt	0		Mysticality Percent: +20, Lasts Until Rollover, Last Available: "2014-12"
-7123	Oprah's lemon drop trousers	0		Maximum MP Percent: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	Oprah's lemon drop trousers	0		Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	magnetized modified lemonhead caviar	0		Effect: "Alchemical, Brother", Effect Duration: 14, Last Available: "2014-12"
 7125	yellow educational gummi sword of temperance	0		Experience: +1, Sleaze Resistance: +5, Last Available: "2014-12"
 7126	alkaline nitrogenated improved small gummi fin	0		Effect: "Healthy Blue Glow", Effect Duration: 47, Last Available: "2014-12"
 7127	chocolate cow bone of the businessman	0		Meat Drop: +50, Last Available: "2014-12"
 7128	irradiated improved gummi fang	0		Effect: "It's Electric!", Effect Duration: 41, Last Available: "2014-12"
 7129	moldy shaking leftover canap&eacute;s	4	crappy	Last Available: "2014-12"
-7130	high-proof hand-crafted enchanted wobbly magnum of champagne	8	EPIC	Effect: "Biologically Shocked", Effect Duration: 30, Last Available: "2014-12"
+7130	enchanted high-proof hand-crafted wobbly magnum of champagne	8	EPIC	Effect: "Biologically Shocked", Effect Duration: 30, Last Available: "2014-12"
 7131	lime green executive Jim Carey's cow creamer of the storm	0		Maximum MP Percent: +40, Monster Level: +25, Meat Drop: +40, Last Available: "2014-12"
 7132	pressed blinking Outer Wolf&trade; cologne	0		Effect: "Bread Burps", Effect Duration: 38, Last Available: "2014-12"
 7133	tumbling purple lupine appetite hormones	0		Last Available: "2014-12"
@@ -7024,11 +7024,11 @@
 7135	bland super-sized blinking witch's bread	5	decent	Last Available: "2014-12"
 7136	oxidized twirling witch's brew	0		Effect: "Healthy Green Glow", Effect Duration: 33, Last Available: "2014-12"
 7137	huge Lo Pan's wholesome smooth witch's bra	0		Moxie: +15, Maximum HP Percent: +10, Spell Critical Percent: +30, Last Available: "2014-12"
-7138	practically non-alcoholic lousy mid-level medieval mead	1	decent	Last Available: "2014-12"
+7138	lousy practically non-alcoholic mid-level medieval mead	1	decent	Last Available: "2014-12"
 7139	frozen deionized blurry R&uuml;mpelstiltz	0		Effect: "Human-Undead Hybrid", Effect Duration: 51, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	quantum hi-octane carrot juice	0		Effect: "The Magic of LOV", Effect Duration: 66, Last Available: "2014-12"
-7142	dry blue spinning twirling hare brush	0		Effect: "Space Tripping", Effect Duration: 46, Last Available: "2014-12"
+7142	dry twirling blue spinning hare brush	0		Effect: "Space Tripping", Effect Duration: 46, Last Available: "2014-12"
 7143	wobbly cool hare pin of the brute	0		Moxie: +5, Muscle Percent: +30, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
 7145	rotten cinnamon cannoli	3	crappy	Last Available: "2014-12"
@@ -7043,9 +7043,9 @@
 7154	teal filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	tumbling hale fire hose of the brute of courage	0		Muscle Percent: +30, Maximum HP: +20, Spooky Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	flavorless tiny spinning lime green fireman's lunch	1	decent	Last Available: "2014-12"
-7159	twirling resourceful plain paper hat of the sewer of the sweet-tooth	0		Maximum MP: +50, Stench Damage: +25, Candy Drop: +100, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7157	tumbling hale fire hose of the brute of courage	0		Muscle Percent: +30, Maximum HP: +20, Spooky Resistance: +3, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7158	tiny flavorless spinning lime green fireman's lunch	1	decent	Last Available: "2014-12"
+7159	twirling resourceful plain paper hat of the sewer of the sweet-tooth	0		Maximum MP: +50, Stench Damage: +25, Candy Drop: +100, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	moldy blurry ice cream sandwich	3	crappy	Last Available: "2014-12"
 7161	censurious MacGyver's sinister &quot;honey&quot; dipper	0		Spell Damage: +10, Maximum MP: +100, Sleaze Resistance: +3, Last Available: "2014-12"
 7162	moldy plumber's lunch	4	crappy	Last Available: "2014-12"
@@ -7055,7 +7055,7 @@
 7166	diet normal can of Adultwitch&trade;	1	good	Last Available: "2014-12"
 7167	concentrated nitrogenated unsweetened smudge stick	0		Effect: "Cinnamouth", Effect Duration: 38, Last Available: "2014-12"
 7168	liquefied wall	0		Effect: "Spooky Demeanor", Effect Duration: 68, Last Available: "2014-12"
-7169	perfectly mixed boozy tankard of ale	5	EPIC	Last Available: "2014-12"
+7169	boozy perfectly mixed tankard of ale	5	EPIC	Last Available: "2014-12"
 7170	adjusted upside-down scroll case	0		Effect: "The Moxious Madrigal", Effect Duration: 60, Last Available: "2014-12"
 7171	colloidal ghostly jug of &quot;wine&quot;	0		Effect: "Hustlin'", Effect Duration: 44, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7088,11 +7088,11 @@
 7199	blowdart	0		
 7200	red executive Buddy Bjorn	0		Meat Drop: +40, Softcore Only, Last Available: "2014-02"
 7201	cyan double-paned energetic veiny The Nuge's favorite crossbow	0		Maximum HP: +10, Maximum MP Percent: +20, Cold Resistance: +5
-7202	rotten half-sized sweet roll Alabama	2	crappy	
+7202	half-sized rotten sweet roll Alabama	2	crappy	
 7203	narrow ghostly sizzling Saturday Night Special	0		Hot Damage: +10
 7204	lynyrd snare	0		
 7205	lime green wholesome fleetwood chain	0		Maximum HP Percent: +10
-7206	practically non-alcoholic artisanal squat Green Manalishi	1	super EPIC	
+7206	artisanal practically non-alcoholic squat Green Manalishi	1	super EPIC	
 7207	Da Vinci's blade	0		Experience (Mysticality): +5
 7208	fire of unknown origin	0		
 7209	pulsating eagle's milk	1	decent	
@@ -7101,7 +7101,7 @@
 7212	wicked Jefferson wings	0		Spell Damage: +5
 7213	mirror fleetwood macaroni	0		
 7214	twirling cheesy eagle sauce	0		
-7215	tiny spoiled fleetwood mac 'n' cheese	1	crappy	
+7215	spoiled tiny fleetwood mac 'n' cheese	1	crappy	
 7216	lynyrd skin	0		
 7217	thinker's lynyrdskin cap	0		Mysticality: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	supercharged lynyrdskin tunic	0		Maximum MP Percent: +30
@@ -7117,7 +7117,7 @@
 7228	tumbling box	0		
 7229	lousy special weak spinning wine	2	decent	Effect: "Kernel Panic!", Effect Duration: 35
 7230	artisanal rum	3	EPIC	
-7231	artisanal practically non-alcoholic Murderer's Punch	1	super ultra EPIC	
+7231	practically non-alcoholic artisanal Murderer's Punch	1	super ultra EPIC	
 7232	yummy velvet cake	3	awesome	
 7233	quadruple-energized dry yellow letter	0		Effect: "Sepia Tan", Effect Duration: 12
 7234	squat fireproof thinker's book	0		Mysticality: +10, Hot Resistance: +3
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	skewed really cocktail shaker	0		Familiar Weight: +5
-7255	special artisanal mini-martini	3	EPIC	Effect: "Cock of the Walk", Effect Duration: 10
+7255	artisanal special mini-martini	3	EPIC	Effect: "Cock of the Walk", Effect Duration: 10
 7256	smoke grenade	0		
 7257	boiled molotov soda	1	good	
 7258	concentrated pile of ashes	0		Effect: "Ichorous Eyesight", Effect Duration: 54
@@ -7196,7 +7196,7 @@
 7307	Lady Spookyraven's dancing shoes	0		
 7308	alkaline boiled modified spinning eyebrow pencil	0		Effect: "damage.enh", Effect Duration: 29
 7309	double-unsweetened blinking rosewater cream	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 16
-7310	activated aerosolized jittery narrow bronzer	0		Effect: "Vinegavotte", Effect Duration: 19
+7310	activated aerosolized narrow jittery bronzer	0		Effect: "Vinegavotte", Effect Duration: 19
 7311	skewed MacGyver's grievous elegant nightstick	0		Weapon Damage Percent: +50, Maximum MP: +100
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	maroon box of hickory chips	0		Familiar Weight: +5
@@ -7214,10 +7214,10 @@
 7325	fancy perfectly mixed spirit-forward jittery snakebite	5	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 15
 7326	spinning Sherlock's educational rubber ribcage	0		Experience: +1, Item Drop: +25, Damage Reduction: 7
 7327	denatured narrow synthetic marrow	1		
-7328	boiled ionized mirror cyan funny bone	0		Effect: "Radium Radicality", Effect Duration: 45
+7328	boiled ionized cyan mirror funny bone	0		Effect: "Radium Radicality", Effect Duration: 45
 7329	shaking sinister half-melted spoon of the cougar	0		Moxie: +20, Spell Damage: +10
-7330	denatured ghostly lime green the funk	1		
-7331	gigantic adequate wobbly gunky chicken	10	good	
+7330	denatured lime green ghostly the funk	1		
+7331	adequate gigantic wobbly gunky chicken	10	good	
 7332	vibrating doll head	0		Maximum MP Percent: +10
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7228,8 +7228,8 @@
 7339	music box mechanism	0		
 7340	tumbling chaotic moose antlers	0		Spell Critical Percent: +10, Familiar Effect: "atk, 1xLep, cap 27"
 7341	extra-dry moose thought	0		Effect: "Human-Elf Hybrid", Effect Duration: 32
-7342	immense rotten enchanted moose chocolate	6	crappy	Effect: "Buttermilk Boogie", Effect Duration: 5
-7343	watered-down bad painting of a glass of wine	2	decent	
+7342	enchanted rotten immense moose chocolate	6	crappy	Effect: "Buttermilk Boogie", Effect Duration: 5
+7343	bad watered-down painting of a glass of wine	2	decent	
 7344	oil painting of yourself	0		
 7345	jittery ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7254,7 +7254,7 @@
 7365	anodized cold-filtered huge fabric hardener	0		Effect: "OMG WTF", Effect Duration: 28
 7366	aged watered-down bottle of laundry sherry	2	awesome	
 7367	extra-vacuum-sealed quadruple-oxidized industrial strength starch	0		Effect: "Eye of the Seal", Effect Duration: 25, Wiki Name: "industrial strength starch"
-7368	huge normal extra-flat panini	7	good	
+7368	normal huge extra-flat panini	7	good	
 7369	denatured boiled Vulcanized wobbly mangled finger	0		Effect: "Mana Tea", Effect Duration: 23
 7370	bad enchanted Psychotic Train wine	3	decent	Effect: "Can't Smell Nothin'", Effect Duration: 10
 7371	blinking crazy hobo notebook	0		
@@ -7299,20 +7299,20 @@
 7410	Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
-7413	green tumbling Steam Card: Meteoid (#2)	0		
+7413	tumbling green Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
-7415	bouncing ghostly Steam Card: DemonStar (#1)	0		
+7415	ghostly bouncing Steam Card: DemonStar (#1)	0		
 7416	Steam Card: DemonStar (#2)	0		
 7417	narrow Steam Card: DemonStar (#3)	0		
 7418	Steam Card: Jackass Plumber (#1)	0		
-7419	wobbly yellow Steam Card: Jackass Plumber (#2)	0		
+7419	yellow wobbly Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	skewed pencil thin mushroom	0		Last Available: "2014-05"
 7422	skewed Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	yellow salty sailor salt	0		Last Available: "2014-05"
 7424	huge bike rental broupon	0		Last Available: "2014-05"
 7425	skewed Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
-7426	purple jittery sprinkle shaker	0		Last Available: "2014-05"
+7426	jittery purple sprinkle shaker	0		Last Available: "2014-05"
 7427	frozen lime green sleight-of-hand mushroom	0		Effect: "Dancing Prowess", Effect Duration: 63, Last Available: "2014-05"
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	blinking Beach Buck	0		Last Available: "2014-05"
@@ -7333,14 +7333,14 @@
 7444	perfectly mixed practically non-alcoholic overpowering mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7445	lousy skewed complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	artisanal smooth mushroom wine	3	super EPIC	Last Available: "2014-05"
-7447	weak drinkable blood-red mushroom wine	2	good	Last Available: "2014-05"
-7448	drinkable watered-down fancy buzzing mushroom wine	2	good	Effect: "Spirit of Alph", Effect Duration: 15, Last Available: "2014-05"
-7449	practically non-alcoholic smooth lime green shaking swirling mushroom wine	1	awesome	Last Available: "2014-05"
+7447	drinkable weak blood-red mushroom wine	2	good	Last Available: "2014-05"
+7448	watered-down drinkable fancy buzzing mushroom wine	2	good	Effect: "Spirit of Alph", Effect Duration: 15, Last Available: "2014-05"
+7449	smooth practically non-alcoholic shaking lime green swirling mushroom wine	1	awesome	Last Available: "2014-05"
 7450	half-sized spoiled Taco Dan's Basic Taco Dan Taco	2	crappy	Last Available: "2014-05"
-7451	diet spoiled Taco Dan's Taco Fish Fish Taco	1	crappy	Last Available: "2014-05"
+7451	spoiled diet Taco Dan's Taco Fish Fish Taco	1	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	lousy triple-distilled regular-size brogurt	10	decent	Last Available: "2014-05"
-7454	delicious practically non-alcoholic skewed lime green super-size brogurt	1	awesome	Last Available: "2014-05"
+7453	triple-distilled lousy regular-size brogurt	10	decent	Last Available: "2014-05"
+7454	practically non-alcoholic delicious lime green skewed super-size brogurt	1	awesome	Last Available: "2014-05"
 7455	watered-down bad broberry brogurt	2	decent	Last Available: "2014-05"
 7456	lousy brocolate brogurt	4	decent	Last Available: "2014-05"
 7457	drinkable squat French bronilla brogurt	3	good	Last Available: "2014-05"
@@ -7348,13 +7348,13 @@
 7459	yellow Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	jittery Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	spinning rosy-cheeked Brogre brorts	0		Maximum HP Percent: +30, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	spinning rosy-cheeked Brogre brorts	0		Maximum HP Percent: +30, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	arcane researcher's Brogre brolo shirt	0		Experience Percent (Mysticality): +10, Last Available: "2014-05"
-7464	bouncing Brogre bucket hat of the wise owl	0		Mysticality: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	bouncing Brogre bucket hat of the wise owl	0		Mysticality: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	maroon airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	Sherlock's energetic 8-billed baseball cap of the boozehound	0		Maximum MP Percent: +20, Item Drop: +25, Booze Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	Sherlock's energetic 8-billed baseball cap of the boozehound	0		Maximum MP Percent: +20, Item Drop: +25, Booze Drop: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	perfumed wholesome Newton's extremely wet T-shirt	0		Experience (Mysticality): +3, Maximum HP Percent: +10, Stench Resistance: +5, Last Available: "2014-05"
 7470	cyan greedy supercharged veiny shrimp fork	0		Maximum HP: +10, Maximum MP Percent: +30, Meat Drop: +20, Last Available: "2014-05"
 7471	nitrogenated deionized BROS Energy Drink	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 65, Last Available: "2014-05"
@@ -7362,22 +7362,22 @@
 7473	double-wet upside-down shrimp cocktail	0		Effect: "Stench Jellied", Effect Duration: 55, Last Available: "2014-05"
 7474	galvanized colloidal Yolo&trade; chocolates	0		Effect: "Super-Mega-Charged", Effect Duration: 55, Last Available: "2020-09"
 7475	string of moist beads of bravery	0		Spooky Resistance: +5, Last Available: "2014-05"
-7476	skewed maroon Ultimate Mind Destroyer	0		Last Available: "2014-05"
+7476	maroon skewed Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	oxidized polarized ghostly Meat-inflating powder	0		Effect: "On the Shoulders of Giants", Effect Duration: 19, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	super-Vulcanized concentrated sugar fairy	0		Effect: "Sleazy Hands", Effect Duration: 61, Last Available: "2014-05"
 7480	non-galvanized maroon pulsating sugar bunny	0		Effect: "Leo Rising", Effect Duration: 23, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	mediocre ghostly skewed Rompedores de Fantasmas	3	decent	
-7483	distilled perfectly mixed huge La Fantasma y La Oscuridad	5	EPIC	
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	mediocre skewed ghostly Rompedores de Fantasmas	3	decent	
+7483	perfectly mixed distilled huge La Fantasma y La Oscuridad	5	EPIC	
 7484	tolerable skewed Fantasma en la M&aacute;quina	3	good	
 7485	loosening powder	0		
-7486	olive tumbling castoreum	0		
+7486	tumbling olive castoreum	0		
 7487	drain dissolver	0		
 7488	huge triple-distilled turpentine	0		
 7489	wobbly detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	lousy blue twirling twirling bottle of Chateau de Vinegar	4	decent	
+7491	lousy twirling twirling blue bottle of Chateau de Vinegar	4	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	ghostly wine bomb	0		
@@ -7406,17 +7406,17 @@
 7517	spinning prompt supercharged spider leg	0		Maximum MP Percent: +30, Adventures: +3
 7518	wand of pigification	0		
 7519	tolerable glass of bourbon	3	good	
-7520	mirror ghostly burned government manual fragment	0		Last Available: "2014-05"
-7521	spoiled low-calorie government cheese	1	crappy	Last Available: "2014-05"
+7520	ghostly mirror burned government manual fragment	0		Last Available: "2014-05"
+7521	low-calorie spoiled government cheese	1	crappy	Last Available: "2014-05"
 7522	red pair of government shades of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2014-05"
-7523	huge fuchsia spinning space junk	0		Last Available: "2014-05"
+7523	fuchsia huge spinning space junk	0		Last Available: "2014-05"
 7524	unsweetened ionized government	0		Effect: "Shredding, Sweating", Effect Duration: 29, Last Available: "2014-05"
 7525	wet bouncing alien drugs	0		Effect: "Strong Spirit", Effect Duration: 53, Last Available: "2023-09"
 7526	pulsating weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	executive wicked government-issued night-vision goggles	0		Spell Damage: +5, Meat Drop: +40, Single Equip, Last Available: "2014-05"
 7529	bland loaf of alien bread	3	decent	Last Available: "2014-05"
-7530	adequate super-sized lime green grilled cheese sandwich	5	good	Last Available: "2014-05"
+7530	super-sized adequate lime green grilled cheese sandwich	5	good	Last Available: "2014-05"
 7531	distilled upside-down alien protein powder	1	decent	Last Available: "2014-05"
 7532	smooth bouncing rocket fuel	4	awesome	Last Available: "2014-05"
 7533	spinning alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
@@ -7425,8 +7425,8 @@
 7536	pulsating olive space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	ribald space beast fur hat	0		Sleaze Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	red stanky space beast fur pants	0		Stench Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	ribald space beast fur hat	0		Sleaze Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	red stanky space beast fur pants	0		Stench Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	wicked space beast fur whip	0		Spell Damage: +5, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	hale occult space heater	0		Spell Damage Percent: +25, Maximum HP: +20, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
@@ -7442,7 +7442,7 @@
 7553	shaker of dry rub	0		Last Available: "2014-06"
 7554	polymerized cold-filtered bouncing bottle of lighter fluid	0		Effect: "Buff as a Baobab", Effect Duration: 48, Last Available: "2014-06"
 7555	shaking page	0		
-7556	skewed squat elephant gift	0		
+7556	squat skewed elephant gift	0		
 7557	triple-unsweetened pickled blood cells	0		Effect: "The Real Deal", Effect Duration: 44
 7558	irresponsibly strong lousy blinking wine	9	decent	
 7559	oxidized colloidal gummi turtle	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 62
@@ -7451,14 +7451,14 @@
 7562	improved magnetized anodized musk turtle	0		Effect: "Vital", Effect Duration: 26
 7563	oxidized blinking programmable turtle	0		Effect: "Yet tea", Effect Duration: 26
 7564	non-modified oxidized blurry mocking turtle	0		Effect: "Here to Kick Ass", Effect Duration: 53
-7565	small adequate jittery teal ham steak	2	good	
+7565	adequate small teal jittery ham steak	2	good	
 7566	tumbling dangerous time-twitching toolbelt	0		Weapon Damage: +10, Single Equip, Free Pull
-7567	blue bouncing Chroner	0		
+7567	bouncing blue Chroner	0		
 7568	steel-toed educational boxer's Time Lord Badge of Honor	0		Muscle Percent: +10, Experience: +1, Damage Reduction: 9
 7569	bouncing ghostly aromatic Annie Oakley's Time Bandit Badge of Courage of the cheetah	0		Critical Hit Percent: +20, Stench Resistance: +1, Initiative: +60
 7570	modified energized activated Friendliness Beverage	0		Effect: "In the Limelight", Effect Duration: 64
 7571	lightning-fast brainy silent pea shooter	0		Mysticality: +5, Initiative: +40
-7572	special adequate D roll	3	good	Effect: "This Is Where You're a Viking", Effect Duration: 40
+7572	adequate special D roll	3	good	Effect: "This Is Where You're a Viking", Effect Duration: 40
 7573	blinking nasty dangerous kiwi beak	0		Weapon Damage: +10, Stench Damage: +5
 7574	hand-crafted spirit-forward New Zealand iced tea	5	EPIC	
 7575	padded grievous droll monocle	0		Weapon Damage Percent: +50, Damage Absorption: +20, Single Equip
@@ -7468,28 +7468,28 @@
 7579	lime green twitching time capsule	0		
 7580	mixed cyan liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	snack-sized stale rack of dinosaur ribs	2	decent	
+7582	stale snack-sized rack of dinosaur ribs	2	decent	
 7583	artisanal blurry scotch on the rocks	3	EPIC	
 7584	upside-down green yabba dabba doo rag of the dark arts of chilblains	0		Spell Damage Percent: +100, Cold Damage: +25, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	supercool beefcake's wooly loincloth	0		Muscle: +25, Moxie Percent: +20, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	drinkable irresponsibly strong glass of &quot;milk&quot;	7	good	Last Available: "2014-07"
-7590	enchanted tolerable pulsating spinning cup of &quot;tea&quot;	3	good	Effect: "Filled with Magic", Effect Duration: 45, Last Available: "2014-07"
-7591	tolerable high-proof fuchsia ghostly thermos of &quot;whiskey&quot;	7	good	Last Available: "2014-07"
-7592	perfectly mixed weak Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
+7589	irresponsibly strong drinkable glass of &quot;milk&quot;	7	good	Last Available: "2014-07"
+7590	enchanted tolerable spinning pulsating cup of &quot;tea&quot;	3	good	Effect: "Filled with Magic", Effect Duration: 45, Last Available: "2014-07"
+7591	high-proof tolerable fuchsia ghostly thermos of &quot;whiskey&quot;	7	good	Last Available: "2014-07"
+7592	weak perfectly mixed Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	boozy tolerable Bee's Knees	5	good	Last Available: "2014-07"
-7594	weak artisanal Sockdollager	2	EPIC	Last Available: "2014-07"
-7595	fancy aged Ish Kabibble	3	awesome	Effect: "Spring Training", Effect Duration: 5, Last Available: "2014-07"
+7594	artisanal weak Sockdollager	2	EPIC	Last Available: "2014-07"
+7595	aged fancy Ish Kabibble	3	awesome	Effect: "Spring Training", Effect Duration: 5, Last Available: "2014-07"
 7596	weak acceptable Hot Socks	2	good	Last Available: "2014-07"
 7597	aged Phonus Balonus	4	awesome	Last Available: "2014-07"
 7598	aged Flivver	3	awesome	Last Available: "2014-07"
-7599	watered-down special mediocre gray Sloppy Jalopy	2	decent	Effect: "Sugar High", Effect Duration: 30, Last Available: "2014-07"
+7599	special mediocre watered-down gray Sloppy Jalopy	2	decent	Effect: "Sugar High", Effect Duration: 30, Last Available: "2014-07"
 7600	unsweetened liquefied flame	0		Effect: "Hustlin'", Effect Duration: 12
 7601	magnetized temporary yak tattoo	0		Effect: "Mariachi Mood", Effect Duration: 21
 7602	denatured moist Fitspiration&trade; poster	0		Effect: "Sparkling Consciousness", Effect Duration: 31
-7603	improved teal huge neckbeard	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 66
+7603	improved huge teal neckbeard	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 66
 7604	magnetized jittery artisanal hand-squeezed wheatgrass juice	0		Effect: "Pla-see-bo", Effect Duration: 38
 7605	polymerized deionized punk patch	0		Effect: "Well-Lubed", Effect Duration: 59
 7606	super-liquefied steampunk potion	0		Effect: "Salsa Satanica", Effect Duration: 36
@@ -7531,7 +7531,7 @@
 7642	pulsating lime green ingot turtle	0		
 7643	huge duty umbrella	0		
 7644	wobbly pool skimmer	0		
-7645	wobbly tumbling life preserver	0		
+7645	tumbling wobbly life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
@@ -7539,7 +7539,7 @@
 7650	nitrogenated pickled blurry catfish whiskers	0		Effect: "Human-Penguin Hybrid", Effect Duration: 26
 7651	freshwater fishbone	0		
 7652	ghostly fishbone catcher's mitt	0		
-7653	spinning bouncing fishbone kneepads	0		Initiative: +60, Single Equip
+7653	bouncing spinning fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
 7656	red fishbone facemask	0		Monster Level: -30
@@ -7553,7 +7553,7 @@
 7664	modified upside-down spinning green Ancient Protector Soda	0		Effect: "Bilious Briskness", Effect Duration: 45
 7665	frozen unsweetened modified liquid ice	0		Effect: "Sweetened and Fattened", Effect Duration: 15
 7666	bad cyan Wet Russian	4	decent	
-7667	moldy jumbo filet of The Fish	5	crappy	
+7667	jumbo moldy filet of The Fish	5	crappy	
 7668	Thwaitgold spider statuette	0		
 7669	cyan miser's scandalous careful thunder down underwear	0		Monster Level: -10, Sleaze Damage: +5, Meat Drop: +10, Lasts Until Rollover
 7670	dog trainer's Temple Grandin's ruddy famous raincoat	0		Maximum HP Percent: +40, Familiar Weight: +7, Experience (familiar): +1, Lasts Until Rollover
@@ -7567,7 +7567,7 @@
 7678	spinning stanky 4-dimensional fez	0		Stench Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 12"
 7679	narrow throwing candy	0		
 7680	super-absorbent tarp of the ox	0		Muscle: +20
-7681	tolerable extra-dry unquiet spirits	5	good	
+7681	extra-dry tolerable unquiet spirits	5	good	
 7682	boxer's banjo kazoo mount	0		Muscle Percent: +10, Single Equip
 7683	concentrated polarized jittery mirror grass	0		Effect: "Serenity", Effect Duration: 38
 7684	frightening Time Lord Participation Mug	0		Spooky Damage: +5
@@ -7607,7 +7607,7 @@
 7718	Roman sadnals of the sweet-tooth	0		Candy Drop: +100, Single Equip
 7719	steel-toed madius	0		Damage Reduction: 9
 7720	Fonzie's radiator heater shield	0		Experience (Moxie): +1, Damage Reduction: 6
-7721	concentrated pulsating bouncing salt wages	0		Effect: "Quaaaaaaa", Effect Duration: 52
+7721	concentrated bouncing pulsating salt wages	0		Effect: "Quaaaaaaa", Effect Duration: 52
 7722	huge upside-down prompt centurion helmet	0		Adventures: +3, Familiar Effect: "1xFairy, atk, cap 25"
 7723	huge Chroner cross	0		
 7724	cyan huge veiny pteruges	0		Maximum HP: +10, Familiar Effect: "1xFairy, atk, cap 25"
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	Jim Carey's Xiblaxian xeno-detection goggles	0		Monster Level: +25, Single Equip, Last Available: "2014-09"
-7753	gravedigger's crafty Xiblaxian stealth cowl	0		Maximum MP: +10, Spooky Damage: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	gravedigger's crafty Xiblaxian stealth cowl	0		Maximum MP: +10, Spooky Damage: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	bouncing Xiblaxian stealth trousers of vim and vigor of the overflowing toilet	0		Maximum HP Percent: +50, Stench Spell Damage: +50, Last Available: "2014-09"
 7755	jittery razor-sharp supercool Xiblaxian stealth vest	0		Moxie Percent: +20, Weapon Damage Percent: +25, Last Available: "2014-09"
 7756	tasty Xiblaxian ultraburrito	3	awesome	Last Available: "2014-09"
 7757	bad upside-down Xiblaxian space-whiskey	3	decent	Last Available: "2014-09"
 7758	skewed Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	boiled improved They liver	0		Effect: "Raging Animal", Effect Duration: 58, Last Available: "2014-09"
-7760	jumbo decent They liver popsicle	5	good	Last Available: "2014-09"
+7760	decent jumbo They liver popsicle	5	good	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	mirror holo-platoon	0		Last Available: "2014-09"
@@ -7668,8 +7668,8 @@
 7779	boiled ionized huge experimental serum G-9	0		Effect: "Floundering", Effect Duration: 41, Last Available: "2014-10"
 7780	executive chaotic heavy-duty clipboard of horror	0		Spell Critical Percent: +10, Spooky Spell Damage: +25, Meat Drop: +40, Damage Reduction: 8, Last Available: "2014-10"
 7781	huge toasty resourceful crafty personal trainer's battery-powered drill	0		Experience Percent (Muscle): +10, Maximum MP: 60, Hot Damage: +5, Last Available: "2014-10"
-7782	thick spoiled limp broccoli	5	crappy	Last Available: "2014-10"
-7783	slick hat of the wise owl of extreme caution	0		Mysticality: +20, Moxie: +10, Monster Level: -25, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7782	spoiled thick limp broccoli	5	crappy	Last Available: "2014-10"
+7783	slick hat of the wise owl of extreme caution	0		Mysticality: +20, Moxie: +10, Monster Level: -25, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	liquefied olive monkey barf	0		Effect: "Haunted Liver", Effect Duration: 24, Last Available: "2014-10"
 7785	quantum enhanced altered candy	0		Effect: "White Blooded", Effect Duration: 51, Last Available: "2014-10"
 7786	red ghostly bouncing inspector's studded jangly bracelet of temperance	0		Damage Absorption: +80, Sleaze Resistance: +5, Item Drop: +15, Last Available: "2014-10"
@@ -7683,14 +7683,14 @@
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	stale initiative shawarma	4	decent	Last Available: "2014-10"
 7796	decent spinning warm war shawarma	4	good	Last Available: "2014-10"
-7797	moldy miniature huge karma shawarma	2	crappy	Last Available: "2014-10"
-7798	aged irresponsibly strong Jungle Juice	9	awesome	Last Available: "2014-10"
+7797	miniature moldy huge karma shawarma	2	crappy	Last Available: "2014-10"
+7798	irresponsibly strong aged Jungle Juice	9	awesome	Last Available: "2014-10"
 7799	mediocre wobbly Amnesiac Ale	4	decent	Last Available: "2014-10"
 7800	weak hand-crafted Highest Bitter	2	super EPIC	Last Available: "2014-10"
 7801	Usain Bolt's sinister mercenary pistol	0		Spell Damage: +10, Initiative: +80, Last Available: "2014-10"
 7802	bouncing healthy mercenary rifle of vim and vigor	0		Maximum HP Percent: 70, Last Available: "2014-10"
 7803	gray Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
-7804	red huge Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
+7804	huge red Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	narrow TI-9000 calculator	0		
@@ -7708,21 +7708,21 @@
 7819	squat simple AI	0		
 7820	blue corrupted bird DNA	0		
 7821	squat sentient meat mass	0		
-7822	upside-down spinning olive zombie dinosaur egg	0		
+7822	spinning upside-down olive zombie dinosaur egg	0		
 7823	purple spinning french-fry grabber	0		Familiar Weight: +5
 7824	spinning olive greedy studded boxer's iShield	0		Muscle Percent: +10, Damage Absorption: +80, Meat Drop: +20, Damage Reduction: 6
 7825	banded boxer's slick earbuds	0		Moxie: +10, Muscle Percent: +10, Damage Absorption: +100, Single Equip
 7826	frosty baleful iFlail of the ox	0		Muscle: +20, Spell Damage: +25, Cold Spell Damage: +10
-7827	snack-sized moldy unidentifiable dried fruit	2	crappy	
+7827	moldy snack-sized unidentifiable dried fruit	2	crappy	
 7828	spirit-forward perfectly mixed flat cider	5	EPIC	
 7829	wool Newton's trench lighter of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Cold Resistance: +1, Last Available: "2014-10"
 7830	vacuum-sealed flattened experimental serum P-00	0		Effect: "Ripping, Dripping", Effect Duration: 36, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
-7833	wobbly purple gore bucket	0		Last Available: "2014-10"
+7833	purple wobbly gore bucket	0		Last Available: "2014-10"
 7834	yellow pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
-7836	fuchsia jittery GPS-tracking wristwatch	0		Last Available: "2014-10"
+7836	jittery fuchsia GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	tumbling Project T. L. B.	0		Last Available: "2014-10"
 7838	blurry Agent Mauve	0		Last Available: "2014-10"
 7839	special clip: tracers	0		Last Available: "2014-10"
@@ -7736,15 +7736,15 @@
 7847	nitrogenated flattened ruby on canes	0		Effect: "Slimy Flavor", Effect Duration: 14, Last Available: "2014-12"
 7848	low-calorie normal pulsating petit fortran	1	good	Last Available: "2014-12"
 7849	moldy pulsating java cookie	4	crappy	Last Available: "2014-12"
-7850	big moldy cookie cookie	5	crappy	Last Available: "2014-12"
+7850	moldy big cookie cookie	5	crappy	Last Available: "2014-12"
 7851	fuchsia plastic exo-suited miner of James Dean	0		Experience (Moxie): +3, Last Available: "2014-12"
 7852	auspicious plastic semi-autonomous drill unit	0		Item Drop: +10, Last Available: "2014-12"
 7853	mirror yellow boxer's plastic ambulatory robo-minecart	0		Muscle Percent: +10, Last Available: "2014-12"
 7854	skewed plastic Crimbot of the brazier	0		Hot Spell Damage: +25, Last Available: "2014-12"
 7855	scorching plastic Crimbomega	0		Hot Damage: +25, Last Available: "2014-12"
 7856	colloidal liquefied flask of mining oil	0		Effect: "Standard Cheer", Effect Duration: 54, Last Available: "2014-12"
-7857	curative radiation-resistant helmet	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	frightening servo-assisted exo-pants	0		Spooky Damage: +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	curative radiation-resistant helmet	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	frightening servo-assisted exo-pants	0		Spooky Damage: +5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	mirror groovy cool high-energy mining laser	0		Moxie: +5, Moxie Percent: +10, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7782,7 +7782,7 @@
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	blurry Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	fuchsia Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
-7896	skewed ghostly Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
+7896	ghostly skewed Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
@@ -7815,9 +7815,9 @@
 7926	practically non-alcoholic artisanal gamma nog	1	super ultra mega EPIC	Last Available: "2014-12"
 7934	squat sneaky wrapping paper	0		Last Available: "2014-12"
 7935	yellow Thwaitgold nit statuette	0		
-7936	green skewed picky tweezers	0		Last Available: "2015-02"
+7936	skewed green picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	mixed cyan blurry blurry single atom	1	good	Last Available: "2015-02"
+7938	mixed blurry cyan blurry single atom	1	good	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	blurry sleeve deuce	0		
@@ -7827,8 +7827,8 @@
 7945	table	0		
 7946	auspicious sizzling healthy outlaw bandana	0		Maximum HP Percent: +20, Hot Damage: +10, Item Drop: +10
 7947	strong tolerable whiskey in a broken glass	5	good	
-7948	boozy acceptable shot of mescal	5	good	
-7949	bad strong bouncing glass of herbal tequila	5	decent	
+7948	acceptable boozy shot of mescal	5	good	
+7949	strong bad bouncing glass of herbal tequila	5	decent	
 7950	minin' dynamite	0		
 7951	Socratic plaid cowboy hat of mayonnaise	0		Experience (Mysticality): +1, Sleaze Spell Damage: +50, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7849,7 +7849,7 @@
 7967	frosty World's Best Adventurer sash	0		Cold Spell Damage: +10
 7968	blurry topiary nugglet	0		
 7969	beehive	0		
-7970	blurry ghostly boning knife	0		
+7970	ghostly blurry boning knife	0		
 7971	green Aggressive Carrot	0		Free Pull
 7972	dried narrow mummified fig	1	decent	
 7973	twisted shaking fuchsia mummified loaf of bread	1	decent	Effect: "The Strength...  of the Future", Effect Duration: 25
@@ -7863,7 +7863,7 @@
 7981	talisman of Thoth	0		
 7982	cure-all	0		
 7983	spinning lion tamer's arcane researcher's Sister Accessory	0		Experience Percent (Mysticality): +10, Experience (familiar): +2, Softcore Only
-7984	wet huge tumbling Boosty Juice	0		Effect: "Flagrantly Fragrant", Effect Duration: 65
+7984	wet tumbling huge Boosty Juice	0		Effect: "Flagrantly Fragrant", Effect Duration: 65
 7985	hardened parachute of Gandalf	0		Damage Reduction: 3, Spell Critical Percent: +20, Last Available: "2015-12"
 7986	pulsating prompt stanky pad	0		Stench Spell Damage: +25, Adventures: +3, Damage Reduction: 3, Last Available: "2015-12"
 7987	wobbly coward's peeler of the early riser	0		Monster Level: -20, Adventures: +7, Last Available: "2015-12"
@@ -7881,12 +7881,12 @@
 7999	dry blinking choco-Crimbot	0		Effect: "Cat-Alyzed", Effect Duration: 34, Last Available: "2014-12"
 8000	warmed ionized squat smart watch	0		Effect: "Elvish", Effect Duration: 20, Last Available: "2014-12"
 8001	unsweetened augmented-reality shades	0		Effect: "Adrenaline Rush", Effect Duration: 52, Last Available: "2014-12"
-8002	nippy toy Crimbot mega face	0		Cold Damage: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8002	nippy toy Crimbot mega face	0		Cold Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
 8003	Van der Graaf toy Crimbot power glove	0		MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	narrow toy Crimbot super fist of the wise owl	0		Mysticality: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	foul-smelling toy Crimbot rocket legs	0		Stench Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	irradiated corrupted wobbly upside-down Crimbot battery	0		Effect: "Hiding in Plain Sight", Effect Duration: 25, Last Available: "2014-12"
-8007	olive blinking Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
+8007	blinking olive Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	ghostly teal Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	spinning Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	cyan Mini-Crimbot crate	0		Last Available: "2014-12"
@@ -7900,8 +7900,8 @@
 8018	alkaline and rain stick	0		Effect: "Tingly Biceps", Effect Duration: 41
 8019	narrow squat Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	moldy miniature Choco-Mint patty	2	crappy	Last Available: "2015-01"
-8021	extra-dry artisanal tumbling hot mint schnocolate	5	EPIC	Last Available: "2015-01"
-8022	denatured squat olive homeopathic mint tea	1	EPIC	Last Available: "2015-01"
+8021	artisanal extra-dry tumbling hot mint schnocolate	5	EPIC	Last Available: "2015-01"
+8022	denatured olive squat homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	mirror bowl of potpourri	0		Last Available: "2015-01"
@@ -7944,7 +7944,7 @@
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	blinking monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
-8066	modified lime green upside-down	1	EPIC	Last Available: "2015-12"
+8066	modified upside-down lime green	1	EPIC	Last Available: "2015-12"
 8067	mirror nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	upside-down Stembridge sidearm	0		Familiar Weight: +5
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	olive perfumed rosy-cheeked dance instructor's Spelunker's fedora	0		Experience Percent (Moxie): +10, Maximum HP Percent: +30, Stench Resistance: +5, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	olive perfumed rosy-cheeked dance instructor's Spelunker's fedora	0		Experience Percent (Moxie): +10, Maximum HP Percent: +30, Stench Resistance: +5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	frosty coward's Annie Oakley's Spelunker's whip	0		Critical Hit Percent: +20, Monster Level: -20, Cold Spell Damage: +10, Last Available: "2015-12"
-8076	squat greasy Socratic Spelunker's khakis of the cheetah	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10, Initiative: +60, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	squat greasy Socratic Spelunker's khakis of the cheetah	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10, Initiative: +60, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	skewed Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	cyan LOLmec statuette	0		Last Available: "2015-12"
 8085	skewed Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8015,16 +8015,16 @@
 8141	wholesome macroplane grater	0		Maximum HP Percent: +10
 8142	bastard baster of the bloodbag	0		Maximum HP: +100
 8143	twirling teal chaotic obsidian nutcracker	0		Spell Critical Percent: +10
-8144	purple twirling talisman of Seshat	0		Free Pull
+8144	twirling purple talisman of Seshat	0		Free Pull
 8145	stiffened smartaleck's glass eye	0		Moxie Percent: +30, Damage Reduction: 1, Single Equip
 8146	nitrogenated extra-altered wobbly invisible potion	0		Effect: "Optimist Primal", Effect Duration: 65
 8147	time shuriken	0		
 8148	pulsating censurious rosy-cheeked ninjammies of chilblains	0		Maximum HP Percent: +30, Cold Damage: +25, Sleaze Resistance: +3, Familiar Effect: "atk, 0.5xPotato, cap 25"
-8149	enhanced quadruple-altered cyan squat blinking Glo-Pop	0		Effect: "Space Cadet", Effect Duration: 40
+8149	enhanced quadruple-altered blinking squat cyan Glo-Pop	0		Effect: "Space Cadet", Effect Duration: 40
 8150	galvanized tumbling sugar sphere	0		Effect: "Swordholder", Effect Duration: 56
 8151	corrupted Shrubble Bubble	0		Effect: "Tea-hee", Effect Duration: 38
 8152	flattened triple-diffused polyeaster egg	0		Effect: "Sinuses For Miles", Effect Duration: 68
-8153	tarnished squat lime green blurry pulsating candy dish	0		Effect: "critical.enh", Effect Duration: 29
+8153	tarnished lime green blurry squat pulsating candy dish	0		Effect: "critical.enh", Effect Duration: 29
 8154	super-oxidized ionized shaking Spechunky bar	0		Effect: "Orc Chops", Effect Duration: 58
 8155	anodized vacuum-sealed talisman of Horus	0		Effect: "Cotton Mouthed", Effect Duration: 56
 8156	check to the Meatsmith	0		
@@ -8032,7 +8032,7 @@
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
 8160	energized gray mouse skull	0		Effect: "Deeply Ironic", Effect Duration: 53
-8161	boiled concentrated bouncing tumbling really thick spine	0		Effect: "Stemonitis Storm", Effect Duration: 17
+8161	boiled concentrated tumbling bouncing really thick spine	0		Effect: "Stemonitis Storm", Effect Duration: 17
 8162	tumbling executive rock-hard skullcap	0		Damage Reduction: 5, Meat Drop: +40, Familiar Effect: "1xVolley,cap 5"
 8163	spinning hardened beefy three-legged pants	0		Muscle: +10, Damage Reduction: 3, Familiar Effect: "hot atk, cap 25"
 8164	shaking lime green remaindered axe of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100
@@ -8041,13 +8041,13 @@
 8167	normal baguette	3	good	
 8168	glob of icing	0		
 8169	irradiated vacuum-sealed wobbly ginger snaps	0		Effect: "damage.enh", Effect Duration: 64
-8170	adjusted moist yellow narrow mostly-broken sunglasses	0		Effect: "Eye of the Seal", Effect Duration: 26
+8170	adjusted moist narrow yellow mostly-broken sunglasses	0		Effect: "Eye of the Seal", Effect Duration: 26
 8171	bad weak unflavored wine cooler	2	decent	
 8172	carton of snake milk	1	good	
 8173	purple experienced sewer snake	0		Experience: +2
 8174	spoiled snack-sized pigeon egg	2	crappy	
 8175	ruddy wholesome jaunty feather	0		Maximum HP Percent: 50
-8176	fortified hand-crafted ghostly premium malt liquor	5	EPIC	
+8176	hand-crafted fortified ghostly premium malt liquor	5	EPIC	
 8177	flame-wreathed crafty brown paper pants	0		Maximum MP: +10, Hot Spell Damage: +10
 8178	bouncing Jim Carey's steel-toed brown paper bag mask	0		Damage Reduction: 9, Monster Level: +25
 8179	ring of telling skeletons what to do of the sweet-tooth	0		Candy Drop: +100, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,17 +8056,17 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	shaking twirling family-friendly bread basket	0		Sleaze Resistance: +1
 8184	Ed the Undying exhibit crate	0		
-8185	lightning-fast clever The Crown of Ed the Undying	0		Maximum MP: +20, Initiative: +40, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	lightning-fast clever The Crown of Ed the Undying	0		Maximum MP: +20, Initiative: +40, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	squat fuchsia map to a hidden booze cache	0		
 8188	acceptable Cherrytastrophe wine cooler	4	good	
-8189	bad weak Radberry Rip wine cooler	2	decent	
+8189	weak bad Radberry Rip wine cooler	2	decent	
 8190	artisanal Orangemageddon wine cooler	4	EPIC	
 8191	tolerable skewed Breakfast Blast wine cooler	4	good	
 8192	artisanal narrow Citrus Crush wine cooler	3	EPIC	
 8193	decent plain bagel	3	good	
 8194	spoiled glob of cream cheese	3	crappy	
-8195	moldy tiny twirling loaf of soda bread	1	crappy	
+8195	tiny moldy twirling loaf of soda bread	1	crappy	
 8196	flavorless pulsating acceptable bagel	3	decent	
 8197	adequate big lime green standard-issue cupcake	5	good	
 8198	bland huge ultra-deluxe cupcake	3	decent	
@@ -8078,8 +8078,8 @@
 8204	one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	olive FunFunds&trade;	0		Last Available: "2015-04"
 8206	skewed educational expensive camera of the bloodbag	0		Experience: +1, Maximum HP: +100, Single Equip, Last Available: "2015-04"
-8207	wobbly blurry sunglasses	0		Single Equip, Last Available: "2015-04"
-8208	triple-corrupted teal narrow How to Avoid Scams	0		Effect: "Egg-stra Arm", Effect Duration: 63, Last Available: "2015-04"
+8207	blurry wobbly sunglasses	0		Single Equip, Last Available: "2015-04"
+8208	triple-corrupted narrow teal How to Avoid Scams	0		Effect: "Egg-stra Arm", Effect Duration: 63, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	mirror bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	pulsating bag of park garbage	0		Last Available: "2015-04"
@@ -8092,14 +8092,14 @@
 8218	toxic globule	0		Last Available: "2015-04"
 8219	decent toxo	4	good	Last Available: "2015-04"
 8220	practically non-alcoholic tolerable narrow lime green Lemonade-235	1	good	Last Available: "2015-04"
-8221	spinning rock-hard isotophat of terror	0		Damage Reduction: 5, Spooky Spell Damage: +10, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	spinning rock-hard isotophat of terror	0		Damage Reduction: 5, Spooky Spell Damage: +10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	up-at-dawn hardy Three Mile Island shorts	0		Maximum HP: +50, Adventures: +5, Last Available: "2015-04"
 8223	spinning frightening careful toxic mop	0		Monster Level: -10, Spooky Damage: +5, Last Available: "2015-04"
 8224	squat inert sludgepuppy	0		Last Available: "2015-04"
 8225	shaking lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	fuchsia jar of swamp honey	0		Last Available: "2015-04"
 8227	careful supercool backwoods banjo of the overflowing toilet	0		Moxie Percent: +20, Monster Level: -10, Stench Spell Damage: +50, Last Available: "2015-04"
-8228	narrow ghostly grody jug	0		Last Available: "2015-04"
+8228	ghostly narrow grody jug	0		Last Available: "2015-04"
 8229	spinning wicked Sinatra's Fonzie's ratskin pajama pants	0		Experience (Moxie): 6, Spell Damage: +5, Last Available: "2015-04"
 8230	aerosolized nitrogenated turtle voicebox	0		Effect: "Guts Feeling", Effect Duration: 56, Last Available: "2015-04"
 8231	teal inspector's Temple Grandin's fake washboard of the blizzard	0		Familiar Weight: +7, Cold Spell Damage: +25, Item Drop: +15, Damage Reduction: 13, Last Available: "2015-04"
@@ -8141,7 +8141,7 @@
 8267	jittery chilly sphygmayomanometer	0		Cold Damage: +5, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	jittery mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	half-sized flavorless blinking unappetizing mayolus	2	decent	Last Available: "2015-05"
+8270	flavorless half-sized blinking unappetizing mayolus	2	decent	Last Available: "2015-05"
 8271	yummy blue uninteresting mayolus	4	awesome	Last Available: "2015-05"
 8272	flavorless acceptable mayolus	3	decent	Last Available: "2015-05"
 8273	stale enticing mayolus	3	decent	Last Available: "2015-05"
@@ -8149,12 +8149,12 @@
 8275	yellow newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	delicious high-proof Afternoon Delight	8	awesome	Last Available: "2015-04"
+8278	high-proof delicious Afternoon Delight	8	awesome	Last Available: "2015-04"
 8279	narrow Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	quantum aerosolized mirror Kokomo Resort Brand Suntan Oil	0		Effect: "Hagnk's Gratitude", Effect Duration: 43, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
-8283	purple tumbling The Cocktail Shaker	0		Last Available: "2015-04"
+8283	tumbling purple The Cocktail Shaker	0		Last Available: "2015-04"
 8284	galvanized frozen spinning Kokomo Resort Pass	0		Effect: "Material Witness", Effect Duration: 27, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	energized magnetized Mayo de Mayo&trade; mayo	0		Effect: "Turtle Titters", Effect Duration: 17
@@ -8174,7 +8174,7 @@
 8300	deionized power pill	0		Effect: "Ironclad", Effect Duration: 13, Last Available: "2015-06"
 8301	nitrogenated polarized pulsating pixel star	0		Effect: "Flaming Weapon", Effect Duration: 32, Last Available: "2015-06"
 8302	bland pixel banana	3	decent	Last Available: "2015-06"
-8303	mediocre watered-down green pixel beer	2	decent	Last Available: "2015-06"
+8303	watered-down mediocre green pixel beer	2	decent	Last Available: "2015-06"
 8304	huge puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	polymerized tarnished jittery sludgesicle	0		Effect: "Mint-Condition Breath", Effect Duration: 68
@@ -8195,11 +8195,11 @@
 8321	altered flattened glove	0		Effect: "Soles of Glass", Effect Duration: 11
 8322	frozen irradiated jittery handful of fire	0		Effect: "Drenched With Filth", Effect Duration: 26
 8323	flattened Cracklin' Oat Bran	0		Effect: "OMG WTF", Effect Duration: 48
-8324	triple-Vulcanized non-colloidal upside-down squat blinking disposable lighter	0		Effect: "Swimming with Sharks", Effect Duration: 68
+8324	triple-Vulcanized non-colloidal blinking upside-down squat disposable lighter	0		Effect: "Swimming with Sharks", Effect Duration: 68
 8325	ionized spinning coal contact lenses	0		Effect: "Wise Spirit", Effect Duration: 51
 8326	quadruple-anodized magnetized bouncing conjured ice cream	0		Effect: "In the Saucestream", Effect Duration: 31
 8327	improved double-aerosolized skewed Iceberglar scarf	0		Effect: "Quadrilled", Effect Duration: 53
-8328	non-frozen olive wobbly icy hairspray	0		Effect: "Hair on Your Chest", Effect Duration: 59
+8328	non-frozen wobbly olive icy hairspray	0		Effect: "Hair on Your Chest", Effect Duration: 59
 8329	quantum double-unsweetened narrow smellbook	0		Effect: "Big", Effect Duration: 23
 8330	tarnished denatured blurry assassin's cheese knife	0		Effect: "Boon of the War Snapper", Effect Duration: 59
 8331	triple-altered galvanized filthy armor	0		Effect: "Cool, Catlike", Effect Duration: 53
@@ -8213,10 +8213,10 @@
 8339	modified pressed warehouse walkie-talkie	0		Effect: "Gobliny Flavor", Effect Duration: 55
 8340	polymerized corrupted irradiated blurry janitor's mop	0		Effect: "Moose Wisdom", Effect Duration: 42
 8341	improved warehouse clerk's glasses	0		Effect: "Jingle Jangle Jingle", Effect Duration: 37
-8342	quantum pulsating green baloney rotgut	0		Effect: "It Didn't Kill You", Effect Duration: 17
+8342	quantum green pulsating baloney rotgut	0		Effect: "It Didn't Kill You", Effect Duration: 17
 8343	deionized improved huge bouncing carton of gaspers	0		Effect: "Good Karma", Effect Duration: 28
 8344	polymerized bronze polish	0		Effect: "Heal Thy Nanoself", Effect Duration: 27
-8345	quadruple-flattened magnetized blurry maroon crident	0		Effect: "meat.enh", Effect Duration: 36
+8345	quadruple-flattened magnetized maroon blurry crident	0		Effect: "meat.enh", Effect Duration: 36
 8346	alkaline nitrogenated skewed skewed totally sweet mohawk helmet	0		Effect: "Sticky Fingers", Effect Duration: 38
 8347	colloidal blurry spray chrome	0		Effect: "Angry like the Wolf", Effect Duration: 21
 8348	diffused deionized blinking filthy monkey head	0		Effect: "Funky Coal Patina", Effect Duration: 59
@@ -8224,7 +8224,7 @@
 8350	enhanced pressed nitrogenated damp bar rag	0		Effect: "Sweet and Red", Effect Duration: 13
 8351	concentrated narrow lump of goofball ore	0		Effect: "Staying Frosty", Effect Duration: 68
 8352	pressed cold-filtered skeleton beans	0		Effect: "Sweetened and Fattened", Effect Duration: 13
-8353	double-Vulcanized mirror spinning grimy lab coat	0		Effect: "Boon of the War Snapper", Effect Duration: 20
+8353	double-Vulcanized spinning mirror grimy lab coat	0		Effect: "Boon of the War Snapper", Effect Duration: 20
 8354	flattened pressed narrow maroon nursery rhyme	0		Effect: "Prideful Strut", Effect Duration: 55
 8355	deionized corrupted iron torso box	0		Effect: "Steroid Boost", Effect Duration: 13
 8356	flattened super-adjusted shaking tumbling mercenary headband	0		Effect: "Nature's Bounty", Effect Duration: 14
@@ -8232,7 +8232,7 @@
 8358	galvanized polarized upside-down x-ray mirror	0		Effect: "Heart of Pink", Effect Duration: 66
 8359	super-galvanized upside-down wrestling mask	0		Effect: "Yes, Can Haz", Effect Duration: 26
 8360	activated hawkface potion	0		Effect: "Feet of Grapefruit", Effect Duration: 32
-8361	pickled flattened ionized ghostly cyan child-sized dracula cloak	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34
+8361	pickled flattened ionized cyan ghostly child-sized dracula cloak	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34
 8362	double-polarized devil-summoning hat	0		Effect: "Fancy Feasted", Effect Duration: 52
 8363	extra-improved tumbling shopkeeper beard	0		Effect: "Red-Shirted Escort", Effect Duration: 43
 8364	vacuum-sealed cold-filtered narrow alien autoautopsy kit	0		Effect: "The Halls of Muscularity", Effect Duration: 65
@@ -8248,8 +8248,8 @@
 8374	corrupted flattened tumbling drinks tray	0		Effect: "Full of Wist", Effect Duration: 16
 8375	magnetized modified chilled huge eyebrow lifter	0		Effect: "Rad-ish", Effect Duration: 22
 8376	submarine	0		Last Available: "2015-06"
-8377	half-sized normal narrow spinning squat pixel lemon	2	good	Last Available: "2015-06"
-8378	tolerable practically non-alcoholic pulsating pixel daiquiri	1	good	Last Available: "2015-06"
+8377	normal half-sized narrow squat spinning pixel lemon	2	good	Last Available: "2015-06"
+8378	practically non-alcoholic tolerable pulsating pixel daiquiri	1	good	Last Available: "2015-06"
 8379	aerosolized power pill	0		Effect: "Big", Effect Duration: 32, Last Available: "2015-06"
 8380	dry narrow pixel potion	0		Effect: "Busy Bein' Delicious", Effect Duration: 45, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8277,26 +8277,26 @@
 8403	jittery squat stanky studded revolver	0		Damage Absorption: +80, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2015-07"
 8404	mirror 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
-8406	upside-down jittery savory dry noodles	0		
+8406	jittery upside-down savory dry noodles	0		
 8407	flavorless thick pestopiary	5	decent	
 8408	alkaline chilled ectoplasmic orbs	0		Effect: "Eye of the Seal", Effect Duration: 53
-8409	small stale ghostly crudles	2	decent	
+8409	stale small ghostly crudles	2	decent	
 8410	normal agnolotti arboli	4	good	
 8411	bland spaghetti with ghost balls	3	decent	
-8412	moldy tiny skewed succulent marrow	1	crappy	
+8412	tiny moldy skewed succulent marrow	1	crappy	
 8413	moldy salacious crumbs	4	crappy	
 8414	rotten fusilli marrownarrow	3	crappy	
 8415	stale miniature teal suggestive strozzapreti	2	decent	
 8416	Mountain Stream gastrique	0		
-8417	big adequate Mt. McLargeHuge oyster	5	good	
+8417	adequate big Mt. McLargeHuge oyster	5	good	
 8418	skewed tumbling oyster sauce	0		
-8419	immense rotten bouncing linguini immondizia bianco	10	crappy	
-8420	gigantic special toothsome shells a la shellfish	7	awesome	Effect: "Make Meat FA$T!", Effect Duration: 45
+8419	rotten immense bouncing linguini immondizia bianco	10	crappy	
+8420	toothsome special gigantic shells a la shellfish	7	awesome	Effect: "Make Meat FA$T!", Effect Duration: 45
 8421	jittery Jick's autograph	0		
 8422	maroon high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	pulsating 1,970 carat	0		Last Available: "2015-08"
-8425	bouncing blinking New Age healing crystal	0		Last Available: "2015-08"
+8425	blinking bouncing New Age healing crystal	0		Last Available: "2015-08"
 8426	upside-down Volcoino	0		Last Available: "2015-08"
 8427	fizzing spore pod	0		
 8428	spore pod	0		
@@ -8329,19 +8329,19 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	narrow crystalline light bulb	0		Last Available: "2015-08"
 8457	olive broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	blinking blinking manspreader's smooth high-temperature mining mask	0		Moxie: +15, Monster Level: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	blinking blinking manspreader's smooth high-temperature mining mask	0		Moxie: +15, Monster Level: +10, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	twirling slick fireproof megaphone of dire peril	0		Moxie: +10, Weapon Damage: +20, Last Available: "2015-08"
-8460	stale huge mineapple	9	decent	Last Available: "2015-08"
-8461	hand-crafted practically non-alcoholic Gold Velvet&trade; whiskey	1	EPIC	Last Available: "2015-08"
+8460	huge stale mineapple	9	decent	Last Available: "2015-08"
+8461	practically non-alcoholic hand-crafted Gold Velvet&trade; whiskey	1	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
-8463	small toothsome smelted roe	2	awesome	Last Available: "2015-08"
+8463	toothsome small smelted roe	2	awesome	Last Available: "2015-08"
 8464	spirit-forward smooth lavawater	5	awesome	Last Available: "2015-08"
 8465	denatured quantum basaltamander tongue	0		Effect: "Nothing Is Impossible", Effect Duration: 66, Last Available: "2015-08"
 8466	sizzling manspreader's MacGyver's lavalarva	0		Maximum MP: +100, Monster Level: +10, Hot Damage: +10, Last Available: "2015-08"
 8467	skewed knitted mansplainer's lava balaclava of wisdom	0		Mysticality: +15, Monster Level: +15, Cold Resistance: +3, Last Available: "2015-08"
 8468	toasty basaltamander buckler of the dark arts of the empath	0		Spell Damage Percent: +100, Familiar Weight: +5, Hot Damage: +5, Damage Reduction: 15, Last Available: "2015-08"
 8469	boiled lava globs	0		Effect: "Coy to the Hurled", Effect Duration: 13, Last Available: "2015-08"
-8470	jumbo fancy toothsome upside-down gooey lava globs	5	awesome	Effect: "Stick Emporium Membership", Effect Duration: 30, Last Available: "2015-08"
+8470	toothsome jumbo fancy upside-down gooey lava globs	5	awesome	Effect: "Stick Emporium Membership", Effect Duration: 30, Last Available: "2015-08"
 8471	gravedigger's lava-proof pants of temperance	0		Spooky Damage: +10, Sleaze Resistance: +5, Last Available: "2015-08"
 8472	up-at-dawn rosy-cheeked heat-resistant necktie	0		Maximum HP Percent: +30, Adventures: +5, Single Equip, Last Available: "2015-08"
 8473	greasy weightlifter's heat-resistant gloves	0		Muscle: +15, Sleaze Spell Damage: +10, Item Drop: +5, Single Equip, Last Available: "2015-08"
@@ -8350,10 +8350,10 @@
 8476	liquefied mirror liquid rhinestones	0		Effect: "Disco Neuropathy", Effect Duration: 67, Last Available: "2015-08"
 8477	moldy disco biscuit	4	crappy	Last Available: "2015-08"
 8478	tolerable twirling Quaatorade&trade;	4	good	Last Available: "2015-08"
-8479	wool ruddy biker's hat of wisdom	0		Mysticality: +15, Maximum HP Percent: +40, Cold Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
-8480	red flame-retardant forbidden slick feathered headdress	0		Moxie: +10, Spell Damage Percent: +50, Hot Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	Newton's smartaleck's cool electrician's hardhat	0		Moxie: +5, Moxie Percent: +30, Experience (Mysticality): +3, Familiar Effect: "atk", Last Available: "2015-08"
-8482	fuchsia blurry narrow Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
+8479	wool ruddy biker's hat of wisdom	0		Mysticality: +15, Maximum HP Percent: +40, Cold Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
+8480	red flame-retardant forbidden slick feathered headdress	0		Moxie: +10, Spell Damage Percent: +50, Hot Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	Newton's smartaleck's cool electrician's hardhat	0		Moxie: +5, Moxie Percent: +30, Experience (Mysticality): +3, Last Available: "2015-08", Familiar Effect: "atk"
+8482	blurry narrow fuchsia Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	pulsating Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	ghostly New Age hurting crystal	0		Last Available: "2015-08"
-8490	smooth velvet pants of the detective	0		Item Drop: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	smooth velvet pants of the detective	0		Item Drop: +20, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	gray frightening smooth velvet shirt	0		Spooky Damage: +5, Last Available: "2015-08"
 8492	smooth velvet hat of terror	0		Spooky Spell Damage: +10, Last Available: "2015-08"
 8493	huge brawny smooth velvet pocket square	0		Muscle Percent: +20, Single Equip, Last Available: "2015-08"
@@ -8379,7 +8379,7 @@
 8505	green half-melted hula girl	0		Last Available: "2015-08"
 8506	tumbling glass ceiling fragments	0		Last Available: "2015-08"
 8507	boiled blurry twirling SMOOCH coffee cup	1	awesome	Effect: "Wax On Your Shoes", Effect Duration: 50, Last Available: "2015-08"
-8508	magnetized polymerized teal mirror labrador cookie	0		Effect: "Carrrsmic", Effect Duration: 26, Last Available: "2015-08"
+8508	magnetized polymerized mirror teal labrador cookie	0		Effect: "Carrrsmic", Effect Duration: 26, Last Available: "2015-08"
 8509	flame-retardant Mr. Cheeng's spectacles of the brazier of the businessman	0		Hot Spell Damage: +25, Hot Resistance: +1, Meat Drop: +50, Single Equip, Last Available: "2015-08"
 8510	shaking sinister Socratic grease cannon	0		Experience (Mysticality): +1, Spell Damage: +10, Last Available: "2015-08"
 8511	dry extra-dry concentrated demon makeup kit	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 28, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	knitted brainy SMOOCH bracers	0		Mysticality: +5, Cold Resistance: +3, Single Equip, Last Available: "2015-08"
 8518	deadly SMOOCH kneepads	0		Weapon Damage: +5, Single Equip, Last Available: "2015-08"
 8519	greasy SMOOCH spaulders	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2015-08"
-8520	sizzling SMOOCH codpiece of Leguizamo	0		Monster Level: +20, Hot Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	sizzling SMOOCH codpiece of Leguizamo	0		Monster Level: +20, Hot Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	tumbling healthy SMOOCH breastplate	0		Maximum HP Percent: +20, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	ghostly fused fuse	0		Last Available: "2015-08"
@@ -8401,7 +8401,7 @@
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	decent devil hair pasta	3	good	
-8530	adequate miniature mirror spagecialetti	2	good	
+8530	miniature adequate mirror spagecialetti	2	good	
 8531	tumbling Salsa Libre	0		
 8532	good gravy	0		
 8533	red illicit fish sauce	0		
@@ -8416,12 +8416,12 @@
 8543	stale miniature fusillocybin	2	decent	
 8544	normal half-sized prescription noodles	2	good	
 8545	pickled maroon blood-drive sticker	1	good	Effect: "Hombre Muerto Caminando", Effect Duration: 10
-8546	alkaline spinning wobbly bag of grain	0		Effect: "Educated (Kinda)", Effect Duration: 41
+8546	alkaline wobbly spinning bag of grain	0		Effect: "Educated (Kinda)", Effect Duration: 41
 8547	modified denatured dry lime green pocket maze	0		Effect: "There Is A Spoon", Effect Duration: 67
 8548	double-dry corrupted shady shades	0		Effect: "Slightly Larger Than Usual", Effect Duration: 53
 8549	double-energized liquefied squeaky toy rose	0		Effect: "Human-Human Hybrid", Effect Duration: 52
-8550	big normal weird gazelle steak	5	good	
-8551	spoiled big teal sausage without a cause	5	crappy	
+8550	normal big weird gazelle steak	5	good	
+8551	big spoiled teal sausage without a cause	5	crappy	
 8552	quadruple-modified pickled face paint	0		Effect: "Punchy, Murdery", Effect Duration: 44
 8553	smooth red emergency margarita	3	awesome	
 8554	mediocre weak vintage smart drink	2	decent	
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	miser's reassuring scandalous barrel lid	0		Sleaze Damage: +5, Spooky Resistance: +1, Meat Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Temple Grandin's electrified barrel hoop earring of the early riser	0		Familiar Weight: +7, Adventures: +7, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2015-09"
-8567	nasty supercool bankruptcy barrel of the ox	0		Muscle: +20, Moxie Percent: +20, Stench Damage: +5, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	nasty supercool bankruptcy barrel of the ox	0		Muscle: +20, Moxie Percent: +20, Stench Damage: +5, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	narrow tun	0		Last Available: "2015-09"
@@ -8471,7 +8471,7 @@
 8598	censurious boxer's barrel beryl ring	0		Muscle Percent: +10, Sleaze Resistance: +3, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	mirror potted tea tree	0		Last Available: "2015-09"
-8601	modified altered narrow lime green cuppa Flamibili tea	0		Effect: "Orchid Blood", Effect Duration: 69, Last Available: "2015-09"
+8601	modified altered lime green narrow cuppa Flamibili tea	0		Effect: "Orchid Blood", Effect Duration: 69, Last Available: "2015-09"
 8602	super-denatured concentrated huge cuppa Yet tea	0		Effect: "Squatting and Thrusting", Effect Duration: 36, Last Available: "2015-09"
 8603	modified colloidal cuppa Boo tea	0		Effect: "You Know Who to Call", Effect Duration: 54, Last Available: "2015-09"
 8604	boiled cuppa Nas tea	0		Effect: "Drenched With Filth", Effect Duration: 59, Last Available: "2015-09"
@@ -8516,7 +8516,7 @@
 8643	decent bowl of maggots	3	good	Last Available: "2015-10"
 8644	acceptable blood and blood	3	good	Last Available: "2015-10"
 8645	hand-crafted Jack-O-Lantern beer	4	EPIC	Last Available: "2015-10"
-8646	drinkable watered-down zombie	2	good	Last Available: "2015-10"
+8646	watered-down drinkable zombie	2	good	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	olive plastic nightmare troll	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	wool electrified veiny hawk	0		Maximum HP: +10, Cold Resistance: +1, MP Regen Min: 3, MP Regen Max: 5
-8655	flavorless ghostly blue hamlet sandwich	3	decent	
+8655	flavorless blue ghostly hamlet sandwich	3	decent	
 8656	deadly Othello's military jacket	0		Weapon Damage: +5
 8657	prompt Othello's dagger	0		Adventures: +3, Single Equip
 8658	pulsating rosy-cheeked Othello's handkerchief	0		Maximum HP Percent: +30, Single Equip
@@ -8533,7 +8533,7 @@
 8660	skewed grip key	0		
 8661	narrow How to Play Othello	0		
 8662	skewed zippy smartaleck's ghostly dagger of the empath	0		Moxie Percent: +30, Familiar Weight: +5, Initiative: +20
-8663	aged watered-down ghost beer	2	awesome	
+8663	watered-down aged ghost beer	2	awesome	
 8664	Van der Graaf Othello set	0		MP Regen Min: 5, MP Regen Max: 7
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8548,35 +8548,35 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	adjusted shoulder-warming lotion	0		Effect: "Emotion Sickness", Effect Duration: 49, Last Available: "2015-11"
 8677	yummy wobbly squat iceberg lettuce	3	awesome	Last Available: "2015-11"
-8678	special acceptable ice wine	3	good	Effect: "Sweet, Nuts", Effect Duration: 10, Last Available: "2015-11"
+8678	acceptable special ice wine	3	good	Effect: "Sweet, Nuts", Effect Duration: 10, Last Available: "2015-11"
 8679	avaricious greasy Wal-Mart snowglobe of the glutton	0		Sleaze Spell Damage: +10, Meat Drop: +30, Food Drop: +100, Last Available: "2015-11"
 8680	supercharged occult Wal-Mart nametag of the wise owl	0		Mysticality: +20, Spell Damage Percent: +25, Maximum MP Percent: +30, Last Available: "2015-11"
 8681	inspector's scandalous deadly Wal-Mart overalls	0		Weapon Damage: +5, Sleaze Damage: +5, Item Drop: +15, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
-8684	pulsating huge Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
+8684	huge pulsating Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	spinning Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	huge The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	bellhop's hat of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	spirit-forward delicious ice porter	5	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	bellhop's hat of doom	0		Spooky Spell Damage: +50, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	delicious spirit-forward ice porter	5	awesome	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	adjusted extra-galvanized spinning exotic travel brochure	0		Effect: "Trufflin'", Effect Duration: 31, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	aerosolized chilled double-chilled shampoo-conditioner	0		Effect: "Mystic Circle", Effect Duration: 63, Last Available: "2015-11"
 8693	wobbly hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
-8695	narrow skewed Martialest Arts trophy	0		Last Available: "2016-01"
+8695	skewed narrow Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered medicinal herbs	1		Last Available: "2016-01"
-8697	big tasty squat ice rice	5	awesome	Last Available: "2016-01"
+8697	tasty big squat ice rice	5	awesome	Last Available: "2016-01"
 8698	hand-crafted iced plum wine	3	EPIC	Last Available: "2016-01"
 8699	supercool brainy training belt of the overflowing toilet	0		Mysticality: +5, Moxie Percent: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2016-01"
 8700	Rosewater's slick training legwarmers of the wise owl	0		Mysticality: +20, Moxie: +10, Mysticality Percent: +30, Single Equip, Last Available: "2016-01"
-8701	fortified smooth training helmet of Tarzan	0		Moxie: +15, Experience (Muscle): +3, Damage Absorption: +60, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	fortified smooth training helmet of Tarzan	0		Moxie: +15, Experience (Muscle): +3, Damage Absorption: +60, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	shaking training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	jittery X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
-8706	squat twirling cyan machine elf capsule	0		Free Pull, Last Available: "2015-12"
+8706	cyan twirling squat machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	mixed abstraction: action	1		Last Available: "2015-12"
 8709	diluted abstraction: thought	1		Effect: "Superheroic", Effect Duration: 30, Last Available: "2015-12"
@@ -8584,13 +8584,13 @@
 8711	compressed abstraction: purpose	1		Last Available: "2015-12"
 8712	altered blinking abstraction: category	1		Last Available: "2015-12"
 8713	pickled abstraction: perception	1		Effect: "Gobliny Flavor", Effect Duration: 5, Last Available: "2015-12"
-8714	altered twirling upside-down abstraction: motion	1		Last Available: "2015-12"
+8714	altered upside-down twirling abstraction: motion	1		Last Available: "2015-12"
 8715	dried spinning abstraction: joy	1		Last Available: "2015-12"
-8716	altered ghostly squat teal abstraction: certainty	1		Last Available: "2015-12"
+8716	altered teal ghostly squat abstraction: certainty	1		Last Available: "2015-12"
 8717	denatured lime green abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	delicious maroon VYKEA meatballs	3	awesome	Last Available: "2015-11"
-8720	watered-down special acceptable VYKEA mead	2	good	Effect: "Ninja, Please", Effect Duration: 15, Last Available: "2015-11"
+8720	special watered-down acceptable VYKEA mead	2	good	Effect: "Ninja, Please", Effect Duration: 15, Last Available: "2015-11"
 8721	altered ionized VYKEA woadpaint	0		Effect: "Dirge of Dreadfulness", Effect Duration: 17, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,17 +8601,17 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	knitted ribald VYKEA hex key of the glutton	0		Sleaze Damage: +10, Cold Resistance: +3, Food Drop: +100, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	spoiled tin of submardines	4	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	delicious irresponsibly strong bottle of norwhiskey	6	awesome	Last Available: "2015-11"
+8731	spoiled tin of submardines	4	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	irresponsibly strong delicious bottle of norwhiskey	6	awesome	Last Available: "2015-11"
 8733	altered wobbly octolus oculus	1	decent	Last Available: "2015-11"
 8734	blurry shellacked fortified sardine can key of terror	0		Damage Absorption: +60, Damage Reduction: 7, Spooky Spell Damage: +10, Last Available: "2015-11"
-8735	Usain Bolt's norwhal helmet of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP: +100, Initiative: +80, Familiar Effect: "atk", Last Available: "2015-11"
+8735	Usain Bolt's norwhal helmet of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP: +100, Initiative: +80, Last Available: "2015-11", Familiar Effect: "atk"
 8736	censurious grievous wizardly octolus-skin cloak	0		Mysticality: +25, Weapon Damage Percent: +50, Sleaze Resistance: +3, Last Available: "2015-11"
 8737	bad perfect cosmopolitan	4	decent	Last Available: "2015-11"
 8738	artisanal ghostly perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	mediocre weak skewed perfect dark and stormy	2	decent	Last Available: "2015-11"
+8739	weak mediocre skewed perfect dark and stormy	2	decent	Last Available: "2015-11"
 8740	delicious maroon perfect mimosa	3	awesome	Last Available: "2015-11"
-8741	acceptable fancy fuchsia perfect old-fashioned	4	good	Effect: "Artificially Sweet", Effect Duration: 30, Last Available: "2015-11"
+8741	fancy acceptable fuchsia perfect old-fashioned	4	good	Effect: "Artificially Sweet", Effect Duration: 30, Last Available: "2015-11"
 8742	tolerable spirit-forward perfect paloma	5	good	Last Available: "2015-11"
 8743	triple-magnetized That 70s Cologne	0		Effect: "Superveiny 9000", Effect Duration: 37, Last Available: "2015-11"
 8744	anodized denatured improved spinning Wal-Mart &quot;diamond&quot; ring	0		Effect: "Human-Pirate Hybrid", Effect Duration: 30, Last Available: "2015-11"
@@ -8640,7 +8640,7 @@
 8767	red narrow Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
-8770	quantum tumbling cyan pitted sheet	0		Effect: "A View to Some Meat", Effect Duration: 29, Last Available: "2015-12"
+8770	quantum cyan tumbling pitted sheet	0		Effect: "A View to Some Meat", Effect Duration: 29, Last Available: "2015-12"
 8771	mirror purple sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	miser's reusable shopping bag of Tarzan of the detective	0		Experience (Muscle): +3, Item Drop: +20, Meat Drop: +10, Last Available: "2015-12"
@@ -8661,7 +8661,7 @@
 8789	book	0		Last Available: "2015-12"
 8790	avaricious elven tambourine	0		Meat Drop: +30, Last Available: "2015-12"
 8791	reindeer sickle of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2015-12"
-8792	purple mirror face paint	0		Free Pull, Last Available: "2015-12"
+8792	mirror purple face paint	0		Free Pull, Last Available: "2015-12"
 8793	face paint	0		Free Pull, Last Available: "2015-12"
 8794	spinning The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	bouncing Batfellow comic	0		Free Pull, Last Available: "2016-12"
@@ -8695,21 +8695,21 @@
 8823	adequate Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	crafty hardy The Jokester's gun	0		Maximum HP: +50, Maximum MP: +10, Item Drop: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	gravedigger's healthy The Jokester's wig of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Spooky Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8826	gravedigger's healthy The Jokester's wig of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Spooky Damage: +10, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	red avaricious rosewater-soaked stanky The Jokester's pants	0		Stench Spell Damage: +25, Stench Resistance: +3, Meat Drop: +30, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	pressed nitrogenated cyan Jokester makeup	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 25, Last Available: "2016-12"
 8829	blinking replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
-8831	purple shaking basking robin	0		Free Pull, Last Available: "2016-12"
+8831	shaking purple basking robin	0		Free Pull, Last Available: "2016-12"
 8832	shaking domino mask	0		Familiar Weight: +5
 8833	double-polarized robin's egg	0		Effect: "Pharmaceutically Cool", Effect Duration: 49, Last Available: "2016-12"
-8834	yummy enchanted robin flan	4	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2016-12"
+8834	enchanted yummy robin flan	4	awesome	Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2016-12"
 8835	artisanal robin nog	3	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	jittery plaintive telegram	0		Last Available: "2016-02"
 8838	narrow exploding gum	0		
-8839	shaking cyan root beer barrel	0		
-8840	activated quadruple-frozen galvanized squat blue Kudzu slaw	0		Effect: "Wintry Breath", Effect Duration: 50
+8839	cyan shaking root beer barrel	0		
+8840	activated quadruple-frozen galvanized blue squat Kudzu slaw	0		Effect: "Wintry Breath", Effect Duration: 50
 8841	oxidized cold-filtered skewed Mansquito's blood	0		Effect: "Pyramid Power", Effect Duration: 37
 8842	galvanized wet maroon infrablack lipstick	0		Effect: "Spookypants", Effect Duration: 20
 8843	altered can of drain cleaner	0		Effect: "Arse-a'fire", Effect Duration: 44
@@ -8718,7 +8718,7 @@
 8846	oxidized quantum tube of pendulum lube	0		Effect: "Man's Worst Enemy", Effect Duration: 66
 8847	frozen red-hot jawbreaker	0		Effect: "Eye of the Seal", Effect Duration: 17
 8848	ionized pressed question juice	0		Effect: "Updated", Effect Duration: 41
-8849	denatured blue twirling tube of villain	0		Effect: "Mushroom Might", Effect Duration: 42
+8849	denatured twirling blue tube of villain	0		Effect: "Mushroom Might", Effect Duration: 42
 8850	yellow Socratic your cowboy boots	0		Experience (Mysticality): +1, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
@@ -8746,20 +8746,20 @@
 8874	lime green asbestos-lined scorching Val-U Brand Every Bean Salad of Leguizamo of the scaredy-cat of temperance	0		Monster Level: 5, Hot Damage: +25, Hot Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-02"
 8875	maroon knitted Shrub's Premium Baked Beans of wisdom of the blizzard	0		Mysticality: +15, Cold Spell Damage: +25, Cold Resistance: +3, Last Available: "2016-02"
 8876	spoiled small plate of Heimz Fortified Kidney Beans	2	crappy	Last Available: "2016-02"
-8877	rotten fancy tiny fuchsia plate of Tesla's Electroplated Beans	1	crappy	Effect: "Gummiheart", Effect Duration: 15, Last Available: "2016-02"
+8877	fancy tiny rotten fuchsia plate of Tesla's Electroplated Beans	1	crappy	Effect: "Gummiheart", Effect Duration: 15, Last Available: "2016-02"
 8878	rotten plate of Mixed Garbanzos and Chickpeas	3	crappy	Last Available: "2016-02"
-8879	snack-sized flavorless plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
-8880	normal snack-sized plate of Frigid Northern Beans	2	good	Last Available: "2016-02"
+8879	flavorless snack-sized plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
+8880	snack-sized normal plate of Frigid Northern Beans	2	good	Last Available: "2016-02"
 8881	flavorless blurry skewed plate of World's Blackest-Eyed Peas	3	decent	Last Available: "2016-02"
 8882	super-sized moldy fancy plate of Trader Olaf's Exotic Stinkbeans	5	crappy	Effect: "[1609]Dancin' Fool", Effect Duration: 45, Last Available: "2016-02"
-8883	tiny fancy flavorless plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Superhuman Sarcasm", Effect Duration: 10, Last Available: "2016-02"
+8883	flavorless fancy tiny plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Superhuman Sarcasm", Effect Duration: 10, Last Available: "2016-02"
 8884	rotten tiny plate of Val-U Brand Every Bean Salad	1	crappy	Last Available: "2016-02"
 8885	tasty plate of Shrub's Premium Baked Beans	4	awesome	Last Available: "2016-02"
 8886	green scorching steel-toed Fancy Jeff's pocket square	0		Damage Reduction: 9, Hot Damage: +25, Last Available: "2016-02"
-8887	fortified Daisy's unclean bloomers of dire peril of chilblains	0		Weapon Damage: +20, Damage Absorption: +60, Cold Damage: +25, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	fortified Daisy's unclean bloomers of dire peril of chilblains	0		Weapon Damage: +20, Damage Absorption: +60, Cold Damage: +25, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	zippy gravedigger's careful Amoon-Ra Cowtep's nemes	0		Monster Level: -10, Spooky Damage: +10, Initiative: +20, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
-8890	skewed blinking Glenn's dice	0		Last Available: "2016-02"
+8889	zippy gravedigger's careful Amoon-Ra Cowtep's nemes	0		Monster Level: -10, Spooky Damage: +10, Initiative: +20, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8890	blinking skewed Glenn's dice	0		Last Available: "2016-02"
 8891	lightning-fast knitted padded groovy Former Sheriff Dan's tin star of wisdom	0		Mysticality: +15, Moxie Percent: +10, Damage Absorption: +20, Cold Resistance: +3, Initiative: +40, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
@@ -8781,7 +8781,7 @@
 8909	jumbo bland rotting beefsteak	5	decent	Last Available: "2016-02"
 8910	perfectly mixed high-proof spinning jittery firemilk	7	EPIC	Last Available: "2016-02"
 8911	oxidized jittery spidercow eye-cluster	0		Effect: "Amorous", Effect Duration: 56, Last Available: "2016-02"
-8912	diluted gray tumbling moomy dust	1		Last Available: "2016-02"
+8912	diluted tumbling gray moomy dust	1		Last Available: "2016-02"
 8913	huge gray nippy Rosewater's western-style skinning knife	0		Mysticality Percent: +30, Cold Damage: +10, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	Usain Bolt's steel knuckles	0		Initiative: +80, Last Available: "2016-02"
@@ -8802,13 +8802,13 @@
 8930	ionized flattened demonic cow's blood	0		Effect: "Sugar High", Effect Duration: 53, Last Available: "2016-02"
 8931	yellow rinky-dink sixgun	0		Last Available: "2016-02"
 8932	makeshift sixgun	0		Last Available: "2016-02"
-8933	lime green mirror custom sixgun	0		Last Available: "2016-02"
+8933	mirror lime green custom sixgun	0		Last Available: "2016-02"
 8934	green baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	blinking mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
-8939	shaking wobbly diamondback skin	0		Last Available: "2016-02"
+8939	wobbly shaking diamondback skin	0		Last Available: "2016-02"
 8940	blurry coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	red narrow rotting cowskin	0		Last Available: "2016-02"
@@ -8826,7 +8826,7 @@
 8954	narrow special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	twirling Tales of the West: Cow Punching	0		
 8956	squat Tales of the West: Beanslinging	0		
-8957	gray jittery Tales of the West: Snake Oiling	0		
+8957	jittery gray Tales of the West: Snake Oiling	0		
 8958	briefcase full of snakes	0		
 8959	clever one-gallon hat	0		Maximum MP: +20, Item Drop: +5
 8960	scandalous forbidden two-gallon hat	0		Spell Damage Percent: +50, Sleaze Damage: +5
@@ -8843,14 +8843,14 @@
 8971	upside-down snake oil	0		
 8972	deionized purple skin oil	0		Effect: "Dreadful Sheen", Effect Duration: 41
 8973	liquefied polarized shaking unusual oil	0		Effect: "Bilious Briskness", Effect Duration: 68
-8974	diffused chilled shaking fuchsia eldritch oil	0		Effect: "Bananas!", Effect Duration: 51
+8974	diffused chilled fuchsia shaking eldritch oil	0		Effect: "Bananas!", Effect Duration: 51
 8975	fuchsia exclusive club	0		
 8976	ionized narrow fuchsia patent preventative tonic	0		Effect: "Papowerful", Effect Duration: 36
 8977	modified vacuum-sealed patent invisibility tonic	0		Effect: "Pumped Stomach", Effect Duration: 68
 8978	quadruple-colloidal upside-down patent aggression tonic	0		Effect: "Superioreo", Effect Duration: 50
 8979	polymerized enhanced nitrogenated twirling squat patent sallowness tonic	0		Effect: "Sourpuss", Effect Duration: 59
 8980	irradiated enhanced mirror skewed patent avarice tonic	0		Effect: "Hairy Palms", Effect Duration: 43
-8981	deionized deionized bouncing tumbling patent alacrity tonic	0		Effect: "Trash-Wrapped", Effect Duration: 47
+8981	deionized deionized tumbling bouncing patent alacrity tonic	0		Effect: "Trash-Wrapped", Effect Duration: 47
 8982	enhanced non-chilled corrupted marrow	0		Effect: "OMG WTF", Effect Duration: 20
 8983	practically non-alcoholic lousy rodeo whiskey	1	decent	
 8984	blue Thwaitgold scorpion statuette	0		
@@ -8862,17 +8862,17 @@
 8990	red electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	altered armored prawn	1		Last Available: "2016-03"
-8993	stale half-sized jumping horseradish	2	decent	Last Available: "2016-03"
-8994	practically non-alcoholic lousy blinking Sacramento wine	1	decent	Last Available: "2016-03"
+8993	half-sized stale jumping horseradish	2	decent	Last Available: "2016-03"
+8994	lousy practically non-alcoholic blinking Sacramento wine	1	decent	Last Available: "2016-03"
 8995	moist triple-dry wobbly Greek fire	0		Effect: "Prince of Seaside Town", Effect Duration: 19, Last Available: "2016-03"
 8996	greedy lion tamer's coward's padded ox-head shield of the scaredy-cat	0		Damage Absorption: +20, Monster Level: -35, Experience (familiar): +2, Meat Drop: +20, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	electrified baleful groovy stylish dented scepter	0		Moxie: +25, Moxie Percent: +10, Spell Damage: +25, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	greedy manspreader's Tesla forbidden smartaleck's very pointy crown	0		Moxie Percent: +30, Spell Damage Percent: +50, Monster Level: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	greedy manspreader's Tesla forbidden smartaleck's very pointy crown	0		Moxie Percent: +30, Spell Damage Percent: +50, Monster Level: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	greasy MacGyver's quilted arcane researcher's battle broom of the early riser	0		Experience Percent (Mysticality): +10, Damage Absorption: +40, Maximum MP: +100, Sleaze Spell Damage: +10, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	wool stiffened savvy carpe of Flo-Jo	0		Mysticality Percent: +20, Damage Reduction: 1, Cold Resistance: +1, Initiative: +100, Lasts Until Rollover, Last Available: "2016-04"
 9002	prompt avaricious censurious mansplainer's codpiece	0		Monster Level: +15, Sleaze Resistance: +3, Meat Drop: +30, Adventures: +3, Lasts Until Rollover, Last Available: "2016-04"
-9003	green Jeselnik's frightening Van der Graaf troutsers of doom	0		Spooky Damage: +5, Spooky Spell Damage: +50, Sleaze Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	green Jeselnik's frightening Van der Graaf troutsers of doom	0		Spooky Damage: +5, Spooky Spell Damage: +50, Sleaze Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	greedy medical-grade slick bass clarinet of chilblains	0		Moxie: +10, Cold Damage: +25, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9005	rosewater-soaked therapeutic Fonzie's experienced fish hatchet	0		Experience: +2, Experience (Moxie): +1, Stench Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
 9006	purple nippy smartaleck's savvy tunac of bravery	0		Mysticality Percent: +20, Moxie Percent: +30, Cold Damage: +10, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	cyan meme generator	0		Last Available: "2016-05"
 9020	upside-down plus one	0		Last Available: "2016-05"
-9021	moldy spinning maroon gallon of milk	3	crappy	Last Available: "2016-05"
+9021	moldy maroon spinning gallon of milk	3	crappy	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	squat screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8901,18 +8901,18 @@
 9029	jittery no spoon	0		
 9030	bland star salad	3	decent	
 9031	Thwaitgold moth statuette	0		
-9032	decent tiny bowl of Tastee-Wheet&trade;	1	good	
+9032	tiny decent bowl of Tastee-Wheet&trade;	1	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	miniature normal browser cookie	2	good	Last Available: "2016-06"
-9036	weak mediocre hacked gibson	2	decent	Last Available: "2016-06"
+9036	mediocre weak hacked gibson	2	decent	Last Available: "2016-06"
 9037	Source shades of the sewer	0		Stench Damage: +25, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	ghostly missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	Source terminal SPAM chip	0		Last Available: "2016-06"
-9043	jittery huge Source terminal CRAM chip	0		Last Available: "2016-06"
+9043	huge jittery Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	ghostly Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	spinning Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	Source terminal INGRAM chip	0		Last Available: "2016-06"
@@ -8929,7 +8929,7 @@
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
-9060	mirror ghostly shaking Source terminal file: familiar.ext	0		Last Available: "2016-06"
+9060	ghostly mirror shaking Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	bouncing Source terminal file: spam.ext	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	gray extremely unsafe Mr. Screege's spectacles	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2016-08"
 9092	blurry fortified grievous Herculean Spookyraven signet	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Damage Absorption: +60, Single Equip, Last Available: "2016-08"
 9093	shaking slick tie-dyed fannypack of the wise owl	0		Mysticality: +20, Moxie: +10, Single Equip, Last Available: "2016-08"
-9094	reassuring nasty burnt snowpants	0		Stench Damage: +5, Spooky Resistance: +1, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	reassuring nasty burnt snowpants	0		Stench Damage: +5, Spooky Resistance: +1, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	energetic standards and practices guide	0		Maximum MP Percent: +20, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	blinking huge lightning-fast sizzling smooth Carpathian longsword	0		Moxie: +15, Hot Damage: +10, Initiative: +40, Last Available: "2016-08"
 9097	careful dangerous Liam's mail of James Dean	0		Experience (Moxie): +3, Weapon Damage: +10, Monster Level: -10, Last Available: "2016-08"
@@ -8988,7 +8988,7 @@
 9116	upside-down time residue	0		Last Available: "2016-09"
 9117	bouncing gravedigger's repaid diaper	0		Spooky Damage: +10
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	tolerable strong Shot of Kardashian Gin	5	good	Last Available: "2016-09"
+9119	strong tolerable Shot of Kardashian Gin	5	good	Last Available: "2016-09"
 9120	energetic Unstable Pointy Ears	0		Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
@@ -9007,27 +9007,27 @@
 9135	acceptable skewed huge very whiskey	4	good	
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	pulsating li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	narrow li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	pulsating li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	narrow li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	enhanced hoarded candy wad	0		Effect: "Oily Flavor", Effect Duration: 11, Last Available: "2016-10"
 9147	modified Prunets	0		Effect: "Riboflavin'", Effect Duration: 44
 9148	Twitching Television Tattoo	0		
 9149	teal baby scorpion	0		Familiar Weight: +10
 9150	polymerized invisible string	0		Lasts Until Rollover, Effect: "Celestial Sheen", Effect Duration: 12, Last Available: "2016-10"
 9151	nitrogenated quadruple-ionized deionized twirling invisible seam ripper	0		Lasts Until Rollover, Effect: "Broken Fast", Effect Duration: 58, Last Available: "2016-10"
-9152	twirling li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	twirling li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	normal raw sweet potato	3	good	Last Available: "2016-11"
 9154	moldy olive raw beans	4	crappy	Last Available: "2016-11"
 9155	moldy raw stuffing	4	crappy	Last Available: "2016-11"
 9156	bland shaking raw cranberry sauce	4	decent	Last Available: "2016-11"
 9157	normal raw turkey	4	good	Last Available: "2016-11"
-9158	fancy delicious bite-sized raw mincemeat	1	awesome	Effect: "Liquid Courage", Effect Duration: 20, Last Available: "2016-11"
+9158	bite-sized fancy delicious raw mincemeat	1	awesome	Effect: "Liquid Courage", Effect Duration: 20, Last Available: "2016-11"
 9159	yummy half-sized raw potato	2	awesome	Last Available: "2016-11"
 9160	stale red raw gravy	3	decent	Last Available: "2016-11"
 9161	rotten raw bread	3	crappy	Last Available: "2016-11"
@@ -9045,30 +9045,30 @@
 9173	yummy baked stuffing	3	awesome	Last Available: "2016-11"
 9174	bland blue cranberry cylinder	3	decent	Last Available: "2016-11"
 9175	toothsome green thanksgiving turkey	3	awesome	Last Available: "2016-11"
-9176	huge fancy yummy mince pie	7	awesome	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2016-11"
-9177	rotten big mashed potatoes	5	crappy	Last Available: "2016-11"
+9176	huge yummy fancy mince pie	7	awesome	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2016-11"
+9177	big rotten mashed potatoes	5	crappy	Last Available: "2016-11"
 9178	stale warm gravy	3	decent	Last Available: "2016-11"
-9179	huge yummy bread roll	9	awesome	Last Available: "2016-11"
-9180	adequate pulsating upside-down leftovers	3	good	Last Available: "2016-11"
+9179	yummy huge bread roll	9	awesome	Last Available: "2016-11"
+9180	adequate upside-down pulsating leftovers	3	good	Last Available: "2016-11"
 9181	jumbo tasty leftovers sandwich	5	awesome	Last Available: "2016-11"
 9182	ghostly Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	spinning cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
-9185	huge red pulsating pilgrim hat	0		Last Available: "2016-11"
+9185	red huge pulsating pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	shaking olive cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	ionized ghostly eldritch concentrate	0		Effect: "items.enh", Effect Duration: 37, Last Available: "2016-11"
-9192	spirit-forward mediocre eldritch extract	5	decent	Last Available: "2016-11"
+9192	mediocre spirit-forward eldritch extract	5	decent	Last Available: "2016-11"
 9193	frightening Da Vinci's Official Council Aide Pin	0		Experience (Mysticality): +5, Spooky Damage: +5, Last Available: "2016-11"
 9194	weak hand-crafted eldritch distillate	2	EPIC	Last Available: "2016-11"
 9195	twisted upside-down eldritch essence	1		Last Available: "2016-11"
 9196	healthy Science Notebook	0		Maximum HP Percent: +20
 9197	tumbling wool banded deadly eldritch hat	0		Weapon Damage: +5, Damage Absorption: +100, Cold Resistance: +1, Last Available: "2016-11"
 9198	weightlifter's eldritch pants of the pedagogue of the dark arts	0		Muscle: +15, Experience: +3, Spell Damage Percent: +100, Last Available: "2016-11"
-9199	watered-down lousy eldritch elixir	2	decent	Last Available: "2016-11"
+9199	lousy watered-down eldritch elixir	2	decent	Last Available: "2016-11"
 9200	fuchsia curative sinister Quartet of Flare Masters Jacket	0		Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	ghostly Adventurer's Kit	0		
@@ -9121,12 +9121,12 @@
 9249	triple-ionized liquefied shaking Inner Wisdom	0		Effect: "Stench Jellied", Effect Duration: 39, Last Available: "2016-12"
 9250	quadruple-oxidized Inner Strength	0		Effect: "Spooky Weapon", Effect Duration: 30, Last Available: "2016-12"
 9251	double-oxidized polymerized super-aerosolized narrow Inner Truth	0		Effect: "Pumped Up", Effect Duration: 45, Last Available: "2016-12"
-9252	gigantic rotten spiritual candy cane	9	crappy	Last Available: "2016-12"
+9252	rotten gigantic spiritual candy cane	9	crappy	Last Available: "2016-12"
 9253	hand-crafted spiritual eggnog	3	EPIC	Last Available: "2016-12"
-9254	special rotten spiritual fruitcake	4	crappy	Effect: "Sappy Blood", Effect Duration: 40, Last Available: "2016-12"
-9255	stale enchanted ghostly spiritual gingerbread	3	decent	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2016-12"
+9254	rotten special spiritual fruitcake	4	crappy	Effect: "Sappy Blood", Effect Duration: 40, Last Available: "2016-12"
+9255	enchanted stale ghostly spiritual gingerbread	3	decent	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
-9257	red narrow chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
+9257	narrow red chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	mirror My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	yellow Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	huge No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
@@ -9134,7 +9134,7 @@
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	bouncing briefcase full of sprinkles	0		Last Available: "2016-12"
-9265	pulsating green teethpick	0		Last Available: "2016-12"
+9265	green pulsating teethpick	0		Last Available: "2016-12"
 9266	warmed rock candy	0		Effect: "Turkey-Ambitious", Effect Duration: 46, Last Available: "2016-12"
 9267	miniature rotten wobbly green-iced sweet roll	2	crappy	Last Available: "2016-12"
 9268	mirror sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
@@ -9145,7 +9145,7 @@
 9273	MacGyver's cool Third Eye	0		Moxie: +5, Maximum MP: +100, Last Available: "2016-12"
 9274	narrow huge Sinatra's stylish Krampus Horn	0		Moxie: +25, Experience (Moxie): +5, Single Equip, Last Available: "2016-12"
 9275	tasty hambrosier	3	awesome	Last Available: "2016-12"
-9276	artisanal strong enchanted chakra-mental wine	5	EPIC	Effect: "Ooh, Sweet!", Effect Duration: 30, Last Available: "2016-12"
+9276	strong artisanal enchanted chakra-mental wine	5	EPIC	Effect: "Ooh, Sweet!", Effect Duration: 30, Last Available: "2016-12"
 9277	quadruple-pickled diffused chakra malt	0		Effect: "[800]Chocolate Reign", Effect Duration: 12, Last Available: "2016-12"
 9278	flavorless bouncing Black Angus blackburger	4	decent	Last Available: "2016-12"
 9279	watered-down mediocre brandy	2	decent	Last Available: "2016-12"
@@ -9166,11 +9166,11 @@
 9294	denatured purple sleaze jelly	1		Last Available: "2017-01"
 9295	altered stench jelly	1		Effect: "No Vertigo", Effect Duration: 40, Last Available: "2017-01"
 9296	blurry space planula	0		Free Pull, Last Available: "2017-01"
-9297	moldy special upside-down toast with hot jelly	3	crappy	Effect: "Phairly Pheromonal", Effect Duration: 15, Last Available: "2017-01"
+9297	special moldy upside-down toast with hot jelly	3	crappy	Effect: "Phairly Pheromonal", Effect Duration: 15, Last Available: "2017-01"
 9298	yummy toast with jelly	3	awesome	Last Available: "2017-01"
 9299	normal jumbo toast with jelly	5	good	Last Available: "2017-01"
 9300	yummy toast with sleaze jelly	4	awesome	Last Available: "2017-01"
-9301	decent special toast with stench jelly	3	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 20, Last Available: "2017-01"
+9301	special decent toast with stench jelly	3	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 20, Last Available: "2017-01"
 9302	teal space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9180,15 +9180,15 @@
 9308	squat Herculean wax face of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Last Available: "2017-01"
 9309	drinkable cyan wax booze	3	good	Last Available: "2017-01"
 9310	blurry glob of melted wax	0		Last Available: "2017-01"
-9311	mixed blinking teal sea jelly	1		Last Available: "2017-01"
+9311	mixed teal blinking sea jelly	1		Last Available: "2017-01"
 9312	spoiled sea truffle	4	crappy	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	rock-hard recovered cufflinks	0		Damage Reduction: 5, Single Equip, Last Available: "2017-01"
 9316	squat heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	deionized dry LOV Elixir #3	0		Effect: "Quadrilled", Effect Duration: 69, Last Available: "2017-02"
-9318	tarnished aerosolized colloidal pulsating gray LOV Elixir #6	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 25, Last Available: "2017-02"
-9319	electrified huge lime green LOV Elixir #9	0		Effect: "Can't Smell Nothin'", Effect Duration: 21, Last Available: "2017-02"
+9318	tarnished aerosolized colloidal gray pulsating LOV Elixir #6	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 25, Last Available: "2017-02"
+9319	electrified lime green huge LOV Elixir #9	0		Effect: "Can't Smell Nothin'", Effect Duration: 21, Last Available: "2017-02"
 9320	huge aromatic resourceful LOV Eardigan of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +50, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2017-02"
 9321	avaricious curative experienced LOV Epaulettes	0		Experience: +2, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2017-02"
 9322	scandalous chilly LOV Earrings of the cougar	0		Moxie: +20, Cold Damage: +5, Sleaze Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
@@ -9232,25 +9232,25 @@
 9360	pulsating fish head	0		Last Available: "2017-03"
 9361	upside-down limepatch	0		Last Available: "2017-03"
 9362	pile of dirt	0		Last Available: "2017-03"
-9363	pulsating fuchsia slime shooter	0		Last Available: "2017-03"
+9363	fuchsia pulsating slime shooter	0		Last Available: "2017-03"
 9364	skewed imaginary lemon	0		Last Available: "2017-03"
 9365	drinkable blue literal grasshopper	4	good	Last Available: "2017-03"
 9366	artisanal huge double entendre	3	EPIC	Last Available: "2017-03"
-9367	watered-down mediocre wobbly Phlegethon	2	decent	Last Available: "2017-03"
+9367	mediocre watered-down wobbly Phlegethon	2	decent	Last Available: "2017-03"
 9368	bad jittery Siberian sunrise	4	decent	Last Available: "2017-03"
 9369	practically non-alcoholic bad teal mentholated wine	1	decent	Last Available: "2017-03"
 9370	drinkable low tide martini	4	good	Last Available: "2017-03"
-9371	irresponsibly strong mediocre shroomtini	10	decent	Last Available: "2017-03"
+9371	mediocre irresponsibly strong shroomtini	10	decent	Last Available: "2017-03"
 9372	fancy hand-crafted bouncing morning dew	4	EPIC	Effect: "Comic Violence", Effect Duration: 25, Last Available: "2017-03"
 9373	artisanal practically non-alcoholic whiskey squeeze	1	EPIC	Last Available: "2017-03"
-9374	artisanal strong jittery great fashioned	5	EPIC	Last Available: "2017-03"
-9375	aged spirit-forward Gnomish sagngria	5	awesome	Last Available: "2017-03"
+9374	strong artisanal jittery great fashioned	5	EPIC	Last Available: "2017-03"
+9375	spirit-forward aged Gnomish sagngria	5	awesome	Last Available: "2017-03"
 9376	bad practically non-alcoholic squat vodka stinger	1	decent	Last Available: "2017-03"
 9377	hand-crafted extremely slippery nipple	4	EPIC	Last Available: "2017-03"
 9378	hand-crafted piscatini	3	EPIC	Last Available: "2017-03"
 9379	watered-down acceptable Churchill	2	good	Last Available: "2017-03"
-9380	practically non-alcoholic acceptable squat soilzerac	1	good	Last Available: "2017-03"
-9381	tolerable weak London frog	2	good	Last Available: "2017-03"
+9380	acceptable practically non-alcoholic squat soilzerac	1	good	Last Available: "2017-03"
+9381	weak tolerable London frog	2	good	Last Available: "2017-03"
 9382	practically non-alcoholic aged nothingtini	1	awesome	Last Available: "2017-03"
 9383	distilled lousy wobbly eighth plague	5	decent	Last Available: "2017-03"
 9384	extra-dry hand-crafted tumbling single entendre	5	EPIC	Last Available: "2017-03"
@@ -9262,13 +9262,13 @@
 9390	hand-crafted boozy hell in a bucket	5	EPIC	Last Available: "2017-03"
 9391	bad Newark	4	decent	Last Available: "2017-03"
 9392	artisanal R'lyeh	4	EPIC	Last Available: "2017-03"
-9393	acceptable high-proof Gnollish sangria	9	good	Last Available: "2017-03"
-9394	drinkable special vodka barracuda	3	good	Effect: "Slippery Tongue", Effect Duration: 45, Last Available: "2017-03"
+9393	high-proof acceptable Gnollish sangria	9	good	Last Available: "2017-03"
+9394	special drinkable vodka barracuda	3	good	Effect: "Slippery Tongue", Effect Duration: 45, Last Available: "2017-03"
 9395	practically non-alcoholic drinkable Mysterious Island iced tea	1	good	Last Available: "2017-03"
 9396	drinkable drive-by shooting	4	good	Last Available: "2017-03"
-9397	mediocre practically non-alcoholic blurry gunner's daughter	1	decent	Last Available: "2017-03"
+9397	practically non-alcoholic mediocre blurry gunner's daughter	1	decent	Last Available: "2017-03"
 9398	bad watered-down cyan dirt julep	2	decent	Last Available: "2017-03"
-9399	boozy bad Simepore slime	5	decent	Last Available: "2017-03"
+9399	bad boozy Simepore slime	5	decent	Last Available: "2017-03"
 9400	practically non-alcoholic acceptable shaking Phil Collins	1	good	Last Available: "2017-03"
 9401	spinning unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9284,11 +9284,11 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	rotten bite-sized mirror edible alien plant bit	1	crappy	Last Available: "2017-04"
+9415	bite-sized rotten mirror edible alien plant bit	1	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	huge complex alien plant sample	0		Last Available: "2017-04"
-9419	skewed ghostly fascinating alien plant sample	0		Last Available: "2017-04"
+9419	ghostly skewed fascinating alien plant sample	0		Last Available: "2017-04"
 9420	dehydrated alien plant goo	1		Effect: "Human-Constellation Hybrid", Effect Duration: 20, Last Available: "2017-04"
 9421	purple alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9335,9 +9335,9 @@
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	cyan Spacegate	0		Last Available: "2017-04"
-9466	flavorless diet gray blinking Aldebaran sardines	1	decent	Last Available: "2017-04"
-9467	lousy weak Centauri fish wine	2	decent	Last Available: "2017-04"
-9468	dried skewed blinking oxygen	1		Effect: "Ooh, Sour!", Effect Duration: 50, Last Available: "2017-04"
+9466	flavorless diet blinking gray Aldebaran sardines	1	decent	Last Available: "2017-04"
+9467	weak lousy Centauri fish wine	2	decent	Last Available: "2017-04"
+9468	dried blinking skewed oxygen	1		Effect: "Ooh, Sour!", Effect Duration: 50, Last Available: "2017-04"
 9469	miser's Sherlock's Spacegate scientist's insignia	0		Item Drop: +25, Meat Drop: +10, Single Equip, Last Available: "2017-04"
 9470	executive double-paned Spacegate military insignia	0		Cold Resistance: +5, Meat Drop: +40, Single Equip, Last Available: "2017-04"
 9471	gravedigger's smartaleck's Spacegate diplomat's insignia of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Spooky Damage: +10, Single Equip, Last Available: "2017-04"
@@ -9355,7 +9355,7 @@
 9483	irradiated adjusted upside-down Daily Affirmation: Be a Mind Master	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 39, Last Available: "2017-05"
 9484	ionized warmed adjusted Daily Affirmation: Work For Hours a Week	0		Effect: "Takin' It Greasy", Effect Duration: 65, Last Available: "2017-05"
 9485	extra-nitrogenated Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Brain Freeze", Effect Duration: 55, Last Available: "2017-05"
-9486	stale fancy Affirmation Cookie	4	decent	Effect: "Stenchtastic", Effect Duration: 5, Last Available: "2017-05"
+9486	fancy stale Affirmation Cookie	4	decent	Effect: "Stenchtastic", Effect Duration: 5, Last Available: "2017-05"
 9487	blinking License To Kill	0		
 9488	squat Thwaitgold bug statuette	0		
 9489	maroon Victor's Spoils	0		
@@ -9363,13 +9363,13 @@
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	chaotic veiny Kremlin's Greatest Briefcase of the ox	0		Muscle: +20, Maximum HP: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	smooth watered-down spinning basic martini	2	awesome	Last Available: "2017-06"
+9494	watered-down smooth spinning basic martini	2	awesome	Last Available: "2017-06"
 9495	acceptable improved martini	3	good	Last Available: "2017-06"
 9496	aged splendid martini	3	awesome	Last Available: "2017-06"
 9497	squat exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	jittery tattoo gun	0		Last Available: "2017-06"
-9500	pulsating mirror narrow gun	0		Free Pull, Last Available: "2017-06"
+9500	narrow mirror pulsating gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	green ribald therapeutic quilted plastic gundam	0		Damage Absorption: +40, Sleaze Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-06"
 9503	twirling License to Chill	0		Last Available: "2017-07"
@@ -9384,11 +9384,11 @@
 9512	blurry Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	stale meteoreo	3	decent	Last Available: "2017-08"
-9515	artisanal special meadeorite	4	EPIC	Effect: "Serendipi Tea", Effect Duration: 45, Last Available: "2017-08"
+9515	special artisanal meadeorite	4	EPIC	Effect: "Serendipi Tea", Effect Duration: 45, Last Available: "2017-08"
 9516	jittery meteoroid	0		Last Available: "2017-08"
 9517	frosty meteortarboard of incineration of courage	0		Cold Spell Damage: +10, Hot Spell Damage: +50, Spooky Resistance: +3, Last Available: "2017-08"
 9518	avaricious wicked cool meteorite guard	0		Moxie: +5, Spell Damage: +5, Meat Drop: +30, Damage Reduction: 9, Last Available: "2017-08"
-9519	stiffened meteorb of James Dean	0		Experience (Moxie): +3, Damage Reduction: 1, Lantern Element: "Hot", Last Available: "2017-08"
+9519	stiffened meteorb of James Dean	0		Experience (Moxie): +3, Damage Reduction: 1, Last Available: "2017-08", Lantern Element: "Hot"
 9520	blinking ribald medical-grade asteroid belt	0		Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-08"
 9521	Jeselnik's smooth meteorthopedic shoes of Calamity Jane	0		Moxie: +15, Critical Hit Percent: +15, Sleaze Damage: +25, Single Equip, Last Available: "2017-08"
 9522	purple tumbling coward's shooting morning star of the pedagogue of the glutton	0		Experience: +3, Monster Level: -20, Food Drop: +100, Single Equip, Last Available: "2017-08"
@@ -9402,10 +9402,10 @@
 9530	hardened razor-sharp blessed rustproof +2 gray dragon scale mail of the detective	0		Weapon Damage Percent: +25, Damage Reduction: 3, Item Drop: +20, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	pony: Shutterfly	0		Last Available: "2017-09"
-9533	jittery fuchsia pony: Pearjack	0		Last Available: "2017-09"
+9533	fuchsia jittery pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
 9535	wobbly pony: Rosey Cake	0		Last Available: "2017-09"
-9536	shaking narrow pony: Spectrum Dash	0		Last Available: "2017-09"
+9536	narrow shaking pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	mirror pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
 9539	hunk of granite	0		
@@ -9413,19 +9413,19 @@
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
-9544	pulsating lime green O	0		Last Available: "2017-10"
+9544	lime green pulsating O	0		Last Available: "2017-10"
 9545	practically non-alcoholic mediocre DUFRESNE Suds	1	decent	Last Available: "2017-09"
 9546	grievous Da Vinci's mafia pinky ring	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Single Equip
 9547	tolerable bouncing flask of port	4	good	
 9548	toasty savvy contract enforcement stick	0		Mysticality Percent: +20, Hot Damage: +5
 9549	decent Hide-rox&trade; cookie	3	good	Last Available: "2017-10"
-9550	boozy delicious jug of booze	5	awesome	Last Available: "2017-10"
+9550	delicious boozy jug of booze	5	awesome	Last Available: "2017-10"
 9551	oxidized pair of candy glasses	0		Effect: "In the Saucestream", Effect Duration: 25, Last Available: "2017-10"
 9552	concentrated temporary X tattoos	0		Effect: "Mad at Science", Effect Duration: 39, Last Available: "2017-10"
-9553	modified blurry green glyph of athleticism	1		Last Available: "2017-10"
+9553	modified green blurry glyph of athleticism	1		Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	super-altered blurry new habit	0		Effect: "Items Are Forever", Effect Duration: 36, Last Available: "2017-10"
-9556	ghostly maroon bridge truss	0		Last Available: "2017-10"
+9556	maroon ghostly bridge truss	0		Last Available: "2017-10"
 9557	Usain Bolt's steel-toed pearl necklace of Flo-Jo	0		Damage Reduction: 9, Initiative: 180, Single Equip, Last Available: "2017-10"
 9558	spinning amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
@@ -9452,7 +9452,7 @@
 9580	ionized and cracker	0		Effect: "Tingly Biceps", Effect Duration: 48, Last Available: "2017-12"
 9581	aged triple-distilled huge neg grog	8	awesome	Last Available: "2017-12"
 9582	massive decent skewed half double fruitcake	10	good	Last Available: "2017-12"
-9583	decent snack-sized purple hushed puppy	2	good	Last Available: "2017-12"
+9583	snack-sized decent purple hushed puppy	2	good	Last Available: "2017-12"
 9584	adequate wobbly muffled muffuletta	3	good	Last Available: "2017-12"
 9585	normal shushed potatoes	3	good	Last Available: "2017-12"
 9586	shellacked plastic mime functionary	0		Damage Reduction: 7, Last Available: "2017-12"
@@ -9512,12 +9512,12 @@
 9640	jittery The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	yellow The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9642	The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9643	bouncing spinning The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
+9643	spinning bouncing The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	skewed The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	squat The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	upside-down mime eraser	0		Last Available: "2017-12"
-9648	weak lousy executive mime flask	2	decent	Last Available: "2017-12"
+9648	lousy weak executive mime flask	2	decent	Last Available: "2017-12"
 9649	bland half-sized nega-mushroom	2	decent	Last Available: "2017-12"
 9650	tolerable nega-mushroom wine	3	good	Last Available: "2017-12"
 9651	quantum denatured jittery Cheer-Up soda	0		Effect: "Turkey-Ambitious", Effect Duration: 44, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	mirror donated candy	0		
 9665	pickled corrupted digital honeypot	0		Effect: "Holiday Bliss", Effect Duration: 65, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	dog trainer's mime army insignia (infantry)	0		Experience (familiar): +1, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	spinning toasty mime army insignia (intelligence)	0		Hot Damage: +5, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	avaricious mime army insignia (espionage)	0		Meat Drop: +30, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	dog trainer's mime army insignia (infantry)	0		Experience (familiar): +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	spinning toasty mime army insignia (intelligence)	0		Hot Damage: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	avaricious mime army insignia (espionage)	0		Meat Drop: +30, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	jittery mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9550,8 +9550,8 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	flavorless bite-sized tumbling extra-toasted half sandwich	1	decent	Last Available: "2018-12"
-9682	perfectly mixed watered-down mulled hobo wine	2	EPIC	Last Available: "2018-12"
+9681	bite-sized flavorless tumbling extra-toasted half sandwich	1	decent	Last Available: "2018-12"
+9682	watered-down perfectly mixed mulled hobo wine	2	EPIC	Last Available: "2018-12"
 9683	ghostly burning newspaper	0		Last Available: "2018-12"
 9684	jittery Oprah's fortified Socratic burning paper hat	0		Experience (Mysticality): +1, Damage Absorption: +60, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2018-12"
 9685	bouncing ruddy wicked arcane researcher's burning cape	0		Experience Percent (Mysticality): +10, Spell Damage: +5, Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2018-12"
@@ -9594,7 +9594,7 @@
 9726	narrow Usain Bolt's gravedigger's psychic's amulet	0		Spooky Damage: +10, Initiative: +80, Last Available: "2018-02"
 9727	half-sized bland heart-shaped candy whetstone	2	decent	Last Available: "2018-02"
 9728	half-sized flavorless wobbly Swedish massage fish	2	decent	Last Available: "2018-02"
-9729	distilled tolerable Third Base	5	good	Last Available: "2018-02"
+9729	tolerable distilled Third Base	5	good	Last Available: "2018-02"
 9730	acceptable Bustle Hustler	4	good	Last Available: "2018-02"
 9731	double-alkaline Fabiotion	0		Effect: "Mint-Condition Breath", Effect Duration: 11, Last Available: "2018-02"
 9732	chilled tarnished blurry Bettie page	0		Effect: "Cool, Catlike", Effect Duration: 57, Last Available: "2018-02"
@@ -9611,7 +9611,7 @@
 9743	magnetized pressed rainbow jellybean	0		Effect: "Sugar, Hello", Effect Duration: 55
 9744	ionized mystery lollipop	0		Effect: "Brocolate Brostidigitation", Effect Duration: 29
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
-9746	frozen extra-polymerized blinking upside-down rhinestone	0		Effect: "Puzzle Fury", Effect Duration: 40
+9746	frozen extra-polymerized upside-down blinking rhinestone	0		Effect: "Puzzle Fury", Effect Duration: 40
 9747	1,960 pok&eacute;dollar bill	0		
 9748	purple metandienone	0		
 9749	jittery riboflavin	0		
@@ -9626,7 +9626,7 @@
 9758	Thwaitgold metabug statuette	0		
 9759	Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
 9760	packet of tall grass seeds	0		Last Available: "2018-03"
-9761	blinking green Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
+9761	green blinking Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	skewed Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
@@ -9662,7 +9662,7 @@
 9794	blurry Nursine	0		Last Available: "2018-03"
 9795	jittery mirror Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
-9797	twirling huge Caramel	0		Last Available: "2018-03"
+9797	huge twirling Caramel	0		Last Available: "2018-03"
 9798	yellow Oppossum	0		Last Available: "2018-03"
 9799	blue Amanitee	0		Last Available: "2018-03"
 9800	cyan Smashmoth	0		Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	dehydrated mirror magnificent oyster egg	1		Effect: "Mad at Science", Effect Duration: 10
 9829	dried gray brilliant oyster egg	1		
 9830	diluted glistening oyster egg	1		
-9831	twisted upside-down teal scintillating oyster egg	1		
+9831	twisted teal upside-down scintillating oyster egg	1		
 9832	diluted pearlescent oyster egg	1		
 9833	mixed lustrous oyster egg	1		Effect: "Brocolate Brostidigitation", Effect Duration: 50
 9834	compressed gleaming oyster egg	1		
@@ -9714,11 +9714,11 @@
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	twirling shaking Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	twirling LyleCo premium pickaxe	0		Last Available: "2018-04"
-9849	upside-down jittery LyleCo premium rope	0		Last Available: "2018-04"
+9849	jittery upside-down LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
-9852	skewed red faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
-9853	mirror maroon poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
+9852	red skewed faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
+9853	maroon mirror poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	upside-down to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	fuchsia flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9726,7 +9726,7 @@
 9858	maroon LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
-9861	narrow blurry LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+9861	blurry narrow LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	super-sized bland FantasyRealm turkey leg	5	decent	Last Available: "2018-04"
 9863	aged FantasyRealm mead	3	awesome	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9734,16 +9734,16 @@
 9866	wobbly arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	huge grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	bland snack-sized upside-down druidic s'more	2	decent	Last Available: "2018-04"
+9869	snack-sized bland upside-down druidic s'more	2	decent	Last Available: "2018-04"
 9870	twisted sachet of powder	1		Last Available: "2018-04"
-9871	weak bad tumbling mourning wine	2	decent	Last Available: "2018-04"
+9871	bad weak tumbling mourning wine	2	decent	Last Available: "2018-04"
 9872	jittery sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	maroon map to the Towering Mountains	0		Last Available: "2018-04"
 9874	upside-down map to the Mystic Wood	0		Last Available: "2018-04"
-9875	blinking cyan spinning map to the Putrid Swamp	0		Last Available: "2018-04"
+9875	blinking spinning cyan map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	decent small denastified haunch	2	good	Last Available: "2018-04"
+9878	small decent denastified haunch	2	good	Last Available: "2018-04"
 9879	acceptable twirling bad rum and good cola	3	good	Last Available: "2018-04"
 9880	chilled Potion of Heroism	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 24, Last Available: "2018-04"
 9881	tumbling medical-grade leggings of the Spider Queen of James Dean of mayonnaise	0		Experience (Moxie): +3, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-04"
@@ -9765,14 +9765,14 @@
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	mediocre blinking two meat muck	4	decent	
 9899	rotten blinking chocolate Ogre Chieftain	3	crappy	
-9900	special rotten chocolate &quot;Phoenix&quot;	4	crappy	Effect: "Spiky Hair", Effect Duration: 10
-9901	bite-sized normal pulsating chocolate Spider Queen	1	good	
+9900	rotten special chocolate &quot;Phoenix&quot;	4	crappy	Effect: "Spiky Hair", Effect Duration: 10
+9901	normal bite-sized pulsating chocolate Spider Queen	1	good	
 9902	artisanal hipster cocktail	4	EPIC	
-9903	fuchsia God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	blue God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	blue God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	fuchsia God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	blue God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	blue God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9790,7 +9790,7 @@
 9922	galvanized fuchsia Shielding Potion	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 11, Last Available: "2018-06"
 9923	frozen ionized non-alkaline Punching Potion	0		Effect: "critical.enh", Effect Duration: 25, Last Available: "2018-06"
 9924	lime green Special Seasoning	0		Last Available: "2018-06"
-9925	pickled maroon shaking Nightmare Fuel	1		Effect: "Go Get 'Em, Tiger!", Effect Duration: 35, Last Available: "2018-06"
+9925	pickled shaking maroon Nightmare Fuel	1		Effect: "Go Get 'Em, Tiger!", Effect Duration: 35, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	pulsating Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9801,7 +9801,7 @@
 9933	denatured moist cyan huge boiling broth	0		Effect: "You Can Taste the Darkness", Effect Duration: 14, Last Available: "2018-07"
 9934	super-wet ionized nitrogenated interrogative elixir	0		Effect: "Danish Cunning", Effect Duration: 43, Last Available: "2018-07"
 9935	spinning Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
-9936	green mirror Bastille Battalion tattoo kit	0		Last Available: "2018-07"
+9936	mirror green Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	mirror Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	kitten burglar	0		Free Pull, Last Available: "2018-07"
@@ -9818,12 +9818,12 @@
 9950	Temple Grandin's hardened pentagram bandana	0		Damage Reduction: 3, Familiar Weight: +7, Last Available: "2018-09"
 9951	purple baleful skull ring	0		Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9952	tumbling electronics kit	0		Last Available: "2018-09"
-9953	snack-sized rotten PB&J with the crusts cut off	2	crappy	Last Available: "2018-09"
+9953	rotten snack-sized PB&J with the crusts cut off	2	crappy	Last Available: "2018-09"
 9954	smooth dorky glasses of the ox	0		Muscle: +20, Moxie: +15, Single Equip, Last Available: "2018-09"
 9955	spinning friendly Oprah's ponytail clip	0		Maximum MP Percent: +50, Familiar Weight: +3, Last Available: "2018-09"
 9956	wobbly dangerous paint palette	0		Weapon Damage: +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
-9958	diluted twirling pulsating Purple Beast energy drink	1		Effect: "Moon'd", Effect Duration: 20, Last Available: "2018-09"
+9958	diluted pulsating twirling Purple Beast energy drink	1		Effect: "Moon'd", Effect Duration: 20, Last Available: "2018-09"
 9959	Jack Frost's cosmetic football	0		Cold Spell Damage: +50, Last Available: "2018-09"
 9960	blurry resourceful shoe ad T-shirt of temperance	0		Maximum MP: +50, Sleaze Resistance: +5, Last Available: "2018-09"
 9961	Socratic pump-up high-tops	0		Experience (Mysticality): +1, Single Equip, Last Available: "2018-09"
@@ -9831,7 +9831,7 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	greasy stylish noticeable pumps	0		Moxie: +25, Sleaze Spell Damage: +10, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	bad fortified blinking everfull glass	5		Last Available: "2018-09"
+9966	fortified bad blinking everfull glass	5		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
 9968	narrow jam band bootleg	0		Last Available: "2018-09"
 9969	huge gravedigger's denim jacket of dire peril	0		Weapon Damage: +20, Spooky Damage: +10, Last Available: "2018-09"
@@ -9843,12 +9843,12 @@
 9976	gravedigger's healthy party pants	0		Maximum HP Percent: +20, Spooky Damage: +10, Last Available: "2018-09"
 9977	arcane researcher's Sinatra's party whip of the overflowing toilet	0		Experience (Moxie): +5, Experience Percent (Mysticality): +10, Stench Spell Damage: +50, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	high-proof bad TRIO cup of beer	8	decent	Last Available: "2018-09"
+9979	bad high-proof TRIO cup of beer	8	decent	Last Available: "2018-09"
 9980	normal party platter for one	3	good	Last Available: "2018-09"
 9981	altered fuchsia Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	blue party pup	0		Last Available: "2018-09"
 9983	MacGyver's hardened party crasher	0		Damage Reduction: 12, Maximum MP: +100, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	maroon skewed Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	skewed maroon Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	tumbling latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
@@ -9874,17 +9874,17 @@
 10008	Jack Frost's cool mutant legs of Flo-Jo	0		Moxie: +5, Cold Spell Damage: +50, Initiative: +100, Last Available: "2018-11"
 10009	dance instructor's Newton's mutant crown of Leguizamo	0		Experience (Mysticality): +3, Experience Percent (Moxie): +10, Monster Level: +20, Last Available: "2018-11"
 10010	jumbo flavorless ghostly ectoplasm	5	decent	Last Available: "2018-11"
-10011	tasty blue jittery	3	awesome	Last Available: "2018-11"
+10011	tasty jittery blue	3	awesome	Last Available: "2018-11"
 10012	smooth watered-down bottle of vodka	2	awesome	Last Available: "2018-11"
 10013	normal pizza	3	good	Last Available: "2018-11"
-10014	lousy watered-down special martini	2	decent	Effect: "Stop the Presses!", Effect Duration: 25, Last Available: "2018-11"
+10014	lousy special watered-down martini	2	decent	Effect: "Stop the Presses!", Effect Duration: 25, Last Available: "2018-11"
 10015	decent jittery cherry pie	3	good	Last Available: "2018-11"
 10016	aged pulsating eggnog	3	awesome	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	normal tiny special blinking Hell ramen	1	good	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2018-11"
+10018	normal special tiny blinking Hell ramen	1	good	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2018-11"
 10019	special lousy gimlet	3	decent	Effect: "Fan-Cooled", Effect Duration: 15, Last Available: "2018-11"
 10020	bad watered-down twice-haunted screwdriver	2	decent	Last Available: "2018-11"
-10021	spoiled enchanted candy cane	4	crappy	Effect: "Hennaliciousness", Effect Duration: 40, Last Available: "2018-12"
+10021	enchanted spoiled candy cane	4	crappy	Effect: "Hennaliciousness", Effect Duration: 40, Last Available: "2018-12"
 10022	lousy runny fermented egg	3	decent	Last Available: "2018-12"
 10023	rotten twirling oldcake	4	crappy	Last Available: "2018-12"
 10024	tasty tumbling traditional Crimbo cookie	3	awesome	Last Available: "2023-06"
@@ -9894,10 +9894,10 @@
 10028	narrow supercool plastic orphan	0		Moxie Percent: +20, Last Available: "2018-12"
 10029	cool plastic Abuela Crimbo	0		Moxie: +5, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
-10031	green jittery Braindeer	0		Last Available: "2018-12"
+10031	jittery green Braindeer	0		Last Available: "2018-12"
 10032	wobbly Crimbo dog sweater	0		Familiar Weight: +5
 10033	twirling baleful personal trainer's pristine walrus tusk	0		Experience Percent (Muscle): +10, Spell Damage: +25, Last Available: "2018-12"
-10034	lime green shaking thick walrus blubber	0		Last Available: "2018-12"
+10034	shaking lime green thick walrus blubber	0		Last Available: "2018-12"
 10035	wobbly huge pulsating vibrating rock-hard wicked Staff of Frozen Lard of vim and vigor	0		Spell Damage: +5, Damage Reduction: 5, Maximum HP Percent: +50, Maximum MP Percent: +10, Last Available: "2018-12"
 10036	bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
@@ -9913,7 +9913,7 @@
 10047	lime green shaking crafty extremely unsafe Canadian lantern	0		Weapon Damage Percent: +100, Maximum MP: +10, Last Available: "2018-12"
 10048	jittery muskox-skin cap of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	snack-sized normal narrow glass of raw eggs	2	good	Last Available: "2018-12"
+10050	normal snack-sized narrow glass of raw eggs	2	good	Last Available: "2018-12"
 10051	watered-down bad blinking punch-drunk punch	2	decent	Last Available: "2018-12"
 10052	boiled upside-down body spradium	1		Last Available: "2018-12"
 10053	yellow Usain Bolt's bauxite beret	0		Initiative: +80, Last Available: "2018-12"
@@ -9923,7 +9923,7 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	Sherlock's perfumed gravedigger's Sinatra's boxer's Kramco Sausage-o-Matic&trade;	0		Muscle Percent: +10, Experience (Moxie): +5, Spooky Damage: +10, Stench Resistance: +5, Item Drop: +25, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	bland half-sized sausage	2	decent	Last Available: "2019-01"
+10060	half-sized bland sausage	2	decent	Last Available: "2019-01"
 10061	Jack Frost's red-hot sausage fork of bravery	0		Cold Spell Damage: +50, Spooky Resistance: +5, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
@@ -9937,7 +9937,7 @@
 10071	compressed Crimbeau de toilette	1		Effect: "The Wisdom... of the Future", Effect Duration: 5, Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	gray Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10074	wobbly squat jittery Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
+10074	jittery wobbly squat Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	blurry Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
@@ -9991,7 +9991,7 @@
 10125	supercharged quilted glass spectacles	0		Damage Absorption: +40, Maximum MP Percent: +30, Single Equip, Last Available: "2021-12"
 10126	Newton's glass shiv of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Last Available: "2021-12"
 10127	twirling hardy banded glass serape	0		Damage Absorption: +100, Maximum HP: +50, Last Available: "2021-12"
-10128	compressed shaking pulsating glass shards	1		Last Available: "2021-12"
+10128	compressed pulsating shaking glass shards	1		Last Available: "2021-12"
 10129	extra-tarnished pickled pressed pulsating hard candy	0		Effect: "Red Misty-Eyed", Effect Duration: 23
 10130	green Tesla brawny loofah lumberjack's hat	0		Muscle Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
 10131	ribald Van der Graaf loofah lei	0		Sleaze Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
@@ -10012,22 +10012,22 @@
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
 10148	careful cobbled-together Meat detector	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2019-12"
-10149	anodized double-activated squat skewed tin thermos of chai	0		Effect: "Extra Backbone", Effect Duration: 37, Last Available: "2019-12"
+10149	anodized double-activated skewed squat tin thermos of chai	0		Effect: "Extra Backbone", Effect Duration: 37, Last Available: "2019-12"
 10150	powdered blurry prototype stimulant	1		Last Available: "2019-12"
 10151	narrow beefy tailored vest	0		Muscle: +10, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	green really nice net	0		Last Available: "2019-12"
 10154	shaking stylish elf army poncho	0		Moxie: +25, Lasts Until Rollover, Last Available: "2019-12"
-10155	adequate low-calorie elf army field rations	1	good	Last Available: "2019-12"
+10155	low-calorie adequate elf army field rations	1	good	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	auspicious extremely unsafe discarded bowtie	0		Weapon Damage Percent: +100, Item Drop: +10, Lasts Until Rollover, Last Available: "2019-12"
-10158	bad weak fancy martiny	2	decent	Effect: "Alchemical, Brother", Effect Duration: 10, Last Available: "2019-12"
+10158	weak bad fancy martiny	2	decent	Effect: "Alchemical, Brother", Effect Duration: 10, Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	modified licorice snake	0		Effect: "Gummiheart", Effect Duration: 54
 10161	diffused red virgin jello shot	0		Effect: "Seriously Mutated", Effect Duration: 16
 10162	denatured blinking mutated candy lump	0		Effect: "Stinking Cloud", Effect Duration: 38
 10163	denatured bouncing government-issued candy	0		Effect: "Stogied", Effect Duration: 69
-10164	extra-ionized bouncing blinking olive Pneumo bar	0		Effect: "Squatting and Thrusting", Effect Duration: 59
+10164	extra-ionized olive bouncing blinking Pneumo bar	0		Effect: "Squatting and Thrusting", Effect Duration: 59
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	lightning-fast Lil' Doctor&trade; bag of courage	0		Spooky Resistance: +3, Initiative: +40, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
@@ -10036,11 +10036,11 @@
 10171	enchanted bland red actual blood sausage	4	decent	Effect: "Voracious Gorging", Effect Duration: 35
 10172	acceptable mulled blood	4	good	
 10173	bland green blood snowcone	3	decent	
-10174	smooth practically non-alcoholic blinking Red Russian	1	awesome	
+10174	practically non-alcoholic smooth blinking Red Russian	1	awesome	
 10175	decent blood roll-up	3	good	
 10176	smooth red bottle of blood	4	awesome	
 10177	normal blood-soaked sponge cake	3	good	
-10178	weak artisanal vampagne	2	super ultra mega turbo EPIC	
+10178	artisanal weak vampagne	2	super ultra mega turbo EPIC	
 10179	moldy plain snowcone	4	crappy	
 10180	yellow tumbling Booke of Vampyric Knowledge	0		
 10181	teal money bag	0		
@@ -10061,7 +10061,7 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	enchanted toothsome crabsicle	4	awesome	Effect: "Crying, Dying", Effect Duration: 50, Last Available: "2019-04"
+10199	toothsome enchanted crabsicle	4	awesome	Effect: "Crying, Dying", Effect Duration: 50, Last Available: "2019-04"
 10200	narrow melty plastic grenade	0		Last Available: "2019-04"
 10201	watered-down acceptable bottle of dark rhum	2	good	Last Available: "2019-04"
 10202	tolerable bottle of extra-dark rhum	3	good	Last Available: "2019-04"
@@ -10069,7 +10069,7 @@
 10204	modified vacuum-sealed enhanced gray pirate shaving cream	0		Effect: "Strawberry Alarm", Effect Duration: 48, Last Available: "2019-04"
 10205	perfumed supercool conquistador's breastplate	0		Moxie Percent: +20, Stench Resistance: +5, Last Available: "2019-04"
 10206	Temple Grandin's baleful pirate pantaloons	0		Spell Damage: +25, Familiar Weight: +7, Last Available: "2019-04"
-10207	blurry jittery spinning [glitch season reward name]	0		
+10207	jittery spinning blurry [glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	mirror rosewater-soaked brawny pirate radio ring	0		Muscle Percent: +20, Stench Resistance: +3, Single Equip, Last Available: "2019-04"
@@ -10098,8 +10098,8 @@
 10233	perfectly mixed watered-down Island Thunderstorm	2	super EPIC	Last Available: "2019-04"
 10234	drinkable shaking Island Hurricane	4	good	Last Available: "2019-04"
 10235	artisanal weak spinning Skull Punch	2	super ultra EPIC	Last Available: "2019-04"
-10236	lousy olive shaking Electric Punch	3	decent	Last Available: "2019-04"
-10237	mediocre watered-down Smuggler's Punch	2	decent	Last Available: "2019-04"
+10236	lousy shaking olive Electric Punch	3	decent	Last Available: "2019-04"
+10237	watered-down mediocre Smuggler's Punch	2	decent	Last Available: "2019-04"
 10238	aged ghostly Scorpion Bowl	4	awesome	Last Available: "2019-04"
 10239	bad boozy Turtle Bowl	5	decent	Last Available: "2019-04"
 10240	bad Cobra Bowl	3	decent	Last Available: "2019-04"
@@ -10118,7 +10118,7 @@
 10253	Thwaitgold nymph statuette	0		
 10254	greasy crafty vibrating medical-grade therapeutic ruddy occult hewn moon-rune spoon of the cougar of the brazier of doom of the boozehound	0		Moxie: +20, Spell Damage Percent: +25, Maximum HP Percent: +40, Maximum MP Percent: +10, Maximum MP: +10, Hot Spell Damage: +25, Spooky Spell Damage: +50, Sleaze Spell Damage: +10, Booze Drop: +100, HP Regen Min: 12, HP Regen Max: 17, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
-10256	upside-down blinking rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
+10256	blinking upside-down rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	lightning-fast reassuring quilted Beach Comb	0		Damage Absorption: +40, Spooky Resistance: +1, Initiative: +40, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
@@ -10127,7 +10127,7 @@
 10262	gray pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	ghostly hourglass	0		Last Available: "2019-07"
-10265	spinning cyan etched hourglass	0		Last Available: "2019-07"
+10265	cyan spinning etched hourglass	0		Last Available: "2019-07"
 10266	wet enhanced pulsating squat magenta seashell	0		Effect: "Egg on your Face", Effect Duration: 35, Last Available: "2019-07"
 10267	quantum jittery cyan seashell	0		Effect: "Spiky Frozen Hair", Effect Duration: 19, Last Available: "2019-07"
 10268	frozen polarized anodized gray seashell	0		Effect: "Super Structure", Effect Duration: 42, Last Available: "2019-07"
@@ -10135,7 +10135,7 @@
 10270	oxidized shaking seashell	0		Effect: "Neuroplastici Tea", Effect Duration: 47, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
 10272	practically non-alcoholic artisanal bottle of sea wine	1	EPIC	Last Available: "2019-07"
-10273	vaporized pulsating bouncing kelp	1		Effect: "Anytwo Five Elevenis?", Effect Duration: 30, Last Available: "2019-07"
+10273	vaporized bouncing pulsating kelp	1		Effect: "Anytwo Five Elevenis?", Effect Duration: 30, Last Available: "2019-07"
 10274	yellow spinning avaricious rosewater-soaked Temple Grandin's electrified stiffened extremely unsafe arcane researcher's driftwood hat of chilblains of the sewer	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +100, Damage Reduction: 1, Familiar Weight: +7, Cold Damage: +25, Stench Damage: +25, Stench Resistance: +3, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-07"
 10275	flame-retardant greasy ribald friendly hale rosy-cheeked deadly Socratic driftwood pants of the bloodbag	0		Experience (Mysticality): +1, Weapon Damage: +5, Maximum HP Percent: +30, Maximum HP: 120, Familiar Weight: +3, Sleaze Damage: +10, Sleaze Spell Damage: +10, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2019-07"
 10276	zippy avaricious stanky hardened studded brainy driftwood bracelet of the cougar of Tarzan of the bloodbag	0		Mysticality: +5, Moxie: +20, Experience (Muscle): +3, Damage Absorption: +80, Damage Reduction: 3, Maximum HP: +100, Stench Spell Damage: +25, Meat Drop: +30, Initiative: +20, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10182,8 +10182,8 @@
 10317	signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
-10320	low-calorie adequate space chowder	1	good	
-10321	weak artisanal space wine	2	super ultra mega EPIC	
+10320	adequate low-calorie space chowder	1	good	
+10321	artisanal weak space wine	2	super ultra mega EPIC	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	tumbling packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10193,7 +10193,7 @@
 10334	jittery unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	small adequate bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
+10337	adequate small bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
 10338	snack-sized bland mirror flan del mar	2	decent	Last Available: "2019-12"
 10339	decent Baja sopapilla	3	good	Last Available: "2019-12"
 10340	olive plastic Mer-kin baker of the businessman	0		Meat Drop: +50, Last Available: "2019-12"
@@ -10221,7 +10221,7 @@
 10362	boiled Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	pickled cyan non-Euclidean angle	1		Effect: "Mmmmmelon", Effect Duration: 20, Last Available: "2019-12"
-10365	diffused triple-quantum ghostly twirling peppermint syrup	0		Effect: "Tin, Man", Effect Duration: 19, Last Available: "2019-12"
+10365	diffused triple-quantum twirling ghostly peppermint syrup	0		Effect: "Tin, Man", Effect Duration: 19, Last Available: "2019-12"
 10366	pickled deionized Mer-kin eyedrops	0		Effect: "Ooh, Bitter!", Effect Duration: 16, Last Available: "2019-12"
 10367	vacuum-sealed quantum vacuum-sealed extra-strength goo	0		Effect: "Trash-Wrapped", Effect Duration: 43, Last Available: "2019-12"
 10368	spinning envelope full of Meat	0		Last Available: "2019-12"
@@ -10245,7 +10245,7 @@
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	pulsating intact anemone spike	0		Last Available: "2019-12"
 10388	purple toasty anemoney clip	0		Hot Damage: +5, Single Equip, Last Available: "2019-12"
-10389	fuchsia skewed runny icing	0		Last Available: "2019-12"
+10389	skewed fuchsia runny icing	0		Last Available: "2019-12"
 10390	dehydrated super-sweet fish goo (spoiled)	1		Effect: "The Grass...  Is Blue...", Effect Duration: 20, Last Available: "2019-12"
 10391	prompt MacGyver's icing poncho of the businessman	0		Maximum MP: +100, Meat Drop: +50, Adventures: +3, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
@@ -10281,7 +10281,7 @@
 10422	Crimbylow-rise jeans of the cougar of the cheetah	0		Moxie: +20, Initiative: +60, Last Available: "2019-12"
 10423	horrifying cool kelp-holly drape	0		Moxie: +5, Spooky Damage: +25, Last Available: "2019-12"
 10424	rosewater-soaked slick Staff of the Peppermint Twist of the brazier of the early riser	0		Moxie: +10, Hot Spell Damage: +25, Stench Resistance: +3, Adventures: +7, Last Available: "2019-12"
-10425	rotten jumbo tempura and bean	5	crappy	Last Available: "2019-12"
+10425	jumbo rotten tempura and bean	5	crappy	Last Available: "2019-12"
 10426	hand-crafted red salt plum sake	4	EPIC	Last Available: "2019-12"
 10427	improved bouncing pressurized potion of possessiveness	0		Effect: "Rave Concentration", Effect Duration: 12, Last Available: "2019-12"
 10428	wet gray shaking almond	0		Effect: "The Halls of Muscularity", Effect Duration: 31
@@ -10294,7 +10294,7 @@
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	narrow flame-retardant nippy Newton's Powerful Glove of extreme caution of the businessman	0		Experience (Mysticality): +3, Monster Level: -25, Cold Damage: +10, Hot Resistance: +1, Meat Drop: +50, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	blurry enhanced signal receiver	0		
-10440	mirror skewed status cymbal	0		Last Available: "2020-02"
+10440	skewed mirror status cymbal	0		Last Available: "2020-02"
 10441	manspreader's supercool wizardly Drip harness	0		Mysticality: +25, Moxie Percent: +20, Monster Level: +10
 10442	blue Van der Graaf drippy truncheon	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip
 10443	Driplet	0		
@@ -10302,7 +10302,7 @@
 10445	bland drippy nugget	3	drippy	
 10446	weak drinkable twirling glass of drippy wine	2	drippy	
 10447	normal bouncing drippy caviar	4	drippy	
-10448	spoiled low-calorie lime green drippy plum(?)	1	drippy	
+10448	low-calorie spoiled lime green drippy plum(?)	1	drippy	
 10449	rosewater-soaked drippy stake	0		Stench Resistance: +3, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10341,9 +10341,9 @@
 10484	twirling plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	jittery free-range mushroom	0		Last Available: "2020-03"
-10487	squat purple immense free-range mushroom	0		Last Available: "2020-03"
+10487	purple squat immense free-range mushroom	0		Last Available: "2020-03"
 10488	blinking colossal free-range mushroom	0		Last Available: "2020-03"
-10489	flavorless thick mushroom filet	5	decent	Last Available: "2020-03"
+10489	thick flavorless mushroom filet	5	decent	Last Available: "2020-03"
 10490	narrow mushroom slab	0		Last Available: "2020-03"
 10491	altered mushroom tea	1		Last Available: "2020-03"
 10492	artisanal mushroom whiskey	4	EPIC	Last Available: "2020-03"
@@ -10369,7 +10369,7 @@
 10512	purple manspreader's chipped coffee mug of the businessman	0		Monster Level: +10, Meat Drop: +50, Last Available: "2020-04"
 10513	upside-down Left-Hand Man action figure of chilblains	0		Cold Damage: +25, Last Available: "2020-04"
 10514	drippy seed	0		
-10515	squat spinning blinking drippy grub	0		
+10515	spinning squat blinking drippy grub	0		
 10516	shaking drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	maroon drippy ichor	0		
@@ -10379,7 +10379,7 @@
 10522	squat drippy bromide	0		
 10523	drippy flux	0		
 10524	blinking maroon spinning drippy stein	0		
-10525	delicious jittery cyan drippy pilsner	4	drippy	
+10525	delicious cyan jittery drippy pilsner	4	drippy	
 10526	huge drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	upside-down drippy orb	0		
 10529	huge lustrous drippy orb	0		
@@ -10397,8 +10397,8 @@
 10541	tolerable Ghiaccio Colada	3	good	Last Available: "2020-05"
 10542	watered-down hand-crafted upside-down Sourfinger	2	EPIC	Last Available: "2020-05"
 10543	spirit-forward tolerable Nog-on-the-Cob	5	good	Last Available: "2020-05"
-10544	artisanal strong enchanted Steamboat	5	EPIC	Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2020-05"
-10545	watered-down lousy mirror Buttery Boy	2	decent	Last Available: "2020-05"
+10544	enchanted strong artisanal Steamboat	5	EPIC	Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2020-05"
+10545	lousy watered-down mirror Buttery Boy	2	decent	Last Available: "2020-05"
 10546	green Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	energetic hardy clown car key	0		Maximum HP: +50, Maximum MP Percent: +20, Last Available: "2020-08"
 10548	twirling Jim Carey's batting cage key of Gandalf of Flo-Jo	0		Spell Critical Percent: +20, Monster Level: +25, Initiative: +100, Last Available: "2020-08"
@@ -10446,7 +10446,7 @@
 10590	wobbly electrified smartaleck's hemlock helm of the blizzard	0		Moxie Percent: +30, Cold Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-08"
 10591	sweaty balsam	0		Last Available: "2020-08"
 10592	Temple Grandin's balsam barrel of the sewer of mayonnaise	0		Familiar Weight: +7, Stench Damage: +25, Sleaze Spell Damage: +50, Last Available: "2020-08"
-10593	shaking purple redwood	0		Last Available: "2020-08"
+10593	purple shaking redwood	0		Last Available: "2020-08"
 10594	galvanized polarized upside-down redwood rain stick	0		Effect: "Muscularrr", Effect Duration: 17, Last Available: "2020-08"
 10595	tumbling purpleheart logs	0		Last Available: "2020-08"
 10596	wobbly double-paned purpleheart &quot;pants&quot; of Calamity Jane of the glutton	0		Critical Hit Percent: +15, Cold Resistance: +5, Food Drop: +100, Last Available: "2020-08"
@@ -10463,7 +10463,7 @@
 10607	diffused magnetized Yeg's Motel hand soap	0		Effect: "Elvish", Effect Duration: 20, Last Available: "2020-09"
 10608	huge pulsating Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	spoiled small Yeg's Motel pillow mint	2	crappy	Last Available: "2020-09"
-10610	bouncing skewed Yeg's Motel disposable razor	0		Last Available: "2020-09"
+10610	skewed bouncing Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	altered Yeg's Motel mouthwash	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 63, Last Available: "2020-09"
 10612	bouncing Van der Graaf padded Yeg's Motel shower cap	0		Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2020-09"
 10613	wobbly prompt rosewater-soaked Yeg's Motel bathrobe	0		Stench Resistance: +3, Adventures: +3, Lasts Until Rollover, Last Available: "2020-09"
@@ -10479,7 +10479,7 @@
 10623	onyx king	0		Last Available: "2020-09"
 10624	upside-down onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
-10626	jittery gray onyx bishop	0		Last Available: "2020-09"
+10626	gray jittery onyx bishop	0		Last Available: "2020-09"
 10627	blurry onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
@@ -10569,24 +10569,24 @@
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	red The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	flavorless and pepper (stale)	3	decent	Last Available: "2020-12"
-10716	smooth strong cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
+10716	strong smooth cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
 10717	upside-down fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	wobbly nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	tolerable purple barrel-aged eggnog	3	good	Last Available: "2020-12"
 10721	normal hand-crafted candy cane	4	good	Last Available: "2020-12"
 10722	jumbo bland drive-thru burger	5	decent	Last Available: "2020-12"
-10723	acceptable irresponsibly strong Boulevardier cocktail	6	good	Last Available: "2020-12"
+10723	irresponsibly strong acceptable Boulevardier cocktail	6	good	Last Available: "2020-12"
 10724	super-altered tumbling jittery Hotwire&trade; brand candy rope	0		Effect: "Fancy Feasted", Effect Duration: 16, Last Available: "2020-12"
 10725	immense flavorless jittery bowl full of jelly	6	decent	Last Available: "2020-12"
 10726	bad mirror Eye and a Twist	4	decent	Last Available: "2020-12"
 10727	tarnished concentrated aerosolized spinning pulsating Chubby and Plump bar	0		Effect: "Salty Dogs", Effect Duration: 26, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
-10730	lime green jittery crystal ball	0		Initiative: +50, Last Available: "2021-01"
+10730	jittery lime green crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	maroon fresh coat of paint	0		Last Available: "2021-12"
-10733	wobbly squat emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	squat wobbly emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 10734	lime green spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	skewed robo-battery	0		
 10736	upside-down Thwaitgold listening bug statuette	0		
@@ -10606,7 +10606,7 @@
 10750	tumbling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	polarized adjusted short beer	0		Effect: "Mana Tea", Effect Duration: 26, Last Available: "2021-05"
-10753	pickled oxidized ghostly teal short stack of pancakes	0		Effect: "Sweetened and Fattened", Effect Duration: 16, Last Available: "2021-05"
+10753	pickled oxidized teal ghostly short stack of pancakes	0		Effect: "Sweetened and Fattened", Effect Duration: 16, Last Available: "2021-05"
 10754	quadruple-improved mirror short stick of butter	0		Effect: "Robocamo", Effect Duration: 33, Last Available: "2021-05"
 10755	super-frozen moist purple short glass of water	0		Effect: "Vinegavotte", Effect Duration: 55, Last Available: "2021-05"
 10756	non-diffused deionized blurry short	0		Effect: "You Know When to Walk Away", Effect Duration: 24, Last Available: "2021-05"
@@ -10629,7 +10629,7 @@
 10773	blurry Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	alkaline olive Scent of a Human&trade; candle	0		Effect: "Pemmican't", Effect Duration: 62, Last Available: "2021-08"
 10775	liquefied spinning The Beast Within&trade; candle	0		Effect: "Resilient Spirit", Effect Duration: 21, Last Available: "2021-08"
-10776	chilled blinking jittery Salsa Caliente&trade; candle	0		Effect: "Spooky Demeanor", Effect Duration: 32, Last Available: "2021-08"
+10776	chilled jittery blinking Salsa Caliente&trade; candle	0		Effect: "Spooky Demeanor", Effect Duration: 32, Last Available: "2021-08"
 10777	double-chilled bouncing Smoldering Clover&trade; candle	0		Effect: "Bilious Brawn", Effect Duration: 11, Last Available: "2021-08"
 10778	quadruple-Vulcanized tarnished blue pulsating Napalm In The Morning&trade; candle	0		Effect: "Less Pervious", Effect Duration: 59, Last Available: "2021-08"
 10779	blinking wobbly curative Da Vinci's extra-large utility candle	0		Experience (Mysticality): +5, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2021-08"
@@ -10661,7 +10661,7 @@
 10805	eggwater	1	crappy	Last Available: "2021-12"
 10806	stale jumbo bread man	5	decent	Last Available: "2021-12"
 10807	thick flavorless plain candy cane	5	decent	Last Available: "2021-12"
-10808	normal bite-sized green pulsating flour cookie	1	good	Last Available: "2021-12"
+10808	bite-sized normal green pulsating flour cookie	1	good	Last Available: "2021-12"
 10809	inspector's plastic food lab	0		Item Drop: +15, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2021-12"
 10811	smooth plastic chem lab	0		Moxie: +15, Single Equip, Last Available: "2021-12"
@@ -10677,10 +10677,10 @@
 10821	decent tumbling fishcake	4	good	Last Available: "2021-12"
 10822	toothsome bone broth	3	awesome	Last Available: "2021-12"
 10823	stale star pop	4	decent	Last Available: "2021-12"
-10824	delicious special bouncing Doc's Fortifying Wine	3	awesome	Effect: "Disco Inferno", Effect Duration: 45, Last Available: "2021-12"
+10824	special delicious bouncing Doc's Fortifying Wine	3	awesome	Effect: "Disco Inferno", Effect Duration: 45, Last Available: "2021-12"
 10825	smooth Doc's Smartifying Wine	4	awesome	Last Available: "2021-12"
-10826	hand-crafted practically non-alcoholic Doc's Limbering Wine	1	EPIC	Last Available: "2021-12"
-10827	enchanted weak tolerable Doc's Medical-Grade Wine	2	good	Effect: "Squatting and Thrusting", Effect Duration: 25, Last Available: "2021-12"
+10826	practically non-alcoholic hand-crafted Doc's Limbering Wine	1	EPIC	Last Available: "2021-12"
+10827	tolerable weak enchanted Doc's Medical-Grade Wine	2	good	Effect: "Squatting and Thrusting", Effect Duration: 25, Last Available: "2021-12"
 10828	diluted Homebodyl&trade;	1		Last Available: "2021-12"
 10829	powdered Extrovermectin&trade;	1		Effect: "Worth Your Salt", Effect Duration: 5, Last Available: "2021-12"
 10830	distilled Breathitin&trade;	1		Last Available: "2021-12"
@@ -10691,15 +10691,15 @@
 10835	dry polymerized red anti-odor cream	0		Effect: "Eldritch Concentration", Effect Duration: 68, Last Available: "2021-12"
 10836	deionized corrupted electrified huge anti-creep cream	0		Effect: "Piratey Flavor", Effect Duration: 63, Last Available: "2021-12"
 10837	aerosolized shaking anti-pain cream	0		Effect: "[1701]Hip to the Jive", Effect Duration: 53, Last Available: "2021-12"
-10838	practically non-alcoholic drinkable blurry Doc's Special Reserve Wine	1	good	Last Available: "2021-12"
-10839	jumbo delicious maroon bread pie	5	awesome	Last Available: "2021-12"
+10838	drinkable practically non-alcoholic blurry Doc's Special Reserve Wine	1	good	Last Available: "2021-12"
+10839	delicious jumbo maroon bread pie	5	awesome	Last Available: "2021-12"
 10840	bad irresponsibly strong clear Russian	7	decent	Last Available: "2021-12"
 10841	blurry zero-trust tanktop	0		Last Available: "2025-12"
 10842	pulsating Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
 10844	ghostly gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
-10846	yellow tumbling gooified mineral matter	0		Last Available: "2021-12"
+10846	tumbling yellow gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
 10848	extra-sweet chocolate and pear nog	3	good	Effect: "Hoity Toity", Effect Duration: 33
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
@@ -10721,7 +10721,7 @@
 10865	gray ghostly universal biscuit	0		Last Available: "2021-12"
 10866	veiny yule hatchet	0		Maximum HP: +10, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	moldy thick lab-grown meat	5	crappy	Last Available: "2021-12"
+10868	thick moldy lab-grown meat	5	crappy	Last Available: "2021-12"
 10869	fleece of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	narrow cloning kit	0		Last Available: "2021-12"
@@ -10740,7 +10740,7 @@
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	stanky frosty Van der Graaf magnifying glass	0		Cold Spell Damage: +10, Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-12"
 10886	artisanal practically non-alcoholic maroon void lager	1	EPIC	Last Available: "2022-12"
-10887	huge stale void burger	6	decent	Last Available: "2022-12"
+10887	stale huge void burger	6	decent	Last Available: "2022-12"
 10888	upside-down void stone	0		Last Available: "2022-12"
 10889	greasy frightening Lo Pan's MacGyver's void shard	0		Maximum MP: +100, Spell Critical Percent: +30, Spooky Damage: +5, Sleaze Spell Damage: +10, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10762,27 +10762,27 @@
 10906	skewed supercool thermal blanket of terror of horror	0		Moxie Percent: +20, Spooky Spell Damage: 35, Lasts Until Rollover, Last Available: "2022-05"
 10907	tumbling bouncing atlas of local maps of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Last Available: "2022-05"
 10908	non-aerosolized modified improved spare battery	0		Effect: "Ready to Snap", Effect Duration: 53, Last Available: "2022-05"
-10909	upside-down narrow purple space blanket	0		Last Available: "2022-05"
+10909	upside-down purple narrow space blanket	0		Last Available: "2022-05"
 10910	double-ionized activated corrupted single-use dust mask	0		Effect: "Bubblin' Rage", Effect Duration: 12, Last Available: "2022-05"
 10911	concentrated jittery gaffer's tape	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 33, Last Available: "2022-05"
 10912	moldy miniature 20-lb can of rice and beans	2	crappy	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	bland skewed expired MRE	4	decent	Last Available: "2022-05"
-10915	snack-sized decent skewed cool mint precipice bar	2	good	Last Available: "2022-05"
-10916	enchanted spoiled carrot cake precipice bar	3	crappy	Effect: "Ready to Snap", Effect Duration: 10, Last Available: "2022-05"
+10915	decent snack-sized skewed cool mint precipice bar	2	good	Last Available: "2022-05"
+10916	spoiled enchanted carrot cake precipice bar	3	crappy	Effect: "Ready to Snap", Effect Duration: 10, Last Available: "2022-05"
 10917	green The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	narrow packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	aromatic Annie Oakley's veiny June cleaver	0		Maximum HP: +10, Critical Hit Percent: +20, Stench Resistance: +1, Attacks Can't Miss, Last Available: "2022-06"
 10921	tolerable Dad's brandy	4	good	Last Available: "2022-06"
 10922	squat twirling Temple Grandin's teacher's pen of the boozehound	0		Familiar Weight: +7, Booze Drop: +100, Last Available: "2022-06"
-10923	spoiled huge pulsating fire-roasted lake trout	8	crappy	Last Available: "2022-06"
+10923	huge spoiled pulsating fire-roasted lake trout	8	crappy	Last Available: "2022-06"
 10924	bland olive guilty sprout	3	decent	Last Available: "2022-06"
 10925	shaking clever mother's necklace of wisdom	0		Mysticality: +15, Maximum MP: +20, Last Available: "2022-06"
 10926	double-quantum bouncing trampled ticket stub	0		Effect: "License to Punch", Effect Duration: 11, Last Available: "2022-06"
 10927	moist aerosolized savings bond	0		Effect: "Proprie Tea", Effect Duration: 26, Last Available: "2022-06"
 10928	cyan designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	ghostly designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	ghostly designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	dehydrated skewed sweat-ade	1		Last Available: "2022-07"
 10931	cyan tumbling unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	mirror stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10825,35 +10825,35 @@
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	rotten diet ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
 10971	miniature adequate fuchsia Jarlsberg's vegetable soup	2	good	Last Available: "2022-11"
-10972	fancy decent miniature green roasted vegetable of Jarlsberg	2	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 30, Last Available: "2022-11"
+10972	miniature fancy decent green roasted vegetable of Jarlsberg	2	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 30, Last Available: "2022-11"
 10973	stale St. Pete's sneaky smoothie	3	decent	Last Available: "2022-11"
 10974	flavorless Pete's wiley whey bar	3	decent	Last Available: "2022-11"
 10975	flavorless Pete's rich ricotta	3	decent	Last Available: "2022-11"
 10976	perfectly mixed ghostly Boris's beer	3	EPIC	Last Available: "2022-11"
-10977	thick rotten honey bun of Boris	5	crappy	Last Available: "2022-11"
+10977	rotten thick honey bun of Boris	5	crappy	Last Available: "2022-11"
 10978	yummy enchanted lime green Boris's bread	4	awesome	Effect: "Nightlit", Effect Duration: 50, Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	twirling squat Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	skewed Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	tumbling mirror Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	tumbling Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	tumbling Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	twirling squat Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	skewed Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	mirror tumbling Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	tumbling Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	tumbling Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	stale baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
-10989	stale gigantic plain calzone	6	decent	Last Available: "2022-11"
+10989	gigantic stale plain calzone	6	decent	Last Available: "2022-11"
 10990	snack-sized tasty roasted vegetable focaccia	2	awesome	Last Available: "2022-11"
 10991	fancy moldy bite-sized Pizza of Legend	1	crappy	Effect: "Greedy Resolve", Effect Duration: 35, Last Available: "2022-11"
-10992	enchanted half-sized flavorless Calzone of Legend	2	decent	Effect: "Ichorous Intensity", Effect Duration: 10, Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	ghostly Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10992	half-sized enchanted flavorless Calzone of Legend	2	decent	Effect: "Ichorous Intensity", Effect Duration: 10, Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	ghostly Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	spoiled snack-sized Deep Dish of Legend	2	crappy	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	snack-sized spoiled Deep Dish of Legend	2	crappy	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	yellow drink chit	0		
 11003	pulsating government per-diem	0		
@@ -10863,13 +10863,13 @@
 11007	squat booze bindle	0		
 11008	chilly rare oboe of the glutton	0		Cold Damage: +5, Food Drop: +100
 11009	wool Rosewater's bullet necklace	0		Mysticality Percent: +30, Cold Resistance: +1, Single Equip
-11010	super-sized normal bouncing swamp haunch	5	good	
+11010	normal super-sized bouncing swamp haunch	5	good	
 11011	wobbly flame-wreathed educational gator shades	0		Experience: +1, Hot Spell Damage: +10, Single Equip
 11012	milk cap	0		
 11013	mediocre practically non-alcoholic green Charleston Choo-Choo	1	decent	
 11014	mediocre Velvet Veil	3	decent	
 11015	lousy Marltini	4	decent	
-11016	fancy smooth Strong, Silent Type	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 15
+11016	smooth fancy Strong, Silent Type	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 15
 11017	artisanal Mysterious Stranger	3	EPIC	
 11018	bad Champagne Shimmy	4	decent	
 11019	the Sot's parcel	0		
@@ -10907,14 +10907,14 @@
 11051	magnetized bouncing Trainbot tubing	0		Effect: "All Branned Up", Effect Duration: 46
 11052	magnetized concentrated Trainbot plating	0		Effect: "Retrograde Relaxation", Effect Duration: 32
 11053	magnetized Trainbot optics	0		Effect: "The Sweats", Effect Duration: 11
-11054	denatured pressed moist twirling fuchsia Trainbot servomotors	0		Effect: "damage.enh", Effect Duration: 16
+11054	denatured pressed moist fuchsia twirling Trainbot servomotors	0		Effect: "damage.enh", Effect Duration: 16
 11055	unsweetened Trainbot linkages	0		Effect: "Concentration", Effect Duration: 33
 11056	ping-pong paddle	0		Single Equip
 11057	blurry ping-pong ball	0		
 11058	MacGyver's Trainbot harness	0		Maximum MP: +100
 11059	jittery ping-pong table	0		
 11060	Crimbo train emergency brake	0		
-11061	bouncing tumbling Trainbot autoassembly module	0		
+11061	tumbling bouncing Trainbot autoassembly module	0		
 11062	family-friendly boxer's head-mounted Trainbot of the ox	0		Muscle: +20, Muscle Percent: +10, Sleaze Resistance: +1, Last Available: "2022-12"
 11063	miser's leg-mounted Trainbots of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Meat Drop: +10, Last Available: "2022-12"
 11064	clever thinker's shoulder-mounted Trainbot of the glutton	0		Mysticality: +10, Maximum MP: +20, Food Drop: +100, Single Equip, Last Available: "2022-12"
@@ -10925,7 +10925,7 @@
 11069	Trainbot luggage hook	0		Single Equip
 11070	bland honey-drenched ham slice	3	decent	
 11071	lousy mostly-empty bottle of cookie wine	4	decent	
-11072	immense bland jittery Crimbo food scraps	6	decent	
+11072	bland immense jittery Crimbo food scraps	6	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	huge automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
@@ -10955,13 +10955,13 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	dried huge upside-down maroon fruity pebble	1		Effect: "Disco Neuropathy", Effect Duration: 35, Last Available: "2023-01"
+11102	dried maroon huge upside-down fruity pebble	1		Effect: "Disco Neuropathy", Effect Duration: 35, Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	maroon bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
-11108	squat maroon hard rock	0		Last Available: "2023-01"
+11108	maroon squat hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	olive chocolate covered ping-pong ball	0		
 11112	spoiled pixel bread	4	crappy	
@@ -10974,12 +10974,12 @@
 11119	wet polarized lime green five-fingered fern resin	0		Effect: "Spookyravin'", Effect Duration: 18, Last Available: "2023-02"
 11120	gigantic stale mirror mirror super good fruit	8	decent	Last Available: "2023-02"
 11121	powdered energized spores	1		Effect: "Turkey-Friendly", Effect Duration: 5, Last Available: "2023-02"
-11122	sage hot pepper of dire peril	0		Mysticality Percent: +10, Weapon Damage: +20, Lantern Element: "Hot", Last Available: "2023-02"
+11122	sage hot pepper of dire peril	0		Mysticality Percent: +10, Weapon Damage: +20, Last Available: "2023-02", Lantern Element: "Hot"
 11123	activated unsweetened yellow out-of-work circus flea	0		Effect: "Super Structure", Effect Duration: 47, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	unsweetened fire ant pheromones	0		Effect: "Tennis Elbow-wow", Effect Duration: 64, Last Available: "2023-02"
 11126	polarized super-energized flapper fly	0		Effect: "Coldfinger", Effect Duration: 58, Last Available: "2023-02"
-11127	weak delicious purple shot of wasp venom	2	awesome	Last Available: "2023-02"
+11127	delicious weak purple shot of wasp venom	2	awesome	Last Available: "2023-02"
 11128	warmed olive filled mosquito	0		Effect: "Radiated and Grodiated", Effect Duration: 46, Last Available: "2023-02"
 11129	activated moist chilled blinking shim of shame shale	0		Effect: "Hyperoffended", Effect Duration: 58, Last Available: "2023-02"
 11130	colloidal pebble of proud pyrite	0		Effect: "Dancing Prowess", Effect Duration: 20, Last Available: "2023-02"
@@ -10987,16 +10987,16 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	enhanced enhanced angry agate	0		Effect: "Heart Aflame", Effect Duration: 69, Last Available: "2023-02"
 11134	nitrogenated skewed lump of loyal latite	0		Effect: "Lifted Spirits", Effect Duration: 19, Last Available: "2023-02"
-11135	rotten massive shadow sausage	10	crappy	Last Available: "2023-03"
+11135	massive rotten shadow sausage	10	crappy	Last Available: "2023-03"
 11136	huge scorching Lo Pan's shadow skin	0		Spell Critical Percent: +30, Hot Damage: +25, Last Available: "2023-03"
 11137	altered blinking shadow flame	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 39, Last Available: "2023-03"
-11138	bland twirling olive shadow bread	3	decent	Last Available: "2023-03"
+11138	bland olive twirling shadow bread	3	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	bad jittery shadow fluid	4	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	squat ghostly shadow sinew	0		Last Available: "2023-03"
-11144	triple-distilled perfectly mixed blurry shadow venom	7	EPIC	Last Available: "2023-03"
+11144	perfectly mixed triple-distilled blurry shadow venom	7	EPIC	Last Available: "2023-03"
 11145	boiled shaking shadow nectar	1		Last Available: "2023-03"
 11146	tumbling arcane researcher's smooth shadow stick of the brazier	0		Moxie: +15, Experience Percent (Mysticality): +10, Hot Spell Damage: +25, Last Available: "2023-03"
 11147	upside-down narrow slick wizardly bat paw	0		Mysticality: +25, Moxie: +10
@@ -11034,7 +11034,7 @@
 11179	blinking executive MacGyver's shadow hammer	0		Maximum MP: +100, Meat Drop: +40
 11180	Rosewater's sage shadow monocle of courage	0		Mysticality Percent: 40, Spooky Resistance: +3, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	decent yellow wobbly shadow hot dog	3	good	
+11182	decent wobbly yellow shadow hot dog	3	good	
 11183	tolerable weak shadow martini	2	good	
 11184	diluted lime green shadow pill	1		
 11185	blurry shadow needle	0		
@@ -11043,7 +11043,7 @@
 11188	irradiated ghostly shadow candy	0		Effect: "Fungal Flambé", Effect Duration: 61
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
-11191	skewed pulsating replica hand turkey outline	0		
+11191	pulsating skewed replica hand turkey outline	0		
 11192	replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
@@ -11060,9 +11060,9 @@
 11205	replica cotton candy cocoon	0		
 11206	wool flame-wreathed manspreader's arcane researcher's replica Elvish sunglasses	0		Experience Percent (Mysticality): +10, Monster Level: +10, Hot Spell Damage: +10, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	fuchsia replica squamous polyp	0		
-11208	blurry jittery replica stone sphere	0		
+11208	jittery blurry replica stone sphere	0		
 11209	shaking manspreader's wizardly brainy replica Greatest American Pants	0		Mysticality: 30, Monster Level: +10
-11210	upside-down wobbly replica organ grinder	0		
+11210	wobbly upside-down replica organ grinder	0		
 11211	quilted thinker's replica Juju Mojo Mask of mayonnaise	0		Mysticality: +10, Damage Absorption: +40, Sleaze Spell Damage: +50, Single Equip
 11212	electrified healthy replica Operation Patriot Shield of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	bouncing replica Libram of Resolutions	0		
@@ -11077,7 +11077,7 @@
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	extremely unsafe Sinatra's Fonzie's Cincho de Mayo of the storm	0		Experience (Moxie): 6, Weapon Damage Percent: +100, Maximum MP Percent: +40, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	jittery dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
-11225	blurry fuchsia replica Little Geneticist DNA-Splicing Lab	0		
+11225	fuchsia blurry replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
 11227	replica Crimbo sapling	0		
 11228	replica puck	0		
@@ -11131,7 +11131,7 @@
 11276	electrified altered tarnished scroll of protection from lycanthropes	0		Effect: "Comprehensively Nourished", Effect Duration: 38, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
-11279	huge lime green Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
+11279	lime green huge Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	lime green Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	blue Mr. Big's Wallet	0		Last Available: "2023-06"
 11282	high-proof bad spinning Sexy Cosmo	8	decent	Last Available: "2023-06"
@@ -11146,7 +11146,7 @@
 11291	blinking educational spider leg	0		Experience: +1
 11292	sage beetle antenna	0		Mysticality Percent: +10
 11293	mantis skull of courage	0		Spooky Resistance: +3
-11294	wet modified activated gray bouncing chitin powder	0		Effect: "Category", Effect Duration: 68
+11294	wet modified activated bouncing gray chitin powder	0		Effect: "Category", Effect Duration: 68
 11295	maroon up-at-dawn MacGyver's daddy shortlegs leg	0		Maximum MP: +100, Adventures: +5
 11296	smartaleck's savvy birdybug antenna	0		Mysticality Percent: +20, Moxie Percent: +30
 11297	supercharged kilopede skull of the bloodbag	0		Maximum HP: +100, Maximum MP Percent: +30
@@ -11163,16 +11163,16 @@
 11308	squat watermelon seed	0		
 11309	blinking water balloon	0		
 11310	tumbling thriftshop coupon	0		
-11311	delicious diet shaking bouncing waffle	1	awesome	
-11312	blinking pulsating fixodent	0		
+11311	delicious diet bouncing shaking waffle	1	awesome	
+11312	pulsating blinking fixodent	0		
 11313	bouncing perfumed smooth cat o' nine teeth	0		Moxie: +15, Stench Resistance: +5
 11314	dog trainer's Fonzie's tooth cap	0		Experience (Moxie): +1, Experience (familiar): +1
 11315	bouncing shaking padded toothy trousers of the businessman	0		Damage Absorption: +20, Meat Drop: +50
-11316	tasty jumbo red banana split	5	awesome	
+11316	jumbo tasty red banana split	5	awesome	
 11317	handful of toilet paper	0		
-11318	skewed pulsating Mrs. Rush	0		
+11318	pulsating skewed Mrs. Rush	0		
 11319	blurry medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	weak drinkable fuchsia bottle of Cabernet Sauvignon	2	good	
+11320	drinkable weak fuchsia bottle of Cabernet Sauvignon	2	good	
 11321	teal flame-wreathed mansplainer's veiny baywatch	0		Maximum HP: +10, Monster Level: +15, Hot Spell Damage: +10, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11323	huge Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
@@ -11225,12 +11225,12 @@
 11370	twirling security automa-core	0		
 11371	clerical automa-core	0		
 11372	purple handful of Boltsmann bearings	0		
-11373	squat gray Spring Bros. solenoid	0		
+11373	gray squat Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
 11375	Boltsmann ID badge	0		
-11376	blurry gray housekeeping automa-core	0		
+11376	gray blurry housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	fancy flavorless pickled bread	3	decent	Effect: "Expert Vacationer", Effect Duration: 45, Last Available: "2023-12"
+11378	flavorless fancy pickled bread	3	decent	Effect: "Expert Vacationer", Effect Duration: 45, Last Available: "2023-12"
 11379	normal salted mutton	3	good	Last Available: "2023-12"
 11380	rotten green corned beet	4	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11238,7 +11238,7 @@
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
 11384	tiny Crimbuccaneer Foundry	0		Initiative: +3
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
-11386	bouncing mirror pirate encryption key alpha	0		Last Available: "2023-12"
+11386	mirror bouncing pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
 11388	pulsating pirate encryption key charlie	0		Last Available: "2023-12"
 11389	skewed pirate encryption key delta	0		Last Available: "2023-12"
@@ -11261,20 +11261,20 @@
 11406	blinking Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	gray skewed savvy Crimbuccaneer shirt	0		Mysticality Percent: [+20*event(December)], Last Available: "2023-12"
 11408	pulsating Elf Guard MPC	0		Last Available: "2023-12"
-11409	huge cyan Crimbuccaneer piece of 12	0		Last Available: "2023-12"
+11409	cyan huge Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	Elf Guard commandeering gloves of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2023-12"
 11411	super-polarized colloidal mirror Elf Guard eyedrops	0		Effect: "Make Meat FA$T!", Effect Duration: 57, Last Available: "2023-12"
 11412	Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	frosty medical-grade Elf Guard officer's sidearm	0		Cold Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11415	scorching hale Elf Guard insignia (general)	0		Maximum HP: +20, Hot Damage: +25, Single Equip, Last Available: "2023-12"
-11416	irresponsibly strong perfectly mixed tumbling lime green Crimbow Rainbo	10	EPIC	Last Available: "2023-12"
+11416	perfectly mixed irresponsibly strong tumbling lime green Crimbow Rainbo	10	EPIC	Last Available: "2023-12"
 11417	tumbling Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	dog trainer's grievous Elf Guard broom	0		Weapon Damage Percent: +50, Experience (familiar): +1, Last Available: "2023-12"
 11420	rosewater-soaked sharpshooter's Crimbuccaneer tavern swab of doom	0		Critical Hit Percent: +10, Spooky Spell Damage: +50, Stench Resistance: +3, Last Available: "2023-12"
 11421	shaking Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	artisanal enchanted old-school pirate grog	4	EPIC	Effect: "Bureaucratized", Effect Duration: 10, Last Available: "2023-12"
+11422	enchanted artisanal old-school pirate grog	4	EPIC	Effect: "Bureaucratized", Effect Duration: 10, Last Available: "2023-12"
 11423	flavorless mirror grog nuts	4	decent	Last Available: "2023-12"
 11424	mirror nasty sharpshooter's rosy-cheeked sawed-off blunderbuss	0		Maximum HP Percent: +30, Critical Hit Percent: +10, Stench Damage: +5, Last Available: "2023-12"
 11425	smooth officer's nog	3	awesome	Last Available: "2023-12"
@@ -11282,7 +11282,7 @@
 11427	toothsome mirror sundae ration	4	awesome	Last Available: "2023-12"
 11428	adequate tiny peppermint tack	1	good	Last Available: "2023-12"
 11429	lime green Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	adequate mirror red whalesteak	4	good	Last Available: "2023-12"
+11430	adequate red mirror whalesteak	4	good	Last Available: "2023-12"
 11431	squat padded whalegun of the ox of the detective	0		Muscle: +20, Damage Absorption: +20, Item Drop: +20, Last Available: "2023-12"
 11432	spinning Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11313,11 +11313,11 @@
 11458	asbestos-lined Crimbuccaneer bombjacket of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	bland sugarplum ration	4	decent	Last Available: "2023-12"
 11460	toothsome gingerbread nylons	3	awesome	Last Available: "2023-12"
-11461	small moldy rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
+11461	moldy small rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
 11462	decent special maroon lime	4	good	Effect: "Always be Collecting", Effect Duration: 45, Last Available: "2023-12"
-11463	delicious skewed cyan gingerbread pirate	3	awesome	Last Available: "2023-12"
-11464	adequate half-sized fruit-stuffed rumcake	2	good	Last Available: "2023-12"
-11465	enchanted watered-down artisanal jittery mulled wine	2	EPIC	Effect: "Dweeby", Effect Duration: 25, Last Available: "2023-12"
+11463	delicious cyan skewed gingerbread pirate	3	awesome	Last Available: "2023-12"
+11464	half-sized adequate fruit-stuffed rumcake	2	good	Last Available: "2023-12"
+11465	watered-down artisanal enchanted jittery mulled wine	2	EPIC	Effect: "Dweeby", Effect Duration: 25, Last Available: "2023-12"
 11466	weak hand-crafted bouncing Swedish coffee	2	EPIC	Last Available: "2023-12"
 11467	perfectly mixed canteen of eggnog	3	super EPIC	Last Available: "2023-12"
 11468	perfectly mixed narrow hot wine	3	EPIC	Last Available: "2023-12"
@@ -11355,7 +11355,7 @@
 11500	shaking The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	double-electrified diffused pulsating ghostly military candy cane	0		Effect: "Slightly Mutated", Effect Duration: 28
-11503	adjusted Vulcanized extra-magnetized twirling gray groggipop	0		Effect: "Very Clean Teeth", Effect Duration: 50
+11503	adjusted Vulcanized extra-magnetized gray twirling groggipop	0		Effect: "Very Clean Teeth", Effect Duration: 50
 11504	manspreader's moss mace of the pedagogue	0		Experience: +3, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
 11505	Lo Pan's deadly moss megaphone	0		Weapon Damage: +5, Spell Critical Percent: +30, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
 11506	veiny Herculean moss medal	0		Experience (Muscle): +1, Maximum HP: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
@@ -11365,7 +11365,7 @@
 11510	vaporized cyan moss mulch	1		Effect: "Lemon Enlightenment", Effect Duration: 5, Last Available: "2024-12"
 11511	ionized spinning huge moss floss	0		Effect: "Smoking like a Bandit", Effect Duration: 49
 11512	purple wobbly adobe arsecover	0		Last Available: "2024-12"
-11513	teal pulsating adobe adze	0		Single Equip, Last Available: "2024-12"
+11513	pulsating teal adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
@@ -11382,8 +11382,8 @@
 11527	improved denatured shaking crepe paper peanut candy	0		Effect: "Educated (Kinda)", Effect Duration: 49
 11528	Sherlock's petrified wood war pike of Leguizamo	0		Monster Level: +20, Item Drop: +25, Last Available: "2025-12"
 11529	dance instructor's petrified wood waist protector of doom	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
-11530	shaking petrified wood wizard's pouch of the sweet-tooth of Flo-Jo	0		Candy Drop: +100, Initiative: +100, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	educational petrified wood water purifier of the wise owl	0		Mysticality: +20, Experience: +1, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	shaking petrified wood wizard's pouch of the sweet-tooth of Flo-Jo	0		Candy Drop: +100, Initiative: +100, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	educational petrified wood water purifier of the wise owl	0		Mysticality: +20, Experience: +1, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	curative petrified wood whoopie panama of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12"
 11533	lard-coated Jack Frost's petrified wood walking pants	0		Cold Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2025-12"
 11534	altered petrified wood waste parts	1		Last Available: "2025-12"
@@ -11426,9 +11426,9 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	spoiled low-calorie yam	1	crappy	Last Available: "2024-05"
-11574	aged triple-distilled yam martini	8	awesome	Last Available: "2024-05"
+11574	triple-distilled aged yam martini	8	awesome	Last Available: "2024-05"
 11575	aged practically non-alcoholic sweet potato o' mine	1	awesome	Last Available: "2024-05"
-11576	mediocre weak Southern yam	2	decent	Last Available: "2024-05"
+11576	weak mediocre Southern yam	2	decent	Last Available: "2024-05"
 11577	tolerable sweet potato punch	3	good	Last Available: "2024-05"
 11578	bland bouncing Mayam spinach	3	decent	Last Available: "2024-05"
 11579	big stale blinking yam and swiss	5	decent	Last Available: "2024-05"
@@ -11441,20 +11441,20 @@
 11586	healthy personal trainer's brawny yamtility belt	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2024-05"
 11587	enchanted tasty yam slider	4	awesome	Effect: "Pharmaceutically Cool", Effect Duration: 30, Last Available: "2024-05"
 11588	delicious jumbo yam mayo	5	awesome	Last Available: "2024-05"
-11589	tasty jumbo blinking mirror lime green yam burrito	5	awesome	Last Available: "2024-05"
+11589	tasty jumbo mirror blinking lime green yam burrito	5	awesome	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	red mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	enchanted stale mini kiwi	3	decent	Effect: "Fancy Feasted", Effect Duration: 30, Last Available: "2024-06"
 11595	miser's steel-toed mini kiwi bikini of temperance	0		Damage Reduction: 9, Sleaze Resistance: +5, Meat Drop: +10, Last Available: "2024-06"
-11596	mediocre watered-down mini kiwitini	2	decent	Last Available: "2024-06"
+11596	watered-down mediocre mini kiwitini	2	decent	Last Available: "2024-06"
 11597	shaking mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	tumbling bouncing mini kiwi aioli	0		
 11599	Jim Carey's steel-toed mini kiwi silicon tiepin of mayonnaise	0		Damage Reduction: 9, Monster Level: +25, Sleaze Spell Damage: +50
 11600	blue mini kiwi tipi	0		
 11601	rotten mini kiwi digitized cookies	4	crappy	
-11602	hand-crafted watered-down bouncing mini kiwi intoxicating spirits	2	EPIC	
+11602	watered-down hand-crafted bouncing mini kiwi intoxicating spirits	2	EPIC	
 11603	unsweetened jittery mini kiwi antimilitaristic hippy petition	0		Effect: "Milk Studly", Effect Duration: 63
 11604	super-ionized mini kiwi illicit antibiotic	0		Effect: "The Halls of Muscularity", Effect Duration: 28
 11605	twirling inspector's Oprah's mini kiwi whipping stick	0		Maximum MP Percent: +50, Item Drop: +15
@@ -11487,13 +11487,13 @@
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	wobbly tattoo gun	0		
-11635	smooth practically non-alcoholic Colera Peste Nebbiolo	1	awesome	
+11635	practically non-alcoholic smooth Colera Peste Nebbiolo	1	awesome	
 11636	blue longbox of Batfellow comics	0		
 11637	green Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	green Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
-11641	bouncing fuchsia boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
+11641	fuchsia bouncing boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	twirling Sept-Ember Censer	0		Last Available: "2024-09"
 11643	friendly blade of dismemberment	0		Familiar Weight: +3, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
@@ -11526,7 +11526,7 @@
 11671	reassuring careful photo booth supply list	0		Monster Level: -10, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	twirling tie-dye headband	0		
-11674	toothsome gigantic blurry olive whirled peas	6	awesome	Last Available: "2024-11"
+11674	toothsome gigantic olive blurry whirled peas	6	awesome	Last Available: "2024-11"
 11675	bland peaza	4	decent	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	altered lime green drenchrome 2.0	1		Last Available: "2025-12"
@@ -11535,7 +11535,7 @@
 11680	narrow quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	denatured flattened wobbly pea brittle	0		Effect: "Dreadful Sheen", Effect Duration: 19, Last Available: "2024-11"
-11683	watered-down drinkable bouncing peasco	2	good	Last Available: "2024-11"
+11683	drinkable watered-down bouncing peasco	2	good	Last Available: "2024-11"
 11684	rotten skewed piece of cake	4	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	maroon Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
@@ -11545,7 +11545,7 @@
 11690	jolly roger flag of Tarzan	0		Experience (Muscle): +3, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	fancy artisanal irresponsibly strong tankard of spiced rum	8	EPIC	Effect: "Eggs-tra Sensory Perception", Effect Duration: 50, Last Available: "2024-12"
+11693	irresponsibly strong fancy artisanal tankard of spiced rum	8	EPIC	Effect: "Eggs-tra Sensory Perception", Effect Duration: 50, Last Available: "2024-12"
 11694	drinkable triple-distilled tankard of spiced Goldschlepper	6	good	Last Available: "2024-12"
 11695	red packaged luxury garment	0		Last Available: "2024-12"
 11696	governor's daughter's lace collar of doom	0		Spooky Spell Damage: +50, Last Available: "2024-12"
@@ -11560,7 +11560,7 @@
 11705	pirate dinghy	0		Last Available: "2024-12"
 11706	tumbling anchor bomb	0		Last Available: "2024-12"
 11707	pulsating shaking Usain Bolt's Annie Oakley's silky pirate drawers	0		Critical Hit Percent: +20, Initiative: +80, Last Available: "2024-12"
-11708	blinking narrow profane eye patch	0		Sleaze Damage: +3
+11708	narrow blinking profane eye patch	0		Sleaze Damage: +3
 11709	alkaline peppermint pegleg	0		Effect: "Salamanderenity", Effect Duration: 44, Last Available: "2024-12"
 11710	acceptable hard cocoa	3	good	Last Available: "2024-12"
 11711	spoiled salmagumdi	3	crappy	Last Available: "2024-12"
@@ -11599,18 +11599,18 @@
 11744	modified boiled LIDAR candle	0		Effect: "Electrolit Up", Effect Duration: 43, Last Available: "2024-12"
 11745	Lo Pan's clever therapeutic Congressional Medal of Insanity	0		Maximum MP: +20, Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11746	narrow pumpkin spice whorl	0		Last Available: "2024-12"
-11747	acceptable watered-down narrow Easter grasshopper	2	good	Last Available: "2024-12"
+11747	watered-down acceptable narrow Easter grasshopper	2	good	Last Available: "2024-12"
 11748	aged weak enchanted Irish eggnog	2	awesome	Effect: "Mad at Science", Effect Duration: 45, Last Available: "2024-12"
-11749	watered-down acceptable canteen of jungle juice	2	good	Last Available: "2024-12"
-11750	hand-crafted fancy pulsating turchucken	3	EPIC	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2024-12"
-11751	weak bad mechanically-mulled cider	2	decent	Last Available: "2024-12"
+11749	acceptable watered-down canteen of jungle juice	2	good	Last Available: "2024-12"
+11750	fancy hand-crafted pulsating turchucken	3	EPIC	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2024-12"
+11751	bad weak mechanically-mulled cider	2	decent	Last Available: "2024-12"
 11752	tolerable holiday trip around the world	3	good	Last Available: "2024-12"
-11753	big moldy chocolate ostrich egg	5	crappy	Last Available: "2024-12"
+11753	moldy big chocolate ostrich egg	5	crappy	Last Available: "2024-12"
 11754	spoiled gray beef and cabbage	4	crappy	Last Available: "2024-12"
-11755	adequate huge maroon candy rations	9	good	Last Available: "2024-12"
+11755	huge adequate maroon candy rations	9	good	Last Available: "2024-12"
 11756	stale huge double-candied yams	4	decent	Last Available: "2024-12"
-11757	normal jumbo Christmas ham	5	good	Last Available: "2024-12"
-11758	moldy low-calorie holiday smorgasbord	1	crappy	Last Available: "2024-12"
+11757	jumbo normal Christmas ham	5	good	Last Available: "2024-12"
+11758	low-calorie moldy holiday smorgasbord	1	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	grievous bejazzled eyepatch	0		Weapon Damage Percent: +50, Last Available: "2024-12"
 11761	yellow squat Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
@@ -11618,7 +11618,7 @@
 11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	bouncing Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	narrow twirling Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	twirling narrow Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11767	red Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
 11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
 11769	narrow Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
@@ -11628,9 +11628,9 @@
 11773	extremely unsafe Rosewater's army helmet of the wise owl of the boozehound	0		Mysticality: +20, Mysticality Percent: +30, Weapon Damage Percent: +100, Booze Drop: +100, Last Available: "2024-12"
 11774	jittery candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
-11776	massive stale Thanksgiving ration	8	decent	Last Available: "2024-12"
+11776	stale massive Thanksgiving ration	8	decent	Last Available: "2024-12"
 11777	hand-crafted fuchsia Easter eggnog	3	super ultra EPIC	Last Available: "2024-12"
-11778	vaporized tumbling red clovermint	1		Effect: "Inner Dog", Effect Duration: 25, Last Available: "2024-12"
+11778	vaporized red tumbling clovermint	1		Effect: "Inner Dog", Effect Duration: 25, Last Available: "2024-12"
 11779	Socratic thinker's brainy nylon Christmas stockings of the detective	0		Mysticality: 15, Experience (Mysticality): +1, Item Drop: +20, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	quantum deviled candy egg	0		Effect: "Improprie Tea", Effect Duration: 27, Last Available: "2024-12"
@@ -11659,12 +11659,12 @@
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
 11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
-11807	skewed blurry CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
+11807	blurry skewed CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
-11812	vaporized jittery shaking psilocyber mushroom	1		Last Available: "2025-12"
+11812	vaporized shaking jittery psilocyber mushroom	1		Last Available: "2025-12"
 11813	skewed dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
@@ -11674,13 +11674,13 @@
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
-11822	maroon spinning OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
+11822	spinning maroon OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	fuchsia STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	fuchsia insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
 11827	ghostly geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
-11828	olive jittery geofencing shield	0		Last Available: "2025-12"
+11828	jittery olive geofencing shield	0		Last Available: "2025-12"
 11829	maroon virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	ghostly ninja crampons	0		
@@ -11716,8 +11716,8 @@
 11861	wobbly Leprecondo	0		Last Available: "2025-03"
 11862	diluted scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	artisanal weak ghostly pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
-11865	twisted lime green ghostly ghostly phosphor traces	1		Effect: "Pisces in the Skyces", Effect Duration: 45, Last Available: "2025-03"
+11864	weak artisanal ghostly pint of Leprechaun Stout	2	EPIC	Last Available: "2025-03"
+11865	twisted ghostly lime green ghostly phosphor traces	1		Effect: "Pisces in the Skyces", Effect Duration: 45, Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	bouncing Book of Irony	0		Skill: "Generate Irony"
 11868	wobbly spoon	0		
@@ -11726,7 +11726,7 @@
 11871	altered pulsating blue leprechaun antidepressant pill	1		Effect: "Going Ape", Effect Duration: 25, Last Available: "2025-03"
 11872	spoiled upside-down Heck ramen	3	crappy	Last Available: "2025-03"
 11873	rotten burrito	3	crappy	Last Available: "2025-03"
-11874	fancy bite-sized flavorless blurry blue small beer brat	1	decent	Effect: "Jacked In", Effect Duration: 35, Last Available: "2025-03"
+11874	flavorless fancy bite-sized blue blurry small beer brat	1	decent	Effect: "Jacked In", Effect Duration: 35, Last Available: "2025-03"
 11875	rotten snack-sized peach pie	2	crappy	Last Available: "2025-03"
 11876	spoiled upside-down incredible mini-pizza	3	crappy	Last Available: "2025-03"
 11877	artisanal triple-distilled Divine sidecar	8	EPIC	Last Available: "2025-03"
@@ -11735,13 +11735,13 @@
 11880	artisanal green vodka stratocaster sidecar	3	EPIC	Last Available: "2025-03"
 11881	tolerable prussian cathouse sidecar	3	good	Last Available: "2025-03"
 11882	hand-crafted Mon Tiki sidecar	4	EPIC	Last Available: "2025-03"
-11883	spinning tumbling lime green Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
+11883	tumbling lime green spinning Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	chilly April Shower Thoughts shield	0		Cold Damage: +5, Item Drop: +5, Damage Reduction: 6, Last Available: "2025-04"
-11885	ghostly yellow glob of wet paper	0		Last Available: "2025-04"
+11885	yellow ghostly glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	ionized nitrogenated wet paper weights	0		Effect: "Quadrilled", Effect Duration: 44, Last Available: "2025-04"
 11888	hand-crafted Three Sheets to the Wind	4	EPIC	Last Available: "2025-04"
-11889	rotten snack-sized olive pile of wet dates	2	crappy	Last Available: "2025-04"
+11889	snack-sized rotten olive pile of wet dates	2	crappy	Last Available: "2025-04"
 11890	teal papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	flame-wreathed wet shower cap	0		Hot Spell Damage: +10, Last Available: "2025-04"
@@ -11751,7 +11751,7 @@
 11896	wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
 11898	dry corrupted olive wobbly wet paper cup	0		Effect: "Fruited", Effect Duration: 48, Last Available: "2025-04"
-11899	flattened yellow squat wet paperback	0		Effect: "The Halls of Moxiousness", Effect Duration: 64, Last Available: "2025-04"
+11899	flattened squat yellow wet paperback	0		Effect: "The Halls of Moxiousness", Effect Duration: 64, Last Available: "2025-04"
 11900	occult wet shower radio	0		Spell Damage Percent: +25, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	pulsating wet shower stamp	0		Last Available: "2025-04"
 11902	lightning-fast birthday bloon	0		Initiative: +40
@@ -11789,8 +11789,8 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	blue confetti grenade	0		
-11937	big rotten Skeleton Wars rations	5	crappy	
-11938	practically non-alcoholic bad fuchsia skeleton war fuel can	1	decent	
+11937	rotten big Skeleton Wars rations	5	crappy	
+11938	bad practically non-alcoholic fuchsia skeleton war fuel can	1	decent	
 11939	blinking skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	skewed M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,11 +11804,11 @@
 11949	frightening bully badge	0		Spooky Damage: +5, Lasts Until Rollover, Last Available: "2025-08"
 11950	time cop top hat of the cougar	0		Moxie: +20, Last Available: "2025-08"
 11951	blinking Stock Certificate	0		Last Available: "2025-08"
-11952	modified squat fuchsia mixed berry jelly	1		Last Available: "2025-08"
+11952	modified fuchsia squat mixed berry jelly	1		Last Available: "2025-08"
 11953	normal toast with mixed berry jelly	3	good	Last Available: "2025-08"
 11954	rotten cup of sugar	4	crappy	Last Available: "2025-08"
-11955	tasty bite-sized Susie's cupcake	1	awesome	Last Available: "2025-08"
-11956	olive mirror clock	0		Last Available: "2025-08"
+11955	bite-sized tasty Susie's cupcake	1	awesome	Last Available: "2025-08"
+11956	mirror olive clock	0		Last Available: "2025-08"
 11957	auspicious Jeselnik's the gun of the sewer	0		Stench Damage: +25, Sleaze Damage: +25, Item Drop: +10, Last Available: "2025-08"
 11958	lousy fuchsia wine	3	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
@@ -11833,20 +11833,20 @@
 11987	perfumed scorching stiffened baleful wicked blood cubic zirconia of the ox	0		Muscle: +20, Spell Damage: 30, Damage Reduction: 1, Hot Damage: +25, Stench Resistance: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	boiled upside-down blood thinner	1		Effect: "Concentrated Concentration", Effect Duration: 5, Last Available: "2025-10"
 12045	tolerable pheromone cocktail	4	good	Last Available: "2025-10"
-12046	delicious spinning wobbly spinal tapas	3	awesome	Last Available: "2025-10"
+12046	delicious wobbly spinning spinal tapas	3	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	huge Jeselnik's padded shrunken head of incineration	0		Damage Absorption: +20, Hot Spell Damage: +50, Sleaze Damage: +25, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	pulsating stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	drinkable practically non-alcoholic jittery Smoking Pope	1	good	
-12053	bland tiny prize turkey	1	decent	
+12052	practically non-alcoholic drinkable jittery Smoking Pope	1	good	
+12053	tiny bland prize turkey	1	decent	
 12054	altered medicinal gruel	1		
 12055	flavorless twirling full-sized pumpkin pie	4	decent	Last Available: "2025-11"
 12056	drinkable fancy vodka cranberry sauce	4	good	Effect: "I See Everything Thrice!", Effect Duration: 10, Last Available: "2025-11"
 12057	anodized yellow yammed candy	0		Effect: "Pill Power", Effect Duration: 35, Last Available: "2025-11"
-12058	miniature stale fancy purple treasure chestnut	2	decent	Effect: "EVISCERATE!", Effect Duration: 25, Last Available: "2025-12"
-12059	watered-down artisanal tumbling mulled butter rum	2	EPIC	Last Available: "2025-12"
+12058	fancy miniature stale purple treasure chestnut	2	decent	Effect: "EVISCERATE!", Effect Duration: 25, Last Available: "2025-12"
+12059	artisanal watered-down tumbling mulled butter rum	2	EPIC	Last Available: "2025-12"
 12060	liquefied pulsating cinnamon doubloon	0		Effect: "Insatiable Hunger", Effect Duration: 51, Last Available: "2025-12"
 12061	chaotic plastic left skeleton arm	0		Spell Critical Percent: +10, Last Available: "2025-12"
 12062	huge yellow Usain Bolt's plastic left skeleton leg	0		Initiative: +80, Last Available: "2025-12"
@@ -11881,7 +11881,7 @@
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	hand-crafted Steve Abrams' Holiday Sampler Beer	3	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	aged watered-down bottle of prize-winning rum	2	awesome	Last Available: "2025-12"
+12126	watered-down aged bottle of prize-winning rum	2	awesome	Last Available: "2025-12"
 12127	prompt resourceful Santa-Slayer medal of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +50, Adventures: +3, Single Equip, Last Available: "2025-12"
 12128	spinning Skull of Claus	0		Last Available: "2025-12"
 12129	tarnished boiling bone marrow	0		Effect: "No Worries", Effect Duration: 12, Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	red Tesla vibrating vermiculite shield	0		Maximum MP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 9, Last Available: "2025-12"
 12169	blinking Usain Bolt's ship's lantern	0		Initiative: +80, Last Available: "2025-12"
 12170	frosty stiffened heat-resistant harpoon pistol	0		Damage Reduction: 1, Cold Spell Damage: +10, Last Available: "2025-12"
-12171	snack-sized bland traditional gingerloaf	2	decent	Last Available: "2025-12"
+12171	bland snack-sized traditional gingerloaf	2	decent	Last Available: "2025-12"
 12172	perfectly mixed fortified Scotch and eggnog	5	EPIC	Last Available: "2025-12"
 12173	colloidal wet gray counterskeleton elixir	0		Effect: "Deeply Ironic", Effect Duration: 47, Last Available: "2025-12"
 12174	lousy triple-distilled &quot;salvaged&quot; wine	10	decent	Last Available: "2025-12"
@@ -11964,16 +11964,16 @@
 12206	blurry Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	green Pork Elf sink	0		Last Available: "2026-03"
 12208	fuchsia Pork Elf toilet	0		Last Available: "2026-03"
-12209	small spoiled rat pizza	2	crappy	Last Available: "2026-03"
+12209	spoiled small rat pizza	2	crappy	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	nasty Lo Pan's resourceful hoverboard	0		Maximum MP: +50, Spell Critical Percent: +30, Stench Damage: +5, Single Equip, Last Available: "2026-03"
 12212	ribald left shark fin of terror of the cheetah	0		Spooky Spell Damage: +10, Sleaze Damage: +10, Initiative: +60, Last Available: "2026-03"
 12213	twirling experienced fitness tracking bracelet	0		Experience: +2, Single Equip, Last Available: "2026-03"
-12214	altered twirling wobbly candy bone	1		Effect: "Mushroom Moxiousness", Effect Duration: 15
+12214	altered wobbly twirling candy bone	1		Effect: "Mushroom Moxiousness", Effect Duration: 15
 12215	spinning wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	huge normal wobbly discarded hot dog	9	good	Last Available: "2026-04"
-12218	bad watered-down most of a beer	2	decent	Last Available: "2026-04"
+12217	normal huge wobbly discarded hot dog	9	good	Last Available: "2026-04"
+12218	watered-down bad most of a beer	2	decent	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
@@ -11990,11 +11990,11 @@
 12236	stale snack-sized maroon Pesto alla Marziano	2	decent	Last Available: "2026-05"
 12237	jumbo stale squat Arrattabbattabiata	5	decent	Last Available: "2026-05"
 12238	jumbo decent Orzo di Riso	5	good	Last Available: "2026-05"
-12239	snack-sized moldy Pasta Grimavera	2	crappy	Last Available: "2026-05"
+12239	moldy snack-sized Pasta Grimavera	2	crappy	Last Available: "2026-05"
 12240	moldy jittery Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
 12241	miniature bland Formica e Pepe	2	decent	Last Available: "2026-05"
 12242	normal Tubetto Gelatto	3	good	Last Available: "2026-05"
-12243	stale diet Gnocci Domani	1	decent	Last Available: "2026-05"
+12243	diet stale Gnocci Domani	1	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12019,13 +12019,13 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	shaking pulsating censurious rosy-cheeked Fonzie's Portable Laughing Stock	0		Experience (Moxie): +1, Maximum HP Percent: +30, Sleaze Resistance: +3, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	scorching wholesome Staff of Anachronistic Churning of the boozehound	0		Maximum HP Percent: +10, Hot Damage: +25, Booze Drop: +100
-12272	normal fancy classic banana	4	good	Effect: "Influence of Sphere", Effect Duration: 5, Last Available: "2026-07"
+12272	fancy normal classic banana	4	good	Effect: "Influence of Sphere", Effect Duration: 5, Last Available: "2026-07"
 12273	delicious spinning watermelon	4	awesome	Last Available: "2026-07"
 12274	normal gigantic quince	8	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	fancy flavorless jittery classic banana pie	4	decent	Effect: "Human-Beast Hybrid", Effect Duration: 50, Last Available: "2026-07"
-12278	triple-concentrated purple blurry essential banana decoction	0		Effect: "Adventurer's Best Friendship", Effect Duration: 17, Last Available: "2026-07"
+12278	triple-concentrated blurry purple essential banana decoction	0		Effect: "Adventurer's Best Friendship", Effect Duration: 17, Last Available: "2026-07"
 12279	unsweetened energized bouncing banana quintessence	0		Effect: "Fishy", Effect Duration: 68, Last Available: "2026-07"
 12280	hand-crafted teal Aesop Daiquiri	3	EPIC	Last Available: "2026-07"
 12281	aged practically non-alcoholic bouncing gray Monkey Congress	1	awesome	Last Available: "2026-07"
@@ -12037,7 +12037,7 @@
 12287	moldy skewed quince pie	3	crappy	Last Available: "2026-07"
 12288	modified quince quaff	0		Effect: "Certainty", Effect Duration: 15, Last Available: "2026-07"
 12289	extra-dry ionized upside-down Quickquince	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 36, Last Available: "2026-07"
-12290	drinkable triple-distilled Quiskey Sour	7	good	Last Available: "2026-07"
+12290	triple-distilled drinkable Quiskey Sour	7	good	Last Available: "2026-07"
 12291	mediocre Quincea&ntilde;era Cooler	4	decent	Last Available: "2026-07"
 12292	mediocre Roth IPA	4	decent	Last Available: "2026-08"
 12293	zippy knitted underdraft protection	0		Cold Resistance: +3, Initiative: +20, Last Available: "2026-08"
@@ -12057,7 +12057,7 @@
 12307	chilled bouncing mint	0		Effect: "Paging Betty", Effect Duration: 42, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	mirror homeowner's loam	0		Last Available: "2026-08"
-12310	dehydrated tumbling spinning toxic asset	1		Last Available: "2026-08"
+12310	dehydrated spinning tumbling toxic asset	1		Last Available: "2026-08"
 12311	mixed huge intangible asset	1		Last Available: "2026-08"
 12312	modified gray liquid asset	1		Effect: "Warm Shoulders", Effect Duration: 30, Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Platypus_cafe_booze.txt
@@ -3,7 +3,7 @@
 -3	perfectly mixed Infinitesimal IPA	3	EPIC	
 -4	tolerable eggnogtini	3	good	
 -5	tolerable candycaine	4	good	
--6	mediocre practically non-alcoholic braincracker sweet	1	decent	
+-6	practically non-alcoholic mediocre braincracker sweet	1	decent	
 -16	mediocre fermented honey	3	decent	
 -17	fortified aged moons-shine	5	awesome	
 -18	smooth irresponsibly strong purple gin	9	awesome	
@@ -11,17 +11,17 @@
 -20	irresponsibly strong drinkable hot toady	7	good	
 -21	artisanal hot choculate	3	EPIC	
 -49	drinkable fancy Cyder	3	good	
--50	watered-down acceptable Oil Nog	2	good	
+-50	acceptable watered-down Oil Nog	2	good	
 -51	hand-crafted Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	mediocre Grimacider	3	decent	
 -59	special lousy purple Isotope Nog	3	decent	
 -60	drinkable Mutagin 'n' Tonic	3	good	
--70	watered-down aged Gin and Herring	2	awesome	
+-70	aged watered-down Gin and Herring	2	awesome	
 -71	aged squat Black and Tan and Red All Over	3	awesome	
 -72	perfectly mixed Antarctic Ice Tea	4	EPIC	
 -76	mediocre CRIMBCO Ribbon Candy Schnapps	3	decent	
 -77	bad practically non-alcoholic CRIMBCO Egg Substitute Nog Substitute	1	decent	
--78	lousy watered-down CRIMBCO Extreme Braincracker Sour	2	decent	
+-78	watered-down lousy CRIMBCO Extreme Braincracker Sour	2	decent	
 -82	watered-down smooth Horseradish-infused Vodka	2	awesome	
 -83	hand-crafted Jerkitini	3	EPIC	
 -84	lousy wobbly Desert Island Iced Tea	3	decent	
@@ -30,4 +30,4 @@
 -90	drinkable Flaming Crimbo Log	3	good	
 -107	bad high-proof Fortified Eggnog Slurry	10	decent	
 -108	high-proof mediocre Hot Buttered Rum	8	decent	
--109	hand-crafted boozy enchanted Spicy Hot Chocolate	5	EPIC	
+-109	enchanted hand-crafted boozy Spicy Hot Chocolate	5	EPIC	

--- a/data/TCRS/TCRS_Disco_Bandit_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Platypus_cafe_food.txt
@@ -1,10 +1,10 @@
 -1	immense bland teal Peche a la Frog	8	decent	
 -2	spoiled half-sized As Jus Gezund Heit	2	crappy	
 -3	delicious Bouillabaise Coucher Avec Moi	3	awesome	
--7	rotten immense gumdrop chow mein	9	crappy	
+-7	immense rotten gumdrop chow mein	9	crappy	
 -8	flavorless candy cane pizza	4	decent	
--9	yummy massive upside-down gingerbread stir-fry	7	awesome	
--10	decent huge squat twigs and gravel	7	good	
+-9	massive yummy upside-down gingerbread stir-fry	7	awesome	
+-10	huge decent squat twigs and gravel	7	good	
 -11	rotten shoots and leaves	4	crappy	
 -12	big rotten bowl of unidentifiable goo	5	crappy	
 -13	flavorless gingerbread massacre	4	decent	
@@ -13,24 +13,24 @@
 -52	flavorless Soylent Red and Green	4	decent	
 -53	normal small narrow Disc-Shaped Nutrition Unit	2	good	
 -54	immense bland spinning Gingerborg Hive	6	decent	
--61	tiny rotten Candy Cane Surprise	1	crappy	
+-61	rotten tiny Candy Cane Surprise	1	crappy	
 -62	normal Grimdrop Chow Mein	4	good	
 -63	bland Grimgerbread House	4	decent	
 -67	decent huge Caviar Carbonara	3	good	
 -68	normal Halibut Alfredo	4	good	
 -69	delicious Red Herring Velvet Cake	4	awesome	
 -73	miniature stale CRIMBCO Reconstituted Gruel	2	decent	
--74	miniature normal skewed New and Improved CRIMBCO Reconstituted Gruel	2	good	
+-74	normal miniature skewed New and Improved CRIMBCO Reconstituted Gruel	2	good	
 -75	snack-sized normal twirling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	good	
 -79	adequate Brussels Sprout Stir-Fry	3	good	
 -80	adequate big twirling Carrot, Cabbage, and Kale Pizza	5	good	
 -81	moldy blue Turnip and Rutabaga Pie	3	crappy	
--85	small special stale shaking Rainbow Spider Fun Roll	2	decent	
+-85	stale small special shaking Rainbow Spider Fun Roll	2	decent	
 -86	tasty Vegas Volcano Lava Roll	3	awesome	
--87	toothsome small wobbly Crazy Dragon Shogun Buddha Roll	2	awesome	
--92	rotten snack-sized basic hot dog	2	crappy	
+-87	small toothsome wobbly Crazy Dragon Shogun Buddha Roll	2	awesome	
+-92	snack-sized rotten basic hot dog	2	crappy	
 -93	tasty savage macho dog	3	awesome	
--94	normal huge upside-down one with everything	9	good	
+-94	huge normal upside-down one with everything	9	good	
 -95	decent super-sized sly dog	5	good	
 -96	toothsome snack-sized devil dog	2	awesome	
 -97	half-sized stale chilly dog	2	decent	
@@ -40,6 +40,6 @@
 -101	bland low-calorie sleeping dog	1	decent	
 -102	rotten tiny optimal dog	1	crappy	
 -103	stale wobbly video games hot dog	3	decent	
--104	huge bland maroon Peppermint Nutrition Block	8	decent	
+-104	bland huge maroon Peppermint Nutrition Block	8	decent	
 -105	normal teal Gingerbread Nutrition Block	4	good	
 -106	bland skewed Cinnamon Nutrition Block	4	decent	

--- a/data/TCRS/TCRS_Disco_Bandit_Vole.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Vole.txt
@@ -1,8 +1,8 @@
-1	pulsating teal bouncing seal-clubbing club	0		
+1	bouncing teal pulsating seal-clubbing club	0		
 2	jittery seal tooth	0		
 3	huge helmet turtle of the ox	0		Muscle: +20, Familiar Effect: "atk, cap 2"
 4	squat turtle totem	0		
-5	mirror fuchsia pasta spoon	0		
+5	fuchsia mirror pasta spoon	0		
 6	chaotic ravioli hat	0		Spell Critical Percent: +10, Familiar Effect: "atk, cap 2"
 7	saucepan	0		
 8	spices	0		
@@ -45,7 +45,7 @@
 46	figurine	0		
 47	rotten wobbly hot buttered roll	3	crappy	
 48	heart of rock and roll	0		
-49	half-sized moldy bowl of cottage cheese	2	crappy	
+49	moldy half-sized bowl of cottage cheese	2	crappy	
 50	jittery twirling Tesla Rock and Roll Legend	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10
 51	mirror clever Knob Goblin Uberpants	0		Maximum MP: +20, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	bouncing banjo strings	0		
@@ -79,7 +79,7 @@
 80	ghostly fairy gravy boat	0		
 81	hand-crafted ice-cold Willer	3	EPIC	
 82	ring	0		
-83	skewed green shaft	0		
+83	green skewed shaft	0		
 84	Orcish meat locker	0		
 85	huge unlocked meat locker	0		
 86	key	0		
@@ -115,9 +115,9 @@
 116	rosewater-soaked personal trainer's Bugfinder Blade	0		Experience Percent (Muscle): +10, Stench Resistance: +3
 117	ghostly Gnollish plunger	0		
 118	spring	0		
-119	wobbly blinking sprocket	0		
+119	blinking wobbly sprocket	0		
 120	cog	0		
-121	wobbly spinning sprocket assembly	0		
+121	spinning wobbly sprocket assembly	0		
 122	blue cog and sprocket assembly	0		
 123	bouncing Gnollish flyswatter	0		
 124	empty meat tank	0		
@@ -158,7 +158,7 @@
 159	lime green wad of dough	0		
 160	squat pie crust	0		
 161	bland olive ghuol egg	3	decent	
-162	miniature flavorless ghuol egg quiche	2	decent	
+162	flavorless miniature ghuol egg quiche	2	decent	
 163	Tesla skeleton bone	0		MP Regen Min: 7, MP Regen Max: 10
 164	purple smart skull	0		
 165	skewer	0		
@@ -167,7 +167,7 @@
 168	blue brainy bone rattle	0		Mysticality: +5
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	fancy normal tiny pulsating lihc eye pie	1	good	Effect: "Oiled Skin", Effect Duration: 30
+171	normal fancy tiny pulsating lihc eye pie	1	good	Effect: "Oiled Skin", Effect Duration: 30
 172	gnoll lips	0		
 173	jittery taco shell	0		
 174	Gnollish casserole dish	0		
@@ -175,7 +175,7 @@
 176	disembodied brain	0		
 177	brainy skull	0		
 178	cyan detective skull	0		
-179	bland small chorizo taco	2	decent	
+179	small bland chorizo taco	2	decent	
 180	mediocre ice-cold fotie	3	decent	
 181	spinning baseball	0		
 182	twirling batgut	0		
@@ -195,14 +195,14 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	ring of the sewer	0		Stench Damage: +25
-200	decent miniature rat appendix kabob	2	good	
-201	spoiled fancy green bat wing kabob	3	crappy	Effect: "Oily Flavor", Effect Duration: 30
+200	miniature decent rat appendix kabob	2	good	
+201	fancy spoiled green bat wing kabob	3	crappy	Effect: "Oily Flavor", Effect Duration: 30
 202	moldy bite-sized carob chunks	1	crappy	
 203	spinning herbs	0		
 204	flavorless carob chunk cookies	4	decent	
 205	teal secret blend of herbs and spices	0		
 206	piercing post	0		
-207	blue blurry hippy herbal tea	1	good	
+207	blurry blue hippy herbal tea	1	good	
 208	bouncing patchouli incense stick	0		
 209	squat wad of tofu	0		
 210	Feng Shui for Big Dumb Idiots	0		
@@ -211,8 +211,8 @@
 213	blurry foul-smelling chaotic filthy corduroys	0		Spell Critical Percent: +10, Stench Damage: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	ruddy filthy knitted dread sack	0		Maximum HP Percent: +40, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	miniature rotten mirror carob brownies	2	crappy	
-217	delicious miniature tumbling skewed herb brownies	2	awesome	
+216	rotten miniature mirror carob brownies	2	crappy	
+217	delicious miniature skewed tumbling herb brownies	2	awesome	
 218	huge hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -221,7 +221,7 @@
 223	phat turquoise bracelet of extreme caution	0		Monster Level: -25
 224	mirror scandalous eyepatch	0		Sleaze Damage: +5, Familiar Effect: "3xBarrr, cap 6"
 225	miniature spoiled blurry tofu casserole	2	crappy	
-226	diluted upside-down tumbling can of Red Minotaur	1	decent	Effect: "Ooh, Sour!", Effect Duration: 30
+226	diluted tumbling upside-down can of Red Minotaur	1	decent	Effect: "Ooh, Sour!", Effect Duration: 30
 227	aromatic Kentucky-fried meat sword	0		Stench Resistance: +1
 228	blurry smartaleck's Kentucky-fried meat staff	0		Moxie Percent: +30
 229	greasy Kentucky-fried meat crossbow	0		Sleaze Spell Damage: +10
@@ -232,16 +232,16 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	Jim Carey's shellacked Bigger Bugfinder Blade	0		Damage Reduction: 7, Monster Level: +25
 236	Queue Du Coq cocktailcrafting kit	0		
-237	watered-down aged mirror blue bottle of gin	2	awesome	
+237	aged watered-down mirror blue bottle of gin	2	awesome	
 238	lousy bottle of vodka	3	decent	
 239	forbidden smooth Orcish baseball cap	0		Moxie: +15, Spell Damage Percent: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	gray avaricious Orcish cargo shorts of incineration	0		Hot Spell Damage: +50, Meat Drop: +30, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	teal squat baleful Orcish frat-paddle	0		Spell Damage: +25
 242	stale	4	decent	
 243	moldy blinking grapefruit	3	crappy	
-244	flavorless tiny grapes	1	decent	
+244	tiny flavorless grapes	1	decent	
 245	gigantic moldy pulsating olive	9	crappy	
-246	tiny bland tomato	1	decent	
+246	bland tiny tomato	1	decent	
 247	blurry fermenting powder	0		
 248	bad mirror salty dog	4	decent	
 249	tolerable bloody mary	3	good	
@@ -249,17 +249,17 @@
 251	mediocre martini	3	decent	
 252	lousy bloody beer	3	decent	
 253	bad shot of schnapps	3	decent	
-254	irresponsibly strong drinkable lime green ghostly shot of grapefruit schnapps	7	good	
+254	drinkable irresponsibly strong ghostly lime green shot of grapefruit schnapps	7	good	
 255	smooth fine wine	4	awesome	
 256	practically non-alcoholic fancy mediocre shot of tomato schnapps	1	decent	Effect: "Always be Collecting", Effect Duration: 45
 257	perfectly mixed extra-spicy bloody mary	3	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
-260	flavorless tiny White Citadel fries	1	decent	
+260	tiny flavorless White Citadel fries	1	decent	
 261	spoiled jittery White Citadel burger	3	crappy	
 262	toothsome piece of wedding cake	4	awesome	
 263	flavorless jittery chocolate chips	4	decent	
-264	special normal squat chocolate chip cookies	3	good	Effect: "Fudge Headache", Effect Duration: 15
+264	normal special squat chocolate chip cookies	3	good	Effect: "Fudge Headache", Effect Duration: 15
 265	wobbly mirror satin pants of chilblains	0		Cold Damage: +25, Familiar Effect: "atk, 2xPotato, cap 10"
 266	drinkable lightning	3	good	
 267	horrifying mullet wig	0		Spooky Damage: +25, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -274,7 +274,7 @@
 276	leprechaun hatchling	0		
 277	compressed squat bouncing extra-strength strongness elixir	1		
 278	distilled jug-o-magicalness	1		
-279	boiled yellow blinking suntan lotion of moxiousness	1		
+279	boiled blinking yellow suntan lotion of moxiousness	1		
 280	bouncing wobbly Pick-O-Matic lockpicks	0		
 281	spinning yellow studded gasmask	0		Damage Absorption: +80, Familiar Effect: "1xBarrr, cap 12"
 282	wobbly Boris's key	0		
@@ -309,25 +309,25 @@
 311	blurry hill of beans	0		
 312	pulsating Knob Goblin visor of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	Annie Oakley's Crown of the Goblin King	0		Critical Hit Percent: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	decent snack-sized bean burrito	2	good	
+314	snack-sized decent bean burrito	2	good	
 315	rotten bean burrito	4	crappy	
 316	decent blue insanely bean burrito	4	good	
 317	moldy bean burrito	3	crappy	
 318	moldy fancy narrow bean burrito	3	crappy	Effect: "Chalked-Up Teeth", Effect Duration: 10
 319	adequate fancy fuchsia insanely bean burrito	3	good	Effect: "Broberry Brotality", Effect Duration: 25
-320	moldy miniature spinning bat haggis	2	crappy	
-321	jumbo rotten huge menudo	5	crappy	
+320	miniature moldy spinning bat haggis	2	crappy	
+321	rotten jumbo huge menudo	5	crappy	
 322	stale goat cheese	4	decent	
 323	rotten plain pizza	3	crappy	
 324	yummy sausage pizza	4	awesome	
-325	enchanted moldy bite-sized goat cheese pizza	1	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 20
-326	enchanted stale diet mushroom pizza	1	decent	Effect: "Comprehensively Nourished", Effect Duration: 50
+325	moldy enchanted bite-sized goat cheese pizza	1	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 20
+326	diet enchanted stale mushroom pizza	1	decent	Effect: "Comprehensively Nourished", Effect Duration: 50
 327	goat	0		
 328	tolerable practically non-alcoholic ghostly bottle of whiskey	1	good	
 329	gravedigger's goat beard	0		Spooky Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
 331	hand-crafted Canadian	4	EPIC	
-332	normal miniature lemon	2	good	
+332	miniature normal lemon	2	good	
 333	huge yummy blinking lime	10	awesome	
 334	wicked sabre teeth	0		Spell Damage: +5
 335	sabre-toothed lime cub	0		
@@ -354,12 +354,12 @@
 356	squat weightlifter's snowboarder pants	0		Muscle: +15, Familiar Effect: "1xPotato, cap 25"
 357	upside-down jittery Mountain Stream soda	0		
 358	miniature stale gr8ps	2	decent	
-359	tiny normal t8r tots	1	good	
+359	normal tiny t8r tots	1	good	
 360	friendly miner's helmet	0		Familiar Weight: +3, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	Jack Frost's miner's pants	0		Cold Spell Damage: +50, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	toasty 7-Foot Dwarven mattock	0		Hot Damage: +5
 363	linoleum ore	0		
-364	twirling skewed asbestos ore	0		
+364	skewed twirling asbestos ore	0		
 365	chrome ore	0		
 366	linoleum sword hilt	0		
 367	linoleum stick	0		
@@ -418,7 +418,7 @@
 420	pickled triple-boiled tomato juice of powerful power	0		Effect: "You Liver", Effect Duration: 32
 421	electrified philter of phorce	0		Effect: "Oth-Jeal-O", Effect Duration: 59
 422	energized tarnished ionized potion of potency	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49
-423	non-liquefied deionized bouncing mirror cordial of concentration	0		Effect: "Gonna Get You, Sucker", Effect Duration: 60
+423	non-liquefied deionized mirror bouncing cordial of concentration	0		Effect: "Gonna Get You, Sucker", Effect Duration: 60
 424	tarnished wet extra-alkaline red ointment of the occult	0		Effect: "Gummiheart", Effect Duration: 30
 425	triple-anodized oil of expertise	0		Effect: "Spiritually Awake", Effect Duration: 36
 426	enhanced blinking potion of temporary gr8ness	0		Effect: "Coated Arms", Effect Duration: 64
@@ -462,11 +462,11 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	pulsating pixel potion	0		
-467	stale special tumbling pixel pie	3	decent	Effect: "In the Saucestream", Effect Duration: 15
+467	special stale tumbling pixel pie	3	decent	Effect: "In the Saucestream", Effect Duration: 15
 468	blurry ruby W	0		
 469	pulsating wussiness potion	0		
 470	perfectly mixed fancy Imp Ale	3	EPIC	Effect: "Spookypants", Effect Duration: 35
-471	diet bland hot wing	1	decent	
+471	bland diet hot wing	1	decent	
 472	avaricious diamond-studded cane	0		Meat Drop: +30, Class: "Disco Bandit"
 473	up-at-dawn crutch	0		Adventures: +5
 474	cast	0		
@@ -492,8 +492,8 @@
 494	batblade of doom	0		Spooky Spell Damage: +50
 495	catgut	0		
 496	narrow cat appendix	0		
-497	yellow tumbling spinning gnatwing	0		
-498	huge decent papaya	6	good	
+497	yellow spinning tumbling gnatwing	0		
+498	decent huge papaya	6	good	
 499	mirror greasy beefcake's denim axe	0		Muscle: +25, Sleaze Spell Damage: +10
 500	Elf Farm Raffle ticket	0		
 501	thick yummy Elfin shortbread	5	awesome	
@@ -504,18 +504,18 @@
 506	bland Hell broth	3	decent	
 507	cool thunderrr guitarrr	0		Moxie: +5
 508	squat sonata	0		
-509	blinking ghostly Hey Deze nuts	0		
+509	ghostly blinking Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	spinning Jarlsberg's key lime	0		
 512	ghostly Sneaky Pete's key lime	0		
 513	bite-sized stale tumbling Boris's key lime pie	1	decent	
-514	bland diet Jarlsberg's key lime pie	1	decent	
+514	diet bland Jarlsberg's key lime pie	1	decent	
 515	half-sized spoiled Sneaky Pete's key lime pie	2	crappy	
-516	mirror blurry Hey Deze map	0		
+516	blurry mirror Hey Deze map	0		
 517	scorching bejeweled accordion strap	0		Hot Damage: +25, Class: "Accordion Thief"
 518	mystery juice	0		
 519	blue moxie magnet	0		
-520	fuchsia tumbling pulsating leaflet	0		
+520	tumbling pulsating fuchsia leaflet	0		
 521	knitted kickback cookbook	0		Cold Resistance: +3
 522	purple one-winged stab bat	0		
 523	pulsating spinning rewinged stab bat	0		
@@ -538,7 +538,7 @@
 540	boiled dry boiled twirling Tasty Fun Good rice candy	0		Effect: "Permafrosty", Effect Duration: 47
 541	Tesla draggin' ball hat of bravery	0		Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley, cap 25"
 542	1337 7r0uZ0RZ of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Familiar Effect: "2xPotato, cap 27"
-543	miniature spoiled jittery Trollhouse cookies	2	crappy	
+543	spoiled miniature jittery Trollhouse cookies	2	crappy	
 544	perfumed lion tamer's talons	0		Experience (familiar): +2, Stench Resistance: +5
 545	special stale Spam Witch sammich	3	decent	Effect: "Loco Motives", Effect Duration: 30
 546	green meat vortex	0		
@@ -559,18 +559,18 @@
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	artisanal special Mad Train wine	3	EPIC	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 50
+564	special artisanal Mad Train wine	3	EPIC	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 50
 565	teal mirror hobo gloves of Tarzan	0		Experience (Muscle): +3, Single Equip
 566	shaking blurry Da Vinci's bum cheek	0		Experience (Mysticality): +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	moldy snack-sized Double Bacon Beelzeburger	2	crappy	
-569	low-calorie spoiled Lord of the Flies-sized fries	1	crappy	
+568	snack-sized moldy Double Bacon Beelzeburger	2	crappy	
+569	spoiled low-calorie Lord of the Flies-sized fries	1	crappy	
 570	decent Chicken Sandwich	3	good	
-571	ghostly purple Jumbo Dr. Lucifer	1	decent	
+571	purple ghostly Jumbo Dr. Lucifer	1	decent	
 572	delicious half-sized upside-down Children's Meal of the Damned	2	awesome	
 573	rotten special green noodles	3	crappy	Effect: "Icy Demeanor", Effect Duration: 35
-574	enchanted half-sized delicious upside-down noodles	2	awesome	Effect: "Action", Effect Duration: 30
-575	miniature stale painful penne pasta	2	decent	
+574	delicious half-sized enchanted upside-down noodles	2	awesome	Effect: "Action", Effect Duration: 30
+575	stale miniature painful penne pasta	2	decent	
 576	spoiled ravioli della hippy	3	crappy	
 577	delicious pr0n m4nic0tti	4	awesome	
 578	stale Hell ramen	4	decent	
@@ -584,7 +584,7 @@
 586	quilted cool ridiculously huge sword	0		Moxie: +5, Damage Absorption: +40
 587	aerosolized olive super-spiky hair gel	0		Effect: "Cookie Backup", Effect Duration: 35
 588	green soft echo eyedrop antidote	0		
-589	normal small cocoa eggshell fragment	2	good	
+589	small normal cocoa eggshell fragment	2	good	
 590	stale cocoa eggshell fragment	4	decent	
 591	olive cocoa egg	0		
 592	house	0		
@@ -603,7 +603,7 @@
 605	Tissue Paper Immateria	0		
 606	Tin Foil Immateria	0		
 607	Gauze Immateria	0		
-608	shaking upside-down Plastic Wrap Immateria	0		
+608	upside-down shaking Plastic Wrap Immateria	0		
 609	S.O.C.K.	0		
 610	procrastination potion	0		
 611	D	0		
@@ -634,7 +634,7 @@
 636	meat globe	0		
 637	toaster	0		
 638	pulsating prompt beefcake's asshat	0		Muscle: +25, Adventures: +3, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	low-calorie spoiled abominable snowcone	1	crappy	
+639	spoiled low-calorie abominable snowcone	1	crappy	
 640	special shaking Ent cider	1	awesome	Effect: "Empathy", Effect Duration: 15
 641	rotten toast	3	crappy	
 642	yellow blurry skeleton key	0		
@@ -644,12 +644,12 @@
 646	tasty wobbly fruitcake	3	awesome	
 647	present	0		Last Available: "2004-11"
 648	Crimbo sword of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2004-10"
-649	green supercharged Crimbo hat	0		Maximum MP Percent: +30, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	arcane researcher's Crimbo pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	green supercharged Crimbo hat	0		Maximum MP Percent: +30, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	arcane researcher's Crimbo pants	0		Experience Percent (Mysticality): +10, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	wobbly twirling ribald exclusive ultra-rare item	0		Sleaze Damage: +10
 652	quantum egg	0		
 653	twirling intragalactic rowboat	0		
-654	bouncing yellow star	0		
+654	yellow bouncing star	0		
 655	line	0		
 656	star chart	0		
 657	blinking wool star sword	0		Cold Resistance: +1
@@ -669,20 +669,20 @@
 671	nippy grave robbing shovel of the storm	0		Maximum MP Percent: +40, Cold Damage: +10
 672	flavorless snack-sized cranberries	2	decent	
 673	hand-crafted weak vodka and cranberry	2	EPIC	
-674	mediocre fortified whiskey	5	decent	
+674	fortified mediocre whiskey	5	decent	
 675	squat nippy skull of the Bonerdagon	0		Cold Damage: +10
 676	ghostly dragonbone belt buckle	0		
 677	zippy badass belt	0		Initiative: +20
 678	chest of the Bonerdagon	0		
-679	practically non-alcoholic bad roll in the hay	1	decent	
+679	bad practically non-alcoholic roll in the hay	1	decent	
 680	mediocre ghostly slap and tickle	4	decent	
 681	drinkable slip 'n' slide	4	good	
-682	fortified drinkable a sump'm sump'm	5	good	
+682	drinkable fortified a sump'm sump'm	5	good	
 683	tolerable shaking horizontal tango	4	good	
-684	smooth practically non-alcoholic pink pony	1	awesome	
+684	practically non-alcoholic smooth pink pony	1	awesome	
 685	red horrifying hardy Mr. Shirt of the blizzard	0		Maximum HP: +50, Cold Spell Damage: +25, Spooky Damage: +25
 686	twirling knuckles of the cougar	0		Moxie: +20
-687	pressed spinning jittery blood of the Wereseal	0		Effect: "Winklered", Effect Duration: 12
+687	pressed jittery spinning blood of the Wereseal	0		Effect: "Winklered", Effect Duration: 12
 688	ribald pixel hat	0		Sleaze Damage: +10, Familiar Effect: "atk, 2xVolley, cap 12"
 689	educational pixel pants	0		Experience: +1, Familiar Effect: "atk, 4xPotato, cap 12"
 690	ghostly Temple Grandin's pixel sword	0		Familiar Weight: +7
@@ -723,7 +723,7 @@
 727	hedge maze puzzle	0		
 728	tumbling hedge maze key	0		
 729	fishbowl	0		
-730	jittery blue fishtank	0		
+730	blue jittery fishtank	0		
 731	fish hose	0		
 732	hosed tank	0		
 733	maroon hosed fishbowl	0		
@@ -735,22 +735,22 @@
 739	tambourine bells	0		
 740	pulsating blurry censurious tambourine	0		Sleaze Resistance: +3
 741	huge broken skull	0		
-742	low-calorie toothsome blue Knoll shroomkabob	1	awesome	
+742	toothsome low-calorie blue Knoll shroomkabob	1	awesome	
 743	stale huge huge mushroom	3	decent	
 744	chilled nitrogenated magnetized hair spray	0		Effect: "Weather, Man", Effect Duration: 24
 746	bouncing stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	jumbo moldy warm mushroom	5	crappy	
-750	big moldy mushroom quesadilla	5	crappy	
+749	moldy jumbo warm mushroom	5	crappy	
+750	moldy big mushroom quesadilla	5	crappy	
 751	diet normal ghostly jittery cool mushroom	1	good	
-752	spoiled miniature ghostly cool mushroom casserole	2	crappy	
+752	miniature spoiled ghostly cool mushroom casserole	2	crappy	
 753	enchanted tasty pulsating pointy mushroom	3	awesome	Effect: "Super Structure", Effect Duration: 45
 754	miniature spoiled cream of pointy mushroom soup	2	crappy	
 755	decent skewed mushroom	4	good	
 756	normal teal mushroom	4	good	
 757	bland squat mushroom	3	decent	
-758	normal gigantic pulsating ghost cucumber	8	good	
+758	gigantic normal pulsating ghost cucumber	8	good	
 759	dill	0		
 760	green vinegar	0		
 761	squat brine	0		
@@ -778,18 +778,18 @@
 783	'Villa' document	0		
 784	bad Acqua Del Piatto Merlot	3	decent	Last Available: "2004-10"
 785	raffle ticket	0		
-786	normal low-calorie strawberry	1	good	
+786	low-calorie normal strawberry	1	good	
 787	distilled artisanal shaking bottle of rum	5	EPIC	
 788	artisanal irresponsibly strong strawberry daiquiri	8	EPIC	
-789	irresponsibly strong lousy spinning rum and cola	9	decent	
+789	lousy irresponsibly strong spinning rum and cola	9	decent	
 790	bad grog	3	decent	
 791	jittery MacGyver's curative Mafia bow tie	0		Maximum MP: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10"
 792	twirling studded Golden Mr. Accessory	0		Damage Absorption: +80, Softcore Only
 793	extra-irradiated boiled oil of stability	0		Effect: "Cybernetic Muscles", Effect Duration: 18
 794	Vulcanized irradiated yellow oil of slipperiness	0		Effect: "Weather, Man", Effect Duration: 61
-795	triple-distilled perfectly mixed skewed Acque Luride Grezze Cabernet	10	EPIC	Last Available: "2004-10"
+795	perfectly mixed triple-distilled skewed Acque Luride Grezze Cabernet	10	EPIC	Last Available: "2004-10"
 796	clever cement shoes of Calamity Jane of the detective	0		Maximum MP: +20, Critical Hit Percent: +15, Item Drop: +20, Last Available: "2004-10"
-797	delicious irresponsibly strong rockin' wagon	8	awesome	
+797	irresponsibly strong delicious rockin' wagon	8	awesome	
 798	irresponsibly strong perfectly mixed spinning lime green ocean motion	10	EPIC	
 799	mediocre mirror fuzzbump	3	decent	
 800	decent poutine	3	good	
@@ -802,8 +802,8 @@
 809	half-sized toothsome bat wing stir-fry	2	awesome	
 810	moldy rat appendix stir-fry	4	crappy	
 811	flavorless huge bouncing tofu stir-fry	8	decent	
-812	snack-sized normal pr0n stir-fry	2	good	
-813	half-sized stale Knob shells	2	decent	
+812	normal snack-sized pr0n stir-fry	2	good	
+813	stale half-sized Knob shells	2	decent	
 814	decent b&auml;tzle	3	good	
 815	normal ratini	3	good	
 816	spoiled snack-sized Knob stroganoff	2	crappy	
@@ -827,12 +827,12 @@
 834	Van der Graaf thinker's cornuthaum	0		Mysticality: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	blinking shaking healthy ring of aggravate monster	0		Maximum HP Percent: +20
 836	moldy super-sized mind flayer corpse	5	crappy	
-837	weak acceptable twirling Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
+837	acceptable weak twirling Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
 838	wobbly censurious sharpshooter's Mafia stogie	0		Critical Hit Percent: +10, Sleaze Resistance: +3, Last Available: "2004-10"
 839	aged boozy Maiali Sifilitici Pinot Noir	5	awesome	Last Available: "2004-10"
 840	lime green Lo Pan's Samson's Mafia violin case	0		Experience (Muscle): +5, Spell Critical Percent: +30, Last Available: "2004-10"
 841	acceptable weak tomato daiquiri	2	good	
-842	high-proof tolerable spinning beertini	8	good	
+842	tolerable high-proof spinning beertini	8	good	
 843	bad mirror salty slug	3	decent	
 844	enchanted mediocre teal papaya slung	4	decent	Effect: "The Magic of LOV", Effect Duration: 20
 845	greasy MAHI fez	0		Sleaze Spell Damage: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -846,14 +846,14 @@
 854	sucky decal	0		Familiar Weight: +5
 855	fuchsia balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
-857	wobbly upside-down moonglasses	0		
+857	upside-down wobbly moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
-862	shaking teal magnifying glass	0		Familiar Weight: +5
+862	teal shaking magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
-864	yellow upside-down ghostly stinger	0		Familiar Weight: +5
+864	upside-down yellow ghostly stinger	0		Familiar Weight: +5
 865	red lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	altered pine tar	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 54
@@ -888,11 +888,11 @@
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	twirling Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
-900	mirror shaking smile-sharpening stone	0		Familiar Weight: +5
+900	shaking mirror smile-sharpening stone	0		Familiar Weight: +5
 901	wobbly espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	fortified artisanal Spasmi Dolorosi Del Rene Champagne	5	EPIC	Last Available: "2004-10"
-904	yellow clever fortified deadly school Mafia knickerbockers	0		Weapon Damage: +5, Damage Absorption: +60, Maximum MP: +20, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+903	artisanal fortified Spasmi Dolorosi Del Rene Champagne	5	EPIC	Last Available: "2004-10"
+904	yellow clever fortified deadly school Mafia knickerbockers	0		Weapon Damage: +5, Damage Absorption: +60, Maximum MP: +20, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	dry Yummy Tummy bean	0		Effect: "Gummiskin", Effect Duration: 32
 906	liquefied Vulcanized altered Rock Pops	0		Effect: "The Q Is Talking To You", Effect Duration: 66
 907	triple-moist chilled Mr. Mediocrebar	0		Effect: "init.enh", Effect Duration: 46
@@ -906,8 +906,8 @@
 915	blinking yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	horrifying intergalactic pom poms of the businessman	0		Spooky Damage: +25, Meat Drop: +50
 917	spinning Mob Penguin protection contract	0		
-918	Radio Free Baseball Cap of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	quilted Radio Free Pants	0		Damage Absorption: +40, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	Radio Free Baseball Cap of the sweet-tooth	0		Candy Drop: +100, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	quilted Radio Free Pants	0		Damage Absorption: +40, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	shaking flame-retardant Radio Free Foil	0		Hot Resistance: +1, Last Available: "2006-07"
 921	special toothsome teal radio button candy	3	awesome	Effect: "Items Are Forever", Effect Duration: 15
 922	maroon quilted severed rocking horse head	0		Damage Absorption: +40
@@ -920,7 +920,7 @@
 929	sizzling arse-shooting crossbow	0		Hot Damage: +10
 931	weak mediocre huge spiced rum	2	decent	
 932	artisanal fortified eggnog	5	EPIC	
-933	rotten snack-sized squat candy cane	2	crappy	
+933	snack-sized rotten squat candy cane	2	crappy	
 934	normal gingerbread bugbear	4	good	
 935	cyan imitation nice watch of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2004-12"
 936	squat squat Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	arcane researcher's bowler	0		Experience Percent (Mysticality): +10, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	arcane researcher's bowler	0		Experience Percent (Mysticality): +10, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	stiffened bow staff of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Last Available: "2004-12"
-944	red MacGyver's bowlegged pants	0		Maximum MP: +100, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	red MacGyver's bowlegged pants	0		Maximum MP: +100, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	wobbly fuchsia skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -943,8 +943,8 @@
 953	red penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	blurry lime green Herculean fez of etymology	0		Experience (Muscle): +1, Familiar Effect: "1xLep, cap 30"
-956	bite-sized adequate carob chunk noodles	1	good	
-957	adequate snack-sized chorizo brownies	2	good	
+956	adequate bite-sized carob chunk noodles	1	good	
+957	snack-sized adequate chorizo brownies	2	good	
 958	spoiled chocolate and tomato pizza	3	crappy	
 959	flange	0		
 960	clockwork key	0		
@@ -989,7 +989,7 @@
 1002	smartaleck's Xlyinia's notebook	0		Moxie Percent: +30
 1003	soda water	0		
 1004	mediocre bottle of tequila	4	decent	
-1005	delicious watered-down jittery boxed wine	2	awesome	
+1005	watered-down delicious jittery boxed wine	2	awesome	
 1006	bland cherry	3	decent	
 1007	fuchsia shellacked coconut shell	0		Damage Reduction: 7, Familiar Effect: "1xFairy, cap 7"
 1008	lightning-fast ice cubes	0		Initiative: +40
@@ -1000,7 +1000,7 @@
 1013	perfectly mixed margarita	4	EPIC	
 1014	lousy narrow strawberry wine	3	decent	
 1015	lousy wine spritzer	3	decent	
-1016	perfectly mixed triple-distilled narrow perpendicular hula	7	EPIC	
+1016	triple-distilled perfectly mixed narrow perpendicular hula	7	EPIC	
 1017	drinkable ducha de oro	4	good	
 1018	practically non-alcoholic aged red calle de miel	1	awesome	
 1019	spirit-forward lousy dry vodka martini	5	decent	
@@ -1008,7 +1008,7 @@
 1021	drinkable ghostly tequila with training wheels	4	good	
 1022	smooth sangria	3	awesome	
 1023	mediocre vesper	3	decent	Last Available: "2004-12"
-1024	mediocre watered-down bodyslam	2	decent	Last Available: "2004-12"
+1024	watered-down mediocre bodyslam	2	decent	Last Available: "2004-12"
 1025	perfectly mixed watered-down sangria del diablo	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1026	twirling Valentine	0		Free Pull
 1027	whip kit	0		
@@ -1024,18 +1024,18 @@
 1037	bouncing executive gnauga hide buckler	0		Meat Drop: +40, Damage Reduction: 5
 1038	enhanced non-improved purple Connery's Elixir of Audacity	0		Effect: "Protection from Bad Stuff", Effect Duration: 22
 1040	narrow Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	watered-down bad bouncing beer	2	decent	
+1041	bad watered-down bouncing beer	2	decent	
 1042	Tesla string of beads	0		MP Regen Min: 7, MP Regen Max: 10
 1043	string of beads of the overflowing toilet	0		Stench Spell Damage: +50
 1044	yellow upside-down reassuring string of beads	0		Spooky Resistance: +1
 1045	forbidden plastic bottle opener	0		Spell Damage Percent: +50
-1046	up-at-dawn frightening traffic cone	0		Spooky Damage: +5, Adventures: +5, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	up-at-dawn frightening traffic cone	0		Spooky Damage: +5, Adventures: +5, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	mediocre N. O. Beer	4	decent	
 1048	pickled oyster egg	1		
 1049	powdered oyster egg	1		
 1050	modified narrow oyster egg	1		
 1051	tumbling plastic oyster egg	0		
-1052	dried skewed gray pulsating oyster egg	1		
+1052	dried gray skewed pulsating oyster egg	1		
 1053	altered teal oyster egg	1		
 1054	boiled oyster egg	1		
 1055	lime green plastic oyster egg	0		
@@ -1047,7 +1047,7 @@
 1061	modified mauve oyster egg	1		Effect: "Puddingskin", Effect Duration: 30
 1062	altered mauve oyster egg	1		
 1063	red mauve plastic oyster egg	0		
-1064	boiled blurry squat oyster egg	1		
+1064	boiled squat blurry oyster egg	1		
 1065	altered green oyster egg	1		
 1066	twisted blinking oyster egg	1		Effect: "Extra-Thick Blood", Effect Duration: 40
 1067	plastic oyster egg	0		
@@ -1090,7 +1090,7 @@
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
 1106	clockwork chef head	0		
-1107	upside-down blurry clockwork maid head	0		
+1107	blurry upside-down clockwork maid head	0		
 1108	clockwork detective skull	0		
 1109	clockwork bartender-head-in-the-box	0		
 1110	twirling huge clockwork chef-head-in-the-box	0		
@@ -1125,12 +1125,12 @@
 1139	hand-crafted shaking lime green mushroom wine	3	EPIC	
 1140	bad icy mushroom wine	3	decent	
 1141	perfectly mixed weak mushroom wine	2	EPIC	
-1142	extra-dry aged pointy mushroom wine	5	awesome	
+1142	aged extra-dry pointy mushroom wine	5	awesome	
 1143	boozy perfectly mixed flat mushroom wine	5	EPIC	
-1144	drinkable strong fancy cool mushroom wine	5	good	Effect: "Mer-kinny Flavor", Effect Duration: 20
+1144	strong drinkable fancy cool mushroom wine	5	good	Effect: "Mer-kinny Flavor", Effect Duration: 20
 1145	hand-crafted knob mushroom wine	4	EPIC	
 1146	tolerable upside-down knoll mushroom wine	3	good	
-1147	practically non-alcoholic hand-crafted blinking mushroom wine	1	super ultra mega turbo EPIC	
+1147	hand-crafted practically non-alcoholic blinking mushroom wine	1	super ultra mega turbo EPIC	
 1148	triple-distilled artisanal ghostly shot of flower schnapps	6	EPIC	
 1149	rotten low-calorie flower petal pie	1	crappy	
 1150	drinkable twirling bottle of single-barrel whiskey	3	good	
@@ -1154,7 +1154,7 @@
 1169	spinning exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	ghostly teal coffin	0		
-1172	gray jittery squat asbestos box	0		
+1172	jittery squat gray asbestos box	0		
 1173	jittery linoleum box	0		
 1174	bouncing chrome box	0		
 1175	cryptic puzzle box	0		
@@ -1164,7 +1164,7 @@
 1179	pulsating daisy	0		
 1180	potted fern	0		
 1181	skewed tulip	0		
-1182	squat skewed Venus flytrap	0		
+1182	skewed squat Venus flytrap	0		
 1183	all-purpose flower	0		
 1184	jittery exotic orchid	0		
 1185	green long-stemmed rose	0		
@@ -1186,15 +1186,15 @@
 1201	jumbo adequate urinal cake	5	good	
 1202	half-sized spoiled Happy Birthday, Claude! cake	2	crappy	
 1203	spoiled squat personalized birthday cake	3	crappy	
-1204	snack-sized rotten three-tiered wedding cake	2	crappy	
+1204	rotten snack-sized three-tiered wedding cake	2	crappy	
 1205	flavorless yellow babycakes	3	decent	
-1206	tiny stale velvet cake	1	decent	
-1207	flavorless super-sized congratulatory cake	5	decent	
+1206	stale tiny velvet cake	1	decent	
+1207	super-sized flavorless congratulatory cake	5	decent	
 1208	small flavorless angel-food cake	2	decent	
 1209	stale devil's-food cake	3	decent	
 1210	spoiled bouncing birthday party jellybean cheesecake	3	crappy	
 1211	mirror balloon	0		
-1212	upside-down jittery balloon	0		
+1212	jittery upside-down balloon	0		
 1213	mirror heart-shaped balloon	0		
 1214	anniversary balloon	0		
 1215	twirling Mylar balloon	0		
@@ -1240,14 +1240,14 @@
 1256	decent green insanely jumping bean burrito	3	good	
 1257	enchanted spoiled rat scrapple	3	crappy	Effect: "Charrrming", Effect Duration: 5
 1258	tumbling pail of pretentious paint	0		
-1259	ghostly auspicious Sinatra's traffic cone	0		Experience (Moxie): +5, Item Drop: +10, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	ghostly auspicious Sinatra's traffic cone	0		Experience (Moxie): +5, Item Drop: +10, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	mirror wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	twisted jittery Hatorade	1		Effect: "Sourpuss", Effect Duration: 50
 1262	aromatic veiny off-hand balloon of the bloodbag	0		Maximum HP: 110, Stench Resistance: +1
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	bouncing nose-bone fetish	0		Last Available: "2011-12"
 1265	narrow box of sunshine	0		Free Pull
-1266	thick decent gloomy mushroom	5	good	
+1266	decent thick gloomy mushroom	5	good	
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	ghostly wobbly ebony wand	0		
@@ -1255,7 +1255,7 @@
 1271	spinning aluminum wand	0		
 1272	marble wand	0		
 1273	magic lamp of the boozehound	0		Booze Drop: +100
-1274	vaporized tumbling wobbly purple Medicinal Herb's medicinal herbs	1		
+1274	vaporized tumbling purple wobbly Medicinal Herb's medicinal herbs	1		
 1275	sage basic meat skirt	0		Mysticality Percent: +10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	weak smooth Otorian Battle Scar	2	awesome	
 1277	squat basic meat kilt of the early riser	0		Adventures: +7, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	bouncing twirling wholesome Fonzie's traffic cone	0		Experience (Moxie): +1, Maximum HP Percent: +10, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	bouncing twirling wholesome Fonzie's traffic cone	0		Experience (Moxie): +1, Maximum HP Percent: +10, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	bouncing calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	shaking attention spanner	0		Familiar Weight: +5
@@ -1298,14 +1298,14 @@
 1314	banded Baron von Ratsworth's tophat	0		Damage Absorption: +100, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
 1315	green huge rose-colored glasses of the bloodbag	0		Maximum HP: +100
 1316	facsimile dictionary	0		
-1317	spinning bouncing blood flower	0		
+1317	bouncing spinning blood flower	0		
 1318	lovecat tail	0		
 1319	green plastic passion fruit	0		
 1320	rotten tumbling questionable taco	3	crappy	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	blurry petrified time	0		Last Available: "2005-10"
-1323	curative time helmet	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	therapeutic time trousers	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	curative time helmet	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	therapeutic time trousers	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	spinning time sword of the sweet-tooth	0		Candy Drop: +100, Last Available: "2005-10"
 1326	jittery twirling banded Dyspepsi-Cola helmet	0		Damage Absorption: +100, Familiar Effect: "3xFairy, cap 7"
 1327	upside-down Herculean Cloaca-Cola shield	0		Experience (Muscle): +1, Damage Reduction: 4
@@ -1323,21 +1323,21 @@
 1340	narrow Cloaca-Cola-issue combat knife	0		
 1341	Jeselnik's Dyspepsi-Cola-issue canteen	0		Sleaze Damage: +25, Single Equip
 1342	picture of a dead guy's girlfriend	0		
-1343	blinking ghostly zombie pineal gland	0		Last Available: "2005-11"
+1343	ghostly blinking zombie pineal gland	0		Last Available: "2005-11"
 1344	moist enhanced frozen tumbling Gummi-Gnauga	0		Effect: "The Halls of Mysticality", Effect Duration: 56
 1345	super-quantum activated Now and Earlier	0		Effect: "Guts Feeling", Effect Duration: 68, Last Available: "2020-09"
 1346	energized warmed shaking Sugar Cog	0		Effect: "Memory of Strength", Effect Duration: 60
 1347	loaded serum blowgun	0		Last Available: "2005-11"
-1348	jittery yellow empty blowgun	0		Last Available: "2005-11"
+1348	yellow jittery empty blowgun	0		Last Available: "2005-11"
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	ghostly 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	ruddy pinky ring	0		Maximum HP Percent: +40, Single Equip
-1352	irresponsibly strong hand-crafted tumbling redrum	8	EPIC	
+1352	hand-crafted irresponsibly strong tumbling redrum	8	EPIC	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	flavorless bowl of oriole's nest soup	4	decent	
 1356	jittery bunny liver	0		
-1357	watered-down bad Mt. Noob Pale Ale	2	decent	
+1357	bad watered-down Mt. Noob Pale Ale	2	decent	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	twirling ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	green pirate zombie robot head	0		Last Available: "2005-11"
@@ -1348,8 +1348,8 @@
 1365	adequate shaking tofurkey leg	4	good	
 1366	yummy tofurkey gravy	3	awesome	
 1367	stale herbal stuffing	3	decent	
-1368	bite-sized bland can-shaped gelatinous cranberry sauce	1	decent	
-1369	gigantic rotten yams	8	crappy	
+1368	bland bite-sized can-shaped gelatinous cranberry sauce	1	decent	
+1369	rotten gigantic yams	8	crappy	
 1370	lightning-fast rhinestone cowboy shirt	0		Initiative: +40
 1371	clever gingham blouse	0		Maximum MP: +20
 1372	squat souvenir ski t-shirt of the empath	0		Familiar Weight: +5
@@ -1361,7 +1361,7 @@
 1378	blinking hale plastic sweet nutcracker	0		Maximum HP: +20, Last Available: "2005-12"
 1379	ghostly lightning-fast plastic Crimbo reindeer	0		Initiative: +40, Single Equip, Last Available: "2005-12"
 1381	aspirin	0		Last Available: "2005-12"
-1382	extra-polarized skewed blinking chocolate	0		Effect: "You Know Who to Call", Effect Duration: 27, Last Available: "2015-11"
+1382	extra-polarized blinking skewed chocolate	0		Effect: "You Know Who to Call", Effect Duration: 27, Last Available: "2015-11"
 1383	length of string	0		
 1384	googly eye	0		
 1385	huge stuffing	0		
@@ -1377,14 +1377,14 @@
 1395	fuchsia teddy bear	0		Last Available: "2005-12"
 1396	cyan dangerous duck-on-a-string of the ox	0		Muscle: +20, Weapon Damage: +10, Last Available: "2005-12"
 1397	shaking toy soldier	0		Last Available: "2005-12"
-1398	lime green wobbly doll house	0		Last Available: "2005-12"
+1398	wobbly lime green doll house	0		Last Available: "2005-12"
 1399	smelly toy train	0		Stench Spell Damage: +10, Single Equip, Last Available: "2005-12"
 1400	lime green scorching marionette	0		Hot Damage: +25, Last Available: "2005-12"
 1401	nippy sock monkey	0		Cold Damage: +10, Last Available: "2005-12"
 1402	teal Jeselnik's rag doll	0		Sleaze Damage: +25, Last Available: "2005-12"
 1403	narrow can of fake snow of courage	0		Spooky Resistance: +3, Last Available: "2005-12"
 1404	lard-coated colored-light &quot;necklace&quot;	0		Sleaze Spell Damage: +25, Last Available: "2005-12"
-1405	wicked tree skirt	0		Spell Damage: +5, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	wicked tree skirt	0		Spell Damage: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	bite-sized rotten blinking wreath-shaped Crimbo cookie	1	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	toothsome gray bell-shaped Crimbo cookie	4	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	snack-sized rotten squat upside-down tree-shaped Crimbo cookie	2	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
@@ -1399,19 +1399,19 @@
 1417	ionized corrupted squat snowcone	0		Effect: "Blood-Rich", Effect Duration: 17, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	narrow shellacked grievous traffic cone	0		Weapon Damage Percent: +50, Damage Reduction: 7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	narrow shellacked grievous traffic cone	0		Weapon Damage Percent: +50, Damage Reduction: 7, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	fuchsia Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	pulsating twirling Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	skewed iceberglet	0		Last Available: "2006-02"
 1424	zippy ice sickle of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +20, Softcore Only, Last Available: "2006-02"
 1425	energetic ice baby	0		Maximum MP Percent: +20, Softcore Only, Last Available: "2006-02"
-1426	frosty ice pick	0		Cold Spell Damage: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	frosty ice pick	0		Cold Spell Damage: +10, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	electrified padded ice skates	0		Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	miniature flavorless jittery grue egg omelette	2	decent	
+1428	flavorless miniature jittery grue egg omelette	2	decent	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	adequate small fuchsia narrow mushroom	2	good	
+1432	adequate small narrow fuchsia mushroom	2	good	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1427,14 +1427,14 @@
 1445	dry blinking hot nuggets	0		Effect: "Christmessy", Effect Duration: 65
 1446	tarnished dry irradiated nuggets	0		Effect: "Compensatory Cruelness", Effect Duration: 16
 1447	extra-anodized super-magnetized vacuum-sealed nuggets	0		Effect: "Tiki Toughness", Effect Duration: 54
-1448	quadruple-anodized blurry yellow stench nuggets	0		Effect: "Sugary World View", Effect Duration: 34
+1448	quadruple-anodized yellow blurry stench nuggets	0		Effect: "Sugary World View", Effect Duration: 34
 1449	denatured frozen colloidal blurry sleaze nuggets	0		Effect: "Spooky Hands", Effect Duration: 45
-1450	diluted mirror wobbly twinkly wad	1		
+1450	diluted wobbly mirror twinkly wad	1		
 1451	distilled hot wad	1		
 1452	vaporized twirling ghostly wad	1		
-1453	modified wobbly blue wad	1		Effect: "Gleaming White Teeth", Effect Duration: 20
+1453	modified blue wobbly wad	1		Effect: "Gleaming White Teeth", Effect Duration: 20
 1454	vaporized blurry stench wad	1		
-1455	denatured cyan tumbling sleaze wad	1		
+1455	denatured tumbling cyan sleaze wad	1		
 1456	fuchsia double daisy	0		
 1457	spinning wobbly Goth Giant	0		
 1458	stale Valentine's Day cake	3	decent	
@@ -1462,7 +1462,7 @@
 1480	red chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	skewed paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
-1483	fuchsia spinning troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
+1483	spinning fuchsia troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	flame-retardant stiffened rabbit's foot	0		Damage Reduction: 1, Hot Resistance: +1
 1486	massive bag of catnip	0		
@@ -1474,8 +1474,8 @@
 1492	maroon shaking ninja mop of the blizzard	0		Cold Spell Damage: +25
 1493	censurious Annie Oakley's ridiculously overelaborate ninja weapon	0		Critical Hit Percent: +20, Sleaze Resistance: +3
 1494	energized modified green sugar-coated pine cone	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 34, Last Available: "2020-09"
-1495	smelly traffic cone of the detective	0		Stench Spell Damage: +10, Item Drop: +20, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	acceptable practically non-alcoholic gloomy mushroom wine	1	good	
+1495	smelly traffic cone of the detective	0		Stench Spell Damage: +10, Item Drop: +20, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1496	practically non-alcoholic acceptable gloomy mushroom wine	1	good	
 1497	aged mushroom wine	4	awesome	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1486,12 +1486,12 @@
 1504	deionized unsweetened tumbling snowcone	0		Effect: "Human-Machine Hybrid", Effect Duration: 23, Last Available: "2006-04"
 1505	wobbly ice cube with a fly in it	0		Last Available: "2006-04"
 1506	drinkable calle de miel with a fly in it	3	good	Last Available: "2006-04"
-1507	lousy watered-down rockin' wagon with a fly in it	2	decent	Last Available: "2006-04"
+1507	watered-down lousy rockin' wagon with a fly in it	2	decent	Last Available: "2006-04"
 1508	acceptable perpendicular hula with a fly in it	3	good	Last Available: "2006-04"
 1509	artisanal slap and tickle with a fly in it	3	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	veiny fake hand	0		Maximum HP: +10, Last Available: "2006-04"
-1512	dried skewed ghostly Knob Goblin pet-buffing spray	1		
+1512	dried ghostly skewed Knob Goblin pet-buffing spray	1		
 1513	vaporized Knob Goblin learning pill	1		
 1514	diluted teal mirror Knob Goblin eyedrops	1		Effect: "Punch Another Day", Effect Duration: 20
 1515	modified Knob Goblin nasal spray	1		Effect: "Simulation Stimulation", Effect Duration: 45
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	fuchsia wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	spinning mirror green pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1526	spinning green mirror pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	upside-down diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	avaricious inspector's corkscrew	0		Item Drop: +15, Meat Drop: +30, Last Available: "2006-04"
-1529	skewed gray St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
+1529	gray skewed St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	bouncing grass skirt of extreme caution	0		Monster Level: -25, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	grass hat of Leguizamo	0		Monster Level: +20, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	bouncing grass skirt of extreme caution	0		Monster Level: -25, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	grass hat of Leguizamo	0		Monster Level: +20, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	personal trainer's grass blade	0		Experience Percent (Muscle): +10, Last Available: "2011-01"
 1534	maroon raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	upside-down healthy sparkly engagement ring	0		Maximum HP Percent: +20, Single Equip
 1539	jittery Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	shaking hardened occult Grimacite goggles	0		Spell Damage Percent: +25, Damage Reduction: 3, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	shaking hardened occult Grimacite goggles	0		Spell Damage Percent: +25, Damage Reduction: 3, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	family-friendly Grimacite glaive of the sweet-tooth	0		Sleaze Resistance: +1, Candy Drop: +100, Last Available: "2008-10"
-1542	inspector's Grimacite greaves of Tarzan	0		Experience (Muscle): +3, Item Drop: +15, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	inspector's Grimacite greaves of Tarzan	0		Experience (Muscle): +3, Item Drop: +15, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	blurry executive strapping Grimacite garter	0		Muscle: +5, Meat Drop: +40, Last Available: "2008-10"
 1544	squat stiffened dangerous Grimacite galoshes	0		Weapon Damage: +10, Damage Reduction: 1, Last Available: "2008-10"
 1545	slick Grimacite gorget of terror	0		Moxie: +10, Spooky Spell Damage: +10, Last Available: "2008-10"
@@ -1528,9 +1528,9 @@
 1548	ghostly fireproof manspreader's Gazpacho's Glacial Grimoire	0		Monster Level: +10, Hot Resistance: +3
 1549	huge MSG	0		
 1550	curative second-hand knockoff engagement ring	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
-1551	lousy weak bottle of Domesticated Turkey	2	decent	
+1551	weak lousy bottle of Domesticated Turkey	2	decent	
 1552	practically non-alcoholic hand-crafted gray bottle of Definit	1	EPIC	
-1553	triple-distilled mediocre bottle of Calcutta Emerald	6	decent	
+1553	mediocre triple-distilled bottle of Calcutta Emerald	6	decent	
 1554	aged bottle of Lieutenant Freeman	4	awesome	
 1555	acceptable bottle of Jorge Sinsonte	4	good	
 1556	distilled tolerable upside-down boxed champagne	5	good	
@@ -1541,7 +1541,7 @@
 1561	diet stale spinning raspberry	1	decent	
 1562	normal kiwi	3	good	
 1563	lousy red whiskey bittersweet	3	decent	
-1564	practically non-alcoholic enchanted lousy mimosette	1	decent	Effect: "Bottle in front of Me", Effect Duration: 40
+1564	practically non-alcoholic lousy enchanted mimosette	1	decent	Effect: "Bottle in front of Me", Effect Duration: 40
 1565	drinkable tequila sunset	3	good	
 1566	acceptable skewed zmobie	4	good	Wiki Name: "Zmobie (drink)"
 1567	drinkable spinning spinning gin and tonic	3	good	
@@ -1551,9 +1551,9 @@
 1571	practically non-alcoholic drinkable parisian cathouse	1	good	
 1572	acceptable rabbit punch	3	good	
 1573	weak tolerable caipifruta	2	good	
-1574	boozy perfectly mixed upside-down teqiwila	5	EPIC	
-1575	perfectly mixed weak Divine	2	super ultra EPIC	
-1576	fancy mediocre bouncing Gordon Bennett	3	decent	Effect: "Ice Packed", Effect Duration: 45
+1574	perfectly mixed boozy upside-down teqiwila	5	EPIC	
+1575	weak perfectly mixed Divine	2	super ultra EPIC	
+1576	mediocre fancy bouncing Gordon Bennett	3	decent	Effect: "Ice Packed", Effect Duration: 45
 1577	drinkable blue tangarita	3	good	
 1578	fortified perfectly mixed mandarina colada	5	EPIC	
 1579	drinkable triple-distilled gimlet	10	good	
@@ -1565,35 +1565,35 @@
 1585	acceptable gray Mon Tiki	4	good	
 1586	weak hand-crafted wobbly teqiwila slammer	2	super ultra EPIC	
 1587	bland mirror Knob lo mein	3	decent	
-1588	jumbo fancy bland mirror wobbly asparagus lo mein	5	decent	Effect: "Slippery Tongue", Effect Duration: 40
+1588	jumbo bland fancy mirror wobbly asparagus lo mein	5	decent	Effect: "Slippery Tongue", Effect Duration: 40
 1589	stale huge cyan Knoll lo mein	9	decent	
 1590	normal snack-sized blurry lo mein	2	good	
-1591	stale low-calorie olive lo mein	1	decent	
+1591	low-calorie stale olive lo mein	1	decent	
 1592	flavorless purple hot hi mein	4	decent	
 1593	immense decent hi mein	7	good	
-1594	toothsome enchanted hi mein	4	awesome	Effect: "Very Clean Teeth", Effect Duration: 45
+1594	enchanted toothsome hi mein	4	awesome	Effect: "Very Clean Teeth", Effect Duration: 45
 1595	flavorless hi mein	4	decent	
 1596	tasty squat teal sleazy hi mein	3	awesome	
 1597	Junior LAAAAME merit badge of the pedagogue	0		Experience: +3, Last Available: "2006-05"
 1598	slick Senior LAAAAME merit badge	0		Moxie: +10, Last Available: "2006-05"
 1599	blinking jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	extra-dry smooth tangarita with a fly in it	5	awesome	
+1600	smooth extra-dry tangarita with a fly in it	5	awesome	
 1601	acceptable mandarina colada with a fly in it	4	good	
 1602	practically non-alcoholic hand-crafted green prussian cathouse with a fly in it	1	EPIC	
-1603	smooth watered-down Mae West with a fly in it	2	awesome	
+1603	watered-down smooth Mae West with a fly in it	2	awesome	
 1604	twisted astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	mixed wobbly ultimate wad	1		Effect: "Quadrilled", Effect Duration: 35
 1607	non-ionized polymerized galvanized ghostly libation of liveliness	0		Effect: "Petit Force", Effect Duration: 51
 1608	dry olive eyedrops of the ermine	0		Effect: "Lemony Goodness", Effect Duration: 43
 1609	magnetized gray perfume of prejudice	0		Effect: "Took Eleven", Effect Duration: 28
-1610	electrified spinning purple eyedrops of the ocelot	0		Effect: "Enraged", Effect Duration: 46
+1610	electrified purple spinning eyedrops of the ocelot	0		Effect: "Enraged", Effect Duration: 46
 1611	modified potent potion of potency	0		Effect: "Speed of the Internet", Effect Duration: 61
 1612	boiled polarized blinking concentrated cordial of concentration	0		Effect: "Frozen Shoulders", Effect Duration: 25
 1613	spinning Usain Bolt's coffin lid	0		Initiative: +80, Damage Reduction: 3
 1614	olive tumbling bouncing reassuring satin shield	0		Spooky Resistance: +1, Damage Reduction: 5
-1615	maroon manspreader's Cerebral Cloche	0		Monster Level: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	Samson's Cerebral Culottes	0		Experience (Muscle): +5, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	maroon manspreader's Cerebral Cloche	0		Monster Level: +10, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	Samson's Cerebral Culottes	0		Experience (Muscle): +5, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	pulsating banded strapping Cerebral Crossbow of the glutton	0		Muscle: +5, Damage Absorption: +100, Food Drop: +100, Last Available: "2006-06"
 1618	purple ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	huge beer cartilage	0		
 1632	upside-down Spanish fly trap	0		
 1633	Spanish fly	0		
-1634	watered-down perfectly mixed around the world	2	EPIC	
+1634	perfectly mixed watered-down around the world	2	EPIC	
 1635	scrumdiddlyumptious solution	0		
 1636	purple upside-down Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	wet lotion of hotness	0		Effect: "The Magic of LOV", Effect Duration: 43
@@ -1628,14 +1628,14 @@
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	moldy thick foie gras	5	crappy	
+1651	thick moldy foie gras	5	crappy	
 1652	dry non-modified candy brain	0		Effect: "Cringle's Curative Carol", Effect Duration: 51, Last Available: "2020-09"
-1653	zippy vibrating razor-sharp jewel-eyed wizard hat	0		Weapon Damage Percent: +25, Maximum MP Percent: +10, Initiative: +20, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
+1653	zippy vibrating razor-sharp jewel-eyed wizard hat	0		Weapon Damage Percent: +25, Maximum MP Percent: +10, Initiative: +20, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	maroon electrified strapping wad of Crovacite	0		Muscle: +5, MP Regen Min: 3, MP Regen Max: 5
 1655	healthy collar of the sweet-tooth	0		Maximum HP Percent: +20, Candy Drop: +100
 1656	tumbling White Citadel Satisfaction Satchel	0		
 1657	blinking onion shurikens	0		
-1658	mirror jittery Cherry Cloaca Cola	0		
+1658	jittery mirror Cherry Cloaca Cola	0		
 1659	cyan Diet Cloaca Cola	0		
 1660	Regular Cloaca Cola	0		
 1661	narrow asbestos-lined Radio KoL Keychain	0		Hot Resistance: +5
@@ -1670,17 +1670,17 @@
 1690	cyan lion tamer's discarded bottlecap of temperance	0		Experience (familiar): +2, Sleaze Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	gray skewed flame-retardant groovy discarded torn-up glove	0		Moxie Percent: +10, Hot Resistance: +1, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	boiled salamander slurry	0		Effect: "The Power of LOV", Effect Duration: 21
-1693	deionized huge ghostly eyedrops of newt	0		Effect: "Disdain of She-Who-Was", Effect Duration: 28
+1693	deionized ghostly huge eyedrops of newt	0		Effect: "Disdain of She-Who-Was", Effect Duration: 28
 1694	improved super-wet ionized Frogade	0		Effect: "Always In Motion", Effect Duration: 33
 1695	dry olive squat papotion of papower	0		Effect: "Psalm of Pointiness", Effect Duration: 42
-1696	stale small yellow jittery royal jelly taco	2	decent	
-1697	decent small gray tofu taco	2	good	
+1696	stale small jittery yellow royal jelly taco	2	decent	
+1697	small decent gray tofu taco	2	good	
 1698	normal jumping bean taco	3	good	
 1699	super-sized moldy lime green catgut taco	5	crappy	
 1700	rotten goat cheese taco	3	crappy	
 1701	adequate pr0n taco	3	good	
 1702	ionized alphabet gum	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 56
-1703	gray ghostly Comma Chameleon egg	0		Free Pull
+1703	ghostly gray Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
 1705	spinning flaregun	0		
 1706	upside-down smartaleck's sword of the dark arts of the detective	0		Moxie Percent: +30, Spell Damage Percent: +100, Item Drop: +20
@@ -1743,9 +1743,9 @@
 1764	Spookyraven library key	0		
 1765	Spookyraven gallery key	0		
 1766	Spookyraven ballroom key	0		
-1767	lime green skewed pack of chewing gum	0		
+1767	skewed lime green pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	bland fancy fricasseed brains	3	decent	Effect: "Gobliny Flavor", Effect Duration: 45
+1769	fancy bland fricasseed brains	3	decent	Effect: "Gobliny Flavor", Effect Duration: 45
 1770	spoiled enchanted brains casserole	4	crappy	Effect: "Vented Spleen", Effect Duration: 15
 1771	tumbling Jack Frost's butcherknife	0		Cold Spell Damage: +50
 1772	corn holder of bravery	0		Spooky Resistance: +5
@@ -1768,18 +1768,18 @@
 1789	squat Mob Penguin	0		
 1790	perfectly mixed Ram's Face Lager	3	EPIC	
 1791	ram horns	0		
-1792	Usain Bolt's Sherlock's cool Travoltan trousers	0		Moxie: +5, Item Drop: +25, Initiative: +80, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	Usain Bolt's Sherlock's cool Travoltan trousers	0		Moxie: +5, Item Drop: +25, Initiative: +80, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	teal pool cue of bravery of the businessman	0		Spooky Resistance: +5, Meat Drop: +50
 1794	adjusted electrified twirling handful of hand chalk	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 35
 1795	olive Counterclockwise Watch of the blizzard	0		Cold Spell Damage: +25, Single Equip
 1796	bone collar	0		Familiar Weight: +5
 1797	bouncing misshapen animal skeleton	0		
 1798	pile of animal bones	0		
-1799	jittery narrow animal skull	0		
+1799	narrow jittery animal skull	0		
 1800	squat animal cranium	0		
 1801	animal jawbone	0		
 1802	first cervical vertebra	0		
-1803	twirling narrow blue second cervical vertebra	0		
+1803	twirling blue narrow second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	twirling twirling fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
@@ -1788,7 +1788,7 @@
 1809	first thoracic vertebra	0		
 1810	upside-down second thoracic vertebra	0		
 1811	blinking third thoracic vertebra	0		
-1812	yellow ghostly fourth thoracic vertebra	0		
+1812	ghostly yellow fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	mirror seventh thoracic vertebra	0		
@@ -1840,7 +1840,7 @@
 1861	huge right eleventh rib	0		
 1862	right twelfth rib	0		
 1863	animal pelvis	0		
-1864	spinning shaking left scapula	0		
+1864	shaking spinning left scapula	0		
 1865	right scapula	0		
 1866	left clavicle	0		
 1867	right clavicle	0		
@@ -1923,21 +1923,21 @@
 1946	blurry frightening accordion pin of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Class: "Accordion Thief", Single Equip
 1947	quilted Da Vinci's worn tophat	0		Experience (Mysticality): +5, Damage Absorption: +40, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	aromatic tap shoes of the pedagogue	0		Experience: +3, Stench Resistance: +1, Single Equip
-1949	jumbo stale Manetwich	5	decent	
+1949	stale jumbo Manetwich	5	decent	
 1950	twirling bottle of Vangoghbitussin	0		
 1951	delicious bottle of Pinot Renoir	3	awesome	
 1952	adequate desiccated apricot	3	good	
 1953	artisanal flute of flat champagne	3	EPIC	
-1954	normal enchanted dehydrated caviar	3	good	Effect: "Clean-Shaven", Effect Duration: 10
+1954	enchanted normal dehydrated caviar	3	good	Effect: "Clean-Shaven", Effect Duration: 10
 1955	styrofoam peanuts	0		
-1956	practically non-alcoholic mediocre blinking olive snifter of thoroughly aged brandy	1	decent	
-1957	huge narrow quill pen	0		
+1956	mediocre practically non-alcoholic blinking olive snifter of thoroughly aged brandy	1	decent	
+1957	narrow huge quill pen	0		
 1958	jittery inkwell	0		
 1959	tattered scrap of paper	0		
 1960	yellow scroll of forbidden unspeakable evil	0		
 1961	squat can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	tarnished dry Bit O' Ectoplasm	0		Effect: "You Can Taste the Darkness", Effect Duration: 66
-1963	wobbly tumbling dance card	0		
+1963	tumbling wobbly dance card	0		
 1964	friendly opera mask	0		Familiar Weight: +3, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
 1966	maroon horrifying Amulet of Yendor of chilblains	0		Cold Damage: +25, Spooky Damage: +25, Single Equip, Last Available: "2011-12"
@@ -1977,7 +1977,7 @@
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
-2003	tumbling spinning Thorny Toad trading card	0		
+2003	spinning tumbling Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	Poison Oak trading card	0		
@@ -1997,11 +1997,11 @@
 2020	bland cherry pie	4	decent	
 2021	delicious strawberry pie	3	awesome	
 2022	stale huge lemon meringue pie	3	decent	
-2023	jittery purple Genalen&trade; Bottle	1	good	
-2024	huge moldy mixed wildflower greens	7	crappy	
+2023	purple jittery Genalen&trade; Bottle	1	good	
+2024	moldy huge mixed wildflower greens	7	crappy	
 2025	spoiled handful of walnuts	3	crappy	
 2026	spoiled nutty organic salad	3	crappy	
-2027	decent special thick super salad	5	good	Effect: "Heart Aflame", Effect Duration: 25
+2027	thick special decent super salad	5	good	Effect: "Heart Aflame", Effect Duration: 25
 2028	gigantic rotten upside-down tofu wonton	10	crappy	
 2029	shaking hippy protest button	0		Single Equip
 2030	cyan scorching brawny Lockenstock&trade; sandals	0		Muscle Percent: +20, Hot Damage: +25, Single Equip
@@ -2019,7 +2019,7 @@
 2042	exploding hacky-sack	0		
 2043	yellow hemp net	0		
 2044	fuchsia your father's MacGuffin diary	0		
-2045	bland immense pulsating brain-meltingly-hot chicken wings	6	decent	
+2045	immense bland pulsating brain-meltingly-hot chicken wings	6	decent	
 2046	super-sized decent frat brats	5	good	
 2047	spoiled narrow knob ka-bobs	4	crappy	
 2049	bad can of Swiller	3	decent	
@@ -2032,11 +2032,11 @@
 2056	energized polarized ionized adder bladder	0		Effect: "Shredding, Sweating", Effect Duration: 29
 2057	pension check	0		
 2058	huge picnic basket	0		
-2059	polymerized skewed ghostly Black No. 2	0		Effect: "Mathematically Precise", Effect Duration: 17
+2059	polymerized ghostly skewed Black No. 2	0		Effect: "Mathematically Precise", Effect Duration: 17
 2060	twirling lime green scandalous sword of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +5
 2061	helmet of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xFairy, cap 40"
 2062	jittery lightning-fast scandalous shield	0		Sleaze Damage: +5, Initiative: +40, Damage Reduction: 10
-2063	massive delicious teal blackberry	7	awesome	
+2063	delicious massive teal blackberry	7	awesome	
 2064	blinking forged identification documents	0		
 2065	PADL Phone	0		
 2066	wicked kick-ass kicks of the boozehound	0		Spell Damage: +5, Booze Drop: +100, Single Equip
@@ -2090,7 +2090,7 @@
 2114	squat yo	0		Last Available: "2006-12"
 2115	rosewater-soaked prehistoric spear	0		Stench Resistance: +3, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	double-paned fire of the cougar	0		Moxie: +20, Cold Resistance: +5, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	double-paned fire of the cougar	0		Moxie: +20, Cold Resistance: +5, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	mirror leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	wobbly sage Grateful Undead T-shirt	0		Mysticality Percent: +10
@@ -2141,9 +2141,9 @@
 2166	wobbly ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	huge toasty fortified toy ray gun	0		Damage Absorption: +60, Hot Damage: +5, Last Available: "2006-12"
-2169	tumbling Sherlock's toy space helmet of James Dean	0		Experience (Moxie): +3, Item Drop: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	tumbling Sherlock's toy space helmet of James Dean	0		Experience (Moxie): +3, Item Drop: +25, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	pulsating lightning-fast Tesla astronaut pants	0		Initiative: +40, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	pulsating lightning-fast Tesla astronaut pants	0		Initiative: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	toy jet pack of the sewer	0		Stench Damage: +25, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2155,7 +2155,7 @@
 2180	squat amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	narrow twirling yellow Harold's hammer handle	0		
+2183	yellow narrow twirling Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	pulsating dog trainer's Kiss the Knob apron	0		Experience (familiar): +1
 2186	unlit birthday cake	0		
@@ -2170,7 +2170,7 @@
 2195	tasty unspeakable fruitcake	3	awesome	Last Available: "2006-12"
 2196	bland gingerbread horror	3	decent	Last Available: "2006-12"
 2197	super-Vulcanized cold-filtered ghostly upside-down but probably evil chocolate	0		Effect: "Quadrilled", Effect Duration: 29, Last Available: "2006-12"
-2198	normal enchanted bat-shaped Crimboween cookie	4	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	enchanted normal bat-shaped Crimboween cookie	4	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	spoiled skull-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	flavorless tombstone-shaped Crimboween cookie	3	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	upside-down narrow teal groovy plastic gift-wrapping vampire	0		Moxie Percent: +10, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	lime green extremely unsafe Crimbo tiki necklace	0		Weapon Damage Percent: +100, Last Available: "2006-12"
 2208	Jim Carey's bobble-hip hula elf doll of the businessman	0		Monster Level: +25, Meat Drop: +50, Last Available: "2006-12"
 2209	dangerous Crimbo ukulele	0		Weapon Damage: +10, Last Available: "2006-12"
-2210	lightning-fast sizzling Tiki lighter	0		Hot Damage: +10, Initiative: +40, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	upside-down studded deck of tropical cards of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	inspector's careful tropical paperweight	0		Monster Level: -10, Item Drop: +15, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	lightning-fast sizzling Tiki lighter	0		Hot Damage: +10, Initiative: +40, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	upside-down studded deck of tropical cards of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	inspector's careful tropical paperweight	0		Monster Level: -10, Item Drop: +15, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	spinning tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	experienced Tropical Crimbo Hat	0		Experience: +2, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	perfumed Tropical Crimbo Shorts	0		Stench Resistance: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	miniature flavorless super ka-bob	2	decent	
+2215	experienced Tropical Crimbo Hat	0		Experience: +2, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	perfumed Tropical Crimbo Shorts	0		Stench Resistance: +5, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2217	flavorless miniature super ka-bob	2	decent	
 2218	bland beer basted brat	3	decent	
 2219	ribald Tropical Crimbo Sword	0		Sleaze Damage: +10, Last Available: "2006-12"
 2220	enhanced colloidal and Crimboween candy	0		Effect: "All Is Forgiven", Effect Duration: 28, Last Available: "2020-09"
 2221	purple Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	blinking nippy liar's pants of the brazier	0		Cold Damage: +10, Hot Spell Damage: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	blinking nippy liar's pants of the brazier	0		Cold Damage: +10, Hot Spell Damage: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	resourceful Sinatra's juggler's balls	0		Experience (Moxie): +5, Maximum MP: +50, Softcore Only, Last Available: "2007-01"
 2224	pink shirt of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2212,7 +2212,7 @@
 2237	green pygmy blowgun	0		
 2238	savvy pygmy nose-bone	0		Mysticality Percent: +20, Single Equip
 2239	lard-coated Oprah's bad voodoo mask	0		Maximum MP Percent: +50, Sleaze Spell Damage: +25, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
-2240	huge olive bottle of alcohol	0		
+2240	olive huge bottle of alcohol	0		
 2241	tumbling careful pygmy spear	0		Monster Level: -10
 2242	double-frozen skewed pygmy pygment	0		Effect: "Fever From the Flavor", Effect Duration: 20
 2243	blinking sizzling Rosewater's headhunter necktie	0		Mysticality Percent: +30, Hot Damage: +10, Single Equip
@@ -2243,11 +2243,11 @@
 2269	spoiled sausage wonton	3	crappy	
 2270	belt of the pedagogue of the bloodbag	0		Experience: +3, Maximum HP: +100, Single Equip
 2271	high-proof bad bottle of Merlot	6	decent	
-2272	weak perfectly mixed twirling bottle of Port	2	EPIC	
+2272	perfectly mixed weak twirling bottle of Port	2	EPIC	
 2273	aged special bottle of Pinot Noir	3	awesome	Effect: "Ogred and Oublietted", Effect Duration: 50
 2274	aged skewed bottle of Zinfandel	4	awesome	
-2275	watered-down acceptable bottle of Marsala	2	good	
-2276	weak acceptable bottle of Muscat	2	good	
+2275	acceptable watered-down bottle of Marsala	2	good	
+2276	acceptable weak bottle of Muscat	2	good	
 2277	upside-down Fernswarthy's key	0		
 2278	blinking Fernswarthy's letter	0		
 2279	book	0		
@@ -2261,7 +2261,7 @@
 2287	manspreader's electrified glowstick	0		Monster Level: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
 2289	paperclip	0		
-2290	tumbling teal really house	0		
+2290	teal tumbling really house	0		
 2291	Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
@@ -2288,7 +2288,7 @@
 2314	yellow candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
 2316	blinking squat broken carburetor	0		
-2317	teal shaking bronze token	0		
+2317	shaking teal bronze token	0		
 2318	bomb	0		
 2319	carved wheel	0		
 2320	worm-riding manual page	0		
@@ -2299,7 +2299,7 @@
 2325	twirling Staff of Ed	0		
 2326	narrow stone rose	0		
 2327	dry can of paint	0		Effect: "Held Closer", Effect Duration: 20
-2328	tumbling upside-down drum machine	0		
+2328	upside-down tumbling drum machine	0		
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
@@ -2309,15 +2309,15 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	asbestos-lined pipe of Gandalf	0		Spell Critical Percent: +20, Hot Resistance: +5
 2337	energetic reinforced beaded headband	0		Maximum MP Percent: +20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	bland half-sized pudding	2	decent	Wiki Name: "black pudding (food)"
+2338	half-sized bland pudding	2	decent	Wiki Name: "black pudding (food)"
 2339	mediocre bouncing Blackfly Chardonnay	3	decent	
 2340	delicious enchanted & tan	3	awesome	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 30
 2341	tumbling pepper	0		
 2342	rotten forest cake	3	crappy	
-2343	rotten gigantic blurry forest ham	8	crappy	
+2343	gigantic rotten blurry forest ham	8	crappy	
 2344	adjusted mirror filthworm hatchling scent gland	0		Effect: "Techno Bliss", Effect Duration: 25
-2345	warmed chilled jittery shaking narrow filthworm drone scent gland	0		Effect: "Covetous Robbery", Effect Duration: 20
-2346	enhanced blurry maroon filthworm royal guard scent gland	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 16
+2345	warmed chilled narrow jittery shaking filthworm drone scent gland	0		Effect: "Covetous Robbery", Effect Duration: 20
+2346	enhanced maroon blurry filthworm royal guard scent gland	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 16
 2347	purple heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	spinning gas balloon	0		
@@ -2327,7 +2327,7 @@
 2353	shaking deadly bejeweled pledge pin	0		Weapon Damage: +5, Single Equip
 2354	communications windchimes	0		
 2355	oxidized henna face paint	0		Effect: "Incensed", Effect Duration: 44
-2356	ionized narrow jittery red tube of dread wax	0		Effect: "Meadulla Oblongota", Effect Duration: 64
+2356	ionized red narrow jittery tube of dread wax	0		Effect: "Meadulla Oblongota", Effect Duration: 64
 2357	Lo Pan's Herculean Gaia beads	0		Experience (Muscle): +1, Spell Critical Percent: +30
 2358	pink clay bead	0		
 2359	jittery clay bead	0		
@@ -2346,7 +2346,7 @@
 2372	squat bunch of bananas	0		
 2373	normal banana	4	good	
 2374	twirling banana peel	0		
-2375	rotten big blurry banana cream pie	5	crappy	
+2375	big rotten blurry banana cream pie	5	crappy	
 2376	lousy spirit-forward banana daiquiri	5	decent	
 2377	bad blinking bungle in the jungle	3	decent	
 2378	banana spritzer	0		
@@ -2401,8 +2401,8 @@
 2427	unsweetened fuchsia freezerburned ice cube	0		Effect: "Chunky", Effect Duration: 44
 2428	cold-filtered dry skewed fake blood	0		Effect: "The Style... of the Future", Effect Duration: 18
 2429	altered Eau de Guaneau	0		Effect: "Chorale of Companionship", Effect Duration: 12
-2430	corrupted huge gray blinking bag of lard	0		Effect: "Leash of Linguini", Effect Duration: 37
-2431	liquefied liquefied purple tumbling bottle of Mystic Shell	0		Effect: "Arcane in the Brain", Effect Duration: 18
+2430	corrupted huge blinking gray bag of lard	0		Effect: "Leash of Linguini", Effect Duration: 37
+2431	liquefied liquefied tumbling purple bottle of Mystic Shell	0		Effect: "Arcane in the Brain", Effect Duration: 18
 2432	boiled aerosolized diffused SPF 451 lip balm	0		Effect: "Disco Concentration", Effect Duration: 54
 2433	polymerized bottle of antifreeze	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
 2434	enhanced skewed eyedrops	0		Effect: "Chow Downed", Effect Duration: 38
@@ -2432,7 +2432,7 @@
 2458	barskin loincloth of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "sleaze atk, 4xVolley, cap 6"
 2459	blue tighty whiteys of the ox	0		Muscle: +20, Familiar Effect: "sleaze atk, 3xVolley, cap 10"
 2460	upside-down lime green friendly yak toupee	0		Familiar Weight: +3, Familiar Effect: "atk, 1xPotato, cap 25"
-2462	lime green twirling odor extractor	0		Last Available: "2019-12"
+2462	twirling lime green odor extractor	0		Last Available: "2019-12"
 2463	bouncing Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	huge moldy bowl of Bounty-Os	8	crappy	
 2465	perfectly mixed Oreille Divis&eacute;e brandy	4	EPIC	
@@ -2461,7 +2461,7 @@
 2488	therapeutic yak anorak	0		HP Regen Min: 5, HP Regen Max: 7
 2489	tuxedo shirt of Leguizamo	0		Monster Level: +20
 2490	stanky energetic gnauga hide vest	0		Maximum MP Percent: +20, Stench Spell Damage: +25
-2491	olive shaking tumbling shirt kit	0		
+2491	olive tumbling shaking shirt kit	0		
 2492	blinking tropical orchid	0		
 2493	stick of dynamite	0		
 2494	fuchsia twirling dog trainer's Herculean Necrotelicomnicon	0		Experience (Muscle): +1, Experience (familiar): +1
@@ -2472,7 +2472,7 @@
 2499	molybdenum screwdriver	0		
 2500	olive molybdenum pliers	0		
 2501	spinning molybdenum crescent wrench	0		
-2502	jittery huge Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
+2502	huge jittery Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	blue necklace chain	0		
@@ -2504,21 +2504,21 @@
 2531	decent gnat lasagna	4	good	
 2532	pork	0		
 2533	diet decent pork chop sandwiches	1	good	
-2534	super-sized stale upside-down pork casserole	5	decent	
-2535	miniature decent gray skewed pork lasagna	2	good	
+2534	stale super-sized upside-down pork casserole	5	decent	
+2535	miniature decent skewed gray pork lasagna	2	good	
 2536	canopic jar	0		
 2537	spinning spice	0		
 2538	lime green blurry organs	0		
 2539	narrow forbidden Ankh of Badahnkadh	0		Spell Damage Percent: +50, Single Equip
 2540	wobbly tomb ratchet	0		
-2541	shaking mirror Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
+2541	mirror shaking Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	liquefied alkaline pulsating lesser grodulated violet	0		Effect: "Hardened Fabric", Effect Duration: 37, Last Available: "2007-05"
 2543	galvanized tin magnolia	0		Effect: "Superioreo", Effect Duration: 32, Last Available: "2007-05"
 2544	concentrated begpwnia	0		Effect: "Bandersnatched", Effect Duration: 36, Last Available: "2007-05"
 2545	alkaline chilled upsy daisy	0		Effect: "Worth Your Salt", Effect Duration: 45, Last Available: "2007-05"
 2546	boiled colloidal half-orchid	0		Effect: "Bureaucratized", Effect Duration: 29, Last Available: "2007-05"
 2547	blinking Socratic tin star of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Last Available: "2007-05"
-2548	blurry extremely unsafe deadly outrageous sombrero	0		Weapon Damage: +5, Weapon Damage Percent: +100, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	blurry extremely unsafe deadly outrageous sombrero	0		Weapon Damage: +5, Weapon Damage Percent: +100, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	strapping &quot;Humorous&quot; T-shirt of the dark arts	0		Muscle: +5, Spell Damage Percent: +100, Last Available: "2007-05"
 2550	narrow Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2544,7 +2544,7 @@
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
-2574	blurry yellow ant pick	0		Familiar Effect: "cold damage, meat"
+2574	yellow blurry ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
 2576	honey-dipped locust	0		
 2577	sage brainy cactus quill	0		Mysticality: +5, Mysticality Percent: +10
@@ -2553,7 +2553,7 @@
 2580	executive auspicious scorpion whip	0		Item Drop: +10, Meat Drop: +40
 2581	ghostly handful of sand	0		
 2582	cyan brick of sand	0		
-2583	enchanted rotten small centipede eggs	2	crappy	Effect: "Go-Gone", Effect Duration: 5
+2583	small rotten enchanted centipede eggs	2	crappy	Effect: "Go-Gone", Effect Duration: 5
 2584	twirling horrifying wonderwall shield	0		Spooky Damage: +25, Damage Reduction: 12
 2585	greedy Colonel Mustard's Lonely Spades Club Jacket	0		Meat Drop: +20
 2586	cyan chaotic General Sage's Lonely Diamonds Club Jacket	0		Spell Critical Percent: +10
@@ -2563,7 +2563,7 @@
 2590	drinkable weak distilled fortified wine	2	good	
 2591	yummy snack-sized tasty tart	2	awesome	
 2592	Knob Goblin lunchbox	0		
-2593	delicious special Knob pasty	3	awesome	Effect: "Happy Salamander", Effect Duration: 5
+2593	special delicious Knob pasty	3	awesome	Effect: "Happy Salamander", Effect Duration: 5
 2594	artisanal thermos full of Knob coffee	3	EPIC	
 2595	frozen Ben-Gal&trade; Balm	0		Effect: "Rootin' Around", Effect Duration: 19
 2596	leathery cat skin	0		
@@ -2585,7 +2585,7 @@
 2612	yellow vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	spoiled snack-sized savoy truffle	2	crappy	
+2615	snack-sized spoiled savoy truffle	2	crappy	
 2616	olive Magi-Wipes	0		
 2617	upside-down boom	0		
 2618	lion tamer's Iiti Kitty phone charm	0		Experience (familiar): +2, Single Equip
@@ -2601,7 +2601,7 @@
 2628	aromatic wholesome catskin buckler	0		Maximum HP Percent: +10, Stench Resistance: +1, Damage Reduction: 11
 2629	supercharged tail o' nine cats of the scaredy-cat	0		Maximum MP Percent: +30, Monster Level: -15
 2630	jittery Hugo's Weaving Manual	0		
-2631	quadruple-concentrated jittery red gremlin juice	0		Effect: "Surreally Buff", Effect Duration: 37
+2631	quadruple-concentrated red jittery gremlin juice	0		Effect: "Surreally Buff", Effect Duration: 37
 2632	frozen mother's helper	0		Effect: "Burning Hands", Effect Duration: 56
 2633	jittery Jeselnik's Da Vinci's pat-a-cake pendant	0		Experience (Mysticality): +5, Sleaze Damage: +25
 2634	mummy wrapping	0		
@@ -2622,18 +2622,18 @@
 2649	rosy-cheeked Lord Spookyraven's ear trumpet	0		Maximum HP Percent: +30, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	gigantic decent S.T.L.T.	10	good	Last Available: "2007-06"
+2652	decent gigantic S.T.L.T.	10	good	Last Available: "2007-06"
 2653	flavorless pulsating honey-dew	4	decent	Last Available: "2007-06"
 2654	strong smooth Xanadian	5	awesome	Last Available: "2007-06"
 2655	deionized mirror bottle of absinthe	0		Effect: "Engorged Weapon", Effect Duration: 52, Last Available: "2007-06"
 2656	olive fireproof Temple Grandin's Drowsy Sword	0		Familiar Weight: +7, Hot Resistance: +3
-2657	immense delicious blinking escargotsicle	10	awesome	Last Available: "2007-06"
+2657	delicious immense blinking escargotsicle	10	awesome	Last Available: "2007-06"
 2658	watered-down perfectly mixed bottle of realpagne	2	EPIC	Last Available: "2007-06"
 2659	albatross necklace of Flo-Jo	0		Initiative: +100, Single Equip, Last Available: "2007-06"
 2660	altered not-a-pipe	1	decent	Last Available: "2007-06"
-2661	high-proof bad flask of Amontillado	9	decent	Last Available: "2007-06"
-2662	prompt ball mask	0		Adventures: +3, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	yellow flame-retardant Can-Can skirt	0		Hot Resistance: +1, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2661	bad high-proof flask of Amontillado	9	decent	Last Available: "2007-06"
+2662	prompt ball mask	0		Adventures: +3, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	yellow flame-retardant Can-Can skirt	0		Hot Resistance: +1, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	cold-filtered huge sensitive poetry journal	0		Effect: "Mitre Cut", Effect Duration: 43, Last Available: "2007-06"
 2665	modified narrow bottled inspiration	0		Effect: "Thickest, Sickest", Effect Duration: 24, Last Available: "2007-06"
 2666	ionized unsweetened bellhop bell	0		Effect: "Phorcefullness", Effect Duration: 17, Last Available: "2007-06"
@@ -2645,7 +2645,7 @@
 2672	jittery gray library card	0		Last Available: "2007-06"
 2673	lime green Bohemian rhapsody	0		Last Available: "2007-06"
 2674	modified polarized bottle of cat tonic	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 17, Last Available: "2007-06"
-2675	compressed pulsating jittery shaking handful of moss	1		Effect: "Hagg-ard", Effect Duration: 15
+2675	compressed pulsating shaking jittery handful of moss	1		Effect: "Hagg-ard", Effect Duration: 15
 2676	altered twirling bit-o-cactus	1		
 2677	boiled lime green protein powder	1		Effect: "Painted-On Bikini", Effect Duration: 10
 2678	spectre scepter	0		
@@ -2695,16 +2695,16 @@
 2722	auspicious Temple Grandin's personal trainer's Fonzie's Staff of the Greasefire	0		Experience (Moxie): +1, Experience Percent (Muscle): +10, Familiar Weight: +7, Item Drop: +10
 2723	baleful personal trainer's beefcake's Staff of the Grand Flamb&eacute;	0		Muscle: +25, Experience Percent (Muscle): +10, Spell Damage: +25
 2724	flavorless bowl of rye sprouts	4	decent	
-2725	moldy small bouncing cob of corn	2	crappy	
+2725	small moldy bouncing cob of corn	2	crappy	
 2726	special stale juniper berries	4	decent	Effect: "Bright!", Effect Duration: 35
 2727	toothsome spinning squat teal plum	4	awesome	
-2728	big delicious blue pear	5	awesome	
+2728	delicious big blue pear	5	awesome	
 2729	adequate peach	4	good	
 2730	tolerable plum wine	4	good	
 2731	mediocre narrow shot of pear schnapps	3	decent	
-2732	weak smooth shot of peach schnapps	2	awesome	
-2733	rotten gigantic spinning bunch of square grapes	7	crappy	
-2734	thick spoiled brown sugar cane	5	crappy	
+2732	smooth weak shot of peach schnapps	2	awesome	
+2733	gigantic rotten spinning bunch of square grapes	7	crappy	
+2734	spoiled thick brown sugar cane	5	crappy	
 2735	rotten sandwich of the gods	4	crappy	
 2736	acceptable Pan-Dimensional Gargle Blaster	4	good	
 2737	denatured leopard-print barbell	1	crappy	
@@ -2712,9 +2712,9 @@
 2739	modified unsweetened panty raider camouflage	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 31
 2740	squat rosy-cheeked shellacked Staff of the Walk-In Freezer of the sweet-tooth	0		Damage Reduction: 7, Maximum HP Percent: +30, Candy Drop: +100
 2741	drinkable boilermaker	3	good	
-2742	jumbo toothsome steel lasagna	5	quest	
-2743	irresponsibly strong delicious steel margarita	9	quest	
-2744	modified tumbling huge steel-scented air freshener	1		Effect: "Can't Smell Nothin'", Effect Duration: 25
+2742	toothsome jumbo steel lasagna	5	quest	
+2743	delicious irresponsibly strong steel margarita	9	quest	
+2744	modified huge tumbling steel-scented air freshener	1		Effect: "Can't Smell Nothin'", Effect Duration: 25
 2745	unsweetened narrow gremlin mutagen	0		Effect: "Cold Throat", Effect Duration: 53
 2746	pressed mirror extra-potent gremlin mutagen	0		Effect: "Human-Human Hybrid", Effect Duration: 15
 2747	pulsating chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2737,9 +2737,9 @@
 2764	greedy foul-smelling Order of the Silver Wossname of the cheetah	0		Stench Damage: +10, Meat Drop: +20, Initiative: +60, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	decent snack-sized Crimbo pie	2	good	
+2767	snack-sized decent Crimbo pie	2	good	
 2768	decent miniature pear tart	2	good	
-2769	immense flavorless olive peach pie	7	decent	
+2769	flavorless immense olive peach pie	7	decent	
 2770	aerosolized chunk of rock salt	0		Effect: "Jittery", Effect Duration: 34
 2771	ionized handful of pine needles	0		Effect: "Mortarfied", Effect Duration: 63
 2772	steamy ruby	0		
@@ -2778,7 +2778,7 @@
 2805	ionized double-polymerized deionized vial of baconstone juice	0		Effect: "Sleazy Weapon", Effect Duration: 19
 2806	boiled modified altered blue vial of porquoise juice	0		Effect: "Tingly Elbows", Effect Duration: 33
 2807	enhanced twirling flask of hamethyst juice	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 53
-2808	magnetized activated shaking jittery flask of baconstone juice	0		Effect: "Mushroom Samba", Effect Duration: 16
+2808	magnetized activated jittery shaking flask of baconstone juice	0		Effect: "Mushroom Samba", Effect Duration: 16
 2809	boiled liquefied flask of porquoise juice	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 40
 2810	enhanced upside-down jug of hamethyst juice	0		Effect: "Flame-Retardant Trousers", Effect Duration: 54
 2811	polymerized blinking jug of baconstone juice	0		Effect: "Reptilian Fortitude", Effect Duration: 60
@@ -2789,9 +2789,9 @@
 2816	blue manspreader's Lo Pan's curative Boxers	0		Spell Critical Percent: +30, Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, 1xLep"
 2817	narrow reassuring foul-smelling ruddy Brooch	0		Maximum HP Percent: +40, Stench Damage: +10, Spooky Resistance: +1, Single Equip
 2818	sharpshooter's electrified educational Bracelet	0		Experience: +1, Critical Hit Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-2819	pulsating blurry banded Grimacite gasmask of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	pulsating blurry banded Grimacite gasmask of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	huge hale rosy-cheeked Grimacite gat	0		Maximum HP Percent: +30, Maximum HP: +20, Last Available: "2008-11"
-2821	rosy-cheeked Grimacite gaiters of the brute	0		Muscle Percent: +30, Maximum HP Percent: +30, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	rosy-cheeked Grimacite gaiters of the brute	0		Muscle Percent: +30, Maximum HP Percent: +30, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	miser's flame-wreathed Grimacite gauntlets	0		Hot Spell Damage: +10, Meat Drop: +10, Single Equip, Last Available: "2008-11"
 2823	sizzling Grimacite go-go boots of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +10, Single Equip, Last Available: "2008-11"
 2824	scorching Samson's Grimacite girdle	0		Experience (Muscle): +5, Hot Damage: +25, Single Equip, Last Available: "2008-11"
@@ -2803,7 +2803,7 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	normal twirling digital key lime pie	4	good	
-2833	moldy fancy immense star key lime pie	6	crappy	Effect: "Insatiable Hunger", Effect Duration: 40
+2833	fancy moldy immense star key lime pie	6	crappy	Effect: "Insatiable Hunger", Effect Duration: 40
 2834	yellow auspicious Van der Graaf bottle-rocket crossbow of the boozehound	0		Item Drop: +10, Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	mirror blurry indie comic hipster glasses of the cheetah	0		Initiative: +60, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2811,7 +2811,7 @@
 2838	aromatic glowstick of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Last Available: "2007-08"
 2839	ghostly greedy Periodical Paintbrush	0		Meat Drop: +20, Softcore Only
 2840	weak acceptable bottle of cooking sherry	2	good	
-2841	low-calorie decent packet of ketchup	1	good	
+2841	decent low-calorie packet of ketchup	1	good	
 2842	artisanal accidental cider	4	EPIC	
 2843	huge decent dire fudgesicle	7	good	
 2844	lard-coated rock-hard occult brainy navel ring of navel gazing	0		Mysticality: +5, Spell Damage Percent: +25, Damage Reduction: 5, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2820,15 +2820,15 @@
 2847	upside-down wobbly Dallas Dynasty Falcon Crest shield of the scaredy-cat	0		Monster Level: -15, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	enchanted irresponsibly strong bad upside-down upside-down moonberry wine cooler	8	decent	Effect: "Overstimulated", Effect Duration: 40
-2851	jumbo toothsome enchanted fine aged cheddarwurst	5	awesome	Effect: "Twinklebritches", Effect Duration: 25
+2850	bad irresponsibly strong enchanted upside-down upside-down moonberry wine cooler	8	decent	Effect: "Overstimulated", Effect Duration: 40
+2851	toothsome jumbo enchanted fine aged cheddarwurst	5	awesome	Effect: "Twinklebritches", Effect Duration: 25
 2852	huge branch from the Great Tree	0		
 2853	fuchsia Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	prompt slick huge mosquito proboscis	0		Moxie: +10, Adventures: +3
 2856	electrified swamp lolly	0		Effect: "Arcane in the Brain", Effect Duration: 47
 2857	moist blue seegar butt	0		Effect: "Human-Insect Hybrid", Effect Duration: 38
-2858	blue bouncing bottled swamp gas	0		
+2858	bouncing blue bottled swamp gas	0		
 2859	nasty witch wart of the empath	0		Familiar Weight: +5, Stench Damage: +5
 2860	normal swamp muck	4	good	
 2861	upside-down ribald Annie Oakley's hardy leechknife	0		Maximum HP: +50, Critical Hit Percent: +20, Sleaze Damage: +10
@@ -2841,7 +2841,7 @@
 2868	quantum pirate pamphlet	0		Effect: "Radium Radicality", Effect Duration: 61
 2869	pickled jittery pirate brochure	0		Effect: "Hangdog", Effect Duration: 32
 2870	wet denatured olive pirate tract	0		Effect: "Dreadful Sheen", Effect Duration: 16
-2871	ghostly cyan burnt flower	0		
+2871	cyan ghostly burnt flower	0		
 2872	foul-smelling lion tamer's plastic Naughty Sorceress	0		Experience (familiar): +2, Stench Damage: +10
 2873	Jeselnik's plastic Ed the Undying of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +25
 2874	plastic Lord Spookyraven of James Dean of the scaredy-cat	0		Experience (Moxie): +3, Monster Level: -15
@@ -2910,7 +2910,7 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	delicious huge Surprise Egg	6	awesome	
+2940	huge delicious Surprise Egg	6	awesome	
 2941	anodized Steal This Candy	0		Effect: "Flamibili Tea", Effect Duration: 37
 2942	diffused quadruple-moist jittery chocolate filthy lucre	0		Effect: "Dreadful Fear", Effect Duration: 11
 2943	nitrogenated ghostly green Angry Farmer's Wife Candy	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 13
@@ -2929,7 +2929,7 @@
 2957	rum barrel charrrm	0		
 2958	low-calorie spoiled tube of cranberry Go-Goo	1	crappy	
 2959	blinking rum barrel charrrm bracelet of the boozehound	0		Booze Drop: +100
-2960	flavorless miniature single-serving herbal stuffing	2	decent	
+2960	miniature flavorless single-serving herbal stuffing	2	decent	
 2961	stale packet of tofurkey gravy	3	decent	
 2962	rotten tofurkey nugget	4	crappy	
 2963	spinning rigging shampoo	0		
@@ -2997,9 +2997,9 @@
 3025	strong perfectly mixed twirling corpse on the beach	5	EPIC	
 3026	perfectly mixed corpsetini	3	super EPIC	
 3027	tolerable huge corpsedriver	3	good	
-3028	distilled hand-crafted special mirror Corpse Island iced tea	5	EPIC	Effect: "Mushroom Magicalness", Effect Duration: 30
-3029	weak drinkable red-headed corpse	2	good	
-3030	practically non-alcoholic acceptable kamicorpse-ee	1	good	
+3028	hand-crafted special distilled mirror Corpse Island iced tea	5	EPIC	Effect: "Mushroom Magicalness", Effect Duration: 30
+3029	drinkable weak red-headed corpse	2	good	
+3030	acceptable practically non-alcoholic kamicorpse-ee	1	good	
 3031	boozy drinkable corpsel	5	good	
 3032	weak tolerable corpsebite	2	good	
 3033	Sherlock's pirate fledges	0		Item Drop: +25
@@ -3015,7 +3015,7 @@
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	shaking metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	normal immense pulsating nanite-infested gingerbread bugbear	9	good	Last Available: "2007-12"
-3046	enchanted bite-sized flavorless nanite-infested candy cane	1	decent	Effect: "Human-Human Hybrid", Effect Duration: 45, Last Available: "2020-09"
+3046	bite-sized enchanted flavorless nanite-infested candy cane	1	decent	Effect: "Human-Human Hybrid", Effect Duration: 45, Last Available: "2020-09"
 3047	bland wobbly maroon nanite-infested fruitcake	3	decent	Last Available: "2007-12"
 3048	acceptable nanite-infested eggnog	4	good	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
@@ -3025,7 +3025,7 @@
 3053	pulsating mood ring	0		Last Available: "2007-02"
 3054	double-denatured triple-chilled narrow candy heart	0		Effect: "Hypercubed", Effect Duration: 53, Last Available: "2007-02"
 3055	chilled pickled liquefied blurry cymbal syrup	0		Free Pull, Effect: "Innately Truthy", Effect Duration: 46, Last Available: "2007-02"
-3056	mirror energetic metallic foil cat ears	0		Maximum MP Percent: +20, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	mirror energetic metallic foil cat ears	0		Maximum MP Percent: +20, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	spinning nanofiber cloth	0		Last Available: "2007-12"
 3058	spinning iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3041,15 +3041,15 @@
 3069	squat laser cannon	0		Last Available: "2007-12"
 3070	tumbling plexifoam chin strap	0		Last Available: "2007-12"
 3071	blinking wobbly silicon-infused gluteal shield	0		Last Available: "2007-12"
-3072	cyan pulsating carbonite visor	0		Last Available: "2007-12"
+3072	pulsating cyan carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
 3074	narrow ghostly polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	skewed laser targeting chip	0		Last Available: "2007-12"
-3077	wobbly twirling hi-density nylocite leg armor	0		Last Available: "2007-12"
+3077	twirling wobbly hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
 3079	tumbling Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
-3080	jittery ghostly teddy borg	0		Last Available: "2007-12"
+3080	ghostly jittery teddy borg	0		Last Available: "2007-12"
 3081	boxer's marionette collective	0		Muscle Percent: +10, Last Available: "2007-12"
 3082	huge monomolecular yo-yo	0		Last Available: "2010-12"
 3083	gray gray blob	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	blurry sizzling roboduck-on-a-string of the sweet-tooth	0		Hot Damage: +10, Candy Drop: +100, Last Available: "2007-12"
 3086	squat mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	Newton's Herculean biomechanical crimborg helmet	0		Experience (Muscle): +1, Experience (Mysticality): +3, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	Newton's Herculean biomechanical crimborg helmet	0		Experience (Muscle): +1, Experience (Mysticality): +3, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	shaking weightlifter's C.B.F.G. of the cheetah	0		Muscle: +15, Initiative: +60, Last Available: "2007-12"
-3090	bouncing shellacked biomechanical crimborg leg armor of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	bouncing shellacked biomechanical crimborg leg armor of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	extra-modified ionized maroon vitachoconutriment capsule	0		Effect: "Superheroic", Effect Duration: 67, Last Available: "2007-12"
 3092	banded handmade hobby horse	0		Damage Absorption: +100, Last Available: "2007-12"
 3093	miser's ball-in-a-cup	0		Meat Drop: +10, Last Available: "2007-12"
@@ -3078,13 +3078,13 @@
 3106	fuchsia toasty careful electrified cyborg stompin' boot	0		Monster Level: -10, Hot Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2007-12"
 3107	pulsating bouncing deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
-3109	ghostly purple Miniborg stomper	0		Last Available: "2007-12"
+3109	purple ghostly Miniborg stomper	0		Last Available: "2007-12"
 3110	pulsating Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	fuchsia Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
-3114	blinking wobbly pulsating Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
-3115	red wobbly old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
+3114	wobbly blinking pulsating Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
+3115	wobbly red old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
 3117	pulsating Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
@@ -3113,7 +3113,7 @@
 3141	olive panhandle panhandling hat of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xLep, cap 37"
 3142	blurry greasy cup of infinite pencils	0		Sleaze Spell Damage: +10
 3143	Hodgman's disgusting technicolor overcoat of the wise owl of Leguizamo	0		Mysticality: +20, Monster Level: +20
-3144	blue bouncing a torn paper strip	0		
+3144	bouncing blue a torn paper strip	0		
 3145	El Vibrato translator	0		
 3146	bouncing El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
@@ -3138,16 +3138,16 @@
 3166	repaired El Vibrato drone	0		
 3167	green augmented El Vibrato drone	0		
 3168	non-wet alkaline seal eyeball	0		Effect: "Orc Chops", Effect Duration: 50
-3169	moldy big turtle soup	5	crappy	Effect: "[598]A Little Bit Evil"
+3169	big moldy turtle soup	5	crappy	Effect: "[598]A Little Bit Evil"
 3170	blurry evil noodles	0		
 3171	nauseating reagent	0		
 3172	huge fuchsia evil paper umbrella of the overflowing toilet	0		Stench Spell Damage: +50
 3173	modified magnetized evil vihuela	0		Effect: "damage.enh", Effect Duration: 29
-3174	enchanted bland narrow evil boring spaghetti	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45
+3174	bland enchanted narrow evil boring spaghetti	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45
 3175	moldy squat mirror evil noodles	4	crappy	
-3176	miniature flavorless tumbling blurry evil noodles	2	decent	
+3176	flavorless miniature tumbling blurry evil noodles	2	decent	
 3177	spoiled bouncing evil painful penne pasta	4	crappy	
-3178	big moldy 3vi1 pr0n m4nic0tti	5	crappy	
+3178	moldy big 3vi1 pr0n m4nic0tti	5	crappy	
 3179	normal half-sized twirling evil ravioli della hippy	2	good	
 3180	moldy lime green evil noodles	4	crappy	
 3181	diffused activated pulsating evil potion of potency	0		Effect: "Arresistible", Effect Duration: 48
@@ -3156,7 +3156,7 @@
 3184	anodized wet upside-down evil eyedrops of the ermine	0		Effect: "Patched In", Effect Duration: 16
 3185	pressed polarized squat evil ointment of the occult	0		Effect: "Strange Mental Acuity", Effect Duration: 29
 3186	dry skewed evil serum of sarcasm	0		Effect: "Turtle Power", Effect Duration: 65
-3187	deionized pickled blue squat evil philter of phorce	0		Effect: "The Grass...  Is Blue...", Effect Duration: 48
+3187	deionized pickled squat blue evil philter of phorce	0		Effect: "The Grass...  Is Blue...", Effect Duration: 48
 3188	bad watered-down an evil sump'm sump'm	2	decent	
 3189	weak lousy evil ducha de oro	2	decent	
 3190	bad jittery evil horizontal tango	4	decent	
@@ -3194,14 +3194,14 @@
 3222	dance instructor's gatorskin umbrella of the scaredy-cat	0		Experience Percent (Moxie): +10, Monster Level: -15
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	tolerable watered-down bottle of sewage schnapps	2	good	
+3225	watered-down tolerable bottle of sewage schnapps	2	good	
 3226	smooth bottle of Ooze-O	3	awesome	
 3227	moldy C.H.U.M. chum	3	crappy	
 3228	adequate unfortunate dumplings	3	good	
 3229	blinking blinking decaying goldfish liver	0		
-3230	polymerized polarized bouncing shaking pulsating oil of oiliness	0		Effect: "Meadulla Oblongota", Effect Duration: 64
+3230	polymerized polarized pulsating bouncing shaking oil of oiliness	0		Effect: "Meadulla Oblongota", Effect Duration: 64
 3231	grievous tattered paper crown	0		Weapon Damage Percent: +50, Familiar Effect: "1xSombrero, cap 15"
-3232	normal tiny special vanilla-frosted king cake	1	good	Effect: "Helping Comes Second", Effect Duration: 50, Last Available: "2008-03"
+3232	normal special tiny vanilla-frosted king cake	1	good	Effect: "Helping Comes Second", Effect Duration: 50, Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	pulsating water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3240,15 +3240,15 @@
 3268	dry lime green handful of Crotchety Pine needles	0		Effect: "EVISCERATE!", Effect Duration: 48
 3269	altered triple-oxidized shaking lump of Saccharine Maple sap	0		Effect: "Armored Innards", Effect Duration: 28
 3270	alkaline quantum polarized lime green handful of Laughing Willow bark	0		Effect: "Snobby", Effect Duration: 65
-3271	jittery bouncing bouncing forbidden crotchety pants	0		Spell Damage Percent: +50, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	jittery bouncing bouncing forbidden crotchety pants	0		Spell Damage Percent: +50, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	steel-toed Saccharine Maple pendant	0		Damage Reduction: 9, Conditional Skill (Equipped): "Spray Sap"
-3273	huge careful willowy bonnet	0		Monster Level: -10, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	huge careful willowy bonnet	0		Monster Level: -10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	teal jittery black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	huge studded belt of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2008-04"
-3279	tumbling olive personal massager	0		Last Available: "2008-04"
+3279	olive tumbling personal massager	0		Last Available: "2008-04"
 3280	upside-down personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	Newton's stick-on eyebrow piercing	0		Experience (Mysticality): +3, Last Available: "2008-04"
@@ -3308,7 +3308,7 @@
 3336	jittery dead guy's piece of double-sided tape	0		
 3337	wholesome dead guy's memento of the sewer	0		Maximum HP Percent: +10, Stench Damage: +25, Single Equip
 3338	rotten narrow banquet	3	crappy	
-3339	bouncing twirling red sharpened hubcap	0		
+3339	twirling red bouncing sharpened hubcap	0		
 3340	blue very caltrop	0		
 3341	maroon The Six-Pack of Pain	0		
 3342	hobo monkey	0		
@@ -3332,7 +3332,7 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	mirror yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	bland snack-sized mole mol&eacute;	2	decent	Last Available: "2008-06"
+3363	snack-sized bland mole mol&eacute;	2	decent	Last Available: "2008-06"
 3364	watered-down drinkable Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
 3365	chilled warmed Climate Colada	0		Effect: "Piratastic", Effect Duration: 18, Last Available: "2008-06"
 3366	vacuum-sealed digital underground potion	0		Effect: "Hustlin'", Effect Duration: 36, Last Available: "2008-06"
@@ -3412,9 +3412,9 @@
 3445	Junior Adventurer's kit	0		
 3446	pulsating groovy prism necklace	0		Single Equip
 3447	medical-grade slick six-rainbow shield	0		Moxie: +10, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 12, Last Available: "2008-07"
-3448	purple spinning twirling rainbow bomb	0		Last Available: "2008-07"
+3448	twirling purple spinning rainbow bomb	0		Last Available: "2008-07"
 3449	cotton candy cone	0		Last Available: "2008-08"
-3450	blinking teal cotton candy pinch	0		Last Available: "2008-08"
+3450	teal blinking cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
 3452	shaking cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
@@ -3423,7 +3423,7 @@
 3456	trusty torch of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-12"
 3457	bouncing mirror baleful Junior Adventurer's merit badge	0		Spell Damage: +25
 3458	ionized polymerized upside-down STYX deodorant body spray	0		Effect: "Hombre Muerto Caminando", Effect Duration: 37
-3459	special practically non-alcoholic drinkable white-label gin	1	good	Effect: "Tearful, Fearful", Effect Duration: 20
+3459	practically non-alcoholic special drinkable white-label gin	1	good	Effect: "Tearful, Fearful", Effect Duration: 20
 3460	bland tin rations	3	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
@@ -3435,7 +3435,7 @@
 3468	jittery auspicious plastic baby	0		Item Drop: +10, Single Equip, Last Available: "2008-12"
 3469	bland tiny blueberry-frosted king cake	1	decent	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
-3471	fuchsia narrow damp boot	0		
+3471	narrow fuchsia damp boot	0		
 3472	twirling Annie Oakley's veiny hardened Seasonal Beret	0		Damage Reduction: 3, Maximum HP: +10, Critical Hit Percent: +20, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	jittery Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	quadruple-aerosolized galvanized cranberry cordial	0		Effect: "Tingling Feeling", Effect Duration: 58
@@ -3453,21 +3453,21 @@
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	twirling pristine fish scale	0		
-3489	special delicious small beefy fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
+3489	special small delicious beefy fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
 3490	stale glistening fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
-3491	fancy big flavorless twirling bouncing slick fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
+3491	flavorless big fancy bouncing twirling slick fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
 3492	Samson's Herculean fish scimitar	0		Experience (Muscle): 6
 3493	squat energetic therapeutic fish stick	0		Maximum MP Percent: +20, HP Regen Min: 5, HP Regen Max: 7
 3494	tumbling flame-wreathed electrified fish bazooka	0		Hot Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5
 3495	frozen spinning sea salt crystal	0		Effect: "One Very Clear Eye", Effect Duration: 33
 3496	vacuum-sealed bazookafish bubble gum	0		Effect: "Super-Charged", Effect Duration: 11
 3497	drinkable bottle of Pete's Sake	3	good	
-3498	blurry blinking invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	adequate tiny canap&eacute;s	1	good	
-3502	dehydrated tumbling blinking thermos of brew	1	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 40, Last Available: "2011-12"
-3503	watered-down acceptable glass of brandy	2	good	Last Available: "2011-12"
+3498	blinking blurry invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3501	tiny adequate canap&eacute;s	1	good	
+3502	dehydrated blinking tumbling thermos of brew	1	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 40, Last Available: "2011-12"
+3503	acceptable watered-down glass of brandy	2	good	Last Available: "2011-12"
 3504	skewed French slippers	0		
 3505	fuchsia pulsating executive LWA ring	0		Meat Drop: +40
 3506	huge LARP membership card	0		Last Available: "2008-10"
@@ -3497,7 +3497,7 @@
 3530	mutant gila monster egg	0		
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	pulsating ant antidepressant	0		Familiar Weight: +5
-3533	green shaking cactus monocle	0		Familiar Weight: +5
+3533	shaking green cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	huge bouncing plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	mirror plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
@@ -3510,8 +3510,8 @@
 3543	Jeselnik's depleted Grimacite gravy boat of the glutton	0		Sleaze Damage: +25, Food Drop: +100, Last Available: "2011-12"
 3544	depleted Grimacite weightlifting belt of the empath of the boozehound	0		Familiar Weight: +5, Booze Drop: +100, Single Equip, Last Available: "2011-12"
 3545	Newton's depleted Grimacite grappling hook of courage	0		Experience (Mysticality): +3, Spooky Resistance: +3, Single Equip, Last Available: "2011-12"
-3546	avaricious depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Meat Drop: +30, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	fortified brainy depleted Grimacite shinguards	0		Mysticality: +5, Damage Absorption: +60, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	avaricious depleted Grimacite ninja mask of dire peril	0		Weapon Damage: +20, Meat Drop: +30, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	fortified brainy depleted Grimacite shinguards	0		Mysticality: +5, Damage Absorption: +60, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	reassuring Lo Pan's depleted Grimacite astrolabe	0		Spell Critical Percent: +30, Spooky Resistance: +1, Single Equip, Last Available: "2011-12"
 3549	jittery fuchsia wholesome KoL Con Cinco Pi&ntilde;ata Bat of incineration	0		Maximum HP Percent: +10, Hot Spell Damage: +50, Softcore Only, Last Available: "2008-09"
 3550	propeller beanie of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, cap 7"
@@ -3524,12 +3524,12 @@
 3557	decent sea avocado	3	good	
 3558	spoiled huge sea lychee	3	crappy	
 3559	bland sea tangelo	3	decent	
-3560	thick decent sea honeydew	5	good	
+3560	decent thick sea honeydew	5	good	
 3561	corrupted double-deionized pressurized potion of puissance	0		Effect: "Human-Insect Hybrid", Effect Duration: 19
 3562	activated frozen maroon pressurized potion of perspicacity	0		Effect: "Rushin' Hands", Effect Duration: 46
 3563	denatured pressurized potion of pulchritude	0		Effect: "Alpine Mintiness", Effect Duration: 34
-3564	lousy practically non-alcoholic huge berry-infused sake	1	decent	
-3565	acceptable spirit-forward citrus-infused sake	5	good	
+3564	practically non-alcoholic lousy huge berry-infused sake	1	decent	
+3565	spirit-forward acceptable citrus-infused sake	5	good	
 3566	smooth jittery melon-infused sake	3	awesome	
 3567	slab of sponge	0		
 3568	skewed greasy scandalous sponge helmet of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +5, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xFairy"
@@ -3548,8 +3548,8 @@
 3581	cyan sushi-rolling mat	0		
 3582	fancy delicious skewed rice	3	awesome	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
 3584	stale irradiated candy cane	3	decent	Last Available: "2008-12"
-3585	thick flavorless spinning gingerbread mutant bugbear	5	decent	Last Available: "2008-12"
-3586	perfectly mixed watered-down blinking oozenog	2	EPIC	Last Available: "2008-12"
+3585	flavorless thick spinning gingerbread mutant bugbear	5	decent	Last Available: "2008-12"
+3586	watered-down perfectly mixed blinking oozenog	2	EPIC	Last Available: "2008-12"
 3587	corrupted energized narrow sugar plum	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 62, Last Available: "2008-12"
 3588	pickled sugar banana	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 47, Last Available: "2008-12"
 3589	deionized anodized boiled sugar lime	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 51, Last Available: "2008-12"
@@ -3573,7 +3573,7 @@
 3607	miser's hale aerated diving helmet of wisdom	0		Mysticality: +15, Maximum HP: +20, Meat Drop: +10, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	live nautical mine	0		
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
-3610	squat jittery olive imitation whetstone	0		
+3610	jittery squat olive imitation whetstone	0		
 3611	warmed sea grease	0		Effect: "Your Eyes are Peeled!", Effect Duration: 69
 3612	sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	narrow battered Crimbo Crate	0		Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	squat chitinous pod	0		Last Available: "2008-12"
 3624	smartaleck's parasitic claw	0		Moxie Percent: +30, Last Available: "2008-12"
-3625	bouncing experienced parasitic tentacles	0		Experience: +2, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	ghostly lightning-fast parasitic headgnawer	0		Initiative: +40, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	bouncing experienced parasitic tentacles	0		Experience: +2, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	ghostly lightning-fast parasitic headgnawer	0		Initiative: +40, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	twirling shellacked parasitic strangleworm	0		Damage Reduction: 7, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,24 +3598,24 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	lime green hardened Fonzie's elven socks	0		Experience (Moxie): +1, Damage Reduction: 3, Last Available: "2008-12"
 3634	lightning-fast therapeutic elven gloves	0		Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-12"
-3635	frightening festive holiday hat of the storm	0		Maximum MP Percent: +40, Spooky Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	frightening festive holiday hat of the storm	0		Maximum MP Percent: +40, Spooky Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	inspector's patent shoes of Flo-Jo	0		Item Drop: +15, Initiative: +100, Last Available: "2008-12"
 3637	shellacked personal trainer's gray bow tie	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Last Available: "2008-12"
 3638	zippy supercharged penguin thesaurus	0		Maximum MP Percent: +30, Initiative: +20, Last Available: "2008-12"
-3639	spoiled small blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	small spoiled blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	shaking seaweed	0		
 3641	jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	jittery pufferfish spine	0		
 3644	depleted Grimacite kneecapping stick of the cougar	0		Moxie: +20, Last Available: "2007-06"
 3645	perfectly mixed canteen of wine	3	EPIC	Last Available: "2008-12"
-3646	super-sized spoiled elven <i>limbos</i> gingerbread	5	crappy	Last Available: "2008-12"
+3646	spoiled super-sized elven <i>limbos</i> gingerbread	5	crappy	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	huge map to Madness Reef	0		
 3650	decent toast with jam	4	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	irresponsibly strong lousy elven moonshine	7	decent	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	lousy irresponsibly strong elven moonshine	7	decent	Last Available: "2008-12"
 3653	flavorless knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	upside-down nippy hale psycho sweater	0		Maximum HP: +20, Cold Damage: +10, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
@@ -3625,8 +3625,8 @@
 3659	shellacked plastic strand of DNA	0		Damage Reduction: 7, Last Available: "2008-12"
 3660	shaking plastic chunk of depleted Grimacite of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2008-12"
 3661	skewed container of Putty	0		Last Available: "2009-01"
-3662	Newton's Putty mitre	0		Experience (Mysticality): +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	shaking clever weightlifter's Putty leotard	0		Muscle: +15, Maximum MP: +20, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	Newton's Putty mitre	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	shaking clever weightlifter's Putty leotard	0		Muscle: +15, Maximum MP: +20, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	fireproof Putty ball	0		Hot Resistance: +3, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	jittery lard-coated smelly beefy Putty snake	0		Muscle: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	sharpshooter's glow-in-the-dark burrowgrub	0		Critical Hit Percent: +10, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	decent small can of franks 'n' beans	2	good	Last Available: "2010-12"
-3673	weak drinkable bottle of peppermint schnapps	2	good	Last Available: "2010-12"
+3673	drinkable weak bottle of peppermint schnapps	2	good	Last Available: "2010-12"
 3674	squat throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
@@ -3646,15 +3646,15 @@
 3680	esca	0		
 3681	teal bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
-3683	tumbling narrow map to the Marinara Trench	0		
-3684	bite-sized tasty tempura carrot	1	awesome	
+3683	narrow tumbling map to the Marinara Trench	0		
+3684	tasty bite-sized tempura carrot	1	awesome	
 3685	yummy upside-down tempura cucumber	3	awesome	
 3686	yummy small tempura avocado	2	awesome	
-3687	decent snack-sized fancy sea broccoli	2	good	Effect: "Heart of Pink", Effect Duration: 40
+3687	snack-sized decent fancy sea broccoli	2	good	Effect: "Heart of Pink", Effect Duration: 40
 3688	miniature moldy sea cauliflower	2	crappy	
 3689	moldy blurry tempura broccoli	3	crappy	
 3690	bland special tempura cauliflower	3	decent	Effect: "Nothing Is Impossible", Effect Duration: 30
-3691	half-sized rotten bouncing sea blueberry	2	crappy	
+3691	rotten half-sized bouncing sea blueberry	2	crappy	
 3692	stale sea persimmon	3	decent	
 3693	concentrated cold-filtered pressurized potion of perception	0		Effect: "Space Cadet", Effect Duration: 42
 3694	double-ionized wet pressurized potion of proficiency	0		Effect: "Ready to Snap", Effect Duration: 37
@@ -3686,7 +3686,7 @@
 3720	decaying pole	0		
 3721	decaying paddle	0		
 3722	mirror tarnished ring	0		
-3723	lime green twirling tarnished rod	0		
+3723	twirling lime green tarnished rod	0		
 3724	brittle plastic handle	0		
 3725	foggy glass globe	0		
 3726	possessed tomato	0		
@@ -3716,7 +3716,7 @@
 3751	moldy snack-sized chocolate chip brownies	2	crappy	
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	ionized galvanized love song of vague ambiguity	0		Effect: "Memento Moir&eacute;", Effect Duration: 61, Last Available: "2009-02"
-3755	enhanced nitrogenated maroon upside-down love song of smoldering passion	0		Effect: "Innately Wise", Effect Duration: 21, Last Available: "2009-02"
+3755	enhanced nitrogenated upside-down maroon love song of smoldering passion	0		Effect: "Innately Wise", Effect Duration: 21, Last Available: "2009-02"
 3756	quantum love song of icy revenge	0		Effect: "Quantum of Moxie", Effect Duration: 39, Last Available: "2009-02"
 3757	dry dry love song of sugary cuteness	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 38, Last Available: "2009-02"
 3758	non-oxidized moist twirling love song of disturbing obsession	0		Effect: "Notably Lovely", Effect Duration: 39, Last Available: "2009-02"
@@ -3726,14 +3726,14 @@
 3762	mirror chaotic vampire pearl necklace	0		Spell Critical Percent: +10, Single Equip
 3763	mediocre slug of vodka	3	decent	
 3764	hand-crafted jittery slug of rum	4	EPIC	
-3765	weak tolerable blinking slug of shochu	2	good	
-3766	artisanal wobbly jittery screwdiver	3	EPIC	
+3765	tolerable weak blinking slug of shochu	2	good	
+3766	artisanal jittery wobbly screwdiver	3	EPIC	
 3767	drinkable dew yoana lei	3	good	
-3768	special distilled acceptable lychee chuhai	5	good	Effect: "In Tuna", Effect Duration: 45
+3768	distilled special acceptable lychee chuhai	5	good	Effect: "In Tuna", Effect Duration: 45
 3769	triple-distilled perfectly mixed squat salacious screwdiver	10	EPIC	
 3770	special drinkable dew yoana salacious lei	4	good	Effect: "Coming Up Roses", Effect Duration: 20
 3771	watered-down mediocre salacious lychee chuhai	2	decent	
-3772	practically non-alcoholic artisanal blinking Alewife&trade; Ale	1	EPIC	
+3772	artisanal practically non-alcoholic blinking Alewife&trade; Ale	1	EPIC	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3753,8 +3753,8 @@
 3789	jittery twitching trigger finger	0		Class: "Pastamancer"
 3799	jittery Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	steel-toed Herculean Mer-kin roundshield of the ox	0		Muscle: +20, Experience (Muscle): +1, Damage Reduction: 23
 3804	tumbling steel-toed Mer-kin breastplate of the brute	0		Muscle Percent: +30, Damage Reduction: 9
 3805	upside-down Mer-kin sneakmask of chilblains of the businessman	0		Cold Damage: +25, Meat Drop: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3780,12 +3780,12 @@
 3826	bouncing Grandma's Chartreuse Yarn	0		
 3827	bouncing plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	rotten massive wobbly tempura radish	10	crappy	
+3829	massive rotten wobbly tempura radish	10	crappy	
 3830	smartaleck's water-polo cap	0		Moxie Percent: +30, Familiar Effect: "1xVolley, 1xBarrr"
 3831	practically non-alcoholic drinkable ghostly Typical Tavern swill	1	good	
 3832	drinkable tropical swill	3	good	
-3833	triple-distilled acceptable fancy squat fruity girl swill	8	good	Effect: "Like a Fish to Walter", Effect Duration: 45
-3834	tolerable upside-down teal blended swill	4	good	
+3833	fancy acceptable triple-distilled squat fruity girl swill	8	good	Effect: "Like a Fish to Walter", Effect Duration: 45
+3834	tolerable teal upside-down blended swill	4	good	
 3835	costume wardrobe	0		Softcore Only
 3836	nippy Jim Carey's brawny Elvish sunglasses of the overflowing toilet	0		Muscle Percent: +20, Monster Level: +25, Cold Damage: +10, Stench Spell Damage: +50, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	horrifying anniversary safety glass vest	0		Spooky Damage: +25
@@ -3826,7 +3826,7 @@
 3872	green pocket theremin of the cheetah	0		Initiative: +60
 3873	upside-down dog trainer's ruddy rave whistle	0		Maximum HP Percent: +40, Experience (familiar): +1
 3874	hellseal hide	0		
-3875	green jittery bouncing shredded hellseal hide	0		
+3875	jittery bouncing green shredded hellseal hide	0		
 3876	hellseal brain	0		
 3877	burst hellseal brain	0		
 3878	hellseal sinew	0		
@@ -3836,7 +3836,7 @@
 3882	encoded cult documents	0		
 3883	tumbling cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
-3885	boiled ionized shaking mirror vial of slime	0		Effect: "damage.enh", Effect Duration: 65
+3885	boiled ionized mirror shaking vial of slime	0		Effect: "damage.enh", Effect Duration: 65
 3886	unsweetened vial of slime	0		Effect: "Fireproof Lips", Effect Duration: 48
 3887	energized vial of slime	0		Effect: "Sourpuss", Effect Duration: 43
 3888	alkaline skewed vial of slime	0		Effect: "Squirming Like a Toad", Effect Duration: 21
@@ -3905,7 +3905,7 @@
 3953	mink	0		
 3954	purple teddy butler	0		
 3955	maroon martini	0		
-3956	maroon spinning crazy bastard sword	0		
+3956	spinning maroon crazy bastard sword	0		
 3957	ghostly tin of caviar	0		
 3958	blurry huge bejeweled cufflinks of the glutton	0		Food Drop: +100, Single Equip
 3959	Oprah's garish pinky ring	0		Maximum MP Percent: +50
@@ -3914,13 +3914,13 @@
 3962	tumbling blue designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	bouncing cell phone	0		Familiar Weight: +10
-3965	dry dry twirling narrow cube of billiard chalk	0		Effect: "Permafrosty", Effect Duration: 65
+3965	dry dry narrow twirling cube of billiard chalk	0		Effect: "Permafrosty", Effect Duration: 65
 3966	lime green avaricious extremely unsafe hot-ass club of temperance	0		Weapon Damage Percent: +100, Sleaze Resistance: +5, Meat Drop: +30, Class: "Seal Clubber"
 3967	perfumed smooth frigid-ass club of the brute	0		Moxie: +15, Muscle Percent: +30, Stench Resistance: +5, Class: "Seal Clubber"
 3968	huge fuchsia perfumed sizzling vibrating creepy-ass club	0		Maximum MP Percent: +10, Hot Damage: +10, Stench Resistance: +5, Class: "Seal Clubber"
 3969	cold-filtered blue sizzling seal fat	0		Effect: "Cool Spirit", Effect Duration: 58
 3970	olive chaotic energetic Abyssal ember	0		Maximum MP Percent: +20, Spell Critical Percent: +10, Class: "Seal Clubber"
-3971	pickled tarnished wobbly pulsating frost-rimed seal hide	0		Effect: "Peppermint Bite", Effect Duration: 47
+3971	pickled tarnished pulsating wobbly frost-rimed seal hide	0		Effect: "Peppermint Bite", Effect Duration: 47
 3972	MacGyver's seal spine of the brazier	0		Maximum MP: +100, Hot Spell Damage: +25, Class: "Seal Clubber"
 3973	frozen tumbling seal lube	0		Effect: "Memento Moir&eacute;", Effect Duration: 37
 3974	mannequin leg of the bloodbag of the sweet-tooth	0		Maximum HP: +100, Candy Drop: +100, Class: "Seal Clubber"
@@ -3950,7 +3950,7 @@
 3998	metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	dehydrated wobbly blinking agua de vida	1	decent	Last Available: "2009-06"
+4001	dehydrated blinking wobbly agua de vida	1	decent	Last Available: "2009-06"
 4002	upside-down lightning-fast tortoboggan shield of the brute	0		Muscle Percent: +30, Initiative: +40, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	quilted soup-chucks	0		Damage Absorption: +40
@@ -3960,7 +3960,7 @@
 4008	memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
-4011	green spinning memory of a CA base pair	0		Last Available: "2009-06"
+4011	spinning green memory of a CA base pair	0		Last Available: "2009-06"
 4012	memory of a CG base pair	0		Last Available: "2009-06"
 4013	memory of a CT base pair	0		Last Available: "2009-06"
 4014	red memory of an AG base pair	0		Last Available: "2009-06"
@@ -3988,17 +3988,17 @@
 4036	caustic slime nodule	0		
 4037	miniature toothsome twirling slimy sweetbreads	2	awesome	
 4038	acceptable green slimy fermented bile bladder	3	good	
-4039	distilled blurry squat slimy alveolus	1		Effect: "Pie in the Sky", Effect Duration: 20
+4039	distilled squat blurry slimy alveolus	1		Effect: "Pie in the Sky", Effect Duration: 20
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	coward's dance instructor's pig-iron helm	0		Experience Percent (Moxie): +10, Monster Level: -20, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	up-at-dawn Sinatra's pig-iron shinguards	0		Experience (Moxie): +5, Adventures: +5, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	coward's dance instructor's pig-iron helm	0		Experience Percent (Moxie): +10, Monster Level: -20, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	up-at-dawn Sinatra's pig-iron shinguards	0		Experience (Moxie): +5, Adventures: +5, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	shaking electrified pig-iron bracers of Gandalf	0		Spell Critical Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2009-06"
 4044	upside-down wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	veiny wumpus-hair whip	0		Maximum HP: +10, Last Available: "2009-06"
-4048	mansplainer's Fonzie's wumpus-hair wig of terror	0		Experience (Moxie): +1, Monster Level: +15, Spooky Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	stanky Herculean boxer's wumpus-hair loincloth	0		Muscle Percent: +10, Experience (Muscle): +1, Stench Spell Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	mansplainer's Fonzie's wumpus-hair wig of terror	0		Experience (Moxie): +1, Monster Level: +15, Spooky Spell Damage: +10, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	stanky Herculean boxer's wumpus-hair loincloth	0		Muscle Percent: +10, Experience (Muscle): +1, Stench Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	therapeutic wizardly wumpus-hair sweater	0		Mysticality: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06"
 4051	ghostly scorching ring of teleportation	0		Hot Damage: +25, Single Equip
 4052	glass of baboon milk	1	awesome	Last Available: "2009-06"
@@ -4018,8 +4018,8 @@
 4066	purple Ruby Rod	0		Last Available: "2009-06"
 4067	spinning essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
-4069	wobbly purple essence of	0		Last Available: "2009-06"
-4070	bouncing pulsating essence of stench	0		Last Available: "2009-06"
+4069	purple wobbly essence of	0		Last Available: "2009-06"
+4070	pulsating bouncing essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	tumbling essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	blue wool Rosewater's grisly shield	0		Mysticality Percent: +30, Cold Resistance: +1, Slime Hates It: +1, Damage Reduction: 13
 4081	huge healthy corroded breeches of terror	0		Maximum HP Percent: +20, Spooky Spell Damage: +10, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	pulsating frightening smartaleck's pernicious cudgel	0		Moxie Percent: +30, Spooky Damage: +5, Slime Hates It: +1
-4083	special tasty cupcake-in-a-cup	3	awesome	Effect: "Morninja", Effect Duration: 5, Last Available: "2009-06"
+4083	tasty special cupcake-in-a-cup	3	awesome	Effect: "Morninja", Effect Duration: 5, Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	spoiled green protein paste	4	crappy	Last Available: "2009-06"
 4086	weightlifter's cyber-mattock of chilblains	0		Muscle: +15, Cold Damage: +25, Last Available: "2009-06"
@@ -4080,11 +4080,11 @@
 4128	pulsating chilly quilted hardened slime pants of the boozehound	0		Damage Absorption: +40, Cold Damage: +5, Booze Drop: +100, Familiar Effect: "atk, 1xPotato"
 4129	ghostly frightening wholesome brainy hardened slime belt	0		Mysticality: +5, Maximum HP Percent: +10, Spooky Damage: +5, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
-4131	distilled squat wobbly spinning boot plant	1	EPIC	Effect: "Sticky Hands", Effect Duration: 40, Last Available: "2009-06"
+4131	distilled wobbly spinning squat boot plant	1	EPIC	Effect: "Sticky Hands", Effect Duration: 40, Last Available: "2009-06"
 4132	drinkable fancy sham champagne	3	good	Effect: "Stench Jellied", Effect Duration: 10, Last Available: "2009-06"
 4133	colloidal deionized lime green tempura air	0		Effect: "Memories of Puppy Love", Effect Duration: 38
 4134	magnetized enhanced pressurized potion of pneumaticity	0		Effect: "Experimental Effect G-9", Effect Duration: 55
-4135	ghostly tumbling moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
+4135	tumbling ghostly moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	tumbling Tesla Bag o' Tricks of the scaredy-cat of the glutton of the early riser	0		Monster Level: -15, Food Drop: +100, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
@@ -4111,7 +4111,7 @@
 4159	squat rock lobster	0		Last Available: "2009-09"
 4160	smooth pebblebr&auml;u	3	awesome	Last Available: "2009-09"
 4161	bland rocky road ice cream	3	decent	Last Available: "2009-09"
-4162	huge jittery extra-strength rubber bands	0		Familiar Weight: +5
+4162	jittery huge extra-strength rubber bands	0		Familiar Weight: +5
 4163	nitrogenated deionized narrow children of the candy corn	0		Effect: "Riboflavin'", Effect Duration: 14
 4164	dry ionized Good 'n' Slimy	0		Effect: "Bread-Lined", Effect Duration: 37
 4165	twirling slick Staff of the Soupbone of the brute of courage	0		Moxie: +10, Muscle Percent: +30, Spooky Resistance: +3
@@ -4126,12 +4126,12 @@
 4174	green sage rock necklace	0		Mysticality Percent: +10, Single Equip
 4175	upside-down spaghetti cult robe	0		
 4176	sugar sheet	0		Last Available: "2009-09"
-4177	squat lime green squat Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
+4177	squat squat lime green Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	sugar shotgun	0		Item Drop: +5, Last Available: "2009-09"
 4179	huge tumbling auspicious sugar shillelagh	0		Item Drop: +10, Last Available: "2009-09"
 4180	sugar shank of the detective	0		Item Drop: +20, Last Available: "2009-09"
-4181	upside-down double-paned toasty groovy sugar chapeau	0		Moxie Percent: +10, Hot Damage: +5, Cold Resistance: +5, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	medical-grade sugar shorts	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	upside-down double-paned toasty groovy sugar chapeau	0		Moxie Percent: +10, Hot Damage: +5, Cold Resistance: +5, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	medical-grade sugar shorts	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	narrow slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4178,7 +4178,7 @@
 4226	blue padded Star of Bravery	0		Damage Absorption: +20, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	narrow perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	tumbling bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4196,25 +4196,25 @@
 4244	bouncing beefcake's leather-bound tome	0		Muscle: +25
 4245	cyan bookmark	0		
 4246	extremely unsafe ivory cue ball	0		Weapon Damage Percent: +100
-4247	artisanal spirit-forward decanter of fine Scotch	5	EPIC	
+4247	spirit-forward artisanal decanter of fine Scotch	5	EPIC	
 4248	modified expensive cigar	1		Effect: "On the Shoulders of Giants", Effect Duration: 35
 4249	tophat	0		Familiar Weight: +5
 4250	shaking fisherman's sack	0		
 4251	olive fish-oil smoke bomb	0		
-4252	ionized jittery spinning bouncing vial of squid ink	0		Effect: "stats.enq", Effect Duration: 40
+4252	ionized jittery bouncing spinning vial of squid ink	0		Effect: "stats.enq", Effect Duration: 40
 4253	warmed vacuum-sealed potion of speed	0		Effect: "Perception", Effect Duration: 34
 4254	bark	0		Last Available: "2009-10"
 4255	blurry Wolfman Nardz	0		Last Available: "2009-10"
-4256	quadruple-altered modified skewed blinking sap	0		Effect: "Eagle Eyes", Effect Duration: 44, Last Available: "2009-10"
+4256	quadruple-altered modified blinking skewed sap	0		Effect: "Eagle Eyes", Effect Duration: 44, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	decent green chocolate-covered scarab beetle	3	good	Last Available: "2009-10"
-4259	practically non-alcoholic mediocre twirling jittery mulled cider	1	decent	Last Available: "2009-10"
-4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4259	mediocre practically non-alcoholic jittery twirling mulled cider	1	decent	Last Available: "2009-10"
+4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	spinning executive bark boxers	0		Meat Drop: +40, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	hardened bark beret	0		Damage Reduction: 3, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	spinning executive bark boxers	0		Meat Drop: +40, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	hardened bark beret	0		Damage Reduction: 3, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	family-friendly bark bracelet	0		Sleaze Resistance: +1, Single Equip
 4267	fuchsia horrifying Krakrox's Loincloth of the cougar	0		Moxie: +20, Spooky Damage: +25, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	narrow foul-smelling resourceful Galapagosian Cuisses	0		Maximum MP: +50, Stench Damage: +10, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	blue family-friendly toasty Ass-Stompers of Violence of the sweet-tooth	0		Hot Damage: +5, Sleaze Resistance: +1, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	twirling green executive auspicious studded Brand of Violence	0		Damage Absorption: +80, Item Drop: +10, Meat Drop: +40, Conditional Skill (Equipped): "Brand"
 4299	Tesla crafty brainy Novelty Belt Buckle of Violence	0		Mysticality: +5, Maximum MP: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-4300	mansplainer's sharpshooter's beefy Lens of Violence	0		Muscle: +10, Critical Hit Percent: +10, Monster Level: +15, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	mansplainer's sharpshooter's beefy Lens of Violence	0		Muscle: +10, Critical Hit Percent: +10, Monster Level: +15, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	Da Vinci's Socratic Pigsticker of Violence of the scaredy-cat	0		Experience (Mysticality): 6, Monster Level: -15
-4302	prompt ruddy Herculean Jodhpurs of Violence	0		Experience (Muscle): +1, Maximum HP Percent: +40, Adventures: +3, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	prompt ruddy Herculean Jodhpurs of Violence	0		Experience (Muscle): +1, Maximum HP Percent: +40, Adventures: +3, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	maroon resourceful extremely unsafe Sinatra's Cold Stone of Hatred	0		Experience (Moxie): +5, Weapon Damage Percent: +100, Maximum MP: +50, Conditional Skill (Equipped): "Chilling Grip"
 4304	Van der Graaf electrified forbidden Girdle of Hatred	0		Spell Damage Percent: +50, MP Regen Min: 8, MP Regen Max: 12, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	blinking smelly hale Staff of Simmering Hatred of the overflowing toilet	0		Maximum HP: +20, Stench Spell Damage: 60
-4306	scorching sizzling personal trainer's Pantaloons of Hatred	0		Experience Percent (Muscle): +10, Hot Damage: 35, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	scorching sizzling personal trainer's Pantaloons of Hatred	0		Experience Percent (Muscle): +10, Hot Damage: 35, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	upside-down scandalous frosty Fuzzy Slippers of Hatred of the pedagogue	0		Experience: +3, Cold Spell Damage: +10, Sleaze Damage: +5, Single Equip
-4308	mirror steel-toed sinister Lens of Hatred of courage	0		Spell Damage: +10, Damage Reduction: 9, Spooky Resistance: +3, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	mirror steel-toed sinister Lens of Hatred of courage	0		Spell Damage: +10, Damage Reduction: 9, Spooky Resistance: +3, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	Herculean savvy brawny Treads of Loathing	0		Muscle Percent: +20, Mysticality Percent: +20, Experience (Muscle): +1, Single Equip
 4310	twirling aromatic experienced Scepter of Loathing of Leguizamo	0		Experience: +2, Monster Level: +20, Stench Resistance: +1
 4311	dog trainer's baleful Belt of Loathing of Calamity Jane	0		Spell Damage: +25, Critical Hit Percent: +15, Experience (familiar): +1, Single Equip
@@ -4279,7 +4279,7 @@
 4327	medical-grade hardy La Hebilla del Cintur&oacute;n de Lopez of courage	0		Maximum HP: +50, Spooky Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Class: "Accordion Thief", Single Equip
 4328	pulsating suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	squat bag of many confections	0		Last Available: "2009-12"
-4330	stale half-sized purple candy kneecapping stick	2	decent	Last Available: "2009-12"
+4330	half-sized stale purple candy kneecapping stick	2	decent	Last Available: "2009-12"
 4331	delicious licorice garrote	3	awesome	Last Available: "2009-12"
 4332	bouncing extremely unsafe candy knuckles	0		Weapon Damage Percent: +100, Last Available: "2009-12"
 4333	massive spoiled jawbruiser	7	crappy	Last Available: "2010-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	pulsating gingerbread house	0		Last Available: "2009-12"
 4348	pulsating leftover Crimbo rations	0		Last Available: "2009-12"
-4349	wicked snow hat	0		Spell Damage: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	ghostly sizzling snow pants	0		Hot Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	wicked snow hat	0		Spell Damage: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	ghostly sizzling snow pants	0		Hot Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	blinking pulsating beefy snow belly	0		Muscle: +10, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	narrow blurry Crimbough	0		Last Available: "2009-12"
@@ -4310,7 +4310,7 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	upside-down A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	jumbo bland expired can of franks 'n' beans	5	decent	Last Available: "2009-12"
-4361	watered-down drinkable expired bottle of peppermint schnapps	2	good	Last Available: "2009-12"
+4361	drinkable watered-down expired bottle of peppermint schnapps	2	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	cold-filtered warmed alkaline elven suicide capsule	0		Effect: "Hare-o-dynamic", Effect Duration: 65, Last Available: "2009-12"
@@ -4321,7 +4321,7 @@
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
-4372	blinking bouncing chunk of cement	0		Last Available: "2009-12"
+4372	bouncing blinking chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	huge spiraling shape	0		Last Available: "2009-12"
@@ -4337,19 +4337,19 @@
 4385	cyan avaricious Tesla pocketwatch on a chain	0		Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-12"
 4386	tumbling skewed beefcake's cement sandals of incineration	0		Muscle: +25, Hot Spell Damage: +50, Single Equip, Last Available: "2009-12"
 4387	knitted horrifying night-vision goggles	0		Spooky Damage: +25, Cold Resistance: +3, Single Equip, Last Available: "2009-12"
-4388	pulsating passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	pulsating passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	mirror peanut brittle shield of temperance	0		Sleaze Resistance: +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	gray auspicious Jeselnik's Red Rover BB gun	0		Sleaze Damage: +25, Item Drop: +10, Last Available: "2009-12"
 4391	red-and-green sweater of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
-4393	enhanced double-enhanced green upside-down Crimbo peppermint bark	0		Effect: "Cold Hands", Effect Duration: 14, Last Available: "2009-12"
+4393	enhanced double-enhanced upside-down green Crimbo peppermint bark	0		Effect: "Cold Hands", Effect Duration: 14, Last Available: "2009-12"
 4394	quantum Crimbo fudge	0		Effect: "Rotten Memories", Effect Duration: 63, Last Available: "2009-12"
 4395	wet Crimbo pecan	0		Effect: "Saucefingers", Effect Duration: 22, Last Available: "2009-12"
 4396	blue Jack-in-the-box	0		Last Available: "2009-12"
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	blue cheese ball	0		Last Available: "2010-01"
 4399	zippy cheese sword	0		Initiative: +20, Softcore Only, Last Available: "2010-01"
-4400	twirling extremely unsafe cheese diaper	0		Weapon Damage Percent: +100, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	twirling extremely unsafe cheese diaper	0		Weapon Damage Percent: +100, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	sage cheese wheel	0		Mysticality Percent: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	cheese eye of the pedagogue	0		Experience: +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	shaking friendly Da Vinci's Staff of Queso Escusado of the businessman	0		Experience (Mysticality): +5, Familiar Weight: +3, Meat Drop: +50, Softcore Only, Last Available: "2010-01"
@@ -4396,7 +4396,7 @@
 4448	diluted bouncing Instant Karma	1	awesome	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	clever pointy hat	0		Maximum MP: +20, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	clever pointy hat	0		Maximum MP: +20, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	machetito of bravery	0		Spooky Resistance: +5, Last Available: "2010-04"
 4453	smartaleck's lawnmower blade	0		Moxie Percent: +30, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4412,12 +4412,12 @@
 4464	non-Vulcanized alkaline quantum chocolate pasta spoon	0		Effect: "Heart of Green", Effect Duration: 28
 4465	super-improved tarnished chocolate saucepan	0		Effect: "Toothy Grin", Effect Duration: 19
 4466	extra-nitrogenated dry spinning jittery chocolate disco ball	0		Effect: "Slimy Flavor", Effect Duration: 50
-4467	dry oxidized skewed narrow chocolate stolen accordion	0		Effect: "Can Has Cyborger", Effect Duration: 18
+4467	dry oxidized narrow skewed chocolate stolen accordion	0		Effect: "Can Has Cyborger", Effect Duration: 18
 4468	narrow Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	deadly BRICKO hat	0		Weapon Damage: +5, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	educational BRICKO pants	0		Experience: +1, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	deadly BRICKO hat	0		Weapon Damage: +5, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	educational BRICKO pants	0		Experience: +1, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	therapeutic BRICKO sword	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4459,40 +4459,40 @@
 4511	stale beautiful soup	4	decent	Last Available: "2010-03"
 4512	narrow eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	rotten big Humpty Dumplings	5	crappy	Last Available: "2010-03"
+4514	big rotten Humpty Dumplings	5	crappy	Last Available: "2010-03"
 4515	decent shaking Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
 4516	perfectly mixed missing wine	4	EPIC	Last Available: "2010-03"
-4517	half-sized spoiled blurry matter custard	2	crappy	Last Available: "2010-03"
+4517	spoiled half-sized blurry matter custard	2	crappy	Last Available: "2010-03"
 4518	triple-galvanized dry flattened comfit?	0		Effect: "Feroci Tea", Effect Duration: 24, Last Available: "2010-03"
 4519	ghostly huge ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	beefcake's flamingo mallet of the glutton	0		Muscle: +25, Food Drop: +100, Last Available: "2010-03"
 4521	narrow croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	tumbling greedy ribald eye of the Tiger-lily	0		Sleaze Damage: +10, Meat Drop: +20, Last Available: "2010-03"
-4524	Jim Carey's strapping wig	0		Muscle: +5, Monster Level: +25, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	Jim Carey's strapping wig	0		Muscle: +5, Monster Level: +25, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	rotten donut	3	crappy	Last Available: "2010-03"
-4526	normal fancy immense bucket of honey	6	good	Effect: "Hangdog", Effect Duration: 40, Last Available: "2010-03"
+4526	fancy normal immense bucket of honey	6	good	Effect: "Hangdog", Effect Duration: 40, Last Available: "2010-03"
 4527	upside-down horrifying Lo Pan's elephant stinger	0		Spell Critical Percent: +30, Spooky Damage: +25, Last Available: "2010-03"
 4528	bland dragon snaps	3	decent	Last Available: "2010-03"
 4529	lightning-fast veiny snapdragon pistil	0		Maximum HP: +10, Initiative: +40, Last Available: "2010-03"
 4530	huge puff of smoke	0		Last Available: "2010-03"
-4531	immense normal rook cookie	8	good	Last Available: "2010-03"
-4532	diet delicious wobbly bishop cookie	1	awesome	Last Available: "2010-03"
+4531	normal immense rook cookie	8	good	Last Available: "2010-03"
+4532	delicious diet wobbly bishop cookie	1	awesome	Last Available: "2010-03"
 4533	normal bouncing knight cookie	3	good	Last Available: "2010-03"
-4534	decent half-sized blurry blinking king cookie	2	good	Last Available: "2010-03"
+4534	half-sized decent blurry blinking king cookie	2	good	Last Available: "2010-03"
 4535	jumbo rotten queen cookie	5	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	huge supercharged insane tophat	0		Maximum MP Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	fuchsia greedy helm of the knight of the scaredy-cat	0		Monster Level: -15, Meat Drop: +20, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	huge supercharged insane tophat	0		Maximum MP Percent: +30, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	fuchsia greedy helm of the knight of the scaredy-cat	0		Monster Level: -15, Meat Drop: +20, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	toasty wristwatch of the knight of incineration	0		Hot Damage: +5, Hot Spell Damage: +50, Single Equip, Last Available: "2010-03"
-4540	blurry twirling sinister trousers of the knight of the ox	0		Muscle: +20, Spell Damage: +10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	blurry twirling sinister trousers of the knight of the ox	0		Muscle: +20, Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	tophat of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xBarrr, cap 25"
 4542	wicked tie	0		Spell Damage: +5, Single Equip
 4543	veiny tuxedo pants	0		Maximum HP: +10, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 4544	porpoise	0		Last Available: "2010-03"
 4545	pocketwatch	0		Last Available: "2010-03"
 4546	bandersnatch	0		Last Available: "2010-03"
-4547	huge shaking caterpillar	0		Last Available: "2010-03"
+4547	shaking huge caterpillar	0		Last Available: "2010-03"
 4548	bouncing walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
 4550	tumbling dodo	0		Last Available: "2010-03"
@@ -4508,7 +4508,7 @@
 4560	gray map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	squat can of depilatory cream	0		Last Available: "2010-04"
 4562	ghostly hair of the calf	0		Last Available: "2010-04"
-4563	aged practically non-alcoholic world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
+4563	practically non-alcoholic aged world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
 4564	wobbly friendly slippery when wet shield	0		Familiar Weight: +3, Damage Reduction: 6, Last Available: "2010-04"
 4565	big tasty maroon raisin	5	awesome	Last Available: "2010-04"
 4566	blurry fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4529,7 +4529,7 @@
 4581	crafty educational T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience: +1, Maximum MP: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	lime green fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	adequate cyan huge six wedges of goat cheese	3	good	
+4584	adequate huge cyan six wedges of goat cheese	3	good	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	blue goth	0		
@@ -4552,7 +4552,7 @@
 4604	jittery keg	0		Last Available: "2010-06"
 4605	avaricious bottle of Goldschn&ouml;ckered of courage	0		Spooky Resistance: +3, Meat Drop: +30, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	flavorless tumbling sun-dried tofu	4	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	tolerable special soyburger juice	4	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	special tolerable soyburger juice	4	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	wobbly essential tofu	0		Last Available: "2010-08"
 4610	ionized extra-dry essential soy	0		Effect: "Bilious Brains", Effect Duration: 36, Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	shaking map to the Magic Commune	0		Last Available: "2010-08"
 4614	arcane researcher's Crown of Thrones	0		Experience Percent (Mysticality): +10, Softcore Only, Last Available: "2010-05"
-4615	distilled aged Cinco Mayo Lager	5	awesome	Last Available: "2010-05"
+4615	aged distilled Cinco Mayo Lager	5	awesome	Last Available: "2010-05"
 4616	blinking spinning Underworld sapling	0		Last Available: "2009-10"
 4617	bouncing pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4568,7 +4568,7 @@
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
-4623	super-corrupted purple huge spinning chocolate-covered caviar	0		Effect: "Ocelot Eyes", Effect Duration: 57, Last Available: "2020-09"
+4623	super-corrupted huge purple spinning chocolate-covered caviar	0		Effect: "Ocelot Eyes", Effect Duration: 57, Last Available: "2020-09"
 4624	rotten narrow pawn cookie	3	crappy	Last Available: "2010-06"
 4625	mixed jittery red coffee pixie stick	1	good	Last Available: "2010-06"
 4626	red superduperball	0		Last Available: "2010-06"
@@ -4577,12 +4577,12 @@
 4629	gravedigger's plastic spider ring	0		Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	red weightlifter's plastic kazoo	0		Muscle: +15, Last Available: "2010-06"
 4631	inflatable baseball bat of the storm	0		Maximum MP Percent: +40, Last Available: "2010-06"
-4632	googly-star hat of wisdom of the sweet-tooth	0		Mysticality: +15, Candy Drop: +100, Familiar Effect: "atk", Last Available: "2010-06"
+4632	googly-star hat of wisdom of the sweet-tooth	0		Mysticality: +15, Candy Drop: +100, Last Available: "2010-06", Familiar Effect: "atk"
 4633	curative googly-ball hat of the ox	0		Muscle: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-06"
 4634	googly-heart hat of wisdom of mayonnaise	0		Mysticality: +15, Sleaze Spell Damage: +50, Last Available: "2010-06"
 4635	skewed aromatic super-sweet boom box of James Dean	0		Experience (Moxie): +3, Stench Resistance: +1, Four Songs, Last Available: "2010-06"
 4636	spinning Game Grid valued membership card	0		Last Available: "2010-06"
-4637	lion tamer's Annie Oakley's sinister demon mask of terror	0		Critical Hit Percent: +20, Experience (familiar): +2, Spooky Spell Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	lion tamer's Annie Oakley's sinister demon mask of terror	0		Critical Hit Percent: +20, Experience (familiar): +2, Spooky Spell Damage: +10, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	spinning jittery censurious friendly streetfighting champion's belt of the businessman	0		Familiar Weight: +3, Sleaze Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2010-06"
 4639	family-friendly Space Trip safety headphones of Tarzan of Calamity Jane	0		Experience (Muscle): +3, Critical Hit Percent: +15, Sleaze Resistance: +1, Single Equip, Last Available: "2010-06"
 4640	foul-smelling LARP carp	0		Stench Damage: +10
@@ -4594,8 +4594,8 @@
 4646	wobbly wool dog trainer's wicked Meteoid ice beam	0		Spell Damage: +5, Experience (familiar): +1, Cold Resistance: +1, Last Available: "2011-12"
 4647	skewed lightning-fast stiffened slick Dungeon Fist gauntlet	0		Moxie: +10, Damage Reduction: 1, Initiative: +40, Last Available: "2011-06"
 4648	gray Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	mirror ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	wobbly Tesla ironic knit cap of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4607,7 +4607,7 @@
 4659	bouncing Annie Oakley's blackberry galoshes	0		Critical Hit Percent: +20, Single Equip
 4660	tumbling purple groovy trout fang of courage	0		Moxie Percent: +10, Spooky Resistance: +3, Last Available: "2010-09"
 4661	bland fancy poisonous caviar	3	decent	Effect: "Mercenary", Effect Duration: 5, Last Available: "2010-09"
-4662	improved nitrogenated olive jittery wet venom duct	0		Effect: "Ooh, Salty!", Effect Duration: 66, Last Available: "2010-09"
+4662	improved nitrogenated jittery olive wet venom duct	0		Effect: "Ooh, Salty!", Effect Duration: 66, Last Available: "2010-09"
 4663	bouncing Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	blinking blurry stiffened beefcake's Ellsbury's skull	0		Muscle: +25, Damage Reduction: 1, Last Available: "2010-09"
 4665	rock-hard hot plate	0		Damage Reduction: 8
@@ -4624,11 +4624,11 @@
 4676	teal tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
-4679	narrow gray volcanic ash	0		
+4679	gray narrow volcanic ash	0		
 4680	smoked potsherd	0		
 4681	chaotic pottery shield	0		Spell Critical Percent: +10, Damage Reduction: 3, Last Available: "2010-09"
-4682	auspicious knitted pottery hat	0		Cold Resistance: +3, Item Drop: +10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	pulsating reassuring pottery training pants of the glutton	0		Spooky Resistance: +1, Food Drop: +100, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	auspicious knitted pottery hat	0		Cold Resistance: +3, Item Drop: +10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	pulsating reassuring pottery training pants of the glutton	0		Spooky Resistance: +1, Food Drop: +100, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	brawny pottery club	0		Muscle Percent: +20, Last Available: "2010-09"
 4685	huge studded pottery yo-yo	0		Damage Absorption: +80, Last Available: "2010-09"
 4686	blurry pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	mirror affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	blue Annie Oakley's smooth cool Greatest American Pants	0		Moxie: 20, Critical Hit Percent: +20, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	blue Annie Oakley's smooth cool Greatest American Pants	0		Moxie: 20, Critical Hit Percent: +20, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	supercharged fossilized necklace	0		Maximum MP Percent: +30, Last Available: "2010-09"
 4698	blinking imp air	0		
 4699	bus pass	0		
@@ -4650,7 +4650,7 @@
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	red-hot medallion of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2010-09"
 4704	fossilized demon skull	0		Last Available: "2010-09"
-4705	spinning huge fossilized spider skull	0		Last Available: "2010-09"
+4705	huge spinning fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
 4708	My First Shaker&trade;	0		
@@ -4667,13 +4667,13 @@
 4719	tumbling maroon Hollandaise helmet of doom	0		Spooky Spell Damage: +50, Familiar Effect: "atk, cap 2"
 4720	spinning organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	tiny decent liver and let pie	1	good	Last Available: "2010-10"
+4722	decent tiny liver and let pie	1	good	Last Available: "2010-10"
 4723	decent lime green badass pie	3	good	Last Available: "2010-10"
-4724	rotten immense enchanted shoo-fish pie	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5, Last Available: "2010-10"
+4724	enchanted rotten immense shoo-fish pie	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5, Last Available: "2010-10"
 4725	bland piping organ pie	3	decent	Last Available: "2010-10"
 4726	fancy adequate igloo pie	3	good	Effect: "White-boy Angst", Effect Duration: 15, Last Available: "2010-10"
 4727	bite-sized normal stomach turnover	1	good	Last Available: "2010-10"
-4728	spoiled snack-sized dead lights pie	2	crappy	Last Available: "2010-10"
+4728	snack-sized spoiled dead lights pie	2	crappy	Last Available: "2010-10"
 4729	gigantic spoiled throbbing organ pie	6	crappy	Last Available: "2010-10"
 4730	beefy stop shield	0		Muscle: +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4693,14 +4693,14 @@
 4745	quantum altered Wax Flask	0		Effect: "Sticky Fingers", Effect Duration: 64
 4746	energized frozen twirling Pain Dip	0		Effect: "Tiki Temerity", Effect Duration: 61
 4747	half-sized rotten bone meal	2	crappy	Last Available: "2010-10"
-4748	weak artisanal bone aperitif	2	EPIC	Last Available: "2010-10"
+4748	artisanal weak bone aperitif	2	EPIC	Last Available: "2010-10"
 4749	quilted bonerang	0		Damage Absorption: +40, Last Available: "2010-10"
 4750	Newton's bone and arrows	0		Experience (Mysticality): +3, Last Available: "2010-10"
 4751	beefy boning knife	0		Muscle: +10, Last Available: "2010-10"
 4752	bone crusher of extreme caution	0		Monster Level: -25, Last Available: "2010-10"
 4753	educational bone spurs	0		Experience: +1, Single Equip, Last Available: "2010-10"
-4754	flame-retardant bonedanna of mayonnaise	0		Sleaze Spell Damage: +50, Hot Resistance: +1, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	boneana hammock of the wise owl of the detective	0		Mysticality: +20, Item Drop: +20, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	flame-retardant bonedanna of mayonnaise	0		Sleaze Spell Damage: +50, Hot Resistance: +1, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	boneana hammock of the wise owl of the detective	0		Mysticality: +20, Item Drop: +20, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	unsweetened candy skeleton	0		Effect: "Impregnably Delicious", Effect Duration: 39, Last Available: "2020-09"
@@ -4751,9 +4751,9 @@
 4842	shaking sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	pulsating The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	jittery rosy-cheeked padded Uncle Hobo's stocking cap	0		Damage Absorption: +20, Maximum HP Percent: +30, Familiar Effect: "atk", Last Available: "2010-12"
+4845	jittery rosy-cheeked padded Uncle Hobo's stocking cap	0		Damage Absorption: +20, Maximum HP Percent: +30, Last Available: "2010-12", Familiar Effect: "atk"
 4846	spinning aromatic chaotic Uncle Hobo's epic beard	0		Spell Critical Percent: +10, Stench Resistance: +1, Single Equip, Last Available: "2010-12"
-4847	smelly friendly Uncle Hobo's gift baggy pants	0		Familiar Weight: +3, Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	smelly friendly Uncle Hobo's gift baggy pants	0		Familiar Weight: +3, Stench Spell Damage: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	arcane researcher's wizardly Uncle Hobo's fingerless tinsel gloves	0		Mysticality: +25, Experience Percent (Mysticality): +10, Single Equip, Last Available: "2010-12"
 4849	olive mansplainer's Oprah's Uncle Hobo's highest bough	0		Maximum MP Percent: +50, Monster Level: +15, Last Available: "2010-12"
 4850	crafty baleful Uncle Hobo's belt	0		Spell Damage: +25, Maximum MP: +10, Single Equip, Last Available: "2010-12"
@@ -4761,7 +4761,7 @@
 4852	gift-a-pult of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2010-12"
 4853	diffused holly-flavored Hob-O	0		Effect: "Frigid Weapon", Effect Duration: 34, Last Available: "2020-09"
 4854	blurry CRIMBCO scrip	0		Last Available: "2011-01"
-4855	blurry fuchsia Toot Oriole care package	0		
+4855	fuchsia blurry Toot Oriole care package	0		
 4856	twirling paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	mirror careful CRIMBCO lanyard	0		Monster Level: -10, Single Equip, Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	electrified fortified brawny paperclip-on tie	0		Muscle Percent: +20, Damage Absorption: +60, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-01"
-4869	Rosewater's paperclip pants of temperance	0		Mysticality Percent: +30, Sleaze Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	blinking grievous beefcake's paperclip turban of the glutton	0		Muscle: +25, Weapon Damage Percent: +50, Food Drop: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	Rosewater's paperclip pants of temperance	0		Mysticality Percent: +30, Sleaze Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	blinking grievous beefcake's paperclip turban of the glutton	0		Muscle: +25, Weapon Damage Percent: +50, Food Drop: +100, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	skewed spinning electrified paperclip cape	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	bouncing photocopied monster	0		Last Available: "2011-01"
@@ -4800,8 +4800,8 @@
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	snack-sized moldy enchanted festive sausage	2	crappy	Effect: "Fastbreaker", Effect Duration: 10, Last Available: "2011-01"
-4895	yummy miniature holiday cheese log	2	awesome	Last Available: "2011-01"
+4894	enchanted moldy snack-sized festive sausage	2	crappy	Effect: "Fastbreaker", Effect Duration: 10, Last Available: "2011-01"
+4895	miniature yummy holiday cheese log	2	awesome	Last Available: "2011-01"
 4896	huge holiday log	0		Last Available: "2011-01"
 4897	green Temple Grandin's grievous BGE 'ferocious fruit' shirt	0		Weapon Damage Percent: +50, Familiar Weight: +7, Last Available: "2010-12"
 4898	Sherlock's scandalous BGE 'cuddly critter' shirt	0		Sleaze Damage: +5, Item Drop: +25, Last Available: "2010-12"
@@ -4824,7 +4824,7 @@
 4915	bouncing knitted Sinatra's Loathing Legion chainsaw	0		Experience (Moxie): +5, Cold Resistance: +3, Softcore Only, Last Available: "2011-01"
 4916	lime green shaking Loathing Legion rollerblades of the detective	0		Item Drop: +20, Single Equip, Softcore Only, Last Available: "2011-01"
 4917	Loathing Legion flamethrower of the bloodbag	0		Maximum HP: +100, Softcore Only, Last Available: "2011-01"
-4918	wobbly olive Loathing Legion tattoo needle	0		Last Available: "2011-01"
+4918	olive wobbly Loathing Legion tattoo needle	0		Last Available: "2011-01"
 4919	bouncing Loathing Legion defibrillator of Flo-Jo	0		Initiative: +100, Softcore Only, Last Available: "2011-01"
 4920	coward's Loathing Legion double prism	0		Monster Level: -20, Softcore Only, Last Available: "2011-01"
 4921	asbestos-lined Loathing Legion tape measure	0		Hot Resistance: +5, Softcore Only, Last Available: "2011-01"
@@ -4860,11 +4860,11 @@
 4957	adjusted non-pressed half-baked potion	0		Effect: "Sugar Smacks", Effect Duration: 50
 4958	sharpshooter's Knob Goblin deluxe scimitar	0		Critical Hit Percent: +10
 4959	moldy thick tumbling Knob nuts	5	crappy	
-4960	fancy hand-crafted Cobb's Knob Wurstbrau	3	EPIC	Effect: "Reedy Pipes", Effect Duration: 15
+4960	hand-crafted fancy Cobb's Knob Wurstbrau	3	EPIC	Effect: "Reedy Pipes", Effect Duration: 15
 4961	Subject 37 file	0		
 4962	auspicious shellacked mysterious lapel pin	0		Damage Reduction: 7, Item Drop: +10, Single Equip
 4963	state loom	0		Familiar Weight: +10
-4964	bouncing tumbling Evilometer	0		
+4964	tumbling bouncing Evilometer	0		
 4965	Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	blurry Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	jittery Alice's Army Swordsman	0		Last Available: "2011-03"
@@ -4888,7 +4888,7 @@
 4985	shaking Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
-4988	upside-down fuchsia Alice's Army Foil Swordsman	0		Last Available: "2011-03"
+4988	fuchsia upside-down Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	Alice's Army Foil Guard	0		Last Available: "2011-03"
@@ -4917,10 +4917,10 @@
 5014	bland tobiko pocky	4	decent	Last Available: "2011-03"
 5015	miniature decent tumbling natto pocky	2	good	Last Available: "2011-03"
 5016	watered-down delicious squat wasabi-infused sake	2	awesome	Last Available: "2011-03"
-5017	strong bad fancy tobiko-infused sake	5	decent	Effect: "Al Dente Inferno", Effect Duration: 40, Last Available: "2011-03"
+5017	fancy bad strong tobiko-infused sake	5	decent	Effect: "Al Dente Inferno", Effect Duration: 40, Last Available: "2011-03"
 5018	acceptable natto-infused sake	4	good	Last Available: "2011-03"
 5019	aerosolized deionized wasabi marble soda	0		Effect: "Human-Demon Hybrid", Effect Duration: 65, Last Available: "2011-03"
-5020	dry nitrogenated fuchsia narrow tobiko marble soda	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 62, Last Available: "2011-03"
+5020	dry nitrogenated narrow fuchsia tobiko marble soda	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 62, Last Available: "2011-03"
 5021	denatured natto marble soda	0		Effect: "Cock of the Walk", Effect Duration: 18, Last Available: "2011-03"
 5022	blue Alice's Army booster box	0		Last Available: "2011-03"
 5023	boiled dry warmed narrow elderly jawbreaker	0		Effect: "Pasty", Effect Duration: 12, Last Available: "2020-09"
@@ -4945,15 +4945,15 @@
 5042	shaking avaricious astral belt of wisdom	0		Mysticality: +15, Meat Drop: +30
 5043	moldy astral hot dog	4		
 5044	irresponsibly strong artisanal pulsating astral pilsner	7		
-5045	jittery narrow gray astral hot dog dinner	0		
+5045	narrow gray jittery astral hot dog dinner	0		
 5046	shaking astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	pulsating shard of double-ice	0		Last Available: "2011-04"
-5049	padded weightlifter's double-ice cap of James Dean	0		Muscle: +15, Experience (Moxie): +3, Damage Absorption: +20, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	padded weightlifter's double-ice cap of James Dean	0		Muscle: +15, Experience (Moxie): +3, Damage Absorption: +20, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	double-paned Fonzie's double-ice box of wisdom	0		Mysticality: +15, Experience (Moxie): +1, Cold Resistance: +5, Last Available: "2011-04"
-5051	mirror Usain Bolt's Sherlock's personal trainer's double-ice britches	0		Experience Percent (Muscle): +10, Item Drop: +25, Initiative: +80, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	mirror Usain Bolt's Sherlock's personal trainer's double-ice britches	0		Experience Percent (Muscle): +10, Item Drop: +25, Initiative: +80, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
-5053	pulsating teal Lars the Cyberian	0		Last Available: "2011-04"
+5053	teal pulsating Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	olive obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
@@ -4967,7 +4967,7 @@
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
 5065	super-sized stale spaghetti con calaveras	5	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	snack-sized stale mirror popcorn	2	decent	Last Available: "2011-04"
+5067	stale snack-sized mirror popcorn	2	decent	Last Available: "2011-04"
 5068	jumbo stale blinking chaos popcorn	5	decent	Last Available: "2011-04"
 5069	frightening chilly therapeutic hole	0		Cold Damage: +5, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-04"
 5070	tumbling innuendo	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	artisanal Russian Ice	4	EPIC	Last Available: "2011-04"
 5074	purple gravedigger's clay ashtray	0		Spooky Damage: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	wobbly lanyard of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2011-05"
-5076	pulsating huge forbidden monster pants	0		Spell Damage Percent: +50, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	pulsating huge forbidden monster pants	0		Spell Damage Percent: +50, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	chilled Pok&euml;mann band-aid	0		Effect: "Marco Polarity", Effect Duration: 46, Last Available: "2011-05"
-5079	huge Usain Bolt's flame-wreathed Van der Graaf helmet	0		Hot Spell Damage: +10, Initiative: +80, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	huge Usain Bolt's flame-wreathed Van der Graaf helmet	0		Hot Spell Damage: +10, Initiative: +80, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	blinking arcane researcher's crutch	0		Experience Percent (Mysticality): +10, Last Available: "2011-05"
 5081	mirror shock belt of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2011-05"
 5082	super-frozen aerosolized Okee-Dokee soda	0		Effect: "Ironclad", Effect Duration: 58, Last Available: "2011-05"
 5083	blue skewed banded rubber band gun	0		Damage Absorption: +100, Last Available: "2011-05"
-5084	beefy pin-stripe slacks	0		Muscle: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	beefy pin-stripe slacks	0		Muscle: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	grievous gloves	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2011-05"
 5086	chilled triple-adjusted polymerized correction fluid	0		Effect: "Butt-Rock Hair", Effect Duration: 65, Last Available: "2011-05"
 5087	blurry jittery fortified Pok&euml;mann figurine: Porkachu	0		Damage Absorption: +60, Single Equip, Last Available: "2011-05"
@@ -5003,7 +5003,7 @@
 5100	nippy Pok&euml;mann figurine: Frank	0		Cold Damage: +10, Single Equip, Last Available: "2011-05"
 5101	quilted Pok&euml;mann figurine: Moog	0		Damage Absorption: +40, Single Equip, Last Available: "2011-05"
 5102	boiled willyweed	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 36, Last Available: "2011-05"
-5103	ionized modified liquefied huge red Nuclear Blastball	0		Effect: "Leash of Linguini", Effect Duration: 15, Last Available: "2011-05"
+5103	ionized modified liquefied red huge Nuclear Blastball	0		Effect: "Leash of Linguini", Effect Duration: 15, Last Available: "2011-05"
 5104	ionized flattened jittery fish juice box	0		Effect: "Well-preserved", Effect Duration: 66, Last Available: "2011-05"
 5105	pulsating paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	upside-down busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	perfumed sizzling hardy Admiral's hat	0		Maximum HP: +50, Hot Damage: +10, Stench Resistance: +5, Familiar Effect: "atk", Last Available: "2011-05"
-5122	zippy Fonzie's aviator's cap of the dark arts	0		Experience (Moxie): +1, Spell Damage Percent: +100, Initiative: +20, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	perfumed sizzling hardy Admiral's hat	0		Maximum HP: +50, Hot Damage: +10, Stench Resistance: +5, Last Available: "2011-05", Familiar Effect: "atk"
+5122	zippy Fonzie's aviator's cap of the dark arts	0		Experience (Moxie): +1, Spell Damage Percent: +100, Initiative: +20, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	hardened sage mirrored aviator shades	0		Mysticality Percent: +10, Damage Reduction: 3, Single Equip, Last Available: "2011-05"
 5124	mirror Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5031,7 +5031,7 @@
 5128	mirror Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	lime green Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	bouncing Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
-5131	non-warmed pulsating bouncing Ultrasoldier Serum	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2011-06"
+5131	non-warmed bouncing pulsating Ultrasoldier Serum	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2011-06"
 5132	bland elven hardtack	4	decent	Last Available: "2011-06"
 5133	bad elven squeeze	3	decent	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
@@ -5040,7 +5040,7 @@
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	ghostly E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
-5140	dehydrated jittery ghostly astral energy drink	1		Effect: "Pla-see-bo", Effect Duration: 30
+5140	dehydrated ghostly jittery astral energy drink	1		Effect: "Pla-see-bo", Effect Duration: 30
 5141	jittery Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	pulsating occult dangerous honey dipper of the storm	0		Weapon Damage: +10, Spell Damage Percent: +25, Maximum MP Percent: +40
 5149	huge prompt flame-wreathed honeybritches of Leguizamo	0		Monster Level: +20, Hot Spell Damage: +10, Adventures: +3, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	prompt stiffened honeycap of the storm	0		Damage Reduction: 1, Maximum MP Percent: +40, Adventures: +3, Familiar Effect: "1xPotato, cap 43"
-5151	gray Moonthril Circlet of the boozehound	0		Booze Drop: +100, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	blinking savvy Moonthril Greaves	0		Mysticality Percent: +20, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	gray Moonthril Circlet of the boozehound	0		Booze Drop: +100, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	blinking savvy Moonthril Greaves	0		Mysticality Percent: +20, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	pulsating stylish Moonthril Flamberge	0		Moxie: +25, Last Available: "2011-06"
 5154	curative Moonthril Longbow	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-06"
 5155	ribald Moonthril Cuirass	0		Sleaze Damage: +10, Softcore Only, Last Available: "2011-06"
@@ -5076,9 +5076,9 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	mediocre Saison du Lune	3	decent	Last Available: "2011-06"
 5175	delicious Moonthril Schnapps	4	awesome	Last Available: "2011-06"
-5176	watered-down acceptable Wrecked Generator	2	good	Last Available: "2011-06"
-5177	snack-sized decent Spaghetti with Moonballs	2	good	Last Available: "2011-06"
-5178	bland diet enchanted fuchsia Crepes a la Lune	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15, Last Available: "2011-06"
+5176	acceptable watered-down Wrecked Generator	2	good	Last Available: "2011-06"
+5177	decent snack-sized Spaghetti with Moonballs	2	good	Last Available: "2011-06"
+5178	enchanted bland diet fuchsia Crepes a la Lune	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15, Last Available: "2011-06"
 5179	moldy Moon Pie	4	crappy	Last Available: "2011-06"
 5180	warmed Comet Pop	0		Effect: "Full-Body Tan", Effect Duration: 64, Last Available: "2011-06"
 5181	galvanized quantum Flan in the Moon	0		Effect: "Thicker, Sicker", Effect Duration: 63, Last Available: "2011-06"
@@ -5089,7 +5089,7 @@
 5186	fuchsia Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	squat Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	anodized improved blue honey stick	0		Effect: "Memory of Strength", Effect Duration: 39
-5189	moist wobbly mirror double-ice gum	0		Effect: "Sticks and Stones", Effect Duration: 18, Last Available: "2011-04"
+5189	moist mirror wobbly double-ice gum	0		Effect: "Sticks and Stones", Effect Duration: 18, Last Available: "2011-04"
 5190	huge careful extremely unsafe Newton's Operation Patriot Shield	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Monster Level: -10, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	warmed flattened corrupted data	0		Effect: "Full of Vinegar", Effect Duration: 62, Last Available: "2011-06"
@@ -5099,10 +5099,10 @@
 5196	wool Great S-Cape	0		Cold Resistance: +1, Softcore Only, Last Available: "2011-07"
 5197	stanky Marvelous Unitard	0		Stench Spell Damage: +25, Softcore Only, Last Available: "2011-07"
 5198	diluted gooey paste	1	good	Last Available: "2011-08"
-5199	compressed pulsating purple beastly paste	1	decent	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 50, Last Available: "2011-08"
+5199	compressed purple pulsating beastly paste	1	decent	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 50, Last Available: "2011-08"
 5200	modified paste	1	decent	Last Available: "2011-08"
 5201	pickled teal ectoplasmic paste	1	good	Last Available: "2011-08"
-5202	altered tumbling lime green pulsating greasy paste	1	good	Effect: "Ass Over Teakettle", Effect Duration: 35, Last Available: "2011-08"
+5202	altered pulsating tumbling lime green greasy paste	1	good	Effect: "Ass Over Teakettle", Effect Duration: 35, Last Available: "2011-08"
 5203	pickled upside-down bug paste	1	good	Last Available: "2011-08"
 5204	modified jittery hippy paste	1	awesome	Last Available: "2011-08"
 5205	pickled orc paste	1	awesome	Last Available: "2011-08"
@@ -5117,11 +5117,11 @@
 5214	modified slimy paste	1	decent	Last Available: "2011-08"
 5215	boiled penguin paste	1	decent	Last Available: "2011-08"
 5216	mixed mirror elemental paste	1	decent	Effect: "Inscrutable exoskeleton", Effect Duration: 45, Last Available: "2011-08"
-5217	altered pulsating bouncing cosmic paste	1	good	Effect: "Winklered", Effect Duration: 35, Last Available: "2011-08"
-5218	altered red upside-down hobo paste	1	EPIC	Effect: "Wintry Breath", Effect Duration: 15, Last Available: "2011-08"
+5217	altered bouncing pulsating cosmic paste	1	good	Effect: "Winklered", Effect Duration: 35, Last Available: "2011-08"
+5218	altered upside-down red hobo paste	1	EPIC	Effect: "Wintry Breath", Effect Duration: 15, Last Available: "2011-08"
 5219	mixed Crimbo paste	1	decent	Last Available: "2011-08"
 5220	twirling Teachings of the Fist	0		
-5221	blue tumbling fat loot token	0		No Pull
+5221	tumbling blue fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	rotten Ur-Donut	3	crappy	Last Available: "2011-09"
@@ -5138,23 +5138,23 @@
 5235	Sinatra's furry halo	0		Experience (Moxie): +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	shellacked frosty halo	0		Damage Reduction: 7, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	Newton's time halo	0		Experience (Mysticality): +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	spirit-forward delicious twirling Lumineux Limnio	5	awesome	Last Available: "2011-09"
+5238	delicious spirit-forward twirling Lumineux Limnio	5	awesome	Last Available: "2011-09"
 5239	acceptable narrow Morto Moreto	3	good	Last Available: "2011-09"
-5240	strong tolerable tumbling Temps Tempranillo	5	good	Last Available: "2011-09"
+5240	tolerable strong tumbling Temps Tempranillo	5	good	Last Available: "2011-09"
 5241	hand-crafted Bordeaux Marteaux	4	EPIC	Last Available: "2011-09"
 5242	drinkable Fromage Pinotage	3	good	Last Available: "2011-09"
-5243	aged practically non-alcoholic spinning Beignet Milgranet	1	awesome	Last Available: "2011-09"
-5244	aged watered-down Muschat	2	awesome	Last Available: "2011-09"
+5243	practically non-alcoholic aged spinning Beignet Milgranet	1	awesome	Last Available: "2011-09"
+5244	watered-down aged Muschat	2	awesome	Last Available: "2011-09"
 5245	moldy bouncing cool jelly donut	3	crappy	Last Available: "2011-09"
-5246	yummy enchanted low-calorie shrapnel jelly donut	1	awesome	Effect: "Strong Grip", Effect Duration: 30, Last Available: "2011-09"
+5246	enchanted low-calorie yummy shrapnel jelly donut	1	awesome	Effect: "Strong Grip", Effect Duration: 30, Last Available: "2011-09"
 5247	bland occult jelly donut	3	decent	Last Available: "2011-09"
 5248	moldy thyme jelly donut	3	crappy	Last Available: "2011-09"
 5249	spoiled danish	3	crappy	Last Available: "2011-09"
 5250	delicious shaking smashed danish	4	awesome	Last Available: "2011-09"
-5251	yummy immense forbidden danish	8	awesome	Last Available: "2011-09"
+5251	immense yummy forbidden danish	8	awesome	Last Available: "2011-09"
 5252	half-sized adequate cool cat claw	2	good	Last Available: "2011-09"
 5253	bland small blunt cat claw	2	decent	Last Available: "2011-09"
-5254	stale gigantic shadowy cat claw	10	decent	Last Available: "2011-09"
+5254	gigantic stale shadowy cat claw	10	decent	Last Available: "2011-09"
 5255	rotten jumbo green cheezburger	5	crappy	Last Available: "2011-09"
 5256	adequate toasted brie	3	good	Last Available: "2011-09"
 5257	altered mirror potion of the field gar	0		Effect: "Boilermade", Effect Duration: 65, Last Available: "2011-09"
@@ -5215,16 +5215,16 @@
 5312	corrupted ghostly body paint	0		Effect: "Insatiable Hunger", Effect Duration: 40, Last Available: "2011-10"
 5313	frozen necrotizing body spray	0		Effect: "Hot Jellied", Effect Duration: 60, Last Available: "2011-10"
 5314	super-chilled lime green bite-me-red lipstick	0		Effect: "Blackberry Politeness", Effect Duration: 52, Last Available: "2011-10"
-5315	quantum upside-down blinking whisker pencil	0		Effect: "Supafly", Effect Duration: 46, Last Available: "2011-10"
+5315	quantum blinking upside-down whisker pencil	0		Effect: "Supafly", Effect Duration: 46, Last Available: "2011-10"
 5316	nitrogenated wobbly press-on ribs	0		Effect: "Improved Candy Vision", Effect Duration: 29, Last Available: "2011-10"
 5317	enhanced Rattlin' Chains	0		Effect: "Got Your Boots On", Effect Duration: 44, Last Available: "2011-10"
 5318	polarized pulsating Gummy Brains	0		Effect: "You Know When to Walk Away", Effect Duration: 65, Last Available: "2011-10"
-5319	modified corrupted mirror wobbly Blood 'n' Plenty	0		Effect: "Dirty Pear", Effect Duration: 16, Last Available: "2011-10"
+5319	modified corrupted wobbly mirror Blood 'n' Plenty	0		Effect: "Dirty Pear", Effect Duration: 16, Last Available: "2011-10"
 5320	liquefied ghostly Lobos Mints	0		Effect: "Limber as Mortimer", Effect Duration: 56, Last Available: "2011-10"
 5321	tarnished Sweet Sword	0		Effect: "Icy Demeanor", Effect Duration: 34, Last Available: "2011-10"
-5322	weak artisanal upside-down Ecto-Cooler	2	EPIC	Last Available: "2011-10"
+5322	artisanal weak upside-down Ecto-Cooler	2	EPIC	Last Available: "2011-10"
 5323	delicious narrow Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
-5324	bad triple-distilled Blood Light	6	decent	Last Available: "2011-10"
+5324	triple-distilled bad Blood Light	6	decent	Last Available: "2011-10"
 5325	tolerable Silver Bullet beer	4	good	Last Available: "2011-10"
 5326	acceptable red Bone's Farm &quot;wine&quot;	3	good	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	frozen oxidized drum of pomade	0		Effect: "Partially Ghosted", Effect Duration: 17, Last Available: "2011-10"
 5331	shaking throwing bone	0		Last Available: "2011-10"
 5332	flame-retardant extra-see-thru nightie	0		Hot Resistance: +1, Last Available: "2011-10"
-5333	Oprah's shellacked BRAINS shorts	0		Damage Reduction: 7, Maximum MP Percent: +50, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	Oprah's shellacked BRAINS shorts	0		Damage Reduction: 7, Maximum MP Percent: +50, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	Mesmereyes&trade; contact lenses of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2011-10"
 5335	manspreader's scrunchie	0		Monster Level: +10, Single Equip, Last Available: "2011-10"
-5336	smelly weightlifter's extremely skinny jeans	0		Muscle: +15, Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	twirling upside-down dangerous The Necbromancer's Hat of the early riser	0		Weapon Damage: +10, Adventures: +7, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	smelly weightlifter's extremely skinny jeans	0		Muscle: +15, Stench Spell Damage: +10, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	twirling upside-down dangerous The Necbromancer's Hat of the early riser	0		Weapon Damage: +10, Adventures: +7, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	ghostly auspicious flame-retardant forbidden The Necbromancer's Stein	0		Spell Damage Percent: +50, Hot Resistance: +1, Item Drop: +10, Last Available: "2011-10"
-5339	rosy-cheeked smartaleck's The Necbromancer's Shorts of the blizzard	0		Moxie Percent: +30, Maximum HP Percent: +30, Cold Spell Damage: +25, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	rosy-cheeked smartaleck's The Necbromancer's Shorts of the blizzard	0		Moxie Percent: +30, Maximum HP Percent: +30, Cold Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	wholesome dance instructor's Samson's The Necbromancer's Wizard Staff	0		Experience (Muscle): +5, Experience Percent (Moxie): +10, Maximum HP Percent: +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	high-proof drinkable fancy The Cooler Out of Space	9	good	Effect: "Okee-Dokee Go!", Effect Duration: 10, Last Available: "2011-10"
@@ -5256,7 +5256,7 @@
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
-5356	ghostly tumbling A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
+5356	tumbling ghostly A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	olive Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
@@ -5279,7 +5279,7 @@
 5376	rosy-cheeked plastic Big Candy of the sweet-tooth	0		Maximum HP Percent: +30, Candy Drop: +100, Last Available: "2011-12"
 5377	upside-down The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	boiled skewed mirror groose grease	1	decent	Effect: "Disco State of Mind", Effect Duration: 30, Last Available: "2012-12"
+5379	boiled mirror skewed groose grease	1	decent	Effect: "Disco State of Mind", Effect Duration: 30, Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
 5382	blinking pearidot	0		Last Available: "2011-11"
@@ -5289,7 +5289,7 @@
 5386	weightlifter's ridiculous belt	0		Muscle: +15, Last Available: "2011-11"
 5387	experienced ridiculous earring	0		Experience: +2, Last Available: "2011-11"
 5388	wobbly frosty ridiculous sunglasses	0		Cold Spell Damage: +10, Last Available: "2011-11"
-5389	fancy flavorless ridiculous sandwich	3	decent	Effect: "Gamer Rage", Effect Duration: 15, Last Available: "2011-11"
+5389	flavorless fancy ridiculous sandwich	3	decent	Effect: "Gamer Rage", Effect Duration: 15, Last Available: "2011-11"
 5390	bad ridiculous cocktail	3	decent	Last Available: "2011-11"
 5391	zombie monkey necklace of extreme caution of chilblains	0		Monster Level: -25, Cold Damage: +25
 5392	upside-down Thwaitgold butterfly statuette	0		
@@ -5297,7 +5297,7 @@
 5394	sandpaper	0		
 5395	peppermint sprout	0		Last Available: "2011-11"
 5396	non-altered aerosolized peppermint twist	0		Effect: "Bonelording", Effect Duration: 46, Last Available: "2011-11"
-5397	spoiled tiny peppermint patty	1	crappy	Last Available: "2011-11"
+5397	tiny spoiled peppermint patty	1	crappy	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	spinning candy cane candygram	0		Last Available: "2011-12"
@@ -5306,18 +5306,18 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	blinking Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	toasty lion tamer's cane-mail shirt of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Hot Damage: +5, Last Available: "2011-12"
-5406	gravedigger's Oprah's wholesome cane-mail pants	0		Maximum HP Percent: +10, Maximum MP Percent: +50, Spooky Damage: +10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	gravedigger's Oprah's wholesome cane-mail pants	0		Maximum HP Percent: +10, Maximum MP Percent: +50, Spooky Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	smooth practically non-alcoholic Vodka Matryoshka	1	awesome	Last Available: "2011-12"
 5408	mediocre watered-down Gin Mint	2	decent	Last Available: "2011-12"
 5409	mediocre Tequiz Navidad	4	decent	Last Available: "2011-12"
 5410	perfectly mixed Mint Yulep	3	EPIC	Last Available: "2011-12"
-5411	tolerable fancy Crimbojito	3	good	Effect: "Army of One", Effect Duration: 50, Last Available: "2011-12"
+5411	fancy tolerable Crimbojito	3	good	Effect: "Army of One", Effect Duration: 50, Last Available: "2011-12"
 5412	smooth Sangria de Menthe	4	awesome	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	non-denatured extra-pressed licorice root	0		Effect: "Corona de la Salsa", Effect Duration: 57, Last Available: "2011-12"
 5416	non-galvanized deionized spinning banana supersucker	0		Effect: "Sweet Taste", Effect Duration: 19, Last Available: "2011-11"
-5417	energized lime green upside-down pear supersucker	0		Effect: "Berry Defensive", Effect Duration: 55, Last Available: "2011-11"
+5417	energized upside-down lime green pear supersucker	0		Effect: "Berry Defensive", Effect Duration: 55, Last Available: "2011-11"
 5418	enhanced lime supersucker	0		Effect: "Cock of the Walk", Effect Duration: 43, Last Available: "2011-11"
 5419	pressed ionized spinning kumquat supersucker	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 48, Last Available: "2011-11"
 5420	unsweetened jittery strawberry supersucker	0		Effect: "Mer-kindliness", Effect Duration: 11, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	Samson's kumquartz ring	0		Experience (Muscle): +5, Single Equip, Last Available: "2011-11"
 5425	upside-down strawberyl necklace of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2011-11"
 5426	zippy beefcake's sucker bucket	0		Muscle: +25, Initiative: +20, Last Available: "2011-11"
-5427	blurry purple deadly sucker hakama	0		Weapon Damage: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	sharpshooter's sucker kabuto	0		Critical Hit Percent: +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	blurry purple deadly sucker hakama	0		Weapon Damage: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	sharpshooter's sucker kabuto	0		Critical Hit Percent: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	baleful sucker tachi	0		Spell Damage: +25, Last Available: "2011-11"
 5430	bouncing sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	huge twirling superheated fudge	0		Last Available: "2011-11"
 5438	concentrated fluid of fudge-finding	0		Effect: "Fishy", Effect Duration: 20, Last Available: "2011-11"
 5439	skewed fudgepuck	0		Last Available: "2011-11"
-5440	half-sized normal special tumbling shaking fudgesicle	2	good	Effect: "Frost Tea", Effect Duration: 50, Last Available: "2011-11"
+5440	half-sized normal special shaking tumbling fudgesicle	2	good	Effect: "Frost Tea", Effect Duration: 50, Last Available: "2011-11"
 5441	wobbly wand of fudge control	0		Last Available: "2011-11"
 5442	mirror The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5358,7 +5358,7 @@
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	pulsating gummi ingot	0		Last Available: "2011-11"
 5457	quantum triple-enhanced energized gray Fudgie Roll	0		Effect: "Arse-a'fire", Effect Duration: 67, Last Available: "2011-11"
-5458	rotten enchanted bouncing fudge bunny	4	crappy	Effect: "Feelin' Philosophical", Effect Duration: 45, Last Available: "2011-11"
+5458	enchanted rotten bouncing fudge bunny	4	crappy	Effect: "Feelin' Philosophical", Effect Duration: 45, Last Available: "2011-11"
 5459	huge fudge spork	0		Last Available: "2011-11"
 5460	huge clever fudgecycle of wisdom of the brute	0		Mysticality: +15, Muscle Percent: +30, Maximum MP: +20, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	diffused tarnished colloidal maroon gummi belemnite	0		Effect: "Rosewater Mark", Effect Duration: 58, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	narrow vibrating Socratic Big Candy's tophat	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	narrow vibrating Socratic Big Candy's tophat	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	bouncing Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	tumbling Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5410,7 +5410,7 @@
 5507	hand-crafted spinning Go-Wassail	4	EPIC	Last Available: "2011-11"
 5508	frozen Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Preternatural Greed", Effect Duration: 49, Last Available: "2011-11"
 5509	tarnished liquefied dry bottle of bubbles	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 42, Last Available: "2011-11"
-5510	electrified activated moist shaking lime green wind-up meatcar	0		Effect: "Aided and Abetted", Effect Duration: 62, Last Available: "2011-11"
+5510	electrified activated moist lime green shaking wind-up meatcar	0		Effect: "Aided and Abetted", Effect Duration: 62, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	narrow Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5433,7 +5433,7 @@
 5530	moist baobab sap	0		Effect: "Larger", Effect Duration: 50, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	spinning magnolia blossom	0		Last Available: "2012-12"
-5533	moist pulsating huge Mortimer's nostrum	0		Effect: "Voracious Gorging", Effect Duration: 69, Last Available: "2012-12"
+5533	moist huge pulsating Mortimer's nostrum	0		Effect: "Voracious Gorging", Effect Duration: 69, Last Available: "2012-12"
 5534	drinkable watered-down special Barulio's bottle	2	good	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 30, Last Available: "2012-12"
 5535	Vulcanized cyan Marvin's marvelous pill	0		Effect: "Oleaginous Soles", Effect Duration: 15, Last Available: "2012-12"
 5536	blurry Winifred's whistle	0		Last Available: "2012-12"
@@ -5441,7 +5441,7 @@
 5538	half-empty carton of milk	0		Last Available: "2012-12"
 5539	glass of warm water	0		Free Pull
 5540	chilled denatured desktop zen garden	0		Effect: "Three Days Slow", Effect Duration: 40, Last Available: "2012-12"
-5541	upside-down shaking Vivian's Vitamin	0		Last Available: "2012-12"
+5541	shaking upside-down Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	huge educational slick Leapin' Trousers	0		Moxie: +10, Experience: +1
 5544	bad eggnog	4	decent	Last Available: "2012-12"
@@ -5459,13 +5459,13 @@
 5556	banded extremely unsafe Rain-Doh wings	0		Weapon Damage Percent: +100, Damage Absorption: +100, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	manspreader's electrified Rain-Doh laser gun	0		Monster Level: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2012-02"
-5559	shellacked Rain-Doh lantern of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	shellacked Rain-Doh lantern of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	shaking Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	brawny Rain-Doh violet bo of horror	0		Muscle Percent: +20, Spooky Spell Damage: +25, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	stale small PB&BP	2	decent	
+5565	small stale PB&BP	2	decent	
 5566	flavorless spinning club sandwich	4	decent	
 5567	stale corned-beef Reuben	4	decent	
 5568	frayed ninja rope	0		
@@ -5474,18 +5474,18 @@
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	aged Drac & Tan	3	awesome	Last Available: "2012-03"
-5574	fancy tolerable Transylvania Sling	4	good	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2012-03"
-5575	distilled lousy Shot of the Living Dead	5	decent	Last Available: "2012-03"
+5574	tolerable fancy Transylvania Sling	4	good	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2012-03"
+5575	lousy distilled Shot of the Living Dead	5	decent	Last Available: "2012-03"
 5576	tolerable Buttery Knob	3	good	Last Available: "2012-03"
 5577	tolerable weak Slippery Knob	2	good	Last Available: "2012-03"
-5578	weak mediocre Flaming Knob	2	decent	Last Available: "2012-03"
-5579	hand-crafted weak Grasshopper	2	EPIC	Last Available: "2012-03"
+5578	mediocre weak Flaming Knob	2	decent	Last Available: "2012-03"
+5579	weak hand-crafted Grasshopper	2	EPIC	Last Available: "2012-03"
 5580	artisanal Locust	4	EPIC	Last Available: "2012-03"
-5581	perfectly mixed fancy Plague of Locusts	3	EPIC	Effect: "Texas Elegance", Effect Duration: 20, Last Available: "2012-03"
-5582	aged enchanted Red Dwarf	4	awesome	Effect: "Healthy Blue Glow", Effect Duration: 15, Last Available: "2012-03"
-5583	hand-crafted high-proof Golden Mean	9	EPIC	Last Available: "2012-03"
-5584	mediocre strong Green Giant	5	decent	Last Available: "2012-03"
-5585	weak drinkable wobbly Aye Aye	2	good	Last Available: "2012-03"
+5581	fancy perfectly mixed Plague of Locusts	3	EPIC	Effect: "Texas Elegance", Effect Duration: 20, Last Available: "2012-03"
+5582	enchanted aged Red Dwarf	4	awesome	Effect: "Healthy Blue Glow", Effect Duration: 15, Last Available: "2012-03"
+5583	high-proof hand-crafted Golden Mean	9	EPIC	Last Available: "2012-03"
+5584	strong mediocre Green Giant	5	decent	Last Available: "2012-03"
+5585	drinkable weak wobbly Aye Aye	2	good	Last Available: "2012-03"
 5586	delicious teal Aye Aye, Captain	3	awesome	Last Available: "2012-03"
 5587	hand-crafted Aye Aye, Tooth Tooth	4	EPIC	Last Available: "2012-03"
 5588	lousy shaking Humanitini	3	decent	Last Available: "2012-03"
@@ -5493,46 +5493,46 @@
 5590	practically non-alcoholic mediocre tumbling Oh, the Humanitini	1	decent	Last Available: "2012-03"
 5591	artisanal Great Older Fashioned	4	EPIC	Last Available: "2012-03"
 5592	delicious Fuzzy Tentacle	3	awesome	Last Available: "2012-03"
-5593	fancy mediocre shaking squat Crazymaker	4	decent	Effect: "Blood-Rich", Effect Duration: 50, Last Available: "2012-03"
+5593	fancy mediocre squat shaking Crazymaker	4	decent	Effect: "Blood-Rich", Effect Duration: 50, Last Available: "2012-03"
 5594	artisanal Zoodriver	4	EPIC	Last Available: "2012-03"
 5595	drinkable watered-down lime green Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
 5596	acceptable boozy Sloe Comfortable Zoo on Fire	5	good	Last Available: "2012-03"
 5597	enchanted perfectly mixed Suffering Sinner	4	EPIC	Effect: "Dreams and Lights", Effect Duration: 5, Last Available: "2012-03"
-5598	perfectly mixed irresponsibly strong Suppurating Sinner	8	EPIC	Last Available: "2012-03"
-5599	watered-down enchanted artisanal Sizzling Sinner	2	EPIC	Effect: "Fit To Be Tide", Effect Duration: 20, Last Available: "2012-03"
+5598	irresponsibly strong perfectly mixed Suppurating Sinner	8	EPIC	Last Available: "2012-03"
+5599	watered-down artisanal enchanted Sizzling Sinner	2	EPIC	Effect: "Fit To Be Tide", Effect Duration: 20, Last Available: "2012-03"
 5600	distilled artisanal skewed Firewater	5	EPIC	Last Available: "2012-03"
-5601	lousy weak Earth and Firewater	2	decent	Last Available: "2012-03"
+5601	weak lousy Earth and Firewater	2	decent	Last Available: "2012-03"
 5602	strong bad Earth, Wind and Firewater	5	decent	Last Available: "2012-03"
 5603	drinkable weak skewed Slimosa	2	good	Last Available: "2012-03"
 5604	drinkable Extra-slimy Slimosa	4	good	Last Available: "2012-03"
 5605	drinkable Slimebite	3	good	Last Available: "2012-03"
-5606	hand-crafted extra-dry Cement Mixer	5	EPIC	Last Available: "2012-03"
+5606	extra-dry hand-crafted Cement Mixer	5	EPIC	Last Available: "2012-03"
 5607	drinkable Jackhammer	3	good	Last Available: "2012-03"
 5608	drinkable watered-down Dump Truck	2	good	Last Available: "2012-03"
 5609	bad practically non-alcoholic Fauna Libre	1	decent	Last Available: "2012-03"
 5610	tolerable enchanted weak tumbling Chakra Libre	2	good	Effect: "Abominably Slippery", Effect Duration: 15, Last Available: "2012-03"
-5611	high-proof artisanal Aura Libre	7	EPIC	Last Available: "2012-03"
-5612	watered-down bad Sazerorc	2	decent	Last Available: "2012-03"
+5611	artisanal high-proof Aura Libre	7	EPIC	Last Available: "2012-03"
+5612	bad watered-down Sazerorc	2	decent	Last Available: "2012-03"
 5613	weak smooth mirror Sazuruk-hai	2	awesome	Last Available: "2012-03"
 5614	tolerable blurry Flaming Sazerorc	3	good	Last Available: "2012-03"
 5615	bad Green Velvet	4	decent	Last Available: "2012-03"
 5616	drinkable Green Muslin	4	good	Last Available: "2012-03"
 5617	weak mediocre Green Burlap	2	decent	Last Available: "2012-03"
-5618	practically non-alcoholic perfectly mixed Mohobo	1	EPIC	Last Available: "2012-03"
+5618	perfectly mixed practically non-alcoholic Mohobo	1	EPIC	Last Available: "2012-03"
 5619	artisanal Moonshine Mohobo	4	EPIC	Last Available: "2012-03"
 5620	artisanal Flaming Mohobo	4	EPIC	Last Available: "2012-03"
-5621	watered-down smooth Drunken Philosopher	2	awesome	Last Available: "2012-03"
+5621	smooth watered-down Drunken Philosopher	2	awesome	Last Available: "2012-03"
 5622	perfectly mixed Drunken Neurologist	4	EPIC	Last Available: "2012-03"
 5623	triple-distilled artisanal Drunken Astrophysicist	6	EPIC	Last Available: "2012-03"
-5624	hand-crafted extra-dry Dark & Starry	5	EPIC	Last Available: "2012-03"
+5624	extra-dry hand-crafted Dark & Starry	5	EPIC	Last Available: "2012-03"
 5625	perfectly mixed spirit-forward Black Hole	5	EPIC	Last Available: "2012-03"
 5626	mediocre squat Event Horizon	3	decent	Last Available: "2012-03"
 5627	acceptable Herring Daiquiri	4	good	Last Available: "2012-03"
-5628	high-proof tolerable Herring Wallbanger	9	good	Last Available: "2012-03"
-5629	fancy drinkable maroon Herringtini	4	good	Effect: "Granolarrrgh", Effect Duration: 10, Last Available: "2012-03"
+5628	tolerable high-proof Herring Wallbanger	9	good	Last Available: "2012-03"
+5629	drinkable fancy maroon Herringtini	4	good	Effect: "Granolarrrgh", Effect Duration: 10, Last Available: "2012-03"
 5630	artisanal triple-distilled tumbling Lollipop Drop	10	EPIC	Last Available: "2012-03"
 5631	acceptable Candy Alexander	4	good	Last Available: "2012-03"
-5632	drinkable watered-down blurry Candicaine	2	good	Last Available: "2012-03"
+5632	watered-down drinkable blurry Candicaine	2	good	Last Available: "2012-03"
 5633	aged Caipiranha	4	awesome	Last Available: "2012-03"
 5634	artisanal Flying Caipiranha	3	EPIC	Last Available: "2012-03"
 5635	hand-crafted tumbling Flaming Caipiranha	3	EPIC	Last Available: "2012-03"
@@ -5541,20 +5541,20 @@
 5638	hand-crafted Haymaker	3	EPIC	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	flavorless enchanted fungus	4	decent	Effect: "Al Dente Inferno", Effect Duration: 50
+5641	enchanted flavorless fungus	4	decent	Effect: "Al Dente Inferno", Effect Duration: 50
 5642	narrow poisoned dart	0		
 5643	modified unsweetened stone wool	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 53
 5644	stones	0		
 5645	pulsating the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	slick calendar	0		Moxie: +10, Damage Reduction: 4
-5648	upside-down Sinatra's brawny Boris's Helm	0		Muscle Percent: +20, Experience (Moxie): +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	upside-down Sinatra's brawny Boris's Helm	0		Muscle Percent: +20, Experience (Moxie): +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	ghostly hardened wicked staph of homophones	0		Spell Damage: +5, Damage Reduction: 3
-5650	shaking fuchsia bouncing greedy frightening arcane researcher's Boris's Helm (askew)	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Meat Drop: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	shaking fuchsia bouncing greedy frightening arcane researcher's Boris's Helm (askew)	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Meat Drop: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	green Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	half-sized moldy enchanted wobbly nailswurst	2	crappy	Effect: "White Blooded", Effect Duration: 30
+5654	moldy half-sized enchanted wobbly nailswurst	2	crappy	Effect: "White Blooded", Effect Duration: 30
 5655	delicious high-proof ghostly used beer	8	awesome	
 5656	Huggler Radio	0		Free Pull
 5657	purple fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5573,15 +5573,15 @@
 5670	normal fettucini &eacute;pines Inconnu	3	good	
 5671	tolerable slap and slap again	3	good	
 5672	gunpowder burrito	2	good	
-5673	blurry blinking beery blood	2	good	
+5673	blinking blurry beery blood	2	good	
 5674	tumbling &quot;L&quot;	0		
 5675	compressed narrow watered-down Red Minotaur	1		Effect: "Fit To Be Tide", Effect Duration: 20
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	bouncing beefy Ze&trade; goggles	0		Muscle: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	bouncing beefy Ze&trade; goggles	0		Muscle: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	huge soggy used band-aid	0		Last Available: "2012-05"
-5679	tumbling stylish swimsuit of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	tumbling stylish swimsuit of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
-5681	snack-sized spoiled P.B.L.T.	2	crappy	
+5681	spoiled snack-sized P.B.L.T.	2	crappy	
 5682	tumbling note from Clancy	0		Skill: "Request Sandwich"
 5683	purple BURT	0		
 5684	huge handful of juicy garbage	0		
@@ -5605,17 +5605,17 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	purple fireproof wax hat of the glutton	0		Hot Resistance: +3, Food Drop: +100, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	knitted wax pants of the blizzard	0		Cold Spell Damage: +25, Cold Resistance: +3, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	purple fireproof wax hat of the glutton	0		Hot Resistance: +3, Food Drop: +100, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	knitted wax pants of the blizzard	0		Cold Spell Damage: +25, Cold Resistance: +3, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	super-colloidal quadruple-chilled blurry drop of water-37	0		Effect: "Chunky", Effect Duration: 68, Last Available: "2012-07"
-5709	skewed steel-toed smartaleck's fireman's helmet	0		Moxie Percent: +30, Damage Reduction: 9, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	skewed steel-toed smartaleck's fireman's helmet	0		Moxie Percent: +30, Damage Reduction: 9, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	fire axe of extreme caution	0		Monster Level: -25, Last Available: "2012-07"
 5713	tumbling frosty careful crafty fire extinguisher	0		Maximum MP: +10, Monster Level: -10, Cold Spell Damage: +10, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	rotten half-sized fancy gray FDKOL hotcakes	2	crappy	Effect: "Hip to Be Square Dancin'", Effect Duration: 30, Last Available: "2012-07"
+5717	half-sized rotten fancy gray FDKOL hotcakes	2	crappy	Effect: "Hip to Be Square Dancin'", Effect Duration: 30, Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	tumbling smoking grass	0		Last Available: "2012-07"
 5720	snack-sized bland fiery wing	2	decent	Last Available: "2012-07"
@@ -5624,25 +5624,25 @@
 5723	pickled fuchsia tumbling bottle of fire	0		Effect: "Electrolit Up", Effect Duration: 67, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	lime green hot daub	0		Last Available: "2012-07"
-5726	squat huge hot daub bun of the dark arts of extreme caution	0		Spell Damage Percent: +100, Monster Level: -25, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	bouncing greedy foul-smelling hot daub stand	0		Stench Damage: +10, Meat Drop: +20, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	squat huge hot daub bun of the dark arts of extreme caution	0		Spell Damage Percent: +100, Monster Level: -25, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	bouncing greedy foul-smelling hot daub stand	0		Stench Damage: +10, Meat Drop: +20, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	fortified brawny foot-long hot daub	0		Muscle Percent: +20, Damage Absorption: +60, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy angst burger	3	crappy	
-5731	distilled tolerable 5-hour acrimony	5	good	
+5731	tolerable distilled 5-hour acrimony	5	good	
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	rotten forbidden sausage	3	crappy	
 5735	miser's Lord Flameface's cloak	0		Meat Drop: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
-5736	Vulcanized polymerized mirror huge Drizzlers&trade; Black Licorice	0		Effect: "Memento Moir&eacute;", Effect Duration: 39
+5736	Vulcanized polymerized huge mirror Drizzlers&trade; Black Licorice	0		Effect: "Memento Moir&eacute;", Effect Duration: 39
 5737	denatured daub-breaker	0		Effect: "Gobliny Flavor", Effect Duration: 41, Last Available: "2020-09"
 5738	quilted Camp Scout backpack	0		Damage Absorption: +40, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	stale bag of GORP	3	decent	Last Available: "2012-07"
-5741	mediocre high-proof water purification pills	9	decent	Last Available: "2012-07"
+5741	high-proof mediocre water purification pills	9	decent	Last Available: "2012-07"
 5742	wobbly Camp Scout pup tent	0		Last Available: "2012-07"
 5743	bad wobbly CSA scoutmaster's &quot;water&quot;	4	decent	Last Available: "2012-07"
-5744	adequate small bag of GORF	2	good	Last Available: "2012-07"
+5744	small adequate bag of GORF	2	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	normal shaking bag of QWOP	3	good	Last Available: "2012-07"
 5747	electrified adjusted CSA bravery badge	0		Effect: "Mmmmmelon", Effect Duration: 24, Last Available: "2012-07"
@@ -5652,9 +5652,9 @@
 5751	Tales of the Word Realms	0		
 5752	gigantic adequate crappy brain	7	good	
 5753	bland olive decent brain	4	decent	
-5754	diet flavorless good brain	1	decent	
+5754	flavorless diet good brain	1	decent	
 5755	miniature normal boss brain	2	good	
-5756	spoiled low-calorie ghostly hunter brain	1	crappy	
+5756	low-calorie spoiled ghostly hunter brain	1	crappy	
 5758	huge jittery smelly slick Staff of Holiday Sensations of Gandalf	0		Moxie: +10, Spell Critical Percent: +20, Stench Spell Damage: +10, Last Available: "2011-11"
 5759	shaking weightlifter's staff of horror	0		Muscle: +15, Spooky Spell Damage: +25
 5760	blue Usain Bolt's lion tamer's staff of Leguizamo	0		Monster Level: +20, Experience (familiar): +2, Initiative: +80
@@ -5665,16 +5665,16 @@
 5765	tumbling ruddy padded fuzzy earmuffs	0		Damage Absorption: +20, Maximum HP Percent: +40, Familiar Effect: "1.5xVolley, cap 32"
 5766	greedy energetic arcane researcher's fuzzy montera	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Meat Drop: +20, Familiar Effect: "1.5xVolley, cap 32"
 5767	olive Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	huge red gnomish swimmer's ears	0		Familiar Effect: "underwater", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
-5770	shaking gnomish tennis elbow	0		Familiar Effect: "damage", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5768	red huge gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	shaking gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	upside-down Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	blinking fronts	0		Familiar Weight: +5
 5776	olive foul-smelling Herculean Barney's rake	0		Experience (Muscle): +1, Stench Damage: +10
-5778	gigantic flavorless idiot brain	8	decent	
+5778	flavorless gigantic idiot brain	8	decent	
 5779	purple rock-hard keel-haulin' knife	0		Damage Reduction: 5
 5780	upside-down rosy-cheeked ice cream scoop	0		Maximum HP Percent: +30
 5781	triple-distilled drinkable soft echo eyedrop antidote martini	6	good	
@@ -5691,7 +5691,7 @@
 5792	foul-smelling sharpshooter's wicked left bear arm	0		Spell Damage: +5, Critical Hit Percent: +10, Stench Damage: +10, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	maroon Jeselnik's Hat O' Nine Tails	0		Sleaze Damage: +25
 5794	tarnished quantum green Enchanted Plunger	0		Effect: "Fudge Headache", Effect Duration: 66
-5795	adjusted blinking lime green Enchanted Flyswatter	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 44
+5795	adjusted lime green blinking Enchanted Flyswatter	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 44
 5796	denatured dry Gearhead Goo	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 21
 5797	magnetized anodized Missing Eye Simulation Device	0		Effect: "Flaming Weapon", Effect Duration: 66
 5798	double-boiled twirling Gnollish Crossdress	0		Effect: "Pasty", Effect Duration: 46
@@ -5707,14 +5707,14 @@
 5808	aerosolized liquefied olive glass of gnat milk	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 14
 5809	triple-colloidal jittery Knob Goblin Mutagen	0		Effect: "Weepy, Creepy", Effect Duration: 47
 5810	non-vacuum-sealed polarized Tears of the Quiet Healer	0		Effect: "Indescribable Flavor", Effect Duration: 38
-5811	double-pressed unsweetened wobbly fuchsia tube of lipstick	0		Effect: "Pronounced Potency", Effect Duration: 49
-5812	boiled colloidal fuchsia narrow skelelton spine	0		Effect: "Ermine Eyes", Effect Duration: 50
+5811	double-pressed unsweetened fuchsia wobbly tube of lipstick	0		Effect: "Pronounced Potency", Effect Duration: 49
+5812	boiled colloidal narrow fuchsia skelelton spine	0		Effect: "Ermine Eyes", Effect Duration: 50
 5813	diffused dry electrified bouncing smut orc sunglasses	0		Effect: "Abyssal Sweat", Effect Duration: 22
 5814	enhanced flattened pickled blob of acid	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 29
-5815	double-improved squat blue shaking flayed mind	0		Effect: "Nasty, Nasty Breath", Effect Duration: 34
+5815	double-improved shaking squat blue flayed mind	0		Effect: "Nasty, Nasty Breath", Effect Duration: 34
 5816	liquefied maroon kobold kibble	0		Effect: "Springy Fusilli", Effect Duration: 20
 5817	double-ionized skewed forest spirit rattle	0		Effect: "Frisky Spirit", Effect Duration: 44
-5818	non-magnetized denatured spinning spinning squat Stone Golem pebbles	0		Effect: "Vital", Effect Duration: 58
+5818	non-magnetized denatured spinning squat spinning Stone Golem pebbles	0		Effect: "Vital", Effect Duration: 58
 5819	aerosolized diffused gravy fairy warlock hat	0		Effect: "Stenchtastic", Effect Duration: 19
 5820	super-alkaline magnetized bull blubber	0		Effect: "Can't Smell Nothin'", Effect Duration: 24
 5821	corrupted non-enhanced huge frog lip-print	0		Effect: "Nutrient-Rich", Effect Duration: 55
@@ -5763,12 +5763,12 @@
 5864	blurry papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	super-anodized cold-filtered jittery papier-mochi	0		Effect: "Celestial Body", Effect Duration: 69, Last Available: "2012-09"
 5866	liquefied quadruple-aerosolized quantum papier-m&acirc;chaeranthera	0		Effect: "damage.enh", Effect Duration: 35, Last Available: "2012-09"
-5867	altered warmed shaking blinking papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 63, Last Available: "2012-09"
+5867	altered warmed blinking shaking papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 63, Last Available: "2012-09"
 5868	bouncing lime green slick papier-m&acirc;ch&eacute;te of wisdom	0		Mysticality: +15, Moxie: +10, Last Available: "2012-09"
 5869	medical-grade papier-m&acirc;chine gun of the brazier	0		Hot Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-09"
 5870	gravedigger's friendly papier-masque	0		Familiar Weight: +3, Spooky Damage: +10, Single Equip, Last Available: "2012-09"
-5871	twirling toasty deadly papier-mitre	0		Weapon Damage: +5, Hot Damage: +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	Temple Grandin's papier-m&acirc;churidars of the businessman	0		Familiar Weight: +7, Meat Drop: +50, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	twirling toasty deadly papier-mitre	0		Weapon Damage: +5, Hot Damage: +5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	Temple Grandin's papier-m&acirc;churidars of the businessman	0		Familiar Weight: +7, Meat Drop: +50, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	tumbling papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5793,7 +5793,7 @@
 5894	red Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	spinning avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	shaking canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
-5897	pickled twirling tumbling Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
+5897	pickled tumbling twirling Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	tumbling maroon jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	narrow ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	maroon BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	dog trainer's brainwave-controlled unicorn horn	0		Experience (familiar): +1, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
+5928	dog trainer's brainwave-controlled unicorn horn	0		Experience (familiar): +1, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	olive bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	Oprah's plastic four-shadowed mime of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Initiative: +60, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	veiny plastic Father McGruber	0		Maximum HP: +10, Last Available: "2012-12"
 5961	censurious plastic Hank North, Photojournalist	0		Sleaze Resistance: +3, Last Available: "2012-12"
 5962	skewed brawny plastic blazing bat	0		Muscle Percent: +20, Last Available: "2012-12"
-5963	blinking Rosewater's weightlifter's electronic dulcimer pants	0		Muscle: +15, Mysticality Percent: +30, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
+5963	blinking Rosewater's weightlifter's electronic dulcimer pants	0		Muscle: +15, Mysticality Percent: +30, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	supercool Frown Exerciser of Flo-Jo	0		Moxie Percent: +20, Initiative: +100, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5877,9 +5877,9 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	tumbling star	0		Last Available: "2013-02"
-5982	practically non-alcoholic delicious tankard of ale	1	awesome	Last Available: "2013-02"
+5982	delicious practically non-alcoholic tankard of ale	1	awesome	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	wobbly prompt zippy wizardly cloth cap	0		Mysticality: +25, Initiative: +20, Adventures: +3, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	wobbly prompt zippy wizardly cloth cap	0		Mysticality: +25, Initiative: +20, Adventures: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	extremely unsafe Samson's sage iron dagger	0		Mysticality Percent: +10, Experience (Muscle): +5, Weapon Damage Percent: +100, Last Available: "2013-02"
 5986	rotten hamburger	4	crappy	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	potion	0		Last Available: "2013-02"
 5990	smooth practically non-alcoholic bottle of wine	1	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	Temple Grandin's resourceful iron helmet of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +50, Familiar Weight: +7, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	Temple Grandin's resourceful iron helmet of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +50, Familiar Weight: +7, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	skewed scandalous grievous steel sword of Flo-Jo	0		Weapon Damage Percent: +50, Sleaze Damage: +5, Initiative: +100, Last Available: "2013-02"
-5994	low-calorie stale pulsating whole roasted chicken	1	decent	Last Available: "2013-02"
+5994	stale low-calorie pulsating whole roasted chicken	1	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	shaking potion	0		Last Available: "2013-02"
-5998	drinkable watered-down shining goblet	2	good	Last Available: "2013-02"
+5998	watered-down drinkable shining goblet	2	good	Last Available: "2013-02"
 5999	blurry fireball	0		Last Available: "2013-02"
-6000	lime green greasy crown of James Dean of vim and vigor	0		Experience (Moxie): +3, Maximum HP Percent: +50, Sleaze Spell Damage: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	lime green greasy crown of James Dean of vim and vigor	0		Experience (Moxie): +3, Maximum HP Percent: +50, Sleaze Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	wobbly Van der Graaf studded sword of the boozehound	0		Damage Absorption: +80, Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-02"
-6002	medical-grade smooth Helm of the Scream Emperor of the storm	0		Moxie: +15, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	medical-grade smooth Helm of the Scream Emperor of the storm	0		Moxie: +15, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	supercharged Samson's Cloak of Dire Shadows of the brazier	0		Experience (Muscle): +5, Maximum MP Percent: +30, Hot Spell Damage: +25, Last Available: "2013-02"
 6004	wholesome Sword of Dark Omens of vim and vigor of the blizzard	0		Maximum HP Percent: 60, Cold Spell Damage: +25, Last Available: "2013-02"
 6005	vibrating rock-hard Shield of Icy Fate of dire peril	0		Weapon Damage: +20, Damage Reduction: 12, Maximum MP Percent: +10, Last Available: "2013-02"
-6006	skewed toasty Tesla Oprah's Greaves of the Murk Lord	0		Maximum MP Percent: +50, Hot Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	skewed toasty Tesla Oprah's Greaves of the Murk Lord	0		Maximum MP Percent: +50, Hot Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	shaking sizzling friendly Gauntlets of the Blood Moon of the sewer	0		Familiar Weight: +3, Hot Damage: +10, Stench Damage: +25, Single Equip, Last Available: "2013-02"
 6008	mirror gravedigger's Herculean Boots of Twilight Whispers of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Spooky Damage: +10, Single Equip, Last Available: "2013-02"
 6009	sharpshooter's curative savvy Belt of Howling Anger	0		Mysticality Percent: +20, Critical Hit Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-02"
@@ -5910,10 +5910,10 @@
 6012	purple freshwater pearl necklace of the detective	0		Item Drop: +20
 6013	red friendly deadly orcish stud-finder	0		Weapon Damage: +5, Familiar Weight: +3
 6014	savvy screwing pooch	0		Mysticality Percent: +20
-6015	pressed bouncing blinking orcish hand lotion	0		Effect: "Influence of Sphere", Effect Duration: 46
+6015	pressed blinking bouncing orcish hand lotion	0		Effect: "Influence of Sphere", Effect Duration: 46
 6016	tarnished tarnished flattened orcish rubber	0		Effect: "Stick Emporium Membership", Effect Duration: 39
 6017	extra-anodized orcish nailing lube	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 38
-6018	tolerable weak backwoods screwdriver	2	good	
+6018	weak tolerable backwoods screwdriver	2	good	
 6019	spinning groovy loadstone	0		Moxie Percent: +10
 6020	Lo Pan's Claybender glasses of the pedagogue	0		Experience: +3, Spell Critical Percent: +30, Single Equip
 6021	Sherlock's Duskwalker fangs of the businessman	0		Item Drop: +25, Meat Drop: +50
@@ -5931,7 +5931,7 @@
 6033	foul-smelling razor-sharp stolen necklace	0		Weapon Damage Percent: +25, Stench Damage: +10
 6034	lightning-fast cool troll britches	0		Moxie: +5, Initiative: +40, Familiar Effect: "1.5xPotato, cap 28"
 6035	frozen skewed vial of The Glistening	0		Effect: "Moon'd", Effect Duration: 61
-6036	triple-distilled smooth artisanal limoncello	10	awesome	
+6036	smooth triple-distilled artisanal limoncello	10	awesome	
 6037	ginger ale	0		
 6038	flavorless jittery incredible pizza	3	decent	
 6039	jittery curative oil cap of chilblains	0		Cold Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "cap 28"
@@ -5941,7 +5941,7 @@
 6043	bouncing boid	0		
 6044	pulsating woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	fuchsia tumbling BittyCar SoulCar	0		Last Available: "2012-12"
+6046	tumbling fuchsia BittyCar SoulCar	0		Last Available: "2012-12"
 6047	curative hardy Misty Cloak	0		Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5
 6048	twirling yellow gravedigger's scorching Misty Robe	0		Hot Damage: +25, Spooky Damage: +10
 6049	lightning-fast therapeutic arcane researcher's Misty Cape	0		Experience Percent (Mysticality): +10, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7
@@ -5972,13 +5972,13 @@
 6074	warmed anodized quantum huge magicberry tablets	0		Effect: "Fungal Flambé", Effect Duration: 35, Last Available: "2012-12"
 6075	magnetized ghostly 37x37x37 puzzle cube	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 47, Last Available: "2012-12"
 6076	tolerable tumbling McLeod's Hard Haggis-Ade	3	good	Last Available: "2012-12"
-6077	half-sized spoiled haggis-wrapped haggis-stuffed haggis	2	crappy	Last Available: "2012-12"
+6077	spoiled half-sized haggis-wrapped haggis-stuffed haggis	2	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	skewed school calculator watch	0		Last Available: "2012-12"
 6080	chaotic haggis socks	0		Spell Critical Percent: +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
 6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
-6083	fuchsia tumbling actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
+6083	tumbling fuchsia actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
 6086	squat blurry MacGyver's Microplushie: Otakulone	0		Maximum MP: +100, Last Available: "2012-12"
@@ -6014,7 +6014,7 @@
 6116	mirror CEO office card	0		Last Available: "2013-12"
 6117	upside-down test site key	0		Last Available: "2013-12"
 6118	squat goggles	0		Last Available: "2013-12"
-6119	upside-down blurry abacus	0		Last Available: "2013-12"
+6119	blurry upside-down abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
 6121	smooth Chinese beer	3	awesome	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
@@ -6040,13 +6040,13 @@
 6142	half-sized tasty blue roasted duck	2	awesome	Last Available: "2013-12"
 6143	flavorless dead meat bun	3	decent	Last Available: "2013-12"
 6144	resourceful cat collar	0		Maximum MP: +50, Single Equip, Last Available: "2013-12"
-6145	ghostly miser's mansplainer's suspicious-looking fedora	0		Monster Level: +15, Meat Drop: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	ghostly miser's mansplainer's suspicious-looking fedora	0		Monster Level: +15, Meat Drop: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	gray Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	gray Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	huge carrot nose	0		Last Available: "2013-01"
-6152	spoiled small carrot cake	2	crappy	Last Available: "2013-01"
+6152	small spoiled carrot cake	2	crappy	Last Available: "2013-01"
 6153	delicious jittery carrot claret	3	awesome	Last Available: "2013-01"
 6154	denatured ghostly carrot juice	1	decent	Effect: "Hobo Flavor", Effect Duration: 20, Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
@@ -6058,12 +6058,12 @@
 6161	huge ruddy regret hose	0		Maximum HP Percent: +40, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	spinning aromatic wool commodore's hat	0		Cold Resistance: +1, Stench Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	Rosewater's naval trousers	0		Mysticality Percent: +30, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	spinning aromatic wool commodore's hat	0		Cold Resistance: +1, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	Rosewater's naval trousers	0		Mysticality Percent: +30, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	bouncing avaricious cool deck cannon	0		Moxie: +5, Meat Drop: +30, Last Available: "2013-12"
 6167	quilted ornamental sextant	0		Damage Absorption: +40, Last Available: "2013-12"
 6168	twirling rosy-cheeked Bloodbath of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +30, Last Available: "2013-12"
-6169	artisanal weak Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
+6169	weak artisanal Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
 6170	bland chum	3	decent	Last Available: "2013-12"
 6171	extra-wet warmed spinning crude crudit&eacute;s	0		Effect: "Burning Ears", Effect Duration: 26
 6172	ionized polymerized candy crayons	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 41, Last Available: "2020-09"
@@ -6080,43 +6080,43 @@
 6183	blurry cosmic fruit	0		
 6184	sizzling smooth Jarlsberg's hat of the scaredy-cat	0		Moxie: +15, Monster Level: -15, Hot Damage: +10
 6185	yummy enchanted consummate hard-boiled egg	3	awesome	Effect: "Healthy Green Glow", Effect Duration: 10
-6186	massive enchanted toothsome consummate fried egg	8	awesome	Effect: "Libra Rising", Effect Duration: 30
-6187	spoiled diet consummate egg salad	1	crappy	
+6186	massive toothsome enchanted consummate fried egg	8	awesome	Effect: "Libra Rising", Effect Duration: 30
+6187	diet spoiled consummate egg salad	1	crappy	
 6188	stale diet consummate bagel	1	decent	
 6189	super-sized flavorless shaking consummate sliced bread	5	decent	
 6190	small adequate wobbly consummate hot dog bun	2	good	
 6191	thick spoiled tumbling consummate brownie	5	crappy	
-6192	jumbo adequate consummate toast	5	good	
-6193	weak tolerable passable stout	2	good	
+6192	adequate jumbo consummate toast	5	good	
+6193	tolerable weak passable stout	2	good	
 6194	rotten pulsating consummate soup	3	crappy	
-6195	adequate bite-sized maroon consummate corn chips	1	good	
-6196	small bland consummate salad	2	decent	
-6197	spoiled half-sized lime green consummate salsa	2	crappy	
-6198	stale half-sized teal pulsating consummate sauerkraut	2	decent	
+6195	bite-sized adequate maroon consummate corn chips	1	good	
+6196	bland small consummate salad	2	decent	
+6197	half-sized spoiled lime green consummate salsa	2	crappy	
+6198	half-sized stale teal pulsating consummate sauerkraut	2	decent	
 6199	rotten consummate cheese slice	4	crappy	
 6200	half-sized flavorless consummate melted cheese	2	decent	
 6201	flavorless spinning consummate bacon	4	decent	
 6202	rotten green consummate meatloaf	4	crappy	
 6203	delicious consummate steak	3	awesome	
 6204	thick stale consummate cuts	5	decent	
-6205	bland massive green consummate frankfurter	10	decent	
+6205	massive bland green consummate frankfurter	10	decent	
 6206	stale consummate french fries	3	decent	
 6207	moldy twirling consummate baked potato	4	crappy	
 6208	smooth high-proof acceptable vodka	8	awesome	
 6209	moldy snack-sized consummate ice cream	2	crappy	
-6210	special bland bite-sized twirling fuchsia consummate whipped cream	1	decent	Effect: "Smugness", Effect Duration: 20
+6210	bland bite-sized special fuchsia twirling consummate whipped cream	1	decent	Effect: "Smugness", Effect Duration: 20
 6211	rotten consummate cream	4	crappy	
 6212	rotten special consummate strawberries	3	crappy	Effect: "Initiative and Let Die", Effect Duration: 35
-6213	fancy yummy bite-sized shaking shaking consummate sorbet	1	awesome	Effect: "Petit Force", Effect Duration: 5
+6213	bite-sized fancy yummy shaking shaking consummate sorbet	1	awesome	Effect: "Petit Force", Effect Duration: 5
 6214	lousy practically non-alcoholic adequate rum	1	decent	
 6215	artisanal mediocre lager	3	EPIC	
-6216	bland pulsating red immaculate grilled cheese	3	decent	
+6216	bland red pulsating immaculate grilled cheese	3	decent	
 6217	decent immaculate ice cream sandwich	3	good	
 6218	adequate immaculate hot dog	4	good	
-6219	normal tiny immaculate egg salad sandwich	1	good	
-6220	normal special perfect sandwich	3	good	Effect: "Beastly Flavor", Effect Duration: 25
+6219	tiny normal immaculate egg salad sandwich	1	good	
+6220	special normal perfect sandwich	3	good	Effect: "Beastly Flavor", Effect Duration: 25
 6221	rotten perfect chef salad	4	crappy	
-6222	rotten super-sized perfect breakfast	5	crappy	
+6222	super-sized rotten perfect breakfast	5	crappy	
 6223	flavorless sublime deluxe hot dog	3	decent	
 6224	stale huge sublime stew	3	decent	
 6225	gigantic decent sublime nachos	9	good	
@@ -6125,11 +6125,11 @@
 6228	moldy thick Omega Sundae	5	crappy	
 6229	delicious shaking Das Sauerlager	3	awesome	
 6230	practically non-alcoholic smooth Bologna Lambic	1	awesome	
-6231	watered-down lousy Vodka Dog	2	decent	
-6232	drinkable practically non-alcoholic purple Disappointed Russian	1	good	
+6231	lousy watered-down Vodka Dog	2	decent	
+6232	practically non-alcoholic drinkable purple Disappointed Russian	1	good	
 6233	acceptable fuchsia blinking Chunky Mary	4	good	
 6234	hand-crafted jittery Nachojito	3	EPIC	
-6235	mediocre enchanted pulsating Le Roi	3	decent	Effect: "Some Cheese with Your Wine", Effect Duration: 50
+6235	enchanted mediocre pulsating Le Roi	3	decent	Effect: "Some Cheese with Your Wine", Effect Duration: 50
 6236	fortified mediocre Over Easy Rider	5	decent	
 6237	upside-down cosmic six-pack	0		
 6239	ionized galvanized cube of ectoplasm	0		Effect: "Outer Wolf&trade;", Effect Duration: 55
@@ -6169,7 +6169,7 @@
 6273	magnetized magnetized upside-down O'RLY manual	0		Effect: "Jittery", Effect Duration: 37
 6274	bad weak open sauce	2	decent	
 6275	olive wool sharpshooter's turkey leg	0		Critical Hit Percent: +10, Cold Resistance: +1
-6276	watered-down mediocre spinning Ye Olde Meade	2	decent	
+6276	mediocre watered-down spinning Ye Olde Meade	2	decent	
 6277	frozen anodized Ye Olde Bawdy Limerick	0		Effect: "Chief Executive Optimism", Effect Duration: 26
 6278	Ye Olde Medieval Insult	0		
 6279	tumbling pewter claymore of chilblains	0		Cold Damage: +25
@@ -6182,7 +6182,7 @@
 6286	family-friendly Da Vinci's Mark II Steam-Hat of horror	0		Experience (Mysticality): +5, Spooky Spell Damage: +25, Sleaze Resistance: +1, Familiar Effect: "1xLep, cap 37"
 6287	tumbling blue Socratic brawny Mark III Steam-Hat of the wise owl of the sewer	0		Mysticality: +20, Muscle Percent: +20, Experience (Mysticality): +1, Stench Damage: +25, Familiar Effect: "1xLep, cap 37"
 6288	flame-wreathed curative Mark IV Steam-Hat of wisdom of the pedagogue of the cheetah	0		Mysticality: +15, Experience: +3, Hot Spell Damage: +10, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
-6289	avaricious asbestos-lined Temple Grandin's sinister Mark V Steam-Hat of temperance	0		Spell Damage: +10, Familiar Weight: +7, Hot Resistance: +5, Sleaze Resistance: +5, Meat Drop: +30, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	avaricious asbestos-lined Temple Grandin's sinister Mark V Steam-Hat of temperance	0		Spell Damage: +10, Familiar Weight: +7, Hot Resistance: +5, Sleaze Resistance: +5, Meat Drop: +30, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	Usain Bolt's fortified punk rock jacket	0		Damage Absorption: +60, Initiative: +80
 6292	vibrating wholesome safety pin	0		Maximum HP Percent: +10, Maximum MP Percent: +10
@@ -6238,7 +6238,7 @@
 6342	ghostly healthy wholesome super-strong air freshener	0		Maximum HP Percent: 30
 6343	oxidized chilled spinning Mer-kin lipstick	0		Effect: "Mer-kinny Flavor", Effect Duration: 39
 6344	teal Mer-kin mouthsoap	0		
-6345	ionized activated teal pulsating Mer-kin strongjuice	0		Effect: "Corona de la Salsa", Effect Duration: 19
+6345	ionized activated pulsating teal Mer-kin strongjuice	0		Effect: "Corona de la Salsa", Effect Duration: 19
 6346	Mer-kin fitbrine	0		
 6347	magnetized Mer-kin ragejuice	0		Effect: "Sweet Nostalgia", Effect Duration: 12
 6348	pulsating Mer-kin dragbelt of the brazier	0		Hot Spell Damage: +25, Experience (Muscle): +20, Single Equip
@@ -6248,7 +6248,7 @@
 6352	miser's Mer-kin stopwatch	0		Meat Drop: +10, Initiative: +50
 6353	Mer-kin dreadscroll	0		
 6354	double-energized Mer-kin smartjuice	0		Effect: "Old Time Hydration", Effect Duration: 24
-6355	irradiated fuchsia twirling Mer-kin cooljuice	0		Effect: "Human-Elf Hybrid", Effect Duration: 54
+6355	irradiated twirling fuchsia Mer-kin cooljuice	0		Effect: "Human-Elf Hybrid", Effect Duration: 54
 6356	twirling Mer-kin worktea	0		
 6357	blurry shaking teal Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
@@ -6257,15 +6257,15 @@
 6361	triple-tarnished tumbling tumbling pulled taffy	0		Effect: "Techno Bliss", Effect Duration: 13, Last Available: "2013-04"
 6362	activated activated bouncing pulled indigo taffy	0		Effect: "Slimily Strong", Effect Duration: 47, Last Available: "2013-04"
 6363	unsweetened pulled taffy	0		Effect: "Crusty Head", Effect Duration: 56, Last Available: "2013-04"
-6364	warmed electrified ghostly spinning pulled taffy	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33, Last Available: "2013-04"
+6364	warmed electrified spinning ghostly pulled taffy	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33, Last Available: "2013-04"
 6365	dry extra-tarnished pulled taffy	0		Effect: "El Vibrations", Effect Duration: 17, Last Available: "2013-04"
 6366	chilled blurry pulled violet taffy	0		Effect: "Super Structure", Effect Duration: 50, Last Available: "2013-04"
 6367	quantum polarized blinking pulled taffy	0		Effect: "Vented Spleen", Effect Duration: 66, Last Available: "2013-04"
-6368	bouncing ghostly Mer-kin hallpass	0		
+6368	ghostly bouncing Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	perfectly mixed watered-down huge can of the cheapest beer	2	EPIC	
-6372	perfectly mixed practically non-alcoholic wobbly tumbling bottle of fruity &quot;wine&quot;	1	EPIC	
+6371	watered-down perfectly mixed huge can of the cheapest beer	2	EPIC	
+6372	perfectly mixed practically non-alcoholic tumbling wobbly bottle of fruity &quot;wine&quot;	1	EPIC	
 6373	delicious practically non-alcoholic single swig of vodka	1	awesome	
 6374	spinning angry inch	0		
 6375	wholesome testy toolbox	0		Maximum HP Percent: +10
@@ -6288,7 +6288,7 @@
 6393	modified tarnished teal comb jelly	0		Effect: "Human-Machine Hybrid", Effect Duration: 68
 6394	anemone sauce	0		
 6395	huge inky squid sauce	0		
-6396	blinking wobbly blurry Mer-kin weaksauce	0		
+6396	wobbly blurry blinking Mer-kin weaksauce	0		
 6397	red peanut sauce	0		
 6398	glass	0		
 6399	unsweetened ionized tumbling Boss Drops	0		Effect: "Pyromania", Effect Duration: 63
@@ -6392,7 +6392,7 @@
 6497	eau de mort	0		
 6498	drinkable bloody kiwitini	3	good	
 6499	skewed moon-amber	0		
-6500	maroon mirror polished moon-amber	0		
+6500	mirror maroon polished moon-amber	0		
 6501	mirror scandalous smartaleck's moon-amber necklace of bravery	0		Moxie Percent: +30, Sleaze Damage: +5, Spooky Resistance: +5, Single Equip
 6502	maroon Dreadsylvanian seed pod	0		
 6503	ghost pencil	0		
@@ -6448,21 +6448,21 @@
 6554	blinking stench cluster	0		
 6555	sleaze cluster	0		
 6556	anodized mirror phial of hotness	0		Effect: "Egg-stortionary Tactics", Effect Duration: 37
-6557	oxidized polymerized ghostly twirling green phial of coldness	0		Effect: "Amplified Fabulousness", Effect Duration: 55
+6557	oxidized polymerized twirling green ghostly phial of coldness	0		Effect: "Amplified Fabulousness", Effect Duration: 55
 6558	moist nitrogenated phial of spookiness	0		Effect: "Halloweeny", Effect Duration: 13
 6559	corrupted corrupted quantum phial of stench	0		Effect: "Poker Faced", Effect Duration: 68
 6560	tarnished improved phial of sleaziness	0		Effect: "It's Electric!", Effect Duration: 35
 6561	narrow adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	narrow mini-Mr. Accessory	0		Familiar Weight: +5
 6563	bouncing healthy hand of Mr. Cards	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	snack-sized fancy adequate Dreadsylvanian hot pocket	2	good	Effect: "Polar Express", Effect Duration: 10
-6565	flavorless bite-sized mirror Dreadsylvanian pocket	1	decent	
-6566	fancy tasty ghostly maroon Dreadsylvanian pocket	4	awesome	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
+6564	adequate fancy snack-sized Dreadsylvanian hot pocket	2	good	Effect: "Polar Express", Effect Duration: 10
+6565	bite-sized flavorless mirror Dreadsylvanian pocket	1	decent	
+6566	tasty fancy maroon ghostly Dreadsylvanian pocket	4	awesome	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
 6567	moldy Dreadsylvanian stink pocket	3	crappy	
-6568	stale huge mirror Dreadsylvanian sleaze pocket	6	decent	
+6568	huge stale mirror Dreadsylvanian sleaze pocket	6	decent	
 6569	acceptable pulsating Dreadsylvanian hot toddy	4	good	
 6570	practically non-alcoholic bad Dreadsylvanian cold-fashioned	1	decent	
-6571	triple-distilled drinkable blinking mirror Dreadsylvanian grimlet	10	good	
+6571	drinkable triple-distilled blinking mirror Dreadsylvanian grimlet	10	good	
 6572	tolerable upside-down Dreadsylvanian dank and stormy	3	good	
 6573	artisanal Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
@@ -6473,8 +6473,8 @@
 6579	narrow Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	dreadful box	0		
-6582	pulsating upside-down Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	maroon twirling vicious spiked collar	0		Familiar Damage: +20
+6582	upside-down pulsating Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
+6583	twirling maroon vicious spiked collar	0		Familiar Damage: +20
 6584	hot dog wrapper of horror	0		Spooky Spell Damage: +25
 6585	wobbly pulsating stanky scorching debonair deboner	0		Hot Damage: +25, Stench Spell Damage: +25
 6586	vacuum-sealed upside-down chicle de salchicha	0		Effect: "Afternoon Insight", Effect Duration: 23
@@ -6521,7 +6521,7 @@
 6627	folder (D-Team)	0		Last Available: "2013-08"
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
-6630	wobbly blurry folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
+6630	blurry wobbly folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	lime green folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	folder (barbarian)	0		Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	triple-boiled triple-frozen upside-down Ogres and Oubliettes&trade; module	0		Effect: "Far Out", Effect Duration: 20
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	perfectly mixed high-proof stepmom's booze	7	EPIC	
+6652	high-proof perfectly mixed stepmom's booze	7	EPIC	
 6653	surgical tape	0		
 6654	twirling energetic band T-shirt	0		Maximum MP Percent: +20
 6655	artisanal fountain 'soda'	3	EPIC	
@@ -6558,18 +6558,18 @@
 6666	mirror eraser	0		
 6667	quasireligious sculpture	0		
 6668	Faraday cage	0		
-6669	olive squat tumbling modeling claymore	0		
+6669	squat olive tumbling modeling claymore	0		
 6670	wobbly clay homunculus	0		
 6671	aerosolized quadruple-tarnished sodium pentasomething	0		Effect: "All Glory To the Toad", Effect Duration: 18
 6672	grains of salt	0		
 6673	yellowcake bomb	0		
 6674	mirror stinkbomb	0		
-6675	flattened polymerized wobbly fuchsia superwater	0		Effect: "Sweet Nostalgia", Effect Duration: 30
+6675	flattened polymerized fuchsia wobbly superwater	0		Effect: "Sweet Nostalgia", Effect Duration: 30
 6676	Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	tumbling auspicious Yearbook Club Camera	0		Item Drop: +10, Conditional Skill (Equipped): "Blinding Flash"
 6679	machete of the blizzard	0		Cold Spell Damage: +25
-6680	watered-down tolerable Cursed Punch	2	good	
+6680	tolerable watered-down Cursed Punch	2	good	
 6681	practically non-alcoholic aged Bowl of Scorpions	1	awesome	
 6682	lousy weak ghostly Fog Murderer	2	decent	
 6683	skewed book of matches	0		
@@ -6581,7 +6581,7 @@
 6689	McClusky file (page 1)	0		
 6690	McClusky file (page 2)	0		
 6691	huge McClusky file (page 3)	0		
-6692	maroon shaking McClusky file (page 4)	0		
+6692	shaking maroon McClusky file (page 4)	0		
 6693	pulsating McClusky file (page 5)	0		
 6694	boring binder clip	0		
 6695	McClusky file (complete)	0		
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	upside-down imitation White Russian	1	good	
 6704	educational short-handled mop of the detective	0		Experience: +1, Item Drop: +20
-6705	yummy snack-sized jungle floor wax	2	awesome	
+6705	snack-sized yummy jungle floor wax	2	awesome	
 6706	smirking shrunken head	0		
 6707	aerosolized triple-irradiated improved jittery blurry colorful toad	0		Effect: "Gummiheart", Effect Duration: 49
 6708	crude voodoo doll	0		
@@ -6619,7 +6619,7 @@
 6727	tropical island souvenir crate	0		
 6728	bouncing ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
-6730	huge blue bouncing funky junk key	0		
+6730	blue bouncing huge funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	narrow spinning claw-foot bathtub	0		
 6733	clothesline pole	0		
@@ -6628,7 +6628,7 @@
 6736	Junk-Bond	0		
 6737	yellow tangle of copper wire	0		
 6738	jagged scrap	0		
-6739	adjusted blurry upside-down bent scrap	0		Effect: "Mushroom Magicalness", Effect Duration: 19
+6739	adjusted upside-down blurry bent scrap	0		Effect: "Mushroom Magicalness", Effect Duration: 19
 6740	blue molten scrap	0		
 6741	cyan eternal car battery	0		
 6742	arcane researcher's junk band	0		Experience Percent (Mysticality): +10
@@ -6650,15 +6650,15 @@
 6758	delicious can of Drooling Monk	3	awesome	Last Available: "2013-09"
 6759	hand-crafted irresponsibly strong bouncing can of Impetuous Scofflaw	7	EPIC	Last Available: "2013-09"
 6760	perfectly mixed narrow bottle of Old Pugilist	3	EPIC	Last Available: "2013-09"
-6761	triple-distilled drinkable bottle of Professor Beer	8	good	Last Available: "2013-09"
+6761	drinkable triple-distilled bottle of Professor Beer	8	good	Last Available: "2013-09"
 6762	acceptable skewed bottle of Rapier Witbier	3	good	Last Available: "2013-09"
-6763	drinkable high-proof blinking bottle of Race Car Red	7	good	Last Available: "2013-09"
+6763	high-proof drinkable blinking bottle of Race Car Red	7	good	Last Available: "2013-09"
 6764	lousy bottle of Greedy Dog	4	decent	Last Available: "2013-09"
 6765	lousy fuchsia bottle of Lambada Lambic	3	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	huge liquid bread	1	crappy	Last Available: "2013-09"
-6769	cool tin tam of the brute of chilblains	0		Moxie: +5, Muscle Percent: +30, Cold Damage: +25, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	cool tin tam of the brute of chilblains	0		Moxie: +5, Muscle Percent: +30, Cold Damage: +25, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	improved fuchsia tin cup	0		Effect: "Fudge Headache", Effect Duration: 13, Last Available: "2013-09"
 6771	family-friendly beefy tin foil of the pedagogue	0		Muscle: +10, Experience: +3, Sleaze Resistance: +1, Last Available: "2013-09"
 6772	knitted gravedigger's personal trainer's tin drum	0		Experience Percent (Muscle): +10, Spooky Damage: +10, Cold Resistance: +3, Last Available: "2013-09"
@@ -6686,7 +6686,7 @@
 6797	tarnished disco horoscope (Aries)	0		Effect: "Boilermade", Effect Duration: 48
 6798	polymerized disco horoscope (Taurus)	0		Effect: "Crimbo Flavor", Effect Duration: 12
 6799	magnetized warmed upside-down disco horoscope (Gemini)	0		Effect: "Blessing of Charcoatl", Effect Duration: 20
-6800	triple-magnetized yellow pulsating disco horoscope (Cancer)	0		Effect: "Good Karma", Effect Duration: 65
+6800	triple-magnetized pulsating yellow disco horoscope (Cancer)	0		Effect: "Good Karma", Effect Duration: 65
 6801	diffused disco horoscope (Leo)	0		Effect: "White Blooded", Effect Duration: 11
 6802	dry concentrated disco horoscope (Virgo)	0		Effect: "Abyssal Sweat", Effect Duration: 33
 6803	dry Vulcanized mirror disco horoscope (Libra)	0		Effect: "Think Win-Lose", Effect Duration: 21
@@ -6723,10 +6723,10 @@
 6834	moist spinning box of Dweebs	0		Effect: "Heal Thy Nanoself", Effect Duration: 57
 6835	aerosolized anodized bag of W&Ws	0		Effect: "Elvish", Effect Duration: 50
 6836	wet tumbling PEEZ dispenser	0		Effect: "The Two-Prong Crown", Effect Duration: 42
-6837	warmed green spinning Swizzler	0		Effect: "Stinkybeard", Effect Duration: 38
+6837	warmed spinning green Swizzler	0		Effect: "Stinkybeard", Effect Duration: 38
 6838	electrified pressed Bugbearclaw Donut	0		Effect: "Vitamin-Maxed", Effect Duration: 24
 6839	anodized oxidized jam	0		Effect: "Stinking Cloud", Effect Duration: 64
-6840	dry squat blue Whenchamacallit bar	0		Effect: "You Know When to Walk Away", Effect Duration: 18
+6840	dry blue squat Whenchamacallit bar	0		Effect: "You Know When to Walk Away", Effect Duration: 18
 6841	alkaline activated 8-bit banana	0		Effect: "Filled with Magic", Effect Duration: 36
 6842	wet alkaline shaking vial of blood simple syrup	0		Effect: "On the Shoulders of Giants", Effect Duration: 52
 6843	nitrogenated bone bons	0		Effect: "Salamanderenity", Effect Duration: 46
@@ -6746,14 +6746,14 @@
 6857	Cajun accordion of Calamity Jane	0		Critical Hit Percent: +15, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	bouncing wizardly quirky accordion	0		Mysticality: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	sage wizardly Skipper's accordion	0		Mysticality: +25, Mysticality Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	jittery asbestos-lined wool veiny smooth Pantsgiving	0		Moxie: +15, Maximum HP: +10, Cold Resistance: +1, Hot Resistance: +5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
+6860	jittery asbestos-lined wool veiny smooth Pantsgiving	0		Moxie: +15, Maximum HP: +10, Cold Resistance: +1, Hot Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	miniature moldy can of sardines	2	crappy	Last Available: "2013-11"
 6862	normal massive high-calorie sugar substitute	6	good	Last Available: "2013-11"
 6863	normal pat of butter	3	good	Last Available: "2013-11"
 6864	rotten shaking dinner roll	3	crappy	Last Available: "2013-11"
-6865	low-calorie yummy mashed potatoes	1	awesome	Last Available: "2013-11"
-6866	flavorless pulsating gray whole turkey leg	3	decent	Last Available: "2013-11"
-6867	flavorless jumbo deviled egg	5	decent	Last Available: "2013-11"
+6865	yummy low-calorie mashed potatoes	1	awesome	Last Available: "2013-11"
+6866	flavorless gray pulsating whole turkey leg	3	decent	Last Available: "2013-11"
+6867	jumbo flavorless deviled egg	5	decent	Last Available: "2013-11"
 6868	double-activated pulsating finger exerciser	0		Effect: "Sappy Blood", Effect Duration: 58, Last Available: "2013-11"
 6869	polymerized oxidized jittery dented spoon	0		Effect: "Vital", Effect Duration: 69, Last Available: "2013-11"
 6870	galvanized enhanced skewed love note	0		Effect: "Woad Warrior", Effect Duration: 49, Last Available: "2013-11"
@@ -6787,12 +6787,12 @@
 6898	skewed Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
 6900	tumbling experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
-6901	narrow cyan hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
+6901	cyan narrow hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	zippy scandalous flask flops	0		Sleaze Damage: +5, Initiative: +20, Single Equip
 6903	double-improved pickled nuts	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 19, Last Available: "2013-12"
 6904	modified bolts	0		Effect: "Gemini Rising", Effect Duration: 12, Last Available: "2013-12"
-6905	decent super-sized gingerbread robot	5	good	Last Available: "2013-12"
-6906	delicious low-calorie petit 4.1	1	awesome	Last Available: "2013-12"
+6905	super-sized decent gingerbread robot	5	good	Last Available: "2013-12"
+6906	low-calorie delicious petit 4.1	1	awesome	Last Available: "2013-12"
 6907	jumbo toothsome nut-shaped Crimbo cookie	5	awesome	Last Available: "2023-06"
 6908	lightning-fast plastic GORM-8	0		Initiative: +40, Last Available: "2013-12"
 6909	dog trainer's plastic warbear	0		Experience (familiar): +1, Last Available: "2013-12"
@@ -6811,28 +6811,28 @@
 6922	stale small spinning warbear warrior bread	2	decent	Last Available: "2013-12"
 6923	delicious warbear thermoregulator bread	4	awesome	Last Available: "2013-12"
 6924	perfectly mixed gray warbear feasting mead	3	EPIC	Last Available: "2013-12"
-6925	artisanal high-proof warbear bearserker mead	8	EPIC	Last Available: "2013-12"
+6925	high-proof artisanal warbear bearserker mead	8	EPIC	Last Available: "2013-12"
 6926	lousy warbear blizzard mead	4	decent	Last Available: "2013-12"
 6927	squat warbear helm fragment	0		Last Available: "2013-12"
-6928	lard-coated foul-smelling stylish warbear plain fedora	0		Moxie: +25, Stench Damage: +10, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	blurry curative warbear feathered fedora	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	chaotic deadly warbear fedora of the blizzard	0		Weapon Damage: +5, Spell Critical Percent: +10, Cold Spell Damage: +25, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	double-paned hardy warbear plain helm of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	red twirling hale warbear spiked helm	0		Maximum HP: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	Annie Oakley's Van der Graaf warbear electro-spiked helm of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	zippy extremely unsafe warbear plain ushanka of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Initiative: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	MacGyver's warbear lined ushanka	0		Maximum MP: +100, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	gray blurry nasty Van der Graaf wizardly warbear heated ushanka	0		Mysticality: +25, Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	lard-coated foul-smelling stylish warbear plain fedora	0		Moxie: +25, Stench Damage: +10, Sleaze Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	blurry curative warbear feathered fedora	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	chaotic deadly warbear fedora of the blizzard	0		Weapon Damage: +5, Spell Critical Percent: +10, Cold Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	double-paned hardy warbear plain helm of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	red twirling hale warbear spiked helm	0		Maximum HP: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	Annie Oakley's Van der Graaf warbear electro-spiked helm of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	zippy extremely unsafe warbear plain ushanka of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Initiative: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	MacGyver's warbear lined ushanka	0		Maximum MP: +100, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	gray blurry nasty Van der Graaf wizardly warbear heated ushanka	0		Mysticality: +25, Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	maroon warbear trouser fragment	0		Last Available: "2013-12"
-6938	avaricious sinister warbear party pants of incineration	0		Spell Damage: +10, Hot Spell Damage: +50, Meat Drop: +30, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	narrow smooth warbear ceremonial party pants	0		Moxie: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	stanky Rosewater's beefy warbear high festival pants	0		Muscle: +10, Mysticality Percent: +30, Stench Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	upside-down fireproof supercharged warbear battle greaves of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Hot Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	huge smooth warbear officer greaves	0		Moxie: +15, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	teal greasy boxer's warbear bearserker greaves of terror	0		Muscle Percent: +10, Spooky Spell Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	avaricious double-paned educational warbear johns	0		Experience: +1, Cold Resistance: +5, Meat Drop: +30, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	coward's warbear fleece-lined johns	0		Monster Level: -20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	Jim Carey's dangerous warbear johns of the scaredy-cat	0		Weapon Damage: +10, Monster Level: 10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	avaricious sinister warbear party pants of incineration	0		Spell Damage: +10, Hot Spell Damage: +50, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	narrow smooth warbear ceremonial party pants	0		Moxie: +15, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	stanky Rosewater's beefy warbear high festival pants	0		Muscle: +10, Mysticality Percent: +30, Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	upside-down fireproof supercharged warbear battle greaves of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Hot Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	huge smooth warbear officer greaves	0		Moxie: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	teal greasy boxer's warbear bearserker greaves of terror	0		Muscle Percent: +10, Spooky Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	avaricious double-paned educational warbear johns	0		Experience: +1, Cold Resistance: +5, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	coward's warbear fleece-lined johns	0		Monster Level: -20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	Jim Carey's dangerous warbear johns of the scaredy-cat	0		Weapon Damage: +10, Monster Level: 10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	maroon warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	sizzling warbear goggles of the scaredy-cat	0		Monster Level: -15, Hot Damage: +10, Item Drop: +5, Single Equip, Last Available: "2013-12"
 6949	baleful warbear snowblindness goggles	0		Spell Damage: +25, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	baleful warbear warscarf of dire peril of the sweet-tooth	0		Weapon Damage: +20, Spell Damage: +25, Candy Drop: +100, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	skewed warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	maroon warbear foil hat of terror	0		Spooky Spell Damage: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	maroon warbear foil hat of terror	0		Spooky Spell Damage: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	blinking Tesla warbear oil pan of the sewer	0		Stench Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	teal warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6897,7 +6897,7 @@
 7008	bland Miserable Pie	3	decent	Last Available: "2013-12"
 7009	stale fancy lime green This Charming Flan	3	decent	Effect: "Alacri Tea", Effect Duration: 45, Last Available: "2013-12"
 7010	hand-crafted irresponsibly strong Irish Coffee, English Heart	7	EPIC	Last Available: "2013-12"
-7011	watered-down drinkable Strikes Again Bigmouth	2	good	Last Available: "2013-12"
+7011	drinkable watered-down Strikes Again Bigmouth	2	good	Last Available: "2013-12"
 7012	lousy Paint A Vulgar Pitcher	3	decent	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	blurry Jeselnik's crafty personal trainer's brawny Sheila Take a Crossbow	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Maximum MP: +10, Sleaze Damage: +25, Last Available: "2013-12"
 7019	mansplainer's veiny padded razor-sharp A Light that Never Goes Out	0		Weapon Damage Percent: +25, Damage Absorption: +20, Maximum HP: +10, Monster Level: +15, Last Available: "2013-12"
 7020	reassuring greasy veiny Herculean Half a Purse	0		Experience (Muscle): +1, Maximum HP: +10, Sleaze Spell Damage: +10, Spooky Resistance: +1, Last Available: "2013-12"
-7021	ghostly gray personal trainer's groovy Hairpiece On Fire of Leguizamo of the businessman	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Monster Level: +20, Meat Drop: +50, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	blurry rosewater-soaked nasty dangerous beefcake's Vicar's Tutu	0		Muscle: +25, Weapon Damage: +10, Stench Damage: +5, Stench Resistance: +3, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	ghostly gray personal trainer's groovy Hairpiece On Fire of Leguizamo of the businessman	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Monster Level: +20, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	blurry rosewater-soaked nasty dangerous beefcake's Vicar's Tutu	0		Muscle: +25, Weapon Damage: +10, Stench Damage: +5, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	pulsating resourceful studded Hand in Glove of the scaredy-cat	0		Damage Absorption: +80, Maximum MP: +50, Monster Level: -15, Single Equip, Last Available: "2013-12"
 7024	shaking inspector's ribald Meat Tenderizer is Murder of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +10, Item Drop: +15, Class: "Seal Clubber", Last Available: "2013-12"
 7025	foul-smelling wholesome sinister Ouija Board, Ouija Board	0		Spell Damage: +10, Maximum HP Percent: +10, Stench Damage: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6921,11 +6921,11 @@
 7032	decent twirling pickled egg	3	good	
 7033	cup of lukewarm tea	1	decent	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
-7035	yellow tumbling mirror warbear box	0		Last Available: "2013-12"
+7035	mirror tumbling yellow warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	cyan warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	shaking warbear gyrocopter	0		Last Available: "2013-12"
-7039	dry green spinning warbear robo-camouflage unit	0		Effect: "Intimidating Mien", Effect Duration: 32, Last Available: "2013-12"
+7039	dry spinning green warbear robo-camouflage unit	0		Effect: "Intimidating Mien", Effect Duration: 32, Last Available: "2013-12"
 7040	olive warbear beeping telegram	0		Last Available: "2013-12"
 7041	narrow warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
@@ -6939,11 +6939,11 @@
 7050	moldy pulsating warbear gyro	3	crappy	Last Available: "2013-12"
 7051	pickled vacuum-sealed shaking recording of Rolando's Rondo of Resisto	0		Effect: "Net Tea", Effect Duration: 11, Last Available: "2013-12"
 7052	twirling warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
-7053	wobbly blue warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
+7053	blue wobbly warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	tumbling warbear drone codes	0		Last Available: "2013-12"
 7055	bland breakfast mess	3	decent	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	decent immense maroon breakfast miracle	10	good	Last Available: "2013-12"
+7057	immense decent maroon breakfast miracle	10	good	Last Available: "2013-12"
 7058	ionized Cloaca Cola Polar	0		Effect: "Sappy Blood", Effect Duration: 47, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6961,7 +6961,7 @@
 7072	stale ice harvest	3	decent	Last Available: "2014-01"
 7073	Vulcanized frost flower	0		Effect: "Mushroom Might", Effect Duration: 33, Last Available: "2014-01"
 7074	double-ionized snow cleats	0		Effect: "Takin' It Greasy", Effect Duration: 69, Last Available: "2014-01"
-7075	non-magnetized upside-down tumbling liquid ice pack	0		Effect: "Abyssal Tears", Effect Duration: 60, Last Available: "2014-01"
+7075	non-magnetized tumbling upside-down liquid ice pack	0		Effect: "Abyssal Tears", Effect Duration: 60, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	decent low-calorie snow crab	1	good	Last Available: "2014-01"
 7078	artisanal spirit-forward Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	sage snow mobile	0		Mysticality Percent: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	sage snow mobile	0		Mysticality Percent: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	blinking scorching ice bucket	0		Hot Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
 7085	snow shovel of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
 7086	steel-toed bod-ice of the blizzard of the businessman	0		Damage Reduction: 9, Cold Spell Damage: +25, Meat Drop: +50, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	blinking snow fort	0		Last Available: "2014-01"
 7090	perfectly mixed En Una Fila Tequila	4	EPIC	
 7091	Skully's hot chocolate	1	crappy	
-7092	double-paned warbear dress helmet of wisdom	0		Mysticality: +15, Cold Resistance: +5, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	double-paned warbear dress helmet of wisdom	0		Mysticality: +15, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	thinker's warbear dress bracers of the sweet-tooth	0		Mysticality: +10, Candy Drop: +100, Single Equip, Last Available: "2013-12"
-7094	beefcake's warbear dress greaves of the pedagogue	0		Muscle: +25, Experience: +3, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	medical-grade ruddy sweatband	0		Maximum HP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	twirling olive blinking asbestos-lined gym shorts of wisdom	0		Mysticality: +15, Hot Resistance: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	beefcake's warbear dress greaves of the pedagogue	0		Muscle: +25, Experience: +3, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	medical-grade ruddy sweatband	0		Maximum HP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	twirling olive blinking asbestos-lined gym shorts of wisdom	0		Mysticality: +15, Hot Resistance: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	Usain Bolt's shellacked ankleweights	0		Damage Reduction: 7, Initiative: +80, Single Equip, Last Available: "2014-12"
 7098	zippy nasty Van der Graaf supercharged sweat socks	0		Maximum MP Percent: +30, Stench Damage: +5, Initiative: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7099	jittery pint of sweat	0		Last Available: "2014-12"
@@ -6992,50 +6992,50 @@
 7103	adjusted unsweetened powder	0		Effect: "The Grass...  Is Blue...", Effect Duration: 14, Last Available: "2014-12"
 7104	wobbly wool licorice whip	0		Cold Resistance: +1, Last Available: "2014-12"
 7105	wobbly anise-flavored venom	0		Last Available: "2014-12"
-7106	irresponsibly strong smooth snakebite	8	awesome	Last Available: "2014-12"
+7106	smooth irresponsibly strong snakebite	8	awesome	Last Available: "2014-12"
 7107	skewed candy stick of the dark arts of terror	0		Spell Damage Percent: +100, Spooky Spell Damage: +10, Last Available: "2014-12"
-7108	moldy maroon twirling pecan	4	crappy	Last Available: "2014-12"
+7108	moldy twirling maroon pecan	4	crappy	Last Available: "2014-12"
 7109	moldy diet pecan pie	1	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	decent small purple candy mountain oyster	2	good	Last Available: "2014-12"
+7111	small decent purple candy mountain oyster	2	good	Last Available: "2014-12"
 7112	artisanal chocotini	3	EPIC	Last Available: "2014-12"
 7113	aromatic hardened experienced chocolate rabbit's foot	0		Experience: +2, Damage Reduction: 3, Stench Resistance: +1, Last Available: "2014-12"
 7114	spoiled tumbling candy carrot	4	crappy	Last Available: "2014-12"
 7115	half-sized rotten candy carrot cake	2	crappy	Last Available: "2014-12"
 7116	arcane researcher's carrot-on-a-stick of Flo-Jo	0		Experience Percent (Mysticality): +10, Initiative: +100, Last Available: "2014-12"
-7117	stanky occult weasel stomping pants	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	stanky occult weasel stomping pants	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	flavorless wobbly mulberry	3	decent	Last Available: "2014-12"
 7119	bad high-proof olive mulled berry wine	8	decent	Last Available: "2014-12"
 7120	green lemony scales	0		Last Available: "2014-12"
-7121	smartaleck's lemon party hat	0		Moxie Percent: +30, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	smartaleck's lemon party hat	0		Moxie Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	weightlifter's lemon shirt	0		Muscle: +15, Lasts Until Rollover, Last Available: "2014-12"
-7123	narrow censurious lemon drop trousers	0		Sleaze Resistance: +3, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	narrow censurious lemon drop trousers	0		Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	adjusted triple-moist red lemonhead caviar	0		Effect: "On Pins and Needles", Effect Duration: 64, Last Available: "2014-12"
 7125	narrow Fonzie's stylish gummi sword	0		Moxie: +25, Experience (Moxie): +1, Last Available: "2014-12"
 7126	double-dry galvanized flattened shaking small gummi fin	0		Effect: "Mint-Condition Breath", Effect Duration: 60, Last Available: "2014-12"
 7127	thinker's chocolate cow bone	0		Mysticality: +10, Last Available: "2014-12"
 7128	galvanized bouncing gummi fang	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 24, Last Available: "2014-12"
 7129	yummy leftover canap&eacute;s	3	awesome	Last Available: "2014-12"
-7130	tolerable high-proof magnum of champagne	7	good	Last Available: "2014-12"
+7130	high-proof tolerable magnum of champagne	7	good	Last Available: "2014-12"
 7131	clever banded supercool cow creamer	0		Moxie Percent: +20, Damage Absorption: +100, Maximum MP: +20, Last Available: "2014-12"
 7132	non-aerosolized colloidal Outer Wolf&trade; cologne	0		Effect: "Puzzle Fury", Effect Duration: 31, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	twirling Lo Pan's medical-grade wolf whistle	0		Spell Critical Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	moldy half-sized pulsating witch's bread	2	crappy	Last Available: "2014-12"
+7135	half-sized moldy pulsating witch's bread	2	crappy	Last Available: "2014-12"
 7136	activated witch's brew	0		Effect: "Berry Critical", Effect Duration: 69, Last Available: "2014-12"
 7137	padded witch's bra of chilblains of horror	0		Damage Absorption: +20, Cold Damage: +25, Spooky Spell Damage: +25, Last Available: "2014-12"
 7138	smooth triple-distilled jittery mid-level medieval mead	7	awesome	Last Available: "2014-12"
 7139	enhanced fuchsia R&uuml;mpelstiltz	0		Effect: "Motion", Effect Duration: 14, Last Available: "2014-12"
-7140	lime green bouncing spinning wheel	0		Last Available: "2014-12"
+7140	bouncing lime green spinning wheel	0		Last Available: "2014-12"
 7141	deionized boiled hi-octane carrot juice	0		Effect: "Wintergreen Warmongery", Effect Duration: 25, Last Available: "2014-12"
 7142	polarized alkaline warmed huge hare brush	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 21, Last Available: "2014-12"
 7143	lightning-fast auspicious hare pin	0		Item Drop: +10, Initiative: +40, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	diet flavorless cinnamon cannoli	1	decent	Last Available: "2014-12"
+7145	flavorless diet cinnamon cannoli	1	decent	Last Available: "2014-12"
 7146	aged lime green expensive champagne	3	awesome	Last Available: "2014-12"
-7147	extra-alkaline huge purple polo trophy	0		Effect: "Super Skill", Effect Duration: 30, Last Available: "2014-12"
+7147	extra-alkaline purple huge polo trophy	0		Effect: "Super Skill", Effect Duration: 30, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
-7149	squat upside-down rosary	0		Last Available: "2014-12"
+7149	upside-down squat rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
 7152		0		Last Available: "2014-12"
@@ -7043,19 +7043,19 @@
 7154	filling	0		Last Available: "2014-12"
 7155	mirror parchment	0		Last Available: "2014-12"
 7156	blinking red glass	0		Last Available: "2014-12"
-7157	yellow reassuring slick fire hose of the boozehound	0		Moxie: +10, Spooky Resistance: +1, Booze Drop: +100, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	yellow reassuring slick fire hose of the boozehound	0		Moxie: +10, Spooky Resistance: +1, Booze Drop: +100, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	normal fancy fireman's lunch	4	good	Effect: "Spirit of Alph", Effect Duration: 50, Last Available: "2014-12"
-7159	Jack Frost's curative plain paper hat of the boozehound	0		Cold Spell Damage: +50, Booze Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	Jack Frost's curative plain paper hat of the boozehound	0		Cold Spell Damage: +50, Booze Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	adequate jittery green ice cream sandwich	3	good	Last Available: "2014-12"
 7161	squat rosy-cheeked studded beefcake's &quot;honey&quot; dipper	0		Muscle: +25, Damage Absorption: +80, Maximum HP Percent: +30, Last Available: "2014-12"
-7162	huge normal blinking plumber's lunch	8	good	Last Available: "2014-12"
+7162	normal huge blinking plumber's lunch	8	good	Last Available: "2014-12"
 7163	hale Da Vinci's skull gearshift knob of Leguizamo	0		Experience (Mysticality): +5, Maximum HP: +20, Monster Level: +20, Last Available: "2014-12"
 7164	tasty nachos of the night	3	awesome	Last Available: "2014-12"
 7165	resourceful Sketcherz&trade; of horror of the early riser	0		Maximum MP: +50, Spooky Spell Damage: +25, Adventures: +7, Last Available: "2014-12"
 7166	small yummy narrow can of Adultwitch&trade;	2	awesome	Last Available: "2014-12"
 7167	polarized flattened jittery smudge stick	0		Effect: "Feet of Grapefruit", Effect Duration: 27, Last Available: "2014-12"
 7168	denatured wall	0		Effect: "Drunk With Power", Effect Duration: 28, Last Available: "2014-12"
-7169	watered-down bad tankard of ale	2	decent	Last Available: "2014-12"
+7169	bad watered-down tankard of ale	2	decent	Last Available: "2014-12"
 7170	irradiated enhanced scroll case	0		Effect: "Spring Training", Effect Duration: 47, Last Available: "2014-12"
 7171	liquefied pickled jug of &quot;wine&quot;	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 51, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7066,7 +7066,7 @@
 7177	electrified non-quantum wobbly crappy waiter disguise	0		Effect: "Cock of the Walk", Effect Duration: 41
 7178	green Copperhead Charm	0		
 7179	The First Pizza	0		
-7180	squat fuchsia The Lacrosse Stick of Lacoronado	0		
+7180	fuchsia squat The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	dog trainer's Buddy Bjorn	0		Experience (familiar): +1, Softcore Only, Last Available: "2014-02"
 7201	censurious baleful boxer's The Nuge's favorite crossbow	0		Muscle Percent: +10, Spell Damage: +25, Sleaze Resistance: +3
-7202	spoiled miniature sweet roll Alabama	2	crappy	
+7202	miniature spoiled sweet roll Alabama	2	crappy	
 7203	smartaleck's Saturday Night Special	0		Moxie Percent: +30
 7204	jittery lynyrd snare	0		
 7205	nippy fleetwood chain	0		Cold Damage: +10
@@ -7108,12 +7108,12 @@
 7219	stylish lynyrdskin breeches	0		Moxie: +25, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	jittery cigarette lighter	0		
 7221	jittery priceless diamond	0		
-7222	delicious enchanted Flamin' Whatshisname	3	awesome	Effect: "Fudgehound", Effect Duration: 20
+7222	enchanted delicious Flamin' Whatshisname	3	awesome	Effect: "Fudgehound", Effect Duration: 20
 7223	alkaline pickled lynyrd musk	0		Effect: "Gamer Rage", Effect Duration: 32
 7224	extremely unsafe Newton's Kashmir sweater	0		Experience (Mysticality): +3, Weapon Damage Percent: +100
-7225	thick rotten custard pie	5	crappy	
+7225	rotten thick custard pie	5	crappy	
 7226	tea for one	1	crappy	
-7227	artisanal practically non-alcoholic enchanted upside-down bottle of Evermore	1	EPIC	Effect: "Ruby-ous", Effect Duration: 25
+7227	enchanted artisanal practically non-alcoholic upside-down bottle of Evermore	1	EPIC	Effect: "Ruby-ous", Effect Duration: 25
 7228	box	0		
 7229	drinkable wine	3	good	
 7230	hand-crafted rum	3	EPIC	
@@ -7176,7 +7176,7 @@
 7287	olive Oprah's Gary Claybender's Time Screwer of mayonnaise	0		Maximum MP Percent: +50, Sleaze Spell Damage: +50, Single Equip, Lasts Until Rollover
 7288	vibrating Space Tourist palmdoctor of the sewer	0		Maximum MP Percent: +10, Stench Damage: +25, Lasts Until Rollover
 7289	blinking grievous thinker's amok putter of the bloodbag	0		Mysticality: +10, Weapon Damage Percent: +50, Maximum HP: +100
-7290	small bland mirror amok pudding	2	decent	
+7290	bland small mirror amok pudding	2	decent	
 7291	skewed deactivated putty buddy	0		
 7292	bouncing putty coat	0		Familiar Weight: +5
 7293	flattened jittery can of V-11	0		Effect: "Stickler for Promptness", Effect Duration: 57, Last Available: "2014-03"
@@ -7210,7 +7210,7 @@
 7321	ribald grievous Stephen's lab coat	0		Weapon Damage Percent: +50, Sleaze Damage: +10
 7322	extra-enhanced colloidal non-boiled Stephen's secret formula	0		Effect: "Memory of Smarts", Effect Duration: 33
 7323	greasy Fonzie's Jacob's rung	0		Experience (Moxie): +1, Sleaze Spell Damage: +10
-7324	compressed gray spinning battery	1		
+7324	compressed spinning gray battery	1		
 7325	bad snakebite	4	decent	
 7326	Jeselnik's rubber ribcage of the cougar	0		Moxie: +20, Sleaze Damage: +25, Damage Reduction: 7
 7327	dried narrow synthetic marrow	1		
@@ -7227,8 +7227,8 @@
 7338	anodized dancer	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 24
 7339	music box mechanism	0		
 7340	moose antlers of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "atk, 1xLep, cap 27"
-7341	chilled warmed fuchsia mirror moose thought	0		Effect: "Feet of Grapefruit", Effect Duration: 54
-7342	spoiled thick moose chocolate	5	crappy	
+7341	chilled warmed mirror fuchsia moose thought	0		Effect: "Feet of Grapefruit", Effect Duration: 54
+7342	thick spoiled moose chocolate	5	crappy	
 7343	mediocre spirit-forward painting of a glass of wine	5	decent	
 7344	narrow narrow oil painting of yourself	0		
 7345	ornate picture frame	0		
@@ -7238,9 +7238,9 @@
 7349	blinking ghost key	0		
 7350	shaking picture of you	0		
 7351	mirror perfumed Annie Oakley's Da Vinci's Staff of the Electric Range	0		Experience (Mysticality): +5, Critical Hit Percent: +20, Stench Resistance: +5
-7352	rotten blinking skewed deluxe layer cake	4	crappy	
-7353	blinking purple chunk of hot iron	0		
-7354	distilled perfectly mixed red-hot boilermaker	5	EPIC	
+7352	rotten skewed blinking deluxe layer cake	4	crappy	
+7353	purple blinking chunk of hot iron	0		
+7354	perfectly mixed distilled red-hot boilermaker	5	EPIC	
 7355	upside-down baleful coal shovel	0		Spell Damage: +25, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	frozen galvanized olive hot coal	0		Effect: "Frozen Hands", Effect Duration: 28
 7357	polymerized galvanized coal dust	0		Effect: "From Nantucket", Effect Duration: 29
@@ -7249,19 +7249,19 @@
 7360	twirling blurry plaid bandage	0		
 7361	censurious plaid pocket square	0		Sleaze Resistance: +3
 7362	Sherlock's smartaleck's plaid skirt	0		Moxie Percent: +30, Item Drop: +25, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-7363	diffused bouncing wobbly bloodstain stick	0		Effect: "Action", Effect Duration: 37
+7363	diffused wobbly bouncing bloodstain stick	0		Effect: "Action", Effect Duration: 37
 7364	fabric softener	0		
 7365	Vulcanized blue fabric hardener	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 48
 7366	lousy bottle of laundry sherry	4	decent	
 7367	deionized pressed industrial strength starch	0		Effect: "Drunk With Power", Effect Duration: 50, Wiki Name: "industrial strength starch"
 7368	normal extra-flat panini	3	good	
 7369	deionized blurry mangled finger	0		Effect: "Pronounced Potency", Effect Duration: 65
-7370	special weak acceptable Psychotic Train wine	2	good	Effect: "A Taste of Rainbow", Effect Duration: 45
+7370	acceptable weak special Psychotic Train wine	2	good	Effect: "A Taste of Rainbow", Effect Duration: 45
 7371	crazy hobo notebook	0		
 7372	snack-sized normal pie man was not meant to eat	2	good	
 7373	healthy sommelier's towel	0		Maximum HP Percent: +20
 7374	tarnished tastevin of wisdom	0		Mysticality: +15, Single Equip
-7375	normal half-sized tumbling actual tapas	2	good	
+7375	half-sized normal tumbling actual tapas	2	good	
 7376	ghast iron ingot	0		
 7377	wobbly horrifying wicked ghast iron cleaver	0		Spell Damage: +5, Spooky Damage: +25
 7378	miser's ghast iron Garibaldi of chilblains	0		Cold Damage: +25, Meat Drop: +10, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7328,33 +7328,33 @@
 7439	immense rotten Brain Food Pastaco	9	crappy	Last Available: "2014-05"
 7440	stale blurry Cool Brunch Pastaco	4	decent	Last Available: "2014-05"
 7441	moldy Medical Pastaco	3	crappy	Last Available: "2014-05"
-7442	decent shaking mirror olive Energy Buzz Pastaco	4	good	Last Available: "2014-05"
+7442	decent olive mirror shaking Energy Buzz Pastaco	4	good	Last Available: "2014-05"
 7443	moldy bouncing Ludovico Pastaco	4	crappy	Last Available: "2014-05"
 7444	tolerable jittery overpowering mushroom wine	3	good	Last Available: "2014-05"
 7445	mediocre complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	artisanal watered-down smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	acceptable blood-red mushroom wine	3	good	Last Available: "2014-05"
-7448	distilled perfectly mixed buzzing mushroom wine	5	EPIC	Last Available: "2014-05"
-7449	triple-distilled hand-crafted swirling mushroom wine	6	EPIC	Last Available: "2014-05"
+7448	perfectly mixed distilled buzzing mushroom wine	5	EPIC	Last Available: "2014-05"
+7449	hand-crafted triple-distilled swirling mushroom wine	6	EPIC	Last Available: "2014-05"
 7450	normal Taco Dan's Basic Taco Dan Taco	3	good	Last Available: "2014-05"
-7451	massive adequate Taco Dan's Taco Fish Fish Taco	6	good	Last Available: "2014-05"
-7452	spinning blinking Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	drinkable weak skewed regular-size brogurt	2	good	Last Available: "2014-05"
+7451	adequate massive Taco Dan's Taco Fish Fish Taco	6	good	Last Available: "2014-05"
+7452	blinking spinning Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
+7453	weak drinkable skewed regular-size brogurt	2	good	Last Available: "2014-05"
 7454	watered-down artisanal super-size brogurt	2	EPIC	Last Available: "2014-05"
-7455	drinkable spirit-forward broberry brogurt	5	good	Last Available: "2014-05"
+7455	spirit-forward drinkable broberry brogurt	5	good	Last Available: "2014-05"
 7456	practically non-alcoholic hand-crafted squat upside-down brocolate brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7457	aged irresponsibly strong blurry French bronilla brogurt	10	awesome	Last Available: "2014-05"
 7458	bouncing History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	squat Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Brogre brorts of the dark arts	0		Spell Damage Percent: +100, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	therapeutic Brogre brolo shirt	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-05"
-7464	shaking avaricious Brogre bucket hat	0		Meat Drop: +30, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	shaking avaricious Brogre bucket hat	0		Meat Drop: +30, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	narrow airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	skewed one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	tumbling MacGyver's sage 8-billed baseball cap of the pedagogue	0		Mysticality Percent: +10, Experience: +3, Maximum MP: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	tumbling MacGyver's sage 8-billed baseball cap of the pedagogue	0		Mysticality Percent: +10, Experience: +3, Maximum MP: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	rosewater-soaked Oprah's quilted extremely wet T-shirt	0		Damage Absorption: +40, Maximum MP Percent: +50, Stench Resistance: +3, Last Available: "2014-05"
 7470	bouncing zippy smelly ruddy shrimp fork	0		Maximum HP Percent: +40, Stench Spell Damage: +10, Initiative: +20, Last Available: "2014-05"
 7471	cold-filtered activated yellow squat BROS Energy Drink	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 48, Last Available: "2014-05"
@@ -7368,7 +7368,7 @@
 7479	galvanized modified fuchsia sugar fairy	0		Effect: "Your Eyes are Peeled!", Effect Duration: 20, Last Available: "2014-05"
 7480	ionized concentrated sugar bunny	0		Effect: "Going Ape", Effect Duration: 36, Last Available: "2014-05"
 7481	tumbling sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	hand-crafted upside-down cyan Rompedores de Fantasmas	3	EPIC	
+7482	hand-crafted cyan upside-down Rompedores de Fantasmas	3	EPIC	
 7483	watered-down hand-crafted mirror La Fantasma y La Oscuridad	2	EPIC	
 7484	smooth green Fantasma en la M&aacute;quina	3	awesome	
 7485	loosening powder	0		
@@ -7415,7 +7415,7 @@
 7526	bouncing weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	lightning-fast extremely unsafe government-issued night-vision goggles	0		Weapon Damage Percent: +100, Initiative: +40, Single Equip, Last Available: "2014-05"
-7529	special low-calorie decent loaf of alien bread	1	good	Effect: "Moose Wisdom", Effect Duration: 10, Last Available: "2014-05"
+7529	decent special low-calorie loaf of alien bread	1	good	Effect: "Moose Wisdom", Effect Duration: 10, Last Available: "2014-05"
 7530	bland grilled cheese sandwich	3	decent	Last Available: "2014-05"
 7531	modified bouncing alien protein powder	1	crappy	Effect: "Booing Radly", Effect Duration: 20, Last Available: "2014-05"
 7532	perfectly mixed rocket fuel	3	EPIC	Last Available: "2014-05"
@@ -7425,13 +7425,13 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	blinking ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	prompt space beast fur pants	0		Adventures: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	prompt space beast fur pants	0		Adventures: +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	blue space beast fur whip of the cougar	0		Moxie: +20, Last Available: "2014-05"
 7542	pulsating space invader	0		Last Available: "2014-05"
 7543	skewed censurious hale space heater	0		Maximum HP: +20, Sleaze Resistance: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
-7545	watered-down bad yellow skewed space port	2	decent	Last Available: "2014-05"
+7545	bad watered-down skewed yellow space port	2	decent	Last Available: "2014-05"
 7546	space needle of the scaredy-cat of horror	0		Monster Level: -15, Spooky Spell Damage: +25, Last Available: "2014-05"
 7547	triple-diffused dry tarnished skewed buffed alien drugs	0		Effect: "Wallflowering", Effect Duration: 56, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7444,7 +7444,7 @@
 7555	page	0		
 7556	gray elephant gift	0		
 7557	quadruple-irradiated shaking blood cells	0		Effect: "Oth-Jeal-O", Effect Duration: 50
-7558	bad triple-distilled wine	10	decent	
+7558	triple-distilled bad wine	10	decent	
 7559	frozen gummi turtle	0		Effect: "You Can Taste the Darkness", Effect Duration: 64
 7560	tumbling turtle-shaped rock	0		
 7561	electrified twirling giraffe-necked turtle	0		Effect: "Hagnk's Gratitude", Effect Duration: 66
@@ -7453,7 +7453,7 @@
 7564	double-boiled electrified mocking turtle	0		Effect: "Strawberry Alarm", Effect Duration: 54
 7565	stale ham steak	3	decent	
 7566	knitted time-twitching toolbelt	0		Cold Resistance: +3, Single Equip, Free Pull
-7567	spinning cyan Chroner	0		
+7567	cyan spinning Chroner	0		
 7568	resourceful Herculean Time Lord Badge of Honor of the glutton	0		Experience (Muscle): +1, Maximum MP: +50, Food Drop: +100
 7569	squat toasty electrified therapeutic Time Bandit Badge of Courage	0		Hot Damage: +5, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7
 7570	polymerized frozen extra-activated ghostly Friendliness Beverage	0		Effect: "Grrrrrrreat!", Effect Duration: 15
@@ -7476,15 +7476,15 @@
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	ghostly Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	hand-crafted glass of &quot;milk&quot;	4	EPIC	Last Available: "2014-07"
-7590	weak aged tumbling cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
-7591	weak tolerable enchanted thermos of &quot;whiskey&quot;	2	good	Effect: "Granolarrrgh", Effect Duration: 30, Last Available: "2014-07"
+7590	aged weak tumbling cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
+7591	tolerable enchanted weak thermos of &quot;whiskey&quot;	2	good	Effect: "Granolarrrgh", Effect Duration: 30, Last Available: "2014-07"
 7592	fortified artisanal Lucky Lindy	5	EPIC	Last Available: "2014-07"
-7593	acceptable practically non-alcoholic mirror Bee's Knees	1	good	Last Available: "2014-07"
-7594	fancy lousy blinking Sockdollager	3	decent	Effect: "Twenty-three Squid, Ew", Effect Duration: 20, Last Available: "2014-07"
-7595	delicious special spirit-forward Ish Kabibble	5	awesome	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2014-07"
-7596	mediocre weak enchanted teal Hot Socks	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2014-07"
-7597	lousy enchanted narrow pulsating Phonus Balonus	3	decent	Effect: "Just the Brown Ones", Effect Duration: 40, Last Available: "2014-07"
-7598	lousy extra-dry narrow Flivver	5	decent	Last Available: "2014-07"
+7593	practically non-alcoholic acceptable mirror Bee's Knees	1	good	Last Available: "2014-07"
+7594	lousy fancy blinking Sockdollager	3	decent	Effect: "Twenty-three Squid, Ew", Effect Duration: 20, Last Available: "2014-07"
+7595	spirit-forward special delicious Ish Kabibble	5	awesome	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2014-07"
+7596	weak enchanted mediocre teal Hot Socks	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2014-07"
+7597	enchanted lousy narrow pulsating Phonus Balonus	3	decent	Effect: "Just the Brown Ones", Effect Duration: 40, Last Available: "2014-07"
+7598	extra-dry lousy narrow Flivver	5	decent	Last Available: "2014-07"
 7599	bad tumbling Sloppy Jalopy	3	decent	Last Available: "2014-07"
 7600	activated energized pulsating flame	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 42
 7601	polymerized bouncing temporary yak tattoo	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 14
@@ -7505,7 +7505,7 @@
 7616	warmed pygmy witchhazel	0		Effect: "Flamingly Floral", Effect Duration: 67
 7617	chilled tarnished short deposition	0		Effect: "Pop-eyed", Effect Duration: 21
 7618	unsweetened straw pole	0		Effect: "Stimulated Body", Effect Duration: 24
-7619	dry moist fuchsia blinking mirror copperhead potion	0		Effect: "Greased-Up Familiar", Effect Duration: 69
+7619	dry moist mirror blinking fuchsia copperhead potion	0		Effect: "Greased-Up Familiar", Effect Duration: 69
 7620	moist twirling yellow ninja fear powder	0		Effect: "Bread-Lined", Effect Duration: 58
 7621	aerosolized enhanced ninja eyeblack	0		Effect: "Pemmican't", Effect Duration: 48
 7622	quadruple-activated chilled button rouge	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 54
@@ -7543,7 +7543,7 @@
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
-7657	skewed green fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
+7657	green skewed fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	red slick neoprene skullcap	0		Moxie: +10, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	electrified polymerized goblin water	0		Effect: "Salty Dogs", Effect Duration: 18
@@ -7599,7 +7599,7 @@
 7710	denatured purple candy UFOs	0		Effect: "You Read The Manual", Effect Duration: 64
 7711	rosy-cheeked water wings for babies of Flo-Jo	0		Maximum HP Percent: +30, Initiative: +100
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	special spoiled bite-sized Strix stix	1	crappy	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45
+7713	bite-sized special spoiled Strix stix	1	crappy	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45
 7714	skewed aromatic ruddy vampire pellet of the blizzard	0		Maximum HP Percent: +40, Cold Spell Damage: +25, Stench Resistance: +1
 7715	hand-crafted non-aged vinegar	3	EPIC	
 7716	blinking avaricious unsanitized scalpel	0		Meat Drop: +30
@@ -7611,13 +7611,13 @@
 7722	resourceful centurion helmet	0		Maximum MP: +50, Familiar Effect: "1xFairy, atk, cap 25"
 7723	Chroner cross	0		
 7724	pteruges of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xFairy, atk, cap 25"
-7725	quadruple-deionized colloidal unsweetened narrow fuchsia Bruno's blessing of Mars	0		Effect: "Tearful, Fearful", Effect Duration: 59
+7725	quadruple-deionized colloidal unsweetened fuchsia narrow Bruno's blessing of Mars	0		Effect: "Tearful, Fearful", Effect Duration: 59
 7726	corrupted enhanced Dennis's blessing of Minerva	0		Effect: "Cranberry Cordiality", Effect Duration: 29
 7727	enhanced wet jittery Burt's blessing of Bacchus	0		Effect: "Hypercubed", Effect Duration: 22
 7728	liquefied adjusted oxidized tumbling Freddie's blessing of Mercury	0		Effect: "The Power of Positive Thinking", Effect Duration: 22
 7729	ghostly Chroner trigger	0		
 7730	blinking olive Xi Receiver Unit	0		Last Available: "2014-09"
-7731	blinking squat transmission from planet Xi	0		Last Available: "2014-09"
+7731	squat blinking transmission from planet Xi	0		Last Available: "2014-09"
 7732	ghostly Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	wobbly Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	jittery Xiblaxian polymer	0		Last Available: "2014-09"
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	yellow cool Xiblaxian xeno-detection goggles	0		Moxie: +5, Single Equip, Last Available: "2014-09"
-7753	scandalous Xiblaxian stealth cowl of the empath	0		Familiar Weight: +5, Sleaze Damage: +5, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	scandalous Xiblaxian stealth cowl of the empath	0		Familiar Weight: +5, Sleaze Damage: +5, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	Xiblaxian stealth trousers of chilblains of the overflowing toilet	0		Cold Damage: +25, Stench Spell Damage: +50, Last Available: "2014-09"
 7755	sharpshooter's hardy Xiblaxian stealth vest	0		Maximum HP: +50, Critical Hit Percent: +10, Last Available: "2014-09"
 7756	bland Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
@@ -7649,7 +7649,7 @@
 7760	stale They liver popsicle	3	decent	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	skewed holo-bomber	0		Last Available: "2014-09"
-7763	jittery blinking holo-platoon	0		Last Available: "2014-09"
+7763	blinking jittery holo-platoon	0		Last Available: "2014-09"
 7764	vaporized gray residual zeal	1		Effect: "World's Shortest Giant", Effect Duration: 15, Last Available: "2014-09"
 7765	fuchsia sizzling Xiblaxian holo-wrist-puter	0		Hot Damage: +10, Last Available: "2014-09"
 7766	bouncing mirror greedy healthy supercool defective Golden Mr. Accessory	0		Moxie Percent: +20, Maximum HP Percent: +20, Meat Drop: +20
@@ -7669,7 +7669,7 @@
 7780	Van der Graaf heavy-duty clipboard of the empath of the cheetah	0		Familiar Weight: +5, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 8, Last Available: "2014-10"
 7781	prompt smelly Lo Pan's medical-grade battery-powered drill	0		Spell Critical Percent: +30, Stench Spell Damage: +10, Adventures: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10"
 7782	bite-sized adequate limp broccoli	1	good	Last Available: "2014-10"
-7783	Annie Oakley's Socratic hat of courage	0		Experience (Mysticality): +1, Critical Hit Percent: +20, Spooky Resistance: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	Annie Oakley's Socratic hat of courage	0		Experience (Mysticality): +1, Critical Hit Percent: +20, Spooky Resistance: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	corrupted boiled cyan monkey barf	0		Effect: "Dwarven Hardiness", Effect Duration: 61, Last Available: "2014-10"
 7785	irradiated spinning candy	0		Effect: "init.enh", Effect Duration: 67, Last Available: "2014-10"
 7786	family-friendly educational jangly bracelet of Leguizamo	0		Experience: +1, Monster Level: +20, Sleaze Resistance: +1, Last Available: "2014-10"
@@ -7682,8 +7682,8 @@
 7793	narrow bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	moldy ghostly initiative shawarma	4	crappy	Last Available: "2014-10"
-7796	immense adequate warm war shawarma	10	good	Last Available: "2014-10"
-7797	gigantic flavorless karma shawarma	10	decent	Last Available: "2014-10"
+7796	adequate immense warm war shawarma	10	good	Last Available: "2014-10"
+7797	flavorless gigantic karma shawarma	10	decent	Last Available: "2014-10"
 7798	acceptable green Jungle Juice	3	good	Last Available: "2014-10"
 7799	hand-crafted Amnesiac Ale	4	EPIC	Last Available: "2014-10"
 7800	drinkable Highest Bitter	4	good	Last Available: "2014-10"
@@ -7700,11 +7700,11 @@
 7811	viral DNA	0		
 7812	shaking tarnished bottlecap	0		
 7813	stale miniature seared dino steak	2	decent	
-7814	fancy smooth extra-dry spinning bottle of drinkin' gas	5	awesome	Effect: "Provocative Perkiness", Effect Duration: 50
+7814	fancy extra-dry smooth spinning bottle of drinkin' gas	5	awesome	Effect: "Provocative Perkiness", Effect Duration: 50
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
-7818	huge maroon 99.44% pure math	0		
+7818	maroon huge 99.44% pure math	0		
 7819	simple AI	0		
 7820	olive corrupted bird DNA	0		
 7821	twirling sentient meat mass	0		
@@ -7713,7 +7713,7 @@
 7824	fireproof nippy iShield	0		Cold Damage: +10, Hot Resistance: +3, Item Drop: +5, Damage Reduction: 6
 7825	arcane researcher's Samson's cool earbuds	0		Moxie: +5, Experience (Muscle): +5, Experience Percent (Mysticality): +10, Single Equip
 7826	blue Jeselnik's frightening veiny iFlail	0		Maximum HP: +10, Spooky Damage: +5, Sleaze Damage: +25
-7827	small toothsome unidentifiable dried fruit	2	awesome	
+7827	toothsome small unidentifiable dried fruit	2	awesome	
 7828	artisanal flat cider	3	EPIC	
 7829	squat reassuring personal trainer's trench lighter of the sewer	0		Experience Percent (Muscle): +10, Stench Damage: +25, Spooky Resistance: +1, Last Available: "2014-10"
 7830	Vulcanized nitrogenated experimental serum P-00	0		Effect: "Tingly Wrists", Effect Duration: 42, Last Available: "2014-10"
@@ -7735,7 +7735,7 @@
 7846	anodized gray Fudge Fiber Armor Plating	0		Effect: "Adrenaline Rush", Effect Duration: 18, Last Available: "2014-12"
 7847	quadruple-concentrated wet ruby on canes	0		Effect: "Warm Belly", Effect Duration: 54, Last Available: "2014-12"
 7848	fancy rotten petit fortran	4	crappy	Effect: "Inappropriate Spirit", Effect Duration: 15, Last Available: "2014-12"
-7849	stale bite-sized enchanted java cookie	1	decent	Effect: "Red Around the Gills", Effect Duration: 30, Last Available: "2014-12"
+7849	bite-sized enchanted stale java cookie	1	decent	Effect: "Red Around the Gills", Effect Duration: 30, Last Available: "2014-12"
 7850	rotten cookie cookie	3	crappy	Last Available: "2014-12"
 7851	prompt plastic exo-suited miner	0		Adventures: +3, Last Available: "2014-12"
 7852	upside-down personal trainer's plastic semi-autonomous drill unit	0		Experience Percent (Muscle): +10, Last Available: "2014-12"
@@ -7743,12 +7743,12 @@
 7854	blinking Lo Pan's plastic Crimbot	0		Spell Critical Percent: +30, Last Available: "2014-12"
 7855	plastic Crimbomega of terror	0		Spooky Spell Damage: +10, Last Available: "2014-12"
 7856	tarnished boiled spinning jittery flask of mining oil	0		Effect: "The Dinsey Spirit", Effect Duration: 69, Last Available: "2014-12"
-7857	censurious radiation-resistant helmet	0		Sleaze Resistance: +3, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	fortified servo-assisted exo-pants	0		Damage Absorption: +60, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	censurious radiation-resistant helmet	0		Sleaze Resistance: +3, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	fortified servo-assisted exo-pants	0		Damage Absorption: +60, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	lion tamer's high-energy mining laser of the boozehound	0		Experience (familiar): +2, Booze Drop: +100, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
-7862	wobbly blinking cylindrical mold	0		Last Available: "2014-12"
+7862	blinking wobbly cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
@@ -7778,7 +7778,7 @@
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	huge Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
-7892	skewed huge Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
+7892	huge skewed Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	tumbling Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
@@ -7798,9 +7798,9 @@
 7909	blinking recovered elf wallet	0		Last Available: "2014-12"
 7910	recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	cyan recovered elf photo album	0		Last Available: "2014-12"
-7912	twirling huge recovered elf smartphone	0		Last Available: "2014-12"
+7912	huge twirling recovered elf smartphone	0		Last Available: "2014-12"
 7913	smelly dog trainer's Size XI Wizard's Robe of the brazier	0		Experience (familiar): +1, Hot Spell Damage: +25, Stench Spell Damage: +10, Last Available: "2014-09"
-7914	magnetized altered blinking red Bit O' Quail Spleen	0		Effect: "Burning Hands", Effect Duration: 35
+7914	magnetized altered red blinking Bit O' Quail Spleen	0		Effect: "Burning Hands", Effect Duration: 35
 7915	diffused activated squat Take Eleven Bar	0		Effect: "Coming Up Roses", Effect Duration: 16
 7916	mimeplasm	0		
 7917	vacuum-sealed triple-magnetized moist BOOterfinger	0		Effect: "Egg-headedness", Effect Duration: 53
@@ -7837,7 +7837,7 @@
 7955	purple bouncing bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	maroon even more tinsel	0		Familiar Weight: +5
-7958	ghostly skewed box of Crimbo decorations	0		
+7958	skewed ghostly box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	huge Jeselnik's fortified brainy beefy Staff of Ed	0		Muscle: +10, Mysticality: +5, Damage Absorption: +60, Sleaze Damage: +25
@@ -7850,17 +7850,17 @@
 7968	topiary nugglet	0		
 7969	beehive	0		
 7970	blinking boning knife	0		
-7971	narrow jittery Aggressive Carrot	0		Free Pull
+7971	jittery narrow Aggressive Carrot	0		Free Pull
 7972	dehydrated mummified fig	1	decent	
-7973	twisted shaking huge wobbly mummified loaf of bread	1	decent	
-7974	altered jittery upside-down mummified beef haunch	1	EPIC	
+7973	twisted shaking wobbly huge mummified loaf of bread	1	decent	
+7974	altered upside-down jittery mummified beef haunch	1	EPIC	
 7975	linen bandages	0		
 7976	cotton bandages	0		
 7977	silk bandages	0		
 7978	holy spring water	0		
 7979	wobbly spirit beer	0		
 7980	skewed sacramental wine	0		
-7981	yellow pulsating narrow talisman of Thoth	0		
+7981	narrow yellow pulsating talisman of Thoth	0		
 7982	cure-all	0		
 7983	skewed wholesome Sister Accessory of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Softcore Only
 7984	activated diffused Boosty Juice	0		Effect: "Crimbo Epiphany", Effect Duration: 64
@@ -7881,14 +7881,14 @@
 7999	deionized upside-down choco-Crimbot	0		Effect: "Peppermint Bite", Effect Duration: 67, Last Available: "2014-12"
 8000	vacuum-sealed smart watch	0		Effect: "Hairless and Airless", Effect Duration: 62, Last Available: "2014-12"
 8001	deionized wobbly spinning augmented-reality shades	0		Effect: "Make Meat FA$T!", Effect Duration: 68, Last Available: "2014-12"
-8002	Samson's toy Crimbot mega face	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
+8002	Samson's toy Crimbot mega face	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	fuchsia grievous toy Crimbot power glove	0		Weapon Damage Percent: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	Samson's toy Crimbot super fist	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	toy Crimbot rocket legs of Flo-Jo	0		Initiative: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	boiled blurry Crimbot battery	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 55, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8009	purple tumbling mirror Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8009	mirror tumbling purple Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	teal heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	healthy savvy Crimbomega drive chain of the sewer	0		Mysticality Percent: +20, Maximum HP Percent: +20, Stench Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
@@ -7900,7 +7900,7 @@
 8018	aerosolized jittery and rain stick	0		Effect: "stats.enq", Effect Duration: 56
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	miniature toothsome Choco-Mint patty	2	awesome	Last Available: "2015-01"
-8021	hand-crafted watered-down hot mint schnocolate	2	EPIC	Last Available: "2015-01"
+8021	watered-down hand-crafted hot mint schnocolate	2	EPIC	Last Available: "2015-01"
 8022	pickled shaking homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
@@ -7952,9 +7952,9 @@
 8071	squat warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	upside-down wool shellacked quilted Spelunker's fedora	0		Damage Absorption: +40, Damage Reduction: 7, Cold Resistance: +1, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	upside-down wool shellacked quilted Spelunker's fedora	0		Damage Absorption: +40, Damage Reduction: 7, Cold Resistance: +1, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	twirling asbestos-lined dog trainer's curative Spelunker's whip	0		Experience (familiar): +1, Hot Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12"
-8076	personal trainer's groovy Spelunker's khakis of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3, Experience Percent (Muscle): +10, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	personal trainer's groovy Spelunker's khakis of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3, Experience Percent (Muscle): +10, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8007,7 +8007,7 @@
 8132	purple manspreader's Van der Graaf fiberglass fedora	0		Monster Level: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
 8133	altered fiberglass fibers	1		Effect: "Bubblin' Rage", Effect Duration: 25, Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
-8135	blurry green winged yeti fur	0		
+8135	green blurry winged yeti fur	0		
 8136	talisman of Renenutet	0		
 8138	reassuring rubber spatula	0		Spooky Resistance: +1
 8139	upside-down red Temple Grandin's spoon	0		Familiar Weight: +7
@@ -8022,7 +8022,7 @@
 8148	fuchsia personal trainer's ninjammies of the ox of chilblains	0		Muscle: +20, Experience Percent (Muscle): +10, Cold Damage: +25, Familiar Effect: "atk, 0.5xPotato, cap 25"
 8149	frozen Glo-Pop	0		Effect: "The Magic of Sharing", Effect Duration: 37
 8150	flattened huge sugar sphere	0		Effect: "Spell Transfer Complete", Effect Duration: 37
-8151	anodized blue upside-down Shrubble Bubble	0		Effect: "Permafrosty", Effect Duration: 15
+8151	anodized upside-down blue Shrubble Bubble	0		Effect: "Permafrosty", Effect Duration: 15
 8152	quadruple-deionized colloidal super-polarized polyeaster egg	0		Effect: "Pork Power", Effect Duration: 56
 8153	moist unsweetened candy dish	0		Effect: "Electrolit Up", Effect Duration: 21
 8154	electrified ghostly Spechunky bar	0		Effect: "Horrid, Torrid", Effect Duration: 20
@@ -8042,7 +8042,7 @@
 8168	glob of icing	0		
 8169	improved deionized ginger snaps	0		Effect: "Corona de la Salsa", Effect Duration: 18
 8170	liquefied teal mostly-broken sunglasses	0		Effect: "Rainbow Bright", Effect Duration: 14
-8171	practically non-alcoholic bad ghostly unflavored wine cooler	1	decent	
+8171	bad practically non-alcoholic ghostly unflavored wine cooler	1	decent	
 8172	spinning carton of snake milk	1	EPIC	
 8173	maroon fortified sewer snake	0		Damage Absorption: +60
 8174	adequate pigeon egg	3	good	
@@ -8056,22 +8056,22 @@
 8182	squat Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	cyan bread basket of horror	0		Spooky Spell Damage: +25
 8184	Ed the Undying exhibit crate	0		
-8185	wobbly The Crown of Ed the Undying of the cougar of mayonnaise	0		Moxie: +20, Sleaze Spell Damage: +50, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	wobbly The Crown of Ed the Undying of the cougar of mayonnaise	0		Moxie: +20, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	shaking map to a hidden booze cache	0		
 8188	hand-crafted spirit-forward Cherrytastrophe wine cooler	5	EPIC	
 8189	hand-crafted huge Radberry Rip wine cooler	3	EPIC	
-8190	hand-crafted extra-dry upside-down Orangemageddon wine cooler	5	EPIC	
+8190	extra-dry hand-crafted upside-down Orangemageddon wine cooler	5	EPIC	
 8191	aged Breakfast Blast wine cooler	4	awesome	
-8192	watered-down hand-crafted shaking huge Citrus Crush wine cooler	2	EPIC	
+8192	watered-down hand-crafted huge shaking Citrus Crush wine cooler	2	EPIC	
 8193	massive rotten red plain bagel	9	crappy	
 8194	fancy moldy glob of cream cheese	3	crappy	Effect: "Fudgehound", Effect Duration: 10
 8195	rotten fancy loaf of soda bread	4	crappy	Effect: "Pockets of Fire", Effect Duration: 15
 8196	rotten blurry acceptable bagel	3	crappy	
 8197	rotten standard-issue cupcake	4	crappy	
-8198	spoiled bite-sized squat ultra-deluxe cupcake	1	crappy	
+8198	bite-sized spoiled squat ultra-deluxe cupcake	1	crappy	
 8199	hypnotic breadcrumbs	0		
-8200	delicious tiny popular tart	1	awesome	
+8200	tiny delicious popular tart	1	awesome	
 8201	ghostly no-handed pie	0		
 8202	warmed lime green Doc Galaktik's Vitality Serum	0		Effect: "Bastard!", Effect Duration: 36
 8203	olive airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8079,7 +8079,7 @@
 8205	blurry blinking FunFunds&trade;	0		Last Available: "2015-04"
 8206	grievous beefcake's expensive camera	0		Muscle: +25, Weapon Damage Percent: +50, Single Equip, Last Available: "2015-04"
 8207	sunglasses	0		Single Equip, Last Available: "2015-04"
-8208	deionized ionized cyan mirror How to Avoid Scams	0		Effect: "Cautious Prowl", Effect Duration: 19, Last Available: "2015-04"
+8208	deionized ionized mirror cyan How to Avoid Scams	0		Effect: "Cautious Prowl", Effect Duration: 19, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	bag of park garbage	0		Last Available: "2015-04"
@@ -8092,7 +8092,7 @@
 8218	blinking toxic globule	0		Last Available: "2015-04"
 8219	diet moldy blurry toxo	1	crappy	Last Available: "2015-04"
 8220	tolerable Lemonade-235	3	good	Last Available: "2015-04"
-8221	forbidden beefy isotophat	0		Muscle: +10, Spell Damage Percent: +50, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	forbidden beefy isotophat	0		Muscle: +10, Spell Damage Percent: +50, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	ghostly brawny Three Mile Island shorts of the cheetah	0		Muscle Percent: +20, Initiative: +60, Last Available: "2015-04"
 8223	pulsating greasy toxic mop of vim and vigor	0		Maximum HP Percent: +50, Sleaze Spell Damage: +10, Last Available: "2015-04"
 8224	olive inert sludgepuppy	0		Last Available: "2015-04"
@@ -8128,7 +8128,7 @@
 8254	cyan Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	deionized narrow wobbly nasty gum	0		Effect: "Flamibili Tea", Effect Duration: 29
+8257	deionized wobbly narrow nasty gum	0		Effect: "Flamibili Tea", Effect Duration: 29
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	wobbly The Lot's engagement ring of the wise owl	0		Mysticality: +20, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	blurry Mayo Clinic	0		Last Available: "2015-05"
@@ -8142,10 +8142,10 @@
 8268	green tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	massive rotten blurry unappetizing mayolus	6	crappy	Last Available: "2015-05"
-8271	immense rotten uninteresting mayolus	8	crappy	Last Available: "2015-05"
+8271	rotten immense uninteresting mayolus	8	crappy	Last Available: "2015-05"
 8272	normal acceptable mayolus	4	good	Last Available: "2015-05"
 8273	yummy enticing mayolus	3	awesome	Last Available: "2015-05"
-8274	bland immense mouth-watering mayolus	6	decent	Last Available: "2015-05"
+8274	immense bland mouth-watering mayolus	6	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	wobbly Essence of Bear	0		Skill: "Bear Essence"
@@ -8209,16 +8209,16 @@
 8335	pickled ionized grease trap	0		Effect: "Dilated Pupils", Effect Duration: 47
 8336	pickled skewed shamanic ham	0		Effect: "Sauce Monocle", Effect Duration: 61
 8337	magnetized electrified porkpocket	0		Effect: "Rainbow Bright", Effect Duration: 44
-8338	super-Vulcanized tarnished spinning upside-down Leonard's glasses	0		Effect: "New Zeal", Effect Duration: 63
+8338	super-Vulcanized tarnished upside-down spinning Leonard's glasses	0		Effect: "New Zeal", Effect Duration: 63
 8339	dry polymerized warehouse walkie-talkie	0		Effect: "Sweetened and Fattened", Effect Duration: 50
 8340	colloidal nitrogenated quadruple-alkaline mirror jittery janitor's mop	0		Effect: "Polar Express", Effect Duration: 31
 8341	polymerized flattened blurry warehouse clerk's glasses	0		Effect: "Cat Class, Cat Style", Effect Duration: 22
-8342	boiled non-alkaline green upside-down baloney rotgut	0		Effect: "Loyal Tea", Effect Duration: 34
+8342	boiled non-alkaline upside-down green baloney rotgut	0		Effect: "Loyal Tea", Effect Duration: 34
 8343	non-modified huge carton of gaspers	0		Effect: "Prideful Strut", Effect Duration: 23
 8344	deionized bronze polish	0		Effect: "Notably Lovely", Effect Duration: 43
 8345	anodized anodized spinning crident	0		Effect: "Aries Rising", Effect Duration: 47
-8346	chilled jittery blinking totally sweet mohawk helmet	0		Effect: "Healthy Green Glow", Effect Duration: 25
-8347	liquefied blurry olive spray chrome	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 61
+8346	chilled blinking jittery totally sweet mohawk helmet	0		Effect: "Healthy Green Glow", Effect Duration: 25
+8347	liquefied olive blurry spray chrome	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 61
 8348	polarized filthy monkey head	0		Effect: "Ham-Fisted", Effect Duration: 15
 8349	altered alkaline huge hand of cards	0		Effect: "Employee of the Month", Effect Duration: 30
 8350	triple-polymerized polarized magnetized blue damp bar rag	0		Effect: "Livin' Large", Effect Duration: 65
@@ -8248,7 +8248,7 @@
 8374	deionized quantum drinks tray	0		Effect: "Icy Composition", Effect Duration: 35
 8375	double-polymerized non-liquefied jittery eyebrow lifter	0		Effect: "Dreadful Heat", Effect Duration: 15
 8376	submarine	0		Last Available: "2015-06"
-8377	stale huge pixel lemon	8	decent	Last Available: "2015-06"
+8377	huge stale pixel lemon	8	decent	Last Available: "2015-06"
 8378	perfectly mixed pixel daiquiri	3	EPIC	Last Available: "2015-06"
 8379	Vulcanized power pill	0		Effect: "Dances with Tweedles", Effect Duration: 38, Last Available: "2015-06"
 8380	galvanized teal pixel potion	0		Effect: "Arabian Knighthood", Effect Duration: 27, Last Available: "2015-06"
@@ -8260,7 +8260,7 @@
 8386	valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
-8389	skewed bouncing blinking mana	0		Last Available: "2015-07"
+8389	blinking bouncing skewed mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	huge gift card	0		Last Available: "2015-07"
@@ -8278,20 +8278,20 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	snack-sized rotten fuchsia pestopiary	2	crappy	
+8407	rotten snack-sized fuchsia pestopiary	2	crappy	
 8408	frozen blurry ectoplasmic orbs	0		Effect: "The Magic of Sharing", Effect Duration: 59
 8409	half-sized stale ghostly crudles	2	decent	
 8410	moldy agnolotti arboli	4	crappy	
-8411	half-sized yummy spaghetti with ghost balls	2	awesome	
+8411	yummy half-sized spaghetti with ghost balls	2	awesome	
 8412	flavorless gray succulent marrow	4	decent	
 8413	miniature bland salacious crumbs	2	decent	
 8414	small spoiled ghostly fusilli marrownarrow	2	crappy	
-8415	adequate special suggestive strozzapreti	3	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 5
+8415	special adequate suggestive strozzapreti	3	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 5
 8416	tumbling Mountain Stream gastrique	0		
 8417	moldy thick Mt. McLargeHuge oyster	5	crappy	
 8418	blinking oyster sauce	0		
 8419	massive normal linguini immondizia bianco	8	good	
-8420	special yummy narrow shells a la shellfish	4	awesome	Effect: "Unusual Perspective", Effect Duration: 50
+8420	yummy special narrow shells a la shellfish	4	awesome	Effect: "Unusual Perspective", Effect Duration: 50
 8421	skewed Jick's autograph	0		
 8422	jittery high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8304,7 +8304,7 @@
 8430	twirling hard spore pod	0		
 8431	spore pod	0		
 8432	narrow hot spore pod	0		
-8433	purple pulsating cool spore pod	0		
+8433	pulsating purple cool spore pod	0		
 8434	spinning jingling spore pod	0		
 8435	scandalous LavaCo Lamp&trade; of incineration	0		Hot Spell Damage: +50, Sleaze Damage: +5, Last Available: "2015-08"
 8436	blurry avaricious miser's LavaCo Lamp&trade;	0		Meat Drop: 40, Last Available: "2015-08"
@@ -8317,7 +8317,7 @@
 8443	ghostly lava globs	0		Last Available: "2015-08"
 8444	lava globs	0		Last Available: "2015-08"
 8445	lava globs	0		Last Available: "2015-08"
-8446	pulsating mirror maroon SMOOCH bottlecap	0		Last Available: "2020-09"
+8446	maroon pulsating mirror SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	blinking uncapped lava bottle	0		Last Available: "2015-08"
 8448	olive uncapped lava bottle	0		Last Available: "2015-08"
 8449	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8329,19 +8329,19 @@
 8455	mirror bouncing New Age crystal	0		Last Available: "2015-08"
 8456	green crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	narrow green high-temperature mining mask of mayonnaise of temperance	0		Sleaze Spell Damage: +50, Sleaze Resistance: +5, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	narrow green high-temperature mining mask of mayonnaise of temperance	0		Sleaze Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	Annie Oakley's deadly fireproof megaphone	0		Weapon Damage: +5, Critical Hit Percent: +20, Last Available: "2015-08"
 8460	bland lime green mineapple	4	decent	Last Available: "2015-08"
 8461	delicious Gold Velvet&trade; whiskey	4	awesome	Last Available: "2015-08"
 8462	skewed SMOOCH soda	1	good	Last Available: "2015-08"
-8463	bland wobbly tumbling smelted roe	3	decent	Last Available: "2015-08"
+8463	bland tumbling wobbly smelted roe	3	decent	Last Available: "2015-08"
 8464	tolerable lavawater	4	good	Last Available: "2015-08"
 8465	concentrated ionized electrified wobbly basaltamander tongue	0		Effect: "Human-Hobo Hybrid", Effect Duration: 31, Last Available: "2015-08"
 8466	Oprah's cool lavalarva of James Dean	0		Moxie: +5, Experience (Moxie): +3, Maximum MP Percent: +50, Last Available: "2015-08"
 8467	sage slick lava balaclava of mayonnaise	0		Moxie: +10, Mysticality Percent: +10, Sleaze Spell Damage: +50, Last Available: "2015-08"
 8468	scorching sharpshooter's stylish basaltamander buckler	0		Moxie: +25, Critical Hit Percent: +10, Hot Damage: +25, Damage Reduction: 15, Last Available: "2015-08"
 8469	nitrogenated quadruple-tarnished tumbling lava globs	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 36, Last Available: "2015-08"
-8470	enchanted decent olive gooey lava globs	3	good	Effect: "Warm Shoulders", Effect Duration: 45, Last Available: "2015-08"
+8470	decent enchanted olive gooey lava globs	3	good	Effect: "Warm Shoulders", Effect Duration: 45, Last Available: "2015-08"
 8471	spinning purple lava-proof pants of the sewer of courage	0		Stench Damage: +25, Spooky Resistance: +3, Last Available: "2015-08"
 8472	skewed Tesla wizardly heat-resistant necktie	0		Mysticality: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2015-08"
 8473	shaking miser's frightening extremely unsafe heat-resistant gloves	0		Weapon Damage Percent: +100, Spooky Damage: +5, Meat Drop: +10, Single Equip, Last Available: "2015-08"
@@ -8349,10 +8349,10 @@
 8475	weak tolerable asbestos thermos	2	good	Last Available: "2015-08"
 8476	liquefied liquefied red liquid rhinestones	0		Effect: "The Power of LOV", Effect Duration: 26, Last Available: "2015-08"
 8477	bland disco biscuit	3	decent	Last Available: "2015-08"
-8478	acceptable high-proof fancy huge Quaatorade&trade;	7	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 25, Last Available: "2015-08"
-8479	wool beefcake's biker's hat of doom	0		Muscle: +25, Spooky Spell Damage: +50, Cold Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
-8480	pulsating blue Lo Pan's occult strapping feathered headdress	0		Muscle: +5, Spell Damage Percent: +25, Spell Critical Percent: +30, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	upside-down Annie Oakley's Sinatra's electrician's hardhat of courage	0		Experience (Moxie): +5, Critical Hit Percent: +20, Spooky Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8478	acceptable fancy high-proof huge Quaatorade&trade;	7	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 25, Last Available: "2015-08"
+8479	wool beefcake's biker's hat of doom	0		Muscle: +25, Spooky Spell Damage: +50, Cold Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
+8480	pulsating blue Lo Pan's occult strapping feathered headdress	0		Muscle: +5, Spell Damage Percent: +25, Spell Critical Percent: +30, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	upside-down Annie Oakley's Sinatra's electrician's hardhat of courage	0		Experience (Moxie): +5, Critical Hit Percent: +20, Spooky Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	red Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	jittery Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	smooth velvet pants of extreme caution	0		Monster Level: -25, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	smooth velvet pants of extreme caution	0		Monster Level: -25, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	smooth smooth velvet shirt	0		Moxie: +15, Last Available: "2015-08"
 8492	tumbling sinister smooth velvet hat	0		Spell Damage: +10, Last Available: "2015-08"
 8493	crafty smooth velvet pocket square	0		Maximum MP: +10, Single Equip, Last Available: "2015-08"
@@ -8391,28 +8391,28 @@
 8517	rosewater-soaked SMOOCH bracers of dire peril	0		Weapon Damage: +20, Stench Resistance: +3, Single Equip, Last Available: "2015-08"
 8518	blinking savvy SMOOCH kneepads	0		Mysticality Percent: +20, Single Equip, Last Available: "2015-08"
 8519	hardened SMOOCH spaulders	0		Damage Reduction: 3, Single Equip, Last Available: "2015-08"
-8520	grievous SMOOCH codpiece of Gandalf	0		Weapon Damage Percent: +50, Spell Critical Percent: +20, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	grievous SMOOCH codpiece of Gandalf	0		Weapon Damage Percent: +50, Spell Critical Percent: +20, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	Socratic SMOOCH breastplate	0		Experience (Mysticality): +1, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	rotten lava cake	4	crappy	Last Available: "2015-08"
-8526	super-sized moldy pink slime	5	crappy	
+8526	moldy super-sized pink slime	5	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	stale devil hair pasta	4	decent	
-8530	half-sized flavorless spagecialetti	2	decent	
+8530	flavorless half-sized spagecialetti	2	decent	
 8531	upside-down Salsa Libre	0		
 8532	good gravy	0		
 8533	huge illicit fish sauce	0		
 8534	moldy libertagliatelle	3	crappy	
-8535	delicious small turkish mostaccioli	2	awesome	
-8536	delicious enchanted linguini of the sea	3	awesome	Effect: "Down With Chow", Effect Duration: 35
-8537	alkaline upside-down blurry teal Hersey&trade; SMOOCH	0		Effect: "Nut-Rition", Effect Duration: 42
+8535	small delicious turkish mostaccioli	2	awesome	
+8536	enchanted delicious linguini of the sea	3	awesome	Effect: "Down With Chow", Effect Duration: 35
+8537	alkaline upside-down teal blurry Hersey&trade; SMOOCH	0		Effect: "Nut-Rition", Effect Duration: 42
 8539	Alexy sauce	0		
 8540	ghostly rainbow sauce	0		
 8541	pulsating drug cocktail sauce	0		
-8542	fancy miniature stale Fettris	2	decent	Effect: "From Nantucket", Effect Duration: 40
+8542	stale miniature fancy Fettris	2	decent	Effect: "From Nantucket", Effect Duration: 40
 8543	flavorless fusillocybin	3	decent	
 8544	decent mirror prescription noodles	3	good	
 8545	denatured maroon blood-drive sticker	1	decent	
@@ -8421,10 +8421,10 @@
 8548	pickled adjusted shady shades	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 60
 8549	quadruple-dry squeaky toy rose	0		Effect: "Mercenary", Effect Duration: 39
 8550	tiny adequate weird gazelle steak	1	good	
-8551	fancy flavorless sausage without a cause	4	decent	Effect: "Twen Tea", Effect Duration: 35
+8551	flavorless fancy sausage without a cause	4	decent	Effect: "Twen Tea", Effect Duration: 35
 8552	electrified modified tumbling face paint	0		Effect: "Rushin' Hands", Effect Duration: 31
 8553	watered-down aged emergency margarita	2	awesome	
-8554	delicious enchanted vintage smart drink	3	awesome	Effect: "Minerva's Zen", Effect Duration: 5
+8554	enchanted delicious vintage smart drink	3	awesome	Effect: "Minerva's Zen", Effect Duration: 5
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8437,7 +8437,7 @@
 8564	blinking shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	lime green wholesome extremely unsafe experienced barrel lid	0		Experience: +2, Weapon Damage Percent: +100, Maximum HP Percent: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	blinking frightening Herculean brawny barrel hoop earring	0		Muscle Percent: +20, Experience (Muscle): +1, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2015-09"
-8567	red personal trainer's Fonzie's bankruptcy barrel	0		Experience (Moxie): +1, Experience Percent (Muscle): +10, Item Drop: +5, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	red personal trainer's Fonzie's bankruptcy barrel	0		Experience (Moxie): +1, Experience Percent (Muscle): +10, Item Drop: +5, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	shaking tun	0		Last Available: "2015-09"
@@ -8448,10 +8448,10 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	artisanal special bottle of Amontillado	3	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 45, Last Available: "2015-09"
+8578	special artisanal bottle of Amontillado	3	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 45, Last Available: "2015-09"
 8579	drinkable barrel-aged martini	4	good	Last Available: "2015-09"
 8580	yummy bite-sized lime green barrel pickle	1	awesome	Last Available: "2015-09"
-8581	moldy small blurry barrel cracker	2	crappy	Last Available: "2015-09"
+8581	small moldy blurry barrel cracker	2	crappy	Last Available: "2015-09"
 8582	powdered vibrating mushroom	1	EPIC	Last Available: "2015-09"
 8583	altered mushroom	1	decent	Effect: "Donho's Bubbly Ballad", Effect Duration: 30, Last Available: "2015-09"
 8584	perfumed KoL Con 12-gauge	0		Stench Resistance: +5, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	dangerous barrel gun	0		Weapon Damage: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	upside-down barrel beryl	0		Last Available: "2015-09"
-8589	moldy gigantic water log	7	crappy	Last Available: "2015-09"
+8589	gigantic moldy water log	7	crappy	Last Available: "2015-09"
 8590	blurry clever grievous barrelhead	0		Weapon Damage Percent: +50, Maximum MP: +20, Last Available: "2015-09"
 8591	bouncing forbidden bottoms of the barrel of the brazier	0		Spell Damage Percent: +50, Hot Spell Damage: +25, Last Available: "2015-09"
 8592	squat double-paned gravedigger's chest barrel	0		Spooky Damage: +10, Cold Resistance: +5, Last Available: "2015-09"
@@ -8471,7 +8471,7 @@
 8598	pulsating friendly slick barrel beryl ring	0		Moxie: +10, Familiar Weight: +3, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
-8601	ionized wobbly huge cuppa Flamibili tea	0		Effect: "Badger Underfoot", Effect Duration: 20, Last Available: "2015-09"
+8601	ionized huge wobbly cuppa Flamibili tea	0		Effect: "Badger Underfoot", Effect Duration: 20, Last Available: "2015-09"
 8602	frozen cuppa Yet tea	0		Effect: "Frisky Spirit", Effect Duration: 30, Last Available: "2015-09"
 8603	super-wet moist corrupted cuppa Boo tea	0		Effect: "You Drank Fish Wine", Effect Duration: 31, Last Available: "2015-09"
 8604	enhanced twirling cuppa Nas tea	0		Effect: "The Wisdom... of the Future", Effect Duration: 36, Last Available: "2015-09"
@@ -8489,13 +8489,13 @@
 8616	super-denatured corrupted cuppa Neuroplastici tea	0		Effect: "Happy Salamander", Effect Duration: 36, Last Available: "2015-09"
 8617	energized quadruple-electrified cuppa Dexteri tea	0		Effect: "Melancholy Burden", Effect Duration: 33, Last Available: "2015-09"
 8618	non-warmed energized wobbly cuppa Flexibili tea	0		Effect: "The Moxious Madrigal", Effect Duration: 44, Last Available: "2015-09"
-8619	nitrogenated dry pulsating teal cuppa Impregnabili tea	0		Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2015-09"
+8619	nitrogenated dry teal pulsating cuppa Impregnabili tea	0		Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2015-09"
 8620	boiled cuppa Obscuri tea	0		Effect: "Sleazy Weapon", Effect Duration: 27, Last Available: "2015-09"
 8621	denatured nitrogenated mirror cuppa Irritabili tea	0		Effect: "Dilated Pupils", Effect Duration: 53, Last Available: "2015-09"
 8622	polymerized double-boiled cuppa Mediocri tea	0		Effect: "Medieval Mage Mayhem", Effect Duration: 41, Last Available: "2015-09"
 8623	diffused pressed cuppa Loyal tea	0		Effect: "Charrrming", Effect Duration: 40, Last Available: "2015-09"
-8624	vaporized pulsating wobbly red cuppa Activi tea	1	awesome	Last Available: "2015-09"
-8625	mixed jittery pulsating cuppa Cruel tea	1		Last Available: "2015-09"
+8624	vaporized red wobbly pulsating cuppa Activi tea	1	awesome	Last Available: "2015-09"
+8625	mixed pulsating jittery cuppa Cruel tea	1		Last Available: "2015-09"
 8626	warmed cuppa Alacri tea	0		Effect: "Boschface", Effect Duration: 18, Last Available: "2015-09"
 8627	ionized enhanced cuppa Vitali tea	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 35, Last Available: "2015-09"
 8628	concentrated quadruple-irradiated maroon cuppa Mana tea	0		Effect: "Frozen Hands", Effect Duration: 55, Last Available: "2015-09"
@@ -8512,7 +8512,7 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	normal bowl of eyeballs	3	good	Last Available: "2015-10"
-8642	bland gray jittery bowl of mummy guts	3	decent	Last Available: "2015-10"
+8642	bland jittery gray bowl of mummy guts	3	decent	Last Available: "2015-10"
 8643	spoiled massive bowl of maggots	7	crappy	Last Available: "2015-10"
 8644	hand-crafted blood and blood	3	EPIC	Last Available: "2015-10"
 8645	weak artisanal Jack-O-Lantern beer	2	EPIC	Last Available: "2015-10"
@@ -8523,7 +8523,7 @@
 8650	tennis ball	0		Last Available: "2015-10"
 8651	ghostly crown of the cougar of James Dean of Gandalf	0		Moxie: +20, Experience (Moxie): +3, Spell Critical Percent: +20, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
-8653	bouncing ghostly stink-penny	0		
+8653	ghostly bouncing stink-penny	0		
 8654	hawk of the dark arts of the boozehound of Flo-Jo	0		Spell Damage Percent: +100, Booze Drop: +100, Initiative: +100
 8655	small decent skewed hamlet sandwich	2	good	
 8656	Othello's military jacket of Flo-Jo	0		Initiative: +100
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	blinking gravedigger's boxer's ghostly dagger of the boozehound	0		Muscle Percent: +10, Spooky Damage: +10, Booze Drop: +100
-8663	mediocre triple-distilled jittery ghost beer	6	decent	
+8663	triple-distilled mediocre jittery ghost beer	6	decent	
 8664	Jeselnik's Othello set	0		Sleaze Damage: +25
 8665	bouncing rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8558,7 +8558,7 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	fuchsia perfect ice cube	0		Last Available: "2015-11"
 8687	blinking The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	skewed Jack Frost's bellhop's hat	0		Cold Spell Damage: +50, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8688	skewed Jack Frost's bellhop's hat	0		Cold Spell Damage: +50, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
 8689	acceptable cyan ice porter	3	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	adjusted exotic travel brochure	0		Effect: "Gummiskin", Effect Duration: 69, Last Available: "2015-11"
 8691	wobbly bag of foreign bribes	0		Last Available: "2015-11"
@@ -8567,11 +8567,11 @@
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	twisted medicinal herbs	1		Last Available: "2016-01"
-8697	flavorless miniature blurry ice rice	2	decent	Last Available: "2016-01"
+8697	miniature flavorless blurry ice rice	2	decent	Last Available: "2016-01"
 8698	hand-crafted iced plum wine	3	EPIC	Last Available: "2016-01"
 8699	blinking huge wicked training belt of Tarzan of horror	0		Experience (Muscle): +3, Spell Damage: +5, Spooky Spell Damage: +25, Single Equip, Last Available: "2016-01"
 8700	friendly hardened banded training legwarmers	0		Damage Absorption: +100, Damage Reduction: 3, Familiar Weight: +3, Single Equip, Last Available: "2016-01"
-8701	narrow flame-retardant Tesla training helmet of the pedagogue	0		Experience: +3, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	narrow flame-retardant Tesla training helmet of the pedagogue	0		Experience: +3, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	jittery green training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8581,12 +8581,12 @@
 8708	altered abstraction: action	1		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 45, Last Available: "2015-12"
 8709	modified abstraction: thought	1		Last Available: "2015-12"
 8710	compressed huge abstraction: sensation	1		Last Available: "2015-12"
-8711	vaporized skewed red abstraction: purpose	1		Last Available: "2015-12"
+8711	vaporized red skewed abstraction: purpose	1		Last Available: "2015-12"
 8712	denatured pulsating pulsating abstraction: category	1		Last Available: "2015-12"
-8713	denatured twirling blinking abstraction: perception	1		Effect: "Buttermilk Boogie", Effect Duration: 25, Last Available: "2015-12"
+8713	denatured blinking twirling abstraction: perception	1		Effect: "Buttermilk Boogie", Effect Duration: 25, Last Available: "2015-12"
 8714	altered shaking abstraction: motion	1		Effect: "Superveiny 9000", Effect Duration: 25, Last Available: "2015-12"
 8715	dehydrated abstraction: joy	1		Last Available: "2015-12"
-8716	compressed blurry twirling abstraction: certainty	1		Last Available: "2015-12"
+8716	compressed twirling blurry abstraction: certainty	1		Last Available: "2015-12"
 8717	twisted jittery jittery pulsating abstraction: comprehension	1		Last Available: "2015-12"
 8718	huge modern picture frame	0		Last Available: "2015-12"
 8719	snack-sized moldy upside-down VYKEA meatballs	2	crappy	Last Available: "2015-11"
@@ -8598,21 +8598,21 @@
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	tumbling VYKEA rail	0		Last Available: "2015-11"
 8727	narrow VYKEA bracket	0		Last Available: "2015-11"
-8728	twirling green VYKEA dowel	0		Last Available: "2015-11"
+8728	green twirling VYKEA dowel	0		Last Available: "2015-11"
 8729	ghostly double-paned Da Vinci's slick VYKEA hex key	0		Moxie: +10, Experience (Mysticality): +5, Cold Resistance: +5, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
 8731	flavorless tin of submardines	3	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	watered-down bad bottle of norwhiskey	2	decent	Last Available: "2015-11"
+8732	bad watered-down bottle of norwhiskey	2	decent	Last Available: "2015-11"
 8733	distilled mirror octolus oculus	1	awesome	Last Available: "2015-11"
 8734	friendly sardine can key of the overflowing toilet of horror	0		Familiar Weight: +3, Stench Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2015-11"
-8735	wobbly spinning lard-coated Jeselnik's sharpshooter's norwhal helmet	0		Critical Hit Percent: +10, Sleaze Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "atk", Last Available: "2015-11"
+8735	wobbly spinning lard-coated Jeselnik's sharpshooter's norwhal helmet	0		Critical Hit Percent: +10, Sleaze Damage: +25, Sleaze Spell Damage: +25, Last Available: "2015-11", Familiar Effect: "atk"
 8736	squat Sherlock's supercharged hardened octolus-skin cloak	0		Damage Reduction: 3, Maximum MP Percent: +30, Item Drop: +25, Last Available: "2015-11"
-8737	weak acceptable perfect cosmopolitan	2	good	Last Available: "2015-11"
-8738	tolerable watered-down perfect negroni	2	good	Last Available: "2015-11"
+8737	acceptable weak perfect cosmopolitan	2	good	Last Available: "2015-11"
+8738	watered-down tolerable perfect negroni	2	good	Last Available: "2015-11"
 8739	acceptable perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	hand-crafted practically non-alcoholic perfect mimosa	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8741	mediocre perfect old-fashioned	4	decent	Last Available: "2015-11"
-8742	smooth watered-down perfect paloma	2	awesome	Last Available: "2015-11"
+8742	watered-down smooth perfect paloma	2	awesome	Last Available: "2015-11"
 8743	adjusted That 70s Cologne	0		Effect: "Seriously Mutated", Effect Duration: 50, Last Available: "2015-11"
 8744	polymerized alkaline bouncing Wal-Mart &quot;diamond&quot; ring	0		Effect: "Pyromania", Effect Duration: 69, Last Available: "2015-11"
 8745	non-electrified dry Puffstone cigar	0		Effect: "Pill Power", Effect Duration: 23, Last Available: "2015-11"
@@ -8622,8 +8622,8 @@
 8749	double-flattened Deep Machine Tunnels snowglobe	0		Effect: "Wet Jaw", Effect Duration: 14, Last Available: "2015-12"
 8750	improved aerosolized hemp candy necklace	0		Effect: "Sweet Taste", Effect Duration: 33, Last Available: "2015-12"
 8751	adjusted extra-vacuum-sealed communal gobstopper	0		Effect: "Crimbo Epiphany", Effect Duration: 21, Last Available: "2015-12"
-8752	stale small Crimbo salad	2	decent	Last Available: "2015-12"
-8753	moldy super-sized bread line	5	crappy	Last Available: "2015-12"
+8752	small stale Crimbo salad	2	decent	Last Available: "2015-12"
+8753	super-sized moldy bread line	5	crappy	Last Available: "2015-12"
 8754	lousy bark rootbeer	4	decent	Last Available: "2015-12"
 8755	drinkable squat ale	4	good	Last Available: "2015-12"
 8756	toasty plastic Tammy the Tambourine Elf	0		Hot Damage: +5, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	fuchsia Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	mediocre special wobbly spinning Gratitude chocolate (bourbon-filled)	4	decent	Effect: "Buggy Flavor", Effect Duration: 45, Last Available: "2016-02"
+8766	mediocre special spinning wobbly Gratitude chocolate (bourbon-filled)	4	decent	Effect: "Buggy Flavor", Effect Duration: 45, Last Available: "2016-02"
 8767	jittery Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8685,17 +8685,17 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	wobbly Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	tiny moldy Kudzu salad	1	crappy	Last Available: "2016-12"
+8816	moldy tiny Kudzu salad	1	crappy	Last Available: "2016-12"
 8817	boiled spinning Mansquito Serum	1		Last Available: "2016-12"
 8818	distilled tolerable Miss Graves' vermouth	5	good	Last Available: "2016-12"
-8819	super-sized delicious The Plumber's mushroom stew	5	awesome	Last Available: "2016-12"
+8819	delicious super-sized The Plumber's mushroom stew	5	awesome	Last Available: "2016-12"
 8820	boiled huge blinking The Author's ink	1		Effect: "Norwhalloped", Effect Duration: 30, Last Available: "2016-02"
 8821	special hand-crafted The Mad Liquor	4	EPIC	Effect: "Feet of Grapefruit", Effect Duration: 50, Last Available: "2016-12"
 8822	hand-crafted practically non-alcoholic ghostly Doc Clock's thyme cocktail	1	super ultra mega turbo EPIC	Last Available: "2016-12"
-8823	thick stale spinning Mr. Burnsger	5	decent	Last Available: "2016-12"
-8824	denatured huge spinning The Inquisitor's unidentifiable object	1		Effect: "Reedy Pipes", Effect Duration: 45, Last Available: "2016-12"
+8823	stale thick spinning Mr. Burnsger	5	decent	Last Available: "2016-12"
+8824	denatured spinning huge The Inquisitor's unidentifiable object	1		Effect: "Reedy Pipes", Effect Duration: 45, Last Available: "2016-12"
 8825	dog trainer's hardened The Jokester's gun of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Experience (familiar): +1, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	Herculean educational The Jokester's wig of Flo-Jo	0		Experience: +1, Experience (Muscle): +1, Initiative: +100, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
+8826	Herculean educational The Jokester's wig of Flo-Jo	0		Experience: +1, Experience (Muscle): +1, Initiative: +100, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	arcane researcher's thinker's The Jokester's pants of mayonnaise	0		Mysticality: +10, Experience Percent (Mysticality): +10, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	modified dry Jokester makeup	0		Effect: "Chalked-Up Teeth", Effect Duration: 63, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
@@ -8703,8 +8703,8 @@
 8831	squat basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	ionized flattened olive robin's egg	0		Effect: "Radiant Personality", Effect Duration: 51, Last Available: "2016-12"
-8834	special adequate miniature robin flan	2	good	Effect: "Innately Wise", Effect Duration: 50, Last Available: "2016-12"
-8835	extra-dry enchanted smooth robin nog	5	awesome	Effect: "You're Rubber", Effect Duration: 25, Last Available: "2016-12"
+8834	special miniature adequate robin flan	2	good	Effect: "Innately Wise", Effect Duration: 50, Last Available: "2016-12"
+8835	smooth enchanted extra-dry robin nog	5	awesome	Effect: "You're Rubber", Effect Duration: 25, Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	mirror plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8713,7 +8713,7 @@
 8841	tarnished tumbling Mansquito's blood	0		Effect: "Tiki Temerity", Effect Duration: 33
 8842	extra-galvanized infrablack lipstick	0		Effect: "Bestial Sympathy", Effect Duration: 47
 8843	Vulcanized can of drain cleaner	0		Effect: "Compensatory Cruelness", Effect Duration: 24
-8844	concentrated ionized narrow green The Author's inkwell	0		Effect: "Chlorophyll Flavor", Effect Duration: 66
+8844	concentrated ionized green narrow The Author's inkwell	0		Effect: "Chlorophyll Flavor", Effect Duration: 66
 8845	improved bag of random words	0		Effect: "Scrappy, Shadowy", Effect Duration: 11
 8846	colloidal triple-pickled blinking spinning tube of pendulum lube	0		Effect: "Ocelot Eyes", Effect Duration: 62
 8847	quantum maroon red-hot jawbreaker	0		Effect: "The Real Deal", Effect Duration: 23
@@ -8726,7 +8726,7 @@
 8854	narrow nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
-8857	bouncing blurry nugget of nicksilver	0		Last Available: "2016-02"
+8857	blurry bouncing nugget of nicksilver	0		Last Available: "2016-02"
 8858	nugget of ticksilver	0		Last Available: "2016-02"
 8859	slick quicksilver ring	0		Moxie: +10, Single Equip, Last Available: "2016-02"
 8860	razor-sharp smartaleck's thicksilver ring of the pedagogue	0		Moxie Percent: +30, Experience: +3, Weapon Damage Percent: +25, Single Equip, Last Available: "2016-02"
@@ -8745,20 +8745,20 @@
 8873	hardened Pork 'n' Pork 'n' Pork 'n' Beans	0		Damage Reduction: 3, Last Available: "2016-02"
 8874	narrow spinning foul-smelling Jim Carey's sharpshooter's banded razor-sharp Val-U Brand Every Bean Salad	0		Weapon Damage Percent: +25, Damage Absorption: +100, Critical Hit Percent: +10, Monster Level: +25, Stench Damage: +10, Last Available: "2016-02"
 8875	mansplainer's occult strapping Shrub's Premium Baked Beans	0		Muscle: +5, Spell Damage Percent: +25, Monster Level: +15, Last Available: "2016-02"
-8876	yummy snack-sized enchanted bouncing plate of Heimz Fortified Kidney Beans	2	awesome	Effect: "Super Speed", Effect Duration: 30, Last Available: "2016-02"
-8877	diet flavorless narrow plate of Tesla's Electroplated Beans	1	decent	Last Available: "2016-02"
+8876	enchanted yummy snack-sized bouncing plate of Heimz Fortified Kidney Beans	2	awesome	Effect: "Super Speed", Effect Duration: 30, Last Available: "2016-02"
+8877	flavorless diet narrow plate of Tesla's Electroplated Beans	1	decent	Last Available: "2016-02"
 8878	special adequate plate of Mixed Garbanzos and Chickpeas	3	good	Effect: "Mushroom Moxiousness", Effect Duration: 30, Last Available: "2016-02"
-8879	moldy half-sized plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
+8879	half-sized moldy plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
 8880	flavorless plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
 8881	stale huge ghostly plate of World's Blackest-Eyed Peas	6	decent	Last Available: "2016-02"
 8882	small decent shaking plate of Trader Olaf's Exotic Stinkbeans	2	good	Last Available: "2016-02"
 8883	flavorless plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Last Available: "2016-02"
 8884	normal skewed plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
-8885	stale bite-sized plate of Shrub's Premium Baked Beans	1	decent	Last Available: "2016-02"
+8885	bite-sized stale plate of Shrub's Premium Baked Beans	1	decent	Last Available: "2016-02"
 8886	Fancy Jeff's pocket square of the ox of Flo-Jo	0		Muscle: +20, Initiative: +100, Last Available: "2016-02"
-8887	twirling rosy-cheeked stylish Daisy's unclean bloomers of the early riser	0		Moxie: +25, Maximum HP Percent: +30, Adventures: +7, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	twirling rosy-cheeked stylish Daisy's unclean bloomers of the early riser	0		Moxie: +25, Maximum HP Percent: +30, Adventures: +7, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	Samson's Amoon-Ra Cowtep's nemes of mayonnaise of the early riser	0		Experience (Muscle): +5, Sleaze Spell Damage: +50, Adventures: +7, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	Samson's Amoon-Ra Cowtep's nemes of mayonnaise of the early riser	0		Experience (Muscle): +5, Sleaze Spell Damage: +50, Adventures: +7, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	jittery Glenn's dice	0		Last Available: "2016-02"
 8891	aromatic clever padded razor-sharp Former Sheriff Dan's tin star of the sewer	0		Weapon Damage Percent: +25, Damage Absorption: +20, Maximum MP: +20, Stench Damage: +25, Stench Resistance: +1, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8770,16 +8770,16 @@
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	decent	Last Available: "2016-02"
 8900	teal gun parts	0		Last Available: "2016-02"
-8901	diffused enhanced purple blurry triggerfingerbone	0		Effect: "Reedy Pipes", Effect Duration: 36, Last Available: "2016-02"
+8901	diffused enhanced blurry purple triggerfingerbone	0		Effect: "Reedy Pipes", Effect Duration: 36, Last Available: "2016-02"
 8902	flattened lime green ghost bit	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25, Last Available: "2016-02"
-8903	energized polarized green wobbly bouncing buzzard feather	0		Effect: "Bricked-In", Effect Duration: 51, Last Available: "2016-02"
+8903	energized polarized green bouncing wobbly buzzard feather	0		Effect: "Bricked-In", Effect Duration: 51, Last Available: "2016-02"
 8904	extra-aerosolized tarnished polarized lion musk	0		Effect: "Certainty", Effect Duration: 65, Last Available: "2016-02"
 8905	toothsome tiny bear claw	1	awesome	Last Available: "2016-02"
 8906	corrupted denatured shaking rattler gland	0		Effect: "It Didn't Kill You", Effect Duration: 54, Last Available: "2016-02"
 8907	activated warmed jittery half-digested coal	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 41, Last Available: "2016-02"
 8908	extra-nitrogenated blinking tightly-wound spine	0		Effect: "Bonelording", Effect Duration: 16, Last Available: "2016-02"
-8909	spoiled low-calorie rotting beefsteak	1	crappy	Last Available: "2016-02"
-8910	hand-crafted watered-down red firemilk	2	EPIC	Last Available: "2016-02"
+8909	low-calorie spoiled rotting beefsteak	1	crappy	Last Available: "2016-02"
+8910	watered-down hand-crafted red firemilk	2	EPIC	Last Available: "2016-02"
 8911	unsweetened spidercow eye-cluster	0		Effect: "Dexteri Tea", Effect Duration: 48, Last Available: "2016-02"
 8912	modified lime green moomy dust	1		Effect: "The Dinsey Spirit", Effect Duration: 5, Last Available: "2016-02"
 8913	mansplainer's wicked western-style skinning knife	0		Spell Damage: +5, Monster Level: +15, Last Available: "2016-02"
@@ -8791,7 +8791,7 @@
 8919	twirling LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
-8922	teal mirror Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
+8922	mirror teal Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
 8924	disc (black)	0		
 8925	disc (red)	0		
@@ -8820,14 +8820,14 @@
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	cyan slicksilver spurs	0		Last Available: "2016-02"
-8951	pulsating shaking sicksilver spurs	0		Last Available: "2016-02"
+8951	shaking pulsating sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
 8954	blurry special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	maroon Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
 8957	Tales of the West: Snake Oiling	0		
-8958	olive blinking briefcase full of snakes	0		
+8958	blinking olive briefcase full of snakes	0		
 8959	jittery chaotic beefy one-gallon hat	0		Muscle: +10, Spell Critical Percent: +10
 8960	fireproof chaotic two-gallon hat	0		Spell Critical Percent: +10, Hot Resistance: +3
 8961	skewed shaking supercharged three-gallon hat of the glutton	0		Maximum MP Percent: +30, Food Drop: +100
@@ -8852,27 +8852,27 @@
 8980	anodized modified green pulsating patent avarice tonic	0		Effect: "Preternatural Greed", Effect Duration: 33
 8981	liquefied adjusted patent alacrity tonic	0		Effect: "Red Door Syndrome", Effect Duration: 43
 8982	electrified enhanced non-deionized corrupted marrow	0		Effect: "Antarctic Memories", Effect Duration: 67
-8983	practically non-alcoholic acceptable rodeo whiskey	1	good	
+8983	acceptable practically non-alcoholic rodeo whiskey	1	good	
 8984	huge Thwaitgold scorpion statuette	0		
 8985	Jim Carey's real cowboy hat	0		Monster Level: +25
-8986	gray narrow Memories of Cow Punching	0		Free Pull
+8986	narrow gray Memories of Cow Punching	0		Free Pull
 8987	Memories of Beanslinging	0		Free Pull
 8988	Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	huge electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	tumbling do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	twisted armored prawn	1		Last Available: "2016-03"
-8993	diet decent jumping horseradish	1	good	Last Available: "2016-03"
+8993	decent diet jumping horseradish	1	good	Last Available: "2016-03"
 8994	acceptable bouncing Sacramento wine	4	good	Last Available: "2016-03"
 8995	dry skewed Greek fire	0		Effect: "You're Not Cooking", Effect Duration: 32, Last Available: "2016-03"
 8996	family-friendly banded Da Vinci's Newton's ox-head shield of vim and vigor	0		Experience (Mysticality): 8, Damage Absorption: +100, Maximum HP Percent: +50, Sleaze Resistance: +1, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	teal tumbling Jeselnik's MacGyver's rock-hard forbidden dented scepter of the sweet-tooth	0		Spell Damage Percent: +50, Damage Reduction: 5, Maximum MP: +100, Sleaze Damage: +25, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	blinking Usain Bolt's greasy forbidden experienced very pointy crown of Flo-Jo	0		Experience: +2, Spell Damage Percent: +50, Sleaze Spell Damage: +10, Initiative: 180, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	blinking Usain Bolt's greasy forbidden experienced very pointy crown of Flo-Jo	0		Experience: +2, Spell Damage Percent: +50, Sleaze Spell Damage: +10, Initiative: 180, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	jittery Usain Bolt's Jeselnik's nippy experienced battle broom of the cougar	0		Moxie: +20, Experience: +2, Cold Damage: +10, Sleaze Damage: +25, Initiative: +80, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	censurious ribald medical-grade carpe of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Sleaze Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9002	studded deadly codpiece of the blizzard of bravery	0		Weapon Damage: +5, Damage Absorption: +80, Cold Spell Damage: +25, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	occult thinker's weightlifter's troutsers of vim and vigor	0		Muscle: +15, Mysticality: +10, Spell Damage Percent: +25, Maximum HP Percent: +50, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	occult thinker's weightlifter's troutsers of vim and vigor	0		Muscle: +15, Mysticality: +10, Spell Damage Percent: +25, Maximum HP Percent: +50, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	blurry sharpshooter's hale deadly brainy bass clarinet	0		Mysticality: +5, Weapon Damage: +5, Maximum HP: +20, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2016-04"
 9005	Usain Bolt's grievous fish hatchet of the overflowing toilet of bravery	0		Weapon Damage Percent: +50, Stench Spell Damage: +50, Spooky Resistance: +5, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04"
 9006	upside-down inspector's family-friendly dance instructor's tunac of Calamity Jane	0		Experience Percent (Moxie): +10, Critical Hit Percent: +15, Sleaze Resistance: +1, Item Drop: +15, Lasts Until Rollover, Last Available: "2016-04"
@@ -8899,7 +8899,7 @@
 9027	tumbling First Post shirt - Cir Senam of the cougar of the dark arts of the early riser	0		Moxie: +20, Spell Damage Percent: +100, Adventures: +7, Last Available: "2016-05"
 9028	teal high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	low-calorie decent tumbling star salad	1	good	
+9030	decent low-calorie tumbling star salad	1	good	
 9031	teal Thwaitgold moth statuette	0		
 9032	normal bowl of Tastee-Wheet&trade;	4	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
@@ -8907,7 +8907,7 @@
 9035	adequate skewed browser cookie	4	good	Last Available: "2016-06"
 9036	irresponsibly strong perfectly mixed hacked gibson	6	EPIC	Last Available: "2016-06"
 9037	skewed Source shades of the storm	0		Maximum MP Percent: +40, Last Available: "2016-06"
-9038	cyan blinking software bug	0		Last Available: "2016-06"
+9038	blinking cyan software bug	0		Last Available: "2016-06"
 9039	pulsating missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
@@ -8947,7 +8947,7 @@
 9075	activated shoe gum	0		Effect: "Thaumodynamic", Effect Duration: 29, Last Available: "2016-07"
 9076	bouncing occult brawny noir fedora of the pedagogue	0		Muscle Percent: +20, Experience: +3, Spell Damage Percent: +25, Last Available: "2016-07"
 9077	skewed miser's frosty trench coat of the pedagogue	0		Experience: +3, Cold Spell Damage: +10, Meat Drop: +10, Last Available: "2016-07"
-9078	perfectly mixed fortified Falcon&trade; Maltese Liquor	5	EPIC	Last Available: "2016-07"
+9078	fortified perfectly mixed Falcon&trade; Maltese Liquor	5	EPIC	Last Available: "2016-07"
 9079	yummy hardboiled egg	3	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	fuchsia knitted Mr. Screege's spectacles	0		Cold Resistance: +3, Single Equip, Last Available: "2016-08"
 9092	chaotic fortified Spookyraven signet of the detective	0		Damage Absorption: +60, Spell Critical Percent: +10, Item Drop: +20, Single Equip, Last Available: "2016-08"
 9093	mirror lime green padded tie-dyed fannypack of the overflowing toilet	0		Damage Absorption: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2016-08"
-9094	spinning wobbly executive burnt snowpants of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +40, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	spinning wobbly executive burnt snowpants of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +40, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	spinning frightening standards and practices guide	0		Spooky Damage: +5, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	jittery scorching savvy Carpathian longsword of the sweet-tooth	0		Mysticality Percent: +20, Hot Damage: +25, Candy Drop: +100, Last Available: "2016-08"
 9097	clever fortified Liam's mail of mayonnaise	0		Damage Absorption: +60, Maximum MP: +20, Sleaze Spell Damage: +50, Last Available: "2016-08"
@@ -8977,7 +8977,7 @@
 9105	wobbly compounded experience	0		Last Available: "2016-09"
 9106	Rad-B-Gone (1 lb.)	0		
 9107	irradiated energized mirror Rad-Pro (1 oz.)	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
-9108	gray huge lead umbrella	0		
+9108	huge gray lead umbrella	0		
 9109	unsweetened narrow Shrieking Weasel holo-record	0		Effect: "Boilermade", Effect Duration: 52
 9110	tarnished jittery Power-Guy 2000 holo-record	0		Effect: "Busy Bein' Delicious", Effect Duration: 33
 9111	colloidal polarized polarized Lucky Strikes holo-record	0		Effect: "Angry Bone", Effect Duration: 47
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	repaid diaper of chilblains	0		Cold Damage: +25
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	lousy watered-down Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
+9119	watered-down lousy Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
 9120	Jim Carey's Unstable Pointy Ears	0		Monster Level: +25, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	crappy	Last Available: "2016-09"
@@ -9004,7 +9004,7 @@
 9132	Rosewater's pistol of the cheetah	0		Mysticality Percent: +30, Initiative: +60
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	flavorless maroon leftover pasty	3	decent	
-9135	weak bad yellow very whiskey	2	decent	
+9135	bad weak yellow very whiskey	2	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9020,9 +9020,9 @@
 9148	pulsating Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	tarnished invisible string	0		Lasts Until Rollover, Effect: "Boon of the Storm Tortoise", Effect Duration: 36, Last Available: "2016-10"
-9151	chilled non-frozen gray shaking invisible seam ripper	0		Lasts Until Rollover, Effect: "Squid Squint", Effect Duration: 28, Last Available: "2016-10"
+9151	chilled non-frozen shaking gray invisible seam ripper	0		Lasts Until Rollover, Effect: "Squid Squint", Effect Duration: 28, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9153	normal half-sized tumbling raw sweet potato	2	good	Last Available: "2016-11"
+9153	half-sized normal tumbling raw sweet potato	2	good	Last Available: "2016-11"
 9154	flavorless raw beans	3	decent	Last Available: "2016-11"
 9155	bland raw stuffing	3	decent	Last Available: "2016-11"
 9156	half-sized decent fuchsia raw cranberry sauce	2	good	Last Available: "2016-11"
@@ -9044,10 +9044,10 @@
 9172	spoiled green bean casserole	4	crappy	Last Available: "2016-11"
 9173	rotten tiny baked stuffing	1	crappy	Last Available: "2016-11"
 9174	bland small cranberry cylinder	2	decent	Last Available: "2016-11"
-9175	diet decent thanksgiving turkey	1	good	Last Available: "2016-11"
-9176	big normal mince pie	5	good	Last Available: "2016-11"
+9175	decent diet thanksgiving turkey	1	good	Last Available: "2016-11"
+9176	normal big mince pie	5	good	Last Available: "2016-11"
 9177	flavorless miniature mashed potatoes	2	decent	Last Available: "2016-11"
-9178	toothsome half-sized warm gravy	2	awesome	Last Available: "2016-11"
+9178	half-sized toothsome warm gravy	2	awesome	Last Available: "2016-11"
 9179	special adequate bouncing bread roll	3	good	Effect: "Supafly", Effect Duration: 15, Last Available: "2016-11"
 9180	moldy leftovers	4	crappy	Last Available: "2016-11"
 9181	yummy leftovers sandwich	3	awesome	Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	boiled fuchsia eldritch concentrate	0		Effect: "Spooky Demeanor", Effect Duration: 44, Last Available: "2016-11"
-9192	watered-down enchanted mediocre upside-down shaking eldritch extract	2	decent	Effect: "Craft Tea", Effect Duration: 40, Last Available: "2016-11"
+9192	enchanted mediocre watered-down shaking upside-down eldritch extract	2	decent	Effect: "Craft Tea", Effect Duration: 40, Last Available: "2016-11"
 9193	lime green Oprah's Sinatra's Official Council Aide Pin	0		Experience (Moxie): +5, Maximum MP Percent: +50, Last Available: "2016-11"
-9194	hand-crafted practically non-alcoholic eldritch distillate	1	super ultra mega EPIC	Last Available: "2016-11"
+9194	practically non-alcoholic hand-crafted eldritch distillate	1	super ultra mega EPIC	Last Available: "2016-11"
 9195	dried mirror eldritch essence	1		Last Available: "2016-11"
 9196	Science Notebook of vim and vigor	0		Maximum HP Percent: +50
 9197	executive rosewater-soaked dance instructor's eldritch hat	0		Experience Percent (Moxie): +10, Stench Resistance: +3, Meat Drop: +40, Last Available: "2016-11"
@@ -9073,8 +9073,8 @@
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
 9203	bouncing Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
-9204	pulsating twirling counterfeit city	0		Last Available: "2016-12"
-9205	wobbly purple wobbly sprinkles	0		Last Available: "2016-12"
+9204	twirling pulsating counterfeit city	0		Last Available: "2016-12"
+9205	purple wobbly wobbly sprinkles	0		Last Available: "2016-12"
 9206	The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	rosy-cheeked ball and chain	0		Maximum HP Percent: +30, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
@@ -9088,9 +9088,9 @@
 9216	green interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	miniature spoiled mirror ghostly narrow animal part cracker	2	crappy	Last Available: "2016-12"
+9219	spoiled miniature mirror ghostly narrow animal part cracker	2	crappy	Last Available: "2016-12"
 9220	artisanal gingerbread wine	4	EPIC	Last Available: "2016-12"
-9221	snack-sized adequate special gingerbread mug	2	good	Effect: "Oily Flavor", Effect Duration: 5, Last Available: "2016-12"
+9221	special snack-sized adequate gingerbread mug	2	good	Effect: "Oily Flavor", Effect Duration: 5, Last Available: "2016-12"
 9222	cyan jittery Rosewater's gingerbread mask	0		Mysticality Percent: +30, Last Available: "2016-12"
 9223	perfumed wicked gingerservo of the cheetah	0		Spell Damage: +5, Stench Resistance: +5, Initiative: +60, Single Equip, Last Available: "2016-12"
 9224	dry tainted icing	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 60, Last Available: "2016-12"
@@ -9102,7 +9102,7 @@
 9230	mirror curative creme brulee torch	0		HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-12"
 9231	occult candy crowbar	0		Spell Damage Percent: +25, Lasts Until Rollover, Last Available: "2016-12"
 9232	stylish slick candy screwdriver	0		Moxie: 35, Last Available: "2016-12"
-9233	blurry blinking gingerbread dog treat	0		Last Available: "2016-12"
+9233	blinking blurry gingerbread dog treat	0		Last Available: "2016-12"
 9234	bouncing pumpkin spice candle of doom	0		Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-12"
 9235	super-unsweetened anodized magnetized mirror bouncing gingerbread spice latte	0		Effect: "Super Vision", Effect Duration: 25, Last Available: "2016-12"
 9236	gingerbread gavel of the pedagogue of vim and vigor	0		Experience: +3, Maximum HP Percent: +50, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	ionized industrial frosting	0		Effect: "Techno Bliss", Effect Duration: 12, Last Available: "2016-12"
 9242	magnetized polymerized blurry fake cocktail	0		Effect: "Very Clean Teeth", Effect Duration: 66, Last Available: "2016-12"
-9243	aged boozy enchanted high-end ginger wine	5	awesome	Effect: "Coming Up Roses", Effect Duration: 50, Last Available: "2016-12"
+9243	boozy aged enchanted high-end ginger wine	5	awesome	Effect: "Coming Up Roses", Effect Duration: 50, Last Available: "2016-12"
 9244	electrified plastic bad vibe	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9245	blurry Socratic plastic angry vikings	0		Experience (Mysticality): +1, Last Available: "2016-12"
 9246	avaricious plastic Knows About Chakras	0		Meat Drop: +30, Last Available: "2016-12"
@@ -9122,8 +9122,8 @@
 9250	galvanized Inner Strength	0		Effect: "On the Trolley", Effect Duration: 38, Last Available: "2016-12"
 9251	Vulcanized adjusted jittery Inner Truth	0		Effect: "Dance Interpreter", Effect Duration: 18, Last Available: "2016-12"
 9252	normal spiritual candy cane	3	good	Last Available: "2016-12"
-9253	hand-crafted watered-down spiritual eggnog	2	EPIC	Last Available: "2016-12"
-9254	yummy gigantic enchanted spiritual fruitcake	7	awesome	Effect: "Snobby", Effect Duration: 10, Last Available: "2016-12"
+9253	watered-down hand-crafted spiritual eggnog	2	EPIC	Last Available: "2016-12"
+9254	enchanted gigantic yummy spiritual fruitcake	7	awesome	Effect: "Snobby", Effect Duration: 10, Last Available: "2016-12"
 9255	normal spiritual gingerbread	3	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9144,8 +9144,8 @@
 9272	lime green negative lump	0		
 9273	fuchsia Da Vinci's smartaleck's Third Eye	0		Moxie Percent: +30, Experience (Mysticality): +5, Last Available: "2016-12"
 9274	wobbly Herculean Krampus Horn of the cougar	0		Moxie: +20, Experience (Muscle): +1, Single Equip, Last Available: "2016-12"
-9275	spoiled special hambrosier	3	crappy	Effect: "Frisky Spirit", Effect Duration: 5, Last Available: "2016-12"
-9276	weak aged chakra-mental wine	2	awesome	Last Available: "2016-12"
+9275	special spoiled hambrosier	3	crappy	Effect: "Frisky Spirit", Effect Duration: 5, Last Available: "2016-12"
+9276	aged weak chakra-mental wine	2	awesome	Last Available: "2016-12"
 9277	nitrogenated ionized blurry chakra malt	0		Effect: "Boon of the War Snapper", Effect Duration: 57, Last Available: "2016-12"
 9278	stale olive Black Angus blackburger	4	decent	Last Available: "2016-12"
 9279	acceptable extra-dry huge brandy	5	good	Last Available: "2016-12"
@@ -9161,15 +9161,15 @@
 9289	spinning blurry prompt electrified Uncle Crimbo's hat of the pedagogue	0		Experience: +3, Adventures: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9290	small stale bouncing Eldritch snap	2	decent	Last Available: "2017-01"
 9291	denatured pulsating hot jelly	1		Effect: "Cute Vision", Effect Duration: 20, Last Available: "2017-01"
-9292	powdered mirror wobbly jelly	1		Last Available: "2017-01"
+9292	powdered wobbly mirror jelly	1		Last Available: "2017-01"
 9293	powdered blurry jelly	1		Effect: "Bottle in front of Me", Effect Duration: 10, Last Available: "2017-01"
 9294	compressed jittery gray sleaze jelly	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20, Last Available: "2017-01"
 9295	modified pulsating ghostly stench jelly	1		Last Available: "2017-01"
 9296	twirling space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal toast with hot jelly	3	good	Last Available: "2017-01"
-9298	miniature moldy skewed cyan toast with jelly	2	crappy	Last Available: "2017-01"
+9298	miniature moldy cyan skewed toast with jelly	2	crappy	Last Available: "2017-01"
 9299	adequate enchanted toast with jelly	3	good	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 20, Last Available: "2017-01"
-9300	fancy half-sized flavorless huge pulsating toast with sleaze jelly	2	decent	Effect: "Space Tripping", Effect Duration: 15, Last Available: "2017-01"
+9300	fancy flavorless half-sized huge pulsating toast with sleaze jelly	2	decent	Effect: "Space Tripping", Effect Duration: 15, Last Available: "2017-01"
 9301	huge stale jittery toast with stench jelly	6	decent	Last Available: "2017-01"
 9302	shaking space jellybicycle	0		Familiar Weight: +5
 9303	red hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9180,8 +9180,8 @@
 9308	ribald beefcake's wax face	0		Muscle: +25, Sleaze Damage: +10, Last Available: "2017-01"
 9309	perfectly mixed wax booze	3	EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	pickled blinking purple sea jelly	1		Last Available: "2017-01"
-9312	rotten special small sea truffle	2	crappy	Effect: "Permanent Halloween", Effect Duration: 5, Last Available: "2017-01"
+9311	pickled purple blinking sea jelly	1		Last Available: "2017-01"
+9312	small special rotten sea truffle	2	crappy	Effect: "Permanent Halloween", Effect Duration: 5, Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	coward's recovered cufflinks	0		Monster Level: -20, Single Equip, Last Available: "2017-01"
@@ -9203,7 +9203,7 @@
 9331	purple Jack Frost's forbidden eldritch hammer of extreme caution	0		Spell Damage Percent: +50, Monster Level: -25, Cold Spell Damage: +50, Last Available: "2017-01"
 9332	moldy eldritch mushroom	3	crappy	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	normal half-sized eldritch mushroom pizza	2	good	Last Available: "2017-03"
+9334	half-sized normal eldritch mushroom pizza	2	good	Last Available: "2017-03"
 9335	lime green eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	tumbling narrow eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	flattened huge eldritch rub	0		Effect: "The Q Is Talking To You", Effect Duration: 13, Last Available: "2017-02"
@@ -9230,45 +9230,45 @@
 9358	ghostly bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	narrow spinning baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
-9361	spinning blue twirling limepatch	0		Last Available: "2017-03"
+9361	twirling spinning blue limepatch	0		Last Available: "2017-03"
 9362	narrow narrow pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	bouncing imaginary lemon	0		Last Available: "2017-03"
-9365	bad enchanted extra-dry literal grasshopper	5	decent	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2017-03"
+9365	extra-dry bad enchanted literal grasshopper	5	decent	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2017-03"
 9366	smooth double entendre	4	awesome	Last Available: "2017-03"
 9367	tolerable practically non-alcoholic spinning Phlegethon	1	good	Last Available: "2017-03"
-9368	acceptable spirit-forward narrow Siberian sunrise	5	good	Last Available: "2017-03"
+9368	spirit-forward acceptable narrow Siberian sunrise	5	good	Last Available: "2017-03"
 9369	hand-crafted ghostly mentholated wine	3	EPIC	Last Available: "2017-03"
-9370	delicious practically non-alcoholic ghostly fuchsia low tide martini	1	awesome	Last Available: "2017-03"
+9370	practically non-alcoholic delicious fuchsia ghostly low tide martini	1	awesome	Last Available: "2017-03"
 9371	acceptable shroomtini	4	good	Last Available: "2017-03"
 9372	mediocre morning dew	3	decent	Last Available: "2017-03"
-9373	watered-down lousy skewed whiskey squeeze	2	decent	Last Available: "2017-03"
+9373	lousy watered-down skewed whiskey squeeze	2	decent	Last Available: "2017-03"
 9374	acceptable squat great fashioned	3	good	Last Available: "2017-03"
 9375	aged Gnomish sagngria	3	awesome	Last Available: "2017-03"
 9376	artisanal vodka stinger	3	EPIC	Last Available: "2017-03"
-9377	mediocre weak fancy extremely slippery nipple	2	decent	Effect: "Lubed", Effect Duration: 20, Last Available: "2017-03"
+9377	fancy weak mediocre extremely slippery nipple	2	decent	Effect: "Lubed", Effect Duration: 20, Last Available: "2017-03"
 9378	hand-crafted piscatini	4	EPIC	Last Available: "2017-03"
 9379	practically non-alcoholic acceptable Churchill	1	good	Last Available: "2017-03"
 9380	drinkable soilzerac	4	good	Last Available: "2017-03"
 9381	hand-crafted bouncing London frog	4	EPIC	Last Available: "2017-03"
 9382	artisanal nothingtini	4	EPIC	Last Available: "2017-03"
 9383	practically non-alcoholic delicious eighth plague	1	awesome	Last Available: "2017-03"
-9384	acceptable weak single entendre	2	good	Last Available: "2017-03"
+9384	weak acceptable single entendre	2	good	Last Available: "2017-03"
 9385	triple-distilled drinkable wobbly spinning reverse Tantalus	7	good	Last Available: "2017-03"
 9386	drinkable weak twirling elemental caipiroska	2	good	Last Available: "2017-03"
-9387	lousy watered-down Feliz Navidad	2	decent	Last Available: "2017-03"
+9387	watered-down lousy Feliz Navidad	2	decent	Last Available: "2017-03"
 9388	mediocre red Bloody Nora	4	decent	Last Available: "2017-03"
 9389	drinkable moreltini	3	good	Last Available: "2017-03"
-9390	weak bad hell in a bucket	2	decent	Last Available: "2017-03"
+9390	bad weak hell in a bucket	2	decent	Last Available: "2017-03"
 9391	bad spirit-forward ghostly Newark	5	decent	Last Available: "2017-03"
-9392	enchanted artisanal watered-down R'lyeh	2	EPIC	Effect: "Rushin' Hands", Effect Duration: 25, Last Available: "2017-03"
+9392	artisanal watered-down enchanted R'lyeh	2	EPIC	Effect: "Rushin' Hands", Effect Duration: 25, Last Available: "2017-03"
 9393	lousy watered-down Gnollish sangria	2	decent	Last Available: "2017-03"
-9394	spirit-forward lousy yellow vodka barracuda	5	decent	Last Available: "2017-03"
-9395	hand-crafted fortified Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
-9396	lousy practically non-alcoholic wobbly drive-by shooting	1	decent	Last Available: "2017-03"
+9394	lousy spirit-forward yellow vodka barracuda	5	decent	Last Available: "2017-03"
+9395	fortified hand-crafted Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
+9396	practically non-alcoholic lousy wobbly drive-by shooting	1	decent	Last Available: "2017-03"
 9397	perfectly mixed gunner's daughter	3	EPIC	Last Available: "2017-03"
 9398	perfectly mixed dirt julep	4	EPIC	Last Available: "2017-03"
-9399	special acceptable Simepore slime	3	good	Effect: "Tenacity of the Snapper", Effect Duration: 25, Last Available: "2017-03"
+9399	acceptable special Simepore slime	3	good	Effect: "Tenacity of the Snapper", Effect Duration: 25, Last Available: "2017-03"
 9400	perfectly mixed practically non-alcoholic Phil Collins	1	EPIC	Last Available: "2017-03"
 9401	spinning unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	normal super-sized edible alien plant bit	5	good	Last Available: "2017-04"
+9415	super-sized normal edible alien plant bit	5	good	Last Available: "2017-04"
 9416	huge alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9302,8 +9302,8 @@
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	dry moist alien medicine	0		Effect: "You Know Where to Go", Effect Duration: 35, Last Available: "2017-04"
-9433	tiny decent alien salad	1	good	Last Available: "2017-04"
-9434	fancy drinkable jittery alien booze	3	good	Effect: "Benetton's Medley of Diversity", Effect Duration: 35, Last Available: "2017-04"
+9433	decent tiny alien salad	1	good	Last Available: "2017-04"
+9434	drinkable fancy jittery alien booze	3	good	Effect: "Benetton's Medley of Diversity", Effect Duration: 35, Last Available: "2017-04"
 9435	ghostly foul-smelling Newton's alien mask of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Stench Damage: +10, Last Available: "2017-04"
 9436	wobbly Jim Carey's savvy alien spear of Calamity Jane	0		Mysticality Percent: +20, Critical Hit Percent: +15, Monster Level: +25, Last Available: "2017-04"
 9437	mirror Van der Graaf vibrating grievous alien blowgun	0		Weapon Damage Percent: +50, Maximum MP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2017-04"
@@ -9336,14 +9336,14 @@
 9464	cyan Space Baby bawbaw	0		Last Available: "2017-04"
 9465	purple Spacegate	0		Last Available: "2017-04"
 9466	low-calorie rotten Aldebaran sardines	1	crappy	Last Available: "2017-04"
-9467	watered-down acceptable Centauri fish wine	2	good	Last Available: "2017-04"
+9467	acceptable watered-down Centauri fish wine	2	good	Last Available: "2017-04"
 9468	mixed shaking oxygen	1		Last Available: "2017-04"
 9469	Usain Bolt's forbidden Spacegate scientist's insignia	0		Spell Damage Percent: +50, Initiative: +80, Single Equip, Last Available: "2017-04"
 9470	Oprah's hardy Spacegate military insignia	0		Maximum HP: +50, Maximum MP Percent: +50, Single Equip, Last Available: "2017-04"
 9471	double-paned lard-coated Jack Frost's Spacegate diplomat's insignia	0		Cold Spell Damage: +50, Sleaze Spell Damage: +25, Cold Resistance: +5, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	enchanted bland massive alien sandwich	7	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2017-04"
+9474	enchanted massive bland alien sandwich	7	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2017-04"
 9475	twirling glitched malware	0		Last Available: "2025-12"
 9476	polarized flattened improved mirror shaking Spant eggs	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 49
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9354,7 +9354,7 @@
 9482	triple-wet squat Daily Affirmation: Adapt to Change Eventually	0		Effect: "Gleaming White Teeth", Effect Duration: 25, Last Available: "2017-05"
 9483	colloidal anodized Daily Affirmation: Be a Mind Master	0		Effect: "Preemptive Medicine", Effect Duration: 14, Last Available: "2017-05"
 9484	activated Daily Affirmation: Work For Hours a Week	0		Effect: "Waxing", Effect Duration: 59, Last Available: "2017-05"
-9485	cold-filtered anodized red mirror blurry Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Innately Strong", Effect Duration: 43, Last Available: "2017-05"
+9485	cold-filtered anodized mirror red blurry Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Innately Strong", Effect Duration: 43, Last Available: "2017-05"
 9486	delicious super-sized Affirmation Cookie	5	awesome	Last Available: "2017-05"
 9487	pulsating License To Kill	0		
 9488	Thwaitgold bug statuette	0		
@@ -9363,9 +9363,9 @@
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	family-friendly thinker's Kremlin's Greatest Briefcase of the empath	0		Mysticality: +10, Familiar Weight: +5, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	spirit-forward lousy basic martini	5	decent	Last Available: "2017-06"
-9495	special tolerable improved martini	4	good	Effect: "Blessing of the Hot Linguine", Effect Duration: 50, Last Available: "2017-06"
-9496	perfectly mixed distilled skewed huge splendid martini	5	EPIC	Last Available: "2017-06"
+9494	lousy spirit-forward basic martini	5	decent	Last Available: "2017-06"
+9495	tolerable special improved martini	4	good	Effect: "Blessing of the Hot Linguine", Effect Duration: 50, Last Available: "2017-06"
+9496	distilled perfectly mixed skewed huge splendid martini	5	EPIC	Last Available: "2017-06"
 9497	teal exploding cigar	0		Last Available: "2017-06"
 9498	yellow can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	narrow tattoo gun	0		Last Available: "2017-06"
@@ -9385,10 +9385,10 @@
 9513	twirling Meteorite-Ade	0		Last Available: "2017-08"
 9514	bite-sized normal meteoreo	1	good	Last Available: "2017-08"
 9515	lousy meadeorite	3	decent	Last Available: "2017-08"
-9516	squat tumbling meteoroid	0		Last Available: "2017-08"
+9516	tumbling squat meteoroid	0		Last Available: "2017-08"
 9517	spinning meteortarboard of Calamity Jane of the glutton	0		Critical Hit Percent: +15, Item Drop: +5, Food Drop: +100, Last Available: "2017-08"
 9518	aromatic smelly arcane researcher's meteorite guard	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +10, Stench Resistance: +1, Damage Reduction: 9, Last Available: "2017-08"
-9519	rosewater-soaked aromatic meteorb	0		Stench Resistance: 4, Lantern Element: "Hot", Last Available: "2017-08"
+9519	rosewater-soaked aromatic meteorb	0		Stench Resistance: 4, Last Available: "2017-08", Lantern Element: "Hot"
 9520	padded asteroid belt of the wise owl	0		Mysticality: +20, Damage Absorption: +20, Single Equip, Last Available: "2017-08"
 9521	frightening dance instructor's meteorthopedic shoes of the cougar	0		Moxie: +20, Experience Percent (Moxie): +10, Spooky Damage: +5, Single Equip, Last Available: "2017-08"
 9522	toasty Jim Carey's shooting morning star of the sweet-tooth	0		Monster Level: +25, Hot Damage: +5, Candy Drop: +100, Single Equip, Last Available: "2017-08"
@@ -9412,14 +9412,14 @@
 9540	shovelful of dirt	0		
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
-9543	pulsating squat upside-down X	0		Last Available: "2017-10"
+9543	squat upside-down pulsating X	0		Last Available: "2017-10"
 9544	tumbling O	0		Last Available: "2017-10"
 9545	artisanal DUFRESNE Suds	3	EPIC	Last Available: "2017-09"
 9546	horrifying frightening mafia pinky ring	0		Spooky Damage: 30, Single Equip
 9547	smooth twirling flask of port	3	awesome	
 9548	bouncing stanky educational contract enforcement stick	0		Experience: +1, Stench Spell Damage: +25
 9549	bland Hide-rox&trade; cookie	4	decent	Last Available: "2017-10"
-9550	watered-down artisanal spinning jug of booze	2	EPIC	Last Available: "2017-10"
+9550	artisanal watered-down spinning jug of booze	2	EPIC	Last Available: "2017-10"
 9551	deionized pair of candy glasses	0		Effect: "Tingly Elbows", Effect Duration: 13, Last Available: "2017-10"
 9552	enhanced colloidal temporary X tattoos	0		Effect: "Pyramid Power", Effect Duration: 16, Last Available: "2017-10"
 9553	distilled glyph of athleticism	1		Last Available: "2017-10"
@@ -9450,10 +9450,10 @@
 9578	transparent nog	1	decent	Last Available: "2017-12"
 9579	rotten unfinished fruitcake	4	crappy	Last Available: "2017-12"
 9580	Vulcanized triple-oxidized wobbly and cracker	0		Effect: "Coal-Powered", Effect Duration: 20, Last Available: "2017-12"
-9581	watered-down acceptable twirling neg grog	2	good	Last Available: "2017-12"
+9581	acceptable watered-down twirling neg grog	2	good	Last Available: "2017-12"
 9582	huge normal half double fruitcake	9	good	Last Available: "2017-12"
 9583	spoiled blue hushed puppy	4	crappy	Last Available: "2017-12"
-9584	thick tasty muffled muffuletta	5	awesome	Last Available: "2017-12"
+9584	tasty thick muffled muffuletta	5	awesome	Last Available: "2017-12"
 9585	normal ghostly shushed potatoes	3	good	Last Available: "2017-12"
 9586	plastic mime functionary of the businessman	0		Meat Drop: +50, Last Available: "2017-12"
 9587	plastic mime scientist of the dark arts	0		Spell Damage Percent: +100, Last Available: "2017-12"
@@ -9498,9 +9498,9 @@
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	gray mime pocket probe	0		Last Available: "2017-12"
-9629	weak lousy twirling green stale cheer wine	2	decent	Last Available: "2017-12"
+9629	lousy weak twirling green stale cheer wine	2	decent	Last Available: "2017-12"
 9630	big flavorless stale Cheer-E-Os	5	decent	Last Available: "2017-12"
-9631	bouncing narrow shaking cheer-o-gram	0		Last Available: "2017-12"
+9631	narrow bouncing shaking cheer-o-gram	0		Last Available: "2017-12"
 9632	reassuring banded cheerful antler hat	0		Damage Absorption: +100, Spooky Resistance: +1, Last Available: "2017-12"
 9633	censurious supercool cheerful Crimbo sweater	0		Moxie Percent: +20, Sleaze Resistance: +3, Last Available: "2017-12"
 9634	upside-down Annie Oakley's cheerful pajama pants of chilblains	0		Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2017-12"
@@ -9517,11 +9517,11 @@
 9645	blurry The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	boozy delicious executive mime flask	5	awesome	Last Available: "2017-12"
-9649	fancy rotten bite-sized nega-mushroom	1	crappy	Effect: "Oth-Jeal-O", Effect Duration: 30, Last Available: "2017-12"
-9650	artisanal weak nega-mushroom wine	2	EPIC	Last Available: "2017-12"
+9648	delicious boozy executive mime flask	5	awesome	Last Available: "2017-12"
+9649	bite-sized fancy rotten nega-mushroom	1	crappy	Effect: "Oth-Jeal-O", Effect Duration: 30, Last Available: "2017-12"
+9650	weak artisanal nega-mushroom wine	2	EPIC	Last Available: "2017-12"
 9651	frozen Cheer-Up soda	0		Effect: "Spookypants", Effect Duration: 66, Last Available: "2017-12"
-9652	toothsome enchanted twirling mime army rations	3	awesome	Effect: "Sagittarius Rising", Effect Duration: 25, Last Available: "2017-12"
+9652	enchanted toothsome twirling mime army rations	3	awesome	Effect: "Sagittarius Rising", Effect Duration: 25, Last Available: "2017-12"
 9653	bad mime army wine	4	decent	Last Available: "2017-12"
 9654	twisted mime army superserum	1		Last Available: "2017-12"
 9655	adjusted mime army camouflage kit	0		Effect: "Holiday Bliss", Effect Duration: 49, Last Available: "2017-12"
@@ -9532,13 +9532,13 @@
 9660	skewed knitted miming gloves of the boozehound	0		Cold Resistance: +3, Booze Drop: +100, Single Equip, Last Available: "2017-12"
 9661	God Lobster Egg	0		Free Pull, Last Available: "2018-05"
 9662	donated booze	0		
-9663	squat ghostly donated food	0		
+9663	ghostly squat donated food	0		
 9664	donated candy	0		
 9665	altered digital honeypot	0		Effect: "Stop the Presses!", Effect Duration: 17, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	Temple Grandin's mime army insignia (infantry)	0		Familiar Weight: +7, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	censurious mime army insignia (intelligence)	0		Sleaze Resistance: +3, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	up-at-dawn mime army insignia (espionage)	0		Adventures: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	Temple Grandin's mime army insignia (infantry)	0		Familiar Weight: +7, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	censurious mime army insignia (intelligence)	0		Sleaze Resistance: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	up-at-dawn mime army insignia (espionage)	0		Adventures: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	bouncing kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	teal fireproof skip lid	0		Familiar Weight: +5
 9681	bland extra-toasted half sandwich	4	decent	Last Available: "2018-12"
-9682	smooth watered-down huge mulled hobo wine	2	awesome	Last Available: "2018-12"
+9682	watered-down smooth huge mulled hobo wine	2	awesome	Last Available: "2018-12"
 9683	wobbly burning newspaper	0		Last Available: "2018-12"
 9684	blinking blue frosty medical-grade brawny burning paper hat	0		Muscle Percent: +20, Cold Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-12"
 9685	green supercool burning cape of the empath of the boozehound	0		Moxie Percent: +20, Familiar Weight: +5, Booze Drop: +100, Lasts Until Rollover, Last Available: "2018-12"
@@ -9571,7 +9571,7 @@
 9699	greedy nasty makeshift garbage shirt of the glutton	0		Stench Damage: +5, Meat Drop: +20, Food Drop: +100, Last Available: "2018-01"
 9700	executive Jim Carey's novelty monorail ticket	0		Monster Level: +25, Meat Drop: +40
 9701	pickled tumbling pills	1		Effect: "Aided and Abetted", Effect Duration: 25
-9702	vaporized mirror green furry pill	1		Effect: "Spooky Jellied", Effect Duration: 10
+9702	vaporized green mirror furry pill	1		Effect: "Spooky Jellied", Effect Duration: 10
 9703	distilled fuchsia beefy pill	1		
 9704	altered green excitement pill	1		
 9705	altered huge vitamin G pill	1		Effect: "Ooh, Salty!", Effect Duration: 35
@@ -9595,7 +9595,7 @@
 9727	bland heart-shaped candy whetstone	3	decent	Last Available: "2018-02"
 9728	stale huge Swedish massage fish	4	decent	Last Available: "2018-02"
 9729	mediocre maroon pulsating Third Base	3	decent	Last Available: "2018-02"
-9730	acceptable watered-down Bustle Hustler	2	good	Last Available: "2018-02"
+9730	watered-down acceptable Bustle Hustler	2	good	Last Available: "2018-02"
 9731	pressed super-enhanced Fabiotion	0		Effect: "Tenacity of the Snapper", Effect Duration: 43, Last Available: "2018-02"
 9732	diffused concentrated Bettie page	0		Effect: "Eagle Eyes", Effect Duration: 22, Last Available: "2018-02"
 9733	triple-modified tonic o' Banderas	0		Effect: "Super Speed", Effect Duration: 56, Last Available: "2018-02"
@@ -9605,7 +9605,7 @@
 9737	eaves droppers	0		Last Available: "2018-02"
 9738	upside-down personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
-9740	upside-down ghostly Mysterious Green Box	0		Last Available: "2018-02"
+9740	ghostly upside-down Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	Mysterious Black Box	0		Last Available: "2018-02"
 9743	tarnished unsweetened mirror blue rainbow jellybean	0		Effect: "Oxygenated Blood", Effect Duration: 68
@@ -9615,7 +9615,7 @@
 9747	1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	teal riboflavin	0		
-9750	narrow tumbling bronze	0		
+9750	tumbling narrow bronze	0		
 9751	piracetam	0		
 9752	ultracalcium	0		
 9753	ginseng	0		
@@ -9631,7 +9631,7 @@
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	pulsating Sledgehamster	0		Last Available: "2018-03"
-9766	jittery bouncing Pimpsqueak	0		Last Available: "2018-03"
+9766	bouncing jittery Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
@@ -9690,13 +9690,13 @@
 9822	ghostly shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	tumbling amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
-9825	pulsating twirling razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9825	twirling pulsating razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	olive rocket	0		
 9828	distilled magnificent oyster egg	1		
 9829	dehydrated shaking brilliant oyster egg	1		
 9830	boiled pulsating glistening oyster egg	1		Effect: "Squatting and Thrusting", Effect Duration: 30
-9831	pickled blinking upside-down scintillating oyster egg	1		
+9831	pickled upside-down blinking scintillating oyster egg	1		
 9832	diluted pearlescent oyster egg	1		
 9833	altered purple lustrous oyster egg	1		
 9834	dried huge gleaming oyster egg	1		Effect: "Artificially Sweet", Effect Duration: 15
@@ -9713,7 +9713,7 @@
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
-9848	squat gray LyleCo premium pickaxe	0		Last Available: "2018-04"
+9848	gray squat LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	olive dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9725,7 +9725,7 @@
 9857	ionized wet mirror universal antivenin	0		Lasts Until Rollover, Effect: "Space Cadet", Effect Duration: 52, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9860	cyan upside-down FantasyRealm tattoo kit	0		Last Available: "2018-04"
+9860	upside-down cyan FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	huge LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	spoiled FantasyRealm turkey leg	4	crappy	Last Available: "2018-04"
 9863	lousy mirror FantasyRealm mead	3	decent	Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	twirling map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	spoiled denastified haunch	4	crappy	Last Available: "2018-04"
-9879	weak special acceptable bad rum and good cola	2	good	Effect: "Permanent Halloween", Effect Duration: 30, Last Available: "2018-04"
+9879	acceptable weak special bad rum and good cola	2	good	Effect: "Permanent Halloween", Effect Duration: 30, Last Available: "2018-04"
 9880	polarized Potion of Heroism	0		Effect: "Booing Radly", Effect Duration: 32, Last Available: "2018-04"
 9881	blurry gravedigger's padded strapping leggings of the Spider Queen	0		Muscle: +5, Damage Absorption: +20, Spooky Damage: +10, Last Available: "2018-04"
 9882	up-at-dawn toasty smooth Master Thief's utility belt	0		Moxie: +15, Hot Damage: +5, Adventures: +5, Single Equip, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	green notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	artisanal two meat muck	3	EPIC	
-9899	normal enchanted maroon chocolate Ogre Chieftain	4	good	Effect: "One Very Clear Eye", Effect Duration: 35
+9899	enchanted normal maroon chocolate Ogre Chieftain	4	good	Effect: "One Very Clear Eye", Effect Duration: 35
 9900	adequate huge chocolate &quot;Phoenix&quot;	8	good	
 9901	spoiled spinning chocolate Spider Queen	4	crappy	
 9902	high-proof perfectly mixed narrow hipster cocktail	9	EPIC	
-9903	fuchsia God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Last Available: "2018-05", Equips On: "God Lobster"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Last Available: "2018-05", Equips On: "God Lobster"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
-9906	blurry God Lobster's Robe	0		Familiar Effect: "block", Last Available: "2018-05", Equips On: "God Lobster"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Last Available: "2018-05", Equips On: "God Lobster"
+9903	fuchsia God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	blurry God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,7 +9780,7 @@
 9912	A-Boo glue	0		
 9913	fuchsia glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	snack-sized stale olive good guava	2	decent	
+9915	stale snack-sized olive good guava	2	decent	
 9916	drinkable pulsating gin and ginger	3	good	
 9917	Thwaitgold chigger statuette	0		
 9918	boiled gaseous gravy	1		
@@ -9833,7 +9833,7 @@
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
 9966	lousy spinning everfull glass	3		Last Available: "2018-09"
 9967	tumbling van key	0		Last Available: "2018-09"
-9968	twirling pulsating jam band bootleg	0		Last Available: "2018-09"
+9968	pulsating twirling jam band bootleg	0		Last Available: "2018-09"
 9969	Temple Grandin's Newton's denim jacket	0		Experience (Mysticality): +3, Familiar Weight: +7, Last Available: "2018-09"
 9970	mirror nasty ratty knitted cap of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +5, Last Available: "2018-09"
 9972	supercharged intimidating chainsaw of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +30, Lasts Until Rollover, Last Available: "2018-09"
@@ -9843,9 +9843,9 @@
 9976	Jeselnik's personal trainer's party pants	0		Experience Percent (Muscle): +10, Sleaze Damage: +25, Last Available: "2018-09"
 9977	prompt energetic party whip of bravery	0		Maximum MP Percent: +20, Spooky Resistance: +5, Adventures: +3, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	weak special perfectly mixed TRIO cup of beer	2	EPIC	Effect: "Witch's Brood", Effect Duration: 5, Last Available: "2018-09"
+9979	special perfectly mixed weak TRIO cup of beer	2	EPIC	Effect: "Witch's Brood", Effect Duration: 5, Last Available: "2018-09"
 9980	delicious party platter for one	4	awesome	Last Available: "2018-09"
-9981	mixed maroon mirror Party-in-a-Can&trade;	1		Effect: "Healthy Green Glow", Effect Duration: 45, Last Available: "2018-09"
+9981	mixed mirror maroon Party-in-a-Can&trade;	1		Effect: "Healthy Green Glow", Effect Duration: 45, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	extremely unsafe party crasher of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	huge Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
@@ -9874,18 +9874,18 @@
 10008	prompt flame-wreathed Lo Pan's mutant legs	0		Spell Critical Percent: +30, Hot Spell Damage: +10, Adventures: +3, Last Available: "2018-11"
 10009	pulsating avaricious hardy mutant crown of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +50, Meat Drop: +30, Last Available: "2018-11"
 10010	tasty ghostly ectoplasm	3	awesome	Last Available: "2018-11"
-10011	rotten thick	5	crappy	Last Available: "2018-11"
+10011	thick rotten	5	crappy	Last Available: "2018-11"
 10012	extra-dry bad jittery jittery bottle of vodka	5	decent	Last Available: "2018-11"
 10013	moldy small pizza	2	crappy	Last Available: "2018-11"
 10014	mediocre watered-down martini	2	decent	Last Available: "2018-11"
 10015	flavorless cherry pie	3	decent	Last Available: "2018-11"
-10016	triple-distilled acceptable eggnog	7	good	Last Available: "2018-11"
+10016	acceptable triple-distilled eggnog	7	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	rotten half-sized Hell ramen	2	crappy	Last Available: "2018-11"
 10019	bad gimlet	4	decent	Last Available: "2018-11"
 10020	acceptable twice-haunted screwdriver	3	good	Last Available: "2018-11"
-10021	bite-sized stale candy cane	1	decent	Last Available: "2018-12"
-10022	triple-distilled drinkable runny fermented egg	8	good	Last Available: "2018-12"
+10021	stale bite-sized candy cane	1	decent	Last Available: "2018-12"
+10022	drinkable triple-distilled runny fermented egg	8	good	Last Available: "2018-12"
 10023	tasty half-sized oldcake	2	awesome	Last Available: "2018-12"
 10024	rotten spinning traditional Crimbo cookie	3	crappy	Last Available: "2023-06"
 10025	purple Jack Frost's plastic wild beaver	0		Cold Spell Damage: +50, Last Available: "2018-12"
@@ -9909,7 +9909,7 @@
 10043	smooth skewed beavermouth	4	awesome	Last Available: "2018-12"
 10044	tolerable skewed beaver punch (papaya)	3	good	Last Available: "2018-12"
 10045	perfectly mixed beaver punch (peach)	3	EPIC	Last Available: "2018-12"
-10046	special perfectly mixed beaver punch (cherry)	4	EPIC	Effect: "Spooky Demeanor", Effect Duration: 50, Last Available: "2018-12"
+10046	perfectly mixed special beaver punch (cherry)	4	EPIC	Effect: "Spooky Demeanor", Effect Duration: 50, Last Available: "2018-12"
 10047	auspicious Canadian lantern of temperance	0		Sleaze Resistance: +5, Item Drop: +10, Last Available: "2018-12"
 10048	padded muskox-skin cap	0		Damage Absorption: +20, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9923,15 +9923,15 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	nasty steel-toed beefy Kramco Sausage-o-Matic&trade; of the overflowing toilet of the cheetah	0		Muscle: +10, Damage Reduction: 9, Stench Damage: +5, Stench Spell Damage: +50, Initiative: +60, Last Available: "2019-01"
 10059	blurry sausage casing	0		Last Available: "2019-01"
-10060	delicious massive sausage	6	awesome	Last Available: "2019-01"
+10060	massive delicious sausage	6	awesome	Last Available: "2019-01"
 10061	squat thinker's red-hot sausage fork of chilblains	0		Mysticality: +10, Cold Damage: +25, Last Available: "2019-01"
 10062	tumbling bag of sausage links	0		Last Available: "2019-01"
 10063	squat sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	hand-crafted beer	4	EPIC	Last Available: "2018-12"
-10067	bland half-sized yule gruel	2	decent	Last Available: "2018-12"
-10068	enchanted practically non-alcoholic acceptable hot watered rum	1	good	Effect: "Stenchtastic", Effect Duration: 45, Last Available: "2018-12"
+10067	half-sized bland yule gruel	2	decent	Last Available: "2018-12"
+10068	practically non-alcoholic enchanted acceptable hot watered rum	1	good	Effect: "Stenchtastic", Effect Duration: 45, Last Available: "2018-12"
 10069	lousy tumbling olive bottle of Crimbognac	4	decent	Last Available: "2018-12"
 10070	tasty pulsating Crimboysters Rockefeller	4	awesome	Last Available: "2018-12"
 10071	modified mirror Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9940,7 +9940,7 @@
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10077	blinking blinking tumbling Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
+10077	tumbling blinking blinking Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	frightening hale Crimbolex watch of courage	0		Maximum HP: +20, Spooky Damage: +5, Spooky Resistance: +3, Single Equip, Last Available: "2018-12"
 10080	Crimbo tattoo kit	0		Last Available: "2018-12"
@@ -10007,8 +10007,8 @@
 10141	red dog trainer's flagstone fez of the cheetah	0		Experience (familiar): +1, Initiative: +60, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	razor-sharp smartaleck's flagstone fleece	0		Moxie Percent: +30, Weapon Damage Percent: +25, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	bouncing Van der Graaf supercharged flagstone fringe	0		Maximum MP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	mixed squat blinking flagstone flagments	1		Last Available: "2022-12"
-10145	liquefied bouncing blinking Flag by the Foot&trade;	0		Effect: "Wit Tea", Effect Duration: 47
+10144	mixed blinking squat flagstone flagments	1		Last Available: "2022-12"
+10145	liquefied blinking bouncing Flag by the Foot&trade;	0		Effect: "Wit Tea", Effect Duration: 47
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
 10148	pulsating flame-retardant cobbled-together Meat detector	0		Hot Resistance: +1, Lasts Until Rollover, Last Available: "2019-12"
@@ -10026,18 +10026,18 @@
 10160	denatured licorice snake	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 23
 10161	modified warmed virgin jello shot	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 68
 10162	extra-polymerized mutated candy lump	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 43
-10163	galvanized super-pickled jittery olive government-issued candy	0		Effect: "Fungal Flambé", Effect Duration: 32
+10163	galvanized super-pickled olive jittery government-issued candy	0		Effect: "Fungal Flambé", Effect Duration: 32
 10164	aerosolized narrow Pneumo bar	0		Effect: "Spooky Blur", Effect Duration: 11
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	spinning Lil' Doctor&trade; bag of the overflowing toilet of terror	0		Stench Spell Damage: +50, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	bouncing blood bag	0		
 10169	bland bloodstick	4	decent	
-10170	irresponsibly strong lousy fuchsia wobbly bottle of Sanguiovese	10	decent	
-10171	immense adequate actual blood sausage	10	good	
+10170	lousy irresponsibly strong fuchsia wobbly bottle of Sanguiovese	10	decent	
+10171	adequate immense actual blood sausage	10	good	
 10172	weak drinkable mulled blood	2	good	
 10173	jumbo moldy blood snowcone	5	crappy	
-10174	boozy acceptable Red Russian	5	good	
-10175	diet bland blood roll-up	1	decent	
+10174	acceptable boozy Red Russian	5	good	
+10175	bland diet blood roll-up	1	decent	
 10176	lousy shaking bottle of blood	4	decent	
 10177	decent thick blood-soaked sponge cake	5	good	
 10178	artisanal vampagne	3	super EPIC	
@@ -10074,7 +10074,7 @@
 10209	windicle	0		Last Available: "2019-04"
 10210	Usain Bolt's rock-hard pirate radio ring	0		Damage Reduction: 5, Initiative: +80, Single Equip, Last Available: "2019-04"
 10211	lime green huge Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	toothsome snack-sized ghostly pineapple slab	2	awesome	Last Available: "2019-04"
+10212	snack-sized toothsome ghostly pineapple slab	2	awesome	Last Available: "2019-04"
 10213	moldy diet hibiscus petal	1	crappy	Last Available: "2019-04"
 10214	boiled huge mint leaf	0		Effect: "[800]Chocolate Reign", Effect Duration: 66, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
@@ -10089,20 +10089,20 @@
 10224	green Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	shaking PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	extremely unsafe plush sea serpent	0		Weapon Damage Percent: +100, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	massive rotten pirate fork	10		Last Available: "2019-04"
+10227	rotten massive pirate fork	10		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	mansplainer's educational piratical blunderbuss	0		Experience: +1, Monster Level: +15, Last Available: "2019-04"
 10231	wobbly Usain Bolt's gravedigger's clever PirateRealm party hat	0		Maximum MP: +20, Spooky Damage: +10, Initiative: +80, Last Available: "2019-04"
 10232	perfectly mixed weak Island Landslide	2	super EPIC	Last Available: "2019-04"
-10233	enchanted practically non-alcoholic smooth fuchsia Island Thunderstorm	1	awesome	Effect: "Fishy Fortification", Effect Duration: 15, Last Available: "2019-04"
+10233	smooth practically non-alcoholic enchanted fuchsia Island Thunderstorm	1	awesome	Effect: "Fishy Fortification", Effect Duration: 15, Last Available: "2019-04"
 10234	hand-crafted bouncing Island Hurricane	4	EPIC	Last Available: "2019-04"
 10235	bad blurry Skull Punch	4	decent	Last Available: "2019-04"
 10236	acceptable spinning Electric Punch	3	good	Last Available: "2019-04"
 10237	drinkable triple-distilled Smuggler's Punch	9	good	Last Available: "2019-04"
 10238	delicious upside-down Scorpion Bowl	4	awesome	Last Available: "2019-04"
 10239	artisanal Turtle Bowl	4	EPIC	Last Available: "2019-04"
-10240	triple-distilled artisanal Cobra Bowl	10	EPIC	Last Available: "2019-04"
+10240	artisanal triple-distilled Cobra Bowl	10	EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	zippy sizzling rock-hard sinister Herculean vampyric cloake	0		Experience (Muscle): +1, Spell Damage: +10, Damage Reduction: 5, Hot Damage: +10, Initiative: +20, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	maroon plastic pirate hat	0		Familiar Weight: +5
@@ -10117,7 +10117,7 @@
 10252	ring	0		Single Equip
 10253	spinning Thwaitgold nymph statuette	0		
 10254	shaking rosewater-soaked Lo Pan's supercharged hale veiny forbidden smooth slick brainy hewn moon-rune spoon of the pedagogue of James Dean	0		Mysticality: +5, Moxie: 25, Experience: +3, Experience (Moxie): +3, Spell Damage Percent: +50, Maximum HP: 30, Maximum MP Percent: +30, Spell Critical Percent: +30, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
-10255	ghostly twirling gray cartoon harpoon	0		Last Available: "2019-06"
+10255	twirling gray ghostly cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	jittery auspicious Beach Comb of doom of the detective	0		Spooky Spell Damage: +50, Item Drop: 30, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
@@ -10132,10 +10132,10 @@
 10267	triple-deionized narrow cyan seashell	0		Effect: "Ancestral Disapproval", Effect Duration: 33, Last Available: "2019-07"
 10268	oxidized activated magnetized gray seashell	0		Effect: "Warm Shoulders", Effect Duration: 37, Last Available: "2019-07"
 10269	colloidal electrified bouncing seashell	0		Effect: "Castaway Physique", Effect Duration: 53, Last Available: "2019-07"
-10270	concentrated fuchsia skewed seashell	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 52, Last Available: "2019-07"
+10270	concentrated skewed fuchsia seashell	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 52, Last Available: "2019-07"
 10271	red bunch of sea grapes	0		Last Available: "2019-07"
-10272	weak acceptable bottle of sea wine	2	good	Last Available: "2019-07"
-10273	modified upside-down yellow ghostly kelp	1		Last Available: "2019-07"
+10272	acceptable weak bottle of sea wine	2	good	Last Available: "2019-07"
+10273	modified yellow upside-down ghostly kelp	1		Last Available: "2019-07"
 10274	upside-down inspector's double-paned lard-coated Jeselnik's mansplainer's resourceful wicked grievous deadly driftwood hat	0		Weapon Damage: +5, Weapon Damage Percent: +50, Spell Damage: +5, Maximum MP: +50, Monster Level: +15, Sleaze Damage: +25, Sleaze Spell Damage: +25, Cold Resistance: +5, Item Drop: +15, Lasts Until Rollover, Last Available: "2019-07"
 10275	executive greasy gravedigger's supercharged supercool cool driftwood pants of Calamity Jane of mayonnaise of the cheetah	0		Moxie: +5, Moxie Percent: +20, Maximum MP Percent: +30, Critical Hit Percent: +15, Spooky Damage: +10, Sleaze Spell Damage: 60, Meat Drop: +40, Initiative: +60, Lasts Until Rollover, Last Available: "2019-07"
 10276	inspector's foul-smelling Jim Carey's Lo Pan's Annie Oakley's shellacked cool beefy driftwood bracelet of the ox	0		Muscle: 30, Moxie: +5, Damage Reduction: 7, Critical Hit Percent: +20, Spell Critical Percent: +30, Monster Level: +25, Stench Damage: +10, Item Drop: +15, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10147,11 +10147,11 @@
 10282	sinister wicked pirate cutlass of Calamity Jane	0		Spell Damage: 15, Critical Hit Percent: +15, Single Equip, Last Available: "2019-07"
 10283	chilly Lo Pan's resourceful tricorn hat	0		Maximum MP: +50, Spell Critical Percent: +30, Cold Damage: +5, Last Available: "2019-07"
 10284	green greasy hale wizardly swash buckle	0		Mysticality: +25, Maximum HP: +20, Sleaze Spell Damage: +10, Single Equip, Last Available: "2019-07"
-10285	spinning ghostly meteorite fragment	0		Last Available: "2019-07"
+10285	ghostly spinning meteorite fragment	0		Last Available: "2019-07"
 10286	blue brawny beefcake's meteorite earring of the bloodbag	0		Muscle: +25, Muscle Percent: +20, Maximum HP: +100, Single Equip, Last Available: "2019-07"
 10287	wobbly MacGyver's fortified Samson's meteorite necklace	0		Experience (Muscle): +5, Damage Absorption: +60, Maximum MP: +100, Single Equip, Last Available: "2019-07"
 10288	twirling Jeselnik's padded Socratic meteorite ring	0		Experience (Mysticality): +1, Damage Absorption: +20, Sleaze Damage: +25, Single Equip, Last Available: "2019-07"
-10289	denatured wet jittery tumbling Finnish Fish	0		Effect: "Burning Hands", Effect Duration: 27
+10289	denatured wet tumbling jittery Finnish Fish	0		Effect: "Burning Hands", Effect Duration: 27
 10290	nitrogenated pickled pulsating chocolate doubloon	0		Effect: "Emotion Sickness", Effect Duration: 44
 10291	Van der Graaf rosy-cheeked dangerous driftwood beach comb	0		Weapon Damage: +10, Maximum HP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	bouncing Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
@@ -10166,7 +10166,7 @@
 10301	aromatic smelly vibrating whittled fox figurine	0		Maximum MP Percent: +10, Stench Spell Damage: +10, Stench Resistance: +1, Single Equip, Last Available: "2019-08"
 10302	rosewater-soaked knitted MacGyver's healthy whittled walking stick	0		Maximum HP Percent: +20, Maximum MP: +100, Cold Resistance: +3, Stench Resistance: +3, Last Available: "2019-08"
 10303	toothsome massive campfire hot dog	10	awesome	Last Available: "2019-08"
-10304	huge special stale skewed campfire baked potato	10	decent	Effect: "The Solution", Effect Duration: 20, Last Available: "2019-08"
+10304	huge stale special skewed campfire baked potato	10	decent	Effect: "The Solution", Effect Duration: 20, Last Available: "2019-08"
 10305	tiny tasty wobbly cyan campfire s'more	1	awesome	Last Available: "2019-08"
 10306	stale thick huge campfire beans	5	decent	Last Available: "2019-08"
 10307	moldy bite-sized lime green campfire stew	1	crappy	Last Available: "2019-08"
@@ -10180,9 +10180,9 @@
 10315	signal receiver	0		
 10316	space shield	0		Damage Reduction: 9
 10317	signal jammer	0		Single Equip
-10318	blue bouncing low-pressure oxygen tank	0		Single Equip
-10319	wobbly blinking Thwaitgold bombardier beetle statuette	0		
-10320	delicious special space chowder	4	awesome	Effect: "Amplified Fabulousness", Effect Duration: 35
+10318	bouncing blue low-pressure oxygen tank	0		Single Equip
+10319	blinking wobbly Thwaitgold bombardier beetle statuette	0		
+10320	special delicious space chowder	4	awesome	Effect: "Amplified Fabulousness", Effect Duration: 35
 10321	fancy acceptable space wine	3	good	Effect: "Wintergreen Warmongery", Effect Duration: 10
 10322	ghostly The Imploded World	0		Skill: "Implode Universe"
 10323	blinking packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	decent purple skewed bu&ntilde;uelos Jaliscos	3	good	Last Available: "2019-12"
 10338	huge delicious flan del mar	7	awesome	Last Available: "2019-12"
-10339	massive rotten olive Baja sopapilla	9	crappy	Last Available: "2019-12"
+10339	rotten massive olive Baja sopapilla	9	crappy	Last Available: "2019-12"
 10340	scandalous plastic Mer-kin baker	0		Sleaze Damage: +5, Last Available: "2019-12"
 10341	prompt plastic sea elf	0		Adventures: +3, Last Available: "2019-12"
 10342	smelly plastic yuleviathan	0		Stench Spell Damage: +10, Last Available: "2019-12"
@@ -10204,8 +10204,8 @@
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	small stale jittery mana-coated yams	2	decent	Last Available: "2019-11"
 10347	decent mana-basted tofurkey leg	4	good	Last Available: "2019-11"
-10348	super-sized rotten mana-fortified cranberry sauce	5	crappy	Last Available: "2019-11"
-10349	moldy miniature blue mana-stuffed herbal stuffing	2	crappy	Last Available: "2019-11"
+10348	rotten super-sized mana-fortified cranberry sauce	5	crappy	Last Available: "2019-11"
+10349	miniature moldy blue mana-stuffed herbal stuffing	2	crappy	Last Available: "2019-11"
 10350	upside-down human musk	0		Last Available: "2019-12"
 10351	enhanced mirror ghostly spinning patch of extra-warm fur	0		Effect: "BOOsted", Effect Duration: 34, Last Available: "2019-12"
 10352	compressed industrial lubricant	1		Last Available: "2019-12"
@@ -10213,8 +10213,8 @@
 10354	powdered squat fuchsia vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dehydrated a bug's lymph	1		Effect: "Armored Innards", Effect Duration: 10, Last Available: "2019-12"
 10356	nitrogenated triple-dry organic potpourri	0		Effect: "The Power of Negative Thinking", Effect Duration: 43, Last Available: "2019-12"
-10357	strong lousy maroon boot flask	5	decent	Last Available: "2019-12"
-10358	double-magnetized unsweetened spinning pulsating infernal snowball	0		Effect: "Pronounced Potency", Effect Duration: 27, Last Available: "2019-12"
+10357	lousy strong maroon boot flask	5	decent	Last Available: "2019-12"
+10358	double-magnetized unsweetened pulsating spinning infernal snowball	0		Effect: "Pronounced Potency", Effect Duration: 27, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	mixed purple fish sauce	1		Last Available: "2019-12"
 10361	normal bite-sized guffin	1	good	Last Available: "2019-12"
@@ -10233,7 +10233,7 @@
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
 10375	adjusted polarized concentrated fish broth	0		Effect: "Antibiotic Saucesphere", Effect Duration: 12, Last Available: "2019-12"
 10376	activated shaking narrow liquid SONAR	0		Effect: "Impregnably Delicious", Effect Duration: 35, Last Available: "2019-12"
-10377	ghostly narrow map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
+10377	narrow ghostly map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
 10378	teal Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	blue jittery auspicious ribald resourceful Dolph Bossin's Crimbo hat	0		Maximum MP: +50, Sleaze Damage: +10, Item Drop: +10, Last Available: "2019-12"
 10380	The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
@@ -10243,7 +10243,7 @@
 10384	modified aerosolized salty gumdrop	0		Effect: "Sugary Tongue", Effect Duration: 33, Last Available: "2019-12"
 10385	sharpshooter's energetic ribbon candy ascot	0		Maximum MP Percent: +20, Critical Hit Percent: +10, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
-10387	pulsating skewed blue intact anemone spike	0		Last Available: "2019-12"
+10387	skewed blue pulsating intact anemone spike	0		Last Available: "2019-12"
 10388	stiffened anemoney clip	0		Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10389	spinning runny icing	0		Last Available: "2019-12"
 10390	dehydrated purple super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
@@ -10260,7 +10260,7 @@
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
-10404	ghostly upside-down waterlogged	0		Last Available: "2019-12"
+10404	upside-down ghostly waterlogged	0		Last Available: "2019-12"
 10405	dog trainer's extremely unsafe nutcracker hat	0		Weapon Damage Percent: +100, Experience (familiar): +1, Last Available: "2019-12"
 10406	avaricious supercharged nutcracker waistcoat	0		Maximum MP Percent: +30, Meat Drop: +30, Last Available: "2019-12"
 10407	Sherlock's nutcracker pants of doom	0		Spooky Spell Damage: +50, Item Drop: +25, Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	lime green fortified occult nutcracker cape	0		Spell Damage Percent: +25, Damage Absorption: +60, Last Available: "2019-12"
 10413	padded sage nutcracker epaulets	0		Mysticality Percent: +10, Damage Absorption: +20, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	fancy adequate mirror salt plum	3	good	Effect: "Super Accuracy", Effect Duration: 30, Last Available: "2019-12"
+10415	adequate fancy mirror salt plum	3	good	Effect: "Super Accuracy", Effect Duration: 30, Last Available: "2019-12"
 10416	skewed peppermint eel sauce	0		Last Available: "2019-12"
 10417	normal snack-sized and bean	2	good	Last Available: "2019-12"
 10418	flame-retardant Jim Carey's vibrating kelp-holly gun	0		Maximum MP Percent: +10, Monster Level: +25, Hot Resistance: +1, Last Available: "2019-12"
@@ -10300,19 +10300,19 @@
 10443	Driplet	0		
 10444	tumbling upside-down drippy snail shell	0		
 10445	big moldy drippy nugget	5	drippy	
-10446	tolerable weak blinking glass of drippy wine	2	drippy	
-10447	snack-sized bland drippy caviar	2	drippy	
+10446	weak tolerable blinking glass of drippy wine	2	drippy	
+10447	bland snack-sized drippy caviar	2	drippy	
 10448	adequate drippy plum(?)	3	drippy	
 10449	family-friendly drippy stake	0		Sleaze Resistance: +1, Single Equip
 10450	The Eye of the Thing in the Basement	0		
-10451	purple twirling drippy khakis	0		
+10451	twirling purple drippy khakis	0		
 10452	drippy shield	0		
 10453	The Fingernail of the Thing in the Basement	0		
 10454	blue coin	0		
 10455	mushroom	0		
 10456	yellow deluxe mushroom	0		
 10457	jittery super deluxe mushroom	0		
-10458	unsweetened huge purple blurry fizzy soda	0		Effect: "Snobby", Effect Duration: 54
+10458	unsweetened purple huge blurry fizzy soda	0		Effect: "Snobby", Effect Duration: 54
 10459	liquefied super-polarized squat healthy juice	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 12
 10460	tumbling hammer	0		
 10461	hammer	0		
@@ -10329,7 +10329,7 @@
 10472	blurry bony back shell of the blizzard	0		Cold Spell Damage: +25
 10473	frosty button	0		Single Equip
 10474	liquefied twirling shaking blooper ink	0		Effect: "Takin' It Greasy", Effect Duration: 37
-10475	yellow bouncing coin	0		
+10475	bouncing yellow coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
 10478	plastic doll arms	0		
@@ -10343,10 +10343,10 @@
 10486	skewed free-range mushroom	0		Last Available: "2020-03"
 10487	huge immense free-range mushroom	0		Last Available: "2020-03"
 10488	spinning colossal free-range mushroom	0		Last Available: "2020-03"
-10489	bland wobbly bouncing mushroom filet	4	decent	Last Available: "2020-03"
+10489	bland bouncing wobbly mushroom filet	4	decent	Last Available: "2020-03"
 10490	bouncing mushroom slab	0		Last Available: "2020-03"
 10491	mixed mirror mushroom tea	1		Last Available: "2020-03"
-10492	artisanal high-proof mushroom whiskey	9	EPIC	Last Available: "2020-03"
+10492	high-proof artisanal mushroom whiskey	9	EPIC	Last Available: "2020-03"
 10493	resourceful savvy mushroom cap of the bloodbag	0		Mysticality Percent: +20, Maximum HP: +100, Maximum MP: +50, Last Available: "2020-03"
 10494	double-paned frightening mushroom shield of terror	0		Spooky Damage: +5, Spooky Spell Damage: +10, Cold Resistance: +5, Item Drop: +5, Damage Reduction: 6, Last Available: "2020-03"
 10495	reassuring healthy boxer's stylish mushroom pants	0		Moxie: +25, Muscle Percent: +10, Maximum HP Percent: +20, Spooky Resistance: +1, Last Available: "2020-03"
@@ -10394,7 +10394,7 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	blue deadly Guzzlr souvenir stein	0		Weapon Damage: +5, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	drinkable enchanted fuchsia Ghiaccio Colada	4	good	Effect: "Bloody-minded", Effect Duration: 45, Last Available: "2020-05"
+10541	enchanted drinkable fuchsia Ghiaccio Colada	4	good	Effect: "Bloody-minded", Effect Duration: 45, Last Available: "2020-05"
 10542	perfectly mixed wobbly Sourfinger	3	EPIC	Last Available: "2020-05"
 10543	mediocre upside-down Nog-on-the-Cob	3	decent	Last Available: "2020-05"
 10544	practically non-alcoholic acceptable Steamboat	1	good	Last Available: "2020-05"
@@ -10425,7 +10425,7 @@
 10569	yellow forbidden stylish discarded bike lock key	0		Moxie: +25, Spell Damage Percent: +50, Last Available: "2020-08"
 10570	skewed Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	oxidized magnetized spinning squat marshroom	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 26
+10572	oxidized magnetized squat spinning marshroom	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 26
 10573	bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
@@ -10473,9 +10473,9 @@
 10617	narrow sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
-10620	blurry upside-down nasty desk bell	0		Last Available: "2020-09"
+10620	upside-down blurry nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
-10622	ghostly wobbly chess set	0		Last Available: "2020-09"
+10622	wobbly ghostly chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	wobbly onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
@@ -10491,12 +10491,12 @@
 10635	wobbly bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	horrifying healthy beefcake's Cargo Cultist Shorts of the businessman	0		Muscle: +25, Maximum HP Percent: +20, Spooky Damage: +25, Meat Drop: +50, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	irresponsibly strong lousy flask of moonshine	7	decent	Last Available: "2020-09"
+10638	lousy irresponsibly strong flask of moonshine	7	decent	Last Available: "2020-09"
 10639	ruddy Samson's Rosewater's sea-worn candlestick	0		Mysticality Percent: +30, Experience (Muscle): +5, Maximum HP Percent: +40, Last Available: "2020-09"
 10640	blinking Universal Seasoning	0		
 10641	ionized super-anodized ghostly null-day exploit	0		Effect: "Pwnd", Effect Duration: 21, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	jumbo moldy narrow chocolate chip muffin	5	crappy	
+10643	moldy jumbo narrow chocolate chip muffin	5	crappy	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	huge Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10539,7 +10539,7 @@
 10683	ionized imported lemon lozenge	0		Effect: "This Is Where You're a Viking", Effect Duration: 51, Last Available: "2020-12"
 10684	liquefied warmed hermedisiac cologne	0		Effect: "Memory of Attractiveness", Effect Duration: 31, Last Available: "2020-12"
 10685	government food shipment	0		Last Available: "2020-12"
-10686	upside-down spinning government booze shipment	0		Last Available: "2020-12"
+10686	spinning upside-down government booze shipment	0		Last Available: "2020-12"
 10687	ghostly government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	Crimbo Carol tattoo kit	0		Last Available: "2020-12"
@@ -10563,7 +10563,7 @@
 10707	tumbling The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
-10710	teal narrow The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10710	narrow teal The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	squat spinning The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
@@ -10573,13 +10573,13 @@
 10717	bouncing fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	maroon squat nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	drinkable practically non-alcoholic barrel-aged eggnog	1	good	Last Available: "2020-12"
-10721	enchanted gigantic yummy hand-crafted candy cane	9	awesome	Effect: "Liquid Courage", Effect Duration: 45, Last Available: "2020-12"
+10720	practically non-alcoholic drinkable barrel-aged eggnog	1	good	Last Available: "2020-12"
+10721	yummy gigantic enchanted hand-crafted candy cane	9	awesome	Effect: "Liquid Courage", Effect Duration: 45, Last Available: "2020-12"
 10722	yummy drive-thru burger	4	awesome	Last Available: "2020-12"
-10723	weak hand-crafted Boulevardier cocktail	2	EPIC	Last Available: "2020-12"
+10723	hand-crafted weak Boulevardier cocktail	2	EPIC	Last Available: "2020-12"
 10724	polymerized Hotwire&trade; brand candy rope	0		Effect: "Got Your Boots On", Effect Duration: 30, Last Available: "2020-12"
-10725	enchanted decent gigantic blue shaking bowl full of jelly	7	good	Effect: "Penguinny Flavor", Effect Duration: 25, Last Available: "2020-12"
-10726	perfectly mixed watered-down Eye and a Twist	2	EPIC	Last Available: "2020-12"
+10725	decent enchanted gigantic shaking blue bowl full of jelly	7	good	Effect: "Penguinny Flavor", Effect Duration: 25, Last Available: "2020-12"
+10726	watered-down perfectly mixed Eye and a Twist	2	EPIC	Last Available: "2020-12"
 10727	dry improved Chubby and Plump bar	0		Effect: "Fizzier Than Light", Effect Duration: 57, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	blurry packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10598,7 +10598,7 @@
 10742	irradiated battery (9-Volt)	0		Effect: "Improved Candy Vision", Effect Duration: 48, Last Available: "2021-03"
 10743	frozen wet battery (lantern)	0		Effect: "Make Meat FA$T!", Effect Duration: 52, Last Available: "2021-03"
 10744	moist Vulcanized battery (car)	0		Effect: "The Grass...  Is Blue...", Effect Duration: 37, Last Available: "2021-03"
-10745	huge olive cryptocloak	0		Last Available: "2025-12"
+10745	olive huge cryptocloak	0		Last Available: "2025-12"
 10746	green marshmallow	0		
 10747	bad practically non-alcoholic marshmallow bomb	1	decent	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
@@ -10659,7 +10659,7 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	coward's slick cool Daylight Shavings Helmet	0		Moxie: 15, Monster Level: -20, Last Available: "2021-11"
 10805	bouncing eggwater	1	decent	Last Available: "2021-12"
-10806	miniature delicious gray bread man	2	awesome	Last Available: "2021-12"
+10806	delicious miniature gray bread man	2	awesome	Last Available: "2021-12"
 10807	decent green plain candy cane	4	good	Last Available: "2021-12"
 10808	small delicious olive flour cookie	2	awesome	Last Available: "2021-12"
 10809	plastic food lab of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2021-12"
@@ -10672,15 +10672,15 @@
 10816	padded Da Vinci's Newton's ice crown	0		Experience (Mysticality): 8, Damage Absorption: +20, Lasts Until Rollover, Last Available: "2021-12"
 10817	blinking manspreader's experienced jeans of James Dean	0		Experience: +2, Experience (Moxie): +3, Monster Level: +10, Lasts Until Rollover, Last Available: "2021-12"
 10818	frightening sinister ice wrap of Tarzan	0		Experience (Muscle): +3, Spell Damage: +10, Spooky Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	special flavorless tofu pop	3	decent	Effect: "Preternatural Greed", Effect Duration: 25, Last Available: "2021-12"
+10819	flavorless special tofu pop	3	decent	Effect: "Preternatural Greed", Effect Duration: 25, Last Available: "2021-12"
 10820	flavorless bowl of prescription candy	3	decent	Last Available: "2021-12"
 10821	moldy special fishcake	4	crappy	Effect: "critical.enh", Effect Duration: 40, Last Available: "2021-12"
 10822	delicious super-sized bone broth	5	awesome	Last Available: "2021-12"
 10823	normal star pop	4	good	Last Available: "2021-12"
 10824	hand-crafted Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
-10825	boozy tolerable bouncing Doc's Smartifying Wine	5	good	Last Available: "2021-12"
+10825	tolerable boozy bouncing Doc's Smartifying Wine	5	good	Last Available: "2021-12"
 10826	tolerable bouncing Doc's Limbering Wine	4	good	Last Available: "2021-12"
-10827	tolerable high-proof Doc's Medical-Grade Wine	8	good	Last Available: "2021-12"
+10827	high-proof tolerable Doc's Medical-Grade Wine	8	good	Last Available: "2021-12"
 10828	mixed blurry Homebodyl&trade;	1		Effect: "Bustle Hustlin'", Effect Duration: 45, Last Available: "2021-12"
 10829	mixed Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	compressed skewed Breathitin&trade;	1		Last Available: "2021-12"
@@ -10691,12 +10691,12 @@
 10835	pickled aerosolized irradiated blinking anti-odor cream	0		Effect: "Lubed", Effect Duration: 14, Last Available: "2021-12"
 10836	concentrated upside-down anti-creep cream	0		Effect: "Sweet and Green", Effect Duration: 37, Last Available: "2021-12"
 10837	enhanced unsweetened anti-pain cream	0		Effect: "Shawarma Warm War", Effect Duration: 17, Last Available: "2021-12"
-10838	watered-down mediocre tumbling Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
+10838	mediocre watered-down tumbling Doc's Special Reserve Wine	2	decent	Last Available: "2021-12"
 10839	spoiled bread pie	3	crappy	Last Available: "2021-12"
-10840	perfectly mixed practically non-alcoholic blue mirror clear Russian	1	EPIC	Last Available: "2021-12"
+10840	practically non-alcoholic perfectly mixed mirror blue clear Russian	1	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
-10843	spinning skewed Crimbo ball	0		Last Available: "2021-12"
+10843	skewed spinning Crimbo ball	0		Last Available: "2021-12"
 10844	ghostly gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	narrow gooified mineral matter	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	huge goo magnet	0		Last Available: "2021-12"
 10851	mirror Sherlock's cozy scarf	0		Item Drop: +25, Last Available: "2021-12"
-10852	massive moldy huge Crimbo cookie	7	crappy	Last Available: "2023-06"
+10852	moldy massive huge Crimbo cookie	7	crappy	Last Available: "2023-06"
 10853	deionized jittery fleshy putty	0		Effect: "Booze Goozles", Effect Duration: 46, Last Available: "2021-12"
 10854	rosy-cheeked third ear	0		Maximum HP Percent: +30, Single Equip, Last Available: "2021-12"
 10855	spinning festive egg sac	0		Last Available: "2021-12"
@@ -10714,14 +10714,14 @@
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	miser's depleted Crimbonium football helmet	0		Meat Drop: +10, Last Available: "2021-12"
-10861	squat skewed synthetic rock	0		Last Available: "2021-12"
-10862	spoiled big &quot;caramel&quot;	5	crappy	Last Available: "2021-12"
+10861	skewed squat synthetic rock	0		Last Available: "2021-12"
+10862	big spoiled &quot;caramel&quot;	5	crappy	Last Available: "2021-12"
 10863	cyan scorching self-repairing earmuffs	0		Hot Damage: +25, Last Available: "2021-12"
 10864	carnivorous potted plant of terror	0		Spooky Spell Damage: +10, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	pulsating occult yule hatchet	0		Spell Damage Percent: +25, Last Available: "2021-12"
 10867	olive potato alarm clock	0		Last Available: "2021-12"
-10868	low-calorie enchanted adequate lab-grown meat	1	good	Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2021-12"
+10868	adequate enchanted low-calorie lab-grown meat	1	good	Effect: "Wintry Breath", Effect Duration: 30, Last Available: "2021-12"
 10869	ghostly fleece of wisdom	0		Mysticality: +15, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	twirling cloning kit	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	Annie Oakley's Van der Graaf can of mixed everything of the detective	0		Critical Hit Percent: +20, Item Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-12"
 10874	huge Site Alpha ID badge	0		Familiar Weight: +5
 10875	yellow jittery the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	decent special meatball	3	good	Effect: "Burning Ears", Effect Duration: 25, Last Available: "2021-12"
+10876	special decent meatball	3	good	Effect: "Burning Ears", Effect Duration: 25, Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	red meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10739,7 +10739,7 @@
 10883	boiled astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	steel-toed magnifying glass of the cougar of dire peril	0		Moxie: +20, Weapon Damage: +20, Damage Reduction: 9, Last Available: "2022-12"
-10886	perfectly mixed watered-down blurry void lager	2	EPIC	Last Available: "2022-12"
+10886	watered-down perfectly mixed blurry void lager	2	EPIC	Last Available: "2022-12"
 10887	bland olive void burger	3	decent	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	shaking upside-down flame-retardant baleful void shard of doom of the early riser	0		Spell Damage: +25, Spooky Spell Damage: +50, Hot Resistance: +1, Adventures: +7, Last Available: "2022-12"
@@ -10749,7 +10749,7 @@
 10893	shellacked combat lover's locket	0		Damage Reduction: 7, Single Equip, Last Available: "2022-02"
 10894	teal Thwaitgold protozoa statuette	0		
 10895	gray grey gosling	0		Free Pull, Last Available: "2022-03"
-10896	spinning huge purple grey down vest	0		Experience (familiar): +2
+10896	purple huge spinning grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	chaotic ruddy shellacked unbreakable umbrella (broken) of the pedagogue	0		Experience: +3, Damage Reduction: 7, Maximum HP Percent: +40, Spell Critical Percent: +10
@@ -10767,9 +10767,9 @@
 10911	non-alkaline narrow gaffer's tape	0		Effect: "Shamboozled", Effect Duration: 42, Last Available: "2022-05"
 10912	adequate 20-lb can of rice and beans	3	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	stale big expired MRE	5	decent	Last Available: "2022-05"
-10915	spoiled fancy huge cool mint precipice bar	10	crappy	Effect: "Super Vision", Effect Duration: 5, Last Available: "2022-05"
-10916	snack-sized moldy carrot cake precipice bar	2	crappy	Last Available: "2022-05"
+10914	big stale expired MRE	5	decent	Last Available: "2022-05"
+10915	huge fancy spoiled cool mint precipice bar	10	crappy	Effect: "Super Vision", Effect Duration: 5, Last Available: "2022-05"
+10916	moldy snack-sized carrot cake precipice bar	2	crappy	Last Available: "2022-05"
 10917	olive wobbly The Big Book of Every Skill	0		
 10918	blurry Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10780,12 +10780,12 @@
 10924	bland enchanted guilty sprout	3	decent	Effect: "Feelin' Philosophical", Effect Duration: 30, Last Available: "2022-06"
 10925	green mother's necklace of mayonnaise of the boozehound	0		Sleaze Spell Damage: +50, Booze Drop: +100, Last Available: "2022-06"
 10926	vacuum-sealed frozen colloidal trampled ticket stub	0		Effect: "Spooky Weapon", Effect Duration: 38, Last Available: "2022-06"
-10927	dry double-polarized mirror tumbling savings bond	0		Effect: "Took Eleven", Effect Duration: 12, Last Available: "2022-06"
+10927	dry double-polarized tumbling mirror savings bond	0		Effect: "Took Eleven", Effect Duration: 12, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	pulsating fuchsia designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
+10929	pulsating fuchsia designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	denatured sweat-ade	1		Last Available: "2022-07"
 10931	bouncing unopened stillsuit	0		Free Pull, Last Available: "2022-08"
-10932	shaking lime green stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
+10932	lime green shaking stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	jittery dinosaur scale	0		
 10935	pristine dinosaur feather	0		
@@ -10824,13 +10824,13 @@
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	upside-down Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	adequate ratatouille de Jarlsberg	4	good	Last Available: "2022-11"
-10971	rotten immense Jarlsberg's vegetable soup	8	crappy	Last Available: "2022-11"
+10971	immense rotten Jarlsberg's vegetable soup	8	crappy	Last Available: "2022-11"
 10972	decent roasted vegetable of Jarlsberg	4	good	Last Available: "2022-11"
 10973	yummy St. Pete's sneaky smoothie	3	awesome	Last Available: "2022-11"
 10974	adequate Pete's wiley whey bar	3	good	Last Available: "2022-11"
 10975	bland Pete's rich ricotta	3	decent	Last Available: "2022-11"
 10976	smooth weak mirror Boris's beer	2	awesome	Last Available: "2022-11"
-10977	stale massive honey bun of Boris	8	decent	Last Available: "2022-11"
+10977	massive stale honey bun of Boris	8	decent	Last Available: "2022-11"
 10978	decent Boris's bread	3	good	Last Available: "2022-11"
 10979	wobbly Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
@@ -10842,12 +10842,12 @@
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	stale baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
-10989	decent half-sized plain calzone	2	good	Last Available: "2022-11"
-10990	bite-sized bland huge roasted vegetable focaccia	1	decent	Last Available: "2022-11"
-10991	yummy immense Pizza of Legend	8	awesome	Last Available: "2022-11"
+10989	half-sized decent plain calzone	2	good	Last Available: "2022-11"
+10990	bland bite-sized huge roasted vegetable focaccia	1	decent	Last Available: "2022-11"
+10991	immense yummy Pizza of Legend	8	awesome	Last Available: "2022-11"
 10992	bite-sized normal Calzone of Legend	1	good	Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	narrow upside-down twirling Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10994	upside-down twirling narrow Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	pulsating Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
 10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
 10997	spinning Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
@@ -10863,15 +10863,15 @@
 11007	ghostly purple booze bindle	0		
 11008	ghostly rare oboe of temperance of the businessman	0		Sleaze Resistance: +5, Meat Drop: +50
 11009	extremely unsafe bullet necklace of terror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +10, Single Equip
-11010	immense delicious swamp haunch	7	awesome	
+11010	delicious immense swamp haunch	7	awesome	
 11011	green nasty Newton's gator shades	0		Experience (Mysticality): +3, Stench Damage: +5, Single Equip
 11012	milk cap	0		
 11013	artisanal bouncing Charleston Choo-Choo	3	EPIC	
-11014	weak tolerable Velvet Veil	2	good	
-11015	spirit-forward artisanal Marltini	5	EPIC	
-11016	distilled mediocre Strong, Silent Type	5	decent	
-11017	artisanal practically non-alcoholic Mysterious Stranger	1	super ultra mega turbo EPIC	
-11018	aged practically non-alcoholic Champagne Shimmy	1	awesome	
+11014	tolerable weak Velvet Veil	2	good	
+11015	artisanal spirit-forward Marltini	5	EPIC	
+11016	mediocre distilled Strong, Silent Type	5	decent	
+11017	practically non-alcoholic artisanal Mysterious Stranger	1	super ultra mega turbo EPIC	
+11018	practically non-alcoholic aged Champagne Shimmy	1	awesome	
 11019	pulsating the Sot's parcel	0		
 11020	Tesla ceramic cestus of dire peril	0		Weapon Damage: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
 11021	pulsating curative thinker's ceramic centurion shield of the wise owl	0		Mysticality: 30, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	ghostly mirror ruddy steel-toed personal trainer's chiffon chaps	0		Experience Percent (Muscle): +10, Damage Reduction: 9, Maximum HP Percent: +40, Last Available: "2023-12"
 11034	diluted upside-down chiffon carbage	1		Last Available: "2023-12"
 11035	extra-cold-filtered diffused upside-down chiffon lemon	0		Effect: "Fever From the Flavor", Effect Duration: 25
-11036	tiny decent chocomotive	1	good	Last Available: "2022-12"
+11036	decent tiny chocomotive	1	good	Last Available: "2022-12"
 11037	bland snack-sized huge freightcake	2	decent	Last Available: "2022-12"
 11038	hand-crafted cabooze	3	EPIC	Last Available: "2022-12"
 11039	blinking plastic caboose	0		Last Available: "2022-12"
@@ -10924,20 +10924,20 @@
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	decent mirror honey-drenched ham slice	3	good	
-11071	special triple-distilled perfectly mixed mostly-empty bottle of cookie wine	8	EPIC	Effect: "[800]Chocolate Reign", Effect Duration: 20
+11071	triple-distilled perfectly mixed special mostly-empty bottle of cookie wine	8	EPIC	Effect: "[800]Chocolate Reign", Effect Duration: 20
 11072	flavorless mirror Crimbo food scraps	4	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	ghostly automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	blurry industrially-crushed ice	0		Last Available: "2022-12"
-11078	bland immense steamed oyster	10	decent	
+11078	immense bland steamed oyster	10	decent	
 11079	teal really nice lump of coal	0		
 11080	yellow deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	wobbly bouncing crystal Crimbo platter	0		
-11084	perfectly mixed weak fancy Crimbosmopolitan	2	super ultra mega EPIC	Effect: "Can Has Cyborger", Effect Duration: 10, Last Available: "2022-12"
+11084	perfectly mixed fancy weak Crimbosmopolitan	2	super ultra mega EPIC	Effect: "Can Has Cyborger", Effect Duration: 10, Last Available: "2022-12"
 11085	decent Crimbo dinner	3	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	fuchsia train whistle	0		Last Available: "2022-12"
@@ -10967,19 +10967,19 @@
 11112	toothsome pixel bread	4	awesome	
 11113	artisanal mirror pixel whiskey	4	EPIC	
 11114	twirling pixel rock	0		
-11115	wobbly maroon S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
-11116	mirror blinking S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
+11115	maroon wobbly S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
+11116	blinking mirror S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	quantum dry glob of extra-green chlorophyll	0		Effect: "Your Eyes are Peeled!", Effect Duration: 67, Last Available: "2023-02"
 11118	activated adjusted corrupted upside-down squat mushroom	0		Effect: "Compensatory Cruelness", Effect Duration: 46, Last Available: "2023-02"
 11119	alkaline altered five-fingered fern resin	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 67, Last Available: "2023-02"
-11120	moldy snack-sized super good fruit	2	crappy	Last Available: "2023-02"
+11120	snack-sized moldy super good fruit	2	crappy	Last Available: "2023-02"
 11121	twisted energized spores	1		Last Available: "2023-02"
-11122	mirror nasty hot pepper of dire peril	0		Weapon Damage: +20, Stench Damage: +5, Lantern Element: "Hot", Last Available: "2023-02"
+11122	mirror nasty hot pepper of dire peril	0		Weapon Damage: +20, Stench Damage: +5, Last Available: "2023-02", Lantern Element: "Hot"
 11123	concentrated out-of-work circus flea	0		Effect: "Fudgehound", Effect Duration: 56, Last Available: "2023-02"
 11124	cyan shaking narrow extra-grubby grub	0		Last Available: "2023-02"
 11125	pickled red fire ant pheromones	0		Effect: "Sleazy Jellied", Effect Duration: 59, Last Available: "2023-02"
 11126	pressed colloidal wobbly flapper fly	0		Effect: "Salty Mouth", Effect Duration: 37, Last Available: "2023-02"
-11127	strong artisanal shot of wasp venom	5	EPIC	Last Available: "2023-02"
+11127	artisanal strong shot of wasp venom	5	EPIC	Last Available: "2023-02"
 11128	moist filled mosquito	0		Effect: "Items Are Forever", Effect Duration: 11, Last Available: "2023-02"
 11129	adjusted non-quantum quantum shim of shame shale	0		Effect: "Slimy Hands", Effect Duration: 56, Last Available: "2023-02"
 11130	dry fuchsia pebble of proud pyrite	0		Effect: "The Smeezingtons", Effect Duration: 17, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	adjusted angry agate	0		Effect: "Bone Homie", Effect Duration: 67, Last Available: "2023-02"
 11134	super-polymerized altered lump of loyal latite	0		Effect: "Hagnk's Gratitude", Effect Duration: 38, Last Available: "2023-02"
-11135	rotten jumbo shadow sausage	5	crappy	Last Available: "2023-03"
+11135	jumbo rotten shadow sausage	5	crappy	Last Available: "2023-03"
 11136	Oprah's Rosewater's shadow skin	0		Mysticality Percent: +30, Maximum MP Percent: +50, Last Available: "2023-03"
 11137	pressed cold-filtered shaking shadow flame	0		Effect: "Red-Shirted Escort", Effect Duration: 61, Last Available: "2023-03"
 11138	decent half-sized shadow bread	2	good	Last Available: "2023-03"
@@ -11027,7 +11027,7 @@
 11172	squat shadow snowflake	0		
 11173	shadow heart	0		
 11174	shadow bucket	0		
-11175	wobbly tumbling shadow wave	0		
+11175	tumbling wobbly shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	tumbling greasy fortified strapping shadow chef's hat	0		Muscle: +5, Damage Absorption: +60, Sleaze Spell Damage: +10
 11178	hardened stiffened shadow trousers of the brute	0		Muscle Percent: +30, Damage Reduction: 8
@@ -11088,7 +11088,7 @@
 11233	replica Witchess Set	0		
 11234	replica genie bottle	0		
 11235	replica space planula	0		
-11236	wobbly pulsating replica unpowered Robortender	0		
+11236	pulsating wobbly replica unpowered Robortender	0		
 11237	bouncing replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
 11239	blinking replica God Lobster Egg	0		
@@ -11100,10 +11100,10 @@
 11245	pulsating clever padded personal trainer's replica Cargo Cultist Shorts of vim and vigor	0		Experience Percent (Muscle): +10, Damage Absorption: +20, Maximum HP Percent: +50, Maximum MP: +20
 11246	chilly supercharged razor-sharp Fonzie's replica industrial fire extinguisher of Gandalf of the boozehound	0		Experience (Moxie): +1, Weapon Damage Percent: +25, Maximum MP Percent: +30, Spell Critical Percent: +20, Cold Damage: +5, Booze Drop: +100, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 11247	narrow replica crystal ball	0		Initiative: +50
-11248	shaking olive jittery replica emotion chip	0		Skill: "Replica Emotionally Chipped"
+11248	jittery shaking olive replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	stanky beefcake's replica Jurassic Parka	0		Muscle: +25, Stench Spell Damage: +25
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	huge replica Ten Dollars	0		
 11254	spinning blurry foul-smelling frosty vibrating replica Cincho de Mayo of bravery	0		Maximum MP Percent: +10, Cold Spell Damage: +10, Stench Damage: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11157,10 +11157,10 @@
 11302	cyan souvenir flag	0		
 11303	name change form	0		
 11304	blinking replica sleeping patriotic eagle	0		
-11305	jittery upside-down boxed august scepter	0		Free Pull
+11305	upside-down jittery boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	stale small watermelon	2	decent	
-11308	lime green ghostly watermelon seed	0		
+11308	ghostly lime green watermelon seed	0		
 11309	water balloon	0		
 11310	purple thriftshop coupon	0		
 11311	flavorless miniature narrow waffle	2	decent	
@@ -11174,7 +11174,7 @@
 11319	yellow medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	bad bottle of Cabernet Sauvignon	3	decent	
 11321	bouncing beefcake's baywatch of mayonnaise of the detective	0		Muscle: +25, Sleaze Spell Damage: +50, Item Drop: +20, Lasts Until Rollover
-11322	huge spinning Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	spinning huge Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	shaking consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
@@ -11224,7 +11224,7 @@
 11369	spinning automa-bot parts	0		
 11370	security automa-core	0		
 11371	clerical automa-core	0		
-11372	red blinking handful of Boltsmann bearings	0		
+11372	blinking red handful of Boltsmann bearings	0		
 11373	Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
 11375	spinning Boltsmann ID badge	0		
@@ -11240,14 +11240,14 @@
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
-11388	blinking green pirate encryption key charlie	0		Last Available: "2023-12"
+11388	green blinking pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
 11390	wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	low-calorie bland peppermint donut	1	decent	
+11395	bland low-calorie peppermint donut	1	decent	
 11396	twirling chaotic Elf Guard insignia (private)	0		Spell Critical Percent: +10, Last Available: "2023-12"
 11397	Jeselnik's Crimbuccaneer fledges (mint)	0		Sleaze Damage: +25, Last Available: "2023-12"
 11398	fuchsia military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11274,13 +11274,13 @@
 11419	olive electrified Newton's Elf Guard broom	0		Experience (Mysticality): +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
 11420	bouncing blinking Jim Carey's wicked Rosewater's Crimbuccaneer tavern swab	0		Mysticality Percent: +30, Spell Damage: +5, Monster Level: +25, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	weak tolerable old-school pirate grog	2	good	Last Available: "2023-12"
+11422	tolerable weak old-school pirate grog	2	good	Last Available: "2023-12"
 11423	stale super-sized grog nuts	5	decent	Last Available: "2023-12"
 11424	stiffened sawed-off blunderbuss of the cougar of courage	0		Moxie: +20, Damage Reduction: 1, Spooky Resistance: +3, Last Available: "2023-12"
-11425	watered-down acceptable officer's nog	2	good	Last Available: "2023-12"
+11425	acceptable watered-down officer's nog	2	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	moldy sundae ration	3	crappy	Last Available: "2023-12"
-11428	bland small peppermint tack	2	decent	Last Available: "2023-12"
+11428	small bland peppermint tack	2	decent	Last Available: "2023-12"
 11429	cyan Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	moldy whalesteak	3	crappy	Last Available: "2023-12"
 11431	resourceful extremely unsafe educational whalegun	0		Experience: +1, Weapon Damage Percent: +100, Maximum MP: +50, Last Available: "2023-12"
@@ -11311,15 +11311,15 @@
 11456	spinning baby rigging snake	0		Last Available: "2023-12"
 11457	supercharged personal trainer's Elvish underarmor of the storm	0		Experience Percent (Muscle): +10, Maximum MP Percent: 70, Single Equip, Last Available: "2023-12"
 11458	hardy razor-sharp Crimbuccaneer bombjacket	0		Weapon Damage Percent: +25, Maximum HP: +50, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	decent miniature enchanted sugarplum ration	2	good	Effect: "Eldritch Concentration", Effect Duration: 5, Last Available: "2023-12"
+11459	miniature enchanted decent sugarplum ration	2	good	Effect: "Eldritch Concentration", Effect Duration: 5, Last Available: "2023-12"
 11460	flavorless gingerbread nylons	3	decent	Last Available: "2023-12"
 11461	enchanted stale tumbling rum-soaked fruitcake	4	decent	Effect: "Gyromitra Gymnastics", Effect Duration: 45, Last Available: "2023-12"
 11462	yummy lime	4	awesome	Last Available: "2023-12"
-11463	small normal enchanted twirling gingerbread pirate	2	good	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 40, Last Available: "2023-12"
+11463	enchanted normal small twirling gingerbread pirate	2	good	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 40, Last Available: "2023-12"
 11464	miniature stale fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
 11465	bad skewed mulled wine	3	decent	Last Available: "2023-12"
 11466	artisanal weak Swedish coffee	2	EPIC	Last Available: "2023-12"
-11467	tolerable strong fancy canteen of eggnog	5	good	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2023-12"
+11467	fancy tolerable strong canteen of eggnog	5	good	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2023-12"
 11468	lousy watered-down hot wine	2	decent	Last Available: "2023-12"
 11469	aged strong squat Jamaican coffee	5	awesome	Last Available: "2023-12"
 11470	artisanal flask of egggrog	4	EPIC	Last Available: "2023-12"
@@ -11328,9 +11328,9 @@
 11473	gray pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	triple-distilled delicious yule grog	9	awesome	Last Available: "2023-12"
 11475	adequate wet tack	4	good	Last Available: "2023-12"
-11476	adequate narrow mirror whalecake	3	good	Last Available: "2023-12"
+11476	adequate mirror narrow whalecake	3	good	Last Available: "2023-12"
 11477	narrow chaotic Oprah's gunwale whalegun of the ox	0		Muscle: +20, Maximum MP Percent: +50, Spell Critical Percent: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
-11478	watered-down hand-crafted and claret	2	super ultra mega EPIC	Last Available: "2023-12"
+11478	hand-crafted watered-down and claret	2	super ultra mega EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	asbestos-lined Jim Carey's Elf Guard squirtgun	0		Monster Level: +25, Hot Resistance: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
@@ -11362,7 +11362,7 @@
 11507	perfumed frosty moss mitre	0		Cold Spell Damage: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
 11508	greedy scorching moss mantle	0		Hot Damage: +25, Meat Drop: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	upside-down MacGyver's moss marlinspike of the businessman	0		Maximum MP: +100, Meat Drop: +50, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	boiled huge purple moss mulch	1		Last Available: "2024-12"
+11510	boiled purple huge moss mulch	1		Last Available: "2024-12"
 11511	polarized moss floss	0		Effect: "Deadly Lampblade", Effect Duration: 43
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11382,8 +11382,8 @@
 11527	ionized nitrogenated crepe paper peanut candy	0		Effect: "Turkey-Ambitious", Effect Duration: 62
 11528	gray clever smartaleck's petrified wood war pike	0		Moxie Percent: +30, Maximum MP: +20, Last Available: "2025-12"
 11529	pulsating narrow prompt aromatic petrified wood waist protector	0		Stench Resistance: +1, Adventures: +3, Single Equip, Last Available: "2025-12"
-11530	resourceful petrified wood wizard's pouch of dire peril	0		Weapon Damage: +20, Maximum MP: +50, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	tumbling scorching electrified petrified wood water purifier	0		Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	resourceful petrified wood wizard's pouch of dire peril	0		Weapon Damage: +20, Maximum MP: +50, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	tumbling scorching electrified petrified wood water purifier	0		Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	nippy careful petrified wood whoopie panama	0		Monster Level: -10, Cold Damage: +10, Last Available: "2025-12"
 11533	bouncing nippy baleful petrified wood walking pants	0		Spell Damage: +25, Cold Damage: +10, Last Available: "2025-12"
 11534	denatured jittery petrified wood waste parts	1		Effect: "Innately Strong", Effect Duration: 5, Last Available: "2025-12"
@@ -11427,11 +11427,11 @@
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	yummy squat yam	3	awesome	Last Available: "2024-05"
 11574	smooth yam martini	4	awesome	Last Available: "2024-05"
-11575	watered-down artisanal sweet potato o' mine	2	EPIC	Last Available: "2024-05"
-11576	acceptable irresponsibly strong shaking Southern yam	10	good	Last Available: "2024-05"
+11575	artisanal watered-down sweet potato o' mine	2	EPIC	Last Available: "2024-05"
+11576	irresponsibly strong acceptable shaking Southern yam	10	good	Last Available: "2024-05"
 11577	artisanal practically non-alcoholic sweet potato punch	1	super ultra mega turbo EPIC	Last Available: "2024-05"
 11578	bland upside-down Mayam spinach	4	decent	Last Available: "2024-05"
-11579	stale thick twirling yam and swiss	5	decent	Last Available: "2024-05"
+11579	thick stale twirling yam and swiss	5	decent	Last Available: "2024-05"
 11580	prompt baleful razor-sharp yam cannon	0		Weapon Damage Percent: +25, Spell Damage: +25, Adventures: +3, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	upside-down yam battery	0		Last Available: "2024-05"
@@ -11453,7 +11453,7 @@
 11598	mini kiwi aioli	0		
 11599	dance instructor's brainy mini kiwi silicon tiepin of the blizzard	0		Mysticality: +5, Experience Percent (Moxie): +10, Cold Spell Damage: +25
 11600	gray mini kiwi tipi	0		
-11601	flavorless thick mini kiwi digitized cookies	5	decent	
+11601	thick flavorless mini kiwi digitized cookies	5	decent	
 11602	drinkable spinning mini kiwi intoxicating spirits	3	good	
 11603	triple-boiled quadruple-unsweetened skewed jittery mini kiwi antimilitaristic hippy petition	0		Effect: "Limber as Mortimer", Effect Duration: 48
 11604	polarized narrow mini kiwi illicit antibiotic	0		Effect: "For Your Brain Only", Effect Duration: 66
@@ -11469,8 +11469,8 @@
 11614	protogenetic chunklet (lips)	0		
 11615	maroon Lo Pan's MacGyver's messenger bag RNA	0		Maximum MP: +100, Spell Critical Percent: +30, Item Drop: +5
 11616	flagellate flagon	0		
-11617	blurry skewed proto-proto-protozoa	0		
-11618	delicious massive bacteria bisque	6	awesome	
+11617	skewed blurry proto-proto-protozoa	0		
+11618	massive delicious bacteria bisque	6	awesome	
 11619	yummy upside-down ciliophora chowder	3	awesome	
 11620	stale cream of chloroplasts	3	decent	
 11621	squat synaptic soup	0		
@@ -11478,7 +11478,7 @@
 11623	flagellate soup	0		
 11624	elbow soup	0		
 11625	lip soup	0		
-11626	huge twirling unevolved organism	0		Free Pull
+11626	twirling huge unevolved organism	0		Free Pull
 11627	extra ooze	0		
 11628	blurry extra DNA	0		Experience (familiar): +1
 11629	untorn tearaway pants package	0		Free Pull
@@ -11487,7 +11487,7 @@
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	blinking tattoo gun	0		
-11635	practically non-alcoholic tolerable shaking gray Colera Peste Nebbiolo	1	good	
+11635	practically non-alcoholic tolerable gray shaking Colera Peste Nebbiolo	1	good	
 11636	longbox of Batfellow comics	0		
 11637	huge Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11505,7 +11505,7 @@
 11650	adequate small bouncing jittery wheel of camembert	2	good	Last Available: "2024-09"
 11651	arcane researcher's Socratic experienced hat of remembering	0		Experience: +2, Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
-11653	blurry shaking head of emberg lettuce	0		Last Available: "2024-09"
+11653	shaking blurry head of emberg lettuce	0		Last Available: "2024-09"
 11654	embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
@@ -11572,7 +11572,7 @@
 11717	Spirit of Easter	0		Last Available: "2024-12"
 11718	Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	squat Spirit of Veteran's Day	0		Last Available: "2024-12"
-11720	mirror narrow Spirit of Thanksgiving	0		Last Available: "2024-12"
+11720	narrow mirror Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	thick decent skewed coney haunch	5	good	Last Available: "2024-12"
 11723	tarnished jittery dark chocolate egg	0		Effect: "Pretending to Pretend", Effect Duration: 21, Last Available: "2024-12"
@@ -11581,7 +11581,7 @@
 11726	yellow narrow half-digested rat	0		Last Available: "2024-12"
 11727	tarnished unsweetened bouncing twirling four-leaf potato sprout	0		Effect: "Polka of Plenty", Effect Duration: 30, Last Available: "2024-12"
 11728	rosewater-soaked cool wizardly potato jacket	0		Mysticality: +25, Moxie: +5, Stench Resistance: +3, Last Available: "2024-12"
-11729	fuchsia blinking traumatic holiday memory	0		Last Available: "2024-12"
+11729	blinking fuchsia traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
 11731	miser's military orb of the boozehound	0		Meat Drop: +10, Booze Drop: +100, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	enhanced rum ball	0		Effect: "Ponderous Potency", Effect Duration: 27
@@ -11600,17 +11600,17 @@
 11745	therapeutic dance instructor's Congressional Medal of Insanity of Gandalf	0		Experience Percent (Moxie): +10, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11746	olive pumpkin spice whorl	0		Last Available: "2024-12"
 11747	perfectly mixed weak Easter grasshopper	2	EPIC	Last Available: "2024-12"
-11748	distilled lousy gray Irish eggnog	5	decent	Last Available: "2024-12"
-11749	fancy delicious canteen of jungle juice	3	awesome	Effect: "Compensatory Cruelness", Effect Duration: 50, Last Available: "2024-12"
+11748	lousy distilled gray Irish eggnog	5	decent	Last Available: "2024-12"
+11749	delicious fancy canteen of jungle juice	3	awesome	Effect: "Compensatory Cruelness", Effect Duration: 50, Last Available: "2024-12"
 11750	drinkable watered-down turchucken	2	good	Last Available: "2024-12"
 11751	bad mechanically-mulled cider	4	decent	Last Available: "2024-12"
 11752	drinkable holiday trip around the world	3	good	Last Available: "2024-12"
 11753	adequate chocolate ostrich egg	3	good	Last Available: "2024-12"
-11754	normal half-sized beef and cabbage	2	good	Last Available: "2024-12"
-11755	half-sized flavorless tumbling upside-down candy rations	2	decent	Last Available: "2024-12"
-11756	delicious immense double-candied yams	6	awesome	Last Available: "2024-12"
+11754	half-sized normal beef and cabbage	2	good	Last Available: "2024-12"
+11755	flavorless half-sized tumbling upside-down candy rations	2	decent	Last Available: "2024-12"
+11756	immense delicious double-candied yams	6	awesome	Last Available: "2024-12"
 11757	bland squat Christmas ham	4	decent	Last Available: "2024-12"
-11758	spoiled diet holiday smorgasbord	1	crappy	Last Available: "2024-12"
+11758	diet spoiled holiday smorgasbord	1	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	friendly bejazzled eyepatch	0		Familiar Weight: +3, Last Available: "2024-12"
 11761	fuchsia Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11666,7 +11666,7 @@
 11811	purple logic grenade	0		Last Available: "2025-12"
 11812	vaporized psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
-11814	yellow squat dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
+11814	squat yellow dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	upside-down dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
@@ -11685,13 +11685,13 @@
 11830	ninja rope	0		
 11831	twirling ninja crampons	0		
 11832	pulsating pulsating ninja carabiner	0		
-11833	anodized nitrogenated shaking pulsating synthetic coffee	0		Effect: "Headstrong", Effect Duration: 47
+11833	anodized nitrogenated pulsating shaking synthetic coffee	0		Effect: "Headstrong", Effect Duration: 47
 11834	modified narrow iDrops	0		Effect: "[1701]Hip to the Jive", Effect Duration: 16
 11835	shame coil	0		
 11836	new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	twirling heat arc	0		
-11839	spinning skewed scrape	0		
+11839	skewed spinning scrape	0		
 11840	ghostly phantom digit	0		
 11841	twirling foul line	0		
 11842	dark manioc	0		
@@ -11703,7 +11703,7 @@
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
-11851	upside-down blurry stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
+11851	blurry upside-down stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	ghostly foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	squat grim cellophane	0		Combat Rate: -5
@@ -11716,7 +11716,7 @@
 11861	blue Leprecondo	0		Last Available: "2025-03"
 11862	altered blinking scoop of pre-workout powder	1		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 40, Last Available: "2025-03"
 11863	tumbling table tennis ball	0		Last Available: "2025-03"
-11864	enchanted artisanal pint of Leprechaun Stout	3	EPIC	Effect: "All Glory To the Toad", Effect Duration: 30, Last Available: "2025-03"
+11864	artisanal enchanted pint of Leprechaun Stout	3	EPIC	Effect: "All Glory To the Toad", Effect Duration: 30, Last Available: "2025-03"
 11865	altered blurry gray phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11729,7 +11729,7 @@
 11874	flavorless tumbling small beer brat	3	decent	Last Available: "2025-03"
 11875	spoiled spinning peach pie	3	crappy	Last Available: "2025-03"
 11876	rotten incredible mini-pizza	4	crappy	Last Available: "2025-03"
-11877	lousy watered-down Divine sidecar	2	decent	Last Available: "2025-03"
+11877	watered-down lousy Divine sidecar	2	decent	Last Available: "2025-03"
 11878	watered-down acceptable tangarita sidecar	2	good	Last Available: "2025-03"
 11879	perfectly mixed high-proof gimlet sidecar	8	EPIC	Last Available: "2025-03"
 11880	practically non-alcoholic acceptable huge vodka stratocaster sidecar	1	good	Last Available: "2025-03"
@@ -11753,7 +11753,7 @@
 11898	warmed nitrogenated wet paper cup	0		Effect: "Twinkly Weapon", Effect Duration: 30, Last Available: "2025-04"
 11899	triple-liquefied frozen wet paperback	0		Effect: "Yuletide Mutations", Effect Duration: 53, Last Available: "2025-04"
 11900	therapeutic wet shower radio	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
-11901	teal pulsating wet shower stamp	0		Last Available: "2025-04"
+11901	pulsating teal wet shower stamp	0		Last Available: "2025-04"
 11902	ghostly brawny birthday bloon	0		Muscle Percent: +20
 11903	moist wet blurry jawwetter	0		Effect: "Initiative and Let Die", Effect Duration: 24
 11904	Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
@@ -11790,7 +11790,7 @@
 11935	pulsating ordnance magnet	0		Single Equip
 11936	tumbling confetti grenade	0		
 11937	spoiled Skeleton Wars rations	3	crappy	
-11938	delicious triple-distilled skeleton war fuel can	9	awesome	
+11938	triple-distilled delicious skeleton war fuel can	9	awesome	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,7 +11804,7 @@
 11949	green manspreader's bully badge	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2025-08"
 11950	greasy time cop top hat	0		Sleaze Spell Damage: +10, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	powdered red blurry twirling mixed berry jelly	1		Effect: "Taurus Rising", Effect Duration: 45, Last Available: "2025-08"
+11952	powdered blurry red twirling mixed berry jelly	1		Effect: "Taurus Rising", Effect Duration: 45, Last Available: "2025-08"
 11953	spoiled half-sized toast with mixed berry jelly	2	crappy	Last Available: "2025-08"
 11954	adequate narrow cup of sugar	3	good	Last Available: "2025-08"
 11955	snack-sized rotten gray Susie's cupcake	2	crappy	Last Available: "2025-08"
@@ -11814,7 +11814,7 @@
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	ghostly undersea surveying goggles of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover
-11963	extra-dry enchanted drinkable Ocean-Touched Rum	5	good	Effect: "Astral Shell", Effect Duration: 15
+11963	extra-dry drinkable enchanted Ocean-Touched Rum	5	good	Effect: "Astral Shell", Effect Duration: 15
 11964	dehydrated pulsating water-logged pill	1		
 11965	small decent kelp puck	2	good	
 11966	scroll of sea strength	0		
@@ -11838,7 +11838,7 @@
 12048	scorching fortified cool shrunken head	0		Moxie: +5, Damage Absorption: +60, Hot Damage: +25, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	lime green small peppermint-flavored sugar walking crook	0		
-12051	red skewed knucklebone	0		
+12051	skewed red knucklebone	0		
 12052	bad Smoking Pope	3	decent	
 12053	special bland prize turkey	3	decent	Effect: "Dreams and Lights", Effect Duration: 35
 12054	twisted mirror medicinal gruel	1		
@@ -11846,7 +11846,7 @@
 12056	artisanal vodka cranberry sauce	3	EPIC	Last Available: "2025-11"
 12057	altered quantum bouncing yammed candy	0		Effect: "Ack!  Barred!", Effect Duration: 23, Last Available: "2025-11"
 12058	bland treasure chestnut	3	decent	Last Available: "2025-12"
-12059	lousy weak blue mulled butter rum	2	decent	Last Available: "2025-12"
+12059	weak lousy blue mulled butter rum	2	decent	Last Available: "2025-12"
 12060	deionized polarized narrow cinnamon doubloon	0		Effect: "Bread-Lined", Effect Duration: 48, Last Available: "2025-12"
 12061	ghostly hardened plastic left skeleton arm	0		Damage Reduction: 3, Last Available: "2025-12"
 12062	olive ribald plastic left skeleton leg	0		Sleaze Damage: +10, Last Available: "2025-12"
@@ -11862,7 +11862,7 @@
 12072	smelly angelbone dice	0		Stench Spell Damage: +10, Single Equip, Last Available: "2026-12"
 12073	zippy angelbone halo of vim and vigor	0		Maximum HP Percent: +50, Initiative: +20, Last Available: "2026-12"
 12074	altered narrow angelbone fragments	1		Last Available: "2026-12"
-12075	denatured purple skewed biblically accurate gumdrops	0		Effect: "Yet tea", Effect Duration: 61
+12075	denatured skewed purple biblically accurate gumdrops	0		Effect: "Yet tea", Effect Duration: 61
 12076	prompt supercool devilbone helmet	0		Moxie Percent: +20, Adventures: +3, Last Available: "2026-12"
 12077	ghostly twirling zippy devilbone greaves	0		Initiative: +20, Last Available: "2026-12"
 12078	jittery hardy devilbone shinguards of the pedagogue	0		Experience: +3, Maximum HP: +50, Single Equip, Last Available: "2026-12"
@@ -11897,7 +11897,7 @@
 12139	family-friendly hardy burnt bone belt of the empath	0		Maximum HP: +50, Familiar Weight: +5, Sleaze Resistance: +1, Single Equip, Last Available: "2025-12"
 12140	mirror vibrating scorched skull trophy	0		Maximum MP Percent: +10, Last Available: "2025-12"
 12141	moldy wing bone	3	crappy	Last Available: "2025-12"
-12142	delicious distilled twirling weak skeleton venom	5	awesome	Last Available: "2025-12"
+12142	distilled delicious twirling weak skeleton venom	5	awesome	Last Available: "2025-12"
 12143	denatured baked bone meal	1		Effect: "Rat-Faced", Effect Duration: 30, Last Available: "2025-12"
 12144	purple Oprah's plastic skeleton rib cage	0		Maximum MP Percent: +50, Last Available: "2025-12"
 12145	ruddy plastic skeleton skull	0		Maximum HP Percent: +40, Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	adequate traditional gingerloaf	3	good	Last Available: "2025-12"
 12172	mediocre mirror Scotch and eggnog	4	decent	Last Available: "2025-12"
 12173	adjusted altered polarized upside-down huge counterskeleton elixir	0		Effect: "Very Clean Guns", Effect Duration: 63, Last Available: "2025-12"
-12174	perfectly mixed weak &quot;salvaged&quot; wine	2	EPIC	Last Available: "2025-12"
+12174	weak perfectly mixed &quot;salvaged&quot; wine	2	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	mirror crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	spoiled big wedge of prize-winning cheese	5	crappy	Last Available: "2025-12"
@@ -11947,7 +11947,7 @@
 12189	bouncing intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
 12191	wobbly unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
-12192	shaking yellow Pork Elf toiletries kit	0		Last Available: "2026-03"
+12192	yellow shaking Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	quadruple-concentrated Pork Elf mouthwash	0		Effect: "Baconstoned", Effect Duration: 65, Last Available: "2026-03"
 12194	improved narrow Pork Elf deodorant	0		Effect: "Waxing", Effect Duration: 37, Last Available: "2026-03"
 12195	activated yellow Pork Elf toothpaste	0		Effect: "Woad Warrior", Effect Duration: 51, Last Available: "2026-03"
@@ -11965,7 +11965,7 @@
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	bouncing Pork Elf toilet	0		Last Available: "2026-03"
 12209	moldy rat pizza	3	crappy	Last Available: "2026-03"
-12210	fuchsia narrow Fleek&trade; mascara	0		Last Available: "2026-03"
+12210	narrow fuchsia Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	olive nasty MacGyver's hoverboard of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Stench Damage: +5, Single Equip, Last Available: "2026-03"
 12212	smelly scorching healthy left shark fin	0		Maximum HP Percent: +20, Hot Damage: +25, Stench Spell Damage: +10, Last Available: "2026-03"
 12213	educational fitness tracking bracelet	0		Experience: +1, Single Equip, Last Available: "2026-03"
@@ -11973,7 +11973,7 @@
 12215	wobbly wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	decent discarded hot dog	3	good	Last Available: "2026-04"
-12218	artisanal practically non-alcoholic special most of a beer	1	EPIC	Effect: "Can Has Cyborger", Effect Duration: 30, Last Available: "2026-04"
+12218	practically non-alcoholic special artisanal most of a beer	1	EPIC	Effect: "Can Has Cyborger", Effect Duration: 30, Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
@@ -11986,9 +11986,9 @@
 12232	small rotten hot honey ant	2	crappy	
 12233	flavorless tomb aspic	3	decent	
 12234	delicious later tots	3	awesome	
-12235	rotten snack-sized Frutti di Scatoletta	2	crappy	Last Available: "2026-05"
-12236	spoiled half-sized Pesto alla Marziano	2	crappy	Last Available: "2026-05"
-12237	low-calorie decent ghostly Arrattabbattabiata	1	good	Last Available: "2026-05"
+12235	snack-sized rotten Frutti di Scatoletta	2	crappy	Last Available: "2026-05"
+12236	half-sized spoiled Pesto alla Marziano	2	crappy	Last Available: "2026-05"
+12237	decent low-calorie ghostly Arrattabbattabiata	1	good	Last Available: "2026-05"
 12238	moldy Orzo di Riso	4	crappy	Last Available: "2026-05"
 12239	half-sized normal Pasta Grimavera	2	good	Last Available: "2026-05"
 12240	rotten super-sized skewed Linguini Ubriacapa	5	crappy	Last Available: "2026-05"
@@ -12000,7 +12000,7 @@
 12246	fuchsia second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	toasty experienced Space Soldier Helmet	0		Experience: +2, Hot Damage: +5
-12253	snack-sized tasty premium turkey leg	2	awesome	
+12253	tasty snack-sized premium turkey leg	2	awesome	
 12254	acceptable styrofoam cup of mead	4	good	
 12255	sword of the detective	0		Item Drop: +20
 12256	friendly staff	0		Familiar Weight: +3
@@ -12024,7 +12024,7 @@
 12274	rotten quince	3	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	tiny decent mirror squat classic banana pie	1	good	Last Available: "2026-07"
+12277	tiny decent squat mirror classic banana pie	1	good	Last Available: "2026-07"
 12278	tarnished ionized essential banana decoction	0		Effect: "Far Out", Effect Duration: 53, Last Available: "2026-07"
 12279	tarnished cold-filtered purple banana quintessence	0		Effect: "Oleaginous Soles", Effect Duration: 11, Last Available: "2026-07"
 12280	smooth extra-dry Aesop Daiquiri	5	awesome	Last Available: "2026-07"
@@ -12034,16 +12034,16 @@
 12284	deionized polarized Aqua Citrulanatae	0		Effect: "Human-Orc Hybrid", Effect Duration: 62, Last Available: "2026-07"
 12285	delicious Melonegroni	4	awesome	Last Available: "2026-07"
 12286	hand-crafted cyan Melonade Spritz	3	EPIC	Last Available: "2026-07"
-12287	adequate big enchanted quince pie	5	good	Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2026-07"
+12287	adequate enchanted big quince pie	5	good	Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2026-07"
 12288	quantum frozen quince quaff	0		Effect: "Cancer Rising", Effect Duration: 51, Last Available: "2026-07"
-12289	activated narrow bouncing Quickquince	0		Effect: "Pumped Stomach", Effect Duration: 11, Last Available: "2026-07"
-12290	bad practically non-alcoholic Quiskey Sour	1	decent	Last Available: "2026-07"
+12289	activated bouncing narrow Quickquince	0		Effect: "Pumped Stomach", Effect Duration: 11, Last Available: "2026-07"
+12290	practically non-alcoholic bad Quiskey Sour	1	decent	Last Available: "2026-07"
 12291	mediocre watered-down Quincea&ntilde;era Cooler	2	decent	Last Available: "2026-07"
 12292	drinkable Roth IPA	3	good	Last Available: "2026-08"
 12293	horrifying underdraft protection of the bloodbag	0		Maximum HP: +100, Spooky Damage: +25, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	adequate teal blurry soybean futures	3	good	Last Available: "2026-08"
-12296	double-pressed improved ghostly skewed housing bubble	0		Effect: "Fan-Cooled", Effect Duration: 30, Last Available: "2026-08"
+12295	adequate blurry teal soybean futures	3	good	Last Available: "2026-08"
+12296	double-pressed improved skewed ghostly housing bubble	0		Effect: "Fan-Cooled", Effect Duration: 30, Last Available: "2026-08"
 12297	nitrogenated improved Pixie-Swordz	0		Effect: "Berry Berry Cold", Effect Duration: 62
 12298	squat ghostly Jim Carey's deadly financial instrument	0		Weapon Damage: +5, Monster Level: +25, Last Available: "2026-08"
 12299	green twirling steel-toed hedge fund clippers of Gandalf	0		Damage Reduction: 9, Spell Critical Percent: +20, Last Available: "2026-08"
@@ -12057,7 +12057,7 @@
 12307	galvanized warmed blinking mint	0		Effect: "Tapped In", Effect Duration: 51, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
-12310	vaporized upside-down huge toxic asset	1		Last Available: "2026-08"
+12310	vaporized huge upside-down toxic asset	1		Last Available: "2026-08"
 12311	boiled intangible asset	1		Last Available: "2026-08"
 12312	vaporized pulsating liquid asset	1		Last Available: "2026-08"
 12313	olive gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Vole_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	bad lime green Petite Porter	3	decent	
 -2	drinkable watered-down huge Scrawny Stout	2	good	
 -3	fancy smooth Infinitesimal IPA	3	awesome	
--4	artisanal enchanted eggnogtini	3	EPIC	
+-4	enchanted artisanal eggnogtini	3	EPIC	
 -5	hand-crafted ghostly candycaine	3	EPIC	
 -6	hand-crafted braincracker sweet	4	EPIC	
 -16	mediocre watered-down fermented honey	2	decent	
 -17	drinkable moons-shine	3	good	
--18	triple-distilled acceptable blurry green gin	9	good	
--19	perfectly mixed watered-down special twirling ecto-nog	2	EPIC	
+-18	acceptable triple-distilled green blurry gin	9	good	
+-19	special watered-down perfectly mixed twirling ecto-nog	2	EPIC	
 -20	perfectly mixed spinning hot toady	4	EPIC	
 -21	bad hot choculate	3	decent	
--49	watered-down delicious Cyder	2	awesome	
+-49	delicious watered-down Cyder	2	awesome	
 -50	lousy extra-dry Oil Nog	5	decent	
 -51	triple-distilled drinkable Hi-Octane Peppermint Jet Fuel	10	good	
 -58	drinkable pulsating Grimacider	4	good	
--59	enchanted artisanal practically non-alcoholic bouncing Isotope Nog	1	EPIC	
+-59	enchanted practically non-alcoholic artisanal bouncing Isotope Nog	1	EPIC	
 -60	weak hand-crafted Mutagin 'n' Tonic	2	EPIC	
--70	special perfectly mixed Gin and Herring	4	EPIC	
--71	enchanted perfectly mixed Black and Tan and Red All Over	4	EPIC	
+-70	perfectly mixed special Gin and Herring	4	EPIC	
+-71	perfectly mixed enchanted Black and Tan and Red All Over	4	EPIC	
 -72	hand-crafted Antarctic Ice Tea	3	EPIC	
 -76	drinkable purple CRIMBCO Ribbon Candy Schnapps	3	good	
 -77	bad twirling CRIMBCO Egg Substitute Nog Substitute	3	decent	
 -78	bad red CRIMBCO Extreme Braincracker Sour	4	decent	
 -82	hand-crafted twirling Horseradish-infused Vodka	3	EPIC	
 -83	tolerable spirit-forward green Jerkitini	5	good	
--84	lousy boozy cyan pulsating wobbly Desert Island Iced Tea	5	decent	
+-84	lousy boozy cyan wobbly pulsating Desert Island Iced Tea	5	decent	
 -88	mediocre wobbly Crimbo Saketini	4	decent	
--89	strong bad Crimboku Drop	5	decent	
+-89	bad strong Crimboku Drop	5	decent	
 -90	tolerable pulsating Flaming Crimbo Log	3	good	
 -107	aged watered-down Fortified Eggnog Slurry	2	awesome	
 -108	practically non-alcoholic lousy Hot Buttered Rum	1	decent	
--109	weak mediocre lime green Spicy Hot Chocolate	2	decent	
+-109	mediocre weak lime green Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Disco_Bandit_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Vole_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	rotten lime green Peche a la Frog	3	crappy	
 -2	stale half-sized huge As Jus Gezund Heit	2	decent	
--3	adequate fancy Bouillabaise Coucher Avec Moi	3	good	
+-3	fancy adequate Bouillabaise Coucher Avec Moi	3	good	
 -7	adequate snack-sized jittery gumdrop chow mein	2	good	
 -8	delicious candy cane pizza	3	awesome	
 -9	normal gingerbread stir-fry	3	good	
 -10	gigantic spoiled bouncing twigs and gravel	7	crappy	
 -11	adequate shoots and leaves	3	good	
--12	super-sized normal yellow bowl of unidentifiable goo	5	good	
--13	toothsome special thick tumbling gingerbread massacre	5	awesome	
--14	yummy tiny It Came From Beyond Dessert	1	awesome	
+-12	normal super-sized yellow bowl of unidentifiable goo	5	good	
+-13	special thick toothsome tumbling gingerbread massacre	5	awesome	
+-14	tiny yummy It Came From Beyond Dessert	1	awesome	
 -15	bland vampire cake	4	decent	
 -52	bland jittery Soylent Red and Green	4	decent	
 -53	stale bouncing Disc-Shaped Nutrition Unit	4	decent	
--54	diet adequate Gingerborg Hive	1	good	
+-54	adequate diet Gingerborg Hive	1	good	
 -61	rotten Candy Cane Surprise	3	crappy	
 -62	normal cyan mirror Grimdrop Chow Mein	4	good	
--63	rotten big Grimgerbread House	5	crappy	
+-63	big rotten Grimgerbread House	5	crappy	
 -67	flavorless diet Caviar Carbonara	1	decent	
 -68	bland jittery Halibut Alfredo	3	decent	
 -69	snack-sized fancy adequate Red Herring Velvet Cake	2	good	
--73	moldy enchanted jittery CRIMBCO Reconstituted Gruel	3	crappy	
+-73	enchanted moldy jittery CRIMBCO Reconstituted Gruel	3	crappy	
 -74	normal big New and Improved CRIMBCO Reconstituted Gruel	5	good	
 -75	flavorless spinning CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	decent	
 -79	spoiled miniature ghostly Brussels Sprout Stir-Fry	2	crappy	
--80	half-sized rotten tumbling ghostly blinking Carrot, Cabbage, and Kale Pizza	2	crappy	
+-80	half-sized rotten tumbling blinking ghostly Carrot, Cabbage, and Kale Pizza	2	crappy	
 -81	adequate Turnip and Rutabaga Pie	4	good	
 -85	moldy Rainbow Spider Fun Roll	4	crappy	
 -86	gigantic rotten Vegas Volcano Lava Roll	6	crappy	
 -87	big bland maroon Crazy Dragon Shogun Buddha Roll	5	decent	
 -92	bland basic hot dog	3	decent	
 -93	yummy gigantic spinning savage macho dog	7	awesome	
--94	adequate snack-sized one with everything	2	good	
--95	yummy enchanted sly dog	3	awesome	
+-94	snack-sized adequate one with everything	2	good	
+-95	enchanted yummy sly dog	3	awesome	
 -96	tasty devil dog	3	awesome	
--97	stale immense chilly dog	9	decent	
+-97	immense stale chilly dog	9	decent	
 -98	decent shaking ghost dog	4	good	
 -99	miniature adequate junkyard dog	2	good	
 -100	bland enchanted wet dog	3	decent	
 -101	bland narrow sleeping dog	4	decent	
 -102	flavorless optimal dog	3	decent	
 -103	delicious video games hot dog	4	awesome	
--104	massive stale blinking Peppermint Nutrition Block	8	decent	
+-104	stale massive blinking Peppermint Nutrition Block	8	decent	
 -105	toothsome skewed Gingerbread Nutrition Block	4	awesome	
 -106	spoiled wobbly Cinnamon Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Disco_Bandit_Wallaby.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wallaby.txt
@@ -9,7 +9,7 @@
 9	jittery executive disco mask	0		Meat Drop: +40, Familiar Effect: "atk, cap 2"
 10	disco ball	0		
 11	blue stolen accordion	0		Song Duration: 5
-12	gray bouncing mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
+12	bouncing gray mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	vaporized ghostly moxie weed	1		
 15	compressed strongness elixir	1		Effect: "Bootyliciousness", Effect Duration: 30
 16	vaporized magicalness-in-a-can	1		
@@ -39,13 +39,13 @@
 40	casino pass	0		
 41	delicious practically non-alcoholic ice-cold Sir Schlitz	1	awesome	
 42	blinking hermit permit	0		
-43	upside-down blue worthless trinket	0		
+43	blue upside-down worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	wobbly figurine	0		
 47	snack-sized flavorless mirror hot buttered roll	2	decent	
 48	heart of rock and roll	0		
-49	stale fancy purple bowl of cottage cheese	3	decent	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 40
+49	fancy stale purple bowl of cottage cheese	3	decent	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 40
 50	Annie Oakley's Rock and Roll Legend	0		Critical Hit Percent: +20, Class: "Accordion Thief", Song Duration: 10
 51	spinning cyan avaricious Knob Goblin Uberpants	0		Meat Drop: +30, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -69,7 +69,7 @@
 70	bar skin	0		
 71	greasy stakes	0		Sleaze Spell Damage: +10
 72	blurry baleful barskin hat	0		Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 13"
-73	green bouncing barskin tent	0		
+73	bouncing green barskin tent	0		
 74	Temple map	0		
 75	sapling	0		
 76	olive blurry Spooky-Gro fertilizer	0		
@@ -101,11 +101,11 @@
 102	shrunken head	0		
 103	mirror nippy stylish staff	0		Moxie: +25, Cold Damage: +10
 104	scarecrow	0		
-105	moldy low-calorie fancy bowl of charms	1	crappy	Effect: "Snobby", Effect Duration: 25
+105	low-calorie moldy fancy bowl of charms	1	crappy	Effect: "Snobby", Effect Duration: 25
 106	ketchup	1	decent	
 107	catsup	1	good	
 108	stick	0		
-109	squat pulsating crossbow string	0		
+109	pulsating squat crossbow string	0		
 110	twirling wool basic meat staff	0		Cold Resistance: +1
 111	shaking smartaleck's basic meat crossbow	0		Moxie Percent: +30
 112	blurry family-friendly slick meatloaf helmet	0		Moxie: +10, Sleaze Resistance: +1, Familiar Effect: "1xBarrr, 1.5xFairy, cap 13"
@@ -129,14 +129,14 @@
 130	smartaleck's eyepatch	0		Moxie Percent: +30, Familiar Effect: "4xBarrr, cap 8"
 131	red frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
-133	bouncing maroon Certificate of Participation	0		
+133	maroon bouncing Certificate of Participation	0		
 134	yellow bitchin' meatcar	0		
 135	sweet rims	0		
 136	tumbling tires	0		
 137	dope wheels	0		
 138	huge ice-cold six-pack	0		
 139	valuable trinket	0		
-140	blurry huge narrow dingy planks	0		
+140	huge blurry narrow dingy planks	0		
 141	dingy dinghy	0		
 142	teal anticheese	0		
 143	cottage	0		
@@ -157,7 +157,7 @@
 158	mirror Gnollish pie tin	0		
 159	wad of dough	0		
 160	pie crust	0		
-161	miniature tasty spinning ghuol egg	2	awesome	
+161	tasty miniature spinning ghuol egg	2	awesome	
 162	stale ghuol egg quiche	3	decent	
 163	quilted skeleton bone	0		Damage Absorption: +40
 164	smart skull	0		
@@ -167,9 +167,9 @@
 168	medical-grade bone rattle	0		HP Regen Min: 7, HP Regen Max: 10
 169	blinking bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	miniature yummy fuchsia lihc eye pie	2	awesome	
+171	yummy miniature fuchsia lihc eye pie	2	awesome	
 172	gnoll lips	0		
-173	maroon narrow taco shell	0		
+173	narrow maroon taco shell	0		
 174	skewed Gnollish casserole dish	0		
 175	spoiled uncooked chorizo	3	crappy	
 176	disembodied brain	0		
@@ -199,7 +199,7 @@
 201	small normal cyan bat wing kabob	2	good	
 202	toothsome carob chunks	3	awesome	
 203	blurry herbs	0		
-204	tiny tasty carob chunk cookies	1	awesome	
+204	tasty tiny carob chunk cookies	1	awesome	
 205	wobbly secret blend of herbs and spices	0		
 206	piercing post	0		
 207	twirling hippy herbal tea	1	EPIC	
@@ -232,7 +232,7 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	Bigger Bugfinder Blade of James Dean of the sweet-tooth	0		Experience (Moxie): +3, Candy Drop: +100
 236	yellow Queue Du Coq cocktailcrafting kit	0		
-237	acceptable special spinning skewed bottle of gin	3	good	Effect: "Bananas!", Effect Duration: 35
+237	special acceptable skewed spinning bottle of gin	3	good	Effect: "Bananas!", Effect Duration: 35
 238	tolerable bottle of vodka	4	good	
 239	tumbling fuchsia Orcish baseball cap of the ox of the brute	0		Muscle: +20, Muscle Percent: +30, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	gray executive sharpshooter's Orcish cargo shorts	0		Critical Hit Percent: +10, Meat Drop: +40, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
@@ -242,33 +242,33 @@
 244	flavorless gigantic ghostly grapes	9	decent	
 245	tasty olive	3	awesome	
 246	special bland tomato	4	decent	Effect: "Stinking Cloud", Effect Duration: 50
-247	cyan squat fermenting powder	0		
-248	high-proof tolerable salty dog	7	good	
-249	watered-down delicious jittery bloody mary	2	awesome	
+247	squat cyan fermenting powder	0		
+248	tolerable high-proof salty dog	7	good	
+249	delicious watered-down jittery bloody mary	2	awesome	
 250	perfectly mixed mirror screwdriver	3	EPIC	
-251	high-proof perfectly mixed red martini	7	EPIC	
-252	artisanal boozy bloody beer	5	EPIC	
+251	perfectly mixed high-proof red martini	7	EPIC	
+252	boozy artisanal bloody beer	5	EPIC	
 253	bad shot of schnapps	3	decent	
 254	bad shot of grapefruit schnapps	3	decent	
 255	lousy fine wine	3	decent	
 256	hand-crafted shot of tomato schnapps	3	EPIC	
-257	distilled artisanal jittery extra-spicy bloody mary	5	EPIC	
+257	artisanal distilled jittery extra-spicy bloody mary	5	EPIC	
 258	dense meat stack	0		
 259	spinning snake skin	0		
 260	decent White Citadel fries	4	good	
-261	miniature rotten White Citadel burger	2	crappy	
+261	rotten miniature White Citadel burger	2	crappy	
 262	bland piece of wedding cake	3	decent	
 263	special decent chocolate chips	3	good	Effect: "Hair on Your Chest", Effect Duration: 30
-264	thick decent chocolate chip cookies	5	good	
+264	decent thick chocolate chip cookies	5	good	
 265	grievous satin pants	0		Weapon Damage Percent: +50, Familiar Effect: "atk, 2xPotato, cap 10"
-266	drinkable weak lightning	2	good	
+266	weak drinkable lightning	2	good	
 267	green mullet wig of the bloodbag	0		Maximum HP: +100, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	careful meat cowboy hat	0		Monster Level: -10, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	perfumed sword	0		Stench Resistance: +5
 270	picket fence	0		
 271	pickled huge skewed narrow barbell	1		Effect: "Inner Dog", Effect Duration: 45
 272	compressed maroon concentrated magicalness pill	1		
-273	boiled shaking purple spinning moxie weed	1		
+273	boiled purple shaking spinning moxie weed	1		
 274	upside-down Familiar-Gro&trade; Terrarium	0		
 275	blurry mosquito larva	0		
 276	leprechaun hatchling	0		
@@ -297,8 +297,8 @@
 299	alkaline pickle-flavored chewing gum	0		Effect: "Fever From the Flavor", Effect Duration: 18
 300	magnetized flattened jaba&ntilde;ero-flavored chewing gum	0		Effect: "Flambé-a-thon", Effect Duration: 65
 301	twirling flat dough	0		
-302	diet toothsome Knob sausage	1	awesome	
-303	delicious miniature Knob mushroom	2	awesome	
+302	toothsome diet Knob sausage	1	awesome	
+303	miniature delicious Knob mushroom	2	awesome	
 304	dry noodles	0		
 305	stiffened Knob Goblin harem pants	0		Damage Reduction: 1, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	nippy Knob Goblin harem veil	0		Cold Damage: +10, Familiar Effect: "5xLep, cap 2"
@@ -306,24 +306,24 @@
 308	careful Knob Goblin elite helm	0		Monster Level: -10, Familiar Effect: "2xFairy, cap 15"
 309	tumbling auspicious Knob Goblin elite pants	0		Item Drop: +10, Familiar Effect: "2xBarrr, cap 15"
 310	blurry Knob Goblin elite polearm of extreme caution	0		Monster Level: -25
-311	red mirror hill of beans	0		
+311	mirror red hill of beans	0		
 312	bouncing frosty Knob Goblin visor	0		Cold Spell Damage: +10, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	wobbly Crown of the Goblin King of wisdom	0		Mysticality: +15, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	decent lime green jittery bean burrito	4	good	
 315	rotten bean burrito	4	crappy	
-316	small delicious insanely bean burrito	2	awesome	
-317	snack-sized decent red bean burrito	2	good	
-318	fancy spoiled bean burrito	3	crappy	Effect: "Waxing", Effect Duration: 40
-319	rotten big insanely bean burrito	5	crappy	
+316	delicious small insanely bean burrito	2	awesome	
+317	decent snack-sized red bean burrito	2	good	
+318	spoiled fancy bean burrito	3	crappy	Effect: "Waxing", Effect Duration: 40
+319	big rotten insanely bean burrito	5	crappy	
 320	yummy bat haggis	3	awesome	
 321	normal menudo	3	good	
 322	flavorless goat cheese	3	decent	
 323	normal plain pizza	3	good	
-324	bite-sized toothsome sausage pizza	1	awesome	
+324	toothsome bite-sized sausage pizza	1	awesome	
 325	diet delicious goat cheese pizza	1	awesome	
 326	tiny moldy mushroom pizza	1	crappy	
 327	goat	0		
-328	practically non-alcoholic acceptable yellow squat bottle of whiskey	1	good	
+328	acceptable practically non-alcoholic yellow squat bottle of whiskey	1	good	
 329	gray horrifying goat beard	0		Spooky Damage: +25, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
 331	drinkable Canadian	3	good	
@@ -354,7 +354,7 @@
 356	upside-down foul-smelling snowboarder pants	0		Stench Damage: +10, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	decent gr8ps	3	good	
-359	decent diet special t8r tots	1	good	Effect: "Buzzard Breath", Effect Duration: 10
+359	decent special diet t8r tots	1	good	Effect: "Buzzard Breath", Effect Duration: 10
 360	jittery MacGyver's miner's helmet	0		Maximum MP: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	hardened miner's pants	0		Damage Reduction: 3, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	blurry beefcake's 7-Foot Dwarven mattock	0		Muscle: +25
@@ -406,7 +406,7 @@
 408	pirate skeleton	0		
 409	vial of patchouli oil	0		
 410	friendly sk8board	0		Familiar Weight: +3
-411	teal squat wobbly squat Jolly Roger charrrm	0		
+411	wobbly squat teal squat Jolly Roger charrrm	0		
 412	barrrnacle	0		
 413	Jolly Roger charrrm bracelet of Tarzan	0		Experience (Muscle): +3
 414	deadly crowbarrr	0		Weapon Damage: +5
@@ -414,7 +414,7 @@
 416	razor-sharp safarrri hat	0		Weapon Damage Percent: +25, Familiar Effect: "2xVolley, cap 22"
 417	oxidized henna tattoo	0		Effect: "Innately Wise", Effect Duration: 41
 418	extra-oxidized electrified dry Ferrigno's Elixir of Power	0		Effect: "Highland Sheen", Effect Duration: 48
-419	boiled huge ghostly serum of sarcasm	0		Effect: "Omphalotus Omnipresence", Effect Duration: 36
+419	boiled ghostly huge serum of sarcasm	0		Effect: "Omphalotus Omnipresence", Effect Duration: 36
 420	activated nitrogenated mirror tomato juice of powerful power	0		Effect: "Hennaliciousness", Effect Duration: 49
 421	nitrogenated philter of phorce	0		Effect: "Carrrsmic", Effect Duration: 11
 422	dry wet potion of potency	0		Effect: "Gonna Get You, Sucker", Effect Duration: 23
@@ -450,8 +450,8 @@
 452	disease	0		
 453	spinning blue sober pill	0		
 454	screwdriver	0		
-455	moldy special jumbo olive	3	crappy	Effect: "Work For Hours a Week", Effect Duration: 10
-456	triple-distilled artisanal green dry martini	10	EPIC	
+455	special moldy jumbo olive	3	crappy	Effect: "Work For Hours a Week", Effect Duration: 10
+456	artisanal triple-distilled green dry martini	10	EPIC	
 457	shaking ye olde golde frontes of Tarzan	0		Experience (Muscle): +3, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
@@ -483,22 +483,22 @@
 485	snakehead charrrm	0		
 486	occult Talisman o' Namsilat	0		Spell Damage Percent: +25, Single Equip
 487	olive ribald arrrgyle socks	0		Sleaze Damage: +10
-488	green shaking guitar pick	0		
+488	shaking green guitar pick	0		
 489	drab sonata	0		
 490	clever mesh cap of horror	0		Maximum MP: +20, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 41"
 491	squat enormous belt buckle	0		
 492	Oprah's dangerous chaps	0		Weapon Damage: +10, Maximum MP Percent: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	ketchup hound	0		
 494	tumbling batblade of temperance	0		Sleaze Resistance: +5
-495	mirror jittery catgut	0		
+495	jittery mirror catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	big rotten fancy papaya	5	crappy	Effect: "It Didn't Kill You", Effect Duration: 50
+498	rotten fancy big papaya	5	crappy	Effect: "It Didn't Kill You", Effect Duration: 50
 499	veiny experienced denim axe	0		Experience: +2, Maximum HP: +10
 500	Elf Farm Raffle ticket	0		
-501	jumbo spoiled Elfin shortbread	5	crappy	
+501	spoiled jumbo Elfin shortbread	5	crappy	
 502	pagoda plans	0		
-503	low-calorie toothsome skewed tumbling skewered cat appendix	1	awesome	
+503	toothsome low-calorie skewed tumbling skewered cat appendix	1	awesome	
 504	evil arches	0		
 505	bouncing wobbly gnatwing earring of Tarzan of the detective	0		Experience (Muscle): +3, Item Drop: +20
 506	massive decent enchanted Hell broth	6	good	Effect: "Ooh, Sweet!", Effect Duration: 20
@@ -509,7 +509,7 @@
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	adequate Boris's key lime pie	3	good	
-514	rotten snack-sized Jarlsberg's key lime pie	2	crappy	
+514	snack-sized rotten Jarlsberg's key lime pie	2	crappy	
 515	special rotten blurry Sneaky Pete's key lime pie	3	crappy	Effect: "Moon'd", Effect Duration: 45
 516	Hey Deze map	0		
 517	mansplainer's bejeweled accordion strap	0		Monster Level: +15, Class: "Accordion Thief"
@@ -528,7 +528,7 @@
 530	oxidized irradiated spray paint	0		Effect: "[800]Chocolate Reign", Effect Duration: 50
 531	Temple Grandin's special sauce glove	0		Familiar Weight: +7, Class: "Sauceror", Single Equip
 532	spinning Temple Grandin's ladle of mystery	0		Familiar Weight: +7, Class: "Sauceror"
-533	spinning squat Gnollish toolbox	0		
+533	squat spinning Gnollish toolbox	0		
 534	abridged dictionary	0		
 535	spinning bridge	0		
 536	shaking dictionary	0		
@@ -555,7 +555,7 @@
 557	practically non-alcoholic mediocre whiskey and cola	1	decent	
 558	decent papaya taco	3	good	
 559	twirling razor-sharp can lid	0		
-560	fancy small spoiled stalk of asparagus	2	crappy	Effect: "Disco State of Mind", Effect Duration: 50
+560	fancy spoiled small stalk of asparagus	2	crappy	Effect: "Disco State of Mind", Effect Duration: 50
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -572,23 +572,23 @@
 574	spoiled special noodles	4	crappy	Effect: "Blessing of the Hot Linguine", Effect Duration: 50
 575	delicious painful penne pasta	4	awesome	
 576	low-calorie tasty ravioli della hippy	1	awesome	
-577	bite-sized flavorless enchanted blurry pr0n m4nic0tti	1	decent	Effect: "Full of Wist", Effect Duration: 50
+577	enchanted flavorless bite-sized blurry pr0n m4nic0tti	1	decent	Effect: "Full of Wist", Effect Duration: 50
 578	stale Hell ramen	3	decent	
-579	flavorless miniature boring spaghetti	2	decent	
+579	miniature flavorless boring spaghetti	2	decent	
 580	sauce of the ages	0		
 581	narrow schmancy cheese sauce	0		
 582	yellow Himalayan Hidalgo sauce	0		
 583	flavorless fettucini Inconnu	4	decent	
 584	normal wobbly spaghetti with Skullheads	3	good	
-585	miniature stale gnocchetti di Nietzsche	2	decent	
+585	stale miniature gnocchetti di Nietzsche	2	decent	
 586	up-at-dawn aromatic ridiculously huge sword	0		Stench Resistance: +1, Adventures: +5
 587	corrupted super-spiky hair gel	0		Effect: "Arse-a'fire", Effect Duration: 18
 588	spinning soft echo eyedrop antidote	0		
-589	delicious immense red cocoa eggshell fragment	7	awesome	
+589	immense delicious red cocoa eggshell fragment	7	awesome	
 590	rotten ghostly cocoa eggshell fragment	4	crappy	
 591	narrow cocoa egg	0		
 592	bouncing house	0		
-593	cyan twirling phonics down	0		
+593	twirling cyan phonics down	0		
 594	boxer's amulet of extreme plot significance	0		Muscle Percent: +10
 595	scroll of drastic healing	0		
 596	energetic titanium assault umbrella	0		Maximum MP Percent: +20
@@ -609,11 +609,11 @@
 611	D	0		
 612	original G	0		
 613	plot hole	0		
-614	electrified blurry bouncing probability potion	0		Effect: "Elbow Sauce", Effect Duration: 23
+614	electrified bouncing blurry probability potion	0		Effect: "Elbow Sauce", Effect Duration: 23
 615	chaos butterfly	0		
 616	furry fur	0		
 617	super-moist non-unsweetened Angry Farmer candy	0		Effect: "Grumpy and Ornery", Effect Duration: 44
-618	vacuum-sealed mirror yellow Mick's IcyVapoHotness Rub	0		Effect: "Prelude of Precision", Effect Duration: 47
+618	vacuum-sealed yellow mirror Mick's IcyVapoHotness Rub	0		Effect: "Prelude of Precision", Effect Duration: 47
 619	upside-down needle of Leguizamo	0		Monster Level: +20
 620	dry thin candle	0		Effect: "Magically Fingered", Effect Duration: 41
 621	Warm Subject gift certificate	0		
@@ -631,7 +631,7 @@
 633	ghostly shaking healthy wolf mask of the blizzard	0		Maximum HP Percent: +20, Cold Spell Damage: +25, Familiar Effect: "1xBarrr, HP regen, cap 37"
 634	fuchsia cool whip	0		
 635	reassuring paper umbrella	0		Spooky Resistance: +1
-636	cyan blurry meat globe	0		
+636	blurry cyan meat globe	0		
 637	toaster	0		
 638	ghostly asshat of the dark arts of the empath	0		Spell Damage Percent: +100, Familiar Weight: +5, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	moldy snack-sized abominable snowcone	2	crappy	
@@ -641,7 +641,7 @@
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	delicious thick fruitcake	5	awesome	
+646	thick delicious fruitcake	5	awesome	
 647	red present	0		Last Available: "2004-11"
 648	pulsating censurious Crimbo sword	0		Sleaze Resistance: +3, Last Available: "2004-10"
 649	tumbling Jack Frost's Crimbo hat	0		Cold Spell Damage: +50, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
@@ -664,22 +664,22 @@
 666	mansplainer's crafty steaming evil of the cougar	0		Moxie: +20, Maximum MP: +10, Monster Level: +15
 667	spinning castle map	0		
 668	wobbly frosty spiked femur	0		Cold Spell Damage: +10
-669	snack-sized stale red ghuol guolash	2	decent	
+669	stale snack-sized red ghuol guolash	2	decent	
 670	deadly lihc face	0		Weapon Damage: +5, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	blinking lard-coated veiny grave robbing shovel	0		Maximum HP: +10, Sleaze Spell Damage: +25
 672	decent cranberries	4	good	
 673	mediocre practically non-alcoholic bouncing vodka and cranberry	1	decent	
-674	acceptable practically non-alcoholic whiskey	1	good	
+674	practically non-alcoholic acceptable whiskey	1	good	
 675	yellow skull of the Bonerdagon of the cheetah	0		Initiative: +60
 676	dragonbone belt buckle	0		
 677	Lo Pan's badass belt	0		Spell Critical Percent: +30
 678	chest of the Bonerdagon	0		
-679	drinkable practically non-alcoholic roll in the hay	1	good	
+679	practically non-alcoholic drinkable roll in the hay	1	good	
 680	distilled hand-crafted slap and tickle	5	EPIC	
 681	perfectly mixed bouncing slip 'n' slide	4	EPIC	
 682	smooth mirror a sump'm sump'm	4	awesome	
 683	hand-crafted horizontal tango	4	EPIC	
-684	lousy irresponsibly strong pink pony	9	decent	
+684	irresponsibly strong lousy pink pony	9	decent	
 685	miser's lard-coated sharpshooter's Mr. Shirt	0		Critical Hit Percent: +10, Sleaze Spell Damage: +25, Meat Drop: +10
 686	hale knuckles	0		Maximum HP: +20
 687	frozen blood of the Wereseal	0		Effect: "Extra Backbone", Effect Duration: 33
@@ -716,8 +716,8 @@
 720	up-at-dawn porquoise necklace of the bloodbag	0		Maximum HP: +100, Adventures: +5, Single Equip
 721	quilted Newton's porquoise bracelet	0		Experience (Mysticality): +3, Damage Absorption: +40
 722	asbestos-lined clever porquoise ring of the cougar	0		Moxie: +20, Maximum MP: +20, Hot Resistance: +5, Single Equip
-723	decent fancy ghostly Knoll mushroom	3	good	Effect: "Tremella Tremens", Effect Duration: 10
-724	moldy super-sized blurry mushroom	5	crappy	
+723	fancy decent ghostly Knoll mushroom	3	good	Effect: "Tremella Tremens", Effect Duration: 10
+724	super-sized moldy blurry mushroom	5	crappy	
 725	one million meat pancakes	0		
 726	lightning-fast huge mirror shard	0		Initiative: +40
 727	hedge maze puzzle	0		
@@ -729,7 +729,7 @@
 733	hosed fishbowl	0		
 734	MacGyver's quilted Fonzie's makeshift SCUBA gear	0		Experience (Moxie): +1, Damage Absorption: +40, Maximum MP: +100, Adventure Underwater
 735	easter egg balloon of the storm	0		Maximum MP Percent: +40
-736	blinking teal stone tablet (Sinister Strumming)	0		
+736	teal blinking stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
 738	stone tablet (Really Evil Rhythm)	0		
 739	tambourine bells	0		
@@ -739,12 +739,12 @@
 743	normal miniature narrow mushroom	2	good	
 744	tarnished deionized hair spray	0		Effect: "Smoky Third Eye", Effect Duration: 13
 746	stat script	0		
-747	squat purple Knob Goblin firecracker	0		
+747	purple squat Knob Goblin firecracker	0		
 748	twirling gourd potion	0		
 749	normal warm mushroom	4	good	
 750	tasty mushroom quesadilla	3	awesome	
 751	huge spoiled huge cool mushroom	6	crappy	
-752	fancy snack-sized decent cool mushroom casserole	2	good	Effect: "Sappy Blood", Effect Duration: 40
+752	snack-sized fancy decent cool mushroom casserole	2	good	Effect: "Sappy Blood", Effect Duration: 40
 753	rotten pointy mushroom	3	crappy	
 754	stale diet squat cream of pointy mushroom soup	1	decent	
 755	yummy mushroom	3	awesome	
@@ -754,9 +754,9 @@
 759	maroon dill	0		
 760	red vinegar	0		
 761	brine	0		
-762	perfectly mixed special high-proof especially salty dog	8	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 10
+762	perfectly mixed high-proof special especially salty dog	8	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 10
 763	mirror ghostly pickling solution	0		
-764	thick normal pulsating spectral pickle	5	good	
+764	normal thick pulsating spectral pickle	5	good	
 765	briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	modified corrupted boiled shaking cologne of contempt	0		Effect: "Cold, Dead Hands", Effect Duration: 45
@@ -782,15 +782,15 @@
 787	lousy bottle of rum	3	decent	
 788	weak artisanal twirling strawberry daiquiri	2	EPIC	
 789	drinkable practically non-alcoholic rum and cola	1	good	
-790	watered-down hand-crafted teal grog	2	EPIC	
+790	hand-crafted watered-down teal grog	2	EPIC	
 791	shellacked Mafia bow tie of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Last Available: "2004-10"
 792	blue upside-down bouncing nippy Golden Mr. Accessory	0		Cold Damage: +10, Softcore Only
 793	pressed oil of stability	0		Effect: "Whole Latte Love", Effect Duration: 13
 794	chilled super-moist twirling fuchsia oil of slipperiness	0		Effect: "Charrrming", Effect Duration: 34
-795	watered-down smooth Acque Luride Grezze Cabernet	2	awesome	Last Available: "2004-10"
+795	smooth watered-down Acque Luride Grezze Cabernet	2	awesome	Last Available: "2004-10"
 796	sharpshooter's curative studded cement shoes	0		Damage Absorption: +80, Critical Hit Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10"
 797	high-proof hand-crafted rockin' wagon	8	EPIC	
-798	artisanal triple-distilled skewed ocean motion	7	EPIC	
+798	triple-distilled artisanal skewed ocean motion	7	EPIC	
 799	triple-distilled mediocre fuzzbump	10	decent	
 800	moldy pulsating poutine	3	crappy	
 801	decent narrow Knob stir-fry	3	good	
@@ -799,14 +799,14 @@
 806	moldy asparagus stir-fry	4	crappy	
 807	spoiled bouncing shaking olive stir-fry	3	crappy	
 808	stale Knob sausage stir-fry	4	decent	
-809	super-sized decent mirror bat wing stir-fry	5	good	
-810	snack-sized rotten rat appendix stir-fry	2	crappy	
+809	decent super-sized mirror bat wing stir-fry	5	good	
+810	rotten snack-sized rat appendix stir-fry	2	crappy	
 811	spoiled bouncing tofu stir-fry	4	crappy	
 812	bland pr0n stir-fry	3	decent	
 813	flavorless Knob shells	4	decent	
 814	immense moldy gray b&auml;tzle	6	crappy	
 815	bland ratini	4	decent	
-816	yummy thick Knob stroganoff	5	awesome	
+816	thick yummy Knob stroganoff	5	awesome	
 817	flavorless menudo ravioli	4	decent	
 818	bouncing plus sign	0		
 819	jittery shaking milky potion	0		
@@ -829,12 +829,12 @@
 836	bland mind flayer corpse	3	decent	
 837	lousy wobbly Uovo Marcio Shiraz	3	decent	Last Available: "2004-10"
 838	lime green pulsating Lo Pan's sinister Mafia stogie	0		Spell Damage: +10, Spell Critical Percent: +30, Last Available: "2004-10"
-839	artisanal practically non-alcoholic Maiali Sifilitici Pinot Noir	1	super ultra mega turbo EPIC	Last Available: "2004-10"
+839	practically non-alcoholic artisanal Maiali Sifilitici Pinot Noir	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 840	teal avaricious scandalous Mafia violin case	0		Sleaze Damage: +5, Meat Drop: +30, Last Available: "2004-10"
-841	irresponsibly strong drinkable purple tomato daiquiri	10	good	
+841	drinkable irresponsibly strong purple tomato daiquiri	10	good	
 842	lousy beertini	3	decent	
 843	perfectly mixed salty slug	3	EPIC	
-844	aged weak papaya slung	2	awesome	
+844	weak aged papaya slung	2	awesome	
 845	chilly MAHI fez	0		Cold Damage: +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	twirling hypodermic needle	0		Familiar Weight: +5
@@ -854,10 +854,10 @@
 862	blurry upside-down magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
 864	skewed stinger	0		Familiar Weight: +5
-865	lime green pulsating lead necklace	0		Familiar Weight: +3
+865	pulsating lime green lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	warmed improved purple pine tar	0		Effect: "Sugar High", Effect Duration: 20
-869	bouncing blinking forest tears	0		
+869	blinking bouncing forest tears	0		
 870	fetus-smashing club of the sewer	0		Stench Damage: +25
 871	red meatcar model	0		Familiar Weight: +5
 872	tumbling Time Juice	0		Last Available: "2004-01"
@@ -878,10 +878,10 @@
 887	blinking leaf	0		
 888	jittery maple leaf	0		
 889	blinking maroon personal trainer's balaclava	0		Experience Percent (Muscle): +10, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	flavorless squat gray balaclava baklava	4	decent	
+890	flavorless gray squat balaclava baklava	4	decent	
 891	stiffened Warehouse 23 bling	0		Damage Reduction: 1
 892	cyan foul-smelling flame-wreathed Van der Graaf bugbear-smiting sword	0		Hot Spell Damage: +10, Stench Damage: +10, MP Regen Min: 5, MP Regen Max: 7
-893	special acceptable lumbering jack	3	good	Effect: "Fancy Feasted", Effect Duration: 50
+893	acceptable special lumbering jack	3	good	Effect: "Fancy Feasted", Effect Duration: 50
 894	ghostly Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	Lo Pan's Ms. Accessory	0		Spell Critical Percent: +30, Softcore Only
 896	reassuring Mr. Accessory Jr. of the cougar	0		Moxie: +20, Spooky Resistance: +1, Softcore Only
@@ -891,15 +891,15 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	weak lousy spinning Spasmi Dolorosi Del Rene Champagne	2	decent	Last Available: "2004-10"
+903	lousy weak spinning Spasmi Dolorosi Del Rene Champagne	2	decent	Last Available: "2004-10"
 904	gray vibrating wholesome school Mafia knickerbockers of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Maximum MP Percent: +10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	modified Yummy Tummy bean	0		Effect: "Mutated", Effect Duration: 13
 906	adjusted ionized double-enhanced bouncing Rock Pops	0		Effect: "Mint-Condition Breath", Effect Duration: 52
-907	altered pulsating olive Mr. Mediocrebar	0		Effect: "Saucefingers", Effect Duration: 65
+907	altered olive pulsating Mr. Mediocrebar	0		Effect: "Saucefingers", Effect Duration: 65
 908	warmed triple-activated Cold Hots candy	0		Effect: "Disco Inferno", Effect Duration: 13
 909	cold-filtered warmed Wint-O-Fresh mint	0		Effect: "Spooky Hands", Effect Duration: 48
 910	spoiled dwarf bread	4	crappy	
-911	alkaline magnetized huge maroon huge Senior Mints	0		Effect: "Strength of Ten Ettins", Effect Duration: 22
+911	alkaline magnetized huge huge maroon Senior Mints	0		Effect: "Strength of Ten Ettins", Effect Duration: 22
 912	ionized unsweetened pixellated candy heart	0		Effect: "Savage Beast Inside", Effect Duration: 39
 913	quadruple-concentrated galvanized narrow kobold	0		Effect: "Fishily Speeding", Effect Duration: 69
 914	bouncing hand turkey outline	0		Free Pull, Last Available: "2004-11"
@@ -915,12 +915,12 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	denatured bouncing Hawking's Elixir of Brilliance	0		Effect: "Greasy Peasy", Effect Duration: 26
-927	bad weak bouncing twirling Ferita Del Petto Zinfandel	2	decent	Last Available: "2006-12"
+927	weak bad bouncing twirling Ferita Del Petto Zinfandel	2	decent	Last Available: "2006-12"
 928	yellow veiny fuzzy bracelets	0		Maximum HP: +10
 929	tumbling skewed strapping arse-shooting crossbow	0		Muscle: +5
 931	perfectly mixed skewed spiced rum	4	EPIC	
 932	mediocre eggnog	3	decent	
-933	adequate jumbo candy cane	5	good	
+933	jumbo adequate candy cane	5	good	
 934	stale small gingerbread bugbear	2	decent	
 935	dog trainer's imitation nice watch	0		Experience (familiar): +1, Single Equip, Last Available: "2004-12"
 936	red Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -936,8 +936,8 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	smooth special martini	3	awesome	Effect: "French Bronilla Brogueishness", Effect Duration: 15, Last Available: "2004-12"
-949	weak bad grogtini	2	decent	Last Available: "2004-12"
-950	mediocre practically non-alcoholic cherry bomb	1	decent	Last Available: "2004-12"
+949	bad weak grogtini	2	decent	Last Available: "2004-12"
+950	practically non-alcoholic mediocre cherry bomb	1	decent	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	occult hockey mask of the overflowing toilet	0		Spell Damage Percent: +25, Stench Spell Damage: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
@@ -983,33 +983,33 @@
 993	skewed dog trainer's deadly educational plastic Sneaky Pete	0		Experience: +1, Weapon Damage: +5, Experience (familiar): +1
 994	skewed fuchsia educational plastic Susie	0		Experience: +1
 995	bland Lucky Surprise Egg	4	decent	
-998	jittery lime green maiden wig	0		Familiar Effect: "2xPotato, cap 8"
+998	lime green jittery maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	maid head	0		
 1000	Meat maid	0		
 1002	Xlyinia's notebook of bravery	0		Spooky Resistance: +5
 1003	soda water	0		
-1004	weak artisanal bottle of tequila	2	EPIC	
-1005	bad boozy squat gray narrow boxed wine	5	decent	
-1006	fancy decent thick cherry	5	good	Effect: "Deadly Flashing Blade", Effect Duration: 25
+1004	artisanal weak bottle of tequila	2	EPIC	
+1005	bad boozy gray narrow squat boxed wine	5	decent	
+1006	fancy thick decent cherry	5	good	Effect: "Deadly Flashing Blade", Effect Duration: 25
 1007	twirling Oprah's coconut shell	0		Maximum MP Percent: +50, Familiar Effect: "1xFairy, cap 7"
 1008	yellow blurry nippy ice cubes	0		Cold Damage: +10
 1009	lousy vodka martini	4	decent	
 1010	bad irresponsibly strong whiskey and soda	6	decent	
-1011	acceptable fancy extra-dry spinning shaking monkey wrench	5	good	Effect: "Chalked-Up Teeth", Effect Duration: 5
-1012	weak smooth tequila sunrise	2	awesome	
+1011	acceptable extra-dry fancy spinning shaking monkey wrench	5	good	Effect: "Chalked-Up Teeth", Effect Duration: 5
+1012	smooth weak tequila sunrise	2	awesome	
 1013	mediocre blinking margarita	4	decent	
 1014	artisanal strawberry wine	3	EPIC	
 1015	drinkable wine spritzer	3	good	
-1016	acceptable tumbling cyan perpendicular hula	3	good	
+1016	acceptable cyan tumbling perpendicular hula	3	good	
 1017	aged strong ducha de oro	5	awesome	
 1018	perfectly mixed squat calle de miel	4	EPIC	
-1019	fortified hand-crafted dry vodka martini	5	EPIC	
+1019	hand-crafted fortified dry vodka martini	5	EPIC	
 1020	high-proof lousy old-fashioned	8	decent	
-1021	artisanal irresponsibly strong twirling tequila with training wheels	10	EPIC	
-1022	practically non-alcoholic hand-crafted sangria	1	super EPIC	
+1021	irresponsibly strong artisanal twirling tequila with training wheels	10	EPIC	
+1022	hand-crafted practically non-alcoholic sangria	1	super EPIC	
 1023	perfectly mixed lime green vesper	3	super ultra EPIC	Last Available: "2004-12"
-1024	drinkable weak bodyslam	2	good	Last Available: "2004-12"
-1025	artisanal watered-down fancy sangria del diablo	2	super ultra mega turbo EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2004-12"
+1024	weak drinkable bodyslam	2	good	Last Available: "2004-12"
+1025	watered-down fancy artisanal sangria del diablo	2	super ultra mega turbo EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1022,7 +1022,7 @@
 1035	ghostly chilly penguin skin buckler	0		Cold Damage: +5, Damage Reduction: 5
 1036	Da Vinci's yakskin buckler	0		Experience (Mysticality): +5, Damage Reduction: 5
 1037	green baleful gnauga hide buckler	0		Spell Damage: +25, Damage Reduction: 5
-1038	corrupted jittery cyan pulsating Connery's Elixir of Audacity	0		Effect: "Helping Comes Second", Effect Duration: 67
+1038	corrupted cyan jittery pulsating Connery's Elixir of Audacity	0		Effect: "Helping Comes Second", Effect Duration: 67
 1040	tumbling Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	mediocre beer	4	decent	
 1042	mirror supercool string of beads	0		Moxie Percent: +20
@@ -1030,7 +1030,7 @@
 1044	shellacked string of beads	0		Damage Reduction: 7
 1045	Sherlock's plastic bottle opener	0		Item Drop: +25
 1046	inspector's razor-sharp traffic cone	0		Weapon Damage Percent: +25, Item Drop: +15, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	practically non-alcoholic lousy N. O. Beer	1	decent	
+1047	lousy practically non-alcoholic N. O. Beer	1	decent	
 1048	dried teal oyster egg	1		Effect: "Wet Willied", Effect Duration: 15
 1049	dehydrated oyster egg	1		
 1050	compressed oyster egg	1		
@@ -1049,7 +1049,7 @@
 1063	twirling mauve plastic oyster egg	0		
 1064	diluted blinking oyster egg	1		
 1065	diluted oyster egg	1		
-1066	diluted blue bouncing oyster egg	1		
+1066	diluted bouncing blue oyster egg	1		
 1067	plastic oyster egg	0		
 1068	modified oyster egg	1		
 1069	mixed oyster egg	1		
@@ -1059,7 +1059,7 @@
 1073	diluted cyan off-white oyster egg	1		Effect: "Hammertime", Effect Duration: 5
 1074	distilled off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	dehydrated skewed fuchsia oyster egg	1		Effect: "Artificially Sweet", Effect Duration: 25
+1076	dehydrated fuchsia skewed oyster egg	1		Effect: "Artificially Sweet", Effect Duration: 25
 1077	vaporized purple oyster egg	1		
 1078	powdered narrow oyster egg	1		Effect: "Thanksgot", Effect Duration: 45
 1079	spinning plastic oyster egg	0		
@@ -1121,22 +1121,22 @@
 1135	ionized quantum eyeliner	0		Effect: "Insulated Trousers", Effect Duration: 11
 1136	triple-colloidal liquefied huge lipstick	0		Effect: "items.enh", Effect Duration: 14
 1137	occult bicycle chain of the bloodbag	0		Spell Damage Percent: +25, Maximum HP: +100
-1138	blinking squat mushroom fermenting solution	0		
+1138	squat blinking mushroom fermenting solution	0		
 1139	bad mushroom wine	4	decent	
-1140	practically non-alcoholic tolerable icy mushroom wine	1	good	
+1140	tolerable practically non-alcoholic icy mushroom wine	1	good	
 1141	bad mushroom wine	3	decent	
 1142	hand-crafted pointy mushroom wine	3	EPIC	
 1143	drinkable flat mushroom wine	3	good	
-1144	fortified enchanted acceptable green upside-down cool mushroom wine	5	good	Effect: "Meadulla Oblongota", Effect Duration: 50
-1145	practically non-alcoholic acceptable tumbling squat teal knob mushroom wine	1	good	
-1146	practically non-alcoholic enchanted perfectly mixed huge knoll mushroom wine	1	super ultra mega turbo EPIC	Effect: "Spookypants", Effect Duration: 30
-1147	practically non-alcoholic special delicious mushroom wine	1	awesome	Effect: "Blackberry Politeness", Effect Duration: 35
+1144	fortified enchanted acceptable upside-down green cool mushroom wine	5	good	Effect: "Meadulla Oblongota", Effect Duration: 50
+1145	practically non-alcoholic acceptable tumbling teal squat knob mushroom wine	1	good	
+1146	enchanted practically non-alcoholic perfectly mixed huge knoll mushroom wine	1	super ultra mega turbo EPIC	Effect: "Spookypants", Effect Duration: 30
+1147	special delicious practically non-alcoholic mushroom wine	1	awesome	Effect: "Blackberry Politeness", Effect Duration: 35
 1148	hand-crafted shot of flower schnapps	3	EPIC	
 1149	toothsome flower petal pie	4	awesome	
 1150	perfectly mixed irresponsibly strong bottle of single-barrel whiskey	10	EPIC	
 1151	squat pulsating double-paned discarded plastic fork of James Dean	0		Experience (Moxie): +3, Cold Resistance: +5
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	adequate low-calorie Retenez L'Herbe Pat&eacute;	1	good	
+1153	low-calorie adequate Retenez L'Herbe Pat&eacute;	1	good	
 1154	distilled Breathetastic&trade; Premium Canned Air	1	EPIC	
 1155	letter from King Ralph XI	0		
 1157	frightening wholeberd	0		Spooky Damage: +5
@@ -1154,7 +1154,7 @@
 1169	shaking exactly-three-shaped box	0		
 1170	mirror chocolate box	0		
 1171	coffin	0		
-1172	wobbly yellow asbestos box	0		
+1172	yellow wobbly asbestos box	0		
 1173	narrow linoleum box	0		
 1174	chrome box	0		
 1175	tumbling cryptic puzzle box	0		
@@ -1184,15 +1184,15 @@
 1199	wobbly bugbear	0		
 1200	flavorless mugcake	3	decent	
 1201	decent urinal cake	3	good	
-1202	half-sized flavorless jittery ghostly Happy Birthday, Claude! cake	2	decent	
-1203	spoiled bite-sized bouncing personalized birthday cake	1	crappy	
+1202	half-sized flavorless ghostly jittery Happy Birthday, Claude! cake	2	decent	
+1203	bite-sized spoiled bouncing personalized birthday cake	1	crappy	
 1204	decent purple three-tiered wedding cake	4	good	
-1205	miniature spoiled special tumbling babycakes	2	crappy	Effect: "Healthy Blue Glow", Effect Duration: 50
+1205	spoiled special miniature tumbling babycakes	2	crappy	Effect: "Healthy Blue Glow", Effect Duration: 50
 1206	tiny flavorless velvet cake	1	decent	
 1207	bland mirror congratulatory cake	3	decent	
 1208	low-calorie bland blurry angel-food cake	1	decent	
-1209	adequate miniature spinning devil's-food cake	2	good	
-1210	bland enchanted half-sized jittery birthday party jellybean cheesecake	2	decent	Effect: "Sweet Taste", Effect Duration: 50
+1209	miniature adequate spinning devil's-food cake	2	good	
+1210	half-sized bland enchanted jittery birthday party jellybean cheesecake	2	decent	Effect: "Sweet Taste", Effect Duration: 50
 1211	balloon	0		
 1212	bouncing balloon	0		
 1213	heart-shaped balloon	0		
@@ -1220,7 +1220,7 @@
 1236	ghostly smelly hockey stick of furious angry rage of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10
 1237	tapped lotus	0		
 1238	lime green glowsticks	0		Familiar Weight: +5
-1239	green shaking skewed iced-out bling	0		Familiar Weight: +5
+1239	skewed shaking green iced-out bling	0		Familiar Weight: +5
 1240	tumbling limburger biker boots	0		Familiar Weight: +5
 1241	bouncing carton of clove cigarettes	0		Familiar Weight: +5
 1242	deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
@@ -1238,16 +1238,16 @@
 1254	stale pulsating jumping bean burrito	3	decent	
 1255	moldy small jumping bean burrito	2	crappy	
 1256	decent insanely jumping bean burrito	3	good	
-1257	diet spoiled skewed tumbling rat scrapple	1	crappy	
+1257	spoiled diet tumbling skewed rat scrapple	1	crappy	
 1258	pail of pretentious paint	0		
 1259	reassuring sharpshooter's traffic cone	0		Critical Hit Percent: +10, Spooky Resistance: +1, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	altered maroon pulsating skewed Hatorade	1		
+1261	altered maroon skewed pulsating Hatorade	1		
 1262	grievous sage off-hand balloon of horror	0		Mysticality Percent: +10, Weapon Damage Percent: +50, Spooky Spell Damage: +25
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	blinking nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	flavorless bite-sized gloomy mushroom	1	decent	
+1266	bite-sized flavorless gloomy mushroom	1	decent	
 1267	wobbly dead mimic	0		
 1268	pine wand	0		
 1269	ebony wand	0		
@@ -1288,7 +1288,7 @@
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
 1306	Oprah's cool traffic cone	0		Moxie: +5, Maximum MP Percent: +50, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
-1307	skewed bouncing calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
+1307	bouncing skewed calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	mirror attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
@@ -1315,7 +1315,7 @@
 1331	beefy Cloaca-Cola helmet	0		Muscle: +10, Familiar Effect: "3xFairy, cap 7"
 1332	blurry Cloaca-Cola knapsack	0		
 1333	Dyspepsi-Cola knapsack	0		
-1334	pulsating jittery purple Cloaca-Cola	0		
+1334	pulsating purple jittery Cloaca-Cola	0		
 1335	pulsating green Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
 1338	Dyspepsi-Cola d-rations	0		
@@ -1327,12 +1327,12 @@
 1344	activated altered magnetized Gummi-Gnauga	0		Effect: "Magically Fingered", Effect Duration: 56
 1345	frozen moist boiled Now and Earlier	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 37, Last Available: "2020-09"
 1346	dry quadruple-irradiated Sugar Cog	0		Effect: "Squatting and Thrusting", Effect Duration: 19
-1347	skewed fuchsia twirling loaded serum blowgun	0		Last Available: "2005-11"
+1347	twirling fuchsia skewed loaded serum blowgun	0		Last Available: "2005-11"
 1348	empty blowgun	0		Last Available: "2005-11"
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	pinky ring of horror	0		Spooky Spell Damage: +25, Single Equip
-1352	smooth weak redrum	2	awesome	
+1352	weak smooth redrum	2	awesome	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	toothsome mirror blurry bowl of oriole's nest soup	4	awesome	
@@ -1347,8 +1347,8 @@
 1364	purple rhesus monkey	0		Familiar Weight: +5
 1365	miniature bland tofurkey leg	2	decent	
 1366	moldy tofurkey gravy	4	crappy	
-1367	super-sized tasty herbal stuffing	5	awesome	
-1368	tasty immense can-shaped gelatinous cranberry sauce	10	awesome	
+1367	tasty super-sized herbal stuffing	5	awesome	
+1368	immense tasty can-shaped gelatinous cranberry sauce	10	awesome	
 1369	decent snack-sized yams	2	good	
 1370	bouncing rhinestone cowboy shirt of Tarzan	0		Experience (Muscle): +3
 1371	slick gingham blouse	0		Moxie: +10
@@ -1394,7 +1394,7 @@
 1412	adjusted nitrogenated snowcone	0		Effect: "Busy Bein' Delicious", Effect Duration: 13, Last Available: "2006-01"
 1413	cold-filtered oxidized snowcone	0		Effect: "The Living Hitpoints", Effect Duration: 19, Last Available: "2006-01"
 1414	magnetized double-concentrated snowcone	0		Effect: "Cold Hard Skin", Effect Duration: 64, Last Available: "2006-01"
-1415	concentrated adjusted chilled upside-down blue snowcone	0		Effect: "Elron's Explosive Etude", Effect Duration: 64, Last Available: "2006-01"
+1415	concentrated adjusted chilled blue upside-down snowcone	0		Effect: "Elron's Explosive Etude", Effect Duration: 64, Last Available: "2006-01"
 1416	improved snowcone	0		Effect: "Trivia Master", Effect Duration: 56, Last Available: "2006-01"
 1417	triple-altered diffused ionized snowcone	0		Effect: "Fortunate Resolve", Effect Duration: 40, Last Available: "2006-01"
 1418	pulsating Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
@@ -1407,7 +1407,7 @@
 1425	blinking ice baby of the businessman	0		Meat Drop: +50, Softcore Only, Last Available: "2006-02"
 1426	Herculean ice pick	0		Experience (Muscle): +1, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	yellow Jeselnik's Jack Frost's ice skates	0		Cold Spell Damage: +50, Sleaze Damage: +25, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	decent huge grue egg omelette	7	good	
+1428	huge decent grue egg omelette	7	good	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1419,7 +1419,7 @@
 1437	useless powder	0		
 1438	denatured ghostly twinkly powder	0		Effect: "Sugar High", Effect Duration: 53
 1439	Vulcanized hot powder	0		Effect: "Beastly Flavor", Effect Duration: 68
-1440	diffused anodized mirror yellow powder	0		Effect: "Low on the Hog", Effect Duration: 58
+1440	diffused anodized yellow mirror powder	0		Effect: "Low on the Hog", Effect Duration: 58
 1441	aerosolized gray powder	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 19
 1442	adjusted dry electrified stench powder	0		Effect: "Emotion Sickness", Effect Duration: 39
 1443	oxidized blue narrow sleaze powder	0		Effect: "Dreadful Fear", Effect Duration: 67
@@ -1429,7 +1429,7 @@
 1447	non-polymerized triple-nitrogenated nuggets	0		Effect: "Ironclad", Effect Duration: 29
 1448	polymerized tumbling stench nuggets	0		Effect: "Tiki Toughness", Effect Duration: 51
 1449	oxidized skewed sleaze nuggets	0		Effect: "Burning Hands", Effect Duration: 19
-1450	modified squat narrow upside-down twinkly wad	1		Effect: "Marbles in Your Mouth", Effect Duration: 30
+1450	modified narrow squat upside-down twinkly wad	1		Effect: "Marbles in Your Mouth", Effect Duration: 30
 1451	pickled hot wad	1		
 1452	powdered jittery wad	1		
 1453	powdered narrow wad	1		
@@ -1437,7 +1437,7 @@
 1455	pickled sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	special low-calorie moldy blinking Valentine's Day cake	1	crappy	Effect: "Swordholder", Effect Duration: 10
+1458	low-calorie special moldy blinking Valentine's Day cake	1	crappy	Effect: "Swordholder", Effect Duration: 10
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	mirror squashed frog	0		
@@ -1454,7 +1454,7 @@
 1472	narrow sack of doorknobs	0		
 1473	shaking ball-and-chain	0		
 1474	automatic catapult	0		
-1475	cyan blurry pentacorn hat	0		Familiar Effect: "atk, cap 10"
+1475	blurry cyan pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	blinking goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	jittery plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	blue salad bowl	0		Familiar Effect: "atk, cap 30"
@@ -1487,22 +1487,22 @@
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	bad watered-down shaking calle de miel with a fly in it	2	decent	Last Available: "2006-04"
 1507	acceptable weak rockin' wagon with a fly in it	2	good	Last Available: "2006-04"
-1508	artisanal blinking narrow perpendicular hula with a fly in it	3	EPIC	Last Available: "2006-04"
-1509	drinkable practically non-alcoholic fuchsia slap and tickle with a fly in it	1	good	Last Available: "2006-04"
+1508	artisanal narrow blinking perpendicular hula with a fly in it	3	EPIC	Last Available: "2006-04"
+1509	practically non-alcoholic drinkable fuchsia slap and tickle with a fly in it	1	good	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	knitted fake hand	0		Cold Resistance: +3, Last Available: "2006-04"
 1512	vaporized Knob Goblin pet-buffing spray	1		
 1513	boiled Knob Goblin learning pill	1		
-1514	modified upside-down yellow pulsating wobbly Knob Goblin eyedrops	1		
+1514	modified yellow pulsating wobbly upside-down Knob Goblin eyedrops	1		
 1515	mixed Knob Goblin nasal spray	1		
 1516	tumbling KWE-brand transistor radio	0		
 1518	vampire heart	0		
-1519	shaking upside-down Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
+1519	upside-down shaking Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	Radio KoL Coffee Mug of the brute	0		Muscle Percent: +30, Item Drop: +5
 1521	narrow Frank Gorshin trophy	0		
 1522	olive stiffened strapping Radio Free Jersey	0		Muscle: +5, Damage Reduction: 1
 1523	bottle of used blood	0		
-1524	skewed huge wind-up chattering teeth	0		Last Available: "2006-04"
+1524	huge skewed wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
@@ -1528,31 +1528,31 @@
 1548	spinning blue lion tamer's occult Gazpacho's Glacial Grimoire	0		Spell Damage Percent: +25, Experience (familiar): +2
 1549	MSG	0		
 1550	bouncing gravedigger's second-hand knockoff engagement ring	0		Spooky Damage: +10, Single Equip
-1551	bad high-proof special bottle of Domesticated Turkey	8	decent	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 35
+1551	bad special high-proof bottle of Domesticated Turkey	8	decent	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 35
 1552	bad bottle of Definit	3	decent	
-1553	acceptable purple jittery bottle of Calcutta Emerald	3	good	
+1553	acceptable jittery purple bottle of Calcutta Emerald	3	good	
 1554	lousy practically non-alcoholic bottle of Lieutenant Freeman	1	decent	
 1555	lousy blinking bottle of Jorge Sinsonte	3	decent	
-1556	acceptable boozy squat boxed champagne	5	good	
+1556	boozy acceptable squat boxed champagne	5	good	
 1557	normal snack-sized kumquat	2	good	
-1558	special bite-sized decent spinning tangerine	1	good	Effect: "Patience of the Tortoise", Effect Duration: 30
+1558	bite-sized decent special spinning tangerine	1	good	Effect: "Patience of the Tortoise", Effect Duration: 30
 1559	ghostly wobbly tonic water	0		
-1560	spoiled fuchsia squat cocktail onion	4	crappy	
+1560	spoiled squat fuchsia cocktail onion	4	crappy	
 1561	moldy raspberry	3	crappy	
 1562	normal maroon spinning kiwi	4	good	
-1563	bad boozy huge spinning whiskey bittersweet	5	decent	
+1563	boozy bad spinning huge whiskey bittersweet	5	decent	
 1564	hand-crafted mimosette	3	EPIC	
 1565	perfectly mixed tequila sunset	4	EPIC	
 1566	delicious watered-down zmobie	2	awesome	Wiki Name: "Zmobie (drink)"
 1567	perfectly mixed gin and tonic	3	EPIC	
 1568	practically non-alcoholic aged vodka and tonic	1	awesome	
 1569	acceptable vodka gibson	4	good	
-1570	weak acceptable gibson	2	good	
+1570	acceptable weak gibson	2	good	
 1571	triple-distilled mediocre tumbling parisian cathouse	7	decent	
 1572	distilled tolerable rabbit punch	5	good	
 1573	hand-crafted caipifruta	3	EPIC	
-1574	smooth triple-distilled teqiwila	7	awesome	
-1575	fortified special artisanal Divine	5	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 10
+1574	triple-distilled smooth teqiwila	7	awesome	
+1575	fortified artisanal special Divine	5	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 10
 1576	acceptable Gordon Bennett	3	good	
 1577	practically non-alcoholic drinkable tangarita	1	good	
 1578	watered-down drinkable mandarina colada	2	good	
@@ -1564,14 +1564,14 @@
 1584	weak acceptable Mae West	2	good	
 1585	hand-crafted watered-down Mon Tiki	2	super ultra EPIC	
 1586	drinkable teqiwila slammer	3	good	
-1587	snack-sized stale Knob lo mein	2	decent	
+1587	stale snack-sized Knob lo mein	2	decent	
 1588	snack-sized adequate olive asparagus lo mein	2	good	
-1589	spoiled immense Knoll lo mein	7	crappy	
+1589	immense spoiled Knoll lo mein	7	crappy	
 1590	stale lo mein	4	decent	
 1591	stale special olive lo mein	3	decent	Effect: "Texas Elegance", Effect Duration: 50
 1592	bite-sized flavorless huge hot hi mein	1	decent	
 1593	bland hi mein	3	decent	
-1594	jumbo normal hi mein	5	good	
+1594	normal jumbo hi mein	5	good	
 1595	yummy hi mein	3	awesome	
 1596	flavorless sleazy hi mein	3	decent	
 1597	cyan wizardly Junior LAAAAME merit badge	0		Mysticality: +25, Last Available: "2006-05"
@@ -1579,7 +1579,7 @@
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	smooth fuchsia tangarita with a fly in it	3	awesome	
 1601	perfectly mixed weak mandarina colada with a fly in it	2	EPIC	
-1602	smooth practically non-alcoholic wobbly prussian cathouse with a fly in it	1	awesome	
+1602	practically non-alcoholic smooth wobbly prussian cathouse with a fly in it	1	awesome	
 1603	weak bad Mae West with a fly in it	2	decent	
 1604	denatured huge astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1589,7 +1589,7 @@
 1609	liquefied perfume of prejudice	0		Effect: "In the Saucestream", Effect Duration: 60
 1610	galvanized mirror eyedrops of the ocelot	0		Effect: "Fratty Flavor", Effect Duration: 58
 1611	cold-filtered skewed potent potion of potency	0		Effect: "Savage Beast Inside", Effect Duration: 37
-1612	ionized wet bouncing blinking concentrated cordial of concentration	0		Effect: "El Vibrations", Effect Duration: 55
+1612	ionized wet blinking bouncing concentrated cordial of concentration	0		Effect: "El Vibrations", Effect Duration: 55
 1613	nippy coffin lid	0		Cold Damage: +10, Damage Reduction: 3
 1614	satin shield of dire peril	0		Weapon Damage: +20, Damage Reduction: 5
 1615	jittery huge sage Cerebral Cloche	0		Mysticality Percent: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
@@ -1604,7 +1604,7 @@
 1624	magnetized liquefied blue-frosted astral cupcake	0		Effect: "Inscrutable exoskeleton", Effect Duration: 22, Last Available: "2006-06"
 1625	dry blinking green-frosted astral cupcake	0		Effect: "Bestial Sympathy", Effect Duration: 65, Last Available: "2006-06"
 1626	ionized narrow twirling orange-frosted astral cupcake	0		Effect: "Fever From the Flavor", Effect Duration: 23, Last Available: "2006-06"
-1627	activated oxidized spinning squat purple-frosted astral cupcake	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 54, Last Available: "2006-06"
+1627	activated oxidized squat spinning purple-frosted astral cupcake	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 54, Last Available: "2006-06"
 1628	wet enhanced huge pink-frosted astral cupcake	0		Effect: "Coated Arms", Effect Duration: 39, Last Available: "2006-06"
 1629	lard-coated raspberry beret	0		Sleaze Spell Damage: +25, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	blurry jittery executive pixel shield	0		Meat Drop: +40, Damage Reduction: 3
@@ -1620,7 +1620,7 @@
 1640	altered lotion of stench	0		Effect: "Ancestral Disapproval", Effect Duration: 27
 1641	alkaline enhanced wobbly lotion of sleaziness	0		Effect: "[1609]Dancin' Fool", Effect Duration: 56
 1642	bad watered-down Grimacite Bock	2	decent	Last Available: "2008-11"
-1643	enchanted miniature delicious tumbling red wedge of gray cheese	2	awesome	Effect: "Your Favorite Flavor", Effect Duration: 5, Last Available: "2008-11"
+1643	delicious enchanted miniature tumbling red wedge of gray cheese	2	awesome	Effect: "Your Favorite Flavor", Effect Duration: 5, Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
@@ -1654,7 +1654,7 @@
 1674	superhero mask of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
 1675	ore	0		
 1676	styrofoam ore	0		
-1677	wobbly red ghostly bubblewrap ore	0		
+1677	ghostly red wobbly bubblewrap ore	0		
 1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	tumbling toasty sword of James Dean	0		Experience (Moxie): +3, Hot Damage: +5
 1680	ghostly personal trainer's smartaleck's staff	0		Moxie Percent: +30, Experience Percent (Muscle): +10
@@ -1673,12 +1673,12 @@
 1693	triple-energized quantum ghostly ghostly eyedrops of newt	0		Effect: "Your Eyes are Peeled!", Effect Duration: 29
 1694	nitrogenated purple Frogade	0		Effect: "Vinegavotte", Effect Duration: 62
 1695	polymerized blinking papotion of papower	0		Effect: "Thanksgot", Effect Duration: 15
-1696	gigantic normal royal jelly taco	8	good	
-1697	toothsome gigantic tofu taco	9	awesome	
+1696	normal gigantic royal jelly taco	8	good	
+1697	gigantic toothsome tofu taco	9	awesome	
 1698	thick rotten blinking jumping bean taco	5	crappy	
 1699	delicious blurry catgut taco	3	awesome	
 1700	spoiled goat cheese taco	4	crappy	
-1701	moldy bite-sized pr0n taco	1	crappy	
+1701	bite-sized moldy pr0n taco	1	crappy	
 1702	triple-cold-filtered chilled improved alphabet gum	0		Effect: "Motion", Effect Duration: 47
 1703	Comma Chameleon egg	0		Free Pull
 1704	yellow shingle	0		
@@ -1740,13 +1740,13 @@
 1761	reassuring supercharged foon of foulness	0		Maximum MP Percent: +30, Spooky Resistance: +1
 1762	bouncing Sinatra's Fonzie's foon of fearfulness	0		Experience (Moxie): 6
 1763	lard-coated foon of fleshiness of bravery	0		Sleaze Spell Damage: +25, Spooky Resistance: +5
-1764	pulsating shaking Spookyraven library key	0		
+1764	shaking pulsating Spookyraven library key	0		
 1765	Spookyraven gallery key	0		
 1766	Spookyraven ballroom key	0		
 1767	pulsating pack of chewing gum	0		
 1768	Gnomish toolbox	0		
 1769	bland fricasseed brains	3	decent	
-1770	spoiled massive brains casserole	7	crappy	
+1770	massive spoiled brains casserole	7	crappy	
 1771	upside-down toasty butcherknife	0		Hot Damage: +5
 1772	blinking corn holder of the businessman	0		Meat Drop: +50
 1773	eggbeater of the sweet-tooth	0		Candy Drop: +100
@@ -1754,7 +1754,7 @@
 1775	tumbling fuchsia resourceful dishrag	0		Maximum MP: +50
 1776	enchanted bland stale baguette	4	decent	Effect: "Incensed", Effect Duration: 40
 1777	leftovers of indeterminate origin	0		
-1778	normal snack-sized dinner	2	good	
+1778	snack-sized normal dinner	2	good	
 1779	reassuring katana	0		Spooky Resistance: +1
 1780	foul-smelling ram stick	0		Stench Damage: +10
 1781	aromatic enchantlers	0		Stench Resistance: +1, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1899,7 +1899,7 @@
 1922	gob of wet hair	0		
 1923	tumbling roll of toilet paper	0		Free Pull
 1924	ghostly tattered wolf standard	0		
-1925	jittery blue tattered snake standard	0		
+1925	blue jittery tattered snake standard	0		
 1926	KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
 1928	olive tuning fork	0		
@@ -1926,7 +1926,7 @@
 1949	moldy Manetwich	3	crappy	
 1950	bouncing bottle of Vangoghbitussin	0		
 1951	mediocre ghostly bottle of Pinot Renoir	3	decent	
-1952	massive spoiled desiccated apricot	6	crappy	
+1952	spoiled massive desiccated apricot	6	crappy	
 1953	hand-crafted flute of flat champagne	4	EPIC	
 1954	decent dehydrated caviar	4	good	
 1955	styrofoam peanuts	0		
@@ -1937,7 +1937,7 @@
 1960	scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	Vulcanized liquefied Bit O' Ectoplasm	0		Effect: "Intimidating Mien", Effect Duration: 43
-1963	green bouncing dance card	0		
+1963	bouncing green dance card	0		
 1964	cyan wholesome opera mask	0		Maximum HP Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	twirling bottle of Monsieur Bubble	0		
 1966	lightning-fast Amulet of Yendor of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Single Equip, Last Available: "2011-12"
@@ -1966,7 +1966,7 @@
 1989	wobbly Cheshire bitten	0		
 1990	jittery yo-yo	0		
 1991	rubber WWJD? bracelet	0		
-1992	bouncing red rubber WWBD? bracelet	0		
+1992	red bouncing rubber WWBD? bracelet	0		
 1993	rubber WWSPD? bracelet	0		
 1994	maroon rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
@@ -1994,7 +1994,7 @@
 2017	spade necklace	0		
 2018	club necklace	0		
 2019	pulsating cream pie	0		Free Pull
-2020	snack-sized tasty cherry pie	2	awesome	
+2020	tasty snack-sized cherry pie	2	awesome	
 2021	flavorless strawberry pie	4	decent	
 2022	small stale lemon meringue pie	2	decent	
 2023	fancy Genalen&trade; Bottle	1	EPIC	Effect: "Patched In", Effect Duration: 40
@@ -2021,8 +2021,8 @@
 2044	huge your father's MacGuffin diary	0		
 2045	miniature stale brain-meltingly-hot chicken wings	2	decent	
 2046	special decent snack-sized frat brats	2	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 30
-2047	thick normal knob ka-bobs	5	good	
-2049	high-proof mediocre can of Swiller	7	decent	
+2047	normal thick knob ka-bobs	5	good	
+2049	mediocre high-proof can of Swiller	7	decent	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
@@ -2032,7 +2032,7 @@
 2056	flattened adder bladder	0		Effect: "Speed of the Internet", Effect Duration: 16
 2057	pension check	0		
 2058	picnic basket	0		
-2059	vacuum-sealed activated huge jittery Black No. 2	0		Effect: "Flamingly Floral", Effect Duration: 33
+2059	vacuum-sealed activated jittery huge Black No. 2	0		Effect: "Flamingly Floral", Effect Duration: 33
 2060	aromatic baleful sword	0		Spell Damage: +25, Stench Resistance: +1
 2061	baleful helmet	0		Spell Damage: +25, Familiar Effect: "1xFairy, cap 40"
 2062	steel-toed stylish shield	0		Moxie: +25, Damage Reduction: 19
@@ -2081,7 +2081,7 @@
 2105	coal button	0		
 2106	burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
-2108	shaking wobbly rock	0		
+2108	wobbly shaking rock	0		
 2109	red stringy sinew	0		Last Available: "2011-12"
 2110	pulsating stick	0		Last Available: "2011-12"
 2111	tooth	0		
@@ -2129,7 +2129,7 @@
 2154	squat ion grid	0		Last Available: "2011-12"
 2155	gray Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
-2157	huge maroon high-resistance ultrapolymer plating	0		Last Available: "2011-12"
+2157	maroon huge high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	yellow servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	purple quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
@@ -2160,14 +2160,14 @@
 2185	pulsating gray family-friendly Kiss the Knob apron	0		Sleaze Resistance: +1
 2186	unlit birthday cake	0		
 2187	blurry blurry lit birthday cake	0		
-2188	wobbly upside-down flask of peppermint oil	1	good	Last Available: "2006-12"
+2188	upside-down wobbly flask of peppermint oil	1	good	Last Available: "2006-12"
 2189	bad flask of peppermint schnapps	3	decent	Last Available: "2006-12"
 2190	ghostly yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	bouncing sheet music	0		Last Available: "2006-12"
-2193	snack-sized adequate candy stake	2	good	Last Available: "2006-12"
-2194	acceptable fortified huge eggnog	5	good	Last Available: "2006-12"
-2195	enchanted decent low-calorie unspeakable fruitcake	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5, Last Available: "2006-12"
+2193	adequate snack-sized candy stake	2	good	Last Available: "2006-12"
+2194	fortified acceptable huge eggnog	5	good	Last Available: "2006-12"
+2195	enchanted low-calorie decent unspeakable fruitcake	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5, Last Available: "2006-12"
 2196	spoiled snack-sized gingerbread horror	2	crappy	Last Available: "2006-12"
 2197	polarized but probably evil chocolate	0		Effect: "Celestial Vision", Effect Duration: 53, Last Available: "2006-12"
 2198	stale bat-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
@@ -2182,9 +2182,9 @@
 2207	reassuring Crimbo tiki necklace	0		Spooky Resistance: +1, Last Available: "2006-12"
 2208	blurry personal trainer's slick bobble-hip hula elf doll	0		Moxie: +10, Experience Percent (Muscle): +10, Last Available: "2006-12"
 2209	crafty Crimbo ukulele	0		Maximum MP: +10, Last Available: "2006-12"
-2210	supercharged stylish Tiki lighter	0		Moxie: +25, Maximum MP Percent: +30, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	skewed twirling wool studded deck of tropical cards	0		Damage Absorption: +80, Cold Resistance: +1, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	upside-down frosty tropical paperweight of the blizzard	0		Cold Spell Damage: 35, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	supercharged stylish Tiki lighter	0		Moxie: +25, Maximum MP Percent: +30, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	skewed twirling wool studded deck of tropical cards	0		Damage Absorption: +80, Cold Resistance: +1, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	upside-down frosty tropical paperweight of the blizzard	0		Cold Spell Damage: 35, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tumbling tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
 2215	olive wobbly Tropical Crimbo Hat of the brute	0		Muscle Percent: +30, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
@@ -2192,7 +2192,7 @@
 2217	bland upside-down blurry super ka-bob	4	decent	
 2218	jumbo tasty spinning beer basted brat	5	awesome	
 2219	deadly Tropical Crimbo Sword	0		Weapon Damage: +5, Last Available: "2006-12"
-2220	cold-filtered red shaking and Crimboween candy	0		Effect: "Abominably Slippery", Effect Duration: 65, Last Available: "2020-09"
+2220	cold-filtered shaking red and Crimboween candy	0		Effect: "Abominably Slippery", Effect Duration: 65, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	avaricious liar's pants of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +30, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	spinning zippy juggler's balls of the blizzard	0		Cold Spell Damage: +25, Initiative: +20, Softcore Only, Last Available: "2007-01"
@@ -2231,20 +2231,20 @@
 2257	clever reinforced furry underpants of the bloodbag	0		Maximum HP: +100, Maximum MP: +20
 2258	teal &quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
-2260	twirling jittery hard rock candy	0		
+2260	jittery twirling hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	immense tasty special stunt nuts	8	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 5
+2264	special immense tasty stunt nuts	8	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 5
 2265	spoiled narrow wet stew	3	crappy	
 2266	wet stunt nut stew	0		
 2267	olive Mega Gem	0		
 2268	yellow wool Staff of Fats	0		Cold Resistance: +1
-2269	gigantic yummy sausage wonton	7	awesome	
+2269	yummy gigantic sausage wonton	7	awesome	
 2270	smelly thinker's belt	0		Mysticality: +10, Stench Spell Damage: +10, Single Equip
 2271	tolerable bottle of Merlot	4	good	
-2272	lousy high-proof bottle of Port	7	decent	
-2273	high-proof mediocre bottle of Pinot Noir	9	decent	
+2272	high-proof lousy bottle of Port	7	decent	
+2273	mediocre high-proof bottle of Pinot Noir	9	decent	
 2274	bad bottle of Zinfandel	3	decent	
 2275	artisanal bottle of Marsala	3	EPIC	
 2276	lousy bottle of Muscat	3	decent	
@@ -2259,13 +2259,13 @@
 2285	blinking chisel	0		
 2286	Eye of Ed	0		
 2287	ghostly sharpshooter's ruddy glowstick	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Last Available: "2007-01"
-2288	gray blinking encoder ring	0		Single Equip
+2288	blinking gray encoder ring	0		Single Equip
 2289	paperclip	0		
 2290	bouncing really house	0		
 2291	bouncing Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
 2293	squat cup of strong herbal tea	0		
-2294	bouncing wobbly Curiously Shiny Ancient Evil-Bashing Axe	0		
+2294	wobbly bouncing Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	bouncing marinated stakes	0		
 2296	knob butter	0		
 2297	blurry vial of ectoplasm	0		
@@ -2292,7 +2292,7 @@
 2318	cyan bomb	0		
 2319	lime green carved wheel	0		
 2320	lime green worm-riding manual page	0		
-2321	twirling squat twirling worm-riding manual page 2	0		
+2321	squat twirling twirling worm-riding manual page 2	0		
 2322	wobbly worm-riding manual pages 3-15	0		
 2323	upside-down headpiece of the Staff of Ed	0		
 2324	Staff of Ed, almost	0		
@@ -2309,7 +2309,7 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	spinning rock-hard pipe of the brazier	0		Damage Reduction: 5, Hot Spell Damage: +25
 2337	huge stylish reinforced beaded headband	0		Moxie: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	small decent pudding	2	good	Wiki Name: "black pudding (food)"
+2338	decent small pudding	2	good	Wiki Name: "black pudding (food)"
 2339	perfectly mixed yellow Blackfly Chardonnay	3	EPIC	
 2340	mediocre & tan	3	decent	
 2341	pulsating ghostly pepper	0		
@@ -2327,7 +2327,7 @@
 2353	bejeweled pledge pin of the brazier	0		Hot Spell Damage: +25, Single Equip
 2354	communications windchimes	0		
 2355	tarnished squat henna face paint	0		Effect: "Danish Cunning", Effect Duration: 32
-2356	concentrated liquefied narrow lime green tube of dread wax	0		Effect: "It Didn't Kill You", Effect Duration: 39
+2356	concentrated liquefied lime green narrow tube of dread wax	0		Effect: "It Didn't Kill You", Effect Duration: 39
 2357	twirling nasty Tesla Gaia beads	0		Stench Damage: +5, MP Regen Min: 7, MP Regen Max: 10
 2358	pink clay bead	0		
 2359	clay bead	0		
@@ -2345,9 +2345,9 @@
 2371	smoke bomb	0		
 2372	tumbling bunch of bananas	0		
 2373	bland shaking purple banana	4	decent	
-2374	twirling squat banana peel	0		
+2374	squat twirling banana peel	0		
 2375	decent miniature tumbling banana cream pie	2	good	
-2376	drinkable high-proof banana daiquiri	8	good	
+2376	high-proof drinkable banana daiquiri	8	good	
 2377	triple-distilled drinkable spinning bungle in the jungle	10	good	
 2378	banana spritzer	0		
 2379	liquefied enhanced liquefied banana smoothie	0		Effect: "Venomous Weapon", Effect Duration: 17
@@ -2381,7 +2381,7 @@
 2407	pink bat eye	0		
 2408	worthless piece of glass	0		
 2409	fuchsia billy idol	0		
-2410	blurry twirling rag	0		
+2410	twirling blurry rag	0		
 2411	broken petri dish	0		
 2412	red sammich crust	0		
 2413	huge triffid bark	0		
@@ -2394,7 +2394,7 @@
 2420	non-wet teeny-tiny magic scroll	0		Effect: "Hairless and Airless", Effect Duration: 47
 2421	enhanced bottle of pirate juice	0		Effect: "Familial Ties", Effect Duration: 33
 2422	modified ionized irradiated pet snacks	0		Effect: "Granolarrrgh", Effect Duration: 37
-2423	electrified double-dry super-boiled blue blinking Mick's IcyVapoHotness Inhaler	0		Effect: "Bandersnatched", Effect Duration: 47
+2423	electrified double-dry super-boiled blinking blue Mick's IcyVapoHotness Inhaler	0		Effect: "Bandersnatched", Effect Duration: 47
 2424	magnetized ionized yellow cyclops eyedrops	0		Effect: "Neutered Nostrils", Effect Duration: 64
 2425	vacuum-sealed olive can of spinach	0		Effect: "All Glory To the Toad", Effect Duration: 58
 2426	energized enhanced shaking fire flower	0		Effect: "Okee-Dokee Go!", Effect Duration: 59
@@ -2415,16 +2415,16 @@
 2441	jittery upside-down Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	mirror double-paned careful pink glowstick	0		Monster Level: -10, Cold Resistance: +5, Last Available: "2007-03"
-2444	practically non-alcoholic fancy perfectly mixed Supernova Champagne	1	super ultra EPIC	Effect: "Corruption of Wretched Wally", Effect Duration: 50
+2444	fancy practically non-alcoholic perfectly mixed Supernova Champagne	1	super ultra EPIC	Effect: "Corruption of Wretched Wally", Effect Duration: 50
 2445	huge Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
-2448	twirling ghostly cyan tasteful bow tie	0		Familiar Weight: +5
+2448	ghostly twirling cyan tasteful bow tie	0		Familiar Weight: +5
 2449	six-pack of New Cloaca-Cola	0		
 2450	empty Cloaca-Cola bottle	0		
 2451	mirror experienced goatskin umbrella	0		Experience: +2
 2452	executive baleful wool hat	0		Spell Damage: +25, Meat Drop: +40, Familiar Effect: "1xLep, cap 43"
-2453	huge jittery tumbling Goodfella contract	0		Last Available: "2011-12"
+2453	jittery tumbling huge Goodfella contract	0		Last Available: "2011-12"
 2454	wholesome belt of the brute	0		Muscle Percent: +30, Maximum HP Percent: +10, Single Equip
 2455	pulsating cyan bar whip of the businessman	0		Meat Drop: +50
 2456	barskin buckler of the empath	0		Familiar Weight: +5, Damage Reduction: 1
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	spinning spinning Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	flavorless tiny bowl of Bounty-Os	1	decent	
-2465	practically non-alcoholic perfectly mixed Oreille Divis&eacute;e brandy	1	super ultra mega turbo EPIC	
+2465	perfectly mixed practically non-alcoholic Oreille Divis&eacute;e brandy	1	super ultra mega turbo EPIC	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2489,15 +2489,15 @@
 2516	blinking horrifying groovy wrench bracelet	0		Moxie Percent: +10, Spooky Damage: +25
 2517	stiffened quilted chain necklace	0		Damage Absorption: +40, Damage Reduction: 1
 2518	jittery ghostly smelly sawblade shield	0		Stench Spell Damage: +10, Damage Reduction: 11
-2519	watered-down drinkable cyan McMillicancuddy's Special Lager	2	good	
+2519	drinkable watered-down cyan McMillicancuddy's Special Lager	2	good	
 2520	bad melted Jell-o shot	4	decent	
 2521	acceptable cruelty-free wine	3	good	
 2522	smooth spinning thistle wine	3	awesome	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	thick decent skewed fish	5	good	
+2525	decent thick skewed fish	5	good	
 2526	tasty fish casserole	3	awesome	
-2527	rotten miniature special fish lasagna	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 35
+2527	miniature rotten special fish lasagna	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 35
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	delicious fancy blurry gnatloaf	3	awesome	Effect: "Coming Up Roses", Effect Duration: 15
 2530	adequate gnatloaf casserole	3	good	
@@ -2505,7 +2505,7 @@
 2532	pork	0		
 2533	stale bouncing pork chop sandwiches	3	decent	
 2534	flavorless snack-sized maroon pork casserole	2	decent	
-2535	special decent cyan pork lasagna	4	good	Effect: "Sticky Fingers", Effect Duration: 10
+2535	decent special cyan pork lasagna	4	good	Effect: "Sticky Fingers", Effect Duration: 10
 2536	canopic jar	0		
 2537	olive spice	0		
 2538	ghostly bouncing fuchsia organs	0		
@@ -2538,7 +2538,7 @@
 2565	can of Ghuol-B-Gone&trade;	0		
 2566	twirling Azazel's unicorn	0		
 2567	bouncing Azazel's lollipop	0		
-2568	shaking huge Azazel's tutu	0		
+2568	huge shaking Azazel's tutu	0		
 2569	chilled huge ant agonist	0		Effect: "Elbow Sauce", Effect Duration: 52
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	blurry ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2549,19 +2549,19 @@
 2576	honey-dipped locust	0		
 2577	maroon skewed skewed family-friendly MacGyver's cactus quill	0		Maximum MP: +100, Sleaze Resistance: +1
 2578	executive sinister Staff of the Short Order Cook of the blizzard	0		Spell Damage: +10, Cold Spell Damage: +25, Meat Drop: +40
-2579	miniature flavorless cactus fruit	2	decent	
+2579	flavorless miniature cactus fruit	2	decent	
 2580	perfumed slick scorpion whip	0		Moxie: +10, Stench Resistance: +5
 2581	fuchsia handful of sand	0		
-2582	jittery red brick of sand	0		
+2582	red jittery brick of sand	0		
 2583	adequate centipede eggs	3	good	
 2584	bouncing squat yellow lightning-fast wonderwall shield	0		Initiative: +40, Damage Reduction: 12
 2585	strapping Colonel Mustard's Lonely Spades Club Jacket	0		Muscle: +5
 2586	twirling greedy General Sage's Lonely Diamonds Club Jacket	0		Meat Drop: +20
 2587	Corporal Fennel's Lonely Clubs Club Jacket of the wise owl	0		Mysticality: +20
 2588	Private Pepper's Lonely Hearts Club Jacket of terror	0		Spooky Spell Damage: +10
-2589	small stale enchanted squat hot date	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45
+2589	stale enchanted small squat hot date	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45
 2590	perfectly mixed distilled fortified wine	3	EPIC	
-2591	fancy miniature rotten tasty tart	2	crappy	Effect: "New and Improved", Effect Duration: 20
+2591	fancy rotten miniature tasty tart	2	crappy	Effect: "New and Improved", Effect Duration: 20
 2592	Knob Goblin lunchbox	0		
 2593	tasty Knob pasty	3	awesome	
 2594	perfectly mixed lime green thermos full of Knob coffee	4	EPIC	
@@ -2623,15 +2623,15 @@
 2650	wobbly bottled pixie	0		Free Pull
 2651	ghostly pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	moldy S.T.L.T.	3	crappy	Last Available: "2007-06"
-2653	moldy miniature honey-dew	2	crappy	Last Available: "2007-06"
-2654	tolerable watered-down Xanadian	2	good	Last Available: "2007-06"
+2653	miniature moldy honey-dew	2	crappy	Last Available: "2007-06"
+2654	watered-down tolerable Xanadian	2	good	Last Available: "2007-06"
 2655	irradiated ionized bottle of absinthe	0		Effect: "meat.enh", Effect Duration: 41, Last Available: "2007-06"
 2656	teal Drowsy Sword of temperance	0		Sleaze Resistance: +5, Item Drop: +5
 2657	small normal escargotsicle	2	good	Last Available: "2007-06"
 2658	mediocre lime green bottle of realpagne	3	decent	Last Available: "2007-06"
 2659	hardy albatross necklace	0		Maximum HP: +50, Single Equip, Last Available: "2007-06"
-2660	distilled blurry shaking not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	triple-distilled acceptable flask of Amontillado	8	good	Last Available: "2007-06"
+2660	distilled shaking blurry not-a-pipe	1	EPIC	Last Available: "2007-06"
+2661	acceptable triple-distilled flask of Amontillado	8	good	Last Available: "2007-06"
 2662	ball mask of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	blinking family-friendly Can-Can skirt	0		Sleaze Resistance: +1, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	boiled twirling sensitive poetry journal	0		Effect: "Mushroom Might", Effect Duration: 31, Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	denatured can-can-in-a-can	1		Effect: "Loco Motives", Effect Duration: 40, Last Available: "2007-06"
 2669	boiled narrow blinking patent antipsychotics	1		Last Available: "2007-06"
 2670	pickled Mariner's Friend cough drops	1		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 30, Last Available: "2007-06"
-2671	practically non-alcoholic drinkable shot of nepenthe schnapps	1	good	Last Available: "2007-06"
+2671	drinkable practically non-alcoholic shot of nepenthe schnapps	1	good	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	oxidized dry bottle of cat tonic	0		Effect: "Disco Nirvana", Effect Duration: 62, Last Available: "2007-06"
@@ -2688,7 +2688,7 @@
 2715	blinking sausage bomb	0		
 2716	Da Vinci's beefcake's battered hubcap of the blizzard	0		Muscle: +25, Experience (Mysticality): +5, Cold Spell Damage: +25, Damage Reduction: 14
 2717	fireproof lard-coated resourceful hood ornament	0		Maximum MP: +50, Sleaze Spell Damage: +25, Hot Resistance: +3
-2718	narrow tumbling squat spare kidney	0		
+2718	narrow squat tumbling spare kidney	0		
 2719	olive rock-hard hand-carved bokken of the brazier of incineration	0		Damage Reduction: 5, Hot Spell Damage: 75
 2720	wobbly ruddy cool hand-carved bow of the sweet-tooth	0		Moxie: +5, Maximum HP Percent: +40, Candy Drop: +100
 2721	Jeselnik's groovy hand-carved staff of incineration	0		Moxie Percent: +10, Hot Spell Damage: +50, Sleaze Damage: +25
@@ -2700,18 +2700,18 @@
 2727	spoiled plum	3	crappy	
 2728	stale miniature shaking pear	2	decent	
 2729	spoiled peach	3	crappy	
-2730	lousy weak jittery plum wine	2	decent	
+2730	weak lousy jittery plum wine	2	decent	
 2731	hand-crafted fancy shot of pear schnapps	4	EPIC	Effect: "Fustulent", Effect Duration: 10
 2732	artisanal teal shot of peach schnapps	3	EPIC	
 2733	adequate narrow skewed bunch of square grapes	3	good	
 2734	adequate small brown sugar cane	2	good	
-2735	snack-sized bland sandwich of the gods	2	decent	
+2735	bland snack-sized sandwich of the gods	2	decent	
 2736	delicious Pan-Dimensional Gargle Blaster	4	awesome	
 2737	powdered tumbling bouncing leopard-print barbell	1	EPIC	Effect: "Mayeaugh", Effect Duration: 25
 2738	pile of smoking rags	0		
 2739	non-flattened unsweetened panty raider camouflage	0		Effect: "Pecan Pied Piper", Effect Duration: 32
 2740	stanky rosy-cheeked quilted Staff of the Walk-In Freezer	0		Damage Absorption: +40, Maximum HP Percent: +30, Stench Spell Damage: +25
-2741	weak acceptable boilermaker	2	good	
+2741	acceptable weak boilermaker	2	good	
 2742	normal steel lasagna	4	quest	
 2743	lousy weak steel margarita	2	quest	
 2744	dehydrated wobbly steel-scented air freshener	1		Effect: "Fit To Be Tide", Effect Duration: 35
@@ -2738,14 +2738,14 @@
 2765	Harold's bell	0		
 2766	bowling ball	0		
 2767	half-sized rotten Crimbo pie	2	crappy	
-2768	massive fancy adequate pear tart	9	good	Effect: "Rainbow Bright", Effect Duration: 30
+2768	fancy adequate massive pear tart	9	good	Effect: "Rainbow Bright", Effect Duration: 30
 2769	moldy huge peach pie	3	crappy	
 2770	quantum chunk of rock salt	0		Effect: "Mortarfied", Effect Duration: 34
 2771	nitrogenated boiled vacuum-sealed handful of pine needles	0		Effect: "Turtle Power", Effect Duration: 68
 2772	steamy ruby	0		
 2773	skewed glacial sapphire	0		
 2774	unearthly onyx	0		
-2775	twirling maroon effluvious emerald	0		
+2775	maroon twirling effluvious emerald	0		
 2776	jittery tawdry amethyst	0		
 2777	sizzling veiny filigreed hamethyst earring	0		Maximum HP: +10, Hot Damage: +10
 2778	ribald studded beefcake's filigreed hamethyst necklace	0		Muscle: +25, Damage Absorption: +80, Sleaze Damage: +10, Single Equip
@@ -2776,13 +2776,13 @@
 2803	twirling jug of Gnomochloric acid	0		
 2804	wet electrified vial of hamethyst juice	0		Effect: "The Smile of Mr. A.", Effect Duration: 42
 2805	polarized blurry vial of baconstone juice	0		Effect: "Voracious Gorging", Effect Duration: 58
-2806	warmed energized pulsating twirling vial of porquoise juice	0		Effect: "Full Bottle in front of Me", Effect Duration: 32
+2806	warmed energized twirling pulsating vial of porquoise juice	0		Effect: "Full Bottle in front of Me", Effect Duration: 32
 2807	cold-filtered quadruple-wet irradiated bouncing flask of hamethyst juice	0		Effect: "You're Not Cooking", Effect Duration: 39
 2808	polarized frozen flask of baconstone juice	0		Effect: "Perception", Effect Duration: 41
 2809	magnetized cold-filtered skewed flask of porquoise juice	0		Effect: "The Q Is Talking To You", Effect Duration: 36
 2810	irradiated wobbly jug of hamethyst juice	0		Effect: "In a Lather", Effect Duration: 11
 2811	colloidal narrow jug of baconstone juice	0		Effect: "Experimental Effect G-9", Effect Duration: 22
-2812	galvanized yellow squat jug of porquoise juice	0		Effect: "Third Based", Effect Duration: 63
+2812	galvanized squat yellow jug of porquoise juice	0		Effect: "Third Based", Effect Duration: 63
 2813	studded Beret of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	jittery aromatic cool Bludgeon of doom	0		Moxie: +5, Spooky Spell Damage: +50, Stench Resistance: +1
 2815	avaricious veiny fortified Bunker	0		Damage Absorption: +60, Maximum HP: +10, Meat Drop: +30, Damage Reduction: 15
@@ -2811,9 +2811,9 @@
 2838	supercharged thinker's glowstick	0		Mysticality: +10, Maximum MP Percent: +30, Last Available: "2007-08"
 2839	Periodical Paintbrush of extreme caution	0		Monster Level: -25, Softcore Only
 2840	hand-crafted bottle of cooking sherry	4	EPIC	
-2841	flavorless miniature packet of ketchup	2	decent	
+2841	miniature flavorless packet of ketchup	2	decent	
 2842	watered-down aged wobbly accidental cider	2	awesome	
-2843	small adequate dire fudgesicle	2	good	
+2843	adequate small dire fudgesicle	2	good	
 2844	blurry blurry lard-coated careful wholesome navel ring of navel gazing of the cougar	0		Moxie: +20, Maximum HP Percent: +10, Monster Level: -10, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	upside-down red plastic bib	0		Last Available: "2011-12"
@@ -2908,7 +2908,7 @@
 2935	beefcake's plastic fluffy bunny	0		Muscle: +25
 2936	castagnets	0		Familiar Weight: +5
 2937	tumbling siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
-2938	shaking bouncing Jacob's ladder	0		Familiar Weight: +5
+2938	bouncing shaking Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	bite-sized delicious wobbly Surprise Egg	1	awesome	
 2941	ionized wet activated Steal This Candy	0		Effect: "Spiritually Awake", Effect Duration: 20
@@ -2929,7 +2929,7 @@
 2957	skewed rum barrel charrrm	0		
 2958	bland bouncing tube of cranberry Go-Goo	3	decent	
 2959	rum barrel charrrm bracelet of dire peril	0		Weapon Damage: +20
-2960	snack-sized spoiled purple single-serving herbal stuffing	2	crappy	
+2960	spoiled snack-sized purple single-serving herbal stuffing	2	crappy	
 2961	moldy packet of tofurkey gravy	4	crappy	
 2962	tiny fancy yummy tofurkey nugget	1	awesome	Effect: "Tin, Man", Effect Duration: 40
 2963	rigging shampoo	0		
@@ -2938,7 +2938,7 @@
 2966	narrow Tom's of the Spanish Main Toothpaste	0		
 2967	triple-moist magnetized Swabbie&trade; swab	0		Effect: "Stop and Smell the Fudge", Effect Duration: 18
 2968	Vulcanized energized concentrated yellow Oil of Parrrlay	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 21
-2969	normal fancy creamsicle	3	good	Effect: "Flamingly Floral", Effect Duration: 35
+2969	fancy normal creamsicle	3	good	Effect: "Flamingly Floral", Effect Duration: 35
 2970	acceptable cream stout	3	good	
 2971	shellacked Fonzie's curmudgel	0		Experience (Moxie): +1, Damage Reduction: 7
 2972	grumpy man charrrm	0		
@@ -2948,7 +2948,7 @@
 2976	perfectly mixed blinking bilge wine	3	EPIC	
 2977	huge witty rapier of extreme caution	0		Monster Level: -25
 2978	teal Socratic yohohoyo of chilblains	0		Experience (Mysticality): +1, Cold Damage: +25
-2979	corrupted upside-down narrow purple fish-liver oil	0		Effect: "Hardened Fabric", Effect Duration: 50
+2979	corrupted narrow purple upside-down fish-liver oil	0		Effect: "Hardened Fabric", Effect Duration: 50
 2980	booty chest charrrm	0		
 2981	tumbling booty chest charrrm bracelet of dire peril	0		Weapon Damage: +20, Single Equip
 2982	cannonball charrrm	0		
@@ -2963,7 +2963,7 @@
 2991	gray flame-wreathed clingfilm slippers	0		Hot Spell Damage: +10, Single Equip
 2992	clingfilm tangle	0		
 2993	decent thick vinegar-soaked lemon slice	5	good	
-2994	quadruple-pressed irradiated narrow gray true grit	0		Effect: "Faboooo", Effect Duration: 20
+2994	quadruple-pressed irradiated gray narrow true grit	0		Effect: "Faboooo", Effect Duration: 20
 2995	tumbling flame-wreathed buoybottoms of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Hot Spell Damage: +10, Initiative: +60, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	inspector's grungy flannel shirt	0		Item Drop: +15
 2997	upside-down scandalous smartaleck's grungy bandana	0		Moxie Percent: +30, Sleaze Damage: +5, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
@@ -2988,7 +2988,7 @@
 3016	blue foot locker	0		
 3017	ornate chest	0		
 3018	gilded chest	0		
-3019	jittery fuchsia blurry all-purpose cleaner	0		
+3019	fuchsia blurry jittery all-purpose cleaner	0		
 3020	upside-down handful of sawdust	0		
 3021	stone triangle	0		
 3022	blinking medium stone triangle	0		
@@ -3001,11 +3001,11 @@
 3029	artisanal red-headed corpse	4	EPIC	
 3030	mediocre distilled kamicorpse-ee	5	decent	
 3031	hand-crafted fuchsia corpsel	3	EPIC	
-3032	perfectly mixed practically non-alcoholic tumbling corpsebite	1	super EPIC	
+3032	practically non-alcoholic perfectly mixed tumbling corpsebite	1	super EPIC	
 3033	pirate fledges of the cheetah	0		Initiative: +60
 3034	tumbling piece of thirteen	0		
-3035	special super-sized moldy pearl onion	5	crappy	Effect: "Stinky Weapon", Effect Duration: 35
-3036	adequate half-sized narrow sea biscuit	2	good	
+3035	moldy super-sized special pearl onion	5	crappy	Effect: "Stinky Weapon", Effect Duration: 35
+3036	half-sized adequate narrow sea biscuit	2	good	
 3037	bad bottle of rum	3	decent	
 3038	practically non-alcoholic bad bottle of black-label rum	1	decent	
 3039	mirror cannonball	0		
@@ -3064,7 +3064,7 @@
 3092	olive medical-grade handmade hobby horse	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2007-12"
 3093	ball-in-a-cup of temperance	0		Sleaze Resistance: +5, Last Available: "2007-12"
 3094	dance instructor's set of jacks	0		Experience Percent (Moxie): +10, Last Available: "2007-12"
-3095	immense toothsome laser-broiled pear	10	awesome	Last Available: "2007-12"
+3095	toothsome immense laser-broiled pear	10	awesome	Last Available: "2007-12"
 3096	skewed resourceful polyalloy shield of chilblains	0		Maximum MP: +50, Cold Damage: +25, Damage Reduction: 9, Last Available: "2007-12"
 3097	twirling bouncing fish scaler	0		Last Available: "2007-12"
 3098	twirling killing feather	0		Last Available: "2007-12"
@@ -3087,7 +3087,7 @@
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
 3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
-3118	yellow jittery divine noisemaker	0		Last Available: "2008-01"
+3118	jittery yellow divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	mirror divine blowout	0		Last Available: "2008-01"
 3121	shaking ghostly divine champagne popper	0		Last Available: "2008-01"
@@ -3098,7 +3098,7 @@
 3126	hobo nickel	0		
 3127	maroon sandcastle	0		
 3128	marshmallow	0		
-3129	normal special roasted marshmallow	3	good	Effect: "Tea-hee", Effect Duration: 10
+3129	special normal roasted marshmallow	3	good	Effect: "Tea-hee", Effect Duration: 10
 3130	disc	0		Last Available: "2008-01"
 3131	bland half-sized tin cup of mulligan stew	2	decent	
 3132	sinister weightlifter's flamin' bindle	0		Muscle: +15, Spell Damage: +10
@@ -3117,10 +3117,10 @@
 3145	El Vibrato translator	0		
 3146	El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
-3148	green narrow El Vibrato punchcard (129 holes)	0		
+3148	narrow green El Vibrato punchcard (129 holes)	0		
 3149	El Vibrato punchcard (213 holes)	0		
 3150	El Vibrato punchcard (165 holes)	0		
-3151	teal mirror El Vibrato punchcard (142 holes)	0		
+3151	mirror teal El Vibrato punchcard (142 holes)	0		
 3152	bouncing El Vibrato punchcard (216 holes)	0		
 3153	El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
@@ -3135,16 +3135,16 @@
 3163	El Vibrato energy spear	0		
 3164	huge El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	wobbly broken El Vibrato drone	0		
-3166	teal narrow repaired El Vibrato drone	0		
+3166	narrow teal repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	galvanized pulsating seal eyeball	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 24
-3169	half-sized flavorless turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	flavorless half-sized turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	blue ruddy evil paper umbrella	0		Maximum HP Percent: +40
 3173	oxidized tumbling evil vihuela	0		Effect: "Witch Breaded", Effect Duration: 20
 3174	flavorless evil boring spaghetti	3	decent	
-3175	flavorless narrow spinning evil noodles	3	decent	
+3175	flavorless spinning narrow evil noodles	3	decent	
 3176	delicious evil noodles	4	awesome	
 3177	fancy flavorless diet ghostly evil painful penne pasta	1	decent	Effect: "Okee-Dokee Go!", Effect Duration: 20
 3178	decent 3vi1 pr0n m4nic0tti	4	good	
@@ -3196,12 +3196,12 @@
 3224	twirling sewer wad	0		
 3225	drinkable red bottle of sewage schnapps	4	good	
 3226	distilled lousy blinking bottle of Ooze-O	5	decent	
-3227	decent shaking squat C.H.U.M. chum	3	good	
+3227	decent squat shaking C.H.U.M. chum	3	good	
 3228	stale unfortunate dumplings	3	decent	
 3229	teal decaying goldfish liver	0		
 3230	colloidal fuchsia oil of oiliness	0		Effect: "Musky", Effect Duration: 12
 3231	tattered paper crown of the sewer	0		Stench Damage: +25, Familiar Effect: "1xSombrero, cap 15"
-3232	stale super-sized vanilla-frosted king cake	5	decent	Last Available: "2008-03"
+3232	super-sized stale vanilla-frosted king cake	5	decent	Last Available: "2008-03"
 3233	red inflatable duck	0		
 3234	bouncing water wings	0		Wiki Name: "water wings"
 3235	tumbling noodle	0		
@@ -3237,7 +3237,7 @@
 3265	blue bag of Crotchety Pine saplings	0		
 3266	spinning bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
-3268	tarnished huge skewed handful of Crotchety Pine needles	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 51
+3268	tarnished skewed huge handful of Crotchety Pine needles	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 51
 3269	liquefied vacuum-sealed teal lump of Saccharine Maple sap	0		Effect: "Stinking Cloud", Effect Duration: 20
 3270	denatured concentrated handful of Laughing Willow bark	0		Effect: "Red-Shirted Escort", Effect Duration: 32
 3271	purple wicked crotchety pants	0		Spell Damage: +5, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
@@ -3268,7 +3268,7 @@
 3296	unusual disco ball	0		
 3297	stray chihuahua	0		
 3298	pretty pink bow	0		
-3299	huge ghostly smiley-face sticker	0		
+3299	ghostly huge smiley-face sticker	0		
 3300	farfalle bow tie	0		
 3301	jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
@@ -3285,7 +3285,7 @@
 3313	rock-hard marinara jug	0		Damage Reduction: 5, Class: "Sauceror"
 3314	jittery reassuring makeshift castanets	0		Spooky Resistance: +1, Class: "Disco Bandit"
 3315	boxer's left-handed melodica	0		Muscle Percent: +10, Class: "Accordion Thief"
-3316	dried red twirling blinking epic wad	1	crappy	
+3316	dried blinking red twirling epic wad	1	crappy	
 3317	ghostly executive bottlecap	0		Meat Drop: +40, Single Equip
 3318	blurry perfumed corncob pipe	0		Stench Resistance: +5, Single Equip
 3319	family-friendly Mr. Joe's bangles	0		Sleaze Resistance: +1, Single Equip
@@ -3294,9 +3294,9 @@
 3322	mirror mayfly bait necklace of the sweet-tooth of the glutton	0		Candy Drop: +100, Food Drop: +100, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	huge Frosty's frosty mug	0		
-3325	drinkable fortified jar of fermented pickle juice	5	good	
+3325	fortified drinkable jar of fermented pickle juice	5	good	
 3326	distilled voodoo snuff	1	decent	
-3327	snack-sized spoiled extra-greasy slider	2	crappy	
+3327	spoiled snack-sized extra-greasy slider	2	crappy	
 3328	smelly crumpled felt fedora of the detective	0		Stench Spell Damage: +10, Item Drop: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	mansplainer's battered top-hat of the sweet-tooth	0		Monster Level: +15, Candy Drop: +100, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	prompt Newton's shapeless wide-brimmed hat	0		Experience (Mysticality): +3, Adventures: +3, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3318,12 +3318,12 @@
 3346	filth-encrusted futon	0		
 3347	comfy coffin	0		
 3348	mattress	0		
-3349	olive spinning dinged-up triangle	0		
+3349	spinning olive dinged-up triangle	0		
 3350	practically non-alcoholic lousy blurry Ralph IX cognac	1	decent	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	pulsating zen motorcycle	0		Last Available: "2008-06"
 3353	quadruple-enhanced aerosolized llama lama gong	0		Effect: "Haunted Liver", Effect Duration: 13, Last Available: "2008-06"
-3354	snack-sized bland banana-frosted king cake	2	decent	Last Available: "2008-08"
+3354	bland snack-sized banana-frosted king cake	2	decent	Last Available: "2008-08"
 3355	tumbling avaricious brown plastic baby	0		Meat Drop: +30, Single Equip, Last Available: "2008-08"
 3356	fuchsia plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3333,15 +3333,15 @@
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	small tasty red mole mol&eacute;	2	awesome	Last Available: "2008-06"
-3364	distilled mediocre blue pulsating Morlock's Mark Bourbon	5	decent	Last Available: "2008-06"
+3364	distilled mediocre pulsating blue Morlock's Mark Bourbon	5	decent	Last Available: "2008-06"
 3365	ionized vacuum-sealed Climate Colada	0		Effect: "Pisces Rising", Effect Duration: 41, Last Available: "2008-06"
 3366	aerosolized pressed digital underground potion	0		Effect: "Full-Body Tan", Effect Duration: 67, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	denatured jittery glimmering roc feather	1	decent	Last Available: "2008-06"
 3369	dried glimmering phoenix feather	1		Effect: "The Wisdom... of the Future", Effect Duration: 30, Last Available: "2008-06"
-3370	denatured spinning purple glimmering penguin feather	1		Effect: "Healthy Blue Glow", Effect Duration: 35, Last Available: "2008-06"
+3370	denatured purple spinning glimmering penguin feather	1		Effect: "Healthy Blue Glow", Effect Duration: 35, Last Available: "2008-06"
 3371	denatured teal blurry glimmering buzzard feather	1		Last Available: "2008-06"
-3372	mixed fuchsia blurry glimmering raven feather	1		Last Available: "2008-06"
+3372	mixed blurry fuchsia glimmering raven feather	1		Last Available: "2008-06"
 3373	compressed jittery glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3362,12 +3362,12 @@
 3390	greedy greasy brawny Staff of the Deepest Freeze	0		Muscle Percent: +20, Sleaze Spell Damage: +10, Meat Drop: +20
 3391	Frosty's iceball	0		
 3392	spinning hardened Oscus's garbage can lid	0		Damage Reduction: 18
-3393	wobbly skewed Oscus's neverending soda	0		
+3393	skewed wobbly Oscus's neverending soda	0		
 3394	chilly Oscus's flypaper pants of the cougar	0		Moxie: +20, Cold Damage: +5, Familiar Effect: "stench atk, 1xPotato"
 3395	mirror dangerous Hodgman's porkpie hat of Calamity Jane	0		Weapon Damage: +10, Critical Hit Percent: +15, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	gray censurious brawny Hodgman's lobsterskin pants	0		Muscle Percent: +20, Sleaze Resistance: +3, Familiar Effect: "atk, 1xPotato"
 3397	Van der Graaf Hodgman's bow tie of horror	0		Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-3398	delicious special Hodgman's blanket	3	awesome	Effect: "Alchemical, Brother", Effect Duration: 15
+3398	special delicious Hodgman's blanket	3	awesome	Effect: "Alchemical, Brother", Effect Duration: 15
 3399	drinkable triple-distilled jar of squeeze	6	good	
 3400	normal bowl of fishysoisse	4	good	
 3401	dry quadruple-alkaline deadly lampshade	0		Effect: "Chow Downed", Effect Duration: 37
@@ -3383,7 +3383,7 @@
 3411	blurry wobbly hardened Hodgman's cane	0		Damage Reduction: 3
 3412	squat Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
 3413	twirling squat Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
-3414	squat blinking Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
+3414	blinking squat Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	jittery Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
 3421	lime green box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
@@ -3474,7 +3474,7 @@
 3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	lime green experienced scratch 'n' sniff sword	0		Experience: +2, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
-3510	fuchsia squat wobbly scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
+3510	wobbly squat fuchsia scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
@@ -3491,7 +3491,7 @@
 3524	unsweetened deionized skewed eel battery	0		Effect: "Adventurer's Best Friendship", Effect Duration: 65
 3525	quantum extra-irradiated narrow jittery temporary teardrop tattoo	0		Effect: "Crimbo Nostalgia", Effect Duration: 52
 3526	skewed weightlifter's scratch 'n' sniff crossbow	0		Muscle: +15, Last Available: "2008-11"
-3527	skewed pulsating mutant rattlesnake egg	0		
+3527	pulsating skewed mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
 3529	twirling mutant cactus bud	0		
 3530	mutant gila monster egg	0		
@@ -3530,16 +3530,16 @@
 3563	alkaline aerosolized pressurized potion of pulchritude	0		Effect: "Pwnd", Effect Duration: 54
 3564	lousy fancy berry-infused sake	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 35
 3565	lousy enchanted practically non-alcoholic citrus-infused sake	1	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 50
-3566	mediocre special melon-infused sake	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 10
+3566	special mediocre melon-infused sake	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 10
 3567	blinking slab of sponge	0		
 3568	electrified sponge helmet of the ox of the empath	0		Muscle: +20, Familiar Weight: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy"
 3569	asbestos-lined boxer's spongy shield of the ox	0		Muscle: +20, Muscle Percent: +10, Hot Resistance: +5, Damage Reduction: 14
 3570	chilly hardy square sponge pants of doom	0		Maximum HP: +50, Cold Damage: +5, Spooky Spell Damage: +50, Familiar Effect: "hot atk, 1xPotato"
 3571	mirror flytrap pellet	0		
 3572	baby cuddlefish	0		
-3573	wobbly jittery lime green six-armed sweater	0		Familiar Weight: +5
+3573	lime green wobbly jittery six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
-3575	spinning tumbling sand dollar	0		
+3575	tumbling spinning sand dollar	0		
 3576	flytrap bezoar	0		
 3577	bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
@@ -3547,19 +3547,19 @@
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	stale rice	3	decent	
-3584	adequate big irradiated candy cane	5	good	Last Available: "2008-12"
-3585	half-sized special stale upside-down gingerbread mutant bugbear	2	decent	Effect: "Human-Horror Hybrid", Effect Duration: 35, Last Available: "2008-12"
+3584	big adequate irradiated candy cane	5	good	Last Available: "2008-12"
+3585	half-sized stale special upside-down gingerbread mutant bugbear	2	decent	Effect: "Human-Horror Hybrid", Effect Duration: 35, Last Available: "2008-12"
 3586	high-proof perfectly mixed oozenog	7	EPIC	Last Available: "2008-12"
 3587	denatured non-moist sugar plum	0		Effect: "Blessing of Charcoatl", Effect Duration: 49, Last Available: "2008-12"
 3588	improved sugar banana	0		Effect: "Stick Emporium Membership", Effect Duration: 11, Last Available: "2008-12"
-3589	ionized oxidized olive tumbling twirling sugar lime	0		Effect: "Souper Vengeful", Effect Duration: 44, Last Available: "2008-12"
+3589	ionized oxidized twirling tumbling olive sugar lime	0		Effect: "Souper Vengeful", Effect Duration: 44, Last Available: "2008-12"
 3590	activated sugar cherry	0		Effect: "Full of Vinegar", Effect Duration: 66, Last Available: "2008-12"
 3591	Usain Bolt's Mer-kin hookspear of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +80
 3592	squat Mer-kin takebag	0		Item Drop: +5
 3593	Mer-kin thingpouch	0		
 3594	lime green Mer-kin killscroll	0		
 3595	frozen Mer-kin fastjuice	0		Effect: "Tea-hee", Effect Duration: 54
-3596	pulsating blurry imitation crab crate	0		
+3596	blurry pulsating imitation crab crate	0		
 3597	blue imitation crab meat	0		
 3598	teal imitation crab zoea	0		
 3599	huge double-paned educational smooth moist sailor's cap	0		Moxie: +15, Experience: +1, Cold Resistance: +5, Familiar Effect: "stench atk"
@@ -3574,7 +3574,7 @@
 3608	live nautical mine	0		
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	blurry imitation whetstone	0		
-3611	magnetized spinning squat bouncing sea grease	0		Effect: "Extra-Thick Blood", Effect Duration: 61
+3611	magnetized squat bouncing spinning sea grease	0		Effect: "Extra-Thick Blood", Effect Duration: 61
 3612	sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	pulsating battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
@@ -3613,10 +3613,10 @@
 3647	lime green elven whittling knife	0		Last Available: "2008-12"
 3648	wobbly shaking magic dragonfish fry	0		
 3649	twirling map to Madness Reef	0		
-3650	snack-sized flavorless wobbly narrow toast with jam	2	decent	Last Available: "2008-12"
-3651	bouncing antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	flavorless snack-sized wobbly narrow toast with jam	2	decent	Last Available: "2008-12"
+3651	bouncing antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	lousy jittery elven moonshine	3	decent	Last Available: "2008-12"
-3653	fancy bland knuckle sandwich	3	decent	Effect: "Inebriate Pride", Effect Duration: 30, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	bland fancy knuckle sandwich	3	decent	Effect: "Inebriate Pride", Effect Duration: 30, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	rosy-cheeked psycho sweater of temperance	0		Maximum HP Percent: +30, Sleaze Resistance: +5, Last Available: "2008-12"
 3655	wobbly fin-bit wax	0		Familiar Weight: +5
 3656	lard-coated plastic Mob Penguin	0		Sleaze Spell Damage: +25, Last Available: "2008-12"
@@ -3641,21 +3641,21 @@
 3675	skewed Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	greasy diving muff	0		Sleaze Spell Damage: +10, Single Equip
-3678	tolerable distilled twirling salinated mint julep	5	good	
+3678	distilled tolerable twirling salinated mint julep	5	good	
 3679	spinning ink bladder	0		
 3680	huge esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	small decent tempura carrot	2	good	
+3684	decent small tempura carrot	2	good	
 3685	adequate upside-down tempura cucumber	3	good	
 3686	decent huge tempura avocado	8	good	
 3687	snack-sized moldy twirling sea broccoli	2	crappy	
-3688	delicious diet sea cauliflower	1	awesome	
+3688	diet delicious sea cauliflower	1	awesome	
 3689	small normal tempura broccoli	2	good	
 3690	small tasty tempura cauliflower	2	awesome	
 3691	normal fancy wobbly sea blueberry	3	good	Effect: "Strong Grip", Effect Duration: 50
-3692	moldy huge jittery sea persimmon	3	crappy	
+3692	moldy jittery huge sea persimmon	3	crappy	
 3693	nitrogenated irradiated dry pressurized potion of perception	0		Effect: "Material Witness", Effect Duration: 26
 3694	polarized gray pressurized potion of proficiency	0		Effect: "So You Can Work More...", Effect Duration: 32
 3695	Temple Grandin's Mer-kin digpick	0		Familiar Weight: +7
@@ -3705,7 +3705,7 @@
 3739	bouncing Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
-3742	nitrogenated narrow huge jellyfish gel	0		Effect: "Vitamin-Maxed", Effect Duration: 25
+3742	nitrogenated huge narrow jellyfish gel	0		Effect: "Vitamin-Maxed", Effect Duration: 25
 3743	unstable quark	0		
 3744	software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
@@ -3726,17 +3726,17 @@
 3762	spinning Temple Grandin's vampire pearl necklace	0		Familiar Weight: +7, Single Equip
 3763	aged slug of vodka	3	awesome	
 3764	aged lime green slug of rum	3	awesome	
-3765	strong tolerable shaking slug of shochu	5	good	
-3766	perfectly mixed extra-dry tumbling screwdiver	5	EPIC	
+3765	tolerable strong shaking slug of shochu	5	good	
+3766	extra-dry perfectly mixed tumbling screwdiver	5	EPIC	
 3767	mediocre dew yoana lei	3	decent	
 3768	tolerable lychee chuhai	3	good	
 3769	bad narrow salacious screwdiver	3	decent	
-3770	distilled artisanal fancy dew yoana salacious lei	5	EPIC	Effect: "Ode to Booze", Effect Duration: 45
-3771	weak hand-crafted salacious lychee chuhai	2	EPIC	
-3772	irresponsibly strong mediocre enchanted spinning Alewife&trade; Ale	10	decent	Effect: "Just the Brown Ones", Effect Duration: 45
+3770	fancy artisanal distilled dew yoana salacious lei	5	EPIC	Effect: "Ode to Booze", Effect Duration: 45
+3771	hand-crafted weak salacious lychee chuhai	2	EPIC	
+3772	irresponsibly strong enchanted mediocre spinning Alewife&trade; Ale	10	decent	Effect: "Just the Brown Ones", Effect Duration: 45
 3773	huge seaode	0		
 3774	map to the Dive Bar	0		
-3775	wobbly spinning Mer-kin pinkslip	0		
+3775	spinning wobbly Mer-kin pinkslip	0		
 3776	studded beefy pink pinkslip slip	0		Muscle: +10, Damage Absorption: +80, Familiar Effect: "1xVolley, 1xBarrr"
 3777	purple blinking brawny sea salt scrubs of the detective	0		Muscle Percent: +20, Item Drop: +20
 3778	wobbly rosy-cheeked wholesome amber aviator shades of horror	0		Maximum HP Percent: 40, Spooky Spell Damage: +25, Single Equip
@@ -3744,9 +3744,9 @@
 3780	electrified Samson's slick nurse's hat	0		Moxie: +10, Experience (Muscle): +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk"
 3781	blank prescription sheet	0		
 3782	mixed bottle of melodramamine	1		
-3783	compressed blurry bouncing bottle of extra-strength melodramamine	1		
+3783	compressed bouncing blurry bottle of extra-strength melodramamine	1		
 3784	yellow paranormal ricotta	0		Class: "Pastamancer"
-3785	olive squat smoking talon	0		Class: "Pastamancer"
+3785	squat olive smoking talon	0		Class: "Pastamancer"
 3786	ghostly vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
 3788	cyan crumbling rat skull	0		Class: "Pastamancer"
@@ -3780,11 +3780,11 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	gray Grandma's Map	0		
-3829	decent olive narrow tempura radish	4	good	
+3829	decent narrow olive tempura radish	4	good	
 3830	upside-down mirror groovy water-polo cap	0		Moxie Percent: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	weak acceptable Typical Tavern swill	2	good	
 3832	acceptable tropical swill	4	good	
-3833	practically non-alcoholic hand-crafted fruity girl swill	1	super ultra mega turbo EPIC	
+3833	hand-crafted practically non-alcoholic fruity girl swill	1	super ultra mega turbo EPIC	
 3834	smooth blended swill	4	awesome	
 3835	costume wardrobe	0		Softcore Only
 3836	Jeselnik's hale fortified padded Elvish sunglasses	0		Damage Absorption: 80, Maximum HP: +20, Sleaze Damage: +25, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3843,7 +3843,7 @@
 3889	corrupted magnetized twirling twirling vial of slime	0		Effect: "Fortunate Resolve", Effect Duration: 29
 3890	pressed double-diffused vial of violet slime	0		Effect: "Strong Grip", Effect Duration: 25
 3891	denatured nitrogenated vial of vermilion slime	0		Effect: "Red Door Syndrome", Effect Duration: 28
-3892	enhanced ghostly huge vial of amber slime	0		Effect: "Hyphemariffic", Effect Duration: 29
+3892	enhanced huge ghostly vial of amber slime	0		Effect: "Hyphemariffic", Effect Duration: 29
 3893	denatured narrow vial of chartreuse slime	0		Effect: "Snobby", Effect Duration: 41
 3894	Vulcanized vial of teal slime	0		Effect: "Fudgehound", Effect Duration: 38
 3895	energized quantum vial of indigo slime	0		Effect: "Mana Tea", Effect Duration: 42
@@ -3855,7 +3855,7 @@
 3903	figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	fuchsia figurine of an seal	0		Class: "Seal Clubber"
-3906	ghostly huge figurine of a sleek seal	0		Class: "Seal Clubber"
+3906	huge ghostly figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
@@ -3876,7 +3876,7 @@
 3924	double-paned grievous spiky turtle helmet	0		Weapon Damage Percent: +50, Cold Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 32"
 3925	stanky spiky turtle shoulderpads	0		Stench Spell Damage: +25, Single Equip
 3926	green lion tamer's padded spiky turtle shield	0		Damage Absorption: +20, Experience (familiar): +2, Damage Reduction: 8
-3927	spinning bouncing turtling rod	0		Class: "Turtle Tamer"
+3927	bouncing spinning turtling rod	0		Class: "Turtle Tamer"
 3928	fuchsia syncopated turtle	0		
 3929	grinning turtle	0		
 3930	modified quantum tainted seal's blood	0		Effect: "Stop the Presses!", Effect Duration: 63
@@ -3945,7 +3945,7 @@
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
 3995	blue bundle of chamoix	0		
-3996	lime green pulsating tumbling boxcar turtle	0		
+3996	tumbling lime green pulsating boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	olive metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
@@ -3986,15 +3986,15 @@
 4034	shaking memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	squat caustic slime nodule	0		
-4037	immense toothsome squat slimy sweetbreads	8	awesome	
+4037	toothsome immense squat slimy sweetbreads	8	awesome	
 4038	bad slimy fermented bile bladder	3	decent	
 4039	boiled narrow mirror slimy alveolus	1		Effect: "Jittery", Effect Duration: 25
-4040	skewed fuchsia memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
+4040	fuchsia skewed memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	tumbling pulsating Lo Pan's pig-iron helm of the blizzard	0		Spell Critical Percent: +30, Cold Spell Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
 4042	steel-toed padded pig-iron shinguards	0		Damage Absorption: +20, Damage Reduction: 9, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	executive nippy pig-iron bracers	0		Cold Damage: +10, Meat Drop: +40, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
-4045	bouncing tumbling wumpus-hair bolo	0		Last Available: "2009-06"
+4045	tumbling bouncing wumpus-hair bolo	0		Last Available: "2009-06"
 4046	huge wumpus-hair net	0		Last Available: "2009-06"
 4047	twirling wumpus-hair whip of the dark arts	0		Spell Damage Percent: +100, Last Available: "2009-06"
 4048	MacGyver's Da Vinci's wumpus-hair wig of chilblains	0		Experience (Mysticality): +5, Maximum MP: +100, Cold Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	mirror sage ring of teleportation	0		Mysticality Percent: +10, Single Equip
 4052	red glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	special banana milkshake	1	crappy	Effect: "Marco Polarity", Effect Duration: 45, Last Available: "2009-06"
-4054	tolerable spirit-forward blue White Hyborian	5	good	Last Available: "2009-06"
+4054	spirit-forward tolerable blue White Hyborian	5	good	Last Available: "2009-06"
 4055	forbidden goblin hunting spear	0		Spell Damage Percent: +50, Last Available: "2009-06"
 4056	maroon hale goblin autoblowgun of the blizzard	0		Maximum HP: +20, Cold Spell Damage: +25, Last Available: "2009-06"
 4057	weightlifter's tribal beads	0		Muscle: +15, Last Available: "2009-06"
@@ -4011,7 +4011,7 @@
 4059	stiffened stone head	0		Damage Reduction: 6, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	bouncing Violet Hunt Invitation	0		Last Available: "2009-06"
-4062	huge wobbly lime green Blue Milk Club Card	0		Last Available: "2009-06"
+4062	lime green huge wobbly Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	wobbly Spacefleet Communicator Badge	0		Last Available: "2009-06"
@@ -4110,7 +4110,7 @@
 4158	mirror rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	lousy pebblebr&auml;u	4	decent	Last Available: "2009-09"
-4161	snack-sized yummy pulsating rocky road ice cream	2	awesome	Last Available: "2009-09"
+4161	yummy snack-sized pulsating rocky road ice cream	2	awesome	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	boiled children of the candy corn	0		Effect: "Can Has Cyborger", Effect Duration: 64
 4164	triple-corrupted boiled chilled Good 'n' Slimy	0		Effect: "[800]Chocolate Reign", Effect Duration: 44
@@ -4173,7 +4173,7 @@
 4221	ghostly lime green electrified yield shield	0		MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
-4224	yellow spinning narrow unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
+4224	yellow narrow spinning unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	bouncing roller skate doll	0		
 4226	Annie Oakley's Star of Bravery	0		Critical Hit Percent: +20, Single Equip
 4227	blinking hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
@@ -4209,7 +4209,7 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	stale chocolate-covered scarab beetle	4	decent	Last Available: "2009-10"
 4259	aged strong purple mulled cider	5	awesome	Last Available: "2009-10"
-4260	squat yellow wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	yellow squat wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	twirling pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	teal Ax of L'rose	0		Last Available: "2009-10"
@@ -4229,7 +4229,7 @@
 4277	skewed Tesla resourceful dance instructor's Staff of the Woodfire	0		Experience Percent (Moxie): +10, Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-10"
 4278	red flame-wreathed Annie Oakley's thinker's Underworld flail	0		Mysticality: +10, Critical Hit Percent: +20, Hot Spell Damage: +10, Last Available: "2009-10"
 4279	Mer-kin cancerstick	0		
-4280	ghostly huge Mer-kin sawdust	0		
+4280	huge ghostly Mer-kin sawdust	0		
 4281	greedy family-friendly Mer-kin bunwig	0		Sleaze Resistance: +1, Meat Drop: +20, Familiar Effect: "1xVolley"
 4282	upside-down perfumed crappy Mer-kin mask of wisdom of the overflowing toilet	0		Mysticality: +15, Stench Spell Damage: +50, Stench Resistance: +5, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
 4283	ghostly red greasy resourceful crappy Mer-kin tailpiece	0		Maximum MP: +50, Sleaze Spell Damage: +10, Familiar Effect: "1xBarrr, 1xFairy"
@@ -4309,13 +4309,13 @@
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	small moldy fancy jittery twirling expired can of franks 'n' beans	2	crappy	Effect: "Gonna Get You, Sucker", Effect Duration: 20, Last Available: "2009-12"
+4360	small fancy moldy twirling jittery expired can of franks 'n' beans	2	crappy	Effect: "Gonna Get You, Sucker", Effect Duration: 20, Last Available: "2009-12"
 4361	weak delicious blinking expired bottle of peppermint schnapps	2	awesome	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	double-boiled super-polymerized frozen elven suicide capsule	0		Effect: "Neuroplastici Tea", Effect Duration: 63, Last Available: "2009-12"
 4365	diet flavorless penguin focaccia bread	1	decent	Last Available: "2009-12"
-4366	strong hand-crafted herringcello	5	EPIC	Last Available: "2009-12"
+4366	hand-crafted strong herringcello	5	EPIC	Last Available: "2009-12"
 4367	smooth distilled lime green elven cellocello	5	awesome	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
@@ -4373,7 +4373,7 @@
 4422	lion tamer's sealhide belt	0		Experience (familiar): +2
 4423	skewed sealhide snare	0		
 4424	puzzling trophy	0		
-4425	denatured chilled narrow blurry sealhide seal doll	0		Effect: "Dreadful Sheen", Effect Duration: 20
+4425	denatured chilled blurry narrow sealhide seal doll	0		Effect: "Dreadful Sheen", Effect Duration: 20
 4426	hymnal	0		Skill: "Canticle of Carboloading"
 4428	jittery greasy glowstick on a string	0		Sleaze Spell Damage: +10
 4429	shellacked candy necklace	0		Damage Reduction: 7, Single Equip
@@ -4409,9 +4409,9 @@
 4461	dry double-boiled seal-brain elixir	0		Effect: "Whippin' It Good", Effect Duration: 37
 4462	triple-oxidized chocolate seal-clubbing club	0		Effect: "Cold as Ice", Effect Duration: 39
 4463	boiled chocolate turtle totem	0		Effect: "Squid Squint", Effect Duration: 14
-4464	extra-electrified alkaline polymerized fuchsia spinning chocolate pasta spoon	0		Effect: "Spooky Weapon", Effect Duration: 24
+4464	extra-electrified alkaline polymerized spinning fuchsia chocolate pasta spoon	0		Effect: "Spooky Weapon", Effect Duration: 24
 4465	non-ionized purple tumbling chocolate saucepan	0		Effect: "Compensatory Cruelness", Effect Duration: 36
-4466	diffused improved wobbly olive chocolate disco ball	0		Effect: "Briny Blood", Effect Duration: 55
+4466	diffused improved olive wobbly chocolate disco ball	0		Effect: "Briny Blood", Effect Duration: 55
 4467	polarized triple-warmed chocolate stolen accordion	0		Effect: "Partially Ghosted", Effect Duration: 60
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	jittery BRICKO brick	0		Last Available: "2010-02"
@@ -4439,7 +4439,7 @@
 4491	bouncing BRICKO brick	0		Last Available: "2010-02"
 4492	twirling BRICKO brick	0		Last Available: "2010-02"
 4493	blinking broken BRICKO brick	0		Last Available: "2010-02"
-4494	gray upside-down BRICKO reactor	0		Last Available: "2010-02"
+4494	upside-down gray BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	extra-tarnished recording of The Ballad of Richie Thingfinder	0		Effect: "The Smeezingtons", Effect Duration: 49
@@ -4450,19 +4450,19 @@
 4502	flattened pulsating recording of Donho's Bubbly Ballad	0		Effect: "Ice Packed", Effect Duration: 41
 4503	dry mirror recording of Inigo's Incantation of Inspiration	0		Effect: "Icy Composition", Effect Duration: 24, Last Available: "2010-02"
 4504	censurious heart of the volcano of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +3
-4505	liquefied anodized lime green twirling Northern pemmican	0		Effect: "Boon of She-Who-Was", Effect Duration: 29
+4505	liquefied anodized twirling lime green Northern pemmican	0		Effect: "Boon of She-Who-Was", Effect Duration: 29
 4506	twirling puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	tarnished anodized fuchsia ghostly &quot;DRINK ME&quot; potion	0		Effect: "Ooh, Bitter!", Effect Duration: 17, Last Available: "2010-03"
+4508	tarnished anodized ghostly fuchsia &quot;DRINK ME&quot; potion	0		Effect: "Ooh, Bitter!", Effect Duration: 17, Last Available: "2010-03"
 4509	blinking green reflection of a map	0		Last Available: "2010-03"
 4510	spoiled pulsating walrus ice cream	3	crappy	Last Available: "2010-03"
 4511	rotten beautiful soup	3	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	huge Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	fancy massive decent mirror Humpty Dumplings	7	good	Effect: "Can Has Cyborger", Effect Duration: 5, Last Available: "2010-03"
-4515	decent fancy jittery upside-down Lobster <i>qua</i> Grill	4	good	Effect: "Using Protection", Effect Duration: 10, Last Available: "2010-03"
+4514	decent massive fancy mirror Humpty Dumplings	7	good	Effect: "Can Has Cyborger", Effect Duration: 5, Last Available: "2010-03"
+4515	decent fancy upside-down jittery Lobster <i>qua</i> Grill	4	good	Effect: "Using Protection", Effect Duration: 10, Last Available: "2010-03"
 4516	special tolerable missing wine	3	good	Effect: "Bark of the Dog", Effect Duration: 35, Last Available: "2010-03"
-4517	immense stale enchanted jittery matter custard	7	decent	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40, Last Available: "2010-03"
+4517	immense enchanted stale jittery matter custard	7	decent	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40, Last Available: "2010-03"
 4518	triple-moist comfit?	0		Effect: "Dirge of Dreadfulness", Effect Duration: 49, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	MacGyver's groovy flamingo mallet	0		Moxie Percent: +10, Maximum MP: +100, Last Available: "2010-03"
@@ -4477,11 +4477,11 @@
 4529	rosewater-soaked snapdragon pistil of Leguizamo	0		Monster Level: +20, Stench Resistance: +3, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	moldy rook cookie	3	crappy	Last Available: "2010-03"
-4532	low-calorie delicious mirror bishop cookie	1	awesome	Last Available: "2010-03"
+4532	delicious low-calorie mirror bishop cookie	1	awesome	Last Available: "2010-03"
 4533	miniature stale knight cookie	2	decent	Last Available: "2010-03"
 4534	spoiled fancy king cookie	4	crappy	Effect: "Amplified Fabulousness", Effect Duration: 15, Last Available: "2010-03"
 4535	enchanted yummy queen cookie	4	awesome	Effect: "Towering Strength", Effect Duration: 30, Last Available: "2010-03"
-4536	twirling blinking yellow fairy-worn boots	0		Free Pull, Last Available: "2011-08"
+4536	blinking twirling yellow fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	insane tophat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
 4538	ribald helm of the knight of the wise owl	0		Mysticality: +20, Sleaze Damage: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	censurious wristwatch of the knight of the cougar	0		Moxie: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2010-03"
@@ -4503,20 +4503,20 @@
 4555	left bracket	0		
 4556	right parenthesis	0		
 4557	dollar sign	0		
-4558	wobbly jittery equal sign	0		
+4558	jittery wobbly equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	upside-down can of depilatory cream	0		Last Available: "2010-04"
 4562	blinking upside-down hair of the calf	0		Last Available: "2010-04"
-4563	enchanted drinkable world's most unappetizing beverage	3	good	Effect: "Like a Fish to Walter", Effect Duration: 35, Last Available: "2010-04"
+4563	drinkable enchanted world's most unappetizing beverage	3	good	Effect: "Like a Fish to Walter", Effect Duration: 35, Last Available: "2010-04"
 4564	beefcake's slippery when wet shield	0		Muscle: +25, Damage Reduction: 6, Last Available: "2010-04"
 4565	enchanted toothsome gray raisin	3	awesome	Effect: "Sleaze-Resistant Trousers", Effect Duration: 20, Last Available: "2010-04"
-4566	squat maroon fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
+4566	maroon squat fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	ghostly supercool weightlifter's flyest of shirts	0		Muscle: +15, Moxie Percent: +20, Last Available: "2010-04"
 4568	stale a dance upon the palate	4	decent	Last Available: "2010-04"
-4569	adequate miniature upside-down maroon prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
+4569	adequate miniature maroon upside-down prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	flavorless super-sized squirmy violent party snack	5	decent	Last Available: "2010-04"
+4571	super-sized flavorless squirmy violent party snack	5	decent	Last Available: "2010-04"
 4572	frightening can-you-dig-it?	0		Spooky Damage: +5, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4529,7 +4529,7 @@
 4581	blurry Sherlock's gravedigger's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Spooky Damage: +10, Item Drop: +25, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	blurry glob of skin	0		
-4584	miniature moldy six wedges of goat cheese	2	crappy	
+4584	moldy miniature six wedges of goat cheese	2	crappy	
 4585	upside-down collection of objects	0		
 4586	twirling boulder	0		
 4587	olive goth	0		
@@ -4546,13 +4546,13 @@
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	practically non-alcoholic mediocre enchanted wobbly plastic cup of beer	1	decent	Effect: "Broken Bone Nubs", Effect Duration: 45, Last Available: "2010-06"
+4601	mediocre enchanted practically non-alcoholic wobbly plastic cup of beer	1	decent	Effect: "Broken Bone Nubs", Effect Duration: 45, Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	shaking keg	0		Last Available: "2010-06"
 4605	Newton's bottle of Goldschn&ouml;ckered of bravery	0		Experience (Mysticality): +3, Spooky Resistance: +5, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	half-sized decent sun-dried tofu	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	artisanal watered-down olive narrow soyburger juice	2	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	decent half-sized sun-dried tofu	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	watered-down artisanal narrow olive soyburger juice	2	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	squat respected companion biscuit	0		Last Available: "2010-08"
 4609	upside-down essential tofu	0		Last Available: "2010-08"
 4610	vacuum-sealed frozen essential soy	0		Effect: "Cold Jellied", Effect Duration: 15, Last Available: "2010-08"
@@ -4603,7 +4603,7 @@
 4655	fuchsia lightning-fast wool ironic jogging shorts of doom	0		Spooky Spell Damage: +50, Cold Resistance: +1, Initiative: +40, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	frightening mole skin notebook	0		Spooky Damage: +5
 4657	pair of jeans	0		Last Available: "2010-09"
-4658	shaking lime green map to Ellsbury's Claim	0		Last Available: "2010-09"
+4658	lime green shaking map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	lime green tumbling blackberry galoshes of the cheetah	0		Initiative: +60, Single Equip
 4660	nippy electrified trout fang	0		Cold Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-09"
 4661	adequate poisonous caviar	3	good	Last Available: "2010-09"
@@ -4617,7 +4617,7 @@
 4669	jittery Newton's hilarious comedy prop	0		Experience (Mysticality): +3
 4670	blinking beer-scented teddy bear	0		
 4671	drinkable blurry booze-soaked cherry	4	good	
-4672	shaking gray comfy pillow	0		
+4672	gray shaking comfy pillow	0		
 4673	normal marshmallow	3	good	
 4674	decent sponge cake	3	good	
 4675	mediocre practically non-alcoholic skewed gin-soaked blotter paper	1	decent	
@@ -4635,7 +4635,7 @@
 4687	fossilized bat skull	0		Last Available: "2010-09"
 4688	fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
-4690	olive upside-down fossilized wyrm skull	0		Last Available: "2010-09"
+4690	upside-down olive fossilized wyrm skull	0		Last Available: "2010-09"
 4691	skewed fossilized wing	0		Last Available: "2010-09"
 4692	olive fossilized limb	0		Last Available: "2010-09"
 4693	bouncing fossilized torso	0		Last Available: "2010-09"
@@ -4659,9 +4659,9 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	blinking narrow GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	yummy diet shaking lemon popsicle	1	awesome	
+4714	diet yummy shaking lemon popsicle	1	awesome	
 4715	tasty popsicle	4	awesome	
-4716	thick special moldy strawberry popsicle	5	crappy	Effect: "init.enh", Effect Duration: 50
+4716	thick moldy special strawberry popsicle	5	crappy	Effect: "init.enh", Effect Duration: 50
 4717	low-calorie yummy spinning liver popsicle	1	awesome	
 4718	shaking sinister mariachi hat	0		Spell Damage: +10, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of the pedagogue	0		Experience: +3, Familiar Effect: "atk, cap 2"
@@ -4677,7 +4677,7 @@
 4729	stale throbbing organ pie	4	decent	Last Available: "2010-10"
 4730	stop shield of the glutton	0		Food Drop: +100, Damage Reduction: 6, Last Available: "2009-12"
 4731	lime green nest egg	0		
-4732	twirling green sleeping piano cat	0		Free Pull, Last Available: "2011-12"
+4732	green twirling sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	spinning kitty sheet music	0		Familiar Weight: +5
 4734	rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	prop sword	0		Familiar Weight: +5
@@ -4685,14 +4685,14 @@
 4737	beer-soaked mop of wisdom	0		Mysticality: +15
 4738	aged mirror day-old beer	4	awesome	
 4739	drinkable plain beer	3	good	
-4740	perfectly mixed extra-dry overpriced &quot;imported&quot; beer	5	EPIC	
+4740	extra-dry perfectly mixed overpriced &quot;imported&quot; beer	5	EPIC	
 4741	smiling rat	0		
 4742	wobbly rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	frozen adjusted improved PlexiPips	0		Effect: "Ancestral Disapproval", Effect Duration: 21
 4745	polymerized diffused triple-dry Wax Flask	0		Effect: "Held Closer", Effect Duration: 16
 4746	improved ionized chilled Pain Dip	0		Effect: "Butt-Rock Hair", Effect Duration: 42
-4747	flavorless upside-down twirling bone meal	3	decent	Last Available: "2010-10"
+4747	flavorless twirling upside-down bone meal	3	decent	Last Available: "2010-10"
 4748	practically non-alcoholic acceptable yellow bone aperitif	1	good	Last Available: "2010-10"
 4749	extremely unsafe bonerang	0		Weapon Damage Percent: +100, Last Available: "2010-10"
 4750	weightlifter's bone and arrows	0		Muscle: +15, Last Available: "2010-10"
@@ -4702,13 +4702,13 @@
 4754	gray ghostly bonedanna of the boozehound of the glutton	0		Booze Drop: +100, Food Drop: +100, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
 4755	family-friendly boneana hammock of courage	0		Spooky Resistance: +3, Sleaze Resistance: +1, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	twirling bag of bones	0		Last Available: "2010-10"
-4757	tumbling skewed narrow Stabonic scroll	0		Last Available: "2010-10"
+4757	skewed tumbling narrow Stabonic scroll	0		Last Available: "2010-10"
 4758	alkaline warmed skewed green candy skeleton	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 35, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	moldy snack-sized fancy mirror pumpkin pie	2	crappy	Effect: "Soles of Glass", Effect Duration: 50, Last Available: "2010-11"
+4763	fancy snack-sized moldy mirror pumpkin pie	2	crappy	Effect: "Soles of Glass", Effect Duration: 50, Last Available: "2010-11"
 4764	drinkable green pumpkin beer	3	good	Last Available: "2010-11"
 4765	polarized twirling pumpkin juice	0		Effect: "Thunderspell", Effect Duration: 22, Last Available: "2010-11"
 4766	upside-down pumpkin bomb	0		Last Available: "2010-11"
@@ -4727,7 +4727,7 @@
 4818	toothsome CRIMBCOIDS mints	3	awesome	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	adequate fuchsia CRIMBCOLOAF	3	good	Last Available: "2011-01"
-4821	miniature adequate upside-down circular CRIMBCOOKIE	2	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	adequate miniature upside-down circular CRIMBCOOKIE	2	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	blinking flame-wreathed plastic CRIMBCO HQ	0		Hot Spell Damage: +10, Last Available: "2010-12"
 4823	blinking lightning-fast plastic fax machine	0		Initiative: +40, Last Available: "2010-12"
 4824	narrow coward's plastic hobo elf	0		Monster Level: -20, Last Available: "2010-12"
@@ -4746,7 +4746,7 @@
 4837	mirror robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	jittery pulsating robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	toothsome big triangular CRIMBCOOKIE	5	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	bite-sized rotten square CRIMBCOOKIE	1	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	rotten bite-sized square CRIMBCOOKIE	1	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	scandalous shellacked bindlestocking of James Dean	0		Experience (Moxie): +3, Damage Reduction: 7, Sleaze Damage: +5, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	wobbly upside-down Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4759,8 +4759,8 @@
 4850	Tesla Rosewater's Uncle Hobo's belt	0		Mysticality Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2010-12"
 4851	triple-electrified Vulcanized chocolate cigar	0		Effect: "Human-Machine Hybrid", Effect Duration: 15, Last Available: "2010-12"
 4852	healthy gift-a-pult	0		Maximum HP Percent: +20, Last Available: "2010-12"
-4853	flattened oxidized ghostly jittery holly-flavored Hob-O	0		Effect: "Shawarma Warm War", Effect Duration: 42, Last Available: "2020-09"
-4854	pulsating blurry CRIMBCO scrip	0		Last Available: "2011-01"
+4853	flattened oxidized jittery ghostly holly-flavored Hob-O	0		Effect: "Shawarma Warm War", Effect Duration: 42, Last Available: "2020-09"
+4854	blurry pulsating CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	blurry paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
@@ -4771,7 +4771,7 @@
 4862	shaking CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	jittery photocopier	0		Last Available: "2011-01"
-4865	tumbling blue deluxe fax machine	0		Last Available: "2011-01"
+4865	blue tumbling deluxe fax machine	0		Last Available: "2011-01"
 4866	blurry Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	beefcake's paperclip-on tie of the overflowing toilet of mayonnaise	0		Muscle: +25, Stench Spell Damage: +50, Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-01"
@@ -4792,16 +4792,16 @@
 4883	ghostly toe jam	0		Last Available: "2011-01"
 4884	stale massive toe jam toast	8	decent	Last Available: "2011-01"
 4885	yellow traffic jam	0		Last Available: "2011-01"
-4886	miniature decent olive traffic jam toast	2	good	Last Available: "2011-01"
+4886	decent miniature olive traffic jam toast	2	good	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	stale narrow lime green tumbling space jam toast	3	decent	Last Available: "2011-01"
-4889	non-pickled extra-modified huge mirror motivational poster	0		Effect: "Elbow Sauce", Effect Duration: 42, Last Available: "2011-01"
+4889	non-pickled extra-modified mirror huge motivational poster	0		Effect: "Elbow Sauce", Effect Duration: 42, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	skewed bath ball gift set	0		Last Available: "2011-01"
 4892	upside-down slow jam collection	0		Last Available: "2011-01"
 4893	huge BGE shotglass	0		Last Available: "2010-12"
 4894	bland big festive sausage	5	decent	Last Available: "2011-01"
-4895	half-sized adequate holiday cheese log	2	good	Last Available: "2011-01"
+4895	adequate half-sized holiday cheese log	2	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	fortified BGE 'ferocious fruit' shirt of wisdom	0		Mysticality: +15, Damage Absorption: +60, Last Available: "2010-12"
 4898	vibrating strapping BGE 'cuddly critter' shirt	0		Muscle: +5, Maximum MP Percent: +10, Last Available: "2010-12"
@@ -4811,7 +4811,7 @@
 4902	resourceful stapler bear	0		Maximum MP: +50, Last Available: "2010-12"
 4903	blue Lo Pan's adhesive tape dolly	0		Spell Critical Percent: +30, Last Available: "2010-12"
 4904	cool scissor duck	0		Moxie: +5, Last Available: "2010-12"
-4905	huge lime green coal paperweight	0		Last Available: "2010-12"
+4905	lime green huge coal paperweight	0		Last Available: "2010-12"
 4906	ghostly jingle bell	0		Last Available: "2010-12"
 4907	gravedigger's Seven Loco	0		Spooky Damage: +10, Item Drop: +5, Last Available: "2010-09"
 4908	Loathing Legion knife	0		Last Available: "2011-01"
@@ -4855,13 +4855,13 @@
 4952	non-energized baggie of sugar	0		Effect: "Brother Corsican's Blessing", Effect Duration: 57
 4953	frosty whalebone corset of the ox	0		Muscle: +20, Cold Spell Damage: +10, Single Equip
 4954	Socratic oven mitts	0		Experience (Mysticality): +1, Single Equip
-4955	bland huge special overcookie	10	decent	Effect: "Icy Demeanor", Effect Duration: 45
+4955	special bland huge overcookie	10	decent	Effect: "Icy Demeanor", Effect Duration: 45
 4956	moldy philosopher's scone	3	crappy	
 4957	warmed moist pulsating half-baked potion	0		Effect: "Slimily Speedy", Effect Duration: 40
 4958	wicked Knob Goblin deluxe scimitar	0		Spell Damage: +5
 4959	tasty Knob nuts	3	awesome	
-4960	tolerable weak Cobb's Knob Wurstbrau	2	good	
-4961	mirror tumbling Subject 37 file	0		
+4960	weak tolerable Cobb's Knob Wurstbrau	2	good	
+4961	tumbling mirror Subject 37 file	0		
 4962	Samson's mysterious lapel pin of the sweet-tooth	0		Experience (Muscle): +5, Candy Drop: +100, Single Equip
 4963	ghostly state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
@@ -4914,7 +4914,7 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	flavorless shaking wasabi pocky	3	decent	Last Available: "2011-03"
-5014	moldy bite-sized mirror tobiko pocky	1	crappy	Last Available: "2011-03"
+5014	bite-sized moldy mirror tobiko pocky	1	crappy	Last Available: "2011-03"
 5015	yummy wobbly natto pocky	4	awesome	Last Available: "2011-03"
 5016	perfectly mixed wasabi-infused sake	4	EPIC	Last Available: "2011-03"
 5017	bad narrow tobiko-infused sake	4	decent	Last Available: "2011-03"
@@ -4924,7 +4924,7 @@
 5021	dry natto marble soda	0		Effect: "Black Lung", Effect Duration: 13, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	improved polymerized deionized jittery elderly jawbreaker	0		Effect: "Shamboozled", Effect Duration: 22, Last Available: "2020-09"
-5024	tolerable practically non-alcoholic marshmallow flamb&eacute;	1	good	Last Available: "2011-03"
+5024	practically non-alcoholic tolerable marshmallow flamb&eacute;	1	good	Last Available: "2011-03"
 5025	perfectly mixed practically non-alcoholic pulsating cranberry schnapps	1	super ultra mega turbo EPIC	Last Available: "2011-03"
 5026	drinkable lime green breaded beer	4	good	Last Available: "2011-03"
 5027	lousy soy cordial	4	decent	Last Available: "2011-03"
@@ -4944,7 +4944,7 @@
 5041	auspicious hale astral shirt of the businessman	0		Maximum HP: +20, Item Drop: +10, Meat Drop: +50
 5042	green forbidden astral belt of the pedagogue	0		Experience: +3, Spell Damage Percent: +50
 5043	special immense decent gray astral hot dog	8		Effect: "Sugar High", Effect Duration: 5
-5044	practically non-alcoholic drinkable teal blinking astral pilsner	1		
+5044	drinkable practically non-alcoholic teal blinking astral pilsner	1		
 5045	jittery astral hot dog dinner	0		
 5046	mirror astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4967,13 +4967,13 @@
 5064	mirror Salsa de las Epocas	0		Last Available: "2011-04"
 5065	stale spaghetti con calaveras	4	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	immense stale popcorn	7	decent	Last Available: "2011-04"
-5068	decent snack-sized chaos popcorn	2	good	Last Available: "2011-04"
+5067	stale immense popcorn	7	decent	Last Available: "2011-04"
+5068	snack-sized decent chaos popcorn	2	good	Last Available: "2011-04"
 5069	nippy steel-toed beefcake's hole	0		Muscle: +25, Damage Reduction: 9, Cold Damage: +10, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	bland s'more	0	decent	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	boozy bad Russian Ice	5	decent	Last Available: "2011-04"
+5073	bad boozy Russian Ice	5	decent	Last Available: "2011-04"
 5074	flame-wreathed clay ashtray	0		Hot Spell Damage: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	spinning perfumed lanyard	0		Stench Resistance: +5, Single Equip, Last Available: "2011-05"
 5076	narrow hardy monster pants	0		Maximum HP: +50, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
@@ -5020,7 +5020,7 @@
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	pulsating bird brain	0		
 5119	busted wings	0		
-5120	jittery gray Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
+5120	gray jittery Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	green auspicious veiny wizardly Admiral's hat	0		Mysticality: +25, Maximum HP: +10, Item Drop: +10, Familiar Effect: "atk", Last Available: "2011-05"
 5122	gravedigger's friendly sinister aviator's cap	0		Spell Damage: +10, Familiar Weight: +3, Spooky Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	mirror pulsating blinking prompt Tesla mirrored aviator shades	0		Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-05"
@@ -5043,9 +5043,9 @@
 5140	modified twirling astral energy drink	1		
 5141	lime green Thwaitgold bee statuette	0		
 5142	mirror squat moon unit	0		Last Available: "2011-06"
-5143	squat cyan shaking E.M.U. Unit	0		Last Available: "2011-06"
+5143	cyan squat shaking E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
-5145	double-altered flattened denatured shaking jittery honeypot	0		Effect: "Pisces in the Skyces", Effect Duration: 38
+5145	double-altered flattened denatured jittery shaking honeypot	0		Effect: "Pisces in the Skyces", Effect Duration: 38
 5146	stale thick ghostly wild honey pie	5	decent	
 5147	bad special honey mead	4	decent	Effect: "Whole Latte Love", Effect Duration: 20
 5148	steel-toed honey dipper of vim and vigor of the overflowing toilet	0		Damage Reduction: 9, Maximum HP Percent: +50, Stench Spell Damage: +50
@@ -5077,10 +5077,10 @@
 5174	extra-dry drinkable Saison du Lune	5	good	Last Available: "2011-06"
 5175	drinkable Moonthril Schnapps	3	good	Last Available: "2011-06"
 5176	mediocre jittery Wrecked Generator	4	decent	Last Available: "2011-06"
-5177	flavorless half-sized Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
+5177	half-sized flavorless Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
 5178	rotten half-sized shaking bouncing Crepes a la Lune	2	crappy	Last Available: "2011-06"
 5179	bland Moon Pie	3	decent	Last Available: "2011-06"
-5180	liquefied warmed blinking blurry Comet Pop	0		Effect: "Holiday Bliss", Effect Duration: 52, Last Available: "2011-06"
+5180	liquefied warmed blurry blinking Comet Pop	0		Effect: "Holiday Bliss", Effect Duration: 52, Last Available: "2011-06"
 5181	unsweetened Flan in the Moon	0		Effect: "Drenched With Filth", Effect Duration: 29, Last Available: "2011-06"
 5182	polymerized moist 1/6th Pound Cake	0		Effect: "Can't Smell Nothin'", Effect Duration: 41, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5110,13 +5110,13 @@
 5207	distilled red indescribably horrible paste	1	decent	Last Available: "2011-08"
 5208	vaporized teal paste	1	decent	Effect: "Physicali Tea", Effect Duration: 45, Last Available: "2011-08"
 5209	boiled shaking goblin paste	1	crappy	Effect: "Amorous Avarice", Effect Duration: 45, Last Available: "2011-08"
-5210	vaporized gray squat pirate paste	1	decent	Last Available: "2011-08"
+5210	vaporized squat gray pirate paste	1	decent	Last Available: "2011-08"
 5211	compressed chlorophyll paste	1	good	Last Available: "2011-08"
 5212	modified spinning paste	1	EPIC	Effect: "Ichorous Eyesight", Effect Duration: 45, Last Available: "2011-08"
 5213	modified bouncing Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	mixed teal slimy paste	1	crappy	Effect: "Kernel Panic!", Effect Duration: 50, Last Available: "2011-08"
 5215	compressed narrow blurry penguin paste	1	good	Effect: "Jawin'", Effect Duration: 15, Last Available: "2011-08"
-5216	compressed teal blurry elemental paste	1	crappy	Last Available: "2011-08"
+5216	compressed blurry teal elemental paste	1	crappy	Last Available: "2011-08"
 5217	twisted red ghostly cosmic paste	1	decent	Last Available: "2011-08"
 5218	compressed hobo paste	1	crappy	Effect: "Healthy Green Glow", Effect Duration: 45, Last Available: "2011-08"
 5219	vaporized squat Crimbo paste	1	decent	Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	yellow Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	adequate immense ghostly green Ur-Donut	9	good	Last Available: "2011-09"
+5224	immense adequate green ghostly Ur-Donut	9	good	Last Available: "2011-09"
 5225	lime green The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	artisanal bucket of wine	3	EPIC	Last Available: "2011-09"
@@ -5141,11 +5141,11 @@
 5238	delicious huge Lumineux Limnio	4	awesome	Last Available: "2011-09"
 5239	smooth Morto Moreto	4	awesome	Last Available: "2011-09"
 5240	perfectly mixed watered-down Temps Tempranillo	2	EPIC	Last Available: "2011-09"
-5241	mediocre fancy Bordeaux Marteaux	3	decent	Effect: "Sugar Smacks", Effect Duration: 10, Last Available: "2011-09"
+5241	fancy mediocre Bordeaux Marteaux	3	decent	Effect: "Sugar Smacks", Effect Duration: 10, Last Available: "2011-09"
 5242	weak smooth Fromage Pinotage	2	awesome	Last Available: "2011-09"
 5243	smooth Beignet Milgranet	4	awesome	Last Available: "2011-09"
-5244	lousy distilled Muschat	5	decent	Last Available: "2011-09"
-5245	toothsome snack-sized twirling cool jelly donut	2	awesome	Last Available: "2011-09"
+5244	distilled lousy Muschat	5	decent	Last Available: "2011-09"
+5245	snack-sized toothsome twirling cool jelly donut	2	awesome	Last Available: "2011-09"
 5246	normal shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	rotten gray narrow occult jelly donut	4	crappy	Last Available: "2011-09"
 5248	normal thyme jelly donut	4	good	Last Available: "2011-09"
@@ -5156,11 +5156,11 @@
 5253	flavorless squat blunt cat claw	4	decent	Last Available: "2011-09"
 5254	spoiled shadowy cat claw	3	crappy	Last Available: "2011-09"
 5255	stale immense cyan cheezburger	6	decent	Last Available: "2011-09"
-5256	bite-sized normal pulsating toasted brie	1	good	Last Available: "2011-09"
+5256	normal bite-sized pulsating toasted brie	1	good	Last Available: "2011-09"
 5257	concentrated quadruple-dry blinking potion of the field gar	0		Effect: "Shot in the Arse", Effect Duration: 69, Last Available: "2011-09"
 5258	extra-flattened deionized warmed blurry too legit potion	0		Effect: "In the Limelight", Effect Duration: 24, Last Available: "2011-09"
 5259	unsweetened super-polymerized dry huge Bright Water	0		Effect: "Burning Tongue", Effect Duration: 69, Last Available: "2011-09"
-5260	irradiated modified diffused huge blinking cold-filtered water	0		Effect: "Holiday Disappointment", Effect Duration: 34, Last Available: "2011-09"
+5260	irradiated modified diffused blinking huge cold-filtered water	0		Effect: "Holiday Disappointment", Effect Duration: 34, Last Available: "2011-09"
 5261	colloidal spinning graveyard snowglobe	0		Effect: "Unusual Fashion Sense", Effect Duration: 24, Last Available: "2011-09"
 5262	adjusted cool cat elixir	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 40, Last Available: "2011-09"
 5263	concentrated vacuum-sealed red potion of the captain's hammer	0		Effect: "Bastard!", Effect Duration: 33, Last Available: "2011-09"
@@ -5198,9 +5198,9 @@
 5295	pulsating newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	rotten bite-sized phish stick	1	crappy	Last Available: "2011-09"
+5298	bite-sized rotten phish stick	1	crappy	Last Available: "2011-09"
 5299	nasty Lo Pan's supercharged plastic vampire fangs	0		Maximum MP Percent: +30, Spell Critical Percent: +30, Stench Damage: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
-5300	twirling cyan mirror Interview With You (a Vampire)	0		Last Available: "2011-10"
+5300	mirror cyan twirling Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
 5303	jittery chilly Sword of the Brouhaha Prince	0		Cold Damage: +5, Last Available: "2011-10"
@@ -5209,7 +5209,7 @@
 5306	wholesome Medallion of the Ventrilo Prince	0		Maximum HP Percent: +10, Last Available: "2011-10"
 5307	upside-down Haunted Sorority House staff guide	0		Last Available: "2011-10"
 5308	ghost trap	0		Last Available: "2011-10"
-5309	olive twirling chainsaw chain	0		Last Available: "2011-10"
+5309	twirling olive chainsaw chain	0		Last Available: "2011-10"
 5310	teal shotgun shell	0		Last Available: "2011-10"
 5311	upside-down funhouse mirror	0		Last Available: "2011-10"
 5312	colloidal enhanced ghostly body paint	0		Effect: "Broberry Brotality", Effect Duration: 50, Last Available: "2011-10"
@@ -5222,7 +5222,7 @@
 5319	adjusted irradiated Blood 'n' Plenty	0		Effect: "Kissed By Fire", Effect Duration: 15, Last Available: "2011-10"
 5320	super-frozen Lobos Mints	0		Effect: "Triangle, Man", Effect Duration: 37, Last Available: "2011-10"
 5321	vacuum-sealed super-ionized Sweet Sword	0		Effect: "Dexteri Tea", Effect Duration: 14, Last Available: "2011-10"
-5322	practically non-alcoholic hand-crafted Ecto-Cooler	1	EPIC	Last Available: "2011-10"
+5322	hand-crafted practically non-alcoholic Ecto-Cooler	1	EPIC	Last Available: "2011-10"
 5323	mediocre Bartles and BRAAAINS wine cooler	3	decent	Last Available: "2011-10"
 5324	tolerable Blood Light	3	good	Last Available: "2011-10"
 5325	smooth Silver Bullet beer	3	awesome	Last Available: "2011-10"
@@ -5230,7 +5230,7 @@
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	denatured warmed modified sorority brain	0		Effect: "One Very Clear Eye", Effect Duration: 52, Last Available: "2011-10"
 5329	modified liquefied vacuum-sealed Nightstalker perfume	0		Effect: "Dirty Pear", Effect Duration: 33, Last Available: "2011-10"
-5330	pressed yellow tumbling upside-down drum of pomade	0		Effect: "Shortened", Effect Duration: 32, Last Available: "2011-10"
+5330	pressed upside-down yellow tumbling drum of pomade	0		Effect: "Shortened", Effect Duration: 32, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extra-see-thru nightie of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2011-10"
 5333	shaking clever groovy BRAINS shorts	0		Moxie Percent: +10, Maximum MP: +20, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
@@ -5244,7 +5244,7 @@
 5341	blinking wobbly The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	watered-down artisanal The Cooler Out of Space	2	EPIC	Last Available: "2011-10"
 5343	squat The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5344	upside-down blinking sorority girl's box	0		Last Available: "2011-10"
+5344	blinking upside-down sorority girl's box	0		Last Available: "2011-10"
 5345	irradiated Necbro wafers	0		Effect: "The Style... of the Future", Effect Duration: 14, Last Available: "2020-09"
 5346	purple death blossom	0		
 5347	A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
@@ -5295,7 +5295,7 @@
 5392	shaking Thwaitgold butterfly statuette	0		
 5393	gray scrap of paper	0		
 5394	sandpaper	0		
-5395	maroon narrow peppermint sprout	0		Last Available: "2011-11"
+5395	narrow maroon peppermint sprout	0		Last Available: "2011-11"
 5396	wet ghostly skewed peppermint twist	0		Effect: "Happy Salamander", Effect Duration: 57, Last Available: "2011-11"
 5397	moldy half-sized peppermint patty	2	crappy	Last Available: "2011-11"
 5398	wobbly peppermint crook	0		Last Available: "2011-11"
@@ -5307,11 +5307,11 @@
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	family-friendly Van der Graaf cane-mail shirt	0		Sleaze Resistance: +1, Item Drop: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-12"
 5406	stanky scorching dog trainer's cane-mail pants	0		Experience (familiar): +1, Hot Damage: +25, Stench Spell Damage: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	watered-down lousy Vodka Matryoshka	2	decent	Last Available: "2011-12"
+5407	lousy watered-down Vodka Matryoshka	2	decent	Last Available: "2011-12"
 5408	triple-distilled artisanal shaking mirror Gin Mint	7	EPIC	Last Available: "2011-12"
 5409	bad Tequiz Navidad	3	decent	Last Available: "2011-12"
 5410	tolerable blue Mint Yulep	3	good	Last Available: "2011-12"
-5411	high-proof perfectly mixed enchanted Crimbojito	7	EPIC	Effect: "Wise Spirit", Effect Duration: 25, Last Available: "2011-12"
+5411	perfectly mixed high-proof enchanted Crimbojito	7	EPIC	Effect: "Wise Spirit", Effect Duration: 25, Last Available: "2011-12"
 5412	lousy Sangria de Menthe	3	decent	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5340,7 +5340,7 @@
 5437	mirror superheated fudge	0		Last Available: "2011-11"
 5438	cold-filtered yellow fluid of fudge-finding	0		Effect: "Ancestral Disapproval", Effect Duration: 25, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	thick moldy fudgesicle	5	crappy	Last Available: "2011-11"
+5440	moldy thick fudgesicle	5	crappy	Last Available: "2011-11"
 5441	mirror wand of fudge control	0		Last Available: "2011-11"
 5442	huge The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5379,12 +5379,12 @@
 5476	dry aerosolized unsweetened gummi salamander	0		Effect: "Bats in the Belfry", Effect Duration: 42, Last Available: "2011-11"
 5477	irradiated blinking gummi snake	0		Effect: "A Contender", Effect Duration: 51, Last Available: "2011-11"
 5478	concentrated fuchsia gummi canary	0		Effect: "Spooky Demeanor", Effect Duration: 68, Last Available: "2011-11"
-5479	toothsome gigantic pulsating gummi bear	8	awesome	Last Available: "2011-11"
+5479	gigantic toothsome pulsating gummi bear	8	awesome	Last Available: "2011-11"
 5480	snack-sized rotten tumbling gummi bear	2	crappy	Last Available: "2011-11"
 5481	moldy fancy gummi bear	4	crappy	Effect: "Thick-Skinned", Effect Duration: 45, Last Available: "2011-11"
 5482	adequate drunki-bear	3	good	Last Available: "2011-11"
 5483	bland tiny mirror drunki-bear	1	decent	Last Available: "2011-11"
-5484	jumbo flavorless lime green mirror drunki-bear	5	decent	Last Available: "2011-11"
+5484	flavorless jumbo lime green mirror drunki-bear	5	decent	Last Available: "2011-11"
 5485	gummi bowtie of doom	0		Spooky Spell Damage: +50, Last Available: "2011-11"
 5486	boxer's fudge pocket square	0		Muscle Percent: +10, Last Available: "2011-11"
 5487	lollipop cufflinks of horror	0		Spooky Spell Damage: +25, Last Available: "2011-11"
@@ -5392,7 +5392,7 @@
 5489	ammonite fossil	0		Last Available: "2011-11"
 5490	belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
-5492	mirror fuchsia ammonite candy mold	0		Last Available: "2011-11"
+5492	fuchsia mirror ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	nitrogenated mirror gummi trilobite	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 52, Last Available: "2011-11"
 5495	vacuum-sealed gummi ammonite	0		Effect: "Alacri Tea", Effect Duration: 59, Last Available: "2011-11"
@@ -5406,7 +5406,7 @@
 5503	pulsating Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	big flavorless jerky coins	5	decent	Last Available: "2011-11"
+5506	flavorless big jerky coins	5	decent	Last Available: "2011-11"
 5507	drinkable boozy squat Go-Wassail	5	good	Last Available: "2011-11"
 5508	oxidized Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Concentrated Concentration", Effect Duration: 63, Last Available: "2011-11"
 5509	ionized enhanced bottle of bubbles	0		Effect: "stats.enq", Effect Duration: 67, Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	mirror magnolia blossom	0		Last Available: "2012-12"
 5533	deionized liquefied enhanced mirror Mortimer's nostrum	0		Effect: "Ack!  Barred!", Effect Duration: 35, Last Available: "2012-12"
-5534	tolerable cyan mirror Barulio's bottle	4	good	Last Available: "2012-12"
+5534	tolerable mirror cyan Barulio's bottle	4	good	Last Available: "2012-12"
 5535	wet Marvin's marvelous pill	0		Effect: "Radiant Personality", Effect Duration: 55, Last Available: "2012-12"
 5536	tumbling Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5445,7 +5445,7 @@
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	foul-smelling Leapin' Trousers of the detective	0		Stench Damage: +10, Item Drop: +20
 5544	high-proof lousy twirling eggnog	10	decent	Last Available: "2012-12"
-5545	adequate snack-sized hamhock	2	good	Last Available: "2012-12"
+5545	snack-sized adequate hamhock	2	good	Last Available: "2012-12"
 5546	blurry The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5461,7 +5461,7 @@
 5558	careful smooth Rain-Doh laser gun	0		Moxie: +15, Monster Level: -10, Softcore Only, Last Available: "2012-02"
 5559	zippy Rain-Doh lantern of chilblains	0		Cold Damage: +25, Initiative: +20, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
-5561	wobbly huge Rain-Doh indigo cup	0		Last Available: "2012-02"
+5561	huge wobbly Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	savvy brainy Rain-Doh violet bo	0		Mysticality: +5, Mysticality Percent: +20, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
@@ -5474,62 +5474,62 @@
 5571	Groar's fur	0		
 5572	shaking Thwaitgold stag beetle statuette	0		
 5573	weak delicious squat Drac & Tan	2	awesome	Last Available: "2012-03"
-5574	watered-down artisanal green skewed Transylvania Sling	2	EPIC	Last Available: "2012-03"
-5575	weak artisanal gray Shot of the Living Dead	2	EPIC	Last Available: "2012-03"
-5576	hand-crafted triple-distilled bouncing Buttery Knob	6	EPIC	Last Available: "2012-03"
+5574	watered-down artisanal skewed green Transylvania Sling	2	EPIC	Last Available: "2012-03"
+5575	artisanal weak gray Shot of the Living Dead	2	EPIC	Last Available: "2012-03"
+5576	triple-distilled hand-crafted bouncing Buttery Knob	6	EPIC	Last Available: "2012-03"
 5577	perfectly mixed Slippery Knob	3	EPIC	Last Available: "2012-03"
 5578	delicious jittery Flaming Knob	3	awesome	Last Available: "2012-03"
 5579	hand-crafted jittery Grasshopper	4	EPIC	Last Available: "2012-03"
 5580	mediocre Locust	3	decent	Last Available: "2012-03"
-5581	hand-crafted spirit-forward squat cyan Plague of Locusts	5	EPIC	Last Available: "2012-03"
-5582	aged practically non-alcoholic Red Dwarf	1	awesome	Last Available: "2012-03"
+5581	spirit-forward hand-crafted squat cyan Plague of Locusts	5	EPIC	Last Available: "2012-03"
+5582	practically non-alcoholic aged Red Dwarf	1	awesome	Last Available: "2012-03"
 5583	tolerable practically non-alcoholic skewed Golden Mean	1	good	Last Available: "2012-03"
-5584	practically non-alcoholic acceptable blinking Green Giant	1	good	Last Available: "2012-03"
+5584	acceptable practically non-alcoholic blinking Green Giant	1	good	Last Available: "2012-03"
 5585	drinkable Aye Aye	4	good	Last Available: "2012-03"
 5586	lousy Aye Aye, Captain	4	decent	Last Available: "2012-03"
 5587	lousy Aye Aye, Tooth Tooth	3	decent	Last Available: "2012-03"
 5588	mediocre practically non-alcoholic ghostly Humanitini	1	decent	Last Available: "2012-03"
-5589	mediocre spirit-forward blurry More Humanitini than Humanitini	5	decent	Last Available: "2012-03"
+5589	spirit-forward mediocre blurry More Humanitini than Humanitini	5	decent	Last Available: "2012-03"
 5590	hand-crafted squat Oh, the Humanitini	4	EPIC	Last Available: "2012-03"
-5591	weak bad Great Older Fashioned	2	decent	Last Available: "2012-03"
+5591	bad weak Great Older Fashioned	2	decent	Last Available: "2012-03"
 5592	delicious high-proof Fuzzy Tentacle	8	awesome	Last Available: "2012-03"
-5593	special delicious green Crazymaker	3	awesome	Effect: "You're Rubber", Effect Duration: 35, Last Available: "2012-03"
+5593	delicious special green Crazymaker	3	awesome	Effect: "You're Rubber", Effect Duration: 35, Last Available: "2012-03"
 5594	practically non-alcoholic acceptable wobbly Zoodriver	1	good	Last Available: "2012-03"
 5595	practically non-alcoholic lousy squat Sloe Comfortable Zoo	1	decent	Last Available: "2012-03"
-5596	mediocre spirit-forward Sloe Comfortable Zoo on Fire	5	decent	Last Available: "2012-03"
+5596	spirit-forward mediocre Sloe Comfortable Zoo on Fire	5	decent	Last Available: "2012-03"
 5597	extra-dry lousy Suffering Sinner	5	decent	Last Available: "2012-03"
 5598	artisanal Suppurating Sinner	3	EPIC	Last Available: "2012-03"
 5599	practically non-alcoholic hand-crafted Sizzling Sinner	1	super ultra EPIC	Last Available: "2012-03"
 5600	mediocre blue Firewater	3	decent	Last Available: "2012-03"
-5601	extra-dry mediocre Earth and Firewater	5	decent	Last Available: "2012-03"
+5601	mediocre extra-dry Earth and Firewater	5	decent	Last Available: "2012-03"
 5602	drinkable Earth, Wind and Firewater	4	good	Last Available: "2012-03"
-5603	aged weak special Slimosa	2	awesome	Effect: "Chalked Weapon", Effect Duration: 10, Last Available: "2012-03"
+5603	special aged weak Slimosa	2	awesome	Effect: "Chalked Weapon", Effect Duration: 10, Last Available: "2012-03"
 5604	bad watered-down upside-down squat Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
 5605	artisanal bouncing Slimebite	3	EPIC	Last Available: "2012-03"
 5606	lousy fuchsia Cement Mixer	4	decent	Last Available: "2012-03"
 5607	distilled perfectly mixed upside-down upside-down Jackhammer	5	EPIC	Last Available: "2012-03"
 5608	mediocre Dump Truck	3	decent	Last Available: "2012-03"
-5609	irresponsibly strong drinkable Fauna Libre	8	good	Last Available: "2012-03"
+5609	drinkable irresponsibly strong Fauna Libre	8	good	Last Available: "2012-03"
 5610	perfectly mixed Chakra Libre	4	EPIC	Last Available: "2012-03"
 5611	acceptable triple-distilled Aura Libre	7	good	Last Available: "2012-03"
-5612	irresponsibly strong fancy bad Sazerorc	10	decent	Effect: "Berry Elemental", Effect Duration: 30, Last Available: "2012-03"
+5612	bad fancy irresponsibly strong Sazerorc	10	decent	Effect: "Berry Elemental", Effect Duration: 30, Last Available: "2012-03"
 5613	delicious Sazuruk-hai	3	awesome	Last Available: "2012-03"
-5614	practically non-alcoholic delicious Flaming Sazerorc	1	awesome	Last Available: "2012-03"
+5614	delicious practically non-alcoholic Flaming Sazerorc	1	awesome	Last Available: "2012-03"
 5615	tolerable twirling Green Velvet	4	good	Last Available: "2012-03"
 5616	hand-crafted fortified Green Muslin	5	EPIC	Last Available: "2012-03"
 5617	special lousy blue skewed squat Green Burlap	3	decent	Effect: "Serenity", Effect Duration: 25, Last Available: "2012-03"
-5618	aged twirling lime green Mohobo	3	awesome	Last Available: "2012-03"
+5618	aged lime green twirling Mohobo	3	awesome	Last Available: "2012-03"
 5619	perfectly mixed Moonshine Mohobo	3	EPIC	Last Available: "2012-03"
-5620	fancy perfectly mixed irresponsibly strong Flaming Mohobo	9	EPIC	Effect: "Robocamo", Effect Duration: 10, Last Available: "2012-03"
-5621	lousy practically non-alcoholic Drunken Philosopher	1	decent	Last Available: "2012-03"
+5620	perfectly mixed irresponsibly strong fancy Flaming Mohobo	9	EPIC	Effect: "Robocamo", Effect Duration: 10, Last Available: "2012-03"
+5621	practically non-alcoholic lousy Drunken Philosopher	1	decent	Last Available: "2012-03"
 5622	drinkable fuchsia Drunken Neurologist	4	good	Last Available: "2012-03"
 5623	acceptable strong Drunken Astrophysicist	5	good	Last Available: "2012-03"
-5624	acceptable strong Dark & Starry	5	good	Last Available: "2012-03"
-5625	special artisanal Black Hole	3	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 15, Last Available: "2012-03"
+5624	strong acceptable Dark & Starry	5	good	Last Available: "2012-03"
+5625	artisanal special Black Hole	3	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 15, Last Available: "2012-03"
 5626	watered-down mediocre yellow Event Horizon	2	decent	Last Available: "2012-03"
 5627	acceptable upside-down Herring Daiquiri	3	good	Last Available: "2012-03"
 5628	acceptable weak jittery wobbly Herring Wallbanger	2	good	Last Available: "2012-03"
-5629	lousy fancy Herringtini	3	decent	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2012-03"
+5629	fancy lousy Herringtini	3	decent	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2012-03"
 5630	smooth Lollipop Drop	3	awesome	Last Available: "2012-03"
 5631	mediocre squat Candy Alexander	4	decent	Last Available: "2012-03"
 5632	watered-down tolerable Candicaine	2	good	Last Available: "2012-03"
@@ -5541,7 +5541,7 @@
 5638	drinkable Haymaker	3	good	Last Available: "2012-03"
 5639	red Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	mirror crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	special thick delicious green fungus	5	awesome	Effect: "The Halls of Mysticality", Effect Duration: 25
+5641	special delicious thick green fungus	5	awesome	Effect: "The Halls of Mysticality", Effect Duration: 25
 5642	skewed poisoned dart	0		
 5643	triple-electrified vacuum-sealed quadruple-dry stone wool	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 38
 5644	stones	0		
@@ -5554,7 +5554,7 @@
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	green key-o-tron	0		
-5654	adequate miniature squat nailswurst	2	good	
+5654	miniature adequate squat nailswurst	2	good	
 5655	mediocre used beer	3	decent	
 5656	Huggler Radio	0		Free Pull
 5657	mirror fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5562,7 +5562,7 @@
 5659	yellow insulting hat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "cap 2"
 5660	teal offensive moustache of the ox	0		Muscle: +20, Single Equip
 5661	Van der Graaf hairshirt	0		MP Regen Min: 5, MP Regen Max: 7
-5662	ghostly upside-down Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
+5662	upside-down ghostly Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	microwave	0		Free Pull
 5664	pony keg	0		Free Pull
 5665	blinking gray How to Tolerate Jerks	0		Skill: "Thick-Skinned"
@@ -5615,10 +5615,10 @@
 5714	tumbling FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	spoiled snack-sized FDKOL hotcakes	2	crappy	Last Available: "2012-07"
+5717	snack-sized spoiled FDKOL hotcakes	2	crappy	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	tasty jumbo special wobbly fiery wing	5	awesome	Effect: "Concentration", Effect Duration: 5, Last Available: "2012-07"
+5720	special tasty jumbo wobbly fiery wing	5	awesome	Effect: "Concentration", Effect Duration: 5, Last Available: "2012-07"
 5721	fuchsia twirling shellacked wings of fire of the sweet-tooth	0		Damage Reduction: 7, Candy Drop: +100, Last Available: "2012-07"
 5722	FDKOL fire hose of extreme caution	0		Monster Level: -25, Last Available: "2012-07"
 5723	double-enhanced olive bottle of fire	0		Effect: "Scrappy, Shadowy", Effect Duration: 35, Last Available: "2012-07"
@@ -5629,7 +5629,7 @@
 5728	healthy foot-long hot daub of the cheetah	0		Maximum HP Percent: +20, Initiative: +60, Last Available: "2012-07"
 5729	upside-down teal ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy miniature angst burger	2	crappy	
-5731	tolerable fancy practically non-alcoholic 5-hour acrimony	1	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 15
+5731	fancy tolerable practically non-alcoholic 5-hour acrimony	1	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 15
 5732	tumbling blank note	0		
 5733	skewed bouncing eerily silent box	0		
 5734	yummy yellow forbidden sausage	3	awesome	
@@ -5651,15 +5651,15 @@
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	adequate yellow crappy brain	4	good	
-5753	bite-sized decent decent brain	1	good	
+5753	decent bite-sized decent brain	1	good	
 5754	decent shaking good brain	4	good	
-5755	thick decent fuchsia tumbling boss brain	5	good	
-5756	enchanted stale olive hunter brain	3	decent	Effect: "Amorous", Effect Duration: 45
+5755	thick decent tumbling fuchsia boss brain	5	good	
+5756	stale enchanted olive hunter brain	3	decent	Effect: "Amorous", Effect Duration: 45
 5758	bouncing resourceful Staff of Holiday Sensations of the dark arts of temperance	0		Spell Damage Percent: +100, Maximum MP: +50, Sleaze Resistance: +5, Last Available: "2011-11"
 5759	beefcake's staff of the glutton	0		Muscle: +25, Food Drop: +100
 5760	Usain Bolt's knitted staff of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +3, Initiative: +80
 5761	executive stanky sharpshooter's Staff of the Scummy Sink	0		Critical Hit Percent: +10, Stench Spell Damage: +25, Meat Drop: +40, Slime Hates It: +1
-5762	wobbly twirling nose	0		
+5762	twirling wobbly nose	0		
 5763	yellow flame-wreathed dog trainer's Superhero Reboots	0		Experience (familiar): +1, Hot Spell Damage: +10
 5764	studded savvy fuzzy busby	0		Mysticality Percent: +20, Damage Absorption: +80, Familiar Effect: "1.5xVolley, cap 32"
 5765	wobbly occult fuzzy earmuffs of the scaredy-cat	0		Spell Damage Percent: +25, Monster Level: -15, Familiar Effect: "1.5xVolley, cap 32"
@@ -5677,7 +5677,7 @@
 5778	decent pulsating idiot brain	3	good	
 5779	curative keel-haulin' knife	0		HP Regen Min: 3, HP Regen Max: 5
 5780	ice cream scoop of the detective	0		Item Drop: +20
-5781	smooth cyan twirling soft echo eyedrop antidote martini	3	awesome	
+5781	smooth twirling cyan soft echo eyedrop antidote martini	3	awesome	
 5782	bouncing morningwood plank	0		
 5783	maroon raging hardwood plank	0		
 5784	squat weirdwood plank	0		
@@ -5699,7 +5699,7 @@
 5800	anodized shaking Charity's choker	0		Effect: "Pemmican't", Effect Duration: 25
 5801	dry dry dry shaking Smart Bone Dust	0		Effect: "Dirge of Dreadfulness", Effect Duration: 61
 5802	unsweetened oxidized perpendicular guano	0		Effect: "Spiro Gyro", Effect Duration: 39
-5803	Vulcanized activated twirling jittery White Chocolate Golem Seeds	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 53
+5803	Vulcanized activated jittery twirling White Chocolate Golem Seeds	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 53
 5804	double-activated spinning Shivering Ch&egrave;vre	0		Effect: "Shot in the Arse", Effect Duration: 46
 5805	aerosolized warmed jittery spinning breath mint	0		Effect: "Ninja, Please", Effect Duration: 49
 5806	liquefied huge muesli	0		Effect: "You Know Where to Go", Effect Duration: 20
@@ -5722,22 +5722,22 @@
 5823	warmed super-tarnished squat canopic jar	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 65
 5824	non-modified extra-modified tumbling clove-flavored lip balm	0		Effect: "Boletus Swoletus", Effect Duration: 17
 5825	extra-oxidized moist Skullery Maid's Knee	0		Effect: "Ooh, Salty!", Effect Duration: 67
-5826	non-anodized teal twirling zombie hollandaise	0		Effect: "Rain Dancin'", Effect Duration: 34
+5826	non-anodized twirling teal zombie hollandaise	0		Effect: "Rain Dancin'", Effect Duration: 34
 5827	liquefied denatured skeletal banana	0		Effect: "Berry Defensive", Effect Duration: 19
 5828	vacuum-sealed moist gilt perfume bottle	0		Effect: "Flamingly Floral", Effect Duration: 56
 5829	deionized janglin' bones	0		Effect: "Riboflavin'", Effect Duration: 62
 5830	concentrated pygmy papers	0		Effect: "The Q Is Talking To You", Effect Duration: 21
 5831	frozen modified blue pygmy dart	0		Effect: "Eyes Wide Propped", Effect Duration: 13
-5832	warmed aerosolized chilled shaking maroon secret mummy herbs and spices	0		Effect: "Saucegoggles", Effect Duration: 17
+5832	warmed aerosolized chilled maroon shaking secret mummy herbs and spices	0		Effect: "Saucegoggles", Effect Duration: 17
 5833	enhanced boiled corrupted green brigand brittle	0		Effect: "Papowerful", Effect Duration: 61
 5834	polarized holistic headache remedy	0		Effect: "Mystic Circle", Effect Duration: 69
 5835	Vulcanized scrunchie tourniquet	0		Effect: "Horrid, Torrid", Effect Duration: 31
 5836	polarized embezzler's oil	0		Effect: "Human-Plant Hybrid", Effect Duration: 60
 5837	altered liquefied frozen Fu Manchu Wax	0		Effect: "Mariachi Mood", Effect Duration: 68
-5838	unsweetened vacuum-sealed magnetized fuchsia blinking Iiti Kitty Gumdrop	0		Effect: "Antibiotic Saucesphere", Effect Duration: 11
+5838	unsweetened vacuum-sealed magnetized blinking fuchsia Iiti Kitty Gumdrop	0		Effect: "Antibiotic Saucesphere", Effect Duration: 11
 5839	non-vacuum-sealed ravenous eye	0		Effect: "Salamander In Your Stomach", Effect Duration: 16
 5840	concentrated twirling Rogue Windmill Rouge	0		Effect: "Egg-stortionary Tactics", Effect Duration: 14
-5841	double-altered jittery bouncing wobbly A muse-bouche	0		Effect: "Strange Mental Acuity", Effect Duration: 60
+5841	double-altered bouncing wobbly jittery A muse-bouche	0		Effect: "Strange Mental Acuity", Effect Duration: 60
 5842	altered extra-cold-filtered toothbrush	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 27
 5843	quadruple-modified pirate cream pie	0		Effect: "Saucemastery", Effect Duration: 52
 5844	quadruple-polymerized wet skewed una poca de gracia	0		Effect: "Sewer-Drenched", Effect Duration: 61
@@ -5749,10 +5749,10 @@
 5850	deionized skewed space marine flash grenade	0		Effect: "Sweet Nostalgia", Effect Duration: 45
 5851	frozen corrupted mirror temporary tribal tattoo	0		Effect: "High Blood Chocolate Content", Effect Duration: 48
 5852	nitrogenated ionized oil-filled donut	0		Effect: "Egg-stra Arm", Effect Duration: 68
-5853	ionized triple-dry narrow gray stick-on gnome beard	0		Effect: "Extra-Sharp Weapon", Effect Duration: 29
+5853	ionized triple-dry gray narrow stick-on gnome beard	0		Effect: "Extra-Sharp Weapon", Effect Duration: 29
 5854	cold-filtered Vulcanized BRICKO stud	0		Effect: "Patched In", Effect Duration: 52
-5855	concentrated dry diffused spinning narrow ghostly Osk'r Chow	0		Effect: "Held Closer", Effect Duration: 25
-5856	ionized cyan skewed Scuba Snack	0		Effect: "Thicker, Sicker", Effect Duration: 47
+5855	concentrated dry diffused narrow ghostly spinning Osk'r Chow	0		Effect: "Held Closer", Effect Duration: 25
+5856	ionized skewed cyan Scuba Snack	0		Effect: "Thicker, Sicker", Effect Duration: 47
 5857	deionized tarnished grey cube	0		Effect: "Updated", Effect Duration: 53
 5858	liquefied votive candle	0		Effect: "Abominably Slippery", Effect Duration: 31
 5859	corrupted liquefied booby trap	0		Effect: "Good with the Ladies", Effect Duration: 17
@@ -5776,7 +5776,7 @@
 5877	blurry papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	savvy Rainbow Jello Mould	0		Mysticality Percent: +20
 5879	Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
-5880	blinking tumbling packet of dragon's teeth	0		Last Available: "2012-10"
+5880	tumbling blinking packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	mirror lightning-fast inspector's stiffened skeleton skis	0		Damage Reduction: 1, Item Drop: +15, Initiative: +40, Single Equip, Last Available: "2012-10"
 5883	stale blurry skeleton quiche	3	decent	Last Available: "2012-10"
@@ -5873,7 +5873,7 @@
 5975	twirling record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	lime green wobbly hale silent beret of James Dean of terror	0		Experience (Moxie): +3, Maximum HP: +20, Spooky Spell Damage: +10, Familiar Effect: "1xVolley, cap 3"
-5978	miniature normal slice of pizza	2	good	Last Available: "2013-02"
+5978	normal miniature slice of pizza	2	good	Last Available: "2013-02"
 5979	fuchsia huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	narrow star	0		Last Available: "2013-02"
@@ -5881,7 +5881,7 @@
 5983	twirling vial of holy water	0		Last Available: "2013-02"
 5984	Jim Carey's medical-grade cloth cap of the blizzard	0		Monster Level: +25, Cold Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	razor-sharp iron dagger of the brute of dire peril	0		Muscle Percent: +30, Weapon Damage: +20, Weapon Damage Percent: +25, Last Available: "2013-02"
-5986	yummy gigantic hamburger	7	awesome	Last Available: "2013-02"
+5986	gigantic yummy hamburger	7	awesome	Last Available: "2013-02"
 5987	pulsating dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	maroon potion	0		Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	super-wet blinking orcish hand lotion	0		Effect: "Tingly Wrists", Effect Duration: 39
 6016	electrified irradiated orcish rubber	0		Effect: "Spookyravin'", Effect Duration: 64
 6017	chilled oxidized orcish nailing lube	0		Effect: "Inner Warmth", Effect Duration: 49
-6018	tolerable fancy weak backwoods screwdriver	2	good	Effect: "Stemonitis Storm", Effect Duration: 25
+6018	weak tolerable fancy backwoods screwdriver	2	good	Effect: "Stemonitis Storm", Effect Duration: 25
 6019	lime green loadstone of the sweet-tooth	0		Candy Drop: +100
 6020	prompt therapeutic Claybender glasses	0		Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 6021	upside-down weightlifter's Duskwalker fangs of the early riser	0		Muscle: +15, Adventures: +7
@@ -5931,9 +5931,9 @@
 6033	blurry sharpshooter's stolen necklace of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +10
 6034	squat troll britches of the businessman	0		Item Drop: +5, Meat Drop: +50, Familiar Effect: "1.5xPotato, cap 28"
 6035	ionized warmed mirror vial of The Glistening	0		Effect: "Strong Grip", Effect Duration: 21
-6036	bad practically non-alcoholic bouncing artisanal limoncello	1	decent	
+6036	practically non-alcoholic bad bouncing artisanal limoncello	1	decent	
 6037	ginger ale	0		
-6038	adequate half-sized incredible pizza	2	good	
+6038	half-sized adequate incredible pizza	2	good	
 6039	pulsating electrified rosy-cheeked oil cap	0		Maximum HP Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cap 28"
 6040	shellacked sinister oil lamp	0		Spell Damage: +10, Damage Reduction: 7
 6041	twirling Jim Carey's oil slacks	0		Monster Level: +25, Familiar Effect: "1xPotato, cap 30"
@@ -5945,10 +5945,10 @@
 6047	cyan family-friendly Jack Frost's Misty Cloak	0		Cold Spell Damage: +50, Sleaze Resistance: +1
 6048	mirror healthy Misty Robe of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5
 6049	aromatic shellacked Misty Cape of mayonnaise	0		Damage Reduction: 7, Sleaze Spell Damage: +50, Stench Resistance: +1
-6050	narrow olive woimbook	0		Familiar Weight: +5
+6050	olive narrow woimbook	0		Familiar Weight: +5
 6051	yellow Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	stale big Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
-6053	artisanal watered-down Taco Dan's Taco Stand Chimichangarita	2	EPIC	Last Available: "2012-12"
+6052	big stale Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
+6053	watered-down artisanal Taco Dan's Taco Stand Chimichangarita	2	EPIC	Last Available: "2012-12"
 6054	extra-frozen mirror tumbling Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Twinklebritches", Effect Duration: 18, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
@@ -5965,13 +5965,13 @@
 6067	stanky chilly Truthsayer	0		Cold Damage: +5, Stench Spell Damage: +25, Last Available: "2013-12"
 6068	loose blade	0		
 6069	goblin bone hilt	0		
-6070	shaking gray ghostly blinking sword blade	0		
+6070	shaking ghostly gray blinking sword blade	0		
 6071	lime green Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	ionized irradiated haggis-infused soap	0		Effect: "Tiki Temerity", Effect Duration: 52, Last Available: "2012-12"
 6074	non-corrupted magicberry tablets	0		Effect: "Ooh, Sour!", Effect Duration: 30, Last Available: "2012-12"
 6075	galvanized wet 37x37x37 puzzle cube	0		Effect: "Fustulent", Effect Duration: 62, Last Available: "2012-12"
-6076	high-proof smooth upside-down McLeod's Hard Haggis-Ade	7	awesome	Last Available: "2012-12"
+6076	smooth high-proof upside-down McLeod's Hard Haggis-Ade	7	awesome	Last Available: "2012-12"
 6077	stale thick haggis-wrapped haggis-stuffed haggis	5	decent	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -5997,7 +5997,7 @@
 6099	Da Vinci's Thinknerd T-Shirt	0		Experience (Mysticality): +5, Last Available: "2012-12"
 6100	olive pile of useless robot parts	0		Last Available: "2012-12"
 6101	skewed bouncing homemade robot	0		Last Available: "2012-12"
-6102	bouncing jittery homemade robot gear	0		Last Available: "2012-12"
+6102	jittery bouncing homemade robot gear	0		Last Available: "2012-12"
 6103	mirror Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	wobbly Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	twirling Artist's Spatula of Despair	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	family-friendly rubber gloves	0		Sleaze Resistance: +1, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	massive spoiled bouncing roasted duck	10	crappy	Last Available: "2013-12"
+6142	spoiled massive bouncing roasted duck	10	crappy	Last Available: "2013-12"
 6143	big flavorless dead meat bun	5	decent	Last Available: "2013-12"
 6144	olive ghostly cool cat collar	0		Moxie: +5, Single Equip, Last Available: "2013-12"
 6145	spinning miser's suspicious-looking fedora of the early riser	0		Meat Drop: +10, Adventures: +7, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
@@ -6063,7 +6063,7 @@
 6166	vibrating padded deck cannon	0		Damage Absorption: +20, Maximum MP Percent: +10, Last Available: "2013-12"
 6167	blue stiffened ornamental sextant	0		Damage Reduction: 1, Last Available: "2013-12"
 6168	upside-down frightening padded Bloodbath	0		Damage Absorption: +20, Spooky Damage: +5, Last Available: "2013-12"
-6169	artisanal watered-down Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
+6169	watered-down artisanal Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
 6170	normal chum	3	good	Last Available: "2013-12"
 6171	vacuum-sealed quadruple-irradiated crude crudit&eacute;s	0		Effect: "It Didn't Kill You", Effect Duration: 21
 6172	warmed liquefied candy crayons	0		Effect: "Pork Power", Effect Duration: 60, Last Available: "2020-09"
@@ -6082,8 +6082,8 @@
 6185	stale twirling consummate hard-boiled egg	4	decent	
 6186	normal consummate fried egg	3	good	
 6187	normal consummate egg salad	3	good	
-6188	gigantic decent consummate bagel	10	good	
-6189	decent low-calorie skewed consummate sliced bread	1	good	
+6188	decent gigantic consummate bagel	10	good	
+6189	low-calorie decent skewed consummate sliced bread	1	good	
 6190	thick adequate consummate hot dog bun	5	good	
 6191	adequate consummate brownie	4	good	
 6192	spoiled low-calorie yellow consummate toast	1	crappy	
@@ -6092,24 +6092,24 @@
 6195	fancy rotten wobbly bouncing consummate corn chips	3	crappy	Effect: "Angry like the Wolf", Effect Duration: 30
 6196	moldy consummate salad	4	crappy	
 6197	adequate consummate salsa	4	good	
-6198	bland gigantic upside-down consummate sauerkraut	7	decent	
+6198	gigantic bland upside-down consummate sauerkraut	7	decent	
 6199	big normal shaking consummate cheese slice	5	good	
 6200	decent tumbling consummate melted cheese	4	good	
 6201	gigantic stale consummate bacon	9	decent	
-6202	rotten fancy thick consummate meatloaf	5	crappy	Effect: "Paging Betty", Effect Duration: 20
-6203	normal tiny blurry consummate steak	1	good	
+6202	thick fancy rotten consummate meatloaf	5	crappy	Effect: "Paging Betty", Effect Duration: 20
+6203	tiny normal blurry consummate steak	1	good	
 6204	snack-sized yummy narrow consummate cuts	2	awesome	
 6205	flavorless narrow consummate frankfurter	3	decent	
 6206	small flavorless huge consummate french fries	2	decent	
 6207	normal consummate baked potato	3	good	
-6208	fortified drinkable shaking acceptable vodka	5	good	
+6208	drinkable fortified shaking acceptable vodka	5	good	
 6209	adequate consummate ice cream	3	good	
-6210	yummy huge consummate whipped cream	9	awesome	
+6210	huge yummy consummate whipped cream	9	awesome	
 6211	normal olive consummate cream	4	good	
 6212	delicious half-sized consummate strawberries	2	awesome	
 6213	decent consummate sorbet	4	good	
 6214	tolerable triple-distilled adequate rum	6	good	
-6215	acceptable fancy narrow mediocre lager	3	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 10
+6215	fancy acceptable narrow mediocre lager	3	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 10
 6216	adequate bite-sized pulsating immaculate grilled cheese	1	good	
 6217	toothsome miniature red immaculate ice cream sandwich	2	awesome	
 6218	spoiled huge immaculate hot dog	8	crappy	
@@ -6118,16 +6118,16 @@
 6221	small decent perfect chef salad	2	good	
 6222	moldy skewed perfect breakfast	3	crappy	
 6223	adequate lime green sublime deluxe hot dog	3	good	
-6224	super-sized rotten sublime stew	5	crappy	
+6224	rotten super-sized sublime stew	5	crappy	
 6225	toothsome cyan sublime nachos	3	awesome	
 6226	bland small Ultimate Breakfast Sandwich	2	decent	
 6227	normal snack-sized Loaded Baked Potato	2	good	
 6228	half-sized normal Omega Sundae	2	good	
-6229	aged strong Das Sauerlager	5	awesome	
+6229	strong aged Das Sauerlager	5	awesome	
 6230	lousy Bologna Lambic	4	decent	
-6231	artisanal boozy Vodka Dog	5	EPIC	
+6231	boozy artisanal Vodka Dog	5	EPIC	
 6232	lousy Disappointed Russian	3	decent	
-6233	weak drinkable Chunky Mary	2	good	
+6233	drinkable weak Chunky Mary	2	good	
 6234	perfectly mixed maroon Nachojito	3	EPIC	
 6235	artisanal red Le Roi	4	EPIC	
 6236	weak bad Over Easy Rider	2	decent	
@@ -6169,8 +6169,8 @@
 6273	modified O'RLY manual	0		Effect: "Fudge Headache", Effect Duration: 56
 6274	perfectly mixed wobbly open sauce	3	EPIC	
 6275	blurry miser's scorching turkey leg	0		Hot Damage: +25, Meat Drop: +10
-6276	lousy weak Ye Olde Meade	2	decent	
-6277	corrupted vacuum-sealed mirror spinning Ye Olde Bawdy Limerick	0		Effect: "Strange Mental Acuity", Effect Duration: 45
+6276	weak lousy Ye Olde Meade	2	decent	
+6277	corrupted vacuum-sealed spinning mirror Ye Olde Bawdy Limerick	0		Effect: "Strange Mental Acuity", Effect Duration: 45
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of Tarzan	0		Experience (Muscle): +3
 6280	twirling lightning-fast artisanal rice peeler	0		Initiative: +40
@@ -6191,9 +6191,9 @@
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
-6298	blue skewed jittery Thwaitgold firefly statuette	0		
+6298	blue jittery skewed Thwaitgold firefly statuette	0		
 6299	spinning model airship	0		
-6300	triple-energized ghostly huge upside-down Super Weight-Gain 9000	0		Effect: "Work For Hours a Week", Effect Duration: 13
+6300	triple-energized huge upside-down ghostly Super Weight-Gain 9000	0		Effect: "Work For Hours a Week", Effect Duration: 13
 6301	dry bouncing possibility potion	0		Effect: "Crimbo Flavor", Effect Duration: 66
 6302	eleven-foot pole	0		
 6303	blurry ring of Detect Boring Doors	0		
@@ -6203,7 +6203,7 @@
 6307	extra-frozen shaking celestial olive oil	0		Effect: "Flambé-a-thon", Effect Duration: 68, Last Available: "2013-03"
 6308	oxidized ghostly celestial carrot juice	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 63, Last Available: "2013-03"
 6309	nitrogenated denatured teal celestial au jus	0		Effect: "Berry Critical", Effect Duration: 27, Last Available: "2013-03"
-6310	double-activated blurry skewed blue celestial squid ink	0		Effect: "Beastly Flavor", Effect Duration: 33, Last Available: "2013-03"
+6310	double-activated blue blurry skewed celestial squid ink	0		Effect: "Beastly Flavor", Effect Duration: 33, Last Available: "2013-03"
 6311	Uncle Buck of the bloodbag	0		Maximum HP: +100, Softcore Only
 6312	crate of fish meat	0		
 6313	damp wallet	0		
@@ -6266,7 +6266,7 @@
 6370	wobbly twisted piece of wire	0		
 6371	artisanal can of the cheapest beer	3	EPIC	
 6372	artisanal bottle of fruity &quot;wine&quot;	4	EPIC	
-6373	perfectly mixed watered-down gray single swig of vodka	2	EPIC	
+6373	watered-down perfectly mixed gray single swig of vodka	2	EPIC	
 6374	bouncing angry inch	0		
 6375	pulsating sharpshooter's testy toolbox	0		Critical Hit Percent: +10
 6376	Jick-o-User	0		
@@ -6307,8 +6307,8 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	moldy fancy flavorless gruel	4	crappy	Effect: "Feroci Tea", Effect Duration: 5
-6416	snack-sized normal mana curds	2	good	
+6415	fancy moldy flavorless gruel	4	crappy	Effect: "Feroci Tea", Effect Duration: 5
+6416	normal snack-sized mana curds	2	good	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	electrified dry flattened moth dust	0		Effect: "Petit Force", Effect Duration: 27
@@ -6321,13 +6321,13 @@
 6426	moldy snack-sized Dreadsylvanian stew	2	crappy	
 6427	drinkable Dreadsylvanian	3	good	
 6428	super-corrupted chilled Dreadsylvanian flask	0		Effect: "Phorcefullness", Effect Duration: 64
-6429	ionized dry modified blurry lime green Dreadsylvanian flask	0		Effect: "Altered Wavelengths", Effect Duration: 44
+6429	ionized dry modified lime green blurry Dreadsylvanian flask	0		Effect: "Altered Wavelengths", Effect Duration: 44
 6430	tumbling upside-down Jack Frost's sage dreadful fedora	0		Mysticality Percent: +10, Cold Spell Damage: +50, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	dreadful sweater of Calamity Jane	0		Critical Hit Percent: +15, Kruegerand Drop: 5
 6432	squat teal inspector's dreadful glove	0		Item Drop: +15, Kruegerand Drop: 5
 6433	lime green Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
-6435	pulsating huge Mark of the Werewolf	0		
+6435	huge pulsating Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
 6438	Mark of the Vampire	0		
@@ -6364,7 +6364,7 @@
 6469	Tesla wicked smooth Thunkula's drinking cap	0		Moxie: +15, Spell Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	deadly Drunkula's cape of Leguizamo of the boozehound	0		Weapon Damage: +5, Monster Level: +20, Booze Drop: +100, Class: "Sauceror"
 6471	fireproof groovy cool Drunkula's silky pants	0		Moxie: +5, Moxie Percent: +10, Hot Resistance: +3, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
-6472	spinning blinking Drunkula's bell	0		
+6472	blinking spinning Drunkula's bell	0		
 6473	red Temple Grandin's manspreader's dance instructor's Drunkula's ring of haze	0		Experience Percent (Moxie): +10, Monster Level: +10, Familiar Weight: +7, Avoid Attack: 1, Single Equip
 6474	blurry Drunkula's wineglass of the wise owl	0		Mysticality: +20
 6475	tolerable distilled bottle of Bloodweiser	5	good	
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	spinning dreadful roast	0		
 6487	narrow stinking agaricus	0		
-6488	moldy jumbo tumbling spinning Dreadsylvanian shepherd's pie	5	crappy	
+6488	moldy jumbo spinning tumbling Dreadsylvanian shepherd's pie	5	crappy	
 6489	spinning music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6408,7 +6408,7 @@
 6513	wobbly spinning arcane researcher's warm fur	0		Experience Percent (Mysticality): +10
 6514	spinning greasy snowstick	0		Sleaze Spell Damage: +10
 6515	shellacked eerie fetish	0		Damage Reduction: 7, Single Equip
-6516	triple-distilled aged stinkwater	7	awesome	
+6516	aged triple-distilled stinkwater	7	awesome	
 6517	bouncing dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	spoiled cyan accidental mutton	3	crappy	
 6519	hale boxer's drafty drawers	0		Muscle Percent: +10, Maximum HP: +20, Familiar Effect: "1.5xVolley"
@@ -6421,7 +6421,7 @@
 6526	upside-down up-at-dawn bag of unfinished business of Flo-Jo	0		Initiative: +100, Adventures: +5
 6527	censurious transparent pants of the ox	0		Muscle: +20, Sleaze Resistance: +3, Familiar Effect: "sleaze atk, 1xPotato"
 6528	skewed deadly hothammer	0		Weapon Damage: +5
-6529	perfectly mixed practically non-alcoholic Thriller Ice	1	super ultra mega turbo EPIC	
+6529	practically non-alcoholic perfectly mixed Thriller Ice	1	super ultra mega turbo EPIC	
 6530	jittery cool grandfather watch	0		Moxie: +5, Single Equip
 6531	narrow muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	jittery veiny brainy spyglass	0		Mysticality: +5, Maximum HP: +10
@@ -6442,7 +6442,7 @@
 6548	cooling iron helmet	0		
 6549	upside-down cooling iron breastplate	0		
 6550	jittery cooling iron greaves	0		
-6551	wobbly fuchsia hot cluster	0		
+6551	fuchsia wobbly hot cluster	0		
 6552	upside-down cluster	0		
 6553	cluster	0		
 6554	twirling stench cluster	0		
@@ -6456,15 +6456,15 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	maroon censurious hand of Mr. Cards	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	flavorless tiny Dreadsylvanian hot pocket	1	decent	
-6565	special bland Dreadsylvanian pocket	4	decent	Effect: "Become Intensely interested", Effect Duration: 40
+6565	bland special Dreadsylvanian pocket	4	decent	Effect: "Become Intensely interested", Effect Duration: 40
 6566	bland wobbly Dreadsylvanian pocket	3	decent	
 6567	delicious fuchsia Dreadsylvanian stink pocket	3	awesome	
 6568	moldy Dreadsylvanian sleaze pocket	3	crappy	
-6569	fortified artisanal Dreadsylvanian hot toddy	5	super EPIC	
+6569	artisanal fortified Dreadsylvanian hot toddy	5	super EPIC	
 6570	perfectly mixed pulsating Dreadsylvanian cold-fashioned	3	super ultra mega turbo EPIC	
 6571	perfectly mixed Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	
 6572	fancy aged Dreadsylvanian dank and stormy	3	awesome	Effect: "Bright!", Effect Duration: 15
-6573	acceptable narrow lime green Dreadsylvanian slithery nipple	4	good	
+6573	acceptable lime green narrow Dreadsylvanian slithery nipple	4	good	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
@@ -6500,10 +6500,10 @@
 6606	pulsating clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
 6608	clockwork numeral VIII	0		
-6609	jittery spinning clockwork numeral IX	0		
+6609	spinning jittery clockwork numeral IX	0		
 6610	clockwork numeral X	0		
-6611	spinning blurry clockwork numeral XI	0		
-6612	skewed huge clockwork numeral XII	0		
+6611	blurry spinning clockwork numeral XI	0		
+6612	huge skewed clockwork numeral XII	0		
 6613	yellow clockwork cuckoo	0		
 6614	tumbling cuckoo clock	0		
 6615	special spirit-forward bad Cold One	5	???	Effect: "Rainbow Bright", Effect Duration: 15
@@ -6544,7 +6544,7 @@
 6652	distilled drinkable stepmom's booze	5	good	
 6653	surgical tape	0		
 6654	red band T-shirt of Tarzan	0		Experience (Muscle): +3
-6655	bad irresponsibly strong fountain 'soda'	8	decent	
+6655	irresponsibly strong bad fountain 'soda'	8	decent	
 6656	illegal firecracker	0		
 6657	wizardly strapping pickelhaube	0		Muscle: +5, Mysticality: +25, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	cold-filtered yellow tumbling hair oil	0		Effect: "Extra-Wet", Effect Duration: 57
@@ -6611,12 +6611,12 @@
 6719	therapeutic midriff scrubs of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 5, HP Regen Max: 7
 6720	enhanced pill cup	0		Effect: "The Strength...  of the Future", Effect Duration: 27
 6721	arcane researcher's water bottle of the brute of the boozehound	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Booze Drop: +100, Familiar Effect: "atk, 1xFairy, cap 40"
-6722	tarnished electrified blue upside-down pygmy phone number	0		Effect: "On the Trolley", Effect Duration: 43
+6722	tarnished electrified upside-down blue pygmy phone number	0		Effect: "On the Trolley", Effect Duration: 43
 6723	purple Boozehounds Anonymous token	0		
 6724	normal huge exotic jungle fruit	3	good	
 6725	fuchsia twirling Shore Inc. Ship Trip Scrip	0		
 6726	blue dude ranch souvenir crate	0		
-6727	shaking red jittery tropical island souvenir crate	0		
+6727	red jittery shaking tropical island souvenir crate	0		
 6728	wobbly ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
 6730	funky junk key	0		
@@ -6624,7 +6624,7 @@
 6732	claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	mirror cigar sign	0		
-6735	tumbling green junk junk	0		
+6735	green tumbling junk junk	0		
 6736	jittery Junk-Bond	0		
 6737	lime green bouncing tangle of copper wire	0		
 6738	blurry jagged scrap	0		
@@ -6649,12 +6649,12 @@
 6757	special smooth can of Br&uuml;talbr&auml;u	4	awesome	Effect: "Techno Bliss", Effect Duration: 5, Last Available: "2013-09"
 6758	acceptable can of Drooling Monk	4	good	Last Available: "2013-09"
 6759	artisanal can of Impetuous Scofflaw	3	EPIC	Last Available: "2013-09"
-6760	acceptable practically non-alcoholic skewed bottle of Old Pugilist	1	good	Last Available: "2013-09"
+6760	practically non-alcoholic acceptable skewed bottle of Old Pugilist	1	good	Last Available: "2013-09"
 6761	aged wobbly bottle of Professor Beer	3	awesome	Last Available: "2013-09"
 6762	perfectly mixed bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
-6763	delicious practically non-alcoholic bottle of Race Car Red	1	awesome	Last Available: "2013-09"
+6763	practically non-alcoholic delicious bottle of Race Car Red	1	awesome	Last Available: "2013-09"
 6764	artisanal ghostly bottle of Greedy Dog	4	EPIC	Last Available: "2013-09"
-6765	practically non-alcoholic artisanal bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6765	artisanal practically non-alcoholic bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	jittery artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
@@ -6714,7 +6714,7 @@
 6825	veiny ruddy alarm accordion	0		Maximum HP Percent: +40, Maximum HP: +10, Class: "Accordion Thief", Song Duration: 20
 6826	resourceful curative sage All-Hallow's Steve's fright wig	0		Mysticality Percent: +10, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	censurious KoL Con X Treasure Map of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3
-6828	lousy watered-down discocktail	2	decent	
+6828	watered-down lousy discocktail	2	decent	
 6829	tumbling green prompt KoL Con X Bingo Card	0		Adventures: +3
 6830	Sherlock's Temporal Tempera Tube	0		Item Drop: +25
 6831	denatured galvanized Tallowcreme Halloween Pumpkin	0		Effect: "Pyromania", Effect Duration: 26
@@ -6750,7 +6750,7 @@
 6861	normal jittery can of sardines	3	good	Last Available: "2013-11"
 6862	adequate high-calorie sugar substitute	3	good	Last Available: "2013-11"
 6863	bland pat of butter	3	decent	Last Available: "2013-11"
-6864	spoiled diet dinner roll	1	crappy	Last Available: "2013-11"
+6864	diet spoiled dinner roll	1	crappy	Last Available: "2013-11"
 6865	half-sized yummy mashed potatoes	2	awesome	Last Available: "2013-11"
 6866	huge tasty whole turkey leg	6	awesome	Last Available: "2013-11"
 6867	moldy half-sized deviled egg	2	crappy	Last Available: "2013-11"
@@ -6758,7 +6758,7 @@
 6869	improved corrupted dented spoon	0		Effect: "Seriously Mutated", Effect Duration: 38, Last Available: "2013-11"
 6870	quantum diffused bouncing love note	0		Effect: "Boon of the War Snapper", Effect Duration: 42, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
-6872	vacuum-sealed irradiated squat ghostly green nail file	0		Effect: "Sweet Incentive", Effect Duration: 56, Last Available: "2013-11"
+6872	vacuum-sealed irradiated ghostly green squat nail file	0		Effect: "Sweet Incentive", Effect Duration: 56, Last Available: "2013-11"
 6873	energized electrified jittery candy wrapper	0		Effect: "Liquid Courage", Effect Duration: 45, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	anodized red post-holiday sale coupon	0		Effect: "Astral Shell", Effect Duration: 32, Last Available: "2013-11"
@@ -6807,12 +6807,12 @@
 6918	alkaline moist warbear wardance potion	0		Effect: "It Didn't Kill You", Effect Duration: 69, Last Available: "2013-12"
 6919	anodized skewed skewed warbear bearserker potion	0		Effect: "Hopped Up on Goofballs", Effect Duration: 21, Last Available: "2013-12"
 6920	flattened warbear liquid overcoat	0		Effect: "Human-Orc Hybrid", Effect Duration: 30, Last Available: "2013-12"
-6921	rotten enchanted upside-down warbear feasting bread	3	crappy	Effect: "PERL of Great Price", Effect Duration: 30, Last Available: "2013-12"
+6921	enchanted rotten upside-down warbear feasting bread	3	crappy	Effect: "PERL of Great Price", Effect Duration: 30, Last Available: "2013-12"
 6922	super-sized flavorless warbear warrior bread	5	decent	Last Available: "2013-12"
 6923	stale warbear thermoregulator bread	4	decent	Last Available: "2013-12"
 6924	smooth warbear feasting mead	3	awesome	Last Available: "2013-12"
-6925	irresponsibly strong bad warbear bearserker mead	8	decent	Last Available: "2013-12"
-6926	practically non-alcoholic acceptable shaking warbear blizzard mead	1	good	Last Available: "2013-12"
+6925	bad irresponsibly strong warbear bearserker mead	8	decent	Last Available: "2013-12"
+6926	acceptable practically non-alcoholic shaking warbear blizzard mead	1	good	Last Available: "2013-12"
 6927	ghostly warbear helm fragment	0		Last Available: "2013-12"
 6928	tumbling squat supercharged personal trainer's warbear plain fedora of James Dean	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Maximum MP Percent: +30, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
 6929	warbear feathered fedora of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
@@ -6893,12 +6893,12 @@
 7004	chilled deionized Flaskfull of Hollow	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 18, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	diluted handful of Smithereens	1	crappy	Last Available: "2013-12"
-7007	small adequate blurry squat Every Day is Like This Sundae	2	good	Last Available: "2013-12"
-7008	big tasty Miserable Pie	5	awesome	Last Available: "2013-12"
+7007	small adequate squat blurry Every Day is Like This Sundae	2	good	Last Available: "2013-12"
+7008	tasty big Miserable Pie	5	awesome	Last Available: "2013-12"
 7009	bland half-sized This Charming Flan	2	decent	Last Available: "2013-12"
 7010	mediocre Irish Coffee, English Heart	3	decent	Last Available: "2013-12"
 7011	acceptable Strikes Again Bigmouth	4	good	Last Available: "2013-12"
-7012	boozy aged upside-down Paint A Vulgar Pitcher	5	awesome	Last Available: "2013-12"
+7012	aged boozy upside-down Paint A Vulgar Pitcher	5	awesome	Last Available: "2013-12"
 7013	narrow Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	teal Handsome Devil	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	mirror skewed inspector's asbestos-lined brainy Shakespeare's Sister's Accordion	0		Mysticality: +5, Hot Resistance: +5, Item Drop: +15, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	Jack Frost's third-hand lantern	0		Cold Spell Damage: +50
 7031	loose purse strings	0		
-7032	gigantic adequate pickled egg	7	good	
+7032	adequate gigantic pickled egg	7	good	
 7033	cup of lukewarm tea	1	decent	
 7034	wobbly warbear soda machine assembler	0		Last Available: "2013-12"
 7035	jittery warbear box	0		Last Available: "2013-12"
@@ -6936,14 +6936,14 @@
 7047	Vulcanized warbear liquid lasers	0		Effect: "Salsa Satanica", Effect Duration: 66, Last Available: "2013-12"
 7048	diffused pressed jittery warbear rejuvenation potion	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 54, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	flavorless miniature teal warbear gyro	2	decent	Last Available: "2013-12"
+7050	miniature flavorless teal warbear gyro	2	decent	Last Available: "2013-12"
 7051	tarnished recording of Rolando's Rondo of Resisto	0		Effect: "You Can Taste the Darkness", Effect Duration: 61, Last Available: "2013-12"
 7052	shaking warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	spoiled huge special breakfast mess	7	crappy	Effect: "Adventurer's Best Friendship", Effect Duration: 10, Last Available: "2013-12"
+7055	huge special spoiled breakfast mess	7	crappy	Effect: "Adventurer's Best Friendship", Effect Duration: 10, Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	moldy jumbo breakfast miracle	5	crappy	Last Available: "2013-12"
+7057	jumbo moldy breakfast miracle	5	crappy	Last Available: "2013-12"
 7058	modified polarized Cloaca Cola Polar	0		Effect: "Bone Chilling", Effect Duration: 31, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6961,10 +6961,10 @@
 7072	massive yummy ice harvest	8	awesome	Last Available: "2014-01"
 7073	galvanized double-irradiated blurry frost flower	0		Effect: "Wax On Your Shoes", Effect Duration: 14, Last Available: "2014-01"
 7074	diffused extra-denatured snow cleats	0		Effect: "Ten out of Ten", Effect Duration: 42, Last Available: "2014-01"
-7075	vacuum-sealed shaking mirror liquid ice pack	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 26, Last Available: "2014-01"
+7075	vacuum-sealed mirror shaking liquid ice pack	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 26, Last Available: "2014-01"
 7076	bouncing snow boards	0		Last Available: "2014-01"
 7077	moldy snow crab	4	crappy	Last Available: "2014-01"
-7078	irresponsibly strong bad Ice Island Long Tea	6	decent	Last Available: "2014-01"
+7078	bad irresponsibly strong Ice Island Long Tea	6	decent	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	pulsating bouncing Annie Oakley's fortified savvy beefcake's snow belt	0		Muscle: +25, Mysticality Percent: +20, Damage Absorption: +60, Critical Hit Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	auspicious mansplainer's sage ice nine of bravery	0		Mysticality Percent: +10, Monster Level: +15, Spooky Resistance: +5, Item Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7089	maroon snow fort	0		Last Available: "2014-01"
-7090	acceptable watered-down En Una Fila Tequila	2	good	
+7090	watered-down acceptable En Una Fila Tequila	2	good	
 7091	teal Skully's hot chocolate	1	decent	
 7092	electrified Oprah's warbear dress helmet	0		Maximum MP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	greasy sinister warbear dress bracers	0		Spell Damage: +10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2013-12"
@@ -6995,16 +6995,16 @@
 7106	tolerable triple-distilled snakebite	6	good	Last Available: "2014-12"
 7107	tumbling Van der Graaf candy stick of the sewer	0		Stench Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7108	moldy small pecan	2	crappy	Last Available: "2014-12"
-7109	moldy small pulsating pecan pie	2	crappy	Last Available: "2014-12"
+7109	small moldy pulsating pecan pie	2	crappy	Last Available: "2014-12"
 7110	huge chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	delicious candy mountain oyster	3	awesome	Last Available: "2014-12"
-7112	high-proof artisanal chocotini	8	EPIC	Last Available: "2014-12"
+7112	artisanal high-proof chocotini	8	EPIC	Last Available: "2014-12"
 7113	zippy Rosewater's chocolate rabbit's foot of the early riser	0		Mysticality Percent: +30, Initiative: +20, Adventures: +7, Last Available: "2014-12"
 7114	spoiled red candy carrot	3	crappy	Last Available: "2014-12"
 7115	adequate mirror candy carrot cake	3	good	Last Available: "2014-12"
 7116	lion tamer's hardy carrot-on-a-stick	0		Maximum HP: +50, Experience (familiar): +2, Last Available: "2014-12"
 7117	fuchsia wholesome weasel stomping pants of the empath	0		Maximum HP Percent: +10, Familiar Weight: +5, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	special flavorless miniature skewed pulsating mulberry	2	decent	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2014-12"
+7118	special miniature flavorless pulsating skewed mulberry	2	decent	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2014-12"
 7119	weak hand-crafted mulled berry wine	2	super ultra mega EPIC	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	lemon party hat of chilblains	0		Cold Damage: +25, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
@@ -7044,28 +7044,28 @@
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	blurry hardy stylish fire hose of extreme caution	0		Moxie: +25, Maximum HP: +50, Monster Level: -25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	bland half-sized fireman's lunch	2	decent	Last Available: "2014-12"
+7158	half-sized bland fireman's lunch	2	decent	Last Available: "2014-12"
 7159	huge stiffened Rosewater's beefcake's plain paper hat	0		Muscle: +25, Mysticality Percent: +30, Damage Reduction: 1, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	moldy enchanted ice cream sandwich	4	crappy	Effect: "Executive Greed", Effect Duration: 30, Last Available: "2014-12"
 7161	skewed executive educational &quot;honey&quot; dipper of extreme caution	0		Experience: +1, Monster Level: -25, Meat Drop: +40, Last Available: "2014-12"
-7162	spoiled half-sized special fuchsia spinning plumber's lunch	2	crappy	Effect: "Toast Tea", Effect Duration: 20, Last Available: "2014-12"
+7162	half-sized spoiled special spinning fuchsia plumber's lunch	2	crappy	Effect: "Toast Tea", Effect Duration: 20, Last Available: "2014-12"
 7163	therapeutic ruddy educational skull gearshift knob	0		Experience: +1, Maximum HP Percent: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7164	snack-sized rotten nachos of the night	2	crappy	Last Available: "2014-12"
 7165	scandalous mansplainer's slick Sketcherz&trade;	0		Moxie: +10, Monster Level: +15, Sleaze Damage: +5, Last Available: "2014-12"
 7166	adequate can of Adultwitch&trade;	4	good	Last Available: "2014-12"
 7167	energized triple-boiled smudge stick	0		Effect: "Bone Chilling", Effect Duration: 64, Last Available: "2014-12"
 7168	electrified wall	0		Effect: "Frosty the Hitman", Effect Duration: 28, Last Available: "2014-12"
-7169	artisanal enchanted tankard of ale	4	EPIC	Effect: "Spiky Hair", Effect Duration: 25, Last Available: "2014-12"
+7169	enchanted artisanal tankard of ale	4	EPIC	Effect: "Spiky Hair", Effect Duration: 25, Last Available: "2014-12"
 7170	improved improved red scroll case	0		Effect: "Chlorophyll Flavor", Effect Duration: 68, Last Available: "2014-12"
 7171	aerosolized quadruple-galvanized huge jug of &quot;wine&quot;	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 26, Last Available: "2014-12"
 7172	spinning juggling ball	0		Last Available: "2014-12"
-7173	squat yellow crappy camera	0		Last Available: "2014-12"
+7173	yellow squat crappy camera	0		Last Available: "2014-12"
 7174	bland spinning humble pie	3	decent	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	oxidized pulsating crappy waiter disguise	0		Effect: "Sewer-Drenched", Effect Duration: 22
 7178	Copperhead Charm	0		
-7179	red blurry The First Pizza	0		
+7179	blurry red The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7082,17 +7082,17 @@
 7193	throwing spoon	0		
 7194	mirror throwing fork	0		
 7195	flame-wreathed Sinatra's breadchucks	0		Experience (Moxie): +5, Hot Spell Damage: +10
-7196	jittery narrow shuriken salad	0		
+7196	narrow jittery shuriken salad	0		
 7197	ghostly combat fan of Flo-Jo	0		Initiative: +100
 7198	maroon veiny Samson's silk skirt	0		Experience (Muscle): +5, Maximum HP: +10, Familiar Effect: "atk, 1xFairy, cap 38"
-7199	huge wobbly blowdart	0		
+7199	wobbly huge blowdart	0		
 7200	Buddy Bjorn of the storm	0		Maximum MP Percent: +40, Softcore Only, Last Available: "2014-02"
 7201	bouncing avaricious flame-retardant wicked The Nuge's favorite crossbow	0		Spell Damage: +5, Hot Resistance: +1, Meat Drop: +30
 7202	stale red sweet roll Alabama	3	decent	
 7203	upside-down chaotic Saturday Night Special	0		Spell Critical Percent: +10
 7204	lynyrd snare	0		
 7205	shaking lion tamer's fleetwood chain	0		Experience (familiar): +2
-7206	high-proof mediocre special Green Manalishi	10	decent	Effect: "Dexteri Tea", Effect Duration: 20
+7206	mediocre special high-proof Green Manalishi	10	decent	Effect: "Dexteri Tea", Effect Duration: 20
 7207	blurry greasy blade	0		Sleaze Spell Damage: +10
 7208	spinning fire of unknown origin	0		
 7209	upside-down eagle's milk	1	EPIC	
@@ -7100,7 +7100,7 @@
 7211	dry upside-down one pill	0		Effect: "Nano-juiced", Effect Duration: 43
 7212	horrifying Jefferson wings	0		Spooky Damage: +25
 7213	fleetwood macaroni	0		
-7214	blurry olive cheesy eagle sauce	0		
+7214	olive blurry cheesy eagle sauce	0		
 7215	spoiled bite-sized olive fleetwood mac 'n' cheese	1	crappy	
 7216	blurry lynyrd skin	0		
 7217	stiffened lynyrdskin cap	0		Damage Reduction: 1, Familiar Effect: "1xPotato, 1xVolley, cap 42"
@@ -7116,8 +7116,8 @@
 7227	delicious spirit-forward bottle of Evermore	5	awesome	
 7228	wobbly box	0		
 7229	practically non-alcoholic smooth wine	1	awesome	
-7230	watered-down bad rum	2	decent	
-7231	irresponsibly strong mediocre Murderer's Punch	6	decent	
+7230	bad watered-down rum	2	decent	
+7231	mediocre irresponsibly strong Murderer's Punch	6	decent	
 7232	tasty lime green velvet cake	3	awesome	
 7233	super-colloidal adjusted bouncing letter	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 32
 7234	mirror grievous book of Gandalf	0		Weapon Damage Percent: +50, Spell Critical Percent: +20
@@ -7152,7 +7152,7 @@
 7263	fuchsia photograph of a dog	0		
 7264	photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
-7266	yellow squat disposable instant camera	0		
+7266	squat yellow disposable instant camera	0		
 7267	olive lion tamer's supercharged smartaleck's Sneaky Pete's jacket (collar popped) of the ox	0		Muscle: +20, Moxie Percent: +30, Maximum MP Percent: +30, Experience (familiar): +2, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	ghostly red Professor What garment	0		
@@ -7229,18 +7229,18 @@
 7340	electrified moose antlers	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	electrified frozen moose thought	0		Effect: "Stinky Hands", Effect Duration: 13
 7342	stale green moose chocolate	4	decent	
-7343	watered-down bad huge red painting of a glass of wine	2	decent	
+7343	bad watered-down red huge painting of a glass of wine	2	decent	
 7344	upside-down blinking oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	skewed lightning-fast ghost toga of the pedagogue	0		Experience: +3, Initiative: +40
-7348	normal small twirling spinning sheet cake	2	good	
+7348	small normal spinning twirling sheet cake	2	good	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	manspreader's Lo Pan's Staff of the Electric Range of the detective	0		Spell Critical Percent: +30, Monster Level: +10, Item Drop: +20
 7352	adequate deluxe layer cake	4	good	
 7353	chunk of hot iron	0		
-7354	high-proof aged red-hot boilermaker	10	awesome	
+7354	aged high-proof red-hot boilermaker	10	awesome	
 7355	bouncing horrifying coal shovel	0		Spooky Damage: +25, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	Vulcanized huge hot coal	0		Effect: "Pemmican't", Effect Duration: 17
 7357	diffused improved adjusted green coal dust	0		Effect: "Itchy Trigger Finger", Effect Duration: 29
@@ -7255,13 +7255,13 @@
 7366	aged bottle of laundry sherry	3	awesome	
 7367	warmed industrial strength starch	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 60, Wiki Name: "industrial strength starch"
 7368	half-sized toothsome extra-flat panini	2	awesome	
-7369	dry squat ghostly mangled finger	0		Effect: "Hyphemariffic", Effect Duration: 49
+7369	dry ghostly squat mangled finger	0		Effect: "Hyphemariffic", Effect Duration: 49
 7370	drinkable Psychotic Train wine	3	good	
 7371	crazy hobo notebook	0		
 7372	adequate pie man was not meant to eat	3	good	
 7373	squat lightning-fast sommelier's towel	0		Initiative: +40
 7374	aromatic tarnished tastevin	0		Stench Resistance: +1, Single Equip
-7375	yummy huge actual tapas	9	awesome	
+7375	huge yummy actual tapas	9	awesome	
 7376	skewed ghast iron ingot	0		
 7377	blurry purple ribald ghast iron cleaver of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10
 7378	shellacked ghast iron Garibaldi	0		Damage Reduction: 7, Item Drop: +5, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7299,7 +7299,7 @@
 7410	Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
 7412	gray Steam Card: Meteoid (#1)	0		
-7413	skewed wobbly wobbly Steam Card: Meteoid (#2)	0		
+7413	wobbly wobbly skewed Steam Card: Meteoid (#2)	0		
 7414	pulsating squat Steam Card: Meteoid (#3)	0		
 7415	Steam Card: DemonStar (#1)	0		
 7416	blurry Steam Card: DemonStar (#2)	0		
@@ -7321,28 +7321,28 @@
 7432	quadruple-frozen wet wobbly Omphalotus Omphaloskepsis mushroom	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 11, Last Available: "2014-05"
 7433	diffused gray Gyromitra Dynomita mushroom	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 22, Last Available: "2014-05"
 7434	Vulcanized dry Helvella Haemophilia mushroom	0		Effect: "Greedy Resolve", Effect Duration: 63, Last Available: "2014-05"
-7435	quantum concentrated tumbling ghostly Stemonitis Staticus mushroom	0		Effect: "Initiative and Let Die", Effect Duration: 13, Last Available: "2014-05"
+7435	quantum concentrated ghostly tumbling Stemonitis Staticus mushroom	0		Effect: "Initiative and Let Die", Effect Duration: 13, Last Available: "2014-05"
 7436	diffused Tremella Tarantella mushroom	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 12, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	flavorless bouncing Beefy Crunch Pastaco	4	decent	Last Available: "2014-05"
-7439	moldy small special Brain Food Pastaco	2	crappy	Effect: "Mucilaginous Moxiousness", Effect Duration: 45, Last Available: "2014-05"
+7439	small special moldy Brain Food Pastaco	2	crappy	Effect: "Mucilaginous Moxiousness", Effect Duration: 45, Last Available: "2014-05"
 7440	yummy Cool Brunch Pastaco	3	awesome	Last Available: "2014-05"
-7441	adequate half-sized Medical Pastaco	2	good	Last Available: "2014-05"
+7441	half-sized adequate Medical Pastaco	2	good	Last Available: "2014-05"
 7442	adequate Energy Buzz Pastaco	3	good	Last Available: "2014-05"
-7443	thick rotten Ludovico Pastaco	5	crappy	Last Available: "2014-05"
-7444	delicious mirror twirling lime green overpowering mushroom wine	3	awesome	Last Available: "2014-05"
+7443	rotten thick Ludovico Pastaco	5	crappy	Last Available: "2014-05"
+7444	delicious lime green mirror twirling overpowering mushroom wine	3	awesome	Last Available: "2014-05"
 7445	lousy complex mushroom wine	3	decent	Last Available: "2014-05"
-7446	perfectly mixed watered-down blurry smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7446	watered-down perfectly mixed blurry smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	smooth blood-red mushroom wine	3	awesome	Last Available: "2014-05"
 7448	aged huge buzzing mushroom wine	4	awesome	Last Available: "2014-05"
-7449	weak bad swirling mushroom wine	2	decent	Last Available: "2014-05"
-7450	snack-sized bland red Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
+7449	bad weak swirling mushroom wine	2	decent	Last Available: "2014-05"
+7450	bland snack-sized red Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
 7451	flavorless Taco Dan's Taco Fish Fish Taco	4	decent	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	perfectly mixed regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	extra-dry acceptable super-size brogurt	5	good	Last Available: "2014-05"
 7455	aged broberry brogurt	3	awesome	Last Available: "2014-05"
-7456	perfectly mixed jittery huge brocolate brogurt	4	EPIC	Last Available: "2014-05"
+7456	perfectly mixed huge jittery brocolate brogurt	4	EPIC	Last Available: "2014-05"
 7457	weak mediocre yellow French bronilla brogurt	2	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
@@ -7358,36 +7358,36 @@
 7469	fuchsia Herculean extremely wet T-shirt of the wise owl of Calamity Jane	0		Mysticality: +20, Experience (Muscle): +1, Critical Hit Percent: +15, Last Available: "2014-05"
 7470	censurious coward's shrimp fork of the detective	0		Monster Level: -20, Sleaze Resistance: +3, Item Drop: +20, Last Available: "2014-05"
 7471	wet non-polymerized BROS Energy Drink	0		Effect: "Phairly Balanced", Effect Duration: 50, Last Available: "2014-05"
-7472	triple-colloidal huge shaking go-go potion	0		Effect: "Memory of Resilience", Effect Duration: 61, Last Available: "2014-05"
+7472	triple-colloidal shaking huge go-go potion	0		Effect: "Memory of Resilience", Effect Duration: 61, Last Available: "2014-05"
 7473	unsweetened adjusted jittery shrimp cocktail	0		Effect: "Petit Force", Effect Duration: 44, Last Available: "2014-05"
 7474	flattened galvanized Yolo&trade; chocolates	0		Effect: "Papowerful", Effect Duration: 36, Last Available: "2020-09"
 7475	foul-smelling string of moist beads	0		Stench Damage: +10, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	corrupted polarized blue Meat-inflating powder	0		Effect: "Alacri Tea", Effect Duration: 65, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
-7479	liquefied purple wobbly sugar fairy	0		Effect: "Amorous", Effect Duration: 53, Last Available: "2014-05"
+7479	liquefied wobbly purple sugar fairy	0		Effect: "Amorous", Effect Duration: 53, Last Available: "2014-05"
 7480	corrupted enhanced galvanized sugar bunny	0		Effect: "Smoky Third Eye", Effect Duration: 25, Last Available: "2014-05"
 7481	blinking sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	watered-down hand-crafted twirling Rompedores de Fantasmas	2	EPIC	
 7483	enchanted acceptable La Fantasma y La Oscuridad	4	good	Effect: "Pronounced Potency", Effect Duration: 20
-7484	aged practically non-alcoholic wobbly Fantasma en la M&aacute;quina	1	awesome	
+7484	practically non-alcoholic aged wobbly Fantasma en la M&aacute;quina	1	awesome	
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	spinning drain dissolver	0		
 7488	triple-distilled turpentine	0		
-7489	cyan spinning detartrated anhydrous sublicalc	0		
+7489	spinning cyan detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
 7491	lousy bottle of Chateau de Vinegar	3	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
-7494	pulsating twirling wine bomb	0		
+7494	twirling pulsating wine bomb	0		
 7495	bouncing recipe: mortar-dissolving solution	0		
 7496	ghostly bottled day	0		
 7497	twirling jittery ghost formula	0		
-7498	huge tumbling Thwaitgold wheel bug statuette	0		
+7498	tumbling huge Thwaitgold wheel bug statuette	0		
 7499	diffused ionized spinning Hot 'n' Scarys	0		Effect: "Bananas!", Effect Duration: 49
 7500	mirror map	0		
-7501	squat spinning	0		
+7501	spinning squat	0		
 7502	non-liquefied twirling squat Texas tea	0		Effect: "Creepypasted", Effect Duration: 58
 7503	purple Da Vinci's dark hamethyst ring	0		Experience (Mysticality): +5
 7504	narrow dark baconstone ring of the early riser	0		Adventures: +7
@@ -7398,14 +7398,14 @@
 7509	tasty Mornington crescent roll	4	awesome	
 7510	ionized super-moist eye shadow	0		Effect: "Mighty Shout", Effect Duration: 56
 7511	crumbling wheel	0		
-7512	corrupted magnetized tumbling lime green poppy	0		Effect: "Berry Defensive", Effect Duration: 52
+7512	corrupted magnetized lime green tumbling poppy	0		Effect: "Berry Defensive", Effect Duration: 52
 7513	upside-down opium grenade	0		
 7514	rosewater-soaked double-paned duonoculars	0		Cold Resistance: +5, Stench Resistance: +3, Single Equip
 7515	pulsating plastic rock	0		
 7516	jittery witch's spare house key	0		
 7517	maroon foul-smelling Tesla spider leg	0		Stench Damage: +10, MP Regen Min: 7, MP Regen Max: 10
 7518	wand of pigification	0		
-7519	acceptable practically non-alcoholic glass of bourbon	1	good	
+7519	practically non-alcoholic acceptable glass of bourbon	1	good	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	rotten half-sized gray government cheese	2	crappy	Last Available: "2014-05"
 7522	skewed pair of government shades of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2014-05"
@@ -7415,13 +7415,13 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	red lion tamer's government-issued night-vision goggles of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Single Equip, Last Available: "2014-05"
-7529	bland jumbo loaf of alien bread	5	decent	Last Available: "2014-05"
+7529	jumbo bland loaf of alien bread	5	decent	Last Available: "2014-05"
 7530	bland diet grilled cheese sandwich	1	decent	Last Available: "2014-05"
 7531	dehydrated skewed maroon alien protein powder	1	awesome	Last Available: "2014-05"
 7532	tolerable enchanted mirror rocket fuel	3	good	Effect: "Burning Ears", Effect Duration: 15, Last Available: "2014-05"
-7533	yellow jittery alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7533	jittery yellow alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	teal pulsating alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	bad practically non-alcoholic stealth bomber	1	decent	Last Available: "2014-05"
+7535	practically non-alcoholic bad stealth bomber	1	decent	Last Available: "2014-05"
 7536	jittery space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7433,22 +7433,22 @@
 7544	space bar	0		Last Available: "2014-05"
 7545	bad space port	3	decent	Last Available: "2014-05"
 7546	narrow occult Sinatra's space needle	0		Experience (Moxie): +5, Spell Damage Percent: +25, Last Available: "2014-05"
-7547	cold-filtered blue tumbling buffed alien drugs	0		Effect: "Gummiskin", Effect Duration: 20, Last Available: "2014-05"
+7547	cold-filtered tumbling blue buffed alien drugs	0		Effect: "Gummiskin", Effect Duration: 20, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
 7549	boiled ash soda	0		Effect: "Armored Innards", Effect Duration: 67, Last Available: "2014-06"
 7550	dry anodized liquid smoke	0		Effect: "Human-Horror Hybrid", Effect Duration: 11, Last Available: "2014-06"
 7551	cold-filtered super-moist dollop of barbecue sauce	0		Effect: "Serenity", Effect Duration: 68, Last Available: "2014-06"
 7552	tarnished galvanized bowl of marinade	0		Effect: "Hare-o-dynamic", Effect Duration: 27, Last Available: "2014-06"
-7553	skewed blue squat shaker of dry rub	0		Last Available: "2014-06"
+7553	blue squat skewed shaker of dry rub	0		Last Available: "2014-06"
 7554	moist cold-filtered mirror bottle of lighter fluid	0		Effect: "The Power of Negative Thinking", Effect Duration: 15, Last Available: "2014-06"
 7555	page	0		
 7556	upside-down elephant gift	0		
 7557	quadruple-polarized extra-tarnished blood cells	0		Effect: "Pumped Up", Effect Duration: 12
-7558	bad distilled wine	5	decent	
+7558	distilled bad wine	5	decent	
 7559	deionized ionized gummi turtle	0		Effect: "Just the Brown Ones", Effect Duration: 23
-7560	pulsating blinking turtle-shaped rock	0		
+7560	blinking pulsating turtle-shaped rock	0		
 7561	galvanized boiled skewed lime green giraffe-necked turtle	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 27
-7562	triple-tarnished tarnished pulsating squat musk turtle	0		Effect: "Natural 20", Effect Duration: 36
+7562	triple-tarnished tarnished squat pulsating musk turtle	0		Effect: "Natural 20", Effect Duration: 36
 7563	boiled twirling green programmable turtle	0		Effect: "Rushin' Hands", Effect Duration: 68
 7564	polymerized mocking turtle	0		Effect: "Angry like the Wolf", Effect Duration: 35
 7565	toothsome huge ham steak	3	awesome	
@@ -7468,7 +7468,7 @@
 7579	twitching time capsule	0		
 7580	boiled skewed liquid shifting time weirdness	1		Effect: "Frozen Hands", Effect Duration: 45
 7581	upside-down shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	snack-sized decent rack of dinosaur ribs	2	good	
+7582	decent snack-sized rack of dinosaur ribs	2	good	
 7583	bad scotch on the rocks	3	decent	
 7584	aromatic cool yabba dabba doo rag	0		Moxie: +5, Stench Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	sharpshooter's wooly loincloth of courage	0		Critical Hit Percent: +10, Spooky Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7476,12 +7476,12 @@
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	hand-crafted triple-distilled glass of &quot;milk&quot;	7	EPIC	Last Available: "2014-07"
-7590	fortified lousy enchanted cup of &quot;tea&quot;	5	decent	Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2014-07"
+7590	enchanted fortified lousy cup of &quot;tea&quot;	5	decent	Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2014-07"
 7591	mediocre thermos of &quot;whiskey&quot;	3	decent	Last Available: "2014-07"
 7592	high-proof aged Lucky Lindy	6	awesome	Last Available: "2014-07"
 7593	aged irresponsibly strong Bee's Knees	7	awesome	Last Available: "2014-07"
 7594	smooth Sockdollager	4	awesome	Last Available: "2014-07"
-7595	lousy fancy weak Ish Kabibble	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2014-07"
+7595	lousy weak fancy Ish Kabibble	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2014-07"
 7596	mediocre watered-down Hot Socks	2	decent	Last Available: "2014-07"
 7597	acceptable boozy Phonus Balonus	5	good	Last Available: "2014-07"
 7598	delicious Flivver	4	awesome	Last Available: "2014-07"
@@ -7512,7 +7512,7 @@
 7623	activated adjusted altered upside-down Red Army camouflage kit	0		Effect: "Your Favorite Flavor", Effect Duration: 63
 7624	nitrogenated lynyrd skinner toothblack	0		Effect: "Educated (Kinda)", Effect Duration: 29
 7625	modified green flask of rainwater	0		Effect: "Emotion Sickness", Effect Duration: 48
-7626	adjusted spinning wobbly oyster badge	0		Effect: "Tiki Temerity", Effect Duration: 43
+7626	adjusted wobbly spinning oyster badge	0		Effect: "Tiki Temerity", Effect Duration: 43
 7627	denatured non-oxidized plastic Jefferson wings	0		Effect: "Demonic Flavor", Effect Duration: 68
 7628	corrupted dancing fan	0		Effect: "Shoesauce", Effect Duration: 57
 7629	ionized teal page of the Necrohobocon	0		Effect: "Uncanny Shot", Effect Duration: 40
@@ -7546,9 +7546,9 @@
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	blinking rosewater-soaked neoprene skullcap	0		Stench Resistance: +3, Familiar Effect: "atk, 1xFairy, cap 16"
-7660	double-cold-filtered upside-down twirling goblin water	0		Effect: "Painted-On Bikini", Effect Duration: 41
+7660	double-cold-filtered twirling upside-down goblin water	0		Effect: "Painted-On Bikini", Effect Duration: 41
 7661	squat dumb mud	0		
-7662	normal half-sized Sogg-Os	2	good	
+7662	half-sized normal Sogg-Os	2	good	
 7663	squat Samson's smartaleck's Lord Soggyraven's Slippers of bravery	0		Moxie Percent: +30, Experience (Muscle): +5, Spooky Resistance: +5, Single Equip
 7664	denatured vacuum-sealed Ancient Protector Soda	0		Effect: "Third Based", Effect Duration: 21
 7665	polymerized modified liquid ice	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 43
@@ -7563,7 +7563,7 @@
 7674	chaotic hep waders	0		Spell Critical Percent: +10, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	flavorless gigantic maroon jive turkey leg	10	decent	
 7676	gray spinning scorching birdbone corset	0		Hot Damage: +25
-7677	frozen unsweetened ghostly twirling candy cigarette	0		Effect: "Frigid Weapon", Effect Duration: 25
+7677	frozen unsweetened twirling ghostly candy cigarette	0		Effect: "Frigid Weapon", Effect Duration: 25
 7678	Jack Frost's 4-dimensional fez	0		Cold Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	wobbly stanky super-absorbent tarp	0		Stench Spell Damage: +25
@@ -7591,7 +7591,7 @@
 7702	modified improved confiscated love note	0		Effect: "Broberry Brotality", Effect Duration: 38, Last Available: "2014-08"
 7703	squat LCD game: Food Eater	0		Last Available: "2014-08"
 7704	narrow LCD game: Garbage River	0		Last Available: "2014-08"
-7705	blurry shaking LCD game: Burger Belt	0		Last Available: "2014-08"
+7705	shaking blurry LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	denatured blue rubber nubbin	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 47, Last Available: "2014-08"
 7708	pulsating lightning-fast banded rubber cape	0		Damage Absorption: +100, Initiative: +40, Last Available: "2014-08"
@@ -7601,7 +7601,7 @@
 7712	upside-down beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	normal Strix stix	4	good	
 7714	rosewater-soaked scorching vampire pellet of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Stench Resistance: +3
-7715	mediocre high-proof enchanted narrow non-aged vinegar	6	decent	Effect: "Super Accuracy", Effect Duration: 25
+7715	enchanted high-proof mediocre narrow non-aged vinegar	6	decent	Effect: "Super Accuracy", Effect Duration: 25
 7716	shaking flame-retardant unsanitized scalpel	0		Hot Resistance: +1
 7717	wicked gladiator tunica	0		Spell Damage: +5
 7718	Jeselnik's Roman sadnals	0		Sleaze Damage: +25, Single Equip
@@ -7650,7 +7650,7 @@
 7761	pulsating holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
-7764	diluted yellow shaking residual zeal	1		Last Available: "2014-09"
+7764	diluted shaking yellow residual zeal	1		Last Available: "2014-09"
 7765	coward's Xiblaxian holo-wrist-puter	0		Monster Level: -20, Last Available: "2014-09"
 7766	smartaleck's defective Golden Mr. Accessory of Leguizamo of the blizzard	0		Moxie Percent: +30, Monster Level: +20, Cold Spell Damage: +25
 7767	airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	inspector's reassuring lard-coated Personal Ventilation Unit	0		Sleaze Spell Damage: +25, Spooky Resistance: +1, Item Drop: +15, Single Equip, Last Available: "2014-10"
 7771	liquefied the most dangerous bait	0		Effect: "Boletus Swoletus", Effect Duration: 16, Last Available: "2014-10"
-7772	massive adequate tumbling narrow &quot;meat&quot; stick	7	good	Last Available: "2014-10"
+7772	massive adequate narrow tumbling &quot;meat&quot; stick	7	good	Last Available: "2014-10"
 7773	boiled narrow transdermal smoke patch	1	decent	Effect: "Feet of Grapefruit", Effect Duration: 45, Last Available: "2014-10"
 7774	pulsating specialty ammo bandolier	0		Last Available: "2014-10"
 7775	Lo Pan's fortified thinker's pair of plants	0		Mysticality: +10, Damage Absorption: +60, Spell Critical Percent: +30, Last Available: "2014-10"
@@ -7668,7 +7668,7 @@
 7779	triple-anodized experimental serum G-9	0		Effect: "protect.enq", Effect Duration: 38, Last Available: "2014-10"
 7780	careful Herculean boxer's heavy-duty clipboard	0		Muscle Percent: +10, Experience (Muscle): +1, Monster Level: -10, Damage Reduction: 8, Last Available: "2014-10"
 7781	green narrow knitted ruddy dangerous battery-powered drill of extreme caution	0		Weapon Damage: +10, Maximum HP Percent: +40, Monster Level: -25, Cold Resistance: +3, Last Available: "2014-10"
-7782	huge decent limp broccoli	7	good	Last Available: "2014-10"
+7782	decent huge limp broccoli	7	good	Last Available: "2014-10"
 7783	savvy hat of doom of Flo-Jo	0		Mysticality Percent: +20, Spooky Spell Damage: +50, Initiative: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	frozen irradiated irradiated spinning monkey barf	0		Effect: "Ticking Clock", Effect Duration: 64, Last Available: "2014-10"
 7785	aerosolized candy	0		Effect: "Paging Betty", Effect Duration: 49, Last Available: "2014-10"
@@ -7683,10 +7683,10 @@
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	moldy wobbly initiative shawarma	3	crappy	Last Available: "2014-10"
 7796	bland thick warm war shawarma	5	decent	Last Available: "2014-10"
-7797	stale half-sized karma shawarma	2	decent	Last Available: "2014-10"
-7798	high-proof delicious Jungle Juice	9	awesome	Last Available: "2014-10"
+7797	half-sized stale karma shawarma	2	decent	Last Available: "2014-10"
+7798	delicious high-proof Jungle Juice	9	awesome	Last Available: "2014-10"
 7799	lousy Amnesiac Ale	4	decent	Last Available: "2014-10"
-7800	practically non-alcoholic artisanal fuchsia Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
+7800	artisanal practically non-alcoholic fuchsia Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
 7801	jittery frightening coward's mercenary pistol	0		Monster Level: -20, Spooky Damage: +5, Last Available: "2014-10"
 7802	spinning studded fortified mercenary rifle	0		Damage Absorption: 140, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7697,10 +7697,10 @@
 7808	unused soap	0		
 7809	impure gasoline	0		
 7810	spinning Z-Bone steak	0		
-7811	ghostly pulsating viral DNA	0		
+7811	pulsating ghostly viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	bland snack-sized seared dino steak	2	decent	
-7814	drinkable triple-distilled narrow green ghostly bottle of drinkin' gas	9	good	
+7813	snack-sized bland seared dino steak	2	decent	
+7814	drinkable triple-distilled ghostly narrow green bottle of drinkin' gas	9	good	
 7815	spinning handful of napalm	0		
 7816	dove DNA	0		
 7817	cyan gelatinous meat mass	0		
@@ -7726,7 +7726,7 @@
 7837	Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	pulsating special clip: tracers	0		Last Available: "2014-10"
-7840	gray skewed huge special clip: wailers	0		Last Available: "2014-10"
+7840	gray huge skewed special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	narrow special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
@@ -7777,7 +7777,7 @@
 7888	Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	jittery Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	blurry Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
-7891	yellow mirror Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
+7891	mirror yellow Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
@@ -7786,7 +7786,7 @@
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	cyan Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
-7900	tumbling blinking maroon Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
+7900	maroon tumbling blinking Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	pulsating Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	green Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
@@ -7798,7 +7798,7 @@
 7909	teal recovered elf wallet	0		Last Available: "2014-12"
 7910	narrow recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	wobbly recovered elf photo album	0		Last Available: "2014-12"
-7912	gray upside-down recovered elf smartphone	0		Last Available: "2014-12"
+7912	upside-down gray recovered elf smartphone	0		Last Available: "2014-12"
 7913	upside-down Oprah's weightlifter's Size XI Wizard's Robe of the ox	0		Muscle: 35, Maximum MP Percent: +50, Last Available: "2014-09"
 7914	moist jittery Bit O' Quail Spleen	0		Effect: "Grape Expectations", Effect Duration: 38
 7915	oxidized Take Eleven Bar	0		Effect: "Shawarma Warm War", Effect Duration: 44
@@ -7811,9 +7811,9 @@
 7922	delicious Friendly Turkey	4	awesome	Last Available: "2014-11"
 7923	weak acceptable Agitated Turkey	2	good	Last Available: "2014-11"
 7924	tolerable teal Ambitious Turkey	3	good	Last Available: "2014-11"
-7925	tiny tasty red neutron lollipop	1	awesome	Last Available: "2014-12"
+7925	tasty tiny red neutron lollipop	1	awesome	Last Available: "2014-12"
 7926	acceptable weak gamma nog	2	good	Last Available: "2014-12"
-7934	twirling yellow sneaky wrapping paper	0		Last Available: "2014-12"
+7934	yellow twirling sneaky wrapping paper	0		Last Available: "2014-12"
 7935	narrow Thwaitgold nit statuette	0		
 7936	purple picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
@@ -7839,7 +7839,7 @@
 7957	even more tinsel	0		Familiar Weight: +5
 7958	red jittery box of Crimbo decorations	0		
 7959	ghostly letter to Ed the Undying	0		
-7960	olive shaking mirror copy of a jerk adventurer's father's diary	0		
+7960	shaking olive mirror copy of a jerk adventurer's father's diary	0		
 7961	twirling coward's Annie Oakley's razor-sharp supercool Staff of Ed	0		Moxie Percent: +20, Weapon Damage Percent: +25, Critical Hit Percent: +20, Monster Level: -20
 7962	skewed cyan Eye of Ed	0		
 7963	skewed amulet	0		
@@ -7850,11 +7850,11 @@
 7968	mirror topiary nugglet	0		
 7969	beehive	0		
 7970	upside-down boning knife	0		
-7971	olive blinking Aggressive Carrot	0		Free Pull
+7971	blinking olive Aggressive Carrot	0		Free Pull
 7972	dried tumbling mummified fig	1	EPIC	Effect: "Mad at Science", Effect Duration: 50
 7973	dried mummified loaf of bread	1	crappy	Effect: "Sweet Tooth", Effect Duration: 50
-7974	altered shaking mirror twirling mummified beef haunch	1	decent	Effect: "Frosty the Hitman", Effect Duration: 10
-7975	huge narrow linen bandages	0		
+7974	altered twirling mirror shaking mummified beef haunch	1	decent	Effect: "Frosty the Hitman", Effect Duration: 10
+7975	narrow huge linen bandages	0		
 7976	cotton bandages	0		
 7977	silk bandages	0		
 7978	huge holy spring water	0		
@@ -7899,8 +7899,8 @@
 8017	quantum polarized flask of tainted mining oil	0		Effect: "Bear Clawed", Effect Duration: 63, Last Available: "2014-12"
 8018	Vulcanized ionized narrow and rain stick	0		Effect: "Balls of Ectoplasm", Effect Duration: 40
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	bite-sized stale special Choco-Mint patty	1	decent	Effect: "Black Lung", Effect Duration: 45, Last Available: "2015-01"
-8021	perfectly mixed huge twirling hot mint schnocolate	4	EPIC	Last Available: "2015-01"
+8020	stale bite-sized special Choco-Mint patty	1	decent	Effect: "Black Lung", Effect Duration: 45, Last Available: "2015-01"
+8021	perfectly mixed twirling huge hot mint schnocolate	4	EPIC	Last Available: "2015-01"
 8022	distilled narrow homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	censurious Annie Oakley's tope&eacute;	0		Critical Hit Percent: +20, Sleaze Resistance: +3, Familiar Effect: "3xBarrr, cap 12"
 8035	ribald sage topiary tights	0		Mysticality Percent: +10, Sleaze Damage: +10
 8036	huge maroon supercool topiary necktie	0		Moxie Percent: +20
-8037	delicious massive bowl of topioca	8	awesome	
+8037	massive delicious bowl of topioca	8	awesome	
 8038	teal topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -8047,7 +8047,7 @@
 8173	red up-at-dawn sewer snake	0		Adventures: +5
 8174	decent snack-sized gray tumbling pigeon egg	2	good	
 8175	wholesome beefy jaunty feather	0		Muscle: +10, Maximum HP Percent: +10
-8176	weak perfectly mixed olive blinking shaking premium malt liquor	2	EPIC	
+8176	weak perfectly mixed blinking shaking olive premium malt liquor	2	EPIC	
 8177	quilted brown paper pants of wisdom	0		Mysticality: +15, Damage Absorption: +40
 8178	frosty occult brown paper bag mask	0		Spell Damage Percent: +25, Cold Spell Damage: +10
 8179	mirror rosewater-soaked ring of telling skeletons what to do	0		Stench Resistance: +3, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8059,16 +8059,16 @@
 8185	red flame-wreathed therapeutic The Crown of Ed the Undying	0		HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	olive Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	distilled artisanal Cherrytastrophe wine cooler	5	EPIC	
+8188	artisanal distilled Cherrytastrophe wine cooler	5	EPIC	
 8189	perfectly mixed mirror Radberry Rip wine cooler	3	EPIC	
 8190	smooth Orangemageddon wine cooler	4	awesome	
 8191	tolerable Breakfast Blast wine cooler	4	good	
-8192	drinkable weak Citrus Crush wine cooler	2	good	
+8192	weak drinkable Citrus Crush wine cooler	2	good	
 8193	flavorless twirling lime green plain bagel	4	decent	
 8194	stale purple glob of cream cheese	3	decent	
 8195	rotten loaf of soda bread	3	crappy	
 8196	normal acceptable bagel	3	good	
-8197	half-sized tasty twirling tumbling standard-issue cupcake	2	awesome	
+8197	tasty half-sized tumbling twirling standard-issue cupcake	2	awesome	
 8198	bite-sized normal ultra-deluxe cupcake	1	good	
 8199	hypnotic breadcrumbs	0		
 8200	miniature bland popular tart	2	decent	
@@ -8085,7 +8085,7 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	wobbly frosty MacGyver's rigging rope	0		Maximum MP: +100, Cold Spell Damage: +10, Last Available: "2015-04"
-8214	compressed blue mirror blinking nasty snuff	1	crappy	Effect: "Frigid Weapon", Effect Duration: 35, Last Available: "2015-04"
+8214	compressed blinking mirror blue nasty snuff	1	crappy	Effect: "Frigid Weapon", Effect Duration: 35, Last Available: "2015-04"
 8215	sharpshooter's sewage-clogged pistol of the dark arts	0		Spell Damage Percent: +100, Critical Hit Percent: +10, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	quadruple-chilled liquefied squat beard incense	0		Effect: "Very Clean Teeth", Effect Duration: 44, Last Available: "2015-04"
 8217	shaking family-friendly perfume-soaked bandana of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Resistance: +1, Single Equip, Last Available: "2015-04"
@@ -8096,7 +8096,7 @@
 8222	Sherlock's Three Mile Island shorts of James Dean	0		Experience (Moxie): +3, Item Drop: +25, Last Available: "2015-04"
 8223	flame-wreathed wizardly toxic mop	0		Mysticality: +25, Hot Spell Damage: +10, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
-8225	skewed blurry lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
+8225	blurry skewed lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	jar of swamp honey	0		Last Available: "2015-04"
 8227	yellow aromatic quilted backwoods banjo of the cougar	0		Moxie: +20, Damage Absorption: +40, Stench Resistance: +1, Last Available: "2015-04"
 8228	upside-down green grody jug	0		Last Available: "2015-04"
@@ -8110,7 +8110,7 @@
 8236	Sherlock's sage Dinsey's glove	0		Mysticality Percent: +10, Item Drop: +25, Single Equip, Last Available: "2015-04"
 8237	Tesla vibrating Dinsey's pants	0		Maximum MP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-04"
 8238	brain preservation fluid	0		Last Available: "2015-04"
-8239	bouncing spinning keycard &alpha;	0		Last Available: "2015-04"
+8239	spinning bouncing keycard &alpha;	0		Last Available: "2015-04"
 8240	mirror keycard &beta;	0		Last Available: "2015-04"
 8241	keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
@@ -8120,7 +8120,7 @@
 8246	Temple Grandin's electrified Dinsey mascot mask of courage	0		Familiar Weight: +7, Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-04"
 8247	adequate Dinsey food-cone	4	good	Last Available: "2015-04"
 8248	perfectly mixed Dinsey Whinskey	3	EPIC	Last Available: "2015-04"
-8249	nitrogenated shaking purple Dinsey face paint	0		Effect: "Held Closer", Effect Duration: 21, Last Available: "2015-04"
+8249	nitrogenated purple shaking Dinsey face paint	0		Effect: "Held Closer", Effect Duration: 21, Last Available: "2015-04"
 8250	foul-smelling fannypack of the businessman	0		Stench Damage: +10, Meat Drop: +50, Last Available: "2015-04"
 8251	lightning-fast gravedigger's Oprah's hale Herculean garbage sticker of Leguizamo	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP Percent: +50, Monster Level: +20, Spooky Damage: +10, Initiative: +40, Last Available: "2015-04"
 8252	shellacked hazmat helmet of the pedagogue of vim and vigor of extreme caution of the sweet-tooth	0		Experience: +3, Damage Reduction: 7, Maximum HP Percent: +50, Monster Level: -25, Candy Drop: +100, Last Available: "2015-04"
@@ -8142,8 +8142,8 @@
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	huge mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	moldy unappetizing mayolus	3	crappy	Last Available: "2015-05"
-8271	half-sized decent green uninteresting mayolus	2	good	Last Available: "2015-05"
-8272	rotten massive acceptable mayolus	6	crappy	Last Available: "2015-05"
+8271	decent half-sized green uninteresting mayolus	2	good	Last Available: "2015-05"
+8272	massive rotten acceptable mayolus	6	crappy	Last Available: "2015-05"
 8273	decent enticing mayolus	3	good	Last Available: "2015-05"
 8274	moldy mouth-watering mayolus	4	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8154,11 +8154,11 @@
 8280	ghostly Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	electrified electrified upside-down gray blurry Kokomo Resort Brand Suntan Oil	0		Effect: "Rave Nirvana", Effect Duration: 35, Last Available: "2015-04"
 8282	yellow Kokomo Resort Order Pad	0		Last Available: "2015-04"
-8283	blue spinning The Cocktail Shaker	0		Last Available: "2015-04"
+8283	spinning blue The Cocktail Shaker	0		Last Available: "2015-04"
 8284	ionized diffused Kokomo Resort Pass	0		Effect: "Thickest, Sickest", Effect Duration: 27, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	alkaline Mayo de Mayo&trade; mayo	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 14
-8287	blinking blurry puck	0		Free Pull, Last Available: "2015-06"
+8287	blurry blinking puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	bouncing flame-retardant dice ring	0		Hot Resistance: +1, Single Equip
@@ -8173,8 +8173,8 @@
 8299	bouncing pixel coin	0		Last Available: "2015-06"
 8300	dry lime green power pill	0		Effect: "Sweet Taste", Effect Duration: 22, Last Available: "2015-06"
 8301	frozen narrow pixel star	0		Effect: "Fruited", Effect Duration: 44, Last Available: "2015-06"
-8302	super-sized yummy blinking pixel banana	5	awesome	Last Available: "2015-06"
-8303	hand-crafted practically non-alcoholic pixel beer	1	super ultra mega EPIC	Last Available: "2015-06"
+8302	yummy super-sized blinking pixel banana	5	awesome	Last Available: "2015-06"
+8303	practically non-alcoholic hand-crafted pixel beer	1	super ultra mega EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	super-cold-filtered wobbly sludgesicle	0		Effect: "Booze Goozles", Effect Duration: 16
@@ -8188,7 +8188,7 @@
 8314	super-dry magnetized wobbly costume rental shop	0		Effect: "Crimbo Epiphany", Effect Duration: 36
 8315	double-adjusted frozen mirror muscle oil	0		Effect: "Innately Wise", Effect Duration: 26
 8316	diffused blurry bottle of Red-Out	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 56
-8317	pickled blinking purple pickpocket protector	0		Effect: "Flambé-a-thon", Effect Duration: 31
+8317	pickled purple blinking pickpocket protector	0		Effect: "Flambé-a-thon", Effect Duration: 31
 8318	extra-improved twirling sinister-looking cat	0		Effect: "Spiro Gyro", Effect Duration: 32
 8319	moist blinking jazzy cigarette holder	0		Effect: "Neutered Nostrils", Effect Duration: 28
 8320	triple-Vulcanized Vulcanized shaking one glove	0		Effect: "Inebriate Pride", Effect Duration: 54
@@ -8196,12 +8196,12 @@
 8322	adjusted handful of fire	0		Effect: "Chlorophyll Flavor", Effect Duration: 21
 8323	aerosolized ionized wet Cracklin' Oat Bran	0		Effect: "Fancy Feasted", Effect Duration: 51
 8324	double-activated disposable lighter	0		Effect: "Mushroom Moxiousness", Effect Duration: 45
-8325	improved ghostly upside-down coal contact lenses	0		Effect: "Fever From the Flavor", Effect Duration: 21
+8325	improved upside-down ghostly coal contact lenses	0		Effect: "Fever From the Flavor", Effect Duration: 21
 8326	vacuum-sealed pickled blue conjured ice cream	0		Effect: "Colorful Gratitude", Effect Duration: 51
 8327	anodized galvanized shaking yellow Iceberglar scarf	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 66
 8328	oxidized tarnished purple icy hairspray	0		Effect: "Cringle's Curative Carol", Effect Duration: 37
 8329	electrified polymerized aerosolized upside-down bouncing smellbook	0		Effect: "Sweet, Nuts", Effect Duration: 11
-8330	ionized triple-unsweetened lime green pulsating assassin's cheese knife	0		Effect: "Smokin'", Effect Duration: 29
+8330	ionized triple-unsweetened pulsating lime green assassin's cheese knife	0		Effect: "Smokin'", Effect Duration: 29
 8331	chilled filthy armor	0		Effect: "Techno Bliss", Effect Duration: 55
 8332	flattened deionized blinking plague pie	0		Effect: "Hella Smooth", Effect Duration: 23
 8333	wet improved blue batarang	0		Effect: "BOOsted", Effect Duration: 50
@@ -8229,7 +8229,7 @@
 8355	super-moist nitrogenated iron torso box	0		Effect: "Stenchtastic", Effect Duration: 15
 8356	double-quantum deionized mercenary headband	0		Effect: "Thickest, Sickest", Effect Duration: 68
 8357	activated radioactive spider venom	0		Effect: "Big", Effect Duration: 25
-8358	altered liquefied shaking pulsating x-ray mirror	0		Effect: "Lemony Goodness", Effect Duration: 11
+8358	altered liquefied pulsating shaking x-ray mirror	0		Effect: "Lemony Goodness", Effect Duration: 11
 8359	quadruple-irradiated polymerized wrestling mask	0		Effect: "License to Punch", Effect Duration: 65
 8360	cold-filtered double-warmed hawkface potion	0		Effect: "Stinking Cloud", Effect Duration: 48
 8361	double-Vulcanized triple-boiled child-sized dracula cloak	0		Effect: "Outer Wolf&trade;", Effect Duration: 43
@@ -8248,7 +8248,7 @@
 8374	oxidized drinks tray	0		Effect: "Squirming Like a Toad", Effect Duration: 30
 8375	extra-boiled maroon eyebrow lifter	0		Effect: "Salsa Satanica", Effect Duration: 26
 8376	submarine	0		Last Available: "2015-06"
-8377	spoiled low-calorie pixel lemon	1	crappy	Last Available: "2015-06"
+8377	low-calorie spoiled pixel lemon	1	crappy	Last Available: "2015-06"
 8378	drinkable weak narrow pixel daiquiri	2	good	Last Available: "2015-06"
 8379	warmed diffused power pill	0		Effect: "Net Tea", Effect Duration: 67, Last Available: "2015-06"
 8380	wet flattened oxidized pixel potion	0		Effect: "Beta Carotene Overdose", Effect Duration: 42, Last Available: "2015-06"
@@ -8256,7 +8256,7 @@
 8382	squat Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
 8384	bubblegum heart	0		Last Available: "2015-07"
-8385	tumbling fuchsia cubic zirconia	0		Last Available: "2015-07"
+8385	fuchsia tumbling cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	blinking mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
@@ -8279,9 +8279,9 @@
 8405	talking spade	0		Free Pull
 8406	ghostly savory dry noodles	0		
 8407	decent yellow pestopiary	3	good	
-8408	denatured chilled ghostly twirling ectoplasmic orbs	0		Effect: "Cold Hard Skin", Effect Duration: 37
+8408	denatured chilled twirling ghostly ectoplasmic orbs	0		Effect: "Cold Hard Skin", Effect Duration: 37
 8409	stale blurry crudles	3	decent	
-8410	rotten low-calorie enchanted agnolotti arboli	1	crappy	Effect: "Weasels Underfoot", Effect Duration: 40
+8410	enchanted low-calorie rotten agnolotti arboli	1	crappy	Effect: "Weasels Underfoot", Effect Duration: 40
 8411	stale shaking spaghetti with ghost balls	4	decent	
 8412	bland pulsating succulent marrow	4	decent	
 8413	delicious wobbly salacious crumbs	3	awesome	
@@ -8293,8 +8293,8 @@
 8419	decent linguini immondizia bianco	3	good	
 8420	rotten shells a la shellfish	4	crappy	
 8421	blue Jick's autograph	0		
-8422	cyan tumbling high-temperature mining drill	0		Last Available: "2015-08"
-8423	olive pulsating unsmoothed velvet	0		Last Available: "2015-08"
+8422	tumbling cyan high-temperature mining drill	0		Last Available: "2015-08"
+8423	pulsating olive unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
 8425	New Age healing crystal	0		Last Available: "2015-08"
 8426	Volcoino	0		Last Available: "2015-08"
@@ -8348,7 +8348,7 @@
 8474	flavorless very hot lunch	4	decent	Last Available: "2015-08"
 8475	bad asbestos thermos	3	decent	Last Available: "2015-08"
 8476	energized adjusted liquid rhinestones	0		Effect: "All Blued Up", Effect Duration: 28, Last Available: "2015-08"
-8477	super-sized stale maroon spinning disco biscuit	5	decent	Last Available: "2015-08"
+8477	stale super-sized maroon spinning disco biscuit	5	decent	Last Available: "2015-08"
 8478	bad squat Quaatorade&trade;	3	decent	Last Available: "2015-08"
 8479	pulsating olive avaricious greasy electrified biker's hat	0		Sleaze Spell Damage: +10, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk", Last Available: "2015-08"
 8480	curative thinker's feathered headdress of vim and vigor	0		Mysticality: +10, Maximum HP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
@@ -8404,9 +8404,9 @@
 8530	decent spagecialetti	3	good	
 8531	Salsa Libre	0		
 8532	mirror good gravy	0		
-8533	blue tumbling illicit fish sauce	0		
+8533	tumbling blue illicit fish sauce	0		
 8534	huge delicious libertagliatelle	9	awesome	
-8535	massive delicious enchanted turkish mostaccioli	8	awesome	Effect: "Memory of Speed", Effect Duration: 45
+8535	enchanted delicious massive turkish mostaccioli	8	awesome	Effect: "Memory of Speed", Effect Duration: 45
 8536	rotten jumbo tumbling linguini of the sea	5	crappy	
 8537	triple-ionized Hersey&trade; SMOOCH	0		Effect: "Hombre Muerto Caminando", Effect Duration: 54
 8539	Alexy sauce	0		
@@ -8414,14 +8414,14 @@
 8541	drug cocktail sauce	0		
 8542	stale small Fettris	2	decent	
 8543	gigantic moldy tumbling fusillocybin	6	crappy	
-8544	flavorless enchanted prescription noodles	4	decent	Effect: "Nut-Rition", Effect Duration: 20
+8544	enchanted flavorless prescription noodles	4	decent	Effect: "Nut-Rition", Effect Duration: 20
 8545	compressed pulsating yellow blood-drive sticker	1	good	
 8546	ionized pressed upside-down bag of grain	0		Effect: "Gunky Dory", Effect Duration: 35
 8547	alkaline diffused alkaline pocket maze	0		Effect: "Slimy Flavor", Effect Duration: 40
 8548	ionized non-improved spinning shady shades	0		Effect: "Amorous Avarice", Effect Duration: 22
 8549	anodized squeaky toy rose	0		Effect: "Your Eyes are Peeled!", Effect Duration: 67
 8550	stale huge weird gazelle steak	8	decent	
-8551	gigantic adequate sausage without a cause	7	good	
+8551	adequate gigantic sausage without a cause	7	good	
 8552	non-moist enhanced denatured face paint	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 61
 8553	acceptable emergency margarita	4	good	
 8554	lousy spinning vintage smart drink	4	decent	
@@ -8449,17 +8449,17 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	wobbly barnacled barrel	0		Last Available: "2015-09"
 8578	watered-down smooth tumbling bottle of Amontillado	2	awesome	Last Available: "2015-09"
-8579	high-proof smooth barrel-aged martini	7	awesome	Last Available: "2015-09"
+8579	smooth high-proof barrel-aged martini	7	awesome	Last Available: "2015-09"
 8580	decent barrel pickle	4	good	Last Available: "2015-09"
-8581	rotten super-sized barrel cracker	5	crappy	Last Available: "2015-09"
-8582	modified pulsating olive vibrating mushroom	1	EPIC	Last Available: "2015-09"
+8581	super-sized rotten barrel cracker	5	crappy	Last Available: "2015-09"
+8582	modified olive pulsating vibrating mushroom	1	EPIC	Last Available: "2015-09"
 8583	diluted skewed mushroom	1	awesome	Last Available: "2015-09"
 8584	avaricious KoL Con 12-gauge	0		Meat Drop: +30, Last Available: "2015-09"
 8585	pulsating razor-sharp Golden Mr. Eh?	0		Weapon Damage Percent: +25, Last Available: "2015-09"
 8586	groovy barrel gun	0		Moxie Percent: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	shaking barrel beryl	0		Last Available: "2015-09"
-8589	miniature normal olive squat water log	2	good	Last Available: "2015-09"
+8589	normal miniature olive squat water log	2	good	Last Available: "2015-09"
 8590	jittery jittery barrelhead of dire peril of temperance	0		Weapon Damage: +20, Sleaze Resistance: +5, Last Available: "2015-09"
 8591	blurry bottoms of the barrel of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, Last Available: "2015-09"
 8592	Jack Frost's chest barrel of temperance	0		Cold Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2015-09"
@@ -8489,12 +8489,12 @@
 8616	non-anodized concentrated cuppa Neuroplastici tea	0		Effect: "Mana Tea", Effect Duration: 43, Last Available: "2015-09"
 8617	denatured vacuum-sealed cuppa Dexteri tea	0		Effect: "Melancholy Burden", Effect Duration: 41, Last Available: "2015-09"
 8618	polarized concentrated cuppa Flexibili tea	0		Effect: "Impregnably Delicious", Effect Duration: 62, Last Available: "2015-09"
-8619	triple-ionized spinning teal pulsating cuppa Impregnabili tea	0		Effect: "Berry Critical", Effect Duration: 32, Last Available: "2015-09"
+8619	triple-ionized pulsating teal spinning cuppa Impregnabili tea	0		Effect: "Berry Critical", Effect Duration: 32, Last Available: "2015-09"
 8620	quantum jittery cuppa Obscuri tea	0		Effect: "Poker Faced", Effect Duration: 57, Last Available: "2015-09"
 8621	cold-filtered cuppa Irritabili tea	0		Effect: "Jungle Juiced", Effect Duration: 39, Last Available: "2015-09"
 8622	quantum squat ghostly cuppa Mediocri tea	0		Effect: "Bottle in front of Me", Effect Duration: 48, Last Available: "2015-09"
 8623	frozen moist squat cuppa Loyal tea	0		Effect: "Nigh-Invincible", Effect Duration: 43, Last Available: "2015-09"
-8624	modified olive spinning cuppa Activi tea	1	awesome	Last Available: "2015-09"
+8624	modified spinning olive cuppa Activi tea	1	awesome	Last Available: "2015-09"
 8625	dried cuppa Cruel tea	1		Effect: "Hyperoxygenated Blood", Effect Duration: 40, Last Available: "2015-09"
 8626	quadruple-chilled cuppa Alacri tea	0		Effect: "Lit Up", Effect Duration: 69, Last Available: "2015-09"
 8627	extra-deionized vacuum-sealed cuppa Vitali tea	0		Effect: "Lemon Enlightenment", Effect Duration: 12, Last Available: "2015-09"
@@ -8502,7 +8502,7 @@
 8629	improved cuppa Monstrosi tea	0		Effect: "Mutated", Effect Duration: 57, Last Available: "2015-09"
 8630	colloidal dry spinning cuppa Twen tea	0		Effect: "Polar Express", Effect Duration: 12, Last Available: "2015-09"
 8631	altered cuppa Gill tea	0		Effect: "Wise Spirit", Effect Duration: 62, Last Available: "2015-09"
-8632	irradiated triple-dry ghostly maroon cuppa Uncertain tea	0		Effect: "Tiki Temerity", Effect Duration: 32, Last Available: "2015-09"
+8632	irradiated triple-dry maroon ghostly cuppa Uncertain tea	0		Effect: "Tiki Temerity", Effect Duration: 32, Last Available: "2015-09"
 8633	squat cuppa Voraci tea	0		Last Available: "2015-09"
 8634	skewed cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
@@ -8512,11 +8512,11 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	moldy bowl of eyeballs	3	crappy	Last Available: "2015-10"
-8642	snack-sized yummy purple ghostly bowl of mummy guts	2	awesome	Last Available: "2015-10"
-8643	big decent narrow skewed bowl of maggots	5	good	Last Available: "2015-10"
+8642	yummy snack-sized ghostly purple bowl of mummy guts	2	awesome	Last Available: "2015-10"
+8643	decent big narrow skewed bowl of maggots	5	good	Last Available: "2015-10"
 8644	weak hand-crafted blood and blood	2	EPIC	Last Available: "2015-10"
 8645	bad Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
-8646	fortified tolerable enchanted blinking zombie	5	good	Effect: "El Vibrations", Effect Duration: 40, Last Available: "2015-10"
+8646	enchanted tolerable fortified blinking zombie	5	good	Effect: "El Vibrations", Effect Duration: 40, Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	shaking wind-up spider	0		Last Available: "2015-10"
 8649	pulsating plastic nightmare troll	0		Last Available: "2015-10"
@@ -8531,9 +8531,9 @@
 8658	crafty Othello's handkerchief	0		Maximum MP: +10, Single Equip
 8659	improved unsweetened green bowl of Jeal-O	0		Effect: "Milk Studly", Effect Duration: 51
 8660	green grip key	0		
-8661	fuchsia huge How to Play Othello	0		
+8661	huge fuchsia How to Play Othello	0		
 8662	quilted padded Rosewater's ghostly dagger	0		Mysticality Percent: +30, Damage Absorption: 60
-8663	drinkable high-proof ghost beer	10	good	
+8663	high-proof drinkable ghost beer	10	good	
 8664	Othello set of the ox	0		Muscle: +20
 8665	rotten tomato	0		
 8666	mirror Twelve Night Energy	0		
@@ -8541,7 +8541,7 @@
 8668	rose	0		
 8669	tulip	0		
 8670	tulip	0		
-8671	mirror shaking tulip	0		
+8671	shaking mirror tulip	0		
 8672	olive Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	upside-down airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	huge The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	educational bellhop's hat	0		Experience: +1, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	high-proof hand-crafted ice porter	6	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	hand-crafted high-proof ice porter	6	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	wet exotic travel brochure	0		Effect: "Oiled Skin", Effect Duration: 45, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	quadruple-activated shampoo-conditioner	0		Effect: "One Foot Heavier", Effect Duration: 56, Last Available: "2015-11"
@@ -8567,7 +8567,7 @@
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	altered medicinal herbs	1		Last Available: "2016-01"
-8697	huge adequate ice rice	7	good	Last Available: "2016-01"
+8697	adequate huge ice rice	7	good	Last Available: "2016-01"
 8698	hand-crafted iced plum wine	3	EPIC	Last Available: "2016-01"
 8699	jittery maroon auspicious aromatic training belt of Gandalf	0		Spell Critical Percent: +20, Stench Resistance: +1, Item Drop: +10, Single Equip, Last Available: "2016-01"
 8700	yellow upside-down Usain Bolt's training legwarmers of the storm of the businessman	0		Maximum MP Percent: +40, Meat Drop: +50, Initiative: +80, Single Equip, Last Available: "2016-01"
@@ -8576,9 +8576,9 @@
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	skewed training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
-8706	bouncing pulsating machine elf capsule	0		Free Pull, Last Available: "2015-12"
+8706	pulsating bouncing machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	wobbly self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
-8708	pickled upside-down upside-down fuchsia abstraction: action	1		Last Available: "2015-12"
+8708	pickled upside-down fuchsia upside-down abstraction: action	1		Last Available: "2015-12"
 8709	altered abstraction: thought	1		Last Available: "2015-12"
 8710	mixed blurry abstraction: sensation	1		Last Available: "2015-12"
 8711	vaporized red abstraction: purpose	1		Last Available: "2015-12"
@@ -8586,16 +8586,16 @@
 8713	compressed abstraction: perception	1		Last Available: "2015-12"
 8714	twisted abstraction: motion	1		Effect: "Bread-Lined", Effect Duration: 40, Last Available: "2015-12"
 8715	denatured squat abstraction: joy	1		Last Available: "2015-12"
-8716	modified cyan skewed abstraction: certainty	1		Effect: "Puddingskin", Effect Duration: 10, Last Available: "2015-12"
+8716	modified skewed cyan abstraction: certainty	1		Effect: "Puddingskin", Effect Duration: 10, Last Available: "2015-12"
 8717	distilled blurry abstraction: comprehension	1		Effect: "Pharmaceutically Cool", Effect Duration: 40, Last Available: "2015-12"
-8718	blue tumbling modern picture frame	0		Last Available: "2015-12"
+8718	tumbling blue modern picture frame	0		Last Available: "2015-12"
 8719	adequate narrow VYKEA meatballs	4	good	Last Available: "2015-11"
 8720	acceptable VYKEA mead	4	good	Last Available: "2015-11"
 8721	enhanced vacuum-sealed narrow VYKEA woadpaint	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 21, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	gray VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
-8725	squat maroon upside-down VYKEA plank	0		Last Available: "2015-11"
+8725	squat upside-down maroon VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
 8727	VYKEA bracket	0		Last Available: "2015-11"
 8728	wobbly VYKEA dowel	0		Last Available: "2015-11"
@@ -8603,14 +8603,14 @@
 8730	VYKEA instructions	0		Last Available: "2015-11"
 8731	stale tin of submardines	3	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	lousy distilled bottle of norwhiskey	5	decent	Last Available: "2015-11"
-8733	powdered cyan upside-down octolus oculus	1	decent	Last Available: "2015-11"
+8733	powdered upside-down cyan octolus oculus	1	decent	Last Available: "2015-11"
 8734	stylish sardine can key of chilblains of mayonnaise	0		Moxie: +25, Cold Damage: +25, Sleaze Spell Damage: +50, Last Available: "2015-11"
 8735	red executive perfumed norwhal helmet of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +5, Meat Drop: +40, Familiar Effect: "atk", Last Available: "2015-11"
 8736	teal auspicious chaotic Socratic octolus-skin cloak	0		Experience (Mysticality): +1, Spell Critical Percent: +10, Item Drop: +10, Last Available: "2015-11"
 8737	smooth wobbly perfect cosmopolitan	3	awesome	Last Available: "2015-11"
 8738	aged blue perfect negroni	4	awesome	Last Available: "2015-11"
-8739	strong perfectly mixed perfect dark and stormy	5	EPIC	Last Available: "2015-11"
-8740	distilled artisanal teal bouncing perfect mimosa	5	EPIC	Last Available: "2015-11"
+8739	perfectly mixed strong perfect dark and stormy	5	EPIC	Last Available: "2015-11"
+8740	artisanal distilled bouncing teal perfect mimosa	5	EPIC	Last Available: "2015-11"
 8741	drinkable shaking perfect old-fashioned	3	good	Last Available: "2015-11"
 8742	irresponsibly strong artisanal perfect paloma	10	EPIC	Last Available: "2015-11"
 8743	dry spinning That 70s Cologne	0		Effect: "Souper Vengeful", Effect Duration: 57, Last Available: "2015-11"
@@ -8620,9 +8620,9 @@
 8747	ionized Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Feroci Tea", Effect Duration: 12, Last Available: "2015-11"
 8748	mirror airplane tattoo	0		Last Available: "2015-11"
 8749	ionized polymerized Deep Machine Tunnels snowglobe	0		Effect: "protect.enq", Effect Duration: 46, Last Available: "2015-12"
-8750	boiled polarized wobbly skewed hemp candy necklace	0		Effect: "Irresistible Resolve", Effect Duration: 37, Last Available: "2015-12"
+8750	boiled polarized skewed wobbly hemp candy necklace	0		Effect: "Irresistible Resolve", Effect Duration: 37, Last Available: "2015-12"
 8751	quadruple-dry communal gobstopper	0		Effect: "Chorale of Companionship", Effect Duration: 49, Last Available: "2015-12"
-8752	normal snack-sized Crimbo salad	2	good	Last Available: "2015-12"
+8752	snack-sized normal Crimbo salad	2	good	Last Available: "2015-12"
 8753	stale gigantic bread line	8	decent	Last Available: "2015-12"
 8754	acceptable bark rootbeer	3	good	Last Available: "2015-12"
 8755	smooth watered-down squat ale	2	awesome	Last Available: "2015-12"
@@ -8653,7 +8653,7 @@
 8781	lard-coated pine cone necklace	0		Sleaze Spell Damage: +25, Last Available: "2015-12"
 8782	dangerous reindeer hammer	0		Weapon Damage: +10, Last Available: "2015-12"
 8783	occult elf ploughshare	0		Spell Damage Percent: +25, Last Available: "2015-12"
-8784	blinking cyan circle drum	0		Last Available: "2015-12"
+8784	cyan blinking circle drum	0		Last Available: "2015-12"
 8785	blurry The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
@@ -8667,7 +8667,7 @@
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	bouncing bat-oomerang	0		Last Available: "2017-01"
-8798	squat fuchsia bat-jute	0		Last Available: "2017-01"
+8798	fuchsia squat bat-jute	0		Last Available: "2017-01"
 8799	tumbling bat-o-mite	0		Last Available: "2017-01"
 8800	skewed ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	incriminating evidence	0		Last Available: "2017-01"
@@ -8685,14 +8685,14 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	blinking Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	enchanted rotten Kudzu salad	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 15, Last Available: "2016-12"
+8816	rotten enchanted Kudzu salad	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 15, Last Available: "2016-12"
 8817	altered jittery Mansquito Serum	1		Last Available: "2016-12"
-8818	hand-crafted practically non-alcoholic Miss Graves' vermouth	1	super ultra mega turbo EPIC	Last Available: "2016-12"
+8818	practically non-alcoholic hand-crafted Miss Graves' vermouth	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 8819	flavorless fuchsia The Plumber's mushroom stew	3	decent	Last Available: "2016-12"
 8820	denatured fuchsia The Author's ink	1		Last Available: "2016-02"
 8821	artisanal blurry The Mad Liquor	4	EPIC	Last Available: "2016-12"
-8822	weak tolerable Doc Clock's thyme cocktail	2	good	Last Available: "2016-12"
-8823	big enchanted spoiled Mr. Burnsger	5	crappy	Effect: "Flower Power", Effect Duration: 20, Last Available: "2016-12"
+8822	tolerable weak Doc Clock's thyme cocktail	2	good	Last Available: "2016-12"
+8823	enchanted big spoiled Mr. Burnsger	5	crappy	Effect: "Flower Power", Effect Duration: 20, Last Available: "2016-12"
 8824	compressed upside-down The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	lion tamer's wicked supercool The Jokester's gun	0		Moxie Percent: +20, Spell Damage: +5, Experience (familiar): +2, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
 8826	slick The Jokester's wig of Gandalf of courage	0		Moxie: +10, Spell Critical Percent: +20, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
@@ -8747,13 +8747,13 @@
 8875	greasy frosty dance instructor's Shrub's Premium Baked Beans	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2016-02"
 8876	yummy plate of Heimz Fortified Kidney Beans	3	awesome	Last Available: "2016-02"
 8877	snack-sized tasty plate of Tesla's Electroplated Beans	2	awesome	Last Available: "2016-02"
-8878	thick delicious plate of Mixed Garbanzos and Chickpeas	5	awesome	Last Available: "2016-02"
+8878	delicious thick plate of Mixed Garbanzos and Chickpeas	5	awesome	Last Available: "2016-02"
 8879	adequate maroon plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
-8880	bite-sized special adequate pulsating plate of Frigid Northern Beans	1	good	Effect: "A Taste of Rainbow", Effect Duration: 25, Last Available: "2016-02"
+8880	special adequate bite-sized pulsating plate of Frigid Northern Beans	1	good	Effect: "A Taste of Rainbow", Effect Duration: 25, Last Available: "2016-02"
 8881	small moldy plate of World's Blackest-Eyed Peas	2	crappy	Last Available: "2016-02"
 8882	normal wobbly plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
 8883	decent miniature plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	good	Last Available: "2016-02"
-8884	normal massive spinning plate of Val-U Brand Every Bean Salad	8	good	Last Available: "2016-02"
+8884	massive normal spinning plate of Val-U Brand Every Bean Salad	8	good	Last Available: "2016-02"
 8885	bland plate of Shrub's Premium Baked Beans	3	decent	Last Available: "2016-02"
 8886	shaking executive Fancy Jeff's pocket square of the early riser	0		Meat Drop: +40, Adventures: +7, Last Available: "2016-02"
 8887	squat foul-smelling forbidden beefy Daisy's unclean bloomers	0		Muscle: +10, Spell Damage Percent: +50, Stench Damage: +10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
@@ -8878,7 +8878,7 @@
 9006	bouncing ghostly educational wizardly tunac of James Dean of the bloodbag	0		Mysticality: +25, Experience: +1, Experience (Moxie): +3, Maximum HP: +100, Lasts Until Rollover, Last Available: "2016-04"
 9007	spinning fishin' pole	0		Last Available: "2016-04"
 9008	improved dry wriggling worm	0		Effect: "It's Electric!", Effect Duration: 19, Last Available: "2016-04"
-9009	enchanted hand-crafted bottle of Fishhead 900-Day IPA	3	EPIC	Effect: "Chalky Hand", Effect Duration: 45, Last Available: "2016-04"
+9009	hand-crafted enchanted bottle of Fishhead 900-Day IPA	3	EPIC	Effect: "Chalky Hand", Effect Duration: 45, Last Available: "2016-04"
 9010	extra-frozen magnetized denatured bouncing high-test fishing line	0		Effect: "Nasty, Nasty Breath", Effect Duration: 68, Last Available: "2016-04"
 9011	wobbly fishin' hat of doom	0		Spooky Spell Damage: +50, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8901,11 +8901,11 @@
 9029	no spoon	0		
 9030	tasty miniature star salad	2	awesome	
 9031	Thwaitgold moth statuette	0		
-9032	miniature moldy fuchsia bowl of Tastee-Wheet&trade;	2	crappy	
+9032	moldy miniature fuchsia bowl of Tastee-Wheet&trade;	2	crappy	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	huge Source essence	0		Last Available: "2016-06"
 9035	delicious blinking browser cookie	3	awesome	Last Available: "2016-06"
-9036	watered-down acceptable hacked gibson	2	good	Last Available: "2016-06"
+9036	acceptable watered-down hacked gibson	2	good	Last Available: "2016-06"
 9037	shaking aromatic Source shades	0		Stench Resistance: +1, Last Available: "2016-06"
 9038	ghostly software bug	0		Last Available: "2016-06"
 9039	olive missing semicolon	0		Familiar Weight: +11
@@ -8941,7 +8941,7 @@
 9069	pulsating Usain Bolt's executive Temple Grandin's bronze detective badge of the boozehound	0		Familiar Weight: +7, Meat Drop: +40, Booze Drop: +100, Initiative: +80, Last Available: "2016-07"
 9070	fireproof nasty medical-grade sinister detective badge	0		Spell Damage: +10, Stench Damage: +5, Hot Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-07"
 9071	zippy nippy padded occult detective badge	0		Spell Damage Percent: +25, Damage Absorption: +20, Cold Damage: +10, Initiative: +20, Last Available: "2016-07"
-9072	skewed lime green cop dollar	0		Last Available: "2016-07"
+9072	lime green skewed cop dollar	0		Last Available: "2016-07"
 9073	pulsating detective school application	0		Free Pull, Last Available: "2016-07"
 9074	frightening rosy-cheeked savvy detective roscoe	0		Mysticality Percent: +20, Maximum HP Percent: +30, Spooky Damage: +5, Last Available: "2016-07"
 9075	Vulcanized shoe gum	0		Effect: "Quadrilled", Effect Duration: 37, Last Available: "2016-07"
@@ -8972,7 +8972,7 @@
 9100	rad	0		
 9101	purification tablet	0		
 9102	rosy-cheeked Wrist-Boy	0		Maximum HP Percent: +30
-9103	teal shaking tumbling Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
+9103	shaking teal tumbling Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
 9105	compounded experience	0		Last Available: "2016-09"
 9106	huge Rad-B-Gone (1 lb.)	0		
@@ -8988,22 +8988,22 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	shaking rosewater-soaked repaid diaper	0		Stench Resistance: +3
 9118	blue Riker's Search History	0		Last Available: "2016-09"
-9119	lousy weak Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
+9119	weak lousy Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
 9120	healthy Unstable Pointy Ears	0		Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
-9123	ghostly blue narrow School of Hard Knocks Diploma	0		
+9123	blue ghostly narrow School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	fortified delicious unidentified drink	5	awesome	
+9126	delicious fortified unidentified drink	5	awesome	
 9127	jittery smelly shellacked KoL Con 13 T-shirt	0		Damage Reduction: 7, Stench Spell Damage: +10
 9128	rosewater-soaked clever dangerous discarded swimming trunks	0		Weapon Damage: +10, Maximum MP: +20, Stench Resistance: +3
-9129	double-ionized ghostly narrow diluted makeup	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 37
+9129	double-ionized narrow ghostly diluted makeup	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 37
 9130	ionized deionized charisma potion	0		Effect: "Stinky Weapon", Effect Duration: 53
 9131	extremely confusing manual	0		
 9132	shaking Fonzie's pistol of the overflowing toilet	0		Experience (Moxie): +1, Stench Spell Damage: +50
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	small moldy leftover pasty	2	crappy	
+9134	moldy small leftover pasty	2	crappy	
 9135	strong acceptable squat very whiskey	5	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9023,13 +9023,13 @@
 9151	alkaline unsweetened wobbly invisible seam ripper	0		Lasts Until Rollover, Effect: "Hot Blooded", Effect Duration: 52, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	flavorless huge raw sweet potato	6	decent	Last Available: "2016-11"
-9154	bite-sized delicious skewed raw beans	1	awesome	Last Available: "2016-11"
+9154	delicious bite-sized skewed raw beans	1	awesome	Last Available: "2016-11"
 9155	adequate wobbly raw stuffing	4	good	Last Available: "2016-11"
 9156	enchanted adequate raw cranberry sauce	3	good	Effect: "Weather, Man", Effect Duration: 5, Last Available: "2016-11"
 9157	flavorless raw turkey	4	decent	Last Available: "2016-11"
 9158	normal tumbling raw mincemeat	3	good	Last Available: "2016-11"
 9159	normal miniature raw potato	2	good	Last Available: "2016-11"
-9160	diet rotten raw gravy	1	crappy	Last Available: "2016-11"
+9160	rotten diet raw gravy	1	crappy	Last Available: "2016-11"
 9161	normal raw bread	3	good	Last Available: "2016-11"
 9162	mini-marshmallow dispenser of vim and vigor of the overflowing toilet	0		Maximum HP Percent: +50, Stench Spell Damage: +50, Last Available: "2016-11"
 9163	double-paned dangerous Rosewater's glass casserole dish	0		Mysticality Percent: +30, Weapon Damage: +10, Cold Resistance: +5, Last Available: "2016-11"
@@ -9041,12 +9041,12 @@
 9169	upside-down gravy boat	0		Last Available: "2016-11"
 9170	upside-down bread mold	0		Last Available: "2016-11"
 9171	yummy squat sweet potatoes	3	awesome	Last Available: "2016-11"
-9172	stale miniature bean casserole	2	decent	Last Available: "2016-11"
+9172	miniature stale bean casserole	2	decent	Last Available: "2016-11"
 9173	diet spoiled baked stuffing	1	crappy	Last Available: "2016-11"
 9174	moldy tiny huge cranberry cylinder	1	crappy	Last Available: "2016-11"
 9175	spoiled thanksgiving turkey	3	crappy	Last Available: "2016-11"
 9176	decent mince pie	3	good	Last Available: "2016-11"
-9177	toothsome snack-sized mashed potatoes	2	awesome	Last Available: "2016-11"
+9177	snack-sized toothsome mashed potatoes	2	awesome	Last Available: "2016-11"
 9178	rotten warm gravy	3	crappy	Last Available: "2016-11"
 9179	adequate bread roll	4	good	Last Available: "2016-11"
 9180	flavorless leftovers	3	decent	Last Available: "2016-11"
@@ -9055,7 +9055,7 @@
 9183	tumbling purple cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	twirling pilgrim hat	0		Last Available: "2016-11"
-9186	teal squat packet of thanksgarden seeds	0		Last Available: "2016-11"
+9186	squat teal packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	skewed bomb of unknown origin	0		Last Available: "2016-11"
 9189	huge Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
@@ -9068,7 +9068,7 @@
 9196	mirror aromatic Science Notebook	0		Stench Resistance: +1
 9197	miser's extremely unsafe eldritch hat of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +100, Meat Drop: +10, Last Available: "2016-11"
 9198	banded slick eldritch pants of wisdom	0		Mysticality: +15, Moxie: +10, Damage Absorption: +100, Last Available: "2016-11"
-9199	lousy distilled eldritch elixir	5	decent	Last Available: "2016-11"
+9199	distilled lousy eldritch elixir	5	decent	Last Available: "2016-11"
 9200	hale fortified Quartet of Flare Masters Jacket	0		Damage Absorption: +60, Maximum HP: +20, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9102,7 +9102,7 @@
 9230	skewed brawny creme brulee torch	0		Muscle Percent: +20, Lasts Until Rollover, Last Available: "2016-12"
 9231	bouncing candy crowbar of temperance	0		Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-12"
 9232	horrifying rosy-cheeked candy screwdriver	0		Maximum HP Percent: +30, Spooky Damage: +25, Last Available: "2016-12"
-9233	olive ghostly gingerbread dog treat	0		Last Available: "2016-12"
+9233	ghostly olive gingerbread dog treat	0		Last Available: "2016-12"
 9234	friendly pumpkin spice candle	0		Familiar Weight: +3, Lasts Until Rollover, Last Available: "2016-12"
 9235	deionized concentrated concentrated jittery gingerbread spice latte	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 60, Last Available: "2016-12"
 9236	tumbling aromatic dog trainer's gingerbread gavel	0		Experience (familiar): +1, Stench Resistance: +1, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	ghostly spare chocolate parts	0		Last Available: "2016-12"
 9241	nitrogenated activated industrial frosting	0		Effect: "Creepypasted", Effect Duration: 26, Last Available: "2016-12"
 9242	activated chilled upside-down fake cocktail	0		Effect: "Lit Up", Effect Duration: 49, Last Available: "2016-12"
-9243	artisanal high-proof skewed red high-end ginger wine	8	EPIC	Last Available: "2016-12"
+9243	artisanal high-proof red skewed high-end ginger wine	8	EPIC	Last Available: "2016-12"
 9244	quilted plastic bad vibe	0		Damage Absorption: +40, Last Available: "2016-12"
 9245	shaking pulsating Da Vinci's plastic angry vikings	0		Experience (Mysticality): +5, Last Available: "2016-12"
 9246	ghostly Lo Pan's plastic Knows About Chakras	0		Spell Critical Percent: +30, Last Available: "2016-12"
@@ -9122,18 +9122,18 @@
 9250	double-activated moist extra-cold-filtered Inner Strength	0		Effect: "Musky", Effect Duration: 23, Last Available: "2016-12"
 9251	quantum magnetized tumbling bouncing Inner Truth	0		Effect: "Cold Blooded", Effect Duration: 15, Last Available: "2016-12"
 9252	stale spiritual candy cane	4	decent	Last Available: "2016-12"
-9253	practically non-alcoholic enchanted hand-crafted wobbly spiritual eggnog	1	super EPIC	Effect: "Lobos Fresh", Effect Duration: 5, Last Available: "2016-12"
-9254	tiny adequate spiritual fruitcake	1	good	Last Available: "2016-12"
+9253	hand-crafted enchanted practically non-alcoholic wobbly spiritual eggnog	1	super EPIC	Effect: "Lobos Fresh", Effect Duration: 5, Last Available: "2016-12"
+9254	adequate tiny spiritual fruitcake	1	good	Last Available: "2016-12"
 9255	flavorless spiritual gingerbread	3	decent	Last Available: "2016-12"
 9256	skewed chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
-9258	spinning huge My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
+9258	huge spinning My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	twirling fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
-9264	teal spinning mirror briefcase full of sprinkles	0		Last Available: "2016-12"
+9264	mirror teal spinning briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	improved electrified huge rock candy	0		Effect: "Hella Tough", Effect Duration: 46, Last Available: "2016-12"
 9267	moldy green-iced sweet roll	3	crappy	Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	enchanted weak smooth chakra-mental wine	2	awesome	Effect: "Piratey Flavor", Effect Duration: 5, Last Available: "2016-12"
 9277	vacuum-sealed chakra malt	0		Effect: "Spooky Weapon", Effect Duration: 52, Last Available: "2016-12"
 9278	flavorless Black Angus blackburger	3	decent	Last Available: "2016-12"
-9279	watered-down aged upside-down brandy	2	awesome	Last Available: "2016-12"
+9279	aged watered-down upside-down brandy	2	awesome	Last Available: "2016-12"
 9280	double-ionized triple-frozen potion of spiritual gunkifying	0		Effect: "Omphalotus Omnipresence", Effect Duration: 31, Last Available: "2016-12"
 9281	stanky rock-hard bad vibroknife	0		Damage Reduction: 5, Stench Spell Damage: +25, Last Available: "2016-12"
 9282	dance instructor's wizardly crystal belt buckle	0		Mysticality: +25, Experience Percent (Moxie): +10, Last Available: "2016-12"
@@ -9159,7 +9159,7 @@
 9287	mirror pet bad vibe	0		Last Available: "2016-12"
 9288	ghostly gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	skewed censurious personal trainer's Uncle Crimbo's hat	0		Experience Percent (Muscle): +10, Sleaze Resistance: +3, Item Drop: +5, Last Available: "2016-12"
-9290	normal small gray Eldritch snap	2	good	Last Available: "2017-01"
+9290	small normal gray Eldritch snap	2	good	Last Available: "2017-01"
 9291	powdered blinking olive hot jelly	1		Last Available: "2017-01"
 9292	powdered jelly	1		Last Available: "2017-01"
 9293	vaporized jelly	1		Effect: "Thunderspell", Effect Duration: 45, Last Available: "2017-01"
@@ -9170,18 +9170,18 @@
 9298	adequate toast with jelly	3	good	Last Available: "2017-01"
 9299	snack-sized spoiled toast with jelly	2	crappy	Last Available: "2017-01"
 9300	flavorless immense blurry toast with sleaze jelly	9	decent	Last Available: "2017-01"
-9301	miniature toothsome spinning toast with stench jelly	2	awesome	Last Available: "2017-01"
+9301	toothsome miniature spinning toast with stench jelly	2	awesome	Last Available: "2017-01"
 9302	squat space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	Rosewater's wax hand of the businessman	0		Mysticality Percent: +30, Meat Drop: +50, Last Available: "2017-01"
 9306	up-at-dawn candle of bravery	0		Spooky Resistance: +5, Adventures: +5, Lasts Until Rollover, Last Available: "2017-01"
-9307	half-sized fancy decent green wax pancake	2	good	Effect: "Coated Arms", Effect Duration: 25, Last Available: "2017-01"
+9307	fancy half-sized decent green wax pancake	2	good	Effect: "Coated Arms", Effect Duration: 25, Last Available: "2017-01"
 9308	dog trainer's wax face of bravery	0		Experience (familiar): +1, Spooky Resistance: +5, Last Available: "2017-01"
 9309	lousy wax booze	3	decent	Last Available: "2017-01"
 9310	bouncing glob of melted wax	0		Last Available: "2017-01"
 9311	mixed sea jelly	1		Last Available: "2017-01"
-9312	rotten fancy jumbo sea truffle	5	crappy	Effect: "Shot in the Arse", Effect Duration: 30, Last Available: "2017-01"
+9312	jumbo rotten fancy sea truffle	5	crappy	Effect: "Shot in the Arse", Effect Duration: 30, Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	arcane researcher's recovered cufflinks	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2017-01"
@@ -9201,7 +9201,7 @@
 9329	vacuum-sealed eldritch alignment spray	0		Effect: "Dexteri Tea", Effect Duration: 13, Last Available: "2017-02"
 9330	maroon LOV Entrance Pass	0		Last Available: "2017-02"
 9331	shaking miser's therapeutic eldritch hammer of extreme caution	0		Monster Level: -25, Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-01"
-9332	stale super-sized gray eldritch mushroom	5	decent	Last Available: "2017-03"
+9332	super-sized stale gray eldritch mushroom	5	decent	Last Available: "2017-03"
 9333	skewed eldritch ichor	0		
 9334	tasty big blue eldritch mushroom pizza	5	awesome	Last Available: "2017-03"
 9335	shaking eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9231,12 +9231,12 @@
 9359	baby oil shooter	0		Last Available: "2017-03"
 9360	cyan fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
-9362	olive blurry pile of dirt	0		Last Available: "2017-03"
+9362	blurry olive pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
-9364	squat skewed imaginary lemon	0		Last Available: "2017-03"
+9364	skewed squat imaginary lemon	0		Last Available: "2017-03"
 9365	delicious literal grasshopper	3	awesome	Last Available: "2017-03"
-9366	strong fancy artisanal double entendre	5	EPIC	Effect: "Human-Slime Hybrid", Effect Duration: 20, Last Available: "2017-03"
-9367	strong hand-crafted wobbly Phlegethon	5	EPIC	Last Available: "2017-03"
+9366	fancy artisanal strong double entendre	5	EPIC	Effect: "Human-Slime Hybrid", Effect Duration: 20, Last Available: "2017-03"
+9367	hand-crafted strong wobbly Phlegethon	5	EPIC	Last Available: "2017-03"
 9368	special artisanal blurry Siberian sunrise	4	EPIC	Effect: "Moon-Eyed", Effect Duration: 50, Last Available: "2017-03"
 9369	artisanal jittery mentholated wine	4	EPIC	Last Available: "2017-03"
 9370	drinkable low tide martini	4	good	Last Available: "2017-03"
@@ -9246,30 +9246,30 @@
 9374	lousy great fashioned	4	decent	Last Available: "2017-03"
 9375	tolerable Gnomish sagngria	3	good	Last Available: "2017-03"
 9376	acceptable vodka stinger	4	good	Last Available: "2017-03"
-9377	triple-distilled lousy red extremely slippery nipple	8	decent	Last Available: "2017-03"
+9377	lousy triple-distilled red extremely slippery nipple	8	decent	Last Available: "2017-03"
 9378	fancy artisanal piscatini	3	EPIC	Effect: "Less Pervious", Effect Duration: 40, Last Available: "2017-03"
 9379	perfectly mixed Churchill	3	EPIC	Last Available: "2017-03"
 9380	practically non-alcoholic mediocre jittery soilzerac	1	decent	Last Available: "2017-03"
 9381	lousy London frog	3	decent	Last Available: "2017-03"
-9382	enchanted spirit-forward acceptable nothingtini	5	good	Effect: "Salty Mouth", Effect Duration: 5, Last Available: "2017-03"
+9382	spirit-forward enchanted acceptable nothingtini	5	good	Effect: "Salty Mouth", Effect Duration: 5, Last Available: "2017-03"
 9383	mediocre eighth plague	4	decent	Last Available: "2017-03"
 9384	smooth irresponsibly strong single entendre	6	awesome	Last Available: "2017-03"
 9385	triple-distilled acceptable pulsating upside-down reverse Tantalus	9	good	Last Available: "2017-03"
 9386	mediocre watered-down blinking elemental caipiroska	2	decent	Last Available: "2017-03"
-9387	drinkable high-proof Feliz Navidad	7	good	Last Available: "2017-03"
+9387	high-proof drinkable Feliz Navidad	7	good	Last Available: "2017-03"
 9388	drinkable Bloody Nora	3	good	Last Available: "2017-03"
-9389	watered-down mediocre moreltini	2	decent	Last Available: "2017-03"
-9390	fancy tolerable hell in a bucket	3	good	Effect: "Fitter, Happier", Effect Duration: 25, Last Available: "2017-03"
-9391	practically non-alcoholic delicious skewed Newark	1	awesome	Last Available: "2017-03"
+9389	mediocre watered-down moreltini	2	decent	Last Available: "2017-03"
+9390	tolerable fancy hell in a bucket	3	good	Effect: "Fitter, Happier", Effect Duration: 25, Last Available: "2017-03"
+9391	delicious practically non-alcoholic skewed Newark	1	awesome	Last Available: "2017-03"
 9392	weak acceptable huge R'lyeh	2	good	Last Available: "2017-03"
 9393	drinkable weak Gnollish sangria	2	good	Last Available: "2017-03"
-9394	weak acceptable vodka barracuda	2	good	Last Available: "2017-03"
+9394	acceptable weak vodka barracuda	2	good	Last Available: "2017-03"
 9395	artisanal watered-down Mysterious Island iced tea	2	EPIC	Last Available: "2017-03"
 9396	practically non-alcoholic acceptable drive-by shooting	1	good	Last Available: "2017-03"
 9397	fancy hand-crafted gunner's daughter	4	EPIC	Effect: "Hot Buttoned", Effect Duration: 30, Last Available: "2017-03"
 9398	acceptable dirt julep	3	good	Last Available: "2017-03"
 9399	practically non-alcoholic perfectly mixed maroon Simepore slime	1	EPIC	Last Available: "2017-03"
-9400	watered-down aged Phil Collins	2	awesome	Last Available: "2017-03"
+9400	aged watered-down Phil Collins	2	awesome	Last Available: "2017-03"
 9401	twirling unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	ghostly toggle switch (Bartend)	0		Familiar Weight: +5
 9403	squat toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9289,20 +9289,20 @@
 9417	tumbling alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	altered mirror shaking teal alien plant goo	1		Last Available: "2017-04"
+9420	altered shaking teal mirror alien plant goo	1		Last Available: "2017-04"
 9421	pulsating alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	fancy jumbo tasty bouncing alien meat	5	awesome	Effect: "Gamer Rage", Effect Duration: 10, Last Available: "2017-04"
+9423	jumbo tasty fancy bouncing alien meat	5	awesome	Effect: "Gamer Rage", Effect Duration: 10, Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	pickled alien animal goo	1		Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
-9430	tumbling fuchsia spant egg casing	0		Last Available: "2017-04"
+9430	fuchsia tumbling spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	alkaline blurry narrow maroon alien medicine	0		Effect: "Greasy Visage", Effect Duration: 44, Last Available: "2017-04"
-9433	jumbo moldy alien salad	5	crappy	Last Available: "2017-04"
+9433	moldy jumbo alien salad	5	crappy	Last Available: "2017-04"
 9434	lousy alien booze	4	decent	Last Available: "2017-04"
 9435	lion tamer's brawny alien mask of mayonnaise	0		Muscle Percent: +20, Experience (familiar): +2, Sleaze Spell Damage: +50, Last Available: "2017-04"
 9436	tumbling Annie Oakley's baleful sage alien spear	0		Mysticality Percent: +10, Spell Damage: +25, Critical Hit Percent: +20, Last Available: "2017-04"
@@ -9355,19 +9355,19 @@
 9483	activated quantum blinking Daily Affirmation: Be a Mind Master	0		Effect: "Stands Alone", Effect Duration: 23, Last Available: "2017-05"
 9484	magnetized double-energized warmed spinning Daily Affirmation: Work For Hours a Week	0		Effect: "Itchy Trigger Finger", Effect Duration: 12, Last Available: "2017-05"
 9485	moist galvanized upside-down upside-down Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Good Karma", Effect Duration: 65, Last Available: "2017-05"
-9486	adequate jumbo spinning Affirmation Cookie	5	good	Last Available: "2017-05"
+9486	jumbo adequate spinning Affirmation Cookie	5	good	Last Available: "2017-05"
 9487	shaking green License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	double-energized Threatening Missive	0		Effect: "Sinuses For Miles", Effect Duration: 26
 9491	gray Targeted Plague Vector	0		
-9492	blue blinking suspicious package	0		Free Pull, Last Available: "2017-06"
+9492	blinking blue suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	tumbling family-friendly double-paned ruddy Kremlin's Greatest Briefcase	0		Maximum HP Percent: +40, Cold Resistance: +5, Sleaze Resistance: +1, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	irresponsibly strong tolerable narrow basic martini	8	good	Last Available: "2017-06"
-9495	practically non-alcoholic artisanal yellow improved martini	1	EPIC	Last Available: "2017-06"
+9495	artisanal practically non-alcoholic yellow improved martini	1	EPIC	Last Available: "2017-06"
 9496	lousy splendid martini	4	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
-9498	narrow ghostly can of Minions-Be-Gone	0		Last Available: "2017-06"
+9498	ghostly narrow can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	ghostly tattoo gun	0		Last Available: "2017-06"
 9500	mirror mirror gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
@@ -9377,7 +9377,7 @@
 9505	squat Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	squat Lazenby's Life Lesson	0		Free Pull
 9507	jittery LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
-9508	jittery green Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
+9508	green jittery Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	pulsating spinning L.I.M.P. Stock Certificate	0		
 9510	Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
@@ -9408,21 +9408,21 @@
 9536	pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	jittery pocket wish	0		Last Available: "2023-09"
 9538	lime green dropped scrap of paper	0		
-9539	squat blurry hunk of granite	0		
+9539	blurry squat hunk of granite	0		
 9540	tumbling shovelful of dirt	0		
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	maroon exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	perfectly mixed practically non-alcoholic DUFRESNE Suds	1	EPIC	Last Available: "2017-09"
+9545	practically non-alcoholic perfectly mixed DUFRESNE Suds	1	EPIC	Last Available: "2017-09"
 9546	rock-hard groovy mafia pinky ring	0		Moxie Percent: +10, Damage Reduction: 5, Single Equip
 9547	smooth blinking flask of port	3	awesome	
 9548	bouncing smartaleck's contract enforcement stick	0		Moxie Percent: +30, Item Drop: +5
-9549	rotten huge fancy Hide-rox&trade; cookie	10	crappy	Effect: "Wreathed in Smoke", Effect Duration: 40, Last Available: "2017-10"
-9550	bad fortified jug of booze	5	decent	Last Available: "2017-10"
+9549	huge fancy rotten Hide-rox&trade; cookie	10	crappy	Effect: "Wreathed in Smoke", Effect Duration: 40, Last Available: "2017-10"
+9550	fortified bad jug of booze	5	decent	Last Available: "2017-10"
 9551	super-polarized oxidized jittery pair of candy glasses	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 45, Last Available: "2017-10"
 9552	polymerized quadruple-liquefied mirror bouncing cyan spinning temporary X tattoos	0		Effect: "Broken Fast", Effect Duration: 55, Last Available: "2017-10"
-9553	dried green squat shaking glyph of athleticism	1		Last Available: "2017-10"
+9553	dried shaking green squat glyph of athleticism	1		Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	electrified new habit	0		Effect: "Wet Rub", Effect Duration: 59, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
@@ -9448,12 +9448,12 @@
 9576	veiny mafia organizer badge	0		Maximum HP: +10, Single Equip
 9577	mafia filofax	0		
 9578	tumbling transparent nog	1	crappy	Last Available: "2017-12"
-9579	bland tiny ghostly unfinished fruitcake	1	decent	Last Available: "2017-12"
+9579	tiny bland ghostly unfinished fruitcake	1	decent	Last Available: "2017-12"
 9580	non-diffused skewed and cracker	0		Effect: "Mushroom Might", Effect Duration: 21, Last Available: "2017-12"
-9581	triple-distilled tolerable blinking neg grog	9	good	Last Available: "2017-12"
+9581	tolerable triple-distilled blinking neg grog	9	good	Last Available: "2017-12"
 9582	rotten half double fruitcake	3	crappy	Last Available: "2017-12"
 9583	spoiled small mirror hushed puppy	2	crappy	Last Available: "2017-12"
-9584	moldy thick muffled muffuletta	5	crappy	Last Available: "2017-12"
+9584	thick moldy muffled muffuletta	5	crappy	Last Available: "2017-12"
 9585	massive decent shushed potatoes	8	good	Last Available: "2017-12"
 9586	personal trainer's plastic mime functionary	0		Experience Percent (Muscle): +10, Last Available: "2017-12"
 9587	miser's plastic mime scientist	0		Meat Drop: +10, Last Available: "2017-12"
@@ -9464,7 +9464,7 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	good	Last Available: "2017-11"
 9594	triple-cold-filtered wishbone	0		Effect: "Healthy Green Glow", Effect Duration: 28, Last Available: "2017-11"
-9595	irresponsibly strong lousy huge Racisto Ruidoso	7	decent	Last Available: "2017-11"
+9595	lousy irresponsibly strong huge Racisto Ruidoso	7	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	tasty bran muffin	3	awesome	
 9598	rotten blueberry muffin	3	crappy	
@@ -9491,14 +9491,14 @@
 9619	silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
-9622	ghostly tumbling silent X	0		Last Available: "2017-12"
+9622	tumbling ghostly silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
 9624	jittery silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
-9629	distilled hand-crafted stale cheer wine	5	EPIC	Last Available: "2017-12"
+9629	hand-crafted distilled stale cheer wine	5	EPIC	Last Available: "2017-12"
 9630	stale stale Cheer-E-Os	3	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	lard-coated chaotic cheerful antler hat	0		Spell Critical Percent: +10, Sleaze Spell Damage: +25, Last Available: "2017-12"
@@ -9517,7 +9517,7 @@
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	wobbly mime eraser	0		Last Available: "2017-12"
-9648	acceptable weak blurry spinning executive mime flask	2	good	Last Available: "2017-12"
+9648	weak acceptable blurry spinning executive mime flask	2	good	Last Available: "2017-12"
 9649	spoiled nega-mushroom	3	crappy	Last Available: "2017-12"
 9650	bad nega-mushroom wine	4	decent	Last Available: "2017-12"
 9651	enhanced Cheer-Up soda	0		Effect: "The Strength...  of the Future", Effect Duration: 64, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	ionized blue digital honeypot	0		Effect: "Techno Bliss", Effect Duration: 11, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	sage mime army insignia (intelligence)	0		Mysticality Percent: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	skewed mime army insignia (espionage) of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	mime army insignia (infantry) of the cheetah	0		Initiative: +60, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	sage mime army insignia (intelligence)	0		Mysticality Percent: +10, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	skewed mime army insignia (espionage) of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9570,10 +9570,10 @@
 9698	dry blinking hot button candy	0		Effect: "Tingling Feeling", Effect Duration: 62
 9699	deadly makeshift garbage shirt of the empath of temperance	0		Weapon Damage: +5, Familiar Weight: +5, Sleaze Resistance: +5, Last Available: "2018-01"
 9700	family-friendly Temple Grandin's novelty monorail ticket	0		Familiar Weight: +7, Sleaze Resistance: +1
-9701	dried gray huge shaking pills	1		Effect: "Heavily Breathing", Effect Duration: 40
+9701	dried gray shaking huge pills	1		Effect: "Heavily Breathing", Effect Duration: 40
 9702	diluted furry pill	1		
 9703	denatured bouncing beefy pill	1		
-9704	dried pulsating blurry excitement pill	1		
+9704	dried blurry pulsating excitement pill	1		
 9705	altered fuchsia vitamin G pill	1		
 9706	altered lucky-ish pill	1		Effect: "Florid Cheeks", Effect Duration: 45
 9707	altered wobbly wobbly dieting pill	1		Effect: "Resilient Spirit", Effect Duration: 40
@@ -9597,8 +9597,8 @@
 9729	acceptable spinning Third Base	4	good	Last Available: "2018-02"
 9730	lousy Bustle Hustler	3	decent	Last Available: "2018-02"
 9731	quadruple-anodized ionized ghostly Fabiotion	0		Effect: "Night Vision", Effect Duration: 19, Last Available: "2018-02"
-9732	denatured blinking twirling Bettie page	0		Effect: "Sepia Tan", Effect Duration: 32, Last Available: "2018-02"
-9733	galvanized pulsating twirling tonic o' Banderas	0		Effect: "Tapped In", Effect Duration: 46, Last Available: "2018-02"
+9732	denatured twirling blinking Bettie page	0		Effect: "Sepia Tan", Effect Duration: 32, Last Available: "2018-02"
+9733	galvanized twirling pulsating tonic o' Banderas	0		Effect: "Tapped In", Effect Duration: 46, Last Available: "2018-02"
 9734	dry skewed heather graham cracker	0		Effect: "Berry Experiential", Effect Duration: 42, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
@@ -9613,7 +9613,7 @@
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	extra-moist improved yellow rhinestone	0		Effect: "Dirty Pear", Effect Duration: 31
 9747	1,960 pok&eacute;dollar bill	0		
-9748	pulsating tumbling metandienone	0		
+9748	tumbling pulsating metandienone	0		
 9749	riboflavin	0		
 9750	mirror bronze	0		
 9751	piracetam	0		
@@ -9635,7 +9635,7 @@
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	twirling Sequestrian	0		Last Available: "2018-03"
-9770	mirror teal Carpricorn	0		Last Available: "2018-03"
+9770	teal mirror Carpricorn	0		Last Available: "2018-03"
 9771	bouncing Turpin	0		Last Available: "2018-03"
 9772	tumbling Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
@@ -9649,7 +9649,7 @@
 9781	red Snoutlet	0		Last Available: "2018-03"
 9782	Ruffalo	0		Last Available: "2018-03"
 9783	mirror Vaporpoise	0		Last Available: "2018-03"
-9784	blinking spinning Ghosprey	0		Last Available: "2018-03"
+9784	spinning blinking Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
 9786	blurry Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
@@ -9675,7 +9675,7 @@
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
-9810	ghostly lime green Bowlet	0		Last Available: "2018-03"
+9810	lime green ghostly Bowlet	0		Last Available: "2018-03"
 9811	squat blinking Cornbeefadon	0		Last Available: "2018-03"
 9812	jittery pulsating Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
@@ -9694,7 +9694,7 @@
 9826	pulsating smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
 9828	diluted magnificent oyster egg	1		
-9829	altered pulsating squat brilliant oyster egg	1		Effect: "Educated (Kinda)", Effect Duration: 40
+9829	altered squat pulsating brilliant oyster egg	1		Effect: "Educated (Kinda)", Effect Duration: 40
 9830	dried glistening oyster egg	1		Effect: "The Power of Positive Thinking", Effect Duration: 25
 9831	denatured scintillating oyster egg	1		Effect: "Patience of the Tortoise", Effect Duration: 25
 9832	twisted tumbling pearlescent oyster egg	1		
@@ -9715,7 +9715,7 @@
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	huge LyleCo premium rope	0		Last Available: "2018-04"
-9850	olive wobbly My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
+9850	wobbly olive My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	skewed dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	huge cyan poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	spinning map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	yummy denastified haunch	4	awesome	Last Available: "2018-04"
-9879	irresponsibly strong tolerable bad rum and good cola	6	good	Last Available: "2018-04"
+9879	tolerable irresponsibly strong bad rum and good cola	6	good	Last Available: "2018-04"
 9880	warmed bouncing Potion of Heroism	0		Effect: "Become Intensely interested", Effect Duration: 23, Last Available: "2018-04"
 9881	Samson's thinker's leggings of the Spider Queen of mayonnaise	0		Mysticality: +10, Experience (Muscle): +5, Sleaze Spell Damage: +50, Last Available: "2018-04"
 9882	toasty medical-grade Master Thief's utility belt of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2018-04"
@@ -9766,8 +9766,8 @@
 9898	artisanal two meat muck	3	EPIC	
 9899	yummy chocolate Ogre Chieftain	3	awesome	
 9900	normal massive chocolate &quot;Phoenix&quot;	10	good	
-9901	enchanted spoiled snack-sized green chocolate Spider Queen	2	crappy	Effect: "Partially Ghosted", Effect Duration: 15
-9902	practically non-alcoholic aged hipster cocktail	1	awesome	
+9901	spoiled enchanted snack-sized green chocolate Spider Queen	2	crappy	Effect: "Partially Ghosted", Effect Duration: 15
+9902	aged practically non-alcoholic hipster cocktail	1	awesome	
 9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
 9904	huge God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
 9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
@@ -9789,10 +9789,10 @@
 9921	A Guide to Safari	0		Skill: "Experience Safari"
 9922	boiled Shielding Potion	0		Effect: "Bats in the Belfry", Effect Duration: 15, Last Available: "2018-06"
 9923	modified huge Punching Potion	0		Effect: "Spiky Hair", Effect Duration: 18, Last Available: "2018-06"
-9924	spinning skewed Special Seasoning	0		Last Available: "2018-06"
+9924	skewed spinning Special Seasoning	0		Last Available: "2018-06"
 9925	diluted blurry Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
-9927	gray tumbling Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
+9927	tumbling gray Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	teal Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	squat bouncing blinking executive healthy shellacked Newton's Brutal brogues	0		Experience (Mysticality): +3, Damage Reduction: 7, Maximum HP Percent: +20, Meat Drop: +40, Lasts Until Rollover, Last Available: "2018-07"
 9930	double-paned supercharged extremely unsafe Draftsman's driving gloves of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: 70, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2018-07"
@@ -9818,7 +9818,7 @@
 9950	green tumbling pentagram bandana of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Last Available: "2018-09"
 9951	electrified skull ring	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-09"
 9952	fuchsia electronics kit	0		Last Available: "2018-09"
-9953	decent diet PB&J with the crusts cut off	1	good	Last Available: "2018-09"
+9953	diet decent PB&J with the crusts cut off	1	good	Last Available: "2018-09"
 9954	huge green electrified Oprah's dorky glasses	0		Maximum MP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-09"
 9955	huge nasty ponytail clip of the cheetah	0		Stench Damage: +5, Initiative: +60, Last Available: "2018-09"
 9956	double-paned paint palette	0		Cold Resistance: +5, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
@@ -9837,14 +9837,14 @@
 9969	brawny thinker's denim jacket	0		Mysticality: +10, Muscle Percent: +20, Last Available: "2018-09"
 9970	miser's ratty knitted cap of the glutton	0		Meat Drop: +10, Food Drop: +100, Last Available: "2018-09"
 9972	twirling wicked sage intimidating chainsaw	0		Mysticality Percent: +10, Spell Damage: +5, Lasts Until Rollover, Last Available: "2018-09"
-9973	acceptable practically non-alcoholic party beer bomb	1	good	Last Available: "2018-09"
+9973	practically non-alcoholic acceptable party beer bomb	1	good	Last Available: "2018-09"
 9974	toothsome bite-sized maroon sweet party mix	1	awesome	Last Available: "2018-09"
 9975	dried pulsating party balloon	1		Last Available: "2018-09"
 9976	chilly energetic party pants	0		Maximum MP Percent: +20, Cold Damage: +5, Last Available: "2018-09"
 9977	blue greedy mansplainer's supercool party whip	0		Moxie Percent: +20, Monster Level: +15, Meat Drop: +20, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	drinkable watered-down TRIO cup of beer	2	good	Last Available: "2018-09"
-9980	low-calorie adequate party platter for one	1	good	Last Available: "2018-09"
+9979	watered-down drinkable TRIO cup of beer	2	good	Last Available: "2018-09"
+9980	adequate low-calorie party platter for one	1	good	Last Available: "2018-09"
 9981	distilled narrow Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	gray party pup	0		Last Available: "2018-09"
 9983	pulsating studded party crasher of courage	0		Damage Absorption: +80, Spooky Resistance: +3, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
@@ -9852,7 +9852,7 @@
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
-9988	wobbly narrow latte lovers club card	0		Free Pull, Last Available: "2018-10"
+9988	narrow wobbly latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	upside-down voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	blue double-paned &quot;I Voted!&quot; sticker	0		Cold Resistance: +5, Lasts Until Rollover, Last Available: "2018-11"
 9991	squat absentee voter ballot	0		Last Available: "2018-11"
@@ -9874,16 +9874,16 @@
 10008	chaotic mutant legs of Gandalf of the sweet-tooth	0		Spell Critical Percent: 30, Candy Drop: +100, Last Available: "2018-11"
 10009	miser's Da Vinci's groovy mutant crown	0		Moxie Percent: +10, Experience (Mysticality): +5, Meat Drop: +10, Last Available: "2018-11"
 10010	yummy ghostly ectoplasm	3	awesome	Last Available: "2018-11"
-10011	huge stale	10	decent	Last Available: "2018-11"
+10011	stale huge	10	decent	Last Available: "2018-11"
 10012	mediocre special bottle of vodka	4	decent	Effect: "Fungal Fortification", Effect Duration: 50, Last Available: "2018-11"
-10013	jumbo decent enchanted upside-down pizza	5	good	Effect: "Red-Shirted Escort", Effect Duration: 35, Last Available: "2018-11"
+10013	jumbo enchanted decent upside-down pizza	5	good	Effect: "Red-Shirted Escort", Effect Duration: 35, Last Available: "2018-11"
 10014	acceptable martini	3	good	Last Available: "2018-11"
 10015	toothsome cherry pie	4	awesome	Last Available: "2018-11"
 10016	tolerable skewed eggnog	3	good	Last Available: "2018-11"
 10017	huge glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	snack-sized moldy mirror Hell ramen	2	crappy	Last Available: "2018-11"
+10018	moldy snack-sized mirror Hell ramen	2	crappy	Last Available: "2018-11"
 10019	tolerable fortified pulsating gimlet	5	good	Last Available: "2018-11"
-10020	boozy tolerable twice-haunted screwdriver	5	good	Last Available: "2018-11"
+10020	tolerable boozy twice-haunted screwdriver	5	good	Last Available: "2018-11"
 10021	spoiled candy cane	4	crappy	Last Available: "2018-12"
 10022	artisanal runny fermented egg	4	EPIC	Last Available: "2018-12"
 10023	rotten bouncing oldcake	4	crappy	Last Available: "2018-12"
@@ -9907,7 +9907,7 @@
 10041	MacGyver's balanced antler	0		Maximum MP: +100, Last Available: "2018-12"
 10042	quilted dam	0		Damage Absorption: +40, Damage Reduction: 9, Last Available: "2018-12"
 10043	strong drinkable beavermouth	5	good	Last Available: "2018-12"
-10044	mediocre strong beaver punch (papaya)	5	decent	Last Available: "2018-12"
+10044	strong mediocre beaver punch (papaya)	5	decent	Last Available: "2018-12"
 10045	artisanal beaver punch (peach)	4	EPIC	Last Available: "2018-12"
 10046	bad weak shaking beaver punch (cherry)	2	decent	Last Available: "2018-12"
 10047	Van der Graaf Canadian lantern of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
@@ -9922,14 +9922,14 @@
 10056	Boxing Day Pass	0		Last Available: "2018-12"
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	miser's fireproof supercharged beefcake's Kramco Sausage-o-Matic&trade; of dire peril	0		Muscle: +25, Weapon Damage: +20, Maximum MP Percent: +30, Hot Resistance: +3, Meat Drop: +10, Last Available: "2019-01"
-10059	maroon skewed sausage casing	0		Last Available: "2019-01"
+10059	skewed maroon sausage casing	0		Last Available: "2019-01"
 10060	adequate sausage	3	good	Last Available: "2019-01"
 10061	rosewater-soaked smelly red-hot sausage fork	0		Stench Spell Damage: +10, Stench Resistance: +3, Last Available: "2019-01"
 10062	yellow bag of sausage links	0		Last Available: "2019-01"
 10063	shaking sausage golem	0		Last Available: "2019-01"
 10064	purple jar of relish	0		Familiar Weight: +5
 10065	tumbling Toyleporter	0		Last Available: "2018-12"
-10066	watered-down tolerable beer	2	good	Last Available: "2018-12"
+10066	tolerable watered-down beer	2	good	Last Available: "2018-12"
 10067	toothsome yule gruel	3	awesome	Last Available: "2018-12"
 10068	perfectly mixed hot watered rum	4	EPIC	Last Available: "2018-12"
 10069	acceptable bottle of Crimbognac	4	good	Last Available: "2018-12"
@@ -9960,7 +9960,7 @@
 10094	teal friendly ruddy marble medallion	0		Maximum HP Percent: +40, Familiar Weight: +3, Single Equip, Last Available: "2019-12"
 10095	prompt lion tamer's marble mariachi hat	0		Experience (familiar): +2, Adventures: +3, Last Available: "2019-12"
 10096	pickled jittery marble molecules	1		Last Available: "2019-12"
-10097	non-irradiated shaking ghostly Mallomarbles	0		Effect: "Spring Training", Effect Duration: 19
+10097	non-irradiated ghostly shaking Mallomarbles	0		Effect: "Spring Training", Effect Duration: 19
 10098	Rosewater's punching bag of the wise owl	0		Mysticality: +20, Mysticality Percent: +30, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10099	smartaleck's pith helmet of the bloodbag	0		Moxie Percent: +30, Maximum HP: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10100	blinking executive flame-wreathed poncho	0		Hot Spell Damage: +10, Meat Drop: +40, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
@@ -9976,7 +9976,7 @@
 10110	experienced terra cotta tie tack of Calamity Jane	0		Experience: +2, Critical Hit Percent: +15, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10111	terra cotta tambourine of the sewer of the overflowing toilet	0		Stench Damage: +25, Stench Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	altered blurry terra cotta tidbits	1		Last Available: "2020-12"
-10113	deionized improved huge blurry red terra panna cotta	0		Effect: "Deeply Ironic", Effect Duration: 27
+10113	deionized improved blurry red huge terra panna cotta	0		Effect: "Deeply Ironic", Effect Duration: 27
 10114	blurry ribald velour voulge of the glutton	0		Sleaze Damage: +10, Food Drop: +100, Last Available: "2021-12"
 10115	blinking forbidden slick velour vambraces	0		Moxie: +10, Spell Damage Percent: +50, Single Equip, Last Available: "2021-12"
 10116	toasty beefy velour veil	0		Muscle: +10, Hot Damage: +5, Single Equip, Last Available: "2021-12"
@@ -10007,7 +10007,7 @@
 10141	scandalous resourceful flagstone fez	0		Maximum MP: +50, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
 10142	smartaleck's flagstone fleece of Leguizamo	0		Moxie Percent: +30, Monster Level: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
 10143	extremely unsafe Samson's flagstone fringe	0		Experience (Muscle): +5, Weapon Damage Percent: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	mixed narrow blurry flagstone flagments	1		Last Available: "2022-12"
+10144	mixed blurry narrow flagstone flagments	1		Last Available: "2022-12"
 10145	improved oxidized super-altered Flag by the Foot&trade;	0		Effect: "Greasy Flavor", Effect Duration: 57
 10146	olive elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	tumbling really nice net	0		Last Available: "2019-12"
 10154	veiny elf army poncho	0		Maximum HP: +10, Lasts Until Rollover, Last Available: "2019-12"
-10155	miniature decent narrow elf army field rations	2	good	Last Available: "2019-12"
+10155	decent miniature narrow elf army field rations	2	good	Last Available: "2019-12"
 10156	cyan gingernade	0		Last Available: "2019-12"
 10157	censurious resourceful discarded bowtie	0		Maximum MP: +50, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2019-12"
 10158	weak drinkable pulsating martiny	2	good	Last Available: "2019-12"
@@ -10031,11 +10031,11 @@
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	foul-smelling therapeutic Lil' Doctor&trade; bag	0		Stench Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	purple blood bag	0		
-10169	small yummy squat bloodstick	2	awesome	
+10169	yummy small squat bloodstick	2	awesome	
 10170	lousy bottle of Sanguiovese	3	decent	
 10171	rotten jittery actual blood sausage	4	crappy	
 10172	practically non-alcoholic lousy mulled blood	1	decent	
-10173	miniature spoiled blood snowcone	2	crappy	
+10173	spoiled miniature blood snowcone	2	crappy	
 10174	artisanal Red Russian	4	EPIC	
 10175	moldy small blood roll-up	2	crappy	
 10176	tolerable bottle of blood	4	good	
@@ -10063,7 +10063,7 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	decent crabsicle	4	good	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	irresponsibly strong mediocre bottle of dark rhum	6	decent	Last Available: "2019-04"
+10201	mediocre irresponsibly strong bottle of dark rhum	6	decent	Last Available: "2019-04"
 10202	drinkable bottle of extra-dark rhum	4	good	Last Available: "2019-04"
 10203	bad tumbling bottle of super-extra-dark rhum	3	decent	Last Available: "2019-04"
 10204	dry pirate shaving cream	0		Effect: "Boon of the War Snapper", Effect Duration: 17, Last Available: "2019-04"
@@ -10071,7 +10071,7 @@
 10206	educational pirate pantaloons of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Last Available: "2019-04"
 10207	ghostly [glitch season reward name]	0		
 10208	teal signal fragment	0		Last Available: "2019-04"
-10209	maroon blurry windicle	0		Last Available: "2019-04"
+10209	blurry maroon windicle	0		Last Available: "2019-04"
 10210	bouncing wool Temple Grandin's pirate radio ring	0		Familiar Weight: +7, Cold Resistance: +1, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	tasty thick pineapple slab	5	awesome	Last Available: "2019-04"
@@ -10095,11 +10095,11 @@
 10230	wobbly avaricious auspicious piratical blunderbuss	0		Item Drop: +10, Meat Drop: +30, Last Available: "2019-04"
 10231	wobbly tumbling rosewater-soaked stylish PirateRealm party hat of wisdom	0		Mysticality: +15, Moxie: +25, Stench Resistance: +3, Last Available: "2019-04"
 10232	aged triple-distilled Island Landslide	9	awesome	Last Available: "2019-04"
-10233	lousy watered-down Island Thunderstorm	2	decent	Last Available: "2019-04"
+10233	watered-down lousy Island Thunderstorm	2	decent	Last Available: "2019-04"
 10234	perfectly mixed upside-down Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	mediocre Skull Punch	3	decent	Last Available: "2019-04"
 10236	aged triple-distilled Electric Punch	6	awesome	Last Available: "2019-04"
-10237	acceptable weak Smuggler's Punch	2	good	Last Available: "2019-04"
+10237	weak acceptable Smuggler's Punch	2	good	Last Available: "2019-04"
 10238	lousy high-proof Scorpion Bowl	8	decent	Last Available: "2019-04"
 10239	drinkable practically non-alcoholic Turtle Bowl	1	good	Last Available: "2019-04"
 10240	acceptable Cobra Bowl	4	good	Last Available: "2019-04"
@@ -10115,13 +10115,13 @@
 10250	cyan Fourth of May Cosplay Saber kit	0		Free Pull
 10251	upside-down Jack Frost's ruddy Samson's Fourth of May Cosplay Saber	0		Experience (Muscle): +5, Maximum HP Percent: +40, Cold Spell Damage: +50, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
-10253	jittery red huge bouncing Thwaitgold nymph statuette	0		
+10253	red jittery bouncing huge Thwaitgold nymph statuette	0		
 10254	Usain Bolt's inspector's auspicious dog trainer's coward's mansplainer's steel-toed padded forbidden thinker's hewn moon-rune spoon of the storm	0		Mysticality: +10, Spell Damage Percent: +50, Damage Absorption: +20, Damage Reduction: 9, Maximum MP Percent: +40, Monster Level: -5, Experience (familiar): +1, Item Drop: 25, Initiative: +80, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	pulsating cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	supercool Beach Comb of the boozehound of the sweet-tooth	0		Moxie Percent: +20, Booze Drop: +100, Candy Drop: +100, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
-10259	teal ghostly grain of sand	0		Last Available: "2019-07"
+10259	ghostly teal grain of sand	0		Last Available: "2019-07"
 10260	spinning tumbling small pile of sand	0		Last Available: "2019-07"
 10261	spinning pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
@@ -10132,10 +10132,10 @@
 10267	galvanized quadruple-flattened narrow cyan seashell	0		Effect: "Slime Time", Effect Duration: 35, Last Available: "2019-07"
 10268	liquefied gray seashell	0		Effect: "Morninja", Effect Duration: 17, Last Available: "2019-07"
 10269	magnetized seashell	0		Effect: "Expert Vacationer", Effect Duration: 14, Last Available: "2019-07"
-10270	enhanced moist purple blinking seashell	0		Effect: "Ooh, Sour!", Effect Duration: 57, Last Available: "2019-07"
+10270	enhanced moist blinking purple seashell	0		Effect: "Ooh, Sour!", Effect Duration: 57, Last Available: "2019-07"
 10271	twirling twirling bunch of sea grapes	0		Last Available: "2019-07"
 10272	lousy bottle of sea wine	4	decent	Last Available: "2019-07"
-10273	altered huge narrow olive kelp	1		Last Available: "2019-07"
+10273	altered narrow huge olive kelp	1		Last Available: "2019-07"
 10274	twirling toasty nippy Tesla rosy-cheeked studded sinister wicked grievous driftwood hat of the storm	0		Weapon Damage Percent: +50, Spell Damage: 15, Damage Absorption: +80, Maximum HP Percent: +30, Maximum MP Percent: +40, Cold Damage: +10, Hot Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10275	rosewater-soaked reassuring knitted Jeselnik's chaotic medical-grade stiffened driftwood pants of the dark arts of the brazier	0		Spell Damage Percent: +100, Damage Reduction: 1, Spell Critical Percent: +10, Hot Spell Damage: +25, Sleaze Damage: +25, Cold Resistance: +3, Spooky Resistance: +1, Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10276	executive family-friendly rosewater-soaked fireproof nasty experienced driftwood bracelet of the cougar of the scaredy-cat of the cheetah	0		Moxie: +20, Experience: +2, Monster Level: -15, Stench Damage: +5, Hot Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +1, Meat Drop: +40, Initiative: +60, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10143,7 +10143,7 @@
 10278	lard-coated medical-grade spearfish fishing spear of mayonnaise	0		Sleaze Spell Damage: 75, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-07"
 10279	cyan grievous supercool brainy rabbitfish fin	0		Mysticality: +5, Moxie Percent: +20, Weapon Damage Percent: +50, Single Equip, Last Available: "2019-07"
 10280	piece of coral	0		Last Available: "2019-07"
-10281	blurry gray piece of driftwood	0		Last Available: "2019-07"
+10281	gray blurry piece of driftwood	0		Last Available: "2019-07"
 10282	reassuring Rosewater's pirate cutlass of horror	0		Mysticality Percent: +30, Spooky Spell Damage: +25, Spooky Resistance: +1, Single Equip, Last Available: "2019-07"
 10283	stanky manspreader's Tesla tricorn hat	0		Monster Level: +10, Stench Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-07"
 10284	spinning rosewater-soaked lard-coated swash buckle of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2019-07"
@@ -10152,7 +10152,7 @@
 10287	tumbling prompt educational meteorite necklace of the businessman	0		Experience: +1, Meat Drop: +50, Adventures: +3, Single Equip, Last Available: "2019-07"
 10288	wobbly sizzling stiffened educational meteorite ring	0		Experience: +1, Damage Reduction: 1, Hot Damage: +10, Single Equip, Last Available: "2019-07"
 10289	flattened triple-galvanized Finnish Fish	0		Effect: "Craft Tea", Effect Duration: 48
-10290	moist adjusted narrow shaking chocolate doubloon	0		Effect: "Turkey-Agitated", Effect Duration: 22
+10290	moist adjusted shaking narrow chocolate doubloon	0		Effect: "Turkey-Agitated", Effect Duration: 22
 10291	steel-toed padded wicked driftwood beach comb	0		Spell Damage: +5, Damage Absorption: +20, Damage Reduction: 9, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	stick of firewood	0		Last Available: "2019-08"
@@ -10168,7 +10168,7 @@
 10303	jumbo decent campfire hot dog	5	good	Last Available: "2019-08"
 10304	delicious narrow campfire baked potato	4	awesome	Last Available: "2019-08"
 10305	rotten shaking campfire s'more	4	crappy	Last Available: "2019-08"
-10306	spoiled super-sized campfire beans	5	crappy	Last Available: "2019-08"
+10306	super-sized spoiled campfire beans	5	crappy	Last Available: "2019-08"
 10307	super-sized bland blue campfire stew	5	decent	Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	double-flattened leftover chocolate bar	0		Effect: "From Nantucket", Effect Duration: 51
@@ -10203,28 +10203,28 @@
 10344	pulsating plastic Dolph Bossin of the ox	0		Muscle: +20, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	adequate ghostly mana-coated yams	4	good	Last Available: "2019-11"
-10347	tiny flavorless spinning mana-basted tofurkey leg	1	decent	Last Available: "2019-11"
+10347	flavorless tiny spinning mana-basted tofurkey leg	1	decent	Last Available: "2019-11"
 10348	bland tiny gray mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
 10349	delicious mana-stuffed herbal stuffing	3	awesome	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	triple-electrified quadruple-anodized ghostly patch of extra-warm fur	0		Effect: "Sweet Incentive", Effect Duration: 40, Last Available: "2019-12"
 10352	pickled ghostly industrial lubricant	1		Last Available: "2019-12"
 10353	polymerized moist unfinished pleasure	0		Effect: "Extra Terrestrial", Effect Duration: 35, Last Available: "2019-12"
-10354	mixed spinning green tumbling vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	mixed tumbling green spinning vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	distilled blinking a bug's lymph	1		Last Available: "2019-12"
 10356	quantum deionized quantum wobbly organic potpourri	0		Effect: "Salamanderenity", Effect Duration: 31, Last Available: "2019-12"
 10357	hand-crafted teal boot flask	3	EPIC	Last Available: "2019-12"
 10358	super-frozen deionized infernal snowball	0		Effect: "Icy Demeanor", Effect Duration: 62, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	distilled fish sauce	1		Last Available: "2019-12"
-10361	flavorless gigantic fuchsia guffin	10	decent	Last Available: "2019-12"
+10361	gigantic flavorless fuchsia guffin	10	decent	Last Available: "2019-12"
 10362	boiled mirror Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	diluted pulsating lime green non-Euclidean angle	1		Effect: "Swimming with Sharks", Effect Duration: 5, Last Available: "2019-12"
+10364	diluted lime green pulsating non-Euclidean angle	1		Effect: "Swimming with Sharks", Effect Duration: 5, Last Available: "2019-12"
 10365	cold-filtered nitrogenated peppermint syrup	0		Effect: "Incensed", Effect Duration: 41, Last Available: "2019-12"
 10366	cold-filtered chilled skewed Mer-kin eyedrops	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 35, Last Available: "2019-12"
 10367	chilled blurry extra-strength goo	0		Effect: "Industrial Strength Starch", Effect Duration: 29, Last Available: "2019-12"
-10368	bouncing maroon envelope full of Meat	0		Last Available: "2019-12"
+10368	maroon bouncing envelope full of Meat	0		Last Available: "2019-12"
 10369	vaporized shaking livid energy	1		Last Available: "2019-12"
 10370	ghostly micronova	0		Last Available: "2019-12"
 10371	distilled blinking beggin' cologne	1		Last Available: "2019-12"
@@ -10254,8 +10254,8 @@
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	narrow tinsel fin	0		Familiar Weight: +5
 10397	decent snack-sized bowl of mernudo	2	good	Last Available: "2019-12"
-10398	bad irresponsibly strong fishelada	9	decent	Last Available: "2019-12"
-10399	flavorless jittery olive ojo de pez burrito	4	decent	Last Available: "2019-12"
+10398	irresponsibly strong bad fishelada	9	decent	Last Available: "2019-12"
+10399	flavorless olive jittery ojo de pez burrito	4	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	bland immense salt plum	10	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	miniature special normal and bean	2	good	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2019-12"
+10417	miniature normal special and bean	2	good	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2019-12"
 10418	ghostly twirling Sherlock's beefcake's kelp-holly gun of Calamity Jane	0		Muscle: +25, Critical Hit Percent: +15, Item Drop: +25, Last Available: "2019-12"
 10419	Yuleviathan necklace of the bloodbag of extreme caution	0		Maximum HP: +100, Monster Level: -25, Single Equip, Last Available: "2019-12"
 10420	lard-coated grievous peppermint spine	0		Weapon Damage Percent: +50, Sleaze Spell Damage: +25, Last Available: "2019-12"
@@ -10281,12 +10281,12 @@
 10422	olive Jeselnik's careful Crimbylow-rise jeans	0		Monster Level: -10, Sleaze Damage: +25, Last Available: "2019-12"
 10423	censurious kelp-holly drape of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3, Last Available: "2019-12"
 10424	lightning-fast flame-retardant sinister Staff of the Peppermint Twist of bravery	0		Spell Damage: +10, Hot Resistance: +1, Spooky Resistance: +5, Initiative: +40, Last Available: "2019-12"
-10425	immense rotten narrow fuchsia tempura and bean	7	crappy	Last Available: "2019-12"
+10425	immense rotten fuchsia narrow tempura and bean	7	crappy	Last Available: "2019-12"
 10426	acceptable salt plum sake	3	good	Last Available: "2019-12"
 10427	tarnished yellow pressurized potion of possessiveness	0		Effect: "Melancholy Burden", Effect Duration: 35, Last Available: "2019-12"
 10428	polarized irradiated squat almond	0		Effect: "Heightened Senses", Effect Duration: 30
 10429	Vulcanized magnetized handful of mixed nuts	0		Effect: "Swimming Head", Effect Duration: 12, Last Available: "2019-12"
-10430	jittery skewed nutcracking pliers	0		
+10430	skewed jittery nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	frightening veiny Retrospecs of wisdom	0		Mysticality: +15, Maximum HP: +10, Spooky Damage: +5, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
@@ -10306,13 +10306,13 @@
 10449	careful drippy stake	0		Monster Level: -10, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	bouncing drippy khakis	0		
-10452	blue blurry drippy shield	0		
+10452	blurry blue drippy shield	0		
 10453	The Fingernail of the Thing in the Basement	0		
 10454	coin	0		
 10455	mushroom	0		
 10456	deluxe mushroom	0		
 10457	super deluxe mushroom	0		
-10458	extra-denatured diffused maroon spinning blurry fizzy soda	0		Effect: "Always In Motion", Effect Duration: 34
+10458	extra-denatured diffused blurry spinning maroon fizzy soda	0		Effect: "Always In Motion", Effect Duration: 34
 10459	wet moist squat healthy juice	0		Effect: "Engorged Weapon", Effect Duration: 31
 10460	hammer	0		
 10461	red hammer	0		
@@ -10334,13 +10334,13 @@
 10477	green rubber doll body	0		
 10478	plastic doll arms	0		
 10479	skewed plastic doll legs	0		
-10480	jittery cyan rubber baby doll	0		
+10480	cyan jittery rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	bouncing packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	spinning plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
-10486	huge red free-range mushroom	0		Last Available: "2020-03"
+10486	red huge free-range mushroom	0		Last Available: "2020-03"
 10487	pulsating immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
 10489	spoiled low-calorie green mushroom filet	1	crappy	Last Available: "2020-03"
@@ -10370,8 +10370,8 @@
 10513	olive smartaleck's Left-Hand Man action figure	0		Moxie Percent: +30, Last Available: "2020-04"
 10514	cyan drippy seed	0		
 10515	twirling drippy grub	0		
-10516	skewed yellow drippy bezoar	0		
-10517	wobbly red Drip Institute petri dish	0		
+10516	yellow skewed drippy bezoar	0		
+10517	red wobbly Drip Institute petri dish	0		
 10518	drippy ichor	0		
 10519	drippy enzyme	0		
 10520	drippy salt	0		
@@ -10473,12 +10473,12 @@
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	pulsating frost-rimed desk bell	0		Last Available: "2020-09"
 10619	purple uncanny desk bell	0		Last Available: "2020-09"
-10620	purple upside-down nasty desk bell	0		Last Available: "2020-09"
+10620	upside-down purple nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	purple onyx queen	0		Last Available: "2020-09"
-10625	pulsating narrow onyx rook	0		Last Available: "2020-09"
+10625	narrow pulsating onyx rook	0		Last Available: "2020-09"
 10626	green onyx bishop	0		Last Available: "2020-09"
 10627	twirling onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
@@ -10510,7 +10510,7 @@
 10654	ionized quadruple-ionized blurry boiling hot cocoa	0		Effect: "Sweetened and Fattened", Effect Duration: 40, Last Available: "2020-12"
 10655	unsweetened blue cool hot cocoa	0		Effect: "Grrrrrrreat!", Effect Duration: 41, Last Available: "2020-12"
 10656	dry shaking overly-fancy hot cocoa	0		Effect: "Turkey-Agitated", Effect Duration: 41, Last Available: "2020-12"
-10657	concentrated cold-filtered spinning blinking hot cocoa au beurre	0		Effect: "Inner Warmth", Effect Duration: 47, Last Available: "2020-12"
+10657	concentrated cold-filtered blinking spinning hot cocoa au beurre	0		Effect: "Inner Warmth", Effect Duration: 47, Last Available: "2020-12"
 10658	improved yellow hot cocoa with rainbow marshmallows	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 51, Last Available: "2020-12"
 10659	Book of Old-Timey Carols of the scaredy-cat	0		Monster Level: [-15*event(December)], Last Available: "2020-12"
 10660	up-at-dawn Crimbo smile	0		Adventures: [+5*event(December)], Last Available: "2020-12"
@@ -10537,8 +10537,8 @@
 10681	bouncing therapeutic candy bucket	0		HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2020-12"
 10682	polymerized prescription teeth whitener	0		Effect: "Slimily Speedy", Effect Duration: 12, Last Available: "2020-12"
 10683	wet improved wobbly imported lemon lozenge	0		Effect: "Going Ape", Effect Duration: 47, Last Available: "2020-12"
-10684	unsweetened wobbly ghostly hermedisiac cologne	0		Effect: "Appeteyes", Effect Duration: 16, Last Available: "2020-12"
-10685	blue pulsating huge government food shipment	0		Last Available: "2020-12"
+10684	unsweetened ghostly wobbly hermedisiac cologne	0		Effect: "Appeteyes", Effect Duration: 16, Last Available: "2020-12"
+10685	pulsating huge blue government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
@@ -10573,7 +10573,7 @@
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	twirling nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	huge goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	perfectly mixed practically non-alcoholic barrel-aged eggnog	1	super ultra mega turbo EPIC	Last Available: "2020-12"
+10720	practically non-alcoholic perfectly mixed barrel-aged eggnog	1	super ultra mega turbo EPIC	Last Available: "2020-12"
 10721	bland hand-crafted candy cane	4	decent	Last Available: "2020-12"
 10722	bland lime green bouncing drive-thru burger	3	decent	Last Available: "2020-12"
 10723	practically non-alcoholic drinkable Boulevardier cocktail	1	good	Last Available: "2020-12"
@@ -10588,7 +10588,7 @@
 10732	fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 10734	narrow spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
-10735	maroon skewed robo-battery	0		
+10735	skewed maroon robo-battery	0		
 10736	spinning Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
@@ -10605,8 +10605,8 @@
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	upside-down shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
-10752	colloidal narrow ghostly fuchsia short beer	0		Effect: "Berry Berry Cold", Effect Duration: 15, Last Available: "2021-05"
-10753	quadruple-polarized irradiated bouncing shaking short stack of pancakes	0		Effect: "Fungal Fortification", Effect Duration: 32, Last Available: "2021-05"
+10752	colloidal fuchsia narrow ghostly short beer	0		Effect: "Berry Berry Cold", Effect Duration: 15, Last Available: "2021-05"
+10753	quadruple-polarized irradiated shaking bouncing short stack of pancakes	0		Effect: "Fungal Fortification", Effect Duration: 32, Last Available: "2021-05"
 10754	Vulcanized short stick of butter	0		Effect: "Hairy Palms", Effect Duration: 68, Last Available: "2021-05"
 10755	extra-ionized flattened upside-down short glass of water	0		Effect: "Nothing Is Impossible", Effect Duration: 25, Last Available: "2021-05"
 10756	alkaline short	0		Effect: "Soles of Glass", Effect Duration: 42, Last Available: "2021-05"
@@ -10621,7 +10621,7 @@
 10765	rocket	0		Last Available: "2021-07"
 10766	pulsating rocket	0		Last Available: "2021-07"
 10767	huge rocket	0		Last Available: "2021-07"
-10768	flavorless bite-sized fire crackers	1	decent	Last Available: "2021-07"
+10768	bite-sized flavorless fire crackers	1	decent	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	maroon fortified slick Catherine Wheel	0		Moxie: +10, Damage Absorption: +60, Lasts Until Rollover, Last Available: "2021-07"
 10771	squat rosy-cheeked razor-sharp rocket boots	0		Weapon Damage Percent: +25, Maximum HP Percent: +30, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10640,7 +10640,7 @@
 10784	colloidal yellow natural magick candle	0		Effect: "Shawarma Warm War", Effect Duration: 23, Last Available: "2021-08"
 10785	magnetized rainbow glitter candle	0		Effect: "Mariachi Mood", Effect Duration: 12, Last Available: "2021-08"
 10786	double-boiled banana candle	0		Effect: "Billiards Belligerence", Effect Duration: 48, Last Available: "2021-08"
-10787	triple-moist dry skewed pulsating ear candle	0		Effect: "Spiritually Awake", Effect Duration: 14, Last Available: "2021-08"
+10787	triple-moist dry pulsating skewed ear candle	0		Effect: "Spiritually Awake", Effect Duration: 14, Last Available: "2021-08"
 10788	pickled energized bouncing votive of confidence	0		Effect: "Sweet Taste", Effect Duration: 14, Last Available: "2021-08"
 10789	squat water candle of temperance	0		Sleaze Resistance: +5, Water: 3, Lasts Until Rollover
 10790	B. L. A. R. T. of Flo-Jo	0		Initiative: +100, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
@@ -10659,7 +10659,7 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	Sherlock's deadly Daylight Shavings Helmet of chilblains	0		Weapon Damage: +5, Cold Damage: +25, Item Drop: +25, Last Available: "2021-11"
 10805	eggwater	1	awesome	Last Available: "2021-12"
-10806	small tasty skewed bread man	2	awesome	Last Available: "2021-12"
+10806	tasty small skewed bread man	2	awesome	Last Available: "2021-12"
 10807	moldy ghostly plain candy cane	4	crappy	Last Available: "2021-12"
 10808	toothsome flour cookie	4	awesome	Last Available: "2021-12"
 10809	rosewater-soaked plastic food lab	0		Stench Resistance: +3, Single Equip, Last Available: "2021-12"
@@ -10674,7 +10674,7 @@
 10818	greedy miser's hardened ice wrap	0		Damage Reduction: 3, Meat Drop: 30, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	decent shaking pulsating tofu pop	3	good	Last Available: "2021-12"
 10820	normal bowl of prescription candy	4	good	Last Available: "2021-12"
-10821	adequate immense fishcake	10	good	Last Available: "2021-12"
+10821	immense adequate fishcake	10	good	Last Available: "2021-12"
 10822	bland thick mirror bone broth	5	decent	Last Available: "2021-12"
 10823	rotten star pop	3	crappy	Last Available: "2021-12"
 10824	smooth Doc's Fortifying Wine	3	awesome	Last Available: "2021-12"
@@ -10685,7 +10685,7 @@
 10829	powdered Extrovermectin&trade;	1		Effect: "Man's Worst Enemy", Effect Duration: 40, Last Available: "2021-12"
 10830	pickled Breathitin&trade;	1		Last Available: "2021-12"
 10831	dried Fleshazole&trade;	1		Last Available: "2021-12"
-10832	polarized moist huge pulsating anti-burn cream	0		Effect: "Oh Snap", Effect Duration: 21, Last Available: "2021-12"
+10832	polarized moist pulsating huge anti-burn cream	0		Effect: "Oh Snap", Effect Duration: 21, Last Available: "2021-12"
 10833	activated red anti-freeze cream	0		Effect: "Biologically Shocked", Effect Duration: 21, Last Available: "2021-12"
 10834	denatured pressed bouncing anti-goosebump cream	0		Effect: "Dreadful Smell", Effect Duration: 34, Last Available: "2021-12"
 10835	modified improved anti-odor cream	0		Effect: "20/20 Vision", Effect Duration: 50, Last Available: "2021-12"
@@ -10697,7 +10697,7 @@
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
-10844	skewed blinking gooified animal matter	0		Last Available: "2021-12"
+10844	blinking skewed gooified animal matter	0		Last Available: "2021-12"
 10845	olive gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10706,7 +10706,7 @@
 10850	spinning goo magnet	0		Last Available: "2021-12"
 10851	cyan therapeutic cozy scarf	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-12"
 10852	immense tasty tumbling shaking huge Crimbo cookie	10	awesome	Last Available: "2023-06"
-10853	diffused squat bouncing fleshy putty	0		Effect: "Haunted Stomach", Effect Duration: 15, Last Available: "2021-12"
+10853	diffused bouncing squat fleshy putty	0		Effect: "Haunted Stomach", Effect Duration: 15, Last Available: "2021-12"
 10854	banded third ear	0		Damage Absorption: +100, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	teal projectile chemistry set	0		Last Available: "2021-12"
 10860	energetic depleted Crimbonium football helmet	0		Maximum MP Percent: +20, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	adequate half-sized &quot;caramel&quot;	2	good	Last Available: "2021-12"
+10862	half-sized adequate &quot;caramel&quot;	2	good	Last Available: "2021-12"
 10863	smartaleck's self-repairing earmuffs	0		Moxie Percent: +30, Last Available: "2021-12"
 10864	brawny carnivorous potted plant	0		Muscle Percent: +20, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	mirror yule hatchet of the glutton	0		Food Drop: +100, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	moldy thick lab-grown meat	5	crappy	Last Available: "2021-12"
+10868	thick moldy lab-grown meat	5	crappy	Last Available: "2021-12"
 10869	shaking huge fireproof fleece	0		Hot Resistance: +3, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10739,8 +10739,8 @@
 10883	powdered ghostly astral energy drink	1		
 10884	skewed mint condition magnifying glass	0		Last Available: "2022-12"
 10885	Tesla magnifying glass of the pedagogue of terror	0		Experience: +3, Spooky Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-12"
-10886	hand-crafted high-proof void lager	10	EPIC	Last Available: "2022-12"
-10887	miniature rotten void burger	2	crappy	Last Available: "2022-12"
+10886	high-proof hand-crafted void lager	10	EPIC	Last Available: "2022-12"
+10887	rotten miniature void burger	2	crappy	Last Available: "2022-12"
 10888	squat void stone	0		Last Available: "2022-12"
 10889	upside-down greasy ruddy weightlifter's void shard of mayonnaise	0		Muscle: +15, Maximum HP Percent: +40, Sleaze Spell Damage: 60, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10749,7 +10749,7 @@
 10893	skewed occult combat lover's locket	0		Spell Damage Percent: +25, Single Equip, Last Available: "2022-02"
 10894	jittery Thwaitgold protozoa statuette	0		
 10895	grey gosling	0		Free Pull, Last Available: "2022-03"
-10896	jittery teal grey down vest	0		Experience (familiar): +2
+10896	teal jittery grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	knitted unbreakable umbrella (broken) of the cougar of Tarzan of James Dean	0		Moxie: +20, Experience (Muscle): +3, Experience (Moxie): +3, Cold Resistance: +3
@@ -10769,10 +10769,10 @@
 10913	tumbling bar of freeze-dried water	1	good	Last Available: "2022-05"
 10914	decent fancy expired MRE	4	good	Effect: "Prelude of Precision", Effect Duration: 40, Last Available: "2022-05"
 10915	bland low-calorie cool mint precipice bar	1	decent	Last Available: "2022-05"
-10916	big normal carrot cake precipice bar	5	good	Last Available: "2022-05"
+10916	normal big carrot cake precipice bar	5	good	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
-10919	mirror huge packaged June cleaver	0		Free Pull, Last Available: "2022-06"
+10919	huge mirror packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	blinking aromatic sizzling June cleaver of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +10, Stench Resistance: +1, Attacks Can't Miss, Last Available: "2022-06"
 10921	perfectly mixed fortified skewed Dad's brandy	5	EPIC	Last Available: "2022-06"
 10922	Temple Grandin's teacher's pen of terror	0		Familiar Weight: +7, Spooky Spell Damage: +10, Last Available: "2022-06"
@@ -10782,8 +10782,8 @@
 10926	non-aerosolized liquefied trampled ticket stub	0		Effect: "stats.enq", Effect Duration: 43, Last Available: "2022-06"
 10927	concentrated savings bond	0		Effect: "Fiery Spirit", Effect Duration: 40, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
-10930	compressed skewed spinning purple sweat-ade	1		Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10930	compressed skewed purple spinning sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	olive stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	jittery thick dinosaur	0		
@@ -10818,7 +10818,7 @@
 10962	powdered autumn breeze	1		Last Available: "2022-10"
 10963	chilled vacuum-sealed autumn years wisdom	0		Effect: "Mistified", Effect Duration: 69, Last Available: "2022-10"
 10964	cyan familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	perfectly mixed watered-down Oopsie IPA	2	EPIC	Last Available: "2022-10"
+10965	watered-down perfectly mixed Oopsie IPA	2	EPIC	Last Available: "2022-10"
 10966	upside-down mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10827,10 +10827,10 @@
 10971	stale miniature Jarlsberg's vegetable soup	2	decent	Last Available: "2022-11"
 10972	rotten roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
 10973	rotten jumbo St. Pete's sneaky smoothie	5	crappy	Last Available: "2022-11"
-10974	adequate miniature bouncing ghostly Pete's wiley whey bar	2	good	Last Available: "2022-11"
+10974	miniature adequate bouncing ghostly Pete's wiley whey bar	2	good	Last Available: "2022-11"
 10975	decent Pete's rich ricotta	3	good	Last Available: "2022-11"
 10976	hand-crafted Boris's beer	4	EPIC	Last Available: "2022-11"
-10977	stale cyan pulsating honey bun of Boris	3	decent	Last Available: "2022-11"
+10977	stale pulsating cyan honey bun of Boris	3	decent	Last Available: "2022-11"
 10978	moldy Boris's bread	4	crappy	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
@@ -10867,8 +10867,8 @@
 11011	squat Sinatra's gator shades of extreme caution	0		Experience (Moxie): +5, Monster Level: -25, Single Equip
 11012	milk cap	0		
 11013	lousy Charleston Choo-Choo	4	decent	
-11014	fancy practically non-alcoholic perfectly mixed teal Velvet Veil	1	super ultra EPIC	Effect: "Sizzling with Fury", Effect Duration: 5
-11015	boozy lousy Marltini	5	decent	
+11014	perfectly mixed fancy practically non-alcoholic teal Velvet Veil	1	super ultra EPIC	Effect: "Sizzling with Fury", Effect Duration: 5
+11015	lousy boozy Marltini	5	decent	
 11016	strong perfectly mixed Strong, Silent Type	5	EPIC	
 11017	fancy hand-crafted wobbly Mysterious Stranger	3	EPIC	Effect: "License to Punch", Effect Duration: 25
 11018	weak drinkable Champagne Shimmy	2	good	
@@ -10890,7 +10890,7 @@
 11034	mixed shaking chiffon carbage	1		Last Available: "2023-12"
 11035	boiled dry olive chiffon lemon	0		Effect: "Cold, Dead Hands", Effect Duration: 39
 11036	spoiled diet narrow chocomotive	1	crappy	Last Available: "2022-12"
-11037	moldy snack-sized freightcake	2	crappy	Last Available: "2022-12"
+11037	snack-sized moldy freightcake	2	crappy	Last Available: "2022-12"
 11038	tolerable maroon cabooze	3	good	Last Available: "2022-12"
 11039	blinking plastic caboose	0		Last Available: "2022-12"
 11040	yellow Da Vinci's plastic passenger car	0		Experience (Mysticality): +5, Last Available: "2022-12"
@@ -10906,9 +10906,9 @@
 11050	chilled modified Trainbot circuitry	0		Effect: "Clyde's Blessing", Effect Duration: 35
 11051	tarnished dry Trainbot tubing	0		Effect: "Coy to the Hurled", Effect Duration: 38
 11052	galvanized colloidal unsweetened Trainbot plating	0		Effect: "Overstimulated", Effect Duration: 66
-11053	energized jittery mirror Trainbot optics	0		Effect: "Minerva's Zen", Effect Duration: 42
+11053	energized mirror jittery Trainbot optics	0		Effect: "Minerva's Zen", Effect Duration: 42
 11054	pressed Trainbot servomotors	0		Effect: "Human-Insect Hybrid", Effect Duration: 16
-11055	deionized blurry mirror Trainbot linkages	0		Effect: "Tenacity of the Snapper", Effect Duration: 51
+11055	deionized mirror blurry Trainbot linkages	0		Effect: "Tenacity of the Snapper", Effect Duration: 51
 11056	tumbling ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	Trainbot harness of the businessman	0		Meat Drop: +50
@@ -10920,10 +10920,10 @@
 11064	auspicious groovy shoulder-mounted Trainbot of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50, Item Drop: +10, Single Equip, Last Available: "2022-12"
 11065	blurry cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	tolerable watered-down dregs of a Crimbo cocktail	2	good	
+11067	watered-down tolerable dregs of a Crimbo cocktail	2	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	moldy small olive honey-drenched ham slice	2	crappy	
+11070	small moldy olive honey-drenched ham slice	2	crappy	
 11071	perfectly mixed mostly-empty bottle of cookie wine	4	EPIC	
 11072	normal blurry Crimbo food scraps	4	good	
 11073	arm towel	0		Last Available: "2022-12"
@@ -10937,7 +10937,7 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	wobbly crystal Crimbo platter	0		
-11084	fortified hand-crafted Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
+11084	hand-crafted fortified Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
 11085	decent Crimbo dinner	4	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10979,7 +10979,7 @@
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	concentrated fire ant pheromones	0		Effect: "Healthy Red Glow", Effect Duration: 26, Last Available: "2023-02"
 11126	tarnished flapper fly	0		Effect: "Ooh, Sweet!", Effect Duration: 60, Last Available: "2023-02"
-11127	weak drinkable bouncing shot of wasp venom	2	good	Last Available: "2023-02"
+11127	drinkable weak bouncing shot of wasp venom	2	good	Last Available: "2023-02"
 11128	super-ionized concentrated wobbly filled mosquito	0		Effect: "Vitali Tea", Effect Duration: 60, Last Available: "2023-02"
 11129	dry activated skewed shim of shame shale	0		Effect: "Trufflin'", Effect Duration: 30, Last Available: "2023-02"
 11130	enhanced ionized pebble of proud pyrite	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 27, Last Available: "2023-02"
@@ -10989,15 +10989,15 @@
 11134	modified lump of loyal latite	0		Effect: "Haunted Stomach", Effect Duration: 28, Last Available: "2023-02"
 11135	bland shadow sausage	4	decent	Last Available: "2023-03"
 11136	scorching brawny shadow skin	0		Muscle Percent: +20, Hot Damage: +25, Last Available: "2023-03"
-11137	non-polarized skewed wobbly shadow flame	0		Effect: "Orchid Blood", Effect Duration: 61, Last Available: "2023-03"
+11137	non-polarized wobbly skewed shadow flame	0		Effect: "Orchid Blood", Effect Duration: 61, Last Available: "2023-03"
 11138	rotten shadow bread	4	crappy	Last Available: "2023-03"
 11139	narrow shadow ice	0		Last Available: "2023-03"
-11140	triple-distilled fancy aged huge shadow fluid	9	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 35, Last Available: "2023-03"
+11140	triple-distilled aged fancy huge shadow fluid	9	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 35, Last Available: "2023-03"
 11141	huge shadow glass	0		Last Available: "2023-03"
-11142	wobbly olive shadow brick	0		Last Available: "2023-03"
+11142	olive wobbly shadow brick	0		Last Available: "2023-03"
 11143	spinning shadow sinew	0		Last Available: "2023-03"
-11144	mediocre watered-down mirror shadow venom	2	decent	Last Available: "2023-03"
-11145	pickled fuchsia mirror spinning shadow nectar	1		Last Available: "2023-03"
+11144	watered-down mediocre mirror shadow venom	2	decent	Last Available: "2023-03"
+11145	pickled mirror spinning fuchsia shadow nectar	1		Last Available: "2023-03"
 11146	studded savvy shadow stick of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Damage Absorption: +80, Last Available: "2023-03"
 11147	asbestos-lined extremely unsafe bat paw	0		Weapon Damage Percent: +100, Hot Resistance: +5
 11148	squat rock-hard uncursed bat paw	0		Damage Reduction: 5
@@ -11071,7 +11071,7 @@
 11216	deadly replica Camp Scout backpack	0		Weapon Damage: +5
 11217	replica deactivated nanobots	0		
 11218	ghostly replica Apathargic Bandersnatch	0		
-11219	cyan blurry replica Smith's Tome	0		
+11219	blurry cyan replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
@@ -11088,7 +11088,7 @@
 11233	replica Witchess Set	0		
 11234	replica genie bottle	0		
 11235	replica space planula	0		
-11236	green squat replica unpowered Robortender	0		
+11236	squat green replica unpowered Robortender	0		
 11237	spinning replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
 11239	blurry replica God Lobster Egg	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	blinking frightening nippy replica Jurassic Parka	0		Cold Damage: +10, Spooky Damage: +5
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	huge replica Ten Dollars	0		
 11254	upside-down reassuring clever sage replica Cincho de Mayo of the bloodbag	0		Mysticality Percent: +10, Maximum HP: +100, Maximum MP: +20, Spooky Resistance: +1, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11125,7 +11125,7 @@
 11270	VHS Tape	0		Last Available: "2023-06"
 11271	improved frozen jittery scroll of minor invulnerability	0		Effect: "Radiant Personality", Effect Duration: 31, Last Available: "2023-06"
 11272	yellow Lapis Lazuli	0		Last Available: "2023-06"
-11273	lime green ghostly Eye Agate	0		Last Available: "2023-06"
+11273	ghostly lime green Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	jittery Arrow (+1)	0		Last Available: "2023-06"
 11276	ionized scroll of protection from lycanthropes	0		Effect: "Sausage Festive", Effect Duration: 56, Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	acceptable ghostly Sexy Cosmo	3	good	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	mirror asbestos-lined stiffened red-soled high heels of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Hot Resistance: +5, Last Available: "2023-06"
-11285	stale twirling blue cyburger	3	decent	Last Available: "2025-12"
+11285	stale blue twirling cyburger	3	decent	Last Available: "2025-12"
 11286	reassuring ncle leg	0		Spooky Resistance: +1
 11287	olive Jack Frost's dance instructor's rutabuga bag	0		Experience Percent (Moxie): +10, Cold Spell Damage: +50
 11288	mesquito proboscis of the detective	0		Item Drop: +20
@@ -11230,9 +11230,9 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	spoiled jumbo pickled bread	5	crappy	Last Available: "2023-12"
+11378	jumbo spoiled pickled bread	5	crappy	Last Available: "2023-12"
 11379	rotten upside-down salted mutton	3	crappy	Last Available: "2023-12"
-11380	toothsome miniature ghostly corned beet	2	awesome	Last Available: "2023-12"
+11380	miniature toothsome ghostly corned beet	2	awesome	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11279,7 +11279,7 @@
 11424	rosewater-soaked chilly chaotic sawed-off blunderbuss	0		Spell Critical Percent: +10, Cold Damage: +5, Stench Resistance: +3, Last Available: "2023-12"
 11425	delicious officer's nog	4	awesome	Last Available: "2023-12"
 11426	skewed peppermint bomb	0		Last Available: "2023-12"
-11427	thick bland jittery sundae ration	5	decent	Last Available: "2023-12"
+11427	bland thick jittery sundae ration	5	decent	Last Available: "2023-12"
 11428	delicious huge peppermint tack	10	awesome	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten miniature whalesteak	2	crappy	Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	chilly dog trainer's mansplainer's Elf Guard clipboard	0		Monster Level: +15, Experience (familiar): +1, Cold Damage: +5, Last Available: "2023-12"
 11435	blinking experienced pegfinger	0		Experience: +2, Single Equip, Last Available: "2023-12"
-11436	watered-down aged and claret	2	awesome	Last Available: "2023-12"
+11436	aged watered-down and claret	2	awesome	Last Available: "2023-12"
 11437	squat Elf Guard and beret of extreme caution	0		Monster Level: [-25*event(December)], Last Available: "2023-12"
 11438	Socratic savvy shipwright's hammer of Gandalf	0		Mysticality Percent: +20, Experience (Mysticality): +1, Spell Critical Percent: +20, Last Available: "2023-12"
 11439	zippy gunwale of dire peril of the blizzard	0		Weapon Damage: +20, Cold Spell Damage: +25, Initiative: +20, Damage Reduction: 9, Last Available: "2023-12"
@@ -11317,10 +11317,10 @@
 11462	adequate lime	3	good	Last Available: "2023-12"
 11463	bland gingerbread pirate	4	decent	Last Available: "2023-12"
 11464	small normal ghostly fruit-stuffed rumcake	2	good	Last Available: "2023-12"
-11465	triple-distilled drinkable lime green mulled wine	8	good	Last Available: "2023-12"
+11465	drinkable triple-distilled lime green mulled wine	8	good	Last Available: "2023-12"
 11466	delicious practically non-alcoholic Swedish coffee	1	awesome	Last Available: "2023-12"
 11467	practically non-alcoholic mediocre twirling canteen of eggnog	1	decent	Last Available: "2023-12"
-11468	high-proof lousy hot wine	9	decent	Last Available: "2023-12"
+11468	lousy high-proof hot wine	9	decent	Last Available: "2023-12"
 11469	tolerable Jamaican coffee	3	good	Last Available: "2023-12"
 11470	fancy weak mediocre flask of egggrog	2	decent	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2023-12"
 11471	squat Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
@@ -11362,7 +11362,7 @@
 11507	hale savvy moss mitre	0		Mysticality Percent: +20, Maximum HP: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
 11508	huge electrified strapping moss mantle	0		Muscle: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	fireproof rosy-cheeked moss marlinspike	0		Maximum HP Percent: +30, Hot Resistance: +3, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	pickled skewed narrow pulsating moss mulch	1		Last Available: "2024-12"
+11510	pickled narrow skewed pulsating moss mulch	1		Last Available: "2024-12"
 11511	liquefied energized moss floss	0		Effect: "Oh Snap", Effect Duration: 26
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11431,7 +11431,7 @@
 11576	mediocre Southern yam	4	decent	Last Available: "2024-05"
 11577	acceptable watered-down twirling sweet potato punch	2	good	Last Available: "2024-05"
 11578	normal massive Mayam spinach	8	good	Last Available: "2024-05"
-11579	half-sized special flavorless red yam and swiss	2	decent	Effect: "Industrial Strength Starch", Effect Duration: 30, Last Available: "2024-05"
+11579	special flavorless half-sized red yam and swiss	2	decent	Effect: "Industrial Strength Starch", Effect Duration: 30, Last Available: "2024-05"
 11580	MacGyver's clever yam cannon of the empath	0		Maximum MP: 120, Familiar Weight: +5, Lasts Until Rollover, Last Available: "2024-05"
 11581	spinning yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11440,8 +11440,8 @@
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	executive frosty wizardly yamtility belt	0		Mysticality: +25, Cold Spell Damage: +10, Meat Drop: +40, Lasts Until Rollover, Last Available: "2024-05"
 11587	stale gigantic upside-down maroon yam slider	7	decent	Last Available: "2024-05"
-11588	massive bland skewed yam mayo	8	decent	Last Available: "2024-05"
-11589	delicious bite-sized squat yam burrito	1	awesome	Last Available: "2024-05"
+11588	bland massive skewed yam mayo	8	decent	Last Available: "2024-05"
+11589	bite-sized delicious squat yam burrito	1	awesome	Last Available: "2024-05"
 11590	fuchsia visual packet sniffer	0		Last Available: "2025-12"
 11591	upside-down mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
@@ -11454,7 +11454,7 @@
 11599	Temple Grandin's weightlifter's mini kiwi silicon tiepin	0		Muscle: +15, Familiar Weight: +7, Item Drop: +5
 11600	mini kiwi tipi	0		
 11601	spoiled green mini kiwi digitized cookies	4	crappy	
-11602	bad weak jittery mini kiwi intoxicating spirits	2	decent	
+11602	weak bad jittery mini kiwi intoxicating spirits	2	decent	
 11603	diffused mini kiwi antimilitaristic hippy petition	0		Effect: "Cold Hands", Effect Duration: 60
 11604	anodized jittery mini kiwi illicit antibiotic	0		Effect: "Hoity Toity", Effect Duration: 64
 11605	tumbling chaotic extremely unsafe mini kiwi whipping stick	0		Weapon Damage Percent: +100, Spell Critical Percent: +10
@@ -11470,9 +11470,9 @@
 11615	upside-down lightning-fast frosty messenger bag RNA of the bloodbag	0		Maximum HP: +100, Cold Spell Damage: +10, Initiative: +40
 11616	yellow flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	moldy super-sized bacteria bisque	5	crappy	
+11618	super-sized moldy bacteria bisque	5	crappy	
 11619	moldy low-calorie skewed ciliophora chowder	1	crappy	
-11620	special toothsome cream of chloroplasts	3	awesome	Effect: "Supafly", Effect Duration: 10
+11620	toothsome special cream of chloroplasts	3	awesome	Effect: "Supafly", Effect Duration: 10
 11621	red narrow synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11483,11 +11483,11 @@
 11628	shaking extra DNA	0		Experience (familiar): +1
 11629	untorn tearaway pants package	0		Free Pull
 11630	flame-wreathed Jack Frost's Oprah's tearaway pants of the pedagogue of incineration	0		Experience: +3, Maximum MP Percent: +50, Cold Spell Damage: +50, Hot Spell Damage: 60, Conditional Skill (Equipped): "Tear Away your Pants!"
-11631	tumbling jittery baby bodyguard	0		
+11631	jittery tumbling baby bodyguard	0		
 11632	cyan Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	mediocre weak maroon Colera Peste Nebbiolo	2	decent	
+11635	weak mediocre maroon Colera Peste Nebbiolo	2	decent	
 11636	longbox of Batfellow comics	0		
 11637	skewed Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11526,8 +11526,8 @@
 11671	up-at-dawn photo booth supply list of Leguizamo	0		Monster Level: +20, Adventures: +5, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	snack-sized spoiled whirled peas	2	crappy	Last Available: "2024-11"
-11675	small moldy peaza	2	crappy	Last Available: "2024-11"
+11674	spoiled snack-sized whirled peas	2	crappy	Last Available: "2024-11"
+11675	moldy small peaza	2	crappy	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	twisted bouncing blue drenchrome 2.0	1		Last Available: "2025-12"
 11678	distilled skewed Synapse Blaster	1		Last Available: "2025-12"
@@ -11535,8 +11535,8 @@
 11680	quantum watch	0		Adventures: +2
 11681	bouncing quantized familiar experience	0		
 11682	flattened pea brittle	0		Effect: "Antsy in your Pantsy", Effect Duration: 22, Last Available: "2024-11"
-11683	weak mediocre maroon peasco	2	decent	Last Available: "2024-11"
-11684	tiny rotten piece of cake	1	crappy	Last Available: "2024-11"
+11683	mediocre weak maroon peasco	2	decent	Last Available: "2024-11"
+11684	rotten tiny piece of cake	1	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11545,7 +11545,7 @@
 11690	wicked jolly roger flag	0		Spell Damage: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	tolerable extra-dry tankard of spiced rum	5	good	Last Available: "2024-12"
+11693	extra-dry tolerable tankard of spiced rum	5	good	Last Available: "2024-12"
 11694	artisanal tankard of spiced Goldschlepper	3	EPIC	Last Available: "2024-12"
 11695	tumbling packaged luxury garment	0		Last Available: "2024-12"
 11696	green squat up-at-dawn governor's daughter's lace collar	0		Adventures: +5, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	squat profane eye patch	0		Sleaze Damage: +3
 11709	double-unsweetened pulsating shaking peppermint pegleg	0		Effect: "Lifted Spirits", Effect Duration: 47, Last Available: "2024-12"
 11710	acceptable squat hard cocoa	3	good	Last Available: "2024-12"
-11711	flavorless big shaking salmagumdi	5	decent	Last Available: "2024-12"
+11711	big flavorless shaking salmagumdi	5	decent	Last Available: "2024-12"
 11712	extremely unsafe plastic Easter Island Bunny	0		Weapon Damage Percent: +100, Last Available: "2024-12"
 11713	smooth plastic St. Patrick	0		Moxie: +15, Last Available: "2024-12"
 11714	forbidden sage plastic Colonel Brando	0		Mysticality Percent: +10, Spell Damage Percent: +50, Last Available: "2024-12"
@@ -11581,7 +11581,7 @@
 11726	twirling half-digested rat	0		Last Available: "2024-12"
 11727	polymerized upside-down blue four-leaf potato sprout	0		Effect: "Savage Beast Inside", Effect Duration: 56, Last Available: "2024-12"
 11728	blurry nippy quilted stylish potato jacket	0		Moxie: +25, Damage Absorption: +40, Cold Damage: +10, Last Available: "2024-12"
-11729	squat twirling traumatic holiday memory	0		Last Available: "2024-12"
+11729	twirling squat traumatic holiday memory	0		Last Available: "2024-12"
 11730	skewed lime green Brandonian footlocker key	0		Last Available: "2024-12"
 11731	MacGyver's steel-toed military orb	0		Damage Reduction: 9, Maximum MP: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	improved jittery rum ball	0		Effect: "Stinky Hands", Effect Duration: 59
@@ -11599,9 +11599,9 @@
 11744	extra-alkaline tarnished upside-down LIDAR candle	0		Effect: "Transcendental Wind", Effect Duration: 27, Last Available: "2024-12"
 11745	scorching experienced Congressional Medal of Insanity of the brute	0		Muscle Percent: +30, Experience: +2, Hot Damage: +25, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	tolerable watered-down twirling Easter grasshopper	2	good	Last Available: "2024-12"
+11747	watered-down tolerable twirling Easter grasshopper	2	good	Last Available: "2024-12"
 11748	acceptable triple-distilled Irish eggnog	10	good	Last Available: "2024-12"
-11749	watered-down bad purple huge canteen of jungle juice	2	decent	Last Available: "2024-12"
+11749	watered-down bad huge purple canteen of jungle juice	2	decent	Last Available: "2024-12"
 11750	fortified bad turchucken	5	decent	Last Available: "2024-12"
 11751	perfectly mixed practically non-alcoholic mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11752	acceptable holiday trip around the world	3	good	Last Available: "2024-12"
@@ -11609,7 +11609,7 @@
 11754	tasty tiny wobbly beef and cabbage	1	awesome	Last Available: "2024-12"
 11755	fancy normal mirror candy rations	3	good	Effect: "Conspiratory Eyes", Effect Duration: 25, Last Available: "2024-12"
 11756	stale double-candied yams	4	decent	Last Available: "2024-12"
-11757	bland snack-sized Christmas ham	2	decent	Last Available: "2024-12"
+11757	snack-sized bland Christmas ham	2	decent	Last Available: "2024-12"
 11758	bland holiday smorgasbord	3	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	wobbly wholesome bejazzled eyepatch	0		Maximum HP Percent: +10, Last Available: "2024-12"
@@ -11628,7 +11628,7 @@
 11773	squat gravedigger's resourceful crafty healthy army helmet	0		Maximum HP Percent: +20, Maximum MP: 60, Spooky Damage: +10, Last Available: "2024-12"
 11774	wobbly candy egg deviler	0		Last Available: "2024-12"
 11775	red twirling napkin	0		Last Available: "2024-12"
-11776	stale low-calorie Thanksgiving ration	1	decent	Last Available: "2024-12"
+11776	low-calorie stale Thanksgiving ration	1	decent	Last Available: "2024-12"
 11777	triple-distilled mediocre narrow Easter eggnog	10	decent	Last Available: "2024-12"
 11778	diluted clovermint	1		Last Available: "2024-12"
 11779	prompt sizzling forbidden nylon Christmas stockings of the scaredy-cat	0		Spell Damage Percent: +50, Monster Level: -15, Hot Damage: +10, Adventures: +3, Single Equip, Last Available: "2024-12"
@@ -11641,7 +11641,7 @@
 11786	purple banded grievous McHugeLarge left ski	0		Weapon Damage Percent: +50, Damage Absorption: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
 11787	upside-down miser's sage McHugeLarge right ski	0		Mysticality Percent: +10, Meat Drop: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	1	0		Last Available: "2025-12"
-11789	teal tumbling 0	0		Last Available: "2025-12"
+11789	tumbling teal 0	0		Last Available: "2025-12"
 11790	mixed jittery eXpand	1		Last Available: "2025-12"
 11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
@@ -11664,7 +11664,7 @@
 11809	narrow 3d printed server room key	0		Last Available: "2025-12"
 11810	shaking dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
-11812	mixed twirling blurry shaking psilocyber mushroom	1		Last Available: "2025-12"
+11812	mixed shaking twirling blurry psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	huge dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	upside-down dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
@@ -11712,11 +11712,11 @@
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	ghostly glover liners	0		Pickpocket Chance: +10
 11859	upside-down mosquito speakers	0		Monster Level: +5
-11860	skewed purple assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
+11860	purple skewed assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	shaking Leprecondo	0		Last Available: "2025-03"
 11862	pickled scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	pulsating table tennis ball	0		Last Available: "2025-03"
-11864	practically non-alcoholic artisanal skewed pint of Leprechaun Stout	1	EPIC	Last Available: "2025-03"
+11864	artisanal practically non-alcoholic skewed pint of Leprechaun Stout	1	EPIC	Last Available: "2025-03"
 11865	pickled phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11724,15 +11724,15 @@
 11869	unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	denatured mirror leprechaun antidepressant pill	1		Effect: "Helping Comes Second", Effect Duration: 35, Last Available: "2025-03"
-11872	massive rotten Heck ramen	8	crappy	Last Available: "2025-03"
+11872	rotten massive Heck ramen	8	crappy	Last Available: "2025-03"
 11873	normal burrito	3	good	Last Available: "2025-03"
 11874	flavorless small beer brat	3	decent	Last Available: "2025-03"
-11875	half-sized rotten peach pie	2	crappy	Last Available: "2025-03"
+11875	rotten half-sized peach pie	2	crappy	Last Available: "2025-03"
 11876	spoiled immense upside-down incredible mini-pizza	7	crappy	Last Available: "2025-03"
-11877	fancy watered-down bad jittery Divine sidecar	2	decent	Effect: "The Power of Negative Thinking", Effect Duration: 25, Last Available: "2025-03"
+11877	watered-down bad fancy jittery Divine sidecar	2	decent	Effect: "The Power of Negative Thinking", Effect Duration: 25, Last Available: "2025-03"
 11878	hand-crafted maroon tangarita sidecar	4	EPIC	Last Available: "2025-03"
-11879	drinkable triple-distilled gimlet sidecar	8	good	Last Available: "2025-03"
-11880	artisanal enchanted weak vodka stratocaster sidecar	2	EPIC	Effect: "Vitali Tea", Effect Duration: 50, Last Available: "2025-03"
+11879	triple-distilled drinkable gimlet sidecar	8	good	Last Available: "2025-03"
+11880	enchanted artisanal weak vodka stratocaster sidecar	2	EPIC	Effect: "Vitali Tea", Effect Duration: 50, Last Available: "2025-03"
 11881	lousy enchanted prussian cathouse sidecar	4	decent	Effect: "Tiki Toughness", Effect Duration: 35, Last Available: "2025-03"
 11882	bad triple-distilled Mon Tiki sidecar	8	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
@@ -11747,7 +11747,7 @@
 11892	ruddy wet shower cap	0		Maximum HP Percent: +40, Last Available: "2025-04"
 11893	clever wet shower shoes	0		Maximum MP: +20, Last Available: "2025-04"
 11894	blurry Tesla wet shower shorts	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-04"
-11895	shaking skewed wet paper tiger	0		Last Available: "2025-04"
+11895	skewed shaking wet paper tiger	0		Last Available: "2025-04"
 11896	wet paper eye	0		Familiar Weight: +15
 11897	blurry wet shower curtain	0		Last Available: "2025-04"
 11898	alkaline frozen magnetized wet paper cup	0		Effect: "Bubblin' Rage", Effect Duration: 69, Last Available: "2025-04"
@@ -11780,7 +11780,7 @@
 11925	fortified baleful Axis fatigues	0		Spell Damage: +25, Damage Absorption: +60
 11926	huge baleful Axis suspenders of the sewer	0		Spell Damage: +25, Stench Damage: +25, Single Equip
 11927	olive stolen artifact	0		
-11928	pulsating huge really expensive stolen artifact	0		
+11928	huge pulsating really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	nice nylon stockings	0		
@@ -11798,19 +11798,19 @@
 11943	bone pacifier	0		Familiar Weight: +5
 11944	narrow executive quilted baleful Allied Forces insignia	0		Spell Damage: +25, Damage Absorption: +40, Meat Drop: +40, Single Equip
 11945	huge Allied Tattoo Kit	0		
-11946	tumbling red handheld Allied radio	0		
+11946	red tumbling handheld Allied radio	0		
 11947	Axis codebook	0		
 11948	unsweetened chilled quantum Life Goals Pamphlet	0		Effect: "Marinated", Effect Duration: 44, Last Available: "2025-08"
 11949	squat curative bully badge	0		HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2025-08"
 11950	Temple Grandin's time cop top hat	0		Familiar Weight: +7, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	mixed ghostly mixed berry jelly	1		Last Available: "2025-08"
-11953	fancy low-calorie stale huge toast with mixed berry jelly	1	decent	Effect: "Guts Feeling", Effect Duration: 15, Last Available: "2025-08"
-11954	diet toothsome cup of sugar	1	awesome	Last Available: "2025-08"
+11953	stale fancy low-calorie huge toast with mixed berry jelly	1	decent	Effect: "Guts Feeling", Effect Duration: 15, Last Available: "2025-08"
+11954	toothsome diet cup of sugar	1	awesome	Last Available: "2025-08"
 11955	flavorless skewed Susie's cupcake	3	decent	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	rosewater-soaked fireproof clever the gun	0		Maximum MP: +20, Hot Resistance: +3, Stench Resistance: +3, Last Available: "2025-08"
-11958	spirit-forward hand-crafted wine	5	EPIC	Last Available: "2025-08"
+11958	hand-crafted spirit-forward wine	5	EPIC	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	occult undersea surveying goggles	0		Spell Damage Percent: +25, Lasts Until Rollover
@@ -11833,20 +11833,20 @@
 11987	lightning-fast family-friendly occult sinister razor-sharp stylish blood cubic zirconia	0		Moxie: +25, Weapon Damage Percent: +25, Spell Damage: +10, Spell Damage Percent: +25, Sleaze Resistance: +1, Initiative: +40, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	distilled shaking blood thinner	1		Effect: "Busy Bein' Delicious", Effect Duration: 50, Last Available: "2025-10"
 12045	perfectly mixed pheromone cocktail	4	EPIC	Last Available: "2025-10"
-12046	decent low-calorie spinal tapas	1	good	Last Available: "2025-10"
+12046	low-calorie decent spinal tapas	1	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	reassuring sizzling boxer's shrunken head	0		Muscle Percent: +10, Hot Damage: +10, Spooky Resistance: +1, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	mediocre watered-down jittery Smoking Pope	2	decent	
+12052	watered-down mediocre jittery Smoking Pope	2	decent	
 12053	bland upside-down prize turkey	3	decent	
 12054	distilled mirror medicinal gruel	1		
 12055	flavorless full-sized pumpkin pie	3	decent	Last Available: "2025-11"
 12056	acceptable vodka cranberry sauce	3	good	Last Available: "2025-11"
 12057	colloidal quadruple-polymerized twirling yammed candy	0		Effect: "Tremella Tremens", Effect Duration: 37, Last Available: "2025-11"
 12058	stale treasure chestnut	3	decent	Last Available: "2025-12"
-12059	perfectly mixed watered-down jittery mulled butter rum	2	EPIC	Last Available: "2025-12"
+12059	watered-down perfectly mixed jittery mulled butter rum	2	EPIC	Last Available: "2025-12"
 12060	non-denatured twirling cinnamon doubloon	0		Effect: "Held Closer", Effect Duration: 19, Last Available: "2025-12"
 12061	squat electrified plastic left skeleton arm	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-12"
 12062	upside-down resourceful plastic left skeleton leg	0		Maximum MP: +50, Last Available: "2025-12"
@@ -11870,7 +11870,7 @@
 12080	huge supercool devilbone flute of the overflowing toilet	0		Moxie Percent: +20, Stench Spell Damage: +50, Last Available: "2026-12"
 12081	fuchsia supercool devilbone rosary	0		Moxie Percent: +20, Single Equip, Last Available: "2026-12"
 12082	twisted squat cyan devilbone chunks	1		Last Available: "2026-12"
-12083	dry cyan jittery Gehenna tattoo	0		Effect: "Hobo Flavor", Effect Duration: 18
+12083	dry jittery cyan Gehenna tattoo	0		Effect: "Hobo Flavor", Effect Duration: 18
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	twirling burnt phalange	0		Last Available: "2025-12"
 12118	jittery burnt radius	0		Last Available: "2025-12"
@@ -11881,7 +11881,7 @@
 12123	ghostly The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	bad mirror Steve Abrams' Holiday Sampler Beer	4	decent	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	watered-down hand-crafted bottle of prize-winning rum	2	super EPIC	Last Available: "2025-12"
+12126	hand-crafted watered-down bottle of prize-winning rum	2	super EPIC	Last Available: "2025-12"
 12127	Van der Graaf Fonzie's Santa-Slayer medal of the brute	0		Muscle Percent: +30, Experience (Moxie): +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	deionized olive skewed boiling bone marrow	0		Effect: "Pride of the Vampire", Effect Duration: 37, Last Available: "2025-12"
@@ -11926,8 +11926,8 @@
 12168	spinning smelly vermiculite shield of the ox	0		Muscle: +20, Stench Spell Damage: +10, Damage Reduction: 9, Last Available: "2025-12"
 12169	ghostly ship's lantern of the scaredy-cat	0		Monster Level: -15, Last Available: "2025-12"
 12170	pulsating hardened heat-resistant harpoon pistol of terror	0		Damage Reduction: 3, Spooky Spell Damage: +10, Last Available: "2025-12"
-12171	snack-sized bland traditional gingerloaf	2	decent	Last Available: "2025-12"
-12172	mediocre practically non-alcoholic Scotch and eggnog	1	decent	Last Available: "2025-12"
+12171	bland snack-sized traditional gingerloaf	2	decent	Last Available: "2025-12"
+12172	practically non-alcoholic mediocre Scotch and eggnog	1	decent	Last Available: "2025-12"
 12173	boiled deionized blinking yellow counterskeleton elixir	0		Effect: "Spooky Hands", Effect Duration: 11, Last Available: "2025-12"
 12174	hand-crafted &quot;salvaged&quot; wine	4	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11980,17 +11980,17 @@
 12226	normal can of tuna	3	good	
 12227	rotten big maroon bouncing alien salad	5	crappy	
 12228	rotten ratbatatouille	3	crappy	
-12229	yummy snack-sized onigiri	2	awesome	
-12230	bite-sized yummy wobbly crudit&eacute;s	1	awesome	
+12229	snack-sized yummy onigiri	2	awesome	
+12230	yummy bite-sized wobbly crudit&eacute;s	1	awesome	
 12231	gigantic bland sauced mutton	8	decent	
-12232	decent squat maroon hot honey ant	3	good	
+12232	decent maroon squat hot honey ant	3	good	
 12233	tasty red tomb aspic	3	awesome	
 12234	spoiled huge purple later tots	6	crappy	
 12235	decent cyan Frutti di Scatoletta	4	good	Last Available: "2026-05"
 12236	tasty Pesto alla Marziano	4	awesome	Last Available: "2026-05"
 12237	spoiled snack-sized Arrattabbattabiata	2	crappy	Last Available: "2026-05"
-12238	moldy special Orzo di Riso	4	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 35, Last Available: "2026-05"
-12239	half-sized toothsome mirror Pasta Grimavera	2	awesome	Last Available: "2026-05"
+12238	special moldy Orzo di Riso	4	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 35, Last Available: "2026-05"
+12239	toothsome half-sized mirror Pasta Grimavera	2	awesome	Last Available: "2026-05"
 12240	delicious massive shaking Linguini Ubriacapa	10	awesome	Last Available: "2026-05"
 12241	bite-sized rotten Formica e Pepe	1	crappy	Last Available: "2026-05"
 12242	rotten pulsating Tubetto Gelatto	4	crappy	Last Available: "2026-05"
@@ -12024,7 +12024,7 @@
 12274	bland quince	4	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	rotten gigantic spinning classic banana pie	6	crappy	Last Available: "2026-07"
+12277	gigantic rotten spinning classic banana pie	6	crappy	Last Available: "2026-07"
 12278	wet electrified olive essential banana decoction	0		Effect: "Salad Days", Effect Duration: 23, Last Available: "2026-07"
 12279	wet vacuum-sealed banana quintessence	0		Effect: "Feet of Watermelon", Effect Duration: 32, Last Available: "2026-07"
 12280	acceptable Aesop Daiquiri	3	good	Last Available: "2026-07"
@@ -12038,11 +12038,11 @@
 12288	ionized quince quaff	0		Effect: "Human-Constellation Hybrid", Effect Duration: 57, Last Available: "2026-07"
 12289	dry Quickquince	0		Effect: "Tingly Wrists", Effect Duration: 19, Last Available: "2026-07"
 12290	perfectly mixed Quiskey Sour	3	EPIC	Last Available: "2026-07"
-12291	practically non-alcoholic mediocre Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
-12292	mediocre watered-down red Roth IPA	2	decent	Last Available: "2026-08"
+12291	mediocre practically non-alcoholic Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
+12292	watered-down mediocre red Roth IPA	2	decent	Last Available: "2026-08"
 12293	Van der Graaf underdraft protection of extreme caution	0		Monster Level: -25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-08"
 12294	upside-down solvent	0		Last Available: "2026-08"
-12295	adequate snack-sized narrow soybean futures	2	good	Last Available: "2026-08"
+12295	snack-sized adequate narrow soybean futures	2	good	Last Available: "2026-08"
 12296	alkaline housing bubble	0		Effect: "Eyes for Miles", Effect Duration: 45, Last Available: "2026-08"
 12297	ionized blinking Pixie-Swordz	0		Effect: "Wintergreen Warmongery", Effect Duration: 37
 12298	reassuring stanky financial instrument	0		Stench Spell Damage: +25, Spooky Resistance: +1, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wallaby_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	drinkable Petite Porter	3	good	
--2	drinkable watered-down squat Scrawny Stout	2	good	
+-2	watered-down drinkable squat Scrawny Stout	2	good	
 -3	mediocre Infinitesimal IPA	4	decent	
--4	tolerable watered-down eggnogtini	2	good	
+-4	watered-down tolerable eggnogtini	2	good	
 -5	delicious triple-distilled candycaine	8	awesome	
 -6	artisanal braincracker sweet	4	EPIC	
--16	weak bad yellow fermented honey	2	decent	
+-16	bad weak yellow fermented honey	2	decent	
 -17	artisanal moons-shine	3	EPIC	
--18	acceptable special blinking gin	4	good	
--19	artisanal boozy mirror ecto-nog	5	EPIC	
+-18	special acceptable blinking gin	4	good	
+-19	boozy artisanal mirror ecto-nog	5	EPIC	
 -20	tolerable hot toady	4	good	
 -21	weak perfectly mixed hot choculate	2	EPIC	
--49	mediocre practically non-alcoholic upside-down Cyder	1	decent	
--50	practically non-alcoholic special hand-crafted narrow Oil Nog	1	EPIC	
--51	acceptable practically non-alcoholic Hi-Octane Peppermint Jet Fuel	1	good	
+-49	practically non-alcoholic mediocre upside-down Cyder	1	decent	
+-50	special practically non-alcoholic hand-crafted narrow Oil Nog	1	EPIC	
+-51	practically non-alcoholic acceptable Hi-Octane Peppermint Jet Fuel	1	good	
 -58	weak acceptable skewed Grimacider	2	good	
 -59	aged gray Isotope Nog	4	awesome	
--60	distilled smooth special Mutagin 'n' Tonic	5	awesome	
--70	tolerable watered-down Gin and Herring	2	good	
+-60	distilled special smooth Mutagin 'n' Tonic	5	awesome	
+-70	watered-down tolerable Gin and Herring	2	good	
 -71	hand-crafted Black and Tan and Red All Over	4	EPIC	
--72	distilled hand-crafted blurry Antarctic Ice Tea	5	EPIC	
+-72	hand-crafted distilled blurry Antarctic Ice Tea	5	EPIC	
 -76	drinkable CRIMBCO Ribbon Candy Schnapps	4	good	
--77	extra-dry aged CRIMBCO Egg Substitute Nog Substitute	5	awesome	
--78	watered-down perfectly mixed CRIMBCO Extreme Braincracker Sour	2	EPIC	
+-77	aged extra-dry CRIMBCO Egg Substitute Nog Substitute	5	awesome	
+-78	perfectly mixed watered-down CRIMBCO Extreme Braincracker Sour	2	EPIC	
 -82	perfectly mixed Horseradish-infused Vodka	3	EPIC	
 -83	spirit-forward hand-crafted Jerkitini	5	EPIC	
 -84	lousy spirit-forward huge Desert Island Iced Tea	5	decent	
 -88	perfectly mixed Crimbo Saketini	3	EPIC	
--89	watered-down drinkable Crimboku Drop	2	good	
+-89	drinkable watered-down Crimboku Drop	2	good	
 -90	smooth Flaming Crimbo Log	4	awesome	
 -107	hand-crafted Fortified Eggnog Slurry	3	EPIC	
 -108	bad Hot Buttered Rum	3	decent	
--109	lousy watered-down Spicy Hot Chocolate	2	decent	
+-109	watered-down lousy Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Disco_Bandit_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wallaby_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	stale Peche a la Frog	3	decent	
--2	stale miniature squat As Jus Gezund Heit	2	decent	
+-2	miniature stale squat As Jus Gezund Heit	2	decent	
 -3	moldy Bouillabaise Coucher Avec Moi	4	crappy	
 -7	bland shaking gumdrop chow mein	3	decent	
 -8	fancy normal candy cane pizza	4	good	
--9	stale diet squat gingerbread stir-fry	1	decent	
+-9	diet stale squat gingerbread stir-fry	1	decent	
 -10	decent special twigs and gravel	4	good	
 -11	bland shoots and leaves	4	decent	
 -12	adequate low-calorie bowl of unidentifiable goo	1	good	
--13	fancy big tasty gingerbread massacre	5	awesome	
--14	decent bite-sized It Came From Beyond Dessert	1	good	
--15	decent wobbly jittery vampire cake	3	good	
+-13	big tasty fancy gingerbread massacre	5	awesome	
+-14	bite-sized decent It Came From Beyond Dessert	1	good	
+-15	decent jittery wobbly vampire cake	3	good	
 -52	moldy jittery narrow Soylent Red and Green	4	crappy	
 -53	rotten skewed Disc-Shaped Nutrition Unit	3	crappy	
 -54	stale Gingerborg Hive	4	decent	
 -61	rotten huge Candy Cane Surprise	7	crappy	
--62	gigantic spoiled Grimdrop Chow Mein	9	crappy	
+-62	spoiled gigantic Grimdrop Chow Mein	9	crappy	
 -63	adequate bouncing Grimgerbread House	4	good	
 -67	flavorless Caviar Carbonara	4	decent	
 -68	moldy shaking Halibut Alfredo	3	crappy	
 -69	stale Red Herring Velvet Cake	4	decent	
 -73	huge decent CRIMBCO Reconstituted Gruel	8	good	
 -74	miniature flavorless New and Improved CRIMBCO Reconstituted Gruel	2	decent	
--75	toothsome miniature CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	awesome	
+-75	miniature toothsome CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	awesome	
 -79	tasty big Brussels Sprout Stir-Fry	5	awesome	
 -80	delicious wobbly Carrot, Cabbage, and Kale Pizza	4	awesome	
 -81	flavorless blurry Turnip and Rutabaga Pie	3	decent	
--85	bland narrow huge Rainbow Spider Fun Roll	4	decent	
+-85	bland huge narrow Rainbow Spider Fun Roll	4	decent	
 -86	rotten snack-sized ghostly Vegas Volcano Lava Roll	2	crappy	
--87	bland immense Crazy Dragon Shogun Buddha Roll	9	decent	
--92	small spoiled blurry basic hot dog	2	crappy	
+-87	immense bland Crazy Dragon Shogun Buddha Roll	9	decent	
+-92	spoiled small blurry basic hot dog	2	crappy	
 -93	rotten savage macho dog	4	crappy	
--94	normal big one with everything	5	good	
+-94	big normal one with everything	5	good	
 -95	decent sly dog	4	good	
--96	decent immense devil dog	8	good	
+-96	immense decent devil dog	8	good	
 -97	moldy low-calorie chilly dog	1	crappy	
 -98	decent ghost dog	3	good	
 -99	snack-sized flavorless junkyard dog	2	decent	
--100	bland snack-sized green pulsating shaking wet dog	2	decent	
+-100	snack-sized bland pulsating green shaking wet dog	2	decent	
 -101	normal sleeping dog	4	good	
--102	rotten enchanted small optimal dog	2	crappy	
+-102	rotten small enchanted optimal dog	2	crappy	
 -103	flavorless small shaking video games hot dog	2	decent	
 -104	yummy super-sized fuchsia Peppermint Nutrition Block	5	awesome	
--105	super-sized special rotten Gingerbread Nutrition Block	5	crappy	
+-105	super-sized rotten special Gingerbread Nutrition Block	5	crappy	
 -106	snack-sized normal jittery Cinnamon Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Wombat.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wombat.txt
@@ -10,7 +10,7 @@
 10	disco ball	0		
 11	stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	dehydrated twirling skewed spinning moxie weed	1		Effect: "Items Are Forever", Effect Duration: 40
+14	dehydrated twirling spinning skewed moxie weed	1		Effect: "Items Are Forever", Effect Duration: 40
 15	compressed strongness elixir	1		
 16	twisted twirling magicalness-in-a-can	1		
 17	adequate noodles	3	good	
@@ -18,7 +18,7 @@
 19	spinning Usain Bolt's asparagus knife	0		Initiative: +80
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	mirror sweet ninja sword	0		
-22	maroon tumbling studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
+22	tumbling maroon studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	cyan chewing gum on a string	0		
 24	tumbling ten-leaf clover	0		
 25	meat paste	0		
@@ -37,7 +37,7 @@
 38	Knob Goblin pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "atk, 5xPotato, cap 6"
 39	gray pretty flower	0		
 40	huge casino pass	0		
-41	extra-dry perfectly mixed ice-cold Sir Schlitz	5	EPIC	
+41	perfectly mixed extra-dry ice-cold Sir Schlitz	5	EPIC	
 42	bouncing hermit permit	0		
 43	worthless trinket	0		
 44	ghostly worthless gewgaw	0		
@@ -57,7 +57,7 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	upside-down Rosewater's Mace of the Tortoise	0		Mysticality Percent: +30, Class: "Turtle Tamer"
-61	rotten snack-sized fortune cookie	2	crappy	
+61	snack-sized rotten fortune cookie	2	crappy	
 62	bouncing banded oriole-feather headdress	0		Damage Absorption: +100, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -66,7 +66,7 @@
 67	yellow spaghetti with rock-balls	0		
 68	maroon Fonzie's Pasta Spoon of Peril of the dark arts	0		Experience (Moxie): +1, Spell Damage Percent: +100, Class: "Pastamancer"
 69	Newbiesport&trade; tent	0		
-70	twirling shaking bar skin	0		
+70	shaking twirling bar skin	0		
 71	stakes of the storm	0		Maximum MP Percent: +40
 72	frosty barskin hat	0		Cold Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 13"
 73	yellow barskin tent	0		
@@ -81,7 +81,7 @@
 82	ring	0		
 83	wobbly shaft	0		
 84	Orcish meat locker	0		
-85	squat jittery unlocked meat locker	0		
+85	jittery squat unlocked meat locker	0		
 86	key	0		
 87	meat from yesterday	0		
 88	skewed meat stack	0		
@@ -101,7 +101,7 @@
 102	skewed shrunken head	0		
 103	nippy sinister staff	0		Spell Damage: +10, Cold Damage: +10
 104	scarecrow	0		
-105	bland snack-sized bowl of charms	2	decent	
+105	snack-sized bland bowl of charms	2	decent	
 106	ketchup	1	crappy	
 107	green catsup	1	good	
 108	stick	0		
@@ -122,7 +122,7 @@
 123	Gnollish flyswatter	0		
 124	empty meat tank	0		
 125	full meat tank	0		
-126	narrow upside-down meat engine	0		
+126	upside-down narrow meat engine	0		
 127	Gnollish autoplunger of the detective	0		Item Drop: +20
 128	spinning Socratic meat pants	0		Experience (Mysticality): +1, Familiar Effect: "2xPotato, cap 11"
 129	padded third-hand nunchaku	0		Damage Absorption: +20
@@ -138,7 +138,7 @@
 139	bouncing valuable trinket	0		
 140	shaking dingy planks	0		
 141	dingy dinghy	0		
-142	bouncing jittery teal anticheese	0		
+142	bouncing teal jittery anticheese	0		
 143	cottage	0		
 144	pulsating stone of eXtreme power	0		
 145	barbed-wire fence	0		
@@ -158,12 +158,12 @@
 159	wad of dough	0		
 160	pie crust	0		
 161	bland immense ghuol egg	10	decent	
-162	yummy special ghuol egg quiche	4	awesome	Effect: "Boilermade", Effect Duration: 25
+162	special yummy ghuol egg quiche	4	awesome	Effect: "Boilermade", Effect Duration: 25
 163	skeleton bone of the wise owl	0		Mysticality: +20
-164	pulsating yellow smart skull	0		
+164	yellow pulsating smart skull	0		
 165	mirror skewer	0		
-166	blurry bouncing ghuol ears	0		
-167	half-sized spoiled ghuol-ear kabob	2	crappy	
+166	bouncing blurry ghuol ears	0		
+167	spoiled half-sized ghuol-ear kabob	2	crappy	
 168	Jim Carey's bone rattle	0		Monster Level: +25
 169	huge bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -175,12 +175,12 @@
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	moldy snack-sized chorizo taco	2	crappy	
+179	snack-sized moldy chorizo taco	2	crappy	
 180	acceptable weak ice-cold fotie	2	good	
 181	baseball	0		
 182	batgut	0		
 183	bat wing	0		
-184	pulsating twirling briefcase	0		
+184	twirling pulsating briefcase	0		
 185	huge fat stacks of cash	0		
 186	bean	0		
 187	loose teeth	0		
@@ -196,10 +196,10 @@
 198	rat appendix	0		
 199	mirror flame-retardant ring	0		Hot Resistance: +1
 200	tasty purple rat appendix kabob	3	awesome	
-201	stale enchanted bat wing kabob	4	decent	Effect: "You Know Who to Call", Effect Duration: 35
+201	enchanted stale bat wing kabob	4	decent	Effect: "You Know Who to Call", Effect Duration: 35
 202	rotten thick tumbling carob chunks	5	crappy	
 203	skewed herbs	0		
-204	fancy massive toothsome pulsating carob chunk cookies	8	awesome	Effect: "Booooooze", Effect Duration: 5
+204	fancy toothsome massive pulsating carob chunk cookies	8	awesome	Effect: "Booooooze", Effect Duration: 5
 205	cyan secret blend of herbs and spices	0		
 206	pulsating piercing post	0		
 207	hippy herbal tea	1	awesome	
@@ -221,7 +221,7 @@
 223	veiny phat turquoise bracelet	0		Maximum HP: +10
 224	supercool eyepatch	0		Moxie Percent: +20, Familiar Effect: "3xBarrr, cap 6"
 225	rotten gigantic twirling tofu casserole	10	crappy	
-226	modified squat cyan can of Red Minotaur	1	good	Effect: "Vitali Tea", Effect Duration: 10
+226	modified cyan squat can of Red Minotaur	1	good	Effect: "Vitali Tea", Effect Duration: 10
 227	Kentucky-fried meat sword of mayonnaise	0		Sleaze Spell Damage: +50
 228	lime green Da Vinci's Kentucky-fried meat staff	0		Experience (Mysticality): +5
 229	prompt Kentucky-fried meat crossbow	0		Adventures: +3
@@ -231,7 +231,7 @@
 233	Doc Galaktik's Restorative Balm	0		
 234	jittery Doc Galaktik's Homeopathic Elixir	0		
 235	greedy Bigger Bugfinder Blade of chilblains	0		Cold Damage: +25, Meat Drop: +20
-236	mirror teal Queue Du Coq cocktailcrafting kit	0		
+236	teal mirror Queue Du Coq cocktailcrafting kit	0		
 237	mediocre distilled bottle of gin	5	decent	
 238	drinkable squat bottle of vodka	3	good	
 239	huge jittery gravedigger's Orcish baseball cap of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
@@ -244,22 +244,22 @@
 246	bland blue tomato	4	decent	
 247	fermenting powder	0		
 248	hand-crafted extra-dry salty dog	5	EPIC	
-249	perfectly mixed high-proof bloody mary	7	EPIC	
+249	high-proof perfectly mixed bloody mary	7	EPIC	
 250	drinkable screwdriver	4	good	
 251	mediocre martini	3	decent	
 252	practically non-alcoholic perfectly mixed bloody beer	1	EPIC	
-253	aged fancy shot of schnapps	3	awesome	Effect: "Carrion' On", Effect Duration: 20
+253	fancy aged shot of schnapps	3	awesome	Effect: "Carrion' On", Effect Duration: 20
 254	tolerable weak shot of grapefruit schnapps	2	good	
 255	fortified perfectly mixed fine wine	5	EPIC	
 256	hand-crafted shot of tomato schnapps	3	EPIC	
 257	tolerable practically non-alcoholic extra-spicy bloody mary	1	good	
 258	shaking dense meat stack	0		
 259	snake skin	0		
-260	snack-sized flavorless huge White Citadel fries	2	decent	
-261	thick rotten spinning White Citadel burger	5	crappy	
-262	bite-sized flavorless piece of wedding cake	1	decent	
+260	flavorless snack-sized huge White Citadel fries	2	decent	
+261	rotten thick spinning White Citadel burger	5	crappy	
+262	flavorless bite-sized piece of wedding cake	1	decent	
 263	decent special chocolate chips	3	good	Effect: "Sleaze-Resistant Trousers", Effect Duration: 10
-264	bland miniature chocolate chip cookies	2	decent	
+264	miniature bland chocolate chip cookies	2	decent	
 265	lightning-fast satin pants	0		Initiative: +40, Familiar Effect: "atk, 2xPotato, cap 10"
 266	delicious lightning	4	awesome	
 267	squat rosy-cheeked mullet wig	0		Maximum HP Percent: +30, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -268,14 +268,14 @@
 270	picket fence	0		
 271	distilled barbell	1		
 272	modified concentrated magicalness pill	1		
-273	compressed upside-down ghostly moxie weed	1		
+273	compressed ghostly upside-down moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	tumbling leprechaun hatchling	0		
 277	pickled squat extra-strength strongness elixir	1		
 278	denatured jug-o-magicalness	1		
 279	powdered yellow suntan lotion of moxiousness	1		
-280	mirror tumbling Pick-O-Matic lockpicks	0		
+280	tumbling mirror Pick-O-Matic lockpicks	0		
 281	padded gasmask	0		Damage Absorption: +20, Familiar Effect: "1xBarrr, cap 12"
 282	fuchsia Boris's key	0		
 283	shaking blurry Jarlsberg's key	0		
@@ -298,7 +298,7 @@
 300	galvanized corrupted jaba&ntilde;ero-flavored chewing gum	0		Effect: "Bells in the Batfry", Effect Duration: 64
 301	flat dough	0		
 302	normal snack-sized Knob sausage	2	good	
-303	adequate small green Knob mushroom	2	good	
+303	small adequate green Knob mushroom	2	good	
 304	narrow dry noodles	0		
 305	flame-retardant Knob Goblin harem pants	0		Hot Resistance: +1, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	Knob Goblin harem veil of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "5xLep, cap 2"
@@ -309,15 +309,15 @@
 311	upside-down hill of beans	0		
 312	blinking Fonzie's Knob Goblin visor	0		Experience (Moxie): +1, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	wobbly Crown of the Goblin King of doom	0		Spooky Spell Damage: +50, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	yummy snack-sized bean burrito	2	awesome	
+314	snack-sized yummy bean burrito	2	awesome	
 315	bland bean burrito	4	decent	
 316	tiny rotten insanely bean burrito	1	crappy	
-317	miniature adequate bean burrito	2	good	
+317	adequate miniature bean burrito	2	good	
 318	moldy snack-sized bean burrito	2	crappy	
 319	normal insanely bean burrito	3	good	
 320	thick normal purple bat haggis	5	good	
 321	fancy adequate menudo	3	good	Effect: "Saucemastery", Effect Duration: 25
-322	huge rotten huge bouncing goat cheese	9	crappy	
+322	rotten huge huge bouncing goat cheese	9	crappy	
 323	yummy low-calorie plain pizza	1	awesome	
 324	normal sausage pizza	3	good	
 325	half-sized flavorless goat cheese pizza	2	decent	
@@ -327,7 +327,7 @@
 329	twirling electrified goat beard	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xPotato, cap 15"
 330	twirling glass of goat's milk	1	decent	
 331	mediocre Canadian	3	decent	
-332	thick spoiled mirror lemon	5	crappy	
+332	spoiled thick mirror lemon	5	crappy	
 333	delicious lime	3	awesome	
 334	coward's sabre teeth	0		Monster Level: -20
 335	mirror sabre-toothed lime cub	0		
@@ -338,7 +338,7 @@
 340	anodized ghostly Knob Goblin steroids	0		Effect: "Memory of Resilience", Effect Duration: 54
 341	adjusted Knob Goblin love potion	0		Effect: "Bored Stiff", Effect Duration: 35
 342	gray Knob Goblin stink bomb	0		
-343	corrupted dry tumbling narrow Knob Goblin sharpening spray	0		Effect: "Salt Rockin'", Effect Duration: 59
+343	corrupted dry narrow tumbling Knob Goblin sharpening spray	0		Effect: "Salt Rockin'", Effect Duration: 59
 344	Knob Goblin seltzer	0		
 345	Knob Goblin superseltzer	0		
 346	skewed scrumptious reagent	0		
@@ -432,7 +432,7 @@
 434	balloon helmet of bravery	0		Spooky Resistance: +5, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	ghostly supercool brainy balloon sword	0		Mysticality: +5, Moxie Percent: +20, Clowniness: 50
 436	ghostly balloon monkey	0		
-437	purple squat bouncing chef skull	0		
+437	bouncing purple squat chef skull	0		
 438	chef-in-the-box	0		
 439	bartender skull	0		
 440	huge bartender-in-the-box	0		
@@ -451,7 +451,7 @@
 453	twirling sober pill	0		
 454	screwdriver	0		
 455	rotten jumbo olive	4	crappy	
-456	weak perfectly mixed dry martini	2	EPIC	
+456	perfectly mixed weak dry martini	2	EPIC	
 457	blinking Tesla ye olde golde frontes	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Disco Bandit", Single Equip
 458	skewed continuum transfunctioner	0		
 459	pixel	0		
@@ -466,7 +466,7 @@
 468	ruby W	0		
 469	wussiness potion	0		
 470	practically non-alcoholic lousy Imp Ale	1	decent	
-471	miniature stale hot wing	2	decent	
+471	stale miniature hot wing	2	decent	
 472	supercharged diamond-studded cane	0		Maximum MP Percent: +30, Class: "Disco Bandit"
 473	crutch of James Dean	0		Experience (Moxie): +3
 474	cast	0		
@@ -510,7 +510,7 @@
 512	Sneaky Pete's key lime	0		
 513	spoiled miniature Boris's key lime pie	2	crappy	
 514	decent skewed yellow Jarlsberg's key lime pie	4	good	
-515	stale big maroon mirror Sneaky Pete's key lime pie	5	decent	
+515	stale big mirror maroon Sneaky Pete's key lime pie	5	decent	
 516	pulsating gray Hey Deze map	0		
 517	gray forbidden bejeweled accordion strap	0		Spell Damage Percent: +50, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -519,7 +519,7 @@
 521	censurious kickback cookbook	0		Sleaze Resistance: +3
 522	spinning teal one-winged stab bat	0		
 523	spinning rewinged stab bat	0		
-524	bad watered-down papaya sling	2	decent	
+524	watered-down bad papaya sling	2	decent	
 525	gray tumbling grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	cyan volleyball	0		
@@ -545,7 +545,7 @@
 547	334 scroll	0		
 548	668 scroll	0		
 549	wobbly 30669 scroll	0		
-550	tumbling maroon 33398 scroll	0		
+550	maroon tumbling 33398 scroll	0		
 551	upside-down 64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
@@ -554,7 +554,7 @@
 556	perfumed Pine-Fresh air freshener	0		Stench Resistance: +5
 557	lousy whiskey and cola	3	decent	
 558	snack-sized rotten papaya taco	2	crappy	
-559	bouncing twirling razor-sharp can lid	0		
+559	twirling bouncing razor-sharp can lid	0		
 560	adequate stalk of asparagus	3	good	
 561	pregnant mushroom	0		
 562	jittery shaking ratgut	0		
@@ -564,11 +564,11 @@
 566	teal bum cheek	0		Item Drop: +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	bland Double Bacon Beelzeburger	3	decent	
-569	massive normal Lord of the Flies-sized fries	10	good	
+569	normal massive Lord of the Flies-sized fries	10	good	
 570	decent diet Chicken Sandwich	1	good	
 571	special Jumbo Dr. Lucifer	1	decent	Effect: "Salt Rockin'", Effect Duration: 20
 572	half-sized spoiled squat Children's Meal of the Damned	2	crappy	
-573	diet toothsome ghostly noodles	1	awesome	
+573	toothsome diet ghostly noodles	1	awesome	
 574	decent cyan noodles	3	good	
 575	flavorless painful penne pasta	4	decent	
 576	normal ravioli della hippy	4	good	
@@ -577,14 +577,14 @@
 579	spoiled boring spaghetti	4	crappy	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
-582	jittery blinking Himalayan Hidalgo sauce	0		
-583	enchanted decent miniature fettucini Inconnu	2	good	Effect: "Extra-Thick Blood", Effect Duration: 30
-584	normal small spaghetti with Skullheads	2	good	
+582	blinking jittery Himalayan Hidalgo sauce	0		
+583	decent miniature enchanted fettucini Inconnu	2	good	Effect: "Extra-Thick Blood", Effect Duration: 30
+584	small normal spaghetti with Skullheads	2	good	
 585	bland teal gnocchetti di Nietzsche	4	decent	
 586	green toasty ridiculously huge sword of the brute	0		Muscle Percent: +30, Hot Damage: +5
 587	ionized non-oxidized twirling super-spiky hair gel	0		Effect: "Woad Warrior", Effect Duration: 43
 588	soft echo eyedrop antidote	0		
-589	rotten half-sized cocoa eggshell fragment	2	crappy	
+589	half-sized rotten cocoa eggshell fragment	2	crappy	
 590	bite-sized rotten cocoa eggshell fragment	1	crappy	
 591	blurry cocoa egg	0		
 592	house	0		
@@ -644,8 +644,8 @@
 646	moldy fruitcake	4	crappy	
 647	spinning spinning present	0		Last Available: "2004-11"
 648	squat zippy Crimbo sword	0		Initiative: +20, Last Available: "2004-10"
-649	supercharged Crimbo hat	0		Maximum MP Percent: +30, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	Crimbo pants of the sweet-tooth	0		Candy Drop: +100, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	supercharged Crimbo hat	0		Maximum MP Percent: +30, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	Crimbo pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	narrow stylish exclusive ultra-rare item	0		Moxie: +25
 652	quantum egg	0		
 653	spinning intragalactic rowboat	0		
@@ -664,7 +664,7 @@
 666	frosty sinister steaming evil of bravery	0		Spell Damage: +10, Cold Spell Damage: +10, Spooky Resistance: +5
 667	castle map	0		
 668	spiked femur of the boozehound	0		Booze Drop: +100
-669	miniature decent blurry ghuol guolash	2	good	
+669	decent miniature blurry ghuol guolash	2	good	
 670	upside-down lihc face of the storm	0		Maximum MP Percent: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	twirling squat avaricious arcane researcher's grave robbing shovel	0		Experience Percent (Mysticality): +10, Meat Drop: +30
 672	flavorless bite-sized cranberries	1	decent	
@@ -674,12 +674,12 @@
 676	shaking yellow dragonbone belt buckle	0		
 677	Oprah's badass belt	0		Maximum MP Percent: +50
 678	chest of the Bonerdagon	0		
-679	drinkable watered-down roll in the hay	2	good	
-680	extra-dry smooth slap and tickle	5	awesome	
+679	watered-down drinkable roll in the hay	2	good	
+680	smooth extra-dry slap and tickle	5	awesome	
 681	tolerable tumbling slip 'n' slide	3	good	
 682	tolerable a sump'm sump'm	3	good	
 683	spirit-forward acceptable horizontal tango	5	good	
-684	artisanal strong pink pony	5	EPIC	
+684	strong artisanal pink pony	5	EPIC	
 685	occult Mr. Shirt of Tarzan of the brazier	0		Experience (Muscle): +3, Spell Damage Percent: +25, Hot Spell Damage: +25
 686	wobbly dance instructor's knuckles	0		Experience Percent (Moxie): +10
 687	polymerized huge blurry blood of the Wereseal	0		Effect: "Oleaginous Soles", Effect Duration: 57
@@ -724,7 +724,7 @@
 728	hedge maze key	0		
 729	fishbowl	0		
 730	fishtank	0		
-731	cyan shaking fish hose	0		
+731	shaking cyan fish hose	0		
 732	fuchsia hosed tank	0		
 733	hosed fishbowl	0		
 734	mirror auspicious smartaleck's makeshift SCUBA gear of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Item Drop: +10, Adventure Underwater
@@ -748,15 +748,15 @@
 753	half-sized spoiled pointy mushroom	2	crappy	
 754	spoiled cream of pointy mushroom soup	4	crappy	
 755	yummy narrow mushroom	3	awesome	
-756	decent diet fuchsia mushroom	1	good	
+756	diet decent fuchsia mushroom	1	good	
 757	stale blurry mushroom	4	decent	
-758	tasty miniature twirling ghost cucumber	2	awesome	
-759	cyan pulsating dill	0		
+758	miniature tasty twirling ghost cucumber	2	awesome	
+759	pulsating cyan dill	0		
 760	vinegar	0		
 761	jittery brine	0		
 762	acceptable especially salty dog	3	good	
 763	wobbly ghostly pickling solution	0		
-764	half-sized normal ghostly teal spectral pickle	2	good	
+764	normal half-sized ghostly teal spectral pickle	2	good	
 765	maroon briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	super-nitrogenated anodized tumbling cologne of contempt	0		Effect: "Super-Electrified", Effect Duration: 20
@@ -776,25 +776,25 @@
 781	quadruple-unsweetened mafia aria	0		Effect: "Overstimulated", Effect Duration: 68
 782	mirror Mr. Exploiter	0		Last Available: "2009-12"
 783	bouncing 'Villa' document	0		
-784	irresponsibly strong tolerable Acqua Del Piatto Merlot	6	good	Last Available: "2004-10"
+784	tolerable irresponsibly strong Acqua Del Piatto Merlot	6	good	Last Available: "2004-10"
 785	blurry raffle ticket	0		
 786	normal green strawberry	4	good	
 787	artisanal mirror bottle of rum	3	EPIC	
 788	bad blurry strawberry daiquiri	3	decent	
-789	high-proof tolerable rum and cola	7	good	
+789	tolerable high-proof rum and cola	7	good	
 790	weak acceptable grog	2	good	
 791	tumbling olive weightlifter's Mafia bow tie of the brute	0		Muscle: +15, Muscle Percent: +30, Last Available: "2004-10"
 792	Golden Mr. Accessory of dire peril	0		Weapon Damage: +20, Softcore Only
 793	denatured deionized purple oil of stability	0		Effect: "Pork Power", Effect Duration: 13
 794	energized chilled frozen green oil of slipperiness	0		Effect: "Fungal Flambé", Effect Duration: 11
-795	spirit-forward delicious Acque Luride Grezze Cabernet	5	awesome	Last Available: "2004-10"
+795	delicious spirit-forward Acque Luride Grezze Cabernet	5	awesome	Last Available: "2004-10"
 796	frightening Newton's cement shoes of Leguizamo	0		Experience (Mysticality): +3, Monster Level: +20, Spooky Damage: +5, Last Available: "2004-10"
 797	lousy enchanted rockin' wagon	3	decent	Effect: "Spiritually Awake", Effect Duration: 35
-798	distilled delicious fancy ocean motion	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 50
+798	delicious distilled fancy ocean motion	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 50
 799	aged fuzzbump	4	awesome	
 800	moldy blurry poutine	3	crappy	
 801	spoiled gigantic Knob stir-fry	8	crappy	
-804	flavorless diet Knoll stir-fry	1	decent	
+804	diet flavorless Knoll stir-fry	1	decent	
 805	rotten snack-sized pulsating stir-fry	2	crappy	
 806	gigantic flavorless asparagus stir-fry	9	decent	
 807	half-sized bland olive stir-fry	2	decent	
@@ -804,7 +804,7 @@
 811	bland special thick tofu stir-fry	5	decent	Effect: "Pla-see-bo", Effect Duration: 30
 812	stale blinking pr0n stir-fry	4	decent	
 813	yummy Knob shells	3	awesome	
-814	rotten snack-sized b&auml;tzle	2	crappy	
+814	snack-sized rotten b&auml;tzle	2	crappy	
 815	spoiled ratini	3	crappy	
 816	yummy Knob stroganoff	3	awesome	
 817	fancy decent menudo ravioli	3	good	Effect: "Weepy, Creepy", Effect Duration: 20
@@ -821,8 +821,8 @@
 828	baby killer bee	0		
 829	narrow anti-anti-antidote	0		
 830	rotten royal jelly	3	crappy	
-831	huge upside-down small box	0		
-832	blurry cyan box	0		
+831	upside-down huge small box	0		
+832	cyan blurry box	0		
 833	mirror miser's vorpal blade	0		Meat Drop: +10
 834	double-paned studded cornuthaum	0		Damage Absorption: +80, Cold Resistance: +5, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	ring of aggravate monster of James Dean	0		Experience (Moxie): +3
@@ -840,7 +840,7 @@
 848	pulsating hypodermic needle	0		Familiar Weight: +5
 849	Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
-851	lime green pulsating prosthetic forehead	0		Familiar Weight: +5
+851	pulsating lime green prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
 853	blundarrrbus	0		Familiar Weight: +5
 854	red sucky decal	0		Familiar Weight: +5
@@ -892,7 +892,7 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	practically non-alcoholic perfectly mixed Spasmi Dolorosi Del Rene Champagne	1	super ultra mega turbo EPIC	Last Available: "2004-10"
-904	lightning-fast therapeutic Rosewater's school Mafia knickerbockers	0		Mysticality Percent: +30, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	lightning-fast therapeutic Rosewater's school Mafia knickerbockers	0		Mysticality Percent: +30, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	magnetized improved Vulcanized bouncing Yummy Tummy bean	0		Effect: "Proprie Tea", Effect Duration: 32
 906	dry cold-filtered Rock Pops	0		Effect: "New Zeal", Effect Duration: 54
 907	Vulcanized concentrated anodized Mr. Mediocrebar	0		Effect: "Salad Days", Effect Duration: 54
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	green tumbling rosewater-soaked experienced intergalactic pom poms	0		Experience: +2, Stench Resistance: +3
 917	Mob Penguin protection contract	0		
-918	beefy Radio Free Baseball Cap	0		Muscle: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	supercool Radio Free Pants	0		Moxie Percent: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	beefy Radio Free Baseball Cap	0		Muscle: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	supercool Radio Free Pants	0		Moxie Percent: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	Radio Free Foil of the cheetah	0		Initiative: +60, Last Available: "2006-07"
 921	adequate radio button candy	3	good	
 922	nippy severed rocking horse head	0		Cold Damage: +10
@@ -918,7 +918,7 @@
 927	delicious blue Ferita Del Petto Zinfandel	4	awesome	Last Available: "2006-12"
 928	jittery weightlifter's fuzzy bracelets	0		Muscle: +15
 929	arse-shooting crossbow of terror	0		Spooky Spell Damage: +10
-931	watered-down tolerable spiced rum	2	good	
+931	tolerable watered-down spiced rum	2	good	
 932	triple-distilled drinkable tumbling eggnog	6	good	
 933	adequate blinking candy cane	3	good	
 934	bland spinning purple gingerbread bugbear	3	decent	
@@ -929,9 +929,9 @@
 939	blinking small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	spinning Da Vinci's bowler	0		Experience (Mysticality): +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	spinning Da Vinci's bowler	0		Experience (Mysticality): +5, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	ruddy educational bow staff	0		Experience: +1, Maximum HP Percent: +40, Last Available: "2004-12"
-944	gray bowlegged pants of dire peril	0		Weapon Damage: +20, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	gray bowlegged pants of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -943,9 +943,9 @@
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	red inspector's fez of etymology	0		Item Drop: +15, Familiar Effect: "1xLep, cap 30"
-956	diet bland carob chunk noodles	1	decent	
+956	bland diet carob chunk noodles	1	decent	
 957	bite-sized decent chorizo brownies	1	good	
-958	flavorless snack-sized chocolate and tomato pizza	2	decent	
+958	snack-sized flavorless chocolate and tomato pizza	2	decent	
 959	flange	0		
 960	clockwork key	0		
 961	tumbling silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -989,23 +989,23 @@
 1002	frosty Xlyinia's notebook	0		Cold Spell Damage: +10
 1003	soda water	0		
 1004	bad bottle of tequila	3	decent	
-1005	watered-down mediocre boxed wine	2	decent	
-1006	snack-sized stale cherry	2	decent	
+1005	mediocre watered-down boxed wine	2	decent	
+1006	stale snack-sized cherry	2	decent	
 1007	red skewed rosy-cheeked coconut shell	0		Maximum HP Percent: +30, Familiar Effect: "1xFairy, cap 7"
 1008	fortified ice cubes	0		Damage Absorption: +60
 1009	practically non-alcoholic lousy ghostly vodka martini	1	decent	
-1010	hand-crafted enchanted whiskey and soda	4	EPIC	Effect: "It Tickles!  It Tickles!", Effect Duration: 45
+1010	enchanted hand-crafted whiskey and soda	4	EPIC	Effect: "It Tickles!  It Tickles!", Effect Duration: 45
 1011	irresponsibly strong mediocre monkey wrench	9	decent	
-1012	fortified drinkable tequila sunrise	5	good	
+1012	drinkable fortified tequila sunrise	5	good	
 1013	smooth fuchsia margarita	3	awesome	
 1014	mediocre yellow strawberry wine	4	decent	
-1015	watered-down tolerable wine spritzer	2	good	
+1015	tolerable watered-down wine spritzer	2	good	
 1016	mediocre perpendicular hula	3	decent	
 1017	drinkable huge ducha de oro	3	good	
-1018	mediocre fancy teal calle de miel	4	decent	Effect: "Baconstoned", Effect Duration: 5
+1018	fancy mediocre teal calle de miel	4	decent	Effect: "Baconstoned", Effect Duration: 5
 1019	delicious dry vodka martini	4	awesome	
 1020	perfectly mixed old-fashioned	4	EPIC	
-1021	weak hand-crafted tequila with training wheels	2	EPIC	
+1021	hand-crafted weak tequila with training wheels	2	EPIC	
 1022	enchanted perfectly mixed squat sangria	4	EPIC	Effect: "Dreadful Sheen", Effect Duration: 50
 1023	bad vesper	4	decent	Last Available: "2004-12"
 1024	drinkable weak bodyslam	2	good	Last Available: "2004-12"
@@ -1029,11 +1029,11 @@
 1043	stiffened string of beads	0		Damage Reduction: 1
 1044	twirling experienced string of beads	0		Experience: +2
 1045	bouncing Rosewater's plastic bottle opener	0		Mysticality Percent: +30
-1046	lime green wicked traffic cone of extreme caution	0		Spell Damage: +5, Monster Level: -25, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	lime green wicked traffic cone of extreme caution	0		Spell Damage: +5, Monster Level: -25, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	bad N. O. Beer	4	decent	
 1048	dried huge oyster egg	1		Effect: "Adapt to Change Eventually", Effect Duration: 45
 1049	compressed jittery wobbly oyster egg	1		
-1050	dehydrated blinking pulsating mirror oyster egg	1		
+1050	dehydrated pulsating mirror blinking oyster egg	1		
 1051	plastic oyster egg	0		
 1052	distilled oyster egg	1		
 1053	twisted blurry oyster egg	1		Effect: "Pumped Stomach", Effect Duration: 15
@@ -1043,16 +1043,16 @@
 1057	dried maroon puce oyster egg	1		
 1058	twisted tumbling gray puce oyster egg	1		Effect: "Jammin'", Effect Duration: 45
 1059	puce plastic oyster egg	0		
-1060	denatured jittery cyan mauve oyster egg	1		
+1060	denatured cyan jittery mauve oyster egg	1		
 1061	mixed blinking mauve oyster egg	1		
 1062	dried skewed mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
-1064	distilled wobbly cyan upside-down oyster egg	1		Effect: "Fastbreaker", Effect Duration: 50
+1064	distilled wobbly upside-down cyan oyster egg	1		Effect: "Fastbreaker", Effect Duration: 50
 1065	dehydrated skewed oyster egg	1		Effect: "Prelude of Precision", Effect Duration: 25
 1066	vaporized spinning oyster egg	1		
-1067	mirror ghostly plastic oyster egg	0		
+1067	ghostly mirror plastic oyster egg	0		
 1068	boiled oyster egg	1		Effect: "Berry Thorny", Effect Duration: 50
-1069	dried squat skewed oyster egg	1		
+1069	dried skewed squat oyster egg	1		
 1070	compressed oyster egg	1		
 1071	plastic oyster egg	0		
 1072	vaporized ghostly off-white oyster egg	1		
@@ -1105,7 +1105,7 @@
 1119	pregnant mushroom	0		
 1120	red narrow pregnant mushroom	0		
 1121	inexplicably rock	0		
-1122	shaking shaking fuchsia fairy gravy	0		
+1122	shaking fuchsia shaking fairy gravy	0		
 1123	halfberd of the scaredy-cat	0		Monster Level: -15
 1124	small glove	0		
 1125	blurry clever curative glove	0		Maximum MP: +20, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5
@@ -1122,21 +1122,21 @@
 1136	tarnished polymerized lipstick	0		Effect: "Destructive Resolve", Effect Duration: 17
 1137	Annie Oakley's padded bicycle chain	0		Damage Absorption: +20, Critical Hit Percent: +20
 1138	mushroom fermenting solution	0		
-1139	lousy weak mushroom wine	2	decent	
+1139	weak lousy mushroom wine	2	decent	
 1140	lousy practically non-alcoholic icy mushroom wine	1	decent	
 1141	irresponsibly strong perfectly mixed mushroom wine	8	EPIC	
 1142	perfectly mixed special pointy mushroom wine	3	EPIC	Effect: "Rosewater Mark", Effect Duration: 10
 1143	artisanal flat mushroom wine	3	EPIC	
-1144	mediocre enchanted watered-down cool mushroom wine	2	decent	Effect: "Amorous", Effect Duration: 20
-1145	perfectly mixed watered-down twirling knob mushroom wine	2	EPIC	
+1144	mediocre watered-down enchanted cool mushroom wine	2	decent	Effect: "Amorous", Effect Duration: 20
+1145	watered-down perfectly mixed twirling knob mushroom wine	2	EPIC	
 1146	triple-distilled perfectly mixed knoll mushroom wine	6	EPIC	
-1147	mediocre watered-down mushroom wine	2	decent	
-1148	smooth high-proof tumbling shot of flower schnapps	10	awesome	
+1147	watered-down mediocre mushroom wine	2	decent	
+1148	high-proof smooth tumbling shot of flower schnapps	10	awesome	
 1149	flavorless miniature flower petal pie	2	decent	
-1150	hand-crafted tumbling blinking bottle of single-barrel whiskey	4	EPIC	
+1150	hand-crafted blinking tumbling bottle of single-barrel whiskey	4	EPIC	
 1151	stylish discarded plastic fork of the storm	0		Moxie: +25, Maximum MP Percent: +40
 1152	fuchsia gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	half-sized stale Retenez L'Herbe Pat&eacute;	2	decent	
+1153	stale half-sized Retenez L'Herbe Pat&eacute;	2	decent	
 1154	powdered Breathetastic&trade; Premium Canned Air	1	good	
 1155	letter from King Ralph XI	0		
 1157	healthy wholeberd	0		Maximum HP Percent: +20
@@ -1146,7 +1146,7 @@
 1161	pile of candy	0		
 1162	anodized skewed handsomeness potion	0		Effect: "Pyramid Power", Effect Duration: 53
 1163	chilled marzipan skull	0		Effect: "Lubed", Effect Duration: 41
-1164	tumbling gray poultrygeist	0		
+1164	gray tumbling poultrygeist	0		
 1165	hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
@@ -1175,7 +1175,7 @@
 1190	dodecapede	0		
 1191	ghostly ghuol whelp	0		
 1192	blinking zmobie	0		
-1193	tumbling shaking Raggedy Hippy doll	0		
+1193	shaking tumbling Raggedy Hippy doll	0		
 1194	stab bat	0		
 1195	blue apathetic lizardman doll	0		
 1196	yeti	0		
@@ -1184,12 +1184,12 @@
 1199	olive bugbear	0		
 1200	bland snack-sized mugcake	2	decent	
 1201	stale urinal cake	3	decent	
-1202	massive decent Happy Birthday, Claude! cake	10	good	
+1202	decent massive Happy Birthday, Claude! cake	10	good	
 1203	normal personalized birthday cake	4	good	
 1204	delicious three-tiered wedding cake	3	awesome	
 1205	toothsome babycakes	4	awesome	
-1206	small adequate mirror velvet cake	2	good	
-1207	moldy half-sized congratulatory cake	2	crappy	
+1206	adequate small mirror velvet cake	2	good	
+1207	half-sized moldy congratulatory cake	2	crappy	
 1208	adequate angel-food cake	3	good	
 1209	miniature spoiled devil's-food cake	2	crappy	
 1210	moldy green birthday party jellybean cheesecake	3	crappy	
@@ -1232,15 +1232,15 @@
 1248	Temple Grandin's crafty Bonerdagon necklace of the sweet-tooth	0		Maximum MP: +10, Familiar Weight: +7, Candy Drop: +100
 1249	nippy Boss Bat britches	0		Cold Damage: +10, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	supercharged cool Boss Bat bling	0		Moxie: +5, Maximum MP Percent: +30
-1251	bland small fuchsia Knob shroomkabob	2	decent	
+1251	small bland fuchsia Knob shroomkabob	2	decent	
 1252	decent shroomkabob	3	good	
 1253	pile of jumping beans	0		
 1254	decent jumping bean burrito	3	good	
-1255	toothsome half-sized jumping bean burrito	2	awesome	
+1255	half-sized toothsome jumping bean burrito	2	awesome	
 1256	spoiled wobbly insanely jumping bean burrito	4	crappy	
 1257	bland rat scrapple	4	decent	
-1258	huge bouncing upside-down pail of pretentious paint	0		
-1259	blinking shellacked traffic cone of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 7, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1258	upside-down bouncing huge pail of pretentious paint	0		
+1259	blinking shellacked traffic cone of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 7, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	dried red Hatorade	1		
 1262	hale savvy stylish off-hand balloon	0		Moxie: +25, Mysticality Percent: +20, Maximum HP: +20
@@ -1287,12 +1287,12 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	jittery sharpshooter's cool traffic cone	0		Moxie: +5, Critical Hit Percent: +10, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	jittery sharpshooter's cool traffic cone	0		Moxie: +5, Critical Hit Percent: +10, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	skewed calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
-1311	bouncing mirror comfy blanket	0		Last Available: "2005-10"
+1311	mirror bouncing comfy blanket	0		Last Available: "2005-10"
 1312	Rosewater's Baron von Ratsworth's monocle	0		Mysticality Percent: +30, Single Equip
 1313	curative Baron von Ratsworth's money clip	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
 1314	Baron von Ratsworth's tophat of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
@@ -1304,8 +1304,8 @@
 1320	stale miniature questionable taco	2	decent	
 1321	ghostly Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	squat educational time helmet	0		Experience: +1, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	red upside-down fireproof time trousers	0		Hot Resistance: +3, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	squat educational time helmet	0		Experience: +1, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	red upside-down fireproof time trousers	0		Hot Resistance: +3, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	time sword of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2005-10"
 1326	mirror Temple Grandin's Dyspepsi-Cola helmet	0		Familiar Weight: +7, Familiar Effect: "3xFairy, cap 7"
 1327	red Socratic Cloaca-Cola shield	0		Experience (Mysticality): +1, Damage Reduction: 4
@@ -1335,9 +1335,9 @@
 1352	lousy spinning redrum	3	decent	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	huge flavorless squat bowl of oriole's nest soup	9	decent	
+1355	flavorless huge squat bowl of oriole's nest soup	9	decent	
 1356	maroon bunny liver	0		
-1357	enchanted mediocre watered-down Mt. Noob Pale Ale	2	decent	Effect: "In Vino Vires", Effect Duration: 30
+1357	watered-down enchanted mediocre Mt. Noob Pale Ale	2	decent	Effect: "In Vino Vires", Effect Duration: 30
 1358	mirror pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	fuchsia pirate zombie robot head	0		Last Available: "2005-11"
@@ -1345,9 +1345,9 @@
 1362	sausage	0		
 1363	skewed clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	half-sized rotten tofurkey leg	2	crappy	
+1365	rotten half-sized tofurkey leg	2	crappy	
 1366	spoiled tofurkey gravy	3	crappy	
-1367	rotten super-sized herbal stuffing	5	crappy	
+1367	super-sized rotten herbal stuffing	5	crappy	
 1368	rotten can-shaped gelatinous cranberry sauce	4	crappy	
 1369	rotten huge yams	4	crappy	
 1370	spinning rhinestone cowboy shirt of temperance	0		Sleaze Resistance: +5
@@ -1384,13 +1384,13 @@
 1402	crafty rag doll	0		Maximum MP: +10, Last Available: "2005-12"
 1403	mirror wool can of fake snow	0		Cold Resistance: +1, Last Available: "2005-12"
 1404	family-friendly colored-light &quot;necklace&quot;	0		Sleaze Resistance: +1, Last Available: "2005-12"
-1405	maroon asbestos-lined tree skirt	0		Hot Resistance: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	maroon asbestos-lined tree skirt	0		Hot Resistance: +5, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	bland bite-sized wreath-shaped Crimbo cookie	1	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	stale jittery bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	tasty miniature green tree-shaped Crimbo cookie	2	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	cyan shaking stanky Unionize The Elves sign	0		Stench Spell Damage: +25, Last Available: "2005-12"
 1410	green sleeping snowy owl	0		Last Available: "2005-12"
-1411	gray Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	gray Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	non-Vulcanized maroon snowcone	0		Effect: "Wasabi With You", Effect Duration: 57, Last Available: "2006-01"
 1413	alkaline bouncing snowcone	0		Effect: "Space Tripping", Effect Duration: 23, Last Available: "2006-01"
 1414	super-colloidal boiled snowcone	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 32, Last Available: "2006-01"
@@ -1399,13 +1399,13 @@
 1417	flattened alkaline snowcone	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 21, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	bouncing teddy bear sewing kit	0		Last Available: "2006-01"
-1420	cyan Usain Bolt's traffic cone of the sweet-tooth	0		Candy Drop: +100, Initiative: +80, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	cyan Usain Bolt's traffic cone of the sweet-tooth	0		Candy Drop: +100, Initiative: +80, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	ghostly iceberglet	0		Last Available: "2006-02"
 1424	ice sickle of the wise owl of the overflowing toilet	0		Mysticality: +20, Stench Spell Damage: +50, Softcore Only, Last Available: "2006-02"
 1425	red shaking wholesome ice baby	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2006-02"
-1426	pulsating ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	pulsating ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	greasy Oprah's ice skates	0		Maximum MP Percent: +50, Sleaze Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	immense adequate grue egg omelette	10	good	
 1429	roll of drink tickets	0		
@@ -1433,11 +1433,11 @@
 1451	modified hot wad	1		
 1452	modified upside-down wad	1		Effect: "Polar Express", Effect Duration: 50
 1453	compressed squat wad	1		
-1454	pickled red tumbling stench wad	1		Effect: "Your Interest is Peaked", Effect Duration: 10
+1454	pickled tumbling red stench wad	1		Effect: "Your Interest is Peaked", Effect Duration: 10
 1455	powdered ghostly sleaze wad	1		
 1456	double daisy	0		
 1457	skewed skewed Goth Giant	0		
-1458	adequate bite-sized skewed Valentine's Day cake	1	good	
+1458	bite-sized adequate skewed Valentine's Day cake	1	good	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1461,7 +1461,7 @@
 1479	shaking squat football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	mirror union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
-1482	skewed spinning paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
+1482	spinning skewed paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	maroon upside-down troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	gravedigger's rabbit's foot of mayonnaise	0		Spooky Damage: +10, Sleaze Spell Damage: +50
@@ -1474,10 +1474,10 @@
 1492	friendly ninja mop	0		Familiar Weight: +3
 1493	wicked ridiculously overelaborate ninja weapon of temperance	0		Spell Damage: +5, Sleaze Resistance: +5
 1494	enhanced quadruple-wet mirror sugar-coated pine cone	0		Effect: "Jerky, Boy", Effect Duration: 57, Last Available: "2020-09"
-1495	mirror rosewater-soaked cool traffic cone	0		Moxie: +5, Stench Resistance: +3, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	mirror rosewater-soaked cool traffic cone	0		Moxie: +5, Stench Resistance: +3, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	lousy shaking pulsating gloomy mushroom wine	4	decent	
-1497	weak hand-crafted lime green mushroom wine	2	super EPIC	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1497	hand-crafted weak lime green mushroom wine	2	super EPIC	
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	liquefied tumbling explosion-flavored chewing gum	0		Effect: "Infernal Thirst", Effect Duration: 49, Last Available: "2006-04"
@@ -1488,7 +1488,7 @@
 1506	tolerable calle de miel with a fly in it	3	good	Last Available: "2006-04"
 1507	delicious rockin' wagon with a fly in it	4	awesome	Last Available: "2006-04"
 1508	lousy perpendicular hula with a fly in it	4	decent	Last Available: "2006-04"
-1509	watered-down aged slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
+1509	aged watered-down slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	perfumed fake hand	0		Stench Resistance: +5, Last Available: "2006-04"
 1512	vaporized ghostly spinning Knob Goblin pet-buffing spray	1		
@@ -1504,22 +1504,22 @@
 1523	upside-down bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	upside-down diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	corkscrew of the cougar of the pedagogue	0		Moxie: +20, Experience: +3, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	squat grass skirt of the early riser	0		Adventures: +7, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	wobbly padded grass hat	0		Damage Absorption: +20, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	squat grass skirt of the early riser	0		Adventures: +7, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	wobbly padded grass hat	0		Damage Absorption: +20, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	squat twirling grass blade of the wise owl	0		Mysticality: +20, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	savvy sparkly engagement ring	0		Mysticality Percent: +20, Single Equip
 1539	narrow Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	reassuring grievous Grimacite goggles	0		Weapon Damage Percent: +50, Spooky Resistance: +1, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	reassuring grievous Grimacite goggles	0		Weapon Damage Percent: +50, Spooky Resistance: +1, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	hardy Grimacite glaive of the blizzard	0		Maximum HP: +50, Cold Spell Damage: +25, Last Available: "2008-10"
-1542	curative studded Grimacite greaves	0		Damage Absorption: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	curative studded Grimacite greaves	0		Damage Absorption: +80, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	squat MacGyver's smartaleck's Grimacite garter	0		Moxie Percent: +30, Maximum MP: +100, Last Available: "2008-10"
 1544	bouncing horrifying hale Grimacite galoshes	0		Maximum HP: +20, Spooky Damage: +25, Last Available: "2008-10"
 1545	blurry zippy Newton's Grimacite gorget	0		Experience (Mysticality): +3, Initiative: +20, Last Available: "2008-10"
@@ -1531,7 +1531,7 @@
 1551	bad bottle of Domesticated Turkey	3	decent	
 1552	artisanal bottle of Definit	4	EPIC	
 1553	artisanal watered-down bottle of Calcutta Emerald	2	EPIC	
-1554	weak acceptable bottle of Lieutenant Freeman	2	good	
+1554	acceptable weak bottle of Lieutenant Freeman	2	good	
 1555	acceptable tumbling bottle of Jorge Sinsonte	3	good	
 1556	acceptable practically non-alcoholic boxed champagne	1	good	
 1557	delicious thick kumquat	5	awesome	
@@ -1539,20 +1539,20 @@
 1559	tonic water	0		
 1560	normal cyan cocktail onion	3	good	
 1561	jumbo bland twirling raspberry	5	decent	
-1562	super-sized adequate kiwi	5	good	
-1563	practically non-alcoholic mediocre special bouncing whiskey bittersweet	1	decent	Effect: "Boo Tea", Effect Duration: 10
+1562	adequate super-sized kiwi	5	good	
+1563	mediocre practically non-alcoholic special bouncing whiskey bittersweet	1	decent	Effect: "Boo Tea", Effect Duration: 10
 1564	perfectly mixed mimosette	4	EPIC	
-1565	hand-crafted practically non-alcoholic tequila sunset	1	super EPIC	
+1565	practically non-alcoholic hand-crafted tequila sunset	1	super EPIC	
 1566	delicious zmobie	3	awesome	Wiki Name: "Zmobie (drink)"
 1567	weak lousy bouncing gin and tonic	2	decent	
 1568	smooth vodka and tonic	4	awesome	
 1569	acceptable vodka gibson	4	good	
-1570	perfectly mixed practically non-alcoholic gibson	1	super EPIC	
+1570	practically non-alcoholic perfectly mixed gibson	1	super EPIC	
 1571	acceptable parisian cathouse	4	good	
-1572	watered-down tolerable gray rabbit punch	2	good	
-1573	mediocre fortified caipifruta	5	decent	
-1574	tolerable practically non-alcoholic teqiwila	1	good	
-1575	watered-down drinkable Divine	2	good	
+1572	tolerable watered-down gray rabbit punch	2	good	
+1573	fortified mediocre caipifruta	5	decent	
+1574	practically non-alcoholic tolerable teqiwila	1	good	
+1575	drinkable watered-down Divine	2	good	
 1576	perfectly mixed blurry Gordon Bennett	4	EPIC	
 1577	aged tangarita	3	awesome	
 1578	fortified artisanal mandarina colada	5	EPIC	
@@ -1564,7 +1564,7 @@
 1584	bad wobbly Mae West	3	decent	
 1585	lousy practically non-alcoholic shaking skewed Mon Tiki	1	decent	
 1586	lousy teqiwila slammer	4	decent	
-1587	moldy huge Knob lo mein	8	crappy	
+1587	huge moldy Knob lo mein	8	crappy	
 1588	spoiled wobbly asparagus lo mein	3	crappy	
 1589	massive flavorless cyan Knoll lo mein	8	decent	
 1590	flavorless lo mein	3	decent	
@@ -1573,14 +1573,14 @@
 1593	normal hi mein	3	good	
 1594	spoiled hi mein	3	crappy	
 1595	rotten skewed hi mein	4	crappy	
-1596	stale jumbo bouncing sleazy hi mein	5	decent	
+1596	jumbo stale bouncing sleazy hi mein	5	decent	
 1597	fuchsia deadly Junior LAAAAME merit badge	0		Weapon Damage: +5, Last Available: "2006-05"
 1598	hardy Senior LAAAAME merit badge	0		Maximum HP: +50, Last Available: "2006-05"
 1599	bouncing jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	weak mediocre tangarita with a fly in it	2	decent	
+1600	mediocre weak tangarita with a fly in it	2	decent	
 1601	mediocre watered-down mandarina colada with a fly in it	2	decent	
-1602	lousy special watered-down olive prussian cathouse with a fly in it	2	decent	Effect: "Disco Inferno", Effect Duration: 10
-1603	acceptable weak Mae West with a fly in it	2	good	
+1602	special lousy watered-down olive prussian cathouse with a fly in it	2	decent	Effect: "Disco Inferno", Effect Duration: 10
+1603	weak acceptable Mae West with a fly in it	2	good	
 1604	diluted twirling astronaut ice-cream	1		Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2006-05"
 1605	narrow delectable catalyst	0		
 1606	twisted tumbling ultimate wad	1		
@@ -1592,8 +1592,8 @@
 1612	activated concentrated cordial of concentration	0		Effect: "Phairly Pheromonal", Effect Duration: 20
 1613	red weightlifter's coffin lid	0		Muscle: +15, Damage Reduction: 3
 1614	tumbling smooth satin shield	0		Moxie: +15, Damage Reduction: 5
-1615	bouncing rosy-cheeked Cerebral Cloche	0		Maximum HP Percent: +30, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	smelly Cerebral Culottes	0		Stench Spell Damage: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	bouncing rosy-cheeked Cerebral Cloche	0		Maximum HP Percent: +30, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	smelly Cerebral Culottes	0		Stench Spell Damage: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	fireproof medical-grade banded Cerebral Crossbow	0		Damage Absorption: +100, Hot Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2006-06"
 1618	blurry ice stein	0		Last Available: "2006-06"
 1619	red blinking munchies pill	0		Last Available: "2006-06"
@@ -1604,7 +1604,7 @@
 1624	enhanced triple-chilled improved blue-frosted astral cupcake	0		Effect: "Danish Cunning", Effect Duration: 29, Last Available: "2006-06"
 1625	irradiated green-frosted astral cupcake	0		Effect: "Gamer Rage", Effect Duration: 30, Last Available: "2006-06"
 1626	adjusted orange-frosted astral cupcake	0		Effect: "Inner Dog", Effect Duration: 34, Last Available: "2006-06"
-1627	irradiated blurry tumbling purple-frosted astral cupcake	0		Effect: "Improprie Tea", Effect Duration: 14, Last Available: "2006-06"
+1627	irradiated tumbling blurry purple-frosted astral cupcake	0		Effect: "Improprie Tea", Effect Duration: 14, Last Available: "2006-06"
 1628	pickled boiled mirror pink-frosted astral cupcake	0		Effect: "Slimy Flavor", Effect Duration: 45, Last Available: "2006-06"
 1629	raspberry beret of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	personal trainer's pixel shield	0		Experience Percent (Muscle): +10, Damage Reduction: 3
@@ -1613,7 +1613,7 @@
 1633	Spanish fly	0		
 1634	practically non-alcoholic drinkable around the world	1	good	
 1635	gray scrumdiddlyumptious solution	0		
-1636	tumbling ghostly twirling Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
+1636	ghostly twirling tumbling Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	magnetized deionized yellow lotion of hotness	0		Effect: "Muscularrr", Effect Duration: 39
 1638	dry improved lotion of coldness	0		Effect: "Here to Kick Ass", Effect Duration: 57
 1639	dry quantum lotion of spookiness	0		Effect: "Bone Homie", Effect Duration: 42
@@ -1628,9 +1628,9 @@
 1648	sleazy and sauce	0		
 1649	mirror brick	0		Free Pull
 1650	tumbling milk of magnesium	0		
-1651	big yummy special twirling foie gras	5	awesome	Effect: "Spiro Gyro", Effect Duration: 35
+1651	special yummy big twirling foie gras	5	awesome	Effect: "Spiro Gyro", Effect Duration: 35
 1652	super-anodized quadruple-wet diffused candy brain	0		Effect: "White Knuckles", Effect Duration: 22, Last Available: "2020-09"
-1653	lime green occult dance instructor's supercool jewel-eyed wizard hat	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Spell Damage Percent: +25, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	lime green occult dance instructor's supercool jewel-eyed wizard hat	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Spell Damage Percent: +25, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	lightning-fast aromatic wad of Crovacite	0		Stench Resistance: +1, Initiative: +40
 1655	twirling smelly Herculean collar	0		Experience (Muscle): +1, Stench Spell Damage: +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	blinking ore	0		
 1676	wobbly styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	red pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	red pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	energetic sword of the detective	0		Maximum MP Percent: +20, Item Drop: +20
 1680	wobbly sharpshooter's staff of Flo-Jo	0		Critical Hit Percent: +10, Initiative: +100
 1681	Van der Graaf bubblewrap sword of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7
@@ -1670,15 +1670,15 @@
 1690	huge bouncing chilly discarded bottlecap of the brute	0		Muscle Percent: +30, Cold Damage: +5, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	jittery Jack Frost's discarded torn-up glove of the glutton	0		Cold Spell Damage: +50, Food Drop: +100, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	magnetized jittery salamander slurry	0		Effect: "Ironclad", Effect Duration: 61
-1693	anodized double-galvanized blurry pulsating cyan eyedrops of newt	0		Effect: "Egg-stra Arm", Effect Duration: 33
+1693	anodized double-galvanized pulsating blurry cyan eyedrops of newt	0		Effect: "Egg-stra Arm", Effect Duration: 33
 1694	unsweetened Frogade	0		Effect: "Bone Homie", Effect Duration: 61
 1695	nitrogenated dry papotion of papower	0		Effect: "Spirit of Alph", Effect Duration: 46
 1696	tasty royal jelly taco	3	awesome	
-1697	miniature special tasty cyan tofu taco	2	awesome	Effect: "Rushtacean'", Effect Duration: 30
+1697	special miniature tasty cyan tofu taco	2	awesome	Effect: "Rushtacean'", Effect Duration: 30
 1698	flavorless jumping bean taco	4	decent	
 1699	toothsome squat catgut taco	4	awesome	
 1700	adequate small goat cheese taco	2	good	
-1701	small adequate pulsating pr0n taco	2	good	
+1701	adequate small pulsating pr0n taco	2	good	
 1702	flattened triple-adjusted diffused squat alphabet gum	0		Effect: "damage.enh", Effect Duration: 24
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1766,9 +1766,9 @@
 1787	deionized bag of Cheat-Os	0		Effect: "Patched In", Effect Duration: 19
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	watered-down fancy delicious jittery Ram's Face Lager	2	awesome	Effect: "Feline Ferocity", Effect Duration: 25
+1790	watered-down delicious fancy jittery Ram's Face Lager	2	awesome	Effect: "Feline Ferocity", Effect Duration: 25
 1791	cyan ram horns	0		
-1792	mirror knitted Tesla occult Travoltan trousers	0		Spell Damage Percent: +25, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	mirror knitted Tesla occult Travoltan trousers	0		Spell Damage Percent: +25, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	auspicious brawny pool cue	0		Muscle Percent: +20, Item Drop: +10
 1794	ionized handful of hand chalk	0		Effect: "Sleazy Weapon", Effect Duration: 45
 1795	jittery wizardly Counterclockwise Watch	0		Mysticality: +25, Single Equip
@@ -1778,7 +1778,7 @@
 1799	animal skull	0		
 1800	animal cranium	0		
 1801	animal jawbone	0		
-1802	mirror maroon first cervical vertebra	0		
+1802	maroon mirror first cervical vertebra	0		
 1803	olive second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	shaking fourth cervical vertebra	0		
@@ -1790,14 +1790,14 @@
 1811	third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
-1814	narrow huge sixth thoracic vertebra	0		
+1814	huge narrow sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	blinking eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	spinning tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
-1820	shaking mirror twelfth thoracic vertebra	0		
-1821	jittery wobbly first lumbar vertebra	0		
+1820	mirror shaking twelfth thoracic vertebra	0		
+1821	wobbly jittery first lumbar vertebra	0		
 1822	squat second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
@@ -1821,7 +1821,7 @@
 1842	left fourth rib	0		
 1843	left fifth rib	0		
 1844	mirror teal left sixth rib	0		
-1845	jittery teal left seventh rib	0		
+1845	teal jittery left seventh rib	0		
 1846	tumbling left eighth rib	0		
 1847	left ninth rib	0		
 1848	left tenth rib	0		
@@ -1831,7 +1831,7 @@
 1852	red right second rib	0		
 1853	right third rib	0		
 1854	right fourth rib	0		
-1855	cyan bouncing right fifth rib	0		
+1855	bouncing cyan right fifth rib	0		
 1856	tumbling right sixth rib	0		
 1857	huge right seventh rib	0		
 1858	right eighth rib	0		
@@ -1842,7 +1842,7 @@
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
-1866	blue blinking left clavicle	0		
+1866	blinking blue left clavicle	0		
 1867	right clavicle	0		
 1868	left humerus	0		
 1869	gray right humerus	0		
@@ -1865,7 +1865,7 @@
 1886	right first front claw	0		
 1887	mirror pulsating right second front claw	0		
 1888	right third front claw	0		
-1889	fuchsia huge right fourth front claw	0		
+1889	huge fuchsia right fourth front claw	0		
 1890	left thumb	0		
 1891	right thumb	0		
 1892	squat left first rear claw	0		
@@ -1900,7 +1900,7 @@
 1923	roll of toilet paper	0		Free Pull
 1924	jittery blurry tattered wolf standard	0		
 1925	twirling tattered snake standard	0		
-1926	fuchsia bouncing KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1926	bouncing fuchsia KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
 1928	tuning fork	0		
 1929	Herculean greaves	0		Experience (Muscle): +1, Familiar Effect: "1xBarrr"
@@ -1913,7 +1913,7 @@
 1936	lupine sword of vim and vigor	0		Maximum HP Percent: +50
 1937	teal snake shield	0		Item Drop: +5, Damage Reduction: 7
 1938	hardy serpentine sword	0		Maximum HP: +50
-1939	shaking wobbly grouchy restless spirit	0		
+1939	wobbly shaking grouchy restless spirit	0		
 1940	yellow squat frosty mansplainer's 9-ball of the storm	0		Maximum MP Percent: +40, Monster Level: +15, Cold Spell Damage: +10
 1941	ghostly seal pendant of the scaredy-cat of the sweet-tooth	0		Monster Level: -15, Candy Drop: +100, Class: "Seal Clubber", Single Equip
 1942	greedy manspreader's turtle brooch	0		Monster Level: +10, Meat Drop: +20, Class: "Turtle Tamer", Single Equip
@@ -1927,13 +1927,13 @@
 1950	bottle of Vangoghbitussin	0		
 1951	bad fuchsia bottle of Pinot Renoir	4	decent	
 1952	bland bouncing desiccated apricot	4	decent	
-1953	mediocre weak flute of flat champagne	2	decent	
+1953	weak mediocre flute of flat champagne	2	decent	
 1954	normal dehydrated caviar	4	good	
-1955	ghostly bouncing styrofoam peanuts	0		
+1955	bouncing ghostly styrofoam peanuts	0		
 1956	mediocre practically non-alcoholic snifter of thoroughly aged brandy	1	decent	
 1957	huge quill pen	0		
 1958	squat inkwell	0		
-1959	squat blinking tattered scrap of paper	0		
+1959	blinking squat tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
 1961	pulsating can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	chilled Bit O' Ectoplasm	0		Effect: "Inebriate Pride", Effect Duration: 58
@@ -1944,7 +1944,7 @@
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	shaking cyan bottle of perfume	0		Familiar Weight: +5
 1969	spoon!	0		Familiar Weight: +5
-1970	tumbling squat nervous tick egg	0		Free Pull, Last Available: "2007-10"
+1970	squat tumbling nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	miser's Jack Frost's shrimp fork	0		Cold Spell Damage: +50, Meat Drop: +10
 1973	skewed half of a memo	0		
@@ -1991,8 +1991,8 @@
 2014	gray Inndya trading card	0		
 2015	purple Kitty the Zmobie Basher trading card	0		
 2016	diamond necklace	0		
-2017	spinning mirror spade necklace	0		
-2018	lime green blurry club necklace	0		
+2017	mirror spinning spade necklace	0		
+2018	blurry lime green club necklace	0		
 2019	twirling cream pie	0		Free Pull
 2020	normal mirror cherry pie	4	good	
 2021	decent strawberry pie	4	good	
@@ -2020,8 +2020,8 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	bland blinking brain-meltingly-hot chicken wings	4	decent	
-2046	normal small mirror frat brats	2	good	
-2047	rotten skewed jittery knob ka-bobs	4	crappy	
+2046	small normal mirror frat brats	2	good	
+2047	rotten jittery skewed knob ka-bobs	4	crappy	
 2049	artisanal twirling can of Swiller	3	EPIC	
 2050	huge broken wings	0		
 2051	sunken eyes	0		
@@ -2032,11 +2032,11 @@
 2056	improved electrified adder bladder	0		Effect: "Heal Thy Nanoself", Effect Duration: 37
 2057	pension check	0		
 2058	picnic basket	0		
-2059	quadruple-polymerized pressed colloidal blinking blue Black No. 2	0		Effect: "Fireproof Lips", Effect Duration: 21
+2059	quadruple-polymerized pressed colloidal blue blinking Black No. 2	0		Effect: "Fireproof Lips", Effect Duration: 21
 2060	zippy perfumed sword	0		Stench Resistance: +5, Initiative: +20
 2061	Sinatra's helmet	0		Experience (Moxie): +5, Familiar Effect: "1xFairy, cap 40"
 2062	mansplainer's Tesla shield	0		Monster Level: +15, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 10
-2063	huge spoiled tumbling squat blackberry	6	crappy	
+2063	spoiled huge tumbling squat blackberry	6	crappy	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	olive wizardly kick-ass kicks of the overflowing toilet	0		Mysticality: +25, Stench Spell Damage: +50, Single Equip
@@ -2067,7 +2067,7 @@
 2091	twirling bath salts	0		
 2092	hand mirror	0		
 2093	hors d'oeuvre tray of courage	0		Spooky Resistance: +3, Damage Reduction: 5
-2094	decent thick ballroom blintz	5	good	
+2094	thick decent ballroom blintz	5	good	
 2095	towel	0		
 2096	pickled fuchsia guy made of bee pollen	1		Effect: "Crocodile Tear", Effect Duration: 40
 2097	upside-down Tesla 17-ball	0		MP Regen Min: 7, MP Regen Max: 10
@@ -2082,7 +2082,7 @@
 2106	upside-down burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
 2108	ghostly rock	0		
-2109	jittery spinning gray stringy sinew	0		Last Available: "2011-12"
+2109	spinning jittery gray stringy sinew	0		Last Available: "2011-12"
 2110	stick	0		Last Available: "2011-12"
 2111	huge bouncing tooth	0		
 2112	leaf	0		Last Available: "2011-12"
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	prehistoric spear of courage	0		Spooky Resistance: +3, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	baleful fire of the pedagogue	0		Experience: +3, Spell Damage: +25, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	baleful fire of the pedagogue	0		Experience: +3, Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	narrow wholesome Grateful Undead T-shirt	0		Maximum HP Percent: +10
@@ -2103,7 +2103,7 @@
 2128	vampire collar	0		Single Equip
 2129	possessed top	0		Last Available: "2010-12"
 2130	toasty killer rag doll	0		Hot Damage: +5, Last Available: "2006-12"
-2131	green mirror tree-eating kite	0		Last Available: "2006-12"
+2131	mirror green tree-eating kite	0		Last Available: "2006-12"
 2132	nippy incredibly marionette	0		Cold Damage: +10, Last Available: "2006-12"
 2133	dress ball	0		Last Available: "2010-12"
 2134	clever mad scientist's sock monkey	0		Maximum MP: +20, Last Available: "2006-12"
@@ -2121,9 +2121,9 @@
 2146	upside-down evil teddy bear	0		Last Available: "2006-12"
 2147	blinking evil teddy bear sewing kit	0		
 2148	narrow toothsome rock	0		
-2149	decent half-sized frank	2	good	Last Available: "2011-12"
-2150	enchanted bland tumbling plate of franks and beans	4	decent	Effect: "Human-Machine Hybrid", Effect Duration: 45, Last Available: "2011-12"
-2151	smooth extra-dry shot of blackberry schnapps	5	awesome	
+2149	half-sized decent frank	2	good	Last Available: "2011-12"
+2150	bland enchanted tumbling plate of franks and beans	4	decent	Effect: "Human-Machine Hybrid", Effect Duration: 45, Last Available: "2011-12"
+2151	extra-dry smooth shot of blackberry schnapps	5	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	yellow carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	jittery wicked toy ray gun of the cougar	0		Moxie: +20, Spell Damage: +5, Last Available: "2006-12"
-2169	fireproof chaotic toy space helmet	0		Spell Critical Percent: +10, Hot Resistance: +3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	fireproof chaotic toy space helmet	0		Spell Critical Percent: +10, Hot Resistance: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	blue MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	smelly Jack Frost's astronaut pants	0		Cold Spell Damage: +50, Stench Spell Damage: +10, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	smelly Jack Frost's astronaut pants	0		Cold Spell Damage: +50, Stench Spell Damage: +10, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	occult toy jet pack	0		Spell Damage Percent: +25, Last Available: "2006-12"
 2173	wobbly triangular stone	0		
 2174	blinking mossy stone sphere	0		
@@ -2161,18 +2161,18 @@
 2186	unlit birthday cake	0		
 2187	blue lit birthday cake	0		
 2188	fancy flask of peppermint oil	1	good	Effect: "Hobo Flavor", Effect Duration: 5, Last Available: "2006-12"
-2189	bad watered-down red flask of peppermint schnapps	2	decent	Last Available: "2006-12"
+2189	watered-down bad red flask of peppermint schnapps	2	decent	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	fuchsia sheet music	0		Last Available: "2006-12"
-2193	half-sized flavorless candy stake	2	decent	Last Available: "2006-12"
-2194	weak lousy eggnog	2	decent	Last Available: "2006-12"
-2195	massive bland unspeakable fruitcake	10	decent	Last Available: "2006-12"
-2196	bland bite-sized gingerbread horror	1	decent	Last Available: "2006-12"
+2193	flavorless half-sized candy stake	2	decent	Last Available: "2006-12"
+2194	lousy weak eggnog	2	decent	Last Available: "2006-12"
+2195	bland massive unspeakable fruitcake	10	decent	Last Available: "2006-12"
+2196	bite-sized bland gingerbread horror	1	decent	Last Available: "2006-12"
 2197	oxidized quadruple-frozen but probably evil chocolate	0		Effect: "Chain Chain Chains", Effect Duration: 25, Last Available: "2006-12"
 2198	big rotten cyan bat-shaped Crimboween cookie	5	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	low-calorie rotten skull-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	stale special squat tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	special stale squat tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	brainy plastic gift-wrapping vampire	0		Mysticality: +5, Last Available: "2006-12"
 2202	Lo Pan's plastic yuletide troll	0		Spell Critical Percent: +30, Last Available: "2006-12"
 2203	plastic skeletal reindeer of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	frightening Crimbo tiki necklace	0		Spooky Damage: +5, Last Available: "2006-12"
 2208	frightening studded bobble-hip hula elf doll	0		Damage Absorption: +80, Spooky Damage: +5, Last Available: "2006-12"
 2209	wobbly dance instructor's Crimbo ukulele	0		Experience Percent (Moxie): +10, Last Available: "2006-12"
-2210	sharpshooter's ruddy Tiki lighter	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	greasy rock-hard deck of tropical cards	0		Damage Reduction: 5, Sleaze Spell Damage: +10, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	foul-smelling deadly tropical paperweight	0		Weapon Damage: +5, Stench Damage: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	sharpshooter's ruddy Tiki lighter	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	greasy rock-hard deck of tropical cards	0		Damage Reduction: 5, Sleaze Spell Damage: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	foul-smelling deadly tropical paperweight	0		Weapon Damage: +5, Stench Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	shaking tropical wrapping paper	0		Last Available: "2006-12"
-2215	friendly Tropical Crimbo Hat	0		Familiar Weight: +3, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	gray Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
-2217	stale big special super ka-bob	5	decent	Effect: "damage.enh", Effect Duration: 40
+2215	friendly Tropical Crimbo Hat	0		Familiar Weight: +3, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	gray Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2217	big stale special super ka-bob	5	decent	Effect: "damage.enh", Effect Duration: 40
 2218	moldy beer basted brat	3	crappy	
 2219	perfumed Tropical Crimbo Sword	0		Stench Resistance: +5, Last Available: "2006-12"
 2220	wet flattened electrified ghostly and Crimboween candy	0		Effect: "Discomfited", Effect Duration: 58, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	narrow fortified educational liar's pants	0		Experience: +1, Damage Absorption: +60, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	narrow fortified educational liar's pants	0		Experience: +1, Damage Absorption: +60, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	flame-retardant Jack Frost's juggler's balls	0		Cold Spell Damage: +50, Hot Resistance: +1, Softcore Only, Last Available: "2007-01"
 2224	blurry stanky pink shirt	0		Stench Spell Damage: +25, Softcore Only, Last Available: "2007-01"
 2225	shaking familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2235,7 +2235,7 @@
 2261	tumbling hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	bland miniature stunt nuts	2	decent	
+2264	miniature bland stunt nuts	2	decent	
 2265	decent wet stew	4	good	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
@@ -2244,10 +2244,10 @@
 2270	olive huge Herculean beefy belt	0		Muscle: +10, Experience (Muscle): +1, Single Equip
 2271	mediocre weak bottle of Merlot	2	decent	
 2272	acceptable bottle of Port	3	good	
-2273	triple-distilled perfectly mixed bottle of Pinot Noir	9	EPIC	
-2274	watered-down mediocre bottle of Zinfandel	2	decent	
-2275	bad enchanted blurry bottle of Marsala	4	decent	Effect: "How to Scam Tourists", Effect Duration: 25
-2276	mediocre triple-distilled bouncing bottle of Muscat	8	decent	
+2273	perfectly mixed triple-distilled bottle of Pinot Noir	9	EPIC	
+2274	mediocre watered-down bottle of Zinfandel	2	decent	
+2275	enchanted bad blurry bottle of Marsala	4	decent	Effect: "How to Scam Tourists", Effect Duration: 25
+2276	triple-distilled mediocre bouncing bottle of Muscat	8	decent	
 2277	Fernswarthy's key	0		
 2278	twirling Fernswarthy's letter	0		
 2279	skewed book	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	activated moist yellow candy heart	0		Effect: "Hood Ridin'", Effect Duration: 12, Last Available: "2007-02"
 2305	diffused frozen wobbly pink candy heart	0		Effect: "Big Punkin'", Effect Duration: 24, Last Available: "2007-02"
 2306	frozen candy heart	0		Effect: "Action", Effect Duration: 55, Last Available: "2007-02"
@@ -2306,18 +2306,18 @@
 2332	rotten Better Than Cuddling Cake	3	crappy	
 2333	tumbling ninja snowman	0		
 2334	Holy MacGuffin	0		
-2335	mirror fuchsia rubber WWBBDD? bracelet	0		
+2335	fuchsia mirror rubber WWBBDD? bracelet	0		
 2336	sharpshooter's shellacked pipe	0		Damage Reduction: 7, Critical Hit Percent: +10
 2337	reinforced beaded headband of the empath	0		Familiar Weight: +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	rotten ghostly pudding	4	crappy	Wiki Name: "black pudding (food)"
 2339	bad weak Blackfly Chardonnay	2	decent	
-2340	irresponsibly strong artisanal & tan	6	EPIC	
-2341	ghostly bouncing maroon pepper	0		
-2342	adequate small twirling forest cake	2	good	
+2340	artisanal irresponsibly strong & tan	6	EPIC	
+2341	maroon bouncing ghostly pepper	0		
+2342	small adequate twirling forest cake	2	good	
 2343	adequate forest ham	3	good	
 2344	vacuum-sealed lime green skewed filthworm hatchling scent gland	0		Effect: "Macho Profundo", Effect Duration: 56
 2345	frozen super-vacuum-sealed filthworm drone scent gland	0		Effect: "Berry Experiential", Effect Duration: 56
-2346	energized mirror olive filthworm royal guard scent gland	0		Effect: "Full-Body Tan", Effect Duration: 58
+2346	energized olive mirror filthworm royal guard scent gland	0		Effect: "Full-Body Tan", Effect Duration: 58
 2347	bouncing heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	gas balloon	0		
@@ -2325,11 +2325,11 @@
 2351	wobbly superamplified boom box	0		
 2352	Oprah's fire poi of terror	0		Maximum MP Percent: +50, Spooky Spell Damage: +10
 2353	purple shellacked bejeweled pledge pin	0		Damage Reduction: 7, Single Equip
-2354	spinning narrow communications windchimes	0		
+2354	narrow spinning communications windchimes	0		
 2355	alkaline triple-modified gray henna face paint	0		Effect: "Spooky Flavor", Effect Duration: 26
 2356	wet quadruple-deionized ionized green tube of dread wax	0		Effect: "items.enh", Effect Duration: 40
 2357	stiffened Gaia beads	0		Damage Reduction: 1, Item Drop: +5
-2358	green squat pink clay bead	0		
+2358	squat green pink clay bead	0		
 2359	clay bead	0		
 2360	tumbling shaking clay bead	0		
 2361	stanky beefy hippy medical kit	0		Muscle: +10, Stench Spell Damage: +25, Single Equip
@@ -2348,7 +2348,7 @@
 2374	banana peel	0		
 2375	moldy banana cream pie	3	crappy	
 2376	bad banana daiquiri	4	decent	
-2377	high-proof perfectly mixed bungle in the jungle	6	EPIC	
+2377	perfectly mixed high-proof bungle in the jungle	6	EPIC	
 2378	banana spritzer	0		
 2379	deionized banana smoothie	0		Effect: "Antsy in your Pantsy", Effect Duration: 40
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2360,7 +2360,7 @@
 2386	twirling strapping keg shield of the pedagogue	0		Muscle: +5, Experience: +3, Damage Reduction: 11
 2387	finger of horror	0		Spooky Spell Damage: +25
 2388	horrifying war tongs of chilblains	0		Cold Damage: +25, Spooky Damage: +25
-2389	red pulsating Monstar energy beverage	0		
+2389	pulsating red Monstar energy beverage	0		
 2390	zippy asbestos apron	0		Initiative: +20
 2391	tumbling beaten-up Chucks of the brute	0		Muscle Percent: +30
 2392	tumbling horrifying natty ascot	0		Spooky Damage: +25
@@ -2384,7 +2384,7 @@
 2410	rag	0		
 2411	broken petri dish	0		
 2412	sammich crust	0		
-2413	gray skewed triffid bark	0		
+2413	skewed gray triffid bark	0		
 2414	purple twirling lint	0		
 2415	discarded pacifier	0		
 2416	razor-sharp bounty-hunting helmet	0		Weapon Damage Percent: +25, Familiar Effect: "1.5xFairy, cap 25"
@@ -2399,7 +2399,7 @@
 2425	alkaline colloidal ghostly upside-down can of spinach	0		Effect: "Stemonitis Storm", Effect Duration: 22
 2426	quadruple-unsweetened extra-diffused fuchsia fire flower	0		Effect: "Nature's Bounty", Effect Duration: 24
 2427	moist freezerburned ice cube	0		Effect: "Greasy Flavor", Effect Duration: 41
-2428	double-quantum squat purple fake blood	0		Effect: "Pronounced Potency", Effect Duration: 27
+2428	double-quantum purple squat fake blood	0		Effect: "Pronounced Potency", Effect Duration: 27
 2429	unsweetened irradiated Eau de Guaneau	0		Effect: "Fortunate Resolve", Effect Duration: 48
 2430	double-deionized bag of lard	0		Effect: "Bats in the Belfry", Effect Duration: 34
 2431	polarized electrified pickled skewed bottle of Mystic Shell	0		Effect: "The Moxious Madrigal", Effect Duration: 34
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	rotten bowl of Bounty-Os	3	crappy	
-2465	high-proof drinkable pulsating Oreille Divis&eacute;e brandy	8	good	
+2465	drinkable high-proof pulsating Oreille Divis&eacute;e brandy	8	good	
 2466	pompadour'd puppy	0		
 2467	wobbly suede shoes	0		Familiar Weight: +5
 2468	ghostly lime green callused fingerbone	0		
@@ -2489,22 +2489,22 @@
 2516	ghostly sinister Herculean wrench bracelet	0		Experience (Muscle): +1, Spell Damage: +10
 2517	yellow supercool chain necklace of the ox	0		Muscle: +20, Moxie Percent: +20
 2518	bouncing shellacked sawblade shield	0		Damage Reduction: 18
-2519	drinkable weak McMillicancuddy's Special Lager	2	good	
+2519	weak drinkable McMillicancuddy's Special Lager	2	good	
 2520	hand-crafted practically non-alcoholic ghostly melted Jell-o shot	1	EPIC	
 2521	drinkable boozy cruelty-free wine	5	good	
-2522	tolerable fortified thistle wine	5	good	
+2522	fortified tolerable thistle wine	5	good	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	flavorless special fish	4	decent	Effect: "Feline Ferocity", Effect Duration: 35
+2525	special flavorless fish	4	decent	Effect: "Feline Ferocity", Effect Duration: 35
 2526	flavorless fish casserole	3	decent	
 2527	moldy enchanted fish lasagna	3	crappy	Effect: "Lemony Goodness", Effect Duration: 5
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	fancy rotten huge mirror shaking gnatloaf	9	crappy	Effect: "Salsa Satanica", Effect Duration: 45
+2529	huge fancy rotten mirror shaking gnatloaf	9	crappy	Effect: "Salsa Satanica", Effect Duration: 45
 2530	adequate gnatloaf casserole	4	good	
 2531	huge bland gnat lasagna	7	decent	
 2532	pork	0		
 2533	bland pork chop sandwiches	3	decent	
-2534	rotten miniature tumbling lime green pork casserole	2	crappy	
+2534	miniature rotten lime green tumbling pork casserole	2	crappy	
 2535	toothsome snack-sized ghostly pork lasagna	2	awesome	
 2536	canopic jar	0		
 2537	spice	0		
@@ -2516,9 +2516,9 @@
 2543	tarnished tin magnolia	0		Effect: "Tiki Temerity", Effect Duration: 16, Last Available: "2007-05"
 2544	non-unsweetened mirror begpwnia	0		Effect: "Sensation", Effect Duration: 15, Last Available: "2007-05"
 2545	magnetized adjusted upsy daisy	0		Effect: "Abyssal Sweat", Effect Duration: 32, Last Available: "2007-05"
-2546	ionized colloidal jittery jittery olive half-orchid	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 60, Last Available: "2007-05"
+2546	ionized colloidal jittery olive jittery half-orchid	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 60, Last Available: "2007-05"
 2547	lard-coated vibrating tin star	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, Last Available: "2007-05"
-2548	yellow pulsating Jim Carey's Fonzie's outrageous sombrero	0		Experience (Moxie): +1, Monster Level: +25, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	yellow pulsating Jim Carey's Fonzie's outrageous sombrero	0		Experience (Moxie): +1, Monster Level: +25, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	padded grievous &quot;Humorous&quot; T-shirt	0		Weapon Damage Percent: +50, Damage Absorption: +20, Last Available: "2007-05"
 2550	blurry Peppercorns of Power	0		
 2551	tumbling vial of mojo	0		
@@ -2563,7 +2563,7 @@
 2590	tolerable distilled distilled fortified wine	5	good	
 2591	rotten tasty tart	4	crappy	
 2592	Knob Goblin lunchbox	0		
-2593	tasty small jittery Knob pasty	2	awesome	
+2593	small tasty jittery Knob pasty	2	awesome	
 2594	acceptable watered-down thermos full of Knob coffee	2	good	
 2595	diffused electrified unsweetened mirror Ben-Gal&trade; Balm	0		Effect: "Chief Executive Optimism", Effect Duration: 43
 2596	gray leathery cat skin	0		
@@ -2590,7 +2590,7 @@
 2617	boom	0		
 2618	steel-toed Iiti Kitty phone charm	0		Damage Reduction: 9, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	adequate thick unidentified jerky	5	good	
+2620	thick adequate unidentified jerky	5	good	
 2621	forbidden boxer's nasty rat mask	0		Muscle Percent: +10, Spell Damage Percent: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	forbidden beefcake's ratskin belt	0		Muscle: +25, Spell Damage Percent: +50, Single Equip
 2623	blurry rattail whip of the wise owl of courage	0		Mysticality: +20, Spooky Resistance: +3
@@ -2605,7 +2605,7 @@
 2632	modified energized mother's helper	0		Effect: "Uncanny Shot", Effect Duration: 14
 2633	narrow nippy pat-a-cake pendant of James Dean	0		Experience (Moxie): +3, Cold Damage: +10
 2634	mummy wrapping	0		
-2635	skewed narrow really thick bandage	0		
+2635	narrow skewed really thick bandage	0		
 2636	medical-grade mummy mask	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	Lo Pan's quilted gauze shorts	0		Damage Absorption: +40, Spell Critical Percent: +30, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
 2638	gauze hammock	0		
@@ -2620,20 +2620,20 @@
 2647	fetid feather	0		
 2648	flirtatious feather	0		
 2649	red squat lard-coated Lord Spookyraven's ear trumpet	0		Sleaze Spell Damage: +25, Single Equip
-2650	cyan shaking bottled pixie	0		Free Pull
+2650	shaking cyan bottled pixie	0		Free Pull
 2651	tumbling pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	toothsome S.T.L.T.	3	awesome	Last Available: "2007-06"
 2653	yummy narrow honey-dew	3	awesome	Last Available: "2007-06"
 2654	tolerable shaking Xanadian	4	good	Last Available: "2007-06"
 2655	corrupted pressed yellow bottle of absinthe	0		Effect: "substats.enh", Effect Duration: 60, Last Available: "2007-06"
 2656	bouncing greedy Sinatra's Drowsy Sword	0		Experience (Moxie): +5, Meat Drop: +20
-2657	miniature adequate escargotsicle	2	good	Last Available: "2007-06"
-2658	practically non-alcoholic perfectly mixed bottle of realpagne	1	EPIC	Last Available: "2007-06"
+2657	adequate miniature escargotsicle	2	good	Last Available: "2007-06"
+2658	perfectly mixed practically non-alcoholic bottle of realpagne	1	EPIC	Last Available: "2007-06"
 2659	hardened albatross necklace	0		Damage Reduction: 3, Single Equip, Last Available: "2007-06"
 2660	compressed tumbling not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	bad fancy flask of Amontillado	4	decent	Effect: "Lobos Fresh", Effect Duration: 35, Last Available: "2007-06"
-2662	wizardly ball mask	0		Mysticality: +25, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	blurry Rosewater's Can-Can skirt	0		Mysticality Percent: +30, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2661	fancy bad flask of Amontillado	4	decent	Effect: "Lobos Fresh", Effect Duration: 35, Last Available: "2007-06"
+2662	wizardly ball mask	0		Mysticality: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	blurry Rosewater's Can-Can skirt	0		Mysticality Percent: +30, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	cold-filtered upside-down upside-down sensitive poetry journal	0		Effect: "Disdain of the War Snapper", Effect Duration: 32, Last Available: "2007-06"
 2665	energized bottled inspiration	0		Effect: "Certainty", Effect Duration: 40, Last Available: "2007-06"
 2666	flattened triple-galvanized ghostly bellhop bell	0		Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2007-06"
@@ -2694,25 +2694,25 @@
 2721	gravedigger's therapeutic hand-carved staff of the glutton	0		Spooky Damage: +10, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7
 2722	clever stiffened stylish beefy Staff of the Greasefire	0		Muscle: +10, Moxie: +25, Damage Reduction: 1, Maximum MP: +20
 2723	reassuring Staff of the Grand Flamb&eacute; of doom of the detective	0		Spooky Spell Damage: +50, Spooky Resistance: +1, Item Drop: +20
-2724	stale bouncing spinning bowl of rye sprouts	3	decent	
+2724	stale spinning bouncing bowl of rye sprouts	3	decent	
 2725	stale cob of corn	4	decent	
-2726	rotten tiny juniper berries	1	crappy	
-2727	normal big fancy plum	5	good	Effect: "Influence of Sphere", Effect Duration: 30
+2726	tiny rotten juniper berries	1	crappy	
+2727	fancy big normal plum	5	good	Effect: "Influence of Sphere", Effect Duration: 30
 2728	flavorless wobbly pear	3	decent	
 2729	bland shaking peach	3	decent	
 2730	acceptable plum wine	4	good	
-2731	irresponsibly strong perfectly mixed squat huge shot of pear schnapps	9	EPIC	
+2731	perfectly mixed irresponsibly strong huge squat shot of pear schnapps	9	EPIC	
 2732	perfectly mixed irresponsibly strong bouncing shot of peach schnapps	9	EPIC	
 2733	miniature delicious bunch of square grapes	2	awesome	
 2734	moldy big upside-down brown sugar cane	5	crappy	
-2735	toothsome jittery bouncing olive sandwich of the gods	3	awesome	
+2735	toothsome bouncing olive jittery sandwich of the gods	3	awesome	
 2736	drinkable wobbly Pan-Dimensional Gargle Blaster	4	good	
 2737	twisted ghostly leopard-print barbell	1	decent	
 2738	pile of smoking rags	0		
 2739	colloidal panty raider camouflage	0		Effect: "Less Pervious", Effect Duration: 35
 2740	scandalous hale Staff of the Walk-In Freezer of wisdom	0		Mysticality: +15, Maximum HP: +20, Sleaze Damage: +5
 2741	spirit-forward artisanal boilermaker	5	EPIC	
-2742	spoiled massive wobbly steel lasagna	10	quest	
+2742	massive spoiled wobbly steel lasagna	10	quest	
 2743	tolerable cyan steel margarita	3	quest	
 2744	vaporized huge steel-scented air freshener	1		
 2745	colloidal denatured unsweetened gremlin mutagen	0		Effect: "Enraged", Effect Duration: 29
@@ -2743,7 +2743,7 @@
 2770	quantum lime green chunk of rock salt	0		Effect: "Egg-headedness", Effect Duration: 54
 2771	pressed shaking twirling handful of pine needles	0		Effect: "Old Time Hydration", Effect Duration: 13
 2772	steamy ruby	0		
-2773	pulsating squat skewed glacial sapphire	0		
+2773	skewed squat pulsating glacial sapphire	0		
 2774	unearthly onyx	0		
 2775	effluvious emerald	0		
 2776	tawdry amethyst	0		
@@ -2780,8 +2780,8 @@
 2807	quadruple-polymerized tumbling flask of hamethyst juice	0		Effect: "Innately Wise", Effect Duration: 53
 2808	electrified green flask of baconstone juice	0		Effect: "Make Meat FA$T!", Effect Duration: 54
 2809	cold-filtered alkaline wobbly flask of porquoise juice	0		Effect: "Metal Speed", Effect Duration: 65
-2810	double-dry upside-down twirling jug of hamethyst juice	0		Effect: "Muscularrr", Effect Duration: 11
-2811	colloidal teal squat jug of baconstone juice	0		Effect: "Carrion' On", Effect Duration: 24
+2810	double-dry twirling upside-down jug of hamethyst juice	0		Effect: "Muscularrr", Effect Duration: 11
+2811	colloidal squat teal jug of baconstone juice	0		Effect: "Carrion' On", Effect Duration: 24
 2812	dry corrupted jittery jug of porquoise juice	0		Effect: "Jammin'", Effect Duration: 64
 2813	narrow wicked beefy Beret	0		Muscle: +10, Spell Damage: +5, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	maroon Samson's cool Bludgeon of the pedagogue	0		Moxie: +5, Experience: +3, Experience (Muscle): +5
@@ -2789,9 +2789,9 @@
 2816	shaking vibrating Rosewater's Boxers of the brazier	0		Mysticality Percent: +30, Maximum MP Percent: +10, Hot Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep"
 2817	lime green twirling asbestos-lined hardy smartaleck's Brooch	0		Moxie Percent: +30, Maximum HP: +50, Hot Resistance: +5, Single Equip
 2818	Jeselnik's scandalous Bracelet of horror	0		Spooky Spell Damage: +25, Sleaze Damage: 30, Single Equip
-2819	smelly Grimacite gasmask of the cougar	0		Moxie: +20, Stench Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	smelly Grimacite gasmask of the cougar	0		Moxie: +20, Stench Spell Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	squat stiffened smooth Grimacite gat	0		Moxie: +15, Damage Reduction: 1, Last Available: "2008-11"
-2821	skewed wobbly sizzling healthy Grimacite gaiters	0		Maximum HP Percent: +20, Hot Damage: +10, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	skewed wobbly sizzling healthy Grimacite gaiters	0		Maximum HP Percent: +20, Hot Damage: +10, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	nasty boxer's Grimacite gauntlets	0		Muscle Percent: +10, Stench Damage: +5, Single Equip, Last Available: "2008-11"
 2823	blurry Oprah's Grimacite go-go boots of doom	0		Maximum MP Percent: +50, Spooky Spell Damage: +50, Single Equip, Last Available: "2008-11"
 2824	twirling savvy Grimacite girdle of bravery	0		Mysticality Percent: +20, Spooky Resistance: +5, Single Equip, Last Available: "2008-11"
@@ -2803,14 +2803,14 @@
 2830	yellow digital key lime	0		
 2831	star key lime	0		
 2832	delicious skewed digital key lime pie	4	awesome	
-2833	decent small star key lime pie	2	good	
+2833	small decent star key lime pie	2	good	
 2834	wool quilted groovy bottle-rocket crossbow	0		Moxie Percent: +10, Damage Absorption: +40, Cold Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	ghostly reassuring indie comic hipster glasses	0		Spooky Resistance: +1, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	frightening chaotic glowstick	0		Spell Critical Percent: +10, Spooky Damage: +5, Last Available: "2007-08"
 2839	Periodical Paintbrush of incineration	0		Hot Spell Damage: +50, Softcore Only
-2840	special spirit-forward bad twirling bottle of cooking sherry	5	decent	Effect: "Tomato Power", Effect Duration: 45
+2840	bad spirit-forward special twirling bottle of cooking sherry	5	decent	Effect: "Tomato Power", Effect Duration: 45
 2841	half-sized bland packet of ketchup	2	decent	
 2842	practically non-alcoholic hand-crafted narrow red accidental cider	1	EPIC	
 2843	spoiled dire fudgesicle	3	crappy	
@@ -2824,7 +2824,7 @@
 2851	adequate mirror fine aged cheddarwurst	3	good	
 2852	olive branch from the Great Tree	0		
 2853	tumbling Phil Bunion's axe	0		
-2854	upside-down squat bouquet of swamp roses	0		
+2854	squat upside-down bouquet of swamp roses	0		
 2855	hale huge mosquito proboscis of doom	0		Maximum HP: +20, Spooky Spell Damage: +50
 2856	frozen aerosolized Vulcanized swamp lolly	0		Effect: "Ancestral Disapproval", Effect Duration: 52
 2857	energized anodized seegar butt	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 40
@@ -2840,8 +2840,8 @@
 2867	Jeselnik's nippy dilapidated wizard hat	0		Cold Damage: +10, Sleaze Damage: +25, Familiar Effect: "cap 31"
 2868	non-enhanced pirate pamphlet	0		Effect: "Well-preserved", Effect Duration: 16
 2869	frozen warmed pirate brochure	0		Effect: "Badger Underfoot", Effect Duration: 42
-2870	triple-electrified triple-adjusted spinning cyan pirate tract	0		Effect: "Sharp Weapon", Effect Duration: 63
-2871	wobbly ghostly burnt flower	0		
+2870	triple-electrified triple-adjusted cyan spinning pirate tract	0		Effect: "Sharp Weapon", Effect Duration: 63
+2871	ghostly wobbly burnt flower	0		
 2872	skewed rock-hard plastic Naughty Sorceress of the overflowing toilet	0		Damage Reduction: 5, Stench Spell Damage: +50
 2873	extremely unsafe plastic Ed the Undying of mayonnaise	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +50
 2874	miser's plastic Lord Spookyraven of Leguizamo	0		Monster Level: +20, Meat Drop: +10
@@ -2927,10 +2927,10 @@
 2955	diet moldy shaking yam candy	1	crappy	
 2956	blurry cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	tiny adequate tube of cranberry Go-Goo	1	good	
+2958	adequate tiny tube of cranberry Go-Goo	1	good	
 2959	ruddy rum barrel charrrm bracelet	0		Maximum HP Percent: +40
 2960	stale small gray squat single-serving herbal stuffing	2	decent	
-2961	delicious miniature purple packet of tofurkey gravy	2	awesome	
+2961	miniature delicious purple packet of tofurkey gravy	2	awesome	
 2962	tasty thick tofurkey nugget	5	awesome	
 2963	blinking rigging shampoo	0		
 2964	shaking ball polish	0		
@@ -2945,10 +2945,10 @@
 2973	nasty grumpy man charrrm bracelet	0		Stench Damage: +5, Single Equip
 2974	blurry tarrrnish charrrm	0		
 2975	ribald shellacked tarrrnished charrrm bracelet	0		Damage Reduction: 7, Sleaze Damage: +10, Single Equip
-2976	aged weak wobbly fuchsia bilge wine	2	awesome	
+2976	weak aged wobbly fuchsia bilge wine	2	awesome	
 2977	mirror beefy witty rapier	0		Muscle: +10
 2978	Jeselnik's yohohoyo of the brute	0		Muscle Percent: +30, Sleaze Damage: +25
-2979	boiled shaking wobbly fish-liver oil	0		Effect: "Human-Hobo Hybrid", Effect Duration: 38
+2979	boiled wobbly shaking fish-liver oil	0		Effect: "Human-Hobo Hybrid", Effect Duration: 38
 2980	huge booty chest charrrm	0		
 2981	hardy booty chest charrrm bracelet	0		Maximum HP: +50, Single Equip
 2982	cannonball charrrm	0		
@@ -2962,7 +2962,7 @@
 2990	friendly manspreader's clingfilm cap	0		Monster Level: +10, Familiar Weight: +3, Familiar Effect: "1xVolley, cap 37"
 2991	flame-retardant clingfilm slippers	0		Hot Resistance: +1, Single Equip
 2992	clingfilm tangle	0		
-2993	adequate massive vinegar-soaked lemon slice	10	good	
+2993	massive adequate vinegar-soaked lemon slice	10	good	
 2994	double-corrupted magnetized blurry true grit	0		Effect: "Stogied", Effect Duration: 41
 2995	aromatic buoybottoms of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Stench Resistance: +1, Initiative: +100, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	grievous grungy flannel shirt	0		Weapon Damage Percent: +50
@@ -2987,17 +2987,17 @@
 3015	bouncing gilded key	0		
 3016	foot locker	0		
 3017	narrow ornate chest	0		
-3018	mirror lime green gilded chest	0		
+3018	lime green mirror gilded chest	0		
 3019	all-purpose cleaner	0		
 3020	handful of sawdust	0		
-3021	shaking pulsating stone triangle	0		
+3021	pulsating shaking stone triangle	0		
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
 3024	blurry stone pyramid	0		
 3025	spirit-forward tolerable corpse on the beach	5	good	
 3026	acceptable weak corpsetini	2	good	
 3027	acceptable pulsating corpsedriver	3	good	
-3028	boozy lousy Corpse Island iced tea	5	decent	
+3028	lousy boozy Corpse Island iced tea	5	decent	
 3029	bad practically non-alcoholic red-headed corpse	1	decent	
 3030	hand-crafted spinning kamicorpse-ee	3	EPIC	
 3031	hand-crafted weak corpsel	2	EPIC	
@@ -3006,17 +3006,17 @@
 3034	teal piece of thirteen	0		
 3035	decent pearl onion	4	good	
 3036	yummy gray sea biscuit	4	awesome	
-3037	practically non-alcoholic tolerable squat bottle of rum	1	good	
-3038	watered-down tolerable bottle of black-label rum	2	good	
+3037	tolerable practically non-alcoholic squat bottle of rum	1	good	
+3038	tolerable watered-down bottle of black-label rum	2	good	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	jittery joke scroll	0		
 3042	upside-down Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	adequate nanite-infested gingerbread bugbear	4	good	Last Available: "2007-12"
 3046	moldy mirror nanite-infested candy cane	4	crappy	Last Available: "2020-09"
-3047	miniature bland nanite-infested fruitcake	2	decent	Last Available: "2007-12"
+3047	bland miniature nanite-infested fruitcake	2	decent	Last Available: "2007-12"
 3048	delicious nanite-infested eggnog	4	awesome	Last Available: "2007-12"
 3049	shaking El Vibrato power sphere	0		
 3050	frosty eyepatch	0		Cold Spell Damage: +10, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3024,8 +3024,8 @@
 3052	prompt breeches	0		Adventures: +3, Familiar Effect: "stench atk, 1xPotato"
 3053	mood ring	0		Last Available: "2007-02"
 3054	denatured bouncing candy heart	0		Effect: "Cautious Prowl", Effect Duration: 12, Last Available: "2007-02"
-3055	pickled shaking blurry cymbal syrup	0		Free Pull, Effect: "No Worries", Effect Duration: 38, Last Available: "2007-02"
-3056	Da Vinci's metallic foil cat ears	0		Experience (Mysticality): +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3055	pickled blurry shaking cymbal syrup	0		Free Pull, Effect: "No Worries", Effect Duration: 38, Last Available: "2007-02"
+3056	Da Vinci's metallic foil cat ears	0		Experience (Mysticality): +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3034,7 +3034,7 @@
 3062	LED block	0		Last Available: "2007-12"
 3063	gyroscope	0		Last Available: "2010-12"
 3064	lime green twirling cyborg doll of extreme caution	0		Monster Level: -25, Last Available: "2007-12"
-3065	fuchsia tumbling buckyball	0		Last Available: "2010-12"
+3065	tumbling fuchsia buckyball	0		Last Available: "2010-12"
 3066	toy maglev monorail of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2007-12"
 3067	dollhive	0		Last Available: "2007-12"
 3068	toy deathbot	0		Last Available: "2007-12"
@@ -3043,7 +3043,7 @@
 3071	tumbling silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	ghostly huge carbonite visor	0		Last Available: "2007-12"
 3073	blue set of Unobtainium straps	0		Last Available: "2007-12"
-3074	blurry squat polymorphic fastening apparatus	0		Last Available: "2007-12"
+3074	squat blurry polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	spinning laser targeting chip	0		Last Available: "2007-12"
 3077	blinking hi-density nylocite leg armor	0		Last Available: "2007-12"
@@ -3051,15 +3051,15 @@
 3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	hale marionette collective	0		Maximum HP: +20, Last Available: "2007-12"
-3082	upside-down tumbling monomolecular yo-yo	0		Last Available: "2010-12"
+3082	tumbling upside-down monomolecular yo-yo	0		Last Available: "2010-12"
 3083	gray blob	0		Last Available: "2007-12"
 3084	miser's borg sock monkey	0		Meat Drop: +10, Last Available: "2007-12"
 3085	blurry extremely unsafe Socratic roboduck-on-a-string	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	inspector's perfumed biomechanical crimborg helmet	0		Stench Resistance: +5, Item Drop: +15, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	inspector's perfumed biomechanical crimborg helmet	0		Stench Resistance: +5, Item Drop: +15, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	hardened extremely unsafe C.B.F.G.	0		Weapon Damage Percent: +100, Damage Reduction: 3, Last Available: "2007-12"
-3090	jittery gray chilly ruddy biomechanical crimborg leg armor	0		Maximum HP Percent: +40, Cold Damage: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	jittery gray chilly ruddy biomechanical crimborg leg armor	0		Maximum HP Percent: +40, Cold Damage: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	oxidized activated cold-filtered vitachoconutriment capsule	0		Effect: "Oiled Skin", Effect Duration: 41, Last Available: "2007-12"
 3092	spinning handmade hobby horse of the brute	0		Muscle Percent: +30, Last Available: "2007-12"
 3093	blinking friendly ball-in-a-cup	0		Familiar Weight: +3, Last Available: "2007-12"
@@ -3078,7 +3078,7 @@
 3106	maroon upside-down beefcake's cyborg stompin' boot of Tarzan of Gandalf	0		Muscle: +25, Experience (Muscle): +3, Spell Critical Percent: +20, Single Equip, Last Available: "2007-12"
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
-3109	teal twirling Miniborg stomper	0		Last Available: "2007-12"
+3109	twirling teal Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	twirling huge Miniborg beeper	0		Last Available: "2007-12"
@@ -3086,12 +3086,12 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	lime green old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	upside-down divine blowout	0		Last Available: "2008-01"
 3121	blinking divine champagne popper	0		Last Available: "2008-01"
-3122	twirling mirror divine cracker	0		Last Available: "2008-01"
+3122	mirror twirling divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	galvanized vacuum-sealed fruitfilm	0		Effect: "Knightlife", Effect Duration: 18
 3125	warmed pressed jittery piece of after eight	0		Effect: "Slimily Strong", Effect Duration: 11
@@ -3144,12 +3144,12 @@
 3172	sage evil paper umbrella	0		Mysticality Percent: +10
 3173	wet evil vihuela	0		Effect: "Sweet Incentive", Effect Duration: 33
 3174	stale evil boring spaghetti	4	decent	
-3175	decent skewed blurry evil noodles	4	good	
+3175	decent blurry skewed evil noodles	4	good	
 3176	big yummy evil noodles	5	awesome	
 3177	rotten evil painful penne pasta	3	crappy	
 3178	flavorless 3vi1 pr0n m4nic0tti	3	decent	
-3179	snack-sized moldy evil ravioli della hippy	2	crappy	
-3180	small normal evil noodles	2	good	
+3179	moldy snack-sized evil ravioli della hippy	2	crappy	
+3180	normal small evil noodles	2	good	
 3181	colloidal quadruple-enhanced spinning evil potion of potency	0		Effect: "Alchemical, Brother", Effect Duration: 25
 3182	irradiated improved evil libation of liveliness	0		Effect: "Trash-Wrapped", Effect Duration: 38
 3183	boiled jittery evil tomato juice of powerful power	0		Effect: "Resilient Spirit", Effect Duration: 35
@@ -3158,8 +3158,8 @@
 3186	polymerized evil serum of sarcasm	0		Effect: "Celestial Vision", Effect Duration: 25
 3187	corrupted evil philter of phorce	0		Effect: "Scavengers Scavenging", Effect Duration: 18
 3188	fortified hand-crafted an evil sump'm sump'm	5	EPIC	
-3189	perfectly mixed teal blurry evil ducha de oro	3	EPIC	
-3190	perfectly mixed spirit-forward teal evil horizontal tango	5	EPIC	
+3189	perfectly mixed blurry teal evil ducha de oro	3	EPIC	
+3190	spirit-forward perfectly mixed teal evil horizontal tango	5	EPIC	
 3191	practically non-alcoholic tolerable evil roll in the hay	1	good	
 3192	squat naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3174,7 +3174,7 @@
 3202	zippy wizardly KoL Con IV Pole of mayonnaise	0		Mysticality: +25, Sleaze Spell Damage: +50, Initiative: +20, Last Available: "2007-09"
 3203	dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
-3205	jittery purple dwarvish war mattock	0		
+3205	purple jittery dwarvish war mattock	0		
 3206	olive dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	ghostly small laminated card	0		
@@ -3183,7 +3183,7 @@
 3211	red unlarge laminated card	0		
 3212	maroon dwarvish document	0		
 3213	dwarvish paper	0		
-3214	wobbly skewed dwarvish parchment	0		
+3214	skewed wobbly dwarvish parchment	0		
 3215	blurry overcharged El Vibrato power sphere	0		
 3216	Fly-By-Knight Heraldry form	0		Free Pull
 3217	El Vibrato Megadrone	0		
@@ -3194,9 +3194,9 @@
 3222	shaking electrified boxer's gatorskin umbrella	0		Muscle Percent: +10, MP Regen Min: 3, MP Regen Max: 5
 3223	sewer nuggets	0		
 3224	shaking sewer wad	0		
-3225	acceptable huge skewed blurry bottle of sewage schnapps	3	good	
+3225	acceptable blurry skewed huge bottle of sewage schnapps	3	good	
 3226	special acceptable high-proof bottle of Ooze-O	7	good	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 50
-3227	decent super-sized jittery C.H.U.M. chum	5	good	
+3227	super-sized decent jittery C.H.U.M. chum	5	good	
 3228	spoiled unfortunate dumplings	3	crappy	
 3229	decaying goldfish liver	0		
 3230	vacuum-sealed pickled oil of oiliness	0		Effect: "Halloweeny", Effect Duration: 55
@@ -3232,7 +3232,7 @@
 3260	wicked Chester's moustache of the scaredy-cat of terror	0		Spell Damage: +5, Monster Level: -15, Spooky Spell Damage: +10, Class: "Disco Bandit", Single Equip
 3261	huge chaotic Herculean Chester's bag of candy	0		Experience (Muscle): +1, Spell Critical Percent: +10, Class: "Disco Bandit"
 3262	razor-sharp Chester's cutoffs of the early riser	0		Weapon Damage Percent: +25, Adventures: +7, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	green bag of Saccharine Maple saplings	0		
@@ -3262,7 +3262,7 @@
 3290	twirling abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
-3293	blinking maroon untamable turtle	0		
+3293	maroon blinking untamable turtle	0		
 3294	spinning spinning macaroni duck	0		
 3295	upside-down ghostly friendly cheez blob	0		
 3296	unusual disco ball	0		
@@ -3293,10 +3293,10 @@
 3321	packet of mayfly bait	0		Last Available: "2008-05"
 3322	cyan executive miser's mayfly bait necklace	0		Meat Drop: 50, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
-3324	ghostly gray Frosty's frosty mug	0		
+3324	gray ghostly Frosty's frosty mug	0		
 3325	acceptable fancy jar of fermented pickle juice	3	good	Effect: "Sparkly!", Effect Duration: 10
 3326	vaporized ghostly fuchsia voodoo snuff	1	crappy	Effect: "[1701]Hip to the Jive", Effect Duration: 30
-3327	huge moldy purple extra-greasy slider	8	crappy	
+3327	moldy huge purple extra-greasy slider	8	crappy	
 3328	mirror crumpled felt fedora of Gandalf of Leguizamo	0		Spell Critical Percent: +20, Monster Level: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	flame-wreathed medical-grade battered top-hat	0		Hot Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	lime green shapeless wide-brimmed hat of Leguizamo of the early riser	0		Monster Level: +20, Adventures: +7, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3323,7 +3323,7 @@
 3351	upside-down llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	magnetized boiled llama lama gong	0		Effect: "Feline Ferocity", Effect Duration: 45, Last Available: "2008-06"
-3354	snack-sized normal banana-frosted king cake	2	good	Last Available: "2008-08"
+3354	normal snack-sized banana-frosted king cake	2	good	Last Available: "2008-08"
 3355	cool brown plastic baby	0		Moxie: +5, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	upside-down shimmering moth	0		Last Available: "2008-06"
@@ -3333,9 +3333,9 @@
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	flavorless mole mol&eacute;	4	decent	Last Available: "2008-06"
-3364	watered-down mediocre Morlock's Mark Bourbon	2	decent	Last Available: "2008-06"
+3364	mediocre watered-down Morlock's Mark Bourbon	2	decent	Last Available: "2008-06"
 3365	quantum concentrated wet Climate Colada	0		Effect: "Astral Shell", Effect Duration: 47, Last Available: "2008-06"
-3366	corrupted vacuum-sealed blurry pulsating digital underground potion	0		Effect: "Partially Ghosted", Effect Duration: 52, Last Available: "2008-06"
+3366	corrupted vacuum-sealed pulsating blurry digital underground potion	0		Effect: "Partially Ghosted", Effect Duration: 52, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	modified ghostly glimmering roc feather	1	decent	Effect: "Slimily Strong", Effect Duration: 50, Last Available: "2008-06"
 3369	denatured wobbly glimmering phoenix feather	1		Last Available: "2008-06"
@@ -3390,7 +3390,7 @@
 3422	triple-denatured galvanized pulsating sterno-flavored Hob-O	0		Effect: "You're Not Cooking", Effect Duration: 52
 3423	adjusted frostbite-flavored Hob-O	0		Effect: "Cold Hard Skin", Effect Duration: 41
 3424	quantum altered aerosolized fry-oil-flavored Hob-O	0		Effect: "Texas Elegance", Effect Duration: 33
-3425	electrified blurry lime green garbage-juice-flavored Hob-O	0		Effect: "Bat Attitude", Effect Duration: 31
+3425	electrified lime green blurry garbage-juice-flavored Hob-O	0		Effect: "Bat Attitude", Effect Duration: 31
 3426	pickled bouncing strawberry-flavored Hob-O	0		Effect: "Woad Warrior", Effect Duration: 30
 3427	roll of Hob-Os	0		
 3428	quadruple-energized green jittery Everlasting Deckswabber	0		Effect: "Creepypasted", Effect Duration: 44
@@ -3409,7 +3409,7 @@
 3442	skewed savvy rainbow crossbow	0		Mysticality Percent: +20, Last Available: "2008-07"
 3443	red mirror kitten	0		
 3444	deadly webbed comic mask	0		Weapon Damage: +5, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
-3445	purple narrow Junior Adventurer's kit	0		
+3445	narrow purple Junior Adventurer's kit	0		
 3446	narrow groovy prism necklace	0		Single Equip
 3447	perfumed rosy-cheeked six-rainbow shield	0		Maximum HP Percent: +30, Stench Resistance: +5, Damage Reduction: 12, Last Available: "2008-07"
 3448	rainbow bomb	0		Last Available: "2008-07"
@@ -3424,16 +3424,16 @@
 3457	stanky Junior Adventurer's merit badge	0		Stench Spell Damage: +25
 3458	polymerized super-pressed squat STYX deodorant body spray	0		Effect: "Wasabi With You", Effect Duration: 48
 3459	acceptable irresponsibly strong twirling white-label gin	8	good	
-3460	small adequate tin rations	2	good	
+3460	adequate small tin rations	2	good	
 3461	fuchsia twirling haiku challenge map	0		
 3462	skewed terrible poem	0		
-3463	lousy enchanted squat bottle of sake	4	decent	Effect: "Elemental Flavor", Effect Duration: 10
+3463	enchanted lousy squat bottle of sake	4	decent	Effect: "Elemental Flavor", Effect Duration: 10
 3464	blue sage round pebble	0		Mysticality Percent: +10
 3465	snack-sized tasty shaking Bash-&#332;s cereal	2	awesome	Wiki Name: "Bash-Os cereal"
 3466	maroon Lo Pan's crafty strapping haiku katana	0		Muscle: +5, Maximum MP: +10, Spell Critical Percent: +30, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	pulsating bargain flash powder	0		
 3468	Jim Carey's plastic baby	0		Monster Level: +25, Single Equip, Last Available: "2008-12"
-3469	moldy miniature blueberry-frosted king cake	2	crappy	Last Available: "2008-12"
+3469	miniature moldy blueberry-frosted king cake	2	crappy	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	lime green damp boot	0		
 3472	forbidden arcane researcher's Seasonal Beret of the glutton	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Food Drop: +100, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3462,16 +3462,16 @@
 3495	frozen enhanced nitrogenated sea salt crystal	0		Effect: "Carrion' On", Effect Duration: 19
 3496	electrified bazookafish bubble gum	0		Effect: "Greasy Peasy", Effect Duration: 32
 3497	triple-distilled perfectly mixed olive bottle of Pete's Sake	6	EPIC	
-3498	olive invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	bouncing witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	olive invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	bouncing witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	toothsome canap&eacute;s	4	awesome	
 3502	dehydrated spinning thermos of brew	1	good	Effect: "Halloweeny", Effect Duration: 10, Last Available: "2011-12"
 3503	drinkable boozy glass of brandy	5	good	Last Available: "2011-12"
 3504	blinking French slippers	0		
 3505	stiffened LWA ring	0		Damage Reduction: 1
 3506	wobbly LARP membership card	0		Last Available: "2008-10"
-3507	ghostly Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	ghostly Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	rosewater-soaked scratch 'n' sniff sword	0		Stench Resistance: +3, Last Available: "2008-11"
 3509	ghostly scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3498,7 +3498,7 @@
 3531	gray rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	pulsating cactus monocle	0		Familiar Weight: +5
-3534	twirling bouncing Jawmaster 2000&trade;	0		Familiar Weight: +5
+3534	bouncing twirling Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	teal plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	shaking plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
@@ -3510,8 +3510,8 @@
 3543	blurry twirling prompt thinker's depleted Grimacite gravy boat	0		Mysticality: +10, Adventures: +3, Last Available: "2011-12"
 3544	gravedigger's depleted Grimacite weightlifting belt of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Single Equip, Last Available: "2011-12"
 3545	personal trainer's educational depleted Grimacite grappling hook	0		Experience: +1, Experience Percent (Muscle): +10, Single Equip, Last Available: "2011-12"
-3546	clever arcane researcher's depleted Grimacite ninja mask	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	blinking spinning green friendly razor-sharp depleted Grimacite shinguards	0		Weapon Damage Percent: +25, Familiar Weight: +3, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	clever arcane researcher's depleted Grimacite ninja mask	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	blinking spinning green friendly razor-sharp depleted Grimacite shinguards	0		Weapon Damage Percent: +25, Familiar Weight: +3, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	up-at-dawn stiffened depleted Grimacite astrolabe	0		Damage Reduction: 1, Adventures: +5, Single Equip, Last Available: "2011-12"
 3549	lion tamer's vibrating KoL Con Cinco Pi&ntilde;ata Bat	0		Maximum MP Percent: +10, Experience (familiar): +2, Softcore Only, Last Available: "2008-09"
 3550	Da Vinci's propeller beanie	0		Experience (Mysticality): +5, Familiar Effect: "atk, cap 7"
@@ -3520,8 +3520,8 @@
 3553	soggy seed packet	0		
 3554	glob of slime	0		
 3555	spoiled blurry sea carrot	3	crappy	
-3556	snack-sized flavorless sea cucumber	2	decent	
-3557	flavorless special sea avocado	3	decent	Effect: "Pisces in the Skyces", Effect Duration: 10
+3556	flavorless snack-sized sea cucumber	2	decent	
+3557	special flavorless sea avocado	3	decent	Effect: "Pisces in the Skyces", Effect Duration: 10
 3558	thick decent sea lychee	5	good	
 3559	adequate narrow sea tangelo	4	good	
 3560	decent sea honeydew	4	good	
@@ -3530,7 +3530,7 @@
 3563	magnetized nitrogenated ghostly pressurized potion of pulchritude	0		Effect: "Danish Cunning", Effect Duration: 23
 3564	smooth high-proof narrow berry-infused sake	6	awesome	
 3565	hand-crafted citrus-infused sake	3	EPIC	
-3566	smooth pulsating blinking melon-infused sake	4	awesome	
+3566	smooth blinking pulsating melon-infused sake	4	awesome	
 3567	slab of sponge	0		
 3568	savvy cool sponge helmet of wisdom	0		Mysticality: +15, Moxie: +5, Mysticality Percent: +20, Familiar Effect: "atk, 1xFairy"
 3569	wool gravedigger's experienced spongy shield	0		Experience: +2, Spooky Damage: +10, Cold Resistance: +1, Damage Reduction: 14
@@ -3539,7 +3539,7 @@
 3572	baby cuddlefish	0		
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	fuchsia slimy chest	0		
-3575	bouncing blinking sand dollar	0		
+3575	blinking bouncing sand dollar	0		
 3576	flytrap bezoar	0		
 3577	tumbling bezoar ring	0		
 3578	blue candy cornucopia	0		Free Pull, Last Available: "2011-12"
@@ -3547,13 +3547,13 @@
 3580	spinning wriggling flytrap pellet	0		
 3581	blue sushi-rolling mat	0		
 3582	normal rice	4	good	
-3584	huge adequate irradiated candy cane	7	good	Last Available: "2008-12"
-3585	spoiled jumbo skewed gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
+3584	adequate huge irradiated candy cane	7	good	Last Available: "2008-12"
+3585	jumbo spoiled skewed gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
 3586	perfectly mixed huge oozenog	3	EPIC	Last Available: "2008-12"
 3587	magnetized non-nitrogenated sugar plum	0		Effect: "There Is A Spoon", Effect Duration: 57, Last Available: "2008-12"
 3588	dry chilled skewed sugar banana	0		Effect: "meat.enh", Effect Duration: 33, Last Available: "2008-12"
 3589	Vulcanized jittery sugar lime	0		Effect: "Dancing Prowess", Effect Duration: 35, Last Available: "2008-12"
-3590	polymerized olive shaking sugar cherry	0		Effect: "Yuletide Industry", Effect Duration: 64, Last Available: "2008-12"
+3590	polymerized shaking olive sugar cherry	0		Effect: "Yuletide Industry", Effect Duration: 64, Last Available: "2008-12"
 3591	asbestos-lined Tesla Mer-kin hookspear	0		Hot Resistance: +5, MP Regen Min: 7, MP Regen Max: 10
 3592	shaking Mer-kin takebag	0		Item Drop: +5
 3593	Mer-kin thingpouch	0		
@@ -3581,15 +3581,15 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	mirror pulsing flesh	0		Last Available: "2008-12"
 3617	dry wet unstable DNA	0		Effect: "A Taste of Rainbow", Effect Duration: 43, Last Available: "2008-12"
-3618	huge huge pulsating The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	pulsating huge huge The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	blurry mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	parasitic claw of the dark arts	0		Spell Damage Percent: +100, Last Available: "2008-12"
-3625	deadly parasitic tentacles	0		Weapon Damage: +5, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	skewed parasitic headgnawer of courage	0		Spooky Resistance: +3, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	deadly parasitic tentacles	0		Weapon Damage: +5, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	skewed parasitic headgnawer of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	Rosewater's parasitic strangleworm	0		Mysticality Percent: +30, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	twirling radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	squat foul-smelling elven socks of the cougar	0		Moxie: +20, Stench Damage: +10, Last Available: "2008-12"
 3634	Jim Carey's healthy elven gloves	0		Maximum HP Percent: +20, Monster Level: +25, Last Available: "2008-12"
-3635	chilly occult festive holiday hat	0		Spell Damage Percent: +25, Cold Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	chilly occult festive holiday hat	0		Spell Damage Percent: +25, Cold Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	rock-hard patent shoes of the cheetah	0		Damage Reduction: 5, Initiative: +60, Last Available: "2008-12"
 3637	wobbly vibrating forbidden gray bow tie	0		Spell Damage Percent: +50, Maximum MP Percent: +10, Last Available: "2008-12"
 3638	zippy penguin thesaurus of horror	0		Spooky Spell Damage: +25, Initiative: +20, Last Available: "2008-12"
@@ -3608,13 +3608,13 @@
 3642	shaking dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	narrow arcane researcher's depleted Grimacite kneecapping stick	0		Experience Percent (Mysticality): +10, Last Available: "2007-06"
-3645	practically non-alcoholic tolerable canteen of wine	1	good	Last Available: "2008-12"
-3646	half-sized stale elven <i>limbos</i> gingerbread	2	decent	Last Available: "2008-12"
+3645	tolerable practically non-alcoholic canteen of wine	1	good	Last Available: "2008-12"
+3646	stale half-sized elven <i>limbos</i> gingerbread	2	decent	Last Available: "2008-12"
 3647	jittery elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	pulsating map to Madness Reef	0		
 3650	moldy gigantic toast with jam	10	crappy	Last Available: "2008-12"
-3651	shaking antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	shaking antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	drinkable elven moonshine	3	good	Last Available: "2008-12"
 3653	flavorless wobbly knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	fireproof groovy psycho sweater	0		Moxie Percent: +10, Hot Resistance: +3, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	lime green plastic strand of DNA of extreme caution	0		Monster Level: -25, Last Available: "2008-12"
 3660	supercool plastic chunk of depleted Grimacite	0		Moxie Percent: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	aromatic Putty mitre	0		Stench Resistance: +1, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	huge flame-retardant curative Putty leotard	0		Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	aromatic Putty mitre	0		Stench Resistance: +1, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	huge flame-retardant curative Putty leotard	0		Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	Sinatra's Putty ball	0		Experience (Moxie): +5, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	lightning-fast foul-smelling educational Putty snake	0		Experience: +1, Stench Damage: +10, Initiative: +40, Softcore Only, Last Available: "2009-01"
@@ -3655,7 +3655,7 @@
 3689	huge moldy tempura broccoli	7	crappy	
 3690	small bland tempura cauliflower	2	decent	
 3691	super-sized decent skewed sea blueberry	5	good	
-3692	miniature moldy sea persimmon	2	crappy	
+3692	moldy miniature sea persimmon	2	crappy	
 3693	magnetized aerosolized pressurized potion of perception	0		Effect: "Stemonitis Storm", Effect Duration: 68
 3694	wet pulsating pressurized potion of proficiency	0		Effect: "Neutered Nostrils", Effect Duration: 26
 3695	tumbling Mer-kin digpick of mayonnaise	0		Sleaze Spell Damage: +50
@@ -3708,13 +3708,13 @@
 3742	modified polarized jittery jellyfish gel	0		Effect: "Whippin' It Good", Effect Duration: 19
 3743	unstable quark	0		
 3744	software glitch	0		
-3745	ghostly huge fumble formula	0		Recipe: "concoction of clumsiness"
+3745	huge ghostly fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	unsweetened concoction of clumsiness	0		Effect: "Swimming Head", Effect Duration: 22
 3750	vampire pearl earring of doom	0		Spooky Spell Damage: +50, Single Equip
 3751	adequate chocolate chip brownies	4	good	
-3753	cyan wobbly Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	wobbly cyan Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	triple-denatured extra-polymerized skewed love song of vague ambiguity	0		Effect: "Dweeby", Effect Duration: 30, Last Available: "2009-02"
 3755	polarized galvanized love song of smoldering passion	0		Effect: "Rootin' Around", Effect Duration: 62, Last Available: "2009-02"
 3756	flattened teal love song of icy revenge	0		Effect: "Healthy Red Glow", Effect Duration: 58, Last Available: "2009-02"
@@ -3724,15 +3724,15 @@
 3760	polymerized breath mint	0		Effect: "Certainty", Effect Duration: 42
 3761	pulsating greasy vampire pearl ring	0		Sleaze Spell Damage: +10, Single Equip
 3762	beefy vampire pearl necklace	0		Muscle: +10, Single Equip
-3763	weak acceptable slug of vodka	2	good	
-3764	triple-distilled lousy huge pulsating slug of rum	10	decent	
+3763	acceptable weak slug of vodka	2	good	
+3764	triple-distilled lousy pulsating huge slug of rum	10	decent	
 3765	drinkable slug of shochu	3	good	
 3766	mediocre blinking screwdiver	3	decent	
 3767	acceptable dew yoana lei	3	good	
 3768	tolerable lychee chuhai	3	good	
 3769	bad salacious screwdiver	3	decent	
 3770	hand-crafted twirling dew yoana salacious lei	4	EPIC	
-3771	practically non-alcoholic hand-crafted squat salacious lychee chuhai	1	super ultra mega turbo EPIC	
+3771	hand-crafted practically non-alcoholic squat salacious lychee chuhai	1	super ultra mega turbo EPIC	
 3772	acceptable blurry Alewife&trade; Ale	4	good	
 3773	seaode	0		
 3774	narrow map to the Dive Bar	0		
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	wobbly crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	wobbly crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	veiny occult experienced Mer-kin roundshield	0		Experience: +2, Spell Damage Percent: +25, Maximum HP: +10, Damage Reduction: 14
 3804	sizzling Mer-kin breastplate of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +10
 3805	sizzling stiffened Mer-kin sneakmask	0		Damage Reduction: 1, Hot Damage: +10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,24 +3768,24 @@
 3813	deadly plastic baby	0		Weapon Damage: +5, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	flavorless snack-sized blue sea radish	2	decent	
+3817	snack-sized flavorless blue sea radish	2	decent	
 3818	wobbly avaricious razor-sharp Rosewater's halibut	0		Mysticality Percent: +30, Weapon Damage Percent: +25, Meat Drop: +30
 3819	eel sauce	0		
 3820	Rosewater's water-polo mitt	0		Mysticality Percent: +30, Single Equip
 3821	aerosolized galvanized syringe	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 53
 3822	jittery bouncing wand	0		Familiar Effect: "fishy spells"
-3823	anodized anodized squat fuchsia spinning wad of cotton	0		Effect: "The Magic of LOV", Effect Duration: 27
+3823	anodized anodized fuchsia squat spinning wad of cotton	0		Effect: "The Magic of LOV", Effect Duration: 27
 3824	Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	red Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	flavorless tiny tempura radish	1	decent	
+3829	tiny flavorless tempura radish	1	decent	
 3830	arcane researcher's water-polo cap	0		Experience Percent (Mysticality): +10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	artisanal Typical Tavern swill	3	EPIC	
-3832	special mediocre ghostly teal tropical swill	3	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 5
+3832	mediocre special ghostly teal tropical swill	3	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 5
 3833	delicious jittery fruity girl swill	4	awesome	
-3834	perfectly mixed special blended swill	3	EPIC	Effect: "Dancing Prowess", Effect Duration: 50
+3834	special perfectly mixed blended swill	3	EPIC	Effect: "Dancing Prowess", Effect Duration: 50
 3835	ghostly costume wardrobe	0		Softcore Only
 3836	MacGyver's experienced Elvish sunglasses of Leguizamo of chilblains	0		Experience: +2, Maximum MP: +100, Monster Level: +20, Cold Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	blinking stiffened anniversary safety glass vest	0		Damage Reduction: 1
@@ -3844,11 +3844,11 @@
 3890	double-altered deionized vial of violet slime	0		Effect: "Perception", Effect Duration: 45
 3891	triple-energized vial of vermilion slime	0		Effect: "Hangdog", Effect Duration: 35
 3892	galvanized extra-liquefied blinking vial of amber slime	0		Effect: "Slimed Stomach", Effect Duration: 52
-3893	magnetized colloidal mirror teal pulsating vial of chartreuse slime	0		Effect: "Bright!", Effect Duration: 38
+3893	magnetized colloidal pulsating teal mirror vial of chartreuse slime	0		Effect: "Bright!", Effect Duration: 38
 3894	non-nitrogenated wet shaking vial of teal slime	0		Effect: "Crusty Head", Effect Duration: 31
 3895	unsweetened double-activated wobbly lime green vial of indigo slime	0		Effect: "Wolf's Bane", Effect Duration: 31
 3896	frozen green vial of slime	0		Effect: "Lubed", Effect Duration: 32
-3897	energized tumbling huge teal vial of brown slime	0		Effect: "Comprehensively Nourished", Effect Duration: 27
+3897	energized huge teal tumbling vial of brown slime	0		Effect: "Comprehensively Nourished", Effect Duration: 27
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
@@ -3856,7 +3856,7 @@
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	wobbly figurine of an seal	0		Class: "Seal Clubber"
 3906	pulsating figurine of a sleek seal	0		Class: "Seal Clubber"
-3907	tumbling red figurine of a shadowy seal	0		Class: "Seal Clubber"
+3907	red tumbling figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	skewed figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	wobbly figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
@@ -3918,7 +3918,7 @@
 3966	squat bouncing Van der Graaf rosy-cheeked personal trainer's hot-ass club	0		Experience Percent (Muscle): +10, Maximum HP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Class: "Seal Clubber"
 3967	spinning weightlifter's frigid-ass club of Tarzan of the blizzard	0		Muscle: +15, Experience (Muscle): +3, Cold Spell Damage: +25, Class: "Seal Clubber"
 3968	supercharged arcane researcher's creepy-ass club of the sewer	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, Stench Damage: +25, Class: "Seal Clubber"
-3969	super-polymerized twirling gray sizzling seal fat	0		Effect: "Expert Vacationer", Effect Duration: 64
+3969	super-polymerized gray twirling sizzling seal fat	0		Effect: "Expert Vacationer", Effect Duration: 64
 3970	nippy studded Abyssal ember	0		Damage Absorption: +80, Cold Damage: +10, Class: "Seal Clubber"
 3971	frozen shaking frost-rimed seal hide	0		Effect: "Eyes of the Dragon", Effect Duration: 16
 3972	electrified Sinatra's seal spine	0		Experience (Moxie): +5, MP Regen Min: 3, MP Regen Max: 5, Class: "Seal Clubber"
@@ -3934,7 +3934,7 @@
 3982	aromatic torquoise ring of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Single Equip
 3983	dueling turtle	0		
 3984	ghostly electrified therapeutic dueling banjo	0		MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7
-3985	skewed ghostly soup turtle	0		
+3985	ghostly skewed soup turtle	0		
 3986	narrow samurai turtle	0		
 3987	Temple Grandin's hale samurai turtle helmet	0		Maximum HP: +20, Familiar Weight: +7, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	maroon turtle shell	0		
@@ -3950,7 +3950,7 @@
 3998	metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	ghostly string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	dehydrated tumbling red skewed agua de vida	1	awesome	Last Available: "2009-06"
+4001	dehydrated red tumbling skewed agua de vida	1	awesome	Last Available: "2009-06"
 4002	tortoboggan shield of dire peril of the sewer	0		Weapon Damage: +20, Stench Damage: +25, Damage Reduction: 6
 4003	wobbly bottle of moontan lotion	0		
 4004	studded soup-chucks	0		Damage Absorption: +80
@@ -3983,27 +3983,27 @@
 4031	squat twirling memory of a stone block	0		Last Available: "2009-06"
 4032	mirror memory of half a stone circle	0		Last Available: "2009-06"
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
-4034	twirling ghostly memory of an iron key	0		Last Available: "2009-06"
+4034	ghostly twirling memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	spinning caustic slime nodule	0		
 4037	miniature decent slimy sweetbreads	2	good	
 4038	perfectly mixed slimy fermented bile bladder	3	EPIC	
 4039	diluted slimy alveolus	1		
 4040	huge memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	hardened groovy pig-iron helm	0		Moxie Percent: +10, Damage Reduction: 3, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	Annie Oakley's beefy pig-iron shinguards	0		Muscle: +10, Critical Hit Percent: +20, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	hardened groovy pig-iron helm	0		Moxie Percent: +10, Damage Reduction: 3, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	Annie Oakley's beefy pig-iron shinguards	0		Muscle: +10, Critical Hit Percent: +20, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	energetic pig-iron bracers of bravery	0		Maximum MP Percent: +20, Spooky Resistance: +5, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	wumpus-hair whip of Flo-Jo	0		Initiative: +100, Last Available: "2009-06"
-4048	shaking mansplainer's deadly smartaleck's wumpus-hair wig	0		Moxie Percent: +30, Weapon Damage: +5, Monster Level: +15, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	flame-retardant wool wumpus-hair loincloth of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +1, Hot Resistance: +1, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	shaking mansplainer's deadly smartaleck's wumpus-hair wig	0		Moxie Percent: +30, Weapon Damage: +5, Monster Level: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	flame-retardant wool wumpus-hair loincloth of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +1, Hot Resistance: +1, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	stiffened dance instructor's wumpus-hair sweater	0		Experience Percent (Moxie): +10, Damage Reduction: 1, Last Available: "2009-06"
 4051	supercharged ring of teleportation	0		Maximum MP Percent: +30, Single Equip
 4052	pulsating glass of baboon milk	1	awesome	Last Available: "2009-06"
 4053	wobbly olive banana milkshake	1	decent	Last Available: "2009-06"
-4054	smooth weak bouncing White Hyborian	2	awesome	Last Available: "2009-06"
+4054	weak smooth bouncing White Hyborian	2	awesome	Last Available: "2009-06"
 4055	goblin hunting spear of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2009-06"
 4056	smelly Newton's goblin autoblowgun	0		Experience (Mysticality): +3, Stench Spell Damage: +10, Last Available: "2009-06"
 4057	smelly tribal beads	0		Stench Spell Damage: +10, Last Available: "2009-06"
@@ -4040,7 +4040,7 @@
 4088	X-37 gun	0		Last Available: "2009-06"
 4089	triple-boiled double-Vulcanized neurostim pill	0		Effect: "Human-Slime Hybrid", Effect Duration: 21, Last Available: "2009-06"
 4090	cold-filtered irradiated super-quantum physiostim pill	0		Effect: "Elemental Mastery", Effect Duration: 33, Last Available: "2009-06"
-4091	ghostly bouncing slimy cyst	0		
+4091	bouncing ghostly slimy cyst	0		
 4092	blue small slimy cyst	0		
 4093	medium slimy cyst	0		
 4094	slimy cyst	0		
@@ -4084,13 +4084,13 @@
 4132	drinkable sham champagne	3	good	Last Available: "2009-06"
 4133	boiled tempura air	0		Effect: "Sausage Festive", Effect Duration: 12
 4134	deionized spinning pressurized potion of pneumaticity	0		Effect: "Cool, Catlike", Effect Duration: 66
-4135	cyan shaking moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
+4135	shaking cyan moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	greasy electrified Fonzie's experienced Bag o' Tricks	0		Experience: +2, Experience (Moxie): +1, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	bouncing slime stack	0		
 4138	blue a rumpled paper strip	0		
 4139	a creased paper strip	0		
 4140	a folded paper strip	0		
-4141	olive squat a crinkled paper strip	0		
+4141	squat olive a crinkled paper strip	0		
 4142	bouncing a crumpled paper strip	0		
 4143	a ragged paper strip	0		
 4144	a ripped paper strip	0		
@@ -4111,9 +4111,9 @@
 4159	rock lobster	0		Last Available: "2009-09"
 4160	aged wobbly pebblebr&auml;u	4	awesome	Last Available: "2009-09"
 4161	moldy fuchsia pulsating rocky road ice cream	4	crappy	Last Available: "2009-09"
-4162	tumbling skewed extra-strength rubber bands	0		Familiar Weight: +5
-4163	altered green squat children of the candy corn	0		Effect: "Ooh, Bitter!", Effect Duration: 66
-4164	flattened blue skewed Good 'n' Slimy	0		Effect: "Sweet and Green", Effect Duration: 32
+4162	skewed tumbling extra-strength rubber bands	0		Familiar Weight: +5
+4163	altered squat green children of the candy corn	0		Effect: "Ooh, Bitter!", Effect Duration: 66
+4164	flattened skewed blue Good 'n' Slimy	0		Effect: "Sweet and Green", Effect Duration: 32
 4165	huge rock-hard razor-sharp Staff of the Soupbone of the overflowing toilet	0		Weapon Damage Percent: +25, Damage Reduction: 5, Stench Spell Damage: +50
 4166	sage Voluminous Radio Pants	0		Mysticality Percent: +10, Familiar Effect: "2xGhoul, cap 37"
 4167	shellacked Voluminous Radio Hat	0		Damage Reduction: 7, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4124,14 +4124,14 @@
 4172	up-at-dawn rock helmet	0		Adventures: +5, Familiar Effect: "1xGhuol, cap 25"
 4173	knitted rock pants	0		Cold Resistance: +3, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
 4174	blurry greasy rock necklace	0		Sleaze Spell Damage: +10, Single Equip
-4175	wobbly skewed gray spaghetti cult robe	0		
+4175	skewed gray wobbly spaghetti cult robe	0		
 4176	sugar sheet	0		Last Available: "2009-09"
 4177	green tumbling Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	purple ruddy sugar shotgun	0		Maximum HP Percent: +40, Last Available: "2009-09"
 4179	flame-wreathed sugar shillelagh	0		Hot Spell Damage: +10, Last Available: "2009-09"
 4180	prompt sugar shank	0		Adventures: +3, Last Available: "2009-09"
-4181	gravedigger's personal trainer's sugar chapeau of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Spooky Damage: +10, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	cyan rosy-cheeked sugar shorts	0		Maximum HP Percent: +30, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	gravedigger's personal trainer's sugar chapeau of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Spooky Damage: +10, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	cyan rosy-cheeked sugar shorts	0		Maximum HP Percent: +30, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	yellow slime convention flyers	0		
@@ -4161,7 +4161,7 @@
 4209	ghostly skate skin	0		
 4210	tumbling roller skate decoy	0		
 4211	fuchsia mermaid's purse	0		
-4212	blinking cyan underwater slingshot	0		
+4212	cyan blinking underwater slingshot	0		
 4213	huge beefcake's skate blade of the scaredy-cat	0		Muscle: +25, Monster Level: -15
 4214	spangly unitard	0		
 4215	Herculean collapsible baton of dire peril	0		Experience (Muscle): +1, Weapon Damage: +20
@@ -4178,10 +4178,10 @@
 4226	wholesome Star of Bravery	0		Maximum HP Percent: +10, Single Equip
 4227	tumbling hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
-4232	spinning blinking ice skate doll	0		
+4232	blinking spinning ice skate doll	0		
 4233	hacienda key	0		
 4234	reassuring pat&eacute; knife	0		Spooky Resistance: +1
 4235	ghostly salt-shaker	0		
@@ -4196,25 +4196,25 @@
 4244	squat electrified leather-bound tome	0		MP Regen Min: 3, MP Regen Max: 5
 4245	bookmark	0		
 4246	manspreader's ivory cue ball	0		Monster Level: +10
-4247	lousy fancy wobbly decanter of fine Scotch	3	decent	Effect: "Human-Beast Hybrid", Effect Duration: 30
+4247	fancy lousy wobbly decanter of fine Scotch	3	decent	Effect: "Human-Beast Hybrid", Effect Duration: 30
 4248	twisted expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
-4251	tumbling narrow fish-oil smoke bomb	0		
+4251	narrow tumbling fish-oil smoke bomb	0		
 4252	quantum flattened vial of squid ink	0		Effect: "Grrrrrrreat!", Effect Duration: 54
 4253	pickled potion of speed	0		Effect: "Castaway Physique", Effect Duration: 24
 4254	fuchsia bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	anodized sap	0		Effect: "Swordholder", Effect Duration: 54, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	miniature delicious special huge chocolate-covered scarab beetle	2	awesome	Effect: "Rosewater Mark", Effect Duration: 5, Last Available: "2009-10"
+4258	special miniature delicious huge chocolate-covered scarab beetle	2	awesome	Effect: "Rosewater Mark", Effect Duration: 5, Last Available: "2009-10"
 4259	perfectly mixed blurry mulled cider	3	EPIC	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	bark boxers of the ox	0		Muscle: +20, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	ruddy bark beret	0		Maximum HP Percent: +40, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	bark boxers of the ox	0		Muscle: +20, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	ruddy bark beret	0		Maximum HP Percent: +40, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	electrified bark bracelet	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 4267	spinning squat flame-wreathed grievous Krakrox's Loincloth	0		Weapon Damage Percent: +50, Hot Spell Damage: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	Van der Graaf Galapagosian Cuisses of temperance	0		Sleaze Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4222,7 +4222,7 @@
 4270	blurry Usain Bolt's experienced Newman's Own Trousers	0		Experience: +2, Initiative: +80, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato, cap 31"
 4271	skewed sizzling Newton's Volartta's bellbottoms	0		Experience (Mysticality): +3, Hot Damage: +10, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 4272	dog trainer's Fonzie's Lederhosen of the Night	0		Experience (Moxie): +1, Experience (familiar): +1, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
-4273	ionized super-corrupted wobbly huge ribbon candy	0		Effect: "Stogied", Effect Duration: 28, Last Available: "2020-09"
+4273	ionized super-corrupted huge wobbly ribbon candy	0		Effect: "Stogied", Effect Duration: 28, Last Available: "2020-09"
 4274	Underworld acorn	0		Free Pull, Last Available: "2009-10"
 4275	blinking Underworld trunk	0		Last Available: "2009-10"
 4276	dance instructor's Underworld truncheon of the ox of vim and vigor	0		Muscle: +20, Experience Percent (Moxie): +10, Maximum HP Percent: +50, Last Available: "2009-10"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	upside-down gingerbread house	0		Last Available: "2009-12"
 4348	blue leftover Crimbo rations	0		Last Available: "2009-12"
-4349	shaking cyan pulsating perfumed snow hat	0		Stench Resistance: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	Samson's snow pants	0		Experience (Muscle): +5, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	shaking cyan pulsating perfumed snow hat	0		Stench Resistance: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	Samson's snow pants	0		Experience (Muscle): +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	gray shellacked snow belly	0		Damage Reduction: 7, Single Equip, Last Available: "2009-12"
 4352	twirling pile of loose snow	0		Last Available: "2009-12"
 4353	pulsating Crimbough	0		Last Available: "2009-12"
@@ -4316,7 +4316,7 @@
 4364	quantum moist upside-down elven suicide capsule	0		Effect: "Uncucumbered", Effect Duration: 19, Last Available: "2009-12"
 4365	low-calorie toothsome penguin focaccia bread	1	awesome	Last Available: "2009-12"
 4366	watered-down lousy herringcello	2	decent	Last Available: "2009-12"
-4367	watered-down perfectly mixed elven cellocello	2	EPIC	Last Available: "2009-12"
+4367	perfectly mixed watered-down elven cellocello	2	EPIC	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	spinning therapeutic pocketwatch on a chain of the detective	0		Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-12"
 4386	Annie Oakley's educational cement sandals	0		Experience: +1, Critical Hit Percent: +20, Single Equip, Last Available: "2009-12"
 4387	bouncing educational sage night-vision goggles	0		Mysticality Percent: +10, Experience: +1, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	jittery stanky peanut brittle shield	0		Stench Spell Damage: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	upside-down weightlifter's Red Rover BB gun of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Last Available: "2009-12"
 4391	huge red-and-green sweater of bravery	0		Spooky Resistance: +5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	wobbly crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	fuchsia blurry cheese ball	0		Last Available: "2010-01"
 4399	squat green healthy cheese sword	0		Maximum HP Percent: +20, Softcore Only, Last Available: "2010-01"
-4400	olive cheese diaper of the early riser	0		Adventures: +7, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	olive cheese diaper of the early riser	0		Adventures: +7, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	medical-grade cheese wheel	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	skewed asbestos-lined cheese eye	0		Hot Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	zippy family-friendly Staff of Queso Escusado of temperance	0		Sleaze Resistance: 6, Initiative: +20, Softcore Only, Last Available: "2010-01"
@@ -4396,7 +4396,7 @@
 4448	vaporized Instant Karma	1	decent	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	ghostly map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	miser's pointy hat	0		Meat Drop: +10, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	miser's pointy hat	0		Meat Drop: +10, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	pulsating spinning Jim Carey's machetito	0		Monster Level: +25, Last Available: "2010-04"
 4453	Van der Graaf lawnmower blade	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4412,12 +4412,12 @@
 4464	alkaline chocolate pasta spoon	0		Effect: "Spookyravin'", Effect Duration: 56
 4465	quantum altered chocolate saucepan	0		Effect: "Dreadful Smell", Effect Duration: 50
 4466	ionized corrupted modified twirling chocolate disco ball	0		Effect: "Corruption of Wretched Wally", Effect Duration: 64
-4467	aerosolized fuchsia blinking chocolate stolen accordion	0		Effect: "Shamboozled", Effect Duration: 56
-4468	squat Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4467	aerosolized blinking fuchsia chocolate stolen accordion	0		Effect: "Shamboozled", Effect Duration: 56
+4468	squat Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	shaking BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	thinker's BRICKO hat	0		Mysticality: +10, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	shellacked BRICKO pants	0		Damage Reduction: 7, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	thinker's BRICKO hat	0		Mysticality: +10, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	shellacked BRICKO pants	0		Damage Reduction: 7, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	jittery sharpshooter's BRICKO sword	0		Critical Hit Percent: +10, Last Available: "2010-02"
 4474	mirror BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4435,7 +4435,7 @@
 4487	tumbling mirror BRICKO bulwark of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Last Available: "2010-02"
 4488	mirror BRICKO trunk	0		Last Available: "2010-02"
 4489	jittery gilded BRICKO brick	0		Last Available: "2010-02"
-4490	twirling skewed gilded BRICKO chalice	0		Last Available: "2010-02"
+4490	skewed twirling gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	BRICKO brick	0		Last Available: "2010-02"
 4492	wobbly BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
@@ -4459,7 +4459,7 @@
 4511	decent blinking beautiful soup	3	good	Last Available: "2010-03"
 4512	pulsating eggman noodles	0		Last Available: "2010-03"
 4513	tumbling Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	spoiled thick ghostly Humpty Dumplings	5	crappy	Last Available: "2010-03"
+4514	thick spoiled ghostly Humpty Dumplings	5	crappy	Last Available: "2010-03"
 4515	super-sized adequate Lobster <i>qua</i> Grill	5	good	Last Available: "2010-03"
 4516	practically non-alcoholic lousy missing wine	1	decent	Last Available: "2010-03"
 4517	bland small matter custard	2	decent	Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	bouncing tumbling pulsating steel-toed Da Vinci's eye of the Tiger-lily	0		Experience (Mysticality): +5, Damage Reduction: 9, Last Available: "2010-03"
-4524	stiffened deadly wig	0		Weapon Damage: +5, Damage Reduction: 1, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	gigantic adequate donut	10	good	Last Available: "2010-03"
+4524	stiffened deadly wig	0		Weapon Damage: +5, Damage Reduction: 1, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4525	adequate gigantic donut	10	good	Last Available: "2010-03"
 4526	normal bucket of honey	3	good	Last Available: "2010-03"
 4527	stanky steel-toed elephant stinger	0		Damage Reduction: 9, Stench Spell Damage: +25, Last Available: "2010-03"
-4528	super-sized bland dragon snaps	5	decent	Last Available: "2010-03"
+4528	bland super-sized dragon snaps	5	decent	Last Available: "2010-03"
 4529	greedy Van der Graaf snapdragon pistil	0		Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-03"
-4530	spinning wobbly puff of smoke	0		Last Available: "2010-03"
-4531	normal thick rook cookie	5	good	Last Available: "2010-03"
+4530	wobbly spinning puff of smoke	0		Last Available: "2010-03"
+4531	thick normal rook cookie	5	good	Last Available: "2010-03"
 4532	flavorless jumbo wobbly bishop cookie	5	decent	Last Available: "2010-03"
 4533	normal knight cookie	3	good	Last Available: "2010-03"
-4534	bland jumbo king cookie	5	decent	Last Available: "2010-03"
+4534	jumbo bland king cookie	5	decent	Last Available: "2010-03"
 4535	adequate queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	dangerous insane tophat	0		Weapon Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	jittery lightning-fast rosewater-soaked helm of the knight	0		Stench Resistance: +3, Initiative: +40, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	dangerous insane tophat	0		Weapon Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	jittery lightning-fast rosewater-soaked helm of the knight	0		Stench Resistance: +3, Initiative: +40, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	wizardly wristwatch of the knight of the detective	0		Mysticality: +25, Item Drop: +20, Single Equip, Last Available: "2010-03"
-4540	zippy savvy trousers of the knight	0		Mysticality Percent: +20, Initiative: +20, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	zippy savvy trousers of the knight	0		Mysticality Percent: +20, Initiative: +20, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	narrow up-at-dawn tophat	0		Adventures: +5, Familiar Effect: "1xBarrr, cap 25"
 4542	razor-sharp tie	0		Weapon Damage Percent: +25, Single Equip
 4543	huge Sinatra's tuxedo pants	0		Experience (Moxie): +5, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4508,7 +4508,7 @@
 4560	tumbling map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	watered-down mediocre world's most unappetizing beverage	2	decent	Last Available: "2010-04"
+4563	mediocre watered-down world's most unappetizing beverage	2	decent	Last Available: "2010-04"
 4564	studded slippery when wet shield	0		Damage Absorption: +80, Damage Reduction: 6, Last Available: "2010-04"
 4565	stale enchanted raisin	4	decent	Effect: "Ooh, Sour!", Effect Duration: 10, Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4521,15 +4521,15 @@
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	bouncing panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	twirling bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	twirling bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	bouncing meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	activated Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Antsy in your Pantsy", Effect Duration: 16, Last Available: "2010-04"
 4580	coward's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Monster Level: -20, Last Available: "2010-04"
 4581	zippy careful T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Monster Level: -10, Initiative: +20, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	red fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	spoiled miniature six wedges of goat cheese	2	crappy	
+4584	miniature spoiled six wedges of goat cheese	2	crappy	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	upside-down goth	0		
@@ -4546,13 +4546,13 @@
 4598	red pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	strong artisanal plastic cup of beer	5	EPIC	Last Available: "2010-06"
+4601	artisanal strong plastic cup of beer	5	EPIC	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	shaking bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	nippy crafty bottle of Goldschn&ouml;ckered	0		Maximum MP: +10, Cold Damage: +10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	adequate massive yellow sun-dried tofu	9	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	spirit-forward tolerable soyburger juice	5	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	tolerable spirit-forward soyburger juice	5	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	green respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	quadruple-electrified essential soy	0		Effect: "Tea-hee", Effect Duration: 18, Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	squat souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	flame-wreathed Crown of Thrones	0		Hot Spell Damage: +10, Softcore Only, Last Available: "2010-05"
-4615	special hand-crafted weak Cinco Mayo Lager	2	super EPIC	Effect: "Oriental Mysticism", Effect Duration: 25, Last Available: "2010-05"
+4615	hand-crafted special weak Cinco Mayo Lager	2	super EPIC	Effect: "Oriental Mysticism", Effect Duration: 25, Last Available: "2010-05"
 4616	spinning Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	fuchsia plastic cup of flat beer	0		
@@ -4569,20 +4569,20 @@
 4621	squat Game Grid token	0		Last Available: "2010-06"
 4622	spinning Game Grid ticket	0		Last Available: "2010-06"
 4623	energized jittery chocolate-covered caviar	0		Effect: "Gummi-Grin", Effect Duration: 13, Last Available: "2020-09"
-4624	moldy half-sized maroon pawn cookie	2	crappy	Last Available: "2010-06"
-4625	denatured yellow jittery narrow squat coffee pixie stick	1	decent	Effect: "Greased-Up Familiar", Effect Duration: 15, Last Available: "2010-06"
+4624	half-sized moldy maroon pawn cookie	2	crappy	Last Available: "2010-06"
+4625	denatured yellow squat jittery narrow coffee pixie stick	1	decent	Effect: "Greased-Up Familiar", Effect Duration: 15, Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	mirror finger cuffs	0		Last Available: "2010-06"
 4628	narrow parachute guy	0		Last Available: "2010-06"
 4629	beefy plastic spider ring	0		Muscle: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	blinking toasty plastic kazoo	0		Hot Damage: +5, Last Available: "2010-06"
 4631	sage inflatable baseball bat	0		Mysticality Percent: +10, Last Available: "2010-06"
-4632	vibrating extremely unsafe googly-star hat	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Last Available: "2010-06", Familiar Effect: "atk"
+4632	vibrating extremely unsafe googly-star hat	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Familiar Effect: "atk", Last Available: "2010-06"
 4633	double-paned groovy googly-ball hat	0		Moxie Percent: +10, Cold Resistance: +5, Last Available: "2010-06"
 4634	inspector's studded googly-heart hat	0		Damage Absorption: +80, Item Drop: +15, Last Available: "2010-06"
 4635	Temple Grandin's Da Vinci's super-sweet boom box	0		Experience (Mysticality): +5, Familiar Weight: +7, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	red Jim Carey's deadly experienced sinister demon mask	0		Experience: +2, Weapon Damage: +5, Monster Level: +25, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	red Jim Carey's deadly experienced sinister demon mask	0		Experience: +2, Weapon Damage: +5, Monster Level: +25, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	tumbling electrified banded streetfighting champion's belt	0		Damage Absorption: +100, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2010-06"
 4639	inspector's quilted deadly Space Trip safety headphones	0		Weapon Damage: +5, Damage Absorption: +40, Item Drop: +15, Single Equip, Last Available: "2010-06"
 4640	wicked LARP carp	0		Spell Damage: +5
@@ -4594,8 +4594,8 @@
 4646	olive flame-wreathed Annie Oakley's Meteoid ice beam of the ox	0		Muscle: +20, Critical Hit Percent: +20, Hot Spell Damage: +10, Last Available: "2011-12"
 4647	olive nippy clever Dungeon Fist gauntlet of Tarzan	0		Experience (Muscle): +3, Maximum MP: +20, Cold Damage: +10, Last Available: "2011-06"
 4648	maroon Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	blinking fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	blinking fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	Oprah's slick ironic knit cap	0		Moxie: +10, Maximum MP Percent: +50, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4620,15 +4620,15 @@
 4672	comfy pillow	0		
 4673	low-calorie adequate marshmallow	1	good	
 4674	moldy sponge cake	3	crappy	
-4675	mediocre practically non-alcoholic jittery tumbling gin-soaked blotter paper	1	decent	
+4675	mediocre practically non-alcoholic tumbling jittery gin-soaked blotter paper	1	decent	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	huge unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	stiffened pottery shield	0		Damage Reduction: 4, Last Available: "2010-09"
-4682	lime green pulsating hardy padded pottery hat	0		Damage Absorption: +20, Maximum HP: +50, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	pottery training pants of horror of Flo-Jo	0		Spooky Spell Damage: +25, Initiative: +100, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	lime green pulsating hardy padded pottery hat	0		Damage Absorption: +20, Maximum HP: +50, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	pottery training pants of horror of Flo-Jo	0		Spooky Spell Damage: +25, Initiative: +100, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	skewed boxer's pottery club	0		Muscle Percent: +10, Last Available: "2010-09"
 4685	pottery yo-yo of the boozehound	0		Booze Drop: +100, Last Available: "2010-09"
 4686	wobbly pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	Van der Graaf Greatest American Pants of temperance of the sweet-tooth	0		Sleaze Resistance: +5, Candy Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	Van der Graaf Greatest American Pants of temperance of the sweet-tooth	0		Sleaze Resistance: +5, Candy Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	stylish fossilized necklace	0		Moxie: +25, Last Available: "2010-09"
 4698	imp air	0		
 4699	ghostly bus pass	0		
@@ -4657,12 +4657,12 @@
 4709	shaking hippo tutu	0		Last Available: "2011-09"
 4710	skewed immense ballet shoes	0		Familiar Weight: +5
 4711	huge sweatpants	0		Familiar Effect: "8xPotato, cap 2"
-4712	squat upside-down GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
+4712	upside-down squat GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	normal lemon popsicle	4	good	
-4715	flavorless massive popsicle	9	decent	
-4716	special bland strawberry popsicle	4	decent	Effect: "Ready to Snap", Effect Duration: 45
-4717	tasty super-sized liver popsicle	5	awesome	
+4715	massive flavorless popsicle	9	decent	
+4716	bland special strawberry popsicle	4	decent	Effect: "Ready to Snap", Effect Duration: 45
+4717	super-sized tasty liver popsicle	5	awesome	
 4718	vibrating mariachi hat	0		Maximum MP Percent: +10, Familiar Effect: "atk, cap 2"
 4719	ghostly studded Hollandaise helmet	0		Damage Absorption: +80, Familiar Effect: "atk, cap 2"
 4720	skewed organ grinder	0		Free Pull, Last Available: "2011-12"
@@ -4683,8 +4683,8 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	shaking dog trainer's beer-soaked mop	0		Experience (familiar): +1
-4738	practically non-alcoholic smooth day-old beer	1	awesome	
-4739	weak hand-crafted plain beer	2	EPIC	
+4738	smooth practically non-alcoholic day-old beer	1	awesome	
+4739	hand-crafted weak plain beer	2	EPIC	
 4740	lousy overpriced &quot;imported&quot; beer	4	decent	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
@@ -4693,30 +4693,30 @@
 4745	galvanized ionized Wax Flask	0		Effect: "Sauce Monocle", Effect Duration: 38
 4746	nitrogenated Pain Dip	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 24
 4747	flavorless bone meal	3	decent	Last Available: "2010-10"
-4748	lousy watered-down bone aperitif	2	decent	Last Available: "2010-10"
+4748	watered-down lousy bone aperitif	2	decent	Last Available: "2010-10"
 4749	stiffened bonerang	0		Damage Reduction: 1, Last Available: "2010-10"
 4750	bone and arrows of Gandalf	0		Spell Critical Percent: +20, Last Available: "2010-10"
 4751	purple boning knife of doom	0		Spooky Spell Damage: +50, Last Available: "2010-10"
 4752	bone crusher of Flo-Jo	0		Initiative: +100, Last Available: "2010-10"
 4753	bone spurs of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2010-10"
-4754	deadly beefy bonedanna	0		Muscle: +10, Weapon Damage: +5, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	Usain Bolt's sinister boneana hammock	0		Spell Damage: +10, Initiative: +80, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	deadly beefy bonedanna	0		Muscle: +10, Weapon Damage: +5, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	Usain Bolt's sinister boneana hammock	0		Spell Damage: +10, Initiative: +80, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	blurry bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
-4758	Vulcanized ghostly squat candy skeleton	0		Effect: "Gleaming White Teeth", Effect Duration: 16, Last Available: "2020-09"
+4758	Vulcanized squat ghostly candy skeleton	0		Effect: "Gleaming White Teeth", Effect Duration: 16, Last Available: "2020-09"
 4759	fuchsia Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	jittery huge pumpkin	0		Last Available: "2010-11"
-4763	flavorless huge pumpkin pie	6	decent	Last Available: "2010-11"
-4764	drinkable boozy huge ghostly pumpkin beer	5	good	Last Available: "2010-11"
+4763	huge flavorless pumpkin pie	6	decent	Last Available: "2010-11"
+4764	boozy drinkable ghostly huge pumpkin beer	5	good	Last Available: "2010-11"
 4765	pressed boiled pumpkin juice	0		Effect: "La Bamba", Effect Duration: 13, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	wool Jeselnik's shin gourds	0		Sleaze Damage: +25, Cold Resistance: +1, Single Equip, Last Available: "2010-11"
 4768	reassuring medical-grade Staff of the November Jack-O-Lantern of terror	0		Spooky Spell Damage: +10, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-11"
 4769	pumpkin carriage	0		Last Available: "2010-11"
 4770	tumbling Desert Bus pass	0		
-4771	wobbly teal ginormous pumpkin	0		Last Available: "2010-11"
+4771	teal wobbly ginormous pumpkin	0		Last Available: "2010-11"
 4804	Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	skewed Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
@@ -4724,7 +4724,7 @@
 4810	upside-down Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	super-sized enchanted moldy CRIMBCOIDS mints	5	crappy	Effect: "Cat-Alyzed", Effect Duration: 15, Last Available: "2011-01"
+4818	enchanted moldy super-sized CRIMBCOIDS mints	5	crappy	Effect: "Cat-Alyzed", Effect Duration: 15, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	bland miniature narrow CRIMBCOLOAF	2	decent	Last Available: "2011-01"
 4821	jumbo yummy tumbling circular CRIMBCOOKIE	5	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4744,16 +4744,16 @@
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	mirror upside-down robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
-4838	wobbly ghostly robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
+4838	ghostly wobbly robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	flavorless triangular CRIMBCOOKIE	4	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	decent immense square CRIMBCOOKIE	9	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	supercharged curative beefcake's bindlestocking	0		Muscle: +25, Maximum MP Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	pulsating stanky dog trainer's Uncle Hobo's stocking cap	0		Experience (familiar): +1, Stench Spell Damage: +25, Last Available: "2010-12", Familiar Effect: "atk"
+4845	pulsating stanky dog trainer's Uncle Hobo's stocking cap	0		Experience (familiar): +1, Stench Spell Damage: +25, Familiar Effect: "atk", Last Available: "2010-12"
 4846	Da Vinci's Uncle Hobo's epic beard of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Single Equip, Last Available: "2010-12"
-4847	Uncle Hobo's gift baggy pants of dire peril of the sweet-tooth	0		Weapon Damage: +20, Candy Drop: +100, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	Uncle Hobo's gift baggy pants of dire peril of the sweet-tooth	0		Weapon Damage: +20, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	padded Uncle Hobo's fingerless tinsel gloves	0		Damage Absorption: +20, Item Drop: +5, Single Equip, Last Available: "2010-12"
 4849	arcane researcher's brainy Uncle Hobo's highest bough	0		Mysticality: +5, Experience Percent (Mysticality): +10, Last Available: "2010-12"
 4850	wool careful Uncle Hobo's belt	0		Monster Level: -10, Cold Resistance: +1, Single Equip, Last Available: "2010-12"
@@ -4771,36 +4771,36 @@
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	bouncing photocopier	0		Last Available: "2011-01"
-4865	gray upside-down deluxe fax machine	0		Last Available: "2011-01"
+4865	upside-down gray deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	squat paperclip sproinger	0		Last Available: "2011-01"
 4868	prompt paperclip-on tie of the cougar of the empath	0		Moxie: +20, Familiar Weight: +5, Adventures: +3, Single Equip, Last Available: "2011-01"
-4869	baleful paperclip pants of vim and vigor	0		Spell Damage: +25, Maximum HP Percent: +50, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	miser's extremely unsafe paperclip turban of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Meat Drop: +10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	baleful paperclip pants of vim and vigor	0		Spell Damage: +25, Maximum HP Percent: +50, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	miser's extremely unsafe paperclip turban of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Meat Drop: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	upside-down paperclip cape of bravery	0		Spooky Resistance: +5, Last Available: "2011-01"
 4872	skewed glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
-4874	bouncing squat maroon gaudy key	0		
+4874	squat bouncing maroon gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
-4876	non-ionized ionized spinning twirling chocolate bath ball	0		Effect: "Rosewater Mark", Effect Duration: 63, Last Available: "2011-01"
+4876	non-ionized ionized twirling spinning chocolate bath ball	0		Effect: "Rosewater Mark", Effect Duration: 63, Last Available: "2011-01"
 4877	chilled ionized bacon bath ball	0		Effect: "French Bronilla Brogueishness", Effect Duration: 49, Last Available: "2011-01"
 4878	super-wet moist upside-down incense bath ball	0		Effect: "Locks Like the Raven", Effect Duration: 51, Last Available: "2011-01"
 4879	nitrogenated unsweetened myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Good Karma", Effect Duration: 65, Last Available: "2011-01"
-4880	wobbly squat CRIMBCO mug	0		Last Available: "2011-01"
+4880	squat wobbly CRIMBCO mug	0		Last Available: "2011-01"
 4881	tolerable CRIMBCO wine	4	good	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	moldy toe jam toast	3	crappy	Last Available: "2011-01"
 4885	skewed traffic jam	0		Last Available: "2011-01"
 4886	miniature delicious blue traffic jam toast	2	awesome	Last Available: "2011-01"
-4887	spinning olive space jam	0		Last Available: "2011-01"
+4887	olive spinning space jam	0		Last Available: "2011-01"
 4888	thick bland space jam toast	5	decent	Last Available: "2011-01"
 4889	nitrogenated aerosolized motivational poster	0		Effect: "Comprehensively Nourished", Effect Duration: 17, Last Available: "2011-01"
-4890	fuchsia ghostly sack lunch	0		Last Available: "2011-01"
+4890	ghostly fuchsia sack lunch	0		Last Available: "2011-01"
 4891	jittery bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	yummy jumbo festive sausage	5	awesome	Last Available: "2011-01"
+4894	jumbo yummy festive sausage	5	awesome	Last Available: "2011-01"
 4895	bland special holiday cheese log	3	decent	Effect: "Thicker, Sicker", Effect Duration: 50, Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	cyan spinning greasy manspreader's BGE 'ferocious fruit' shirt	0		Monster Level: +10, Sleaze Spell Damage: +10, Last Available: "2010-12"
@@ -4842,7 +4842,7 @@
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	flavorless small Knob jelly donut	2	decent	
-4942	purple blurry Knob cake	0		
+4942	blurry purple Knob cake	0		
 4943	wobbly Knob cake pan	0		
 4944	pulsating Knob batter	0		
 4945	shaking Knob frosting	0		
@@ -4855,7 +4855,7 @@
 4952	ionized energized mirror baggie of sugar	0		Effect: "Burning Ears", Effect Duration: 32
 4953	lion tamer's Annie Oakley's whalebone corset	0		Critical Hit Percent: +20, Experience (familiar): +2, Single Equip
 4954	gray huge avaricious oven mitts	0		Meat Drop: +30, Single Equip
-4955	bland gigantic huge overcookie	10	decent	
+4955	gigantic bland huge overcookie	10	decent	
 4956	super-sized rotten red philosopher's scone	5	crappy	
 4957	nitrogenated half-baked potion	0		Effect: "Swimming with Sharks", Effect Duration: 19
 4958	executive Knob Goblin deluxe scimitar	0		Meat Drop: +40
@@ -4916,7 +4916,7 @@
 5013	bland blue shaking wasabi pocky	4	decent	Last Available: "2011-03"
 5014	enchanted moldy tobiko pocky	3	crappy	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2011-03"
 5015	normal low-calorie natto pocky	1	good	Last Available: "2011-03"
-5016	enchanted smooth wasabi-infused sake	3	awesome	Effect: "Ruby-ous", Effect Duration: 45, Last Available: "2011-03"
+5016	smooth enchanted wasabi-infused sake	3	awesome	Effect: "Ruby-ous", Effect Duration: 45, Last Available: "2011-03"
 5017	delicious watered-down upside-down tobiko-infused sake	2	awesome	Last Available: "2011-03"
 5018	mediocre natto-infused sake	4	decent	Last Available: "2011-03"
 5019	deionized electrified wasabi marble soda	0		Effect: "Memory of Resilience", Effect Duration: 19, Last Available: "2011-03"
@@ -4924,10 +4924,10 @@
 5021	chilled pressed frozen natto marble soda	0		Effect: "Thunderheart", Effect Duration: 36, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	anodized quadruple-chilled Vulcanized elderly jawbreaker	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 56, Last Available: "2020-09"
-5024	watered-down perfectly mixed marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
-5025	aged enchanted cranberry schnapps	4	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 20, Last Available: "2011-03"
+5024	perfectly mixed watered-down marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
+5025	enchanted aged cranberry schnapps	4	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 20, Last Available: "2011-03"
 5026	acceptable weak cyan breaded beer	2	good	Last Available: "2011-03"
-5027	high-proof acceptable soy cordial	7	good	Last Available: "2011-03"
+5027	acceptable high-proof soy cordial	7	good	Last Available: "2011-03"
 5028	toasty careful educational astral bludgeon	0		Experience: +1, Monster Level: -10, Hot Damage: +5
 5029	avaricious manspreader's astral shield	0		Monster Level: +10, Meat Drop: +30, Damage Reduction: 15
 5030	huge lightning-fast veiny smartaleck's astral chapeau	0		Moxie Percent: +30, Maximum HP: +10, Initiative: +40, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4949,16 +4949,16 @@
 5046	jittery astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	rosewater-soaked supercharged Newton's double-ice cap	0		Experience (Mysticality): +3, Maximum MP Percent: +30, Stench Resistance: +3, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	rosewater-soaked supercharged Newton's double-ice cap	0		Experience (Mysticality): +3, Maximum MP Percent: +30, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	pulsating greasy fortified double-ice box of the boozehound	0		Damage Absorption: +60, Sleaze Spell Damage: +10, Booze Drop: +100, Last Available: "2011-04"
-5051	blinking aromatic double-ice britches of the brute of the overflowing toilet	0		Muscle Percent: +30, Stench Spell Damage: +50, Stench Resistance: +1, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	blinking aromatic double-ice britches of the brute of the overflowing toilet	0		Muscle Percent: +30, Stench Spell Damage: +50, Stench Resistance: +1, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	ghostly handful of numbers	0		Last Available: "2020-09"
 5053	narrow Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	magnetized liquefied Atomic Comic	0		Effect: "Drenched With Filth", Effect Duration: 45, Last Available: "2011-04"
-5058	irradiated ghostly skewed olive Red Pill	0		Effect: "Angry like the Wolf", Effect Duration: 21, Last Available: "2011-04"
+5058	irradiated ghostly olive skewed Red Pill	0		Effect: "Angry like the Wolf", Effect Duration: 21, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
 5061	fuchsia boxing-glove-in-a-box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	lousy tumbling Russian Ice	3	decent	Last Available: "2011-04"
 5074	zippy clay ashtray	0		Initiative: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	scandalous lanyard	0		Sleaze Damage: +5, Single Equip, Last Available: "2011-05"
-5076	censurious monster pants	0		Sleaze Resistance: +3, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	censurious monster pants	0		Sleaze Resistance: +3, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	ghostly box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	concentrated double-dry blurry Pok&euml;mann band-aid	0		Effect: "Army of One", Effect Duration: 29, Last Available: "2011-05"
-5079	dangerous Socratic Van der Graaf helmet	0		Experience (Mysticality): +1, Weapon Damage: +10, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	dangerous Socratic Van der Graaf helmet	0		Experience (Mysticality): +1, Weapon Damage: +10, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	wool crutch	0		Cold Resistance: +1, Last Available: "2011-05"
 5081	shock belt of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2011-05"
 5082	frozen bouncing Okee-Dokee soda	0		Effect: "Sweet and Green", Effect Duration: 65, Last Available: "2011-05"
 5083	bouncing careful rubber band gun	0		Monster Level: -10, Last Available: "2011-05"
-5084	rosewater-soaked pin-stripe slacks	0		Stench Resistance: +3, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	rosewater-soaked pin-stripe slacks	0		Stench Resistance: +3, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	gloves of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2011-05"
 5086	concentrated improved teal ghostly correction fluid	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 50, Last Available: "2011-05"
 5087	grievous Pok&euml;mann figurine: Porkachu	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2011-05"
@@ -5004,11 +5004,11 @@
 5101	gravedigger's Pok&euml;mann figurine: Moog	0		Spooky Damage: +10, Single Equip, Last Available: "2011-05"
 5102	modified willyweed	0		Effect: "Human-Machine Hybrid", Effect Duration: 24, Last Available: "2011-05"
 5103	electrified Nuclear Blastball	0		Effect: "Covetous Robbery", Effect Duration: 40, Last Available: "2011-05"
-5104	liquefied quadruple-galvanized galvanized spinning blue fish juice box	0		Effect: "Berry Critical", Effect Duration: 48, Last Available: "2011-05"
+5104	liquefied quadruple-galvanized galvanized blue spinning fish juice box	0		Effect: "Berry Critical", Effect Duration: 48, Last Available: "2011-05"
 5105	green paint bomb	0		Last Available: "2011-05"
 5106	blinking hideous egg	0		Last Available: "2011-05"
-5107	artisanal practically non-alcoholic blurry Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
-5108	blurry mirror fistful of ashes	0		
+5107	practically non-alcoholic artisanal blurry Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
+5108	mirror blurry fistful of ashes	0		
 5109	stress ball of dire peril	0		Weapon Damage: +20, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	fuchsia crafty Ultracolor&trade; shirt	0		Maximum MP: +10, Last Available: "2011-05"
@@ -5019,10 +5019,10 @@
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	jittery bird brain	0		
-5119	huge jittery busted wings	0		
+5119	jittery huge busted wings	0		
 5120	narrow Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	gravedigger's Admiral's hat of the wise owl of the storm	0		Mysticality: +20, Maximum MP Percent: +40, Spooky Damage: +10, Last Available: "2011-05", Familiar Effect: "atk"
-5122	greedy smelly padded aviator's cap	0		Damage Absorption: +20, Stench Spell Damage: +10, Meat Drop: +20, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	gravedigger's Admiral's hat of the wise owl of the storm	0		Mysticality: +20, Maximum MP Percent: +40, Spooky Damage: +10, Familiar Effect: "atk", Last Available: "2011-05"
+5122	greedy smelly padded aviator's cap	0		Damage Absorption: +20, Stench Spell Damage: +10, Meat Drop: +20, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	upside-down purple wizardly mirrored aviator shades of the boozehound	0		Mysticality: +25, Booze Drop: +100, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5033,7 +5033,7 @@
 5130	blinking Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	alkaline Ultrasoldier Serum	0		Effect: "Dreadful Fear", Effect Duration: 40, Last Available: "2011-06"
 5132	bland elven hardtack	4	decent	Last Available: "2011-06"
-5133	extra-dry delicious elven squeeze	5	awesome	Last Available: "2011-06"
+5133	delicious extra-dry elven squeeze	5	awesome	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	jittery E.M.U. joystick	0		Last Available: "2011-06"
 5136	ghostly E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5042,7 +5042,7 @@
 5139	narrow carton of astral energy drinks	0		
 5140	twisted astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
-5142	ghostly skewed moon unit	0		Last Available: "2011-06"
+5142	skewed ghostly moon unit	0		Last Available: "2011-06"
 5143	lime green E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	vacuum-sealed anodized olive honeypot	0		Effect: "Inscrutable exoskeleton", Effect Duration: 56
@@ -5051,8 +5051,8 @@
 5148	auspicious stanky educational honey dipper	0		Experience: +1, Stench Spell Damage: +25, Item Drop: +10
 5149	zippy friendly groovy honeybritches	0		Moxie Percent: +10, Familiar Weight: +3, Initiative: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	blinking greedy smartaleck's honeycap of the brazier	0		Moxie Percent: +30, Hot Spell Damage: +25, Meat Drop: +20, Familiar Effect: "1xPotato, cap 43"
-5151	censurious Moonthril Circlet	0		Sleaze Resistance: +3, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	ruddy Moonthril Greaves	0		Maximum HP Percent: +40, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	censurious Moonthril Circlet	0		Sleaze Resistance: +3, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	ruddy Moonthril Greaves	0		Maximum HP Percent: +40, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	ribald Moonthril Flamberge	0		Sleaze Damage: +10, Last Available: "2011-06"
 5154	narrow Moonthril Longbow of horror	0		Spooky Spell Damage: +25, Last Available: "2011-06"
 5155	friendly Moonthril Cuirass	0		Familiar Weight: +3, Softcore Only, Last Available: "2011-06"
@@ -5074,7 +5074,7 @@
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	huge elven magi-pack	0		Last Available: "2011-06"
-5174	lousy practically non-alcoholic special Saison du Lune	1	decent	Effect: "You're Rubber", Effect Duration: 30, Last Available: "2011-06"
+5174	lousy special practically non-alcoholic Saison du Lune	1	decent	Effect: "You're Rubber", Effect Duration: 30, Last Available: "2011-06"
 5175	smooth Moonthril Schnapps	3	awesome	Last Available: "2011-06"
 5176	tolerable Wrecked Generator	3	good	Last Available: "2011-06"
 5177	delicious half-sized Spaghetti with Moonballs	2	awesome	Last Available: "2011-06"
@@ -5083,7 +5083,7 @@
 5180	extra-ionized deionized maroon Comet Pop	0		Effect: "Happy Salamander", Effect Duration: 41, Last Available: "2011-06"
 5181	dry extra-polymerized bouncing Flan in the Moon	0		Effect: "Familial Ties", Effect Duration: 28, Last Available: "2011-06"
 5182	irradiated denatured deionized 1/6th Pound Cake	0		Effect: "Proprie Tea", Effect Duration: 48, Last Available: "2011-06"
-5183	pulsating ghostly Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
+5183	ghostly pulsating Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	wobbly Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	tumbling Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
@@ -5103,18 +5103,18 @@
 5200	boiled teal jittery paste	1	good	Effect: "Fancy Feasted", Effect Duration: 10, Last Available: "2011-08"
 5201	denatured blinking huge ectoplasmic paste	1	EPIC	Last Available: "2011-08"
 5202	dehydrated greasy paste	1	good	Last Available: "2011-08"
-5203	altered jittery bouncing blue bug paste	1	decent	Effect: "Sausage Festive", Effect Duration: 5, Last Available: "2011-08"
+5203	altered jittery blue bouncing bug paste	1	decent	Effect: "Sausage Festive", Effect Duration: 5, Last Available: "2011-08"
 5204	vaporized gray hippy paste	1	good	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2011-08"
-5205	modified huge upside-down wobbly orc paste	1	decent	Last Available: "2011-08"
+5205	modified huge wobbly upside-down orc paste	1	decent	Last Available: "2011-08"
 5206	pickled tumbling green demonic paste	1	decent	Last Available: "2011-08"
-5207	dried twirling fuchsia indescribably horrible paste	1	EPIC	Last Available: "2011-08"
+5207	dried fuchsia twirling indescribably horrible paste	1	EPIC	Last Available: "2011-08"
 5208	powdered wobbly paste	1	awesome	Effect: "Space Cadet", Effect Duration: 15, Last Available: "2011-08"
 5209	powdered tumbling goblin paste	1	good	Last Available: "2011-08"
 5210	modified blinking pirate paste	1	crappy	Effect: "Squid Squint", Effect Duration: 5, Last Available: "2011-08"
 5211	pickled blurry yellow chlorophyll paste	1	crappy	Last Available: "2011-08"
 5212	mixed tumbling paste	1	decent	Effect: "Sweet Tooth", Effect Duration: 35, Last Available: "2011-08"
 5213	altered ghostly Mer-kin paste	1	decent	Last Available: "2011-08"
-5214	pickled squat upside-down teal slimy paste	1	awesome	Last Available: "2011-08"
+5214	pickled teal squat upside-down slimy paste	1	awesome	Last Available: "2011-08"
 5215	twisted penguin paste	1	crappy	Effect: "Swimming with Sharks", Effect Duration: 5, Last Available: "2011-08"
 5216	dehydrated tumbling shaking elemental paste	1	EPIC	Last Available: "2011-08"
 5217	denatured blinking cosmic paste	1	decent	Last Available: "2011-08"
@@ -5123,11 +5123,11 @@
 5220	pulsating Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	olive Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	spoiled huge upside-down Ur-Donut	7	crappy	Last Available: "2011-09"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5224	huge spoiled upside-down Ur-Donut	7	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	blurry box of Familiar Jacks	0		Last Available: "2011-09"
-5227	high-proof mediocre bucket of wine	8	decent	Last Available: "2011-09"
+5227	mediocre high-proof bucket of wine	8	decent	Last Available: "2011-09"
 5228	delicious ultrafondue	3	awesome	Last Available: "2011-09"
 5229	gray unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5142,18 +5142,18 @@
 5239	aged Morto Moreto	3	awesome	Last Available: "2011-09"
 5240	hand-crafted fortified Temps Tempranillo	5	EPIC	Last Available: "2011-09"
 5241	acceptable weak Bordeaux Marteaux	2	good	Last Available: "2011-09"
-5242	lousy weak Fromage Pinotage	2	decent	Last Available: "2011-09"
+5242	weak lousy Fromage Pinotage	2	decent	Last Available: "2011-09"
 5243	watered-down artisanal Beignet Milgranet	2	EPIC	Last Available: "2011-09"
-5244	watered-down lousy blinking Muschat	2	decent	Last Available: "2011-09"
-5245	rotten half-sized cool jelly donut	2	crappy	Last Available: "2011-09"
+5244	lousy watered-down blinking Muschat	2	decent	Last Available: "2011-09"
+5245	half-sized rotten cool jelly donut	2	crappy	Last Available: "2011-09"
 5246	normal shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	flavorless occult jelly donut	4	decent	Last Available: "2011-09"
-5248	half-sized stale yellow skewed thyme jelly donut	2	decent	Last Available: "2011-09"
+5248	stale half-sized yellow skewed thyme jelly donut	2	decent	Last Available: "2011-09"
 5249	bland danish	4	decent	Last Available: "2011-09"
 5250	diet delicious smashed danish	1	awesome	Last Available: "2011-09"
 5251	tasty jumbo forbidden danish	5	awesome	Last Available: "2011-09"
 5252	rotten cool cat claw	3	crappy	Last Available: "2011-09"
-5253	decent cyan narrow blunt cat claw	4	good	Last Available: "2011-09"
+5253	decent narrow cyan blunt cat claw	4	good	Last Available: "2011-09"
 5254	spoiled jittery shadowy cat claw	3	crappy	Last Available: "2011-09"
 5255	immense adequate cheezburger	8	good	Last Available: "2011-09"
 5256	stale toasted brie	3	decent	Last Available: "2011-09"
@@ -5161,12 +5161,12 @@
 5258	extra-denatured teal squat too legit potion	0		Effect: "Blood-Rich", Effect Duration: 21, Last Available: "2011-09"
 5259	activated Bright Water	0		Effect: "Sweet Incentive", Effect Duration: 53, Last Available: "2011-09"
 5260	moist diffused cold-filtered water	0		Effect: "20-20 Second Sight", Effect Duration: 37, Last Available: "2011-09"
-5261	polarized twirling olive spinning graveyard snowglobe	0		Effect: "All Is Forgiven", Effect Duration: 66, Last Available: "2011-09"
+5261	polarized twirling spinning olive graveyard snowglobe	0		Effect: "All Is Forgiven", Effect Duration: 66, Last Available: "2011-09"
 5262	quadruple-energized extra-flattened twirling cool cat elixir	0		Effect: "Human-Elf Hybrid", Effect Duration: 41, Last Available: "2011-09"
 5263	dry quantum twirling potion of the captain's hammer	0		Effect: "Savage Beast Inside", Effect Duration: 29, Last Available: "2011-09"
 5264	liquefied extra-electrified blinking yellow potion of X-ray vision	0		Effect: "Leisurely Amblin'", Effect Duration: 64, Last Available: "2011-09"
 5265	ionized chilled fuchsia potion of the litterbox	0		Effect: "Buggy Flavor", Effect Duration: 69, Last Available: "2011-09"
-5266	ionized wobbly ghostly potion of animal rage	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 27, Last Available: "2011-09"
+5266	ionized ghostly wobbly potion of animal rage	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 27, Last Available: "2011-09"
 5267	wet green potion of punctual companionship	0		Effect: "Sticks and Stones", Effect Duration: 34, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
@@ -5174,18 +5174,18 @@
 5271	skewed broken glass grenade	0		Last Available: "2011-09"
 5272	lime green noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
-5274	purple blinking boozebomb	0		Last Available: "2011-09"
+5274	blinking purple boozebomb	0		Last Available: "2011-09"
 5275	energetic hammerus	0		Maximum MP Percent: +20, Last Available: "2011-09"
 5276	blunt icepick of chilblains	0		Cold Damage: +25, Last Available: "2011-09"
 5277	bouncing fluorescent lightbulb of wisdom	0		Mysticality: +15, Last Available: "2011-09"
 5278	reassuring Annie Oakley's blammer	0		Critical Hit Percent: +20, Spooky Resistance: +1, Last Available: "2011-09"
 5279	boxer's clock-cleaning hammer	0		Muscle Percent: +10, Last Available: "2011-09"
-5280	blinking ghostly 4:20 bomb	0		Last Available: "2011-09"
+5280	ghostly blinking 4:20 bomb	0		Last Available: "2011-09"
 5281	upside-down therapeutic broken clock	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-09"
 5282	asbestos-lined dethklok	0		Hot Resistance: +5, Last Available: "2011-09"
 5283	banded glacial clock	0		Damage Absorption: +100, Last Available: "2011-09"
-5284	skewed Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
-5285	tumbling teal d4	0		Last Available: "2011-09"
+5284	skewed Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5285	teal tumbling d4	0		Last Available: "2011-09"
 5286	purple d6	0		Last Available: "2011-09"
 5287	pulsating d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
@@ -5215,37 +5215,37 @@
 5312	non-unsweetened oxidized teal ghostly body paint	0		Effect: "The Magic of Sharing", Effect Duration: 18, Last Available: "2011-10"
 5313	nitrogenated boiled necrotizing body spray	0		Effect: "Space Tripping", Effect Duration: 47, Last Available: "2011-10"
 5314	deionized double-anodized bite-me-red lipstick	0		Effect: "Perception", Effect Duration: 44, Last Available: "2011-10"
-5315	extra-cold-filtered bouncing squat whisker pencil	0		Effect: "Disco Neuropathy", Effect Duration: 37, Last Available: "2011-10"
+5315	extra-cold-filtered squat bouncing whisker pencil	0		Effect: "Disco Neuropathy", Effect Duration: 37, Last Available: "2011-10"
 5316	energized denatured press-on ribs	0		Effect: "Ichorous Intensity", Effect Duration: 27, Last Available: "2011-10"
 5317	super-alkaline Rattlin' Chains	0		Effect: "Elron's Explosive Etude", Effect Duration: 53, Last Available: "2011-10"
 5318	oxidized dry super-enhanced Gummy Brains	0		Effect: "Inappropriate Spirit", Effect Duration: 27, Last Available: "2011-10"
 5319	diffused ionized shaking Blood 'n' Plenty	0		Effect: "Stregngth of the Gnome", Effect Duration: 53, Last Available: "2011-10"
-5320	magnetized mirror twirling wobbly Lobos Mints	0		Effect: "Thanksgot", Effect Duration: 25, Last Available: "2011-10"
+5320	magnetized twirling mirror wobbly Lobos Mints	0		Effect: "Thanksgot", Effect Duration: 25, Last Available: "2011-10"
 5321	quadruple-irradiated spinning Sweet Sword	0		Effect: "Lubed", Effect Duration: 68, Last Available: "2011-10"
 5322	perfectly mixed green Ecto-Cooler	4	EPIC	Last Available: "2011-10"
-5323	aged fortified Bartles and BRAAAINS wine cooler	5	awesome	Last Available: "2011-10"
-5324	hand-crafted extra-dry Blood Light	5	EPIC	Last Available: "2011-10"
-5325	hand-crafted weak Silver Bullet beer	2	EPIC	Last Available: "2011-10"
-5326	smooth irresponsibly strong Bone's Farm &quot;wine&quot;	8	awesome	Last Available: "2011-10"
+5323	fortified aged Bartles and BRAAAINS wine cooler	5	awesome	Last Available: "2011-10"
+5324	extra-dry hand-crafted Blood Light	5	EPIC	Last Available: "2011-10"
+5325	weak hand-crafted Silver Bullet beer	2	EPIC	Last Available: "2011-10"
+5326	irresponsibly strong smooth Bone's Farm &quot;wine&quot;	8	awesome	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	modified triple-magnetized teal shaking sorority brain	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 17, Last Available: "2011-10"
 5329	polarized colloidal huge Nightstalker perfume	0		Effect: "Fudgehound", Effect Duration: 53, Last Available: "2011-10"
 5330	frozen frozen polymerized tumbling drum of pomade	0		Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	frosty extra-see-thru nightie	0		Cold Spell Damage: +10, Last Available: "2011-10"
-5333	asbestos-lined BRAINS shorts of the pedagogue	0		Experience: +3, Hot Resistance: +5, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	asbestos-lined BRAINS shorts of the pedagogue	0		Experience: +3, Hot Resistance: +5, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	narrow squat personal trainer's Mesmereyes&trade; contact lenses	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2011-10"
 5335	energetic scrunchie	0		Maximum MP Percent: +20, Single Equip, Last Available: "2011-10"
-5336	blurry Fonzie's strapping extremely skinny jeans	0		Muscle: +5, Experience (Moxie): +1, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	mansplainer's The Necbromancer's Hat of James Dean	0		Experience (Moxie): +3, Monster Level: +15, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	blurry Fonzie's strapping extremely skinny jeans	0		Muscle: +5, Experience (Moxie): +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	mansplainer's The Necbromancer's Hat of James Dean	0		Experience (Moxie): +3, Monster Level: +15, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	knitted Sinatra's The Necbromancer's Stein of the scaredy-cat	0		Experience (Moxie): +5, Monster Level: -15, Cold Resistance: +3, Last Available: "2011-10"
-5339	lightning-fast chaotic veiny The Necbromancer's Shorts	0		Maximum HP: +10, Spell Critical Percent: +10, Initiative: +40, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	lightning-fast chaotic veiny The Necbromancer's Shorts	0		Maximum HP: +10, Spell Critical Percent: +10, Initiative: +40, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	nasty mansplainer's The Necbromancer's Wizard Staff of the overflowing toilet	0		Monster Level: +15, Stench Damage: +5, Stench Spell Damage: +50, Last Available: "2011-10"
 5341	blinking The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	weak lousy ghostly The Cooler Out of Space	2	decent	Last Available: "2011-10"
 5343	wobbly The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
-5345	polarized purple huge Necbro wafers	0		Effect: "Shot in the Arse", Effect Duration: 57, Last Available: "2020-09"
+5345	polarized huge purple Necbro wafers	0		Effect: "Shot in the Arse", Effect Duration: 57, Last Available: "2020-09"
 5346	death blossom	0		
 5347	A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	blurry A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -5254,11 +5254,11 @@
 5351	purple A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	green A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
-5354	huge wobbly The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+5354	wobbly huge The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	bouncing Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	purple A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
-5358	ghostly purple Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
+5358	purple ghostly Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
@@ -5266,7 +5266,7 @@
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-5366	upside-down narrow CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+5366	narrow upside-down CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5368	Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	narrow blinking Fonzie's KoL Con 8-Bit power bracelet	0		Experience (Moxie): +1, Last Available: "2011-09"
@@ -5306,14 +5306,14 @@
 5403	twirling Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	medical-grade brawny cane-mail shirt of Calamity Jane	0		Muscle Percent: +20, Critical Hit Percent: +15, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-12"
-5406	frightening Jim Carey's cane-mail pants of bravery	0		Monster Level: +25, Spooky Damage: +5, Spooky Resistance: +5, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	frightening Jim Carey's cane-mail pants of bravery	0		Monster Level: +25, Spooky Damage: +5, Spooky Resistance: +5, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	drinkable cyan Vodka Matryoshka	4	good	Last Available: "2011-12"
-5408	hand-crafted extra-dry Gin Mint	5	EPIC	Last Available: "2011-12"
+5408	extra-dry hand-crafted Gin Mint	5	EPIC	Last Available: "2011-12"
 5409	mediocre weak Tequiz Navidad	2	decent	Last Available: "2011-12"
 5410	artisanal Mint Yulep	3	EPIC	Last Available: "2011-12"
 5411	weak bad lime green Crimbojito	2	decent	Last Available: "2011-12"
 5412	aged upside-down Sangria de Menthe	3	awesome	Last Available: "2011-12"
-5413	mirror mirror green candycaine powder	0		Last Available: "2011-12"
+5413	mirror green mirror candycaine powder	0		Last Available: "2011-12"
 5414	blinking licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	ionized narrow green licorice root	0		Effect: "Badger Underfoot", Effect Duration: 33, Last Available: "2011-12"
 5416	aerosolized wet huge banana supersucker	0		Effect: "Amplified Fabulousness", Effect Duration: 27, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	ghostly kumquartz ring of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2011-11"
 5425	strawberyl necklace of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2011-11"
 5426	frosty sucker bucket of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2011-11"
-5427	sucker hakama of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	shaking sucker kabuto of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	sucker hakama of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	shaking sucker kabuto of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	aromatic sucker tachi	0		Stench Resistance: +1, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	ghostly cinnamon troll doll	0		Last Available: "2011-11"
@@ -5359,11 +5359,11 @@
 5456	fuchsia gummi ingot	0		Last Available: "2011-11"
 5457	magnetized Fudgie Roll	0		Effect: "Libra Rising", Effect Duration: 13, Last Available: "2011-11"
 5458	bland fudge bunny	3	decent	Last Available: "2011-11"
-5459	bouncing upside-down fudge spork	0		Last Available: "2011-11"
+5459	upside-down bouncing fudge spork	0		Last Available: "2011-11"
 5460	censurious smelly fudgecycle of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, Sleaze Resistance: +3, Single Equip, Last Available: "2011-11"
 5461	squat squat fudge cube	0		Last Available: "2011-11"
 5462	ghostly blank fudge mold	0		Last Available: "2011-11"
-5463	upside-down blurry Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	upside-down blurry Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	warmed corrupted non-enhanced skewed resolution: be wealthier	0		Effect: "Towering Strength", Effect Duration: 40, Last Available: "2012-01"
 5465	frozen mirror resolution: be happier	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 65, Last Available: "2012-01"
 5466	non-dry galvanized resolution: be stronger	0		Effect: "Frog In Your Throat", Effect Duration: 15, Last Available: "2012-01"
@@ -5383,7 +5383,7 @@
 5480	half-sized flavorless gummi bear	2	decent	Last Available: "2011-11"
 5481	jumbo stale mirror gummi bear	5	decent	Last Available: "2011-11"
 5482	rotten drunki-bear	4	crappy	Last Available: "2011-11"
-5483	tasty thick drunki-bear	5	awesome	Last Available: "2011-11"
+5483	thick tasty drunki-bear	5	awesome	Last Available: "2011-11"
 5484	stale drunki-bear	3	decent	Last Available: "2011-11"
 5485	skewed gummi bowtie of chilblains	0		Cold Damage: +25, Last Available: "2011-11"
 5486	veiny fudge pocket square	0		Maximum HP: +10, Last Available: "2011-11"
@@ -5396,10 +5396,10 @@
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	modified polarized jittery gummi trilobite	0		Effect: "Sugar, Hello", Effect Duration: 26, Last Available: "2011-11"
 5495	moist unsweetened gummi ammonite	0		Effect: "Pride of the Vampire", Effect Duration: 14, Last Available: "2011-11"
-5496	improved ghostly blurry gummi belemnite	0		Effect: "Partially Ghosted", Effect Duration: 22, Last Available: "2011-11"
+5496	improved blurry ghostly gummi belemnite	0		Effect: "Partially Ghosted", Effect Duration: 22, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	mirror lion tamer's groovy Big Candy's tophat	0		Moxie Percent: +10, Experience (familiar): +2, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	mirror lion tamer's groovy Big Candy's tophat	0		Moxie Percent: +10, Experience (familiar): +2, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	wobbly Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5410,7 +5410,7 @@
 5507	drinkable Go-Wassail	3	good	Last Available: "2011-11"
 5508	dry Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Ice Packed", Effect Duration: 53, Last Available: "2011-11"
 5509	adjusted maroon bottle of bubbles	0		Effect: "Moon-Eyed", Effect Duration: 13, Last Available: "2011-11"
-5510	frozen cyan spinning wind-up meatcar	0		Effect: "Burning Tongue", Effect Duration: 30, Last Available: "2011-11"
+5510	frozen spinning cyan wind-up meatcar	0		Effect: "Burning Tongue", Effect Duration: 30, Last Available: "2011-11"
 5511	wobbly Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	wobbly Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5435,7 +5435,7 @@
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	cold-filtered oxidized alkaline Mortimer's nostrum	0		Effect: "Banono", Effect Duration: 23, Last Available: "2012-12"
 5534	hand-crafted Barulio's bottle	4	EPIC	Last Available: "2012-12"
-5535	dry dry teal bouncing Marvin's marvelous pill	0		Effect: "Old School Pompadour", Effect Duration: 63, Last Available: "2012-12"
+5535	dry dry bouncing teal Marvin's marvelous pill	0		Effect: "Old School Pompadour", Effect Duration: 63, Last Available: "2012-12"
 5536	shaking Winifred's whistle	0		Last Available: "2012-12"
 5537	huge prose pen	0		Last Available: "2012-12"
 5538	blurry half-empty carton of milk	0		Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	Samson's Rain-Doh wings of the bloodbag	0		Experience (Muscle): +5, Maximum HP: +100, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	occult Rain-Doh laser gun of the cheetah	0		Spell Damage Percent: +25, Initiative: +60, Softcore Only, Last Available: "2012-02"
-5559	Rain-Doh lantern of Calamity Jane of Leguizamo	0		Critical Hit Percent: +15, Monster Level: +20, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	Rain-Doh lantern of Calamity Jane of Leguizamo	0		Critical Hit Percent: +15, Monster Level: +20, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	shaking twirling Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	Usain Bolt's Rain-Doh violet bo of the boozehound	0		Booze Drop: +100, Initiative: +80, Softcore Only, Last Available: "2012-02"
@@ -5467,28 +5467,28 @@
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	stale yellow PB&BP	4	decent	
 5566	rotten club sandwich	3	crappy	
-5567	gigantic enchanted rotten corned-beef Reuben	7	crappy	Effect: "Well Owl Be!", Effect Duration: 40
+5567	enchanted gigantic rotten corned-beef Reuben	7	crappy	Effect: "Well Owl Be!", Effect Duration: 40
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	blinking Thwaitgold stag beetle statuette	0		
-5573	bad practically non-alcoholic fuchsia Drac & Tan	1	decent	Last Available: "2012-03"
+5573	practically non-alcoholic bad fuchsia Drac & Tan	1	decent	Last Available: "2012-03"
 5574	mediocre lime green Transylvania Sling	4	decent	Last Available: "2012-03"
 5575	drinkable Shot of the Living Dead	4	good	Last Available: "2012-03"
 5576	bad practically non-alcoholic huge Buttery Knob	1	decent	Last Available: "2012-03"
-5577	mediocre fancy Slippery Knob	3	decent	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2012-03"
+5577	fancy mediocre Slippery Knob	3	decent	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2012-03"
 5578	mediocre Flaming Knob	3	decent	Last Available: "2012-03"
 5579	hand-crafted Grasshopper	3	EPIC	Last Available: "2012-03"
 5580	drinkable high-proof Locust	8	good	Last Available: "2012-03"
 5581	acceptable Plague of Locusts	3	good	Last Available: "2012-03"
 5582	bad weak Red Dwarf	2	decent	Last Available: "2012-03"
 5583	artisanal jittery Golden Mean	3	EPIC	Last Available: "2012-03"
-5584	drinkable extra-dry Green Giant	5	good	Last Available: "2012-03"
+5584	extra-dry drinkable Green Giant	5	good	Last Available: "2012-03"
 5585	mediocre Aye Aye	4	decent	Last Available: "2012-03"
-5586	perfectly mixed watered-down red Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
+5586	watered-down perfectly mixed red Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
 5587	tolerable squat Aye Aye, Tooth Tooth	3	good	Last Available: "2012-03"
-5588	high-proof acceptable special tumbling Humanitini	8	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2012-03"
+5588	acceptable special high-proof tumbling Humanitini	8	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2012-03"
 5589	tolerable More Humanitini than Humanitini	3	good	Last Available: "2012-03"
 5590	mediocre blinking Oh, the Humanitini	3	decent	Last Available: "2012-03"
 5591	lousy extra-dry Great Older Fashioned	5	decent	Last Available: "2012-03"
@@ -5498,34 +5498,34 @@
 5595	tolerable practically non-alcoholic blue Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
 5596	hand-crafted high-proof Sloe Comfortable Zoo on Fire	7	EPIC	Last Available: "2012-03"
 5597	tolerable fuchsia Suffering Sinner	4	good	Last Available: "2012-03"
-5598	drinkable boozy special Suppurating Sinner	5	good	Effect: "Tingly Biceps", Effect Duration: 5, Last Available: "2012-03"
+5598	boozy special drinkable Suppurating Sinner	5	good	Effect: "Tingly Biceps", Effect Duration: 5, Last Available: "2012-03"
 5599	smooth high-proof Sizzling Sinner	10	awesome	Last Available: "2012-03"
-5600	enchanted tolerable practically non-alcoholic squat yellow Firewater	1	good	Effect: "Wreathed in Smoke", Effect Duration: 10, Last Available: "2012-03"
+5600	tolerable enchanted practically non-alcoholic yellow squat Firewater	1	good	Effect: "Wreathed in Smoke", Effect Duration: 10, Last Available: "2012-03"
 5601	perfectly mixed Earth and Firewater	3	EPIC	Last Available: "2012-03"
-5602	hand-crafted strong Earth, Wind and Firewater	5	EPIC	Last Available: "2012-03"
+5602	strong hand-crafted Earth, Wind and Firewater	5	EPIC	Last Available: "2012-03"
 5603	boozy bad Slimosa	5	decent	Last Available: "2012-03"
 5604	perfectly mixed Extra-slimy Slimosa	3	EPIC	Last Available: "2012-03"
-5605	high-proof acceptable maroon Slimebite	7	good	Last Available: "2012-03"
-5606	weak acceptable Cement Mixer	2	good	Last Available: "2012-03"
+5605	acceptable high-proof maroon Slimebite	7	good	Last Available: "2012-03"
+5606	acceptable weak Cement Mixer	2	good	Last Available: "2012-03"
 5607	high-proof acceptable Jackhammer	8	good	Last Available: "2012-03"
 5608	acceptable practically non-alcoholic Dump Truck	1	good	Last Available: "2012-03"
 5609	hand-crafted Fauna Libre	4	EPIC	Last Available: "2012-03"
 5610	acceptable Chakra Libre	3	good	Last Available: "2012-03"
 5611	aged practically non-alcoholic Aura Libre	1	awesome	Last Available: "2012-03"
 5612	smooth weak jittery Sazerorc	2	awesome	Last Available: "2012-03"
-5613	high-proof lousy spinning Sazuruk-hai	10	decent	Last Available: "2012-03"
-5614	lousy spirit-forward Flaming Sazerorc	5	decent	Last Available: "2012-03"
+5613	lousy high-proof spinning Sazuruk-hai	10	decent	Last Available: "2012-03"
+5614	spirit-forward lousy Flaming Sazerorc	5	decent	Last Available: "2012-03"
 5615	acceptable weak Green Velvet	2	good	Last Available: "2012-03"
 5616	watered-down perfectly mixed Green Muslin	2	EPIC	Last Available: "2012-03"
-5617	triple-distilled tolerable Green Burlap	7	good	Last Available: "2012-03"
+5617	tolerable triple-distilled Green Burlap	7	good	Last Available: "2012-03"
 5618	strong smooth Mohobo	5	awesome	Last Available: "2012-03"
 5619	perfectly mixed mirror Moonshine Mohobo	4	EPIC	Last Available: "2012-03"
 5620	bad yellow Flaming Mohobo	3	decent	Last Available: "2012-03"
-5621	fortified bad Drunken Philosopher	5	decent	Last Available: "2012-03"
-5622	special aged Drunken Neurologist	3	awesome	Effect: "In a Lather", Effect Duration: 10, Last Available: "2012-03"
+5621	bad fortified Drunken Philosopher	5	decent	Last Available: "2012-03"
+5622	aged special Drunken Neurologist	3	awesome	Effect: "In a Lather", Effect Duration: 10, Last Available: "2012-03"
 5623	drinkable practically non-alcoholic gray Drunken Astrophysicist	1	good	Last Available: "2012-03"
-5624	spirit-forward artisanal Dark & Starry	5	EPIC	Last Available: "2012-03"
-5625	acceptable watered-down Black Hole	2	good	Last Available: "2012-03"
+5624	artisanal spirit-forward Dark & Starry	5	EPIC	Last Available: "2012-03"
+5625	watered-down acceptable Black Hole	2	good	Last Available: "2012-03"
 5626	bad Event Horizon	3	decent	Last Available: "2012-03"
 5627	tolerable high-proof Herring Daiquiri	9	good	Last Available: "2012-03"
 5628	drinkable Herring Wallbanger	3	good	Last Available: "2012-03"
@@ -5536,9 +5536,9 @@
 5633	weak artisanal mirror olive Caipiranha	2	EPIC	Last Available: "2012-03"
 5634	enchanted bad Flying Caipiranha	3	decent	Effect: "Extra Backbone", Effect Duration: 20, Last Available: "2012-03"
 5635	hand-crafted wobbly Flaming Caipiranha	3	EPIC	Last Available: "2012-03"
-5636	delicious boozy Punchplanter	5	awesome	Last Available: "2012-03"
+5636	boozy delicious Punchplanter	5	awesome	Last Available: "2012-03"
 5637	lousy skewed Doublepunchplanter	3	decent	Last Available: "2012-03"
-5638	acceptable weak Haymaker	2	good	Last Available: "2012-03"
+5638	weak acceptable Haymaker	2	good	Last Available: "2012-03"
 5639	shaking Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	flavorless fungus	4	decent	
@@ -5548,14 +5548,14 @@
 5645	purple the Nostril of the Serpent	0		
 5646	skewed calendar fragment	0		
 5647	forbidden calendar	0		Spell Damage Percent: +50, Damage Reduction: 4
-5648	Temple Grandin's wicked Boris's Helm	0		Spell Damage: +5, Familiar Weight: +7, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	Temple Grandin's wicked Boris's Helm	0		Spell Damage: +5, Familiar Weight: +7, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	therapeutic thinker's staph of homophones	0		Mysticality: +10, HP Regen Min: 5, HP Regen Max: 7
-5650	spinning Annie Oakley's hardened occult Boris's Helm (askew)	0		Spell Damage Percent: +25, Damage Reduction: 3, Critical Hit Percent: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	spinning Annie Oakley's hardened occult Boris's Helm (askew)	0		Spell Damage Percent: +25, Damage Reduction: 3, Critical Hit Percent: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	cyan mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	spoiled enchanted nailswurst	4	crappy	Effect: "Industrial Strength Starch", Effect Duration: 10
-5655	delicious watered-down pulsating used beer	2	awesome	
+5654	enchanted spoiled nailswurst	4	crappy	Effect: "Industrial Strength Starch", Effect Duration: 10
+5655	watered-down delicious pulsating used beer	2	awesome	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5566,20 +5566,20 @@
 5663	microwave	0		Free Pull
 5664	pony keg	0		Free Pull
 5665	wobbly red How to Tolerate Jerks	0		Skill: "Thick-Skinned"
-5666	huge lime green How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
+5666	lime green huge How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	shaking puppet strings	0		Free Pull
 5668	upside-down bagged &quot;L&quot;	0		
 5669	club	0		
-5670	low-calorie flavorless fettucini &eacute;pines Inconnu	1	decent	
+5670	flavorless low-calorie fettucini &eacute;pines Inconnu	1	decent	
 5671	smooth slap and slap again	4	awesome	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	jittery &quot;L&quot;	0		
-5675	powdered spinning pulsating watered-down Red Minotaur	1		
+5675	powdered pulsating spinning watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	shaking savvy Ze&trade; goggles	0		Mysticality Percent: +20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	shaking savvy Ze&trade; goggles	0		Mysticality Percent: +20, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	Annie Oakley's slick stylish swimsuit	0		Moxie: +10, Critical Hit Percent: +20, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	Annie Oakley's slick stylish swimsuit	0		Moxie: +10, Critical Hit Percent: +20, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	moldy P.B.L.T.	4	crappy	
 5682	blue note from Clancy	0		Skill: "Request Sandwich"
@@ -5594,7 +5594,7 @@
 5691	blinking ghostly pacification grenade	0		
 5692	quantum disintegrator pistol of the detective	0		Item Drop: +20
 5693	twirling Oprah's phase-tuned shield generator belt	0		Maximum MP Percent: +50, Single Equip
-5694	bouncing tumbling Thwaitgold woollybear statuette	0		
+5694	tumbling bouncing Thwaitgold woollybear statuette	0		
 5695	greasy bugbear detector	0		Sleaze Spell Damage: +10, Single Equip
 5696	green bugbear purification pill	0		
 5697	shaking 1 Meat	0		
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	spinning experienced wax hat of dire peril	0		Experience: +2, Weapon Damage: +20, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	frosty Temple Grandin's wax pants	0		Familiar Weight: +7, Cold Spell Damage: +10, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	spinning experienced wax hat of dire peril	0		Experience: +2, Weapon Damage: +20, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	frosty Temple Grandin's wax pants	0		Familiar Weight: +7, Cold Spell Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	jittery blinking FDKOL commendation	0		Last Available: "2012-07"
-5708	modified spinning yellow spinning drop of water-37	0		Effect: "init.enh", Effect Duration: 45, Last Available: "2012-07"
-5709	Sinatra's educational fireman's helmet	0		Experience: +1, Experience (Moxie): +5, Last Available: "2012-07", Familiar Effect: "cold atk"
+5708	modified spinning spinning yellow drop of water-37	0		Effect: "init.enh", Effect Duration: 45, Last Available: "2012-07"
+5709	Sinatra's educational fireman's helmet	0		Experience: +1, Experience (Moxie): +5, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	squat up-at-dawn fire axe	0		Adventures: +5, Last Available: "2012-07"
 5713	asbestos-lined frightening smooth fire extinguisher	0		Moxie: +15, Spooky Damage: +5, Hot Resistance: +5, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,30 +5618,30 @@
 5717	normal blurry FDKOL hotcakes	3	good	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	pulsating smoking grass	0		Last Available: "2012-07"
-5720	flavorless diet fiery wing	1	decent	Last Available: "2012-07"
+5720	diet flavorless fiery wing	1	decent	Last Available: "2012-07"
 5721	Oprah's wings of fire of the cougar	0		Moxie: +20, Maximum MP Percent: +50, Last Available: "2012-07"
 5722	twirling razor-sharp FDKOL fire hose	0		Weapon Damage Percent: +25, Last Available: "2012-07"
 5723	double-deionized Vulcanized ionized bottle of fire	0		Effect: "Metal Speed", Effect Duration: 65, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	purple wobbly forbidden hot daub bun of the cheetah	0		Spell Damage Percent: +50, Initiative: +60, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	fortified sage hot daub stand	0		Mysticality Percent: +10, Damage Absorption: +60, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	purple wobbly forbidden hot daub bun of the cheetah	0		Spell Damage Percent: +50, Initiative: +60, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	fortified sage hot daub stand	0		Mysticality Percent: +10, Damage Absorption: +60, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	spinning double-paned foot-long hot daub of the cheetah	0		Cold Resistance: +5, Initiative: +60, Last Available: "2012-07"
 5729	bouncing ballpark hot daub	0		Last Available: "2012-07"
-5730	rotten thick angst burger	5	crappy	
+5730	thick rotten angst burger	5	crappy	
 5731	perfectly mixed 5-hour acrimony	4	EPIC	
 5732	blank note	0		
 5733	eerily silent box	0		
-5734	flavorless small forbidden sausage	2	decent	
+5734	small flavorless forbidden sausage	2	decent	
 5735	Sherlock's Lord Flameface's cloak	0		Item Drop: +25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	frozen quantum Drizzlers&trade; Black Licorice	0		Effect: "Motion", Effect Duration: 58
 5737	tarnished daub-breaker	0		Effect: "Slimily Strong", Effect Duration: 12, Last Available: "2020-09"
 5738	mirror twirling rock-hard Camp Scout backpack	0		Damage Reduction: 5, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	normal fancy big bag of GORP	5	good	Effect: "Loyal Tea", Effect Duration: 5, Last Available: "2012-07"
+5740	big normal fancy bag of GORP	5	good	Effect: "Loyal Tea", Effect Duration: 5, Last Available: "2012-07"
 5741	bad water purification pills	3	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	watered-down tolerable CSA scoutmaster's &quot;water&quot;	2	good	Last Available: "2012-07"
+5743	tolerable watered-down CSA scoutmaster's &quot;water&quot;	2	good	Last Available: "2012-07"
 5744	low-calorie flavorless blinking bag of GORF	1	decent	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	stale mirror bag of QWOP	3	decent	Last Available: "2012-07"
@@ -5651,9 +5651,9 @@
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	flavorless super-sized ghostly crappy brain	5	decent	
-5753	bland huge pulsating decent brain	6	decent	
+5753	huge bland pulsating decent brain	6	decent	
 5754	decent good brain	4	good	
-5755	adequate gigantic spinning boss brain	8	good	
+5755	gigantic adequate spinning boss brain	8	good	
 5756	flavorless narrow hunter brain	4	decent	
 5758	hale hardened Staff of Holiday Sensations of bravery	0		Damage Reduction: 3, Maximum HP: +20, Spooky Resistance: +5, Last Available: "2011-11"
 5759	reassuring staff of the brute	0		Muscle Percent: +30, Spooky Resistance: +1
@@ -5665,11 +5665,11 @@
 5765	upside-down bouncing Usain Bolt's hardy fuzzy earmuffs	0		Maximum HP: +50, Initiative: +80, Familiar Effect: "1.5xVolley, cap 32"
 5766	scorching ruddy smooth fuzzy montera	0		Moxie: +15, Maximum HP Percent: +40, Hot Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	ghostly shaking gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	shaking ghostly gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	lime green pulsating fronts	0		Familiar Weight: +5
@@ -5711,7 +5711,7 @@
 5812	dry nitrogenated spinning skelelton spine	0		Effect: "Gleaming White Teeth", Effect Duration: 36
 5813	improved smut orc sunglasses	0		Effect: "French Bronilla Brogueishness", Effect Duration: 16
 5814	frozen tarnished blob of acid	0		Effect: "Unusual Fashion Sense", Effect Duration: 27
-5815	triple-cold-filtered red upside-down flayed mind	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 47
+5815	triple-cold-filtered upside-down red flayed mind	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 47
 5816	chilled ionized blue kobold kibble	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 61
 5817	chilled pickled forest spirit rattle	0		Effect: "Aloofah", Effect Duration: 11
 5818	activated twirling Stone Golem pebbles	0		Effect: "Disco Neuropathy", Effect Duration: 15
@@ -5723,7 +5723,7 @@
 5824	ionized clove-flavored lip balm	0		Effect: "Jingle Jangle Jingle", Effect Duration: 44
 5825	galvanized purple Skullery Maid's Knee	0		Effect: "Can't Smell Nothin'", Effect Duration: 47
 5826	oxidized pickled yellow zombie hollandaise	0		Effect: "Dweeby", Effect Duration: 18
-5827	triple-cold-filtered lime green upside-down skeletal banana	0		Effect: "Strength of Ten Ettins", Effect Duration: 15
+5827	triple-cold-filtered upside-down lime green skeletal banana	0		Effect: "Strength of Ten Ettins", Effect Duration: 15
 5828	unsweetened gilt perfume bottle	0		Effect: "Meatwise", Effect Duration: 48
 5829	unsweetened pressed janglin' bones	0		Effect: "Gummi-Grin", Effect Duration: 61
 5830	tarnished pygmy papers	0		Effect: "Ocelot Eyes", Effect Duration: 53
@@ -5757,8 +5757,8 @@
 5858	double-ionized polarized votive candle	0		Effect: "Almost Cool", Effect Duration: 39
 5859	electrified booby trap	0		Effect: "Category", Effect Duration: 56
 5860	anodized pressed maroon Agent Corrigan's cigarette	0		Effect: "Thick, Sick", Effect Duration: 65
-5861	quantum dry maroon upside-down pulsating good ash	0		Effect: "Metal Speed", Effect Duration: 49
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5861	quantum dry upside-down maroon pulsating good ash	0		Effect: "Metal Speed", Effect Duration: 49
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	green Rad Lib	0		Last Available: "2012-09"
 5864	fuchsia papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	flattened energized chilled blinking papier-mochi	0		Effect: "Human-Fish Hybrid", Effect Duration: 46, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	squat gray executive Rosewater's papier-m&acirc;ch&eacute;te	0		Mysticality Percent: +30, Meat Drop: +40, Last Available: "2012-09"
 5869	perfumed Jeselnik's papier-m&acirc;chine gun	0		Sleaze Damage: +25, Stench Resistance: +5, Last Available: "2012-09"
 5870	Jeselnik's papier-masque of Gandalf	0		Spell Critical Percent: +20, Sleaze Damage: +25, Single Equip, Last Available: "2012-09"
-5871	quilted experienced papier-mitre	0		Experience: +2, Damage Absorption: +40, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	tumbling nippy experienced papier-m&acirc;churidars	0		Experience: +2, Cold Damage: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	quilted experienced papier-mitre	0		Experience: +2, Damage Absorption: +40, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	tumbling nippy experienced papier-m&acirc;churidars	0		Experience: +2, Cold Damage: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	upside-down papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	huge papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	tumbling skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	skewed scorching sinister beefcake's Bonestabber of doom	0		Muscle: +25, Spell Damage: +10, Hot Damage: +25, Spooky Spell Damage: +50, Last Available: "2012-10"
-5887	perfectly mixed boozy crystal skeleton vodka	5	EPIC	Last Available: "2012-10"
+5887	boozy perfectly mixed crystal skeleton vodka	5	EPIC	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	teal energetic auxiliary backbone	0		Maximum MP Percent: +20, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5823,7 +5823,7 @@
 5925	blue ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	shaking brainwave-controlled unicorn horn of the brute	0		Muscle Percent: +30, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	shaking brainwave-controlled unicorn horn of the brute	0		Muscle Percent: +30, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	wobbly Tesla rock-hard plastic four-shadowed mime of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	steel-toed plastic Father McGruber	0		Damage Reduction: 9, Last Available: "2012-12"
 5961	squat plastic Hank North, Photojournalist of the detective	0		Item Drop: +20, Last Available: "2012-12"
 5962	medical-grade plastic blazing bat	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-12"
-5963	jittery inspector's supercool electronic dulcimer pants	0		Moxie Percent: +20, Item Drop: +15, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	jittery inspector's supercool electronic dulcimer pants	0		Moxie Percent: +20, Item Drop: +15, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	jittery MacGyver's Frown Exerciser of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5877,31 +5877,31 @@
 5979	blue huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	special mediocre weak tankard of ale	2	decent	Effect: "I See Everything Thrice!", Effect Duration: 5, Last Available: "2013-02"
+5982	mediocre special weak tankard of ale	2	decent	Effect: "I See Everything Thrice!", Effect Duration: 5, Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	blurry Socratic strapping cloth cap of the sewer	0		Muscle: +5, Experience (Mysticality): +1, Stench Damage: +25, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	blurry Socratic strapping cloth cap of the sewer	0		Muscle: +5, Experience (Mysticality): +1, Stench Damage: +25, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	tumbling healthy banded iron dagger of the cheetah	0		Damage Absorption: +100, Maximum HP Percent: +20, Initiative: +60, Last Available: "2013-02"
 5986	tasty teal hamburger	4	awesome	Last Available: "2013-02"
 5987	wobbly dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	aged practically non-alcoholic tumbling bottle of wine	1	awesome	Last Available: "2013-02"
+5990	practically non-alcoholic aged tumbling bottle of wine	1	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	aromatic reassuring thinker's iron helmet	0		Mysticality: +10, Spooky Resistance: +1, Stench Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	aromatic reassuring thinker's iron helmet	0		Mysticality: +10, Spooky Resistance: +1, Stench Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	Annie Oakley's forbidden Newton's steel sword	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Critical Hit Percent: +20, Last Available: "2013-02"
-5994	half-sized decent upside-down pulsating whole roasted chicken	2	good	Last Available: "2013-02"
+5994	half-sized decent pulsating upside-down whole roasted chicken	2	good	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	artisanal shining goblet	4	EPIC	Last Available: "2013-02"
-5999	blue twirling fireball	0		Last Available: "2013-02"
-6000	prompt auspicious cool crown	0		Moxie: +5, Item Drop: +10, Adventures: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+5999	twirling blue fireball	0		Last Available: "2013-02"
+6000	prompt auspicious cool crown	0		Moxie: +5, Item Drop: +10, Adventures: +3, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	mirror Sherlock's family-friendly sword of vim and vigor	0		Maximum HP Percent: +50, Sleaze Resistance: +1, Item Drop: +25, Last Available: "2013-02"
-6002	narrow prompt frosty Van der Graaf Helm of the Scream Emperor	0		Cold Spell Damage: +10, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	narrow prompt frosty Van der Graaf Helm of the Scream Emperor	0		Cold Spell Damage: +10, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	shaking fortified Cloak of Dire Shadows of incineration of the detective	0		Damage Absorption: +60, Hot Spell Damage: +50, Item Drop: +20, Last Available: "2013-02"
 6004	chilly dog trainer's arcane researcher's Sword of Dark Omens	0		Experience Percent (Mysticality): +10, Experience (familiar): +1, Cold Damage: +5, Last Available: "2013-02"
 6005	hardy baleful experienced Shield of Icy Fate	0		Experience: +2, Spell Damage: +25, Maximum HP: +50, Damage Reduction: 7, Last Available: "2013-02"
-6006	lime green foul-smelling razor-sharp Greaves of the Murk Lord of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +25, Stench Damage: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	lime green foul-smelling razor-sharp Greaves of the Murk Lord of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +25, Stench Damage: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	fireproof Gauntlets of the Blood Moon of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Hot Resistance: +3, Single Equip, Last Available: "2013-02"
 6008	zippy miser's supercool Boots of Twilight Whispers	0		Moxie Percent: +20, Meat Drop: +10, Initiative: +20, Single Equip, Last Available: "2013-02"
 6009	Jeselnik's sizzling Belt of Howling Anger of the sewer	0		Hot Damage: +10, Stench Damage: +25, Sleaze Damage: +25, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	energized orcish hand lotion	0		Effect: "Fishy", Effect Duration: 39
 6016	aerosolized olive blinking orcish rubber	0		Effect: "Hagnk's Gratitude", Effect Duration: 14
 6017	non-liquefied extra-oxidized orcish nailing lube	0		Effect: "Sweet Taste", Effect Duration: 29
-6018	artisanal watered-down backwoods screwdriver	2	EPIC	
+6018	watered-down artisanal backwoods screwdriver	2	EPIC	
 6019	loadstone of James Dean	0		Experience (Moxie): +3
 6020	Claybender glasses of the empath of horror	0		Familiar Weight: +5, Spooky Spell Damage: +25, Single Equip
 6021	frosty strapping Duskwalker fangs	0		Muscle: +5, Cold Spell Damage: +10
@@ -5931,9 +5931,9 @@
 6033	aromatic savvy stolen necklace	0		Mysticality Percent: +20, Stench Resistance: +1
 6034	greasy friendly troll britches	0		Familiar Weight: +3, Sleaze Spell Damage: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	warmed vial of The Glistening	0		Effect: "Yuletide Mutations", Effect Duration: 35
-6036	perfectly mixed watered-down twirling artisanal limoncello	2	EPIC	
+6036	watered-down perfectly mixed twirling artisanal limoncello	2	EPIC	
 6037	ginger ale	0		
-6038	flavorless bite-sized wobbly incredible pizza	1	decent	
+6038	bite-sized flavorless wobbly incredible pizza	1	decent	
 6039	Oprah's oil cap of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Familiar Effect: "cap 28"
 6040	double-paned supercharged oil lamp	0		Maximum MP Percent: +30, Cold Resistance: +5
 6041	skewed chaotic oil slacks	0		Spell Critical Percent: +10, Familiar Effect: "1xPotato, cap 30"
@@ -5949,7 +5949,7 @@
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	spoiled Taco Dan's Taco Stand Taco	3	crappy	Last Available: "2012-12"
 6053	acceptable Taco Dan's Taco Stand Chimichangarita	3	good	Last Available: "2012-12"
-6054	triple-frozen colloidal jittery twirling maroon Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Danish Cunning", Effect Duration: 37, Last Available: "2012-12"
+6054	triple-frozen colloidal twirling jittery maroon Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Danish Cunning", Effect Duration: 37, Last Available: "2012-12"
 6055	jittery psychoanalytic jar	0		Last Available: "2013-12"
 6056	skewed twirling The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	greedy veiny Meatcleaver	0		Maximum HP: +10, Meat Drop: +20, Last Available: "2013-12"
@@ -5966,14 +5966,14 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	narrow sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	ionized tarnished jittery haggis-infused soap	0		Effect: "Slimy Hands", Effect Duration: 11, Last Available: "2012-12"
 6074	enhanced cold-filtered red mirror ghostly magicberry tablets	0		Effect: "Feet of Watermelon", Effect Duration: 25, Last Available: "2012-12"
 6075	magnetized shaking 37x37x37 puzzle cube	0		Effect: "Demonic Taint", Effect Duration: 37, Last Available: "2012-12"
-6076	smooth special weak McLeod's Hard Haggis-Ade	2	awesome	Effect: "Oriental Mysticism", Effect Duration: 15, Last Available: "2012-12"
+6076	smooth weak special McLeod's Hard Haggis-Ade	2	awesome	Effect: "Oriental Mysticism", Effect Duration: 15, Last Available: "2012-12"
 6077	flavorless haggis-wrapped haggis-stuffed haggis	3	decent	Last Available: "2012-12"
-6078	fuchsia shaking home robotics kit	0		Last Available: "2012-12"
+6078	shaking fuchsia home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	tumbling arcane researcher's haggis socks	0		Experience Percent (Mysticality): +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
 6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
@@ -6037,10 +6037,10 @@
 6139	narrow sage rubber gloves	0		Mysticality Percent: +10, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	blinking triad summoning scroll	0		Last Available: "2013-12"
-6142	miniature tasty roasted duck	2	awesome	Last Available: "2013-12"
+6142	tasty miniature roasted duck	2	awesome	Last Available: "2013-12"
 6143	adequate dead meat bun	4	good	Last Available: "2013-12"
 6144	stylish cat collar	0		Moxie: +25, Single Equip, Last Available: "2013-12"
-6145	Usain Bolt's rosewater-soaked suspicious-looking fedora	0		Stench Resistance: +3, Initiative: +80, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	Usain Bolt's rosewater-soaked suspicious-looking fedora	0		Stench Resistance: +3, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,17 +6058,17 @@
 6161	boxer's regret hose	0		Muscle Percent: +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	blue pulsating Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	sinister commodore's hat of dire peril	0		Weapon Damage: +20, Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	narrow frosty naval trousers	0		Cold Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	sinister commodore's hat of dire peril	0		Weapon Damage: +20, Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	narrow frosty naval trousers	0		Cold Spell Damage: +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	chaotic Oprah's deck cannon	0		Maximum MP Percent: +50, Spell Critical Percent: +10, Last Available: "2013-12"
 6167	bouncing teal ornamental sextant of incineration	0		Hot Spell Damage: +50, Last Available: "2013-12"
 6168	Jim Carey's thinker's Bloodbath	0		Mysticality: +10, Monster Level: +25, Last Available: "2013-12"
-6169	practically non-alcoholic aged special Hundred Headed IPA	1	awesome	Effect: "Hypercubed", Effect Duration: 35, Last Available: "2013-12"
-6170	stale gigantic chum	10	decent	Last Available: "2013-12"
+6169	aged practically non-alcoholic special Hundred Headed IPA	1	awesome	Effect: "Hypercubed", Effect Duration: 35, Last Available: "2013-12"
+6170	gigantic stale chum	10	decent	Last Available: "2013-12"
 6171	quadruple-anodized pulsating crude crudit&eacute;s	0		Effect: "Voracious Gorging", Effect Duration: 52
 6172	colloidal liquefied teal candy crayons	0		Effect: "Drunk With Power", Effect Duration: 22, Last Available: "2020-09"
 6173	smelly pixel grappling hook of dire peril	0		Weapon Damage: +20, Stench Spell Damage: +10
-6174	mirror twirling GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
+6174	twirling mirror GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	cosmic dough	0		
@@ -6076,34 +6076,34 @@
 6179	cosmic cheese	0		
 6180	cosmic potted meat product	0		
 6181	cyan skewed cosmic potato	0		
-6182	twirling pulsating cosmic cream	0		
+6182	pulsating twirling cosmic cream	0		
 6183	cosmic fruit	0		
 6184	fuchsia foul-smelling Fonzie's Jarlsberg's hat of doom	0		Experience (Moxie): +1, Stench Damage: +10, Spooky Spell Damage: +50
 6185	bland skewed consummate hard-boiled egg	3	decent	
 6186	bland consummate fried egg	4	decent	
-6187	spoiled super-sized consummate egg salad	5	crappy	
+6187	super-sized spoiled consummate egg salad	5	crappy	
 6188	flavorless thick mirror consummate bagel	5	decent	
-6189	tasty low-calorie consummate sliced bread	1	awesome	
+6189	low-calorie tasty consummate sliced bread	1	awesome	
 6190	adequate pulsating consummate hot dog bun	3	good	
 6191	snack-sized spoiled blurry spinning consummate brownie	2	crappy	
 6192	immense delicious consummate toast	8	awesome	
-6193	lousy weak passable stout	2	decent	
-6194	toothsome tiny consummate soup	1	awesome	
+6193	weak lousy passable stout	2	decent	
+6194	tiny toothsome consummate soup	1	awesome	
 6195	decent purple consummate corn chips	3	good	
 6196	normal wobbly consummate salad	3	good	
 6197	stale consummate salsa	3	decent	
-6198	small delicious blinking consummate sauerkraut	2	awesome	
+6198	delicious small blinking consummate sauerkraut	2	awesome	
 6199	snack-sized flavorless ghostly consummate cheese slice	2	decent	
 6200	normal consummate melted cheese	3	good	
 6201	moldy jumbo consummate bacon	5	crappy	
-6202	bland miniature consummate meatloaf	2	decent	
+6202	miniature bland consummate meatloaf	2	decent	
 6203	flavorless pulsating consummate steak	3	decent	
 6204	adequate consummate cuts	3	good	
 6205	bland consummate frankfurter	4	decent	
 6206	rotten miniature shaking consummate french fries	2	crappy	
 6207	low-calorie decent jittery consummate baked potato	1	good	
 6208	tolerable acceptable vodka	4	good	
-6209	small spoiled consummate ice cream	2	crappy	
+6209	spoiled small consummate ice cream	2	crappy	
 6210	normal huge consummate whipped cream	3	good	
 6211	adequate ghostly twirling consummate cream	3	good	
 6212	tasty consummate strawberries	3	awesome	
@@ -6111,27 +6111,27 @@
 6214	artisanal adequate rum	4	EPIC	
 6215	artisanal mediocre lager	4	EPIC	
 6216	decent immaculate grilled cheese	4	good	
-6217	stale bite-sized upside-down blurry immaculate ice cream sandwich	1	decent	
+6217	bite-sized stale blurry upside-down immaculate ice cream sandwich	1	decent	
 6218	enchanted yummy mirror immaculate hot dog	4	awesome	Effect: "Red Misty-Eyed", Effect Duration: 25
-6219	normal thick immaculate egg salad sandwich	5	good	
-6220	normal miniature twirling perfect sandwich	2	good	
+6219	thick normal immaculate egg salad sandwich	5	good	
+6220	miniature normal twirling perfect sandwich	2	good	
 6221	stale low-calorie lime green perfect chef salad	1	decent	
 6222	moldy perfect breakfast	3	crappy	
-6223	bland tumbling cyan wobbly sublime deluxe hot dog	3	decent	
+6223	bland cyan tumbling wobbly sublime deluxe hot dog	3	decent	
 6224	thick normal sublime stew	5	good	
-6225	fancy tasty sublime nachos	3	awesome	Effect: "Healthy, Elfy, and Wise", Effect Duration: 5
-6226	massive decent shaking Ultimate Breakfast Sandwich	10	good	
+6225	tasty fancy sublime nachos	3	awesome	Effect: "Healthy, Elfy, and Wise", Effect Duration: 5
+6226	decent massive shaking Ultimate Breakfast Sandwich	10	good	
 6227	moldy bite-sized Loaded Baked Potato	1	crappy	
 6228	moldy Omega Sundae	3	crappy	
 6229	lousy shaking Das Sauerlager	3	decent	
 6230	lousy Bologna Lambic	3	decent	
 6231	watered-down smooth Vodka Dog	2	awesome	
 6232	mediocre Disappointed Russian	3	decent	
-6233	lousy watered-down Chunky Mary	2	decent	
+6233	watered-down lousy Chunky Mary	2	decent	
 6234	drinkable spinning Nachojito	3	good	
 6235	fancy drinkable Le Roi	4	good	Effect: "A Few Extra Pounds", Effect Duration: 20
 6236	delicious Over Easy Rider	3	awesome	
-6237	bouncing purple cosmic six-pack	0		
+6237	purple bouncing cosmic six-pack	0		
 6239	liquefied boiled cold-filtered cube of ectoplasm	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 42
 6240	anodized Illuminati earpiece	0		Effect: "The Wisdom... of the Future", Effect Duration: 38
 6241	warmed dry censored can label	0		Effect: "Rat-Faced", Effect Duration: 46
@@ -6139,7 +6139,7 @@
 6243	dry the kindest cut	0		Effect: "Lobos Fresh", Effect Duration: 67
 6244	irradiated bouncing cat's paw	0		Effect: "The Moxious Madrigal", Effect Duration: 33
 6245	Vulcanized improved narrow ASCII fu manchu	0		Effect: "Stenchtastic", Effect Duration: 17
-6246	quantum mirror blurry demonic surgical gloves	0		Effect: "You Know When to Walk Away", Effect Duration: 21
+6246	quantum blurry mirror demonic surgical gloves	0		Effect: "You Know When to Walk Away", Effect Duration: 21
 6247	adjusted purple clip-on ninja tie	0		Effect: "Dreadful Sheen", Effect Duration: 32
 6248	enhanced triple-dry upside-down gamer slurry	0		Effect: "Bloodstain-Resistant", Effect Duration: 36
 6249	twirling dungeoneering kit	0		Last Available: "2013-02"
@@ -6160,8 +6160,8 @@
 6264	bouncing Staff of Fruit Salad of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Item Drop: +5, Jiggle: "Deal Some Prismatic Damage"
 6265	pulsating wool padded brawny Staff of the Cream of the Cream	0		Muscle Percent: +20, Damage Absorption: +20, Cold Resistance: +1, Jiggle: "Attune to Monster's Essence"
 6266	mirror jar of protein powder	0		
-6267	bland gigantic fancy grain of protein powder	7	decent	Effect: "Jammin'", Effect Duration: 15
-6268	quantum jittery upside-down shaking pec oil	0		Effect: "Melancholy Burden", Effect Duration: 50
+6267	gigantic bland fancy grain of protein powder	7	decent	Effect: "Jammin'", Effect Duration: 15
+6268	quantum jittery shaking upside-down pec oil	0		Effect: "Melancholy Burden", Effect Duration: 50
 6269	lard-coated gym membership card	0		Sleaze Spell Damage: +25
 6270	diffused diffused colloidal Squat-Thrust Magazine	0		Effect: "Night of the Nachos", Effect Duration: 69
 6271	massive dumbbell	0		
@@ -6195,7 +6195,7 @@
 6299	blinking model airship	0		
 6300	altered Super Weight-Gain 9000	0		Effect: "Patent Prevention", Effect Duration: 49
 6301	deionized vacuum-sealed teal blinking possibility potion	0		Effect: "Bats in the Belfry", Effect Duration: 46
-6302	wobbly spinning eleven-foot pole	0		
+6302	spinning wobbly eleven-foot pole	0		
 6303	ring of Detect Boring Doors	0		
 6304	fireproof dance instructor's wizardly Jarlsberg's pan (Cosmic portal mode) of the brute of the glutton	0		Mysticality: +25, Muscle Percent: +30, Experience Percent (Moxie): +10, Hot Resistance: +3, Food Drop: +100, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	bouncing frightening baleful strapping Jarlsberg's pan of the cougar of James Dean	0		Muscle: +5, Moxie: +20, Experience (Moxie): +3, Spell Damage: +25, Spooky Damage: +5, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	squat Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	wool Mer-kin begsign	0		Cold Resistance: +1, Meat Drop: +40
-6360	blurry Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	blurry Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	galvanized non-Vulcanized pulled taffy	0		Effect: "Hairy Palms", Effect Duration: 51, Last Available: "2013-04"
 6362	double-altered denatured spinning pulled indigo taffy	0		Effect: "Egg on your Face", Effect Duration: 39, Last Available: "2013-04"
 6363	double-pressed narrow pulled taffy	0		Effect: "In the Slimelight", Effect Duration: 23, Last Available: "2013-04"
@@ -6264,14 +6264,14 @@
 6368	blurry Mer-kin hallpass	0		
 6369	jittery lump of clay	0		
 6370	narrow twisted piece of wire	0		
-6371	drinkable practically non-alcoholic can of the cheapest beer	1	good	
-6372	triple-distilled hand-crafted maroon tumbling bottle of fruity &quot;wine&quot;	7	EPIC	
+6371	practically non-alcoholic drinkable can of the cheapest beer	1	good	
+6372	triple-distilled hand-crafted tumbling maroon bottle of fruity &quot;wine&quot;	7	EPIC	
 6373	aged twirling single swig of vodka	4	awesome	
 6374	angry inch	0		
 6375	zippy testy toolbox	0		Initiative: +20
 6376	blurry Jick-o-User	0		
 6378	bouncing eraser nubbin	0		
-6379	upside-down yellow chlorine crystal	0		
+6379	yellow upside-down chlorine crystal	0		
 6380	colloidal ph balancer	0		Effect: "Artificially Sweet", Effect Duration: 48
 6381	ionized pressed purple twirling mysterious chemical residue	0		Effect: "Hyphemariffic", Effect Duration: 11
 6382	nugget of sodium	0		
@@ -6294,11 +6294,11 @@
 6399	denatured Boss Drops	0		Effect: "Ancestral Disapproval", Effect Duration: 29
 6400	Mer-kin lunchbox	0		
 6401	magnetized extra-alkaline tear	0		Effect: "Sausage Festive", Effect Duration: 39
-6402	triple-pickled alkaline squat huge jagged tooth	0		Effect: "Berry Thorny", Effect Duration: 44
+6402	triple-pickled alkaline huge squat jagged tooth	0		Effect: "Berry Thorny", Effect Duration: 44
 6403	warmed altered blinking tumbling grisly shell fragment	0		Effect: "Hammered", Effect Duration: 47
 6404	unsweetened polarized violent pastilles	0		Effect: "Amplified Fabulousness", Effect Duration: 65
 6405	quadruple-quantum worst candy	0		Effect: "Cold Jellied", Effect Duration: 46
-6406	extra-cold-filtered wet magnetized huge narrow fudge-shaped hole in space-time	0		Effect: "Uncaged Power", Effect Duration: 40
+6406	extra-cold-filtered wet magnetized narrow huge fudge-shaped hole in space-time	0		Effect: "Uncaged Power", Effect Duration: 40
 6407	inspector's reassuring Pocket Square of Loathing of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, Item Drop: +15, Single Equip
 6408	corrupted stardust	0		
 6409	green Star Spawn	0		
@@ -6314,7 +6314,7 @@
 6419	ionized moth dust	0		Effect: "In a Lather", Effect Duration: 17
 6420	triple-liquefied colloidal glob of spoiled mayo	0		Effect: "Outer Wolf&trade;", Effect Duration: 23
 6421	tonic djinn	0		
-6422	special adequate vampire chowder	4	good	Effect: "Tenacity of the Snapper", Effect Duration: 15
+6422	adequate special vampire chowder	4	good	Effect: "Tenacity of the Snapper", Effect Duration: 15
 6423	skewed Tales of Dread	0		Free Pull
 6424	cyan Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6388,7 +6388,7 @@
 6493	complicated lock impression	0		
 6494	replica key	0		
 6495	huge foul-smelling Dreadsylvania Auditor's badge	0		Stench Damage: +10, Kruegerand Drop: 5, Single Equip
-6496	upside-down ghostly olive blood kiwi	0		
+6496	ghostly olive upside-down blood kiwi	0		
 6497	eau de mort	0		
 6498	mediocre bloody kiwitini	4	decent	
 6499	moon-amber	0		
@@ -6429,7 +6429,7 @@
 6534	remorseless knife of the pedagogue	0		Experience: +3
 6535	reassuring intimidating coiffure	0		Spooky Resistance: +1, Familiar Effect: "hot afk, 1xPotato"
 6536	teal twirling prompt Fonzie's cod cape	0		Experience (Moxie): +1, Adventures: +3
-6537	decent half-sized enchanted blood sausage	2	good	Effect: "Eagle Eyes", Effect Duration: 50
+6537	half-sized enchanted decent blood sausage	2	good	Effect: "Eagle Eyes", Effect Duration: 50
 6538	tumbling vibrating quilted frying brainpan	0		Damage Absorption: +40, Maximum MP Percent: +10
 6539	teal ball and chain of Tarzan of the early riser	0		Experience (Muscle): +3, Adventures: +7, Single Equip
 6540	ghostly steel-toed dry bone	0		Damage Reduction: 9
@@ -6449,20 +6449,20 @@
 6555	sleaze cluster	0		
 6556	tarnished adjusted phial of hotness	0		Effect: "I See Everything Thrice!", Effect Duration: 53
 6557	colloidal deionized skewed phial of coldness	0		Effect: "Hiding in Plain Sight", Effect Duration: 38
-6558	enhanced deionized activated mirror ghostly phial of spookiness	0		Effect: "Updated", Effect Duration: 41
+6558	enhanced deionized activated ghostly mirror phial of spookiness	0		Effect: "Updated", Effect Duration: 41
 6559	oxidized flattened blue skewed phial of stench	0		Effect: "Antarctic Memories", Effect Duration: 52
 6560	colloidal boiled quadruple-vacuum-sealed phial of sleaziness	0		Effect: "Overstimulated", Effect Duration: 22
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mirror mini-Mr. Accessory	0		Familiar Weight: +5
 6563	huge green frightening hand of Mr. Cards	0		Spooky Damage: +5, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	stale thick Dreadsylvanian hot pocket	5	decent	
+6564	thick stale Dreadsylvanian hot pocket	5	decent	
 6565	toothsome Dreadsylvanian pocket	3	awesome	
-6566	half-sized normal Dreadsylvanian pocket	2	good	
-6567	small normal Dreadsylvanian stink pocket	2	good	
+6566	normal half-sized Dreadsylvanian pocket	2	good	
+6567	normal small Dreadsylvanian stink pocket	2	good	
 6568	super-sized adequate wobbly Dreadsylvanian sleaze pocket	5	good	
 6569	lousy enchanted Dreadsylvanian hot toddy	4	decent	Effect: "Pie in the Sky", Effect Duration: 15
-6570	acceptable watered-down mirror tumbling Dreadsylvanian cold-fashioned	2	good	
-6571	practically non-alcoholic drinkable shaking Dreadsylvanian grimlet	1	good	
+6570	watered-down acceptable mirror tumbling Dreadsylvanian cold-fashioned	2	good	
+6571	drinkable practically non-alcoholic shaking Dreadsylvanian grimlet	1	good	
 6572	perfectly mixed Dreadsylvanian dank and stormy	3	super ultra mega turbo EPIC	
 6573	perfectly mixed watered-down yellow Dreadsylvanian slithery nipple	2	super ultra mega turbo EPIC	
 6574	teal ghostly pulsating hot clusterbomb	0		
@@ -6477,12 +6477,12 @@
 6583	vicious spiked collar	0		Familiar Damage: +20
 6584	rosy-cheeked hot dog wrapper	0		Maximum HP Percent: +30
 6585	zippy hardened debonair deboner	0		Damage Reduction: 3, Initiative: +20
-6586	frozen aerosolized upside-down lime green chicle de salchicha	0		Effect: "Beta Carotene Overdose", Effect Duration: 63
+6586	frozen aerosolized lime green upside-down chicle de salchicha	0		Effect: "Beta Carotene Overdose", Effect Duration: 63
 6587	Usain Bolt's jar of frostigkraut	0		Initiative: +80
 6588	veiny rock-hard gnawed-up dog bone	0		Damage Reduction: 5, Maximum HP: +10
 6589	purple Herculean Grey Guanon	0		Experience (Muscle): +1
 6590	aromatic greasy Engorged Sausages and You of terror	0		Spooky Spell Damage: +10, Sleaze Spell Damage: +10, Stench Resistance: +1
-6591	fancy practically non-alcoholic acceptable dream of a dog	1	good	Effect: "Hot Hands", Effect Duration: 15
+6591	practically non-alcoholic fancy acceptable dream of a dog	1	good	Effect: "Hot Hands", Effect Duration: 15
 6592	up-at-dawn shellacked optimal spreadsheet of dire peril	0		Weapon Damage: +20, Damage Reduction: 7, Adventures: +5
 6593	pulsating defective Game Grid token	0		
 6594	red blinking hot Dreadsylvanian cocoa	0		
@@ -6535,7 +6535,7 @@
 6641	folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
 6642	shaking folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
 6643	folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
-6644	jittery ghostly folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
+6644	ghostly jittery folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	hardy padded slide rule	0		Damage Absorption: +20, Maximum HP: +50
 6649	polymerized Ogres and Oubliettes&trade; module	0		Effect: "The Smile of Mr. A.", Effect Duration: 62
@@ -6557,7 +6557,7 @@
 6665	Temple Grandin's deathchucks of the detective	0		Familiar Weight: +7, Item Drop: +20
 6666	eraser	0		
 6667	shaking quasireligious sculpture	0		
-6668	pulsating green Faraday cage	0		
+6668	green pulsating Faraday cage	0		
 6669	modeling claymore	0		
 6670	clay homunculus	0		
 6671	frozen pulsating sodium pentasomething	0		Effect: "Petit Forbearance", Effect Duration: 16
@@ -6602,7 +6602,7 @@
 6710	ghostly wool chilly pygmy briefs	0		Cold Damage: +5, Cold Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
 6712	bone abacus	0		
-6713	pulsating blue adder	0		
+6713	blue pulsating adder	0		
 6714	short calculator	0		
 6715	pulsating smooth beefcake's sphygmomanometer	0		Muscle: +25, Moxie: +15
 6716	magnetized quadruple-altered bag of pygmy blood	0		Effect: "Witch's Brood", Effect Duration: 65
@@ -6612,8 +6612,8 @@
 6720	aerosolized corrupted maroon pill cup	0		Effect: "Hiding in Plain Sight", Effect Duration: 29
 6721	Oprah's dance instructor's water bottle of horror	0		Experience Percent (Moxie): +10, Maximum MP Percent: +50, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	nitrogenated irradiated pygmy phone number	0		Effect: "Nature's Bounty", Effect Duration: 26
-6723	gray pulsating Boozehounds Anonymous token	0		
-6724	spoiled massive exotic jungle fruit	8	crappy	
+6723	pulsating gray Boozehounds Anonymous token	0		
+6724	massive spoiled exotic jungle fruit	8	crappy	
 6725	pulsating Shore Inc. Ship Trip Scrip	0		
 6726	tumbling dude ranch souvenir crate	0		
 6727	pulsating tropical island souvenir crate	0		
@@ -6634,8 +6634,8 @@
 6742	blurry frosty junk band	0		Cold Spell Damage: +10
 6743	lion tamer's junk trunks	0		Experience (familiar): +2, Familiar Effect: "cap 15"
 6744	MacGyver's junk-mail shirt	0		Maximum MP: +100
-6745	stale snack-sized junk food	2	decent	
-6746	watered-down lousy spinning junk yard	2	decent	
+6745	snack-sized stale junk food	2	decent	
+6746	lousy watered-down spinning junk yard	2	decent	
 6747	mansplainer's beefy swordzall	0		Muscle: +10, Monster Level: +15
 6748	censurious arm buzzer	0		Sleaze Resistance: +3, Damage Reduction: 6
 6749	jittery Rosewater's boilgun of the sewer	0		Mysticality Percent: +30, Stench Damage: +25
@@ -6650,15 +6650,15 @@
 6758	irresponsibly strong artisanal can of Drooling Monk	9	EPIC	Last Available: "2013-09"
 6759	tolerable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	perfectly mixed bottle of Old Pugilist	3	EPIC	Last Available: "2013-09"
-6761	mediocre weak wobbly bottle of Professor Beer	2	decent	Last Available: "2013-09"
-6762	artisanal irresponsibly strong bottle of Rapier Witbier	6	EPIC	Last Available: "2013-09"
+6761	weak mediocre wobbly bottle of Professor Beer	2	decent	Last Available: "2013-09"
+6762	irresponsibly strong artisanal bottle of Rapier Witbier	6	EPIC	Last Available: "2013-09"
 6763	perfectly mixed watered-down skewed lime green bottle of Race Car Red	2	super ultra mega EPIC	Last Available: "2013-09"
 6764	perfectly mixed bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
-6765	weak drinkable huge bottle of Lambada Lambic	2	good	Last Available: "2013-09"
+6765	drinkable weak huge bottle of Lambada Lambic	2	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	narrow artisanal homebrew gift package	0		
 6768	narrow liquid bread	1	decent	Last Available: "2013-09"
-6769	toasty fortified tin tam of incineration	0		Damage Absorption: +60, Hot Damage: +5, Hot Spell Damage: +50, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	toasty fortified tin tam of incineration	0		Damage Absorption: +60, Hot Damage: +5, Hot Spell Damage: +50, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	quadruple-ionized electrified tin cup	0		Effect: "Lubed", Effect Duration: 64, Last Available: "2013-09"
 6771	gray vibrating tin foil of vim and vigor of courage	0		Maximum HP Percent: +50, Maximum MP Percent: +10, Spooky Resistance: +3, Last Available: "2013-09"
 6772	curative grievous Newton's tin drum	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-09"
@@ -6682,7 +6682,7 @@
 6792	teal candy knife	0		
 6793	soap knife	0		
 6795	enhanced ionized disco horoscope (Aquarius)	0		Effect: "Swimming with Sharks", Effect Duration: 61
-6796	anodized upside-down blurry yellow disco horoscope (Pisces)	0		Effect: "Berry Statistical", Effect Duration: 53
+6796	anodized blurry yellow upside-down disco horoscope (Pisces)	0		Effect: "Berry Statistical", Effect Duration: 53
 6797	aerosolized disco horoscope (Aries)	0		Effect: "Pockets of Fire", Effect Duration: 58
 6798	alkaline disco horoscope (Taurus)	0		Effect: "Celestial Vision", Effect Duration: 12
 6799	corrupted fuchsia disco horoscope (Gemini)	0		Effect: "Alacri Tea", Effect Duration: 32
@@ -6726,7 +6726,7 @@
 6837	anodized galvanized Swizzler	0		Effect: "A Taste of Rainbow", Effect Duration: 56
 6838	oxidized pickled Bugbearclaw Donut	0		Effect: "Liquid Luck", Effect Duration: 30
 6839	dry aerosolized blurry jam	0		Effect: "Good Motivator", Effect Duration: 68
-6840	liquefied shaking blue Whenchamacallit bar	0		Effect: "Tea-hee", Effect Duration: 64
+6840	liquefied blue shaking Whenchamacallit bar	0		Effect: "Tea-hee", Effect Duration: 64
 6841	extra-corrupted 8-bit banana	0		Effect: "Hairless and Airless", Effect Duration: 32
 6842	pickled quantum vial of blood simple syrup	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 40
 6843	adjusted bone bons	0		Effect: "Educated (Sorta)", Effect Duration: 40
@@ -6746,8 +6746,8 @@
 6857	lightning-fast Cajun accordion	0		Initiative: +40, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	pulsating quirky accordion of the dark arts	0		Spell Damage Percent: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	tumbling avaricious Skipper's accordion of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	spinning pulsating censurious fortified Newton's boxer's Pantsgiving	0		Muscle Percent: +10, Experience (Mysticality): +3, Damage Absorption: +60, Sleaze Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
-6861	yummy jumbo can of sardines	5	awesome	Last Available: "2013-11"
+6860	spinning pulsating censurious fortified Newton's boxer's Pantsgiving	0		Muscle Percent: +10, Experience (Mysticality): +3, Damage Absorption: +60, Sleaze Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6861	jumbo yummy can of sardines	5	awesome	Last Available: "2013-11"
 6862	yummy immense high-calorie sugar substitute	6	awesome	Last Available: "2013-11"
 6863	stale pat of butter	3	decent	Last Available: "2013-11"
 6864	stale dinner roll	3	decent	Last Available: "2013-11"
@@ -6780,7 +6780,7 @@
 6891	olive MacGyver's Rosewater's spirit bell of the empath	0		Mysticality Percent: +30, Maximum MP: +100, Familiar Weight: +5, Class: "Turtle Tamer"
 6892	pickled spoonful of Linguine-Os	0		Effect: "Gyromitra Gymnastics", Effect Duration: 17, Last Available: "2013-11"
 6893	modified freezer-burned frost-bitten tortellini	0		Effect: "Faboooo", Effect Duration: 17, Last Available: "2013-11"
-6894	ionized teal squat blurry blob of Alphredo&trade;	0		Effect: "Biologically Shocked", Effect Duration: 46, Last Available: "2013-11"
+6894	ionized blurry squat teal blob of Alphredo&trade;	0		Effect: "Biologically Shocked", Effect Duration: 46, Last Available: "2013-11"
 6895	frozen improved handful of crafty noodles	0		Effect: "Kissed By Fire", Effect Duration: 16, Last Available: "2013-11"
 6896	moist olive tangled mass of pasta	0		Effect: "Super Skill", Effect Duration: 14, Last Available: "2013-11"
 6897	enhanced ionized frozen Can of Spaghetto	0		Effect: "Greased-Up Familiar", Effect Duration: 66, Last Available: "2013-11"
@@ -6791,7 +6791,7 @@
 6902	pulsating rock-hard razor-sharp flask flops	0		Weapon Damage Percent: +25, Damage Reduction: 5, Single Equip
 6903	activated nuts	0		Effect: "Fangs and Pangs", Effect Duration: 63, Last Available: "2013-12"
 6904	boiled ionized bolts	0		Effect: "Dexteri Tea", Effect Duration: 23, Last Available: "2013-12"
-6905	moldy half-sized spinning gingerbread robot	2	crappy	Last Available: "2013-12"
+6905	half-sized moldy spinning gingerbread robot	2	crappy	Last Available: "2013-12"
 6906	stale special petit 4.1	4	decent	Effect: "Marco Polarity", Effect Duration: 25, Last Available: "2013-12"
 6907	delicious jumbo teal nut-shaped Crimbo cookie	5	awesome	Last Available: "2023-06"
 6908	smooth plastic GORM-8	0		Moxie: +15, Last Available: "2013-12"
@@ -6809,30 +6809,30 @@
 6920	non-tarnished warbear liquid overcoat	0		Effect: "Tingly Biceps", Effect Duration: 40, Last Available: "2013-12"
 6921	stale small shaking warbear feasting bread	2	decent	Last Available: "2013-12"
 6922	delicious bite-sized wobbly warbear warrior bread	1	awesome	Last Available: "2013-12"
-6923	big rotten narrow bouncing warbear thermoregulator bread	5	crappy	Last Available: "2013-12"
+6923	rotten big bouncing narrow warbear thermoregulator bread	5	crappy	Last Available: "2013-12"
 6924	lousy warbear feasting mead	3	decent	Last Available: "2013-12"
-6925	watered-down lousy warbear bearserker mead	2	decent	Last Available: "2013-12"
+6925	lousy watered-down warbear bearserker mead	2	decent	Last Available: "2013-12"
 6926	distilled aged skewed warbear blizzard mead	5	awesome	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	wobbly executive auspicious warbear plain fedora of the cougar	0		Moxie: +20, Item Drop: +10, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	Samson's warbear feathered fedora	0		Experience (Muscle): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	jittery aromatic gravedigger's dog trainer's warbear fedora	0		Experience (familiar): +1, Spooky Damage: +10, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	perfumed greasy manspreader's warbear plain helm	0		Monster Level: +10, Sleaze Spell Damage: +10, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	manspreader's warbear spiked helm	0		Monster Level: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	lightning-fast healthy Da Vinci's warbear electro-spiked helm	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Initiative: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	hale rock-hard groovy warbear plain ushanka	0		Moxie Percent: +10, Damage Reduction: 5, Maximum HP: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	wobbly studded warbear lined ushanka	0		Damage Absorption: +80, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	forbidden stylish warbear heated ushanka of the early riser	0		Moxie: +25, Spell Damage Percent: +50, Adventures: +7, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	wobbly executive auspicious warbear plain fedora of the cougar	0		Moxie: +20, Item Drop: +10, Meat Drop: +40, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	Samson's warbear feathered fedora	0		Experience (Muscle): +5, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	jittery aromatic gravedigger's dog trainer's warbear fedora	0		Experience (familiar): +1, Spooky Damage: +10, Stench Resistance: +1, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	perfumed greasy manspreader's warbear plain helm	0		Monster Level: +10, Sleaze Spell Damage: +10, Stench Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	manspreader's warbear spiked helm	0		Monster Level: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	lightning-fast healthy Da Vinci's warbear electro-spiked helm	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Initiative: +40, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	hale rock-hard groovy warbear plain ushanka	0		Moxie Percent: +10, Damage Reduction: 5, Maximum HP: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	wobbly studded warbear lined ushanka	0		Damage Absorption: +80, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	forbidden stylish warbear heated ushanka of the early riser	0		Moxie: +25, Spell Damage Percent: +50, Adventures: +7, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	teal warbear trouser fragment	0		Last Available: "2013-12"
-6938	Sherlock's toasty warbear party pants of the sweet-tooth	0		Hot Damage: +5, Item Drop: +25, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	jittery inspector's warbear ceremonial party pants	0		Item Drop: +15, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	sharpshooter's baleful warbear high festival pants of the pedagogue	0		Experience: +3, Spell Damage: +25, Critical Hit Percent: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	mirror shellacked Rosewater's warbear battle greaves of Flo-Jo	0		Mysticality Percent: +30, Damage Reduction: 7, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	warbear officer greaves of dire peril	0		Weapon Damage: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	scorching smooth warbear bearserker greaves of the pedagogue	0		Moxie: +15, Experience: +3, Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	squat purple mansplainer's Annie Oakley's Sinatra's warbear johns	0		Experience (Moxie): +5, Critical Hit Percent: +20, Monster Level: +15, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	MacGyver's warbear fleece-lined johns	0		Maximum MP: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	rosewater-soaked rock-hard warbear johns of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	Sherlock's toasty warbear party pants of the sweet-tooth	0		Hot Damage: +5, Item Drop: +25, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	jittery inspector's warbear ceremonial party pants	0		Item Drop: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	sharpshooter's baleful warbear high festival pants of the pedagogue	0		Experience: +3, Spell Damage: +25, Critical Hit Percent: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	mirror shellacked Rosewater's warbear battle greaves of Flo-Jo	0		Mysticality Percent: +30, Damage Reduction: 7, Initiative: +100, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	warbear officer greaves of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	scorching smooth warbear bearserker greaves of the pedagogue	0		Moxie: +15, Experience: +3, Hot Damage: +25, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	squat purple mansplainer's Annie Oakley's Sinatra's warbear johns	0		Experience (Moxie): +5, Critical Hit Percent: +20, Monster Level: +15, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	MacGyver's warbear fleece-lined johns	0		Maximum MP: +100, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	rosewater-soaked rock-hard warbear johns of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40, Stench Resistance: +3, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	maroon warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	inspector's shellacked warbear goggles of doom	0		Damage Reduction: 7, Spooky Spell Damage: +50, Item Drop: +15, Single Equip, Last Available: "2013-12"
 6949	gray up-at-dawn warbear snowblindness goggles	0		Adventures: +5, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	Van der Graaf warbear warscarf of chilblains of the overflowing toilet	0		Cold Damage: +25, Stench Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	huge warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	shaking shaking flame-retardant warbear foil hat	0		Hot Resistance: +1, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	shaking shaking flame-retardant warbear foil hat	0		Hot Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	cyan fireproof double-paned warbear oil pan	0		Cold Resistance: +5, Hot Resistance: +3, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	aromatic sage die-cast Don Crimbo	0		Mysticality Percent: +10, Stench Resistance: +1, Last Available: "2013-12"
 7001	pulsating crafty steel-toed die-cast Uncle Hobo	0		Damage Reduction: 9, Maximum MP: +10, Last Available: "2013-12"
 7002	shellacked die-cast Father Crimbo of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	warmed yellow blinking Flaskfull of Hollow	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 50, Last Available: "2013-12"
-7005	jittery green narrow lump of Brituminous coal	0		Last Available: "2013-12"
+7005	jittery narrow green lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered handful of Smithereens	1	good	Last Available: "2013-12"
 7007	normal red Every Day is Like This Sundae	3	good	Last Available: "2013-12"
-7008	fancy massive bland Miserable Pie	10	decent	Effect: "You're High as a Crow, Marty", Effect Duration: 15, Last Available: "2013-12"
+7008	bland fancy massive Miserable Pie	10	decent	Effect: "You're High as a Crow, Marty", Effect Duration: 15, Last Available: "2013-12"
 7009	toothsome This Charming Flan	3	awesome	Last Available: "2013-12"
 7010	aged Irish Coffee, English Heart	3	awesome	Last Available: "2013-12"
-7011	watered-down lousy Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
-7012	drinkable practically non-alcoholic Paint A Vulgar Pitcher	1	good	Last Available: "2013-12"
+7011	lousy watered-down Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
+7012	practically non-alcoholic drinkable Paint A Vulgar Pitcher	1	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	bouncing studded wicked Sheila Take a Crossbow of the bloodbag of the scaredy-cat	0		Spell Damage: +5, Damage Absorption: +80, Maximum HP: +100, Monster Level: -15, Last Available: "2013-12"
 7019	shaking healthy Herculean A Light that Never Goes Out of Leguizamo of bravery	0		Experience (Muscle): +1, Maximum HP Percent: +20, Monster Level: +20, Spooky Resistance: +5, Last Available: "2013-12"
 7020	sharpshooter's padded razor-sharp Half a Purse of the scaredy-cat	0		Weapon Damage Percent: +25, Damage Absorption: +20, Critical Hit Percent: +10, Monster Level: -15, Last Available: "2013-12"
-7021	wobbly lion tamer's hardy extremely unsafe Samson's Hairpiece On Fire	0		Experience (Muscle): +5, Weapon Damage Percent: +100, Maximum HP: +50, Experience (familiar): +2, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	ribald scandalous sizzling experienced Vicar's Tutu	0		Experience: +2, Hot Damage: +10, Sleaze Damage: 15, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	wobbly lion tamer's hardy extremely unsafe Samson's Hairpiece On Fire	0		Experience (Muscle): +5, Weapon Damage Percent: +100, Maximum HP: +50, Experience (familiar): +2, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	ribald scandalous sizzling experienced Vicar's Tutu	0		Experience: +2, Hot Damage: +10, Sleaze Damage: 15, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	inspector's Hand in Glove of the blizzard of the overflowing toilet	0		Cold Spell Damage: +25, Stench Spell Damage: +50, Item Drop: +15, Single Equip, Last Available: "2013-12"
 7024	greasy MacGyver's Meat Tenderizer is Murder of temperance	0		Maximum MP: +100, Sleaze Spell Damage: +10, Sleaze Resistance: +5, Class: "Seal Clubber", Last Available: "2013-12"
 7025	teal asbestos-lined wool Newton's Ouija Board, Ouija Board	0		Experience (Mysticality): +3, Cold Resistance: +1, Hot Resistance: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	blurry warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	denatured blinking glass slipper	0		Effect: "Empty Inside", Effect Duration: 67, Last Available: "2014-12"
-7045	vaporized teal huge antimatter wad	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 30, Last Available: "2013-12"
+7045	vaporized huge teal antimatter wad	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 30, Last Available: "2013-12"
 7046	magnetized polarized flattened warbear superpotion	0		Effect: "Mucilaginous Mentalism", Effect Duration: 26, Last Available: "2013-12"
 7047	boiled tarnished warbear liquid lasers	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 32, Last Available: "2013-12"
 7048	ionized warbear rejuvenation potion	0		Effect: "Arresistible", Effect Duration: 67, Last Available: "2013-12"
@@ -6964,25 +6964,25 @@
 7075	electrified liquid ice pack	0		Effect: "Pisces in the Skyces", Effect Duration: 30, Last Available: "2014-01"
 7076	upside-down snow boards	0		Last Available: "2014-01"
 7077	flavorless snow crab	3	decent	Last Available: "2014-01"
-7078	weak aged Ice Island Long Tea	2	awesome	Last Available: "2014-01"
+7078	aged weak Ice Island Long Tea	2	awesome	Last Available: "2014-01"
 7079	pulsating twirling unfinished ice sculpture	0		Last Available: "2014-01"
 7080	upside-down maroon ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	mirror personal trainer's snow mobile	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	mirror personal trainer's snow mobile	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	yellow flame-wreathed ice bucket	0		Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	green supercharged snow shovel of the detective	0		Maximum MP Percent: +30, Item Drop: +20, Lasts Until Rollover, Last Available: "2014-01"
 7086	yellow censurious foul-smelling stiffened bod-ice	0		Damage Reduction: 1, Stench Damage: +10, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2014-01"
 7087	auspicious Jeselnik's smartaleck's snow belt of the empath	0		Moxie Percent: +30, Familiar Weight: +5, Sleaze Damage: +25, Item Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	double-paned shellacked Da Vinci's ice nine of the blizzard	0		Experience (Mysticality): +5, Damage Reduction: 7, Cold Spell Damage: +25, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	practically non-alcoholic lousy purple En Una Fila Tequila	1	decent	
-7091	maroon narrow Skully's hot chocolate	1	good	
-7092	skewed teal Temple Grandin's brainy warbear dress helmet	0		Mysticality: +5, Familiar Weight: +7, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7090	lousy practically non-alcoholic purple En Una Fila Tequila	1	decent	
+7091	narrow maroon Skully's hot chocolate	1	good	
+7092	skewed teal Temple Grandin's brainy warbear dress helmet	0		Mysticality: +5, Familiar Weight: +7, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	Tesla groovy warbear dress bracers	0		Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-12"
-7094	cool weightlifter's warbear dress greaves	0		Muscle: +15, Moxie: +5, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	cyan strapping sweatband of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	hale gym shorts of Calamity Jane	0		Maximum HP: +20, Critical Hit Percent: +15, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	cool weightlifter's warbear dress greaves	0		Muscle: +15, Moxie: +5, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	cyan strapping sweatband of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	hale gym shorts of Calamity Jane	0		Maximum HP: +20, Critical Hit Percent: +15, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	skewed maroon scorching ankleweights of the boozehound	0		Hot Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2014-12"
 7098	bouncing cyan huge lion tamer's sharpshooter's arcane researcher's Samson's sweat socks	0		Experience (Muscle): +5, Experience Percent (Mysticality): +10, Critical Hit Percent: +10, Experience (familiar): +2, Last Available: "2014-12"
 7099	blue pint of sweat	0		Last Available: "2014-12"
@@ -6997,25 +6997,25 @@
 7108	normal pecan	3	good	Last Available: "2014-12"
 7109	delicious snack-sized pecan pie	2	awesome	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	adequate half-sized candy mountain oyster	2	good	Last Available: "2014-12"
-7112	boozy artisanal fancy chocotini	5	EPIC	Effect: "Total Protonic Reversal", Effect Duration: 10, Last Available: "2014-12"
+7111	half-sized adequate candy mountain oyster	2	good	Last Available: "2014-12"
+7112	artisanal fancy boozy chocotini	5	EPIC	Effect: "Total Protonic Reversal", Effect Duration: 10, Last Available: "2014-12"
 7113	rosewater-soaked Newton's smartaleck's chocolate rabbit's foot	0		Moxie Percent: +30, Experience (Mysticality): +3, Stench Resistance: +3, Last Available: "2014-12"
-7114	fancy toothsome candy carrot	3	awesome	Effect: "Sweet and Red", Effect Duration: 35, Last Available: "2014-12"
-7115	decent big candy carrot cake	5	good	Last Available: "2014-12"
+7114	toothsome fancy candy carrot	3	awesome	Effect: "Sweet and Red", Effect Duration: 35, Last Available: "2014-12"
+7115	big decent candy carrot cake	5	good	Last Available: "2014-12"
 7116	blinking MacGyver's carrot-on-a-stick of Gandalf	0		Maximum MP: +100, Spell Critical Percent: +20, Last Available: "2014-12"
-7117	avaricious asbestos-lined weasel stomping pants	0		Hot Resistance: +5, Meat Drop: +30, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	avaricious asbestos-lined weasel stomping pants	0		Hot Resistance: +5, Meat Drop: +30, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	normal mulberry	4	good	Last Available: "2014-12"
 7119	high-proof hand-crafted mulled berry wine	10	EPIC	Last Available: "2014-12"
 7120	pulsating lemony scales	0		Last Available: "2014-12"
-7121	perfumed lemon party hat	0		Stench Resistance: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	perfumed lemon party hat	0		Stench Resistance: +5, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	padded lemon shirt	0		Damage Absorption: +20, Lasts Until Rollover, Last Available: "2014-12"
-7123	educational lemon drop trousers	0		Experience: +1, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	educational lemon drop trousers	0		Experience: +1, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	deionized blurry lemonhead caviar	0		Effect: "Gamer Rage", Effect Duration: 55, Last Available: "2014-12"
 7125	wobbly supercharged brawny gummi sword	0		Muscle Percent: +20, Maximum MP Percent: +30, Last Available: "2014-12"
-7126	nitrogenated triple-polymerized spinning skewed small gummi fin	0		Effect: "Savage Beast Inside", Effect Duration: 42, Last Available: "2014-12"
+7126	nitrogenated triple-polymerized skewed spinning small gummi fin	0		Effect: "Savage Beast Inside", Effect Duration: 42, Last Available: "2014-12"
 7127	chocolate cow bone of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2014-12"
 7128	ionized gummi fang	0		Effect: "Pyromania", Effect Duration: 41, Last Available: "2014-12"
-7129	normal special wobbly leftover canap&eacute;s	3	good	Effect: "Feet of Grapefruit", Effect Duration: 10, Last Available: "2014-12"
+7129	special normal wobbly leftover canap&eacute;s	3	good	Effect: "Feet of Grapefruit", Effect Duration: 10, Last Available: "2014-12"
 7130	aged magnum of champagne	3	awesome	Last Available: "2014-12"
 7131	family-friendly sage cow creamer of Flo-Jo	0		Mysticality Percent: +10, Sleaze Resistance: +1, Initiative: +100, Last Available: "2014-12"
 7132	activated ionized Outer Wolf&trade; cologne	0		Effect: "Super-Electrified", Effect Duration: 65, Last Available: "2014-12"
@@ -7031,24 +7031,24 @@
 7142	concentrated frozen hare brush	0		Effect: "Saucemastery", Effect Duration: 20, Last Available: "2014-12"
 7143	chilly steel-toed hare pin	0		Damage Reduction: 9, Cold Damage: +5, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	stale bite-sized huge cinnamon cannoli	1	decent	Last Available: "2014-12"
+7145	bite-sized stale huge cinnamon cannoli	1	decent	Last Available: "2014-12"
 7146	weak acceptable expensive champagne	2	good	Last Available: "2014-12"
-7147	warmed oxidized twirling upside-down polo trophy	0		Effect: "The Power of Positive Thinking", Effect Duration: 35, Last Available: "2014-12"
+7147	warmed oxidized upside-down twirling polo trophy	0		Effect: "The Power of Positive Thinking", Effect Duration: 35, Last Available: "2014-12"
 7148	red oil painting	0		Last Available: "2014-12"
 7149	huge rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
-7152	green twirling	0		Last Available: "2014-12"
+7152	twirling green	0		Last Available: "2014-12"
 7153	clay	0		Last Available: "2014-12"
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	blinking miser's Jim Carey's baleful fire hose	0		Spell Damage: +25, Monster Level: +25, Meat Drop: +10, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	blinking miser's Jim Carey's baleful fire hose	0		Spell Damage: +25, Monster Level: +25, Meat Drop: +10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	snack-sized normal fireman's lunch	2	good	Last Available: "2014-12"
-7159	prompt Van der Graaf veiny plain paper hat	0		Maximum HP: +10, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	prompt Van der Graaf veiny plain paper hat	0		Maximum HP: +10, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	spoiled ice cream sandwich	3	crappy	Last Available: "2014-12"
 7161	prompt scorching &quot;honey&quot; dipper of the overflowing toilet	0		Hot Damage: +25, Stench Spell Damage: +50, Adventures: +3, Last Available: "2014-12"
-7162	bland half-sized plumber's lunch	2	decent	Last Available: "2014-12"
+7162	half-sized bland plumber's lunch	2	decent	Last Available: "2014-12"
 7163	lime green asbestos-lined arcane researcher's skull gearshift knob of the glutton	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Food Drop: +100, Last Available: "2014-12"
 7164	thick decent nachos of the night	5	good	Last Available: "2014-12"
 7165	executive double-paned Sketcherz&trade; of Leguizamo	0		Monster Level: +20, Cold Resistance: +5, Meat Drop: +40, Last Available: "2014-12"
@@ -7068,12 +7068,12 @@
 7179	The First Pizza	0		
 7180	purple squat The Lacrosse Stick of Lacoronado	0		
 7181	twirling skewed The Eye of the Stars	0		
-7182	gray skewed The Stankara Stone	0		
+7182	skewed gray The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	watered-down acceptable bouncing unnamed cocktail	2	good	
+7187	acceptable watered-down bouncing unnamed cocktail	2	good	
 7188	olive handful of tips	0		
 7189	avaricious unrequired jacket	0		Meat Drop: +30
 7190	deadly tommy gun	0		Weapon Damage: +5, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7108,10 +7108,10 @@
 7219	ghostly maroon chilly lynyrdskin breeches	0		Cold Damage: +5, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	aged weak squat Flamin' Whatshisname	2	awesome	
+7222	weak aged squat Flamin' Whatshisname	2	awesome	
 7223	vacuum-sealed cyan lynyrd musk	0		Effect: "Angry Bone", Effect Duration: 30
 7224	mirror Temple Grandin's Kashmir sweater of extreme caution	0		Monster Level: -25, Familiar Weight: +7
-7225	diet decent ghostly custard pie	1	good	
+7225	decent diet ghostly custard pie	1	good	
 7226	skewed tea for one	1	EPIC	
 7227	delicious strong bottle of Evermore	5	awesome	
 7228	upside-down box	0		
@@ -7187,7 +7187,7 @@
 7298	heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
 7300	sewing kit	0		
-7301	upside-down shaking squat Spookyraven billiards room key	0		
+7301	shaking upside-down squat Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	olive Lady Spookyraven's necklace	0		
 7304	telegram from Lady Spookyraven	0		
@@ -7210,11 +7210,11 @@
 7321	ribald groovy Stephen's lab coat	0		Moxie Percent: +10, Sleaze Damage: +10
 7322	magnetized Stephen's secret formula	0		Effect: "The Dinsey Way", Effect Duration: 27
 7323	knitted Jacob's rung of the glutton	0		Cold Resistance: +3, Food Drop: +100
-7324	dried jittery tumbling teal battery	1		
+7324	dried jittery teal tumbling battery	1		
 7325	perfectly mixed huge snakebite	4	EPIC	
 7326	lightning-fast rubber ribcage of the ox	0		Muscle: +20, Initiative: +40, Damage Reduction: 7
 7327	dried pulsating blue synthetic marrow	1		Effect: "Marbles in Your Mouth", Effect Duration: 35
-7328	tarnished ionized teal ghostly funny bone	0		Effect: "Feroci Tea", Effect Duration: 33
+7328	tarnished ionized ghostly teal funny bone	0		Effect: "Feroci Tea", Effect Duration: 33
 7329	supercharged half-melted spoon of the boozehound	0		Maximum MP Percent: +30, Booze Drop: +100
 7330	modified the funk	1		
 7331	normal gunky chicken	3	good	
@@ -7224,7 +7224,7 @@
 7335	avaricious Jack Frost's paddle-ball	0		Cold Spell Damage: +50, Meat Drop: +30
 7336	oxidized alkaline sound effects record	0		Effect: "Winning Smile", Effect Duration: 30
 7337	alphabet block	0		
-7338	adjusted tumbling spinning red dancer	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 35
+7338	adjusted red spinning tumbling dancer	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 35
 7339	music box mechanism	0		
 7340	wobbly tumbling beefcake's moose antlers	0		Muscle: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	improved alkaline improved moose thought	0		Effect: "Red Around the Gills", Effect Duration: 37
@@ -7234,7 +7234,7 @@
 7345	narrow ornate picture frame	0		
 7346	squat doll-eye amulet	0		Single Equip
 7347	pulsating huge tumbling Jim Carey's weightlifter's ghost toga	0		Muscle: +15, Monster Level: +25
-7348	super-sized decent sheet cake	5	good	
+7348	decent super-sized sheet cake	5	good	
 7349	bouncing ghost key	0		
 7350	twirling picture of you	0		
 7351	executive Temple Grandin's groovy Staff of the Electric Range	0		Moxie Percent: +10, Familiar Weight: +7, Meat Drop: +40
@@ -7243,7 +7243,7 @@
 7354	lousy red-hot boilermaker	3	decent	
 7355	twirling coal shovel of mayonnaise	0		Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	super-ionized cold-filtered pickled narrow hot coal	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 49
-7357	enhanced boiled cold-filtered narrow olive coal dust	0		Effect: "Musky", Effect Duration: 47
+7357	enhanced boiled cold-filtered olive narrow coal dust	0		Effect: "Musky", Effect Duration: 47
 7358	energetic Herculean cool Bram's choker	0		Moxie: +5, Experience (Muscle): +1, Maximum MP Percent: +20, Single Equip
 7359	plaid swatch	0		
 7360	plaid bandage	0		
@@ -7252,7 +7252,7 @@
 7363	energized bloodstain stick	0		Effect: "Coated Arms", Effect Duration: 47
 7364	twirling fabric softener	0		
 7365	denatured fabric hardener	0		Effect: "Stimulated Brain", Effect Duration: 28
-7366	fancy watered-down lousy ghostly blue bottle of laundry sherry	2	decent	Effect: "Initiative and Let Die", Effect Duration: 45
+7366	lousy watered-down fancy ghostly blue bottle of laundry sherry	2	decent	Effect: "Initiative and Let Die", Effect Duration: 45
 7367	quantum chilled industrial strength starch	0		Effect: "A Taste of Rainbow", Effect Duration: 50, Wiki Name: "industrial strength starch"
 7368	flavorless extra-flat panini	4	decent	
 7369	wet mirror mangled finger	0		Effect: "Cute Vision", Effect Duration: 31
@@ -7261,7 +7261,7 @@
 7372	small moldy pie man was not meant to eat	2	crappy	
 7373	upside-down sommelier's towel of the overflowing toilet	0		Stench Spell Damage: +50
 7374	reassuring tarnished tastevin	0		Spooky Resistance: +1, Single Equip
-7375	stale half-sized teal actual tapas	2	decent	
+7375	half-sized stale teal actual tapas	2	decent	
 7376	ghast iron ingot	0		
 7377	resourceful brawny ghast iron cleaver	0		Muscle Percent: +20, Maximum MP: +50
 7378	gravedigger's ghast iron Garibaldi of the boozehound	0		Spooky Damage: +10, Booze Drop: +100, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7287,7 +7287,7 @@
 7398	triple-corrupted Vulcanized Gene Tonic: Weird	0		Effect: "Haunted Stomach", Effect Duration: 52, Last Available: "2014-04"
 7399	ionized energized Gene Tonic: Elf	0		Effect: "Oiled Skin", Effect Duration: 14, Last Available: "2014-04"
 7400	anodized corrupted enhanced huge Gene Tonic: Mer-kin	0		Effect: "Purity of Spirit", Effect Duration: 56, Last Available: "2014-04"
-7401	concentrated dry ghostly maroon mirror Gene Tonic: Slime	0		Effect: "Slimed Stomach", Effect Duration: 40, Last Available: "2014-04"
+7401	concentrated dry mirror maroon ghostly Gene Tonic: Slime	0		Effect: "Slimed Stomach", Effect Duration: 40, Last Available: "2014-04"
 7402	polymerized altered extra-dry Gene Tonic: Penguin	0		Effect: "Danish Cunning", Effect Duration: 22, Last Available: "2014-04"
 7403	corrupted bouncing Gene Tonic: Elemental	0		Effect: "Twen Tea", Effect Duration: 21, Last Available: "2014-04"
 7404	quadruple-moist Gene Tonic: Constellation	0		Effect: "Nightstalkin'", Effect Duration: 69, Last Available: "2014-04"
@@ -7297,7 +7297,7 @@
 7408	Steam Card: Dungeon Fist (#3)	0		
 7409	tumbling Steam Card: Space Trip (#1)	0		
 7410	Steam Card: Space Trip (#2)	0		
-7411	pulsating purple Steam Card: Space Trip (#3)	0		
+7411	purple pulsating Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
 7413	narrow Steam Card: Meteoid (#2)	0		
 7414	red Steam Card: Meteoid (#3)	0		
@@ -7307,7 +7307,7 @@
 7418	Steam Card: Jackass Plumber (#1)	0		
 7419	pulsating Steam Card: Jackass Plumber (#2)	0		
 7420	wobbly Steam Card: Jackass Plumber (#3)	0		
-7421	blurry olive pencil thin mushroom	0		Last Available: "2014-05"
+7421	olive blurry pencil thin mushroom	0		Last Available: "2014-05"
 7422	Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	wobbly salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
@@ -7326,20 +7326,20 @@
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	stale jittery Beefy Crunch Pastaco	4	decent	Last Available: "2014-05"
 7439	spoiled narrow Brain Food Pastaco	3	crappy	Last Available: "2014-05"
-7440	decent super-sized Cool Brunch Pastaco	5	good	Last Available: "2014-05"
-7441	thick spoiled Medical Pastaco	5	crappy	Last Available: "2014-05"
+7440	super-sized decent Cool Brunch Pastaco	5	good	Last Available: "2014-05"
+7441	spoiled thick Medical Pastaco	5	crappy	Last Available: "2014-05"
 7442	adequate immense Energy Buzz Pastaco	7	good	Last Available: "2014-05"
-7443	diet spoiled upside-down squat Ludovico Pastaco	1	crappy	Last Available: "2014-05"
+7443	diet spoiled squat upside-down Ludovico Pastaco	1	crappy	Last Available: "2014-05"
 7444	bad weak purple overpowering mushroom wine	2	decent	Last Available: "2014-05"
-7445	bad fortified complex mushroom wine	5	decent	Last Available: "2014-05"
+7445	fortified bad complex mushroom wine	5	decent	Last Available: "2014-05"
 7446	bad twirling smooth mushroom wine	3	decent	Last Available: "2014-05"
-7447	smooth weak blood-red mushroom wine	2	awesome	Last Available: "2014-05"
+7447	weak smooth blood-red mushroom wine	2	awesome	Last Available: "2014-05"
 7448	special distilled drinkable buzzing mushroom wine	5	good	Effect: "Feeling No Pain", Effect Duration: 20, Last Available: "2014-05"
 7449	acceptable weak blinking swirling mushroom wine	2	good	Last Available: "2014-05"
 7450	small decent red Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
 7451	adequate Taco Dan's Taco Fish Fish Taco	3	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	practically non-alcoholic tolerable regular-size brogurt	1	good	Last Available: "2014-05"
+7453	tolerable practically non-alcoholic regular-size brogurt	1	good	Last Available: "2014-05"
 7454	bad weak super-size brogurt	2	decent	Last Available: "2014-05"
 7455	delicious weak bouncing broberry brogurt	2	awesome	Last Available: "2014-05"
 7456	aged huge brocolate brogurt	3	awesome	Last Available: "2014-05"
@@ -7348,13 +7348,13 @@
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	squat Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Sherlock's Brogre brorts	0		Item Drop: +25, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	Sherlock's Brogre brorts	0		Item Drop: +25, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	cyan fortified Brogre brolo shirt	0		Damage Absorption: +60, Last Available: "2014-05"
-7464	spinning clever Brogre bucket hat	0		Maximum MP: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	spinning clever Brogre bucket hat	0		Maximum MP: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	blinking Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	mirror one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	greasy grievous razor-sharp 8-billed baseball cap	0		Weapon Damage Percent: 75, Sleaze Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	greasy grievous razor-sharp 8-billed baseball cap	0		Weapon Damage Percent: 75, Sleaze Spell Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	aromatic stanky educational extremely wet T-shirt	0		Experience: +1, Stench Spell Damage: +25, Stench Resistance: +1, Last Available: "2014-05"
 7470	double-paned frosty sharpshooter's shrimp fork	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Cold Resistance: +5, Last Available: "2014-05"
 7471	anodized unsweetened BROS Energy Drink	0		Effect: "Vitamin-Maxed", Effect Duration: 15, Last Available: "2014-05"
@@ -7377,9 +7377,9 @@
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	blurry triatomaceous dust	0		
-7491	bad watered-down bottle of Chateau de Vinegar	2	decent	
+7491	watered-down bad bottle of Chateau de Vinegar	2	decent	
 7492	tumbling blasting soda	0		
-7493	blurry blurry red unstable fulminate	0		
+7493	blurry red blurry unstable fulminate	0		
 7494	wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
 7496	upside-down bottled day	0		
@@ -7399,7 +7399,7 @@
 7510	adjusted lime green skewed skewed eye shadow	0		Effect: "Psalm of Pointiness", Effect Duration: 41
 7511	purple crumbling wheel	0		
 7512	pressed quadruple-vacuum-sealed poppy	0		Effect: "Happy Trails", Effect Duration: 64
-7513	twirling olive opium grenade	0		
+7513	olive twirling opium grenade	0		
 7514	energetic duonoculars of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +20, Single Equip
 7515	plastic rock	0		
 7516	narrow witch's spare house key	0		
@@ -7407,7 +7407,7 @@
 7518	pulsating huge wand of pigification	0		
 7519	aged twirling glass of bourbon	4	awesome	
 7520	narrow burned government manual fragment	0		Last Available: "2014-05"
-7521	yummy half-sized government cheese	2	awesome	Last Available: "2014-05"
+7521	half-sized yummy government cheese	2	awesome	Last Available: "2014-05"
 7522	mirror savvy pair of government shades	0		Mysticality Percent: +20, Single Equip, Last Available: "2014-05"
 7523	wobbly space junk	0		Last Available: "2014-05"
 7524	cold-filtered dry government	0		Effect: "Dwarven Hardiness", Effect Duration: 36, Last Available: "2014-05"
@@ -7416,17 +7416,17 @@
 7527	twirling alien force field disruptor bean	0		Last Available: "2014-05"
 7528	narrow up-at-dawn rosy-cheeked government-issued night-vision goggles	0		Maximum HP Percent: +30, Adventures: +5, Single Equip, Last Available: "2014-05"
 7529	gigantic rotten loaf of alien bread	6	crappy	Last Available: "2014-05"
-7530	diet moldy grilled cheese sandwich	1	crappy	Last Available: "2014-05"
+7530	moldy diet grilled cheese sandwich	1	crappy	Last Available: "2014-05"
 7531	modified blinking alien protein powder	1	awesome	Last Available: "2014-05"
-7532	mediocre practically non-alcoholic rocket fuel	1	decent	Last Available: "2014-05"
+7532	practically non-alcoholic mediocre rocket fuel	1	decent	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	hand-crafted watered-down ghostly stealth bomber	2	EPIC	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	tumbling ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	dance instructor's space beast fur hat	0		Experience Percent (Moxie): +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	gravedigger's space beast fur pants	0		Spooky Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	dance instructor's space beast fur hat	0		Experience Percent (Moxie): +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	gravedigger's space beast fur pants	0		Spooky Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	tumbling personal trainer's space beast fur whip	0		Experience Percent (Muscle): +10, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	rosewater-soaked gravedigger's space heater	0		Spooky Damage: +10, Stench Resistance: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7444,14 +7444,14 @@
 7555	red page	0		
 7556	elephant gift	0		
 7557	boiled modified non-alkaline upside-down yellow blood cells	0		Effect: "Egg-headedness", Effect Duration: 57
-7558	smooth weak wine	2	awesome	
+7558	weak smooth wine	2	awesome	
 7559	ionized gummi turtle	0		Effect: "Turkey-Friendly", Effect Duration: 27
 7560	turtle-shaped rock	0		
 7561	electrified pressed nitrogenated fuchsia giraffe-necked turtle	0		Effect: "Thought", Effect Duration: 19
 7562	aerosolized wet wobbly ghostly musk turtle	0		Effect: "Fastbreaker", Effect Duration: 11
 7563	pickled quadruple-magnetized blurry programmable turtle	0		Effect: "familiar.enq", Effect Duration: 26
-7564	ionized nitrogenated blinking fuchsia mocking turtle	0		Effect: "Gyromitra Gymnastics", Effect Duration: 22
-7565	stale super-sized ham steak	5	decent	
+7564	ionized nitrogenated fuchsia blinking mocking turtle	0		Effect: "Gyromitra Gymnastics", Effect Duration: 22
+7565	super-sized stale ham steak	5	decent	
 7566	deadly time-twitching toolbelt	0		Weapon Damage: +5, Single Equip, Free Pull
 7567	Chroner	0		
 7568	lightning-fast MacGyver's steel-toed Time Lord Badge of Honor	0		Damage Reduction: 9, Maximum MP: +100, Initiative: +40
@@ -7469,23 +7469,23 @@
 7580	compressed liquid shifting time weirdness	1		Effect: "Sagittarius Rising", Effect Duration: 15
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	flavorless rack of dinosaur ribs	4	decent	
-7583	irresponsibly strong acceptable scotch on the rocks	6	good	
+7583	acceptable irresponsibly strong scotch on the rocks	6	good	
 7584	Rosewater's cool yabba dabba doo rag	0		Moxie: +5, Mysticality Percent: +30, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	teal arcane researcher's wooly loincloth of the pedagogue	0		Experience: +3, Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	mirror S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	delicious special bouncing glass of &quot;milk&quot;	3	awesome	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2014-07"
-7590	watered-down drinkable blurry cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
+7590	drinkable watered-down blurry cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
 7591	perfectly mixed weak thermos of &quot;whiskey&quot;	2	EPIC	Last Available: "2014-07"
 7592	perfectly mixed watered-down huge blurry Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	perfectly mixed Bee's Knees	4	EPIC	Last Available: "2014-07"
 7594	irresponsibly strong bad Sockdollager	7	decent	Last Available: "2014-07"
-7595	triple-distilled acceptable skewed Ish Kabibble	10	good	Last Available: "2014-07"
+7595	acceptable triple-distilled skewed Ish Kabibble	10	good	Last Available: "2014-07"
 7596	hand-crafted bouncing Hot Socks	3	EPIC	Last Available: "2014-07"
 7597	hand-crafted Phonus Balonus	4	EPIC	Last Available: "2014-07"
 7598	tolerable blinking Flivver	4	good	Last Available: "2014-07"
-7599	fancy weak delicious Sloppy Jalopy	2	awesome	Effect: "You Know Where to Go", Effect Duration: 25, Last Available: "2014-07"
+7599	weak fancy delicious Sloppy Jalopy	2	awesome	Effect: "You Know Where to Go", Effect Duration: 25, Last Available: "2014-07"
 7600	improved flame	0		Effect: "Concentration", Effect Duration: 24
 7601	electrified Vulcanized wobbly temporary yak tattoo	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 55
 7602	activated Fitspiration&trade; poster	0		Effect: "Human-Pirate Hybrid", Effect Duration: 47
@@ -7497,7 +7497,7 @@
 7608	altered concentrated electrified skewed turtle mud	0		Effect: "Celestial Sheen", Effect Duration: 54
 7609	chilled upside-down Redeye&trade; Eyedrops	0		Effect: "Salamander In Your Stomach", Effect Duration: 56
 7610	pressed Vulcanized colloidal Dweebisol&trade; inhaler	0		Effect: "Reedy Pipes", Effect Duration: 40
-7611	chilled mirror spinning Lewd Lemmy Hair Oil	0		Effect: "Kernel Panic!", Effect Duration: 29
+7611	chilled spinning mirror Lewd Lemmy Hair Oil	0		Effect: "Kernel Panic!", Effect Duration: 29
 7612	modified tarnished tomato soup poster	0		Effect: "Extra-Wet", Effect Duration: 28
 7613	diffused polymerized bubblin' chemistry solution	0		Effect: "Orc Chops", Effect Duration: 11
 7614	vacuum-sealed twirling voodoo glowskull	0		Effect: "Bananas!", Effect Duration: 69
@@ -7506,10 +7506,10 @@
 7617	corrupted short deposition	0		Effect: "Blood-Gorged", Effect Duration: 65
 7618	improved cold-filtered straw pole	0		Effect: "Mer-kindliness", Effect Duration: 37
 7619	galvanized copperhead potion	0		Effect: "Ichorous Intensity", Effect Duration: 20
-7620	adjusted wobbly blurry ninja fear powder	0		Effect: "Perception", Effect Duration: 55
-7621	quantum narrow shaking yellow ninja eyeblack	0		Effect: "Crimbo Epiphany", Effect Duration: 52
-7622	polarized altered blurry twirling button rouge	0		Effect: "Shawarma Initiative", Effect Duration: 46
-7623	adjusted extra-Vulcanized unsweetened ghostly squat Red Army camouflage kit	0		Effect: "Cool Spirit", Effect Duration: 17
+7620	adjusted blurry wobbly ninja fear powder	0		Effect: "Perception", Effect Duration: 55
+7621	quantum yellow narrow shaking ninja eyeblack	0		Effect: "Crimbo Epiphany", Effect Duration: 52
+7622	polarized altered twirling blurry button rouge	0		Effect: "Shawarma Initiative", Effect Duration: 46
+7623	adjusted extra-Vulcanized unsweetened squat ghostly Red Army camouflage kit	0		Effect: "Cool Spirit", Effect Duration: 17
 7624	extra-moist colloidal irradiated lynyrd skinner toothblack	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 66
 7625	deionized flask of rainwater	0		Effect: "Tiki Temerity", Effect Duration: 69
 7626	diffused jittery pulsating oyster badge	0		Effect: "Puddingface", Effect Duration: 33
@@ -7529,17 +7529,17 @@
 7640	shaking prompt experienced turtle shell of the storm	0		Experience: +2, Maximum MP Percent: +40, Adventures: +3, Class: "Turtle Tamer"
 7641	shocked shell	0		Class: "Turtle Tamer"
 7642	ingot turtle	0		
-7643	teal skewed duty umbrella	0		
+7643	skewed teal duty umbrella	0		
 7644	skewed pool skimmer	0		
 7645	narrow life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
 7648	ghostly thunder thigh	0		
-7649	Vulcanized tumbling skewed gourmet gourami oil	0		Effect: "The Halls of Moxiousness", Effect Duration: 36
-7650	triple-flattened yellow twirling catfish whiskers	0		Effect: "Nut-Rition", Effect Duration: 54
+7649	Vulcanized skewed tumbling gourmet gourami oil	0		Effect: "The Halls of Moxiousness", Effect Duration: 36
+7650	triple-flattened twirling yellow catfish whiskers	0		Effect: "Nut-Rition", Effect Duration: 54
 7651	shaking freshwater fishbone	0		
 7652	jittery maroon fishbone catcher's mitt	0		
-7653	blinking tumbling fishbone kneepads	0		Initiative: +60, Single Equip
+7653	tumbling blinking fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
@@ -7548,26 +7548,26 @@
 7659	ruddy neoprene skullcap	0		Maximum HP Percent: +40, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	dry activated goblin water	0		Effect: "Smelly Pants", Effect Duration: 30
 7661	squat dumb mud	0		
-7662	bite-sized spoiled shaking Sogg-Os	1	crappy	
+7662	spoiled bite-sized shaking Sogg-Os	1	crappy	
 7663	sharpshooter's grievous boxer's Lord Soggyraven's Slippers	0		Muscle Percent: +10, Weapon Damage Percent: +50, Critical Hit Percent: +10, Single Equip
 7664	energized pressed double-moist lime green Ancient Protector Soda	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 16
 7665	electrified ionized liquid ice	0		Effect: "The Grass...  Is Blue...", Effect Duration: 40
 7666	weak tolerable teal Wet Russian	2	good	
-7667	flavorless immense filet of The Fish	9	decent	
+7667	immense flavorless filet of The Fish	9	decent	
 7668	Thwaitgold spider statuette	0		
 7669	Herculean thunder down underwear of the cougar of chilblains	0		Moxie: +20, Experience (Muscle): +1, Cold Damage: +25, Lasts Until Rollover
 7670	skewed stiffened sage famous raincoat of the blizzard	0		Mysticality Percent: +10, Damage Reduction: 1, Cold Spell Damage: +25, Lasts Until Rollover
 7671	narrow educational wizardly lightning rod of the early riser	0		Mysticality: +25, Experience: +1, Adventures: +7, Lasts Until Rollover
 7672	rosewater-soaked law-abiding citizen cane	0		Stench Resistance: +3, Single Equip
-7673	irresponsibly strong lousy legitimate business on the beach	10	decent	
+7673	lousy irresponsibly strong legitimate business on the beach	10	decent	
 7674	wobbly cool hep waders	0		Moxie: +5, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	decent massive jive turkey leg	9	good	
+7675	massive decent jive turkey leg	9	good	
 7676	wizardly birdbone corset	0		Mysticality: +25
 7677	flattened dry candy cigarette	0		Effect: "Cheered Up", Effect Duration: 13
 7678	tumbling miser's 4-dimensional fez	0		Meat Drop: +10, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	spinning super-absorbent tarp of the sewer	0		Stench Damage: +25
-7681	mediocre weak unquiet spirits	2	decent	
+7681	weak mediocre unquiet spirits	2	decent	
 7682	flame-wreathed banjo kazoo mount	0		Hot Spell Damage: +10, Single Equip
 7683	boiled flattened ghostly blurry grass	0		Effect: "Serendipi Tea", Effect Duration: 39
 7684	Herculean Time Lord Participation Mug	0		Experience (Muscle): +1
@@ -7592,13 +7592,13 @@
 7703	shaking LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	electrified oxidized triple-warmed blurry olive rubber nubbin	0		Effect: "protect.enq", Effect Duration: 24, Last Available: "2014-08"
 7708	family-friendly foul-smelling rubber cape	0		Stench Damage: +10, Sleaze Resistance: +1, Last Available: "2014-08"
 7709	perfumed asbestos-lined Jack Frost's fortified Thor's Pliers	0		Damage Absorption: +60, Cold Spell Damage: +50, Hot Resistance: +5, Stench Resistance: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	quantum jittery candy UFOs	0		Effect: "Turtle Titters", Effect Duration: 58
 7711	gray spinning censurious educational water wings for babies	0		Experience: +1, Sleaze Resistance: +3
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	tasty Strix stix	3	awesome	
 7714	scandalous coward's vampire pellet of terror	0		Monster Level: -20, Spooky Spell Damage: +10, Sleaze Damage: +5
 7715	drinkable non-aged vinegar	3	good	
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	studded Xiblaxian xeno-detection goggles	0		Damage Absorption: +80, Single Equip, Last Available: "2014-09"
-7753	ghostly Jim Carey's Fonzie's Xiblaxian stealth cowl	0		Experience (Moxie): +1, Monster Level: +25, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	ghostly Jim Carey's Fonzie's Xiblaxian stealth cowl	0		Experience (Moxie): +1, Monster Level: +25, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	Da Vinci's cool Xiblaxian stealth trousers	0		Moxie: +5, Experience (Mysticality): +5, Last Available: "2014-09"
 7755	thinker's beefcake's Xiblaxian stealth vest	0		Muscle: +25, Mysticality: +10, Last Available: "2014-09"
 7756	rotten massive Xiblaxian ultraburrito	8	crappy	Last Available: "2014-09"
@@ -7668,8 +7668,8 @@
 7779	irradiated olive experimental serum G-9	0		Effect: "Good Motivator", Effect Duration: 37, Last Available: "2014-10"
 7780	squat scandalous foul-smelling heavy-duty clipboard of the sewer	0		Stench Damage: 35, Sleaze Damage: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	skewed ruddy Socratic beefy battery-powered drill of the scaredy-cat	0		Muscle: +10, Experience (Mysticality): +1, Maximum HP Percent: +40, Monster Level: -15, Last Available: "2014-10"
-7782	super-sized yummy limp broccoli	5	awesome	Last Available: "2014-10"
-7783	blurry greedy aromatic medical-grade hat	0		Stench Resistance: +1, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	yummy super-sized limp broccoli	5	awesome	Last Available: "2014-10"
+7783	blurry greedy aromatic medical-grade hat	0		Stench Resistance: +1, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	dry quantum monkey barf	0		Effect: "Marinated", Effect Duration: 30, Last Available: "2014-10"
 7785	dry double-nitrogenated candy	0		Effect: "Took Eleven", Effect Duration: 25, Last Available: "2014-10"
 7786	auspicious gravedigger's forbidden jangly bracelet	0		Spell Damage Percent: +50, Spooky Damage: +10, Item Drop: +10, Last Available: "2014-10"
@@ -7685,12 +7685,12 @@
 7796	tiny adequate warm war shawarma	1	good	Last Available: "2014-10"
 7797	massive normal karma shawarma	6	good	Last Available: "2014-10"
 7798	artisanal Jungle Juice	4	EPIC	Last Available: "2014-10"
-7799	mediocre weak squat Amnesiac Ale	2	decent	Last Available: "2014-10"
-7800	delicious weak Highest Bitter	2	awesome	Last Available: "2014-10"
+7799	weak mediocre squat Amnesiac Ale	2	decent	Last Available: "2014-10"
+7800	weak delicious Highest Bitter	2	awesome	Last Available: "2014-10"
 7801	foul-smelling smooth mercenary pistol	0		Moxie: +15, Stench Damage: +10, Last Available: "2014-10"
 7802	hardened mercenary rifle of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3, Last Available: "2014-10"
 7803	pulsating Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
-7804	wobbly blinking blue Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
+7804	wobbly blue blinking Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	Merc Core challenge coin	0		Last Available: "2014-10"
 7806	wobbly Merc Core deployment orders	0		Last Available: "2014-10"
 7807	wobbly TI-9000 calculator	0		
@@ -7700,7 +7700,7 @@
 7811	twirling viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	bland half-sized seared dino steak	2	decent	
-7814	practically non-alcoholic mediocre bottle of drinkin' gas	1	decent	
+7814	mediocre practically non-alcoholic bottle of drinkin' gas	1	decent	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7714,18 +7714,18 @@
 7825	reassuring shellacked wizardly earbuds	0		Mysticality: +25, Damage Reduction: 7, Spooky Resistance: +1, Single Equip
 7826	lightning-fast chilly razor-sharp iFlail	0		Weapon Damage Percent: +25, Cold Damage: +5, Initiative: +40
 7827	rotten unidentifiable dried fruit	3	crappy	
-7828	bad practically non-alcoholic upside-down shaking flat cider	1	decent	
+7828	bad practically non-alcoholic shaking upside-down flat cider	1	decent	
 7829	twirling purple knitted cool trench lighter of James Dean	0		Moxie: +5, Experience (Moxie): +3, Cold Resistance: +3, Last Available: "2014-10"
 7830	activated experimental serum P-00	0		Effect: "Mental A-cue-ity", Effect Duration: 51, Last Available: "2014-10"
 7831	olive military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
-7834	fuchsia bouncing pack of smokes	0		Last Available: "2014-10"
+7834	bouncing fuchsia pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	pulsating Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
-7839	olive blurry special clip: tracers	0		Last Available: "2014-10"
+7839	blurry olive special clip: tracers	0		Last Available: "2014-10"
 7840	special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
@@ -7743,8 +7743,8 @@
 7854	Sherlock's plastic Crimbot	0		Item Drop: +25, Last Available: "2014-12"
 7855	thinker's plastic Crimbomega	0		Mysticality: +10, Last Available: "2014-12"
 7856	moist flask of mining oil	0		Effect: "Top Dog", Effect Duration: 44, Last Available: "2014-12"
-7857	radiation-resistant helmet of the brazier	0		Hot Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	jittery tumbling rock-hard servo-assisted exo-pants	0		Damage Reduction: 5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	radiation-resistant helmet of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	jittery tumbling rock-hard servo-assisted exo-pants	0		Damage Reduction: 5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	jittery beefy high-energy mining laser of mayonnaise	0		Muscle: +10, Sleaze Spell Damage: +50, Last Available: "2014-12"
 7860	huge peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7756,7 +7756,7 @@
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
-7870	blue wobbly Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
+7870	wobbly blue Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	wobbly Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	green Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
@@ -7767,7 +7767,7 @@
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
 7880	Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
-7881	narrow blue Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
+7881	blue narrow Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
@@ -7787,7 +7787,7 @@
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	wobbly Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
-7901	narrow olive Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
+7901	olive narrow Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	bouncing bouncing Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	wobbly Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	squat Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
@@ -7800,12 +7800,12 @@
 7911	recovered elf photo album	0		Last Available: "2014-12"
 7912	recovered elf smartphone	0		Last Available: "2014-12"
 7913	blurry tumbling sinister groovy Size XI Wizard's Robe of chilblains	0		Moxie Percent: +10, Spell Damage: +10, Cold Damage: +25, Last Available: "2014-09"
-7914	extra-anodized spinning narrow Bit O' Quail Spleen	0		Effect: "Staying Frosty", Effect Duration: 28
+7914	extra-anodized narrow spinning Bit O' Quail Spleen	0		Effect: "Staying Frosty", Effect Duration: 28
 7915	flattened squat teal Take Eleven Bar	0		Effect: "Sepia Tan", Effect Duration: 13
 7916	mimeplasm	0		
 7917	triple-corrupted galvanized blurry BOOterfinger	0		Effect: "Chlorophyll Flavor", Effect Duration: 16
 7918	aerosolized energized purple Moonds	0		Effect: "The Moxious Madrigal", Effect Duration: 12
-7919	polarized galvanized ghostly red Big Punk	0		Effect: "The Power of LOV", Effect Duration: 13
+7919	polarized galvanized red ghostly Big Punk	0		Effect: "The Power of LOV", Effect Duration: 13
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	tumbling turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	acceptable Friendly Turkey	3	good	Last Available: "2014-11"
@@ -7817,7 +7817,7 @@
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	mixed mirror squat shaking single atom	1	decent	Last Available: "2015-02"
+7938	mixed shaking mirror squat single atom	1	decent	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	blinking Time Cloak	0		Last Available: "2014-11"
 7941	narrow sleeve deuce	0		
@@ -7881,7 +7881,7 @@
 7999	flattened denatured twirling choco-Crimbot	0		Effect: "Stinking Cloud", Effect Duration: 64, Last Available: "2014-12"
 8000	irradiated unsweetened mirror smart watch	0		Effect: "Human-Beast Hybrid", Effect Duration: 22, Last Available: "2014-12"
 8001	pickled triple-irradiated purple augmented-reality shades	0		Effect: "Boo Tea", Effect Duration: 47, Last Available: "2014-12"
-8002	green blurry toy Crimbot mega face of the wise owl	0		Mysticality: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8002	green blurry toy Crimbot mega face of the wise owl	0		Mysticality: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
 8003	Samson's toy Crimbot power glove	0		Experience (Muscle): +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	blue crafty toy Crimbot super fist	0		Maximum MP: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	skewed friendly toy Crimbot rocket legs	0		Familiar Weight: +3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7917,7 +7917,7 @@
 8035	Oprah's topiary tights of the early riser	0		Maximum MP Percent: +50, Adventures: +7
 8036	Jack Frost's topiary necktie	0		Cold Spell Damage: +50
 8037	flavorless bowl of topioca	4	decent	
-8038	red wobbly topiary skunk	0		
+8038	wobbly red topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
 8041	skewed crumbling skull	0		
@@ -7937,7 +7937,7 @@
 8056	skewed torch	0		
 8057	prompt manspreader's [spelunking test kit]	0		Monster Level: +10, Adventures: +3
 8058	boxer's plasma rifle	0		Muscle Percent: +10
-8059	red blinking Bananubis's Staff	0		Luck: -6
+8059	blinking red Bananubis's Staff	0		Luck: -6
 8060	The Joke Book of the Dead of the blizzard of the sweet-tooth	0		Cold Spell Damage: +25, Candy Drop: +100, Luck: -6
 8061	spinning The Clown Crown	0		Luck: -6
 8062	skewed coffee cup	0		Luck: -2
@@ -7952,9 +7952,9 @@
 8071	bouncing warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	squat twirling executive chaotic hale Spelunker's fedora	0		Maximum HP: +20, Spell Critical Percent: +10, Meat Drop: +40, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	squat twirling executive chaotic hale Spelunker's fedora	0		Maximum HP: +20, Spell Critical Percent: +10, Meat Drop: +40, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	bouncing narrow MacGyver's fortified Spelunker's whip of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, Maximum MP: +100, Last Available: "2015-12"
-8076	flame-wreathed Spelunker's khakis of wisdom of the early riser	0		Mysticality: +15, Hot Spell Damage: +10, Adventures: +7, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	flame-wreathed Spelunker's khakis of wisdom of the early riser	0		Mysticality: +15, Hot Spell Damage: +10, Adventures: +7, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	skewed LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7984,7 +7984,7 @@
 8109	executive double-paned ascot	0		Cold Resistance: +5, Meat Drop: +40, Single Equip, Last Available: "2017-12"
 8110	pulsating scandalous attache case of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +5, Last Available: "2017-12"
 8111	smelly accordion of the scaredy-cat	0		Monster Level: -15, Stench Spell Damage: +10, Song Duration: 10, Last Available: "2017-12"
-8112	distilled shaking blinking aerosolized	1		Effect: "Become Intensely interested", Effect Duration: 5, Last Available: "2017-12"
+8112	distilled blinking shaking aerosolized	1		Effect: "Become Intensely interested", Effect Duration: 5, Last Available: "2017-12"
 8113	mansplainer's wig of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +15, Last Available: "2017-12"
 8114	stanky arcane researcher's winch crank	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +25, Single Equip, Last Available: "2017-12"
 8115	narrow miser's widget of dire peril	0		Weapon Damage: +20, Meat Drop: +10, Single Equip, Last Available: "2017-12"
@@ -8026,7 +8026,7 @@
 8152	frozen cold-filtered tumbling polyeaster egg	0		Effect: "Wit Tea", Effect Duration: 32
 8153	improved spinning blinking candy dish	0		Effect: "Mana Tea", Effect Duration: 55
 8154	diffused Vulcanized quadruple-Vulcanized Spechunky bar	0		Effect: "Bloodstain-Resistant", Effect Duration: 19
-8155	polarized boiled narrow purple jittery talisman of Horus	0		Effect: "Ruthlessly Efficient", Effect Duration: 50
+8155	polarized boiled narrow jittery purple talisman of Horus	0		Effect: "Ruthlessly Efficient", Effect Duration: 50
 8156	blinking check to the Meatsmith	0		
 8157	spinning bouncing Skeleton Store office key	0		
 8158	jittery bone with a price tag on it	0		
@@ -8038,14 +8038,14 @@
 8164	Lo Pan's therapeutic remaindered axe	0		Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7
 8165	low-budget shield	0		Damage Reduction: 3
 8166	baleful Da Vinci's cr&ecirc;epy mask	0		Experience (Mysticality): +5, Spell Damage: +25, Familiar Effect: "spooky atk, cap 5"
-8167	delicious bite-sized baguette	1	awesome	
+8167	bite-sized delicious baguette	1	awesome	
 8168	glob of icing	0		
 8169	altered ginger snaps	0		Effect: "items.enh", Effect Duration: 51
 8170	corrupted non-flattened upside-down mostly-broken sunglasses	0		Effect: "Prince of Seaside Town", Effect Duration: 33
-8171	watered-down acceptable unflavored wine cooler	2	good	
+8171	acceptable watered-down unflavored wine cooler	2	good	
 8172	blurry carton of snake milk	1	EPIC	
 8173	Socratic sewer snake	0		Experience (Mysticality): +1
-8174	rotten massive blinking narrow pigeon egg	6	crappy	
+8174	rotten massive narrow blinking pigeon egg	6	crappy	
 8175	dog trainer's manspreader's jaunty feather	0		Monster Level: +10, Experience (familiar): +1
 8176	bad premium malt liquor	4	decent	
 8177	miser's brown paper pants of the pedagogue	0		Experience: +3, Meat Drop: +10
@@ -8056,7 +8056,7 @@
 8182	squat Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	electrified bread basket	0		MP Regen Min: 3, MP Regen Max: 5
 8184	Ed the Undying exhibit crate	0		
-8185	maroon Annie Oakley's Oprah's The Crown of Ed the Undying	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	maroon Annie Oakley's Oprah's The Crown of Ed the Undying	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	lime green Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	mediocre Cherrytastrophe wine cooler	4	decent	
@@ -8066,12 +8066,12 @@
 8192	tolerable pulsating Citrus Crush wine cooler	3	good	
 8193	decent upside-down plain bagel	3	good	
 8194	stale glob of cream cheese	4	decent	
-8195	tiny bland mirror loaf of soda bread	1	decent	
-8196	enchanted big stale yellow acceptable bagel	5	decent	Effect: "Physicali Tea", Effect Duration: 45
-8197	stale tiny yellow upside-down standard-issue cupcake	1	decent	
-8198	rotten huge blurry ultra-deluxe cupcake	3	crappy	
+8195	bland tiny mirror loaf of soda bread	1	decent	
+8196	big stale enchanted yellow acceptable bagel	5	decent	Effect: "Physicali Tea", Effect Duration: 45
+8197	tiny stale upside-down yellow standard-issue cupcake	1	decent	
+8198	rotten blurry huge ultra-deluxe cupcake	3	crappy	
 8199	squat hypnotic breadcrumbs	0		
-8200	adequate miniature popular tart	2	good	
+8200	miniature adequate popular tart	2	good	
 8201	no-handed pie	0		
 8202	ionized pickled Doc Galaktik's Vitality Serum	0		Effect: "Tightly-Wound Spine", Effect Duration: 35
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8080,19 +8080,19 @@
 8206	Rosewater's expensive camera of the scaredy-cat	0		Mysticality Percent: +30, Monster Level: -15, Single Equip, Last Available: "2015-04"
 8207	sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	ionized warmed wobbly How to Avoid Scams	0		Effect: "Balls of Ectoplasm", Effect Duration: 64, Last Available: "2015-04"
-8209	wobbly tumbling filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
+8209	tumbling wobbly filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	tumbling bag of park garbage	0		Last Available: "2015-04"
 8212	spinning grogpagne	0		Last Available: "2021-07"
 8213	reassuring rigging rope of temperance	0		Spooky Resistance: +1, Sleaze Resistance: +5, Last Available: "2015-04"
-8214	powdered gray mirror nasty snuff	1	good	Last Available: "2015-04"
+8214	powdered mirror gray nasty snuff	1	good	Last Available: "2015-04"
 8215	narrow deadly slick sewage-clogged pistol	0		Moxie: +10, Weapon Damage: +5, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	Vulcanized gray beard incense	0		Effect: "Crocodile Tear", Effect Duration: 65, Last Available: "2015-04"
 8217	sinister perfume-soaked bandana of the empath	0		Spell Damage: +10, Familiar Weight: +5, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	spoiled ghostly teal toxo	4	crappy	Last Available: "2015-04"
 8220	weak perfectly mixed huge green Lemonade-235	2	EPIC	Last Available: "2015-04"
-8221	cyan nasty manspreader's isotophat	0		Monster Level: +10, Stench Damage: +5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8221	cyan nasty manspreader's isotophat	0		Monster Level: +10, Stench Damage: +5, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	tumbling Sherlock's supercool Three Mile Island shorts	0		Moxie Percent: +20, Item Drop: +25, Last Available: "2015-04"
 8223	foul-smelling banded toxic mop	0		Damage Absorption: +100, Stench Damage: +10, Last Available: "2015-04"
 8224	bouncing red inert sludgepuppy	0		Last Available: "2015-04"
@@ -8135,21 +8135,21 @@
 8261	Mayonex	0		Last Available: "2015-05"
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	Mayostat	0		Last Available: "2015-05"
-8264	twirling blurry Mayozapine	0		Last Available: "2015-05"
+8264	blurry twirling Mayozapine	0		Last Available: "2015-05"
 8265	Mayoflex	0		Last Available: "2015-05"
 8266	nippy healthy dance instructor's miracle whip of the empath	0		Experience Percent (Moxie): +10, Maximum HP Percent: +20, Familiar Weight: +5, Cold Damage: +10, Lasts Until Rollover, Last Available: "2015-05"
 8267	wobbly banded sphygmayomanometer	0		Damage Absorption: +100, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
-8269	mirror squat mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
+8269	squat mirror mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	flavorless mirror unappetizing mayolus	4	decent	Last Available: "2015-05"
 8271	flavorless uninteresting mayolus	3	decent	Last Available: "2015-05"
-8272	moldy snack-sized blinking acceptable mayolus	2	crappy	Last Available: "2015-05"
+8272	snack-sized moldy blinking acceptable mayolus	2	crappy	Last Available: "2015-05"
 8273	decent bouncing enticing mayolus	3	good	Last Available: "2015-05"
 8274	rotten bite-sized pulsating mouth-watering mayolus	1	crappy	Last Available: "2015-05"
 8275	green tumbling tumbling newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	cyan mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	weak artisanal Afternoon Delight	2	EPIC	Last Available: "2015-04"
+8278	artisanal weak Afternoon Delight	2	EPIC	Last Available: "2015-04"
 8279	jittery Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	deionized pressed jittery Kokomo Resort Brand Suntan Oil	0		Effect: "Red-Shirted Escort", Effect Duration: 11, Last Available: "2015-04"
@@ -8175,14 +8175,14 @@
 8301	corrupted energized narrow spinning pixel star	0		Effect: "Human-Machine Hybrid", Effect Duration: 44, Last Available: "2015-06"
 8302	moldy pixel banana	3	crappy	Last Available: "2015-06"
 8303	aged pixel beer	3	awesome	Last Available: "2015-06"
-8304	upside-down narrow puck with a bow on it	0		Free Pull, Last Available: "2015-06"
+8304	narrow upside-down puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	non-polarized magnetized jittery sludgesicle	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 18
 8307	improved skewed &Uuml;berraschthexengebr&auml;u	0		Effect: "Stick Emporium Membership", Effect Duration: 22
 8308	Vulcanized cyan piggy tattoo	0		Effect: "Lobos Fresh", Effect Duration: 24
 8309	colloidal blurry baggie of regular-sized tardigrades	0		Effect: "Weird Vibrations", Effect Duration: 40
 8310	improved triple-modified altered cyan .epub file	0		Effect: "Fishy", Effect Duration: 47
-8311	aerosolized enhanced diffused blue skewed BUBBLE GUM	0		Effect: "Woad Warrior", Effect Duration: 26
+8311	aerosolized enhanced diffused skewed blue BUBBLE GUM	0		Effect: "Woad Warrior", Effect Duration: 26
 8312	dry non-deionized hustler shades	0		Effect: "Granolarrrgh", Effect Duration: 22
 8313	quadruple-unsweetened denatured green wobbly jerky stick	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 45
 8314	nitrogenated costume rental shop	0		Effect: "Stinking Cloud", Effect Duration: 30
@@ -8240,7 +8240,7 @@
 8366	tarnished triple-quantum wet invisibility cream	0		Effect: "Okee-Dokee Computer", Effect Duration: 25
 8367	oxidized activated energized handful of stubble	0		Effect: "Human-Elf Hybrid", Effect Duration: 13
 8368	wet electrified triple-oxidized garbage juice slurpee	0		Effect: "Sweet and Green", Effect Duration: 54
-8369	polarized ghostly skewed plunge-leg	0		Effect: "Broken Bone Nubs", Effect Duration: 29
+8369	polarized skewed ghostly plunge-leg	0		Effect: "Broken Bone Nubs", Effect Duration: 29
 8370	oxidized extra-dry funky eyepatch	0		Effect: "The Q Is Talking To You", Effect Duration: 55
 8371	irradiated fuchsia bucket of fish juice	0		Effect: "Stregngth of the Gnome", Effect Duration: 34
 8372	warmed electrified flashy pirate dreadlocks	0		Effect: "Triangle, Man", Effect Duration: 46
@@ -8248,14 +8248,14 @@
 8374	boiled drinks tray	0		Effect: "Ichorous Intensity", Effect Duration: 35
 8375	deionized polarized teal eyebrow lifter	0		Effect: "Truly Gritty", Effect Duration: 51
 8376	submarine	0		Last Available: "2015-06"
-8377	stale miniature pixel lemon	2	decent	Last Available: "2015-06"
+8377	miniature stale pixel lemon	2	decent	Last Available: "2015-06"
 8378	hand-crafted pixel daiquiri	4	EPIC	Last Available: "2015-06"
 8379	frozen power pill	0		Effect: "Wise Spirit", Effect Duration: 21, Last Available: "2015-06"
 8380	tarnished upside-down pixel potion	0		Effect: "Stimulated Brain", Effect Duration: 13, Last Available: "2015-06"
 8381	wobbly Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
-8384	olive huge bubblegum heart	0		Last Available: "2015-07"
+8384	huge olive bubblegum heart	0		Last Available: "2015-07"
 8385	cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
@@ -8280,18 +8280,18 @@
 8406	savory dry noodles	0		
 8407	moldy green pestopiary	4	crappy	
 8408	quantum aerosolized olive ectoplasmic orbs	0		Effect: "Sticky Fingers", Effect Duration: 15
-8409	bland half-sized crudles	2	decent	
+8409	half-sized bland crudles	2	decent	
 8410	flavorless thick yellow agnolotti arboli	5	decent	
 8411	special spoiled spaghetti with ghost balls	4	crappy	Effect: "Yes, Can Haz", Effect Duration: 45
 8412	fancy decent succulent marrow	3	good	Effect: "Wings of the Grasshopper", Effect Duration: 50
-8413	thick tasty yellow salacious crumbs	5	awesome	
+8413	tasty thick yellow salacious crumbs	5	awesome	
 8414	flavorless lime green fusilli marrownarrow	4	decent	
-8415	jumbo flavorless suggestive strozzapreti	5	decent	
+8415	flavorless jumbo suggestive strozzapreti	5	decent	
 8416	Mountain Stream gastrique	0		
-8417	gigantic spoiled Mt. McLargeHuge oyster	9	crappy	
+8417	spoiled gigantic Mt. McLargeHuge oyster	9	crappy	
 8418	mirror oyster sauce	0		
 8419	yummy blinking linguini immondizia bianco	4	awesome	
-8420	bite-sized rotten huge shells a la shellfish	1	crappy	
+8420	rotten bite-sized huge shells a la shellfish	1	crappy	
 8421	blinking Jick's autograph	0		
 8422	teal high-temperature mining drill	0		Last Available: "2015-08"
 8423	blinking unsmoothed velvet	0		Last Available: "2015-08"
@@ -8329,11 +8329,11 @@
 8455	squat New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	spinning Usain Bolt's resourceful high-temperature mining mask	0		Maximum MP: +50, Initiative: +80, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	spinning Usain Bolt's resourceful high-temperature mining mask	0		Maximum MP: +50, Initiative: +80, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	blue horrifying studded fireproof megaphone	0		Damage Absorption: +80, Spooky Damage: +25, Last Available: "2015-08"
 8460	normal narrow mineapple	4	good	Last Available: "2015-08"
 8461	mediocre triple-distilled Gold Velvet&trade; whiskey	9	decent	Last Available: "2015-08"
-8462	ghostly tumbling SMOOCH soda	1	decent	Last Available: "2015-08"
+8462	tumbling ghostly SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	decent shaking smelted roe	3	good	Last Available: "2015-08"
 8464	bad practically non-alcoholic maroon lavawater	1	decent	Last Available: "2015-08"
 8465	super-aerosolized basaltamander tongue	0		Effect: "Can't Smell Nothin'", Effect Duration: 56, Last Available: "2015-08"
@@ -8348,11 +8348,11 @@
 8474	normal enchanted very hot lunch	4	good	Effect: "Hot Blooded", Effect Duration: 25, Last Available: "2015-08"
 8475	tolerable asbestos thermos	4	good	Last Available: "2015-08"
 8476	dry triple-cold-filtered bouncing liquid rhinestones	0		Effect: "Fire Inside", Effect Duration: 37, Last Available: "2015-08"
-8477	fancy normal half-sized spinning blurry disco biscuit	2	good	Effect: "Pretending to Pretend", Effect Duration: 20, Last Available: "2015-08"
-8478	drinkable fancy Quaatorade&trade;	3	good	Effect: "Quiet 'n' Good", Effect Duration: 20, Last Available: "2015-08"
-8479	green aromatic crafty Da Vinci's biker's hat	0		Experience (Mysticality): +5, Maximum MP: +10, Stench Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
-8480	sage weightlifter's feathered headdress of wisdom	0		Muscle: +15, Mysticality: +15, Mysticality Percent: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	gravedigger's Socratic electrician's hardhat of the dark arts	0		Experience (Mysticality): +1, Spell Damage Percent: +100, Spooky Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
+8477	normal fancy half-sized spinning blurry disco biscuit	2	good	Effect: "Pretending to Pretend", Effect Duration: 20, Last Available: "2015-08"
+8478	fancy drinkable Quaatorade&trade;	3	good	Effect: "Quiet 'n' Good", Effect Duration: 20, Last Available: "2015-08"
+8479	green aromatic crafty Da Vinci's biker's hat	0		Experience (Mysticality): +5, Maximum MP: +10, Stench Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
+8480	sage weightlifter's feathered headdress of wisdom	0		Muscle: +15, Mysticality: +15, Mysticality Percent: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	gravedigger's Socratic electrician's hardhat of the dark arts	0		Experience (Mysticality): +1, Spell Damage Percent: +100, Spooky Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
 8482	mirror Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	mirror smooth velvet pants of doom	0		Spooky Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	mirror smooth velvet pants of doom	0		Spooky Spell Damage: +50, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	smooth velvet shirt of doom	0		Spooky Spell Damage: +50, Last Available: "2015-08"
 8492	skewed smooth velvet hat of the cougar	0		Moxie: +20, Last Available: "2015-08"
 8493	blue zippy smooth velvet pocket square	0		Initiative: +20, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	perfumed SMOOCH bracers of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +5, Single Equip, Last Available: "2015-08"
 8518	ghostly SMOOCH kneepads of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2015-08"
 8519	narrow olive thinker's SMOOCH spaulders	0		Mysticality: +10, Single Equip, Last Available: "2015-08"
-8520	foul-smelling SMOOCH codpiece of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	foul-smelling SMOOCH codpiece of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	SMOOCH breastplate of the cougar	0		Moxie: +20, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8406,18 +8406,18 @@
 8532	jittery good gravy	0		
 8533	skewed illicit fish sauce	0		
 8534	spoiled libertagliatelle	3	crappy	
-8535	tiny rotten turkish mostaccioli	1	crappy	
-8536	normal fancy narrow linguini of the sea	3	good	Effect: "Sinuses For Miles", Effect Duration: 25
+8535	rotten tiny turkish mostaccioli	1	crappy	
+8536	fancy normal narrow linguini of the sea	3	good	Effect: "Sinuses For Miles", Effect Duration: 25
 8537	unsweetened extra-chilled quantum Hersey&trade; SMOOCH	0		Effect: "The Moxie of LOV", Effect Duration: 27
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	skewed drug cocktail sauce	0		
-8542	bland snack-sized green huge Fettris	2	decent	
+8542	bland snack-sized huge green Fettris	2	decent	
 8543	adequate massive special shaking fusillocybin	10	good	Effect: "Egged On", Effect Duration: 20
-8544	snack-sized normal prescription noodles	2	good	
+8544	normal snack-sized prescription noodles	2	good	
 8545	pickled narrow cyan blood-drive sticker	1	EPIC	
 8546	tarnished alkaline anodized blinking bag of grain	0		Effect: "Heart of Orange", Effect Duration: 63
-8547	extra-nitrogenated aerosolized shaking fuchsia pocket maze	0		Effect: "Updated", Effect Duration: 52
+8547	extra-nitrogenated aerosolized fuchsia shaking pocket maze	0		Effect: "Updated", Effect Duration: 52
 8548	frozen boiled shady shades	0		Effect: "Baconstoned", Effect Duration: 59
 8549	liquefied red ghostly squeaky toy rose	0		Effect: "Mer-kinny Flavor", Effect Duration: 25
 8550	flavorless wobbly weird gazelle steak	3	decent	
@@ -8426,7 +8426,7 @@
 8553	aged emergency margarita	3	awesome	
 8554	practically non-alcoholic tolerable vintage smart drink	1	good	
 8555	jittery a ten-percent bonus	0		
-8556	twirling yellow Thwaitgold termite statuette	0		
+8556	yellow twirling Thwaitgold termite statuette	0		
 8557	pulsating The Emperor's new cookie	0		
 8558	adjusted non-enhanced Wickers bar	0		Effect: "Arse-a'fire", Effect Duration: 30
 8559	pressed enhanced bakelite-covered bacon	0		Effect: "Nas Tea", Effect Duration: 25
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	Tesla rock-hard Fonzie's barrel lid	0		Experience (Moxie): +1, Damage Reduction: 14, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-09"
 8566	greedy scandalous clever barrel hoop earring	0		Maximum MP: +20, Sleaze Damage: +5, Meat Drop: +20, Lasts Until Rollover, Last Available: "2015-09"
-8567	shaking aromatic toasty extremely unsafe bankruptcy barrel	0		Weapon Damage Percent: +100, Hot Damage: +5, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	shaking aromatic toasty extremely unsafe bankruptcy barrel	0		Weapon Damage Percent: +100, Hot Damage: +5, Stench Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8448,10 +8448,10 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	twirling mouldering barrel	0		Last Available: "2015-09"
 8577	jittery barnacled barrel	0		Last Available: "2015-09"
-8578	triple-distilled bad enchanted bottle of Amontillado	8	decent	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2015-09"
+8578	enchanted bad triple-distilled bottle of Amontillado	8	decent	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2015-09"
 8579	weak drinkable blinking barrel-aged martini	2	good	Last Available: "2015-09"
 8580	yummy barrel pickle	3	awesome	Last Available: "2015-09"
-8581	bland lime green mirror barrel cracker	3	decent	Last Available: "2015-09"
+8581	bland mirror lime green barrel cracker	3	decent	Last Available: "2015-09"
 8582	twisted skewed vibrating mushroom	1	good	Last Available: "2015-09"
 8583	powdered mirror mushroom	1	crappy	Effect: "Drunk With Power", Effect Duration: 50, Last Available: "2015-09"
 8584	beefcake's KoL Con 12-gauge	0		Muscle: +25, Last Available: "2015-09"
@@ -8474,7 +8474,7 @@
 8601	polymerized cuppa Flamibili tea	0		Effect: "Boon of She-Who-Was", Effect Duration: 53, Last Available: "2015-09"
 8602	frozen polarized mirror cuppa Yet tea	0		Effect: "Mayeaugh", Effect Duration: 62, Last Available: "2015-09"
 8603	galvanized cuppa Boo tea	0		Effect: "Super-Electrified", Effect Duration: 14, Last Available: "2015-09"
-8604	boiled shaking blinking cuppa Nas tea	0		Effect: "Gummi-Grin", Effect Duration: 45, Last Available: "2015-09"
+8604	boiled blinking shaking cuppa Nas tea	0		Effect: "Gummi-Grin", Effect Duration: 45, Last Available: "2015-09"
 8605	wet cuppa Improprie tea	0		Effect: "Smokin'", Effect Duration: 43, Last Available: "2015-09"
 8606	double-magnetized improved triple-nitrogenated cuppa Frost tea	0		Effect: "Spooky Jellied", Effect Duration: 32, Last Available: "2015-09"
 8607	quadruple-dry boiled alkaline cuppa Toast tea	0		Effect: "Bestial Sympathy", Effect Duration: 12, Last Available: "2015-09"
@@ -8490,12 +8490,12 @@
 8617	irradiated blue cuppa Dexteri tea	0		Effect: "Top Dog", Effect Duration: 12, Last Available: "2015-09"
 8618	oxidized cuppa Flexibili tea	0		Effect: "Cautious Prowl", Effect Duration: 67, Last Available: "2015-09"
 8619	extra-dry magnetized cuppa Impregnabili tea	0		Effect: "Chalked Weapon", Effect Duration: 58, Last Available: "2015-09"
-8620	quadruple-dry bouncing blinking jittery cuppa Obscuri tea	0		Effect: "Eyes Wide Propped", Effect Duration: 33, Last Available: "2015-09"
+8620	quadruple-dry blinking jittery bouncing cuppa Obscuri tea	0		Effect: "Eyes Wide Propped", Effect Duration: 33, Last Available: "2015-09"
 8621	deionized cuppa Irritabili tea	0		Effect: "Hangdog", Effect Duration: 60, Last Available: "2015-09"
-8622	chilled shaking skewed maroon cuppa Mediocri tea	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 19, Last Available: "2015-09"
+8622	chilled maroon skewed shaking cuppa Mediocri tea	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 19, Last Available: "2015-09"
 8623	improved super-aerosolized cuppa Loyal tea	0		Effect: "Swimming Head", Effect Duration: 33, Last Available: "2015-09"
 8624	compressed shaking cuppa Activi tea	1	decent	Effect: "Big", Effect Duration: 5, Last Available: "2015-09"
-8625	diluted gray wobbly cuppa Cruel tea	1		Last Available: "2015-09"
+8625	diluted wobbly gray cuppa Cruel tea	1		Last Available: "2015-09"
 8626	irradiated dry bouncing cuppa Alacri tea	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 65, Last Available: "2015-09"
 8627	corrupted ionized nitrogenated twirling cuppa Vitali tea	0		Effect: "Haunted Liver", Effect Duration: 43, Last Available: "2015-09"
 8628	quantum tarnished yellow cuppa Mana tea	0		Effect: "Berry Experiential", Effect Duration: 23, Last Available: "2015-09"
@@ -8513,10 +8513,10 @@
 8640	blinking Ghost Dog Chow	0		Last Available: "2015-10"
 8641	normal big bowl of eyeballs	5	good	Last Available: "2015-10"
 8642	rotten lime green bowl of mummy guts	3	crappy	Last Available: "2015-10"
-8643	flavorless jumbo spinning bowl of maggots	5	decent	Last Available: "2015-10"
+8643	jumbo flavorless spinning bowl of maggots	5	decent	Last Available: "2015-10"
 8644	lousy blood and blood	3	decent	Last Available: "2015-10"
 8645	bad Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
-8646	artisanal weak zombie	2	EPIC	Last Available: "2015-10"
+8646	weak artisanal zombie	2	EPIC	Last Available: "2015-10"
 8647	jittery Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	pulsating plastic nightmare troll	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	shaking ear poison	0		
 8653	stink-penny	0		
 8654	flame-retardant Da Vinci's hawk of the brazier	0		Experience (Mysticality): +5, Hot Spell Damage: +25, Hot Resistance: +1
-8655	miniature stale hamlet sandwich	2	decent	
+8655	stale miniature hamlet sandwich	2	decent	
 8656	pulsating brainy Othello's military jacket	0		Mysticality: +5
 8657	fuchsia steel-toed Othello's dagger	0		Damage Reduction: 9, Single Equip
 8658	mirror perfumed Othello's handkerchief	0		Stench Resistance: +5, Single Equip
@@ -8546,9 +8546,9 @@
 8673	lime green Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	red airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	squat one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	pickled squat purple shoulder-warming lotion	0		Effect: "Salsa Satanica", Effect Duration: 31, Last Available: "2015-11"
+8676	pickled purple squat shoulder-warming lotion	0		Effect: "Salsa Satanica", Effect Duration: 31, Last Available: "2015-11"
 8677	miniature flavorless ghostly iceberg lettuce	2	decent	Last Available: "2015-11"
-8678	bad strong ice wine	5	decent	Last Available: "2015-11"
+8678	strong bad ice wine	5	decent	Last Available: "2015-11"
 8679	skewed cyan dog trainer's mansplainer's ruddy Wal-Mart snowglobe	0		Maximum HP Percent: +40, Monster Level: +15, Experience (familiar): +1, Last Available: "2015-11"
 8680	prompt zippy groovy Wal-Mart nametag	0		Moxie Percent: +10, Initiative: +20, Adventures: +3, Last Available: "2015-11"
 8681	twirling nippy brainy Wal-Mart overalls of the sewer	0		Mysticality: +5, Cold Damage: +10, Stench Damage: +25, Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	extremely unsafe bellhop's hat	0		Weapon Damage Percent: +100, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	perfectly mixed practically non-alcoholic narrow ice porter	1	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	extremely unsafe bellhop's hat	0		Weapon Damage Percent: +100, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	practically non-alcoholic perfectly mixed narrow ice porter	1	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	adjusted alkaline exotic travel brochure	0		Effect: "Rushtacean'", Effect Duration: 41, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	pickled super-liquefied mirror shampoo-conditioner	0		Effect: "Loco Motives", Effect Duration: 23, Last Available: "2015-11"
@@ -8568,10 +8568,10 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	pickled blurry medicinal herbs	1		Last Available: "2016-01"
 8697	flavorless wobbly ice rice	4	decent	Last Available: "2016-01"
-8698	watered-down hand-crafted iced plum wine	2	EPIC	Last Available: "2016-01"
+8698	hand-crafted watered-down iced plum wine	2	EPIC	Last Available: "2016-01"
 8699	curative ruddy training belt of the blizzard	0		Maximum HP Percent: +40, Cold Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2016-01"
 8700	curative hardy wizardly training legwarmers	0		Mysticality: +25, Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2016-01"
-8701	purple supercool training helmet of James Dean of the empath	0		Moxie Percent: +20, Experience (Moxie): +3, Familiar Weight: +5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	purple supercool training helmet of James Dean of the empath	0		Moxie Percent: +20, Experience (Moxie): +3, Familiar Weight: +5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	ghostly gray training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8586,12 +8586,12 @@
 8713	modified fuchsia abstraction: perception	1		Last Available: "2015-12"
 8714	twisted jittery abstraction: motion	1		Last Available: "2015-12"
 8715	diluted bouncing abstraction: joy	1		Last Available: "2015-12"
-8716	pickled skewed wobbly abstraction: certainty	1		Last Available: "2015-12"
+8716	pickled wobbly skewed abstraction: certainty	1		Last Available: "2015-12"
 8717	mixed abstraction: comprehension	1		Effect: "Video Game Hot Dog", Effect Duration: 10, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	miniature decent jittery VYKEA meatballs	2	good	Last Available: "2015-11"
-8720	perfectly mixed fancy tumbling VYKEA mead	3	EPIC	Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2015-11"
-8721	galvanized mirror spinning upside-down VYKEA woadpaint	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 41, Last Available: "2015-11"
+8719	decent miniature jittery VYKEA meatballs	2	good	Last Available: "2015-11"
+8720	fancy perfectly mixed tumbling VYKEA mead	3	EPIC	Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2015-11"
+8721	galvanized upside-down mirror spinning VYKEA woadpaint	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 41, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	skewed VYKEA blood rune	0		Last Available: "2015-11"
 8724	tumbling VYKEA lightning rune	0		Last Available: "2015-11"
@@ -8605,17 +8605,17 @@
 8732	drinkable bottle of norwhiskey	4	good	Last Available: "2015-11"
 8733	dried pulsating octolus oculus	1	good	Effect: "Human-Human Hybrid", Effect Duration: 10, Last Available: "2015-11"
 8734	skewed cyan flame-retardant Socratic cool sardine can key	0		Moxie: +5, Experience (Mysticality): +1, Hot Resistance: +1, Last Available: "2015-11"
-8735	chilly therapeutic Samson's norwhal helmet	0		Experience (Muscle): +5, Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-11", Familiar Effect: "atk"
+8735	chilly therapeutic Samson's norwhal helmet	0		Experience (Muscle): +5, Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk", Last Available: "2015-11"
 8736	blurry lion tamer's razor-sharp octolus-skin cloak of Calamity Jane	0		Weapon Damage Percent: +25, Critical Hit Percent: +15, Experience (familiar): +2, Last Available: "2015-11"
 8737	boozy tolerable perfect cosmopolitan	5	good	Last Available: "2015-11"
 8738	tolerable spirit-forward shaking perfect negroni	5	good	Last Available: "2015-11"
-8739	high-proof smooth perfect dark and stormy	10	awesome	Last Available: "2015-11"
-8740	special bad squat perfect mimosa	4	decent	Effect: "Deadly Lampblade", Effect Duration: 35, Last Available: "2015-11"
+8739	smooth high-proof perfect dark and stormy	10	awesome	Last Available: "2015-11"
+8740	bad special squat perfect mimosa	4	decent	Effect: "Deadly Lampblade", Effect Duration: 35, Last Available: "2015-11"
 8741	aged weak blurry perfect old-fashioned	2	awesome	Last Available: "2015-11"
-8742	acceptable enchanted skewed fuchsia bouncing perfect paloma	3	good	Effect: "Bestial Sympathy", Effect Duration: 20, Last Available: "2015-11"
+8742	acceptable enchanted bouncing skewed fuchsia perfect paloma	3	good	Effect: "Bestial Sympathy", Effect Duration: 20, Last Available: "2015-11"
 8743	moist tumbling That 70s Cologne	0		Effect: "Updated", Effect Duration: 40, Last Available: "2015-11"
 8744	triple-alkaline lime green Wal-Mart &quot;diamond&quot; ring	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 28, Last Available: "2015-11"
-8745	extra-quantum skewed blinking Puffstone cigar	0		Effect: "Dirty Pear", Effect Duration: 45, Last Available: "2015-11"
+8745	extra-quantum blinking skewed Puffstone cigar	0		Effect: "Dirty Pear", Effect Duration: 45, Last Available: "2015-11"
 8746	non-aerosolized quantum olive Conspiracy&trade; mascara	0		Effect: "You Drank Fish Wine", Effect Duration: 23, Last Available: "2015-11"
 8747	moist Spring Break Beach &quot;swimsuit&quot;	0		Effect: "The Solution", Effect Duration: 13, Last Available: "2015-11"
 8748	ghostly airplane tattoo	0		Last Available: "2015-11"
@@ -8623,9 +8623,9 @@
 8750	super-Vulcanized galvanized hemp candy necklace	0		Effect: "Sugar High", Effect Duration: 54, Last Available: "2015-12"
 8751	enhanced anodized huge communal gobstopper	0		Effect: "Browbeaten", Effect Duration: 16, Last Available: "2015-12"
 8752	flavorless huge Crimbo salad	10	decent	Last Available: "2015-12"
-8753	delicious small bread line	2	awesome	Last Available: "2015-12"
+8753	small delicious bread line	2	awesome	Last Available: "2015-12"
 8754	weak enchanted perfectly mixed bark rootbeer	2	EPIC	Effect: "Nature's Bounty", Effect Duration: 5, Last Available: "2015-12"
-8755	practically non-alcoholic tolerable ale	1	good	Last Available: "2015-12"
+8755	tolerable practically non-alcoholic ale	1	good	Last Available: "2015-12"
 8756	blurry toasty plastic Tammy the Tambourine Elf	0		Hot Damage: +5, Last Available: "2015-12"
 8757	healthy plastic Rudolph the Red	0		Maximum HP Percent: +20, Last Available: "2015-12"
 8758	banded plastic Gaia'ajh-dsli Ak'lwej	0		Damage Absorption: +100, Last Available: "2015-12"
@@ -8653,8 +8653,8 @@
 8781	deadly pine cone necklace	0		Weapon Damage: +5, Last Available: "2015-12"
 8782	huge smartaleck's reindeer hammer	0		Moxie Percent: +30, Last Available: "2015-12"
 8783	Tesla elf ploughshare	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
-8784	pulsating tumbling circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8784	tumbling pulsating circle drum	0		Last Available: "2015-12"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	jittery faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8690,14 +8690,14 @@
 8818	delicious wobbly Miss Graves' vermouth	3	awesome	Last Available: "2016-12"
 8819	tasty red The Plumber's mushroom stew	4	awesome	Last Available: "2016-12"
 8820	dehydrated twirling The Author's ink	1		Last Available: "2016-02"
-8821	lousy spirit-forward The Mad Liquor	5	decent	Last Available: "2016-12"
-8822	enchanted bad weak teal Doc Clock's thyme cocktail	2	decent	Effect: "Slime Time", Effect Duration: 30, Last Available: "2016-12"
+8821	spirit-forward lousy The Mad Liquor	5	decent	Last Available: "2016-12"
+8822	bad weak enchanted teal Doc Clock's thyme cocktail	2	decent	Effect: "Slime Time", Effect Duration: 30, Last Available: "2016-12"
 8823	spoiled diet Mr. Burnsger	1	crappy	Last Available: "2016-12"
 8824	diluted The Inquisitor's unidentifiable object	1		Effect: "Rad-ish", Effect Duration: 10, Last Available: "2016-12"
 8825	toasty mansplainer's curative The Jokester's gun	0		Monster Level: +15, Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	wobbly asbestos-lined careful smooth The Jokester's wig	0		Moxie: +15, Monster Level: -10, Hot Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8826	wobbly asbestos-lined careful smooth The Jokester's wig	0		Moxie: +15, Monster Level: -10, Hot Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
 8827	up-at-dawn reassuring studded The Jokester's pants	0		Damage Absorption: +80, Spooky Resistance: +1, Adventures: +5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
-8828	improved non-polarized jittery purple Jokester makeup	0		Effect: "French Bronilla Brogueishness", Effect Duration: 11, Last Available: "2016-12"
+8828	improved non-polarized purple jittery Jokester makeup	0		Effect: "French Bronilla Brogueishness", Effect Duration: 11, Last Available: "2016-12"
 8829	twirling replica bat-oomerang	0		Last Available: "2016-12"
 8830	cyan battoo kit	0		Last Available: "2016-12"
 8831	pulsating basking robin	0		Free Pull, Last Available: "2016-12"
@@ -8752,20 +8752,20 @@
 8880	spoiled plate of Frigid Northern Beans	3	crappy	Last Available: "2016-02"
 8881	stale diet plate of World's Blackest-Eyed Peas	1	decent	Last Available: "2016-02"
 8882	adequate plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
-8883	moldy low-calorie plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	crappy	Last Available: "2016-02"
+8883	low-calorie moldy plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	crappy	Last Available: "2016-02"
 8884	bland plate of Val-U Brand Every Bean Salad	4	decent	Last Available: "2016-02"
 8885	flavorless plate of Shrub's Premium Baked Beans	4	decent	Last Available: "2016-02"
 8886	skewed executive Fancy Jeff's pocket square of wisdom	0		Mysticality: +15, Meat Drop: +40, Last Available: "2016-02"
-8887	upside-down zippy extremely unsafe Daisy's unclean bloomers of the sewer	0		Weapon Damage Percent: +100, Stench Damage: +25, Initiative: +20, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	upside-down zippy extremely unsafe Daisy's unclean bloomers of the sewer	0		Weapon Damage Percent: +100, Stench Damage: +25, Initiative: +20, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	blue Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	aromatic wicked Amoon-Ra Cowtep's nemes of the wise owl	0		Mysticality: +20, Spell Damage: +5, Stench Resistance: +1, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
-8890	upside-down fuchsia Glenn's dice	0		Last Available: "2016-02"
+8889	aromatic wicked Amoon-Ra Cowtep's nemes of the wise owl	0		Mysticality: +20, Spell Damage: +5, Stench Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8890	fuchsia upside-down Glenn's dice	0		Last Available: "2016-02"
 8891	pulsating sizzling Van der Graaf slick strapping Former Sheriff Dan's tin star of the brazier	0		Muscle: +5, Moxie: +10, Hot Damage: +10, Hot Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
 8893	cyan Clara's bell	0		Last Available: "2016-02"
 8894	forbidden Granny Hackleton's Gatling gun of wisdom of James Dean	0		Mysticality: +15, Experience (Moxie): +3, Spell Damage Percent: +50, Last Available: "2016-02"
 8895	narrow buffalo dime	0		Last Available: "2016-02"
-8896	bouncing narrow cow poker	0		Last Available: "2016-02"
+8896	narrow bouncing cow poker	0		Last Available: "2016-02"
 8897	concentrated shaking poker face paint	0		Effect: "Salad Days", Effect Duration: 12, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	good	Last Available: "2016-02"
@@ -8773,14 +8773,14 @@
 8901	chilled triggerfingerbone	0		Effect: "Fishily Speeding", Effect Duration: 17, Last Available: "2016-02"
 8902	alkaline galvanized ghost bit	0		Effect: "Bestial Sympathy", Effect Duration: 61, Last Available: "2016-02"
 8903	pickled shaking teal buzzard feather	0		Effect: "Wintergreen Warmongery", Effect Duration: 28, Last Available: "2016-02"
-8904	wet dry cyan spinning lion musk	0		Effect: "Human-Slime Hybrid", Effect Duration: 69, Last Available: "2016-02"
+8904	wet dry spinning cyan lion musk	0		Effect: "Human-Slime Hybrid", Effect Duration: 69, Last Available: "2016-02"
 8905	decent bear claw	4	good	Last Available: "2016-02"
 8906	altered quadruple-polarized narrow rattler gland	0		Effect: "Pyromania", Effect Duration: 20, Last Available: "2016-02"
 8907	vacuum-sealed double-dry half-digested coal	0		Effect: "Patience of the Tortoise", Effect Duration: 21, Last Available: "2016-02"
 8908	corrupted super-ionized maroon tightly-wound spine	0		Effect: "Punchy, Murdery", Effect Duration: 29, Last Available: "2016-02"
-8909	flavorless special massive rotting beefsteak	8	decent	Effect: "Healthy Green Glow", Effect Duration: 30, Last Available: "2016-02"
+8909	flavorless massive special rotting beefsteak	8	decent	Effect: "Healthy Green Glow", Effect Duration: 30, Last Available: "2016-02"
 8910	tolerable firemilk	4	good	Last Available: "2016-02"
-8911	electrified red squat spidercow eye-cluster	0		Effect: "Tingly Biceps", Effect Duration: 28, Last Available: "2016-02"
+8911	electrified squat red spidercow eye-cluster	0		Effect: "Tingly Biceps", Effect Duration: 28, Last Available: "2016-02"
 8912	compressed moomy dust	1		Last Available: "2016-02"
 8913	Newton's educational western-style skinning knife	0		Experience: +1, Experience (Mysticality): +3, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
@@ -8793,8 +8793,8 @@
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	blue Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	fuchsia disc (white)	0		
-8924	jittery yellow disc (black)	0		
-8925	mirror teal disc (red)	0		
+8924	yellow jittery disc (black)	0		
+8925	teal mirror disc (red)	0		
 8926	pulsating mirror disc (green)	0		
 8927	blinking disc (blue)	0		
 8928	blinking disc (yellow)	0		
@@ -8814,7 +8814,7 @@
 8942	blurry rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
 8944	rhinestone cowhorn	0		Familiar Weight: +5
-8945	pulsating narrow narrow cow skull	0		Last Available: "2016-02"
+8945	narrow pulsating narrow cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
@@ -8850,7 +8850,7 @@
 8978	super-energized diffused squat patent aggression tonic	0		Effect: "Fudgehound", Effect Duration: 38
 8979	non-vacuum-sealed dry quadruple-galvanized yellow patent sallowness tonic	0		Effect: "Ass Over Teakettle", Effect Duration: 64
 8980	corrupted skewed patent avarice tonic	0		Effect: "One Foot Heavier", Effect Duration: 13
-8981	concentrated squat yellow patent alacrity tonic	0		Effect: "Fangs and Pangs", Effect Duration: 16
+8981	concentrated yellow squat patent alacrity tonic	0		Effect: "Fangs and Pangs", Effect Duration: 16
 8982	tarnished denatured ghostly corrupted marrow	0		Effect: "Pwnd", Effect Duration: 29
 8983	hand-crafted rodeo whiskey	4	EPIC	
 8984	Thwaitgold scorpion statuette	0		
@@ -8862,17 +8862,17 @@
 8990	blurry electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	denatured armored prawn	1		Last Available: "2016-03"
-8993	toothsome low-calorie upside-down blinking jumping horseradish	1	awesome	Last Available: "2016-03"
+8993	low-calorie toothsome upside-down blinking jumping horseradish	1	awesome	Last Available: "2016-03"
 8994	hand-crafted Sacramento wine	4	EPIC	Last Available: "2016-03"
 8995	concentrated blurry maroon Greek fire	0		Effect: "Ponderous Potency", Effect Duration: 19, Last Available: "2016-03"
 8996	cyan prompt frosty Lo Pan's Tesla forbidden ox-head shield	0		Spell Damage Percent: +50, Spell Critical Percent: +30, Cold Spell Damage: +10, Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	squat hale veiny forbidden beefy dented scepter of Flo-Jo	0		Muscle: +10, Spell Damage Percent: +50, Maximum HP: 30, Initiative: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	coward's Fonzie's groovy sage very pointy crown of Tarzan	0		Mysticality Percent: +10, Moxie Percent: +10, Experience (Muscle): +3, Experience (Moxie): +1, Monster Level: -20, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	coward's Fonzie's groovy sage very pointy crown of Tarzan	0		Mysticality Percent: +10, Moxie Percent: +10, Experience (Muscle): +3, Experience (Moxie): +1, Monster Level: -20, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	wool Herculean thinker's battle broom of terror of the sweet-tooth	0		Mysticality: +10, Experience (Muscle): +1, Spooky Spell Damage: +10, Cold Resistance: +1, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-9000	lime green bouncing Clan Floundry	0		Free Pull, Last Available: "2016-04"
+9000	bouncing lime green Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	Usain Bolt's nippy Newton's beefcake's carpe	0		Muscle: +25, Experience (Mysticality): +3, Cold Damage: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04"
 9002	crafty grievous strapping codpiece of dire peril	0		Muscle: +5, Weapon Damage: +20, Weapon Damage Percent: +50, Maximum MP: +10, Lasts Until Rollover, Last Available: "2016-04"
-9003	quilted Sinatra's savvy troutsers of the blizzard	0		Mysticality Percent: +20, Experience (Moxie): +5, Damage Absorption: +40, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	quilted Sinatra's savvy troutsers of the blizzard	0		Mysticality Percent: +20, Experience (Moxie): +5, Damage Absorption: +40, Cold Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	up-at-dawn knitted resourceful arcane researcher's bass clarinet	0		Experience Percent (Mysticality): +10, Maximum MP: +50, Cold Resistance: +3, Adventures: +5, Lasts Until Rollover, Last Available: "2016-04"
 9005	skewed aromatic clever crafty fish hatchet of the cougar	0		Moxie: +20, Maximum MP: 30, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9006	family-friendly stanky chaotic tunac of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +10, Stench Spell Damage: +25, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
@@ -8893,7 +8893,7 @@
 9021	moldy purple gallon of milk	4	crappy	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
-9024	squat teal daily dungeon malware	0		Last Available: "2016-05"
+9024	teal squat daily dungeon malware	0		Last Available: "2016-05"
 9025	cyan infinite BACON machine	0		Last Available: "2016-05"
 9026	purple First Post shirt package	0		Last Available: "2016-05"
 9027	skewed rosewater-soaked Annie Oakley's First Post shirt - Cir Senam of the businessman	0		Critical Hit Percent: +20, Stench Resistance: +3, Meat Drop: +50, Last Available: "2016-05"
@@ -8922,11 +8922,11 @@
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	huge Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	spinning Source terminal file: damage.enh	0		Last Available: "2016-06"
-9053	maroon narrow Source terminal file: critical.enh	0		Last Available: "2016-06"
+9053	narrow maroon Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	upside-down Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	upside-down Source terminal file: compress.edu	0		Last Available: "2016-06"
-9057	fuchsia upside-down Source terminal file: duplicate.edu	0		Last Available: "2016-06"
+9057	upside-down fuchsia Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	skewed Source terminal file: familiar.ext	0		Last Available: "2016-06"
@@ -8948,7 +8948,7 @@
 9076	frightening noir fedora of the empath of mayonnaise	0		Familiar Weight: +5, Spooky Damage: +5, Sleaze Spell Damage: +50, Last Available: "2016-07"
 9077	shellacked banded sage trench coat	0		Mysticality Percent: +10, Damage Absorption: +100, Damage Reduction: 7, Last Available: "2016-07"
 9078	perfectly mixed Falcon&trade; Maltese Liquor	3	EPIC	Last Available: "2016-07"
-9079	fancy normal hardboiled egg	3	good	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 40, Last Available: "2016-07"
+9079	normal fancy hardboiled egg	3	good	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 40, Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	squat DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	Sherlock's smelly ruddy Samson's strapping protonic accelerator pack of terror	0		Muscle: +5, Experience (Muscle): +5, Maximum HP Percent: +40, Stench Spell Damage: +10, Spooky Spell Damage: +10, Item Drop: +25, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	skewed beefy Mr. Screege's spectacles	0		Muscle: +10, Single Equip, Last Available: "2016-08"
 9092	twirling fireproof smelly stylish Spookyraven signet	0		Moxie: +25, Stench Spell Damage: +10, Hot Resistance: +3, Single Equip, Last Available: "2016-08"
 9093	executive stanky tie-dyed fannypack	0		Stench Spell Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2016-08"
-9094	olive Usain Bolt's banded burnt snowpants	0		Damage Absorption: +100, Initiative: +80, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9094	olive Usain Bolt's banded burnt snowpants	0		Damage Absorption: +100, Initiative: +80, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
 9095	Herculean standards and practices guide	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	Sherlock's foul-smelling fortified Carpathian longsword	0		Damage Absorption: +60, Stench Damage: +10, Item Drop: +25, Last Available: "2016-08"
 9097	jittery jittery Jeselnik's manspreader's Liam's mail of wisdom	0		Mysticality: +15, Monster Level: +10, Sleaze Damage: +25, Last Available: "2016-08"
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	cyan blinking studded repaid diaper	0		Damage Absorption: +80
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	special bad skewed Shot of Kardashian Gin	3	decent	Effect: "Fustulent", Effect Duration: 45, Last Available: "2016-09"
+9119	bad special skewed Shot of Kardashian Gin	3	decent	Effect: "Fustulent", Effect Duration: 45, Last Available: "2016-09"
 9120	Jeselnik's Unstable Pointy Ears	0		Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	crappy	Last Available: "2016-09"
@@ -9007,22 +9007,22 @@
 9135	special aged very whiskey	4	awesome	Effect: "Hobonic", Effect Duration: 5
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	blinking pulsating bouncing li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	fuchsia li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	squat upside-down li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	pulsating li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	spinning li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	bouncing pulsating blinking li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	fuchsia li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	squat upside-down li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	pulsating li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	spinning li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	Vulcanized hoarded candy wad	0		Effect: "Dreadful Sheen", Effect Duration: 31, Last Available: "2016-10"
 9147	flattened deionized green Prunets	0		Effect: "Going Ape", Effect Duration: 15
 9148	Twitching Television Tattoo	0		
-9149	maroon blinking twirling baby scorpion	0		Familiar Weight: +10
+9149	maroon twirling blinking baby scorpion	0		Familiar Weight: +10
 9150	pickled altered invisible string	0		Lasts Until Rollover, Effect: "Extra-Thick Blood", Effect Duration: 34, Last Available: "2016-10"
 9151	concentrated mirror invisible seam ripper	0		Lasts Until Rollover, Effect: "Magically Fingered", Effect Duration: 16, Last Available: "2016-10"
-9152	pulsating li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9153	spoiled twirling bouncing raw sweet potato	4	crappy	Last Available: "2016-11"
+9152	pulsating li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9153	spoiled bouncing twirling raw sweet potato	4	crappy	Last Available: "2016-11"
 9154	bland raw beans	3	decent	Last Available: "2016-11"
 9155	moldy raw stuffing	3	crappy	Last Available: "2016-11"
 9156	normal raw cranberry sauce	3	good	Last Available: "2016-11"
@@ -9030,7 +9030,7 @@
 9158	rotten purple raw mincemeat	4	crappy	Last Available: "2016-11"
 9159	fancy immense rotten ghostly raw potato	7	crappy	Effect: "Stenchtastic", Effect Duration: 5, Last Available: "2016-11"
 9160	flavorless raw gravy	3	decent	Last Available: "2016-11"
-9161	moldy small upside-down raw bread	2	crappy	Last Available: "2016-11"
+9161	small moldy upside-down raw bread	2	crappy	Last Available: "2016-11"
 9162	studded mini-marshmallow dispenser of incineration	0		Damage Absorption: +80, Hot Spell Damage: +50, Last Available: "2016-11"
 9163	double-paned Annie Oakley's glass casserole dish of the businessman	0		Critical Hit Percent: +20, Cold Resistance: +5, Meat Drop: +50, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9045,16 +9045,16 @@
 9173	spoiled baked stuffing	3	crappy	Last Available: "2016-11"
 9174	spoiled cranberry cylinder	3	crappy	Last Available: "2016-11"
 9175	tasty thanksgiving turkey	3	awesome	Last Available: "2016-11"
-9176	gigantic stale upside-down mince pie	6	decent	Last Available: "2016-11"
-9177	normal spinning shaking mashed potatoes	4	good	Last Available: "2016-11"
-9178	special stale bouncing warm gravy	3	decent	Effect: "Pygmy Drinking Buddy", Effect Duration: 15, Last Available: "2016-11"
+9176	stale gigantic upside-down mince pie	6	decent	Last Available: "2016-11"
+9177	normal shaking spinning mashed potatoes	4	good	Last Available: "2016-11"
+9178	stale special bouncing warm gravy	3	decent	Effect: "Pygmy Drinking Buddy", Effect Duration: 15, Last Available: "2016-11"
 9179	stale skewed bread roll	3	decent	Last Available: "2016-11"
 9180	flavorless leftovers	3	decent	Last Available: "2016-11"
 9181	moldy leftovers sandwich	4	crappy	Last Available: "2016-11"
 9182	narrow Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
-9185	green blinking pilgrim hat	0		Last Available: "2016-11"
+9185	blinking green pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	blurry sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	moldy fancy red spinning animal part cracker	3	crappy	Effect: "Turtle Power", Effect Duration: 15, Last Available: "2016-12"
+9219	fancy moldy spinning red animal part cracker	3	crappy	Effect: "Turtle Power", Effect Duration: 15, Last Available: "2016-12"
 9220	mediocre weak gingerbread wine	2	decent	Last Available: "2016-12"
 9221	adequate gingerbread mug	3	good	Last Available: "2016-12"
 9222	auspicious gingerbread mask	0		Item Drop: +10, Last Available: "2016-12"
@@ -9104,9 +9104,9 @@
 9232	squat shaking wool candy screwdriver of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +1, Last Available: "2016-12"
 9233	blinking gingerbread dog treat	0		Last Available: "2016-12"
 9234	shaking knitted pumpkin spice candle	0		Cold Resistance: +3, Lasts Until Rollover, Last Available: "2016-12"
-9235	altered upside-down fuchsia gingerbread spice latte	0		Effect: "You're Rubber", Effect Duration: 37, Last Available: "2016-12"
+9235	altered fuchsia upside-down gingerbread spice latte	0		Effect: "You're Rubber", Effect Duration: 37, Last Available: "2016-12"
 9236	twirling avaricious smooth gingerbread gavel	0		Moxie: +15, Meat Drop: +30, Last Available: "2016-12"
-9237	jittery teal gingerbread cigarette	0		Last Available: "2016-12"
+9237	teal jittery gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	artisanal weak wobbly ginger beer	2	EPIC	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
@@ -9124,7 +9124,7 @@
 9252	bland fuchsia spiritual candy cane	4	decent	Last Available: "2016-12"
 9253	lousy weak spiritual eggnog	2	decent	Last Available: "2016-12"
 9254	jumbo stale spiritual fruitcake	5	decent	Last Available: "2016-12"
-9255	tiny stale pulsating spiritual gingerbread	1	decent	Last Available: "2016-12"
+9255	stale tiny pulsating spiritual gingerbread	1	decent	Last Available: "2016-12"
 9256	spinning chocolate puppy	0		Last Available: "2016-12"
 9257	upside-down chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,7 +9144,7 @@
 9272	tumbling negative lump	0		
 9273	narrow family-friendly weightlifter's Third Eye	0		Muscle: +15, Sleaze Resistance: +1, Last Available: "2016-12"
 9274	scandalous beefcake's Krampus Horn	0		Muscle: +25, Sleaze Damage: +5, Single Equip, Last Available: "2016-12"
-9275	moldy diet jittery hambrosier	1	crappy	Last Available: "2016-12"
+9275	diet moldy jittery hambrosier	1	crappy	Last Available: "2016-12"
 9276	artisanal gray chakra-mental wine	4	EPIC	Last Available: "2016-12"
 9277	cold-filtered blinking chakra malt	0		Effect: "Weapon of Mass Destruction", Effect Duration: 27, Last Available: "2016-12"
 9278	normal Black Angus blackburger	3	good	Last Available: "2016-12"
@@ -9161,16 +9161,16 @@
 9289	supercharged extremely unsafe Herculean Uncle Crimbo's hat	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Maximum MP Percent: +30, Last Available: "2016-12"
 9290	spoiled jumbo Eldritch snap	5	crappy	Last Available: "2017-01"
 9291	dried skewed hot jelly	1		Last Available: "2017-01"
-9292	modified green ghostly jelly	1		Effect: "Hella Tough", Effect Duration: 40, Last Available: "2017-01"
+9292	modified ghostly green jelly	1		Effect: "Hella Tough", Effect Duration: 40, Last Available: "2017-01"
 9293	denatured spinning jelly	1		Last Available: "2017-01"
-9294	powdered pulsating gray sleaze jelly	1		Effect: "Oiled Skin", Effect Duration: 25, Last Available: "2017-01"
+9294	powdered gray pulsating sleaze jelly	1		Effect: "Oiled Skin", Effect Duration: 25, Last Available: "2017-01"
 9295	vaporized wobbly stench jelly	1		Effect: "Amorous Avarice", Effect Duration: 5, Last Available: "2017-01"
-9296	upside-down huge space planula	0		Free Pull, Last Available: "2017-01"
+9296	huge upside-down space planula	0		Free Pull, Last Available: "2017-01"
 9297	half-sized yummy toast with hot jelly	2	awesome	Last Available: "2017-01"
 9298	toothsome toast with jelly	3	awesome	Last Available: "2017-01"
-9299	half-sized adequate toast with jelly	2	good	Last Available: "2017-01"
+9299	adequate half-sized toast with jelly	2	good	Last Available: "2017-01"
 9300	decent toast with sleaze jelly	3	good	Last Available: "2017-01"
-9301	fancy stale toast with stench jelly	4	decent	Effect: "Three Days Slow", Effect Duration: 10, Last Available: "2017-01"
+9301	stale fancy toast with stench jelly	4	decent	Effect: "Three Days Slow", Effect Duration: 10, Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	blinking hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9180,12 +9180,12 @@
 9308	huge clever wax face of the cougar	0		Moxie: +20, Maximum MP: +20, Last Available: "2017-01"
 9309	acceptable watered-down wax booze	2	good	Last Available: "2017-01"
 9310	blinking glob of melted wax	0		Last Available: "2017-01"
-9311	dried blurry ghostly blue sea jelly	1		Last Available: "2017-01"
+9311	dried ghostly blue blurry sea jelly	1		Last Available: "2017-01"
 9312	bland sea truffle	3	decent	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	purple recovered cufflinks of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2017-01"
-9316	tumbling blinking heart-shaped crate	0		Free Pull, Last Available: "2017-02"
+9316	blinking tumbling heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	dry skewed squat LOV Elixir #3	0		Effect: "Dancing Prowess", Effect Duration: 67, Last Available: "2017-02"
 9318	dry LOV Elixir #6	0		Effect: "Stinkybeard", Effect Duration: 23, Last Available: "2017-02"
 9319	polymerized LOV Elixir #9	0		Effect: "Super-Electrified", Effect Duration: 38, Last Available: "2017-02"
@@ -9214,7 +9214,7 @@
 9342	Diamond HP-35 Calculator	0		
 9343	bottlecap	0		
 9344	discarded button	0		
-9345	yellow spinning Gummi-Memory	0		
+9345	spinning yellow Gummi-Memory	0		
 9346	purple Thwaitgold amoeba statuette	0		
 9347	pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
@@ -9235,38 +9235,38 @@
 9363	slime shooter	0		Last Available: "2017-03"
 9364	pulsating imaginary lemon	0		Last Available: "2017-03"
 9365	lousy literal grasshopper	3	decent	Last Available: "2017-03"
-9366	boozy mediocre wobbly double entendre	5	decent	Last Available: "2017-03"
+9366	mediocre boozy wobbly double entendre	5	decent	Last Available: "2017-03"
 9367	drinkable Phlegethon	3	good	Last Available: "2017-03"
 9368	artisanal jittery ghostly Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	bad mentholated wine	3	decent	Last Available: "2017-03"
 9370	mediocre jittery low tide martini	4	decent	Last Available: "2017-03"
 9371	mediocre cyan shroomtini	4	decent	Last Available: "2017-03"
-9372	weak perfectly mixed blinking pulsating morning dew	2	EPIC	Last Available: "2017-03"
-9373	watered-down delicious whiskey squeeze	2	awesome	Last Available: "2017-03"
+9372	perfectly mixed weak blinking pulsating morning dew	2	EPIC	Last Available: "2017-03"
+9373	delicious watered-down whiskey squeeze	2	awesome	Last Available: "2017-03"
 9374	perfectly mixed bouncing great fashioned	3	EPIC	Last Available: "2017-03"
 9375	spirit-forward acceptable Gnomish sagngria	5	good	Last Available: "2017-03"
-9376	watered-down perfectly mixed vodka stinger	2	EPIC	Last Available: "2017-03"
+9376	perfectly mixed watered-down vodka stinger	2	EPIC	Last Available: "2017-03"
 9377	tolerable extremely slippery nipple	3	good	Last Available: "2017-03"
 9378	tolerable piscatini	4	good	Last Available: "2017-03"
 9379	lousy Churchill	4	decent	Last Available: "2017-03"
-9380	weak mediocre soilzerac	2	decent	Last Available: "2017-03"
+9380	mediocre weak soilzerac	2	decent	Last Available: "2017-03"
 9381	bad bouncing London frog	3	decent	Last Available: "2017-03"
 9382	tolerable nothingtini	3	good	Last Available: "2017-03"
 9383	lousy eighth plague	3	decent	Last Available: "2017-03"
 9384	artisanal bouncing single entendre	4	EPIC	Last Available: "2017-03"
-9385	weak acceptable gray upside-down reverse Tantalus	2	good	Last Available: "2017-03"
+9385	weak acceptable upside-down gray reverse Tantalus	2	good	Last Available: "2017-03"
 9386	delicious elemental caipiroska	3	awesome	Last Available: "2017-03"
 9387	perfectly mixed Feliz Navidad	3	EPIC	Last Available: "2017-03"
 9388	boozy perfectly mixed Bloody Nora	5	EPIC	Last Available: "2017-03"
 9389	acceptable red moreltini	3	good	Last Available: "2017-03"
 9390	acceptable hell in a bucket	3	good	Last Available: "2017-03"
 9391	drinkable Newark	3	good	Last Available: "2017-03"
-9392	lousy distilled R'lyeh	5	decent	Last Available: "2017-03"
-9393	hand-crafted extra-dry Gnollish sangria	5	EPIC	Last Available: "2017-03"
+9392	distilled lousy R'lyeh	5	decent	Last Available: "2017-03"
+9393	extra-dry hand-crafted Gnollish sangria	5	EPIC	Last Available: "2017-03"
 9394	artisanal weak red vodka barracuda	2	EPIC	Last Available: "2017-03"
 9395	bad Mysterious Island iced tea	3	decent	Last Available: "2017-03"
 9396	acceptable drive-by shooting	3	good	Last Available: "2017-03"
-9397	bad distilled gunner's daughter	5	decent	Last Available: "2017-03"
+9397	distilled bad gunner's daughter	5	decent	Last Available: "2017-03"
 9398	hand-crafted weak dirt julep	2	EPIC	Last Available: "2017-03"
 9399	tolerable Simepore slime	4	good	Last Available: "2017-03"
 9400	spirit-forward bad mirror Phil Collins	5	decent	Last Available: "2017-03"
@@ -9279,7 +9279,7 @@
 9407	gray rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	jittery gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9410	narrow jittery Spacegate Research	0		Last Available: "2017-04"
+9410	jittery narrow Spacegate Research	0		Last Available: "2017-04"
 9411	alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9292,7 +9292,7 @@
 9420	powdered huge alien plant goo	1		Effect: "Space Cadet", Effect Duration: 15, Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	fancy bland alien meat	3	decent	Effect: "You Can Taste the Darkness", Effect Duration: 10, Last Available: "2017-04"
+9423	bland fancy alien meat	3	decent	Effect: "You Can Taste the Darkness", Effect Duration: 10, Last Available: "2017-04"
 9424	twirling alien toenails	0		Last Available: "2017-04"
 9425	olive alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9350,7 +9350,7 @@
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	polarized quadruple-enhanced tumbling Daily Affirmation: Always be Collecting	0		Effect: "Salty Dogs", Effect Duration: 12, Last Available: "2017-05"
 9480	ionized colloidal bouncing Daily Affirmation: Think Win-Lose	0		Effect: "Abyssal Tears", Effect Duration: 64, Last Available: "2017-05"
-9481	energized activated blinking ghostly Daily Affirmation: Be Superficially interested	0		Effect: "Tingly Biceps", Effect Duration: 37, Last Available: "2017-05"
+9481	energized activated ghostly blinking Daily Affirmation: Be Superficially interested	0		Effect: "Tingly Biceps", Effect Duration: 37, Last Available: "2017-05"
 9482	extra-aerosolized ionized activated Daily Affirmation: Adapt to Change Eventually	0		Effect: "Elemental Mastery", Effect Duration: 33, Last Available: "2017-05"
 9483	dry moist huge Daily Affirmation: Be a Mind Master	0		Effect: "You're Not Cooking", Effect Duration: 19, Last Available: "2017-05"
 9484	oxidized nitrogenated energized ghostly Daily Affirmation: Work For Hours a Week	0		Effect: "Like a Fish to Walter", Effect Duration: 19, Last Available: "2017-05"
@@ -9364,7 +9364,7 @@
 9492	tumbling twirling suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	friendly Annie Oakley's Kremlin's Greatest Briefcase of the sewer	0		Critical Hit Percent: +20, Familiar Weight: +3, Stench Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	enchanted mediocre basic martini	4	decent	Effect: "Rainbow Bright", Effect Duration: 25, Last Available: "2017-06"
-9495	hand-crafted watered-down fancy improved martini	2	EPIC	Effect: "Space Cadet", Effect Duration: 10, Last Available: "2017-06"
+9495	fancy watered-down hand-crafted improved martini	2	EPIC	Effect: "Space Cadet", Effect Duration: 10, Last Available: "2017-06"
 9496	fancy acceptable practically non-alcoholic splendid martini	1	good	Effect: "Amorous Avarice", Effect Duration: 15, Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	bouncing Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	decent meteoreo	3	good	Last Available: "2017-08"
-9515	perfectly mixed triple-distilled blurry meadeorite	6	EPIC	Last Available: "2017-08"
+9515	triple-distilled perfectly mixed blurry meadeorite	6	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	ribald smooth meteortarboard of Gandalf	0		Moxie: +15, Spell Critical Percent: +20, Sleaze Damage: +10, Last Available: "2017-08"
 9518	ghostly smelly scorching quilted meteorite guard	0		Damage Absorption: +40, Hot Damage: +25, Stench Spell Damage: +10, Damage Reduction: 9, Last Available: "2017-08"
-9519	wholesome meteorb of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Last Available: "2017-08", Lantern Element: "Hot"
+9519	wholesome meteorb of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Lantern Element: "Hot", Last Available: "2017-08"
 9520	greedy grievous asteroid belt	0		Weapon Damage Percent: +50, Meat Drop: +20, Single Equip, Last Available: "2017-08"
 9521	vibrating Da Vinci's brawny meteorthopedic shoes	0		Muscle Percent: +20, Experience (Mysticality): +5, Maximum MP Percent: +10, Single Equip, Last Available: "2017-08"
 9522	wholesome dangerous shooting morning star of Leguizamo	0		Weapon Damage: +10, Maximum HP Percent: +10, Monster Level: +20, Single Equip, Last Available: "2017-08"
@@ -9419,7 +9419,7 @@
 9547	artisanal weak upside-down flask of port	2	EPIC	
 9548	jittery toasty electrified contract enforcement stick	0		Hot Damage: +5, MP Regen Min: 3, MP Regen Max: 5
 9549	gigantic normal Hide-rox&trade; cookie	8	good	Last Available: "2017-10"
-9550	watered-down artisanal special narrow jug of booze	2	EPIC	Effect: "Simulation Stimulation", Effect Duration: 30, Last Available: "2017-10"
+9550	watered-down special artisanal narrow jug of booze	2	EPIC	Effect: "Simulation Stimulation", Effect Duration: 30, Last Available: "2017-10"
 9551	adjusted galvanized pair of candy glasses	0		Effect: "Eau de Tortue", Effect Duration: 40, Last Available: "2017-10"
 9552	altered electrified wobbly temporary X tattoos	0		Effect: "Holiday Disappointment", Effect Duration: 48, Last Available: "2017-10"
 9553	denatured wobbly glyph of athleticism	1		Last Available: "2017-10"
@@ -9432,7 +9432,7 @@
 9560	O	0		Last Available: "2017-11"
 9561	amorphous blob	0		Last Available: "2017-11"
 9562	prompt chaotic Annie Oakley's sinister protection stick	0		Spell Damage: +10, Critical Hit Percent: +20, Spell Critical Percent: +10, Adventures: +3
-9563	ionized double-unsweetened huge maroon roll of meat	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
+9563	ionized double-unsweetened maroon huge roll of meat	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
 9564	mafia thumb ring of the wise owl of the scaredy-cat	0		Mysticality: +20, Monster Level: -15, Single Equip
 9565	double-dry cocoa chondrule	0		Effect: "Techno Bliss", Effect Duration: 65, Last Available: "2020-09"
 9566	savvy brainy mafia middle finger ring	0		Mysticality: +5, Mysticality Percent: +20, Single Equip, Conditional Skill (Equipped): "Show them your ring"
@@ -9451,7 +9451,7 @@
 9579	yummy unfinished fruitcake	4	awesome	Last Available: "2017-12"
 9580	quadruple-deionized blinking and cracker	0		Effect: "Extra-Sharp Weapon", Effect Duration: 24, Last Available: "2017-12"
 9581	smooth weak neg grog	2	awesome	Last Available: "2017-12"
-9582	diet rotten half double fruitcake	1	crappy	Last Available: "2017-12"
+9582	rotten diet half double fruitcake	1	crappy	Last Available: "2017-12"
 9583	decent hushed puppy	3	good	Last Available: "2017-12"
 9584	stale muffled muffuletta	4	decent	Last Available: "2017-12"
 9585	bland shushed potatoes	4	decent	Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	concentrated wishbone	0		Effect: "Rad-ish", Effect Duration: 54, Last Available: "2017-11"
 9595	practically non-alcoholic tolerable Racisto Ruidoso	1	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	tiny moldy cyan bran muffin	1	crappy	
+9597	moldy tiny cyan bran muffin	1	crappy	
 9598	rotten low-calorie blueberry muffin	1	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	tumbling silent B	0		Last Available: "2017-12"
@@ -9484,7 +9484,7 @@
 9612	silent N	0		Last Available: "2017-12"
 9613	upside-down silent O	0		Last Available: "2017-12"
 9614	silent P	0		Last Available: "2017-12"
-9615	tumbling huge olive silent Q	0		Last Available: "2017-12"
+9615	olive huge tumbling silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	maroon silent T	0		Last Available: "2017-12"
@@ -9514,12 +9514,12 @@
 9642	upside-down The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	jittery The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
-9645	blurry skewed lime green The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9645	lime green skewed blurry The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	weak artisanal skewed executive mime flask	2	EPIC	Last Available: "2017-12"
+9648	artisanal weak skewed executive mime flask	2	EPIC	Last Available: "2017-12"
 9649	delicious upside-down spinning nega-mushroom	3	awesome	Last Available: "2017-12"
-9650	watered-down lousy twirling nega-mushroom wine	2	decent	Last Available: "2017-12"
+9650	lousy watered-down twirling nega-mushroom wine	2	decent	Last Available: "2017-12"
 9651	denatured unsweetened dry wobbly mirror Cheer-Up soda	0		Effect: "Aquarius Rising", Effect Duration: 47, Last Available: "2017-12"
 9652	yummy mime army rations	3	awesome	Last Available: "2017-12"
 9653	acceptable mime army wine	3	good	Last Available: "2017-12"
@@ -9531,14 +9531,14 @@
 9659	double-paned electrified miming boots	0		Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2017-12"
 9660	ghostly scorching careful miming gloves	0		Monster Level: -10, Hot Damage: +25, Single Equip, Last Available: "2017-12"
 9661	God Lobster Egg	0		Free Pull, Last Available: "2018-05"
-9662	lime green ghostly donated booze	0		
+9662	ghostly lime green donated booze	0		
 9663	donated food	0		
 9664	donated candy	0		
 9665	ionized activated digital honeypot	0		Effect: "Headstrong", Effect Duration: 12, Last Available: "2025-12"
 9666	wobbly mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	narrow twirling rosy-cheeked mime army insignia (intelligence)	0		Maximum HP Percent: +30, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	healthy mime army insignia (espionage)	0		Maximum HP Percent: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	mime army insignia (infantry) of James Dean	0		Experience (Moxie): +3, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	narrow twirling rosy-cheeked mime army insignia (intelligence)	0		Maximum HP Percent: +30, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	healthy mime army insignia (espionage)	0		Maximum HP Percent: +20, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9550,8 +9550,8 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	mirror fireproof skip lid	0		Familiar Weight: +5
-9681	bland thick extra-toasted half sandwich	5	decent	Last Available: "2018-12"
-9682	perfectly mixed weak mulled hobo wine	2	EPIC	Last Available: "2018-12"
+9681	thick bland extra-toasted half sandwich	5	decent	Last Available: "2018-12"
+9682	weak perfectly mixed mulled hobo wine	2	EPIC	Last Available: "2018-12"
 9683	spinning burning newspaper	0		Last Available: "2018-12"
 9684	mirror stiffened smooth burning paper hat of Flo-Jo	0		Moxie: +15, Damage Reduction: 1, Initiative: +100, Lasts Until Rollover, Last Available: "2018-12"
 9685	inspector's Annie Oakley's padded burning cape	0		Damage Absorption: +20, Critical Hit Percent: +20, Item Drop: +15, Lasts Until Rollover, Last Available: "2018-12"
@@ -9565,7 +9565,7 @@
 9693	scorching grievous tinsel tights	0		Weapon Damage Percent: +50, Hot Damage: +25, Last Available: "2018-01"
 9694	Oprah's wholesome fortified wad of used tape	0		Damage Absorption: +60, Maximum HP Percent: +10, Maximum MP Percent: +50, Last Available: "2018-01"
 9695	knitted horrifying mansplainer's silent nightlight of the wise owl	0		Mysticality: +20, Monster Level: +15, Spooky Damage: +25, Cold Resistance: +3
-9696	altered pickled upside-down wobbly sweetened reindeer fat	0		Effect: "Emotion Sickness", Effect Duration: 53
+9696	altered pickled wobbly upside-down sweetened reindeer fat	0		Effect: "Emotion Sickness", Effect Duration: 53
 9697	activated frozen blue Good 'n' Quiet	0		Effect: "Chalky Hand", Effect Duration: 50
 9698	pickled pickled hot button candy	0		Effect: "Shredding, Sweating", Effect Duration: 24
 9699	bouncing mirror Temple Grandin's smooth wizardly makeshift garbage shirt	0		Mysticality: +25, Moxie: +15, Familiar Weight: +7, Last Available: "2018-01"
@@ -9575,7 +9575,7 @@
 9703	distilled beefy pill	1		
 9704	dried excitement pill	1		
 9705	mixed vitamin G pill	1		Effect: "Armored Innards", Effect Duration: 35
-9706	mixed olive bouncing shaking huge lucky-ish pill	1		Effect: "Bats in the Belfry", Effect Duration: 5
+9706	mixed huge shaking bouncing olive lucky-ish pill	1		Effect: "Bats in the Belfry", Effect Duration: 5
 9707	denatured upside-down dieting pill	1		Effect: "Sweet Taste", Effect Duration: 25
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
@@ -9592,15 +9592,15 @@
 9724	psychic's crystal ball of terror of courage	0		Spooky Spell Damage: +10, Spooky Resistance: +3, Last Available: "2018-02"
 9725	blurry Usain Bolt's MacGyver's psychic's pslacks	0		Maximum MP: +100, Initiative: +80, Last Available: "2018-02"
 9726	family-friendly psychic's amulet of horror	0		Spooky Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2018-02"
-9727	snack-sized flavorless fancy lime green heart-shaped candy whetstone	2	decent	Effect: "Gummiheart", Effect Duration: 30, Last Available: "2018-02"
+9727	fancy flavorless snack-sized lime green heart-shaped candy whetstone	2	decent	Effect: "Gummiheart", Effect Duration: 30, Last Available: "2018-02"
 9728	rotten Swedish massage fish	4	crappy	Last Available: "2018-02"
-9729	acceptable watered-down gray blinking Third Base	2	good	Last Available: "2018-02"
+9729	watered-down acceptable gray blinking Third Base	2	good	Last Available: "2018-02"
 9730	artisanal practically non-alcoholic Bustle Hustler	1	EPIC	Last Available: "2018-02"
 9731	vacuum-sealed aerosolized dry Fabiotion	0		Effect: "Milk Studly", Effect Duration: 42, Last Available: "2018-02"
 9732	quadruple-tarnished corrupted modified purple Bettie page	0		Effect: "Craft Tea", Effect Duration: 37, Last Available: "2018-02"
 9733	polymerized alkaline tonic o' Banderas	0		Effect: "Amplified Fabulousness", Effect Duration: 64, Last Available: "2018-02"
 9734	unsweetened bouncing heather graham cracker	0		Effect: "Lifted Spirits", Effect Duration: 37, Last Available: "2018-02"
-9735	pulsating olive Lolsipop	0		Last Available: "2018-02"
+9735	olive pulsating Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
 9738	personal graffiti kit	0		Last Available: "2018-02"
@@ -9631,7 +9631,7 @@
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
-9766	ghostly lime green Pimpsqueak	0		Last Available: "2018-03"
+9766	lime green ghostly Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
@@ -9655,7 +9655,7 @@
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	bouncing Ched	0		Last Available: "2018-03"
 9789	pulsating Gazelleton	0		Last Available: "2018-03"
-9790	skewed maroon Mechamelion	0		Last Available: "2018-03"
+9790	maroon skewed Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
 9792	bouncing Vamprey	0		Last Available: "2018-03"
 9793	gray Wullabye	0		Last Available: "2018-03"
@@ -9676,7 +9676,7 @@
 9808	Stooper	0		Last Available: "2018-03"
 9809	wobbly Disgeist	0		Last Available: "2018-03"
 9810	Bowlet	0		Last Available: "2018-03"
-9811	narrow huge Cornbeefadon	0		Last Available: "2018-03"
+9811	huge narrow Cornbeefadon	0		Last Available: "2018-03"
 9812	mirror Mu	0		Last Available: "2018-03"
 9813	bouncing Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
@@ -9695,11 +9695,11 @@
 9827	tumbling rocket	0		
 9828	dried magnificent oyster egg	1		
 9829	powdered jittery brilliant oyster egg	1		
-9830	dried huge cyan glistening oyster egg	1		
+9830	dried cyan huge glistening oyster egg	1		
 9831	vaporized teal scintillating oyster egg	1		Effect: "On Pins and Needles", Effect Duration: 25
 9832	dried fuchsia pearlescent oyster egg	1		
 9833	dehydrated jittery lustrous oyster egg	1		
-9834	dried blinking narrow gleaming oyster egg	1		
+9834	dried narrow blinking gleaming oyster egg	1		
 9835	mirror FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	huge energetic baleful savvy FantasyRealm G. E. M.	0		Mysticality Percent: +20, Spell Damage: +25, Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2018-04"
@@ -9734,18 +9734,18 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	special rotten tiny pulsating druidic s'more	1	crappy	Effect: "Peppermint Bite", Effect Duration: 25, Last Available: "2018-04"
+9869	tiny rotten special pulsating druidic s'more	1	crappy	Effect: "Peppermint Bite", Effect Duration: 25, Last Available: "2018-04"
 9870	boiled blue sachet of powder	1		Effect: "Gummibrain", Effect Duration: 15, Last Available: "2018-04"
-9871	fortified hand-crafted mourning wine	5	EPIC	Last Available: "2018-04"
+9871	hand-crafted fortified mourning wine	5	EPIC	Last Available: "2018-04"
 9872	blinking sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
-9875	shaking gray map to the Putrid Swamp	0		Last Available: "2018-04"
+9875	gray shaking map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	blue map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	rotten snack-sized denastified haunch	2	crappy	Last Available: "2018-04"
 9879	practically non-alcoholic artisanal bad rum and good cola	1	EPIC	Last Available: "2018-04"
-9880	activated aerosolized cyan skewed Potion of Heroism	0		Effect: "Material Witness", Effect Duration: 37, Last Available: "2018-04"
+9880	activated aerosolized skewed cyan Potion of Heroism	0		Effect: "Material Witness", Effect Duration: 37, Last Available: "2018-04"
 9881	red rosy-cheeked Herculean sage leggings of the Spider Queen	0		Mysticality Percent: +10, Experience (Muscle): +1, Maximum HP Percent: +30, Last Available: "2018-04"
 9882	shaking razor-sharp Master Thief's utility belt of dire peril of courage	0		Weapon Damage: +20, Weapon Damage Percent: +25, Spooky Resistance: +3, Single Equip, Last Available: "2018-04"
 9883	asbestos-lined Temple Grandin's extremely unsafe Duke Vampire's regal cloak	0		Weapon Damage Percent: +100, Familiar Weight: +7, Hot Resistance: +5, Last Available: "2018-04"
@@ -9768,19 +9768,19 @@
 9900	delicious chocolate &quot;Phoenix&quot;	4	awesome	
 9901	fancy bland chocolate Spider Queen	3	decent	Effect: "Expert Vacationer", Effect Duration: 15
 9902	lousy hipster cocktail	4	decent	
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	twirling God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	narrow God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	twirling God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	narrow God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
-9909	lime green bouncing blinking G	0		
+9909	bouncing lime green blinking G	0		
 9910	Garland of Greatness	0		
 9911	gattoo	0		
 9912	A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	purple crude oil congealer	0		
-9915	rotten big good guava	5	crappy	
+9915	big rotten good guava	5	crappy	
 9916	drinkable teal blinking gin and ginger	4	good	
 9917	twirling Thwaitgold chigger statuette	0		
 9918	denatured lime green gaseous gravy	1		
@@ -9799,26 +9799,26 @@
 9931	Lo Pan's fortified Nouveau nosering of Gandalf of the brazier	0		Damage Absorption: +60, Spell Critical Percent: 50, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-07"
 9932	diffused irradiated mirror sharkfin gumbo	0		Effect: "Wet Rub", Effect Duration: 36, Last Available: "2018-07"
 9933	warmed boiling broth	0		Effect: "Surreally Buff", Effect Duration: 44, Last Available: "2018-07"
-9934	tarnished blurry upside-down tumbling interrogative elixir	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 69, Last Available: "2018-07"
-9935	narrow bouncing mirror Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
+9934	tarnished blurry tumbling upside-down interrogative elixir	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 69, Last Available: "2018-07"
+9935	mirror narrow bouncing Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	tumbling Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	jittery Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	squat kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	burglar/sleep mask	0		Last Available: "2018-07"
 9941	mirror teal Thwaitgold masked hunter statuette	0		
-9942	blinking jittery Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
+9942	jittery blinking Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
 9943	Neverending Party guest pass	0		Last Available: "2018-09"
 9944	zippy family-friendly PARTY HARD T-shirt of horror	0		Spooky Spell Damage: +25, Sleaze Resistance: +1, Initiative: +20, Last Available: "2018-09"
 9945	mirror Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	artisanal extra-dry Middle of the Road&trade; brand whiskey	5	EPIC	Last Available: "2018-09"
+9948	extra-dry artisanal Middle of the Road&trade; brand whiskey	5	EPIC	Last Available: "2018-09"
 9949	gray neverending wallet chain	0		Last Available: "2018-09"
 9950	pentagram bandana of Leguizamo of the brazier	0		Monster Level: +20, Hot Spell Damage: +25, Last Available: "2018-09"
 9951	gravedigger's skull ring	0		Spooky Damage: +10, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	decent tiny PB&J with the crusts cut off	1	good	Last Available: "2018-09"
+9953	tiny decent PB&J with the crusts cut off	1	good	Last Available: "2018-09"
 9954	wobbly auspicious dorky glasses of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +10, Single Equip, Last Available: "2018-09"
 9955	blue Van der Graaf ponytail clip of the storm	0		Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-09"
 9956	inspector's paint palette	0		Item Drop: +15, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
@@ -9827,7 +9827,7 @@
 9959	yellow squat Fonzie's cosmetic football	0		Experience (Moxie): +1, Last Available: "2018-09"
 9960	wizardly shoe ad T-shirt of temperance	0		Mysticality: +25, Sleaze Resistance: +5, Last Available: "2018-09"
 9961	Sherlock's pump-up high-tops	0		Item Drop: +25, Single Equip, Last Available: "2018-09"
-9962	vacuum-sealed huge blue runproof mascara	0		Effect: "Material Witness", Effect Duration: 21, Last Available: "2018-09"
+9962	vacuum-sealed blue huge runproof mascara	0		Effect: "Material Witness", Effect Duration: 21, Last Available: "2018-09"
 9963	yellow very small dress	0		Last Available: "2018-09"
 9964	scorching noticeable pumps of the brazier	0		Hot Damage: +25, Hot Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9843,12 +9843,12 @@
 9976	party pants of Leguizamo	0		Monster Level: +20, Item Drop: +5, Last Available: "2018-09"
 9977	maroon Tesla hale strapping party whip	0		Muscle: +5, Maximum HP: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-09"
 9978	narrow Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	weak lousy blurry TRIO cup of beer	2	decent	Last Available: "2018-09"
+9979	lousy weak blurry TRIO cup of beer	2	decent	Last Available: "2018-09"
 9980	stale snack-sized upside-down party platter for one	2	decent	Last Available: "2018-09"
 9981	mixed Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	ghostly party pup	0		Last Available: "2018-09"
 9983	wool weightlifter's party crasher	0		Muscle: +15, Cold Resistance: +1, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9876,18 +9876,18 @@
 10010	massive normal upside-down ghostly ectoplasm	9	good	Last Available: "2018-11"
 10011	bland	4	decent	Last Available: "2018-11"
 10012	weak tolerable bottle of vodka	2	good	Last Available: "2018-11"
-10013	moldy huge pizza	6	crappy	Last Available: "2018-11"
+10013	huge moldy pizza	6	crappy	Last Available: "2018-11"
 10014	mediocre upside-down martini	3	decent	Last Available: "2018-11"
-10015	stale enchanted half-sized cherry pie	2	decent	Effect: "Human-Constellation Hybrid", Effect Duration: 35, Last Available: "2018-11"
-10016	bad distilled eggnog	5	decent	Last Available: "2018-11"
+10015	enchanted half-sized stale cherry pie	2	decent	Effect: "Human-Constellation Hybrid", Effect Duration: 35, Last Available: "2018-11"
+10016	distilled bad eggnog	5	decent	Last Available: "2018-11"
 10017	purple glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	decent squat Hell ramen	3	good	Last Available: "2018-11"
 10019	delicious gimlet	4	awesome	Last Available: "2018-11"
 10020	bad twice-haunted screwdriver	3	decent	Last Available: "2018-11"
-10021	immense moldy candy cane	6	crappy	Last Available: "2018-12"
+10021	moldy immense candy cane	6	crappy	Last Available: "2018-12"
 10022	perfectly mixed practically non-alcoholic runny fermented egg	1	EPIC	Last Available: "2018-12"
-10023	super-sized tasty oldcake	5	awesome	Last Available: "2018-12"
-10024	special bland traditional Crimbo cookie	4	decent	Effect: "Frigid Weapon", Effect Duration: 5, Last Available: "2023-06"
+10023	tasty super-sized oldcake	5	awesome	Last Available: "2018-12"
+10024	bland special traditional Crimbo cookie	4	decent	Effect: "Frigid Weapon", Effect Duration: 5, Last Available: "2023-06"
 10025	plastic wild beaver of bravery	0		Spooky Resistance: +5, Last Available: "2018-12"
 10026	plastic reindeer of chilblains	0		Cold Damage: +25, Last Available: "2018-12"
 10027	prompt plastic Caf&eacute; Elf	0		Adventures: +3, Last Available: "2018-12"
@@ -9902,13 +9902,13 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	big moldy grilled mooseflank	5	crappy	Last Available: "2018-12"
+10039	moldy big grilled mooseflank	5	crappy	Last Available: "2018-12"
 10040	spoiled moosemeat pie	3	crappy	Last Available: "2018-12"
 10041	MacGyver's balanced antler	0		Maximum MP: +100, Last Available: "2018-12"
 10042	baleful dam	0		Spell Damage: +25, Damage Reduction: 9, Last Available: "2018-12"
-10043	watered-down artisanal beavermouth	2	EPIC	Last Available: "2018-12"
+10043	artisanal watered-down beavermouth	2	EPIC	Last Available: "2018-12"
 10044	lousy weak beaver punch (papaya)	2	decent	Last Available: "2018-12"
-10045	tolerable watered-down wobbly beaver punch (peach)	2	good	Last Available: "2018-12"
+10045	watered-down tolerable wobbly beaver punch (peach)	2	good	Last Available: "2018-12"
 10046	drinkable beaver punch (cherry)	3	good	Last Available: "2018-12"
 10047	manspreader's baleful Canadian lantern	0		Spell Damage: +25, Monster Level: +10, Last Available: "2018-12"
 10048	foul-smelling muskox-skin cap	0		Stench Damage: +10, Last Available: "2018-12"
@@ -9926,12 +9926,12 @@
 10060	toothsome sausage	3	awesome	Last Available: "2019-01"
 10061	pulsating foul-smelling red-hot sausage fork of Leguizamo	0		Monster Level: +20, Stench Damage: +10, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
-10063	upside-down mirror sausage golem	0		Last Available: "2019-01"
+10063	mirror upside-down sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
-10065	blurry pulsating skewed Toyleporter	0		Last Available: "2018-12"
+10065	skewed pulsating blurry Toyleporter	0		Last Available: "2018-12"
 10066	lousy beer	3	decent	Last Available: "2018-12"
 10067	bland tiny green yule gruel	1	decent	Last Available: "2018-12"
-10068	weak smooth hot watered rum	2	awesome	Last Available: "2018-12"
+10068	smooth weak hot watered rum	2	awesome	Last Available: "2018-12"
 10069	drinkable bottle of Crimbognac	3	good	Last Available: "2018-12"
 10070	flavorless miniature Crimboysters Rockefeller	2	decent	Last Available: "2018-12"
 10071	altered maroon Crimbeau de toilette	1		Effect: "Creepypasted", Effect Duration: 40, Last Available: "2018-12"
@@ -9959,7 +9959,7 @@
 10093	skewed sharpshooter's wholesome marble mignonette bowl	0		Maximum HP Percent: +10, Critical Hit Percent: +10, Last Available: "2019-12"
 10094	green frosty smooth marble medallion	0		Moxie: +15, Cold Spell Damage: +10, Single Equip, Last Available: "2019-12"
 10095	fortified marble mariachi hat of doom	0		Damage Absorption: +60, Spooky Spell Damage: +50, Last Available: "2019-12"
-10096	vaporized olive tumbling marble molecules	1		Last Available: "2019-12"
+10096	vaporized tumbling olive marble molecules	1		Last Available: "2019-12"
 10097	concentrated pickled Mallomarbles	0		Effect: "Frisky Spirit", Effect Duration: 44
 10098	stiffened boxer's punching bag	0		Muscle Percent: +10, Damage Reduction: 1, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10099	Van der Graaf pith helmet of courage	0		Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
@@ -9984,7 +9984,7 @@
 10118	horrifying velour valise of wisdom	0		Mysticality: +15, Spooky Damage: +25, Last Available: "2021-12"
 10119	blurry teal family-friendly weightlifter's velour vaqueros	0		Muscle: +15, Sleaze Resistance: +1, Last Available: "2021-12"
 10120	vaporized blinking velour veneer	1		Effect: "Human-Horror Hybrid", Effect Duration: 40, Last Available: "2021-12"
-10121	Vulcanized galvanized Vulcanized tumbling gray Velougats&trade;	0		Effect: "You're Not Cooking", Effect Duration: 33
+10121	Vulcanized galvanized Vulcanized gray tumbling Velougats&trade;	0		Effect: "You're Not Cooking", Effect Duration: 33
 10122	ghostly deadly glass suspenders of the cougar	0		Moxie: +20, Weapon Damage: +5, Single Equip, Last Available: "2021-12"
 10123	wicked dance instructor's glass shield	0		Experience Percent (Moxie): +10, Spell Damage: +5, Damage Reduction: 7, Last Available: "2021-12"
 10124	mansplainer's therapeutic glass stetson	0		Monster Level: +15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-12"
@@ -10007,7 +10007,7 @@
 10141	stiffened grievous flagstone fez	0		Weapon Damage Percent: +50, Damage Reduction: 1, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	upside-down careful ruddy flagstone fleece	0		Maximum HP Percent: +40, Monster Level: -10, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	smartaleck's flagstone fringe of the detective	0		Moxie Percent: +30, Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	denatured squat lime green flagstone flagments	1		Effect: "Hot Jellied", Effect Duration: 25, Last Available: "2022-12"
+10144	denatured lime green squat flagstone flagments	1		Effect: "Hot Jellied", Effect Duration: 25, Last Available: "2022-12"
 10145	non-liquefied non-quantum Flag by the Foot&trade;	0		Effect: "The Two-Prong Crown", Effect Duration: 49
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	pulsating red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,10 +10018,10 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	double-paned elf army poncho	0		Cold Resistance: +5, Lasts Until Rollover, Last Available: "2019-12"
-10155	bite-sized stale enchanted blurry elf army field rations	1	decent	Effect: "Slightly Mutated", Effect Duration: 10, Last Available: "2019-12"
+10155	stale bite-sized enchanted blurry elf army field rations	1	decent	Effect: "Slightly Mutated", Effect Duration: 10, Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	mirror ribald discarded bowtie of the pedagogue	0		Experience: +3, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
-10158	tolerable irresponsibly strong skewed martiny	6	good	Last Available: "2019-12"
+10158	irresponsibly strong tolerable skewed martiny	6	good	Last Available: "2019-12"
 10159	red tryptophan dart	0		Last Available: "2019-12"
 10160	anodized licorice snake	0		Effect: "Uncaged Power", Effect Duration: 42
 10161	super-energized polarized virgin jello shot	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 61
@@ -10031,17 +10031,17 @@
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	Jim Carey's shellacked Lil' Doctor&trade; bag	0		Damage Reduction: 7, Monster Level: +25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
-10169	delicious special bloodstick	3	awesome	Effect: "Disco Nirvana", Effect Duration: 5
+10169	special delicious bloodstick	3	awesome	Effect: "Disco Nirvana", Effect Duration: 5
 10170	perfectly mixed enchanted bottle of Sanguiovese	3	EPIC	Effect: "Bloody-minded", Effect Duration: 25
 10171	adequate skewed actual blood sausage	3	good	
 10172	weak delicious mulled blood	2	awesome	
 10173	decent snack-sized blood snowcone	2	good	
 10174	tolerable weak tumbling Red Russian	2	good	
-10175	bland gigantic blood roll-up	7	decent	
+10175	gigantic bland blood roll-up	7	decent	
 10176	tolerable huge bottle of blood	4	good	
 10177	bland blood-soaked sponge cake	3	decent	
 10178	drinkable vampagne	3	good	
-10179	rotten pulsating narrow plain snowcone	3	crappy	
+10179	rotten narrow pulsating plain snowcone	3	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	blinking money bag	0		
 10182	money bag	0		
@@ -10061,11 +10061,11 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	big rotten crabsicle	5	crappy	Last Available: "2019-04"
+10199	rotten big crabsicle	5	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	hand-crafted bottle of dark rhum	3	EPIC	Last Available: "2019-04"
 10202	weak hand-crafted purple bottle of extra-dark rhum	2	EPIC	Last Available: "2019-04"
-10203	hand-crafted blinking purple bottle of super-extra-dark rhum	4	EPIC	Last Available: "2019-04"
+10203	hand-crafted purple blinking bottle of super-extra-dark rhum	4	EPIC	Last Available: "2019-04"
 10204	colloidal modified blinking pirate shaving cream	0		Effect: "Arabian Knighthood", Effect Duration: 45, Last Available: "2019-04"
 10205	medical-grade hardy conquistador's breastplate	0		Maximum HP: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-04"
 10206	jittery extremely unsafe wizardly pirate pantaloons	0		Mysticality: +25, Weapon Damage Percent: +100, Last Available: "2019-04"
@@ -10089,19 +10089,19 @@
 10224	skewed Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	fuchsia PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	plush sea serpent of the sweet-tooth	0		Candy Drop: +100, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	small delicious pirate fork	2		Last Available: "2019-04"
+10227	delicious small pirate fork	2		Last Available: "2019-04"
 10228	spinning maroon Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	narrow ring	0		Single Equip, Last Available: "2019-04"
 10230	Sherlock's Tesla piratical blunderbuss	0		Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-04"
 10231	ghostly skewed reassuring electrified PirateRealm party hat of the brute	0		Muscle Percent: +30, Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-04"
-10232	practically non-alcoholic hand-crafted Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10232	hand-crafted practically non-alcoholic Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10233	acceptable Island Thunderstorm	3	good	Last Available: "2019-04"
 10234	lousy upside-down yellow Island Hurricane	4	decent	Last Available: "2019-04"
 10235	artisanal Skull Punch	4	EPIC	Last Available: "2019-04"
 10236	triple-distilled bad Electric Punch	10	decent	Last Available: "2019-04"
-10237	watered-down hand-crafted Smuggler's Punch	2	super ultra mega turbo EPIC	Last Available: "2019-04"
+10237	hand-crafted watered-down Smuggler's Punch	2	super ultra mega turbo EPIC	Last Available: "2019-04"
 10238	watered-down bad Scorpion Bowl	2	decent	Last Available: "2019-04"
-10239	practically non-alcoholic perfectly mixed Turtle Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10239	perfectly mixed practically non-alcoholic Turtle Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10240	acceptable blurry Cobra Bowl	3	good	Last Available: "2019-04"
 10241	upside-down vampyric cloake pattern	0		Free Pull
 10242	zippy lion tamer's cool vampyric cloake of the bloodbag of the glutton	0		Moxie: +5, Maximum HP: +100, Experience (familiar): +2, Food Drop: +100, Initiative: +20, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
@@ -10131,7 +10131,7 @@
 10266	chilled blinking magenta seashell	0		Effect: "Big Meat Big Prizes", Effect Duration: 59, Last Available: "2019-07"
 10267	quadruple-altered cyan seashell	0		Effect: "Slimy Flavor", Effect Duration: 23, Last Available: "2019-07"
 10268	unsweetened spinning gray seashell	0		Effect: "Extra-Wet", Effect Duration: 41, Last Available: "2019-07"
-10269	warmed improved cyan huge seashell	0		Effect: "Slime Time", Effect Duration: 50, Last Available: "2019-07"
+10269	warmed improved huge cyan seashell	0		Effect: "Slime Time", Effect Duration: 50, Last Available: "2019-07"
 10270	super-Vulcanized enhanced seashell	0		Effect: "It Didn't Kill You", Effect Duration: 67, Last Available: "2019-07"
 10271	purple bunch of sea grapes	0		Last Available: "2019-07"
 10272	artisanal jittery bottle of sea wine	3	EPIC	Last Available: "2019-07"
@@ -10154,7 +10154,7 @@
 10289	dry Finnish Fish	0		Effect: "It's Soporiffic!", Effect Duration: 46
 10290	flattened extra-activated modified pulsating chocolate doubloon	0		Effect: "Prelude of Precision", Effect Duration: 27
 10291	aromatic stiffened driftwood beach comb of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
-10292	twirling jittery Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
+10292	jittery twirling Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	skewed skewed stick of firewood	0		Last Available: "2019-08"
 10294	flame-wreathed lion tamer's Tesla whittled tiara	0		Experience (familiar): +2, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-08"
 10295	Lo Pan's dangerous whittled shorts of Flo-Jo	0		Weapon Damage: +10, Spell Critical Percent: +30, Initiative: +100, Last Available: "2019-08"
@@ -10166,7 +10166,7 @@
 10301	narrow stiffened whittled fox figurine of the overflowing toilet	0		Damage Reduction: 1, Stench Spell Damage: +50, Item Drop: +5, Single Equip, Last Available: "2019-08"
 10302	Sherlock's greasy banded Rosewater's whittled walking stick	0		Mysticality Percent: +30, Damage Absorption: +100, Sleaze Spell Damage: +10, Item Drop: +25, Last Available: "2019-08"
 10303	decent campfire hot dog	3	good	Last Available: "2019-08"
-10304	huge stale spinning campfire baked potato	10	decent	Last Available: "2019-08"
+10304	stale huge spinning campfire baked potato	10	decent	Last Available: "2019-08"
 10305	spoiled tiny campfire s'more	1	crappy	Last Available: "2019-08"
 10306	normal campfire beans	4	good	Last Available: "2019-08"
 10307	miniature delicious campfire stew	2	awesome	Last Available: "2019-08"
@@ -10188,14 +10188,14 @@
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	blue Pocket Professor memory chip	0		
 10325	Law of Averages	0		
-10332	twirling upside-down Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
+10332	upside-down twirling Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	inspector's stiffened dangerous Eight Days a Week Pill Keeper	0		Weapon Damage: +10, Damage Reduction: 1, Item Drop: +15, Last Available: "2019-10"
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	enchanted adequate bu&ntilde;uelos Jaliscos	3	good	Effect: "Stinky Hands", Effect Duration: 45, Last Available: "2019-12"
-10338	decent jumbo fancy maroon flan del mar	5	good	Effect: "Feet of Grapefruit", Effect Duration: 20, Last Available: "2019-12"
-10339	moldy huge Baja sopapilla	9	crappy	Last Available: "2019-12"
+10337	adequate enchanted bu&ntilde;uelos Jaliscos	3	good	Effect: "Stinky Hands", Effect Duration: 45, Last Available: "2019-12"
+10338	fancy decent jumbo maroon flan del mar	5	good	Effect: "Feet of Grapefruit", Effect Duration: 20, Last Available: "2019-12"
+10339	huge moldy Baja sopapilla	9	crappy	Last Available: "2019-12"
 10340	mirror Temple Grandin's plastic Mer-kin baker	0		Familiar Weight: +7, Last Available: "2019-12"
 10341	plastic sea elf of horror	0		Spooky Spell Damage: +25, Last Available: "2019-12"
 10342	jittery plastic yuleviathan of doom	0		Spooky Spell Damage: +50, Last Available: "2019-12"
@@ -10213,11 +10213,11 @@
 10354	dehydrated blue vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dried blue a bug's lymph	1		Last Available: "2019-12"
 10356	adjusted tumbling organic potpourri	0		Effect: "Cool Spirit", Effect Duration: 31, Last Available: "2019-12"
-10357	tolerable practically non-alcoholic fancy twirling boot flask	1	good	Effect: "Empathy", Effect Duration: 15, Last Available: "2019-12"
-10358	denatured ionized squat skewed infernal snowball	0		Effect: "Craft Tea", Effect Duration: 59, Last Available: "2019-12"
+10357	tolerable fancy practically non-alcoholic twirling boot flask	1	good	Effect: "Empathy", Effect Duration: 15, Last Available: "2019-12"
+10358	denatured ionized skewed squat infernal snowball	0		Effect: "Craft Tea", Effect Duration: 59, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	powdered pulsating fish sauce	1		Last Available: "2019-12"
-10361	snack-sized stale fancy guffin	2	decent	Effect: "Chunky", Effect Duration: 20, Last Available: "2019-12"
+10361	fancy snack-sized stale guffin	2	decent	Effect: "Chunky", Effect Duration: 20, Last Available: "2019-12"
 10362	altered yellow Shantix&trade;	1		Effect: "Muddled", Effect Duration: 50, Last Available: "2019-12"
 10363	red jittery goodberry	0		Last Available: "2019-12"
 10364	altered non-Euclidean angle	1		Last Available: "2019-12"
@@ -10225,7 +10225,7 @@
 10366	boiled fuchsia Mer-kin eyedrops	0		Effect: "Shamboozled", Effect Duration: 52, Last Available: "2019-12"
 10367	non-nitrogenated spinning extra-strength goo	0		Effect: "Muscularrr", Effect Duration: 31, Last Available: "2019-12"
 10368	fuchsia envelope full of Meat	0		Last Available: "2019-12"
-10369	compressed tumbling yellow livid energy	1		Last Available: "2019-12"
+10369	compressed yellow tumbling livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
 10371	denatured spinning beggin' cologne	1		Last Available: "2019-12"
 10372	lime green arcane researcher's weightlifter's oxygenated eggnog helmet	0		Muscle: +15, Experience Percent (Mysticality): +10, Adventure Underwater, Last Available: "2019-12"
@@ -10255,12 +10255,12 @@
 10396	tumbling tinsel fin	0		Familiar Weight: +5
 10397	bland bowl of mernudo	3	decent	Last Available: "2019-12"
 10398	mediocre wobbly fishelada	3	decent	Last Available: "2019-12"
-10399	decent enchanted small wobbly ojo de pez burrito	2	good	Effect: "Analog Drunk", Effect Duration: 5, Last Available: "2019-12"
+10399	enchanted small decent wobbly ojo de pez burrito	2	good	Effect: "Analog Drunk", Effect Duration: 5, Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
-10404	spinning bouncing waterlogged	0		Last Available: "2019-12"
+10404	bouncing spinning waterlogged	0		Last Available: "2019-12"
 10405	miser's wizardly nutcracker hat	0		Mysticality: +25, Meat Drop: +10, Last Available: "2019-12"
 10406	lard-coated dog trainer's nutcracker waistcoat	0		Experience (familiar): +1, Sleaze Spell Damage: +25, Last Available: "2019-12"
 10407	avaricious reassuring nutcracker pants	0		Spooky Resistance: +1, Meat Drop: +30, Last Available: "2019-12"
@@ -10282,7 +10282,7 @@
 10423	pulsating reassuring frightening kelp-holly drape	0		Spooky Damage: +5, Spooky Resistance: +1, Last Available: "2019-12"
 10424	blinking perfumed curative Staff of the Peppermint Twist of the pedagogue	0		Experience: +3, Stench Resistance: +5, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10425	spoiled tempura and bean	3	crappy	Last Available: "2019-12"
-10426	watered-down mediocre cyan salt plum sake	2	decent	Last Available: "2019-12"
+10426	mediocre watered-down cyan salt plum sake	2	decent	Last Available: "2019-12"
 10427	corrupted altered pressurized potion of possessiveness	0		Effect: "Turkey-Ambitious", Effect Duration: 24, Last Available: "2019-12"
 10428	vacuum-sealed ghostly almond	0		Effect: "Bubblin' Rage", Effect Duration: 30
 10429	pressed wobbly handful of mixed nuts	0		Effect: "Oth-Jeal-O", Effect Duration: 18, Last Available: "2019-12"
@@ -10293,16 +10293,16 @@
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	green squat mansplainer's manspreader's Herculean Powerful Glove of the empath of the sweet-tooth	0		Experience (Muscle): +1, Monster Level: 25, Familiar Weight: +5, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
-10439	spinning narrow blinking enhanced signal receiver	0		
+10439	blinking spinning narrow enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	jittery chilly MacGyver's boxer's Drip harness	0		Muscle Percent: +10, Maximum MP: +100, Cold Damage: +5
 10442	foul-smelling drippy truncheon	0		Stench Damage: +10, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	spoiled bite-sized drippy nugget	1	drippy	
-10446	practically non-alcoholic perfectly mixed glass of drippy wine	1	drippy	
+10446	perfectly mixed practically non-alcoholic glass of drippy wine	1	drippy	
 10447	normal twirling drippy caviar	3	drippy	
-10448	thick fancy flavorless drippy plum(?)	5	drippy	Effect: "Sweet Nostalgia", Effect Duration: 40
+10448	thick flavorless fancy drippy plum(?)	5	drippy	Effect: "Sweet Nostalgia", Effect Duration: 40
 10449	savvy drippy stake	0		Mysticality Percent: +20, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10315,7 +10315,7 @@
 10458	cold-filtered diffused fizzy soda	0		Effect: "Vanity Rage", Effect Duration: 45
 10459	non-pressed purple healthy juice	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 38
 10460	hammer	0		
-10461	narrow red mirror hammer	0		
+10461	red narrow mirror hammer	0		
 10462	fire flower	0		
 10463	shaking bonfire flower	0		
 10464	work boots	0		Single Equip
@@ -10346,7 +10346,7 @@
 10489	bland mushroom filet	4	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	boiled narrow mushroom tea	1		Effect: "Patched In", Effect Duration: 10, Last Available: "2020-03"
-10492	drinkable enchanted mushroom whiskey	3	good	Effect: "Squatting and Thrusting", Effect Duration: 10, Last Available: "2020-03"
+10492	enchanted drinkable mushroom whiskey	3	good	Effect: "Squatting and Thrusting", Effect Duration: 10, Last Available: "2020-03"
 10493	wool forbidden mushroom cap of Gandalf	0		Spell Damage Percent: +50, Spell Critical Percent: +20, Cold Resistance: +1, Last Available: "2020-03"
 10494	censurious friendly stiffened forbidden mushroom shield	0		Spell Damage Percent: +50, Damage Reduction: 7, Familiar Weight: +3, Sleaze Resistance: +3, Last Available: "2020-03"
 10495	squat lightning-fast mansplainer's rock-hard quilted mushroom pants	0		Damage Absorption: +40, Damage Reduction: 5, Monster Level: +15, Initiative: +40, Last Available: "2020-03"
@@ -10394,11 +10394,11 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	Van der Graaf Guzzlr souvenir stein	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	watered-down acceptable olive Ghiaccio Colada	2	good	Last Available: "2020-05"
+10541	acceptable watered-down olive Ghiaccio Colada	2	good	Last Available: "2020-05"
 10542	bad Sourfinger	3	decent	Last Available: "2020-05"
 10543	tolerable Nog-on-the-Cob	4	good	Last Available: "2020-05"
-10544	watered-down perfectly mixed huge Steamboat	2	EPIC	Last Available: "2020-05"
-10545	practically non-alcoholic smooth Buttery Boy	1	awesome	Last Available: "2020-05"
+10544	perfectly mixed watered-down huge Steamboat	2	EPIC	Last Available: "2020-05"
+10545	smooth practically non-alcoholic Buttery Boy	1	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	green rosy-cheeked clown car key of extreme caution	0		Maximum HP Percent: +30, Monster Level: -25, Last Available: "2020-08"
 10548	frightening healthy brainy batting cage key	0		Mysticality: +5, Maximum HP Percent: +20, Spooky Damage: +5, Last Available: "2020-08"
@@ -10423,7 +10423,7 @@
 10567	resourceful banded actual skeleton key	0		Damage Absorption: +100, Maximum MP: +50, Last Available: "2020-08"
 10568	perfumed scandalous Newton's deep-fried key	0		Experience (Mysticality): +3, Sleaze Damage: +5, Stench Resistance: +5, Last Available: "2020-08"
 10569	mirror asbestos-lined supercharged discarded bike lock key	0		Maximum MP Percent: +30, Hot Resistance: +5, Last Available: "2020-08"
-10570	huge blurry blurry Thwaitgold keyhole spider statuette	0		
+10570	blurry huge blurry Thwaitgold keyhole spider statuette	0		
 10571	teal Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	magnetized quantum marshroom	0		Effect: "Thought", Effect Duration: 30
 10573	bag of Iunion stones	0		Free Pull
@@ -10495,7 +10495,7 @@
 10639	jittery dangerous sea-worn candlestick of the pedagogue of the early riser	0		Experience: +3, Weapon Damage: +10, Adventures: +7, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	frozen spinning shaking null-day exploit	0		Effect: "Jingle Jangle Jingle", Effect Duration: 42, Last Available: "2025-12"
-10642	ghostly pulsating flame orb	0		Last Available: "2020-09"
+10642	pulsating ghostly flame orb	0		Last Available: "2020-09"
 10643	normal upside-down chocolate chip muffin	3	good	
 10644	blurry Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
@@ -10545,7 +10545,7 @@
 10689	gray Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
-10692	blinking maroon booze drive button	0		Single Equip, Last Available: "2020-12"
+10692	maroon blinking booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
 10695	blue booze mailing list	0		Last Available: "2020-12"
@@ -10559,37 +10559,37 @@
 10703	The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10705	The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
-10706	spinning huge The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+10706	huge spinning The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	shaking upside-down The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
-10710	purple blurry The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10710	blurry purple The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
-10712	blurry cyan The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
+10712	cyan blurry The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	blinking The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	massive decent huge and pepper (stale)	9	good	Last Available: "2020-12"
-10716	hand-crafted weak shaking cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
+10716	weak hand-crafted shaking cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	maroon goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	drinkable gray barrel-aged eggnog	4	good	Last Available: "2020-12"
-10721	big normal hand-crafted candy cane	5	good	Last Available: "2020-12"
+10721	normal big hand-crafted candy cane	5	good	Last Available: "2020-12"
 10722	moldy drive-thru burger	4	crappy	Last Available: "2020-12"
 10723	aged Boulevardier cocktail	3	awesome	Last Available: "2020-12"
-10724	triple-polarized jittery spinning Hotwire&trade; brand candy rope	0		Effect: "Mushroom Samba", Effect Duration: 34, Last Available: "2020-12"
-10725	stale super-sized narrow purple bowl full of jelly	5	decent	Last Available: "2020-12"
-10726	practically non-alcoholic tolerable fancy lime green Eye and a Twist	1	good	Effect: "Memory of Speed", Effect Duration: 35, Last Available: "2020-12"
+10724	triple-polarized spinning jittery Hotwire&trade; brand candy rope	0		Effect: "Mushroom Samba", Effect Duration: 34, Last Available: "2020-12"
+10725	stale super-sized purple narrow bowl full of jelly	5	decent	Last Available: "2020-12"
+10726	fancy tolerable practically non-alcoholic lime green Eye and a Twist	1	good	Effect: "Memory of Speed", Effect Duration: 35, Last Available: "2020-12"
 10727	ionized triple-frozen skewed Chubby and Plump bar	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 50, Last Available: "2020-12"
 10728	twirling digibritches	0		Last Available: "2025-12"
 10729	fuchsia huge packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	shaking fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	skewed fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	fuchsia robo-battery	0		
-10736	shaking ghostly Thwaitgold listening bug statuette	0		
+10736	ghostly shaking Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	twirling potted power plant	0		Last Available: "2021-03"
 10739	triple-oxidized battery (AAA)	0		Effect: "Dragged Through the Coals", Effect Duration: 64, Last Available: "2021-03"
@@ -10610,7 +10610,7 @@
 10754	alkaline modified short stick of butter	0		Effect: "Updated", Effect Duration: 11, Last Available: "2021-05"
 10755	irradiated modified tumbling short glass of water	0		Effect: "Enraged", Effect Duration: 45, Last Available: "2021-05"
 10756	flattened bouncing short	0		Effect: "Salamander In Your Stomach", Effect Duration: 67, Last Available: "2021-05"
-10757	blurry blinking Thwaitgold quantum bug statuette	0		
+10757	blinking blurry Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
 10759	reassuring dog trainer's familiar scrapbook	0		Experience (familiar): +1, Spooky Resistance: +1, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
@@ -10645,8 +10645,8 @@
 10789	narrow resourceful water candle	0		Maximum MP: +50, Water: 3, Lasts Until Rollover
 10790	veiny B. L. A. R. T.	0		Maximum HP: +10, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	mirror Thwaitgold fire beetle statuette	0		
-10792	olive blinking blurry empty nacho cheese can	0		Water: 1
-10793	green twirling literal bucket hat	0		Water: 5
+10792	blinking blurry olive empty nacho cheese can	0		Water: 1
+10793	twirling green literal bucket hat	0		Water: 5
 10794	wobbly rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
@@ -10659,9 +10659,9 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	chilly MacGyver's Samson's Daylight Shavings Helmet	0		Experience (Muscle): +5, Maximum MP: +100, Cold Damage: +5, Last Available: "2021-11"
 10805	eggwater	1	good	Last Available: "2021-12"
-10806	decent small blurry bread man	2	good	Last Available: "2021-12"
-10807	small bland plain candy cane	2	decent	Last Available: "2021-12"
-10808	rotten super-sized bouncing olive flour cookie	5	crappy	Last Available: "2021-12"
+10806	small decent blurry bread man	2	good	Last Available: "2021-12"
+10807	bland small plain candy cane	2	decent	Last Available: "2021-12"
+10808	super-sized rotten olive bouncing flour cookie	5	crappy	Last Available: "2021-12"
 10809	wobbly plastic food lab of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2021-12"
 10810	studded plastic nog lab	0		Damage Absorption: +80, Single Equip, Last Available: "2021-12"
 10811	hardened plastic chem lab	0		Damage Reduction: 3, Single Equip, Last Available: "2021-12"
@@ -10675,22 +10675,22 @@
 10819	special adequate thick wobbly tofu pop	5	good	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2021-12"
 10820	tiny stale bowl of prescription candy	1	decent	Last Available: "2021-12"
 10821	thick flavorless fishcake	5	decent	Last Available: "2021-12"
-10822	enchanted bland bone broth	3	decent	Effect: "Extra-Thick Blood", Effect Duration: 10, Last Available: "2021-12"
-10823	small spoiled red star pop	2	crappy	Last Available: "2021-12"
-10824	practically non-alcoholic aged jittery Doc's Fortifying Wine	1	awesome	Last Available: "2021-12"
-10825	hand-crafted pulsating purple Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
-10826	lousy twirling blue Doc's Limbering Wine	3	decent	Last Available: "2021-12"
+10822	bland enchanted bone broth	3	decent	Effect: "Extra-Thick Blood", Effect Duration: 10, Last Available: "2021-12"
+10823	spoiled small red star pop	2	crappy	Last Available: "2021-12"
+10824	aged practically non-alcoholic jittery Doc's Fortifying Wine	1	awesome	Last Available: "2021-12"
+10825	hand-crafted purple pulsating Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
+10826	lousy blue twirling Doc's Limbering Wine	3	decent	Last Available: "2021-12"
 10827	weak drinkable twirling Doc's Medical-Grade Wine	2	good	Last Available: "2021-12"
 10828	diluted Homebodyl&trade;	1		Last Available: "2021-12"
 10829	dehydrated squat Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	twisted twirling Breathitin&trade;	1		Last Available: "2021-12"
 10831	dried Fleshazole&trade;	1		Last Available: "2021-12"
-10832	quadruple-dry cyan narrow anti-burn cream	0		Effect: "Stop the Presses!", Effect Duration: 68, Last Available: "2021-12"
+10832	quadruple-dry narrow cyan anti-burn cream	0		Effect: "Stop the Presses!", Effect Duration: 68, Last Available: "2021-12"
 10833	pressed ghostly anti-freeze cream	0		Effect: "High Blood Chocolate Content", Effect Duration: 13, Last Available: "2021-12"
 10834	liquefied teal anti-goosebump cream	0		Effect: "Bread-Lined", Effect Duration: 45, Last Available: "2021-12"
 10835	wet flattened fuchsia anti-odor cream	0		Effect: "Can't Smell Nothin'", Effect Duration: 12, Last Available: "2021-12"
 10836	super-Vulcanized anti-creep cream	0		Effect: "The Grass...  Is Blue...", Effect Duration: 25, Last Available: "2021-12"
-10837	pickled alkaline blinking twirling anti-pain cream	0		Effect: "Perfect Hair", Effect Duration: 53, Last Available: "2021-12"
+10837	pickled alkaline twirling blinking anti-pain cream	0		Effect: "Perfect Hair", Effect Duration: 53, Last Available: "2021-12"
 10838	drinkable maroon Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
 10839	normal olive bread pie	3	good	Last Available: "2021-12"
 10840	bad clear Russian	3	decent	Last Available: "2021-12"
@@ -10706,7 +10706,7 @@
 10850	bouncing goo magnet	0		Last Available: "2021-12"
 10851	bouncing Newton's cozy scarf	0		Experience (Mysticality): +3, Last Available: "2021-12"
 10852	spoiled huge Crimbo cookie	3	crappy	Last Available: "2023-06"
-10853	adjusted jittery wobbly fleshy putty	0		Effect: "Feeling No Pain", Effect Duration: 51, Last Available: "2021-12"
+10853	adjusted wobbly jittery fleshy putty	0		Effect: "Feeling No Pain", Effect Duration: 51, Last Available: "2021-12"
 10854	third ear of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2021-12"
 10855	green festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	huge wicked depleted Crimbonium football helmet	0		Spell Damage: +5, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	snack-sized decent &quot;caramel&quot;	2	good	Last Available: "2021-12"
+10862	decent snack-sized &quot;caramel&quot;	2	good	Last Available: "2021-12"
 10863	tumbling self-repairing earmuffs of doom	0		Spooky Spell Damage: +50, Last Available: "2021-12"
 10864	ghostly shaking Annie Oakley's carnivorous potted plant	0		Critical Hit Percent: +20, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	red yule hatchet	0		Item Drop: +5, Last Available: "2021-12"
-10867	shaking yellow potato alarm clock	0		Last Available: "2021-12"
-10868	spoiled big lab-grown meat	5	crappy	Last Available: "2021-12"
+10867	yellow shaking potato alarm clock	0		Last Available: "2021-12"
+10868	big spoiled lab-grown meat	5	crappy	Last Available: "2021-12"
 10869	narrow pulsating scorching fleece	0		Hot Damage: +25, Last Available: "2021-12"
 10870	blurry boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10739,8 +10739,8 @@
 10883	pickled jittery bouncing astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	family-friendly Socratic magnifying glass of the overflowing toilet	0		Experience (Mysticality): +1, Stench Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2022-12"
-10886	hand-crafted weak void lager	2	EPIC	Last Available: "2022-12"
-10887	snack-sized stale void burger	2	decent	Last Available: "2022-12"
+10886	weak hand-crafted void lager	2	EPIC	Last Available: "2022-12"
+10887	stale snack-sized void burger	2	decent	Last Available: "2022-12"
 10888	squat void stone	0		Last Available: "2022-12"
 10889	greedy scorching Van der Graaf stiffened void shard	0		Damage Reduction: 1, Hot Damage: +25, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10761,15 +10761,15 @@
 10905	pulsating Temple Grandin's headlamp	0		Familiar Weight: +7, Lasts Until Rollover, Last Available: "2022-05"
 10906	greedy auspicious thermal blanket of mayonnaise	0		Sleaze Spell Damage: +50, Item Drop: +10, Meat Drop: +20, Lasts Until Rollover, Last Available: "2022-05"
 10907	huge hardy atlas of local maps	0		Maximum HP: +50, Lasts Until Rollover, Last Available: "2022-05"
-10908	dry spinning twirling spare battery	0		Effect: "Ham-Fisted", Effect Duration: 45, Last Available: "2022-05"
+10908	dry twirling spinning spare battery	0		Effect: "Ham-Fisted", Effect Duration: 45, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
 10910	modified yellow single-use dust mask	0		Effect: "Ooh, Sweet!", Effect Duration: 35, Last Available: "2022-05"
 10911	super-modified colloidal gaffer's tape	0		Effect: "Haunted Stomach", Effect Duration: 14, Last Available: "2022-05"
-10912	miniature bland tumbling 20-lb can of rice and beans	2	decent	Last Available: "2022-05"
+10912	bland miniature tumbling 20-lb can of rice and beans	2	decent	Last Available: "2022-05"
 10913	skewed bar of freeze-dried water	1	good	Last Available: "2022-05"
 10914	normal expired MRE	4	good	Last Available: "2022-05"
-10915	big flavorless cool mint precipice bar	5	decent	Last Available: "2022-05"
-10916	decent jumbo carrot cake precipice bar	5	good	Last Available: "2022-05"
+10915	flavorless big cool mint precipice bar	5	decent	Last Available: "2022-05"
+10916	jumbo decent carrot cake precipice bar	5	good	Last Available: "2022-05"
 10917	spinning The Big Book of Every Skill	0		
 10918	gray Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	oxidized boiled trampled ticket stub	0		Effect: "Amorphous Cheer", Effect Duration: 52, Last Available: "2022-06"
 10927	deionized nitrogenated savings bond	0		Effect: "Transcendental Wind", Effect Duration: 58, Last Available: "2022-06"
 10928	mirror designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	teal designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	teal designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	modified sweat-ade	1		Effect: "Very Clean Teeth", Effect Duration: 15, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	wobbly stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10828,31 +10828,31 @@
 10972	delicious gigantic fuchsia roasted vegetable of Jarlsberg	7	awesome	Last Available: "2022-11"
 10973	thick adequate St. Pete's sneaky smoothie	5	good	Last Available: "2022-11"
 10974	normal Pete's wiley whey bar	4	good	Last Available: "2022-11"
-10975	snack-sized normal Pete's rich ricotta	2	good	Last Available: "2022-11"
+10975	normal snack-sized Pete's rich ricotta	2	good	Last Available: "2022-11"
 10976	mediocre Boris's beer	3	decent	Last Available: "2022-11"
-10977	half-sized delicious honey bun of Boris	2	awesome	Last Available: "2022-11"
+10977	delicious half-sized honey bun of Boris	2	awesome	Last Available: "2022-11"
 10978	bland Boris's bread	3	decent	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	teal Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	blurry Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	twirling blurry teal Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	teal Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	blurry Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	twirling teal blurry Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	flavorless spinning baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
 10989	adequate squat plain calzone	3	good	Last Available: "2022-11"
 10990	immense adequate roasted vegetable focaccia	9	good	Last Available: "2022-11"
 10991	huge adequate shaking Pizza of Legend	10	good	Last Available: "2022-11"
-10992	decent gigantic Calzone of Legend	9	good	Last Available: "2022-11"
-10993	jittery blinking Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	bouncing Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	blurry Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	blinking Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10992	gigantic decent Calzone of Legend	9	good	Last Available: "2022-11"
+10993	blinking jittery Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	bouncing Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	blurry Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	blinking Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	flavorless Deep Dish of Legend	3	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	huge drink chit	0		
@@ -10867,10 +10867,10 @@
 11011	scandalous groovy gator shades	0		Moxie Percent: +10, Sleaze Damage: +5, Single Equip
 11012	yellow milk cap	0		
 11013	acceptable high-proof Charleston Choo-Choo	8	good	
-11014	delicious weak enchanted blurry Velvet Veil	2	awesome	Effect: "Inappropriate Spirit", Effect Duration: 5
+11014	enchanted weak delicious blurry Velvet Veil	2	awesome	Effect: "Inappropriate Spirit", Effect Duration: 5
 11015	bad Marltini	3	decent	
 11016	perfectly mixed Strong, Silent Type	3	EPIC	
-11017	triple-distilled lousy Mysterious Stranger	8	decent	
+11017	lousy triple-distilled Mysterious Stranger	8	decent	
 11018	perfectly mixed Champagne Shimmy	3	EPIC	
 11019	the Sot's parcel	0		
 11020	squat perfumed studded ceramic cestus	0		Damage Absorption: +80, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10922,10 +10922,10 @@
 11066	Crimbo crystal shards	0		
 11067	hand-crafted dregs of a Crimbo cocktail	3	EPIC	
 11068	lost elf luggage	0		
-11069	upside-down teal Trainbot luggage hook	0		Single Equip
+11069	teal upside-down Trainbot luggage hook	0		Single Equip
 11070	stale diet huge honey-drenched ham slice	1	decent	
-11071	high-proof mediocre mostly-empty bottle of cookie wine	9	decent	
-11072	super-sized normal green Crimbo food scraps	5	good	
+11071	mediocre high-proof mostly-empty bottle of cookie wine	9	decent	
+11072	normal super-sized green Crimbo food scraps	5	good	
 11073	arm towel	0		Last Available: "2022-12"
 11074	fuchsia automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
@@ -10951,7 +10951,7 @@
 11095	bouncing coward's Tesla forbidden grubby wool gloves of the businessman	0		Spell Damage Percent: +50, Monster Level: -20, Meat Drop: +50, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11096	yellow grubby wool beerwarmer	0		
 11097	fancy bad pulsating tumbling nice warm beer	3	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 25
-11098	gray spinning grubby woolball	0		
+11098	spinning gray grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	wobbly groveling gravel	0		Last Available: "2023-01"
@@ -10974,7 +10974,7 @@
 11119	altered five-fingered fern resin	0		Effect: "Knightlife", Effect Duration: 46, Last Available: "2023-02"
 11120	moldy super good fruit	3	crappy	Last Available: "2023-02"
 11121	compressed energized spores	1		Last Available: "2023-02"
-11122	shaking ribald occult hot pepper	0		Spell Damage Percent: +25, Sleaze Damage: +10, Last Available: "2023-02", Lantern Element: "Hot"
+11122	shaking ribald occult hot pepper	0		Spell Damage Percent: +25, Sleaze Damage: +10, Lantern Element: "Hot", Last Available: "2023-02"
 11123	adjusted bouncing out-of-work circus flea	0		Effect: "Shredding, Sweating", Effect Duration: 15, Last Available: "2023-02"
 11124	teal extra-grubby grub	0		Last Available: "2023-02"
 11125	triple-enhanced fire ant pheromones	0		Effect: "Salt Rockin'", Effect Duration: 48, Last Available: "2023-02"
@@ -10992,7 +10992,7 @@
 11137	warmed mirror shadow flame	0		Effect: "Tearful, Fearful", Effect Duration: 56, Last Available: "2023-03"
 11138	bland ghostly narrow shadow bread	4	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	aged practically non-alcoholic shadow fluid	1	awesome	Last Available: "2023-03"
+11140	practically non-alcoholic aged shadow fluid	1	awesome	Last Available: "2023-03"
 11141	ghostly shadow glass	0		Last Available: "2023-03"
 11142	shaking shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11022,7 +11022,7 @@
 11167	shadowy cheat sheet	0		Free Pull
 11168	bouncing pulsating closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
-11170	ghostly cyan shadow lighter	0		
+11170	cyan ghostly shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	pulsating shadow snowflake	0		
 11173	shadow heart	0		
@@ -11036,7 +11036,7 @@
 11181	narrow shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	spoiled ghostly shadow hot dog	3	crappy	
 11183	drinkable shadow martini	4	good	
-11184	dehydrated lime green tumbling shadow pill	1		
+11184	dehydrated tumbling lime green shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	squat monkey glove	0		Free Pull, Last Available: "2023-04"
@@ -11083,7 +11083,7 @@
 11228	replica puck	0		
 11229	replica Chateau Mantegna room key	0		
 11230	yellow replica Deck of Every Card	0		
-11231	cyan ghostly replica Source terminal	0		
+11231	ghostly cyan replica Source terminal	0		
 11232	purple replica disconnected intergnat	0		
 11233	olive replica Witchess Set	0		
 11234	replica genie bottle	0		
@@ -11107,7 +11107,7 @@
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	family-friendly hardy Rosewater's replica Cincho de Mayo of temperance	0		Mysticality Percent: +30, Maximum HP: +50, Sleaze Resistance: 6, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
-11255	upside-down pulsating purple Thwaitgold splendor beetle statuette	0		
+11255	upside-down purple pulsating Thwaitgold splendor beetle statuette	0		
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	mirror skewed lightning-fast Jeselnik's horrifying quilted personal trainer's &quot;I survived Y2K&quot; T-Shirt of temperance	0		Experience Percent (Muscle): +10, Damage Absorption: +40, Spooky Damage: +25, Sleaze Damage: +25, Sleaze Resistance: +5, Initiative: +40, Single Equip, Last Available: "2023-06"
@@ -11117,7 +11117,7 @@
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	upside-down Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	gray Jim Carey's Flash Liquidizer Ultra Dousing Accessory	0		Monster Level: +25, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	shaking stanky mansplainer's strapping Amulet of Perpetual Darkness of horror	0		Muscle: +5, Monster Level: +15, Stench Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2023-06"
 11268	tumbling Giant monolith	0		Last Available: "2023-06"
@@ -11127,14 +11127,14 @@
 11272	Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	bouncing Azurite	0		Last Available: "2023-06"
-11275	spinning narrow Arrow (+1)	0		Last Available: "2023-06"
+11275	narrow spinning Arrow (+1)	0		Last Available: "2023-06"
 11276	non-pressed scroll of protection from lycanthropes	0		Effect: "Flamingly Floral", Effect Duration: 43, Last Available: "2023-06"
 11277	tumbling Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	mirror Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	mediocre practically non-alcoholic enchanted Sexy Cosmo	1	decent	Effect: "Serendipi Tea", Effect Duration: 50, Last Available: "2023-06"
+11282	enchanted mediocre practically non-alcoholic Sexy Cosmo	1	decent	Effect: "Serendipi Tea", Effect Duration: 50, Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	blinking dance instructor's red-soled high heels of the pedagogue of the cheetah	0		Experience: +3, Experience Percent (Moxie): +10, Initiative: +60, Last Available: "2023-06"
 11285	jumbo spoiled jittery blinking cyburger	5	crappy	Last Available: "2025-12"
@@ -11172,10 +11172,10 @@
 11317	blurry handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	watered-down lousy bottle of Cabernet Sauvignon	2	decent	
+11320	lousy watered-down bottle of Cabernet Sauvignon	2	decent	
 11321	pulsating avaricious wholesome deadly baywatch	0		Weapon Damage: +5, Maximum HP Percent: +10, Meat Drop: +30, Lasts Until Rollover
-11322	skewed Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	huge Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	skewed Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	huge Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	tumbling consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11184,7 +11184,7 @@
 11329	diluted lime green meat	1		Effect: "Serenity", Effect Duration: 20
 11330	compressed sparkling orb	1		Effect: "Sewer-Drenched", Effect Duration: 40
 11331	vaporized purple hardening cream	1		
-11332	denatured teal squat wobbly pool shark hair oil	1		
+11332	denatured squat wobbly teal pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11222,7 +11222,7 @@
 11367	shaking Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	automa-bot parts	0		
-11370	ghostly lime green security automa-core	0		
+11370	lime green ghostly security automa-core	0		
 11371	clerical automa-core	0		
 11372	fuchsia handful of Boltsmann bearings	0		
 11373	shaking Spring Bros. solenoid	0		
@@ -11274,7 +11274,7 @@
 11419	supercharged brawny Elf Guard broom	0		Muscle Percent: +20, Maximum MP Percent: +30, Last Available: "2023-12"
 11420	bouncing lion tamer's Annie Oakley's Crimbuccaneer tavern swab of the early riser	0		Critical Hit Percent: +20, Experience (familiar): +2, Adventures: +7, Last Available: "2023-12"
 11421	wobbly Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	strong smooth special mirror jittery old-school pirate grog	5	awesome	Effect: "Mercenary", Effect Duration: 45, Last Available: "2023-12"
+11422	strong special smooth jittery mirror old-school pirate grog	5	awesome	Effect: "Mercenary", Effect Duration: 45, Last Available: "2023-12"
 11423	thick spoiled grog nuts	5	crappy	Last Available: "2023-12"
 11424	lime green Annie Oakley's MacGyver's rosy-cheeked sawed-off blunderbuss	0		Maximum HP Percent: +30, Maximum MP: +100, Critical Hit Percent: +20, Last Available: "2023-12"
 11425	artisanal officer's nog	4	EPIC	Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	teal curative Herculean wizardly Elf Guard clipboard	0		Mysticality: +25, Experience (Muscle): +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
 11435	quilted pegfinger	0		Damage Absorption: +40, Single Equip, Last Available: "2023-12"
-11436	enchanted practically non-alcoholic artisanal and claret	1	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 10, Last Available: "2023-12"
+11436	practically non-alcoholic artisanal enchanted and claret	1	EPIC	Effect: "Bustle Hustlin'", Effect Duration: 10, Last Available: "2023-12"
 11437	wobbly brawny Elf Guard and beret	0		Muscle Percent: [+20*event(December)], Last Available: "2023-12"
 11438	foul-smelling smooth thinker's shipwright's hammer	0		Mysticality: +10, Moxie: +15, Stench Damage: +10, Last Available: "2023-12"
 11439	knitted smelly sizzling gunwale	0		Hot Damage: +10, Stench Spell Damage: +10, Cold Resistance: +3, Damage Reduction: 9, Last Available: "2023-12"
@@ -11306,28 +11306,28 @@
 11451	huge punching mirror	0		Last Available: "2023-12"
 11452	toasty medical-grade rock-hard fortified smartaleck's stylish Elf dessert spoon	0		Moxie: +25, Moxie Percent: +30, Damage Absorption: +60, Damage Reduction: 5, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11453	blinking Annie Oakley's Newton's Elf Guard SCUBA tank	0		Experience (Mysticality): +3, Critical Hit Percent: +20, Last Available: "2023-12"
-11454	spinning upside-down Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
+11454	upside-down spinning Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11455	frightening studded free boots	0		Damage Absorption: +80, Spooky Damage: +5, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	careful chaotic arcane researcher's Elvish underarmor	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Monster Level: -10, Single Equip, Last Available: "2023-12"
 11458	Jim Carey's chaotic Crimbuccaneer bombjacket	0		Spell Critical Percent: +10, Monster Level: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	spoiled blurry sugarplum ration	4	crappy	Last Available: "2023-12"
-11460	half-sized moldy gingerbread nylons	2	crappy	Last Available: "2023-12"
-11461	super-sized bland skewed rum-soaked fruitcake	5	decent	Last Available: "2023-12"
+11460	moldy half-sized gingerbread nylons	2	crappy	Last Available: "2023-12"
+11461	bland super-sized skewed rum-soaked fruitcake	5	decent	Last Available: "2023-12"
 11462	gigantic bland lime	8	decent	Last Available: "2023-12"
-11463	fancy flavorless small gingerbread pirate	2	decent	Effect: "Bark of the Dog", Effect Duration: 10, Last Available: "2023-12"
+11463	small fancy flavorless gingerbread pirate	2	decent	Effect: "Bark of the Dog", Effect Duration: 10, Last Available: "2023-12"
 11464	bland fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
 11465	acceptable ghostly mulled wine	3	good	Last Available: "2023-12"
 11466	artisanal Swedish coffee	4	EPIC	Last Available: "2023-12"
-11467	artisanal high-proof canteen of eggnog	8	EPIC	Last Available: "2023-12"
-11468	drinkable watered-down wobbly hot wine	2	good	Last Available: "2023-12"
-11469	enchanted mediocre squat Jamaican coffee	3	decent	Effect: "You Know Where to Go", Effect Duration: 50, Last Available: "2023-12"
+11467	high-proof artisanal canteen of eggnog	8	EPIC	Last Available: "2023-12"
+11468	watered-down drinkable wobbly hot wine	2	good	Last Available: "2023-12"
+11469	mediocre enchanted squat Jamaican coffee	3	decent	Effect: "You Know Where to Go", Effect Duration: 50, Last Available: "2023-12"
 11470	hand-crafted flask of egggrog	3	super EPIC	Last Available: "2023-12"
-11471	purple twirling Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
+11471	twirling purple Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	tumbling pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	watered-down drinkable special twirling yule grog	2	good	Effect: "Hennaliciousness", Effect Duration: 10, Last Available: "2023-12"
-11475	moldy thick pulsating shaking pulsating wet tack	5	crappy	Last Available: "2023-12"
+11474	drinkable watered-down special twirling yule grog	2	good	Effect: "Hennaliciousness", Effect Duration: 10, Last Available: "2023-12"
+11475	thick moldy pulsating shaking pulsating wet tack	5	crappy	Last Available: "2023-12"
 11476	adequate jittery whalecake	3	good	Last Available: "2023-12"
 11477	miser's flame-retardant curative gunwale whalegun	0		Hot Resistance: +1, Meat Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	mediocre boozy and claret	5	decent	Last Available: "2023-12"
@@ -11346,7 +11346,7 @@
 11491	skewed narrow hale dangerous Crimbuccaneer nose ring of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Maximum HP: +20, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	teal mirror Elf Guard safety bear	0		Last Available: "2023-12"
+11494	mirror teal Elf Guard safety bear	0		Last Available: "2023-12"
 11495	shaking kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11363,14 +11363,14 @@
 11508	moss mantle of chilblains of the blizzard	0		Cold Damage: +25, Cold Spell Damage: +25, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	aromatic baleful moss marlinspike	0		Spell Damage: +25, Stench Resistance: +1, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	distilled spinning moss mulch	1		Last Available: "2024-12"
-11511	anodized anodized green shaking moss floss	0		Effect: "Vitali Tea", Effect Duration: 43
+11511	anodized anodized shaking green moss floss	0		Effect: "Vitali Tea", Effect Duration: 43
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	adobe ayam	0		Last Available: "2024-12"
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
-11518	vaporized skewed blurry spinning fuchsia adobe assortment	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 50, Last Available: "2024-12"
+11518	vaporized skewed blurry fuchsia spinning adobe assortment	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 50, Last Available: "2024-12"
 11519	pressed bouncing adobe brittle	0		Effect: "Ancient Protected", Effect Duration: 50
 11520	up-at-dawn banded strapping crepe paper phrygian cap	0		Muscle: +5, Damage Absorption: +100, Adventures: +5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	foul-smelling Rosewater's savvy crepe paper parachute cape	0		Mysticality Percent: 50, Stench Damage: +10, Last Available: "2025-12"
@@ -11382,8 +11382,8 @@
 11527	concentrated frozen nitrogenated crepe paper peanut candy	0		Effect: "Sewer-Drenched", Effect Duration: 60
 11528	wobbly spinning hardy veiny petrified wood war pike	0		Maximum HP: 60, Last Available: "2025-12"
 11529	teal knitted nasty petrified wood waist protector	0		Stench Damage: +5, Cold Resistance: +3, Single Equip, Last Available: "2025-12"
-11530	rosewater-soaked boxer's petrified wood wizard's pouch	0		Muscle Percent: +10, Stench Resistance: +3, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	stanky fortified petrified wood water purifier	0		Damage Absorption: +60, Stench Spell Damage: +25, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	rosewater-soaked boxer's petrified wood wizard's pouch	0		Muscle Percent: +10, Stench Resistance: +3, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	stanky fortified petrified wood water purifier	0		Damage Absorption: +60, Stench Spell Damage: +25, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	dog trainer's deadly petrified wood whoopie panama	0		Weapon Damage: +5, Experience (familiar): +1, Last Available: "2025-12"
 11533	friendly Fonzie's petrified wood walking pants	0		Experience (Moxie): +1, Familiar Weight: +3, Last Available: "2025-12"
 11534	twisted purple petrified wood waste parts	1		Last Available: "2025-12"
@@ -11428,25 +11428,25 @@
 11573	delicious yam	4	awesome	Last Available: "2024-05"
 11574	weak perfectly mixed yam martini	2	EPIC	Last Available: "2024-05"
 11575	mediocre sweet potato o' mine	4	decent	Last Available: "2024-05"
-11576	fortified bad Southern yam	5	decent	Last Available: "2024-05"
+11576	bad fortified Southern yam	5	decent	Last Available: "2024-05"
 11577	smooth sweet potato punch	3	awesome	Last Available: "2024-05"
 11578	spoiled Mayam spinach	4	crappy	Last Available: "2024-05"
 11579	flavorless yam and swiss	4	decent	Last Available: "2024-05"
 11580	teal pulsating wobbly deadly yam cannon of the ox of the empath	0		Muscle: +20, Weapon Damage: +5, Familiar Weight: +5, Lasts Until Rollover, Last Available: "2024-05"
 11581	pulsating yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
-11582	upside-down shaking yam battery	0		Last Available: "2024-05"
+11582	shaking upside-down yam battery	0		Last Available: "2024-05"
 11583	mirror yam stinkbomb	0		Last Available: "2024-05"
 11584	cyan perfumed knitted wool furry yam buckler	0		Cold Resistance: 4, Stench Resistance: +5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	red therapeutic shellacked occult yamtility belt	0		Spell Damage Percent: +25, Damage Reduction: 7, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-05"
 11587	bland yam slider	3	decent	Last Available: "2024-05"
-11588	massive enchanted moldy yam mayo	8	crappy	Effect: "Soles of Glass", Effect Duration: 25, Last Available: "2024-05"
+11588	enchanted massive moldy yam mayo	8	crappy	Effect: "Soles of Glass", Effect Duration: 25, Last Available: "2024-05"
 11589	normal yam burrito	4	good	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	blinking Thwaitgold Illinigina illinoiensis model	0		
-11594	half-sized spoiled spinning mini kiwi	2	crappy	Last Available: "2024-06"
+11594	spoiled half-sized spinning mini kiwi	2	crappy	Last Available: "2024-06"
 11595	pulsating Lo Pan's quilted extremely unsafe mini kiwi bikini	0		Weapon Damage Percent: +100, Damage Absorption: +40, Spell Critical Percent: +30, Last Available: "2024-06"
 11596	mediocre strong mini kiwitini	5	decent	Last Available: "2024-06"
 11597	purple mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11487,7 +11487,7 @@
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	skewed tattoo gun	0		
-11635	perfectly mixed irresponsibly strong red Colera Peste Nebbiolo	8	EPIC	
+11635	irresponsibly strong perfectly mixed red Colera Peste Nebbiolo	8	EPIC	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11526,7 +11526,7 @@
 11671	quilted photo booth supply list of the brazier	0		Damage Absorption: +40, Hot Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	ghostly peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	spoiled big enchanted whirled peas	5	crappy	Effect: "Mutated", Effect Duration: 5, Last Available: "2024-11"
+11674	spoiled enchanted big whirled peas	5	crappy	Effect: "Mutated", Effect Duration: 5, Last Available: "2024-11"
 11675	half-sized bland peaza	2	decent	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	mixed drenchrome 2.0	1		Last Available: "2025-12"
@@ -11534,9 +11534,9 @@
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
-11682	moist wet spinning pulsating pea brittle	0		Effect: "Baconstoned", Effect Duration: 63, Last Available: "2024-11"
+11682	moist wet pulsating spinning pea brittle	0		Effect: "Baconstoned", Effect Duration: 63, Last Available: "2024-11"
 11683	artisanal blinking peasco	3	EPIC	Last Available: "2024-11"
-11684	jumbo spoiled piece of cake	5	crappy	Last Available: "2024-11"
+11684	spoiled jumbo piece of cake	5	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11551,7 +11551,7 @@
 11696	upside-down tumbling prompt governor's daughter's lace collar	0		Adventures: +3, Last Available: "2024-12"
 11697	hardened governor's daughter's petticoats	0		Damage Reduction: 3, Last Available: "2024-12"
 11698	governor's daughter's pearl hairpin of Gandalf	0		Spell Critical Percent: +20, Last Available: "2024-12"
-11699	olive squat harpoon	0		Last Available: "2024-12"
+11699	squat olive harpoon	0		Last Available: "2024-12"
 11700	wobbly red MacGyver's chili powder cutlass	0		Maximum MP: +100, Last Available: "2024-12"
 11701	half-sized decent Aztec tamale	2	good	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
@@ -11562,8 +11562,8 @@
 11707	narrow grievous silky pirate drawers of Gandalf	0		Weapon Damage Percent: +50, Spell Critical Percent: +20, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	modified peppermint pegleg	0		Effect: "Provocative Perkiness", Effect Duration: 51, Last Available: "2024-12"
-11710	lousy weak hard cocoa	2	decent	Last Available: "2024-12"
-11711	tasty half-sized salmagumdi	2	awesome	Last Available: "2024-12"
+11710	weak lousy hard cocoa	2	decent	Last Available: "2024-12"
+11711	half-sized tasty salmagumdi	2	awesome	Last Available: "2024-12"
 11712	wicked plastic Easter Island Bunny	0		Spell Damage: +5, Last Available: "2024-12"
 11713	friendly plastic St. Patrick	0		Familiar Weight: +3, Last Available: "2024-12"
 11714	blurry censurious plastic Colonel Brando of the boozehound	0		Sleaze Resistance: +3, Booze Drop: +100, Last Available: "2024-12"
@@ -11576,12 +11576,12 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	normal diet coney haunch	1	good	Last Available: "2024-12"
 11723	adjusted bouncing dark chocolate egg	0		Effect: "Greasy Visage", Effect Duration: 21, Last Available: "2024-12"
-11724	acceptable pulsating wobbly moai toai	3	good	
+11724	acceptable wobbly pulsating moai toai	3	good	
 11725	green auspicious sharpshooter's moaiball of the scaredy-cat	0		Critical Hit Percent: +10, Monster Level: -15, Item Drop: +10, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	pressed four-leaf potato sprout	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 59, Last Available: "2024-12"
 11728	experienced potato jacket of terror of the sweet-tooth	0		Experience: +2, Spooky Spell Damage: +10, Candy Drop: +100, Last Available: "2024-12"
-11729	squat shaking lime green traumatic holiday memory	0		Last Available: "2024-12"
+11729	lime green squat shaking traumatic holiday memory	0		Last Available: "2024-12"
 11730	spinning Brandonian footlocker key	0		Last Available: "2024-12"
 11731	jittery dangerous military orb of the brazier	0		Weapon Damage: +10, Hot Spell Damage: +25, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	concentrated rum ball	0		Effect: "Sepia Tan", Effect Duration: 32
@@ -11591,7 +11591,7 @@
 11736	veiny gravyskin skirt of Tarzan	0		Experience (Muscle): +3, Maximum HP: +10, Last Available: "2024-12"
 11737	twirling wobbly electrified gravyskin pants of chilblains	0		Cold Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12"
 11738	dry magnetized mirror fuchsia crystallized pumpkin spice	0		Effect: "PERL of Great Price", Effect Duration: 67, Last Available: "2024-12"
-11739	half-sized flavorless room scale bean casserole	2	decent	Last Available: "2024-12"
+11739	flavorless half-sized room scale bean casserole	2	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	auspicious perfect Christmas scarf of the blizzard	0		Cold Spell Damage: [+25*event(December)], Item Drop: [15*event(December)], Single Equip, Last Available: "2024-12"
@@ -11610,23 +11610,23 @@
 11755	rotten candy rations	3	crappy	Last Available: "2024-12"
 11756	stale double-candied yams	4	decent	Last Available: "2024-12"
 11757	stale wobbly Christmas ham	3	decent	Last Available: "2024-12"
-11758	toothsome blinking wobbly holiday smorgasbord	3	awesome	Last Available: "2024-12"
+11758	toothsome wobbly blinking holiday smorgasbord	3	awesome	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	yellow twirling flame-retardant bejazzled eyepatch	0		Hot Resistance: +1, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	huge How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	huge How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	blue blurry Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	squat Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	blinking Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	fuchsia Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	huge How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	huge How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	blue blurry Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	squat Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	blinking Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	fuchsia Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	twirling moai statuette	0		Last Available: "2024-12"
 11772	greedy Oprah's quilted wizardly egg gun	0		Mysticality: +25, Damage Absorption: +40, Maximum MP Percent: +50, Meat Drop: +20, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	coward's therapeutic slick strapping army helmet	0		Muscle: +5, Moxie: +10, Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
-11774	huge wobbly candy egg deviler	0		Last Available: "2024-12"
+11774	wobbly huge candy egg deviler	0		Last Available: "2024-12"
 11775	cyan napkin	0		Last Available: "2024-12"
 11776	flavorless Thanksgiving ration	4	decent	Last Available: "2024-12"
 11777	tolerable pulsating Easter eggnog	3	good	Last Available: "2024-12"
@@ -11646,7 +11646,7 @@
 11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
-11794	shaking lime green dedigitizer schematic: malware injector	0		Last Available: "2025-12"
+11794	lime green shaking dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
@@ -11673,7 +11673,7 @@
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	jittery dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	ghostly dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
-11821	tumbling huge SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
+11821	huge tumbling SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
@@ -11686,7 +11686,7 @@
 11831	ninja crampons	0		
 11832	ninja carabiner	0		
 11833	frozen galvanized synthetic coffee	0		Effect: "Object Detection", Effect Duration: 30
-11834	triple-dry blinking wobbly iDrops	0		Effect: "Fastbreaker", Effect Duration: 12
+11834	triple-dry wobbly blinking iDrops	0		Effect: "Fastbreaker", Effect Duration: 12
 11835	narrow shame coil	0		
 11836	shaking new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
@@ -11708,7 +11708,7 @@
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	red grim cellophane	0		Combat Rate: -5
 11855	narrow rift oculus	0		Combat Rate: +5
-11856	skewed lime green sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11856	lime green skewed sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	jittery glover liners	0		Pickpocket Chance: +10
 11859	upside-down mosquito speakers	0		Monster Level: +5
@@ -11716,16 +11716,16 @@
 11861	jittery Leprecondo	0		Last Available: "2025-03"
 11862	pickled bouncing scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	tumbling table tennis ball	0		Last Available: "2025-03"
-11864	strong artisanal pint of Leprechaun Stout	5	EPIC	Last Available: "2025-03"
+11864	artisanal strong pint of Leprechaun Stout	5	EPIC	Last Available: "2025-03"
 11865	powdered phosphor traces	1		Last Available: "2025-03"
 11866	pulsating crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	teal spoon	0		
 11869	unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
-11871	twisted pulsating blurry leprechaun antidepressant pill	1		Last Available: "2025-03"
+11871	twisted blurry pulsating leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	low-calorie moldy Heck ramen	1	crappy	Last Available: "2025-03"
-11873	flavorless half-sized special burrito	2	decent	Effect: "The Sweats", Effect Duration: 15, Last Available: "2025-03"
+11873	special half-sized flavorless burrito	2	decent	Effect: "The Sweats", Effect Duration: 15, Last Available: "2025-03"
 11874	decent small beer brat	3	good	Last Available: "2025-03"
 11875	jumbo delicious peach pie	5	awesome	Last Available: "2025-03"
 11876	adequate incredible mini-pizza	3	good	Last Available: "2025-03"
@@ -11733,7 +11733,7 @@
 11878	bad tangarita sidecar	3	decent	Last Available: "2025-03"
 11879	watered-down hand-crafted gimlet sidecar	2	EPIC	Last Available: "2025-03"
 11880	bad vodka stratocaster sidecar	4	decent	Last Available: "2025-03"
-11881	lousy watered-down wobbly prussian cathouse sidecar	2	decent	Last Available: "2025-03"
+11881	watered-down lousy wobbly prussian cathouse sidecar	2	decent	Last Available: "2025-03"
 11882	weak artisanal Mon Tiki sidecar	2	EPIC	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	tumbling jittery beefy April Shower Thoughts shield of the businessman	0		Muscle: +10, Meat Drop: +50, Damage Reduction: 6, Last Available: "2025-04"
@@ -11741,7 +11741,7 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	galvanized polarized wet paper weights	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 40, Last Available: "2025-04"
 11888	bad twirling Three Sheets to the Wind	3	decent	Last Available: "2025-04"
-11889	special bland big teal pile of wet dates	5	decent	Effect: "Livin' Large", Effect Duration: 5, Last Available: "2025-04"
+11889	big bland special teal pile of wet dates	5	decent	Effect: "Livin' Large", Effect Duration: 5, Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	narrow lion tamer's wet shower cap	0		Experience (familiar): +2, Last Available: "2025-04"
@@ -11769,8 +11769,8 @@
 11914	tumbling sage imposing pilgrim's hat	0		Mysticality Percent: +10
 11915	crown of thorns	0		
 11916	supercharged stylish bycocket	0		Maximum MP Percent: +30
-11917	ghostly wobbly Thwaitgold mad hatterpillar statuette	0		
-11918	maroon jittery packaged prismatic beret	0		Free Pull
+11917	wobbly ghostly Thwaitgold mad hatterpillar statuette	0		
+11918	jittery maroon packaged prismatic beret	0		Free Pull
 11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
@@ -11779,11 +11779,11 @@
 11924	Axis helmet of mayonnaise of the detective	0		Sleaze Spell Damage: +50, Item Drop: +20
 11925	shaking horrifying smartaleck's Axis fatigues	0		Moxie Percent: +30, Spooky Damage: +25
 11926	Herculean Axis suspenders of the cheetah	0		Experience (Muscle): +1, Initiative: +60, Single Equip
-11927	wobbly squat stolen artifact	0		
+11927	squat wobbly stolen artifact	0		
 11928	really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	skewed chocolate rations	0		
-11931	huge upside-down nice nylon stockings	0		
+11931	upside-down huge nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	mirror reassuring gravedigger's Temple Grandin's Allied Radio Backpack	0		Familiar Weight: +7, Spooky Damage: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
@@ -11805,7 +11805,7 @@
 11950	weightlifter's time cop top hat	0		Muscle: +15, Last Available: "2025-08"
 11951	olive Stock Certificate	0		Last Available: "2025-08"
 11952	mixed mixed berry jelly	1		Last Available: "2025-08"
-11953	spoiled diet toast with mixed berry jelly	1	crappy	Last Available: "2025-08"
+11953	diet spoiled toast with mixed berry jelly	1	crappy	Last Available: "2025-08"
 11954	small stale cup of sugar	2	decent	Last Available: "2025-08"
 11955	stale Susie's cupcake	3	decent	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
@@ -11814,14 +11814,14 @@
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	blue dance instructor's undersea surveying goggles	0		Experience Percent (Moxie): +10, Lasts Until Rollover
-11963	weak aged Ocean-Touched Rum	2	awesome	
+11963	aged weak Ocean-Touched Rum	2	awesome	
 11964	mixed jittery water-logged pill	1		
-11965	moldy diet teal kelp puck	1	crappy	
+11965	diet moldy teal kelp puck	1	crappy	
 11966	tumbling scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
-11970	upside-down squat sea gel	0		
+11970	squat upside-down sea gel	0		
 11971	cold-filtered octopus ink bladder	0		Effect: "Elron's Explosive Etude", Effect Duration: 14
 11972	skewed durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
@@ -11842,11 +11842,11 @@
 12052	tolerable shaking fuchsia Smoking Pope	3	good	
 12053	spoiled prize turkey	3	crappy	
 12054	modified blurry pulsating medicinal gruel	1		
-12055	bite-sized flavorless tumbling narrow wobbly full-sized pumpkin pie	1	decent	Last Available: "2025-11"
+12055	flavorless bite-sized wobbly narrow tumbling full-sized pumpkin pie	1	decent	Last Available: "2025-11"
 12056	acceptable weak vodka cranberry sauce	2	good	Last Available: "2025-11"
 12057	non-Vulcanized dry ghostly yammed candy	0		Effect: "Ocelot Eyes", Effect Duration: 18, Last Available: "2025-11"
 12058	snack-sized normal treasure chestnut	2	good	Last Available: "2025-12"
-12059	bad practically non-alcoholic jittery mulled butter rum	1	decent	Last Available: "2025-12"
+12059	practically non-alcoholic bad jittery mulled butter rum	1	decent	Last Available: "2025-12"
 12060	pickled corrupted cinnamon doubloon	0		Effect: "Jittery", Effect Duration: 59, Last Available: "2025-12"
 12061	plastic left skeleton arm of terror	0		Spooky Spell Damage: +10, Last Available: "2025-12"
 12062	blurry plastic left skeleton leg of Flo-Jo	0		Initiative: +100, Last Available: "2025-12"
@@ -11879,8 +11879,8 @@
 12121	wobbly Crymbocurrency	0		Last Available: "2025-12"
 12122	tumbling lightning-fast extra-thick Crimbo sweater	0		Initiative: +40, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	special triple-distilled mediocre Steve Abrams' Holiday Sampler Beer	10	decent	Effect: "Floundering", Effect Duration: 50, Last Available: "2025-12"
-12125	gray blinking squat crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
+12124	mediocre triple-distilled special Steve Abrams' Holiday Sampler Beer	10	decent	Effect: "Floundering", Effect Duration: 50, Last Available: "2025-12"
+12125	squat blinking gray crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	bad practically non-alcoholic special olive bottle of prize-winning rum	1	decent	Effect: "Disco Concentration", Effect Duration: 25, Last Available: "2025-12"
 12127	sizzling Sinatra's Santa-Slayer medal of extreme caution	0		Experience (Moxie): +5, Monster Level: -25, Hot Damage: +10, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
@@ -11891,7 +11891,7 @@
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
-12136	ghostly green volatile bone bomb	0		Last Available: "2025-12"
+12136	green ghostly volatile bone bomb	0		Last Available: "2025-12"
 12137	purple fireproof wholesome hot boning knife of the empath	0		Maximum HP Percent: +10, Familiar Weight: +5, Hot Resistance: +3, Single Equip, Last Available: "2025-12"
 12138	rosy-cheeked sinister wicked fistbone	0		Spell Damage: 15, Maximum HP Percent: +30, Last Available: "2025-12"
 12139	occult Rosewater's burnt bone belt of the early riser	0		Mysticality Percent: +30, Spell Damage Percent: +25, Adventures: +7, Single Equip, Last Available: "2025-12"
@@ -11915,7 +11915,7 @@
 12157	ghostly Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	squat Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	yellow Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
-12160	huge tumbling Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12160	tumbling huge Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	olive Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
@@ -11932,7 +11932,7 @@
 12174	hand-crafted shaking &quot;salvaged&quot; wine	3	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	moldy snack-sized wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
+12177	snack-sized moldy wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
 12178	flattened colloidal skewed gummi fingerbone	0		Effect: "Cold Jellied", Effect Duration: 56
 12179	coward's occult glimmering crystal	0		Spell Damage Percent: +25, Monster Level: -20, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11949,7 +11949,7 @@
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	double-quantum polymerized polymerized Pork Elf mouthwash	0		Effect: "All Is Forgiven", Effect Duration: 52, Last Available: "2026-03"
-12194	enhanced non-polymerized aerosolized ghostly wobbly green Pork Elf deodorant	0		Effect: "Spiritually Awake", Effect Duration: 49, Last Available: "2026-03"
+12194	enhanced non-polymerized aerosolized ghostly green wobbly Pork Elf deodorant	0		Effect: "Spiritually Awake", Effect Duration: 49, Last Available: "2026-03"
 12195	cold-filtered blue huge Pork Elf toothpaste	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 23, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
 12197	dog trainer's and dress of the sweet-tooth	0		Experience (familiar): +1, Candy Drop: +100, Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	purple Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	moldy tumbling tumbling narrow rat pizza	4	crappy	Last Available: "2026-03"
+12209	moldy narrow tumbling tumbling rat pizza	4	crappy	Last Available: "2026-03"
 12210	bouncing jittery Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	avaricious vibrating personal trainer's hoverboard	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Meat Drop: +30, Single Equip, Last Available: "2026-03"
 12212	scandalous Van der Graaf left shark fin of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-03"
@@ -11977,24 +11977,24 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	stale mirror fuchsia can of tuna	3	decent	
-12227	big rotten alien salad	5	crappy	
-12228	low-calorie stale upside-down cyan ratbatatouille	1	decent	
+12226	stale fuchsia mirror can of tuna	3	decent	
+12227	rotten big alien salad	5	crappy	
+12228	low-calorie stale cyan upside-down ratbatatouille	1	decent	
 12229	adequate olive onigiri	4	good	
 12230	normal crudit&eacute;s	3	good	
 12231	tasty mirror sauced mutton	3	awesome	
 12232	rotten hot honey ant	3	crappy	
-12233	flavorless small jittery tomb aspic	2	decent	
+12233	small flavorless jittery tomb aspic	2	decent	
 12234	rotten huge huge later tots	9	crappy	
-12235	fancy rotten Frutti di Scatoletta	4	crappy	Effect: "Red Door Syndrome", Effect Duration: 40, Last Available: "2026-05"
-12236	enchanted flavorless Pesto alla Marziano	4	decent	Effect: "Unusual Perspective", Effect Duration: 45, Last Available: "2026-05"
+12235	rotten fancy Frutti di Scatoletta	4	crappy	Effect: "Red Door Syndrome", Effect Duration: 40, Last Available: "2026-05"
+12236	flavorless enchanted Pesto alla Marziano	4	decent	Effect: "Unusual Perspective", Effect Duration: 45, Last Available: "2026-05"
 12237	delicious cyan Arrattabbattabiata	3	awesome	Last Available: "2026-05"
-12238	rotten snack-sized huge Orzo di Riso	2	crappy	Last Available: "2026-05"
+12238	snack-sized rotten huge Orzo di Riso	2	crappy	Last Available: "2026-05"
 12239	bland spinning Pasta Grimavera	3	decent	Last Available: "2026-05"
-12240	stale jumbo Linguini Ubriacapa	5	decent	Last Available: "2026-05"
-12241	enchanted rotten big Formica e Pepe	5	crappy	Effect: "Crud&eacute;", Effect Duration: 20, Last Available: "2026-05"
+12240	jumbo stale Linguini Ubriacapa	5	decent	Last Available: "2026-05"
+12241	big rotten enchanted Formica e Pepe	5	crappy	Effect: "Crud&eacute;", Effect Duration: 20, Last Available: "2026-05"
 12242	super-sized bland blinking Tubetto Gelatto	5	decent	Last Available: "2026-05"
-12243	enchanted delicious Gnocci Domani	3	awesome	Effect: "Chain Chain Chains", Effect Duration: 30, Last Available: "2026-05"
+12243	delicious enchanted Gnocci Domani	3	awesome	Effect: "Chain Chain Chains", Effect Duration: 30, Last Available: "2026-05"
 12244	blinking Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12019,8 +12019,8 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	chaotic hardy Portable Laughing Stock of horror	0		Maximum HP: +50, Spell Critical Percent: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	gray stylish Staff of Anachronistic Churning of Calamity Jane of chilblains	0		Moxie: +25, Critical Hit Percent: +15, Cold Damage: +25
-12272	miniature spoiled classic banana	2	crappy	Last Available: "2026-07"
-12273	massive spoiled watermelon	6	crappy	Last Available: "2026-07"
+12272	spoiled miniature classic banana	2	crappy	Last Available: "2026-07"
+12273	spoiled massive watermelon	6	crappy	Last Available: "2026-07"
 12274	miniature moldy quince	2	crappy	Last Available: "2026-07"
 12275	gray spinning Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
@@ -12033,12 +12033,12 @@
 12283	non-energized energized twirling concentrated watermelon juice	0		Effect: "Lemon Enlightenment", Effect Duration: 39, Last Available: "2026-07"
 12284	denatured Aqua Citrulanatae	0		Effect: "The Smeezingtons", Effect Duration: 42, Last Available: "2026-07"
 12285	aged Melonegroni	3	awesome	Last Available: "2026-07"
-12286	enchanted smooth watered-down Melonade Spritz	2	awesome	Effect: "Influence of Sphere", Effect Duration: 15, Last Available: "2026-07"
+12286	smooth watered-down enchanted Melonade Spritz	2	awesome	Effect: "Influence of Sphere", Effect Duration: 15, Last Available: "2026-07"
 12287	moldy snack-sized quince pie	2	crappy	Last Available: "2026-07"
 12288	magnetized quantum skewed jittery quince quaff	0		Effect: "A Few Extra Pounds", Effect Duration: 35, Last Available: "2026-07"
 12289	diffused anodized jittery Quickquince	0		Effect: "Sleazy Weapon", Effect Duration: 35, Last Available: "2026-07"
 12290	drinkable Quiskey Sour	3	good	Last Available: "2026-07"
-12291	artisanal extra-dry maroon Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
+12291	extra-dry artisanal maroon Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
 12292	lousy pulsating Roth IPA	3	decent	Last Available: "2026-08"
 12293	zippy knitted underdraft protection	0		Cold Resistance: +3, Initiative: +20, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Disco_Bandit_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wombat_cafe_booze.txt
@@ -3,31 +3,31 @@
 -3	fortified bad Infinitesimal IPA	5	decent	
 -4	acceptable tumbling eggnogtini	3	good	
 -5	lousy candycaine	4	decent	
--6	watered-down tolerable braincracker sweet	2	good	
+-6	tolerable watered-down braincracker sweet	2	good	
 -16	acceptable fermented honey	4	good	
 -17	weak drinkable moons-shine	2	good	
 -18	hand-crafted squat gin	3	EPIC	
--19	lousy fancy ecto-nog	4	decent	
+-19	fancy lousy ecto-nog	4	decent	
 -20	artisanal blue hot toady	3	EPIC	
 -21	mediocre hot choculate	4	decent	
--49	smooth weak Cyder	2	awesome	
--50	smooth watered-down yellow Oil Nog	2	awesome	
+-49	weak smooth Cyder	2	awesome	
+-50	watered-down smooth yellow Oil Nog	2	awesome	
 -51	perfectly mixed squat Hi-Octane Peppermint Jet Fuel	3	EPIC	
--58	bad weak Grimacider	2	decent	
+-58	weak bad Grimacider	2	decent	
 -59	hand-crafted high-proof bouncing Isotope Nog	8	EPIC	
 -60	bad watered-down Mutagin 'n' Tonic	2	decent	
--70	practically non-alcoholic smooth Gin and Herring	1	awesome	
--71	perfectly mixed watered-down Black and Tan and Red All Over	2	EPIC	
+-70	smooth practically non-alcoholic Gin and Herring	1	awesome	
+-71	watered-down perfectly mixed Black and Tan and Red All Over	2	EPIC	
 -72	mediocre enchanted Antarctic Ice Tea	4	decent	
 -76	tolerable practically non-alcoholic CRIMBCO Ribbon Candy Schnapps	1	good	
 -77	weak tolerable pulsating CRIMBCO Egg Substitute Nog Substitute	2	good	
 -78	watered-down aged CRIMBCO Extreme Braincracker Sour	2	awesome	
 -82	acceptable extra-dry mirror Horseradish-infused Vodka	5	good	
--83	high-proof hand-crafted Jerkitini	9	EPIC	
+-83	hand-crafted high-proof Jerkitini	9	EPIC	
 -84	artisanal Desert Island Iced Tea	3	EPIC	
 -88	drinkable upside-down Crimbo Saketini	4	good	
 -89	bad pulsating Crimboku Drop	4	decent	
 -90	artisanal spinning Flaming Crimbo Log	4	EPIC	
 -107	weak acceptable maroon Fortified Eggnog Slurry	2	good	
--108	practically non-alcoholic acceptable ghostly Hot Buttered Rum	1	good	
--109	tolerable weak blurry Spicy Hot Chocolate	2	good	
+-108	acceptable practically non-alcoholic ghostly Hot Buttered Rum	1	good	
+-109	weak tolerable blurry Spicy Hot Chocolate	2	good	

--- a/data/TCRS/TCRS_Disco_Bandit_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Disco_Bandit_Wombat_cafe_food.txt
@@ -1,26 +1,26 @@
 -1	delicious Peche a la Frog	4	awesome	
 -2	adequate As Jus Gezund Heit	3	good	
--3	rotten thick Bouillabaise Coucher Avec Moi	5	crappy	
+-3	thick rotten Bouillabaise Coucher Avec Moi	5	crappy	
 -7	bland gumdrop chow mein	3	decent	
--8	decent massive tumbling squat candy cane pizza	10	good	
+-8	decent massive squat tumbling candy cane pizza	10	good	
 -9	rotten massive gingerbread stir-fry	9	crappy	
 -10	spoiled twigs and gravel	4	crappy	
--11	adequate massive teal shaking shoots and leaves	6	good	
+-11	adequate massive shaking teal shoots and leaves	6	good	
 -12	spoiled bowl of unidentifiable goo	3	crappy	
--13	spoiled low-calorie blinking gingerbread massacre	1	crappy	
+-13	low-calorie spoiled blinking gingerbread massacre	1	crappy	
 -14	rotten It Came From Beyond Dessert	4	crappy	
--15	enchanted stale vampire cake	3	decent	
+-15	stale enchanted vampire cake	3	decent	
 -52	decent Soylent Red and Green	4	good	
 -53	flavorless Disc-Shaped Nutrition Unit	3	decent	
--54	bland diet Gingerborg Hive	1	decent	
+-54	diet bland Gingerborg Hive	1	decent	
 -61	huge normal Candy Cane Surprise	9	good	
 -62	tasty miniature Grimdrop Chow Mein	2	awesome	
 -63	rotten Grimgerbread House	4	crappy	
 -67	normal green Caviar Carbonara	4	good	
--68	moldy tiny Halibut Alfredo	1	crappy	
+-68	tiny moldy Halibut Alfredo	1	crappy	
 -69	bland wobbly Red Herring Velvet Cake	4	decent	
 -73	adequate huge CRIMBCO Reconstituted Gruel	7	good	
--74	flavorless small jittery New and Improved CRIMBCO Reconstituted Gruel	2	decent	
+-74	small flavorless jittery New and Improved CRIMBCO Reconstituted Gruel	2	decent	
 -75	moldy massive jittery CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	9	crappy	
 -79	flavorless Brussels Sprout Stir-Fry	4	decent	
 -80	decent enchanted Carrot, Cabbage, and Kale Pizza	4	good	
@@ -30,16 +30,16 @@
 -87	diet toothsome Crazy Dragon Shogun Buddha Roll	1	awesome	
 -92	enchanted stale basic hot dog	4	decent	
 -93	normal maroon savage macho dog	3	good	
--94	snack-sized bland one with everything	2	decent	
--95	massive spoiled wobbly sly dog	9	crappy	
+-94	bland snack-sized one with everything	2	decent	
+-95	spoiled massive wobbly sly dog	9	crappy	
 -96	miniature delicious devil dog	2	awesome	
 -97	moldy chilly dog	3	crappy	
 -98	flavorless ghost dog	3	decent	
 -99	stale junkyard dog	3	decent	
--100	half-sized rotten wet dog	2	crappy	
+-100	rotten half-sized wet dog	2	crappy	
 -101	rotten sleeping dog	3	crappy	
 -102	moldy optimal dog	4	crappy	
 -103	decent video games hot dog	3	good	
 -104	flavorless Peppermint Nutrition Block	4	decent	
 -105	adequate Gingerbread Nutrition Block	3	good	
--106	rotten miniature Cinnamon Nutrition Block	2	crappy	
+-106	miniature rotten Cinnamon Nutrition Block	2	crappy	

--- a/data/TCRS/TCRS_Pastamancer_Blender.txt
+++ b/data/TCRS/TCRS_Pastamancer_Blender.txt
@@ -10,7 +10,7 @@
 10	teal disco ball	0		
 11	stolen accordion	0		Song Duration: 5
 12	squat mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	modified narrow upside-down wobbly moxie weed	1		Effect: "Kindly Resolve", Effect Duration: 40
+14	modified wobbly upside-down narrow moxie weed	1		Effect: "Kindly Resolve", Effect Duration: 40
 15	modified strongness elixir	1		
 16	dried bouncing magicalness-in-a-can	1		
 17	bland noodles	4	decent	
@@ -37,7 +37,7 @@
 38	Knob Goblin pants of the detective	0		Item Drop: +20, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pulsating pretty flower	0		
 40	spinning shaking casino pass	0		
-41	practically non-alcoholic acceptable squat ice-cold Sir Schlitz	1	good	
+41	acceptable practically non-alcoholic squat ice-cold Sir Schlitz	1	good	
 42	pulsating hermit permit	0		
 43	worthless trinket	0		
 44	mirror worthless gewgaw	0		
@@ -45,7 +45,7 @@
 46	figurine	0		
 47	yummy huge hot buttered roll	3	awesome	
 48	blurry heart of rock and roll	0		
-49	enchanted flavorless half-sized jittery bowl of cottage cheese	2	decent	Effect: "Mer-kinny Flavor", Effect Duration: 25
+49	half-sized enchanted flavorless jittery bowl of cottage cheese	2	decent	Effect: "Mer-kinny Flavor", Effect Duration: 25
 50	purple padded Rock and Roll Legend	0		Damage Absorption: +20, Class: "Accordion Thief", Song Duration: 10
 51	Knob Goblin Uberpants of bravery	0		Spooky Resistance: +5, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -57,7 +57,7 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	upside-down wobbly miser's Mace of the Tortoise	0		Meat Drop: +10, Class: "Turtle Tamer"
-61	toothsome thick blurry ghostly fortune cookie	5	awesome	
+61	thick toothsome ghostly blurry fortune cookie	5	awesome	
 62	executive oriole-feather headdress	0		Meat Drop: +40, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	shaking fuchsia action figure head	0		
@@ -130,7 +130,7 @@
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
 133	Certificate of Participation	0		
-134	skewed green bitchin' meatcar	0		
+134	green skewed bitchin' meatcar	0		
 135	sweet rims	0		
 136	tires	0		
 137	dope wheels	0		
@@ -158,14 +158,14 @@
 159	wobbly wad of dough	0		
 160	pie crust	0		
 161	adequate ghuol egg	3	good	
-162	flavorless diet ghuol egg quiche	1	decent	
+162	diet flavorless ghuol egg quiche	1	decent	
 163	hale skeleton bone	0		Maximum HP: +20
 164	green smart skull	0		
 165	fuchsia skewer	0		
 166	red huge ghuol ears	0		
-167	snack-sized flavorless fancy twirling ghuol-ear kabob	2	decent	Effect: "Yet tea", Effect Duration: 15
+167	flavorless fancy snack-sized twirling ghuol-ear kabob	2	decent	Effect: "Yet tea", Effect Duration: 15
 168	red MacGyver's bone rattle	0		Maximum MP: +100
-169	jittery blurry narrow bugbear beanie	0		Familiar Effect: "atk, cap 7"
+169	narrow blurry jittery bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	huge lihc eye	0		
 171	miniature flavorless lihc eye pie	2	decent	
 172	lime green gnoll lips	0		
@@ -179,7 +179,7 @@
 180	watered-down acceptable ice-cold fotie	2	good	
 181	baseball	0		
 182	batgut	0		
-183	pulsating twirling blinking bat wing	0		
+183	pulsating blinking twirling bat wing	0		
 184	upside-down briefcase	0		
 185	fat stacks of cash	0		
 186	twirling bean	0		
@@ -195,11 +195,11 @@
 197	rat whisker	0		
 198	jittery rat appendix	0		
 199	lime green curative ring	0		HP Regen Min: 3, HP Regen Max: 5
-200	thick spoiled rat appendix kabob	5	crappy	
+200	spoiled thick rat appendix kabob	5	crappy	
 201	delicious half-sized bat wing kabob	2	awesome	
 202	spoiled super-sized wobbly carob chunks	5	crappy	
 203	herbs	0		
-204	decent tiny carob chunk cookies	1	good	
+204	tiny decent carob chunk cookies	1	good	
 205	huge secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	good	
@@ -211,7 +211,7 @@
 213	inspector's brainy filthy corduroys	0		Mysticality: +5, Item Drop: +15, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	zippy filthy knitted dread sack	0		Initiative: +20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	thick bland carob brownies	5	decent	
+216	bland thick carob brownies	5	decent	
 217	spoiled herb brownies	3	crappy	
 218	upside-down hemp string	0		
 219	necklace chain	0		
@@ -221,7 +221,7 @@
 223	curative phat turquoise bracelet	0		HP Regen Min: 3, HP Regen Max: 5
 224	upside-down Jack Frost's eyepatch	0		Cold Spell Damage: +50, Familiar Effect: "3xBarrr, cap 6"
 225	bland low-calorie tofu casserole	1	decent	
-226	distilled olive mirror can of Red Minotaur	1	good	Effect: "Beta Carotene Overdose", Effect Duration: 40
+226	distilled mirror olive can of Red Minotaur	1	good	Effect: "Beta Carotene Overdose", Effect Duration: 40
 227	resourceful Kentucky-fried meat sword	0		Maximum MP: +50
 228	stiffened Kentucky-fried meat staff	0		Damage Reduction: 1
 229	Kentucky-fried meat crossbow of dire peril	0		Weapon Damage: +20
@@ -237,20 +237,20 @@
 239	gravedigger's Lo Pan's Orcish baseball cap	0		Spell Critical Percent: +30, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	maroon Annie Oakley's therapeutic Orcish cargo shorts	0		Critical Hit Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	squat pulsating Newton's Orcish frat-paddle	0		Experience (Mysticality): +3
-242	thick bland	5	decent	
+242	bland thick	5	decent	
 243	delicious gigantic grapefruit	10	awesome	
 244	moldy squat huge grapes	3	crappy	
-245	miniature spoiled wobbly olive	2	crappy	
+245	spoiled miniature wobbly olive	2	crappy	
 246	spoiled pulsating tomato	3	crappy	
-247	maroon skewed fermenting powder	0		
+247	skewed maroon fermenting powder	0		
 248	artisanal salty dog	3	EPIC	
 249	drinkable teal ghostly bloody mary	4	good	
-250	spirit-forward tolerable screwdriver	5	good	
-251	watered-down drinkable twirling squat martini	2	good	
+250	tolerable spirit-forward screwdriver	5	good	
+251	drinkable watered-down twirling squat martini	2	good	
 252	perfectly mixed bloody beer	3	EPIC	
 253	bad weak shot of schnapps	2	decent	
-254	weak perfectly mixed shot of grapefruit schnapps	2	EPIC	
-255	practically non-alcoholic smooth fine wine	1	awesome	
+254	perfectly mixed weak shot of grapefruit schnapps	2	EPIC	
+255	smooth practically non-alcoholic fine wine	1	awesome	
 256	hand-crafted tumbling shot of tomato schnapps	3	EPIC	
 257	lousy extra-spicy bloody mary	4	decent	
 258	dense meat stack	0		
@@ -259,7 +259,7 @@
 261	stale White Citadel burger	3	decent	
 262	stale piece of wedding cake	3	decent	
 263	yummy chocolate chips	3	awesome	
-264	miniature moldy chocolate chip cookies	2	crappy	
+264	moldy miniature chocolate chip cookies	2	crappy	
 265	slick satin pants	0		Moxie: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	tolerable lightning	3	good	
 267	dangerous mullet wig	0		Weapon Damage: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -271,7 +271,7 @@
 273	compressed huge moxie weed	1		
 274	twirling Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
-276	bouncing spinning leprechaun hatchling	0		
+276	spinning bouncing leprechaun hatchling	0		
 277	twisted huge extra-strength strongness elixir	1		Effect: "In the Saucestream", Effect Duration: 15
 278	denatured wobbly jug-o-magicalness	1		
 279	mixed suntan lotion of moxiousness	1		
@@ -298,7 +298,7 @@
 300	frozen jaba&ntilde;ero-flavored chewing gum	0		Effect: "On Pins and Needles", Effect Duration: 56
 301	flat dough	0		
 302	normal Knob sausage	3	good	
-303	flavorless half-sized Knob mushroom	2	decent	
+303	half-sized flavorless Knob mushroom	2	decent	
 304	dry noodles	0		
 305	avaricious Knob Goblin harem pants	0		Meat Drop: +30, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	Knob Goblin harem veil of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "5xLep, cap 2"
@@ -309,19 +309,19 @@
 311	hill of beans	0		
 312	tumbling ghostly Knob Goblin visor of the cheetah	0		Initiative: +60, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	blinking up-at-dawn Crown of the Goblin King	0		Adventures: +5, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	decent bite-sized squat bean burrito	1	good	
-315	spoiled special bean burrito	3	crappy	Effect: "Thunderspell", Effect Duration: 20
-316	diet flavorless insanely bean burrito	1	decent	
+314	bite-sized decent squat bean burrito	1	good	
+315	special spoiled bean burrito	3	crappy	Effect: "Thunderspell", Effect Duration: 20
+316	flavorless diet insanely bean burrito	1	decent	
 317	spoiled small bean burrito	2	crappy	
 318	adequate ghostly bean burrito	3	good	
-319	flavorless big special insanely bean burrito	5	decent	Effect: "Booooooze", Effect Duration: 5
-320	big enchanted moldy bat haggis	5	crappy	Effect: "Super Vision", Effect Duration: 40
+319	big flavorless special insanely bean burrito	5	decent	Effect: "Booooooze", Effect Duration: 5
+320	moldy enchanted big bat haggis	5	crappy	Effect: "Super Vision", Effect Duration: 40
 321	decent menudo	3	good	
 322	stale goat cheese	4	decent	
-323	super-sized moldy plain pizza	5	crappy	
+323	moldy super-sized plain pizza	5	crappy	
 324	normal huge sausage pizza	4	good	
 325	stale goat cheese pizza	3	decent	
-326	low-calorie flavorless mushroom pizza	1	decent	
+326	flavorless low-calorie mushroom pizza	1	decent	
 327	goat	0		
 328	drinkable bottle of whiskey	4	good	
 329	ghostly goat beard of the empath	0		Familiar Weight: +5, Familiar Effect: "atk, 1xPotato, cap 15"
@@ -412,13 +412,13 @@
 414	mirror crowbarrr of the empath	0		Familiar Weight: +5
 415	leotarrrd of the empath	0		Familiar Weight: +5, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	wobbly savvy safarrri hat	0		Mysticality Percent: +20, Familiar Effect: "2xVolley, cap 22"
-417	enhanced wobbly blue henna tattoo	0		Effect: "Faboooo", Effect Duration: 29
+417	enhanced blue wobbly henna tattoo	0		Effect: "Faboooo", Effect Duration: 29
 418	enhanced Ferrigno's Elixir of Power	0		Effect: "Super Structure", Effect Duration: 17
 419	polarized super-unsweetened serum of sarcasm	0		Effect: "stats.enq", Effect Duration: 57
 420	Vulcanized galvanized tomato juice of powerful power	0		Effect: "Patent Avarice", Effect Duration: 20
 421	nitrogenated twirling philter of phorce	0		Effect: "Executive Greed", Effect Duration: 13
 422	corrupted ionized blue potion of potency	0		Effect: "Irresistible Resolve", Effect Duration: 49
-423	improved tumbling huge green cordial of concentration	0		Effect: "Human-Goblin Hybrid", Effect Duration: 62
+423	improved huge green tumbling cordial of concentration	0		Effect: "Human-Goblin Hybrid", Effect Duration: 62
 424	pickled energized ointment of the occult	0		Effect: "Got Your Boots On", Effect Duration: 53
 425	aerosolized oil of expertise	0		Effect: "Burnt 'n' Turnt", Effect Duration: 25
 426	polarized anodized Vulcanized tumbling potion of temporary gr8ness	0		Effect: "Pumped Stomach", Effect Duration: 12
@@ -450,7 +450,7 @@
 452	huge disease	0		
 453	blurry sober pill	0		
 454	screwdriver	0		
-455	small bland jumbo olive	2	decent	
+455	bland small jumbo olive	2	decent	
 456	perfectly mixed shaking dry martini	3	EPIC	
 457	blinking Tesla ye olde golde frontes	0		MP Regen Min: 7, MP Regen Max: 10, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
@@ -465,7 +465,7 @@
 467	snack-sized flavorless cyan pixel pie	2	decent	
 468	lime green ruby W	0		
 469	blue wussiness potion	0		
-470	weak artisanal Imp Ale	2	EPIC	
+470	artisanal weak Imp Ale	2	EPIC	
 471	gigantic flavorless huge hot wing	10	decent	
 472	Usain Bolt's diamond-studded cane	0		Initiative: +80, Class: "Disco Bandit"
 473	olive crutch of courage	0		Spooky Resistance: +3
@@ -493,12 +493,12 @@
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	fancy toothsome tiny papaya	1	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 5
+498	toothsome fancy tiny papaya	1	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 5
 499	frightening rosy-cheeked denim axe	0		Maximum HP Percent: +30, Spooky Damage: +5
 500	Elf Farm Raffle ticket	0		
 501	toothsome bouncing Elfin shortbread	4	awesome	
 502	pagoda plans	0		
-503	normal diet skewered cat appendix	1	good	
+503	diet normal skewered cat appendix	1	good	
 504	evil arches	0		
 505	purple clever Samson's gnatwing earring	0		Experience (Muscle): +5, Maximum MP: +20
 506	normal Hell broth	3	good	
@@ -509,7 +509,7 @@
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	spoiled diet Boris's key lime pie	1	crappy	
-514	immense toothsome shaking Jarlsberg's key lime pie	9	awesome	
+514	toothsome immense shaking Jarlsberg's key lime pie	9	awesome	
 515	immense normal teal Sneaky Pete's key lime pie	7	good	
 516	Hey Deze map	0		
 517	shaking smartaleck's bejeweled accordion strap	0		Moxie Percent: +30, Class: "Accordion Thief"
@@ -518,11 +518,11 @@
 520	twirling leaflet	0		
 521	kickback cookbook of dire peril	0		Weapon Damage: +20
 522	one-winged stab bat	0		
-523	narrow gray rewinged stab bat	0		
+523	gray narrow rewinged stab bat	0		
 524	bad papaya sling	3	decent	
 525	grue egg	0		
 526	spinning cyan Frobozz Real-Estate Company Instant House (TM)	0		
-527	spinning gray volleyball	0		
+527	gray spinning volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
 530	polarized double-pickled ionized red spray paint	0		Effect: "Blubbered Up", Effect Duration: 17
@@ -540,7 +540,7 @@
 542	wobbly horrifying extremely unsafe 1337 7r0uZ0RZ	0		Weapon Damage Percent: +100, Spooky Damage: +25, Familiar Effect: "2xPotato, cap 27"
 543	normal special Trollhouse cookies	3	good	Effect: "Spooky Flavor", Effect Duration: 15
 544	sharpshooter's clever talons	0		Maximum MP: +20, Critical Hit Percent: +10
-545	snack-sized spoiled Spam Witch sammich	2	crappy	
+545	spoiled snack-sized Spam Witch sammich	2	crappy	
 546	meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -564,28 +564,28 @@
 566	banded bum cheek	0		Damage Absorption: +100, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	immense decent bouncing Double Bacon Beelzeburger	7	good	
-569	adequate enchanted blurry Lord of the Flies-sized fries	4	good	Effect: "Rushin' Hands", Effect Duration: 40
+569	enchanted adequate blurry Lord of the Flies-sized fries	4	good	Effect: "Rushin' Hands", Effect Duration: 40
 570	half-sized delicious twirling Chicken Sandwich	2	awesome	
-571	red spinning Jumbo Dr. Lucifer	1	decent	
+571	spinning red Jumbo Dr. Lucifer	1	decent	
 572	low-calorie moldy Children's Meal of the Damned	1	crappy	
-573	yummy low-calorie noodles	1	awesome	
-574	jumbo adequate noodles	5	good	
+573	low-calorie yummy noodles	1	awesome	
+574	adequate jumbo noodles	5	good	
 575	moldy painful penne pasta	3	crappy	
 576	flavorless ravioli della hippy	3	decent	
-577	bland fancy snack-sized pr0n m4nic0tti	2	decent	Effect: "Cold Blooded", Effect Duration: 50
+577	fancy snack-sized bland pr0n m4nic0tti	2	decent	Effect: "Cold Blooded", Effect Duration: 50
 578	toothsome Hell ramen	3	awesome	
 579	spoiled boring spaghetti	4	crappy	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	yummy small fettucini Inconnu	2	awesome	
+583	small yummy fettucini Inconnu	2	awesome	
 584	spoiled spaghetti with Skullheads	3	crappy	
-585	normal enchanted gnocchetti di Nietzsche	3	good	Effect: "Cautious Prowl", Effect Duration: 20
+585	enchanted normal gnocchetti di Nietzsche	3	good	Effect: "Cautious Prowl", Effect Duration: 20
 586	bouncing teal hardened arcane researcher's ridiculously huge sword	0		Experience Percent (Mysticality): +10, Damage Reduction: 3
 587	frozen frozen maroon super-spiky hair gel	0		Effect: "Gummibrain", Effect Duration: 33
 588	mirror soft echo eyedrop antidote	0		
 589	bland gray cocoa eggshell fragment	3	decent	
-590	adequate small cocoa eggshell fragment	2	good	
+590	small adequate cocoa eggshell fragment	2	good	
 591	cocoa egg	0		
 592	bouncing house	0		
 593	phonics down	0		
@@ -641,7 +641,7 @@
 643	skeleton key ring	0		
 644	huge shaking Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	small toothsome fruitcake	2	awesome	
+646	toothsome small fruitcake	2	awesome	
 647	present	0		Last Available: "2004-11"
 648	olive brawny Crimbo sword	0		Muscle Percent: +20, Last Available: "2004-10"
 649	wobbly energetic Crimbo hat	0		Maximum MP Percent: +20, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
@@ -675,7 +675,7 @@
 677	mansplainer's badass belt	0		Monster Level: +15
 678	chest of the Bonerdagon	0		
 679	aged watered-down roll in the hay	2	awesome	
-680	lousy practically non-alcoholic slap and tickle	1	decent	
+680	practically non-alcoholic lousy slap and tickle	1	decent	
 681	smooth slip 'n' slide	4	awesome	
 682	tolerable a sump'm sump'm	3	good	
 683	tolerable irresponsibly strong horizontal tango	10	good	
@@ -735,8 +735,8 @@
 739	tambourine bells	0		
 740	blinking maroon tambourine of mayonnaise	0		Sleaze Spell Damage: +50
 741	broken skull	0		
-742	super-sized adequate Knoll shroomkabob	5	good	
-743	diet tasty mushroom	1	awesome	
+742	adequate super-sized Knoll shroomkabob	5	good	
+743	tasty diet mushroom	1	awesome	
 744	pickled activated yellow hair spray	0		Effect: "Fishy Fortification", Effect Duration: 64
 746	blurry stat script	0		
 747	Knob Goblin firecracker	0		
@@ -744,17 +744,17 @@
 749	tasty narrow warm mushroom	4	awesome	
 750	super-sized adequate mushroom quesadilla	5	good	
 751	rotten cool mushroom	3	crappy	
-752	enchanted big delicious wobbly twirling cool mushroom casserole	5	awesome	Effect: "I See Everything Thrice!", Effect Duration: 25
-753	huge adequate jittery pointy mushroom	8	good	
+752	enchanted delicious big wobbly twirling cool mushroom casserole	5	awesome	Effect: "I See Everything Thrice!", Effect Duration: 25
+753	adequate huge jittery pointy mushroom	8	good	
 754	adequate miniature cream of pointy mushroom soup	2	good	
-755	super-sized decent green mushroom	5	good	
+755	decent super-sized green mushroom	5	good	
 756	miniature delicious green mushroom	2	awesome	
 757	rotten mushroom	3	crappy	
-758	bland jittery blinking ghost cucumber	4	decent	
+758	bland blinking jittery ghost cucumber	4	decent	
 759	narrow dill	0		
 760	squat vinegar	0		
 761	brine	0		
-762	tolerable boozy special upside-down especially salty dog	5	good	Effect: "The Real Deal", Effect Duration: 40
+762	boozy tolerable special upside-down especially salty dog	5	good	Effect: "The Real Deal", Effect Duration: 40
 763	twirling ghostly pickling solution	0		
 764	rotten spectral pickle	3	crappy	
 765	briny vinegar	0		
@@ -777,7 +777,7 @@
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
 784	drinkable bouncing Acqua Del Piatto Merlot	3	good	Last Available: "2004-10"
-785	skewed red raffle ticket	0		
+785	red skewed raffle ticket	0		
 786	moldy small bouncing strawberry	2	crappy	
 787	mediocre practically non-alcoholic bottle of rum	1	decent	
 788	lousy narrow strawberry daiquiri	3	decent	
@@ -785,13 +785,13 @@
 790	bad ghostly grog	3	decent	
 791	healthy Mafia bow tie of the glutton	0		Maximum HP Percent: +20, Food Drop: +100, Last Available: "2004-10"
 792	razor-sharp Golden Mr. Accessory	0		Weapon Damage Percent: +25, Softcore Only
-793	modified unsweetened blurry upside-down oil of stability	0		Effect: "Staying Frosty", Effect Duration: 58
+793	modified unsweetened upside-down blurry oil of stability	0		Effect: "Staying Frosty", Effect Duration: 58
 794	warmed triple-dry oil of slipperiness	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 38
-795	delicious practically non-alcoholic blinking Acque Luride Grezze Cabernet	1	awesome	Last Available: "2004-10"
+795	practically non-alcoholic delicious blinking Acque Luride Grezze Cabernet	1	awesome	Last Available: "2004-10"
 796	aromatic careful therapeutic cement shoes	0		Monster Level: -10, Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-10"
 797	perfectly mixed huge rockin' wagon	3	EPIC	
-798	tolerable high-proof ghostly ocean motion	6	good	
-799	artisanal fancy watered-down fuzzbump	2	EPIC	Effect: "Bone Chilling", Effect Duration: 15
+798	high-proof tolerable ghostly ocean motion	6	good	
+799	watered-down fancy artisanal fuzzbump	2	EPIC	Effect: "Bone Chilling", Effect Duration: 15
 800	stale immense poutine	6	decent	
 801	flavorless Knob stir-fry	3	decent	
 804	moldy mirror Knoll stir-fry	3	crappy	
@@ -800,14 +800,14 @@
 807	half-sized normal olive stir-fry	2	good	
 808	normal Knob sausage stir-fry	3	good	
 809	moldy bat wing stir-fry	4	crappy	
-810	immense adequate rat appendix stir-fry	10	good	
+810	adequate immense rat appendix stir-fry	10	good	
 811	adequate tofu stir-fry	3	good	
-812	decent miniature pr0n stir-fry	2	good	
+812	miniature decent pr0n stir-fry	2	good	
 813	spoiled Knob shells	4	crappy	
 814	toothsome b&auml;tzle	3	awesome	
-815	enchanted flavorless snack-sized ratini	2	decent	Effect: "Greasy Flavor", Effect Duration: 25
-816	spoiled diet Knob stroganoff	1	crappy	
-817	bite-sized stale menudo ravioli	1	decent	
+815	flavorless snack-sized enchanted ratini	2	decent	Effect: "Greasy Flavor", Effect Duration: 25
+816	diet spoiled Knob stroganoff	1	crappy	
+817	stale bite-sized menudo ravioli	1	decent	
 818	plus sign	0		
 819	milky potion	0		
 820	lime green swirly potion	0		
@@ -818,7 +818,7 @@
 825	spinning fizzy potion	0		
 826	dark potion	0		
 827	gray huge murky potion	0		
-828	maroon wobbly baby killer bee	0		
+828	wobbly maroon baby killer bee	0		
 829	anti-anti-antidote	0		
 830	rotten small royal jelly	2	crappy	
 831	small box	0		
@@ -831,8 +831,8 @@
 838	spinning executive sharpshooter's Mafia stogie	0		Critical Hit Percent: +10, Meat Drop: +40, Last Available: "2004-10"
 839	lousy Maiali Sifilitici Pinot Noir	4	decent	Last Available: "2004-10"
 840	personal trainer's Mafia violin case of courage	0		Experience Percent (Muscle): +10, Spooky Resistance: +3, Last Available: "2004-10"
-841	boozy fancy bad tomato daiquiri	5	decent	Effect: "Human-Human Hybrid", Effect Duration: 50
-842	high-proof perfectly mixed beertini	10	EPIC	
+841	bad fancy boozy tomato daiquiri	5	decent	Effect: "Human-Human Hybrid", Effect Duration: 50
+842	perfectly mixed high-proof beertini	10	EPIC	
 843	fortified hand-crafted salty slug	5	EPIC	
 844	practically non-alcoholic perfectly mixed papaya slung	1	EPIC	
 845	brainy MAHI fez	0		Mysticality: +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -853,7 +853,7 @@
 861	chocolate spurs	0		Familiar Weight: +5
 862	magnifying glass	0		Familiar Weight: +5
 863	shaking skewer-mounted razor blade	0		Familiar Weight: +5
-864	narrow tumbling stinger	0		Familiar Weight: +5
+864	tumbling narrow stinger	0		Familiar Weight: +5
 865	blue lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	activated pickled pine tar	0		Effect: "Tremella Tremens", Effect Duration: 29
@@ -861,7 +861,7 @@
 870	double-paned fetus-smashing club	0		Cold Resistance: +5
 871	skewed meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
-873	spinning jittery rolling pin	0		
+873	jittery spinning rolling pin	0		
 874	unrolling pin	0		
 875	curative crazy bastard sword of the overflowing toilet of the sweet-tooth	0		Stench Spell Damage: +50, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5
 876	miser's inspector's incredibly dense meat gem of the early riser	0		Item Drop: +15, Meat Drop: +10, Adventures: +7
@@ -871,17 +871,17 @@
 880	ghostly disbelief suspenders of mayonnaise	0		Sleaze Spell Damage: +50
 881	supportive bra of the ox	0		Muscle: +20
 882	gray tumbling Blatantly Canadian	0		
-883	huge ghostly maple syrup	1	EPIC	
+883	ghostly huge maple syrup	1	EPIC	
 884	los chinos of the detective	0		Item Drop: +20, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	purple wicked axe	0		Spell Damage: +5
 886	leaflet	0		
 887	leaf	0		
 888	upside-down maple leaf	0		
 889	greasy balaclava	0		Sleaze Spell Damage: +10, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	rotten half-sized special balaclava baklava	2	crappy	Effect: "Vanity Rage", Effect Duration: 40
+890	special rotten half-sized balaclava baklava	2	crappy	Effect: "Vanity Rage", Effect Duration: 40
 891	flame-retardant Warehouse 23 bling	0		Hot Resistance: +1
 892	flame-retardant Sinatra's bugbear-smiting sword of bravery	0		Experience (Moxie): +5, Hot Resistance: +1, Spooky Resistance: +5
-893	practically non-alcoholic acceptable lumbering jack	1	good	
+893	acceptable practically non-alcoholic lumbering jack	1	good	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	teal Ms. Accessory of doom	0		Spooky Spell Damage: +50, Softcore Only
 896	rosewater-soaked chaotic Mr. Accessory Jr.	0		Spell Critical Percent: +10, Stench Resistance: +3, Softcore Only
@@ -898,7 +898,7 @@
 907	aerosolized liquefied twirling Mr. Mediocrebar	0		Effect: "Fratty Flavor", Effect Duration: 48
 908	aerosolized blinking Cold Hots candy	0		Effect: "Musky", Effect Duration: 29
 909	frozen Wint-O-Fresh mint	0		Effect: "Stenchtastic", Effect Duration: 51
-910	moldy half-sized dwarf bread	2	crappy	
+910	half-sized moldy dwarf bread	2	crappy	
 911	irradiated colloidal Senior Mints	0		Effect: "Saucegoggles", Effect Duration: 53
 912	diffused huge pixellated candy heart	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 35
 913	super-concentrated electrified bouncing kobold	0		Effect: "Dweeby", Effect Duration: 60
@@ -915,7 +915,7 @@
 924	yellow crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	cyan dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	chilled Hawking's Elixir of Brilliance	0		Effect: "Insulated Trousers", Effect Duration: 15
-927	tolerable fancy Ferita Del Petto Zinfandel	3	good	Effect: "Leash of Linguini", Effect Duration: 50, Last Available: "2006-12"
+927	fancy tolerable Ferita Del Petto Zinfandel	3	good	Effect: "Leash of Linguini", Effect Duration: 50, Last Available: "2006-12"
 928	studded fuzzy bracelets	0		Damage Absorption: +80
 929	Sherlock's arse-shooting crossbow	0		Item Drop: +25
 931	smooth blurry spiced rum	3	awesome	
@@ -936,7 +936,7 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	strong smooth martini	5	awesome	Last Available: "2004-12"
-949	mediocre practically non-alcoholic grogtini	1	decent	Last Available: "2004-12"
+949	practically non-alcoholic mediocre grogtini	1	decent	Last Available: "2004-12"
 950	perfectly mixed strong cherry bomb	5	EPIC	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	frosty hockey mask of wisdom	0		Mysticality: +15, Cold Spell Damage: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
@@ -945,7 +945,7 @@
 955	fez of etymology of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xLep, cap 30"
 956	stale squat carob chunk noodles	3	decent	
 957	spoiled squat chorizo brownies	3	crappy	
-958	adequate half-sized chocolate and tomato pizza	2	good	
+958	half-sized adequate chocolate and tomato pizza	2	good	
 959	bouncing flange	0		
 960	red clockwork key	0		
 961	mirror silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -989,7 +989,7 @@
 1002	wool Xlyinia's notebook	0		Cold Resistance: +1
 1003	jittery soda water	0		
 1004	practically non-alcoholic smooth skewed bottle of tequila	1	awesome	
-1005	high-proof perfectly mixed boxed wine	7	EPIC	
+1005	perfectly mixed high-proof boxed wine	7	EPIC	
 1006	stale cherry	3	decent	
 1007	upside-down coconut shell of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xFairy, cap 7"
 1008	Jack Frost's ice cubes	0		Cold Spell Damage: +50
@@ -1003,13 +1003,13 @@
 1016	acceptable perpendicular hula	4	good	
 1017	spirit-forward delicious ducha de oro	5	awesome	
 1018	acceptable calle de miel	4	good	
-1019	weak bad lime green dry vodka martini	2	decent	
+1019	bad weak lime green dry vodka martini	2	decent	
 1020	hand-crafted mirror old-fashioned	4	EPIC	
 1021	tolerable tequila with training wheels	4	good	
-1022	special drinkable sangria	4	good	Effect: "Holiday Bliss", Effect Duration: 20
+1022	drinkable special sangria	4	good	Effect: "Holiday Bliss", Effect Duration: 20
 1023	lousy practically non-alcoholic vesper	1	decent	Last Available: "2004-12"
 1024	high-proof mediocre twirling bodyslam	8	decent	Last Available: "2004-12"
-1025	mediocre special sangria del diablo	3	decent	Effect: "Inebriate Pride", Effect Duration: 10, Last Available: "2004-12"
+1025	special mediocre sangria del diablo	3	decent	Effect: "Inebriate Pride", Effect Duration: 10, Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1033,7 +1033,7 @@
 1047	delicious gray N. O. Beer	4	awesome	
 1048	denatured blurry wobbly oyster egg	1		Effect: "Marbles in Your Mouth", Effect Duration: 15
 1049	twisted oyster egg	1		
-1050	boiled wobbly mirror oyster egg	1		
+1050	boiled mirror wobbly oyster egg	1		
 1051	squat plastic oyster egg	0		
 1052	twisted upside-down oyster egg	1		
 1053	dehydrated oyster egg	1		
@@ -1041,12 +1041,12 @@
 1055	ghostly plastic oyster egg	0		
 1056	modified tumbling puce oyster egg	1		
 1057	twisted spinning puce oyster egg	1		Effect: "Shoesauce", Effect Duration: 30
-1058	twisted narrow skewed puce oyster egg	1		
+1058	twisted skewed narrow puce oyster egg	1		
 1059	puce plastic oyster egg	0		
 1060	diluted bouncing skewed mauve oyster egg	1		
-1061	diluted mirror blue mauve oyster egg	1		
+1061	diluted blue mirror mauve oyster egg	1		
 1062	boiled narrow narrow green mauve oyster egg	1		
-1063	lime green spinning shaking tumbling mauve plastic oyster egg	0		
+1063	tumbling spinning lime green shaking mauve plastic oyster egg	0		
 1064	twisted oyster egg	1		
 1065	dried oyster egg	1		Effect: "Banono", Effect Duration: 45
 1066	twisted ghostly oyster egg	1		Effect: "Shamboozled", Effect Duration: 25
@@ -1056,7 +1056,7 @@
 1070	mixed olive blurry oyster egg	1		
 1071	spinning plastic oyster egg	0		
 1072	modified blurry skewed off-white oyster egg	1		
-1073	vaporized narrow skewed off-white oyster egg	1		
+1073	vaporized skewed narrow off-white oyster egg	1		
 1074	distilled off-white oyster egg	1		
 1075	skewed off-white plastic oyster egg	0		
 1076	pickled twirling oyster egg	1		Effect: "'Roids of the Rhinoceros", Effect Duration: 35
@@ -1095,11 +1095,11 @@
 1109	clockwork bartender-head-in-the-box	0		
 1110	clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
-1112	blurry mirror clockwork chef-in-the-box	0		
+1112	mirror blurry clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
 1114	tisket	0		
-1115	skewed narrow tasket	0		
-1116	lime green narrow annoying pitchfork	0		Monster Level: +5
+1115	narrow skewed tasket	0		
+1116	narrow lime green annoying pitchfork	0		Monster Level: +5
 1117	ghostly sizzling Socratic Stupid University Diploma of James Dean	0		Experience (Mysticality): +1, Experience (Moxie): +3, Hot Damage: +10
 1118	red pregnant mushroom	0		
 1119	pregnant mushroom	0		
@@ -1123,17 +1123,17 @@
 1137	bicycle chain of the businessman of the cheetah	0		Meat Drop: +50, Initiative: +60
 1138	mushroom fermenting solution	0		
 1139	perfectly mixed mirror mushroom wine	4	EPIC	
-1140	strong bad icy mushroom wine	5	decent	
-1141	weak fancy hand-crafted mushroom wine	2	EPIC	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 45
+1140	bad strong icy mushroom wine	5	decent	
+1141	weak hand-crafted fancy mushroom wine	2	EPIC	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 45
 1142	acceptable pointy mushroom wine	4	good	
-1143	irresponsibly strong drinkable pulsating flat mushroom wine	9	good	
+1143	drinkable irresponsibly strong pulsating flat mushroom wine	9	good	
 1144	strong drinkable green cool mushroom wine	5	good	
-1145	smooth gray upside-down knob mushroom wine	4	awesome	
+1145	smooth upside-down gray knob mushroom wine	4	awesome	
 1146	hand-crafted watered-down knoll mushroom wine	2	EPIC	
 1147	triple-distilled artisanal mushroom wine	6	EPIC	
 1148	mediocre teal shot of flower schnapps	3	decent	
 1149	decent flower petal pie	3	good	
-1150	weak smooth bottle of single-barrel whiskey	2	awesome	
+1150	smooth weak bottle of single-barrel whiskey	2	awesome	
 1151	Temple Grandin's beefcake's discarded plastic fork	0		Muscle: +25, Familiar Weight: +7
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	spoiled Retenez L'Herbe Pat&eacute;	4	crappy	
@@ -1182,21 +1182,21 @@
 1197	spinning Mob Penguin	0		
 1198	twirling sabre-toothed lime	0		
 1199	shaking bugbear	0		
-1200	enchanted adequate mugcake	3	good	Effect: "Dances with Tweedles", Effect Duration: 30
+1200	adequate enchanted mugcake	3	good	Effect: "Dances with Tweedles", Effect Duration: 30
 1201	rotten urinal cake	3	crappy	
 1202	moldy Happy Birthday, Claude! cake	3	crappy	
-1203	adequate enchanted low-calorie personalized birthday cake	1	good	Effect: "Salty Mouth", Effect Duration: 50
+1203	low-calorie adequate enchanted personalized birthday cake	1	good	Effect: "Salty Mouth", Effect Duration: 50
 1204	flavorless immense enchanted three-tiered wedding cake	9	decent	Effect: "The Halls of Mysticality", Effect Duration: 35
 1205	tasty babycakes	4	awesome	
-1206	enchanted flavorless velvet cake	3	decent	Effect: "Sated and Furious", Effect Duration: 20
-1207	snack-sized rotten squat congratulatory cake	2	crappy	
+1206	flavorless enchanted velvet cake	3	decent	Effect: "Sated and Furious", Effect Duration: 20
+1207	rotten snack-sized squat congratulatory cake	2	crappy	
 1208	tasty snack-sized blinking angel-food cake	2	awesome	
 1209	tasty devil's-food cake	3	awesome	
-1210	enchanted decent birthday party jellybean cheesecake	4	good	Effect: "Waxing", Effect Duration: 50
+1210	decent enchanted birthday party jellybean cheesecake	4	good	Effect: "Waxing", Effect Duration: 50
 1211	balloon	0		
 1212	balloon	0		
 1213	teal heart-shaped balloon	0		
-1214	blue blinking anniversary balloon	0		
+1214	blinking blue anniversary balloon	0		
 1215	Mylar balloon	0		
 1216	mirror Kevlar balloon	0		
 1217	mirror thought balloon	0		
@@ -1232,7 +1232,7 @@
 1248	resourceful grievous Bonerdagon necklace of terror	0		Weapon Damage Percent: +50, Maximum MP: +50, Spooky Spell Damage: +10
 1249	Lo Pan's Boss Bat britches	0		Spell Critical Percent: +30, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	smelly groovy Boss Bat bling	0		Moxie Percent: +10, Stench Spell Damage: +10
-1251	bland fuchsia squat Knob shroomkabob	3	decent	
+1251	bland squat fuchsia Knob shroomkabob	3	decent	
 1252	diet spoiled shroomkabob	1	crappy	
 1253	pile of jumping beans	0		
 1254	spoiled blinking jumping bean burrito	4	crappy	
@@ -1247,17 +1247,17 @@
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	bouncing box of sunshine	0		Free Pull
-1266	spoiled jumbo gloomy mushroom	5	crappy	
+1266	jumbo spoiled gloomy mushroom	5	crappy	
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	twirling ebony wand	0		
-1270	huge pulsating cyan hexagonal wand	0		
+1270	cyan pulsating huge hexagonal wand	0		
 1271	aluminum wand	0		
 1272	marble wand	0		
 1273	experienced magic lamp	0		Experience: +2
 1274	dehydrated mirror Medicinal Herb's medicinal herbs	1		Effect: "Red-Shirted Escort", Effect Duration: 40
 1275	supercool basic meat skirt	0		Moxie Percent: +20, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	artisanal watered-down Otorian Battle Scar	2	EPIC	
+1276	watered-down artisanal Otorian Battle Scar	2	EPIC	
 1277	stylish basic meat kilt	0		Moxie: +25, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	squat dance instructor's meat skirt	0		Experience Percent (Moxie): +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	squat meat kilt of Flo-Jo	0		Initiative: +100, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1291,7 +1291,7 @@
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	squat attention spanner	0		Familiar Weight: +5
-1310	spinning maroon funky fez	0		Familiar Weight: +5
+1310	maroon spinning funky fez	0		Familiar Weight: +5
 1311	mirror comfy blanket	0		Last Available: "2005-10"
 1312	teal inspector's Baron von Ratsworth's monocle	0		Item Drop: +15, Single Equip
 1313	skewed thinker's Baron von Ratsworth's money clip	0		Mysticality: +10, Single Equip
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	spoiled bowl of oriole's nest soup	3	crappy	
 1356	bunny liver	0		
-1357	watered-down mediocre blue blinking narrow Mt. Noob Pale Ale	2	decent	
+1357	mediocre watered-down narrow blinking blue Mt. Noob Pale Ale	2	decent	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	jittery ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1345,11 +1345,11 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	squat rhesus monkey	0		Familiar Weight: +5
-1365	bland snack-sized tofurkey leg	2	decent	
+1365	snack-sized bland tofurkey leg	2	decent	
 1366	moldy miniature tofurkey gravy	2	crappy	
-1367	normal thick herbal stuffing	5	good	
-1368	flavorless miniature narrow can-shaped gelatinous cranberry sauce	2	decent	
-1369	rotten small yams	2	crappy	
+1367	thick normal herbal stuffing	5	good	
+1368	miniature flavorless narrow can-shaped gelatinous cranberry sauce	2	decent	
+1369	small rotten yams	2	crappy	
 1370	sage rhinestone cowboy shirt	0		Mysticality Percent: +10
 1371	blue dog trainer's gingham blouse	0		Experience (familiar): +1
 1372	sage souvenir ski t-shirt	0		Mysticality Percent: +10
@@ -1385,7 +1385,7 @@
 1403	foul-smelling can of fake snow	0		Stench Damage: +10, Last Available: "2005-12"
 1404	cyan greedy colored-light &quot;necklace&quot;	0		Meat Drop: +20, Last Available: "2005-12"
 1405	squat occult tree skirt	0		Spell Damage Percent: +25, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	bite-sized tasty wreath-shaped Crimbo cookie	1	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	tasty bite-sized wreath-shaped Crimbo cookie	1	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	decent bell-shaped Crimbo cookie	3	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	decent tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	lion tamer's Unionize The Elves sign	0		Experience (familiar): +2, Last Available: "2005-12"
@@ -1402,16 +1402,16 @@
 1420	upside-down dog trainer's traffic cone of the detective	0		Experience (familiar): +1, Item Drop: +20, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
-1423	blue upside-down iceberglet	0		Last Available: "2006-02"
+1423	upside-down blue iceberglet	0		Last Available: "2006-02"
 1424	careful ice sickle of incineration	0		Monster Level: -10, Hot Spell Damage: +50, Softcore Only, Last Available: "2006-02"
 1425	fireproof ice baby	0		Hot Resistance: +3, Softcore Only, Last Available: "2006-02"
 1426	mirror toasty ice pick	0		Hot Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	blinking skewed veiny savvy ice skates	0		Mysticality Percent: +20, Maximum HP: +10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	miniature enchanted normal grue egg omelette	2	good	Effect: "Vented Spleen", Effect Duration: 5
+1428	enchanted normal miniature grue egg omelette	2	good	Effect: "Vented Spleen", Effect Duration: 5
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	shaking pregnant mushroom	0		
-1432	spoiled miniature mirror mushroom	2	crappy	
+1432	miniature spoiled mirror mushroom	2	crappy	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1439,13 +1439,13 @@
 1457	ghostly Goth Giant	0		
 1458	spoiled Valentine's Day cake	3	crappy	
 1459	mirror arrow'd heart balloon	0		
-1460	jittery lime green velvet box	0		
+1460	lime green jittery velvet box	0		
 1461	tumbling squashed frog	0		
 1462	eye of newt	0		
 1463	ghostly salamander spleen	0		
 1464	sleazy fairy gravy	0		
 1465	suede shortsword	0		
-1466	upside-down wobbly bamboo bokuto	0		
+1466	wobbly upside-down bamboo bokuto	0		
 1467	25-meat staff	0		
 1468	two-handed depthsword	0		
 1469	twirling bill bec-de-bardiche glaive-guisarme	0		
@@ -1456,7 +1456,7 @@
 1474	automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	blurry bouncing goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
-1477	bouncing ghostly plastic hard hat	0		Familiar Effect: "atk, cap 22"
+1477	ghostly bouncing plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	squat salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	olive football helmet	0		Familiar Effect: "atk, cap 37"
 1480	upside-down chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
@@ -1475,7 +1475,7 @@
 1493	banded ridiculously overelaborate ninja weapon of the early riser	0		Damage Absorption: +100, Adventures: +7
 1494	anodized warmed sugar-coated pine cone	0		Effect: "meat.enh", Effect Duration: 26, Last Available: "2020-09"
 1495	narrow Socratic traffic cone of the brazier	0		Experience (Mysticality): +1, Hot Spell Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	high-proof lousy gray gloomy mushroom wine	9	decent	
+1496	lousy high-proof gray gloomy mushroom wine	9	decent	
 1497	smooth mushroom wine	3	awesome	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	mirror whoopie cushion	0		Last Available: "2006-04"
@@ -1486,9 +1486,9 @@
 1504	quantum skewed snowcone	0		Effect: "Berry Thorny", Effect Duration: 67, Last Available: "2006-04"
 1505	tumbling ice cube with a fly in it	0		Last Available: "2006-04"
 1506	drinkable teal calle de miel with a fly in it	4	good	Last Available: "2006-04"
-1507	distilled bad enchanted rockin' wagon with a fly in it	5	decent	Effect: "Pill Power", Effect Duration: 45, Last Available: "2006-04"
-1508	drinkable weak perpendicular hula with a fly in it	2	good	Last Available: "2006-04"
-1509	bad weak slap and tickle with a fly in it	2	decent	Last Available: "2006-04"
+1507	bad distilled enchanted rockin' wagon with a fly in it	5	decent	Effect: "Pill Power", Effect Duration: 45, Last Available: "2006-04"
+1508	weak drinkable perpendicular hula with a fly in it	2	good	Last Available: "2006-04"
+1509	weak bad slap and tickle with a fly in it	2	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	toasty fake hand	0		Hot Damage: +5, Last Available: "2006-04"
 1512	altered wobbly Knob Goblin pet-buffing spray	1		
@@ -1499,12 +1499,12 @@
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	rock-hard banded Radio KoL Coffee Mug	0		Damage Absorption: +100, Damage Reduction: 5
-1521	blue pulsating Frank Gorshin trophy	0		
+1521	pulsating blue Frank Gorshin trophy	0		
 1522	lard-coated ruddy Radio Free Jersey	0		Maximum HP Percent: +40, Sleaze Spell Damage: +25
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	ghostly skewed diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Jack Frost's corkscrew of dire peril	0		Weapon Damage: +20, Cold Spell Damage: +50, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
@@ -1512,7 +1512,7 @@
 1531	blinking cool grass skirt	0		Moxie: +5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
 1532	rosewater-soaked grass hat	0		Stench Resistance: +3, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	Socratic grass blade	0		Experience (Mysticality): +1, Last Available: "2011-01"
-1534	green narrow raffle prize box	0		
+1534	narrow green raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	wobbly smartaleck's sparkly engagement ring	0		Moxie Percent: +30, Single Equip
@@ -1528,59 +1528,59 @@
 1548	blue Gazpacho's Glacial Grimoire of dire peril of the blizzard	0		Weapon Damage: +20, Cold Spell Damage: +25
 1549	bouncing MSG	0		
 1550	narrow blinking green family-friendly second-hand knockoff engagement ring	0		Sleaze Resistance: +1, Single Equip
-1551	enchanted artisanal green tumbling squat bottle of Domesticated Turkey	4	EPIC	Effect: "Moon-Eyed", Effect Duration: 30
-1552	lousy practically non-alcoholic bottle of Definit	1	decent	
-1553	acceptable strong bottle of Calcutta Emerald	5	good	
+1551	artisanal enchanted green squat tumbling bottle of Domesticated Turkey	4	EPIC	Effect: "Moon-Eyed", Effect Duration: 30
+1552	practically non-alcoholic lousy bottle of Definit	1	decent	
+1553	strong acceptable bottle of Calcutta Emerald	5	good	
 1554	acceptable bottle of Lieutenant Freeman	4	good	
 1555	drinkable bottle of Jorge Sinsonte	4	good	
-1556	fancy perfectly mixed practically non-alcoholic boxed champagne	1	EPIC	Effect: "Eggs-tra Sensory Perception", Effect Duration: 45
+1556	perfectly mixed practically non-alcoholic fancy boxed champagne	1	EPIC	Effect: "Eggs-tra Sensory Perception", Effect Duration: 45
 1557	flavorless bite-sized kumquat	1	decent	
 1558	bland blurry tangerine	3	decent	
 1559	tonic water	0		
 1560	stale cocktail onion	3	decent	
 1561	flavorless jumbo raspberry	5	decent	
-1562	snack-sized stale mirror kiwi	2	decent	
+1562	stale snack-sized mirror kiwi	2	decent	
 1563	lousy whiskey bittersweet	4	decent	
 1564	delicious narrow mimosette	4	awesome	
 1565	artisanal twirling tequila sunset	3	EPIC	
 1566	bad zmobie	4	decent	Wiki Name: "Zmobie (drink)"
 1567	high-proof hand-crafted blinking gin and tonic	7	EPIC	
-1568	perfectly mixed watered-down gray spinning vodka and tonic	2	EPIC	
+1568	watered-down perfectly mixed spinning gray vodka and tonic	2	EPIC	
 1569	special artisanal huge vodka gibson	3	EPIC	Effect: "On the Trolley", Effect Duration: 35
 1570	irresponsibly strong hand-crafted jittery gibson	8	EPIC	
-1571	special lousy parisian cathouse	3	decent	Effect: "Bone Homie", Effect Duration: 20
+1571	lousy special parisian cathouse	3	decent	Effect: "Bone Homie", Effect Duration: 20
 1572	bad blurry rabbit punch	3	decent	
-1573	spirit-forward fancy aged caipifruta	5	awesome	Effect: "Pop-eyed", Effect Duration: 5
+1573	spirit-forward aged fancy caipifruta	5	awesome	Effect: "Pop-eyed", Effect Duration: 5
 1574	lousy strong tumbling teqiwila	5	decent	
-1575	practically non-alcoholic lousy Divine	1	decent	
+1575	lousy practically non-alcoholic Divine	1	decent	
 1576	tolerable Gordon Bennett	3	good	
 1577	bad weak tangarita	2	decent	
-1578	hand-crafted weak mandarina colada	2	super ultra EPIC	
+1578	weak hand-crafted mandarina colada	2	super ultra EPIC	
 1579	bad extra-dry green gimlet	5	decent	
 1580	aged irresponsibly strong brick road	6	awesome	
 1581	acceptable vodka stratocaster	3	good	
-1582	aged boozy pulsating Neuromancer	5	awesome	
+1582	boozy aged pulsating Neuromancer	5	awesome	
 1583	enchanted mediocre prussian cathouse	4	decent	Effect: "Hot Blooded", Effect Duration: 30
 1584	perfectly mixed fortified Mae West	5	EPIC	
 1585	artisanal Mon Tiki	3	EPIC	
 1586	drinkable shaking teqiwila slammer	3	good	
-1587	delicious gigantic Knob lo mein	6	awesome	
+1587	gigantic delicious Knob lo mein	6	awesome	
 1588	adequate tumbling asparagus lo mein	3	good	
-1589	small stale Knoll lo mein	2	decent	
+1589	stale small Knoll lo mein	2	decent	
 1590	stale lo mein	3	decent	
 1591	toothsome olive lo mein	3	awesome	
 1592	thick normal hot hi mein	5	good	
-1593	adequate spinning lime green hi mein	4	good	
+1593	adequate lime green spinning hi mein	4	good	
 1594	decent hi mein	4	good	
 1595	adequate half-sized blinking hi mein	2	good	
-1596	flavorless special small jittery sleazy hi mein	2	decent	Effect: "Mushroom Might", Effect Duration: 50
+1596	small special flavorless jittery sleazy hi mein	2	decent	Effect: "Mushroom Might", Effect Duration: 50
 1597	crafty Junior LAAAAME merit badge	0		Maximum MP: +10, Last Available: "2006-05"
 1598	upside-down Senior LAAAAME merit badge of the storm	0		Maximum MP Percent: +40, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	perfectly mixed bouncing tangarita with a fly in it	3	EPIC	
 1601	hand-crafted practically non-alcoholic mandarina colada with a fly in it	1	EPIC	
-1602	boozy artisanal prussian cathouse with a fly in it	5	EPIC	
-1603	mediocre spirit-forward Mae West with a fly in it	5	decent	
+1602	artisanal boozy prussian cathouse with a fly in it	5	EPIC	
+1603	spirit-forward mediocre Mae West with a fly in it	5	decent	
 1604	mixed astronaut ice-cream	1		Effect: "Heart Aflame", Effect Duration: 5, Last Available: "2006-05"
 1605	skewed delectable catalyst	0		
 1606	pickled ultimate wad	1		
@@ -1611,7 +1611,7 @@
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	spinning lime green Spanish fly	0		
-1634	acceptable strong around the world	5	good	
+1634	strong acceptable around the world	5	good	
 1635	scrumdiddlyumptious solution	0		
 1636	blinking Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	unsweetened galvanized lotion of hotness	0		Effect: "Well-Lubed", Effect Duration: 15
@@ -1619,7 +1619,7 @@
 1639	frozen alkaline squat lotion of spookiness	0		Effect: "Preternatural Greed", Effect Duration: 20
 1640	aerosolized lotion of stench	0		Effect: "Turkey-Agitated", Effect Duration: 22
 1641	concentrated lotion of sleaziness	0		Effect: "Vented Spleen", Effect Duration: 62
-1642	strong lousy gray skewed Grimacite Bock	5	decent	Last Available: "2008-11"
+1642	lousy strong skewed gray Grimacite Bock	5	decent	Last Available: "2008-11"
 1643	bland tumbling wedge of gray cheese	4	decent	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
@@ -1628,13 +1628,13 @@
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	spoiled miniature foie gras	2	crappy	
+1651	miniature spoiled foie gras	2	crappy	
 1652	double-activated candy brain	0		Effect: "Wintry Breath", Effect Duration: 60, Last Available: "2020-09"
-1653	flame-wreathed smooth jewel-eyed wizard hat of the wise owl	0		Mysticality: +20, Moxie: +15, Hot Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	flame-wreathed smooth jewel-eyed wizard hat of the wise owl	0		Mysticality: +20, Moxie: +15, Hot Spell Damage: +10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
 1654	Jeselnik's lion tamer's wad of Crovacite	0		Experience (familiar): +2, Sleaze Damage: +25
 1655	spinning inspector's foul-smelling collar	0		Stench Damage: +10, Item Drop: +15
 1656	White Citadel Satisfaction Satchel	0		
-1657	blinking tumbling onion shurikens	0		
+1657	tumbling blinking onion shurikens	0		
 1658	purple Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
 1660	red pulsating Regular Cloaca Cola	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	fuchsia wobbly bubblewrap ore	0		
-1678	skewed jittery pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	jittery skewed pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	Jeselnik's Rosewater's sword	0		Mysticality Percent: +30, Sleaze Damage: +25
 1680	twirling hardened staff of Flo-Jo	0		Damage Reduction: 3, Initiative: +100
 1681	sinister brawny bubblewrap sword	0		Muscle Percent: +20, Spell Damage: +10
@@ -1677,7 +1677,7 @@
 1697	adequate tofu taco	3	good	
 1698	flavorless jumping bean taco	3	decent	
 1699	decent jumbo jittery catgut taco	5	good	
-1700	moldy tiny goat cheese taco	1	crappy	
+1700	tiny moldy goat cheese taco	1	crappy	
 1701	stale skewed green pr0n taco	3	decent	
 1702	energized galvanized wobbly alphabet gum	0		Effect: "Penguinny Flavor", Effect Duration: 32
 1703	Comma Chameleon egg	0		Free Pull
@@ -1702,7 +1702,7 @@
 1722	purple pulsating Lo Pan's crafty glistening staff	0		Maximum MP: +10, Spell Critical Percent: +30
 1723	cyan careful sage repeating crossbow	0		Mysticality Percent: +10, Monster Level: -10
 1725	jittery skewed bigger stick	0		
-1726	spinning blue sinewy crossbow string	0		
+1726	blue spinning sinewy crossbow string	0		
 1727	ghostly sturdy sword hilt	0		
 1728	tumbling curative dense meat sword	0		HP Regen Min: 3, HP Regen Max: 5
 1729	razor-sharp dense meat staff	0		Weapon Damage Percent: +25
@@ -1742,7 +1742,7 @@
 1763	censurious foon of fleshiness of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3
 1764	Spookyraven library key	0		
 1765	Spookyraven gallery key	0		
-1766	teal wobbly Spookyraven ballroom key	0		
+1766	wobbly teal Spookyraven ballroom key	0		
 1767	upside-down pack of chewing gum	0		
 1768	Gnomish toolbox	0		
 1769	rotten fricasseed brains	4	crappy	
@@ -1767,7 +1767,7 @@
 1788	shaking unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
 1790	perfectly mixed Ram's Face Lager	4	EPIC	
-1791	lime green upside-down skewed ram horns	0		
+1791	upside-down skewed lime green ram horns	0		
 1792	blinking fireproof coward's Travoltan trousers of vim and vigor	0		Maximum HP Percent: +50, Monster Level: -20, Hot Resistance: +3, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	bouncing grievous pool cue of the scaredy-cat	0		Weapon Damage Percent: +50, Monster Level: -15
 1794	denatured oxidized handful of hand chalk	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 33
@@ -1777,7 +1777,7 @@
 1798	narrow pile of animal bones	0		
 1799	narrow animal skull	0		
 1800	animal cranium	0		
-1801	lime green pulsating shaking animal jawbone	0		
+1801	shaking pulsating lime green animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	squat second cervical vertebra	0		
 1804	third cervical vertebra	0		
@@ -1827,7 +1827,7 @@
 1848	pulsating left tenth rib	0		
 1849	left eleventh rib	0		
 1850	left twelfth rib	0		
-1851	spinning maroon right first rib	0		
+1851	maroon spinning right first rib	0		
 1852	right second rib	0		
 1853	right third rib	0		
 1854	right fourth rib	0		
@@ -1924,13 +1924,13 @@
 1947	foul-smelling brainy worn tophat	0		Mysticality: +5, Stench Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	fuchsia clever veiny tap shoes	0		Maximum HP: +10, Maximum MP: +20, Single Equip
 1949	spoiled Manetwich	4	crappy	
-1950	yellow shaking bottle of Vangoghbitussin	0		
+1950	shaking yellow bottle of Vangoghbitussin	0		
 1951	hand-crafted bottle of Pinot Renoir	3	EPIC	
 1952	rotten diet desiccated apricot	1	crappy	
 1953	delicious watered-down flute of flat champagne	2	awesome	
-1954	spoiled small dehydrated caviar	2	crappy	
+1954	small spoiled dehydrated caviar	2	crappy	
 1955	fuchsia styrofoam peanuts	0		
-1956	high-proof hand-crafted snifter of thoroughly aged brandy	9	EPIC	
+1956	hand-crafted high-proof snifter of thoroughly aged brandy	9	EPIC	
 1957	huge quill pen	0		
 1958	inkwell	0		
 1959	tattered scrap of paper	0		
@@ -1969,13 +1969,13 @@
 1992	squat rubber WWBD? bracelet	0		
 1993	shaking cyan rubber WWSPD? bracelet	0		
 1994	fuchsia rubber WWtNSD? bracelet	0		
-1995	upside-down lime green heart necklace	0		Free Pull
+1995	lime green upside-down heart necklace	0		Free Pull
 1996	right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
-2001	fuchsia pulsating Vaso De Agua trading card	0		
+2001	pulsating fuchsia Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	Thorny Toad trading card	0		
 2004	cyan Chori Zo trading card	0		
@@ -1984,7 +1984,7 @@
 2007	Princess Rutabaga trading card	0		
 2008	cyan Roo trading card	0		
 2009	tumbling Woldo trading card	0		
-2010	jittery blinking The Snake trading card	0		
+2010	blinking jittery The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
 2012	tumbling Arrrmetia trading card	0		
 2013	Serenity trading card	0		
@@ -1993,14 +1993,14 @@
 2016	diamond necklace	0		
 2017	upside-down spade necklace	0		
 2018	club necklace	0		
-2019	upside-down blue upside-down cream pie	0		Free Pull
-2020	snack-sized normal cherry pie	2	good	
-2021	small rotten ghostly yellow strawberry pie	2	crappy	
+2019	upside-down upside-down blue cream pie	0		Free Pull
+2020	normal snack-sized cherry pie	2	good	
+2021	small rotten yellow ghostly strawberry pie	2	crappy	
 2022	half-sized moldy bouncing lemon meringue pie	2	crappy	
 2023	huge Genalen&trade; Bottle	1	crappy	
 2024	flavorless ghostly mixed wildflower greens	4	decent	
 2025	flavorless handful of walnuts	4	decent	
-2026	half-sized normal ghostly skewed nutty organic salad	2	good	
+2026	normal half-sized skewed ghostly nutty organic salad	2	good	
 2027	flavorless bouncing super salad	4	decent	
 2028	half-sized stale tofu wonton	2	decent	
 2029	bouncing hippy protest button	0		Single Equip
@@ -2032,11 +2032,11 @@
 2056	vacuum-sealed adder bladder	0		Effect: "Cold Blooded", Effect Duration: 35
 2057	pension check	0		
 2058	wobbly wobbly picnic basket	0		
-2059	cold-filtered vacuum-sealed narrow purple Black No. 2	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 59
+2059	cold-filtered vacuum-sealed purple narrow Black No. 2	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 59
 2060	jittery stanky sword of James Dean	0		Experience (Moxie): +3, Stench Spell Damage: +25
 2061	gravedigger's helmet	0		Spooky Damage: +10, Familiar Effect: "1xFairy, cap 40"
 2062	squat censurious shield of temperance	0		Sleaze Resistance: 8, Damage Reduction: 10
-2063	flavorless big blackberry	5	decent	
+2063	big flavorless blackberry	5	decent	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	blue twirling Annie Oakley's kick-ass kicks of Tarzan	0		Experience (Muscle): +3, Critical Hit Percent: +20, Single Equip
@@ -2122,9 +2122,9 @@
 2147	tumbling evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	jumbo spoiled frank	5	crappy	Last Available: "2011-12"
-2150	snack-sized decent fuchsia plate of franks and beans	2	good	Last Available: "2011-12"
+2150	decent snack-sized fuchsia plate of franks and beans	2	good	Last Available: "2011-12"
 2151	aged ghostly shot of blackberry schnapps	3	awesome	
-2152	green skewed capacitor relay	0		Last Available: "2011-12"
+2152	skewed green capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
 2155	skewed Feynman gate	0		Last Available: "2011-12"
@@ -2146,7 +2146,7 @@
 2171	squat lightning-fast astronaut pants of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +40, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	shaking ribald toy jet pack	0		Sleaze Damage: +10, Last Available: "2006-12"
 2173	wobbly triangular stone	0		
-2174	maroon jittery mossy stone sphere	0		
+2174	jittery maroon mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	bouncing cracked stone sphere	0		
 2177	rough stone sphere	0		
@@ -2161,18 +2161,18 @@
 2186	lime green unlit birthday cake	0		
 2187	lime green lit birthday cake	0		
 2188	ghostly flask of peppermint oil	1	decent	Last Available: "2006-12"
-2189	smooth spirit-forward flask of peppermint schnapps	5	awesome	Last Available: "2006-12"
+2189	spirit-forward smooth flask of peppermint schnapps	5	awesome	Last Available: "2006-12"
 2190	cyan yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	squat sheet music	0		Last Available: "2006-12"
 2193	half-sized stale shaking candy stake	2	decent	Last Available: "2006-12"
 2194	acceptable yellow eggnog	3	good	Last Available: "2006-12"
-2195	half-sized rotten maroon narrow bouncing unspeakable fruitcake	2	crappy	Last Available: "2006-12"
+2195	rotten half-sized maroon narrow bouncing unspeakable fruitcake	2	crappy	Last Available: "2006-12"
 2196	moldy gingerbread horror	4	crappy	Last Available: "2006-12"
 2197	liquefied alkaline but probably evil chocolate	0		Effect: "Weapon of Mass Destruction", Effect Duration: 39, Last Available: "2006-12"
 2198	spoiled bouncing bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	thick bland yellow blurry skull-shaped Crimboween cookie	5	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	big normal cyan tombstone-shaped Crimboween cookie	5	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	normal big cyan tombstone-shaped Crimboween cookie	5	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	zippy plastic gift-wrapping vampire	0		Initiative: +20, Last Available: "2006-12"
 2202	rock-hard plastic yuletide troll	0		Damage Reduction: 5, Last Available: "2006-12"
 2203	brainy plastic skeletal reindeer	0		Mysticality: +5, Single Equip, Last Available: "2006-12"
@@ -2192,7 +2192,7 @@
 2217	stale super ka-bob	3	decent	
 2218	small spoiled beer basted brat	2	crappy	
 2219	wicked Tropical Crimbo Sword	0		Spell Damage: +5, Last Available: "2006-12"
-2220	altered extra-alkaline moist olive spinning and Crimboween candy	0		Effect: "Sweetened and Fattened", Effect Duration: 22, Last Available: "2020-09"
+2220	altered extra-alkaline moist spinning olive and Crimboween candy	0		Effect: "Sweetened and Fattened", Effect Duration: 22, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	prompt liar's pants of the ox	0		Muscle: +20, Adventures: +3, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	friendly arcane researcher's juggler's balls	0		Experience Percent (Mysticality): +10, Familiar Weight: +3, Softcore Only, Last Available: "2007-01"
@@ -2200,7 +2200,7 @@
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	pulsating beefy evil eyeball pendant of doom	0		Muscle: +10, Spooky Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	colloidal arse-a'fire elixir	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 35, Last Available: "2007-01"
-2228	nitrogenated twirling mirror fuchsia cosmic lemonade	0		Effect: "Always In Motion", Effect Duration: 20, Last Available: "2007-01"
+2228	nitrogenated mirror twirling fuchsia cosmic lemonade	0		Effect: "Always In Motion", Effect Duration: 20, Last Available: "2007-01"
 2229	ionized non-denatured toad horn	0		Effect: "Ponderous Potency", Effect Duration: 28, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	mote	0		
@@ -2236,18 +2236,18 @@
 2262	bird rib	0		
 2263	lion oil	0		
 2264	adequate stunt nuts	4	good	
-2265	moldy half-sized wet stew	2	crappy	
+2265	half-sized moldy wet stew	2	crappy	
 2266	red wet stunt nut stew	0		
 2267	blue Mega Gem	0		
 2268	healthy Staff of Fats	0		Maximum HP Percent: +20
-2269	delicious half-sized sausage wonton	2	awesome	
+2269	half-sized delicious sausage wonton	2	awesome	
 2270	huge experienced belt of the blizzard	0		Experience: +2, Cold Spell Damage: +25, Single Equip
 2271	aged extra-dry bottle of Merlot	5	awesome	
 2272	fortified acceptable squat bottle of Port	5	good	
 2273	fortified delicious bottle of Pinot Noir	5	awesome	
-2274	practically non-alcoholic lousy shaking bottle of Zinfandel	1	decent	
+2274	lousy practically non-alcoholic shaking bottle of Zinfandel	1	decent	
 2275	bad bottle of Marsala	4	decent	
-2276	mediocre fancy fortified bottle of Muscat	5	decent	Effect: "Frog In Your Throat", Effect Duration: 50
+2276	fortified mediocre fancy bottle of Muscat	5	decent	Effect: "Frog In Your Throat", Effect Duration: 50
 2277	bouncing Fernswarthy's key	0		
 2278	upside-down huge Fernswarthy's letter	0		
 2279	book	0		
@@ -2303,17 +2303,17 @@
 2329	upside-down handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	yummy huge Better Than Cuddling Cake	6	awesome	
+2332	huge yummy Better Than Cuddling Cake	6	awesome	
 2333	ninja snowman	0		
 2334	upside-down Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
 2336	aromatic ruddy pipe	0		Maximum HP Percent: +40, Stench Resistance: +1
 2337	reinforced beaded headband of the brute	0		Muscle Percent: +30, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	half-sized rotten pudding	2	crappy	Wiki Name: "black pudding (food)"
-2339	weak smooth Blackfly Chardonnay	2	awesome	
-2340	weak tolerable enchanted & tan	2	good	Effect: "Salt Rockin'", Effect Duration: 25
+2338	rotten half-sized pudding	2	crappy	Wiki Name: "black pudding (food)"
+2339	smooth weak Blackfly Chardonnay	2	awesome	
+2340	tolerable enchanted weak & tan	2	good	Effect: "Salt Rockin'", Effect Duration: 25
 2341	tumbling pepper	0		
-2342	half-sized decent forest cake	2	good	
+2342	decent half-sized forest cake	2	good	
 2343	stale forest ham	3	decent	
 2344	flattened extra-polarized shaking filthworm hatchling scent gland	0		Effect: "Powdered", Effect Duration: 44
 2345	oxidized filthworm drone scent gland	0		Effect: "Inappropriate Spirit", Effect Duration: 39
@@ -2341,17 +2341,17 @@
 2367	pulsating carbonated soy milk	0		
 2368	up-at-dawn flowing hippy skirt of the dark arts	0		Spell Damage Percent: +100, Adventures: +5, Familiar Effect: "stench atk, 1xFairy, cap 45"
 2369	gray filthy poultice	0		
-2370	fuchsia bouncing natural fennel soda	0		
+2370	bouncing fuchsia natural fennel soda	0		
 2371	jittery smoke bomb	0		
 2372	bunch of bananas	0		
-2373	moldy diet banana	1	crappy	
+2373	diet moldy banana	1	crappy	
 2374	banana peel	0		
-2375	normal super-sized banana cream pie	5	good	
+2375	super-sized normal banana cream pie	5	good	
 2376	perfectly mixed banana daiquiri	3	EPIC	
-2377	aged high-proof wobbly bungle in the jungle	7	awesome	
+2377	high-proof aged wobbly bungle in the jungle	7	awesome	
 2378	purple banana spritzer	0		
 2379	super-ionized twirling banana smoothie	0		Effect: "Fruited", Effect Duration: 22
-2380	red skewed dandy lion cub	0		Free Pull, Last Available: "2007-03"
+2380	skewed red dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	shaking woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	tumbling class ring	0		
@@ -2374,7 +2374,7 @@
 2400	huge molotov cocktail cocktail	0		
 2401	bouncing hale smartaleck's beer bong	0		Moxie Percent: +30, Maximum HP: +20
 2402	gauze garter	0		
-2403	shaking lime green barrel of gunpowder	0		
+2403	lime green shaking barrel of gunpowder	0		
 2404	cyan jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
@@ -2391,7 +2391,7 @@
 2417	Jack Frost's bounty-hunting rifle	0		Cold Spell Damage: +50
 2418	bounty-hunting pants of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	activated pickled bottle of rhinoceros hormones	0		Effect: "Gingerbread Robust", Effect Duration: 12
-2420	flattened blinking jittery teeny-tiny magic scroll	0		Effect: "Cute Vision", Effect Duration: 63
+2420	flattened jittery blinking teeny-tiny magic scroll	0		Effect: "Cute Vision", Effect Duration: 63
 2421	quantum quadruple-concentrated polymerized bottle of pirate juice	0		Effect: "Cold as Ice", Effect Duration: 69
 2422	warmed irradiated pet snacks	0		Effect: "The Style... of the Future", Effect Duration: 12
 2423	improved modified Mick's IcyVapoHotness Inhaler	0		Effect: "Shredding, Sweating", Effect Duration: 23
@@ -2492,20 +2492,20 @@
 2519	lousy tumbling McMillicancuddy's Special Lager	3	decent	
 2520	mediocre weak melted Jell-o shot	2	decent	
 2521	practically non-alcoholic drinkable cruelty-free wine	1	good	
-2522	lousy spinning spinning fuchsia thistle wine	3	decent	
+2522	lousy spinning fuchsia spinning thistle wine	3	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	tasty special jittery fish	3	awesome	Effect: "Improprie Tea", Effect Duration: 10
-2526	adequate mirror olive blinking fish casserole	3	good	
+2526	adequate olive mirror blinking fish casserole	3	good	
 2527	moldy half-sized fish lasagna	2	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	big decent gnatloaf	5	good	
+2529	decent big gnatloaf	5	good	
 2530	moldy gnatloaf casserole	3	crappy	
 2531	flavorless olive gnat lasagna	4	decent	
 2532	pork	0		
 2533	normal bite-sized pork chop sandwiches	1	good	
 2534	flavorless mirror pork casserole	3	decent	
-2535	special big rotten blurry pork lasagna	5	crappy	Effect: "Little Mouse Skull Buddy", Effect Duration: 10
+2535	big rotten special blurry pork lasagna	5	crappy	Effect: "Little Mouse Skull Buddy", Effect Duration: 10
 2536	canopic jar	0		
 2537	spice	0		
 2538	huge organs	0		
@@ -2535,7 +2535,7 @@
 2562	half-rotten brain	0		
 2563	bonesaw	0		
 2564	plus-sized phylactery	0		
-2565	bouncing teal narrow can of Ghuol-B-Gone&trade;	0		
+2565	teal narrow bouncing can of Ghuol-B-Gone&trade;	0		
 2566	pulsating Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
 2568	Azazel's tutu	0		
@@ -2567,13 +2567,13 @@
 2594	strong acceptable thermos full of Knob coffee	5	good	
 2595	pickled Ben-Gal&trade; Balm	0		Effect: "Billiards Belligerence", Effect Duration: 12
 2596	leathery cat skin	0		
-2597	upside-down purple leathery bat skin	0		
+2597	purple upside-down leathery bat skin	0		
 2598	leathery rat skin	0		
 2599	teal Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	blurry Da Vinci's savvy Staff of the Midnight Snack of the sewer	0		Mysticality Percent: +20, Experience (Mysticality): +5, Stench Damage: +25
 2602	veiny brainy Staff of Blood and Pudding of the scaredy-cat	0		Mysticality: +5, Maximum HP: +10, Monster Level: -15
-2603	huge pulsating smoldering box	0		
+2603	pulsating huge smoldering box	0		
 2604	bouncing supercharged Tuesday's ruby	0		Maximum MP Percent: +30
 2605	palm frond	0		
 2606	huge palm-frond fan	0		
@@ -2585,12 +2585,12 @@
 2612	ghostly vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	ghostly mojo filter	0		
-2615	snack-sized normal skewed savoy truffle	2	good	
+2615	normal snack-sized skewed savoy truffle	2	good	
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	Annie Oakley's Iiti Kitty phone charm	0		Critical Hit Percent: +20, Single Equip
 2619	purple jar of swamp gas	0		Last Available: "2007-05"
-2620	yummy miniature unidentified jerky	2	awesome	
+2620	miniature yummy unidentified jerky	2	awesome	
 2621	executive nasty rat mask of Tarzan	0		Experience (Muscle): +3, Meat Drop: +40, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	flame-retardant foul-smelling ratskin belt	0		Stench Damage: +10, Hot Resistance: +1, Single Equip
 2623	shaking ghostly dance instructor's supercool rattail whip	0		Moxie Percent: +20, Experience Percent (Moxie): +10
@@ -2622,16 +2622,16 @@
 2649	narrow careful Lord Spookyraven's ear trumpet	0		Monster Level: -10, Single Equip
 2650	red bottled pixie	0		Free Pull
 2651	red pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	stale small S.T.L.T.	2	decent	Last Available: "2007-06"
+2652	small stale S.T.L.T.	2	decent	Last Available: "2007-06"
 2653	bland miniature mirror honey-dew	2	decent	Last Available: "2007-06"
 2654	spirit-forward hand-crafted Xanadian	5	EPIC	Last Available: "2007-06"
 2655	irradiated bottle of absinthe	0		Effect: "Mushroom Samba", Effect Duration: 61, Last Available: "2007-06"
 2656	baleful Fonzie's Drowsy Sword	0		Experience (Moxie): +1, Spell Damage: +25
-2657	snack-sized normal escargotsicle	2	good	Last Available: "2007-06"
+2657	normal snack-sized escargotsicle	2	good	Last Available: "2007-06"
 2658	acceptable bottle of realpagne	3	good	Last Available: "2007-06"
 2659	shaking padded albatross necklace	0		Damage Absorption: +20, Single Equip, Last Available: "2007-06"
 2660	dried lime green not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	acceptable special flask of Amontillado	3	good	Effect: "Spiro Gyro", Effect Duration: 35, Last Available: "2007-06"
+2661	special acceptable flask of Amontillado	3	good	Effect: "Spiro Gyro", Effect Duration: 35, Last Available: "2007-06"
 2662	Newton's ball mask	0		Experience (Mysticality): +3, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	shellacked Can-Can skirt	0		Damage Reduction: 7, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	unsweetened sensitive poetry journal	0		Effect: "Hombre Muerto Caminando", Effect Duration: 21, Last Available: "2007-06"
@@ -2640,7 +2640,7 @@
 2667	polymerized polarized spiky collar	0		Effect: "Warm Shoulders", Effect Duration: 31, Last Available: "2007-06"
 2668	powdered can-can-in-a-can	1		Last Available: "2007-06"
 2669	diluted patent antipsychotics	1		Effect: "Boo Tea", Effect Duration: 35, Last Available: "2007-06"
-2670	compressed cyan squat Mariner's Friend cough drops	1		Last Available: "2007-06"
+2670	compressed squat cyan Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	artisanal shot of nepenthe schnapps	3	EPIC	Last Available: "2007-06"
 2672	olive library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
@@ -2665,7 +2665,7 @@
 2692	cyan clever steel-toed driftwood sculpture	0		Damage Reduction: 9, Maximum MP: +20
 2693	flame-retardant deadly massive sitar	0		Weapon Damage: +5, Hot Resistance: +1
 2694	rosewater-soaked nasty stone baseball cap of the scaredy-cat	0		Monster Level: -15, Stench Damage: +5, Stench Resistance: +3, Familiar Effect: "1xVolley, cap 48"
-2695	tolerable practically non-alcoholic cup of beer	1	good	
+2695	practically non-alcoholic tolerable cup of beer	1	good	
 2696	ovoid thing	0		
 2697	squat teal duct tape	0		
 2698	duct tape wallet	0		
@@ -2694,27 +2694,27 @@
 2721	lightning-fast Sherlock's educational hand-carved staff	0		Experience: +1, Item Drop: +25, Initiative: +40
 2722	jittery shaking scandalous banded forbidden Staff of the Greasefire of Gandalf	0		Spell Damage Percent: +50, Damage Absorption: +100, Spell Critical Percent: +20, Sleaze Damage: +5
 2723	flame-retardant Jeselnik's Staff of the Grand Flamb&eacute; of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +25, Hot Resistance: +1
-2724	moldy super-sized bowl of rye sprouts	5	crappy	
-2725	stale half-sized blurry cob of corn	2	decent	
+2724	super-sized moldy bowl of rye sprouts	5	crappy	
+2725	half-sized stale blurry cob of corn	2	decent	
 2726	immense decent blinking juniper berries	6	good	
 2727	stale plum	4	decent	
 2728	normal blinking pear	4	good	
-2729	stale spinning blurry peach	4	decent	
-2730	weak artisanal plum wine	2	EPIC	
+2729	stale blurry spinning peach	4	decent	
+2730	artisanal weak plum wine	2	EPIC	
 2731	acceptable high-proof shot of pear schnapps	6	good	
 2732	artisanal gray shot of peach schnapps	4	EPIC	
-2733	spoiled fancy half-sized teal bunch of square grapes	2	crappy	Effect: "Seeing Colors", Effect Duration: 30
-2734	flavorless huge fancy blurry brown sugar cane	10	decent	Effect: "Fireproof Lips", Effect Duration: 45
-2735	adequate thick sandwich of the gods	5	good	
+2733	spoiled half-sized fancy teal bunch of square grapes	2	crappy	Effect: "Seeing Colors", Effect Duration: 30
+2734	fancy huge flavorless blurry brown sugar cane	10	decent	Effect: "Fireproof Lips", Effect Duration: 45
+2735	thick adequate sandwich of the gods	5	good	
 2736	smooth upside-down Pan-Dimensional Gargle Blaster	4	awesome	
 2737	boiled leopard-print barbell	1	crappy	Effect: "Rotten Memories", Effect Duration: 45
 2738	pile of smoking rags	0		
-2739	quadruple-pressed double-activated narrow teal panty raider camouflage	0		Effect: "Stop and Smell the Fudge", Effect Duration: 38
+2739	quadruple-pressed double-activated teal narrow panty raider camouflage	0		Effect: "Stop and Smell the Fudge", Effect Duration: 38
 2740	family-friendly knitted nasty Staff of the Walk-In Freezer	0		Stench Damage: +5, Cold Resistance: +3, Sleaze Resistance: +1
-2741	drinkable weak boilermaker	2	good	
+2741	weak drinkable boilermaker	2	good	
 2742	normal bouncing steel lasagna	3	quest	
 2743	mediocre steel margarita	3	quest	
-2744	compressed shaking yellow steel-scented air freshener	1		
+2744	compressed yellow shaking steel-scented air freshener	1		
 2745	galvanized gremlin mutagen	0		Effect: "Stimulated Brain", Effect Duration: 14
 2746	colloidal blinking extra-potent gremlin mutagen	0		Effect: "Dreadful Smell", Effect Duration: 62
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2737,16 +2737,16 @@
 2764	Usain Bolt's Jeselnik's steel-toed Order of the Silver Wossname	0		Damage Reduction: 9, Sleaze Damage: +25, Initiative: +80, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	rotten half-sized enchanted Crimbo pie	2	crappy	Effect: "Hood Ridin'", Effect Duration: 35
+2767	half-sized enchanted rotten Crimbo pie	2	crappy	Effect: "Hood Ridin'", Effect Duration: 35
 2768	flavorless pear tart	3	decent	
 2769	half-sized normal peach pie	2	good	
 2770	improved double-wet chunk of rock salt	0		Effect: "Dance Interpreter", Effect Duration: 21
 2771	enhanced polymerized mirror handful of pine needles	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 59
-2772	gray shaking steamy ruby	0		
+2772	shaking gray steamy ruby	0		
 2773	tumbling glacial sapphire	0		
 2774	unearthly onyx	0		
 2775	effluvious emerald	0		
-2776	pulsating wobbly tawdry amethyst	0		
+2776	wobbly pulsating tawdry amethyst	0		
 2777	Van der Graaf personal trainer's filigreed hamethyst earring	0		Experience Percent (Muscle): +10, MP Regen Min: 5, MP Regen Max: 7
 2778	chilly stylish strapping filigreed hamethyst necklace	0		Muscle: +5, Moxie: +25, Cold Damage: +5, Single Equip
 2779	Jeselnik's padded filigreed hamethyst ring of the empath	0		Damage Absorption: +20, Familiar Weight: +5, Sleaze Damage: +25, Single Equip
@@ -2811,7 +2811,7 @@
 2838	stanky slick glowstick	0		Moxie: +10, Stench Spell Damage: +25, Last Available: "2007-08"
 2839	dog trainer's Periodical Paintbrush	0		Experience (familiar): +1, Softcore Only
 2840	hand-crafted bouncing bottle of cooking sherry	4	EPIC	
-2841	decent big packet of ketchup	5	good	
+2841	big decent packet of ketchup	5	good	
 2842	artisanal accidental cider	4	EPIC	
 2843	normal dire fudgesicle	4	good	
 2844	ribald frightening occult navel ring of navel gazing of Tarzan	0		Experience (Muscle): +3, Spell Damage Percent: +25, Spooky Damage: +5, Sleaze Damage: +10, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2820,7 +2820,7 @@
 2847	blinking cyan zippy Dallas Dynasty Falcon Crest shield	0		Initiative: +20, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	smooth practically non-alcoholic moonberry wine cooler	1	awesome	
+2850	practically non-alcoholic smooth moonberry wine cooler	1	awesome	
 2851	decent fine aged cheddarwurst	4	good	
 2852	pulsating branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2917,17 +2917,17 @@
 2945	lard-coated Jeselnik's party hat	0		Sleaze Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "4xLep, cap 7"
 2946	frightening coward's V for Vivala mask	0		Monster Level: -20, Spooky Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	irresponsibly strong fancy artisanal shot of rotgut	7	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 5
+2948	artisanal irresponsibly strong fancy shot of rotgut	7	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 5
 2949	altered twirling jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Thought", Effect Duration: 35
 2950	Cap'm Caronch's Map	0		
-2951	cyan skewed Orcish Frat House blueprints	0		
+2951	skewed cyan Orcish Frat House blueprints	0		
 2952	narrow glowstick of the wise owl of the businessman	0		Mysticality: +20, Meat Drop: +50, Last Available: "2007-11"
 2953	yellow charrrm bracelet	0		
 2954	green tip jar of doom	0		Spooky Spell Damage: +50
-2955	rotten massive yam candy	9	crappy	
+2955	massive rotten yam candy	9	crappy	
 2956	cocktail napkin	0		
 2957	pulsating rum barrel charrrm	0		
-2958	bland enchanted twirling tube of cranberry Go-Goo	4	decent	Effect: "Amorous Avarice", Effect Duration: 20
+2958	enchanted bland twirling tube of cranberry Go-Goo	4	decent	Effect: "Amorous Avarice", Effect Duration: 20
 2959	sizzling rum barrel charrrm bracelet	0		Hot Damage: +10
 2960	normal jumbo single-serving herbal stuffing	5	good	
 2961	tiny tasty ghostly packet of tofurkey gravy	1	awesome	
@@ -2995,29 +2995,29 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	watered-down acceptable corpse on the beach	2	good	
-3026	weak acceptable corpsetini	2	good	
-3027	enchanted acceptable high-proof corpsedriver	8	good	Effect: "Crusty Head", Effect Duration: 25
+3026	acceptable weak corpsetini	2	good	
+3027	high-proof enchanted acceptable corpsedriver	8	good	Effect: "Crusty Head", Effect Duration: 25
 3028	bad Corpse Island iced tea	3	decent	
 3029	mediocre red-headed corpse	3	decent	
 3030	drinkable blurry kamicorpse-ee	4	good	
-3031	spirit-forward artisanal ghostly corpsel	5	EPIC	
+3031	artisanal spirit-forward ghostly corpsel	5	EPIC	
 3032	perfectly mixed purple corpsebite	4	EPIC	
 3033	spinning hardy pirate fledges	0		Maximum HP: +50
 3034	piece of thirteen	0		
-3035	snack-sized bland pearl onion	2	decent	
-3036	bite-sized spoiled sea biscuit	1	crappy	
+3035	bland snack-sized pearl onion	2	decent	
+3036	spoiled bite-sized sea biscuit	1	crappy	
 3037	delicious practically non-alcoholic bottle of rum	1	awesome	
 3038	acceptable practically non-alcoholic bottle of black-label rum	1	good	
-3039	jittery tumbling cannonball	0		
+3039	tumbling jittery cannonball	0		
 3040	voodoo skull	0		
 3041	teal joke scroll	0		
 3042	squat Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	lime green spinning metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	skewed narrow metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	spoiled gigantic nanite-infested gingerbread bugbear	7	crappy	Last Available: "2007-12"
+3044	skewed narrow metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	gigantic spoiled nanite-infested gingerbread bugbear	7	crappy	Last Available: "2007-12"
 3046	fancy decent gray blurry nanite-infested candy cane	3	good	Effect: "Wintergreen Warmongery", Effect Duration: 40, Last Available: "2020-09"
 3047	stale nanite-infested fruitcake	4	decent	Last Available: "2007-12"
-3048	acceptable irresponsibly strong nanite-infested eggnog	9	good	Last Available: "2007-12"
+3048	irresponsibly strong acceptable nanite-infested eggnog	9	good	Last Available: "2007-12"
 3049	green El Vibrato power sphere	0		
 3050	flame-wreathed eyepatch	0		Hot Spell Damage: +10, Familiar Effect: "spooky atk, 1xBarrr"
 3051	blurry frightening cutlass	0		Spooky Damage: +5
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	narrow hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	greedy marionette collective	0		Meat Drop: +20, Last Available: "2007-12"
 3082	twirling monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3097,10 +3097,10 @@
 3125	unsweetened boiled piece of after eight	0		Effect: "Pockets of Fire", Effect Duration: 17
 3126	hobo nickel	0		
 3127	sandcastle	0		
-3128	olive squat marshmallow	0		
-3129	miniature normal squat roasted marshmallow	2	good	
+3128	squat olive marshmallow	0		
+3129	normal miniature squat roasted marshmallow	2	good	
 3130	disc	0		Last Available: "2008-01"
-3131	snack-sized fancy delicious tin cup of mulligan stew	2	awesome	Effect: "Mutated", Effect Duration: 25
+3131	fancy delicious snack-sized tin cup of mulligan stew	2	awesome	Effect: "Mutated", Effect Duration: 25
 3132	greasy flamin' bindle of the pedagogue	0		Experience: +3, Sleaze Spell Damage: +10
 3133	jittery spinning rosewater-soaked freezin' bindle of the pedagogue	0		Experience: +3, Stench Resistance: +3
 3134	healthy stinkin' bindle of the cougar	0		Moxie: +20, Maximum HP Percent: +20
@@ -3139,17 +3139,17 @@
 3167	augmented El Vibrato drone	0		
 3168	quantum ghostly seal eyeball	0		Effect: "Cranberry Cordiality", Effect Duration: 20
 3169	stale turtle soup	4	decent	Effect: "[598]A Little Bit Evil"
-3170	cyan jittery evil noodles	0		
+3170	jittery cyan evil noodles	0		
 3171	spinning skewed spinning nauseating reagent	0		
 3172	squat evil paper umbrella of courage	0		Spooky Resistance: +3
 3173	oxidized polarized blurry evil vihuela	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 67
 3174	stale evil boring spaghetti	3	decent	
-3175	decent enchanted massive evil noodles	10	good	Effect: "Blessing of the Hot Linguine", Effect Duration: 10
+3175	enchanted massive decent evil noodles	10	good	Effect: "Blessing of the Hot Linguine", Effect Duration: 10
 3176	yummy blurry evil noodles	3	awesome	
 3177	miniature toothsome evil painful penne pasta	2	awesome	
 3178	decent 3vi1 pr0n m4nic0tti	4	good	
-3179	snack-sized moldy maroon evil ravioli della hippy	2	crappy	
-3180	super-sized delicious evil noodles	5	awesome	
+3179	moldy snack-sized maroon evil ravioli della hippy	2	crappy	
+3180	delicious super-sized evil noodles	5	awesome	
 3181	ionized corrupted squat evil potion of potency	0		Effect: "Dirty Pear", Effect Duration: 31
 3182	ionized activated shaking evil libation of liveliness	0		Effect: "Whitened Teeth", Effect Duration: 19
 3183	frozen evil tomato juice of powerful power	0		Effect: "Bricked-In", Effect Duration: 44
@@ -3158,7 +3158,7 @@
 3186	electrified evil serum of sarcasm	0		Effect: "Worth Your Salt", Effect Duration: 62
 3187	pickled magnetized dry upside-down evil philter of phorce	0		Effect: "Cringle's Curative Carol", Effect Duration: 23
 3188	watered-down mediocre an evil sump'm sump'm	2	decent	
-3189	aged weak evil ducha de oro	2	awesome	
+3189	weak aged evil ducha de oro	2	awesome	
 3190	weak artisanal evil horizontal tango	2	super EPIC	
 3191	mediocre upside-down cyan evil roll in the hay	3	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3173,7 +3173,7 @@
 3201	thick padded envelope	0		
 3202	reassuring dog trainer's steel-toed KoL Con IV Pole	0		Damage Reduction: 9, Experience (familiar): +1, Spooky Resistance: +1, Last Available: "2007-09"
 3203	dwarvish magazine	0		
-3204	jittery squat dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
+3204	squat jittery dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
@@ -3195,16 +3195,16 @@
 3223	tumbling sewer nuggets	0		
 3224	sewer wad	0		
 3225	lousy triple-distilled pulsating bottle of sewage schnapps	8	decent	
-3226	special lousy watered-down bottle of Ooze-O	2	decent	Effect: "Haunted Liver", Effect Duration: 15
+3226	lousy special watered-down bottle of Ooze-O	2	decent	Effect: "Haunted Liver", Effect Duration: 15
 3227	miniature moldy C.H.U.M. chum	2	crappy	
 3228	half-sized decent huge unfortunate dumplings	2	good	
 3229	decaying goldfish liver	0		
 3230	enhanced narrow oil of oiliness	0		Effect: "Capricorn Rising", Effect Duration: 53
 3231	nasty tattered paper crown	0		Stench Damage: +5, Familiar Effect: "1xSombrero, cap 15"
-3232	snack-sized spoiled vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
+3232	spoiled snack-sized vanilla-frosted king cake	2	crappy	Last Available: "2008-03"
 3233	yellow inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
-3235	wobbly blurry noodle	0		
+3235	blurry wobbly noodle	0		
 3236	Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	squat Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
@@ -3237,12 +3237,12 @@
 3265	bag of Crotchety Pine saplings	0		
 3266	green bag of Saccharine Maple saplings	0		
 3267	blurry bag of Laughing Willow saplings	0		
-3268	cold-filtered Vulcanized skewed skewed maroon handful of Crotchety Pine needles	0		Effect: "Hare-o-dynamic", Effect Duration: 55
+3268	cold-filtered Vulcanized maroon skewed skewed handful of Crotchety Pine needles	0		Effect: "Hare-o-dynamic", Effect Duration: 55
 3269	polymerized lump of Saccharine Maple sap	0		Effect: "Memory of Resilience", Effect Duration: 18
 3270	galvanized quantum handful of Laughing Willow bark	0		Effect: "Bandersnatched", Effect Duration: 34
-3271	rosewater-soaked crotchety pants	0		Stench Resistance: +3, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	rosewater-soaked crotchety pants	0		Stench Resistance: +3, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	chaotic Saccharine Maple pendant	0		Spell Critical Percent: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	Jack Frost's willowy bonnet	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	Jack Frost's willowy bonnet	0		Cold Spell Damage: +50, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	blinking flavored foot massage oil	0		Last Available: "2008-04"
 3275	blurry dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	frosty stick-on eyebrow piercing	0		Cold Spell Damage: +10, Last Available: "2008-04"
-3283	big stale tumbling salad	5	decent	
+3283	stale big tumbling salad	5	decent	
 3284	hardened strapping C.H.U.M. lantern	0		Muscle: +5, Damage Reduction: 3
 3285	maroon toasty C.H.U.M. knife	0		Hot Damage: +5
 3286	tumbling Usain Bolt's Frosty's snowball sack	0		Initiative: +80
@@ -3325,7 +3325,7 @@
 3353	energized llama lama gong	0		Effect: "Inebriate Pride", Effect Duration: 14, Last Available: "2008-06"
 3354	snack-sized bland banana-frosted king cake	2	decent	Last Available: "2008-08"
 3355	pulsating cyan weightlifter's brown plastic baby	0		Muscle: +15, Single Equip, Last Available: "2008-08"
-3356	upside-down skewed plump juicy grub	0		Last Available: "2008-06"
+3356	skewed upside-down plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	twirling delectable fire ant	0		Last Available: "2008-06"
 3359	narrow scrumptious ice ant	0		Last Available: "2008-06"
@@ -3339,7 +3339,7 @@
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	pickled mirror squat glimmering roc feather	1	awesome	Last Available: "2008-06"
 3369	modified jittery glimmering phoenix feather	1		Last Available: "2008-06"
-3370	diluted spinning squat glimmering penguin feather	1		Last Available: "2008-06"
+3370	diluted squat spinning glimmering penguin feather	1		Last Available: "2008-06"
 3371	distilled pulsating glimmering buzzard feather	1		Effect: "Egg-stortionary Tactics", Effect Duration: 35, Last Available: "2008-06"
 3372	powdered glimmering raven feather	1		Last Available: "2008-06"
 3373	dehydrated skewed glimmering great tit feather	1		Effect: "Headstrong", Effect Duration: 45, Last Available: "2008-06"
@@ -3419,7 +3419,7 @@
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	twirling cotton candy plug	0		Last Available: "2008-08"
 3454	lime green cotton candy pillow	0		Last Available: "2008-08"
-3455	red jittery cotton candy bale	0		Last Available: "2008-08"
+3455	jittery red cotton candy bale	0		Last Available: "2008-08"
 3456	curative trusty torch	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-12"
 3457	yellow brainy Junior Adventurer's merit badge	0		Mysticality: +5
 3458	quantum deionized STYX deodorant body spray	0		Effect: "Arse-a'fire", Effect Duration: 69
@@ -3429,7 +3429,7 @@
 3462	terrible poem	0		
 3463	hand-crafted bottle of sake	4	EPIC	
 3464	healthy round pebble	0		Maximum HP Percent: +20
-3465	rotten special miniature Bash-&#332;s cereal	2	crappy	Effect: "Feet of Watermelon", Effect Duration: 40, Wiki Name: "Bash-Os cereal"
+3465	special miniature rotten Bash-&#332;s cereal	2	crappy	Effect: "Feet of Watermelon", Effect Duration: 40, Wiki Name: "Bash-Os cereal"
 3466	wobbly flame-wreathed Temple Grandin's groovy haiku katana	0		Moxie Percent: +10, Familiar Weight: +7, Hot Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	ghostly scorching plastic baby	0		Hot Damage: +25, Single Equip, Last Available: "2008-12"
@@ -3448,12 +3448,12 @@
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	upside-down passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	ghostly psychedelic bubble wand	0		Familiar Weight: +5
-3484	mirror gray eye 'n' horn shampoo	0		Familiar Weight: +5
+3484	gray mirror eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	activated glittery mascara	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 41
 3486	bouncing dull fish scale	0		
 3487	upside-down rough fish scale	0		
 3488	pristine fish scale	0		
-3489	flavorless bite-sized beefy fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
+3489	bite-sized flavorless beefy fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
 3490	immense enchanted stale glistening fish meat	6	decent	Effect: "Fishy", Effect Duration: 5
 3491	normal slick fish meat	3	good	Effect: "Fishy", Effect Duration: 5
 3492	healthy fish scimitar of Flo-Jo	0		Maximum HP Percent: +20, Initiative: +100
@@ -3461,13 +3461,13 @@
 3494	skewed ghostly perfumed wholesome fish bazooka	0		Maximum HP Percent: +10, Stench Resistance: +5
 3495	polymerized green sea salt crystal	0		Effect: "Electrolit Up", Effect Duration: 22
 3496	magnetized oxidized bazookafish bubble gum	0		Effect: "Preemptive Medicine", Effect Duration: 23
-3497	drinkable weak bottle of Pete's Sake	2	good	
+3497	weak drinkable bottle of Pete's Sake	2	good	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	green witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	tiny bland canap&eacute;s	1	decent	
+3501	bland tiny canap&eacute;s	1	decent	
 3502	twisted blurry thermos of brew	1	crappy	Effect: "Red Misty-Eyed", Effect Duration: 30, Last Available: "2011-12"
-3503	boozy artisanal jittery huge glass of brandy	5	EPIC	Last Available: "2011-12"
+3503	artisanal boozy jittery huge glass of brandy	5	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	aromatic LWA ring	0		Stench Resistance: +1
 3506	narrow LARP membership card	0		Last Available: "2008-10"
@@ -3487,7 +3487,7 @@
 3520	shark tooth	0		
 3521	censurious boxer's shark tooth necklace	0		Muscle Percent: +10, Sleaze Resistance: +3, Single Equip
 3522	mirror Samson's shark jumper of the storm	0		Experience (Muscle): +5, Maximum MP Percent: +40
-3523	boiled narrow jittery shark cartilage	0		Effect: "Reptilian Fortitude", Effect Duration: 33
+3523	boiled jittery narrow shark cartilage	0		Effect: "Reptilian Fortitude", Effect Duration: 33
 3524	enhanced dry eel battery	0		Effect: "Ack!  Barred!", Effect Duration: 54
 3525	activated upside-down temporary teardrop tattoo	0		Effect: "Big Meat Big Prizes", Effect Duration: 26
 3526	ghostly scratch 'n' sniff crossbow of temperance	0		Sleaze Resistance: +5, Last Available: "2008-11"
@@ -3498,7 +3498,7 @@
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	cactus monocle	0		Familiar Weight: +5
-3534	huge upside-down Jawmaster 2000&trade;	0		Familiar Weight: +5
+3534	upside-down huge Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	upside-down plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
@@ -3519,18 +3519,18 @@
 3552	cyan jittery wobbly shellacked octopus's spade of terror of doom	0		Damage Reduction: 7, Spooky Spell Damage: 60
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	stale thick sea carrot	5	decent	
+3555	thick stale sea carrot	5	decent	
 3556	spoiled yellow shaking sea cucumber	3	crappy	
 3557	yummy sea avocado	3	awesome	
-3558	massive rotten sea lychee	10	crappy	
-3559	delicious twirling tumbling sea tangelo	4	awesome	
-3560	special spoiled mirror sea honeydew	4	crappy	Effect: "Human-Undead Hybrid", Effect Duration: 40
+3558	rotten massive sea lychee	10	crappy	
+3559	delicious tumbling twirling sea tangelo	4	awesome	
+3560	spoiled special mirror sea honeydew	4	crappy	Effect: "Human-Undead Hybrid", Effect Duration: 40
 3561	altered chilled skewed pressurized potion of puissance	0		Effect: "Corona de la Salsa", Effect Duration: 28
 3562	magnetized modified nitrogenated pressurized potion of perspicacity	0		Effect: "Aided and Abetted", Effect Duration: 62
-3563	wet super-wet mirror cyan pressurized potion of pulchritude	0		Effect: "Artificially Sweet", Effect Duration: 62
-3564	practically non-alcoholic mediocre berry-infused sake	1	decent	
+3563	wet super-wet cyan mirror pressurized potion of pulchritude	0		Effect: "Artificially Sweet", Effect Duration: 62
+3564	mediocre practically non-alcoholic berry-infused sake	1	decent	
 3565	acceptable citrus-infused sake	4	good	
-3566	acceptable triple-distilled blue melon-infused sake	10	good	
+3566	triple-distilled acceptable blue melon-infused sake	10	good	
 3567	slab of sponge	0		
 3568	lard-coated dog trainer's savvy sponge helmet	0		Mysticality Percent: +20, Experience (familiar): +1, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xFairy"
 3569	jittery therapeutic spongy shield of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 14
@@ -3546,8 +3546,8 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	moldy huge rice	6	crappy	
-3584	rotten miniature fuchsia huge irradiated candy cane	2	crappy	Last Available: "2008-12"
+3582	huge moldy rice	6	crappy	
+3584	miniature rotten huge fuchsia irradiated candy cane	2	crappy	Last Available: "2008-12"
 3585	bland super-sized gingerbread mutant bugbear	5	decent	Last Available: "2008-12"
 3586	artisanal twirling oozenog	4	EPIC	Last Available: "2008-12"
 3587	dry triple-deionized ghostly blurry sugar plum	0		Effect: "Brother Corsican's Blessing", Effect Duration: 12, Last Available: "2008-12"
@@ -3561,7 +3561,7 @@
 3595	deionized Mer-kin fastjuice	0		Effect: "Izchak's Blessing", Effect Duration: 59
 3596	yellow imitation crab crate	0		
 3597	narrow imitation crab meat	0		
-3598	gray huge ghostly imitation crab zoea	0		
+3598	huge ghostly gray imitation crab zoea	0		
 3599	stanky Tesla Samson's moist sailor's cap	0		Experience (Muscle): +5, Stench Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "stench atk"
 3600	lard-coated baleful speargun	0		Spell Damage: +25, Sleaze Spell Damage: +25
 3601	bouncing toasty compass	0		Hot Damage: +5
@@ -3584,7 +3584,7 @@
 3618	blinking The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
-3621	bouncing tumbling pair of twitching claws	0		Last Available: "2008-12"
+3621	tumbling bouncing pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	gravedigger's parasitic claw	0		Spooky Damage: +10, Last Available: "2008-12"
@@ -3611,12 +3611,12 @@
 3645	delicious canteen of wine	3	awesome	Last Available: "2008-12"
 3646	yummy elven <i>limbos</i> gingerbread	3	awesome	Last Available: "2008-12"
 3647	upside-down elven whittling knife	0		Last Available: "2008-12"
-3648	red bouncing magic dragonfish fry	0		
+3648	bouncing red magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	toothsome blurry toast with jam	4	awesome	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	tolerable elven moonshine	3	good	Last Available: "2008-12"
-3653	half-sized adequate knuckle sandwich	2	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	half-sized adequate knuckle sandwich	2	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	blue toasty dog trainer's psycho sweater	0		Experience (familiar): +1, Hot Damage: +5, Last Available: "2008-12"
 3655	huge fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of the businessman	0		Meat Drop: +50, Last Available: "2008-12"
@@ -3636,26 +3636,26 @@
 3670	spinning forbidden glow-in-the-dark burrowgrub	0		Spell Damage Percent: +50, Last Available: "2009-01"
 3671	yellow Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	bite-sized flavorless bouncing can of franks 'n' beans	1	decent	Last Available: "2010-12"
-3673	extra-dry drinkable bottle of peppermint schnapps	5	good	Last Available: "2010-12"
+3673	drinkable extra-dry bottle of peppermint schnapps	5	good	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	fuchsia huge forbidden diving muff	0		Spell Damage Percent: +50, Single Equip
-3678	perfectly mixed irresponsibly strong tumbling salinated mint julep	8	EPIC	
+3678	irresponsibly strong perfectly mixed tumbling salinated mint julep	8	EPIC	
 3679	wobbly ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	blinking globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	rotten miniature tempura carrot	2	crappy	
+3684	miniature rotten tempura carrot	2	crappy	
 3685	flavorless tempura cucumber	3	decent	
 3686	thick rotten tempura avocado	5	crappy	
 3687	adequate jumbo sea broccoli	5	good	
-3688	massive stale sea cauliflower	9	decent	
+3688	stale massive sea cauliflower	9	decent	
 3689	snack-sized adequate tempura broccoli	2	good	
-3690	adequate miniature tempura cauliflower	2	good	
-3691	decent gigantic sea blueberry	10	good	
-3692	big stale skewed sea persimmon	5	decent	
+3690	miniature adequate tempura cauliflower	2	good	
+3691	gigantic decent sea blueberry	10	good	
+3692	stale big skewed sea persimmon	5	decent	
 3693	quantum quadruple-polarized pressurized potion of perception	0		Effect: "Sticky Fingers", Effect Duration: 64
 3694	improved pressurized potion of proficiency	0		Effect: "Ginger Snapped", Effect Duration: 11
 3695	Mer-kin digpick of the cheetah	0		Initiative: +60
@@ -3714,10 +3714,10 @@
 3749	ionized huge concoction of clumsiness	0		Effect: "Fudge Headache", Effect Duration: 34
 3750	Fonzie's vampire pearl earring	0		Experience (Moxie): +1, Single Equip
 3751	bland chocolate chip brownies	3	decent	
-3753	red spinning Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	spinning red Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	extra-anodized anodized love song of vague ambiguity	0		Effect: "Capricorn Rising", Effect Duration: 46, Last Available: "2009-02"
 3755	corrupted squat love song of smoldering passion	0		Effect: "Well Owl Be!", Effect Duration: 15, Last Available: "2009-02"
-3756	alkaline quantum nitrogenated tumbling twirling maroon love song of icy revenge	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 11, Last Available: "2009-02"
+3756	alkaline quantum nitrogenated tumbling maroon twirling love song of icy revenge	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 11, Last Available: "2009-02"
 3757	moist love song of sugary cuteness	0		Effect: "Slimily Sagacious", Effect Duration: 45, Last Available: "2009-02"
 3758	altered moist blinking love song of disturbing obsession	0		Effect: "Smoking like a Bandit", Effect Duration: 60, Last Available: "2009-02"
 3759	enhanced ionized love song of naughty innuendo	0		Effect: "20-20 Second Sight", Effect Duration: 25, Last Available: "2009-02"
@@ -3728,7 +3728,7 @@
 3764	bad slug of rum	3	decent	
 3765	lousy slug of shochu	3	decent	
 3766	watered-down lousy screwdiver	2	decent	
-3767	special strong acceptable red dew yoana lei	5	good	Effect: "Fizzier Than Light", Effect Duration: 50
+3767	strong acceptable special red dew yoana lei	5	good	Effect: "Fizzier Than Light", Effect Duration: 50
 3768	delicious lychee chuhai	4	awesome	
 3769	artisanal salacious screwdiver	4	EPIC	
 3770	artisanal dew yoana salacious lei	4	EPIC	
@@ -3750,7 +3750,7 @@
 3786	vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
 3788	ghostly skewed crumbling rat skull	0		Class: "Pastamancer"
-3789	skewed ghostly twitching trigger finger	0		Class: "Pastamancer"
+3789	ghostly skewed twitching trigger finger	0		Class: "Pastamancer"
 3799	mirror Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
 3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
@@ -3759,7 +3759,7 @@
 3804	auspicious Rosewater's Mer-kin breastplate	0		Mysticality Percent: +30, Item Drop: +10
 3805	twirling steel-toed experienced Mer-kin sneakmask	0		Experience: +2, Damage Reduction: 9, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
-3807	super-adjusted mirror wobbly Mer-kin hidepaint	0		Effect: "Fire Inside", Effect Duration: 40
+3807	super-adjusted wobbly mirror Mer-kin hidepaint	0		Effect: "Fire Inside", Effect Duration: 40
 3808	green Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
 3810	narrow Mer-kin lockkey	0		
@@ -3768,7 +3768,7 @@
 3813	squat medical-grade plastic baby	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2009-06"
 3815	spinning midget clownfish	0		
 3816	cyan half-height unicycle	0		Familiar Weight: +5
-3817	spoiled miniature sea radish	2	crappy	
+3817	miniature spoiled sea radish	2	crappy	
 3818	fuchsia nasty curative halibut of wisdom	0		Mysticality: +15, Stench Damage: +5, HP Regen Min: 3, HP Regen Max: 5
 3819	skewed spinning eel sauce	0		
 3820	ruddy water-polo mitt	0		Maximum HP Percent: +40, Single Equip
@@ -3783,9 +3783,9 @@
 3829	toothsome mirror tempura radish	3	awesome	
 3830	wool water-polo cap	0		Cold Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr"
 3831	lousy Typical Tavern swill	3	decent	
-3832	tolerable distilled tropical swill	5	good	
+3832	distilled tolerable tropical swill	5	good	
 3833	bad special blinking fruity girl swill	4	decent	Effect: "Castaway Physique", Effect Duration: 10
-3834	special distilled mediocre twirling maroon blended swill	5	decent	Effect: "Newt Gets In Your Eyes", Effect Duration: 30
+3834	distilled mediocre special maroon twirling blended swill	5	decent	Effect: "Newt Gets In Your Eyes", Effect Duration: 30
 3835	costume wardrobe	0		Softcore Only
 3836	chilly medical-grade wicked Elvish sunglasses of vim and vigor	0		Spell Damage: +5, Maximum HP Percent: +50, Cold Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	blue nippy anniversary safety glass vest	0		Cold Damage: +10
@@ -3862,7 +3862,7 @@
 3910	huge figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	boozy drinkable mirror blended swill with a fly in it	5	good	
+3913	drinkable boozy mirror blended swill with a fly in it	5	good	
 3914	turtle wax	0		
 3915	blurry zippy turtle wax shield	0		Initiative: +20, Damage Reduction: 2
 3916	scandalous turtle wax helmet	0		Sleaze Damage: +5, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3943,14 +3943,14 @@
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	fuchsia slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
-3994	green narrow upside-down security blankie	0		Familiar Weight: +5
+3994	upside-down green narrow security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
 3996	boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	bouncing metrognome	0		Familiar Weight: +5
-3999	bouncing wobbly infant sandworm	0		Free Pull, Last Available: "2011-12"
+3999	wobbly bouncing infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	spinning upside-down string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	powdered blinking bouncing purple pulsating agua de vida	1	decent	Last Available: "2009-06"
+4001	powdered blinking pulsating bouncing purple agua de vida	1	decent	Last Available: "2009-06"
 4002	healthy cool tortoboggan shield	0		Moxie: +5, Maximum HP Percent: +20, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	narrow wobbly soup-chucks of James Dean	0		Experience (Moxie): +3
@@ -3986,7 +3986,7 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	skewed memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	gigantic moldy slimy sweetbreads	7	crappy	
+4037	moldy gigantic slimy sweetbreads	7	crappy	
 4038	acceptable enchanted tumbling slimy fermented bile bladder	3	good	Effect: "Inner Warmth", Effect Duration: 40
 4039	dehydrated squat huge slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
@@ -4088,7 +4088,7 @@
 4136	energetic vibrating Newton's smooth Bag o' Tricks	0		Moxie: +15, Experience (Mysticality): +3, Maximum MP Percent: 30, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	green slime stack	0		
 4138	a rumpled paper strip	0		
-4139	spinning bouncing a creased paper strip	0		
+4139	bouncing spinning a creased paper strip	0		
 4140	wobbly a folded paper strip	0		
 4141	a crinkled paper strip	0		
 4142	tumbling a crumpled paper strip	0		
@@ -4098,7 +4098,7 @@
 4146	warmed sand	0		Effect: "Corona de la Salsa", Effect Duration: 33
 4147	censurious charged magnet of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3, Last Available: "2009-09"
 4148	blue stone sphere	0		Free Pull, Last Available: "2009-09"
-4149	blinking blurry quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
+4149	blurry blinking quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	teal lint	0		Last Available: "2011-12"
 4151	triple-polymerized twirling dubious peppermint	0		Effect: "Mana Tea", Effect Duration: 62, Last Available: "2020-09"
 4152	triple-pressed polymerized spinning Elvish delight	0		Effect: "Abyssal Blood", Effect Duration: 21
@@ -4146,7 +4146,7 @@
 4194	wobbly dog trainer's baggy rave pants	0		Experience (familiar): +1, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 4195	jittery razor-sharp pacifier necklace	0		Weapon Damage Percent: +25, Single Equip
 4196	bouncing sea cowbell	0		
-4197	tumbling maroon sea	0		
+4197	maroon tumbling sea	0		
 4198	jittery sea lasso	0		
 4199	sharpshooter's crafty sea cowboy hat of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Critical Hit Percent: +10, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
@@ -4182,12 +4182,12 @@
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
-4233	squat ghostly hacienda key	0		
+4233	ghostly squat hacienda key	0		
 4234	mirror maroon mansplainer's pat&eacute; knife	0		Monster Level: +15
 4235	upside-down salt-shaker	0		
 4236	huge can of sterno	0		
 4237	cheese-slicer of the sweet-tooth	0		Candy Drop: +100
-4238	fancy snack-sized adequate beef jerky	2	good	Effect: "Inscrutable exoskeleton", Effect Duration: 35
+4238	snack-sized fancy adequate beef jerky	2	good	Effect: "Inscrutable exoskeleton", Effect Duration: 35
 4239	pipe wrench of the cougar	0		Moxie: +20
 4240	ionized gun cleaning kit	0		Effect: "Ancient Protected", Effect Duration: 11
 4241	curative sleep mask	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4208,7 +4208,7 @@
 4256	alkaline sap	0		Effect: "So Fresh and So Clean", Effect Duration: 43, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	spoiled chocolate-covered scarab beetle	3	crappy	Last Available: "2009-10"
-4259	high-proof enchanted mediocre mulled cider	8	decent	Effect: "Impregnabili Tea", Effect Duration: 35, Last Available: "2009-10"
+4259	enchanted mediocre high-proof mulled cider	8	decent	Effect: "Impregnabili Tea", Effect Duration: 35, Last Available: "2009-10"
 4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	narrow mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	narrow nippy deadly Ass-Stompers of Violence of James Dean	0		Experience (Moxie): +3, Weapon Damage: +5, Cold Damage: +10, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	blurry grievous brawny Brand of Violence of the bloodbag	0		Muscle Percent: +20, Weapon Damage Percent: +50, Maximum HP: +100, Conditional Skill (Equipped): "Brand"
 4299	Usain Bolt's Novelty Belt Buckle of Violence of Leguizamo of the early riser	0		Monster Level: +20, Initiative: +80, Adventures: +7, Single Equip
-4300	spinning Sherlock's fireproof toasty Lens of Violence	0		Hot Damage: +5, Hot Resistance: +3, Item Drop: +25, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	spinning Sherlock's fireproof toasty Lens of Violence	0		Hot Damage: +5, Hot Resistance: +3, Item Drop: +25, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	miser's smelly hale Pigsticker of Violence	0		Maximum HP: +20, Stench Spell Damage: +10, Meat Drop: +10
-4302	flame-wreathed Jodhpurs of Violence of the wise owl of the scaredy-cat	0		Mysticality: +20, Monster Level: -15, Hot Spell Damage: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	flame-wreathed Jodhpurs of Violence of the wise owl of the scaredy-cat	0		Mysticality: +20, Monster Level: -15, Hot Spell Damage: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	skewed rock-hard fortified smooth Cold Stone of Hatred	0		Moxie: +15, Damage Absorption: +60, Damage Reduction: 5, Conditional Skill (Equipped): "Chilling Grip"
 4304	huge yellow lightning-fast wool toasty Girdle of Hatred	0		Hot Damage: +5, Cold Resistance: +1, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	hardy hardened experienced Staff of Simmering Hatred	0		Experience: +2, Damage Reduction: 3, Maximum HP: +50
-4306	hale Pantaloons of Hatred of the businessman of the early riser	0		Maximum HP: +20, Meat Drop: +50, Adventures: +7, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	hale Pantaloons of Hatred of the businessman of the early riser	0		Maximum HP: +20, Meat Drop: +50, Adventures: +7, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	horrifying Tesla Fuzzy Slippers of Hatred of the early riser	0		Spooky Damage: +25, Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-4308	red toasty steel-toed Lens of Hatred of the sweet-tooth	0		Damage Reduction: 9, Hot Damage: +5, Candy Drop: +100, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	red toasty steel-toed Lens of Hatred of the sweet-tooth	0		Damage Reduction: 9, Hot Damage: +5, Candy Drop: +100, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	lime green frosty groovy Treads of Loathing of the businessman	0		Moxie Percent: +10, Cold Spell Damage: +10, Meat Drop: +50, Single Equip
 4310	blurry Annie Oakley's weightlifter's Scepter of Loathing of doom	0		Muscle: +15, Critical Hit Percent: +20, Spooky Spell Damage: +50
 4311	frightening hardy shellacked Belt of Loathing	0		Damage Reduction: 7, Maximum HP: +50, Spooky Damage: +5, Single Equip
@@ -4279,8 +4279,8 @@
 4327	Sinatra's strapping La Hebilla del Cintur&oacute;n de Lopez of temperance	0		Muscle: +5, Experience (Moxie): +5, Sleaze Resistance: +5, Class: "Accordion Thief", Single Equip
 4328	olive suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	rotten miniature spinning candy kneecapping stick	2	crappy	Last Available: "2009-12"
-4331	fancy toothsome thick licorice garrote	5	awesome	Effect: "Muscle Unbound", Effect Duration: 10, Last Available: "2009-12"
+4330	miniature rotten spinning candy kneecapping stick	2	crappy	Last Available: "2009-12"
+4331	thick fancy toothsome licorice garrote	5	awesome	Effect: "Muscle Unbound", Effect Duration: 10, Last Available: "2009-12"
 4332	ghostly candy knuckles of the blizzard	0		Cold Spell Damage: +25, Last Available: "2009-12"
 4333	tiny toothsome narrow jawbruiser	1	awesome	Last Available: "2010-12"
 4334	modified pickled maroon chocolate car	0		Effect: "Neuromancy", Effect Duration: 30, Last Available: "2009-12"
@@ -4296,7 +4296,7 @@
 4344	Crimbo wreath	0		Last Available: "2009-12"
 4345	narrow string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
-4347	olive twirling gingerbread house	0		Last Available: "2009-12"
+4347	twirling olive gingerbread house	0		Last Available: "2009-12"
 4348	teal leftover Crimbo rations	0		Last Available: "2009-12"
 4349	cool snow hat	0		Moxie: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
 4350	snow pants	0		Item Drop: +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
@@ -4316,13 +4316,13 @@
 4364	vacuum-sealed spinning elven suicide capsule	0		Effect: "Icy Composition", Effect Duration: 44, Last Available: "2009-12"
 4365	bland penguin focaccia bread	3	decent	Last Available: "2009-12"
 4366	artisanal practically non-alcoholic herringcello	1	EPIC	Last Available: "2009-12"
-4367	high-proof aged elven cellocello	10	awesome	Last Available: "2009-12"
+4367	aged high-proof elven cellocello	10	awesome	Last Available: "2009-12"
 4368	gray blurry wrench handle	0		Last Available: "2009-12"
 4369	green handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	red handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
-4373	ghostly spinning grappling hook	0		Last Available: "2009-12"
+4373	spinning ghostly grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
@@ -4401,7 +4401,7 @@
 4453	lawnmower blade of the detective	0		Item Drop: +20, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
 4455	sinister The Landscaper's leafblower	0		Spell Damage: +10, Last Available: "2010-04"
-4456	cyan pulsating upside-down snowball	0		
+4456	upside-down pulsating cyan snowball	0		
 4457	shaking snailmail bits	0		
 4458	rosewater-soaked wizardly snailmail coif	0		Mysticality: +25, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 41"
 4459	flame-retardant snailmail breeches of dire peril	0		Weapon Damage: +20, Hot Resistance: +1, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
@@ -4421,10 +4421,10 @@
 4473	BRICKO sword of the boozehound	0		Booze Drop: +100, Last Available: "2010-02"
 4474	upside-down BRICKO ooze	0		Last Available: "2010-02"
 4475	yellow BRICKO bat	0		Last Available: "2010-02"
-4476	shaking fuchsia BRICKO oyster	0		Last Available: "2010-02"
+4476	fuchsia shaking BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
-4478	teal wobbly upside-down BRICKO elephant	0		Last Available: "2010-02"
-4479	maroon pulsating BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4478	wobbly teal upside-down BRICKO elephant	0		Last Available: "2010-02"
+4479	pulsating maroon BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	lime green BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4442,10 +4442,10 @@
 4494	spinning BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	blue extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
-4497	vacuum-sealed denatured super-galvanized gray ghostly recording of The Ballad of Richie Thingfinder	0		Effect: "Cautious Prowl", Effect Duration: 15
+4497	vacuum-sealed denatured super-galvanized ghostly gray recording of The Ballad of Richie Thingfinder	0		Effect: "Cautious Prowl", Effect Duration: 15
 4498	nitrogenated quantum skewed blinking recording of Benetton's Medley of Diversity	0		Effect: "Sticks and Stones", Effect Duration: 11
 4499	dry huge recording of Elron's Explosive Etude	0		Effect: "Corona de la Salsa", Effect Duration: 46
-4500	cold-filtered lime green shaking recording of Chorale of Companionship	0		Effect: "Eyes for Miles", Effect Duration: 26
+4500	cold-filtered shaking lime green recording of Chorale of Companionship	0		Effect: "Eyes for Miles", Effect Duration: 26
 4501	energized double-tarnished narrow recording of Prelude of Precision	0		Effect: "Dreadful Smell", Effect Duration: 57
 4502	oxidized recording of Donho's Bubbly Ballad	0		Effect: "Boletus Swoletus", Effect Duration: 52
 4503	chilled recording of Inigo's Incantation of Inspiration	0		Effect: "Frostbeard", Effect Duration: 40, Last Available: "2010-02"
@@ -4470,16 +4470,16 @@
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	blue Jim Carey's Da Vinci's eye of the Tiger-lily	0		Experience (Mysticality): +5, Monster Level: +25, Last Available: "2010-03"
 4524	clever vibrating wig	0		Maximum MP Percent: +10, Maximum MP: +20, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	decent diet donut	1	good	Last Available: "2010-03"
-4526	big bland spinning bucket of honey	5	decent	Last Available: "2010-03"
+4525	diet decent donut	1	good	Last Available: "2010-03"
+4526	bland big spinning bucket of honey	5	decent	Last Available: "2010-03"
 4527	energetic Samson's elephant stinger	0		Experience (Muscle): +5, Maximum MP Percent: +20, Last Available: "2010-03"
-4528	adequate big dragon snaps	5	good	Last Available: "2010-03"
+4528	big adequate dragon snaps	5	good	Last Available: "2010-03"
 4529	blinking maroon friendly MacGyver's snapdragon pistil	0		Maximum MP: +100, Familiar Weight: +3, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	adequate snack-sized yellow rook cookie	2	good	Last Available: "2010-03"
+4531	snack-sized adequate yellow rook cookie	2	good	Last Available: "2010-03"
 4532	adequate immense squat bishop cookie	10	good	Last Available: "2010-03"
 4533	rotten maroon knight cookie	3	crappy	Last Available: "2010-03"
-4534	jumbo rotten king cookie	5	crappy	Last Available: "2010-03"
+4534	rotten jumbo king cookie	5	crappy	Last Available: "2010-03"
 4535	flavorless upside-down queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	lime green fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	knitted insane tophat	0		Cold Resistance: +3, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4491,7 +4491,7 @@
 4543	skewed Oprah's tuxedo pants	0		Maximum MP Percent: +50, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 4544	porpoise	0		Last Available: "2010-03"
 4545	pocketwatch	0		Last Available: "2010-03"
-4546	upside-down teal bandersnatch	0		Last Available: "2010-03"
+4546	teal upside-down bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
@@ -4508,25 +4508,25 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	upside-down hair of the calf	0		Last Available: "2010-04"
-4563	mediocre watered-down world's most unappetizing beverage	2	decent	Last Available: "2010-04"
+4563	watered-down mediocre world's most unappetizing beverage	2	decent	Last Available: "2010-04"
 4564	maroon chaotic slippery when wet shield	0		Spell Critical Percent: +10, Damage Reduction: 6, Last Available: "2010-04"
-4565	small flavorless blinking raisin	2	decent	Last Available: "2010-04"
-4566	teal squat fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
+4565	flavorless small blinking raisin	2	decent	Last Available: "2010-04"
+4566	squat teal fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	ghostly vibrating flyest of shirts of the brazier	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Last Available: "2010-04"
 4568	stale a dance upon the palate	3	decent	Last Available: "2010-04"
-4569	adequate special small prehistoric meteorite jawbreaker	2	good	Effect: "Corona de la Salsa", Effect Duration: 40, Last Available: "2010-04"
+4569	small special adequate prehistoric meteorite jawbreaker	2	good	Effect: "Corona de la Salsa", Effect Duration: 40, Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	yummy immense squirmy violent party snack	6	awesome	Last Available: "2010-04"
 4572	jittery Socratic can-you-dig-it?	0		Experience (Mysticality): +1, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	shaking bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	skewed bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	shaking bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	skewed bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	altered twirling cyan pulsating Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Human-Machine Hybrid", Effect Duration: 69, Last Available: "2010-04"
+4579	altered cyan pulsating twirling Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Human-Machine Hybrid", Effect Duration: 69, Last Available: "2010-04"
 4580	blinking shaking brainy school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Mysticality: +5, Last Available: "2010-04"
-4581	Usain Bolt's studded T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Damage Absorption: +80, Initiative: +80, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	Usain Bolt's studded T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Damage Absorption: +80, Initiative: +80, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	upside-down fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	normal tiny six wedges of goat cheese	1	good	
@@ -4541,8 +4541,8 @@
 4593	squat pixellated moneybag	0		Last Available: "2010-07"
 4594	blinking pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
-4596	blue pulsating map to Vanya's Castle	0		Last Available: "2010-07"
-4597	bouncing yellow 8-Bit Power magazine	0		Last Available: "2010-07"
+4596	pulsating blue map to Vanya's Castle	0		Last Available: "2010-07"
+4597	yellow bouncing 8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	pulsating bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
@@ -4551,8 +4551,8 @@
 4603	cyan bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	narrow lime green clever bottle of Goldschn&ouml;ckered of the cheetah	0		Maximum MP: +20, Initiative: +60, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	gigantic normal sun-dried tofu	6	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	tolerable high-proof soyburger juice	7	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	normal gigantic sun-dried tofu	6	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	high-proof tolerable soyburger juice	7	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	liquefied essential soy	0		Effect: "Sparkly!", Effect Duration: 40, Last Available: "2010-08"
@@ -4619,8 +4619,8 @@
 4671	drinkable booze-soaked cherry	3	good	
 4672	mirror skewed comfy pillow	0		
 4673	spoiled upside-down marshmallow	3	crappy	
-4674	decent teal mirror sponge cake	3	good	
-4675	hand-crafted fancy gin-soaked blotter paper	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 10
+4674	decent mirror teal sponge cake	3	good	
+4675	fancy hand-crafted gin-soaked blotter paper	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 10
 4676	ghostly tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
@@ -4639,7 +4639,7 @@
 4691	lime green fossilized wing	0		Last Available: "2010-09"
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	narrow fossilized torso	0		Last Available: "2010-09"
-4694	upside-down jittery fossilized spine	0		Last Available: "2010-09"
+4694	jittery upside-down fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
 4696	olive toasty deadly Greatest American Pants of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40, Hot Damage: +5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	pulsating fossilized necklace of extreme caution	0		Monster Level: -25, Last Available: "2010-09"
@@ -4653,7 +4653,7 @@
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	twirling E-Z Cook&trade; oven	0		
-4708	yellow huge My First Shaker&trade;	0		
+4708	huge yellow My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
 4710	gray tumbling immense ballet shoes	0		Familiar Weight: +5
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
@@ -4667,13 +4667,13 @@
 4719	asbestos-lined Hollandaise helmet	0		Hot Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	blinking organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	yellow microwave stogie	0		Last Available: "2011-12"
-4722	snack-sized moldy liver and let pie	2	crappy	Last Available: "2010-10"
+4722	moldy snack-sized liver and let pie	2	crappy	Last Available: "2010-10"
 4723	snack-sized adequate badass pie	2	good	Last Available: "2010-10"
 4724	tasty shoo-fish pie	3	awesome	Last Available: "2010-10"
 4725	miniature rotten piping organ pie	2	crappy	Last Available: "2010-10"
 4726	stale igloo pie	4	decent	Last Available: "2010-10"
 4727	spoiled tiny bouncing stomach turnover	1	crappy	Last Available: "2010-10"
-4728	bland enchanted dead lights pie	3	decent	Effect: "Macho, Macho Dog", Effect Duration: 20, Last Available: "2010-10"
+4728	enchanted bland dead lights pie	3	decent	Effect: "Macho, Macho Dog", Effect Duration: 20, Last Available: "2010-10"
 4729	bland huge throbbing organ pie	3	decent	Last Available: "2010-10"
 4730	hardened stop shield	0		Damage Reduction: 9, Last Available: "2009-12"
 4731	jittery nest egg	0		
@@ -4684,7 +4684,7 @@
 4736	upside-down tangle of rat tails	0		
 4737	veiny beer-soaked mop	0		Maximum HP: +10
 4738	perfectly mixed day-old beer	4	EPIC	
-4739	extra-dry enchanted tolerable plain beer	5	good	Effect: "Influence of Sphere", Effect Duration: 50
+4739	tolerable enchanted extra-dry plain beer	5	good	Effect: "Influence of Sphere", Effect Duration: 50
 4740	aged skewed overpriced &quot;imported&quot; beer	3	awesome	
 4741	squat smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
@@ -4727,7 +4727,7 @@
 4818	huge flavorless jittery CRIMBCOIDS mints	7	decent	Last Available: "2011-01"
 4819	twirling can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	normal half-sized CRIMBCOLOAF	2	good	Last Available: "2011-01"
-4821	spoiled huge squat circular CRIMBCOOKIE	9	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	huge spoiled squat circular CRIMBCOOKIE	9	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	upside-down strapping plastic CRIMBCO HQ	0		Muscle: +5, Last Available: "2010-12"
 4823	plastic fax machine of the sewer	0		Stench Damage: +25, Last Available: "2010-12"
 4824	squat foul-smelling plastic hobo elf	0		Stench Damage: +10, Last Available: "2010-12"
@@ -4745,7 +4745,7 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	flavorless super-sized ghostly triangular CRIMBCOOKIE	5	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	super-sized flavorless ghostly triangular CRIMBCOOKIE	5	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	stale square CRIMBCOOKIE	3	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	huge gravedigger's bindlestocking of wisdom of the glutton	0		Mysticality: +15, Spooky Damage: +10, Food Drop: +100, Last Available: "2010-12"
 4842	purple sleeping stocking	0		Last Available: "2010-12"
@@ -4787,7 +4787,7 @@
 4878	triple-altered non-adjusted incense bath ball	0		Effect: "Penguinny Flavor", Effect Duration: 20, Last Available: "2011-01"
 4879	triple-diffused non-galvanized myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Your Favorite Flavor", Effect Duration: 62, Last Available: "2011-01"
 4880	blurry CRIMBCO mug	0		Last Available: "2011-01"
-4881	mediocre fortified CRIMBCO wine	5	decent	Last Available: "2011-01"
+4881	fortified mediocre CRIMBCO wine	5	decent	Last Available: "2011-01"
 4882	shaking Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	wobbly spinning toe jam	0		Last Available: "2011-01"
 4884	massive normal toe jam toast	9	good	Last Available: "2011-01"
@@ -4800,7 +4800,7 @@
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	gray slow jam collection	0		Last Available: "2011-01"
 4893	jittery BGE shotglass	0		Last Available: "2010-12"
-4894	spoiled wobbly squat festive sausage	3	crappy	Last Available: "2011-01"
+4894	spoiled squat wobbly festive sausage	3	crappy	Last Available: "2011-01"
 4895	normal special wobbly holiday cheese log	3	good	Effect: "Stone-Faced", Effect Duration: 25, Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	pulsating double-paned Socratic BGE 'ferocious fruit' shirt	0		Experience (Mysticality): +1, Cold Resistance: +5, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	spinning quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	blurry arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	delicious jumbo Knob jelly donut	5	awesome	
+4941	jumbo delicious Knob jelly donut	5	awesome	
 4942	ghostly Knob cake	0		
 4943	spinning Knob cake pan	0		
 4944	blue skewed Knob batter	0		
@@ -4856,7 +4856,7 @@
 4953	Herculean whalebone corset of the brute	0		Muscle Percent: +30, Experience (Muscle): +1, Single Equip
 4954	shellacked oven mitts	0		Damage Reduction: 7, Single Equip
 4955	half-sized adequate overcookie	2	good	
-4956	rotten diet huge philosopher's scone	1	crappy	
+4956	diet rotten huge philosopher's scone	1	crappy	
 4957	chilled anodized half-baked potion	0		Effect: "Christmessy", Effect Duration: 52
 4958	smelly Knob Goblin deluxe scimitar	0		Stench Spell Damage: +10
 4959	stale tumbling skewed Knob nuts	4	decent	
@@ -4866,7 +4866,7 @@
 4963	mirror state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
 4965	gray Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
-4966	tumbling blinking skewed gray Pack of Alice's Army Cards	0		Last Available: "2011-03"
+4966	gray blinking skewed tumbling Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	lime green Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	wobbly Alice's Army Halberder	0		Last Available: "2011-03"
@@ -4913,11 +4913,11 @@
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	snack-sized rotten wasabi pocky	2	crappy	Last Available: "2011-03"
-5014	flavorless gigantic tobiko pocky	8	decent	Last Available: "2011-03"
-5015	stale small spinning natto pocky	2	decent	Last Available: "2011-03"
+5013	rotten snack-sized wasabi pocky	2	crappy	Last Available: "2011-03"
+5014	gigantic flavorless tobiko pocky	8	decent	Last Available: "2011-03"
+5015	small stale spinning natto pocky	2	decent	Last Available: "2011-03"
 5016	weak drinkable wasabi-infused sake	2	good	Last Available: "2011-03"
-5017	delicious high-proof bouncing tobiko-infused sake	6	awesome	Last Available: "2011-03"
+5017	high-proof delicious bouncing tobiko-infused sake	6	awesome	Last Available: "2011-03"
 5018	acceptable mirror natto-infused sake	3	good	Last Available: "2011-03"
 5019	vacuum-sealed cold-filtered wasabi marble soda	0		Effect: "Oriental Mysticism", Effect Duration: 23, Last Available: "2011-03"
 5020	anodized tobiko marble soda	0		Effect: "Poker Faced", Effect Duration: 49, Last Available: "2011-03"
@@ -4965,15 +4965,15 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	spinning the finger	0		Last Available: "2011-04"
 5064	olive Salsa de las Epocas	0		Last Available: "2011-04"
-5065	delicious massive shaking spaghetti con calaveras	6	awesome	Last Available: "2011-04"
+5065	massive delicious shaking spaghetti con calaveras	6	awesome	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	spoiled jumbo popcorn	5	crappy	Last Available: "2011-04"
+5067	jumbo spoiled popcorn	5	crappy	Last Available: "2011-04"
 5068	normal chaos popcorn	3	good	Last Available: "2011-04"
 5069	shaking flame-wreathed Rosewater's weightlifter's hole	0		Muscle: +15, Mysticality Percent: +30, Hot Spell Damage: +10, Last Available: "2011-04"
 5070	ghostly innuendo	0		Last Available: "2011-04"
-5071	stale miniature s'more	0	decent	Last Available: "2011-04"
+5071	miniature stale s'more	0	decent	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	acceptable practically non-alcoholic Russian Ice	1	good	Last Available: "2011-04"
+5073	practically non-alcoholic acceptable Russian Ice	1	good	Last Available: "2011-04"
 5074	huge olive strapping clay ashtray	0		Muscle: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	studded lanyard	0		Damage Absorption: +80, Single Equip, Last Available: "2011-05"
 5076	shaking Jim Carey's monster pants	0		Monster Level: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
@@ -5004,10 +5004,10 @@
 5101	nasty Pok&euml;mann figurine: Moog	0		Stench Damage: +5, Single Equip, Last Available: "2011-05"
 5102	alkaline willyweed	0		Effect: "Boo Tea", Effect Duration: 60, Last Available: "2011-05"
 5103	ionized wet wobbly Nuclear Blastball	0		Effect: "The Living Hitpoints", Effect Duration: 14, Last Available: "2011-05"
-5104	anodized bouncing skewed fish juice box	0		Effect: "Uncanny Shot", Effect Duration: 11, Last Available: "2011-05"
+5104	anodized skewed bouncing fish juice box	0		Effect: "Uncanny Shot", Effect Duration: 11, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	acceptable irresponsibly strong Jeppson's Malort	6	good	Last Available: "2011-06"
+5107	irresponsibly strong acceptable Jeppson's Malort	6	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	blinking lion tamer's stress ball	0		Experience (familiar): +2, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5018,7 +5018,7 @@
 5115	hedge trimmers	0		
 5116	huge A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
-5118	maroon shaking jittery bird brain	0		
+5118	shaking maroon jittery bird brain	0		
 5119	blinking blinking busted wings	0		
 5120	twirling Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	tumbling rosewater-soaked arcane researcher's Admiral's hat of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Stench Resistance: +3, Familiar Effect: "atk", Last Available: "2011-05"
@@ -5038,7 +5038,7 @@
 5135	ghostly E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	jittery E.M.U. helmet	0		Last Available: "2011-06"
-5138	fuchsia shaking E.M.U. harness	0		Last Available: "2011-06"
+5138	shaking fuchsia E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
 5140	denatured olive astral energy drink	1		Effect: "Frozen Hands", Effect Duration: 35
 5141	shaking Thwaitgold bee statuette	0		
@@ -5066,10 +5066,10 @@
 5163	vibrating studded plush mutated alielephant	0		Damage Absorption: +80, Maximum MP Percent: +10, Last Available: "2011-06"
 5164	mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	Oprah's girl	0		Maximum MP Percent: +50, Last Available: "2011-06"
-5166	blurry shaking top hat and cane	0		Last Available: "2011-06"
+5166	shaking blurry top hat and cane	0		Last Available: "2011-06"
 5167	wobbly synthetic dog hair pill	0		Last Available: "2011-06"
-5168	shaking ghostly squat distention pill	0		Last Available: "2011-06"
-5169	gray twirling elven medi-pack	0		Last Available: "2011-06"
+5168	ghostly shaking squat distention pill	0		Last Available: "2011-06"
+5169	twirling gray elven medi-pack	0		Last Available: "2011-06"
 5170	tarnished Vulcanized transporter transponder	0		Effect: "Riboflavin'", Effect Duration: 24, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
@@ -5077,8 +5077,8 @@
 5174	weak mediocre Saison du Lune	2	decent	Last Available: "2011-06"
 5175	lousy maroon Moonthril Schnapps	3	decent	Last Available: "2011-06"
 5176	tolerable Wrecked Generator	4	good	Last Available: "2011-06"
-5177	half-sized flavorless Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
-5178	snack-sized adequate Crepes a la Lune	2	good	Last Available: "2011-06"
+5177	flavorless half-sized Spaghetti with Moonballs	2	decent	Last Available: "2011-06"
+5178	adequate snack-sized Crepes a la Lune	2	good	Last Available: "2011-06"
 5179	yummy mirror Moon Pie	4	awesome	Last Available: "2011-06"
 5180	improved green Comet Pop	0		Effect: "Quadrilled", Effect Duration: 31, Last Available: "2011-06"
 5181	diffused activated modified olive Flan in the Moon	0		Effect: "Disdain of She-Who-Was", Effect Duration: 29, Last Available: "2011-06"
@@ -5086,9 +5086,9 @@
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	huge Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	cyan Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
-5186	blurry spinning Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
+5186	spinning blurry Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
-5188	chilled cold-filtered blue ghostly honey stick	0		Effect: "Yes, Can Haz", Effect Duration: 67
+5188	chilled cold-filtered ghostly blue honey stick	0		Effect: "Yes, Can Haz", Effect Duration: 67
 5189	flattened double-ice gum	0		Effect: "Liquid Courage", Effect Duration: 65, Last Available: "2011-04"
 5190	manspreader's wicked Rosewater's Operation Patriot Shield	0		Mysticality Percent: +30, Spell Damage: +5, Monster Level: +10, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
@@ -5106,7 +5106,7 @@
 5203	dehydrated bug paste	1	good	Last Available: "2011-08"
 5204	vaporized hippy paste	1	awesome	Last Available: "2011-08"
 5205	dried orc paste	1	good	Last Available: "2011-08"
-5206	modified narrow blue demonic paste	1	decent	Last Available: "2011-08"
+5206	modified blue narrow demonic paste	1	decent	Last Available: "2011-08"
 5207	powdered fuchsia indescribably horrible paste	1	decent	Last Available: "2011-08"
 5208	diluted shaking paste	1	crappy	Last Available: "2011-08"
 5209	dehydrated tumbling goblin paste	1	awesome	Last Available: "2011-08"
@@ -5116,7 +5116,7 @@
 5213	vaporized fuchsia huge Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	pickled blinking shaking slimy paste	1	EPIC	Last Available: "2011-08"
 5215	twisted ghostly penguin paste	1	EPIC	Effect: "Shortened", Effect Duration: 45, Last Available: "2011-08"
-5216	altered maroon ghostly elemental paste	1	decent	Last Available: "2011-08"
+5216	altered ghostly maroon elemental paste	1	decent	Last Available: "2011-08"
 5217	diluted squat cosmic paste	1	awesome	Effect: "Puddingface", Effect Duration: 50, Last Available: "2011-08"
 5218	dehydrated hobo paste	1	decent	Last Available: "2011-08"
 5219	compressed wobbly Crimbo paste	1	good	Last Available: "2011-08"
@@ -5124,9 +5124,9 @@
 5221	blinking fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	moldy special narrow Ur-Donut	3	crappy	Effect: "Sinuses For Miles", Effect Duration: 20, Last Available: "2011-09"
+5224	special moldy narrow Ur-Donut	3	crappy	Effect: "Sinuses For Miles", Effect Duration: 20, Last Available: "2011-09"
 5225	olive The Bomb	0		Last Available: "2011-09"
-5226	twirling mirror box of Familiar Jacks	0		Last Available: "2011-09"
+5226	mirror twirling box of Familiar Jacks	0		Last Available: "2011-09"
 5227	weak artisanal bucket of wine	2	super ultra EPIC	Last Available: "2011-09"
 5228	tasty thick green ultrafondue	5	awesome	Last Available: "2011-09"
 5229	skewed unbearable light	0		Last Available: "2011-09"
@@ -5141,23 +5141,23 @@
 5238	bad irresponsibly strong Lumineux Limnio	9	decent	Last Available: "2011-09"
 5239	smooth Morto Moreto	4	awesome	Last Available: "2011-09"
 5240	lousy Temps Tempranillo	3	decent	Last Available: "2011-09"
-5241	perfectly mixed spirit-forward huge huge Bordeaux Marteaux	5	EPIC	Last Available: "2011-09"
+5241	spirit-forward perfectly mixed huge huge Bordeaux Marteaux	5	EPIC	Last Available: "2011-09"
 5242	bad wobbly twirling twirling Fromage Pinotage	4	decent	Last Available: "2011-09"
 5243	perfectly mixed upside-down Beignet Milgranet	4	EPIC	Last Available: "2011-09"
 5244	aged Muschat	3	awesome	Last Available: "2011-09"
-5245	snack-sized spoiled cool jelly donut	2	crappy	Last Available: "2011-09"
+5245	spoiled snack-sized cool jelly donut	2	crappy	Last Available: "2011-09"
 5246	rotten shrapnel jelly donut	3	crappy	Last Available: "2011-09"
 5247	decent mirror occult jelly donut	3	good	Last Available: "2011-09"
-5248	bland special thyme jelly donut	3	decent	Last Available: "2011-09"
-5249	diet flavorless special danish	1	decent	Effect: "Strong Grip", Effect Duration: 15, Last Available: "2011-09"
+5248	special bland thyme jelly donut	3	decent	Last Available: "2011-09"
+5249	special diet flavorless danish	1	decent	Effect: "Strong Grip", Effect Duration: 15, Last Available: "2011-09"
 5250	stale smashed danish	3	decent	Last Available: "2011-09"
-5251	tasty big forbidden danish	5	awesome	Last Available: "2011-09"
+5251	big tasty forbidden danish	5	awesome	Last Available: "2011-09"
 5252	adequate cool cat claw	3	good	Last Available: "2011-09"
-5253	massive stale blunt cat claw	7	decent	Last Available: "2011-09"
+5253	stale massive blunt cat claw	7	decent	Last Available: "2011-09"
 5254	moldy shadowy cat claw	3	crappy	Last Available: "2011-09"
-5255	super-sized bland cyan squat spinning cheezburger	5	decent	Last Available: "2011-09"
+5255	bland super-sized squat spinning cyan cheezburger	5	decent	Last Available: "2011-09"
 5256	decent toasted brie	3	good	Last Available: "2011-09"
-5257	warmed cold-filtered tumbling yellow potion of the field gar	0		Effect: "Coldfinger", Effect Duration: 26, Last Available: "2011-09"
+5257	warmed cold-filtered yellow tumbling potion of the field gar	0		Effect: "Coldfinger", Effect Duration: 26, Last Available: "2011-09"
 5258	pressed polarized too legit potion	0		Effect: "Sweet and Red", Effect Duration: 13, Last Available: "2011-09"
 5259	boiled quadruple-magnetized frozen Bright Water	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 67, Last Available: "2011-09"
 5260	magnetized improved pulsating yellow cold-filtered water	0		Effect: "[800]Chocolate Reign", Effect Duration: 57, Last Available: "2011-09"
@@ -5166,12 +5166,12 @@
 5263	cold-filtered improved potion of the captain's hammer	0		Effect: "Angry like the Wolf", Effect Duration: 56, Last Available: "2011-09"
 5264	colloidal bouncing potion of X-ray vision	0		Effect: "Taurus Rising", Effect Duration: 69, Last Available: "2011-09"
 5265	triple-modified nitrogenated concentrated potion of the litterbox	0		Effect: "Thicker, Sicker", Effect Duration: 67, Last Available: "2011-09"
-5266	flattened twirling squat wobbly potion of animal rage	0		Effect: "Libra Rising", Effect Duration: 66, Last Available: "2011-09"
+5266	flattened wobbly twirling squat potion of animal rage	0		Effect: "Libra Rising", Effect Duration: 66, Last Available: "2011-09"
 5267	enhanced pressed blurry potion of punctual companionship	0		Effect: "Baconstoned", Effect Duration: 14, Last Available: "2011-09"
 5268	skewed holy bomb, batman	0		Last Available: "2011-09"
 5269	huge bobcat grenade	0		Last Available: "2011-09"
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
-5271	jittery gray ghostly broken glass grenade	0		Last Available: "2011-09"
+5271	jittery ghostly gray broken glass grenade	0		Last Available: "2011-09"
 5272	jittery noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	small moldy blinking phish stick	2	crappy	Last Available: "2011-09"
+5298	moldy small blinking phish stick	2	crappy	Last Available: "2011-09"
 5299	gray hale Fonzie's plastic vampire fangs of the wise owl	0		Mysticality: +20, Experience (Moxie): +1, Maximum HP: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5227,7 +5227,7 @@
 5324	acceptable Blood Light	3	good	Last Available: "2011-10"
 5325	smooth Silver Bullet beer	3	awesome	Last Available: "2011-10"
 5326	perfectly mixed watered-down twirling Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
-5327	blurry bouncing ghost protocol	0		Last Available: "2011-10"
+5327	bouncing blurry ghost protocol	0		Last Available: "2011-10"
 5328	ionized anodized sorority brain	0		Effect: "Patent Prevention", Effect Duration: 15, Last Available: "2011-10"
 5329	dry lime green Nightstalker perfume	0		Effect: "Outer Wolf&trade;", Effect Duration: 59, Last Available: "2011-10"
 5330	quadruple-energized drum of pomade	0		Effect: "Icy Composition", Effect Duration: 25, Last Available: "2011-10"
@@ -5243,7 +5243,7 @@
 5340	supercharged experienced cool The Necbromancer's Wizard Staff	0		Moxie: +5, Experience: +2, Maximum MP Percent: +30, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	lousy The Cooler Out of Space	4	decent	Last Available: "2011-10"
-5343	wobbly jittery The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
+5343	jittery wobbly The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	diffused denatured quantum twirling Necbro wafers	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 47, Last Available: "2020-09"
 5346	death blossom	0		
@@ -5254,7 +5254,7 @@
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
-5354	jittery gray The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+5354	gray jittery The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
@@ -5285,7 +5285,7 @@
 5382	pulsating pearidot	0		Last Available: "2011-11"
 5383	fuchsia tourmalime	0		Last Available: "2011-11"
 5384	kumquartz	0		Last Available: "2011-11"
-5385	mirror blue strawberyl	0		Last Available: "2011-11"
+5385	blue mirror strawberyl	0		Last Available: "2011-11"
 5386	ridiculous belt of Flo-Jo	0		Initiative: +100, Last Available: "2011-11"
 5387	dangerous ridiculous earring	0		Weapon Damage: +10, Last Available: "2011-11"
 5388	curative ridiculous sunglasses	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-11"
@@ -5294,11 +5294,11 @@
 5391	auspicious Lo Pan's zombie monkey necklace	0		Spell Critical Percent: +30, Item Drop: +10
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
-5394	blurry narrow sandpaper	0		
+5394	narrow blurry sandpaper	0		
 5395	spinning peppermint sprout	0		Last Available: "2011-11"
 5396	chilled peppermint twist	0		Effect: "Clyde's Blessing", Effect Duration: 63, Last Available: "2011-11"
 5397	bite-sized stale peppermint patty	1	decent	Last Available: "2011-11"
-5398	wobbly red peppermint crook	0		Last Available: "2011-11"
+5398	red wobbly peppermint crook	0		Last Available: "2011-11"
 5399	blurry tumbling peppermint rhino baby	0		Last Available: "2011-11"
 5400	fuchsia candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
@@ -5308,16 +5308,16 @@
 5405	sizzling dog trainer's Van der Graaf cane-mail shirt	0		Experience (familiar): +1, Hot Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-12"
 5406	purple ghostly censurious lard-coated healthy cane-mail pants	0		Maximum HP Percent: +20, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	high-proof hand-crafted Vodka Matryoshka	7	EPIC	Last Available: "2011-12"
-5408	special delicious Gin Mint	4	awesome	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 35, Last Available: "2011-12"
+5408	delicious special Gin Mint	4	awesome	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 35, Last Available: "2011-12"
 5409	tolerable Tequiz Navidad	4	good	Last Available: "2011-12"
 5410	hand-crafted Mint Yulep	3	EPIC	Last Available: "2011-12"
 5411	acceptable wobbly Crimbojito	4	good	Last Available: "2011-12"
-5412	weak acceptable Sangria de Menthe	2	good	Last Available: "2011-12"
-5413	mirror shaking olive candycaine powder	0		Last Available: "2011-12"
+5412	acceptable weak Sangria de Menthe	2	good	Last Available: "2011-12"
+5413	mirror olive shaking candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	corrupted twirling licorice root	0		Effect: "Feelin' Philosophical", Effect Duration: 64, Last Available: "2011-12"
 5416	polarized banana supersucker	0		Effect: "All Fired Up", Effect Duration: 14, Last Available: "2011-11"
-5417	frozen dry huge cyan pear supersucker	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 42, Last Available: "2011-11"
+5417	frozen dry cyan huge pear supersucker	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 42, Last Available: "2011-11"
 5418	deionized boiled lime supersucker	0		Effect: "Chlorophyll Flavor", Effect Duration: 43, Last Available: "2011-11"
 5419	Vulcanized chilled maroon kumquat supersucker	0		Effect: "Arabian Knighthood", Effect Duration: 14, Last Available: "2011-11"
 5420	super-nitrogenated strawberry supersucker	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 54, Last Available: "2011-11"
@@ -5335,7 +5335,7 @@
 5432	grape troll doll	0		Last Available: "2011-11"
 5433	blinking raspberry troll doll	0		Last Available: "2011-11"
 5434	DNOTC Box	0		Last Available: "2017-12"
-5435	pulsating cyan fudgecule	0		Last Available: "2011-11"
+5435	cyan pulsating fudgecule	0		Last Available: "2011-11"
 5436	ionized bouncing mirror fudge lily	0		Effect: "Wistfully Nostalgic", Effect Duration: 29, Last Available: "2011-11"
 5437	blurry superheated fudge	0		Last Available: "2011-11"
 5438	improved mirror pulsating narrow fluid of fudge-finding	0		Effect: "Tenacity of the Snapper", Effect Duration: 39, Last Available: "2011-11"
@@ -5361,9 +5361,9 @@
 5458	adequate half-sized blurry fudge bunny	2	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	friendly extremely unsafe fudgecycle of wisdom	0		Mysticality: +15, Weapon Damage Percent: +100, Familiar Weight: +3, Single Equip, Last Available: "2011-11"
-5461	gray blinking fudge cube	0		Last Available: "2011-11"
+5461	blinking gray fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	wobbly ghostly Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	ghostly wobbly Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	ionized wet resolution: be wealthier	0		Effect: "You Read The Manual", Effect Duration: 57, Last Available: "2012-01"
 5465	alkaline double-wet resolution: be happier	0		Effect: "Thickest, Sickest", Effect Duration: 69, Last Available: "2012-01"
 5466	tarnished deionized resolution: be stronger	0		Effect: "Mystic Circle", Effect Duration: 38, Last Available: "2012-01"
@@ -5377,12 +5377,12 @@
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	flattened blinking gummi salamander	0		Effect: "White Blooded", Effect Duration: 37, Last Available: "2011-11"
-5477	quadruple-dry triple-improved bouncing jittery gummi snake	0		Effect: "Tightly-Wound Spine", Effect Duration: 26, Last Available: "2011-11"
+5477	quadruple-dry triple-improved jittery bouncing gummi snake	0		Effect: "Tightly-Wound Spine", Effect Duration: 26, Last Available: "2011-11"
 5478	extra-irradiated gummi canary	0		Effect: "Hopped Up on Goofballs", Effect Duration: 50, Last Available: "2011-11"
 5479	stale snack-sized gummi bear	2	decent	Last Available: "2011-11"
 5480	decent thick gummi bear	5	good	Last Available: "2011-11"
 5481	flavorless skewed gummi bear	4	decent	Last Available: "2011-11"
-5482	tiny bland drunki-bear	1	decent	Last Available: "2011-11"
+5482	bland tiny drunki-bear	1	decent	Last Available: "2011-11"
 5483	miniature flavorless drunki-bear	2	decent	Last Available: "2011-11"
 5484	rotten teal drunki-bear	4	crappy	Last Available: "2011-11"
 5485	lime green rock-hard gummi bowtie	0		Damage Reduction: 5, Last Available: "2011-11"
@@ -5390,7 +5390,7 @@
 5487	lollipop cufflinks of terror	0		Spooky Spell Damage: +10, Last Available: "2011-11"
 5488	trilobite fossil	0		Last Available: "2011-11"
 5489	ammonite fossil	0		Last Available: "2011-11"
-5490	huge teal belemnite fossil	0		Last Available: "2011-11"
+5490	teal huge belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
@@ -5400,7 +5400,7 @@
 5497	squat all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
 5499	nasty Big Candy's tophat of the overflowing toilet	0		Stench Damage: +5, Stench Spell Damage: +50, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
-5500	blurry lime green Fuzzby	0		Free Pull, Last Available: "2011-11"
+5500	lime green blurry Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	jittery upside-down Tickle-Me Emilio	0		Last Available: "2011-11"
@@ -5409,7 +5409,7 @@
 5506	moldy jerky coins	3	crappy	Last Available: "2011-11"
 5507	drinkable weak gray Go-Wassail	2	good	Last Available: "2011-11"
 5508	triple-cold-filtered dry Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Really Deep Breath", Effect Duration: 53, Last Available: "2011-11"
-5509	unsweetened concentrated shaking maroon bottle of bubbles	0		Effect: "Irresistible Resolve", Effect Duration: 11, Last Available: "2011-11"
+5509	unsweetened concentrated maroon shaking bottle of bubbles	0		Effect: "Irresistible Resolve", Effect Duration: 11, Last Available: "2011-11"
 5510	improved triple-ionized bouncing wind-up meatcar	0		Effect: "A Taste of Rainbow", Effect Duration: 59, Last Available: "2011-11"
 5511	mirror Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
@@ -5420,7 +5420,7 @@
 5517	gray mirror pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	twirling pog #05 (ninja snowman)	0		Last Available: "2011-11"
-5520	bouncing huge pog #06 (filthy hippy)	0		Last Available: "2011-11"
+5520	huge bouncing pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	skewed pog #08 (hellion)	0		Last Available: "2011-11"
 5523	lime green pog #09 (pirate)	0		Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	pickled Mortimer's nostrum	0		Effect: "Mushroom Samba", Effect Duration: 17, Last Available: "2012-12"
-5534	special high-proof hand-crafted Barulio's bottle	7	EPIC	Effect: "Singer's Faithful Ocelot", Effect Duration: 15, Last Available: "2012-12"
+5534	high-proof special hand-crafted Barulio's bottle	7	EPIC	Effect: "Singer's Faithful Ocelot", Effect Duration: 15, Last Available: "2012-12"
 5535	adjusted super-enhanced Marvin's marvelous pill	0		Effect: "Unrunnable Face", Effect Duration: 46, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5447,11 +5447,11 @@
 5544	tolerable ghostly eggnog	3	good	Last Available: "2012-12"
 5545	spoiled hamhock	3	crappy	Last Available: "2012-12"
 5546	twirling The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
-5547	pulsating gray jittery Clancy's sackbut	0		Last Available: "2012-12"
+5547	pulsating jittery gray Clancy's sackbut	0		Last Available: "2012-12"
 5548	teal Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
 5549	Clancy's crumhorn	0		Last Available: "2012-12"
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
-5551	spinning mirror Clancy's lute	0		Last Available: "2012-12"
+5551	mirror spinning Clancy's lute	0		Last Available: "2012-12"
 5552	therapeutic Trusty	0		HP Regen Min: 5, HP Regen Max: 7
 5553	can of Rain-Doh	0		Last Available: "2012-02"
 5554	green empty Rain-Doh can	0		Last Available: "2012-02"
@@ -5465,80 +5465,80 @@
 5562	Rain-Doh violet bo of mayonnaise of bravery	0		Sleaze Spell Damage: +50, Spooky Resistance: +5, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	skewed Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	huge bland PB&BP	6	decent	
-5566	low-calorie normal huge club sandwich	1	good	
+5565	bland huge PB&BP	6	decent	
+5566	normal low-calorie huge club sandwich	1	good	
 5567	flavorless fancy gray corned-beef Reuben	4	decent	Effect: "On a Roll", Effect Duration: 30
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
-5570	red mirror loose ninja carabiner	0		
-5571	wobbly tumbling Groar's fur	0		
+5570	mirror red loose ninja carabiner	0		
+5571	tumbling wobbly Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	fortified mediocre twirling Drac & Tan	5	decent	Last Available: "2012-03"
-5574	practically non-alcoholic mediocre Transylvania Sling	1	decent	Last Available: "2012-03"
+5573	mediocre fortified twirling Drac & Tan	5	decent	Last Available: "2012-03"
+5574	mediocre practically non-alcoholic Transylvania Sling	1	decent	Last Available: "2012-03"
 5575	drinkable blinking Shot of the Living Dead	3	good	Last Available: "2012-03"
 5576	fancy bad wobbly Buttery Knob	3	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 15, Last Available: "2012-03"
-5577	tolerable watered-down Slippery Knob	2	good	Last Available: "2012-03"
+5577	watered-down tolerable Slippery Knob	2	good	Last Available: "2012-03"
 5578	drinkable Flaming Knob	3	good	Last Available: "2012-03"
 5579	strong perfectly mixed Grasshopper	5	EPIC	Last Available: "2012-03"
-5580	hand-crafted irresponsibly strong Locust	9	EPIC	Last Available: "2012-03"
+5580	irresponsibly strong hand-crafted Locust	9	EPIC	Last Available: "2012-03"
 5581	distilled lousy bouncing Plague of Locusts	5	decent	Last Available: "2012-03"
-5582	mediocre weak Red Dwarf	2	decent	Last Available: "2012-03"
+5582	weak mediocre Red Dwarf	2	decent	Last Available: "2012-03"
 5583	artisanal practically non-alcoholic lime green spinning Golden Mean	1	EPIC	Last Available: "2012-03"
-5584	acceptable triple-distilled huge Green Giant	7	good	Last Available: "2012-03"
-5585	weak drinkable Aye Aye	2	good	Last Available: "2012-03"
+5584	triple-distilled acceptable huge Green Giant	7	good	Last Available: "2012-03"
+5585	drinkable weak Aye Aye	2	good	Last Available: "2012-03"
 5586	drinkable Aye Aye, Captain	4	good	Last Available: "2012-03"
 5587	tolerable upside-down Aye Aye, Tooth Tooth	3	good	Last Available: "2012-03"
 5588	acceptable pulsating Humanitini	3	good	Last Available: "2012-03"
-5589	hand-crafted triple-distilled fancy More Humanitini than Humanitini	8	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2012-03"
-5590	weak enchanted lousy narrow Oh, the Humanitini	2	decent	Effect: "Oriental Mysticism", Effect Duration: 10, Last Available: "2012-03"
+5589	fancy hand-crafted triple-distilled More Humanitini than Humanitini	8	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2012-03"
+5590	weak lousy enchanted narrow Oh, the Humanitini	2	decent	Effect: "Oriental Mysticism", Effect Duration: 10, Last Available: "2012-03"
 5591	hand-crafted practically non-alcoholic shaking yellow Great Older Fashioned	1	EPIC	Last Available: "2012-03"
-5592	fancy fortified mediocre Fuzzy Tentacle	5	decent	Effect: "Toast Tea", Effect Duration: 35, Last Available: "2012-03"
+5592	mediocre fortified fancy Fuzzy Tentacle	5	decent	Effect: "Toast Tea", Effect Duration: 35, Last Available: "2012-03"
 5593	hand-crafted blurry Crazymaker	4	EPIC	Last Available: "2012-03"
 5594	drinkable blue spinning Zoodriver	4	good	Last Available: "2012-03"
 5595	acceptable Sloe Comfortable Zoo	4	good	Last Available: "2012-03"
 5596	fancy tolerable Sloe Comfortable Zoo on Fire	4	good	Effect: "Gonna Get You, Sucker", Effect Duration: 5, Last Available: "2012-03"
-5597	lousy triple-distilled Suffering Sinner	7	decent	Last Available: "2012-03"
+5597	triple-distilled lousy Suffering Sinner	7	decent	Last Available: "2012-03"
 5598	mediocre practically non-alcoholic ghostly Suppurating Sinner	1	decent	Last Available: "2012-03"
 5599	bad teal Sizzling Sinner	3	decent	Last Available: "2012-03"
 5600	delicious Firewater	3	awesome	Last Available: "2012-03"
 5601	tolerable practically non-alcoholic Earth and Firewater	1	good	Last Available: "2012-03"
 5602	perfectly mixed Earth, Wind and Firewater	3	EPIC	Last Available: "2012-03"
 5603	smooth Slimosa	4	awesome	Last Available: "2012-03"
-5604	lousy watered-down Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
-5605	special artisanal Slimebite	4	EPIC	Effect: "Amorphous Cheer", Effect Duration: 25, Last Available: "2012-03"
+5604	watered-down lousy Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
+5605	artisanal special Slimebite	4	EPIC	Effect: "Amorphous Cheer", Effect Duration: 25, Last Available: "2012-03"
 5606	mediocre Cement Mixer	4	decent	Last Available: "2012-03"
-5607	high-proof hand-crafted Jackhammer	6	EPIC	Last Available: "2012-03"
+5607	hand-crafted high-proof Jackhammer	6	EPIC	Last Available: "2012-03"
 5608	bad blurry Dump Truck	3	decent	Last Available: "2012-03"
 5609	delicious skewed Fauna Libre	3	awesome	Last Available: "2012-03"
-5610	weak aged Chakra Libre	2	awesome	Last Available: "2012-03"
+5610	aged weak Chakra Libre	2	awesome	Last Available: "2012-03"
 5611	artisanal Aura Libre	3	EPIC	Last Available: "2012-03"
-5612	practically non-alcoholic enchanted acceptable blinking Sazerorc	1	good	Effect: "Alchemical, Brother", Effect Duration: 50, Last Available: "2012-03"
+5612	enchanted acceptable practically non-alcoholic blinking Sazerorc	1	good	Effect: "Alchemical, Brother", Effect Duration: 50, Last Available: "2012-03"
 5613	aged olive Sazuruk-hai	3	awesome	Last Available: "2012-03"
 5614	aged wobbly Flaming Sazerorc	3	awesome	Last Available: "2012-03"
 5615	hand-crafted jittery Green Velvet	3	EPIC	Last Available: "2012-03"
 5616	artisanal shaking Green Muslin	3	EPIC	Last Available: "2012-03"
-5617	drinkable spirit-forward upside-down Green Burlap	5	good	Last Available: "2012-03"
+5617	spirit-forward drinkable upside-down Green Burlap	5	good	Last Available: "2012-03"
 5618	drinkable watered-down shaking Mohobo	2	good	Last Available: "2012-03"
-5619	mediocre practically non-alcoholic Moonshine Mohobo	1	decent	Last Available: "2012-03"
+5619	practically non-alcoholic mediocre Moonshine Mohobo	1	decent	Last Available: "2012-03"
 5620	acceptable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	smooth cyan Drunken Philosopher	3	awesome	Last Available: "2012-03"
 5622	mediocre watered-down maroon wobbly Drunken Neurologist	2	decent	Last Available: "2012-03"
-5623	watered-down bad skewed Drunken Astrophysicist	2	decent	Last Available: "2012-03"
+5623	bad watered-down skewed Drunken Astrophysicist	2	decent	Last Available: "2012-03"
 5624	irresponsibly strong aged Dark & Starry	6	awesome	Last Available: "2012-03"
-5625	perfectly mixed weak Black Hole	2	EPIC	Last Available: "2012-03"
+5625	weak perfectly mixed Black Hole	2	EPIC	Last Available: "2012-03"
 5626	perfectly mixed lime green Event Horizon	3	EPIC	Last Available: "2012-03"
-5627	hand-crafted skewed purple Herring Daiquiri	4	EPIC	Last Available: "2012-03"
-5628	aged special ghostly green Herring Wallbanger	3	awesome	Effect: "Improprie Tea", Effect Duration: 15, Last Available: "2012-03"
+5627	hand-crafted purple skewed Herring Daiquiri	4	EPIC	Last Available: "2012-03"
+5628	special aged ghostly green Herring Wallbanger	3	awesome	Effect: "Improprie Tea", Effect Duration: 15, Last Available: "2012-03"
 5629	artisanal wobbly Herringtini	4	EPIC	Last Available: "2012-03"
-5630	smooth watered-down Lollipop Drop	2	awesome	Last Available: "2012-03"
+5630	watered-down smooth Lollipop Drop	2	awesome	Last Available: "2012-03"
 5631	tolerable skewed Candy Alexander	3	good	Last Available: "2012-03"
 5632	delicious Candicaine	4	awesome	Last Available: "2012-03"
-5633	artisanal watered-down bouncing yellow Caipiranha	2	EPIC	Last Available: "2012-03"
+5633	artisanal watered-down yellow bouncing Caipiranha	2	EPIC	Last Available: "2012-03"
 5634	hand-crafted Flying Caipiranha	4	EPIC	Last Available: "2012-03"
 5635	tolerable pulsating pulsating Flaming Caipiranha	3	good	Last Available: "2012-03"
-5636	practically non-alcoholic artisanal squat Punchplanter	1	EPIC	Last Available: "2012-03"
-5637	practically non-alcoholic aged Doublepunchplanter	1	awesome	Last Available: "2012-03"
-5638	practically non-alcoholic bad Haymaker	1	decent	Last Available: "2012-03"
+5636	artisanal practically non-alcoholic squat Punchplanter	1	EPIC	Last Available: "2012-03"
+5637	aged practically non-alcoholic Doublepunchplanter	1	awesome	Last Available: "2012-03"
+5638	bad practically non-alcoholic Haymaker	1	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	wobbly crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	flavorless fungus	3	decent	
@@ -5570,7 +5570,7 @@
 5667	huge puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	fuchsia club	0		
-5670	tiny spoiled maroon fettucini &eacute;pines Inconnu	1	crappy	
+5670	spoiled tiny maroon fettucini &eacute;pines Inconnu	1	crappy	
 5671	mediocre slap and slap again	4	decent	
 5672	narrow gunpowder burrito	2	good	
 5673	twirling beery blood	2	good	
@@ -5581,13 +5581,13 @@
 5678	teal soggy used band-aid	0		Last Available: "2012-05"
 5679	veiny stylish swimsuit of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +10, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
-5681	tiny normal P.B.L.T.	1	good	
+5681	normal tiny P.B.L.T.	1	good	
 5682	upside-down note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	pulsating shaking handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	purple mirror bugbear autopsy tweezers	0		
+5687	mirror purple bugbear autopsy tweezers	0		
 5688	green brainy UV monocular	0		Mysticality: +5, Single Equip
 5689	purple drone self-destruct chip	0		
 5690	squat Jeff Goldblum larva	0		
@@ -5612,13 +5612,13 @@
 5709	maroon MacGyver's rosy-cheeked fireman's helmet	0		Maximum HP Percent: +30, Maximum MP: +100, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	twirling toasty fire axe	0		Hot Damage: +5, Last Available: "2012-07"
 5713	ribald ruddy extremely unsafe fire extinguisher	0		Weapon Damage Percent: +100, Maximum HP Percent: +40, Sleaze Damage: +10, Last Available: "2012-07"
-5714	blinking mirror FDKOL tattoo	0		
+5714	mirror blinking FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	adequate bouncing FDKOL hotcakes	4	good	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	olive smoking grass	0		Last Available: "2012-07"
-5720	adequate snack-sized narrow fiery wing	2	good	Last Available: "2012-07"
+5720	snack-sized adequate narrow fiery wing	2	good	Last Available: "2012-07"
 5721	bouncing Jeselnik's Van der Graaf wings of fire	0		Sleaze Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-07"
 5722	Annie Oakley's FDKOL fire hose	0		Critical Hit Percent: +20, Last Available: "2012-07"
 5723	quadruple-colloidal pulsating bottle of fire	0		Effect: "Cat Class, Cat Style", Effect Duration: 68, Last Available: "2012-07"
@@ -5632,49 +5632,49 @@
 5731	hand-crafted fancy 5-hour acrimony	3	EPIC	Effect: "Inner Warmth", Effect Duration: 40
 5732	blank note	0		
 5733	eerily silent box	0		
-5734	snack-sized normal upside-down forbidden sausage	2	good	
+5734	normal snack-sized upside-down forbidden sausage	2	good	
 5735	Fonzie's Lord Flameface's cloak	0		Experience (Moxie): +1, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	energized mirror Drizzlers&trade; Black Licorice	0		Effect: "Oleaginous Soles", Effect Duration: 17
 5737	energized daub-breaker	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 32, Last Available: "2020-09"
 5738	gray blurry lightning-fast Camp Scout backpack	0		Initiative: +40, Softcore Only, Last Available: "2012-07"
 5739	purple upside-down CSA fire-starting kit	0		Last Available: "2012-07"
-5740	small stale bag of GORP	2	decent	Last Available: "2012-07"
-5741	weak artisanal water purification pills	2	EPIC	Last Available: "2012-07"
+5740	stale small bag of GORP	2	decent	Last Available: "2012-07"
+5741	artisanal weak water purification pills	2	EPIC	Last Available: "2012-07"
 5742	spinning Camp Scout pup tent	0		Last Available: "2012-07"
 5743	aged CSA scoutmaster's &quot;water&quot;	3	awesome	Last Available: "2012-07"
-5744	snack-sized moldy bag of GORF	2	crappy	Last Available: "2012-07"
+5744	moldy snack-sized bag of GORF	2	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	diet normal bag of QWOP	1	good	Last Available: "2012-07"
 5747	polarized irradiated CSA bravery badge	0		Effect: "Spooky Blur", Effect Duration: 28, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	bad practically non-alcoholic blurry CSA cheerfulness ration	1	decent	Last Available: "2012-07"
+5749	practically non-alcoholic bad blurry CSA cheerfulness ration	1	decent	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	gray Tales of the Word Realms	0		
-5752	small flavorless crappy brain	2	decent	
+5752	flavorless small crappy brain	2	decent	
 5753	decent tumbling decent brain	4	good	
 5754	normal good brain	4	good	
 5755	small bland boss brain	2	decent	
-5756	moldy massive hunter brain	9	crappy	
+5756	massive moldy hunter brain	9	crappy	
 5758	teal rosewater-soaked razor-sharp smartaleck's Staff of Holiday Sensations	0		Moxie Percent: +30, Weapon Damage Percent: +25, Stench Resistance: +3, Last Available: "2011-11"
 5759	lard-coated energetic staff	0		Maximum MP Percent: +20, Sleaze Spell Damage: +25
 5760	Tesla curative staff of courage	0		Spooky Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5
 5761	gray hardened Newton's Staff of the Scummy Sink of the cougar	0		Moxie: +20, Experience (Mysticality): +3, Damage Reduction: 3, Slime Hates It: +1
-5762	purple ghostly nose	0		
+5762	ghostly purple nose	0		
 5763	wizardly Superhero Reboots of the wise owl	0		Mysticality: 45
 5764	double-paned thinker's fuzzy busby	0		Mysticality: +10, Cold Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5765	supercharged strapping fuzzy earmuffs	0		Muscle: +5, Maximum MP Percent: +30, Familiar Effect: "1.5xVolley, cap 32"
 5766	censurious Da Vinci's brawny fuzzy montera	0		Muscle Percent: +20, Experience (Mysticality): +5, Sleaze Resistance: +3, Familiar Effect: "1.5xVolley, cap 32"
 5767	tumbling Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	huge gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	huge gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	blinking gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	ghostly gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	huge gnomish swimmer's ears	0		Familiar Effect: "underwater", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5769	huge gnomish coal miner's lung	0		Familiar Effect: "block", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5770	blinking gnomish tennis elbow	0		Familiar Effect: "damage", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
+5772	ghostly gnomish athlete's foot	0		Familiar Effect: "delevel", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
 5773	squat Thwaitgold maggot statuette	0		
 5774	green talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	Da Vinci's Barney's rake of doom	0		Experience (Mysticality): +5, Spooky Spell Damage: +50
-5778	decent fancy half-sized shaking idiot brain	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
+5778	fancy half-sized decent shaking idiot brain	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
 5779	blurry mansplainer's keel-haulin' knife	0		Monster Level: +15
 5780	miser's ice cream scoop	0		Meat Drop: +10
 5781	hand-crafted soft echo eyedrop antidote martini	4	EPIC	
@@ -5684,7 +5684,7 @@
 5785	thick caulk	0		
 5786	hard screw	0		
 5787	blinking messy butt joint	0		
-5788	blurry maroon smut orc keepsake box	0		
+5788	maroon blurry smut orc keepsake box	0		
 5789	cyan spinning bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
 5791	toasty brainy right bear arm	0		Mysticality: +5, Hot Damage: +5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
@@ -5703,7 +5703,7 @@
 5804	magnetized activated tumbling Shivering Ch&egrave;vre	0		Effect: "Punch Another Day", Effect Duration: 60
 5805	double-deionized skewed breath mint	0		Effect: "Tingly Elbows", Effect Duration: 68
 5806	Vulcanized ionized muesli	0		Effect: "Dreadful Fear", Effect Duration: 56
-5807	corrupted pulsating mirror glass of warm milk	0		Effect: "Good with the Ladies", Effect Duration: 62
+5807	corrupted mirror pulsating glass of warm milk	0		Effect: "Good with the Ladies", Effect Duration: 62
 5808	alkaline spinning glass of gnat milk	0		Effect: "Permanent Halloween", Effect Duration: 50
 5809	quantum diffused Knob Goblin Mutagen	0		Effect: "Ironclad", Effect Duration: 13
 5810	corrupted boiled Tears of the Quiet Healer	0		Effect: "Big Meat Big Prizes", Effect Duration: 33
@@ -5721,7 +5721,7 @@
 5822	altered super-galvanized huge tumbling gazely stare	0		Effect: "Twen Tea", Effect Duration: 54
 5823	vacuum-sealed ghostly canopic jar	0		Effect: "You Read The Manual", Effect Duration: 27
 5824	double-warmed irradiated clove-flavored lip balm	0		Effect: "Florid Cheeks", Effect Duration: 33
-5825	quantum Vulcanized ghostly fuchsia Skullery Maid's Knee	0		Effect: "damage.enh", Effect Duration: 11
+5825	quantum Vulcanized fuchsia ghostly Skullery Maid's Knee	0		Effect: "damage.enh", Effect Duration: 11
 5826	quantum corrupted moist mirror ghostly zombie hollandaise	0		Effect: "Cold Hard Skin", Effect Duration: 36
 5827	flattened magnetized skeletal banana	0		Effect: "Moon-Eyed", Effect Duration: 42
 5828	magnetized tarnished gilt perfume bottle	0		Effect: "Corona de la Salsa", Effect Duration: 68
@@ -5776,10 +5776,10 @@
 5877	bouncing bouncing papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	Rainbow Jello Mould of the boozehound	0		Booze Drop: +100
 5879	pulsating Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
-5880	maroon blurry packet of dragon's teeth	0		Last Available: "2012-10"
+5880	blurry maroon packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	wobbly upside-down prompt skeleton skis of Gandalf of the glutton	0		Spell Critical Percent: +20, Food Drop: +100, Adventures: +3, Single Equip, Last Available: "2012-10"
-5883	stale massive skeleton quiche	6	decent	Last Available: "2012-10"
+5883	massive stale skeleton quiche	6	decent	Last Available: "2012-10"
 5884	squat skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	spinning skeletal skiff	0		Last Available: "2012-10"
 5886	executive Van der Graaf resourceful Herculean Bonestabber	0		Experience (Muscle): +1, Maximum MP: +50, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-10"
@@ -5791,7 +5791,7 @@
 5892	aerosolized bouncing fuchsia that gum you like	0		Effect: "Super-Electrified", Effect Duration: 68
 5893	jittery dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
-5895	ghostly maroon avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
+5895	maroon ghostly avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	squat canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	modified Unconscious Collective Dream Jar	1	decent	Effect: "Sleazy Jellied", Effect Duration: 5, Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
@@ -5800,7 +5800,7 @@
 5901	upside-down jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
-5905	squat lime green blinking jar of psychoses (Jick)	0		Last Available: "2013-12"
+5905	lime green blinking squat jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	pixel pill	0		
 5907	blurry pixel energy tank	0		
 5908	wobbly ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
@@ -5819,11 +5819,11 @@
 5921	blinking beefy plastic Uncle Crimboku	0		Muscle: +10, Last Available: "2012-12"
 5922	maroon hardened plastic MechaElf	0		Damage Reduction: 3, Last Available: "2012-12"
 5923	wobbly plastic ingot	0		Last Available: "2012-12"
-5924	lime green blinking electrical thingamabob	0		Last Available: "2012-12"
+5924	blinking lime green electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	narrow Jack Frost's brainwave-controlled unicorn horn	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	narrow Jack Frost's brainwave-controlled unicorn horn	0		Cold Spell Damage: +50, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
 5929	ghostly tumbling bubble-wrap simulator	0		Last Available: "2012-12"
 5930	olive blind-packed capsule toy	0		Last Available: "2012-12"
 5931	tumbling spinning blue aromatic razor-sharp plastic four-shadowed mime of the dark arts	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Stench Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	skewed fuchsia flame-wreathed plastic Father McGruber	0		Hot Spell Damage: +10, Last Available: "2012-12"
 5961	blurry Tesla plastic Hank North, Photojournalist	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-12"
 5962	pulsating plastic blazing bat of temperance	0		Sleaze Resistance: +5, Last Available: "2012-12"
-5963	therapeutic electronic dulcimer pants of the cougar	0		Moxie: +20, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	therapeutic electronic dulcimer pants of the cougar	0		Moxie: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	banded educational Frown Exerciser	0		Experience: +1, Damage Absorption: +100, Single Equip, Last Available: "2012-12"
 5966	twirling soul monocle	0		Single Equip
@@ -5882,7 +5882,7 @@
 5984	squat inspector's reassuring steel-toed cloth cap	0		Damage Reduction: 9, Spooky Resistance: +1, Item Drop: +15, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	upside-down executive Jeselnik's scorching iron dagger	0		Hot Damage: +25, Sleaze Damage: +25, Meat Drop: +40, Last Available: "2013-02"
 5986	massive decent hamburger	9	good	Last Available: "2013-02"
-5987	fuchsia spinning dollar-sign bag	0		Last Available: "2013-02"
+5987	spinning fuchsia dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
 5990	boozy lousy bottle of wine	5	decent	Last Available: "2013-02"
@@ -5933,7 +5933,7 @@
 6035	pressed pressed shaking vial of The Glistening	0		Effect: "Salsa Satanica", Effect Duration: 56
 6036	drinkable pulsating artisanal limoncello	3	good	
 6037	squat ginger ale	0		
-6038	massive rotten mirror incredible pizza	10	crappy	
+6038	rotten massive mirror incredible pizza	10	crappy	
 6039	medical-grade oil cap of temperance	0		Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cap 28"
 6040	gravedigger's oil lamp of courage	0		Spooky Damage: +10, Spooky Resistance: +3
 6041	oil slacks	0		Item Drop: +5, Familiar Effect: "1xPotato, cap 30"
@@ -5949,9 +5949,9 @@
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	bland massive Taco Dan's Taco Stand Taco	6	decent	Last Available: "2012-12"
 6053	lousy huge Taco Dan's Taco Stand Chimichangarita	4	decent	Last Available: "2012-12"
-6054	diffused mirror shaking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Gyromitra Gymnastics", Effect Duration: 22, Last Available: "2012-12"
+6054	diffused shaking mirror Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Gyromitra Gymnastics", Effect Duration: 22, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	medical-grade occult Meatcleaver	0		Spell Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12"
 6058	skewed cyan Crimbo Elf bobble-head of the cheetah	0		Initiative: +60, Last Available: "2012-12"
 6059	red dog trainer's Crimbo stogie-scented room odorizer	0		Experience (familiar): +1, Last Available: "2012-12"
@@ -5993,7 +5993,7 @@
 6095	sizzling Microplushie: Fauxnerditide	0		Hot Damage: +10, Last Available: "2012-12"
 6096	educational Microplushie: Hipsterine	0		Experience: +1, Last Available: "2012-12"
 6097	bouncing classy monkey	0		Last Available: "2012-12"
-6098	upside-down wobbly gourd potion	0		Last Available: "2013-12"
+6098	wobbly upside-down gourd potion	0		Last Available: "2013-12"
 6099	blurry beefy Thinknerd T-Shirt	0		Muscle: +10, Last Available: "2012-12"
 6100	wobbly pile of useless robot parts	0		Last Available: "2012-12"
 6101	spinning homemade robot	0		Last Available: "2012-12"
@@ -6031,14 +6031,14 @@
 6133	twirling padded White Dragon Fang of the pedagogue of the blizzard	0		Experience: +3, Damage Absorption: +20, Cold Spell Damage: +25, Last Available: "2013-12"
 6134	purple blinking arcane researcher's butterfly knife	0		Experience Percent (Mysticality): +10, Last Available: "2013-12"
 6135	tube of herbal ointment	0		Last Available: "2013-12"
-6136	blinking spinning bouncing pencil kunai	0		Last Available: "2013-12"
+6136	blinking bouncing spinning pencil kunai	0		Last Available: "2013-12"
 6137	ghostly weighted paperclip chain of the bloodbag	0		Maximum HP: +100, Last Available: "2013-12"
 6138	great capacitor	0		Last Available: "2013-12"
 6139	rubber gloves of the detective	0		Item Drop: +20, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	small normal roasted duck	2	good	Last Available: "2013-12"
-6143	enchanted rotten huge dead meat bun	7	crappy	Effect: "Abominably Slippery", Effect Duration: 40, Last Available: "2013-12"
+6143	huge rotten enchanted dead meat bun	7	crappy	Effect: "Abominably Slippery", Effect Duration: 40, Last Available: "2013-12"
 6144	bouncing cat collar of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2013-12"
 6145	spinning jittery ruddy sage suspicious-looking fedora	0		Mysticality Percent: +10, Maximum HP Percent: +40, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6046,8 +6046,8 @@
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	lime green Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	olive carrot nose	0		Last Available: "2013-01"
-6152	small bland upside-down carrot cake	2	decent	Last Available: "2013-01"
-6153	weak hand-crafted ghostly carrot claret	2	EPIC	Last Available: "2013-01"
+6152	bland small upside-down carrot cake	2	decent	Last Available: "2013-01"
+6153	hand-crafted weak ghostly carrot claret	2	EPIC	Last Available: "2013-01"
 6154	denatured maroon skewed carrot juice	1	crappy	Effect: "Sagittarius Rising", Effect Duration: 40, Last Available: "2013-01"
 6155	lime green pixel power cell	0		Last Available: "2013-12"
 6156	blurry flickering pixel	0		Last Available: "2013-12"
@@ -6085,63 +6085,63 @@
 6188	bland consummate bagel	3	decent	
 6189	snack-sized flavorless consummate sliced bread	2	decent	
 6190	bland wobbly consummate hot dog bun	3	decent	
-6191	diet normal narrow upside-down consummate brownie	1	good	
+6191	diet normal upside-down narrow consummate brownie	1	good	
 6192	adequate consummate toast	3	good	
 6193	practically non-alcoholic drinkable passable stout	1	good	
 6194	stale huge consummate soup	9	decent	
 6195	adequate green consummate corn chips	4	good	
 6196	stale blue consummate salad	4	decent	
 6197	adequate tiny consummate salsa	1	good	
-6198	bland fancy miniature consummate sauerkraut	2	decent	Effect: "You Can Really Taste the Dormouse", Effect Duration: 50
+6198	fancy bland miniature consummate sauerkraut	2	decent	Effect: "You Can Really Taste the Dormouse", Effect Duration: 50
 6199	tasty consummate cheese slice	4	awesome	
 6200	adequate half-sized jittery jittery consummate melted cheese	2	good	
-6201	rotten miniature consummate bacon	2	crappy	
-6202	normal big bouncing consummate meatloaf	5	good	
-6203	big enchanted yummy consummate steak	5	awesome	Effect: "Buttermilk Boogie", Effect Duration: 30
-6204	diet bland special tumbling consummate cuts	1	decent	Effect: "Toothy Grin", Effect Duration: 25
-6205	stale half-sized enchanted skewed consummate frankfurter	2	decent	Effect: "PERL of Great Price", Effect Duration: 40
+6201	miniature rotten consummate bacon	2	crappy	
+6202	big normal bouncing consummate meatloaf	5	good	
+6203	enchanted big yummy consummate steak	5	awesome	Effect: "Buttermilk Boogie", Effect Duration: 30
+6204	bland diet special tumbling consummate cuts	1	decent	Effect: "Toothy Grin", Effect Duration: 25
+6205	half-sized stale enchanted skewed consummate frankfurter	2	decent	Effect: "PERL of Great Price", Effect Duration: 40
 6206	flavorless huge consummate french fries	9	decent	
 6207	jumbo flavorless green consummate baked potato	5	decent	
 6208	drinkable weak acceptable vodka	2	good	
 6209	delicious consummate ice cream	3	awesome	
-6210	moldy miniature wobbly consummate whipped cream	2	crappy	
-6211	big moldy consummate cream	5	crappy	
+6210	miniature moldy wobbly consummate whipped cream	2	crappy	
+6211	moldy big consummate cream	5	crappy	
 6212	miniature decent consummate strawberries	2	good	
 6213	yummy consummate sorbet	4	awesome	
 6214	weak smooth adequate rum	2	awesome	
 6215	acceptable squat mediocre lager	3	good	
-6216	rotten tiny immaculate grilled cheese	1	crappy	
-6217	tasty half-sized yellow mirror immaculate ice cream sandwich	2	awesome	
+6216	tiny rotten immaculate grilled cheese	1	crappy	
+6217	tasty half-sized mirror yellow immaculate ice cream sandwich	2	awesome	
 6218	spoiled shaking immaculate hot dog	3	crappy	
 6219	spoiled immaculate egg salad sandwich	4	crappy	
 6220	decent perfect sandwich	4	good	
-6221	enchanted spoiled tiny perfect chef salad	1	crappy	Effect: "Serendipi Tea", Effect Duration: 5
-6222	yummy huge perfect breakfast	8	awesome	
+6221	enchanted tiny spoiled perfect chef salad	1	crappy	Effect: "Serendipi Tea", Effect Duration: 5
+6222	huge yummy perfect breakfast	8	awesome	
 6223	fancy bland sublime deluxe hot dog	3	decent	Effect: "Savage Beast Inside", Effect Duration: 40
-6224	tiny bland teal sublime stew	1	decent	
+6224	bland tiny teal sublime stew	1	decent	
 6225	small adequate skewed pulsating sublime nachos	2	good	
 6226	miniature decent blurry Ultimate Breakfast Sandwich	2	good	
 6227	flavorless Loaded Baked Potato	4	decent	
 6228	jumbo decent mirror Omega Sundae	5	good	
 6229	perfectly mixed fortified Das Sauerlager	5	EPIC	
-6230	weak tolerable Bologna Lambic	2	good	
+6230	tolerable weak Bologna Lambic	2	good	
 6231	tolerable Vodka Dog	4	good	
-6232	practically non-alcoholic mediocre Disappointed Russian	1	decent	
-6233	triple-distilled hand-crafted Chunky Mary	6	EPIC	
+6232	mediocre practically non-alcoholic Disappointed Russian	1	decent	
+6233	hand-crafted triple-distilled Chunky Mary	6	EPIC	
 6234	lousy Nachojito	3	decent	
 6235	tolerable Le Roi	3	good	
-6236	bad irresponsibly strong pulsating Over Easy Rider	9	decent	
+6236	irresponsibly strong bad pulsating Over Easy Rider	9	decent	
 6237	cyan cosmic six-pack	0		
 6239	magnetized warmed cube of ectoplasm	0		Effect: "Buff as a Baobab", Effect Duration: 27
-6240	extra-quantum boiled blue tumbling Illuminati earpiece	0		Effect: "Slippery Tongue", Effect Duration: 30
+6240	extra-quantum boiled tumbling blue Illuminati earpiece	0		Effect: "Slippery Tongue", Effect Duration: 30
 6241	ionized shaking censored can label	0		Effect: "Gobliny Flavor", Effect Duration: 34
 6242	flattened improved ectoplasm <i>au jus</i>	0		Effect: "Superhuman Sarcasm", Effect Duration: 35
 6243	ionized bouncing the kindest cut	0		Effect: "Inebriate Pride", Effect Duration: 13
-6244	flattened spinning jittery cat's paw	0		Effect: "Pork Power", Effect Duration: 27
+6244	flattened jittery spinning cat's paw	0		Effect: "Pork Power", Effect Duration: 27
 6245	super-modified electrified narrow ASCII fu manchu	0		Effect: "Adrenaline Rush", Effect Duration: 16
 6246	corrupted galvanized demonic surgical gloves	0		Effect: "Violent Night", Effect Duration: 21
 6247	quantum polymerized tumbling maroon clip-on ninja tie	0		Effect: "Human-Human Hybrid", Effect Duration: 61
-6248	pressed double-cold-filtered squat red spinning gamer slurry	0		Effect: "Become Intensely interested", Effect Duration: 12
+6248	pressed double-cold-filtered red spinning squat gamer slurry	0		Effect: "Become Intensely interested", Effect Duration: 12
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	Sherlock's auspicious chilly Annie Oakley's vibrating numberwang of the overflowing toilet	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Cold Damage: +5, Stench Spell Damage: +50, Item Drop: 35, Single Equip
 6251	enhanced scroll of Protection from Bad Stuff	0		Effect: "Virgo Rising", Effect Duration: 15, Last Available: "2013-02"
@@ -6167,14 +6167,14 @@
 6271	massive dumbbell	0		
 6272	lard-coated penguin keychain of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +25, Damage Reduction: 10
 6273	colloidal nitrogenated spinning O'RLY manual	0		Effect: "Bark of the Dog", Effect Duration: 29
-6274	delicious watered-down narrow open sauce	2	awesome	
+6274	watered-down delicious narrow open sauce	2	awesome	
 6275	chilly smartaleck's turkey leg	0		Moxie Percent: +30, Cold Damage: +5
 6276	tolerable Ye Olde Meade	3	good	
 6277	non-moist Ye Olde Bawdy Limerick	0		Effect: "Jingle Jangle Jingle", Effect Duration: 15
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of the storm	0		Maximum MP Percent: +40
 6280	razor-sharp artisanal rice peeler	0		Weapon Damage Percent: +25
-6281	huge flavorless heirloom grape tomato	10	decent	
+6281	flavorless huge heirloom grape tomato	10	decent	
 6282	chipotle wasabi cilantro aioli	0		
 6283	hardy brown felt tophat	0		Maximum HP: +50, Familiar Effect: "1xLep, cap 37"
 6284	blurry gear	0		
@@ -6182,7 +6182,7 @@
 6286	jittery fireproof educational slick Mark II Steam-Hat	0		Moxie: +10, Experience: +1, Hot Resistance: +3, Familiar Effect: "1xLep, cap 37"
 6287	miser's frosty vibrating Mark III Steam-Hat of horror	0		Maximum MP Percent: +10, Cold Spell Damage: +10, Spooky Spell Damage: +25, Meat Drop: +10, Familiar Effect: "1xLep, cap 37"
 6288	skewed veiny banded wicked Mark IV Steam-Hat of dire peril of Leguizamo	0		Weapon Damage: +20, Spell Damage: +5, Damage Absorption: +100, Maximum HP: +10, Monster Level: +20, Familiar Effect: "1xLep, cap 37"
-6289	frightening coward's manspreader's razor-sharp beefcake's Mark V Steam-Hat	0		Muscle: +25, Weapon Damage Percent: +25, Monster Level: -10, Spooky Damage: +5, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	frightening coward's manspreader's razor-sharp beefcake's Mark V Steam-Hat	0		Muscle: +25, Weapon Damage Percent: +25, Monster Level: -10, Spooky Damage: +5, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	steam-powered model rocketship	0		
 6291	experienced supercool punk rock jacket	0		Moxie Percent: +20, Experience: +2
 6292	spinning red Jim Carey's Socratic safety pin	0		Experience (Mysticality): +1, Monster Level: +25
@@ -6257,10 +6257,10 @@
 6361	concentrated cyan pulled taffy	0		Effect: "Knightlife", Effect Duration: 49, Last Available: "2013-04"
 6362	adjusted squat pulled indigo taffy	0		Effect: "Sourpuss", Effect Duration: 60, Last Available: "2013-04"
 6363	super-polymerized blue pulled taffy	0		Effect: "Dreadful Smell", Effect Duration: 21, Last Available: "2013-04"
-6364	concentrated blinking red pulled taffy	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2013-04"
+6364	concentrated red blinking pulled taffy	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2013-04"
 6365	colloidal pulled taffy	0		Effect: "Muscle Unbound", Effect Duration: 33, Last Available: "2013-04"
 6366	activated colloidal pulled violet taffy	0		Effect: "Purpose", Effect Duration: 57, Last Available: "2013-04"
-6367	wet huge blinking pulled taffy	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2013-04"
+6367	wet blinking huge pulled taffy	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
@@ -6285,7 +6285,7 @@
 6390	alkaline cold-filtered irradiated Mer-kin saltmint	0		Effect: "From Nantucket", Effect Duration: 50
 6391	triple-pressed non-polymerized Mer-kin saltsquid	0		Effect: "Piratey Flavor", Effect Duration: 60
 6392	smelly scale-mail underwear of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +10, Familiar Effect: "2xVolley"
-6393	concentrated adjusted ghostly squat comb jelly	0		Effect: "Analog Drunk", Effect Duration: 11
+6393	concentrated adjusted squat ghostly comb jelly	0		Effect: "Analog Drunk", Effect Duration: 11
 6394	anemone sauce	0		
 6395	spinning inky squid sauce	0		
 6396	bouncing Mer-kin weaksauce	0		
@@ -6293,9 +6293,9 @@
 6398	glass	0		
 6399	chilled green Boss Drops	0		Effect: "Fizzier Than Light", Effect Duration: 43
 6400	upside-down Mer-kin lunchbox	0		
-6401	galvanized triple-aerosolized flattened mirror mirror blinking tear	0		Effect: "Big", Effect Duration: 66
+6401	galvanized triple-aerosolized flattened mirror blinking mirror tear	0		Effect: "Big", Effect Duration: 66
 6402	denatured dry dry jagged tooth	0		Effect: "Sweet Nostalgia", Effect Duration: 16
-6403	unsweetened cold-filtered wobbly ghostly grisly shell fragment	0		Effect: "Shawarma Initiative", Effect Duration: 61
+6403	unsweetened cold-filtered ghostly wobbly grisly shell fragment	0		Effect: "Shawarma Initiative", Effect Duration: 61
 6404	boiled violent pastilles	0		Effect: "Really Deep Breath", Effect Duration: 20
 6405	electrified skewed worst candy	0		Effect: "Sewer-Drenched", Effect Duration: 20
 6406	nitrogenated fuchsia fudge-shaped hole in space-time	0		Effect: "Partially Ghosted", Effect Duration: 47
@@ -6308,18 +6308,18 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	tasty upside-down flavorless gruel	3	awesome	
-6416	thick moldy lime green mana curds	5	crappy	
+6416	moldy thick lime green mana curds	5	crappy	
 6417	twirling twist of lime	0		
 6418	squat pencil stub	0		
 6419	triple-Vulcanized quantum mirror green moth dust	0		Effect: "Chain Chain Chains", Effect Duration: 29
 6420	adjusted electrified upside-down glob of spoiled mayo	0		Effect: "Mushroom Might", Effect Duration: 48
 6421	tonic djinn	0		
-6422	stale half-sized vampire chowder	2	decent	
+6422	half-sized stale vampire chowder	2	decent	
 6423	Tales of Dread	0		Free Pull
 6424	cyan Dreadsylvanian skeleton key	0		
 6425	maroon Official Seal of Dreadsylvania	0		
-6426	gigantic decent shaking Dreadsylvanian stew	8	good	
-6427	acceptable irresponsibly strong skewed Dreadsylvanian	10	good	
+6426	decent gigantic shaking Dreadsylvanian stew	8	good	
+6427	irresponsibly strong acceptable skewed Dreadsylvanian	10	good	
 6428	polarized ionized bouncing Dreadsylvanian flask	0		Effect: "Shot in the Arse", Effect Duration: 16
 6429	flattened cold-filtered Dreadsylvanian flask	0		Effect: "Tennis Elbow-wow", Effect Duration: 54
 6430	up-at-dawn careful dreadful fedora	0		Monster Level: -10, Adventures: +5, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6331,7 +6331,7 @@
 6436	Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
 6438	mirror Mark of the Vampire	0		
-6439	spinning yellow Mark of the Skeleton	0		
+6439	yellow spinning Mark of the Skeleton	0		
 6440	cyan upside-down curative rock-hard Covers-Your-Head of the overflowing toilet	0		Damage Reduction: 5, Stench Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
 6441	lime green veiny steel-toed personal trainer's Drapes-You-Regally	0		Experience Percent (Muscle): +10, Damage Reduction: 9, Maximum HP: +10, Class: "Disco Bandit"
 6442	Sherlock's occult Da Vinci's Warms-Your-Tush	0		Experience (Mysticality): +5, Spell Damage Percent: +25, Item Drop: +25, Class: "Disco Bandit", Familiar Effect: "1xVolley, 1xPotato"
@@ -6408,16 +6408,16 @@
 6513	tumbling warm fur of the storm	0		Maximum MP Percent: +40
 6514	snowstick	0		Item Drop: +5
 6515	friendly eerie fetish	0		Familiar Weight: +3, Single Equip
-6516	watered-down acceptable stinkwater	2	good	
+6516	acceptable watered-down stinkwater	2	good	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	snack-sized stale accidental mutton	2	decent	
+6518	stale snack-sized accidental mutton	2	decent	
 6519	ghostly lime green mansplainer's extremely unsafe drafty drawers	0		Weapon Damage Percent: +100, Monster Level: +15, Familiar Effect: "1.5xVolley"
 6520	green Newton's smooth wolfskull mask	0		Moxie: +15, Experience (Mysticality): +3, Familiar Effect: "spooky atk, 1xBarrr"
 6521	blinking zippy guts necklace	0		Initiative: +20, Single Equip
 6522	Herculean savvy groping claw	0		Mysticality Percent: +20, Experience (Muscle): +1
 6523	upside-down censurious vengeful spirit	0		Sleaze Resistance: +3
 6524	BOOtonniere of Gandalf	0		Spell Critical Percent: +20, Single Equip
-6525	diffused blue twirling ghost thread	0		Effect: "Beta Carotene Overdose", Effect Duration: 29
+6525	diffused twirling blue ghost thread	0		Effect: "Beta Carotene Overdose", Effect Duration: 29
 6526	arcane researcher's bag of unfinished business of Calamity Jane	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +15
 6527	purple mirror chaotic hardy transparent pants	0		Maximum HP: +50, Spell Critical Percent: +10, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of Gandalf	0		Spell Critical Percent: +20
@@ -6444,24 +6444,24 @@
 6550	cooling iron greaves	0		
 6551	squat hot cluster	0		
 6552	blurry cluster	0		
-6553	pulsating bouncing cluster	0		
+6553	bouncing pulsating cluster	0		
 6554	stench cluster	0		
 6555	sleaze cluster	0		
 6556	polarized triple-alkaline phial of hotness	0		Effect: "Twinklebritches", Effect Duration: 40
 6557	improved maroon jittery huge phial of coldness	0		Effect: "Berry Elemental", Effect Duration: 11
 6558	deionized phial of spookiness	0		Effect: "Creepin' Up on You", Effect Duration: 20
-6559	diffused altered mirror bouncing phial of stench	0		Effect: "Mmmmmelon", Effect Duration: 63
+6559	diffused altered bouncing mirror phial of stench	0		Effect: "Mmmmmelon", Effect Duration: 63
 6560	magnetized non-liquefied blurry phial of sleaziness	0		Effect: "Can Has Cyborger", Effect Duration: 43
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	red mini-Mr. Accessory	0		Familiar Weight: +5
 6563	beefcake's hand of Mr. Cards	0		Muscle: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	stale bite-sized Dreadsylvanian hot pocket	1	decent	
+6564	bite-sized stale Dreadsylvanian hot pocket	1	decent	
 6565	stale huge Dreadsylvanian pocket	8	decent	
-6566	immense rotten Dreadsylvanian pocket	9	crappy	
+6566	rotten immense Dreadsylvanian pocket	9	crappy	
 6567	flavorless snack-sized twirling squat Dreadsylvanian stink pocket	2	decent	
 6568	jumbo moldy Dreadsylvanian sleaze pocket	5	crappy	
 6569	high-proof lousy Dreadsylvanian hot toddy	7	decent	
-6570	special bad Dreadsylvanian cold-fashioned	3	decent	Effect: "Wistfully Nostalgic", Effect Duration: 15
+6570	bad special Dreadsylvanian cold-fashioned	3	decent	Effect: "Wistfully Nostalgic", Effect Duration: 15
 6571	acceptable Dreadsylvanian grimlet	4	good	
 6572	hand-crafted squat Dreadsylvanian dank and stormy	3	super ultra mega turbo EPIC	
 6573	perfectly mixed lime green Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
@@ -6473,7 +6473,7 @@
 6579	Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	upside-down dreadful box	0		
-6582	blurry skewed Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
+6582	skewed blurry Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	olive vicious spiked collar	0		Familiar Damage: +20
 6584	foul-smelling hot dog wrapper	0		Stench Damage: +10
 6585	Socratic cool debonair deboner	0		Moxie: +5, Experience (Mysticality): +1
@@ -6490,7 +6490,7 @@
 6596	clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	clockwork disc	0		
-6599	mirror squat clockwork hand	0		
+6599	squat mirror clockwork hand	0		
 6600	clockwork hand	0		
 6601	clockwork numeral I	0		
 6602	clockwork numeral II	0		
@@ -6506,10 +6506,10 @@
 6612	clockwork numeral XII	0		
 6613	huge clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	practically non-alcoholic perfectly mixed blinking Cold One	1	???	
+6615	perfectly mixed practically non-alcoholic blinking Cold One	1	???	
 6616	spoiled gigantic spaghetti breakfast	7	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
-6618	spinning mirror folder (red)	0		Muscle: +20, Last Available: "2013-08"
+6618	mirror spinning folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	spinning teal folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
@@ -6517,7 +6517,7 @@
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	purple folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
-6626	lime green mirror twirling folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
+6626	mirror twirling lime green folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
 6628	squat folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
@@ -6539,16 +6539,16 @@
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	frosty dangerous slide rule	0		Weapon Damage: +10, Cold Spell Damage: +10
 6649	pickled ionized blurry Ogres and Oubliettes&trade; module	0		Effect: "Certainty", Effect Duration: 14
-6650	mirror gray Mountain Stream Code Black Alert	0		
+6650	gray mirror Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	artisanal fancy fortified stepmom's booze	5	EPIC	Effect: "Crud&eacute;", Effect Duration: 15
+6652	fortified artisanal fancy stepmom's booze	5	EPIC	Effect: "Crud&eacute;", Effect Duration: 15
 6653	purple surgical tape	0		
 6654	therapeutic band T-shirt	0		HP Regen Min: 5, HP Regen Max: 7
 6655	lousy fountain 'soda'	3	decent	
 6656	squat illegal firecracker	0		
 6657	family-friendly curative pickelhaube	0		Sleaze Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	adjusted magnetized hair oil	0		Effect: "All Is Forgiven", Effect Duration: 47
-6659	Vulcanized concentrated nitrogenated spinning blue scrap	0		Effect: "Okee-Dokee Go!", Effect Duration: 23
+6659	Vulcanized concentrated nitrogenated blue spinning scrap	0		Effect: "Okee-Dokee Go!", Effect Duration: 23
 6660	squat school spirit socket set	0		
 6661	suspension bridge	0		
 6662	tumbling resourceful wicked Socratic Staff of the Lunch Lady of the ox	0		Muscle: +20, Experience (Mysticality): +1, Spell Damage: +5, Maximum MP: +50
@@ -6559,7 +6559,7 @@
 6667	quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	modeling claymore	0		
-6670	blinking mirror clay homunculus	0		
+6670	mirror blinking clay homunculus	0		
 6671	modified dry sodium pentasomething	0		Effect: "Heal Thy Nanoself", Effect Duration: 54
 6672	grains of salt	0		
 6673	yellowcake bomb	0		
@@ -6569,9 +6569,9 @@
 6677	crude monster sculpture	0		
 6678	lion tamer's Yearbook Club Camera	0		Experience (familiar): +2, Conditional Skill (Equipped): "Blinding Flash"
 6679	Usain Bolt's machete	0		Initiative: +80
-6680	drinkable irresponsibly strong squat Cursed Punch	8	good	
-6681	tolerable triple-distilled Bowl of Scorpions	10	good	
-6682	tolerable boozy pulsating olive Fog Murderer	5	good	
+6680	irresponsibly strong drinkable squat Cursed Punch	8	good	
+6681	triple-distilled tolerable Bowl of Scorpions	10	good	
+6682	tolerable boozy olive pulsating Fog Murderer	5	good	
 6683	cyan book of matches	0		
 6684	veiny surgical mask	0		Maximum HP: +10, Surgeonosity: +1
 6685	beefy head mirror	0		Muscle: +10, Surgeonosity: +1
@@ -6620,7 +6620,7 @@
 6728	mirror ski resort souvenir crate	0		
 6729	upside-down UV-resistant compass	0		
 6730	funky junk key	0		
-6731	pulsating jittery Worse Homes and Gardens	0		
+6731	jittery pulsating Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	jittery wobbly clothesline pole	0		
 6734	cigar sign	0		
@@ -6635,7 +6635,7 @@
 6743	Van der Graaf junk trunks	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cap 15"
 6744	spinning electrified junk-mail shirt	0		MP Regen Min: 3, MP Regen Max: 5
 6745	moldy junk food	3	crappy	
-6746	aged boozy junk yard	5	awesome	
+6746	boozy aged junk yard	5	awesome	
 6747	lion tamer's chaotic swordzall	0		Spell Critical Percent: +10, Experience (familiar): +2
 6748	wobbly Jim Carey's arm buzzer	0		Monster Level: +25, Damage Reduction: 6
 6749	greedy boilgun of the cougar	0		Moxie: +20, Meat Drop: +20
@@ -6650,7 +6650,7 @@
 6758	triple-distilled lousy cyan can of Drooling Monk	7	decent	Last Available: "2013-09"
 6759	tolerable can of Impetuous Scofflaw	4	good	Last Available: "2013-09"
 6760	perfectly mixed bottle of Old Pugilist	3	EPIC	Last Available: "2013-09"
-6761	acceptable practically non-alcoholic bottle of Professor Beer	1	good	Last Available: "2013-09"
+6761	practically non-alcoholic acceptable bottle of Professor Beer	1	good	Last Available: "2013-09"
 6762	perfectly mixed mirror bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
 6763	mediocre weak blurry bottle of Race Car Red	2	decent	Last Available: "2013-09"
 6764	mediocre bottle of Greedy Dog	3	decent	Last Available: "2013-09"
@@ -6667,14 +6667,14 @@
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	dry jittery foetid seal tear	0		Effect: "Spiky Hair", Effect Duration: 23
 6777	non-anodized boiled nitrogenated seal sweat	0		Effect: "Witch Breaded", Effect Duration: 46
-6778	concentrated Vulcanized bouncing jittery shaking boiling seal blood	0		Effect: "All Fired Up", Effect Duration: 19
+6778	concentrated Vulcanized shaking bouncing jittery boiling seal blood	0		Effect: "All Fired Up", Effect Duration: 19
 6779	crystalline seal eye	0		Single Equip
 6780	ghostly perfumed studded sealhide shield of the wise owl	0		Mysticality: +20, Stench Resistance: +5, Damage Reduction: 7
 6781	banded scabrous seal epaulets of courage	0		Damage Absorption: +100, Spooky Resistance: +3, Single Equip
 6782	teal abyssal battle plans	0		
 6783	Sherlock's fireproof stiffened seal medal	0		Damage Reduction: 1, Hot Resistance: +3, Item Drop: +25
 6784	deanimated reanimator's coffin	0		Free Pull
-6785	tumbling skewed flask of embalming fluid	0		
+6785	skewed tumbling flask of embalming fluid	0		
 6788	blank diary	0		
 6789	boot knife	0		
 6790	broken beer bottle	0		
@@ -6684,7 +6684,7 @@
 6795	modified alkaline wobbly disco horoscope (Aquarius)	0		Effect: "Salad Days", Effect Duration: 13
 6796	activated vacuum-sealed disco horoscope (Pisces)	0		Effect: "The Moxious Madrigal", Effect Duration: 22
 6797	pickled irradiated olive mirror disco horoscope (Aries)	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 64
-6798	dry diffused boiled green bouncing blinking disco horoscope (Taurus)	0		Effect: "Greasy Peasy", Effect Duration: 16
+6798	dry diffused boiled green blinking bouncing disco horoscope (Taurus)	0		Effect: "Greasy Peasy", Effect Duration: 16
 6799	colloidal blinking disco horoscope (Gemini)	0		Effect: "Well Owl Be!", Effect Duration: 40
 6800	Vulcanized ghostly disco horoscope (Cancer)	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 24
 6801	concentrated polarized green twirling disco horoscope (Leo)	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 22
@@ -6714,7 +6714,7 @@
 6825	skewed greasy forbidden alarm accordion	0		Spell Damage Percent: +50, Sleaze Spell Damage: +10, Class: "Accordion Thief", Song Duration: 20
 6826	zippy sizzling wholesome All-Hallow's Steve's fright wig	0		Maximum HP Percent: +10, Hot Damage: +10, Initiative: +20, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	hardy Sinatra's KoL Con X Treasure Map	0		Experience (Moxie): +5, Maximum HP: +50
-6828	artisanal enchanted high-proof discocktail	10	EPIC	Effect: "Chief Executive Optimism", Effect Duration: 40
+6828	high-proof enchanted artisanal discocktail	10	EPIC	Effect: "Chief Executive Optimism", Effect Duration: 40
 6829	deadly KoL Con X Bingo Card	0		Weapon Damage: +5
 6830	shaking bouncing lard-coated Temporal Tempera Tube	0		Sleaze Spell Damage: +25
 6831	pickled Tallowcreme Halloween Pumpkin	0		Effect: "Buggy Flavor", Effect Duration: 67
@@ -6723,7 +6723,7 @@
 6834	diffused pickled box of Dweebs	0		Effect: "Here's Mud in Your Eye", Effect Duration: 34
 6835	anodized ionized bag of W&Ws	0		Effect: "Coldfinger", Effect Duration: 59
 6836	flattened blurry PEEZ dispenser	0		Effect: "Cold, Dead Hands", Effect Duration: 49
-6837	irradiated pressed upside-down squat Swizzler	0		Effect: "Sticky Fingers", Effect Duration: 69
+6837	irradiated pressed squat upside-down Swizzler	0		Effect: "Sticky Fingers", Effect Duration: 69
 6838	nitrogenated ionized tarnished wobbly Bugbearclaw Donut	0		Effect: "Baconstoned", Effect Duration: 62
 6839	quantum jam	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 64
 6840	diffused warmed jittery Whenchamacallit bar	0		Effect: "Souper Vengeful", Effect Duration: 11
@@ -6741,25 +6741,25 @@
 6852	Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	desert sightseeing pamphlet	0		
-6855	mirror tumbling a suspicious address	0		
+6855	tumbling mirror a suspicious address	0		
 6856	pulsating sage Bal-musette accordion	0		Mysticality Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	huge electrified Cajun accordion	0		MP Regen Min: 3, MP Regen Max: 5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	squat censurious quirky accordion	0		Sleaze Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	Lo Pan's Fonzie's Skipper's accordion	0		Experience (Moxie): +1, Spell Critical Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	curative arcane researcher's personal trainer's Pantsgiving of Gandalf	0		Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Spell Critical Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6860	curative arcane researcher's personal trainer's Pantsgiving of Gandalf	0		Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Spell Critical Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
 6861	big adequate can of sardines	5	good	Last Available: "2013-11"
 6862	stale high-calorie sugar substitute	4	decent	Last Available: "2013-11"
 6863	normal pat of butter	3	good	Last Available: "2013-11"
 6864	moldy dinner roll	4	crappy	Last Available: "2013-11"
-6865	decent small narrow mashed potatoes	2	good	Last Available: "2013-11"
+6865	small decent narrow mashed potatoes	2	good	Last Available: "2013-11"
 6866	spoiled green whole turkey leg	4	crappy	Last Available: "2013-11"
-6867	half-sized adequate deviled egg	2	good	Last Available: "2013-11"
+6867	adequate half-sized deviled egg	2	good	Last Available: "2013-11"
 6868	activated anodized finger exerciser	0		Effect: "Healthy Blue Glow", Effect Duration: 49, Last Available: "2013-11"
 6869	dry polymerized dented spoon	0		Effect: "Sparkling Consciousness", Effect Duration: 52, Last Available: "2013-11"
 6870	activated frozen gray love note	0		Effect: "Vented Spleen", Effect Duration: 60, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	extra-cold-filtered nail file	0		Effect: "Sauce Monocle", Effect Duration: 15, Last Available: "2013-11"
-6873	triple-denatured twirling mirror candy wrapper	0		Effect: "Abyssal Blood", Effect Duration: 13, Last Available: "2013-11"
+6873	triple-denatured mirror twirling candy wrapper	0		Effect: "Abyssal Blood", Effect Duration: 13, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	Vulcanized olive narrow post-holiday sale coupon	0		Effect: "You Can Taste the Darkness", Effect Duration: 54, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
@@ -6789,11 +6789,11 @@
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	bouncing hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	beefcake's flask flops of James Dean	0		Muscle: +25, Experience (Moxie): +3, Single Equip
-6903	flattened green mirror nuts	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 14, Last Available: "2013-12"
-6904	adjusted oxidized mirror pulsating bolts	0		Effect: "Cold Blooded", Effect Duration: 20, Last Available: "2013-12"
+6903	flattened mirror green nuts	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 14, Last Available: "2013-12"
+6904	adjusted oxidized pulsating mirror bolts	0		Effect: "Cold Blooded", Effect Duration: 20, Last Available: "2013-12"
 6905	bland bite-sized gingerbread robot	1	decent	Last Available: "2013-12"
-6906	moldy jumbo petit 4.1	5	crappy	Last Available: "2013-12"
-6907	stale olive blinking nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
+6906	jumbo moldy petit 4.1	5	crappy	Last Available: "2013-12"
+6907	stale blinking olive nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
 6908	beefcake's plastic GORM-8	0		Muscle: +25, Last Available: "2013-12"
 6909	wholesome plastic warbear	0		Maximum HP Percent: +10, Last Available: "2013-12"
 6910	Annie Oakley's plastic Toybot	0		Critical Hit Percent: +20, Last Available: "2013-12"
@@ -6807,12 +6807,12 @@
 6918	alkaline pulsating warbear wardance potion	0		Effect: "Salt Rockin'", Effect Duration: 36, Last Available: "2013-12"
 6919	ionized diffused spinning warbear bearserker potion	0		Effect: "Ponderous Potency", Effect Duration: 37, Last Available: "2013-12"
 6920	double-ionized deionized purple warbear liquid overcoat	0		Effect: "Twen Tea", Effect Duration: 63, Last Available: "2013-12"
-6921	flavorless huge warbear feasting bread	7	decent	Last Available: "2013-12"
+6921	huge flavorless warbear feasting bread	7	decent	Last Available: "2013-12"
 6922	small delicious warbear warrior bread	2	awesome	Last Available: "2013-12"
 6923	tasty warbear thermoregulator bread	4	awesome	Last Available: "2013-12"
 6924	acceptable warbear feasting mead	4	good	Last Available: "2013-12"
-6925	smooth irresponsibly strong warbear bearserker mead	9	awesome	Last Available: "2013-12"
-6926	aged huge shaking warbear blizzard mead	4	awesome	Last Available: "2013-12"
+6925	irresponsibly strong smooth warbear bearserker mead	9	awesome	Last Available: "2013-12"
+6926	aged shaking huge warbear blizzard mead	4	awesome	Last Available: "2013-12"
 6927	gray warbear helm fragment	0		Last Available: "2013-12"
 6928	squat friendly Van der Graaf warbear plain fedora of the sewer	0		Familiar Weight: +3, Stench Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
 6929	warbear feathered fedora of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
@@ -6893,8 +6893,8 @@
 7004	deionized wet yellow Flaskfull of Hollow	0		Effect: "Liquid Courage", Effect Duration: 63, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	twisted shaking handful of Smithereens	1	decent	Last Available: "2013-12"
-7007	diet stale Every Day is Like This Sundae	1	decent	Last Available: "2013-12"
-7008	enchanted gigantic spoiled green Miserable Pie	7	crappy	Effect: "Booooooze", Effect Duration: 25, Last Available: "2013-12"
+7007	stale diet Every Day is Like This Sundae	1	decent	Last Available: "2013-12"
+7008	gigantic enchanted spoiled green Miserable Pie	7	crappy	Effect: "Booooooze", Effect Duration: 25, Last Available: "2013-12"
 7009	rotten This Charming Flan	3	crappy	Last Available: "2013-12"
 7010	watered-down smooth Irish Coffee, English Heart	2	awesome	Last Available: "2013-12"
 7011	mediocre olive Strikes Again Bigmouth	4	decent	Last Available: "2013-12"
@@ -6918,8 +6918,8 @@
 7029	bouncing jittery scandalous stylish weightlifter's Shakespeare's Sister's Accordion	0		Muscle: +15, Moxie: +25, Sleaze Damage: +5, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	third-hand lantern of the storm	0		Maximum MP Percent: +40
 7031	loose purse strings	0		
-7032	huge adequate pickled egg	8	good	
-7033	upside-down huge cup of lukewarm tea	1	good	
+7032	adequate huge pickled egg	8	good	
+7033	huge upside-down cup of lukewarm tea	1	good	
 7034	pulsating warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
 7036	jittery warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6930,8 +6930,8 @@
 7041	twirling warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	shaking warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	pickled colloidal purple tumbling shaking glass slipper	0		Effect: "Hammered", Effect Duration: 57, Last Available: "2014-12"
-7045	compressed lime green wobbly antimatter wad	1	crappy	Last Available: "2013-12"
+7044	pickled colloidal purple shaking tumbling glass slipper	0		Effect: "Hammered", Effect Duration: 57, Last Available: "2014-12"
+7045	compressed wobbly lime green antimatter wad	1	crappy	Last Available: "2013-12"
 7046	liquefied warbear superpotion	0		Effect: "Gamer Rage", Effect Duration: 11, Last Available: "2013-12"
 7047	flattened warbear liquid lasers	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 65, Last Available: "2013-12"
 7048	alkaline warbear rejuvenation potion	0		Effect: "Dilated Pupils", Effect Duration: 20, Last Available: "2013-12"
@@ -6960,7 +6960,7 @@
 7071	stale upside-down snow berries	3	decent	Last Available: "2014-01"
 7072	flavorless super-sized skewed ice harvest	5	decent	Last Available: "2014-01"
 7073	deionized galvanized mirror fuchsia frost flower	0		Effect: "Woad Warrior", Effect Duration: 35, Last Available: "2014-01"
-7074	nitrogenated mirror cyan snow cleats	0		Effect: "Tiki Thoughtfulness", Effect Duration: 31, Last Available: "2014-01"
+7074	nitrogenated cyan mirror snow cleats	0		Effect: "Tiki Thoughtfulness", Effect Duration: 31, Last Available: "2014-01"
 7075	corrupted bouncing liquid ice pack	0		Effect: "Super Speed", Effect Duration: 61, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	normal thick spinning snow crab	5	good	Last Available: "2014-01"
@@ -6987,25 +6987,25 @@
 7098	Usain Bolt's Da Vinci's sweat socks of wisdom of the pedagogue	0		Mysticality: +15, Experience: +3, Experience (Mysticality): +5, Initiative: +80, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	powdered ghostly upside-down Five Second Energy&trade;	1		Last Available: "2014-12"
+7101	powdered upside-down ghostly Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	spinning pixie axie	0		Last Available: "2014-12"
 7103	magnetized polymerized upside-down powder	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 41, Last Available: "2014-12"
 7104	squat licorice whip of the wise owl	0		Mysticality: +20, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	drinkable watered-down spinning snakebite	2	good	Last Available: "2014-12"
+7106	watered-down drinkable spinning snakebite	2	good	Last Available: "2014-12"
 7107	twirling dog trainer's banded candy stick	0		Damage Absorption: +100, Experience (familiar): +1, Last Available: "2014-12"
 7108	big adequate pecan	5	good	Last Available: "2014-12"
 7109	delicious pecan pie	4	awesome	Last Available: "2014-12"
 7110	gray chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	decent narrow candy mountain oyster	4	good	Last Available: "2014-12"
-7112	aged watered-down chocotini	2	awesome	Last Available: "2014-12"
+7112	watered-down aged chocotini	2	awesome	Last Available: "2014-12"
 7113	cyan reassuring Temple Grandin's stiffened chocolate rabbit's foot	0		Damage Reduction: 1, Familiar Weight: +7, Spooky Resistance: +1, Last Available: "2014-12"
 7114	flavorless candy carrot	4	decent	Last Available: "2014-12"
-7115	snack-sized adequate candy carrot cake	2	good	Last Available: "2014-12"
+7115	adequate snack-sized candy carrot cake	2	good	Last Available: "2014-12"
 7116	stanky carrot-on-a-stick of the cheetah	0		Stench Spell Damage: +25, Initiative: +60, Last Available: "2014-12"
 7117	supercool weasel stomping pants of the blizzard	0		Moxie Percent: +20, Cold Spell Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	decent mulberry	3	good	Last Available: "2014-12"
-7119	lousy boozy mulled berry wine	5	decent	Last Available: "2014-12"
+7119	boozy lousy mulled berry wine	5	decent	Last Available: "2014-12"
 7120	pulsating lemony scales	0		Last Available: "2014-12"
 7121	gravedigger's lemon party hat	0		Spooky Damage: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	shaking Da Vinci's lemon shirt	0		Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2014-12"
@@ -7014,8 +7014,8 @@
 7125	Samson's gummi sword of the sewer	0		Experience (Muscle): +5, Stench Damage: +25, Last Available: "2014-12"
 7126	denatured small gummi fin	0		Effect: "Vanity Rage", Effect Duration: 14, Last Available: "2014-12"
 7127	Temple Grandin's chocolate cow bone	0		Familiar Weight: +7, Last Available: "2014-12"
-7128	pickled pulsating shaking gummi fang	0		Effect: "Extra Backbone", Effect Duration: 66, Last Available: "2014-12"
-7129	moldy low-calorie leftover canap&eacute;s	1	crappy	Last Available: "2014-12"
+7128	pickled shaking pulsating gummi fang	0		Effect: "Extra Backbone", Effect Duration: 66, Last Available: "2014-12"
+7129	low-calorie moldy leftover canap&eacute;s	1	crappy	Last Available: "2014-12"
 7130	watered-down tolerable jittery magnum of champagne	2	good	Last Available: "2014-12"
 7131	spinning hardened cool weightlifter's cow creamer	0		Muscle: +15, Moxie: +5, Damage Reduction: 3, Last Available: "2014-12"
 7132	modified wet twirling Outer Wolf&trade; cologne	0		Effect: "The Magic of LOV", Effect Duration: 16, Last Available: "2014-12"
@@ -7048,7 +7048,7 @@
 7159	purple mirror narrow baleful Sinatra's plain paper hat of the glutton	0		Experience (Moxie): +5, Spell Damage: +25, Food Drop: +100, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	rotten ice cream sandwich	4	crappy	Last Available: "2014-12"
 7161	vibrating Samson's slick &quot;honey&quot; dipper	0		Moxie: +10, Experience (Muscle): +5, Maximum MP Percent: +10, Last Available: "2014-12"
-7162	normal half-sized plumber's lunch	2	good	Last Available: "2014-12"
+7162	half-sized normal plumber's lunch	2	good	Last Available: "2014-12"
 7163	occult skull gearshift knob of incineration of bravery	0		Spell Damage Percent: +25, Hot Spell Damage: +50, Spooky Resistance: +5, Last Available: "2014-12"
 7164	diet moldy nachos of the night	1	crappy	Last Available: "2014-12"
 7165	flame-retardant Herculean Sketcherz&trade; of the glutton	0		Experience (Muscle): +1, Hot Resistance: +1, Food Drop: +100, Last Available: "2014-12"
@@ -7088,7 +7088,7 @@
 7199	bouncing blowdart	0		
 7200	avaricious Buddy Bjorn	0		Meat Drop: +30, Softcore Only, Last Available: "2014-02"
 7201	mirror flame-retardant sharpshooter's clever The Nuge's favorite crossbow	0		Maximum MP: +20, Critical Hit Percent: +10, Hot Resistance: +1
-7202	spoiled massive jittery sweet roll Alabama	10	crappy	
+7202	massive spoiled jittery sweet roll Alabama	10	crappy	
 7203	squat tumbling sharpshooter's Saturday Night Special	0		Critical Hit Percent: +10
 7204	blurry lynyrd snare	0		
 7205	upside-down Oprah's fleetwood chain	0		Maximum MP Percent: +50
@@ -7099,7 +7099,7 @@
 7210	dry improved eagle feather	0		Effect: "One For Tea", Effect Duration: 42
 7211	anodized tarnished bouncing one pill	0		Effect: "Extra-Wet", Effect Duration: 42
 7212	Annie Oakley's Jefferson wings	0		Critical Hit Percent: +20
-7213	yellow pulsating fleetwood macaroni	0		
+7213	pulsating yellow fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
 7215	spoiled jittery fleetwood mac 'n' cheese	3	crappy	
 7216	lime green lynyrd skin	0		
@@ -7118,7 +7118,7 @@
 7229	acceptable blinking wine	4	good	
 7230	perfectly mixed enchanted rum	4	EPIC	Effect: "Jammin'", Effect Duration: 30
 7231	bad Murderer's Punch	3	decent	
-7232	half-sized flavorless velvet cake	2	decent	
+7232	flavorless half-sized velvet cake	2	decent	
 7233	pickled enhanced letter	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 12
 7234	supercharged brainy book	0		Mysticality: +5, Maximum MP Percent: +30
 7235	asbestos-lined wicked masque	0		Spell Damage: +5, Hot Resistance: +5, Single Equip
@@ -7129,12 +7129,12 @@
 7240	arcane researcher's coat of the glutton	0		Experience Percent (Mysticality): +10, Food Drop: +100
 7241	Jack Frost's grievous shoe	0		Weapon Damage Percent: +50, Cold Spell Damage: +50, Single Equip
 7242	tumbling button	0		
-7243	yellow skewed button	0		
+7243	skewed yellow button	0		
 7244	vacuum-sealed nitrogenated triple-activated huge blood cells	0		Effect: "Kissed By Fire", Effect Duration: 56
 7245	anodized boiled narrow eye	0		Effect: "Squid Squint", Effect Duration: 15
 7246	blurry glark cable	0		
 7247	spinning family-friendly frosty Red Fox glove	0		Cold Spell Damage: +10, Sleaze Resistance: +1, Attacks Can't Miss, Single Equip
-7248	super-polarized polarized triple-activated wobbly blurry foxglove	0		Effect: "Tasting the Rainbow", Effect Duration: 39
+7248	super-polarized polarized triple-activated blurry wobbly foxglove	0		Effect: "Tasting the Rainbow", Effect Duration: 39
 7249	mirror Thwaitgold dragonfly statuette	0		
 7250	narrow frosty friendly energetic Sinatra's Sneaky Pete's jacket	0		Experience (Moxie): +5, Maximum MP Percent: +20, Familiar Weight: +3, Cold Spell Damage: +10, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	jug of Sneaky Pete's Mojo	0		Free Pull
@@ -7179,7 +7179,7 @@
 7290	normal mirror amok pudding	4	good	
 7291	deactivated putty buddy	0		
 7292	fuchsia putty coat	0		Familiar Weight: +5
-7293	pickled electrified squat gray can of V-11	0		Effect: "Graham Crackling", Effect Duration: 22, Last Available: "2014-03"
+7293	pickled electrified gray squat can of V-11	0		Effect: "Graham Crackling", Effect Duration: 22, Last Available: "2014-03"
 7294	bouncing dog trainer's studded elevennis shoes	0		Damage Absorption: +80, Experience (familiar): +1, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
 7296	baleful arcane researcher's elevenderizing hammer	0		Experience Percent (Mysticality): +10, Spell Damage: +25, Last Available: "2014-03"
@@ -7196,7 +7196,7 @@
 7307	spinning Lady Spookyraven's dancing shoes	0		
 7308	chilled eyebrow pencil	0		Effect: "Object Detection", Effect Duration: 62
 7309	corrupted deionized teal rosewater cream	0		Effect: "Resilient Spirit", Effect Duration: 41
-7310	quantum quadruple-irradiated jittery ghostly bronzer	0		Effect: "Physicali Tea", Effect Duration: 60
+7310	quantum quadruple-irradiated ghostly jittery bronzer	0		Effect: "Physicali Tea", Effect Duration: 60
 7311	shaking beefy elegant nightstick of the pedagogue	0		Muscle: +10, Experience: +3
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	bouncing box of hickory chips	0		Familiar Weight: +5
@@ -7211,7 +7211,7 @@
 7322	galvanized Stephen's secret formula	0		Effect: "Glo-Face", Effect Duration: 21
 7323	coward's baleful Jacob's rung	0		Spell Damage: +25, Monster Level: -20
 7324	diluted shaking battery	1		Effect: "Your Favorite Flavor", Effect Duration: 35
-7325	mediocre skewed spinning snakebite	4	decent	
+7325	mediocre spinning skewed snakebite	4	decent	
 7326	crafty educational rubber ribcage	0		Experience: +1, Maximum MP: +10, Damage Reduction: 7
 7327	pickled synthetic marrow	1		
 7328	triple-boiled frozen narrow funny bone	0		Effect: "Spookypants", Effect Duration: 68
@@ -7234,7 +7234,7 @@
 7345	ornate picture frame	0		
 7346	blinking doll-eye amulet	0		Single Equip
 7347	fireproof extremely unsafe ghost toga	0		Weapon Damage Percent: +100, Hot Resistance: +3
-7348	bite-sized decent squat sheet cake	1	good	
+7348	decent bite-sized squat sheet cake	1	good	
 7349	ghost key	0		
 7350	shaking picture of you	0		
 7351	spinning blurry forbidden smartaleck's brawny Staff of the Electric Range	0		Muscle Percent: +20, Moxie Percent: +30, Spell Damage Percent: +50
@@ -7249,7 +7249,7 @@
 7360	blinking plaid bandage	0		
 7361	pulsating greedy plaid pocket square	0		Meat Drop: +20
 7362	friendly medical-grade plaid skirt	0		Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-7363	irradiated irradiated mirror squat bloodstain stick	0		Effect: "Briny Blood", Effect Duration: 14
+7363	irradiated irradiated squat mirror bloodstain stick	0		Effect: "Briny Blood", Effect Duration: 14
 7364	fabric softener	0		
 7365	quadruple-modified corrupted tarnished fabric hardener	0		Effect: "Stench Jellied", Effect Duration: 60
 7366	perfectly mixed bottle of laundry sherry	4	EPIC	
@@ -7276,7 +7276,7 @@
 7387	unsweetened narrow Gene Tonic: Undead	0		Effect: "On Pins and Needles", Effect Duration: 31, Last Available: "2014-04"
 7388	super-dry vacuum-sealed Gene Tonic: Humanoid	0		Effect: "Hood Ridin'", Effect Duration: 62, Last Available: "2014-04"
 7389	super-nitrogenated Gene Tonic: Insect	0		Effect: "Three Days Slow", Effect Duration: 58, Last Available: "2014-04"
-7390	chilled tarnished blinking skewed Gene Tonic: Hippy	0		Effect: "You're High as a Crow, Marty", Effect Duration: 57, Last Available: "2014-04"
+7390	chilled tarnished skewed blinking Gene Tonic: Hippy	0		Effect: "You're High as a Crow, Marty", Effect Duration: 57, Last Available: "2014-04"
 7391	super-flattened narrow Gene Tonic: Orc	0		Effect: "Eye of the Seal", Effect Duration: 23, Last Available: "2014-04"
 7392	double-dry Gene Tonic: Demon	0		Effect: "Sourpuss", Effect Duration: 55, Last Available: "2014-04"
 7393	adjusted aerosolized gray Gene Tonic: Horror	0		Effect: "Void Between the Stars", Effect Duration: 53, Last Available: "2014-04"
@@ -7325,20 +7325,20 @@
 7436	dry teal Tremella Tarantella mushroom	0		Effect: "White Blooded", Effect Duration: 45, Last Available: "2014-05"
 7437	ghostly Pastaco shell	0		Last Available: "2014-05"
 7438	moldy purple Beefy Crunch Pastaco	4	crappy	Last Available: "2014-05"
-7439	immense flavorless Brain Food Pastaco	9	decent	Last Available: "2014-05"
+7439	flavorless immense Brain Food Pastaco	9	decent	Last Available: "2014-05"
 7440	adequate Cool Brunch Pastaco	4	good	Last Available: "2014-05"
-7441	thick adequate Medical Pastaco	5	good	Last Available: "2014-05"
+7441	adequate thick Medical Pastaco	5	good	Last Available: "2014-05"
 7442	adequate gigantic cyan Energy Buzz Pastaco	7	good	Last Available: "2014-05"
 7443	spoiled upside-down Ludovico Pastaco	4	crappy	Last Available: "2014-05"
 7444	lousy irresponsibly strong overpowering mushroom wine	10	decent	Last Available: "2014-05"
-7445	weak hand-crafted blinking complex mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7445	hand-crafted weak blinking complex mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7446	lousy smooth mushroom wine	4	decent	Last Available: "2014-05"
-7447	drinkable special blood-red mushroom wine	3	good	Effect: "Sparkling Consciousness", Effect Duration: 50, Last Available: "2014-05"
+7447	special drinkable blood-red mushroom wine	3	good	Effect: "Sparkling Consciousness", Effect Duration: 50, Last Available: "2014-05"
 7448	delicious watered-down buzzing mushroom wine	2	awesome	Last Available: "2014-05"
 7449	watered-down mediocre teal swirling mushroom wine	2	decent	Last Available: "2014-05"
 7450	delicious thick Taco Dan's Basic Taco Dan Taco	5	awesome	Last Available: "2014-05"
-7451	flavorless miniature tumbling Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
-7452	ghostly wobbly Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
+7451	miniature flavorless tumbling Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
+7452	wobbly ghostly Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	artisanal regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	lousy super-size brogurt	4	decent	Last Available: "2014-05"
 7455	perfectly mixed broberry brogurt	3	EPIC	Last Available: "2014-05"
@@ -7359,7 +7359,7 @@
 7470	vibrating razor-sharp dance instructor's shrimp fork	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Maximum MP Percent: +10, Last Available: "2014-05"
 7471	denatured blurry BROS Energy Drink	0		Effect: "Halloweeny", Effect Duration: 65, Last Available: "2014-05"
 7472	triple-Vulcanized aerosolized dry huge go-go potion	0		Effect: "Wolf's Bane", Effect Duration: 66, Last Available: "2014-05"
-7473	galvanized nitrogenated cyan mirror shrimp cocktail	0		Effect: "In Vino Vires", Effect Duration: 44, Last Available: "2014-05"
+7473	galvanized nitrogenated mirror cyan shrimp cocktail	0		Effect: "In Vino Vires", Effect Duration: 44, Last Available: "2014-05"
 7474	oxidized quadruple-deionized Yolo&trade; chocolates	0		Effect: "French Bronilla Brogueishness", Effect Duration: 66, Last Available: "2020-09"
 7475	prompt string of moist beads	0		Adventures: +3, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
@@ -7367,17 +7367,17 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	super-dry boiled nitrogenated sugar fairy	0		Effect: "Turkey-Agitated", Effect Duration: 37, Last Available: "2014-05"
 7480	chilled oxidized cyan sugar bunny	0		Effect: "Burning Ears", Effect Duration: 57, Last Available: "2014-05"
-7481	narrow sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	narrow sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	smooth maroon Rompedores de Fantasmas	4	awesome	
 7483	boozy lousy La Fantasma y La Oscuridad	5	decent	
 7484	hand-crafted practically non-alcoholic Fantasma en la M&aacute;quina	1	super ultra EPIC	
 7485	lime green mirror loosening powder	0		
-7486	huge olive castoreum	0		
+7486	olive huge castoreum	0		
 7487	olive drain dissolver	0		
 7488	triple-distilled turpentine	0		
-7489	mirror twirling detartrated anhydrous sublicalc	0		
+7489	twirling mirror detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	high-proof tolerable lime green bottle of Chateau de Vinegar	8	good	
+7491	tolerable high-proof lime green bottle of Chateau de Vinegar	8	good	
 7492	narrow blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
@@ -7407,9 +7407,9 @@
 7518	blurry wand of pigification	0		
 7519	mediocre squat glass of bourbon	4	decent	
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	low-calorie stale government cheese	1	decent	Last Available: "2014-05"
+7521	stale low-calorie government cheese	1	decent	Last Available: "2014-05"
 7522	upside-down pair of government shades of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2014-05"
-7523	olive narrow space junk	0		Last Available: "2014-05"
+7523	narrow olive space junk	0		Last Available: "2014-05"
 7524	polarized anodized mirror government	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 36, Last Available: "2014-05"
 7525	vacuum-sealed extra-dry shaking yellow alien drugs	0		Effect: "Fancy Feasted", Effect Duration: 22, Last Available: "2023-09"
 7526	weird space book	0		Last Available: "2014-05"
@@ -7444,7 +7444,7 @@
 7555	wobbly ghostly yellow page	0		
 7556	elephant gift	0		
 7557	nitrogenated blurry blood cells	0		Effect: "Piratey Flavor", Effect Duration: 12
-7558	mediocre watered-down wine	2	decent	
+7558	watered-down mediocre wine	2	decent	
 7559	modified moist cold-filtered gummi turtle	0		Effect: "Down With Chow", Effect Duration: 29
 7560	skewed turtle-shaped rock	0		
 7561	anodized cyan bouncing giraffe-necked turtle	0		Effect: "familiar.enq", Effect Duration: 61
@@ -7456,7 +7456,7 @@
 7567	Chroner	0		
 7568	chaotic MacGyver's dance instructor's Time Lord Badge of Honor	0		Experience Percent (Moxie): +10, Maximum MP: +100, Spell Critical Percent: +10
 7569	Sherlock's stiffened Time Bandit Badge of Courage of the sweet-tooth	0		Damage Reduction: 1, Item Drop: +25, Candy Drop: +100
-7570	moist deionized blinking spinning Friendliness Beverage	0		Effect: "Fungal Fortification", Effect Duration: 59
+7570	moist deionized spinning blinking Friendliness Beverage	0		Effect: "Fungal Fortification", Effect Duration: 59
 7571	mirror nasty fortified silent pea shooter	0		Damage Absorption: +60, Stench Damage: +5
 7572	decent jittery D roll	3	good	
 7573	upside-down lightning-fast forbidden kiwi beak	0		Spell Damage Percent: +50, Initiative: +40
@@ -7475,14 +7475,14 @@
 7586	helix fossil	0		
 7587	spinning S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	fancy fortified tolerable glass of &quot;milk&quot;	5	good	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2014-07"
+7589	tolerable fortified fancy glass of &quot;milk&quot;	5	good	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2014-07"
 7590	mediocre spirit-forward squat blinking cup of &quot;tea&quot;	5	decent	Last Available: "2014-07"
 7591	drinkable thermos of &quot;whiskey&quot;	4	good	Last Available: "2014-07"
 7592	tolerable Lucky Lindy	4	good	Last Available: "2014-07"
 7593	drinkable narrow Bee's Knees	3	good	Last Available: "2014-07"
 7594	fancy mediocre Sockdollager	3	decent	Effect: "The Moxie of LOV", Effect Duration: 5, Last Available: "2014-07"
-7595	drinkable watered-down tumbling blurry Ish Kabibble	2	good	Last Available: "2014-07"
-7596	special hand-crafted Hot Socks	4	EPIC	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2014-07"
+7595	watered-down drinkable blurry tumbling Ish Kabibble	2	good	Last Available: "2014-07"
+7596	hand-crafted special Hot Socks	4	EPIC	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2014-07"
 7597	delicious extra-dry mirror Phonus Balonus	5	awesome	Last Available: "2014-07"
 7598	lousy fortified Flivver	5	decent	Last Available: "2014-07"
 7599	fancy perfectly mixed Sloppy Jalopy	3	super EPIC	Effect: "Appeteyes", Effect Duration: 40, Last Available: "2014-07"
@@ -7496,9 +7496,9 @@
 7607	corrupted vial of swamp vapors	0		Effect: "Fudgehound", Effect Duration: 13
 7608	colloidal twirling blurry turtle mud	0		Effect: "Bells in the Batfry", Effect Duration: 64
 7609	tarnished Redeye&trade; Eyedrops	0		Effect: "Superheroic", Effect Duration: 69
-7610	boiled upside-down green ghostly Dweebisol&trade; inhaler	0		Effect: "Pwnd", Effect Duration: 51
+7610	boiled upside-down ghostly green Dweebisol&trade; inhaler	0		Effect: "Pwnd", Effect Duration: 51
 7611	enhanced Lewd Lemmy Hair Oil	0		Effect: "Greasy Flavor", Effect Duration: 20
-7612	magnetized wet huge pulsating blue tomato soup poster	0		Effect: "Human-Machine Hybrid", Effect Duration: 39
+7612	magnetized wet pulsating huge blue tomato soup poster	0		Effect: "Human-Machine Hybrid", Effect Duration: 39
 7613	ionized bubblin' chemistry solution	0		Effect: "Sappy Blood", Effect Duration: 69
 7614	adjusted maroon voodoo glowskull	0		Effect: "Healthy Green Glow", Effect Duration: 14
 7615	dry pygmy adder oil	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 26
@@ -7513,7 +7513,7 @@
 7624	chilled twirling lynyrd skinner toothblack	0		Effect: "Gutterminded", Effect Duration: 45
 7625	ionized blurry flask of rainwater	0		Effect: "Big Meat Big Prizes", Effect Duration: 52
 7626	moist improved jittery oyster badge	0		Effect: "Egged On", Effect Duration: 65
-7627	triple-altered blurry blue plastic Jefferson wings	0		Effect: "Emotion Sickness", Effect Duration: 39
+7627	triple-altered blue blurry plastic Jefferson wings	0		Effect: "Emotion Sickness", Effect Duration: 39
 7628	boiled ionized dancing fan	0		Effect: "Lobos Fresh", Effect Duration: 65
 7629	deionized bouncing page of the Necrohobocon	0		Effect: "Ooh, Umami!", Effect Duration: 47
 7630	deionized quadruple-energized blinking cyan magic powder	0		Effect: "Tiki Toughness", Effect Duration: 30
@@ -7559,7 +7559,7 @@
 7670	spinning miser's careful extremely unsafe famous raincoat	0		Weapon Damage Percent: +100, Monster Level: -10, Meat Drop: +10, Lasts Until Rollover
 7671	tumbling narrow crafty dance instructor's Socratic lightning rod	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Maximum MP: +10, Lasts Until Rollover
 7672	huge mansplainer's law-abiding citizen cane	0		Monster Level: +15, Single Equip
-7673	boozy artisanal legitimate business on the beach	5	EPIC	
+7673	artisanal boozy legitimate business on the beach	5	EPIC	
 7674	friendly hep waders	0		Familiar Weight: +3, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	moldy jive turkey leg	3	crappy	
 7676	yellow hardened birdbone corset	0		Damage Reduction: 3
@@ -7567,7 +7567,7 @@
 7678	huge 4-dimensional fez of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	coward's super-absorbent tarp	0		Monster Level: -20
-7681	acceptable squat huge unquiet spirits	3	good	
+7681	acceptable huge squat unquiet spirits	3	good	
 7682	extremely unsafe banjo kazoo mount	0		Weapon Damage Percent: +100, Single Equip
 7683	denatured extra-unsweetened pressed purple grass	0		Effect: "Meadulla Oblongota", Effect Duration: 39
 7684	Time Lord Participation Mug of the overflowing toilet	0		Stench Spell Damage: +50
@@ -7613,7 +7613,7 @@
 7724	gravedigger's pteruges	0		Spooky Damage: +10, Familiar Effect: "1xFairy, atk, cap 25"
 7725	polarized purple Bruno's blessing of Mars	0		Effect: "From Nantucket", Effect Duration: 48
 7726	unsweetened frozen wet ghostly Dennis's blessing of Minerva	0		Effect: "Intimidating Mien", Effect Duration: 21
-7727	anodized narrow mirror Burt's blessing of Bacchus	0		Effect: "Well Owl Be!", Effect Duration: 55
+7727	anodized mirror narrow Burt's blessing of Bacchus	0		Effect: "Well Owl Be!", Effect Duration: 55
 7728	vacuum-sealed denatured dry mirror Freddie's blessing of Mercury	0		Effect: "Hagnk's Gratitude", Effect Duration: 69
 7729	Chroner trigger	0		
 7730	skewed olive Xi Receiver Unit	0		Last Available: "2014-09"
@@ -7643,9 +7643,9 @@
 7754	maroon Da Vinci's Xiblaxian stealth trousers of the bloodbag	0		Experience (Mysticality): +5, Maximum HP: +100, Last Available: "2014-09"
 7755	hardy Xiblaxian stealth vest of the brute	0		Muscle Percent: +30, Maximum HP: +50, Last Available: "2014-09"
 7756	yummy twirling Xiblaxian ultraburrito	3	awesome	Last Available: "2014-09"
-7757	practically non-alcoholic mediocre Xiblaxian space-whiskey	1	decent	Last Available: "2014-09"
+7757	mediocre practically non-alcoholic Xiblaxian space-whiskey	1	decent	Last Available: "2014-09"
 7758	huge Xiblaxian residence-cube	0		Last Available: "2014-09"
-7759	quadruple-polarized teal wobbly They liver	0		Effect: "Whitened Teeth", Effect Duration: 13, Last Available: "2014-09"
+7759	quadruple-polarized wobbly teal They liver	0		Effect: "Whitened Teeth", Effect Duration: 13, Last Available: "2014-09"
 7760	spoiled wobbly They liver popsicle	4	crappy	Last Available: "2014-09"
 7761	tumbling holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
@@ -7654,7 +7654,7 @@
 7765	sage Xiblaxian holo-wrist-puter	0		Mysticality Percent: +10, Last Available: "2014-09"
 7766	hardy rock-hard hardened defective Golden Mr. Accessory	0		Damage Reduction: 16, Maximum HP: +50
 7767	narrow airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
-7768	mirror spinning one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
+7768	spinning mirror one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	prompt nippy Tesla Personal Ventilation Unit	0		Cold Damage: +10, Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2014-10"
 7771	aerosolized the most dangerous bait	0		Effect: "Stands Alone", Effect Duration: 53, Last Available: "2014-10"
@@ -7668,7 +7668,7 @@
 7779	boiled pickled green experimental serum G-9	0		Effect: "All Glory To the Toad", Effect Duration: 17, Last Available: "2014-10"
 7780	veiny heavy-duty clipboard of extreme caution of the brazier	0		Maximum HP: +10, Monster Level: -25, Hot Spell Damage: +25, Damage Reduction: 8, Last Available: "2014-10"
 7781	upside-down savvy brawny battery-powered drill of the scaredy-cat of the overflowing toilet	0		Muscle Percent: +20, Mysticality Percent: +20, Monster Level: -15, Stench Spell Damage: +50, Last Available: "2014-10"
-7782	moldy thick limp broccoli	5	crappy	Last Available: "2014-10"
+7782	thick moldy limp broccoli	5	crappy	Last Available: "2014-10"
 7783	twirling resourceful quilted hat of the sweet-tooth	0		Damage Absorption: +40, Maximum MP: +50, Candy Drop: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	adjusted upside-down monkey barf	0		Effect: "Spooky Jellied", Effect Duration: 45, Last Available: "2014-10"
 7785	magnetized chilled candy	0		Effect: "Fire Inside", Effect Duration: 27, Last Available: "2014-10"
@@ -7682,8 +7682,8 @@
 7793	blurry bottle-opener keycard	0		Last Available: "2014-10"
 7794	fuchsia shaking Armory keycard	0		Last Available: "2014-10"
 7795	rotten huge initiative shawarma	6	crappy	Last Available: "2014-10"
-7796	moldy miniature maroon warm war shawarma	2	crappy	Last Available: "2014-10"
-7797	decent half-sized fancy pulsating karma shawarma	2	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 10, Last Available: "2014-10"
+7796	miniature moldy maroon warm war shawarma	2	crappy	Last Available: "2014-10"
+7797	fancy decent half-sized pulsating karma shawarma	2	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 10, Last Available: "2014-10"
 7798	fancy acceptable teal Jungle Juice	4	good	Effect: "Jacked In", Effect Duration: 40, Last Available: "2014-10"
 7799	smooth ghostly maroon Amnesiac Ale	3	awesome	Last Available: "2014-10"
 7800	drinkable Highest Bitter	3	good	Last Available: "2014-10"
@@ -7692,14 +7692,14 @@
 7803	upside-down Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
 7804	pulsating Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	Merc Core challenge coin	0		Last Available: "2014-10"
-7806	olive blinking Merc Core deployment orders	0		Last Available: "2014-10"
+7806	blinking olive Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
 7809	pulsating impure gasoline	0		
 7810	blinking Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	normal miniature fancy squat red seared dino steak	2	good	Effect: "Corona de la Salsa", Effect Duration: 30
+7813	normal fancy miniature red squat seared dino steak	2	good	Effect: "Corona de la Salsa", Effect Duration: 30
 7814	acceptable weak fuchsia bottle of drinkin' gas	2	good	
 7815	skewed handful of napalm	0		
 7816	dove DNA	0		
@@ -7726,17 +7726,17 @@
 7837	cyan Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	special clip: tracers	0		Last Available: "2014-10"
-7840	fuchsia huge special clip: wailers	0		Last Available: "2014-10"
+7840	huge fuchsia special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	mirror special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	blurry special clip: graveburpers	0		Last Available: "2014-10"
 7845	altered flattened perl necklace	0		Effect: "Banono", Effect Duration: 54, Last Available: "2014-12"
-7846	aerosolized dry bouncing squat Fudge Fiber Armor Plating	0		Effect: "Eyes Wide Propped", Effect Duration: 51, Last Available: "2014-12"
+7846	aerosolized dry squat bouncing Fudge Fiber Armor Plating	0		Effect: "Eyes Wide Propped", Effect Duration: 51, Last Available: "2014-12"
 7847	quantum ruby on canes	0		Effect: "Space Cadet", Effect Duration: 57, Last Available: "2014-12"
 7848	rotten tumbling petit fortran	4	crappy	Last Available: "2014-12"
 7849	adequate java cookie	3	good	Last Available: "2014-12"
-7850	miniature adequate cookie cookie	2	good	Last Available: "2014-12"
+7850	adequate miniature cookie cookie	2	good	Last Available: "2014-12"
 7851	squat occult plastic exo-suited miner	0		Spell Damage Percent: +25, Last Available: "2014-12"
 7852	crafty plastic semi-autonomous drill unit	0		Maximum MP: +10, Last Available: "2014-12"
 7853	skewed rosewater-soaked plastic ambulatory robo-minecart	0		Stench Resistance: +3, Last Available: "2014-12"
@@ -7756,14 +7756,14 @@
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	mirror Crimbot schematic: Crab Core	0		Last Available: "2014-12"
-7870	upside-down pulsating Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
+7870	pulsating upside-down Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	red Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	wobbly Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
-7877	mirror tumbling Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
+7877	tumbling mirror Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	fuchsia pulsating Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
 7880	Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
@@ -7784,21 +7784,21 @@
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	ghostly Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
-7898	bouncing mirror Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
+7898	mirror bouncing Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	twirling Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
-7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7901	wobbly Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
+7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
-7905	wobbly blinking recovered elf magazine	0		Last Available: "2014-12"
+7905	blinking wobbly recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
 7907	recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	skewed recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	mirror recovered elf photo album	0		Last Available: "2014-12"
-7912	skewed fuchsia recovered elf smartphone	0		Last Available: "2014-12"
+7912	fuchsia skewed recovered elf smartphone	0		Last Available: "2014-12"
 7913	foul-smelling Socratic Size XI Wizard's Robe of mayonnaise	0		Experience (Mysticality): +1, Stench Damage: +10, Sleaze Spell Damage: +50, Last Available: "2014-09"
 7914	pressed squat maroon Bit O' Quail Spleen	0		Effect: "Adrenaline Rush", Effect Duration: 38
 7915	magnetized gray Take Eleven Bar	0		Effect: "You Know Where to Go", Effect Duration: 15
@@ -7834,10 +7834,10 @@
 7952	lasso	0		
 7953	bouncing knitted stylish rusted-out shootin' iron of the ox	0		Muscle: +20, Moxie: +25, Cold Resistance: +3
 7954	rattler rattle	0		
-7955	fuchsia mirror bag of money	0		
+7955	mirror fuchsia bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	even more tinsel	0		Familiar Weight: +5
-7958	pulsating ghostly box of Crimbo decorations	0		
+7958	ghostly pulsating box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
 7960	yellow copy of a jerk adventurer's father's diary	0		
 7961	blurry double-paned nippy boxer's Staff of Ed of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Cold Damage: +10, Cold Resistance: +5
@@ -7850,10 +7850,10 @@
 7968	shaking blurry topiary nugglet	0		
 7969	beehive	0		
 7970	twirling boning knife	0		
-7971	shaking teal Aggressive Carrot	0		Free Pull
-7972	distilled mirror tumbling mummified fig	1	awesome	
+7971	teal shaking Aggressive Carrot	0		Free Pull
+7972	distilled tumbling mirror mummified fig	1	awesome	
 7973	compressed gray mummified loaf of bread	1	decent	
-7974	denatured upside-down blurry mummified beef haunch	1	good	Effect: "Abyssal Sweat", Effect Duration: 35
+7974	denatured blurry upside-down mummified beef haunch	1	good	Effect: "Abyssal Sweat", Effect Duration: 35
 7975	linen bandages	0		
 7976	yellow pulsating cotton bandages	0		
 7977	silk bandages	0		
@@ -7881,7 +7881,7 @@
 7999	super-magnetized ionized choco-Crimbot	0		Effect: "Broken Fast", Effect Duration: 37, Last Available: "2014-12"
 8000	non-energized blinking smart watch	0		Effect: "Patent Avarice", Effect Duration: 67, Last Available: "2014-12"
 8001	electrified Vulcanized colloidal augmented-reality shades	0		Effect: "Scavengers Scavenging", Effect Duration: 60, Last Available: "2014-12"
-8002	upside-down occult toy Crimbot mega face	0		Spell Damage Percent: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8002	upside-down occult toy Crimbot mega face	0		Spell Damage Percent: +25, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
 8003	lard-coated toy Crimbot power glove	0		Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	supercharged toy Crimbot super fist	0		Maximum MP Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	toy Crimbot rocket legs of the blizzard	0		Cold Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7895,12 +7895,12 @@
 8013	bouncing Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8016	pickled dry spinning squat fitness wristband	0		Effect: "Hyphemariffic", Effect Duration: 29, Last Available: "2014-12"
+8016	pickled dry squat spinning fitness wristband	0		Effect: "Hyphemariffic", Effect Duration: 29, Last Available: "2014-12"
 8017	electrified ionized lime green flask of tainted mining oil	0		Effect: "Cool, Catlike", Effect Duration: 27, Last Available: "2014-12"
 8018	chilled anodized and rain stick	0		Effect: "Stinking Cloud", Effect Duration: 49
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	spoiled super-sized Choco-Mint patty	5	crappy	Last Available: "2015-01"
-8021	weak lousy hot mint schnocolate	2	decent	Last Available: "2015-01"
+8020	super-sized spoiled Choco-Mint patty	5	crappy	Last Available: "2015-01"
+8021	lousy weak hot mint schnocolate	2	decent	Last Available: "2015-01"
 8022	distilled maroon pulsating homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	spinning foreign language tapes	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	mirror cyan deadly tope&eacute; of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Familiar Effect: "3xBarrr, cap 12"
 8035	knitted Tesla topiary tights	0		Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10
 8036	electrified topiary necktie	0		MP Regen Min: 3, MP Regen Max: 5
-8037	spoiled low-calorie narrow huge olive bowl of topioca	1	crappy	
+8037	low-calorie spoiled huge narrow olive bowl of topioca	1	crappy	
 8038	topiary skunk	0		
 8039	ghostly topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -7984,7 +7984,7 @@
 8109	dangerous ascot of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Single Equip, Last Available: "2017-12"
 8110	Van der Graaf attache case of the boozehound	0		Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2017-12"
 8111	accordion of wisdom of the boozehound	0		Mysticality: +15, Booze Drop: +100, Song Duration: 10, Last Available: "2017-12"
-8112	distilled blinking tumbling aerosolized	1		Last Available: "2017-12"
+8112	distilled tumbling blinking aerosolized	1		Last Available: "2017-12"
 8113	blue aromatic wig of wisdom	0		Mysticality: +15, Stench Resistance: +1, Last Available: "2017-12"
 8114	narrow spinning electrified rock-hard winch crank	0		Damage Reduction: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2017-12"
 8115	maroon wool widget of wisdom	0		Mysticality: +15, Cold Resistance: +1, Single Equip, Last Available: "2017-12"
@@ -7998,7 +7998,7 @@
 8123	huge ribald garibaldi of the brute	0		Muscle Percent: +30, Sleaze Damage: +10, Last Available: "2018-12"
 8124	smelly girdle of Tarzan	0		Experience (Muscle): +3, Stench Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	mirror miser's vibrating gloves	0		Maximum MP Percent: +10, Meat Drop: +10, Single Equip, Last Available: "2018-12"
-8126	dehydrated wobbly lime green smithereens	1		Effect: "Pasta Oneness", Effect Duration: 25, Last Available: "2018-12"
+8126	dehydrated lime green wobbly smithereens	1		Effect: "Pasta Oneness", Effect Duration: 25, Last Available: "2018-12"
 8127	Jim Carey's beefy fiberglass fetish	0		Muscle: +10, Monster Level: +25, Last Available: "2018-12"
 8128	upside-down rosy-cheeked dangerous fiberglass foil	0		Weapon Damage: +10, Maximum HP Percent: +30, Last Available: "2018-12"
 8129	double-paned electrified fiberglass fannypack	0		Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-12"
@@ -8032,7 +8032,7 @@
 8158	bone with a price tag on it	0		
 8159	blinking half of a tooth	0		
 8160	cold-filtered pressed oxidized mouse skull	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
-8161	double-chilled cyan spinning really thick spine	0		Effect: "You're Rubber", Effect Duration: 56
+8161	double-chilled spinning cyan really thick spine	0		Effect: "You're Rubber", Effect Duration: 56
 8162	weightlifter's skullcap of courage	0		Muscle: +15, Spooky Resistance: +3, Familiar Effect: "1xVolley,cap 5"
 8163	Sinatra's three-legged pants of the storm	0		Experience (Moxie): +5, Maximum MP Percent: +40, Familiar Effect: "hot atk, cap 25"
 8164	MacGyver's sinister remaindered axe	0		Spell Damage: +10, Maximum MP: +100
@@ -8040,12 +8040,12 @@
 8166	fuchsia dangerous beefy cr&ecirc;epy mask	0		Muscle: +10, Weapon Damage: +10, Familiar Effect: "spooky atk, cap 5"
 8167	stale baguette	3	decent	
 8168	glob of icing	0		
-8169	quantum liquefied corrupted purple narrow ginger snaps	0		Effect: "Sweetened and Fattened", Effect Duration: 37
+8169	quantum liquefied corrupted narrow purple ginger snaps	0		Effect: "Sweetened and Fattened", Effect Duration: 37
 8170	magnetized mostly-broken sunglasses	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 13
 8171	weak smooth unflavored wine cooler	2	awesome	
 8172	carton of snake milk	1	awesome	
 8173	sewer snake of the wise owl	0		Mysticality: +20
-8174	stale big pigeon egg	5	decent	
+8174	big stale pigeon egg	5	decent	
 8175	blue asbestos-lined jaunty feather of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +5
 8176	drinkable practically non-alcoholic premium malt liquor	1	good	
 8177	family-friendly therapeutic brown paper pants	0		Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
@@ -8061,13 +8061,13 @@
 8187	map to a hidden booze cache	0		
 8188	tolerable special squat Cherrytastrophe wine cooler	3	good	Effect: "Vanity Rage", Effect Duration: 50
 8189	tolerable Radberry Rip wine cooler	3	good	
-8190	mediocre weak enchanted Orangemageddon wine cooler	2	decent	Effect: "Cotton Mouthed", Effect Duration: 25
+8190	enchanted weak mediocre Orangemageddon wine cooler	2	decent	Effect: "Cotton Mouthed", Effect Duration: 25
 8191	drinkable Breakfast Blast wine cooler	4	good	
 8192	distilled smooth Citrus Crush wine cooler	5	awesome	
 8193	normal gray plain bagel	3	good	
 8194	tasty glob of cream cheese	3	awesome	
 8195	moldy loaf of soda bread	3	crappy	
-8196	stale huge acceptable bagel	8	decent	
+8196	huge stale acceptable bagel	8	decent	
 8197	stale immense standard-issue cupcake	10	decent	
 8198	flavorless ultra-deluxe cupcake	4	decent	
 8199	hypnotic breadcrumbs	0		
@@ -8085,7 +8085,7 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	bouncing jittery maroon frosty rigging rope of the businessman	0		Cold Spell Damage: +10, Meat Drop: +50, Last Available: "2015-04"
-8214	vaporized upside-down lime green nasty snuff	1	decent	Effect: "Oh Snap", Effect Duration: 40, Last Available: "2015-04"
+8214	vaporized lime green upside-down nasty snuff	1	decent	Effect: "Oh Snap", Effect Duration: 40, Last Available: "2015-04"
 8215	Jim Carey's banded sewage-clogged pistol	0		Damage Absorption: +100, Monster Level: +25, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	nitrogenated cold-filtered beard incense	0		Effect: "Rainbow Bright", Effect Duration: 13, Last Available: "2015-04"
 8217	mirror brawny perfume-soaked bandana of temperance	0		Muscle Percent: +20, Sleaze Resistance: +5, Single Equip, Last Available: "2015-04"
@@ -8129,14 +8129,14 @@
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	squat Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	concentrated bouncing nasty gum	0		Effect: "All Is Forgiven", Effect Duration: 19
-8258	olive shaking Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
+8258	shaking olive Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	Lo Pan's The Lot's engagement ring	0		Spell Critical Percent: +30, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	skewed Mayo Clinic	0		Last Available: "2015-05"
 8261	spinning Mayonex	0		Last Available: "2015-05"
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	Mayostat	0		Last Available: "2015-05"
 8264	mirror Mayozapine	0		Last Available: "2015-05"
-8265	wobbly bouncing Mayoflex	0		Last Available: "2015-05"
+8265	bouncing wobbly Mayoflex	0		Last Available: "2015-05"
 8266	mirror MacGyver's therapeutic Samson's miracle whip of Gandalf	0		Experience (Muscle): +5, Maximum MP: +100, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2015-05"
 8267	strapping sphygmayomanometer	0		Muscle: +5, Lasts Until Rollover, Last Available: "2015-05"
 8268	fuchsia twirling tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
@@ -8146,10 +8146,10 @@
 8272	decent acceptable mayolus	3	good	Last Available: "2015-05"
 8273	spoiled enticing mayolus	3	crappy	Last Available: "2015-05"
 8274	adequate red mouth-watering mayolus	4	good	Last Available: "2015-05"
-8275	jittery teal newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
+8275	teal jittery newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	gray Essence of Bear	0		Skill: "Bear Essence"
-8278	high-proof hand-crafted Afternoon Delight	9	EPIC	Last Available: "2015-04"
+8278	hand-crafted high-proof Afternoon Delight	9	EPIC	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	wobbly Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	aerosolized deionized Kokomo Resort Brand Suntan Oil	0		Effect: "Dance Interpreter", Effect Duration: 21, Last Available: "2015-04"
@@ -8169,11 +8169,11 @@
 8295	tumbling up-at-dawn dice sunglasses	0		Adventures: +5, Single Equip
 8296	Thwaitgold caterpillar statuette	0		
 8297	magnetized purple dice	0		Effect: "Frosty the Hitman", Effect Duration: 21
-8298	wobbly squat pixel	0		Last Available: "2015-06"
+8298	squat wobbly pixel	0		Last Available: "2015-06"
 8299	pixel coin	0		Last Available: "2015-06"
-8300	electrified liquefied spinning narrow power pill	0		Effect: "Tingling Feeling", Effect Duration: 23, Last Available: "2015-06"
+8300	electrified liquefied narrow spinning power pill	0		Effect: "Tingling Feeling", Effect Duration: 23, Last Available: "2015-06"
 8301	deionized altered yellow pixel star	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 28, Last Available: "2015-06"
-8302	immense decent pixel banana	6	good	Last Available: "2015-06"
+8302	decent immense pixel banana	6	good	Last Available: "2015-06"
 8303	lousy weak pixel beer	2	decent	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	gray pumps	0		Last Available: "2015-06"
@@ -8198,7 +8198,7 @@
 8324	diffused quadruple-irradiated tumbling disposable lighter	0		Effect: "Virgo Rising", Effect Duration: 22
 8325	super-energized improved triple-dry coal contact lenses	0		Effect: "Preemptive Medicine", Effect Duration: 11
 8326	liquefied modified shaking conjured ice cream	0		Effect: "Turtle Power", Effect Duration: 58
-8327	warmed nitrogenated blinking mirror Iceberglar scarf	0		Effect: "Steroid Boost", Effect Duration: 26
+8327	warmed nitrogenated mirror blinking Iceberglar scarf	0		Effect: "Steroid Boost", Effect Duration: 26
 8328	denatured pressed icy hairspray	0		Effect: "Sharp Weapon", Effect Duration: 12
 8329	flattened smellbook	0		Effect: "Booze Goozles", Effect Duration: 27
 8330	flattened extra-moist narrow assassin's cheese knife	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 62
@@ -8207,13 +8207,13 @@
 8333	liquefied batarang	0		Effect: "Transcendental Wind", Effect Duration: 50
 8334	wet aerosolized spare neck bolts	0		Effect: "Old School Pompadour", Effect Duration: 17
 8335	electrified altered grease trap	0		Effect: "Rave Concentration", Effect Duration: 59
-8336	galvanized improved fuchsia squat shamanic ham	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 67
+8336	galvanized improved squat fuchsia shamanic ham	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 67
 8337	nitrogenated aerosolized porkpocket	0		Effect: "Crying, Dying", Effect Duration: 47
 8338	concentrated Leonard's glasses	0		Effect: "Melancholy Burden", Effect Duration: 41
-8339	galvanized twirling olive warehouse walkie-talkie	0		Effect: "Can't Be a Chooser", Effect Duration: 18
+8339	galvanized olive twirling warehouse walkie-talkie	0		Effect: "Can't Be a Chooser", Effect Duration: 18
 8340	diffused red janitor's mop	0		Effect: "Carol of the Bones", Effect Duration: 17
 8341	dry warehouse clerk's glasses	0		Effect: "Broken Bone Nubs", Effect Duration: 37
-8342	deionized pressed blurry skewed cyan baloney rotgut	0		Effect: "Using Protection", Effect Duration: 60
+8342	deionized pressed cyan skewed blurry baloney rotgut	0		Effect: "Using Protection", Effect Duration: 60
 8343	colloidal yellow carton of gaspers	0		Effect: "Butt-Rock Hair", Effect Duration: 32
 8344	polymerized frozen pulsating bronze polish	0		Effect: "Cake Caked", Effect Duration: 38
 8345	polymerized crident	0		Effect: "In Vino Vires", Effect Duration: 11
@@ -8244,12 +8244,12 @@
 8370	extra-chilled corrupted alkaline funky eyepatch	0		Effect: "Bloody-minded", Effect Duration: 31
 8371	enhanced pressed huge bucket of fish juice	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 65
 8372	aerosolized flashy pirate dreadlocks	0		Effect: "Jungle Juiced", Effect Duration: 50
-8373	cold-filtered corrupted spinning wobbly captured boozles	0		Effect: "Metal Speed", Effect Duration: 45
+8373	cold-filtered corrupted wobbly spinning captured boozles	0		Effect: "Metal Speed", Effect Duration: 45
 8374	boiled dry narrow gray drinks tray	0		Effect: "Paging Betty", Effect Duration: 34
 8375	vacuum-sealed jittery eyebrow lifter	0		Effect: "Moon-Eyed", Effect Duration: 12
 8376	ghostly shaking submarine	0		Last Available: "2015-06"
 8377	moldy pixel lemon	3	crappy	Last Available: "2015-06"
-8378	special delicious skewed pixel daiquiri	3	awesome	Effect: "Aloofah", Effect Duration: 25, Last Available: "2015-06"
+8378	delicious special skewed pixel daiquiri	3	awesome	Effect: "Aloofah", Effect Duration: 25, Last Available: "2015-06"
 8379	frozen wobbly power pill	0		Effect: "Top Dog", Effect Duration: 21, Last Available: "2015-06"
 8380	moist pixel potion	0		Effect: "There Is A Spoon", Effect Duration: 68, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8280,18 +8280,18 @@
 8406	savory dry noodles	0		
 8407	adequate pestopiary	3	good	
 8408	electrified huge ectoplasmic orbs	0		Effect: "Robocamo", Effect Duration: 57
-8409	bite-sized rotten crudles	1	crappy	
+8409	rotten bite-sized crudles	1	crappy	
 8410	normal agnolotti arboli	3	good	
-8411	half-sized delicious wobbly spaghetti with ghost balls	2	awesome	
+8411	delicious half-sized wobbly spaghetti with ghost balls	2	awesome	
 8412	normal succulent marrow	3	good	
 8413	delicious teal salacious crumbs	3	awesome	
 8414	decent special fusilli marrownarrow	4	good	Effect: "No Vertigo", Effect Duration: 20
 8415	rotten suggestive strozzapreti	3	crappy	
 8416	Mountain Stream gastrique	0		
-8417	super-sized special spoiled Mt. McLargeHuge oyster	5	crappy	Effect: "Overstimulated", Effect Duration: 30
+8417	super-sized spoiled special Mt. McLargeHuge oyster	5	crappy	Effect: "Overstimulated", Effect Duration: 30
 8418	squat oyster sauce	0		
-8419	miniature rotten linguini immondizia bianco	2	crappy	
-8420	spoiled enchanted maroon shells a la shellfish	4	crappy	Effect: "Elvish", Effect Duration: 20
+8419	rotten miniature linguini immondizia bianco	2	crappy	
+8420	enchanted spoiled maroon shells a la shellfish	4	crappy	Effect: "Elvish", Effect Duration: 20
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8327,21 +8327,21 @@
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	ghostly LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
-8456	squat lime green crystalline light bulb	0		Last Available: "2015-08"
+8456	lime green squat crystalline light bulb	0		Last Available: "2015-08"
 8457	blurry broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	avaricious auspicious high-temperature mining mask	0		Item Drop: +10, Meat Drop: +30, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	knitted brainy fireproof megaphone	0		Mysticality: +5, Cold Resistance: +3, Last Available: "2015-08"
 8460	tasty immense mineapple	6	awesome	Last Available: "2015-08"
-8461	lousy triple-distilled Gold Velvet&trade; whiskey	6	decent	Last Available: "2015-08"
+8461	triple-distilled lousy Gold Velvet&trade; whiskey	6	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	EPIC	Last Available: "2015-08"
-8463	diet spoiled smelted roe	1	crappy	Last Available: "2015-08"
+8463	spoiled diet smelted roe	1	crappy	Last Available: "2015-08"
 8464	practically non-alcoholic mediocre twirling lavawater	1	decent	Last Available: "2015-08"
 8465	aerosolized activated irradiated basaltamander tongue	0		Effect: "Blackberry Politeness", Effect Duration: 55, Last Available: "2015-08"
 8466	ghostly auspicious curative lavalarva of the sewer	0		Stench Damage: +25, Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-08"
 8467	pulsating ghostly nasty rosy-cheeked lava balaclava of Flo-Jo	0		Maximum HP Percent: +30, Stench Damage: +5, Initiative: +100, Last Available: "2015-08"
 8468	censurious double-paned clever basaltamander buckler	0		Maximum MP: +20, Cold Resistance: +5, Sleaze Resistance: +3, Damage Reduction: 15, Last Available: "2015-08"
 8469	improved spinning lava globs	0		Effect: "Ooh, Bitter!", Effect Duration: 56, Last Available: "2015-08"
-8470	special tasty snack-sized gooey lava globs	2	awesome	Effect: "Heart of White", Effect Duration: 20, Last Available: "2015-08"
+8470	snack-sized special tasty gooey lava globs	2	awesome	Effect: "Heart of White", Effect Duration: 20, Last Available: "2015-08"
 8471	bouncing supercharged fortified lava-proof pants	0		Damage Absorption: +60, Maximum MP Percent: +30, Last Available: "2015-08"
 8472	supercharged heat-resistant necktie of Gandalf	0		Maximum MP Percent: +30, Spell Critical Percent: +20, Single Equip, Last Available: "2015-08"
 8473	Annie Oakley's vibrating heat-resistant gloves of terror	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Spooky Spell Damage: +10, Single Equip, Last Available: "2015-08"
@@ -8349,7 +8349,7 @@
 8475	mediocre yellow asbestos thermos	3	decent	Last Available: "2015-08"
 8476	wet unsweetened energized liquid rhinestones	0		Effect: "Punchy, Murdery", Effect Duration: 58, Last Available: "2015-08"
 8477	diet stale spinning bouncing disco biscuit	1	decent	Last Available: "2015-08"
-8478	boozy artisanal squat Quaatorade&trade;	5	EPIC	Last Available: "2015-08"
+8478	artisanal boozy squat Quaatorade&trade;	5	EPIC	Last Available: "2015-08"
 8479	mirror greedy lard-coated greasy biker's hat	0		Sleaze Spell Damage: 35, Meat Drop: +20, Familiar Effect: "atk", Last Available: "2015-08"
 8480	yellow lightning-fast flame-wreathed Tesla feathered headdress	0		Hot Spell Damage: +10, Initiative: +40, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
 8481	zippy frightening veiny electrician's hardhat	0		Maximum HP: +10, Spooky Damage: +5, Initiative: +20, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8379,7 +8379,7 @@
 8505	half-melted hula girl	0		Last Available: "2015-08"
 8506	cyan glass ceiling fragments	0		Last Available: "2015-08"
 8507	powdered SMOOCH coffee cup	1	decent	Last Available: "2015-08"
-8508	polarized maroon squat labrador cookie	0		Effect: "It Didn't Kill You", Effect Duration: 59, Last Available: "2015-08"
+8508	polarized squat maroon labrador cookie	0		Effect: "It Didn't Kill You", Effect Duration: 59, Last Available: "2015-08"
 8509	crafty Mr. Cheeng's spectacles of the ox of terror	0		Muscle: +20, Maximum MP: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8510	yellow experienced grease cannon of horror	0		Experience: +2, Spooky Spell Damage: +25, Last Available: "2015-08"
 8511	extra-denatured electrified super-improved demon makeup kit	0		Effect: "The Power of Positive Thinking", Effect Duration: 51, Last Available: "2015-08"
@@ -8406,21 +8406,21 @@
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	bland libertagliatelle	4	decent	
-8535	miniature tasty narrow spinning turkish mostaccioli	2	awesome	
-8536	enchanted diet adequate linguini of the sea	1	good	Effect: "Heightened Senses", Effect Duration: 35
+8535	miniature tasty spinning narrow turkish mostaccioli	2	awesome	
+8536	enchanted adequate diet linguini of the sea	1	good	Effect: "Heightened Senses", Effect Duration: 35
 8537	diffused Hersey&trade; SMOOCH	0		Effect: "Virgo Rising", Effect Duration: 39
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	blurry drug cocktail sauce	0		
-8542	small rotten Fettris	2	crappy	
+8542	rotten small Fettris	2	crappy	
 8543	bland fusillocybin	3	decent	
-8544	super-sized rotten prescription noodles	5	crappy	
-8545	dried blinking shaking blood-drive sticker	1	awesome	Effect: "Waxing", Effect Duration: 40
+8544	rotten super-sized prescription noodles	5	crappy	
+8545	dried shaking blinking blood-drive sticker	1	awesome	Effect: "Waxing", Effect Duration: 40
 8546	chilled narrow bag of grain	0		Effect: "Frozen Hands", Effect Duration: 65
 8547	adjusted pulsating pocket maze	0		Effect: "Pasta Oneness", Effect Duration: 44
 8548	ionized chilled shady shades	0		Effect: "Heart of Green", Effect Duration: 25
 8549	oxidized diffused boiled squeaky toy rose	0		Effect: "20-20 Second Sight", Effect Duration: 63
-8550	jumbo rotten enchanted ghostly purple weird gazelle steak	5	crappy	Effect: "Pyramid Power", Effect Duration: 20
+8550	rotten jumbo enchanted purple ghostly weird gazelle steak	5	crappy	Effect: "Pyramid Power", Effect Duration: 20
 8551	yummy sausage without a cause	4	awesome	
 8552	double-diffused adjusted diffused face paint	0		Effect: "Gemini Rising", Effect Duration: 69
 8553	tolerable irresponsibly strong bouncing emergency margarita	7	good	
@@ -8446,7 +8446,7 @@
 8573	barrel	0		Last Available: "2015-09"
 8574	bouncing moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
-8576	huge fuchsia mouldering barrel	0		Last Available: "2015-09"
+8576	fuchsia huge mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	tolerable bottle of Amontillado	4	good	Last Available: "2015-09"
 8579	artisanal barrel-aged martini	3	EPIC	Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	asbestos-lined barrel gun	0		Hot Resistance: +5, Last Available: "2015-09"
 8587	blue barrel	0		Last Available: "2015-09"
 8588	mirror barrel beryl	0		Last Available: "2015-09"
-8589	bland bite-sized water log	1	decent	Last Available: "2015-09"
+8589	bite-sized bland water log	1	decent	Last Available: "2015-09"
 8590	barrelhead of the cougar of the detective	0		Moxie: +20, Item Drop: +20, Last Available: "2015-09"
 8591	mirror lion tamer's curative bottoms of the barrel	0		Experience (familiar): +2, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-09"
 8592	occult chest barrel of the dark arts	0		Spell Damage Percent: 125, Last Available: "2015-09"
@@ -8477,20 +8477,20 @@
 8604	frozen warmed cuppa Nas tea	0		Effect: "Swimming with Sharks", Effect Duration: 62, Last Available: "2015-09"
 8605	double-irradiated cuppa Improprie tea	0		Effect: "Tomato Power", Effect Duration: 65, Last Available: "2015-09"
 8606	super-cold-filtered squat cuppa Frost tea	0		Effect: "Eagle Eyes", Effect Duration: 67, Last Available: "2015-09"
-8607	dry dry tumbling squat cuppa Toast tea	0		Effect: "Hagg-ard", Effect Duration: 44, Last Available: "2015-09"
+8607	dry dry squat tumbling cuppa Toast tea	0		Effect: "Hagg-ard", Effect Duration: 44, Last Available: "2015-09"
 8608	vacuum-sealed mirror cuppa Net tea	0		Effect: "Enraged", Effect Duration: 18, Last Available: "2015-09"
 8609	wet non-adjusted cuppa Proprie tea	0		Effect: "Orchid Blood", Effect Duration: 24, Last Available: "2015-09"
 8610	alkaline alkaline cuppa Morbidi tea	0		Effect: "You're Rubber", Effect Duration: 24, Last Available: "2015-09"
 8611	modified pickled magnetized cuppa Chari tea	0		Effect: "Moose Wisdom", Effect Duration: 13, Last Available: "2015-09"
 8612	extra-chilled electrified cold-filtered ghostly cuppa Serendipi tea	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 69, Last Available: "2015-09"
-8613	super-enhanced huge ghostly purple cuppa Feroci tea	0		Effect: "Unrunnable Face", Effect Duration: 24, Last Available: "2015-09"
+8613	super-enhanced ghostly huge purple cuppa Feroci tea	0		Effect: "Unrunnable Face", Effect Duration: 24, Last Available: "2015-09"
 8614	moist cuppa Physicali tea	0		Effect: "Human-Hobo Hybrid", Effect Duration: 50, Last Available: "2015-09"
 8615	vacuum-sealed bouncing cuppa Wit tea	0		Effect: "Hella Tough", Effect Duration: 19, Last Available: "2015-09"
 8616	vacuum-sealed cuppa Neuroplastici tea	0		Effect: "Burning Hands", Effect Duration: 41, Last Available: "2015-09"
 8617	activated cuppa Dexteri tea	0		Effect: "Weather, Man", Effect Duration: 25, Last Available: "2015-09"
 8618	cold-filtered warmed cuppa Flexibili tea	0		Effect: "Fastbreaker", Effect Duration: 54, Last Available: "2015-09"
 8619	electrified cuppa Impregnabili tea	0		Effect: "Standard Issue Bravery", Effect Duration: 21, Last Available: "2015-09"
-8620	colloidal energized squat mirror cuppa Obscuri tea	0		Effect: "Chilblains of the Corn", Effect Duration: 15, Last Available: "2015-09"
+8620	colloidal energized mirror squat cuppa Obscuri tea	0		Effect: "Chilblains of the Corn", Effect Duration: 15, Last Available: "2015-09"
 8621	electrified blurry twirling cuppa Irritabili tea	0		Effect: "Shoesauce", Effect Duration: 39, Last Available: "2015-09"
 8622	pressed concentrated cuppa Mediocri tea	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 51, Last Available: "2015-09"
 8623	liquefied magnetized ionized cuppa Loyal tea	0		Effect: "Natural 20", Effect Duration: 39, Last Available: "2015-09"
@@ -8559,14 +8559,14 @@
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	shaking hardened bellhop's hat	0		Damage Reduction: 3, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	mediocre ice porter	3	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	mediocre ice porter	3	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	boiled electrified blue exotic travel brochure	0		Effect: "Sugar, Hello", Effect Duration: 38, Last Available: "2015-11"
 8691	teal bag of foreign bribes	0		Last Available: "2015-11"
 8692	electrified pressed shampoo-conditioner	0		Effect: "Dreams and Lights", Effect Duration: 63, Last Available: "2015-11"
 8693	blurry hotel minibar key	0		Last Available: "2015-11"
 8694	pulsating ice hotel bell	0		Last Available: "2015-11"
 8695	bouncing Martialest Arts trophy	0		Last Available: "2016-01"
-8696	distilled spinning bouncing medicinal herbs	1		Effect: "Thicker, Sicker", Effect Duration: 15, Last Available: "2016-01"
+8696	distilled bouncing spinning medicinal herbs	1		Effect: "Thicker, Sicker", Effect Duration: 15, Last Available: "2016-01"
 8697	flavorless ice rice	4	decent	Last Available: "2016-01"
 8698	aged iced plum wine	3	awesome	Last Available: "2016-01"
 8699	ribald padded smooth training belt	0		Moxie: +15, Damage Absorption: +20, Sleaze Damage: +10, Single Equip, Last Available: "2016-01"
@@ -8586,22 +8586,22 @@
 8713	compressed bouncing abstraction: perception	1		Effect: "Notably Lovely", Effect Duration: 30, Last Available: "2015-12"
 8714	mixed narrow abstraction: motion	1		Last Available: "2015-12"
 8715	denatured abstraction: joy	1		Effect: "Red Around the Gills", Effect Duration: 50, Last Available: "2015-12"
-8716	compressed cyan blurry abstraction: certainty	1		Last Available: "2015-12"
+8716	compressed blurry cyan abstraction: certainty	1		Last Available: "2015-12"
 8717	denatured abstraction: comprehension	1		Last Available: "2015-12"
 8718	squat modern picture frame	0		Last Available: "2015-12"
-8719	flavorless enchanted maroon VYKEA meatballs	3	decent	Effect: "Radiant Personality", Effect Duration: 10, Last Available: "2015-11"
+8719	enchanted flavorless maroon VYKEA meatballs	3	decent	Effect: "Radiant Personality", Effect Duration: 10, Last Available: "2015-11"
 8720	drinkable blinking VYKEA mead	3	good	Last Available: "2015-11"
 8721	energized VYKEA woadpaint	0		Effect: "Stench Jellied", Effect Duration: 43, Last Available: "2015-11"
 8722	shaking VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
-8724	blue jittery VYKEA lightning rune	0		Last Available: "2015-11"
+8724	jittery blue VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
-8727	gray blurry VYKEA bracket	0		Last Available: "2015-11"
+8727	blurry gray VYKEA bracket	0		Last Available: "2015-11"
 8728	olive VYKEA dowel	0		Last Available: "2015-11"
 8729	tumbling auspicious nasty MacGyver's VYKEA hex key	0		Maximum MP: +100, Stench Damage: +5, Item Drop: +10, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	small yummy enchanted tin of submardines	2	awesome	Effect: "Sweet and Yellow", Effect Duration: 40, Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	yummy enchanted small tin of submardines	2	awesome	Effect: "Sweet and Yellow", Effect Duration: 40, Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	acceptable weak bottle of norwhiskey	2	good	Last Available: "2015-11"
 8733	mixed blinking octolus oculus	1	decent	Last Available: "2015-11"
 8734	pulsating asbestos-lined greasy boxer's sardine can key	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Last Available: "2015-11"
@@ -8609,10 +8609,10 @@
 8736	maroon studded octolus-skin cloak of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Damage Absorption: +80, Last Available: "2015-11"
 8737	delicious irresponsibly strong perfect cosmopolitan	6	awesome	Last Available: "2015-11"
 8738	smooth fancy wobbly perfect negroni	3	awesome	Effect: "Busy Bein' Delicious", Effect Duration: 40, Last Available: "2015-11"
-8739	weak special artisanal spinning perfect dark and stormy	2	super ultra EPIC	Effect: "Billiards Belligerence", Effect Duration: 5, Last Available: "2015-11"
+8739	special artisanal weak spinning perfect dark and stormy	2	super ultra EPIC	Effect: "Billiards Belligerence", Effect Duration: 5, Last Available: "2015-11"
 8740	weak bad perfect mimosa	2	decent	Last Available: "2015-11"
 8741	perfectly mixed perfect old-fashioned	4	EPIC	Last Available: "2015-11"
-8742	drinkable enchanted perfect paloma	3	good	Effect: "La Bamba", Effect Duration: 45, Last Available: "2015-11"
+8742	enchanted drinkable perfect paloma	3	good	Effect: "La Bamba", Effect Duration: 45, Last Available: "2015-11"
 8743	extra-ionized That 70s Cologne	0		Effect: "Here's Mud in Your Eye", Effect Duration: 49, Last Available: "2015-11"
 8744	colloidal flattened Wal-Mart &quot;diamond&quot; ring	0		Effect: "Rad-ish", Effect Duration: 25, Last Available: "2015-11"
 8745	nitrogenated enhanced Puffstone cigar	0		Effect: "White-boy Angst", Effect Duration: 41, Last Available: "2015-11"
@@ -8621,8 +8621,8 @@
 8748	upside-down airplane tattoo	0		Last Available: "2015-11"
 8749	polymerized concentrated Deep Machine Tunnels snowglobe	0		Effect: "Happy Salamander", Effect Duration: 37, Last Available: "2015-12"
 8750	diffused deionized hemp candy necklace	0		Effect: "Bastard!", Effect Duration: 34, Last Available: "2015-12"
-8751	irradiated blurry jittery wobbly communal gobstopper	0		Effect: "Boo Tea", Effect Duration: 18, Last Available: "2015-12"
-8752	bland half-sized Crimbo salad	2	decent	Last Available: "2015-12"
+8751	irradiated wobbly blurry jittery communal gobstopper	0		Effect: "Boo Tea", Effect Duration: 18, Last Available: "2015-12"
+8752	half-sized bland Crimbo salad	2	decent	Last Available: "2015-12"
 8753	moldy bread line	3	crappy	Last Available: "2015-12"
 8754	bad skewed bark rootbeer	3	decent	Last Available: "2015-12"
 8755	acceptable ale	3	good	Last Available: "2015-12"
@@ -8632,11 +8632,11 @@
 8759	twirling plastic Crimborgatron of the wise owl	0		Mysticality: +20, Last Available: "2015-12"
 8760	asbestos-lined plastic Crimbodhisattva	0		Hot Resistance: +5, Last Available: "2015-12"
 8761	teal bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
-8762	red narrow stack of communist leaflets	0		Last Available: "2015-12"
+8762	narrow red stack of communist leaflets	0		Last Available: "2015-12"
 8763	BACON	0		Last Available: "2016-05"
 8764	gray box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	tumbling Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	practically non-alcoholic tolerable upside-down skewed Gratitude chocolate (bourbon-filled)	1	good	Last Available: "2016-02"
+8766	tolerable practically non-alcoholic upside-down skewed Gratitude chocolate (bourbon-filled)	1	good	Last Available: "2016-02"
 8767	ghostly Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8676,7 +8676,7 @@
 8804	ghostly high-grade	0		Last Available: "2017-01"
 8805	wobbly high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
-8807	blinking tumbling upside-down experimental gene therapy	0		Last Available: "2017-01"
+8807	upside-down blinking tumbling experimental gene therapy	0		Last Available: "2017-01"
 8808	wobbly ultracoagulator	0		Last Available: "2017-01"
 8809	spinning self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
@@ -8689,20 +8689,20 @@
 8817	dried ghostly Mansquito Serum	1		Last Available: "2016-12"
 8818	extra-dry drinkable pulsating Miss Graves' vermouth	5	good	Last Available: "2016-12"
 8819	normal snack-sized The Plumber's mushroom stew	2	good	Last Available: "2016-12"
-8820	diluted narrow maroon The Author's ink	1		Last Available: "2016-02"
+8820	diluted maroon narrow The Author's ink	1		Last Available: "2016-02"
 8821	mediocre The Mad Liquor	3	decent	Last Available: "2016-12"
-8822	delicious weak fancy Doc Clock's thyme cocktail	2	awesome	Effect: "Meat the Flintstones", Effect Duration: 25, Last Available: "2016-12"
+8822	fancy weak delicious Doc Clock's thyme cocktail	2	awesome	Effect: "Meat the Flintstones", Effect Duration: 25, Last Available: "2016-12"
 8823	rotten Mr. Burnsger	4	crappy	Last Available: "2016-12"
 8824	pickled yellow spinning The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	clever The Jokester's gun of the wise owl of Calamity Jane	0		Mysticality: +20, Maximum MP: +20, Critical Hit Percent: +15, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	purple executive stanky groovy The Jokester's wig	0		Moxie Percent: +10, Stench Spell Damage: +25, Meat Drop: +40, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8826	purple executive stanky groovy The Jokester's wig	0		Moxie Percent: +10, Stench Spell Damage: +25, Meat Drop: +40, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
 8827	reassuring Herculean The Jokester's pants of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Spooky Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	aerosolized super-diffused quadruple-energized upside-down Jokester makeup	0		Effect: "Egg Burps", Effect Duration: 48, Last Available: "2016-12"
 8829	jittery green replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	skewed domino mask	0		Familiar Weight: +5
-8833	moist yellow skewed robin's egg	0		Effect: "Bastard!", Effect Duration: 68, Last Available: "2016-12"
+8833	moist skewed yellow robin's egg	0		Effect: "Bastard!", Effect Duration: 68, Last Available: "2016-12"
 8834	flavorless bite-sized robin flan	1	decent	Last Available: "2016-12"
 8835	artisanal practically non-alcoholic huge robin nog	1	super ultra EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
@@ -8727,7 +8727,7 @@
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	fuchsia nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
-8858	cyan bouncing nugget of ticksilver	0		Last Available: "2016-02"
+8858	bouncing cyan nugget of ticksilver	0		Last Available: "2016-02"
 8859	blurry sinister quicksilver ring	0		Spell Damage: +10, Single Equip, Last Available: "2016-02"
 8860	bouncing avaricious ribald Lo Pan's thicksilver ring	0		Spell Critical Percent: +30, Sleaze Damage: +10, Meat Drop: +30, Single Equip, Last Available: "2016-02"
 8861	rock-hard experienced wicksilver ring of Flo-Jo	0		Experience: +2, Damage Reduction: 5, Initiative: +100, Single Equip, Last Available: "2016-02"
@@ -8754,7 +8754,7 @@
 8882	decent jumbo plate of Trader Olaf's Exotic Stinkbeans	5	good	Last Available: "2016-02"
 8883	huge delicious plate of Pork 'n' Pork 'n' Pork 'n' Beans	8	awesome	Last Available: "2016-02"
 8884	flavorless big plate of Val-U Brand Every Bean Salad	5	decent	Last Available: "2016-02"
-8885	spoiled big plate of Shrub's Premium Baked Beans	5	crappy	Last Available: "2016-02"
+8885	big spoiled plate of Shrub's Premium Baked Beans	5	crappy	Last Available: "2016-02"
 8886	sizzling Sinatra's Fancy Jeff's pocket square	0		Experience (Moxie): +5, Hot Damage: +10, Last Available: "2016-02"
 8887	Lo Pan's razor-sharp dance instructor's Daisy's unclean bloomers	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Spell Critical Percent: +30, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	tumbling Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8774,11 +8774,11 @@
 8902	unsweetened improved twirling ghost bit	0		Effect: "Comprehensively Nourished", Effect Duration: 18, Last Available: "2016-02"
 8903	non-colloidal wobbly buzzard feather	0		Effect: "Elron's Explosive Etude", Effect Duration: 24, Last Available: "2016-02"
 8904	boiled frozen lion musk	0		Effect: "Punch Another Day", Effect Duration: 46, Last Available: "2016-02"
-8905	special flavorless super-sized bear claw	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 20, Last Available: "2016-02"
+8905	flavorless super-sized special bear claw	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 20, Last Available: "2016-02"
 8906	Vulcanized rattler gland	0		Effect: "Chunky", Effect Duration: 51, Last Available: "2016-02"
 8907	colloidal denatured half-digested coal	0		Effect: "Poker Faced", Effect Duration: 35, Last Available: "2016-02"
 8908	concentrated diffused tightly-wound spine	0		Effect: "Sinuses For Miles", Effect Duration: 57, Last Available: "2016-02"
-8909	adequate miniature rotting beefsteak	2	good	Last Available: "2016-02"
+8909	miniature adequate rotting beefsteak	2	good	Last Available: "2016-02"
 8910	special delicious squat firemilk	4	awesome	Effect: "Unrunnable Face", Effect Duration: 25, Last Available: "2016-02"
 8911	frozen spidercow eye-cluster	0		Effect: "Piratastic", Effect Duration: 21, Last Available: "2016-02"
 8912	dehydrated moomy dust	1		Last Available: "2016-02"
@@ -8788,7 +8788,7 @@
 8916	spinning Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
 8918	The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
-8919	upside-down ghostly LT&T tattoo kit	0		Last Available: "2016-02"
+8919	ghostly upside-down LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	blurry Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
@@ -8816,7 +8816,7 @@
 8944	bouncing rhinestone cowhorn	0		Familiar Weight: +5
 8945	twirling cow skull	0		Last Available: "2016-02"
 8946	squat jangly spurs	0		Last Available: "2016-02"
-8947	ghostly twirling quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
+8947	twirling ghostly quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	teal thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	slicksilver spurs	0		Last Available: "2016-02"
@@ -8839,7 +8839,7 @@
 8967	upside-down horrifying nine-gallon hat of Calamity Jane	0		Critical Hit Percent: +15, Spooky Damage: +25
 8968	padded educational ten-gallon hat	0		Experience: +1, Damage Absorption: +20
 8969	toasty Van der Graaf eleven-gallon hat	0		Hot Damage: +5, MP Regen Min: 5, MP Regen Max: 7
-8970	jittery huge toy sixgun	0		
+8970	huge jittery toy sixgun	0		
 8971	snake oil	0		
 8972	Vulcanized mirror upside-down skin oil	0		Effect: "Pyramid Power", Effect Duration: 50
 8973	diffused spinning unusual oil	0		Effect: "Staying Frosty", Effect Duration: 14
@@ -8850,9 +8850,9 @@
 8978	ionized magnetized patent aggression tonic	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 13
 8979	deionized frozen bouncing twirling patent sallowness tonic	0		Effect: "Analog Drunk", Effect Duration: 55
 8980	liquefied chilled patent avarice tonic	0		Effect: "Space Cadet", Effect Duration: 63
-8981	deionized shaking mirror patent alacrity tonic	0		Effect: "Frog In Your Throat", Effect Duration: 11
+8981	deionized mirror shaking patent alacrity tonic	0		Effect: "Frog In Your Throat", Effect Duration: 11
 8982	diffused corrupted marrow	0		Effect: "License to Punch", Effect Duration: 66
-8983	tolerable weak rodeo whiskey	2	good	
+8983	weak tolerable rodeo whiskey	2	good	
 8984	Thwaitgold scorpion statuette	0		
 8985	squat fortified real cowboy hat	0		Damage Absorption: +60
 8986	Memories of Cow Punching	0		Free Pull
@@ -8899,13 +8899,13 @@
 9027	skewed Rosewater's First Post shirt - Cir Senam of the wise owl of extreme caution	0		Mysticality: +20, Mysticality Percent: +30, Monster Level: -25, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	normal super-sized star salad	5	good	
+9030	super-sized normal star salad	5	good	
 9031	bouncing Thwaitgold moth statuette	0		
-9032	small tasty bowl of Tastee-Wheet&trade;	2	awesome	
+9032	tasty small bowl of Tastee-Wheet&trade;	2	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	rotten shaking browser cookie	3	crappy	Last Available: "2016-06"
-9036	lousy enchanted hacked gibson	3	decent	Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2016-06"
+9036	enchanted lousy hacked gibson	3	decent	Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2016-06"
 9037	ruddy Source shades	0		Maximum HP Percent: +40, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	maroon missing semicolon	0		Familiar Weight: +11
@@ -8928,15 +8928,15 @@
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	wobbly Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
-9059	maroon tumbling Source terminal file: turbo.edu	0		Last Available: "2016-06"
+9059	tumbling maroon Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	huge twirling Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	huge Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
-9064	fuchsia pulsating Source terminal file: cram.ext	0		Last Available: "2016-06"
+9064	pulsating fuchsia Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	huge Source terminal file: tram.ext	0		Last Available: "2016-06"
-9067	upside-down cyan pill	0		Last Available: "2016-06"
+9067	cyan upside-down pill	0		Last Available: "2016-06"
 9068	Jeselnik's forbidden razor-sharp plastic detective badge of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +25, Spell Damage Percent: +50, Sleaze Damage: +25, Last Available: "2016-07"
 9069	up-at-dawn Fonzie's beefcake's bronze detective badge of the blizzard	0		Muscle: +25, Experience (Moxie): +1, Cold Spell Damage: +25, Adventures: +5, Last Available: "2016-07"
 9070	up-at-dawn occult detective badge of the blizzard of courage	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Spooky Resistance: +3, Adventures: +5, Last Available: "2016-07"
@@ -8947,7 +8947,7 @@
 9075	aerosolized energized red shoe gum	0		Effect: "Swordholder", Effect Duration: 50, Last Available: "2016-07"
 9076	huge avaricious rosewater-soaked noir fedora of temperance	0		Stench Resistance: +3, Sleaze Resistance: +5, Meat Drop: +30, Last Available: "2016-07"
 9077	red Annie Oakley's sinister Sinatra's trench coat	0		Experience (Moxie): +5, Spell Damage: +10, Critical Hit Percent: +20, Last Available: "2016-07"
-9078	drinkable practically non-alcoholic Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
+9078	practically non-alcoholic drinkable Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
 9079	normal hardboiled egg	4	good	Last Available: "2016-07"
 9080	pulsating detective tattoo	0		Last Available: "2016-07"
 9081	gray DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
@@ -8969,14 +8969,14 @@
 9097	avaricious fireproof deadly Liam's mail	0		Weapon Damage: +5, Hot Resistance: +3, Meat Drop: +30, Last Available: "2016-08"
 9098	fireproof Oprah's Unfortunato's foolscap of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Hot Resistance: +3, Last Available: "2016-08"
 9099	blinking blinking Thwaitgold cockroach statuette	0		
-9100	upside-down ghostly rad	0		
+9100	ghostly upside-down rad	0		
 9101	purification tablet	0		
 9102	Da Vinci's Wrist-Boy	0		Experience (Mysticality): +5
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	blinking Time-Spinner	0		Last Available: "2016-09"
 9105	compounded experience	0		Last Available: "2016-09"
-9106	twirling blue Rad-B-Gone (1 lb.)	0		
-9107	extra-energized unsweetened maroon twirling Rad-Pro (1 oz.)	0		Effect: "Takin' It Greasy", Effect Duration: 22
+9106	blue twirling Rad-B-Gone (1 lb.)	0		
+9107	extra-energized unsweetened twirling maroon Rad-Pro (1 oz.)	0		Effect: "Takin' It Greasy", Effect Duration: 22
 9108	lead umbrella	0		
 9109	moist oxidized Shrieking Weasel holo-record	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 35
 9110	oxidized alkaline enhanced Power-Guy 2000 holo-record	0		Effect: "Eyes All Black", Effect Duration: 49
@@ -8985,10 +8985,10 @@
 9113	diffused activated concentrated Superdrifter holo-record	0		Effect: "Pronounced Potency", Effect Duration: 59
 9114	improved The Pigs holo-record	0		Effect: "Engorged Weapon", Effect Duration: 66
 9115	double-flattened Drunk Uncles holo-record	0		Effect: "Antibiotic Saucesphere", Effect Duration: 55
-9116	red huge time residue	0		Last Available: "2016-09"
+9116	huge red time residue	0		Last Available: "2016-09"
 9117	prompt repaid diaper	0		Adventures: +3
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	practically non-alcoholic acceptable Shot of Kardashian Gin	1	good	Last Available: "2016-09"
+9119	acceptable practically non-alcoholic Shot of Kardashian Gin	1	good	Last Available: "2016-09"
 9120	huge Unstable Pointy Ears of James Dean	0		Experience (Moxie): +3, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
@@ -9004,31 +9004,31 @@
 9132	skewed foul-smelling pistol of incineration	0		Hot Spell Damage: +50, Stench Damage: +10
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	bland wobbly leftover pasty	3	decent	
-9135	acceptable watered-down very whiskey	2	good	
+9135	watered-down acceptable very whiskey	2	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	wobbly li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	skewed li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	maroon li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	shaking li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	wobbly li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	skewed li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	maroon li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	shaking li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	activated upside-down hoarded candy wad	0		Effect: "Antsy in your Pantsy", Effect Duration: 16, Last Available: "2016-10"
 9147	quadruple-enhanced Prunets	0		Effect: "Super Structure", Effect Duration: 43
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	improved polarized invisible string	0		Lasts Until Rollover, Effect: "Ghost Finger", Effect Duration: 27, Last Available: "2016-10"
 9151	unsweetened huge invisible seam ripper	0		Lasts Until Rollover, Effect: "Dirty Pear", Effect Duration: 50, Last Available: "2016-10"
-9152	upside-down li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	upside-down li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	flavorless low-calorie upside-down raw sweet potato	1	decent	Last Available: "2016-11"
-9154	miniature special flavorless maroon raw beans	2	decent	Effect: "Ode to Booze", Effect Duration: 15, Last Available: "2016-11"
+9154	flavorless special miniature maroon raw beans	2	decent	Effect: "Ode to Booze", Effect Duration: 15, Last Available: "2016-11"
 9155	delicious bouncing raw stuffing	3	awesome	Last Available: "2016-11"
-9156	rotten half-sized raw cranberry sauce	2	crappy	Last Available: "2016-11"
+9156	half-sized rotten raw cranberry sauce	2	crappy	Last Available: "2016-11"
 9157	toothsome raw turkey	3	awesome	Last Available: "2016-11"
 9158	thick stale raw mincemeat	5	decent	Last Available: "2016-11"
-9159	jumbo adequate raw potato	5	good	Last Available: "2016-11"
+9159	adequate jumbo raw potato	5	good	Last Available: "2016-11"
 9160	spoiled raw gravy	4	crappy	Last Available: "2016-11"
 9161	decent snack-sized raw bread	2	good	Last Available: "2016-11"
 9162	mini-marshmallow dispenser of terror of courage	0		Spooky Spell Damage: +10, Spooky Resistance: +3, Last Available: "2016-11"
@@ -9041,11 +9041,11 @@
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	yummy sweet potatoes	3	awesome	Last Available: "2016-11"
-9172	low-calorie flavorless lime green bean casserole	1	decent	Last Available: "2016-11"
-9173	decent blinking spinning baked stuffing	4	good	Last Available: "2016-11"
+9172	flavorless low-calorie lime green bean casserole	1	decent	Last Available: "2016-11"
+9173	decent spinning blinking baked stuffing	4	good	Last Available: "2016-11"
 9174	bland small cranberry cylinder	2	decent	Last Available: "2016-11"
-9175	moldy diet thanksgiving turkey	1	crappy	Last Available: "2016-11"
-9176	tiny stale maroon mince pie	1	decent	Last Available: "2016-11"
+9175	diet moldy thanksgiving turkey	1	crappy	Last Available: "2016-11"
+9176	stale tiny maroon mince pie	1	decent	Last Available: "2016-11"
 9177	small stale mashed potatoes	2	decent	Last Available: "2016-11"
 9178	adequate warm gravy	3	good	Last Available: "2016-11"
 9179	massive adequate bread roll	9	good	Last Available: "2016-11"
@@ -9053,22 +9053,22 @@
 9181	miniature stale leftovers sandwich	2	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
-9184	shaking wobbly tumbling megacopia	0		Last Available: "2016-11"
+9184	tumbling shaking wobbly megacopia	0		Last Available: "2016-11"
 9185	blurry jittery pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
-9187	bouncing wobbly cashew	0		Last Available: "2016-11"
+9187	wobbly bouncing cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	pulsating Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	extra-altered squat eldritch concentrate	0		Effect: "Provocative Perkiness", Effect Duration: 60, Last Available: "2016-11"
 9192	mediocre eldritch extract	3	decent	Last Available: "2016-11"
 9193	smartaleck's beefcake's Official Council Aide Pin	0		Muscle: +25, Moxie Percent: +30, Last Available: "2016-11"
-9194	aged triple-distilled eldritch distillate	8	awesome	Last Available: "2016-11"
-9195	compressed twirling bouncing eldritch essence	1		Last Available: "2016-11"
+9194	triple-distilled aged eldritch distillate	8	awesome	Last Available: "2016-11"
+9195	compressed bouncing twirling eldritch essence	1		Last Available: "2016-11"
 9196	blurry olive Science Notebook of courage	0		Spooky Resistance: +3
 9197	blurry teal miser's toasty medical-grade eldritch hat	0		Hot Damage: +5, Meat Drop: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-11"
 9198	padded eldritch pants of vim and vigor of Calamity Jane	0		Damage Absorption: +20, Maximum HP Percent: +50, Critical Hit Percent: +15, Last Available: "2016-11"
-9199	fancy artisanal eldritch elixir	4	EPIC	Effect: "Patent Avarice", Effect Duration: 35, Last Available: "2016-11"
+9199	artisanal fancy eldritch elixir	4	EPIC	Effect: "Patent Avarice", Effect Duration: 35, Last Available: "2016-11"
 9200	teal pulsating censurious Quartet of Flare Masters Jacket of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +3, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9089,7 +9089,7 @@
 9217	spinning gingerbread restraining order	0		Last Available: "2016-12"
 9218	pulsating mirror sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	thick adequate blurry animal part cracker	5	good	Last Available: "2016-12"
-9220	delicious triple-distilled gingerbread wine	6	awesome	Last Available: "2016-12"
+9220	triple-distilled delicious gingerbread wine	6	awesome	Last Available: "2016-12"
 9221	bland gingerbread mug	3	decent	Last Available: "2016-12"
 9222	bouncing nippy gingerbread mask	0		Cold Damage: +10, Last Available: "2016-12"
 9223	censurious smooth gingerservo of mayonnaise	0		Moxie: +15, Sleaze Spell Damage: +50, Sleaze Resistance: +3, Single Equip, Last Available: "2016-12"
@@ -9102,7 +9102,7 @@
 9230	jittery educational creme brulee torch	0		Experience: +1, Lasts Until Rollover, Last Available: "2016-12"
 9231	resourceful candy crowbar	0		Maximum MP: +50, Lasts Until Rollover, Last Available: "2016-12"
 9232	horrifying toasty candy screwdriver	0		Hot Damage: +5, Spooky Damage: +25, Last Available: "2016-12"
-9233	olive skewed gingerbread dog treat	0		Last Available: "2016-12"
+9233	skewed olive gingerbread dog treat	0		Last Available: "2016-12"
 9234	greasy pumpkin spice candle	0		Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-12"
 9235	denatured teal gingerbread spice latte	0		Effect: "Warm Belly", Effect Duration: 51, Last Available: "2016-12"
 9236	greedy careful gingerbread gavel	0		Monster Level: -10, Meat Drop: +20, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	polymerized skewed green industrial frosting	0		Effect: "Sugar, Hello", Effect Duration: 17, Last Available: "2016-12"
 9242	non-altered polymerized fake cocktail	0		Effect: "Colorful Gratitude", Effect Duration: 43, Last Available: "2016-12"
-9243	spirit-forward hand-crafted high-end ginger wine	5	EPIC	Last Available: "2016-12"
+9243	hand-crafted spirit-forward high-end ginger wine	5	EPIC	Last Available: "2016-12"
 9244	shaking blinking plastic bad vibe of the sewer	0		Stench Damage: +25, Last Available: "2016-12"
 9245	padded plastic angry vikings	0		Damage Absorption: +20, Last Available: "2016-12"
 9246	plastic Knows About Chakras of the brazier	0		Hot Spell Damage: +25, Last Available: "2016-12"
@@ -9123,8 +9123,8 @@
 9251	galvanized galvanized purple Inner Truth	0		Effect: "Flame-Retardant Trousers", Effect Duration: 49, Last Available: "2016-12"
 9252	rotten spiritual candy cane	4	crappy	Last Available: "2016-12"
 9253	perfectly mixed boozy spiritual eggnog	5	EPIC	Last Available: "2016-12"
-9254	half-sized decent fancy spiritual fruitcake	2	good	Effect: "Egg Burps", Effect Duration: 15, Last Available: "2016-12"
-9255	immense spoiled spiritual gingerbread	8	crappy	Last Available: "2016-12"
+9254	fancy half-sized decent spiritual fruitcake	2	good	Effect: "Egg Burps", Effect Duration: 15, Last Available: "2016-12"
+9255	spoiled immense spiritual gingerbread	8	crappy	Last Available: "2016-12"
 9256	blinking chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9135,7 +9135,7 @@
 9263	red gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	red briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
-9266	double-tarnished spinning twirling rock candy	0		Effect: "Broberry Brotality", Effect Duration: 65, Last Available: "2016-12"
+9266	double-tarnished twirling spinning rock candy	0		Effect: "Broberry Brotality", Effect Duration: 65, Last Available: "2016-12"
 9267	flavorless jumbo green-iced sweet roll	5	decent	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	narrow chocolate sculpture	0		Last Available: "2016-12"
@@ -9145,11 +9145,11 @@
 9273	pulsating stiffened Third Eye	0		Damage Reduction: 1, Item Drop: +5, Last Available: "2016-12"
 9274	lightning-fast Krampus Horn of the boozehound	0		Booze Drop: +100, Initiative: +40, Single Equip, Last Available: "2016-12"
 9275	massive normal narrow hambrosier	10	good	Last Available: "2016-12"
-9276	bad practically non-alcoholic chakra-mental wine	1	decent	Last Available: "2016-12"
-9277	ionized skewed wobbly chakra malt	0		Effect: "Dragged Through the Coals", Effect Duration: 53, Last Available: "2016-12"
+9276	practically non-alcoholic bad chakra-mental wine	1	decent	Last Available: "2016-12"
+9277	ionized wobbly skewed chakra malt	0		Effect: "Dragged Through the Coals", Effect Duration: 53, Last Available: "2016-12"
 9278	stale Black Angus blackburger	4	decent	Last Available: "2016-12"
 9279	aged brandy	3	awesome	Last Available: "2016-12"
-9280	denatured enhanced maroon pulsating potion of spiritual gunkifying	0		Effect: "Human-Constellation Hybrid", Effect Duration: 65, Last Available: "2016-12"
+9280	denatured enhanced pulsating maroon potion of spiritual gunkifying	0		Effect: "Human-Constellation Hybrid", Effect Duration: 65, Last Available: "2016-12"
 9281	deadly bad vibroknife of the businessman	0		Weapon Damage: +5, Meat Drop: +50, Last Available: "2016-12"
 9282	bouncing Jeselnik's Herculean crystal belt buckle	0		Experience (Muscle): +1, Sleaze Damage: +25, Last Available: "2016-12"
 9283	upside-down saffron antaravasaka of the brute of the boozehound	0		Muscle Percent: +30, Booze Drop: +100, Last Available: "2016-12"
@@ -9166,7 +9166,7 @@
 9294	pickled bouncing sleaze jelly	1		Last Available: "2017-01"
 9295	dried pulsating stench jelly	1		Effect: "Jingle Jangle Jingle", Effect Duration: 35, Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	half-sized toothsome toast with hot jelly	2	awesome	Last Available: "2017-01"
+9297	toothsome half-sized toast with hot jelly	2	awesome	Last Available: "2017-01"
 9298	bland toast with jelly	4	decent	Last Available: "2017-01"
 9299	yummy big toast with jelly	5	awesome	Last Available: "2017-01"
 9300	tiny adequate toast with sleaze jelly	1	good	Last Available: "2017-01"
@@ -9176,17 +9176,17 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	flame-wreathed wax hand of the blizzard	0		Cold Spell Damage: +25, Hot Spell Damage: +10, Last Available: "2017-01"
 9306	blue foul-smelling candle of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +10, Lasts Until Rollover, Last Available: "2017-01"
-9307	thick adequate bouncing wax pancake	5	good	Last Available: "2017-01"
+9307	adequate thick bouncing wax pancake	5	good	Last Available: "2017-01"
 9308	energetic wax face of mayonnaise	0		Maximum MP Percent: +20, Sleaze Spell Damage: +50, Last Available: "2017-01"
 9309	weak artisanal twirling wax booze	2	EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	distilled huge fuchsia blinking sea jelly	1		Last Available: "2017-01"
-9312	adequate immense sea truffle	8	good	Last Available: "2017-01"
+9311	distilled fuchsia blinking huge sea jelly	1		Last Available: "2017-01"
+9312	immense adequate sea truffle	8	good	Last Available: "2017-01"
 9313	lime green tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	educational recovered cufflinks	0		Experience: +1, Single Equip, Last Available: "2017-01"
 9316	upside-down heart-shaped crate	0		Free Pull, Last Available: "2017-02"
-9317	electrified blurry twirling LOV Elixir #3	0		Effect: "Boletus Swoletus", Effect Duration: 48, Last Available: "2017-02"
+9317	electrified twirling blurry LOV Elixir #3	0		Effect: "Boletus Swoletus", Effect Duration: 48, Last Available: "2017-02"
 9318	diffused ghostly LOV Elixir #6	0		Effect: "Block-Rockin' Beet", Effect Duration: 39, Last Available: "2017-02"
 9319	pickled Vulcanized electrified LOV Elixir #9	0		Effect: "Dexteri Tea", Effect Duration: 47, Last Available: "2017-02"
 9320	huge knitted brainy LOV Eardigan of the sewer	0		Mysticality: +5, Stench Damage: +25, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2017-02"
@@ -9199,7 +9199,7 @@
 9327	greasy LOV Elephant	0		Sleaze Spell Damage: +10, Damage Reduction: 6, Last Available: "2017-02"
 9328	miser's eldritch scanner	0		Meat Drop: +10, Last Available: "2017-02"
 9329	energized eldritch alignment spray	0		Effect: "Night of the Nachos", Effect Duration: 22, Last Available: "2017-02"
-9330	blurry yellow shaking LOV Entrance Pass	0		Last Available: "2017-02"
+9330	shaking blurry yellow LOV Entrance Pass	0		Last Available: "2017-02"
 9331	toasty eldritch hammer of the cougar of doom	0		Moxie: +20, Hot Damage: +5, Spooky Spell Damage: +50, Last Available: "2017-01"
 9332	half-sized normal eldritch mushroom	2	good	Last Available: "2017-03"
 9333	eldritch ichor	0		
@@ -9241,14 +9241,14 @@
 9369	aged watered-down pulsating mentholated wine	2	awesome	Last Available: "2017-03"
 9370	bad ghostly low tide martini	4	decent	Last Available: "2017-03"
 9371	acceptable watered-down shroomtini	2	good	Last Available: "2017-03"
-9372	bad practically non-alcoholic blurry morning dew	1	decent	Last Available: "2017-03"
+9372	practically non-alcoholic bad blurry morning dew	1	decent	Last Available: "2017-03"
 9373	boozy lousy whiskey squeeze	5	decent	Last Available: "2017-03"
 9374	distilled acceptable great fashioned	5	good	Last Available: "2017-03"
-9375	watered-down mediocre Gnomish sagngria	2	decent	Last Available: "2017-03"
-9376	practically non-alcoholic delicious vodka stinger	1	awesome	Last Available: "2017-03"
-9377	acceptable fortified extremely slippery nipple	5	good	Last Available: "2017-03"
+9375	mediocre watered-down Gnomish sagngria	2	decent	Last Available: "2017-03"
+9376	delicious practically non-alcoholic vodka stinger	1	awesome	Last Available: "2017-03"
+9377	fortified acceptable extremely slippery nipple	5	good	Last Available: "2017-03"
 9378	tolerable piscatini	4	good	Last Available: "2017-03"
-9379	hand-crafted high-proof Churchill	9	EPIC	Last Available: "2017-03"
+9379	high-proof hand-crafted Churchill	9	EPIC	Last Available: "2017-03"
 9380	delicious soilzerac	3	awesome	Last Available: "2017-03"
 9381	watered-down aged London frog	2	awesome	Last Available: "2017-03"
 9382	mediocre nothingtini	3	decent	Last Available: "2017-03"
@@ -9261,14 +9261,14 @@
 9389	watered-down hand-crafted moreltini	2	EPIC	Last Available: "2017-03"
 9390	lousy hell in a bucket	3	decent	Last Available: "2017-03"
 9391	acceptable Newark	3	good	Last Available: "2017-03"
-9392	triple-distilled acceptable tumbling tumbling R'lyeh	7	good	Last Available: "2017-03"
+9392	acceptable triple-distilled tumbling tumbling R'lyeh	7	good	Last Available: "2017-03"
 9393	perfectly mixed blurry Gnollish sangria	4	EPIC	Last Available: "2017-03"
 9394	hand-crafted vodka barracuda	3	EPIC	Last Available: "2017-03"
-9395	hand-crafted distilled Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
+9395	distilled hand-crafted Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
 9396	perfectly mixed drive-by shooting	4	EPIC	Last Available: "2017-03"
 9397	mediocre jittery wobbly gunner's daughter	4	decent	Last Available: "2017-03"
 9398	tolerable wobbly dirt julep	4	good	Last Available: "2017-03"
-9399	high-proof mediocre Simepore slime	9	decent	Last Available: "2017-03"
+9399	mediocre high-proof Simepore slime	9	decent	Last Available: "2017-03"
 9400	artisanal Phil Collins	4	EPIC	Last Available: "2017-03"
 9401	olive wobbly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	ghostly toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9278,9 +9278,9 @@
 9406	tumbling exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	narrow rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9409	teal pulsating high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9409	pulsating teal high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
-9411	mirror fuchsia alien rock sample	0		Last Available: "2017-04"
+9411	fuchsia mirror alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9297,12 +9297,12 @@
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	powdered huge yellow alien animal goo	1		Last Available: "2017-04"
+9428	powdered yellow huge alien animal goo	1		Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	huge spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	altered unsweetened green alien medicine	0		Effect: "On the Shoulders of Giants", Effect Duration: 69, Last Available: "2017-04"
-9433	rotten tiny alien salad	1	crappy	Last Available: "2017-04"
+9433	tiny rotten alien salad	1	crappy	Last Available: "2017-04"
 9434	mediocre watered-down alien booze	2	decent	Last Available: "2017-04"
 9435	hardy alien mask of the ox	0		Muscle: +20, Maximum HP: +50, Item Drop: +5, Last Available: "2017-04"
 9436	huge lard-coated alien spear of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Sleaze Spell Damage: +25, Last Available: "2017-04"
@@ -9336,26 +9336,26 @@
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	bland Aldebaran sardines	4	decent	Last Available: "2017-04"
-9467	irresponsibly strong mediocre twirling Centauri fish wine	7	decent	Last Available: "2017-04"
+9467	mediocre irresponsibly strong twirling Centauri fish wine	7	decent	Last Available: "2017-04"
 9468	dehydrated oxygen	1		Last Available: "2017-04"
 9469	spinning wobbly prompt rosy-cheeked Spacegate scientist's insignia	0		Maximum HP Percent: +30, Adventures: +3, Single Equip, Last Available: "2017-04"
 9470	wobbly MacGyver's supercharged Spacegate military insignia	0		Maximum MP Percent: +30, Maximum MP: +100, Single Equip, Last Available: "2017-04"
 9471	grievous deadly groovy Spacegate diplomat's insignia	0		Moxie Percent: +10, Weapon Damage: +5, Weapon Damage Percent: +50, Single Equip, Last Available: "2017-04"
 9472	olive Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	bouncing Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	flavorless big alien sandwich	5	decent	Last Available: "2017-04"
+9474	big flavorless alien sandwich	5	decent	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	anodized Spant eggs	0		Effect: "Wallflowering", Effect Duration: 38
 9477	red Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	oxidized upside-down blinking Daily Affirmation: Always be Collecting	0		Effect: "Hare-o-dynamic", Effect Duration: 43, Last Available: "2017-05"
 9480	boiled gray Daily Affirmation: Think Win-Lose	0		Effect: "Dirty Pear", Effect Duration: 64, Last Available: "2017-05"
-9481	enhanced upside-down narrow Daily Affirmation: Be Superficially interested	0		Effect: "Impregnabili Tea", Effect Duration: 27, Last Available: "2017-05"
+9481	enhanced narrow upside-down Daily Affirmation: Be Superficially interested	0		Effect: "Impregnabili Tea", Effect Duration: 27, Last Available: "2017-05"
 9482	polarized narrow Daily Affirmation: Adapt to Change Eventually	0		Effect: "Crud&eacute;", Effect Duration: 69, Last Available: "2017-05"
 9483	wet galvanized jittery Daily Affirmation: Be a Mind Master	0		Effect: "Tiki Temerity", Effect Duration: 54, Last Available: "2017-05"
 9484	alkaline corrupted enhanced spinning wobbly Daily Affirmation: Work For Hours a Week	0		Effect: "Cat Class, Cat Style", Effect Duration: 16, Last Available: "2017-05"
 9485	frozen electrified spinning Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Demonic Taint", Effect Duration: 21, Last Available: "2017-05"
-9486	half-sized rotten bouncing Affirmation Cookie	2	crappy	Last Available: "2017-05"
+9486	rotten half-sized bouncing Affirmation Cookie	2	crappy	Last Available: "2017-05"
 9487	huge License To Kill	0		
 9488	skewed Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
@@ -9364,7 +9364,7 @@
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	frightening careful Kremlin's Greatest Briefcase of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: -10, Spooky Damage: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	aged blurry basic martini	3	awesome	Last Available: "2017-06"
-9495	watered-down delicious bouncing improved martini	2	awesome	Last Available: "2017-06"
+9495	delicious watered-down bouncing improved martini	2	awesome	Last Available: "2017-06"
 9496	hand-crafted lime green splendid martini	3	EPIC	Last Available: "2017-06"
 9497	teal exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,7 +9384,7 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	red Meteorite-Ade	0		Last Available: "2017-08"
 9514	special tasty meteoreo	4	awesome	Effect: "Pop-eyed", Effect Duration: 5, Last Available: "2017-08"
-9515	hand-crafted distilled meadeorite	5	EPIC	Last Available: "2017-08"
+9515	distilled hand-crafted meadeorite	5	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	huge nasty MacGyver's hardy meteortarboard	0		Maximum HP: +50, Maximum MP: +100, Stench Damage: +5, Last Available: "2017-08"
 9518	sinister Da Vinci's Newton's meteorite guard	0		Experience (Mysticality): 8, Spell Damage: +10, Damage Reduction: 9, Last Available: "2017-08"
@@ -9395,17 +9395,17 @@
 9523	narrow meteoroid	0		Last Available: "2017-08"
 9524	meteor shower cap	0		Familiar Weight: +5
 9525	blinking Thwaitgold time fly statuette	0		
-9526	squat blurry perfectly fair coin	0		Last Available: "2017-11"
+9526	blurry squat perfectly fair coin	0		Last Available: "2017-11"
 9527	Horsery contract	0		Free Pull, Last Available: "2018-08"
-9528	purple blurry corked genie bottle	0		Free Pull, Last Available: "2017-09"
+9528	blurry purple corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	genie bottle	0		Last Available: "2017-09"
 9530	greedy double-paned grievous blessed rustproof +2 gray dragon scale mail	0		Weapon Damage Percent: +50, Cold Resistance: +5, Meat Drop: +20, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	pony: Shutterfly	0		Last Available: "2017-09"
 9533	narrow pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
-9535	jittery maroon pony: Rosey Cake	0		Last Available: "2017-09"
-9536	wobbly bouncing pony: Spectrum Dash	0		Last Available: "2017-09"
+9535	maroon jittery pony: Rosey Cake	0		Last Available: "2017-09"
+9536	bouncing wobbly pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
 9538	shaking dropped scrap of paper	0		
 9539	hunk of granite	0		
@@ -9421,7 +9421,7 @@
 9549	decent Hide-rox&trade; cookie	3	good	Last Available: "2017-10"
 9550	tolerable weak jug of booze	2	good	Last Available: "2017-10"
 9551	irradiated pair of candy glasses	0		Effect: "Thunderspell", Effect Duration: 22, Last Available: "2017-10"
-9552	chilled flattened blurry skewed spinning temporary X tattoos	0		Effect: "Livin' Large", Effect Duration: 68, Last Available: "2017-10"
+9552	chilled flattened blurry spinning skewed temporary X tattoos	0		Effect: "Livin' Large", Effect Duration: 68, Last Available: "2017-10"
 9553	diluted huge jittery glyph of athleticism	1		Effect: "Infernal Thirst", Effect Duration: 35, Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	polarized new habit	0		Effect: "Grrrrrrreat!", Effect Duration: 53, Last Available: "2017-10"
@@ -9453,8 +9453,8 @@
 9581	artisanal neg grog	3	EPIC	Last Available: "2017-12"
 9582	toothsome half double fruitcake	4	awesome	Last Available: "2017-12"
 9583	fancy moldy yellow narrow hushed puppy	4	crappy	Effect: "Proprie Tea", Effect Duration: 40, Last Available: "2017-12"
-9584	flavorless small muffled muffuletta	2	decent	Last Available: "2017-12"
-9585	miniature toothsome shushed potatoes	2	awesome	Last Available: "2017-12"
+9584	small flavorless muffled muffuletta	2	decent	Last Available: "2017-12"
+9585	toothsome miniature shushed potatoes	2	awesome	Last Available: "2017-12"
 9586	gravedigger's plastic mime functionary	0		Spooky Damage: +10, Last Available: "2017-12"
 9587	perfumed plastic mime scientist	0		Stench Resistance: +5, Last Available: "2017-12"
 9588	Lo Pan's plastic mime soldier	0		Spell Critical Percent: +30, Last Available: "2017-12"
@@ -9464,7 +9464,7 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	awesome	Last Available: "2017-11"
 9594	wet wishbone	0		Effect: "Slimily Speedy", Effect Duration: 41, Last Available: "2017-11"
-9595	drinkable practically non-alcoholic Racisto Ruidoso	1	good	Last Available: "2017-11"
+9595	practically non-alcoholic drinkable Racisto Ruidoso	1	good	Last Available: "2017-11"
 9596	pulsating mirror earthenware muffin tin	0		
 9597	flavorless bran muffin	3	decent	
 9598	moldy special teal blueberry muffin	3	crappy	Effect: "Human-Humanoid Hybrid", Effect Duration: 30
@@ -9483,16 +9483,16 @@
 9611	olive silent M	0		Last Available: "2017-12"
 9612	silent N	0		Last Available: "2017-12"
 9613	silent O	0		Last Available: "2017-12"
-9614	squat blinking silent P	0		Last Available: "2017-12"
+9614	blinking squat silent P	0		Last Available: "2017-12"
 9615	silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
-9620	blinking narrow silent V	0		Last Available: "2017-12"
+9620	narrow blinking silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
-9623	spinning upside-down silent Y	0		Last Available: "2017-12"
+9623	upside-down spinning silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
 9625	green crystalline cheer	0		Last Available: "2017-12"
 9626	twirling anti-earplugs	0		Last Available: "2017-12"
@@ -9507,7 +9507,7 @@
 9635	The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	shaking The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
-9638	red shaking The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
+9638	shaking red The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	olive The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
@@ -9518,9 +9518,9 @@
 9646	twirling The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	skewed mime eraser	0		Last Available: "2017-12"
 9648	acceptable watered-down executive mime flask	2	good	Last Available: "2017-12"
-9649	low-calorie adequate nega-mushroom	1	good	Last Available: "2017-12"
+9649	adequate low-calorie nega-mushroom	1	good	Last Available: "2017-12"
 9650	drinkable nega-mushroom wine	3	good	Last Available: "2017-12"
-9651	warmed flattened polarized upside-down bouncing Cheer-Up soda	0		Effect: "familiar.enq", Effect Duration: 52, Last Available: "2017-12"
+9651	warmed flattened polarized bouncing upside-down Cheer-Up soda	0		Effect: "familiar.enq", Effect Duration: 52, Last Available: "2017-12"
 9652	tasty diet mime army rations	1	awesome	Last Available: "2017-12"
 9653	weak drinkable mime army wine	2	good	Last Available: "2017-12"
 9654	compressed spinning mime army superserum	1		Last Available: "2017-12"
@@ -9543,7 +9543,7 @@
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	jittery mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
-9674	ghostly blinking mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
+9674	blinking ghostly mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	clever personal trainer's mime army infiltration glove	0		Experience Percent (Muscle): +10, Maximum MP: +20, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
 9677	mime army challenge coin	0		Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	twirling fireproof skip lid	0		Familiar Weight: +5
 9681	rotten ghostly extra-toasted half sandwich	4	crappy	Last Available: "2018-12"
-9682	acceptable strong mulled hobo wine	5	good	Last Available: "2018-12"
+9682	strong acceptable mulled hobo wine	5	good	Last Available: "2018-12"
 9683	fuchsia burning newspaper	0		Last Available: "2018-12"
 9684	narrow sharpshooter's smartaleck's weightlifter's burning paper hat	0		Muscle: +15, Moxie Percent: +30, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2018-12"
 9685	Lo Pan's Van der Graaf burning cape of the glutton	0		Spell Critical Percent: +30, Food Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2018-12"
@@ -9593,8 +9593,8 @@
 9725	prompt chaotic psychic's pslacks	0		Spell Critical Percent: +10, Adventures: +3, Last Available: "2018-02"
 9726	resourceful arcane researcher's psychic's amulet	0		Experience Percent (Mysticality): +10, Maximum MP: +50, Last Available: "2018-02"
 9727	bland heart-shaped candy whetstone	3	decent	Last Available: "2018-02"
-9728	diet normal Swedish massage fish	1	good	Last Available: "2018-02"
-9729	bad watered-down mirror Third Base	2	decent	Last Available: "2018-02"
+9728	normal diet Swedish massage fish	1	good	Last Available: "2018-02"
+9729	watered-down bad mirror Third Base	2	decent	Last Available: "2018-02"
 9730	drinkable distilled Bustle Hustler	5	good	Last Available: "2018-02"
 9731	oxidized boiled Fabiotion	0		Effect: "Spirit of Alph", Effect Duration: 45, Last Available: "2018-02"
 9732	energized ghostly Bettie page	0		Effect: "Billiards Belligerence", Effect Duration: 32, Last Available: "2018-02"
@@ -9625,7 +9625,7 @@
 9757	healthy Mu cap	0		Maximum HP Percent: +20
 9758	Thwaitgold metabug statuette	0		
 9759	olive Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
-9760	upside-down bouncing packet of tall grass seeds	0		Last Available: "2018-03"
+9760	bouncing upside-down packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	spinning Globmule	0		Last Available: "2018-03"
 9763	yellow Bluzzard	0		Last Available: "2018-03"
@@ -9647,13 +9647,13 @@
 9779	Gorillape	0		Last Available: "2018-03"
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	green Snoutlet	0		Last Available: "2018-03"
-9782	lime green pulsating tumbling Ruffalo	0		Last Available: "2018-03"
+9782	pulsating tumbling lime green Ruffalo	0		Last Available: "2018-03"
 9783	blinking Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
-9788	bouncing spinning Ched	0		Last Available: "2018-03"
+9788	spinning bouncing Ched	0		Last Available: "2018-03"
 9789	gray Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	maroon Bicycle	0		Last Available: "2018-03"
@@ -9718,7 +9718,7 @@
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
-9853	shaking fuchsia poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
+9853	fuchsia shaking poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	tumbling to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	spinning flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	wobbly map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	adequate thick denastified haunch	5	good	Last Available: "2018-04"
+9878	thick adequate denastified haunch	5	good	Last Available: "2018-04"
 9879	bad bad rum and good cola	3	decent	Last Available: "2018-04"
 9880	magnetized Potion of Heroism	0		Effect: "Wolf's Bane", Effect Duration: 62, Last Available: "2018-04"
 9881	energetic groovy leggings of the Spider Queen of the scaredy-cat	0		Moxie Percent: +10, Maximum MP Percent: +20, Monster Level: -15, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	olive dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	ghostly tumbling notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	artisanal two meat muck	3	EPIC	
-9899	tasty enchanted chocolate Ogre Chieftain	3	awesome	Effect: "Dirty Pear", Effect Duration: 45
+9899	enchanted tasty chocolate Ogre Chieftain	3	awesome	Effect: "Dirty Pear", Effect Duration: 45
 9900	rotten chocolate &quot;Phoenix&quot;	3	crappy	
 9901	fancy flavorless bouncing chocolate Spider Queen	4	decent	Effect: "Experimental Effect G-9", Effect Duration: 10
 9902	practically non-alcoholic hand-crafted hipster cocktail	1	super ultra mega turbo EPIC	
-9903	squat narrow God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	skewed mirror teal God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	wobbly God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	narrow squat God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Last Available: "2018-05", Equips On: "God Lobster"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Last Available: "2018-05", Equips On: "God Lobster"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
+9906	mirror teal skewed God Lobster's Robe	0		Familiar Effect: "block", Last Available: "2018-05", Equips On: "God Lobster"
+9907	wobbly God Lobster's Crown	0		Familiar Effect: "fairy", Last Available: "2018-05", Equips On: "God Lobster"
 9908	ghostly Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	fuchsia G	0		
 9910	Garland of Greatness	0		
@@ -9787,10 +9787,10 @@
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	blinking huge SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	jittery A Guide to Safari	0		Skill: "Experience Safari"
-9922	ionized shaking skewed Shielding Potion	0		Effect: "Cosmic Flavor", Effect Duration: 58, Last Available: "2018-06"
+9922	ionized skewed shaking Shielding Potion	0		Effect: "Cosmic Flavor", Effect Duration: 58, Last Available: "2018-06"
 9923	non-cold-filtered pickled Punching Potion	0		Effect: "A Few Extra Pounds", Effect Duration: 51, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	vaporized shaking skewed maroon Nightmare Fuel	1		Effect: "Go-Gone", Effect Duration: 35, Last Available: "2018-06"
+9925	vaporized skewed maroon shaking Nightmare Fuel	1		Effect: "Go-Gone", Effect Duration: 35, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	squat Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9812,8 +9812,8 @@
 9944	asbestos-lined hale Fonzie's PARTY HARD T-shirt	0		Experience (Moxie): +1, Maximum HP: +20, Hot Resistance: +5, Last Available: "2018-09"
 9945	shaking Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
-9947	bouncing blurry gas can	0		Last Available: "2018-09"
-9948	bad weak Middle of the Road&trade; brand whiskey	2	decent	Last Available: "2018-09"
+9947	blurry bouncing gas can	0		Last Available: "2018-09"
+9948	weak bad Middle of the Road&trade; brand whiskey	2	decent	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	blinking mansplainer's groovy pentagram bandana	0		Moxie Percent: +10, Monster Level: +15, Last Available: "2018-09"
 9951	gravedigger's skull ring	0		Spooky Damage: +10, Single Equip, Last Available: "2018-09"
@@ -9837,15 +9837,15 @@
 9969	aromatic mansplainer's denim jacket	0		Monster Level: +15, Stench Resistance: +1, Last Available: "2018-09"
 9970	pulsating dance instructor's ratty knitted cap of the overflowing toilet	0		Experience Percent (Moxie): +10, Stench Spell Damage: +50, Last Available: "2018-09"
 9972	skewed veiny intimidating chainsaw of horror	0		Maximum HP: +10, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-09"
-9973	mediocre practically non-alcoholic enchanted party beer bomb	1	decent	Effect: "Salamanderenity", Effect Duration: 45, Last Available: "2018-09"
+9973	practically non-alcoholic enchanted mediocre party beer bomb	1	decent	Effect: "Salamanderenity", Effect Duration: 45, Last Available: "2018-09"
 9974	normal sweet party mix	4	good	Last Available: "2018-09"
 9975	compressed party balloon	1		Last Available: "2018-09"
 9976	therapeutic thinker's party pants	0		Mysticality: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-09"
 9977	party whip of the brute of the empath of mayonnaise	0		Muscle Percent: +30, Familiar Weight: +5, Sleaze Spell Damage: +50, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	delicious irresponsibly strong TRIO cup of beer	10	awesome	Last Available: "2018-09"
-9980	super-sized adequate party platter for one	5	good	Last Available: "2018-09"
-9981	dehydrated maroon skewed skewed Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9979	irresponsibly strong delicious TRIO cup of beer	10	awesome	Last Available: "2018-09"
+9980	adequate super-sized party platter for one	5	good	Last Available: "2018-09"
+9981	dehydrated skewed skewed maroon Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	olive chaotic Herculean party crasher	0		Experience (Muscle): +1, Spell Critical Percent: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	tumbling Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
@@ -9873,18 +9873,18 @@
 10007	zippy energetic Fonzie's mutant arm	0		Experience (Moxie): +1, Maximum MP Percent: +20, Initiative: +20, Last Available: "2018-11"
 10008	wool therapeutic ruddy mutant legs	0		Maximum HP Percent: +40, Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-11"
 10009	gravedigger's educational mutant crown of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Spooky Damage: +10, Last Available: "2018-11"
-10010	half-sized stale purple wobbly ghostly ectoplasm	2	decent	Last Available: "2018-11"
-10011	bland miniature	2	decent	Last Available: "2018-11"
+10010	stale half-sized wobbly purple ghostly ectoplasm	2	decent	Last Available: "2018-11"
+10011	miniature bland	2	decent	Last Available: "2018-11"
 10012	drinkable bottle of vodka	3	good	Last Available: "2018-11"
 10013	flavorless skewed pizza	4	decent	Last Available: "2018-11"
 10014	watered-down perfectly mixed mirror martini	2	EPIC	Last Available: "2018-11"
 10015	moldy huge cherry pie	3	crappy	Last Available: "2018-11"
-10016	drinkable upside-down bouncing eggnog	4	good	Last Available: "2018-11"
+10016	drinkable bouncing upside-down eggnog	4	good	Last Available: "2018-11"
 10017	jittery glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	normal small Hell ramen	2	good	Last Available: "2018-11"
 10019	hand-crafted gimlet	3	EPIC	Last Available: "2018-11"
 10020	lousy ghostly twice-haunted screwdriver	3	decent	Last Available: "2018-11"
-10021	moldy super-sized candy cane	5	crappy	Last Available: "2018-12"
+10021	super-sized moldy candy cane	5	crappy	Last Available: "2018-12"
 10022	delicious runny fermented egg	3	awesome	Last Available: "2018-12"
 10023	moldy oldcake	3	crappy	Last Available: "2018-12"
 10024	rotten wobbly traditional Crimbo cookie	4	crappy	Last Available: "2023-06"
@@ -9906,7 +9906,7 @@
 10040	toothsome diet moosemeat pie	1	awesome	Last Available: "2018-12"
 10041	steel-toed balanced antler	0		Damage Reduction: 9, Last Available: "2018-12"
 10042	huge inspector's dam	0		Item Drop: +15, Damage Reduction: 9, Last Available: "2018-12"
-10043	mediocre weak narrow jittery beavermouth	2	decent	Last Available: "2018-12"
+10043	weak mediocre narrow jittery beavermouth	2	decent	Last Available: "2018-12"
 10044	high-proof drinkable beaver punch (papaya)	8	good	Last Available: "2018-12"
 10045	mediocre beaver punch (peach)	4	decent	Last Available: "2018-12"
 10046	artisanal teal beaver punch (cherry)	4	EPIC	Last Available: "2018-12"
@@ -9933,7 +9933,7 @@
 10067	immense yummy yule gruel	10	awesome	Last Available: "2018-12"
 10068	boozy aged hot watered rum	5	awesome	Last Available: "2018-12"
 10069	tolerable bottle of Crimbognac	3	good	Last Available: "2018-12"
-10070	snack-sized stale Crimboysters Rockefeller	2	decent	Last Available: "2018-12"
+10070	stale snack-sized Crimboysters Rockefeller	2	decent	Last Available: "2018-12"
 10071	dried ghostly Crimbeau de toilette	1		Effect: "Feelin' Philosophical", Effect Duration: 30, Last Available: "2018-12"
 10072	squat upside-down Crimbo candle	0		Last Available: "2018-12"
 10073	tumbling Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9943,7 +9943,7 @@
 10077	shaking Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	mirror knitted coward's Crimbolex watch of the dark arts	0		Spell Damage Percent: +100, Monster Level: -20, Cold Resistance: +3, Single Equip, Last Available: "2018-12"
-10080	olive bouncing Crimbo tattoo kit	0		Last Available: "2018-12"
+10080	bouncing olive Crimbo tattoo kit	0		Last Available: "2018-12"
 10081	jittery boxer's beefy hand-knitted Crimbo socks of the ox	0		Muscle: 30, Muscle Percent: +10
 10082	Newton's chalk chlamys of the sewer	0		Experience (Mysticality): +3, Stench Damage: +25, Last Available: "2019-12"
 10083	occult chalk chain of horror	0		Spell Damage Percent: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2019-12"
@@ -9960,14 +9960,14 @@
 10094	beefy marble medallion of temperance	0		Muscle: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2019-12"
 10095	lion tamer's sage marble mariachi hat	0		Mysticality Percent: +10, Experience (familiar): +2, Last Available: "2019-12"
 10096	dried ghostly red marble molecules	1		Last Available: "2019-12"
-10097	irradiated quantum green tumbling Mallomarbles	0		Effect: "Ice Packed", Effect Duration: 22
+10097	irradiated quantum tumbling green Mallomarbles	0		Effect: "Ice Packed", Effect Duration: 22
 10098	blinking foul-smelling shellacked punching bag	0		Damage Reduction: 7, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10099	chaotic beefcake's pith helmet	0		Muscle: +25, Spell Critical Percent: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10100	Oprah's poncho of the scaredy-cat	0		Maximum MP Percent: +50, Monster Level: -15, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10101	auspicious chaotic pendant	0		Spell Critical Percent: +10, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10102	yellow palazzos of the pedagogue of the bloodbag	0		Experience: +3, Maximum HP: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10103	gravedigger's MacGyver's pseudoaccordion	0		Maximum MP: +100, Spooky Damage: +10, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10104	distilled mirror shaking pieces	1		Last Available: "2020-12"
+10104	distilled shaking mirror pieces	1		Last Available: "2020-12"
 10105	colloidal Para-Pop	0		Effect: "Stimulated Brain", Effect Duration: 64
 10106	deadly terra cotta truss of doom	0		Weapon Damage: +5, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10107	jittery dog trainer's terra cotta trousers of Leguizamo	0		Monster Level: +20, Experience (familiar): +1, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
@@ -9983,7 +9983,7 @@
 10117	asbestos-lined velour viscometer of the bloodbag	0		Maximum HP: +100, Hot Resistance: +5, Single Equip, Last Available: "2021-12"
 10118	scandalous Annie Oakley's velour valise	0		Critical Hit Percent: +20, Sleaze Damage: +5, Last Available: "2021-12"
 10119	ghostly studded smooth velour vaqueros	0		Moxie: +15, Damage Absorption: +80, Last Available: "2021-12"
-10120	dehydrated fuchsia twirling velour veneer	1		Effect: "Yeah, It's Just Gasoline", Effect Duration: 10, Last Available: "2021-12"
+10120	dehydrated twirling fuchsia velour veneer	1		Effect: "Yeah, It's Just Gasoline", Effect Duration: 10, Last Available: "2021-12"
 10121	vacuum-sealed Velougats&trade;	0		Effect: "Jungle Juiced", Effect Duration: 25
 10122	supercool glass suspenders of the boozehound	0		Moxie Percent: +20, Booze Drop: +100, Single Equip, Last Available: "2021-12"
 10123	knitted foul-smelling glass shield	0		Stench Damage: +10, Cold Resistance: +3, Damage Reduction: 7, Last Available: "2021-12"
@@ -10015,7 +10015,7 @@
 10149	adjusted jittery tin thermos of chai	0		Effect: "Healthy Green Glow", Effect Duration: 59, Last Available: "2019-12"
 10150	twisted prototype stimulant	1		Last Available: "2019-12"
 10151	olive tailored vest of the businessman	0		Meat Drop: +50, Lasts Until Rollover, Last Available: "2019-12"
-10152	green shaking sew-on bandage	0		Last Available: "2019-12"
+10152	shaking green sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	therapeutic elf army poncho	0		HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2019-12"
 10155	flavorless big squat squat elf army field rations	5	decent	Last Available: "2019-12"
@@ -10033,7 +10033,7 @@
 10168	blood bag	0		
 10169	immense decent bloodstick	6	good	
 10170	acceptable weak bottle of Sanguiovese	2	good	
-10171	snack-sized rotten actual blood sausage	2	crappy	
+10171	rotten snack-sized actual blood sausage	2	crappy	
 10172	delicious watered-down green mulled blood	2	awesome	
 10173	adequate blood snowcone	3	good	
 10174	hand-crafted boozy huge Red Russian	5	EPIC	
@@ -10045,7 +10045,7 @@
 10180	squat Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
-10183	ghostly skewed money bag	0		
+10183	skewed ghostly money bag	0		
 10184	ghostly Thwaitgold mosquito statuette	0		
 10185	bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
@@ -10063,9 +10063,9 @@
 10198	red blurry Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	spoiled crabsicle	4	crappy	Last Available: "2019-04"
 10200	tumbling melty plastic grenade	0		Last Available: "2019-04"
-10201	tolerable high-proof bottle of dark rhum	9	good	Last Available: "2019-04"
+10201	high-proof tolerable bottle of dark rhum	9	good	Last Available: "2019-04"
 10202	perfectly mixed spinning bottle of extra-dark rhum	3	EPIC	Last Available: "2019-04"
-10203	triple-distilled drinkable blinking shaking bottle of super-extra-dark rhum	10	good	Last Available: "2019-04"
+10203	drinkable triple-distilled blinking shaking bottle of super-extra-dark rhum	10	good	Last Available: "2019-04"
 10204	extra-vacuum-sealed super-activated skewed pirate shaving cream	0		Effect: "Amorous", Effect Duration: 34, Last Available: "2019-04"
 10205	toasty hardened conquistador's breastplate	0		Damage Reduction: 3, Hot Damage: +5, Last Available: "2019-04"
 10206	miser's wholesome pirate pantaloons	0		Maximum HP Percent: +10, Meat Drop: +10, Last Available: "2019-04"
@@ -10075,13 +10075,13 @@
 10210	maroon perfumed smooth pirate radio ring	0		Moxie: +15, Stench Resistance: +5, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	huge normal pineapple slab	9	good	Last Available: "2019-04"
-10213	half-sized flavorless bouncing hibiscus petal	2	decent	Last Available: "2019-04"
+10213	flavorless half-sized bouncing hibiscus petal	2	decent	Last Available: "2019-04"
 10214	extra-dry boiled huge mint leaf	0		Effect: "You're Not Cooking", Effect Duration: 29, Last Available: "2019-04"
 10215	blue cocoa of youth	0		Last Available: "2019-04"
 10216	altered shaking ice molecule	1		Last Available: "2019-04"
 10217	skewed Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
-10219	spinning maroon Red Roger's left hand	0		Last Available: "2019-04"
+10219	maroon spinning Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
@@ -10089,19 +10089,19 @@
 10224	teal twirling Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	olive pulsating knitted plush sea serpent	0		Cold Resistance: +3, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	yummy small shaking pirate fork	2		Last Available: "2019-04"
+10227	small yummy shaking pirate fork	2		Last Available: "2019-04"
 10228	tumbling Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	purple ring	0		Single Equip, Last Available: "2019-04"
 10230	rosy-cheeked baleful piratical blunderbuss	0		Spell Damage: +25, Maximum HP Percent: +30, Last Available: "2019-04"
 10231	Annie Oakley's razor-sharp thinker's PirateRealm party hat	0		Mysticality: +10, Weapon Damage Percent: +25, Critical Hit Percent: +20, Last Available: "2019-04"
 10232	drinkable weak Island Landslide	2	good	Last Available: "2019-04"
 10233	bad spirit-forward fancy Island Thunderstorm	5	decent	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 15, Last Available: "2019-04"
-10234	drinkable enchanted Island Hurricane	4	good	Effect: "Extra-Wet", Effect Duration: 45, Last Available: "2019-04"
-10235	artisanal practically non-alcoholic jittery Skull Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10234	enchanted drinkable Island Hurricane	4	good	Effect: "Extra-Wet", Effect Duration: 45, Last Available: "2019-04"
+10235	practically non-alcoholic artisanal jittery Skull Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10236	bad Electric Punch	3	decent	Last Available: "2019-04"
-10237	extra-dry drinkable Smuggler's Punch	5	good	Last Available: "2019-04"
-10238	aged practically non-alcoholic gray jittery Scorpion Bowl	1	awesome	Last Available: "2019-04"
-10239	watered-down artisanal blinking Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10237	drinkable extra-dry Smuggler's Punch	5	good	Last Available: "2019-04"
+10238	aged practically non-alcoholic jittery gray Scorpion Bowl	1	awesome	Last Available: "2019-04"
+10239	artisanal watered-down blinking Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10240	acceptable spirit-forward Cobra Bowl	5	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	wobbly ghostly dog trainer's dangerous cool brainy vampyric cloake of the cheetah	0		Mysticality: +5, Moxie: +5, Weapon Damage: +10, Experience (familiar): +1, Initiative: +60, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
@@ -10165,10 +10165,10 @@
 10300	gray double-paned manspreader's whittled owl figurine of terror	0		Monster Level: +10, Spooky Spell Damage: +10, Cold Resistance: +5, Single Equip, Last Available: "2019-08"
 10301	wobbly Annie Oakley's vibrating whittled fox figurine of the scaredy-cat	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Monster Level: -15, Single Equip, Last Available: "2019-08"
 10302	greedy wicked sage whittled walking stick of the detective	0		Mysticality Percent: +10, Spell Damage: +5, Item Drop: +20, Meat Drop: +20, Last Available: "2019-08"
-10303	special adequate super-sized campfire hot dog	5	good	Effect: "Elemental Flavor", Effect Duration: 5, Last Available: "2019-08"
-10304	rotten snack-sized skewed campfire baked potato	2	crappy	Last Available: "2019-08"
-10305	miniature normal lime green narrow twirling campfire s'more	2	good	Last Available: "2019-08"
-10306	moldy miniature campfire beans	2	crappy	Last Available: "2019-08"
+10303	special super-sized adequate campfire hot dog	5	good	Effect: "Elemental Flavor", Effect Duration: 5, Last Available: "2019-08"
+10304	snack-sized rotten skewed campfire baked potato	2	crappy	Last Available: "2019-08"
+10305	miniature normal narrow twirling lime green campfire s'more	2	good	Last Available: "2019-08"
+10306	miniature moldy campfire beans	2	crappy	Last Available: "2019-08"
 10307	bland campfire stew	4	decent	Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	anodized nitrogenated leftover chocolate bar	0		Effect: "Ancestral Disapproval", Effect Duration: 54
@@ -10193,8 +10193,8 @@
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	twirling diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	normal miniature bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
-10338	huge delicious bouncing flan del mar	7	awesome	Last Available: "2019-12"
+10337	miniature normal bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
+10338	delicious huge bouncing flan del mar	7	awesome	Last Available: "2019-12"
 10339	adequate Baja sopapilla	4	good	Last Available: "2019-12"
 10340	curative plastic Mer-kin baker	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10341	lard-coated plastic sea elf	0		Sleaze Spell Damage: +25, Last Available: "2019-12"
@@ -10203,7 +10203,7 @@
 10344	Rosewater's plastic Dolph Bossin	0		Mysticality Percent: +30, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	normal mana-coated yams	3	good	Last Available: "2019-11"
-10347	spoiled small teal mana-basted tofurkey leg	2	crappy	Last Available: "2019-11"
+10347	small spoiled teal mana-basted tofurkey leg	2	crappy	Last Available: "2019-11"
 10348	flavorless immense mirror mana-fortified cranberry sauce	6	decent	Last Available: "2019-11"
 10349	decent mana-stuffed herbal stuffing	4	good	Last Available: "2019-11"
 10350	maroon human musk	0		Last Available: "2019-12"
@@ -10211,13 +10211,13 @@
 10352	dried blinking industrial lubricant	1		Effect: "Booooooze", Effect Duration: 50, Last Available: "2019-12"
 10353	altered warmed unfinished pleasure	0		Effect: "Mint-Condition Breath", Effect Duration: 58, Last Available: "2019-12"
 10354	altered skewed narrow vial of humanoid growth hormone	1		Last Available: "2019-12"
-10355	powdered cyan ghostly a bug's lymph	1		Effect: "White Blooded", Effect Duration: 10, Last Available: "2019-12"
+10355	powdered ghostly cyan a bug's lymph	1		Effect: "White Blooded", Effect Duration: 10, Last Available: "2019-12"
 10356	polymerized wet tarnished mirror organic potpourri	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 38, Last Available: "2019-12"
 10357	artisanal mirror boot flask	4	EPIC	Last Available: "2019-12"
 10358	enhanced flattened infernal snowball	0		Effect: "Buff as a Baobab", Effect Duration: 41, Last Available: "2019-12"
 10359	twirling madness	0		Last Available: "2019-12"
 10360	dehydrated fish sauce	1		Effect: "Greasy Visage", Effect Duration: 25, Last Available: "2019-12"
-10361	decent miniature enchanted guffin	2	good	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2019-12"
+10361	decent enchanted miniature guffin	2	good	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2019-12"
 10362	boiled Shantix&trade;	1		Effect: "Boon of the Storm Tortoise", Effect Duration: 25, Last Available: "2019-12"
 10363	ghostly goodberry	0		Last Available: "2019-12"
 10364	mixed huge non-Euclidean angle	1		Effect: "Seeing Colors", Effect Duration: 50, Last Available: "2019-12"
@@ -10246,15 +10246,15 @@
 10387	purple intact anemone spike	0		Last Available: "2019-12"
 10388	razor-sharp anemoney clip	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2019-12"
 10389	runny icing	0		Last Available: "2019-12"
-10390	vaporized lime green wobbly super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	vaporized wobbly lime green super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	hardened razor-sharp icing poncho of incineration	0		Weapon Damage Percent: +25, Damage Reduction: 3, Hot Spell Damage: +50, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	alkaline dry yellow glob of salty molasses	0		Effect: "One For Tea", Effect Duration: 23, Last Available: "2019-12"
 10394	Mer-kin rollpin of Calamity Jane of the overflowing toilet	0		Critical Hit Percent: +15, Stench Spell Damage: +50, Last Available: "2019-12"
-10395	shaking yellow personalizable gingerbread cookie	0		Last Available: "2019-12"
-10396	upside-down wobbly red tinsel fin	0		Familiar Weight: +5
-10397	yummy low-calorie bowl of mernudo	1	awesome	Last Available: "2019-12"
-10398	extra-dry smooth fishelada	5	awesome	Last Available: "2019-12"
+10395	yellow shaking personalizable gingerbread cookie	0		Last Available: "2019-12"
+10396	red upside-down wobbly tinsel fin	0		Familiar Weight: +5
+10397	low-calorie yummy bowl of mernudo	1	awesome	Last Available: "2019-12"
+10398	smooth extra-dry fishelada	5	awesome	Last Available: "2019-12"
 10399	normal miniature wobbly ojo de pez burrito	2	good	Last Available: "2019-12"
 10400	pulsating waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10293,14 +10293,14 @@
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	yellow zippy dog trainer's hardened Powerful Glove of the blizzard of bravery	0		Damage Reduction: 3, Experience (familiar): +1, Cold Spell Damage: +25, Spooky Resistance: +5, Initiative: +20, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
-10439	upside-down blurry enhanced signal receiver	0		
+10439	blurry upside-down enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	double-paned veiny brawny Drip harness	0		Muscle Percent: +20, Maximum HP: +10, Cold Resistance: +5
 10442	drippy truncheon of extreme caution	0		Monster Level: -25, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	decent small drippy nugget	2	drippy	
-10446	strong hand-crafted glass of drippy wine	5	drippy	
+10446	hand-crafted strong glass of drippy wine	5	drippy	
 10447	flavorless drippy caviar	3	drippy	
 10448	decent drippy plum(?)	3	drippy	
 10449	blinking stiffened drippy stake	0		Damage Reduction: 1, Single Equip
@@ -10312,23 +10312,23 @@
 10455	purple mushroom	0		
 10456	deluxe mushroom	0		
 10457	gray super deluxe mushroom	0		
-10458	magnetized aerosolized pulsating olive fizzy soda	0		Effect: "Motion", Effect Duration: 59
+10458	magnetized aerosolized olive pulsating fizzy soda	0		Effect: "Motion", Effect Duration: 59
 10459	non-energized wet healthy juice	0		Effect: "Dreams and Lights", Effect Duration: 38
 10460	hammer	0		
 10461	hammer	0		
 10462	fuchsia fire flower	0		
-10463	squat wobbly teal bonfire flower	0		
+10463	teal squat wobbly bonfire flower	0		
 10464	spinning work boots	0		Single Equip
 10465	boots	0		Single Equip
 10466	cool cape	0		Moxie: +5
 10467	spinning family-friendly asbestos-lined back shell	0		Hot Resistance: +5, Sleaze Resistance: +1
 10468	huge maroon spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
-10470	pulsating shaking Thwaitgold buzzy beetle statuette	0		
+10470	shaking pulsating Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
 10472	dance instructor's bony back shell	0		Experience Percent (Moxie): +10
 10473	frosty button	0		Single Equip
-10474	super-energized pulsating lime green blooper ink	0		Effect: "Milk Studly", Effect Duration: 16
+10474	super-energized lime green pulsating blooper ink	0		Effect: "Milk Studly", Effect Duration: 16
 10475	coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
@@ -10385,7 +10385,7 @@
 10529	squat lustrous drippy orb	0		
 10530	ghostly Sinatra's gory drippy orb	0		Experience (Moxie): +5
 10531	annealed drippy orb	0		
-10532	wobbly blue Guzzlr application	0		Free Pull
+10532	blue wobbly Guzzlr application	0		Free Pull
 10533	nasty shellacked Guzzlr tablet	0		Damage Reduction: 7, Stench Damage: +5, Last Available: "2020-05"
 10534	narrow Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
@@ -10396,8 +10396,8 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	artisanal weak Ghiaccio Colada	2	EPIC	Last Available: "2020-05"
 10542	smooth skewed Sourfinger	4	awesome	Last Available: "2020-05"
-10543	lousy extra-dry Nog-on-the-Cob	5	decent	Last Available: "2020-05"
-10544	drinkable blurry twirling Steamboat	3	good	Last Available: "2020-05"
+10543	extra-dry lousy Nog-on-the-Cob	5	decent	Last Available: "2020-05"
+10544	drinkable twirling blurry Steamboat	3	good	Last Available: "2020-05"
 10545	triple-distilled smooth lime green Buttery Boy	7	awesome	Last Available: "2020-05"
 10546	mirror Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	baleful clown car key of terror	0		Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2020-08"
@@ -10462,7 +10462,7 @@
 10606	anodized colloidal vacuum-sealed yellow Yeg's Motel toothbrush	0		Effect: "Appeteyes", Effect Duration: 27, Last Available: "2020-09"
 10607	quadruple-frozen maroon Yeg's Motel hand soap	0		Effect: "Quadrilled", Effect Duration: 56, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	low-calorie stale Yeg's Motel pillow mint	1	decent	Last Available: "2020-09"
+10609	stale low-calorie Yeg's Motel pillow mint	1	decent	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	colloidal wobbly Yeg's Motel mouthwash	0		Effect: "Loyal Tea", Effect Duration: 26, Last Available: "2020-09"
 10612	olive Yeg's Motel shower cap of the sweet-tooth of the glutton	0		Candy Drop: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2020-09"
@@ -10472,7 +10472,7 @@
 10616	Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
-10619	twirling maroon uncanny desk bell	0		Last Available: "2020-09"
+10619	maroon twirling uncanny desk bell	0		Last Available: "2020-09"
 10620	olive nasty desk bell	0		Last Available: "2020-09"
 10621	squat greasy desk bell	0		Last Available: "2020-09"
 10622	wobbly chess set	0		Last Available: "2020-09"
@@ -10538,7 +10538,7 @@
 10682	modified maroon prescription teeth whitener	0		Effect: "Towering Strength", Effect Duration: 47, Last Available: "2020-12"
 10683	aerosolized non-oxidized shaking imported lemon lozenge	0		Effect: "Strong Grip", Effect Duration: 22, Last Available: "2020-12"
 10684	enhanced hermedisiac cologne	0		Effect: "Frisky Spirit", Effect Duration: 18, Last Available: "2020-12"
-10685	mirror cyan government food shipment	0		Last Available: "2020-12"
+10685	cyan mirror government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
@@ -10573,9 +10573,9 @@
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	squat nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	smooth watered-down barrel-aged eggnog	2	awesome	Last Available: "2020-12"
+10720	watered-down smooth barrel-aged eggnog	2	awesome	Last Available: "2020-12"
 10721	decent half-sized special hand-crafted candy cane	2	good	Effect: "Cold, Dead Hands", Effect Duration: 45, Last Available: "2020-12"
-10722	tasty big purple drive-thru burger	5	awesome	Last Available: "2020-12"
+10722	big tasty purple drive-thru burger	5	awesome	Last Available: "2020-12"
 10723	hand-crafted practically non-alcoholic Boulevardier cocktail	1	EPIC	Last Available: "2020-12"
 10724	pressed tarnished jittery wobbly Hotwire&trade; brand candy rope	0		Effect: "Fiery Spirit", Effect Duration: 65, Last Available: "2020-12"
 10725	stale bowl full of jelly	4	decent	Last Available: "2020-12"
@@ -10600,7 +10600,7 @@
 10744	magnetized blue battery (car)	0		Effect: "Puzzle Fury", Effect Duration: 60, Last Available: "2021-03"
 10745	fuchsia cryptocloak	0		Last Available: "2025-12"
 10746	purple marshmallow	0		
-10747	weak tolerable marshmallow bomb	2	good	Last Available: "2021-03"
+10747	tolerable weak marshmallow bomb	2	good	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	lime green shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10629,9 +10629,9 @@
 10773	Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	dry skewed Scent of a Human&trade; candle	0		Effect: "Stop and Smell the Fudge", Effect Duration: 68, Last Available: "2021-08"
 10775	liquefied The Beast Within&trade; candle	0		Effect: "Lemony Goodness", Effect Duration: 29, Last Available: "2021-08"
-10776	boiled tumbling bouncing Salsa Caliente&trade; candle	0		Effect: "White Blooded", Effect Duration: 23, Last Available: "2021-08"
+10776	boiled bouncing tumbling Salsa Caliente&trade; candle	0		Effect: "White Blooded", Effect Duration: 23, Last Available: "2021-08"
 10777	chilled Smoldering Clover&trade; candle	0		Effect: "Ancestral Disapproval", Effect Duration: 35, Last Available: "2021-08"
-10778	alkaline gray jittery blinking Napalm In The Morning&trade; candle	0		Effect: "Fitter, Happier", Effect Duration: 52, Last Available: "2021-08"
+10778	alkaline jittery gray blinking Napalm In The Morning&trade; candle	0		Effect: "Fitter, Happier", Effect Duration: 52, Last Available: "2021-08"
 10779	lime green Jack Frost's rosy-cheeked extra-large utility candle	0		Maximum HP Percent: +30, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 10780	chilly runed taper candle of wisdom	0		Mysticality: +15, Cold Damage: +5, Lasts Until Rollover, Last Available: "2021-08"
 10781	smelly healthy novelty sparkling candle of Gandalf	0		Maximum HP Percent: +20, Spell Critical Percent: +20, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-08"
@@ -10660,8 +10660,8 @@
 10804	auspicious supercharged veiny Daylight Shavings Helmet	0		Maximum HP: +10, Maximum MP Percent: +30, Item Drop: +10, Last Available: "2021-11"
 10805	eggwater	1	awesome	Last Available: "2021-12"
 10806	adequate bread man	3	good	Last Available: "2021-12"
-10807	immense normal skewed plain candy cane	6	good	Last Available: "2021-12"
-10808	decent diet enchanted narrow ghostly flour cookie	1	good	Effect: "Fungal Fortification", Effect Duration: 5, Last Available: "2021-12"
+10807	normal immense skewed plain candy cane	6	good	Last Available: "2021-12"
+10808	diet decent enchanted ghostly narrow flour cookie	1	good	Effect: "Fungal Fortification", Effect Duration: 5, Last Available: "2021-12"
 10809	plastic food lab of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2021-12"
 10811	wobbly scorching plastic chem lab	0		Hot Damage: +25, Single Equip, Last Available: "2021-12"
@@ -10678,12 +10678,12 @@
 10822	flavorless bone broth	4	decent	Last Available: "2021-12"
 10823	bite-sized adequate star pop	1	good	Last Available: "2021-12"
 10824	artisanal weak green Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
-10825	watered-down perfectly mixed mirror Doc's Smartifying Wine	2	EPIC	Last Available: "2021-12"
+10825	perfectly mixed watered-down mirror Doc's Smartifying Wine	2	EPIC	Last Available: "2021-12"
 10826	mediocre Doc's Limbering Wine	4	decent	Last Available: "2021-12"
 10827	perfectly mixed watered-down Doc's Medical-Grade Wine	2	EPIC	Last Available: "2021-12"
 10828	modified Homebodyl&trade;	1		Effect: "Held Closer", Effect Duration: 30, Last Available: "2021-12"
 10829	pickled Extrovermectin&trade;	1		Last Available: "2021-12"
-10830	mixed shaking ghostly Breathitin&trade;	1		Effect: "Cat Class, Cat Style", Effect Duration: 50, Last Available: "2021-12"
+10830	mixed ghostly shaking Breathitin&trade;	1		Effect: "Cat Class, Cat Style", Effect Duration: 50, Last Available: "2021-12"
 10831	pickled ghostly ghostly Fleshazole&trade;	1		Last Available: "2021-12"
 10832	quadruple-diffused anti-burn cream	0		Effect: "Oh Snap", Effect Duration: 58, Last Available: "2021-12"
 10833	energized ionized double-wet purple anti-freeze cream	0		Effect: "The Moxie of LOV", Effect Duration: 26, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	corrupted wet narrow anti-creep cream	0		Effect: "Crusty Head", Effect Duration: 68, Last Available: "2021-12"
 10837	extra-nitrogenated upside-down anti-pain cream	0		Effect: "Nightlit", Effect Duration: 29, Last Available: "2021-12"
 10838	mediocre irresponsibly strong Doc's Special Reserve Wine	6	decent	Last Available: "2021-12"
-10839	adequate immense bread pie	8	good	Last Available: "2021-12"
+10839	immense adequate bread pie	8	good	Last Available: "2021-12"
 10840	lousy clear Russian	3	decent	Last Available: "2021-12"
 10841	yellow shaking zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	spinning goo magnet	0		Last Available: "2021-12"
 10851	cozy scarf of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2021-12"
-10852	normal special immense huge Crimbo cookie	10	good	Effect: "Afternoon Insight", Effect Duration: 45, Last Available: "2023-06"
+10852	special normal immense huge Crimbo cookie	10	good	Effect: "Afternoon Insight", Effect Duration: 45, Last Available: "2023-06"
 10853	ionized activated fleshy putty	0		Effect: "Cancer Rising", Effect Duration: 68, Last Available: "2021-12"
 10854	cyan tumbling third ear of the detective	0		Item Drop: +20, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10728,7 +10728,7 @@
 10872	savvy pants	0		Mysticality Percent: +20, Last Available: "2021-12"
 10873	upside-down miser's Oprah's savvy can of mixed everything	0		Mysticality Percent: +20, Maximum MP Percent: +50, Meat Drop: +10, Last Available: "2021-12"
 10874	tumbling Site Alpha ID badge	0		Familiar Weight: +5
-10875	cyan shaking ghostly the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10875	shaking cyan ghostly the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	moldy meatball	3	crappy	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	twirling meatball machine	0		Last Available: "2021-12"
@@ -10739,11 +10739,11 @@
 10883	altered squat astral energy drink	1		Effect: "Saucemastery", Effect Duration: 40
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	flame-wreathed lion tamer's resourceful magnifying glass	0		Maximum MP: +50, Experience (familiar): +2, Hot Spell Damage: +10, Last Available: "2022-12"
-10886	watered-down bad shaking blinking void lager	2	decent	Last Available: "2022-12"
+10886	bad watered-down blinking shaking void lager	2	decent	Last Available: "2022-12"
 10887	gigantic moldy void burger	7	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	Jeselnik's toasty supercharged savvy void shard	0		Mysticality Percent: +20, Maximum MP Percent: +30, Hot Damage: +5, Sleaze Damage: +25, Last Available: "2022-12"
-10890	shaking wobbly undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
+10890	wobbly shaking undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	shaking cosmic bowling ball	0		Last Available: "2022-01"
 10892	purple combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	manspreader's combat lover's locket	0		Monster Level: +10, Single Equip, Last Available: "2022-02"
@@ -10767,7 +10767,7 @@
 10911	diffused gaffer's tape	0		Effect: "Fireproof Lips", Effect Duration: 30, Last Available: "2022-05"
 10912	half-sized delicious 20-lb can of rice and beans	2	awesome	Last Available: "2022-05"
 10913	ghostly bar of freeze-dried water	1	awesome	Last Available: "2022-05"
-10914	small fancy decent expired MRE	2	good	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2022-05"
+10914	small decent fancy expired MRE	2	good	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2022-05"
 10915	moldy wobbly cool mint precipice bar	4	crappy	Last Available: "2022-05"
 10916	spoiled tumbling carrot cake precipice bar	3	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
@@ -10777,12 +10777,12 @@
 10921	bad Dad's brandy	4	decent	Last Available: "2022-06"
 10922	ghostly zippy teacher's pen of the sweet-tooth	0		Candy Drop: +100, Initiative: +20, Last Available: "2022-06"
 10923	adequate fire-roasted lake trout	3	good	Last Available: "2022-06"
-10924	bland diet guilty sprout	1	decent	Last Available: "2022-06"
+10924	diet bland guilty sprout	1	decent	Last Available: "2022-06"
 10925	hardened mother's necklace of chilblains	0		Damage Reduction: 3, Cold Damage: +25, Last Available: "2022-06"
 10926	alkaline frozen trampled ticket stub	0		Effect: "Banono", Effect Duration: 65, Last Available: "2022-06"
 10927	wet savings bond	0		Effect: "Medieval Mage Mayhem", Effect Duration: 67, Last Available: "2022-06"
 10928	skewed designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
 10930	altered narrow sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10809,7 +10809,7 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	quantum polymerized autumn leaf	0		Effect: "Trash-Wrapped", Effect Duration: 14, Last Available: "2022-10"
-10956	enchanted boozy hand-crafted AutumnFest ale	5	EPIC	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2022-10"
+10956	hand-crafted enchanted boozy AutumnFest ale	5	EPIC	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2022-10"
 10957	squat aromatic Van der Graaf autumn sweater-weather sweater of the pedagogue	0		Experience: +3, Stench Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2022-10"
 10958	mirror Tesla Van der Graaf deadly cool autumn debris shield	0		Moxie: +5, Weapon Damage: +5, MP Regen Min: 12, MP Regen Max: 17, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	normal bite-sized autumn-spice donut	1	good	Last Available: "2022-10"
@@ -10818,7 +10818,7 @@
 10962	altered skewed autumn breeze	1		Last Available: "2022-10"
 10963	vacuum-sealed ionized autumn years wisdom	0		Effect: "Be a Mind Master", Effect Duration: 28, Last Available: "2022-10"
 10964	spinning familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	aged distilled special twirling Oopsie IPA	5	awesome	Effect: "Cravin' for a Ravin'", Effect Duration: 35, Last Available: "2022-10"
+10965	aged special distilled twirling Oopsie IPA	5	awesome	Effect: "Cravin' for a Ravin'", Effect Duration: 35, Last Available: "2022-10"
 10966	cyan mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10827,7 +10827,7 @@
 10971	snack-sized adequate Jarlsberg's vegetable soup	2	good	Last Available: "2022-11"
 10972	immense toothsome shaking pulsating roasted vegetable of Jarlsberg	8	awesome	Last Available: "2022-11"
 10973	spoiled St. Pete's sneaky smoothie	4	crappy	Last Available: "2022-11"
-10974	decent jumbo huge wobbly Pete's wiley whey bar	5	good	Last Available: "2022-11"
+10974	decent jumbo wobbly huge Pete's wiley whey bar	5	good	Last Available: "2022-11"
 10975	spoiled Pete's rich ricotta	3	crappy	Last Available: "2022-11"
 10976	distilled perfectly mixed blue ghostly Boris's beer	5	EPIC	Last Available: "2022-11"
 10977	thick special spoiled upside-down honey bun of Boris	5	crappy	Effect: "Dancing Prowess", Effect Duration: 40, Last Available: "2022-11"
@@ -10841,14 +10841,14 @@
 10985	purple Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
 10986	mirror Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
-10988	low-calorie moldy skewed baked veggie ricotta casserole	1	crappy	Last Available: "2022-11"
-10989	decent half-sized plain calzone	2	good	Last Available: "2022-11"
+10988	moldy low-calorie skewed baked veggie ricotta casserole	1	crappy	Last Available: "2022-11"
+10989	half-sized decent plain calzone	2	good	Last Available: "2022-11"
 10990	flavorless fancy roasted vegetable focaccia	4	decent	Effect: "Smokin'", Effect Duration: 40, Last Available: "2022-11"
 10991	stale pulsating Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	moldy Calzone of Legend	3	crappy	Last Available: "2022-11"
-10993	maroon skewed Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10993	skewed maroon Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
 10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	wobbly twirling Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10995	twirling wobbly Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
 10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
 10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	upside-down cookbookbat book	0		Familiar Weight: +5
@@ -10866,11 +10866,11 @@
 11010	bland maroon swamp haunch	3	decent	
 11011	spinning friendly chaotic gator shades	0		Spell Critical Percent: +10, Familiar Weight: +3, Single Equip
 11012	shaking milk cap	0		
-11013	watered-down lousy Charleston Choo-Choo	2	decent	
-11014	bad watered-down Velvet Veil	2	decent	
-11015	watered-down lousy spinning Marltini	2	decent	
+11013	lousy watered-down Charleston Choo-Choo	2	decent	
+11014	watered-down bad Velvet Veil	2	decent	
+11015	lousy watered-down spinning Marltini	2	decent	
 11016	weak hand-crafted Strong, Silent Type	2	EPIC	
-11017	mediocre practically non-alcoholic teal Mysterious Stranger	1	decent	
+11017	practically non-alcoholic mediocre teal Mysterious Stranger	1	decent	
 11018	mediocre Champagne Shimmy	3	decent	
 11019	the Sot's parcel	0		
 11020	censurious hardened ceramic cestus	0		Damage Reduction: 3, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10920,27 +10920,27 @@
 11064	double-paned scandalous wholesome shoulder-mounted Trainbot	0		Maximum HP Percent: +10, Sleaze Damage: +5, Cold Resistance: +5, Single Equip, Last Available: "2022-12"
 11065	blue cinnamon machine oil	0		
 11066	shaking Crimbo crystal shards	0		
-11067	high-proof mediocre dregs of a Crimbo cocktail	10	decent	
+11067	mediocre high-proof dregs of a Crimbo cocktail	10	decent	
 11068	lost elf luggage	0		
 11069	blurry Trainbot luggage hook	0		Single Equip
 11070	decent honey-drenched ham slice	3	good	
-11071	lousy practically non-alcoholic bouncing mostly-empty bottle of cookie wine	1	decent	
+11071	practically non-alcoholic lousy bouncing mostly-empty bottle of cookie wine	1	decent	
 11072	decent Crimbo food scraps	3	good	
 11073	bouncing arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	snack-sized toothsome huge steamed oyster	2	awesome	
+11078	toothsome snack-sized huge steamed oyster	2	awesome	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	weak tolerable Crimbosmopolitan	2	good	Last Available: "2022-12"
-11085	bland gigantic twirling Crimbo dinner	10	decent	Last Available: "2022-12"
+11085	gigantic bland twirling Crimbo dinner	10	decent	Last Available: "2022-12"
 11086	teal overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
-11087	olive upside-down spinning train whistle	0		Last Available: "2022-12"
+11087	spinning olive upside-down train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	blinking half-height cigar	0		Familiar Weight: +5
@@ -10955,16 +10955,16 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	twirling packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	dried skewed narrow cyan fruity pebble	1		Effect: "Human-Pirate Hybrid", Effect Duration: 5, Last Available: "2023-01"
+11102	dried cyan narrow skewed fruity pebble	1		Effect: "Human-Pirate Hybrid", Effect Duration: 5, Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
-11105	bouncing purple bolder boulder	0		Last Available: "2023-01"
+11105	purple bouncing bolder boulder	0		Last Available: "2023-01"
 11106	pulsating molehill mountain	0		Last Available: "2023-01"
 11107	blinking whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	blinking stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	delicious super-sized spinning tumbling pixel bread	5	awesome	
+11112	delicious super-sized tumbling spinning pixel bread	5	awesome	
 11113	mediocre pixel whiskey	4	decent	
 11114	pixel rock	0		
 11115	squat S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -11016,10 +11016,10 @@
 11161	yellow twirling Usain Bolt's studded medallion of the cougar	0		Moxie: +20, Damage Absorption: +80, Initiative: +80
 11162	stanky uncursed medallion	0		Stench Spell Damage: +25
 11163	Advanced Pig Skinning	0		
-11164	blurry lime green The Cheese Wizard's Companion	0		
+11164	lime green blurry The Cheese Wizard's Companion	0		
 11165	Jazz Agent sheet music	0		
 11166	Thwaitgold anti-moth statuette	0		
-11167	lime green blinking shadowy cheat sheet	0		Free Pull
+11167	blinking lime green shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
 11169	spinning closed-circuit pay phone	0		
 11170	shadow lighter	0		
@@ -11044,12 +11044,12 @@
 11189	squat upside-down replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
-11192	twirling shaking replica crimbo elfling	0		
+11192	shaking twirling replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	huge replica wax lips	0		Experience: +3
-11197	spinning blue replica Tome of Snowcone Summoning	0		
+11197	blue spinning replica Tome of Snowcone Summoning	0		
 11198	dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	grievous smartaleck's wizardly replica jewel-eyed wizard hat	0		Mysticality: +25, Moxie Percent: +30, Weapon Damage Percent: +50, Conditional Skill (Equipped): "Magic Missile"
 11200	blinking miser's frightening replica bottle-rocket crossbow of the sweet-tooth	0		Spooky Damage: +5, Meat Drop: +10, Candy Drop: +100, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
@@ -11060,7 +11060,7 @@
 11205	replica cotton candy cocoon	0		
 11206	bouncing extremely unsafe Samson's beefcake's replica Elvish sunglasses of the cougar	0		Muscle: +25, Moxie: +20, Experience (Muscle): +5, Weapon Damage Percent: +100, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
-11208	wobbly narrow replica stone sphere	0		
+11208	narrow wobbly replica stone sphere	0		
 11209	blinking wholesome stiffened replica Greatest American Pants of James Dean	0		Experience (Moxie): +3, Damage Reduction: 1, Maximum HP Percent: +10
 11210	squat replica organ grinder	0		
 11211	nippy educational replica Juju Mojo Mask of the overflowing toilet	0		Experience: +1, Cold Damage: +10, Stench Spell Damage: +50, Single Equip
@@ -11073,7 +11073,7 @@
 11218	ghostly replica Apathargic Bandersnatch	0		
 11219	replica Smith's Tome	0		
 11220	narrow replica over-the-shoulder Folder Holder	0		
-11221	purple upside-down replica Order of the Green Thumb Order Form	0		
+11221	upside-down purple replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	tumbling sizzling dog trainer's Cincho de Mayo of the wise owl of the empath	0		Mysticality: +20, Familiar Weight: +5, Experience (familiar): +1, Hot Damage: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	teal dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	stylish replica Jurassic Parka of bravery	0		Moxie: +25, Spooky Resistance: +5
 11250	gray replica grey gosling	0		
-11251	pulsating pulsating replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	pulsating pulsating replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	mirror blue replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	olive replica Ten Dollars	0		
 11254	zippy nippy medical-grade replica Cincho de Mayo of the detective	0		Cold Damage: +10, Item Drop: +20, Initiative: +20, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11122,7 +11122,7 @@
 11267	coward's chaotic Amulet of Perpetual Darkness of bravery of the glutton	0		Spell Critical Percent: +10, Monster Level: -20, Spooky Resistance: +5, Food Drop: +100, Last Available: "2023-06"
 11268	wobbly Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
-11270	fuchsia ghostly huge VHS Tape	0		Last Available: "2023-06"
+11270	huge ghostly fuchsia VHS Tape	0		Last Available: "2023-06"
 11271	aerosolized dry corrupted wobbly scroll of minor invulnerability	0		Effect: "Dance Interpreter", Effect Duration: 67, Last Available: "2023-06"
 11272	Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
@@ -11134,7 +11134,7 @@
 11279	gray blinking Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	acceptable triple-distilled Sexy Cosmo	7	good	Last Available: "2023-06"
+11282	triple-distilled acceptable Sexy Cosmo	7	good	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	gravedigger's deadly red-soled high heels of the detective	0		Weapon Damage: +5, Spooky Damage: +10, Item Drop: +20, Last Available: "2023-06"
 11285	adequate cyburger	4	good	Last Available: "2025-12"
@@ -11172,7 +11172,7 @@
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	blue medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	perfectly mixed practically non-alcoholic pulsating bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	
+11320	practically non-alcoholic perfectly mixed pulsating bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	
 11321	clever arcane researcher's baywatch of the storm	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +40, Maximum MP: +20, Lasts Until Rollover
 11322	squat Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	pulsating Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
@@ -11180,7 +11180,7 @@
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	blurry Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	dehydrated mirror shaking concentrated cooking	1		Effect: "Milk Studly", Effect Duration: 10
+11328	dehydrated shaking mirror concentrated cooking	1		Effect: "Milk Studly", Effect Duration: 10
 11329	denatured cyan meat	1		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 15
 11330	dried twirling sparkling orb	1		
 11331	diluted jittery hardening cream	1		
@@ -11252,7 +11252,7 @@
 11397	Crimbuccaneer fledges (mint) of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
-11400	gray squat Elf Guard tinsel grenade	0		Last Available: "2023-12"
+11400	squat gray Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	practically non-alcoholic smooth Crimbuccaneer mologrog cocktail	1	awesome	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
@@ -11274,13 +11274,13 @@
 11419	rosy-cheeked razor-sharp Elf Guard broom	0		Weapon Damage Percent: +25, Maximum HP Percent: +30, Last Available: "2023-12"
 11420	huge Tesla curative Crimbuccaneer tavern swab of the empath	0		Familiar Weight: +5, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	watered-down drinkable old-school pirate grog	2	good	Last Available: "2023-12"
-11423	small moldy grog nuts	2	crappy	Last Available: "2023-12"
+11422	drinkable watered-down old-school pirate grog	2	good	Last Available: "2023-12"
+11423	moldy small grog nuts	2	crappy	Last Available: "2023-12"
 11424	huge fireproof medical-grade sawed-off blunderbuss of Flo-Jo	0		Hot Resistance: +3, Initiative: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
-11425	perfectly mixed high-proof blurry officer's nog	9	EPIC	Last Available: "2023-12"
+11425	high-proof perfectly mixed blurry officer's nog	9	EPIC	Last Available: "2023-12"
 11426	shaking peppermint bomb	0		Last Available: "2023-12"
 11427	bland sundae ration	3	decent	Last Available: "2023-12"
-11428	huge adequate shaking blinking peppermint tack	6	good	Last Available: "2023-12"
+11428	huge adequate blinking shaking peppermint tack	6	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	adequate whalesteak	3	good	Last Available: "2023-12"
 11431	hardy savvy whalegun of Calamity Jane	0		Mysticality Percent: +20, Maximum HP: +50, Critical Hit Percent: +15, Last Available: "2023-12"
@@ -11318,10 +11318,10 @@
 11463	moldy gingerbread pirate	3	crappy	Last Available: "2023-12"
 11464	decent fruit-stuffed rumcake	3	good	Last Available: "2023-12"
 11465	tolerable mulled wine	3	good	Last Available: "2023-12"
-11466	watered-down delicious Swedish coffee	2	awesome	Last Available: "2023-12"
+11466	delicious watered-down Swedish coffee	2	awesome	Last Available: "2023-12"
 11467	hand-crafted twirling canteen of eggnog	4	EPIC	Last Available: "2023-12"
-11468	tolerable watered-down hot wine	2	good	Last Available: "2023-12"
-11469	delicious high-proof lime green Jamaican coffee	6	awesome	Last Available: "2023-12"
+11468	watered-down tolerable hot wine	2	good	Last Available: "2023-12"
+11469	high-proof delicious lime green Jamaican coffee	6	awesome	Last Available: "2023-12"
 11470	hand-crafted huge flask of egggrog	3	super EPIC	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
@@ -11348,7 +11348,7 @@
 11493	squat Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	jittery Elf Guard safety bear	0		Last Available: "2023-12"
 11495	green kraken	0		Last Available: "2023-12"
-11496	teal twirling precision snowball	0		Last Available: "2023-12"
+11496	twirling teal precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	narrow Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	pulsating pulsating Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
@@ -11425,11 +11425,11 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	teal Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	normal snack-sized narrow yam	2	good	Last Available: "2024-05"
+11573	snack-sized normal narrow yam	2	good	Last Available: "2024-05"
 11574	watered-down drinkable yam martini	2	good	Last Available: "2024-05"
 11575	aged weak sweet potato o' mine	2	awesome	Last Available: "2024-05"
 11576	perfectly mixed blinking Southern yam	3	EPIC	Last Available: "2024-05"
-11577	watered-down delicious sweet potato punch	2	awesome	Last Available: "2024-05"
+11577	delicious watered-down sweet potato punch	2	awesome	Last Available: "2024-05"
 11578	adequate Mayam spinach	4	good	Last Available: "2024-05"
 11579	flavorless squat yam and swiss	4	decent	Last Available: "2024-05"
 11580	twirling personal trainer's experienced cool yam cannon	0		Moxie: +5, Experience: +2, Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,14 +11439,14 @@
 11584	huge wobbly knitted horrifying electrified furry yam buckler	0		Spooky Damage: +25, Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	greedy lard-coated sharpshooter's yamtility belt	0		Critical Hit Percent: +10, Sleaze Spell Damage: +25, Meat Drop: +20, Lasts Until Rollover, Last Available: "2024-05"
-11587	super-sized moldy yam slider	5	crappy	Last Available: "2024-05"
+11587	moldy super-sized yam slider	5	crappy	Last Available: "2024-05"
 11588	bland upside-down yam mayo	4	decent	Last Available: "2024-05"
 11589	huge spoiled yam burrito	10	crappy	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	cyan mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	fancy normal blinking mini kiwi	3	good	Effect: "Hustlin'", Effect Duration: 15, Last Available: "2024-06"
+11594	normal fancy blinking mini kiwi	3	good	Effect: "Hustlin'", Effect Duration: 15, Last Available: "2024-06"
 11595	aromatic foul-smelling mini kiwi bikini of the cheetah	0		Stench Damage: +10, Stench Resistance: +1, Initiative: +60, Last Available: "2024-06"
 11596	artisanal mini kiwitini	4	EPIC	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11454,7 +11454,7 @@
 11599	lion tamer's boxer's cool mini kiwi silicon tiepin	0		Moxie: +5, Muscle Percent: +10, Experience (familiar): +2
 11600	mini kiwi tipi	0		
 11601	spoiled mini kiwi digitized cookies	4	crappy	
-11602	weak tolerable enchanted mini kiwi intoxicating spirits	2	good	Effect: "Heavily Breathing", Effect Duration: 40
+11602	tolerable enchanted weak mini kiwi intoxicating spirits	2	good	Effect: "Heavily Breathing", Effect Duration: 40
 11603	boiled pressed green mini kiwi antimilitaristic hippy petition	0		Effect: "Mariachi Mood", Effect Duration: 32
 11604	double-liquefied quantum tumbling mini kiwi illicit antibiotic	0		Effect: "You Know Who to Call", Effect Duration: 61
 11605	asbestos-lined shellacked mini kiwi whipping stick	0		Damage Reduction: 7, Hot Resistance: +5
@@ -11483,11 +11483,11 @@
 11628	extra DNA	0		Experience (familiar): +1
 11629	spinning untorn tearaway pants package	0		Free Pull
 11630	bouncing gravedigger's sizzling banded smooth tearaway pants of the overflowing toilet	0		Moxie: +15, Damage Absorption: +100, Hot Damage: +10, Stench Spell Damage: +50, Spooky Damage: +10, Conditional Skill (Equipped): "Tear Away your Pants!"
-11631	yellow narrow baby bodyguard	0		
+11631	narrow yellow baby bodyguard	0		
 11632	Doll Moll violin case	0		
 11633	squat blinking Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	watered-down bad Colera Peste Nebbiolo	2	decent	
+11635	bad watered-down Colera Peste Nebbiolo	2	decent	
 11636	mirror longbox of Batfellow comics	0		
 11637	huge Thwaitgold shield bug statuette	0		
 11638	huge bodyguard badge	0		
@@ -11502,7 +11502,7 @@
 11647	shaking teal structural ember	0		Last Available: "2024-09"
 11648	twirling auspicious forbidden brainy embers-only jacket	0		Mysticality: +5, Spell Damage Percent: +50, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-09"
 11649	prompt bembershoot	0		Adventures: +3, Lasts Until Rollover, Last Available: "2024-09"
-11650	special big flavorless wheel of camembert	5	decent	Effect: "Sludgesick", Effect Duration: 40, Last Available: "2024-09"
+11650	big flavorless special wheel of camembert	5	decent	Effect: "Sludgesick", Effect Duration: 40, Last Available: "2024-09"
 11651	asbestos-lined foul-smelling educational hat of remembering	0		Experience: +1, Stench Damage: +10, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2024-09"
 11652	pulsating throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11545,7 +11545,7 @@
 11690	chilly jolly roger flag	0		Cold Damage: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	skewed sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	enchanted mediocre tankard of spiced rum	3	decent	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2024-12"
+11693	mediocre enchanted tankard of spiced rum	3	decent	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2024-12"
 11694	hand-crafted special irresponsibly strong squat tankard of spiced Goldschlepper	9	EPIC	Effect: "Dweeby", Effect Duration: 35, Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	governor's daughter's lace collar of the detective	0		Item Drop: +20, Last Available: "2024-12"
@@ -11558,7 +11558,7 @@
 11703	pet rock	0		Last Available: "2024-12"
 11704	perfumed groggles	0		Stench Resistance: +5, Last Available: "2024-12"
 11705	pirate dinghy	0		Last Available: "2024-12"
-11706	spinning maroon anchor bomb	0		Last Available: "2024-12"
+11706	maroon spinning anchor bomb	0		Last Available: "2024-12"
 11707	gravedigger's smelly silky pirate drawers	0		Stench Spell Damage: +10, Spooky Damage: +10, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	dry peppermint pegleg	0		Effect: "Tin, Man", Effect Duration: 55, Last Available: "2024-12"
@@ -11582,7 +11582,7 @@
 11727	chilled ghostly four-leaf potato sprout	0		Effect: "Pyramid Power", Effect Duration: 67, Last Available: "2024-12"
 11728	shaking Sherlock's Socratic potato jacket of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Item Drop: +25, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
-11730	ghostly squat Brandonian footlocker key	0		Last Available: "2024-12"
+11730	squat ghostly Brandonian footlocker key	0		Last Available: "2024-12"
 11731	shaking Annie Oakley's deadly military orb	0		Weapon Damage: +5, Critical Hit Percent: +20, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	concentrated wobbly rum ball	0		Effect: "Ooh, Sour!", Effect Duration: 44
 11733	gravy skin	0		Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	wizardly gravyskin skirt of the bloodbag	0		Mysticality: +25, Maximum HP: +100, Last Available: "2024-12"
 11737	prompt gravyskin pants of the glutton	0		Food Drop: +100, Adventures: +3, Last Available: "2024-12"
 11738	quantum ghostly crystallized pumpkin spice	0		Effect: "Meat the Flintstones", Effect Duration: 12, Last Available: "2024-12"
-11739	diet stale room scale bean casserole	1	decent	Last Available: "2024-12"
+11739	stale diet room scale bean casserole	1	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	yellow bouncing double-paned banded perfect Christmas scarf of the sewer	0		Damage Absorption: [+100*event(December)], Stench Damage: [+25*event(December)], Cold Resistance: [+5*event(December)], Single Equip, Last Available: "2024-12"
@@ -11599,17 +11599,17 @@
 11744	electrified LIDAR candle	0		Effect: "Hopped Up on Goofballs", Effect Duration: 25, Last Available: "2024-12"
 11745	Jim Carey's resourceful Congressional Medal of Insanity of the ox	0		Muscle: +20, Maximum MP: +50, Monster Level: +25, Last Available: "2024-12"
 11746	twirling wobbly pumpkin spice whorl	0		Last Available: "2024-12"
-11747	high-proof perfectly mixed Easter grasshopper	10	EPIC	Last Available: "2024-12"
-11748	practically non-alcoholic hand-crafted special Irish eggnog	1	super ultra mega turbo EPIC	Effect: "Ichorous Eyesight", Effect Duration: 20, Last Available: "2024-12"
-11749	watered-down artisanal enchanted canteen of jungle juice	2	EPIC	Effect: "Swimming Head", Effect Duration: 45, Last Available: "2024-12"
-11750	aged fancy turchucken	4	awesome	Effect: "Frosty the Hitman", Effect Duration: 25, Last Available: "2024-12"
+11747	perfectly mixed high-proof Easter grasshopper	10	EPIC	Last Available: "2024-12"
+11748	special hand-crafted practically non-alcoholic Irish eggnog	1	super ultra mega turbo EPIC	Effect: "Ichorous Eyesight", Effect Duration: 20, Last Available: "2024-12"
+11749	watered-down enchanted artisanal canteen of jungle juice	2	EPIC	Effect: "Swimming Head", Effect Duration: 45, Last Available: "2024-12"
+11750	fancy aged turchucken	4	awesome	Effect: "Frosty the Hitman", Effect Duration: 25, Last Available: "2024-12"
 11751	lousy watered-down upside-down mechanically-mulled cider	2	decent	Last Available: "2024-12"
 11752	acceptable holiday trip around the world	3	good	Last Available: "2024-12"
 11753	flavorless chocolate ostrich egg	4	decent	Last Available: "2024-12"
 11754	stale beef and cabbage	3	decent	Last Available: "2024-12"
 11755	bland candy rations	3	decent	Last Available: "2024-12"
 11756	stale double-candied yams	3	decent	Last Available: "2024-12"
-11757	toothsome thick tumbling Christmas ham	5	awesome	Last Available: "2024-12"
+11757	thick toothsome tumbling Christmas ham	5	awesome	Last Available: "2024-12"
 11758	normal holiday smorgasbord	4	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	frosty bejazzled eyepatch	0		Cold Spell Damage: +10, Last Available: "2024-12"
@@ -11618,8 +11618,8 @@
 11763	blurry How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	bouncing cyan Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	cyan bouncing Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11766	cyan bouncing Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	bouncing cyan Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	fuchsia twirling Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	twirling pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	jittery wobbly malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	wobbly jittery malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	narrow blinking server room key	0		Last Available: "2025-12"
 11809	lime green 3d printed server room key	0		Last Available: "2025-12"
@@ -11684,7 +11684,7 @@
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	blurry ninja rope	0		
 11831	green ninja crampons	0		
-11832	twirling purple ninja carabiner	0		
+11832	purple twirling ninja carabiner	0		
 11833	unsweetened synthetic coffee	0		Effect: "Angry like the Wolf", Effect Duration: 43
 11834	polymerized quantum shaking cyan iDrops	0		Effect: "The Real Deal", Effect Duration: 69
 11835	purple shame coil	0		
@@ -11699,14 +11699,14 @@
 11844	chill gherkin	0		
 11845	spinning blue jittery childrens' stapler	0		
 11846	plover's egg	0		
-11847	blurry spinning yellow flyswatter	0		
+11847	yellow blurry spinning flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	ghostly heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
-11854	blinking jittery grim cellophane	0		Combat Rate: -5
+11854	jittery blinking grim cellophane	0		Combat Rate: -5
 11855	blinking rift oculus	0		Combat Rate: +5
 11856	skewed wobbly sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	gray carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
@@ -11727,20 +11727,20 @@
 11872	diet stale twirling Heck ramen	1	decent	Last Available: "2025-03"
 11873	spoiled narrow burrito	3	crappy	Last Available: "2025-03"
 11874	rotten small beer brat	3	crappy	Last Available: "2025-03"
-11875	decent jumbo peach pie	5	good	Last Available: "2025-03"
-11876	enchanted miniature spoiled incredible mini-pizza	2	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 50, Last Available: "2025-03"
-11877	fortified artisanal ghostly Divine sidecar	5	EPIC	Last Available: "2025-03"
+11875	jumbo decent peach pie	5	good	Last Available: "2025-03"
+11876	spoiled miniature enchanted incredible mini-pizza	2	crappy	Effect: "Seal Clubbing Frenzy", Effect Duration: 50, Last Available: "2025-03"
+11877	artisanal fortified ghostly Divine sidecar	5	EPIC	Last Available: "2025-03"
 11878	artisanal tangarita sidecar	4	EPIC	Last Available: "2025-03"
 11879	fortified tolerable green gimlet sidecar	5	good	Last Available: "2025-03"
-11880	weak hand-crafted teal vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
-11881	high-proof drinkable wobbly prussian cathouse sidecar	10	good	Last Available: "2025-03"
+11880	hand-crafted weak teal vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
+11881	drinkable high-proof wobbly prussian cathouse sidecar	10	good	Last Available: "2025-03"
 11882	artisanal Mon Tiki sidecar	3	EPIC	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	wool foul-smelling April Shower Thoughts shield	0		Stench Damage: +10, Cold Resistance: +1, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	triple-tarnished modified wet paper weights	0		Effect: "Okee-Dokee Computer", Effect Duration: 60, Last Available: "2025-04"
-11888	irresponsibly strong hand-crafted Three Sheets to the Wind	10	EPIC	Last Available: "2025-04"
+11888	hand-crafted irresponsibly strong Three Sheets to the Wind	10	EPIC	Last Available: "2025-04"
 11889	immense yummy pile of wet dates	7	awesome	Last Available: "2025-04"
 11890	olive papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	narrow wet blanket	0		Last Available: "2025-04"
@@ -11790,7 +11790,7 @@
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	stale skewed Skeleton Wars rations	4	decent	
-11938	lousy irresponsibly strong skeleton war fuel can	6	decent	
+11938	irresponsibly strong lousy skeleton war fuel can	6	decent	
 11939	squat skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	spinning M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11805,10 +11805,10 @@
 11950	medical-grade time cop top hat	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-08"
 11951	lime green Stock Certificate	0		Last Available: "2025-08"
 11952	powdered ghostly mixed berry jelly	1		Last Available: "2025-08"
-11953	bite-sized normal spinning squat toast with mixed berry jelly	1	good	Last Available: "2025-08"
-11954	gigantic moldy cup of sugar	8	crappy	Last Available: "2025-08"
+11953	normal bite-sized spinning squat toast with mixed berry jelly	1	good	Last Available: "2025-08"
+11954	moldy gigantic cup of sugar	8	crappy	Last Available: "2025-08"
 11955	half-sized adequate Susie's cupcake	2	good	Last Available: "2025-08"
-11956	upside-down green clock	0		Last Available: "2025-08"
+11956	green upside-down clock	0		Last Available: "2025-08"
 11957	resourceful wicked savvy the gun	0		Mysticality Percent: +20, Spell Damage: +5, Maximum MP: +50, Last Available: "2025-08"
 11958	bad wine	3	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
@@ -11816,7 +11816,7 @@
 11962	nippy undersea surveying goggles	0		Cold Damage: +10, Lasts Until Rollover
 11963	bad red Ocean-Touched Rum	3	decent	
 11964	boiled shaking tumbling cyan water-logged pill	1		Effect: "All Fired Up", Effect Duration: 30
-11965	moldy enchanted kelp puck	3	crappy	Effect: "Tingling Feeling", Effect Duration: 30
+11965	enchanted moldy kelp puck	3	crappy	Effect: "Tingling Feeling", Effect Duration: 30
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	wobbly scroll of sea smarm	0		
@@ -11824,7 +11824,7 @@
 11970	sea gel	0		
 11971	colloidal energized skewed octopus ink bladder	0		Effect: "Stop and Smell the Fudge", Effect Duration: 49
 11972	durable dolphin whistle	0		
-11973	olive blurry Thwaitgold lobster statuette	0		
+11973	blurry olive Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
@@ -11839,13 +11839,13 @@
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	artisanal high-proof Smoking Pope	10	EPIC	
+12052	high-proof artisanal Smoking Pope	10	EPIC	
 12053	stale gigantic pulsating prize turkey	7	decent	
-12054	denatured olive wobbly wobbly medicinal gruel	1		Effect: "The Smeezingtons", Effect Duration: 35
-12055	fancy massive toothsome full-sized pumpkin pie	10	awesome	Effect: "Brother Smothers's Blessing", Effect Duration: 5, Last Available: "2025-11"
-12056	hand-crafted practically non-alcoholic vodka cranberry sauce	1	super ultra mega turbo EPIC	Last Available: "2025-11"
+12054	denatured wobbly wobbly olive medicinal gruel	1		Effect: "The Smeezingtons", Effect Duration: 35
+12055	toothsome fancy massive full-sized pumpkin pie	10	awesome	Effect: "Brother Smothers's Blessing", Effect Duration: 5, Last Available: "2025-11"
+12056	practically non-alcoholic hand-crafted vodka cranberry sauce	1	super ultra mega turbo EPIC	Last Available: "2025-11"
 12057	adjusted yammed candy	0		Effect: "Pemmican't", Effect Duration: 21, Last Available: "2025-11"
-12058	gigantic stale treasure chestnut	7	decent	Last Available: "2025-12"
+12058	stale gigantic treasure chestnut	7	decent	Last Available: "2025-12"
 12059	lousy mulled butter rum	3	decent	Last Available: "2025-12"
 12060	unsweetened nitrogenated energized cinnamon doubloon	0		Effect: "Mercenary", Effect Duration: 50, Last Available: "2025-12"
 12061	scorching plastic left skeleton arm	0		Hot Damage: +25, Last Available: "2025-12"
@@ -11911,22 +11911,22 @@
 12153	yellow deadly scorched skeleton pants of the bloodbag	0		Weapon Damage: +5, Maximum HP: +100, Last Available: "2025-12"
 12154	messenger parrot egg	0		Last Available: "2025-12"
 12155	blinking buryable chest	0		Last Available: "2025-12"
-12156	blue spinning Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
+12156	spinning blue Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12161	huge ghostly Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12161	ghostly huge Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
-12164	gray narrow Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
+12164	narrow gray Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12165	wobbly Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12166	teal Crymbocurrency tattoo	0		Last Available: "2025-12"
 12167	reassuring brawny fireproof bonesaw	0		Muscle Percent: +20, Spooky Resistance: +1, Last Available: "2025-12"
 12168	ghostly skewed studded vermiculite shield of the detective	0		Damage Absorption: +80, Item Drop: +20, Damage Reduction: 9, Last Available: "2025-12"
 12169	narrow greedy ship's lantern	0		Meat Drop: +20, Last Available: "2025-12"
 12170	maroon huge lard-coated extremely unsafe heat-resistant harpoon pistol	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Last Available: "2025-12"
-12171	tasty snack-sized special spinning traditional gingerloaf	2	awesome	Effect: "Hood Ridin'", Effect Duration: 10, Last Available: "2025-12"
+12171	special tasty snack-sized spinning traditional gingerloaf	2	awesome	Effect: "Hood Ridin'", Effect Duration: 10, Last Available: "2025-12"
 12172	drinkable upside-down Scotch and eggnog	3	good	Last Available: "2025-12"
 12173	pickled colloidal counterskeleton elixir	0		Effect: "Fortunate Resolve", Effect Duration: 69, Last Available: "2025-12"
 12174	mediocre &quot;salvaged&quot; wine	3	decent	Last Available: "2025-12"
@@ -11972,8 +11972,8 @@
 12214	mixed jittery pulsating candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	adequate immense jittery discarded hot dog	7	good	Last Available: "2026-04"
-12218	perfectly mixed strong most of a beer	5	EPIC	Last Available: "2026-04"
+12217	immense adequate jittery discarded hot dog	7	good	Last Available: "2026-04"
+12218	strong perfectly mixed most of a beer	5	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
@@ -11986,21 +11986,21 @@
 12232	toothsome small hot honey ant	2	awesome	
 12233	normal tomb aspic	4	good	
 12234	normal later tots	4	good	
-12235	thick stale Frutti di Scatoletta	5	decent	Last Available: "2026-05"
+12235	stale thick Frutti di Scatoletta	5	decent	Last Available: "2026-05"
 12236	tiny spoiled Pesto alla Marziano	1	crappy	Last Available: "2026-05"
 12237	delicious purple Arrattabbattabiata	3	awesome	Last Available: "2026-05"
 12238	flavorless Orzo di Riso	3	decent	Last Available: "2026-05"
-12239	miniature yummy bouncing shaking Pasta Grimavera	2	awesome	Last Available: "2026-05"
+12239	miniature yummy shaking bouncing Pasta Grimavera	2	awesome	Last Available: "2026-05"
 12240	fancy moldy gray Linguini Ubriacapa	3	crappy	Effect: "Crud&eacute;", Effect Duration: 50, Last Available: "2026-05"
-12241	super-sized delicious enchanted Formica e Pepe	5	awesome	Effect: "Tenacity of the Snapper", Effect Duration: 30, Last Available: "2026-05"
+12241	super-sized enchanted delicious Formica e Pepe	5	awesome	Effect: "Tenacity of the Snapper", Effect Duration: 30, Last Available: "2026-05"
 12242	tiny spoiled Tubetto Gelatto	1	crappy	Last Available: "2026-05"
-12243	stale immense Gnocci Domani	6	decent	Last Available: "2026-05"
+12243	immense stale Gnocci Domani	6	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	squat scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	mirror second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	shaking mega helmet	0		
 12252	cyan flame-wreathed dangerous Space Soldier Helmet	0		Weapon Damage: +10, Hot Spell Damage: +10
-12253	delicious immense premium turkey leg	8	awesome	
+12253	immense delicious premium turkey leg	8	awesome	
 12254	acceptable styrofoam cup of mead	3	good	
 12255	gray skewed steel-toed sword	0		Damage Reduction: 9
 12256	mansplainer's staff	0		Monster Level: +15
@@ -12027,12 +12027,12 @@
 12277	decent super-sized blue classic banana pie	5	good	Last Available: "2026-07"
 12278	energized modified mirror shaking essential banana decoction	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 40, Last Available: "2026-07"
 12279	pickled anodized huge banana quintessence	0		Effect: "Mana Tea", Effect Duration: 28, Last Available: "2026-07"
-12280	fancy lousy Aesop Daiquiri	3	decent	Effect: "Object Detection", Effect Duration: 50, Last Available: "2026-07"
+12280	lousy fancy Aesop Daiquiri	3	decent	Effect: "Object Detection", Effect Duration: 50, Last Available: "2026-07"
 12281	artisanal Monkey Congress	3	EPIC	Last Available: "2026-07"
-12282	special stale watermelon pie	4	decent	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2026-07"
+12282	stale special watermelon pie	4	decent	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2026-07"
 12283	frozen quantum concentrated watermelon juice	0		Effect: "Pemmican't", Effect Duration: 23, Last Available: "2026-07"
 12284	irradiated chilled improved pulsating Aqua Citrulanatae	0		Effect: "Gemini Rising", Effect Duration: 11, Last Available: "2026-07"
-12285	practically non-alcoholic hand-crafted spinning Melonegroni	1	super EPIC	Last Available: "2026-07"
+12285	hand-crafted practically non-alcoholic spinning Melonegroni	1	super EPIC	Last Available: "2026-07"
 12286	fortified bad spinning Melonade Spritz	5	decent	Last Available: "2026-07"
 12287	decent blurry quince pie	4	good	Last Available: "2026-07"
 12288	pressed ghostly quince quaff	0		Effect: "Cool, Catlike", Effect Duration: 63, Last Available: "2026-07"
@@ -12058,7 +12058,7 @@
 12308	ghostly savings bondo	0		Last Available: "2026-08"
 12309	upside-down homeowner's loam	0		Last Available: "2026-08"
 12310	compressed toxic asset	1		Last Available: "2026-08"
-12311	boiled blurry pulsating intangible asset	1		Effect: "Supafly", Effect Duration: 15, Last Available: "2026-08"
+12311	boiled pulsating blurry intangible asset	1		Effect: "Supafly", Effect Duration: 15, Last Available: "2026-08"
 12312	pickled blurry pulsating liquid asset	1		Effect: "Flambé-a-thon", Effect Duration: 35, Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	yellow squat cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Pastamancer_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Blender_cafe_booze.txt
@@ -1,16 +1,16 @@
--1	weak bad Petite Porter	2	decent	
--2	distilled drinkable ghostly squat Scrawny Stout	5	good	
+-1	bad weak Petite Porter	2	decent	
+-2	drinkable distilled ghostly squat Scrawny Stout	5	good	
 -3	acceptable purple Infinitesimal IPA	3	good	
 -4	acceptable red eggnogtini	4	good	
 -5	perfectly mixed candycaine	4	EPIC	
 -6	artisanal extra-dry braincracker sweet	5	EPIC	
 -16	tolerable squat blurry fermented honey	4	good	
--17	hand-crafted high-proof moons-shine	6	EPIC	
+-17	high-proof hand-crafted moons-shine	6	EPIC	
 -18	watered-down mediocre gin	2	decent	
 -19	lousy twirling ecto-nog	4	decent	
--20	practically non-alcoholic lousy hot toady	1	decent	
+-20	lousy practically non-alcoholic hot toady	1	decent	
 -21	artisanal hot choculate	3	EPIC	
--49	tolerable fortified Cyder	5	good	
+-49	fortified tolerable Cyder	5	good	
 -50	lousy Oil Nog	3	decent	
 -51	perfectly mixed Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	practically non-alcoholic perfectly mixed Grimacider	1	EPIC	
@@ -20,14 +20,14 @@
 -71	drinkable Black and Tan and Red All Over	4	good	
 -72	acceptable wobbly Antarctic Ice Tea	3	good	
 -76	artisanal CRIMBCO Ribbon Candy Schnapps	3	EPIC	
--77	bad high-proof olive CRIMBCO Egg Substitute Nog Substitute	10	decent	
+-77	high-proof bad olive CRIMBCO Egg Substitute Nog Substitute	10	decent	
 -78	perfectly mixed CRIMBCO Extreme Braincracker Sour	4	EPIC	
--82	high-proof lousy Horseradish-infused Vodka	6	decent	
+-82	lousy high-proof Horseradish-infused Vodka	6	decent	
 -83	perfectly mixed blurry Jerkitini	3	EPIC	
--84	watered-down lousy Desert Island Iced Tea	2	decent	
+-84	lousy watered-down Desert Island Iced Tea	2	decent	
 -88	tolerable Crimbo Saketini	4	good	
 -89	fancy bad Crimboku Drop	4	decent	
 -90	mediocre Flaming Crimbo Log	3	decent	
--107	practically non-alcoholic perfectly mixed huge Fortified Eggnog Slurry	1	EPIC	
+-107	perfectly mixed practically non-alcoholic huge Fortified Eggnog Slurry	1	EPIC	
 -108	mediocre green Hot Buttered Rum	3	decent	
 -109	hand-crafted squat Spicy Hot Chocolate	3	EPIC	

--- a/data/TCRS/TCRS_Pastamancer_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Blender_cafe_food.txt
@@ -1,9 +1,9 @@
 -1	rotten small Peche a la Frog	2	crappy	
 -2	stale jumbo ghostly squat As Jus Gezund Heit	5	decent	
 -3	bland purple Bouillabaise Coucher Avec Moi	3	decent	
--7	spoiled half-sized gumdrop chow mein	2	crappy	
+-7	half-sized spoiled gumdrop chow mein	2	crappy	
 -8	normal mirror candy cane pizza	4	good	
--9	diet bland wobbly gingerbread stir-fry	1	decent	
+-9	bland diet wobbly gingerbread stir-fry	1	decent	
 -10	decent twigs and gravel	4	good	
 -11	stale lime green shoots and leaves	3	decent	
 -12	half-sized yummy bowl of unidentifiable goo	2	awesome	
@@ -16,30 +16,30 @@
 -61	flavorless Candy Cane Surprise	3	decent	
 -62	stale Grimdrop Chow Mein	4	decent	
 -63	flavorless red Grimgerbread House	3	decent	
--67	tasty half-sized blinking Caviar Carbonara	2	awesome	
+-67	half-sized tasty blinking Caviar Carbonara	2	awesome	
 -68	rotten big Halibut Alfredo	5	crappy	
--69	yummy low-calorie jittery Red Herring Velvet Cake	1	awesome	
--73	miniature normal narrow CRIMBCO Reconstituted Gruel	2	good	
+-69	low-calorie yummy jittery Red Herring Velvet Cake	1	awesome	
+-73	normal miniature narrow CRIMBCO Reconstituted Gruel	2	good	
 -74	flavorless New and Improved CRIMBCO Reconstituted Gruel	3	decent	
--75	miniature special delicious CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	awesome	
+-75	delicious special miniature CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	awesome	
 -79	flavorless Brussels Sprout Stir-Fry	4	decent	
 -80	flavorless skewed Carrot, Cabbage, and Kale Pizza	3	decent	
 -81	delicious Turnip and Rutabaga Pie	3	awesome	
 -85	adequate enchanted Rainbow Spider Fun Roll	3	good	
--86	enchanted stale diet squat Vegas Volcano Lava Roll	1	decent	
+-86	stale enchanted diet squat Vegas Volcano Lava Roll	1	decent	
 -87	normal small Crazy Dragon Shogun Buddha Roll	2	good	
 -92	spoiled basic hot dog	4	crappy	
--93	flavorless snack-sized savage macho dog	2	decent	
+-93	snack-sized flavorless savage macho dog	2	decent	
 -94	tiny moldy one with everything	1	crappy	
 -95	moldy purple sly dog	3	crappy	
 -96	spoiled devil dog	4	crappy	
 -97	decent upside-down chilly dog	3	good	
 -98	normal huge ghost dog	8	good	
 -99	delicious tumbling junkyard dog	4	awesome	
--100	half-sized bland wet dog	2	decent	
+-100	bland half-sized wet dog	2	decent	
 -101	adequate thick sleeping dog	5	good	
--102	delicious diet optimal dog	1	awesome	
+-102	diet delicious optimal dog	1	awesome	
 -103	big decent video games hot dog	5	good	
--104	small rotten Peppermint Nutrition Block	2	crappy	
--105	thick spoiled tumbling Gingerbread Nutrition Block	5	crappy	
--106	fancy massive tasty Cinnamon Nutrition Block	8	awesome	
+-104	rotten small Peppermint Nutrition Block	2	crappy	
+-105	spoiled thick tumbling Gingerbread Nutrition Block	5	crappy	
+-106	massive tasty fancy Cinnamon Nutrition Block	8	awesome	

--- a/data/TCRS/TCRS_Pastamancer_Marmot.txt
+++ b/data/TCRS/TCRS_Pastamancer_Marmot.txt
@@ -23,7 +23,7 @@
 24	ten-leaf clover	0		
 25	meat paste	0		
 26	pulsating Dolphin King's map	0		
-27	teal squat spider web	0		
+27	squat teal spider web	0		
 28	really spider web	0		
 29	really really spider web	0		
 30	rock	0		
@@ -37,18 +37,18 @@
 38	Newton's Knob Goblin pants	0		Experience (Mysticality): +3, Familiar Effect: "atk, 5xPotato, cap 6"
 39	blue pretty flower	0		
 40	blinking casino pass	0		
-41	mediocre weak ice-cold Sir Schlitz	2	decent	
+41	weak mediocre ice-cold Sir Schlitz	2	decent	
 42	hermit permit	0		
 43	worthless trinket	0		
 44	upside-down worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	figurine	0		
-47	rotten enchanted blinking tumbling mirror hot buttered roll	3	crappy	Effect: "Brother Smothers's Blessing", Effect Duration: 15
+47	enchanted rotten mirror blinking tumbling hot buttered roll	3	crappy	Effect: "Brother Smothers's Blessing", Effect Duration: 15
 48	mirror heart of rock and roll	0		
 49	moldy bowl of cottage cheese	3	crappy	
 50	Rock and Roll Legend of the sweet-tooth	0		Candy Drop: +100, Class: "Accordion Thief", Song Duration: 10
 51	Knob Goblin Uberpants of the cougar	0		Moxie: +20, Familiar Effect: "3xPotato, 3xFairy, cap 11"
-52	narrow pulsating banjo strings	0		
+52	pulsating narrow banjo strings	0		
 53	bouncing fireproof stone banjo	0		Hot Resistance: +3
 54	olive perfumed Disco Banjo of courage	0		Spooky Resistance: +3, Stench Resistance: +5, Class: "Disco Bandit"
 55	jaba&ntilde;ero pepper	0		
@@ -61,7 +61,7 @@
 62	lard-coated oriole-feather headdress	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
-65	fuchsia twirling Mighty Bjorn action figure	0		
+65	twirling fuchsia Mighty Bjorn action figure	0		
 66	twig	0		
 67	spaghetti with rock-balls	0		
 68	wholesome weightlifter's Pasta Spoon of Peril	0		Muscle: +15, Maximum HP Percent: +10, Class: "Pastamancer"
@@ -77,7 +77,7 @@
 78	yellow Rosewater's pretty bouquet	0		Mysticality Percent: +30
 79	mirror bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	tolerable watered-down blurry ice-cold Willer	2	good	
+81	watered-down tolerable blurry ice-cold Willer	2	good	
 82	spinning ring	0		
 83	wobbly shaft	0		
 84	Orcish meat locker	0		
@@ -133,7 +133,7 @@
 134	huge bitchin' meatcar	0		
 135	sweet rims	0		
 136	tires	0		
-137	pulsating ghostly dope wheels	0		
+137	ghostly pulsating dope wheels	0		
 138	wobbly ice-cold six-pack	0		
 139	valuable trinket	0		
 140	pulsating dingy planks	0		
@@ -157,7 +157,7 @@
 158	Gnollish pie tin	0		
 159	squat wad of dough	0		
 160	pulsating pie crust	0		
-161	half-sized spoiled ghuol egg	2	crappy	
+161	spoiled half-sized ghuol egg	2	crappy	
 162	normal spinning ghuol egg quiche	3	good	
 163	purple slick skeleton bone	0		Moxie: +10
 164	lime green smart skull	0		
@@ -171,21 +171,21 @@
 172	tumbling gnoll lips	0		
 173	taco shell	0		
 174	upside-down Gnollish casserole dish	0		
-175	half-sized bland bouncing uncooked chorizo	2	decent	
+175	bland half-sized bouncing uncooked chorizo	2	decent	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	spinning detective skull	0		
 179	toothsome chorizo taco	3	awesome	
 180	drinkable skewed ice-cold fotie	4	good	
 181	baseball	0		
-182	pulsating wobbly batgut	0		
+182	wobbly pulsating batgut	0		
 183	huge blue bat wing	0		
 184	skewed briefcase	0		
 185	green fat stacks of cash	0		
 186	bean	0		
 187	loose teeth	0		
 188	bat guano	0		
-189	maroon jittery guano coffee cup	0		
+189	jittery maroon guano coffee cup	0		
 191	lime green batskin belt of doom	0		Spooky Spell Damage: +50
 192	batskin belt	0		
 193	teal birthday candle	0		
@@ -213,8 +213,8 @@
 215	Uncle Jick's Brownie Mix	0		
 216	bland carob brownies	4	decent	
 217	spoiled herb brownies	3	crappy	
-218	blue jittery hemp string	0		
-219	fuchsia wobbly necklace chain	0		
+218	jittery blue hemp string	0		
+219	wobbly fuchsia necklace chain	0		
 220	maroon gnoll teeth	0		
 221	stiffened gnoll-tooth necklace	0		Damage Reduction: 1
 222	phat turquoise bead	0		
@@ -233,30 +233,30 @@
 235	narrow educational Bigger Bugfinder Blade of the early riser	0		Experience: +1, Adventures: +7
 236	spinning Queue Du Coq cocktailcrafting kit	0		
 237	acceptable bottle of gin	4	good	
-238	drinkable teal narrow bottle of vodka	4	good	
+238	drinkable narrow teal bottle of vodka	4	good	
 239	dangerous cool Orcish baseball cap	0		Moxie: +5, Weapon Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	studded supercool Orcish cargo shorts	0		Moxie Percent: +20, Damage Absorption: +80, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	chaotic Orcish frat-paddle	0		Spell Critical Percent: +10
 242	toothsome miniature	2	awesome	
-243	stale small grapefruit	2	decent	
-244	snack-sized decent grapes	2	good	
+243	small stale grapefruit	2	decent	
+244	decent snack-sized grapes	2	good	
 245	low-calorie delicious olive	1	awesome	
 246	spoiled blinking huge tomato	4	crappy	
 247	spinning fermenting powder	0		
 248	tolerable shaking salty dog	4	good	
-249	weak acceptable bloody mary	2	good	
+249	acceptable weak bloody mary	2	good	
 250	perfectly mixed screwdriver	3	EPIC	
 251	watered-down tolerable cyan martini	2	good	
-252	practically non-alcoholic lousy bloody beer	1	decent	
+252	lousy practically non-alcoholic bloody beer	1	decent	
 253	perfectly mixed shot of schnapps	3	EPIC	
 254	mediocre shot of grapefruit schnapps	4	decent	
-255	fancy practically non-alcoholic tolerable fine wine	1	good	Effect: "Spookypants", Effect Duration: 35
+255	tolerable fancy practically non-alcoholic fine wine	1	good	Effect: "Spookypants", Effect Duration: 35
 256	lousy shot of tomato schnapps	3	decent	
 257	mediocre triple-distilled blurry extra-spicy bloody mary	6	decent	
 258	blurry dense meat stack	0		
 259	yellow snake skin	0		
 260	snack-sized adequate White Citadel fries	2	good	
-261	normal huge White Citadel burger	9	good	
+261	huge normal White Citadel burger	9	good	
 262	delicious mirror piece of wedding cake	3	awesome	
 263	yummy snack-sized chocolate chips	2	awesome	
 264	snack-sized decent special chocolate chip cookies	2	good	Effect: "Rainbow Bright", Effect Duration: 35
@@ -267,14 +267,14 @@
 269	sword of horror	0		Spooky Spell Damage: +25
 270	mirror yellow picket fence	0		
 271	vaporized twirling barbell	1		
-272	pickled narrow maroon concentrated magicalness pill	1		Effect: "In the Saucestream", Effect Duration: 35
-273	dehydrated skewed spinning spinning moxie weed	1		
+272	pickled maroon narrow concentrated magicalness pill	1		Effect: "In the Saucestream", Effect Duration: 35
+273	dehydrated spinning skewed spinning moxie weed	1		
 274	mirror blurry Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
 277	twisted extra-strength strongness elixir	1		
 278	dried gray jug-o-magicalness	1		
-279	vaporized shaking narrow suntan lotion of moxiousness	1		
+279	vaporized narrow shaking suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	boxer's gasmask	0		Muscle Percent: +10, Familiar Effect: "1xBarrr, cap 12"
 282	Boris's key	0		
@@ -297,7 +297,7 @@
 299	quantum mirror maroon pickle-flavored chewing gum	0		Effect: "Adventurer's Best Friendship", Effect Duration: 53
 300	double-warmed jaba&ntilde;ero-flavored chewing gum	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 44
 301	flat dough	0		
-302	big decent Knob sausage	5	good	
+302	decent big Knob sausage	5	good	
 303	immense normal Knob mushroom	10	good	
 304	spinning dry noodles	0		
 305	gray lion tamer's Knob Goblin harem pants	0		Experience (familiar): +2, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -309,18 +309,18 @@
 311	hill of beans	0		
 312	medical-grade Knob Goblin visor	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	wholesome Crown of the Goblin King	0		Maximum HP Percent: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	super-sized decent bean burrito	5	good	
+314	decent super-sized bean burrito	5	good	
 315	normal bean burrito	3	good	
-316	enchanted small normal insanely bean burrito	2	good	Effect: "Fastbreaker", Effect Duration: 15
-317	low-calorie normal blurry bean burrito	1	good	
+316	enchanted normal small insanely bean burrito	2	good	Effect: "Fastbreaker", Effect Duration: 15
+317	normal low-calorie blurry bean burrito	1	good	
 318	small tasty bean burrito	2	awesome	
 319	gigantic flavorless mirror insanely bean burrito	7	decent	
 320	normal bat haggis	3	good	
-321	tiny rotten menudo	1	crappy	
-322	gigantic spoiled goat cheese	8	crappy	
+321	rotten tiny menudo	1	crappy	
+322	spoiled gigantic goat cheese	8	crappy	
 323	tasty wobbly plain pizza	3	awesome	
 324	stale huge spinning sausage pizza	7	decent	
-325	enchanted bland goat cheese pizza	3	decent	Effect: "All Branned Up", Effect Duration: 20
+325	bland enchanted goat cheese pizza	3	decent	Effect: "All Branned Up", Effect Duration: 20
 326	moldy mushroom pizza	3	crappy	
 327	goat	0		
 328	artisanal bottle of whiskey	4	EPIC	
@@ -335,7 +335,7 @@
 337	ol' trophy	0		
 338	jittery tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
-340	triple-frozen pressed tumbling ghostly Knob Goblin steroids	0		Effect: "Angry Bone", Effect Duration: 33
+340	triple-frozen pressed ghostly tumbling Knob Goblin steroids	0		Effect: "Angry Bone", Effect Duration: 33
 341	altered blurry Knob Goblin love potion	0		Effect: "Mystic Circle", Effect Duration: 53
 342	Knob Goblin stink bomb	0		
 343	flattened spinning Knob Goblin sharpening spray	0		Effect: "Slippery Tongue", Effect Duration: 51
@@ -354,14 +354,14 @@
 356	lard-coated snowboarder pants	0		Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, cap 25"
 357	blue Mountain Stream soda	0		
 358	bland gr8ps	3	decent	
-359	toothsome huge narrow t8r tots	4	awesome	
+359	toothsome narrow huge t8r tots	4	awesome	
 360	jittery reassuring miner's helmet	0		Spooky Resistance: +1, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	twirling miner's pants of James Dean	0		Experience (Moxie): +3, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	extremely unsafe 7-Foot Dwarven mattock	0		Weapon Damage Percent: +100
 363	linoleum ore	0		
 364	asbestos ore	0		
 365	chrome ore	0		
-366	blinking lime green linoleum sword hilt	0		
+366	lime green blinking linoleum sword hilt	0		
 367	linoleum stick	0		
 368	linoleum crossbow string	0		
 369	asbestos sword hilt	0		
@@ -383,7 +383,7 @@
 385	chrome staff of Leguizamo of extreme caution	0		Monster Level: -5
 386	chilly slick chrome crossbow	0		Moxie: +10, Cold Damage: +5
 387	fuzzy dice	0		
-388	spinning blue yeti fur	0		
+388	blue spinning yeti fur	0		
 389	squat chaotic meaty helmet turtle	0		Spell Critical Percent: +10, Familiar Effect: "sleaze atk, 1xFairy, cap 17"
 390	chaotic asbestos helmet turtle	0		Spell Critical Percent: +10, Familiar Effect: "hot atk, 1xFairy, cap 20"
 391	linoleum helmet turtle of incineration	0		Hot Spell Damage: +50, Familiar Effect: "stench atk, 1xFairy, cap 25"
@@ -451,7 +451,7 @@
 453	jittery sober pill	0		
 454	teal screwdriver	0		
 455	immense rotten jumbo olive	8	crappy	
-456	weak perfectly mixed upside-down dry martini	2	EPIC	
+456	perfectly mixed weak upside-down dry martini	2	EPIC	
 457	blurry weightlifter's ye olde golde frontes	0		Muscle: +15, Class: "Disco Bandit", Single Equip
 458	mirror continuum transfunctioner	0		
 459	pixel	0		
@@ -462,11 +462,11 @@
 464	pixel potion	0		
 465	narrow squat pixel potion	0		
 466	blurry pixel potion	0		
-467	miniature decent huge pixel pie	2	good	
+467	decent miniature huge pixel pie	2	good	
 468	ruby W	0		
 469	wussiness potion	0		
 470	bad Imp Ale	3	decent	
-471	flavorless jumbo hot wing	5	decent	
+471	jumbo flavorless hot wing	5	decent	
 472	pulsating rosy-cheeked diamond-studded cane	0		Maximum HP Percent: +30, Class: "Disco Bandit"
 473	wobbly wobbly crutch of the storm	0		Maximum MP Percent: +40
 474	cast	0		
@@ -498,10 +498,10 @@
 500	shaking Elf Farm Raffle ticket	0		
 501	stale Elfin shortbread	4	decent	
 502	pagoda plans	0		
-503	decent tiny narrow skewered cat appendix	1	good	
+503	tiny decent narrow skewered cat appendix	1	good	
 504	skewed evil arches	0		
 505	family-friendly baleful gnatwing earring	0		Spell Damage: +25, Sleaze Resistance: +1
-506	thick tasty Hell broth	5	awesome	
+506	tasty thick Hell broth	5	awesome	
 507	bouncing banded thunderrr guitarrr	0		Damage Absorption: +100
 508	jittery sonata	0		
 509	Hey Deze nuts	0		
@@ -510,7 +510,7 @@
 512	Sneaky Pete's key lime	0		
 513	miniature bland Boris's key lime pie	2	decent	
 514	normal tumbling Jarlsberg's key lime pie	3	good	
-515	moldy jumbo enchanted Sneaky Pete's key lime pie	5	crappy	Effect: "Quaaaaaaa", Effect Duration: 50
+515	enchanted jumbo moldy Sneaky Pete's key lime pie	5	crappy	Effect: "Quaaaaaaa", Effect Duration: 50
 516	tumbling Hey Deze map	0		
 517	jittery boxer's bejeweled accordion strap	0		Muscle Percent: +10, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -540,20 +540,20 @@
 542	1337 7r0uZ0RZ of chilblains of the boozehound	0		Cold Damage: +25, Booze Drop: +100, Familiar Effect: "2xPotato, cap 27"
 543	flavorless gigantic Trollhouse cookies	6	decent	
 544	narrow beefy talons of dire peril	0		Muscle: +10, Weapon Damage: +20
-545	small bland narrow Spam Witch sammich	2	decent	
+545	bland small narrow Spam Witch sammich	2	decent	
 546	yellow meat vortex	0		
-547	shaking twirling 334 scroll	0		
+547	twirling shaking 334 scroll	0		
 548	green 668 scroll	0		
 549	squat 30669 scroll	0		
 550	33398 scroll	0		
 551	shaking 64067 scroll	0		
 552	64735 scroll	0		
 553	huge 31337 scroll	0		
-554	bite-sized adequate spinning pr0n cocktail	1	good	
+554	adequate bite-sized spinning pr0n cocktail	1	good	
 555	tumbling drywall axe of terror of the boozehound	0		Spooky Spell Damage: +10, Booze Drop: +100
 556	stiffened Pine-Fresh air freshener	0		Damage Reduction: 1
 557	lousy whiskey and cola	3	decent	
-558	flavorless miniature blue papaya taco	2	decent	
+558	miniature flavorless blue papaya taco	2	decent	
 559	razor-sharp can lid	0		
 560	flavorless upside-down stalk of asparagus	3	decent	
 561	pregnant mushroom	0		
@@ -567,14 +567,14 @@
 569	tasty Lord of the Flies-sized fries	4	awesome	
 570	spoiled miniature blinking Chicken Sandwich	2	crappy	
 571	Jumbo Dr. Lucifer	1	awesome	
-572	spoiled huge tumbling Children's Meal of the Damned	7	crappy	
+572	huge spoiled tumbling Children's Meal of the Damned	7	crappy	
 573	half-sized bland wobbly noodles	2	decent	
 574	rotten noodles	3	crappy	
 575	bland painful penne pasta	3	decent	
 576	normal ravioli della hippy	3	good	
 577	normal tiny pr0n m4nic0tti	1	good	
-578	normal snack-sized blinking Hell ramen	2	good	
-579	half-sized rotten boring spaghetti	2	crappy	
+578	snack-sized normal blinking Hell ramen	2	good	
+579	rotten half-sized boring spaghetti	2	crappy	
 580	sauce of the ages	0		
 581	mirror schmancy cheese sauce	0		
 582	cyan Himalayan Hidalgo sauce	0		
@@ -612,7 +612,7 @@
 614	tarnished probability potion	0		Effect: "Sweet Incentive", Effect Duration: 46
 615	chaos butterfly	0		
 616	furry fur	0		
-617	ionized upside-down maroon Angry Farmer candy	0		Effect: "Bubblin' Rage", Effect Duration: 17
+617	ionized maroon upside-down Angry Farmer candy	0		Effect: "Bubblin' Rage", Effect Duration: 17
 618	altered Mick's IcyVapoHotness Rub	0		Effect: "Cold Hands", Effect Duration: 41
 619	clever needle	0		Maximum MP: +20
 620	Vulcanized triple-moist twirling thin candle	0		Effect: "Stop the Presses!", Effect Duration: 25
@@ -664,12 +664,12 @@
 666	knitted scorching brawny steaming evil	0		Muscle Percent: +20, Hot Damage: +25, Cold Resistance: +3
 667	castle map	0		
 668	educational spiked femur	0		Experience: +1
-669	immense toothsome ghuol guolash	8	awesome	
+669	toothsome immense ghuol guolash	8	awesome	
 670	smartaleck's lihc face	0		Moxie Percent: +30, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	blinking electrified ruddy grave robbing shovel	0		Maximum HP Percent: +40, MP Regen Min: 3, MP Regen Max: 5
 672	adequate cranberries	3	good	
 673	tolerable vodka and cranberry	3	good	
-674	artisanal special extra-dry whiskey	5	EPIC	Effect: "Destructive Resolve", Effect Duration: 10
+674	special artisanal extra-dry whiskey	5	EPIC	Effect: "Destructive Resolve", Effect Duration: 10
 675	mirror Herculean skull of the Bonerdagon	0		Experience (Muscle): +1
 676	dragonbone belt buckle	0		
 677	Sinatra's badass belt	0		Experience (Moxie): +5
@@ -677,9 +677,9 @@
 679	weak tolerable squat roll in the hay	2	good	
 680	smooth teal slap and tickle	3	awesome	
 681	aged triple-distilled slip 'n' slide	6	awesome	
-682	artisanal fuchsia pulsating a sump'm sump'm	4	EPIC	
-683	boozy acceptable twirling horizontal tango	5	good	
-684	perfectly mixed watered-down pink pony	2	EPIC	
+682	artisanal pulsating fuchsia a sump'm sump'm	4	EPIC	
+683	acceptable boozy twirling horizontal tango	5	good	
+684	watered-down perfectly mixed pink pony	2	EPIC	
 685	blinking rock-hard dance instructor's Mr. Shirt of the sweet-tooth	0		Experience Percent (Moxie): +10, Damage Reduction: 5, Candy Drop: +100
 686	maroon mirror knuckles of doom	0		Spooky Spell Damage: +50
 687	vacuum-sealed corrupted blood of the Wereseal	0		Effect: "Uncucumbered", Effect Duration: 46
@@ -735,7 +735,7 @@
 739	gray tambourine bells	0		
 740	clever tambourine	0		Maximum MP: +20
 741	huge broken skull	0		
-742	decent enchanted Knoll shroomkabob	3	good	Effect: "All Blued Up", Effect Duration: 10
+742	enchanted decent Knoll shroomkabob	3	good	Effect: "All Blued Up", Effect Duration: 10
 743	stale snack-sized mushroom	2	decent	
 744	adjusted chilled hair spray	0		Effect: "meat.enh", Effect Duration: 54
 746	narrow stat script	0		
@@ -744,17 +744,17 @@
 749	rotten snack-sized lime green warm mushroom	2	crappy	
 750	massive flavorless squat mushroom quesadilla	8	decent	
 751	normal squat jittery cool mushroom	3	good	
-752	flavorless massive green cool mushroom casserole	7	decent	
+752	massive flavorless green cool mushroom casserole	7	decent	
 753	stale pointy mushroom	3	decent	
 754	stale twirling cream of pointy mushroom soup	3	decent	
 755	moldy mushroom	3	crappy	
-756	half-sized flavorless fancy mushroom	2	decent	Effect: "Human-Insect Hybrid", Effect Duration: 25
+756	fancy half-sized flavorless mushroom	2	decent	Effect: "Human-Insect Hybrid", Effect Duration: 25
 757	delicious narrow mushroom	4	awesome	
-758	delicious bite-sized ghost cucumber	1	awesome	
-759	narrow blue ghostly dill	0		
+758	bite-sized delicious ghost cucumber	1	awesome	
+759	blue narrow ghostly dill	0		
 760	blue vinegar	0		
 761	brine	0		
-762	practically non-alcoholic drinkable especially salty dog	1	good	
+762	drinkable practically non-alcoholic especially salty dog	1	good	
 763	ghostly pickling solution	0		
 764	flavorless spectral pickle	4	decent	
 765	upside-down blurry briny vinegar	0		
@@ -767,14 +767,14 @@
 772	weightlifter's foon	0		Muscle: +15
 773	ghostly banded basic meat spork of terror	0		Damage Absorption: +100, Spooky Spell Damage: +10
 774	shaking greedy smartaleck's basic meat foon	0		Moxie Percent: +30, Meat Drop: +20
-775	wobbly red Yeti Protest Sign	0		
+775	red wobbly Yeti Protest Sign	0		
 776	twirling smooth kneecapping stick	0		Moxie: +15
 777	blurry Da Vinci's iron pasta spoon	0		Experience (Mysticality): +5
 778	MacGyver's support cummerbund	0		Maximum MP: +100
 779	Mob Penguin cellular phone	0		
 780	tumbling mirror scroll of pasta summoning	0		
 781	unsweetened mafia aria	0		Effect: "Sweet Nostalgia", Effect Duration: 60
-782	upside-down shaking Mr. Exploiter	0		Last Available: "2009-12"
+782	shaking upside-down Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
 784	perfectly mixed blinking Acqua Del Piatto Merlot	3	super EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
@@ -787,10 +787,10 @@
 792	jittery lime green quilted Golden Mr. Accessory	0		Damage Absorption: +40, Softcore Only
 793	improved oil of stability	0		Effect: "Heart of Green", Effect Duration: 47
 794	quadruple-chilled galvanized blinking oil of slipperiness	0		Effect: "Halloweeny", Effect Duration: 57
-795	lousy watered-down Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
+795	watered-down lousy Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
 796	shellacked wizardly cement shoes of the sewer	0		Mysticality: +25, Damage Reduction: 7, Stench Damage: +25, Last Available: "2004-10"
 797	spirit-forward aged blinking rockin' wagon	5	awesome	
-798	drinkable high-proof ocean motion	9	good	
+798	high-proof drinkable ocean motion	9	good	
 799	acceptable fuzzbump	4	good	
 800	spoiled blinking poutine	4	crappy	
 801	bite-sized moldy Knob stir-fry	1	crappy	
@@ -803,7 +803,7 @@
 810	normal huge rat appendix stir-fry	4	good	
 811	decent mirror tofu stir-fry	4	good	
 812	adequate pr0n stir-fry	3	good	
-813	super-sized normal Knob shells	5	good	
+813	normal super-sized Knob shells	5	good	
 814	normal blurry jittery b&auml;tzle	3	good	
 815	decent ratini	3	good	
 816	gigantic rotten Knob stroganoff	10	crappy	
@@ -829,12 +829,12 @@
 836	flavorless super-sized mind flayer corpse	5	decent	
 837	drinkable jittery Uovo Marcio Shiraz	4	good	Last Available: "2004-10"
 838	upside-down executive brawny Mafia stogie	0		Muscle Percent: +20, Meat Drop: +40, Last Available: "2004-10"
-839	high-proof perfectly mixed upside-down shaking Maiali Sifilitici Pinot Noir	10	EPIC	Last Available: "2004-10"
+839	high-proof perfectly mixed shaking upside-down Maiali Sifilitici Pinot Noir	10	EPIC	Last Available: "2004-10"
 840	clever stiffened Mafia violin case	0		Damage Reduction: 1, Maximum MP: +20, Last Available: "2004-10"
-841	weak lousy red wobbly tomato daiquiri	2	decent	
+841	lousy weak wobbly red tomato daiquiri	2	decent	
 842	irresponsibly strong lousy beertini	10	decent	
 843	aged salty slug	4	awesome	
-844	fancy practically non-alcoholic drinkable blinking papaya slung	1	good	Effect: "Speed of the Internet", Effect Duration: 20
+844	practically non-alcoholic drinkable fancy blinking papaya slung	1	good	Effect: "Speed of the Internet", Effect Duration: 20
 845	quilted MAHI fez	0		Damage Absorption: +40, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -881,7 +881,7 @@
 890	flavorless blinking balaclava baklava	4	decent	
 891	upside-down strapping Warehouse 23 bling	0		Muscle: +5
 892	yellow dangerous Newton's bugbear-smiting sword of temperance	0		Experience (Mysticality): +3, Weapon Damage: +10, Sleaze Resistance: +5
-893	watered-down perfectly mixed lumbering jack	2	EPIC	
+893	perfectly mixed watered-down lumbering jack	2	EPIC	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	censurious Ms. Accessory	0		Sleaze Resistance: +3, Softcore Only
 896	Temple Grandin's sharpshooter's Mr. Accessory Jr.	0		Critical Hit Percent: +10, Familiar Weight: +7, Softcore Only
@@ -891,36 +891,36 @@
 900	tumbling smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	boozy drinkable Spasmi Dolorosi Del Rene Champagne	5	good	Last Available: "2004-10"
+903	drinkable boozy Spasmi Dolorosi Del Rene Champagne	5	good	Last Available: "2004-10"
 904	lard-coated wholesome school Mafia knickerbockers of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	altered boiled chilled huge Yummy Tummy bean	0		Effect: "Flamibili Tea", Effect Duration: 23
 906	boiled pulsating Rock Pops	0		Effect: "High Blood Chocolate Content", Effect Duration: 37
 907	Vulcanized twirling Mr. Mediocrebar	0		Effect: "The Two-Prong Crown", Effect Duration: 49
 908	super-frozen dry magnetized jittery Cold Hots candy	0		Effect: "Aloofah", Effect Duration: 45
 909	extra-enhanced Wint-O-Fresh mint	0		Effect: "Bananas!", Effect Duration: 40
-910	gigantic fancy tasty skewed dwarf bread	6	awesome	Effect: "Chunky", Effect Duration: 20
+910	tasty fancy gigantic skewed dwarf bread	6	awesome	Effect: "Chunky", Effect Duration: 20
 911	diffused Senior Mints	0		Effect: "Berry Critical", Effect Duration: 55
 912	concentrated ionized pixellated candy heart	0		Effect: "[1609]Dancin' Fool", Effect Duration: 59
 913	non-flattened gray kobold	0		Effect: "Chow Downed", Effect Duration: 22
 914	gray hand turkey outline	0		Free Pull, Last Available: "2004-11"
-915	ghostly bouncing yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
+915	bouncing ghostly yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fuchsia supercharged intergalactic pom poms of Flo-Jo	0		Maximum MP Percent: +30, Initiative: +100
 917	yellow Mob Penguin protection contract	0		
 918	smartaleck's Radio Free Baseball Cap	0		Moxie Percent: +30, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
 919	Jeselnik's Radio Free Pants	0		Sleaze Damage: +25, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	Radio Free Foil of the storm	0		Maximum MP Percent: +40, Last Available: "2006-07"
-921	half-sized stale radio button candy	2	decent	
+921	stale half-sized radio button candy	2	decent	
 922	blinking severed rocking horse head of courage	0		Spooky Resistance: +3
-923	blinking huge broken cellular phone	0		Last Available: "2004-01"
+923	huge blinking broken cellular phone	0		Last Available: "2004-01"
 924	mirror crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	oxidized adjusted Hawking's Elixir of Brilliance	0		Effect: "Heart of Lavender", Effect Duration: 50
-927	artisanal boozy fancy Ferita Del Petto Zinfandel	5	EPIC	Effect: "Carrion' On", Effect Duration: 50, Last Available: "2006-12"
+927	fancy artisanal boozy Ferita Del Petto Zinfandel	5	EPIC	Effect: "Carrion' On", Effect Duration: 50, Last Available: "2006-12"
 928	huge Annie Oakley's fuzzy bracelets	0		Critical Hit Percent: +20
 929	yellow Tesla arse-shooting crossbow	0		MP Regen Min: 7, MP Regen Max: 10
 931	artisanal fortified spiced rum	5	EPIC	
 932	smooth green eggnog	3	awesome	
-933	rotten immense fancy teal candy cane	9	crappy	Effect: "Springy Fusilli", Effect Duration: 15
+933	rotten fancy immense teal candy cane	9	crappy	Effect: "Springy Fusilli", Effect Duration: 15
 934	yummy mirror gingerbread bugbear	4	awesome	
 935	stylish imitation nice watch	0		Moxie: +25, Single Equip, Last Available: "2004-12"
 936	huge Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -935,7 +935,7 @@
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	weak fancy drinkable martini	2	good	Effect: "Shamboozled", Effect Duration: 50, Last Available: "2004-12"
+948	fancy drinkable weak martini	2	good	Effect: "Shamboozled", Effect Duration: 50, Last Available: "2004-12"
 949	acceptable weak grogtini	2	good	Last Available: "2004-12"
 950	acceptable twirling cherry bomb	3	good	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -982,7 +982,7 @@
 992	ghostly ribald hale plastic Jarlsberg of the glutton	0		Maximum HP: +20, Sleaze Damage: +10, Food Drop: +100
 993	jittery cool beefcake's plastic Sneaky Pete of the brute	0		Muscle: +25, Moxie: +5, Muscle Percent: +30
 994	supercool plastic Susie	0		Moxie Percent: +20
-995	tiny bland cyan Lucky Surprise Egg	1	decent	
+995	bland tiny cyan Lucky Surprise Egg	1	decent	
 998	narrow maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	maid head	0		
 1000	yellow Meat maid	0		
@@ -995,20 +995,20 @@
 1008	blurry red brainy ice cubes	0		Mysticality: +5
 1009	acceptable vodka martini	3	good	
 1010	tolerable whiskey and soda	4	good	
-1011	delicious triple-distilled monkey wrench	6	awesome	
+1011	triple-distilled delicious monkey wrench	6	awesome	
 1012	lousy tequila sunrise	4	decent	
 1013	hand-crafted margarita	3	EPIC	
 1014	perfectly mixed strawberry wine	3	EPIC	
 1015	mediocre boozy wine spritzer	5	decent	
 1016	hand-crafted perpendicular hula	3	EPIC	
-1017	aged weak ducha de oro	2	awesome	
-1018	tolerable blinking jittery calle de miel	4	good	
+1017	weak aged ducha de oro	2	awesome	
+1018	tolerable jittery blinking calle de miel	4	good	
 1019	strong mediocre dry vodka martini	5	decent	
 1020	aged old-fashioned	3	awesome	
-1021	irresponsibly strong bad tequila with training wheels	7	decent	
-1022	watered-down artisanal pulsating sangria	2	EPIC	
+1021	bad irresponsibly strong tequila with training wheels	7	decent	
+1022	artisanal watered-down pulsating sangria	2	EPIC	
 1023	weak perfectly mixed vesper	2	super ultra mega turbo EPIC	Last Available: "2004-12"
-1024	spirit-forward special perfectly mixed bodyslam	5	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5, Last Available: "2004-12"
+1024	spirit-forward perfectly mixed special bodyslam	5	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5, Last Available: "2004-12"
 1025	perfectly mixed sangria del diablo	3	super ultra EPIC	Last Available: "2004-12"
 1026	wobbly Valentine	0		Free Pull
 1027	fuchsia whip kit	0		
@@ -1045,9 +1045,9 @@
 1059	huge puce plastic oyster egg	0		
 1060	vaporized mauve oyster egg	1		
 1061	powdered mauve oyster egg	1		
-1062	vaporized blinking purple mauve oyster egg	1		Effect: "Powdered", Effect Duration: 15
+1062	vaporized purple blinking mauve oyster egg	1		Effect: "Powdered", Effect Duration: 15
 1063	mauve plastic oyster egg	0		
-1064	powdered teal blurry oyster egg	1		
+1064	powdered blurry teal oyster egg	1		
 1065	twisted mirror oyster egg	1		Effect: "Tenacity of the Snapper", Effect Duration: 25
 1066	diluted oyster egg	1		
 1067	plastic oyster egg	0		
@@ -1071,7 +1071,7 @@
 1085	clockwork widget	0		
 1086	clockwork thingamajig	0		
 1087	clockwork doohickey	0		
-1088	bouncing fuchsia clockwork clockwise dome	0		
+1088	fuchsia bouncing clockwork clockwise dome	0		
 1089	clockwork spine	0		
 1090	clockwork rings	0		
 1091	clockwork claws	0		
@@ -1122,7 +1122,7 @@
 1136	electrified lipstick	0		Effect: "Human-Elemental Hybrid", Effect Duration: 18
 1137	wool resourceful bicycle chain	0		Maximum MP: +50, Cold Resistance: +1
 1138	pulsating ghostly mushroom fermenting solution	0		
-1139	tolerable high-proof skewed mushroom wine	8	good	
+1139	high-proof tolerable skewed mushroom wine	8	good	
 1140	tolerable shaking icy mushroom wine	3	good	
 1141	perfectly mixed fancy mushroom wine	3	EPIC	Effect: "Boon of the War Snapper", Effect Duration: 40
 1142	mediocre blue pointy mushroom wine	3	decent	
@@ -1135,7 +1135,7 @@
 1149	normal gigantic green flower petal pie	7	good	
 1150	lousy practically non-alcoholic bottle of single-barrel whiskey	1	decent	
 1151	teal flame-retardant arcane researcher's discarded plastic fork	0		Experience Percent (Mysticality): +10, Hot Resistance: +1
-1152	olive huge gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
+1152	huge olive gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	flavorless Retenez L'Herbe Pat&eacute;	4	decent	
 1154	compressed skewed ghostly Breathetastic&trade; Premium Canned Air	1	EPIC	Effect: "Egg on your Face", Effect Duration: 5
 1155	letter from King Ralph XI	0		
@@ -1147,7 +1147,7 @@
 1162	denatured cold-filtered mirror handsomeness potion	0		Effect: "Good Karma", Effect Duration: 50
 1163	corrupted irradiated marzipan skull	0		Effect: "init.enh", Effect Duration: 12
 1164	poultrygeist	0		
-1165	maroon spinning hovering sombrero	0		
+1165	spinning maroon hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	less-than-three-shaped box	0		
@@ -1161,14 +1161,14 @@
 1176	refrigerated biohazard container	0		
 1177	magnetic field	0		
 1178	potted cactus	0		
-1179	jittery skewed purple daisy	0		
+1179	skewed jittery purple daisy	0		
 1180	jittery potted fern	0		
 1181	tulip	0		
 1182	Venus flytrap	0		
 1183	all-purpose flower	0		
 1184	exotic orchid	0		
 1185	long-stemmed rose	0		
-1186	spinning green tumbling gilded lily	0		
+1186	spinning tumbling green gilded lily	0		
 1187	deadly nightshade	0		
 1188	spinning lotus	0		
 1189	can of asparagus	0		
@@ -1183,16 +1183,16 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	flavorless mugcake	3	decent	
-1201	bland low-calorie urinal cake	1	decent	
-1202	low-calorie decent Happy Birthday, Claude! cake	1	good	
+1201	low-calorie bland urinal cake	1	decent	
+1202	decent low-calorie Happy Birthday, Claude! cake	1	good	
 1203	decent gigantic personalized birthday cake	6	good	
 1204	adequate pulsating three-tiered wedding cake	4	good	
 1205	huge decent babycakes	8	good	
 1206	yummy blurry velvet cake	3	awesome	
-1207	moldy snack-sized narrow congratulatory cake	2	crappy	
+1207	snack-sized moldy narrow congratulatory cake	2	crappy	
 1208	yummy half-sized mirror angel-food cake	2	awesome	
-1209	yummy big devil's-food cake	5	awesome	
-1210	big stale birthday party jellybean cheesecake	5	decent	
+1209	big yummy devil's-food cake	5	awesome	
+1210	stale big birthday party jellybean cheesecake	5	decent	
 1211	mirror balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
@@ -1238,10 +1238,10 @@
 1254	flavorless jumping bean burrito	3	decent	
 1255	stale jumping bean burrito	3	decent	
 1256	tiny decent insanely jumping bean burrito	1	good	
-1257	tiny stale rat scrapple	1	decent	
+1257	stale tiny rat scrapple	1	decent	
 1258	pail of pretentious paint	0		
 1259	shaking up-at-dawn traffic cone of the sewer	0		Stench Damage: +25, Adventures: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
-1260	mirror lime green wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
+1260	lime green mirror wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	denatured blurry Hatorade	1		Effect: "Boilermade", Effect Duration: 45
 1262	pulsating censurious rock-hard off-hand balloon of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Sleaze Resistance: +3
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	toothsome bowl of oriole's nest soup	3	awesome	
 1356	skewed bunny liver	0		
-1357	watered-down perfectly mixed Mt. Noob Pale Ale	2	EPIC	
+1357	perfectly mixed watered-down Mt. Noob Pale Ale	2	EPIC	
 1358	red pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1348,7 +1348,7 @@
 1365	small yummy tofurkey leg	2	awesome	
 1366	stale tofurkey gravy	4	decent	
 1367	decent blinking herbal stuffing	4	good	
-1368	huge adequate blurry can-shaped gelatinous cranberry sauce	8	good	
+1368	adequate huge blurry can-shaped gelatinous cranberry sauce	8	good	
 1369	adequate big yams	5	good	
 1370	Socratic rhinestone cowboy shirt	0		Experience (Mysticality): +1
 1371	ghostly dangerous gingham blouse	0		Weapon Damage: +10
@@ -1386,12 +1386,12 @@
 1404	thinker's colored-light &quot;necklace&quot;	0		Mysticality: +10, Last Available: "2005-12"
 1405	beefy tree skirt	0		Muscle: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	rotten half-sized wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	miniature adequate bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	adequate miniature bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	half-sized normal tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	knitted Unionize The Elves sign	0		Cold Resistance: +3, Last Available: "2005-12"
 1410	olive upside-down sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
-1412	boiled huge yellow snowcone	0		Effect: "Empty Inside", Effect Duration: 67, Last Available: "2006-01"
+1412	boiled yellow huge snowcone	0		Effect: "Empty Inside", Effect Duration: 67, Last Available: "2006-01"
 1413	moist pickled bouncing snowcone	0		Effect: "Whippin' It Good", Effect Duration: 33, Last Available: "2006-01"
 1414	chilled ghostly snowcone	0		Effect: "Towering Strength", Effect Duration: 49, Last Available: "2006-01"
 1415	polymerized dry vacuum-sealed skewed snowcone	0		Effect: "Slimy Flavor", Effect Duration: 67, Last Available: "2006-01"
@@ -1407,7 +1407,7 @@
 1425	prompt ice baby	0		Adventures: +3, Softcore Only, Last Available: "2006-02"
 1426	teal jittery lion tamer's ice pick	0		Experience (familiar): +2, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	lime green therapeutic Newton's ice skates	0		Experience (Mysticality): +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	moldy huge blinking grue egg omelette	10	crappy	
+1428	huge moldy blinking grue egg omelette	10	crappy	
 1429	ghostly roll of drink tickets	0		
 1430	huge pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1429,7 +1429,7 @@
 1447	oxidized nuggets	0		Effect: "Nuts about Candy", Effect Duration: 56
 1448	triple-adjusted tarnished galvanized stench nuggets	0		Effect: "Antibiotic Saucesphere", Effect Duration: 20
 1449	dry sleaze nuggets	0		Effect: "Army of One", Effect Duration: 45
-1450	dehydrated twirling tumbling teal tumbling twinkly wad	1		
+1450	dehydrated tumbling teal tumbling twirling twinkly wad	1		
 1451	dehydrated wobbly hot wad	1		
 1452	diluted olive wad	1		
 1453	denatured huge twirling wad	1		Effect: "Neutered Nostrils", Effect Duration: 30
@@ -1449,7 +1449,7 @@
 1467	25-meat staff	0		
 1468	two-handed depthsword	0		
 1469	bill bec-de-bardiche glaive-guisarme	0		
-1470	gray upside-down lead yo-yo	0		
+1470	upside-down gray lead yo-yo	0		
 1471	slightly peevedbow	0		
 1472	sack of doorknobs	0		
 1473	skewed ball-and-chain	0		
@@ -1503,7 +1503,7 @@
 1522	shaking family-friendly wool Radio Free Jersey	0		Cold Resistance: +1, Sleaze Resistance: +1
 1523	jittery bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	skewed pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	twirling diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Annie Oakley's Rosewater's corkscrew	0		Mysticality Percent: +30, Critical Hit Percent: +20, Last Available: "2006-04"
@@ -1533,46 +1533,46 @@
 1553	artisanal mirror bottle of Calcutta Emerald	4	EPIC	
 1554	lousy bottle of Lieutenant Freeman	3	decent	
 1555	mediocre huge bottle of Jorge Sinsonte	3	decent	
-1556	bad high-proof skewed boxed champagne	9	decent	
+1556	high-proof bad skewed boxed champagne	9	decent	
 1557	yummy kumquat	3	awesome	
 1558	normal green tangerine	4	good	
 1559	tonic water	0		
 1560	bland ghostly cocktail onion	3	decent	
 1561	spoiled teal raspberry	4	crappy	
-1562	bland miniature kiwi	2	decent	
-1563	tolerable strong blurry whiskey bittersweet	5	good	
+1562	miniature bland kiwi	2	decent	
+1563	strong tolerable blurry whiskey bittersweet	5	good	
 1564	bad practically non-alcoholic ghostly mimosette	1	decent	
-1565	high-proof artisanal tequila sunset	10	EPIC	
+1565	artisanal high-proof tequila sunset	10	EPIC	
 1566	perfectly mixed zmobie	4	EPIC	Wiki Name: "Zmobie (drink)"
-1567	tolerable triple-distilled upside-down gin and tonic	6	good	
-1568	triple-distilled drinkable blurry vodka and tonic	9	good	
+1567	triple-distilled tolerable upside-down gin and tonic	6	good	
+1568	drinkable triple-distilled blurry vodka and tonic	9	good	
 1569	tolerable vodka gibson	3	good	
 1570	artisanal weak gibson	2	EPIC	
-1571	enchanted distilled lousy parisian cathouse	5	decent	Effect: "Powder Power", Effect Duration: 20
+1571	enchanted lousy distilled parisian cathouse	5	decent	Effect: "Powder Power", Effect Duration: 20
 1572	delicious rabbit punch	4	awesome	
-1573	high-proof hand-crafted tumbling pulsating caipifruta	9	EPIC	
-1574	acceptable watered-down tumbling squat teqiwila	2	good	
+1573	hand-crafted high-proof pulsating tumbling caipifruta	9	EPIC	
+1574	watered-down acceptable squat tumbling teqiwila	2	good	
 1575	drinkable wobbly narrow Divine	3	good	
 1576	delicious narrow Gordon Bennett	3	awesome	
-1577	delicious irresponsibly strong tangarita	7	awesome	
+1577	irresponsibly strong delicious tangarita	7	awesome	
 1578	mediocre mandarina colada	4	decent	
-1579	tolerable high-proof gimlet	6	good	
+1579	high-proof tolerable gimlet	6	good	
 1580	triple-distilled artisanal brick road	8	EPIC	
-1581	hand-crafted fancy squat vodka stratocaster	3	EPIC	Effect: "Magically Delicious", Effect Duration: 50
+1581	fancy hand-crafted squat vodka stratocaster	3	EPIC	Effect: "Magically Delicious", Effect Duration: 50
 1582	lousy ghostly Neuromancer	4	decent	
-1583	aged blinking cyan prussian cathouse	4	awesome	
+1583	aged cyan blinking prussian cathouse	4	awesome	
 1584	fortified perfectly mixed Mae West	5	EPIC	
 1585	acceptable Mon Tiki	3	good	
 1586	mediocre teqiwila slammer	4	decent	
 1587	stale jittery Knob lo mein	3	decent	
 1588	spoiled asparagus lo mein	3	crappy	
 1589	spoiled narrow Knoll lo mein	4	crappy	
-1590	stale thick enchanted red lo mein	5	decent	Effect: "Moon'd", Effect Duration: 45
+1590	thick enchanted stale red lo mein	5	decent	Effect: "Moon'd", Effect Duration: 45
 1591	bland olive lo mein	4	decent	
 1592	immense yummy upside-down hot hi mein	8	awesome	
 1593	decent cyan hi mein	4	good	
 1594	stale half-sized hi mein	2	decent	
-1595	fancy adequate pulsating hi mein	3	good	Effect: "Corruption of Wretched Wally", Effect Duration: 10
+1595	adequate fancy pulsating hi mein	3	good	Effect: "Corruption of Wretched Wally", Effect Duration: 10
 1596	bland sleazy hi mein	4	decent	
 1597	Junior LAAAAME merit badge of the storm	0		Maximum MP Percent: +40, Last Available: "2006-05"
 1598	vibrating Senior LAAAAME merit badge	0		Maximum MP Percent: +10, Last Available: "2006-05"
@@ -1588,8 +1588,8 @@
 1608	improved adjusted mirror eyedrops of the ermine	0		Effect: "Incredibly Hulking", Effect Duration: 15
 1609	alkaline ghostly perfume of prejudice	0		Effect: "Buzzard Breath", Effect Duration: 53
 1610	colloidal eyedrops of the ocelot	0		Effect: "Graham Crackling", Effect Duration: 27
-1611	anodized quadruple-diffused liquefied shaking bouncing potent potion of potency	0		Effect: "Eagle Eyes", Effect Duration: 39
-1612	triple-colloidal denatured fuchsia upside-down concentrated cordial of concentration	0		Effect: "Bats in the Belfry", Effect Duration: 64
+1611	anodized quadruple-diffused liquefied bouncing shaking potent potion of potency	0		Effect: "Eagle Eyes", Effect Duration: 39
+1612	triple-colloidal denatured upside-down fuchsia concentrated cordial of concentration	0		Effect: "Bats in the Belfry", Effect Duration: 64
 1613	green wobbly banded coffin lid	0		Damage Absorption: +100, Damage Reduction: 3
 1614	satin shield of the cheetah	0		Initiative: +60, Damage Reduction: 5
 1615	Cerebral Cloche of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
@@ -1619,7 +1619,7 @@
 1639	enhanced pulsating lotion of spookiness	0		Effect: "Limber as Mortimer", Effect Duration: 11
 1640	extra-frozen lotion of stench	0		Effect: "Starry-Eyed", Effect Duration: 42
 1641	flattened blinking lotion of sleaziness	0		Effect: "Trufflin'", Effect Duration: 57
-1642	watered-down acceptable Grimacite Bock	2	good	Last Available: "2008-11"
+1642	acceptable watered-down Grimacite Bock	2	good	Last Available: "2008-11"
 1643	stale wobbly wedge of gray cheese	3	decent	Last Available: "2008-11"
 1644	lime green hot and sauce	0		
 1645	and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	thick decent foie gras	5	good	
 1652	activated galvanized candy brain	0		Effect: "Brother Corsican's Blessing", Effect Duration: 62, Last Available: "2020-09"
-1653	up-at-dawn sizzling jewel-eyed wizard hat of the pedagogue	0		Experience: +3, Hot Damage: +10, Adventures: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	up-at-dawn sizzling jewel-eyed wizard hat of the pedagogue	0		Experience: +3, Hot Damage: +10, Adventures: +5, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	Sinatra's groovy wad of Crovacite	0		Moxie Percent: +10, Experience (Moxie): +5
 1655	Oprah's brawny collar	0		Muscle Percent: +20, Maximum MP Percent: +50
 1656	shaking White Citadel Satisfaction Satchel	0		
@@ -1652,7 +1652,7 @@
 1672	swindleblossom	0		
 1673	skewed miser's Van der Graaf grave robbing shovel	0		Meat Drop: +10, MP Regen Min: 5, MP Regen Max: 7
 1674	superhero mask of the cheetah	0		Initiative: +60, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
-1675	narrow blinking ore	0		
+1675	blinking narrow ore	0		
 1676	blurry styrofoam ore	0		
 1677	spinning bubblewrap ore	0		
 1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
@@ -1676,7 +1676,7 @@
 1696	toothsome thick pulsating royal jelly taco	5	awesome	
 1697	decent lime green tofu taco	4	good	
 1698	moldy jumping bean taco	3	crappy	
-1699	delicious small gray wobbly catgut taco	2	awesome	
+1699	small delicious gray wobbly catgut taco	2	awesome	
 1700	moldy gigantic goat cheese taco	8	crappy	
 1701	stale pr0n taco	4	decent	
 1702	nitrogenated altered alphabet gum	0		Effect: "Happy Salamander", Effect Duration: 51
@@ -1754,7 +1754,7 @@
 1775	reassuring dishrag	0		Spooky Resistance: +1
 1776	snack-sized adequate tumbling stale baguette	2	good	
 1777	huge lime green leftovers of indeterminate origin	0		
-1778	enchanted rotten snack-sized purple dinner	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 45
+1778	rotten snack-sized enchanted purple dinner	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 45
 1779	squat wizardly katana	0		Mysticality: +25
 1780	ram stick of the glutton	0		Food Drop: +100
 1781	jittery yellow aromatic enchantlers	0		Stench Resistance: +1, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1766,7 +1766,7 @@
 1787	quantum pickled bouncing fuchsia bag of Cheat-Os	0		Effect: "Fishy Fortification", Effect Duration: 65
 1788	jittery unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	bad irresponsibly strong gray Ram's Face Lager	8	decent	
+1790	irresponsibly strong bad gray Ram's Face Lager	8	decent	
 1791	ram horns	0		
 1792	mansplainer's extremely unsafe Travoltan trousers of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +100, Monster Level: +15, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	aromatic pool cue of James Dean	0		Experience (Moxie): +3, Stench Resistance: +1
@@ -1776,14 +1776,14 @@
 1797	misshapen animal skeleton	0		
 1798	pile of animal bones	0		
 1799	animal skull	0		
-1800	shaking wobbly olive animal cranium	0		
+1800	shaking olive wobbly animal cranium	0		
 1801	upside-down narrow animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
-1807	maroon huge blurry sixth cervical vertebra	0		
+1807	huge blurry maroon sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
 1809	twirling first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
@@ -1810,7 +1810,7 @@
 1831	twirling skewed third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
-1834	teal shaking sixth caudal vertebra	0		
+1834	shaking teal sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
 1836	shaking eighth caudal vertebra	0		
 1837	ninth caudal vertebra	0		
@@ -1818,7 +1818,7 @@
 1839	yellow left first rib	0		
 1840	huge left second rib	0		
 1841	twirling left third rib	0		
-1842	tumbling spinning left fourth rib	0		
+1842	spinning tumbling left fourth rib	0		
 1843	left fifth rib	0		
 1844	pulsating left sixth rib	0		
 1845	left seventh rib	0		
@@ -1853,7 +1853,7 @@
 1874	wobbly left femur	0		
 1875	right femur	0		
 1876	left tibia	0		
-1877	narrow huge right tibia	0		
+1877	huge narrow right tibia	0		
 1878	green left fibula	0		
 1879	wobbly right fibula	0		
 1880	squat wobbly left kneecap	0		
@@ -1862,7 +1862,7 @@
 1883	left second front claw	0		
 1884	left third front claw	0		
 1885	left fourth front claw	0		
-1886	bouncing tumbling right first front claw	0		
+1886	tumbling bouncing right first front claw	0		
 1887	right second front claw	0		
 1888	right third front claw	0		
 1889	pulsating right fourth front claw	0		
@@ -1891,7 +1891,7 @@
 1914	olive clockwork rod	0		
 1915	clockwork shank	0		
 1916	Lord Spookyraven's spectacles	0		
-1917	bouncing maroon wallet	0		
+1917	maroon bouncing wallet	0		
 1918	blue coin purse	0		
 1919	English to A. F. U. E. Dictionary	0		
 1920	bizarre illegible sheet music	0		
@@ -1933,7 +1933,7 @@
 1956	extra-dry mediocre snifter of thoroughly aged brandy	5	decent	
 1957	yellow quill pen	0		
 1958	bouncing inkwell	0		
-1959	shaking blue tattered scrap of paper	0		
+1959	blue shaking tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	Vulcanized tumbling Bit O' Ectoplasm	0		Effect: "Ruby-ous", Effect Duration: 21
@@ -1981,7 +1981,7 @@
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	gray Poison Oak trading card	0		
-2007	blurry maroon spinning Princess Rutabaga trading card	0		
+2007	spinning blurry maroon Princess Rutabaga trading card	0		
 2008	narrow Roo trading card	0		
 2009	red Woldo trading card	0		
 2010	The Snake trading card	0		
@@ -2000,7 +2000,7 @@
 2023	Genalen&trade; Bottle	1	decent	
 2024	adequate squat mixed wildflower greens	3	good	
 2025	flavorless teal handful of walnuts	3	decent	
-2026	normal big nutty organic salad	5	good	
+2026	big normal nutty organic salad	5	good	
 2027	bland half-sized blurry super salad	2	decent	
 2028	stale tofu wonton	3	decent	
 2029	hippy protest button	0		Single Equip
@@ -2011,7 +2011,7 @@
 2034	wicker shield of James Dean	0		Experience (Moxie): +3, Damage Reduction: 11
 2035	wobbly Marquis de Poivre soda	0		
 2036	alkaline radium-flavored potato chips	0		Effect: "Innately Truthy", Effect Duration: 28
-2037	diffused moist ghostly wobbly wintergreen-flavored potato chips	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 60
+2037	diffused moist wobbly ghostly wintergreen-flavored potato chips	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 60
 2038	concentrated irradiated narrow ennui-flavored potato chips	0		Effect: "Berry Experiential", Effect Duration: 42
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
@@ -2020,9 +2020,9 @@
 2043	tumbling hemp net	0		
 2044	tumbling your father's MacGuffin diary	0		
 2045	stale brain-meltingly-hot chicken wings	3	decent	
-2046	bite-sized flavorless frat brats	1	decent	
-2047	huge moldy squat knob ka-bobs	8	crappy	
-2049	extra-dry hand-crafted can of Swiller	5	EPIC	
+2046	flavorless bite-sized frat brats	1	decent	
+2047	moldy huge squat knob ka-bobs	8	crappy	
+2049	hand-crafted extra-dry can of Swiller	5	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	skewed reassembled blackbird	0		
@@ -2038,7 +2038,7 @@
 2062	supercool shield of Tarzan	0		Moxie Percent: +20, Experience (Muscle): +3, Damage Reduction: 10
 2063	decent blackberry	3	good	
 2064	forged identification documents	0		
-2065	huge twirling PADL Phone	0		
+2065	twirling huge PADL Phone	0		
 2066	ribald lion tamer's kick-ass kicks	0		Experience (familiar): +2, Sleaze Damage: +10, Single Equip
 2067	sake bomb	0		
 2068	tequila grenade	0		
@@ -2056,9 +2056,9 @@
 2080	hardy makeshift cape	0		Maximum HP: +50
 2081	manspreader's makeshift skirt	0		Monster Level: +10, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 2082	green toothbrush	0		
-2083	mirror red makeshift crane	0		
+2083	red mirror makeshift crane	0		
 2084	can of starch	0		
-2085	altered skewed cyan ghostly bottle of ultravitamins	1		
+2085	altered cyan skewed ghostly bottle of ultravitamins	1		
 2086	boiled bottle of cough syrup	1		
 2087	modified maroon tube of hair oil	1		
 2088	diffused dry ionized spinning Daffy Taffy	0		Effect: "Haunted Stomach", Effect Duration: 19
@@ -2067,12 +2067,12 @@
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	lard-coated hors d'oeuvre tray	0		Sleaze Spell Damage: +25, Damage Reduction: 5
-2094	rotten big ghostly ballroom blintz	5	crappy	
+2094	big rotten ghostly ballroom blintz	5	crappy	
 2095	towel	0		
 2096	modified blurry guy made of bee pollen	1		Effect: "Carrrsmic", Effect Duration: 5
 2097	nippy 17-ball	0		Cold Damage: +10
 2098	filthy lucre	0		
-2099	fuchsia ghostly hobo gristle	0		
+2099	ghostly fuchsia hobo gristle	0		
 2100	shredded can label	0		
 2101	bloodstained briquette	0		
 2102	greasy dreadlock	0		
@@ -2105,7 +2105,7 @@
 2130	Sinatra's killer rag doll	0		Experience (Moxie): +5, Last Available: "2006-12"
 2131	skewed tree-eating kite	0		Last Available: "2006-12"
 2132	teal electrified incredibly marionette	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12"
-2133	blurry bouncing narrow dress ball	0		Last Available: "2010-12"
+2133	blurry narrow bouncing dress ball	0		Last Available: "2010-12"
 2134	gray asbestos-lined mad scientist's sock monkey	0		Hot Resistance: +5, Last Available: "2006-12"
 2135	alien blob	0		Last Available: "2006-12"
 2136	upside-down personal trainer's vampire duck-on-a-string of Leguizamo	0		Experience Percent (Muscle): +10, Monster Level: +20, Last Available: "2006-12"
@@ -2134,7 +2134,7 @@
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	mirror bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
-2162	jittery pulsating reverse-oscillating klystron	0		Last Available: "2011-12"
+2162	pulsating jittery reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	huge sub-molecular interocitor	0		Last Available: "2011-12"
 2164	olive recursive spline reticulator	0		Last Available: "2011-12"
 2165	atomic vector plotter	0		Last Available: "2011-12"
@@ -2161,18 +2161,18 @@
 2186	unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	ghostly flask of peppermint oil	1	crappy	Last Available: "2006-12"
-2189	weak delicious tumbling tumbling flask of peppermint schnapps	2	awesome	Last Available: "2006-12"
+2189	delicious weak tumbling tumbling flask of peppermint schnapps	2	awesome	Last Available: "2006-12"
 2190	tumbling yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	twirling sheet music	0		Last Available: "2006-12"
-2193	bland jumbo spinning candy stake	5	decent	Last Available: "2006-12"
+2193	jumbo bland spinning candy stake	5	decent	Last Available: "2006-12"
 2194	fancy weak bad eggnog	2	decent	Effect: "Almost Cool", Effect Duration: 50, Last Available: "2006-12"
 2195	spoiled unspeakable fruitcake	4	crappy	Last Available: "2006-12"
 2196	flavorless snack-sized gingerbread horror	2	decent	Last Available: "2006-12"
 2197	activated alkaline but probably evil chocolate	0		Effect: "Powdered", Effect Duration: 40, Last Available: "2006-12"
 2198	spoiled bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	tasty diet huge skull-shaped Crimboween cookie	1	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	huge bland mirror tombstone-shaped Crimboween cookie	10	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	bland huge mirror tombstone-shaped Crimboween cookie	10	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	plastic gift-wrapping vampire of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-12"
 2202	spinning dance instructor's plastic yuletide troll	0		Experience Percent (Moxie): +10, Last Available: "2006-12"
 2203	jittery shellacked plastic skeletal reindeer	0		Damage Reduction: 7, Single Equip, Last Available: "2006-12"
@@ -2190,7 +2190,7 @@
 2215	Tropical Crimbo Hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	purple asbestos-lined Tropical Crimbo Shorts	0		Hot Resistance: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	adequate purple super ka-bob	4	good	
-2218	decent snack-sized beer basted brat	2	good	
+2218	snack-sized decent beer basted brat	2	good	
 2219	frightening Tropical Crimbo Sword	0		Spooky Damage: +5, Last Available: "2006-12"
 2220	nitrogenated aerosolized green and Crimboween candy	0		Effect: "Discomfited", Effect Duration: 46, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2214,7 +2214,7 @@
 2239	squat maroon miser's greasy bad voodoo mask	0		Sleaze Spell Damage: +10, Meat Drop: +10, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	blue bottle of alcohol	0		
 2241	sizzling pygmy spear	0		Hot Damage: +10
-2242	enhanced bouncing tumbling pygmy pygment	0		Effect: "Mushroom Melody", Effect Duration: 41
+2242	enhanced tumbling bouncing pygmy pygment	0		Effect: "Mushroom Melody", Effect Duration: 41
 2243	steel-toed forbidden headhunter necktie	0		Spell Damage Percent: +50, Damage Reduction: 9, Single Equip
 2244	miser's perfumed pointed stick	0		Stench Resistance: +5, Meat Drop: +10
 2245	inspector's knobby helmet turtle	0		Item Drop: +15, Familiar Effect: "atk, 2xFairy, cap 5"
@@ -2234,17 +2234,17 @@
 2260	jittery hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	squat bird rib	0		
-2263	jittery olive lion oil	0		
-2264	flavorless massive stunt nuts	9	decent	
+2263	olive jittery lion oil	0		
+2264	massive flavorless stunt nuts	9	decent	
 2265	bland twirling wet stew	3	decent	
 2266	huge narrow wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats	0		Item Drop: +5
 2269	flavorless sausage wonton	4	decent	
 2270	belt of courage of the detective	0		Spooky Resistance: +3, Item Drop: +20, Single Equip
-2271	boozy hand-crafted bottle of Merlot	5	EPIC	
+2271	hand-crafted boozy bottle of Merlot	5	EPIC	
 2272	triple-distilled acceptable red bottle of Port	6	good	
-2273	watered-down hand-crafted bottle of Pinot Noir	2	EPIC	
+2273	hand-crafted watered-down bottle of Pinot Noir	2	EPIC	
 2274	boozy drinkable bottle of Zinfandel	5	good	
 2275	hand-crafted bottle of Marsala	3	EPIC	
 2276	acceptable bottle of Muscat	3	good	
@@ -2303,7 +2303,7 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	maroon ghostly bouquet of circular saw blades	0		
-2332	stale skewed blinking Better Than Cuddling Cake	4	decent	
+2332	stale blinking skewed Better Than Cuddling Cake	4	decent	
 2333	huge squat ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2311,11 +2311,11 @@
 2337	reinforced beaded headband of the detective	0		Item Drop: +20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	flavorless pudding	4	decent	Wiki Name: "black pudding (food)"
 2339	tolerable Blackfly Chardonnay	3	good	
-2340	practically non-alcoholic aged & tan	1	awesome	
+2340	aged practically non-alcoholic & tan	1	awesome	
 2341	upside-down pepper	0		
-2342	moldy snack-sized forest cake	2	crappy	
+2342	snack-sized moldy forest cake	2	crappy	
 2343	spoiled green forest ham	3	crappy	
-2344	dry non-electrified purple shaking filthworm hatchling scent gland	0		Effect: "Warm Shoulders", Effect Duration: 48
+2344	dry non-electrified shaking purple filthworm hatchling scent gland	0		Effect: "Warm Shoulders", Effect Duration: 48
 2345	polarized blinking filthworm drone scent gland	0		Effect: "Granolarrrgh", Effect Duration: 54
 2346	ionized blinking filthworm royal guard scent gland	0		Effect: "The Magic of Sharing", Effect Duration: 24
 2347	heart of the filthworm queen	0		
@@ -2329,7 +2329,7 @@
 2355	deionized irradiated tumbling henna face paint	0		Effect: "Salty Mouth", Effect Duration: 69
 2356	dry tube of dread wax	0		Effect: "Mystic Circle", Effect Duration: 22
 2357	skewed prompt careful Gaia beads	0		Monster Level: -10, Adventures: +3
-2358	squat upside-down pink clay bead	0		
+2358	upside-down squat pink clay bead	0		
 2359	tumbling clay bead	0		
 2360	clay bead	0		
 2361	bouncing chilly fortified hippy medical kit	0		Damage Absorption: +60, Cold Damage: +5, Single Equip
@@ -2344,11 +2344,11 @@
 2370	natural fennel soda	0		
 2371	ghostly shaking smoke bomb	0		
 2372	shaking bunch of bananas	0		
-2373	stale fancy miniature banana	2	decent	Effect: "All Blued Up", Effect Duration: 15
+2373	miniature stale fancy banana	2	decent	Effect: "All Blued Up", Effect Duration: 15
 2374	blinking banana peel	0		
 2375	decent banana cream pie	3	good	
 2376	bad banana daiquiri	4	decent	
-2377	mediocre irresponsibly strong bungle in the jungle	10	decent	
+2377	irresponsibly strong mediocre bungle in the jungle	10	decent	
 2378	banana spritzer	0		
 2379	non-modified narrow banana smoothie	0		Effect: "Adventurer's Best Friendship", Effect Duration: 21
 2380	lime green dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	stale special blue bowl of Bounty-Os	4	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 35
-2465	watered-down perfectly mixed mirror Oreille Divis&eacute;e brandy	2	super EPIC	
+2465	perfectly mixed watered-down mirror Oreille Divis&eacute;e brandy	2	super EPIC	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2491,21 +2491,21 @@
 2518	sawblade shield of Calamity Jane	0		Critical Hit Percent: +15, Damage Reduction: 11
 2519	perfectly mixed irresponsibly strong mirror McMillicancuddy's Special Lager	8	EPIC	
 2520	practically non-alcoholic tolerable melted Jell-o shot	1	good	
-2521	irresponsibly strong drinkable shaking cruelty-free wine	7	good	
-2522	drinkable practically non-alcoholic thistle wine	1	good	
+2521	drinkable irresponsibly strong shaking cruelty-free wine	7	good	
+2522	practically non-alcoholic drinkable thistle wine	1	good	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	half-sized stale fish	2	decent	
 2526	adequate blinking fish casserole	3	good	
-2527	jumbo rotten fish lasagna	5	crappy	
+2527	rotten jumbo fish lasagna	5	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	toothsome low-calorie gnatloaf	1	awesome	
-2530	flavorless diet yellow skewed gnatloaf casserole	1	decent	
+2529	low-calorie toothsome gnatloaf	1	awesome	
+2530	diet flavorless yellow skewed gnatloaf casserole	1	decent	
 2531	spoiled gnat lasagna	3	crappy	
 2532	pork	0		
 2533	spoiled jittery pork chop sandwiches	4	crappy	
 2534	spoiled pork casserole	3	crappy	
-2535	normal gigantic teal pork lasagna	6	good	
+2535	gigantic normal teal pork lasagna	6	good	
 2536	canopic jar	0		
 2537	spice	0		
 2538	organs	0		
@@ -2520,7 +2520,7 @@
 2547	tin star of the scaredy-cat of the blizzard	0		Monster Level: -15, Cold Spell Damage: +25, Last Available: "2007-05"
 2548	mirror rock-hard Fonzie's outrageous sombrero	0		Experience (Moxie): +1, Damage Reduction: 5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	blurry scandalous &quot;Humorous&quot; T-shirt of the sewer	0		Stench Damage: +25, Sleaze Damage: +5, Last Available: "2007-05"
-2550	cyan mirror bouncing Peppercorns of Power	0		
+2550	mirror bouncing cyan Peppercorns of Power	0		
 2551	mirror vial of mojo	0		
 2552	reeds	0		
 2553	turtle chain	0		
@@ -2535,11 +2535,11 @@
 2562	half-rotten brain	0		
 2563	ghostly bonesaw	0		
 2564	spinning plus-sized phylactery	0		
-2565	blinking squat can of Ghuol-B-Gone&trade;	0		
+2565	squat blinking can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
 2568	jittery Azazel's tutu	0		
-2569	double-electrified electrified skewed yellow ant agonist	0		Effect: "Low on the Hog", Effect Duration: 52
+2569	double-electrified electrified yellow skewed ant agonist	0		Effect: "Low on the Hog", Effect Duration: 52
 2570	lime green ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	lime green ant pitchfork	0		Familiar Effect: "stench damage, meat"
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	studded deadly cactus quill	0		Weapon Damage: +5, Damage Absorption: +80
 2578	cyan scorching toasty Staff of the Short Order Cook of the wise owl	0		Mysticality: +20, Hot Damage: 30
-2579	jumbo toothsome cactus fruit	5	awesome	
+2579	toothsome jumbo cactus fruit	5	awesome	
 2580	auspicious horrifying scorpion whip	0		Spooky Damage: +25, Item Drop: +10
 2581	handful of sand	0		
 2582	brick of sand	0		
@@ -2559,11 +2559,11 @@
 2586	tumbling dangerous General Sage's Lonely Diamonds Club Jacket	0		Weapon Damage: +10
 2587	tumbling Corporal Fennel's Lonely Clubs Club Jacket of extreme caution	0		Monster Level: -25
 2588	foul-smelling Private Pepper's Lonely Hearts Club Jacket	0		Stench Damage: +10
-2589	half-sized normal hot date	2	good	
+2589	normal half-sized hot date	2	good	
 2590	bad distilled fortified wine	3	decent	
 2591	delicious big narrow tasty tart	5	awesome	
-2592	gray spinning Knob Goblin lunchbox	0		
-2593	small rotten Knob pasty	2	crappy	
+2592	spinning gray Knob Goblin lunchbox	0		
+2593	rotten small Knob pasty	2	crappy	
 2594	delicious thermos full of Knob coffee	3	awesome	
 2595	modified Ben-Gal&trade; Balm	0		Effect: "Oh Snap", Effect Duration: 63
 2596	leathery cat skin	0		
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	half-sized flavorless lime green savoy truffle	2	decent	
+2615	flavorless half-sized lime green savoy truffle	2	decent	
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	wobbly sage Iiti Kitty phone charm	0		Mysticality Percent: +10, Single Equip
@@ -2622,15 +2622,15 @@
 2649	Herculean Lord Spookyraven's ear trumpet	0		Experience (Muscle): +1, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	upside-down ghostly pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	low-calorie flavorless lime green S.T.L.T.	1	decent	Last Available: "2007-06"
-2653	low-calorie normal honey-dew	1	good	Last Available: "2007-06"
+2652	flavorless low-calorie lime green S.T.L.T.	1	decent	Last Available: "2007-06"
+2653	normal low-calorie honey-dew	1	good	Last Available: "2007-06"
 2654	smooth Xanadian	3	awesome	Last Available: "2007-06"
 2655	irradiated corrupted activated narrow bottle of absinthe	0		Effect: "Magically Fingered", Effect Duration: 41, Last Available: "2007-06"
 2656	pulsating yellow wool Drowsy Sword of terror	0		Spooky Spell Damage: +10, Cold Resistance: +1
 2657	small spoiled escargotsicle	2	crappy	Last Available: "2007-06"
-2658	drinkable enchanted triple-distilled bottle of realpagne	8	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 40, Last Available: "2007-06"
+2658	triple-distilled enchanted drinkable bottle of realpagne	8	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 40, Last Available: "2007-06"
 2659	aromatic albatross necklace	0		Stench Resistance: +1, Single Equip, Last Available: "2007-06"
-2660	twisted pulsating lime green not-a-pipe	1	crappy	Last Available: "2007-06"
+2660	twisted lime green pulsating not-a-pipe	1	crappy	Last Available: "2007-06"
 2661	enchanted mediocre ghostly flask of Amontillado	3	decent	Effect: "Cat Class, Cat Style", Effect Duration: 40, Last Available: "2007-06"
 2662	rosy-cheeked ball mask	0		Maximum HP Percent: +30, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	upside-down cool Can-Can skirt	0		Moxie: +5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	altered bouncing can-can-in-a-can	1		Last Available: "2007-06"
 2669	dried patent antipsychotics	1		Effect: "Go-Gone", Effect Duration: 40, Last Available: "2007-06"
 2670	powdered Mariner's Friend cough drops	1		Effect: "Thaumodynamic", Effect Duration: 5, Last Available: "2007-06"
-2671	acceptable distilled squat shot of nepenthe schnapps	5	good	Last Available: "2007-06"
+2671	distilled acceptable squat shot of nepenthe schnapps	5	good	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	liquefied ionized concentrated bottle of cat tonic	0		Effect: "Irresistible Resolve", Effect Duration: 51, Last Available: "2007-06"
@@ -2652,7 +2652,7 @@
 2679	magnetized sparkler	0		Effect: "Grrrrrrreat!", Effect Duration: 40
 2680	wet snake	0		Effect: "Eldritch Concentration", Effect Duration: 31, Wiki Name: "snake"
 2681	corrupted M-242	0		Effect: "Innately Wise", Effect Duration: 58
-2682	blinking blue detuned radio	0		
+2682	blue blinking detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	ghostly wobbly blinking mansplainer's armgun of courage	0		Monster Level: +15, Spooky Resistance: +3
 2685	seashell necklace	0		
@@ -2665,7 +2665,7 @@
 2692	Usain Bolt's MacGyver's driftwood sculpture	0		Maximum MP: +100, Initiative: +80
 2693	upside-down ruddy brawny massive sitar	0		Muscle Percent: +20, Maximum HP Percent: +40
 2694	upside-down executive lion tamer's stylish stone baseball cap	0		Moxie: +25, Experience (familiar): +2, Meat Drop: +40, Familiar Effect: "1xVolley, cap 48"
-2695	artisanal high-proof cup of beer	7	EPIC	
+2695	high-proof artisanal cup of beer	7	EPIC	
 2696	ovoid thing	0		
 2697	green duct tape	0		
 2698	spinning duct tape wallet	0		
@@ -2683,7 +2683,7 @@
 2710	squat tumbling cracker	0		Familiar Weight: +15
 2711	pressed altered twirling facepaint	0		Effect: "Crimbo Flavor", Effect Duration: 35
 2712	moist non-irradiated sheepskin diploma	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 59
-2713	altered denatured squat skewed Black Body&trade; spray	0		Effect: "Cookie Backup", Effect Duration: 57
+2713	altered denatured skewed squat Black Body&trade; spray	0		Effect: "Cookie Backup", Effect Duration: 57
 2714	wobbly floorboard cruft	0		
 2715	sausage bomb	0		
 2716	clever grievous battered hubcap of wisdom	0		Mysticality: +15, Weapon Damage Percent: +50, Maximum MP: +20, Damage Reduction: 14
@@ -2696,23 +2696,23 @@
 2723	sage Staff of the Grand Flamb&eacute; of the pedagogue of the early riser	0		Mysticality Percent: +10, Experience: +3, Adventures: +7
 2724	stale bowl of rye sprouts	3	decent	
 2725	flavorless cob of corn	3	decent	
-2726	gigantic moldy juniper berries	6	crappy	
+2726	moldy gigantic juniper berries	6	crappy	
 2727	delicious snack-sized fuchsia plum	2	awesome	
 2728	stale pear	3	decent	
 2729	bland peach	4	decent	
-2730	irresponsibly strong aged teal plum wine	6	awesome	
-2731	high-proof acceptable bouncing shot of pear schnapps	7	good	
-2732	triple-distilled hand-crafted shot of peach schnapps	10	EPIC	
+2730	aged irresponsibly strong teal plum wine	6	awesome	
+2731	acceptable high-proof bouncing shot of pear schnapps	7	good	
+2732	hand-crafted triple-distilled shot of peach schnapps	10	EPIC	
 2733	stale bunch of square grapes	3	decent	
 2734	snack-sized normal brown sugar cane	2	good	
 2735	stale sandwich of the gods	3	decent	
-2736	enchanted mediocre irresponsibly strong Pan-Dimensional Gargle Blaster	7	decent	Effect: "Litterboxing", Effect Duration: 25
-2737	powdered wobbly skewed leopard-print barbell	1	EPIC	
+2736	enchanted irresponsibly strong mediocre Pan-Dimensional Gargle Blaster	7	decent	Effect: "Litterboxing", Effect Duration: 25
+2737	powdered skewed wobbly leopard-print barbell	1	EPIC	
 2738	yellow pile of smoking rags	0		
 2739	deionized aerosolized cyan blurry panty raider camouflage	0		Effect: "High Blood Chocolate Content", Effect Duration: 28
 2740	spinning wool rosy-cheeked Sinatra's Staff of the Walk-In Freezer	0		Experience (Moxie): +5, Maximum HP Percent: +30, Cold Resistance: +1
 2741	watered-down smooth pulsating boilermaker	2	awesome	
-2742	bite-sized toothsome steel lasagna	1	quest	
+2742	toothsome bite-sized steel lasagna	1	quest	
 2743	weak artisanal steel margarita	2	quest	
 2744	diluted steel-scented air freshener	1		Effect: "Cheered Up", Effect Duration: 35
 2745	non-Vulcanized ionized gremlin mutagen	0		Effect: "Sweet Taste", Effect Duration: 25
@@ -2736,16 +2736,16 @@
 2763	chilly Temple Grandin's Pink Heart of Spirit	0		Familiar Weight: +7, Cold Damage: +5, Single Equip
 2764	double-paned crafty sinister Order of the Silver Wossname	0		Spell Damage: +10, Maximum MP: +10, Cold Resistance: +5, Single Equip
 2765	tumbling Harold's bell	0		
-2766	green spinning bowling ball	0		
+2766	spinning green bowling ball	0		
 2767	flavorless Crimbo pie	3	decent	
 2768	immense spoiled pear tart	9	crappy	
 2769	moldy peach pie	3	crappy	
-2770	denatured wet gray bouncing chunk of rock salt	0		Effect: "Uncucumbered", Effect Duration: 58
+2770	denatured wet bouncing gray chunk of rock salt	0		Effect: "Uncucumbered", Effect Duration: 58
 2771	alkaline magnetized tarnished handful of pine needles	0		Effect: "Hyphemariffic", Effect Duration: 47
 2772	steamy ruby	0		
 2773	red glacial sapphire	0		
 2774	bouncing unearthly onyx	0		
-2775	narrow purple effluvious emerald	0		
+2775	purple narrow effluvious emerald	0		
 2776	tawdry amethyst	0		
 2777	narrow pulsating studded filigreed hamethyst earring of horror	0		Damage Absorption: +80, Spooky Spell Damage: +25
 2778	huge executive smelly dance instructor's filigreed hamethyst necklace	0		Experience Percent (Moxie): +10, Stench Spell Damage: +10, Meat Drop: +40, Single Equip
@@ -2803,8 +2803,8 @@
 2830	digital key lime	0		
 2831	green star key lime	0		
 2832	massive adequate digital key lime pie	10	good	
-2833	toothsome snack-sized blue star key lime pie	2	awesome	
-2834	family-friendly scorching bottle-rocket crossbow of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2833	snack-sized toothsome blue star key lime pie	2	awesome	
+2834	family-friendly scorching bottle-rocket crossbow of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Sleaze Resistance: +1, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	cyan hardened indie comic hipster glasses	0		Damage Reduction: 3, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	bouncing wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
@@ -2812,7 +2812,7 @@
 2839	jittery Usain Bolt's Periodical Paintbrush	0		Initiative: +80, Softcore Only
 2840	practically non-alcoholic lousy jittery bottle of cooking sherry	1	decent	
 2841	spoiled blue packet of ketchup	3	crappy	
-2842	weak tolerable accidental cider	2	good	
+2842	tolerable weak accidental cider	2	good	
 2843	moldy blurry dire fudgesicle	3	crappy	
 2844	chilly rosy-cheeked hardened navel ring of navel gazing of the early riser	0		Damage Reduction: 3, Maximum HP Percent: +30, Cold Damage: +5, Adventures: +7, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2821,7 +2821,7 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	delicious extra-dry moonberry wine cooler	5	awesome	
-2851	half-sized normal fine aged cheddarwurst	2	good	
+2851	normal half-sized fine aged cheddarwurst	2	good	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	yellow squat bouquet of swamp roses	0		
@@ -2830,7 +2830,7 @@
 2857	improved ionized seegar butt	0		Effect: "The Power of Negative Thinking", Effect Duration: 19
 2858	bottled swamp gas	0		
 2859	zippy nasty witch wart	0		Stench Damage: +5, Initiative: +20
-2860	stale snack-sized swamp muck	2	decent	
+2860	snack-sized stale swamp muck	2	decent	
 2861	healthy Herculean leechknife of the brazier	0		Experience (Muscle): +1, Maximum HP Percent: +20, Hot Spell Damage: +25
 2862	wobbly decomposed boot	0		
 2863	anodized dry pulsating dribbly candle	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 55
@@ -2910,14 +2910,14 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	yellow Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	special normal Surprise Egg	3	good	Effect: "Hobonic", Effect Duration: 40
+2940	normal special Surprise Egg	3	good	Effect: "Hobonic", Effect Duration: 40
 2941	unsweetened non-irradiated yellow Steal This Candy	0		Effect: "Leash of Linguini", Effect Duration: 41
 2942	wet ionized jittery chocolate filthy lucre	0		Effect: "Amorphous Cheer", Effect Duration: 40
-2943	pickled galvanized yellow blinking Angry Farmer's Wife Candy	0		Effect: "Sleazy Hands", Effect Duration: 24
+2943	pickled galvanized blinking yellow Angry Farmer's Wife Candy	0		Effect: "Sleazy Hands", Effect Duration: 24
 2945	skewed Newton's thinker's party hat	0		Mysticality: +10, Experience (Mysticality): +3, Familiar Effect: "4xLep, cap 7"
-2946	sinister wizardly V for Vivala mask	0		Mysticality: +25, Spell Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	sinister wizardly V for Vivala mask	0		Mysticality: +25, Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	bouncing The Big Book of Pirate Insults	0		
-2948	practically non-alcoholic artisanal shot of rotgut	1	EPIC	
+2948	artisanal practically non-alcoholic shot of rotgut	1	EPIC	
 2949	denatured oxidized wet jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Shortened", Effect Duration: 14
 2950	Cap'm Caronch's Map	0		
 2951	blue Orcish Frat House blueprints	0		
@@ -2929,7 +2929,7 @@
 2957	jittery rum barrel charrrm	0		
 2958	stale low-calorie tube of cranberry Go-Goo	1	decent	
 2959	rum barrel charrrm bracelet of the pedagogue	0		Experience: +3
-2960	toothsome miniature single-serving herbal stuffing	2	awesome	
+2960	miniature toothsome single-serving herbal stuffing	2	awesome	
 2961	decent tumbling packet of tofurkey gravy	4	good	
 2962	moldy tofurkey nugget	3	crappy	
 2963	blinking rigging shampoo	0		
@@ -2938,7 +2938,7 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	colloidal nitrogenated yellow mirror Swabbie&trade; swab	0		Effect: "Buggy Flavor", Effect Duration: 40
 2968	super-chilled quantum Oil of Parrrlay	0		Effect: "Deadly Lampblade", Effect Duration: 23
-2969	normal immense creamsicle	6	good	
+2969	immense normal creamsicle	6	good	
 2970	smooth weak cream stout	2	awesome	
 2971	blue greedy coward's curmudgel	0		Monster Level: -20, Meat Drop: +20
 2972	grumpy man charrrm	0		
@@ -2997,16 +2997,16 @@
 3025	acceptable corpse on the beach	4	good	
 3026	strong acceptable corpsetini	5	good	
 3027	aged triple-distilled corpsedriver	6	awesome	
-3028	mediocre irresponsibly strong Corpse Island iced tea	8	decent	
+3028	irresponsibly strong mediocre Corpse Island iced tea	8	decent	
 3029	hand-crafted red-headed corpse	4	EPIC	
 3030	watered-down acceptable kamicorpse-ee	2	good	
-3031	watered-down hand-crafted teal corpsel	2	EPIC	
-3032	watered-down tolerable wobbly skewed corpsebite	2	good	
+3031	hand-crafted watered-down teal corpsel	2	EPIC	
+3032	tolerable watered-down wobbly skewed corpsebite	2	good	
 3033	wobbly blurry chaotic pirate fledges	0		Spell Critical Percent: +10
 3034	piece of thirteen	0		
-3035	bite-sized rotten tumbling pearl onion	1	crappy	
+3035	rotten bite-sized tumbling pearl onion	1	crappy	
 3036	adequate immense upside-down pulsating sea biscuit	10	good	
-3037	lousy irresponsibly strong bottle of rum	8	decent	
+3037	irresponsibly strong lousy bottle of rum	8	decent	
 3038	hand-crafted high-proof jittery bottle of black-label rum	7	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
@@ -3015,7 +3015,7 @@
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	delicious nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
-3046	delicious small mirror blinking nanite-infested candy cane	2	awesome	Last Available: "2020-09"
+3046	delicious small blinking mirror nanite-infested candy cane	2	awesome	Last Available: "2020-09"
 3047	adequate miniature nanite-infested fruitcake	2	good	Last Available: "2007-12"
 3048	bad shaking nanite-infested eggnog	3	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
@@ -3046,7 +3046,7 @@
 3074	bouncing polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	laser targeting chip	0		Last Available: "2007-12"
-3077	pulsating gray hi-density nylocite leg armor	0		Last Available: "2007-12"
+3077	gray pulsating hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	ghostly kevlateflocite helmet	0		Last Available: "2007-12"
 3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
@@ -3098,7 +3098,7 @@
 3126	hobo nickel	0		
 3127	maroon sandcastle	0		
 3128	marshmallow	0		
-3129	rotten fancy massive roasted marshmallow	7	crappy	Effect: "Shawarma Initiative", Effect Duration: 35
+3129	massive rotten fancy roasted marshmallow	7	crappy	Effect: "Shawarma Initiative", Effect Duration: 35
 3130	yellow disc	0		Last Available: "2008-01"
 3131	flavorless tin cup of mulligan stew	3	decent	
 3132	boxer's beefy flamin' bindle	0		Muscle: +10, Muscle Percent: +10
@@ -3115,7 +3115,7 @@
 3143	huge greasy ribald Hodgman's disgusting technicolor overcoat	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 3144	a torn paper strip	0		
 3145	El Vibrato translator	0		
-3146	narrow yellow El Vibrato punchcard (115 holes)	0		
+3146	yellow narrow El Vibrato punchcard (115 holes)	0		
 3147	squat El Vibrato punchcard (97 holes)	0		
 3148	teal El Vibrato punchcard (129 holes)	0		
 3149	El Vibrato punchcard (213 holes)	0		
@@ -3134,20 +3134,20 @@
 3162	purple El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
-3165	twirling wobbly broken El Vibrato drone	0		
+3165	wobbly twirling broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	concentrated dry blurry seal eyeball	0		Effect: "Hot Blooded", Effect Duration: 55
-3169	huge rotten turtle soup	8	crappy	Effect: "[598]A Little Bit Evil"
+3169	rotten huge turtle soup	8	crappy	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	green nauseating reagent	0		
 3172	bouncing stylish evil paper umbrella	0		Moxie: +25
 3173	warmed aerosolized evil vihuela	0		Effect: "Can't Be a Chooser", Effect Duration: 68
-3174	bite-sized decent enchanted fuchsia evil boring spaghetti	1	good	Effect: "Fustulent", Effect Duration: 5
+3174	decent bite-sized enchanted fuchsia evil boring spaghetti	1	good	Effect: "Fustulent", Effect Duration: 5
 3175	spoiled evil noodles	3	crappy	
 3176	rotten super-sized evil noodles	5	crappy	
 3177	normal evil painful penne pasta	4	good	
-3178	adequate fancy 3vi1 pr0n m4nic0tti	3	good	Effect: "Angry Bone", Effect Duration: 20
+3178	fancy adequate 3vi1 pr0n m4nic0tti	3	good	Effect: "Angry Bone", Effect Duration: 20
 3179	delicious evil ravioli della hippy	3	awesome	
 3180	miniature rotten blurry shaking evil noodles	2	crappy	
 3181	polarized oxidized deionized evil potion of potency	0		Effect: "Educated (Kinda)", Effect Duration: 19
@@ -3157,8 +3157,8 @@
 3185	dry modified shaking evil ointment of the occult	0		Effect: "Chunky", Effect Duration: 16
 3186	flattened aerosolized evil serum of sarcasm	0		Effect: "Frostbeard", Effect Duration: 38
 3187	magnetized triple-pressed evil philter of phorce	0		Effect: "Fudgehound", Effect Duration: 37
-3188	watered-down delicious an evil sump'm sump'm	2	awesome	
-3189	hand-crafted weak evil ducha de oro	2	super EPIC	
+3188	delicious watered-down an evil sump'm sump'm	2	awesome	
+3189	weak hand-crafted evil ducha de oro	2	super EPIC	
 3190	mediocre evil horizontal tango	4	decent	
 3191	acceptable weak fancy evil roll in the hay	2	good	Effect: "Venomous Weapon", Effect Duration: 40
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3176,7 +3176,7 @@
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
-3207	blinking purple jittery dwarvish punchcard	0		
+3207	purple jittery blinking dwarvish punchcard	0		
 3208	maroon skewed small laminated card	0		
 3209	blurry laminated card	0		
 3210	notbig laminated card	0		
@@ -3194,8 +3194,8 @@
 3222	shaking double-paned wizardly gatorskin umbrella	0		Mysticality: +25, Cold Resistance: +5
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	practically non-alcoholic aged special bottle of sewage schnapps	1	awesome	Effect: "Mo' Hobo", Effect Duration: 20
-3226	smooth distilled bottle of Ooze-O	5	awesome	
+3225	special practically non-alcoholic aged bottle of sewage schnapps	1	awesome	Effect: "Mo' Hobo", Effect Duration: 20
+3226	distilled smooth bottle of Ooze-O	5	awesome	
 3227	snack-sized rotten C.H.U.M. chum	2	crappy	
 3228	bland unfortunate dumplings	3	decent	
 3229	decaying goldfish liver	0		
@@ -3213,7 +3213,7 @@
 3241	Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
-3244	upside-down ghostly Summer Nights	0		Skill: "Grease Lightning"
+3244	ghostly upside-down Summer Nights	0		Skill: "Grease Lightning"
 3245	twirling Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	Ol' Scratch's ol' britches of the cougar of the blizzard	0		Moxie: +20, Cold Spell Damage: +25, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
 3247	boxer's Ol' Scratch's stovepipe hat of bravery	0		Muscle Percent: +10, Spooky Resistance: +5, Class: "Sauceror", Familiar Effect: "hot atk"
@@ -3234,19 +3234,19 @@
 3262	greasy Chester's cutoffs of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +10, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
 3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
-3265	gray jittery bag of Crotchety Pine saplings	0		
+3265	jittery gray bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
 3267	squat bag of Laughing Willow saplings	0		
 3268	altered handful of Crotchety Pine needles	0		Effect: "The Moxie of LOV", Effect Duration: 48
 3269	adjusted chilled irradiated lump of Saccharine Maple sap	0		Effect: "Antsy in your Pantsy", Effect Duration: 55
 3270	wet handful of Laughing Willow bark	0		Effect: "Human-Constellation Hybrid", Effect Duration: 16
-3271	scorching crotchety pants	0		Hot Damage: +25, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	scorching crotchety pants	0		Hot Damage: +25, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	upside-down Saccharine Maple pendant of James Dean	0		Experience (Moxie): +3, Conditional Skill (Equipped): "Spray Sap"
-3273	quilted willowy bonnet	0		Damage Absorption: +40, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	quilted willowy bonnet	0		Damage Absorption: +40, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	bouncing flavored foot massage oil	0		Last Available: "2008-04"
 3275	jittery dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
-3277	spinning purple Loudmouth Larry Lamprey	0		Last Available: "2008-04"
+3277	purple spinning Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	mirror rosewater-soaked studded belt	0		Stench Resistance: +3, Last Available: "2008-04"
 3279	personal massager	0		Last Available: "2008-04"
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
@@ -3263,7 +3263,7 @@
 3291	wobbly secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
 3293	untamable turtle	0		
-3294	olive blurry macaroni duck	0		
+3294	blurry olive macaroni duck	0		
 3295	friendly cheez blob	0		
 3296	mirror unusual disco ball	0		
 3297	tumbling stray chihuahua	0		
@@ -3291,10 +3291,10 @@
 3319	studded Mr. Joe's bangles	0		Damage Absorption: +80, Single Equip
 3320	manspreader's frayed rope belt	0		Monster Level: +10, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	lime green zippy baleful mayfly bait necklace	0		Spell Damage: +25, Initiative: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	lime green zippy baleful mayfly bait necklace	0		Spell Damage: +25, Initiative: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	skewed Frosty's frosty mug	0		
-3325	perfectly mixed special jar of fermented pickle juice	3	super ultra mega EPIC	Effect: "Remaining Alive", Effect Duration: 35
+3325	special perfectly mixed jar of fermented pickle juice	3	super ultra mega EPIC	Effect: "Remaining Alive", Effect Duration: 35
 3326	altered voodoo snuff	1	good	
 3327	stale extra-greasy slider	3	decent	
 3328	careful crumpled felt fedora of the empath	0		Monster Level: -10, Familiar Weight: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	blurry dead guy's piece of double-sided tape	0		
 3337	spinning Annie Oakley's thinker's dead guy's memento	0		Mysticality: +10, Critical Hit Percent: +20, Single Equip
-3338	half-sized decent banquet	2	good	
+3338	decent half-sized banquet	2	good	
 3339	shaking sharpened hubcap	0		
 3340	huge very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3331,7 +3331,7 @@
 3359	scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
-3362	upside-down blurry tasty louse	0		Last Available: "2008-06"
+3362	blurry upside-down tasty louse	0		Last Available: "2008-06"
 3363	adequate small bouncing mole mol&eacute;	2	good	Last Available: "2008-06"
 3364	mediocre narrow Morlock's Mark Bourbon	3	decent	Last Available: "2008-06"
 3365	deionized activated Climate Colada	0		Effect: "Disco State of Mind", Effect Duration: 33, Last Available: "2008-06"
@@ -3342,7 +3342,7 @@
 3370	dehydrated bouncing glimmering penguin feather	1		Last Available: "2008-06"
 3371	compressed glimmering buzzard feather	1		Effect: "Chunky", Effect Duration: 50, Last Available: "2008-06"
 3372	compressed tumbling glimmering raven feather	1		Last Available: "2008-06"
-3373	dehydrated teal ghostly twirling glimmering great tit feather	1		Effect: "Well-preserved", Effect Duration: 20, Last Available: "2008-06"
+3373	dehydrated ghostly teal twirling glimmering great tit feather	1		Effect: "Well-preserved", Effect Duration: 20, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3357,7 +3357,7 @@
 3385	zippy executive Chester's Aquarius medallion	0		Meat Drop: +40, Initiative: +20, Single Equip
 3386	baleful Zombo's shoulder blade of temperance	0		Spell Damage: +25, Sleaze Resistance: +5
 3387	squat Zombo's skull ring of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, Single Equip
-3388	skewed huge Zombo's empty eye	0		
+3388	huge skewed Zombo's empty eye	0		
 3389	gravedigger's toasty Frosty's arm	0		Hot Damage: +5, Spooky Damage: +10
 3390	knitted ruddy fortified Staff of the Deepest Freeze	0		Damage Absorption: +60, Maximum HP Percent: +40, Cold Resistance: +3
 3391	Frosty's iceball	0		
@@ -3368,8 +3368,8 @@
 3396	grievous Hodgman's lobsterskin pants of the empath	0		Weapon Damage Percent: +50, Familiar Weight: +5, Familiar Effect: "atk, 1xPotato"
 3397	red upside-down therapeutic forbidden Hodgman's bow tie	0		Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 3398	artisanal Hodgman's blanket	4	EPIC	
-3399	practically non-alcoholic tolerable jar of squeeze	1	good	
-3400	decent snack-sized bowl of fishysoisse	2	good	
+3399	tolerable practically non-alcoholic jar of squeeze	1	good	
+3400	snack-sized decent bowl of fishysoisse	2	good	
 3401	triple-dry blue deadly lampshade	0		Effect: "Omphalotus Omnipresence", Effect Duration: 25
 3402	diffused polarized super-magnetized ghostly yellow concentrated garbage juice	0		Effect: "Disdain of the War Snapper", Effect Duration: 35
 3403	lewd playing card	0		
@@ -3386,7 +3386,7 @@
 3414	gray Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	fuchsia Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	blurry hobo fortress blueprints	0		
-3421	huge box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	huge box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	adjusted spinning sterno-flavored Hob-O	0		Effect: "Sepia Tan", Effect Duration: 58
 3423	boiled yellow frostbite-flavored Hob-O	0		Effect: "The Strength...  of the Future", Effect Duration: 68
 3424	aerosolized oxidized diffused yellow fry-oil-flavored Hob-O	0		Effect: "The Spy Who Loved XP", Effect Duration: 48
@@ -3427,13 +3427,13 @@
 3460	flavorless upside-down tin rations	3	decent	
 3461	fuchsia haiku challenge map	0		
 3462	terrible poem	0		
-3463	mediocre weak bottle of sake	2	decent	
+3463	weak mediocre bottle of sake	2	decent	
 3464	Oprah's round pebble	0		Maximum MP Percent: +50
 3465	toothsome tumbling Bash-&#332;s cereal	3	awesome	Wiki Name: "Bash-Os cereal"
-3466	frosty supercharged haiku katana of bravery	0		Maximum MP Percent: +30, Cold Spell Damage: +10, Spooky Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	frosty supercharged haiku katana of bravery	0		Maximum MP Percent: +30, Cold Spell Damage: +10, Spooky Resistance: +5, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	huge groovy plastic baby	0		Moxie Percent: +10, Single Equip, Last Available: "2008-12"
-3469	enchanted rotten wobbly narrow blueberry-frosted king cake	4	crappy	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 45, Last Available: "2008-12"
+3469	enchanted rotten narrow wobbly blueberry-frosted king cake	4	crappy	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 45, Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	upside-down Annie Oakley's rosy-cheeked occult Seasonal Beret	0		Spell Damage Percent: +25, Maximum HP Percent: +30, Critical Hit Percent: +20, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3447,7 +3447,7 @@
 3480	spot	0		
 3481	gray uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
-3483	purple bouncing psychedelic bubble wand	0		Familiar Weight: +5
+3483	bouncing purple psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	concentrated energized glittery mascara	0		Effect: "Crusty Head", Effect Duration: 54
 3486	wobbly dull fish scale	0		
@@ -3461,7 +3461,7 @@
 3494	horrifying fish bazooka of the sewer	0		Stench Damage: +25, Spooky Damage: +25
 3495	vacuum-sealed sea salt crystal	0		Effect: "The Halls of Mysticality", Effect Duration: 36
 3496	boiled tarnished pickled bazookafish bubble gum	0		Effect: "Strange Mental Acuity", Effect Duration: 33
-3497	weak lousy bottle of Pete's Sake	2	decent	
+3497	lousy weak bottle of Pete's Sake	2	decent	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	tumbling beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
@@ -3480,7 +3480,7 @@
 3513	scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	ruddy ganger bandana of the businessman	0		Maximum HP Percent: +40, Meat Drop: +50, Familiar Effect: "atk"
-3516	pulsating spinning eel skin	0		
+3516	spinning pulsating eel skin	0		
 3517	padded eelskin hat	0		Damage Absorption: +20, Familiar Effect: "atk"
 3518	foul-smelling eelskin pants	0		Stench Damage: +10, Familiar Effect: "1xPotato, MP regen"
 3519	skewed eelskin shield of the ox	0		Muscle: +20, Damage Reduction: 13
@@ -3520,16 +3520,16 @@
 3553	soggy seed packet	0		
 3554	glob of slime	0		
 3555	adequate tumbling sea carrot	3	good	
-3556	stale fancy sea cucumber	4	decent	Effect: "Mushroom Samba", Effect Duration: 15
+3556	fancy stale sea cucumber	4	decent	Effect: "Mushroom Samba", Effect Duration: 15
 3557	bland blue sea avocado	3	decent	
 3558	rotten sea lychee	3	crappy	
 3559	adequate blinking sea tangelo	4	good	
-3560	miniature normal sea honeydew	2	good	
+3560	normal miniature sea honeydew	2	good	
 3561	wet pulsating pressurized potion of puissance	0		Effect: "Paging Betty", Effect Duration: 13
 3562	flattened pressurized potion of perspicacity	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 36
 3563	denatured cold-filtered pressurized potion of pulchritude	0		Effect: "Far Out", Effect Duration: 37
 3564	artisanal ghostly berry-infused sake	3	EPIC	
-3565	lousy distilled fancy purple citrus-infused sake	5	decent	Effect: "Pisces in the Skyces", Effect Duration: 15
+3565	fancy distilled lousy purple citrus-infused sake	5	decent	Effect: "Pisces in the Skyces", Effect Duration: 15
 3566	aged melon-infused sake	4	awesome	
 3567	wobbly slab of sponge	0		
 3568	fuchsia perfumed Newton's sponge helmet of the boozehound	0		Experience (Mysticality): +3, Stench Resistance: +5, Booze Drop: +100, Familiar Effect: "atk, 1xFairy"
@@ -3581,7 +3581,7 @@
 3615	gray rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	electrified unstable DNA	0		Effect: "Very Clean Guns", Effect Duration: 46, Last Available: "2008-12"
-3618	twirling The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	twirling The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	shaking wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	teal pair of twitching claws	0		Last Available: "2008-12"
@@ -3608,14 +3608,14 @@
 3642	red dragonfish caviar	0		
 3643	green pufferfish spine	0		
 3644	jittery nasty depleted Grimacite kneecapping stick	0		Stench Damage: +5, Last Available: "2007-06"
-3645	weak aged upside-down canteen of wine	2	awesome	Last Available: "2008-12"
-3646	diet normal narrow elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
+3645	aged weak upside-down canteen of wine	2	awesome	Last Available: "2008-12"
+3646	normal diet narrow elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	purple magic dragonfish fry	0		
 3649	skewed map to Madness Reef	0		
 3650	normal thick twirling toast with jam	5	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	watered-down mediocre elven moonshine	2	decent	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	mediocre watered-down elven moonshine	2	decent	Last Available: "2008-12"
 3653	bland pulsating blue knuckle sandwich	3	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	lightning-fast toasty psycho sweater	0		Hot Damage: +5, Initiative: +40, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
@@ -3647,13 +3647,13 @@
 3681	purple skewed bubbling tempura batter	0		
 3682	pulsating globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	jumbo delicious olive tempura carrot	5	awesome	
+3684	delicious jumbo olive tempura carrot	5	awesome	
 3685	adequate bite-sized blinking tempura cucumber	1	good	
-3686	spoiled thick tempura avocado	5	crappy	
+3686	thick spoiled tempura avocado	5	crappy	
 3687	half-sized normal spinning sea broccoli	2	good	
 3688	toothsome small sea cauliflower	2	awesome	
 3689	stale tempura broccoli	4	decent	
-3690	big delicious tempura cauliflower	5	awesome	
+3690	delicious big tempura cauliflower	5	awesome	
 3691	bland sea blueberry	3	decent	
 3692	spoiled sea persimmon	3	crappy	
 3693	ionized pressurized potion of perception	0		Effect: "The Real Deal", Effect Duration: 16
@@ -3717,7 +3717,7 @@
 3753	squat Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	aerosolized aerosolized blue love song of vague ambiguity	0		Effect: "Mystically Oiled", Effect Duration: 31, Last Available: "2009-02"
 3755	irradiated love song of smoldering passion	0		Effect: "White Blooded", Effect Duration: 43, Last Available: "2009-02"
-3756	liquefied altered skewed gray love song of icy revenge	0		Effect: "Egg-stortionary Tactics", Effect Duration: 23, Last Available: "2009-02"
+3756	liquefied altered gray skewed love song of icy revenge	0		Effect: "Egg-stortionary Tactics", Effect Duration: 23, Last Available: "2009-02"
 3757	diffused blurry love song of sugary cuteness	0		Effect: "Ancestral Disapproval", Effect Duration: 23, Last Available: "2009-02"
 3758	flattened love song of disturbing obsession	0		Effect: "Superioreo", Effect Duration: 16, Last Available: "2009-02"
 3759	unsweetened love song of naughty innuendo	0		Effect: "The Best a Pirate Can Get", Effect Duration: 11, Last Available: "2009-02"
@@ -3725,15 +3725,15 @@
 3761	chilly vampire pearl ring	0		Cold Damage: +5, Single Equip
 3762	stiffened vampire pearl necklace	0		Damage Reduction: 1, Single Equip
 3763	mediocre slug of vodka	3	decent	
-3764	watered-down tolerable slug of rum	2	good	
-3765	weak artisanal slug of shochu	2	EPIC	
+3764	tolerable watered-down slug of rum	2	good	
+3765	artisanal weak slug of shochu	2	EPIC	
 3766	mediocre screwdiver	4	decent	
 3767	bad practically non-alcoholic dew yoana lei	1	decent	
 3768	lousy lychee chuhai	3	decent	
 3769	aged salacious screwdiver	4	awesome	
 3770	drinkable dew yoana salacious lei	3	good	
-3771	artisanal practically non-alcoholic spinning ghostly salacious lychee chuhai	1	super ultra mega turbo EPIC	
-3772	smooth spirit-forward Alewife&trade; Ale	5	awesome	
+3771	artisanal practically non-alcoholic ghostly spinning salacious lychee chuhai	1	super ultra mega turbo EPIC	
+3772	spirit-forward smooth Alewife&trade; Ale	5	awesome	
 3773	seaode	0		
 3774	skewed map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3743,7 +3743,7 @@
 3779	liquefied aerosolized hair of the fish	0		Effect: "Stop and Smell the Fudge", Effect Duration: 54
 3780	avaricious deadly nurse's hat of incineration	0		Weapon Damage: +5, Hot Spell Damage: +50, Meat Drop: +30, Familiar Effect: "atk"
 3781	blank prescription sheet	0		
-3782	distilled pulsating upside-down bottle of melodramamine	1		
+3782	distilled upside-down pulsating bottle of melodramamine	1		
 3783	modified skewed bottle of extra-strength melodramamine	1		
 3784	shaking paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
@@ -3764,11 +3764,11 @@
 3809	ghostly Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	half-sized decent chocolate-frosted king cake	2	good	Last Available: "2009-06"
+3812	decent half-sized chocolate-frosted king cake	2	good	Last Available: "2009-06"
 3813	chilly plastic baby	0		Cold Damage: +5, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	adequate bite-sized sea radish	1	good	
+3817	bite-sized adequate sea radish	1	good	
 3818	blinking resourceful weightlifter's halibut of the scaredy-cat	0		Muscle: +15, Maximum MP: +50, Monster Level: -15
 3819	eel sauce	0		
 3820	spinning water-polo mitt of Flo-Jo	0		Initiative: +100, Single Equip
@@ -3784,10 +3784,10 @@
 3830	tumbling hale water-polo cap	0		Maximum HP: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	mediocre spirit-forward Typical Tavern swill	5	decent	
 3832	bad weak tropical swill	2	decent	
-3833	perfectly mixed high-proof fruity girl swill	6	EPIC	
+3833	high-proof perfectly mixed fruity girl swill	6	EPIC	
 3834	acceptable blended swill	3	good	
 3835	costume wardrobe	0		Softcore Only
-3836	upside-down narrow skewed rosewater-soaked dangerous brawny Elvish sunglasses of James Dean	0		Muscle Percent: +20, Experience (Moxie): +3, Weapon Damage: +10, Stench Resistance: +3, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	upside-down narrow skewed rosewater-soaked dangerous brawny Elvish sunglasses of James Dean	0		Muscle Percent: +20, Experience (Moxie): +3, Weapon Damage: +10, Stench Resistance: +3, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	anniversary safety glass vest of the sweet-tooth	0		Candy Drop: +100
 3838	chaotic anniversary burlap belt	0		Spell Critical Percent: +10
 3839	blurry vibrating anniversary balsa wood socks	0		Maximum MP Percent: +10
@@ -3855,7 +3855,7 @@
 3903	jittery figurine of a baby seal	0		Class: "Seal Clubber"
 3904	red figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
-3906	mirror maroon figurine of a sleek seal	0		Class: "Seal Clubber"
+3906	maroon mirror figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	fuchsia pulsating figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
@@ -3905,7 +3905,7 @@
 3953	mink	0		
 3954	blinking teddy butler	0		
 3955	skewed martini	0		
-3956	purple ghostly crazy bastard sword	0		
+3956	ghostly purple crazy bastard sword	0		
 3957	olive tin of caviar	0		
 3958	aromatic bejeweled cufflinks	0		Stench Resistance: +1, Single Equip
 3959	stanky garish pinky ring	0		Stench Spell Damage: +25
@@ -3986,8 +3986,8 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	ghostly memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	snack-sized spoiled slimy sweetbreads	2	crappy	
-4038	watered-down acceptable slimy fermented bile bladder	2	good	
+4037	spoiled snack-sized slimy sweetbreads	2	crappy	
+4038	acceptable watered-down slimy fermented bile bladder	2	good	
 4039	diluted slimy alveolus	1		
 4040	jittery memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	banded beefcake's pig-iron helm	0		Muscle: +25, Damage Absorption: +100, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	squat experienced ring of teleportation	0		Experience: +2, Single Equip
 4052	wobbly glass of baboon milk	1	good	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	tolerable weak red White Hyborian	2	good	Last Available: "2009-06"
+4054	weak tolerable red White Hyborian	2	good	Last Available: "2009-06"
 4055	smartaleck's goblin hunting spear	0		Moxie Percent: +30, Last Available: "2009-06"
 4056	coward's goblin autoblowgun of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Last Available: "2009-06"
 4057	upside-down deadly tribal beads	0		Weapon Damage: +5, Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	frozen double-flattened corrupted blinking shaking tempura air	0		Effect: "Mer-kinny Flavor", Effect Duration: 29
 4134	warmed pressurized potion of pneumaticity	0		Effect: "Crimbo Nostalgia", Effect Duration: 62
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	hardy grievous Fonzie's Bag o' Tricks of the storm	0		Experience (Moxie): +1, Weapon Damage Percent: +50, Maximum HP: +50, Maximum MP Percent: +40, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	hardy grievous Fonzie's Bag o' Tricks of the storm	0		Experience (Moxie): +1, Weapon Damage Percent: +50, Maximum HP: +50, Maximum MP Percent: +40, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	mirror slime stack	0		
 4138	bouncing a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4177,26 +4177,26 @@
 4225	teal roller skate doll	0		
 4226	Star of Bravery of extreme caution	0		Monster Level: -25, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
-4228	bouncing upside-down perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
+4228	upside-down bouncing perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
 4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
 4233	narrow hacienda key	0		
 4234	steel-toed pat&eacute; knife	0		Damage Reduction: 9
-4235	tumbling fuchsia salt-shaker	0		
+4235	fuchsia tumbling salt-shaker	0		
 4236	can of sterno	0		
 4237	cheese-slicer of the cheetah	0		Initiative: +60
-4238	yummy small beef jerky	2	awesome	
+4238	small yummy beef jerky	2	awesome	
 4239	upside-down pipe wrench of Calamity Jane	0		Critical Hit Percent: +15
-4240	magnetized blue squat gun cleaning kit	0		Effect: "Industrial Strength Starch", Effect Duration: 60
+4240	magnetized squat blue gun cleaning kit	0		Effect: "Industrial Strength Starch", Effect Duration: 60
 4241	blinking narrow supercool sleep mask	0		Moxie Percent: +20, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	upside-down cyan educational sock garters	0		Experience: +1, Single Equip
 4243	galvanized extra-electrified blue mariachi toothpaste	0		Effect: "Nut-Rition", Effect Duration: 38
 4244	prompt leather-bound tome	0		Adventures: +3
 4245	skewed bookmark	0		
 4246	slick ivory cue ball	0		Moxie: +10
-4247	acceptable enchanted decanter of fine Scotch	3	good	Effect: "Moon-Eyed", Effect Duration: 20
+4247	enchanted acceptable decanter of fine Scotch	3	good	Effect: "Moon-Eyed", Effect Duration: 20
 4248	vaporized expensive cigar	1		Effect: "BOOsted", Effect Duration: 20
 4249	spinning tophat	0		Familiar Weight: +5
 4250	skewed fisherman's sack	0		
@@ -4249,15 +4249,15 @@
 4297	Jack Frost's coward's Ass-Stompers of Violence of bravery	0		Monster Level: -20, Cold Spell Damage: +50, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	maroon Jack Frost's therapeutic Samson's Brand of Violence	0		Experience (Muscle): +5, Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Brand"
 4299	bouncing blinking resourceful supercharged sinister Novelty Belt Buckle of Violence	0		Spell Damage: +10, Maximum MP Percent: +30, Maximum MP: +50, Single Equip
-4300	deadly Herculean Lens of Violence of the detective	0		Experience (Muscle): +1, Weapon Damage: +5, Item Drop: +20, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	deadly Herculean Lens of Violence of the detective	0		Experience (Muscle): +1, Weapon Damage: +5, Item Drop: +20, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	lime green inspector's foul-smelling stiffened Pigsticker of Violence	0		Damage Reduction: 1, Stench Damage: +10, Item Drop: +15
-4302	ribald stylish Jodhpurs of Violence of the scaredy-cat	0		Moxie: +25, Monster Level: -15, Sleaze Damage: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	ribald stylish Jodhpurs of Violence of the scaredy-cat	0		Moxie: +25, Monster Level: -15, Sleaze Damage: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	yellow smartaleck's smooth Cold Stone of Hatred of the overflowing toilet	0		Moxie: +15, Moxie Percent: +30, Stench Spell Damage: +50, Conditional Skill (Equipped): "Chilling Grip"
 4304	aromatic stanky supercharged Girdle of Hatred	0		Maximum MP Percent: +30, Stench Spell Damage: +25, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	Sherlock's friendly Staff of Simmering Hatred of the businessman	0		Familiar Weight: +3, Item Drop: +25, Meat Drop: +50
-4306	prompt fireproof Pantaloons of Hatred of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +3, Adventures: +3, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	prompt fireproof Pantaloons of Hatred of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +3, Adventures: +3, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	jittery Sherlock's ribald Herculean Fuzzy Slippers of Hatred	0		Experience (Muscle): +1, Sleaze Damage: +10, Item Drop: +25, Single Equip
-4308	sizzling manspreader's hale Lens of Hatred	0		Maximum HP: +20, Monster Level: +10, Hot Damage: +10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	sizzling manspreader's hale Lens of Hatred	0		Maximum HP: +20, Monster Level: +10, Hot Damage: +10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	fuchsia aromatic ruddy beefy Treads of Loathing	0		Muscle: +10, Maximum HP Percent: +40, Stench Resistance: +1, Single Equip
 4310	avaricious Da Vinci's Scepter of Loathing of the blizzard	0		Experience (Mysticality): +5, Cold Spell Damage: +25, Meat Drop: +30
 4311	blinking fireproof greasy Belt of Loathing of the detective	0		Sleaze Spell Damage: +10, Hot Resistance: +3, Item Drop: +20, Single Equip
@@ -4280,9 +4280,9 @@
 4328	green suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	blurry bag of many confections	0		Last Available: "2009-12"
 4330	spoiled half-sized maroon candy kneecapping stick	2	crappy	Last Available: "2009-12"
-4331	toothsome low-calorie licorice garrote	1	awesome	Last Available: "2009-12"
+4331	low-calorie toothsome licorice garrote	1	awesome	Last Available: "2009-12"
 4332	Lo Pan's candy knuckles	0		Spell Critical Percent: +30, Last Available: "2009-12"
-4333	snack-sized spoiled jawbruiser	2	crappy	Last Available: "2010-12"
+4333	spoiled snack-sized jawbruiser	2	crappy	Last Available: "2010-12"
 4334	corrupted magnetized tumbling chocolate car	0		Effect: "Ichorous Eyesight", Effect Duration: 36, Last Available: "2009-12"
 4335	maroon plastic 11 Dealer of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2009-12"
 4336	tumbling razor-sharp plastic Crimbo Casino	0		Weapon Damage Percent: +25, Last Available: "2009-12"
@@ -4309,12 +4309,12 @@
 4357	spinning red A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	spinning A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	normal gigantic expired can of franks 'n' beans	10	good	Last Available: "2009-12"
-4361	boozy bad expired bottle of peppermint schnapps	5	decent	Last Available: "2009-12"
+4360	gigantic normal expired can of franks 'n' beans	10	good	Last Available: "2009-12"
+4361	bad boozy expired bottle of peppermint schnapps	5	decent	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	lime green elf resistance button	0		Last Available: "2009-12"
 4364	quadruple-quantum twirling elven suicide capsule	0		Effect: "License to Punch", Effect Duration: 47, Last Available: "2009-12"
-4365	moldy snack-sized penguin focaccia bread	2	crappy	Last Available: "2009-12"
+4365	snack-sized moldy penguin focaccia bread	2	crappy	Last Available: "2009-12"
 4366	lousy herringcello	3	decent	Last Available: "2009-12"
 4367	drinkable twirling elven cellocello	3	good	Last Available: "2009-12"
 4368	olive wrench handle	0		Last Available: "2009-12"
@@ -4340,10 +4340,10 @@
 4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	wizardly peanut brittle shield	0		Mysticality: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	gray huge personal trainer's Red Rover BB gun of the empath	0		Experience Percent (Muscle): +10, Familiar Weight: +5, Last Available: "2009-12"
-4391	red-and-green sweater of doom	0		Spooky Spell Damage: +50, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	red-and-green sweater of doom	0		Spooky Spell Damage: +50, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	polarized quadruple-alkaline pulsating Crimbo peppermint bark	0		Effect: "Human-Elf Hybrid", Effect Duration: 66, Last Available: "2009-12"
-4394	boiled Vulcanized cyan squat Crimbo fudge	0		Effect: "Bandersnatched", Effect Duration: 59, Last Available: "2009-12"
+4394	boiled Vulcanized squat cyan Crimbo fudge	0		Effect: "Bandersnatched", Effect Duration: 59, Last Available: "2009-12"
 4395	aerosolized polarized Crimbo pecan	0		Effect: "Fudge Headache", Effect Duration: 13, Last Available: "2009-12"
 4396	lime green Jack-in-the-box	0		Last Available: "2009-12"
 4397	blurry crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	wholesome cheese sword	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2010-01"
 4400	boxer's cheese diaper	0		Muscle Percent: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	fireproof cheese wheel	0		Hot Resistance: +3, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	knitted cheese eye	0		Cold Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	knitted cheese eye	0		Cold Resistance: +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	executive Staff of Queso Escusado of Gandalf of the sweet-tooth	0		Spell Critical Percent: +20, Meat Drop: +40, Candy Drop: +100, Softcore Only, Last Available: "2010-01"
 4405	pulsating foreign box	0		
 4406	bouncing The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4393,7 +4393,7 @@
 4445	spangly mariachi pants	0		Item Drop: +5, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	mirror spangly mariachi vest of extreme caution of doom	0		Monster Level: -25, Spooky Spell Damage: +50
 4447	resourceful spangly sombrero	0		Maximum MP: +50, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	modified wobbly huge Instant Karma	1	good	
+4448	modified huge wobbly Instant Karma	1	good	
 4449	jittery painting of a landscape	0		Last Available: "2010-04"
 4450	huge map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	bouncing dangerous pointy hat	0		Weapon Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
@@ -4428,9 +4428,9 @@
 4480	skewed skewed BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	pulsating BRICKO airship	0		Last Available: "2010-02"
-4483	narrow mirror BRICKO cathedral	0		Last Available: "2010-02"
+4483	mirror narrow BRICKO cathedral	0		Last Available: "2010-02"
 4484	BRICKO gargantuchicken	0		Last Available: "2010-02"
-4485	shaking huge huge BRICKO pyramid	0		Last Available: "2010-02"
+4485	huge shaking huge BRICKO pyramid	0		Last Available: "2010-02"
 4486	huge BRICKO pearl	0		Last Available: "2010-02"
 4487	resourceful BRICKO bulwark	0		Maximum MP: +50, Damage Reduction: 3, Last Available: "2010-02"
 4488	BRICKO trunk	0		Last Available: "2010-02"
@@ -4445,24 +4445,24 @@
 4497	moist recording of The Ballad of Richie Thingfinder	0		Effect: "Moon-Eyed", Effect Duration: 40
 4498	adjusted spinning recording of Benetton's Medley of Diversity	0		Effect: "Elron's Explosive Etude", Effect Duration: 29
 4499	extra-quantum super-flattened skewed recording of Elron's Explosive Etude	0		Effect: "Leo Rising", Effect Duration: 69
-4500	aerosolized bouncing ghostly recording of Chorale of Companionship	0		Effect: "Extra-Sharp Weapon", Effect Duration: 22
+4500	aerosolized ghostly bouncing recording of Chorale of Companionship	0		Effect: "Extra-Sharp Weapon", Effect Duration: 22
 4501	non-corrupted concentrated triple-cold-filtered blue recording of Prelude of Precision	0		Effect: "Stop and Smell the Fudge", Effect Duration: 28
 4502	quantum recording of Donho's Bubbly Ballad	0		Effect: "Hopped Up on Goofballs", Effect Duration: 36
 4503	diffused electrified quadruple-quantum olive recording of Inigo's Incantation of Inspiration	0		Effect: "Deep-Seated Rage", Effect Duration: 57, Last Available: "2010-02"
 4504	purple lard-coated dance instructor's heart of the volcano	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +25
 4505	chilled flattened moist Northern pemmican	0		Effect: "Venomous Weapon", Effect Duration: 17
 4506	tumbling puzzling ribbon	0		
-4507	huge shaking Clan looking glass	0		Free Pull, Last Available: "2010-03"
+4507	shaking huge Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	double-oxidized yellow &quot;DRINK ME&quot; potion	0		Effect: "The Style... of the Future", Effect Duration: 55, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	flavorless thick walrus ice cream	5	decent	Last Available: "2010-03"
-4511	tiny delicious beautiful soup	1	awesome	Last Available: "2010-03"
+4511	delicious tiny beautiful soup	1	awesome	Last Available: "2010-03"
 4512	mirror eggman noodles	0		Last Available: "2010-03"
 4513	red Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	toothsome Humpty Dumplings	4	awesome	Last Available: "2010-03"
-4515	tasty gigantic Lobster <i>qua</i> Grill	8	awesome	Last Available: "2010-03"
+4515	gigantic tasty Lobster <i>qua</i> Grill	8	awesome	Last Available: "2010-03"
 4516	acceptable practically non-alcoholic missing wine	1	good	Last Available: "2010-03"
-4517	normal big matter custard	5	good	Last Available: "2010-03"
+4517	big normal matter custard	5	good	Last Available: "2010-03"
 4518	non-electrified comfit?	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 46, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	educational flamingo mallet of the scaredy-cat	0		Experience: +1, Monster Level: -15, Last Available: "2010-03"
@@ -4470,7 +4470,7 @@
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	banded eye of the Tiger-lily of horror	0		Damage Absorption: +100, Spooky Spell Damage: +25, Last Available: "2010-03"
 4524	jittery Temple Grandin's grievous wig	0		Weapon Damage Percent: +50, Familiar Weight: +7, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	flavorless bite-sized donut	1	decent	Last Available: "2010-03"
+4525	bite-sized flavorless donut	1	decent	Last Available: "2010-03"
 4526	moldy big bucket of honey	5	crappy	Last Available: "2010-03"
 4527	ghostly shellacked Sinatra's elephant stinger	0		Experience (Moxie): +5, Damage Reduction: 7, Last Available: "2010-03"
 4528	low-calorie bland dragon snaps	1	decent	Last Available: "2010-03"
@@ -4479,7 +4479,7 @@
 4531	yummy rook cookie	3	awesome	Last Available: "2010-03"
 4532	normal diet spinning bishop cookie	1	good	Last Available: "2010-03"
 4533	fancy moldy teal knight cookie	3	crappy	Effect: "Human-Machine Hybrid", Effect Duration: 30, Last Available: "2010-03"
-4534	huge toothsome king cookie	6	awesome	Last Available: "2010-03"
+4534	toothsome huge king cookie	6	awesome	Last Available: "2010-03"
 4535	stale massive queen cookie	9	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	spinning fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	pulsating insane tophat of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4491,7 +4491,7 @@
 4543	narrow purple Annie Oakley's tuxedo pants	0		Critical Hit Percent: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 4544	lime green porpoise	0		Last Available: "2010-03"
 4545	upside-down pocketwatch	0		Last Available: "2010-03"
-4546	shaking green tumbling bandersnatch	0		Last Available: "2010-03"
+4546	shaking tumbling green bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
 4549	tumbling carpenter	0		Last Available: "2010-03"
@@ -4508,7 +4508,7 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	mirror can of depilatory cream	0		Last Available: "2010-04"
 4562	tumbling hair of the calf	0		Last Available: "2010-04"
-4563	bad extra-dry world's most unappetizing beverage	5	decent	Last Available: "2010-04"
+4563	extra-dry bad world's most unappetizing beverage	5	decent	Last Available: "2010-04"
 4564	Rosewater's slippery when wet shield	0		Mysticality Percent: +30, Damage Reduction: 6, Last Available: "2010-04"
 4565	spoiled raisin	4	crappy	Last Available: "2010-04"
 4566	twirling fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4550,7 +4550,7 @@
 4602	gray orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	miser's Fonzie's bottle of Goldschn&ouml;ckered	0		Experience (Moxie): +1, Meat Drop: +10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	miser's Fonzie's bottle of Goldschn&ouml;ckered	0		Experience (Moxie): +1, Meat Drop: +10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	tasty fancy sun-dried tofu	4	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	practically non-alcoholic mediocre tumbling soyburger juice	1	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	bouncing respected companion biscuit	0		Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	fuchsia souvenir drawing	0		Last Available: "2010-08"
 4613	pulsating map to the Magic Commune	0		Last Available: "2010-08"
 4614	squat wholesome Crown of Thrones	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2010-05"
-4615	fancy extra-dry lousy bouncing Cinco Mayo Lager	5	decent	Effect: "Loyal Tea", Effect Duration: 35, Last Available: "2010-05"
+4615	fancy lousy extra-dry bouncing Cinco Mayo Lager	5	decent	Effect: "Loyal Tea", Effect Duration: 35, Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4574,7 +4574,7 @@
 4626	purple superduperball	0		Last Available: "2010-06"
 4627	ghostly finger cuffs	0		Last Available: "2010-06"
 4628	lime green parachute guy	0		Last Available: "2010-06"
-4629	veiny plastic spider ring	0		Maximum HP: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	veiny plastic spider ring	0		Maximum HP: +10, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	cool plastic kazoo	0		Moxie: +5, Last Available: "2010-06"
 4631	skewed groovy inflatable baseball bat	0		Moxie Percent: +10, Last Available: "2010-06"
 4632	dog trainer's shellacked googly-star hat	0		Damage Reduction: 7, Experience (familiar): +1, Familiar Effect: "atk", Last Available: "2010-06"
@@ -4619,7 +4619,7 @@
 4671	bad watered-down booze-soaked cherry	2	decent	
 4672	comfy pillow	0		
 4673	stale marshmallow	3	decent	
-4674	enchanted spoiled small sponge cake	2	crappy	Effect: "Fudgehound", Effect Duration: 25
+4674	spoiled small enchanted sponge cake	2	crappy	Effect: "Fudgehound", Effect Duration: 25
 4675	fortified delicious gin-soaked blotter paper	5	awesome	
 4676	tree-holed coin	0		
 4677	maroon unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4632,7 +4632,7 @@
 4684	supercharged pottery club	0		Maximum MP Percent: +30, Last Available: "2010-09"
 4685	dangerous pottery yo-yo	0		Weapon Damage: +10, Last Available: "2010-09"
 4686	red pottery barn owl figurine	0		Last Available: "2010-09"
-4687	red pulsating blurry fossilized bat skull	0		Last Available: "2010-09"
+4687	pulsating red blurry fossilized bat skull	0		Last Available: "2010-09"
 4688	fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
 4690	fossilized wyrm skull	0		Last Available: "2010-09"
@@ -4659,17 +4659,17 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	ghostly GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	yellow popsicle stick	0		
-4714	immense flavorless huge ghostly lemon popsicle	9	decent	
+4714	immense flavorless ghostly huge lemon popsicle	9	decent	
 4715	miniature flavorless wobbly popsicle	2	decent	
-4716	gigantic decent strawberry popsicle	10	good	
-4717	bland massive spinning liver popsicle	6	decent	
+4716	decent gigantic strawberry popsicle	10	good	
+4717	massive bland spinning liver popsicle	6	decent	
 4718	twirling sharpshooter's mariachi hat	0		Critical Hit Percent: +10, Familiar Effect: "atk, cap 2"
 4719	jittery foul-smelling Hollandaise helmet	0		Stench Damage: +10, Familiar Effect: "atk, cap 2"
 4720	olive organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	huge huge microwave stogie	0		Last Available: "2011-12"
-4722	flavorless fancy small liver and let pie	2	decent	Effect: "Sugar, Hello", Effect Duration: 20, Last Available: "2010-10"
-4723	miniature normal fancy badass pie	2	good	Effect: "All Is Forgiven", Effect Duration: 30, Last Available: "2010-10"
-4724	small tasty shoo-fish pie	2	awesome	Last Available: "2010-10"
+4722	small fancy flavorless liver and let pie	2	decent	Effect: "Sugar, Hello", Effect Duration: 20, Last Available: "2010-10"
+4723	normal fancy miniature badass pie	2	good	Effect: "All Is Forgiven", Effect Duration: 30, Last Available: "2010-10"
+4724	tasty small shoo-fish pie	2	awesome	Last Available: "2010-10"
 4725	low-calorie flavorless piping organ pie	1	decent	Last Available: "2010-10"
 4726	normal miniature igloo pie	2	good	Last Available: "2010-10"
 4727	thick flavorless blurry stomach turnover	5	decent	Last Available: "2010-10"
@@ -4678,14 +4678,14 @@
 4730	wobbly Annie Oakley's stop shield	0		Critical Hit Percent: +20, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	upside-down sleeping piano cat	0		Free Pull, Last Available: "2011-12"
-4733	blue wobbly kitty sheet music	0		Familiar Weight: +5
+4733	wobbly blue kitty sheet music	0		Familiar Weight: +5
 4734	rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	tumbling rock-hard beer-soaked mop	0		Damage Reduction: 5
 4738	aged day-old beer	4	awesome	
-4739	practically non-alcoholic special hand-crafted plain beer	1	EPIC	Effect: "Bilious Brains", Effect Duration: 30
-4740	bad high-proof fancy spinning overpriced &quot;imported&quot; beer	9	decent	Effect: "Fancy Feasted", Effect Duration: 40
+4739	hand-crafted practically non-alcoholic special plain beer	1	EPIC	Effect: "Bilious Brains", Effect Duration: 30
+4740	high-proof bad fancy spinning overpriced &quot;imported&quot; beer	9	decent	Effect: "Fancy Feasted", Effect Duration: 40
 4741	smiling rat	0		
 4742	spinning narrow rat tooth polish	0		Familiar Weight: +5
 4743	jittery bone chips	0		Last Available: "2011-12"
@@ -4693,7 +4693,7 @@
 4745	diffused upside-down mirror Wax Flask	0		Effect: "Polar Express", Effect Duration: 41
 4746	ionized Pain Dip	0		Effect: "Spooky Flavor", Effect Duration: 47
 4747	huge spoiled bone meal	6	crappy	Last Available: "2010-10"
-4748	acceptable practically non-alcoholic bone aperitif	1	good	Last Available: "2010-10"
+4748	practically non-alcoholic acceptable bone aperitif	1	good	Last Available: "2010-10"
 4749	bonerang of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2010-10"
 4750	frosty bone and arrows	0		Cold Spell Damage: +10, Last Available: "2010-10"
 4751	aromatic boning knife	0		Stench Resistance: +1, Last Available: "2010-10"
@@ -4727,7 +4727,7 @@
 4818	low-calorie flavorless CRIMBCOIDS mints	1	decent	Last Available: "2011-01"
 4819	twirling can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	normal CRIMBCOLOAF	4	good	Last Available: "2011-01"
-4821	special spoiled diet olive circular CRIMBCOOKIE	1	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	diet spoiled special olive circular CRIMBCOOKIE	1	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	bouncing Jim Carey's plastic CRIMBCO HQ	0		Monster Level: +25, Last Available: "2010-12"
 4823	Usain Bolt's plastic fax machine	0		Initiative: +80, Last Available: "2010-12"
 4824	red plastic hobo elf of the brazier	0		Hot Spell Damage: +25, Last Available: "2010-12"
@@ -4738,14 +4738,14 @@
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	gray robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
-4832	upside-down olive robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
+4832	olive upside-down robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
-4835	bouncing skewed robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
+4835	skewed bouncing robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	olive robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	wobbly robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	bite-sized decent triangular CRIMBCOOKIE	1	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	decent bite-sized triangular CRIMBCOOKIE	1	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	flavorless half-sized square CRIMBCOOKIE	2	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	executive educational bindlestocking of the bloodbag	0		Experience: +1, Maximum HP: +100, Meat Drop: +40, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
@@ -4765,7 +4765,7 @@
 4856	yellow paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	skewed thinker's CRIMBCO lanyard	0		Mysticality: +10, Single Equip, Last Available: "2011-01"
-4859	wobbly jittery CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+4859	jittery wobbly CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	ghostly CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	twirling CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
@@ -4790,7 +4790,7 @@
 4881	tolerable CRIMBCO wine	4	good	Last Available: "2011-01"
 4882	narrow Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	skewed toe jam	0		Last Available: "2011-01"
-4884	jumbo special decent narrow toe jam toast	5	good	Effect: "Steroid Boost", Effect Duration: 20, Last Available: "2011-01"
+4884	special decent jumbo narrow toe jam toast	5	good	Effect: "Steroid Boost", Effect Duration: 20, Last Available: "2011-01"
 4885	olive traffic jam	0		Last Available: "2011-01"
 4886	decent traffic jam toast	4	good	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	red BGE shotglass	0		Last Available: "2010-12"
 4894	stale festive sausage	3	decent	Last Available: "2011-01"
-4895	special flavorless holiday cheese log	4	decent	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 50, Last Available: "2011-01"
+4895	flavorless special holiday cheese log	4	decent	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 50, Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	perfumed grievous BGE 'ferocious fruit' shirt	0		Weapon Damage Percent: +50, Stench Resistance: +5, Last Available: "2010-12"
 4898	inspector's sizzling BGE 'cuddly critter' shirt	0		Hot Damage: +10, Item Drop: +15, Last Available: "2010-12"
@@ -4811,7 +4811,7 @@
 4902	wobbly wool stapler bear	0		Cold Resistance: +1, Last Available: "2010-12"
 4903	auspicious adhesive tape dolly	0		Item Drop: +10, Last Available: "2010-12"
 4904	baleful scissor duck	0		Spell Damage: +25, Last Available: "2010-12"
-4905	ghostly fuchsia tumbling coal paperweight	0		Last Available: "2010-12"
+4905	fuchsia tumbling ghostly coal paperweight	0		Last Available: "2010-12"
 4906	jingle bell	0		Last Available: "2010-12"
 4907	Samson's Seven Loco of the detective	0		Experience (Muscle): +5, Item Drop: +20, Last Available: "2010-09"
 4908	pulsating Loathing Legion knife	0		Last Available: "2011-01"
@@ -4832,7 +4832,7 @@
 4923	flame-wreathed Loathing Legion abacus	0		Hot Spell Damage: +10, Softcore Only, Last Available: "2011-01"
 4924	Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
 4925	maroon narrow healthy Loathing Legion pizza stone	0		Maximum HP Percent: +20, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
-4926	bouncing blue Loathing Legion universal screwdriver	0		Last Available: "2011-01"
+4926	blue bouncing Loathing Legion universal screwdriver	0		Last Available: "2011-01"
 4927	Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
 4928	extremely unsafe Loathing Legion hammer	0		Weapon Damage Percent: +100, Softcore Only, Last Available: "2011-01"
 4929	Uncle Crimbo's Sack	0		Last Available: "2011-01"
@@ -4859,12 +4859,12 @@
 4956	spoiled philosopher's scone	4	crappy	
 4957	oxidized anodized skewed half-baked potion	0		Effect: "Cotton Mouthed", Effect Duration: 27
 4958	Knob Goblin deluxe scimitar	0		Item Drop: +5
-4959	normal enchanted squat Knob nuts	3	good	Effect: "Human-Plant Hybrid", Effect Duration: 30
+4959	enchanted normal squat Knob nuts	3	good	Effect: "Human-Plant Hybrid", Effect Duration: 30
 4960	artisanal cyan Cobb's Knob Wurstbrau	3	EPIC	
 4961	Subject 37 file	0		
 4962	scorching manspreader's mysterious lapel pin	0		Monster Level: +10, Hot Damage: +25, Single Equip
 4963	state loom	0		Familiar Weight: +10
-4964	spinning lime green Evilometer	0		
+4964	lime green spinning Evilometer	0		
 4965	Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	narrow Alice's Army Swordsman	0		Last Available: "2011-03"
@@ -4881,7 +4881,7 @@
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
-4981	mirror gray Alice's Army Horseman	0		Last Available: "2011-03"
+4981	gray mirror Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
 4983	ghostly Alice's Army Cleric	0		Last Available: "2011-03"
 4984	Alice's Army Sniper	0		Last Available: "2011-03"
@@ -4898,7 +4898,7 @@
 4995	Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	olive Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
 4997	Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
-4998	mirror wobbly Alice's Army Foil Nurse	0		Last Available: "2011-03"
+4998	wobbly mirror Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	gray Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	green Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	Alice's Army Foil Lanceman	0		Last Available: "2011-03"
@@ -4913,10 +4913,10 @@
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	moldy big bouncing wasabi pocky	5	crappy	Last Available: "2011-03"
+5013	big moldy bouncing wasabi pocky	5	crappy	Last Available: "2011-03"
 5014	bland tobiko pocky	4	decent	Last Available: "2011-03"
 5015	adequate natto pocky	3	good	Last Available: "2011-03"
-5016	watered-down mediocre wasabi-infused sake	2	decent	Last Available: "2011-03"
+5016	mediocre watered-down wasabi-infused sake	2	decent	Last Available: "2011-03"
 5017	fancy hand-crafted tobiko-infused sake	3	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 20, Last Available: "2011-03"
 5018	bad maroon natto-infused sake	3	decent	Last Available: "2011-03"
 5019	ionized ionized adjusted blurry wasabi marble soda	0		Effect: "Impregnabili Tea", Effect Duration: 33, Last Available: "2011-03"
@@ -4926,8 +4926,8 @@
 5023	modified elderly jawbreaker	0		Effect: "Armor-Plated", Effect Duration: 38, Last Available: "2020-09"
 5024	delicious irresponsibly strong marshmallow flamb&eacute;	8	awesome	Last Available: "2011-03"
 5025	artisanal cranberry schnapps	3	EPIC	Last Available: "2011-03"
-5026	hand-crafted weak breaded beer	2	super ultra mega turbo EPIC	Last Available: "2011-03"
-5027	acceptable spirit-forward soy cordial	5	good	Last Available: "2011-03"
+5026	weak hand-crafted breaded beer	2	super ultra mega turbo EPIC	Last Available: "2011-03"
+5027	spirit-forward acceptable soy cordial	5	good	Last Available: "2011-03"
 5028	shaking zippy flame-wreathed Newton's astral bludgeon	0		Experience (Mysticality): +3, Hot Spell Damage: +10, Initiative: +20
 5029	fuchsia supercool stylish astral shield	0		Moxie: +25, Moxie Percent: +20, Damage Reduction: 15
 5030	yellow avaricious foul-smelling Socratic astral chapeau	0		Experience (Mysticality): +1, Stench Damage: +10, Meat Drop: +30, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -5009,7 +5009,7 @@
 5106	huge yellow hideous egg	0		Last Available: "2011-05"
 5107	weak bad Jeppson's Malort	2	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	red squat thinker's stress ball	0		Mysticality: +10, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	red squat thinker's stress ball	0		Mysticality: +10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Ultracolor&trade; shirt of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5025,7 +5025,7 @@
 5122	blurry dog trainer's padded aviator's cap of the sewer	0		Damage Absorption: +20, Experience (familiar): +1, Stench Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	hardened groovy mirrored aviator shades	0		Moxie Percent: +10, Damage Reduction: 3, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
-5125	shaking spinning Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
+5125	spinning shaking Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	tumbling Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
@@ -5038,7 +5038,7 @@
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
-5138	lime green blinking bouncing jittery E.M.U. harness	0		Last Available: "2011-06"
+5138	bouncing blinking lime green jittery E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
 5140	distilled upside-down astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
@@ -5046,8 +5046,8 @@
 5143	mirror twirling E.M.U. Unit	0		Last Available: "2011-06"
 5144	upside-down handful of honey	0		
 5145	unsweetened honeypot	0		Effect: "Speed of the Internet", Effect Duration: 45
-5146	adequate half-sized wild honey pie	2	good	
-5147	fancy hand-crafted irresponsibly strong teal honey mead	9	EPIC	Effect: "Virgo Rising", Effect Duration: 30
+5146	half-sized adequate wild honey pie	2	good	
+5147	hand-crafted fancy irresponsibly strong teal honey mead	9	EPIC	Effect: "Virgo Rising", Effect Duration: 30
 5148	up-at-dawn flame-retardant nasty honey dipper	0		Stench Damage: +5, Hot Resistance: +1, Adventures: +5
 5149	lion tamer's stiffened thinker's honeybritches	0		Mysticality: +10, Damage Reduction: 1, Experience (familiar): +2, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	cyan foul-smelling chilly hale honeycap	0		Maximum HP: +20, Cold Damage: +5, Stench Damage: +10, Familiar Effect: "1xPotato, cap 43"
@@ -5077,8 +5077,8 @@
 5174	tolerable Saison du Lune	3	good	Last Available: "2011-06"
 5175	drinkable ghostly Moonthril Schnapps	3	good	Last Available: "2011-06"
 5176	perfectly mixed Wrecked Generator	4	super EPIC	Last Available: "2011-06"
-5177	fancy spoiled Spaghetti with Moonballs	3	crappy	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2011-06"
-5178	moldy diet Crepes a la Lune	1	crappy	Last Available: "2011-06"
+5177	spoiled fancy Spaghetti with Moonballs	3	crappy	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2011-06"
+5178	diet moldy Crepes a la Lune	1	crappy	Last Available: "2011-06"
 5179	delicious wobbly Moon Pie	3	awesome	Last Available: "2011-06"
 5180	chilled anodized bouncing Comet Pop	0		Effect: "Rushin' Hands", Effect Duration: 50, Last Available: "2011-06"
 5181	denatured electrified pulsating Flan in the Moon	0		Effect: "Square to be Hip", Effect Duration: 54, Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	pickled honey stick	0		Effect: "Square to be Hip", Effect Duration: 62
 5189	galvanized double-aerosolized double-ice gum	0		Effect: "Some Cheese with Your Wine", Effect Duration: 63, Last Available: "2011-04"
-5190	vibrating ruddy Sinatra's Operation Patriot Shield	0		Experience (Moxie): +5, Maximum HP Percent: +40, Maximum MP Percent: +10, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	vibrating ruddy Sinatra's Operation Patriot Shield	0		Experience (Moxie): +5, Maximum HP Percent: +40, Maximum MP Percent: +10, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	jittery squirming egg sac	0		Last Available: "2011-06"
 5192	magnetized dry electrified corrupted data	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 69, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5117,17 +5117,17 @@
 5214	boiled blurry ghostly slimy paste	1	EPIC	Effect: "Conspiratory Eyes", Effect Duration: 15, Last Available: "2011-08"
 5215	boiled lime green penguin paste	1	awesome	Last Available: "2011-08"
 5216	denatured ghostly elemental paste	1	crappy	Last Available: "2011-08"
-5217	denatured skewed ghostly squat cosmic paste	1	EPIC	Effect: "Fortunate Resolve", Effect Duration: 50, Last Available: "2011-08"
-5218	powdered spinning skewed hobo paste	1	EPIC	Last Available: "2011-08"
+5217	denatured skewed squat ghostly cosmic paste	1	EPIC	Effect: "Fortunate Resolve", Effect Duration: 50, Last Available: "2011-08"
+5218	powdered skewed spinning hobo paste	1	EPIC	Last Available: "2011-08"
 5219	diluted skewed Crimbo paste	1	awesome	Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	jittery Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	moldy Ur-Donut	3	crappy	Last Available: "2011-09"
-5225	spinning green The Bomb	0		Last Available: "2011-09"
+5225	green spinning The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	aged irresponsibly strong gray bucket of wine	8	awesome	Last Available: "2011-09"
+5227	irresponsibly strong aged gray bucket of wine	8	awesome	Last Available: "2011-09"
 5228	stale gigantic spinning ultrafondue	9	decent	Last Available: "2011-09"
 5229	lime green unbearable light	0		Last Available: "2011-09"
 5230	narrow snowflake	0		Last Available: "2011-09"
@@ -5139,7 +5139,7 @@
 5236	frosty halo of wisdom	0		Mysticality: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	tumbling huge resourceful time halo	0		Maximum MP: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	drinkable Lumineux Limnio	3	good	Last Available: "2011-09"
-5239	watered-down delicious Morto Moreto	2	awesome	Last Available: "2011-09"
+5239	delicious watered-down Morto Moreto	2	awesome	Last Available: "2011-09"
 5240	tolerable watered-down Temps Tempranillo	2	good	Last Available: "2011-09"
 5241	mediocre practically non-alcoholic Bordeaux Marteaux	1	decent	Last Available: "2011-09"
 5242	artisanal Fromage Pinotage	3	EPIC	Last Available: "2011-09"
@@ -5149,14 +5149,14 @@
 5246	normal thick shrapnel jelly donut	5	good	Last Available: "2011-09"
 5247	spoiled cyan occult jelly donut	3	crappy	Last Available: "2011-09"
 5248	rotten narrow thyme jelly donut	3	crappy	Last Available: "2011-09"
-5249	bite-sized adequate danish	1	good	Last Available: "2011-09"
-5250	stale immense smashed danish	9	decent	Last Available: "2011-09"
+5249	adequate bite-sized danish	1	good	Last Available: "2011-09"
+5250	immense stale smashed danish	9	decent	Last Available: "2011-09"
 5251	spoiled tiny forbidden danish	1	crappy	Last Available: "2011-09"
 5252	delicious tiny cool cat claw	1	awesome	Last Available: "2011-09"
-5253	flavorless immense bouncing blunt cat claw	9	decent	Last Available: "2011-09"
+5253	immense flavorless bouncing blunt cat claw	9	decent	Last Available: "2011-09"
 5254	spoiled shadowy cat claw	3	crappy	Last Available: "2011-09"
 5255	half-sized adequate blinking cheezburger	2	good	Last Available: "2011-09"
-5256	adequate thick toasted brie	5	good	Last Available: "2011-09"
+5256	thick adequate toasted brie	5	good	Last Available: "2011-09"
 5257	corrupted potion of the field gar	0		Effect: "Greasy Visage", Effect Duration: 40, Last Available: "2011-09"
 5258	alkaline jittery too legit potion	0		Effect: "Fustulent", Effect Duration: 11, Last Available: "2011-09"
 5259	Vulcanized bouncing blinking Bright Water	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 51, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of chilblains	0		Cold Damage: +25, Last Available: "2011-09"
 5282	ghostly arcane researcher's dethklok	0		Experience Percent (Mysticality): +10, Last Available: "2011-09"
 5283	glacial clock of the cougar	0		Moxie: +20, Last Available: "2011-09"
-5284	gray huge skewed Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	skewed huge gray Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	jittery d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	shaking dungeon dragon chest	0		Last Available: "2011-09"
 5298	adequate tumbling phish stick	4	good	Last Available: "2011-09"
-5299	up-at-dawn occult plastic vampire fangs of the brazier	0		Spell Damage Percent: +25, Hot Spell Damage: +25, Adventures: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	up-at-dawn occult plastic vampire fangs of the brazier	0		Spell Damage Percent: +25, Hot Spell Damage: +25, Adventures: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5223,10 +5223,10 @@
 5320	liquefied improved enhanced Lobos Mints	0		Effect: "Hiding in Plain Sight", Effect Duration: 41, Last Available: "2011-10"
 5321	colloidal Sweet Sword	0		Effect: "Stinking Cloud", Effect Duration: 39, Last Available: "2011-10"
 5322	acceptable weak Ecto-Cooler	2	good	Last Available: "2011-10"
-5323	special weak perfectly mixed Bartles and BRAAAINS wine cooler	2	EPIC	Effect: "Ready to Snap", Effect Duration: 40, Last Available: "2011-10"
+5323	perfectly mixed special weak Bartles and BRAAAINS wine cooler	2	EPIC	Effect: "Ready to Snap", Effect Duration: 40, Last Available: "2011-10"
 5324	tolerable weak Blood Light	2	good	Last Available: "2011-10"
-5325	watered-down tolerable Silver Bullet beer	2	good	Last Available: "2011-10"
-5326	fancy artisanal spirit-forward Bone's Farm &quot;wine&quot;	5	EPIC	Effect: "Knightlife", Effect Duration: 35, Last Available: "2011-10"
+5325	tolerable watered-down Silver Bullet beer	2	good	Last Available: "2011-10"
+5326	spirit-forward artisanal fancy Bone's Farm &quot;wine&quot;	5	EPIC	Effect: "Knightlife", Effect Duration: 35, Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	energized sorority brain	0		Effect: "Deadly Flashing Blade", Effect Duration: 23, Last Available: "2011-10"
 5329	extra-colloidal Nightstalker perfume	0		Effect: "Educated (Kinda)", Effect Duration: 39, Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	censurious reassuring The Necbromancer's Shorts of courage	0		Spooky Resistance: 4, Sleaze Resistance: +3, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	greasy The Necbromancer's Wizard Staff of Tarzan of the sweet-tooth	0		Experience (Muscle): +3, Sleaze Spell Damage: +10, Candy Drop: +100, Last Available: "2011-10"
 5341	ghostly The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	strong enchanted tolerable huge The Cooler Out of Space	5	good	Effect: "Sticks and Stones", Effect Duration: 5, Last Available: "2011-10"
+5342	strong tolerable enchanted huge The Cooler Out of Space	5	good	Effect: "Sticks and Stones", Effect Duration: 5, Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	polymerized corrupted squat Necbro wafers	0		Effect: "Sausage Festive", Effect Duration: 61, Last Available: "2020-09"
@@ -5254,7 +5254,7 @@
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
-5354	blinking maroon The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+5354	maroon blinking The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	wobbly squat Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
@@ -5284,12 +5284,12 @@
 5381	bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
 5383	tourmalime	0		Last Available: "2011-11"
-5384	squat fuchsia kumquartz	0		Last Available: "2011-11"
-5385	yellow narrow strawberyl	0		Last Available: "2011-11"
+5384	fuchsia squat kumquartz	0		Last Available: "2011-11"
+5385	narrow yellow strawberyl	0		Last Available: "2011-11"
 5386	lime green Newton's ridiculous belt	0		Experience (Mysticality): +3, Last Available: "2011-11"
 5387	grievous ridiculous earring	0		Weapon Damage Percent: +50, Last Available: "2011-11"
 5388	double-paned ridiculous sunglasses	0		Cold Resistance: +5, Last Available: "2011-11"
-5389	bland massive ridiculous sandwich	10	decent	Last Available: "2011-11"
+5389	massive bland ridiculous sandwich	10	decent	Last Available: "2011-11"
 5390	drinkable mirror ridiculous cocktail	3	good	Last Available: "2011-11"
 5391	hale Herculean zombie monkey necklace	0		Experience (Muscle): +1, Maximum HP: +20
 5392	purple Thwaitgold butterfly statuette	0		
@@ -5298,7 +5298,7 @@
 5395	peppermint sprout	0		Last Available: "2011-11"
 5396	polymerized unsweetened pulsating peppermint twist	0		Effect: "Jawin'", Effect Duration: 65, Last Available: "2011-11"
 5397	half-sized yummy peppermint patty	2	awesome	Last Available: "2011-11"
-5398	wobbly ghostly peppermint crook	0		Last Available: "2011-11"
+5398	ghostly wobbly peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	bouncing candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
@@ -5309,7 +5309,7 @@
 5406	flame-retardant Annie Oakley's slick cane-mail pants	0		Moxie: +10, Critical Hit Percent: +20, Hot Resistance: +1, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	perfectly mixed spinning Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
 5408	perfectly mixed practically non-alcoholic twirling Gin Mint	1	super ultra mega turbo EPIC	Last Available: "2011-12"
-5409	hand-crafted high-proof Tequiz Navidad	6	EPIC	Last Available: "2011-12"
+5409	high-proof hand-crafted Tequiz Navidad	6	EPIC	Last Available: "2011-12"
 5410	mediocre ghostly Mint Yulep	3	decent	Last Available: "2011-12"
 5411	weak aged pulsating Crimbojito	2	awesome	Last Available: "2011-12"
 5412	perfectly mixed blurry Sangria de Menthe	4	EPIC	Last Available: "2011-12"
@@ -5355,7 +5355,7 @@
 5452	avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
-5455	skewed squat gummi ingot	0		Last Available: "2011-11"
+5455	squat skewed gummi ingot	0		Last Available: "2011-11"
 5456	huge gummi ingot	0		Last Available: "2011-11"
 5457	dry enhanced Fudgie Roll	0		Effect: "Dancing Prowess", Effect Duration: 50, Last Available: "2011-11"
 5458	diet decent fudge bunny	1	good	Last Available: "2011-11"
@@ -5379,11 +5379,11 @@
 5476	oxidized enhanced wobbly tumbling gummi salamander	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 20, Last Available: "2011-11"
 5477	corrupted ionized gummi snake	0		Effect: "Egg-stra Arm", Effect Duration: 21, Last Available: "2011-11"
 5478	quadruple-pickled super-frozen magnetized gummi canary	0		Effect: "Moon'd", Effect Duration: 54, Last Available: "2011-11"
-5479	normal immense gummi bear	9	good	Last Available: "2011-11"
+5479	immense normal gummi bear	9	good	Last Available: "2011-11"
 5480	snack-sized toothsome ghostly gummi bear	2	awesome	Last Available: "2011-11"
-5481	miniature bland gummi bear	2	decent	Last Available: "2011-11"
+5481	bland miniature gummi bear	2	decent	Last Available: "2011-11"
 5482	super-sized stale drunki-bear	5	decent	Last Available: "2011-11"
-5483	bite-sized toothsome drunki-bear	1	awesome	Last Available: "2011-11"
+5483	toothsome bite-sized drunki-bear	1	awesome	Last Available: "2011-11"
 5484	decent big drunki-bear	5	good	Last Available: "2011-11"
 5485	grievous gummi bowtie	0		Weapon Damage Percent: +50, Last Available: "2011-11"
 5486	electrified fudge pocket square	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
@@ -5435,7 +5435,7 @@
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	chilled anodized blurry Mortimer's nostrum	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 44, Last Available: "2012-12"
 5534	artisanal shaking Barulio's bottle	4	EPIC	Last Available: "2012-12"
-5535	altered squat pulsating Marvin's marvelous pill	0		Effect: "Sweet and Red", Effect Duration: 61, Last Available: "2012-12"
+5535	altered pulsating squat Marvin's marvelous pill	0		Effect: "Sweet and Red", Effect Duration: 61, Last Available: "2012-12"
 5536	pulsating Winifred's whistle	0		Last Available: "2012-12"
 5537	fuchsia prose pen	0		Last Available: "2012-12"
 5538	half-empty carton of milk	0		Last Available: "2012-12"
@@ -5444,8 +5444,8 @@
 5541	tumbling tumbling Vivian's Vitamin	0		Last Available: "2012-12"
 5542	red pink-belly slapper	0		Last Available: "2012-12"
 5543	purple twirling rosy-cheeked sage Leapin' Trousers	0		Mysticality Percent: +10, Maximum HP Percent: +30
-5544	lousy irresponsibly strong eggnog	9	decent	Last Available: "2012-12"
-5545	low-calorie stale enchanted hamhock	1	decent	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2012-12"
+5544	irresponsibly strong lousy eggnog	9	decent	Last Available: "2012-12"
+5545	stale enchanted low-calorie hamhock	1	decent	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2012-12"
 5546	olive The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5465,79 +5465,79 @@
 5562	fuchsia blinking chilly Rain-Doh violet bo of mayonnaise	0		Cold Damage: +5, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	miniature tasty spinning PB&BP	2	awesome	
-5566	adequate small club sandwich	2	good	
+5565	tasty miniature spinning PB&BP	2	awesome	
+5566	small adequate club sandwich	2	good	
 5567	rotten miniature blinking corned-beef Reuben	2	crappy	
-5568	cyan wobbly frayed ninja rope	0		
+5568	wobbly cyan frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	huge loose ninja carabiner	0		
 5571	tumbling Groar's fur	0		
 5572	olive Thwaitgold stag beetle statuette	0		
 5573	artisanal Drac & Tan	4	EPIC	Last Available: "2012-03"
-5574	practically non-alcoholic hand-crafted Transylvania Sling	1	EPIC	Last Available: "2012-03"
+5574	hand-crafted practically non-alcoholic Transylvania Sling	1	EPIC	Last Available: "2012-03"
 5575	drinkable Shot of the Living Dead	3	good	Last Available: "2012-03"
 5576	special mediocre huge Buttery Knob	3	decent	Effect: "Quiet 'n' Good", Effect Duration: 50, Last Available: "2012-03"
 5577	tolerable Slippery Knob	3	good	Last Available: "2012-03"
 5578	artisanal huge Flaming Knob	4	EPIC	Last Available: "2012-03"
-5579	boozy bad Grasshopper	5	decent	Last Available: "2012-03"
+5579	bad boozy Grasshopper	5	decent	Last Available: "2012-03"
 5580	acceptable green Locust	4	good	Last Available: "2012-03"
 5581	hand-crafted watered-down Plague of Locusts	2	EPIC	Last Available: "2012-03"
 5582	aged ghostly Red Dwarf	4	awesome	Last Available: "2012-03"
 5583	irresponsibly strong delicious huge Golden Mean	8	awesome	Last Available: "2012-03"
 5584	practically non-alcoholic delicious narrow Green Giant	1	awesome	Last Available: "2012-03"
-5585	acceptable practically non-alcoholic Aye Aye	1	good	Last Available: "2012-03"
+5585	practically non-alcoholic acceptable Aye Aye	1	good	Last Available: "2012-03"
 5586	tolerable wobbly Aye Aye, Captain	3	good	Last Available: "2012-03"
-5587	bad watered-down pulsating green Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
+5587	watered-down bad pulsating green Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
 5588	bad Humanitini	4	decent	Last Available: "2012-03"
-5589	artisanal weak upside-down More Humanitini than Humanitini	2	EPIC	Last Available: "2012-03"
+5589	weak artisanal upside-down More Humanitini than Humanitini	2	EPIC	Last Available: "2012-03"
 5590	watered-down hand-crafted Oh, the Humanitini	2	EPIC	Last Available: "2012-03"
 5591	spirit-forward tolerable Great Older Fashioned	5	good	Last Available: "2012-03"
-5592	hand-crafted weak tumbling Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5592	weak hand-crafted tumbling Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	aged narrow Crazymaker	4	awesome	Last Available: "2012-03"
-5594	acceptable maroon skewed Zoodriver	3	good	Last Available: "2012-03"
-5595	practically non-alcoholic acceptable Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
+5594	acceptable skewed maroon Zoodriver	3	good	Last Available: "2012-03"
+5595	acceptable practically non-alcoholic Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
 5596	artisanal Sloe Comfortable Zoo on Fire	4	EPIC	Last Available: "2012-03"
 5597	smooth Suffering Sinner	3	awesome	Last Available: "2012-03"
-5598	weak delicious Suppurating Sinner	2	awesome	Last Available: "2012-03"
-5599	weak acceptable blurry Sizzling Sinner	2	good	Last Available: "2012-03"
-5600	practically non-alcoholic lousy Firewater	1	decent	Last Available: "2012-03"
-5601	hand-crafted extra-dry Earth and Firewater	5	EPIC	Last Available: "2012-03"
+5598	delicious weak Suppurating Sinner	2	awesome	Last Available: "2012-03"
+5599	acceptable weak blurry Sizzling Sinner	2	good	Last Available: "2012-03"
+5600	lousy practically non-alcoholic Firewater	1	decent	Last Available: "2012-03"
+5601	extra-dry hand-crafted Earth and Firewater	5	EPIC	Last Available: "2012-03"
 5602	bad Earth, Wind and Firewater	3	decent	Last Available: "2012-03"
 5603	aged Slimosa	3	awesome	Last Available: "2012-03"
 5604	perfectly mixed Extra-slimy Slimosa	3	EPIC	Last Available: "2012-03"
 5605	smooth high-proof Slimebite	10	awesome	Last Available: "2012-03"
-5606	weak drinkable Cement Mixer	2	good	Last Available: "2012-03"
+5606	drinkable weak Cement Mixer	2	good	Last Available: "2012-03"
 5607	practically non-alcoholic aged ghostly Jackhammer	1	awesome	Last Available: "2012-03"
 5608	watered-down smooth huge Dump Truck	2	awesome	Last Available: "2012-03"
 5609	aged Fauna Libre	3	awesome	Last Available: "2012-03"
 5610	delicious maroon Chakra Libre	3	awesome	Last Available: "2012-03"
 5611	drinkable Aura Libre	3	good	Last Available: "2012-03"
 5612	drinkable Sazerorc	4	good	Last Available: "2012-03"
-5613	mediocre distilled squat Sazuruk-hai	5	decent	Last Available: "2012-03"
+5613	distilled mediocre squat Sazuruk-hai	5	decent	Last Available: "2012-03"
 5614	hand-crafted blinking Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
-5615	mediocre weak Green Velvet	2	decent	Last Available: "2012-03"
+5615	weak mediocre Green Velvet	2	decent	Last Available: "2012-03"
 5616	delicious blinking Green Muslin	3	awesome	Last Available: "2012-03"
 5617	spirit-forward perfectly mixed Green Burlap	5	EPIC	Last Available: "2012-03"
 5618	mediocre Mohobo	3	decent	Last Available: "2012-03"
 5619	irresponsibly strong delicious Moonshine Mohobo	7	awesome	Last Available: "2012-03"
-5620	weak smooth Flaming Mohobo	2	awesome	Last Available: "2012-03"
+5620	smooth weak Flaming Mohobo	2	awesome	Last Available: "2012-03"
 5621	tolerable Drunken Philosopher	3	good	Last Available: "2012-03"
 5622	perfectly mixed Drunken Neurologist	3	EPIC	Last Available: "2012-03"
 5623	drinkable Drunken Astrophysicist	3	good	Last Available: "2012-03"
-5624	mediocre enchanted Dark & Starry	3	decent	Effect: "Mystic Circle", Effect Duration: 15, Last Available: "2012-03"
+5624	enchanted mediocre Dark & Starry	3	decent	Effect: "Mystic Circle", Effect Duration: 15, Last Available: "2012-03"
 5625	hand-crafted Black Hole	4	EPIC	Last Available: "2012-03"
 5626	drinkable Event Horizon	3	good	Last Available: "2012-03"
-5627	hand-crafted watered-down Herring Daiquiri	2	EPIC	Last Available: "2012-03"
-5628	irresponsibly strong special bad Herring Wallbanger	10	decent	Effect: "Antarctic Memories", Effect Duration: 10, Last Available: "2012-03"
-5629	lousy practically non-alcoholic Herringtini	1	decent	Last Available: "2012-03"
-5630	distilled delicious Lollipop Drop	5	awesome	Last Available: "2012-03"
+5627	watered-down hand-crafted Herring Daiquiri	2	EPIC	Last Available: "2012-03"
+5628	bad special irresponsibly strong Herring Wallbanger	10	decent	Effect: "Antarctic Memories", Effect Duration: 10, Last Available: "2012-03"
+5629	practically non-alcoholic lousy Herringtini	1	decent	Last Available: "2012-03"
+5630	delicious distilled Lollipop Drop	5	awesome	Last Available: "2012-03"
 5631	smooth red Candy Alexander	4	awesome	Last Available: "2012-03"
 5632	drinkable Candicaine	4	good	Last Available: "2012-03"
 5633	perfectly mixed Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	practically non-alcoholic delicious squat Flying Caipiranha	1	awesome	Last Available: "2012-03"
-5635	high-proof bad blinking Flaming Caipiranha	10	decent	Last Available: "2012-03"
-5636	weak bad Punchplanter	2	decent	Last Available: "2012-03"
-5637	mediocre weak blurry spinning Doublepunchplanter	2	decent	Last Available: "2012-03"
+5635	bad high-proof blinking Flaming Caipiranha	10	decent	Last Available: "2012-03"
+5636	bad weak Punchplanter	2	decent	Last Available: "2012-03"
+5637	mediocre weak spinning blurry Doublepunchplanter	2	decent	Last Available: "2012-03"
 5638	tolerable Haymaker	4	good	Last Available: "2012-03"
 5639	bouncing Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
@@ -5555,7 +5555,7 @@
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	flavorless blinking nailswurst	3	decent	
-5655	delicious watered-down fuchsia huge used beer	2	awesome	
+5655	watered-down delicious huge fuchsia used beer	2	awesome	
 5656	Huggler Radio	0		Free Pull
 5657	twirling fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5570,7 +5570,7 @@
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
-5670	moldy miniature narrow fettucini &eacute;pines Inconnu	2	crappy	
+5670	miniature moldy narrow fettucini &eacute;pines Inconnu	2	crappy	
 5671	hand-crafted slap and slap again	3	EPIC	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
@@ -5578,13 +5578,13 @@
 5675	diluted pulsating watered-down Red Minotaur	1		Effect: "Indescribable Flavor", Effect Duration: 35
 5676	pulsating pool torpedo	0		Last Available: "2012-05"
 5677	frightening Ze&trade; goggles	0		Spooky Damage: +5, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
-5678	blinking pulsating soggy used band-aid	0		Last Available: "2012-05"
+5678	pulsating blinking soggy used band-aid	0		Last Available: "2012-05"
 5679	coward's Oprah's stylish swimsuit	0		Maximum MP Percent: +50, Monster Level: -20, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	moldy half-sized P.B.L.T.	2	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	teal BURT	0		
-5684	twirling blurry handful of juicy garbage	0		
+5684	blurry twirling handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
 5687	bugbear autopsy tweezers	0		
@@ -5632,19 +5632,19 @@
 5731	hand-crafted huge 5-hour acrimony	3	EPIC	
 5732	blank note	0		
 5733	skewed eerily silent box	0		
-5734	snack-sized rotten forbidden sausage	2	crappy	
-5735	steel-toed Lord Flameface's cloak	0		Damage Reduction: 9, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5734	rotten snack-sized forbidden sausage	2	crappy	
+5735	steel-toed Lord Flameface's cloak	0		Damage Reduction: 9, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	cold-filtered flattened narrow Drizzlers&trade; Black Licorice	0		Effect: "Mushroom Samba", Effect Duration: 36
 5737	corrupted blurry daub-breaker	0		Effect: "Altered Wavelengths", Effect Duration: 15, Last Available: "2020-09"
 5738	avaricious Camp Scout backpack	0		Meat Drop: +30, Softcore Only, Last Available: "2012-07"
-5739	skewed jittery CSA fire-starting kit	0		Last Available: "2012-07"
+5739	jittery skewed CSA fire-starting kit	0		Last Available: "2012-07"
 5740	normal bag of GORP	4	good	Last Available: "2012-07"
-5741	artisanal triple-distilled upside-down upside-down water purification pills	10	EPIC	Last Available: "2012-07"
+5741	triple-distilled artisanal upside-down upside-down water purification pills	10	EPIC	Last Available: "2012-07"
 5742	spinning Camp Scout pup tent	0		Last Available: "2012-07"
 5743	hand-crafted spinning CSA scoutmaster's &quot;water&quot;	3	EPIC	Last Available: "2012-07"
-5744	half-sized adequate huge bag of GORF	2	good	Last Available: "2012-07"
+5744	adequate half-sized huge bag of GORF	2	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	low-calorie special flavorless bag of QWOP	1	decent	Effect: "Gummiskin", Effect Duration: 5, Last Available: "2012-07"
+5746	flavorless special low-calorie bag of QWOP	1	decent	Effect: "Gummiskin", Effect Duration: 5, Last Available: "2012-07"
 5747	chilled green CSA bravery badge	0		Effect: "On Pins and Needles", Effect Duration: 27, Last Available: "2012-07"
 5748	bouncing twirling CSA all-purpose soap	0		Last Available: "2012-07"
 5749	drinkable CSA cheerfulness ration	3	good	Last Available: "2012-07"
@@ -5652,7 +5652,7 @@
 5751	twirling Tales of the Word Realms	0		
 5752	rotten crappy brain	4	crappy	
 5753	low-calorie adequate decent brain	1	good	
-5754	stale big fancy wobbly good brain	5	decent	Effect: "Macho, Macho Dog", Effect Duration: 35
+5754	fancy big stale wobbly good brain	5	decent	Effect: "Macho, Macho Dog", Effect Duration: 35
 5755	super-sized normal boss brain	5	good	
 5756	yummy yellow hunter brain	3	awesome	
 5758	squat avaricious crafty Newton's Staff of Holiday Sensations	0		Experience (Mysticality): +3, Maximum MP: +10, Meat Drop: +30, Last Available: "2011-11"
@@ -5674,10 +5674,10 @@
 5774	talkative skull	0		
 5775	teal fronts	0		Familiar Weight: +5
 5776	squat lion tamer's Barney's rake of the businessman	0		Experience (familiar): +2, Meat Drop: +50
-5778	small flavorless ghostly jittery idiot brain	2	decent	
+5778	small flavorless jittery ghostly idiot brain	2	decent	
 5779	keel-haulin' knife of Flo-Jo	0		Initiative: +100
 5780	ice cream scoop of Gandalf	0		Spell Critical Percent: +20
-5781	strong perfectly mixed soft echo eyedrop antidote martini	5	EPIC	
+5781	perfectly mixed strong soft echo eyedrop antidote martini	5	EPIC	
 5782	narrow morningwood plank	0		
 5783	pulsating raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5687,11 +5687,11 @@
 5788	mirror jittery smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	blue executive groovy right bear arm	0		Moxie Percent: +10, Meat Drop: +40, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	cyan ghostly Lo Pan's left bear arm of temperance of the early riser	0		Spell Critical Percent: +30, Sleaze Resistance: +5, Adventures: +7, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	blue executive groovy right bear arm	0		Moxie Percent: +10, Meat Drop: +40, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	cyan ghostly Lo Pan's left bear arm of temperance of the early riser	0		Spell Critical Percent: +30, Sleaze Resistance: +5, Adventures: +7, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	prompt Hat O' Nine Tails	0		Adventures: +3
 5794	warmed Enchanted Plunger	0		Effect: "Marbles in Your Mouth", Effect Duration: 60
-5795	extra-aerosolized quadruple-modified wobbly upside-down Enchanted Flyswatter	0		Effect: "Cookie Backup", Effect Duration: 34
+5795	extra-aerosolized quadruple-modified upside-down wobbly Enchanted Flyswatter	0		Effect: "Cookie Backup", Effect Duration: 34
 5796	vacuum-sealed anodized Gearhead Goo	0		Effect: "Educated (Sorta)", Effect Duration: 47
 5797	dry pressed upside-down Missing Eye Simulation Device	0		Effect: "Twinkly Weapon", Effect Duration: 57
 5798	dry Gnollish Crossdress	0		Effect: "Thought", Effect Duration: 49
@@ -5706,7 +5706,7 @@
 5807	pickled cold-filtered spinning glass of warm milk	0		Effect: "Human-Penguin Hybrid", Effect Duration: 37
 5808	corrupted colloidal glass of gnat milk	0		Effect: "Oily Flavor", Effect Duration: 26
 5809	nitrogenated polarized Knob Goblin Mutagen	0		Effect: "Neuroplastici Tea", Effect Duration: 54
-5810	unsweetened cold-filtered yellow skewed ghostly Tears of the Quiet Healer	0		Effect: "Mushroom Melody", Effect Duration: 43
+5810	unsweetened cold-filtered ghostly skewed yellow Tears of the Quiet Healer	0		Effect: "Mushroom Melody", Effect Duration: 43
 5811	electrified oxidized tube of lipstick	0		Effect: "Orc Chops", Effect Duration: 35
 5812	adjusted quantum skelelton spine	0		Effect: "The Style... of the Future", Effect Duration: 19
 5813	oxidized frozen smut orc sunglasses	0		Effect: "Mmmmmelon", Effect Duration: 15
@@ -5739,7 +5739,7 @@
 5840	quadruple-enhanced concentrated chilled upside-down Rogue Windmill Rouge	0		Effect: "Action", Effect Duration: 39
 5841	deionized frozen purple huge A muse-bouche	0		Effect: "Helvella Health", Effect Duration: 41
 5842	denatured corrupted concentrated toothbrush	0		Effect: "Partially Ghosted", Effect Duration: 48
-5843	oxidized activated blue squat pirate cream pie	0		Effect: "Slightly Larger Than Usual", Effect Duration: 43
+5843	oxidized activated squat blue pirate cream pie	0		Effect: "Slightly Larger Than Usual", Effect Duration: 43
 5844	vacuum-sealed dry enhanced una poca de gracia	0		Effect: "Brother Corsican's Blessing", Effect Duration: 36
 5845	non-modified extra-improved jittery compressed air canister	0		Effect: "Strange Mental Acuity", Effect Duration: 66
 5846	wet tumbling salt water taffy	0		Effect: "Puddingskin", Effect Duration: 67
@@ -5748,7 +5748,7 @@
 5849	nitrogenated boiled handyman &quot;hand soap&quot;	0		Effect: "Booooooze", Effect Duration: 66
 5850	double-pressed galvanized space marine flash grenade	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 31
 5851	corrupted denatured frozen skewed temporary tribal tattoo	0		Effect: "Strength of Ten Ettins", Effect Duration: 38
-5852	deionized adjusted ghostly mirror oil-filled donut	0		Effect: "Employee of the Month", Effect Duration: 36
+5852	deionized adjusted mirror ghostly oil-filled donut	0		Effect: "Employee of the Month", Effect Duration: 36
 5853	quadruple-pickled pickled denatured stick-on gnome beard	0		Effect: "How to Scam Tourists", Effect Duration: 65
 5854	polarized oxidized skewed BRICKO stud	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 43
 5855	ionized blinking Osk'r Chow	0		Effect: "Eyes of the Dragon", Effect Duration: 63
@@ -5762,7 +5762,7 @@
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	red papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	super-ionized magnetized triple-enhanced papier-mochi	0		Effect: "A Contender", Effect Duration: 54, Last Available: "2012-09"
-5866	denatured enhanced bouncing pulsating red papier-m&acirc;chaeranthera	0		Effect: "Mystic Circle", Effect Duration: 11, Last Available: "2012-09"
+5866	denatured enhanced pulsating bouncing red papier-m&acirc;chaeranthera	0		Effect: "Mystic Circle", Effect Duration: 11, Last Available: "2012-09"
 5867	concentrated papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Took Eleven", Effect Duration: 61, Last Available: "2012-09"
 5868	upside-down papier-m&acirc;ch&eacute;te of the brute of temperance	0		Muscle Percent: +30, Sleaze Resistance: +5, Last Available: "2012-09"
 5869	lion tamer's clever papier-m&acirc;chine gun	0		Maximum MP: +20, Experience (familiar): +2, Last Available: "2012-09"
@@ -5811,7 +5811,7 @@
 5913	dry moist candy sushi set	0		Effect: "Sleazy Weapon", Effect Duration: 53, Last Available: "2012-12"
 5914	enhanced cold-filtered sweet mochi ball	0		Effect: "Memories of Puppy Love", Effect Duration: 38, Last Available: "2012-12"
 5915	electrified concentrated spinning beet-flavored Mr. Mediocrebar	0		Effect: "Thunderspell", Effect Duration: 66, Last Available: "2012-12"
-5916	liquefied ghostly maroon sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Amplified Fabulousness", Effect Duration: 11, Last Available: "2012-12"
+5916	liquefied maroon ghostly sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Amplified Fabulousness", Effect Duration: 11, Last Available: "2012-12"
 5917	non-deionized unsweetened upside-down cabbage-flavored Mr. Mediocrebar	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 28, Last Available: "2012-12"
 5918	blurry rock-hard plastic animelf	0		Damage Reduction: 5, Last Available: "2012-12"
 5919	MacGyver's plastic ChibiBuddy&trade;	0		Maximum MP: +100, Last Available: "2012-12"
@@ -5823,9 +5823,9 @@
 5925	cyan ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	huge blinking BittyCar MeatCar	0		Last Available: "2012-12"
 5927	skewed BittyCar HotCar	0		Last Available: "2012-12"
-5928	wholesome brainwave-controlled unicorn horn	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	wholesome brainwave-controlled unicorn horn	0		Maximum HP Percent: +10, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	pulsating bubble-wrap simulator	0		Last Available: "2012-12"
-5930	wobbly fuchsia wobbly blind-packed capsule toy	0		Last Available: "2012-12"
+5930	fuchsia wobbly wobbly blind-packed capsule toy	0		Last Available: "2012-12"
 5931	blurry purple bouncing perfumed gravedigger's occult plastic four-shadowed mime	0		Spell Damage Percent: +25, Spooky Damage: +10, Stench Resistance: +5, Single Equip, Last Available: "2012-12"
 5932	cool plastic Bugbear Captain of the bloodbag	0		Moxie: +5, Maximum HP: +100, Single Equip, Last Available: "2012-12"
 5933	teal huge Newton's plastic Rene C. Corman	0		Experience (Mysticality): +3, Item Drop: +5, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	Newton's plastic Father McGruber	0		Experience (Mysticality): +3, Last Available: "2012-12"
 5961	blinking lion tamer's plastic Hank North, Photojournalist	0		Experience (familiar): +2, Last Available: "2012-12"
 5962	plastic blazing bat of Leguizamo	0		Monster Level: +20, Last Available: "2012-12"
-5963	reassuring electronic dulcimer pants of horror	0		Spooky Spell Damage: +25, Spooky Resistance: +1, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	reassuring electronic dulcimer pants of horror	0		Spooky Spell Damage: +25, Spooky Resistance: +1, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	Usain Bolt's clever Frown Exerciser	0		Maximum MP: +20, Initiative: +80, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5875,13 +5875,13 @@
 5977	flame-retardant resourceful brainy silent beret	0		Mysticality: +5, Maximum MP: +50, Hot Resistance: +1, Familiar Effect: "1xVolley, cap 3"
 5978	normal slice of pizza	4	good	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
-5980	mirror huge cartoon heart	0		Last Available: "2013-02"
+5980	huge mirror cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	bad tankard of ale	4	decent	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	foul-smelling cloth cap of wisdom of the early riser	0		Mysticality: +15, Stench Damage: +10, Adventures: +7, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	blurry careful Tesla iron dagger of temperance	0		Monster Level: -10, Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02"
-5986	adequate miniature blinking hamburger	2	good	Last Available: "2013-02"
+5986	miniature adequate blinking hamburger	2	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	wobbly potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
@@ -5922,8 +5922,8 @@
 6024	Whatsian Ionic Pliers of extreme caution	0		Monster Level: -25
 6025	nitrogenated narrow Polysniff Perfume	0		Effect: "Izchak's Blessing", Effect Duration: 34
 6026	Duskwalker syringe	0		
-6027	skewed lime green Space Tours Tripple	0		
-6028	narrow pulsating Battlie Light Saver	0		
+6027	lime green skewed Space Tours Tripple	0		
+6028	pulsating narrow Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	mirror lime green wicked dress pants	0		Spell Damage: +5, Familiar Effect: "2xFairy, cap 28"
 6031	wobbly friendly badge of authority	0		Familiar Weight: +3, Single Equip
@@ -5947,9 +5947,9 @@
 6049	spinning Fonzie's supercool beefcake's Misty Cape	0		Muscle: +25, Moxie Percent: +20, Experience (Moxie): +1
 6050	teal twirling woimbook	0		Familiar Weight: +5
 6051	blurry Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	tiny moldy mirror Taco Dan's Taco Stand Taco	1	crappy	Last Available: "2012-12"
+6052	moldy tiny mirror Taco Dan's Taco Stand Taco	1	crappy	Last Available: "2012-12"
 6053	triple-distilled bad upside-down Taco Dan's Taco Stand Chimichangarita	7	decent	Last Available: "2012-12"
-6054	non-improved shaking wobbly Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Thought", Effect Duration: 53, Last Available: "2012-12"
+6054	non-improved wobbly shaking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Thought", Effect Duration: 53, Last Available: "2012-12"
 6055	olive psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	tumbling fireproof dance instructor's Meatcleaver	0		Experience Percent (Moxie): +10, Hot Resistance: +3, Last Available: "2013-12"
@@ -5971,15 +5971,15 @@
 6073	extra-alkaline twirling green haggis-infused soap	0		Effect: "Sugar High", Effect Duration: 52, Last Available: "2012-12"
 6074	ionized polymerized frozen magicberry tablets	0		Effect: "I See Everything Thrice!", Effect Duration: 59, Last Available: "2012-12"
 6075	flattened huge olive 37x37x37 puzzle cube	0		Effect: "Human-Machine Hybrid", Effect Duration: 49, Last Available: "2012-12"
-6076	lousy watered-down McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
+6076	watered-down lousy McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
 6077	rotten cyan squat bouncing haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	narrow stanky haggis socks	0		Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	narrow stanky haggis socks	0		Stench Spell Damage: +25, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	blinking Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
-6084	mirror bouncing Mr. Haggis	0		Last Available: "2012-12"
+6084	bouncing mirror Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
 6086	hardy Microplushie: Otakulone	0		Maximum HP: +50, Last Available: "2012-12"
 6087	fortified Microplushie: Hippylase	0		Damage Absorption: +60, Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	weak lousy Chinese beer	2	decent	Last Available: "2013-12"
+6121	lousy weak Chinese beer	2	decent	Last Available: "2013-12"
 6122	narrow cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6037,8 +6037,8 @@
 6139	huge rubber gloves of the bloodbag	0		Maximum HP: +100, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	small toothsome olive roasted duck	2	awesome	Last Available: "2013-12"
-6143	moldy gigantic dead meat bun	9	crappy	Last Available: "2013-12"
+6142	toothsome small olive roasted duck	2	awesome	Last Available: "2013-12"
+6143	gigantic moldy dead meat bun	9	crappy	Last Available: "2013-12"
 6144	therapeutic cat collar	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
 6145	red healthy occult suspicious-looking fedora	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	twirling Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6052,10 +6052,10 @@
 6155	bouncing pixel power cell	0		Last Available: "2013-12"
 6156	mirror flickering pixel	0		Last Available: "2013-12"
 6157	narrow cyan Sherlock's veiny Byte	0		Maximum HP: +10, Item Drop: +25, Last Available: "2013-12"
-6158	Van der Graaf anger blaster	0		MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	rosy-cheeked doubt cannon	0		Maximum HP Percent: +30, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	mansplainer's fear condenser	0		Monster Level: +15, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	ghostly zippy regret hose	0		Initiative: +20, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	Van der Graaf anger blaster	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	rosy-cheeked doubt cannon	0		Maximum HP Percent: +30, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	mansplainer's fear condenser	0		Monster Level: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	ghostly zippy regret hose	0		Initiative: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	twirling Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	Herculean commodore's hat of vim and vigor	0		Experience (Muscle): +1, Maximum HP Percent: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
@@ -6066,7 +6066,7 @@
 6169	mediocre Hundred Headed IPA	3	decent	Last Available: "2013-12"
 6170	moldy thick chum	5	crappy	Last Available: "2013-12"
 6171	diffused alkaline enhanced crude crudit&eacute;s	0		Effect: "Berry Critical", Effect Duration: 24
-6172	ionized wet red jittery candy crayons	0		Effect: "Riboflavin'", Effect Duration: 25, Last Available: "2020-09"
+6172	ionized wet jittery red candy crayons	0		Effect: "Riboflavin'", Effect Duration: 25, Last Available: "2020-09"
 6173	purple prompt healthy pixel grappling hook	0		Maximum HP Percent: +20, Adventures: +3
 6174	ghostly GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6081,16 +6081,16 @@
 6184	blinking Jack Frost's Fonzie's Jarlsberg's hat of vim and vigor	0		Experience (Moxie): +1, Maximum HP Percent: +50, Cold Spell Damage: +50
 6185	delicious teal consummate hard-boiled egg	4	awesome	
 6186	bland consummate fried egg	3	decent	
-6187	immense decent skewed consummate egg salad	10	good	
+6187	decent immense skewed consummate egg salad	10	good	
 6188	delicious bouncing consummate bagel	4	awesome	
-6189	normal ghostly red consummate sliced bread	3	good	
-6190	spoiled bite-sized consummate hot dog bun	1	crappy	
+6189	normal red ghostly consummate sliced bread	3	good	
+6190	bite-sized spoiled consummate hot dog bun	1	crappy	
 6191	stale consummate brownie	3	decent	
 6192	decent twirling consummate toast	4	good	
 6193	drinkable watered-down passable stout	2	good	
 6194	rotten half-sized consummate soup	2	crappy	
 6195	adequate huge consummate corn chips	4	good	
-6196	gigantic flavorless cyan consummate salad	6	decent	
+6196	flavorless gigantic cyan consummate salad	6	decent	
 6197	gigantic flavorless consummate salsa	10	decent	
 6198	yummy gigantic blurry consummate sauerkraut	10	awesome	
 6199	spoiled consummate cheese slice	4	crappy	
@@ -6100,19 +6100,19 @@
 6203	stale consummate steak	4	decent	
 6204	normal consummate cuts	4	good	
 6205	normal miniature consummate frankfurter	2	good	
-6206	stale big consummate french fries	5	decent	
-6207	spoiled bite-sized consummate baked potato	1	crappy	
+6206	big stale consummate french fries	5	decent	
+6207	bite-sized spoiled consummate baked potato	1	crappy	
 6208	lousy acceptable vodka	3	decent	
 6209	adequate immense consummate ice cream	7	good	
 6210	tiny adequate pulsating consummate whipped cream	1	good	
-6211	diet flavorless consummate cream	1	decent	
-6212	snack-sized normal consummate strawberries	2	good	
+6211	flavorless diet consummate cream	1	decent	
+6212	normal snack-sized consummate strawberries	2	good	
 6213	adequate consummate sorbet	3	good	
-6214	irresponsibly strong artisanal tumbling lime green jittery adequate rum	7	EPIC	
+6214	artisanal irresponsibly strong lime green jittery tumbling adequate rum	7	EPIC	
 6215	delicious mediocre lager	4	awesome	
 6216	adequate enchanted narrow immaculate grilled cheese	4	good	Effect: "Human-Fish Hybrid", Effect Duration: 15
 6217	bland lime green immaculate ice cream sandwich	3	decent	
-6218	snack-sized flavorless immaculate hot dog	2	decent	
+6218	flavorless snack-sized immaculate hot dog	2	decent	
 6219	delicious immaculate egg salad sandwich	3	awesome	
 6220	flavorless perfect sandwich	3	decent	
 6221	bland perfect chef salad	4	decent	
@@ -6120,12 +6120,12 @@
 6223	flavorless gigantic narrow sublime deluxe hot dog	9	decent	
 6224	flavorless tiny narrow sublime stew	1	decent	
 6225	normal sublime nachos	4	good	
-6226	bland half-sized narrow Ultimate Breakfast Sandwich	2	decent	
+6226	half-sized bland narrow Ultimate Breakfast Sandwich	2	decent	
 6227	tasty tiny twirling Loaded Baked Potato	1	awesome	
 6228	big spoiled Omega Sundae	5	crappy	
 6229	drinkable Das Sauerlager	3	good	
 6230	acceptable Bologna Lambic	4	good	
-6231	irresponsibly strong artisanal skewed Vodka Dog	8	EPIC	
+6231	artisanal irresponsibly strong skewed Vodka Dog	8	EPIC	
 6232	tolerable Disappointed Russian	3	good	
 6233	artisanal Chunky Mary	3	EPIC	
 6234	lousy wobbly Nachojito	3	decent	
@@ -6136,7 +6136,7 @@
 6240	vacuum-sealed galvanized maroon Illuminati earpiece	0		Effect: "Aloofah", Effect Duration: 66
 6241	Vulcanized deionized censored can label	0		Effect: "Industrial Strength Starch", Effect Duration: 19
 6242	diffused ectoplasm <i>au jus</i>	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 50
-6243	magnetized anodized bouncing huge the kindest cut	0		Effect: "You Know When to Walk Away", Effect Duration: 41
+6243	magnetized anodized huge bouncing the kindest cut	0		Effect: "You Know When to Walk Away", Effect Duration: 41
 6244	modified chilled cat's paw	0		Effect: "Feeling No Pain", Effect Duration: 27
 6245	pressed quantum ASCII fu manchu	0		Effect: "Pwnd", Effect Duration: 17
 6246	alkaline magnetized olive demonic surgical gloves	0		Effect: "The Strength...  of the Future", Effect Duration: 21
@@ -6160,7 +6160,7 @@
 6264	prompt Newton's Staff of Fruit Salad of Calamity Jane	0		Experience (Mysticality): +3, Critical Hit Percent: +15, Adventures: +3, Jiggle: "Deal Some Prismatic Damage"
 6265	squat cyan fortified Staff of the Cream of the Cream of horror of temperance	0		Damage Absorption: +60, Spooky Spell Damage: +25, Sleaze Resistance: +5, Jiggle: "Attune to Monster's Essence"
 6266	purple jar of protein powder	0		
-6267	rotten half-sized grain of protein powder	2	crappy	
+6267	half-sized rotten grain of protein powder	2	crappy	
 6268	triple-Vulcanized nitrogenated pec oil	0		Effect: "Video Game Hot Dog", Effect Duration: 62
 6269	gym membership card of Gandalf	0		Spell Critical Percent: +20
 6270	altered super-aerosolized Squat-Thrust Magazine	0		Effect: "Corruption of Wretched Wally", Effect Duration: 29
@@ -6169,12 +6169,12 @@
 6273	modified frozen blurry O'RLY manual	0		Effect: "Muscularrr", Effect Duration: 65
 6274	aged shaking open sauce	3	awesome	
 6275	twirling rosewater-soaked Da Vinci's turkey leg	0		Experience (Mysticality): +5, Stench Resistance: +3
-6276	mediocre boozy Ye Olde Meade	5	decent	
+6276	boozy mediocre Ye Olde Meade	5	decent	
 6277	galvanized maroon blurry Ye Olde Bawdy Limerick	0		Effect: "Wings of the Grasshopper", Effect Duration: 69
 6278	twirling Ye Olde Medieval Insult	0		
 6279	friendly pewter claymore	0		Familiar Weight: +3
 6280	shaking dog trainer's artisanal rice peeler	0		Experience (familiar): +1
-6281	fancy spoiled heirloom grape tomato	3	crappy	Effect: "Brother Corsican's Blessing", Effect Duration: 35
+6281	spoiled fancy heirloom grape tomato	3	crappy	Effect: "Brother Corsican's Blessing", Effect Duration: 35
 6282	blinking chipotle wasabi cilantro aioli	0		
 6283	Annie Oakley's brown felt tophat	0		Critical Hit Percent: +20, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6182,15 +6182,15 @@
 6286	wobbly prompt Mark II Steam-Hat of the ox of incineration	0		Muscle: +20, Hot Spell Damage: +50, Adventures: +3, Familiar Effect: "1xLep, cap 37"
 6287	cyan scorching supercharged Herculean Mark III Steam-Hat of the ox	0		Muscle: +20, Experience (Muscle): +1, Maximum MP Percent: +30, Hot Damage: +25, Familiar Effect: "1xLep, cap 37"
 6288	Usain Bolt's stanky sizzling dangerous Mark IV Steam-Hat of the empath	0		Weapon Damage: +10, Familiar Weight: +5, Hot Damage: +10, Stench Spell Damage: +25, Initiative: +80, Familiar Effect: "1xLep, cap 37"
-6289	red auspicious dog trainer's chaotic personal trainer's Mark V Steam-Hat of the glutton	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Experience (familiar): +1, Item Drop: +10, Food Drop: +100, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	red auspicious dog trainer's chaotic personal trainer's Mark V Steam-Hat of the glutton	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Experience (familiar): +1, Item Drop: +10, Food Drop: +100, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	steam-powered model rocketship	0		
 6291	fuchsia dangerous personal trainer's punk rock jacket	0		Experience Percent (Muscle): +10, Weapon Damage: +10
 6292	shaking smelly savvy safety pin	0		Mysticality Percent: +20, Stench Spell Damage: +10
-6293	bland miniature stolen sushi	2	decent	
+6293	miniature bland stolen sushi	2	decent	
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	gray cosmic bucket	0		Free Pull
-6297	blinking ghostly fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
+6297	ghostly blinking fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	non-boiled Super Weight-Gain 9000	0		Effect: "Good Karma", Effect Duration: 26
@@ -6246,7 +6246,7 @@
 6350	mirror beefy Mer-kin gutgirdle	0		Muscle: +10, Experience (Moxie): +20, Single Equip
 6351	jittery Annie Oakley's Mer-kin finpaddle	0		Critical Hit Percent: +20
 6352	huge extremely unsafe Mer-kin stopwatch	0		Weapon Damage Percent: +100, Initiative: +50
-6353	squat green Mer-kin dreadscroll	0		
+6353	green squat Mer-kin dreadscroll	0		
 6354	triple-energized alkaline non-improved tumbling Mer-kin smartjuice	0		Effect: "Sewer-Drenched", Effect Duration: 22
 6355	liquefied Mer-kin cooljuice	0		Effect: "Itchy Trigger Finger", Effect Duration: 53
 6356	Mer-kin worktea	0		
@@ -6257,15 +6257,15 @@
 6361	moist vacuum-sealed purple pulled taffy	0		Effect: "Fireproof Lips", Effect Duration: 48, Last Available: "2013-04"
 6362	super-enhanced tarnished narrow twirling pulled indigo taffy	0		Effect: "Earthen Fist", Effect Duration: 28, Last Available: "2013-04"
 6363	extra-activated pulled taffy	0		Effect: "License to Punch", Effect Duration: 61, Last Available: "2013-04"
-6364	triple-Vulcanized alkaline green spinning pulled taffy	0		Effect: "You're Not Cooking", Effect Duration: 53, Last Available: "2013-04"
+6364	triple-Vulcanized alkaline spinning green pulled taffy	0		Effect: "You're Not Cooking", Effect Duration: 53, Last Available: "2013-04"
 6365	non-electrified tarnished polymerized blurry pulled taffy	0		Effect: "Corona de la Salsa", Effect Duration: 27, Last Available: "2013-04"
 6366	modified blinking pulled violet taffy	0		Effect: "Dancing Prowess", Effect Duration: 26, Last Available: "2013-04"
 6367	wet wobbly pulled taffy	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34, Last Available: "2013-04"
 6368	lime green Mer-kin hallpass	0		
-6369	wobbly upside-down lump of clay	0		
+6369	upside-down wobbly lump of clay	0		
 6370	narrow twisted piece of wire	0		
-6371	artisanal watered-down upside-down can of the cheapest beer	2	EPIC	
-6372	acceptable boozy bottle of fruity &quot;wine&quot;	5	good	
+6371	watered-down artisanal upside-down can of the cheapest beer	2	EPIC	
+6372	boozy acceptable bottle of fruity &quot;wine&quot;	5	good	
 6373	distilled acceptable huge single swig of vodka	5	good	
 6374	angry inch	0		
 6375	narrow maroon extremely unsafe testy toolbox	0		Weapon Damage Percent: +100
@@ -6294,7 +6294,7 @@
 6399	energized denatured Boss Drops	0		Effect: "Crusty Head", Effect Duration: 56
 6400	Mer-kin lunchbox	0		
 6401	pickled narrow tear	0		Effect: "Greasy Flavor", Effect Duration: 59
-6402	diffused huge narrow jagged tooth	0		Effect: "Heart of Lavender", Effect Duration: 56
+6402	diffused narrow huge jagged tooth	0		Effect: "Heart of Lavender", Effect Duration: 56
 6403	denatured corrupted huge grisly shell fragment	0		Effect: "Full Bottle in front of Me", Effect Duration: 64
 6404	pressed violent pastilles	0		Effect: "Experimental Effect G-9", Effect Duration: 24
 6405	Vulcanized worst candy	0		Effect: "Bread Burps", Effect Duration: 39
@@ -6307,25 +6307,25 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	rotten upside-down red flavorless gruel	3	crappy	
+6415	rotten red upside-down flavorless gruel	3	crappy	
 6416	bland mana curds	4	decent	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	pressed double-modified moth dust	0		Effect: "Adventurer's Best Friendship", Effect Duration: 39
-6420	boiled non-polarized maroon skewed glob of spoiled mayo	0		Effect: "Spooky Jellied", Effect Duration: 40
+6420	boiled non-polarized skewed maroon glob of spoiled mayo	0		Effect: "Spooky Jellied", Effect Duration: 40
 6421	tonic djinn	0		
-6422	adequate snack-sized vampire chowder	2	good	
+6422	snack-sized adequate vampire chowder	2	good	
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	decent miniature Dreadsylvanian stew	2	good	
+6426	miniature decent Dreadsylvanian stew	2	good	
 6427	weak lousy green Dreadsylvanian	2	decent	
 6428	pressed unsweetened Dreadsylvanian flask	0		Effect: "Electrolit Up", Effect Duration: 33
 6429	flattened Dreadsylvanian flask	0		Effect: "Always be Collecting", Effect Duration: 36
 6430	miser's grievous dreadful fedora	0		Weapon Damage Percent: +50, Meat Drop: +10, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	Sherlock's dreadful sweater	0		Item Drop: +25, Kruegerand Drop: 5
 6432	bouncing mirror studded dreadful glove	0		Damage Absorption: +80, Kruegerand Drop: 5
-6433	red shaking spinning Freddy Kruegerand	0		
+6433	shaking red spinning Freddy Kruegerand	0		
 6434	wobbly Mark of the Bugbear	0		
 6435	ghostly blue Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
@@ -6338,7 +6338,7 @@
 6443	squat miser's Helps-You-Sleep of terror	0		Spooky Spell Damage: +10, Meat Drop: +10, Single Equip
 6444	greedy chaotic experienced Quiets-Your-Steps	0		Experience: +2, Spell Critical Percent: +10, Meat Drop: +20, Single Equip
 6445	wobbly wholesome Protects-Your-Junk of the early riser	0		Maximum HP Percent: +10, Adventures: +7, Single Equip
-6446	tolerable watered-down Gets-You-Drunk	2	good	
+6446	watered-down tolerable Gets-You-Drunk	2	good	
 6447	wobbly reassuring resourceful padded Great Wolf's headband	0		Damage Absorption: +20, Maximum MP: +50, Spooky Resistance: +1, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	red Great Wolf's left paw of the brute of dire peril of the dark arts	0		Muscle Percent: +30, Weapon Damage: +20, Spell Damage Percent: +100, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	aromatic hardy Great Wolf's right paw of the sewer	0		Maximum HP: +50, Stench Damage: +25, Stench Resistance: +1, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6367,7 +6367,7 @@
 6472	Drunkula's bell	0		
 6473	nasty hardened smartaleck's Drunkula's ring of haze	0		Moxie Percent: +30, Damage Reduction: 3, Stench Damage: +5, Avoid Attack: 1, Single Equip
 6474	sizzling Drunkula's wineglass	0		Hot Damage: +10
-6475	perfectly mixed strong bottle of Bloodweiser	5	EPIC	
+6475	strong perfectly mixed bottle of Bloodweiser	5	EPIC	
 6476	executive coward's strapping Unkillable Skeleton's skullcap	0		Muscle: +5, Monster Level: -20, Meat Drop: +40, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	gravedigger's careful Unkillable Skeleton's breastplate of the pedagogue	0		Experience: +3, Monster Level: -10, Spooky Damage: +10, Class: "Turtle Tamer"
 6478	savvy sage Unkillable Skeleton's shinguards of the brazier	0		Mysticality Percent: 30, Hot Spell Damage: +25, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6408,7 +6408,7 @@
 6513	warm fur of the bloodbag	0		Maximum HP: +100
 6514	gravedigger's snowstick	0		Spooky Damage: +10
 6515	jittery skewed eerie fetish of temperance	0		Sleaze Resistance: +5, Single Equip
-6516	smooth fancy blinking stinkwater	4	awesome	Effect: "Fishily Speeding", Effect Duration: 30
+6516	fancy smooth blinking stinkwater	4	awesome	Effect: "Fishily Speeding", Effect Duration: 30
 6517	upside-down dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	snack-sized spoiled huge accidental mutton	2	crappy	
 6519	spinning avaricious drafty drawers of dire peril	0		Weapon Damage: +20, Meat Drop: +30, Familiar Effect: "1.5xVolley"
@@ -6423,7 +6423,7 @@
 6528	experienced hothammer	0		Experience: +2
 6529	lousy watered-down Thriller Ice	2	decent	
 6530	gray grandfather watch of Leguizamo	0		Monster Level: +20, Single Equip
-6531	tumbling jittery olive muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
+6531	jittery tumbling olive muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	aromatic hardy spyglass	0		Maximum HP: +50, Stench Resistance: +1
 6533	vial of hot blood of James Dean	0		Experience (Moxie): +3, Single Equip
 6534	remorseless knife of temperance	0		Sleaze Resistance: +5
@@ -6460,9 +6460,9 @@
 6566	flavorless small Dreadsylvanian pocket	2	decent	
 6567	thick flavorless Dreadsylvanian stink pocket	5	decent	
 6568	moldy yellow Dreadsylvanian sleaze pocket	3	crappy	
-6569	hand-crafted watered-down Dreadsylvanian hot toddy	2	super ultra mega turbo EPIC	
-6570	perfectly mixed high-proof pulsating Dreadsylvanian cold-fashioned	6	EPIC	
-6571	aged practically non-alcoholic huge Dreadsylvanian grimlet	1	awesome	
+6569	watered-down hand-crafted Dreadsylvanian hot toddy	2	super ultra mega turbo EPIC	
+6570	high-proof perfectly mixed pulsating Dreadsylvanian cold-fashioned	6	EPIC	
+6571	practically non-alcoholic aged huge Dreadsylvanian grimlet	1	awesome	
 6572	hand-crafted triple-distilled bouncing Dreadsylvanian dank and stormy	9	EPIC	
 6573	artisanal Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	mirror hot clusterbomb	0		
@@ -6506,13 +6506,13 @@
 6612	twirling clockwork numeral XII	0		
 6613	skewed clockwork cuckoo	0		
 6614	shaking cuckoo clock	0		
-6615	enchanted bad jittery skewed Cold One	3	???	Effect: "Gummi Badass", Effect Duration: 30
-6616	low-calorie toothsome blinking spaghetti breakfast	1	???	
+6615	bad enchanted skewed jittery Cold One	3	???	Effect: "Gummi Badass", Effect Duration: 30
+6616	toothsome low-calorie blinking spaghetti breakfast	1	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	purple folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	gray folder (green)	0		Moxie: +20, Last Available: "2013-08"
-6621	skewed purple folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
+6621	purple skewed folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
@@ -6569,9 +6569,9 @@
 6677	crude monster sculpture	0		
 6678	Tesla Yearbook Club Camera	0		MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Blinding Flash"
 6679	lion tamer's machete	0		Experience (familiar): +2
-6680	acceptable watered-down gray Cursed Punch	2	good	
+6680	watered-down acceptable gray Cursed Punch	2	good	
 6681	hand-crafted Bowl of Scorpions	4	EPIC	
-6682	lousy weak narrow Fog Murderer	2	decent	
+6682	weak lousy narrow Fog Murderer	2	decent	
 6683	book of matches	0		
 6684	gray hardy surgical mask	0		Maximum HP: +50, Surgeonosity: +1
 6685	blue lard-coated head mirror	0		Sleaze Spell Damage: +25, Surgeonosity: +1
@@ -6580,7 +6580,7 @@
 6688	spinning dangerous bloodied surgical dungarees	0		Weapon Damage: +10, Surgeonosity: +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 6689	bouncing bouncing McClusky file (page 1)	0		
 6690	bouncing gray McClusky file (page 2)	0		
-6691	lime green bouncing mirror McClusky file (page 3)	0		
+6691	bouncing lime green mirror McClusky file (page 3)	0		
 6692	McClusky file (page 4)	0		
 6693	blinking McClusky file (page 5)	0		
 6694	boring binder clip	0		
@@ -6613,7 +6613,7 @@
 6721	dog trainer's Jim Carey's Herculean water bottle	0		Experience (Muscle): +1, Monster Level: +25, Experience (familiar): +1, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	corrupted polarized bouncing pygmy phone number	0		Effect: "Demonic Flavor", Effect Duration: 15
 6723	Boozehounds Anonymous token	0		
-6724	normal diet exotic jungle fruit	1	good	
+6724	diet normal exotic jungle fruit	1	good	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	bouncing dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6634,7 +6634,7 @@
 6742	junk band of the sweet-tooth	0		Candy Drop: +100
 6743	green energetic junk trunks	0		Maximum MP Percent: +20, Familiar Effect: "cap 15"
 6744	twirling junk-mail shirt of Leguizamo	0		Monster Level: +20
-6745	stale enchanted half-sized blinking junk food	2	decent	Effect: "Savage Beast Inside", Effect Duration: 50
+6745	half-sized stale enchanted blinking junk food	2	decent	Effect: "Savage Beast Inside", Effect Duration: 50
 6746	hand-crafted spinning junk yard	3	EPIC	
 6747	avaricious Rosewater's swordzall	0		Mysticality Percent: +30, Meat Drop: +30
 6748	arm buzzer of bravery	0		Spooky Resistance: +5, Damage Reduction: 6
@@ -6645,18 +6645,18 @@
 6753	cyan cluster of hops	0		
 6754	beer bottle	0		
 6755	beer label	0		
-6756	mirror yellow artisanal homebrew sampler	0		
+6756	yellow mirror artisanal homebrew sampler	0		
 6757	artisanal jittery can of Br&uuml;talbr&auml;u	3	EPIC	Last Available: "2013-09"
 6758	practically non-alcoholic aged blurry can of Drooling Monk	1	awesome	Last Available: "2013-09"
-6759	drinkable extra-dry can of Impetuous Scofflaw	5	good	Last Available: "2013-09"
+6759	extra-dry drinkable can of Impetuous Scofflaw	5	good	Last Available: "2013-09"
 6760	bad upside-down bottle of Old Pugilist	3	decent	Last Available: "2013-09"
 6761	tolerable bottle of Professor Beer	3	good	Last Available: "2013-09"
-6762	smooth fortified bottle of Rapier Witbier	5	awesome	Last Available: "2013-09"
+6762	fortified smooth bottle of Rapier Witbier	5	awesome	Last Available: "2013-09"
 6763	practically non-alcoholic bad bottle of Race Car Red	1	decent	Last Available: "2013-09"
 6764	perfectly mixed blinking bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
-6765	smooth high-proof ghostly bottle of Lambada Lambic	10	awesome	Last Available: "2013-09"
+6765	high-proof smooth ghostly bottle of Lambada Lambic	10	awesome	Last Available: "2013-09"
 6766	tin beer can	0		
-6767	skewed olive artisanal homebrew gift package	0		
+6767	olive skewed artisanal homebrew gift package	0		
 6768	liquid bread	1	crappy	Last Available: "2013-09"
 6769	upside-down flame-retardant wizardly tin tam of Flo-Jo	0		Mysticality: +25, Hot Resistance: +1, Initiative: +100, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	unsweetened tin cup	0		Effect: "Adrenaline Rush", Effect Duration: 45, Last Available: "2013-09"
@@ -6714,11 +6714,11 @@
 6825	ghostly Jeselnik's alarm accordion of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +25, Class: "Accordion Thief", Song Duration: 20
 6826	teal ghostly flame-retardant greasy All-Hallow's Steve's fright wig of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Hot Resistance: +1, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	blinking mansplainer's crafty KoL Con X Treasure Map	0		Maximum MP: +10, Monster Level: +15
-6828	enchanted aged discocktail	3	awesome	Effect: "Pecan Pied Piper", Effect Duration: 35
+6828	aged enchanted discocktail	3	awesome	Effect: "Pecan Pied Piper", Effect Duration: 35
 6829	pulsating beefy KoL Con X Bingo Card	0		Muscle: +10
 6830	crafty Temporal Tempera Tube	0		Maximum MP: +10
 6831	extra-improved Tallowcreme Halloween Pumpkin	0		Effect: "Wreathed in Smoke", Effect Duration: 26
-6832	narrow bouncing Way More Tears&trade; pepper spray	0		
+6832	bouncing narrow Way More Tears&trade; pepper spray	0		
 6833	cold-filtered moist Milk Studs	0		Effect: "Slimy Flavor", Effect Duration: 12
 6834	alkaline concentrated box of Dweebs	0		Effect: "Concentrated Concentration", Effect Duration: 20
 6835	colloidal triple-cold-filtered improved bag of W&Ws	0		Effect: "This Is Where You're a Viking", Effect Duration: 27
@@ -6746,12 +6746,12 @@
 6857	wobbly Socratic Cajun accordion	0		Experience (Mysticality): +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	quirky accordion of the businessman	0		Meat Drop: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	narrow flame-retardant Tesla Skipper's accordion	0		Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	huge green jittery wool stiffened Fonzie's smartaleck's Pantsgiving	0		Moxie Percent: +30, Experience (Moxie): +1, Damage Reduction: 1, Cold Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
-6861	stale snack-sized mirror blurry can of sardines	2	decent	Last Available: "2013-11"
+6860	huge green jittery wool stiffened Fonzie's smartaleck's Pantsgiving	0		Moxie Percent: +30, Experience (Moxie): +1, Damage Reduction: 1, Cold Resistance: +1, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6861	stale snack-sized blurry mirror can of sardines	2	decent	Last Available: "2013-11"
 6862	rotten high-calorie sugar substitute	4	crappy	Last Available: "2013-11"
-6863	spoiled special pat of butter	3	crappy	Effect: "Frosty the Hitman", Effect Duration: 35, Last Available: "2013-11"
+6863	special spoiled pat of butter	3	crappy	Effect: "Frosty the Hitman", Effect Duration: 35, Last Available: "2013-11"
 6864	miniature spoiled dinner roll	2	crappy	Last Available: "2013-11"
-6865	immense adequate mashed potatoes	8	good	Last Available: "2013-11"
+6865	adequate immense mashed potatoes	8	good	Last Available: "2013-11"
 6866	decent whole turkey leg	3	good	Last Available: "2013-11"
 6867	normal deviled egg	3	good	Last Available: "2013-11"
 6868	aerosolized diffused finger exerciser	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 19, Last Available: "2013-11"
@@ -6782,7 +6782,7 @@
 6893	diffused liquefied freezer-burned frost-bitten tortellini	0		Effect: "Initiative and Let Die", Effect Duration: 20, Last Available: "2013-11"
 6894	diffused non-corrupted triple-chilled blob of Alphredo&trade;	0		Effect: "Elvish", Effect Duration: 49, Last Available: "2013-11"
 6895	electrified denatured galvanized handful of crafty noodles	0		Effect: "Hare-o-dynamic", Effect Duration: 11, Last Available: "2013-11"
-6896	irradiated skewed yellow tangled mass of pasta	0		Effect: "Ironclad", Effect Duration: 43, Last Available: "2013-11"
+6896	irradiated yellow skewed tangled mass of pasta	0		Effect: "Ironclad", Effect Duration: 43, Last Available: "2013-11"
 6897	frozen warmed Can of Spaghetto	0		Effect: "One Foot Heavier", Effect Duration: 26, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
@@ -6793,7 +6793,7 @@
 6904	energized aerosolized pressed bolts	0		Effect: "Buggy Flavor", Effect Duration: 53, Last Available: "2013-12"
 6905	decent gingerbread robot	4	good	Last Available: "2013-12"
 6906	snack-sized toothsome narrow petit 4.1	2	awesome	Last Available: "2013-12"
-6907	immense normal nut-shaped Crimbo cookie	9	good	Last Available: "2023-06"
+6907	normal immense nut-shaped Crimbo cookie	9	good	Last Available: "2023-06"
 6908	plastic GORM-8 of the storm	0		Maximum MP Percent: +40, Last Available: "2013-12"
 6909	horrifying plastic warbear	0		Spooky Damage: +25, Last Available: "2013-12"
 6910	plastic Toybot of the sweet-tooth	0		Candy Drop: +100, Last Available: "2013-12"
@@ -6847,7 +6847,7 @@
 6958	green shaking warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	frightening warbear foil hat	0		Spooky Damage: +5, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	pulsating warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	tumbling inspector's perfumed warbear oil pan	0		Stench Resistance: +5, Item Drop: +15, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	tumbling inspector's perfumed warbear oil pan	0		Stench Resistance: +5, Item Drop: +15, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	huge MacGyver's warbear exhaust manifold	0		Maximum MP: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6890,11 +6890,11 @@
 7001	family-friendly lion tamer's die-cast Uncle Hobo	0		Experience (familiar): +2, Sleaze Resistance: +1, Last Available: "2013-12"
 7002	teal spinning wool ribald die-cast Father Crimbo	0		Sleaze Damage: +10, Cold Resistance: +1, Last Available: "2013-12"
 7003	bouncing The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
-7004	unsweetened red pulsating Flaskfull of Hollow	0		Effect: "Mucilaginous Mentalism", Effect Duration: 46, Last Available: "2013-12"
+7004	unsweetened pulsating red Flaskfull of Hollow	0		Effect: "Mucilaginous Mentalism", Effect Duration: 46, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	denatured jittery handful of Smithereens	1	good	Effect: "Gobliny Flavor", Effect Duration: 10, Last Available: "2013-12"
-7007	bland jumbo Every Day is Like This Sundae	5	decent	Last Available: "2013-12"
-7008	adequate fancy small Miserable Pie	2	good	Effect: "Pronounced Potency", Effect Duration: 10, Last Available: "2013-12"
+7007	jumbo bland Every Day is Like This Sundae	5	decent	Last Available: "2013-12"
+7008	small adequate fancy Miserable Pie	2	good	Effect: "Pronounced Potency", Effect Duration: 10, Last Available: "2013-12"
 7009	flavorless spinning bouncing This Charming Flan	3	decent	Last Available: "2013-12"
 7010	artisanal Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
 7011	drinkable Strikes Again Bigmouth	3	good	Last Available: "2013-12"
@@ -6918,8 +6918,8 @@
 7029	Sherlock's fortified extremely unsafe Shakespeare's Sister's Accordion	0		Weapon Damage Percent: +100, Damage Absorption: +60, Item Drop: +25, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	blinking lard-coated third-hand lantern	0		Sleaze Spell Damage: +25
 7031	loose purse strings	0		
-7032	toothsome immense pickled egg	6	awesome	
-7033	yellow wobbly cup of lukewarm tea	1	crappy	
+7032	immense toothsome pickled egg	6	awesome	
+7033	wobbly yellow cup of lukewarm tea	1	crappy	
 7034	blurry fuchsia warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6937,7 +6937,7 @@
 7048	frozen warbear rejuvenation potion	0		Effect: "Rat-Faced", Effect Duration: 58, Last Available: "2013-12"
 7049	upside-down broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	decent ghostly warbear gyro	3	good	Last Available: "2013-12"
-7051	tarnished yellow blurry recording of Rolando's Rondo of Resisto	0		Effect: "Slimily Speedy", Effect Duration: 28, Last Available: "2013-12"
+7051	tarnished blurry yellow recording of Rolando's Rondo of Resisto	0		Effect: "Slimily Speedy", Effect Duration: 28, Last Available: "2013-12"
 7052	lime green warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	blurry warbear drone codes	0		Last Available: "2013-12"
@@ -6947,7 +6947,7 @@
 7058	denatured irradiated Cloaca Cola Polar	0		Effect: "Pronounced Potency", Effect Duration: 19, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
-7061	jittery teal grimstone mask	0		Last Available: "2014-12"
+7061	teal jittery grimstone mask	0		Last Available: "2014-12"
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	narrow Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
@@ -6958,12 +6958,12 @@
 7069	upside-down Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	olive packet of winter seeds	0		Last Available: "2014-01"
 7071	diet decent teal snow berries	1	good	Last Available: "2014-01"
-7072	decent jumbo ice harvest	5	good	Last Available: "2014-01"
+7072	jumbo decent ice harvest	5	good	Last Available: "2014-01"
 7073	dry anodized ghostly frost flower	0		Effect: "Ocelot Eyes", Effect Duration: 41, Last Available: "2014-01"
 7074	colloidal nitrogenated snow cleats	0		Effect: "Barking Mad", Effect Duration: 63, Last Available: "2014-01"
 7075	extra-frozen blurry blinking liquid ice pack	0		Effect: "Cringle's Curative Carol", Effect Duration: 61, Last Available: "2014-01"
-7076	pulsating maroon bouncing snow boards	0		Last Available: "2014-01"
-7077	special decent snow crab	4	good	Effect: "Berry Statistical", Effect Duration: 45, Last Available: "2014-01"
+7076	bouncing pulsating maroon snow boards	0		Last Available: "2014-01"
+7077	decent special snow crab	4	good	Effect: "Berry Statistical", Effect Duration: 45, Last Available: "2014-01"
 7078	fancy acceptable Ice Island Long Tea	3	good	Effect: "Gummiskin", Effect Duration: 25, Last Available: "2014-01"
 7079	blurry unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	wool studded quilted strapping snow belt	0		Muscle: +5, Damage Absorption: 120, Cold Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	cyan frightening Sinatra's ice nine of Gandalf of extreme caution	0		Experience (Moxie): +5, Spell Critical Percent: +20, Monster Level: -25, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	practically non-alcoholic lousy En Una Fila Tequila	1	decent	
+7090	lousy practically non-alcoholic En Una Fila Tequila	1	decent	
 7091	Skully's hot chocolate	1	decent	
 7092	gray wizardly warbear dress helmet of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	blue Socratic warbear dress bracers of extreme caution	0		Experience (Mysticality): +1, Monster Level: -25, Single Equip, Last Available: "2013-12"
@@ -6997,10 +6997,10 @@
 7108	tiny bland squat pecan	1	decent	Last Available: "2014-12"
 7109	bland pecan pie	4	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	stale special immense jittery candy mountain oyster	10	decent	Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2014-12"
-7112	drinkable weak chocotini	2	good	Last Available: "2014-12"
+7111	special immense stale jittery candy mountain oyster	10	decent	Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2014-12"
+7112	weak drinkable chocotini	2	good	Last Available: "2014-12"
 7113	jittery frosty boxer's chocolate rabbit's foot of courage	0		Muscle Percent: +10, Cold Spell Damage: +10, Spooky Resistance: +3, Last Available: "2014-12"
-7114	miniature yummy shaking candy carrot	2	awesome	Last Available: "2014-12"
+7114	yummy miniature shaking candy carrot	2	awesome	Last Available: "2014-12"
 7115	flavorless candy carrot cake	4	decent	Last Available: "2014-12"
 7116	coward's therapeutic carrot-on-a-stick	0		Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7117	mirror weasel stomping pants of the ox of horror	0		Muscle: +20, Spooky Spell Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
@@ -7015,16 +7015,16 @@
 7126	cold-filtered frozen blurry small gummi fin	0		Effect: "Fiery Spirit", Effect Duration: 41, Last Available: "2014-12"
 7127	chocolate cow bone of the empath	0		Familiar Weight: +5, Last Available: "2014-12"
 7128	warmed energized bouncing gummi fang	0		Effect: "Winklered", Effect Duration: 63, Last Available: "2014-12"
-7129	normal miniature leftover canap&eacute;s	2	good	Last Available: "2014-12"
+7129	miniature normal leftover canap&eacute;s	2	good	Last Available: "2014-12"
 7130	bad magnum of champagne	3	decent	Last Available: "2014-12"
 7131	jittery ribald medical-grade cow creamer of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12"
 7132	moist warmed blinking Outer Wolf&trade; cologne	0		Effect: "Oxygenated Blood", Effect Duration: 51, Last Available: "2014-12"
 7133	wobbly lupine appetite hormones	0		Last Available: "2014-12"
-7134	ghostly zippy Jim Carey's wolf whistle	0		Monster Level: +25, Initiative: +20, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	special half-sized decent witch's bread	2	good	Effect: "stats.enq", Effect Duration: 45, Last Available: "2014-12"
+7134	ghostly zippy Jim Carey's wolf whistle	0		Monster Level: +25, Initiative: +20, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7135	decent half-sized special witch's bread	2	good	Effect: "stats.enq", Effect Duration: 45, Last Available: "2014-12"
 7136	pickled pulsating witch's brew	0		Effect: "Motion", Effect Duration: 65, Last Available: "2014-12"
 7137	wobbly reassuring wool Tesla witch's bra	0		Cold Resistance: +1, Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12"
-7138	perfectly mixed triple-distilled mid-level medieval mead	8	EPIC	Last Available: "2014-12"
+7138	triple-distilled perfectly mixed mid-level medieval mead	8	EPIC	Last Available: "2014-12"
 7139	non-energized altered cyan R&uuml;mpelstiltz	0		Effect: "Night Vision", Effect Duration: 57, Last Available: "2014-12"
 7140	purple spinning wheel	0		Last Available: "2014-12"
 7141	dry quadruple-pressed hi-octane carrot juice	0		Effect: "Clyde's Blessing", Effect Duration: 21, Last Available: "2014-12"
@@ -7052,19 +7052,19 @@
 7163	fireproof supercool skull gearshift knob of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Hot Resistance: +3, Last Available: "2014-12"
 7164	normal huge nachos of the night	3	good	Last Available: "2014-12"
 7165	greedy rosewater-soaked grievous Sketcherz&trade;	0		Weapon Damage Percent: +50, Stench Resistance: +3, Meat Drop: +20, Last Available: "2014-12"
-7166	diet moldy can of Adultwitch&trade;	1	crappy	Last Available: "2014-12"
+7166	moldy diet can of Adultwitch&trade;	1	crappy	Last Available: "2014-12"
 7167	galvanized concentrated spinning smudge stick	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 69, Last Available: "2014-12"
 7168	diffused Vulcanized wall	0		Effect: "Stick Emporium Membership", Effect Duration: 43, Last Available: "2014-12"
 7169	hand-crafted high-proof tankard of ale	6	EPIC	Last Available: "2014-12"
 7170	flattened irradiated scroll case	0		Effect: "BOOsted", Effect Duration: 30, Last Available: "2014-12"
 7171	non-flattened jug of &quot;wine&quot;	0		Effect: "What's That Smell?", Effect Duration: 17, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
-7173	shaking pulsating crappy camera	0		Last Available: "2014-12"
+7173	pulsating shaking crappy camera	0		Last Available: "2014-12"
 7174	normal humble pie	3	good	Last Available: "2014-12"
 7175	bouncing small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	improved spinning crappy waiter disguise	0		Effect: "Human-Constellation Hybrid", Effect Duration: 43
-7178	jittery narrow Copperhead Charm	0		
+7178	narrow jittery Copperhead Charm	0		
 7179	purple The First Pizza	0		
 7180	maroon jittery The Lacrosse Stick of Lacoronado	0		
 7181	tumbling The Eye of the Stars	0		
@@ -7097,11 +7097,11 @@
 7208	spinning fire of unknown origin	0		
 7209	ghostly eagle's milk	1	decent	
 7210	irradiated ionized blinking eagle feather	0		Effect: "Ooh, Umami!", Effect Duration: 25
-7211	non-pressed deionized shaking red one pill	0		Effect: "Fan-Cooled", Effect Duration: 23
+7211	non-pressed deionized red shaking one pill	0		Effect: "Fan-Cooled", Effect Duration: 23
 7212	blurry Oprah's Jefferson wings	0		Maximum MP Percent: +50
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	snack-sized moldy fleetwood mac 'n' cheese	2	crappy	
+7215	moldy snack-sized fleetwood mac 'n' cheese	2	crappy	
 7216	lynyrd skin	0		
 7217	ghostly fireproof lynyrdskin cap	0		Hot Resistance: +3, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	Da Vinci's lynyrdskin tunic	0		Experience (Mysticality): +5
@@ -7115,9 +7115,9 @@
 7226	tea for one	1	decent	
 7227	mediocre practically non-alcoholic blurry bottle of Evermore	1	decent	
 7228	squat spinning box	0		
-7229	practically non-alcoholic artisanal wine	1	EPIC	
-7230	smooth practically non-alcoholic fancy rum	1	awesome	Effect: "Mayeaugh", Effect Duration: 35
-7231	mediocre boozy enchanted tumbling Murderer's Punch	5	decent	Effect: "The Halls of Moxiousness", Effect Duration: 40
+7229	artisanal practically non-alcoholic wine	1	EPIC	
+7230	fancy smooth practically non-alcoholic rum	1	awesome	Effect: "Mayeaugh", Effect Duration: 35
+7231	boozy mediocre enchanted tumbling Murderer's Punch	5	decent	Effect: "The Halls of Moxiousness", Effect Duration: 40
 7232	normal velvet cake	3	good	
 7233	non-polarized letter	0		Effect: "Horrid, Torrid", Effect Duration: 14
 7234	fortified smooth book	0		Moxie: +15, Damage Absorption: +60
@@ -7169,14 +7169,14 @@
 7280	tarnished wet cyan pulsating wind-up vampire teeth	0		Effect: "Shortened", Effect Duration: 30
 7281	ionized improved wind-up navigation droid	0		Effect: "Cranberry Cordiality", Effect Duration: 26
 7282	nitrogenated quantum gray wind-up owl	0		Effect: "Petit Forbearance", Effect Duration: 56
-7283	diffused blurry huge wind-up ensign	0		Effect: "Tingly Biceps", Effect Duration: 31
+7283	diffused huge blurry wind-up ensign	0		Effect: "Tingly Biceps", Effect Duration: 31
 7284	lightning-fast educational crying statue earrings	0		Experience: +1, Initiative: +40, Single Equip, Lasts Until Rollover
 7285	educational sage plastic Duskwalker necklace	0		Mysticality Percent: +10, Experience: +1, Single Equip, Lasts Until Rollover
 7286	MacGyver's arcane researcher's plastic replica blaster pistol	0		Experience Percent (Mysticality): +10, Maximum MP: +100, Lasts Until Rollover
 7287	upside-down smooth Gary Claybender's Time Screwer of James Dean	0		Moxie: +15, Experience (Moxie): +3, Single Equip, Lasts Until Rollover
 7288	supercool Space Tourist palmdoctor of horror	0		Moxie Percent: +20, Spooky Spell Damage: +25, Lasts Until Rollover
 7289	ghostly fuchsia prompt lion tamer's cool amok putter	0		Moxie: +5, Experience (familiar): +2, Adventures: +3
-7290	normal miniature upside-down amok pudding	2	good	
+7290	miniature normal upside-down amok pudding	2	good	
 7291	deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	pickled purple can of V-11	0		Effect: "Armored Innards", Effect Duration: 26, Last Available: "2014-03"
@@ -7216,7 +7216,7 @@
 7327	dehydrated lime green synthetic marrow	1		
 7328	super-dry funny bone	0		Effect: "Deadly Flashing Blade", Effect Duration: 35
 7329	Sherlock's coward's half-melted spoon	0		Monster Level: -20, Item Drop: +25
-7330	boiled fuchsia upside-down the funk	1		
+7330	boiled upside-down fuchsia the funk	1		
 7331	normal gunky chicken	3	good	
 7332	perfumed doll head	0		Stench Resistance: +5
 7333	upside-down droopy doll eye	0		
@@ -7229,14 +7229,14 @@
 7340	smelly moose antlers	0		Stench Spell Damage: +10, Familiar Effect: "atk, 1xLep, cap 27"
 7341	vacuum-sealed extra-quantum spinning moose thought	0		Effect: "Quaaaaaaa", Effect Duration: 62
 7342	decent ghostly moose chocolate	3	good	
-7343	bad weak spinning painting of a glass of wine	2	decent	
+7343	weak bad spinning painting of a glass of wine	2	decent	
 7344	oil painting of yourself	0		
 7345	shaking ornate picture frame	0		
 7346	wobbly doll-eye amulet	0		Single Equip
 7347	twirling blinking tumbling sinister ghost toga of extreme caution	0		Spell Damage: +10, Monster Level: -25
 7348	special normal tumbling sheet cake	4	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
 7349	green ghost key	0		
-7350	upside-down squat red picture of you	0		
+7350	red squat upside-down picture of you	0		
 7351	rock-hard dance instructor's smartaleck's Staff of the Electric Range	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Damage Reduction: 5
 7352	thick normal deluxe layer cake	5	good	
 7353	chunk of hot iron	0		
@@ -7254,11 +7254,11 @@
 7365	non-dry blurry fabric hardener	0		Effect: "Appeteyes", Effect Duration: 31
 7366	drinkable bottle of laundry sherry	4	good	
 7367	aerosolized olive industrial strength starch	0		Effect: "Human-Fish Hybrid", Effect Duration: 46, Wiki Name: "industrial strength starch"
-7368	gigantic delicious extra-flat panini	9	awesome	
+7368	delicious gigantic extra-flat panini	9	awesome	
 7369	cold-filtered mangled finger	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 44
 7370	artisanal pulsating Psychotic Train wine	4	EPIC	
 7371	shaking narrow crazy hobo notebook	0		
-7372	rotten thick fuchsia pie man was not meant to eat	5	crappy	
+7372	thick rotten fuchsia pie man was not meant to eat	5	crappy	
 7373	nippy sommelier's towel	0		Cold Damage: +10
 7374	bouncing mirror grievous tarnished tastevin	0		Weapon Damage Percent: +50, Single Equip
 7375	fancy bland actual tapas	3	decent	Effect: "The Halls of Moxiousness", Effect Duration: 45
@@ -7268,7 +7268,7 @@
 7379	blue therapeutic wicked ghast iron heater shield	0		Spell Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 11
 7380	bouncing purple flame-retardant toasty ghast iron codpiece	0		Hot Damage: +5, Hot Resistance: +1, Familiar Effect: "atk, 1xBarrr, cap 42"
 7381	jittery pulsating Pendant of Gargalesis of the dark arts	0		Spell Damage Percent: +100
-7382	narrow olive Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
+7382	olive narrow Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	DNA extraction syringe	0		Last Available: "2014-04"
 7384	triple-improved chilled jittery pulsating Gene Tonic: Dude	0		Effect: "Blubbered Up", Effect Duration: 30, Last Available: "2014-04"
 7385	vacuum-sealed triple-adjusted concentrated maroon Gene Tonic: Beast	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 69, Last Available: "2014-04"
@@ -7287,7 +7287,7 @@
 7398	cold-filtered olive pulsating Gene Tonic: Weird	0		Effect: "Medieval Mage Mayhem", Effect Duration: 56, Last Available: "2014-04"
 7399	ionized moist Gene Tonic: Elf	0		Effect: "Pasty", Effect Duration: 27, Last Available: "2014-04"
 7400	wet wet Gene Tonic: Mer-kin	0		Effect: "Loyal Tea", Effect Duration: 41, Last Available: "2014-04"
-7401	unsweetened pressed warmed bouncing tumbling pulsating Gene Tonic: Slime	0		Effect: "Coming Up Roses", Effect Duration: 63, Last Available: "2014-04"
+7401	unsweetened pressed warmed tumbling pulsating bouncing Gene Tonic: Slime	0		Effect: "Coming Up Roses", Effect Duration: 63, Last Available: "2014-04"
 7402	altered blinking blue Gene Tonic: Penguin	0		Effect: "Less Pervious", Effect Duration: 57, Last Available: "2014-04"
 7403	enhanced blurry Gene Tonic: Elemental	0		Effect: "Nuts about Candy", Effect Duration: 55, Last Available: "2014-04"
 7404	flattened alkaline Gene Tonic: Constellation	0		Effect: "Good with the Ladies", Effect Duration: 31, Last Available: "2014-04"
@@ -7320,18 +7320,18 @@
 7431	alkaline Boletus Broletus mushroom	0		Effect: "Ode to Booze", Effect Duration: 16, Last Available: "2014-05"
 7432	extra-energized Omphalotus Omphaloskepsis mushroom	0		Effect: "What's That Smell?", Effect Duration: 32, Last Available: "2014-05"
 7433	liquefied pressed yellow Gyromitra Dynomita mushroom	0		Effect: "Stone-Faced", Effect Duration: 12, Last Available: "2014-05"
-7434	pickled pulsating green shaking Helvella Haemophilia mushroom	0		Effect: "Frigid Weapon", Effect Duration: 55, Last Available: "2014-05"
+7434	pickled green pulsating shaking Helvella Haemophilia mushroom	0		Effect: "Frigid Weapon", Effect Duration: 55, Last Available: "2014-05"
 7435	extra-enhanced activated blurry Stemonitis Staticus mushroom	0		Effect: "Appeteyes", Effect Duration: 21, Last Available: "2014-05"
 7436	quantum pressed Tremella Tarantella mushroom	0		Effect: "Blood-Gorged", Effect Duration: 26, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	flavorless Beefy Crunch Pastaco	3	decent	Last Available: "2014-05"
-7439	massive stale Brain Food Pastaco	9	decent	Last Available: "2014-05"
-7440	flavorless miniature Cool Brunch Pastaco	2	decent	Last Available: "2014-05"
+7439	stale massive Brain Food Pastaco	9	decent	Last Available: "2014-05"
+7440	miniature flavorless Cool Brunch Pastaco	2	decent	Last Available: "2014-05"
 7441	stale huge cyan Medical Pastaco	9	decent	Last Available: "2014-05"
-7442	fancy immense toothsome Energy Buzz Pastaco	8	awesome	Effect: "Hennaliciousness", Effect Duration: 50, Last Available: "2014-05"
+7442	immense fancy toothsome Energy Buzz Pastaco	8	awesome	Effect: "Hennaliciousness", Effect Duration: 50, Last Available: "2014-05"
 7443	rotten super-sized jittery Ludovico Pastaco	5	crappy	Last Available: "2014-05"
 7444	extra-dry hand-crafted green overpowering mushroom wine	5	EPIC	Last Available: "2014-05"
-7445	watered-down perfectly mixed fancy tumbling shaking complex mushroom wine	2	super ultra mega turbo EPIC	Effect: "Cosmic Flavor", Effect Duration: 40, Last Available: "2014-05"
+7445	perfectly mixed fancy watered-down tumbling shaking complex mushroom wine	2	super ultra mega turbo EPIC	Effect: "Cosmic Flavor", Effect Duration: 40, Last Available: "2014-05"
 7446	irresponsibly strong drinkable smooth mushroom wine	8	good	Last Available: "2014-05"
 7447	aged watered-down blood-red mushroom wine	2	awesome	Last Available: "2014-05"
 7448	irresponsibly strong acceptable buzzing mushroom wine	6	good	Last Available: "2014-05"
@@ -7342,7 +7342,7 @@
 7453	hand-crafted regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	hand-crafted teal super-size brogurt	3	EPIC	Last Available: "2014-05"
 7455	lousy narrow broberry brogurt	3	decent	Last Available: "2014-05"
-7456	watered-down artisanal brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7456	artisanal watered-down brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
 7457	acceptable watered-down bouncing French bronilla brogurt	2	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	pulsating Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
@@ -7395,7 +7395,7 @@
 7506	upside-down Sherlock's clever book	0		Maximum MP: +20, Item Drop: +25
 7507	Newton's cloak	0		Experience (Mysticality): +3
 7508	label	0		
-7509	adequate half-sized Mornington crescent roll	2	good	
+7509	half-sized adequate Mornington crescent roll	2	good	
 7510	unsweetened eye shadow	0		Effect: "Piratastic", Effect Duration: 67
 7511	crumbling wheel	0		
 7512	tarnished poppy	0		Effect: "Pumped Stomach", Effect Duration: 22
@@ -7410,10 +7410,10 @@
 7521	flavorless maroon government cheese	3	decent	Last Available: "2014-05"
 7522	twirling pair of government shades of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
-7524	improved oxidized shaking mirror government	0		Effect: "World's Shortest Giant", Effect Duration: 17, Last Available: "2014-05"
+7524	improved oxidized mirror shaking government	0		Effect: "World's Shortest Giant", Effect Duration: 17, Last Available: "2014-05"
 7525	activated tarnished wobbly alien drugs	0		Effect: "Aided and Abetted", Effect Duration: 44, Last Available: "2023-09"
-7526	skewed red weird space book	0		Last Available: "2014-05"
-7527	huge blurry alien force field disruptor bean	0		Last Available: "2014-05"
+7526	red skewed weird space book	0		Last Available: "2014-05"
+7527	blurry huge alien force field disruptor bean	0		Last Available: "2014-05"
 7528	jittery steel-toed government-issued night-vision goggles of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Single Equip, Last Available: "2014-05"
 7529	diet adequate loaf of alien bread	1	good	Last Available: "2014-05"
 7530	gigantic rotten grilled cheese sandwich	7	crappy	Last Available: "2014-05"
@@ -7421,7 +7421,7 @@
 7532	drinkable rocket fuel	4	good	Last Available: "2014-05"
 7533	skewed alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	skewed alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	extra-dry delicious squat stealth bomber	5	awesome	Last Available: "2014-05"
+7535	delicious extra-dry squat stealth bomber	5	awesome	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	blue twitching space egg	0		Last Available: "2014-05"
 7538	mirror ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7429,7 +7429,7 @@
 7540	greedy space beast fur pants	0		Meat Drop: +20, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	reassuring space beast fur whip	0		Spooky Resistance: +1, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	twirling inspector's knitted space heater	0		Cold Resistance: +3, Item Drop: +15, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	twirling inspector's knitted space heater	0		Cold Resistance: +3, Item Drop: +15, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
 7545	watered-down tolerable bouncing space port	2	good	Last Available: "2014-05"
 7546	narrow censurious stanky space needle	0		Stench Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2014-05"
@@ -7443,7 +7443,7 @@
 7554	dry ionized bottle of lighter fluid	0		Effect: "Ooh, Sour!", Effect Duration: 44, Last Available: "2014-06"
 7555	tumbling page	0		
 7556	bouncing elephant gift	0		
-7557	aerosolized huge shaking blood cells	0		Effect: "Marinated", Effect Duration: 36
+7557	aerosolized shaking huge blood cells	0		Effect: "Marinated", Effect Duration: 36
 7558	acceptable wine	3	good	
 7559	irradiated teal gummi turtle	0		Effect: "20-20 Second Sight", Effect Duration: 62
 7560	wobbly turtle-shaped rock	0		
@@ -7458,18 +7458,18 @@
 7569	maroon deadly arcane researcher's Newton's Time Bandit Badge of Courage	0		Experience (Mysticality): +3, Experience Percent (Mysticality): +10, Weapon Damage: +5
 7570	quantum Friendliness Beverage	0		Effect: "Industrial Strength Starch", Effect Duration: 29
 7571	rosewater-soaked silent pea shooter of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +3
-7572	jumbo moldy D roll	5	crappy	
+7572	moldy jumbo D roll	5	crappy	
 7573	Annie Oakley's kiwi beak of the early riser	0		Critical Hit Percent: +20, Adventures: +7
 7574	special drinkable New Zealand iced tea	4	good	Effect: "Held Closer", Effect Duration: 15
 7575	upside-down mansplainer's droll monocle of the brazier	0		Monster Level: +15, Hot Spell Damage: +25, Single Equip
 7576	tarnished oxidized cold-filtered future drug: Muscularactum	0		Effect: "Smelly Pants", Effect Duration: 27
 7577	polarized altered gray future drug: Smartinex	0		Effect: "Held Closer", Effect Duration: 36
 7578	energized red future drug: Coolscaline	0		Effect: "Fancy Feasted", Effect Duration: 63
-7579	narrow pulsating twitching time capsule	0		
-7580	modified shaking huge liquid shifting time weirdness	1		
+7579	pulsating narrow twitching time capsule	0		
+7580	modified huge shaking liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	normal rack of dinosaur ribs	3	good	
-7583	weak drinkable spinning scotch on the rocks	2	good	
+7583	drinkable weak spinning scotch on the rocks	2	good	
 7584	lion tamer's hardy yabba dabba doo rag	0		Maximum HP: +50, Experience (familiar): +2, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	MacGyver's veiny wooly loincloth	0		Maximum HP: +10, Maximum MP: +100, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	red helix fossil	0		
@@ -7477,20 +7477,20 @@
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	special mediocre glass of &quot;milk&quot;	3	decent	Effect: "Preemptive Medicine", Effect Duration: 40, Last Available: "2014-07"
 7590	acceptable cup of &quot;tea&quot;	3	good	Last Available: "2014-07"
-7591	watered-down mediocre thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
+7591	mediocre watered-down thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
 7592	acceptable high-proof green Lucky Lindy	10	good	Last Available: "2014-07"
 7593	hand-crafted Bee's Knees	4	EPIC	Last Available: "2014-07"
-7594	drinkable irresponsibly strong Sockdollager	9	good	Last Available: "2014-07"
+7594	irresponsibly strong drinkable Sockdollager	9	good	Last Available: "2014-07"
 7595	acceptable strong lime green Ish Kabibble	5	good	Last Available: "2014-07"
-7596	fancy weak lousy Hot Socks	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2014-07"
+7596	fancy lousy weak Hot Socks	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2014-07"
 7597	hand-crafted boozy Phonus Balonus	5	EPIC	Last Available: "2014-07"
-7598	irresponsibly strong lousy pulsating gray Flivver	7	decent	Last Available: "2014-07"
+7598	lousy irresponsibly strong gray pulsating Flivver	7	decent	Last Available: "2014-07"
 7599	aged Sloppy Jalopy	3	awesome	Last Available: "2014-07"
 7600	triple-adjusted flame	0		Effect: "Boon of She-Who-Was", Effect Duration: 35
 7601	super-magnetized warmed temporary yak tattoo	0		Effect: "Hiding in Plain Sight", Effect Duration: 28
 7602	activated Fitspiration&trade; poster	0		Effect: "Tomato Power", Effect Duration: 13
 7603	Vulcanized upside-down neckbeard	0		Effect: "Become Superficially interested", Effect Duration: 18
-7604	cold-filtered jittery maroon artisanal hand-squeezed wheatgrass juice	0		Effect: "Toast Tea", Effect Duration: 42
+7604	cold-filtered maroon jittery artisanal hand-squeezed wheatgrass juice	0		Effect: "Toast Tea", Effect Duration: 42
 7605	extra-oxidized blinking punk patch	0		Effect: "Whippin' It Good", Effect Duration: 42
 7606	extra-quantum warmed blinking steampunk potion	0		Effect: "Human-Insect Hybrid", Effect Duration: 38
 7607	ionized modified vial of swamp vapors	0		Effect: "Disco Concentration", Effect Duration: 19
@@ -7510,12 +7510,12 @@
 7621	boiled aerosolized ghostly ninja eyeblack	0		Effect: "Cravin' for a Ravin'", Effect Duration: 19
 7622	irradiated button rouge	0		Effect: "Hairless and Airless", Effect Duration: 59
 7623	boiled huge Red Army camouflage kit	0		Effect: "Phoenix, Right?", Effect Duration: 27
-7624	unsweetened quantum upside-down wobbly lynyrd skinner toothblack	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 28
+7624	unsweetened quantum wobbly upside-down lynyrd skinner toothblack	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 28
 7625	irradiated upside-down flask of rainwater	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 21
 7626	quadruple-flattened warmed oyster badge	0		Effect: "Heightened Senses", Effect Duration: 59
-7627	extra-cold-filtered tumbling green plastic Jefferson wings	0		Effect: "Coming Up Roses", Effect Duration: 25
+7627	extra-cold-filtered green tumbling plastic Jefferson wings	0		Effect: "Coming Up Roses", Effect Duration: 25
 7628	nitrogenated electrified adjusted ghostly dancing fan	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 21
-7629	flattened magnetized skewed gray page of the Necrohobocon	0		Effect: "Berry Experiential", Effect Duration: 11
+7629	flattened magnetized gray skewed page of the Necrohobocon	0		Effect: "Berry Experiential", Effect Duration: 11
 7630	enhanced ionized upside-down magic powder	0		Effect: "Pill Power", Effect Duration: 42
 7631	adjusted skewed friar's tonsure	0		Effect: "Is This Your Card?", Effect Duration: 41
 7632	triple-boiled teal government-issue identification badge	0		Effect: "Squatting and Thrusting", Effect Duration: 41
@@ -7548,12 +7548,12 @@
 7659	neoprene skullcap of the pedagogue	0		Experience: +3, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	diffused extra-cold-filtered purple goblin water	0		Effect: "Natural 20", Effect Duration: 69
 7661	dumb mud	0		
-7662	adequate snack-sized Sogg-Os	2	good	
+7662	snack-sized adequate Sogg-Os	2	good	
 7663	skewed Fonzie's Da Vinci's savvy Lord Soggyraven's Slippers	0		Mysticality Percent: +20, Experience (Mysticality): +5, Experience (Moxie): +1, Single Equip
 7664	adjusted electrified huge Ancient Protector Soda	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 48
 7665	altered boiled liquid ice	0		Effect: "Rosewater Mark", Effect Duration: 41
-7666	artisanal irresponsibly strong jittery Wet Russian	8	EPIC	
-7667	bite-sized bland filet of The Fish	1	decent	
+7666	irresponsibly strong artisanal jittery Wet Russian	8	EPIC	
+7667	bland bite-sized filet of The Fish	1	decent	
 7668	Thwaitgold spider statuette	0		
 7669	medical-grade razor-sharp brawny thunder down underwear	0		Muscle Percent: +20, Weapon Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 7670	coward's famous raincoat of the ox of the boozehound	0		Muscle: +20, Monster Level: -20, Booze Drop: +100, Lasts Until Rollover
@@ -7581,7 +7581,7 @@
 7692	blinking mirror rosewater-soaked hand whip of the cougar of extreme caution	0		Moxie: +20, Monster Level: -25, Stench Resistance: +3, Last Available: "2014-08"
 7693	inspector's greasy dog trainer's glow-in-the-dark necklace	0		Experience (familiar): +1, Sleaze Spell Damage: +10, Item Drop: +15, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	greedy experienced cap gun of bravery	0		Experience: +2, Spooky Resistance: +5, Meat Drop: +20, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	greedy experienced cap gun of bravery	0		Experience: +2, Spooky Resistance: +5, Meat Drop: +20, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	fuchsia perfumed thinker's cassette player	0		Mysticality: +10, Stench Resistance: +5, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7595,13 +7595,13 @@
 7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	modified bouncing rubber nubbin	0		Effect: "Grumpy and Ornery", Effect Duration: 57, Last Available: "2014-08"
 7708	shellacked dance instructor's rubber cape	0		Experience Percent (Moxie): +10, Damage Reduction: 7, Last Available: "2014-08"
-7709	huge vibrating stylish Thor's Pliers of the pedagogue of horror	0		Moxie: +25, Experience: +3, Maximum MP Percent: +10, Spooky Spell Damage: +25, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	huge vibrating stylish Thor's Pliers of the pedagogue of horror	0		Moxie: +25, Experience: +3, Maximum MP Percent: +10, Spooky Spell Damage: +25, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	nitrogenated candy UFOs	0		Effect: "Salty Dogs", Effect Duration: 44
 7711	lime green Lo Pan's therapeutic water wings for babies	0		Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7
 7712	shaking beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	flavorless Strix stix	3	decent	
 7714	sizzling dog trainer's manspreader's vampire pellet	0		Monster Level: +10, Experience (familiar): +1, Hot Damage: +10
-7715	smooth weak non-aged vinegar	2	awesome	
+7715	weak smooth non-aged vinegar	2	awesome	
 7716	skewed red unsanitized scalpel of the glutton	0		Food Drop: +100
 7717	gladiator tunica of Calamity Jane	0		Critical Hit Percent: +15
 7718	Roman sadnals of the blizzard	0		Cold Spell Damage: +25, Single Equip
@@ -7614,11 +7614,11 @@
 7725	magnetized Bruno's blessing of Mars	0		Effect: "Spiky Hair", Effect Duration: 38
 7726	concentrated warmed Dennis's blessing of Minerva	0		Effect: "Techno Bliss", Effect Duration: 26
 7727	aerosolized Burt's blessing of Bacchus	0		Effect: "Dragged Through the Coals", Effect Duration: 59
-7728	irradiated triple-electrified quantum mirror red Freddie's blessing of Mercury	0		Effect: "Initiative and Let Die", Effect Duration: 49
+7728	irradiated triple-electrified quantum red mirror Freddie's blessing of Mercury	0		Effect: "Initiative and Let Die", Effect Duration: 49
 7729	Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
 7731	blurry transmission from planet Xi	0		Last Available: "2014-09"
-7732	tumbling cyan Black Bart's Booty	0		Skill: "Pirate Bellow"
+7732	cyan tumbling Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	teal Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	Xiblaxian polymer	0		Last Available: "2014-09"
 7735	Xiblaxian alloy	0		Last Available: "2014-09"
@@ -7643,7 +7643,7 @@
 7754	mansplainer's Xiblaxian stealth trousers of bravery	0		Monster Level: +15, Spooky Resistance: +5, Last Available: "2014-09"
 7755	nasty brawny Xiblaxian stealth vest	0		Muscle Percent: +20, Stench Damage: +5, Last Available: "2014-09"
 7756	decent purple Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
-7757	bad fuchsia bouncing Xiblaxian space-whiskey	4	decent	Last Available: "2014-09"
+7757	bad bouncing fuchsia Xiblaxian space-whiskey	4	decent	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	galvanized altered extra-flattened pulsating They liver	0		Effect: "Dirge of Dreadfulness", Effect Duration: 26, Last Available: "2014-09"
 7760	moldy They liver popsicle	4	crappy	Last Available: "2014-09"
@@ -7673,7 +7673,7 @@
 7784	galvanized tumbling monkey barf	0		Effect: "Natural 20", Effect Duration: 55, Last Available: "2014-10"
 7785	adjusted concentrated warmed blurry narrow candy	0		Effect: "Moon'd", Effect Duration: 26, Last Available: "2014-10"
 7786	bouncing inspector's friendly fortified jangly bracelet	0		Damage Absorption: +60, Familiar Weight: +3, Item Drop: +15, Last Available: "2014-10"
-7787	miser's cuddly teddy bear	0		Meat Drop: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	miser's cuddly teddy bear	0		Meat Drop: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	pulsating Jim Carey's first-aid pouch of temperance	0		Monster Level: +25, Sleaze Resistance: +5, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7685,8 +7685,8 @@
 7796	decent olive warm war shawarma	3	good	Last Available: "2014-10"
 7797	bland skewed karma shawarma	3	decent	Last Available: "2014-10"
 7798	tolerable watered-down wobbly Jungle Juice	2	good	Last Available: "2014-10"
-7799	drinkable triple-distilled Amnesiac Ale	7	good	Last Available: "2014-10"
-7800	tolerable practically non-alcoholic Highest Bitter	1	good	Last Available: "2014-10"
+7799	triple-distilled drinkable Amnesiac Ale	7	good	Last Available: "2014-10"
+7800	practically non-alcoholic tolerable Highest Bitter	1	good	Last Available: "2014-10"
 7801	Socratic mercenary pistol of doom	0		Experience (Mysticality): +1, Spooky Spell Damage: +50, Last Available: "2014-10"
 7802	flame-wreathed coward's mercenary rifle	0		Monster Level: -20, Hot Spell Damage: +10, Last Available: "2014-10"
 7803	skewed Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7706,7 +7706,7 @@
 7817	blurry twirling gelatinous meat mass	0		
 7818	99.44% pure math	0		
 7819	jittery simple AI	0		
-7820	upside-down squat corrupted bird DNA	0		
+7820	squat upside-down corrupted bird DNA	0		
 7821	gray blinking sentient meat mass	0		
 7822	blue zombie dinosaur egg	0		
 7823	teal french-fry grabber	0		Familiar Weight: +5
@@ -7714,18 +7714,18 @@
 7825	mirror cyan Van der Graaf weightlifter's earbuds of the bloodbag	0		Muscle: +15, Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 7826	Van der Graaf vibrating stylish iFlail	0		Moxie: +25, Maximum MP Percent: +10, MP Regen Min: 5, MP Regen Max: 7
 7827	rotten unidentifiable dried fruit	4	crappy	
-7828	perfectly mixed triple-distilled flat cider	8	EPIC	
+7828	triple-distilled perfectly mixed flat cider	8	EPIC	
 7829	zippy foul-smelling trench lighter of wisdom	0		Mysticality: +15, Stench Damage: +10, Initiative: +20, Last Available: "2014-10"
-7830	tarnished ghostly teal experimental serum P-00	0		Effect: "All Blued Up", Effect Duration: 41, Last Available: "2014-10"
+7830	tarnished teal ghostly experimental serum P-00	0		Effect: "All Blued Up", Effect Duration: 41, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	shaking tumbling encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
 7834	pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	pulsating GPS-tracking wristwatch	0		Last Available: "2014-10"
-7837	blinking shaking Project T. L. B.	0		Last Available: "2014-10"
+7837	shaking blinking Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
-7839	bouncing tumbling special clip: tracers	0		Last Available: "2014-10"
+7839	tumbling bouncing special clip: tracers	0		Last Available: "2014-10"
 7840	special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	modified shaking perl necklace	0		Effect: "Hustlin'", Effect Duration: 69, Last Available: "2014-12"
 7846	wet pulsating Fudge Fiber Armor Plating	0		Effect: "Powder Power", Effect Duration: 65, Last Available: "2014-12"
 7847	wet frozen ruby on canes	0		Effect: "Took Eleven", Effect Duration: 37, Last Available: "2014-12"
-7848	snack-sized rotten petit fortran	2	crappy	Last Available: "2014-12"
+7848	rotten snack-sized petit fortran	2	crappy	Last Available: "2014-12"
 7849	super-sized decent java cookie	5	good	Last Available: "2014-12"
 7850	delicious cookie cookie	3	awesome	Last Available: "2014-12"
 7851	blurry therapeutic plastic exo-suited miner	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
@@ -7805,16 +7805,16 @@
 7916	olive mimeplasm	0		
 7917	deionized BOOterfinger	0		Effect: "Saucemastery", Effect Duration: 69
 7918	wet denatured blinking Moonds	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 29
-7919	aerosolized blue blurry Big Punk	0		Effect: "On the Trolley", Effect Duration: 32
+7919	aerosolized blurry blue Big Punk	0		Effect: "On the Trolley", Effect Duration: 32
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	gray turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	watered-down acceptable Friendly Turkey	2	good	Last Available: "2014-11"
-7923	bad practically non-alcoholic jittery Agitated Turkey	1	decent	Last Available: "2014-11"
+7922	acceptable watered-down Friendly Turkey	2	good	Last Available: "2014-11"
+7923	practically non-alcoholic bad jittery Agitated Turkey	1	decent	Last Available: "2014-11"
 7924	delicious Ambitious Turkey	4	awesome	Last Available: "2014-11"
-7925	bland massive neutron lollipop	7	decent	Last Available: "2014-12"
+7925	massive bland neutron lollipop	7	decent	Last Available: "2014-12"
 7926	perfectly mixed gamma nog	3	EPIC	Last Available: "2014-12"
-7934	red jittery sneaky wrapping paper	0		Last Available: "2014-12"
-7935	green squat Thwaitgold nit statuette	0		
+7934	jittery red sneaky wrapping paper	0		Last Available: "2014-12"
+7935	squat green Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
 7938	vaporized maroon upside-down single atom	1	decent	Last Available: "2015-02"
@@ -7826,7 +7826,7 @@
 7944	blinking tooth	0		
 7945	table	0		
 7946	manspreader's hardened occult outlaw bandana	0		Spell Damage Percent: +25, Damage Reduction: 3, Monster Level: +10
-7947	lousy strong huge whiskey in a broken glass	5	decent	
+7947	strong lousy huge whiskey in a broken glass	5	decent	
 7948	mediocre shot of mescal	4	decent	
 7949	drinkable practically non-alcoholic pulsating glass of herbal tequila	1	good	
 7950	green minin' dynamite	0		
@@ -7859,7 +7859,7 @@
 7977	silk bandages	0		
 7978	huge holy spring water	0		
 7979	pulsating purple spirit beer	0		
-7980	twirling blue sacramental wine	0		
+7980	blue twirling sacramental wine	0		
 7981	mirror talisman of Thoth	0		
 7982	cure-all	0		
 7983	zippy rosewater-soaked Sister Accessory	0		Stench Resistance: +3, Initiative: +20, Softcore Only
@@ -7881,17 +7881,17 @@
 7999	deionized narrow choco-Crimbot	0		Effect: "Sparkling Consciousness", Effect Duration: 34, Last Available: "2014-12"
 8000	diffused smart watch	0		Effect: "Innately Strong", Effect Duration: 36, Last Available: "2014-12"
 8001	pressed alkaline augmented-reality shades	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 61, Last Available: "2014-12"
-8002	personal trainer's toy Crimbot mega face	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
-8003	healthy toy Crimbot power glove	0		Maximum HP Percent: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	jittery toy Crimbot super fist of the boozehound	0		Booze Drop: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	narrow curative toy Crimbot rocket legs	0		HP Regen Min: 3, HP Regen Max: 5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	personal trainer's toy Crimbot mega face	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	healthy toy Crimbot power glove	0		Maximum HP Percent: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	jittery toy Crimbot super fist of the boozehound	0		Booze Drop: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	narrow curative toy Crimbot rocket legs	0		HP Regen Min: 3, HP Regen Max: 5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	flattened Crimbot battery	0		Effect: "Spiritually Awake", Effect Duration: 56, Last Available: "2014-12"
 8007	twirling Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	blurry Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8010	green tumbling Mini-Crimbot crate	0		Last Available: "2014-12"
+8010	tumbling green Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	jittery heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	perfumed chilly Crimbomega drive chain of incineration	0		Cold Damage: +5, Hot Spell Damage: +50, Stench Resistance: +5, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	perfumed chilly Crimbomega drive chain of incineration	0		Cold Damage: +5, Hot Spell Damage: +50, Stench Resistance: +5, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	cyan Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	huge Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7932,9 +7932,9 @@
 8051	blurry cape of temperance	0		Sleaze Resistance: +5
 8052	smartaleck's jetpack	0		Moxie Percent: +30
 8053	spring boots	0		
-8054	yellow squat spiked boots	0		
+8054	squat yellow spiked boots	0		
 8055	pickaxe of courage	0		Spooky Resistance: +3
-8056	blinking yellow torch	0		
+8056	yellow blinking torch	0		
 8057	gray squat knitted Lo Pan's [spelunking test kit]	0		Spell Critical Percent: +30, Cold Resistance: +3
 8058	twirling foul-smelling plasma rifle	0		Stench Damage: +10
 8059	Bananubis's Staff	0		Luck: -6
@@ -7947,7 +7947,7 @@
 8066	distilled spinning	1	awesome	Effect: "Gonna Get You, Sucker", Effect Duration: 5, Last Available: "2015-12"
 8067	teal nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
-8069	jittery shaking Stembridge sidearm	0		Familiar Weight: +5
+8069	shaking jittery Stembridge sidearm	0		Familiar Weight: +5
 8070	warehouse map page	0		
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
@@ -7996,7 +7996,7 @@
 8121	tumbling knitted wizardly garland	0		Mysticality: +25, Cold Resistance: +3, Single Equip, Last Available: "2018-12"
 8122	avaricious groovy gunnysack	0		Moxie Percent: +10, Meat Drop: +30, Last Available: "2018-12"
 8123	wholesome Herculean garibaldi	0		Experience (Muscle): +1, Maximum HP Percent: +10, Last Available: "2018-12"
-8124	Van der Graaf girdle of the cougar	0		Moxie: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	Van der Graaf girdle of the cougar	0		Moxie: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	jittery lime green savvy gloves of chilblains	0		Mysticality Percent: +20, Cold Damage: +25, Single Equip, Last Available: "2018-12"
 8126	denatured blurry smithereens	1		Last Available: "2018-12"
 8127	Usain Bolt's foul-smelling fiberglass fetish	0		Stench Damage: +10, Initiative: +80, Last Available: "2018-12"
@@ -8005,7 +8005,7 @@
 8130	sinister fiberglass frock of the early riser	0		Spell Damage: +10, Adventures: +7, Last Available: "2018-12"
 8131	Sinatra's experienced fiberglass fingerguard	0		Experience: +2, Experience (Moxie): +5, Single Equip, Last Available: "2018-12"
 8132	steel-toed Fonzie's fiberglass fedora	0		Experience (Moxie): +1, Damage Reduction: 9, Last Available: "2018-12"
-8133	pickled blinking blue fiberglass fibers	1		Last Available: "2018-12"
+8133	pickled blue blinking fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	blue talisman of Renenutet	0		
@@ -8024,10 +8024,10 @@
 8150	corrupted narrow sugar sphere	0		Effect: "It's Electric!", Effect Duration: 47
 8151	concentrated Shrubble Bubble	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 25
 8152	extra-galvanized polyeaster egg	0		Effect: "Ichorous Eyesight", Effect Duration: 24
-8153	adjusted modified frozen twirling blinking candy dish	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 33
-8154	pressed liquefied bouncing teal Spechunky bar	0		Effect: "Ice Packed", Effect Duration: 56
+8153	adjusted modified frozen blinking twirling candy dish	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 33
+8154	pressed liquefied teal bouncing Spechunky bar	0		Effect: "Ice Packed", Effect Duration: 56
 8155	galvanized liquefied huge talisman of Horus	0		Effect: "Inner Warmth", Effect Duration: 17
-8156	ghostly spinning check to the Meatsmith	0		
+8156	spinning ghostly check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
@@ -8038,16 +8038,16 @@
 8164	huge Jeselnik's remaindered axe of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100
 8165	upside-down low-budget shield	0		Damage Reduction: 3
 8166	spinning Tesla thinker's cr&ecirc;epy mask	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "spooky atk, cap 5"
-8167	decent snack-sized pulsating cyan baguette	2	good	
+8167	snack-sized decent cyan pulsating baguette	2	good	
 8168	ghostly glob of icing	0		
 8169	unsweetened Vulcanized ginger snaps	0		Effect: "Snobby", Effect Duration: 18
 8170	frozen activated jittery mostly-broken sunglasses	0		Effect: "Innately Truthy", Effect Duration: 45
-8171	weak hand-crafted unflavored wine cooler	2	EPIC	
+8171	hand-crafted weak unflavored wine cooler	2	EPIC	
 8172	bouncing carton of snake milk	1	EPIC	
 8173	blinking bouncing sewer snake of the cheetah	0		Initiative: +60
 8174	yummy pigeon egg	4	awesome	
 8175	greasy groovy jaunty feather	0		Moxie Percent: +10, Sleaze Spell Damage: +10
-8176	perfectly mixed weak premium malt liquor	2	EPIC	
+8176	weak perfectly mixed premium malt liquor	2	EPIC	
 8177	hardened brown paper pants of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3
 8178	up-at-dawn miser's brown paper bag mask	0		Meat Drop: +10, Adventures: +5
 8179	fuchsia Rosewater's ring of telling skeletons what to do	0		Mysticality Percent: +30, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8057,18 +8057,18 @@
 8183	nippy bread basket	0		Cold Damage: +10
 8184	Ed the Undying exhibit crate	0		
 8185	veiny The Crown of Ed the Undying	0		Maximum HP: +10, Item Drop: +5, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
-8186	olive pulsating Doc Galaktik's Invigorating Tonic	0		
+8186	pulsating olive Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	watered-down perfectly mixed Cherrytastrophe wine cooler	2	EPIC	
 8189	aged jittery bouncing Radberry Rip wine cooler	4	awesome	
-8190	irresponsibly strong mediocre Orangemageddon wine cooler	8	decent	
+8190	mediocre irresponsibly strong Orangemageddon wine cooler	8	decent	
 8191	tolerable blue Breakfast Blast wine cooler	4	good	
 8192	lousy Citrus Crush wine cooler	3	decent	
 8193	gigantic moldy upside-down plain bagel	10	crappy	
 8194	flavorless yellow glob of cream cheese	3	decent	
-8195	immense bland loaf of soda bread	7	decent	
+8195	bland immense loaf of soda bread	7	decent	
 8196	stale special acceptable bagel	4	decent	Effect: "Sleazy Hands", Effect Duration: 5
-8197	thick adequate narrow standard-issue cupcake	5	good	
+8197	adequate thick narrow standard-issue cupcake	5	good	
 8198	spoiled snack-sized ultra-deluxe cupcake	2	crappy	
 8199	hypnotic breadcrumbs	0		
 8200	adequate red popular tart	4	good	
@@ -8078,7 +8078,7 @@
 8204	one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	spinning jittery FunFunds&trade;	0		Last Available: "2015-04"
 8206	upside-down family-friendly smooth expensive camera	0		Moxie: +15, Sleaze Resistance: +1, Single Equip, Last Available: "2015-04"
-8207	purple narrow sunglasses	0		Single Equip, Last Available: "2015-04"
+8207	narrow purple sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	anodized How to Avoid Scams	0		Effect: "Cookie Backup", Effect Duration: 42, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
@@ -8086,12 +8086,12 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	wool rigging rope of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1, Last Available: "2015-04"
 8214	twisted nasty snuff	1	decent	Last Available: "2015-04"
-8215	shaking sewage-clogged pistol of the overflowing toilet of mayonnaise	0		Stench Spell Damage: +50, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8215	shaking sewage-clogged pistol of the overflowing toilet of mayonnaise	0		Stench Spell Damage: +50, Sleaze Spell Damage: +50, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	double-polarized improved fuchsia beard incense	0		Effect: "Initiative and Let Die", Effect Duration: 28, Last Available: "2015-04"
 8217	wholesome beefy perfume-soaked bandana	0		Muscle: +10, Maximum HP Percent: +10, Single Equip, Last Available: "2015-04"
 8218	blurry toxic globule	0		Last Available: "2015-04"
 8219	yummy half-sized toxo	2	awesome	Last Available: "2015-04"
-8220	high-proof drinkable huge Lemonade-235	7	good	Last Available: "2015-04"
+8220	drinkable high-proof huge Lemonade-235	7	good	Last Available: "2015-04"
 8221	jittery lion tamer's smooth isotophat	0		Moxie: +15, Experience (familiar): +2, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	red skewed Usain Bolt's fireproof Three Mile Island shorts	0		Hot Resistance: +3, Initiative: +80, Last Available: "2015-04"
 8223	resourceful medical-grade toxic mop	0		Maximum MP: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04"
@@ -8109,7 +8109,7 @@
 8235	olive chaotic Dinsey's brain of wisdom	0		Mysticality: +15, Spell Critical Percent: +10, Last Available: "2015-04"
 8236	perfumed MacGyver's Dinsey's glove	0		Maximum MP: +100, Stench Resistance: +5, Single Equip, Last Available: "2015-04"
 8237	coward's Dinsey's pants of extreme caution	0		Monster Level: -45, Last Available: "2015-04"
-8238	red bouncing pulsating brain preservation fluid	0		Last Available: "2015-04"
+8238	red pulsating bouncing brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
 8240	keycard &beta;	0		Last Available: "2015-04"
 8241	keycard &gamma;	0		Last Available: "2015-04"
@@ -8126,7 +8126,7 @@
 8252	nippy hale hazmat helmet of the overflowing toilet of courage of the glutton	0		Maximum HP: +20, Cold Damage: +10, Stench Spell Damage: +50, Spooky Resistance: +3, Food Drop: +100, Last Available: "2015-04"
 8253	huge upside-down Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	blue blinking Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
-8255	spinning blurry Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
+8255	blurry spinning Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	Vulcanized nasty gum	0		Effect: "Chalked-Up Teeth", Effect Duration: 46
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
@@ -8144,18 +8144,18 @@
 8270	adequate unappetizing mayolus	3	good	Last Available: "2015-05"
 8271	bland narrow uninteresting mayolus	3	decent	Last Available: "2015-05"
 8272	stale pulsating acceptable mayolus	4	decent	Last Available: "2015-05"
-8273	adequate small enticing mayolus	2	good	Last Available: "2015-05"
+8273	small adequate enticing mayolus	2	good	Last Available: "2015-05"
 8274	stale gigantic mouth-watering mayolus	8	decent	Last Available: "2015-05"
 8275	spinning newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	weak enchanted hand-crafted cyan twirling Afternoon Delight	2	EPIC	Effect: "Natural 20", Effect Duration: 40, Last Available: "2015-04"
+8278	enchanted hand-crafted weak cyan twirling Afternoon Delight	2	EPIC	Effect: "Natural 20", Effect Duration: 40, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	ghostly Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	non-nitrogenated Kokomo Resort Brand Suntan Oil	0		Effect: "Cockroach Scurry", Effect Duration: 11, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	pulsating The Cocktail Shaker	0		Last Available: "2015-04"
-8284	electrified activated mirror squat Kokomo Resort Pass	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49, Last Available: "2023-08"
+8284	electrified activated squat mirror Kokomo Resort Pass	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49, Last Available: "2023-08"
 8285	mirror Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	dry quadruple-tarnished Mayo de Mayo&trade; mayo	0		Effect: "Egged On", Effect Duration: 32
 8287	ghostly puck	0		Free Pull, Last Available: "2015-06"
@@ -8174,7 +8174,7 @@
 8300	activated altered huge power pill	0		Effect: "Crotchety, Pining", Effect Duration: 31, Last Available: "2015-06"
 8301	corrupted shaking pixel star	0		Effect: "Omphalotus Omnipresence", Effect Duration: 65, Last Available: "2015-06"
 8302	normal pixel banana	3	good	Last Available: "2015-06"
-8303	weak acceptable tumbling pixel beer	2	good	Last Available: "2015-06"
+8303	acceptable weak tumbling pixel beer	2	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	unsweetened polymerized sludgesicle	0		Effect: "You Know What's Up", Effect Duration: 33
@@ -8183,12 +8183,12 @@
 8309	colloidal baggie of regular-sized tardigrades	0		Effect: "Feet of Grapefruit", Effect Duration: 42
 8310	triple-frozen .epub file	0		Effect: "Mer-kindliness", Effect Duration: 23
 8311	nitrogenated flattened BUBBLE GUM	0		Effect: "Pla-see-bo", Effect Duration: 36
-8312	altered squat cyan blurry hustler shades	0		Effect: "Cat-Alyzed", Effect Duration: 59
+8312	altered squat blurry cyan hustler shades	0		Effect: "Cat-Alyzed", Effect Duration: 59
 8313	chilled jerky stick	0		Effect: "In the Limelight", Effect Duration: 57
 8314	oxidized costume rental shop	0		Effect: "Melancholy Burden", Effect Duration: 39
 8315	pressed non-colloidal blurry muscle oil	0		Effect: "Crud&eacute;", Effect Duration: 27
 8316	pickled bottle of Red-Out	0		Effect: "All Blued Up", Effect Duration: 59
-8317	colloidal magnetized cyan twirling pickpocket protector	0		Effect: "Soles of Glass", Effect Duration: 31
+8317	colloidal magnetized twirling cyan pickpocket protector	0		Effect: "Soles of Glass", Effect Duration: 31
 8318	chilled frozen sinister-looking cat	0		Effect: "Burnt 'n' Turnt", Effect Duration: 37
 8319	boiled twirling jazzy cigarette holder	0		Effect: "Yuletide Sappiness", Effect Duration: 66
 8320	dry one glove	0		Effect: "Neutered Nostrils", Effect Duration: 41
@@ -8196,7 +8196,7 @@
 8322	magnetized upside-down handful of fire	0		Effect: "Granolarrrgh", Effect Duration: 59
 8323	moist Cracklin' Oat Bran	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 37
 8324	pressed spinning disposable lighter	0		Effect: "Psalm of Pointiness", Effect Duration: 53
-8325	non-moist tumbling yellow coal contact lenses	0		Effect: "Gonna Get You, Sucker", Effect Duration: 25
+8325	non-moist yellow tumbling coal contact lenses	0		Effect: "Gonna Get You, Sucker", Effect Duration: 25
 8326	galvanized teal conjured ice cream	0		Effect: "Mariachi Mood", Effect Duration: 30
 8327	polymerized unsweetened Iceberglar scarf	0		Effect: "Gummi Badass", Effect Duration: 68
 8328	polarized super-ionized lime green icy hairspray	0		Effect: "Sweet Nostalgia", Effect Duration: 32
@@ -8204,7 +8204,7 @@
 8330	non-pressed assassin's cheese knife	0		Effect: "It's Electric!", Effect Duration: 65
 8331	flattened skewed blinking filthy armor	0		Effect: "Cock of the Walk", Effect Duration: 66
 8332	dry plague pie	0		Effect: "Nutrient-Rich", Effect Duration: 20
-8333	enhanced colloidal mirror narrow batarang	0		Effect: "Super Skill", Effect Duration: 54
+8333	enhanced colloidal narrow mirror batarang	0		Effect: "Super Skill", Effect Duration: 54
 8334	denatured quantum spare neck bolts	0		Effect: "Greased-Up Familiar", Effect Duration: 64
 8335	double-liquefied warmed narrow cyan grease trap	0		Effect: "Covetous Robbery", Effect Duration: 44
 8336	pickled Vulcanized upside-down shamanic ham	0		Effect: "Disdain of the War Snapper", Effect Duration: 59
@@ -8213,7 +8213,7 @@
 8339	frozen vacuum-sealed wobbly warehouse walkie-talkie	0		Effect: "Blood-Rich", Effect Duration: 11
 8340	moist quadruple-flattened twirling janitor's mop	0		Effect: "PERL of Great Price", Effect Duration: 18
 8341	pickled warehouse clerk's glasses	0		Effect: "Flower Power", Effect Duration: 43
-8342	dry vacuum-sealed vacuum-sealed olive skewed huge baloney rotgut	0		Effect: "Wintry Breath", Effect Duration: 56
+8342	dry vacuum-sealed vacuum-sealed skewed huge olive baloney rotgut	0		Effect: "Wintry Breath", Effect Duration: 56
 8343	enhanced anodized denatured carton of gaspers	0		Effect: "The Power of Positive Thinking", Effect Duration: 34
 8344	liquefied activated bronze polish	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 15
 8345	triple-altered alkaline adjusted blinking ghostly crident	0		Effect: "Prince of Seaside Town", Effect Duration: 54
@@ -8239,7 +8239,7 @@
 8365	improved denatured warmed upside-down novelty fruit hat	0		Effect: "Icy Demeanor", Effect Duration: 59
 8366	diffused pressed fuchsia bouncing invisibility cream	0		Effect: "Nuts about Candy", Effect Duration: 53
 8367	quantum super-pickled cold-filtered huge handful of stubble	0		Effect: "The Power of LOV", Effect Duration: 13
-8368	colloidal anodized twirling gray garbage juice slurpee	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 62
+8368	colloidal anodized gray twirling garbage juice slurpee	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 62
 8369	flattened gray plunge-leg	0		Effect: "Spiky Hair", Effect Duration: 30
 8370	double-unsweetened pickled funky eyepatch	0		Effect: "Oh Snap", Effect Duration: 38
 8371	non-boiled maroon bucket of fish juice	0		Effect: "Oleaginous Soles", Effect Duration: 69
@@ -8248,7 +8248,7 @@
 8374	dry wet blinking drinks tray	0		Effect: "One Very Clear Eye", Effect Duration: 43
 8375	chilled polymerized blinking eyebrow lifter	0		Effect: "The Sweats", Effect Duration: 41
 8376	red submarine	0		Last Available: "2015-06"
-8377	fancy moldy huge pixel lemon	4	crappy	Effect: "Human-Hippy Hybrid", Effect Duration: 15, Last Available: "2015-06"
+8377	moldy fancy huge pixel lemon	4	crappy	Effect: "Human-Hippy Hybrid", Effect Duration: 15, Last Available: "2015-06"
 8378	perfectly mixed pixel daiquiri	4	EPIC	Last Available: "2015-06"
 8379	warmed frozen spinning power pill	0		Effect: "Boo Tea", Effect Duration: 22, Last Available: "2015-06"
 8380	quadruple-oxidized pixel potion	0		Effect: "Jungle Juiced", Effect Duration: 43, Last Available: "2015-06"
@@ -8280,12 +8280,12 @@
 8406	spinning savory dry noodles	0		
 8407	yummy pestopiary	3	awesome	
 8408	non-polarized ectoplasmic orbs	0		Effect: "Smokin'", Effect Duration: 29
-8409	thick adequate crudles	5	good	
+8409	adequate thick crudles	5	good	
 8410	spoiled diet agnolotti arboli	1	crappy	
 8411	normal spaghetti with ghost balls	4	good	
 8412	moldy ghostly succulent marrow	3	crappy	
 8413	moldy salacious crumbs	4	crappy	
-8414	yummy immense fusilli marrownarrow	7	awesome	
+8414	immense yummy fusilli marrownarrow	7	awesome	
 8415	decent suggestive strozzapreti	3	good	
 8416	shaking Mountain Stream gastrique	0		
 8417	bland Mt. McLargeHuge oyster	3	decent	
@@ -8297,7 +8297,7 @@
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
 8425	New Age healing crystal	0		Last Available: "2015-08"
-8426	shaking bouncing Volcoino	0		Last Available: "2015-08"
+8426	bouncing shaking Volcoino	0		Last Available: "2015-08"
 8427	fizzing spore pod	0		
 8428	wobbly spore pod	0		
 8429	veiny spore pod	0		
@@ -8335,7 +8335,7 @@
 8461	acceptable Gold Velvet&trade; whiskey	4	good	Last Available: "2015-08"
 8462	cyan SMOOCH soda	1	crappy	Last Available: "2015-08"
 8463	stale smelted roe	3	decent	Last Available: "2015-08"
-8464	practically non-alcoholic bad blurry lavawater	1	decent	Last Available: "2015-08"
+8464	bad practically non-alcoholic blurry lavawater	1	decent	Last Available: "2015-08"
 8465	irradiated non-deionized bouncing basaltamander tongue	0		Effect: "Weasels Underfoot", Effect Duration: 42, Last Available: "2015-08"
 8466	gray wholesome Fonzie's slick lavalarva	0		Moxie: +10, Experience (Moxie): +1, Maximum HP Percent: +10, Last Available: "2015-08"
 8467	wobbly shaking sizzling hale lava balaclava of the detective	0		Maximum HP: +20, Hot Damage: +10, Item Drop: +20, Last Available: "2015-08"
@@ -8346,7 +8346,7 @@
 8472	upside-down hale heat-resistant necktie of the cougar	0		Moxie: +20, Maximum HP: +20, Single Equip, Last Available: "2015-08"
 8473	supercharged therapeutic arcane researcher's heat-resistant gloves	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2015-08"
 8474	moldy very hot lunch	3	crappy	Last Available: "2015-08"
-8475	fancy mediocre asbestos thermos	3	decent	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2015-08"
+8475	mediocre fancy asbestos thermos	3	decent	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2015-08"
 8476	pickled liquid rhinestones	0		Effect: "All Blued Up", Effect Duration: 14, Last Available: "2015-08"
 8477	spoiled disco biscuit	3	crappy	Last Available: "2015-08"
 8478	hand-crafted triple-distilled Quaatorade&trade;	8	EPIC	Last Available: "2015-08"
@@ -8358,7 +8358,7 @@
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	gray &quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	bouncing wobbly airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	wobbly bouncing airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	ghostly Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	shaking New Age hurting crystal	0		Last Available: "2015-08"
 8490	ghostly smooth velvet pants of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
@@ -8377,12 +8377,12 @@
 8503	purple signed deuce	0		Last Available: "2015-08"
 8504	Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
-8506	squat red glass ceiling fragments	0		Last Available: "2015-08"
-8507	twisted huge tumbling SMOOCH coffee cup	1	decent	Effect: "Mighty Shout", Effect Duration: 10, Last Available: "2015-08"
+8506	red squat glass ceiling fragments	0		Last Available: "2015-08"
+8507	twisted tumbling huge SMOOCH coffee cup	1	decent	Effect: "Mighty Shout", Effect Duration: 10, Last Available: "2015-08"
 8508	double-colloidal cold-filtered labrador cookie	0		Effect: "Moon'd", Effect Duration: 20, Last Available: "2015-08"
 8509	flame-retardant Jack Frost's groovy Mr. Cheeng's spectacles	0		Moxie Percent: +10, Cold Spell Damage: +50, Hot Resistance: +1, Single Equip, Last Available: "2015-08"
 8510	banded grease cannon of the glutton	0		Damage Absorption: +100, Food Drop: +100, Last Available: "2015-08"
-8511	non-tarnished polarized double-polymerized wobbly maroon demon makeup kit	0		Effect: "In Tuna", Effect Duration: 59, Last Available: "2015-08"
+8511	non-tarnished polarized double-polymerized maroon wobbly demon makeup kit	0		Effect: "In Tuna", Effect Duration: 59, Last Available: "2015-08"
 8512	dance instructor's personal trainer's love of terror	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Spooky Spell Damage: +10, Last Available: "2015-08"
 8513	Herculean smartaleck's supercool Pener's drumstick	0		Moxie Percent: 50, Experience (Muscle): +1, Last Available: "2015-08"
 8514	experienced deuce cape of vim and vigor	0		Experience: +2, Maximum HP Percent: +50, Last Available: "2015-08"
@@ -8396,7 +8396,7 @@
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	rotten cyan spinning spinning lava cake	3	crappy	Last Available: "2015-08"
+8525	rotten spinning spinning cyan lava cake	3	crappy	Last Available: "2015-08"
 8526	bland pink slime	3	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	yellow Special&trade; Sauce	0		
@@ -8406,25 +8406,25 @@
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	moldy libertagliatelle	4	crappy	
-8535	fancy decent yellow turkish mostaccioli	4	good	Effect: "Gummi Badass", Effect Duration: 10
+8535	decent fancy yellow turkish mostaccioli	4	good	Effect: "Gummi Badass", Effect Duration: 10
 8536	yummy small linguini of the sea	2	awesome	
 8537	diffused electrified twirling Hersey&trade; SMOOCH	0		Effect: "Ichorous Eyesight", Effect Duration: 52
 8539	blurry Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	spinning drug cocktail sauce	0		
-8542	low-calorie bland Fettris	1	decent	
-8543	decent miniature fusillocybin	2	good	
+8542	bland low-calorie Fettris	1	decent	
+8543	miniature decent fusillocybin	2	good	
 8544	stale small blinking jittery prescription noodles	2	decent	
 8545	vaporized blood-drive sticker	1	decent	Effect: "Norwhalloped", Effect Duration: 10
 8546	denatured shaking bag of grain	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 47
 8547	cold-filtered Vulcanized pocket maze	0		Effect: "Mucilaginous Mentalism", Effect Duration: 13
 8548	frozen quadruple-irradiated adjusted blurry shady shades	0		Effect: "Corruption of Wretched Wally", Effect Duration: 67
 8549	oxidized ionized pulsating squeaky toy rose	0		Effect: "Man's Worst Enemy", Effect Duration: 19
-8550	stale big weird gazelle steak	5	decent	
+8550	big stale weird gazelle steak	5	decent	
 8551	toothsome upside-down sausage without a cause	3	awesome	
 8552	dry shaking face paint	0		Effect: "Here to Kick Ass", Effect Duration: 47
 8553	acceptable emergency margarita	4	good	
-8554	spirit-forward mediocre huge vintage smart drink	5	decent	
+8554	mediocre spirit-forward huge vintage smart drink	5	decent	
 8555	skewed a ten-percent bonus	0		
 8556	blue Thwaitgold termite statuette	0		
 8557	huge The Emperor's new cookie	0		
@@ -8449,7 +8449,7 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	mediocre bottle of Amontillado	3	decent	Last Available: "2015-09"
-8579	acceptable strong bouncing barrel-aged martini	5	good	Last Available: "2015-09"
+8579	strong acceptable bouncing barrel-aged martini	5	good	Last Available: "2015-09"
 8580	moldy barrel pickle	3	crappy	Last Available: "2015-09"
 8581	spoiled half-sized barrel cracker	2	crappy	Last Available: "2015-09"
 8582	mixed vibrating mushroom	1	good	Last Available: "2015-09"
@@ -8481,12 +8481,12 @@
 8608	magnetized polymerized cuppa Net tea	0		Effect: "Muscle Unbound", Effect Duration: 44, Last Available: "2015-09"
 8609	enhanced anodized bouncing cuppa Proprie tea	0		Effect: "Like a Fish to Walter", Effect Duration: 62, Last Available: "2015-09"
 8610	dry cuppa Morbidi tea	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 62, Last Available: "2015-09"
-8611	enhanced super-galvanized twirling narrow cuppa Chari tea	0		Effect: "Fungal Fortification", Effect Duration: 25, Last Available: "2015-09"
+8611	enhanced super-galvanized narrow twirling cuppa Chari tea	0		Effect: "Fungal Fortification", Effect Duration: 25, Last Available: "2015-09"
 8612	alkaline cuppa Serendipi tea	0		Effect: "Turkey-Agitated", Effect Duration: 29, Last Available: "2015-09"
 8613	pressed cuppa Feroci tea	0		Effect: "Pork Power", Effect Duration: 69, Last Available: "2015-09"
 8614	cold-filtered skewed fuchsia cuppa Physicali tea	0		Effect: "Rad-ish", Effect Duration: 34, Last Available: "2015-09"
 8615	corrupted gray cuppa Wit tea	0		Effect: "Powder Power", Effect Duration: 60, Last Available: "2015-09"
-8616	Vulcanized lime green twirling cuppa Neuroplastici tea	0		Effect: "One For Tea", Effect Duration: 68, Last Available: "2015-09"
+8616	Vulcanized twirling lime green cuppa Neuroplastici tea	0		Effect: "One For Tea", Effect Duration: 68, Last Available: "2015-09"
 8617	ionized tumbling cuppa Dexteri tea	0		Effect: "Chain Chain Chains", Effect Duration: 44, Last Available: "2015-09"
 8618	alkaline spinning cuppa Flexibili tea	0		Effect: "Army of One", Effect Duration: 30, Last Available: "2015-09"
 8619	corrupted huge cuppa Impregnabili tea	0		Effect: "Chock Full o' Nanites", Effect Duration: 56, Last Available: "2015-09"
@@ -8511,12 +8511,12 @@
 8638	miser's greasy shellacked Royal scepter	0		Damage Reduction: 7, Sleaze Spell Damage: +10, Meat Drop: +10, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	snack-sized rotten bowl of eyeballs	2	crappy	Last Available: "2015-10"
+8641	rotten snack-sized bowl of eyeballs	2	crappy	Last Available: "2015-10"
 8642	rotten bowl of mummy guts	3	crappy	Last Available: "2015-10"
 8643	bland mirror bowl of maggots	3	decent	Last Available: "2015-10"
 8644	tolerable practically non-alcoholic wobbly blood and blood	1	good	Last Available: "2015-10"
 8645	artisanal practically non-alcoholic Jack-O-Lantern beer	1	super ultra EPIC	Last Available: "2015-10"
-8646	tolerable distilled zombie	5	good	Last Available: "2015-10"
+8646	distilled tolerable zombie	5	good	Last Available: "2015-10"
 8647	yellow Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
@@ -8563,12 +8563,12 @@
 8690	extra-dry blue exotic travel brochure	0		Effect: "One Very Clear Eye", Effect Duration: 20, Last Available: "2015-11"
 8691	blurry bag of foreign bribes	0		Last Available: "2015-11"
 8692	quantum electrified olive shampoo-conditioner	0		Effect: "Bilious Brains", Effect Duration: 50, Last Available: "2015-11"
-8693	pulsating upside-down hotel minibar key	0		Last Available: "2015-11"
+8693	upside-down pulsating hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	denatured medicinal herbs	1		Last Available: "2016-01"
 8697	big decent ice rice	5	good	Last Available: "2016-01"
-8698	hand-crafted practically non-alcoholic iced plum wine	1	EPIC	Last Available: "2016-01"
+8698	practically non-alcoholic hand-crafted iced plum wine	1	EPIC	Last Available: "2016-01"
 8699	zippy ribald training belt of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Initiative: +20, Single Equip, Last Available: "2016-01"
 8700	blurry green scandalous beefcake's training legwarmers of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Sleaze Damage: +5, Single Equip, Last Available: "2016-01"
 8701	vibrating training helmet of the bloodbag	0		Maximum HP: +100, Maximum MP Percent: +10, Item Drop: +5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
@@ -8581,13 +8581,13 @@
 8708	powdered bouncing abstraction: action	1		Last Available: "2015-12"
 8709	compressed shaking abstraction: thought	1		Effect: "Human-Beast Hybrid", Effect Duration: 45, Last Available: "2015-12"
 8710	distilled bouncing abstraction: sensation	1		Last Available: "2015-12"
-8711	distilled narrow huge abstraction: purpose	1		Effect: "Souper Vengeful", Effect Duration: 25, Last Available: "2015-12"
+8711	distilled huge narrow abstraction: purpose	1		Effect: "Souper Vengeful", Effect Duration: 25, Last Available: "2015-12"
 8712	altered fuchsia abstraction: category	1		Last Available: "2015-12"
 8713	mixed abstraction: perception	1		Last Available: "2015-12"
 8714	powdered abstraction: motion	1		Last Available: "2015-12"
 8715	diluted blurry abstraction: joy	1		Last Available: "2015-12"
 8716	modified twirling abstraction: certainty	1		Last Available: "2015-12"
-8717	diluted blurry gray abstraction: comprehension	1		Last Available: "2015-12"
+8717	diluted gray blurry abstraction: comprehension	1		Last Available: "2015-12"
 8718	blue modern picture frame	0		Last Available: "2015-12"
 8719	tasty VYKEA meatballs	4	awesome	Last Available: "2015-11"
 8720	drinkable extra-dry VYKEA mead	5	good	Last Available: "2015-11"
@@ -8601,8 +8601,8 @@
 8728	squat VYKEA dowel	0		Last Available: "2015-11"
 8729	yellow sharpshooter's healthy VYKEA hex key of the businessman	0		Maximum HP Percent: +20, Critical Hit Percent: +10, Meat Drop: +50, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	low-calorie normal tin of submardines	1	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	special drinkable shaking bottle of norwhiskey	3	good	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2015-11"
+8731	normal low-calorie tin of submardines	1	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8732	drinkable special shaking bottle of norwhiskey	3	good	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2015-11"
 8733	boiled twirling huge octolus oculus	1	good	Effect: "Also Schmeckt Zarathustra", Effect Duration: 45, Last Available: "2015-11"
 8734	gray sharpshooter's medical-grade therapeutic sardine can key	0		Critical Hit Percent: +10, HP Regen Min: 12, HP Regen Max: 17, Last Available: "2015-11"
 8735	lard-coated supercool norwhal helmet of the sewer	0		Moxie Percent: +20, Stench Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "atk", Last Available: "2015-11"
@@ -8610,9 +8610,9 @@
 8737	tolerable practically non-alcoholic perfect cosmopolitan	1	good	Last Available: "2015-11"
 8738	tolerable perfect negroni	4	good	Last Available: "2015-11"
 8739	drinkable perfect dark and stormy	4	good	Last Available: "2015-11"
-8740	hand-crafted practically non-alcoholic perfect mimosa	1	super ultra mega turbo EPIC	Last Available: "2015-11"
+8740	practically non-alcoholic hand-crafted perfect mimosa	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8741	hand-crafted perfect old-fashioned	3	EPIC	Last Available: "2015-11"
-8742	lousy practically non-alcoholic perfect paloma	1	decent	Last Available: "2015-11"
+8742	practically non-alcoholic lousy perfect paloma	1	decent	Last Available: "2015-11"
 8743	liquefied huge narrow That 70s Cologne	0		Effect: "Cheered Up", Effect Duration: 47, Last Available: "2015-11"
 8744	quadruple-alkaline Wal-Mart &quot;diamond&quot; ring	0		Effect: "Amorphous Cheer", Effect Duration: 63, Last Available: "2015-11"
 8745	Vulcanized Puffstone cigar	0		Effect: "There Wolf", Effect Duration: 66, Last Available: "2015-11"
@@ -8636,7 +8636,7 @@
 8763	squat BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	teal huge Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	delicious weak Gratitude chocolate (bourbon-filled)	2	awesome	Last Available: "2016-02"
+8766	weak delicious Gratitude chocolate (bourbon-filled)	2	awesome	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	upside-down Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8687,16 +8687,16 @@
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	decent Kudzu salad	4	good	Last Available: "2016-12"
 8817	altered teal Mansquito Serum	1		Effect: "Bloodstain-Resistant", Effect Duration: 20, Last Available: "2016-12"
-8818	fancy strong lousy Miss Graves' vermouth	5	decent	Effect: "Stimulated Brain", Effect Duration: 30, Last Available: "2016-12"
-8819	huge moldy olive The Plumber's mushroom stew	7	crappy	Last Available: "2016-12"
+8818	fancy lousy strong Miss Graves' vermouth	5	decent	Effect: "Stimulated Brain", Effect Duration: 30, Last Available: "2016-12"
+8819	moldy huge olive The Plumber's mushroom stew	7	crappy	Last Available: "2016-12"
 8820	diluted The Author's ink	1		Last Available: "2016-02"
 8821	tolerable watered-down The Mad Liquor	2	good	Last Available: "2016-12"
-8822	lousy weak Doc Clock's thyme cocktail	2	decent	Last Available: "2016-12"
+8822	weak lousy Doc Clock's thyme cocktail	2	decent	Last Available: "2016-12"
 8823	huge adequate Mr. Burnsger	8	good	Last Available: "2016-12"
 8824	diluted The Inquisitor's unidentifiable object	1		Effect: "Got Your Boots On", Effect Duration: 15, Last Available: "2016-12"
-8825	skewed maroon hardened banded The Jokester's gun of chilblains	0		Damage Absorption: +100, Damage Reduction: 3, Cold Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	jittery foul-smelling The Jokester's wig of the brute of vim and vigor	0		Muscle Percent: +30, Maximum HP Percent: +50, Stench Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
-8827	twirling electrified therapeutic The Jokester's pants of Flo-Jo	0		Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	skewed maroon hardened banded The Jokester's gun of chilblains	0		Damage Absorption: +100, Damage Reduction: 3, Cold Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	jittery foul-smelling The Jokester's wig of the brute of vim and vigor	0		Muscle Percent: +30, Maximum HP Percent: +50, Stench Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	twirling electrified therapeutic The Jokester's pants of Flo-Jo	0		Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	anodized Jokester makeup	0		Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	twirling mirror battoo kit	0		Last Available: "2016-12"
@@ -8704,13 +8704,13 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	colloidal improved maroon robin's egg	0		Effect: "The Wisdom... of the Future", Effect Duration: 24, Last Available: "2016-12"
 8834	decent massive fancy robin flan	9	good	Effect: "Human-Elf Hybrid", Effect Duration: 25, Last Available: "2016-12"
-8835	perfectly mixed watered-down robin nog	2	EPIC	Last Available: "2016-12"
+8835	watered-down perfectly mixed robin nog	2	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	twirling teal exploding gum	0		
 8839	root beer barrel	0		
 8840	polymerized polarized Kudzu slaw	0		Effect: "Pemmican't", Effect Duration: 50
-8841	activated liquefied ghostly spinning Mansquito's blood	0		Effect: "Sweet Taste", Effect Duration: 43
+8841	activated liquefied spinning ghostly Mansquito's blood	0		Effect: "Sweet Taste", Effect Duration: 43
 8842	chilled vacuum-sealed infrablack lipstick	0		Effect: "Squirming Like a Toad", Effect Duration: 64
 8843	flattened can of drain cleaner	0		Effect: "The Power of Negative Thinking", Effect Duration: 62
 8844	alkaline purple spinning The Author's inkwell	0		Effect: "Memory of Resilience", Effect Duration: 29
@@ -8719,7 +8719,7 @@
 8847	frozen twirling red-hot jawbreaker	0		Effect: "Some Cheese with Your Wine", Effect Duration: 39
 8848	pickled enhanced question juice	0		Effect: "Sticks and Stones", Effect Duration: 60
 8849	adjusted ghostly tube of villain	0		Effect: "Weird Flavor", Effect Duration: 11
-8850	blinking Usain Bolt's your cowboy boots	0		Initiative: +80, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	blinking Usain Bolt's your cowboy boots	0		Initiative: +80, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	shaking inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,11 +8746,11 @@
 8874	inspector's MacGyver's stiffened razor-sharp Val-U Brand Every Bean Salad of mayonnaise	0		Weapon Damage Percent: +25, Damage Reduction: 1, Maximum MP: +100, Sleaze Spell Damage: +50, Item Drop: +15, Last Available: "2016-02"
 8875	tumbling blurry Annie Oakley's crafty Shrub's Premium Baked Beans of the ox	0		Muscle: +20, Maximum MP: +10, Critical Hit Percent: +20, Last Available: "2016-02"
 8876	big delicious plate of Heimz Fortified Kidney Beans	5	awesome	Last Available: "2016-02"
-8877	snack-sized rotten plate of Tesla's Electroplated Beans	2	crappy	Last Available: "2016-02"
-8878	flavorless immense blinking plate of Mixed Garbanzos and Chickpeas	10	decent	Last Available: "2016-02"
-8879	stale super-sized plate of Hellfire Spicy Beans	5	decent	Last Available: "2016-02"
+8877	rotten snack-sized plate of Tesla's Electroplated Beans	2	crappy	Last Available: "2016-02"
+8878	immense flavorless blinking plate of Mixed Garbanzos and Chickpeas	10	decent	Last Available: "2016-02"
+8879	super-sized stale plate of Hellfire Spicy Beans	5	decent	Last Available: "2016-02"
 8880	spoiled plate of Frigid Northern Beans	3	crappy	Last Available: "2016-02"
-8881	diet moldy plate of World's Blackest-Eyed Peas	1	crappy	Last Available: "2016-02"
+8881	moldy diet plate of World's Blackest-Eyed Peas	1	crappy	Last Available: "2016-02"
 8882	adequate lime green narrow plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
 8883	tiny normal plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	good	Last Available: "2016-02"
 8884	moldy miniature plate of Val-U Brand Every Bean Salad	2	crappy	Last Available: "2016-02"
@@ -8778,8 +8778,8 @@
 8906	enhanced polarized narrow rattler gland	0		Effect: "Sharp Weapon", Effect Duration: 69, Last Available: "2016-02"
 8907	polymerized squat half-digested coal	0		Effect: "Void Between the Stars", Effect Duration: 43, Last Available: "2016-02"
 8908	adjusted spinning tightly-wound spine	0		Effect: "A Taste of Rainbow", Effect Duration: 50, Last Available: "2016-02"
-8909	moldy half-sized upside-down rotting beefsteak	2	crappy	Last Available: "2016-02"
-8910	mediocre distilled firemilk	5	decent	Last Available: "2016-02"
+8909	half-sized moldy upside-down rotting beefsteak	2	crappy	Last Available: "2016-02"
+8910	distilled mediocre firemilk	5	decent	Last Available: "2016-02"
 8911	adjusted electrified blurry spidercow eye-cluster	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 62, Last Available: "2016-02"
 8912	mixed huge moomy dust	1		Last Available: "2016-02"
 8913	blinking reassuring therapeutic western-style skinning knife	0		Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02"
@@ -8787,12 +8787,12 @@
 8915	scorching steel knuckles	0		Hot Damage: +25, Last Available: "2016-02"
 8916	Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
-8918	ghostly wobbly The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
+8918	wobbly ghostly The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
 8919	gray LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	jittery Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	blinking Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
-8923	yellow narrow spinning disc (white)	0		
+8923	spinning yellow narrow disc (white)	0		
 8924	twirling disc (black)	0		
 8925	blinking disc (red)	0		
 8926	disc (green)	0		
@@ -8821,7 +8821,7 @@
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	upside-down slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
-8952	blinking yellow nicksilver spurs	0		Last Available: "2016-02"
+8952	yellow blinking nicksilver spurs	0		Last Available: "2016-02"
 8953	blurry ticksilver spurs	0		Last Available: "2016-02"
 8954	skewed special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
@@ -8863,7 +8863,7 @@
 8991	blinking do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	modified blurry armored prawn	1		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 35, Last Available: "2016-03"
 8993	miniature adequate jumping horseradish	2	good	Last Available: "2016-03"
-8994	watered-down tolerable cyan Sacramento wine	2	good	Last Available: "2016-03"
+8994	tolerable watered-down cyan Sacramento wine	2	good	Last Available: "2016-03"
 8995	wet red Greek fire	0		Effect: "Crocodile Tear", Effect Duration: 39, Last Available: "2016-03"
 8996	Jeselnik's wicked wizardly ox-head shield of the pedagogue of the businessman	0		Mysticality: +25, Experience: +3, Spell Damage: +5, Sleaze Damage: +25, Meat Drop: +50, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	shaking fuchsia blinking therapeutic baleful Sinatra's experienced dented scepter of the empath	0		Experience: +2, Experience (Moxie): +5, Spell Damage: +25, Familiar Weight: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8904,13 +8904,13 @@
 9032	spoiled bowl of Tastee-Wheet&trade;	3	crappy	
 9033	skewed Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	rotten huge browser cookie	9	crappy	Last Available: "2016-06"
+9035	huge rotten browser cookie	9	crappy	Last Available: "2016-06"
 9036	drinkable hacked gibson	3	good	Last Available: "2016-06"
 9037	blurry Source shades of the glutton	0		Food Drop: +100, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
-9041	twirling teal Source terminal GRAM chip	0		Last Available: "2016-06"
+9041	teal twirling Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	narrow lime green Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
@@ -8948,10 +8948,10 @@
 9076	stiffened arcane researcher's noir fedora of the glutton	0		Experience Percent (Mysticality): +10, Damage Reduction: 1, Food Drop: +100, Last Available: "2016-07"
 9077	tumbling blinking aromatic Herculean trench coat of Gandalf	0		Experience (Muscle): +1, Spell Critical Percent: +20, Stench Resistance: +1, Last Available: "2016-07"
 9078	bad spinning Falcon&trade; Maltese Liquor	3	decent	Last Available: "2016-07"
-9079	massive normal hardboiled egg	10	good	Last Available: "2016-07"
+9079	normal massive hardboiled egg	10	good	Last Available: "2016-07"
 9080	skewed detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	flame-wreathed Jim Carey's occult sage brawny beefy protonic accelerator pack	0		Muscle: +10, Muscle Percent: +20, Mysticality Percent: +10, Spell Damage Percent: +25, Monster Level: +25, Hot Spell Damage: +10, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	flame-wreathed Jim Carey's occult sage brawny beefy protonic accelerator pack	0		Muscle: +10, Muscle Percent: +20, Mysticality Percent: +10, Spell Damage Percent: +25, Monster Level: +25, Hot Spell Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	spinning almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	bouncing blinking lard-coated Adventurer bobblehead	0		Sleaze Spell Damage: +25, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	inspector's gravedigger's extremely unsafe Spookyraven signet	0		Weapon Damage Percent: +100, Spooky Damage: +10, Item Drop: +15, Single Equip, Last Available: "2016-08"
 9093	bouncing spinning hale tie-dyed fannypack of mayonnaise	0		Maximum HP: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2016-08"
 9094	hale healthy burnt snowpants	0		Maximum HP Percent: +20, Maximum HP: +20, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	blinking inspector's standards and practices guide	0		Item Drop: +15, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9095	blinking inspector's standards and practices guide	0		Item Drop: +15, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	narrow wholesome deadly Sinatra's Carpathian longsword	0		Experience (Moxie): +5, Weapon Damage: +5, Maximum HP Percent: +10, Last Available: "2016-08"
 9097	rosewater-soaked Da Vinci's experienced Liam's mail	0		Experience: +2, Experience (Mysticality): +5, Stench Resistance: +3, Last Available: "2016-08"
 9098	executive scorching studded Unfortunato's foolscap	0		Damage Absorption: +80, Hot Damage: +25, Meat Drop: +40, Last Available: "2016-08"
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	skewed repaid diaper of the empath	0		Familiar Weight: +5
 9118	bouncing Riker's Search History	0		Last Available: "2016-09"
-9119	smooth fuchsia ghostly Shot of Kardashian Gin	3	awesome	Last Available: "2016-09"
+9119	smooth ghostly fuchsia Shot of Kardashian Gin	3	awesome	Last Available: "2016-09"
 9120	foul-smelling Unstable Pointy Ears	0		Stench Damage: +10, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	crappy	Last Available: "2016-09"
@@ -8998,12 +8998,12 @@
 9126	drinkable unidentified drink	4	good	
 9127	hardy studded KoL Con 13 T-shirt	0		Damage Absorption: +80, Maximum HP: +50
 9128	squat stanky crafty razor-sharp discarded swimming trunks	0		Weapon Damage Percent: +25, Maximum MP: +10, Stench Spell Damage: +25
-9129	adjusted anodized ghostly mirror diluted makeup	0		Effect: "Ruthlessly Efficient", Effect Duration: 37
+9129	adjusted anodized mirror ghostly diluted makeup	0		Effect: "Ruthlessly Efficient", Effect Duration: 37
 9130	super-unsweetened charisma potion	0		Effect: "Filled with Magic", Effect Duration: 66
 9131	extremely confusing manual	0		
 9132	olive healthy pistol of extreme caution	0		Maximum HP Percent: +20, Monster Level: -25
 9133	mirror KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	moldy small blurry leftover pasty	2	crappy	
+9134	small moldy blurry leftover pasty	2	crappy	
 9135	hand-crafted twirling very whiskey	3	EPIC	
 9136	twirling shaking li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9023,7 +9023,7 @@
 9151	extra-energized polarized invisible seam ripper	0		Lasts Until Rollover, Effect: "Human-Demon Hybrid", Effect Duration: 26, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	spoiled pulsating red raw sweet potato	4	crappy	Last Available: "2016-11"
-9154	tiny spoiled raw beans	1	crappy	Last Available: "2016-11"
+9154	spoiled tiny raw beans	1	crappy	Last Available: "2016-11"
 9155	moldy raw stuffing	4	crappy	Last Available: "2016-11"
 9156	spoiled upside-down raw cranberry sauce	3	crappy	Last Available: "2016-11"
 9157	stale small mirror raw turkey	2	decent	Last Available: "2016-11"
@@ -9035,21 +9035,21 @@
 9163	toasty slick glass casserole dish of Leguizamo	0		Moxie: +10, Monster Level: +20, Hot Damage: +5, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	quilted educational can opener	0		Experience: +1, Damage Absorption: +40, Last Available: "2016-11"
-9166	compressed purple skewed turkey blaster	1		Last Available: "2016-11"
+9166	compressed skewed purple turkey blaster	1		Last Available: "2016-11"
 9167	cyan strapping glass pie plate of the boozehound	0		Muscle: +5, Booze Drop: +100, Damage Reduction: 7, Last Available: "2016-11"
 9168	dog trainer's therapeutic potato masher	0		Experience (familiar): +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	low-calorie spoiled sweet potatoes	1	crappy	Last Available: "2016-11"
-9172	adequate tiny bean casserole	1	good	Last Available: "2016-11"
-9173	snack-sized delicious baked stuffing	2	awesome	Last Available: "2016-11"
-9174	gigantic fancy decent cranberry cylinder	9	good	Effect: "Coated Arms", Effect Duration: 15, Last Available: "2016-11"
+9171	spoiled low-calorie sweet potatoes	1	crappy	Last Available: "2016-11"
+9172	tiny adequate bean casserole	1	good	Last Available: "2016-11"
+9173	delicious snack-sized baked stuffing	2	awesome	Last Available: "2016-11"
+9174	fancy gigantic decent cranberry cylinder	9	good	Effect: "Coated Arms", Effect Duration: 15, Last Available: "2016-11"
 9175	big flavorless thanksgiving turkey	5	decent	Last Available: "2016-11"
 9176	adequate mince pie	3	good	Last Available: "2016-11"
 9177	normal mashed potatoes	3	good	Last Available: "2016-11"
 9178	spoiled warm gravy	4	crappy	Last Available: "2016-11"
 9179	decent wobbly bread roll	3	good	Last Available: "2016-11"
-9180	bite-sized rotten leftovers	1	crappy	Last Available: "2016-11"
+9180	rotten bite-sized leftovers	1	crappy	Last Available: "2016-11"
 9181	spoiled leftovers sandwich	4	crappy	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9057,7 +9057,7 @@
 9185	blinking pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
-9188	spinning wobbly bomb of unknown origin	0		Last Available: "2016-11"
+9188	wobbly spinning bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	double-irradiated ionized eldritch concentrate	0		Effect: "Frost Tea", Effect Duration: 52, Last Available: "2016-11"
@@ -9068,9 +9068,9 @@
 9196	blinking sinister Science Notebook	0		Spell Damage: +10
 9197	Jeselnik's nasty hardy eldritch hat	0		Maximum HP: +50, Stench Damage: +5, Sleaze Damage: +25, Last Available: "2016-11"
 9198	friendly steel-toed experienced eldritch pants	0		Experience: +2, Damage Reduction: 9, Familiar Weight: +3, Last Available: "2016-11"
-9199	triple-distilled tolerable wobbly eldritch elixir	10	good	Last Available: "2016-11"
+9199	tolerable triple-distilled wobbly eldritch elixir	10	good	Last Available: "2016-11"
 9200	medical-grade quilted Quartet of Flare Masters Jacket	0		Damage Absorption: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-11"
-9201	cyan ghostly skewed lump of not really wriggling eldritch matter	0		
+9201	cyan skewed ghostly lump of not really wriggling eldritch matter	0		
 9202	huge Adventurer's Kit	0		
 9203	Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
@@ -9089,8 +9089,8 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	wobbly sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	jumbo bland twirling animal part cracker	5	decent	Last Available: "2016-12"
-9220	distilled tolerable gingerbread wine	5	good	Last Available: "2016-12"
-9221	special bite-sized adequate spinning gingerbread mug	1	good	Effect: "Uncucumbered", Effect Duration: 15, Last Available: "2016-12"
+9220	tolerable distilled gingerbread wine	5	good	Last Available: "2016-12"
+9221	bite-sized special adequate spinning gingerbread mug	1	good	Effect: "Uncucumbered", Effect Duration: 15, Last Available: "2016-12"
 9222	narrow ghostly crafty gingerbread mask	0		Maximum MP: +10, Last Available: "2016-12"
 9223	jittery MacGyver's occult brawny gingerservo	0		Muscle Percent: +20, Spell Damage Percent: +25, Maximum MP: +100, Single Equip, Last Available: "2016-12"
 9224	Vulcanized triple-activated skewed tainted icing	0		Effect: "Tea-hee", Effect Duration: 61, Last Available: "2016-12"
@@ -9122,9 +9122,9 @@
 9250	tarnished tumbling Inner Strength	0		Effect: "Afternoon Insight", Effect Duration: 68, Last Available: "2016-12"
 9251	corrupted upside-down shaking Inner Truth	0		Effect: "Void Between the Stars", Effect Duration: 54, Last Available: "2016-12"
 9252	rotten half-sized spiritual candy cane	2	crappy	Last Available: "2016-12"
-9253	lousy high-proof cyan spiritual eggnog	7	decent	Last Available: "2016-12"
+9253	high-proof lousy cyan spiritual eggnog	7	decent	Last Available: "2016-12"
 9254	rotten spiritual fruitcake	4	crappy	Last Available: "2016-12"
-9255	special normal diet tumbling spiritual gingerbread	1	good	Effect: "Smelly Pants", Effect Duration: 50, Last Available: "2016-12"
+9255	diet special normal tumbling spiritual gingerbread	1	good	Effect: "Smelly Pants", Effect Duration: 50, Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	negative lump	0		
 9273	gravedigger's Third Eye of bravery	0		Spooky Damage: +10, Spooky Resistance: +5, Last Available: "2016-12"
 9274	horrifying Krampus Horn of the boozehound	0		Spooky Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2016-12"
-9275	flavorless super-sized hambrosier	5	decent	Last Available: "2016-12"
+9275	super-sized flavorless hambrosier	5	decent	Last Available: "2016-12"
 9276	mediocre chakra-mental wine	3	decent	Last Available: "2016-12"
 9277	nitrogenated chakra malt	0		Effect: "Resilient Spirit", Effect Duration: 59, Last Available: "2016-12"
 9278	moldy Black Angus blackburger	4	crappy	Last Available: "2016-12"
-9279	strong perfectly mixed brandy	5	EPIC	Last Available: "2016-12"
+9279	perfectly mixed strong brandy	5	EPIC	Last Available: "2016-12"
 9280	corrupted anodized potion of spiritual gunkifying	0		Effect: "Appeteyes", Effect Duration: 31, Last Available: "2016-12"
 9281	therapeutic hale bad vibroknife	0		Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-12"
 9282	shaking cyan wicked crystal belt buckle of extreme caution	0		Spell Damage: +5, Monster Level: -25, Last Available: "2016-12"
@@ -9159,12 +9159,12 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	shaking gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	Lo Pan's Tesla sage Uncle Crimbo's hat	0		Mysticality Percent: +10, Spell Critical Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-12"
-9290	jumbo moldy Eldritch snap	5	crappy	Last Available: "2017-01"
+9290	moldy jumbo Eldritch snap	5	crappy	Last Available: "2017-01"
 9291	powdered hot jelly	1		Last Available: "2017-01"
-9292	modified blinking red jelly	1		Last Available: "2017-01"
+9292	modified red blinking jelly	1		Last Available: "2017-01"
 9293	modified gray jelly	1		Last Available: "2017-01"
 9294	diluted sleaze jelly	1		Effect: "Grumpy and Ornery", Effect Duration: 20, Last Available: "2017-01"
-9295	distilled huge blurry red stench jelly	1		Last Available: "2017-01"
+9295	distilled blurry red huge stench jelly	1		Last Available: "2017-01"
 9296	gray space planula	0		Free Pull, Last Available: "2017-01"
 9297	flavorless massive toast with hot jelly	9	decent	Last Available: "2017-01"
 9298	decent tiny toast with jelly	1	good	Last Available: "2017-01"
@@ -9181,9 +9181,9 @@
 9309	tolerable bouncing wax booze	4	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	pickled shaking sea jelly	1		Effect: "Sweetened and Fattened", Effect Duration: 20, Last Available: "2017-01"
-9312	adequate jumbo sea truffle	5	good	Last Available: "2017-01"
-9313	mirror mirror blue tarnished luggage key	0		Last Available: "2017-01"
-9314	narrow skewed crushed steamer trunk	0		Last Available: "2017-01"
+9312	jumbo adequate sea truffle	5	good	Last Available: "2017-01"
+9313	blue mirror mirror tarnished luggage key	0		Last Available: "2017-01"
+9314	skewed narrow crushed steamer trunk	0		Last Available: "2017-01"
 9315	personal trainer's recovered cufflinks	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2017-01"
 9316	heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	extra-aerosolized spinning LOV Elixir #3	0		Effect: "Patched In", Effect Duration: 13, Last Available: "2017-02"
@@ -9201,12 +9201,12 @@
 9329	polarized squat eldritch alignment spray	0		Effect: "Got Your Boots On", Effect Duration: 27, Last Available: "2017-02"
 9330	maroon LOV Entrance Pass	0		Last Available: "2017-02"
 9331	lime green double-paned arcane researcher's experienced eldritch hammer	0		Experience: +2, Experience Percent (Mysticality): +10, Cold Resistance: +5, Last Available: "2017-01"
-9332	special adequate snack-sized shaking squat eldritch mushroom	2	good	Effect: "The Moxie of LOV", Effect Duration: 25, Last Available: "2017-03"
+9332	adequate special snack-sized squat shaking eldritch mushroom	2	good	Effect: "The Moxie of LOV", Effect Duration: 25, Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	big decent eldritch mushroom pizza	5	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	mirror eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
-9337	deionized dry blinking green eldritch rub	0		Effect: "Protection from Bad Stuff", Effect Duration: 40, Last Available: "2017-02"
+9337	deionized dry green blinking eldritch rub	0		Effect: "Protection from Bad Stuff", Effect Duration: 40, Last Available: "2017-02"
 9338	HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
@@ -9229,44 +9229,44 @@
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	baby oil shooter	0		Last Available: "2017-03"
-9360	shaking yellow fish head	0		Last Available: "2017-03"
+9360	yellow shaking fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
 9362	blue pile of dirt	0		Last Available: "2017-03"
 9363	wobbly slime shooter	0		Last Available: "2017-03"
 9364	mirror imaginary lemon	0		Last Available: "2017-03"
-9365	mediocre high-proof ghostly literal grasshopper	7	decent	Last Available: "2017-03"
+9365	high-proof mediocre ghostly literal grasshopper	7	decent	Last Available: "2017-03"
 9366	practically non-alcoholic tolerable jittery double entendre	1	good	Last Available: "2017-03"
 9367	boozy mediocre Phlegethon	5	decent	Last Available: "2017-03"
 9368	artisanal Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	hand-crafted mentholated wine	4	EPIC	Last Available: "2017-03"
 9370	tolerable low tide martini	4	good	Last Available: "2017-03"
-9371	lousy weak shroomtini	2	decent	Last Available: "2017-03"
+9371	weak lousy shroomtini	2	decent	Last Available: "2017-03"
 9372	artisanal morning dew	4	EPIC	Last Available: "2017-03"
-9373	boozy artisanal whiskey squeeze	5	EPIC	Last Available: "2017-03"
+9373	artisanal boozy whiskey squeeze	5	EPIC	Last Available: "2017-03"
 9374	artisanal watered-down spinning great fashioned	2	EPIC	Last Available: "2017-03"
 9375	lousy spinning Gnomish sagngria	3	decent	Last Available: "2017-03"
-9376	mediocre practically non-alcoholic teal vodka stinger	1	decent	Last Available: "2017-03"
+9376	practically non-alcoholic mediocre teal vodka stinger	1	decent	Last Available: "2017-03"
 9377	hand-crafted irresponsibly strong extremely slippery nipple	6	EPIC	Last Available: "2017-03"
-9378	artisanal high-proof piscatini	7	EPIC	Last Available: "2017-03"
-9379	triple-distilled hand-crafted pulsating upside-down Churchill	7	EPIC	Last Available: "2017-03"
+9378	high-proof artisanal piscatini	7	EPIC	Last Available: "2017-03"
+9379	triple-distilled hand-crafted upside-down pulsating Churchill	7	EPIC	Last Available: "2017-03"
 9380	mediocre soilzerac	4	decent	Last Available: "2017-03"
 9381	hand-crafted London frog	3	EPIC	Last Available: "2017-03"
 9382	perfectly mixed nothingtini	3	EPIC	Last Available: "2017-03"
 9383	fancy acceptable spinning wobbly eighth plague	4	good	Effect: "Fortunate Resolve", Effect Duration: 25, Last Available: "2017-03"
 9384	perfectly mixed strong single entendre	5	EPIC	Last Available: "2017-03"
-9385	tolerable boozy reverse Tantalus	5	good	Last Available: "2017-03"
+9385	boozy tolerable reverse Tantalus	5	good	Last Available: "2017-03"
 9386	bad huge elemental caipiroska	3	decent	Last Available: "2017-03"
 9387	artisanal Feliz Navidad	4	EPIC	Last Available: "2017-03"
-9388	practically non-alcoholic special tolerable Bloody Nora	1	good	Effect: "Your Eyes are Peeled!", Effect Duration: 10, Last Available: "2017-03"
-9389	hand-crafted special fortified olive moreltini	5	EPIC	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2017-03"
+9388	tolerable special practically non-alcoholic Bloody Nora	1	good	Effect: "Your Eyes are Peeled!", Effect Duration: 10, Last Available: "2017-03"
+9389	special fortified hand-crafted olive moreltini	5	EPIC	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2017-03"
 9390	perfectly mixed hell in a bucket	4	EPIC	Last Available: "2017-03"
 9391	perfectly mixed skewed Newark	3	EPIC	Last Available: "2017-03"
 9392	smooth R'lyeh	3	awesome	Last Available: "2017-03"
-9393	enchanted perfectly mixed Gnollish sangria	3	EPIC	Effect: "Army of One", Effect Duration: 20, Last Available: "2017-03"
-9394	triple-distilled drinkable vodka barracuda	7	good	Last Available: "2017-03"
-9395	lousy high-proof enchanted Mysterious Island iced tea	9	decent	Effect: "Mushroom Samba", Effect Duration: 10, Last Available: "2017-03"
+9393	perfectly mixed enchanted Gnollish sangria	3	EPIC	Effect: "Army of One", Effect Duration: 20, Last Available: "2017-03"
+9394	drinkable triple-distilled vodka barracuda	7	good	Last Available: "2017-03"
+9395	enchanted lousy high-proof Mysterious Island iced tea	9	decent	Effect: "Mushroom Samba", Effect Duration: 10, Last Available: "2017-03"
 9396	acceptable drive-by shooting	3	good	Last Available: "2017-03"
-9397	lousy blue huge gunner's daughter	4	decent	Last Available: "2017-03"
+9397	lousy huge blue gunner's daughter	4	decent	Last Available: "2017-03"
 9398	drinkable huge dirt julep	4	good	Last Available: "2017-03"
 9399	bad watered-down Simepore slime	2	decent	Last Available: "2017-03"
 9400	lousy Phil Collins	4	decent	Last Available: "2017-03"
@@ -9297,7 +9297,7 @@
 9425	wobbly alien zoological sample	0		Last Available: "2017-04"
 9426	pulsating complex alien zoological sample	0		Last Available: "2017-04"
 9427	skewed fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	compressed squat skewed wobbly alien animal goo	1		Effect: "Meat the Flintstones", Effect Duration: 20, Last Available: "2017-04"
+9428	compressed wobbly skewed squat alien animal goo	1		Effect: "Meat the Flintstones", Effect Duration: 20, Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	upside-down murderbot data core	0		Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	censurious greasy toasty murderbot mask	0		Hot Damage: +5, Sleaze Spell Damage: +10, Sleaze Resistance: +3, Avatar: "Murderbot", Last Available: "2017-04"
 9454	improved blue murderbot spring injector	0		Effect: "Rotten Memories", Effect Duration: 40, Last Available: "2017-04"
 9455	asbestos-lined hale murderbot whip	0		Maximum HP: +20, Hot Resistance: +5, Last Available: "2017-04"
-9456	censurious sharpshooter's murderbot plasma rifle	0		Critical Hit Percent: +10, Sleaze Resistance: +3, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	censurious sharpshooter's murderbot plasma rifle	0		Critical Hit Percent: +10, Sleaze Resistance: +3, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9336,8 +9336,8 @@
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	mirror yellow Spacegate	0		Last Available: "2017-04"
 9466	rotten Aldebaran sardines	3	crappy	Last Available: "2017-04"
-9467	triple-distilled tolerable Centauri fish wine	7	good	Last Available: "2017-04"
-9468	vaporized red tumbling oxygen	1		Last Available: "2017-04"
+9467	tolerable triple-distilled Centauri fish wine	7	good	Last Available: "2017-04"
+9468	vaporized tumbling red oxygen	1		Last Available: "2017-04"
 9469	pulsating ruddy Spacegate scientist's insignia of wisdom	0		Mysticality: +15, Maximum HP Percent: +40, Single Equip, Last Available: "2017-04"
 9470	tumbling curative fortified Spacegate military insignia	0		Damage Absorption: +60, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2017-04"
 9471	ribald Spacegate diplomat's insignia of wisdom of the early riser	0		Mysticality: +15, Sleaze Damage: +10, Adventures: +7, Single Equip, Last Available: "2017-04"
@@ -9357,14 +9357,14 @@
 9485	super-unsweetened Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "items.enh", Effect Duration: 54, Last Available: "2017-05"
 9486	bland shaking Affirmation Cookie	3	decent	Last Available: "2017-05"
 9487	License To Kill	0		
-9488	twirling mirror Thwaitgold bug statuette	0		
+9488	mirror twirling Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	pressed Threatening Missive	0		Effect: "Wings of the Grasshopper", Effect Duration: 52
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	nippy friendly slick Kremlin's Greatest Briefcase	0		Moxie: +10, Familiar Weight: +3, Cold Damage: +10, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	nippy friendly slick Kremlin's Greatest Briefcase	0		Moxie: +10, Familiar Weight: +3, Cold Damage: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	acceptable practically non-alcoholic olive basic martini	1	good	Last Available: "2017-06"
-9495	mediocre triple-distilled lime green improved martini	9	decent	Last Available: "2017-06"
+9495	triple-distilled mediocre lime green improved martini	9	decent	Last Available: "2017-06"
 9496	perfectly mixed splendid martini	4	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	narrow can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9374,17 +9374,17 @@
 9502	steel-toed supercool plastic gundam of the cheetah	0		Moxie Percent: +20, Damage Reduction: 9, Initiative: +60, Last Available: "2017-06"
 9503	License to Chill	0		Last Available: "2017-07"
 9504	squat Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
-9505	wobbly maroon jittery Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
+9505	maroon jittery wobbly Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	skewed Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	upside-down L.I.M.P. Stock Certificate	0		
 9510	Dust bunny	0		
-9511	wobbly wobbly yellow Pocket Meteor Guide	0		Last Available: "2017-08"
+9511	yellow wobbly wobbly Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	teal Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	upside-down Meteorite-Ade	0		Last Available: "2017-08"
-9514	stale enchanted diet meteoreo	1	decent	Effect: "El Vibrations", Effect Duration: 25, Last Available: "2017-08"
-9515	enchanted practically non-alcoholic artisanal meadeorite	1	EPIC	Effect: "Abominably Slippery", Effect Duration: 25, Last Available: "2017-08"
+9514	diet enchanted stale meteoreo	1	decent	Effect: "El Vibrations", Effect Duration: 25, Last Available: "2017-08"
+9515	enchanted artisanal practically non-alcoholic meadeorite	1	EPIC	Effect: "Abominably Slippery", Effect Duration: 25, Last Available: "2017-08"
 9516	fuchsia meteoroid	0		Last Available: "2017-08"
 9517	careful studded meteortarboard of the early riser	0		Damage Absorption: +80, Monster Level: -10, Adventures: +7, Last Available: "2017-08"
 9518	up-at-dawn wizardly brainy meteorite guard	0		Mysticality: 30, Adventures: +5, Damage Reduction: 9, Last Available: "2017-08"
@@ -9452,7 +9452,7 @@
 9580	extra-energized warmed and cracker	0		Effect: "Nano-juiced", Effect Duration: 25, Last Available: "2017-12"
 9581	smooth distilled neg grog	5	awesome	Last Available: "2017-12"
 9582	rotten spinning half double fruitcake	4	crappy	Last Available: "2017-12"
-9583	toothsome massive hushed puppy	8	awesome	Last Available: "2017-12"
+9583	massive toothsome hushed puppy	8	awesome	Last Available: "2017-12"
 9584	half-sized flavorless wobbly muffled muffuletta	2	decent	Last Available: "2017-12"
 9585	stale blinking shushed potatoes	3	decent	Last Available: "2017-12"
 9586	plastic mime functionary of the ox	0		Muscle: +20, Last Available: "2017-12"
@@ -9464,10 +9464,10 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	good	Last Available: "2017-11"
 9594	triple-improved wobbly wishbone	0		Effect: "Tea-hee", Effect Duration: 56, Last Available: "2017-11"
-9595	hand-crafted triple-distilled ghostly Racisto Ruidoso	8	EPIC	Last Available: "2017-11"
+9595	triple-distilled hand-crafted ghostly Racisto Ruidoso	8	EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	massive adequate pulsating bran muffin	7	good	
-9598	miniature adequate blueberry muffin	2	good	
+9598	adequate miniature blueberry muffin	2	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9478,7 +9478,7 @@
 9606	green silent H	0		Last Available: "2017-12"
 9607	twirling silent I	0		Last Available: "2017-12"
 9608	silent J	0		Last Available: "2017-12"
-9609	blue bouncing silent K	0		Last Available: "2017-12"
+9609	bouncing blue silent K	0		Last Available: "2017-12"
 9610	silent L	0		Last Available: "2017-12"
 9611	skewed silent M	0		Last Available: "2017-12"
 9612	spinning silent N	0		Last Available: "2017-12"
@@ -9494,7 +9494,7 @@
 9622	skewed silent X	0		Last Available: "2017-12"
 9623	ghostly silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
-9625	spinning green crystalline cheer	0		Last Available: "2017-12"
+9625	green spinning crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	blinking warehouse key	0		Last Available: "2017-12"
 9628	yellow narrow mime pocket probe	0		Last Available: "2017-12"
@@ -9511,7 +9511,7 @@
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	blurry The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9642	jittery cyan The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9642	cyan jittery The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
@@ -9521,7 +9521,7 @@
 9649	bland nega-mushroom	3	decent	Last Available: "2017-12"
 9650	drinkable nega-mushroom wine	4	good	Last Available: "2017-12"
 9651	warmed concentrated Cheer-Up soda	0		Effect: "Greasy Flavor", Effect Duration: 24, Last Available: "2017-12"
-9652	delicious small mime army rations	2	awesome	Last Available: "2017-12"
+9652	small delicious mime army rations	2	awesome	Last Available: "2017-12"
 9653	hand-crafted shaking mime army wine	4	super ultra EPIC	Last Available: "2017-12"
 9654	dehydrated spinning mime army superserum	1		Last Available: "2017-12"
 9655	aerosolized wobbly mime army camouflage kit	0		Effect: "Salt Rockin'", Effect Duration: 68, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	moldy diet pulsating extra-toasted half sandwich	1	crappy	Last Available: "2018-12"
-9682	weak bad mulled hobo wine	2	decent	Last Available: "2018-12"
+9682	bad weak mulled hobo wine	2	decent	Last Available: "2018-12"
 9683	skewed burning newspaper	0		Last Available: "2018-12"
 9684	asbestos-lined Fonzie's cool burning paper hat	0		Moxie: +5, Experience (Moxie): +1, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2018-12"
 9685	mansplainer's educational burning cape of the sewer	0		Experience: +1, Monster Level: +15, Stench Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
@@ -9565,12 +9565,12 @@
 9693	lion tamer's groovy tinsel tights	0		Moxie Percent: +10, Experience (familiar): +2, Last Available: "2018-01"
 9694	greasy frightening wad of used tape of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Damage: +5, Sleaze Spell Damage: +10, Last Available: "2018-01"
 9695	vibrating hale silent nightlight of Tarzan of the empath	0		Experience (Muscle): +3, Maximum HP: +20, Maximum MP Percent: +10, Familiar Weight: +5
-9696	electrified aerosolized shaking bouncing sweetened reindeer fat	0		Effect: "Greasy Visage", Effect Duration: 14
+9696	electrified aerosolized bouncing shaking sweetened reindeer fat	0		Effect: "Greasy Visage", Effect Duration: 14
 9697	altered liquefied twirling olive Good 'n' Quiet	0		Effect: "Booze Goozles", Effect Duration: 60
 9698	pressed hot button candy	0		Effect: "Cat Class, Cat Style", Effect Duration: 61
 9699	family-friendly hardy hale makeshift garbage shirt	0		Maximum HP: 70, Sleaze Resistance: +1, Last Available: "2018-01"
 9700	squat gray Annie Oakley's novelty monorail ticket of Leguizamo	0		Critical Hit Percent: +20, Monster Level: +20
-9701	dehydrated teal skewed tumbling pills	1		
+9701	dehydrated skewed tumbling teal pills	1		
 9702	mixed furry pill	1		
 9703	vaporized yellow beefy pill	1		Effect: "Mercenary", Effect Duration: 20
 9704	twisted spinning excitement pill	1		
@@ -9592,9 +9592,9 @@
 9724	skewed bouncing brainy psychic's crystal ball of the businessman	0		Mysticality: +5, Meat Drop: +50, Last Available: "2018-02"
 9725	up-at-dawn Tesla psychic's pslacks	0		Adventures: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-02"
 9726	gravedigger's psychic's amulet of chilblains	0		Cold Damage: +25, Spooky Damage: +10, Last Available: "2018-02"
-9727	moldy thick maroon blurry twirling heart-shaped candy whetstone	5	crappy	Last Available: "2018-02"
+9727	thick moldy maroon blurry twirling heart-shaped candy whetstone	5	crappy	Last Available: "2018-02"
 9728	rotten Swedish massage fish	4	crappy	Last Available: "2018-02"
-9729	watered-down tolerable Third Base	2	good	Last Available: "2018-02"
+9729	tolerable watered-down Third Base	2	good	Last Available: "2018-02"
 9730	smooth fancy Bustle Hustler	4	awesome	Effect: "Crusty Head", Effect Duration: 45, Last Available: "2018-02"
 9731	triple-oxidized colloidal Fabiotion	0		Effect: "Florid Cheeks", Effect Duration: 40, Last Available: "2018-02"
 9732	denatured double-modified Bettie page	0		Effect: "Three Days Slow", Effect Duration: 18, Last Available: "2018-02"
@@ -9612,7 +9612,7 @@
 9744	frozen quantum shaking mystery lollipop	0		Effect: "Preemptive Medicine", Effect Duration: 52
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	moist chilled rhinestone	0		Effect: "Dreams and Lights", Effect Duration: 55
-9747	narrow red 1,960 pok&eacute;dollar bill	0		
+9747	red narrow 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	green riboflavin	0		
 9750	bronze	0		
@@ -9641,29 +9641,29 @@
 9773	Cycloney	0		Last Available: "2018-03"
 9774	jittery Peaclock	0		Last Available: "2018-03"
 9775	Turtive	0		Last Available: "2018-03"
-9776	jittery yellow Lepardner	0		Last Available: "2018-03"
+9776	yellow jittery Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
 9779	Gorillape	0		Last Available: "2018-03"
-9780	ghostly jittery Wendtigo	0		Last Available: "2018-03"
-9781	teal twirling Snoutlet	0		Last Available: "2018-03"
+9780	jittery ghostly Wendtigo	0		Last Available: "2018-03"
+9781	twirling teal Snoutlet	0		Last Available: "2018-03"
 9782	lime green Ruffalo	0		Last Available: "2018-03"
-9783	spinning ghostly Vaporpoise	0		Last Available: "2018-03"
+9783	ghostly spinning Vaporpoise	0		Last Available: "2018-03"
 9784	ghostly Ghosprey	0		Last Available: "2018-03"
 9785	skewed Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
-9787	huge tumbling cyan Mustardigrade	0		Last Available: "2018-03"
+9787	cyan huge tumbling Mustardigrade	0		Last Available: "2018-03"
 9788	Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
-9791	blinking twirling Bicycle	0		Last Available: "2018-03"
+9791	twirling blinking Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
 9794	skewed Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	mirror Ungulant	0		Last Available: "2018-03"
 9797	upside-down Caramel	0		Last Available: "2018-03"
-9798	blinking shaking Oppossum	0		Last Available: "2018-03"
+9798	shaking blinking Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
 9800	narrow Smashmoth	0		Last Available: "2018-03"
 9801	ghostly Vulgure	0		Last Available: "2018-03"
@@ -9695,7 +9695,7 @@
 9827	gray rocket	0		
 9828	altered blurry magnificent oyster egg	1		
 9829	vaporized mirror brilliant oyster egg	1		
-9830	pickled jittery maroon glistening oyster egg	1		
+9830	pickled maroon jittery glistening oyster egg	1		
 9831	twisted blinking scintillating oyster egg	1		Effect: "Halloweeny", Effect Duration: 45
 9832	dehydrated shaking pearlescent oyster egg	1		
 9833	powdered lustrous oyster egg	1		
@@ -9728,14 +9728,14 @@
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	squat fuchsia LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	decent FantasyRealm turkey leg	4	good	Last Available: "2018-04"
-9863	drinkable watered-down FantasyRealm mead	2	good	Last Available: "2018-04"
+9863	watered-down drinkable FantasyRealm mead	2	good	Last Available: "2018-04"
 9864	narrow nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	upside-down hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	spoiled big druidic s'more	5	crappy	Last Available: "2018-04"
-9870	distilled bouncing huge gray sachet of powder	1		Last Available: "2018-04"
+9870	distilled huge bouncing gray sachet of powder	1		Last Available: "2018-04"
 9871	bad weak mourning wine	2	decent	Last Available: "2018-04"
 9872	mirror ghostly sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	blinking map to the Cursed Village	0		Last Available: "2018-04"
 9877	spinning map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	half-sized flavorless squat denastified haunch	2	decent	Last Available: "2018-04"
-9879	perfectly mixed practically non-alcoholic shaking bad rum and good cola	1	EPIC	Last Available: "2018-04"
+9879	practically non-alcoholic perfectly mixed shaking bad rum and good cola	1	EPIC	Last Available: "2018-04"
 9880	nitrogenated cold-filtered Potion of Heroism	0		Effect: "Got Your Boots On", Effect Duration: 11, Last Available: "2018-04"
 9881	steel-toed dance instructor's Sinatra's leggings of the Spider Queen	0		Experience (Moxie): +5, Experience Percent (Moxie): +10, Damage Reduction: 9, Last Available: "2018-04"
 9882	greasy personal trainer's Master Thief's utility belt of courage	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +10, Spooky Resistance: +3, Single Equip, Last Available: "2018-04"
@@ -9763,7 +9763,7 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	bouncing dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	bad weak blinking two meat muck	2	decent	
+9898	weak bad blinking two meat muck	2	decent	
 9899	spoiled tiny chocolate Ogre Chieftain	1	crappy	
 9900	rotten twirling chocolate &quot;Phoenix&quot;	3	crappy	
 9901	moldy squat chocolate Spider Queen	3	crappy	
@@ -9778,19 +9778,19 @@
 9910	Garland of Greatness	0		
 9911	gattoo	0		
 9912	A-Boo glue	0		
-9913	squat huge skewed glued A-Boo clue	0		
+9913	huge squat skewed glued A-Boo clue	0		
 9914	mirror crude oil congealer	0		
 9915	flavorless good guava	3	decent	
 9916	artisanal distilled gin and ginger	5	EPIC	
 9917	wobbly Thwaitgold chigger statuette	0		
-9918	distilled pulsating lime green gaseous gravy	1		
+9918	distilled lime green pulsating gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	squat A Guide to Safari	0		Skill: "Experience Safari"
 9922	pickled Shielding Potion	0		Effect: "Mortarfied", Effect Duration: 62, Last Available: "2018-06"
 9923	energized Punching Potion	0		Effect: "Neutered Nostrils", Effect Duration: 57, Last Available: "2018-06"
 9924	squat Special Seasoning	0		Last Available: "2018-06"
-9925	pickled bouncing tumbling purple Nightmare Fuel	1		Last Available: "2018-06"
+9925	pickled purple tumbling bouncing Nightmare Fuel	1		Last Available: "2018-06"
 9926	olive Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	narrow Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9813,7 +9813,7 @@
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	distilled lousy Middle of the Road&trade; brand whiskey	5	decent	Last Available: "2018-09"
+9948	lousy distilled Middle of the Road&trade; brand whiskey	5	decent	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	shaking inspector's resourceful pentagram bandana	0		Maximum MP: +50, Item Drop: +15, Last Available: "2018-09"
 9951	slick skull ring	0		Moxie: +10, Single Equip, Last Available: "2018-09"
@@ -9821,7 +9821,7 @@
 9953	normal PB&J with the crusts cut off	3	good	Last Available: "2018-09"
 9954	clever dorky glasses of courage	0		Maximum MP: +20, Spooky Resistance: +3, Single Equip, Last Available: "2018-09"
 9955	curative ponytail clip of the sweet-tooth	0		Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-09"
-9956	banded paint palette	0		Damage Absorption: +100, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	banded paint palette	0		Damage Absorption: +100, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	twisted skewed Purple Beast energy drink	1		Last Available: "2018-09"
 9959	scorching cosmetic football	0		Hot Damage: +25, Last Available: "2018-09"
@@ -9847,15 +9847,15 @@
 9980	snack-sized normal gray party platter for one	2	good	Last Available: "2018-09"
 9981	vaporized Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	rosewater-soaked party crasher of the ox	0		Muscle: +20, Stench Resistance: +3, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9983	rosewater-soaked party crasher of the ox	0		Muscle: +20, Stench Resistance: +3, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	spinning Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
-9986	bouncing ghostly party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9986	ghostly bouncing party mouse hat	0		Familiar Weight: +5
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	shaking latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	fuchsia blurry careful &quot;I Voted!&quot; sticker	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2018-11"
-9991	mirror lime green absentee voter ballot	0		Last Available: "2018-11"
+9991	lime green mirror absentee voter ballot	0		Last Available: "2018-11"
 9992	snake skin	0		Last Available: "2018-11"
 9993	flame-wreathed razor-sharp snakeskin thighboots	0		Weapon Damage Percent: +25, Hot Spell Damage: +10, Last Available: "2018-11"
 9994	strapping snakeskin cowboy hat of chilblains	0		Muscle: +5, Cold Damage: +25, Last Available: "2018-11"
@@ -9874,19 +9874,19 @@
 10008	lard-coated boxer's mutant legs of the overflowing toilet	0		Muscle Percent: +10, Stench Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2018-11"
 10009	chilly crafty mutant crown of mayonnaise	0		Maximum MP: +10, Cold Damage: +5, Sleaze Spell Damage: +50, Last Available: "2018-11"
 10010	bite-sized spoiled ghostly ectoplasm	1	crappy	Last Available: "2018-11"
-10011	spoiled huge mirror	7	crappy	Last Available: "2018-11"
+10011	huge spoiled mirror	7	crappy	Last Available: "2018-11"
 10012	mediocre cyan bottle of vodka	4	decent	Last Available: "2018-11"
 10013	yummy tiny pizza	1	awesome	Last Available: "2018-11"
 10014	high-proof hand-crafted martini	6	EPIC	Last Available: "2018-11"
 10015	spoiled cherry pie	3	crappy	Last Available: "2018-11"
-10016	irresponsibly strong drinkable eggnog	7	good	Last Available: "2018-11"
+10016	drinkable irresponsibly strong eggnog	7	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	bland Hell ramen	3	decent	Last Available: "2018-11"
-10019	weak bad blurry blue gimlet	2	decent	Last Available: "2018-11"
+10019	bad weak blurry blue gimlet	2	decent	Last Available: "2018-11"
 10020	mediocre twice-haunted screwdriver	4	decent	Last Available: "2018-11"
-10021	delicious half-sized candy cane	2	awesome	Last Available: "2018-12"
+10021	half-sized delicious candy cane	2	awesome	Last Available: "2018-12"
 10022	drinkable runny fermented egg	3	good	Last Available: "2018-12"
-10023	stale low-calorie oldcake	1	decent	Last Available: "2018-12"
+10023	low-calorie stale oldcake	1	decent	Last Available: "2018-12"
 10024	spoiled traditional Crimbo cookie	4	crappy	Last Available: "2023-06"
 10025	rosewater-soaked plastic wild beaver	0		Stench Resistance: +3, Last Available: "2018-12"
 10026	red plastic reindeer of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2018-12"
@@ -9903,13 +9903,13 @@
 10037	ghostly plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	bland super-sized maroon grilled mooseflank	5	decent	Last Available: "2018-12"
-10040	huge normal moosemeat pie	10	good	Last Available: "2018-12"
+10040	normal huge moosemeat pie	10	good	Last Available: "2018-12"
 10041	sizzling balanced antler	0		Hot Damage: +10, Last Available: "2018-12"
 10042	squat miser's dam	0		Meat Drop: +10, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable triple-distilled beavermouth	7	good	Last Available: "2018-12"
-10044	mediocre watered-down beaver punch (papaya)	2	decent	Last Available: "2018-12"
+10044	watered-down mediocre beaver punch (papaya)	2	decent	Last Available: "2018-12"
 10045	bad twirling beaver punch (peach)	4	decent	Last Available: "2018-12"
-10046	weak artisanal beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
+10046	artisanal weak beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
 10047	sharpshooter's wholesome Canadian lantern	0		Maximum HP Percent: +10, Critical Hit Percent: +10, Last Available: "2018-12"
 10048	shaking bouncing sizzling muskox-skin cap	0		Hot Damage: +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9927,7 +9927,7 @@
 10061	shaking blue cool red-hot sausage fork of Gandalf	0		Moxie: +5, Spell Critical Percent: +20, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
-10064	jittery yellow jar of relish	0		Familiar Weight: +5
+10064	yellow jittery jar of relish	0		Familiar Weight: +5
 10065	squat Toyleporter	0		Last Available: "2018-12"
 10066	drinkable beer	3	good	Last Available: "2018-12"
 10067	adequate yule gruel	3	good	Last Available: "2018-12"
@@ -9939,7 +9939,7 @@
 10073	fuchsia Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	ghostly Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10076	cyan wobbly Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10076	wobbly cyan Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	teal Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	shaking Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	tumbling crafty baleful Crimbolex watch of James Dean	0		Experience (Moxie): +3, Spell Damage: +25, Maximum MP: +10, Single Equip, Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	blurry flame-retardant stanky marble mariachi hat	0		Stench Spell Damage: +25, Hot Resistance: +1, Last Available: "2019-12"
 10096	mixed marble molecules	1		Last Available: "2019-12"
 10097	nitrogenated wet moist blue Mallomarbles	0		Effect: "Grumpy and Ornery", Effect Duration: 65
-10098	cool punching bag of Calamity Jane	0		Moxie: +5, Critical Hit Percent: +15, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	blurry shaking Usain Bolt's flame-retardant pith helmet	0		Hot Resistance: +1, Initiative: +80, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	manspreader's poncho of the blizzard	0		Monster Level: +10, Cold Spell Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	ghostly censurious scandalous pendant	0		Sleaze Damage: +5, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	executive palazzos of bravery	0		Spooky Resistance: +5, Meat Drop: +40, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	squat miser's extremely unsafe pseudoaccordion	0		Weapon Damage Percent: +100, Meat Drop: +10, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10104	boiled ghostly pulsating pieces	1		Last Available: "2020-12"
+10098	cool punching bag of Calamity Jane	0		Moxie: +5, Critical Hit Percent: +15, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	blurry shaking Usain Bolt's flame-retardant pith helmet	0		Hot Resistance: +1, Initiative: +80, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	manspreader's poncho of the blizzard	0		Monster Level: +10, Cold Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	ghostly censurious scandalous pendant	0		Sleaze Damage: +5, Sleaze Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	executive palazzos of bravery	0		Spooky Resistance: +5, Meat Drop: +40, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	squat miser's extremely unsafe pseudoaccordion	0		Weapon Damage Percent: +100, Meat Drop: +10, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10104	boiled pulsating ghostly pieces	1		Last Available: "2020-12"
 10105	flattened aerosolized Para-Pop	0		Effect: "Feline Ferocity", Effect Duration: 52
-10106	slick terra cotta truss of the dark arts	0		Moxie: +10, Spell Damage Percent: +100, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	blinking double-paned Jim Carey's terra cotta trousers	0		Monster Level: +25, Cold Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	shaking spinning studded terra cotta tongs of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	nasty occult terra cotta train	0		Spell Damage Percent: +25, Stench Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	sizzling arcane researcher's terra cotta tie tack	0		Experience Percent (Mysticality): +10, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	gravedigger's Sinatra's terra cotta tambourine	0		Experience (Moxie): +5, Spooky Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	slick terra cotta truss of the dark arts	0		Moxie: +10, Spell Damage Percent: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	blinking double-paned Jim Carey's terra cotta trousers	0		Monster Level: +25, Cold Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	shaking spinning studded terra cotta tongs of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	nasty occult terra cotta train	0		Spell Damage Percent: +25, Stench Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	sizzling arcane researcher's terra cotta tie tack	0		Experience Percent (Mysticality): +10, Hot Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	gravedigger's Sinatra's terra cotta tambourine	0		Experience (Moxie): +5, Spooky Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	diluted terra cotta tidbits	1		Effect: "Stinking Cloud", Effect Duration: 25, Last Available: "2020-12"
 10113	diffused anodized skewed terra panna cotta	0		Effect: "Bananas!", Effect Duration: 12
 10114	horrifying extremely unsafe velour voulge	0		Weapon Damage Percent: +100, Spooky Damage: +25, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	frightening glass serape of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Last Available: "2021-12"
 10128	pickled upside-down glass shards	1		Effect: "Joyful Resolve", Effect Duration: 20, Last Available: "2021-12"
 10129	dry denatured hard candy	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 53
-10130	mirror personal trainer's stylish loofah lumberjack's hat	0		Moxie: +25, Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	nasty personal trainer's loofah lei	0		Experience Percent (Muscle): +10, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	blurry Sinatra's loofah lederhosen of courage	0		Experience (Moxie): +5, Spooky Resistance: +3, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	auspicious loofah ladle of dire peril	0		Weapon Damage: +20, Item Drop: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	huge loofah legwarmers of the scaredy-cat of doom	0		Monster Level: -15, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	chilly sharpshooter's loofah lavalier	0		Critical Hit Percent: +10, Cold Damage: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	mirror personal trainer's stylish loofah lumberjack's hat	0		Moxie: +25, Experience Percent (Muscle): +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	nasty personal trainer's loofah lei	0		Experience Percent (Muscle): +10, Stench Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	blurry Sinatra's loofah lederhosen of courage	0		Experience (Moxie): +5, Spooky Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	auspicious loofah ladle of dire peril	0		Weapon Damage: +20, Item Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	huge loofah legwarmers of the scaredy-cat of doom	0		Monster Level: -15, Spooky Spell Damage: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	chilly sharpshooter's loofah lavalier	0		Critical Hit Percent: +10, Cold Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	dehydrated pulsating loofah lumps	1		Last Available: "2022-12"
 10137	Vulcanized anodized chocolate-covered loofah	0		Effect: "Cold Hands", Effect Duration: 28
-10138	frightening frosty flagstone flag	0		Cold Spell Damage: +10, Spooky Damage: +5, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	jittery prompt stanky flagstone flail	0		Stench Spell Damage: +25, Adventures: +3, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	family-friendly extremely unsafe flagstone flip-flops	0		Weapon Damage Percent: +100, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	cyan inspector's flagstone fez of chilblains	0		Cold Damage: +25, Item Drop: +15, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	huge squat electrified flagstone fleece of the sewer	0		Stench Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	inspector's flagstone fringe of Leguizamo	0		Monster Level: +20, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	frightening frosty flagstone flag	0		Cold Spell Damage: +10, Spooky Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	jittery prompt stanky flagstone flail	0		Stench Spell Damage: +25, Adventures: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	family-friendly extremely unsafe flagstone flip-flops	0		Weapon Damage Percent: +100, Sleaze Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	cyan inspector's flagstone fez of chilblains	0		Cold Damage: +25, Item Drop: +15, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	huge squat electrified flagstone fleece of the sewer	0		Stench Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	inspector's flagstone fringe of Leguizamo	0		Monster Level: +20, Item Drop: +15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	altered flagstone flagments	1		Effect: "No Worries", Effect Duration: 20, Last Available: "2022-12"
 10145	denatured dry irradiated squat Flag by the Foot&trade;	0		Effect: "Nigh-Invincible", Effect Duration: 11
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10029,23 +10029,23 @@
 10163	unsweetened vacuum-sealed government-issued candy	0		Effect: "Weasels Underfoot", Effect Duration: 24
 10164	warmed activated mirror Pneumo bar	0		Effect: "Become Superficially interested", Effect Duration: 16
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	blue sage Lil' Doctor&trade; bag of the ox	0		Muscle: +20, Mysticality Percent: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	blue sage Lil' Doctor&trade; bag of the ox	0		Muscle: +20, Mysticality Percent: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	adequate half-sized bloodstick	2	good	
+10169	half-sized adequate bloodstick	2	good	
 10170	spirit-forward lousy narrow bottle of Sanguiovese	5	decent	
 10171	rotten massive actual blood sausage	7	crappy	
-10172	lousy strong maroon mulled blood	5	decent	
+10172	strong lousy maroon mulled blood	5	decent	
 10173	bland blinking blood snowcone	4	decent	
 10174	perfectly mixed pulsating Red Russian	3	EPIC	
 10175	moldy tumbling maroon blood roll-up	4	crappy	
 10176	artisanal bottle of blood	3	super EPIC	
 10177	spoiled blood-soaked sponge cake	3	crappy	
-10178	practically non-alcoholic bad vampagne	1	decent	
-10179	massive flavorless jittery plain snowcone	7	decent	
+10178	bad practically non-alcoholic vampagne	1	decent	
+10179	flavorless massive jittery plain snowcone	7	decent	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
-10183	blurry pulsating money bag	0		
+10183	pulsating blurry money bag	0		
 10184	Thwaitgold mosquito statuette	0		
 10185	purple bucket of Vampyre blood	0		
 10186	huge blood knife	0		Lasts Until Rollover
@@ -10063,7 +10063,7 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	flavorless wobbly crabsicle	3	decent	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	watered-down acceptable bottle of dark rhum	2	good	Last Available: "2019-04"
+10201	acceptable watered-down bottle of dark rhum	2	good	Last Available: "2019-04"
 10202	watered-down mediocre bottle of extra-dark rhum	2	decent	Last Available: "2019-04"
 10203	special bad bottle of super-extra-dark rhum	3	decent	Effect: "Super-Charged", Effect Duration: 45, Last Available: "2019-04"
 10204	dry pirate shaving cream	0		Effect: "Block-Rockin' Beet", Effect Duration: 42, Last Available: "2019-04"
@@ -10074,19 +10074,19 @@
 10209	pulsating windicle	0		Last Available: "2019-04"
 10210	bouncing grievous stylish pirate radio ring	0		Moxie: +25, Weapon Damage Percent: +50, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	super-sized stale pineapple slab	5	decent	Last Available: "2019-04"
+10212	stale super-sized pineapple slab	5	decent	Last Available: "2019-04"
 10213	moldy huge hibiscus petal	3	crappy	Last Available: "2019-04"
 10214	chilled cyan huge mint leaf	0		Effect: "Once Bitten Twice Fried", Effect Duration: 33, Last Available: "2019-04"
 10215	ghostly cocoa of youth	0		Last Available: "2019-04"
 10216	boiled cyan ice molecule	1		Effect: "Ass Over Teakettle", Effect Duration: 50, Last Available: "2019-04"
-10217	fuchsia blurry Red Roger's reliquary	0		Last Available: "2019-04"
+10217	blurry fuchsia Red Roger's reliquary	0		Last Available: "2019-04"
 10218	pulsating Red Roger's right hand	0		Last Available: "2019-04"
 10219	ghostly Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	jittery Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
-10222	ghostly huge Red Roger's skull	0		Last Available: "2019-04"
+10222	huge ghostly Red Roger's skull	0		Last Available: "2019-04"
 10223	vaporized maroon pewter shavings	1		Last Available: "2019-04"
-10224	olive squat Red Roger tattoo kit	0		Last Available: "2019-04"
+10224	squat olive Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	squat PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	ruddy plush sea serpent	0		Maximum HP Percent: +40, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	normal pirate fork	4		Last Available: "2019-04"
@@ -10099,12 +10099,12 @@
 10234	lousy Island Hurricane	4	decent	Last Available: "2019-04"
 10235	lousy watered-down Skull Punch	2	decent	Last Available: "2019-04"
 10236	mediocre Electric Punch	3	decent	Last Available: "2019-04"
-10237	tolerable mirror ghostly Smuggler's Punch	3	good	Last Available: "2019-04"
-10238	strong drinkable Scorpion Bowl	5	good	Last Available: "2019-04"
+10237	tolerable ghostly mirror Smuggler's Punch	3	good	Last Available: "2019-04"
+10238	drinkable strong Scorpion Bowl	5	good	Last Available: "2019-04"
 10239	watered-down lousy tumbling Turtle Bowl	2	decent	Last Available: "2019-04"
 10240	mediocre narrow Cobra Bowl	3	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	huge veiny shellacked baleful weightlifter's vampyric cloake of horror	0		Muscle: +15, Spell Damage: +25, Damage Reduction: 7, Maximum HP: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	huge veiny shellacked baleful weightlifter's vampyric cloake of horror	0		Muscle: +15, Spell Damage: +25, Damage Reduction: 7, Maximum HP: +10, Spooky Spell Damage: +25, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	extra-dry altered dry jittery one piece of bubble gum	0		Effect: "Weird Vibrations", Effect Duration: 23
 10245	blue arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	red Fourth of May Cosplay Saber kit	0		Free Pull
-10251	lard-coated nippy quilted Fourth of May Cosplay Saber	0		Damage Absorption: +40, Cold Damage: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	lard-coated nippy quilted Fourth of May Cosplay Saber	0		Damage Absorption: +40, Cold Damage: +10, Sleaze Spell Damage: +25, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	shaking Thwaitgold nymph statuette	0		
-10254	wobbly shaking up-at-dawn miser's inspector's reassuring smelly flame-wreathed crafty fortified dangerous hewn moon-rune spoon of Tarzan of the scaredy-cat	0		Experience (Muscle): +3, Weapon Damage: +10, Damage Absorption: +60, Maximum MP: +10, Monster Level: -15, Hot Spell Damage: +10, Stench Spell Damage: +10, Spooky Resistance: +1, Item Drop: +15, Meat Drop: +10, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	wobbly shaking up-at-dawn miser's inspector's reassuring smelly flame-wreathed crafty fortified dangerous hewn moon-rune spoon of Tarzan of the scaredy-cat	0		Experience (Muscle): +3, Weapon Damage: +10, Damage Absorption: +60, Maximum MP: +10, Monster Level: -15, Hot Spell Damage: +10, Stench Spell Damage: +10, Spooky Resistance: +1, Item Drop: +15, Meat Drop: +10, Adventures: +5, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	wobbly cartoon harpoon	0		Last Available: "2019-06"
 10256	bouncing rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	blurry lime green Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	flame-retardant Tesla slick Beach Comb	0		Moxie: +10, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	flame-retardant Tesla slick Beach Comb	0		Moxie: +10, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	gray small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10169,8 +10169,8 @@
 10304	adequate campfire baked potato	3	good	Last Available: "2019-08"
 10305	special toothsome fuchsia campfire s'more	3	awesome	Effect: "Dirty Pear", Effect Duration: 10, Last Available: "2019-08"
 10306	stale small campfire beans	2	decent	Last Available: "2019-08"
-10307	snack-sized normal spinning campfire stew	2	good	Last Available: "2019-08"
-10308	maroon squat campfire coffee	1	good	Last Available: "2019-08"
+10307	normal snack-sized spinning campfire stew	2	good	Last Available: "2019-08"
+10308	squat maroon campfire coffee	1	good	Last Available: "2019-08"
 10309	extra-galvanized altered leftover chocolate bar	0		Effect: "Granolarrrgh", Effect Duration: 49
 10310	rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
@@ -10182,16 +10182,16 @@
 10317	signal jammer	0		Single Equip
 10318	blue low-pressure oxygen tank	0		Single Equip
 10319	bouncing Thwaitgold bombardier beetle statuette	0		
-10320	adequate snack-sized pulsating space chowder	2	good	
+10320	snack-sized adequate pulsating space chowder	2	good	
 10321	acceptable weak space wine	2	good	
 10322	The Imploded World	0		Skill: "Implode Universe"
-10323	shaking blinking packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
+10323	blinking shaking packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	teal tumbling Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	wobbly wool Fonzie's Eight Days a Week Pill Keeper of the brute	0		Muscle Percent: +30, Experience (Moxie): +1, Cold Resistance: +1, Last Available: "2019-10"
 10334	narrow unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
-10335	pulsating tumbling diabolic pizza cube	0		Last Available: "2019-11"
+10335	tumbling pulsating diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	tasty bu&ntilde;uelos Jaliscos	3	awesome	Last Available: "2019-12"
 10338	decent jumbo flan del mar	5	good	Last Available: "2019-12"
@@ -10205,7 +10205,7 @@
 10346	delicious mana-coated yams	3	awesome	Last Available: "2019-11"
 10347	decent miniature mana-basted tofurkey leg	2	good	Last Available: "2019-11"
 10348	decent mana-fortified cranberry sauce	4	good	Last Available: "2019-11"
-10349	spoiled snack-sized special teal mirror mana-stuffed herbal stuffing	2	crappy	Effect: "On Pins and Needles", Effect Duration: 50, Last Available: "2019-11"
+10349	special snack-sized spoiled mirror teal mana-stuffed herbal stuffing	2	crappy	Effect: "On Pins and Needles", Effect Duration: 50, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	corrupted tarnished wobbly patch of extra-warm fur	0		Effect: "Broken Bone Nubs", Effect Duration: 22, Last Available: "2019-12"
 10352	powdered blurry industrial lubricant	1		Effect: "Icy Composition", Effect Duration: 25, Last Available: "2019-12"
@@ -10221,7 +10221,7 @@
 10362	modified twirling Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	pickled squat non-Euclidean angle	1		Effect: "Bilious Brawn", Effect Duration: 50, Last Available: "2019-12"
-10365	flattened nitrogenated upside-down spinning peppermint syrup	0		Effect: "Bilious Brains", Effect Duration: 65, Last Available: "2019-12"
+10365	flattened nitrogenated spinning upside-down peppermint syrup	0		Effect: "Bilious Brains", Effect Duration: 65, Last Available: "2019-12"
 10366	polymerized blinking Mer-kin eyedrops	0		Effect: "Can't Be a Chooser", Effect Duration: 26, Last Available: "2019-12"
 10367	warmed tumbling extra-strength goo	0		Effect: "Pla-see-bo", Effect Duration: 34, Last Available: "2019-12"
 10368	blinking envelope full of Meat	0		Last Available: "2019-12"
@@ -10254,12 +10254,12 @@
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	moldy bowl of mernudo	3	crappy	Last Available: "2019-12"
-10398	artisanal high-proof fishelada	9	EPIC	Last Available: "2019-12"
+10398	high-proof artisanal fishelada	9	EPIC	Last Available: "2019-12"
 10399	flavorless ojo de pez burrito	3	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	tumbling waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
-10403	mirror wobbly squat waterlogged	0		Last Available: "2019-12"
+10403	mirror squat wobbly waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
 10405	green nutcracker hat of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Last Available: "2019-12"
 10406	perfumed nutcracker waistcoat of the businessman	0		Stench Resistance: +5, Meat Drop: +50, Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	perfumed Samson's Crimbylow-rise jeans	0		Experience (Muscle): +5, Stench Resistance: +5, Last Available: "2019-12"
 10423	Oprah's healthy kelp-holly drape	0		Maximum HP Percent: +20, Maximum MP Percent: +50, Last Available: "2019-12"
 10424	blinking Usain Bolt's aromatic Van der Graaf smartaleck's Staff of the Peppermint Twist	0		Moxie Percent: +30, Stench Resistance: +1, Initiative: +80, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
-10425	super-sized spoiled tempura and bean	5	crappy	Last Available: "2019-12"
+10425	spoiled super-sized tempura and bean	5	crappy	Last Available: "2019-12"
 10426	smooth tumbling salt plum sake	3	awesome	Last Available: "2019-12"
 10427	corrupted quantum mirror pressurized potion of possessiveness	0		Effect: "Inner Warmth", Effect Duration: 11, Last Available: "2019-12"
 10428	energized activated dry wobbly almond	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 55
 10429	frozen pressed handful of mixed nuts	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2019-12"
 10430	nutcracking pliers	0		
-10431	teal tumbling Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	tumbling vibrating Retrospecs of the brazier of mayonnaise	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Sleaze Spell Damage: +50, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10431	tumbling teal Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
+10432	tumbling vibrating Retrospecs of the brazier of mayonnaise	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Sleaze Spell Damage: +50, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	twirling Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	spinning family-friendly stylish smooth Powerful Glove of the sewer of the early riser	0		Moxie: 40, Stench Damage: +25, Sleaze Resistance: +1, Adventures: +7, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	spinning family-friendly stylish smooth Powerful Glove of the sewer of the early riser	0		Moxie: 40, Stench Damage: +25, Sleaze Resistance: +1, Adventures: +7, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	green enhanced signal receiver	0		
 10440	blue squat status cymbal	0		Last Available: "2020-02"
 10441	deadly smartaleck's Drip harness of the blizzard	0		Moxie Percent: +30, Weapon Damage: +5, Cold Spell Damage: +25
@@ -10301,7 +10301,7 @@
 10444	drippy snail shell	0		
 10445	adequate drippy nugget	4	drippy	
 10446	strong artisanal tumbling glass of drippy wine	5	drippy	
-10447	tasty thick drippy caviar	5	drippy	
+10447	thick tasty drippy caviar	5	drippy	
 10448	flavorless wobbly drippy plum(?)	3	drippy	
 10449	pulsating drippy stake of Flo-Jo	0		Initiative: +100, Single Equip
 10450	huge gray The Eye of the Thing in the Basement	0		
@@ -10335,7 +10335,7 @@
 10478	plastic doll arms	0		
 10479	plastic doll legs	0		
 10480	maroon rubber baby doll	0		
-10481	shaking jittery yellow Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
+10481	jittery shaking yellow Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	skewed packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	shaking plump free-range mushroom	0		Last Available: "2020-03"
@@ -10379,7 +10379,7 @@
 10522	skewed drippy bromide	0		
 10523	bouncing drippy flux	0		
 10524	drippy stein	0		
-10525	weak perfectly mixed drippy pilsner	2	drippy	
+10525	perfectly mixed weak drippy pilsner	2	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	skewed lustrous drippy orb	0		
@@ -10396,9 +10396,9 @@
 10540	yellow blinking Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	bad Ghiaccio Colada	3	decent	Last Available: "2020-05"
 10542	aged Sourfinger	3	awesome	Last Available: "2020-05"
-10543	tolerable high-proof fancy maroon Nog-on-the-Cob	7	good	Effect: "Sparkling Consciousness", Effect Duration: 45, Last Available: "2020-05"
-10544	spirit-forward lousy blurry Steamboat	5	decent	Last Available: "2020-05"
-10545	watered-down lousy Buttery Boy	2	decent	Last Available: "2020-05"
+10543	fancy high-proof tolerable maroon Nog-on-the-Cob	7	good	Effect: "Sparkling Consciousness", Effect Duration: 45, Last Available: "2020-05"
+10544	lousy spirit-forward blurry Steamboat	5	decent	Last Available: "2020-05"
+10545	lousy watered-down Buttery Boy	2	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	clown car key of extreme caution of the sewer	0		Monster Level: -25, Stench Damage: +25, Last Available: "2020-08"
 10548	blurry fireproof clever rock-hard batting cage key	0		Damage Reduction: 5, Maximum MP: +20, Hot Resistance: +3, Last Available: "2020-08"
@@ -10429,7 +10429,7 @@
 10573	squat bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
-10576	warmed quadruple-adjusted wobbly skewed salty drippy candy bar	0		Effect: "Rosewater Mark", Effect Duration: 57
+10576	warmed quadruple-adjusted skewed wobbly salty drippy candy bar	0		Effect: "Rosewater Mark", Effect Duration: 57
 10577	activated ionized twirling writhing drippy candy bar	0		Effect: "Slimed Stomach", Effect Duration: 54
 10578	quantum cold-filtered triple-modified gooey drippy candy bar	0		Effect: "Block-Rockin' Beet", Effect Duration: 52
 10579	gray baby camelCalf	0		Free Pull, Last Available: "2020-07"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	mirror flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	stiffened birch battery of the glutton	0		Damage Reduction: 1, Food Drop: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	upside-down Jeselnik's brainy ebony epee of the sweet-tooth	0		Mysticality: +5, Sleaze Damage: +25, Candy Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	censurious wool flame-wreathed weeping willow wand	0		Hot Spell Damage: +10, Cold Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	narrow cyan knitted scorching beechwood blowgun of terror	0		Hot Damage: +25, Spooky Spell Damage: +10, Cold Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	upside-down Jeselnik's brainy ebony epee of the sweet-tooth	0		Mysticality: +5, Sleaze Damage: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	censurious wool flame-wreathed weeping willow wand	0		Hot Spell Damage: +10, Cold Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	narrow cyan knitted scorching beechwood blowgun of terror	0		Hot Damage: +25, Spooky Spell Damage: +10, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	vibrating quilted Rosewater's maple magnet	0		Mysticality Percent: +30, Damage Absorption: +40, Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2020-08"
 10589	blurry Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	Jeselnik's flame-wreathed smooth hemlock helm	0		Moxie: +15, Hot Spell Damage: +10, Sleaze Damage: +25, Last Available: "2020-08"
@@ -10486,7 +10486,7 @@
 10630	jittery alabaster queen	0		Last Available: "2020-09"
 10631	purple bouncing alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
-10633	blinking blurry alabaster knight	0		Last Available: "2020-09"
+10633	blurry blinking alabaster knight	0		Last Available: "2020-09"
 10634	wobbly alabaster pawn	0		Last Available: "2020-09"
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	ghostly frightening foul-smelling beefcake's beefy Cargo Cultist Shorts	0		Muscle: 35, Stench Damage: +10, Spooky Damage: +5, Last Available: "2020-09"
@@ -10505,7 +10505,7 @@
 10649	narrow gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	spinning grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	upside-down greedy ghostling	0		Free Pull, Last Available: "2020-12"
-10652	gray blurry subscription cocoa dispenser	0		Last Available: "2020-12"
+10652	blurry gray subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	nitrogenated super-activated pulsating fortifying hot cocoa	0		Effect: "Took Eleven", Effect Duration: 49, Last Available: "2020-12"
 10654	magnetized wobbly boiling hot cocoa	0		Effect: "Capricorn Rising", Effect Duration: 39, Last Available: "2020-12"
 10655	super-polarized warmed cool hot cocoa	0		Effect: "Slimy Flavor", Effect Duration: 67, Last Available: "2020-12"
@@ -10540,12 +10540,12 @@
 10684	adjusted corrupted irradiated shaking hermedisiac cologne	0		Effect: "Memory of Smarts", Effect Duration: 54, Last Available: "2020-12"
 10685	skewed government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
-10687	lime green wobbly squat government candy shipment	0		Last Available: "2020-12"
+10687	wobbly lime green squat government candy shipment	0		Last Available: "2020-12"
 10688	narrow Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	spinning Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	blinking Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
-10692	bouncing tumbling booze drive button	0		Single Equip, Last Available: "2020-12"
+10692	tumbling bouncing booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
 10695	booze mailing list	0		Last Available: "2020-12"
@@ -10578,21 +10578,21 @@
 10722	bland drive-thru burger	4	decent	Last Available: "2020-12"
 10723	bad Boulevardier cocktail	4	decent	Last Available: "2020-12"
 10724	dry liquefied shaking Hotwire&trade; brand candy rope	0		Effect: "Lubed", Effect Duration: 47, Last Available: "2020-12"
-10725	stale small bowl full of jelly	2	decent	Last Available: "2020-12"
+10725	small stale bowl full of jelly	2	decent	Last Available: "2020-12"
 10726	practically non-alcoholic aged Eye and a Twist	1	awesome	Last Available: "2020-12"
 10727	ionized warmed Chubby and Plump bar	0		Effect: "Pumped Up", Effect Duration: 34, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	squat packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
-10732	yellow blinking fresh coat of paint	0		Last Available: "2021-12"
+10732	blinking yellow fresh coat of paint	0		Last Available: "2021-12"
 10733	twirling emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
 10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
-10739	electrified squat yellow battery (AAA)	0		Effect: "You're Not Cooking", Effect Duration: 65, Last Available: "2021-03"
+10739	electrified yellow squat battery (AAA)	0		Effect: "You're Not Cooking", Effect Duration: 65, Last Available: "2021-03"
 10740	moist irradiated battery (AA)	0		Effect: "Devil Inside", Effect Duration: 59, Last Available: "2021-03"
 10741	corrupted chilled skewed mirror battery (D)	0		Effect: "Void Between the Stars", Effect Duration: 51, Last Available: "2021-03"
 10742	ionized lime green battery (9-Volt)	0		Effect: "World's Shortest Giant", Effect Duration: 28, Last Available: "2021-03"
@@ -10600,21 +10600,21 @@
 10744	moist battery (car)	0		Effect: "Stop the Presses!", Effect Duration: 21, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	practically non-alcoholic drinkable special marshmallow bomb	1	good	Effect: "The Style... of the Future", Effect Duration: 15, Last Available: "2021-03"
+10747	drinkable practically non-alcoholic special marshmallow bomb	1	good	Effect: "The Style... of the Future", Effect Duration: 15, Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	skewed plate	0		Familiar Weight: +5
 10752	aerosolized short beer	0		Effect: "Liquidy Smoky", Effect Duration: 34, Last Available: "2021-05"
 10753	adjusted deionized quantum yellow short stack of pancakes	0		Effect: "Jerky, Boy", Effect Duration: 25, Last Available: "2021-05"
-10754	quadruple-cold-filtered unsweetened concentrated mirror huge short stick of butter	0		Effect: "Impregnabili Tea", Effect Duration: 54, Last Available: "2021-05"
+10754	quadruple-cold-filtered unsweetened concentrated huge mirror short stick of butter	0		Effect: "Impregnabili Tea", Effect Duration: 54, Last Available: "2021-05"
 10755	triple-oxidized short glass of water	0		Effect: "Pie in the Sky", Effect Duration: 60, Last Available: "2021-05"
 10756	triple-aerosolized anodized short	0		Effect: "Fudgehound", Effect Duration: 38, Last Available: "2021-05"
-10757	blurry red narrow Thwaitgold quantum bug statuette	0		
+10757	blurry narrow red Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	reassuring brawny familiar scrapbook	0		Muscle Percent: +20, Spooky Resistance: +1, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
-10760	twirling red packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
-10761	squat lime green clan underground fireworks shop	0		Last Available: "2021-07"
+10759	reassuring brawny familiar scrapbook	0		Muscle Percent: +20, Spooky Resistance: +1, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10760	red twirling packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
+10761	lime green squat clan underground fireworks shop	0		Last Available: "2021-07"
 10762	upside-down asbestos-lined Lo Pan's clever fedora-mounted fountain	0		Maximum MP: +20, Spell Critical Percent: +30, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2021-07"
 10763	squat ribald MacGyver's sombrero-mounted sparkler of the storm	0		Maximum MP Percent: +40, Maximum MP: +100, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10764	narrow Jack Frost's occult Socratic porkpie-mounted popper	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-07"
@@ -10639,7 +10639,7 @@
 10783	shaking miser's extra-wide head candle of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Lasts Until Rollover, Last Available: "2021-08"
 10784	chilled natural magick candle	0		Effect: "Mushroom Samba", Effect Duration: 64, Last Available: "2021-08"
 10785	colloidal rainbow glitter candle	0		Effect: "Ham-Fisted", Effect Duration: 11, Last Available: "2021-08"
-10786	aerosolized wet deionized purple upside-down banana candle	0		Effect: "Cool, Catlike", Effect Duration: 59, Last Available: "2021-08"
+10786	aerosolized wet deionized upside-down purple banana candle	0		Effect: "Cool, Catlike", Effect Duration: 59, Last Available: "2021-08"
 10787	diffused wobbly ear candle	0		Effect: "Perfect Hair", Effect Duration: 20, Last Available: "2021-08"
 10788	dry wobbly blue votive of confidence	0		Effect: "Mucilaginous Mentalism", Effect Duration: 14, Last Available: "2021-08"
 10789	hardy water candle	0		Maximum HP: +50, Water: 3, Lasts Until Rollover
@@ -10650,12 +10650,12 @@
 10794	rainproof barrel caulk	0		
 10795	squat pump grease	0		
 10796	bouncing packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	scorching Annie Oakley's steel-toed forbidden weightlifter's industrial fire extinguisher of the dark arts	0		Muscle: +15, Spell Damage Percent: 150, Damage Reduction: 9, Critical Hit Percent: +20, Hot Damage: +25, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	scorching Annie Oakley's steel-toed forbidden weightlifter's industrial fire extinguisher of the dark arts	0		Muscle: +15, Spell Damage Percent: 150, Damage Reduction: 9, Critical Hit Percent: +20, Hot Damage: +25, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	jittery The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	red wobbly bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
-10802	yellow upside-down French-Transylvanian Dictionary	0		Familiar Weight: +5
+10802	upside-down yellow French-Transylvanian Dictionary	0		Familiar Weight: +5
 10803	ghostly lime green packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	blue ghostly auspicious padded Socratic Daylight Shavings Helmet	0		Experience (Mysticality): +1, Damage Absorption: +20, Item Drop: +10, Last Available: "2021-11"
 10805	twirling eggwater	1	EPIC	Last Available: "2021-12"
@@ -10675,14 +10675,14 @@
 10819	thick rotten tofu pop	5	crappy	Last Available: "2021-12"
 10820	stale immense bowl of prescription candy	8	decent	Last Available: "2021-12"
 10821	yummy fishcake	3	awesome	Last Available: "2021-12"
-10822	bland tiny bone broth	1	decent	Last Available: "2021-12"
+10822	tiny bland bone broth	1	decent	Last Available: "2021-12"
 10823	normal star pop	4	good	Last Available: "2021-12"
-10824	watered-down perfectly mixed Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
-10825	artisanal irresponsibly strong Doc's Smartifying Wine	6	EPIC	Last Available: "2021-12"
+10824	perfectly mixed watered-down Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
+10825	irresponsibly strong artisanal Doc's Smartifying Wine	6	EPIC	Last Available: "2021-12"
 10826	aged gray Doc's Limbering Wine	4	awesome	Last Available: "2021-12"
 10827	hand-crafted distilled Doc's Medical-Grade Wine	5	EPIC	Last Available: "2021-12"
 10828	pickled blinking Homebodyl&trade;	1		Effect: "All Blued Up", Effect Duration: 40, Last Available: "2021-12"
-10829	distilled olive twirling shaking Extrovermectin&trade;	1		Last Available: "2021-12"
+10829	distilled olive shaking twirling Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	powdered squat Breathitin&trade;	1		Effect: "Concentrated Concentration", Effect Duration: 15, Last Available: "2021-12"
 10831	denatured twirling skewed Fleshazole&trade;	1		Effect: "Healthy, Elfy, and Wise", Effect Duration: 30, Last Available: "2021-12"
 10832	alkaline extra-vacuum-sealed anti-burn cream	0		Effect: "Angry like the Wolf", Effect Duration: 14, Last Available: "2021-12"
@@ -10691,11 +10691,11 @@
 10835	anodized irradiated mirror anti-odor cream	0		Effect: "Slimy Flavor", Effect Duration: 11, Last Available: "2021-12"
 10836	quadruple-energized dry mirror teal anti-creep cream	0		Effect: "Tenacity of the Snapper", Effect Duration: 52, Last Available: "2021-12"
 10837	nitrogenated adjusted anti-pain cream	0		Effect: "Musky", Effect Duration: 27, Last Available: "2021-12"
-10838	triple-distilled mediocre Doc's Special Reserve Wine	8	decent	Last Available: "2021-12"
-10839	super-sized stale bread pie	5	decent	Last Available: "2021-12"
-10840	practically non-alcoholic drinkable clear Russian	1	good	Last Available: "2021-12"
+10838	mediocre triple-distilled Doc's Special Reserve Wine	8	decent	Last Available: "2021-12"
+10839	stale super-sized bread pie	5	decent	Last Available: "2021-12"
+10840	drinkable practically non-alcoholic clear Russian	1	good	Last Available: "2021-12"
 10841	shaking zero-trust tanktop	0		Last Available: "2025-12"
-10842	tumbling maroon Crimbo ball	0		Last Available: "2021-12"
+10842	maroon tumbling Crimbo ball	0		Last Available: "2021-12"
 10843	huge Crimbo ball	0		Last Available: "2021-12"
 10844	gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	sinister cozy scarf	0		Spell Damage: +10, Last Available: "2021-12"
-10852	normal tiny huge Crimbo cookie	1	good	Last Available: "2023-06"
+10852	tiny normal huge Crimbo cookie	1	good	Last Available: "2023-06"
 10853	frozen tarnished wet fleshy putty	0		Effect: "Spooky Weapon", Effect Duration: 57, Last Available: "2021-12"
 10854	third ear of the glutton	0		Food Drop: +100, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10714,7 +10714,7 @@
 10858	pulsating the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	depleted Crimbonium football helmet of the sewer	0		Stench Damage: +25, Last Available: "2021-12"
-10861	yellow wobbly synthetic rock	0		Last Available: "2021-12"
+10861	wobbly yellow synthetic rock	0		Last Available: "2021-12"
 10862	rotten &quot;caramel&quot;	4	crappy	Last Available: "2021-12"
 10863	inspector's self-repairing earmuffs	0		Item Drop: +15, Last Available: "2021-12"
 10864	wobbly banded carnivorous potted plant	0		Damage Absorption: +100, Last Available: "2021-12"
@@ -10731,7 +10731,7 @@
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	flavorless meatball	3	decent	Last Available: "2021-12"
 10877	huge cloned monster	0		Last Available: "2021-12"
-10878	teal bouncing meatball machine	0		Last Available: "2021-12"
+10878	bouncing teal meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	vaporized narrow fried air	1		Effect: "Abyssal Tears", Effect Duration: 25, Last Available: "2021-12"
 10881	11-leaf clover	0		
@@ -10774,15 +10774,15 @@
 10918	upside-down Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	purple avaricious Jack Frost's vibrating June cleaver	0		Maximum MP Percent: +10, Cold Spell Damage: +50, Meat Drop: +30, Attacks Can't Miss, Last Available: "2022-06"
-10921	tolerable practically non-alcoholic Dad's brandy	1	good	Last Available: "2022-06"
+10921	practically non-alcoholic tolerable Dad's brandy	1	good	Last Available: "2022-06"
 10922	mirror toasty banded teacher's pen	0		Damage Absorption: +100, Hot Damage: +5, Last Available: "2022-06"
-10923	moldy snack-sized fire-roasted lake trout	2	crappy	Last Available: "2022-06"
-10924	flavorless massive guilty sprout	10	decent	Last Available: "2022-06"
+10923	snack-sized moldy fire-roasted lake trout	2	crappy	Last Available: "2022-06"
+10924	massive flavorless guilty sprout	10	decent	Last Available: "2022-06"
 10925	wholesome savvy mother's necklace	0		Mysticality Percent: +20, Maximum HP Percent: +10, Last Available: "2022-06"
 10926	electrified flattened trampled ticket stub	0		Effect: "The Style... of the Future", Effect Duration: 33, Last Available: "2022-06"
 10927	boiled fuchsia savings bond	0		Effect: "All Blued Up", Effect Duration: 57, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	narrow designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	narrow designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	twisted maroon sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10797,19 +10797,19 @@
 10941	magnetized Dino DNAde&trade;	0		Effect: "Human-Hippy Hybrid", Effect Duration: 53
 10942	dinosaur repellent	0		
 10943	bouncing smooth camouflage vest	0		Moxie: +15
-10944	ghostly upside-down Dinodollar	0		
+10944	upside-down ghostly Dinodollar	0		
 10945	valuable dinosaur droppings	0		
 10946	jittery dinosaur pheromone kit	0		
 10947	up-at-dawn prompt cool awkward dinosaur research harness	0		Moxie: +5, Adventures: 8
 10948	reflective vest of Leguizamo	0		Monster Level: +20
 10949	educational dinosaur	0		Experience: +1
-10950	lime green squat Thwaitgold mosquito-in-amber statuette	0		
+10950	squat lime green Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	fuchsia Usain Bolt's fortified Jurassic Parka	0		Damage Absorption: +60, Initiative: +80, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	fuchsia Usain Bolt's fortified Jurassic Parka	0		Damage Absorption: +60, Initiative: +80, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	tarnished autumn leaf	0		Effect: "familiar.enq", Effect Duration: 38, Last Available: "2022-10"
-10956	high-proof lousy pulsating AutumnFest ale	8	decent	Last Available: "2022-10"
+10956	lousy high-proof pulsating AutumnFest ale	8	decent	Last Available: "2022-10"
 10957	spinning manspreader's deadly autumn sweater-weather sweater of mayonnaise	0		Weapon Damage: +5, Monster Level: +10, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2022-10"
 10958	huge Temple Grandin's manspreader's sage autumn debris shield of incineration	0		Mysticality Percent: +10, Monster Level: +10, Familiar Weight: +7, Hot Spell Damage: +50, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	stale autumn-spice donut	3	decent	Last Available: "2022-10"
@@ -10818,7 +10818,7 @@
 10962	modified autumn breeze	1		Last Available: "2022-10"
 10963	energized autumn years wisdom	0		Effect: "Hot Buttoned", Effect Duration: 20, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	lousy enchanted Oopsie IPA	4	decent	Effect: "Rushtacean'", Effect Duration: 45, Last Available: "2022-10"
+10965	enchanted lousy Oopsie IPA	4	decent	Effect: "Rushtacean'", Effect Duration: 45, Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10827,10 +10827,10 @@
 10971	normal Jarlsberg's vegetable soup	3	good	Last Available: "2022-11"
 10972	miniature adequate roasted vegetable of Jarlsberg	2	good	Last Available: "2022-11"
 10973	flavorless St. Pete's sneaky smoothie	3	decent	Last Available: "2022-11"
-10974	small adequate Pete's wiley whey bar	2	good	Last Available: "2022-11"
-10975	miniature normal Pete's rich ricotta	2	good	Last Available: "2022-11"
-10976	spirit-forward drinkable Boris's beer	5	good	Last Available: "2022-11"
-10977	spoiled fancy teal honey bun of Boris	4	crappy	Effect: "Seeing Colors", Effect Duration: 50, Last Available: "2022-11"
+10974	adequate small Pete's wiley whey bar	2	good	Last Available: "2022-11"
+10975	normal miniature Pete's rich ricotta	2	good	Last Available: "2022-11"
+10976	drinkable spirit-forward Boris's beer	5	good	Last Available: "2022-11"
+10977	fancy spoiled teal honey bun of Boris	4	crappy	Effect: "Seeing Colors", Effect Duration: 50, Last Available: "2022-11"
 10978	spoiled bite-sized mirror Boris's bread	1	crappy	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
@@ -10841,19 +10841,19 @@
 10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
 10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	blue Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
-10988	toothsome gigantic enchanted lime green baked veggie ricotta casserole	10	awesome	Effect: "Lubed", Effect Duration: 30, Last Available: "2022-11"
+10988	toothsome enchanted gigantic lime green baked veggie ricotta casserole	10	awesome	Effect: "Lubed", Effect Duration: 30, Last Available: "2022-11"
 10989	rotten plain calzone	3	crappy	Last Available: "2022-11"
 10990	tasty roasted vegetable focaccia	3	awesome	Last Available: "2022-11"
-10991	bland gray narrow Pizza of Legend	3	decent	Last Available: "2022-11"
-10992	enchanted spoiled Calzone of Legend	4	crappy	Effect: "The Halls of Muscularity", Effect Duration: 25, Last Available: "2022-11"
+10991	bland narrow gray Pizza of Legend	3	decent	Last Available: "2022-11"
+10992	spoiled enchanted Calzone of Legend	4	crappy	Effect: "The Halls of Muscularity", Effect Duration: 25, Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
 10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
 10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	huge upside-down Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10997	upside-down huge Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	flavorless snack-sized skewed Deep Dish of Legend	2	decent	Last Available: "2022-11"
+11000	snack-sized flavorless skewed Deep Dish of Legend	2	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	purple government per-diem	0		
@@ -10873,14 +10873,14 @@
 11017	hand-crafted weak fancy Mysterious Stranger	2	EPIC	Effect: "Nothing Is Impossible", Effect Duration: 50
 11018	practically non-alcoholic smooth Champagne Shimmy	1	awesome	
 11019	red the Sot's parcel	0		
-11020	twirling lion tamer's veiny ceramic cestus	0		Maximum HP: +10, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	inspector's frosty dangerous ceramic centurion shield	0		Weapon Damage: +10, Cold Spell Damage: +10, Item Drop: +15, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	ceramic celery grater of extreme caution of the businessman	0		Monster Level: -25, Meat Drop: +50, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	zippy foul-smelling brawny ceramic celsiturometer	0		Muscle Percent: +20, Stench Damage: +10, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	mirror razor-sharp dangerous ceramic cerecloth belt of the early riser	0		Weapon Damage: +10, Weapon Damage Percent: +25, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	Usain Bolt's resourceful Sinatra's ceramic cenobite's robe	0		Experience (Moxie): +5, Maximum MP: +50, Initiative: +80, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	twirling lion tamer's veiny ceramic cestus	0		Maximum HP: +10, Experience (familiar): +2, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	inspector's frosty dangerous ceramic centurion shield	0		Weapon Damage: +10, Cold Spell Damage: +10, Item Drop: +15, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	ceramic celery grater of extreme caution of the businessman	0		Monster Level: -25, Meat Drop: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	zippy foul-smelling brawny ceramic celsiturometer	0		Muscle Percent: +20, Stench Damage: +10, Initiative: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	mirror razor-sharp dangerous ceramic cerecloth belt of the early riser	0		Weapon Damage: +10, Weapon Damage Percent: +25, Adventures: +7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	Usain Bolt's resourceful Sinatra's ceramic cenobite's robe	0		Experience (Moxie): +5, Maximum MP: +50, Initiative: +80, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	boiled wobbly ceramic scree	1		Last Available: "2023-12"
-11027	enhanced unsweetened ghostly twirling extra-hard jawbreaker	0		Effect: "Mutated", Effect Duration: 52
+11027	enhanced unsweetened twirling ghostly extra-hard jawbreaker	0		Effect: "Mutated", Effect Duration: 52
 11028	lion tamer's banded sage chiffon chevrons	0		Mysticality Percent: +10, Damage Absorption: +100, Experience (familiar): +2, Single Equip, Last Available: "2023-12"
 11029	miser's inspector's toasty chiffon chapeau	0		Hot Damage: +5, Item Drop: +15, Meat Drop: +10, Last Available: "2023-12"
 11030	lightning-fast fireproof chiffon chamberpot of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3, Initiative: +40, Last Available: "2023-12"
@@ -10891,7 +10891,7 @@
 11035	ionized chiffon lemon	0		Effect: "Slimily Sagacious", Effect Duration: 32
 11036	adequate immense chocomotive	7	good	Last Available: "2022-12"
 11037	stale blurry freightcake	3	decent	Last Available: "2022-12"
-11038	distilled fancy bad cabooze	5	decent	Effect: "Greasy Peasy", Effect Duration: 20, Last Available: "2022-12"
+11038	fancy distilled bad cabooze	5	decent	Effect: "Greasy Peasy", Effect Duration: 20, Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	medical-grade plastic passenger car	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2022-12"
 11041	upside-down ribald plastic dining car	0		Sleaze Damage: +10, Last Available: "2022-12"
@@ -10920,10 +10920,10 @@
 11064	narrow perfumed ribald sinister shoulder-mounted Trainbot	0		Spell Damage: +10, Sleaze Damage: +10, Stench Resistance: +5, Single Equip, Last Available: "2022-12"
 11065	shaking cinnamon machine oil	0		
 11066	blinking Crimbo crystal shards	0		
-11067	drinkable spirit-forward dregs of a Crimbo cocktail	5	good	
+11067	spirit-forward drinkable dregs of a Crimbo cocktail	5	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	yummy immense honey-drenched ham slice	10	awesome	
+11070	immense yummy honey-drenched ham slice	10	awesome	
 11071	bad mostly-empty bottle of cookie wine	3	decent	
 11072	delicious fancy cyan Crimbo food scraps	3	awesome	Effect: "Become Intensely interested", Effect Duration: 15
 11073	squat arm towel	0		Last Available: "2022-12"
@@ -10931,14 +10931,14 @@
 11075	blurry table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	moldy half-sized steamed oyster	2	crappy	
+11078	half-sized moldy steamed oyster	2	crappy	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	gray steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
-11083	red ghostly crystal Crimbo platter	0		
+11083	ghostly red crystal Crimbo platter	0		
 11084	lousy practically non-alcoholic Crimbosmopolitan	1	decent	Last Available: "2022-12"
-11085	half-sized rotten narrow cyan Crimbo dinner	2	crappy	Last Available: "2022-12"
+11085	half-sized rotten cyan narrow Crimbo dinner	2	crappy	Last Available: "2022-12"
 11086	squat overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10972,7 +10972,7 @@
 11117	colloidal blue glob of extra-green chlorophyll	0		Effect: "Dwarven Hardiness", Effect Duration: 33, Last Available: "2023-02"
 11118	warmed electrified mushroom	0		Effect: "Fudgehound", Effect Duration: 63, Last Available: "2023-02"
 11119	boiled wobbly five-fingered fern resin	0		Effect: "Pill Power", Effect Duration: 32, Last Available: "2023-02"
-11120	small adequate super good fruit	2	good	Last Available: "2023-02"
+11120	adequate small super good fruit	2	good	Last Available: "2023-02"
 11121	pickled blinking red energized spores	1		Last Available: "2023-02"
 11122	wholesome forbidden hot pepper	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Lantern Element: "Hot", Last Available: "2023-02"
 11123	irradiated tumbling out-of-work circus flea	0		Effect: "Papowerful", Effect Duration: 38, Last Available: "2023-02"
@@ -10985,7 +10985,7 @@
 11130	double-activated vacuum-sealed pebble of proud pyrite	0		Effect: "EVISCERATE!", Effect Duration: 15, Last Available: "2023-02"
 11131	dry tarnished red pile of gritty sand	0		Effect: "Abyssal Sweat", Effect Duration: 36, Last Available: "2023-02"
 11132	huge hollow rock	0		Last Available: "2023-02"
-11133	improved anodized skewed cyan angry agate	0		Effect: "Sweet and Red", Effect Duration: 68, Last Available: "2023-02"
+11133	improved anodized cyan skewed angry agate	0		Effect: "Sweet and Red", Effect Duration: 68, Last Available: "2023-02"
 11134	irradiated galvanized super-wet ghostly lump of loyal latite	0		Effect: "Unusual Fashion Sense", Effect Duration: 54, Last Available: "2023-02"
 11135	flavorless half-sized spinning shadow sausage	2	decent	Last Available: "2023-03"
 11136	shadow skin of James Dean of courage	0		Experience (Moxie): +3, Spooky Resistance: +3, Last Available: "2023-03"
@@ -11035,10 +11035,10 @@
 11180	skewed upside-down toasty Samson's shadow monocle of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Hot Damage: +5, Single Equip
 11181	bouncing shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	rotten low-calorie shadow hot dog	1	crappy	
-11183	weak tolerable teal shadow martini	2	good	
+11183	tolerable weak teal shadow martini	2	good	
 11184	mixed skewed shadow pill	1		
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	huge monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	irradiated pressed mirror shadow candy	0		Effect: "Nut-Rition", Effect Duration: 56
 11189	replica Mr. Accessory	0		
@@ -11062,7 +11062,7 @@
 11207	huge replica squamous polyp	0		
 11208	replica stone sphere	0		
 11209	wicked Newton's replica Greatest American Pants of the glutton	0		Experience (Mysticality): +3, Spell Damage: +5, Food Drop: +100
-11210	bouncing lime green replica organ grinder	0		
+11210	lime green bouncing replica organ grinder	0		
 11211	therapeutic boxer's cool replica Juju Mojo Mask	0		Moxie: +5, Muscle Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 11212	bouncing lightning-fast Temple Grandin's steel-toed replica Operation Patriot Shield	0		Damage Reduction: 24, Familiar Weight: +7, Initiative: +40, Conditional Skill (Equipped): "Throw Shield"
 11213	replica Libram of Resolutions	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	wobbly shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	jittery wool sharpshooter's dance instructor's Cincho de Mayo of extreme caution	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Monster Level: -25, Cold Resistance: +1, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	jittery wool sharpshooter's dance instructor's Cincho de Mayo of extreme caution	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Monster Level: -25, Cold Resistance: +1, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	upside-down dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	skewed mirror replica Little Geneticist DNA-Splicing Lab	0		
 11226	ghostly replica still grill	0		
@@ -11102,8 +11102,8 @@
 11247	replica crystal ball	0		Initiative: +50
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	upside-down perfumed chilly replica Jurassic Parka	0		Cold Damage: +5, Stench Resistance: +5
-11250	narrow bouncing replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11250	bouncing narrow replica grey gosling	0		
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	ghostly replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	miser's friendly quilted replica Cincho de Mayo of vim and vigor	0		Damage Absorption: +40, Maximum HP Percent: +50, Familiar Weight: +3, Meat Drop: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,18 +11112,18 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	ghostly greedy aromatic Tesla personal trainer's &quot;I survived Y2K&quot; T-Shirt of the dark arts of the sweet-tooth	0		Experience Percent (Muscle): +10, Spell Damage Percent: +100, Stench Resistance: +1, Meat Drop: +20, Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	skewed Jack Frost's pro skateboard of the detective	0		Cold Spell Damage: +50, Item Drop: +20, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	skewed Jack Frost's pro skateboard of the detective	0		Cold Spell Damage: +50, Item Drop: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	mansplainer's Flash Liquidizer Ultra Dousing Accessory	0		Monster Level: +15, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	mansplainer's Flash Liquidizer Ultra Dousing Accessory	0		Monster Level: +15, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	rosewater-soaked experienced cool Amulet of Perpetual Darkness of chilblains	0		Moxie: +5, Experience: +2, Cold Damage: +25, Stench Resistance: +3, Last Available: "2023-06"
 11268	huge Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
-11271	frozen boiled mirror ghostly scroll of minor invulnerability	0		Effect: "Swordholder", Effect Duration: 41, Last Available: "2023-06"
+11271	frozen boiled ghostly mirror scroll of minor invulnerability	0		Effect: "Swordholder", Effect Duration: 41, Last Available: "2023-06"
 11272	Lapis Lazuli	0		Last Available: "2023-06"
 11273	blinking Eye Agate	0		Last Available: "2023-06"
 11274	tumbling twirling Azurite	0		Last Available: "2023-06"
@@ -11133,20 +11133,20 @@
 11278	blinking Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
-11281	ghostly huge Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	extra-dry delicious Sexy Cosmo	5	awesome	Last Available: "2023-06"
+11281	huge ghostly Mr. Big's Wallet	0		Last Available: "2023-06"
+11282	delicious extra-dry Sexy Cosmo	5	awesome	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	extremely unsafe experienced red-soled high heels of dire peril	0		Experience: +2, Weapon Damage: +20, Weapon Damage Percent: +100, Last Available: "2023-06"
-11285	enchanted decent cyburger	3	good	Effect: "Thick, Sick", Effect Duration: 15, Last Available: "2025-12"
+11285	decent enchanted cyburger	3	good	Effect: "Thick, Sick", Effect Duration: 15, Last Available: "2025-12"
 11286	green lion tamer's ncle leg	0		Experience (familiar): +2
 11287	therapeutic ruddy rutabuga bag	0		Maximum HP Percent: +40, HP Regen Min: 5, HP Regen Max: 7
 11288	family-friendly mesquito proboscis	0		Sleaze Resistance: +1
 11289	blinking senate fly thorax of the cheetah	0		Initiative: +60
-11290	extra-dry blinking mirror green bug juice	0		Effect: "Spirit of Alph", Effect Duration: 65
+11290	extra-dry mirror green blinking bug juice	0		Effect: "Spirit of Alph", Effect Duration: 65
 11291	maroon spider leg	0		Item Drop: +5
 11292	beetle antenna of the wise owl	0		Mysticality: +20
 11293	studded mantis skull	0		Damage Absorption: +80
-11294	galvanized dry skewed jittery olive chitin powder	0		Effect: "Gobliny Flavor", Effect Duration: 57
+11294	galvanized dry jittery olive skewed chitin powder	0		Effect: "Gobliny Flavor", Effect Duration: 57
 11295	Lo Pan's wholesome daddy shortlegs leg	0		Maximum HP Percent: +10, Spell Critical Percent: +30
 11296	chaotic smooth birdybug antenna	0		Moxie: +15, Spell Critical Percent: +10
 11297	upside-down boxer's kilopede skull of chilblains	0		Muscle Percent: +10, Cold Damage: +25
@@ -11182,7 +11182,7 @@
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	denatured cyan jittery concentrated cooking	1		
 11329	vaporized tumbling meat	1		
-11330	dehydrated skewed blue sparkling orb	1		
+11330	dehydrated blue skewed sparkling orb	1		
 11331	modified spinning hardening cream	1		
 11332	vaporized upside-down pool shark hair oil	1		Effect: "Waxing", Effect Duration: 5
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11230,7 +11230,7 @@
 11375	narrow Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	blue housekeeping robot	0		
-11378	bland ghostly blinking twirling pickled bread	4	decent	Last Available: "2023-12"
+11378	bland ghostly twirling blinking pickled bread	4	decent	Last Available: "2023-12"
 11379	flavorless upside-down salted mutton	3	decent	Last Available: "2023-12"
 11380	bland maroon corned beet	3	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11274,12 +11274,12 @@
 11419	Elf Guard broom of the glutton	0		Item Drop: +5, Food Drop: +100, Last Available: "2023-12"
 11420	knitted Temple Grandin's Crimbuccaneer tavern swab of the sewer	0		Familiar Weight: +7, Stench Damage: +25, Cold Resistance: +3, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	smooth watered-down pulsating old-school pirate grog	2	awesome	Last Available: "2023-12"
-11423	rotten super-sized special wobbly grog nuts	5	crappy	Effect: "Charrrming", Effect Duration: 35, Last Available: "2023-12"
+11422	watered-down smooth pulsating old-school pirate grog	2	awesome	Last Available: "2023-12"
+11423	super-sized special rotten wobbly grog nuts	5	crappy	Effect: "Charrrming", Effect Duration: 35, Last Available: "2023-12"
 11424	lard-coated gravedigger's weightlifter's sawed-off blunderbuss	0		Muscle: +15, Spooky Damage: +10, Sleaze Spell Damage: +25, Last Available: "2023-12"
-11425	weak drinkable officer's nog	2	good	Last Available: "2023-12"
+11425	drinkable weak officer's nog	2	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	normal half-sized sundae ration	2	good	Last Available: "2023-12"
+11427	half-sized normal sundae ration	2	good	Last Available: "2023-12"
 11428	delicious jumbo peppermint tack	5	awesome	Last Available: "2023-12"
 11429	skewed Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	moldy skewed whalesteak	3	crappy	Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	resourceful veiny grievous beefy Elf dessert spoon of the detective	0		Muscle: +10, Weapon Damage Percent: +50, Maximum HP: +10, Maximum MP: +50, Item Drop: 25, Last Available: "2023-12"
 11453	twirling tumbling reassuring smelly Elf Guard SCUBA tank	0		Stench Spell Damage: +10, Spooky Resistance: +1, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	maroon executive groovy free boots	0		Moxie Percent: +10, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	maroon executive groovy free boots	0		Moxie Percent: +10, Meat Drop: +40, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	squat sizzling Van der Graaf smartaleck's Elvish underarmor	0		Moxie Percent: +30, Hot Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2023-12"
 11458	red smelly brainy Crimbuccaneer bombjacket	0		Mysticality: +5, Stench Spell Damage: +10, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	bland super-sized sugarplum ration	5	decent	Last Available: "2023-12"
+11459	super-sized bland sugarplum ration	5	decent	Last Available: "2023-12"
 11460	adequate gingerbread nylons	4	good	Last Available: "2023-12"
 11461	rotten rum-soaked fruitcake	4	crappy	Last Available: "2023-12"
 11462	rotten lime	3	crappy	Last Available: "2023-12"
-11463	gigantic adequate gingerbread pirate	10	good	Last Available: "2023-12"
+11463	adequate gigantic gingerbread pirate	10	good	Last Available: "2023-12"
 11464	decent fruit-stuffed rumcake	3	good	Last Available: "2023-12"
 11465	tolerable mulled wine	3	good	Last Available: "2023-12"
 11466	drinkable jittery Swedish coffee	3	good	Last Available: "2023-12"
 11467	hand-crafted jittery canteen of eggnog	3	super EPIC	Last Available: "2023-12"
 11468	hand-crafted blue hot wine	3	EPIC	Last Available: "2023-12"
 11469	hand-crafted twirling Jamaican coffee	3	EPIC	Last Available: "2023-12"
-11470	drinkable weak skewed flask of egggrog	2	good	Last Available: "2023-12"
+11470	weak drinkable skewed flask of egggrog	2	good	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	tolerable practically non-alcoholic yule grog	1	good	Last Available: "2023-12"
+11474	practically non-alcoholic tolerable yule grog	1	good	Last Available: "2023-12"
 11475	bland wet tack	4	decent	Last Available: "2023-12"
 11476	bland whalecake	3	decent	Last Available: "2023-12"
-11477	mirror scorching Van der Graaf deadly gunwale whalegun	0		Weapon Damage: +5, Hot Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11477	mirror scorching Van der Graaf deadly gunwale whalegun	0		Weapon Damage: +5, Hot Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	hand-crafted and claret	3	super EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	blurry trick coin	0		Last Available: "2023-12"
-11481	hardened extremely unsafe Elf Guard squirtgun	0		Weapon Damage Percent: +100, Damage Reduction: 3, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	hardened extremely unsafe Elf Guard squirtgun	0		Weapon Damage Percent: +100, Damage Reduction: 3, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	blue chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	pulsating razor-sharp sequin-encrusted sweater	0		Weapon Damage Percent: +25, Last Available: "2023-12"
 11484	fuchsia up-at-dawn prompt horrifying replica Elf Guard medal	0		Spooky Damage: +25, Adventures: 8, Last Available: "2023-12"
@@ -11356,13 +11356,13 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	non-nitrogenated military candy cane	0		Effect: "The Living Hitpoints", Effect Duration: 28
 11503	wet twirling groggipop	0		Effect: "Infernal Thirst", Effect Duration: 65
-11504	blurry savvy moss mace of Tarzan	0		Mysticality Percent: +20, Experience (Muscle): +3, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	ribald supercharged moss megaphone	0		Maximum MP Percent: +30, Sleaze Damage: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	Fonzie's strapping moss medal	0		Muscle: +5, Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	huge flame-retardant moss mitre of doom	0		Spooky Spell Damage: +50, Hot Resistance: +1, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	supercharged moss mantle of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	blurry savvy moss mace of Tarzan	0		Mysticality Percent: +20, Experience (Muscle): +3, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	ribald supercharged moss megaphone	0		Maximum MP Percent: +30, Sleaze Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	Fonzie's strapping moss medal	0		Muscle: +5, Experience (Moxie): +1, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	huge flame-retardant moss mitre of doom	0		Spooky Spell Damage: +50, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	supercharged moss mantle of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	upside-down clever moss marlinspike of horror	0		Maximum MP: +20, Spooky Spell Damage: +25, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	altered twirling cyan mirror moss mulch	1		Last Available: "2024-12"
+11510	altered cyan twirling mirror moss mulch	1		Last Available: "2024-12"
 11511	dry cyan shaking moss floss	0		Effect: "Dance Interpreter", Effect Duration: 48
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	shaking adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11372,12 +11372,12 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	powdered gray adobe assortment	1		Last Available: "2024-12"
 11519	super-pressed adobe brittle	0		Effect: "Robocamo", Effect Duration: 28
-11520	sharpshooter's veiny Newton's crepe paper phrygian cap	0		Experience (Mysticality): +3, Maximum HP: +10, Critical Hit Percent: +10, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	sharpshooter's veiny Newton's crepe paper phrygian cap	0		Experience (Mysticality): +3, Maximum HP: +10, Critical Hit Percent: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	pulsating blinking prompt crepe paper parachute cape of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Adventures: +3, Last Available: "2025-12"
-11522	lime green flame-wreathed grievous Samson's crepe paper pie clip	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Hot Spell Damage: +10, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	scandalous chilly Rosewater's crepe paper puzzle cube	0		Mysticality Percent: +30, Cold Damage: +5, Sleaze Damage: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	greedy padded smooth crepe paper plunge camisole	0		Moxie: +15, Damage Absorption: +20, Meat Drop: +20, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	occult crepe paper polka charm of wisdom of the cheetah	0		Mysticality: +15, Spell Damage Percent: +25, Initiative: +60, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	lime green flame-wreathed grievous Samson's crepe paper pie clip	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Hot Spell Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	scandalous chilly Rosewater's crepe paper puzzle cube	0		Mysticality Percent: +30, Cold Damage: +5, Sleaze Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	greedy padded smooth crepe paper plunge camisole	0		Moxie: +15, Damage Absorption: +20, Meat Drop: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	occult crepe paper polka charm of wisdom of the cheetah	0		Mysticality: +15, Spell Damage Percent: +25, Initiative: +60, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	vaporized bouncing green crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	denatured nitrogenated olive crepe paper peanut candy	0		Effect: "Is This Your Card?", Effect Duration: 69
 11528	fuchsia coward's petrified wood war pike of the blizzard	0		Monster Level: -20, Cold Spell Damage: +25, Last Available: "2025-12"
@@ -11388,17 +11388,17 @@
 11533	wool petrified wood walking pants of bravery	0		Cold Resistance: +1, Spooky Resistance: +5, Last Available: "2025-12"
 11534	denatured upside-down petrified wood waste parts	1		Last Available: "2025-12"
 11535	wet narrow petrified wood wafer praline	0		Effect: "Hammered", Effect Duration: 18
-11536	high-proof artisanal cybeer	9	EPIC	Last Available: "2025-12"
+11536	artisanal high-proof cybeer	9	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	squat wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	squat encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	squat wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	squat encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	blue baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	blue prompt hardened Crimbuccaneer war standard	0		Damage Reduction: 3, Adventures: +3, Last Available: "2023-12"
 11544	fuchsia steel-toed Elf Guard war standard of horror	0		Damage Reduction: 9, Spooky Spell Damage: +25, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	blurry Usain Bolt's miser's hardened spring shoes	0		Damage Reduction: 3, Meat Drop: +10, Initiative: +80, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	blurry Usain Bolt's miser's hardened spring shoes	0		Damage Reduction: 3, Meat Drop: +10, Initiative: +80, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	ionized ultra-soft ferns	0		Effect: "Spooky Jellied", Effect Duration: 38, Last Available: "2024-02"
 11548	modified crunchy brush	0		Effect: "Hairless and Airless", Effect Duration: 38, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11427,10 +11427,10 @@
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	toothsome blue yam	4	awesome	Last Available: "2024-05"
 11574	watered-down drinkable bouncing yam martini	2	good	Last Available: "2024-05"
-11575	practically non-alcoholic hand-crafted sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
+11575	hand-crafted practically non-alcoholic sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
 11576	smooth Southern yam	3	awesome	Last Available: "2024-05"
-11577	tolerable triple-distilled sweet potato punch	10	good	Last Available: "2024-05"
-11578	snack-sized moldy Mayam spinach	2	crappy	Last Available: "2024-05"
+11577	triple-distilled tolerable sweet potato punch	10	good	Last Available: "2024-05"
+11578	moldy snack-sized Mayam spinach	2	crappy	Last Available: "2024-05"
 11579	spoiled yam and swiss	3	crappy	Last Available: "2024-05"
 11580	pulsating ribald fortified quilted yam cannon	0		Damage Absorption: 100, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,14 +11439,14 @@
 11584	upside-down censurious supercool furry yam buckler of the wise owl	0		Mysticality: +20, Moxie Percent: +20, Sleaze Resistance: +3, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	pulsating huge sharpshooter's yamtility belt of the brute of the businessman	0		Muscle Percent: +30, Critical Hit Percent: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2024-05"
-11587	snack-sized bland cyan yam slider	2	decent	Last Available: "2024-05"
+11587	bland snack-sized cyan yam slider	2	decent	Last Available: "2024-05"
 11588	bland yam mayo	3	decent	Last Available: "2024-05"
 11589	bite-sized rotten yam burrito	1	crappy	Last Available: "2024-05"
 11590	yellow visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	huge aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	special adequate mini kiwi	3	good	Effect: "Mushroom Moxiousness", Effect Duration: 15, Last Available: "2024-06"
+11594	adequate special mini kiwi	3	good	Effect: "Mushroom Moxiousness", Effect Duration: 15, Last Available: "2024-06"
 11595	spinning foul-smelling friendly coward's mini kiwi bikini	0		Monster Level: -20, Familiar Weight: +3, Stench Damage: +10, Last Available: "2024-06"
 11596	aged red mini kiwitini	3	awesome	Last Available: "2024-06"
 11597	shaking mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11461,8 +11461,8 @@
 11606	lion tamer's mini kiwi icepick	0		Experience (familiar): +2
 11607	anodized denatured bouncing mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Natural 20", Effect Duration: 13
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
-11610	upside-down gray protogenetic chunklet (synapse)	0		
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11610	gray upside-down protogenetic chunklet (synapse)	0		
 11611	olive protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
 11613	protogenetic chunklet (elbow)	0		
@@ -11470,9 +11470,9 @@
 11615	dance instructor's smooth messenger bag RNA of the empath	0		Moxie: +15, Experience Percent (Moxie): +10, Familiar Weight: +5
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	jumbo delicious bacteria bisque	5	awesome	
+11618	delicious jumbo bacteria bisque	5	awesome	
 11619	snack-sized spoiled ciliophora chowder	2	crappy	
-11620	flavorless half-sized cream of chloroplasts	2	decent	
+11620	half-sized flavorless cream of chloroplasts	2	decent	
 11621	blinking synaptic soup	0		
 11622	gray muscular soup	0		
 11623	wobbly flagellate soup	0		
@@ -11510,7 +11510,7 @@
 11655	upside-down soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	ghostly executive reassuring bat wings of extreme caution	0		Monster Level: -25, Spooky Resistance: +1, Meat Drop: +40, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	ghostly executive reassuring bat wings of extreme caution	0		Monster Level: -25, Spooky Resistance: +1, Meat Drop: +40, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	shaking ember	0		Cold Resistance: +1
 11661	chaotic veiny monocle on a stick	0		Maximum HP: +10, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,9 +11523,9 @@
 11668	narrow gray rosewater-soaked wizardly Sheriff badge	0		Mysticality: +25, Stench Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	greedy boxer's Sheriff pistol	0		Muscle Percent: +10, Meat Drop: +20, Lasts Until Rollover, Last Available: "2024-10"
 11670	bouncing mansplainer's Sheriff moustache of the boozehound	0		Monster Level: +15, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	beefcake's photo booth supply list of bravery	0		Muscle: +25, Spooky Resistance: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	beefcake's photo booth supply list of bravery	0		Muscle: +25, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
-11673	blurry pulsating spinning tie-dye headband	0		
+11673	spinning blurry pulsating tie-dye headband	0		
 11674	miniature stale whirled peas	2	decent	Last Available: "2024-11"
 11675	small decent squat lime green peaza	2	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
@@ -11533,15 +11533,15 @@
 11678	dried maroon Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	ghostly quantum watch	0		Adventures: +2
-11681	purple spinning quantized familiar experience	0		
-11682	extra-electrified huge cyan spinning pea brittle	0		Effect: "Capricorn Rising", Effect Duration: 20, Last Available: "2024-11"
+11681	spinning purple quantized familiar experience	0		
+11682	extra-electrified spinning huge cyan pea brittle	0		Effect: "Capricorn Rising", Effect Duration: 20, Last Available: "2024-11"
 11683	drinkable peasco	4	good	Last Available: "2024-11"
 11684	jumbo rotten piece of cake	5	crappy	Last Available: "2024-11"
 11685	lime green handful of split pea soup	0		Last Available: "2024-11"
 11686	huge Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	cyan rosewater-soaked supercool deft pirate hook	0		Moxie Percent: +20, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2024-12"
-11689	Annie Oakley's educational iron tricorn hat	0		Experience: +1, Critical Hit Percent: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	Annie Oakley's educational iron tricorn hat	0		Experience: +1, Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	jolly roger flag	0		Item Drop: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	skewed sleeping profane parrot	0		Last Available: "2024-12"
 11692	blue pirrrate's currrse	0		Last Available: "2024-12"
@@ -11558,7 +11558,7 @@
 11703	pet rock	0		Last Available: "2024-12"
 11704	squat groggles of horror	0		Spooky Spell Damage: +25, Last Available: "2024-12"
 11705	pirate dinghy	0		Last Available: "2024-12"
-11706	wobbly huge anchor bomb	0		Last Available: "2024-12"
+11706	huge wobbly anchor bomb	0		Last Available: "2024-12"
 11707	miser's Herculean silky pirate drawers	0		Experience (Muscle): +1, Meat Drop: +10, Last Available: "2024-12"
 11708	narrow profane eye patch	0		Sleaze Damage: +3
 11709	quadruple-liquefied warmed olive peppermint pegleg	0		Effect: "Extra Terrestrial", Effect Duration: 44, Last Available: "2024-12"
@@ -11574,16 +11574,16 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	purple Spirit of Christmas	0		Last Available: "2024-12"
-11722	big bland coney haunch	5	decent	Last Available: "2024-12"
+11722	bland big coney haunch	5	decent	Last Available: "2024-12"
 11723	frozen Vulcanized altered dark chocolate egg	0		Effect: "Bottle in front of Me", Effect Duration: 36, Last Available: "2024-12"
-11724	enchanted aged weak moai toai	2	awesome	Effect: "On Pins and Needles", Effect Duration: 30
+11724	enchanted weak aged moai toai	2	awesome	Effect: "On Pins and Needles", Effect Duration: 30
 11725	horrifying Jack Frost's Newton's moaiball	0		Experience (Mysticality): +3, Cold Spell Damage: +50, Spooky Damage: +25, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	cold-filtered vacuum-sealed adjusted four-leaf potato sprout	0		Effect: "Rat-Faced", Effect Duration: 58, Last Available: "2024-12"
 11728	Sinatra's potato jacket of wisdom	0		Mysticality: +15, Experience (Moxie): +5, Item Drop: +5, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	shaking Brandonian footlocker key	0		Last Available: "2024-12"
-11731	greasy educational military orb	0		Experience: +1, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	greasy educational military orb	0		Experience: +1, Sleaze Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	boiled ionized narrow rum ball	0		Effect: "Ninja, Please", Effect Duration: 28
 11733	gravy skin	0		Last Available: "2024-12"
 11734	friendly extremely unsafe gravyskin hat	0		Weapon Damage Percent: +100, Familiar Weight: +3, Last Available: "2024-12"
@@ -11595,23 +11595,23 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	skewed Temple Grandin's healthy perfect Christmas scarf of mayonnaise	0		Maximum HP Percent: [+20*event(December)], Familiar Weight: [+7*event(December)], Sleaze Spell Damage: [+50*event(December)], Single Equip, Last Available: "2024-12"
-11743	electrified savvy snowman-enchanting tophat	0		Mysticality Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	electrified savvy snowman-enchanting tophat	0		Mysticality Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	non-adjusted alkaline LIDAR candle	0		Effect: "Berry Berry Cold", Effect Duration: 32, Last Available: "2024-12"
 11745	crafty Da Vinci's weightlifter's Congressional Medal of Insanity	0		Muscle: +15, Experience (Mysticality): +5, Maximum MP: +10, Last Available: "2024-12"
 11746	spinning pumpkin spice whorl	0		Last Available: "2024-12"
 11747	drinkable Easter grasshopper	4	good	Last Available: "2024-12"
-11748	watered-down drinkable Irish eggnog	2	good	Last Available: "2024-12"
+11748	drinkable watered-down Irish eggnog	2	good	Last Available: "2024-12"
 11749	mediocre practically non-alcoholic blue twirling canteen of jungle juice	1	decent	Last Available: "2024-12"
 11750	triple-distilled smooth turchucken	10	awesome	Last Available: "2024-12"
 11751	smooth mechanically-mulled cider	4	awesome	Last Available: "2024-12"
 11752	fancy tolerable wobbly holiday trip around the world	3	good	Effect: "Big Flaming Whip", Effect Duration: 20, Last Available: "2024-12"
 11753	big stale chocolate ostrich egg	5	decent	Last Available: "2024-12"
-11754	yummy half-sized beef and cabbage	2	awesome	Last Available: "2024-12"
+11754	half-sized yummy beef and cabbage	2	awesome	Last Available: "2024-12"
 11755	bland candy rations	3	decent	Last Available: "2024-12"
 11756	rotten ghostly double-candied yams	4	crappy	Last Available: "2024-12"
 11757	moldy super-sized Christmas ham	5	crappy	Last Available: "2024-12"
-11758	bland narrow upside-down holiday smorgasbord	3	decent	Last Available: "2024-12"
-11759	tumbling shaking Bowl of Infinite Jelly	0		Last Available: "2024-12"
+11758	bland upside-down narrow holiday smorgasbord	3	decent	Last Available: "2024-12"
+11759	shaking tumbling Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bejazzled eyepatch of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2024-12"
 11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
 11762	cyan Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11624,26 +11624,26 @@
 11769	mirror Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	upside-down moai statuette	0		Last Available: "2024-12"
-11772	huge toasty quilted egg gun of vim and vigor of the storm	0		Damage Absorption: +40, Maximum HP Percent: +50, Maximum MP Percent: +40, Hot Damage: +5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	huge toasty quilted egg gun of vim and vigor of the storm	0		Damage Absorption: +40, Maximum HP Percent: +50, Maximum MP Percent: +40, Hot Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	knitted Socratic brainy army helmet of the detective	0		Mysticality: +5, Experience (Mysticality): +1, Cold Resistance: +3, Item Drop: +20, Last Available: "2024-12"
 11774	lime green candy egg deviler	0		Last Available: "2024-12"
 11775	yellow napkin	0		Last Available: "2024-12"
 11776	rotten Thanksgiving ration	4	crappy	Last Available: "2024-12"
-11777	weak lousy upside-down Easter eggnog	2	decent	Last Available: "2024-12"
+11777	lousy weak upside-down Easter eggnog	2	decent	Last Available: "2024-12"
 11778	vaporized clovermint	1		Effect: "Punch Another Day", Effect Duration: 30, Last Available: "2024-12"
 11779	auspicious Lo Pan's Samson's weightlifter's nylon Christmas stockings	0		Muscle: +15, Experience (Muscle): +5, Spell Critical Percent: +30, Item Drop: +10, Single Equip, Last Available: "2024-12"
 11780	skewed tattoo of two turkeys	0		Last Available: "2024-12"
 11781	enhanced triple-anodized pulsating deviled candy egg	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 50, Last Available: "2024-12"
 11782	wobbly McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	narrow greasy sizzling McHugeLarge duffel bag	0		Hot Damage: +10, Sleaze Spell Damage: +10, Last Available: "2025-01"
-11784	energetic deadly McHugeLarge left pole of the brute	0		Muscle Percent: +30, Weapon Damage: +5, Maximum MP Percent: +20, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	avaricious personal trainer's McHugeLarge right pole of the cheetah	0		Experience Percent (Muscle): +10, Meat Drop: +30, Initiative: +60, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	perfumed MacGyver's McHugeLarge left ski	0		Maximum MP: +100, Stench Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	McHugeLarge right ski of dire peril of extreme caution	0		Weapon Damage: +20, Monster Level: -25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	energetic deadly McHugeLarge left pole of the brute	0		Muscle Percent: +30, Weapon Damage: +5, Maximum MP Percent: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	avaricious personal trainer's McHugeLarge right pole of the cheetah	0		Experience Percent (Muscle): +10, Meat Drop: +30, Initiative: +60, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	perfumed MacGyver's McHugeLarge left ski	0		Maximum MP: +100, Stench Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	McHugeLarge right ski of dire peril of extreme caution	0		Weapon Damage: +20, Monster Level: -25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	1	0		Last Available: "2025-12"
 11789	huge 0	0		Last Available: "2025-12"
 11790	powdered eXpand	1		Last Available: "2025-12"
-11791	tumbling brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	tumbling brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	tumbling dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	blurry dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11651,18 +11651,18 @@
 11796	fuchsia dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	bouncing dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
-11799	blinking blurry dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
+11799	blurry blinking dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	purple cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	twirling pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	squat server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
-11810	red ghostly dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
+11810	ghostly red dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	tumbling logic grenade	0		Last Available: "2025-12"
 11812	dried psilocyber mushroom	1		Last Available: "2025-12"
 11813	tumbling dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	mirror skewed insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11716,7 +11716,7 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	denatured huge scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	mirror table tennis ball	0		Last Available: "2025-03"
-11864	smooth watered-down pint of Leprechaun Stout	2	awesome	Last Available: "2025-03"
+11864	watered-down smooth pint of Leprechaun Stout	2	awesome	Last Available: "2025-03"
 11865	distilled huge phosphor traces	1		Effect: "Innately Truthy", Effect Duration: 50, Last Available: "2025-03"
 11866	shaking crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11725,15 +11725,15 @@
 11870	bar dart	0		Last Available: "2025-03"
 11871	boiled narrow leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	rotten Heck ramen	3	crappy	Last Available: "2025-03"
-11873	half-sized flavorless burrito	2	decent	Last Available: "2025-03"
+11873	flavorless half-sized burrito	2	decent	Last Available: "2025-03"
 11874	normal small beer brat	3	good	Last Available: "2025-03"
-11875	moldy gigantic red peach pie	10	crappy	Last Available: "2025-03"
+11875	gigantic moldy red peach pie	10	crappy	Last Available: "2025-03"
 11876	adequate gigantic pulsating incredible mini-pizza	10	good	Last Available: "2025-03"
-11877	enchanted mediocre Divine sidecar	3	decent	Effect: "Thaumodynamic", Effect Duration: 45, Last Available: "2025-03"
+11877	mediocre enchanted Divine sidecar	3	decent	Effect: "Thaumodynamic", Effect Duration: 45, Last Available: "2025-03"
 11878	hand-crafted olive narrow tangarita sidecar	4	EPIC	Last Available: "2025-03"
 11879	acceptable gimlet sidecar	4	good	Last Available: "2025-03"
 11880	tolerable practically non-alcoholic vodka stratocaster sidecar	1	good	Last Available: "2025-03"
-11881	weak bad prussian cathouse sidecar	2	decent	Last Available: "2025-03"
+11881	bad weak prussian cathouse sidecar	2	decent	Last Available: "2025-03"
 11882	perfectly mixed Mon Tiki sidecar	3	EPIC	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	skewed wholesome experienced April Shower Thoughts shield	0		Experience: +2, Maximum HP Percent: +10, Damage Reduction: 6, Last Available: "2025-04"
@@ -11751,7 +11751,7 @@
 11896	wet paper eye	0		Familiar Weight: +15
 11897	olive wet shower curtain	0		Last Available: "2025-04"
 11898	nitrogenated wobbly wet paper cup	0		Effect: "Ironclad", Effect Duration: 18, Last Available: "2025-04"
-11899	alkaline modified squat bouncing wet paperback	0		Effect: "Sleazy Hands", Effect Duration: 34, Last Available: "2025-04"
+11899	alkaline modified bouncing squat wet paperback	0		Effect: "Sleazy Hands", Effect Duration: 34, Last Available: "2025-04"
 11900	spinning executive wet shower radio	0		Meat Drop: +40, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	wet shower stamp	0		Last Available: "2025-04"
 11902	ghostly birthday bloon of the brute	0		Muscle Percent: +30
@@ -11771,7 +11771,7 @@
 11916	jittery bouncing shaking sinister stylish bycocket	0		Spell Damage: +10
 11917	maroon Thwaitgold mad hatterpillar statuette	0		
 11918	wobbly packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11783,7 +11783,7 @@
 11928	ghostly pulsating really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	chocolate rations	0		
-11931	olive shaking nice nylon stockings	0		
+11931	shaking olive nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	purple Lo Pan's Allied Radio Backpack of wisdom of doom	0		Mysticality: +15, Spell Critical Percent: +30, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	huge orphaned baby skeleton	0		
@@ -11810,7 +11810,7 @@
 11955	diet decent Susie's cupcake	1	good	Last Available: "2025-08"
 11956	wobbly clock	0		Last Available: "2025-08"
 11957	nasty chaotic the gun of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +10, Stench Damage: +5, Last Available: "2025-08"
-11958	smooth boozy wine	5	awesome	Last Available: "2025-08"
+11958	boozy smooth wine	5	awesome	Last Available: "2025-08"
 11960	teal really, really nice swimming trunks	0		
 11961	squat sand penny	0		
 11962	undersea surveying goggles of extreme caution	0		Monster Level: -25, Lasts Until Rollover
@@ -11826,16 +11826,16 @@
 11972	narrow durable dolphin whistle	0		
 11973	olive Thwaitgold lobster statuette	0		
 11974	teal packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	red unblemished pearl	0		
 11977	squat wobbly auspicious dentadent	0		Item Drop: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	miser's knitted coward's mansplainer's smooth blood cubic zirconia of the sweet-tooth	0		Moxie: +15, Monster Level: -5, Cold Resistance: +3, Meat Drop: +10, Candy Drop: +100, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	miser's knitted coward's mansplainer's smooth blood cubic zirconia of the sweet-tooth	0		Moxie: +15, Monster Level: -5, Cold Resistance: +3, Meat Drop: +10, Candy Drop: +100, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	powdered yellow blood thinner	1		Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2025-10"
-12045	acceptable fortified pheromone cocktail	5	good	Last Available: "2025-10"
+12045	fortified acceptable pheromone cocktail	5	good	Last Available: "2025-10"
 12046	stale thick spinal tapas	5	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	cyan Lo Pan's occult Da Vinci's shrunken head	0		Experience (Mysticality): +5, Spell Damage Percent: +25, Spell Critical Percent: +30, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	cyan Lo Pan's occult Da Vinci's shrunken head	0		Experience (Mysticality): +5, Spell Damage Percent: +25, Spell Critical Percent: +30, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	gray small peppermint-flavored sugar walking crook	0		
 12051	squat huge knucklebone	0		
@@ -11862,7 +11862,7 @@
 12072	frosty angelbone dice	0		Cold Spell Damage: +10, Single Equip, Last Available: "2026-12"
 12073	inspector's angelbone halo of the bloodbag	0		Maximum HP: +100, Item Drop: +15, Last Available: "2026-12"
 12074	pickled angelbone fragments	1		Effect: "Ancient Protected", Effect Duration: 15, Last Available: "2026-12"
-12075	denatured enhanced twirling pulsating biblically accurate gumdrops	0		Effect: "No Worries", Effect Duration: 55
+12075	denatured enhanced pulsating twirling biblically accurate gumdrops	0		Effect: "No Worries", Effect Duration: 55
 12076	Lo Pan's Herculean devilbone helmet	0		Experience (Muscle): +1, Spell Critical Percent: +30, Last Available: "2026-12"
 12077	jittery gray zippy devilbone greaves	0		Initiative: +20, Last Available: "2026-12"
 12078	occult devilbone shinguards of courage	0		Spell Damage Percent: +25, Spooky Resistance: +3, Single Equip, Last Available: "2026-12"
@@ -11879,26 +11879,26 @@
 12121	ghostly Crymbocurrency	0		Last Available: "2025-12"
 12122	blinking wizardly extra-thick Crimbo sweater	0		Mysticality: +25, Last Available: "2025-12"
 12123	shaking The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	weak smooth Steve Abrams' Holiday Sampler Beer	2	awesome	Last Available: "2025-12"
+12124	smooth weak Steve Abrams' Holiday Sampler Beer	2	awesome	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	delicious watered-down bottle of prize-winning rum	2	awesome	Last Available: "2025-12"
+12126	watered-down delicious bottle of prize-winning rum	2	awesome	Last Available: "2025-12"
 12127	clever Herculean boxer's Santa-Slayer medal	0		Muscle Percent: +10, Experience (Muscle): +1, Maximum MP: +20, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	flattened ionized boiling bone marrow	0		Effect: "Eagle Eyes", Effect Duration: 14, Last Available: "2025-12"
 12130	colloidal blinking boiling cerebrospinal fluid	0		Effect: "Chain Chain Chains", Effect Duration: 43, Last Available: "2025-12"
 12131	polymerized corrupted boiling synovial fluid	0		Effect: "Snobby", Effect Duration: 40, Last Available: "2025-12"
 12132	sinister dangerous stylish smoldering vertebra	0		Moxie: +25, Weapon Damage: +10, Spell Damage: +10, Single Equip, Last Available: "2025-12"
-12133	skewed wobbly seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
-12135	jittery blinking smoldering bone dust	0		Last Available: "2025-12"
+12133	wobbly skewed seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12135	blinking jittery smoldering bone dust	0		Last Available: "2025-12"
 12136	blurry volatile bone bomb	0		Last Available: "2025-12"
 12137	jittery extremely unsafe deadly brainy hot boning knife	0		Mysticality: +5, Weapon Damage: +5, Weapon Damage Percent: +100, Single Equip, Last Available: "2025-12"
 12138	olive manspreader's dangerous fistbone of the brazier	0		Weapon Damage: +10, Monster Level: +10, Hot Spell Damage: +25, Last Available: "2025-12"
 12139	blurry crafty burnt bone belt of the overflowing toilet of doom	0		Maximum MP: +10, Stench Spell Damage: +50, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12140	cool scorched skull trophy	0		Moxie: +5, Last Available: "2025-12"
-12141	bland bite-sized wing bone	1	decent	Last Available: "2025-12"
+12141	bite-sized bland wing bone	1	decent	Last Available: "2025-12"
 12142	hand-crafted weak skeleton venom	4	EPIC	Last Available: "2025-12"
-12143	vaporized spinning squat spinning baked bone meal	1		Last Available: "2025-12"
+12143	vaporized spinning spinning squat baked bone meal	1		Last Available: "2025-12"
 12144	rosewater-soaked plastic skeleton rib cage	0		Stench Resistance: +3, Last Available: "2025-12"
 12145	gray plastic skeleton skull of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2025-12"
 12146	wool plastic skeleton Crimbo hat	0		Cold Resistance: +1, Last Available: "2025-12"
@@ -11926,17 +11926,17 @@
 12168	toasty ruddy vermiculite shield	0		Maximum HP Percent: +40, Hot Damage: +5, Damage Reduction: 9, Last Available: "2025-12"
 12169	ghostly hale ship's lantern	0		Maximum HP: +20, Last Available: "2025-12"
 12170	supercharged sage heat-resistant harpoon pistol	0		Mysticality Percent: +10, Maximum MP Percent: +30, Last Available: "2025-12"
-12171	decent tiny traditional gingerloaf	1	good	Last Available: "2025-12"
+12171	tiny decent traditional gingerloaf	1	good	Last Available: "2025-12"
 12172	lousy huge Scotch and eggnog	3	decent	Last Available: "2025-12"
 12173	modified counterskeleton elixir	0		Effect: "A Few Extra Pounds", Effect Duration: 14, Last Available: "2025-12"
-12174	artisanal distilled skewed &quot;salvaged&quot; wine	5	EPIC	Last Available: "2025-12"
+12174	distilled artisanal skewed &quot;salvaged&quot; wine	5	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	normal teal bouncing wedge of prize-winning cheese	3	good	Last Available: "2025-12"
 12178	magnetized quadruple-dry gummi fingerbone	0		Effect: "Towering Strength", Effect Duration: 19
 12179	lime green dangerous glimmering crystal of extreme caution	0		Weapon Damage: +10, Monster Level: -25, Last Available: "2025-12"
 12180	purple boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11950,7 +11950,7 @@
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	modified pressed huge Pork Elf mouthwash	0		Effect: "Haunted Stomach", Effect Duration: 38, Last Available: "2026-03"
 12194	colloidal corrupted Pork Elf deodorant	0		Effect: "Bilious Briskness", Effect Duration: 41, Last Available: "2026-03"
-12195	triple-moist enhanced blinking olive Pork Elf toothpaste	0		Effect: "Tingly Biceps", Effect Duration: 27, Last Available: "2026-03"
+12195	triple-moist enhanced olive blinking Pork Elf toothpaste	0		Effect: "Tingly Biceps", Effect Duration: 27, Last Available: "2026-03"
 12196	yellow bolt of fabric	0		Last Available: "2026-03"
 12197	teal clever arcane researcher's and dress	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Last Available: "2026-03"
 12198	narrow hardy rock-hard and dress	0		Damage Reduction: 5, Maximum HP: +50, Last Available: "2026-03"
@@ -11965,14 +11965,14 @@
 12207	twirling Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
 12209	normal rat pizza	4	good	Last Available: "2026-03"
-12210	squat jittery Fleek&trade; mascara	0		Last Available: "2026-03"
+12210	jittery squat Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	reassuring sharpshooter's Tesla hoverboard	0		Critical Hit Percent: +10, Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2026-03"
 12212	wholesome forbidden left shark fin of the boozehound	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Booze Drop: +100, Last Available: "2026-03"
 12213	steel-toed fitness tracking bracelet	0		Damage Reduction: 9, Single Equip, Last Available: "2026-03"
 12214	altered candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	moldy small tumbling discarded hot dog	2	crappy	Last Available: "2026-04"
+12217	small moldy tumbling discarded hot dog	2	crappy	Last Available: "2026-04"
 12218	acceptable most of a beer	4	good	Last Available: "2026-04"
 12222	blue pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
@@ -11980,7 +11980,7 @@
 12226	spoiled can of tuna	4	crappy	
 12227	adequate alien salad	3	good	
 12228	stale diet ratbatatouille	1	decent	
-12229	stale gigantic onigiri	6	decent	
+12229	gigantic stale onigiri	6	decent	
 12230	spoiled mirror crudit&eacute;s	3	crappy	
 12231	adequate sauced mutton	3	good	
 12232	yummy hot honey ant	4	awesome	
@@ -11992,9 +11992,9 @@
 12238	rotten half-sized Orzo di Riso	2	crappy	Last Available: "2026-05"
 12239	half-sized stale Pasta Grimavera	2	decent	Last Available: "2026-05"
 12240	decent Linguini Ubriacapa	3	good	Last Available: "2026-05"
-12241	enchanted decent mirror Formica e Pepe	3	good	Effect: "Lubed", Effect Duration: 40, Last Available: "2026-05"
+12241	decent enchanted mirror Formica e Pepe	3	good	Effect: "Lubed", Effect Duration: 40, Last Available: "2026-05"
 12242	yummy twirling narrow Tubetto Gelatto	4	awesome	Last Available: "2026-05"
-12243	low-calorie stale Gnocci Domani	1	decent	Last Available: "2026-05"
+12243	stale low-calorie Gnocci Domani	1	decent	Last Available: "2026-05"
 12244	huge Thwaitgold wallet moth statuette	0		
 12245	upside-down scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12005,7 +12005,7 @@
 12255	upside-down inspector's sword	0		Item Drop: +15
 12256	medical-grade staff	0		HP Regen Min: 7, HP Regen Max: 10
 12257	asbestos-lined lute	0		Hot Resistance: +5
-12258	blinking mirror shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
+12258	mirror blinking shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	purple Temple Grandin's manspreader's Socratic The Wizard's Android	0		Experience (Mysticality): +1, Monster Level: +10, Familiar Weight: +7
 12261	flash paperwad	0		
@@ -12017,13 +12017,13 @@
 12267	tumbling olive weightlifter's flimsy plastic breastplate	0		Muscle: +15
 12268	deadly flimsy plastic shield	0		Weapon Damage: +5, Damage Reduction: 3
 12269	fuchsia packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	medical-grade Sinatra's boxer's Portable Laughing Stock	0		Muscle Percent: +10, Experience (Moxie): +5, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	medical-grade Sinatra's boxer's Portable Laughing Stock	0		Muscle Percent: +10, Experience (Moxie): +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	double-paned razor-sharp Staff of Anachronistic Churning of the bloodbag	0		Weapon Damage Percent: +25, Maximum HP: +100, Cold Resistance: +5
-12272	moldy snack-sized classic banana	2	crappy	Last Available: "2026-07"
-12273	special bland watermelon	3	decent	Effect: "Swimming Head", Effect Duration: 10, Last Available: "2026-07"
+12272	snack-sized moldy classic banana	2	crappy	Last Available: "2026-07"
+12273	bland special watermelon	3	decent	Effect: "Swimming Head", Effect Duration: 10, Last Available: "2026-07"
 12274	bland diet quince	1	decent	Last Available: "2026-07"
 12275	huge Interesting Coin	0		Last Available: "2026-08"
-12276	upside-down tumbling Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
+12276	tumbling upside-down Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	yummy classic banana pie	4	awesome	Last Available: "2026-07"
 12278	concentrated pickled essential banana decoction	0		Effect: "Holiday Disappointment", Effect Duration: 18, Last Available: "2026-07"
 12279	liquefied banana quintessence	0		Effect: "Human-Horror Hybrid", Effect Duration: 28, Last Available: "2026-07"
@@ -12032,9 +12032,9 @@
 12282	flavorless gray watermelon pie	3	decent	Last Available: "2026-07"
 12283	vacuum-sealed concentrated watermelon juice	0		Effect: "Sappy Blood", Effect Duration: 16, Last Available: "2026-07"
 12284	chilled magnetized Aqua Citrulanatae	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 37, Last Available: "2026-07"
-12285	drinkable boozy Melonegroni	5	good	Last Available: "2026-07"
-12286	spirit-forward tolerable purple Melonade Spritz	5	good	Last Available: "2026-07"
-12287	normal diet quince pie	1	good	Last Available: "2026-07"
+12285	boozy drinkable Melonegroni	5	good	Last Available: "2026-07"
+12286	tolerable spirit-forward purple Melonade Spritz	5	good	Last Available: "2026-07"
+12287	diet normal quince pie	1	good	Last Available: "2026-07"
 12288	moist quince quaff	0		Effect: "You Drank Fish Wine", Effect Duration: 69, Last Available: "2026-07"
 12289	frozen Quickquince	0		Effect: "Bread-Lined", Effect Duration: 38, Last Available: "2026-07"
 12290	triple-distilled hand-crafted Quiskey Sour	6	EPIC	Last Available: "2026-07"
@@ -12042,7 +12042,7 @@
 12292	weak bad shaking Roth IPA	2	decent	Last Available: "2026-08"
 12293	horrifying rock-hard underdraft protection	0		Damage Reduction: 5, Spooky Damage: +25, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	decent jumbo soybean futures	5	good	Last Available: "2026-08"
+12295	jumbo decent soybean futures	5	good	Last Available: "2026-08"
 12296	wet housing bubble	0		Effect: "Sugary Tongue", Effect Duration: 16, Last Available: "2026-08"
 12297	moist Pixie-Swordz	0		Effect: "Turkey-Ambitious", Effect Duration: 61
 12298	Samson's financial instrument of James Dean	0		Experience (Muscle): +5, Experience (Moxie): +3, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Pastamancer_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Marmot_cafe_booze.txt
@@ -5,29 +5,29 @@
 -5	smooth candycaine	4	awesome	
 -6	spirit-forward drinkable braincracker sweet	5	good	
 -16	hand-crafted fermented honey	3	EPIC	
--17	weak special smooth spinning moons-shine	2	awesome	
+-17	smooth weak special spinning moons-shine	2	awesome	
 -18	hand-crafted gin	4	EPIC	
 -19	perfectly mixed ecto-nog	3	EPIC	
 -20	tolerable practically non-alcoholic hot toady	1	good	
--21	watered-down tolerable blurry hot choculate	2	good	
+-21	tolerable watered-down blurry hot choculate	2	good	
 -49	irresponsibly strong artisanal Cyder	9	EPIC	
 -50	lousy watered-down Oil Nog	2	decent	
 -51	watered-down tolerable Hi-Octane Peppermint Jet Fuel	2	good	
 -58	tolerable shaking Grimacider	4	good	
 -59	bad upside-down Isotope Nog	4	decent	
--60	drinkable practically non-alcoholic Mutagin 'n' Tonic	1	good	
+-60	practically non-alcoholic drinkable Mutagin 'n' Tonic	1	good	
 -70	perfectly mixed special Gin and Herring	4	EPIC	
 -71	tolerable Black and Tan and Red All Over	4	good	
 -72	drinkable Antarctic Ice Tea	3	good	
--76	artisanal boozy cyan CRIMBCO Ribbon Candy Schnapps	5	EPIC	
+-76	boozy artisanal cyan CRIMBCO Ribbon Candy Schnapps	5	EPIC	
 -77	drinkable red CRIMBCO Egg Substitute Nog Substitute	4	good	
 -78	artisanal watered-down olive CRIMBCO Extreme Braincracker Sour	2	EPIC	
--82	mediocre irresponsibly strong narrow Horseradish-infused Vodka	8	decent	
+-82	irresponsibly strong mediocre narrow Horseradish-infused Vodka	8	decent	
 -83	bad weak Jerkitini	2	decent	
 -84	hand-crafted Desert Island Iced Tea	4	EPIC	
 -88	acceptable skewed Crimbo Saketini	3	good	
--89	drinkable practically non-alcoholic Crimboku Drop	1	good	
--90	extra-dry lousy cyan upside-down Flaming Crimbo Log	5	decent	
+-89	practically non-alcoholic drinkable Crimboku Drop	1	good	
+-90	lousy extra-dry upside-down cyan Flaming Crimbo Log	5	decent	
 -107	perfectly mixed Fortified Eggnog Slurry	4	EPIC	
 -108	mediocre Hot Buttered Rum	3	decent	
--109	practically non-alcoholic perfectly mixed skewed Spicy Hot Chocolate	1	EPIC	
+-109	perfectly mixed practically non-alcoholic skewed Spicy Hot Chocolate	1	EPIC	

--- a/data/TCRS/TCRS_Pastamancer_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Marmot_cafe_food.txt
@@ -2,44 +2,44 @@
 -2	big spoiled As Jus Gezund Heit	5	crappy	
 -3	bland Bouillabaise Coucher Avec Moi	3	decent	
 -7	flavorless diet gumdrop chow mein	1	decent	
--8	low-calorie yummy candy cane pizza	1	awesome	
+-8	yummy low-calorie candy cane pizza	1	awesome	
 -9	adequate jumbo spinning gingerbread stir-fry	5	good	
 -10	diet stale twigs and gravel	1	decent	
--11	normal immense shoots and leaves	6	good	
--12	thick bland bowl of unidentifiable goo	5	decent	
--13	bite-sized rotten gingerbread massacre	1	crappy	
--14	miniature moldy It Came From Beyond Dessert	2	crappy	
+-11	immense normal shoots and leaves	6	good	
+-12	bland thick bowl of unidentifiable goo	5	decent	
+-13	rotten bite-sized gingerbread massacre	1	crappy	
+-14	moldy miniature It Came From Beyond Dessert	2	crappy	
 -15	moldy vampire cake	3	crappy	
 -52	rotten massive Soylent Red and Green	7	crappy	
 -53	decent Disc-Shaped Nutrition Unit	4	good	
--54	half-sized flavorless Gingerborg Hive	2	decent	
+-54	flavorless half-sized Gingerborg Hive	2	decent	
 -61	rotten Candy Cane Surprise	4	crappy	
--62	gigantic moldy Grimdrop Chow Mein	9	crappy	
+-62	moldy gigantic Grimdrop Chow Mein	9	crappy	
 -63	rotten skewed Grimgerbread House	3	crappy	
 -67	bland Caviar Carbonara	3	decent	
--68	jumbo special flavorless narrow Halibut Alfredo	5	decent	
+-68	jumbo flavorless special narrow Halibut Alfredo	5	decent	
 -69	snack-sized normal Red Herring Velvet Cake	2	good	
 -73	yummy CRIMBCO Reconstituted Gruel	3	awesome	
 -74	normal New and Improved CRIMBCO Reconstituted Gruel	3	good	
--75	flavorless huge CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	decent	
+-75	huge flavorless CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	decent	
 -79	tasty Brussels Sprout Stir-Fry	3	awesome	
 -80	bland snack-sized green Carrot, Cabbage, and Kale Pizza	2	decent	
 -81	tiny rotten special Turnip and Rutabaga Pie	1	crappy	
 -85	decent miniature Rainbow Spider Fun Roll	2	good	
 -86	flavorless red Vegas Volcano Lava Roll	3	decent	
--87	rotten immense Crazy Dragon Shogun Buddha Roll	7	crappy	
+-87	immense rotten Crazy Dragon Shogun Buddha Roll	7	crappy	
 -92	rotten basic hot dog	3	crappy	
 -93	decent savage macho dog	4	good	
--94	enchanted stale purple one with everything	4	decent	
+-94	stale enchanted purple one with everything	4	decent	
 -95	rotten sly dog	4	crappy	
--96	bland big devil dog	5	decent	
+-96	big bland devil dog	5	decent	
 -97	delicious yellow chilly dog	4	awesome	
--98	snack-sized toothsome ghost dog	2	awesome	
+-98	toothsome snack-sized ghost dog	2	awesome	
 -99	stale olive junkyard dog	4	decent	
--100	massive adequate spinning tumbling wet dog	7	good	
+-100	massive adequate tumbling spinning wet dog	7	good	
 -101	adequate narrow squat sleeping dog	3	good	
--102	bland small fuchsia optimal dog	2	decent	
+-102	small bland fuchsia optimal dog	2	decent	
 -103	spoiled purple video games hot dog	3	crappy	
--104	massive toothsome blinking Peppermint Nutrition Block	10	awesome	
--105	super-sized spoiled Gingerbread Nutrition Block	5	crappy	
--106	special decent miniature Cinnamon Nutrition Block	2	good	
+-104	toothsome massive blinking Peppermint Nutrition Block	10	awesome	
+-105	spoiled super-sized Gingerbread Nutrition Block	5	crappy	
+-106	miniature special decent Cinnamon Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Pastamancer_Mongoose.txt
+++ b/data/TCRS/TCRS_Pastamancer_Mongoose.txt
@@ -10,7 +10,7 @@
 10	wobbly disco ball	0		
 11	jittery stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	pickled wobbly purple twirling moxie weed	1		Effect: "Mint-Condition Breath", Effect Duration: 20
+14	pickled wobbly twirling purple moxie weed	1		Effect: "Mint-Condition Breath", Effect Duration: 20
 15	boiled squat gray strongness elixir	1		Effect: "Perception", Effect Duration: 10
 16	compressed upside-down magicalness-in-a-can	1		
 17	tasty noodles	3	awesome	
@@ -77,7 +77,7 @@
 78	padded pretty bouquet	0		Damage Absorption: +20
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	lime green fairy gravy boat	0		
-81	irresponsibly strong acceptable ice-cold Willer	10	good	
+81	acceptable irresponsibly strong ice-cold Willer	10	good	
 82	bouncing jittery ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
@@ -96,7 +96,7 @@
 97	twirling greasy Temple Grandin's pimpin' meat hat	0		Familiar Weight: +7, Sleaze Spell Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 13"
 98	dried face	0		
 99	meat face	0		
-100	mirror narrow purple lifeless meat doll	0		
+100	narrow mirror purple lifeless meat doll	0		
 101	meat golem	0		
 102	yellow shrunken head	0		
 103	narrow auspicious staff of the sweet-tooth	0		Item Drop: +10, Candy Drop: +100
@@ -105,7 +105,7 @@
 106	ketchup	1	good	
 107	catsup	1	good	
 108	stick	0		
-109	skewed wobbly red crossbow string	0		
+109	red skewed wobbly crossbow string	0		
 110	shellacked basic meat staff	0		Damage Reduction: 7
 111	bouncing basic meat crossbow of wisdom	0		Mysticality: +15
 112	ghostly lime green grievous meatloaf helmet of the detective	0		Weapon Damage Percent: +50, Item Drop: +20, Familiar Effect: "1xBarrr, 1.5xFairy, cap 13"
@@ -121,7 +121,7 @@
 122	cog and sprocket assembly	0		
 123	narrow upside-down Gnollish flyswatter	0		
 124	empty meat tank	0		
-125	blurry bouncing full meat tank	0		
+125	bouncing blurry full meat tank	0		
 126	meat engine	0		
 127	coward's Gnollish autoplunger	0		Monster Level: -20
 128	squat friendly meat pants	0		Familiar Weight: +3, Familiar Effect: "2xPotato, cap 11"
@@ -138,7 +138,7 @@
 139	valuable trinket	0		
 140	dingy planks	0		
 141	lime green dingy dinghy	0		
-142	blinking skewed anticheese	0		
+142	skewed blinking anticheese	0		
 143	shaking cottage	0		
 144	stone of eXtreme power	0		
 145	blurry barbed-wire fence	0		
@@ -156,14 +156,14 @@
 157	spinning Dramatic&trade; range	0		
 158	Gnollish pie tin	0		
 159	tumbling wad of dough	0		
-160	skewed twirling cyan pie crust	0		
+160	twirling skewed cyan pie crust	0		
 161	half-sized rotten ghuol egg	2	crappy	
 162	adequate jumbo ghuol egg quiche	5	good	
 163	skeleton bone of doom	0		Spooky Spell Damage: +50
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	diet moldy ghuol-ear kabob	1	crappy	
+167	moldy diet ghuol-ear kabob	1	crappy	
 168	manspreader's bone rattle	0		Monster Level: +10
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	shaking lihc eye	0		
@@ -171,7 +171,7 @@
 172	gnoll lips	0		
 173	narrow taco shell	0		
 174	Gnollish casserole dish	0		
-175	rotten tiny uncooked chorizo	1	crappy	
+175	tiny rotten uncooked chorizo	1	crappy	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
@@ -191,7 +191,7 @@
 193	skewed birthday candle	0		
 194	Mr. Accessory of the boozehound	0		Booze Drop: +100, Softcore Only
 195	eXtreme nose ring of vim and vigor	0		Maximum HP Percent: +50
-196	pulsating squat spinning disassembled clover	0		
+196	pulsating spinning squat disassembled clover	0		
 197	rat whisker	0		
 198	rat appendix	0		
 199	Da Vinci's ring	0		Experience (Mysticality): +5
@@ -199,7 +199,7 @@
 201	adequate bat wing kabob	4	good	
 202	adequate yellow carob chunks	3	good	
 203	herbs	0		
-204	yummy fancy fuchsia tumbling carob chunk cookies	4	awesome	Effect: "You Can Really Taste the Dormouse", Effect Duration: 10
+204	fancy yummy fuchsia tumbling carob chunk cookies	4	awesome	Effect: "You Can Really Taste the Dormouse", Effect Duration: 10
 205	skewed secret blend of herbs and spices	0		
 206	upside-down piercing post	0		
 207	hippy herbal tea	1	awesome	
@@ -211,8 +211,8 @@
 213	filthy corduroys of the ox of James Dean	0		Muscle: +20, Experience (Moxie): +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	jittery careful filthy knitted dread sack	0		Monster Level: -10, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	miniature adequate enchanted carob brownies	2	good	Effect: "White Knuckles", Effect Duration: 25
-217	rotten diet herb brownies	1	crappy	
+216	miniature enchanted adequate carob brownies	2	good	Effect: "White Knuckles", Effect Duration: 25
+217	diet rotten herb brownies	1	crappy	
 218	hemp string	0		
 219	squat necklace chain	0		
 220	gnoll teeth	0		
@@ -231,7 +231,7 @@
 233	wobbly Doc Galaktik's Restorative Balm	0		
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	bouncing groovy Bigger Bugfinder Blade of the blizzard	0		Moxie Percent: +10, Cold Spell Damage: +25
-236	blue wobbly Queue Du Coq cocktailcrafting kit	0		
+236	wobbly blue Queue Du Coq cocktailcrafting kit	0		
 237	delicious weak bottle of gin	2	awesome	
 238	practically non-alcoholic artisanal blue bottle of vodka	1	EPIC	
 239	banded smartaleck's Orcish baseball cap	0		Moxie Percent: +30, Damage Absorption: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
@@ -239,16 +239,16 @@
 241	therapeutic Orcish frat-paddle	0		HP Regen Min: 5, HP Regen Max: 7
 242	yummy	3	awesome	
 243	adequate grapefruit	3	good	
-244	bite-sized bland grapes	1	decent	
-245	spoiled snack-sized olive	2	crappy	
+244	bland bite-sized grapes	1	decent	
+245	snack-sized spoiled olive	2	crappy	
 246	normal tomato	3	good	
 247	fermenting powder	0		
-248	special lousy blinking salty dog	3	decent	Effect: "Quadrilled", Effect Duration: 5
-249	watered-down lousy bloody mary	2	decent	
+248	lousy special blinking salty dog	3	decent	Effect: "Quadrilled", Effect Duration: 5
+249	lousy watered-down bloody mary	2	decent	
 250	smooth screwdriver	3	awesome	
 251	practically non-alcoholic perfectly mixed maroon wobbly martini	1	EPIC	
 252	tolerable upside-down purple bloody beer	4	good	
-253	watered-down smooth shot of schnapps	2	awesome	
+253	smooth watered-down shot of schnapps	2	awesome	
 254	drinkable irresponsibly strong twirling shot of grapefruit schnapps	9	good	
 255	practically non-alcoholic mediocre fine wine	1	decent	
 256	special tolerable shot of tomato schnapps	3	good	Effect: "The Strength...  of the Future", Effect Duration: 35
@@ -258,7 +258,7 @@
 260	decent White Citadel fries	3	good	
 261	small spoiled White Citadel burger	2	crappy	
 262	massive bland piece of wedding cake	8	decent	
-263	flavorless huge chocolate chips	7	decent	
+263	huge flavorless chocolate chips	7	decent	
 264	delicious chocolate chip cookies	3	awesome	
 265	satin pants of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "atk, 2xPotato, cap 10"
 266	lousy lightning	3	decent	
@@ -310,25 +310,25 @@
 312	jittery Knob Goblin visor of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	blinking yellow Crown of the Goblin King of dire peril	0		Weapon Damage: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	snack-sized decent bean burrito	2	good	
-315	delicious diet skewed tumbling bean burrito	1	awesome	
+315	diet delicious tumbling skewed bean burrito	1	awesome	
 316	moldy insanely bean burrito	4	crappy	
 317	rotten bean burrito	3	crappy	
-318	big adequate red spinning tumbling bean burrito	5	good	
+318	big adequate tumbling spinning red bean burrito	5	good	
 319	massive flavorless insanely bean burrito	9	decent	
 320	bland bat haggis	3	decent	
-321	decent fancy thick menudo	5	good	Effect: "Jingle Jangle Jingle", Effect Duration: 25
+321	thick fancy decent menudo	5	good	Effect: "Jingle Jangle Jingle", Effect Duration: 25
 322	tiny flavorless purple goat cheese	1	decent	
-323	decent half-sized plain pizza	2	good	
+323	half-sized decent plain pizza	2	good	
 324	rotten immense sausage pizza	7	crappy	
 325	bland red goat cheese pizza	4	decent	
-326	gigantic adequate mushroom pizza	6	good	
+326	adequate gigantic mushroom pizza	6	good	
 327	goat	0		
 328	drinkable tumbling bottle of whiskey	3	good	
 329	bouncing rosewater-soaked goat beard	0		Stench Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 15"
 330	huge glass of goat's milk	1	awesome	
 331	drinkable Canadian	3	good	
-332	moldy big tumbling lemon	5	crappy	
-333	bland miniature mirror lime	2	decent	
+332	big moldy tumbling lemon	5	crappy	
+333	miniature bland mirror lime	2	decent	
 334	blue sabre teeth of the cheetah	0		Initiative: +60
 335	sabre-toothed lime cub	0		
 336	consolation ribbon of doom	0		Spooky Spell Damage: +50
@@ -341,7 +341,7 @@
 343	magnetized Knob Goblin sharpening spray	0		Effect: "Inebriate Pride", Effect Duration: 46
 344	Knob Goblin seltzer	0		
 345	Knob Goblin superseltzer	0		
-346	twirling maroon scrumptious reagent	0		
+346	maroon twirling scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
 348	rosy-cheeked ninja mask	0		Maximum HP Percent: +30, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
@@ -354,7 +354,7 @@
 356	Annie Oakley's snowboarder pants	0		Critical Hit Percent: +20, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	adequate gr8ps	4	good	
-359	special diet stale t8r tots	1	decent	Effect: "Super Accuracy", Effect Duration: 40
+359	diet stale special t8r tots	1	decent	Effect: "Super Accuracy", Effect Duration: 40
 360	Da Vinci's miner's helmet	0		Experience (Mysticality): +5, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	shaking narrow groovy miner's pants	0		Moxie Percent: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	therapeutic 7-Foot Dwarven mattock	0		HP Regen Min: 5, HP Regen Max: 7
@@ -414,7 +414,7 @@
 416	brainy safarrri hat	0		Mysticality: +5, Familiar Effect: "2xVolley, cap 22"
 417	polarized henna tattoo	0		Effect: "Trufflin'", Effect Duration: 26
 418	moist twirling Ferrigno's Elixir of Power	0		Effect: "In the Limelight", Effect Duration: 45
-419	energized twirling blurry serum of sarcasm	0		Effect: "Innately Wise", Effect Duration: 69
+419	energized blurry twirling serum of sarcasm	0		Effect: "Innately Wise", Effect Duration: 69
 420	galvanized alkaline tomato juice of powerful power	0		Effect: "Itchy Trigger Finger", Effect Duration: 45
 421	tarnished pickled shaking philter of phorce	0		Effect: "Become Intensely interested", Effect Duration: 67
 422	vacuum-sealed potion of potency	0		Effect: "Rain Dancin'", Effect Duration: 57
@@ -434,7 +434,7 @@
 436	huge balloon monkey	0		
 437	chef skull	0		
 438	upside-down chef-in-the-box	0		
-439	shaking narrow bartender skull	0		
+439	narrow shaking bartender skull	0		
 440	narrow bartender-in-the-box	0		
 441	chef-skull-in-the-box	0		
 442	squat bouncing bartender-skull-in-the-box	0		
@@ -448,7 +448,7 @@
 450	cyan pretentious paintbrush	0		
 451	pretentious palette	0		
 452	disease	0		
-453	bouncing olive sober pill	0		
+453	olive bouncing sober pill	0		
 454	mirror screwdriver	0		
 455	yummy jumbo olive	4	awesome	
 456	smooth enchanted dry martini	4	awesome	Effect: "Preemptive Medicine", Effect Duration: 30
@@ -484,7 +484,7 @@
 486	padded Talisman o' Namsilat	0		Damage Absorption: +20, Single Equip
 487	frightening arrrgyle socks	0		Spooky Damage: +5
 488	guitar pick	0		
-489	red spinning drab sonata	0		
+489	spinning red drab sonata	0		
 490	upside-down manspreader's energetic mesh cap	0		Maximum MP Percent: +20, Monster Level: +10, Familiar Effect: "atk, 1xVolley, cap 41"
 491	blinking enormous belt buckle	0		
 492	fuchsia hale chaps of mayonnaise	0		Maximum HP: +20, Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
@@ -493,7 +493,7 @@
 495	catgut	0		
 496	cat appendix	0		
 497	olive gnatwing	0		
-498	stale jumbo papaya	5	decent	
+498	jumbo stale papaya	5	decent	
 499	lightning-fast ruddy denim axe	0		Maximum HP Percent: +40, Initiative: +40
 500	Elf Farm Raffle ticket	0		
 501	moldy Elfin shortbread	4	crappy	
@@ -501,16 +501,16 @@
 503	big stale skewered cat appendix	5	decent	
 504	blurry fuchsia evil arches	0		
 505	chaotic gnatwing earring of the boozehound	0		Spell Critical Percent: +10, Booze Drop: +100
-506	huge rotten Hell broth	10	crappy	
+506	rotten huge Hell broth	10	crappy	
 507	ghostly miser's thunderrr guitarrr	0		Meat Drop: +10
 508	sonata	0		
 509	Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	enchanted snack-sized adequate Boris's key lime pie	2	good	Effect: "Mushroom Melody", Effect Duration: 10
+513	adequate snack-sized enchanted Boris's key lime pie	2	good	Effect: "Mushroom Melody", Effect Duration: 10
 514	rotten Jarlsberg's key lime pie	3	crappy	
-515	super-sized flavorless olive Sneaky Pete's key lime pie	5	decent	
+515	flavorless super-sized olive Sneaky Pete's key lime pie	5	decent	
 516	Hey Deze map	0		
 517	bejeweled accordion strap of the sewer	0		Stench Damage: +25, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -519,13 +519,13 @@
 521	tumbling gray asbestos-lined kickback cookbook	0		Hot Resistance: +5
 522	huge one-winged stab bat	0		
 523	purple rewinged stab bat	0		
-524	weak smooth papaya sling	2	awesome	
+524	smooth weak papaya sling	2	awesome	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
-530	boiled blurry lime green shaking spray paint	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 46
+530	boiled lime green blurry shaking spray paint	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 46
 531	green smelly special sauce glove	0		Stench Spell Damage: +10, Class: "Sauceror", Single Equip
 532	jittery lard-coated ladle of mystery	0		Sleaze Spell Damage: +25, Class: "Sauceror"
 533	mirror Gnollish toolbox	0		
@@ -549,34 +549,34 @@
 551	spinning 64067 scroll	0		
 552	64735 scroll	0		
 553	blurry 31337 scroll	0		
-554	small flavorless pr0n cocktail	2	decent	
+554	flavorless small pr0n cocktail	2	decent	
 555	stanky drywall axe of Flo-Jo	0		Stench Spell Damage: +25, Initiative: +100
 556	Pine-Fresh air freshener of extreme caution	0		Monster Level: -25
 557	tolerable spinning whiskey and cola	4	good	
-558	half-sized adequate papaya taco	2	good	
+558	adequate half-sized papaya taco	2	good	
 559	pulsating razor-sharp can lid	0		
 560	flavorless stalk of asparagus	3	decent	
 561	bouncing pregnant mushroom	0		
 562	twirling ratgut	0		
 563	squat sonar-in-a-biscuit	0		
-564	weak drinkable blinking Mad Train wine	2	good	
+564	drinkable weak blinking Mad Train wine	2	good	
 565	arcane researcher's hobo gloves	0		Experience Percent (Mysticality): +10, Single Equip
 566	skewed avaricious bum cheek	0		Meat Drop: +30, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	upside-down hermit script	0		
-568	flavorless snack-sized Double Bacon Beelzeburger	2	decent	
+568	snack-sized flavorless Double Bacon Beelzeburger	2	decent	
 569	small decent Lord of the Flies-sized fries	2	good	
 570	moldy blurry Chicken Sandwich	4	crappy	
 571	Jumbo Dr. Lucifer	1	crappy	
 572	adequate immense Children's Meal of the Damned	6	good	
 573	super-sized decent noodles	5	good	
-574	spoiled big spinning spinning noodles	5	crappy	
+574	big spoiled spinning spinning noodles	5	crappy	
 575	miniature spoiled purple painful penne pasta	2	crappy	
 576	adequate miniature ravioli della hippy	2	good	
 577	snack-sized rotten pr0n m4nic0tti	2	crappy	
 578	decent diet Hell ramen	1	good	
-579	half-sized moldy boring spaghetti	2	crappy	
+579	moldy half-sized boring spaghetti	2	crappy	
 580	sauce of the ages	0		
-581	ghostly tumbling schmancy cheese sauce	0		
+581	tumbling ghostly schmancy cheese sauce	0		
 582	gray Himalayan Hidalgo sauce	0		
 583	flavorless fettucini Inconnu	4	decent	
 584	tasty spaghetti with Skullheads	3	awesome	
@@ -584,7 +584,7 @@
 586	skewed green frightening smelly ridiculously huge sword	0		Stench Spell Damage: +10, Spooky Damage: +5
 587	quantum narrow super-spiky hair gel	0		Effect: "Brain Freeze", Effect Duration: 64
 588	soft echo eyedrop antidote	0		
-589	spoiled snack-sized cocoa eggshell fragment	2	crappy	
+589	snack-sized spoiled cocoa eggshell fragment	2	crappy	
 590	rotten cocoa eggshell fragment	3	crappy	
 591	cocoa egg	0		
 592	house	0		
@@ -634,14 +634,14 @@
 636	meat globe	0		
 637	toaster	0		
 638	Jack Frost's curative asshat	0		Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	jumbo toothsome abominable snowcone	5	awesome	
-640	special wobbly bouncing Ent cider	1	decent	Effect: "Crusty Head", Effect Duration: 5
+639	toothsome jumbo abominable snowcone	5	awesome	
+640	special bouncing wobbly Ent cider	1	decent	Effect: "Crusty Head", Effect Duration: 5
 641	stale toast	3	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	purple Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	diet fancy normal fruitcake	1	good	Effect: "Down With Chow", Effect Duration: 25
+646	fancy normal diet fruitcake	1	good	Effect: "Down With Chow", Effect Duration: 25
 647	mirror present	0		Last Available: "2004-11"
 648	Crimbo sword of the wise owl	0		Mysticality: +20, Last Available: "2004-10"
 649	experienced Crimbo hat	0		Experience: +2, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
@@ -675,7 +675,7 @@
 677	upside-down greasy badass belt	0		Sleaze Spell Damage: +10
 678	chest of the Bonerdagon	0		
 679	delicious roll in the hay	3	awesome	
-680	drinkable enchanted extra-dry slap and tickle	5	good	Effect: "Stinkybeard", Effect Duration: 35
+680	drinkable extra-dry enchanted slap and tickle	5	good	Effect: "Stinkybeard", Effect Duration: 35
 681	irresponsibly strong artisanal slip 'n' slide	10	EPIC	
 682	aged watered-down a sump'm sump'm	2	awesome	
 683	aged huge horizontal tango	4	awesome	
@@ -736,16 +736,16 @@
 740	squat tambourine of horror	0		Spooky Spell Damage: +25
 741	tumbling broken skull	0		
 742	spoiled wobbly Knoll shroomkabob	3	crappy	
-743	diet adequate mushroom	1	good	
+743	adequate diet mushroom	1	good	
 744	super-aerosolized triple-colloidal bouncing hair spray	0		Effect: "Pasta Oneness", Effect Duration: 58
 746	ghostly stat script	0		
-747	narrow twirling Knob Goblin firecracker	0		
+747	twirling narrow Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	adequate warm mushroom	4	good	
 750	small stale mushroom quesadilla	2	decent	
 751	tasty small cool mushroom	2	awesome	
 752	adequate miniature cool mushroom casserole	2	good	
-753	normal tiny gray pointy mushroom	1	good	
+753	tiny normal gray pointy mushroom	1	good	
 754	flavorless cream of pointy mushroom soup	4	decent	
 755	decent mushroom	3	good	
 756	stale mushroom	3	decent	
@@ -772,17 +772,17 @@
 777	supercool iron pasta spoon	0		Moxie Percent: +20
 778	blue veiny support cummerbund	0		Maximum HP: +10
 779	Mob Penguin cellular phone	0		
-780	fuchsia jittery scroll of pasta summoning	0		
+780	jittery fuchsia scroll of pasta summoning	0		
 781	double-alkaline denatured narrow mafia aria	0		Effect: "Red Misty-Eyed", Effect Duration: 63
 782	narrow Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
 784	bad Acqua Del Piatto Merlot	4	decent	Last Available: "2004-10"
 785	raffle ticket	0		
-786	special flavorless olive strawberry	4	decent	Effect: "Superhuman Sarcasm", Effect Duration: 5
+786	flavorless special olive strawberry	4	decent	Effect: "Superhuman Sarcasm", Effect Duration: 5
 787	distilled hand-crafted bottle of rum	5	EPIC	
 788	artisanal yellow strawberry daiquiri	3	EPIC	
 789	drinkable rum and cola	3	good	
-790	strong perfectly mixed ghostly grog	5	EPIC	
+790	perfectly mixed strong ghostly grog	5	EPIC	
 791	vibrating Mafia bow tie of bravery	0		Maximum MP Percent: +10, Spooky Resistance: +5, Last Available: "2004-10"
 792	knitted Golden Mr. Accessory	0		Cold Resistance: +3, Softcore Only
 793	corrupted oil of stability	0		Effect: "Taurus Rising", Effect Duration: 57
@@ -795,14 +795,14 @@
 800	thick decent poutine	5	good	
 801	spoiled super-sized tumbling Knob stir-fry	5	crappy	
 804	flavorless red Knoll stir-fry	4	decent	
-805	miniature bland stir-fry	2	decent	
+805	bland miniature stir-fry	2	decent	
 806	decent asparagus stir-fry	4	good	
 807	rotten olive stir-fry	3	crappy	
-808	adequate massive upside-down Knob sausage stir-fry	10	good	
+808	massive adequate upside-down Knob sausage stir-fry	10	good	
 809	toothsome miniature bat wing stir-fry	2	awesome	
 810	decent rat appendix stir-fry	3	good	
-811	small stale tofu stir-fry	2	decent	
-812	delicious thick pr0n stir-fry	5	awesome	
+811	stale small tofu stir-fry	2	decent	
+812	thick delicious pr0n stir-fry	5	awesome	
 813	spoiled Knob shells	3	crappy	
 814	delicious bouncing b&auml;tzle	3	awesome	
 815	stale purple ratini	4	decent	
@@ -819,7 +819,7 @@
 826	huge dark potion	0		
 827	murky potion	0		
 828	upside-down baby killer bee	0		
-829	ghostly green anti-anti-antidote	0		
+829	green ghostly anti-anti-antidote	0		
 830	spoiled royal jelly	3	crappy	
 831	small box	0		
 832	box	0		
@@ -834,7 +834,7 @@
 841	artisanal tomato daiquiri	3	EPIC	
 842	artisanal distilled beertini	5	EPIC	
 843	mediocre boozy ghostly squat salty slug	5	decent	
-844	practically non-alcoholic lousy wobbly papaya slung	1	decent	
+844	lousy practically non-alcoholic wobbly papaya slung	1	decent	
 845	blurry MAHI fez of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	squat hypodermic needle	0		Familiar Weight: +5
@@ -874,14 +874,14 @@
 883	fuchsia maple syrup	1	crappy	
 884	bouncing thinker's los chinos	0		Mysticality: +10, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	hardy axe	0		Maximum HP: +50
-886	blinking gray leaflet	0		
+886	gray blinking leaflet	0		
 887	leaf	0		
 888	huge maple leaf	0		
 889	squat dangerous balaclava	0		Weapon Damage: +10, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 890	stale snack-sized balaclava baklava	2	decent	
 891	family-friendly Warehouse 23 bling	0		Sleaze Resistance: +1
 892	mirror lightning-fast chaotic Van der Graaf bugbear-smiting sword	0		Spell Critical Percent: +10, Initiative: +40, MP Regen Min: 5, MP Regen Max: 7
-893	tolerable tumbling cyan lumbering jack	4	good	
+893	tolerable cyan tumbling lumbering jack	4	good	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	crafty Ms. Accessory	0		Maximum MP: +10, Softcore Only
 896	savvy Mr. Accessory Jr. of Tarzan	0		Mysticality Percent: +20, Experience (Muscle): +3, Softcore Only
@@ -895,7 +895,7 @@
 904	hardened fortified sinister school Mafia knickerbockers	0		Spell Damage: +10, Damage Absorption: +60, Damage Reduction: 3, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	triple-ionized pressed Yummy Tummy bean	0		Effect: "Abyssal Tears", Effect Duration: 65
 906	vacuum-sealed bouncing Rock Pops	0		Effect: "Intimidating Mien", Effect Duration: 65
-907	cold-filtered polymerized narrow red Mr. Mediocrebar	0		Effect: "Gummi Badass", Effect Duration: 38
+907	cold-filtered polymerized red narrow Mr. Mediocrebar	0		Effect: "Gummi Badass", Effect Duration: 38
 908	aerosolized tumbling Cold Hots candy	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 22
 909	Vulcanized extra-ionized Wint-O-Fresh mint	0		Effect: "Minerva's Zen", Effect Duration: 65
 910	diet moldy tumbling dwarf bread	1	crappy	
@@ -945,7 +945,7 @@
 955	teal clever fez of etymology	0		Maximum MP: +20, Familiar Effect: "1xLep, cap 30"
 956	massive spoiled wobbly carob chunk noodles	9	crappy	
 957	rotten chorizo brownies	3	crappy	
-958	stale snack-sized chocolate and tomato pizza	2	decent	
+958	snack-sized stale chocolate and tomato pizza	2	decent	
 959	flange	0		
 960	pulsating clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -987,9 +987,9 @@
 999	maid head	0		
 1000	Meat maid	0		
 1002	dangerous Xlyinia's notebook	0		Weapon Damage: +10
-1003	fuchsia squat soda water	0		
-1004	lousy boozy bottle of tequila	5	decent	
-1005	high-proof hand-crafted mirror boxed wine	8	EPIC	
+1003	squat fuchsia soda water	0		
+1004	boozy lousy bottle of tequila	5	decent	
+1005	hand-crafted high-proof mirror boxed wine	8	EPIC	
 1006	spoiled cherry	4	crappy	
 1007	coconut shell of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xFairy, cap 7"
 1008	huge extremely unsafe ice cubes	0		Weapon Damage Percent: +100
@@ -997,18 +997,18 @@
 1010	bad shaking whiskey and soda	4	decent	
 1011	hand-crafted monkey wrench	4	EPIC	
 1012	mediocre practically non-alcoholic tequila sunrise	1	decent	
-1013	lousy practically non-alcoholic margarita	1	decent	
+1013	practically non-alcoholic lousy margarita	1	decent	
 1014	bad practically non-alcoholic strawberry wine	1	decent	
 1015	bad spinning wine spritzer	4	decent	
 1016	mediocre practically non-alcoholic narrow perpendicular hula	1	decent	
-1017	watered-down lousy ducha de oro	2	decent	
+1017	lousy watered-down ducha de oro	2	decent	
 1018	bad distilled calle de miel	5	decent	
 1019	drinkable blurry dry vodka martini	3	good	
 1020	hand-crafted old-fashioned	3	EPIC	
-1021	weak perfectly mixed pulsating tequila with training wheels	2	EPIC	
+1021	perfectly mixed weak pulsating tequila with training wheels	2	EPIC	
 1022	hand-crafted sangria	3	EPIC	
-1023	triple-distilled tolerable vesper	10	good	Last Available: "2004-12"
-1024	distilled artisanal tumbling bodyslam	5	EPIC	Last Available: "2004-12"
+1023	tolerable triple-distilled vesper	10	good	Last Available: "2004-12"
+1024	artisanal distilled tumbling bodyslam	5	EPIC	Last Available: "2004-12"
 1025	delicious practically non-alcoholic sangria del diablo	1	awesome	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	narrow whip kit	0		
@@ -1024,13 +1024,13 @@
 1037	Samson's gnauga hide buckler	0		Experience (Muscle): +5, Damage Reduction: 5
 1038	triple-electrified unsweetened adjusted teal Connery's Elixir of Audacity	0		Effect: "Wallflowering", Effect Duration: 31
 1040	blue twirling Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	triple-distilled lousy huge beer	9	decent	
+1041	lousy triple-distilled huge beer	9	decent	
 1042	narrow MacGyver's string of beads	0		Maximum MP: +100
 1043	Oprah's string of beads	0		Maximum MP Percent: +50
 1044	deadly string of beads	0		Weapon Damage: +5
 1045	shellacked plastic bottle opener	0		Damage Reduction: 7
 1046	fuchsia flame-wreathed traffic cone of the ox	0		Muscle: +20, Hot Spell Damage: +10, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	smooth weak N. O. Beer	2	awesome	
+1047	weak smooth N. O. Beer	2	awesome	
 1048	powdered twirling oyster egg	1		
 1049	dehydrated shaking upside-down oyster egg	1		
 1050	mixed twirling squat oyster egg	1		Effect: "Artificially Sweet", Effect Duration: 15
@@ -1055,7 +1055,7 @@
 1069	vaporized oyster egg	1		
 1070	compressed oyster egg	1		Effect: "Is This Your Card?", Effect Duration: 50
 1071	blue plastic oyster egg	0		
-1072	compressed twirling maroon off-white oyster egg	1		
+1072	compressed maroon twirling off-white oyster egg	1		
 1073	distilled off-white oyster egg	1		Effect: "Tingly Elbows", Effect Duration: 35
 1074	distilled blinking squat off-white oyster egg	1		Effect: "Phairly Balanced", Effect Duration: 30
 1075	blurry off-white plastic oyster egg	0		
@@ -1087,14 +1087,14 @@
 1101	false eyelashes	0		Familiar Weight: +5
 1102	shaking targeting chip	0		
 1103	unwound clockwork grapefruit	0		
-1104	bouncing skewed Mountie hat	0		Familiar Weight: +5
+1104	skewed bouncing Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
-1106	bouncing huge clockwork chef head	0		
+1106	huge bouncing clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	clockwork detective skull	0		
-1109	tumbling olive skewed clockwork bartender-head-in-the-box	0		
+1109	olive skewed tumbling clockwork bartender-head-in-the-box	0		
 1110	clockwork chef-head-in-the-box	0		
-1111	cyan twirling clockwork bartender-in-the-box	0		
+1111	twirling cyan clockwork bartender-in-the-box	0		
 1112	maroon clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
 1114	tisket	0		
@@ -1126,17 +1126,17 @@
 1140	tolerable icy mushroom wine	4	good	
 1141	watered-down perfectly mixed twirling mushroom wine	2	EPIC	
 1142	acceptable practically non-alcoholic pulsating pointy mushroom wine	1	good	
-1143	watered-down drinkable flat mushroom wine	2	good	
+1143	drinkable watered-down flat mushroom wine	2	good	
 1144	artisanal shaking cool mushroom wine	3	EPIC	
 1145	watered-down mediocre special gray jittery knob mushroom wine	2	decent	Effect: "Heal Thy Nanoself", Effect Duration: 25
 1146	perfectly mixed huge knoll mushroom wine	4	EPIC	
-1147	tolerable special mushroom wine	4	good	Effect: "Greased-Up Familiar", Effect Duration: 10
-1148	enchanted drinkable shot of flower schnapps	3	good	Effect: "Creepypasted", Effect Duration: 5
+1147	special tolerable mushroom wine	4	good	Effect: "Greased-Up Familiar", Effect Duration: 10
+1148	drinkable enchanted shot of flower schnapps	3	good	Effect: "Creepypasted", Effect Duration: 5
 1149	bite-sized bland flower petal pie	1	decent	
 1150	drinkable high-proof red bottle of single-barrel whiskey	8	good	
 1151	discarded plastic fork of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100
 1152	blinking gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	normal snack-sized Retenez L'Herbe Pat&eacute;	2	good	
+1153	snack-sized normal Retenez L'Herbe Pat&eacute;	2	good	
 1154	compressed upside-down Breathetastic&trade; Premium Canned Air	1	EPIC	
 1155	letter from King Ralph XI	0		
 1157	studded wholeberd	0		Damage Absorption: +80
@@ -1151,9 +1151,9 @@
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	less-than-three-shaped box	0		
-1169	yellow spinning spinning exactly-three-shaped box	0		
+1169	spinning spinning yellow exactly-three-shaped box	0		
 1170	blinking chocolate box	0		
-1171	twirling narrow coffin	0		
+1171	narrow twirling coffin	0		
 1172	yellow asbestos box	0		
 1173	linoleum box	0		
 1174	chrome box	0		
@@ -1183,16 +1183,16 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	normal pulsating mugcake	4	good	
-1201	massive decent fancy narrow urinal cake	10	good	Effect: "Thick-Skinned", Effect Duration: 5
+1201	fancy massive decent narrow urinal cake	10	good	Effect: "Thick-Skinned", Effect Duration: 5
 1202	small normal narrow Happy Birthday, Claude! cake	2	good	
-1203	rotten half-sized personalized birthday cake	2	crappy	
+1203	half-sized rotten personalized birthday cake	2	crappy	
 1204	adequate narrow three-tiered wedding cake	3	good	
 1205	yummy jumbo babycakes	5	awesome	
-1206	moldy special velvet cake	3	crappy	Effect: "Carol of the Bones", Effect Duration: 25
-1207	delicious teal huge congratulatory cake	4	awesome	
+1206	special moldy velvet cake	3	crappy	Effect: "Carol of the Bones", Effect Duration: 25
+1207	delicious huge teal congratulatory cake	4	awesome	
 1208	bland angel-food cake	3	decent	
-1209	rotten jumbo devil's-food cake	5	crappy	
-1210	small flavorless birthday party jellybean cheesecake	2	decent	
+1209	jumbo rotten devil's-food cake	5	crappy	
+1210	flavorless small birthday party jellybean cheesecake	2	decent	
 1211	balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
@@ -1232,7 +1232,7 @@
 1248	foul-smelling wicked Bonerdagon necklace of the blizzard	0		Spell Damage: +5, Cold Spell Damage: +25, Stench Damage: +10
 1249	Samson's Boss Bat britches	0		Experience (Muscle): +5, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	blurry resourceful grievous Boss Bat bling	0		Weapon Damage Percent: +50, Maximum MP: +50
-1251	stale jumbo Knob shroomkabob	5	decent	
+1251	jumbo stale Knob shroomkabob	5	decent	
 1252	small stale shroomkabob	2	decent	
 1253	pile of jumping beans	0		
 1254	massive normal jumping bean burrito	9	good	
@@ -1246,7 +1246,7 @@
 1262	spinning shellacked grievous off-hand balloon of the bloodbag	0		Weapon Damage Percent: +50, Damage Reduction: 7, Maximum HP: +100
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
-1265	twirling mirror box of sunshine	0		Free Pull
+1265	mirror twirling box of sunshine	0		Free Pull
 1266	bland gloomy mushroom	4	decent	
 1267	upside-down purple dead mimic	0		
 1268	pine wand	0		
@@ -1255,7 +1255,7 @@
 1271	blurry aluminum wand	0		
 1272	marble wand	0		
 1273	Herculean magic lamp	0		Experience (Muscle): +1
-1274	distilled upside-down lime green Medicinal Herb's medicinal herbs	1		
+1274	distilled lime green upside-down Medicinal Herb's medicinal herbs	1		
 1275	medical-grade basic meat skirt	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	smooth watered-down Otorian Battle Scar	2	awesome	
 1277	greasy basic meat kilt	0		Sleaze Spell Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1330,7 +1330,7 @@
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	purple empty blowgun	0		Last Available: "2005-11"
 1349	mirror miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
-1350	shaking blurry 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
+1350	blurry shaking 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	huge Oprah's pinky ring	0		Maximum MP Percent: +50, Single Equip
 1352	hand-crafted redrum	4	EPIC	
 1353	ninja pirate zombie robot	0		
@@ -1346,8 +1346,8 @@
 1363	lime green narrow clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	spoiled tofurkey leg	3	crappy	
-1366	immense moldy bouncing tofurkey gravy	9	crappy	
-1367	special adequate herbal stuffing	4	good	Effect: "Frost Tea", Effect Duration: 45
+1366	moldy immense bouncing tofurkey gravy	9	crappy	
+1367	adequate special herbal stuffing	4	good	Effect: "Frost Tea", Effect Duration: 45
 1368	rotten can-shaped gelatinous cranberry sauce	3	crappy	
 1369	decent jittery yams	4	good	
 1370	occult rhinestone cowboy shirt	0		Spell Damage Percent: +25
@@ -1385,7 +1385,7 @@
 1403	can of fake snow of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2005-12"
 1404	dog trainer's colored-light &quot;necklace&quot;	0		Experience (familiar): +1, Last Available: "2005-12"
 1405	ruddy tree skirt	0		Maximum HP Percent: +40, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	gigantic flavorless tumbling wreath-shaped Crimbo cookie	7	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	flavorless gigantic tumbling wreath-shaped Crimbo cookie	7	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	adequate purple bell-shaped Crimbo cookie	3	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	spoiled maroon tree-shaped Crimbo cookie	3	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	narrow executive Unionize The Elves sign	0		Meat Drop: +40, Last Available: "2005-12"
@@ -1411,7 +1411,7 @@
 1429	jittery roll of drink tickets	0		
 1430	twirling pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	enchanted delicious mushroom	4	awesome	Effect: "Fancy Feasted", Effect Duration: 10
+1432	delicious enchanted mushroom	4	awesome	Effect: "Fancy Feasted", Effect Duration: 10
 1433	olive fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1422,7 +1422,7 @@
 1440	chilled energized spinning powder	0		Effect: "Booooooze", Effect Duration: 60
 1441	aerosolized red powder	0		Effect: "Dirty Pear", Effect Duration: 14
 1442	non-modified dry upside-down stench powder	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 23
-1443	warmed huge ghostly sleaze powder	0		Effect: "Dweeby", Effect Duration: 43
+1443	warmed ghostly huge sleaze powder	0		Effect: "Dweeby", Effect Duration: 43
 1444	quadruple-moist denatured alkaline twinkly nuggets	0		Effect: "Broken Bone Nubs", Effect Duration: 57
 1445	aerosolized hot nuggets	0		Effect: "Full of Vinegar", Effect Duration: 13
 1446	ionized nuggets	0		Effect: "Neuromancy", Effect Duration: 55
@@ -1486,8 +1486,8 @@
 1504	irradiated wet blinking olive snowcone	0		Effect: "You Can Taste the Darkness", Effect Duration: 11, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	bad mirror calle de miel with a fly in it	3	decent	Last Available: "2006-04"
-1507	triple-distilled perfectly mixed rockin' wagon with a fly in it	8	EPIC	Last Available: "2006-04"
-1508	smooth weak perpendicular hula with a fly in it	2	awesome	Last Available: "2006-04"
+1507	perfectly mixed triple-distilled rockin' wagon with a fly in it	8	EPIC	Last Available: "2006-04"
+1508	weak smooth perpendicular hula with a fly in it	2	awesome	Last Available: "2006-04"
 1509	aged slap and tickle with a fly in it	3	awesome	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	dangerous fake hand	0		Weapon Damage: +10, Last Available: "2006-04"
@@ -1504,7 +1504,7 @@
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	olive diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	studded corkscrew of terror	0		Damage Absorption: +80, Spooky Spell Damage: +10, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
@@ -1530,57 +1530,57 @@
 1550	personal trainer's second-hand knockoff engagement ring	0		Experience Percent (Muscle): +10, Single Equip
 1551	delicious bottle of Domesticated Turkey	4	awesome	
 1552	bad bottle of Definit	3	decent	
-1553	distilled acceptable bottle of Calcutta Emerald	5	good	
-1554	smooth weak cyan squat bottle of Lieutenant Freeman	2	awesome	
+1553	acceptable distilled bottle of Calcutta Emerald	5	good	
+1554	weak smooth cyan squat bottle of Lieutenant Freeman	2	awesome	
 1555	drinkable special bottle of Jorge Sinsonte	3	good	Effect: "Glittering Eyelashes", Effect Duration: 10
 1556	artisanal boxed champagne	3	EPIC	
-1557	thick rotten kumquat	5	crappy	
+1557	rotten thick kumquat	5	crappy	
 1558	spoiled tangerine	3	crappy	
 1559	purple tonic water	0		
 1560	decent cocktail onion	3	good	
-1561	snack-sized stale raspberry	2	decent	
+1561	stale snack-sized raspberry	2	decent	
 1562	bland ghostly kiwi	3	decent	
 1563	enchanted lousy blurry whiskey bittersweet	3	decent	Effect: "Good Karma", Effect Duration: 50
 1564	artisanal mimosette	3	EPIC	
 1565	artisanal strong tumbling gray tequila sunset	5	EPIC	
 1566	lousy enchanted zmobie	3	decent	Effect: "Thick, Sick", Effect Duration: 40, Wiki Name: "Zmobie (drink)"
-1567	hand-crafted weak gin and tonic	2	EPIC	
+1567	weak hand-crafted gin and tonic	2	EPIC	
 1568	drinkable vodka and tonic	3	good	
 1569	bad vodka gibson	3	decent	
 1570	delicious gibson	4	awesome	
 1571	lousy watered-down parisian cathouse	2	decent	
 1572	delicious purple rabbit punch	3	awesome	
-1573	practically non-alcoholic bad caipifruta	1	decent	
+1573	bad practically non-alcoholic caipifruta	1	decent	
 1574	bad teqiwila	3	decent	
 1575	smooth Divine	4	awesome	
-1576	perfectly mixed weak special huge Gordon Bennett	2	super ultra EPIC	Effect: "Inner Warmth", Effect Duration: 30
+1576	special weak perfectly mixed huge Gordon Bennett	2	super ultra EPIC	Effect: "Inner Warmth", Effect Duration: 30
 1577	smooth gray tangarita	3	awesome	
 1578	acceptable mandarina colada	3	good	
-1579	perfectly mixed triple-distilled gimlet	7	EPIC	
+1579	triple-distilled perfectly mixed gimlet	7	EPIC	
 1580	perfectly mixed brick road	3	EPIC	
 1581	delicious mirror vodka stratocaster	3	awesome	
-1582	acceptable strong ghostly Neuromancer	5	good	
+1582	strong acceptable ghostly Neuromancer	5	good	
 1583	hand-crafted prussian cathouse	3	EPIC	
 1584	tolerable Mae West	3	good	
-1585	mediocre triple-distilled Mon Tiki	9	decent	
+1585	triple-distilled mediocre Mon Tiki	9	decent	
 1586	distilled artisanal skewed teqiwila slammer	5	EPIC	
 1587	bland miniature Knob lo mein	2	decent	
-1588	massive decent asparagus lo mein	8	good	
+1588	decent massive asparagus lo mein	8	good	
 1589	normal green shaking Knoll lo mein	3	good	
-1590	huge toothsome lo mein	10	awesome	
-1591	decent immense tumbling spinning olive lo mein	6	good	
+1590	toothsome huge lo mein	10	awesome	
+1591	immense decent tumbling spinning olive lo mein	6	good	
 1592	adequate hot hi mein	3	good	
 1593	stale big mirror hi mein	5	decent	
-1594	small enchanted moldy hi mein	2	crappy	Effect: "Grape Expectations", Effect Duration: 10
-1595	stale shaking jittery hi mein	3	decent	
-1596	normal half-sized sleazy hi mein	2	good	
+1594	moldy small enchanted hi mein	2	crappy	Effect: "Grape Expectations", Effect Duration: 10
+1595	stale jittery shaking hi mein	3	decent	
+1596	half-sized normal sleazy hi mein	2	good	
 1597	Junior LAAAAME merit badge of the glutton	0		Food Drop: +100, Last Available: "2006-05"
 1598	rosewater-soaked Senior LAAAAME merit badge	0		Stench Resistance: +3, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	fancy tolerable tangarita with a fly in it	3	good	Effect: "Always In Motion", Effect Duration: 50
-1601	boozy drinkable mandarina colada with a fly in it	5	good	
+1600	tolerable fancy tangarita with a fly in it	3	good	Effect: "Always In Motion", Effect Duration: 50
+1601	drinkable boozy mandarina colada with a fly in it	5	good	
 1602	acceptable prussian cathouse with a fly in it	4	good	
-1603	practically non-alcoholic tolerable Mae West with a fly in it	1	good	
+1603	tolerable practically non-alcoholic Mae West with a fly in it	1	good	
 1604	compressed skewed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	boiled ultimate wad	1		Effect: "Wreathed in Merriment", Effect Duration: 5
@@ -1588,7 +1588,7 @@
 1608	colloidal colloidal blinking eyedrops of the ermine	0		Effect: "La Bamba", Effect Duration: 47
 1609	pickled denatured perfume of prejudice	0		Effect: "Ermine Eyes", Effect Duration: 24
 1610	extra-aerosolized denatured eyedrops of the ocelot	0		Effect: "Sugary World View", Effect Duration: 23
-1611	polarized spinning tumbling purple potent potion of potency	0		Effect: "Rainbow Bright", Effect Duration: 40
+1611	polarized purple spinning tumbling potent potion of potency	0		Effect: "Rainbow Bright", Effect Duration: 40
 1612	warmed upside-down maroon concentrated cordial of concentration	0		Effect: "Sepia Tan", Effect Duration: 37
 1613	pulsating censurious coffin lid	0		Sleaze Resistance: +3, Damage Reduction: 3
 1614	satin shield of the cheetah	0		Initiative: +60, Damage Reduction: 5
@@ -1616,11 +1616,11 @@
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	chilled tarnished lotion of hotness	0		Effect: "Hare-o-dynamic", Effect Duration: 20
 1638	improved improved skewed lime green squat lotion of coldness	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 61
-1639	altered ionized squat purple lotion of spookiness	0		Effect: "Spookypants", Effect Duration: 26
+1639	altered ionized purple squat lotion of spookiness	0		Effect: "Spookypants", Effect Duration: 26
 1640	nitrogenated activated ghostly lotion of stench	0		Effect: "Jelly Combed", Effect Duration: 29
 1641	vacuum-sealed lotion of sleaziness	0		Effect: "Well-Swabbed Ear", Effect Duration: 69
 1642	artisanal Grimacite Bock	4	EPIC	Last Available: "2008-11"
-1643	moldy thick blinking wedge of gray cheese	5	crappy	Last Available: "2008-11"
+1643	thick moldy blinking wedge of gray cheese	5	crappy	Last Available: "2008-11"
 1644	huge hot and sauce	0		
 1645	twirling and sauce	0		
 1646	and sauce	0		
@@ -1628,9 +1628,9 @@
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	normal enchanted jittery foie gras	4	good	Effect: "Nano-juiced", Effect Duration: 25
+1651	enchanted normal jittery foie gras	4	good	Effect: "Nano-juiced", Effect Duration: 25
 1652	unsweetened super-irradiated chilled upside-down candy brain	0		Effect: "Retrograde Relaxation", Effect Duration: 47, Last Available: "2020-09"
-1653	lime green executive foul-smelling veiny jewel-eyed wizard hat	0		Maximum HP: +10, Stench Damage: +10, Meat Drop: +40, Softcore Only, Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	lime green executive foul-smelling veiny jewel-eyed wizard hat	0		Maximum HP: +10, Stench Damage: +10, Meat Drop: +40, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	greedy Rosewater's wad of Crovacite	0		Mysticality Percent: +30, Meat Drop: +20
 1655	shellacked experienced collar	0		Experience: +2, Damage Reduction: 7
 1656	spinning White Citadel Satisfaction Satchel	0		
@@ -1647,7 +1647,7 @@
 1667	Cat-Herding Prod of terror	0		Spooky Spell Damage: +10
 1668	beefy star boomerang	0		Muscle: +10
 1669	grievous star stiletto	0		Weapon Damage Percent: +50
-1670	tumbling bouncing fraudwort	0		
+1670	bouncing tumbling fraudwort	0		
 1671	gray shysterweed	0		
 1672	huge swindleblossom	0		
 1673	teal blinking prompt smooth grave robbing shovel	0		Moxie: +15, Adventures: +3
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	blurry styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	bouncing knitted Da Vinci's sword	0		Experience (Mysticality): +5, Cold Resistance: +3
 1680	clever staff of the pedagogue	0		Experience: +3, Maximum MP: +20
 1681	wobbly veiny bubblewrap sword of the pedagogue	0		Experience: +3, Maximum HP: +10
@@ -1671,18 +1671,18 @@
 1691	chaotic Socratic discarded torn-up glove	0		Experience (Mysticality): +1, Spell Critical Percent: +10, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	super-oxidized unsweetened tarnished mirror salamander slurry	0		Effect: "Chari Tea", Effect Duration: 12
 1693	deionized anodized quantum blurry eyedrops of newt	0		Effect: "Antarctic Memories", Effect Duration: 16
-1694	colloidal ionized frozen wobbly skewed spinning Frogade	0		Effect: "Deep-Seated Rage", Effect Duration: 66
+1694	colloidal ionized frozen skewed wobbly spinning Frogade	0		Effect: "Deep-Seated Rage", Effect Duration: 66
 1695	energized adjusted papotion of papower	0		Effect: "Here's Mud in Your Eye", Effect Duration: 58
-1696	miniature decent royal jelly taco	2	good	
+1696	decent miniature royal jelly taco	2	good	
 1697	stale tofu taco	4	decent	
 1698	moldy jumping bean taco	3	crappy	
 1699	stale skewed catgut taco	3	decent	
 1700	yummy goat cheese taco	4	awesome	
-1701	bland diet pr0n taco	1	decent	
+1701	diet bland pr0n taco	1	decent	
 1702	frozen adjusted alphabet gum	0		Effect: "Memories of Puppy Love", Effect Duration: 46
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
-1705	upside-down cyan blinking flaregun	0		
+1705	upside-down blinking cyan flaregun	0		
 1706	clever brainy sword of Leguizamo	0		Mysticality: +5, Maximum MP: +20, Monster Level: +20
 1707	scandalous sizzling supercool flypaper staff	0		Moxie Percent: +20, Hot Damage: +10, Sleaze Damage: +5
 1708	Fonzie's grease gun of the scaredy-cat of the blizzard	0		Experience (Moxie): +1, Monster Level: -15, Cold Spell Damage: +25
@@ -1750,16 +1750,16 @@
 1771	vibrating butcherknife	0		Maximum MP Percent: +10
 1772	rosewater-soaked corn holder	0		Stench Resistance: +3
 1773	Socratic eggbeater	0		Experience (Mysticality): +1
-1774	bad distilled bottle of popskull	5	decent	
+1774	distilled bad bottle of popskull	5	decent	
 1775	healthy dishrag	0		Maximum HP Percent: +20
-1776	yummy immense purple stale baguette	10	awesome	
+1776	immense yummy purple stale baguette	10	awesome	
 1777	huge leftovers of indeterminate origin	0		
 1778	moldy dinner	3	crappy	
 1779	teal razor-sharp katana	0		Weapon Damage Percent: +25
 1780	tumbling slick ram stick	0		Moxie: +10
 1781	shaking greedy enchantlers	0		Meat Drop: +20, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	ruddy weightlifter's ram-battering staff	0		Muscle: +15, Maximum HP Percent: +40
-1783	moldy enchanted crazy Turkish delight	3	crappy	Effect: "Sappy Blood", Effect Duration: 45
+1783	enchanted moldy crazy Turkish delight	3	crappy	Effect: "Sappy Blood", Effect Duration: 45
 1784	cyan Snow Queen Crown of the ox of wisdom	0		Muscle: +20, Mysticality: +15, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	aromatic personal trainer's ga-ga radio of the ox	0		Muscle: +20, Experience Percent (Muscle): +10, Stench Resistance: +1
 1786	six pack of Mountain Stream	0		
@@ -1782,7 +1782,7 @@
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
-1806	blue pulsating spinning fifth cervical vertebra	0		
+1806	spinning blue pulsating fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	huge seventh cervical vertebra	0		
 1809	upside-down first thoracic vertebra	0		
@@ -1815,7 +1815,7 @@
 1836	eighth caudal vertebra	0		
 1837	ninth caudal vertebra	0		
 1838	ghostly tenth caudal vertebra	0		
-1839	squat shaking left first rib	0		
+1839	shaking squat left first rib	0		
 1840	left second rib	0		
 1841	blinking left third rib	0		
 1842	left fourth rib	0		
@@ -1827,11 +1827,11 @@
 1848	left tenth rib	0		
 1849	blurry left eleventh rib	0		
 1850	left twelfth rib	0		
-1851	shaking pulsating right first rib	0		
+1851	pulsating shaking right first rib	0		
 1852	right second rib	0		
-1853	skewed twirling right third rib	0		
+1853	twirling skewed right third rib	0		
 1854	bouncing right fourth rib	0		
-1855	pulsating huge right fifth rib	0		
+1855	huge pulsating right fifth rib	0		
 1856	yellow right sixth rib	0		
 1857	right seventh rib	0		
 1858	right eighth rib	0		
@@ -1842,7 +1842,7 @@
 1863	animal pelvis	0		
 1864	bouncing left scapula	0		
 1865	right scapula	0		
-1866	yellow squat left clavicle	0		
+1866	squat yellow left clavicle	0		
 1867	right clavicle	0		
 1868	left humerus	0		
 1869	twirling right humerus	0		
@@ -1923,12 +1923,12 @@
 1946	sharpshooter's accordion pin of the cougar	0		Moxie: +20, Critical Hit Percent: +10, Class: "Accordion Thief", Single Equip
 1947	arcane researcher's worn tophat of temperance	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	spinning electrified tap shoes of the brute	0		Muscle Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-1949	spoiled half-sized Manetwich	2	crappy	
+1949	half-sized spoiled Manetwich	2	crappy	
 1950	bottle of Vangoghbitussin	0		
 1951	weak artisanal pulsating bottle of Pinot Renoir	2	EPIC	
 1952	normal desiccated apricot	4	good	
 1953	tolerable flute of flat champagne	4	good	
-1954	bite-sized adequate red dehydrated caviar	1	good	
+1954	adequate bite-sized red dehydrated caviar	1	good	
 1955	styrofoam peanuts	0		
 1956	artisanal wobbly snifter of thoroughly aged brandy	4	EPIC	
 1957	quill pen	0		
@@ -1939,7 +1939,7 @@
 1962	triple-magnetized nitrogenated blinking Bit O' Ectoplasm	0		Effect: "Hyperoffended", Effect Duration: 28
 1963	dance card	0		
 1964	squat opera mask of the cougar	0		Moxie: +20, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
-1965	wobbly cyan bottle of Monsieur Bubble	0		
+1965	cyan wobbly bottle of Monsieur Bubble	0		
 1966	razor-sharp Amulet of Yendor of the boozehound	0		Weapon Damage Percent: +25, Booze Drop: +100, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	maroon wobbly bottle of perfume	0		Familiar Weight: +5
@@ -1996,12 +1996,12 @@
 2019	cream pie	0		Free Pull
 2020	half-sized yummy cherry pie	2	awesome	
 2021	small moldy strawberry pie	2	crappy	
-2022	spoiled jumbo lemon meringue pie	5	crappy	
+2022	jumbo spoiled lemon meringue pie	5	crappy	
 2023	Genalen&trade; Bottle	1	crappy	
 2024	rotten mixed wildflower greens	3	crappy	
 2025	tasty massive handful of walnuts	8	awesome	
 2026	flavorless half-sized nutty organic salad	2	decent	
-2027	tiny rotten super salad	1	crappy	
+2027	rotten tiny super salad	1	crappy	
 2028	bland tumbling tofu wonton	3	decent	
 2029	hippy protest button	0		Single Equip
 2030	vibrating forbidden Lockenstock&trade; sandals	0		Spell Damage Percent: +50, Maximum MP Percent: +10, Single Equip
@@ -2017,14 +2017,14 @@
 2040	patchouli oil bomb	0		
 2041	teal ferret bait	0		
 2042	maroon bouncing exploding hacky-sack	0		
-2043	tumbling spinning hemp net	0		
+2043	spinning tumbling hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	adequate huge brain-meltingly-hot chicken wings	3	good	
 2046	flavorless jumbo frat brats	5	decent	
 2047	half-sized rotten knob ka-bobs	2	crappy	
 2049	practically non-alcoholic perfectly mixed can of Swiller	1	EPIC	
 2050	broken wings	0		
-2051	ghostly green pulsating blinking sunken eyes	0		
+2051	pulsating green ghostly blinking sunken eyes	0		
 2052	blurry reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
@@ -2069,7 +2069,7 @@
 2093	Temple Grandin's hors d'oeuvre tray	0		Familiar Weight: +7, Damage Reduction: 5
 2094	stale ballroom blintz	4	decent	
 2095	towel	0		
-2096	denatured blinking olive guy made of bee pollen	1		Effect: "Lifted Spirits", Effect Duration: 25
+2096	denatured olive blinking guy made of bee pollen	1		Effect: "Lifted Spirits", Effect Duration: 25
 2097	bouncing personal trainer's 17-ball	0		Experience Percent (Muscle): +10
 2098	filthy lucre	0		
 2099	hobo gristle	0		
@@ -2122,7 +2122,7 @@
 2147	evil teddy bear sewing kit	0		
 2148	skewed toothsome rock	0		
 2149	moldy frank	3	crappy	Last Available: "2011-12"
-2150	delicious gigantic narrow plate of franks and beans	10	awesome	Last Available: "2011-12"
+2150	gigantic delicious narrow plate of franks and beans	10	awesome	Last Available: "2011-12"
 2151	bad shot of blackberry schnapps	4	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2138,7 +2138,7 @@
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
 2165	blue atomic vector plotter	0		Last Available: "2011-12"
-2166	cyan jittery ion-pulse modulation stabilizer	0		Last Available: "2011-12"
+2166	jittery cyan ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	Jeselnik's toy ray gun of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Last Available: "2006-12"
 2169	healthy toy space helmet of the early riser	0		Maximum HP Percent: +20, Adventures: +7, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
@@ -2146,7 +2146,7 @@
 2171	auspicious weightlifter's astronaut pants	0		Muscle: +15, Item Drop: +10, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	squat cyan careful toy jet pack	0		Monster Level: -10, Last Available: "2006-12"
 2173	triangular stone	0		
-2174	squat huge mossy stone sphere	0		
+2174	huge squat mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	blinking cracked stone sphere	0		
 2177	skewed rough stone sphere	0		
@@ -2190,9 +2190,9 @@
 2215	veiny Tropical Crimbo Hat	0		Maximum HP: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
 2216	wobbly teal quilted Tropical Crimbo Shorts	0		Damage Absorption: +40, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	normal super ka-bob	4	good	
-2218	decent big twirling beer basted brat	5	good	
+2218	big decent twirling beer basted brat	5	good	
 2219	ghostly yellow manspreader's Tropical Crimbo Sword	0		Monster Level: +10, Last Available: "2006-12"
-2220	Vulcanized corrupted shaking red mirror and Crimboween candy	0		Effect: "Ancestral Disapproval", Effect Duration: 51, Last Available: "2020-09"
+2220	Vulcanized corrupted red mirror shaking and Crimboween candy	0		Effect: "Ancestral Disapproval", Effect Duration: 51, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	narrow prompt lion tamer's liar's pants	0		Experience (familiar): +2, Adventures: +3, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	yellow wobbly scorching healthy juggler's balls	0		Maximum HP Percent: +20, Hot Damage: +25, Softcore Only, Last Available: "2007-01"
@@ -2201,7 +2201,7 @@
 2226	blurry cyan Rosewater's evil eyeball pendant of doom	0		Mysticality Percent: +30, Spooky Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	super-quantum huge arse-a'fire elixir	0		Effect: "Wings of the Grasshopper", Effect Duration: 20, Last Available: "2007-01"
 2228	frozen cosmic lemonade	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 43, Last Available: "2007-01"
-2229	aerosolized altered bouncing yellow toad horn	0		Effect: "Violent Night", Effect Duration: 64, Last Available: "2007-01"
+2229	aerosolized altered yellow bouncing toad horn	0		Effect: "Violent Night", Effect Duration: 64, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	mote	0		
 2232	yellow smudged alchemical recipe	0		
@@ -2231,21 +2231,21 @@
 2257	coward's chaotic reinforced furry underpants	0		Spell Critical Percent: +10, Monster Level: -20
 2258	&quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
-2260	shaking wobbly hard rock candy	0		
+2260	wobbly shaking hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	ghostly lion oil	0		
-2264	snack-sized delicious gray stunt nuts	2	awesome	
-2265	stale fancy fuchsia wet stew	4	decent	Effect: "Big", Effect Duration: 35
+2264	delicious snack-sized gray stunt nuts	2	awesome	
+2265	fancy stale fuchsia wet stew	4	decent	Effect: "Big", Effect Duration: 35
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	perfumed Staff of Fats	0		Stench Resistance: +5
-2269	half-sized normal blurry sausage wonton	2	good	
+2269	normal half-sized blurry sausage wonton	2	good	
 2270	fireproof occult belt	0		Spell Damage Percent: +25, Hot Resistance: +3, Single Equip
 2271	lousy bottle of Merlot	4	decent	
 2272	mediocre bottle of Port	3	decent	
 2273	acceptable bottle of Pinot Noir	4	good	
-2274	drinkable watered-down bottle of Zinfandel	2	good	
+2274	watered-down drinkable bottle of Zinfandel	2	good	
 2275	irresponsibly strong drinkable bottle of Marsala	6	good	
 2276	smooth shaking bottle of Muscat	3	awesome	
 2277	shaking Fernswarthy's key	0		
@@ -2280,7 +2280,7 @@
 2306	concentrated magnetized candy heart	0		Effect: "Turtle Power", Effect Duration: 28, Last Available: "2007-02"
 2307	ionized pulsating candy heart	0		Effect: "Industrial Strength Starch", Effect Duration: 60, Last Available: "2007-02"
 2308	corrupted altered jittery candy heart	0		Effect: "Category", Effect Duration: 64, Last Available: "2007-02"
-2309	cold-filtered wobbly spinning candy heart	0		Effect: "Ooh, Sour!", Effect Duration: 28, Last Available: "2007-02"
+2309	cold-filtered spinning wobbly candy heart	0		Effect: "Ooh, Sour!", Effect Duration: 28, Last Available: "2007-02"
 2310	narrow candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
 2312	narrow candygram	0		Last Available: "2007-02"
@@ -2290,7 +2290,7 @@
 2316	lime green broken carburetor	0		
 2317	bronze token	0		
 2318	bomb	0		
-2319	blue blurry carved wheel	0		
+2319	blurry blue carved wheel	0		
 2320	red worm-riding manual page	0		
 2321	pulsating worm-riding manual page 2	0		
 2322	red worm-riding manual pages 3-15	0		
@@ -2311,9 +2311,9 @@
 2337	teal Sinatra's reinforced beaded headband	0		Experience (Moxie): +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	spoiled pudding	3	crappy	Wiki Name: "black pudding (food)"
 2339	perfectly mixed weak Blackfly Chardonnay	2	EPIC	
-2340	practically non-alcoholic smooth red & tan	1	awesome	
+2340	smooth practically non-alcoholic red & tan	1	awesome	
 2341	mirror pepper	0		
-2342	gigantic adequate fancy forest cake	6	good	Effect: "Highland Sheen", Effect Duration: 15
+2342	adequate fancy gigantic forest cake	6	good	Effect: "Highland Sheen", Effect Duration: 15
 2343	snack-sized adequate forest ham	2	good	
 2344	anodized nitrogenated filthworm hatchling scent gland	0		Effect: "Patience of the Tortoise", Effect Duration: 50
 2345	dry filthworm drone scent gland	0		Effect: "Fishy Fortification", Effect Duration: 67
@@ -2344,10 +2344,10 @@
 2370	spinning pulsating natural fennel soda	0		
 2371	smoke bomb	0		
 2372	bunch of bananas	0		
-2373	low-calorie normal olive banana	1	good	
+2373	normal low-calorie olive banana	1	good	
 2374	banana peel	0		
 2375	moldy banana cream pie	3	crappy	
-2376	mediocre watered-down fancy banana daiquiri	2	decent	Effect: "[1701]Hip to the Jive", Effect Duration: 35
+2376	mediocre fancy watered-down banana daiquiri	2	decent	Effect: "[1701]Hip to the Jive", Effect Duration: 35
 2377	drinkable bungle in the jungle	3	good	
 2378	blue banana spritzer	0		
 2379	energized cold-filtered corrupted spinning banana smoothie	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 56
@@ -2373,9 +2373,9 @@
 2399	blinking hardened Elmley shades of Leguizamo	0		Damage Reduction: 3, Monster Level: +20, Single Equip
 2400	molotov cocktail cocktail	0		
 2401	jittery nasty beer bong of wisdom	0		Mysticality: +15, Stench Damage: +5
-2402	jittery shaking gauze garter	0		
+2402	shaking jittery gauze garter	0		
 2403	mirror barrel of gunpowder	0		
-2404	blurry cyan jam band flyers	0		
+2404	cyan blurry jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	mirror pink bat eye	0		
@@ -2394,8 +2394,8 @@
 2420	modified dry teeny-tiny magic scroll	0		Effect: "Chalk Outline", Effect Duration: 19
 2421	super-electrified bottle of pirate juice	0		Effect: "Turkey-Friendly", Effect Duration: 13
 2422	improved gray pulsating irradiated pet snacks	0		Effect: "It's Soporiffic!", Effect Duration: 64
-2423	chilled triple-anodized yellow shaking Mick's IcyVapoHotness Inhaler	0		Effect: "Updated", Effect Duration: 25
-2424	denatured pulsating teal cyclops eyedrops	0		Effect: "Sourpuss", Effect Duration: 24
+2423	chilled triple-anodized shaking yellow Mick's IcyVapoHotness Inhaler	0		Effect: "Updated", Effect Duration: 25
+2424	denatured teal pulsating cyclops eyedrops	0		Effect: "Sourpuss", Effect Duration: 24
 2425	improved activated ionized blurry can of spinach	0		Effect: "Weird Flavor", Effect Duration: 46
 2426	triple-altered fire flower	0		Effect: "Once Bitten Twice Fried", Effect Duration: 59
 2427	triple-electrified freezerburned ice cube	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 17
@@ -2404,7 +2404,7 @@
 2430	non-irradiated corrupted mirror bag of lard	0		Effect: "Rampage!", Effect Duration: 11
 2431	quadruple-warmed bottle of Mystic Shell	0		Effect: "Ripping, Dripping", Effect Duration: 25
 2432	quadruple-cold-filtered bouncing ghostly SPF 451 lip balm	0		Effect: "Healthy Blue Glow", Effect Duration: 60
-2433	unsweetened magnetized oxidized teal spinning ghostly bottle of antifreeze	0		Effect: "Woad Warrior", Effect Duration: 58
+2433	unsweetened magnetized oxidized spinning ghostly teal bottle of antifreeze	0		Effect: "Woad Warrior", Effect Duration: 58
 2434	non-altered super-liquefied eyedrops	0		Effect: "Optimist Primal", Effect Duration: 59
 2435	electrified purple Dogsgotnonoz pills	0		Effect: "Fishily Speeding", Effect Duration: 14
 2436	polarized enhanced donkey flipbook	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 51
@@ -2435,14 +2435,14 @@
 2462	squat odor extractor	0		Last Available: "2019-12"
 2463	ghostly Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	spoiled teal bowl of Bounty-Os	3	crappy	
-2465	acceptable watered-down Oreille Divis&eacute;e brandy	2	good	
+2465	watered-down acceptable Oreille Divis&eacute;e brandy	2	good	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	bundle of receipts	0		
 2470	cork	0		
 2471	stardust	0		
-2472	squat huge pulsating wilted lettuce	0		
+2472	pulsating huge squat wilted lettuce	0		
 2473	squat empty greasepaint tube	0		
 2474	clown skin	0		
 2475	chilly ruddy clown wig	0		Maximum HP Percent: +40, Cold Damage: +5, Clowniness: 50, Familiar Effect: "chromatic atk, 1xPotato, cap 12"
@@ -2472,7 +2472,7 @@
 2499	molybdenum screwdriver	0		
 2500	skewed molybdenum pliers	0		
 2501	molybdenum crescent wrench	0		
-2502	cyan twirling Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
+2502	twirling cyan Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	spinning necklace chain	0		
@@ -2481,7 +2481,7 @@
 2508	green medical-grade beach glass necklace	0		HP Regen Min: 7, HP Regen Max: 10
 2509	flame-retardant peace-sign necklace	0		Hot Resistance: +1
 2510	shaking cyan extremely unsafe round sunglasses of the sweet-tooth	0		Weapon Damage Percent: +100, Candy Drop: +100, Single Equip
-2511	purple shaking Frat Army FGF	0		
+2511	shaking purple Frat Army FGF	0		
 2512	Hippy Army MPE	0		
 2513	teal vibrating stiffened spark plug earring	0		Damage Reduction: 1, Maximum MP Percent: +10
 2514	bouncing yellow wizardly woven baling wire bracelets of the brute	0		Mysticality: +25, Muscle Percent: +30
@@ -2491,24 +2491,24 @@
 2518	censurious sawblade shield	0		Sleaze Resistance: +3, Damage Reduction: 11
 2519	boozy hand-crafted McMillicancuddy's Special Lager	5	EPIC	
 2520	practically non-alcoholic perfectly mixed melted Jell-o shot	1	EPIC	
-2521	extra-dry perfectly mixed maroon cruelty-free wine	5	EPIC	
+2521	perfectly mixed extra-dry maroon cruelty-free wine	5	EPIC	
 2522	aged weak thistle wine	2	awesome	
 2523	ghostly megatofu	0		
 2524	displaced fish	0		
 2525	small stale jittery fish	2	decent	
-2526	huge adequate fish casserole	10	good	
+2526	adequate huge fish casserole	10	good	
 2527	rotten spinning squat fish lasagna	4	crappy	
 2528	purple filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	toothsome gnatloaf	3	awesome	
-2530	moldy super-sized mirror gnatloaf casserole	5	crappy	
-2531	bite-sized yummy gnat lasagna	1	awesome	
+2530	super-sized moldy mirror gnatloaf casserole	5	crappy	
+2531	yummy bite-sized gnat lasagna	1	awesome	
 2532	narrow pork	0		
 2533	toothsome big pork chop sandwiches	5	awesome	
-2534	tiny normal fancy pork casserole	1	good	Effect: "A View to Some Meat", Effect Duration: 50
+2534	tiny fancy normal pork casserole	1	good	Effect: "A View to Some Meat", Effect Duration: 50
 2535	delicious pork lasagna	4	awesome	
 2536	canopic jar	0		
 2537	spice	0		
-2538	bouncing shaking organs	0		
+2538	shaking bouncing organs	0		
 2539	educational Ankh of Badahnkadh	0		Experience: +1, Single Equip
 2540	tomb ratchet	0		
 2541	bouncing Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
@@ -2520,12 +2520,12 @@
 2547	stanky banded tin star	0		Damage Absorption: +100, Stench Spell Damage: +25, Last Available: "2007-05"
 2548	spinning foul-smelling outrageous sombrero of Leguizamo	0		Monster Level: +20, Stench Damage: +10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	Annie Oakley's Da Vinci's &quot;Humorous&quot; T-shirt	0		Experience (Mysticality): +5, Critical Hit Percent: +20, Last Available: "2007-05"
-2550	fuchsia jittery Peppercorns of Power	0		
+2550	jittery fuchsia Peppercorns of Power	0		
 2551	vial of mojo	0		
 2552	ghostly reeds	0		
 2553	mirror turtle chain	0		
 2554	distilled seal blood	0		
-2555	purple twirling high-octane olive oil	0		
+2555	twirling purple high-octane olive oil	0		
 2556	Jeselnik's supercharged Shagadelic Disco Banjo of the brute	0		Muscle Percent: +30, Maximum MP Percent: +30, Sleaze Damage: +25, Class: "Disco Bandit"
 2557	lard-coated nasty Squeezebox of the Ages	0		Stench Damage: +5, Sleaze Spell Damage: +25, Class: "Accordion Thief", Song Duration: 15
 2558	sage Chelonian Morningstar of the scaredy-cat	0		Mysticality Percent: +10, Monster Level: -15, Class: "Turtle Tamer"
@@ -2559,16 +2559,16 @@
 2586	General Sage's Lonely Diamonds Club Jacket of the dark arts	0		Spell Damage Percent: +100
 2587	twirling Corporal Fennel's Lonely Clubs Club Jacket of James Dean	0		Experience (Moxie): +3
 2588	beefy Private Pepper's Lonely Hearts Club Jacket	0		Muscle: +10
-2589	low-calorie spoiled hot date	1	crappy	
+2589	spoiled low-calorie hot date	1	crappy	
 2590	weak drinkable wobbly distilled fortified wine	2	good	
 2591	yummy snack-sized tasty tart	2	awesome	
 2592	Knob Goblin lunchbox	0		
-2593	normal massive Knob pasty	6	good	
-2594	special bad weak thermos full of Knob coffee	2	decent	Effect: "Stinking Cloud", Effect Duration: 20
+2593	massive normal Knob pasty	6	good	
+2594	special weak bad thermos full of Knob coffee	2	decent	Effect: "Stinking Cloud", Effect Duration: 20
 2595	enhanced tumbling purple Ben-Gal&trade; Balm	0		Effect: "Stregngth of the Gnome", Effect Duration: 31
 2596	wobbly leathery cat skin	0		
 2597	fuchsia leathery bat skin	0		
-2598	spinning fuchsia leathery rat skin	0		
+2598	fuchsia spinning leathery rat skin	0		
 2599	jittery Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	lightning-fast stylish Staff of the Midnight Snack of incineration	0		Moxie: +25, Hot Spell Damage: +50, Initiative: +40
@@ -2604,7 +2604,7 @@
 2631	quantum gremlin juice	0		Effect: "Human-Orc Hybrid", Effect Duration: 44
 2632	moist ghostly mother's helper	0		Effect: "Indescribable Flavor", Effect Duration: 66
 2633	tumbling knitted Annie Oakley's pat-a-cake pendant	0		Critical Hit Percent: +20, Cold Resistance: +3
-2634	spinning maroon mummy wrapping	0		
+2634	maroon spinning mummy wrapping	0		
 2635	ghostly really thick bandage	0		
 2636	sizzling mummy mask	0		Hot Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	huge flame-retardant gauze shorts of vim and vigor	0		Maximum HP Percent: +50, Hot Resistance: +1, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
@@ -2642,7 +2642,7 @@
 2669	powdered blurry patent antipsychotics	1		Last Available: "2007-06"
 2670	diluted Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	enchanted perfectly mixed upside-down shot of nepenthe schnapps	3	EPIC	Effect: "Booze Goozles", Effect Duration: 40, Last Available: "2007-06"
-2672	purple shaking library card	0		Last Available: "2007-06"
+2672	shaking purple library card	0		Last Available: "2007-06"
 2673	shaking Bohemian rhapsody	0		Last Available: "2007-06"
 2674	oxidized triple-unsweetened deionized skewed bottle of cat tonic	0		Effect: "Orchid Blood", Effect Duration: 41, Last Available: "2007-06"
 2675	dehydrated handful of moss	1		
@@ -2661,7 +2661,7 @@
 2688	lightning-fast reassuring chaotic dreadlock whip	0		Spell Critical Percent: +10, Spooky Resistance: +1, Initiative: +40
 2689	Van der Graaf sage beer-a-pult	0		Mysticality Percent: +10, MP Regen Min: 5, MP Regen Max: 7
 2690	cast-iron legacy paddle of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100
-2691	miniature normal handful of nuts and berries	2	good	
+2691	normal miniature handful of nuts and berries	2	good	
 2692	zippy savvy driftwood sculpture	0		Mysticality Percent: +20, Initiative: +20
 2693	massive sitar of the brazier of incineration	0		Hot Spell Damage: 75
 2694	rock-hard Samson's stone baseball cap of Tarzan	0		Experience (Muscle): 8, Damage Reduction: 5, Familiar Effect: "1xVolley, cap 48"
@@ -2696,24 +2696,24 @@
 2723	medical-grade Rosewater's beefy Staff of the Grand Flamb&eacute;	0		Muscle: +10, Mysticality Percent: +30, HP Regen Min: 7, HP Regen Max: 10
 2724	normal purple bowl of rye sprouts	4	good	
 2725	tasty huge cob of corn	3	awesome	
-2726	diet stale juniper berries	1	decent	
+2726	stale diet juniper berries	1	decent	
 2727	delicious plum	4	awesome	
 2728	spoiled pear	3	crappy	
 2729	moldy pulsating peach	4	crappy	
 2730	drinkable plum wine	3	good	
 2731	enchanted tolerable shot of pear schnapps	3	good	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 5
-2732	perfectly mixed irresponsibly strong tumbling pulsating shot of peach schnapps	9	EPIC	
+2732	perfectly mixed irresponsibly strong pulsating tumbling shot of peach schnapps	9	EPIC	
 2733	normal bunch of square grapes	4	good	
 2734	tasty squat brown sugar cane	3	awesome	
 2735	bite-sized yummy narrow sandwich of the gods	1	awesome	
-2736	high-proof drinkable Pan-Dimensional Gargle Blaster	9	good	
+2736	drinkable high-proof Pan-Dimensional Gargle Blaster	9	good	
 2737	pickled skewed leopard-print barbell	1	awesome	
 2738	pile of smoking rags	0		
 2739	deionized extra-denatured panty raider camouflage	0		Effect: "Fishily Speeding", Effect Duration: 62
 2740	foul-smelling sinister experienced Staff of the Walk-In Freezer	0		Experience: +2, Spell Damage: +10, Stench Damage: +10
 2741	artisanal boilermaker	3	EPIC	
 2742	stale steel lasagna	3	quest	
-2743	smooth weak gray steel margarita	2	quest	
+2743	weak smooth gray steel margarita	2	quest	
 2744	altered wobbly steel-scented air freshener	1		
 2745	polarized gremlin mutagen	0		Effect: "Prideful Strut", Effect Duration: 31
 2746	concentrated extra-potent gremlin mutagen	0		Effect: "Spiky Hair", Effect Duration: 68
@@ -2737,11 +2737,11 @@
 2764	occult weightlifter's Order of the Silver Wossname of Calamity Jane	0		Muscle: +15, Spell Damage Percent: +25, Critical Hit Percent: +15, Single Equip
 2765	squat Harold's bell	0		
 2766	twirling bowling ball	0		
-2767	flavorless super-sized Crimbo pie	5	decent	
+2767	super-sized flavorless Crimbo pie	5	decent	
 2768	bland pear tart	3	decent	
 2769	toothsome tumbling peach pie	3	awesome	
 2770	moist corrupted chunk of rock salt	0		Effect: "Salt Rockin'", Effect Duration: 56
-2771	activated shaking maroon handful of pine needles	0		Effect: "Toast Tea", Effect Duration: 35
+2771	activated maroon shaking handful of pine needles	0		Effect: "Toast Tea", Effect Duration: 35
 2772	steamy ruby	0		
 2773	glacial sapphire	0		
 2774	unearthly onyx	0		
@@ -2802,7 +2802,7 @@
 2829	really dense meat stack	0		
 2830	digital key lime	0		
 2831	narrow star key lime	0		
-2832	special spoiled digital key lime pie	3	crappy	Effect: "Spirit of Alph", Effect Duration: 15
+2832	spoiled special digital key lime pie	3	crappy	Effect: "Spirit of Alph", Effect Duration: 15
 2833	decent star key lime pie	3	good	
 2834	narrow prompt brainy bottle-rocket crossbow of chilblains	0		Mysticality: +5, Cold Damage: +25, Adventures: +3, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	skewed up-at-dawn indie comic hipster glasses	0		Adventures: +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -2821,16 +2821,16 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	delicious moonberry wine cooler	3	awesome	
-2851	miniature decent fine aged cheddarwurst	2	good	
+2851	decent miniature fine aged cheddarwurst	2	good	
 2852	twirling branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	rosewater-soaked lion tamer's huge mosquito proboscis	0		Experience (familiar): +2, Stench Resistance: +3
 2856	anodized non-polarized ghostly swamp lolly	0		Effect: "Flambé-a-thon", Effect Duration: 52
 2857	corrupted twirling seegar butt	0		Effect: "Here to Kick Ass", Effect Duration: 14
-2858	blurry fuchsia bottled swamp gas	0		
+2858	fuchsia blurry bottled swamp gas	0		
 2859	zippy cool witch wart	0		Moxie: +5, Initiative: +20
-2860	fancy toothsome swamp muck	3	awesome	Effect: "Tin, Man", Effect Duration: 30
+2860	toothsome fancy swamp muck	3	awesome	Effect: "Tin, Man", Effect Duration: 30
 2861	reassuring leechknife of terror of temperance	0		Spooky Spell Damage: +10, Spooky Resistance: +1, Sleaze Resistance: +5
 2862	decomposed boot	0		
 2863	warmed dribbly candle	0		Effect: "Flower Power", Effect Duration: 53
@@ -2924,28 +2924,28 @@
 2952	green razor-sharp glowstick of incineration	0		Weapon Damage Percent: +25, Hot Spell Damage: +50, Last Available: "2007-11"
 2953	lime green charrrm bracelet	0		
 2954	therapeutic tip jar	0		HP Regen Min: 5, HP Regen Max: 7
-2955	bite-sized toothsome yam candy	1	awesome	
+2955	toothsome bite-sized yam candy	1	awesome	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	diet normal teal shaking tube of cranberry Go-Goo	1	good	
 2959	gray up-at-dawn rum barrel charrrm bracelet	0		Adventures: +5
 2960	flavorless single-serving herbal stuffing	4	decent	
 2961	delicious miniature packet of tofurkey gravy	2	awesome	
-2962	flavorless super-sized tofurkey nugget	5	decent	
+2962	super-sized flavorless tofurkey nugget	5	decent	
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	narrow mizzenmast mop	0		
 2966	ghostly Tom's of the Spanish Main Toothpaste	0		
 2967	adjusted Swabbie&trade; swab	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 33
 2968	warmed double-polymerized huge Oil of Parrrlay	0		Effect: "Blood-Gorged", Effect Duration: 58
-2969	adequate jumbo creamsicle	5	good	
+2969	jumbo adequate creamsicle	5	good	
 2970	lousy spinning cream stout	3	decent	
 2971	maroon pulsating nasty curmudgel of the pedagogue	0		Experience: +3, Stench Damage: +5
 2972	grumpy man charrrm	0		
 2973	grumpy man charrrm bracelet of James Dean	0		Experience (Moxie): +3, Single Equip
-2974	ghostly mirror jittery tarrrnish charrrm	0		
+2974	mirror ghostly jittery tarrrnish charrrm	0		
 2975	red thinker's tarrrnished charrrm bracelet of the blizzard	0		Mysticality: +10, Cold Spell Damage: +25, Single Equip
-2976	special bad bilge wine	4	decent	Effect: "Gummi-Grin", Effect Duration: 35
+2976	bad special bilge wine	4	decent	Effect: "Gummi-Grin", Effect Duration: 35
 2977	skewed Samson's witty rapier	0		Experience (Muscle): +5
 2978	upside-down twirling ghostly Usain Bolt's wholesome yohohoyo	0		Maximum HP Percent: +10, Initiative: +80
 2979	chilled pickled improved fish-liver oil	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 53
@@ -2962,7 +2962,7 @@
 2990	crafty extremely unsafe clingfilm cap	0		Weapon Damage Percent: +100, Maximum MP: +10, Familiar Effect: "1xVolley, cap 37"
 2991	spinning maroon studded clingfilm slippers	0		Damage Absorption: +80, Single Equip
 2992	narrow clingfilm tangle	0		
-2993	stale small vinegar-soaked lemon slice	2	decent	
+2993	small stale vinegar-soaked lemon slice	2	decent	
 2994	polymerized true grit	0		Effect: "Pronounced Potency", Effect Duration: 32
 2995	perfumed scandalous buoybottoms of mayonnaise	0		Sleaze Damage: +5, Sleaze Spell Damage: +50, Stench Resistance: +5, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	narrow zippy grungy flannel shirt	0		Initiative: +20
@@ -2985,7 +2985,7 @@
 3013	simple key	0		
 3014	ornate key	0		
 3015	gilded key	0		
-3016	skewed spinning foot locker	0		
+3016	spinning skewed foot locker	0		
 3017	blurry green ornate chest	0		
 3018	gilded chest	0		
 3019	all-purpose cleaner	0		
@@ -2993,27 +2993,27 @@
 3021	stone triangle	0		
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
-3024	maroon upside-down stone pyramid	0		
+3024	upside-down maroon stone pyramid	0		
 3025	delicious corpse on the beach	4	awesome	
 3026	bad fortified corpsetini	5	decent	
 3027	mediocre twirling corpsedriver	4	decent	
 3028	perfectly mixed Corpse Island iced tea	4	EPIC	
 3029	delicious red-headed corpse	4	awesome	
-3030	triple-distilled acceptable kamicorpse-ee	6	good	
+3030	acceptable triple-distilled kamicorpse-ee	6	good	
 3031	weak bad corpsel	2	decent	
 3032	perfectly mixed corpsebite	4	EPIC	
 3033	scandalous pirate fledges	0		Sleaze Damage: +5
 3034	piece of thirteen	0		
 3035	normal pearl onion	4	good	
-3036	small adequate sea biscuit	2	good	
+3036	adequate small sea biscuit	2	good	
 3037	bad upside-down bottle of rum	4	decent	
-3038	enchanted extra-dry bad bottle of black-label rum	5	decent	Effect: "Lemony Goodness", Effect Duration: 35
+3038	bad enchanted extra-dry bottle of black-label rum	5	decent	Effect: "Lemony Goodness", Effect Duration: 35
 3039	cannonball	0		
 3040	huge voodoo skull	0		
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	normal mirror nanite-infested gingerbread bugbear	3	good	Last Available: "2007-12"
 3046	normal nanite-infested candy cane	3	good	Last Available: "2020-09"
 3047	decent nanite-infested fruitcake	4	good	Last Available: "2007-12"
@@ -3022,7 +3022,7 @@
 3050	clever eyepatch	0		Maximum MP: +20, Familiar Effect: "spooky atk, 1xBarrr"
 3051	squat mirror shellacked cutlass	0		Damage Reduction: 7
 3052	electrified breeches	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "stench atk, 1xPotato"
-3053	twirling upside-down mood ring	0		Last Available: "2007-02"
+3053	upside-down twirling mood ring	0		Last Available: "2007-02"
 3054	tarnished polarized squat shaking candy heart	0		Effect: "Inappropriate Spirit", Effect Duration: 28, Last Available: "2007-02"
 3055	deionized shaking cymbal syrup	0		Free Pull, Effect: "Disdain of She-Who-Was", Effect Duration: 50, Last Available: "2007-02"
 3056	Da Vinci's metallic foil cat ears	0		Experience (Mysticality): +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
@@ -3055,7 +3055,7 @@
 3083	gray blob	0		Last Available: "2007-12"
 3084	wobbly dangerous borg sock monkey	0		Weapon Damage: +10, Last Available: "2007-12"
 3085	nasty cool roboduck-on-a-string	0		Moxie: +5, Stench Damage: +5, Last Available: "2007-12"
-3086	narrow lime green mylar scout drone	0		Last Available: "2007-12"
+3086	lime green narrow mylar scout drone	0		Last Available: "2007-12"
 3087	spinning teddy borg sewing kit	0		Last Available: "2007-12"
 3088	banded strapping biomechanical crimborg helmet	0		Muscle: +5, Damage Absorption: +100, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	lime green wobbly personal trainer's C.B.F.G. of the detective	0		Experience Percent (Muscle): +10, Item Drop: +20, Last Available: "2007-12"
@@ -3079,7 +3079,7 @@
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	fuchsia Miniborg stomper	0		Last Available: "2007-12"
-3110	jittery mirror Miniborg strangler	0		Last Available: "2007-12"
+3110	mirror jittery Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
@@ -3093,12 +3093,12 @@
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
-3124	corrupted Vulcanized activated upside-down blinking fruitfilm	0		Effect: "Sausage Festive", Effect Duration: 35
+3124	corrupted Vulcanized activated blinking upside-down fruitfilm	0		Effect: "Sausage Festive", Effect Duration: 35
 3125	pressed galvanized piece of after eight	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 48
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	tasty snack-sized ghostly roasted marshmallow	2	awesome	
+3129	snack-sized tasty ghostly roasted marshmallow	2	awesome	
 3130	disc	0		Last Available: "2008-01"
 3131	stale tin cup of mulligan stew	3	decent	
 3132	red narrow Rosewater's flamin' bindle of the wise owl	0		Mysticality: +20, Mysticality Percent: +30
@@ -3128,24 +3128,24 @@
 3156	El Vibrato punchcard (104 holes)	0		
 3157	El Vibrato drone	0		
 3158	cyan sparking El Vibrato drone	0		
-3159	denatured vacuum-sealed ghostly tumbling warm El Vibrato drone	0		Effect: "Walberg's Dim Bulb", Effect Duration: 34
-3160	concentrated fuchsia upside-down shaking humming El Vibrato drone	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 14
+3159	denatured vacuum-sealed tumbling ghostly warm El Vibrato drone	0		Effect: "Walberg's Dim Bulb", Effect Duration: 34
+3160	concentrated shaking upside-down fuchsia humming El Vibrato drone	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 14
 3161	ionized squat El Vibrato drone	0		Effect: "One For Tea", Effect Duration: 45
-3162	blinking squat yellow El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
-3163	shaking teal spinning El Vibrato energy spear	0		
+3162	blinking yellow squat El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
+3163	shaking spinning teal El Vibrato energy spear	0		
 3164	narrow El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	wobbly broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	denatured extra-wet seal eyeball	0		Effect: "init.enh", Effect Duration: 66
-3169	snack-sized flavorless turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	flavorless snack-sized turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	evil paper umbrella of the storm	0		Maximum MP Percent: +40
 3173	oxidized activated evil vihuela	0		Effect: "Improprie Tea", Effect Duration: 27
 3174	rotten evil boring spaghetti	3	crappy	
 3175	rotten miniature huge evil noodles	2	crappy	
-3176	stale huge evil noodles	10	decent	
+3176	huge stale evil noodles	10	decent	
 3177	delicious tumbling evil painful penne pasta	4	awesome	
 3178	diet bland 3vi1 pr0n m4nic0tti	1	decent	
 3179	spoiled evil ravioli della hippy	3	crappy	
@@ -3160,7 +3160,7 @@
 3188	weak lousy skewed tumbling an evil sump'm sump'm	2	decent	
 3189	drinkable skewed evil ducha de oro	3	good	
 3190	drinkable evil horizontal tango	4	good	
-3191	drinkable weak evil roll in the hay	2	good	
+3191	weak drinkable evil roll in the hay	2	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	skewed origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3194,14 +3194,14 @@
 3222	spinning curative gatorskin umbrella of horror	0		Spooky Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5
 3223	shaking sewer nuggets	0		
 3224	tumbling sewer wad	0		
-3225	watered-down tolerable enchanted bottle of sewage schnapps	2	good	Effect: "Memory of Speed", Effect Duration: 40
+3225	watered-down enchanted tolerable bottle of sewage schnapps	2	good	Effect: "Memory of Speed", Effect Duration: 40
 3226	tolerable bottle of Ooze-O	4	good	
-3227	snack-sized decent squat C.H.U.M. chum	2	good	
-3228	huge toothsome unfortunate dumplings	7	awesome	
+3227	decent snack-sized squat C.H.U.M. chum	2	good	
+3228	toothsome huge unfortunate dumplings	7	awesome	
 3229	ghostly decaying goldfish liver	0		
 3230	irradiated frozen improved oil of oiliness	0		Effect: "Well-Swabbed Ear", Effect Duration: 25
 3231	narrow energetic tattered paper crown	0		Maximum MP Percent: +20, Familiar Effect: "1xSombrero, cap 15"
-3232	stale snack-sized olive vanilla-frosted king cake	2	decent	Last Available: "2008-03"
+3232	snack-sized stale olive vanilla-frosted king cake	2	decent	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	skewed noodle	0		
@@ -3232,17 +3232,17 @@
 3260	lime green perfumed gravedigger's smooth Chester's moustache	0		Moxie: +15, Spooky Damage: +10, Stench Resistance: +5, Class: "Disco Bandit", Single Equip
 3261	knitted frosty Chester's bag of candy	0		Cold Spell Damage: +10, Cold Resistance: +3, Class: "Disco Bandit"
 3262	fireproof sinister Chester's cutoffs	0		Spell Damage: +10, Hot Resistance: +3, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	ghostly narrow gray Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	ghostly gray narrow Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	squat candygram	0		Last Available: "2008-04"
 3265	upside-down bag of Crotchety Pine saplings	0		
 3266	mirror bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
-3268	unsweetened blinking red handful of Crotchety Pine needles	0		Effect: "Patent Alacrity", Effect Duration: 24
+3268	unsweetened red blinking handful of Crotchety Pine needles	0		Effect: "Patent Alacrity", Effect Duration: 24
 3269	pressed squat lump of Saccharine Maple sap	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 55
 3270	improved polarized twirling spinning handful of Laughing Willow bark	0		Effect: "Serendipi Tea", Effect Duration: 56
-3271	rock-hard crotchety pants	0		Damage Reduction: 5, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	rock-hard crotchety pants	0		Damage Reduction: 5, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	blinking green huge avaricious Saccharine Maple pendant	0		Meat Drop: +30, Conditional Skill (Equipped): "Spray Sap"
-3273	auspicious willowy bonnet	0		Item Drop: +10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	auspicious willowy bonnet	0		Item Drop: +10, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3296,7 +3296,7 @@
 3324	spinning Frosty's frosty mug	0		
 3325	acceptable jar of fermented pickle juice	3	good	
 3326	vaporized ghostly voodoo snuff	1	good	
-3327	half-sized stale extra-greasy slider	2	decent	
+3327	stale half-sized extra-greasy slider	2	decent	
 3328	chilly quilted crumpled felt fedora	0		Damage Absorption: +40, Cold Damage: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	blue grievous battered top-hat of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	lightning-fast shapeless wide-brimmed hat of the dark arts	0		Spell Damage Percent: +100, Initiative: +40, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3319,7 +3319,7 @@
 3347	comfy coffin	0		
 3348	mattress	0		
 3349	upside-down dinged-up triangle	0		
-3350	hand-crafted weak enchanted ghostly squat Ralph IX cognac	2	super ultra mega turbo EPIC	Effect: "Ready to Snap", Effect Duration: 40
+3350	enchanted hand-crafted weak squat ghostly Ralph IX cognac	2	super ultra mega turbo EPIC	Effect: "Ready to Snap", Effect Duration: 40
 3351	twirling llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	shaking zen motorcycle	0		Last Available: "2008-06"
 3353	magnetized lime green llama lama gong	0		Effect: "Booing Radly", Effect Duration: 16, Last Available: "2008-06"
@@ -3332,8 +3332,8 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	bland massive shaking mole mol&eacute;	9	decent	Last Available: "2008-06"
-3364	fancy aged watered-down red Morlock's Mark Bourbon	2	awesome	Effect: "Filled with Magic", Effect Duration: 15, Last Available: "2008-06"
+3363	massive bland shaking mole mol&eacute;	9	decent	Last Available: "2008-06"
+3364	aged watered-down fancy red Morlock's Mark Bourbon	2	awesome	Effect: "Filled with Magic", Effect Duration: 15, Last Available: "2008-06"
 3365	triple-boiled blinking cyan Climate Colada	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 28, Last Available: "2008-06"
 3366	denatured digital underground potion	0		Effect: "Enraged", Effect Duration: 49, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3342,7 +3342,7 @@
 3370	compressed blurry glimmering penguin feather	1		Last Available: "2008-06"
 3371	dried wobbly pulsating glimmering buzzard feather	1		Last Available: "2008-06"
 3372	mixed jittery glimmering raven feather	1		Last Available: "2008-06"
-3373	denatured upside-down teal glimmering great tit feather	1		Effect: "Human-Pirate Hybrid", Effect Duration: 50, Last Available: "2008-06"
+3373	denatured teal upside-down glimmering great tit feather	1		Effect: "Human-Pirate Hybrid", Effect Duration: 50, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	blinking Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3362,7 +3362,7 @@
 3390	executive smartaleck's Staff of the Deepest Freeze of the businessman	0		Moxie Percent: +30, Meat Drop: 90
 3391	Frosty's iceball	0		
 3392	pulsating squat Sherlock's Oscus's garbage can lid	0		Item Drop: +25, Damage Reduction: 15
-3393	yellow bouncing Oscus's neverending soda	0		
+3393	bouncing yellow Oscus's neverending soda	0		
 3394	tumbling double-paned Oscus's flypaper pants of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +5, Familiar Effect: "stench atk, 1xPotato"
 3395	energetic rosy-cheeked Hodgman's porkpie hat	0		Maximum HP Percent: +30, Maximum MP Percent: +20, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	studded beefy Hodgman's lobsterskin pants	0		Muscle: +10, Damage Absorption: +80, Familiar Effect: "atk, 1xPotato"
@@ -3390,7 +3390,7 @@
 3422	adjusted colloidal wobbly sterno-flavored Hob-O	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 41
 3423	altered spinning frostbite-flavored Hob-O	0		Effect: "Woad Warrior", Effect Duration: 34
 3424	ionized energized twirling fry-oil-flavored Hob-O	0		Effect: "So You Can Work More...", Effect Duration: 35
-3425	enhanced moist pulsating huge garbage-juice-flavored Hob-O	0		Effect: "Trufflin'", Effect Duration: 19
+3425	enhanced moist huge pulsating garbage-juice-flavored Hob-O	0		Effect: "Trufflin'", Effect Duration: 19
 3426	boiled warmed strawberry-flavored Hob-O	0		Effect: "Ancestral Disapproval", Effect Duration: 50
 3427	bouncing roll of Hob-Os	0		
 3428	colloidal shaking gray Everlasting Deckswabber	0		Effect: "Nano-juiced", Effect Duration: 20
@@ -3404,7 +3404,7 @@
 3437	blue dance instructor's Staff of the Black Kettle of James Dean of terror	0		Experience (Moxie): +3, Experience Percent (Moxie): +10, Spooky Spell Damage: +10
 3438	Lo Pan's Staff of the Well-Tempered Cauldron of the blizzard of courage	0		Spell Critical Percent: +30, Cold Spell Damage: +25, Spooky Resistance: +3
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	powdered upside-down olive prismatic wad	1	decent	Effect: "Berry Thorny", Effect Duration: 40, Last Available: "2008-07"
+3440	powdered olive upside-down prismatic wad	1	decent	Effect: "Berry Thorny", Effect Duration: 40, Last Available: "2008-07"
 3441	cyan club of the five seasons of bravery	0		Spooky Resistance: +5, Last Available: "2008-07"
 3442	electrified rainbow crossbow	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-07"
 3443	kitten	0		
@@ -3422,12 +3422,12 @@
 3455	bouncing purple cotton candy bale	0		Last Available: "2008-08"
 3456	beefy trusty torch	0		Muscle: +10, Last Available: "2011-12"
 3457	asbestos-lined Junior Adventurer's merit badge	0		Hot Resistance: +5
-3458	chilled warmed blinking yellow STYX deodorant body spray	0		Effect: "Reedy Pipes", Effect Duration: 54
+3458	chilled warmed yellow blinking STYX deodorant body spray	0		Effect: "Reedy Pipes", Effect Duration: 54
 3459	bad white-label gin	3	decent	
-3460	moldy jumbo tin rations	5	crappy	
+3460	jumbo moldy tin rations	5	crappy	
 3461	shaking haiku challenge map	0		
 3462	jittery terrible poem	0		
-3463	weak acceptable bouncing bottle of sake	2	good	
+3463	acceptable weak bouncing bottle of sake	2	good	
 3464	dangerous round pebble	0		Weapon Damage: +10
 3465	adequate small Bash-&#332;s cereal	2	good	Wiki Name: "Bash-Os cereal"
 3466	baleful Rosewater's wizardly haiku katana	0		Mysticality: +25, Mysticality Percent: +30, Spell Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
@@ -3453,7 +3453,7 @@
 3486	ghostly huge bouncing dull fish scale	0		
 3487	mirror rough fish scale	0		
 3488	pristine fish scale	0		
-3489	adequate big beefy fish meat	5	good	Effect: "Fishy", Effect Duration: 5
+3489	big adequate beefy fish meat	5	good	Effect: "Fishy", Effect Duration: 5
 3490	bland glistening fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3491	yummy slick fish meat	4	awesome	Effect: "Fishy", Effect Duration: 5
 3492	vibrating Da Vinci's fish scimitar	0		Experience (Mysticality): +5, Maximum MP Percent: +10
@@ -3476,7 +3476,7 @@
 3509	upside-down scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	blue scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
-3512	wobbly green scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
+3512	green wobbly scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	bouncing scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	horrifying banded ganger bandana	0		Damage Absorption: +100, Spooky Damage: +25, Familiar Effect: "atk"
@@ -3504,7 +3504,7 @@
 3537	jittery plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	green plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	blurry plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
-3540	blurry ghostly plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
+3540	ghostly blurry plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
 3541	skewed plans for depleted Grimacite astrolabe	0		Recipe: "depleted Grimacite astrolabe"
 3542	friendly depleted Grimacite hammer	0		Familiar Weight: +3, Last Available: "2011-12"
 3543	pulsating Herculean wizardly depleted Grimacite gravy boat	0		Mysticality: +25, Experience (Muscle): +1, Last Available: "2011-12"
@@ -3519,19 +3519,19 @@
 3552	Lo Pan's vibrating octopus's spade of Gandalf	0		Maximum MP Percent: +10, Spell Critical Percent: 50
 3553	soggy seed packet	0		
 3554	shaking glob of slime	0		
-3555	rotten enchanted twirling sea carrot	4	crappy	Effect: "Sparkly!", Effect Duration: 5
+3555	enchanted rotten twirling sea carrot	4	crappy	Effect: "Sparkly!", Effect Duration: 5
 3556	decent sea cucumber	4	good	
 3557	moldy sea avocado	3	crappy	
 3558	jumbo yummy wobbly sea lychee	5	awesome	
-3559	yummy small squat jittery sea tangelo	2	awesome	
-3560	bite-sized stale sea honeydew	1	decent	
+3559	small yummy jittery squat sea tangelo	2	awesome	
+3560	stale bite-sized sea honeydew	1	decent	
 3561	denatured oxidized pressurized potion of puissance	0		Effect: "Human-Constellation Hybrid", Effect Duration: 65
 3562	liquefied wobbly bouncing cyan pressurized potion of perspicacity	0		Effect: "Painted-On Bikini", Effect Duration: 28
 3563	super-liquefied wobbly pressurized potion of pulchritude	0		Effect: "Pop-eyed", Effect Duration: 51
 3564	lousy fuchsia berry-infused sake	3	decent	
 3565	special acceptable citrus-infused sake	4	good	Effect: "Whole Latte Love", Effect Duration: 10
-3566	bad watered-down melon-infused sake	2	decent	
-3567	blurry shaking lime green slab of sponge	0		
+3566	watered-down bad melon-infused sake	2	decent	
+3567	lime green shaking blurry slab of sponge	0		
 3568	groovy stylish sponge helmet of James Dean	0		Moxie: +25, Moxie Percent: +10, Experience (Moxie): +3, Familiar Effect: "atk, 1xFairy"
 3569	red shaking toasty Tesla spongy shield of the cheetah	0		Hot Damage: +5, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 14
 3570	avaricious crafty educational square sponge pants	0		Experience: +1, Maximum MP: +10, Meat Drop: +30, Familiar Effect: "hot atk, 1xPotato"
@@ -3555,7 +3555,7 @@
 3589	dry sugar lime	0		Effect: "Fan-Cooled", Effect Duration: 59, Last Available: "2008-12"
 3590	Vulcanized galvanized sugar cherry	0		Effect: "Strength of Ten Ettins", Effect Duration: 23, Last Available: "2008-12"
 3591	mirror clever weightlifter's Mer-kin hookspear	0		Muscle: +15, Maximum MP: +20
-3592	spinning upside-down Mer-kin takebag	0		Item Drop: +5
+3592	upside-down spinning Mer-kin takebag	0		Item Drop: +5
 3593	wobbly Mer-kin thingpouch	0		
 3594	mirror Mer-kin killscroll	0		
 3595	colloidal frozen upside-down Mer-kin fastjuice	0		Effect: "Ready to Snap", Effect Duration: 55
@@ -3608,13 +3608,13 @@
 3642	dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	resourceful depleted Grimacite kneecapping stick	0		Maximum MP: +50, Last Available: "2007-06"
-3645	weak lousy canteen of wine	2	decent	Last Available: "2008-12"
-3646	diet tasty twirling elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
+3645	lousy weak canteen of wine	2	decent	Last Available: "2008-12"
+3646	tasty diet twirling elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	flavorless snack-sized blurry toast with jam	2	decent	Last Available: "2008-12"
-3651	yellow antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	yellow antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	bad elven moonshine	4	decent	Last Available: "2008-12"
 3653	rotten teal knuckle sandwich	3	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	quilted psycho sweater of the sweet-tooth	0		Damage Absorption: +40, Candy Drop: +100, Last Available: "2008-12"
@@ -3634,11 +3634,11 @@
 3668	green wool glow-in-the-dark wristwatch of the boozehound	0		Cold Resistance: +1, Booze Drop: +100, Single Equip, Last Available: "2009-01"
 3669	chaotic glow-in-the-dark dart gun	0		Spell Critical Percent: +10, Last Available: "2009-01"
 3670	tumbling glow-in-the-dark burrowgrub of James Dean	0		Experience (Moxie): +3, Last Available: "2009-01"
-3671	spinning mirror shaking Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	flavorless bite-sized tumbling can of franks 'n' beans	1	decent	Last Available: "2010-12"
+3671	mirror shaking spinning Uncle Crimbo's Rations	0		Last Available: "2010-12"
+3672	bite-sized flavorless tumbling can of franks 'n' beans	1	decent	Last Available: "2010-12"
 3673	lousy huge bottle of peppermint schnapps	3	decent	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
-3675	mirror bouncing purple Mer-kin pressureglobe	0		
+3675	mirror purple bouncing Mer-kin pressureglobe	0		
 3676	skewed Mer-kin foodbucket	0		
 3677	steel-toed diving muff	0		Damage Reduction: 9, Single Equip
 3678	tolerable salinated mint julep	3	good	
@@ -3649,10 +3649,10 @@
 3683	map to the Marinara Trench	0		
 3684	stale super-sized tempura carrot	5	decent	
 3685	flavorless red tempura cucumber	3	decent	
-3686	adequate gigantic upside-down tempura avocado	10	good	
+3686	gigantic adequate upside-down tempura avocado	10	good	
 3687	moldy sea broccoli	4	crappy	
 3688	toothsome spinning sea cauliflower	4	awesome	
-3689	tasty miniature tempura broccoli	2	awesome	
+3689	miniature tasty tempura broccoli	2	awesome	
 3690	decent tumbling tempura cauliflower	4	good	
 3691	normal sea blueberry	4	good	
 3692	moldy big sea persimmon	5	crappy	
@@ -3664,10 +3664,10 @@
 3698	blinking teal velcro ore	0		
 3699	teflon ore	0		
 3700	upside-down vinyl ore	0		
-3701	skewed teal map to Anemone Mine	0		
+3701	teal skewed map to Anemone Mine	0		
 3702	marine aquamarine	0		
 3703	valve wheel	0		
-3704	cyan huge waterlogged bootstraps	0		
+3704	huge cyan waterlogged bootstraps	0		
 3705	fireproof arcane researcher's strapping velcro broadsword	0		Muscle: +5, Experience Percent (Mysticality): +10, Hot Resistance: +3
 3706	nasty manspreader's velcro paddle ball of Flo-Jo	0		Monster Level: +10, Stench Damage: +5, Initiative: +100
 3707	reassuring cool brainy velcro shield	0		Mysticality: +5, Moxie: +5, Spooky Resistance: +1, Damage Reduction: 14
@@ -3698,7 +3698,7 @@
 3732	ionized anodized pulsating cigar butt	0		Effect: "There Wolf", Effect Duration: 57
 3733	ghostly careful veiny manly bloomers	0		Maximum HP: +10, Monster Level: -10, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
 3734	blurry Colon Annihilation Hot Sauce	0		
-3735	fuchsia pulsating fat wallet	0		
+3735	pulsating fuchsia fat wallet	0		
 3736	skewed stanky strapping handwarmer	0		Muscle: +5, Stench Spell Damage: +25, Single Equip
 3737	horrifying lighter of the early riser	0		Spooky Damage: +25, Adventures: +7
 3738	rotten ghostly packet of beer nuts	3	crappy	
@@ -3719,24 +3719,24 @@
 3755	double-frozen altered love song of smoldering passion	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 35, Last Available: "2009-02"
 3756	triple-wet love song of icy revenge	0		Effect: "Florid Cheeks", Effect Duration: 16, Last Available: "2009-02"
 3757	adjusted tumbling love song of sugary cuteness	0		Effect: "Booooooze", Effect Duration: 65, Last Available: "2009-02"
-3758	extra-chilled skewed upside-down blue love song of disturbing obsession	0		Effect: "Down With Chow", Effect Duration: 18, Last Available: "2009-02"
+3758	extra-chilled upside-down skewed blue love song of disturbing obsession	0		Effect: "Down With Chow", Effect Duration: 18, Last Available: "2009-02"
 3759	irradiated dry love song of naughty innuendo	0		Effect: "The Halls of Muscularity", Effect Duration: 24, Last Available: "2009-02"
-3760	corrupted cold-filtered blinking squat breath mint	0		Effect: "Stinky Hands", Effect Duration: 64
+3760	corrupted cold-filtered squat blinking breath mint	0		Effect: "Stinky Hands", Effect Duration: 64
 3761	greedy vampire pearl ring	0		Meat Drop: +20, Single Equip
 3762	vampire pearl necklace of the bloodbag	0		Maximum HP: +100, Single Equip
 3763	perfectly mixed slug of vodka	4	EPIC	
-3764	artisanal practically non-alcoholic enchanted slug of rum	1	EPIC	Effect: "Fishy Fortification", Effect Duration: 20
+3764	practically non-alcoholic artisanal enchanted slug of rum	1	EPIC	Effect: "Fishy Fortification", Effect Duration: 20
 3765	artisanal slug of shochu	4	EPIC	
 3766	lousy blurry wobbly screwdiver	4	decent	
 3767	acceptable dew yoana lei	3	good	
 3768	tolerable bouncing lychee chuhai	3	good	
-3769	acceptable practically non-alcoholic bouncing salacious screwdiver	1	good	
+3769	practically non-alcoholic acceptable bouncing salacious screwdiver	1	good	
 3770	high-proof drinkable narrow spinning dew yoana salacious lei	10	good	
 3771	watered-down smooth salacious lychee chuhai	2	awesome	
 3772	bad Alewife&trade; Ale	3	decent	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
-3775	bouncing lime green Mer-kin pinkslip	0		
+3775	lime green bouncing Mer-kin pinkslip	0		
 3776	pink pinkslip slip of chilblains of the overflowing toilet	0		Cold Damage: +25, Stench Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr"
 3777	flame-wreathed sea salt scrubs of dire peril	0		Weapon Damage: +20, Hot Spell Damage: +10
 3778	blue Temple Grandin's Tesla amber aviator shades of extreme caution	0		Monster Level: -25, Familiar Weight: +7, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -3762,9 +3762,9 @@
 3807	aerosolized concentrated upside-down Mer-kin hidepaint	0		Effect: "Purpose", Effect Duration: 35
 3808	Mer-kin trailmap	0		
 3809	pulsating Mer-kin healscroll	0		
-3810	cyan bouncing narrow Mer-kin lockkey	0		
+3810	narrow cyan bouncing Mer-kin lockkey	0		
 3811	pulsating Mer-kin stashbox	0		
-3812	decent jumbo pulsating mirror lime green chocolate-frosted king cake	5	good	Last Available: "2009-06"
+3812	jumbo decent lime green mirror pulsating chocolate-frosted king cake	5	good	Last Available: "2009-06"
 3813	narrow plastic baby of the detective	0		Item Drop: +20, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	cyan half-height unicycle	0		Familiar Weight: +5
@@ -3842,11 +3842,11 @@
 3888	oxidized vial of slime	0		Effect: "Like a Fish to Walter", Effect Duration: 49
 3889	colloidal modified vial of slime	0		Effect: "Neuromancy", Effect Duration: 25
 3890	moist vial of violet slime	0		Effect: "Pork Power", Effect Duration: 53
-3891	liquefied unsweetened gray tumbling vial of vermilion slime	0		Effect: "Hot Hands", Effect Duration: 69
+3891	liquefied unsweetened tumbling gray vial of vermilion slime	0		Effect: "Hot Hands", Effect Duration: 69
 3892	irradiated huge vial of amber slime	0		Effect: "Adventurer's Best Friendship", Effect Duration: 11
 3893	frozen super-improved vial of chartreuse slime	0		Effect: "Nature's Bounty", Effect Duration: 50
 3894	warmed enhanced bouncing vial of teal slime	0		Effect: "Muscularrr", Effect Duration: 14
-3895	double-anodized Vulcanized wobbly olive vial of indigo slime	0		Effect: "Notably Lovely", Effect Duration: 49
+3895	double-anodized Vulcanized olive wobbly vial of indigo slime	0		Effect: "Notably Lovely", Effect Duration: 49
 3896	quantum chilled blurry vial of slime	0		Effect: "Human-Orc Hybrid", Effect Duration: 12
 3897	nitrogenated bouncing vial of brown slime	0		Effect: "Neuromancy", Effect Duration: 56
 3898	cyan bottle of G&uuml;-Gone	0		
@@ -3937,7 +3937,7 @@
 3985	tumbling soup turtle	0		
 3986	samurai turtle	0		
 3987	foul-smelling curative samurai turtle helmet	0		Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xPotato, cap 6"
-3988	fuchsia tumbling turtle shell	0		
+3988	tumbling fuchsia turtle shell	0		
 3989	turtle shell powder	0		
 3990	coward's turtle shell helmet	0		Monster Level: -20, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
@@ -3956,7 +3956,7 @@
 4004	dog trainer's soup-chucks	0		Experience (familiar): +1
 4005	tarnished flattened ballast turtle	0		Effect: "Billiards Belligerence", Effect Duration: 46
 4006	memory of some amino acids	0		Last Available: "2009-06"
-4007	tumbling huge memory of a C	0		Last Available: "2009-06"
+4007	huge tumbling memory of a C	0		Last Available: "2009-06"
 4008	spinning memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
 4010	spinning memory of a T	0		Last Available: "2009-06"
@@ -3965,7 +3965,7 @@
 4013	purple memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
-4016	shaking fuchsia memory of a GT base pair	0		Last Available: "2009-06"
+4016	fuchsia shaking memory of a GT base pair	0		Last Available: "2009-06"
 4017	squirming Slime larva	0		
 4018	mirror nippy greaves	0		Cold Damage: +10, Familiar Effect: "1xBarrr, cap 37"
 4019	undissolvable contact lenses	0		
@@ -3979,15 +3979,15 @@
 4027	gray blinking greedy steel-toed smartaleck's greaves	0		Moxie Percent: +30, Damage Reduction: 9, Meat Drop: +20, Familiar Effect: "sleaze atk, 0.5xBarrr"
 4028	Usain Bolt's curative cool club	0		Moxie: +5, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5
 4029	memory of a grappling hook	0		Last Available: "2009-06"
-4030	cyan mirror memory of a small stone block	0		Last Available: "2009-06"
+4030	mirror cyan memory of a small stone block	0		Last Available: "2009-06"
 4031	memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
 4033	blurry wobbly memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
-4035	blinking wobbly memory of a crystal	0		Last Available: "2009-06"
+4035	wobbly blinking memory of a crystal	0		Last Available: "2009-06"
 4036	olive caustic slime nodule	0		
 4037	stale spinning slimy sweetbreads	3	decent	
-4038	hand-crafted watered-down slimy fermented bile bladder	2	EPIC	
+4038	watered-down hand-crafted slimy fermented bile bladder	2	EPIC	
 4039	dehydrated tumbling slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	greedy pig-iron helm of bravery	0		Spooky Resistance: +5, Meat Drop: +20, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
@@ -4009,7 +4009,7 @@
 4057	scorching tribal beads	0		Hot Damage: +25, Last Available: "2009-06"
 4058	occult stone fist of the blizzard	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Last Available: "2009-06"
 4059	narrow upside-down teal ribald stone head	0		Sleaze Damage: +10, Damage Reduction: 5, Last Available: "2009-06"
-4060	fuchsia pulsating narrow Indigo Party Invitation	0		Last Available: "2009-06"
+4060	fuchsia narrow pulsating Indigo Party Invitation	0		Last Available: "2009-06"
 4061	green Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	blurry Blue Milk Club Card	0		Last Available: "2009-06"
 4063	upside-down narrow Mecha Mayhem Club Card	0		Last Available: "2009-06"
@@ -4032,8 +4032,8 @@
 4080	shaking knitted careful grisly shield	0		Monster Level: -10, Cold Resistance: +3, Slime Hates It: +1, Damage Reduction: 13
 4081	reassuring Fonzie's corroded breeches	0		Experience (Moxie): +1, Spooky Resistance: +1, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	beefy pernicious cudgel of the dark arts	0		Muscle: +10, Spell Damage Percent: +100, Slime Hates It: +1
-4083	special yummy cupcake-in-a-cup	4	awesome	Effect: "Thick-Skinned", Effect Duration: 40, Last Available: "2009-06"
-4084	mirror lime green pool of liquid	0		Last Available: "2009-06"
+4083	yummy special cupcake-in-a-cup	4	awesome	Effect: "Thick-Skinned", Effect Duration: 40, Last Available: "2009-06"
+4084	lime green mirror pool of liquid	0		Last Available: "2009-06"
 4085	normal protein paste	4	good	Last Available: "2009-06"
 4086	Lo Pan's cyber-mattock of mayonnaise	0		Spell Critical Percent: +30, Sleaze Spell Damage: +50, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
@@ -4152,7 +4152,7 @@
 4200	grouper fangirl	0		
 4201	gill rings	0		Familiar Weight: +5
 4202	urchin roe	0		
-4203	upside-down ghostly pet anemone	0		Familiar Weight: +5
+4203	ghostly upside-down pet anemone	0		Familiar Weight: +5
 4204	Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
 4206	yellow lion tamer's savvy brand new key	0		Mysticality Percent: +20, Experience (familiar): +2
@@ -4178,7 +4178,7 @@
 4226	therapeutic Star of Bravery	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
 4227	blinking hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	twirling fuchsia amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	fuchsia twirling amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	blurry ice skate doll	0		
@@ -4187,16 +4187,16 @@
 4235	twirling salt-shaker	0		
 4236	can of sterno	0		
 4237	yellow healthy cheese-slicer	0		Maximum HP Percent: +20
-4238	moldy jumbo beef jerky	5	crappy	
+4238	jumbo moldy beef jerky	5	crappy	
 4239	medical-grade pipe wrench	0		HP Regen Min: 7, HP Regen Max: 10
-4240	flattened magnetized upside-down tumbling gun cleaning kit	0		Effect: "Shot in the Arse", Effect Duration: 32
+4240	flattened magnetized tumbling upside-down gun cleaning kit	0		Effect: "Shot in the Arse", Effect Duration: 32
 4241	narrow arcane researcher's sleep mask	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	fuchsia Socratic sock garters	0		Experience (Mysticality): +1, Single Equip
 4243	unsweetened mariachi toothpaste	0		Effect: "Patent Prevention", Effect Duration: 62
 4244	crafty leather-bound tome	0		Maximum MP: +10
 4245	bookmark	0		
 4246	bouncing Oprah's ivory cue ball	0		Maximum MP Percent: +50
-4247	artisanal weak blurry shaking decanter of fine Scotch	2	super ultra mega EPIC	
+4247	weak artisanal blurry shaking decanter of fine Scotch	2	super ultra mega EPIC	
 4248	vaporized expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4207,7 +4207,7 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	denatured sap	0		Effect: "Deep-Seated Rage", Effect Duration: 36, Last Available: "2009-10"
 4257	blinking petrified wood	0		Last Available: "2009-10"
-4258	tiny stale chocolate-covered scarab beetle	1	decent	Last Available: "2009-10"
+4258	stale tiny chocolate-covered scarab beetle	1	decent	Last Available: "2009-10"
 4259	acceptable mulled cider	3	good	Last Available: "2009-10"
 4260	huge wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4224,7 +4224,7 @@
 4272	Temple Grandin's resourceful Lederhosen of the Night	0		Maximum MP: +50, Familiar Weight: +7, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
 4273	anodized twirling ribbon candy	0		Effect: "Danish Cunning", Effect Duration: 41, Last Available: "2020-09"
 4274	Underworld acorn	0		Free Pull, Last Available: "2009-10"
-4275	wobbly spinning Underworld trunk	0		Last Available: "2009-10"
+4275	spinning wobbly Underworld trunk	0		Last Available: "2009-10"
 4276	spinning jittery Usain Bolt's sinister experienced Underworld truncheon	0		Experience: +2, Spell Damage: +10, Initiative: +80, Last Available: "2009-10"
 4277	tumbling olive tumbling double-paned studded Staff of the Woodfire of terror	0		Damage Absorption: +80, Spooky Spell Damage: +10, Cold Resistance: +5, Last Available: "2009-10"
 4278	wobbly lard-coated curative Underworld flail of Leguizamo	0		Monster Level: +20, Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	dog trainer's rosy-cheeked Ass-Stompers of Violence of courage	0		Maximum HP Percent: +30, Experience (familiar): +1, Spooky Resistance: +3, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	extremely unsafe Brand of Violence of dire peril of vim and vigor	0		Weapon Damage: +20, Weapon Damage Percent: +100, Maximum HP Percent: +50, Conditional Skill (Equipped): "Brand"
 4299	huge rock-hard dance instructor's Novelty Belt Buckle of Violence of the businessman	0		Experience Percent (Moxie): +10, Damage Reduction: 5, Meat Drop: +50, Single Equip
-4300	red knitted Da Vinci's smooth Lens of Violence	0		Moxie: +15, Experience (Mysticality): +5, Cold Resistance: +3, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	red knitted Da Vinci's smooth Lens of Violence	0		Moxie: +15, Experience (Mysticality): +5, Cold Resistance: +3, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	Temple Grandin's Newton's Pigsticker of Violence of the dark arts	0		Experience (Mysticality): +3, Spell Damage Percent: +100, Familiar Weight: +7
-4302	blinking therapeutic baleful Jodhpurs of Violence of the overflowing toilet	0		Spell Damage: +25, Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	blinking therapeutic baleful Jodhpurs of Violence of the overflowing toilet	0		Spell Damage: +25, Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	chilly sinister Cold Stone of Hatred of Leguizamo	0		Spell Damage: +10, Monster Level: +20, Cold Damage: +5, Conditional Skill (Equipped): "Chilling Grip"
 4304	narrow dangerous Girdle of Hatred of vim and vigor of the sewer	0		Weapon Damage: +10, Maximum HP Percent: +50, Stench Damage: +25, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	careful quilted padded Staff of Simmering Hatred	0		Damage Absorption: 60, Monster Level: -10
-4306	Pantaloons of Hatred of the storm of the blizzard of incineration	0		Maximum MP Percent: +40, Cold Spell Damage: +25, Hot Spell Damage: +50, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	Pantaloons of Hatred of the storm of the blizzard of incineration	0		Maximum MP Percent: +40, Cold Spell Damage: +25, Hot Spell Damage: +50, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	skewed veiny thinker's Fuzzy Slippers of Hatred of the brazier	0		Mysticality: +10, Maximum HP: +10, Hot Spell Damage: +25, Single Equip
-4308	Sherlock's nippy Lens of Hatred of the pedagogue	0		Experience: +3, Cold Damage: +10, Item Drop: +25, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	Sherlock's nippy Lens of Hatred of the pedagogue	0		Experience: +3, Cold Damage: +10, Item Drop: +25, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	zippy Jim Carey's Treads of Loathing of the pedagogue	0		Experience: +3, Monster Level: +25, Initiative: +20, Single Equip
 4310	pulsating curative veiny rock-hard Scepter of Loathing	0		Damage Reduction: 5, Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5
 4311	lime green ghostly Newton's smartaleck's wizardly Belt of Loathing	0		Mysticality: +25, Moxie Percent: +30, Experience (Mysticality): +3, Single Equip
@@ -4293,7 +4293,7 @@
 4341	double-boiled deionized pulsating BitterSweetTarts	0		Effect: "Berry Critical", Effect Duration: 32, Last Available: "2009-12"
 4342	polarized maroon Polka Pop	0		Effect: "Lobos Fresh", Effect Duration: 46, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
-4344	squat green tumbling Crimbo wreath	0		Last Available: "2009-12"
+4344	green tumbling squat Crimbo wreath	0		Last Available: "2009-12"
 4345	mirror string of Crimbo lights	0		Last Available: "2009-12"
 4346	spinning plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
@@ -4303,7 +4303,7 @@
 4351	mansplainer's snow belly	0		Monster Level: +15, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
-4354	shaking bouncing A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	bouncing shaking A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	tumbling A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
@@ -4341,7 +4341,7 @@
 4389	peanut brittle shield of horror	0		Spooky Spell Damage: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	coward's Red Rover BB gun of vim and vigor	0		Maximum HP Percent: +50, Monster Level: -20, Last Available: "2009-12"
 4391	blinking frightening red-and-green sweater	0		Spooky Damage: +5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
-4392	pulsating cyan Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
+4392	cyan pulsating Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	denatured ionized maroon Crimbo peppermint bark	0		Effect: "Hoity Toity", Effect Duration: 33, Last Available: "2009-12"
 4394	energized Crimbo fudge	0		Effect: "Innately Truthy", Effect Duration: 12, Last Available: "2009-12"
 4395	polymerized deionized liquefied blurry Crimbo pecan	0		Effect: "Irresistible Resolve", Effect Duration: 66, Last Available: "2009-12"
@@ -4354,14 +4354,14 @@
 4402	prompt cheese eye	0		Adventures: +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	skewed medical-grade slick weightlifter's Staff of Queso Escusado	0		Muscle: +15, Moxie: +10, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2010-01"
 4405	huge foreign box	0		
-4406	narrow cyan The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+4406	cyan narrow The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	bouncing A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	mirror Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	green The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	lime green Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	bland pulsating quantum taco	0		Last Available: "2010-10"
-4413	weak lousy Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	lousy weak Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	occult sealhide hood	0		Spell Damage Percent: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	therapeutic sealhide leggings	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, cap 40"
@@ -4373,7 +4373,7 @@
 4422	twirling razor-sharp sealhide belt	0		Weapon Damage Percent: +25
 4423	sealhide snare	0		
 4424	puzzling trophy	0		
-4425	magnetized diffused red upside-down sealhide seal doll	0		Effect: "It's Soporiffic!", Effect Duration: 20
+4425	magnetized diffused upside-down red sealhide seal doll	0		Effect: "It's Soporiffic!", Effect Duration: 20
 4426	hymnal	0		Skill: "Canticle of Carboloading"
 4428	blinking zippy glowstick on a string	0		Initiative: +20
 4429	spinning censurious candy necklace	0		Sleaze Resistance: +3, Single Equip
@@ -4393,7 +4393,7 @@
 4445	Socratic spangly mariachi pants	0		Experience (Mysticality): +1, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	chilly wholesome spangly mariachi vest	0		Maximum HP Percent: +10, Cold Damage: +5
 4447	flame-wreathed spangly sombrero	0		Hot Spell Damage: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	diluted bouncing gray shaking Instant Karma	1	decent	Effect: "Oily Flavor", Effect Duration: 40
+4448	diluted shaking gray bouncing Instant Karma	1	decent	Effect: "Oily Flavor", Effect Duration: 40
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	wobbly map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	Rosewater's pointy hat	0		Mysticality Percent: +30, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
@@ -4439,7 +4439,7 @@
 4491	BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
 4493	jittery broken BRICKO brick	0		Last Available: "2010-02"
-4494	ghostly tumbling BRICKO reactor	0		Last Available: "2010-02"
+4494	tumbling ghostly BRICKO reactor	0		Last Available: "2010-02"
 4495	twirling BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	dry lime green recording of The Ballad of Richie Thingfinder	0		Effect: "Fishy Fortification", Effect Duration: 35
@@ -4456,10 +4456,10 @@
 4508	galvanized altered tumbling &quot;DRINK ME&quot; potion	0		Effect: "Winklered", Effect Duration: 30, Last Available: "2010-03"
 4509	pulsating reflection of a map	0		Last Available: "2010-03"
 4510	normal walrus ice cream	3	good	Last Available: "2010-03"
-4511	massive rotten fancy beautiful soup	6	crappy	Effect: "Aloofah", Effect Duration: 35, Last Available: "2010-03"
+4511	rotten massive fancy beautiful soup	6	crappy	Effect: "Aloofah", Effect Duration: 35, Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	blue upside-down Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	snack-sized bland bouncing jittery Humpty Dumplings	2	decent	Last Available: "2010-03"
+4514	bland snack-sized jittery bouncing Humpty Dumplings	2	decent	Last Available: "2010-03"
 4515	yummy Lobster <i>qua</i> Grill	3	awesome	Last Available: "2010-03"
 4516	aged missing wine	3	awesome	Last Available: "2010-03"
 4517	decent half-sized matter custard	2	good	Last Available: "2010-03"
@@ -4476,7 +4476,7 @@
 4528	diet decent enchanted narrow dragon snaps	1	good	Effect: "No Worries", Effect Duration: 25, Last Available: "2010-03"
 4529	clever Samson's snapdragon pistil	0		Experience (Muscle): +5, Maximum MP: +20, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	diet moldy rook cookie	1	crappy	Last Available: "2010-03"
+4531	moldy diet rook cookie	1	crappy	Last Available: "2010-03"
 4532	small decent bishop cookie	2	good	Last Available: "2010-03"
 4533	bland knight cookie	4	decent	Last Available: "2010-03"
 4534	moldy king cookie	3	crappy	Last Available: "2010-03"
@@ -4495,10 +4495,10 @@
 4547	shaking purple caterpillar	0		Last Available: "2010-03"
 4548	yellow walrus	0		Last Available: "2010-03"
 4549	upside-down carpenter	0		Last Available: "2010-03"
-4550	pulsating twirling dodo	0		Last Available: "2010-03"
+4550	twirling pulsating dodo	0		Last Available: "2010-03"
 4551	blurry studded detour shield	0		Damage Absorption: +80, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
-4553	blurry skewed lowercase a	0		
+4553	skewed blurry lowercase a	0		
 4554	percent sign	0		
 4555	huge left bracket	0		
 4556	squat right parenthesis	0		
@@ -4510,21 +4510,21 @@
 4562	jittery hair of the calf	0		Last Available: "2010-04"
 4563	enchanted hand-crafted world's most unappetizing beverage	4	EPIC	Effect: "Prelude of Precision", Effect Duration: 25, Last Available: "2010-04"
 4564	quilted slippery when wet shield	0		Damage Absorption: +40, Damage Reduction: 6, Last Available: "2010-04"
-4565	spoiled half-sized raisin	2	crappy	Last Available: "2010-04"
+4565	half-sized spoiled raisin	2	crappy	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	hale flyest of shirts of terror	0		Maximum HP: +20, Spooky Spell Damage: +10, Last Available: "2010-04"
-4568	miniature toothsome cyan a dance upon the palate	2	awesome	Last Available: "2010-04"
+4568	toothsome miniature cyan a dance upon the palate	2	awesome	Last Available: "2010-04"
 4569	jumbo flavorless prehistoric meteorite jawbreaker	5	decent	Last Available: "2010-04"
-4570	yellow blurry Crazyleg's razor	0		Last Available: "2010-04"
+4570	blurry yellow Crazyleg's razor	0		Last Available: "2010-04"
 4571	bland squirmy violent party snack	3	decent	Last Available: "2010-04"
 4572	Socratic can-you-dig-it?	0		Experience (Mysticality): +1, Last Available: "2010-04"
 4573	green The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	tumbling bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	tumbling bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bouncing bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	tumbling bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bouncing bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	magnetized olive twirling Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Spore-Wreathed", Effect Duration: 21, Last Available: "2010-04"
+4579	magnetized twirling olive Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Spore-Wreathed", Effect Duration: 21, Last Available: "2010-04"
 4580	coward's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Monster Level: -20, Last Available: "2010-04"
 4581	upside-down miser's deadly T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Weapon Damage: +5, Meat Drop: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
@@ -4532,7 +4532,7 @@
 4584	normal gray six wedges of goat cheese	4	good	
 4585	lime green collection of objects	0		
 4586	boulder	0		
-4587	maroon shaking squat goth	0		
+4587	shaking maroon squat goth	0		
 4588	brown pixel	0		
 4589	strapping pixel whip	0		Muscle: +5
 4590	upside-down pixel chain whip of incineration	0		Hot Spell Damage: +50, Last Available: "2010-07"
@@ -4540,7 +4540,7 @@
 4592	pixel orb	0		Last Available: "2010-07"
 4593	bouncing pixellated moneybag	0		Last Available: "2010-07"
 4594	pixel cross	0		
-4595	ghostly olive pixel holy water	0		Last Available: "2010-07"
+4595	olive ghostly pixel holy water	0		Last Available: "2010-07"
 4596	narrow map to Vanya's Castle	0		Last Available: "2010-07"
 4597	8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
@@ -4552,7 +4552,7 @@
 4604	keg	0		Last Available: "2010-06"
 4605	veiny ruddy bottle of Goldschn&ouml;ckered	0		Maximum HP Percent: +40, Maximum HP: +10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	moldy shaking sun-dried tofu	3	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	weak tolerable spinning green soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	weak tolerable green spinning soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	moist essential soy	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 47, Last Available: "2010-08"
@@ -4569,11 +4569,11 @@
 4621	upside-down Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	electrified olive chocolate-covered caviar	0		Effect: "The Sweats", Effect Duration: 65, Last Available: "2020-09"
-4624	fancy thick delicious pawn cookie	5	awesome	Effect: "In the Slimelight", Effect Duration: 10, Last Available: "2010-06"
+4624	fancy delicious thick pawn cookie	5	awesome	Effect: "In the Slimelight", Effect Duration: 10, Last Available: "2010-06"
 4625	twisted maroon coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	narrow superduperball	0		Last Available: "2010-06"
 4627	shaking finger cuffs	0		Last Available: "2010-06"
-4628	wobbly squat spinning maroon parachute guy	0		Last Available: "2010-06"
+4628	maroon squat spinning wobbly parachute guy	0		Last Available: "2010-06"
 4629	blurry plastic spider ring of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	lime green plastic kazoo of incineration	0		Hot Spell Damage: +50, Last Available: "2010-06"
 4631	vibrating inflatable baseball bat	0		Maximum MP Percent: +10, Last Available: "2010-06"
@@ -4619,7 +4619,7 @@
 4671	lousy booze-soaked cherry	4	decent	
 4672	fuchsia comfy pillow	0		
 4673	decent marshmallow	3	good	
-4674	spoiled snack-sized mirror sponge cake	2	crappy	
+4674	snack-sized spoiled mirror sponge cake	2	crappy	
 4675	lousy distilled blurry gin-soaked blotter paper	5	decent	
 4676	maroon tree-holed coin	0		
 4677	jittery unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4656,20 +4656,20 @@
 4708	My First Shaker&trade;	0		
 4709	wobbly hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
-4711	gray shaking sweatpants	0		Familiar Effect: "8xPotato, cap 2"
+4711	shaking gray sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	jittery GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	flavorless small teal lemon popsicle	2	decent	
-4715	normal thick popsicle	5	good	
+4715	thick normal popsicle	5	good	
 4716	miniature adequate strawberry popsicle	2	good	
 4717	fancy normal liver popsicle	3	good	Effect: "Polar Express", Effect Duration: 15
 4718	Herculean mariachi hat	0		Experience (Muscle): +1, Familiar Effect: "atk, cap 2"
 4719	Usain Bolt's Hollandaise helmet	0		Initiative: +80, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	thick moldy liver and let pie	5	crappy	Last Available: "2010-10"
-4723	thick rotten narrow badass pie	5	crappy	Last Available: "2010-10"
-4724	stale upside-down olive shoo-fish pie	3	decent	Last Available: "2010-10"
+4722	moldy thick liver and let pie	5	crappy	Last Available: "2010-10"
+4723	rotten thick narrow badass pie	5	crappy	Last Available: "2010-10"
+4724	stale olive upside-down shoo-fish pie	3	decent	Last Available: "2010-10"
 4725	flavorless snack-sized huge piping organ pie	2	decent	Last Available: "2010-10"
 4726	snack-sized moldy mirror jittery igloo pie	2	crappy	Last Available: "2010-10"
 4727	moldy stomach turnover	3	crappy	Last Available: "2010-10"
@@ -4683,7 +4683,7 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	wobbly slick beer-soaked mop	0		Moxie: +10
-4738	watered-down perfectly mixed blue day-old beer	2	EPIC	
+4738	perfectly mixed watered-down blue day-old beer	2	EPIC	
 4739	artisanal pulsating plain beer	4	EPIC	
 4740	irresponsibly strong bad overpriced &quot;imported&quot; beer	8	decent	
 4741	blinking smiling rat	0		
@@ -4692,7 +4692,7 @@
 4744	energized unsweetened ionized PlexiPips	0		Effect: "Object Detection", Effect Duration: 47
 4745	galvanized blinking spinning fuchsia Wax Flask	0		Effect: "On a Roll", Effect Duration: 30
 4746	triple-adjusted Pain Dip	0		Effect: "Floundering", Effect Duration: 47
-4747	half-sized special normal tumbling olive bone meal	2	good	Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2010-10"
+4747	normal half-sized special tumbling olive bone meal	2	good	Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2010-10"
 4748	bad skewed bone aperitif	3	decent	Last Available: "2010-10"
 4749	energetic bonerang	0		Maximum MP Percent: +20, Last Available: "2010-10"
 4750	upside-down tumbling bone and arrows of chilblains	0		Cold Damage: +25, Last Available: "2010-10"
@@ -4707,7 +4707,7 @@
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
-4762	narrow blue squat huge pumpkin	0		Last Available: "2010-11"
+4762	blue narrow squat huge pumpkin	0		Last Available: "2010-11"
 4763	stale lime green pumpkin pie	4	decent	Last Available: "2010-11"
 4764	bad pumpkin beer	3	decent	Last Available: "2010-11"
 4765	quantum corrupted ionized teal pumpkin juice	0		Effect: "Extra-Thick Blood", Effect Duration: 25, Last Available: "2010-11"
@@ -4727,13 +4727,13 @@
 4818	moldy immense CRIMBCOIDS mints	10	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	decent CRIMBCOLOAF	4	good	Last Available: "2011-01"
-4821	miniature delicious circular CRIMBCOOKIE	2	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	delicious miniature circular CRIMBCOOKIE	2	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	educational plastic CRIMBCO HQ	0		Experience: +1, Last Available: "2010-12"
 4823	electrified plastic fax machine	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-12"
 4824	huge plastic hobo elf	0		Item Drop: +5, Last Available: "2010-12"
 4825	lard-coated plastic Mr. Mination	0		Sleaze Spell Damage: +25, Last Available: "2010-12"
 4826	pulsating plastic Best Game Ever of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-12"
-4827	blue shaking hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
+4827	shaking blue hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	tumbling S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
@@ -4743,10 +4743,10 @@
 4834	narrow robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	narrow purple robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	purple narrow robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	spoiled cyan triangular CRIMBCOOKIE	3	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	enchanted rotten immense wobbly square CRIMBCOOKIE	9	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	rotten enchanted immense wobbly square CRIMBCOOKIE	9	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	reassuring Jeselnik's weightlifter's bindlestocking	0		Muscle: +15, Sleaze Damage: +25, Spooky Resistance: +1, Last Available: "2010-12"
 4842	green sleeping stocking	0		Last Available: "2010-12"
 4843	blinking Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4872,14 +4872,14 @@
 4969	tumbling Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
-4972	huge squat Alice's Army Ninja	0		Last Available: "2011-03"
+4972	squat huge Alice's Army Ninja	0		Last Available: "2011-03"
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	narrow Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
-4976	tumbling shaking spinning Alice's Army Mad Bomber	0		Last Available: "2011-03"
+4976	shaking spinning tumbling Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
-4979	shaking olive Alice's Army Bowman	0		Last Available: "2011-03"
+4979	olive shaking Alice's Army Bowman	0		Last Available: "2011-03"
 4980	huge blinking Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
@@ -4889,12 +4889,12 @@
 4986	upside-down Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	jittery narrow Alice's Army Foil Swordsman	0		Last Available: "2011-03"
-4989	blurry ghostly Alice's Army Foil Spearsman	0		Last Available: "2011-03"
+4989	ghostly blurry Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	narrow Alice's Army Foil Ninja	0		Last Available: "2011-03"
-4994	pulsating skewed pulsating Alice's Army Foil Alchemist	0		Last Available: "2011-03"
+4994	skewed pulsating pulsating Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
 4997	blinking Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
@@ -4913,19 +4913,19 @@
 5010	evil eye	0		
 5011	narrow Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	red Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	diet flavorless blurry green wasabi pocky	1	decent	Last Available: "2011-03"
+5013	flavorless diet green blurry wasabi pocky	1	decent	Last Available: "2011-03"
 5014	rotten wobbly tobiko pocky	4	crappy	Last Available: "2011-03"
 5015	tasty small natto pocky	2	awesome	Last Available: "2011-03"
 5016	tolerable wasabi-infused sake	3	good	Last Available: "2011-03"
-5017	enchanted boozy acceptable fuchsia tobiko-infused sake	5	good	Effect: "Cat Class, Cat Style", Effect Duration: 30, Last Available: "2011-03"
-5018	weak hand-crafted lime green natto-infused sake	2	EPIC	Last Available: "2011-03"
-5019	electrified tumbling squat wasabi marble soda	0		Effect: "Heart of Pink", Effect Duration: 63, Last Available: "2011-03"
+5017	acceptable boozy enchanted fuchsia tobiko-infused sake	5	good	Effect: "Cat Class, Cat Style", Effect Duration: 30, Last Available: "2011-03"
+5018	hand-crafted weak lime green natto-infused sake	2	EPIC	Last Available: "2011-03"
+5019	electrified squat tumbling wasabi marble soda	0		Effect: "Heart of Pink", Effect Duration: 63, Last Available: "2011-03"
 5020	wet diffused liquefied wobbly tobiko marble soda	0		Effect: "There Wolf", Effect Duration: 41, Last Available: "2011-03"
 5021	extra-alkaline boiled altered natto marble soda	0		Effect: "Neuroplastici Tea", Effect Duration: 23, Last Available: "2011-03"
 5022	squat Alice's Army booster box	0		Last Available: "2011-03"
 5023	adjusted bouncing elderly jawbreaker	0		Effect: "In the Slimelight", Effect Duration: 69, Last Available: "2020-09"
 5024	enchanted tolerable marshmallow flamb&eacute;	4	good	Effect: "In the Slimelight", Effect Duration: 15, Last Available: "2011-03"
-5025	weak perfectly mixed cranberry schnapps	2	super ultra EPIC	Last Available: "2011-03"
+5025	perfectly mixed weak cranberry schnapps	2	super ultra EPIC	Last Available: "2011-03"
 5026	drinkable breaded beer	3	good	Last Available: "2011-03"
 5027	artisanal soy cordial	4	super EPIC	Last Available: "2011-03"
 5028	ghostly supercool astral bludgeon of Tarzan of the businessman	0		Moxie Percent: +20, Experience (Muscle): +3, Meat Drop: +50
@@ -4943,11 +4943,11 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	padded Newton's astral shirt of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Damage Absorption: +20
 5042	huge shaking fortified forbidden astral belt	0		Spell Damage Percent: +50, Damage Absorption: +60
-5043	tiny flavorless jittery upside-down astral hot dog	1		
+5043	flavorless tiny jittery upside-down astral hot dog	1		
 5044	smooth astral pilsner	3		
 5045	blinking astral hot dog dinner	0		
 5046	shaking astral six-pack	0		
-5047	skewed green Clan shower	0		Free Pull, Last Available: "2011-04"
+5047	green skewed Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	fuchsia shard of double-ice	0		Last Available: "2011-04"
 5049	chilly deadly double-ice cap of incineration	0		Weapon Damage: +5, Cold Damage: +5, Hot Spell Damage: +50, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	twirling zippy clever Oprah's double-ice box	0		Maximum MP Percent: +50, Maximum MP: +20, Initiative: +20, Last Available: "2011-04"
@@ -4973,7 +4973,7 @@
 5070	spinning innuendo	0		Last Available: "2011-04"
 5071	moldy tumbling red s'more	0	crappy	Last Available: "2011-04"
 5072	blurry diamond ring	0		Last Available: "2011-04"
-5073	practically non-alcoholic mediocre Russian Ice	1	decent	Last Available: "2011-04"
+5073	mediocre practically non-alcoholic Russian Ice	1	decent	Last Available: "2011-04"
 5074	tumbling perfumed clay ashtray	0		Stench Resistance: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	squat ruddy lanyard	0		Maximum HP Percent: +40, Single Equip, Last Available: "2011-05"
 5076	frosty monster pants	0		Cold Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
@@ -4986,7 +4986,7 @@
 5083	maroon steel-toed rubber band gun	0		Damage Reduction: 9, Last Available: "2011-05"
 5084	upside-down studded pin-stripe slacks	0		Damage Absorption: +80, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	olive clever gloves	0		Maximum MP: +20, Single Equip, Last Available: "2011-05"
-5086	quadruple-alkaline magnetized ghostly twirling correction fluid	0		Effect: "Litterboxing", Effect Duration: 59, Last Available: "2011-05"
+5086	quadruple-alkaline magnetized twirling ghostly correction fluid	0		Effect: "Litterboxing", Effect Duration: 59, Last Available: "2011-05"
 5087	olive mansplainer's Pok&euml;mann figurine: Porkachu	0		Monster Level: +15, Single Equip, Last Available: "2011-05"
 5088	crafty Pok&euml;mann figurine: Magikrap	0		Maximum MP: +10, Single Equip, Last Available: "2011-05"
 5089	nippy Pok&euml;mann figurine: Vegemite	0		Cold Damage: +10, Single Equip, Last Available: "2011-05"
@@ -5006,8 +5006,8 @@
 5103	polymerized gray Nuclear Blastball	0		Effect: "Kernel Panic!", Effect Duration: 49, Last Available: "2011-05"
 5104	pressed enhanced fish juice box	0		Effect: "Abyssal Sweat", Effect Duration: 54, Last Available: "2011-05"
 5105	spinning paint bomb	0		Last Available: "2011-05"
-5106	teal blinking hideous egg	0		Last Available: "2011-05"
-5107	mediocre fortified Jeppson's Malort	5	decent	Last Available: "2011-06"
+5106	blinking teal hideous egg	0		Last Available: "2011-05"
+5107	fortified mediocre Jeppson's Malort	5	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	quilted stress ball	0		Damage Absorption: +40, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5032,7 +5032,7 @@
 5129	mirror Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	narrow Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	non-electrified polarized Ultrasoldier Serum	0		Effect: "Spooky Blur", Effect Duration: 55, Last Available: "2011-06"
-5132	tiny flavorless twirling elven hardtack	1	decent	Last Available: "2011-06"
+5132	flavorless tiny twirling elven hardtack	1	decent	Last Available: "2011-06"
 5133	weak aged elven squeeze	2	awesome	Last Available: "2011-06"
 5134	maroon lunar isotope	0		Last Available: "2011-06"
 5135	teal E.M.U. joystick	0		Last Available: "2011-06"
@@ -5046,7 +5046,7 @@
 5143	twirling E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	wet quantum bouncing honeypot	0		Effect: "Leo Rising", Effect Duration: 37
-5146	adequate half-sized blurry wild honey pie	2	good	
+5146	half-sized adequate blurry wild honey pie	2	good	
 5147	bad honey mead	3	decent	
 5148	bouncing friendly honey dipper of incineration of courage	0		Familiar Weight: +3, Hot Spell Damage: +50, Spooky Resistance: +3
 5149	asbestos-lined fireproof friendly honeybritches	0		Familiar Weight: +3, Hot Resistance: 8, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5066,7 +5066,7 @@
 5163	manspreader's plush mutated alielephant of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +10, Last Available: "2011-06"
 5164	mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	wicked girl	0		Spell Damage: +5, Last Available: "2011-06"
-5166	skewed blinking spinning top hat and cane	0		Last Available: "2011-06"
+5166	blinking spinning skewed top hat and cane	0		Last Available: "2011-06"
 5167	synthetic dog hair pill	0		Last Available: "2011-06"
 5168	distention pill	0		Last Available: "2011-06"
 5169	spinning elven medi-pack	0		Last Available: "2011-06"
@@ -5075,9 +5075,9 @@
 5172	narrow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	spinning elven magi-pack	0		Last Available: "2011-06"
 5174	lousy Saison du Lune	4	decent	Last Available: "2011-06"
-5175	aged strong maroon jittery Moonthril Schnapps	5	awesome	Last Available: "2011-06"
+5175	strong aged jittery maroon Moonthril Schnapps	5	awesome	Last Available: "2011-06"
 5176	aged weak Wrecked Generator	2	awesome	Last Available: "2011-06"
-5177	decent immense spinning Spaghetti with Moonballs	7	good	Last Available: "2011-06"
+5177	immense decent spinning Spaghetti with Moonballs	7	good	Last Available: "2011-06"
 5178	spoiled Crepes a la Lune	3	crappy	Last Available: "2011-06"
 5179	adequate jumbo Moon Pie	5	good	Last Available: "2011-06"
 5180	electrified yellow Comet Pop	0		Effect: "Can Has Cyborger", Effect Duration: 41, Last Available: "2011-06"
@@ -5103,9 +5103,9 @@
 5200	diluted wobbly pulsating paste	1	decent	Last Available: "2011-08"
 5201	vaporized spinning ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	compressed narrow greasy paste	1	good	Effect: "The Moxie of LOV", Effect Duration: 30, Last Available: "2011-08"
-5203	distilled upside-down tumbling bug paste	1	EPIC	Last Available: "2011-08"
+5203	distilled tumbling upside-down bug paste	1	EPIC	Last Available: "2011-08"
 5204	powdered shaking hippy paste	1	decent	Effect: "Disco State of Mind", Effect Duration: 45, Last Available: "2011-08"
-5205	compressed pulsating wobbly jittery orc paste	1	good	Effect: "Oh Snap", Effect Duration: 10, Last Available: "2011-08"
+5205	compressed wobbly jittery pulsating orc paste	1	good	Effect: "Oh Snap", Effect Duration: 10, Last Available: "2011-08"
 5206	twisted olive demonic paste	1	EPIC	Last Available: "2011-08"
 5207	mixed indescribably horrible paste	1	good	Effect: "Well-preserved", Effect Duration: 5, Last Available: "2011-08"
 5208	dried paste	1	good	Last Available: "2011-08"
@@ -5127,7 +5127,7 @@
 5224	bland gray Ur-Donut	3	decent	Last Available: "2011-09"
 5225	narrow The Bomb	0		Last Available: "2011-09"
 5226	skewed box of Familiar Jacks	0		Last Available: "2011-09"
-5227	bad weak bucket of wine	2	decent	Last Available: "2011-09"
+5227	weak bad bucket of wine	2	decent	Last Available: "2011-09"
 5228	toothsome ultrafondue	4	awesome	Last Available: "2011-09"
 5229	skewed unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5138,30 +5138,30 @@
 5235	narrow thinker's furry halo	0		Mysticality: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	extremely unsafe frosty halo	0		Weapon Damage Percent: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	lion tamer's time halo	0		Experience (familiar): +2, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	watered-down acceptable Lumineux Limnio	2	good	Last Available: "2011-09"
+5238	acceptable watered-down Lumineux Limnio	2	good	Last Available: "2011-09"
 5239	acceptable Morto Moreto	3	good	Last Available: "2011-09"
 5240	hand-crafted Temps Tempranillo	3	EPIC	Last Available: "2011-09"
-5241	acceptable fancy weak spinning Bordeaux Marteaux	2	good	Effect: "Tennis Elbow-wow", Effect Duration: 20, Last Available: "2011-09"
+5241	fancy acceptable weak spinning Bordeaux Marteaux	2	good	Effect: "Tennis Elbow-wow", Effect Duration: 20, Last Available: "2011-09"
 5242	mediocre jittery Fromage Pinotage	4	decent	Last Available: "2011-09"
 5243	tolerable Beignet Milgranet	4	good	Last Available: "2011-09"
 5244	smooth Muschat	3	awesome	Last Available: "2011-09"
 5245	spoiled cool jelly donut	3	crappy	Last Available: "2011-09"
 5246	spoiled snack-sized shrapnel jelly donut	2	crappy	Last Available: "2011-09"
-5247	decent shaking blurry occult jelly donut	3	good	Last Available: "2011-09"
+5247	decent blurry shaking occult jelly donut	3	good	Last Available: "2011-09"
 5248	tasty squat thyme jelly donut	4	awesome	Last Available: "2011-09"
 5249	normal danish	3	good	Last Available: "2011-09"
-5250	low-calorie moldy smashed danish	1	crappy	Last Available: "2011-09"
-5251	big delicious fancy skewed forbidden danish	5	awesome	Effect: "Infernal Thirst", Effect Duration: 15, Last Available: "2011-09"
+5250	moldy low-calorie smashed danish	1	crappy	Last Available: "2011-09"
+5251	big fancy delicious skewed forbidden danish	5	awesome	Effect: "Infernal Thirst", Effect Duration: 15, Last Available: "2011-09"
 5252	moldy small cool cat claw	2	crappy	Last Available: "2011-09"
 5253	flavorless blunt cat claw	3	decent	Last Available: "2011-09"
-5254	moldy small shadowy cat claw	2	crappy	Last Available: "2011-09"
+5254	small moldy shadowy cat claw	2	crappy	Last Available: "2011-09"
 5255	adequate cheezburger	3	good	Last Available: "2011-09"
-5256	adequate miniature toasted brie	2	good	Last Available: "2011-09"
+5256	miniature adequate toasted brie	2	good	Last Available: "2011-09"
 5257	warmed mirror potion of the field gar	0		Effect: "Aquarius Rising", Effect Duration: 46, Last Available: "2011-09"
 5258	oxidized pickled too legit potion	0		Effect: "Mer-kindliness", Effect Duration: 45, Last Available: "2011-09"
 5259	quadruple-corrupted red Bright Water	0		Effect: "Sugary World View", Effect Duration: 35, Last Available: "2011-09"
-5260	frozen bouncing spinning cold-filtered water	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 17, Last Available: "2011-09"
-5261	magnetized pressed narrow jittery graveyard snowglobe	0		Effect: "Go-Gone", Effect Duration: 47, Last Available: "2011-09"
+5260	frozen spinning bouncing cold-filtered water	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 17, Last Available: "2011-09"
+5261	magnetized pressed jittery narrow graveyard snowglobe	0		Effect: "Go-Gone", Effect Duration: 47, Last Available: "2011-09"
 5262	irradiated upside-down cool cat elixir	0		Effect: "Helvella Health", Effect Duration: 28, Last Available: "2011-09"
 5263	warmed purple potion of the captain's hammer	0		Effect: "Witch's Brood", Effect Duration: 61, Last Available: "2011-09"
 5264	oxidized dry blurry gray potion of X-ray vision	0		Effect: "Saucefingers", Effect Duration: 66, Last Available: "2011-09"
@@ -5221,12 +5221,12 @@
 5318	modified polarized olive ghostly Gummy Brains	0		Effect: "Crocodile Tear", Effect Duration: 31, Last Available: "2011-10"
 5319	pickled Blood 'n' Plenty	0		Effect: "Rave Concentration", Effect Duration: 53, Last Available: "2011-10"
 5320	nitrogenated electrified narrow Lobos Mints	0		Effect: "Big", Effect Duration: 19, Last Available: "2011-10"
-5321	quadruple-pressed quantum spinning blinking mirror Sweet Sword	0		Effect: "Egg-stra Arm", Effect Duration: 30, Last Available: "2011-10"
-5322	watered-down mediocre Ecto-Cooler	2	decent	Last Available: "2011-10"
+5321	quadruple-pressed quantum mirror blinking spinning Sweet Sword	0		Effect: "Egg-stra Arm", Effect Duration: 30, Last Available: "2011-10"
+5322	mediocre watered-down Ecto-Cooler	2	decent	Last Available: "2011-10"
 5323	acceptable Bartles and BRAAAINS wine cooler	3	good	Last Available: "2011-10"
-5324	acceptable distilled tumbling Blood Light	5	good	Last Available: "2011-10"
+5324	distilled acceptable tumbling Blood Light	5	good	Last Available: "2011-10"
 5325	artisanal spinning Silver Bullet beer	3	EPIC	Last Available: "2011-10"
-5326	tolerable boozy Bone's Farm &quot;wine&quot;	5	good	Last Available: "2011-10"
+5326	boozy tolerable Bone's Farm &quot;wine&quot;	5	good	Last Available: "2011-10"
 5327	spinning ghost protocol	0		Last Available: "2011-10"
 5328	double-pickled sorority brain	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 41, Last Available: "2011-10"
 5329	ionized extra-dry squat squat Nightstalker perfume	0		Effect: "Dreams and Lights", Effect Duration: 65, Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	censurious ruddy The Necbromancer's Shorts of temperance	0		Maximum HP Percent: +40, Sleaze Resistance: 8, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	mirror lion tamer's wizardly The Necbromancer's Wizard Staff of bravery	0		Mysticality: +25, Experience (familiar): +2, Spooky Resistance: +5, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	aged distilled The Cooler Out of Space	5	awesome	Last Available: "2011-10"
+5342	distilled aged The Cooler Out of Space	5	awesome	Last Available: "2011-10"
 5343	twirling twirling The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	maroon sorority girl's box	0		Last Available: "2011-10"
 5345	galvanized Necbro wafers	0		Effect: "Dragged Through the Coals", Effect Duration: 67, Last Available: "2020-09"
@@ -5254,7 +5254,7 @@
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	jittery A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
-5354	blurry twirling The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
+5354	twirling blurry The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
@@ -5266,7 +5266,7 @@
 5363	spinning CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	squat CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-5366	huge mirror CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+5366	mirror huge CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	mirror Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5368	narrow Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	huge ruddy KoL Con 8-Bit power bracelet	0		Maximum HP Percent: +40, Last Available: "2011-09"
@@ -5278,7 +5278,7 @@
 5375	spinning Annie Oakley's plastic colollilossus	0		Critical Hit Percent: +20, Last Available: "2011-12"
 5376	Oprah's plastic Big Candy of Flo-Jo	0		Maximum MP Percent: +50, Initiative: +100, Last Available: "2011-12"
 5377	purple The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
-5378	upside-down huge spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
+5378	huge upside-down spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	altered ghostly bouncing groose grease	1	good	Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
@@ -5290,14 +5290,14 @@
 5387	Jim Carey's ridiculous earring	0		Monster Level: +25, Last Available: "2011-11"
 5388	ridiculous sunglasses of terror	0		Spooky Spell Damage: +10, Last Available: "2011-11"
 5389	rotten ridiculous sandwich	4	crappy	Last Available: "2011-11"
-5390	acceptable red twirling ridiculous cocktail	3	good	Last Available: "2011-11"
+5390	acceptable twirling red ridiculous cocktail	3	good	Last Available: "2011-11"
 5391	squat sharpshooter's Da Vinci's zombie monkey necklace	0		Experience (Mysticality): +5, Critical Hit Percent: +10
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
 5394	sandpaper	0		
-5395	spinning mirror peppermint sprout	0		Last Available: "2011-11"
+5395	mirror spinning peppermint sprout	0		Last Available: "2011-11"
 5396	extra-quantum tarnished peppermint twist	0		Effect: "Mushroom Might", Effect Duration: 66, Last Available: "2011-11"
-5397	tasty thick peppermint patty	5	awesome	Last Available: "2011-11"
+5397	thick tasty peppermint patty	5	awesome	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5312,7 +5312,7 @@
 5409	drinkable Tequiz Navidad	3	good	Last Available: "2011-12"
 5410	mediocre Mint Yulep	3	decent	Last Available: "2011-12"
 5411	bad practically non-alcoholic Crimbojito	1	decent	Last Available: "2011-12"
-5412	acceptable high-proof Sangria de Menthe	6	good	Last Available: "2011-12"
+5412	high-proof acceptable Sangria de Menthe	6	good	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	ionized licorice root	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 68, Last Available: "2011-12"
@@ -5330,7 +5330,7 @@
 5427	asbestos-lined sucker hakama	0		Hot Resistance: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
 5428	spinning miser's sucker kabuto	0		Meat Drop: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	huge Usain Bolt's sucker tachi	0		Initiative: +80, Last Available: "2011-11"
-5430	huge blinking lime green sucker scaffold	0		Last Available: "2011-11"
+5430	blinking huge lime green sucker scaffold	0		Last Available: "2011-11"
 5431	upside-down cinnamon troll doll	0		Last Available: "2011-11"
 5432	grape troll doll	0		Last Available: "2011-11"
 5433	tumbling raspberry troll doll	0		Last Available: "2011-11"
@@ -5342,7 +5342,7 @@
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	yummy gigantic fudgesicle	10	awesome	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
-5442	yellow pulsating The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
+5442	pulsating yellow The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	galvanized ghostly devilish folio	0		Effect: "Yuletide Mutations", Effect Duration: 33, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
@@ -5352,12 +5352,12 @@
 5449	vanity stone	0		Last Available: "2012-12"
 5450	fuchsia lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
-5452	red tumbling narrow avarice stone	0		Last Available: "2012-12"
+5452	tumbling narrow red avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	mirror gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
-5457	pickled skewed upside-down Fudgie Roll	0		Effect: "Bolts about Candy", Effect Duration: 50, Last Available: "2011-11"
+5457	pickled upside-down skewed Fudgie Roll	0		Effect: "Bolts about Candy", Effect Duration: 50, Last Available: "2011-11"
 5458	normal fudge bunny	3	good	Last Available: "2011-11"
 5459	skewed fudge spork	0		Last Available: "2011-11"
 5460	red chaotic wicked savvy fudgecycle	0		Mysticality Percent: +20, Spell Damage: +5, Spell Critical Percent: +10, Single Equip, Last Available: "2011-11"
@@ -5376,12 +5376,12 @@
 5473	maroon gummi ingot	0		Last Available: "2011-11"
 5474	twirling gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
-5476	aerosolized non-oxidized cyan spinning gummi salamander	0		Effect: "Bananas!", Effect Duration: 40, Last Available: "2011-11"
+5476	aerosolized non-oxidized spinning cyan gummi salamander	0		Effect: "Bananas!", Effect Duration: 40, Last Available: "2011-11"
 5477	quadruple-nitrogenated gummi snake	0		Effect: "Ocelot Eyes", Effect Duration: 23, Last Available: "2011-11"
 5478	dry polymerized gummi canary	0		Effect: "Sweetened and Fattened", Effect Duration: 68, Last Available: "2011-11"
 5479	flavorless skewed gummi bear	3	decent	Last Available: "2011-11"
 5480	adequate gummi bear	3	good	Last Available: "2011-11"
-5481	spoiled big gummi bear	5	crappy	Last Available: "2011-11"
+5481	big spoiled gummi bear	5	crappy	Last Available: "2011-11"
 5482	toothsome lime green drunki-bear	4	awesome	Last Available: "2011-11"
 5483	rotten drunki-bear	3	crappy	Last Available: "2011-11"
 5484	rotten twirling drunki-bear	4	crappy	Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	diffused wobbly Atomic Pop	0		Effect: "Dwarven Hardiness", Effect Duration: 55, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	blue whimpering willow bark	0		Last Available: "2012-12"
-5529	bland big blue berries of suffering	5	decent	Last Available: "2012-12"
+5529	big bland blue berries of suffering	5	decent	Last Available: "2012-12"
 5530	non-chilled teal baobab sap	0		Effect: "Strange Mental Acuity", Effect Duration: 64, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	olive magnolia blossom	0		Last Available: "2012-12"
@@ -5442,7 +5442,7 @@
 5539	glass of warm water	0		Free Pull
 5540	liquefied desktop zen garden	0		Effect: "Floundering", Effect Duration: 23, Last Available: "2012-12"
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
-5542	squat fuchsia pink-belly slapper	0		Last Available: "2012-12"
+5542	fuchsia squat pink-belly slapper	0		Last Available: "2012-12"
 5543	Leapin' Trousers of Leguizamo of terror	0		Monster Level: +20, Spooky Spell Damage: +10
 5544	drinkable practically non-alcoholic eggnog	1	good	Last Available: "2012-12"
 5545	spoiled hamhock	3	crappy	Last Available: "2012-12"
@@ -5459,14 +5459,14 @@
 5556	blinking reassuring wholesome Rain-Doh wings	0		Maximum HP Percent: +10, Spooky Resistance: +1, Softcore Only, Last Available: "2012-02"
 5557	twirling Rain-Doh agent	0		Last Available: "2012-02"
 5558	stylish Rain-Doh laser gun of the bloodbag	0		Moxie: +25, Maximum HP: +100, Softcore Only, Last Available: "2012-02"
-5559	lion tamer's Tesla Rain-Doh lantern	0		Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	lion tamer's Tesla Rain-Doh lantern	0		Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	huge Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	Tesla Rain-Doh violet bo of dire peril	0		Weapon Damage: +20, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	ghostly Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	special low-calorie rotten teal PB&BP	1	crappy	Effect: "Hot Jellied", Effect Duration: 20
-5566	decent small club sandwich	2	good	
+5565	special rotten low-calorie teal PB&BP	1	crappy	Effect: "Hot Jellied", Effect Duration: 20
+5566	small decent club sandwich	2	good	
 5567	fancy rotten corned-beef Reuben	4	crappy	Effect: "Shamboozled", Effect Duration: 10
 5568	frayed ninja rope	0		
 5569	tumbling dull ninja crampons	0		
@@ -5474,53 +5474,53 @@
 5571	Groar's fur	0		
 5572	mirror mirror Thwaitgold stag beetle statuette	0		
 5573	aged Drac & Tan	3	awesome	Last Available: "2012-03"
-5574	enchanted perfectly mixed Transylvania Sling	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2012-03"
-5575	hand-crafted watered-down Shot of the Living Dead	2	EPIC	Last Available: "2012-03"
+5574	perfectly mixed enchanted Transylvania Sling	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2012-03"
+5575	watered-down hand-crafted Shot of the Living Dead	2	EPIC	Last Available: "2012-03"
 5576	tolerable Buttery Knob	4	good	Last Available: "2012-03"
-5577	practically non-alcoholic lousy Slippery Knob	1	decent	Last Available: "2012-03"
+5577	lousy practically non-alcoholic Slippery Knob	1	decent	Last Available: "2012-03"
 5578	perfectly mixed practically non-alcoholic Flaming Knob	1	super ultra EPIC	Last Available: "2012-03"
 5579	artisanal shaking Grasshopper	3	EPIC	Last Available: "2012-03"
-5580	watered-down fancy artisanal Locust	2	EPIC	Effect: "One For Tea", Effect Duration: 40, Last Available: "2012-03"
+5580	watered-down artisanal fancy Locust	2	EPIC	Effect: "One For Tea", Effect Duration: 40, Last Available: "2012-03"
 5581	hand-crafted boozy shaking Plague of Locusts	5	EPIC	Last Available: "2012-03"
-5582	watered-down tolerable Red Dwarf	2	good	Last Available: "2012-03"
+5582	tolerable watered-down Red Dwarf	2	good	Last Available: "2012-03"
 5583	hand-crafted practically non-alcoholic Golden Mean	1	EPIC	Last Available: "2012-03"
 5584	lousy Green Giant	3	decent	Last Available: "2012-03"
 5585	triple-distilled drinkable olive Aye Aye	6	good	Last Available: "2012-03"
-5586	bad high-proof Aye Aye, Captain	6	decent	Last Available: "2012-03"
-5587	practically non-alcoholic mediocre wobbly Aye Aye, Tooth Tooth	1	decent	Last Available: "2012-03"
+5586	high-proof bad Aye Aye, Captain	6	decent	Last Available: "2012-03"
+5587	mediocre practically non-alcoholic wobbly Aye Aye, Tooth Tooth	1	decent	Last Available: "2012-03"
 5588	acceptable Humanitini	4	good	Last Available: "2012-03"
 5589	drinkable practically non-alcoholic More Humanitini than Humanitini	1	good	Last Available: "2012-03"
-5590	weak bad Oh, the Humanitini	2	decent	Last Available: "2012-03"
-5591	watered-down mediocre Great Older Fashioned	2	decent	Last Available: "2012-03"
+5590	bad weak Oh, the Humanitini	2	decent	Last Available: "2012-03"
+5591	mediocre watered-down Great Older Fashioned	2	decent	Last Available: "2012-03"
 5592	practically non-alcoholic artisanal Fuzzy Tentacle	1	EPIC	Last Available: "2012-03"
-5593	mediocre boozy Crazymaker	5	decent	Last Available: "2012-03"
+5593	boozy mediocre Crazymaker	5	decent	Last Available: "2012-03"
 5594	perfectly mixed Zoodriver	3	EPIC	Last Available: "2012-03"
 5595	special mediocre Sloe Comfortable Zoo	3	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2012-03"
-5596	fortified artisanal Sloe Comfortable Zoo on Fire	5	EPIC	Last Available: "2012-03"
+5596	artisanal fortified Sloe Comfortable Zoo on Fire	5	EPIC	Last Available: "2012-03"
 5597	watered-down lousy yellow jittery Suffering Sinner	2	decent	Last Available: "2012-03"
 5598	artisanal Suppurating Sinner	3	EPIC	Last Available: "2012-03"
-5599	weak mediocre Sizzling Sinner	2	decent	Last Available: "2012-03"
+5599	mediocre weak Sizzling Sinner	2	decent	Last Available: "2012-03"
 5600	enchanted drinkable Firewater	4	good	Effect: "Celestial Sheen", Effect Duration: 45, Last Available: "2012-03"
 5601	artisanal weak teal Earth and Firewater	2	EPIC	Last Available: "2012-03"
 5602	aged Earth, Wind and Firewater	3	awesome	Last Available: "2012-03"
 5603	hand-crafted weak Slimosa	2	EPIC	Last Available: "2012-03"
-5604	bad watered-down Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
+5604	watered-down bad Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
 5605	artisanal lime green Slimebite	3	EPIC	Last Available: "2012-03"
-5606	acceptable weak Cement Mixer	2	good	Last Available: "2012-03"
+5606	weak acceptable Cement Mixer	2	good	Last Available: "2012-03"
 5607	special drinkable lime green Jackhammer	3	good	Effect: "Healthy Bronze Glow", Effect Duration: 5, Last Available: "2012-03"
 5608	drinkable purple Dump Truck	3	good	Last Available: "2012-03"
-5609	delicious strong Fauna Libre	5	awesome	Last Available: "2012-03"
-5610	mediocre high-proof Chakra Libre	6	decent	Last Available: "2012-03"
+5609	strong delicious Fauna Libre	5	awesome	Last Available: "2012-03"
+5610	high-proof mediocre Chakra Libre	6	decent	Last Available: "2012-03"
 5611	tolerable Aura Libre	4	good	Last Available: "2012-03"
-5612	drinkable high-proof Sazerorc	10	good	Last Available: "2012-03"
-5613	watered-down drinkable Sazuruk-hai	2	good	Last Available: "2012-03"
+5612	high-proof drinkable Sazerorc	10	good	Last Available: "2012-03"
+5613	drinkable watered-down Sazuruk-hai	2	good	Last Available: "2012-03"
 5614	tolerable Flaming Sazerorc	3	good	Last Available: "2012-03"
 5615	tolerable blinking Green Velvet	3	good	Last Available: "2012-03"
 5616	mediocre Green Muslin	3	decent	Last Available: "2012-03"
-5617	tolerable practically non-alcoholic Green Burlap	1	good	Last Available: "2012-03"
-5618	bad watered-down Mohobo	2	decent	Last Available: "2012-03"
-5619	watered-down tolerable huge Moonshine Mohobo	2	good	Last Available: "2012-03"
-5620	aged watered-down fancy blinking Flaming Mohobo	2	awesome	Effect: "Bats in the Belfry", Effect Duration: 35, Last Available: "2012-03"
+5617	practically non-alcoholic tolerable Green Burlap	1	good	Last Available: "2012-03"
+5618	watered-down bad Mohobo	2	decent	Last Available: "2012-03"
+5619	tolerable watered-down huge Moonshine Mohobo	2	good	Last Available: "2012-03"
+5620	fancy aged watered-down blinking Flaming Mohobo	2	awesome	Effect: "Bats in the Belfry", Effect Duration: 35, Last Available: "2012-03"
 5621	delicious Drunken Philosopher	4	awesome	Last Available: "2012-03"
 5622	tolerable weak spinning Drunken Neurologist	2	good	Last Available: "2012-03"
 5623	delicious irresponsibly strong Drunken Astrophysicist	6	awesome	Last Available: "2012-03"
@@ -5532,19 +5532,19 @@
 5629	boozy delicious Herringtini	5	awesome	Last Available: "2012-03"
 5630	watered-down lousy Lollipop Drop	2	decent	Last Available: "2012-03"
 5631	delicious Candy Alexander	3	awesome	Last Available: "2012-03"
-5632	distilled acceptable Candicaine	5	good	Last Available: "2012-03"
-5633	irresponsibly strong lousy shaking jittery Caipiranha	9	decent	Last Available: "2012-03"
+5632	acceptable distilled Candicaine	5	good	Last Available: "2012-03"
+5633	irresponsibly strong lousy jittery shaking Caipiranha	9	decent	Last Available: "2012-03"
 5634	bad Flying Caipiranha	4	decent	Last Available: "2012-03"
 5635	special drinkable squat Flaming Caipiranha	4	good	Effect: "Thaumodynamic", Effect Duration: 45, Last Available: "2012-03"
 5636	mediocre Punchplanter	4	decent	Last Available: "2012-03"
 5637	mediocre high-proof twirling Doublepunchplanter	7	decent	Last Available: "2012-03"
-5638	enchanted weak artisanal upside-down blinking Haymaker	2	EPIC	Effect: "Weather, Man", Effect Duration: 40, Last Available: "2012-03"
+5638	weak artisanal enchanted blinking upside-down Haymaker	2	EPIC	Effect: "Weather, Man", Effect Duration: 40, Last Available: "2012-03"
 5639	blue Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	bouncing crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	decent fungus	3	good	
 5642	gray poisoned dart	0		
 5643	quantum ionized shaking pulsating stone wool	0		Effect: "Bored Stiff", Effect Duration: 29
-5644	squat gray stones	0		
+5644	gray squat stones	0		
 5645	upside-down the Nostril of the Serpent	0		
 5646	ghostly calendar fragment	0		
 5647	occult calendar	0		Spell Damage Percent: +25, Damage Reduction: 4
@@ -5552,10 +5552,10 @@
 5649	ghostly thinker's staph of homophones of the pedagogue	0		Mysticality: +10, Experience: +3
 5650	lightning-fast aromatic Boris's Helm (askew) of the early riser	0		Stench Resistance: +1, Initiative: +40, Adventures: +7, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mirror mime soul fragment	0		Last Available: "2012-04"
-5652	narrow yellow Monster Manuel	0		Free Pull
+5652	yellow narrow Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	decent special nailswurst	3	good	Effect: "Think Win-Lose", Effect Duration: 35
-5655	artisanal extra-dry used beer	5	EPIC	
+5655	extra-dry artisanal used beer	5	EPIC	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5564,18 +5564,18 @@
 5661	wholesome hairshirt	0		Maximum HP Percent: +10
 5662	Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	cyan microwave	0		Free Pull
-5664	jittery ghostly pony keg	0		Free Pull
+5664	ghostly jittery pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	pulsating pulsating puppet strings	0		Free Pull
 5668	yellow bagged &quot;L&quot;	0		
 5669	twirling club	0		
-5670	super-sized delicious red fettucini &eacute;pines Inconnu	5	awesome	
+5670	delicious super-sized red fettucini &eacute;pines Inconnu	5	awesome	
 5671	weak artisanal slap and slap again	2	EPIC	
 5672	gunpowder burrito	2	good	
 5673	yellow beery blood	2	good	
 5674	mirror blurry &quot;L&quot;	0		
-5675	modified olive wobbly watered-down Red Minotaur	1		
+5675	modified wobbly olive watered-down Red Minotaur	1		
 5676	tumbling pool torpedo	0		Last Available: "2012-05"
 5677	cyan Ze&trade; goggles of the brute	0		Muscle Percent: +30, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
@@ -5608,7 +5608,7 @@
 5705	shaking Van der Graaf wax hat of the brute	0		Muscle Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
 5706	wobbly Lo Pan's wax pants of dire peril	0		Weapon Damage: +20, Spell Critical Percent: +30, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
-5708	ionized vacuum-sealed shaking red drop of water-37	0		Effect: "There Wolf", Effect Duration: 54, Last Available: "2012-07"
+5708	ionized vacuum-sealed red shaking drop of water-37	0		Effect: "There Wolf", Effect Duration: 54, Last Available: "2012-07"
 5709	blue miser's fireman's helmet of doom	0		Spooky Spell Damage: +50, Meat Drop: +10, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	lard-coated fire axe	0		Sleaze Spell Damage: +25, Last Available: "2012-07"
 5713	frightening MacGyver's boxer's fire extinguisher	0		Muscle Percent: +10, Maximum MP: +100, Spooky Damage: +5, Last Available: "2012-07"
@@ -5632,15 +5632,15 @@
 5731	watered-down perfectly mixed 5-hour acrimony	2	EPIC	
 5732	blank note	0		
 5733	jittery eerily silent box	0		
-5734	super-sized tasty wobbly forbidden sausage	5	awesome	
+5734	tasty super-sized wobbly forbidden sausage	5	awesome	
 5735	red Lord Flameface's cloak of the empath	0		Familiar Weight: +5, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	denatured quadruple-deionized enhanced upside-down Drizzlers&trade; Black Licorice	0		Effect: "Marinated", Effect Duration: 20
 5737	oxidized daub-breaker	0		Effect: "Nut-Rition", Effect Duration: 55, Last Available: "2020-09"
 5738	gray Camp Scout backpack of the boozehound	0		Booze Drop: +100, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	moldy bouncing bag of GORP	4	crappy	Last Available: "2012-07"
-5741	practically non-alcoholic hand-crafted water purification pills	1	EPIC	Last Available: "2012-07"
-5742	blurry spinning Camp Scout pup tent	0		Last Available: "2012-07"
+5741	hand-crafted practically non-alcoholic water purification pills	1	EPIC	Last Available: "2012-07"
+5742	spinning blurry Camp Scout pup tent	0		Last Available: "2012-07"
 5743	smooth boozy CSA scoutmaster's &quot;water&quot;	5	awesome	Last Available: "2012-07"
 5744	diet spoiled bag of GORF	1	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
@@ -5650,11 +5650,11 @@
 5749	perfectly mixed CSA cheerfulness ration	3	EPIC	Last Available: "2012-07"
 5750	jittery CSA obedience grenade	0		Last Available: "2012-07"
 5751	shaking Tales of the Word Realms	0		
-5752	huge stale crappy brain	6	decent	
+5752	stale huge crappy brain	6	decent	
 5753	spoiled decent brain	3	crappy	
 5754	half-sized tasty red good brain	2	awesome	
 5755	bland boss brain	3	decent	
-5756	decent diet hunter brain	1	good	
+5756	diet decent hunter brain	1	good	
 5758	fireproof resourceful Staff of Holiday Sensations of the bloodbag	0		Maximum HP: +100, Maximum MP: +50, Hot Resistance: +3, Last Available: "2011-11"
 5759	careful MacGyver's staff	0		Maximum MP: +100, Monster Level: -10
 5760	blurry double-paned coward's experienced staff	0		Experience: +2, Monster Level: -20, Cold Resistance: +5
@@ -5665,11 +5665,11 @@
 5765	hardened Samson's fuzzy earmuffs	0		Experience (Muscle): +5, Damage Reduction: 3, Familiar Effect: "1.5xVolley, cap 32"
 5766	friendly fortified fuzzy montera of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Familiar Weight: +3, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	yellow gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "underwater"
-5769	gray gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "delevel"
+5768	yellow gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gray gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	blurry Thwaitgold maggot statuette	0		
 5774	squat talkative skull	0		
 5775	squat fronts	0		Familiar Weight: +5
@@ -5678,7 +5678,7 @@
 5779	teal squat energetic keel-haulin' knife	0		Maximum MP Percent: +20
 5780	jittery coward's ice cream scoop	0		Monster Level: -20
 5781	drinkable soft echo eyedrop antidote martini	4	good	
-5782	tumbling purple morningwood plank	0		
+5782	purple tumbling morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
 5785	thick caulk	0		
@@ -5691,7 +5691,7 @@
 5792	pulsating arcane researcher's left bear arm of Leguizamo of the cheetah	0		Experience Percent (Mysticality): +10, Monster Level: +20, Initiative: +60, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	ghostly Hat O' Nine Tails of Gandalf	0		Spell Critical Percent: +20
 5794	moist energized Enchanted Plunger	0		Effect: "The Smeezingtons", Effect Duration: 50
-5795	triple-warmed colloidal tumbling shaking pulsating Enchanted Flyswatter	0		Effect: "Gobliny Flavor", Effect Duration: 63
+5795	triple-warmed colloidal shaking pulsating tumbling Enchanted Flyswatter	0		Effect: "Gobliny Flavor", Effect Duration: 63
 5796	modified Gearhead Goo	0		Effect: "Dance Interpreter", Effect Duration: 56
 5797	double-quantum spinning Missing Eye Simulation Device	0		Effect: "Petit Force", Effect Duration: 18
 5798	energized irradiated huge maroon blinking Gnollish Crossdress	0		Effect: "Mint-Condition Breath", Effect Duration: 29
@@ -5747,7 +5747,7 @@
 5848	boiled anodized Bangyomaman battle juice	0		Effect: "Cotton Mouthed", Effect Duration: 62
 5849	cold-filtered handyman &quot;hand soap&quot;	0		Effect: "Thicker, Sicker", Effect Duration: 50
 5850	pickled space marine flash grenade	0		Effect: "Very Clean Guns", Effect Duration: 43
-5851	electrified skewed jittery narrow temporary tribal tattoo	0		Effect: "Insatiable Hunger", Effect Duration: 64
+5851	electrified skewed narrow jittery temporary tribal tattoo	0		Effect: "Insatiable Hunger", Effect Duration: 64
 5852	flattened activated irradiated squat oil-filled donut	0		Effect: "Cancer Rising", Effect Duration: 52
 5853	quantum stick-on gnome beard	0		Effect: "Eyes Wide Propped", Effect Duration: 57
 5854	double-improved BRICKO stud	0		Effect: "Analog Drunk", Effect Duration: 59
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	wool lard-coated skeleton skis of the cheetah	0		Sleaze Spell Damage: +25, Cold Resistance: +1, Initiative: +60, Single Equip, Last Available: "2012-10"
-5883	miniature rotten bouncing skeleton quiche	2	crappy	Last Available: "2012-10"
+5883	rotten miniature bouncing skeleton quiche	2	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	prompt aromatic hardy fortified Bonestabber	0		Damage Absorption: +60, Maximum HP: +50, Stench Resistance: +1, Adventures: +3, Last Available: "2012-10"
@@ -5809,7 +5809,7 @@
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	mirror Jack Frost's slick Solstice Shield	0		Moxie: +10, Cold Spell Damage: +50
 5913	adjusted chilled candy sushi set	0		Effect: "Turtle Power", Effect Duration: 33, Last Available: "2012-12"
-5914	boiled extra-alkaline wobbly lime green sweet mochi ball	0		Effect: "Gemini Rising", Effect Duration: 45, Last Available: "2012-12"
+5914	boiled extra-alkaline lime green wobbly sweet mochi ball	0		Effect: "Gemini Rising", Effect Duration: 45, Last Available: "2012-12"
 5915	quadruple-pressed concentrated beet-flavored Mr. Mediocrebar	0		Effect: "Army of One", Effect Duration: 45, Last Available: "2012-12"
 5916	liquefied aerosolized cyan sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Trivia Master", Effect Duration: 54, Last Available: "2012-12"
 5917	altered altered cabbage-flavored Mr. Mediocrebar	0		Effect: "Spookyravin'", Effect Duration: 58, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	blue ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	jittery tumbling narrow BittyCar HotCar	0		Last Available: "2012-12"
-5928	red brainwave-controlled unicorn horn of Flo-Jo	0		Initiative: +100, Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	red brainwave-controlled unicorn horn of Flo-Jo	0		Initiative: +100, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	bouncing blind-packed capsule toy	0		Last Available: "2012-12"
 5931	twirling gray prompt avaricious quilted plastic four-shadowed mime	0		Damage Absorption: +40, Meat Drop: +30, Adventures: +3, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	grievous plastic Father McGruber	0		Weapon Damage Percent: +50, Last Available: "2012-12"
 5961	narrow boxer's plastic Hank North, Photojournalist	0		Muscle Percent: +10, Last Available: "2012-12"
 5962	plastic blazing bat of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2012-12"
-5963	blurry gravedigger's electronic dulcimer pants of the wise owl	0		Mysticality: +20, Spooky Damage: +10, Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2"
+5963	blurry gravedigger's electronic dulcimer pants of the wise owl	0		Mysticality: +20, Spooky Damage: +10, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	yellow A-Boo clue	0		
 5965	Frown Exerciser of the dark arts of vim and vigor	0		Spell Damage Percent: +100, Maximum HP Percent: +50, Single Equip, Last Available: "2012-12"
 5966	squat soul monocle	0		Single Equip
@@ -5873,7 +5873,7 @@
 5975	teal record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	lime green wholesome steel-toed silent beret of the brazier	0		Damage Reduction: 9, Maximum HP Percent: +10, Hot Spell Damage: +25, Familiar Effect: "1xVolley, cap 3"
-5978	snack-sized spoiled slice of pizza	2	crappy	Last Available: "2013-02"
+5978	spoiled snack-sized slice of pizza	2	crappy	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
@@ -5889,7 +5889,7 @@
 5991	round bomb	0		Last Available: "2013-02"
 5992	frightening manspreader's iron helmet of mayonnaise	0		Monster Level: +10, Spooky Damage: +5, Sleaze Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	auspicious Jeselnik's crafty steel sword	0		Maximum MP: +10, Sleaze Damage: +25, Item Drop: +10, Last Available: "2013-02"
-5994	stale miniature whole roasted chicken	2	decent	Last Available: "2013-02"
+5994	miniature stale whole roasted chicken	2	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	bouncing potion	0		Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	altered mirror orcish hand lotion	0		Effect: "Rad-ish", Effect Duration: 15
 6016	super-anodized unsweetened mirror orcish rubber	0		Effect: "Frost Tea", Effect Duration: 18
 6017	wet jittery orcish nailing lube	0		Effect: "In the Slimelight", Effect Duration: 23
-6018	weak tolerable twirling backwoods screwdriver	2	good	
+6018	tolerable weak twirling backwoods screwdriver	2	good	
 6019	stylish loadstone	0		Moxie: +25
 6020	MacGyver's Claybender glasses of the glutton	0		Maximum MP: +100, Food Drop: +100, Single Equip
 6021	shaking knitted thinker's Duskwalker fangs	0		Mysticality: +10, Cold Resistance: +3
@@ -5923,7 +5923,7 @@
 6025	adjusted tumbling Polysniff Perfume	0		Effect: "Bread-Lined", Effect Duration: 64
 6026	Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
-6028	pulsating green Battlie Light Saver	0		
+6028	green pulsating Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	dress pants of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "2xFairy, cap 28"
 6031	extremely unsafe badge of authority	0		Weapon Damage Percent: +100, Single Equip
@@ -5931,24 +5931,24 @@
 6033	hale stolen necklace of the boozehound	0		Maximum HP: +20, Booze Drop: +100
 6034	troll britches of the empath of the glutton	0		Familiar Weight: +5, Food Drop: +100, Familiar Effect: "1.5xPotato, cap 28"
 6035	alkaline activated shaking vial of The Glistening	0		Effect: "You Know When to Walk Away", Effect Duration: 49
-6036	special delicious artisanal limoncello	3	awesome	Effect: "Chow Downed", Effect Duration: 15
+6036	delicious special artisanal limoncello	3	awesome	Effect: "Chow Downed", Effect Duration: 15
 6037	ginger ale	0		
-6038	adequate big incredible pizza	5	good	
+6038	big adequate incredible pizza	5	good	
 6039	pulsating savvy oil cap of bravery	0		Mysticality Percent: +20, Spooky Resistance: +5, Familiar Effect: "cap 28"
 6040	wobbly executive hale oil lamp	0		Maximum HP: +20, Meat Drop: +40
 6041	zippy oil slacks	0		Initiative: +20, Familiar Effect: "1xPotato, cap 30"
 6042	chilly oil pan	0		Cold Damage: +5
 6043	boid	0		
 6044	blurry woim	0		
-6045	skewed pulsating Thwaitgold praying mantis statuette	0		
+6045	pulsating skewed Thwaitgold praying mantis statuette	0		
 6046	blue BittyCar SoulCar	0		Last Available: "2012-12"
 6047	upside-down zippy Misty Cloak of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +20
 6048	Misty Robe of chilblains	0		Cold Damage: +25, Item Drop: +5
 6049	bouncing therapeutic healthy wicked Misty Cape	0		Spell Damage: +5, Maximum HP Percent: +20, HP Regen Min: 5, HP Regen Max: 7
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	diet decent ghostly Taco Dan's Taco Stand Taco	1	good	Last Available: "2012-12"
-6053	hand-crafted boozy Taco Dan's Taco Stand Chimichangarita	5	EPIC	Last Available: "2012-12"
+6052	decent diet ghostly Taco Dan's Taco Stand Taco	1	good	Last Available: "2012-12"
+6053	boozy hand-crafted Taco Dan's Taco Stand Chimichangarita	5	EPIC	Last Available: "2012-12"
 6054	cold-filtered galvanized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Antarctic Memories", Effect Duration: 51, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	squat green The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
@@ -5971,13 +5971,13 @@
 6073	frozen blurry haggis-infused soap	0		Effect: "Warm Belly", Effect Duration: 22, Last Available: "2012-12"
 6074	oxidized huge jittery magicberry tablets	0		Effect: "Nature's Bounty", Effect Duration: 11, Last Available: "2012-12"
 6075	triple-dry corrupted purple 37x37x37 puzzle cube	0		Effect: "Cancer Rising", Effect Duration: 19, Last Available: "2012-12"
-6076	watered-down bad cyan McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
+6076	bad watered-down cyan McLeod's Hard Haggis-Ade	2	decent	Last Available: "2012-12"
 6077	spoiled mirror haggis-wrapped haggis-stuffed haggis	4	crappy	Last Available: "2012-12"
 6078	olive home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	smooth haggis socks	0		Moxie: +15, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
 6081	twirling airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
-6082	narrow tumbling Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
+6082	tumbling narrow Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	narrow Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
@@ -6001,7 +6001,7 @@
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	yellow Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	blinking Artist's Spatula of Despair	0		Last Available: "2013-12"
-6106	jittery tumbling Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
+6106	tumbling jittery Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	bouncing Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	bouncing huge inspector's wizardly Ginsu&trade;	0		Mysticality: +25, Item Drop: +15, Last Available: "2013-12"
 6109	bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
@@ -6047,7 +6047,7 @@
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	tasty carrot cake	3	awesome	Last Available: "2013-01"
-6153	hand-crafted triple-distilled carrot claret	8	EPIC	Last Available: "2013-01"
+6153	triple-distilled hand-crafted carrot claret	8	EPIC	Last Available: "2013-01"
 6154	dried mirror skewed carrot juice	1	good	Effect: "Salamander In Your Stomach", Effect Duration: 15, Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
@@ -6064,9 +6064,9 @@
 6167	pulsating huge hardened ornamental sextant	0		Damage Reduction: 3, Last Available: "2013-12"
 6168	thinker's Bloodbath of terror	0		Mysticality: +10, Spooky Spell Damage: +10, Last Available: "2013-12"
 6169	smooth Hundred Headed IPA	4	awesome	Last Available: "2013-12"
-6170	thick spoiled green chum	5	crappy	Last Available: "2013-12"
+6170	spoiled thick green chum	5	crappy	Last Available: "2013-12"
 6171	activated extra-unsweetened crude crudit&eacute;s	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 13
-6172	alkaline polarized shaking jittery candy crayons	0		Effect: "Whippin' It Good", Effect Duration: 11, Last Available: "2020-09"
+6172	alkaline polarized jittery shaking candy crayons	0		Effect: "Whippin' It Good", Effect Duration: 11, Last Available: "2020-09"
 6173	Fonzie's pixel grappling hook of bravery	0		Experience (Moxie): +1, Spooky Resistance: +5
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	skewed GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6081,45 +6081,45 @@
 6184	ghostly hardy Rosewater's Jarlsberg's hat of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Maximum HP: +50
 6185	spoiled consummate hard-boiled egg	4	crappy	
 6186	rotten bouncing consummate fried egg	4	crappy	
-6187	special stale consummate egg salad	4	decent	Effect: "Ode to Booze", Effect Duration: 5
-6188	spoiled snack-sized blurry red consummate bagel	2	crappy	
+6187	stale special consummate egg salad	4	decent	Effect: "Ode to Booze", Effect Duration: 5
+6188	spoiled snack-sized red blurry consummate bagel	2	crappy	
 6189	normal wobbly consummate sliced bread	4	good	
 6190	low-calorie stale tumbling consummate hot dog bun	1	decent	
 6191	normal tiny consummate brownie	1	good	
 6192	stale consummate toast	3	decent	
-6193	weak smooth wobbly passable stout	2	awesome	
+6193	smooth weak wobbly passable stout	2	awesome	
 6194	rotten consummate soup	4	crappy	
 6195	decent consummate corn chips	3	good	
-6196	stale enchanted consummate salad	4	decent	Effect: "Flambé-a-thon", Effect Duration: 40
+6196	enchanted stale consummate salad	4	decent	Effect: "Flambé-a-thon", Effect Duration: 40
 6197	decent consummate salsa	3	good	
 6198	spoiled consummate sauerkraut	3	crappy	
 6199	small bland ghostly consummate cheese slice	2	decent	
-6200	jumbo bland consummate melted cheese	5	decent	
+6200	bland jumbo consummate melted cheese	5	decent	
 6201	stale consummate bacon	3	decent	
 6202	adequate consummate meatloaf	4	good	
 6203	rotten huge consummate steak	3	crappy	
 6204	delicious big fuchsia consummate cuts	5	awesome	
-6205	normal thick consummate frankfurter	5	good	
-6206	fancy decent snack-sized blue twirling consummate french fries	2	good	Effect: "Burning Ears", Effect Duration: 40
+6205	thick normal consummate frankfurter	5	good	
+6206	snack-sized decent fancy twirling blue consummate french fries	2	good	Effect: "Burning Ears", Effect Duration: 40
 6207	immense moldy consummate baked potato	8	crappy	
 6208	mediocre acceptable vodka	3	decent	
 6209	decent consummate ice cream	3	good	
-6210	gigantic toothsome consummate whipped cream	9	awesome	
+6210	toothsome gigantic consummate whipped cream	9	awesome	
 6211	super-sized adequate consummate cream	5	good	
 6212	rotten consummate strawberries	3	crappy	
 6213	spoiled consummate sorbet	4	crappy	
-6214	drinkable fancy adequate rum	3	good	Effect: "Cold Jellied", Effect Duration: 5
+6214	fancy drinkable adequate rum	3	good	Effect: "Cold Jellied", Effect Duration: 5
 6215	artisanal special extra-dry blurry mediocre lager	5	EPIC	Effect: "Boo Tea", Effect Duration: 20
 6216	tiny rotten enchanted immaculate grilled cheese	1	crappy	Effect: "Thunderspell", Effect Duration: 40
-6217	snack-sized yummy immaculate ice cream sandwich	2	awesome	
-6218	fancy snack-sized normal spinning immaculate hot dog	2	good	Effect: "Locks Like the Raven", Effect Duration: 30
+6217	yummy snack-sized immaculate ice cream sandwich	2	awesome	
+6218	normal fancy snack-sized spinning immaculate hot dog	2	good	Effect: "Locks Like the Raven", Effect Duration: 30
 6219	decent miniature immaculate egg salad sandwich	2	good	
 6220	moldy perfect sandwich	3	crappy	
-6221	moldy diet perfect chef salad	1	crappy	
-6222	moldy immense narrow perfect breakfast	7	crappy	
-6223	flavorless small sublime deluxe hot dog	2	decent	
+6221	diet moldy perfect chef salad	1	crappy	
+6222	immense moldy narrow perfect breakfast	7	crappy	
+6223	small flavorless sublime deluxe hot dog	2	decent	
 6224	decent fuchsia sublime stew	3	good	
-6225	gigantic stale sublime nachos	7	decent	
+6225	stale gigantic sublime nachos	7	decent	
 6226	stale enchanted Ultimate Breakfast Sandwich	3	decent	Effect: "One For Tea", Effect Duration: 50
 6227	adequate Loaded Baked Potato	3	good	
 6228	half-sized spoiled Omega Sundae	2	crappy	
@@ -6128,9 +6128,9 @@
 6231	drinkable high-proof Vodka Dog	10	good	
 6232	artisanal Disappointed Russian	4	EPIC	
 6233	mediocre weak mirror wobbly Chunky Mary	2	decent	
-6234	drinkable weak jittery bouncing Nachojito	2	good	
+6234	weak drinkable jittery bouncing Nachojito	2	good	
 6235	drinkable cyan Le Roi	4	good	
-6236	perfectly mixed practically non-alcoholic maroon Over Easy Rider	1	super ultra EPIC	
+6236	practically non-alcoholic perfectly mixed maroon Over Easy Rider	1	super ultra EPIC	
 6237	cosmic six-pack	0		
 6239	extra-oxidized moist cube of ectoplasm	0		Effect: "Slimily Strong", Effect Duration: 36
 6240	liquefied Illuminati earpiece	0		Effect: "Ack!  Barred!", Effect Duration: 64
@@ -6142,7 +6142,7 @@
 6246	boiled demonic surgical gloves	0		Effect: "Executive Greed", Effect Duration: 58
 6247	ionized mirror clip-on ninja tie	0		Effect: "Sweet and Green", Effect Duration: 33
 6248	double-irradiated wet ionized pulsating gamer slurry	0		Effect: "Sweet and Red", Effect Duration: 63
-6249	lime green mirror wobbly dungeoneering kit	0		Last Available: "2013-02"
+6249	lime green wobbly mirror dungeoneering kit	0		Last Available: "2013-02"
 6250	Jeselnik's chaotic medical-grade studded numberwang of the brute of temperance	0		Muscle Percent: +30, Damage Absorption: +80, Spell Critical Percent: +10, Sleaze Damage: +25, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 6251	quadruple-irradiated dry squat scroll of Protection from Bad Stuff	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 67, Last Available: "2013-02"
 6252	quantum shaking scroll of Puddingskin	0		Effect: "Spore-Wreathed", Effect Duration: 33, Last Available: "2013-02"
@@ -6167,9 +6167,9 @@
 6271	spinning massive dumbbell	0		
 6272	blurry greasy Fonzie's penguin keychain	0		Experience (Moxie): +1, Sleaze Spell Damage: +10, Damage Reduction: 10
 6273	colloidal tarnished spinning O'RLY manual	0		Effect: "Gr8ness", Effect Duration: 51
-6274	watered-down bad open sauce	2	decent	
+6274	bad watered-down open sauce	2	decent	
 6275	Socratic Herculean turkey leg	0		Experience (Muscle): +1, Experience (Mysticality): +1
-6276	mediocre weak huge Ye Olde Meade	2	decent	
+6276	weak mediocre huge Ye Olde Meade	2	decent	
 6277	wet dry mirror Ye Olde Bawdy Limerick	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 64
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of the pedagogue	0		Experience: +3
@@ -6182,7 +6182,7 @@
 6286	up-at-dawn curative Mark II Steam-Hat of temperance	0		Sleaze Resistance: +5, Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6287	inspector's rosewater-soaked Mark III Steam-Hat of the blizzard of bravery	0		Cold Spell Damage: +25, Spooky Resistance: +5, Stench Resistance: +3, Item Drop: +15, Familiar Effect: "1xLep, cap 37"
 6288	blurry scorching lion tamer's Oprah's wicked Mark IV Steam-Hat of the pedagogue	0		Experience: +3, Spell Damage: +5, Maximum MP Percent: +50, Experience (familiar): +2, Hot Damage: +25, Familiar Effect: "1xLep, cap 37"
-6289	wool dance instructor's Herculean Mark V Steam-Hat of the pedagogue of vim and vigor	0		Experience: +3, Experience (Muscle): +1, Experience Percent (Moxie): +10, Maximum HP Percent: +50, Cold Resistance: +1, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	wool dance instructor's Herculean Mark V Steam-Hat of the pedagogue of vim and vigor	0		Experience: +3, Experience (Muscle): +1, Experience Percent (Moxie): +10, Maximum HP Percent: +50, Cold Resistance: +1, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	jittery steam-powered model rocketship	0		
 6291	fireproof punk rock jacket of the pedagogue	0		Experience: +3, Hot Resistance: +3
 6292	nasty safety pin of the detective	0		Stench Damage: +5, Item Drop: +20
@@ -6212,7 +6212,7 @@
 6316	lime green Newton's groovy deep six-shooter	0		Moxie Percent: +10, Experience (Mysticality): +3
 6317	frosty Temple Grandin's sea chaps	0		Familiar Weight: +7, Cold Spell Damage: +10, Familiar Effect: "atk, 2xBarrr"
 6318	horrifying flame-wreathed forbidden sea holster	0		Spell Damage Percent: +50, Hot Spell Damage: +10, Spooky Damage: +25, Single Equip
-6319	quantum magnetized fuchsia jittery shavin' razor	0		Effect: "Ooh, Umami!", Effect Duration: 60
+6319	quantum magnetized jittery fuchsia shavin' razor	0		Effect: "Ooh, Umami!", Effect Duration: 60
 6320	rosewater-soaked long-forgotten necklace	0		Stench Resistance: +3
 6321	pearl	0		
 6322	teal sea lace	0		
@@ -6258,18 +6258,18 @@
 6362	dry pulled indigo taffy	0		Effect: "Outer Wolf&trade;", Effect Duration: 24, Last Available: "2013-04"
 6363	warmed pulled taffy	0		Effect: "Frigid Weapon", Effect Duration: 63, Last Available: "2013-04"
 6364	modified improved pulled taffy	0		Effect: "Painted-On Bikini", Effect Duration: 12, Last Available: "2013-04"
-6365	diffused irradiated spinning lime green pulled taffy	0		Effect: "Sweet and Green", Effect Duration: 55, Last Available: "2013-04"
+6365	diffused irradiated lime green spinning pulled taffy	0		Effect: "Sweet and Green", Effect Duration: 55, Last Available: "2013-04"
 6366	ionized adjusted pulled violet taffy	0		Effect: "Full-Body Tan", Effect Duration: 25, Last Available: "2013-04"
 6367	wet anodized pulled taffy	0		Effect: "Mo' Hobo", Effect Duration: 48, Last Available: "2013-04"
 6368	jittery wobbly Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	weak drinkable blinking can of the cheapest beer	2	good	
+6371	drinkable weak blinking can of the cheapest beer	2	good	
 6372	tolerable bottle of fruity &quot;wine&quot;	4	good	
 6373	perfectly mixed bouncing single swig of vodka	3	EPIC	
 6374	angry inch	0		
 6375	inspector's testy toolbox	0		Item Drop: +15
-6376	twirling narrow Jick-o-User	0		
+6376	narrow twirling Jick-o-User	0		
 6378	blinking eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	alkaline blinking ph balancer	0		Effect: "Badger Underfoot", Effect Duration: 11
@@ -6281,7 +6281,7 @@
 6386	mirror balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
-6389	vacuum-sealed wobbly purple Mer-kin rocksalt	0		Effect: "Eagle Eyes", Effect Duration: 29
+6389	vacuum-sealed purple wobbly Mer-kin rocksalt	0		Effect: "Eagle Eyes", Effect Duration: 29
 6390	frozen Vulcanized shaking Mer-kin saltmint	0		Effect: "Sharp Weapon", Effect Duration: 67
 6391	polymerized wobbly upside-down Mer-kin saltsquid	0		Effect: "Heart of Yellow", Effect Duration: 24
 6392	rosewater-soaked scale-mail underwear of incineration	0		Hot Spell Damage: +50, Stench Resistance: +3, Familiar Effect: "2xVolley"
@@ -6308,13 +6308,13 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	lime green clutch of dodecapede eggs	0		
 6415	flavorless flavorless gruel	3	decent	
-6416	spoiled special gigantic pulsating mana curds	7	crappy	Effect: "Cravin' for a Ravin'", Effect Duration: 30
+6416	special spoiled gigantic pulsating mana curds	7	crappy	Effect: "Cravin' for a Ravin'", Effect Duration: 30
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	liquefied ionized skewed fuchsia moth dust	0		Effect: "Sweetened and Fattened", Effect Duration: 45
 6420	colloidal dry tumbling glob of spoiled mayo	0		Effect: "Full-Body Tan", Effect Duration: 49
 6421	tonic djinn	0		
-6422	spoiled diet vampire chowder	1	crappy	
+6422	diet spoiled vampire chowder	1	crappy	
 6423	Tales of Dread	0		Free Pull
 6424	ghostly Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6381,7 +6381,7 @@
 6486	dreadful roast	0		
 6487	red stinking agaricus	0		
 6488	spoiled Dreadsylvanian shepherd's pie	4	crappy	
-6489	shaking twirling music box parts	0		
+6489	twirling shaking music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	skewed tailfeathers	0		Familiar Weight: +5
 6492	wax banana	0		
@@ -6410,7 +6410,7 @@
 6515	inspector's eerie fetish	0		Item Drop: +15, Single Equip
 6516	drinkable practically non-alcoholic wobbly stinkwater	1	good	
 6517	shaking dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	spoiled skewed blinking accidental mutton	4	crappy	
+6518	spoiled blinking skewed accidental mutton	4	crappy	
 6519	jittery fireproof manspreader's drafty drawers	0		Monster Level: +10, Hot Resistance: +3, Familiar Effect: "1.5xVolley"
 6520	upside-down Jim Carey's wolfskull mask of temperance	0		Monster Level: +25, Sleaze Resistance: +5, Familiar Effect: "spooky atk, 1xBarrr"
 6521	sizzling guts necklace	0		Hot Damage: +10, Single Equip
@@ -6421,7 +6421,7 @@
 6526	bouncing lime green banded grievous bag of unfinished business	0		Weapon Damage Percent: +50, Damage Absorption: +100
 6527	wobbly blinking baleful beefy transparent pants	0		Muscle: +10, Spell Damage: +25, Familiar Effect: "sleaze atk, 1xPotato"
 6528	nippy hothammer	0		Cold Damage: +10
-6529	perfectly mixed fortified Thriller Ice	5	EPIC	
+6529	fortified perfectly mixed Thriller Ice	5	EPIC	
 6530	teal prompt grandfather watch	0		Adventures: +3, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	rosy-cheeked Da Vinci's spyglass	0		Experience (Mysticality): +5, Maximum HP Percent: +30
@@ -6429,7 +6429,7 @@
 6534	beefcake's remorseless knife	0		Muscle: +25
 6535	intimidating coiffure of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "hot afk, 1xPotato"
 6536	Jack Frost's Samson's cod cape	0		Experience (Muscle): +5, Cold Spell Damage: +50
-6537	big decent yellow blood sausage	5	good	
+6537	decent big yellow blood sausage	5	good	
 6538	wizardly strapping frying brainpan	0		Muscle: +5, Mysticality: +25
 6539	flame-wreathed ball and chain of the blizzard	0		Cold Spell Damage: +25, Hot Spell Damage: +10, Single Equip
 6540	red smartaleck's dry bone	0		Moxie Percent: +30
@@ -6456,24 +6456,24 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	shaking executive hand of Mr. Cards	0		Meat Drop: +40, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	stale Dreadsylvanian hot pocket	4	decent	
-6565	half-sized adequate Dreadsylvanian pocket	2	good	
+6565	adequate half-sized Dreadsylvanian pocket	2	good	
 6566	decent Dreadsylvanian pocket	3	good	
 6567	decent cyan Dreadsylvanian stink pocket	3	good	
-6568	small yummy tumbling Dreadsylvanian sleaze pocket	2	awesome	
+6568	yummy small tumbling Dreadsylvanian sleaze pocket	2	awesome	
 6569	artisanal practically non-alcoholic Dreadsylvanian hot toddy	1	super ultra mega turbo EPIC	
 6570	bad enchanted jittery Dreadsylvanian cold-fashioned	4	decent	Effect: "Spell Transfer Complete", Effect Duration: 40
-6571	acceptable practically non-alcoholic Dreadsylvanian grimlet	1	good	
+6571	practically non-alcoholic acceptable Dreadsylvanian grimlet	1	good	
 6572	mediocre Dreadsylvanian dank and stormy	3	decent	
 6573	perfectly mixed green Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
-6576	teal narrow upside-down clusterbomb	0		
+6576	upside-down narrow teal clusterbomb	0		
 6577	stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	blurry Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	dreadful box	0		
-6582	olive skewed Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
+6582	skewed olive Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	skewed vicious spiked collar	0		Familiar Damage: +20
 6584	extremely unsafe hot dog wrapper	0		Weapon Damage Percent: +100
 6585	reassuring ribald debonair deboner	0		Sleaze Damage: +10, Spooky Resistance: +1
@@ -6499,7 +6499,7 @@
 6605	pulsating clockwork numeral V	0		
 6606	clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
-6608	squat gray clockwork numeral VIII	0		
+6608	gray squat clockwork numeral VIII	0		
 6609	mirror clockwork numeral IX	0		
 6610	skewed clockwork numeral X	0		
 6611	squat clockwork numeral XI	0		
@@ -6519,7 +6519,7 @@
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	jittery folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	bouncing folder (D-Team)	0		Last Available: "2013-08"
-6628	blurry cyan twirling folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
+6628	blurry twirling cyan folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	ghostly folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	mediocre squat stepmom's booze	3	decent	
 6653	surgical tape	0		
 6654	weightlifter's band T-shirt	0		Muscle: +15
-6655	lousy fancy twirling fountain 'soda'	3	decent	Effect: "Nightstalkin'", Effect Duration: 20
+6655	fancy lousy twirling fountain 'soda'	3	decent	Effect: "Nightstalkin'", Effect Duration: 20
 6656	illegal firecracker	0		
 6657	beefy pickelhaube of the sweet-tooth	0		Muscle: +10, Candy Drop: +100, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	corrupted denatured ghostly hair oil	0		Effect: "Cold Hard Skin", Effect Duration: 35
@@ -6569,7 +6569,7 @@
 6677	shaking crude monster sculpture	0		
 6678	double-paned Yearbook Club Camera	0		Cold Resistance: +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	narrow machete of the glutton	0		Food Drop: +100
-6680	watered-down drinkable pulsating Cursed Punch	2	good	
+6680	drinkable watered-down pulsating Cursed Punch	2	good	
 6681	weak artisanal Bowl of Scorpions	2	EPIC	
 6682	watered-down mediocre Fog Murderer	2	decent	
 6683	book of matches	0		
@@ -6586,15 +6586,15 @@
 6694	boring binder clip	0		
 6695	McClusky file (complete)	0		
 6696	twirling bowling ball	0		
-6697	olive squat moss-covered stone sphere	0		
+6697	squat olive moss-covered stone sphere	0		
 6698	green dripping stone sphere	0		
-6699	narrow blurry crackling stone sphere	0		
+6699	blurry narrow crackling stone sphere	0		
 6700	scorched stone sphere	0		
 6701	stone triangle	0		
 6702	bowler	0		
 6703	blurry imitation White Russian	1	awesome	
 6704	purple short-handled mop of wisdom of the early riser	0		Mysticality: +15, Adventures: +7
-6705	massive bland jungle floor wax	8	decent	
+6705	bland massive jungle floor wax	8	decent	
 6706	smirking shrunken head	0		
 6707	liquefied activated colorful toad	0		Effect: "Eyes of the Dragon", Effect Duration: 21
 6708	crude voodoo doll	0		
@@ -6616,17 +6616,17 @@
 6724	rotten exotic jungle fruit	3	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	gray dude ranch souvenir crate	0		
-6727	skewed upside-down tropical island souvenir crate	0		
+6727	upside-down skewed tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
 6729	red UV-resistant compass	0		
-6730	wobbly tumbling funky junk key	0		
+6730	tumbling wobbly funky junk key	0		
 6731	Worse Homes and Gardens	0		
-6732	blinking gray claw-foot bathtub	0		
+6732	gray blinking claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	squat skewed cigar sign	0		
-6735	upside-down mirror pulsating junk junk	0		
+6735	upside-down pulsating mirror junk junk	0		
 6736	Junk-Bond	0		
-6737	olive blurry tangle of copper wire	0		
+6737	blurry olive tangle of copper wire	0		
 6738	jagged scrap	0		
 6739	quantum quadruple-flattened bent scrap	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 22
 6740	molten scrap	0		
@@ -6635,7 +6635,7 @@
 6743	blue wobbly junk trunks of temperance	0		Sleaze Resistance: +5, Familiar Effect: "cap 15"
 6744	censurious junk-mail shirt	0		Sleaze Resistance: +3
 6745	special yummy junk food	4	awesome	Effect: "Memory of Smarts", Effect Duration: 45
-6746	lousy skewed wobbly junk yard	4	decent	
+6746	lousy wobbly skewed junk yard	4	decent	
 6747	auspicious sinister swordzall	0		Spell Damage: +10, Item Drop: +10
 6748	bouncing arm buzzer of James Dean	0		Experience (Moxie): +3, Damage Reduction: 6
 6749	teal family-friendly dog trainer's boilgun	0		Experience (familiar): +1, Sleaze Resistance: +1
@@ -6647,12 +6647,12 @@
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	drinkable purple can of Br&uuml;talbr&auml;u	4	good	Last Available: "2013-09"
-6758	lousy watered-down bouncing can of Drooling Monk	2	decent	Last Available: "2013-09"
+6758	watered-down lousy bouncing can of Drooling Monk	2	decent	Last Available: "2013-09"
 6759	mediocre squat can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
-6760	smooth skewed shaking bottle of Old Pugilist	4	awesome	Last Available: "2013-09"
-6761	boozy acceptable bottle of Professor Beer	5	good	Last Available: "2013-09"
-6762	practically non-alcoholic mediocre bottle of Rapier Witbier	1	decent	Last Available: "2013-09"
-6763	tolerable strong bottle of Race Car Red	5	good	Last Available: "2013-09"
+6760	smooth shaking skewed bottle of Old Pugilist	4	awesome	Last Available: "2013-09"
+6761	acceptable boozy bottle of Professor Beer	5	good	Last Available: "2013-09"
+6762	mediocre practically non-alcoholic bottle of Rapier Witbier	1	decent	Last Available: "2013-09"
+6763	strong tolerable bottle of Race Car Red	5	good	Last Available: "2013-09"
 6764	lousy ghostly bottle of Greedy Dog	3	decent	Last Available: "2013-09"
 6765	artisanal blurry bottle of Lambada Lambic	3	EPIC	Last Available: "2013-09"
 6766	tin beer can	0		
@@ -6674,7 +6674,7 @@
 6782	abyssal battle plans	0		
 6783	energetic extremely unsafe seal medal of the boozehound	0		Weapon Damage Percent: +100, Maximum MP Percent: +20, Booze Drop: +100
 6784	deanimated reanimator's coffin	0		Free Pull
-6785	blue mirror flask of embalming fluid	0		
+6785	mirror blue flask of embalming fluid	0		
 6788	blank diary	0		
 6789	boot knife	0		
 6790	broken beer bottle	0		
@@ -6746,13 +6746,13 @@
 6857	miser's Cajun accordion	0		Meat Drop: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	savvy quirky accordion	0		Mysticality Percent: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	gray scandalous smartaleck's Skipper's accordion	0		Moxie Percent: +30, Sleaze Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	prompt hardy Herculean Pantsgiving of the storm	0		Experience (Muscle): +1, Maximum HP: +50, Maximum MP Percent: +40, Adventures: +3, Softcore Only, Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25"
+6860	prompt hardy Herculean Pantsgiving of the storm	0		Experience (Muscle): +1, Maximum HP: +50, Maximum MP Percent: +40, Adventures: +3, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	bland can of sardines	3	decent	Last Available: "2013-11"
 6862	rotten high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
-6863	moldy miniature huge ghostly tumbling pat of butter	2	crappy	Last Available: "2013-11"
+6863	miniature moldy huge tumbling ghostly pat of butter	2	crappy	Last Available: "2013-11"
 6864	flavorless dinner roll	3	decent	Last Available: "2013-11"
-6865	adequate small mashed potatoes	2	good	Last Available: "2013-11"
-6866	snack-sized special toothsome whole turkey leg	2	awesome	Effect: "Going Ape", Effect Duration: 40, Last Available: "2013-11"
+6865	small adequate mashed potatoes	2	good	Last Available: "2013-11"
+6866	toothsome snack-sized special whole turkey leg	2	awesome	Effect: "Going Ape", Effect Duration: 40, Last Available: "2013-11"
 6867	spoiled deviled egg	3	crappy	Last Available: "2013-11"
 6868	ionized double-flattened cyan finger exerciser	0		Effect: "Squid Squint", Effect Duration: 44, Last Available: "2013-11"
 6869	Vulcanized oxidized olive dented spoon	0		Effect: "Clyde's Blessing", Effect Duration: 25, Last Available: "2013-11"
@@ -6791,7 +6791,7 @@
 6902	twirling horrifying steel-toed flask flops	0		Damage Reduction: 9, Spooky Damage: +25, Single Equip
 6903	oxidized polarized nuts	0		Effect: "Oriental Mysticism", Effect Duration: 13, Last Available: "2013-12"
 6904	quadruple-ionized boiled spinning bolts	0		Effect: "Familial Ties", Effect Duration: 11, Last Available: "2013-12"
-6905	moldy thick gingerbread robot	5	crappy	Last Available: "2013-12"
+6905	thick moldy gingerbread robot	5	crappy	Last Available: "2013-12"
 6906	yummy snack-sized petit 4.1	2	awesome	Last Available: "2013-12"
 6907	super-sized normal nut-shaped Crimbo cookie	5	good	Last Available: "2023-06"
 6908	double-paned plastic GORM-8	0		Cold Resistance: +5, Last Available: "2013-12"
@@ -6807,12 +6807,12 @@
 6918	boiled tumbling warbear wardance potion	0		Effect: "Nothing Is Impossible", Effect Duration: 22, Last Available: "2013-12"
 6919	quantum electrified warbear bearserker potion	0		Effect: "Just the Brown Ones", Effect Duration: 22, Last Available: "2013-12"
 6920	deionized adjusted warbear liquid overcoat	0		Effect: "Weather, Man", Effect Duration: 55, Last Available: "2013-12"
-6921	miniature adequate warbear feasting bread	2	good	Last Available: "2013-12"
+6921	adequate miniature warbear feasting bread	2	good	Last Available: "2013-12"
 6922	moldy warbear warrior bread	4	crappy	Last Available: "2013-12"
 6923	bite-sized spoiled teal warbear thermoregulator bread	1	crappy	Last Available: "2013-12"
-6924	fancy lousy warbear feasting mead	3	decent	Effect: "Celestial Body", Effect Duration: 20, Last Available: "2013-12"
+6924	lousy fancy warbear feasting mead	3	decent	Effect: "Celestial Body", Effect Duration: 20, Last Available: "2013-12"
 6925	mediocre warbear bearserker mead	3	decent	Last Available: "2013-12"
-6926	watered-down tolerable warbear blizzard mead	2	good	Last Available: "2013-12"
+6926	tolerable watered-down warbear blizzard mead	2	good	Last Available: "2013-12"
 6927	huge warbear helm fragment	0		Last Available: "2013-12"
 6928	forbidden experienced warbear plain fedora of the cheetah	0		Experience: +2, Spell Damage Percent: +50, Initiative: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	chilly warbear feathered fedora	0		Cold Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6893,10 +6893,10 @@
 7004	liquefied Flaskfull of Hollow	0		Effect: "Sparkling Consciousness", Effect Duration: 52, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	mixed handful of Smithereens	1	EPIC	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 25, Last Available: "2013-12"
-7007	moldy immense jittery Every Day is Like This Sundae	10	crappy	Last Available: "2013-12"
+7007	immense moldy jittery Every Day is Like This Sundae	10	crappy	Last Available: "2013-12"
 7008	rotten narrow Miserable Pie	3	crappy	Last Available: "2013-12"
-7009	yummy thick upside-down This Charming Flan	5	awesome	Last Available: "2013-12"
-7010	watered-down drinkable Irish Coffee, English Heart	2	good	Last Available: "2013-12"
+7009	thick yummy upside-down This Charming Flan	5	awesome	Last Available: "2013-12"
+7010	drinkable watered-down Irish Coffee, English Heart	2	good	Last Available: "2013-12"
 7011	acceptable blue Strikes Again Bigmouth	3	good	Last Available: "2013-12"
 7012	weak hand-crafted Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	blinking zippy mansplainer's Shakespeare's Sister's Accordion of James Dean	0		Experience (Moxie): +3, Monster Level: +15, Initiative: +20, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	third-hand lantern of vim and vigor	0		Maximum HP Percent: +50
 7031	teal loose purse strings	0		
-7032	immense normal pickled egg	10	good	
+7032	normal immense pickled egg	10	good	
 7033	cup of lukewarm tea	1	decent	
 7034	blue warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6941,9 +6941,9 @@
 7052	teal warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	snack-sized flavorless breakfast mess	2	decent	Last Available: "2013-12"
+7055	flavorless snack-sized breakfast mess	2	decent	Last Available: "2013-12"
 7056	narrow warbear breakfast machine	0		Last Available: "2013-12"
-7057	flavorless enchanted breakfast miracle	3	decent	Effect: "Prelude of Precision", Effect Duration: 35, Last Available: "2013-12"
+7057	enchanted flavorless breakfast miracle	3	decent	Effect: "Prelude of Precision", Effect Duration: 35, Last Available: "2013-12"
 7058	altered Cloaca Cola Polar	0		Effect: "Leisurely Amblin'", Effect Duration: 39, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	green festive warbear bank	0		Last Available: "2013-12"
@@ -6955,21 +6955,21 @@
 7066	twirling grimstone galoshes	0		Familiar Weight: +5
 7067	extra-frozen single of Inigo's Incantation of Inspiration	0		Effect: "Jelly Combed", Effect Duration: 56, Last Available: "2010-02"
 7068	quadruple-dry aerosolized boiled single of Donho's Bubbly Ballad	0		Effect: "Always be Collecting", Effect Duration: 16
-7069	twirling blurry Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
+7069	blurry twirling Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	maroon packet of winter seeds	0		Last Available: "2014-01"
 7071	miniature stale lime green snow berries	2	decent	Last Available: "2014-01"
 7072	rotten ice harvest	3	crappy	Last Available: "2014-01"
 7073	super-concentrated frost flower	0		Effect: "A Contender", Effect Duration: 38, Last Available: "2014-01"
 7074	pressed anodized snow cleats	0		Effect: "Grumpy and Ornery", Effect Duration: 14, Last Available: "2014-01"
-7075	quantum skewed narrow liquid ice pack	0		Effect: "Radium Radicality", Effect Duration: 61, Last Available: "2014-01"
+7075	quantum narrow skewed liquid ice pack	0		Effect: "Radium Radicality", Effect Duration: 61, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	adequate special snow crab	3	good	Effect: "Dreadful Chill", Effect Duration: 30, Last Available: "2014-01"
+7077	special adequate snow crab	3	good	Effect: "Dreadful Chill", Effect Duration: 30, Last Available: "2014-01"
 7078	weak tolerable Ice Island Long Tea	2	good	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	snow mobile	0		Item Drop: +5, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	snow mobile	0		Item Drop: +5, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	blue narrow ice bucket of the storm	0		Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2014-01"
 7085	frightening wicked snow shovel	0		Spell Damage: +5, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
 7086	gravedigger's sizzling wholesome bod-ice	0		Maximum HP Percent: +10, Hot Damage: +10, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
@@ -6987,7 +6987,7 @@
 7098	aromatic wool grievous sweat socks of Calamity Jane	0		Weapon Damage Percent: +50, Critical Hit Percent: +15, Cold Resistance: +1, Stench Resistance: +1, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
 7100	teal Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	pickled yellow ghostly spinning Five Second Energy&trade;	1		Effect: "Joyful Resolve", Effect Duration: 15, Last Available: "2014-12"
+7101	pickled spinning yellow ghostly Five Second Energy&trade;	1		Effect: "Joyful Resolve", Effect Duration: 15, Last Available: "2014-12"
 7102	bouncing pixie axie	0		Last Available: "2014-12"
 7103	super-chilled altered powder	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 56, Last Available: "2014-12"
 7104	groovy licorice whip	0		Moxie Percent: +10, Last Available: "2014-12"
@@ -6997,14 +6997,14 @@
 7108	adequate pecan	4	good	Last Available: "2014-12"
 7109	moldy pecan pie	4	crappy	Last Available: "2014-12"
 7110	tumbling chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	small delicious candy mountain oyster	2	awesome	Last Available: "2014-12"
+7111	delicious small candy mountain oyster	2	awesome	Last Available: "2014-12"
 7112	tolerable twirling chocotini	3	good	Last Available: "2014-12"
 7113	lard-coated extremely unsafe groovy chocolate rabbit's foot	0		Moxie Percent: +10, Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7114	diet moldy green ghostly candy carrot	1	crappy	Last Available: "2014-12"
+7114	diet moldy ghostly green candy carrot	1	crappy	Last Available: "2014-12"
 7115	adequate big candy carrot cake	5	good	Last Available: "2014-12"
 7116	lion tamer's carrot-on-a-stick of wisdom	0		Mysticality: +15, Experience (familiar): +2, Last Available: "2014-12"
 7117	coward's boxer's weasel stomping pants	0		Muscle Percent: +10, Monster Level: -20, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	miniature moldy yellow mulberry	2	crappy	Last Available: "2014-12"
+7118	moldy miniature yellow mulberry	2	crappy	Last Available: "2014-12"
 7119	practically non-alcoholic artisanal mulled berry wine	1	super ultra mega turbo EPIC	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	red shaking educational lemon party hat	0		Experience: +1, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
@@ -7024,7 +7024,7 @@
 7135	yummy witch's bread	4	awesome	Last Available: "2014-12"
 7136	quantum anodized pulsating witch's brew	0		Effect: "Inner Dog", Effect Duration: 58, Last Available: "2014-12"
 7137	banded quilted witch's bra of the businessman	0		Damage Absorption: 140, Meat Drop: +50, Last Available: "2014-12"
-7138	aged distilled mid-level medieval mead	5	awesome	Last Available: "2014-12"
+7138	distilled aged mid-level medieval mead	5	awesome	Last Available: "2014-12"
 7139	frozen squat R&uuml;mpelstiltz	0		Effect: "Human-Pirate Hybrid", Effect Duration: 45, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	vacuum-sealed hi-octane carrot juice	0		Effect: "It Didn't Kill You", Effect Duration: 54, Last Available: "2014-12"
@@ -7034,7 +7034,7 @@
 7145	moldy cinnamon cannoli	3	crappy	Last Available: "2014-12"
 7146	practically non-alcoholic mediocre bouncing squat expensive champagne	1	decent	Last Available: "2014-12"
 7147	moist triple-aerosolized polo trophy	0		Effect: "Puddingface", Effect Duration: 42, Last Available: "2014-12"
-7148	fuchsia jittery oil painting	0		Last Available: "2014-12"
+7148	jittery fuchsia oil painting	0		Last Available: "2014-12"
 7149	bouncing rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	olive straw	0		Last Available: "2014-12"
@@ -7056,16 +7056,16 @@
 7167	energized maroon smudge stick	0		Effect: "Bear Clawed", Effect Duration: 26, Last Available: "2014-12"
 7168	wet oxidized wall	0		Effect: "Nothing Is Impossible", Effect Duration: 44, Last Available: "2014-12"
 7169	tolerable tankard of ale	3	good	Last Available: "2014-12"
-7170	warmed deionized maroon twirling scroll case	0		Effect: "Holiday Bliss", Effect Duration: 22, Last Available: "2014-12"
+7170	warmed deionized twirling maroon scroll case	0		Effect: "Holiday Bliss", Effect Duration: 22, Last Available: "2014-12"
 7171	adjusted dry improved jug of &quot;wine&quot;	0		Effect: "Berry Defensive", Effect Duration: 65, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	flavorless bite-sized humble pie	1	decent	Last Available: "2014-12"
+7174	bite-sized flavorless humble pie	1	decent	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	unsweetened galvanized crappy waiter disguise	0		Effect: "Tiki Temerity", Effect Duration: 62
 7178	purple Copperhead Charm	0		
-7179	gray twirling bouncing The First Pizza	0		
+7179	bouncing gray twirling The First Pizza	0		
 7180	twirling The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7101,23 +7101,23 @@
 7212	brawny Jefferson wings	0		Muscle Percent: +20
 7213	fleetwood macaroni	0		
 7214	wobbly narrow cheesy eagle sauce	0		
-7215	adequate tiny fleetwood mac 'n' cheese	1	good	
-7216	blurry upside-down lynyrd skin	0		
+7215	tiny adequate fleetwood mac 'n' cheese	1	good	
+7216	upside-down blurry lynyrd skin	0		
 7217	twirling squat Herculean lynyrdskin cap	0		Experience (Muscle): +1, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	stanky lynyrdskin tunic	0		Stench Spell Damage: +25
 7219	lynyrdskin breeches of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	upside-down cigarette lighter	0		
 7221	priceless diamond	0		
-7222	artisanal weak Flamin' Whatshisname	2	EPIC	
-7223	ionized olive skewed lynyrd musk	0		Effect: "Chorale of Companionship", Effect Duration: 39
+7222	weak artisanal Flamin' Whatshisname	2	EPIC	
+7223	ionized skewed olive lynyrd musk	0		Effect: "Chorale of Companionship", Effect Duration: 39
 7224	Jim Carey's weightlifter's Kashmir sweater	0		Muscle: +15, Monster Level: +25
 7225	normal ghostly tumbling custard pie	4	good	
 7226	blurry tea for one	1	good	
-7227	watered-down drinkable skewed bottle of Evermore	2	good	
+7227	drinkable watered-down skewed bottle of Evermore	2	good	
 7228	box	0		
 7229	smooth wine	3	awesome	
 7230	perfectly mixed upside-down rum	3	EPIC	
-7231	artisanal fortified Murderer's Punch	5	EPIC	
+7231	fortified artisanal Murderer's Punch	5	EPIC	
 7232	bland velvet cake	4	decent	
 7233	adjusted letter	0		Effect: "Tin, Man", Effect Duration: 23
 7234	aromatic book of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +1
@@ -7130,7 +7130,7 @@
 7241	ribald Oprah's shoe	0		Maximum MP Percent: +50, Sleaze Damage: +10, Single Equip
 7242	huge button	0		
 7243	purple button	0		
-7244	polarized spinning maroon ghostly blood cells	0		Effect: "Oriental Mysticism", Effect Duration: 28
+7244	polarized maroon spinning ghostly blood cells	0		Effect: "Oriental Mysticism", Effect Duration: 28
 7245	boiled aerosolized eye	0		Effect: "Arcane in the Brain", Effect Duration: 17
 7246	glark cable	0		
 7247	pulsating bouncing manspreader's Red Fox glove of the early riser	0		Monster Level: +10, Adventures: +7, Attacks Can't Miss, Single Equip
@@ -7168,7 +7168,7 @@
 7279	double-nitrogenated pickled yellow wind-up Whatsian robot	0		Effect: "Dancing Prowess", Effect Duration: 61
 7280	extra-altered moist ionized fuchsia pulsating wind-up vampire teeth	0		Effect: "Gummi-Grin", Effect Duration: 14
 7281	cold-filtered wind-up navigation droid	0		Effect: "Purpose", Effect Duration: 60
-7282	deionized activated skewed purple huge wind-up owl	0		Effect: "Just the Brown Ones", Effect Duration: 17
+7282	deionized activated purple huge skewed wind-up owl	0		Effect: "Just the Brown Ones", Effect Duration: 17
 7283	chilled polymerized wind-up ensign	0		Effect: "Burnt 'n' Turnt", Effect Duration: 66
 7284	tumbling brainy crying statue earrings of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25, Single Equip, Lasts Until Rollover
 7285	jittery healthy arcane researcher's plastic Duskwalker necklace	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +20, Single Equip, Lasts Until Rollover
@@ -7208,15 +7208,15 @@
 7319	blinking Newton's Elizabeth's Dollie of the sewer	0		Experience (Mysticality): +3, Stench Damage: +25
 7320	pressed tumbling Elizabeth's paintbrush	0		Effect: "Red Misty-Eyed", Effect Duration: 34
 7321	lime green curative Stephen's lab coat of wisdom	0		Mysticality: +15, HP Regen Min: 3, HP Regen Max: 5
-7322	adjusted irradiated blue pulsating Stephen's secret formula	0		Effect: "Charrrming", Effect Duration: 36
+7322	adjusted irradiated pulsating blue Stephen's secret formula	0		Effect: "Charrrming", Effect Duration: 36
 7323	rock-hard Jacob's rung of wisdom	0		Mysticality: +15, Damage Reduction: 5
 7324	mixed blurry battery	1		Effect: "Strawberry Alarm", Effect Duration: 30
-7325	smooth fancy practically non-alcoholic snakebite	1	awesome	Effect: "Frozen Hands", Effect Duration: 20
+7325	practically non-alcoholic fancy smooth snakebite	1	awesome	Effect: "Frozen Hands", Effect Duration: 20
 7326	ribald weightlifter's rubber ribcage	0		Muscle: +15, Sleaze Damage: +10, Damage Reduction: 7
 7327	dehydrated synthetic marrow	1		
 7328	flattened funny bone	0		Effect: "Baconstoned", Effect Duration: 67
 7329	shaking friendly experienced half-melted spoon	0		Experience: +2, Familiar Weight: +3
-7330	dehydrated narrow blurry the funk	1		
+7330	dehydrated blurry narrow the funk	1		
 7331	gigantic stale gunky chicken	7	decent	
 7332	dog trainer's doll head	0		Experience (familiar): +1
 7333	droopy doll eye	0		
@@ -7229,7 +7229,7 @@
 7340	hardened moose antlers	0		Damage Reduction: 3, Familiar Effect: "atk, 1xLep, cap 27"
 7341	triple-alkaline moose thought	0		Effect: "Chorale of Companionship", Effect Duration: 45
 7342	bland moose chocolate	3	decent	
-7343	fortified bad painting of a glass of wine	5	decent	
+7343	bad fortified painting of a glass of wine	5	decent	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	blue doll-eye amulet	0		Single Equip
@@ -7240,10 +7240,10 @@
 7351	Sherlock's sinister personal trainer's Staff of the Electric Range	0		Experience Percent (Muscle): +10, Spell Damage: +10, Item Drop: +25
 7352	normal snack-sized special shaking deluxe layer cake	2	good	Effect: "Locks Like the Raven", Effect Duration: 50
 7353	narrow chunk of hot iron	0		
-7354	perfectly mixed watered-down red-hot boilermaker	2	EPIC	
+7354	watered-down perfectly mixed red-hot boilermaker	2	EPIC	
 7355	auspicious coal shovel	0		Item Drop: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	polymerized magnetized hot coal	0		Effect: "Powder Power", Effect Duration: 36
-7357	ionized ghostly wobbly coal dust	0		Effect: "Berry Statistical", Effect Duration: 11
+7357	ionized wobbly ghostly coal dust	0		Effect: "Berry Statistical", Effect Duration: 11
 7358	greedy medical-grade Bram's choker of the sewer	0		Stench Damage: +25, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 7359	spinning fuchsia plaid swatch	0		
 7360	plaid bandage	0		
@@ -7255,7 +7255,7 @@
 7366	practically non-alcoholic aged bottle of laundry sherry	1	awesome	
 7367	moist extra-frozen industrial strength starch	0		Effect: "Rave Nirvana", Effect Duration: 44, Wiki Name: "industrial strength starch"
 7368	decent tumbling extra-flat panini	4	good	
-7369	quantum cold-filtered pulsating mirror mangled finger	0		Effect: "Powdered", Effect Duration: 26
+7369	quantum cold-filtered mirror pulsating mangled finger	0		Effect: "Powdered", Effect Duration: 26
 7370	acceptable Psychotic Train wine	4	good	
 7371	crazy hobo notebook	0		
 7372	moldy half-sized twirling pie man was not meant to eat	2	crappy	
@@ -7280,7 +7280,7 @@
 7391	Vulcanized Gene Tonic: Orc	0		Effect: "Robocamo", Effect Duration: 25, Last Available: "2014-04"
 7392	liquefied cold-filtered skewed Gene Tonic: Demon	0		Effect: "Hippy Flavor", Effect Duration: 51, Last Available: "2014-04"
 7393	Vulcanized blurry Gene Tonic: Horror	0		Effect: "Rosewater Mark", Effect Duration: 34, Last Available: "2014-04"
-7394	denatured frozen polymerized squat tumbling Gene Tonic: Fish	0		Effect: "Rave Nirvana", Effect Duration: 44, Last Available: "2014-04"
+7394	denatured frozen polymerized tumbling squat Gene Tonic: Fish	0		Effect: "Rave Nirvana", Effect Duration: 44, Last Available: "2014-04"
 7395	non-magnetized warmed jittery Gene Tonic: Goblin	0		Effect: "Adapt to Change Eventually", Effect Duration: 37, Last Available: "2014-04"
 7396	energized Gene Tonic: Pirate	0		Effect: "Dwarven Hardiness", Effect Duration: 19, Last Available: "2014-04"
 7397	diffused double-oxidized Gene Tonic: Plant	0		Effect: "Going Ape", Effect Duration: 50, Last Available: "2014-04"
@@ -7305,7 +7305,7 @@
 7416	Steam Card: DemonStar (#2)	0		
 7417	fuchsia Steam Card: DemonStar (#3)	0		
 7418	Steam Card: Jackass Plumber (#1)	0		
-7419	ghostly spinning Steam Card: Jackass Plumber (#2)	0		
+7419	spinning ghostly Steam Card: Jackass Plumber (#2)	0		
 7420	maroon Steam Card: Jackass Plumber (#3)	0		
 7421	mirror pencil thin mushroom	0		Last Available: "2014-05"
 7422	tumbling Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
@@ -7315,16 +7315,16 @@
 7426	sprinkle shaker	0		Last Available: "2014-05"
 7427	triple-ionized sleight-of-hand mushroom	0		Effect: "The Moxious Madrigal", Effect Duration: 35, Last Available: "2014-05"
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
-7429	blinking spinning Beach Buck	0		Last Available: "2014-05"
+7429	spinning blinking Beach Buck	0		Last Available: "2014-05"
 7430	frozen jittery Fun-Guy spore	0		Effect: "Baconstoned", Effect Duration: 15, Last Available: "2014-05"
 7431	quadruple-oxidized huge Boletus Broletus mushroom	0		Effect: "Fruited", Effect Duration: 50, Last Available: "2014-05"
-7432	galvanized huge purple Omphalotus Omphaloskepsis mushroom	0		Effect: "Sepia Tan", Effect Duration: 65, Last Available: "2014-05"
+7432	galvanized purple huge Omphalotus Omphaloskepsis mushroom	0		Effect: "Sepia Tan", Effect Duration: 65, Last Available: "2014-05"
 7433	energized Gyromitra Dynomita mushroom	0		Effect: "Bootyliciousness", Effect Duration: 14, Last Available: "2014-05"
 7434	ionized denatured upside-down gray Helvella Haemophilia mushroom	0		Effect: "Starry-Eyed", Effect Duration: 26, Last Available: "2014-05"
 7435	non-oxidized irradiated ionized narrow Stemonitis Staticus mushroom	0		Effect: "The Grass...  Is Blue...", Effect Duration: 16, Last Available: "2014-05"
 7436	unsweetened Tremella Tarantella mushroom	0		Effect: "Neuroplastici Tea", Effect Duration: 15, Last Available: "2014-05"
 7437	ghostly Pastaco shell	0		Last Available: "2014-05"
-7438	bland super-sized Beefy Crunch Pastaco	5	decent	Last Available: "2014-05"
+7438	super-sized bland Beefy Crunch Pastaco	5	decent	Last Available: "2014-05"
 7439	delicious Brain Food Pastaco	4	awesome	Last Available: "2014-05"
 7440	spoiled Cool Brunch Pastaco	3	crappy	Last Available: "2014-05"
 7441	spoiled blurry Medical Pastaco	3	crappy	Last Available: "2014-05"
@@ -7332,19 +7332,19 @@
 7443	yummy skewed Ludovico Pastaco	4	awesome	Last Available: "2014-05"
 7444	mediocre narrow overpowering mushroom wine	4	decent	Last Available: "2014-05"
 7445	acceptable complex mushroom wine	3	good	Last Available: "2014-05"
-7446	artisanal watered-down special smooth mushroom wine	2	super ultra mega turbo EPIC	Effect: "Berry Thorny", Effect Duration: 35, Last Available: "2014-05"
+7446	artisanal special watered-down smooth mushroom wine	2	super ultra mega turbo EPIC	Effect: "Berry Thorny", Effect Duration: 35, Last Available: "2014-05"
 7447	special perfectly mixed blood-red mushroom wine	3	super ultra EPIC	Effect: "Oth-Jeal-O", Effect Duration: 25, Last Available: "2014-05"
 7448	drinkable watered-down buzzing mushroom wine	2	good	Last Available: "2014-05"
-7449	perfectly mixed spirit-forward swirling mushroom wine	5	EPIC	Last Available: "2014-05"
-7450	stale thick spinning Taco Dan's Basic Taco Dan Taco	5	decent	Last Available: "2014-05"
-7451	miniature moldy Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
+7449	spirit-forward perfectly mixed swirling mushroom wine	5	EPIC	Last Available: "2014-05"
+7450	thick stale spinning Taco Dan's Basic Taco Dan Taco	5	decent	Last Available: "2014-05"
+7451	moldy miniature Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	irresponsibly strong tolerable regular-size brogurt	10	good	Last Available: "2014-05"
+7453	tolerable irresponsibly strong regular-size brogurt	10	good	Last Available: "2014-05"
 7454	tolerable watered-down super-size brogurt	2	good	Last Available: "2014-05"
 7455	perfectly mixed strong broberry brogurt	5	EPIC	Last Available: "2014-05"
 7456	acceptable brocolate brogurt	4	good	Last Available: "2014-05"
 7457	enchanted tolerable French bronilla brogurt	4	good	Effect: "Libra Rising", Effect Duration: 25, Last Available: "2014-05"
-7458	squat wobbly History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
+7458	wobbly squat History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	huge Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
@@ -7368,7 +7368,7 @@
 7479	nitrogenated polymerized tumbling sugar fairy	0		Effect: "Leisurely Amblin'", Effect Duration: 21, Last Available: "2014-05"
 7480	diffused boiled twirling sugar bunny	0		Effect: "Almost Cool", Effect Duration: 20, Last Available: "2014-05"
 7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	perfectly mixed practically non-alcoholic Rompedores de Fantasmas	1	super ultra EPIC	
+7482	practically non-alcoholic perfectly mixed Rompedores de Fantasmas	1	super ultra EPIC	
 7483	artisanal blue La Fantasma y La Oscuridad	4	EPIC	
 7484	tolerable Fantasma en la M&aacute;quina	3	good	
 7485	twirling loosening powder	0		
@@ -7376,7 +7376,7 @@
 7487	pulsating drain dissolver	0		
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
-7490	upside-down bouncing triatomaceous dust	0		
+7490	bouncing upside-down triatomaceous dust	0		
 7491	watered-down lousy mirror bottle of Chateau de Vinegar	2	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
@@ -7385,7 +7385,7 @@
 7496	blue bottled day	0		
 7497	lime green ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
-7499	oxidized altered teal mirror Hot 'n' Scarys	0		Effect: "Weapon of Mass Destruction", Effect Duration: 26
+7499	oxidized altered mirror teal Hot 'n' Scarys	0		Effect: "Weapon of Mass Destruction", Effect Duration: 26
 7500	map	0		
 7501		0		
 7502	galvanized Texas tea	0		Effect: "Cat Class, Cat Style", Effect Duration: 30
@@ -7402,7 +7402,7 @@
 7513	huge opium grenade	0		
 7514	skewed clever duonoculars of horror	0		Maximum MP: +20, Spooky Spell Damage: +25, Single Equip
 7515	plastic rock	0		
-7516	narrow teal witch's spare house key	0		
+7516	teal narrow witch's spare house key	0		
 7517	blurry spider leg of the ox of the brute	0		Muscle: +20, Muscle Percent: +30
 7518	wand of pigification	0		
 7519	drinkable glass of bourbon	4	good	
@@ -7415,13 +7415,13 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	Samson's government-issued night-vision goggles of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Single Equip, Last Available: "2014-05"
-7529	decent massive skewed loaf of alien bread	6	good	Last Available: "2014-05"
-7530	decent thick shaking wobbly grilled cheese sandwich	5	good	Last Available: "2014-05"
+7529	massive decent skewed loaf of alien bread	6	good	Last Available: "2014-05"
+7530	decent thick wobbly shaking grilled cheese sandwich	5	good	Last Available: "2014-05"
 7531	denatured blue bouncing alien protein powder	1	decent	Last Available: "2014-05"
 7532	bad bouncing rocket fuel	4	decent	Last Available: "2014-05"
-7533	twirling blue alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7533	blue twirling alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	lousy watered-down blinking stealth bomber	2	decent	Last Available: "2014-05"
+7535	watered-down lousy blinking stealth bomber	2	decent	Last Available: "2014-05"
 7536	blinking space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	upside-down jittery ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7442,9 +7442,9 @@
 7553	shaker of dry rub	0		Last Available: "2014-06"
 7554	non-ionized pickled diffused bottle of lighter fluid	0		Effect: "Carol of the Bones", Effect Duration: 39, Last Available: "2014-06"
 7555	tumbling page	0		
-7556	purple tumbling elephant gift	0		
+7556	tumbling purple elephant gift	0		
 7557	polymerized corrupted blood cells	0		Effect: "Rain Dancin'", Effect Duration: 53
-7558	lousy extra-dry special wine	5	decent	Effect: "Spookyravin'", Effect Duration: 5
+7558	special extra-dry lousy wine	5	decent	Effect: "Spookyravin'", Effect Duration: 5
 7559	activated squat gummi turtle	0		Effect: "Thick-Skinned", Effect Duration: 46
 7560	cyan turtle-shaped rock	0		
 7561	enhanced giraffe-necked turtle	0		Effect: "In Vino Vires", Effect Duration: 59
@@ -7467,7 +7467,7 @@
 7578	tarnished activated pressed future drug: Coolscaline	0		Effect: "Polar Express", Effect Duration: 49
 7579	yellow twitching time capsule	0		
 7580	altered liquid shifting time weirdness	1		
-7581	upside-down skewed shifting time weirdness	0		Adventures: +4, PvP Fights: +4
+7581	skewed upside-down shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	spoiled rack of dinosaur ribs	3	crappy	
 7583	enchanted artisanal weak scotch on the rocks	2	super ultra EPIC	Effect: "Took Eleven", Effect Duration: 30
 7584	gray asbestos-lined careful yabba dabba doo rag	0		Monster Level: -10, Hot Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7477,12 +7477,12 @@
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	irresponsibly strong delicious glass of &quot;milk&quot;	10	awesome	Last Available: "2014-07"
 7590	lousy practically non-alcoholic yellow cup of &quot;tea&quot;	1	decent	Last Available: "2014-07"
-7591	smooth watered-down thermos of &quot;whiskey&quot;	2	awesome	Last Available: "2014-07"
+7591	watered-down smooth thermos of &quot;whiskey&quot;	2	awesome	Last Available: "2014-07"
 7592	bad upside-down Lucky Lindy	4	decent	Last Available: "2014-07"
-7593	high-proof tolerable Bee's Knees	6	good	Last Available: "2014-07"
+7593	tolerable high-proof Bee's Knees	6	good	Last Available: "2014-07"
 7594	lousy Sockdollager	3	decent	Last Available: "2014-07"
 7595	mediocre jittery Ish Kabibble	4	decent	Last Available: "2014-07"
-7596	watered-down delicious olive Hot Socks	2	awesome	Last Available: "2014-07"
+7596	delicious watered-down olive Hot Socks	2	awesome	Last Available: "2014-07"
 7597	weak delicious Phonus Balonus	2	awesome	Last Available: "2014-07"
 7598	lousy Flivver	3	decent	Last Available: "2014-07"
 7599	delicious huge Sloppy Jalopy	3	awesome	Last Available: "2014-07"
@@ -7517,7 +7517,7 @@
 7628	polymerized jittery dancing fan	0		Effect: "Gunky Dory", Effect Duration: 30
 7629	electrified squat page of the Necrohobocon	0		Effect: "Spookyravin'", Effect Duration: 13
 7630	nitrogenated twirling purple magic powder	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 42
-7631	colloidal dry blinking squat friar's tonsure	0		Effect: "Crud&eacute;", Effect Duration: 18
+7631	colloidal dry squat blinking friar's tonsure	0		Effect: "Crud&eacute;", Effect Duration: 18
 7632	improved pickled boiled gray government-issue identification badge	0		Effect: "Vitali Tea", Effect Duration: 47
 7633	flattened alien hologram projector	0		Effect: "Puddingface", Effect Duration: 58
 7634	unsweetened non-cold-filtered irradiated turtle	0		Effect: "All Is Forgiven", Effect Duration: 32
@@ -7561,13 +7561,13 @@
 7672	law-abiding citizen cane of the brazier	0		Hot Spell Damage: +25, Single Equip
 7673	lousy legitimate business on the beach	3	decent	
 7674	cyan hep waders of Leguizamo	0		Monster Level: +20, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	flavorless immense jive turkey leg	8	decent	
+7675	immense flavorless jive turkey leg	8	decent	
 7676	pulsating greedy birdbone corset	0		Meat Drop: +20
 7677	frozen deionized candy cigarette	0		Effect: "Thaumodynamic", Effect Duration: 41
 7678	green 4-dimensional fez of the ox	0		Muscle: +20, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	twirling frosty super-absorbent tarp	0		Cold Spell Damage: +10
-7681	fancy lousy unquiet spirits	4	decent	Effect: "Wasabi With You", Effect Duration: 50
+7681	lousy fancy unquiet spirits	4	decent	Effect: "Wasabi With You", Effect Duration: 50
 7682	avaricious banjo kazoo mount	0		Meat Drop: +30, Single Equip
 7683	dry grass	0		Effect: "Milk Studly", Effect Duration: 30
 7684	red perfumed Time Lord Participation Mug	0		Stench Resistance: +5
@@ -7585,7 +7585,7 @@
 7696	blurry ribald cassette player of the early riser	0		Sleaze Damage: +10, Adventures: +7, Single Equip, Last Available: "2014-08"
 7697	narrow chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	blurry rubber spider	0		Last Available: "2014-08"
-7699	huge red &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
+7699	red huge &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	nitrogenated polarized squat jittery confiscated comic book	0		Effect: "Can Has Cyborger", Effect Duration: 21, Last Available: "2014-08"
 7701	corrupted blinking confiscated cell phone	0		Effect: "Kissed By Fire", Effect Duration: 61, Last Available: "2014-08"
 7702	aerosolized pressed yellow confiscated love note	0		Effect: "Tingly Elbows", Effect Duration: 28, Last Available: "2014-08"
@@ -7643,9 +7643,9 @@
 7754	blue frightening dance instructor's Xiblaxian stealth trousers	0		Experience Percent (Moxie): +10, Spooky Damage: +5, Last Available: "2014-09"
 7755	blurry rosewater-soaked Annie Oakley's Xiblaxian stealth vest	0		Critical Hit Percent: +20, Stench Resistance: +3, Last Available: "2014-09"
 7756	stale Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
-7757	distilled delicious Xiblaxian space-whiskey	5	awesome	Last Available: "2014-09"
+7757	delicious distilled Xiblaxian space-whiskey	5	awesome	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
-7759	flattened upside-down narrow They liver	0		Effect: "Be a Mind Master", Effect Duration: 34, Last Available: "2014-09"
+7759	flattened narrow upside-down They liver	0		Effect: "Be a Mind Master", Effect Duration: 34, Last Available: "2014-09"
 7760	spoiled half-sized spinning They liver popsicle	2	crappy	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
@@ -7659,7 +7659,7 @@
 7770	miser's flame-retardant smooth Personal Ventilation Unit	0		Moxie: +15, Hot Resistance: +1, Meat Drop: +10, Single Equip, Last Available: "2014-10"
 7771	non-concentrated extra-polarized teal the most dangerous bait	0		Effect: "Thick-Skinned", Effect Duration: 61, Last Available: "2014-10"
 7772	low-calorie spoiled narrow &quot;meat&quot; stick	1	crappy	Last Available: "2014-10"
-7773	modified twirling twirling cyan transdermal smoke patch	1	crappy	Effect: "Knightlife", Effect Duration: 30, Last Available: "2014-10"
+7773	modified twirling cyan twirling transdermal smoke patch	1	crappy	Effect: "Knightlife", Effect Duration: 30, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	scorching boxer's pair of plants of the bloodbag	0		Muscle Percent: +10, Maximum HP: +100, Hot Damage: +25, Last Available: "2014-10"
 7776	double-paned scandalous boxer's Sasq&trade; watch	0		Muscle Percent: +10, Sleaze Damage: +5, Cold Resistance: +5, Single Equip, Last Available: "2014-10"
@@ -7671,7 +7671,7 @@
 7782	moldy limp broccoli	3	crappy	Last Available: "2014-10"
 7783	careful MacGyver's extremely unsafe hat	0		Weapon Damage Percent: +100, Maximum MP: +100, Monster Level: -10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	cold-filtered vacuum-sealed quantum monkey barf	0		Effect: "Eagle Eyes", Effect Duration: 66, Last Available: "2014-10"
-7785	energized upside-down blue candy	0		Effect: "Slimily Speedy", Effect Duration: 57, Last Available: "2014-10"
+7785	energized blue upside-down candy	0		Effect: "Slimily Speedy", Effect Duration: 57, Last Available: "2014-10"
 7786	sharpshooter's hardy hardened jangly bracelet	0		Damage Reduction: 3, Maximum HP: +50, Critical Hit Percent: +10, Last Available: "2014-10"
 7787	strapping cuddly teddy bear	0		Muscle: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	upside-down ice-cold Cloaca Zero	0		Last Available: "2014-10"
@@ -7683,10 +7683,10 @@
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	moldy initiative shawarma	4	crappy	Last Available: "2014-10"
 7796	adequate diet warm war shawarma	1	good	Last Available: "2014-10"
-7797	miniature decent karma shawarma	2	good	Last Available: "2014-10"
+7797	decent miniature karma shawarma	2	good	Last Available: "2014-10"
 7798	delicious Jungle Juice	4	awesome	Last Available: "2014-10"
 7799	bad Amnesiac Ale	3	decent	Last Available: "2014-10"
-7800	weak drinkable Highest Bitter	2	good	Last Available: "2014-10"
+7800	drinkable weak Highest Bitter	2	good	Last Available: "2014-10"
 7801	jittery lime green perfumed Jack Frost's mercenary pistol	0		Cold Spell Damage: +50, Stench Resistance: +5, Last Available: "2014-10"
 7802	spinning up-at-dawn lightning-fast mercenary rifle	0		Initiative: +40, Adventures: +5, Last Available: "2014-10"
 7803	squat Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7700,13 +7700,13 @@
 7811	viral DNA	0		
 7812	skewed tarnished bottlecap	0		
 7813	decent seared dino steak	3	good	
-7814	triple-distilled aged jittery bottle of drinkin' gas	6	awesome	
+7814	aged triple-distilled jittery bottle of drinkin' gas	6	awesome	
 7815	blue handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
 7818	99.44% pure math	0		
 7819	narrow simple AI	0		
-7820	blinking shaking corrupted bird DNA	0		
+7820	shaking blinking corrupted bird DNA	0		
 7821	huge sentient meat mass	0		
 7822	spinning zombie dinosaur egg	0		
 7823	french-fry grabber	0		Familiar Weight: +5
@@ -7714,7 +7714,7 @@
 7825	asbestos-lined vibrating supercool earbuds	0		Moxie Percent: +20, Maximum MP Percent: +10, Hot Resistance: +5, Single Equip
 7826	inspector's Samson's iFlail of Flo-Jo	0		Experience (Muscle): +5, Item Drop: +15, Initiative: +100
 7827	tasty unidentifiable dried fruit	4	awesome	
-7828	mediocre fortified lime green skewed flat cider	5	decent	
+7828	fortified mediocre lime green skewed flat cider	5	decent	
 7829	narrow experienced Rosewater's trench lighter of the scaredy-cat	0		Mysticality Percent: +30, Experience: +2, Monster Level: -15, Last Available: "2014-10"
 7830	energized diffused lime green experimental serum P-00	0		Effect: "From Nantucket", Effect Duration: 46, Last Available: "2014-10"
 7831	purple military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7736,7 +7736,7 @@
 7847	altered ruby on canes	0		Effect: "Melancholy Burden", Effect Duration: 40, Last Available: "2014-12"
 7848	spoiled tumbling petit fortran	3	crappy	Last Available: "2014-12"
 7849	moldy java cookie	3	crappy	Last Available: "2014-12"
-7850	bland jumbo cookie cookie	5	decent	Last Available: "2014-12"
+7850	jumbo bland cookie cookie	5	decent	Last Available: "2014-12"
 7851	plastic exo-suited miner of the sewer	0		Stench Damage: +25, Last Available: "2014-12"
 7852	occult plastic semi-autonomous drill unit	0		Spell Damage Percent: +25, Last Available: "2014-12"
 7853	plastic ambulatory robo-minecart of courage	0		Spooky Resistance: +3, Last Available: "2014-12"
@@ -7785,7 +7785,7 @@
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	spinning skewed Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
-7899	huge fuchsia Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
+7899	fuchsia huge Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	twirling Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	spinning Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
@@ -7808,7 +7808,7 @@
 7919	warmed magnetized shaking Big Punk	0		Effect: "Izchak's Blessing", Effect Duration: 60
 7920	red fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	tolerable enchanted Friendly Turkey	4	good	Effect: "Heart of Orange", Effect Duration: 45, Last Available: "2014-11"
+7922	enchanted tolerable Friendly Turkey	4	good	Effect: "Heart of Orange", Effect Duration: 45, Last Available: "2014-11"
 7923	acceptable blinking Agitated Turkey	4	good	Last Available: "2014-11"
 7924	weak perfectly mixed Ambitious Turkey	2	EPIC	Last Available: "2014-11"
 7925	adequate neutron lollipop	3	good	Last Available: "2014-12"
@@ -7826,8 +7826,8 @@
 7944	huge tooth	0		
 7945	lime green table	0		
 7946	perfumed sharpshooter's experienced outlaw bandana	0		Experience: +2, Critical Hit Percent: +10, Stench Resistance: +5
-7947	watered-down bad whiskey in a broken glass	2	decent	
-7948	drinkable weak shot of mescal	2	good	
+7947	bad watered-down whiskey in a broken glass	2	decent	
+7948	weak drinkable shot of mescal	2	good	
 7949	drinkable olive glass of herbal tequila	4	good	
 7950	minin' dynamite	0		
 7951	huge mansplainer's brainy plaid cowboy hat	0		Mysticality: +5, Monster Level: +15, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7881,7 +7881,7 @@
 7999	colloidal jittery choco-Crimbot	0		Effect: "Gummi Badass", Effect Duration: 12, Last Available: "2014-12"
 8000	aerosolized smart watch	0		Effect: "Standard Cheer", Effect Duration: 43, Last Available: "2014-12"
 8001	irradiated chilled maroon augmented-reality shades	0		Effect: "The Real Deal", Effect Duration: 26, Last Available: "2014-12"
-8002	flame-retardant toy Crimbot mega face	0		Hot Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12"
+8002	flame-retardant toy Crimbot mega face	0		Hot Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
 8003	toy Crimbot power glove of Leguizamo	0		Monster Level: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	experienced toy Crimbot super fist	0		Experience: +2, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	toy Crimbot rocket legs of Leguizamo	0		Monster Level: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
@@ -7900,8 +7900,8 @@
 8018	quadruple-altered triple-nitrogenated and rain stick	0		Effect: "Disdain of She-Who-Was", Effect Duration: 41
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	delicious miniature Choco-Mint patty	2	awesome	Last Available: "2015-01"
-8021	aged watered-down blurry ghostly hot mint schnocolate	2	awesome	Last Available: "2015-01"
-8022	powdered twirling upside-down homeopathic mint tea	1	decent	Effect: "Devil Inside", Effect Duration: 35, Last Available: "2015-01"
+8021	aged watered-down ghostly blurry hot mint schnocolate	2	awesome	Last Available: "2015-01"
+8022	powdered upside-down twirling homeopathic mint tea	1	decent	Effect: "Devil Inside", Effect Duration: 35, Last Available: "2015-01"
 8023	upside-down tumbling muscle stimulator	0		Last Available: "2015-01"
 8024	red blurry foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
@@ -7909,14 +7909,14 @@
 8027	yellow antler chandelier	0		Last Available: "2015-01"
 8028	upside-down squat artificial skylight	0		Last Available: "2015-01"
 8029	huge Swiss piggy bank	0		Last Available: "2015-01"
-8030	narrow fuchsia continental juice bar	0		Last Available: "2015-01"
+8030	fuchsia narrow continental juice bar	0		Last Available: "2015-01"
 8031	lime green stationery set	0		Last Available: "2015-01"
 8032	calligraphy pen	0		Free Pull, Last Available: "2015-01"
 8033	alpine watercolor set	0		Last Available: "2015-01"
 8034	auspicious baleful tope&eacute;	0		Spell Damage: +25, Item Drop: +10, Familiar Effect: "3xBarrr, cap 12"
 8035	censurious topiary tights of the detective	0		Sleaze Resistance: +3, Item Drop: +20
 8036	blue thinker's topiary necktie	0		Mysticality: +10
-8037	massive bland spinning upside-down bowl of topioca	8	decent	
+8037	bland massive upside-down spinning bowl of topioca	8	decent	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -7941,7 +7941,7 @@
 8060	toasty curative The Joke Book of the Dead	0		Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Luck: -6
 8061	The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	wobbly upside-down Tales of Spelunking	0		Last Available: "2015-12"
+8063	upside-down wobbly Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
 8066	twisted squat	1	decent	Last Available: "2015-12"
@@ -7970,7 +7970,7 @@
 8095	dog trainer's hale wicker ticker	0		Maximum HP: +20, Experience (familiar): +1, Single Equip, Last Available: "2016-12"
 8096	upside-down foul-smelling hardy wicker sticker	0		Maximum HP: +50, Stench Damage: +10, Last Available: "2016-12"
 8097	gravedigger's wicker clicker of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Last Available: "2016-12"
-8098	dried upside-down shaking wickerbits	1		Last Available: "2016-12"
+8098	dried shaking upside-down wickerbits	1		Last Available: "2016-12"
 8099	fuchsia double-paned dog trainer's belt	0		Experience (familiar): +1, Cold Resistance: +5, Single Equip, Last Available: "2016-12"
 8100	badge of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, Single Equip, Last Available: "2016-12"
 8101	arcane researcher's bowl of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15, Last Available: "2016-12"
@@ -7991,7 +7991,7 @@
 8116	Lo Pan's whisk of the cheetah	0		Spell Critical Percent: +30, Initiative: +60, Last Available: "2017-12"
 8117	huge Lo Pan's Rosewater's walker	0		Mysticality Percent: +30, Spell Critical Percent: +30, Single Equip, Last Available: "2017-12"
 8118	jittery scandalous slick waders	0		Moxie: +10, Sleaze Damage: +5, Last Available: "2017-12"
-8119	pickled twirling red flakes	1		Last Available: "2017-12"
+8119	pickled red twirling flakes	1		Last Available: "2017-12"
 8120	miser's nippy gaiters	0		Cold Damage: +10, Meat Drop: +10, Last Available: "2018-12"
 8121	shaking mirror censurious lard-coated garland	0		Sleaze Spell Damage: +25, Sleaze Resistance: +3, Single Equip, Last Available: "2018-12"
 8122	gunnysack of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Initiative: +60, Last Available: "2018-12"
@@ -8031,7 +8031,7 @@
 8157	Skeleton Store office key	0		
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
-8160	non-frozen magnetized mirror narrow mouse skull	0		Effect: "Extra-Thick Blood", Effect Duration: 34
+8160	non-frozen magnetized narrow mirror mouse skull	0		Effect: "Extra-Thick Blood", Effect Duration: 34
 8161	dry galvanized really thick spine	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 43
 8162	hardy skullcap of the empath	0		Maximum HP: +50, Familiar Weight: +5, Familiar Effect: "1xVolley,cap 5"
 8163	Rosewater's three-legged pants of courage	0		Mysticality Percent: +30, Spooky Resistance: +3, Familiar Effect: "hot atk, cap 25"
@@ -8047,7 +8047,7 @@
 8173	educational sewer snake	0		Experience: +1
 8174	small flavorless pigeon egg	2	decent	
 8175	double-paned jaunty feather of doom	0		Spooky Spell Damage: +50, Cold Resistance: +5
-8176	irresponsibly strong hand-crafted upside-down premium malt liquor	7	EPIC	
+8176	hand-crafted irresponsibly strong upside-down premium malt liquor	7	EPIC	
 8177	sage brown paper pants of the cougar	0		Moxie: +20, Mysticality Percent: +10
 8178	squat double-paned educational brown paper bag mask	0		Experience: +1, Cold Resistance: +5
 8179	blue aromatic ring of telling skeletons what to do	0		Stench Resistance: +1, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8062,18 +8062,18 @@
 8188	tolerable Cherrytastrophe wine cooler	4	good	
 8189	tolerable Radberry Rip wine cooler	4	good	
 8190	weak perfectly mixed gray Orangemageddon wine cooler	2	EPIC	
-8191	weak acceptable Breakfast Blast wine cooler	2	good	
-8192	artisanal fancy practically non-alcoholic Citrus Crush wine cooler	1	EPIC	Effect: "Slimy Hands", Effect Duration: 10
-8193	special moldy plain bagel	3	crappy	Effect: "Bolts about Candy", Effect Duration: 45
+8191	acceptable weak Breakfast Blast wine cooler	2	good	
+8192	fancy artisanal practically non-alcoholic Citrus Crush wine cooler	1	EPIC	Effect: "Slimy Hands", Effect Duration: 10
+8193	moldy special plain bagel	3	crappy	Effect: "Bolts about Candy", Effect Duration: 45
 8194	toothsome glob of cream cheese	4	awesome	
 8195	moldy loaf of soda bread	3	crappy	
-8196	adequate low-calorie acceptable bagel	1	good	
+8196	low-calorie adequate acceptable bagel	1	good	
 8197	moldy standard-issue cupcake	4	crappy	
 8198	flavorless ultra-deluxe cupcake	4	decent	
 8199	narrow hypnotic breadcrumbs	0		
 8200	toothsome popular tart	4	awesome	
 8201	wobbly no-handed pie	0		
-8202	oxidized liquefied yellow blurry Doc Galaktik's Vitality Serum	0		Effect: "Blood-Rich", Effect Duration: 35
+8202	oxidized liquefied blurry yellow Doc Galaktik's Vitality Serum	0		Effect: "Blood-Rich", Effect Duration: 35
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
 8204	shaking one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	pulsating twirling FunFunds&trade;	0		Last Available: "2015-04"
@@ -8085,12 +8085,12 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	pulsating grogpagne	0		Last Available: "2021-07"
 8213	Van der Graaf cool rigging rope	0		Moxie: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-04"
-8214	twisted bouncing squat jittery nasty snuff	1	good	Last Available: "2015-04"
+8214	twisted squat jittery bouncing nasty snuff	1	good	Last Available: "2015-04"
 8215	stanky veiny sewage-clogged pistol	0		Maximum HP: +10, Stench Spell Damage: +25, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	frozen tarnished beard incense	0		Effect: "Glo-Face", Effect Duration: 42, Last Available: "2015-04"
 8217	supercharged perfume-soaked bandana of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	flavorless immense olive squat twirling toxo	7	decent	Last Available: "2015-04"
+8219	immense flavorless squat olive twirling toxo	7	decent	Last Available: "2015-04"
 8220	artisanal red Lemonade-235	4	EPIC	Last Available: "2015-04"
 8221	electrified hale isotophat	0		Maximum HP: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	occult Three Mile Island shorts of the pedagogue	0		Experience: +3, Spell Damage Percent: +25, Last Available: "2015-04"
@@ -8141,13 +8141,13 @@
 8267	brawny sphygmayomanometer	0		Muscle Percent: +20, Lasts Until Rollover, Last Available: "2015-05"
 8268	green tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	jumbo flavorless bouncing unappetizing mayolus	5	decent	Last Available: "2015-05"
-8271	rotten snack-sized uninteresting mayolus	2	crappy	Last Available: "2015-05"
+8270	flavorless jumbo bouncing unappetizing mayolus	5	decent	Last Available: "2015-05"
+8271	snack-sized rotten uninteresting mayolus	2	crappy	Last Available: "2015-05"
 8272	decent ghostly acceptable mayolus	3	good	Last Available: "2015-05"
 8273	stale blurry enticing mayolus	3	decent	Last Available: "2015-05"
 8274	delicious mouth-watering mayolus	3	awesome	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
-8276	mirror blurry mayo pump	0		Familiar Weight: +5
+8276	blurry mirror mayo pump	0		Familiar Weight: +5
 8277	fuchsia Essence of Bear	0		Skill: "Bear Essence"
 8278	mediocre Afternoon Delight	4	decent	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
@@ -8158,7 +8158,7 @@
 8284	dry ionized Kokomo Resort Pass	0		Effect: "Industrial Strength Starch", Effect Duration: 63, Last Available: "2023-08"
 8285	upside-down Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	deionized corrupted Mayo de Mayo&trade; mayo	0		Effect: "Big", Effect Duration: 53
-8287	cyan spinning ghostly puck	0		Free Pull, Last Available: "2015-06"
+8287	ghostly spinning cyan puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	narrow executive dice ring	0		Meat Drop: +40, Single Equip
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	super-liquefied concentrated vacuum-sealed power pill	0		Effect: "Ooh, Salty!", Effect Duration: 23, Last Available: "2015-06"
 8301	ionized irradiated narrow pixel star	0		Effect: "Ooh, Sweet!", Effect Duration: 46, Last Available: "2015-06"
-8302	toothsome miniature pixel banana	2	awesome	Last Available: "2015-06"
+8302	miniature toothsome pixel banana	2	awesome	Last Available: "2015-06"
 8303	perfectly mixed pixel beer	3	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8192,10 +8192,10 @@
 8318	colloidal ghostly sinister-looking cat	0		Effect: "Balls of Ectoplasm", Effect Duration: 30
 8319	boiled jazzy cigarette holder	0		Effect: "20/20 Vision", Effect Duration: 21
 8320	pickled frozen extra-pickled blurry one glove	0		Effect: "Egged On", Effect Duration: 17
-8321	Vulcanized extra-dry twirling gray glove	0		Effect: "Sludgesick", Effect Duration: 41
+8321	Vulcanized extra-dry gray twirling glove	0		Effect: "Sludgesick", Effect Duration: 41
 8322	colloidal upside-down handful of fire	0		Effect: "Boo Tea", Effect Duration: 50
 8323	concentrated quantum ghostly Cracklin' Oat Bran	0		Effect: "Spooky Jellied", Effect Duration: 65
-8324	double-polymerized alkaline jittery yellow disposable lighter	0		Effect: "Big", Effect Duration: 63
+8324	double-polymerized alkaline yellow jittery disposable lighter	0		Effect: "Big", Effect Duration: 63
 8325	pickled coal contact lenses	0		Effect: "Hood Ridin'", Effect Duration: 55
 8326	vacuum-sealed magnetized conjured ice cream	0		Effect: "Crimbo Epiphany", Effect Duration: 62
 8327	irradiated magnetized Iceberglar scarf	0		Effect: "Flambé-a-thon", Effect Duration: 21
@@ -8209,7 +8209,7 @@
 8335	anodized grease trap	0		Effect: "Wet Willied", Effect Duration: 45
 8336	adjusted upside-down shamanic ham	0		Effect: "Ghost Finger", Effect Duration: 25
 8337	triple-oxidized porkpocket	0		Effect: "Chalky White Pallor", Effect Duration: 40
-8338	tarnished blurry huge Leonard's glasses	0		Effect: "Stuck-Up Hair", Effect Duration: 62
+8338	tarnished huge blurry Leonard's glasses	0		Effect: "Stuck-Up Hair", Effect Duration: 62
 8339	triple-aerosolized flattened warehouse walkie-talkie	0		Effect: "Thunderheart", Effect Duration: 38
 8340	improved janitor's mop	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 13
 8341	oxidized warehouse clerk's glasses	0		Effect: "Wise Spirit", Effect Duration: 42
@@ -8224,7 +8224,7 @@
 8350	ionized twirling damp bar rag	0		Effect: "Mental A-cue-ity", Effect Duration: 49
 8351	energized lump of goofball ore	0		Effect: "Burning Hands", Effect Duration: 19
 8352	irradiated aerosolized upside-down skeleton beans	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 30
-8353	cold-filtered huge blinking grimy lab coat	0		Effect: "Unusual Perspective", Effect Duration: 45
+8353	cold-filtered blinking huge grimy lab coat	0		Effect: "Unusual Perspective", Effect Duration: 45
 8354	denatured upside-down nursery rhyme	0		Effect: "Beta Carotene Overdose", Effect Duration: 55
 8355	irradiated wet iron torso box	0		Effect: "Neuroplastici Tea", Effect Duration: 42
 8356	cold-filtered colloidal shaking mercenary headband	0		Effect: "Mushroom Moxiousness", Effect Duration: 51
@@ -8257,8 +8257,8 @@
 8383	popular part	0		
 8384	tumbling bubblegum heart	0		Last Available: "2015-07"
 8385	cubic zirconia	0		Last Available: "2015-07"
-8386	olive mirror valuable coin	0		Last Available: "2015-07"
-8387	pulsating jittery tumbling mana	0		Last Available: "2015-07"
+8386	mirror olive valuable coin	0		Last Available: "2015-07"
+8387	jittery pulsating tumbling mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
 8389	mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
@@ -8282,11 +8282,11 @@
 8408	super-alkaline skewed ectoplasmic orbs	0		Effect: "Super Vision", Effect Duration: 39
 8409	decent shaking crudles	4	good	
 8410	low-calorie tasty agnolotti arboli	1	awesome	
-8411	gigantic adequate spaghetti with ghost balls	8	good	
+8411	adequate gigantic spaghetti with ghost balls	8	good	
 8412	super-sized moldy succulent marrow	5	crappy	
 8413	flavorless salacious crumbs	3	decent	
-8414	bland half-sized enchanted ghostly fusilli marrownarrow	2	decent	Effect: "Deadly Lampblade", Effect Duration: 25
-8415	diet flavorless suggestive strozzapreti	1	decent	
+8414	bland enchanted half-sized ghostly fusilli marrownarrow	2	decent	Effect: "Deadly Lampblade", Effect Duration: 25
+8415	flavorless diet suggestive strozzapreti	1	decent	
 8416	Mountain Stream gastrique	0		
 8417	decent Mt. McLargeHuge oyster	3	good	
 8418	oyster sauce	0		
@@ -8313,7 +8313,7 @@
 8439	jittery insulated wire	0		Last Available: "2015-08"
 8440	yellow empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
-8442	blinking blurry viscous lava globs	0		Last Available: "2015-08"
+8442	blurry blinking viscous lava globs	0		Last Available: "2015-08"
 8443	ghostly lava globs	0		Last Available: "2015-08"
 8444	squat mirror lava globs	0		Last Available: "2015-08"
 8445	lava globs	0		Last Available: "2015-08"
@@ -8331,12 +8331,12 @@
 8457	gray broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	Newton's high-temperature mining mask of the early riser	0		Experience (Mysticality): +3, Adventures: +7, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	mirror hale weightlifter's fireproof megaphone	0		Muscle: +15, Maximum HP: +20, Last Available: "2015-08"
-8460	decent small pulsating mineapple	2	good	Last Available: "2015-08"
+8460	small decent pulsating mineapple	2	good	Last Available: "2015-08"
 8461	weak hand-crafted pulsating Gold Velvet&trade; whiskey	2	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	awesome	Last Available: "2015-08"
-8463	adequate thick smelted roe	5	good	Last Available: "2015-08"
-8464	special drinkable high-proof pulsating lavawater	9	good	Effect: "Polka Face", Effect Duration: 30, Last Available: "2015-08"
-8465	magnetized shaking blurry basaltamander tongue	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 20, Last Available: "2015-08"
+8463	thick adequate smelted roe	5	good	Last Available: "2015-08"
+8464	drinkable special high-proof pulsating lavawater	9	good	Effect: "Polka Face", Effect Duration: 30, Last Available: "2015-08"
+8465	magnetized blurry shaking basaltamander tongue	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 20, Last Available: "2015-08"
 8466	Usain Bolt's manspreader's lavalarva of terror	0		Monster Level: +10, Spooky Spell Damage: +10, Initiative: +80, Last Available: "2015-08"
 8467	savvy lava balaclava of extreme caution of incineration	0		Mysticality Percent: +20, Monster Level: -25, Hot Spell Damage: +50, Last Available: "2015-08"
 8468	frightening lion tamer's beefy basaltamander buckler	0		Muscle: +10, Experience (familiar): +2, Spooky Damage: +5, Damage Reduction: 15, Last Available: "2015-08"
@@ -8346,9 +8346,9 @@
 8472	heat-resistant necktie of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100, Single Equip, Last Available: "2015-08"
 8473	skewed reassuring dog trainer's heat-resistant gloves of dire peril	0		Weapon Damage: +20, Experience (familiar): +1, Spooky Resistance: +1, Single Equip, Last Available: "2015-08"
 8474	rotten fuchsia very hot lunch	3	crappy	Last Available: "2015-08"
-8475	weak artisanal asbestos thermos	2	super EPIC	Last Available: "2015-08"
+8475	artisanal weak asbestos thermos	2	super EPIC	Last Available: "2015-08"
 8476	electrified denatured shaking liquid rhinestones	0		Effect: "Cold Blooded", Effect Duration: 53, Last Available: "2015-08"
-8477	decent miniature disco biscuit	2	good	Last Available: "2015-08"
+8477	miniature decent disco biscuit	2	good	Last Available: "2015-08"
 8478	triple-distilled drinkable Quaatorade&trade;	7	good	Last Available: "2015-08"
 8479	bouncing miser's smelly biker's hat of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10, Meat Drop: +10, Last Available: "2015-08", Familiar Effect: "atk"
 8480	jittery wool thinker's feathered headdress of vim and vigor	0		Mysticality: +10, Maximum HP Percent: +50, Cold Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
@@ -8373,7 +8373,7 @@
 8499	blurry Saturday Night thermometer	0		Last Available: "2015-08"
 8500	blinking the tongue of Smimmons	0		Last Available: "2015-08"
 8501	tumbling Raul's guitar pick	0		Last Available: "2015-08"
-8502	purple blurry Pener's crisps	0		Last Available: "2015-08"
+8502	blurry purple Pener's crisps	0		Last Available: "2015-08"
 8503	huge signed deuce	0		Last Available: "2015-08"
 8504	pulsating Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
@@ -8406,7 +8406,7 @@
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	rotten libertagliatelle	3	crappy	
-8535	adequate lime green bouncing turkish mostaccioli	3	good	
+8535	adequate bouncing lime green turkish mostaccioli	3	good	
 8536	normal snack-sized ghostly linguini of the sea	2	good	
 8537	activated ionized pulsating Hersey&trade; SMOOCH	0		Effect: "Certainty", Effect Duration: 11
 8539	ghostly Alexy sauce	0		
@@ -8424,7 +8424,7 @@
 8551	bland yellow sausage without a cause	3	decent	
 8552	ionized colloidal nitrogenated shaking face paint	0		Effect: "Permanent Halloween", Effect Duration: 21
 8553	aged emergency margarita	4	awesome	
-8554	high-proof smooth vintage smart drink	9	awesome	
+8554	smooth high-proof vintage smart drink	9	awesome	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8432,7 +8432,7 @@
 8559	aerosolized bakelite-covered bacon	0		Effect: "Strong Grip", Effect Duration: 12
 8560	polarized activated oxidized twirling Aerheads	0		Effect: "Slimily Speedy", Effect Duration: 50
 8561	magnetized colloidal Wrotz	0		Effect: "Stinking Cloud", Effect Duration: 54
-8562	moist altered narrow bouncing Gabarbar	0		Effect: "The Power of LOV", Effect Duration: 23
+8562	moist altered bouncing narrow Gabarbar	0		Effect: "The Power of LOV", Effect Duration: 23
 8563	denatured fiberglass insulation	0		Effect: "The Style... of the Future", Effect Duration: 57
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	miser's barrel lid of the empath of the businessman	0		Familiar Weight: +5, Meat Drop: 60, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
@@ -8449,11 +8449,11 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	squat barnacled barrel	0		Last Available: "2015-09"
 8578	bad shaking bottle of Amontillado	3	decent	Last Available: "2015-09"
-8579	perfectly mixed high-proof upside-down barrel-aged martini	9	EPIC	Last Available: "2015-09"
+8579	high-proof perfectly mixed upside-down barrel-aged martini	9	EPIC	Last Available: "2015-09"
 8580	normal barrel pickle	4	good	Last Available: "2015-09"
-8581	diet normal barrel cracker	1	good	Last Available: "2015-09"
-8582	vaporized spinning jittery vibrating mushroom	1	awesome	Effect: "In Tuna", Effect Duration: 40, Last Available: "2015-09"
-8583	compressed blinking upside-down pulsating mushroom	1	crappy	Last Available: "2015-09"
+8581	normal diet barrel cracker	1	good	Last Available: "2015-09"
+8582	vaporized jittery spinning vibrating mushroom	1	awesome	Effect: "In Tuna", Effect Duration: 40, Last Available: "2015-09"
+8583	compressed upside-down blinking pulsating mushroom	1	crappy	Last Available: "2015-09"
 8584	olive double-paned KoL Con 12-gauge	0		Cold Resistance: +5, Last Available: "2015-09"
 8585	foul-smelling Golden Mr. Eh?	0		Stench Damage: +10, Last Available: "2015-09"
 8586	therapeutic barrel gun	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-09"
@@ -8477,8 +8477,8 @@
 8604	modified deionized cuppa Nas tea	0		Effect: "Armored Innards", Effect Duration: 31, Last Available: "2015-09"
 8605	altered aerosolized adjusted cuppa Improprie tea	0		Effect: "Your Eyes are Peeled!", Effect Duration: 62, Last Available: "2015-09"
 8606	enhanced spinning blurry cuppa Frost tea	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40, Last Available: "2015-09"
-8607	concentrated moist moist mirror gray cuppa Toast tea	0		Effect: "Creepin' Up on You", Effect Duration: 13, Last Available: "2015-09"
-8608	extra-alkaline blinking wobbly cyan cuppa Net tea	0		Effect: "Pyramid Power", Effect Duration: 36, Last Available: "2015-09"
+8607	concentrated moist moist gray mirror cuppa Toast tea	0		Effect: "Creepin' Up on You", Effect Duration: 13, Last Available: "2015-09"
+8608	extra-alkaline wobbly blinking cyan cuppa Net tea	0		Effect: "Pyramid Power", Effect Duration: 36, Last Available: "2015-09"
 8609	galvanized activated flattened squat cuppa Proprie tea	0		Effect: "Spiky Hair", Effect Duration: 59, Last Available: "2015-09"
 8610	dry ionized cuppa Morbidi tea	0		Effect: "Smoky Third Eye", Effect Duration: 33, Last Available: "2015-09"
 8611	enhanced teal cuppa Chari tea	0		Effect: "Squid Squint", Effect Duration: 30, Last Available: "2015-09"
@@ -8490,7 +8490,7 @@
 8617	dry activated cuppa Dexteri tea	0		Effect: "Some Cheese with Your Wine", Effect Duration: 64, Last Available: "2015-09"
 8618	double-tarnished cuppa Flexibili tea	0		Effect: "Creepypasted", Effect Duration: 37, Last Available: "2015-09"
 8619	vacuum-sealed chilled cuppa Impregnabili tea	0		Effect: "Items Are Forever", Effect Duration: 59, Last Available: "2015-09"
-8620	extra-moist twirling lime green cuppa Obscuri tea	0		Effect: "Super Speed", Effect Duration: 63, Last Available: "2015-09"
+8620	extra-moist lime green twirling cuppa Obscuri tea	0		Effect: "Super Speed", Effect Duration: 63, Last Available: "2015-09"
 8621	diffused ionized blinking cuppa Irritabili tea	0		Effect: "Mushroom Magicalness", Effect Duration: 54, Last Available: "2015-09"
 8622	super-energized adjusted pulsating cuppa Mediocri tea	0		Effect: "Salsa Satanica", Effect Duration: 60, Last Available: "2015-09"
 8623	activated pressed wobbly cuppa Loyal tea	0		Effect: "Educated (Kinda)", Effect Duration: 50, Last Available: "2015-09"
@@ -8509,13 +8509,13 @@
 8636	quadruple-polarized pickled olive twirling cuppa Craft tea	0		Effect: "Swordholder", Effect Duration: 49, Last Available: "2015-09"
 8637	flattened cuppa Insani tea	0		Effect: "Bandersnatched", Effect Duration: 40, Last Available: "2015-09"
 8638	Tesla hardened wicked Royal scepter	0		Spell Damage: +5, Damage Reduction: 3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-09"
-8639	jittery ghostly doghouse	0		Free Pull, Last Available: "2015-10"
+8639	ghostly jittery doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	spoiled bowl of eyeballs	3	crappy	Last Available: "2015-10"
-8642	flavorless half-sized bowl of mummy guts	2	decent	Last Available: "2015-10"
-8643	flavorless fancy ghostly shaking bowl of maggots	3	decent	Effect: "Thanksgot", Effect Duration: 45, Last Available: "2015-10"
+8642	half-sized flavorless bowl of mummy guts	2	decent	Last Available: "2015-10"
+8643	flavorless fancy shaking ghostly bowl of maggots	3	decent	Effect: "Thanksgot", Effect Duration: 45, Last Available: "2015-10"
 8644	bad blood and blood	4	decent	Last Available: "2015-10"
-8645	enchanted weak aged Jack-O-Lantern beer	2	awesome	Effect: "You Read The Manual", Effect Duration: 25, Last Available: "2015-10"
+8645	weak enchanted aged Jack-O-Lantern beer	2	awesome	Effect: "You Read The Manual", Effect Duration: 25, Last Available: "2015-10"
 8646	bad zombie	3	decent	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8538,9 +8538,9 @@
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
 8667	pulsating chilly rosy-cheeked Yorick of the scaredy-cat	0		Maximum HP Percent: +30, Monster Level: -15, Cold Damage: +5
-8668	yellow tumbling rose	0		
+8668	tumbling yellow rose	0		
 8669	tulip	0		
-8670	wobbly olive blinking tulip	0		
+8670	olive blinking wobbly tulip	0		
 8671	tulip	0		
 8672	Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
@@ -8548,7 +8548,7 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	moist improved diffused shoulder-warming lotion	0		Effect: "Stickler for Promptness", Effect Duration: 40, Last Available: "2015-11"
 8677	moldy bouncing iceberg lettuce	3	crappy	Last Available: "2015-11"
-8678	lousy watered-down blinking ice wine	2	decent	Last Available: "2015-11"
+8678	watered-down lousy blinking ice wine	2	decent	Last Available: "2015-11"
 8679	tumbling lightning-fast asbestos-lined baleful Wal-Mart snowglobe	0		Spell Damage: +25, Hot Resistance: +5, Initiative: +40, Last Available: "2015-11"
 8680	twirling cyan lard-coated sizzling careful Wal-Mart nametag	0		Monster Level: -10, Hot Damage: +10, Sleaze Spell Damage: +25, Last Available: "2015-11"
 8681	spinning yellow smooth Wal-Mart overalls of Leguizamo of courage	0		Moxie: +15, Monster Level: +20, Spooky Resistance: +3, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	pulsating perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	tumbling brawny bellhop's hat	0		Muscle Percent: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	lousy watered-down upside-down ice porter	2	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	watered-down lousy upside-down ice porter	2	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	oxidized wobbly exotic travel brochure	0		Effect: "Dreadful Fear", Effect Duration: 21, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	pickled polymerized fuchsia shampoo-conditioner	0		Effect: "Stimulated Body", Effect Duration: 22, Last Available: "2015-11"
@@ -8596,7 +8596,7 @@
 8723	VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
-8726	huge fuchsia VYKEA rail	0		Last Available: "2015-11"
+8726	fuchsia huge VYKEA rail	0		Last Available: "2015-11"
 8727	spinning VYKEA bracket	0		Last Available: "2015-11"
 8728	blue VYKEA dowel	0		Last Available: "2015-11"
 8729	executive asbestos-lined VYKEA hex key of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +5, Meat Drop: +40, Last Available: "2015-11"
@@ -8608,11 +8608,11 @@
 8735	wholesome Rosewater's norwhal helmet of extreme caution	0		Mysticality Percent: +30, Maximum HP Percent: +10, Monster Level: -25, Last Available: "2015-11", Familiar Effect: "atk"
 8736	greedy nasty electrified octolus-skin cloak	0		Stench Damage: +5, Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8737	bad distilled perfect cosmopolitan	5	decent	Last Available: "2015-11"
-8738	irresponsibly strong aged enchanted fuchsia wobbly perfect negroni	7	awesome	Effect: "Familial Ties", Effect Duration: 45, Last Available: "2015-11"
+8738	aged enchanted irresponsibly strong fuchsia wobbly perfect negroni	7	awesome	Effect: "Familial Ties", Effect Duration: 45, Last Available: "2015-11"
 8739	mediocre weak perfect dark and stormy	2	decent	Last Available: "2015-11"
-8740	strong delicious perfect mimosa	5	awesome	Last Available: "2015-11"
+8740	delicious strong perfect mimosa	5	awesome	Last Available: "2015-11"
 8741	lousy perfect old-fashioned	3	decent	Last Available: "2015-11"
-8742	enchanted artisanal blurry perfect paloma	3	EPIC	Effect: "Sugar Smacks", Effect Duration: 20, Last Available: "2015-11"
+8742	artisanal enchanted blurry perfect paloma	3	EPIC	Effect: "Sugar Smacks", Effect Duration: 20, Last Available: "2015-11"
 8743	electrified diffused That 70s Cologne	0		Effect: "Feroci Tea", Effect Duration: 55, Last Available: "2015-11"
 8744	altered electrified oxidized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Egg Burps", Effect Duration: 58, Last Available: "2015-11"
 8745	extra-chilled jittery twirling Puffstone cigar	0		Effect: "Brain Freeze", Effect Duration: 39, Last Available: "2015-11"
@@ -8641,7 +8641,7 @@
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	tumbling chocolate bowtie	0		Familiar Weight: +5
 8770	moist super-anodized mirror pitted sheet	0		Effect: "Trufflin'", Effect Duration: 16, Last Available: "2015-12"
-8771	wobbly upside-down sparking robo-battery	0		Last Available: "2015-12"
+8771	upside-down wobbly sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	olive Oprah's energetic reusable shopping bag of chilblains	0		Maximum MP Percent: 70, Cold Damage: +25, Last Available: "2015-12"
 8775	maroon executive coarse hemp socks	0		Meat Drop: +40, Single Equip, Last Available: "2015-12"
@@ -8653,7 +8653,7 @@
 8781	chilly pine cone necklace	0		Cold Damage: +5, Last Available: "2015-12"
 8782	gray Annie Oakley's reindeer hammer	0		Critical Hit Percent: +20, Last Available: "2015-12"
 8783	therapeutic elf ploughshare	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-12"
-8784	teal upside-down circle drum	0		Last Available: "2015-12"
+8784	upside-down teal circle drum	0		Last Available: "2015-12"
 8785	twirling The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
@@ -8675,11 +8675,11 @@
 8803	kidnapped orphan	0		Last Available: "2017-01"
 8804	blinking high-grade	0		Last Available: "2017-01"
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
-8806	yellow huge high-grade explosives	0		Last Available: "2017-01"
+8806	huge yellow high-grade explosives	0		Last Available: "2017-01"
 8807	lime green experimental gene therapy	0		Last Available: "2017-01"
 8808	ultracoagulator	0		Last Available: "2017-01"
 8809	blurry self-defense training	0		Last Available: "2017-01"
-8810	cyan huge fingerprint dusting kit	0		Last Available: "2017-01"
+8810	huge cyan fingerprint dusting kit	0		Last Available: "2017-01"
 8811	upside-down confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
 8813	tumbling glob of Bat-Glue	0		Last Available: "2017-01"
@@ -8688,14 +8688,14 @@
 8816	spoiled upside-down Kudzu salad	3	crappy	Last Available: "2016-12"
 8817	twisted huge Mansquito Serum	1		Last Available: "2016-12"
 8818	lousy Miss Graves' vermouth	4	decent	Last Available: "2016-12"
-8819	special super-sized stale The Plumber's mushroom stew	5	decent	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2016-12"
+8819	super-sized stale special The Plumber's mushroom stew	5	decent	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2016-12"
 8820	powdered tumbling The Author's ink	1		Last Available: "2016-02"
 8821	bad The Mad Liquor	3	decent	Last Available: "2016-12"
 8822	tolerable Doc Clock's thyme cocktail	4	good	Last Available: "2016-12"
 8823	decent jittery Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	denatured upside-down The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	occult wizardly The Jokester's gun of Gandalf	0		Mysticality: +25, Spell Damage Percent: +25, Spell Critical Percent: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	narrow quilted The Jokester's wig of doom of courage	0		Damage Absorption: +40, Spooky Spell Damage: +50, Spooky Resistance: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol"
+8826	narrow quilted The Jokester's wig of doom of courage	0		Damage Absorption: +40, Spooky Spell Damage: +50, Spooky Resistance: +3, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	avaricious miser's Oprah's The Jokester's pants	0		Maximum MP Percent: +50, Meat Drop: 40, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	altered tarnished Jokester makeup	0		Effect: "Ichorous Eyesight", Effect Duration: 52, Last Available: "2016-12"
 8829	squat replica bat-oomerang	0		Last Available: "2016-12"
@@ -8746,8 +8746,8 @@
 8874	shaking mirror Sherlock's lion tamer's Temple Grandin's healthy smartaleck's Val-U Brand Every Bean Salad	0		Moxie Percent: +30, Maximum HP Percent: +20, Familiar Weight: +7, Experience (familiar): +2, Item Drop: +25, Last Available: "2016-02"
 8875	Jack Frost's hardy Sinatra's Shrub's Premium Baked Beans	0		Experience (Moxie): +5, Maximum HP: +50, Cold Spell Damage: +50, Last Available: "2016-02"
 8876	stale twirling plate of Heimz Fortified Kidney Beans	4	decent	Last Available: "2016-02"
-8877	miniature normal plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
-8878	half-sized decent plate of Mixed Garbanzos and Chickpeas	2	good	Last Available: "2016-02"
+8877	normal miniature plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
+8878	decent half-sized plate of Mixed Garbanzos and Chickpeas	2	good	Last Available: "2016-02"
 8879	flavorless narrow olive plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	flavorless bouncing plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
 8881	normal small mirror plate of World's Blackest-Eyed Peas	2	good	Last Available: "2016-02"
@@ -8759,27 +8759,27 @@
 8887	lightning-fast wool Lo Pan's Daisy's unclean bloomers	0		Spell Critical Percent: +30, Cold Resistance: +1, Initiative: +40, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
 8889	bouncing sharpshooter's hardy groovy Amoon-Ra Cowtep's nemes	0		Moxie Percent: +10, Maximum HP: +50, Critical Hit Percent: +10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
-8890	blinking bouncing green Glenn's dice	0		Last Available: "2016-02"
+8890	blinking green bouncing Glenn's dice	0		Last Available: "2016-02"
 8891	pulsating rosewater-soaked double-paned Herculean stylish Former Sheriff Dan's tin star of the sewer	0		Moxie: +25, Experience (Muscle): +1, Stench Damage: +25, Cold Resistance: +5, Stench Resistance: +3, Last Available: "2016-02"
 8892	twirling mirror El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	banded beefy Granny Hackleton's Gatling gun of Flo-Jo	0		Muscle: +10, Damage Absorption: +100, Initiative: +100, Last Available: "2016-02"
-8895	bouncing red buffalo dime	0		Last Available: "2016-02"
+8895	red bouncing buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
 8897	non-warmed poker face paint	0		Effect: "Crocodile Tear", Effect Duration: 67, Last Available: "2016-02"
 8898	squat realistic cap gun	0		Last Available: "2016-02"
-8899	huge spinning tainted milk	1	good	Last Available: "2016-02"
+8899	spinning huge tainted milk	1	good	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
 8901	enhanced shaking triggerfingerbone	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 39, Last Available: "2016-02"
 8902	warmed quantum non-polymerized ghost bit	0		Effect: "Mucilaginous Mentalism", Effect Duration: 54, Last Available: "2016-02"
-8903	tarnished lime green shaking buzzard feather	0		Effect: "Egged On", Effect Duration: 56, Last Available: "2016-02"
+8903	tarnished shaking lime green buzzard feather	0		Effect: "Egged On", Effect Duration: 56, Last Available: "2016-02"
 8904	improved lion musk	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 59, Last Available: "2016-02"
 8905	tasty purple bear claw	4	awesome	Last Available: "2016-02"
 8906	magnetized rattler gland	0		Effect: "Bone Homie", Effect Duration: 62, Last Available: "2016-02"
 8907	pickled altered tumbling half-digested coal	0		Effect: "Cookie Backup", Effect Duration: 52, Last Available: "2016-02"
 8908	denatured quadruple-vacuum-sealed tightly-wound spine	0		Effect: "Patience of the Tortoise", Effect Duration: 37, Last Available: "2016-02"
 8909	adequate rotting beefsteak	3	good	Last Available: "2016-02"
-8910	weak bad bouncing upside-down firemilk	2	decent	Last Available: "2016-02"
+8910	weak bad upside-down bouncing firemilk	2	decent	Last Available: "2016-02"
 8911	polymerized red spidercow eye-cluster	0		Effect: "Izchak's Blessing", Effect Duration: 62, Last Available: "2016-02"
 8912	modified blue moomy dust	1		Effect: "Kernel Panic!", Effect Duration: 20, Last Available: "2016-02"
 8913	Usain Bolt's zippy western-style skinning knife	0		Initiative: 100, Last Available: "2016-02"
@@ -8803,7 +8803,7 @@
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
 8932	wobbly makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
-8934	ghostly pulsating baconstone-handled sixgun	0		Last Available: "2016-02"
+8934	pulsating ghostly baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
@@ -8813,7 +8813,7 @@
 8941	jittery frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	blurry rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
-8944	skewed fuchsia rhinestone cowhorn	0		Familiar Weight: +5
+8944	fuchsia skewed rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
@@ -8849,10 +8849,10 @@
 8977	ionized magnetized patent invisibility tonic	0		Effect: "Petit Forbearance", Effect Duration: 56
 8978	flattened ghostly patent aggression tonic	0		Effect: "Bureaucratized", Effect Duration: 60
 8979	pressed flattened patent sallowness tonic	0		Effect: "Cancer Rising", Effect Duration: 35
-8980	activated dry mirror jittery patent avarice tonic	0		Effect: "Uncucumbered", Effect Duration: 27
+8980	activated dry jittery mirror patent avarice tonic	0		Effect: "Uncucumbered", Effect Duration: 27
 8981	alkaline patent alacrity tonic	0		Effect: "Ham-Fisted", Effect Duration: 29
 8982	pickled alkaline corrupted marrow	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 58
-8983	enchanted mediocre weak blinking rodeo whiskey	2	decent	Effect: "Bestial Sympathy", Effect Duration: 50
+8983	mediocre weak enchanted blinking rodeo whiskey	2	decent	Effect: "Bestial Sympathy", Effect Duration: 50
 8984	Thwaitgold scorpion statuette	0		
 8985	real cowboy hat of the overflowing toilet	0		Stench Spell Damage: +50
 8986	tumbling Memories of Cow Punching	0		Free Pull
@@ -8905,7 +8905,7 @@
 9033	tumbling Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	normal browser cookie	4	good	Last Available: "2016-06"
-9036	special weak drinkable hacked gibson	2	good	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 20, Last Available: "2016-06"
+9036	drinkable weak special hacked gibson	2	good	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 20, Last Available: "2016-06"
 9037	tumbling upside-down greedy Source shades	0		Meat Drop: +20, Last Available: "2016-06"
 9038	tumbling software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -9003,31 +9003,31 @@
 9131	squat extremely confusing manual	0		
 9132	stiffened pistol of the pedagogue	0		Experience: +3, Damage Reduction: 1
 9133	jittery upside-down KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	stale miniature leftover pasty	2	decent	
-9135	aged triple-distilled very whiskey	9	awesome	
+9134	miniature stale leftover pasty	2	decent	
+9135	triple-distilled aged very whiskey	9	awesome	
 9136	twirling li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	wet mirror hoarded candy wad	0		Effect: "Human-Orc Hybrid", Effect Duration: 25, Last Available: "2016-10"
 9147	wet Prunets	0		Effect: "Mad at Science", Effect Duration: 26
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	aerosolized wobbly invisible string	0		Lasts Until Rollover, Effect: "Bright!", Effect Duration: 46, Last Available: "2016-10"
 9151	concentrated gray invisible seam ripper	0		Lasts Until Rollover, Effect: "Frozen Hands", Effect Duration: 24, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	spoiled small raw sweet potato	2	crappy	Last Available: "2016-11"
 9154	toothsome big purple raw beans	5	awesome	Last Available: "2016-11"
 9155	toothsome huge raw stuffing	3	awesome	Last Available: "2016-11"
-9156	adequate gray spinning raw cranberry sauce	4	good	Last Available: "2016-11"
-9157	flavorless massive raw turkey	10	decent	Last Available: "2016-11"
-9158	rotten jumbo raw mincemeat	5	crappy	Last Available: "2016-11"
+9156	adequate spinning gray raw cranberry sauce	4	good	Last Available: "2016-11"
+9157	massive flavorless raw turkey	10	decent	Last Available: "2016-11"
+9158	jumbo rotten raw mincemeat	5	crappy	Last Available: "2016-11"
 9159	stale diet raw potato	1	decent	Last Available: "2016-11"
 9160	normal raw gravy	3	good	Last Available: "2016-11"
 9161	miniature rotten raw bread	2	crappy	Last Available: "2016-11"
@@ -9035,17 +9035,17 @@
 9163	wobbly flame-wreathed wicked glass casserole dish of the glutton	0		Spell Damage: +5, Hot Spell Damage: +10, Food Drop: +100, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	yellow censurious supercharged can opener	0		Maximum MP Percent: +30, Sleaze Resistance: +3, Last Available: "2016-11"
-9166	mixed olive upside-down turkey blaster	1		Effect: "Hyperoxygenated Blood", Effect Duration: 20, Last Available: "2016-11"
+9166	mixed upside-down olive turkey blaster	1		Effect: "Hyperoxygenated Blood", Effect Duration: 20, Last Available: "2016-11"
 9167	pulsating up-at-dawn fireproof glass pie plate	0		Hot Resistance: +3, Adventures: +5, Damage Reduction: 7, Last Available: "2016-11"
 9168	censurious scandalous potato masher	0		Sleaze Damage: +5, Sleaze Resistance: +3, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	normal sweet potatoes	3	good	Last Available: "2016-11"
-9172	moldy big enchanted bean casserole	5	crappy	Effect: "Alchemical, Brother", Effect Duration: 40, Last Available: "2016-11"
+9172	big enchanted moldy bean casserole	5	crappy	Effect: "Alchemical, Brother", Effect Duration: 40, Last Available: "2016-11"
 9173	normal enchanted baked stuffing	3	good	Effect: "Healthy Blue Glow", Effect Duration: 15, Last Available: "2016-11"
-9174	yummy low-calorie purple spinning cranberry cylinder	1	awesome	Last Available: "2016-11"
+9174	low-calorie yummy purple spinning cranberry cylinder	1	awesome	Last Available: "2016-11"
 9175	flavorless snack-sized thanksgiving turkey	2	decent	Last Available: "2016-11"
-9176	small stale skewed mince pie	2	decent	Last Available: "2016-11"
+9176	stale small skewed mince pie	2	decent	Last Available: "2016-11"
 9177	rotten mashed potatoes	3	crappy	Last Available: "2016-11"
 9178	stale lime green bouncing warm gravy	3	decent	Last Available: "2016-11"
 9179	bland bouncing huge bread roll	4	decent	Last Available: "2016-11"
@@ -9053,24 +9053,24 @@
 9181	flavorless leftovers sandwich	4	decent	Last Available: "2016-11"
 9182	jittery Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	spinning cornucopia	0		Last Available: "2016-11"
-9184	pulsating shaking megacopia	0		Last Available: "2016-11"
+9184	shaking pulsating megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
-9191	corrupted twirling mirror eldritch concentrate	0		Effect: "Berry Experiential", Effect Duration: 69, Last Available: "2016-11"
+9191	corrupted mirror twirling eldritch concentrate	0		Effect: "Berry Experiential", Effect Duration: 69, Last Available: "2016-11"
 9192	drinkable eldritch extract	3	good	Last Available: "2016-11"
 9193	ruddy groovy Official Council Aide Pin	0		Moxie Percent: +10, Maximum HP Percent: +40, Last Available: "2016-11"
 9194	delicious eldritch distillate	3	awesome	Last Available: "2016-11"
-9195	boiled jittery jittery narrow eldritch essence	1		Effect: "Orc Chops", Effect Duration: 45, Last Available: "2016-11"
+9195	boiled jittery narrow jittery eldritch essence	1		Effect: "Orc Chops", Effect Duration: 45, Last Available: "2016-11"
 9196	slick Science Notebook	0		Moxie: +10
 9197	scandalous toasty eldritch hat of the cheetah	0		Hot Damage: +5, Sleaze Damage: +5, Initiative: +60, Last Available: "2016-11"
 9198	Oprah's Socratic eldritch pants of the cheetah	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Initiative: +60, Last Available: "2016-11"
-9199	mediocre triple-distilled eldritch elixir	6	decent	Last Available: "2016-11"
+9199	triple-distilled mediocre eldritch elixir	6	decent	Last Available: "2016-11"
 9200	narrow prompt lion tamer's Quartet of Flare Masters Jacket	0		Experience (familiar): +2, Adventures: +3, Last Available: "2016-11"
-9201	jittery blue tumbling lump of not really wriggling eldritch matter	0		
+9201	blue tumbling jittery lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
 9203	Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	upside-down counterfeit city	0		Last Available: "2016-12"
@@ -9087,7 +9087,7 @@
 9215	broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
-9218	tumbling squat sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
+9218	squat tumbling sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	spoiled animal part cracker	3	crappy	Last Available: "2016-12"
 9220	drinkable special gingerbread wine	4	good	Effect: "Sweet Incentive", Effect Duration: 35, Last Available: "2016-12"
 9221	decent gingerbread mug	4	good	Last Available: "2016-12"
@@ -9108,11 +9108,11 @@
 9236	Sinatra's gingerbread gavel of the sewer	0		Experience (Moxie): +5, Stench Damage: +25, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	acceptable extra-dry ginger beer	5	good	Last Available: "2016-12"
+9239	extra-dry acceptable ginger beer	5	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	super-frozen modified upside-down blinking industrial frosting	0		Effect: "Magically Delicious", Effect Duration: 11, Last Available: "2016-12"
 9242	quadruple-irradiated polymerized alkaline cyan bouncing fake cocktail	0		Effect: "Fan-Cooled", Effect Duration: 21, Last Available: "2016-12"
-9243	tolerable extra-dry high-end ginger wine	5	good	Last Available: "2016-12"
+9243	extra-dry tolerable high-end ginger wine	5	good	Last Available: "2016-12"
 9244	jittery flame-wreathed plastic bad vibe	0		Hot Spell Damage: +10, Last Available: "2016-12"
 9245	green rosewater-soaked plastic angry vikings	0		Stench Resistance: +3, Last Available: "2016-12"
 9246	chaotic plastic Knows About Chakras	0		Spell Critical Percent: +10, Last Available: "2016-12"
@@ -9121,8 +9121,8 @@
 9249	Vulcanized blue Inner Wisdom	0		Effect: "Old Time Hydration", Effect Duration: 59, Last Available: "2016-12"
 9250	super-tarnished Inner Strength	0		Effect: "Craft Tea", Effect Duration: 59, Last Available: "2016-12"
 9251	cold-filtered moist irradiated Inner Truth	0		Effect: "No Worries", Effect Duration: 68, Last Available: "2016-12"
-9252	bland half-sized wobbly spiritual candy cane	2	decent	Last Available: "2016-12"
-9253	special watered-down artisanal spiritual eggnog	2	EPIC	Effect: "Sweet Incentive", Effect Duration: 15, Last Available: "2016-12"
+9252	half-sized bland wobbly spiritual candy cane	2	decent	Last Available: "2016-12"
+9253	artisanal special watered-down spiritual eggnog	2	EPIC	Effect: "Sweet Incentive", Effect Duration: 15, Last Available: "2016-12"
 9254	decent special ghostly spiritual fruitcake	3	good	Effect: "Flamingly Floral", Effect Duration: 35, Last Available: "2016-12"
 9255	tasty spiritual gingerbread	4	awesome	Last Available: "2016-12"
 9256	green chocolate puppy	0		Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	activated rock candy	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 59, Last Available: "2016-12"
-9267	tiny stale green-iced sweet roll	1	decent	Last Available: "2016-12"
+9267	stale tiny green-iced sweet roll	1	decent	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	narrow chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9144,8 +9144,8 @@
 9272	blurry purple negative lump	0		
 9273	sizzling Third Eye of the sewer	0		Hot Damage: +10, Stench Damage: +25, Last Available: "2016-12"
 9274	zippy Krampus Horn of the ox	0		Muscle: +20, Initiative: +20, Single Equip, Last Available: "2016-12"
-9275	huge adequate lime green hambrosier	6	good	Last Available: "2016-12"
-9276	watered-down tolerable chakra-mental wine	2	good	Last Available: "2016-12"
+9275	adequate huge lime green hambrosier	6	good	Last Available: "2016-12"
+9276	tolerable watered-down chakra-mental wine	2	good	Last Available: "2016-12"
 9277	galvanized tumbling chakra malt	0		Effect: "Cravin' for a Ravin'", Effect Duration: 67, Last Available: "2016-12"
 9278	miniature delicious Black Angus blackburger	2	awesome	Last Available: "2016-12"
 9279	perfectly mixed brandy	3	EPIC	Last Available: "2016-12"
@@ -9159,24 +9159,24 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	shaking gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	mirror dog trainer's friendly wholesome Uncle Crimbo's hat	0		Maximum HP Percent: +10, Familiar Weight: +3, Experience (familiar): +1, Last Available: "2016-12"
-9290	adequate special Eldritch snap	3	good	Effect: "Discomfited", Effect Duration: 40, Last Available: "2017-01"
+9290	special adequate Eldritch snap	3	good	Effect: "Discomfited", Effect Duration: 40, Last Available: "2017-01"
 9291	diluted upside-down hot jelly	1		Effect: "Educated (Sorta)", Effect Duration: 50, Last Available: "2017-01"
 9292	altered jelly	1		Last Available: "2017-01"
 9293	diluted jittery jelly	1		Effect: "Elron's Explosive Etude", Effect Duration: 20, Last Available: "2017-01"
 9294	mixed wobbly sleaze jelly	1		Last Available: "2017-01"
 9295	altered spinning stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	diet yummy shaking toast with hot jelly	1	awesome	Last Available: "2017-01"
-9298	super-sized stale blinking toast with jelly	5	decent	Last Available: "2017-01"
+9297	yummy diet shaking toast with hot jelly	1	awesome	Last Available: "2017-01"
+9298	stale super-sized blinking toast with jelly	5	decent	Last Available: "2017-01"
 9299	spoiled super-sized ghostly toast with jelly	5	crappy	Last Available: "2017-01"
-9300	rotten small toast with sleaze jelly	2	crappy	Last Available: "2017-01"
-9301	snack-sized bland toast with stench jelly	2	decent	Last Available: "2017-01"
+9300	small rotten toast with sleaze jelly	2	crappy	Last Available: "2017-01"
+9301	bland snack-sized toast with stench jelly	2	decent	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	avaricious razor-sharp wax hand	0		Weapon Damage Percent: +25, Meat Drop: +30, Last Available: "2017-01"
 9306	smelly Sinatra's candle	0		Experience (Moxie): +5, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2017-01"
-9307	low-calorie bland fuchsia wax pancake	1	decent	Last Available: "2017-01"
+9307	bland low-calorie fuchsia wax pancake	1	decent	Last Available: "2017-01"
 9308	deadly wax face of the sewer	0		Weapon Damage: +5, Stench Damage: +25, Last Available: "2017-01"
 9309	tolerable wax booze	3	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
@@ -9203,7 +9203,7 @@
 9331	jittery knitted scandalous experienced eldritch hammer	0		Experience: +2, Sleaze Damage: +5, Cold Resistance: +3, Last Available: "2017-01"
 9332	decent blinking eldritch mushroom	4	good	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	half-sized decent eldritch mushroom pizza	2	good	Last Available: "2017-03"
+9334	decent half-sized eldritch mushroom pizza	2	good	Last Available: "2017-03"
 9335	jittery eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	galvanized oxidized skewed eldritch rub	0		Effect: "Covetous Robbery", Effect Duration: 50, Last Available: "2017-02"
@@ -9214,7 +9214,7 @@
 9342	olive Diamond HP-35 Calculator	0		
 9343	blurry bottlecap	0		
 9344	discarded button	0		
-9345	blurry mirror Gummi-Memory	0		
+9345	mirror blurry Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
 9347	tumbling pickled grasshopper	0		Last Available: "2017-03"
 9348	narrow bottle of an&iacute;s	0		Last Available: "2017-03"
@@ -9236,40 +9236,40 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	irresponsibly strong acceptable literal grasshopper	9	good	Last Available: "2017-03"
 9366	perfectly mixed pulsating double entendre	3	EPIC	Last Available: "2017-03"
-9367	fancy tolerable Phlegethon	3	good	Effect: "Christmessy", Effect Duration: 30, Last Available: "2017-03"
-9368	artisanal irresponsibly strong Siberian sunrise	7	EPIC	Last Available: "2017-03"
+9367	tolerable fancy Phlegethon	3	good	Effect: "Christmessy", Effect Duration: 30, Last Available: "2017-03"
+9368	irresponsibly strong artisanal Siberian sunrise	7	EPIC	Last Available: "2017-03"
 9369	delicious weak mentholated wine	2	awesome	Last Available: "2017-03"
-9370	acceptable triple-distilled low tide martini	10	good	Last Available: "2017-03"
+9370	triple-distilled acceptable low tide martini	10	good	Last Available: "2017-03"
 9371	tolerable shroomtini	3	good	Last Available: "2017-03"
 9372	delicious red morning dew	4	awesome	Last Available: "2017-03"
 9373	acceptable whiskey squeeze	3	good	Last Available: "2017-03"
 9374	drinkable great fashioned	3	good	Last Available: "2017-03"
 9375	distilled drinkable Gnomish sagngria	5	good	Last Available: "2017-03"
-9376	distilled perfectly mixed vodka stinger	5	EPIC	Last Available: "2017-03"
+9376	perfectly mixed distilled vodka stinger	5	EPIC	Last Available: "2017-03"
 9377	tolerable pulsating extremely slippery nipple	3	good	Last Available: "2017-03"
-9378	mediocre watered-down piscatini	2	decent	Last Available: "2017-03"
+9378	watered-down mediocre piscatini	2	decent	Last Available: "2017-03"
 9379	drinkable Churchill	3	good	Last Available: "2017-03"
 9380	irresponsibly strong tolerable soilzerac	7	good	Last Available: "2017-03"
 9381	triple-distilled lousy lime green London frog	6	decent	Last Available: "2017-03"
 9382	tolerable blue nothingtini	4	good	Last Available: "2017-03"
-9383	irresponsibly strong lousy eighth plague	9	decent	Last Available: "2017-03"
+9383	lousy irresponsibly strong eighth plague	9	decent	Last Available: "2017-03"
 9384	mediocre single entendre	3	decent	Last Available: "2017-03"
-9385	watered-down artisanal reverse Tantalus	2	EPIC	Last Available: "2017-03"
+9385	artisanal watered-down reverse Tantalus	2	EPIC	Last Available: "2017-03"
 9386	tolerable elemental caipiroska	3	good	Last Available: "2017-03"
 9387	mediocre Feliz Navidad	3	decent	Last Available: "2017-03"
-9388	boozy perfectly mixed Bloody Nora	5	EPIC	Last Available: "2017-03"
+9388	perfectly mixed boozy Bloody Nora	5	EPIC	Last Available: "2017-03"
 9389	lousy moreltini	3	decent	Last Available: "2017-03"
-9390	weak bad hell in a bucket	2	decent	Last Available: "2017-03"
+9390	bad weak hell in a bucket	2	decent	Last Available: "2017-03"
 9391	watered-down tolerable Newark	2	good	Last Available: "2017-03"
-9392	lousy weak R'lyeh	2	decent	Last Available: "2017-03"
+9392	weak lousy R'lyeh	2	decent	Last Available: "2017-03"
 9393	drinkable blinking Gnollish sangria	3	good	Last Available: "2017-03"
 9394	lousy red vodka barracuda	4	decent	Last Available: "2017-03"
 9395	aged Mysterious Island iced tea	3	awesome	Last Available: "2017-03"
-9396	watered-down artisanal drive-by shooting	2	EPIC	Last Available: "2017-03"
+9396	artisanal watered-down drive-by shooting	2	EPIC	Last Available: "2017-03"
 9397	hand-crafted gunner's daughter	3	EPIC	Last Available: "2017-03"
-9398	acceptable fancy spirit-forward dirt julep	5	good	Effect: "Mushroom Magicalness", Effect Duration: 5, Last Available: "2017-03"
-9399	perfectly mixed triple-distilled shaking Simepore slime	10	EPIC	Last Available: "2017-03"
-9400	watered-down lousy Phil Collins	2	decent	Last Available: "2017-03"
+9398	fancy spirit-forward acceptable dirt julep	5	good	Effect: "Mushroom Magicalness", Effect Duration: 5, Last Available: "2017-03"
+9399	triple-distilled perfectly mixed shaking Simepore slime	10	EPIC	Last Available: "2017-03"
+9400	lousy watered-down Phil Collins	2	decent	Last Available: "2017-03"
 9401	wobbly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	skewed toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9298,9 +9298,9 @@
 9426	green complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	denatured purple alien animal goo	1		Last Available: "2017-04"
-9429	blinking maroon alien animal milk	0		Last Available: "2017-04"
+9429	maroon blinking alien animal milk	0		Last Available: "2017-04"
 9430	cyan spant egg casing	0		Last Available: "2017-04"
-9431	green blurry murderbot data core	0		Last Available: "2017-04"
+9431	blurry green murderbot data core	0		Last Available: "2017-04"
 9432	triple-wet improved alien medicine	0		Effect: "Happy Trails", Effect Duration: 42, Last Available: "2017-04"
 9433	normal spinning alien salad	3	good	Last Available: "2017-04"
 9434	hand-crafted alien booze	3	EPIC	Last Available: "2017-04"
@@ -9326,14 +9326,14 @@
 9454	triple-chilled polarized murderbot spring injector	0		Effect: "Elemental Flavor", Effect Duration: 43, Last Available: "2017-04"
 9455	auspicious murderbot whip of the cheetah	0		Item Drop: +10, Initiative: +60, Last Available: "2017-04"
 9456	prompt weightlifter's murderbot plasma rifle	0		Muscle: +15, Adventures: +3, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
-9457	lime green huge murderbot memory chip	0		Last Available: "2017-04"
+9457	huge lime green murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
-9459	tumbling spinning Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
+9459	spinning tumbling Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	tumbling Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	Space Baby children's book	0		Last Available: "2017-04"
-9464	olive jittery tumbling Space Baby bawbaw	0		Last Available: "2017-04"
+9464	jittery tumbling olive Space Baby bawbaw	0		Last Available: "2017-04"
 9465	yellow Spacegate	0		Last Available: "2017-04"
 9466	flavorless half-sized Aldebaran sardines	2	decent	Last Available: "2017-04"
 9467	practically non-alcoholic drinkable upside-down Centauri fish wine	1	good	Last Available: "2017-04"
@@ -9355,17 +9355,17 @@
 9483	alkaline electrified Daily Affirmation: Be a Mind Master	0		Effect: "Charrrming", Effect Duration: 33, Last Available: "2017-05"
 9484	boiled dry Daily Affirmation: Work For Hours a Week	0		Effect: "Compensatory Cruelness", Effect Duration: 13, Last Available: "2017-05"
 9485	boiled deionized oxidized Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Okee-Dokee Go!", Effect Duration: 50, Last Available: "2017-05"
-9486	special low-calorie stale Affirmation Cookie	1	decent	Effect: "Warm Belly", Effect Duration: 35, Last Available: "2017-05"
+9486	stale special low-calorie Affirmation Cookie	1	decent	Effect: "Warm Belly", Effect Duration: 35, Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	moist Threatening Missive	0		Effect: "Extra-Thick Blood", Effect Duration: 25
 9491	Targeted Plague Vector	0		
-9492	shaking tumbling mirror blue suspicious package	0		Free Pull, Last Available: "2017-06"
+9492	mirror tumbling blue shaking suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	knitted lard-coated vibrating Kremlin's Greatest Briefcase	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, Cold Resistance: +3, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	bad triple-distilled narrow basic martini	7	decent	Last Available: "2017-06"
+9494	triple-distilled bad narrow basic martini	7	decent	Last Available: "2017-06"
 9495	drinkable huge improved martini	4	good	Last Available: "2017-06"
-9496	watered-down bad splendid martini	2	decent	Last Available: "2017-06"
+9496	bad watered-down splendid martini	2	decent	Last Available: "2017-06"
 9497	squat exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	purple tattoo gun	0		Last Available: "2017-06"
@@ -9388,7 +9388,7 @@
 9516	red meteoroid	0		Last Available: "2017-08"
 9517	coward's sage meteortarboard of the cheetah	0		Mysticality Percent: +10, Monster Level: -20, Initiative: +60, Last Available: "2017-08"
 9518	curative meteorite guard of Calamity Jane of Gandalf	0		Critical Hit Percent: +15, Spell Critical Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 9, Last Available: "2017-08"
-9519	fortified smartaleck's meteorb	0		Moxie Percent: +30, Damage Absorption: +60, Lantern Element: "Hot", Last Available: "2017-08"
+9519	fortified smartaleck's meteorb	0		Moxie Percent: +30, Damage Absorption: +60, Last Available: "2017-08", Lantern Element: "Hot"
 9520	twirling rock-hard sage asteroid belt	0		Mysticality Percent: +10, Damage Reduction: 5, Single Equip, Last Available: "2017-08"
 9521	dog trainer's Tesla meteorthopedic shoes of James Dean	0		Experience (Moxie): +3, Experience (familiar): +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2017-08"
 9522	executive hardy shooting morning star of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Meat Drop: +40, Single Equip, Last Available: "2017-08"
@@ -9448,7 +9448,7 @@
 9576	mafia organizer badge of Leguizamo	0		Monster Level: +20, Single Equip
 9577	mafia filofax	0		
 9578	lime green transparent nog	1	awesome	Last Available: "2017-12"
-9579	toothsome snack-sized huge unfinished fruitcake	2	awesome	Last Available: "2017-12"
+9579	snack-sized toothsome huge unfinished fruitcake	2	awesome	Last Available: "2017-12"
 9580	diffused alkaline blue and cracker	0		Effect: "Scavengers Scavenging", Effect Duration: 56, Last Available: "2017-12"
 9581	drinkable neg grog	4	good	Last Available: "2017-12"
 9582	stale massive half double fruitcake	9	decent	Last Available: "2017-12"
@@ -9464,7 +9464,7 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	good	Last Available: "2017-11"
 9594	activated jittery wishbone	0		Effect: "Uncucumbered", Effect Duration: 57, Last Available: "2017-11"
-9595	drinkable irresponsibly strong Racisto Ruidoso	7	good	Last Available: "2017-11"
+9595	irresponsibly strong drinkable Racisto Ruidoso	7	good	Last Available: "2017-11"
 9596	olive earthenware muffin tin	0		
 9597	adequate bran muffin	4	good	
 9598	normal tiny upside-down blueberry muffin	1	good	
@@ -9505,7 +9505,7 @@
 9633	red spinning Temple Grandin's groovy cheerful Crimbo sweater	0		Moxie Percent: +10, Familiar Weight: +7, Last Available: "2017-12"
 9634	supercharged cheerful pajama pants of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Last Available: "2017-12"
 9635	lime green blurry The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
-9636	huge shaking The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9636	shaking huge The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
@@ -9515,14 +9515,14 @@
 9643	green The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	lime green The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
-9646	lime green twirling The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9646	twirling lime green The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	cyan mime eraser	0		Last Available: "2017-12"
 9648	hand-crafted bouncing executive mime flask	3	EPIC	Last Available: "2017-12"
 9649	bland special nega-mushroom	3	decent	Effect: "Thaumodynamic", Effect Duration: 15, Last Available: "2017-12"
 9650	drinkable nega-mushroom wine	4	good	Last Available: "2017-12"
 9651	triple-pressed deionized enhanced spinning Cheer-Up soda	0		Effect: "Deeply Ironic", Effect Duration: 30, Last Available: "2017-12"
 9652	delicious mime army rations	3	awesome	Last Available: "2017-12"
-9653	special smooth mime army wine	3	awesome	Effect: "items.enh", Effect Duration: 50, Last Available: "2017-12"
+9653	smooth special mime army wine	3	awesome	Effect: "items.enh", Effect Duration: 50, Last Available: "2017-12"
 9654	denatured mime army superserum	1		Last Available: "2017-12"
 9655	vacuum-sealed alkaline tumbling mime army camouflage kit	0		Effect: "Gonna Get You, Sucker", Effect Duration: 18, Last Available: "2017-12"
 9656	family-friendly Samson's miming beret	0		Experience (Muscle): +5, Sleaze Resistance: +1, Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	wobbly cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	gigantic normal extra-toasted half sandwich	8	good	Last Available: "2018-12"
+9681	normal gigantic extra-toasted half sandwich	8	good	Last Available: "2018-12"
 9682	smooth mulled hobo wine	4	awesome	Last Available: "2018-12"
 9683	wobbly burning newspaper	0		Last Available: "2018-12"
 9684	squat curative cool beefy burning paper hat	0		Muscle: +10, Moxie: +5, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2018-12"
@@ -9577,8 +9577,8 @@
 9705	vaporized huge pulsating vitamin G pill	1		Effect: "Je Ne Sais Porquoise", Effect Duration: 35
 9706	pickled blurry lucky-ish pill	1		Effect: "Donho's Bubbly Ballad", Effect Duration: 10
 9707	distilled shaking dieting pill	1		Effect: "Demonic Flavor", Effect Duration: 20
-9712	green shaking Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
-9713	teal huge How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
+9712	shaking green Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
+9713	huge teal How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	pulsating Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
@@ -9595,7 +9595,7 @@
 9727	miniature stale special heart-shaped candy whetstone	2	decent	Effect: "The Halls of Muscularity", Effect Duration: 15, Last Available: "2018-02"
 9728	fancy spoiled Swedish massage fish	3	crappy	Effect: "OMG WTF", Effect Duration: 45, Last Available: "2018-02"
 9729	weak artisanal Third Base	2	EPIC	Last Available: "2018-02"
-9730	spirit-forward drinkable special Bustle Hustler	5	good	Effect: "Employee of the Month", Effect Duration: 20, Last Available: "2018-02"
+9730	special spirit-forward drinkable Bustle Hustler	5	good	Effect: "Employee of the Month", Effect Duration: 20, Last Available: "2018-02"
 9731	Vulcanized super-energized huge Fabiotion	0		Effect: "The Halls of Muscularity", Effect Duration: 55, Last Available: "2018-02"
 9732	liquefied chilled Bettie page	0		Effect: "Human-Undead Hybrid", Effect Duration: 62, Last Available: "2018-02"
 9733	cold-filtered frozen tonic o' Banderas	0		Effect: "Halloweeny", Effect Duration: 67, Last Available: "2018-02"
@@ -9609,7 +9609,7 @@
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	Mysterious Black Box	0		Last Available: "2018-02"
 9743	super-pickled unsweetened upside-down rainbow jellybean	0		Effect: "Scrappy, Shadowy", Effect Duration: 13
-9744	denatured wobbly lime green mystery lollipop	0		Effect: "Good Motivator", Effect Duration: 12
+9744	denatured lime green wobbly mystery lollipop	0		Effect: "Good Motivator", Effect Duration: 12
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	triple-improved triple-altered blurry maroon rhinestone	0		Effect: "Spirit of Alph", Effect Duration: 60
 9747	lime green 1,960 pok&eacute;dollar bill	0		
@@ -9657,7 +9657,7 @@
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	red Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
-9792	blurry skewed Vamprey	0		Last Available: "2018-03"
+9792	skewed blurry Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
 9794	spinning Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
@@ -9681,10 +9681,10 @@
 9813	Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
 9815	gray shaking Sitrep berry	0		Last Available: "2018-03"
-9816	blurry skewed gray Nadsat berry	0		Last Available: "2018-03"
+9816	skewed blurry gray Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
 9818	olive skewed Tapioc berry	0		Last Available: "2018-03"
-9819	cyan narrow Snarf berry	0		Last Available: "2018-03"
+9819	narrow cyan Snarf berry	0		Last Available: "2018-03"
 9820	olive ghostly Keese berry	0		Last Available: "2018-03"
 9821	tumbling luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	blurry shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9695,8 +9695,8 @@
 9827	lime green rocket	0		
 9828	diluted magnificent oyster egg	1		
 9829	twisted brilliant oyster egg	1		
-9830	vaporized tumbling upside-down glistening oyster egg	1		
-9831	compressed purple pulsating scintillating oyster egg	1		Effect: "Pockets of Fire", Effect Duration: 10
+9830	vaporized upside-down tumbling glistening oyster egg	1		
+9831	compressed pulsating purple scintillating oyster egg	1		Effect: "Pockets of Fire", Effect Duration: 10
 9832	dried wobbly pearlescent oyster egg	1		
 9833	altered twirling lustrous oyster egg	1		Effect: "Yet tea", Effect Duration: 45
 9834	dried gleaming oyster egg	1		
@@ -9727,8 +9727,8 @@
 9859	ghostly mirror LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	bouncing LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	fancy immense adequate FantasyRealm turkey leg	8	good	Effect: "Twenty-three Squid, Ew", Effect Duration: 20, Last Available: "2018-04"
-9863	bad watered-down shaking FantasyRealm mead	2	decent	Last Available: "2018-04"
+9862	adequate immense fancy FantasyRealm turkey leg	8	good	Effect: "Twenty-three Squid, Ew", Effect Duration: 20, Last Available: "2018-04"
+9863	watered-down bad shaking FantasyRealm mead	2	decent	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9767,12 +9767,12 @@
 9899	flavorless diet chocolate Ogre Chieftain	1	decent	
 9900	stale chocolate &quot;Phoenix&quot;	3	decent	
 9901	low-calorie decent chocolate Spider Queen	1	good	
-9902	mediocre high-proof pulsating pulsating hipster cocktail	7	decent	
-9903	God Lobster's Scepter	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "sombrero"
-9905	upside-down God Lobster's Rod	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "block"
-9907	wobbly God Lobster's Crown	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "fairy"
+9902	high-proof mediocre pulsating pulsating hipster cocktail	7	decent	
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	upside-down God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	wobbly God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9783,15 +9783,15 @@
 9915	normal small good guava	2	good	
 9916	delicious gin and ginger	4	awesome	
 9917	gray Thwaitgold chigger statuette	0		
-9918	compressed spinning red spinning gaseous gravy	1		
+9918	compressed red spinning spinning gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
-9920	skewed blurry SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
+9920	blurry skewed SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	upside-down A Guide to Safari	0		Skill: "Experience Safari"
 9922	Vulcanized concentrated Shielding Potion	0		Effect: "Stinky Hands", Effect Duration: 40, Last Available: "2018-06"
 9923	flattened Punching Potion	0		Effect: "Hyphemariffic", Effect Duration: 28, Last Available: "2018-06"
 9924	yellow Special Seasoning	0		Last Available: "2018-06"
 9925	pickled spinning Nightmare Fuel	1		Last Available: "2018-06"
-9926	spinning mirror Gathered Meat-Clip	0		Last Available: "2020-09"
+9926	mirror spinning Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	huge blinking Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	narrow ribald coward's Rosewater's Brutal brogues of incineration	0		Mysticality Percent: +30, Monster Level: -20, Hot Spell Damage: +50, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2018-07"
@@ -9812,13 +9812,13 @@
 9944	smelly crafty PARTY HARD T-shirt of the early riser	0		Maximum MP: +10, Stench Spell Damage: +10, Adventures: +7, Last Available: "2018-09"
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
-9947	squat jittery gas can	0		Last Available: "2018-09"
+9947	jittery squat gas can	0		Last Available: "2018-09"
 9948	hand-crafted squat Middle of the Road&trade; brand whiskey	3	EPIC	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	green ribald pentagram bandana of the businessman	0		Sleaze Damage: +10, Meat Drop: +50, Last Available: "2018-09"
 9951	blinking yellow ghostly Jack Frost's skull ring	0		Cold Spell Damage: +50, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	bite-sized flavorless PB&J with the crusts cut off	1	decent	Last Available: "2018-09"
+9953	flavorless bite-sized PB&J with the crusts cut off	1	decent	Last Available: "2018-09"
 9954	Jeselnik's therapeutic dorky glasses	0		Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-09"
 9955	flame-retardant ponytail clip of the sewer	0		Stench Damage: +25, Hot Resistance: +1, Last Available: "2018-09"
 9956	ghostly wizardly paint palette	0		Mysticality: +25, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
@@ -9851,7 +9851,7 @@
 9984	red Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	skewed Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	fuchsia wobbly huge latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	fuchsia huge wobbly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	pulsating latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	jittery cyan voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-11"
@@ -9875,19 +9875,19 @@
 10009	green Jim Carey's vibrating therapeutic mutant crown	0		Maximum MP Percent: +10, Monster Level: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-11"
 10010	stale ghostly ghostly ectoplasm	4	decent	Last Available: "2018-11"
 10011	delicious mirror	4	awesome	Last Available: "2018-11"
-10012	distilled aged bottle of vodka	5	awesome	Last Available: "2018-11"
+10012	aged distilled bottle of vodka	5	awesome	Last Available: "2018-11"
 10013	stale thick pizza	5	decent	Last Available: "2018-11"
 10014	aged weak martini	2	awesome	Last Available: "2018-11"
-10015	small adequate cherry pie	2	good	Last Available: "2018-11"
+10015	adequate small cherry pie	2	good	Last Available: "2018-11"
 10016	artisanal eggnog	3	EPIC	Last Available: "2018-11"
 10017	upside-down glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	big flavorless Hell ramen	5	decent	Last Available: "2018-11"
-10019	spirit-forward bad gimlet	5	decent	Last Available: "2018-11"
+10019	bad spirit-forward gimlet	5	decent	Last Available: "2018-11"
 10020	lousy boozy twice-haunted screwdriver	5	decent	Last Available: "2018-11"
 10021	flavorless candy cane	3	decent	Last Available: "2018-12"
-10022	special perfectly mixed high-proof runny fermented egg	9	EPIC	Effect: "Mmmmmelon", Effect Duration: 50, Last Available: "2018-12"
+10022	high-proof special perfectly mixed runny fermented egg	9	EPIC	Effect: "Mmmmmelon", Effect Duration: 50, Last Available: "2018-12"
 10023	spoiled oldcake	3	crappy	Last Available: "2018-12"
-10024	enchanted toothsome traditional Crimbo cookie	3	awesome	Effect: "Clean-Shaven", Effect Duration: 35, Last Available: "2023-06"
+10024	toothsome enchanted traditional Crimbo cookie	3	awesome	Effect: "Clean-Shaven", Effect Duration: 35, Last Available: "2023-06"
 10025	shaking baleful plastic wild beaver	0		Spell Damage: +25, Last Available: "2018-12"
 10026	deadly plastic reindeer	0		Weapon Damage: +5, Last Available: "2018-12"
 10027	spinning frightening plastic Caf&eacute; Elf	0		Spooky Damage: +5, Last Available: "2018-12"
@@ -9903,17 +9903,17 @@
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	stale grilled mooseflank	3	decent	Last Available: "2018-12"
-10040	flavorless special moosemeat pie	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2018-12"
+10040	special flavorless moosemeat pie	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2018-12"
 10041	brainy balanced antler	0		Mysticality: +5, Last Available: "2018-12"
 10042	deadly dam	0		Weapon Damage: +5, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted beavermouth	3	EPIC	Last Available: "2018-12"
 10044	mediocre watered-down beaver punch (papaya)	2	decent	Last Available: "2018-12"
-10045	enchanted drinkable beaver punch (peach)	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2018-12"
+10045	drinkable enchanted beaver punch (peach)	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2018-12"
 10046	drinkable pulsating beaver punch (cherry)	3	good	Last Available: "2018-12"
 10047	dangerous thinker's Canadian lantern	0		Mysticality: +10, Weapon Damage: +10, Last Available: "2018-12"
 10048	blinking muskox-skin cap of terror	0		Spooky Spell Damage: +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	adequate enchanted big glass of raw eggs	5	good	Effect: "Glo-Face", Effect Duration: 5, Last Available: "2018-12"
+10050	enchanted big adequate glass of raw eggs	5	good	Effect: "Glo-Face", Effect Duration: 5, Last Available: "2018-12"
 10051	triple-distilled tolerable punch-drunk punch	8	good	Last Available: "2018-12"
 10052	denatured tumbling body spradium	1		Last Available: "2018-12"
 10053	careful bauxite beret	0		Monster Level: -10, Last Available: "2018-12"
@@ -9923,16 +9923,16 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	blinking lion tamer's educational Kramco Sausage-o-Matic&trade; of the overflowing toilet of bravery	0		Experience: +1, Experience (familiar): +2, Stench Spell Damage: +50, Spooky Resistance: +5, Item Drop: +5, Last Available: "2019-01"
 10059	twirling sausage casing	0		Last Available: "2019-01"
-10060	half-sized stale sausage	2	decent	Last Available: "2019-01"
+10060	stale half-sized sausage	2	decent	Last Available: "2019-01"
 10061	educational brainy red-hot sausage fork	0		Mysticality: +5, Experience: +1, Last Available: "2019-01"
 10062	gray bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	smooth distilled beer	5	awesome	Last Available: "2018-12"
+10066	distilled smooth beer	5	awesome	Last Available: "2018-12"
 10067	flavorless yule gruel	3	decent	Last Available: "2018-12"
 10068	weak mediocre hot watered rum	2	decent	Last Available: "2018-12"
-10069	watered-down lousy bottle of Crimbognac	2	decent	Last Available: "2018-12"
+10069	lousy watered-down bottle of Crimbognac	2	decent	Last Available: "2018-12"
 10070	rotten half-sized Crimboysters Rockefeller	2	crappy	Last Available: "2018-12"
 10071	mixed Crimbeau de toilette	1		Effect: "Insulated Trousers", Effect Duration: 45, Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
@@ -9952,7 +9952,7 @@
 10086	occult chalk chapeau of the overflowing toilet	0		Spell Damage Percent: +25, Stench Spell Damage: +50, Last Available: "2019-12"
 10087	horrifying clever chalk choker	0		Maximum MP: +20, Spooky Damage: +25, Single Equip, Last Available: "2019-12"
 10088	pickled ghostly chalk chunks	1		Last Available: "2019-12"
-10089	anodized Vulcanized blurry green candy chalk	0		Effect: "Crimbo Nostalgia", Effect Duration: 60
+10089	anodized Vulcanized green blurry candy chalk	0		Effect: "Crimbo Nostalgia", Effect Duration: 60
 10090	marble maebari of extreme caution of the boozehound	0		Monster Level: -25, Booze Drop: +100, Last Available: "2019-12"
 10091	Jim Carey's shellacked marble mantle	0		Damage Reduction: 7, Monster Level: +25, Last Available: "2019-12"
 10092	gray banded marble magnet of the detective	0		Damage Absorption: +100, Item Drop: +20, Single Equip, Last Available: "2019-12"
@@ -10015,7 +10015,7 @@
 10149	polarized polymerized irradiated mirror tin thermos of chai	0		Effect: "Demonic Taint", Effect Duration: 24, Last Available: "2019-12"
 10150	modified yellow prototype stimulant	1		Last Available: "2019-12"
 10151	blinking tailored vest of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2019-12"
-10152	red blurry sew-on bandage	0		Last Available: "2019-12"
+10152	blurry red sew-on bandage	0		Last Available: "2019-12"
 10153	lime green really nice net	0		Last Available: "2019-12"
 10154	huge Newton's elf army poncho	0		Experience (Mysticality): +3, Lasts Until Rollover, Last Available: "2019-12"
 10155	snack-sized tasty elf army field rations	2	awesome	Last Available: "2019-12"
@@ -10031,17 +10031,17 @@
 10165	huge mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	wicked weightlifter's Lil' Doctor&trade; bag	0		Muscle: +15, Spell Damage: +5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	enchanted flavorless bloodstick	3	decent	Effect: "Barking Mad", Effect Duration: 5
+10169	flavorless enchanted bloodstick	3	decent	Effect: "Barking Mad", Effect Duration: 5
 10170	perfectly mixed practically non-alcoholic bottle of Sanguiovese	1	super ultra mega turbo EPIC	
 10171	diet adequate green actual blood sausage	1	good	
 10172	mediocre triple-distilled mulled blood	7	decent	
 10173	immense spoiled blood snowcone	8	crappy	
 10174	special perfectly mixed squat Red Russian	3	EPIC	Effect: "Ginger Snapped", Effect Duration: 25
 10175	adequate big blood roll-up	5	good	
-10176	weak smooth bottle of blood	2	awesome	
+10176	smooth weak bottle of blood	2	awesome	
 10177	decent half-sized green blood-soaked sponge cake	2	good	
 10178	lousy vampagne	4	decent	
-10179	snack-sized decent plain snowcone	2	good	
+10179	decent snack-sized plain snowcone	2	good	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
@@ -10061,7 +10061,7 @@
 10196	jittery recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	twirling Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	snack-sized fancy flavorless crabsicle	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 10, Last Available: "2019-04"
+10199	snack-sized flavorless fancy crabsicle	2	decent	Effect: "This Is Where You're a Viking", Effect Duration: 10, Last Available: "2019-04"
 10200	upside-down melty plastic grenade	0		Last Available: "2019-04"
 10201	lousy bottle of dark rhum	4	decent	Last Available: "2019-04"
 10202	smooth bottle of extra-dark rhum	3	awesome	Last Available: "2019-04"
@@ -10074,8 +10074,8 @@
 10209	narrow windicle	0		Last Available: "2019-04"
 10210	skewed supercharged padded pirate radio ring	0		Damage Absorption: +20, Maximum MP Percent: +30, Single Equip, Last Available: "2019-04"
 10211	wobbly Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	spoiled immense pineapple slab	8	crappy	Last Available: "2019-04"
-10213	decent half-sized enchanted hibiscus petal	2	good	Effect: "Blubbered Up", Effect Duration: 50, Last Available: "2019-04"
+10212	immense spoiled pineapple slab	8	crappy	Last Available: "2019-04"
+10213	half-sized decent enchanted hibiscus petal	2	good	Effect: "Blubbered Up", Effect Duration: 50, Last Available: "2019-04"
 10214	ionized huge mint leaf	0		Effect: "Rainbow Bright", Effect Duration: 15, Last Available: "2019-04"
 10215	ghostly cocoa of youth	0		Last Available: "2019-04"
 10216	compressed ice molecule	1		Effect: "Bread-Lined", Effect Duration: 30, Last Available: "2019-04"
@@ -10089,20 +10089,20 @@
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	miser's plush sea serpent	0		Meat Drop: +10, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	special jumbo yummy cyan pirate fork	5		Effect: "Cold Throat", Effect Duration: 5, Last Available: "2019-04"
+10227	yummy jumbo special cyan pirate fork	5		Effect: "Cold Throat", Effect Duration: 5, Last Available: "2019-04"
 10228	twirling Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	huge smooth piratical blunderbuss of Flo-Jo	0		Moxie: +15, Initiative: +100, Last Available: "2019-04"
 10231	Usain Bolt's lard-coated PirateRealm party hat of the scaredy-cat	0		Monster Level: -15, Sleaze Spell Damage: +25, Initiative: +80, Last Available: "2019-04"
 10232	acceptable mirror Island Landslide	4	good	Last Available: "2019-04"
-10233	delicious weak Island Thunderstorm	2	awesome	Last Available: "2019-04"
+10233	weak delicious Island Thunderstorm	2	awesome	Last Available: "2019-04"
 10234	artisanal Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	acceptable teal Skull Punch	4	good	Last Available: "2019-04"
 10236	tolerable fancy bouncing pulsating Electric Punch	4	good	Effect: "Bricked-In", Effect Duration: 35, Last Available: "2019-04"
 10237	bad blurry Smuggler's Punch	3	decent	Last Available: "2019-04"
 10238	perfectly mixed extra-dry bouncing Scorpion Bowl	5	EPIC	Last Available: "2019-04"
-10239	extra-dry mediocre shaking Turtle Bowl	5	decent	Last Available: "2019-04"
-10240	weak tolerable maroon Cobra Bowl	2	good	Last Available: "2019-04"
+10239	mediocre extra-dry shaking Turtle Bowl	5	decent	Last Available: "2019-04"
+10240	tolerable weak maroon Cobra Bowl	2	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	Jeselnik's nasty curative extremely unsafe vampyric cloake of the cheetah	0		Weapon Damage Percent: +100, Stench Damage: +5, Sleaze Damage: +25, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
@@ -10134,7 +10134,7 @@
 10269	energized pulsating seashell	0		Effect: "Heart Aflame", Effect Duration: 16, Last Available: "2019-07"
 10270	cold-filtered squat seashell	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 43, Last Available: "2019-07"
 10271	wobbly bunch of sea grapes	0		Last Available: "2019-07"
-10272	acceptable watered-down bottle of sea wine	2	good	Last Available: "2019-07"
+10272	watered-down acceptable bottle of sea wine	2	good	Last Available: "2019-07"
 10273	compressed ghostly kelp	1		Effect: "Abominably Slippery", Effect Duration: 20, Last Available: "2019-07"
 10274	asbestos-lined chaotic Annie Oakley's Van der Graaf supercharged razor-sharp Da Vinci's driftwood hat of Tarzan of temperance	0		Experience (Muscle): +3, Experience (Mysticality): +5, Weapon Damage Percent: +25, Maximum MP Percent: +30, Critical Hit Percent: +20, Spell Critical Percent: +10, Hot Resistance: +5, Sleaze Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2019-07"
 10275	greasy toasty Jim Carey's supercharged wholesome extremely unsafe personal trainer's supercool driftwood pants of bravery	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Weapon Damage Percent: +100, Maximum HP Percent: +10, Maximum MP Percent: +30, Monster Level: +25, Hot Damage: +5, Sleaze Spell Damage: +10, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2019-07"
@@ -10165,9 +10165,9 @@
 10300	educational whittled owl figurine of the overflowing toilet of the businessman	0		Experience: +1, Stench Spell Damage: +50, Meat Drop: +50, Single Equip, Last Available: "2019-08"
 10301	lion tamer's dog trainer's whittled fox figurine of Calamity Jane	0		Critical Hit Percent: +15, Experience (familiar): 3, Single Equip, Last Available: "2019-08"
 10302	chaotic electrified hardened whittled walking stick	0		Damage Reduction: 3, Spell Critical Percent: +10, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-08"
-10303	spoiled fancy campfire hot dog	3	crappy	Effect: "Hyperoxygenated Blood", Effect Duration: 40, Last Available: "2019-08"
+10303	fancy spoiled campfire hot dog	3	crappy	Effect: "Hyperoxygenated Blood", Effect Duration: 40, Last Available: "2019-08"
 10304	flavorless snack-sized red campfire baked potato	2	decent	Last Available: "2019-08"
-10305	fancy stale immense campfire s'more	10	decent	Effect: "Retrograde Relaxation", Effect Duration: 15, Last Available: "2019-08"
+10305	fancy immense stale campfire s'more	10	decent	Effect: "Retrograde Relaxation", Effect Duration: 15, Last Available: "2019-08"
 10306	stale fuchsia campfire beans	4	decent	Last Available: "2019-08"
 10307	moldy twirling campfire stew	3	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
@@ -10175,7 +10175,7 @@
 10310	rare Meat isotope	0		
 10311	mirror burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
-10313	mirror blurry olive campfire smoke	0		
+10313	blurry mirror olive campfire smoke	0		
 10314	squat twirling Murgatroyd diode	0		
 10315	signal receiver	0		
 10316	space shield	0		Damage Reduction: 9
@@ -10210,15 +10210,15 @@
 10351	colloidal olive patch of extra-warm fur	0		Effect: "Stimulated Brain", Effect Duration: 48, Last Available: "2019-12"
 10352	dehydrated industrial lubricant	1		Last Available: "2019-12"
 10353	super-electrified diffused yellow narrow unfinished pleasure	0		Effect: "Spiro Gyro", Effect Duration: 69, Last Available: "2019-12"
-10354	mixed purple squat huge vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	mixed purple huge squat vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dehydrated twirling a bug's lymph	1		Last Available: "2019-12"
 10356	adjusted maroon organic potpourri	0		Effect: "Strong Grip", Effect Duration: 15, Last Available: "2019-12"
-10357	high-proof acceptable yellow boot flask	6	good	Last Available: "2019-12"
+10357	acceptable high-proof yellow boot flask	6	good	Last Available: "2019-12"
 10358	irradiated infernal snowball	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 63, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	vaporized fish sauce	1		Last Available: "2019-12"
-10361	low-calorie spoiled spinning guffin	1	crappy	Last Available: "2019-12"
-10362	compressed tumbling shaking Shantix&trade;	1		Last Available: "2019-12"
+10361	spoiled low-calorie spinning guffin	1	crappy	Last Available: "2019-12"
+10362	compressed shaking tumbling Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	modified non-Euclidean angle	1		Last Available: "2019-12"
 10365	nitrogenated aerosolized extra-activated twirling cyan peppermint syrup	0		Effect: "Elemental Flavor", Effect Duration: 18, Last Available: "2019-12"
@@ -10248,14 +10248,14 @@
 10389	runny icing	0		Last Available: "2019-12"
 10390	dehydrated bouncing super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	huge medical-grade curative sage icing poncho	0		Mysticality Percent: +10, HP Regen Min: 10, HP Regen Max: 15, Last Available: "2019-12"
-10392	pulsating blinking Mer-kin cookiestove	0		Last Available: "2019-12"
+10392	blinking pulsating Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	dry twirling glob of salty molasses	0		Effect: "You're Rubber", Effect Duration: 23, Last Available: "2019-12"
 10394	Lo Pan's deadly Mer-kin rollpin	0		Weapon Damage: +5, Spell Critical Percent: +30, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	super-sized delicious bowl of mernudo	5	awesome	Last Available: "2019-12"
 10398	triple-distilled bad bouncing fishelada	8	decent	Last Available: "2019-12"
-10399	bite-sized toothsome mirror ojo de pez burrito	1	awesome	Last Available: "2019-12"
+10399	toothsome bite-sized mirror ojo de pez burrito	1	awesome	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	squat waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10290,7 +10290,7 @@
 10431	shaking Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	Usain Bolt's Retrospecs of the blizzard of the glutton	0		Cold Spell Damage: +25, Food Drop: +100, Initiative: +80, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
-10434	ghostly squat Bird-a-Day calendar	0		Last Available: "2020-01"
+10434	squat ghostly Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	teal reassuring electrified arcane researcher's supercool wizardly Powerful Glove	0		Mysticality: +25, Moxie Percent: +20, Experience Percent (Mysticality): +10, Spooky Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
@@ -10300,7 +10300,7 @@
 10443	Driplet	0		
 10444	upside-down blue drippy snail shell	0		
 10445	normal fuchsia drippy nugget	3	drippy	
-10446	smooth fancy teal glass of drippy wine	4	drippy	Effect: "Got Your Boots On", Effect Duration: 50
+10446	fancy smooth teal glass of drippy wine	4	drippy	Effect: "Got Your Boots On", Effect Duration: 50
 10447	stale drippy caviar	4	drippy	
 10448	bite-sized decent drippy plum(?)	1	drippy	
 10449	pulsating drippy stake of the businessman	0		Meat Drop: +50, Single Equip
@@ -10329,7 +10329,7 @@
 10472	educational bony back shell	0		Experience: +1
 10473	frosty button	0		Single Equip
 10474	galvanized wobbly blooper ink	0		Effect: "Flaming Weapon", Effect Duration: 28
-10475	jittery twirling coin	0		
+10475	twirling jittery coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
 10478	plastic doll arms	0		
@@ -10339,11 +10339,11 @@
 10482	packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
-10485	green spinning bulky free-range mushroom	0		Last Available: "2020-03"
+10485	spinning green bulky free-range mushroom	0		Last Available: "2020-03"
 10486	blue free-range mushroom	0		Last Available: "2020-03"
 10487	tumbling immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	decent small enchanted mushroom filet	2	good	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 10, Last Available: "2020-03"
+10489	small enchanted decent mushroom filet	2	good	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 10, Last Available: "2020-03"
 10490	blurry mushroom slab	0		Last Available: "2020-03"
 10491	dehydrated mushroom tea	1		Last Available: "2020-03"
 10492	drinkable irresponsibly strong mushroom whiskey	7	good	Last Available: "2020-03"
@@ -10378,7 +10378,7 @@
 10521	drippy pigment	0		
 10522	drippy bromide	0		
 10523	blurry drippy flux	0		
-10524	gray skewed drippy stein	0		
+10524	skewed gray drippy stein	0		
 10525	boozy drinkable drippy pilsner	5	drippy	
 10526	pulsating drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
@@ -10477,7 +10477,7 @@
 10621	greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
-10624	shaking fuchsia twirling onyx queen	0		Last Available: "2020-09"
+10624	shaking twirling fuchsia onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
@@ -10506,7 +10506,7 @@
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	lime green greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	shaking subscription cocoa dispenser	0		Last Available: "2020-12"
-10653	energized tarnished blinking shaking fortifying hot cocoa	0		Effect: "Fungal Flambé", Effect Duration: 14, Last Available: "2020-12"
+10653	energized tarnished shaking blinking fortifying hot cocoa	0		Effect: "Fungal Flambé", Effect Duration: 14, Last Available: "2020-12"
 10654	moist nitrogenated boiling hot cocoa	0		Effect: "Christmessy", Effect Duration: 54, Last Available: "2020-12"
 10655	extra-corrupted cool hot cocoa	0		Effect: "Minerva's Zen", Effect Duration: 29, Last Available: "2020-12"
 10656	magnetized double-polarized overly-fancy hot cocoa	0		Effect: "Scrappy, Shadowy", Effect Duration: 59, Last Available: "2020-12"
@@ -10515,8 +10515,8 @@
 10659	blue Book of Old-Timey Carols of extreme caution	0		Monster Level: [-25*event(December)], Last Available: "2020-12"
 10660	olive quilted Crimbo smile	0		Damage Absorption: [+40*event(December)], Last Available: "2020-12"
 10661	supercharged SalesCo sample kit	0		Maximum MP Percent: [+30*event(December)], Last Available: "2020-12"
-10662	diffused quantum huge shaking candy harmonica	0		Effect: "Stregngth of the Gnome", Effect Duration: 21, Last Available: "2020-12"
-10663	adjusted blurry cyan sugar	0		Effect: "Broken Bone Nubs", Effect Duration: 43, Last Available: "2020-12"
+10662	diffused quantum shaking huge candy harmonica	0		Effect: "Stregngth of the Gnome", Effect Duration: 21, Last Available: "2020-12"
+10663	adjusted cyan blurry sugar	0		Effect: "Broken Bone Nubs", Effect Duration: 43, Last Available: "2020-12"
 10664	moist multi-level marzipan	0		Effect: "Sleazy Hands", Effect Duration: 50, Last Available: "2020-12"
 10665	cool plastic Crimbo caroler	0		Moxie: +5, Last Available: "2020-12"
 10666	plastic multi-level marketer of Leguizamo	0		Monster Level: +20, Last Available: "2020-12"
@@ -10569,11 +10569,11 @@
 10713	red The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	blurry The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	stale and pepper (stale)	4	decent	Last Available: "2020-12"
-10716	hand-crafted watered-down cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
+10716	watered-down hand-crafted cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	purple nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	jittery goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	perfectly mixed watered-down skewed barrel-aged eggnog	2	super ultra EPIC	Last Available: "2020-12"
+10720	watered-down perfectly mixed skewed barrel-aged eggnog	2	super ultra EPIC	Last Available: "2020-12"
 10721	diet adequate blurry hand-crafted candy cane	1	good	Last Available: "2020-12"
 10722	flavorless olive drive-thru burger	4	decent	Last Available: "2020-12"
 10723	lousy Boulevardier cocktail	4	decent	Last Available: "2020-12"
@@ -10598,16 +10598,16 @@
 10742	oxidized deionized irradiated battery (9-Volt)	0		Effect: "Fancy Feasted", Effect Duration: 26, Last Available: "2021-03"
 10743	altered battery (lantern)	0		Effect: "Liquid Luck", Effect Duration: 23, Last Available: "2021-03"
 10744	altered alkaline red battery (car)	0		Effect: "Punchy, Murdery", Effect Duration: 56, Last Available: "2021-03"
-10745	huge pulsating cryptocloak	0		Last Available: "2025-12"
+10745	pulsating huge cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
 10747	practically non-alcoholic tolerable yellow marshmallow bomb	1	good	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	upside-down shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	teal plate	0		Familiar Weight: +5
-10752	enhanced mirror upside-down short beer	0		Effect: "Billiards Belligerence", Effect Duration: 32, Last Available: "2021-05"
+10752	enhanced upside-down mirror short beer	0		Effect: "Billiards Belligerence", Effect Duration: 32, Last Available: "2021-05"
 10753	polarized dry short stack of pancakes	0		Effect: "Irresistible Resolve", Effect Duration: 50, Last Available: "2021-05"
-10754	modified Vulcanized spinning upside-down short stick of butter	0		Effect: "Uncaged Power", Effect Duration: 16, Last Available: "2021-05"
+10754	modified Vulcanized upside-down spinning short stick of butter	0		Effect: "Uncaged Power", Effect Duration: 16, Last Available: "2021-05"
 10755	tarnished short glass of water	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 27, Last Available: "2021-05"
 10756	ionized moist blinking short	0		Effect: "Cockroach Scurry", Effect Duration: 15, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
@@ -10648,7 +10648,7 @@
 10792	empty nacho cheese can	0		Water: 1
 10793	literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
-10795	squat yellow pump grease	0		
+10795	yellow squat pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	squat Van der Graaf deadly beefcake's industrial fire extinguisher of the scaredy-cat of the brazier of incineration	0		Muscle: +25, Weapon Damage: +5, Monster Level: -15, Hot Spell Damage: 75, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	yellow The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
@@ -10676,7 +10676,7 @@
 10820	adequate bowl of prescription candy	4	good	Last Available: "2021-12"
 10821	tasty fishcake	4	awesome	Last Available: "2021-12"
 10822	adequate bone broth	4	good	Last Available: "2021-12"
-10823	diet normal star pop	1	good	Last Available: "2021-12"
+10823	normal diet star pop	1	good	Last Available: "2021-12"
 10824	perfectly mixed huge Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
 10825	tolerable Doc's Smartifying Wine	3	good	Last Available: "2021-12"
 10826	lousy Doc's Limbering Wine	3	decent	Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	Temple Grandin's cozy scarf	0		Familiar Weight: +7, Last Available: "2021-12"
-10852	normal huge huge Crimbo cookie	6	good	Last Available: "2023-06"
+10852	huge normal huge Crimbo cookie	6	good	Last Available: "2023-06"
 10853	oxidized liquefied fleshy putty	0		Effect: "Natural 20", Effect Duration: 35, Last Available: "2021-12"
 10854	groovy third ear	0		Moxie Percent: +10, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	avaricious perfumed MacGyver's can of mixed everything	0		Maximum MP: +100, Stench Resistance: +5, Meat Drop: +30, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	mirror the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	super-sized adequate twirling meatball	5	good	Last Available: "2021-12"
+10876	adequate super-sized twirling meatball	5	good	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10739,7 +10739,7 @@
 10883	compressed astral energy drink	1		Effect: "Dirty Pear", Effect Duration: 45
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	flame-retardant magnifying glass of the storm of the blizzard	0		Maximum MP Percent: +40, Cold Spell Damage: +25, Hot Resistance: +1, Last Available: "2022-12"
-10886	tolerable distilled void lager	5	good	Last Available: "2022-12"
+10886	distilled tolerable void lager	5	good	Last Available: "2022-12"
 10887	rotten skewed void burger	3	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	olive medical-grade healthy supercool void shard of mayonnaise	0		Moxie Percent: +20, Maximum HP Percent: +20, Sleaze Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2022-12"
@@ -10748,9 +10748,9 @@
 10892	combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	gray combat lover's locket of terror	0		Spooky Spell Damage: +10, Single Equip, Last Available: "2022-02"
 10894	Thwaitgold protozoa statuette	0		
-10895	mirror yellow grey gosling	0		Free Pull, Last Available: "2022-03"
+10895	yellow mirror grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	twirling grey down vest	0		Experience (familiar): +2
-10897	spinning blurry trojan horseshoe	0		Last Available: "2025-12"
+10897	blurry spinning trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	reassuring careful unbreakable umbrella (broken) of the wise owl of horror	0		Mysticality: +20, Monster Level: -10, Spooky Spell Damage: +25, Spooky Resistance: +1
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
@@ -10774,17 +10774,17 @@
 10918	Thwaitgold harvestman statuette	0		
 10919	twirling packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	rosewater-soaked rosy-cheeked June cleaver of the brute	0		Muscle Percent: +30, Maximum HP Percent: +30, Stench Resistance: +3, Attacks Can't Miss, Last Available: "2022-06"
-10921	irresponsibly strong mediocre red Dad's brandy	6	decent	Last Available: "2022-06"
+10921	mediocre irresponsibly strong red Dad's brandy	6	decent	Last Available: "2022-06"
 10922	Herculean teacher's pen	0		Experience (Muscle): +1, Item Drop: +5, Last Available: "2022-06"
 10923	rotten fire-roasted lake trout	3	crappy	Last Available: "2022-06"
 10924	huge spoiled bouncing squat guilty sprout	7	crappy	Last Available: "2022-06"
 10925	weightlifter's mother's necklace of the bloodbag	0		Muscle: +15, Maximum HP: +100, Last Available: "2022-06"
 10926	galvanized tumbling trampled ticket stub	0		Effect: "Hagg-ard", Effect Duration: 53, Last Available: "2022-06"
-10927	quadruple-ionized purple skewed savings bond	0		Effect: "Burning Ears", Effect Duration: 49, Last Available: "2022-06"
+10927	quadruple-ionized skewed purple savings bond	0		Effect: "Burning Ears", Effect Duration: 49, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	blue designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	blue designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	mixed huge pulsating sweat-ade	1		Effect: "Taurus Rising", Effect Duration: 10, Last Available: "2022-07"
-10931	twirling red unopened stillsuit	0		Free Pull, Last Available: "2022-08"
+10931	red twirling unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	dinosaur scale	0		
@@ -10816,7 +10816,7 @@
 10960	dry polymerized colloidal autumn dollar	0		Effect: "Shortened", Effect Duration: 18, Last Available: "2022-10"
 10961	narrow Usain Bolt's curative stylish autumn leaf pendant	0		Moxie: +25, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
 10962	powdered cyan autumn breeze	1		Effect: "Ancestral Disapproval", Effect Duration: 25, Last Available: "2022-10"
-10963	altered purple twirling jittery autumn years wisdom	0		Effect: "Dilated Pupils", Effect Duration: 36, Last Available: "2022-10"
+10963	altered jittery twirling purple autumn years wisdom	0		Effect: "Dilated Pupils", Effect Duration: 36, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	practically non-alcoholic aged mirror ghostly Oopsie IPA	1	awesome	Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
@@ -10830,29 +10830,29 @@
 10974	rotten Pete's wiley whey bar	3	crappy	Last Available: "2022-11"
 10975	enchanted spoiled Pete's rich ricotta	3	crappy	Effect: "Dwarven Hardiness", Effect Duration: 40, Last Available: "2022-11"
 10976	aged Boris's beer	3	awesome	Last Available: "2022-11"
-10977	rotten upside-down olive honey bun of Boris	3	crappy	Last Available: "2022-11"
+10977	rotten olive upside-down honey bun of Boris	3	crappy	Last Available: "2022-11"
 10978	flavorless Boris's bread	3	decent	Last Available: "2022-11"
-10979	lime green Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	twirling blurry lime green Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	squat Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	pulsating Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	huge shaking Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	lime green Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	twirling lime green blurry Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	squat Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	pulsating Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	shaking huge Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	adequate baked veggie ricotta casserole	3	good	Last Available: "2022-11"
 10989	flavorless plain calzone	4	decent	Last Available: "2022-11"
 10990	moldy roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	normal narrow Pizza of Legend	3	good	Last Available: "2022-11"
 10992	huge spoiled narrow Calzone of Legend	6	crappy	Last Available: "2022-11"
-10993	pulsating Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	squat Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	lime green Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	jittery Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	blurry Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	pulsating Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	squat Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	lime green Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	jittery Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	blurry Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	miniature moldy Deep Dish of Legend	2	crappy	Last Available: "2022-11"
 11001	red deed to Oliver's Place	0		Free Pull
 11002	squat drink chit	0		
@@ -10867,11 +10867,11 @@
 11011	gator shades of wisdom of extreme caution	0		Mysticality: +15, Monster Level: -25, Single Equip
 11012	red milk cap	0		
 11013	irresponsibly strong drinkable Charleston Choo-Choo	9	good	
-11014	acceptable practically non-alcoholic Velvet Veil	1	good	
+11014	practically non-alcoholic acceptable Velvet Veil	1	good	
 11015	perfectly mixed mirror Marltini	4	EPIC	
 11016	bad Strong, Silent Type	3	decent	
 11017	acceptable Mysterious Stranger	3	good	
-11018	acceptable weak upside-down Champagne Shimmy	2	good	
+11018	weak acceptable upside-down Champagne Shimmy	2	good	
 11019	the Sot's parcel	0		
 11020	prompt zippy ceramic cestus	0		Initiative: +20, Adventures: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
 11021	narrow inspector's chaotic sinister ceramic centurion shield	0		Spell Damage: +10, Spell Critical Percent: +10, Item Drop: +15, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
@@ -10889,7 +10889,7 @@
 11033	supercharged dance instructor's chiffon chaps of the ox	0		Muscle: +20, Experience Percent (Moxie): +10, Maximum MP Percent: +30, Last Available: "2023-12"
 11034	powdered upside-down spinning chiffon carbage	1		Last Available: "2023-12"
 11035	extra-boiled adjusted anodized chiffon lemon	0		Effect: "El Vibrations", Effect Duration: 33
-11036	bland bouncing wobbly chocomotive	3	decent	Last Available: "2022-12"
+11036	bland wobbly bouncing chocomotive	3	decent	Last Available: "2022-12"
 11037	spoiled freightcake	3	crappy	Last Available: "2022-12"
 11038	acceptable cabooze	3	good	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10922,16 +10922,16 @@
 11066	Crimbo crystal shards	0		
 11067	hand-crafted jittery tumbling jittery dregs of a Crimbo cocktail	4	EPIC	
 11068	lost elf luggage	0		
-11069	mirror gray Trainbot luggage hook	0		Single Equip
+11069	gray mirror Trainbot luggage hook	0		Single Equip
 11070	decent pulsating honey-drenched ham slice	4	good	
-11071	fancy artisanal fortified olive mostly-empty bottle of cookie wine	5	EPIC	Effect: "Radiant Personality", Effect Duration: 35
+11071	fortified fancy artisanal olive mostly-empty bottle of cookie wine	5	EPIC	Effect: "Radiant Personality", Effect Duration: 35
 11072	rotten bite-sized Crimbo food scraps	1	crappy	
 11073	teal arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	normal fancy steamed oyster	3	good	Effect: "Experimental Effect G-9", Effect Duration: 5
+11078	fancy normal steamed oyster	3	good	Effect: "Experimental Effect G-9", Effect Duration: 5
 11079	really nice lump of coal	0		
 11080	twirling deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
@@ -10953,14 +10953,14 @@
 11097	lousy squat nice warm beer	3	decent	
 11098	grubby woolball	0		
 11099	blue Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
-11100	olive huge packet of rock seeds	0		Last Available: "2023-01"
+11100	huge olive packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
 11102	denatured upside-down fruity pebble	1		Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
-11107	upside-down maroon whet stone	0		Last Available: "2023-01"
+11107	maroon upside-down whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	green chocolate covered ping-pong ball	0		
@@ -10974,22 +10974,22 @@
 11119	enhanced double-altered galvanized five-fingered fern resin	0		Effect: "Mitre Cut", Effect Duration: 33, Last Available: "2023-02"
 11120	moldy enchanted super good fruit	4	crappy	Effect: "Triangle, Man", Effect Duration: 50, Last Available: "2023-02"
 11121	mixed energized spores	1		Last Available: "2023-02"
-11122	medical-grade hot pepper of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Lantern Element: "Hot", Last Available: "2023-02"
+11122	medical-grade hot pepper of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-02", Lantern Element: "Hot"
 11123	deionized wet ionized bouncing out-of-work circus flea	0		Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	vacuum-sealed wet yellow fire ant pheromones	0		Effect: "Full-Body Tan", Effect Duration: 12, Last Available: "2023-02"
 11126	ionized flapper fly	0		Effect: "Yuletide Industry", Effect Duration: 12, Last Available: "2023-02"
-11127	special perfectly mixed irresponsibly strong shot of wasp venom	9	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 30, Last Available: "2023-02"
+11127	perfectly mixed special irresponsibly strong shot of wasp venom	9	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 30, Last Available: "2023-02"
 11128	denatured filled mosquito	0		Effect: "Berry Experiential", Effect Duration: 28, Last Available: "2023-02"
 11129	galvanized double-magnetized bouncing spinning shim of shame shale	0		Effect: "Beta Carotene Overdose", Effect Duration: 33, Last Available: "2023-02"
 11130	liquefied pebble of proud pyrite	0		Effect: "Mer-kinny Flavor", Effect Duration: 13, Last Available: "2023-02"
-11131	wet energized skewed teal pile of gritty sand	0		Effect: "Discomfited", Effect Duration: 17, Last Available: "2023-02"
+11131	wet energized teal skewed pile of gritty sand	0		Effect: "Discomfited", Effect Duration: 17, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	energized activated skewed ghostly angry agate	0		Effect: "Tomato Power", Effect Duration: 11, Last Available: "2023-02"
 11134	flattened ionized ionized purple lump of loyal latite	0		Effect: "Adrenaline Rush", Effect Duration: 47, Last Available: "2023-02"
-11135	huge yummy shadow sausage	9	awesome	Last Available: "2023-03"
+11135	yummy huge shadow sausage	9	awesome	Last Available: "2023-03"
 11136	shaking rosy-cheeked shadow skin of temperance	0		Maximum HP Percent: +30, Sleaze Resistance: +5, Last Available: "2023-03"
-11137	enhanced galvanized ghostly shaking shadow flame	0		Effect: "Improprie Tea", Effect Duration: 55, Last Available: "2023-03"
+11137	enhanced galvanized shaking ghostly shadow flame	0		Effect: "Improprie Tea", Effect Duration: 55, Last Available: "2023-03"
 11138	half-sized bland shadow bread	2	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	watered-down drinkable shadow fluid	2	good	Last Available: "2023-03"
@@ -11035,7 +11035,7 @@
 11180	shadow monocle of the cougar of extreme caution of incineration	0		Moxie: +20, Monster Level: -25, Hot Spell Damage: +50, Single Equip
 11181	yellow shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	flavorless shadow hot dog	3	decent	
-11183	artisanal practically non-alcoholic shadow martini	1	EPIC	
+11183	practically non-alcoholic artisanal shadow martini	1	EPIC	
 11184	denatured twirling shadow pill	1		
 11185	jittery shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	baleful replica Jurassic Parka of bravery	0		Spell Damage: +25, Spooky Resistance: +5
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	jittery replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	fuchsia inspector's rosewater-soaked replica Cincho de Mayo of Gandalf of mayonnaise	0		Spell Critical Percent: +20, Sleaze Spell Damage: +50, Stench Resistance: +3, Item Drop: +15, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11124,7 +11124,7 @@
 11269	blurry Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	narrow VHS Tape	0		Last Available: "2023-06"
 11271	polarized altered wobbly maroon scroll of minor invulnerability	0		Effect: "Educated (Sorta)", Effect Duration: 67, Last Available: "2023-06"
-11272	pulsating gray Lapis Lazuli	0		Last Available: "2023-06"
+11272	gray pulsating Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	mirror Arrow (+1)	0		Last Available: "2023-06"
@@ -11159,7 +11159,7 @@
 11304	upside-down replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	spoiled gigantic watermelon	10	crappy	
+11307	gigantic spoiled watermelon	10	crappy	
 11308	squat watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
@@ -11170,12 +11170,12 @@
 11315	bouncing hardened dangerous toothy trousers	0		Weapon Damage: +10, Damage Reduction: 3
 11316	stale pulsating banana split	3	decent	
 11317	handful of toilet paper	0		
-11318	skewed pulsating Mrs. Rush	0		
+11318	pulsating skewed Mrs. Rush	0		
 11319	lime green pulsating medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	practically non-alcoholic perfectly mixed upside-down bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	
 11321	miser's fireproof baywatch of Flo-Jo	0		Hot Resistance: +3, Meat Drop: +10, Initiative: +100, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	maroon skewed twirling Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	twirling skewed maroon Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	huge Thwaitgold fairyfly statue	0		
@@ -11185,7 +11185,7 @@
 11330	distilled twirling sparkling orb	1		
 11331	modified hardening cream	1		
 11332	vaporized blue pool shark hair oil	1		
-11333	twirling pulsating cyan book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
+11333	pulsating cyan twirling book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
@@ -11213,7 +11213,7 @@
 11358	twirling smoldering leafcutter ant egg	0		
 11359	family-friendly rosewater-soaked therapeutic studded baleful brainy leaf crown	0		Mysticality: +5, Spell Damage: +25, Damage Absorption: +80, Stench Resistance: +3, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 11360	delicious leafy browns	4	awesome	
-11361	nitrogenated shaking skewed autumnic balm	0		Effect: "Motion", Effect Duration: 31
+11361	nitrogenated skewed shaking autumnic balm	0		Effect: "Motion", Effect Duration: 31
 11362	altered coping juice	0		Effect: "Full of Wist", Effect Duration: 39
 11363	pulsating Annie Oakley's grievous Herculean beefcake's candy cane sword cane of the bloodbag	0		Muscle: +25, Experience (Muscle): +1, Weapon Damage Percent: +50, Maximum HP: +100, Critical Hit Percent: +20, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
@@ -11226,11 +11226,11 @@
 11371	clerical automa-core	0		
 11372	handful of Boltsmann bearings	0		
 11373	Spring Bros. solenoid	0		
-11374	fuchsia huge Spring Bros. ID badge	0		
+11374	huge fuchsia Spring Bros. ID badge	0		
 11375	tumbling Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	massive adequate blue upside-down pickled bread	9	good	Last Available: "2023-12"
+11378	massive adequate upside-down blue pickled bread	9	good	Last Available: "2023-12"
 11379	decent super-sized bouncing salted mutton	5	good	Last Available: "2023-12"
 11380	yummy corned beet	3	awesome	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11275,11 +11275,11 @@
 11420	double-paned beefcake's Crimbuccaneer tavern swab of doom	0		Muscle: +25, Spooky Spell Damage: +50, Cold Resistance: +5, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	bad old-school pirate grog	4	decent	Last Available: "2023-12"
-11423	half-sized rotten narrow grog nuts	2	crappy	Last Available: "2023-12"
+11423	rotten half-sized narrow grog nuts	2	crappy	Last Available: "2023-12"
 11424	cyan family-friendly stiffened sawed-off blunderbuss of chilblains	0		Damage Reduction: 1, Cold Damage: +25, Sleaze Resistance: +1, Last Available: "2023-12"
 11425	lousy officer's nog	3	decent	Last Available: "2023-12"
 11426	shaking peppermint bomb	0		Last Available: "2023-12"
-11427	huge decent skewed maroon sundae ration	9	good	Last Available: "2023-12"
+11427	decent huge maroon skewed sundae ration	9	good	Last Available: "2023-12"
 11428	stale peppermint tack	3	decent	Last Available: "2023-12"
 11429	pulsating Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	flavorless whalesteak	3	decent	Last Available: "2023-12"
@@ -11312,22 +11312,22 @@
 11457	blinking vibrating dangerous sage Elvish underarmor	0		Mysticality Percent: +10, Weapon Damage: +10, Maximum MP Percent: +10, Single Equip, Last Available: "2023-12"
 11458	fortified Crimbuccaneer bombjacket of the brute	0		Muscle Percent: +30, Damage Absorption: +60, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	rotten sugarplum ration	3	crappy	Last Available: "2023-12"
-11460	immense enchanted adequate pulsating gingerbread nylons	6	good	Effect: "Super Accuracy", Effect Duration: 45, Last Available: "2023-12"
-11461	special adequate rum-soaked fruitcake	4	good	Effect: "Ruthlessly Efficient", Effect Duration: 35, Last Available: "2023-12"
+11460	immense adequate enchanted pulsating gingerbread nylons	6	good	Effect: "Super Accuracy", Effect Duration: 45, Last Available: "2023-12"
+11461	adequate special rum-soaked fruitcake	4	good	Effect: "Ruthlessly Efficient", Effect Duration: 35, Last Available: "2023-12"
 11462	stale diet lime	1	decent	Last Available: "2023-12"
 11463	spoiled gingerbread pirate	3	crappy	Last Available: "2023-12"
 11464	big normal fruit-stuffed rumcake	5	good	Last Available: "2023-12"
 11465	artisanal mulled wine	3	EPIC	Last Available: "2023-12"
-11466	fancy bad Swedish coffee	3	decent	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 15, Last Available: "2023-12"
+11466	bad fancy Swedish coffee	3	decent	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 15, Last Available: "2023-12"
 11467	acceptable canteen of eggnog	4	good	Last Available: "2023-12"
 11468	lousy hot wine	3	decent	Last Available: "2023-12"
 11469	aged bouncing Jamaican coffee	3	awesome	Last Available: "2023-12"
-11470	artisanal practically non-alcoholic flask of egggrog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11470	practically non-alcoholic artisanal flask of egggrog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11471	pulsating Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	enchanted delicious cyan yule grog	3	awesome	Effect: "Improprie Tea", Effect Duration: 10, Last Available: "2023-12"
-11475	enchanted half-sized stale wet tack	2	decent	Effect: "Emotion Sickness", Effect Duration: 45, Last Available: "2023-12"
+11475	stale enchanted half-sized wet tack	2	decent	Effect: "Emotion Sickness", Effect Duration: 45, Last Available: "2023-12"
 11476	small flavorless upside-down whalecake	2	decent	Last Available: "2023-12"
 11477	flame-wreathed Temple Grandin's gunwale whalegun of the detective	0		Familiar Weight: +7, Hot Spell Damage: +10, Item Drop: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	special drinkable and claret	3	good	Effect: "Winning Smile", Effect Duration: 40, Last Available: "2023-12"
@@ -11382,8 +11382,8 @@
 11527	non-boiled cold-filtered vacuum-sealed crepe paper peanut candy	0		Effect: "Square to be Hip", Effect Duration: 51
 11528	tumbling dog trainer's rock-hard petrified wood war pike	0		Damage Reduction: 5, Experience (familiar): +1, Last Available: "2025-12"
 11529	forbidden petrified wood waist protector of Calamity Jane	0		Spell Damage Percent: +50, Critical Hit Percent: +15, Single Equip, Last Available: "2025-12"
-11530	double-paned petrified wood wizard's pouch of the glutton	0		Cold Resistance: +5, Food Drop: +100, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	sizzling cool petrified wood water purifier	0		Moxie: +5, Hot Damage: +10, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	double-paned petrified wood wizard's pouch of the glutton	0		Cold Resistance: +5, Food Drop: +100, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	sizzling cool petrified wood water purifier	0		Moxie: +5, Hot Damage: +10, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	sharpshooter's petrified wood whoopie panama of the overflowing toilet	0		Critical Hit Percent: +10, Stench Spell Damage: +50, Last Available: "2025-12"
 11533	perfumed experienced petrified wood walking pants	0		Experience: +2, Stench Resistance: +5, Last Available: "2025-12"
 11534	modified tumbling petrified wood waste parts	1		Last Available: "2025-12"
@@ -11425,9 +11425,9 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	twirling wobbly Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	normal small ghostly yam	2	good	Last Available: "2024-05"
-11574	enchanted watered-down acceptable yam martini	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2024-05"
-11575	mediocre watered-down sweet potato o' mine	2	decent	Last Available: "2024-05"
+11573	small normal ghostly yam	2	good	Last Available: "2024-05"
+11574	enchanted acceptable watered-down yam martini	2	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 35, Last Available: "2024-05"
+11575	watered-down mediocre sweet potato o' mine	2	decent	Last Available: "2024-05"
 11576	perfectly mixed Southern yam	3	EPIC	Last Available: "2024-05"
 11577	fancy distilled mediocre sweet potato punch	5	decent	Effect: "Hot Blooded", Effect Duration: 20, Last Available: "2024-05"
 11578	snack-sized adequate Mayam spinach	2	good	Last Available: "2024-05"
@@ -11439,28 +11439,28 @@
 11584	family-friendly crafty furry yam buckler of the businessman	0		Maximum MP: +10, Sleaze Resistance: +1, Meat Drop: +50, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	Sherlock's inspector's yamtility belt of the ox	0		Muscle: +20, Item Drop: 40, Lasts Until Rollover, Last Available: "2024-05"
-11587	flavorless special yam slider	4	decent	Effect: "Strength of Ten Ettins", Effect Duration: 15, Last Available: "2024-05"
-11588	tiny bland pulsating yam mayo	1	decent	Last Available: "2024-05"
-11589	miniature flavorless yam burrito	2	decent	Last Available: "2024-05"
+11587	special flavorless yam slider	4	decent	Effect: "Strength of Ten Ettins", Effect Duration: 15, Last Available: "2024-05"
+11588	bland tiny pulsating yam mayo	1	decent	Last Available: "2024-05"
+11589	flavorless miniature yam burrito	2	decent	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	shaking aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	super-sized stale narrow mini kiwi	5	decent	Last Available: "2024-06"
+11594	stale super-sized narrow mini kiwi	5	decent	Last Available: "2024-06"
 11595	ghostly jittery greedy Fonzie's Rosewater's mini kiwi bikini	0		Mysticality Percent: +30, Experience (Moxie): +1, Meat Drop: +20, Last Available: "2024-06"
 11596	lousy mini kiwitini	3	decent	Last Available: "2024-06"
 11597	spinning mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	hardened dangerous mini kiwi silicon tiepin of dire peril	0		Weapon Damage: 30, Damage Reduction: 3
 11600	blurry mini kiwi tipi	0		
-11601	enchanted decent mini kiwi digitized cookies	3	good	Effect: "Sugar, Hello", Effect Duration: 35
+11601	decent enchanted mini kiwi digitized cookies	3	good	Effect: "Sugar, Hello", Effect Duration: 35
 11602	drinkable mini kiwi intoxicating spirits	4	good	
 11603	polymerized quadruple-ionized altered mini kiwi antimilitaristic hippy petition	0		Effect: "Stick Emporium Membership", Effect Duration: 65
 11604	extra-unsweetened polymerized mini kiwi illicit antibiotic	0		Effect: "Boschface", Effect Duration: 44
 11605	mansplainer's fortified mini kiwi whipping stick	0		Damage Absorption: +60, Monster Level: +15
 11606	Jack Frost's mini kiwi icepick	0		Cold Spell Damage: +50
 11607	moist diffused twirling mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Orchid Blood", Effect Duration: 39
-11608	pulsating blurry packaged Roman Candelabra	0		Free Pull
+11608	blurry pulsating packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	blue protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
@@ -11471,8 +11471,8 @@
 11616	lime green flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	rotten bacteria bisque	3	crappy	
-11619	immense flavorless narrow ciliophora chowder	7	decent	
-11620	bland massive cream of chloroplasts	8	decent	
+11619	flavorless immense narrow ciliophora chowder	7	decent	
+11620	massive bland cream of chloroplasts	8	decent	
 11621	purple synaptic soup	0		
 11622	muscular soup	0		
 11623	mirror flagellate soup	0		
@@ -11487,7 +11487,7 @@
 11632	upside-down Doll Moll violin case	0		
 11633	pulsating Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	perfectly mixed extra-dry Colera Peste Nebbiolo	5	EPIC	
+11635	extra-dry perfectly mixed Colera Peste Nebbiolo	5	EPIC	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11498,7 +11498,7 @@
 11643	jittery shellacked blade of dismemberment	0		Damage Reduction: 7, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
 11645	maroon Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
-11646	shaking blinking Septapus summoning charm	0		Last Available: "2024-09"
+11646	blinking shaking Septapus summoning charm	0		Last Available: "2024-09"
 11647	structural ember	0		Last Available: "2024-09"
 11648	toasty medical-grade stiffened embers-only jacket	0		Damage Reduction: 1, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-09"
 11649	asbestos-lined bembershoot	0		Hot Resistance: +5, Lasts Until Rollover, Last Available: "2024-09"
@@ -11526,11 +11526,11 @@
 11671	chaotic photo booth supply list of Flo-Jo	0		Spell Critical Percent: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	bouncing peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	decent jittery tumbling whirled peas	3	good	Last Available: "2024-11"
+11674	decent tumbling jittery whirled peas	3	good	Last Available: "2024-11"
 11675	rotten peaza	3	crappy	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	pickled lime green blurry drenchrome 2.0	1		Last Available: "2025-12"
-11678	powdered bouncing twirling Synapse Blaster	1		Last Available: "2025-12"
+11678	powdered twirling bouncing Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	fuchsia quantized familiar experience	0		
@@ -11538,7 +11538,7 @@
 11683	delicious special peasco	3	awesome	Effect: "Hardened Fabric", Effect Duration: 40, Last Available: "2024-11"
 11684	stale snack-sized upside-down piece of cake	2	decent	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
-11686	pulsating maroon Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
+11686	maroon pulsating Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	squat TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	ghostly greasy Herculean deft pirate hook	0		Experience (Muscle): +1, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 11689	hardy occult iron tricorn hat	0		Spell Damage Percent: +25, Maximum HP: +50, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
@@ -11557,7 +11557,7 @@
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	flame-wreathed groggles	0		Hot Spell Damage: +10, Last Available: "2024-12"
-11705	red tumbling pirate dinghy	0		Last Available: "2024-12"
+11705	tumbling red pirate dinghy	0		Last Available: "2024-12"
 11706	spinning blinking anchor bomb	0		Last Available: "2024-12"
 11707	smelly resourceful silky pirate drawers	0		Maximum MP: +50, Stench Spell Damage: +10, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
@@ -11576,7 +11576,7 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	delicious coney haunch	3	awesome	Last Available: "2024-12"
 11723	oxidized altered dark chocolate egg	0		Effect: "Tingly Wrists", Effect Duration: 48, Last Available: "2024-12"
-11724	triple-distilled perfectly mixed moai toai	7	EPIC	
+11724	perfectly mixed triple-distilled moai toai	7	EPIC	
 11725	crafty moaiball of the wise owl of the dark arts	0		Mysticality: +20, Spell Damage Percent: +100, Maximum MP: +10, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	dry enhanced four-leaf potato sprout	0		Effect: "Optimist Primal", Effect Duration: 51, Last Available: "2024-12"
@@ -11600,17 +11600,17 @@
 11745	horrifying steel-toed Congressional Medal of Insanity of the wise owl	0		Mysticality: +20, Damage Reduction: 9, Spooky Damage: +25, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	hand-crafted upside-down Easter grasshopper	4	EPIC	Last Available: "2024-12"
-11748	bad watered-down Irish eggnog	2	decent	Last Available: "2024-12"
+11748	watered-down bad Irish eggnog	2	decent	Last Available: "2024-12"
 11749	aged canteen of jungle juice	3	awesome	Last Available: "2024-12"
 11750	lousy upside-down turchucken	4	decent	Last Available: "2024-12"
 11751	practically non-alcoholic bad mechanically-mulled cider	1	decent	Last Available: "2024-12"
-11752	delicious twirling green holiday trip around the world	4	awesome	Last Available: "2024-12"
+11752	delicious green twirling holiday trip around the world	4	awesome	Last Available: "2024-12"
 11753	stale green chocolate ostrich egg	3	decent	Last Available: "2024-12"
-11754	toothsome miniature beef and cabbage	2	awesome	Last Available: "2024-12"
+11754	miniature toothsome beef and cabbage	2	awesome	Last Available: "2024-12"
 11755	flavorless candy rations	4	decent	Last Available: "2024-12"
-11756	spoiled small special jittery bouncing double-candied yams	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10, Last Available: "2024-12"
-11757	delicious huge spinning Christmas ham	6	awesome	Last Available: "2024-12"
-11758	fancy rotten half-sized holiday smorgasbord	2	crappy	Effect: "Leisurely Amblin'", Effect Duration: 15, Last Available: "2024-12"
+11756	small special spoiled jittery bouncing double-candied yams	2	crappy	Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 10, Last Available: "2024-12"
+11757	huge delicious spinning Christmas ham	6	awesome	Last Available: "2024-12"
+11758	rotten fancy half-sized holiday smorgasbord	2	crappy	Effect: "Leisurely Amblin'", Effect Duration: 15, Last Available: "2024-12"
 11759	bouncing ghostly Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	narrow skewed bejazzled eyepatch of Gandalf	0		Spell Critical Percent: +20, Last Available: "2024-12"
 11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
@@ -11633,7 +11633,7 @@
 11778	boiled blinking mirror clovermint	1		Last Available: "2024-12"
 11779	blurry steel-toed smooth nylon Christmas stockings of dire peril of the bloodbag	0		Moxie: +15, Weapon Damage: +20, Damage Reduction: 9, Maximum HP: +100, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
-11781	electrified flattened lime green bouncing deviled candy egg	0		Effect: "Carrrsmic", Effect Duration: 40, Last Available: "2024-12"
+11781	electrified flattened bouncing lime green deviled candy egg	0		Effect: "Carrrsmic", Effect Duration: 40, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	smelly brainy McHugeLarge duffel bag	0		Mysticality: +5, Stench Spell Damage: +10, Last Available: "2025-01"
 11784	careful healthy McHugeLarge left pole of doom	0		Maximum HP Percent: +20, Monster Level: -10, Spooky Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
@@ -11650,7 +11650,7 @@
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
-11798	red pulsating dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
+11798	pulsating red dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	wobbly dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
@@ -11665,14 +11665,14 @@
 11810	jittery dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	mixed green ghostly psilocyber mushroom	1		Effect: "Stogied", Effect Duration: 40, Last Available: "2025-12"
-11813	huge pulsating dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
+11813	pulsating huge dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	olive dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	bouncing dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	gray huge dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11820	huge gray dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	spinning OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
@@ -11696,9 +11696,9 @@
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
-11844	twirling huge chill gherkin	0		
+11844	huge twirling chill gherkin	0		
 11845	childrens' stapler	0		
-11846	skewed wobbly purple plover's egg	0		
+11846	skewed purple wobbly plover's egg	0		
 11847	flyswatter	0		
 11848	tumbling Thwaitgold cordyceps ant statuette	0		
 11849	heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11708,10 +11708,10 @@
 11853	spinning foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
-11856	blurry mirror sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11856	mirror blurry sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	teal glover liners	0		Pickpocket Chance: +10
-11859	purple ghostly wobbly mosquito speakers	0		Monster Level: +5
+11859	ghostly wobbly purple mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	mixed teal mirror spinning scoop of pre-workout powder	1		Last Available: "2025-03"
@@ -11720,19 +11720,19 @@
 11865	compressed gray pulsating phosphor traces	1		Last Available: "2025-03"
 11866	squat crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
-11868	pulsating red spoon	0		
+11868	red pulsating spoon	0		
 11869	huge unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	diluted upside-down leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	stale Heck ramen	4	decent	Last Available: "2025-03"
 11873	bland burrito	4	decent	Last Available: "2025-03"
-11874	diet moldy small beer brat	1	crappy	Last Available: "2025-03"
-11875	stale small mirror peach pie	2	decent	Last Available: "2025-03"
+11874	moldy diet small beer brat	1	crappy	Last Available: "2025-03"
+11875	small stale mirror peach pie	2	decent	Last Available: "2025-03"
 11876	rotten incredible mini-pizza	3	crappy	Last Available: "2025-03"
 11877	tolerable fancy Divine sidecar	4	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 15, Last Available: "2025-03"
-11878	weak perfectly mixed fancy tangarita sidecar	2	EPIC	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2025-03"
+11878	weak fancy perfectly mixed tangarita sidecar	2	EPIC	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2025-03"
 11879	practically non-alcoholic acceptable gimlet sidecar	1	good	Last Available: "2025-03"
-11880	special drinkable triple-distilled vodka stratocaster sidecar	8	good	Effect: "Capricorn Rising", Effect Duration: 10, Last Available: "2025-03"
+11880	drinkable triple-distilled special vodka stratocaster sidecar	8	good	Effect: "Capricorn Rising", Effect Duration: 10, Last Available: "2025-03"
 11881	aged blinking prussian cathouse sidecar	3	awesome	Last Available: "2025-03"
 11882	practically non-alcoholic bad ghostly Mon Tiki sidecar	1	decent	Last Available: "2025-03"
 11883	green Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
@@ -11770,7 +11770,7 @@
 11915	crown of thorns	0		
 11916	upside-down crafty stylish bycocket	0		Maximum MP: +10
 11917	Thwaitgold mad hatterpillar statuette	0		
-11918	bouncing purple packaged prismatic beret	0		Free Pull
+11918	purple bouncing packaged prismatic beret	0		Free Pull
 11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	spinning flak shield	0		Damage Reduction: 9
 11921	cyan Axis HQ Code	0		
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	jittery ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	decent big blurry wobbly Skeleton Wars rations	5	good	
+11937	big decent blurry wobbly Skeleton Wars rations	5	good	
 11938	hand-crafted skeleton war fuel can	3	EPIC	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11811,7 +11811,7 @@
 11956	clock	0		Last Available: "2025-08"
 11957	up-at-dawn the gun of the ox of horror	0		Muscle: +20, Spooky Spell Damage: +25, Adventures: +5, Last Available: "2025-08"
 11958	bad spirit-forward wine	5	decent	Last Available: "2025-08"
-11960	skewed green really, really nice swimming trunks	0		
+11960	green skewed really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	zippy undersea surveying goggles	0		Initiative: +20, Lasts Until Rollover
 11963	tolerable Ocean-Touched Rum	3	good	
@@ -11824,7 +11824,7 @@
 11970	sea gel	0		
 11971	alkaline skewed octopus ink bladder	0		Effect: "Comprehensively Nourished", Effect Duration: 62
 11972	shaking durable dolphin whistle	0		
-11973	twirling blurry Thwaitgold lobster statuette	0		
+11973	blurry twirling Thwaitgold lobster statuette	0		
 11974	blinking packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	skewed unblemished pearl	0		
@@ -11845,7 +11845,7 @@
 12055	rotten full-sized pumpkin pie	3	crappy	Last Available: "2025-11"
 12056	bad practically non-alcoholic huge vodka cranberry sauce	1	decent	Last Available: "2025-11"
 12057	altered ionized jittery yammed candy	0		Effect: "Feelin' Philosophical", Effect Duration: 69, Last Available: "2025-11"
-12058	adequate snack-sized special treasure chestnut	2	good	Effect: "Buttermilk Boogie", Effect Duration: 30, Last Available: "2025-12"
+12058	special adequate snack-sized treasure chestnut	2	good	Effect: "Buttermilk Boogie", Effect Duration: 30, Last Available: "2025-12"
 12059	lousy weak mulled butter rum	2	decent	Last Available: "2025-12"
 12060	oxidized liquefied ionized huge cinnamon doubloon	0		Effect: "Tomato Power", Effect Duration: 29, Last Available: "2025-12"
 12061	twirling studded plastic left skeleton arm	0		Damage Absorption: +80, Last Available: "2025-12"
@@ -11871,7 +11871,7 @@
 12081	resourceful devilbone rosary	0		Maximum MP: +50, Single Equip, Last Available: "2026-12"
 12082	denatured devilbone chunks	1		Last Available: "2026-12"
 12083	polarized nitrogenated narrow Gehenna tattoo	0		Effect: "Stone-Faced", Effect Duration: 59
-12116	jittery fuchsia burnt incisor	0		Last Available: "2025-12"
+12116	fuchsia jittery burnt incisor	0		Last Available: "2025-12"
 12117	fuchsia pulsating burnt phalange	0		Last Available: "2025-12"
 12118	burnt radius	0		Last Available: "2025-12"
 12119	huge burnt rib	0		Last Available: "2025-12"
@@ -11880,8 +11880,8 @@
 12122	upside-down ghostly cyan deadly extra-thick Crimbo sweater	0		Weapon Damage: +5, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	weak mediocre Steve Abrams' Holiday Sampler Beer	2	decent	Last Available: "2025-12"
-12125	green skewed crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	extra-dry mediocre teal bottle of prize-winning rum	5	decent	Last Available: "2025-12"
+12125	skewed green crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
+12126	mediocre extra-dry teal bottle of prize-winning rum	5	decent	Last Available: "2025-12"
 12127	sizzling careful Santa-Slayer medal of courage	0		Monster Level: -10, Hot Damage: +10, Spooky Resistance: +3, Single Equip, Last Available: "2025-12"
 12128	upside-down Skull of Claus	0		Last Available: "2025-12"
 12129	frozen gray boiling bone marrow	0		Effect: "Ogred and Oublietted", Effect Duration: 25, Last Available: "2025-12"
@@ -11896,7 +11896,7 @@
 12138	greasy crafty fistbone of the wise owl	0		Mysticality: +20, Maximum MP: +10, Sleaze Spell Damage: +10, Last Available: "2025-12"
 12139	censurious Jeselnik's burnt bone belt of the detective	0		Sleaze Damage: +25, Sleaze Resistance: +3, Item Drop: +20, Single Equip, Last Available: "2025-12"
 12140	green frosty scorched skull trophy	0		Cold Spell Damage: +10, Last Available: "2025-12"
-12141	adequate big wing bone	5	good	Last Available: "2025-12"
+12141	big adequate wing bone	5	good	Last Available: "2025-12"
 12142	artisanal high-proof tumbling weak skeleton venom	10	EPIC	Last Available: "2025-12"
 12143	diluted baked bone meal	1		Last Available: "2025-12"
 12144	brainy plastic skeleton rib cage	0		Mysticality: +5, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	Usain Bolt's ship's lantern	0		Initiative: +80, Last Available: "2025-12"
 12170	heat-resistant harpoon pistol of Tarzan of terror	0		Experience (Muscle): +3, Spooky Spell Damage: +10, Last Available: "2025-12"
 12171	decent big traditional gingerloaf	5	good	Last Available: "2025-12"
-12172	artisanal fancy Scotch and eggnog	3	EPIC	Effect: "Ichorous Intensity", Effect Duration: 35, Last Available: "2025-12"
+12172	fancy artisanal Scotch and eggnog	3	EPIC	Effect: "Ichorous Intensity", Effect Duration: 35, Last Available: "2025-12"
 12173	pickled alkaline moist counterskeleton elixir	0		Effect: "Eye of the Seal", Effect Duration: 56, Last Available: "2025-12"
 12174	drinkable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11954,17 +11954,17 @@
 12196	pulsating bolt of fabric	0		Last Available: "2026-03"
 12197	veiny and dress of extreme caution	0		Maximum HP: +10, Monster Level: -25, Last Available: "2026-03"
 12198	bouncing and dress of dire peril of the brazier	0		Weapon Damage: +20, Hot Spell Damage: +25, Last Available: "2026-03"
-12199	activated lime green tumbling dinosaur bone broth	0		Effect: "Fangs and Pangs", Effect Duration: 33, Last Available: "2026-03"
+12199	activated tumbling lime green dinosaur bone broth	0		Effect: "Fangs and Pangs", Effect Duration: 33, Last Available: "2026-03"
 12200	jittery gnawing bone	0		Last Available: "2026-03"
 12201	supercool dinosaur bone club	0		Moxie Percent: +20, Last Available: "2026-03"
 12202	thinker's dinosaur skull helmet of extreme caution	0		Mysticality: +10, Monster Level: -25, Last Available: "2026-03"
 12203	teal zippy Temple Grandin's chaotic dinosaur bone corset	0		Spell Critical Percent: +10, Familiar Weight: +7, Initiative: +20, Last Available: "2026-03"
-12204	weak lousy twirling Pork Elf cough syrup	2	decent	Last Available: "2026-03"
+12204	lousy weak twirling Pork Elf cough syrup	2	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
-12208	skewed blurry Pork Elf toilet	0		Last Available: "2026-03"
-12209	bland immense rat pizza	9	decent	Last Available: "2026-03"
+12208	blurry skewed Pork Elf toilet	0		Last Available: "2026-03"
+12209	immense bland rat pizza	9	decent	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	narrow mirror knitted quilted hoverboard of dire peril	0		Weapon Damage: +20, Damage Absorption: +40, Cold Resistance: +3, Single Equip, Last Available: "2026-03"
 12212	stanky manspreader's sharpshooter's left shark fin	0		Critical Hit Percent: +10, Monster Level: +10, Stench Spell Damage: +25, Last Available: "2026-03"
@@ -11972,8 +11972,8 @@
 12214	powdered ghostly candy bone	1		
 12215	twirling wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	flavorless low-calorie discarded hot dog	1	decent	Last Available: "2026-04"
-12218	distilled mediocre most of a beer	5	decent	Last Available: "2026-04"
+12217	low-calorie flavorless discarded hot dog	1	decent	Last Available: "2026-04"
+12218	mediocre distilled most of a beer	5	decent	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	blurry legendary noodles	0		Last Available: "2026-05"
@@ -11982,10 +11982,10 @@
 12228	jumbo rotten lime green ratbatatouille	5	crappy	
 12229	decent huge teal onigiri	10	good	
 12230	small normal blurry crudit&eacute;s	2	good	
-12231	stale miniature sauced mutton	2	decent	
+12231	miniature stale sauced mutton	2	decent	
 12232	huge moldy hot honey ant	6	crappy	
 12233	delicious upside-down tomb aspic	4	awesome	
-12234	rotten special jittery later tots	3	crappy	Effect: "Abominably Slippery", Effect Duration: 45
+12234	special rotten jittery later tots	3	crappy	Effect: "Abominably Slippery", Effect Duration: 45
 12235	snack-sized spoiled Frutti di Scatoletta	2	crappy	Last Available: "2026-05"
 12236	small moldy Pesto alla Marziano	2	crappy	Last Available: "2026-05"
 12237	normal Arrattabbattabiata	3	good	Last Available: "2026-05"
@@ -11993,14 +11993,14 @@
 12239	normal squat Pasta Grimavera	3	good	Last Available: "2026-05"
 12240	normal small narrow Linguini Ubriacapa	2	good	Last Available: "2026-05"
 12241	yummy ghostly Formica e Pepe	3	awesome	Last Available: "2026-05"
-12242	special rotten half-sized Tubetto Gelatto	2	crappy	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2026-05"
+12242	half-sized special rotten Tubetto Gelatto	2	crappy	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2026-05"
 12243	moldy Gnocci Domani	3	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	spinning scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
-12246	olive pulsating second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
+12246	pulsating olive second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	lime green mega helmet	0		
 12252	asbestos-lined veiny Space Soldier Helmet	0		Maximum HP: +10, Hot Resistance: +5
-12253	adequate jumbo wobbly premium turkey leg	5	good	
+12253	jumbo adequate wobbly premium turkey leg	5	good	
 12254	acceptable practically non-alcoholic styrofoam cup of mead	1	good	
 12255	sword of the wise owl	0		Mysticality: +20
 12256	staff of incineration	0		Hot Spell Damage: +50
@@ -12029,7 +12029,7 @@
 12279	non-moist altered electrified green banana quintessence	0		Effect: "Fungal Flambé", Effect Duration: 28, Last Available: "2026-07"
 12280	acceptable Aesop Daiquiri	4	good	Last Available: "2026-07"
 12281	weak mediocre tumbling Monkey Congress	2	decent	Last Available: "2026-07"
-12282	delicious ghostly shaking watermelon pie	4	awesome	Last Available: "2026-07"
+12282	delicious shaking ghostly watermelon pie	4	awesome	Last Available: "2026-07"
 12283	enhanced fuchsia concentrated watermelon juice	0		Effect: "Mucilaginous Muscle", Effect Duration: 65, Last Available: "2026-07"
 12284	ionized concentrated aerosolized Aqua Citrulanatae	0		Effect: "Extra-Wet", Effect Duration: 66, Last Available: "2026-07"
 12285	acceptable wobbly Melonegroni	4	good	Last Available: "2026-07"

--- a/data/TCRS/TCRS_Pastamancer_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Mongoose_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	enchanted lousy Petite Porter	3	decent	
+-1	lousy enchanted Petite Porter	3	decent	
 -2	artisanal Scrawny Stout	4	EPIC	
 -3	drinkable blurry Infinitesimal IPA	3	good	
--4	lousy irresponsibly strong eggnogtini	7	decent	
+-4	irresponsibly strong lousy eggnogtini	7	decent	
 -5	artisanal weak candycaine	2	EPIC	
 -6	bad jittery braincracker sweet	4	decent	
 -16	fancy bad fermented honey	4	decent	
--17	fancy weak bad bouncing moons-shine	2	decent	
+-17	bad fancy weak bouncing moons-shine	2	decent	
 -18	watered-down mediocre upside-down gin	2	decent	
 -19	delicious narrow maroon ecto-nog	4	awesome	
--20	watered-down mediocre hot toady	2	decent	
+-20	mediocre watered-down hot toady	2	decent	
 -21	hand-crafted hot choculate	3	EPIC	
 -49	lousy bouncing Cyder	3	decent	
 -50	lousy practically non-alcoholic wobbly Oil Nog	1	decent	
 -51	smooth Hi-Octane Peppermint Jet Fuel	3	awesome	
--58	extra-dry acceptable Grimacider	5	good	
--59	weak perfectly mixed Isotope Nog	2	EPIC	
--60	fancy tolerable Mutagin 'n' Tonic	4	good	
--70	strong aged Gin and Herring	5	awesome	
--71	distilled smooth Black and Tan and Red All Over	5	awesome	
+-58	acceptable extra-dry Grimacider	5	good	
+-59	perfectly mixed weak Isotope Nog	2	EPIC	
+-60	tolerable fancy Mutagin 'n' Tonic	4	good	
+-70	aged strong Gin and Herring	5	awesome	
+-71	smooth distilled Black and Tan and Red All Over	5	awesome	
 -72	perfectly mixed Antarctic Ice Tea	4	EPIC	
 -76	artisanal irresponsibly strong CRIMBCO Ribbon Candy Schnapps	9	EPIC	
--77	fancy acceptable blurry CRIMBCO Egg Substitute Nog Substitute	4	good	
+-77	acceptable fancy blurry CRIMBCO Egg Substitute Nog Substitute	4	good	
 -78	hand-crafted narrow CRIMBCO Extreme Braincracker Sour	3	EPIC	
 -82	bad practically non-alcoholic Horseradish-infused Vodka	1	decent	
--83	tolerable weak blinking Jerkitini	2	good	
+-83	weak tolerable blinking Jerkitini	2	good	
 -84	fancy artisanal narrow Desert Island Iced Tea	4	EPIC	
 -88	drinkable mirror twirling Crimbo Saketini	4	good	
 -89	mediocre lime green Crimboku Drop	3	decent	
--90	acceptable distilled upside-down Flaming Crimbo Log	5	good	
+-90	distilled acceptable upside-down Flaming Crimbo Log	5	good	
 -107	perfectly mixed Fortified Eggnog Slurry	3	EPIC	
--108	tolerable maroon ghostly Hot Buttered Rum	4	good	
--109	watered-down acceptable Spicy Hot Chocolate	2	good	
+-108	tolerable ghostly maroon Hot Buttered Rum	4	good	
+-109	acceptable watered-down Spicy Hot Chocolate	2	good	

--- a/data/TCRS/TCRS_Pastamancer_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Mongoose_cafe_food.txt
@@ -2,10 +2,10 @@
 -2	adequate As Jus Gezund Heit	4	good	
 -3	stale blurry Bouillabaise Coucher Avec Moi	3	decent	
 -7	bland gumdrop chow mein	3	decent	
--8	super-sized moldy candy cane pizza	5	crappy	
+-8	moldy super-sized candy cane pizza	5	crappy	
 -9	stale gingerbread stir-fry	3	decent	
--10	diet bland twigs and gravel	1	decent	
--11	adequate immense shoots and leaves	10	good	
+-10	bland diet twigs and gravel	1	decent	
+-11	immense adequate shoots and leaves	10	good	
 -12	decent bowl of unidentifiable goo	3	good	
 -13	toothsome huge gingerbread massacre	7	awesome	
 -14	stale olive It Came From Beyond Dessert	4	decent	
@@ -15,31 +15,31 @@
 -54	decent lime green Gingerborg Hive	3	good	
 -61	delicious gigantic blurry Candy Cane Surprise	8	awesome	
 -62	decent Grimdrop Chow Mein	4	good	
--63	half-sized stale narrow Grimgerbread House	2	decent	
+-63	stale half-sized narrow Grimgerbread House	2	decent	
 -67	bland immense jittery Caviar Carbonara	9	decent	
 -68	toothsome huge Halibut Alfredo	9	awesome	
--69	immense rotten Red Herring Velvet Cake	10	crappy	
+-69	rotten immense Red Herring Velvet Cake	10	crappy	
 -73	spoiled red CRIMBCO Reconstituted Gruel	3	crappy	
 -74	toothsome New and Improved CRIMBCO Reconstituted Gruel	4	awesome	
 -75	spoiled spinning CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	crappy	
 -79	miniature flavorless Brussels Sprout Stir-Fry	2	decent	
 -80	tiny adequate teal Carrot, Cabbage, and Kale Pizza	1	good	
 -81	stale Turnip and Rutabaga Pie	4	decent	
--85	jumbo spoiled spinning green Rainbow Spider Fun Roll	5	crappy	
--86	flavorless snack-sized Vegas Volcano Lava Roll	2	decent	
+-85	spoiled jumbo green spinning Rainbow Spider Fun Roll	5	crappy	
+-86	snack-sized flavorless Vegas Volcano Lava Roll	2	decent	
 -87	normal half-sized Crazy Dragon Shogun Buddha Roll	2	good	
 -92	bland snack-sized basic hot dog	2	decent	
 -93	rotten immense savage macho dog	6	crappy	
 -94	thick normal one with everything	5	good	
--95	stale bite-sized sly dog	1	decent	
--96	flavorless small devil dog	2	decent	
+-95	bite-sized stale sly dog	1	decent	
+-96	small flavorless devil dog	2	decent	
 -97	stale massive chilly dog	7	decent	
--98	moldy immense ghost dog	9	crappy	
+-98	immense moldy ghost dog	9	crappy	
 -99	small flavorless junkyard dog	2	decent	
--100	immense decent wet dog	9	good	
--101	yummy gigantic sleeping dog	7	awesome	
--102	bland small optimal dog	2	decent	
--103	stale enchanted half-sized cyan video games hot dog	2	decent	
+-100	decent immense wet dog	9	good	
+-101	gigantic yummy sleeping dog	7	awesome	
+-102	small bland optimal dog	2	decent	
+-103	stale half-sized enchanted cyan video games hot dog	2	decent	
 -104	decent low-calorie tumbling Peppermint Nutrition Block	1	good	
 -105	adequate blinking Gingerbread Nutrition Block	3	good	
--106	snack-sized decent Cinnamon Nutrition Block	2	good	
+-106	decent snack-sized Cinnamon Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Pastamancer_Opossum.txt
+++ b/data/TCRS/TCRS_Pastamancer_Opossum.txt
@@ -19,7 +19,7 @@
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
 22	studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
-23	spinning blurry green chewing gum on a string	0		
+23	blurry green spinning chewing gum on a string	0		
 24	ten-leaf clover	0		
 25	yellow meat paste	0		
 26	Dolphin King's map	0		
@@ -52,7 +52,7 @@
 53	Tesla stone banjo	0		MP Regen Min: 7, MP Regen Max: 10
 54	gravedigger's cool Disco Banjo	0		Moxie: +5, Spooky Damage: +10, Class: "Disco Bandit"
 55	jaba&ntilde;ero pepper	0		
-56	bouncing twirling hot sauce	0		
+56	twirling bouncing hot sauce	0		
 57	healthy 5-Alarm Saucepan	0		Maximum HP Percent: +20, Class: "Sauceror"
 58	skewed stone turtle	0		
 59	slingshot	0		
@@ -76,8 +76,8 @@
 77	Da Vinci's stick	0		Experience (Mysticality): +5
 78	wool pretty bouquet	0		Cold Resistance: +1
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
-80	huge pulsating blinking fairy gravy boat	0		
-81	bad watered-down ice-cold Willer	2	decent	
+80	pulsating blinking huge fairy gravy boat	0		
+81	watered-down bad ice-cold Willer	2	decent	
 82	ring	0		
 83	shaft	0		
 84	wobbly Orcish meat locker	0		
@@ -114,7 +114,7 @@
 115	tumbling nasty dripping meat crossbow	0		Stench Damage: +5
 116	perfumed hale Bugfinder Blade	0		Maximum HP: +20, Stench Resistance: +5
 117	twirling Gnollish plunger	0		
-118	bouncing teal spring	0		
+118	teal bouncing spring	0		
 119	sprocket	0		
 120	pulsating cog	0		
 121	sprocket assembly	0		
@@ -136,7 +136,7 @@
 137	jittery dope wheels	0		
 138	pulsating ice-cold six-pack	0		
 139	valuable trinket	0		
-140	bouncing ghostly dingy planks	0		
+140	ghostly bouncing dingy planks	0		
 141	dingy dinghy	0		
 142	anticheese	0		
 143	cottage	0		
@@ -175,12 +175,12 @@
 176	blurry disembodied brain	0		
 177	blinking pulsating brainy skull	0		
 178	mirror lime green detective skull	0		
-179	bland big chorizo taco	5	decent	
-180	perfectly mixed fortified ice-cold fotie	5	EPIC	
+179	big bland chorizo taco	5	decent	
+180	fortified perfectly mixed ice-cold fotie	5	EPIC	
 181	baseball	0		
 182	batgut	0		
 183	squat lime green bat wing	0		
-184	red spinning briefcase	0		
+184	spinning red briefcase	0		
 185	fuchsia fat stacks of cash	0		
 186	wobbly bean	0		
 187	loose teeth	0		
@@ -192,7 +192,7 @@
 194	groovy Mr. Accessory	0		Moxie Percent: +10, Softcore Only
 195	upside-down miser's eXtreme nose ring	0		Meat Drop: +10
 196	disassembled clover	0		
-197	red huge rat whisker	0		
+197	huge red rat whisker	0		
 198	red rat appendix	0		
 199	gray ring of bravery	0		Spooky Resistance: +5
 200	rotten blinking rat appendix kabob	4	crappy	
@@ -211,16 +211,16 @@
 213	upside-down executive educational filthy corduroys	0		Experience: +1, Meat Drop: +40, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	tumbling coward's filthy knitted dread sack	0		Monster Level: -20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	blue Uncle Jick's Brownie Mix	0		
-216	massive moldy carob brownies	9	crappy	
+216	moldy massive carob brownies	9	crappy	
 217	flavorless herb brownies	3	decent	
 218	hemp string	0		
 219	necklace chain	0		
-220	skewed wobbly pulsating gnoll teeth	0		
+220	wobbly skewed pulsating gnoll teeth	0		
 221	gnoll-tooth necklace of the scaredy-cat	0		Monster Level: -15
-222	shaking green phat turquoise bead	0		
+222	green shaking phat turquoise bead	0		
 223	phat turquoise bracelet of Tarzan	0		Experience (Muscle): +3
 224	forbidden eyepatch	0		Spell Damage Percent: +50, Familiar Effect: "3xBarrr, cap 6"
-225	rotten blinking spinning tofu casserole	3	crappy	
+225	rotten spinning blinking tofu casserole	3	crappy	
 226	modified cyan can of Red Minotaur	1	EPIC	
 227	arcane researcher's Kentucky-fried meat sword	0		Experience Percent (Mysticality): +10
 228	shaking therapeutic Kentucky-fried meat staff	0		HP Regen Min: 5, HP Regen Max: 7
@@ -238,27 +238,27 @@
 240	scorching Orcish cargo shorts of the cougar	0		Moxie: +20, Hot Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Orcish frat-paddle of Leguizamo	0		Monster Level: +20
 242	moldy upside-down fuchsia	4	crappy	
-243	moldy bite-sized olive grapefruit	1	crappy	
-244	low-calorie flavorless grapes	1	decent	
+243	bite-sized moldy olive grapefruit	1	crappy	
+244	flavorless low-calorie grapes	1	decent	
 245	small tasty olive	2	awesome	
 246	fancy decent tomato	3	good	Effect: "Deadly Lampblade", Effect Duration: 40
 247	huge fermenting powder	0		
 248	lousy spinning salty dog	4	decent	
-249	boozy smooth bouncing red bloody mary	5	awesome	
+249	smooth boozy red bouncing bloody mary	5	awesome	
 250	artisanal screwdriver	4	EPIC	
 251	hand-crafted spirit-forward martini	5	EPIC	
 252	delicious weak skewed tumbling bloody beer	2	awesome	
-253	special boozy smooth shot of schnapps	5	awesome	Effect: "Salamanderenity", Effect Duration: 35
+253	smooth special boozy shot of schnapps	5	awesome	Effect: "Salamanderenity", Effect Duration: 35
 254	aged shot of grapefruit schnapps	4	awesome	
 255	delicious jittery fine wine	4	awesome	
-256	practically non-alcoholic bad blue shot of tomato schnapps	1	decent	
-257	high-proof bad special green extra-spicy bloody mary	7	decent	Effect: "Booooooze", Effect Duration: 25
+256	bad practically non-alcoholic blue shot of tomato schnapps	1	decent	
+257	bad high-proof special green extra-spicy bloody mary	7	decent	Effect: "Booooooze", Effect Duration: 25
 258	dense meat stack	0		
 259	wobbly snake skin	0		
-260	moldy enchanted ghostly White Citadel fries	3	crappy	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 40
+260	enchanted moldy ghostly White Citadel fries	3	crappy	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 40
 261	low-calorie moldy wobbly White Citadel burger	1	crappy	
-262	jumbo rotten piece of wedding cake	5	crappy	
-263	spoiled big chocolate chips	5	crappy	
+262	rotten jumbo piece of wedding cake	5	crappy	
+263	big spoiled chocolate chips	5	crappy	
 264	adequate chocolate chip cookies	3	good	
 265	blinking wholesome satin pants	0		Maximum HP Percent: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	delicious lightning	4	awesome	
@@ -266,7 +266,7 @@
 268	bouncing meat cowboy hat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	slick sword	0		Moxie: +10
 270	picket fence	0		
-271	twisted lime green shaking barbell	1		Effect: "Goldentongue", Effect Duration: 20
+271	twisted shaking lime green barbell	1		Effect: "Goldentongue", Effect Duration: 20
 272	modified concentrated magicalness pill	1		
 273	diluted teal jittery moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
@@ -314,12 +314,12 @@
 316	rotten insanely bean burrito	4	crappy	
 317	flavorless small mirror bean burrito	2	decent	
 318	decent gigantic bean burrito	10	good	
-319	small stale narrow insanely bean burrito	2	decent	
-320	tiny yummy bat haggis	1	awesome	
+319	stale small narrow insanely bean burrito	2	decent	
+320	yummy tiny bat haggis	1	awesome	
 321	miniature normal twirling menudo	2	good	
 322	spoiled wobbly goat cheese	4	crappy	
-323	diet moldy plain pizza	1	crappy	
-324	super-sized decent jittery sausage pizza	5	good	
+323	moldy diet plain pizza	1	crappy	
+324	decent super-sized jittery sausage pizza	5	good	
 325	spoiled red goat cheese pizza	4	crappy	
 326	super-sized flavorless blurry upside-down mushroom pizza	5	decent	
 327	goat	0		
@@ -353,7 +353,7 @@
 355	maroon eXtreme scarf of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	shaking red supercool snowboarder pants	0		Moxie Percent: +20, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	delicious tiny blinking gr8ps	1	awesome	
+358	tiny delicious blinking gr8ps	1	awesome	
 359	adequate t8r tots	4	good	
 360	studded miner's helmet	0		Damage Absorption: +80, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	wobbly gray flame-retardant miner's pants	0		Hot Resistance: +1, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -453,7 +453,7 @@
 455	normal jumbo olive	4	good	
 456	weak acceptable dry martini	2	good	
 457	lightning-fast ye olde golde frontes	0		Initiative: +40, Class: "Disco Bandit", Single Equip
-458	spinning shaking continuum transfunctioner	0		
+458	shaking spinning continuum transfunctioner	0		
 459	pixel	0		
 460	pixel	0		
 461	gray pixel	0		
@@ -466,7 +466,7 @@
 468	pulsating ruby W	0		
 469	wussiness potion	0		
 470	weak smooth mirror Imp Ale	2	awesome	
-471	stale snack-sized squat hot wing	2	decent	
+471	snack-sized stale squat hot wing	2	decent	
 472	diamond-studded cane of the pedagogue	0		Experience: +3, Class: "Disco Bandit"
 473	crutch of the dark arts	0		Spell Damage Percent: +100
 474	jittery cast	0		
@@ -495,10 +495,10 @@
 497	gnatwing	0		
 498	flavorless papaya	4	decent	
 499	olive avaricious Socratic denim axe	0		Experience (Mysticality): +1, Meat Drop: +30
-500	tumbling jittery Elf Farm Raffle ticket	0		
+500	jittery tumbling Elf Farm Raffle ticket	0		
 501	fancy stale wobbly Elfin shortbread	4	decent	Effect: "Disdain of the War Snapper", Effect Duration: 40
 502	pulsating pagoda plans	0		
-503	huge special decent twirling ghostly skewered cat appendix	9	good	Effect: "Glo-Face", Effect Duration: 50
+503	decent huge special ghostly twirling skewered cat appendix	9	good	Effect: "Glo-Face", Effect Duration: 50
 504	evil arches	0		
 505	gnatwing earring of the glutton of the early riser	0		Food Drop: +100, Adventures: +7
 506	adequate blue Hell broth	3	good	
@@ -507,10 +507,10 @@
 509	Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
-512	lime green bouncing tumbling Sneaky Pete's key lime	0		
-513	yummy twirling blurry Boris's key lime pie	3	awesome	
-514	gigantic normal Jarlsberg's key lime pie	8	good	
-515	huge normal Sneaky Pete's key lime pie	10	good	
+512	bouncing lime green tumbling Sneaky Pete's key lime	0		
+513	yummy blurry twirling Boris's key lime pie	3	awesome	
+514	normal gigantic Jarlsberg's key lime pie	8	good	
+515	normal huge Sneaky Pete's key lime pie	10	good	
 516	Hey Deze map	0		
 517	gray shellacked bejeweled accordion strap	0		Damage Reduction: 7, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -534,7 +534,7 @@
 536	pulsating dictionary	0		
 537	teal pr0n legs	0		
 538	yellow mirror f3d0r4 of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 1xLep, cap 27"
-539	narrow teal lowercase N	0		
+539	teal narrow lowercase N	0		
 540	pressed magnetized blurry Tasty Fun Good rice candy	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 35
 541	smartaleck's smooth draggin' ball hat	0		Moxie: +15, Moxie Percent: +30, Familiar Effect: "atk, 1xVolley, cap 25"
 542	bouncing fireproof 1337 7r0uZ0RZ of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +3, Familiar Effect: "2xPotato, cap 27"
@@ -555,7 +555,7 @@
 557	lousy weak whiskey and cola	2	decent	
 558	flavorless tiny papaya taco	1	decent	
 559	razor-sharp can lid	0		
-560	flavorless half-sized stalk of asparagus	2	decent	
+560	half-sized flavorless stalk of asparagus	2	decent	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -564,22 +564,22 @@
 566	bum cheek of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	enchanted huge normal Double Bacon Beelzeburger	9	good	Effect: "Turkey-Ambitious", Effect Duration: 40
-569	toothsome immense special Lord of the Flies-sized fries	8	awesome	Effect: "Abyssal Tears", Effect Duration: 40
-570	gigantic enchanted bland Chicken Sandwich	6	decent	Effect: "Reedy Pipes", Effect Duration: 40
+569	special immense toothsome Lord of the Flies-sized fries	8	awesome	Effect: "Abyssal Tears", Effect Duration: 40
+570	enchanted gigantic bland Chicken Sandwich	6	decent	Effect: "Reedy Pipes", Effect Duration: 40
 571	red Jumbo Dr. Lucifer	1	good	
 572	bland miniature Children's Meal of the Damned	2	decent	
 573	flavorless twirling noodles	4	decent	
-574	immense fancy tasty maroon noodles	9	awesome	Effect: "Old School Pompadour", Effect Duration: 5
-575	normal small bouncing gray painful penne pasta	2	good	
-576	bland super-sized ravioli della hippy	5	decent	
+574	tasty fancy immense maroon noodles	9	awesome	Effect: "Old School Pompadour", Effect Duration: 5
+575	small normal gray bouncing painful penne pasta	2	good	
+576	super-sized bland ravioli della hippy	5	decent	
 577	toothsome pr0n m4nic0tti	3	awesome	
 578	moldy Hell ramen	4	crappy	
 579	stale boring spaghetti	3	decent	
 580	shaking blinking sauce of the ages	0		
 581	mirror schmancy cheese sauce	0		
 582	cyan Himalayan Hidalgo sauce	0		
-583	enchanted stale fettucini Inconnu	3	decent	Effect: "Elbow Sauce", Effect Duration: 15
-584	normal big fancy narrow spaghetti with Skullheads	5	good	Effect: "stats.enq", Effect Duration: 5
+583	stale enchanted fettucini Inconnu	3	decent	Effect: "Elbow Sauce", Effect Duration: 15
+584	big fancy normal narrow spaghetti with Skullheads	5	good	Effect: "stats.enq", Effect Duration: 5
 585	yummy gnocchetti di Nietzsche	3	awesome	
 586	Van der Graaf energetic ridiculously huge sword	0		Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7
 587	electrified warmed super-spiky hair gel	0		Effect: "Night of the Nachos", Effect Duration: 63
@@ -636,7 +636,7 @@
 638	spinning bouncing red hale asshat of the early riser	0		Maximum HP: +20, Adventures: +7, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	moldy abominable snowcone	4	crappy	
 640	Ent cider	1	decent	
-641	thick stale toast	5	decent	
+641	stale thick toast	5	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	wobbly Crimbo pressie	0		Last Available: "2003-12"
@@ -664,10 +664,10 @@
 666	Usain Bolt's weightlifter's strapping steaming evil	0		Muscle: 20, Initiative: +80
 667	castle map	0		
 668	spiked femur of terror	0		Spooky Spell Damage: +10
-669	small decent ghuol guolash	2	good	
+669	decent small ghuol guolash	2	good	
 670	wobbly wobbly greasy lihc face	0		Sleaze Spell Damage: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	blinking flame-wreathed personal trainer's grave robbing shovel	0		Experience Percent (Muscle): +10, Hot Spell Damage: +10
-672	immense flavorless cranberries	7	decent	
+672	flavorless immense cranberries	7	decent	
 673	perfectly mixed strong wobbly vodka and cranberry	5	EPIC	
 674	acceptable mirror whiskey	4	good	
 675	fortified skull of the Bonerdagon	0		Damage Absorption: +60
@@ -678,7 +678,7 @@
 680	aged slap and tickle	3	awesome	
 681	lousy jittery slip 'n' slide	3	decent	
 682	distilled hand-crafted huge a sump'm sump'm	5	EPIC	
-683	lousy strong horizontal tango	5	decent	
+683	strong lousy horizontal tango	5	decent	
 684	tolerable pink pony	4	good	
 685	miser's medical-grade Mr. Shirt of the ox	0		Muscle: +20, Meat Drop: +10, HP Regen Min: 7, HP Regen Max: 10
 686	fuchsia dog trainer's knuckles	0		Experience (familiar): +1
@@ -700,10 +700,10 @@
 703	pulsating foul-smelling goth kid t-shirt	0		Stench Damage: +10
 704	hamethyst	0		
 705	baconstone	0		
-706	tumbling teal jittery porquoise	0		
+706	teal tumbling jittery porquoise	0		
 707	pork elf goodies sack	0		
 708	ring setting	0		
-709	pulsating twirling jewelry-making pliers	0		
+709	twirling pulsating jewelry-making pliers	0		
 711	cyan stiffened hamethyst earring of the scaredy-cat	0		Damage Reduction: 1, Monster Level: -15
 712	wool frosty wholesome hamethyst necklace	0		Maximum HP Percent: +10, Cold Spell Damage: +10, Cold Resistance: +1, Single Equip
 713	studded razor-sharp hamethyst bracelet	0		Weapon Damage Percent: +25, Damage Absorption: +80, Single Equip
@@ -716,14 +716,14 @@
 720	cyan shaking upside-down auspicious porquoise necklace of wisdom	0		Mysticality: +15, Item Drop: +10, Single Equip
 721	twirling sharpshooter's porquoise bracelet of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +10
 722	up-at-dawn family-friendly studded porquoise ring	0		Damage Absorption: +80, Sleaze Resistance: +1, Adventures: +5, Single Equip
-723	normal big Knoll mushroom	5	good	
+723	big normal Knoll mushroom	5	good	
 724	delicious mushroom	3	awesome	
 725	one million meat pancakes	0		
 726	MacGyver's huge mirror shard	0		Maximum MP: +100
 727	hedge maze puzzle	0		
 728	hedge maze key	0		
 729	maroon fishbowl	0		
-730	pulsating blinking fishtank	0		
+730	blinking pulsating fishtank	0		
 731	fish hose	0		
 732	blue hosed tank	0		
 733	hosed fishbowl	0		
@@ -738,25 +738,25 @@
 742	adequate Knoll shroomkabob	3	good	
 743	toothsome mushroom	3	awesome	
 744	activated liquefied squat hair spray	0		Effect: "familiar.enq", Effect Duration: 33
-746	mirror green stat script	0		
+746	green mirror stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	flavorless twirling warm mushroom	3	decent	
 750	rotten lime green mushroom quesadilla	4	crappy	
-751	tiny toothsome teal cool mushroom	1	awesome	
-752	bite-sized rotten cool mushroom casserole	1	crappy	
+751	toothsome tiny teal cool mushroom	1	awesome	
+752	rotten bite-sized cool mushroom casserole	1	crappy	
 753	flavorless pointy mushroom	4	decent	
 754	adequate cream of pointy mushroom soup	3	good	
 755	rotten purple mushroom	3	crappy	
-756	flavorless half-sized mushroom	2	decent	
+756	half-sized flavorless mushroom	2	decent	
 757	miniature rotten mushroom	2	crappy	
-758	bland immense blue ghost cucumber	8	decent	
+758	immense bland blue ghost cucumber	8	decent	
 759	upside-down dill	0		
 760	shaking vinegar	0		
 761	brine	0		
 762	tolerable especially salty dog	3	good	
 763	ghostly pickling solution	0		
-764	thick bland pulsating jittery spectral pickle	5	decent	
+764	bland thick jittery pulsating spectral pickle	5	decent	
 765	pulsating briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	modified polarized cologne of contempt	0		Effect: "Mushroom Melody", Effect Duration: 42
@@ -778,16 +778,16 @@
 783	'Villa' document	0		
 784	perfectly mixed Acqua Del Piatto Merlot	3	super EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
-786	gigantic spoiled strawberry	8	crappy	
+786	spoiled gigantic strawberry	8	crappy	
 787	hand-crafted bottle of rum	3	EPIC	
 788	practically non-alcoholic hand-crafted yellow strawberry daiquiri	1	EPIC	
-789	hand-crafted practically non-alcoholic rum and cola	1	EPIC	
+789	practically non-alcoholic hand-crafted rum and cola	1	EPIC	
 790	acceptable irresponsibly strong grog	8	good	
 791	perfumed Mafia bow tie of the boozehound	0		Stench Resistance: +5, Booze Drop: +100, Last Available: "2004-10"
 792	pulsating huge supercharged Golden Mr. Accessory	0		Maximum MP Percent: +30, Softcore Only
-793	energized polarized spinning blue oil of stability	0		Effect: "Work For Hours a Week", Effect Duration: 47
+793	energized polarized blue spinning oil of stability	0		Effect: "Work For Hours a Week", Effect Duration: 47
 794	corrupted shaking oil of slipperiness	0		Effect: "Turtle Titters", Effect Duration: 34
-795	delicious weak Acque Luride Grezze Cabernet	2	awesome	Last Available: "2004-10"
+795	weak delicious Acque Luride Grezze Cabernet	2	awesome	Last Available: "2004-10"
 796	teal blinking executive gravedigger's cement shoes of incineration	0		Hot Spell Damage: +50, Spooky Damage: +10, Meat Drop: +40, Last Available: "2004-10"
 797	bad fancy rockin' wagon	4	decent	Effect: "Shot in the Arse", Effect Duration: 45
 798	irresponsibly strong bad ocean motion	6	decent	
@@ -797,15 +797,15 @@
 804	decent Knoll stir-fry	3	good	
 805	moldy jittery stir-fry	3	crappy	
 806	flavorless asparagus stir-fry	3	decent	
-807	snack-sized moldy mirror olive stir-fry	2	crappy	
+807	moldy snack-sized mirror olive stir-fry	2	crappy	
 808	adequate Knob sausage stir-fry	3	good	
 809	toothsome bat wing stir-fry	4	awesome	
 810	bland shaking rat appendix stir-fry	4	decent	
-811	small spoiled special tofu stir-fry	2	crappy	Effect: "Dances with Tweedles", Effect Duration: 5
+811	special small spoiled tofu stir-fry	2	crappy	Effect: "Dances with Tweedles", Effect Duration: 5
 812	bland pr0n stir-fry	3	decent	
-813	half-sized stale wobbly Knob shells	2	decent	
+813	stale half-sized wobbly Knob shells	2	decent	
 814	bland small lime green jittery b&auml;tzle	2	decent	
-815	low-calorie enchanted adequate ratini	1	good	Effect: "On the Trolley", Effect Duration: 5
+815	enchanted adequate low-calorie ratini	1	good	Effect: "On the Trolley", Effect Duration: 5
 816	decent Knob stroganoff	4	good	
 817	rotten snack-sized skewed menudo ravioli	2	crappy	
 818	plus sign	0		
@@ -831,10 +831,10 @@
 838	blinking wizardly Mafia stogie of the dark arts	0		Mysticality: +25, Spell Damage Percent: +100, Last Available: "2004-10"
 839	hand-crafted watered-down Maiali Sifilitici Pinot Noir	2	super ultra mega EPIC	Last Available: "2004-10"
 840	ribald Tesla Mafia violin case	0		Sleaze Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2004-10"
-841	spirit-forward perfectly mixed tomato daiquiri	5	EPIC	
-842	perfectly mixed fortified teal beertini	5	EPIC	
+841	perfectly mixed spirit-forward tomato daiquiri	5	EPIC	
+842	fortified perfectly mixed teal beertini	5	EPIC	
 843	hand-crafted triple-distilled salty slug	9	EPIC	
-844	weak hand-crafted papaya slung	2	EPIC	
+844	hand-crafted weak papaya slung	2	EPIC	
 845	red Da Vinci's MAHI fez	0		Experience (Mysticality): +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -843,7 +843,7 @@
 851	prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
 853	narrow blundarrrbus	0		Familiar Weight: +5
-854	bouncing spinning sucky decal	0		Familiar Weight: +5
+854	spinning bouncing sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	ghostly shock collar	0		
 857	mirror moonglasses	0		
@@ -881,7 +881,7 @@
 890	snack-sized fancy stale balaclava baklava	2	decent	Effect: "Hairy Palms", Effect Duration: 45
 891	spinning scorching Warehouse 23 bling	0		Hot Damage: +25
 892	spinning curative educational bugbear-smiting sword of dire peril	0		Experience: +1, Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5
-893	delicious fortified lumbering jack	5	awesome	
+893	fortified delicious lumbering jack	5	awesome	
 894	bouncing upside-down teal Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	supercool Ms. Accessory	0		Moxie Percent: +20, Softcore Only
 896	quilted Mr. Accessory Jr. of the glutton	0		Damage Absorption: +40, Food Drop: +100, Softcore Only
@@ -902,8 +902,8 @@
 911	galvanized extra-enhanced super-denatured pulsating Senior Mints	0		Effect: "Wet Willied", Effect Duration: 62
 912	diffused unsweetened pixellated candy heart	0		Effect: "Savage Beast Inside", Effect Duration: 60
 913	enhanced kobold	0		Effect: "Mushroom Melody", Effect Duration: 28
-914	twirling pulsating hand turkey outline	0		Free Pull, Last Available: "2004-11"
-915	teal wobbly yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
+914	pulsating twirling hand turkey outline	0		Free Pull, Last Available: "2004-11"
+915	wobbly teal yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	skewed spinning perfumed careful intergalactic pom poms	0		Monster Level: -10, Stench Resistance: +5
 917	Mob Penguin protection contract	0		
 918	gray medical-grade Radio Free Baseball Cap	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
@@ -919,8 +919,8 @@
 928	mirror huge fuzzy bracelets of Leguizamo	0		Monster Level: +20
 929	arse-shooting crossbow of extreme caution	0		Monster Level: -25
 931	acceptable pulsating spiced rum	4	good	
-932	mediocre practically non-alcoholic eggnog	1	decent	
-933	adequate miniature candy cane	2	good	
+932	practically non-alcoholic mediocre eggnog	1	decent	
+933	miniature adequate candy cane	2	good	
 934	toothsome gingerbread bugbear	4	awesome	
 935	jittery energetic imitation nice watch	0		Maximum MP Percent: +20, Single Equip, Last Available: "2004-12"
 936	upside-down Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -935,7 +935,7 @@
 945	cyan skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	perfectly mixed weak pulsating martini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
+948	weak perfectly mixed pulsating martini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 949	delicious practically non-alcoholic blue grogtini	1	awesome	Last Available: "2004-12"
 950	perfectly mixed special jittery cherry bomb	3	super ultra EPIC	Effect: "Fury of the Bells", Effect Duration: 5, Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -943,9 +943,9 @@
 953	penguin-smacking club	0		Familiar Damage: +15
 954	narrow orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	brawny fez of etymology	0		Muscle Percent: +20, Familiar Effect: "1xLep, cap 30"
-956	big flavorless mirror yellow carob chunk noodles	5	decent	
+956	big flavorless yellow mirror carob chunk noodles	5	decent	
 957	moldy ghostly chorizo brownies	4	crappy	
-958	immense flavorless chocolate and tomato pizza	9	decent	
+958	flavorless immense chocolate and tomato pizza	9	decent	
 959	green flange	0		
 960	clockwork key	0		
 961	red silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -994,16 +994,16 @@
 1007	coconut shell of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xFairy, cap 7"
 1008	teal nippy ice cubes	0		Cold Damage: +10
 1009	lousy vodka martini	3	decent	
-1010	triple-distilled lousy whiskey and soda	9	decent	
+1010	lousy triple-distilled whiskey and soda	9	decent	
 1011	bad monkey wrench	4	decent	
 1012	aged tequila sunrise	3	awesome	
-1013	boozy perfectly mixed bouncing margarita	5	EPIC	
+1013	perfectly mixed boozy bouncing margarita	5	EPIC	
 1014	drinkable strawberry wine	3	good	
-1015	perfectly mixed watered-down huge squat twirling wine spritzer	2	EPIC	
+1015	watered-down perfectly mixed squat huge twirling wine spritzer	2	EPIC	
 1016	watered-down delicious perpendicular hula	2	awesome	
-1017	special tolerable upside-down ducha de oro	3	good	Effect: "Sewer-Drenched", Effect Duration: 20
-1018	lousy spinning pulsating calle de miel	4	decent	
-1019	drinkable distilled dry vodka martini	5	good	
+1017	tolerable special upside-down ducha de oro	3	good	Effect: "Sewer-Drenched", Effect Duration: 20
+1018	lousy pulsating spinning calle de miel	4	decent	
+1019	distilled drinkable dry vodka martini	5	good	
 1020	mediocre old-fashioned	4	decent	
 1021	tolerable teal tequila with training wheels	4	good	
 1022	acceptable bouncing sangria	4	good	
@@ -1024,7 +1024,7 @@
 1037	mirror narrow gnauga hide buckler of the storm	0		Maximum MP Percent: +40, Damage Reduction: 5
 1038	modified cyan Connery's Elixir of Audacity	0		Effect: "Chow Downed", Effect Duration: 67
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	bad practically non-alcoholic beer	1	decent	
+1041	practically non-alcoholic bad beer	1	decent	
 1042	jittery string of beads of the glutton	0		Food Drop: +100
 1043	fortified string of beads	0		Damage Absorption: +60
 1044	fireproof string of beads	0		Hot Resistance: +3
@@ -1033,7 +1033,7 @@
 1047	hand-crafted ghostly N. O. Beer	4	EPIC	
 1048	diluted oyster egg	1		
 1049	modified oyster egg	1		
-1050	mixed jittery green oyster egg	1		Effect: "Oiled Skin", Effect Duration: 30
+1050	mixed green jittery oyster egg	1		Effect: "Oiled Skin", Effect Duration: 30
 1051	plastic oyster egg	0		
 1052	boiled squat oyster egg	1		
 1053	compressed blurry twirling oyster egg	1		Effect: "Glo-Face", Effect Duration: 40
@@ -1090,7 +1090,7 @@
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
 1106	upside-down clockwork chef head	0		
-1107	spinning squat clockwork maid head	0		
+1107	squat spinning clockwork maid head	0		
 1108	clockwork detective skull	0		
 1109	clockwork bartender-head-in-the-box	0		
 1110	lime green clockwork chef-head-in-the-box	0		
@@ -1119,10 +1119,10 @@
 1133	rosy-cheeked star shirt	0		Maximum HP Percent: +30
 1134	cosmetics bag	0		
 1135	warmed adjusted eyeliner	0		Effect: "Disco Inferno", Effect Duration: 66
-1136	super-chilled narrow cyan lipstick	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 15
+1136	super-chilled cyan narrow lipstick	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 15
 1137	razor-sharp bicycle chain of the sewer	0		Weapon Damage Percent: +25, Stench Damage: +25
 1138	jittery mushroom fermenting solution	0		
-1139	watered-down tolerable wobbly mushroom wine	2	good	
+1139	tolerable watered-down wobbly mushroom wine	2	good	
 1140	lousy bouncing icy mushroom wine	3	decent	
 1141	tolerable mushroom wine	3	good	
 1142	bad pointy mushroom wine	3	decent	
@@ -1130,10 +1130,10 @@
 1144	lousy cool mushroom wine	3	decent	
 1145	hand-crafted huge knob mushroom wine	4	EPIC	
 1146	perfectly mixed knoll mushroom wine	4	EPIC	
-1147	watered-down artisanal mushroom wine	2	EPIC	
+1147	artisanal watered-down mushroom wine	2	EPIC	
 1148	bad shot of flower schnapps	4	decent	
-1149	spoiled immense spinning flower petal pie	8	crappy	
-1150	distilled lousy gray shaking bottle of single-barrel whiskey	5	decent	
+1149	immense spoiled spinning flower petal pie	8	crappy	
+1150	distilled lousy shaking gray bottle of single-barrel whiskey	5	decent	
 1151	healthy discarded plastic fork of the blizzard	0		Maximum HP Percent: +20, Cold Spell Damage: +25
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	decent Retenez L'Herbe Pat&eacute;	3	good	
@@ -1144,9 +1144,9 @@
 1159	fuchsia mariachi G-string	0		
 1160	huge greasy irate sombrero	0		Sleaze Spell Damage: +10, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
-1162	extra-warmed cyan bouncing handsomeness potion	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 68
+1162	extra-warmed bouncing cyan handsomeness potion	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 68
 1163	tarnished dry cold-filtered tumbling marzipan skull	0		Effect: "Flower Power", Effect Duration: 24
-1164	mirror red poultrygeist	0		
+1164	red mirror poultrygeist	0		
 1165	mirror hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
@@ -1162,12 +1162,12 @@
 1177	magnetic field	0		
 1178	potted cactus	0		
 1179	spinning daisy	0		
-1180	twirling teal potted fern	0		
+1180	teal twirling potted fern	0		
 1181	tulip	0		
 1182	Venus flytrap	0		
 1183	olive all-purpose flower	0		
 1184	huge exotic orchid	0		
-1185	blinking spinning long-stemmed rose	0		
+1185	spinning blinking long-stemmed rose	0		
 1186	gilded lily	0		
 1187	deadly nightshade	0		
 1188	lotus	0		
@@ -1178,23 +1178,23 @@
 1193	tumbling Raggedy Hippy doll	0		
 1194	blurry stab bat	0		
 1195	shaking apathetic lizardman doll	0		
-1196	jittery olive yeti	0		
+1196	olive jittery yeti	0		
 1197	maroon Mob Penguin	0		
-1198	narrow spinning sabre-toothed lime	0		
+1198	spinning narrow sabre-toothed lime	0		
 1199	bugbear	0		
-1200	miniature bland mugcake	2	decent	
+1200	bland miniature mugcake	2	decent	
 1201	tasty blinking urinal cake	4	awesome	
-1202	bite-sized decent upside-down Happy Birthday, Claude! cake	1	good	
+1202	decent bite-sized upside-down Happy Birthday, Claude! cake	1	good	
 1203	spoiled personalized birthday cake	3	crappy	
-1204	bite-sized normal squat three-tiered wedding cake	1	good	
+1204	normal bite-sized squat three-tiered wedding cake	1	good	
 1205	delicious babycakes	4	awesome	
-1206	miniature decent velvet cake	2	good	
-1207	fancy flavorless bite-sized congratulatory cake	1	decent	Effect: "Human-Human Hybrid", Effect Duration: 15
-1208	decent tiny enchanted angel-food cake	1	good	Effect: "Alacri Tea", Effect Duration: 40
+1206	decent miniature velvet cake	2	good	
+1207	bite-sized fancy flavorless congratulatory cake	1	decent	Effect: "Human-Human Hybrid", Effect Duration: 15
+1208	tiny enchanted decent angel-food cake	1	good	Effect: "Alacri Tea", Effect Duration: 40
 1209	flavorless devil's-food cake	3	decent	
 1210	decent shaking birthday party jellybean cheesecake	3	good	
 1211	spinning green balloon	0		
-1212	squat maroon balloon	0		
+1212	maroon squat balloon	0		
 1213	heart-shaped balloon	0		
 1214	anniversary balloon	0		
 1215	Mylar balloon	0		
@@ -1233,7 +1233,7 @@
 1249	hardy Boss Bat britches	0		Maximum HP: +50, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	energetic deadly Boss Bat bling	0		Weapon Damage: +5, Maximum MP Percent: +20
 1251	toothsome blurry Knob shroomkabob	4	awesome	
-1252	immense tasty enchanted shroomkabob	10	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 45
+1252	tasty enchanted immense shroomkabob	10	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 45
 1253	pile of jumping beans	0		
 1254	yummy jumping bean burrito	3	awesome	
 1255	spoiled snack-sized jumping bean burrito	2	crappy	
@@ -1242,11 +1242,11 @@
 1258	pail of pretentious paint	0		
 1259	teal up-at-dawn beefcake's traffic cone	0		Muscle: +25, Adventures: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	twisted olive upside-down Hatorade	1		
+1261	twisted upside-down olive Hatorade	1		
 1262	studded off-hand balloon of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Damage Absorption: +80
 1263	bouncing pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
-1264	wobbly blue nose-bone fetish	0		Last Available: "2011-12"
-1265	jittery fuchsia box of sunshine	0		Free Pull
+1264	blue wobbly nose-bone fetish	0		Last Available: "2011-12"
+1265	fuchsia jittery box of sunshine	0		Free Pull
 1266	normal snack-sized gloomy mushroom	2	good	
 1267	wobbly dead mimic	0		
 1268	pine wand	0		
@@ -1255,9 +1255,9 @@
 1271	squat aluminum wand	0		
 1272	marble wand	0		
 1273	wholesome magic lamp	0		Maximum HP Percent: +10
-1274	twisted twirling wobbly Medicinal Herb's medicinal herbs	1		
+1274	twisted wobbly twirling Medicinal Herb's medicinal herbs	1		
 1275	narrow basic meat skirt of temperance	0		Sleaze Resistance: +5, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	perfectly mixed practically non-alcoholic Otorian Battle Scar	1	EPIC	
+1276	practically non-alcoholic perfectly mixed Otorian Battle Scar	1	EPIC	
 1277	medical-grade basic meat kilt	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	huge censurious meat skirt	0		Sleaze Resistance: +3, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	brainy meat kilt	0		Mysticality: +5, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1300,10 +1300,10 @@
 1316	facsimile dictionary	0		
 1317	blood flower	0		
 1318	lovecat tail	0		
-1319	cyan ghostly plastic passion fruit	0		
+1319	ghostly cyan plastic passion fruit	0		
 1320	bland bouncing questionable taco	4	decent	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
-1322	yellow upside-down petrified time	0		Last Available: "2005-10"
+1322	upside-down yellow petrified time	0		Last Available: "2005-10"
 1323	gravedigger's time helmet	0		Spooky Damage: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
 1324	shaking veiny time trousers	0		Maximum HP: +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	bouncing hale time sword	0		Maximum HP: +20, Last Available: "2005-10"
@@ -1324,7 +1324,7 @@
 1341	thinker's Dyspepsi-Cola-issue canteen	0		Mysticality: +10, Single Equip
 1342	picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
-1344	quadruple-diffused cyan jittery Gummi-Gnauga	0		Effect: "Human-Constellation Hybrid", Effect Duration: 49
+1344	quadruple-diffused jittery cyan Gummi-Gnauga	0		Effect: "Human-Constellation Hybrid", Effect Duration: 49
 1345	chilled adjusted upside-down Now and Earlier	0		Effect: "Dweeby", Effect Duration: 46, Last Available: "2020-09"
 1346	corrupted Sugar Cog	0		Effect: "Rave Nirvana", Effect Duration: 53
 1347	teal loaded serum blowgun	0		Last Available: "2005-11"
@@ -1338,16 +1338,16 @@
 1355	decent bowl of oriole's nest soup	3	good	
 1356	green bunny liver	0		
 1357	acceptable red Mt. Noob Pale Ale	3	good	
-1358	pulsating spinning pirate zombie head	0		Last Available: "2005-11"
+1358	spinning pulsating pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	steel-toed disembodied smile	0		Damage Reduction: 9, Single Equip
 1362	sausage	0		
 1363	lime green clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	immense normal fancy tofurkey leg	6	good	Effect: "All Is Forgiven", Effect Duration: 25
+1365	fancy normal immense tofurkey leg	6	good	Effect: "All Is Forgiven", Effect Duration: 25
 1366	spoiled jumbo squat tofurkey gravy	5	crappy	
-1367	jumbo rotten herbal stuffing	5	crappy	
+1367	rotten jumbo herbal stuffing	5	crappy	
 1368	bland can-shaped gelatinous cranberry sauce	3	decent	
 1369	stale immense yams	9	decent	
 1370	Jack Frost's rhinestone cowboy shirt	0		Cold Spell Damage: +50
@@ -1386,17 +1386,17 @@
 1404	fireproof colored-light &quot;necklace&quot;	0		Hot Resistance: +3, Last Available: "2005-12"
 1405	razor-sharp tree skirt	0		Weapon Damage Percent: +25, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	normal wreath-shaped Crimbo cookie	3	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	moldy shaking pulsating bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	huge decent ghostly tree-shaped Crimbo cookie	9	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1407	moldy pulsating shaking bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1408	decent huge ghostly tree-shaped Crimbo cookie	9	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	cool Unionize The Elves sign	0		Moxie: +5, Last Available: "2005-12"
-1410	huge red sleeping snowy owl	0		Last Available: "2005-12"
+1410	red huge sleeping snowy owl	0		Last Available: "2005-12"
 1411	squat Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	double-denatured wet squat snowcone	0		Effect: "Raging Animal", Effect Duration: 58, Last Available: "2006-01"
 1413	polarized blurry narrow snowcone	0		Effect: "Fruited", Effect Duration: 43, Last Available: "2006-01"
 1414	wet galvanized Vulcanized snowcone	0		Effect: "Lobos Fresh", Effect Duration: 26, Last Available: "2006-01"
 1415	corrupted dry snowcone	0		Effect: "Disco Inferno", Effect Duration: 35, Last Available: "2006-01"
 1416	boiled colloidal tarnished tumbling tumbling snowcone	0		Effect: "Rampage!", Effect Duration: 32, Last Available: "2006-01"
-1417	liquefied adjusted bouncing blinking snowcone	0		Effect: "Unusual Perspective", Effect Duration: 34, Last Available: "2006-01"
+1417	liquefied adjusted blinking bouncing snowcone	0		Effect: "Unusual Perspective", Effect Duration: 34, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
 1420	executive padded traffic cone	0		Damage Absorption: +20, Meat Drop: +40, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
@@ -1417,7 +1417,7 @@
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
 1437	spinning useless powder	0		
-1438	electrified corrupted blurry spinning twinkly powder	0		Effect: "Disco Nirvana", Effect Duration: 68
+1438	electrified corrupted spinning blurry twinkly powder	0		Effect: "Disco Nirvana", Effect Duration: 68
 1439	polarized squat hot powder	0		Effect: "Disco Inferno", Effect Duration: 19
 1440	quadruple-colloidal powder	0		Effect: "La Bamba", Effect Duration: 64
 1441	ionized powder	0		Effect: "Flamibili Tea", Effect Duration: 26
@@ -1434,7 +1434,7 @@
 1452	pickled wad	1		Effect: "Provocative Perkiness", Effect Duration: 35
 1453	pickled squat fuchsia wad	1		
 1454	pickled stench wad	1		
-1455	boiled lime green shaking sleaze wad	1		
+1455	boiled shaking lime green sleaze wad	1		
 1456	maroon double daisy	0		
 1457	teal Goth Giant	0		
 1458	stale Valentine's Day cake	4	decent	
@@ -1452,7 +1452,7 @@
 1470	lead yo-yo	0		
 1471	slightly peevedbow	0		
 1472	ghostly sack of doorknobs	0		
-1473	jittery purple ball-and-chain	0		
+1473	purple jittery ball-and-chain	0		
 1474	cyan automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	blurry goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
@@ -1465,7 +1465,7 @@
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	olive alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	shaking rabbit's foot of Gandalf of doom	0		Spell Critical Percent: +20, Spooky Spell Damage: +50
-1486	ghostly maroon massive bag of catnip	0		
+1486	maroon ghostly massive bag of catnip	0		
 1487	shaking hang glider	0		
 1488	March hat	0		Free Pull
 1489	dormouse	0		
@@ -1482,11 +1482,11 @@
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	frozen explosion-flavored chewing gum	0		Effect: "Human-Hippy Hybrid", Effect Duration: 59, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
-1503	skewed olive huge rubber emo roe	0		Last Available: "2006-04"
+1503	olive skewed huge rubber emo roe	0		Last Available: "2006-04"
 1504	tarnished adjusted wobbly snowcone	0		Effect: "Arabian Knighthood", Effect Duration: 56, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	acceptable lime green calle de miel with a fly in it	4	good	Last Available: "2006-04"
-1507	delicious practically non-alcoholic rockin' wagon with a fly in it	1	awesome	Last Available: "2006-04"
+1507	practically non-alcoholic delicious rockin' wagon with a fly in it	1	awesome	Last Available: "2006-04"
 1508	watered-down mediocre bouncing perpendicular hula with a fly in it	2	decent	Last Available: "2006-04"
 1509	aged pulsating slap and tickle with a fly in it	3	awesome	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
@@ -1534,52 +1534,52 @@
 1554	bad bottle of Lieutenant Freeman	3	decent	
 1555	delicious bottle of Jorge Sinsonte	3	awesome	
 1556	mediocre squat boxed champagne	3	decent	
-1557	miniature tasty kumquat	2	awesome	
+1557	tasty miniature kumquat	2	awesome	
 1558	bland massive tangerine	9	decent	
 1559	tonic water	0		
-1560	stale small cocktail onion	2	decent	
+1560	small stale cocktail onion	2	decent	
 1561	flavorless tiny green raspberry	1	decent	
 1562	rotten kiwi	3	crappy	
 1563	bad whiskey bittersweet	4	decent	
 1564	tolerable blinking mimosette	3	good	
 1565	lousy shaking tequila sunset	3	decent	
-1566	perfectly mixed irresponsibly strong pulsating zmobie	8	EPIC	Wiki Name: "Zmobie (drink)"
+1566	irresponsibly strong perfectly mixed pulsating zmobie	8	EPIC	Wiki Name: "Zmobie (drink)"
 1567	smooth high-proof gin and tonic	8	awesome	
 1568	tolerable vodka and tonic	3	good	
 1569	drinkable gray tumbling vodka gibson	4	good	
-1570	artisanal weak teal gibson	2	EPIC	
+1570	weak artisanal teal gibson	2	EPIC	
 1571	acceptable teal parisian cathouse	4	good	
 1572	smooth practically non-alcoholic rabbit punch	1	awesome	
 1573	weak mediocre caipifruta	2	decent	
-1574	weak perfectly mixed enchanted teqiwila	2	EPIC	Effect: "Belch the Rainbow&trade;", Effect Duration: 40
+1574	enchanted perfectly mixed weak teqiwila	2	EPIC	Effect: "Belch the Rainbow&trade;", Effect Duration: 40
 1575	practically non-alcoholic acceptable Divine	1	good	
 1576	bad Gordon Bennett	3	decent	
 1577	artisanal enchanted wobbly tangarita	4	EPIC	Effect: "Bone Chilling", Effect Duration: 30
-1578	smooth weak bouncing mandarina colada	2	awesome	
+1578	weak smooth bouncing mandarina colada	2	awesome	
 1579	bad gimlet	3	decent	
-1580	tolerable watered-down brick road	2	good	
+1580	watered-down tolerable brick road	2	good	
 1581	smooth watered-down vodka stratocaster	2	awesome	
-1582	enchanted acceptable watered-down teal Neuromancer	2	good	Effect: "Dilated Pupils", Effect Duration: 15
+1582	watered-down acceptable enchanted teal Neuromancer	2	good	Effect: "Dilated Pupils", Effect Duration: 15
 1583	lousy prussian cathouse	3	decent	
 1584	drinkable irresponsibly strong Mae West	7	good	
 1585	distilled mediocre Mon Tiki	5	decent	
 1586	acceptable high-proof teqiwila slammer	9	good	
 1587	miniature moldy Knob lo mein	2	crappy	
-1588	adequate half-sized blue asparagus lo mein	2	good	
+1588	half-sized adequate blue asparagus lo mein	2	good	
 1589	decent bite-sized Knoll lo mein	1	good	
-1590	moldy big lo mein	5	crappy	
-1591	bite-sized enchanted normal blurry olive lo mein	1	good	Effect: "Salamander In Your Stomach", Effect Duration: 5
+1590	big moldy lo mein	5	crappy	
+1591	enchanted bite-sized normal blurry olive lo mein	1	good	Effect: "Salamander In Your Stomach", Effect Duration: 5
 1592	toothsome hot hi mein	3	awesome	
-1593	adequate fancy big purple hi mein	5	good	Effect: "Human-Weird Thing Hybrid", Effect Duration: 50
+1593	fancy adequate big purple hi mein	5	good	Effect: "Human-Weird Thing Hybrid", Effect Duration: 50
 1594	decent squat hi mein	4	good	
-1595	jumbo decent tumbling hi mein	5	good	
+1595	decent jumbo tumbling hi mein	5	good	
 1596	decent sleazy hi mein	4	good	
 1597	perfumed Junior LAAAAME merit badge	0		Stench Resistance: +5, Last Available: "2006-05"
 1598	pulsating energetic Senior LAAAAME merit badge	0		Maximum MP Percent: +20, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	hand-crafted irresponsibly strong tangarita with a fly in it	10	EPIC	
+1600	irresponsibly strong hand-crafted tangarita with a fly in it	10	EPIC	
 1601	lousy wobbly twirling mandarina colada with a fly in it	4	decent	
-1602	weak tolerable prussian cathouse with a fly in it	2	good	
+1602	tolerable weak prussian cathouse with a fly in it	2	good	
 1603	perfectly mixed Mae West with a fly in it	3	EPIC	
 1604	compressed pulsating astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1601,7 +1601,7 @@
 1621	cyan astral badger	0		Free Pull, Last Available: "2006-06"
 1622	wet cold-filtered astral mushroom	0		Effect: "Wax On Your Shoes", Effect Duration: 46, Last Available: "2006-06"
 1623	blue badger badge	0		Last Available: "2006-06"
-1624	galvanized vacuum-sealed dry bouncing olive blue-frosted astral cupcake	0		Effect: "Ancestral Disapproval", Effect Duration: 22, Last Available: "2006-06"
+1624	galvanized vacuum-sealed dry olive bouncing blue-frosted astral cupcake	0		Effect: "Ancestral Disapproval", Effect Duration: 22, Last Available: "2006-06"
 1625	anodized aerosolized double-Vulcanized green-frosted astral cupcake	0		Effect: "Reptilian Fortitude", Effect Duration: 64, Last Available: "2006-06"
 1626	dry electrified orange-frosted astral cupcake	0		Effect: "The Sweats", Effect Duration: 61, Last Available: "2006-06"
 1627	galvanized activated non-boiled skewed tumbling purple-frosted astral cupcake	0		Effect: "Pla-see-bo", Effect Duration: 44, Last Available: "2006-06"
@@ -1617,7 +1617,7 @@
 1637	electrified polarized pressed lotion of hotness	0		Effect: "Yes, Can Haz", Effect Duration: 55
 1638	unsweetened lotion of coldness	0		Effect: "The Wisdom... of the Future", Effect Duration: 51
 1639	activated ionized corrupted lotion of spookiness	0		Effect: "Vitali Tea", Effect Duration: 14
-1640	magnetized Vulcanized shaking mirror pulsating lotion of stench	0		Effect: "Egg on your Face", Effect Duration: 19
+1640	magnetized Vulcanized mirror pulsating shaking lotion of stench	0		Effect: "Egg on your Face", Effect Duration: 19
 1641	energized red lotion of sleaziness	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 53
 1642	bad Grimacite Bock	3	decent	Last Available: "2008-11"
 1643	spoiled half-sized wedge of gray cheese	2	crappy	Last Available: "2008-11"
@@ -1628,7 +1628,7 @@
 1648	green sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	moldy miniature foie gras	2	crappy	
+1651	miniature moldy foie gras	2	crappy	
 1652	denatured flattened candy brain	0		Effect: "Superhuman Sarcasm", Effect Duration: 28, Last Available: "2020-09"
 1653	deadly supercool jewel-eyed wizard hat of temperance	0		Moxie Percent: +20, Weapon Damage: +5, Sleaze Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	Tesla wad of Crovacite of James Dean	0		Experience (Moxie): +3, MP Regen Min: 7, MP Regen Max: 10
@@ -1671,13 +1671,13 @@
 1691	bouncing supercool sage discarded torn-up glove	0		Mysticality Percent: +10, Moxie Percent: +20, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	dry chilled twirling salamander slurry	0		Effect: "Heart of Pink", Effect Duration: 59
 1693	unsweetened magnetized galvanized eyedrops of newt	0		Effect: "Sticks and Stones", Effect Duration: 66
-1694	magnetized activated skewed green Frogade	0		Effect: "Jelly Combed", Effect Duration: 65
+1694	magnetized activated green skewed Frogade	0		Effect: "Jelly Combed", Effect Duration: 65
 1695	triple-improved irradiated papotion of papower	0		Effect: "20/20 Vision", Effect Duration: 69
 1696	toothsome royal jelly taco	4	awesome	
 1697	rotten tofu taco	4	crappy	
 1698	snack-sized bland jumping bean taco	2	decent	
 1699	bland catgut taco	3	decent	
-1700	flavorless massive lime green goat cheese taco	7	decent	
+1700	massive flavorless lime green goat cheese taco	7	decent	
 1701	adequate blue pr0n taco	3	good	
 1702	activated quadruple-nitrogenated alphabet gum	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 69
 1703	twirling Comma Chameleon egg	0		Free Pull
@@ -1750,9 +1750,9 @@
 1771	Jim Carey's butcherknife	0		Monster Level: +25
 1772	executive corn holder	0		Meat Drop: +40
 1773	maroon quilted eggbeater	0		Damage Absorption: +40
-1774	weak perfectly mixed bottle of popskull	2	EPIC	
+1774	perfectly mixed weak bottle of popskull	2	EPIC	
 1775	fuchsia studded dishrag	0		Damage Absorption: +80
-1776	moldy snack-sized narrow stale baguette	2	crappy	
+1776	snack-sized moldy narrow stale baguette	2	crappy	
 1777	leftovers of indeterminate origin	0		
 1778	enchanted decent squat dinner	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 10
 1779	reassuring katana	0		Spooky Resistance: +1
@@ -1845,8 +1845,8 @@
 1866	fuchsia left clavicle	0		
 1867	yellow right clavicle	0		
 1868	narrow left humerus	0		
-1869	teal skewed right humerus	0		
-1870	gray huge left radius	0		
+1869	skewed teal right humerus	0		
+1870	huge gray left radius	0		
 1871	right radius	0		
 1872	narrow left ulna	0		
 1873	yellow huge right ulna	0		
@@ -1862,7 +1862,7 @@
 1883	left second front claw	0		
 1884	left third front claw	0		
 1885	left fourth front claw	0		
-1886	tumbling blinking purple right first front claw	0		
+1886	purple tumbling blinking right first front claw	0		
 1887	right second front claw	0		
 1888	right third front claw	0		
 1889	right fourth front claw	0		
@@ -1899,7 +1899,7 @@
 1922	gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
 1924	wobbly wobbly tattered wolf standard	0		
-1925	shaking purple tattered snake standard	0		
+1925	purple shaking tattered snake standard	0		
 1926	KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	shaking cyan scary death orb	0		
 1928	tuning fork	0		
@@ -1923,9 +1923,9 @@
 1946	mirror careful accordion pin of the brazier	0		Monster Level: -10, Hot Spell Damage: +25, Class: "Accordion Thief", Single Equip
 1947	censurious groovy worn tophat	0		Moxie Percent: +10, Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	huge shaking gravedigger's tap shoes of the scaredy-cat	0		Monster Level: -15, Spooky Damage: +10, Single Equip
-1949	rotten small Manetwich	2	crappy	
+1949	small rotten Manetwich	2	crappy	
 1950	bottle of Vangoghbitussin	0		
-1951	artisanal fancy practically non-alcoholic shaking bottle of Pinot Renoir	1	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 5
+1951	practically non-alcoholic artisanal fancy shaking bottle of Pinot Renoir	1	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 5
 1952	spoiled desiccated apricot	3	crappy	
 1953	artisanal weak flute of flat champagne	2	EPIC	
 1954	rotten dehydrated caviar	3	crappy	
@@ -1944,7 +1944,7 @@
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	bottle of perfume	0		Familiar Weight: +5
 1969	spoon!	0		Familiar Weight: +5
-1970	spinning twirling nervous tick egg	0		Free Pull, Last Available: "2007-10"
+1970	twirling spinning nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	red plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	Sherlock's shrimp fork of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25
 1973	tumbling half of a memo	0		
@@ -1976,7 +1976,7 @@
 1999	stick of &quot;gum&quot;	0		
 2000	upside-down Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	Vaso De Agua trading card	0		
-2002	blurry green The Grand Poo-Bah trading card	0		
+2002	green blurry The Grand Poo-Bah trading card	0		
 2003	lime green Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
@@ -1999,7 +1999,7 @@
 2022	flavorless lemon meringue pie	3	decent	
 2023	special blinking Genalen&trade; Bottle	1	decent	Effect: "Top Dog", Effect Duration: 30
 2024	decent mixed wildflower greens	4	good	
-2025	special stale narrow handful of walnuts	4	decent	Effect: "X-Ray Vision", Effect Duration: 45
+2025	stale special narrow handful of walnuts	4	decent	Effect: "X-Ray Vision", Effect Duration: 45
 2026	toothsome snack-sized nutty organic salad	2	awesome	
 2027	spoiled miniature super salad	2	crappy	
 2028	normal thick tumbling tofu wonton	5	good	
@@ -2020,16 +2020,16 @@
 2043	huge hemp net	0		
 2044	mirror your father's MacGuffin diary	0		
 2045	flavorless upside-down brain-meltingly-hot chicken wings	3	decent	
-2046	tiny decent frat brats	1	good	
+2046	decent tiny frat brats	1	good	
 2047	stale blurry wobbly knob ka-bobs	3	decent	
-2049	artisanal weak can of Swiller	2	EPIC	
+2049	weak artisanal can of Swiller	2	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	narrow huge maroon bust of Pallas	0		Familiar Weight: +5
 2054	mirror market map	0		
 2055	jittery snake skin	0		
-2056	extra-boiled pulsating narrow adder bladder	0		Effect: "Cat Class, Cat Style", Effect Duration: 16
+2056	extra-boiled narrow pulsating adder bladder	0		Effect: "Cat Class, Cat Style", Effect Duration: 16
 2057	pension check	0		
 2058	picnic basket	0		
 2059	tarnished double-enhanced Black No. 2	0		Effect: "Emotion Sickness", Effect Duration: 42
@@ -2040,7 +2040,7 @@
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	twirling nippy supercool kick-ass kicks	0		Moxie Percent: +20, Cold Damage: +10, Single Equip
-2067	shaking blue sake bomb	0		
+2067	blue shaking sake bomb	0		
 2068	tequila grenade	0		
 2069	wool beer helmet	0		Cold Resistance: +1, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2070	ruddy distressed denim pants of the cougar	0		Moxie: +20, Maximum HP Percent: +40, Familiar Effect: "sleaze atk, 1xPotato, cap 42"
@@ -2059,7 +2059,7 @@
 2083	makeshift crane	0		
 2084	can of starch	0		
 2085	denatured fuchsia bottle of ultravitamins	1		
-2086	powdered narrow green bottle of cough syrup	1		
+2086	powdered green narrow bottle of cough syrup	1		
 2087	dried tube of hair oil	1		
 2088	improved warmed Daffy Taffy	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 45
 2089	green Crimboween memo	0		Last Available: "2006-10"
@@ -2069,7 +2069,7 @@
 2093	hors d'oeuvre tray of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 5
 2094	tasty upside-down ballroom blintz	3	awesome	
 2095	towel	0		
-2096	denatured blue squat wobbly guy made of bee pollen	1		
+2096	denatured blue wobbly squat guy made of bee pollen	1		
 2097	occult 17-ball	0		Spell Damage Percent: +25
 2098	filthy lucre	0		
 2099	hobo gristle	0		
@@ -2123,7 +2123,7 @@
 2148	toothsome rock	0		
 2149	gigantic moldy huge frank	9	crappy	Last Available: "2011-12"
 2150	spoiled bouncing plate of franks and beans	3	crappy	Last Available: "2011-12"
-2151	fancy lousy weak shot of blackberry schnapps	2	decent	Effect: "Human-Orc Hybrid", Effect Duration: 5
+2151	weak fancy lousy shot of blackberry schnapps	2	decent	Effect: "Human-Orc Hybrid", Effect Duration: 5
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2147,11 +2147,11 @@
 2172	fuchsia ruddy toy jet pack	0		Maximum HP Percent: +40, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
-2175	jittery upside-down lime green smooth stone sphere	0		
+2175	jittery lime green upside-down smooth stone sphere	0		
 2176	cracked stone sphere	0		
 2177	rough stone sphere	0		
 2178	obsidian dagger of the wise owl	0		Mysticality: +20
-2179	red blurry archaeologist's notebook	0		
+2179	blurry red archaeologist's notebook	0		
 2180	amulet	0		
 2181	jittery chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
@@ -2167,10 +2167,10 @@
 2192	sheet music	0		Last Available: "2006-12"
 2193	bland candy stake	3	decent	Last Available: "2006-12"
 2194	lousy blinking eggnog	3	decent	Last Available: "2006-12"
-2195	fancy spoiled miniature mirror unspeakable fruitcake	2	crappy	Effect: "Cat Class, Cat Style", Effect Duration: 35, Last Available: "2006-12"
+2195	spoiled miniature fancy mirror unspeakable fruitcake	2	crappy	Effect: "Cat Class, Cat Style", Effect Duration: 35, Last Available: "2006-12"
 2196	immense flavorless gingerbread horror	10	decent	Last Available: "2006-12"
 2197	pickled concentrated denatured but probably evil chocolate	0		Effect: "Chari Tea", Effect Duration: 37, Last Available: "2006-12"
-2198	delicious half-sized tumbling shaking bat-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	delicious half-sized shaking tumbling bat-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	massive enchanted rotten bouncing skull-shaped Crimboween cookie	9	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	decent tombstone-shaped Crimboween cookie	4	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	blinking Herculean plastic gift-wrapping vampire	0		Experience (Muscle): +1, Last Available: "2006-12"
@@ -2230,13 +2230,13 @@
 2256	executive furry earmuffs	0		Meat Drop: +40
 2257	Sinatra's smooth reinforced furry underpants	0		Moxie: +15, Experience (Moxie): +5
 2258	&quot;I Love Me, Vol. I&quot;	0		
-2259	upside-down squat maroon photograph of God	0		
+2259	squat maroon upside-down photograph of God	0		
 2260	hard rock candy	0		
 2261	narrow hard-boiled ostrich egg	0		
 2262	gray bird rib	0		
 2263	lion oil	0		
 2264	yummy stunt nuts	4	awesome	
-2265	rotten diet narrow wet stew	1	crappy	
+2265	diet rotten narrow wet stew	1	crappy	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	scandalous Staff of Fats	0		Sleaze Damage: +5
@@ -2244,10 +2244,10 @@
 2270	Usain Bolt's manspreader's belt	0		Monster Level: +10, Initiative: +80, Single Equip
 2271	acceptable red huge bottle of Merlot	3	good	
 2272	perfectly mixed jittery bottle of Port	3	EPIC	
-2273	mediocre distilled bottle of Pinot Noir	5	decent	
+2273	distilled mediocre bottle of Pinot Noir	5	decent	
 2274	tolerable tumbling bottle of Zinfandel	4	good	
 2275	watered-down acceptable bottle of Marsala	2	good	
-2276	perfectly mixed weak bottle of Muscat	2	EPIC	
+2276	weak perfectly mixed bottle of Muscat	2	EPIC	
 2277	Fernswarthy's key	0		
 2278	gray Fernswarthy's letter	0		
 2279	mirror book	0		
@@ -2259,10 +2259,10 @@
 2285	chisel	0		
 2286	red Eye of Ed	0		
 2287	blinking flame-retardant dog trainer's glowstick	0		Experience (familiar): +1, Hot Resistance: +1, Last Available: "2007-01"
-2288	blinking maroon encoder ring	0		Single Equip
+2288	maroon blinking encoder ring	0		Single Equip
 2289	mirror paperclip	0		
 2290	really house	0		
-2291	ghostly yellow tumbling Non-Essential Amulet	0		
+2291	ghostly tumbling yellow Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
 2294	Curiously Shiny Ancient Evil-Bashing Axe	0		
@@ -2279,7 +2279,7 @@
 2305	quadruple-aerosolized pink candy heart	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 40, Last Available: "2007-02"
 2306	magnetized concentrated tumbling candy heart	0		Effect: "Educated (Kinda)", Effect Duration: 68, Last Available: "2007-02"
 2307	concentrated corrupted polymerized ghostly candy heart	0		Effect: "Seriously Mutated", Effect Duration: 55, Last Available: "2007-02"
-2308	triple-vacuum-sealed huge narrow candy heart	0		Effect: "Heart Aflame", Effect Duration: 30, Last Available: "2007-02"
+2308	triple-vacuum-sealed narrow huge candy heart	0		Effect: "Heart Aflame", Effect Duration: 30, Last Available: "2007-02"
 2309	alkaline yellow candy heart	0		Effect: "Sugar, Hello", Effect Duration: 57, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
@@ -2296,7 +2296,7 @@
 2322	worm-riding manual pages 3-15	0		
 2323	squat headpiece of the Staff of Ed	0		
 2324	squat Staff of Ed, almost	0		
-2325	cyan spinning Staff of Ed	0		
+2325	spinning cyan Staff of Ed	0		
 2326	stone rose	0		
 2327	improved can of paint	0		Effect: "Cat-Alyzed", Effect Duration: 28
 2328	skewed drum machine	0		
@@ -2313,7 +2313,7 @@
 2339	perfectly mixed high-proof blinking Blackfly Chardonnay	9	EPIC	
 2340	tolerable & tan	4	good	
 2341	huge pepper	0		
-2342	low-calorie normal forest cake	1	good	
+2342	normal low-calorie forest cake	1	good	
 2343	tasty forest ham	3	awesome	
 2344	electrified filthworm hatchling scent gland	0		Effect: "Triangle, Man", Effect Duration: 37
 2345	ionized warmed filthworm drone scent gland	0		Effect: "Ancestral Disapproval", Effect Duration: 40
@@ -2322,7 +2322,7 @@
 2348	water pipe bomb	0		
 2349	tumbling gas balloon	0		
 2350	red beer bomb	0		
-2351	shaking spinning superamplified boom box	0		
+2351	spinning shaking superamplified boom box	0		
 2352	huge teal censurious fire poi of the glutton	0		Sleaze Resistance: +3, Food Drop: +100
 2353	bejeweled pledge pin of extreme caution	0		Monster Level: -25, Single Equip
 2354	communications windchimes	0		
@@ -2392,11 +2392,11 @@
 2418	censurious bounty-hunting pants	0		Sleaze Resistance: +3, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	dry maroon skewed bottle of rhinoceros hormones	0		Effect: "Wallflowering", Effect Duration: 23
 2420	alkaline lime green teeny-tiny magic scroll	0		Effect: "Yes, Can Haz", Effect Duration: 55
-2421	pickled galvanized skewed shaking bottle of pirate juice	0		Effect: "Human-Undead Hybrid", Effect Duration: 18
+2421	pickled galvanized shaking skewed bottle of pirate juice	0		Effect: "Human-Undead Hybrid", Effect Duration: 18
 2422	diffused irradiated pet snacks	0		Effect: "Weird Flavor", Effect Duration: 16
 2423	non-cold-filtered Mick's IcyVapoHotness Inhaler	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 62
 2424	pickled moist cyclops eyedrops	0		Effect: "Fancy Feasted", Effect Duration: 57
-2425	colloidal extra-frozen pulsating maroon can of spinach	0		Effect: "Inappropriate Spirit", Effect Duration: 53
+2425	colloidal extra-frozen maroon pulsating can of spinach	0		Effect: "Inappropriate Spirit", Effect Duration: 53
 2426	adjusted fire flower	0		Effect: "Tiki Temerity", Effect Duration: 39
 2427	oxidized teal freezerburned ice cube	0		Effect: "Sleazy Hands", Effect Duration: 44
 2428	non-altered corrupted fake blood	0		Effect: "Ass Over Teakettle", Effect Duration: 42
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	mirror Cobb's Knob map	0		
 2443	Van der Graaf pink glowstick of incineration	0		Hot Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-03"
-2444	watered-down tolerable Supernova Champagne	2	good	
+2444	tolerable watered-down Supernova Champagne	2	good	
 2445	blinking Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	bouncing hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	lime green bad penguin egg	0		Free Pull
@@ -2489,21 +2489,21 @@
 2516	blurry Jack Frost's groovy wrench bracelet	0		Moxie Percent: +10, Cold Spell Damage: +50
 2517	bouncing ghostly scorching Samson's chain necklace	0		Experience (Muscle): +5, Hot Damage: +25
 2518	olive jittery experienced sawblade shield	0		Experience: +2, Damage Reduction: 11
-2519	special tolerable McMillicancuddy's Special Lager	4	good	Effect: "Phoenix, Right?", Effect Duration: 5
+2519	tolerable special McMillicancuddy's Special Lager	4	good	Effect: "Phoenix, Right?", Effect Duration: 5
 2520	tolerable melted Jell-o shot	3	good	
-2521	mediocre practically non-alcoholic lime green cruelty-free wine	1	decent	
-2522	artisanal practically non-alcoholic twirling thistle wine	1	EPIC	
+2521	practically non-alcoholic mediocre lime green cruelty-free wine	1	decent	
+2522	practically non-alcoholic artisanal twirling thistle wine	1	EPIC	
 2523	purple tumbling megatofu	0		
 2524	spinning displaced fish	0		
 2525	spoiled fish	3	crappy	
-2526	flavorless small yellow fish casserole	2	decent	
+2526	small flavorless yellow fish casserole	2	decent	
 2527	decent thick fish lasagna	5	good	
 2528	purple filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	flavorless red gnatloaf	3	decent	
-2530	rotten olive jittery gnatloaf casserole	3	crappy	
-2531	rotten special miniature gnat lasagna	2	crappy	Effect: "In the Slimelight", Effect Duration: 50
+2530	rotten jittery olive gnatloaf casserole	3	crappy	
+2531	special miniature rotten gnat lasagna	2	crappy	Effect: "In the Slimelight", Effect Duration: 50
 2532	pulsating pork	0		
-2533	miniature toothsome purple pork chop sandwiches	2	awesome	
+2533	toothsome miniature purple pork chop sandwiches	2	awesome	
 2534	delicious pork casserole	4	awesome	
 2535	big tasty pork lasagna	5	awesome	
 2536	canopic jar	0		
@@ -2553,14 +2553,14 @@
 2580	fireproof scorpion whip of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3
 2581	squat handful of sand	0		
 2582	brick of sand	0		
-2583	normal half-sized centipede eggs	2	good	
+2583	half-sized normal centipede eggs	2	good	
 2584	blinking hardy wonderwall shield	0		Maximum HP: +50, Damage Reduction: 12
 2585	censurious Colonel Mustard's Lonely Spades Club Jacket	0		Sleaze Resistance: +3
 2586	strapping General Sage's Lonely Diamonds Club Jacket	0		Muscle: +5
 2587	maroon Corporal Fennel's Lonely Clubs Club Jacket of Tarzan	0		Experience (Muscle): +3
 2588	skewed wholesome Private Pepper's Lonely Hearts Club Jacket	0		Maximum HP Percent: +10
-2589	enchanted bland small hot date	2	decent	Effect: "Fortunate Resolve", Effect Duration: 50
-2590	drinkable weak distilled fortified wine	2	good	
+2589	bland small enchanted hot date	2	decent	Effect: "Fortunate Resolve", Effect Duration: 50
+2590	weak drinkable distilled fortified wine	2	good	
 2591	spoiled diet enchanted tasty tart	1	crappy	Effect: "Meat the Flintstones", Effect Duration: 30
 2592	bouncing Knob Goblin lunchbox	0		
 2593	small moldy Knob pasty	2	crappy	
@@ -2590,7 +2590,7 @@
 2617	boom	0		
 2618	quilted Iiti Kitty phone charm	0		Damage Absorption: +40, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	flavorless miniature unidentified jerky	2	decent	
+2620	miniature flavorless unidentified jerky	2	decent	
 2621	bouncing inspector's Tesla nasty rat mask	0		Item Drop: +15, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	blue padded ratskin belt of courage	0		Damage Absorption: +20, Spooky Resistance: +3, Single Equip
 2623	double-paned boxer's rattail whip	0		Muscle Percent: +10, Cold Resistance: +5
@@ -2631,7 +2631,7 @@
 2658	mediocre practically non-alcoholic bottle of realpagne	1	decent	Last Available: "2007-06"
 2659	jittery toasty albatross necklace	0		Hot Damage: +5, Single Equip, Last Available: "2007-06"
 2660	dried teal not-a-pipe	1	good	Last Available: "2007-06"
-2661	artisanal enchanted flask of Amontillado	3	EPIC	Effect: "Weepy, Creepy", Effect Duration: 15, Last Available: "2007-06"
+2661	enchanted artisanal flask of Amontillado	3	EPIC	Effect: "Weepy, Creepy", Effect Duration: 15, Last Available: "2007-06"
 2662	hardened ball mask	0		Damage Reduction: 3, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 2663	Can-Can skirt of the businessman	0		Meat Drop: +50, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	tarnished cold-filtered pickled squat sensitive poetry journal	0		Effect: "You Know Who to Call", Effect Duration: 30, Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	dehydrated tumbling can-can-in-a-can	1		Last Available: "2007-06"
 2669	powdered mirror patent antipsychotics	1		Last Available: "2007-06"
 2670	denatured Mariner's Friend cough drops	1		Effect: "Well-Oiled", Effect Duration: 15, Last Available: "2007-06"
-2671	mediocre teal twirling bouncing shot of nepenthe schnapps	3	decent	Last Available: "2007-06"
+2671	mediocre twirling bouncing teal shot of nepenthe schnapps	3	decent	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	frozen bottle of cat tonic	0		Effect: "Yuletide Mutations", Effect Duration: 51, Last Available: "2007-06"
@@ -2650,7 +2650,7 @@
 2677	altered wobbly protein powder	1		Effect: "Greasy Visage", Effect Duration: 15
 2678	red spectre scepter	0		
 2679	irradiated dry sparkler	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 55
-2680	irradiated spinning pulsating spinning snake	0		Effect: "Wings of the Grasshopper", Effect Duration: 46, Wiki Name: "snake"
+2680	irradiated pulsating spinning spinning snake	0		Effect: "Wings of the Grasshopper", Effect Duration: 46, Wiki Name: "snake"
 2681	electrified mirror M-242	0		Effect: "Litterboxing", Effect Duration: 40
 2682	skewed detuned radio	0		
 2683	pulsating Warehouse 23 crate	0		
@@ -2665,7 +2665,7 @@
 2692	double-paned extremely unsafe driftwood sculpture	0		Weapon Damage Percent: +100, Cold Resistance: +5
 2693	gray massive sitar of the cougar	0		Moxie: +20, Item Drop: +5
 2694	shaking pulsating chaotic educational stone baseball cap of James Dean	0		Experience: +1, Experience (Moxie): +3, Spell Critical Percent: +10, Familiar Effect: "1xVolley, cap 48"
-2695	distilled bad cup of beer	5	decent	
+2695	bad distilled cup of beer	5	decent	
 2696	ovoid thing	0		
 2697	blue duct tape	0		
 2698	twirling duct tape wallet	0		
@@ -2678,7 +2678,7 @@
 2705	stanky brainy blackberry slippers of the dark arts	0		Mysticality: +5, Spell Damage Percent: +100, Stench Spell Damage: +25, Single Equip
 2706	fireproof dog trainer's blackberry moccasins of the brute	0		Muscle Percent: +30, Experience (familiar): +1, Hot Resistance: +3, Single Equip
 2707	Lo Pan's razor-sharp Samson's blackberry combat boots	0		Experience (Muscle): +5, Weapon Damage Percent: +25, Spell Critical Percent: +30, Single Equip
-2708	ionized diffused fuchsia mirror funky dried mushroom	0		Effect: "Superheroic", Effect Duration: 35
+2708	ionized diffused mirror fuchsia funky dried mushroom	0		Effect: "Superheroic", Effect Duration: 35
 2709	exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
 2711	warmed double-pickled facepaint	0		Effect: "Triangle, Man", Effect Duration: 30
@@ -2696,15 +2696,15 @@
 2723	auspicious dog trainer's Staff of the Grand Flamb&eacute; of the ox	0		Muscle: +20, Experience (familiar): +1, Item Drop: +10
 2724	low-calorie decent bowl of rye sprouts	1	good	
 2725	normal low-calorie cob of corn	1	good	
-2726	small bland juniper berries	2	decent	
+2726	bland small juniper berries	2	decent	
 2727	fancy decent squat plum	4	good	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 25
 2728	moldy pear	3	crappy	
 2729	adequate massive peach	7	good	
 2730	hand-crafted plum wine	4	EPIC	
 2731	perfectly mixed shot of pear schnapps	3	EPIC	
-2732	practically non-alcoholic artisanal mirror shot of peach schnapps	1	EPIC	
+2732	artisanal practically non-alcoholic mirror shot of peach schnapps	1	EPIC	
 2733	tasty bunch of square grapes	3	awesome	
-2734	rotten small tumbling brown sugar cane	2	crappy	
+2734	small rotten tumbling brown sugar cane	2	crappy	
 2735	tasty sandwich of the gods	4	awesome	
 2736	triple-distilled mediocre Pan-Dimensional Gargle Blaster	9	decent	
 2737	pickled leopard-print barbell	1	crappy	
@@ -2737,7 +2737,7 @@
 2764	ghostly rosewater-soaked energetic hale Order of the Silver Wossname	0		Maximum HP: +20, Maximum MP Percent: +20, Stench Resistance: +3, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	spoiled massive Crimbo pie	10	crappy	
+2767	massive spoiled Crimbo pie	10	crappy	
 2768	stale pear tart	3	decent	
 2769	bland purple peach pie	3	decent	
 2770	cold-filtered boiled ionized chunk of rock salt	0		Effect: "Night of the Nachos", Effect Duration: 33
@@ -2841,7 +2841,7 @@
 2868	cold-filtered yellow pirate pamphlet	0		Effect: "Human-Orc Hybrid", Effect Duration: 44
 2869	liquefied blurry pirate brochure	0		Effect: "Flame-Retardant Trousers", Effect Duration: 40
 2870	ionized jittery yellow pirate tract	0		Effect: "Starry-Eyed", Effect Duration: 19
-2871	huge skewed burnt flower	0		
+2871	skewed huge burnt flower	0		
 2872	fuchsia sharpshooter's dangerous plastic Naughty Sorceress	0		Weapon Damage: +10, Critical Hit Percent: +10
 2873	lard-coated groovy plastic Ed the Undying	0		Moxie Percent: +10, Sleaze Spell Damage: +25
 2874	shaking blinking knitted plastic Lord Spookyraven of the wise owl	0		Mysticality: +20, Cold Resistance: +3
@@ -2910,10 +2910,10 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	wobbly unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	special delicious skewed Surprise Egg	3	awesome	Effect: "Horrid, Torrid", Effect Duration: 20
+2940	delicious special skewed Surprise Egg	3	awesome	Effect: "Horrid, Torrid", Effect Duration: 20
 2941	ionized diffused ionized lime green Steal This Candy	0		Effect: "Go-Gone", Effect Duration: 47
 2942	colloidal chocolate filthy lucre	0		Effect: "Armor-Plated", Effect Duration: 52
-2943	dry tarnished squat upside-down Angry Farmer's Wife Candy	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
+2943	dry tarnished upside-down squat Angry Farmer's Wife Candy	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
 2945	flame-retardant party hat of dire peril	0		Weapon Damage: +20, Hot Resistance: +1, Familiar Effect: "4xLep, cap 7"
 2946	Annie Oakley's V for Vivala mask of the businessman	0		Critical Hit Percent: +20, Meat Drop: +50, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
@@ -2924,7 +2924,7 @@
 2952	Temple Grandin's steel-toed glowstick	0		Damage Reduction: 9, Familiar Weight: +7, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	wobbly cyan sinister tip jar	0		Spell Damage: +10
-2955	normal half-sized yam candy	2	good	
+2955	half-sized normal yam candy	2	good	
 2956	cyan ghostly cocktail napkin	0		
 2957	upside-down rum barrel charrrm	0		
 2958	decent tube of cranberry Go-Goo	3	good	
@@ -2938,22 +2938,22 @@
 2966	purple Tom's of the Spanish Main Toothpaste	0		
 2967	nitrogenated diffused blue blinking Swabbie&trade; swab	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 52
 2968	aerosolized upside-down Oil of Parrrlay	0		Effect: "Old Time Hydration", Effect Duration: 23
-2969	rotten tiny creamsicle	1	crappy	
+2969	tiny rotten creamsicle	1	crappy	
 2970	lousy cream stout	3	decent	
 2971	Sherlock's Herculean curmudgel	0		Experience (Muscle): +1, Item Drop: +25
 2972	grumpy man charrrm	0		
 2973	shaking Annie Oakley's grumpy man charrrm bracelet	0		Critical Hit Percent: +20, Single Equip
 2974	tarrrnish charrrm	0		
 2975	supercool tarrrnished charrrm bracelet of wisdom	0		Mysticality: +15, Moxie Percent: +20, Single Equip
-2976	practically non-alcoholic mediocre bilge wine	1	decent	
+2976	mediocre practically non-alcoholic bilge wine	1	decent	
 2977	educational witty rapier	0		Experience: +1
 2978	scandalous hale yohohoyo	0		Maximum HP: +20, Sleaze Damage: +5
 2979	deionized triple-polarized fish-liver oil	0		Effect: "Physicali Tea", Effect Duration: 15
-2980	olive spinning booty chest charrrm	0		
+2980	spinning olive booty chest charrrm	0		
 2981	booty chest charrrm bracelet of the businessman	0		Meat Drop: +50, Single Equip
 2982	cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
-2984	gray huge copper ha'penny charrrm	0		
+2984	huge gray copper ha'penny charrrm	0		
 2985	mirror frosty copper ha'penny charrrm bracelet	0		Cold Spell Damage: +10
 2986	tongue charrrm	0		
 2987	knitted greasy tongue charrrm bracelet	0		Sleaze Spell Damage: +10, Cold Resistance: +3, Single Equip
@@ -2994,19 +2994,19 @@
 3022	medium stone triangle	0		
 3023	upside-down small stone triangle	0		
 3024	stone pyramid	0		
-3025	hand-crafted irresponsibly strong wobbly maroon corpse on the beach	7	EPIC	
+3025	irresponsibly strong hand-crafted wobbly maroon corpse on the beach	7	EPIC	
 3026	perfectly mixed corpsetini	3	super EPIC	
 3027	tolerable corpsedriver	3	good	
-3028	fancy artisanal skewed Corpse Island iced tea	3	super EPIC	Effect: "Phoenix, Right?", Effect Duration: 15
-3029	high-proof bad fancy red-headed corpse	6	decent	Effect: "You Can Taste the Darkness", Effect Duration: 25
+3028	artisanal fancy skewed Corpse Island iced tea	3	super EPIC	Effect: "Phoenix, Right?", Effect Duration: 15
+3029	bad fancy high-proof red-headed corpse	6	decent	Effect: "You Can Taste the Darkness", Effect Duration: 25
 3030	bad kamicorpse-ee	4	decent	
 3031	drinkable corpsel	3	good	
 3032	watered-down delicious corpsebite	2	awesome	
 3033	tumbling wobbly manspreader's pirate fledges	0		Monster Level: +10
 3034	piece of thirteen	0		
 3035	spoiled huge pearl onion	4	crappy	
-3036	decent massive sea biscuit	10	good	
-3037	bad boozy bottle of rum	5	decent	
+3036	massive decent sea biscuit	10	good	
+3037	boozy bad bottle of rum	5	decent	
 3038	watered-down tolerable blue bottle of black-label rum	2	good	
 3039	tumbling cannonball	0		
 3040	voodoo skull	0		
@@ -3017,7 +3017,7 @@
 3045	moldy nanite-infested gingerbread bugbear	4	crappy	Last Available: "2007-12"
 3046	stale nanite-infested candy cane	4	decent	Last Available: "2020-09"
 3047	rotten fancy nanite-infested fruitcake	3	crappy	Effect: "Starry-Eyed", Effect Duration: 25, Last Available: "2007-12"
-3048	fancy triple-distilled hand-crafted nanite-infested eggnog	6	EPIC	Effect: "Human-Orc Hybrid", Effect Duration: 45, Last Available: "2007-12"
+3048	hand-crafted fancy triple-distilled nanite-infested eggnog	6	EPIC	Effect: "Human-Orc Hybrid", Effect Duration: 45, Last Available: "2007-12"
 3049	squat El Vibrato power sphere	0		
 3050	smooth eyepatch	0		Moxie: +15, Familiar Effect: "spooky atk, 1xBarrr"
 3051	cutlass of the dark arts	0		Spell Damage Percent: +100
@@ -3056,7 +3056,7 @@
 3084	padded borg sock monkey	0		Damage Absorption: +20, Last Available: "2007-12"
 3085	Sherlock's shellacked roboduck-on-a-string	0		Damage Reduction: 7, Item Drop: +25, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
-3087	blinking yellow teddy borg sewing kit	0		Last Available: "2007-12"
+3087	yellow blinking teddy borg sewing kit	0		Last Available: "2007-12"
 3088	biomechanical crimborg helmet of the empath of courage	0		Familiar Weight: +5, Spooky Resistance: +3, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	censurious arcane researcher's C.B.F.G.	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +3, Last Available: "2007-12"
 3090	quilted biomechanical crimborg leg armor of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
@@ -3098,7 +3098,7 @@
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	bland teal narrow roasted marshmallow	3	decent	
+3129	bland narrow teal roasted marshmallow	3	decent	
 3130	disc	0		Last Available: "2008-01"
 3131	stale spinning tin cup of mulligan stew	3	decent	
 3132	clever flamin' bindle of Leguizamo	0		Maximum MP: +20, Monster Level: +20
@@ -3114,7 +3114,7 @@
 3142	Jim Carey's cup of infinite pencils	0		Monster Level: +25
 3143	ghostly lion tamer's Tesla Hodgman's disgusting technicolor overcoat	0		Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10
 3144	spinning a torn paper strip	0		
-3145	maroon shaking El Vibrato translator	0		
+3145	shaking maroon El Vibrato translator	0		
 3146	El Vibrato punchcard (115 holes)	0		
 3147	purple El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
@@ -3129,7 +3129,7 @@
 3157	El Vibrato drone	0		
 3158	cyan sparking El Vibrato drone	0		
 3159	double-denatured frozen oxidized warm El Vibrato drone	0		Effect: "Aloofah", Effect Duration: 46
-3160	magnetized double-nitrogenated upside-down blurry humming El Vibrato drone	0		Effect: "Educated (Kinda)", Effect Duration: 49
+3160	magnetized double-nitrogenated blurry upside-down humming El Vibrato drone	0		Effect: "Educated (Kinda)", Effect Duration: 49
 3161	corrupted El Vibrato drone	0		Effect: "Vanity Rage", Effect Duration: 47
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
@@ -3138,18 +3138,18 @@
 3166	fuchsia blurry repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	quadruple-colloidal yellow huge seal eyeball	0		Effect: "Triangle, Man", Effect Duration: 40
-3169	decent snack-sized turtle soup	2	good	Effect: "[598]A Little Bit Evil"
+3169	snack-sized decent turtle soup	2	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	narrow nauseating reagent	0		
 3172	yellow spinning wholesome evil paper umbrella	0		Maximum HP Percent: +10
 3173	double-adjusted squat evil vihuela	0		Effect: "Chlorophyll Flavor", Effect Duration: 64
 3174	fancy stale evil boring spaghetti	4	decent	Effect: "The Rich Get Richer", Effect Duration: 25
-3175	spoiled squat ghostly evil noodles	4	crappy	
-3176	special delicious small evil noodles	2	awesome	Effect: "Sugar Smacks", Effect Duration: 40
+3175	spoiled ghostly squat evil noodles	4	crappy	
+3176	delicious special small evil noodles	2	awesome	Effect: "Sugar Smacks", Effect Duration: 40
 3177	tasty evil painful penne pasta	4	awesome	
 3178	stale 3vi1 pr0n m4nic0tti	3	decent	
 3179	small decent huge evil ravioli della hippy	2	good	
-3180	stale low-calorie narrow evil noodles	1	decent	
+3180	low-calorie stale narrow evil noodles	1	decent	
 3181	denatured olive evil potion of potency	0		Effect: "Memory of Smarts", Effect Duration: 67
 3182	flattened vacuum-sealed mirror wobbly evil libation of liveliness	0		Effect: "Insatiable Hunger", Effect Duration: 31
 3183	denatured upside-down evil tomato juice of powerful power	0		Effect: "Nutrient-Rich", Effect Duration: 65
@@ -3160,7 +3160,7 @@
 3188	mediocre an evil sump'm sump'm	4	decent	
 3189	acceptable evil ducha de oro	3	good	
 3190	mediocre evil horizontal tango	3	decent	
-3191	high-proof lousy evil roll in the hay	10	decent	
+3191	lousy high-proof evil roll in the hay	10	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3178,7 +3178,7 @@
 3206	upside-down pulsating dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	pulsating cyan dwarvish punchcard	0		
 3208	blinking small laminated card	0		
-3209	shaking maroon pulsating blinking laminated card	0		
+3209	shaking pulsating maroon blinking laminated card	0		
 3210	gray notbig laminated card	0		
 3211	huge unlarge laminated card	0		
 3212	dwarvish document	0		
@@ -3201,7 +3201,7 @@
 3229	decaying goldfish liver	0		
 3230	aerosolized magnetized oil of oiliness	0		Effect: "Metal Speed", Effect Duration: 19
 3231	yellow flame-retardant tattered paper crown	0		Hot Resistance: +1, Familiar Effect: "1xSombrero, cap 15"
-3232	jumbo enchanted spoiled wobbly vanilla-frosted king cake	5	crappy	Effect: "Weather, Man", Effect Duration: 20, Last Available: "2008-03"
+3232	spoiled enchanted jumbo wobbly vanilla-frosted king cake	5	crappy	Effect: "Weather, Man", Effect Duration: 20, Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	pulsating noodle	0		
@@ -3239,7 +3239,7 @@
 3267	bag of Laughing Willow saplings	0		
 3268	deionized handful of Crotchety Pine needles	0		Effect: "Feet of Watermelon", Effect Duration: 33
 3269	modified flattened lump of Saccharine Maple sap	0		Effect: "Berry Berry Cold", Effect Duration: 21
-3270	activated activated spinning red handful of Laughing Willow bark	0		Effect: "Corruption of Wretched Wally", Effect Duration: 56
+3270	activated activated red spinning handful of Laughing Willow bark	0		Effect: "Corruption of Wretched Wally", Effect Duration: 56
 3271	hale crotchety pants	0		Maximum HP: +20, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	ghostly Saccharine Maple pendant of bravery	0		Spooky Resistance: +5, Conditional Skill (Equipped): "Spray Sap"
 3273	blinking flame-retardant willowy bonnet	0		Hot Resistance: +1, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
@@ -3265,17 +3265,17 @@
 3293	bouncing untamable turtle	0		
 3294	macaroni duck	0		
 3295	upside-down friendly cheez blob	0		
-3296	spinning pulsating unusual disco ball	0		
+3296	pulsating spinning unusual disco ball	0		
 3297	skewed stray chihuahua	0		
 3298	pretty pink bow	0		
-3299	huge tumbling smiley-face sticker	0		
+3299	tumbling huge smiley-face sticker	0		
 3300	wobbly farfalle bow tie	0		
 3301	mirror jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
 3304	Argarggagarg's fang	0		
 3305	teal Safari Jack's moustache	0		
-3306	blue wobbly Yakisoba's hat	0		
+3306	wobbly blue Yakisoba's hat	0		
 3307	blurry Heimandatz's heart	0		
 3308	Jocko Homo's head	0		
 3309	shaking The Mariachi's guitar case	0		
@@ -3295,8 +3295,8 @@
 3323	jittery Ol' Scratch's salad fork	0		
 3324	tumbling Frosty's frosty mug	0		
 3325	drinkable jar of fermented pickle juice	4	good	
-3326	compressed squat blurry ghostly voodoo snuff	1	EPIC	
-3327	fancy rotten ghostly extra-greasy slider	4	crappy	Effect: "Fiery Spirit", Effect Duration: 30
+3326	compressed blurry squat ghostly voodoo snuff	1	EPIC	
+3327	rotten fancy ghostly extra-greasy slider	4	crappy	Effect: "Fiery Spirit", Effect Duration: 30
 3328	avaricious smelly crumpled felt fedora	0		Stench Spell Damage: +10, Meat Drop: +30, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	careful groovy battered top-hat	0		Moxie Percent: +10, Monster Level: -10, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	tumbling chaotic smartaleck's shapeless wide-brimmed hat	0		Moxie Percent: +30, Spell Critical Percent: +10, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3319,7 +3319,7 @@
 3347	teal comfy coffin	0		
 3348	mattress	0		
 3349	narrow dinged-up triangle	0		
-3350	spirit-forward acceptable Ralph IX cognac	5	good	
+3350	acceptable spirit-forward Ralph IX cognac	5	good	
 3351	blinking llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	warmed lime green llama lama gong	0		Effect: "Amorphous Cheer", Effect Duration: 22, Last Available: "2008-06"
@@ -3329,7 +3329,7 @@
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	scrumptious ice ant	0		Last Available: "2008-06"
-3360	twirling huge stinkbug	0		Last Available: "2008-06"
+3360	huge twirling stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	adequate blinking mole mol&eacute;	3	good	Last Available: "2008-06"
@@ -3339,7 +3339,7 @@
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	diluted glimmering roc feather	1	EPIC	Last Available: "2008-06"
 3369	pickled glimmering phoenix feather	1		Last Available: "2008-06"
-3370	dehydrated blurry tumbling glimmering penguin feather	1		Effect: "Gamer Rage", Effect Duration: 35, Last Available: "2008-06"
+3370	dehydrated tumbling blurry glimmering penguin feather	1		Effect: "Gamer Rage", Effect Duration: 35, Last Available: "2008-06"
 3371	twisted ghostly skewed glimmering buzzard feather	1		Last Available: "2008-06"
 3372	mixed glimmering raven feather	1		Last Available: "2008-06"
 3373	powdered bouncing glimmering great tit feather	1		Last Available: "2008-06"
@@ -3368,10 +3368,10 @@
 3396	savvy brainy Hodgman's lobsterskin pants	0		Mysticality: +5, Mysticality Percent: +20, Familiar Effect: "atk, 1xPotato"
 3397	Jack Frost's manspreader's Hodgman's bow tie	0		Monster Level: +10, Cold Spell Damage: +50, Single Equip
 3398	hand-crafted enchanted Hodgman's blanket	3	EPIC	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 20
-3399	bad practically non-alcoholic jar of squeeze	1	decent	
+3399	practically non-alcoholic bad jar of squeeze	1	decent	
 3400	spoiled tiny skewed bowl of fishysoisse	1	crappy	
 3401	improved unsweetened mirror deadly lampshade	0		Effect: "Horrid, Torrid", Effect Duration: 56
-3402	Vulcanized nitrogenated maroon blurry concentrated garbage juice	0		Effect: "[1701]Hip to the Jive", Effect Duration: 58
+3402	Vulcanized nitrogenated blurry maroon concentrated garbage juice	0		Effect: "[1701]Hip to the Jive", Effect Duration: 58
 3403	lewd playing card	0		
 3404	blinking electrified rock-hard Da Vinci's deck of lewd playing cards	0		Experience (Mysticality): +5, Damage Reduction: 5, MP Regen Min: 3, MP Regen Max: 5
 3405	narrow experienced Hodgman's sock	0		Experience: +2, Single Equip
@@ -3382,12 +3382,12 @@
 3410	lard-coated Hodgman's detector	0		Sleaze Spell Damage: +25
 3411	scandalous Hodgman's cane	0		Sleaze Damage: +5
 3412	Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
-3413	mirror maroon Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
+3413	maroon mirror Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	olive hobo fortress blueprints	0		
 3421	lime green box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
-3422	corrupted blue pulsating sterno-flavored Hob-O	0		Effect: "Heart of Pink", Effect Duration: 47
+3422	corrupted pulsating blue sterno-flavored Hob-O	0		Effect: "Heart of Pink", Effect Duration: 47
 3423	enhanced quantum bouncing frostbite-flavored Hob-O	0		Effect: "Adorable Lookout", Effect Duration: 11
 3424	concentrated polymerized green fry-oil-flavored Hob-O	0		Effect: "Inebriate Pride", Effect Duration: 18
 3425	galvanized garbage-juice-flavored Hob-O	0		Effect: "substats.enh", Effect Duration: 63
@@ -3395,7 +3395,7 @@
 3427	bouncing roll of Hob-Os	0		
 3428	ionized blinking Everlasting Deckswabber	0		Effect: "X-Ray Vision", Effect Duration: 41
 3430	bindle of joy	0		
-3431	fuchsia ghostly cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
+3431	ghostly fuchsia cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	green cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
 3434	rattling cigar box	0		Free Pull, Last Available: "2011-12"
@@ -3424,7 +3424,7 @@
 3457	ribald Junior Adventurer's merit badge	0		Sleaze Damage: +10
 3458	altered STYX deodorant body spray	0		Effect: "Vented Spleen", Effect Duration: 60
 3459	mediocre white-label gin	3	decent	
-3460	bite-sized spoiled tin rations	1	crappy	
+3460	spoiled bite-sized tin rations	1	crappy	
 3461	fuchsia haiku challenge map	0		
 3462	terrible poem	0		
 3463	lousy skewed bottle of sake	3	decent	
@@ -3439,13 +3439,13 @@
 3472	lion tamer's quilted Seasonal Beret of chilblains	0		Damage Absorption: +40, Experience (familiar): +2, Cold Damage: +25, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	twirling wobbly Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	non-moist wet cranberry cordial	0		Effect: "Poker Faced", Effect Duration: 27
-3475	dry blurry squat cyan blackberry polite	0		Effect: "Nature's Bounty", Effect Duration: 19
+3475	dry squat cyan blurry blackberry polite	0		Effect: "Nature's Bounty", Effect Duration: 19
 3476	moist liquefied tumbling plum lozenge	0		Effect: "Your Favorite Flavor", Effect Duration: 57
-3477	pressed jittery olive tumbling pear lozenge	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25
+3477	pressed tumbling olive jittery pear lozenge	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25
 3478	alkaline energized peach lozenge	0		Effect: "Far Out", Effect Duration: 64
 3479	purple balloon shield	0		Damage Reduction: 3
 3480	spot	0		
-3481	jittery red uniclops egg	0		Free Pull, Last Available: "2009-10"
+3481	red jittery uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
 3484	tumbling eye 'n' horn shampoo	0		Familiar Weight: +5
@@ -3459,7 +3459,7 @@
 3492	stiffened fish scimitar of Calamity Jane	0		Damage Reduction: 1, Critical Hit Percent: +15
 3493	Jeselnik's Tesla fish stick	0		Sleaze Damage: +25, MP Regen Min: 7, MP Regen Max: 10
 3494	bouncing shaking Lo Pan's smartaleck's fish bazooka	0		Moxie Percent: +30, Spell Critical Percent: +30
-3495	concentrated upside-down huge sea salt crystal	0		Effect: "Red-Shirted Escort", Effect Duration: 23
+3495	concentrated huge upside-down sea salt crystal	0		Effect: "Red-Shirted Escort", Effect Duration: 23
 3496	deionized colloidal jittery bazookafish bubble gum	0		Effect: "Cool Spirit", Effect Duration: 45
 3497	boozy perfectly mixed bottle of Pete's Sake	5	EPIC	
 3498	pulsating invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
@@ -3519,12 +3519,12 @@
 3552	ghostly wobbly family-friendly healthy octopus's spade of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Sleaze Resistance: +1
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	tasty special sea carrot	3	awesome	Effect: "Hiding in Plain Sight", Effect Duration: 30
+3555	special tasty sea carrot	3	awesome	Effect: "Hiding in Plain Sight", Effect Duration: 30
 3556	small spoiled sea cucumber	2	crappy	
 3557	spoiled miniature jittery sea avocado	2	crappy	
-3558	gigantic spoiled sea lychee	10	crappy	
-3559	diet tasty sea tangelo	1	awesome	
-3560	immense adequate sea honeydew	8	good	
+3558	spoiled gigantic sea lychee	10	crappy	
+3559	tasty diet sea tangelo	1	awesome	
+3560	adequate immense sea honeydew	8	good	
 3561	improved pressed pressurized potion of puissance	0		Effect: "One Very Clear Eye", Effect Duration: 48
 3562	adjusted pulsating pressurized potion of perspicacity	0		Effect: "Berry Experiential", Effect Duration: 26
 3563	colloidal pressurized potion of pulchritude	0		Effect: "Aquarius Rising", Effect Duration: 55
@@ -3546,7 +3546,7 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	maroon wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	yummy enchanted green rice	4	awesome	Effect: "Frosty the Hitman", Effect Duration: 30
+3582	enchanted yummy green rice	4	awesome	Effect: "Frosty the Hitman", Effect Duration: 30
 3584	flavorless irradiated candy cane	4	decent	Last Available: "2008-12"
 3585	flavorless gingerbread mutant bugbear	4	decent	Last Available: "2008-12"
 3586	drinkable gray oozenog	3	good	Last Available: "2008-12"
@@ -3558,8 +3558,8 @@
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	red Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
-3595	non-Vulcanized mirror purple Mer-kin fastjuice	0		Effect: "From Nantucket", Effect Duration: 46
-3596	ghostly cyan imitation crab crate	0		
+3595	non-Vulcanized purple mirror Mer-kin fastjuice	0		Effect: "From Nantucket", Effect Duration: 46
+3596	cyan ghostly imitation crab crate	0		
 3597	imitation crab meat	0		
 3598	imitation crab zoea	0		
 3599	teal bouncing scandalous crafty arcane researcher's moist sailor's cap	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Sleaze Damage: +5, Familiar Effect: "stench atk"
@@ -3608,13 +3608,13 @@
 3642	dragonfish caviar	0		
 3643	bouncing pufferfish spine	0		
 3644	upside-down gravedigger's depleted Grimacite kneecapping stick	0		Spooky Damage: +10, Last Available: "2007-06"
-3645	fancy drinkable irresponsibly strong bouncing lime green canteen of wine	9	good	Effect: "Stregngth of the Gnome", Effect Duration: 35, Last Available: "2008-12"
-3646	diet decent elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
+3645	drinkable irresponsibly strong fancy bouncing lime green canteen of wine	9	good	Effect: "Stregngth of the Gnome", Effect Duration: 35, Last Available: "2008-12"
+3646	decent diet elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	tiny normal toast with jam	1	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	normal tiny toast with jam	1	good	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	hand-crafted irresponsibly strong enchanted elven moonshine	10	EPIC	Effect: "Good Karma", Effect Duration: 35, Last Available: "2008-12"
 3653	flavorless wobbly knuckle sandwich	4	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	Sherlock's boxer's psycho sweater	0		Muscle Percent: +10, Item Drop: +25, Last Available: "2008-12"
@@ -3648,15 +3648,15 @@
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
 3684	normal half-sized tempura carrot	2	good	
-3685	toothsome miniature tempura cucumber	2	awesome	
+3685	miniature toothsome tempura cucumber	2	awesome	
 3686	flavorless pulsating tempura avocado	3	decent	
 3687	spoiled sea broccoli	3	crappy	
 3688	adequate half-sized sea cauliflower	2	good	
 3689	bite-sized moldy pulsating tempura broccoli	1	crappy	
 3690	bland miniature tempura cauliflower	2	decent	
-3691	half-sized decent upside-down sea blueberry	2	good	
-3692	bland fancy sea persimmon	4	decent	Effect: "Neuroplastici Tea", Effect Duration: 35
-3693	extra-Vulcanized blinking narrow pressurized potion of perception	0		Effect: "Be a Mind Master", Effect Duration: 15
+3691	decent half-sized upside-down sea blueberry	2	good	
+3692	fancy bland sea persimmon	4	decent	Effect: "Neuroplastici Tea", Effect Duration: 35
+3693	extra-Vulcanized narrow blinking pressurized potion of perception	0		Effect: "Be a Mind Master", Effect Duration: 15
 3694	super-pickled galvanized bouncing pressurized potion of proficiency	0		Effect: "Goldentongue", Effect Duration: 37
 3695	Mer-kin digpick of the glutton	0		Food Drop: +100
 3696	blue anemone nematocyst	0		
@@ -3701,13 +3701,13 @@
 3735	fat wallet	0		
 3736	savvy handwarmer of temperance	0		Mysticality Percent: +20, Sleaze Resistance: +5, Single Equip
 3737	asbestos-lined flame-retardant lighter	0		Hot Resistance: 6
-3738	thick adequate packet of beer nuts	5	good	
+3738	adequate thick packet of beer nuts	5	good	
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
 3742	ionized liquefied olive squat jellyfish gel	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 67
 3743	squat unstable quark	0		
-3744	mirror blue software glitch	0		
+3744	blue mirror software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
@@ -3716,7 +3716,7 @@
 3751	rotten snack-sized chocolate chip brownies	2	crappy	
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	galvanized Vulcanized adjusted love song of vague ambiguity	0		Effect: "One Very Clear Eye", Effect Duration: 28, Last Available: "2009-02"
-3755	moist magnetized shaking upside-down love song of smoldering passion	0		Effect: "Cheered Up", Effect Duration: 59, Last Available: "2009-02"
+3755	moist magnetized upside-down shaking love song of smoldering passion	0		Effect: "Cheered Up", Effect Duration: 59, Last Available: "2009-02"
 3756	adjusted shaking love song of icy revenge	0		Effect: "Boschface", Effect Duration: 65, Last Available: "2009-02"
 3757	alkaline ghostly love song of sugary cuteness	0		Effect: "Wreathed in Merriment", Effect Duration: 29, Last Available: "2009-02"
 3758	ionized moist love song of disturbing obsession	0		Effect: "Sweet and Red", Effect Duration: 46, Last Available: "2009-02"
@@ -3726,7 +3726,7 @@
 3762	red mirror lion tamer's vampire pearl necklace	0		Experience (familiar): +2, Single Equip
 3763	practically non-alcoholic aged slug of vodka	1	awesome	
 3764	hand-crafted slug of rum	4	EPIC	
-3765	tolerable weak slug of shochu	2	good	
+3765	weak tolerable slug of shochu	2	good	
 3766	artisanal screwdiver	4	EPIC	
 3767	weak artisanal spinning dew yoana lei	2	EPIC	
 3768	weak hand-crafted lychee chuhai	2	EPIC	
@@ -3784,8 +3784,8 @@
 3830	squat lime green dance instructor's water-polo cap	0		Experience Percent (Moxie): +10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	delicious Typical Tavern swill	4	awesome	
 3832	smooth weak blurry tropical swill	2	awesome	
-3833	spirit-forward bad fruity girl swill	5	decent	
-3834	watered-down perfectly mixed blended swill	2	EPIC	
+3833	bad spirit-forward fruity girl swill	5	decent	
+3834	perfectly mixed watered-down blended swill	2	EPIC	
 3835	costume wardrobe	0		Softcore Only
 3836	ghostly up-at-dawn gravedigger's Lo Pan's sharpshooter's Elvish sunglasses	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Spooky Damage: +10, Adventures: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	lime green anniversary safety glass vest of Gandalf	0		Spell Critical Percent: +20
@@ -3843,11 +3843,11 @@
 3889	wet non-nitrogenated vial of slime	0		Effect: "Hoity Toity", Effect Duration: 39
 3890	adjusted quadruple-pressed vial of violet slime	0		Effect: "Feelin' Philosophical", Effect Duration: 66
 3891	cold-filtered vial of vermilion slime	0		Effect: "Fit To Be Tide", Effect Duration: 48
-3892	wet bouncing spinning vial of amber slime	0		Effect: "Night Vision", Effect Duration: 41
+3892	wet spinning bouncing vial of amber slime	0		Effect: "Night Vision", Effect Duration: 41
 3893	energized flattened extra-irradiated vial of chartreuse slime	0		Effect: "Worth Your Salt", Effect Duration: 57
 3894	irradiated modified vial of teal slime	0		Effect: "Nigh-Invincible", Effect Duration: 65
 3895	nitrogenated enhanced twirling vial of indigo slime	0		Effect: "Wet Jaw", Effect Duration: 11
-3896	warmed maroon blurry vial of slime	0		Effect: "The Halls of Moxiousness", Effect Duration: 24
+3896	warmed blurry maroon vial of slime	0		Effect: "The Halls of Moxiousness", Effect Duration: 24
 3897	nitrogenated huge vial of brown slime	0		Effect: "Extra-Wet", Effect Duration: 31
 3898	bottle of G&uuml;-Gone	0		
 3901	blinking seal-blubber candle	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	red figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	huge imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	bad watered-down blended swill with a fly in it	2	decent	
+3913	watered-down bad blended swill with a fly in it	2	decent	
 3914	turtle wax	0		
 3915	baleful turtle wax shield	0		Spell Damage: +25, Damage Reduction: 2
 3916	turtle wax helmet of the cougar	0		Moxie: +20, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3904,7 +3904,7 @@
 3952	monocle	0		
 3953	purple mink	0		
 3954	teddy butler	0		
-3955	upside-down squat martini	0		
+3955	squat upside-down martini	0		
 3956	crazy bastard sword	0		
 3957	tin of caviar	0		
 3958	supercharged bejeweled cufflinks	0		Maximum MP Percent: +30, Single Equip
@@ -3950,7 +3950,7 @@
 3998	yellow metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	olive string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	mixed shaking fuchsia squat agua de vida	1	decent	Last Available: "2009-06"
+4001	mixed fuchsia shaking squat agua de vida	1	decent	Last Available: "2009-06"
 4002	pulsating mirror razor-sharp wizardly tortoboggan shield	0		Mysticality: +25, Weapon Damage Percent: +25, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	ruddy soup-chucks	0		Maximum HP Percent: +40
@@ -3960,8 +3960,8 @@
 4008	memory of an A	0		Last Available: "2009-06"
 4009	wobbly memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
-4011	pulsating yellow memory of a CA base pair	0		Last Available: "2009-06"
-4012	tumbling huge memory of a CG base pair	0		Last Available: "2009-06"
+4011	yellow pulsating memory of a CA base pair	0		Last Available: "2009-06"
+4012	huge tumbling memory of a CG base pair	0		Last Available: "2009-06"
 4013	blue memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
@@ -3988,7 +3988,7 @@
 4036	caustic slime nodule	0		
 4037	stale slimy sweetbreads	3	decent	
 4038	delicious narrow red slimy fermented bile bladder	4	awesome	
-4039	dried olive blurry slimy alveolus	1		
+4039	dried blurry olive slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	double-paned Lo Pan's pig-iron helm	0		Spell Critical Percent: +30, Cold Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
 4042	bouncing fireproof strapping pig-iron shinguards	0		Muscle: +5, Hot Resistance: +3, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
@@ -4003,7 +4003,7 @@
 4051	grievous ring of teleportation	0		Weapon Damage Percent: +50, Single Equip
 4052	green glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	banana milkshake	1	super EPIC	Last Available: "2009-06"
-4054	high-proof delicious White Hyborian	7	awesome	Last Available: "2009-06"
+4054	delicious high-proof White Hyborian	7	awesome	Last Available: "2009-06"
 4055	razor-sharp goblin hunting spear	0		Weapon Damage Percent: +25, Last Available: "2009-06"
 4056	Sherlock's goblin autoblowgun of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25, Last Available: "2009-06"
 4057	skewed tribal beads of James Dean	0		Experience (Moxie): +3, Last Available: "2009-06"
@@ -4012,18 +4012,18 @@
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
-4063	yellow pulsating blinking Mecha Mayhem Club Card	0		Last Available: "2009-06"
-4064	teal bouncing 'Smuggler Shot First' Button	0		Last Available: "2009-06"
+4063	blinking pulsating yellow Mecha Mayhem Club Card	0		Last Available: "2009-06"
+4064	bouncing teal 'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
 4070	twirling essence of stench	0		Last Available: "2009-06"
-4071	blue mirror essence of fright	0		Last Available: "2009-06"
+4071	mirror blue essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
-4074	blinking jittery multi-pass	0		Last Available: "2009-06"
+4074	jittery blinking multi-pass	0		Last Available: "2009-06"
 4075	purple chilly brainy villainous scythe	0		Mysticality: +5, Cold Damage: +5, Slime Hates It: +2
 4076	ghostly avaricious baneful bandolier of the dark arts	0		Spell Damage Percent: +100, Meat Drop: +30, Slime Hates It: +1
 4077	olive Jack Frost's diabolical crossbow of the bloodbag	0		Maximum HP: +100, Cold Spell Damage: +50, Slime Hates It: +1
@@ -4089,7 +4089,7 @@
 4137	twirling slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
-4140	yellow upside-down a folded paper strip	0		
+4140	upside-down yellow a folded paper strip	0		
 4141	a crinkled paper strip	0		
 4142	a crumpled paper strip	0		
 4143	a ragged paper strip	0		
@@ -4118,7 +4118,7 @@
 4166	spinning dance instructor's Voluminous Radio Pants	0		Experience Percent (Moxie): +10, Familiar Effect: "2xGhoul, cap 37"
 4167	smelly Voluminous Radio Hat	0		Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
 4168	Voluminous Radio Sneakers of Gandalf	0		Spell Critical Percent: +20, Single Equip
-4169	teal spinning 4-d camera	0		
+4169	spinning teal 4-d camera	0		
 4170	shaking 4-d camera	0		
 4171	crystallized memory	0		
 4172	spinning mansplainer's rock helmet	0		Monster Level: +15, Familiar Effect: "1xGhuol, cap 25"
@@ -4280,7 +4280,7 @@
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	adequate candy kneecapping stick	3	good	Last Available: "2009-12"
-4331	half-sized decent narrow licorice garrote	2	good	Last Available: "2009-12"
+4331	decent half-sized narrow licorice garrote	2	good	Last Available: "2009-12"
 4332	lime green dance instructor's candy knuckles	0		Experience Percent (Moxie): +10, Last Available: "2009-12"
 4333	normal jawbruiser	3	good	Last Available: "2010-12"
 4334	cold-filtered chocolate car	0		Effect: "Educated (Kinda)", Effect Duration: 40, Last Available: "2009-12"
@@ -4313,9 +4313,9 @@
 4361	weak acceptable expired bottle of peppermint schnapps	2	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
-4364	tarnished shaking jittery elven suicide capsule	0		Effect: "Tingly Elbows", Effect Duration: 66, Last Available: "2009-12"
+4364	tarnished jittery shaking elven suicide capsule	0		Effect: "Tingly Elbows", Effect Duration: 66, Last Available: "2009-12"
 4365	miniature spoiled penguin focaccia bread	2	crappy	Last Available: "2009-12"
-4366	special artisanal irresponsibly strong herringcello	6	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 5, Last Available: "2009-12"
+4366	irresponsibly strong artisanal special herringcello	6	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 5, Last Available: "2009-12"
 4367	artisanal elven cellocello	3	EPIC	Last Available: "2009-12"
 4368	wobbly wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
@@ -4342,7 +4342,7 @@
 4390	skewed Red Rover BB gun of the scaredy-cat of the cheetah	0		Monster Level: -15, Initiative: +60, Last Available: "2009-12"
 4391	reassuring red-and-green sweater	0		Spooky Resistance: +1, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
-4393	anodized dry huge squat Crimbo peppermint bark	0		Effect: "In Tuna", Effect Duration: 55, Last Available: "2009-12"
+4393	anodized dry squat huge Crimbo peppermint bark	0		Effect: "In Tuna", Effect Duration: 55, Last Available: "2009-12"
 4394	unsweetened unsweetened Crimbo fudge	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 53, Last Available: "2009-12"
 4395	alkaline cold-filtered Crimbo pecan	0		Effect: "Bilious Brains", Effect Duration: 64, Last Available: "2009-12"
 4396	upside-down Jack-in-the-box	0		Last Available: "2009-12"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	bouncing Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	decent quantum taco	0		Last Available: "2010-10"
-4413	hand-crafted boozy Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	boozy hand-crafted Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	blue colorful plastic ball	0		Last Available: "2010-01"
 4415	sealhide hood of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	studded sealhide leggings	0		Damage Absorption: +80, Familiar Effect: "1xVolley, cap 40"
@@ -4444,7 +4444,7 @@
 4496	mirror extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	oxidized irradiated recording of The Ballad of Richie Thingfinder	0		Effect: "Bats in the Belfry", Effect Duration: 65
 4498	double-altered altered skewed recording of Benetton's Medley of Diversity	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 64
-4499	flattened polarized wobbly red recording of Elron's Explosive Etude	0		Effect: "Took Eleven", Effect Duration: 48
+4499	flattened polarized red wobbly recording of Elron's Explosive Etude	0		Effect: "Took Eleven", Effect Duration: 48
 4500	boiled dry recording of Chorale of Companionship	0		Effect: "The Rich Get Richer", Effect Duration: 22
 4501	oxidized moist recording of Prelude of Precision	0		Effect: "Hennaliciousness", Effect Duration: 36
 4502	quantum wobbly recording of Donho's Bubbly Ballad	0		Effect: "Night of the Nachos", Effect Duration: 28
@@ -4455,13 +4455,13 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	non-pressed dry quadruple-concentrated &quot;DRINK ME&quot; potion	0		Effect: "Hopped Up on Goofballs", Effect Duration: 61, Last Available: "2010-03"
 4509	skewed reflection of a map	0		Last Available: "2010-03"
-4510	small fancy spoiled walrus ice cream	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30, Last Available: "2010-03"
+4510	spoiled small fancy walrus ice cream	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30, Last Available: "2010-03"
 4511	small yummy spinning beautiful soup	2	awesome	Last Available: "2010-03"
 4512	mirror eggman noodles	0		Last Available: "2010-03"
 4513	twirling Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	decent jumbo Humpty Dumplings	5	good	Last Available: "2010-03"
-4515	stale thick pulsating blinking Lobster <i>qua</i> Grill	5	decent	Last Available: "2010-03"
-4516	practically non-alcoholic delicious skewed tumbling missing wine	1	awesome	Last Available: "2010-03"
+4514	jumbo decent Humpty Dumplings	5	good	Last Available: "2010-03"
+4515	stale thick blinking pulsating Lobster <i>qua</i> Grill	5	decent	Last Available: "2010-03"
+4516	delicious practically non-alcoholic tumbling skewed missing wine	1	awesome	Last Available: "2010-03"
 4517	bland ghostly matter custard	3	decent	Last Available: "2010-03"
 4518	vacuum-sealed ghostly comfit?	0		Effect: "Pride of the Vampire", Effect Duration: 21, Last Available: "2010-03"
 4519	spinning ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4508,7 +4508,7 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	mediocre practically non-alcoholic world's most unappetizing beverage	1	decent	Last Available: "2010-04"
+4563	practically non-alcoholic mediocre world's most unappetizing beverage	1	decent	Last Available: "2010-04"
 4564	curative slippery when wet shield	0		HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 6, Last Available: "2010-04"
 4565	normal snack-sized bouncing raisin	2	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4516,7 +4516,7 @@
 4568	yummy a dance upon the palate	4	awesome	Last Available: "2010-04"
 4569	toothsome prehistoric meteorite jawbreaker	3	awesome	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	gigantic normal squirmy violent party snack	9	good	Last Available: "2010-04"
+4571	normal gigantic squirmy violent party snack	9	good	Last Available: "2010-04"
 4572	upside-down can-you-dig-it? of Leguizamo	0		Monster Level: +20, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4542,7 +4542,7 @@
 4594	pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
-4597	blinking lime green 8-Bit Power magazine	0		Last Available: "2010-07"
+4597	lime green blinking 8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	shaking bottle opener	0		Last Available: "2010-06"
 4600	mirror map to the Kegger in the Woods	0		Last Available: "2010-06"
@@ -4552,15 +4552,15 @@
 4604	keg	0		Last Available: "2010-06"
 4605	shaking lard-coated bottle of Goldschn&ouml;ckered of the blizzard	0		Cold Spell Damage: +25, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	flavorless ghostly sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	extra-dry lousy bouncing soyburger juice	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	lousy extra-dry bouncing soyburger juice	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	lime green essential tofu	0		Last Available: "2010-08"
-4610	warmed cyan ghostly essential soy	0		Effect: "Haunted Stomach", Effect Duration: 31, Last Available: "2010-08"
-4611	altered skewed lime green essential cameraderie	0		Effect: "Brain Freeze", Effect Duration: 64, Last Available: "2010-08"
+4610	warmed ghostly cyan essential soy	0		Effect: "Haunted Stomach", Effect Duration: 31, Last Available: "2010-08"
+4611	altered lime green skewed essential cameraderie	0		Effect: "Brain Freeze", Effect Duration: 64, Last Available: "2010-08"
 4612	blurry souvenir drawing	0		Last Available: "2010-08"
 4613	mirror map to the Magic Commune	0		Last Available: "2010-08"
 4614	jittery wool Crown of Thrones	0		Cold Resistance: +1, Softcore Only, Last Available: "2010-05"
-4615	watered-down delicious Cinco Mayo Lager	2	awesome	Last Available: "2010-05"
+4615	delicious watered-down Cinco Mayo Lager	2	awesome	Last Available: "2010-05"
 4616	twirling Underworld sapling	0		Last Available: "2009-10"
 4617	blurry pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4569,7 +4569,7 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	alkaline dry narrow chocolate-covered caviar	0		Effect: "Bootyliciousness", Effect Duration: 23, Last Available: "2020-09"
-4624	super-sized decent pawn cookie	5	good	Last Available: "2010-06"
+4624	decent super-sized pawn cookie	5	good	Last Available: "2010-06"
 4625	distilled mirror coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	blurry superduperball	0		Last Available: "2010-06"
 4627	blue finger cuffs	0		Last Available: "2010-06"
@@ -4620,7 +4620,7 @@
 4672	comfy pillow	0		
 4673	special moldy half-sized tumbling marshmallow	2	crappy	Effect: "Empty Inside", Effect Duration: 50
 4674	adequate sponge cake	3	good	
-4675	artisanal weak gin-soaked blotter paper	2	EPIC	
+4675	weak artisanal gin-soaked blotter paper	2	EPIC	
 4676	ghostly tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	cyan unearthed potsherd	0		
@@ -4654,13 +4654,13 @@
 4706	blue sinister tablet	0		
 4707	pulsating E-Z Cook&trade; oven	0		
 4708	My First Shaker&trade;	0		
-4709	narrow mirror hippo tutu	0		Last Available: "2011-09"
+4709	mirror narrow hippo tutu	0		Last Available: "2011-09"
 4710	upside-down immense ballet shoes	0		Familiar Weight: +5
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	skewed popsicle stick	0		
-4714	special adequate immense lemon popsicle	8	good	Effect: "Mushroom Melody", Effect Duration: 35
-4715	bland special small popsicle	2	decent	Effect: "Highland Sheen", Effect Duration: 35
+4714	adequate special immense lemon popsicle	8	good	Effect: "Mushroom Melody", Effect Duration: 35
+4715	bland small special popsicle	2	decent	Effect: "Highland Sheen", Effect Duration: 35
 4716	enchanted moldy twirling strawberry popsicle	4	crappy	Effect: "Faboooo", Effect Duration: 5
 4717	stale liver popsicle	4	decent	
 4718	groovy mariachi hat	0		Moxie Percent: +10, Familiar Effect: "atk, cap 2"
@@ -4673,8 +4673,8 @@
 4725	flavorless blinking piping organ pie	3	decent	Last Available: "2010-10"
 4726	stale narrow igloo pie	4	decent	Last Available: "2010-10"
 4727	decent small stomach turnover	2	good	Last Available: "2010-10"
-4728	tiny moldy fancy huge spinning bouncing dead lights pie	1	crappy	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2010-10"
-4729	small stale blue throbbing organ pie	2	decent	Last Available: "2010-10"
+4728	fancy tiny moldy bouncing spinning huge dead lights pie	1	crappy	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2010-10"
+4729	stale small blue throbbing organ pie	2	decent	Last Available: "2010-10"
 4730	Jack Frost's stop shield	0		Cold Spell Damage: +50, Damage Reduction: 6, Last Available: "2009-12"
 4731	mirror nest egg	0		
 4732	blue sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4685,14 +4685,14 @@
 4737	rock-hard beer-soaked mop	0		Damage Reduction: 5
 4738	mediocre day-old beer	3	decent	
 4739	bad plain beer	4	decent	
-4740	irresponsibly strong hand-crafted overpriced &quot;imported&quot; beer	9	EPIC	
+4740	hand-crafted irresponsibly strong overpriced &quot;imported&quot; beer	9	EPIC	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	oxidized cold-filtered liquefied bouncing PlexiPips	0		Effect: "Sticks and Stones", Effect Duration: 33
 4745	colloidal Wax Flask	0		Effect: "Optimist Primal", Effect Duration: 64
 4746	improved Pain Dip	0		Effect: "Hangdog", Effect Duration: 58
-4747	half-sized adequate fancy bone meal	2	good	Effect: "Disco Concentration", Effect Duration: 45, Last Available: "2010-10"
+4747	fancy adequate half-sized bone meal	2	good	Effect: "Disco Concentration", Effect Duration: 45, Last Available: "2010-10"
 4748	practically non-alcoholic mediocre blue bone aperitif	1	decent	Last Available: "2010-10"
 4749	olive bonerang	0		Item Drop: +5, Last Available: "2010-10"
 4750	zippy bone and arrows	0		Initiative: +20, Last Available: "2010-10"
@@ -4701,7 +4701,7 @@
 4753	bone spurs of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2010-10"
 4754	olive jittery blinking brainy bonedanna of the early riser	0		Mysticality: +5, Adventures: +7, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
 4755	twirling coward's boneana hammock of the ox	0		Muscle: +20, Monster Level: -20, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
-4756	shaking blue bag of bones	0		Last Available: "2010-10"
+4756	blue shaking bag of bones	0		Last Available: "2010-10"
 4757	squat Stabonic scroll	0		Last Available: "2010-10"
 4758	energized polarized pickled tumbling candy skeleton	0		Effect: "Jungle Juiced", Effect Duration: 41, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	decent green pumpkin pie	4	good	Last Available: "2010-11"
-4764	practically non-alcoholic perfectly mixed pumpkin beer	1	EPIC	Last Available: "2010-11"
+4764	perfectly mixed practically non-alcoholic pumpkin beer	1	EPIC	Last Available: "2010-11"
 4765	ionized enhanced ionized pumpkin juice	0		Effect: "Leisurely Amblin'", Effect Duration: 24, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	rock-hard cool shin gourds	0		Moxie: +5, Damage Reduction: 5, Single Equip, Last Available: "2010-11"
@@ -4746,7 +4746,7 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	stale snack-sized triangular CRIMBCOOKIE	2	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	adequate gigantic square CRIMBCOOKIE	10	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	gigantic adequate square CRIMBCOOKIE	10	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	Jeselnik's clever savvy bindlestocking	0		Mysticality Percent: +20, Maximum MP: +20, Sleaze Damage: +25, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4790,7 +4790,7 @@
 4881	perfectly mixed practically non-alcoholic twirling CRIMBCO wine	1	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	moldy thick toe jam toast	5	crappy	Last Available: "2011-01"
+4884	thick moldy toe jam toast	5	crappy	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	toothsome traffic jam toast	3	awesome	Last Available: "2011-01"
 4887	green space jam	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	ghostly slow jam collection	0		Last Available: "2011-01"
 4893	blurry BGE shotglass	0		Last Available: "2010-12"
 4894	stale small festive sausage	2	decent	Last Available: "2011-01"
-4895	jumbo normal maroon holiday cheese log	5	good	Last Available: "2011-01"
+4895	normal jumbo maroon holiday cheese log	5	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	smartaleck's BGE 'ferocious fruit' shirt of the bloodbag	0		Moxie Percent: +30, Maximum HP: +100, Last Available: "2010-12"
 4898	shaking scorching educational BGE 'cuddly critter' shirt	0		Experience: +1, Hot Damage: +25, Last Available: "2010-12"
@@ -4857,7 +4857,7 @@
 4954	cool oven mitts	0		Moxie: +5, Single Equip
 4955	small flavorless mirror overcookie	2	decent	
 4956	adequate philosopher's scone	4	good	
-4957	irradiated jittery teal half-baked potion	0		Effect: "Marinated", Effect Duration: 61
+4957	irradiated teal jittery half-baked potion	0		Effect: "Marinated", Effect Duration: 61
 4958	Usain Bolt's Knob Goblin deluxe scimitar	0		Initiative: +80
 4959	big decent spinning squat Knob nuts	5	good	
 4960	lousy Cobb's Knob Wurstbrau	3	decent	
@@ -4876,7 +4876,7 @@
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	skewed Alice's Army Page	0		Last Available: "2011-03"
 4975	blue Alice's Army Shieldmaiden	0		Last Available: "2011-03"
-4976	red skewed Alice's Army Mad Bomber	0		Last Available: "2011-03"
+4976	skewed red Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	wobbly Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
@@ -4915,18 +4915,18 @@
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	half-sized tasty special maroon wasabi pocky	2	awesome	Effect: "Chunky", Effect Duration: 40, Last Available: "2011-03"
 5014	tasty tobiko pocky	3	awesome	Last Available: "2011-03"
-5015	half-sized rotten jittery natto pocky	2	crappy	Last Available: "2011-03"
+5015	rotten half-sized jittery natto pocky	2	crappy	Last Available: "2011-03"
 5016	mediocre wasabi-infused sake	4	decent	Last Available: "2011-03"
 5017	hand-crafted lime green tobiko-infused sake	3	EPIC	Last Available: "2011-03"
-5018	special acceptable mirror natto-infused sake	3	good	Effect: "Devil Inside", Effect Duration: 40, Last Available: "2011-03"
+5018	acceptable special mirror natto-infused sake	3	good	Effect: "Devil Inside", Effect Duration: 40, Last Available: "2011-03"
 5019	chilled skewed wasabi marble soda	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 49, Last Available: "2011-03"
 5020	quantum tobiko marble soda	0		Effect: "Tennis Elbow-wow", Effect Duration: 15, Last Available: "2011-03"
 5021	electrified aerosolized bouncing natto marble soda	0		Effect: "Saucemastery", Effect Duration: 21, Last Available: "2011-03"
 5022	red Alice's Army booster box	0		Last Available: "2011-03"
-5023	polarized deionized skewed jittery elderly jawbreaker	0		Effect: "Pyromania", Effect Duration: 47, Last Available: "2020-09"
-5024	weak mediocre yellow marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
+5023	polarized deionized jittery skewed elderly jawbreaker	0		Effect: "Pyromania", Effect Duration: 47, Last Available: "2020-09"
+5024	mediocre weak yellow marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
 5025	hand-crafted blinking cranberry schnapps	4	EPIC	Last Available: "2011-03"
-5026	perfectly mixed strong breaded beer	5	EPIC	Last Available: "2011-03"
+5026	strong perfectly mixed breaded beer	5	EPIC	Last Available: "2011-03"
 5027	bad lime green soy cordial	3	decent	Last Available: "2011-03"
 5028	astral bludgeon of the empath of the overflowing toilet of Flo-Jo	0		Familiar Weight: +5, Stench Spell Damage: +50, Initiative: +100
 5029	healthy astral shield of wisdom	0		Mysticality: +15, Maximum HP Percent: +20, Damage Reduction: 15
@@ -4944,7 +4944,7 @@
 5041	upside-down upside-down dog trainer's healthy astral shirt of wisdom	0		Mysticality: +15, Maximum HP Percent: +20, Experience (familiar): +1
 5042	squat rosewater-soaked astral belt of the storm	0		Maximum MP Percent: +40, Stench Resistance: +3
 5043	moldy blurry astral hot dog	3		
-5044	bad triple-distilled astral pilsner	10		
+5044	triple-distilled bad astral pilsner	10		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	pulsating Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4958,7 +4958,7 @@
 5055	obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	galvanized jittery Atomic Comic	0		Effect: "Bonelording", Effect Duration: 69, Last Available: "2011-04"
-5058	irradiated wobbly bouncing Red Pill	0		Effect: "Punch Another Day", Effect Duration: 43, Last Available: "2011-04"
+5058	irradiated bouncing wobbly Red Pill	0		Effect: "Punch Another Day", Effect Duration: 43, Last Available: "2011-04"
 5059	bouncing Skullhead's Screw	0		Last Available: "2011-04"
 5060	spinning mysterious present	0		Last Available: "2011-04"
 5061	mirror boxing-glove-in-a-box	0		Last Available: "2011-04"
@@ -4973,7 +4973,7 @@
 5070	red upside-down innuendo	0		Last Available: "2011-04"
 5071	snack-sized flavorless s'more	0	decent	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	artisanal watered-down Russian Ice	2	EPIC	Last Available: "2011-04"
+5073	watered-down artisanal Russian Ice	2	EPIC	Last Available: "2011-04"
 5074	clay ashtray of Leguizamo	0		Monster Level: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	banded lanyard	0		Damage Absorption: +100, Single Equip, Last Available: "2011-05"
 5076	personal trainer's monster pants	0		Experience Percent (Muscle): +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
@@ -5007,7 +5007,7 @@
 5104	flattened fish juice box	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 38, Last Available: "2011-05"
 5105	olive tumbling paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	weak artisanal Jeppson's Malort	2	super ultra mega turbo EPIC	Last Available: "2011-06"
+5107	artisanal weak Jeppson's Malort	2	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	wobbly Jeselnik's stress ball	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5025,8 +5025,8 @@
 5122	bouncing spinning auspicious aviator's cap of extreme caution of the empath	0		Monster Level: -25, Familiar Weight: +5, Item Drop: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	scandalous supercool mirrored aviator shades	0		Moxie Percent: +20, Sleaze Damage: +5, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
-5125	fuchsia upside-down Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
-5126	ghostly huge Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
+5125	upside-down fuchsia Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
+5126	huge ghostly Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	spinning Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	twirling Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
@@ -5046,7 +5046,7 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	warmed gray honeypot	0		Effect: "Super-Electrified", Effect Duration: 30
-5146	low-calorie spoiled wild honey pie	1	crappy	
+5146	spoiled low-calorie wild honey pie	1	crappy	
 5147	lousy honey mead	3	decent	
 5148	spinning yellow Temple Grandin's mansplainer's razor-sharp honey dipper	0		Weapon Damage Percent: +25, Monster Level: +15, Familiar Weight: +7
 5149	censurious ribald honeybritches of dire peril	0		Weapon Damage: +20, Sleaze Damage: +10, Sleaze Resistance: +3, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5076,19 +5076,19 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	mediocre practically non-alcoholic Saison du Lune	1	decent	Last Available: "2011-06"
 5175	drinkable Moonthril Schnapps	4	good	Last Available: "2011-06"
-5176	drinkable watered-down spinning Wrecked Generator	2	good	Last Available: "2011-06"
+5176	watered-down drinkable spinning Wrecked Generator	2	good	Last Available: "2011-06"
 5177	big rotten Spaghetti with Moonballs	5	crappy	Last Available: "2011-06"
 5178	normal pulsating Crepes a la Lune	3	good	Last Available: "2011-06"
-5179	spoiled half-sized Moon Pie	2	crappy	Last Available: "2011-06"
+5179	half-sized spoiled Moon Pie	2	crappy	Last Available: "2011-06"
 5180	cold-filtered skewed Comet Pop	0		Effect: "Rat-Faced", Effect Duration: 49, Last Available: "2011-06"
 5181	polarized mirror Flan in the Moon	0		Effect: "Fury of the Bells", Effect Duration: 42, Last Available: "2011-06"
 5182	alkaline extra-magnetized wobbly 1/6th Pound Cake	0		Effect: "Chain Chain Chains", Effect Duration: 28, Last Available: "2011-06"
-5183	huge shaking Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
+5183	shaking huge Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	gray jittery Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
-5188	deionized non-unsweetened wobbly blurry honey stick	0		Effect: "Insatiable Hunger", Effect Duration: 17
+5188	deionized non-unsweetened blurry wobbly honey stick	0		Effect: "Insatiable Hunger", Effect Duration: 17
 5189	super-moist modified double-ice gum	0		Effect: "Bottle in front of Me", Effect Duration: 32, Last Available: "2011-04"
 5190	studded arcane researcher's Operation Patriot Shield of Calamity Jane	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Critical Hit Percent: +15, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
@@ -5098,10 +5098,10 @@
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	olive ghostly slick Great S-Cape	0		Moxie: +10, Softcore Only, Last Available: "2011-07"
 5197	strapping Marvelous Unitard	0		Muscle: +5, Softcore Only, Last Available: "2011-07"
-5198	altered huge blinking yellow gooey paste	1	decent	Last Available: "2011-08"
+5198	altered yellow huge blinking gooey paste	1	decent	Last Available: "2011-08"
 5199	altered ghostly beastly paste	1	good	Last Available: "2011-08"
 5200	modified olive paste	1	good	Last Available: "2011-08"
-5201	diluted tumbling jittery blue ectoplasmic paste	1	good	Last Available: "2011-08"
+5201	diluted blue tumbling jittery ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	vaporized pulsating greasy paste	1	decent	Last Available: "2011-08"
 5203	distilled bug paste	1	good	Effect: "Joyful Resolve", Effect Duration: 15, Last Available: "2011-08"
 5204	dried shaking hippy paste	1	good	Last Available: "2011-08"
@@ -5111,9 +5111,9 @@
 5208	powdered blinking squat paste	1	good	Last Available: "2011-08"
 5209	powdered fuchsia goblin paste	1	awesome	Effect: "Yeah, It's Just Gasoline", Effect Duration: 50, Last Available: "2011-08"
 5210	powdered huge pirate paste	1	crappy	Last Available: "2011-08"
-5211	boiled blurry blinking chlorophyll paste	1	good	Last Available: "2011-08"
+5211	boiled blinking blurry chlorophyll paste	1	good	Last Available: "2011-08"
 5212	modified pulsating upside-down paste	1	EPIC	Last Available: "2011-08"
-5213	modified gray shaking squat Mer-kin paste	1	awesome	Effect: "Smoky Third Eye", Effect Duration: 45, Last Available: "2011-08"
+5213	modified squat gray shaking Mer-kin paste	1	awesome	Effect: "Smoky Third Eye", Effect Duration: 45, Last Available: "2011-08"
 5214	compressed slimy paste	1	decent	Last Available: "2011-08"
 5215	dehydrated penguin paste	1	EPIC	Last Available: "2011-08"
 5216	dried elemental paste	1	good	Effect: "Human-Demon Hybrid", Effect Duration: 5, Last Available: "2011-08"
@@ -5140,12 +5140,12 @@
 5237	skewed pulsating Jack Frost's time halo	0		Cold Spell Damage: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	mediocre Lumineux Limnio	4	decent	Last Available: "2011-09"
 5239	drinkable Morto Moreto	4	good	Last Available: "2011-09"
-5240	acceptable practically non-alcoholic Temps Tempranillo	1	good	Last Available: "2011-09"
+5240	practically non-alcoholic acceptable Temps Tempranillo	1	good	Last Available: "2011-09"
 5241	mediocre ghostly Bordeaux Marteaux	4	decent	Last Available: "2011-09"
 5242	acceptable Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	mediocre purple Beignet Milgranet	3	decent	Last Available: "2011-09"
 5244	acceptable Muschat	4	good	Last Available: "2011-09"
-5245	tiny yummy cool jelly donut	1	awesome	Last Available: "2011-09"
+5245	yummy tiny cool jelly donut	1	awesome	Last Available: "2011-09"
 5246	miniature toothsome shrapnel jelly donut	2	awesome	Last Available: "2011-09"
 5247	stale occult jelly donut	4	decent	Last Available: "2011-09"
 5248	stale small thyme jelly donut	2	decent	Last Available: "2011-09"
@@ -5153,14 +5153,14 @@
 5250	delicious smashed danish	3	awesome	Last Available: "2011-09"
 5251	bland forbidden danish	3	decent	Last Available: "2011-09"
 5252	rotten cool cat claw	3	crappy	Last Available: "2011-09"
-5253	snack-sized bland blunt cat claw	2	decent	Last Available: "2011-09"
+5253	bland snack-sized blunt cat claw	2	decent	Last Available: "2011-09"
 5254	adequate blinking shadowy cat claw	3	good	Last Available: "2011-09"
 5255	immense normal cheezburger	8	good	Last Available: "2011-09"
 5256	normal toasted brie	3	good	Last Available: "2011-09"
 5257	nitrogenated dry potion of the field gar	0		Effect: "Mariachi Mood", Effect Duration: 41, Last Available: "2011-09"
 5258	quadruple-polymerized polarized blue too legit potion	0		Effect: "Powder Power", Effect Duration: 48, Last Available: "2011-09"
 5259	double-altered Bright Water	0		Effect: "Wet Rub", Effect Duration: 25, Last Available: "2011-09"
-5260	frozen concentrated fuchsia upside-down cold-filtered water	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 69, Last Available: "2011-09"
+5260	frozen concentrated upside-down fuchsia cold-filtered water	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 69, Last Available: "2011-09"
 5261	Vulcanized graveyard snowglobe	0		Effect: "Marbles in Your Mouth", Effect Duration: 17, Last Available: "2011-09"
 5262	improved double-wet cool cat elixir	0		Effect: "Total Protonic Reversal", Effect Duration: 45, Last Available: "2011-09"
 5263	aerosolized aerosolized wobbly potion of the captain's hammer	0		Effect: "Material Witness", Effect Duration: 43, Last Available: "2011-09"
@@ -5200,7 +5200,7 @@
 5297	pulsating dungeon dragon chest	0		Last Available: "2011-09"
 5298	snack-sized tasty skewed huge phish stick	2	awesome	Last Available: "2011-09"
 5299	Temple Grandin's sharpshooter's plastic vampire fangs of the brazier	0		Critical Hit Percent: +10, Familiar Weight: +7, Hot Spell Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
-5300	pulsating purple Interview With You (a Vampire)	0		Last Available: "2011-10"
+5300	purple pulsating Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	tumbling Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	jittery your own heart	0		Last Available: "2011-10"
 5303	resourceful Sword of the Brouhaha Prince	0		Maximum MP: +50, Last Available: "2011-10"
@@ -5225,7 +5225,7 @@
 5322	lousy weak Ecto-Cooler	2	decent	Last Available: "2011-10"
 5323	strong acceptable maroon Bartles and BRAAAINS wine cooler	5	good	Last Available: "2011-10"
 5324	mediocre Blood Light	4	decent	Last Available: "2011-10"
-5325	mediocre practically non-alcoholic Silver Bullet beer	1	decent	Last Available: "2011-10"
+5325	practically non-alcoholic mediocre Silver Bullet beer	1	decent	Last Available: "2011-10"
 5326	artisanal Bone's Farm &quot;wine&quot;	3	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	cold-filtered yellow sorority brain	0		Effect: "Frigid Weapon", Effect Duration: 19, Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	shaking purple shellacked educational The Necbromancer's Shorts of chilblains	0		Experience: +1, Damage Reduction: 7, Cold Damage: +25, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	nasty grievous educational The Necbromancer's Wizard Staff	0		Experience: +1, Weapon Damage Percent: +50, Stench Damage: +5, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	drinkable practically non-alcoholic The Cooler Out of Space	1	good	Last Available: "2011-10"
+5342	practically non-alcoholic drinkable The Cooler Out of Space	1	good	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	warmed modified jittery Necbro wafers	0		Effect: "You Know When to Walk Away", Effect Duration: 18, Last Available: "2020-09"
@@ -5303,8 +5303,8 @@
 5400	candy cane candygram	0		Last Available: "2011-12"
 5401	purple skewed peppermint parasol	0		Last Available: "2011-11"
 5402	green jittery Da Vinci's candy cane	0		Experience (Mysticality): +5, Last Available: "2011-12"
-5403	bouncing tumbling blinking Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
-5404	shaking narrow Peppermint Pip Packet	0		Last Available: "2011-11"
+5403	tumbling blinking bouncing Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
+5404	narrow shaking Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	skewed upside-down greedy Annie Oakley's razor-sharp cane-mail shirt	0		Weapon Damage Percent: +25, Critical Hit Percent: +20, Meat Drop: +20, Last Available: "2011-12"
 5406	double-paned manspreader's cane-mail pants of the scaredy-cat	0		Monster Level: -5, Cold Resistance: +5, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	bad Vodka Matryoshka	4	decent	Last Available: "2011-12"
@@ -5337,7 +5337,7 @@
 5434	pulsating DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
 5436	triple-diffused irradiated fudge lily	0		Effect: "Man's Worst Enemy", Effect Duration: 67, Last Available: "2011-11"
-5437	blinking teal superheated fudge	0		Last Available: "2011-11"
+5437	teal blinking superheated fudge	0		Last Available: "2011-11"
 5438	quadruple-polarized flattened pulsating fluid of fudge-finding	0		Effect: "Halloweeny", Effect Duration: 51, Last Available: "2011-11"
 5439	maroon fudgepuck	0		Last Available: "2011-11"
 5440	yummy fudgesicle	4	awesome	Last Available: "2011-11"
@@ -5355,7 +5355,7 @@
 5452	avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
-5455	maroon bouncing gummi ingot	0		Last Available: "2011-11"
+5455	bouncing maroon gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	super-boiled improved Fudgie Roll	0		Effect: "Whole Latte Love", Effect Duration: 58, Last Available: "2011-11"
 5458	moldy snack-sized ghostly fudge bunny	2	crappy	Last Available: "2011-11"
@@ -5380,10 +5380,10 @@
 5477	energized skewed gummi snake	0		Effect: "Banono", Effect Duration: 50, Last Available: "2011-11"
 5478	liquefied quadruple-Vulcanized quantum ghostly gummi canary	0		Effect: "Strange Mental Acuity", Effect Duration: 54, Last Available: "2011-11"
 5479	stale gummi bear	4	decent	Last Available: "2011-11"
-5480	spoiled spinning pulsating gummi bear	4	crappy	Last Available: "2011-11"
+5480	spoiled pulsating spinning gummi bear	4	crappy	Last Available: "2011-11"
 5481	stale jittery gummi bear	3	decent	Last Available: "2011-11"
 5482	bland ghostly drunki-bear	3	decent	Last Available: "2011-11"
-5483	bite-sized fancy spoiled drunki-bear	1	crappy	Effect: "Gamer Rage", Effect Duration: 50, Last Available: "2011-11"
+5483	fancy bite-sized spoiled drunki-bear	1	crappy	Effect: "Gamer Rage", Effect Duration: 50, Last Available: "2011-11"
 5484	bland special drunki-bear	3	decent	Effect: "Tasting the Rainbow", Effect Duration: 15, Last Available: "2011-11"
 5485	horrifying gummi bowtie	0		Spooky Damage: +25, Last Available: "2011-11"
 5486	Jeselnik's fudge pocket square	0		Sleaze Damage: +25, Last Available: "2011-11"
@@ -5403,13 +5403,13 @@
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
-5503	blinking ghostly Tickle-Me Emilio	0		Last Available: "2011-11"
+5503	ghostly blinking Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	small decent enchanted jerky coins	2	good	Effect: "Pasty", Effect Duration: 5, Last Available: "2011-11"
+5506	small enchanted decent jerky coins	2	good	Effect: "Pasty", Effect Duration: 5, Last Available: "2011-11"
 5507	lousy blurry Go-Wassail	3	decent	Last Available: "2011-11"
 5508	colloidal fuchsia squat Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Barbecue Saucy", Effect Duration: 51, Last Available: "2011-11"
-5509	activated narrow tumbling bottle of bubbles	0		Effect: "Big Meat Big Prizes", Effect Duration: 68, Last Available: "2011-11"
+5509	activated tumbling narrow bottle of bubbles	0		Effect: "Big Meat Big Prizes", Effect Duration: 68, Last Available: "2011-11"
 5510	electrified maroon wind-up meatcar	0		Effect: "Flower Power", Effect Duration: 35, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
@@ -5422,17 +5422,17 @@
 5519	gray pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	shaking pog #07 (orcish frat boy)	0		Last Available: "2011-11"
-5522	huge twirling pog #08 (hellion)	0		Last Available: "2011-11"
+5522	twirling huge pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pulsating pog #10 (hobo)	0		Last Available: "2011-11"
-5525	green wobbly pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
+5525	wobbly green pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	adjusted Atomic Pop	0		Effect: "Infernal Thirst", Effect Duration: 47, Last Available: "2020-09"
 5527	twirling do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	green whimpering willow bark	0		Last Available: "2012-12"
-5529	miniature yummy berries of suffering	2	awesome	Last Available: "2012-12"
+5529	yummy miniature berries of suffering	2	awesome	Last Available: "2012-12"
 5530	concentrated wobbly baobab sap	0		Effect: "The Moxious Madrigal", Effect Duration: 39, Last Available: "2012-12"
 5531	upside-down cup of hickory chicory	0		Last Available: "2012-12"
-5532	upside-down narrow gray magnolia blossom	0		Last Available: "2012-12"
+5532	upside-down gray narrow magnolia blossom	0		Last Available: "2012-12"
 5533	nitrogenated triple-anodized Mortimer's nostrum	0		Effect: "Industrial Strength Starch", Effect Duration: 20, Last Available: "2012-12"
 5534	acceptable high-proof Barulio's bottle	6	good	Last Available: "2012-12"
 5535	electrified galvanized Marvin's marvelous pill	0		Effect: "Squirming Like a Toad", Effect Duration: 25, Last Available: "2012-12"
@@ -5465,9 +5465,9 @@
 5562	lime green flame-retardant greasy Rain-Doh violet bo	0		Sleaze Spell Damage: +10, Hot Resistance: +1, Softcore Only, Last Available: "2012-02"
 5563	maroon Rain-Doh box	0		Last Available: "2012-02"
 5564	pulsating Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	moldy big PB&BP	5	crappy	
+5565	big moldy PB&BP	5	crappy	
 5566	flavorless club sandwich	3	decent	
-5567	bite-sized stale blinking gray spinning corned-beef Reuben	1	decent	
+5567	stale bite-sized spinning gray blinking corned-beef Reuben	1	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
@@ -5480,25 +5480,25 @@
 5577	drinkable Slippery Knob	4	good	Last Available: "2012-03"
 5578	delicious weak yellow Flaming Knob	2	awesome	Last Available: "2012-03"
 5579	mediocre Grasshopper	4	decent	Last Available: "2012-03"
-5580	irresponsibly strong smooth Locust	8	awesome	Last Available: "2012-03"
-5581	acceptable practically non-alcoholic Plague of Locusts	1	good	Last Available: "2012-03"
+5580	smooth irresponsibly strong Locust	8	awesome	Last Available: "2012-03"
+5581	practically non-alcoholic acceptable Plague of Locusts	1	good	Last Available: "2012-03"
 5582	drinkable Red Dwarf	3	good	Last Available: "2012-03"
 5583	weak acceptable Golden Mean	2	good	Last Available: "2012-03"
 5584	high-proof bad Green Giant	10	decent	Last Available: "2012-03"
 5585	hand-crafted Aye Aye	3	EPIC	Last Available: "2012-03"
 5586	practically non-alcoholic perfectly mixed skewed Aye Aye, Captain	1	EPIC	Last Available: "2012-03"
-5587	high-proof perfectly mixed bouncing Aye Aye, Tooth Tooth	10	EPIC	Last Available: "2012-03"
+5587	perfectly mixed high-proof bouncing Aye Aye, Tooth Tooth	10	EPIC	Last Available: "2012-03"
 5588	artisanal Humanitini	3	EPIC	Last Available: "2012-03"
 5589	acceptable green More Humanitini than Humanitini	3	good	Last Available: "2012-03"
-5590	lousy enchanted watered-down Oh, the Humanitini	2	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2012-03"
+5590	watered-down enchanted lousy Oh, the Humanitini	2	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2012-03"
 5591	lousy Great Older Fashioned	4	decent	Last Available: "2012-03"
-5592	mediocre tumbling olive Fuzzy Tentacle	3	decent	Last Available: "2012-03"
+5592	mediocre olive tumbling Fuzzy Tentacle	3	decent	Last Available: "2012-03"
 5593	bad irresponsibly strong blue Crazymaker	8	decent	Last Available: "2012-03"
-5594	artisanal high-proof yellow Zoodriver	9	EPIC	Last Available: "2012-03"
-5595	special delicious practically non-alcoholic Sloe Comfortable Zoo	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2012-03"
+5594	high-proof artisanal yellow Zoodriver	9	EPIC	Last Available: "2012-03"
+5595	practically non-alcoholic special delicious Sloe Comfortable Zoo	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2012-03"
 5596	smooth Sloe Comfortable Zoo on Fire	4	awesome	Last Available: "2012-03"
-5597	acceptable distilled ghostly Suffering Sinner	5	good	Last Available: "2012-03"
-5598	boozy smooth Suppurating Sinner	5	awesome	Last Available: "2012-03"
+5597	distilled acceptable ghostly Suffering Sinner	5	good	Last Available: "2012-03"
+5598	smooth boozy Suppurating Sinner	5	awesome	Last Available: "2012-03"
 5599	drinkable Sizzling Sinner	3	good	Last Available: "2012-03"
 5600	triple-distilled bad twirling Firewater	9	decent	Last Available: "2012-03"
 5601	mediocre Earth and Firewater	3	decent	Last Available: "2012-03"
@@ -5509,8 +5509,8 @@
 5606	hand-crafted high-proof Cement Mixer	10	EPIC	Last Available: "2012-03"
 5607	acceptable Jackhammer	4	good	Last Available: "2012-03"
 5608	tolerable Dump Truck	3	good	Last Available: "2012-03"
-5609	lousy strong pulsating Fauna Libre	5	decent	Last Available: "2012-03"
-5610	aged bouncing squat Chakra Libre	4	awesome	Last Available: "2012-03"
+5609	strong lousy pulsating Fauna Libre	5	decent	Last Available: "2012-03"
+5610	aged squat bouncing Chakra Libre	4	awesome	Last Available: "2012-03"
 5611	bad Aura Libre	4	decent	Last Available: "2012-03"
 5612	hand-crafted pulsating Sazerorc	4	EPIC	Last Available: "2012-03"
 5613	smooth practically non-alcoholic red jittery Sazuruk-hai	1	awesome	Last Available: "2012-03"
@@ -5518,27 +5518,27 @@
 5615	lousy practically non-alcoholic Green Velvet	1	decent	Last Available: "2012-03"
 5616	acceptable Green Muslin	3	good	Last Available: "2012-03"
 5617	perfectly mixed Green Burlap	3	EPIC	Last Available: "2012-03"
-5618	mediocre irresponsibly strong Mohobo	10	decent	Last Available: "2012-03"
+5618	irresponsibly strong mediocre Mohobo	10	decent	Last Available: "2012-03"
 5619	bad spirit-forward Moonshine Mohobo	5	decent	Last Available: "2012-03"
 5620	tolerable jittery Flaming Mohobo	4	good	Last Available: "2012-03"
-5621	lousy weak special blurry Drunken Philosopher	2	decent	Effect: "Mighty Shout", Effect Duration: 45, Last Available: "2012-03"
+5621	weak lousy special blurry Drunken Philosopher	2	decent	Effect: "Mighty Shout", Effect Duration: 45, Last Available: "2012-03"
 5622	perfectly mixed Drunken Neurologist	4	EPIC	Last Available: "2012-03"
-5623	smooth watered-down Drunken Astrophysicist	2	awesome	Last Available: "2012-03"
-5624	hand-crafted practically non-alcoholic Dark & Starry	1	EPIC	Last Available: "2012-03"
-5625	boozy bad Black Hole	5	decent	Last Available: "2012-03"
+5623	watered-down smooth Drunken Astrophysicist	2	awesome	Last Available: "2012-03"
+5624	practically non-alcoholic hand-crafted Dark & Starry	1	EPIC	Last Available: "2012-03"
+5625	bad boozy Black Hole	5	decent	Last Available: "2012-03"
 5626	hand-crafted watered-down Event Horizon	2	EPIC	Last Available: "2012-03"
 5627	delicious Herring Daiquiri	4	awesome	Last Available: "2012-03"
 5628	artisanal maroon Herring Wallbanger	4	EPIC	Last Available: "2012-03"
-5629	special perfectly mixed fuchsia Herringtini	4	EPIC	Effect: "Coated Arms", Effect Duration: 35, Last Available: "2012-03"
-5630	weak hand-crafted blurry Lollipop Drop	2	EPIC	Last Available: "2012-03"
+5629	perfectly mixed special fuchsia Herringtini	4	EPIC	Effect: "Coated Arms", Effect Duration: 35, Last Available: "2012-03"
+5630	hand-crafted weak blurry Lollipop Drop	2	EPIC	Last Available: "2012-03"
 5631	smooth Candy Alexander	4	awesome	Last Available: "2012-03"
 5632	artisanal Candicaine	3	EPIC	Last Available: "2012-03"
 5633	aged watered-down Caipiranha	2	awesome	Last Available: "2012-03"
-5634	distilled smooth gray huge Flying Caipiranha	5	awesome	Last Available: "2012-03"
-5635	triple-distilled acceptable Flaming Caipiranha	8	good	Last Available: "2012-03"
+5634	distilled smooth huge gray Flying Caipiranha	5	awesome	Last Available: "2012-03"
+5635	acceptable triple-distilled Flaming Caipiranha	8	good	Last Available: "2012-03"
 5636	mediocre fancy Punchplanter	3	decent	Effect: "El Tango de la Maldita Suegra", Effect Duration: 10, Last Available: "2012-03"
 5637	acceptable Doublepunchplanter	3	good	Last Available: "2012-03"
-5638	lousy special weak Haymaker	2	decent	Effect: "Sweet and Yellow", Effect Duration: 10, Last Available: "2012-03"
+5638	lousy weak special Haymaker	2	decent	Effect: "Sweet and Yellow", Effect Duration: 10, Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	spoiled fungus	3	crappy	
@@ -5555,7 +5555,7 @@
 5652	fuchsia Monster Manuel	0		Free Pull
 5653	shaking key-o-tron	0		
 5654	adequate blinking nailswurst	4	good	
-5655	drinkable irresponsibly strong bouncing used beer	9	good	
+5655	irresponsibly strong drinkable bouncing used beer	9	good	
 5656	shaking Huggler Radio	0		Free Pull
 5657	green fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5569,7 +5569,7 @@
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
-5669	huge wobbly club	0		
+5669	wobbly huge club	0		
 5670	stale fettucini &eacute;pines Inconnu	3	decent	
 5671	delicious slap and slap again	3	awesome	
 5672	blinking gunpowder burrito	2	good	
@@ -5618,7 +5618,7 @@
 5717	stale maroon shaking FDKOL hotcakes	3	decent	Last Available: "2012-07"
 5718	ghostly hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	bland miniature purple fiery wing	2	decent	Last Available: "2012-07"
+5720	miniature bland purple fiery wing	2	decent	Last Available: "2012-07"
 5721	nasty baleful wings of fire	0		Spell Damage: +25, Stench Damage: +5, Last Available: "2012-07"
 5722	ghostly supercool FDKOL fire hose	0		Moxie Percent: +20, Last Available: "2012-07"
 5723	quantum bottle of fire	0		Effect: "Human-Elf Hybrid", Effect Duration: 61, Last Available: "2012-07"
@@ -5634,12 +5634,12 @@
 5733	upside-down eerily silent box	0		
 5734	stale forbidden sausage	3	decent	
 5735	ribald Lord Flameface's cloak	0		Sleaze Damage: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
-5736	frozen fuchsia squat Drizzlers&trade; Black Licorice	0		Effect: "Capricorn Rising", Effect Duration: 33
+5736	frozen squat fuchsia Drizzlers&trade; Black Licorice	0		Effect: "Capricorn Rising", Effect Duration: 33
 5737	moist daub-breaker	0		Effect: "Sugar, Hello", Effect Duration: 16, Last Available: "2020-09"
 5738	jittery steel-toed Camp Scout backpack	0		Damage Reduction: 9, Softcore Only, Last Available: "2012-07"
 5739	teal CSA fire-starting kit	0		Last Available: "2012-07"
 5740	rotten half-sized twirling green bag of GORP	2	crappy	Last Available: "2012-07"
-5741	tolerable weak water purification pills	2	good	Last Available: "2012-07"
+5741	weak tolerable water purification pills	2	good	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	practically non-alcoholic hand-crafted CSA scoutmaster's &quot;water&quot;	1	super ultra EPIC	Last Available: "2012-07"
 5744	rotten bag of GORF	3	crappy	Last Available: "2012-07"
@@ -5652,9 +5652,9 @@
 5751	tumbling Tales of the Word Realms	0		
 5752	moldy tiny crappy brain	1	crappy	
 5753	stale decent brain	3	decent	
-5754	small bland good brain	2	decent	
+5754	bland small good brain	2	decent	
 5755	thick spoiled boss brain	5	crappy	
-5756	half-sized decent fancy hunter brain	2	good	Effect: "Pumped Stomach", Effect Duration: 30
+5756	decent half-sized fancy hunter brain	2	good	Effect: "Pumped Stomach", Effect Duration: 30
 5758	greedy therapeutic supercool Staff of Holiday Sensations	0		Moxie Percent: +20, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-11"
 5759	wool staff of bravery	0		Cold Resistance: +1, Spooky Resistance: +5
 5760	miser's Oprah's staff of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Meat Drop: +10
@@ -5674,7 +5674,7 @@
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	pulsating lightning-fast savvy Barney's rake	0		Mysticality Percent: +20, Initiative: +40
-5778	huge adequate jittery idiot brain	9	good	
+5778	adequate huge jittery idiot brain	9	good	
 5779	maroon hardy keel-haulin' knife	0		Maximum HP: +50
 5780	ice cream scoop of horror	0		Spooky Spell Damage: +25
 5781	triple-distilled mediocre soft echo eyedrop antidote martini	10	decent	
@@ -5685,7 +5685,7 @@
 5786	hard screw	0		
 5787	twirling messy butt joint	0		
 5788	smut orc keepsake box	0		
-5789	yellow pulsating bubblin' crude	0		
+5789	pulsating yellow bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
 5791	lightning-fast Samson's right bear arm	0		Experience (Muscle): +5, Initiative: +40, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
 5792	ghostly smelly left bear arm of the brute of incineration	0		Muscle Percent: +30, Hot Spell Damage: +50, Stench Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
@@ -5695,7 +5695,7 @@
 5796	electrified warmed Gearhead Goo	0		Effect: "init.enh", Effect Duration: 42
 5797	boiled wobbly Missing Eye Simulation Device	0		Effect: "Haunted Liver", Effect Duration: 52
 5798	modified quantum blinking Gnollish Crossdress	0		Effect: "Patent Avarice", Effect Duration: 46
-5799	cold-filtered moist wobbly narrow eldritch dough	0		Effect: "Hairy Palms", Effect Duration: 57
+5799	cold-filtered moist narrow wobbly eldritch dough	0		Effect: "Hairy Palms", Effect Duration: 57
 5800	polarized Charity's choker	0		Effect: "Hennaliciousness", Effect Duration: 59
 5801	moist twirling Smart Bone Dust	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 15
 5802	chilled perpendicular guano	0		Effect: "Become Superficially interested", Effect Duration: 36
@@ -5713,7 +5713,7 @@
 5814	flattened ionized blob of acid	0		Effect: "All Fired Up", Effect Duration: 27
 5815	frozen blue flayed mind	0		Effect: "Trash-Wrapped", Effect Duration: 57
 5816	oxidized nitrogenated kobold kibble	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 56
-5817	ionized skewed blue forest spirit rattle	0		Effect: "Disdain of the War Snapper", Effect Duration: 34
+5817	ionized blue skewed forest spirit rattle	0		Effect: "Disdain of the War Snapper", Effect Duration: 34
 5818	quantum twirling twirling Stone Golem pebbles	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 27
 5819	colloidal liquefied gravy fairy warlock hat	0		Effect: "Oily Flavor", Effect Duration: 63
 5820	alkaline bull blubber	0		Effect: "Super Skill", Effect Duration: 63
@@ -5724,7 +5724,7 @@
 5825	frozen spinning Skullery Maid's Knee	0		Effect: "Macho Profundo", Effect Duration: 23
 5826	super-vacuum-sealed huge zombie hollandaise	0		Effect: "Ooh, Salty!", Effect Duration: 20
 5827	quadruple-electrified magnetized olive shaking skeletal banana	0		Effect: "Bear Clawed", Effect Duration: 17
-5828	magnetized activated red pulsating gilt perfume bottle	0		Effect: "Coy to the Hurled", Effect Duration: 63
+5828	magnetized activated pulsating red gilt perfume bottle	0		Effect: "Coy to the Hurled", Effect Duration: 63
 5829	anodized mirror janglin' bones	0		Effect: "Thanksgot", Effect Duration: 30
 5830	activated Vulcanized tumbling purple pygmy papers	0		Effect: "Mushroom Melody", Effect Duration: 14
 5831	flattened diffused oxidized wobbly pygmy dart	0		Effect: "Gummiheart", Effect Duration: 61
@@ -5738,7 +5738,7 @@
 5839	pickled ravenous eye	0		Effect: "Flashing Eyes", Effect Duration: 42
 5840	quantum bouncing Rogue Windmill Rouge	0		Effect: "Night of the Nachos", Effect Duration: 25
 5841	enhanced upside-down A muse-bouche	0		Effect: "Ancestral Disapproval", Effect Duration: 24
-5842	polymerized triple-polymerized blinking twirling toothbrush	0		Effect: "Thick-Skinned", Effect Duration: 59
+5842	polymerized triple-polymerized twirling blinking toothbrush	0		Effect: "Thick-Skinned", Effect Duration: 59
 5843	alkaline tumbling pirate cream pie	0		Effect: "Phairly Balanced", Effect Duration: 65
 5844	ionized galvanized una poca de gracia	0		Effect: "How to Scam Tourists", Effect Duration: 31
 5845	anodized wet compressed air canister	0		Effect: "Full Bottle in front of Me", Effect Duration: 20
@@ -5871,7 +5871,7 @@
 5973	record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	blurry record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	spinning record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
-5976	teal upside-down record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
+5976	upside-down teal record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	spinning rosewater-soaked sizzling nippy silent beret	0		Cold Damage: +10, Hot Damage: +10, Stench Resistance: +3, Familiar Effect: "1xVolley, cap 3"
 5978	rotten slice of pizza	3	crappy	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
@@ -5893,7 +5893,7 @@
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	purple extra-strength potion	0		Last Available: "2013-02"
 5997	squat potion	0		Last Available: "2013-02"
-5998	practically non-alcoholic bad shining goblet	1	decent	Last Available: "2013-02"
+5998	bad practically non-alcoholic shining goblet	1	decent	Last Available: "2013-02"
 5999	mirror fireball	0		Last Available: "2013-02"
 6000	zippy perfumed scandalous crown	0		Sleaze Damage: +5, Stench Resistance: +5, Initiative: +20, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	chilly dog trainer's wicked sword	0		Spell Damage: +5, Experience (familiar): +1, Cold Damage: +5, Last Available: "2013-02"
@@ -5917,7 +5917,7 @@
 6019	loadstone of the boozehound	0		Booze Drop: +100
 6020	Sherlock's razor-sharp Claybender glasses	0		Weapon Damage Percent: +25, Item Drop: +25, Single Equip
 6021	ruddy educational Duskwalker fangs	0		Experience: +1, Maximum HP Percent: +40
-6022	maroon twirling Space Tourist Phaser	0		
+6022	twirling maroon Space Tourist Phaser	0		
 6023	foul-smelling Whoompa Fur Pants of the brazier	0		Hot Spell Damage: +25, Stench Damage: +10, Familiar Effect: "atk, cap 27"
 6024	deadly Whatsian Ionic Pliers	0		Weapon Damage: +5
 6025	diffused Polysniff Perfume	0		Effect: "Marinated", Effect Duration: 30
@@ -5931,9 +5931,9 @@
 6033	medical-grade stolen necklace of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 7, HP Regen Max: 10
 6034	jittery supercharged dangerous troll britches	0		Weapon Damage: +10, Maximum MP Percent: +30, Familiar Effect: "1.5xPotato, cap 28"
 6035	frozen energized red twirling vial of The Glistening	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 37
-6036	triple-distilled bad artisanal limoncello	9	decent	
+6036	bad triple-distilled artisanal limoncello	9	decent	
 6037	ginger ale	0		
-6038	moldy snack-sized special incredible pizza	2	crappy	Effect: "Extra-Wet", Effect Duration: 50
+6038	special moldy snack-sized incredible pizza	2	crappy	Effect: "Extra-Wet", Effect Duration: 50
 6039	Rosewater's oil cap of the brute	0		Muscle Percent: +30, Mysticality Percent: +30, Familiar Effect: "cap 28"
 6040	red quilted weightlifter's oil lamp	0		Muscle: +15, Damage Absorption: +40
 6041	stylish oil slacks	0		Moxie: +25, Familiar Effect: "1xPotato, cap 30"
@@ -5948,7 +5948,7 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	wobbly Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	spoiled bouncing Taco Dan's Taco Stand Taco	3	crappy	Last Available: "2012-12"
-6053	enchanted triple-distilled smooth Taco Dan's Taco Stand Chimichangarita	7	awesome	Effect: "Metal Speed", Effect Duration: 5, Last Available: "2012-12"
+6053	triple-distilled enchanted smooth Taco Dan's Taco Stand Chimichangarita	7	awesome	Effect: "Metal Speed", Effect Duration: 5, Last Available: "2012-12"
 6054	boiled adjusted mirror Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 66, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
@@ -5966,7 +5966,7 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	twirling skewed Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	skewed twirling Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	tumbling spinning shaking confusing LED clock	0		Last Available: "2012-12"
 6073	adjusted haggis-infused soap	0		Effect: "Adrenaline Rush", Effect Duration: 56, Last Available: "2012-12"
 6074	quantum chilled spinning magicberry tablets	0		Effect: "Natural 20", Effect Duration: 54, Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	red goggles	0		Last Available: "2013-12"
 6119	wobbly abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	enchanted practically non-alcoholic mediocre squat Chinese beer	1	decent	Effect: "Stuck-Up Hair", Effect Duration: 40, Last Available: "2013-12"
+6121	mediocre enchanted practically non-alcoholic squat Chinese beer	1	decent	Effect: "Stuck-Up Hair", Effect Duration: 40, Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6064,7 +6064,7 @@
 6167	aromatic ornamental sextant	0		Stench Resistance: +1, Last Available: "2013-12"
 6168	Van der Graaf Bloodbath of the sewer	0		Stench Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
 6169	hand-crafted high-proof Hundred Headed IPA	9	EPIC	Last Available: "2013-12"
-6170	flavorless big chum	5	decent	Last Available: "2013-12"
+6170	big flavorless chum	5	decent	Last Available: "2013-12"
 6171	colloidal pressed crude crudit&eacute;s	0		Effect: "Fit To Be Tide", Effect Duration: 36
 6172	boiled super-electrified candy crayons	0		Effect: "On the Trolley", Effect Duration: 60, Last Available: "2020-09"
 6173	skewed flame-retardant pixel grappling hook of Leguizamo	0		Monster Level: +20, Hot Resistance: +1
@@ -6079,7 +6079,7 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	baleful Sinatra's Jarlsberg's hat of terror	0		Experience (Moxie): +5, Spell Damage: +25, Spooky Spell Damage: +10
-6185	bland massive consummate hard-boiled egg	10	decent	
+6185	massive bland consummate hard-boiled egg	10	decent	
 6186	toothsome skewed consummate fried egg	4	awesome	
 6187	adequate consummate egg salad	4	good	
 6188	rotten shaking consummate bagel	3	crappy	
@@ -6087,7 +6087,7 @@
 6190	bland consummate hot dog bun	3	decent	
 6191	spoiled consummate brownie	3	crappy	
 6192	stale gray consummate toast	4	decent	
-6193	watered-down smooth passable stout	2	awesome	
+6193	smooth watered-down passable stout	2	awesome	
 6194	massive decent consummate soup	6	good	
 6195	adequate consummate corn chips	4	good	
 6196	stale consummate salad	3	decent	
@@ -6097,22 +6097,22 @@
 6200	moldy consummate melted cheese	4	crappy	
 6201	spoiled enchanted consummate bacon	3	crappy	Effect: "Chalked-Up Teeth", Effect Duration: 40
 6202	flavorless consummate meatloaf	3	decent	
-6203	snack-sized spoiled consummate steak	2	crappy	
-6204	small flavorless consummate cuts	2	decent	
+6203	spoiled snack-sized consummate steak	2	crappy	
+6204	flavorless small consummate cuts	2	decent	
 6205	spoiled twirling consummate frankfurter	3	crappy	
 6206	adequate special consummate french fries	4	good	Effect: "Eyes Wide Propped", Effect Duration: 35
-6207	decent half-sized consummate baked potato	2	good	
+6207	half-sized decent consummate baked potato	2	good	
 6208	drinkable watered-down acceptable vodka	2	good	
 6209	decent spinning teal consummate ice cream	4	good	
 6210	normal narrow bouncing consummate whipped cream	4	good	
-6211	special rotten consummate cream	3	crappy	Effect: "Horrid, Torrid", Effect Duration: 25
-6212	normal half-sized twirling narrow consummate strawberries	2	good	
+6211	rotten special consummate cream	3	crappy	Effect: "Horrid, Torrid", Effect Duration: 25
+6212	half-sized normal twirling narrow consummate strawberries	2	good	
 6213	decent consummate sorbet	4	good	
-6214	distilled mediocre adequate rum	5	decent	
-6215	smooth distilled mediocre lager	5	awesome	
+6214	mediocre distilled adequate rum	5	decent	
+6215	distilled smooth mediocre lager	5	awesome	
 6216	gigantic spoiled immaculate grilled cheese	8	crappy	
 6217	tasty immaculate ice cream sandwich	3	awesome	
-6218	spoiled miniature squat immaculate hot dog	2	crappy	
+6218	miniature spoiled squat immaculate hot dog	2	crappy	
 6219	delicious immaculate egg salad sandwich	3	awesome	
 6220	delicious small perfect sandwich	2	awesome	
 6221	big spoiled perfect chef salad	5	crappy	
@@ -6121,17 +6121,17 @@
 6224	snack-sized fancy rotten sublime stew	2	crappy	Effect: "Horrid, Torrid", Effect Duration: 45
 6225	adequate jumbo sublime nachos	5	good	
 6226	stale Ultimate Breakfast Sandwich	4	decent	
-6227	rotten small Loaded Baked Potato	2	crappy	
+6227	small rotten Loaded Baked Potato	2	crappy	
 6228	bland Omega Sundae	3	decent	
-6229	acceptable extra-dry Das Sauerlager	5	good	
-6230	practically non-alcoholic hand-crafted maroon Bologna Lambic	1	super ultra EPIC	
+6229	extra-dry acceptable Das Sauerlager	5	good	
+6230	hand-crafted practically non-alcoholic maroon Bologna Lambic	1	super ultra EPIC	
 6231	practically non-alcoholic tolerable blurry Vodka Dog	1	good	
 6232	artisanal Disappointed Russian	4	EPIC	
 6233	hand-crafted extra-dry Chunky Mary	5	EPIC	
-6234	perfectly mixed weak Nachojito	2	EPIC	
-6235	practically non-alcoholic acceptable yellow Le Roi	1	good	
+6234	weak perfectly mixed Nachojito	2	EPIC	
+6235	acceptable practically non-alcoholic yellow Le Roi	1	good	
 6236	hand-crafted Over Easy Rider	3	EPIC	
-6237	maroon spinning cosmic six-pack	0		
+6237	spinning maroon cosmic six-pack	0		
 6239	cold-filtered cube of ectoplasm	0		Effect: "All Is Forgiven", Effect Duration: 23
 6240	triple-nitrogenated electrified upside-down Illuminati earpiece	0		Effect: "Worth Your Salt", Effect Duration: 28
 6241	frozen censored can label	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 55
@@ -6160,7 +6160,7 @@
 6264	rosewater-soaked asbestos-lined Lo Pan's Staff of Fruit Salad	0		Spell Critical Percent: +30, Hot Resistance: +5, Stench Resistance: +3, Jiggle: "Deal Some Prismatic Damage"
 6265	perfumed shellacked Socratic Staff of the Cream of the Cream	0		Experience (Mysticality): +1, Damage Reduction: 7, Stench Resistance: +5, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	big bland grain of protein powder	5	decent	
+6267	bland big grain of protein powder	5	decent	
 6268	modified flattened green pec oil	0		Effect: "Phairly Balanced", Effect Duration: 48
 6269	grievous gym membership card	0		Weapon Damage Percent: +50
 6270	super-liquefied Squat-Thrust Magazine	0		Effect: "In Tuna", Effect Duration: 42
@@ -6174,7 +6174,7 @@
 6278	wobbly Ye Olde Medieval Insult	0		
 6279	jittery nippy pewter claymore	0		Cold Damage: +10
 6280	pulsating skewed careful artisanal rice peeler	0		Monster Level: -10
-6281	stale immense heirloom grape tomato	9	decent	
+6281	immense stale heirloom grape tomato	9	decent	
 6282	chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6186,7 +6186,7 @@
 6290	steam-powered model rocketship	0		
 6291	twirling careful punk rock jacket of Flo-Jo	0		Monster Level: -10, Initiative: +100
 6292	lime green Da Vinci's safety pin of the scaredy-cat	0		Experience (Mysticality): +5, Monster Level: -15
-6293	rotten small stolen sushi	2	crappy	
+6293	small rotten stolen sushi	2	crappy	
 6294	blurry very overdue library book	0		
 6295	blinking drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6238,7 +6238,7 @@
 6342	pulsating Usain Bolt's educational super-strong air freshener	0		Experience: +1, Initiative: +80
 6343	alkaline anodized tumbling Mer-kin lipstick	0		Effect: "Intimidating Mien", Effect Duration: 47
 6344	Mer-kin mouthsoap	0		
-6345	quantum colloidal tumbling blurry blue Mer-kin strongjuice	0		Effect: "Twinkly Weapon", Effect Duration: 44
+6345	quantum colloidal blurry blue tumbling Mer-kin strongjuice	0		Effect: "Twinkly Weapon", Effect Duration: 44
 6346	Mer-kin fitbrine	0		
 6347	Vulcanized Mer-kin ragejuice	0		Effect: "Meat the Flintstones", Effect Duration: 47
 6348	perfumed Mer-kin dragbelt	0		Stench Resistance: +5, Experience (Muscle): +20, Single Equip
@@ -6247,7 +6247,7 @@
 6351	Usain Bolt's Mer-kin finpaddle	0		Initiative: +80
 6352	Mer-kin stopwatch of the detective	0		Item Drop: +20, Initiative: +50
 6353	Mer-kin dreadscroll	0		
-6354	concentrated super-alkaline huge blue narrow Mer-kin smartjuice	0		Effect: "Inebriate Pride", Effect Duration: 68
+6354	concentrated super-alkaline blue huge narrow Mer-kin smartjuice	0		Effect: "Inebriate Pride", Effect Duration: 68
 6355	unsweetened Mer-kin cooljuice	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 68
 6356	skewed Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
@@ -6266,7 +6266,7 @@
 6370	twisted piece of wire	0		
 6371	tolerable can of the cheapest beer	4	good	
 6372	enchanted perfectly mixed bottle of fruity &quot;wine&quot;	3	EPIC	Effect: "Sweet Taste", Effect Duration: 25
-6373	bad special watered-down single swig of vodka	2	decent	Effect: "Salad Days", Effect Duration: 30
+6373	watered-down special bad single swig of vodka	2	decent	Effect: "Salad Days", Effect Duration: 30
 6374	angry inch	0		
 6375	olive shaking testy toolbox of terror	0		Spooky Spell Damage: +10
 6376	blurry tumbling Jick-o-User	0		
@@ -6316,7 +6316,7 @@
 6421	tonic djinn	0		
 6422	yummy vampire chowder	4	awesome	
 6423	Tales of Dread	0		Free Pull
-6424	green huge wobbly Dreadsylvanian skeleton key	0		
+6424	huge wobbly green Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	toothsome Dreadsylvanian stew	3	awesome	
 6427	artisanal practically non-alcoholic Dreadsylvanian	1	super ultra EPIC	
@@ -6338,14 +6338,14 @@
 6443	teal banded Helps-You-Sleep of the early riser	0		Damage Absorption: +100, Adventures: +7, Single Equip
 6444	auspicious energetic healthy Quiets-Your-Steps	0		Maximum HP Percent: +20, Maximum MP Percent: +20, Item Drop: +10, Single Equip
 6445	blinking Protects-Your-Junk of the dark arts of the businessman	0		Spell Damage Percent: +100, Meat Drop: +50, Single Equip
-6446	bad weak Gets-You-Drunk	2	decent	
+6446	weak bad Gets-You-Drunk	2	decent	
 6447	blinking rosewater-soaked ribald foul-smelling Great Wolf's headband	0		Stench Damage: +10, Sleaze Damage: +10, Stench Resistance: +3, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	thinker's weightlifter's Great Wolf's left paw of Calamity Jane	0		Muscle: +15, Mysticality: +10, Critical Hit Percent: +15, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	ghostly Oprah's vibrating brawny Great Wolf's right paw	0		Muscle Percent: +20, Maximum MP Percent: 60, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	upside-down Oprah's therapeutic Great Wolf's rocket launcher	0		Maximum MP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	rosewater-soaked frosty medical-grade Great Wolf's beastly trousers	0		Cold Spell Damage: +10, Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, 1.5xWhelp"
 6452	yellow Great Wolf's lice	0		
-6453	flattened ionized vacuum-sealed bouncing pulsating Hunger&trade; Sauce	0		Effect: "stats.enq", Effect Duration: 22
+6453	flattened ionized vacuum-sealed pulsating bouncing Hunger&trade; Sauce	0		Effect: "stats.enq", Effect Duration: 22
 6454	zombie mariachi hat of wisdom of the dark arts of the boozehound	0		Mysticality: +15, Spell Damage Percent: +100, Booze Drop: +100, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	forbidden brawny zombie accordion of dire peril	0		Muscle Percent: +20, Weapon Damage: +20, Spell Damage Percent: +50, Class: "Accordion Thief", Single Equip, Song Duration: 20
 6456	up-at-dawn savvy zombie mariachi pants of Tarzan	0		Mysticality Percent: +20, Experience (Muscle): +3, Adventures: +5, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
@@ -6360,7 +6360,7 @@
 6465	fireproof Mayor Ghost's gavel of the storm of terror	0		Maximum MP Percent: +40, Spooky Spell Damage: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Hammer Ghost"
 6466	scandalous horrifying fortified Mayor Ghost's sash	0		Damage Absorption: +60, Spooky Damage: +25, Sleaze Damage: +5, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	special normal ghost pepper	3	good	Effect: "Impregnabili Tea", Effect Duration: 25
+6468	normal special ghost pepper	3	good	Effect: "Impregnabili Tea", Effect Duration: 25
 6469	padded beefcake's Thunkula's drinking cap of the bloodbag	0		Muscle: +25, Damage Absorption: +20, Maximum HP: +100, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	bouncing Socratic Drunkula's cape of the storm of the sewer	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Stench Damage: +25, Class: "Sauceror"
 6471	teal lightning-fast lion tamer's smooth Drunkula's silky pants	0		Moxie: +15, Experience (familiar): +2, Initiative: +40, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6379,7 +6379,7 @@
 6484	dread tarragon	0		
 6485	bone flour	0		
 6486	squat dreadful roast	0		
-6487	huge pulsating stinking agaricus	0		
+6487	pulsating huge stinking agaricus	0		
 6488	low-calorie adequate fuchsia Dreadsylvanian shepherd's pie	1	good	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
@@ -6390,7 +6390,7 @@
 6495	Jim Carey's Dreadsylvania Auditor's badge	0		Monster Level: +25, Kruegerand Drop: 5, Single Equip
 6496	twirling blood kiwi	0		
 6497	eau de mort	0		
-6498	lousy practically non-alcoholic bloody kiwitini	1	decent	
+6498	practically non-alcoholic lousy bloody kiwitini	1	decent	
 6499	blinking spinning moon-amber	0		
 6500	polished moon-amber	0		
 6501	knitted educational moon-amber necklace of Leguizamo	0		Experience: +1, Monster Level: +20, Cold Resistance: +3, Single Equip
@@ -6408,7 +6408,7 @@
 6513	blurry wool warm fur	0		Cold Resistance: +1
 6514	auspicious snowstick	0		Item Drop: +10
 6515	spinning wholesome eerie fetish	0		Maximum HP Percent: +10, Single Equip
-6516	watered-down acceptable stinkwater	2	good	
+6516	acceptable watered-down stinkwater	2	good	
 6517	wobbly dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	moldy enchanted accidental mutton	3	crappy	Effect: "On Pins and Needles", Effect Duration: 35
 6519	ghostly horrifying wicked drafty drawers	0		Spell Damage: +5, Spooky Damage: +25, Familiar Effect: "1.5xVolley"
@@ -6421,9 +6421,9 @@
 6526	rosewater-soaked healthy bag of unfinished business	0		Maximum HP Percent: +20, Stench Resistance: +3
 6527	asbestos-lined stylish transparent pants	0		Moxie: +25, Hot Resistance: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	upside-down grievous hothammer	0		Weapon Damage Percent: +50
-6529	aged enchanted watered-down Thriller Ice	2	awesome	Effect: "Sealed Brain", Effect Duration: 15
+6529	enchanted aged watered-down Thriller Ice	2	awesome	Effect: "Sealed Brain", Effect Duration: 15
 6530	Da Vinci's grandfather watch	0		Experience (Mysticality): +5, Single Equip
-6531	shaking wobbly muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
+6531	wobbly shaking muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	huge lion tamer's supercool spyglass	0		Moxie Percent: +20, Experience (familiar): +2
 6533	skewed hardy vial of hot blood	0		Maximum HP: +50, Single Equip
 6534	therapeutic remorseless knife	0		HP Regen Min: 5, HP Regen Max: 7
@@ -6442,7 +6442,7 @@
 6548	olive huge cooling iron helmet	0		
 6549	cooling iron breastplate	0		
 6550	cooling iron greaves	0		
-6551	lime green wobbly hot cluster	0		
+6551	wobbly lime green hot cluster	0		
 6552	cluster	0		
 6553	jittery cluster	0		
 6554	stench cluster	0		
@@ -6457,13 +6457,13 @@
 6563	wool hand of Mr. Cards	0		Cold Resistance: +1, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	decent maroon Dreadsylvanian hot pocket	4	good	
 6565	bite-sized bland Dreadsylvanian pocket	1	decent	
-6566	stale low-calorie Dreadsylvanian pocket	1	decent	
+6566	low-calorie stale Dreadsylvanian pocket	1	decent	
 6567	yummy pulsating Dreadsylvanian stink pocket	3	awesome	
 6568	bland bite-sized spinning Dreadsylvanian sleaze pocket	1	decent	
 6569	fancy hand-crafted Dreadsylvanian hot toddy	3	super ultra mega turbo EPIC	Effect: "Human-Beast Hybrid", Effect Duration: 40
 6570	acceptable triple-distilled Dreadsylvanian cold-fashioned	7	good	
 6571	bad strong blue Dreadsylvanian grimlet	5	decent	
-6572	weak drinkable Dreadsylvanian dank and stormy	2	good	
+6572	drinkable weak Dreadsylvanian dank and stormy	2	good	
 6573	tolerable Dreadsylvanian slithery nipple	4	good	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6484,7 +6484,7 @@
 6590	blinking upside-down curative Engorged Sausages and You of temperance of the businessman	0		Sleaze Resistance: +5, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5
 6591	bad dream of a dog	3	decent	
 6592	red Temple Grandin's rock-hard grievous optimal spreadsheet	0		Weapon Damage Percent: +50, Damage Reduction: 5, Familiar Weight: +7
-6593	skewed teal defective Game Grid token	0		
+6593	teal skewed defective Game Grid token	0		
 6594	mirror hot Dreadsylvanian cocoa	0		
 6595	distilled epic cluster	1	awesome	Effect: "Crud&eacute;", Effect Duration: 30
 6596	clockwork egg	0		
@@ -6510,9 +6510,9 @@
 6616	decent small jittery spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	huge maroon folder (red)	0		Muscle: +20, Last Available: "2013-08"
-6619	blue pulsating folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
+6619	pulsating blue folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	purple folder (green)	0		Moxie: +20, Last Available: "2013-08"
-6621	wobbly huge folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
+6621	huge wobbly folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
@@ -6557,7 +6557,7 @@
 6665	red strapping deathchucks of wisdom	0		Muscle: +5, Mysticality: +15
 6666	eraser	0		
 6667	quasireligious sculpture	0		
-6668	blurry fuchsia Faraday cage	0		
+6668	fuchsia blurry Faraday cage	0		
 6669	modeling claymore	0		
 6670	clay homunculus	0		
 6671	double-Vulcanized spinning sodium pentasomething	0		Effect: "Spiritually Awake", Effect Duration: 34
@@ -6584,7 +6584,7 @@
 6692	McClusky file (page 4)	0		
 6693	McClusky file (page 5)	0		
 6694	boring binder clip	0		
-6695	tumbling blue McClusky file (complete)	0		
+6695	blue tumbling McClusky file (complete)	0		
 6696	bowling ball	0		
 6697	moss-covered stone sphere	0		
 6698	cyan dripping stone sphere	0		
@@ -6613,7 +6613,7 @@
 6721	twirling Fonzie's water bottle of doom of the cheetah	0		Experience (Moxie): +1, Spooky Spell Damage: +50, Initiative: +60, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	magnetized oxidized dry ghostly blue pygmy phone number	0		Effect: "Abyssal Tears", Effect Duration: 64
 6723	Boozehounds Anonymous token	0		
-6724	huge flavorless huge exotic jungle fruit	8	decent	
+6724	flavorless huge huge exotic jungle fruit	8	decent	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6621,7 +6621,7 @@
 6729	UV-resistant compass	0		
 6730	bouncing funky junk key	0		
 6731	Worse Homes and Gardens	0		
-6732	ghostly red claw-foot bathtub	0		
+6732	red ghostly claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	cigar sign	0		
 6735	junk junk	0		
@@ -6634,8 +6634,8 @@
 6742	ribald junk band	0		Sleaze Damage: +10
 6743	therapeutic junk trunks	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "cap 15"
 6744	teal wobbly perfumed junk-mail shirt	0		Stench Resistance: +5
-6745	normal small junk food	2	good	
-6746	drinkable weak junk yard	2	good	
+6745	small normal junk food	2	good	
+6746	weak drinkable junk yard	2	good	
 6747	supercool swordzall of the cheetah	0		Moxie Percent: +20, Initiative: +60
 6748	skewed executive arm buzzer	0		Meat Drop: +40, Damage Reduction: 6
 6749	foul-smelling boilgun of mayonnaise	0		Stench Damage: +10, Sleaze Spell Damage: +50
@@ -6646,14 +6646,14 @@
 6754	beer bottle	0		
 6755	beer label	0		
 6756	squat artisanal homebrew sampler	0		
-6757	tolerable fancy wobbly can of Br&uuml;talbr&auml;u	3	good	Effect: "Ooh, Umami!", Effect Duration: 40, Last Available: "2013-09"
+6757	fancy tolerable wobbly can of Br&uuml;talbr&auml;u	3	good	Effect: "Ooh, Umami!", Effect Duration: 40, Last Available: "2013-09"
 6758	drinkable can of Drooling Monk	4	good	Last Available: "2013-09"
 6759	lousy watered-down teal can of Impetuous Scofflaw	2	decent	Last Available: "2013-09"
-6760	perfectly mixed irresponsibly strong narrow bottle of Old Pugilist	8	EPIC	Last Available: "2013-09"
-6761	triple-distilled bad special bottle of Professor Beer	6	decent	Effect: "Mushroom Magicalness", Effect Duration: 25, Last Available: "2013-09"
+6760	irresponsibly strong perfectly mixed narrow bottle of Old Pugilist	8	EPIC	Last Available: "2013-09"
+6761	bad special triple-distilled bottle of Professor Beer	6	decent	Effect: "Mushroom Magicalness", Effect Duration: 25, Last Available: "2013-09"
 6762	mediocre ghostly bottle of Rapier Witbier	3	decent	Last Available: "2013-09"
 6763	weak aged maroon bottle of Race Car Red	2	awesome	Last Available: "2013-09"
-6764	hand-crafted irresponsibly strong bottle of Greedy Dog	9	EPIC	Last Available: "2013-09"
+6764	irresponsibly strong hand-crafted bottle of Greedy Dog	9	EPIC	Last Available: "2013-09"
 6765	bad purple bottle of Lambada Lambic	3	decent	Last Available: "2013-09"
 6766	tumbling tin beer can	0		
 6767	artisanal homebrew gift package	0		
@@ -6682,12 +6682,12 @@
 6792	huge candy knife	0		
 6793	shaking soap knife	0		
 6795	super-aerosolized triple-alkaline disco horoscope (Aquarius)	0		Effect: "Pop-eyed", Effect Duration: 16
-6796	unsweetened liquefied ghostly narrow disco horoscope (Pisces)	0		Effect: "Lubed", Effect Duration: 62
+6796	unsweetened liquefied narrow ghostly disco horoscope (Pisces)	0		Effect: "Lubed", Effect Duration: 62
 6797	extra-magnetized denatured altered disco horoscope (Aries)	0		Effect: "Rotten Memories", Effect Duration: 19
 6798	double-boiled disco horoscope (Taurus)	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 27
 6799	Vulcanized chilled mirror disco horoscope (Gemini)	0		Effect: "Stenchtastic", Effect Duration: 59
 6800	warmed upside-down disco horoscope (Cancer)	0		Effect: "Bustle Hustlin'", Effect Duration: 33
-6801	tarnished double-magnetized gray ghostly disco horoscope (Leo)	0		Effect: "Sparkling Consciousness", Effect Duration: 15
+6801	tarnished double-magnetized ghostly gray disco horoscope (Leo)	0		Effect: "Sparkling Consciousness", Effect Duration: 15
 6802	galvanized disco horoscope (Virgo)	0		Effect: "Chock Full o' Nanites", Effect Duration: 56
 6803	improved disco horoscope (Libra)	0		Effect: "Puddingface", Effect Duration: 30
 6804	electrified concentrated tumbling twirling disco horoscope (Scorpio)	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 51
@@ -6735,7 +6735,7 @@
 6846	walkie-talkie	0		Free Pull
 6847	killing jar	0		
 6848	security flashlight of Gandalf	0		Spell Critical Percent: +20
-6849	aerosolized flattened olive mirror Effermint&trade; tablets	0		Effect: "Chalky White Pallor", Effect Duration: 15
+6849	aerosolized flattened mirror olive Effermint&trade; tablets	0		Effect: "Chalky White Pallor", Effect Duration: 15
 6850	purple huge resourceful sturdy cane of the scaredy-cat of the early riser	0		Maximum MP: +50, Monster Level: -15, Adventures: +7
 6851	spinning huge bowl of candy	0		
 6852	jittery Ultra Mega Sour Ball	0		
@@ -6748,11 +6748,11 @@
 6859	fuchsia skewed bouncing chilly rock-hard Skipper's accordion	0		Damage Reduction: 5, Cold Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6860	green lard-coated savvy slick Pantsgiving of the glutton	0		Moxie: +10, Mysticality Percent: +20, Sleaze Spell Damage: +25, Food Drop: +100, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	rotten can of sardines	3	crappy	Last Available: "2013-11"
-6862	enchanted spoiled high-calorie sugar substitute	4	crappy	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2013-11"
+6862	spoiled enchanted high-calorie sugar substitute	4	crappy	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2013-11"
 6863	huge adequate pat of butter	7	good	Last Available: "2013-11"
-6864	adequate fancy gigantic dinner roll	10	good	Effect: "Tiki Temerity", Effect Duration: 15, Last Available: "2013-11"
+6864	gigantic adequate fancy dinner roll	10	good	Effect: "Tiki Temerity", Effect Duration: 15, Last Available: "2013-11"
 6865	super-sized bland mashed potatoes	5	decent	Last Available: "2013-11"
-6866	delicious snack-sized huge whole turkey leg	2	awesome	Last Available: "2013-11"
+6866	snack-sized delicious huge whole turkey leg	2	awesome	Last Available: "2013-11"
 6867	bland deviled egg	3	decent	Last Available: "2013-11"
 6868	enhanced finger exerciser	0		Effect: "Good Karma", Effect Duration: 37, Last Available: "2013-11"
 6869	quadruple-galvanized wobbly dented spoon	0		Effect: "Flashing Eyes", Effect Duration: 67, Last Available: "2013-11"
@@ -6778,7 +6778,7 @@
 6889	mirror spirit blanket	0		
 6890	spirit bed	0		
 6891	friendly Samson's spirit bell of the overflowing toilet	0		Experience (Muscle): +5, Familiar Weight: +3, Stench Spell Damage: +50, Class: "Turtle Tamer"
-6892	extra-quantum bouncing bouncing blinking spoonful of Linguine-Os	0		Effect: "Deadly Flashing Blade", Effect Duration: 39, Last Available: "2013-11"
+6892	extra-quantum bouncing blinking bouncing spoonful of Linguine-Os	0		Effect: "Deadly Flashing Blade", Effect Duration: 39, Last Available: "2013-11"
 6893	pressed freezer-burned frost-bitten tortellini	0		Effect: "Broberry Brotality", Effect Duration: 55, Last Available: "2013-11"
 6894	cold-filtered teal blob of Alphredo&trade;	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 25, Last Available: "2013-11"
 6895	altered polymerized moist handful of crafty noodles	0		Effect: "Bricked-In", Effect Duration: 58, Last Available: "2013-11"
@@ -6792,15 +6792,15 @@
 6903	polymerized jittery nuts	0		Effect: "Boon of She-Who-Was", Effect Duration: 30, Last Available: "2013-12"
 6904	altered bolts	0		Effect: "Ooh, Salty!", Effect Duration: 13, Last Available: "2013-12"
 6905	spoiled wobbly gingerbread robot	3	crappy	Last Available: "2013-12"
-6906	huge yummy upside-down petit 4.1	9	awesome	Last Available: "2013-12"
-6907	decent jumbo nut-shaped Crimbo cookie	5	good	Last Available: "2023-06"
+6906	yummy huge upside-down petit 4.1	9	awesome	Last Available: "2013-12"
+6907	jumbo decent nut-shaped Crimbo cookie	5	good	Last Available: "2023-06"
 6908	experienced plastic GORM-8	0		Experience: +2, Last Available: "2013-12"
 6909	family-friendly plastic warbear	0		Sleaze Resistance: +1, Last Available: "2013-12"
 6910	Herculean plastic Toybot	0		Experience (Muscle): +1, Last Available: "2013-12"
 6911	auspicious plastic warbear fortress	0		Item Drop: +10, Last Available: "2013-12"
 6912	spinning mirror gravedigger's Da Vinci's plastic K.R.A.M.P.U.S.	0		Experience (Mysticality): +5, Spooky Damage: +10, Last Available: "2013-12"
 6913	blinking warbear whosit	0		Last Available: "2013-12"
-6914	bouncing teal warbear hoverbelt piecepart	0		Last Available: "2013-12"
+6914	teal bouncing warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	Sherlock's rosy-cheeked stylish warbear hoverbelt	0		Moxie: +25, Maximum HP Percent: +30, Item Drop: +25, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
@@ -6811,7 +6811,7 @@
 6922	moldy bouncing warbear warrior bread	4	crappy	Last Available: "2013-12"
 6923	bland warbear thermoregulator bread	4	decent	Last Available: "2013-12"
 6924	weak tolerable skewed warbear feasting mead	2	good	Last Available: "2013-12"
-6925	spirit-forward hand-crafted warbear bearserker mead	5	EPIC	Last Available: "2013-12"
+6925	hand-crafted spirit-forward warbear bearserker mead	5	EPIC	Last Available: "2013-12"
 6926	watered-down aged special warbear blizzard mead	2	awesome	Effect: "Toast Tea", Effect Duration: 35, Last Available: "2013-12"
 6927	teal warbear helm fragment	0		Last Available: "2013-12"
 6928	reassuring medical-grade fortified warbear plain fedora	0		Damage Absorption: +60, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
@@ -6918,7 +6918,7 @@
 7029	zippy hardy strapping Shakespeare's Sister's Accordion	0		Muscle: +5, Maximum HP: +50, Initiative: +20, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	jittery chaotic third-hand lantern	0		Spell Critical Percent: +10
 7031	loose purse strings	0		
-7032	flavorless thick huge pickled egg	5	decent	
+7032	thick flavorless huge pickled egg	5	decent	
 7033	cup of lukewarm tea	1	good	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6954,7 +6954,7 @@
 7065	boiled grim fairy tale	1	good	Effect: "Eyes Wide Propped", Effect Duration: 50, Last Available: "2014-12"
 7066	cyan grimstone galoshes	0		Familiar Weight: +5
 7067	enhanced tumbling single of Inigo's Incantation of Inspiration	0		Effect: "Full-Body Tan", Effect Duration: 39, Last Available: "2010-02"
-7068	anodized fuchsia huge single of Donho's Bubbly Ballad	0		Effect: "Simulation Stimulation", Effect Duration: 33
+7068	anodized huge fuchsia single of Donho's Bubbly Ballad	0		Effect: "Simulation Stimulation", Effect Duration: 33
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
 7071	adequate snow berries	3	good	Last Available: "2014-01"
@@ -6963,7 +6963,7 @@
 7074	energized irradiated wobbly snow cleats	0		Effect: "Florid Cheeks", Effect Duration: 56, Last Available: "2014-01"
 7075	extra-galvanized non-moist liquid ice pack	0		Effect: "Boletus Swoletus", Effect Duration: 42, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	tasty bite-sized snow crab	1	awesome	Last Available: "2014-01"
+7077	bite-sized tasty snow crab	1	awesome	Last Available: "2014-01"
 7078	watered-down tolerable Ice Island Long Tea	2	good	Last Available: "2014-01"
 7079	blue unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
@@ -7001,7 +7001,7 @@
 7112	smooth chocotini	3	awesome	Last Available: "2014-12"
 7113	jittery mansplainer's vibrating chocolate rabbit's foot of extreme caution	0		Maximum MP Percent: +10, Monster Level: -10, Last Available: "2014-12"
 7114	rotten narrow candy carrot	3	crappy	Last Available: "2014-12"
-7115	gigantic decent blurry candy carrot cake	10	good	Last Available: "2014-12"
+7115	decent gigantic blurry candy carrot cake	10	good	Last Available: "2014-12"
 7116	tumbling Sherlock's personal trainer's carrot-on-a-stick	0		Experience Percent (Muscle): +10, Item Drop: +25, Last Available: "2014-12"
 7117	lightning-fast wool weasel stomping pants	0		Cold Resistance: +1, Initiative: +40, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	fancy adequate mulberry	4	good	Effect: "Sticky Fingers", Effect Duration: 20, Last Available: "2014-12"
@@ -7010,28 +7010,28 @@
 7121	dangerous lemon party hat	0		Weapon Damage: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	jittery sharpshooter's lemon shirt	0		Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2014-12"
 7123	huge zippy lemon drop trousers	0		Initiative: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
-7124	super-polymerized huge blue lemonhead caviar	0		Effect: "Sweet Taste", Effect Duration: 62, Last Available: "2014-12"
+7124	super-polymerized blue huge lemonhead caviar	0		Effect: "Sweet Taste", Effect Duration: 62, Last Available: "2014-12"
 7125	asbestos-lined chaotic gummi sword	0		Spell Critical Percent: +10, Hot Resistance: +5, Last Available: "2014-12"
 7126	activated alkaline small gummi fin	0		Effect: "Mariachi Mood", Effect Duration: 59, Last Available: "2014-12"
 7127	chocolate cow bone of terror	0		Spooky Spell Damage: +10, Last Available: "2014-12"
 7128	oxidized chilled gummi fang	0		Effect: "Frisky Spirit", Effect Duration: 13, Last Available: "2014-12"
 7129	low-calorie flavorless leftover canap&eacute;s	1	decent	Last Available: "2014-12"
-7130	triple-distilled lousy magnum of champagne	7	decent	Last Available: "2014-12"
+7130	lousy triple-distilled magnum of champagne	7	decent	Last Available: "2014-12"
 7131	rosewater-soaked stylish cow creamer of the bloodbag	0		Moxie: +25, Maximum HP: +100, Stench Resistance: +3, Last Available: "2014-12"
 7132	flattened polymerized ghostly Outer Wolf&trade; cologne	0		Effect: "Heart of Yellow", Effect Duration: 35, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	avaricious wolf whistle of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	thick spoiled witch's bread	5	crappy	Last Available: "2014-12"
+7135	spoiled thick witch's bread	5	crappy	Last Available: "2014-12"
 7136	chilled moist witch's brew	0		Effect: "Here's Mud in Your Eye", Effect Duration: 21, Last Available: "2014-12"
 7137	lard-coated brawny stylish witch's bra	0		Moxie: +25, Muscle Percent: +20, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7138	smooth watered-down mirror mid-level medieval mead	2	awesome	Last Available: "2014-12"
+7138	watered-down smooth mirror mid-level medieval mead	2	awesome	Last Available: "2014-12"
 7139	super-anodized R&uuml;mpelstiltz	0		Effect: "Sugary Tongue", Effect Duration: 12, Last Available: "2014-12"
 7140	lime green spinning wheel	0		Last Available: "2014-12"
 7141	non-dry spinning hi-octane carrot juice	0		Effect: "Tiki Temerity", Effect Duration: 46, Last Available: "2014-12"
 7142	Vulcanized blinking hare brush	0		Effect: "Uncanny Shot", Effect Duration: 36, Last Available: "2014-12"
 7143	hardy slick hare pin	0		Moxie: +10, Maximum HP: +50, Single Equip, Last Available: "2014-12"
 7144	spinning odd coin	0		Last Available: "2014-12"
-7145	flavorless miniature special cinnamon cannoli	2	decent	Effect: "Sticks and Stones", Effect Duration: 50, Last Available: "2014-12"
+7145	flavorless special miniature cinnamon cannoli	2	decent	Effect: "Sticks and Stones", Effect Duration: 50, Last Available: "2014-12"
 7146	artisanal expensive champagne	3	EPIC	Last Available: "2014-12"
 7147	unsweetened polymerized polo trophy	0		Effect: "Disco Inferno", Effect Duration: 17, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7046,13 +7046,13 @@
 7157	olive Oprah's fire hose of chilblains	0		Maximum MP Percent: +50, Cold Damage: +25, Item Drop: +5, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	half-sized adequate bouncing fireman's lunch	2	good	Last Available: "2014-12"
 7159	pulsating squat Sherlock's deadly plain paper hat of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Item Drop: +25, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	miniature spoiled narrow ice cream sandwich	2	crappy	Last Available: "2014-12"
+7160	spoiled miniature narrow ice cream sandwich	2	crappy	Last Available: "2014-12"
 7161	crafty smartaleck's cool &quot;honey&quot; dipper	0		Moxie: +5, Moxie Percent: +30, Maximum MP: +10, Last Available: "2014-12"
 7162	stale plumber's lunch	3	decent	Last Available: "2014-12"
 7163	zippy Herculean thinker's skull gearshift knob	0		Mysticality: +10, Experience (Muscle): +1, Initiative: +20, Last Available: "2014-12"
 7164	spoiled nachos of the night	4	crappy	Last Available: "2014-12"
 7165	teal narrow flame-retardant energetic Sketcherz&trade; of the early riser	0		Maximum MP Percent: +20, Hot Resistance: +1, Adventures: +7, Last Available: "2014-12"
-7166	adequate diet narrow can of Adultwitch&trade;	1	good	Last Available: "2014-12"
+7166	diet adequate narrow can of Adultwitch&trade;	1	good	Last Available: "2014-12"
 7167	triple-modified smudge stick	0		Effect: "Incensed", Effect Duration: 54, Last Available: "2014-12"
 7168	ionized wall	0		Effect: "Elvish", Effect Duration: 50, Last Available: "2014-12"
 7169	weak delicious huge huge tankard of ale	2	awesome	Last Available: "2014-12"
@@ -7060,12 +7060,12 @@
 7171	moist narrow jug of &quot;wine&quot;	0		Effect: "Thanksgot", Effect Duration: 46, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	special bland half-sized humble pie	2	decent	Effect: "Meatwise", Effect Duration: 20, Last Available: "2014-12"
-7175	blurry squat small golem	0		Last Available: "2014-12"
+7174	special half-sized bland humble pie	2	decent	Effect: "Meatwise", Effect Duration: 20, Last Available: "2014-12"
+7175	squat blurry small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	modified frozen quadruple-energized yellow crappy waiter disguise	0		Effect: "Arresistible", Effect Duration: 49
 7178	Copperhead Charm	0		
-7179	fuchsia tumbling The First Pizza	0		
+7179	tumbling fuchsia The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
@@ -7073,7 +7073,7 @@
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	lime green Copperhead Charm (rampant)	0		
-7187	weak hand-crafted red unnamed cocktail	2	EPIC	
+7187	hand-crafted weak red unnamed cocktail	2	EPIC	
 7188	skewed handful of tips	0		
 7189	upside-down aromatic unrequired jacket	0		Stench Resistance: +1
 7190	cyan MacGyver's tommy gun	0		Maximum MP: +100, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7111,14 +7111,14 @@
 7222	practically non-alcoholic acceptable purple Flamin' Whatshisname	1	good	
 7223	cold-filtered lynyrd musk	0		Effect: "On a Roll", Effect Duration: 15
 7224	mirror mansplainer's deadly Kashmir sweater	0		Weapon Damage: +5, Monster Level: +15
-7225	normal special shaking custard pie	3	good	Effect: "Pumped Stomach", Effect Duration: 25
+7225	special normal shaking custard pie	3	good	Effect: "Pumped Stomach", Effect Duration: 25
 7226	tea for one	1	awesome	
-7227	hand-crafted watered-down bottle of Evermore	2	EPIC	
+7227	watered-down hand-crafted bottle of Evermore	2	EPIC	
 7228	olive box	0		
 7229	mediocre wine	4	decent	
 7230	tolerable irresponsibly strong rum	8	good	
 7231	lousy Murderer's Punch	3	decent	
-7232	immense enchanted rotten velvet cake	7	crappy	Effect: "Supafly", Effect Duration: 20
+7232	rotten immense enchanted velvet cake	7	crappy	Effect: "Supafly", Effect Duration: 20
 7233	electrified magnetized letter	0		Effect: "Artificially Sweet", Effect Duration: 27
 7234	spinning medical-grade studded book	0		Damage Absorption: +80, HP Regen Min: 7, HP Regen Max: 10
 7235	pulsating Temple Grandin's masque of temperance	0		Familiar Weight: +7, Sleaze Resistance: +5, Single Equip
@@ -7144,7 +7144,7 @@
 7255	practically non-alcoholic delicious upside-down mini-martini	1	awesome	
 7256	smoke grenade	0		
 7257	powdered tumbling molotov soda	1	EPIC	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 45
-7258	extra-flattened Vulcanized concentrated tumbling spinning pile of ashes	0		Effect: "Ichorous Eyesight", Effect Duration: 53
+7258	extra-flattened Vulcanized concentrated spinning tumbling pile of ashes	0		Effect: "Ichorous Eyesight", Effect Duration: 53
 7259	crate of firebombs	0		
 7260	wobbly firebomb	0		
 7261	narrow Samson's groovy thinker's Sneaky Pete's basket	0		Mysticality: +10, Moxie Percent: +10, Experience (Muscle): +5
@@ -7152,7 +7152,7 @@
 7263	photograph of a dog	0		
 7264	photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
-7266	green mirror disposable instant camera	0		
+7266	mirror green disposable instant camera	0		
 7267	flame-retardant foul-smelling grievous Sneaky Pete's jacket (collar popped) of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25, Stench Damage: +10, Hot Resistance: +1, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
@@ -7176,7 +7176,7 @@
 7287	cyan toasty mansplainer's Gary Claybender's Time Screwer	0		Monster Level: +15, Hot Damage: +5, Single Equip, Lasts Until Rollover
 7288	yellow jittery Space Tourist palmdoctor of the blizzard of the boozehound	0		Cold Spell Damage: +25, Booze Drop: +100, Lasts Until Rollover
 7289	resourceful sinister amok putter of chilblains	0		Spell Damage: +10, Maximum MP: +50, Cold Damage: +25
-7290	spoiled super-sized amok pudding	5	crappy	
+7290	super-sized spoiled amok pudding	5	crappy	
 7291	wobbly deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	cold-filtered wobbly can of V-11	0		Effect: "Bear Clawed", Effect Duration: 32, Last Available: "2014-03"
@@ -7191,10 +7191,10 @@
 7302	Spookyraven library key	0		
 7303	shaking Lady Spookyraven's necklace	0		
 7304	telegram from Lady Spookyraven	0		
-7305	olive pulsating blinking Lady Spookyraven's powder puff	0		
-7306	upside-down spinning Lady Spookyraven's finest gown	0		
+7305	olive blinking pulsating Lady Spookyraven's powder puff	0		
+7306	spinning upside-down Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
-7308	polarized teal tumbling eyebrow pencil	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 14
+7308	polarized tumbling teal eyebrow pencil	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 14
 7309	galvanized rosewater cream	0		Effect: "The Dinsey Spirit", Effect Duration: 14
 7310	double-electrified aerosolized bronzer	0		Effect: "Memory of Attractiveness", Effect Duration: 43
 7311	spinning greedy hardened elegant nightstick	0		Damage Reduction: 3, Meat Drop: +20
@@ -7202,16 +7202,16 @@
 7313	wobbly box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	skewed rickety rocking horse	0		
-7316	cyan wobbly jack-in-the-box	0		
+7316	wobbly cyan jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	mirror mirror energetic ghost of a necklace of the pedagogue of the glutton	0		Experience: +3, Maximum MP Percent: +20, Food Drop: +100
 7319	Sinatra's Elizabeth's Dollie of the blizzard	0		Experience (Moxie): +5, Cold Spell Damage: +25
-7320	irradiated upside-down green Elizabeth's paintbrush	0		Effect: "Dweeby", Effect Duration: 21
+7320	irradiated green upside-down Elizabeth's paintbrush	0		Effect: "Dweeby", Effect Duration: 21
 7321	cyan padded Stephen's lab coat of the pedagogue	0		Experience: +3, Damage Absorption: +20
 7322	energized nitrogenated green Stephen's secret formula	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 49
 7323	Jacob's rung of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Spell Damage: +50
 7324	distilled huge battery	1		
-7325	artisanal watered-down snakebite	2	EPIC	
+7325	watered-down artisanal snakebite	2	EPIC	
 7326	yellow huge censurious rubber ribcage of doom	0		Spooky Spell Damage: +50, Sleaze Resistance: +3, Damage Reduction: 7
 7327	distilled blue synthetic marrow	1		Effect: "Improprie Tea", Effect Duration: 25
 7328	alkaline dry funny bone	0		Effect: "Thanksgot", Effect Duration: 24
@@ -7229,12 +7229,12 @@
 7340	bouncing smooth moose antlers	0		Moxie: +15, Familiar Effect: "atk, 1xLep, cap 27"
 7341	concentrated vacuum-sealed moose thought	0		Effect: "Intimidating Mien", Effect Duration: 48
 7342	enchanted spoiled moose chocolate	3	crappy	Effect: "This Is Where You're a Viking", Effect Duration: 45
-7343	tolerable squat wobbly painting of a glass of wine	4	good	
+7343	tolerable wobbly squat painting of a glass of wine	4	good	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	crafty wicked ghost toga	0		Spell Damage: +5, Maximum MP: +10
-7348	rotten super-sized sheet cake	5	crappy	
+7348	super-sized rotten sheet cake	5	crappy	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	lightning-fast Socratic Samson's Staff of the Electric Range	0		Experience (Muscle): +5, Experience (Mysticality): +1, Initiative: +40
@@ -7255,7 +7255,7 @@
 7366	smooth bottle of laundry sherry	4	awesome	
 7367	deionized industrial strength starch	0		Effect: "Uncanny Shot", Effect Duration: 15, Wiki Name: "industrial strength starch"
 7368	spoiled extra-flat panini	3	crappy	
-7369	altered shaking olive narrow mangled finger	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 18
+7369	altered shaking narrow olive mangled finger	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 18
 7370	bad watered-down green Psychotic Train wine	2	decent	
 7371	crazy hobo notebook	0		
 7372	decent snack-sized pie man was not meant to eat	2	good	
@@ -7271,7 +7271,7 @@
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	DNA extraction syringe	0		Last Available: "2014-04"
 7384	cold-filtered pressed moist maroon Gene Tonic: Dude	0		Effect: "Stregngth of the Gnome", Effect Duration: 62, Last Available: "2014-04"
-7385	super-cold-filtered quadruple-activated mirror red Gene Tonic: Beast	0		Effect: "Scorpio Rising", Effect Duration: 53, Last Available: "2014-04"
+7385	super-cold-filtered quadruple-activated red mirror Gene Tonic: Beast	0		Effect: "Scorpio Rising", Effect Duration: 53, Last Available: "2014-04"
 7386	magnetized pressed gray Gene Tonic: Construct	0		Effect: "Jingle Jangle Jingle", Effect Duration: 55, Last Available: "2014-04"
 7387	energized Gene Tonic: Undead	0		Effect: "Disdain of She-Who-Was", Effect Duration: 60, Last Available: "2014-04"
 7388	improved shaking Gene Tonic: Humanoid	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 49, Last Available: "2014-04"
@@ -7322,11 +7322,11 @@
 7433	triple-dry enhanced Gyromitra Dynomita mushroom	0		Effect: "Mariachi Mood", Effect Duration: 40, Last Available: "2014-05"
 7434	magnetized chilled tarnished narrow Helvella Haemophilia mushroom	0		Effect: "Vanity Rage", Effect Duration: 67, Last Available: "2014-05"
 7435	vacuum-sealed activated Stemonitis Staticus mushroom	0		Effect: "Walberg's Dim Bulb", Effect Duration: 42, Last Available: "2014-05"
-7436	warmed quadruple-activated non-cold-filtered blue huge Tremella Tarantella mushroom	0		Effect: "You Can Taste the Darkness", Effect Duration: 52, Last Available: "2014-05"
+7436	warmed quadruple-activated non-cold-filtered huge blue Tremella Tarantella mushroom	0		Effect: "You Can Taste the Darkness", Effect Duration: 52, Last Available: "2014-05"
 7437	spinning Pastaco shell	0		Last Available: "2014-05"
 7438	stale skewed Beefy Crunch Pastaco	4	decent	Last Available: "2014-05"
-7439	small rotten Brain Food Pastaco	2	crappy	Last Available: "2014-05"
-7440	low-calorie bland Cool Brunch Pastaco	1	decent	Last Available: "2014-05"
+7439	rotten small Brain Food Pastaco	2	crappy	Last Available: "2014-05"
+7440	bland low-calorie Cool Brunch Pastaco	1	decent	Last Available: "2014-05"
 7441	decent Medical Pastaco	3	good	Last Available: "2014-05"
 7442	flavorless Energy Buzz Pastaco	4	decent	Last Available: "2014-05"
 7443	decent Ludovico Pastaco	4	good	Last Available: "2014-05"
@@ -7340,14 +7340,14 @@
 7451	bland small Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
 7452	bouncing olive Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	hand-crafted regular-size brogurt	4	EPIC	Last Available: "2014-05"
-7454	tolerable spinning teal super-size brogurt	3	good	Last Available: "2014-05"
-7455	smooth practically non-alcoholic broberry brogurt	1	awesome	Last Available: "2014-05"
+7454	tolerable teal spinning super-size brogurt	3	good	Last Available: "2014-05"
+7455	practically non-alcoholic smooth broberry brogurt	1	awesome	Last Available: "2014-05"
 7456	lousy green brocolate brogurt	3	decent	Last Available: "2014-05"
 7457	weak aged French bronilla brogurt	2	awesome	Last Available: "2014-05"
 7458	twirling blinking History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	purple Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
-7461	gray mirror upside-down industrial strength anti-fungal spray	0		Last Available: "2014-05"
+7461	upside-down mirror gray industrial strength anti-fungal spray	0		Last Available: "2014-05"
 7462	slick Brogre brorts	0		Moxie: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	upside-down Annie Oakley's Brogre brolo shirt	0		Critical Hit Percent: +20, Last Available: "2014-05"
 7464	skewed Brogre bucket hat of the pedagogue	0		Experience: +3, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
@@ -7368,7 +7368,7 @@
 7479	non-activated ionized pulsating sugar fairy	0		Effect: "Red Around the Gills", Effect Duration: 16, Last Available: "2014-05"
 7480	wet sugar bunny	0		Effect: "Yuletide Mutations", Effect Duration: 67, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	fancy lousy upside-down Rompedores de Fantasmas	3	decent	Effect: "The Q Is Talking To You", Effect Duration: 40
+7482	lousy fancy upside-down Rompedores de Fantasmas	3	decent	Effect: "The Q Is Talking To You", Effect Duration: 40
 7483	lousy upside-down La Fantasma y La Oscuridad	3	decent	
 7484	delicious watered-down Fantasma en la M&aacute;quina	2	awesome	
 7485	loosening powder	0		
@@ -7378,7 +7378,7 @@
 7489	wobbly detartrated anhydrous sublicalc	0		
 7490	squat huge triatomaceous dust	0		
 7491	drinkable bottle of Chateau de Vinegar	3	good	
-7492	blurry mirror blasting soda	0		
+7492	mirror blurry blasting soda	0		
 7493	unstable fulminate	0		
 7494	gray wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
@@ -7387,7 +7387,7 @@
 7498	Thwaitgold wheel bug statuette	0		
 7499	activated vacuum-sealed ionized Hot 'n' Scarys	0		Effect: "It Didn't Kill You", Effect Duration: 33
 7500	shaking map	0		
-7501	tumbling pulsating ghostly	0		
+7501	ghostly pulsating tumbling	0		
 7502	pickled anodized maroon tumbling Texas tea	0		Effect: "Twen Tea", Effect Duration: 20
 7503	jittery baleful dark hamethyst ring	0		Spell Damage: +25
 7504	blue family-friendly dark baconstone ring	0		Sleaze Resistance: +1
@@ -7395,7 +7395,7 @@
 7506	wool stanky book	0		Stench Spell Damage: +25, Cold Resistance: +1
 7507	cloak of extreme caution	0		Monster Level: -25
 7508	label	0		
-7509	stale big Mornington crescent roll	5	decent	
+7509	big stale Mornington crescent roll	5	decent	
 7510	concentrated oxidized eye shadow	0		Effect: "Flower Power", Effect Duration: 64
 7511	crumbling wheel	0		
 7512	nitrogenated pulsating poppy	0		Effect: "Radium Radicality", Effect Duration: 59
@@ -7430,8 +7430,8 @@
 7541	space beast fur whip of Gandalf	0		Spell Critical Percent: +20, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	lime green zippy banded space heater	0		Damage Absorption: +100, Initiative: +20, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
-7544	ghostly upside-down space bar	0		Last Available: "2014-05"
-7545	bad watered-down space port	2	decent	Last Available: "2014-05"
+7544	upside-down ghostly space bar	0		Last Available: "2014-05"
+7545	watered-down bad space port	2	decent	Last Available: "2014-05"
 7546	Usain Bolt's supercharged space needle	0		Maximum MP Percent: +30, Initiative: +80, Last Available: "2014-05"
 7547	ionized buffed alien drugs	0		Effect: "Retrograde Relaxation", Effect Duration: 40, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7456,9 +7456,9 @@
 7567	Chroner	0		
 7568	upside-down fuchsia electrified Da Vinci's Time Lord Badge of Honor of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5
 7569	shaking stanky Jack Frost's Fonzie's Time Bandit Badge of Courage	0		Experience (Moxie): +1, Cold Spell Damage: +50, Stench Spell Damage: +25
-7570	vacuum-sealed narrow yellow tumbling Friendliness Beverage	0		Effect: "Hot Buttoned", Effect Duration: 19
+7570	vacuum-sealed yellow narrow tumbling Friendliness Beverage	0		Effect: "Hot Buttoned", Effect Duration: 19
 7571	horrifying sinister silent pea shooter	0		Spell Damage: +10, Spooky Damage: +25
-7572	decent tiny D roll	1	good	
+7572	tiny decent D roll	1	good	
 7573	nasty kiwi beak of the empath	0		Familiar Weight: +5, Stench Damage: +5
 7574	lousy New Zealand iced tea	3	decent	
 7575	personal trainer's droll monocle of courage	0		Experience Percent (Muscle): +10, Spooky Resistance: +3, Single Equip
@@ -7472,20 +7472,20 @@
 7583	aged scotch on the rocks	4	awesome	
 7584	huge Jack Frost's forbidden yabba dabba doo rag	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	cyan rock-hard wooly loincloth of terror	0		Damage Reduction: 5, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 27"
-7586	fuchsia wobbly helix fossil	0		
+7586	wobbly fuchsia helix fossil	0		
 7587	twirling S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	bad distilled glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
-7590	weak drinkable cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
+7589	distilled bad glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
+7590	drinkable weak cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
 7591	delicious jittery thermos of &quot;whiskey&quot;	3	awesome	Last Available: "2014-07"
 7592	bad Lucky Lindy	3	decent	Last Available: "2014-07"
 7593	tolerable Bee's Knees	4	good	Last Available: "2014-07"
 7594	acceptable Sockdollager	3	good	Last Available: "2014-07"
 7595	bad tumbling Ish Kabibble	4	decent	Last Available: "2014-07"
-7596	practically non-alcoholic tolerable Hot Socks	1	good	Last Available: "2014-07"
-7597	acceptable special irresponsibly strong skewed squat Phonus Balonus	6	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45, Last Available: "2014-07"
-7598	weak aged ghostly Flivver	2	awesome	Last Available: "2014-07"
-7599	acceptable practically non-alcoholic Sloppy Jalopy	1	good	Last Available: "2014-07"
+7596	tolerable practically non-alcoholic Hot Socks	1	good	Last Available: "2014-07"
+7597	irresponsibly strong special acceptable skewed squat Phonus Balonus	6	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45, Last Available: "2014-07"
+7598	aged weak ghostly Flivver	2	awesome	Last Available: "2014-07"
+7599	practically non-alcoholic acceptable Sloppy Jalopy	1	good	Last Available: "2014-07"
 7600	unsweetened flame	0		Effect: "Spore-Wreathed", Effect Duration: 54
 7601	oxidized adjusted adjusted twirling temporary yak tattoo	0		Effect: "Optimist Primal", Effect Duration: 56
 7602	magnetized nitrogenated enhanced Fitspiration&trade; poster	0		Effect: "Walberg's Dim Bulb", Effect Duration: 63
@@ -7534,9 +7534,9 @@
 7645	life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
-7648	fuchsia tumbling thunder thigh	0		
+7648	tumbling fuchsia thunder thigh	0		
 7649	ionized polarized bouncing gourmet gourami oil	0		Effect: "Frog In Your Throat", Effect Duration: 43
-7650	activated pickled pulsating mirror catfish whiskers	0		Effect: "Bark of the Dog", Effect Duration: 42
+7650	activated pickled mirror pulsating catfish whiskers	0		Effect: "Bark of the Dog", Effect Duration: 42
 7651	upside-down spinning freshwater fishbone	0		
 7652	shaking fishbone catcher's mitt	0		
 7653	twirling fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7561,7 +7561,7 @@
 7672	careful law-abiding citizen cane	0		Monster Level: -10, Single Equip
 7673	mediocre shaking legitimate business on the beach	3	decent	
 7674	smartaleck's hep waders	0		Moxie Percent: +30, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	snack-sized flavorless jive turkey leg	2	decent	
+7675	flavorless snack-sized jive turkey leg	2	decent	
 7676	squat wool birdbone corset	0		Cold Resistance: +1
 7677	cold-filtered galvanized candy cigarette	0		Effect: "Techno Bliss", Effect Duration: 52
 7678	shaking quilted 4-dimensional fez	0		Damage Absorption: +40, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7569,7 +7569,7 @@
 7680	bouncing savvy super-absorbent tarp	0		Mysticality Percent: +20
 7681	boozy lousy squat unquiet spirits	5	decent	
 7682	twirling Van der Graaf banjo kazoo mount	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip
-7683	double-dry mirror narrow green grass	0		Effect: "Jingle Jangle Jingle", Effect Duration: 39
+7683	double-dry narrow mirror green grass	0		Effect: "Jingle Jangle Jingle", Effect Duration: 39
 7684	double-paned Time Lord Participation Mug	0		Cold Resistance: +5
 7685	vibrating Time Bandit Time Towel of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +10
 7686	Temple Grandin's rosy-cheeked Caveman Dan's favorite rock of the brazier	0		Maximum HP Percent: +30, Familiar Weight: +7, Hot Spell Damage: +25, Single Equip
@@ -7592,7 +7592,7 @@
 7703	green LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	maroon LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	ghostly jittery The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	jittery ghostly The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	modified rubber nubbin	0		Effect: "Barbecue Saucy", Effect Duration: 30, Last Available: "2014-08"
 7708	auspicious Annie Oakley's rubber cape	0		Critical Hit Percent: +20, Item Drop: +10, Last Available: "2014-08"
 7709	smelly flame-wreathed stiffened slick Thor's Pliers	0		Moxie: +10, Damage Reduction: 1, Hot Spell Damage: +10, Stench Spell Damage: +10, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
@@ -7618,7 +7618,7 @@
 7729	Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
-7732	ghostly shaking Black Bart's Booty	0		Skill: "Pirate Bellow"
+7732	shaking ghostly Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	huge Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	Xiblaxian polymer	0		Last Available: "2014-09"
 7735	mirror Xiblaxian alloy	0		Last Available: "2014-09"
@@ -7636,17 +7636,17 @@
 7747	bouncing Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	blue Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
-7750	blinking olive blurry Xiblaxian 5D printer	0		Last Available: "2014-09"
+7750	blinking blurry olive Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	knitted Xiblaxian xeno-detection goggles	0		Cold Resistance: +3, Single Equip, Last Available: "2014-09"
 7753	gray stylish Xiblaxian stealth cowl of the businessman	0		Moxie: +25, Meat Drop: +50, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	tumbling padded Xiblaxian stealth trousers of the blizzard	0		Damage Absorption: +20, Cold Spell Damage: +25, Last Available: "2014-09"
 7755	Lo Pan's smartaleck's Xiblaxian stealth vest	0		Moxie Percent: +30, Spell Critical Percent: +30, Last Available: "2014-09"
 7756	stale Xiblaxian ultraburrito	4	decent	Last Available: "2014-09"
-7757	aged practically non-alcoholic lime green Xiblaxian space-whiskey	1	awesome	Last Available: "2014-09"
+7757	practically non-alcoholic aged lime green Xiblaxian space-whiskey	1	awesome	Last Available: "2014-09"
 7758	skewed Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	cold-filtered boiled skewed They liver	0		Effect: "Adventurer's Best Friendship", Effect Duration: 14, Last Available: "2014-09"
-7760	bland small pulsating They liver popsicle	2	decent	Last Available: "2014-09"
+7760	small bland pulsating They liver popsicle	2	decent	Last Available: "2014-09"
 7761	blurry holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	jittery holo-platoon	0		Last Available: "2014-09"
@@ -7682,11 +7682,11 @@
 7793	yellow bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	bland initiative shawarma	3	decent	Last Available: "2014-10"
-7796	adequate small squat warm war shawarma	2	good	Last Available: "2014-10"
+7796	small adequate squat warm war shawarma	2	good	Last Available: "2014-10"
 7797	stale narrow karma shawarma	3	decent	Last Available: "2014-10"
 7798	practically non-alcoholic artisanal Jungle Juice	1	EPIC	Last Available: "2014-10"
-7799	practically non-alcoholic mediocre Amnesiac Ale	1	decent	Last Available: "2014-10"
-7800	special weak drinkable Highest Bitter	2	good	Effect: "Hot Hands", Effect Duration: 35, Last Available: "2014-10"
+7799	mediocre practically non-alcoholic Amnesiac Ale	1	decent	Last Available: "2014-10"
+7800	special drinkable weak Highest Bitter	2	good	Effect: "Hot Hands", Effect Duration: 35, Last Available: "2014-10"
 7801	blurry mercenary pistol of James Dean	0		Experience (Moxie): +3, Item Drop: +5, Last Available: "2014-10"
 7802	tumbling nippy mercenary rifle of the empath	0		Familiar Weight: +5, Cold Damage: +10, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7698,9 +7698,9 @@
 7809	fuchsia impure gasoline	0		
 7810	red Z-Bone steak	0		
 7811	viral DNA	0		
-7812	shaking blurry tarnished bottlecap	0		
+7812	blurry shaking tarnished bottlecap	0		
 7813	flavorless pulsating seared dino steak	4	decent	
-7814	delicious enchanted weak bottle of drinkin' gas	2	awesome	Effect: "Limber as Mortimer", Effect Duration: 20
+7814	enchanted delicious weak bottle of drinkin' gas	2	awesome	Effect: "Limber as Mortimer", Effect Duration: 20
 7815	handful of napalm	0		
 7816	gray dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7733,7 +7733,7 @@
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	pickled perl necklace	0		Effect: "Can't Smell Nothin'", Effect Duration: 44, Last Available: "2014-12"
 7846	warmed quantum spinning shaking Fudge Fiber Armor Plating	0		Effect: "Destructive Resolve", Effect Duration: 52, Last Available: "2014-12"
-7847	quadruple-electrified bouncing maroon blinking ruby on canes	0		Effect: "Night Vision", Effect Duration: 53, Last Available: "2014-12"
+7847	quadruple-electrified maroon blinking bouncing ruby on canes	0		Effect: "Night Vision", Effect Duration: 53, Last Available: "2014-12"
 7848	toothsome maroon petit fortran	3	awesome	Last Available: "2014-12"
 7849	snack-sized flavorless purple java cookie	2	decent	Last Available: "2014-12"
 7850	stale huge cookie cookie	3	decent	Last Available: "2014-12"
@@ -7756,7 +7756,7 @@
 7867	jittery Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	red Crimbot schematic: Crab Core	0		Last Available: "2014-12"
-7870	teal tumbling Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
+7870	tumbling teal Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	bouncing lime green Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	lime green Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
@@ -7787,7 +7787,7 @@
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	red Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
-7901	cyan skewed Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
+7901	skewed cyan Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	skewed green Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
@@ -7808,15 +7808,15 @@
 7919	polymerized nitrogenated huge Big Punk	0		Effect: "Dances with Tweedles", Effect Duration: 52
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	jittery turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	perfectly mixed watered-down spinning Friendly Turkey	2	EPIC	Last Available: "2014-11"
-7923	enchanted practically non-alcoholic bad Agitated Turkey	1	decent	Effect: "Afternoon Insight", Effect Duration: 10, Last Available: "2014-11"
-7924	irresponsibly strong perfectly mixed Ambitious Turkey	9	EPIC	Last Available: "2014-11"
+7922	watered-down perfectly mixed spinning Friendly Turkey	2	EPIC	Last Available: "2014-11"
+7923	bad practically non-alcoholic enchanted Agitated Turkey	1	decent	Effect: "Afternoon Insight", Effect Duration: 10, Last Available: "2014-11"
+7924	perfectly mixed irresponsibly strong Ambitious Turkey	9	EPIC	Last Available: "2014-11"
 7925	rotten neutron lollipop	3	crappy	Last Available: "2014-12"
 7926	aged gamma nog	3	awesome	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	green picky tweezers	0		Last Available: "2015-02"
-7937	olive jittery Crimbo Credit	0		
+7937	jittery olive Crimbo Credit	0		
 7938	diluted maroon tumbling single atom	1	crappy	Last Available: "2015-02"
 7939	blurry Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
@@ -7826,7 +7826,7 @@
 7944	blinking squat tooth	0		
 7945	table	0		
 7946	red mirror frosty dance instructor's outlaw bandana of terror	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Spooky Spell Damage: +10
-7947	practically non-alcoholic acceptable whiskey in a broken glass	1	good	
+7947	acceptable practically non-alcoholic whiskey in a broken glass	1	good	
 7948	lousy shot of mescal	4	decent	
 7949	watered-down mediocre twirling glass of herbal tequila	2	decent	
 7950	minin' dynamite	0		
@@ -7850,7 +7850,7 @@
 7968	wobbly mirror topiary nugglet	0		
 7969	green beehive	0		
 7970	boning knife	0		
-7971	blurry teal Aggressive Carrot	0		Free Pull
+7971	teal blurry Aggressive Carrot	0		Free Pull
 7972	twisted teal mummified fig	1	good	Effect: "Orchid Blood", Effect Duration: 40
 7973	pickled mummified loaf of bread	1	decent	Effect: "Paging Betty", Effect Duration: 5
 7974	pickled mummified beef haunch	1	crappy	Effect: "Astral Shell", Effect Duration: 30
@@ -7900,7 +7900,7 @@
 8018	deionized ionized spinning and rain stick	0		Effect: "Certainty", Effect Duration: 46
 8019	squat Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	flavorless massive jittery Choco-Mint patty	7	decent	Last Available: "2015-01"
-8021	watered-down bad squat hot mint schnocolate	2	decent	Last Available: "2015-01"
+8021	bad watered-down squat hot mint schnocolate	2	decent	Last Available: "2015-01"
 8022	twisted squat homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
@@ -7998,16 +7998,16 @@
 8123	ribald Lo Pan's garibaldi	0		Spell Critical Percent: +30, Sleaze Damage: +10, Last Available: "2018-12"
 8124	Herculean girdle of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	jittery sharpshooter's occult gloves	0		Spell Damage Percent: +25, Critical Hit Percent: +10, Single Equip, Last Available: "2018-12"
-8126	powdered skewed narrow smithereens	1		Effect: "Steroid Boost", Effect Duration: 50, Last Available: "2018-12"
+8126	powdered narrow skewed smithereens	1		Effect: "Steroid Boost", Effect Duration: 50, Last Available: "2018-12"
 8127	groovy fiberglass fetish of the empath	0		Moxie Percent: +10, Familiar Weight: +5, Last Available: "2018-12"
 8128	chilly wicked fiberglass foil	0		Spell Damage: +5, Cold Damage: +5, Last Available: "2018-12"
 8129	curative fiberglass fannypack of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2018-12"
 8130	blinking frosty fiberglass frock of Calamity Jane	0		Critical Hit Percent: +15, Cold Spell Damage: +10, Last Available: "2018-12"
 8131	Newton's Herculean fiberglass fingerguard	0		Experience (Muscle): +1, Experience (Mysticality): +3, Single Equip, Last Available: "2018-12"
 8132	brawny fiberglass fedora of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Last Available: "2018-12"
-8133	boiled narrow mirror shaking fiberglass fibers	1		Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2018-12"
+8133	boiled narrow shaking mirror fiberglass fibers	1		Effect: "Mushroom Moxiousness", Effect Duration: 10, Last Available: "2018-12"
 8134	shaking bottle of lovebug pheromones	0		Free Pull
-8135	wobbly blurry cyan winged yeti fur	0		
+8135	cyan wobbly blurry winged yeti fur	0		
 8136	wobbly talisman of Renenutet	0		
 8138	rubber spatula of Calamity Jane	0		Critical Hit Percent: +15
 8139	Jack Frost's spoon	0		Cold Spell Damage: +50
@@ -8063,10 +8063,10 @@
 8189	watered-down drinkable Radberry Rip wine cooler	2	good	
 8190	perfectly mixed Orangemageddon wine cooler	3	EPIC	
 8191	perfectly mixed shaking huge Breakfast Blast wine cooler	3	EPIC	
-8192	strong artisanal Citrus Crush wine cooler	5	EPIC	
-8193	tasty massive plain bagel	6	awesome	
+8192	artisanal strong Citrus Crush wine cooler	5	EPIC	
+8193	massive tasty plain bagel	6	awesome	
 8194	stale glob of cream cheese	3	decent	
-8195	flavorless huge mirror loaf of soda bread	3	decent	
+8195	flavorless mirror huge loaf of soda bread	3	decent	
 8196	bland acceptable bagel	3	decent	
 8197	tasty standard-issue cupcake	4	awesome	
 8198	tiny adequate ultra-deluxe cupcake	1	good	
@@ -8080,12 +8080,12 @@
 8206	huge jittery Jeselnik's nippy expensive camera	0		Cold Damage: +10, Sleaze Damage: +25, Single Equip, Last Available: "2015-04"
 8207	mirror sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	alkaline extra-energized skewed How to Avoid Scams	0		Effect: "Ghost Finger", Effect Duration: 48, Last Available: "2015-04"
-8209	twirling narrow skewed filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
+8209	narrow twirling skewed filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	blurry mirror bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	green rosewater-soaked rigging rope of dire peril	0		Weapon Damage: +20, Stench Resistance: +3, Last Available: "2015-04"
-8214	powdered mirror tumbling nasty snuff	1	good	Last Available: "2015-04"
+8214	powdered tumbling mirror nasty snuff	1	good	Last Available: "2015-04"
 8215	mirror twirling stiffened stylish sewage-clogged pistol	0		Moxie: +25, Damage Reduction: 1, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	ionized activated beard incense	0		Effect: "Red-Shirted Escort", Effect Duration: 55, Last Available: "2015-04"
 8217	skewed olive Samson's cool perfume-soaked bandana	0		Moxie: +5, Experience (Muscle): +5, Single Equip, Last Available: "2015-04"
@@ -8096,7 +8096,7 @@
 8222	family-friendly Three Mile Island shorts of the cougar	0		Moxie: +20, Sleaze Resistance: +1, Last Available: "2015-04"
 8223	blinking toxic mop of James Dean of incineration	0		Experience (Moxie): +3, Hot Spell Damage: +50, Last Available: "2015-04"
 8224	upside-down inert sludgepuppy	0		Last Available: "2015-04"
-8225	skewed red lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
+8225	red skewed lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	yellow jar of swamp honey	0		Last Available: "2015-04"
 8227	pulsating hardy studded fortified backwoods banjo	0		Damage Absorption: 140, Maximum HP: +50, Last Available: "2015-04"
 8228	grody jug	0		Last Available: "2015-04"
@@ -8111,7 +8111,7 @@
 8237	mirror lard-coated nasty Dinsey's pants	0		Stench Damage: +5, Sleaze Spell Damage: +25, Last Available: "2015-04"
 8238	mirror brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
-8240	wobbly tumbling keycard &beta;	0		Last Available: "2015-04"
+8240	tumbling wobbly keycard &beta;	0		Last Available: "2015-04"
 8241	keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
@@ -8132,7 +8132,7 @@
 8258	spinning Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	blinking Newton's The Lot's engagement ring	0		Experience (Mysticality): +3, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	narrow Mayo Clinic	0		Last Available: "2015-05"
-8261	shaking squat Mayonex	0		Last Available: "2015-05"
+8261	squat shaking Mayonex	0		Last Available: "2015-05"
 8262	upside-down Mayodiol	0		Last Available: "2015-05"
 8263	Mayostat	0		Last Available: "2015-05"
 8264	blurry lime green Mayozapine	0		Last Available: "2015-05"
@@ -8142,14 +8142,14 @@
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	flavorless unappetizing mayolus	3	decent	Last Available: "2015-05"
-8271	bland thick uninteresting mayolus	5	decent	Last Available: "2015-05"
+8271	thick bland uninteresting mayolus	5	decent	Last Available: "2015-05"
 8272	adequate acceptable mayolus	3	good	Last Available: "2015-05"
-8273	immense spoiled gray enticing mayolus	6	crappy	Last Available: "2015-05"
+8273	spoiled immense gray enticing mayolus	6	crappy	Last Available: "2015-05"
 8274	normal mouth-watering mayolus	3	good	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	narrow mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	fortified lousy blurry wobbly Afternoon Delight	5	decent	Last Available: "2015-04"
+8278	lousy fortified blurry wobbly Afternoon Delight	5	decent	Last Available: "2015-04"
 8279	bouncing Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	mirror Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	super-moist Vulcanized narrow Kokomo Resort Brand Suntan Oil	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 29, Last Available: "2015-04"
@@ -8178,17 +8178,17 @@
 8304	jittery puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	dry dry wobbly sludgesicle	0		Effect: "Work For Hours a Week", Effect Duration: 55
-8307	non-oxidized mirror ghostly &Uuml;berraschthexengebr&auml;u	0		Effect: "La Bamba", Effect Duration: 23
+8307	non-oxidized ghostly mirror &Uuml;berraschthexengebr&auml;u	0		Effect: "La Bamba", Effect Duration: 23
 8308	pressed magnetized piggy tattoo	0		Effect: "Demonic Taint", Effect Duration: 35
 8309	wet baggie of regular-sized tardigrades	0		Effect: "Neuroplastici Tea", Effect Duration: 18
 8310	adjusted magnetized blinking .epub file	0		Effect: "Flashing Eyes", Effect Duration: 20
 8311	aerosolized pressed pressed BUBBLE GUM	0		Effect: "Floundering", Effect Duration: 56
-8312	altered super-liquefied blinking gray hustler shades	0		Effect: "Mer-kinny Flavor", Effect Duration: 55
+8312	altered super-liquefied gray blinking hustler shades	0		Effect: "Mer-kinny Flavor", Effect Duration: 55
 8313	moist concentrated spinning jerky stick	0		Effect: "Alpine Mintiness", Effect Duration: 15
 8314	extra-anodized maroon mirror costume rental shop	0		Effect: "Hiding in Plain Sight", Effect Duration: 45
 8315	vacuum-sealed dry muscle oil	0		Effect: "White Knuckles", Effect Duration: 57
 8316	corrupted irradiated pulsating bottle of Red-Out	0		Effect: "Stone-Faced", Effect Duration: 68
-8317	alkaline corrupted spinning narrow pickpocket protector	0		Effect: "Cybernetic Muscles", Effect Duration: 55
+8317	alkaline corrupted narrow spinning pickpocket protector	0		Effect: "Cybernetic Muscles", Effect Duration: 55
 8318	denatured sinister-looking cat	0		Effect: "White Blooded", Effect Duration: 65
 8319	denatured nitrogenated bouncing yellow jazzy cigarette holder	0		Effect: "Spooky Jellied", Effect Duration: 40
 8320	ionized tumbling tumbling one glove	0		Effect: "The Strength...  of the Future", Effect Duration: 27
@@ -8202,7 +8202,7 @@
 8328	modified squat icy hairspray	0		Effect: "Heavily Breathing", Effect Duration: 52
 8329	modified huge smellbook	0		Effect: "Stop and Smell the Fudge", Effect Duration: 47
 8330	quadruple-moist skewed assassin's cheese knife	0		Effect: "Moose Wisdom", Effect Duration: 53
-8331	polarized modified skewed narrow filthy armor	0		Effect: "Medieval Mage Mayhem", Effect Duration: 44
+8331	polarized modified narrow skewed filthy armor	0		Effect: "Medieval Mage Mayhem", Effect Duration: 44
 8332	triple-electrified liquefied activated maroon plague pie	0		Effect: "Carrrsmic", Effect Duration: 62
 8333	boiled batarang	0		Effect: "Super Structure", Effect Duration: 49
 8334	non-pressed pulsating spare neck bolts	0		Effect: "Lobos Fresh", Effect Duration: 32
@@ -8213,9 +8213,9 @@
 8339	anodized irradiated warehouse walkie-talkie	0		Effect: "A View to Some Meat", Effect Duration: 44
 8340	pickled janitor's mop	0		Effect: "Phorcefullness", Effect Duration: 54
 8341	extra-deionized warehouse clerk's glasses	0		Effect: "Insulated Trousers", Effect Duration: 48
-8342	liquefied skewed squat baloney rotgut	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 33
+8342	liquefied squat skewed baloney rotgut	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 33
 8343	cold-filtered polarized skewed carton of gaspers	0		Effect: "Steroid Boost", Effect Duration: 42
-8344	activated squat teal bronze polish	0		Effect: "Celestial Vision", Effect Duration: 38
+8344	activated teal squat bronze polish	0		Effect: "Celestial Vision", Effect Duration: 38
 8345	modified crident	0		Effect: "Well-Lubed", Effect Duration: 65
 8346	quadruple-magnetized denatured totally sweet mohawk helmet	0		Effect: "French Bronilla Brogueishness", Effect Duration: 16
 8347	energized nitrogenated spray chrome	0		Effect: "Human-Goblin Hybrid", Effect Duration: 36
@@ -8280,25 +8280,25 @@
 8406	pulsating savory dry noodles	0		
 8407	normal low-calorie pestopiary	1	good	
 8408	quantum upside-down ectoplasmic orbs	0		Effect: "Sticks and Stones", Effect Duration: 62
-8409	half-sized flavorless crudles	2	decent	
+8409	flavorless half-sized crudles	2	decent	
 8410	decent special agnolotti arboli	3	good	Effect: "Human-Demon Hybrid", Effect Duration: 25
 8411	decent spinning spaghetti with ghost balls	4	good	
-8412	half-sized stale succulent marrow	2	decent	
+8412	stale half-sized succulent marrow	2	decent	
 8413	stale narrow cyan salacious crumbs	3	decent	
-8414	bite-sized delicious fusilli marrownarrow	1	awesome	
+8414	delicious bite-sized fusilli marrownarrow	1	awesome	
 8415	bland super-sized suggestive strozzapreti	5	decent	
 8416	Mountain Stream gastrique	0		
 8417	bland miniature Mt. McLargeHuge oyster	2	decent	
 8418	oyster sauce	0		
-8419	stale jumbo linguini immondizia bianco	5	decent	
-8420	rotten snack-sized squat pulsating shells a la shellfish	2	crappy	
+8419	jumbo stale linguini immondizia bianco	5	decent	
+8420	snack-sized rotten pulsating squat shells a la shellfish	2	crappy	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	olive unsmoothed velvet	0		Last Available: "2015-08"
 8424	squat 1,970 carat	0		Last Available: "2015-08"
 8425	upside-down New Age healing crystal	0		Last Available: "2015-08"
 8426	green huge Volcoino	0		Last Available: "2015-08"
-8427	blurry huge fizzing spore pod	0		
+8427	huge blurry fizzing spore pod	0		
 8428	teal spore pod	0		
 8429	veiny spore pod	0		
 8430	narrow hard spore pod	0		
@@ -8345,11 +8345,11 @@
 8471	wobbly yellow wizardly lava-proof pants of the brazier	0		Mysticality: +25, Hot Spell Damage: +25, Last Available: "2015-08"
 8472	greedy heat-resistant necktie of the brazier	0		Hot Spell Damage: +25, Meat Drop: +20, Single Equip, Last Available: "2015-08"
 8473	Usain Bolt's arcane researcher's experienced heat-resistant gloves	0		Experience: +2, Experience Percent (Mysticality): +10, Initiative: +80, Single Equip, Last Available: "2015-08"
-8474	enchanted immense decent very hot lunch	9	good	Effect: "Elemental Mastery", Effect Duration: 45, Last Available: "2015-08"
+8474	decent immense enchanted very hot lunch	9	good	Effect: "Elemental Mastery", Effect Duration: 45, Last Available: "2015-08"
 8475	hand-crafted asbestos thermos	3	EPIC	Last Available: "2015-08"
-8476	nitrogenated blurry narrow liquid rhinestones	0		Effect: "Ironclad", Effect Duration: 23, Last Available: "2015-08"
+8476	nitrogenated narrow blurry liquid rhinestones	0		Effect: "Ironclad", Effect Duration: 23, Last Available: "2015-08"
 8477	flavorless green disco biscuit	3	decent	Last Available: "2015-08"
-8478	bad special fuchsia Quaatorade&trade;	3	decent	Effect: "Shawarma Initiative", Effect Duration: 5, Last Available: "2015-08"
+8478	special bad fuchsia Quaatorade&trade;	3	decent	Effect: "Shawarma Initiative", Effect Duration: 5, Last Available: "2015-08"
 8479	double-paned scandalous dog trainer's biker's hat	0		Experience (familiar): +1, Sleaze Damage: +5, Cold Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk"
 8480	Temple Grandin's MacGyver's stiffened feathered headdress	0		Damage Reduction: 1, Maximum MP: +100, Familiar Weight: +7, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	MacGyver's cool electrician's hardhat of Flo-Jo	0		Moxie: +5, Maximum MP: +100, Initiative: +100, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8382,7 +8382,7 @@
 8508	warmed Vulcanized colloidal labrador cookie	0		Effect: "Educated (Kinda)", Effect Duration: 12, Last Available: "2015-08"
 8509	family-friendly friendly Mr. Cheeng's spectacles of Leguizamo	0		Monster Level: +20, Familiar Weight: +3, Sleaze Resistance: +1, Single Equip, Last Available: "2015-08"
 8510	wholesome grease cannon of courage	0		Maximum HP Percent: +10, Spooky Resistance: +3, Last Available: "2015-08"
-8511	deionized spinning huge demon makeup kit	0		Effect: "Piratastic", Effect Duration: 11, Last Available: "2015-08"
+8511	deionized huge spinning demon makeup kit	0		Effect: "Piratastic", Effect Duration: 11, Last Available: "2015-08"
 8512	flame-retardant foul-smelling lion tamer's love	0		Experience (familiar): +2, Stench Damage: +10, Hot Resistance: +1, Last Available: "2015-08"
 8513	frosty smartaleck's Pener's drumstick of courage	0		Moxie Percent: +30, Cold Spell Damage: +10, Spooky Resistance: +3, Last Available: "2015-08"
 8514	twirling groovy deuce cape of the cougar	0		Moxie: +20, Moxie Percent: +10, Last Available: "2015-08"
@@ -8396,7 +8396,7 @@
 8522	mirror superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	adequate super-sized lava cake	5	good	Last Available: "2015-08"
+8525	super-sized adequate lava cake	5	good	Last Available: "2015-08"
 8526	rotten pink slime	3	crappy	
 8527	wobbly Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
@@ -8405,26 +8405,26 @@
 8531	maroon huge Salsa Libre	0		
 8532	good gravy	0		
 8533	gray illicit fish sauce	0		
-8534	flavorless bite-sized blurry libertagliatelle	1	decent	
+8534	bite-sized flavorless blurry libertagliatelle	1	decent	
 8535	yummy turkish mostaccioli	4	awesome	
-8536	bland enchanted linguini of the sea	3	decent	Effect: "Mmmmmelon", Effect Duration: 50
+8536	enchanted bland linguini of the sea	3	decent	Effect: "Mmmmmelon", Effect Duration: 50
 8537	flattened galvanized Hersey&trade; SMOOCH	0		Effect: "Mystically Oiled", Effect Duration: 26
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	special big decent skewed Fettris	5	good	Effect: "Larger", Effect Duration: 5
+8542	decent special big skewed Fettris	5	good	Effect: "Larger", Effect Duration: 5
 8543	rotten diet fusillocybin	1	crappy	
-8544	bland special prescription noodles	3	decent	Effect: "Amplified Fabulousness", Effect Duration: 50
+8544	special bland prescription noodles	3	decent	Effect: "Amplified Fabulousness", Effect Duration: 50
 8545	dried narrow blood-drive sticker	1	EPIC	
 8546	boiled blurry bag of grain	0		Effect: "Squid Squint", Effect Duration: 45
-8547	corrupted wobbly ghostly pocket maze	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 65
+8547	corrupted ghostly wobbly pocket maze	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 65
 8548	modified alkaline tumbling shady shades	0		Effect: "Briny Blood", Effect Duration: 35
 8549	unsweetened anodized squeaky toy rose	0		Effect: "Shot in the Arse", Effect Duration: 61
-8550	stale snack-sized huge weird gazelle steak	2	decent	
+8550	snack-sized stale huge weird gazelle steak	2	decent	
 8551	miniature moldy sausage without a cause	2	crappy	
 8552	pickled alkaline huge green face paint	0		Effect: "You're Rubber", Effect Duration: 57
 8553	hand-crafted mirror emergency margarita	3	super ultra mega turbo EPIC	
-8554	extra-dry artisanal vintage smart drink	5	super ultra EPIC	
+8554	artisanal extra-dry vintage smart drink	5	super ultra EPIC	
 8555	mirror a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8450,7 +8450,7 @@
 8577	teal barnacled barrel	0		Last Available: "2015-09"
 8578	drinkable weak bottle of Amontillado	2	good	Last Available: "2015-09"
 8579	acceptable barrel-aged martini	3	good	Last Available: "2015-09"
-8580	massive adequate tumbling barrel pickle	10	good	Last Available: "2015-09"
+8580	adequate massive tumbling barrel pickle	10	good	Last Available: "2015-09"
 8581	yummy barrel cracker	3	awesome	Last Available: "2015-09"
 8582	denatured spinning gray vibrating mushroom	1	decent	Last Available: "2015-09"
 8583	distilled mushroom	1	EPIC	Effect: "Slightly Mutated", Effect Duration: 40, Last Available: "2015-09"
@@ -8458,7 +8458,7 @@
 8585	fuchsia Da Vinci's Golden Mr. Eh?	0		Experience (Mysticality): +5, Last Available: "2015-09"
 8586	barrel gun of the storm	0		Maximum MP Percent: +40, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
-8588	ghostly narrow barrel beryl	0		Last Available: "2015-09"
+8588	narrow ghostly barrel beryl	0		Last Available: "2015-09"
 8589	adequate water log	3	good	Last Available: "2015-09"
 8590	rosy-cheeked groovy barrelhead	0		Moxie Percent: +10, Maximum HP Percent: +30, Last Available: "2015-09"
 8591	curative hardy bottoms of the barrel	0		Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-09"
@@ -8484,9 +8484,9 @@
 8611	double-alkaline ghostly cuppa Chari tea	0		Effect: "Turkey-Agitated", Effect Duration: 45, Last Available: "2015-09"
 8612	moist cuppa Serendipi tea	0		Effect: "Space Cowboy", Effect Duration: 66, Last Available: "2015-09"
 8613	quadruple-enhanced improved cuppa Feroci tea	0		Effect: "Hagg-ard", Effect Duration: 68, Last Available: "2015-09"
-8614	extra-colloidal tarnished twirling gray cuppa Physicali tea	0		Effect: "Nigh-Invincible", Effect Duration: 17, Last Available: "2015-09"
+8614	extra-colloidal tarnished gray twirling cuppa Physicali tea	0		Effect: "Nigh-Invincible", Effect Duration: 17, Last Available: "2015-09"
 8615	pickled alkaline cuppa Wit tea	0		Effect: "Be a Mind Master", Effect Duration: 52, Last Available: "2015-09"
-8616	pickled activated spinning squat cuppa Neuroplastici tea	0		Effect: "Thick, Sick", Effect Duration: 47, Last Available: "2015-09"
+8616	pickled activated squat spinning cuppa Neuroplastici tea	0		Effect: "Thick, Sick", Effect Duration: 47, Last Available: "2015-09"
 8617	aerosolized moist cuppa Dexteri tea	0		Effect: "Initiative and Let Die", Effect Duration: 24, Last Available: "2015-09"
 8618	warmed cuppa Flexibili tea	0		Effect: "Yuletide Sappiness", Effect Duration: 29, Last Available: "2015-09"
 8619	improved magnetized green cuppa Impregnabili tea	0		Effect: "Notably Lovely", Effect Duration: 40, Last Available: "2015-09"
@@ -8495,7 +8495,7 @@
 8622	boiled cuppa Mediocri tea	0		Effect: "Spooky Hands", Effect Duration: 65, Last Available: "2015-09"
 8623	quadruple-modified cuppa Loyal tea	0		Effect: "Mmmmmelon", Effect Duration: 62, Last Available: "2015-09"
 8624	modified cuppa Activi tea	1	crappy	Effect: "Phoenix, Right?", Effect Duration: 25, Last Available: "2015-09"
-8625	modified squat shaking cuppa Cruel tea	1		Last Available: "2015-09"
+8625	modified shaking squat cuppa Cruel tea	1		Last Available: "2015-09"
 8626	galvanized alkaline maroon cuppa Alacri tea	0		Effect: "Stimulated Body", Effect Duration: 63, Last Available: "2015-09"
 8627	denatured cuppa Vitali tea	0		Effect: "Sealed Brain", Effect Duration: 16, Last Available: "2015-09"
 8628	concentrated liquefied spinning ghostly cuppa Mana tea	0		Effect: "Moon-Eyed", Effect Duration: 66, Last Available: "2015-09"
@@ -8516,7 +8516,7 @@
 8643	spoiled blurry bowl of maggots	3	crappy	Last Available: "2015-10"
 8644	acceptable spinning blood and blood	3	good	Last Available: "2015-10"
 8645	lousy Jack-O-Lantern beer	4	decent	Last Available: "2015-10"
-8646	hand-crafted watered-down zombie	2	EPIC	Last Available: "2015-10"
+8646	watered-down hand-crafted zombie	2	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	extremely unsafe Samson's hawk of the sewer	0		Experience (Muscle): +5, Weapon Damage Percent: +100, Stench Damage: +25
-8655	thick stale spinning hamlet sandwich	5	decent	
+8655	stale thick spinning hamlet sandwich	5	decent	
 8656	Socratic Othello's military jacket	0		Experience (Mysticality): +1
 8657	Othello's dagger of wisdom	0		Mysticality: +15, Single Equip
 8658	crafty Othello's handkerchief	0		Maximum MP: +10, Single Equip
@@ -8547,7 +8547,7 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	fuchsia one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	modified shoulder-warming lotion	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 27, Last Available: "2015-11"
-8677	bland thick iceberg lettuce	5	decent	Last Available: "2015-11"
+8677	thick bland iceberg lettuce	5	decent	Last Available: "2015-11"
 8678	perfectly mixed ice wine	3	EPIC	Last Available: "2015-11"
 8679	squat flame-retardant hardy Da Vinci's Wal-Mart snowglobe	0		Experience (Mysticality): +5, Maximum HP: +50, Hot Resistance: +1, Last Available: "2015-11"
 8680	yellow Jack Frost's dance instructor's Wal-Mart nametag of mayonnaise	0		Experience Percent (Moxie): +10, Cold Spell Damage: +50, Sleaze Spell Damage: +50, Last Available: "2015-11"
@@ -8588,7 +8588,7 @@
 8715	twisted abstraction: joy	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 30, Last Available: "2015-12"
 8716	vaporized abstraction: certainty	1		Last Available: "2015-12"
 8717	dried abstraction: comprehension	1		Effect: "Innately Wise", Effect Duration: 35, Last Available: "2015-12"
-8718	upside-down red modern picture frame	0		Last Available: "2015-12"
+8718	red upside-down modern picture frame	0		Last Available: "2015-12"
 8719	normal half-sized VYKEA meatballs	2	good	Last Available: "2015-11"
 8720	delicious mirror VYKEA mead	3	awesome	Last Available: "2015-11"
 8721	irradiated huge VYKEA woadpaint	0		Effect: "How to Scam Tourists", Effect Duration: 62, Last Available: "2015-11"
@@ -8602,15 +8602,15 @@
 8729	mirror red prompt energetic weightlifter's VYKEA hex key	0		Muscle: +15, Maximum MP Percent: +20, Adventures: +3, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
 8731	spoiled fancy huge tin of submardines	4	crappy	Effect: "Strange Mental Acuity", Effect Duration: 10, Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	watered-down drinkable bottle of norwhiskey	2	good	Last Available: "2015-11"
+8732	drinkable watered-down bottle of norwhiskey	2	good	Last Available: "2015-11"
 8733	distilled pulsating octolus oculus	1	good	Last Available: "2015-11"
 8734	greasy wicked sardine can key of the sweet-tooth	0		Spell Damage: +5, Sleaze Spell Damage: +10, Candy Drop: +100, Last Available: "2015-11"
 8735	blue avaricious extremely unsafe Sinatra's norwhal helmet	0		Experience (Moxie): +5, Weapon Damage Percent: +100, Meat Drop: +30, Last Available: "2015-11", Familiar Effect: "atk"
 8736	upside-down greedy Rosewater's octolus-skin cloak of the brazier	0		Mysticality Percent: +30, Hot Spell Damage: +25, Meat Drop: +20, Last Available: "2015-11"
-8737	watered-down drinkable perfect cosmopolitan	2	good	Last Available: "2015-11"
-8738	practically non-alcoholic special bad perfect negroni	1	decent	Effect: "Worth Your Salt", Effect Duration: 45, Last Available: "2015-11"
-8739	watered-down acceptable yellow perfect dark and stormy	2	good	Last Available: "2015-11"
-8740	hand-crafted distilled perfect mimosa	5	EPIC	Last Available: "2015-11"
+8737	drinkable watered-down perfect cosmopolitan	2	good	Last Available: "2015-11"
+8738	special practically non-alcoholic bad perfect negroni	1	decent	Effect: "Worth Your Salt", Effect Duration: 45, Last Available: "2015-11"
+8739	acceptable watered-down yellow perfect dark and stormy	2	good	Last Available: "2015-11"
+8740	distilled hand-crafted perfect mimosa	5	EPIC	Last Available: "2015-11"
 8741	mediocre perfect old-fashioned	3	decent	Last Available: "2015-11"
 8742	hand-crafted perfect paloma	4	EPIC	Last Available: "2015-11"
 8743	modified modified That 70s Cologne	0		Effect: "Analog Drunk", Effect Duration: 49, Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	polymerized altered red tumbling hemp candy necklace	0		Effect: "Spiro Gyro", Effect Duration: 32, Last Available: "2015-12"
 8751	magnetized activated bouncing communal gobstopper	0		Effect: "Mistified", Effect Duration: 30, Last Available: "2015-12"
 8752	tasty immense Crimbo salad	7	awesome	Last Available: "2015-12"
-8753	fancy rotten huge bread line	6	crappy	Effect: "Mathematically Precise", Effect Duration: 40, Last Available: "2015-12"
+8753	huge rotten fancy bread line	6	crappy	Effect: "Mathematically Precise", Effect Duration: 40, Last Available: "2015-12"
 8754	acceptable bark rootbeer	3	good	Last Available: "2015-12"
 8755	perfectly mixed ale	3	EPIC	Last Available: "2015-12"
 8756	rosy-cheeked plastic Tammy the Tambourine Elf	0		Maximum HP Percent: +30, Last Available: "2015-12"
@@ -8632,11 +8632,11 @@
 8759	healthy plastic Crimborgatron	0		Maximum HP Percent: +20, Last Available: "2015-12"
 8760	experienced plastic Crimbodhisattva	0		Experience: +2, Last Available: "2015-12"
 8761	bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
-8762	upside-down olive stack of communist leaflets	0		Last Available: "2015-12"
+8762	olive upside-down stack of communist leaflets	0		Last Available: "2015-12"
 8763	BACON	0		Last Available: "2016-05"
 8764	bouncing box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	high-proof drinkable Gratitude chocolate (bourbon-filled)	7	good	Last Available: "2016-02"
+8766	drinkable high-proof Gratitude chocolate (bourbon-filled)	7	good	Last Available: "2016-02"
 8767	bouncing Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	wobbly Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8648,7 +8648,7 @@
 8776	extremely unsafe armband	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2015-12"
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	tumbling nuclear stockpile	0		Last Available: "2015-12"
-8779	tumbling wobbly pine cone	0		Last Available: "2015-12"
+8779	wobbly tumbling pine cone	0		Last Available: "2015-12"
 8780	tumbling iron chain	0		Last Available: "2015-12"
 8781	arcane researcher's pine cone necklace	0		Experience Percent (Mysticality): +10, Last Available: "2015-12"
 8782	mirror manspreader's reindeer hammer	0		Monster Level: +10, Last Available: "2015-12"
@@ -8657,7 +8657,7 @@
 8785	spinning The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	twirling upside-down faded protest sign	0		Last Available: "2015-12"
 8787	maroon faded protest sign	0		Last Available: "2015-12"
-8788	twirling maroon nasty-smelling moss	0		Last Available: "2015-12"
+8788	maroon twirling nasty-smelling moss	0		Last Available: "2015-12"
 8789	book	0		Last Available: "2015-12"
 8790	Herculean elven tambourine	0		Experience (Muscle): +1, Last Available: "2015-12"
 8791	Temple Grandin's reindeer sickle	0		Familiar Weight: +7, Last Available: "2015-12"
@@ -8689,9 +8689,9 @@
 8817	distilled blurry red Mansquito Serum	1		Last Available: "2016-12"
 8818	perfectly mixed weak wobbly Miss Graves' vermouth	2	super ultra EPIC	Last Available: "2016-12"
 8819	super-sized tasty The Plumber's mushroom stew	5	awesome	Last Available: "2016-12"
-8820	compressed blinking narrow The Author's ink	1		Last Available: "2016-02"
-8821	mediocre irresponsibly strong shaking The Mad Liquor	9	decent	Last Available: "2016-12"
-8822	weak artisanal Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
+8820	compressed narrow blinking The Author's ink	1		Last Available: "2016-02"
+8821	irresponsibly strong mediocre shaking The Mad Liquor	9	decent	Last Available: "2016-12"
+8822	artisanal weak Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
 8823	decent Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	denatured squat The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	scandalous stylish strapping The Jokester's gun	0		Muscle: +5, Moxie: +25, Sleaze Damage: +5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
@@ -8746,11 +8746,11 @@
 8874	wobbly aromatic experienced smartaleck's Val-U Brand Every Bean Salad of the pedagogue of Gandalf	0		Moxie Percent: +30, Experience: 5, Spell Critical Percent: +20, Stench Resistance: +1, Last Available: "2016-02"
 8875	flame-wreathed Sinatra's Shrub's Premium Baked Beans of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Hot Spell Damage: +10, Last Available: "2016-02"
 8876	rotten plate of Heimz Fortified Kidney Beans	3	crappy	Last Available: "2016-02"
-8877	normal bite-sized upside-down mirror plate of Tesla's Electroplated Beans	1	good	Last Available: "2016-02"
+8877	bite-sized normal mirror upside-down plate of Tesla's Electroplated Beans	1	good	Last Available: "2016-02"
 8878	bland plate of Mixed Garbanzos and Chickpeas	4	decent	Last Available: "2016-02"
-8879	rotten pulsating mirror green plate of Hellfire Spicy Beans	3	crappy	Last Available: "2016-02"
-8880	diet decent fancy plate of Frigid Northern Beans	1	good	Effect: "Balls of Ectoplasm", Effect Duration: 50, Last Available: "2016-02"
-8881	yummy huge plate of World's Blackest-Eyed Peas	6	awesome	Last Available: "2016-02"
+8879	rotten green pulsating mirror plate of Hellfire Spicy Beans	3	crappy	Last Available: "2016-02"
+8880	fancy diet decent plate of Frigid Northern Beans	1	good	Effect: "Balls of Ectoplasm", Effect Duration: 50, Last Available: "2016-02"
+8881	huge yummy plate of World's Blackest-Eyed Peas	6	awesome	Last Available: "2016-02"
 8882	special stale plate of Trader Olaf's Exotic Stinkbeans	4	decent	Effect: "Cotton Mouthed", Effect Duration: 5, Last Available: "2016-02"
 8883	stale narrow plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	decent	Last Available: "2016-02"
 8884	bland plate of Val-U Brand Every Bean Salad	3	decent	Last Available: "2016-02"
@@ -8769,8 +8769,8 @@
 8897	nitrogenated super-flattened poker face paint	0		Effect: "Pemmican't", Effect Duration: 33, Last Available: "2016-02"
 8898	cyan realistic cap gun	0		Last Available: "2016-02"
 8899	ghostly tainted milk	1	decent	Last Available: "2016-02"
-8900	twirling gray gun parts	0		Last Available: "2016-02"
-8901	colloidal improved wobbly twirling triggerfingerbone	0		Effect: "Pyramid Power", Effect Duration: 63, Last Available: "2016-02"
+8900	gray twirling gun parts	0		Last Available: "2016-02"
+8901	colloidal improved twirling wobbly triggerfingerbone	0		Effect: "Pyramid Power", Effect Duration: 63, Last Available: "2016-02"
 8902	flattened pickled energized ghost bit	0		Effect: "Shot in the Arse", Effect Duration: 18, Last Available: "2016-02"
 8903	dry cold-filtered buzzard feather	0		Effect: "Whippin' It Good", Effect Duration: 37, Last Available: "2016-02"
 8904	oxidized lion musk	0		Effect: "Truly Gritty", Effect Duration: 64, Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	activated squat rattler gland	0		Effect: "Strange Mental Acuity", Effect Duration: 12, Last Available: "2016-02"
 8907	electrified dry green half-digested coal	0		Effect: "Ogred and Oublietted", Effect Duration: 65, Last Available: "2016-02"
 8908	polymerized shaking tightly-wound spine	0		Effect: "Three Days Slow", Effect Duration: 44, Last Available: "2016-02"
-8909	massive toothsome rotting beefsteak	10	awesome	Last Available: "2016-02"
+8909	toothsome massive rotting beefsteak	10	awesome	Last Available: "2016-02"
 8910	triple-distilled perfectly mixed firemilk	8	EPIC	Last Available: "2016-02"
 8911	triple-dry spidercow eye-cluster	0		Effect: "Stands Alone", Effect Duration: 50, Last Available: "2016-02"
 8912	dehydrated spinning moomy dust	1		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 5, Last Available: "2016-02"
@@ -8796,7 +8796,7 @@
 8924	blinking disc (black)	0		
 8925	disc (red)	0		
 8926	skewed disc (green)	0		
-8927	narrow purple disc (blue)	0		
+8927	purple narrow disc (blue)	0		
 8928	cyan disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	liquefied ghostly narrow demonic cow's blood	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 36, Last Available: "2016-02"
@@ -8878,7 +8878,7 @@
 9006	frosty dog trainer's hardened tunac of the sewer	0		Damage Reduction: 3, Experience (familiar): +1, Cold Spell Damage: +10, Stench Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	frozen wriggling worm	0		Effect: "Down With Chow", Effect Duration: 51, Last Available: "2016-04"
-9009	perfectly mixed weak bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
+9009	weak perfectly mixed bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
 9010	extra-aerosolized high-test fishing line	0		Effect: "Pumped Up", Effect Duration: 50, Last Available: "2016-04"
 9011	prompt fishin' hat	0		Adventures: +3, Last Available: "2016-04"
 9012	upside-down cyan Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	wobbly internet point	0		Last Available: "2016-05"
 9019	blurry meme generator	0		Last Available: "2016-05"
 9020	yellow plus one	0		Last Available: "2016-05"
-9021	bite-sized bland special gallon of milk	1	decent	Effect: "Sticky Hands", Effect Duration: 45, Last Available: "2016-05"
+9021	bland special bite-sized gallon of milk	1	decent	Effect: "Sticky Hands", Effect Duration: 45, Last Available: "2016-05"
 9022	green jittery print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8899,19 +8899,19 @@
 9027	executive banded supercool First Post shirt - Cir Senam	0		Moxie Percent: +20, Damage Absorption: +100, Meat Drop: +40, Last Available: "2016-05"
 9028	ghostly high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	delicious small star salad	2	awesome	
+9030	small delicious star salad	2	awesome	
 9031	Thwaitgold moth statuette	0		
-9032	thick adequate mirror bowl of Tastee-Wheet&trade;	5	good	
+9032	adequate thick mirror bowl of Tastee-Wheet&trade;	5	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	bouncing Source essence	0		Last Available: "2016-06"
-9035	miniature bland browser cookie	2	decent	Last Available: "2016-06"
+9035	bland miniature browser cookie	2	decent	Last Available: "2016-06"
 9036	bad mirror hacked gibson	3	decent	Last Available: "2016-06"
 9037	forbidden Source shades	0		Spell Damage Percent: +50, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
-9042	spinning cyan Source terminal SPAM chip	0		Last Available: "2016-06"
+9042	cyan spinning Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	twirling Source terminal TRAM chip	0		Last Available: "2016-06"
@@ -8941,7 +8941,7 @@
 9069	horrifying resourceful bronze detective badge of the wise owl of bravery	0		Mysticality: +20, Maximum MP: +50, Spooky Damage: +25, Spooky Resistance: +5, Last Available: "2016-07"
 9070	lion tamer's Rosewater's savvy wizardly detective badge	0		Mysticality: +25, Mysticality Percent: 50, Experience (familiar): +2, Last Available: "2016-07"
 9071	shaking family-friendly frosty rock-hard Herculean detective badge	0		Experience (Muscle): +1, Damage Reduction: 5, Cold Spell Damage: +10, Sleaze Resistance: +1, Last Available: "2016-07"
-9072	blue squat cop dollar	0		Last Available: "2016-07"
+9072	squat blue cop dollar	0		Last Available: "2016-07"
 9073	detective school application	0		Free Pull, Last Available: "2016-07"
 9074	mansplainer's clever baleful detective roscoe	0		Spell Damage: +25, Maximum MP: +20, Monster Level: +15, Last Available: "2016-07"
 9075	liquefied adjusted blue shoe gum	0		Effect: "Eldritch Concentration", Effect Duration: 18, Last Available: "2016-07"
@@ -8988,14 +8988,14 @@
 9116	blinking time residue	0		Last Available: "2016-09"
 9117	Socratic repaid diaper	0		Experience (Mysticality): +1
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	smooth watered-down maroon shaking blinking Shot of Kardashian Gin	2	awesome	Last Available: "2016-09"
+9119	smooth watered-down blinking maroon shaking Shot of Kardashian Gin	2	awesome	Last Available: "2016-09"
 9120	miser's Unstable Pointy Ears	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2016-09"
 9121	narrow Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
 9123	green School of Hard Knocks Diploma	0		
 9124	bouncing baby bark scorpion	0		
 9125	gray droppable microphone	0		
-9126	lousy narrow upside-down unidentified drink	4	decent	
+9126	lousy upside-down narrow unidentified drink	4	decent	
 9127	manspreader's healthy KoL Con 13 T-shirt	0		Maximum HP Percent: +20, Monster Level: +10
 9128	blinking frightening toasty discarded swimming trunks of mayonnaise	0		Hot Damage: +5, Spooky Damage: +5, Sleaze Spell Damage: +50
 9129	double-pickled dry diluted makeup	0		Effect: "Patience of the Tortoise", Effect Duration: 35
@@ -9025,45 +9025,45 @@
 9153	bland raw sweet potato	3	decent	Last Available: "2016-11"
 9154	spoiled special squat raw beans	3	crappy	Effect: "Wintergreen Warmongery", Effect Duration: 35, Last Available: "2016-11"
 9155	toothsome raw stuffing	3	awesome	Last Available: "2016-11"
-9156	snack-sized rotten raw cranberry sauce	2	crappy	Last Available: "2016-11"
+9156	rotten snack-sized raw cranberry sauce	2	crappy	Last Available: "2016-11"
 9157	thick flavorless blue blinking raw turkey	5	decent	Last Available: "2016-11"
 9158	stale jumbo raw mincemeat	5	decent	Last Available: "2016-11"
 9159	adequate raw potato	4	good	Last Available: "2016-11"
 9160	stale jumbo raw gravy	5	decent	Last Available: "2016-11"
-9161	small stale blinking raw bread	2	decent	Last Available: "2016-11"
+9161	stale small blinking raw bread	2	decent	Last Available: "2016-11"
 9162	frightening wizardly mini-marshmallow dispenser	0		Mysticality: +25, Spooky Damage: +5, Last Available: "2016-11"
 9163	frosty studded baleful glass casserole dish	0		Spell Damage: +25, Damage Absorption: +80, Cold Spell Damage: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	upside-down blue hardy dance instructor's can opener	0		Experience Percent (Moxie): +10, Maximum HP: +50, Last Available: "2016-11"
-9166	altered wobbly spinning teal turkey blaster	1		Effect: "Patent Avarice", Effect Duration: 35, Last Available: "2016-11"
+9166	altered teal spinning wobbly turkey blaster	1		Effect: "Patent Avarice", Effect Duration: 35, Last Available: "2016-11"
 9167	narrow rosewater-soaked beefcake's glass pie plate	0		Muscle: +25, Stench Resistance: +3, Damage Reduction: 7, Last Available: "2016-11"
 9168	skewed bouncing censurious potato masher of the early riser	0		Sleaze Resistance: +3, Adventures: +7, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
-9170	bouncing skewed bread mold	0		Last Available: "2016-11"
+9170	skewed bouncing bread mold	0		Last Available: "2016-11"
 9171	decent sweet potatoes	4	good	Last Available: "2016-11"
 9172	adequate immense bean casserole	6	good	Last Available: "2016-11"
-9173	thick adequate special baked stuffing	5	good	Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2016-11"
+9173	thick special adequate baked stuffing	5	good	Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2016-11"
 9174	adequate cranberry cylinder	3	good	Last Available: "2016-11"
 9175	spoiled thanksgiving turkey	4	crappy	Last Available: "2016-11"
 9176	stale jumbo blurry mince pie	5	decent	Last Available: "2016-11"
 9177	normal mashed potatoes	3	good	Last Available: "2016-11"
 9178	moldy blue warm gravy	4	crappy	Last Available: "2016-11"
 9179	adequate bread roll	4	good	Last Available: "2016-11"
-9180	spoiled enchanted leftovers	3	crappy	Effect: "Cold Hard Skin", Effect Duration: 35, Last Available: "2016-11"
-9181	immense rotten blinking blurry leftovers sandwich	8	crappy	Last Available: "2016-11"
+9180	enchanted spoiled leftovers	3	crappy	Effect: "Cold Hard Skin", Effect Duration: 35, Last Available: "2016-11"
+9181	rotten immense blurry blinking leftovers sandwich	8	crappy	Last Available: "2016-11"
 9182	red Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
-9185	blinking twirling pilgrim hat	0		Last Available: "2016-11"
+9185	twirling blinking pilgrim hat	0		Last Available: "2016-11"
 9186	jittery teal packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	skewed eldritch effluvium	0		
-9191	enhanced enhanced yellow twirling eldritch concentrate	0		Effect: "Permanent Halloween", Effect Duration: 56, Last Available: "2016-11"
+9191	enhanced enhanced twirling yellow eldritch concentrate	0		Effect: "Permanent Halloween", Effect Duration: 56, Last Available: "2016-11"
 9192	practically non-alcoholic perfectly mixed eldritch extract	1	super ultra mega EPIC	Last Available: "2016-11"
 9193	tumbling Newton's Official Council Aide Pin of temperance	0		Experience (Mysticality): +3, Sleaze Resistance: +5, Last Available: "2016-11"
-9194	high-proof acceptable eldritch distillate	8	good	Last Available: "2016-11"
+9194	acceptable high-proof eldritch distillate	8	good	Last Available: "2016-11"
 9195	boiled eldritch essence	1		Last Available: "2016-11"
 9196	frosty Science Notebook	0		Cold Spell Damage: +10
 9197	skewed padded slick cool eldritch hat	0		Moxie: 15, Damage Absorption: +20, Last Available: "2016-11"
@@ -9090,7 +9090,7 @@
 9218	huge sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	decent red animal part cracker	3	good	Last Available: "2016-12"
 9220	triple-distilled perfectly mixed gingerbread wine	6	EPIC	Last Available: "2016-12"
-9221	massive stale pulsating gingerbread mug	10	decent	Last Available: "2016-12"
+9221	stale massive pulsating gingerbread mug	10	decent	Last Available: "2016-12"
 9222	gingerbread mask of the detective	0		Item Drop: +20, Last Available: "2016-12"
 9223	tumbling lightning-fast knitted sharpshooter's gingerservo	0		Critical Hit Percent: +10, Cold Resistance: +3, Initiative: +40, Single Equip, Last Available: "2016-12"
 9224	denatured vacuum-sealed tainted icing	0		Effect: "Speed of the Internet", Effect Duration: 15, Last Available: "2016-12"
@@ -9108,11 +9108,11 @@
 9236	blurry baleful gingerbread gavel of the cheetah	0		Spell Damage: +25, Initiative: +60, Last Available: "2016-12"
 9237	wobbly gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	practically non-alcoholic drinkable ghostly ginger beer	1	good	Last Available: "2016-12"
+9239	drinkable practically non-alcoholic ghostly ginger beer	1	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	aerosolized skewed industrial frosting	0		Effect: "Polka of Plenty", Effect Duration: 20, Last Available: "2016-12"
 9242	liquefied fake cocktail	0		Effect: "Hippy Flavor", Effect Duration: 36, Last Available: "2016-12"
-9243	tolerable practically non-alcoholic high-end ginger wine	1	good	Last Available: "2016-12"
+9243	practically non-alcoholic tolerable high-end ginger wine	1	good	Last Available: "2016-12"
 9244	jittery Van der Graaf plastic bad vibe	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12"
 9245	greedy plastic angry vikings	0		Meat Drop: +20, Last Available: "2016-12"
 9246	wobbly plastic Knows About Chakras of the scaredy-cat	0		Monster Level: -15, Last Available: "2016-12"
@@ -9133,7 +9133,7 @@
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
-9264	lime green huge briefcase full of sprinkles	0		Last Available: "2016-12"
+9264	huge lime green briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	quadruple-cold-filtered colloidal blinking rock candy	0		Effect: "Old Time Hydration", Effect Duration: 12, Last Available: "2016-12"
 9267	decent massive green-iced sweet roll	6	good	Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	strong hand-crafted chakra-mental wine	5	EPIC	Last Available: "2016-12"
 9277	boiled super-warmed blue chakra malt	0		Effect: "Gutterminded", Effect Duration: 56, Last Available: "2016-12"
 9278	stale ghostly Black Angus blackburger	4	decent	Last Available: "2016-12"
-9279	acceptable triple-distilled brandy	9	good	Last Available: "2016-12"
+9279	triple-distilled acceptable brandy	9	good	Last Available: "2016-12"
 9280	modified potion of spiritual gunkifying	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 61, Last Available: "2016-12"
 9281	Jack Frost's careful bad vibroknife	0		Monster Level: -10, Cold Spell Damage: +50, Last Available: "2016-12"
 9282	bouncing toasty baleful crystal belt buckle	0		Spell Damage: +25, Hot Damage: +5, Last Available: "2016-12"
@@ -9178,7 +9178,7 @@
 9306	gray wobbly hardy beefcake's candle	0		Muscle: +25, Maximum HP: +50, Lasts Until Rollover, Last Available: "2017-01"
 9307	bland wax pancake	4	decent	Last Available: "2017-01"
 9308	hale dance instructor's wax face	0		Experience Percent (Moxie): +10, Maximum HP: +20, Last Available: "2017-01"
-9309	perfectly mixed practically non-alcoholic spinning wax booze	1	super ultra EPIC	Last Available: "2017-01"
+9309	practically non-alcoholic perfectly mixed spinning wax booze	1	super ultra EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	dried upside-down sea jelly	1		Effect: "Bloody Bloody Bloody!", Effect Duration: 10, Last Available: "2017-01"
 9312	moldy sea truffle	3	crappy	Last Available: "2017-01"
@@ -9201,7 +9201,7 @@
 9329	wet quantum irradiated skewed olive eldritch alignment spray	0		Effect: "Horrid, Torrid", Effect Duration: 17, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	foul-smelling crafty Herculean eldritch hammer	0		Experience (Muscle): +1, Maximum MP: +10, Stench Damage: +10, Last Available: "2017-01"
-9332	rotten massive eldritch mushroom	7	crappy	Last Available: "2017-03"
+9332	massive rotten eldritch mushroom	7	crappy	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	moldy twirling eldritch mushroom pizza	3	crappy	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9220,7 +9220,7 @@
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	squat bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	elemental sugarcube	0		Last Available: "2017-03"
-9351	teal twirling tumbling tumbling peppermint sprig	0		Last Available: "2017-03"
+9351	tumbling tumbling teal twirling peppermint sprig	0		Last Available: "2017-03"
 9352	bottle of clam juice	0		Last Available: "2017-03"
 9353	cocktail mushroom	0		Last Available: "2017-03"
 9354	shot of granola liqueur	0		Last Available: "2017-03"
@@ -9235,9 +9235,9 @@
 9363	squat slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	watered-down artisanal literal grasshopper	2	EPIC	Last Available: "2017-03"
-9366	weak drinkable blue double entendre	2	good	Last Available: "2017-03"
-9367	acceptable special Phlegethon	4	good	Effect: "Sharpened Sweet Tooth", Effect Duration: 10, Last Available: "2017-03"
-9368	hand-crafted watered-down purple Siberian sunrise	2	EPIC	Last Available: "2017-03"
+9366	drinkable weak blue double entendre	2	good	Last Available: "2017-03"
+9367	special acceptable Phlegethon	4	good	Effect: "Sharpened Sweet Tooth", Effect Duration: 10, Last Available: "2017-03"
+9368	watered-down hand-crafted purple Siberian sunrise	2	EPIC	Last Available: "2017-03"
 9369	tolerable strong mentholated wine	5	good	Last Available: "2017-03"
 9370	drinkable fancy blurry low tide martini	3	good	Effect: "Frozen Hands", Effect Duration: 40, Last Available: "2017-03"
 9371	tolerable shroomtini	4	good	Last Available: "2017-03"
@@ -9246,21 +9246,21 @@
 9374	drinkable great fashioned	4	good	Last Available: "2017-03"
 9375	mediocre Gnomish sagngria	4	decent	Last Available: "2017-03"
 9376	mediocre irresponsibly strong vodka stinger	10	decent	Last Available: "2017-03"
-9377	practically non-alcoholic fancy artisanal extremely slippery nipple	1	EPIC	Effect: "Pla-see-bo", Effect Duration: 15, Last Available: "2017-03"
-9378	enchanted perfectly mixed watered-down piscatini	2	EPIC	Effect: "damage.enh", Effect Duration: 40, Last Available: "2017-03"
+9377	practically non-alcoholic artisanal fancy extremely slippery nipple	1	EPIC	Effect: "Pla-see-bo", Effect Duration: 15, Last Available: "2017-03"
+9378	perfectly mixed enchanted watered-down piscatini	2	EPIC	Effect: "damage.enh", Effect Duration: 40, Last Available: "2017-03"
 9379	mediocre practically non-alcoholic Churchill	1	decent	Last Available: "2017-03"
-9380	practically non-alcoholic acceptable soilzerac	1	good	Last Available: "2017-03"
-9381	extra-dry acceptable London frog	5	good	Last Available: "2017-03"
+9380	acceptable practically non-alcoholic soilzerac	1	good	Last Available: "2017-03"
+9381	acceptable extra-dry London frog	5	good	Last Available: "2017-03"
 9382	perfectly mixed nothingtini	3	EPIC	Last Available: "2017-03"
 9383	artisanal blurry eighth plague	3	EPIC	Last Available: "2017-03"
 9384	aged single entendre	4	awesome	Last Available: "2017-03"
 9385	watered-down smooth reverse Tantalus	2	awesome	Last Available: "2017-03"
 9386	lousy blue elemental caipiroska	3	decent	Last Available: "2017-03"
-9387	mediocre practically non-alcoholic pulsating Feliz Navidad	1	decent	Last Available: "2017-03"
-9388	bad fancy Bloody Nora	4	decent	Effect: "Ancient Protected", Effect Duration: 45, Last Available: "2017-03"
-9389	irresponsibly strong bad shaking yellow moreltini	9	decent	Last Available: "2017-03"
+9387	practically non-alcoholic mediocre pulsating Feliz Navidad	1	decent	Last Available: "2017-03"
+9388	fancy bad Bloody Nora	4	decent	Effect: "Ancient Protected", Effect Duration: 45, Last Available: "2017-03"
+9389	bad irresponsibly strong yellow shaking moreltini	9	decent	Last Available: "2017-03"
 9390	weak aged mirror hell in a bucket	2	awesome	Last Available: "2017-03"
-9391	bad high-proof Newark	9	decent	Last Available: "2017-03"
+9391	high-proof bad Newark	9	decent	Last Available: "2017-03"
 9392	lousy R'lyeh	3	decent	Last Available: "2017-03"
 9393	delicious Gnollish sangria	3	awesome	Last Available: "2017-03"
 9394	hand-crafted vodka barracuda	3	EPIC	Last Available: "2017-03"
@@ -9268,8 +9268,8 @@
 9396	perfectly mixed drive-by shooting	3	EPIC	Last Available: "2017-03"
 9397	strong tolerable bouncing gunner's daughter	5	good	Last Available: "2017-03"
 9398	mediocre blue dirt julep	4	decent	Last Available: "2017-03"
-9399	enchanted artisanal Simepore slime	3	EPIC	Effect: "Dreams and Lights", Effect Duration: 25, Last Available: "2017-03"
-9400	enchanted hand-crafted skewed blue Phil Collins	4	EPIC	Effect: "Barking Mad", Effect Duration: 35, Last Available: "2017-03"
+9399	artisanal enchanted Simepore slime	3	EPIC	Effect: "Dreams and Lights", Effect Duration: 25, Last Available: "2017-03"
+9400	enchanted hand-crafted blue skewed Phil Collins	4	EPIC	Effect: "Barking Mad", Effect Duration: 35, Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	gray toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9292,7 +9292,7 @@
 9420	twisted alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	jittery zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	bland miniature skewed squat alien meat	2	decent	Last Available: "2017-04"
+9423	bland miniature squat skewed alien meat	2	decent	Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	olive shaking blinking alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9301,7 +9301,7 @@
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	mirror spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
-9432	triple-ionized denatured magnetized bouncing green alien medicine	0		Effect: "License to Punch", Effect Duration: 20, Last Available: "2017-04"
+9432	triple-ionized denatured magnetized green bouncing alien medicine	0		Effect: "License to Punch", Effect Duration: 20, Last Available: "2017-04"
 9433	moldy small alien salad	2	crappy	Last Available: "2017-04"
 9434	mediocre alien booze	3	decent	Last Available: "2017-04"
 9435	miser's Temple Grandin's brainy alien mask	0		Mysticality: +5, Familiar Weight: +7, Meat Drop: +10, Last Available: "2017-04"
@@ -9336,7 +9336,7 @@
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	bland Aldebaran sardines	3	decent	Last Available: "2017-04"
-9467	perfectly mixed practically non-alcoholic blue Centauri fish wine	1	super ultra mega EPIC	Last Available: "2017-04"
+9467	practically non-alcoholic perfectly mixed blue Centauri fish wine	1	super ultra mega EPIC	Last Available: "2017-04"
 9468	powdered oxygen	1		Last Available: "2017-04"
 9469	olive ribald studded Spacegate scientist's insignia	0		Damage Absorption: +80, Sleaze Damage: +10, Single Equip, Last Available: "2017-04"
 9470	boxer's Spacegate military insignia of the ox	0		Muscle: +20, Muscle Percent: +10, Single Equip, Last Available: "2017-04"
@@ -9355,17 +9355,17 @@
 9483	electrified quadruple-modified Daily Affirmation: Be a Mind Master	0		Effect: "Ninja, Please", Effect Duration: 27, Last Available: "2017-05"
 9484	pickled olive Daily Affirmation: Work For Hours a Week	0		Effect: "Ooh, Sour!", Effect Duration: 30, Last Available: "2017-05"
 9485	quadruple-galvanized altered Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 24, Last Available: "2017-05"
-9486	miniature stale ghostly Affirmation Cookie	2	decent	Last Available: "2017-05"
+9486	stale miniature ghostly Affirmation Cookie	2	decent	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	altered Threatening Missive	0		Effect: "Resilient Spirit", Effect Duration: 33
 9491	blurry Targeted Plague Vector	0		
-9492	skewed olive suspicious package	0		Free Pull, Last Available: "2017-06"
+9492	olive skewed suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	censurious smooth Kremlin's Greatest Briefcase of the brute	0		Moxie: +15, Muscle Percent: +30, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	strong drinkable jittery basic martini	5	good	Last Available: "2017-06"
-9495	lousy weak improved martini	2	decent	Last Available: "2017-06"
-9496	artisanal watered-down gray wobbly splendid martini	2	EPIC	Last Available: "2017-06"
+9494	drinkable strong jittery basic martini	5	good	Last Available: "2017-06"
+9495	weak lousy improved martini	2	decent	Last Available: "2017-06"
+9496	watered-down artisanal gray wobbly splendid martini	2	EPIC	Last Available: "2017-06"
 9497	bouncing exploding cigar	0		Last Available: "2017-06"
 9498	spinning can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9410,7 +9410,7 @@
 9538	dropped scrap of paper	0		
 9539	gray hunk of granite	0		
 9540	shovelful of dirt	0		
-9541	red huge xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
+9541	huge red xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	huge exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
@@ -9429,7 +9429,7 @@
 9557	teal up-at-dawn pearl necklace of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Adventures: +5, Single Equip, Last Available: "2017-10"
 9558	amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
-9560	huge lime green O	0		Last Available: "2017-11"
+9560	lime green huge O	0		Last Available: "2017-11"
 9561	squat amorphous blob	0		Last Available: "2017-11"
 9562	lion tamer's Lo Pan's baleful protection stick of the brazier	0		Spell Damage: +25, Spell Critical Percent: +30, Experience (familiar): +2, Hot Spell Damage: +25
 9563	corrupted pulsating roll of meat	0		Effect: "Tingling Feeling", Effect Duration: 63
@@ -9450,9 +9450,9 @@
 9578	transparent nog	1	EPIC	Last Available: "2017-12"
 9579	delicious unfinished fruitcake	3	awesome	Last Available: "2017-12"
 9580	ionized warmed tumbling and cracker	0		Effect: "Memories of Puppy Love", Effect Duration: 47, Last Available: "2017-12"
-9581	aged weak neg grog	2	awesome	Last Available: "2017-12"
+9581	weak aged neg grog	2	awesome	Last Available: "2017-12"
 9582	super-sized flavorless half double fruitcake	5	decent	Last Available: "2017-12"
-9583	rotten half-sized hushed puppy	2	crappy	Last Available: "2017-12"
+9583	half-sized rotten hushed puppy	2	crappy	Last Available: "2017-12"
 9584	bland muffled muffuletta	3	decent	Last Available: "2017-12"
 9585	adequate small shushed potatoes	2	good	Last Available: "2017-12"
 9586	Sherlock's plastic mime functionary	0		Item Drop: +25, Last Available: "2017-12"
@@ -9467,7 +9467,7 @@
 9595	mediocre Racisto Ruidoso	3	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	rotten bran muffin	3	crappy	
-9598	bland half-sized mirror ghostly blueberry muffin	2	decent	
+9598	half-sized bland mirror ghostly blueberry muffin	2	decent	
 9599	silent A	0		Last Available: "2017-12"
 9600	blue silent B	0		Last Available: "2017-12"
 9601	shaking silent C	0		Last Available: "2017-12"
@@ -9499,14 +9499,14 @@
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	acceptable stale cheer wine	3	good	Last Available: "2017-12"
-9630	half-sized adequate stale Cheer-E-Os	2	good	Last Available: "2017-12"
+9630	adequate half-sized stale Cheer-E-Os	2	good	Last Available: "2017-12"
 9631	bouncing cheer-o-gram	0		Last Available: "2017-12"
 9632	skewed Da Vinci's slick cheerful antler hat	0		Moxie: +10, Experience (Mysticality): +5, Last Available: "2017-12"
 9633	toasty ruddy cheerful Crimbo sweater	0		Maximum HP Percent: +40, Hot Damage: +5, Last Available: "2017-12"
 9634	beefy cheerful pajama pants of the empath	0		Muscle: +10, Familiar Weight: +5, Last Available: "2017-12"
-9635	jittery wobbly The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9635	wobbly jittery The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	narrow The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
-9637	huge purple The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
+9637	purple huge The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
@@ -9517,12 +9517,12 @@
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	wobbly The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	fortified tolerable executive mime flask	5	good	Last Available: "2017-12"
-9649	low-calorie yummy bouncing nega-mushroom	1	awesome	Last Available: "2017-12"
+9648	tolerable fortified executive mime flask	5	good	Last Available: "2017-12"
+9649	yummy low-calorie bouncing nega-mushroom	1	awesome	Last Available: "2017-12"
 9650	lousy nega-mushroom wine	4	decent	Last Available: "2017-12"
 9651	deionized vacuum-sealed cold-filtered tumbling Cheer-Up soda	0		Effect: "Bureaucratized", Effect Duration: 12, Last Available: "2017-12"
 9652	tasty mime army rations	4	awesome	Last Available: "2017-12"
-9653	artisanal practically non-alcoholic olive mime army wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
+9653	practically non-alcoholic artisanal olive mime army wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
 9654	mixed mime army superserum	1		Last Available: "2017-12"
 9655	alkaline irradiated mime army camouflage kit	0		Effect: "Brain Freeze", Effect Duration: 18, Last Available: "2017-12"
 9656	spinning asbestos-lined miming beret of the ox	0		Muscle: +20, Hot Resistance: +5, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	huge kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	stale extra-toasted half sandwich	4	decent	Last Available: "2018-12"
-9682	weak aged mulled hobo wine	2	awesome	Last Available: "2018-12"
+9682	aged weak mulled hobo wine	2	awesome	Last Available: "2018-12"
 9683	lime green burning newspaper	0		Last Available: "2018-12"
 9684	burning paper hat of the wise owl of the empath of doom	0		Mysticality: +20, Familiar Weight: +5, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-12"
 9685	teal Temple Grandin's rock-hard burning cape of vim and vigor	0		Damage Reduction: 5, Maximum HP Percent: +50, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2018-12"
@@ -9570,7 +9570,7 @@
 9698	boiled double-energized shaking hot button candy	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 68
 9699	purple fireproof boxer's wizardly makeshift garbage shirt	0		Mysticality: +25, Muscle Percent: +10, Hot Resistance: +3, Last Available: "2018-01"
 9700	slick thinker's novelty monorail ticket	0		Mysticality: +10, Moxie: +10
-9701	denatured maroon jittery bouncing pills	1		Effect: "Celestial Vision", Effect Duration: 35
+9701	denatured bouncing jittery maroon pills	1		Effect: "Celestial Vision", Effect Duration: 35
 9702	boiled gray furry pill	1		
 9703	compressed beefy pill	1		
 9704	powdered excitement pill	1		
@@ -9594,7 +9594,7 @@
 9726	nippy steel-toed psychic's amulet	0		Damage Reduction: 9, Cold Damage: +10, Last Available: "2018-02"
 9727	thick rotten skewed yellow heart-shaped candy whetstone	5	crappy	Last Available: "2018-02"
 9728	normal Swedish massage fish	4	good	Last Available: "2018-02"
-9729	practically non-alcoholic acceptable spinning Third Base	1	good	Last Available: "2018-02"
+9729	acceptable practically non-alcoholic spinning Third Base	1	good	Last Available: "2018-02"
 9730	aged skewed Bustle Hustler	3	awesome	Last Available: "2018-02"
 9731	deionized flattened huge Fabiotion	0		Effect: "There Is A Spoon", Effect Duration: 52, Last Available: "2018-02"
 9732	irradiated Bettie page	0		Effect: "Well Owl Be!", Effect Duration: 43, Last Available: "2018-02"
@@ -9628,7 +9628,7 @@
 9760	upside-down packet of tall grass seeds	0		Last Available: "2018-03"
 9761	skewed Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
-9763	fuchsia upside-down Bluzzard	0		Last Available: "2018-03"
+9763	upside-down fuchsia Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	mirror Sledgehamster	0		Last Available: "2018-03"
 9766	spinning Pimpsqueak	0		Last Available: "2018-03"
@@ -9638,7 +9638,7 @@
 9770	tumbling Carpricorn	0		Last Available: "2018-03"
 9771	green Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
-9773	red bouncing Cycloney	0		Last Available: "2018-03"
+9773	bouncing red Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
 9775	Turtive	0		Last Available: "2018-03"
 9776	squat Lepardner	0		Last Available: "2018-03"
@@ -9659,7 +9659,7 @@
 9791	Bicycle	0		Last Available: "2018-03"
 9792	blurry Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
-9794	bouncing mirror Nursine	0		Last Available: "2018-03"
+9794	mirror bouncing Nursine	0		Last Available: "2018-03"
 9795	yellow Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
@@ -9669,13 +9669,13 @@
 9801	Vulgure	0		Last Available: "2018-03"
 9802	skewed Squib	0		Last Available: "2018-03"
 9803	Trafikoan	0		Last Available: "2018-03"
-9804	shaking blurry Slotter	0		Last Available: "2018-03"
+9804	blurry shaking Slotter	0		Last Available: "2018-03"
 9805	cyan Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	narrow green Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
-9810	blurry pulsating gray Bowlet	0		Last Available: "2018-03"
+9810	gray blurry pulsating Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	spinning Glum berry	0		Last Available: "2018-03"
@@ -9686,19 +9686,19 @@
 9818	teal Tapioc berry	0		Last Available: "2018-03"
 9819	Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
-9821	upside-down huge luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
+9821	huge upside-down luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	blurry muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
-9825	shaking jittery razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9825	jittery shaking razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	blue rocket	0		
 9828	dried blue magnificent oyster egg	1		
 9829	boiled brilliant oyster egg	1		
 9830	dried pulsating glistening oyster egg	1		
 9831	denatured pulsating scintillating oyster egg	1		
-9832	denatured huge teal pearlescent oyster egg	1		
-9833	dehydrated ghostly blurry squat lustrous oyster egg	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 30
+9832	denatured teal huge pearlescent oyster egg	1		
+9833	dehydrated blurry ghostly squat lustrous oyster egg	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 30
 9834	powdered gleaming oyster egg	1		
 9835	skewed FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	yellow FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9714,7 +9714,7 @@
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	blue Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	wobbly LyleCo premium pickaxe	0		Last Available: "2018-04"
-9849	upside-down teal shaking LyleCo premium rope	0		Last Available: "2018-04"
+9849	upside-down shaking teal LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	bouncing map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	tiny normal denastified haunch	1	good	Last Available: "2018-04"
+9878	normal tiny denastified haunch	1	good	Last Available: "2018-04"
 9879	mediocre extra-dry bad rum and good cola	5	decent	Last Available: "2018-04"
 9880	tarnished dry quadruple-nitrogenated Potion of Heroism	0		Effect: "Fratty Flavor", Effect Duration: 16, Last Available: "2018-04"
 9881	wobbly inspector's veiny leggings of the Spider Queen of bravery	0		Maximum HP: +10, Spooky Resistance: +5, Item Drop: +15, Last Available: "2018-04"
@@ -9766,8 +9766,8 @@
 9898	mediocre shaking two meat muck	4	decent	
 9899	flavorless small chocolate Ogre Chieftain	2	decent	
 9900	normal purple chocolate &quot;Phoenix&quot;	3	good	
-9901	bland small chocolate Spider Queen	2	decent	
-9902	irresponsibly strong perfectly mixed mirror hipster cocktail	9	EPIC	
+9901	small bland chocolate Spider Queen	2	decent	
+9902	perfectly mixed irresponsibly strong mirror hipster cocktail	9	EPIC	
 9903	green God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
@@ -9790,7 +9790,7 @@
 9922	wet dry Shielding Potion	0		Effect: "Bureaucratized", Effect Duration: 69, Last Available: "2018-06"
 9923	nitrogenated triple-pickled Punching Potion	0		Effect: "Squirming Like a Toad", Effect Duration: 41, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	denatured bouncing pulsating cyan Nightmare Fuel	1		Last Available: "2018-06"
+9925	denatured bouncing cyan pulsating Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9813,7 +9813,7 @@
 9945	tumbling Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	aged enchanted Middle of the Road&trade; brand whiskey	4	awesome	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2018-09"
+9948	enchanted aged Middle of the Road&trade; brand whiskey	4	awesome	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	cyan mansplainer's pentagram bandana of the brazier	0		Monster Level: +15, Hot Spell Damage: +25, Last Available: "2018-09"
 9951	experienced skull ring	0		Experience: +2, Single Equip, Last Available: "2018-09"
@@ -9827,7 +9827,7 @@
 9959	cyan blinking cosmetic football of wisdom	0		Mysticality: +15, Last Available: "2018-09"
 9960	sinister wizardly shoe ad T-shirt	0		Mysticality: +25, Spell Damage: +10, Last Available: "2018-09"
 9961	curative pump-up high-tops	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2018-09"
-9962	extra-Vulcanized pulsating twirling runproof mascara	0		Effect: "Concentrated Concentration", Effect Duration: 45, Last Available: "2018-09"
+9962	extra-Vulcanized twirling pulsating runproof mascara	0		Effect: "Concentrated Concentration", Effect Duration: 45, Last Available: "2018-09"
 9963	very small dress	0		Last Available: "2018-09"
 9964	horrifying deadly noticeable pumps	0		Weapon Damage: +5, Spooky Damage: +25, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9844,7 +9844,7 @@
 9977	censurious knitted stylish party whip	0		Moxie: +25, Cold Resistance: +3, Sleaze Resistance: +3, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	drinkable TRIO cup of beer	3	good	Last Available: "2018-09"
-9980	small moldy party platter for one	2	crappy	Last Available: "2018-09"
+9980	moldy small party platter for one	2	crappy	Last Available: "2018-09"
 9981	vaporized skewed Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	rosewater-soaked Annie Oakley's party crasher	0		Critical Hit Percent: +20, Stench Resistance: +3, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
@@ -9879,12 +9879,12 @@
 10013	moldy pizza	3	crappy	Last Available: "2018-11"
 10014	smooth martini	4	awesome	Last Available: "2018-11"
 10015	diet flavorless upside-down cherry pie	1	decent	Last Available: "2018-11"
-10016	artisanal watered-down red eggnog	2	EPIC	Last Available: "2018-11"
+10016	watered-down artisanal red eggnog	2	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	moldy mirror Hell ramen	4	crappy	Last Available: "2018-11"
 10019	acceptable gimlet	3	good	Last Available: "2018-11"
 10020	acceptable fuchsia twice-haunted screwdriver	3	good	Last Available: "2018-11"
-10021	adequate enchanted candy cane	3	good	Effect: "The Halls of Mysticality", Effect Duration: 10, Last Available: "2018-12"
+10021	enchanted adequate candy cane	3	good	Effect: "The Halls of Mysticality", Effect Duration: 10, Last Available: "2018-12"
 10022	watered-down delicious twirling runny fermented egg	2	awesome	Last Available: "2018-12"
 10023	spoiled miniature oldcake	2	crappy	Last Available: "2018-12"
 10024	bland traditional Crimbo cookie	4	decent	Last Available: "2023-06"
@@ -9902,7 +9902,7 @@
 10036	red bomb	0		Last Available: "2018-12"
 10037	wobbly plastic bazooka	0		Last Available: "2018-12"
 10038	pulsating mooseflank	0		Last Available: "2018-12"
-10039	special decent small shaking huge grilled mooseflank	2	good	Effect: "Emotion Sickness", Effect Duration: 10, Last Available: "2018-12"
+10039	small decent special shaking huge grilled mooseflank	2	good	Effect: "Emotion Sickness", Effect Duration: 10, Last Available: "2018-12"
 10040	small yummy moosemeat pie	2	awesome	Last Available: "2018-12"
 10041	steel-toed balanced antler	0		Damage Reduction: 9, Last Available: "2018-12"
 10042	mirror cool dam	0		Moxie: +5, Damage Reduction: 9, Last Available: "2018-12"
@@ -9930,10 +9930,10 @@
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	weak mediocre beer	2	decent	Last Available: "2018-12"
-10067	bland diet wobbly yule gruel	1	decent	Last Available: "2018-12"
+10067	diet bland wobbly yule gruel	1	decent	Last Available: "2018-12"
 10068	practically non-alcoholic tolerable hot watered rum	1	good	Last Available: "2018-12"
 10069	bad bottle of Crimbognac	3	decent	Last Available: "2018-12"
-10070	moldy jumbo Crimboysters Rockefeller	5	crappy	Last Available: "2018-12"
+10070	jumbo moldy Crimboysters Rockefeller	5	crappy	Last Available: "2018-12"
 10071	twisted Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -10012,13 +10012,13 @@
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	pulsating red-and-green microcamera	0		Familiar Weight: +5
 10148	cobbled-together Meat detector of the empath	0		Familiar Weight: +5, Lasts Until Rollover, Last Available: "2019-12"
-10149	boiled narrow blurry tin thermos of chai	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 49, Last Available: "2019-12"
-10150	altered green ghostly prototype stimulant	1		Effect: "Holiday Bliss", Effect Duration: 35, Last Available: "2019-12"
+10149	boiled blurry narrow tin thermos of chai	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 49, Last Available: "2019-12"
+10150	altered ghostly green prototype stimulant	1		Effect: "Holiday Bliss", Effect Duration: 35, Last Available: "2019-12"
 10151	resourceful tailored vest	0		Maximum MP: +50, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	maroon really nice net	0		Last Available: "2019-12"
 10154	blinking occult elf army poncho	0		Spell Damage Percent: +25, Lasts Until Rollover, Last Available: "2019-12"
-10155	moldy half-sized elf army field rations	2	crappy	Last Available: "2019-12"
+10155	half-sized moldy elf army field rations	2	crappy	Last Available: "2019-12"
 10156	cyan gingernade	0		Last Available: "2019-12"
 10157	Usain Bolt's boxer's discarded bowtie	0		Muscle Percent: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2019-12"
 10158	drinkable martiny	4	good	Last Available: "2019-12"
@@ -10032,14 +10032,14 @@
 10166	ghostly Tesla clever Lil' Doctor&trade; bag	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	spoiled ghostly bloodstick	4	crappy	
-10170	irresponsibly strong enchanted bad bottle of Sanguiovese	7	decent	Effect: "Hennaliciousness", Effect Duration: 40
+10170	bad irresponsibly strong enchanted bottle of Sanguiovese	7	decent	Effect: "Hennaliciousness", Effect Duration: 40
 10171	normal bite-sized narrow actual blood sausage	1	good	
 10172	artisanal mulled blood	3	EPIC	
 10173	decent blood snowcone	4	good	
 10174	fancy aged lime green Red Russian	3	awesome	Effect: "Boletus Swoletus", Effect Duration: 30
-10175	enchanted diet normal blood roll-up	1	good	Effect: "Chilblains of the Corn", Effect Duration: 10
+10175	normal diet enchanted blood roll-up	1	good	Effect: "Chilblains of the Corn", Effect Duration: 10
 10176	mediocre strong blurry bottle of blood	5	decent	
-10177	snack-sized spoiled blood-soaked sponge cake	2	crappy	
+10177	spoiled snack-sized blood-soaked sponge cake	2	crappy	
 10178	drinkable fortified vampagne	5	good	
 10179	stale plain snowcone	4	decent	
 10180	Booke of Vampyric Knowledge	0		
@@ -10075,14 +10075,14 @@
 10210	miser's pirate radio ring of the cheetah	0		Meat Drop: +10, Initiative: +60, Single Equip, Last Available: "2019-04"
 10211	tumbling Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	gigantic rotten pineapple slab	9	crappy	Last Available: "2019-04"
-10213	thick stale hibiscus petal	5	decent	Last Available: "2019-04"
+10213	stale thick hibiscus petal	5	decent	Last Available: "2019-04"
 10214	wet oxidized purple huge mint leaf	0		Effect: "Sweet Nostalgia", Effect Duration: 63, Last Available: "2019-04"
 10215	jittery cocoa of youth	0		Last Available: "2019-04"
 10216	mixed blue ice molecule	1		Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2019-04"
 10217	gray Red Roger's reliquary	0		Last Available: "2019-04"
 10218	skewed purple Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
-10220	spinning olive Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10220	olive spinning Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	shaking Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	distilled pewter shavings	1		Last Available: "2019-04"
@@ -10101,9 +10101,9 @@
 10236	mediocre Electric Punch	3	decent	Last Available: "2019-04"
 10237	triple-distilled mediocre Smuggler's Punch	6	decent	Last Available: "2019-04"
 10238	hand-crafted Scorpion Bowl	4	EPIC	Last Available: "2019-04"
-10239	practically non-alcoholic bad Turtle Bowl	1	decent	Last Available: "2019-04"
+10239	bad practically non-alcoholic Turtle Bowl	1	decent	Last Available: "2019-04"
 10240	lousy Cobra Bowl	4	decent	Last Available: "2019-04"
-10241	huge twirling vampyric cloake pattern	0		Free Pull
+10241	twirling huge vampyric cloake pattern	0		Free Pull
 10242	rosy-cheeked occult Socratic stylish beefy vampyric cloake	0		Muscle: +10, Moxie: +25, Experience (Mysticality): +1, Spell Damage Percent: +25, Maximum HP Percent: +30, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	upside-down plastic pirate hat	0		Familiar Weight: +5
 10244	extra-aerosolized super-moist jittery one piece of bubble gum	0		Effect: "Tasting the Rainbow", Effect Duration: 30
@@ -10155,7 +10155,7 @@
 10290	polymerized chocolate doubloon	0		Effect: "Taurus Rising", Effect Duration: 39
 10291	jittery frightening driftwood beach comb of the cheetah of Flo-Jo	0		Spooky Damage: +5, Initiative: 160, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
-10293	wobbly blurry stick of firewood	0		Last Available: "2019-08"
+10293	blurry wobbly stick of firewood	0		Last Available: "2019-08"
 10294	vibrating whittled tiara of James Dean of the early riser	0		Experience (Moxie): +3, Maximum MP Percent: +10, Adventures: +7, Last Available: "2019-08"
 10295	huge scandalous occult whittled shorts of horror	0		Spell Damage Percent: +25, Spooky Spell Damage: +25, Sleaze Damage: +5, Last Available: "2019-08"
 10296	brainy whittled flail of the dark arts of doom	0		Mysticality: +5, Spell Damage Percent: +100, Spooky Spell Damage: +50, Last Available: "2019-08"
@@ -10166,13 +10166,13 @@
 10301	narrow knitted healthy whittled fox figurine of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Cold Resistance: +3, Single Equip, Last Available: "2019-08"
 10302	aromatic electrified wholesome whittled walking stick of the ox	0		Muscle: +20, Maximum HP Percent: +10, Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-08"
 10303	adequate campfire hot dog	3	good	Last Available: "2019-08"
-10304	jumbo moldy ghostly campfire baked potato	5	crappy	Last Available: "2019-08"
+10304	moldy jumbo ghostly campfire baked potato	5	crappy	Last Available: "2019-08"
 10305	stale red campfire s'more	3	decent	Last Available: "2019-08"
 10306	decent campfire beans	3	good	Last Available: "2019-08"
 10307	flavorless campfire stew	4	decent	Last Available: "2019-08"
 10308	jittery campfire coffee	1	good	Last Available: "2019-08"
 10309	super-pressed tarnished leftover chocolate bar	0		Effect: "The Moxie of LOV", Effect Duration: 33
-10310	upside-down wobbly rare Meat isotope	0		
+10310	wobbly upside-down rare Meat isotope	0		
 10311	blinking burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
 10313	campfire smoke	0		
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	tasty bu&ntilde;uelos Jaliscos	4	awesome	Last Available: "2019-12"
 10338	flavorless half-sized shaking flan del mar	2	decent	Last Available: "2019-12"
-10339	spoiled fancy low-calorie Baja sopapilla	1	crappy	Effect: "Bastard!", Effect Duration: 35, Last Available: "2019-12"
+10339	low-calorie spoiled fancy Baja sopapilla	1	crappy	Effect: "Bastard!", Effect Duration: 35, Last Available: "2019-12"
 10340	blue energetic plastic Mer-kin baker	0		Maximum MP Percent: +20, Last Available: "2019-12"
 10341	ruddy plastic sea elf	0		Maximum HP Percent: +40, Last Available: "2019-12"
 10342	blurry scorching plastic yuleviathan	0		Hot Damage: +25, Last Available: "2019-12"
@@ -10220,7 +10220,7 @@
 10361	flavorless huge guffin	8	decent	Last Available: "2019-12"
 10362	distilled Shantix&trade;	1		Effect: "Spiky Hair", Effect Duration: 25, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	diluted squat green non-Euclidean angle	1		Last Available: "2019-12"
+10364	diluted green squat non-Euclidean angle	1		Last Available: "2019-12"
 10365	galvanized pulsating peppermint syrup	0		Effect: "Almost Cool", Effect Duration: 46, Last Available: "2019-12"
 10366	polymerized Vulcanized Mer-kin eyedrops	0		Effect: "Elron's Explosive Etude", Effect Duration: 56, Last Available: "2019-12"
 10367	pickled wobbly extra-strength goo	0		Effect: "Ocelot Eyes", Effect Duration: 59, Last Available: "2019-12"
@@ -10253,7 +10253,7 @@
 10394	prompt Oprah's Mer-kin rollpin	0		Maximum MP Percent: +50, Adventures: +3, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
-10397	flavorless special bowl of mernudo	3	decent	Effect: "Antibiotic Saucesphere", Effect Duration: 10, Last Available: "2019-12"
+10397	special flavorless bowl of mernudo	3	decent	Effect: "Antibiotic Saucesphere", Effect Duration: 10, Last Available: "2019-12"
 10398	lousy weak fishelada	2	decent	Last Available: "2019-12"
 10399	bland jumbo skewed ojo de pez burrito	5	decent	Last Available: "2019-12"
 10400	huge waterlogged wood	0		Last Available: "2019-12"
@@ -10300,8 +10300,8 @@
 10443	skewed Driplet	0		
 10444	pulsating drippy snail shell	0		
 10445	yummy olive drippy nugget	3	drippy	
-10446	hand-crafted fancy skewed glass of drippy wine	3	drippy	Effect: "Burnt 'n' Turnt", Effect Duration: 30
-10447	tasty wobbly spinning drippy caviar	4	drippy	
+10446	fancy hand-crafted skewed glass of drippy wine	3	drippy	Effect: "Burnt 'n' Turnt", Effect Duration: 30
+10447	tasty spinning wobbly drippy caviar	4	drippy	
 10448	yummy fuchsia shaking drippy plum(?)	3	drippy	
 10449	cyan boxer's drippy stake	0		Muscle Percent: +10, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10323,14 +10323,14 @@
 10466	narrow cape of Calamity Jane	0		Critical Hit Percent: +15
 10467	ribald dangerous back shell	0		Weapon Damage: +10, Sleaze Damage: +10
 10468	spiky back shell	0		
-10469	tumbling twirling power pants	0		Maximum PP: +1
+10469	twirling tumbling power pants	0		Maximum PP: +1
 10470	Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
 10472	Lo Pan's bony back shell	0		Spell Critical Percent: +30
 10473	squat frosty button	0		Single Equip
 10474	unsweetened blooper ink	0		Effect: "Phoenix, Right?", Effect Duration: 58
 10475	coin	0		
-10476	purple tumbling rubber doll head	0		
+10476	tumbling purple rubber doll head	0		
 10477	upside-down rubber doll body	0		
 10478	bouncing plastic doll arms	0		
 10479	squat plastic doll legs	0		
@@ -10343,10 +10343,10 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	spoiled fancy mushroom filet	3	crappy	Effect: "Wet Jaw", Effect Duration: 35, Last Available: "2020-03"
+10489	fancy spoiled mushroom filet	3	crappy	Effect: "Wet Jaw", Effect Duration: 35, Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	distilled mushroom tea	1		Effect: "Scavengers Scavenging", Effect Duration: 5, Last Available: "2020-03"
-10492	smooth spirit-forward blinking jittery mushroom whiskey	5	awesome	Last Available: "2020-03"
+10492	spirit-forward smooth jittery blinking mushroom whiskey	5	awesome	Last Available: "2020-03"
 10493	Sherlock's chilly mushroom cap of the early riser	0		Cold Damage: +5, Item Drop: +25, Adventures: +7, Last Available: "2020-03"
 10494	spinning Jeselnik's lion tamer's rosy-cheeked Samson's mushroom shield	0		Experience (Muscle): +5, Maximum HP Percent: +30, Experience (familiar): +2, Sleaze Damage: +25, Damage Reduction: 6, Last Available: "2020-03"
 10495	blinking family-friendly clever Socratic groovy mushroom pants	0		Moxie Percent: +10, Experience (Mysticality): +1, Maximum MP: +20, Sleaze Resistance: +1, Last Available: "2020-03"
@@ -10379,7 +10379,7 @@
 10522	squat drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
-10525	watered-down special bad drippy pilsner	2	drippy	Effect: "Superhuman Sarcasm", Effect Duration: 35
+10525	special watered-down bad drippy pilsner	2	drippy	Effect: "Superhuman Sarcasm", Effect Duration: 35
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	green lustrous drippy orb	0		
@@ -10390,15 +10390,15 @@
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
 10536	Guzzlr hat	0		Last Available: "2020-05"
-10537	wobbly blinking Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
+10537	blinking wobbly Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	lime green frightening Guzzlr souvenir stein	0		Spooky Damage: +5, Last Available: "2020-05"
 10540	lime green Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	extra-dry artisanal Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
+10541	artisanal extra-dry Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
 10542	delicious Sourfinger	4	awesome	Last Available: "2020-05"
 10543	watered-down bad blue Nog-on-the-Cob	2	decent	Last Available: "2020-05"
 10544	drinkable Steamboat	3	good	Last Available: "2020-05"
-10545	mediocre watered-down Buttery Boy	2	decent	Last Available: "2020-05"
+10545	watered-down mediocre Buttery Boy	2	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	skewed Temple Grandin's savvy clown car key	0		Mysticality Percent: +20, Familiar Weight: +7, Last Available: "2020-08"
 10548	vibrating banded fortified batting cage key	0		Damage Absorption: 160, Maximum MP Percent: +10, Last Available: "2020-08"
@@ -10433,7 +10433,7 @@
 10577	warmed enhanced writhing drippy candy bar	0		Effect: "Conspiratory Eyes", Effect Duration: 52
 10578	dry triple-quantum gooey drippy candy bar	0		Effect: "The Wisdom... of the Future", Effect Duration: 43
 10579	lime green jittery baby camelCalf	0		Free Pull, Last Available: "2020-07"
-10580	maroon wobbly dromedary drinking helmet	0		
+10580	wobbly maroon dromedary drinking helmet	0		
 10581	huge packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
@@ -10462,7 +10462,7 @@
 10606	anodized dry activated pulsating Yeg's Motel toothbrush	0		Effect: "Pie in the Sky", Effect Duration: 26, Last Available: "2020-09"
 10607	non-dry dry Yeg's Motel hand soap	0		Effect: "Chalky Hand", Effect Duration: 63, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	stale fancy Yeg's Motel pillow mint	3	decent	Effect: "Fungal Fortification", Effect Duration: 5, Last Available: "2020-09"
+10609	fancy stale Yeg's Motel pillow mint	3	decent	Effect: "Fungal Fortification", Effect Duration: 5, Last Available: "2020-09"
 10610	teal Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	double-irradiated Yeg's Motel mouthwash	0		Effect: "Brocolate Brostidigitation", Effect Duration: 63, Last Available: "2020-09"
 10612	Jim Carey's Socratic Yeg's Motel shower cap	0		Experience (Mysticality): +1, Monster Level: +25, Lasts Until Rollover, Last Available: "2020-09"
@@ -10517,13 +10517,13 @@
 10661	spinning sizzling SalesCo sample kit	0		Hot Damage: [+10*event(December)], Last Available: "2020-12"
 10662	corrupted candy harmonica	0		Effect: "Smoking like a Bandit", Effect Duration: 39, Last Available: "2020-12"
 10663	moist extra-dry purple sugar	0		Effect: "Gobliny Flavor", Effect Duration: 32, Last Available: "2020-12"
-10664	chilled extra-deionized ghostly wobbly multi-level marzipan	0		Effect: "Become Superficially interested", Effect Duration: 63, Last Available: "2020-12"
+10664	chilled extra-deionized wobbly ghostly multi-level marzipan	0		Effect: "Become Superficially interested", Effect Duration: 63, Last Available: "2020-12"
 10665	toasty plastic Crimbo caroler	0		Hot Damage: +5, Last Available: "2020-12"
 10666	plastic multi-level marketer of wisdom	0		Mysticality: +15, Last Available: "2020-12"
 10667	plastic Crimbo cheer of the sweet-tooth	0		Candy Drop: +100, Last Available: "2020-12"
 10668	plastic Mirth of James Dean	0		Experience (Moxie): +3, Last Available: "2020-12"
 10669	huge zippy plastic Penny	0		Initiative: +20, Last Available: "2020-12"
-10670	skewed blue overflowing gift basket	0		Last Available: "2020-12"
+10670	blue skewed overflowing gift basket	0		Last Available: "2020-12"
 10671	personalized wassail stein	0		Last Available: "2020-12"
 10672	blurry tabletop candy dispenser	0		Last Available: "2020-12"
 10673	Sherlock's neck wreath	0		Item Drop: [+25*event(December)], Single Equip, Last Available: "2020-12"
@@ -10538,7 +10538,7 @@
 10682	quantum prescription teeth whitener	0		Effect: "Partially Ghosted", Effect Duration: 33, Last Available: "2020-12"
 10683	non-modified imported lemon lozenge	0		Effect: "Gummi Badass", Effect Duration: 27, Last Available: "2020-12"
 10684	colloidal nitrogenated hermedisiac cologne	0		Effect: "Just the Brown Ones", Effect Duration: 65, Last Available: "2020-12"
-10685	wobbly blue skewed government food shipment	0		Last Available: "2020-12"
+10685	skewed wobbly blue government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
@@ -10589,7 +10589,7 @@
 10733	narrow emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
 10734	huge spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	jittery robo-battery	0		
-10736	blue pulsating Thwaitgold listening bug statuette	0		
+10736	pulsating blue Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
 10739	magnetized huge upside-down battery (AAA)	0		Effect: "Wistfully Nostalgic", Effect Duration: 51, Last Available: "2021-03"
@@ -10600,14 +10600,14 @@
 10744	frozen oxidized battery (car)	0		Effect: "Fan-Cooled", Effect Duration: 13, Last Available: "2021-03"
 10745	blurry cryptocloak	0		Last Available: "2025-12"
 10746	purple skewed marshmallow	0		
-10747	fortified artisanal marshmallow bomb	5	EPIC	Last Available: "2021-03"
+10747	artisanal fortified marshmallow bomb	5	EPIC	Last Available: "2021-03"
 10748	narrow packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	tumbling plate	0		Familiar Weight: +5
 10752	nitrogenated gray short beer	0		Effect: "Improved Candy Vision", Effect Duration: 26, Last Available: "2021-05"
 10753	unsweetened spinning short stack of pancakes	0		Effect: "Vitamin-Maxed", Effect Duration: 65, Last Available: "2021-05"
-10754	enhanced non-electrified bouncing olive short stick of butter	0		Effect: "Briny Blood", Effect Duration: 25, Last Available: "2021-05"
+10754	enhanced non-electrified olive bouncing short stick of butter	0		Effect: "Briny Blood", Effect Duration: 25, Last Available: "2021-05"
 10755	triple-adjusted polarized tumbling short glass of water	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 16, Last Available: "2021-05"
 10756	quantum boiled skewed short	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 21, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
@@ -10621,14 +10621,14 @@
 10765	upside-down rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	rocket	0		Last Available: "2021-07"
-10768	immense bland huge fire crackers	9	decent	Last Available: "2021-07"
+10768	bland immense huge fire crackers	9	decent	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	executive Catherine Wheel of the empath	0		Familiar Weight: +5, Meat Drop: +40, Lasts Until Rollover, Last Available: "2021-07"
 10771	auspicious baleful rocket boots	0		Spell Damage: +25, Item Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	upside-down lion tamer's beefy sparkler	0		Muscle: +10, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2021-07"
 10773	Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	anodized diffused yellow Scent of a Human&trade; candle	0		Effect: "Think Win-Lose", Effect Duration: 25, Last Available: "2021-08"
-10775	altered blinking olive wobbly The Beast Within&trade; candle	0		Effect: "Morninja", Effect Duration: 47, Last Available: "2021-08"
+10775	altered wobbly blinking olive The Beast Within&trade; candle	0		Effect: "Morninja", Effect Duration: 47, Last Available: "2021-08"
 10776	warmed dry bouncing Salsa Caliente&trade; candle	0		Effect: "Piratastic", Effect Duration: 33, Last Available: "2021-08"
 10777	quantum non-frozen spinning lime green Smoldering Clover&trade; candle	0		Effect: "Hairy Palms", Effect Duration: 34, Last Available: "2021-08"
 10778	altered shaking Napalm In The Morning&trade; candle	0		Effect: "Loco Motives", Effect Duration: 31, Last Available: "2021-08"
@@ -10660,7 +10660,7 @@
 10804	blurry ruddy padded Daylight Shavings Helmet of the boozehound	0		Damage Absorption: +20, Maximum HP Percent: +40, Booze Drop: +100, Last Available: "2021-11"
 10805	green eggwater	1	good	Last Available: "2021-12"
 10806	moldy bread man	4	crappy	Last Available: "2021-12"
-10807	flavorless enchanted plain candy cane	3	decent	Effect: "Berry Statistical", Effect Duration: 35, Last Available: "2021-12"
+10807	enchanted flavorless plain candy cane	3	decent	Effect: "Berry Statistical", Effect Duration: 35, Last Available: "2021-12"
 10808	half-sized delicious flour cookie	2	awesome	Last Available: "2021-12"
 10809	yellow gravedigger's plastic food lab	0		Spooky Damage: +10, Single Equip, Last Available: "2021-12"
 10810	Jim Carey's plastic nog lab	0		Monster Level: +25, Single Equip, Last Available: "2021-12"
@@ -10674,13 +10674,13 @@
 10818	squat stanky savvy ice wrap of incineration	0		Mysticality Percent: +20, Hot Spell Damage: +50, Stench Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	rotten tofu pop	3	crappy	Last Available: "2021-12"
 10820	rotten purple bowl of prescription candy	3	crappy	Last Available: "2021-12"
-10821	stale enchanted fishcake	4	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2021-12"
+10821	enchanted stale fishcake	4	decent	Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2021-12"
 10822	moldy gigantic bone broth	10	crappy	Last Available: "2021-12"
 10823	adequate star pop	4	good	Last Available: "2021-12"
-10824	perfectly mixed weak Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
+10824	weak perfectly mixed Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
 10825	triple-distilled smooth cyan Doc's Smartifying Wine	8	awesome	Last Available: "2021-12"
 10826	mediocre Doc's Limbering Wine	4	decent	Last Available: "2021-12"
-10827	bad fortified blinking Doc's Medical-Grade Wine	5	decent	Last Available: "2021-12"
+10827	fortified bad blinking Doc's Medical-Grade Wine	5	decent	Last Available: "2021-12"
 10828	dehydrated shaking Homebodyl&trade;	1		Effect: "Paging Betty", Effect Duration: 25, Last Available: "2021-12"
 10829	pickled Extrovermectin&trade;	1		Effect: "Tiki Temerity", Effect Duration: 10, Last Available: "2021-12"
 10830	mixed jittery Breathitin&trade;	1		Effect: "Sweet, Nuts", Effect Duration: 50, Last Available: "2021-12"
@@ -10691,8 +10691,8 @@
 10835	cold-filtered pulsating anti-odor cream	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 55, Last Available: "2021-12"
 10836	wet triple-unsweetened anti-creep cream	0		Effect: "BOOsted", Effect Duration: 17, Last Available: "2021-12"
 10837	alkaline irradiated anti-pain cream	0		Effect: "Broken Fast", Effect Duration: 64, Last Available: "2021-12"
-10838	mediocre enchanted weak Doc's Special Reserve Wine	2	decent	Effect: "Okee-Dokee Computer", Effect Duration: 20, Last Available: "2021-12"
-10839	bite-sized toothsome bread pie	1	awesome	Last Available: "2021-12"
+10838	mediocre weak enchanted Doc's Special Reserve Wine	2	decent	Effect: "Okee-Dokee Computer", Effect Duration: 20, Last Available: "2021-12"
+10839	toothsome bite-sized bread pie	1	awesome	Last Available: "2021-12"
 10840	lousy ghostly clear Russian	3	decent	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	skewed Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	squat cozy scarf of extreme caution	0		Monster Level: -25, Last Available: "2021-12"
-10852	spoiled diet huge Crimbo cookie	1	crappy	Last Available: "2023-06"
+10852	diet spoiled huge Crimbo cookie	1	crappy	Last Available: "2023-06"
 10853	cold-filtered irradiated fleshy putty	0		Effect: "Optimist Primal", Effect Duration: 17, Last Available: "2021-12"
 10854	sinister third ear	0		Spell Damage: +10, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10733,7 +10733,7 @@
 10877	narrow cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	teal refurbished air fryer	0		Last Available: "2021-12"
-10880	dehydrated huge red wobbly fried air	1		Effect: "A Contender", Effect Duration: 35, Last Available: "2021-12"
+10880	dehydrated huge wobbly red fried air	1		Effect: "A Contender", Effect Duration: 35, Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	dehydrated blurry astral energy drink	1		
@@ -10748,7 +10748,7 @@
 10892	bouncing combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	greasy combat lover's locket	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2022-02"
 10894	tumbling Thwaitgold protozoa statuette	0		
-10895	bouncing skewed gray grey gosling	0		Free Pull, Last Available: "2022-03"
+10895	gray bouncing skewed grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	huge undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
@@ -10765,16 +10765,16 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	tarnished wet single-use dust mask	0		Effect: "Stenchtastic", Effect Duration: 14, Last Available: "2022-05"
 10911	chilled gaffer's tape	0		Effect: "Elemental Flavor", Effect Duration: 37, Last Available: "2022-05"
-10912	low-calorie rotten twirling 20-lb can of rice and beans	1	crappy	Last Available: "2022-05"
+10912	rotten low-calorie twirling 20-lb can of rice and beans	1	crappy	Last Available: "2022-05"
 10913	olive bar of freeze-dried water	1	crappy	Last Available: "2022-05"
-10914	rotten small expired MRE	2	crappy	Last Available: "2022-05"
+10914	small rotten expired MRE	2	crappy	Last Available: "2022-05"
 10915	spoiled yellow cool mint precipice bar	3	crappy	Last Available: "2022-05"
 10916	normal miniature blinking carrot cake precipice bar	2	good	Last Available: "2022-05"
 10917	huge The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	upside-down mansplainer's clever June cleaver of the bloodbag	0		Maximum HP: +100, Maximum MP: +20, Monster Level: +15, Attacks Can't Miss, Last Available: "2022-06"
-10921	mediocre practically non-alcoholic Dad's brandy	1	decent	Last Available: "2022-06"
+10921	practically non-alcoholic mediocre Dad's brandy	1	decent	Last Available: "2022-06"
 10922	green squat teacher's pen of extreme caution of horror	0		Monster Level: -25, Spooky Spell Damage: +25, Last Available: "2022-06"
 10923	special normal fire-roasted lake trout	4	good	Effect: "Purity of Spirit", Effect Duration: 30, Last Available: "2022-06"
 10924	enchanted rotten gigantic guilty sprout	8	crappy	Effect: "Weapon of Mass Destruction", Effect Duration: 30, Last Available: "2022-06"
@@ -10789,12 +10789,12 @@
 10933	pulsating squat thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	pristine dinosaur feather	0		
-10936	squat blue nasty dinosaur spike	0		
+10936	blue squat nasty dinosaur spike	0		
 10937	curative pterodactyl rifle	0		HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
 10939	flatusaur gasmask	0		
 10940	dinosaur dart	0		
-10941	frozen oxidized blue huge Dino DNAde&trade;	0		Effect: "Shot in the Arse", Effect Duration: 48
+10941	frozen oxidized huge blue Dino DNAde&trade;	0		Effect: "Shot in the Arse", Effect Duration: 48
 10942	dinosaur repellent	0		
 10943	olive camouflage vest of the sewer	0		Stench Damage: +25
 10944	wobbly Dinodollar	0		
@@ -10812,24 +10812,24 @@
 10956	drinkable wobbly AutumnFest ale	4	good	Last Available: "2022-10"
 10957	wobbly nippy fortified autumn sweater-weather sweater of doom	0		Damage Absorption: +60, Cold Damage: +10, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2022-10"
 10958	tumbling ghostly Usain Bolt's Jack Frost's brawny autumn debris shield of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Cold Spell Damage: +50, Initiative: +80, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	stale miniature autumn-spice donut	2	decent	Last Available: "2022-10"
+10959	miniature stale autumn-spice donut	2	decent	Last Available: "2022-10"
 10960	vacuum-sealed liquefied fuchsia autumn dollar	0		Effect: "Tennis Elbow-wow", Effect Duration: 55, Last Available: "2022-10"
 10961	asbestos-lined friendly autumn leaf pendant of Leguizamo	0		Monster Level: +20, Familiar Weight: +3, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2022-10"
 10962	denatured shaking autumn breeze	1		Effect: "Fever From the Flavor", Effect Duration: 10, Last Available: "2022-10"
 10963	non-ionized autumn years wisdom	0		Effect: "Healthy Blue Glow", Effect Duration: 25, Last Available: "2022-10"
 10964	pulsating familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	drinkable watered-down fancy spinning Oopsie IPA	2	good	Effect: "Eau de Tortue", Effect Duration: 15, Last Available: "2022-10"
+10965	watered-down drinkable fancy spinning Oopsie IPA	2	good	Effect: "Eau de Tortue", Effect Duration: 15, Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	blinking Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	moldy ratatouille de Jarlsberg	3	crappy	Last Available: "2022-11"
-10971	bite-sized delicious Jarlsberg's vegetable soup	1	awesome	Last Available: "2022-11"
+10971	delicious bite-sized Jarlsberg's vegetable soup	1	awesome	Last Available: "2022-11"
 10972	decent roasted vegetable of Jarlsberg	4	good	Last Available: "2022-11"
-10973	normal bite-sized St. Pete's sneaky smoothie	1	good	Last Available: "2022-11"
+10973	bite-sized normal St. Pete's sneaky smoothie	1	good	Last Available: "2022-11"
 10974	adequate big olive Pete's wiley whey bar	5	good	Last Available: "2022-11"
 10975	rotten Pete's rich ricotta	3	crappy	Last Available: "2022-11"
-10976	mediocre weak Boris's beer	2	decent	Last Available: "2022-11"
+10976	weak mediocre Boris's beer	2	decent	Last Available: "2022-11"
 10977	decent bouncing honey bun of Boris	3	good	Last Available: "2022-11"
 10978	flavorless Boris's bread	3	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
@@ -10837,13 +10837,13 @@
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
 10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	tumbling ghostly Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10984	ghostly tumbling Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
 10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	teal bouncing Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10986	bouncing teal Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	shaking Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	bland green baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
 10989	rotten mirror plain calzone	4	crappy	Last Available: "2022-11"
-10990	miniature rotten roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
+10990	rotten miniature roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
 10991	stale Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	spoiled ghostly Calzone of Legend	4	crappy	Last Available: "2022-11"
 10993	shaking Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
@@ -10866,11 +10866,11 @@
 11010	bland swamp haunch	3	decent	
 11011	extremely unsafe brainy gator shades	0		Mysticality: +5, Weapon Damage Percent: +100, Single Equip
 11012	milk cap	0		
-11013	fancy hand-crafted Charleston Choo-Choo	3	EPIC	Effect: "Supafly", Effect Duration: 10
-11014	watered-down acceptable Velvet Veil	2	good	
-11015	drinkable weak Marltini	2	good	
-11016	tolerable enchanted weak Strong, Silent Type	2	good	Effect: "Saucemastery", Effect Duration: 40
-11017	delicious irresponsibly strong special Mysterious Stranger	9	awesome	Effect: "Dreadful Chill", Effect Duration: 15
+11013	hand-crafted fancy Charleston Choo-Choo	3	EPIC	Effect: "Supafly", Effect Duration: 10
+11014	acceptable watered-down Velvet Veil	2	good	
+11015	weak drinkable Marltini	2	good	
+11016	enchanted weak tolerable Strong, Silent Type	2	good	Effect: "Saucemastery", Effect Duration: 40
+11017	special delicious irresponsibly strong Mysterious Stranger	9	awesome	Effect: "Dreadful Chill", Effect Duration: 15
 11018	mediocre watered-down Champagne Shimmy	2	decent	
 11019	upside-down the Sot's parcel	0		
 11020	red ruddy grievous ceramic cestus	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10890,7 +10890,7 @@
 11034	dried chiffon carbage	1		Last Available: "2023-12"
 11035	dry tumbling chiffon lemon	0		Effect: "Smelly Pants", Effect Duration: 54
 11036	spoiled chocomotive	3	crappy	Last Available: "2022-12"
-11037	small stale narrow blurry freightcake	2	decent	Last Available: "2022-12"
+11037	stale small blurry narrow freightcake	2	decent	Last Available: "2022-12"
 11038	boozy aged gray cabooze	5	awesome	Last Available: "2022-12"
 11039	bouncing plastic caboose	0		Last Available: "2022-12"
 11040	arcane researcher's plastic passenger car	0		Experience Percent (Mysticality): +10, Last Available: "2022-12"
@@ -10906,8 +10906,8 @@
 11050	altered diffused Trainbot circuitry	0		Effect: "Big Meat Big Prizes", Effect Duration: 46
 11051	enhanced galvanized blue Trainbot tubing	0		Effect: "Familial Ties", Effect Duration: 25
 11052	cold-filtered triple-flattened twirling Trainbot plating	0		Effect: "Chalked-Up Teeth", Effect Duration: 49
-11053	boiled alkaline spinning tumbling Trainbot optics	0		Effect: "There Wolf", Effect Duration: 51
-11054	enhanced narrow bouncing Trainbot servomotors	0		Effect: "Devil Inside", Effect Duration: 20
+11053	boiled alkaline tumbling spinning Trainbot optics	0		Effect: "There Wolf", Effect Duration: 51
+11054	enhanced bouncing narrow Trainbot servomotors	0		Effect: "Devil Inside", Effect Duration: 20
 11055	dry polymerized triple-tarnished shaking Trainbot linkages	0		Effect: "Guts Feeling", Effect Duration: 45
 11056	ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
@@ -10924,20 +10924,20 @@
 11068	skewed lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	adequate shaking honey-drenched ham slice	3	good	
-11071	artisanal fortified mostly-empty bottle of cookie wine	5	EPIC	
-11072	rotten snack-sized blurry Crimbo food scraps	2	crappy	
+11071	fortified artisanal mostly-empty bottle of cookie wine	5	EPIC	
+11072	snack-sized rotten blurry Crimbo food scraps	2	crappy	
 11073	arm towel	0		Last Available: "2022-12"
 11074	shaking automatic wine thief	0		Single Equip
 11075	blinking table-scraper	0		Single Equip
 11076	gray Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	spoiled enchanted steamed oyster	4	crappy	Effect: "The Halls of Moxiousness", Effect Duration: 10
+11078	enchanted spoiled steamed oyster	4	crappy	Effect: "The Halls of Moxiousness", Effect Duration: 10
 11079	blurry really nice lump of coal	0		
-11080	tumbling maroon tumbling deactivated mini-Trainbot	0		Last Available: "2022-12"
+11080	maroon tumbling tumbling deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	teal crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	bad watered-down Crimbosmopolitan	2	decent	Last Available: "2022-12"
+11084	watered-down bad Crimbosmopolitan	2	decent	Last Available: "2022-12"
 11085	normal twirling Crimbo dinner	4	good	Last Available: "2022-12"
 11086	jittery overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10949,12 +10949,12 @@
 11093	Tesla rock-hard grubby wool scarf	0		Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11094	twirling censurious wholesome slick grubby wool trousers	0		Moxie: +10, Maximum HP Percent: +10, Sleaze Resistance: +3
 11095	sizzling friendly Sinatra's grubby wool gloves of incineration	0		Experience (Moxie): +5, Familiar Weight: +3, Hot Damage: +10, Hot Spell Damage: +50, Single Equip
-11096	spinning mirror wobbly grubby wool beerwarmer	0		
+11096	wobbly mirror spinning grubby wool beerwarmer	0		
 11097	acceptable nice warm beer	3	good	
 11098	grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
-11101	red twirling groveling gravel	0		Last Available: "2023-01"
+11101	twirling red groveling gravel	0		Last Available: "2023-01"
 11102	diluted narrow fruity pebble	1		Last Available: "2023-01"
 11103	tumbling lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
@@ -10971,14 +10971,14 @@
 11116	tumbling S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	chilled improved olive glob of extra-green chlorophyll	0		Effect: "Got Your Boots On", Effect Duration: 68, Last Available: "2023-02"
 11118	ionized oxidized triple-denatured lime green mushroom	0		Effect: "Good Karma", Effect Duration: 13, Last Available: "2023-02"
-11119	dry oxidized mirror purple jittery five-fingered fern resin	0		Effect: "Inscrutable exoskeleton", Effect Duration: 38, Last Available: "2023-02"
-11120	big spoiled super good fruit	5	crappy	Last Available: "2023-02"
+11119	dry oxidized purple jittery mirror five-fingered fern resin	0		Effect: "Inscrutable exoskeleton", Effect Duration: 38, Last Available: "2023-02"
+11120	spoiled big super good fruit	5	crappy	Last Available: "2023-02"
 11121	boiled blurry teal energized spores	1		Effect: "Favored by Lyle", Effect Duration: 10, Last Available: "2023-02"
 11122	knitted flame-wreathed hot pepper	0		Hot Spell Damage: +10, Cold Resistance: +3, Last Available: "2023-02", Lantern Element: "Hot"
 11123	pickled wobbly out-of-work circus flea	0		Effect: "Bloody-minded", Effect Duration: 45, Last Available: "2023-02"
-11124	squat purple extra-grubby grub	0		Last Available: "2023-02"
+11124	purple squat extra-grubby grub	0		Last Available: "2023-02"
 11125	vacuum-sealed jittery fire ant pheromones	0		Effect: "Bread Burps", Effect Duration: 47, Last Available: "2023-02"
-11126	alkaline green upside-down narrow flapper fly	0		Effect: "Can't Be a Chooser", Effect Duration: 69, Last Available: "2023-02"
+11126	alkaline upside-down green narrow flapper fly	0		Effect: "Can't Be a Chooser", Effect Duration: 69, Last Available: "2023-02"
 11127	practically non-alcoholic drinkable tumbling shot of wasp venom	1	good	Last Available: "2023-02"
 11128	improved galvanized blinking filled mosquito	0		Effect: "Disdain of She-Who-Was", Effect Duration: 49, Last Available: "2023-02"
 11129	oxidized squat shim of shame shale	0		Effect: "Blackberry Politeness", Effect Duration: 11, Last Available: "2023-02"
@@ -10987,12 +10987,12 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	oxidized magnetized angry agate	0		Effect: "Witch's Brood", Effect Duration: 59, Last Available: "2023-02"
 11134	warmed polarized lump of loyal latite	0		Effect: "Celestial Body", Effect Duration: 48, Last Available: "2023-02"
-11135	flavorless bite-sized shadow sausage	1	decent	Last Available: "2023-03"
+11135	bite-sized flavorless shadow sausage	1	decent	Last Available: "2023-03"
 11136	huge Usain Bolt's healthy shadow skin	0		Maximum HP Percent: +20, Initiative: +80, Last Available: "2023-03"
 11137	anodized activated gray shadow flame	0		Effect: "Mortarfied", Effect Duration: 63, Last Available: "2023-03"
-11138	stale bite-sized wobbly shadow bread	1	decent	Last Available: "2023-03"
+11138	bite-sized stale wobbly shadow bread	1	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	artisanal special shadow fluid	4	EPIC	Effect: "Superioreo", Effect Duration: 15, Last Available: "2023-03"
+11140	special artisanal shadow fluid	4	EPIC	Effect: "Superioreo", Effect Duration: 15, Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	huge shadow sinew	0		Last Available: "2023-03"
@@ -11035,7 +11035,7 @@
 11180	lard-coated Tesla weightlifter's shadow monocle	0		Muscle: +15, Sleaze Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	moldy miniature shadow hot dog	2	crappy	
-11183	mediocre high-proof lime green shadow martini	9	decent	
+11183	high-proof mediocre lime green shadow martini	9	decent	
 11184	distilled skewed shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
@@ -11083,7 +11083,7 @@
 11228	replica puck	0		
 11229	replica Chateau Mantegna room key	0		
 11230	tumbling replica Deck of Every Card	0		
-11231	bouncing shaking replica Source terminal	0		
+11231	shaking bouncing replica Source terminal	0		
 11232	upside-down blurry replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
 11234	upside-down pulsating replica genie bottle	0		
@@ -11134,10 +11134,10 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	tumbling Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	cyan Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	bad watered-down mirror squat Sexy Cosmo	2	decent	Last Available: "2023-06"
-11283	twirling blurry Souvenir Chopsticks	0		Last Available: "2023-06"
+11282	watered-down bad mirror squat Sexy Cosmo	2	decent	Last Available: "2023-06"
+11283	blurry twirling Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	aromatic quilted red-soled high heels of the pedagogue	0		Experience: +3, Damage Absorption: +40, Stench Resistance: +1, Last Available: "2023-06"
-11285	enchanted rotten snack-sized cyburger	2	crappy	Effect: "Brother Corsican's Blessing", Effect Duration: 20, Last Available: "2025-12"
+11285	rotten enchanted snack-sized cyburger	2	crappy	Effect: "Brother Corsican's Blessing", Effect Duration: 20, Last Available: "2025-12"
 11286	blurry green scorching ncle leg	0		Hot Damage: +25
 11287	ghostly manspreader's rutabuga bag of the cougar	0		Moxie: +20, Monster Level: +10
 11288	mesquito proboscis of the detective	0		Item Drop: +20
@@ -11157,7 +11157,7 @@
 11302	lime green souvenir flag	0		
 11303	maroon name change form	0		
 11304	narrow replica sleeping patriotic eagle	0		
-11305	tumbling maroon boxed august scepter	0		Free Pull
+11305	maroon tumbling boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	yummy twirling watermelon	3	awesome	
 11308	skewed watermelon seed	0		
@@ -11172,10 +11172,10 @@
 11317	tumbling handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	bad watered-down bottle of Cabernet Sauvignon	2	decent	
+11320	watered-down bad bottle of Cabernet Sauvignon	2	decent	
 11321	fuchsia friendly baywatch of the ox of Leguizamo	0		Muscle: +20, Monster Level: +20, Familiar Weight: +3, Lasts Until Rollover
-11322	narrow cyan Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	pulsating blue Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	cyan narrow Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	blue pulsating Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	wobbly consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	mirror jittery Thwaitgold fairyfly statue	0		
@@ -11184,7 +11184,7 @@
 11329	modified tumbling meat	1		Effect: "Human-Insect Hybrid", Effect Duration: 5
 11330	compressed mirror sparkling orb	1		
 11331	pickled spinning hardening cream	1		Effect: "Prelude of Precision", Effect Duration: 40
-11332	twisted pulsating wobbly purple pool shark hair oil	1		
+11332	twisted purple wobbly pulsating pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	ghostly book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	skewed Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11217,7 +11217,7 @@
 11362	non-aerosolized liquefied coping juice	0		Effect: "Egg-stra Arm", Effect Duration: 31
 11363	aromatic smelly studded brainy candy cane sword cane of terror	0		Mysticality: +5, Damage Absorption: +80, Stench Spell Damage: +10, Spooky Spell Damage: +10, Stench Resistance: +1, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	maroon wrapped candy cane sword cane	0		Free Pull
-11365	pulsating ghostly Elf Guard patrol cap	0		Last Available: "2023-12"
+11365	ghostly pulsating Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
@@ -11257,14 +11257,14 @@
 11402	maroon Elf Army machine parts	0		Last Available: "2023-12"
 11403	blurry Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	greasy steel-toed banded Crimbuccaneer lantern	0		Damage Absorption: +100, Damage Reduction: 9, Sleaze Spell Damage: +10, Last Available: "2023-12"
-11405	tumbling spinning purple Crimbuccaneer flotsam	0		Last Available: "2023-12"
+11405	tumbling purple spinning Crimbuccaneer flotsam	0		Last Available: "2023-12"
 11406	blurry Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	narrow family-friendly Crimbuccaneer shirt	0		Sleaze Resistance: [+1*event(December)], Last Available: "2023-12"
 11408	pulsating Elf Guard MPC	0		Last Available: "2023-12"
 11409	yellow Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	shellacked Elf Guard commandeering gloves	0		Damage Reduction: 7, Single Equip, Last Available: "2023-12"
 11411	dry Elf Guard eyedrops	0		Effect: "Al Dente Inferno", Effect Duration: 52, Last Available: "2023-12"
-11412	jittery blurry Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
+11412	blurry jittery Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	thinker's Elf Guard officer's sidearm	0		Mysticality: +10, Item Drop: +5, Last Available: "2023-12"
 11415	personal trainer's Elf Guard insignia (general) of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Single Equip, Last Available: "2023-12"
@@ -11274,13 +11274,13 @@
 11419	lime green spinning family-friendly wizardly Elf Guard broom	0		Mysticality: +25, Sleaze Resistance: +1, Last Available: "2023-12"
 11420	cyan perfumed Van der Graaf Crimbuccaneer tavern swab of the scaredy-cat	0		Monster Level: -15, Stench Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	high-proof mediocre olive old-school pirate grog	6	decent	Last Available: "2023-12"
+11422	mediocre high-proof olive old-school pirate grog	6	decent	Last Available: "2023-12"
 11423	enchanted bland grog nuts	4	decent	Effect: "You Ate Some Hemp Candy", Effect Duration: 15, Last Available: "2023-12"
 11424	skewed lightning-fast Socratic thinker's sawed-off blunderbuss	0		Mysticality: +10, Experience (Mysticality): +1, Initiative: +40, Last Available: "2023-12"
 11425	acceptable practically non-alcoholic officer's nog	1	good	Last Available: "2023-12"
 11426	wobbly peppermint bomb	0		Last Available: "2023-12"
 11427	moldy jumbo sundae ration	5	crappy	Last Available: "2023-12"
-11428	thick rotten narrow peppermint tack	5	crappy	Last Available: "2023-12"
+11428	rotten thick narrow peppermint tack	5	crappy	Last Available: "2023-12"
 11429	shaking Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	flavorless super-sized whalesteak	5	decent	Last Available: "2023-12"
 11431	blurry avaricious banded Newton's whalegun	0		Experience (Mysticality): +3, Damage Absorption: +100, Meat Drop: +30, Last Available: "2023-12"
@@ -11317,18 +11317,18 @@
 11462	flavorless green lime	4	decent	Last Available: "2023-12"
 11463	decent mirror gingerbread pirate	3	good	Last Available: "2023-12"
 11464	stale wobbly wobbly fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
-11465	extra-dry hand-crafted mulled wine	5	EPIC	Last Available: "2023-12"
-11466	hand-crafted watered-down wobbly Swedish coffee	2	EPIC	Last Available: "2023-12"
+11465	hand-crafted extra-dry mulled wine	5	EPIC	Last Available: "2023-12"
+11466	watered-down hand-crafted wobbly Swedish coffee	2	EPIC	Last Available: "2023-12"
 11467	drinkable canteen of eggnog	4	good	Last Available: "2023-12"
-11468	high-proof acceptable hot wine	8	good	Last Available: "2023-12"
+11468	acceptable high-proof hot wine	8	good	Last Available: "2023-12"
 11469	lousy Jamaican coffee	4	decent	Last Available: "2023-12"
-11470	lousy pulsating red flask of egggrog	3	decent	Last Available: "2023-12"
+11470	lousy red pulsating flask of egggrog	3	decent	Last Available: "2023-12"
 11471	blurry Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	artisanal yule grog	4	EPIC	Last Available: "2023-12"
 11475	super-sized spoiled narrow wet tack	5	crappy	Last Available: "2023-12"
-11476	rotten jumbo whalecake	5	crappy	Last Available: "2023-12"
+11476	jumbo rotten whalecake	5	crappy	Last Available: "2023-12"
 11477	reassuring foul-smelling coward's gunwale whalegun	0		Monster Level: -20, Stench Damage: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	delicious mirror and claret	3	awesome	Last Available: "2023-12"
 11479	upside-down rigging knot	0		Familiar Weight: +5
@@ -11370,7 +11370,7 @@
 11515	adobe ayam	0		Last Available: "2024-12"
 11516	jittery lime green blurry adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	pulsating adobe abaya	0		Last Available: "2024-12"
-11518	vaporized maroon narrow adobe assortment	1		Last Available: "2024-12"
+11518	vaporized narrow maroon adobe assortment	1		Last Available: "2024-12"
 11519	nitrogenated adobe brittle	0		Effect: "Hustlin'", Effect Duration: 20
 11520	blinking wicked personal trainer's crepe paper phrygian cap of the bloodbag	0		Experience Percent (Muscle): +10, Spell Damage: +5, Maximum HP: +100, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	red Usain Bolt's gravedigger's dangerous crepe paper parachute cape	0		Weapon Damage: +10, Spooky Damage: +10, Initiative: +80, Last Available: "2025-12"
@@ -11378,7 +11378,7 @@
 11523	shaking chaotic medical-grade beefy crepe paper puzzle cube	0		Muscle: +10, Spell Critical Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
 11524	lard-coated smelly crepe paper plunge camisole of the dark arts	0		Spell Damage Percent: +100, Stench Spell Damage: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
 11525	fortified Rosewater's beefcake's crepe paper polka charm	0		Muscle: +25, Mysticality Percent: +30, Damage Absorption: +60, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
-11526	twisted blue skewed crepe paper pared cuttings	1		Effect: "Dreadful Chill", Effect Duration: 40, Last Available: "2025-12"
+11526	twisted skewed blue crepe paper pared cuttings	1		Effect: "Dreadful Chill", Effect Duration: 40, Last Available: "2025-12"
 11527	ionized squat crepe paper peanut candy	0		Effect: "Become Superficially interested", Effect Duration: 27
 11528	aromatic sinister petrified wood war pike	0		Spell Damage: +10, Stench Resistance: +1, Last Available: "2025-12"
 11529	Annie Oakley's crafty petrified wood waist protector	0		Maximum MP: +10, Critical Hit Percent: +20, Single Equip, Last Available: "2025-12"
@@ -11397,7 +11397,7 @@
 11542	mimic egg	0		
 11543	prompt groovy Crimbuccaneer war standard	0		Moxie Percent: +10, Adventures: +3, Last Available: "2023-12"
 11544	Oprah's Elf Guard war standard	0		Maximum MP Percent: +50, Item Drop: +5, Last Available: "2023-12"
-11545	squat jittery in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
+11545	jittery squat in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	blinking Sherlock's forbidden razor-sharp spring shoes	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Item Drop: +25, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	energized altered ultra-soft ferns	0		Effect: "Big Flaming Whip", Effect Duration: 67, Last Available: "2024-02"
 11548	improved modified activated crunchy brush	0		Effect: "Steroid Boost", Effect Duration: 11, Last Available: "2024-02"
@@ -11405,7 +11405,7 @@
 11550	twirling biphasic molecular oculus	0		No Pull
 11551	spinning triphasic molecular oculus	0		
 11552	yellow high-tension exoskeleton	0		
-11553	blurry red ultra-high-tension exoskeleton	0		
+11553	red blurry ultra-high-tension exoskeleton	0		
 11554	olive irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
@@ -11422,15 +11422,15 @@
 11567	narrow stiffened dance instructor's Sinatra's savvy Apriling band quad tom	0		Mysticality Percent: +20, Experience (Moxie): +5, Experience Percent (Moxie): +10, Damage Reduction: 1, Lasts Until Rollover
 11568	Oprah's medical-grade Apriling band tuba of dire peril of the bloodbag of the sewer	0		Weapon Damage: +20, Maximum HP: +100, Maximum MP Percent: +50, Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 11569	sharpshooter's Oprah's medical-grade fortified smartaleck's Apriling band staff of the scaredy-cat	0		Moxie Percent: +30, Damage Absorption: +60, Maximum MP Percent: +50, Critical Hit Percent: +10, Monster Level: -15, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
-11570	mirror upside-down Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
+11570	upside-down mirror Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	twirling boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	bite-sized normal yam	1	good	Last Available: "2024-05"
-11574	weak acceptable yam martini	2	good	Last Available: "2024-05"
+11573	normal bite-sized yam	1	good	Last Available: "2024-05"
+11574	acceptable weak yam martini	2	good	Last Available: "2024-05"
 11575	triple-distilled fancy tolerable upside-down sweet potato o' mine	8	good	Effect: "Mayeaugh", Effect Duration: 40, Last Available: "2024-05"
 11576	bad Southern yam	3	decent	Last Available: "2024-05"
 11577	acceptable spinning sweet potato punch	3	good	Last Available: "2024-05"
-11578	jumbo delicious spinning Mayam spinach	5	awesome	Last Available: "2024-05"
+11578	delicious jumbo spinning Mayam spinach	5	awesome	Last Available: "2024-05"
 11579	half-sized flavorless upside-down yam and swiss	2	decent	Last Available: "2024-05"
 11580	up-at-dawn foul-smelling yam cannon of the brute	0		Muscle Percent: +30, Stench Damage: +10, Adventures: +5, Lasts Until Rollover, Last Available: "2024-05"
 11581	green yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11446,7 +11446,7 @@
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	miniature moldy shaking mini kiwi	2	crappy	Last Available: "2024-06"
+11594	moldy miniature shaking mini kiwi	2	crappy	Last Available: "2024-06"
 11595	ghostly horrifying MacGyver's mini kiwi bikini of the sewer	0		Maximum MP: +100, Stench Damage: +25, Spooky Damage: +25, Last Available: "2024-06"
 11596	boozy delicious mini kiwitini	5	awesome	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11454,7 +11454,7 @@
 11599	family-friendly fireproof Samson's mini kiwi silicon tiepin	0		Experience (Muscle): +5, Hot Resistance: +3, Sleaze Resistance: +1
 11600	mini kiwi tipi	0		
 11601	delicious mini kiwi digitized cookies	3	awesome	
-11602	acceptable weak mini kiwi intoxicating spirits	2	good	
+11602	weak acceptable mini kiwi intoxicating spirits	2	good	
 11603	irradiated extra-cold-filtered mini kiwi antimilitaristic hippy petition	0		Effect: "Disdain of She-Who-Was", Effect Duration: 23
 11604	dry teal skewed mini kiwi illicit antibiotic	0		Effect: "Healthy Bronze Glow", Effect Duration: 19
 11605	vibrating mini kiwi whipping stick of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50
@@ -11477,7 +11477,7 @@
 11622	muscular soup	0		
 11623	skewed flagellate soup	0		
 11624	elbow soup	0		
-11625	blurry pulsating lip soup	0		
+11625	pulsating blurry lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	extra ooze	0		
 11628	blinking extra DNA	0		Experience (familiar): +1
@@ -11487,7 +11487,7 @@
 11632	twirling Doll Moll violin case	0		
 11633	upside-down Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	extra-dry aged blue narrow Colera Peste Nebbiolo	5	awesome	
+11635	aged extra-dry narrow blue Colera Peste Nebbiolo	5	awesome	
 11636	longbox of Batfellow comics	0		
 11637	teal Thwaitgold shield bug statuette	0		
 11638	mirror bodyguard badge	0		
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	spinning scandalous vibrating cool embers-only jacket	0		Moxie: +5, Maximum MP Percent: +10, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2024-09"
 11649	pulsating sizzling bembershoot	0		Hot Damage: +10, Lasts Until Rollover, Last Available: "2024-09"
-11650	bite-sized enchanted decent wheel of camembert	1	good	Effect: "Permanent Halloween", Effect Duration: 50, Last Available: "2024-09"
+11650	bite-sized decent enchanted wheel of camembert	1	good	Effect: "Permanent Halloween", Effect Duration: 50, Last Available: "2024-09"
 11651	asbestos-lined electrified hat of remembering of Flo-Jo	0		Hot Resistance: +5, Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11511,7 +11511,7 @@
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
 11658	prompt forbidden bat wings of the wise owl	0		Mysticality: +20, Spell Damage Percent: +50, Adventures: +3, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
-11659	green squat ember egg	0		Last Available: "2024-09"
+11659	squat green ember egg	0		Last Available: "2024-09"
 11660	red ember	0		Cold Resistance: +1
 11661	bouncing personal trainer's monocle on a stick of the pedagogue	0		Experience: +3, Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2024-10"
 11662	friendly energetic plastic pipe	0		Maximum MP Percent: +20, Familiar Weight: +3, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
@@ -11528,9 +11528,9 @@
 11673	tie-dye headband	0		
 11674	moldy whirled peas	4	crappy	Last Available: "2024-11"
 11675	half-sized bland peaza	2	decent	Last Available: "2024-11"
-11676	pulsating cyan peace shooter	0		Last Available: "2024-11"
+11676	cyan pulsating peace shooter	0		Last Available: "2024-11"
 11677	boiled teal drenchrome 2.0	1		Effect: "The Halls of Mysticality", Effect Duration: 45, Last Available: "2025-12"
-11678	mixed skewed ghostly Synapse Blaster	1		Effect: "Ruthlessly Efficient", Effect Duration: 15, Last Available: "2025-12"
+11678	mixed ghostly skewed Synapse Blaster	1		Effect: "Ruthlessly Efficient", Effect Duration: 15, Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	ghostly quantum watch	0		Adventures: +2
 11681	mirror quantized familiar experience	0		
@@ -11546,7 +11546,7 @@
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
 11693	irresponsibly strong artisanal tankard of spiced rum	10	EPIC	Last Available: "2024-12"
-11694	high-proof delicious tankard of spiced Goldschlepper	10	awesome	Last Available: "2024-12"
+11694	delicious high-proof tankard of spiced Goldschlepper	10	awesome	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	scorching governor's daughter's lace collar	0		Hot Damage: +25, Last Available: "2024-12"
 11697	rosewater-soaked governor's daughter's petticoats	0		Stench Resistance: +3, Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	dog trainer's educational silky pirate drawers	0		Experience: +1, Experience (familiar): +1, Last Available: "2024-12"
 11708	ghostly lime green profane eye patch	0		Sleaze Damage: +3
 11709	flattened quantum jittery yellow peppermint pegleg	0		Effect: "Stench Jellied", Effect Duration: 23, Last Available: "2024-12"
-11710	distilled bad hard cocoa	5	decent	Last Available: "2024-12"
+11710	bad distilled hard cocoa	5	decent	Last Available: "2024-12"
 11711	spoiled salmagumdi	3	crappy	Last Available: "2024-12"
 11712	huge hardy plastic Easter Island Bunny	0		Maximum HP: +50, Last Available: "2024-12"
 11713	plastic St. Patrick of horror	0		Spooky Spell Damage: +25, Last Available: "2024-12"
@@ -11576,7 +11576,7 @@
 11721	pulsating Spirit of Christmas	0		Last Available: "2024-12"
 11722	normal enchanted coney haunch	4	good	Effect: "Papowerful", Effect Duration: 20, Last Available: "2024-12"
 11723	boiled colloidal pulsating dark chocolate egg	0		Effect: "Less Pervious", Effect Duration: 55, Last Available: "2024-12"
-11724	acceptable weak moai toai	2	good	
+11724	weak acceptable moai toai	2	good	
 11725	spinning lime green skewed mirror Samson's groovy moaiball of the sewer	0		Moxie Percent: +10, Experience (Muscle): +5, Stench Damage: +25, Last Available: "2024-12"
 11726	shaking half-digested rat	0		Last Available: "2024-12"
 11727	corrupted huge four-leaf potato sprout	0		Effect: "Sugary World View", Effect Duration: 43, Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	squat Usain Bolt's gravyskin skirt of Gandalf	0		Spell Critical Percent: +20, Initiative: +80, Last Available: "2024-12"
 11737	medical-grade gravyskin pants of chilblains	0		Cold Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11738	activated concentrated cyan bouncing crystallized pumpkin spice	0		Effect: "Nutrient-Rich", Effect Duration: 46, Last Available: "2024-12"
-11739	moldy small room scale bean casserole	2	crappy	Last Available: "2024-12"
+11739	small moldy room scale bean casserole	2	crappy	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	skewed ragged wool yarn	0		Last Available: "2024-12"
 11742	banded sinister wizardly perfect Christmas scarf	0		Mysticality: [+25*event(December)], Spell Damage: [+10*event(December)], Damage Absorption: [+100*event(December)], Single Equip, Last Available: "2024-12"
@@ -11599,18 +11599,18 @@
 11744	electrified aerosolized super-corrupted wobbly LIDAR candle	0		Effect: "Improved Candy Vision", Effect Duration: 21, Last Available: "2024-12"
 11745	blinking flame-wreathed crafty Congressional Medal of Insanity of Leguizamo	0		Maximum MP: +10, Monster Level: +20, Hot Spell Damage: +10, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	perfectly mixed weak Easter grasshopper	2	EPIC	Last Available: "2024-12"
+11747	weak perfectly mixed Easter grasshopper	2	EPIC	Last Available: "2024-12"
 11748	tolerable spinning Irish eggnog	3	good	Last Available: "2024-12"
-11749	perfectly mixed irresponsibly strong canteen of jungle juice	9	EPIC	Last Available: "2024-12"
+11749	irresponsibly strong perfectly mixed canteen of jungle juice	9	EPIC	Last Available: "2024-12"
 11750	drinkable bouncing turchucken	3	good	Last Available: "2024-12"
 11751	watered-down artisanal mechanically-mulled cider	2	EPIC	Last Available: "2024-12"
-11752	irresponsibly strong enchanted tolerable upside-down holiday trip around the world	7	good	Effect: "Your Favorite Flavor", Effect Duration: 50, Last Available: "2024-12"
+11752	enchanted irresponsibly strong tolerable upside-down holiday trip around the world	7	good	Effect: "Your Favorite Flavor", Effect Duration: 50, Last Available: "2024-12"
 11753	rotten chocolate ostrich egg	3	crappy	Last Available: "2024-12"
 11754	normal beef and cabbage	3	good	Last Available: "2024-12"
-11755	massive delicious candy rations	10	awesome	Last Available: "2024-12"
-11756	small normal double-candied yams	2	good	Last Available: "2024-12"
+11755	delicious massive candy rations	10	awesome	Last Available: "2024-12"
+11756	normal small double-candied yams	2	good	Last Available: "2024-12"
 11757	decent Christmas ham	3	good	Last Available: "2024-12"
-11758	snack-sized moldy holiday smorgasbord	2	crappy	Last Available: "2024-12"
+11758	moldy snack-sized holiday smorgasbord	2	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	slick bejazzled eyepatch	0		Moxie: +10, Last Available: "2024-12"
 11761	upside-down Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11628,8 +11628,8 @@
 11773	inspector's horrifying veiny army helmet of James Dean	0		Experience (Moxie): +3, Maximum HP: +10, Spooky Damage: +25, Item Drop: +15, Last Available: "2024-12"
 11774	upside-down candy egg deviler	0		Last Available: "2024-12"
 11775	jittery bouncing napkin	0		Last Available: "2024-12"
-11776	spoiled gigantic shaking jittery Thanksgiving ration	8	crappy	Last Available: "2024-12"
-11777	watered-down mediocre Easter eggnog	2	decent	Last Available: "2024-12"
+11776	gigantic spoiled shaking jittery Thanksgiving ration	8	crappy	Last Available: "2024-12"
+11777	mediocre watered-down Easter eggnog	2	decent	Last Available: "2024-12"
 11778	dried pulsating clovermint	1		Effect: "Wet and Greedy", Effect Duration: 50, Last Available: "2024-12"
 11779	shaking twirling asbestos-lined therapeutic healthy baleful nylon Christmas stockings	0		Spell Damage: +25, Maximum HP Percent: +20, Hot Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11667,12 +11667,12 @@
 11812	vaporized psilocyber mushroom	1		Last Available: "2025-12"
 11813	bouncing dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	jittery dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
-11815	gray blinking tumbling dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
+11815	blinking tumbling gray dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	tumbling mirror dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11820	mirror tumbling dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	bouncing SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
@@ -11709,7 +11709,7 @@
 11854	grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
-11857	tumbling ghostly carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
+11857	ghostly tumbling carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	red glover liners	0		Pickpocket Chance: +10
 11859	narrow mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
@@ -11725,13 +11725,13 @@
 11870	bar dart	0		Last Available: "2025-03"
 11871	dried purple leprechaun antidepressant pill	1		Effect: "Macho Profundo", Effect Duration: 25, Last Available: "2025-03"
 11872	yummy Heck ramen	3	awesome	Last Available: "2025-03"
-11873	fancy spoiled burrito	3	crappy	Effect: "Riboflavin'", Effect Duration: 15, Last Available: "2025-03"
-11874	bland huge small beer brat	9	decent	Last Available: "2025-03"
+11873	spoiled fancy burrito	3	crappy	Effect: "Riboflavin'", Effect Duration: 15, Last Available: "2025-03"
+11874	huge bland small beer brat	9	decent	Last Available: "2025-03"
 11875	decent small peach pie	2	good	Last Available: "2025-03"
 11876	rotten incredible mini-pizza	3	crappy	Last Available: "2025-03"
-11877	drinkable triple-distilled squat Divine sidecar	8	good	Last Available: "2025-03"
-11878	delicious watered-down twirling tangarita sidecar	2	awesome	Last Available: "2025-03"
-11879	practically non-alcoholic tolerable gimlet sidecar	1	good	Last Available: "2025-03"
+11877	triple-distilled drinkable squat Divine sidecar	8	good	Last Available: "2025-03"
+11878	watered-down delicious twirling tangarita sidecar	2	awesome	Last Available: "2025-03"
+11879	tolerable practically non-alcoholic gimlet sidecar	1	good	Last Available: "2025-03"
 11880	perfectly mixed practically non-alcoholic vodka stratocaster sidecar	1	super ultra EPIC	Last Available: "2025-03"
 11881	delicious watered-down prussian cathouse sidecar	2	awesome	Last Available: "2025-03"
 11882	spirit-forward artisanal Mon Tiki sidecar	5	EPIC	Last Available: "2025-03"
@@ -11741,14 +11741,14 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	pickled modified blinking wet paper weights	0		Effect: "Armored Innards", Effect Duration: 36, Last Available: "2025-04"
 11888	perfectly mixed Three Sheets to the Wind	3	EPIC	Last Available: "2025-04"
-11889	bland tiny fuchsia pile of wet dates	1	decent	Last Available: "2025-04"
+11889	tiny bland fuchsia pile of wet dates	1	decent	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	pulsating supercharged wet shower cap	0		Maximum MP Percent: +30, Last Available: "2025-04"
 11893	wholesome wet shower shoes	0		Maximum HP Percent: +10, Last Available: "2025-04"
 11894	cyan squat wet shower shorts of terror	0		Spooky Spell Damage: +10, Last Available: "2025-04"
 11895	huge wet paper tiger	0		Last Available: "2025-04"
-11896	ghostly gray wet paper eye	0		Familiar Weight: +15
+11896	gray ghostly wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
 11898	magnetized unsweetened skewed wet paper cup	0		Effect: "Human-Beast Hybrid", Effect Duration: 39, Last Available: "2025-04"
 11899	dry moist wet paperback	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 48, Last Available: "2025-04"
@@ -11824,7 +11824,7 @@
 11970	sea gel	0		
 11971	nitrogenated extra-polymerized mirror octopus ink bladder	0		Effect: "Outer Wolf&trade;", Effect Duration: 29
 11972	durable dolphin whistle	0		
-11973	yellow wobbly Thwaitgold lobster statuette	0		
+11973	wobbly yellow Thwaitgold lobster statuette	0		
 11974	purple packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
@@ -11833,7 +11833,7 @@
 11987	horrifying stanky sharpshooter's educational cool blood cubic zirconia of the overflowing toilet	0		Moxie: +5, Experience: +1, Critical Hit Percent: +10, Stench Spell Damage: 75, Spooky Damage: +25, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	dehydrated fuchsia blood thinner	1		Last Available: "2025-10"
 12045	artisanal pheromone cocktail	3	EPIC	Last Available: "2025-10"
-12046	gigantic rotten pulsating spinning spinal tapas	8	crappy	Last Available: "2025-10"
+12046	rotten gigantic pulsating spinning spinal tapas	8	crappy	Last Available: "2025-10"
 12047	tumbling shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	aromatic boxer's shrunken head of the dark arts	0		Muscle Percent: +10, Spell Damage Percent: +100, Stench Resistance: +1, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	wobbly stocking full of bones	0		Free Pull, Last Available: "2025-12"
@@ -11881,12 +11881,12 @@
 12123	ghostly The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	watered-down delicious olive Steve Abrams' Holiday Sampler Beer	2	awesome	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	perfectly mixed practically non-alcoholic bottle of prize-winning rum	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12126	practically non-alcoholic perfectly mixed bottle of prize-winning rum	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12127	electrified vibrating Santa-Slayer medal of incineration	0		Maximum MP Percent: +10, Hot Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2025-12"
 12128	mirror Skull of Claus	0		Last Available: "2025-12"
 12129	magnetized ghostly boiling bone marrow	0		Effect: "Memory of Smarts", Effect Duration: 20, Last Available: "2025-12"
 12130	deionized shaking boiling cerebrospinal fluid	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 56, Last Available: "2025-12"
-12131	chilled Vulcanized blinking spinning boiling synovial fluid	0		Effect: "Bilious Brains", Effect Duration: 15, Last Available: "2025-12"
+12131	chilled Vulcanized spinning blinking boiling synovial fluid	0		Effect: "Bilious Brains", Effect Duration: 15, Last Available: "2025-12"
 12132	knitted sinister smoldering vertebra of the brute	0		Muscle Percent: +30, Spell Damage: +10, Cold Resistance: +3, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
@@ -11898,13 +11898,13 @@
 12140	Jack Frost's scorched skull trophy	0		Cold Spell Damage: +50, Last Available: "2025-12"
 12141	small bland wing bone	2	decent	Last Available: "2025-12"
 12142	bad weak skeleton venom	3	decent	Last Available: "2025-12"
-12143	twisted blurry bouncing baked bone meal	1		Last Available: "2025-12"
+12143	twisted bouncing blurry baked bone meal	1		Last Available: "2025-12"
 12144	blinking squat therapeutic plastic skeleton rib cage	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2025-12"
 12145	bouncing Annie Oakley's plastic skeleton skull	0		Critical Hit Percent: +20, Last Available: "2025-12"
 12146	shaking supercharged plastic skeleton Crimbo hat	0		Maximum MP Percent: +30, Last Available: "2025-12"
 12147	assembled plastic Santa skeleton	0		Last Available: "2025-12"
 12148	sleigh	0		Familiar Weight: +10
-12149	blinking tumbling undertakers' forceps	0		Last Available: "2025-12"
+12149	tumbling blinking undertakers' forceps	0		Last Available: "2025-12"
 12150	bone-polishing rag	0		Last Available: "2025-12"
 12151	Temple Grandin's brainy scorched skeleton mask	0		Mysticality: +5, Familiar Weight: +7, Last Available: "2025-12"
 12152	upside-down greedy reassuring scorched skeleton shirt	0		Spooky Resistance: +1, Meat Drop: +20, Last Available: "2025-12"
@@ -11913,7 +11913,7 @@
 12155	buryable chest	0		Last Available: "2025-12"
 12156	wobbly Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
-12158	jittery red Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
+12158	red jittery Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	upside-down Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
@@ -11928,11 +11928,11 @@
 12170	squat lime green sizzling beefy heat-resistant harpoon pistol	0		Muscle: +10, Hot Damage: +10, Last Available: "2025-12"
 12171	normal traditional gingerloaf	3	good	Last Available: "2025-12"
 12172	smooth Scotch and eggnog	4	awesome	Last Available: "2025-12"
-12173	non-chilled blinking ghostly counterskeleton elixir	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 65, Last Available: "2025-12"
+12173	non-chilled ghostly blinking counterskeleton elixir	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 65, Last Available: "2025-12"
 12174	perfectly mixed &quot;salvaged&quot; wine	4	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	normal big wedge of prize-winning cheese	5	good	Last Available: "2025-12"
+12177	big normal wedge of prize-winning cheese	5	good	Last Available: "2025-12"
 12178	concentrated deionized cold-filtered lime green gummi fingerbone	0		Effect: "Polka Face", Effect Duration: 41
 12179	wholesome glimmering crystal of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Last Available: "2025-12"
 12180	jittery boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11944,7 +11944,7 @@
 12186	dinosaur bone fragment	0		Last Available: "2026-03"
 12187	Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	tumbling huge 2015 landfill detritus	0		Last Available: "2026-03"
-12189	upside-down blurry intact dinosaur egg	0		Last Available: "2026-03"
+12189	blurry upside-down intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
 12191	tumbling unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	huge Pork Elf toiletries kit	0		Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	ghostly Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	fuchsia Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	fancy moldy small squat rat pizza	2	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 5, Last Available: "2026-03"
+12209	fancy small moldy squat rat pizza	2	crappy	Effect: "Human-Slime Hybrid", Effect Duration: 5, Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	mirror gravedigger's weightlifter's hoverboard of the detective	0		Muscle: +15, Spooky Damage: +10, Item Drop: +20, Single Equip, Last Available: "2026-03"
 12212	twirling aromatic Socratic brainy left shark fin	0		Mysticality: +5, Experience (Mysticality): +1, Stench Resistance: +1, Last Available: "2026-03"
@@ -11973,7 +11973,7 @@
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	half-sized bland discarded hot dog	2	decent	Last Available: "2026-04"
-12218	practically non-alcoholic lousy most of a beer	1	decent	Last Available: "2026-04"
+12218	lousy practically non-alcoholic most of a beer	1	decent	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	blurry legendary noodles	0		Last Available: "2026-05"
@@ -11981,27 +11981,27 @@
 12227	spoiled alien salad	4	crappy	
 12228	normal diet ratbatatouille	1	good	
 12229	flavorless onigiri	3	decent	
-12230	huge adequate crudit&eacute;s	7	good	
+12230	adequate huge crudit&eacute;s	7	good	
 12231	stale sauced mutton	4	decent	
-12232	adequate bite-sized hot honey ant	1	good	
+12232	bite-sized adequate hot honey ant	1	good	
 12233	adequate diet tomb aspic	1	good	
 12234	bland later tots	4	decent	
 12235	delicious Frutti di Scatoletta	3	awesome	Last Available: "2026-05"
-12236	half-sized flavorless Pesto alla Marziano	2	decent	Last Available: "2026-05"
+12236	flavorless half-sized Pesto alla Marziano	2	decent	Last Available: "2026-05"
 12237	moldy Arrattabbattabiata	4	crappy	Last Available: "2026-05"
-12238	miniature fancy flavorless narrow Orzo di Riso	2	decent	Effect: "Lemony Goodness", Effect Duration: 40, Last Available: "2026-05"
-12239	flavorless miniature Pasta Grimavera	2	decent	Last Available: "2026-05"
+12238	fancy flavorless miniature narrow Orzo di Riso	2	decent	Effect: "Lemony Goodness", Effect Duration: 40, Last Available: "2026-05"
+12239	miniature flavorless Pasta Grimavera	2	decent	Last Available: "2026-05"
 12240	bite-sized flavorless spinning Linguini Ubriacapa	1	decent	Last Available: "2026-05"
 12241	small adequate Formica e Pepe	2	good	Last Available: "2026-05"
 12242	moldy Tubetto Gelatto	4	crappy	Last Available: "2026-05"
 12243	spoiled Gnocci Domani	4	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
-12245	gray blurry shaking scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
+12245	blurry shaking gray scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	upside-down second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mirror mega helmet	0		
 12252	Van der Graaf MacGyver's Space Soldier Helmet	0		Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7
 12253	stale premium turkey leg	3	decent	
-12254	mediocre triple-distilled styrofoam cup of mead	10	decent	
+12254	triple-distilled mediocre styrofoam cup of mead	10	decent	
 12255	padded sword	0		Damage Absorption: +20
 12256	squat fuchsia wobbly staff of incineration	0		Hot Spell Damage: +50
 12257	cyan flame-retardant lute	0		Hot Resistance: +1
@@ -12023,7 +12023,7 @@
 12273	spoiled watermelon	4	crappy	Last Available: "2026-07"
 12274	spoiled super-sized quince	5	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
-12276	narrow spinning Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
+12276	spinning narrow Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	adequate bite-sized wobbly classic banana pie	1	good	Last Available: "2026-07"
 12278	non-adjusted boiled essential banana decoction	0		Effect: "Ooh, Salty!", Effect Duration: 28, Last Available: "2026-07"
 12279	anodized dry banana quintessence	0		Effect: "Grrrrrrreat!", Effect Duration: 61, Last Available: "2026-07"
@@ -12037,7 +12037,7 @@
 12287	spoiled gray quince pie	3	crappy	Last Available: "2026-07"
 12288	moist jittery quince quaff	0		Effect: "Chalky Hand", Effect Duration: 62, Last Available: "2026-07"
 12289	super-corrupted purple blinking Quickquince	0		Effect: "Rain Dancin'", Effect Duration: 67, Last Available: "2026-07"
-12290	fancy artisanal olive Quiskey Sour	3	EPIC	Effect: "Antarctic Memories", Effect Duration: 50, Last Available: "2026-07"
+12290	artisanal fancy olive Quiskey Sour	3	EPIC	Effect: "Antarctic Memories", Effect Duration: 50, Last Available: "2026-07"
 12291	artisanal distilled Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
 12292	mediocre watered-down mirror Roth IPA	2	decent	Last Available: "2026-08"
 12293	cyan blurry double-paned underdraft protection of the wise owl	0		Mysticality: +20, Cold Resistance: +5, Last Available: "2026-08"
@@ -12048,7 +12048,7 @@
 12298	perfumed wholesome financial instrument	0		Maximum HP Percent: +10, Stench Resistance: +5, Last Available: "2026-08"
 12299	blue ghostly hedge fund clippers of Tarzan of terror	0		Experience (Muscle): +3, Spooky Spell Damage: +10, Last Available: "2026-08"
 12300	stiffened selling shorts	0		Damage Reduction: 1, Last Available: "2026-08"
-12301	blurry blinking bear tattoo	0		Last Available: "2026-08"
+12301	blinking blurry bear tattoo	0		Last Available: "2026-08"
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	healthy 401k ring of the pedagogue	0		Experience: +3, Maximum HP Percent: +20, Last Available: "2026-08"
 12304	red bouncing balance sheet	0		Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	pickled ghostly toxic asset	1		Effect: "Melancholy Burden", Effect Duration: 40, Last Available: "2026-08"
-12311	powdered yellow ghostly intangible asset	1		Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2026-08"
-12312	modified wobbly jittery liquid asset	1		Last Available: "2026-08"
+12311	powdered ghostly yellow intangible asset	1		Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2026-08"
+12312	modified jittery wobbly liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Pastamancer_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Opossum_cafe_booze.txt
@@ -1,22 +1,22 @@
 -1	artisanal pulsating gray Petite Porter	4	EPIC	
--2	weak perfectly mixed Scrawny Stout	2	EPIC	
--3	enchanted mediocre yellow Infinitesimal IPA	4	decent	
+-2	perfectly mixed weak Scrawny Stout	2	EPIC	
+-3	mediocre enchanted yellow Infinitesimal IPA	4	decent	
 -4	tolerable eggnogtini	3	good	
 -5	acceptable candycaine	4	good	
--6	lousy weak braincracker sweet	2	decent	
+-6	weak lousy braincracker sweet	2	decent	
 -16	acceptable watered-down shaking fermented honey	2	good	
 -17	acceptable moons-shine	4	good	
 -18	aged gin	3	awesome	
--19	triple-distilled mediocre maroon ecto-nog	10	decent	
+-19	mediocre triple-distilled maroon ecto-nog	10	decent	
 -20	drinkable hot toady	3	good	
 -21	lousy blurry hot choculate	3	decent	
 -49	fortified hand-crafted Cyder	5	EPIC	
--50	artisanal weak Oil Nog	2	EPIC	
+-50	weak artisanal Oil Nog	2	EPIC	
 -51	artisanal Hi-Octane Peppermint Jet Fuel	4	EPIC	
--58	triple-distilled hand-crafted Grimacider	8	EPIC	
--59	fancy high-proof hand-crafted Isotope Nog	7	EPIC	
+-58	hand-crafted triple-distilled Grimacider	8	EPIC	
+-59	hand-crafted fancy high-proof Isotope Nog	7	EPIC	
 -60	practically non-alcoholic acceptable Mutagin 'n' Tonic	1	good	
--70	practically non-alcoholic perfectly mixed Gin and Herring	1	EPIC	
+-70	perfectly mixed practically non-alcoholic Gin and Herring	1	EPIC	
 -71	bad Black and Tan and Red All Over	3	decent	
 -72	tolerable bouncing Antarctic Ice Tea	3	good	
 -76	mediocre CRIMBCO Ribbon Candy Schnapps	3	decent	
@@ -24,10 +24,10 @@
 -78	tolerable ghostly CRIMBCO Extreme Braincracker Sour	3	good	
 -82	lousy Horseradish-infused Vodka	4	decent	
 -83	lousy practically non-alcoholic cyan Jerkitini	1	decent	
--84	practically non-alcoholic perfectly mixed Desert Island Iced Tea	1	EPIC	
+-84	perfectly mixed practically non-alcoholic Desert Island Iced Tea	1	EPIC	
 -88	hand-crafted Crimbo Saketini	3	EPIC	
 -89	delicious upside-down Crimboku Drop	3	awesome	
 -90	tolerable squat Flaming Crimbo Log	3	good	
--107	bad special Fortified Eggnog Slurry	4	decent	
+-107	special bad Fortified Eggnog Slurry	4	decent	
 -108	tolerable skewed Hot Buttered Rum	3	good	
 -109	mediocre Spicy Hot Chocolate	3	decent	

--- a/data/TCRS/TCRS_Pastamancer_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Opossum_cafe_food.txt
@@ -1,7 +1,7 @@
 -1	adequate pulsating gray Peche a la Frog	4	good	
 -2	delicious small As Jus Gezund Heit	2	awesome	
 -3	moldy yellow Bouillabaise Coucher Avec Moi	4	crappy	
--7	flavorless special gumdrop chow mein	3	decent	
+-7	special flavorless gumdrop chow mein	3	decent	
 -8	spoiled blinking candy cane pizza	3	crappy	
 -9	normal gingerbread stir-fry	4	good	
 -10	snack-sized adequate twigs and gravel	2	good	
@@ -11,13 +11,13 @@
 -14	decent It Came From Beyond Dessert	3	good	
 -15	tasty snack-sized blue shaking vampire cake	2	awesome	
 -52	rotten Soylent Red and Green	3	crappy	
--53	diet adequate Disc-Shaped Nutrition Unit	1	good	
--54	massive spoiled skewed cyan blurry Gingerborg Hive	10	crappy	
+-53	adequate diet Disc-Shaped Nutrition Unit	1	good	
+-54	spoiled massive cyan skewed blurry Gingerborg Hive	10	crappy	
 -61	yummy Candy Cane Surprise	3	awesome	
 -62	yummy enchanted Grimdrop Chow Mein	3	awesome	
 -63	bland gigantic Grimgerbread House	8	decent	
 -67	spoiled miniature Caviar Carbonara	2	crappy	
--68	moldy special super-sized Halibut Alfredo	5	crappy	
+-68	special moldy super-sized Halibut Alfredo	5	crappy	
 -69	normal Red Herring Velvet Cake	4	good	
 -73	adequate CRIMBCO Reconstituted Gruel	4	good	
 -74	bland lime green New and Improved CRIMBCO Reconstituted Gruel	3	decent	
@@ -26,20 +26,20 @@
 -80	rotten immense Carrot, Cabbage, and Kale Pizza	9	crappy	
 -81	normal small Turnip and Rutabaga Pie	2	good	
 -85	moldy upside-down Rainbow Spider Fun Roll	3	crappy	
--86	adequate enchanted red Vegas Volcano Lava Roll	3	good	
--87	fancy spoiled twirling Crazy Dragon Shogun Buddha Roll	4	crappy	
+-86	enchanted adequate red Vegas Volcano Lava Roll	3	good	
+-87	spoiled fancy twirling Crazy Dragon Shogun Buddha Roll	4	crappy	
 -92	adequate basic hot dog	3	good	
 -93	adequate blue upside-down savage macho dog	4	good	
 -94	miniature stale upside-down one with everything	2	decent	
 -95	normal sly dog	3	good	
 -96	flavorless green devil dog	4	decent	
 -97	rotten chilly dog	3	crappy	
--98	huge bland squat blinking ghost dog	10	decent	
+-98	bland huge blinking squat ghost dog	10	decent	
 -99	decent junkyard dog	3	good	
--100	decent miniature narrow wet dog	2	good	
+-100	miniature decent narrow wet dog	2	good	
 -101	moldy sleeping dog	3	crappy	
 -102	yummy optimal dog	4	awesome	
 -103	adequate video games hot dog	3	good	
--104	bland small Peppermint Nutrition Block	2	decent	
--105	enchanted low-calorie spoiled Gingerbread Nutrition Block	1	crappy	
--106	bland immense Cinnamon Nutrition Block	6	decent	
+-104	small bland Peppermint Nutrition Block	2	decent	
+-105	spoiled low-calorie enchanted Gingerbread Nutrition Block	1	crappy	
+-106	immense bland Cinnamon Nutrition Block	6	decent	

--- a/data/TCRS/TCRS_Pastamancer_Packrat.txt
+++ b/data/TCRS/TCRS_Pastamancer_Packrat.txt
@@ -2,7 +2,7 @@
 2	seal tooth	0		
 3	upside-down helmet turtle of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "atk, cap 2"
 4	turtle totem	0		
-5	blue upside-down pasta spoon	0		
+5	upside-down blue pasta spoon	0		
 6	ravioli hat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, cap 2"
 7	blurry saucepan	0		
 8	blinking spices	0		
@@ -12,7 +12,7 @@
 12	mirror mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	powdered moxie weed	1		
 15	powdered strongness elixir	1		
-16	dehydrated squat pulsating magicalness-in-a-can	1		
+16	dehydrated pulsating squat magicalness-in-a-can	1		
 17	moldy noodles	3	crappy	
 18	huge tortoise's blessing	0		
 19	wobbly toasty asparagus knife	0		Hot Damage: +5
@@ -78,10 +78,10 @@
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	pulsating fairy gravy boat	0		
 81	delicious ice-cold Willer	4	awesome	
-82	narrow blue ring	0		
+82	blue narrow ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
-85	shaking twirling unlocked meat locker	0		
+85	twirling shaking unlocked meat locker	0		
 86	key	0		
 87	huge meat from yesterday	0		
 88	meat stack	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	wobbly shaking toasty Rosewater's staff	0		Mysticality Percent: +30, Hot Damage: +5
 104	scarecrow	0		
-105	bland diet bowl of charms	1	decent	
+105	diet bland bowl of charms	1	decent	
 106	ketchup	1	crappy	
 107	catsup	1	awesome	
 108	stick	0		
@@ -129,13 +129,13 @@
 130	smartaleck's eyepatch	0		Moxie Percent: +30, Familiar Effect: "4xBarrr, cap 8"
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
-133	lime green spinning Certificate of Participation	0		
+133	spinning lime green Certificate of Participation	0		
 134	blurry bitchin' meatcar	0		
 135	sweet rims	0		
 136	lime green tires	0		
 137	blurry dope wheels	0		
 138	bouncing ice-cold six-pack	0		
-139	shaking blue valuable trinket	0		
+139	blue shaking valuable trinket	0		
 140	ghostly dingy planks	0		
 141	dingy dinghy	0		
 142	bouncing anticheese	0		
@@ -163,7 +163,7 @@
 164	smart skull	0		
 165	jittery skewer	0		
 166	ghuol ears	0		
-167	adequate blinking skewed ghuol-ear kabob	3	good	
+167	adequate skewed blinking ghuol-ear kabob	3	good	
 168	bone rattle of the blizzard	0		Cold Spell Damage: +25
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	bouncing lihc eye	0		
@@ -174,9 +174,9 @@
 175	big stale pulsating uncooked chorizo	5	decent	
 176	disembodied brain	0		
 177	brainy skull	0		
-178	tumbling bouncing detective skull	0		
+178	bouncing tumbling detective skull	0		
 179	bland chorizo taco	3	decent	
-180	acceptable extra-dry ice-cold fotie	5	good	
+180	extra-dry acceptable ice-cold fotie	5	good	
 181	baseball	0		
 182	tumbling batgut	0		
 183	upside-down bat wing	0		
@@ -196,10 +196,10 @@
 198	rat appendix	0		
 199	teal flame-wreathed ring	0		Hot Spell Damage: +10
 200	rotten shaking rat appendix kabob	3	crappy	
-201	super-sized tasty bat wing kabob	5	awesome	
-202	jumbo rotten mirror carob chunks	5	crappy	
+201	tasty super-sized bat wing kabob	5	awesome	
+202	rotten jumbo mirror carob chunks	5	crappy	
 203	purple herbs	0		
-204	special normal small carob chunk cookies	2	good	Effect: "Electrolit Up", Effect Duration: 40
+204	small normal special carob chunk cookies	2	good	Effect: "Electrolit Up", Effect Duration: 40
 205	squat secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	awesome	
@@ -211,8 +211,8 @@
 213	gray wicked filthy corduroys of the cheetah	0		Spell Damage: +5, Initiative: +60, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	narrow auspicious filthy knitted dread sack	0		Item Drop: +10, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	huge Uncle Jick's Brownie Mix	0		
-216	moldy huge carob brownies	7	crappy	
-217	enchanted bland huge blurry herb brownies	8	decent	Effect: "Butt-Rock Hair", Effect Duration: 25
+216	huge moldy carob brownies	7	crappy	
+217	bland huge enchanted blurry herb brownies	8	decent	Effect: "Butt-Rock Hair", Effect Duration: 25
 218	blurry ghostly hemp string	0		
 219	mirror necklace chain	0		
 220	gnoll teeth	0		
@@ -221,7 +221,7 @@
 223	sage phat turquoise bracelet	0		Mysticality Percent: +10
 224	Sherlock's eyepatch	0		Item Drop: +25, Familiar Effect: "3xBarrr, cap 6"
 225	decent enchanted blurry tofu casserole	3	good	Effect: "Happy Trails", Effect Duration: 50
-226	vaporized squat pulsating can of Red Minotaur	1	awesome	
+226	vaporized pulsating squat can of Red Minotaur	1	awesome	
 227	bouncing clever Kentucky-fried meat sword	0		Maximum MP: +20
 228	Kentucky-fried meat staff of bravery	0		Spooky Resistance: +5
 229	red rock-hard Kentucky-fried meat crossbow	0		Damage Reduction: 5
@@ -232,8 +232,8 @@
 234	blue Doc Galaktik's Homeopathic Elixir	0		
 235	perfumed Samson's Bigger Bugfinder Blade	0		Experience (Muscle): +5, Stench Resistance: +5
 236	huge Queue Du Coq cocktailcrafting kit	0		
-237	hand-crafted strong bottle of gin	5	EPIC	
-238	drinkable extra-dry tumbling bottle of vodka	5	good	
+237	strong hand-crafted bottle of gin	5	EPIC	
+238	extra-dry drinkable tumbling bottle of vodka	5	good	
 239	foul-smelling toasty Orcish baseball cap	0		Hot Damage: +5, Stench Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	jittery greasy steel-toed Orcish cargo shorts	0		Damage Reduction: 9, Sleaze Spell Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	careful Orcish frat-paddle	0		Monster Level: -10
@@ -243,7 +243,7 @@
 245	spoiled olive	3	crappy	
 246	adequate snack-sized tomato	2	good	
 247	fermenting powder	0		
-248	triple-distilled artisanal salty dog	7	EPIC	
+248	artisanal triple-distilled salty dog	7	EPIC	
 249	lousy bloody mary	3	decent	
 250	hand-crafted practically non-alcoholic screwdriver	1	EPIC	
 251	watered-down bad cyan martini	2	decent	
@@ -253,12 +253,12 @@
 255	bad blurry fine wine	4	decent	
 256	drinkable watered-down shot of tomato schnapps	2	good	
 257	drinkable extra-spicy bloody mary	3	good	
-258	maroon ghostly shaking dense meat stack	0		
+258	maroon shaking ghostly dense meat stack	0		
 259	snake skin	0		
-260	special spoiled tiny White Citadel fries	1	crappy	Effect: "Eye of the Seal", Effect Duration: 15
+260	spoiled special tiny White Citadel fries	1	crappy	Effect: "Eye of the Seal", Effect Duration: 15
 261	half-sized decent White Citadel burger	2	good	
 262	thick rotten piece of wedding cake	5	crappy	
-263	tiny adequate yellow ghostly chocolate chips	1	good	
+263	adequate tiny yellow ghostly chocolate chips	1	good	
 264	yummy chocolate chip cookies	4	awesome	
 265	careful satin pants	0		Monster Level: -10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	acceptable narrow lightning	3	good	
@@ -297,7 +297,7 @@
 299	Vulcanized pickle-flavored chewing gum	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 19
 300	double-alkaline boiled jaba&ntilde;ero-flavored chewing gum	0		Effect: "Shoesauce", Effect Duration: 50
 301	pulsating flat dough	0		
-302	decent immense yellow Knob sausage	6	good	
+302	immense decent yellow Knob sausage	6	good	
 303	decent Knob mushroom	4	good	
 304	dry noodles	0		
 305	Knob Goblin harem pants of the glutton	0		Food Drop: +100, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -311,16 +311,16 @@
 313	dog trainer's Crown of the Goblin King	0		Experience (familiar): +1, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	toothsome half-sized bean burrito	2	awesome	
 315	flavorless bean burrito	3	decent	
-316	big flavorless fancy red insanely bean burrito	5	decent	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 25
+316	flavorless fancy big red insanely bean burrito	5	decent	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 25
 317	bland twirling bean burrito	4	decent	
 318	delicious bean burrito	3	awesome	
 319	small moldy insanely bean burrito	2	crappy	
 320	decent bat haggis	3	good	
 321	small delicious skewed menudo	2	awesome	
 322	tasty goat cheese	3	awesome	
-323	low-calorie toothsome plain pizza	1	awesome	
+323	toothsome low-calorie plain pizza	1	awesome	
 324	normal sausage pizza	4	good	
-325	flavorless thick goat cheese pizza	5	decent	
+325	thick flavorless goat cheese pizza	5	decent	
 326	adequate mushroom pizza	3	good	
 327	jittery goat	0		
 328	perfectly mixed bottle of whiskey	3	EPIC	
@@ -339,7 +339,7 @@
 341	denatured cold-filtered Knob Goblin love potion	0		Effect: "All Is Forgiven", Effect Duration: 49
 342	Knob Goblin stink bomb	0		
 343	dry Knob Goblin sharpening spray	0		Effect: "Egg on your Face", Effect Duration: 18
-344	tumbling squat Knob Goblin seltzer	0		
+344	squat tumbling Knob Goblin seltzer	0		
 345	pulsating twirling Knob Goblin superseltzer	0		
 346	shaking scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
@@ -354,7 +354,7 @@
 356	deadly snowboarder pants	0		Weapon Damage: +5, Familiar Effect: "1xPotato, cap 25"
 357	shaking Mountain Stream soda	0		
 358	adequate gr8ps	3	good	
-359	gigantic moldy maroon t8r tots	6	crappy	
+359	moldy gigantic maroon t8r tots	6	crappy	
 360	beefcake's miner's helmet	0		Muscle: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	miner's pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	thinker's 7-Foot Dwarven mattock	0		Mysticality: +10
@@ -412,26 +412,26 @@
 414	crowbarrr of James Dean	0		Experience (Moxie): +3
 415	leotarrrd of Leguizamo	0		Monster Level: +20, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	safarrri hat of the sewer	0		Stench Damage: +25, Familiar Effect: "2xVolley, cap 22"
-417	unsweetened wobbly pulsating fuchsia henna tattoo	0		Effect: "Rainbow Bright", Effect Duration: 57
+417	unsweetened wobbly fuchsia pulsating henna tattoo	0		Effect: "Rainbow Bright", Effect Duration: 57
 418	alkaline super-magnetized Ferrigno's Elixir of Power	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 15
 419	corrupted serum of sarcasm	0		Effect: "Feline Ferocity", Effect Duration: 11
 420	electrified anodized skewed tomato juice of powerful power	0		Effect: "Spooky Blur", Effect Duration: 55
 421	alkaline gray philter of phorce	0		Effect: "Toothy Grin", Effect Duration: 50
-422	improved magnetized bouncing narrow potion of potency	0		Effect: "Gunky Dory", Effect Duration: 64
+422	improved magnetized narrow bouncing potion of potency	0		Effect: "Gunky Dory", Effect Duration: 64
 423	polarized wobbly cordial of concentration	0		Effect: "Squid Squint", Effect Duration: 27
 424	oxidized blinking ointment of the occult	0		Effect: "Always In Motion", Effect Duration: 23
 425	modified polarized mirror oil of expertise	0		Effect: "Stemonitis Storm", Effect Duration: 53
 426	dry ionized potion of temporary gr8ness	0		Effect: "Very Clean Guns", Effect Duration: 63
 427	twirling teal box of Calamity Jane	0		Critical Hit Percent: +15, Wiki Name: "box"
 428	skewed ghostly pulsating nothing-in-the-box	0		
-429	narrow fuchsia beanbag chair	0		
+429	fuchsia narrow beanbag chair	0		
 430	purple acid-squirting flower	0		Single Equip
 431	up-at-dawn clown shoes	0		Adventures: +5, Clowniness: 25
 432	bloody clown pants of the bloodbag	0		Maximum HP: +100, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
 433	skinny balloon	0		
 434	teal ghostly balloon helmet of the sewer	0		Stench Damage: +25, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	blinking avaricious careful balloon sword	0		Monster Level: -10, Meat Drop: +30, Clowniness: 50
-436	spinning red balloon monkey	0		
+436	red spinning balloon monkey	0		
 437	chef skull	0		
 438	blue chef-in-the-box	0		
 439	bartender skull	0		
@@ -451,9 +451,9 @@
 453	sober pill	0		
 454	screwdriver	0		
 455	decent spinning jumbo olive	3	good	
-456	drinkable practically non-alcoholic dry martini	1	good	
+456	practically non-alcoholic drinkable dry martini	1	good	
 457	squat slick ye olde golde frontes	0		Moxie: +10, Class: "Disco Bandit", Single Equip
-458	maroon skewed continuum transfunctioner	0		
+458	skewed maroon continuum transfunctioner	0		
 459	pixel	0		
 460	bouncing pixel	0		
 461	pixel	0		
@@ -464,7 +464,7 @@
 466	pixel potion	0		
 467	bland pixel pie	3	decent	
 468	ruby W	0		
-469	gray blurry wussiness potion	0		
+469	blurry gray wussiness potion	0		
 470	tolerable Imp Ale	4	good	
 471	moldy hot wing	4	crappy	
 472	diamond-studded cane of the overflowing toilet	0		Stench Spell Damage: +50, Class: "Disco Bandit"
@@ -538,7 +538,7 @@
 540	pickled nitrogenated skewed Tasty Fun Good rice candy	0		Effect: "Towering Strength", Effect Duration: 46
 541	narrow fireproof experienced draggin' ball hat	0		Experience: +2, Hot Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 25"
 542	twirling lightning-fast brawny 1337 7r0uZ0RZ	0		Muscle Percent: +20, Initiative: +40, Familiar Effect: "2xPotato, cap 27"
-543	fancy delicious twirling Trollhouse cookies	3	awesome	Effect: "Pisces Rising", Effect Duration: 25
+543	delicious fancy twirling Trollhouse cookies	3	awesome	Effect: "Pisces Rising", Effect Duration: 25
 544	double-paned frightening talons	0		Spooky Damage: +5, Cold Resistance: +5
 545	stale twirling Spam Witch sammich	4	decent	
 546	meat vortex	0		
@@ -563,15 +563,15 @@
 565	huge frosty hobo gloves	0		Cold Spell Damage: +10, Single Equip
 566	energetic bum cheek	0		Maximum MP Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	small rotten olive Double Bacon Beelzeburger	2	crappy	
+568	rotten small olive Double Bacon Beelzeburger	2	crappy	
 569	toothsome Lord of the Flies-sized fries	4	awesome	
 570	toothsome Chicken Sandwich	4	awesome	
 571	Jumbo Dr. Lucifer	1	awesome	
 572	stale special Children's Meal of the Damned	3	decent	Effect: "Buzzard Breath", Effect Duration: 35
 573	normal blurry noodles	3	good	
-574	tasty miniature jittery noodles	2	awesome	
+574	miniature tasty jittery noodles	2	awesome	
 575	spoiled painful penne pasta	3	crappy	
-576	special bland purple ravioli della hippy	4	decent	Effect: "Ermine Eyes", Effect Duration: 45
+576	bland special purple ravioli della hippy	4	decent	Effect: "Ermine Eyes", Effect Duration: 45
 577	decent pr0n m4nic0tti	3	good	
 578	moldy Hell ramen	4	crappy	
 579	thick spoiled special boring spaghetti	5	crappy	Effect: "Fishy Fortification", Effect Duration: 40
@@ -608,7 +608,7 @@
 610	jittery procrastination potion	0		
 611	D	0		
 612	original G	0		
-613	yellow spinning plot hole	0		
+613	spinning yellow plot hole	0		
 614	ionized boiled probability potion	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 64
 615	pulsating chaos butterfly	0		
 616	wobbly furry fur	0		
@@ -621,7 +621,7 @@
 623	skewed wobbly WA	0		
 624	spinning NG	0		
 625	wang	0		
-626	bouncing blurry Wand of Nagamar	0		
+626	blurry bouncing Wand of Nagamar	0		
 627	ND	0		
 628	metallic A	0		
 629	fuchsia ribald eye	0		Sleaze Damage: +10
@@ -634,7 +634,7 @@
 636	meat globe	0		
 637	toaster	0		
 638	Socratic asshat of horror	0		Experience (Mysticality): +1, Spooky Spell Damage: +25, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	half-sized adequate abominable snowcone	2	good	
+639	adequate half-sized abominable snowcone	2	good	
 640	wobbly Ent cider	1	EPIC	
 641	massive stale toast	7	decent	
 642	skeleton key	0		
@@ -644,8 +644,8 @@
 646	stale jittery fruitcake	3	decent	
 647	narrow present	0		Last Available: "2004-11"
 648	hardened Crimbo sword	0		Damage Reduction: 3, Last Available: "2004-10"
-649	Crimbo hat of the wise owl	0		Mysticality: +20, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	ghostly wizardly Crimbo pants	0		Mysticality: +25, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	Crimbo hat of the wise owl	0		Mysticality: +20, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	ghostly wizardly Crimbo pants	0		Mysticality: +25, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	shellacked exclusive ultra-rare item	0		Damage Reduction: 7
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -674,12 +674,12 @@
 676	dragonbone belt buckle	0		
 677	groovy badass belt	0		Moxie Percent: +10
 678	chest of the Bonerdagon	0		
-679	drinkable high-proof roll in the hay	7	good	
+679	high-proof drinkable roll in the hay	7	good	
 680	aged slap and tickle	3	awesome	
 681	aged slip 'n' slide	3	awesome	
 682	tolerable ghostly a sump'm sump'm	4	good	
 683	hand-crafted twirling horizontal tango	3	EPIC	
-684	bad fortified green skewed pink pony	5	decent	
+684	fortified bad green skewed pink pony	5	decent	
 685	huge inspector's ruddy Mr. Shirt of wisdom	0		Mysticality: +15, Maximum HP Percent: +40, Item Drop: +15
 686	bouncing frosty knuckles	0		Cold Spell Damage: +10
 687	enhanced blood of the Wereseal	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 42
@@ -698,7 +698,7 @@
 701	floral print shirt of mayonnaise	0		Sleaze Spell Damage: +50
 702	horrifying coconut bikini top	0		Spooky Damage: +25
 703	olive wholesome goth kid t-shirt	0		Maximum HP Percent: +10
-704	green narrow hamethyst	0		
+704	narrow green hamethyst	0		
 705	blue baconstone	0		
 706	green porquoise	0		
 707	pork elf goodies sack	0		
@@ -716,9 +716,9 @@
 720	rosy-cheeked hardened porquoise necklace	0		Damage Reduction: 3, Maximum HP Percent: +30, Single Equip
 721	fuchsia zippy porquoise bracelet of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +20
 722	greedy asbestos-lined knitted porquoise ring	0		Cold Resistance: +3, Hot Resistance: +5, Meat Drop: +20, Single Equip
-723	flavorless bouncing olive huge Knoll mushroom	3	decent	
+723	flavorless huge bouncing olive Knoll mushroom	3	decent	
 724	rotten mushroom	4	crappy	
-725	squat upside-down pulsating one million meat pancakes	0		
+725	pulsating upside-down squat one million meat pancakes	0		
 726	ribald huge mirror shard	0		Sleaze Damage: +10
 727	huge hedge maze puzzle	0		
 728	tumbling hedge maze key	0		
@@ -742,21 +742,21 @@
 747	squat Knob Goblin firecracker	0		
 748	upside-down gourd potion	0		
 749	spoiled warm mushroom	3	crappy	
-750	miniature yummy fuchsia mushroom quesadilla	2	awesome	
+750	yummy miniature fuchsia mushroom quesadilla	2	awesome	
 751	decent upside-down cool mushroom	3	good	
 752	spoiled gigantic cool mushroom casserole	7	crappy	
 753	toothsome half-sized pointy mushroom	2	awesome	
 754	decent cream of pointy mushroom soup	3	good	
-755	spoiled diet mushroom	1	crappy	
+755	diet spoiled mushroom	1	crappy	
 756	normal red mushroom	4	good	
-757	decent diet mushroom	1	good	
+757	diet decent mushroom	1	good	
 758	tasty ghost cucumber	3	awesome	
 759	olive dill	0		
 760	pulsating olive vinegar	0		
 761	olive brine	0		
 762	perfectly mixed irresponsibly strong especially salty dog	10	EPIC	
 763	ghostly pickling solution	0		
-764	decent super-sized blinking spectral pickle	5	good	
+764	super-sized decent blinking spectral pickle	5	good	
 765	blue briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	adjusted huge cologne of contempt	0		Effect: "Squatting and Thrusting", Effect Duration: 37
@@ -790,18 +790,18 @@
 795	special mediocre Acque Luride Grezze Cabernet	3	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 30, Last Available: "2004-10"
 796	skewed cement shoes of the empath of courage of the early riser	0		Familiar Weight: +5, Spooky Resistance: +3, Adventures: +7, Last Available: "2004-10"
 797	hand-crafted practically non-alcoholic rockin' wagon	1	super ultra mega turbo EPIC	
-798	perfectly mixed special green shaking wobbly ocean motion	3	EPIC	Effect: "Always be Collecting", Effect Duration: 5
+798	special perfectly mixed shaking green wobbly ocean motion	3	EPIC	Effect: "Always be Collecting", Effect Duration: 5
 799	mediocre fuzzbump	3	decent	
 800	spoiled snack-sized skewed narrow poutine	2	crappy	
 801	yummy miniature maroon Knob stir-fry	2	awesome	
 804	moldy big Knoll stir-fry	5	crappy	
-805	big flavorless stir-fry	5	decent	
-806	thick fancy normal narrow pulsating mirror asparagus stir-fry	5	good	Effect: "A Contender", Effect Duration: 35
-807	massive delicious olive stir-fry	9	awesome	
+805	flavorless big stir-fry	5	decent	
+806	fancy thick normal mirror narrow pulsating asparagus stir-fry	5	good	Effect: "A Contender", Effect Duration: 35
+807	delicious massive olive stir-fry	9	awesome	
 808	miniature decent Knob sausage stir-fry	2	good	
 809	stale bat wing stir-fry	3	decent	
-810	spoiled jumbo rat appendix stir-fry	5	crappy	
-811	special jumbo decent tofu stir-fry	5	good	Effect: "Egg-stortionary Tactics", Effect Duration: 35
+810	jumbo spoiled rat appendix stir-fry	5	crappy	
+811	decent jumbo special tofu stir-fry	5	good	Effect: "Egg-stortionary Tactics", Effect Duration: 35
 812	super-sized flavorless pr0n stir-fry	5	decent	
 813	stale green Knob shells	3	decent	
 814	massive stale b&auml;tzle	9	decent	
@@ -812,7 +812,7 @@
 819	milky potion	0		
 820	gray swirly potion	0		
 821	narrow bubbly potion	0		
-822	ghostly yellow smoky potion	0		
+822	yellow ghostly smoky potion	0		
 823	cloudy potion	0		
 824	effervescent potion	0		
 825	mirror fizzy potion	0		
@@ -881,7 +881,7 @@
 890	flavorless balaclava baklava	3	decent	
 891	blinking blinking curative Warehouse 23 bling	0		HP Regen Min: 3, HP Regen Max: 5
 892	skewed resourceful stylish bugbear-smiting sword of doom	0		Moxie: +25, Maximum MP: +50, Spooky Spell Damage: +50
-893	mediocre triple-distilled skewed lumbering jack	8	decent	
+893	triple-distilled mediocre skewed lumbering jack	8	decent	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	friendly Ms. Accessory	0		Familiar Weight: +3, Softcore Only
 896	flame-retardant Mr. Accessory Jr. of dire peril	0		Weapon Damage: +20, Hot Resistance: +1, Softcore Only
@@ -891,8 +891,8 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	pulsating espresso maker	0		Familiar Weight: +5
 902	squat 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	weak tolerable Spasmi Dolorosi Del Rene Champagne	2	good	Last Available: "2004-10"
-904	mirror auspicious MacGyver's Herculean school Mafia knickerbockers	0		Experience (Muscle): +1, Maximum MP: +100, Item Drop: +10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+903	tolerable weak Spasmi Dolorosi Del Rene Champagne	2	good	Last Available: "2004-10"
+904	mirror auspicious MacGyver's Herculean school Mafia knickerbockers	0		Experience (Muscle): +1, Maximum MP: +100, Item Drop: +10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	corrupted huge Yummy Tummy bean	0		Effect: "From Nantucket", Effect Duration: 38
 906	diffused Rock Pops	0		Effect: "Fudge Headache", Effect Duration: 33
 907	magnetized dry bouncing Mr. Mediocrebar	0		Effect: "Alpine Mintiness", Effect Duration: 19
@@ -906,22 +906,22 @@
 915	jittery yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	toasty ruddy intergalactic pom poms	0		Maximum HP Percent: +40, Hot Damage: +5
 917	Mob Penguin protection contract	0		
-918	huge Radio Free Baseball Cap of terror	0		Spooky Spell Damage: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	wobbly lion tamer's Radio Free Pants	0		Experience (familiar): +2, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	huge Radio Free Baseball Cap of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	wobbly lion tamer's Radio Free Pants	0		Experience (familiar): +2, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	brainy Radio Free Foil	0		Mysticality: +5, Last Available: "2006-07"
 921	tiny bland special radio button candy	1	decent	Effect: "Standard Issue Bravery", Effect Duration: 25
 922	severed rocking horse head of the dark arts	0		Spell Damage Percent: +100
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
-925	yellow skewed dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
+925	skewed yellow dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	extra-irradiated mirror Hawking's Elixir of Brilliance	0		Effect: "Inappropriate Spirit", Effect Duration: 32
-927	tolerable practically non-alcoholic Ferita Del Petto Zinfandel	1	good	Last Available: "2006-12"
+927	practically non-alcoholic tolerable Ferita Del Petto Zinfandel	1	good	Last Available: "2006-12"
 928	weightlifter's fuzzy bracelets	0		Muscle: +15
 929	arse-shooting crossbow of the bloodbag	0		Maximum HP: +100
-931	practically non-alcoholic delicious spiced rum	1	awesome	
-932	weak aged eggnog	2	awesome	
-933	flavorless snack-sized candy cane	2	decent	
-934	rotten huge gingerbread bugbear	6	crappy	
+931	delicious practically non-alcoholic spiced rum	1	awesome	
+932	aged weak eggnog	2	awesome	
+933	snack-sized flavorless candy cane	2	decent	
+934	huge rotten gingerbread bugbear	6	crappy	
 935	hardy imitation nice watch	0		Maximum HP: +50, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	blurry menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,14 +929,14 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	bouncing Crimbo stocking	0		Last Available: "2004-12"
-942	Jim Carey's bowler	0		Monster Level: +25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	Jim Carey's bowler	0		Monster Level: +25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	energetic bow staff of the detective	0		Maximum MP Percent: +20, Item Drop: +20, Last Available: "2004-12"
-944	ruddy bowlegged pants	0		Maximum HP Percent: +40, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	ruddy bowlegged pants	0		Maximum HP Percent: +40, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	aged practically non-alcoholic martini	1	awesome	Last Available: "2004-12"
-949	mediocre fortified grogtini	5	decent	Last Available: "2004-12"
+949	fortified mediocre grogtini	5	decent	Last Available: "2004-12"
 950	perfectly mixed cherry bomb	3	super ultra EPIC	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	Da Vinci's beefy hockey mask	0		Muscle: +10, Experience (Mysticality): +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
@@ -994,17 +994,17 @@
 1007	shaking upside-down up-at-dawn coconut shell	0		Adventures: +5, Familiar Effect: "1xFairy, cap 7"
 1008	boxer's ice cubes	0		Muscle Percent: +10
 1009	artisanal vodka martini	4	EPIC	
-1010	mediocre extra-dry whiskey and soda	5	decent	
+1010	extra-dry mediocre whiskey and soda	5	decent	
 1011	perfectly mixed monkey wrench	3	EPIC	
 1012	mediocre tequila sunrise	4	decent	
-1013	perfectly mixed practically non-alcoholic maroon skewed margarita	1	EPIC	
-1014	watered-down acceptable bouncing strawberry wine	2	good	
+1013	practically non-alcoholic perfectly mixed maroon skewed margarita	1	EPIC	
+1014	acceptable watered-down bouncing strawberry wine	2	good	
 1015	lousy practically non-alcoholic wine spritzer	1	decent	
 1016	enchanted lousy perpendicular hula	3	decent	Effect: "Net Tea", Effect Duration: 15
 1017	watered-down drinkable ducha de oro	2	good	
 1018	fortified mediocre calle de miel	5	decent	
 1019	lousy dry vodka martini	4	decent	
-1020	lousy practically non-alcoholic narrow old-fashioned	1	decent	
+1020	practically non-alcoholic lousy narrow old-fashioned	1	decent	
 1021	practically non-alcoholic aged tequila with training wheels	1	awesome	
 1022	triple-distilled acceptable sangria	7	good	
 1023	delicious watered-down vesper	2	awesome	Last Available: "2004-12"
@@ -1029,15 +1029,15 @@
 1043	twirling frightening string of beads	0		Spooky Damage: +5
 1044	skewed baleful string of beads	0		Spell Damage: +25
 1045	censurious plastic bottle opener	0		Sleaze Resistance: +3
-1046	jittery wholesome traffic cone of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	drinkable practically non-alcoholic squat N. O. Beer	1	good	
+1046	jittery wholesome traffic cone of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Familiar Effect: "cap 15", Last Available: "2005-03"
+1047	practically non-alcoholic drinkable squat N. O. Beer	1	good	
 1048	vaporized mirror oyster egg	1		
-1049	vaporized fuchsia pulsating oyster egg	1		Effect: "Buttermilk Boogie", Effect Duration: 25
+1049	vaporized pulsating fuchsia oyster egg	1		Effect: "Buttermilk Boogie", Effect Duration: 25
 1050	altered cyan oyster egg	1		
 1051	plastic oyster egg	0		
 1052	boiled oyster egg	1		
 1053	boiled blinking oyster egg	1		
-1054	distilled squat red oyster egg	1		Effect: "Heart of Green", Effect Duration: 10
+1054	distilled red squat oyster egg	1		Effect: "Heart of Green", Effect Duration: 10
 1055	skewed plastic oyster egg	0		
 1056	diluted puce oyster egg	1		
 1057	pickled huge puce oyster egg	1		
@@ -1047,9 +1047,9 @@
 1061	mixed pulsating mauve oyster egg	1		
 1062	boiled mauve oyster egg	1		
 1063	upside-down mauve plastic oyster egg	0		
-1064	powdered pulsating spinning purple oyster egg	1		
+1064	powdered spinning pulsating purple oyster egg	1		
 1065	diluted pulsating oyster egg	1		Effect: "The Grass...  Is Blue...", Effect Duration: 35
-1066	twisted shaking upside-down oyster egg	1		Effect: "Conspiratory Eyes", Effect Duration: 35
+1066	twisted upside-down shaking oyster egg	1		Effect: "Conspiratory Eyes", Effect Duration: 35
 1067	plastic oyster egg	0		
 1068	mixed huge oyster egg	1		Effect: "Sharpened Sweet Tooth", Effect Duration: 45
 1069	dehydrated huge oyster egg	1		
@@ -1059,7 +1059,7 @@
 1073	diluted gray off-white oyster egg	1		
 1074	boiled off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	dehydrated ghostly tumbling jittery oyster egg	1		
+1076	dehydrated jittery tumbling ghostly oyster egg	1		
 1077	denatured blurry upside-down oyster egg	1		Effect: "Pumped Stomach", Effect Duration: 35
 1078	modified oyster egg	1		
 1079	narrow plastic oyster egg	0		
@@ -1103,7 +1103,7 @@
 1117	blurry Sherlock's Fonzie's Stupid University Diploma of the detective	0		Experience (Moxie): +1, Item Drop: 45
 1118	pregnant mushroom	0		
 1119	pregnant mushroom	0		
-1120	blurry teal pregnant mushroom	0		
+1120	teal blurry pregnant mushroom	0		
 1121	inexplicably rock	0		
 1122	blinking fairy gravy	0		
 1123	gray bouncing halfberd of the dark arts	0		Spell Damage Percent: +100
@@ -1119,17 +1119,17 @@
 1133	spinning star shirt of the wise owl	0		Mysticality: +20
 1134	purple cosmetics bag	0		
 1135	corrupted eyeliner	0		Effect: "Morninja", Effect Duration: 52
-1136	flattened colloidal activated red pulsating lipstick	0		Effect: "Video Game Hot Dog", Effect Duration: 49
+1136	flattened colloidal activated pulsating red lipstick	0		Effect: "Video Game Hot Dog", Effect Duration: 49
 1137	maroon rosewater-soaked bicycle chain of the sewer	0		Stench Damage: +25, Stench Resistance: +3
 1138	mirror mushroom fermenting solution	0		
 1139	tolerable bouncing mushroom wine	3	good	
 1140	smooth triple-distilled icy mushroom wine	6	awesome	
-1141	triple-distilled mediocre fancy mushroom wine	7	decent	Effect: "Favored by Lyle", Effect Duration: 45
+1141	fancy mediocre triple-distilled mushroom wine	7	decent	Effect: "Favored by Lyle", Effect Duration: 45
 1142	aged huge pointy mushroom wine	3	awesome	
-1143	weak perfectly mixed flat mushroom wine	2	EPIC	
+1143	perfectly mixed weak flat mushroom wine	2	EPIC	
 1144	mediocre fuchsia cool mushroom wine	3	decent	
 1145	practically non-alcoholic bad knob mushroom wine	1	decent	
-1146	special tolerable spinning knoll mushroom wine	4	good	Effect: "Kernel Panic!", Effect Duration: 5
+1146	tolerable special spinning knoll mushroom wine	4	good	Effect: "Kernel Panic!", Effect Duration: 5
 1147	hand-crafted mushroom wine	3	EPIC	
 1148	perfectly mixed upside-down shot of flower schnapps	3	EPIC	
 1149	miniature spoiled flower petal pie	2	crappy	
@@ -1143,7 +1143,7 @@
 1158	enhanced Meleegra&trade; pills	0		Effect: "Balls of Ectoplasm", Effect Duration: 28
 1159	mariachi G-string	0		
 1160	teal friendly irate sombrero	0		Familiar Weight: +3, Familiar Effect: "1xPotato, 3xLep, cap 11"
-1161	upside-down lime green pile of candy	0		
+1161	lime green upside-down pile of candy	0		
 1162	modified chilled dry handsomeness potion	0		Effect: "Nightlit", Effect Duration: 66
 1163	improved green marzipan skull	0		Effect: "Stogied", Effect Duration: 32
 1164	blinking poultrygeist	0		
@@ -1175,8 +1175,8 @@
 1190	dodecapede	0		
 1191	ghuol whelp	0		
 1192	teal pulsating zmobie	0		
-1193	tumbling skewed Raggedy Hippy doll	0		
-1194	cyan twirling stab bat	0		
+1193	skewed tumbling Raggedy Hippy doll	0		
+1194	twirling cyan stab bat	0		
 1195	maroon apathetic lizardman doll	0		
 1196	shaking yeti	0		
 1197	jittery Mob Penguin	0		
@@ -1185,13 +1185,13 @@
 1200	bland mugcake	4	decent	
 1201	special moldy urinal cake	3	crappy	Effect: "Sugary World View", Effect Duration: 10
 1202	normal olive Happy Birthday, Claude! cake	3	good	
-1203	small normal squat blinking personalized birthday cake	2	good	
+1203	normal small blinking squat personalized birthday cake	2	good	
 1204	flavorless three-tiered wedding cake	4	decent	
-1205	huge spoiled enchanted skewed babycakes	8	crappy	Effect: "Hustlin'", Effect Duration: 40
+1205	spoiled enchanted huge skewed babycakes	8	crappy	Effect: "Hustlin'", Effect Duration: 40
 1206	decent velvet cake	3	good	
 1207	diet flavorless lime green congratulatory cake	1	decent	
 1208	flavorless angel-food cake	3	decent	
-1209	normal small devil's-food cake	2	good	
+1209	small normal devil's-food cake	2	good	
 1210	toothsome birthday party jellybean cheesecake	3	awesome	
 1211	balloon	0		
 1212	balloon	0		
@@ -1221,7 +1221,7 @@
 1237	tapped lotus	0		
 1238	glowsticks	0		Familiar Weight: +5
 1239	jittery iced-out bling	0		Familiar Weight: +5
-1240	spinning maroon upside-down limburger biker boots	0		Familiar Weight: +5
+1240	upside-down spinning maroon limburger biker boots	0		Familiar Weight: +5
 1241	carton of clove cigarettes	0		Familiar Weight: +5
 1242	jittery deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
 1243	toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
@@ -1233,14 +1233,14 @@
 1249	Boss Bat britches of the early riser	0		Adventures: +7, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	prompt toasty Boss Bat bling	0		Hot Damage: +5, Adventures: +3
 1251	rotten fancy Knob shroomkabob	3	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 40
-1252	super-sized normal mirror shroomkabob	5	good	
+1252	normal super-sized mirror shroomkabob	5	good	
 1253	lime green narrow pile of jumping beans	0		
 1254	decent fancy jumping bean burrito	4	good	Effect: "Flower Power", Effect Duration: 30
 1255	rotten big jumping bean burrito	5	crappy	
 1256	moldy insanely jumping bean burrito	3	crappy	
 1257	adequate rat scrapple	3	good	
 1258	pail of pretentious paint	0		
-1259	twirling experienced traffic cone of the empath	0		Experience: +2, Familiar Weight: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	twirling experienced traffic cone of the empath	0		Experience: +2, Familiar Weight: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	mixed Hatorade	1		Effect: "Some Cheese with Your Wine", Effect Duration: 5
 1262	forbidden thinker's strapping off-hand balloon	0		Muscle: +5, Mysticality: +10, Spell Damage Percent: +50
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	tumbling makeup kit	0		Familiar Weight: +15
-1306	Socratic traffic cone of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	Socratic traffic cone of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	squat unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	adequate thick questionable taco	5	good	
 1321	gray Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	pulsating petrified time	0		Last Available: "2005-10"
-1323	squat forbidden time helmet	0		Spell Damage Percent: +50, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	cool time trousers	0		Moxie: +5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	squat forbidden time helmet	0		Spell Damage Percent: +50, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	cool time trousers	0		Moxie: +5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	veiny time sword	0		Maximum HP: +10, Last Available: "2005-10"
 1326	flame-wreathed Dyspepsi-Cola helmet	0		Hot Spell Damage: +10, Familiar Effect: "3xFairy, cap 7"
 1327	Cloaca-Cola shield of terror	0		Spooky Spell Damage: +10, Damage Reduction: 4
@@ -1335,7 +1335,7 @@
 1352	enchanted artisanal redrum	4	EPIC	Effect: "Certainty", Effect Duration: 45
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	miniature stale bowl of oriole's nest soup	2	decent	
+1355	stale miniature bowl of oriole's nest soup	2	decent	
 1356	bunny liver	0		
 1357	acceptable watered-down skewed Mt. Noob Pale Ale	2	good	
 1358	green pirate zombie head	0		Last Available: "2005-11"
@@ -1346,8 +1346,8 @@
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	immense spoiled tofurkey leg	6	crappy	
-1366	flavorless jumbo tofurkey gravy	5	decent	
-1367	small adequate herbal stuffing	2	good	
+1366	jumbo flavorless tofurkey gravy	5	decent	
+1367	adequate small herbal stuffing	2	good	
 1368	miniature rotten can-shaped gelatinous cranberry sauce	2	crappy	
 1369	tiny spoiled tumbling yams	1	crappy	
 1370	Socratic rhinestone cowboy shirt	0		Experience (Mysticality): +1
@@ -1362,7 +1362,7 @@
 1379	beefy plastic Crimbo reindeer	0		Muscle: +10, Single Equip, Last Available: "2005-12"
 1381	skewed huge aspirin	0		Last Available: "2005-12"
 1382	boiled ghostly chocolate	0		Effect: "Smugness", Effect Duration: 21, Last Available: "2015-11"
-1383	ghostly huge length of string	0		
+1383	huge ghostly length of string	0		
 1384	red googly eye	0		
 1385	stuffing	0		
 1386	shaking felt	0		
@@ -1384,13 +1384,13 @@
 1402	olive rag doll of the cougar	0		Moxie: +20, Last Available: "2005-12"
 1403	wholesome can of fake snow	0		Maximum HP Percent: +10, Last Available: "2005-12"
 1404	colored-light &quot;necklace&quot; of the brute	0		Muscle Percent: +30, Last Available: "2005-12"
-1405	supercharged tree skirt	0		Maximum MP Percent: +30, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	jumbo adequate ghostly wreath-shaped Crimbo cookie	5	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	supercharged tree skirt	0		Maximum MP Percent: +30, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1406	adequate jumbo ghostly wreath-shaped Crimbo cookie	5	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	spoiled bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	decent bite-sized tree-shaped Crimbo cookie	1	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	bite-sized decent tree-shaped Crimbo cookie	1	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of the storm	0		Maximum MP Percent: +40, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	deionized adjusted flattened gray snowcone	0		Effect: "Pasta Oneness", Effect Duration: 35, Last Available: "2006-01"
 1413	pressed denatured extra-magnetized squat snowcone	0		Effect: "Neutered Nostrils", Effect Duration: 37, Last Available: "2006-01"
 1414	adjusted snowcone	0		Effect: "Musky", Effect Duration: 37, Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	non-colloidal polymerized snowcone	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 34, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	educational smartaleck's traffic cone	0		Moxie Percent: +30, Experience: +1, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	educational smartaleck's traffic cone	0		Moxie Percent: +30, Experience: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	maroon Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	squat twirling censurious ice sickle of mayonnaise	0		Sleaze Spell Damage: +50, Sleaze Resistance: +3, Softcore Only, Last Available: "2006-02"
 1425	fortified ice baby	0		Damage Absorption: +60, Softcore Only, Last Available: "2006-02"
-1426	cyan twirling steel-toed ice pick	0		Damage Reduction: 9, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	cyan twirling steel-toed ice pick	0		Damage Reduction: 9, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	sage weightlifter's ice skates	0		Muscle: +15, Mysticality Percent: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	special yummy grue egg omelette	3	awesome	Effect: "Space Cadet", Effect Duration: 50
 1429	teal twirling roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	normal miniature mushroom	2	good	
+1432	miniature normal mushroom	2	good	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	maroon hot pink lipstick	0		Familiar Weight: +5
@@ -1433,11 +1433,11 @@
 1451	powdered shaking red hot wad	1		
 1452	altered red wad	1		
 1453	vaporized wad	1		
-1454	twisted bouncing jittery stench wad	1		
-1455	denatured wobbly yellow sleaze wad	1		
+1454	twisted jittery bouncing stench wad	1		
+1455	denatured yellow wobbly sleaze wad	1		
 1456	bouncing double daisy	0		
-1457	skewed cyan Goth Giant	0		
-1458	massive toothsome Valentine's Day cake	8	awesome	
+1457	cyan skewed Goth Giant	0		
+1458	toothsome massive Valentine's Day cake	8	awesome	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	olive squashed frog	0		
@@ -1462,22 +1462,22 @@
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	green union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
-1483	ghostly pulsating troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
+1483	pulsating ghostly troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	shaking alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	blurry Rosewater's rabbit's foot of Calamity Jane	0		Mysticality Percent: +30, Critical Hit Percent: +15
 1486	massive bag of catnip	0		
 1487	hang glider	0		
-1488	narrow skewed March hat	0		Free Pull
+1488	skewed narrow March hat	0		Free Pull
 1489	dormouse	0		
 1490	huge chopsticks of dire peril of the glutton	0		Weapon Damage: +20, Food Drop: +100
 1491	bouncing rice bowl of the businessman	0		Meat Drop: +50
 1492	ninja mop of the detective	0		Item Drop: +20
 1493	wobbly hardy ridiculously overelaborate ninja weapon of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100
 1494	modified boiled sugar-coated pine cone	0		Effect: "Saucegoggles", Effect Duration: 58, Last Available: "2020-09"
-1495	olive clever traffic cone of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	mediocre strong wobbly gray gloomy mushroom wine	5	decent	
+1495	olive clever traffic cone of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1496	mediocre strong gray wobbly gloomy mushroom wine	5	decent	
 1497	aged mushroom wine	3	awesome	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	warmed explosion-flavored chewing gum	0		Effect: "Spring Training", Effect Duration: 49, Last Available: "2006-04"
@@ -1486,9 +1486,9 @@
 1504	quadruple-electrified pressed snowcone	0		Effect: "Lemon Enlightenment", Effect Duration: 28, Last Available: "2006-04"
 1505	wobbly ice cube with a fly in it	0		Last Available: "2006-04"
 1506	drinkable extra-dry calle de miel with a fly in it	5	good	Last Available: "2006-04"
-1507	practically non-alcoholic perfectly mixed rockin' wagon with a fly in it	1	EPIC	Last Available: "2006-04"
+1507	perfectly mixed practically non-alcoholic rockin' wagon with a fly in it	1	EPIC	Last Available: "2006-04"
 1508	artisanal perpendicular hula with a fly in it	4	EPIC	Last Available: "2006-04"
-1509	smooth watered-down slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
+1509	watered-down smooth slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	Newton's fake hand	0		Experience (Mysticality): +3, Last Available: "2006-04"
 1512	distilled yellow shaking Knob Goblin pet-buffing spray	1		
@@ -1503,23 +1503,23 @@
 1522	spinning up-at-dawn deadly Radio Free Jersey	0		Weapon Damage: +5, Adventures: +5
 1523	lime green bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	corkscrew of the wise owl of bravery	0		Mysticality: +20, Spooky Resistance: +5, Last Available: "2006-04"
-1529	purple squat St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
+1529	squat purple St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	cyan scorching grass skirt	0		Hot Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	narrow hardy grass hat	0		Maximum HP: +50, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	cyan scorching grass skirt	0		Hot Damage: +25, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	narrow hardy grass hat	0		Maximum HP: +50, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	tumbling beefcake's grass blade	0		Muscle: +25, Last Available: "2011-01"
 1534	shaking raffle prize box	0		
 1536	huge homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	narrow weegee sqouija	0		Last Available: "2011-12"
 1538	reassuring sparkly engagement ring	0		Spooky Resistance: +1, Single Equip
 1539	green Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	nippy coward's Grimacite goggles	0		Monster Level: -20, Cold Damage: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	nippy coward's Grimacite goggles	0		Monster Level: -20, Cold Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	Lo Pan's educational Grimacite glaive	0		Experience: +1, Spell Critical Percent: +30, Last Available: "2008-10"
-1542	scorching shellacked Grimacite greaves	0		Damage Reduction: 7, Hot Damage: +25, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	scorching shellacked Grimacite greaves	0		Damage Reduction: 7, Hot Damage: +25, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	blurry ghostly wizardly Grimacite garter of courage	0		Mysticality: +25, Spooky Resistance: +3, Last Available: "2008-10"
 1544	hardened Grimacite galoshes of the detective	0		Damage Reduction: 3, Item Drop: +20, Last Available: "2008-10"
 1545	green flame-retardant scorching Grimacite gorget	0		Hot Damage: +25, Hot Resistance: +1, Last Available: "2008-10"
@@ -1528,80 +1528,80 @@
 1548	Gazpacho's Glacial Grimoire of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50
 1549	maroon MSG	0		
 1550	Annie Oakley's second-hand knockoff engagement ring	0		Critical Hit Percent: +20, Single Equip
-1551	delicious practically non-alcoholic twirling bottle of Domesticated Turkey	1	awesome	
+1551	practically non-alcoholic delicious twirling bottle of Domesticated Turkey	1	awesome	
 1552	artisanal watered-down bottle of Definit	2	EPIC	
-1553	practically non-alcoholic enchanted drinkable skewed bottle of Calcutta Emerald	1	good	Effect: "Amplified Fabulousness", Effect Duration: 10
+1553	enchanted drinkable practically non-alcoholic skewed bottle of Calcutta Emerald	1	good	Effect: "Amplified Fabulousness", Effect Duration: 10
 1554	mediocre bottle of Lieutenant Freeman	3	decent	
 1555	perfectly mixed bottle of Jorge Sinsonte	4	EPIC	
-1556	weak enchanted acceptable mirror boxed champagne	2	good	Effect: "Baconstoned", Effect Duration: 15
+1556	acceptable enchanted weak mirror boxed champagne	2	good	Effect: "Baconstoned", Effect Duration: 15
 1557	yummy spinning narrow kumquat	3	awesome	
 1558	gigantic decent tangerine	10	good	
 1559	tonic water	0		
-1560	flavorless half-sized cocktail onion	2	decent	
+1560	half-sized flavorless cocktail onion	2	decent	
 1561	tasty tumbling raspberry	4	awesome	
 1562	adequate kiwi	3	good	
-1563	high-proof bad whiskey bittersweet	9	decent	
+1563	bad high-proof whiskey bittersweet	9	decent	
 1564	perfectly mixed pulsating mimosette	4	EPIC	
 1565	acceptable bouncing tequila sunset	4	good	
-1566	strong delicious upside-down zmobie	5	awesome	Wiki Name: "Zmobie (drink)"
-1567	acceptable fortified gin and tonic	5	good	
-1568	artisanal weak vodka and tonic	2	EPIC	
-1569	special strong artisanal vodka gibson	5	EPIC	Effect: "Going Ape", Effect Duration: 15
+1566	delicious strong upside-down zmobie	5	awesome	Wiki Name: "Zmobie (drink)"
+1567	fortified acceptable gin and tonic	5	good	
+1568	weak artisanal vodka and tonic	2	EPIC	
+1569	strong artisanal special vodka gibson	5	EPIC	Effect: "Going Ape", Effect Duration: 15
 1570	high-proof artisanal huge gibson	7	EPIC	
 1571	boozy lousy lime green parisian cathouse	5	decent	
 1572	acceptable weak rabbit punch	2	good	
-1573	lousy triple-distilled bouncing caipifruta	7	decent	
+1573	triple-distilled lousy bouncing caipifruta	7	decent	
 1574	artisanal fancy wobbly teqiwila	4	EPIC	Effect: "Smokin'", Effect Duration: 10
-1575	practically non-alcoholic hand-crafted Divine	1	super ultra mega turbo EPIC	
+1575	hand-crafted practically non-alcoholic Divine	1	super ultra mega turbo EPIC	
 1576	mediocre Gordon Bennett	3	decent	
-1577	practically non-alcoholic smooth tangarita	1	awesome	
-1578	drinkable strong mandarina colada	5	good	
+1577	smooth practically non-alcoholic tangarita	1	awesome	
+1578	strong drinkable mandarina colada	5	good	
 1579	tolerable practically non-alcoholic gimlet	1	good	
 1580	smooth weak brick road	2	awesome	
 1581	tolerable vodka stratocaster	4	good	
 1582	bad Neuromancer	3	decent	
 1583	acceptable prussian cathouse	3	good	
 1584	tolerable twirling Mae West	3	good	
-1585	mediocre fortified huge blue ghostly Mon Tiki	5	decent	
+1585	mediocre fortified huge ghostly blue Mon Tiki	5	decent	
 1586	perfectly mixed teqiwila slammer	3	EPIC	
 1587	spoiled twirling Knob lo mein	4	crappy	
 1588	fancy decent asparagus lo mein	3	good	Effect: "Afternoon Insight", Effect Duration: 35
 1589	spoiled skewed Knoll lo mein	3	crappy	
-1590	snack-sized bland lo mein	2	decent	
+1590	bland snack-sized lo mein	2	decent	
 1591	spoiled twirling olive lo mein	4	crappy	
-1592	snack-sized tasty hot hi mein	2	awesome	
-1593	special decent pulsating hi mein	4	good	Effect: "Block-Rockin' Beet", Effect Duration: 40
+1592	tasty snack-sized hot hi mein	2	awesome	
+1593	decent special pulsating hi mein	4	good	Effect: "Block-Rockin' Beet", Effect Duration: 40
 1594	adequate hi mein	4	good	
 1595	adequate hi mein	4	good	
 1596	rotten yellow sleazy hi mein	3	crappy	
 1597	Da Vinci's Junior LAAAAME merit badge	0		Experience (Mysticality): +5, Last Available: "2006-05"
 1598	upside-down wobbly Senior LAAAAME merit badge of the early riser	0		Adventures: +7, Last Available: "2006-05"
 1599	bouncing jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	watered-down artisanal jittery tangarita with a fly in it	2	EPIC	
-1601	fancy artisanal mandarina colada with a fly in it	3	EPIC	Effect: "Ooh, Salty!", Effect Duration: 30
+1600	artisanal watered-down jittery tangarita with a fly in it	2	EPIC	
+1601	artisanal fancy mandarina colada with a fly in it	3	EPIC	Effect: "Ooh, Salty!", Effect Duration: 30
 1602	acceptable prussian cathouse with a fly in it	4	good	
-1603	watered-down aged Mae West with a fly in it	2	awesome	
+1603	aged watered-down Mae West with a fly in it	2	awesome	
 1604	dehydrated mirror astronaut ice-cream	1		Last Available: "2006-05"
 1605	blue delectable catalyst	0		
 1606	altered ultimate wad	1		
 1607	magnetized libation of liveliness	0		Effect: "Abyssal Sweat", Effect Duration: 32
 1608	moist eyedrops of the ermine	0		Effect: "Piratey Flavor", Effect Duration: 21
 1609	diffused bouncing bouncing perfume of prejudice	0		Effect: "The Real Deal", Effect Duration: 45
-1610	alkaline boiled upside-down spinning eyedrops of the ocelot	0		Effect: "Limber as Mortimer", Effect Duration: 55
+1610	alkaline boiled spinning upside-down eyedrops of the ocelot	0		Effect: "Limber as Mortimer", Effect Duration: 55
 1611	aerosolized mirror tumbling potent potion of potency	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 50
 1612	aerosolized blue concentrated cordial of concentration	0		Effect: "Emotion Sickness", Effect Duration: 67
 1613	coffin lid of Flo-Jo	0		Initiative: +100, Damage Reduction: 3
 1614	skewed zippy satin shield	0		Initiative: +20, Damage Reduction: 5
-1615	blurry healthy Cerebral Cloche	0		Maximum HP Percent: +20, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	shaking frosty Cerebral Culottes	0		Cold Spell Damage: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	blurry healthy Cerebral Cloche	0		Maximum HP Percent: +20, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	shaking frosty Cerebral Culottes	0		Cold Spell Damage: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	dog trainer's clever brawny Cerebral Crossbow	0		Muscle Percent: +20, Maximum MP: +20, Experience (familiar): +1, Last Available: "2006-06"
 1618	mirror ice stein	0		Last Available: "2006-06"
 1619	pulsating munchies pill	0		Last Available: "2006-06"
 1620	narrow homeopathic healing powder	0		Last Available: "2006-06"
 1621	mirror astral badger	0		Free Pull, Last Available: "2006-06"
 1622	quadruple-flattened astral mushroom	0		Effect: "Loyal Tea", Effect Duration: 69, Last Available: "2006-06"
-1623	olive skewed badger badge	0		Last Available: "2006-06"
-1624	tarnished anodized liquefied blinking narrow blue-frosted astral cupcake	0		Effect: "The Halls of Muscularity", Effect Duration: 19, Last Available: "2006-06"
+1623	skewed olive badger badge	0		Last Available: "2006-06"
+1624	tarnished anodized liquefied narrow blinking blue-frosted astral cupcake	0		Effect: "The Halls of Muscularity", Effect Duration: 19, Last Available: "2006-06"
 1625	cold-filtered blue green-frosted astral cupcake	0		Effect: "Punchy, Murdery", Effect Duration: 54, Last Available: "2006-06"
 1626	cold-filtered adjusted upside-down orange-frosted astral cupcake	0		Effect: "Warm Shoulders", Effect Duration: 12, Last Available: "2006-06"
 1627	non-colloidal ghostly purple-frosted astral cupcake	0		Effect: "Briny Blood", Effect Duration: 28, Last Available: "2006-06"
@@ -1619,18 +1619,18 @@
 1639	unsweetened cold-filtered lotion of spookiness	0		Effect: "Dreadful Chill", Effect Duration: 12
 1640	boiled extra-oxidized lotion of stench	0		Effect: "Hella Tough", Effect Duration: 66
 1641	frozen colloidal green squat lotion of sleaziness	0		Effect: "How to Scam Tourists", Effect Duration: 57
-1642	hand-crafted watered-down ghostly Grimacite Bock	2	EPIC	Last Available: "2008-11"
+1642	watered-down hand-crafted ghostly Grimacite Bock	2	EPIC	Last Available: "2008-11"
 1643	moldy wedge of gray cheese	4	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	tumbling and sauce	0		
 1646	mirror and sauce	0		
-1647	jittery spinning stench and sauce	0		
+1647	spinning jittery stench and sauce	0		
 1648	lime green sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	half-sized stale jittery olive foie gras	2	decent	
+1651	half-sized stale olive jittery foie gras	2	decent	
 1652	galvanized extra-energized candy brain	0		Effect: "Colorful Gratitude", Effect Duration: 44, Last Available: "2020-09"
-1653	medical-grade fortified jewel-eyed wizard hat	0		Damage Absorption: +60, Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1653	medical-grade fortified jewel-eyed wizard hat	0		Damage Absorption: +60, Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
 1654	narrow twirling brainy wad of Crovacite of the brute	0		Mysticality: +5, Muscle Percent: +30
 1655	manspreader's collar of the empath	0		Monster Level: +10, Familiar Weight: +5
 1656	teal White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	up-at-dawn sword of the wise owl	0		Mysticality: +20, Adventures: +5
 1680	hale weightlifter's staff	0		Muscle: +15, Maximum HP: +20
 1681	lightning-fast family-friendly bubblewrap sword	0		Sleaze Resistance: +1, Initiative: +40
@@ -1680,8 +1680,8 @@
 1700	normal goat cheese taco	3	good	
 1701	half-sized spoiled pr0n taco	2	crappy	
 1702	polarized shaking alphabet gum	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 26
-1703	blurry bouncing Comma Chameleon egg	0		Free Pull
-1704	upside-down shaking shingle	0		
+1703	bouncing blurry Comma Chameleon egg	0		Free Pull
+1704	shaking upside-down shingle	0		
 1705	flaregun	0		
 1706	Van der Graaf Oprah's sword of wisdom	0		Mysticality: +15, Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7
 1707	auspicious flypaper staff of the scaredy-cat of the empath	0		Monster Level: -15, Familiar Weight: +5, Item Drop: +10
@@ -1745,7 +1745,7 @@
 1766	bouncing bouncing Spookyraven ballroom key	0		
 1767	skewed pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	jumbo normal fricasseed brains	5	good	
+1769	normal jumbo fricasseed brains	5	good	
 1770	decent squat brains casserole	3	good	
 1771	sinister butcherknife	0		Spell Damage: +10
 1772	padded corn holder	0		Damage Absorption: +20
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	watered-down drinkable Ram's Face Lager	2	good	
 1791	ram horns	0		
-1792	twirling ghostly experienced cool Travoltan trousers of chilblains	0		Moxie: +5, Experience: +2, Cold Damage: +25, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	twirling ghostly experienced cool Travoltan trousers of chilblains	0		Moxie: +5, Experience: +2, Cold Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	jittery wholesome Fonzie's pool cue	0		Experience (Moxie): +1, Maximum HP Percent: +10
 1794	irradiated skewed handful of hand chalk	0		Effect: "Phairly Balanced", Effect Duration: 67
 1795	Counterclockwise Watch of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
@@ -1776,7 +1776,7 @@
 1797	misshapen animal skeleton	0		
 1798	skewed pile of animal bones	0		
 1799	jittery animal skull	0		
-1800	teal pulsating animal cranium	0		
+1800	pulsating teal animal cranium	0		
 1801	animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
@@ -1811,7 +1811,7 @@
 1832	fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
-1835	skewed shaking seventh caudal vertebra	0		
+1835	shaking skewed seventh caudal vertebra	0		
 1836	eighth caudal vertebra	0		
 1837	ninth caudal vertebra	0		
 1838	tenth caudal vertebra	0		
@@ -1820,7 +1820,7 @@
 1841	left third rib	0		
 1842	blue left fourth rib	0		
 1843	left fifth rib	0		
-1844	lime green jittery left sixth rib	0		
+1844	jittery lime green left sixth rib	0		
 1845	left seventh rib	0		
 1846	left eighth rib	0		
 1847	cyan left ninth rib	0		
@@ -1836,7 +1836,7 @@
 1857	right seventh rib	0		
 1858	purple right eighth rib	0		
 1859	teal right ninth rib	0		
-1860	mirror twirling right tenth rib	0		
+1860	twirling mirror right tenth rib	0		
 1861	tumbling right eleventh rib	0		
 1862	narrow right twelfth rib	0		
 1863	upside-down jittery animal pelvis	0		
@@ -1888,7 +1888,7 @@
 1911	perfumed stanky wizardly clockwork staff	0		Mysticality: +25, Stench Spell Damage: +25, Stench Resistance: +5
 1912	wool toasty brawny clockwork crossbow	0		Muscle Percent: +20, Hot Damage: +5, Cold Resistance: +1
 1913	tumbling clockwork handle	0		
-1914	gray mirror clockwork rod	0		
+1914	mirror gray clockwork rod	0		
 1915	clockwork shank	0		
 1916	narrow Lord Spookyraven's spectacles	0		
 1917	cyan wallet	0		
@@ -1923,19 +1923,19 @@
 1946	healthy accordion pin of the blizzard	0		Maximum HP Percent: +20, Cold Spell Damage: +25, Class: "Accordion Thief", Single Equip
 1947	smelly worn tophat of the scaredy-cat	0		Monster Level: -15, Stench Spell Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	inspector's tap shoes of the early riser	0		Item Drop: +15, Adventures: +7, Single Equip
-1949	miniature adequate Manetwich	2	good	
+1949	adequate miniature Manetwich	2	good	
 1950	bottle of Vangoghbitussin	0		
 1951	artisanal bottle of Pinot Renoir	4	EPIC	
 1952	special stale twirling desiccated apricot	4	decent	Effect: "Mistified", Effect Duration: 5
 1953	perfectly mixed flute of flat champagne	4	EPIC	
-1954	small spoiled dehydrated caviar	2	crappy	
+1954	spoiled small dehydrated caviar	2	crappy	
 1955	styrofoam peanuts	0		
-1956	drinkable fortified olive snifter of thoroughly aged brandy	5	good	
+1956	fortified drinkable olive snifter of thoroughly aged brandy	5	good	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	ghostly tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
-1961	tumbling shaking cyan can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
+1961	cyan tumbling shaking can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	pressed blinking Bit O' Ectoplasm	0		Effect: "There Is A Spoon", Effect Duration: 69
 1963	squat wobbly dance card	0		
 1964	hardy opera mask	0		Maximum HP: +50, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
@@ -1955,7 +1955,7 @@
 1978	gravy fairy	0		
 1979	gravy fairy	0		
 1980	sleazy gravy fairy	0		
-1981	wobbly blurry astral badger	0		
+1981	blurry wobbly astral badger	0		
 1982	MagiMechTech MicroMechaMech	0		
 1983	jittery hand turkey	0		
 1984	yellow snowy owl	0		
@@ -1985,7 +1985,7 @@
 2008	twirling Roo trading card	0		
 2009	narrow Woldo trading card	0		
 2010	blurry blurry The Snake trading card	0		
-2011	skewed narrow Nayztameetjoo trading card	0		
+2011	narrow skewed Nayztameetjoo trading card	0		
 2012	ghostly Arrrmetia trading card	0		
 2013	Serenity trading card	0		
 2014	squat Inndya trading card	0		
@@ -1998,7 +1998,7 @@
 2021	flavorless gigantic strawberry pie	7	decent	
 2022	spoiled lemon meringue pie	3	crappy	
 2023	Genalen&trade; Bottle	1	crappy	
-2024	delicious snack-sized shaking mixed wildflower greens	2	awesome	
+2024	snack-sized delicious shaking mixed wildflower greens	2	awesome	
 2025	small flavorless handful of walnuts	2	decent	
 2026	bland nutty organic salad	4	decent	
 2027	half-sized tasty super salad	2	awesome	
@@ -2019,10 +2019,10 @@
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	big rotten brain-meltingly-hot chicken wings	5	crappy	
+2045	rotten big brain-meltingly-hot chicken wings	5	crappy	
 2046	rotten fancy low-calorie frat brats	1	crappy	Effect: "Full of Wist", Effect Duration: 50
-2047	bite-sized rotten cyan knob ka-bobs	1	crappy	
-2049	strong perfectly mixed can of Swiller	5	EPIC	
+2047	rotten bite-sized cyan knob ka-bobs	1	crappy	
+2049	perfectly mixed strong can of Swiller	5	EPIC	
 2050	skewed broken wings	0		
 2051	mirror sunken eyes	0		
 2052	reassembled blackbird	0		
@@ -2060,7 +2060,7 @@
 2084	can of starch	0		
 2085	boiled skewed bottle of ultravitamins	1		
 2086	twisted bottle of cough syrup	1		
-2087	twisted tumbling blinking tube of hair oil	1		
+2087	twisted blinking tumbling tube of hair oil	1		
 2088	ionized Daffy Taffy	0		Effect: "Arabian Knighthood", Effect Duration: 42
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	family-friendly lard-coated Annie Oakley's personal trainer's pilgrim shield of mayonnaise	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Sleaze Spell Damage: 75, Sleaze Resistance: +1, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
@@ -2075,11 +2075,11 @@
 2099	hobo gristle	0		
 2100	narrow shredded can label	0		
 2101	cyan bloodstained briquette	0		
-2102	squat blinking tumbling greasy dreadlock	0		
+2102	tumbling squat blinking greasy dreadlock	0		
 2103	bouncing vial of pirate sweat	0		
 2104	empty aftershave bottle	0		
 2105	mirror coal button	0		
-2106	ghostly squat burned-out arcanodiode	0		
+2106	squat ghostly burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
 2108	skewed rock	0		
 2109	pulsating stringy sinew	0		Last Available: "2011-12"
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	narrow shaking avaricious prehistoric spear	0		Meat Drop: +30, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	chaotic hardy fire	0		Maximum HP: +50, Spell Critical Percent: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	chaotic hardy fire	0		Maximum HP: +50, Spell Critical Percent: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	ghostly miser's Grateful Undead T-shirt	0		Meat Drop: +10
@@ -2133,7 +2133,7 @@
 2158	shaking servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
-2161	tumbling huge computronic processing unit	0		Last Available: "2011-12"
+2161	huge tumbling computronic processing unit	0		Last Available: "2011-12"
 2162	fuchsia reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	green ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	perfumed boxer's toy ray gun	0		Muscle Percent: +10, Stench Resistance: +5, Last Available: "2006-12"
-2169	green fireproof toy space helmet of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	green fireproof toy space helmet of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	green MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	wobbly executive reassuring astronaut pants	0		Spooky Resistance: +1, Meat Drop: +40, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	wobbly executive reassuring astronaut pants	0		Spooky Resistance: +1, Meat Drop: +40, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	Sinatra's toy jet pack	0		Experience (Moxie): +5, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	cyan mossy stone sphere	0		
@@ -2165,10 +2165,10 @@
 2190	spinning yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	tumbling sheet music	0		Last Available: "2006-12"
-2193	rotten diet mirror candy stake	1	crappy	Last Available: "2006-12"
+2193	diet rotten mirror candy stake	1	crappy	Last Available: "2006-12"
 2194	drinkable watered-down blurry eggnog	2	good	Last Available: "2006-12"
 2195	normal enchanted unspeakable fruitcake	4	good	Effect: "Memory of Attractiveness", Effect Duration: 35, Last Available: "2006-12"
-2196	toothsome half-sized gingerbread horror	2	awesome	Last Available: "2006-12"
+2196	half-sized toothsome gingerbread horror	2	awesome	Last Available: "2006-12"
 2197	deionized blinking but probably evil chocolate	0		Effect: "Deadly Flashing Blade", Effect Duration: 34, Last Available: "2006-12"
 2198	flavorless snack-sized bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	spoiled skull-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2182,19 +2182,19 @@
 2207	Crimbo tiki necklace of extreme caution	0		Monster Level: -25, Last Available: "2006-12"
 2208	bobble-hip hula elf doll of the dark arts of the early riser	0		Spell Damage Percent: +100, Adventures: +7, Last Available: "2006-12"
 2209	rosewater-soaked Crimbo ukulele	0		Stench Resistance: +3, Last Available: "2006-12"
-2210	auspicious experienced Tiki lighter	0		Experience: +2, Item Drop: +10, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	upside-down up-at-dawn family-friendly deck of tropical cards	0		Sleaze Resistance: +1, Adventures: +5, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	sinister brainy tropical paperweight	0		Mysticality: +5, Spell Damage: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	auspicious experienced Tiki lighter	0		Experience: +2, Item Drop: +10, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	upside-down up-at-dawn family-friendly deck of tropical cards	0		Sleaze Resistance: +1, Adventures: +5, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	sinister brainy tropical paperweight	0		Mysticality: +5, Spell Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	blinking tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	huge nasty Tropical Crimbo Hat	0		Stench Damage: +5, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	pulsating Tropical Crimbo Shorts of the cougar	0		Moxie: +20, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	huge nasty Tropical Crimbo Hat	0		Stench Damage: +5, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	pulsating Tropical Crimbo Shorts of the cougar	0		Moxie: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	stale super ka-bob	3	decent	
 2218	small adequate beer basted brat	2	good	
 2219	Tropical Crimbo Sword of extreme caution	0		Monster Level: -25, Last Available: "2006-12"
 2220	dry quadruple-nitrogenated and Crimboween candy	0		Effect: "Crimbo Nostalgia", Effect Duration: 11, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	frightening forbidden liar's pants	0		Spell Damage Percent: +50, Spooky Damage: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	frightening forbidden liar's pants	0		Spell Damage Percent: +50, Spooky Damage: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	purple blinking horrifying electrified juggler's balls	0		Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2007-01"
 2224	smartaleck's pink shirt	0		Moxie Percent: +30, Softcore Only, Last Available: "2007-01"
 2225	blinking bouncing familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2208,7 +2208,7 @@
 2233	lime green bow tie of courage	0		Spooky Resistance: +3, Clowniness: 75
 2234	ruddy calavera concertina	0		Maximum HP Percent: +40, Song Duration: 7
 2235	spinning healthy savvy ratarang	0		Mysticality Percent: +20, Maximum HP Percent: +20
-2236	warmed wobbly green tumbling turtle pheromones	0		Effect: "Crocodile Tear", Effect Duration: 37
+2236	warmed tumbling wobbly green turtle pheromones	0		Effect: "Crocodile Tear", Effect Duration: 37
 2237	pygmy blowgun	0		
 2238	dance instructor's pygmy nose-bone	0		Experience Percent (Moxie): +10, Single Equip
 2239	prompt sinister bad voodoo mask	0		Spell Damage: +10, Adventures: +3, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
@@ -2231,21 +2231,21 @@
 2257	up-at-dawn toasty reinforced furry underpants	0		Hot Damage: +5, Adventures: +5
 2258	&quot;I Love Me, Vol. I&quot;	0		
 2259	green photograph of God	0		
-2260	mirror ghostly hard rock candy	0		
+2260	ghostly mirror hard rock candy	0		
 2261	blue narrow hard-boiled ostrich egg	0		
 2262	mirror bird rib	0		
 2263	lion oil	0		
-2264	fancy tasty stunt nuts	4	awesome	Effect: "Quiet 'n' Good", Effect Duration: 50
+2264	tasty fancy stunt nuts	4	awesome	Effect: "Quiet 'n' Good", Effect Duration: 50
 2265	normal wet stew	3	good	
 2266	tumbling wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats of the glutton	0		Food Drop: +100
 2269	spoiled special sausage wonton	3	crappy	Effect: "Gummiskin", Effect Duration: 35
 2270	frightening belt of the ox	0		Muscle: +20, Spooky Damage: +5, Single Equip
-2271	special bad blurry bottle of Merlot	4	decent	Effect: "Weird Flavor", Effect Duration: 25
+2271	bad special blurry bottle of Merlot	4	decent	Effect: "Weird Flavor", Effect Duration: 25
 2272	perfectly mixed practically non-alcoholic bottle of Port	1	EPIC	
 2273	lousy pulsating bottle of Pinot Noir	3	decent	
-2274	practically non-alcoholic drinkable narrow bottle of Zinfandel	1	good	
+2274	drinkable practically non-alcoholic narrow bottle of Zinfandel	1	good	
 2275	mediocre jittery bottle of Marsala	3	decent	
 2276	drinkable bottle of Muscat	4	good	
 2277	Fernswarthy's key	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	pulsating worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	unsweetened candy heart	0		Effect: "Superioreo", Effect Duration: 24, Last Available: "2007-02"
 2305	tarnished pink candy heart	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 27, Last Available: "2007-02"
 2306	magnetized maroon ghostly candy heart	0		Effect: "Thick-Skinned", Effect Duration: 64, Last Available: "2007-02"
@@ -2301,9 +2301,9 @@
 2327	frozen chilled upside-down can of paint	0		Effect: "Sugary Tongue", Effect Duration: 45
 2328	drum machine	0		
 2329	handful of confetti	0		
-2330	lime green blinking chocolate-covered diamond-studded roses	0		
+2330	blinking lime green chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	small stale teal Better Than Cuddling Cake	2	decent	
+2332	stale small teal Better Than Cuddling Cake	2	decent	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2350,7 +2350,7 @@
 2376	perfectly mixed irresponsibly strong banana daiquiri	10	EPIC	
 2377	hand-crafted shaking bungle in the jungle	3	EPIC	
 2378	banana spritzer	0		
-2379	colloidal ionized cyan bouncing banana smoothie	0		Effect: "Vented Spleen", Effect Duration: 21
+2379	colloidal ionized bouncing cyan banana smoothie	0		Effect: "Vented Spleen", Effect Duration: 21
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
@@ -2391,12 +2391,12 @@
 2417	reassuring bounty-hunting rifle	0		Spooky Resistance: +1
 2418	bounty-hunting pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	flattened flattened wet spinning bottle of rhinoceros hormones	0		Effect: "Oriental Mysticism", Effect Duration: 20
-2420	dry twirling fuchsia wobbly teeny-tiny magic scroll	0		Effect: "Creepypasted", Effect Duration: 65
+2420	dry wobbly fuchsia twirling teeny-tiny magic scroll	0		Effect: "Creepypasted", Effect Duration: 65
 2421	boiled oxidized pulsating bottle of pirate juice	0		Effect: "Ten out of Ten", Effect Duration: 42
 2422	quadruple-activated irradiated pet snacks	0		Effect: "Heightened Senses", Effect Duration: 67
 2423	alkaline Mick's IcyVapoHotness Inhaler	0		Effect: "Deep-Seated Rage", Effect Duration: 49
 2424	cold-filtered jittery cyclops eyedrops	0		Effect: "Lubed", Effect Duration: 11
-2425	vacuum-sealed extra-modified lime green jittery can of spinach	0		Effect: "Scorpio Rising", Effect Duration: 24
+2425	vacuum-sealed extra-modified jittery lime green can of spinach	0		Effect: "Scorpio Rising", Effect Duration: 24
 2426	non-anodized fuchsia fire flower	0		Effect: "Familial Ties", Effect Duration: 46
 2427	polymerized mirror freezerburned ice cube	0		Effect: "Stands Alone", Effect Duration: 57
 2428	galvanized frozen blinking fake blood	0		Effect: "Alchemical, Brother", Effect Duration: 38
@@ -2461,8 +2461,8 @@
 2488	quilted yak anorak	0		Damage Absorption: +40
 2489	skewed energetic tuxedo shirt	0		Maximum MP Percent: +20
 2490	double-paned wicked gnauga hide vest	0		Spell Damage: +5, Cold Resistance: +5
-2491	bouncing gray shirt kit	0		
-2492	jittery lime green tropical orchid	0		
+2491	gray bouncing shirt kit	0		
+2492	lime green jittery tropical orchid	0		
 2493	mirror stick of dynamite	0		
 2494	spinning Herculean Necrotelicomnicon of vim and vigor	0		Experience (Muscle): +1, Maximum HP Percent: +50
 2495	mirror Usain Bolt's Da Vinci's Cookbook of the Damned	0		Experience (Mysticality): +5, Initiative: +80
@@ -2489,23 +2489,23 @@
 2516	ghostly manspreader's wrench bracelet of the overflowing toilet	0		Monster Level: +10, Stench Spell Damage: +50
 2517	friendly studded chain necklace	0		Damage Absorption: +80, Familiar Weight: +3
 2518	occult sawblade shield	0		Spell Damage Percent: +25, Damage Reduction: 11
-2519	hand-crafted practically non-alcoholic McMillicancuddy's Special Lager	1	EPIC	
+2519	practically non-alcoholic hand-crafted McMillicancuddy's Special Lager	1	EPIC	
 2520	artisanal distilled melted Jell-o shot	5	EPIC	
-2521	practically non-alcoholic drinkable fancy cruelty-free wine	1	good	Effect: "Prideful Strut", Effect Duration: 10
+2521	drinkable practically non-alcoholic fancy cruelty-free wine	1	good	Effect: "Prideful Strut", Effect Duration: 10
 2522	tolerable thistle wine	3	good	
 2523	megatofu	0		
 2524	twirling displaced fish	0		
 2525	stale mirror fish	3	decent	
-2526	thick flavorless fancy pulsating gray fish casserole	5	decent	Effect: "Macho Profundo", Effect Duration: 15
-2527	big toothsome narrow fish lasagna	5	awesome	
+2526	flavorless thick fancy pulsating gray fish casserole	5	decent	Effect: "Macho Profundo", Effect Duration: 15
+2527	toothsome big narrow fish lasagna	5	awesome	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	half-sized adequate gnatloaf	2	good	
+2529	adequate half-sized gnatloaf	2	good	
 2530	decent pulsating gnatloaf casserole	3	good	
-2531	bland spinning gray gnat lasagna	4	decent	
+2531	bland gray spinning gnat lasagna	4	decent	
 2532	pork	0		
 2533	spoiled pork chop sandwiches	4	crappy	
 2534	decent spinning pork casserole	3	good	
-2535	moldy big pork lasagna	5	crappy	
+2535	big moldy pork lasagna	5	crappy	
 2536	blurry canopic jar	0		
 2537	wobbly spice	0		
 2538	huge organs	0		
@@ -2518,7 +2518,7 @@
 2545	double-energized super-aerosolized upsy daisy	0		Effect: "items.enh", Effect Duration: 55, Last Available: "2007-05"
 2546	warmed half-orchid	0		Effect: "Adventurer's Best Friendship", Effect Duration: 60, Last Available: "2007-05"
 2547	chaotic MacGyver's tin star	0		Maximum MP: +100, Spell Critical Percent: +10, Last Available: "2007-05"
-2548	lightning-fast dance instructor's outrageous sombrero	0		Experience Percent (Moxie): +10, Initiative: +40, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	lightning-fast dance instructor's outrageous sombrero	0		Experience Percent (Moxie): +10, Initiative: +40, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	greedy grievous &quot;Humorous&quot; T-shirt	0		Weapon Damage Percent: +50, Meat Drop: +20, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2549,19 +2549,19 @@
 2576	honey-dipped locust	0		
 2577	flame-retardant greasy cactus quill	0		Sleaze Spell Damage: +10, Hot Resistance: +1
 2578	olive bouncing crafty hardy Staff of the Short Order Cook of bravery	0		Maximum HP: +50, Maximum MP: +10, Spooky Resistance: +5
-2579	half-sized moldy cactus fruit	2	crappy	
+2579	moldy half-sized cactus fruit	2	crappy	
 2580	scorpion whip of the dark arts of courage	0		Spell Damage Percent: +100, Spooky Resistance: +3
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	adequate blinking huge centipede eggs	3	good	
+2583	adequate huge blinking centipede eggs	3	good	
 2584	shaking skewed wonderwall shield of bravery	0		Spooky Resistance: +5, Damage Reduction: 12
 2585	upside-down groovy Colonel Mustard's Lonely Spades Club Jacket	0		Moxie Percent: +10
 2586	nasty General Sage's Lonely Diamonds Club Jacket	0		Stench Damage: +5
 2587	hardened Corporal Fennel's Lonely Clubs Club Jacket	0		Damage Reduction: 3
 2588	Private Pepper's Lonely Hearts Club Jacket of Calamity Jane	0		Critical Hit Percent: +15
 2589	decent wobbly hot date	3	good	
-2590	acceptable fortified distilled fortified wine	5	good	
-2591	bland jumbo tasty tart	5	decent	
+2590	fortified acceptable distilled fortified wine	5	good	
+2591	jumbo bland tasty tart	5	decent	
 2592	gray Knob Goblin lunchbox	0		
 2593	moldy bouncing Knob pasty	4	crappy	
 2594	drinkable thermos full of Knob coffee	3	good	
@@ -2586,11 +2586,11 @@
 2613	rocky raccoon	0		
 2614	yellow mojo filter	0		
 2615	spoiled savoy truffle	3	crappy	
-2616	narrow upside-down Magi-Wipes	0		
+2616	upside-down narrow Magi-Wipes	0		
 2617	boom	0		
 2618	chilly Iiti Kitty phone charm	0		Cold Damage: +5, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	bland bite-sized fuchsia unidentified jerky	1	decent	
+2620	bite-sized bland fuchsia unidentified jerky	1	decent	
 2621	asbestos-lined nasty rat mask of dire peril	0		Weapon Damage: +20, Hot Resistance: +5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	lime green shellacked arcane researcher's ratskin belt	0		Experience Percent (Mysticality): +10, Damage Reduction: 7, Single Equip
 2623	Lo Pan's savvy rattail whip	0		Mysticality Percent: +20, Spell Critical Percent: +30
@@ -2623,17 +2623,17 @@
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	decent shaking S.T.L.T.	4	good	Last Available: "2007-06"
-2653	decent enchanted upside-down honey-dew	4	good	Effect: "Sparkly!", Effect Duration: 20, Last Available: "2007-06"
-2654	acceptable watered-down Xanadian	2	good	Last Available: "2007-06"
+2653	enchanted decent upside-down honey-dew	4	good	Effect: "Sparkly!", Effect Duration: 20, Last Available: "2007-06"
+2654	watered-down acceptable Xanadian	2	good	Last Available: "2007-06"
 2655	aerosolized super-frozen bottle of absinthe	0		Effect: "Sweetened and Fattened", Effect Duration: 44, Last Available: "2007-06"
 2656	skewed asbestos-lined Drowsy Sword of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +5
 2657	moldy low-calorie escargotsicle	1	crappy	Last Available: "2007-06"
-2658	mediocre enchanted watered-down bottle of realpagne	2	decent	Effect: "Whippin' It Good", Effect Duration: 45, Last Available: "2007-06"
+2658	enchanted mediocre watered-down bottle of realpagne	2	decent	Effect: "Whippin' It Good", Effect Duration: 45, Last Available: "2007-06"
 2659	albatross necklace of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2007-06"
 2660	altered tumbling not-a-pipe	1	good	Last Available: "2007-06"
 2661	spirit-forward artisanal flask of Amontillado	5	EPIC	Last Available: "2007-06"
-2662	ball mask of Flo-Jo	0		Initiative: +100, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	Can-Can skirt of bravery	0		Spooky Resistance: +5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	ball mask of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	Can-Can skirt of bravery	0		Spooky Resistance: +5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	improved triple-polymerized sensitive poetry journal	0		Effect: "Weasels Underfoot", Effect Duration: 40, Last Available: "2007-06"
 2665	chilled bottled inspiration	0		Effect: "Cotton Mouthed", Effect Duration: 56, Last Available: "2007-06"
 2666	polymerized squat maroon bellhop bell	0		Effect: "Seeing Colors", Effect Duration: 49, Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	boiled olive twirling can-can-in-a-can	1		Last Available: "2007-06"
 2669	pickled teal patent antipsychotics	1		Last Available: "2007-06"
 2670	dehydrated Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	lousy enchanted shot of nepenthe schnapps	3	decent	Effect: "Muddled", Effect Duration: 50, Last Available: "2007-06"
+2671	enchanted lousy shot of nepenthe schnapps	3	decent	Effect: "Muddled", Effect Duration: 50, Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	energized quantum dry green bottle of cat tonic	0		Effect: "Pretending to Pretend", Effect Duration: 47, Last Available: "2007-06"
@@ -2699,7 +2699,7 @@
 2726	normal shaking juniper berries	3	good	
 2727	adequate plum	3	good	
 2728	tasty pear	4	awesome	
-2729	immense moldy peach	9	crappy	
+2729	moldy immense peach	9	crappy	
 2730	perfectly mixed plum wine	3	EPIC	
 2731	mediocre shot of pear schnapps	3	decent	
 2732	hand-crafted shot of peach schnapps	3	EPIC	
@@ -2707,13 +2707,13 @@
 2734	adequate brown sugar cane	3	good	
 2735	tiny spoiled sandwich of the gods	1	crappy	
 2736	mediocre boozy Pan-Dimensional Gargle Blaster	5	decent	
-2737	powdered wobbly skewed leopard-print barbell	1	decent	
+2737	powdered skewed wobbly leopard-print barbell	1	decent	
 2738	narrow pile of smoking rags	0		
-2739	altered narrow squat yellow ghostly panty raider camouflage	0		Effect: "Hombre Muerto Caminando", Effect Duration: 39
+2739	altered narrow squat ghostly yellow panty raider camouflage	0		Effect: "Hombre Muerto Caminando", Effect Duration: 39
 2740	Sinatra's groovy stylish Staff of the Walk-In Freezer	0		Moxie: +25, Moxie Percent: +10, Experience (Moxie): +5
 2741	perfectly mixed weak boilermaker	2	EPIC	
-2742	miniature stale enchanted steel lasagna	2	quest	Effect: "Floundering", Effect Duration: 45
-2743	lousy triple-distilled steel margarita	7	quest	
+2742	miniature enchanted stale steel lasagna	2	quest	Effect: "Floundering", Effect Duration: 45
+2743	triple-distilled lousy steel margarita	7	quest	
 2744	mixed steel-scented air freshener	1		
 2745	pickled alkaline extra-frozen fuchsia gremlin mutagen	0		Effect: "Concentrated Concentration", Effect Duration: 69
 2746	concentrated improved bouncing extra-potent gremlin mutagen	0		Effect: "Brain Freeze", Effect Duration: 11
@@ -2737,7 +2737,7 @@
 2764	chilly dance instructor's Order of the Silver Wossname of the early riser	0		Experience Percent (Moxie): +10, Cold Damage: +5, Adventures: +7, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	small flavorless Crimbo pie	2	decent	
+2767	flavorless small Crimbo pie	2	decent	
 2768	normal fuchsia pear tart	3	good	
 2769	moldy peach pie	4	crappy	
 2770	dry magnetized chunk of rock salt	0		Effect: "Cake Caked", Effect Duration: 14
@@ -2789,9 +2789,9 @@
 2816	forbidden baleful Boxers of incineration	0		Spell Damage: +25, Spell Damage Percent: +50, Hot Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep"
 2817	Van der Graaf supercool Rosewater's Brooch	0		Mysticality Percent: +30, Moxie Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2818	blurry Usain Bolt's stanky Bracelet of extreme caution	0		Monster Level: -25, Stench Spell Damage: +25, Initiative: +80, Single Equip
-2819	nasty Temple Grandin's Grimacite gasmask	0		Familiar Weight: +7, Stench Damage: +5, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	nasty Temple Grandin's Grimacite gasmask	0		Familiar Weight: +7, Stench Damage: +5, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	huge Grimacite gat of the scaredy-cat of temperance	0		Monster Level: -15, Sleaze Resistance: +5, Last Available: "2008-11"
-2821	inspector's educational Grimacite gaiters	0		Experience: +1, Item Drop: +15, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	inspector's educational Grimacite gaiters	0		Experience: +1, Item Drop: +15, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	gray Fonzie's educational Grimacite gauntlets	0		Experience: +1, Experience (Moxie): +1, Single Equip, Last Available: "2008-11"
 2823	quilted smartaleck's Grimacite go-go boots	0		Moxie Percent: +30, Damage Absorption: +40, Single Equip, Last Available: "2008-11"
 2824	double-paned Grimacite girdle of the ox	0		Muscle: +20, Cold Resistance: +5, Single Equip, Last Available: "2008-11"
@@ -2804,7 +2804,7 @@
 2831	pulsating star key lime	0		
 2832	big decent upside-down digital key lime pie	5	good	
 2833	flavorless narrow star key lime pie	3	decent	
-2834	tumbling Jack Frost's frosty bottle-rocket crossbow of terror	0		Cold Spell Damage: 60, Spooky Spell Damage: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	tumbling Jack Frost's frosty bottle-rocket crossbow of terror	0		Cold Spell Damage: 60, Spooky Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	shaking weightlifter's indie comic hipster glasses	0		Muscle: +15, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
@@ -2910,12 +2910,12 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	adequate immense Surprise Egg	9	good	
+2940	immense adequate Surprise Egg	9	good	
 2941	polymerized olive Steal This Candy	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 41
 2942	quadruple-ionized flattened chocolate filthy lucre	0		Effect: "Sweet Nostalgia", Effect Duration: 66
 2943	irradiated narrow Angry Farmer's Wife Candy	0		Effect: "Pork Power", Effect Duration: 13
 2945	executive party hat of temperance	0		Sleaze Resistance: +5, Meat Drop: +40, Familiar Effect: "4xLep, cap 7"
-2946	chilly Socratic V for Vivala mask	0		Experience (Mysticality): +1, Cold Damage: +5, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	chilly Socratic V for Vivala mask	0		Experience (Mysticality): +1, Cold Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	wobbly The Big Book of Pirate Insults	0		
 2948	lousy ghostly shot of rotgut	3	decent	
 2949	anodized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Rat-Faced", Effect Duration: 27
@@ -2927,11 +2927,11 @@
 2955	rotten small teal yam candy	2	crappy	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	flavorless fancy squat tube of cranberry Go-Goo	3	decent	Effect: "Updated", Effect Duration: 30
+2958	fancy flavorless squat tube of cranberry Go-Goo	3	decent	Effect: "Updated", Effect Duration: 30
 2959	twirling rum barrel charrrm bracelet of temperance	0		Sleaze Resistance: +5
 2960	bland mirror single-serving herbal stuffing	3	decent	
-2961	small bland packet of tofurkey gravy	2	decent	
-2962	snack-sized tasty tofurkey nugget	2	awesome	
+2961	bland small packet of tofurkey gravy	2	decent	
+2962	tasty snack-sized tofurkey nugget	2	awesome	
 2963	bouncing rigging shampoo	0		
 2964	ball polish	0		
 2965	blue mizzenmast mop	0		
@@ -2945,10 +2945,10 @@
 2973	deadly grumpy man charrrm bracelet	0		Weapon Damage: +5, Single Equip
 2974	jittery tarrrnish charrrm	0		
 2975	narrow wool scorching tarrrnished charrrm bracelet	0		Hot Damage: +25, Cold Resistance: +1, Single Equip
-2976	mediocre weak bilge wine	2	decent	
+2976	weak mediocre bilge wine	2	decent	
 2977	avaricious witty rapier	0		Meat Drop: +30
 2978	pulsating huge Usain Bolt's Van der Graaf yohohoyo	0		Initiative: +80, MP Regen Min: 5, MP Regen Max: 7
-2979	Vulcanized concentrated dry bouncing blinking yellow fish-liver oil	0		Effect: "Memories of Puppy Love", Effect Duration: 11
+2979	Vulcanized concentrated dry blinking yellow bouncing fish-liver oil	0		Effect: "Memories of Puppy Love", Effect Duration: 11
 2980	booty chest charrrm	0		
 2981	veiny booty chest charrrm bracelet	0		Maximum HP: +10, Single Equip
 2982	cannonball charrrm	0		
@@ -2962,7 +2962,7 @@
 2990	Jim Carey's chaotic clingfilm cap	0		Spell Critical Percent: +10, Monster Level: +25, Familiar Effect: "1xVolley, cap 37"
 2991	maroon arcane researcher's clingfilm slippers	0		Experience Percent (Mysticality): +10, Single Equip
 2992	twirling clingfilm tangle	0		
-2993	immense flavorless pulsating vinegar-soaked lemon slice	8	decent	
+2993	flavorless immense pulsating vinegar-soaked lemon slice	8	decent	
 2994	oxidized moist true grit	0		Effect: "Danish Cunning", Effect Duration: 18
 2995	wobbly therapeutic savvy buoybottoms of Flo-Jo	0		Mysticality Percent: +20, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	hardened grungy flannel shirt	0		Damage Reduction: 3
@@ -2994,11 +2994,11 @@
 3022	medium stone triangle	0		
 3023	lime green small stone triangle	0		
 3024	stone pyramid	0		
-3025	practically non-alcoholic lousy corpse on the beach	1	decent	
+3025	lousy practically non-alcoholic corpse on the beach	1	decent	
 3026	artisanal distilled mirror corpsetini	5	EPIC	
 3027	bad corpsedriver	4	decent	
 3028	watered-down acceptable blinking Corpse Island iced tea	2	good	
-3029	spirit-forward mediocre red-headed corpse	5	decent	
+3029	mediocre spirit-forward red-headed corpse	5	decent	
 3030	perfectly mixed kamicorpse-ee	3	EPIC	
 3031	bad corpsel	3	decent	
 3032	enchanted hand-crafted squat corpsebite	4	EPIC	Effect: "Ancestral Disapproval", Effect Duration: 5
@@ -3006,16 +3006,16 @@
 3034	wobbly piece of thirteen	0		
 3035	spoiled huge spinning pearl onion	6	crappy	
 3036	moldy sea biscuit	3	crappy	
-3037	drinkable practically non-alcoholic bottle of rum	1	good	
+3037	practically non-alcoholic drinkable bottle of rum	1	good	
 3038	tolerable bottle of black-label rum	3	good	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	squat joke scroll	0		
 3042	narrow Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	huge normal nanite-infested gingerbread bugbear	6	good	Last Available: "2007-12"
-3046	spoiled low-calorie nanite-infested candy cane	1	crappy	Last Available: "2020-09"
+3046	low-calorie spoiled nanite-infested candy cane	1	crappy	Last Available: "2020-09"
 3047	miniature rotten nanite-infested fruitcake	2	crappy	Last Available: "2007-12"
 3048	watered-down hand-crafted teal blinking nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
@@ -3025,7 +3025,7 @@
 3053	narrow mood ring	0		Last Available: "2007-02"
 3054	deionized flattened deionized pulsating candy heart	0		Effect: "Bonelording", Effect Duration: 64, Last Available: "2007-02"
 3055	triple-deionized extra-electrified cymbal syrup	0		Free Pull, Effect: "Ginger Snapped", Effect Duration: 18, Last Available: "2007-02"
-3056	Jim Carey's metallic foil cat ears	0		Monster Level: +25, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	Jim Carey's metallic foil cat ears	0		Monster Level: +25, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	squat kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	twirling teddy borg	0		Last Available: "2007-12"
 3081	sage marionette collective	0		Mysticality Percent: +10, Last Available: "2007-12"
 3082	teal monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	double-paned sharpshooter's roboduck-on-a-string	0		Critical Hit Percent: +10, Cold Resistance: +5, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	shaking Jim Carey's biomechanical crimborg helmet of the overflowing toilet	0		Monster Level: +25, Stench Spell Damage: +50, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	shaking Jim Carey's biomechanical crimborg helmet of the overflowing toilet	0		Monster Level: +25, Stench Spell Damage: +50, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	spinning family-friendly Jeselnik's C.B.F.G.	0		Sleaze Damage: +25, Sleaze Resistance: +1, Last Available: "2007-12"
-3090	ghostly Van der Graaf arcane researcher's biomechanical crimborg leg armor	0		Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	ghostly Van der Graaf arcane researcher's biomechanical crimborg leg armor	0		Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	moist modified non-improved spinning vitachoconutriment capsule	0		Effect: "Pyramid Power", Effect Duration: 30, Last Available: "2007-12"
 3092	squat knitted handmade hobby horse	0		Cold Resistance: +3, Last Available: "2007-12"
 3093	padded ball-in-a-cup	0		Damage Absorption: +20, Last Available: "2007-12"
@@ -3071,7 +3071,7 @@
 3099	ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	tumbling twirling rogue swarmer	0		Last Available: "2007-12"
-3102	lime green skewed sawblade fragment	0		Last Available: "2007-12"
+3102	skewed lime green sawblade fragment	0		Last Available: "2007-12"
 3103	tumbling unstable laser battery	0		Last Available: "2007-12"
 3104	lime green scandalous beefcake's vibrating cyborg knife	0		Muscle: +25, Sleaze Damage: +5, Last Available: "2007-12"
 3105	MacGyver's clever immense cyborg hand	0		Maximum MP: 120, Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	shaking divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	massive spoiled roasted marshmallow	9	crappy	
 3130	disc	0		Last Available: "2008-01"
-3131	enchanted flavorless tin cup of mulligan stew	3	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 15
+3131	flavorless enchanted tin cup of mulligan stew	3	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 15
 3132	double-paned flame-wreathed flamin' bindle	0		Hot Spell Damage: +10, Cold Resistance: +5
 3133	blinking cyan Jim Carey's thinker's freezin' bindle	0		Mysticality: +10, Monster Level: +25
 3134	Rosewater's slick stinkin' bindle	0		Moxie: +10, Mysticality Percent: +30
@@ -3126,7 +3126,7 @@
 3154	El Vibrato punchcard (182 holes)	0		
 3155	El Vibrato punchcard (176 holes)	0		
 3156	El Vibrato punchcard (104 holes)	0		
-3157	shaking mirror El Vibrato drone	0		
+3157	mirror shaking El Vibrato drone	0		
 3158	sparking El Vibrato drone	0		
 3159	quantum dry upside-down warm El Vibrato drone	0		Effect: "20-20 Second Sight", Effect Duration: 58
 3160	super-diffused nitrogenated humming El Vibrato drone	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 58
@@ -3154,7 +3154,7 @@
 3182	improved unsweetened maroon evil libation of liveliness	0		Effect: "Hobo Flavor", Effect Duration: 42
 3183	super-dry evil tomato juice of powerful power	0		Effect: "Pockets of Fire", Effect Duration: 66
 3184	aerosolized blue evil eyedrops of the ermine	0		Effect: "All Is Forgiven", Effect Duration: 33
-3185	vacuum-sealed squat blinking evil ointment of the occult	0		Effect: "Cockroach Scurry", Effect Duration: 63
+3185	vacuum-sealed blinking squat evil ointment of the occult	0		Effect: "Cockroach Scurry", Effect Duration: 63
 3186	corrupted twirling twirling evil serum of sarcasm	0		Effect: "Riboflavin'", Effect Duration: 43
 3187	super-galvanized evil philter of phorce	0		Effect: "Human-Constellation Hybrid", Effect Duration: 32
 3188	mediocre an evil sump'm sump'm	4	decent	
@@ -3162,12 +3162,12 @@
 3190	hand-crafted evil horizontal tango	4	EPIC	
 3191	perfectly mixed shaking teal evil roll in the hay	3	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
-3193	huge yellow naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
+3193	yellow huge naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	bouncing origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	coward's origami pasties	0		Monster Level: -20, Softcore Only, Last Available: "2008-02"
 3197	censurious fireproof slick origami riding crop	0		Moxie: +10, Hot Resistance: +3, Sleaze Resistance: +3, Softcore Only, Last Available: "2008-02"
-3198	blinking wobbly El Vibrato trapezoid	0		
+3198	wobbly blinking El Vibrato trapezoid	0		
 3199	lump of coal	0		
 3200	upside-down wobbly lump of diamond	0		
 3201	twirling thick padded envelope	0		
@@ -3194,10 +3194,10 @@
 3222	executive flame-retardant gatorskin umbrella	0		Hot Resistance: +1, Meat Drop: +40
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	bad spirit-forward enchanted bottle of sewage schnapps	5	decent	Effect: "Slightly Larger Than Usual", Effect Duration: 45
+3225	enchanted spirit-forward bad bottle of sewage schnapps	5	decent	Effect: "Slightly Larger Than Usual", Effect Duration: 45
 3226	mediocre mirror bottle of Ooze-O	3	decent	
 3227	adequate C.H.U.M. chum	4	good	
-3228	half-sized normal squat unfortunate dumplings	2	good	
+3228	normal half-sized squat unfortunate dumplings	2	good	
 3229	decaying goldfish liver	0		
 3230	irradiated oil of oiliness	0		Effect: "Wreathed in Smoke", Effect Duration: 33
 3231	blurry grievous tattered paper crown	0		Weapon Damage Percent: +50, Familiar Effect: "1xSombrero, cap 15"
@@ -3232,7 +3232,7 @@
 3260	yellow therapeutic Socratic Samson's Chester's moustache	0		Experience (Muscle): +5, Experience (Mysticality): +1, HP Regen Min: 5, HP Regen Max: 7, Class: "Disco Bandit", Single Equip
 3261	narrow miser's experienced Chester's bag of candy	0		Experience: +2, Meat Drop: +10, Class: "Disco Bandit"
 3262	shaking arcane researcher's Chester's cutoffs of courage	0		Experience Percent (Mysticality): +10, Spooky Resistance: +3, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3273,7 +3273,7 @@
 3301	jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
-3304	shaking wobbly Argarggagarg's fang	0		
+3304	wobbly shaking Argarggagarg's fang	0		
 3305	Safari Jack's moustache	0		
 3306	Yakisoba's hat	0		
 3307	blue Heimandatz's heart	0		
@@ -3291,12 +3291,12 @@
 3319	ghostly gray greasy Mr. Joe's bangles	0		Sleaze Spell Damage: +10, Single Equip
 3320	stiffened frayed rope belt	0		Damage Reduction: 1, Single Equip
 3321	olive packet of mayfly bait	0		Last Available: "2008-05"
-3322	asbestos-lined razor-sharp mayfly bait necklace	0		Weapon Damage Percent: +25, Hot Resistance: +5, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	asbestos-lined razor-sharp mayfly bait necklace	0		Weapon Damage Percent: +25, Hot Resistance: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	perfectly mixed irresponsibly strong jar of fermented pickle juice	7	EPIC	
 3326	vaporized blurry cyan voodoo snuff	1	EPIC	Effect: "Cold, Dead Hands", Effect Duration: 50
-3327	normal fancy extra-greasy slider	4	good	Effect: "Feline Ferocity", Effect Duration: 30
+3327	fancy normal extra-greasy slider	4	good	Effect: "Feline Ferocity", Effect Duration: 30
 3328	padded experienced crumpled felt fedora	0		Experience: +2, Damage Absorption: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	skewed Da Vinci's thinker's battered top-hat	0		Mysticality: +10, Experience (Mysticality): +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	manspreader's shapeless wide-brimmed hat of bravery	0		Monster Level: +10, Spooky Resistance: +5, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3333,7 +3333,7 @@
 3361	blinking yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	decent mole mol&eacute;	4	good	Last Available: "2008-06"
-3364	enchanted watered-down acceptable purple Morlock's Mark Bourbon	2	good	Effect: "Gummiskin", Effect Duration: 10, Last Available: "2008-06"
+3364	acceptable watered-down enchanted purple Morlock's Mark Bourbon	2	good	Effect: "Gummiskin", Effect Duration: 10, Last Available: "2008-06"
 3365	deionized spinning Climate Colada	0		Effect: "Hustlin'", Effect Duration: 48, Last Available: "2008-06"
 3366	modified digital underground potion	0		Effect: "Chalky White Pallor", Effect Duration: 11, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3386,9 +3386,9 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	blurry mirror Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	twirling box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	twirling box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	diffused sterno-flavored Hob-O	0		Effect: "Crusty Head", Effect Duration: 52
-3423	frozen super-enhanced ghostly bouncing frostbite-flavored Hob-O	0		Effect: "Cat Class, Cat Style", Effect Duration: 40
+3423	frozen super-enhanced bouncing ghostly frostbite-flavored Hob-O	0		Effect: "Cat Class, Cat Style", Effect Duration: 40
 3424	unsweetened irradiated olive fry-oil-flavored Hob-O	0		Effect: "Slimily Sagacious", Effect Duration: 47
 3425	frozen spinning garbage-juice-flavored Hob-O	0		Effect: "Jingle Jangle Jingle", Effect Duration: 15
 3426	Vulcanized jittery strawberry-flavored Hob-O	0		Effect: "Heal Thy Nanoself", Effect Duration: 25
@@ -3404,7 +3404,7 @@
 3437	lard-coated mansplainer's wicked Staff of the Black Kettle	0		Spell Damage: +5, Monster Level: +15, Sleaze Spell Damage: +25
 3438	supercharged supercool slick Staff of the Well-Tempered Cauldron	0		Moxie: +10, Moxie Percent: +20, Maximum MP Percent: +30
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	compressed purple bouncing skewed prismatic wad	1	decent	Last Available: "2008-07"
+3440	compressed skewed purple bouncing prismatic wad	1	decent	Last Available: "2008-07"
 3441	club of the five seasons of the pedagogue	0		Experience: +3, Last Available: "2008-07"
 3442	beefcake's rainbow crossbow	0		Muscle: +25, Last Available: "2008-07"
 3443	huge kitten	0		
@@ -3425,12 +3425,12 @@
 3458	cold-filtered tumbling STYX deodorant body spray	0		Effect: "Hangdog", Effect Duration: 15
 3459	boozy perfectly mixed red white-label gin	5	EPIC	
 3460	flavorless tin rations	3	decent	
-3461	shaking narrow haiku challenge map	0		
+3461	narrow shaking haiku challenge map	0		
 3462	terrible poem	0		
 3463	aged bouncing bottle of sake	3	awesome	
 3464	veiny round pebble	0		Maximum HP: +10
 3465	decent Bash-&#332;s cereal	3	good	Wiki Name: "Bash-Os cereal"
-3466	asbestos-lined brawny thinker's haiku katana	0		Mysticality: +10, Muscle Percent: +20, Hot Resistance: +5, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	asbestos-lined brawny thinker's haiku katana	0		Mysticality: +10, Muscle Percent: +20, Hot Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	huge veiny plastic baby	0		Maximum HP: +10, Single Equip, Last Available: "2008-12"
 3469	normal blueberry-frosted king cake	4	good	Last Available: "2008-12"
@@ -3444,7 +3444,7 @@
 3477	corrupted super-Vulcanized huge pear lozenge	0		Effect: "Cold Jellied", Effect Duration: 16
 3478	oxidized huge peach lozenge	0		Effect: "Flaming Weapon", Effect Duration: 31
 3479	olive balloon shield	0		Damage Reduction: 3
-3480	skewed tumbling purple spot	0		
+3480	tumbling purple skewed spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
@@ -3455,23 +3455,23 @@
 3488	pristine fish scale	0		
 3489	flavorless small beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3490	bland low-calorie ghostly glistening fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
-3491	normal huge tumbling slick fish meat	8	good	Effect: "Fishy", Effect Duration: 5
+3491	huge normal tumbling slick fish meat	8	good	Effect: "Fishy", Effect Duration: 5
 3492	fireproof fish scimitar of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3
 3493	nippy fish stick of the sewer	0		Cold Damage: +10, Stench Damage: +25
 3494	rosewater-soaked Van der Graaf fish bazooka	0		Stench Resistance: +3, MP Regen Min: 5, MP Regen Max: 7
-3495	super-Vulcanized boiled blinking shaking blue sea salt crystal	0		Effect: "Jacked In", Effect Duration: 14
+3495	super-Vulcanized boiled blue blinking shaking sea salt crystal	0		Effect: "Jacked In", Effect Duration: 14
 3496	extra-pressed bazookafish bubble gum	0		Effect: "Boon of She-Who-Was", Effect Duration: 47
-3497	artisanal weak bottle of Pete's Sake	2	EPIC	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	maroon beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3497	weak artisanal bottle of Pete's Sake	2	EPIC	
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	maroon beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	flavorless miniature canap&eacute;s	2	decent	
 3502	diluted thermos of brew	1	awesome	Last Available: "2011-12"
 3503	weak smooth bouncing glass of brandy	2	awesome	Last Available: "2011-12"
 3504	French slippers	0		
 3505	hardened LWA ring	0		Damage Reduction: 3
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	wobbly Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	wobbly Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	scratch 'n' sniff sword of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3494,7 +3494,7 @@
 3527	narrow mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
 3529	mutant cactus bud	0		
-3530	squat jittery mutant gila monster egg	0		
+3530	jittery squat mutant gila monster egg	0		
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	fuchsia cactus monocle	0		Familiar Weight: +5
@@ -3504,14 +3504,14 @@
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	mirror plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	squat plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
-3540	skewed spinning plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
-3541	blurry green upside-down plans for depleted Grimacite astrolabe	0		Recipe: "depleted Grimacite astrolabe"
+3540	spinning skewed plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
+3541	green upside-down blurry plans for depleted Grimacite astrolabe	0		Recipe: "depleted Grimacite astrolabe"
 3542	Temple Grandin's depleted Grimacite hammer	0		Familiar Weight: +7, Last Available: "2011-12"
 3543	dance instructor's depleted Grimacite gravy boat of doom	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +50, Last Available: "2011-12"
 3544	wobbly flame-retardant Jack Frost's depleted Grimacite weightlifting belt	0		Cold Spell Damage: +50, Hot Resistance: +1, Single Equip, Last Available: "2011-12"
 3545	Oprah's depleted Grimacite grappling hook of the scaredy-cat	0		Maximum MP Percent: +50, Monster Level: -15, Single Equip, Last Available: "2011-12"
-3546	lard-coated brawny depleted Grimacite ninja mask	0		Muscle Percent: +20, Sleaze Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	Annie Oakley's depleted Grimacite shinguards of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	lard-coated brawny depleted Grimacite ninja mask	0		Muscle Percent: +20, Sleaze Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	Annie Oakley's depleted Grimacite shinguards of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	tumbling depleted Grimacite astrolabe of Leguizamo of the early riser	0		Monster Level: +20, Adventures: +7, Single Equip, Last Available: "2011-12"
 3549	supercool KoL Con Cinco Pi&ntilde;ata Bat of wisdom	0		Mysticality: +15, Moxie Percent: +20, Softcore Only, Last Available: "2008-09"
 3550	lime green propeller beanie of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, cap 7"
@@ -3521,7 +3521,7 @@
 3554	glob of slime	0		
 3555	normal immense sea carrot	6	good	
 3556	immense toothsome sea cucumber	9	awesome	
-3557	tasty small sea avocado	2	awesome	
+3557	small tasty sea avocado	2	awesome	
 3558	moldy sea lychee	4	crappy	
 3559	spoiled green sea tangelo	3	crappy	
 3560	rotten sea honeydew	4	crappy	
@@ -3546,10 +3546,10 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	mirror sushi-rolling mat	0		
-3582	moldy snack-sized red rice	2	crappy	
+3582	snack-sized moldy red rice	2	crappy	
 3584	normal irradiated candy cane	3	good	Last Available: "2008-12"
 3585	rotten gingerbread mutant bugbear	3	crappy	Last Available: "2008-12"
-3586	acceptable triple-distilled oozenog	8	good	Last Available: "2008-12"
+3586	triple-distilled acceptable oozenog	8	good	Last Available: "2008-12"
 3587	deionized sugar plum	0		Effect: "Dexteri Tea", Effect Duration: 18, Last Available: "2008-12"
 3588	magnetized bouncing sugar banana	0		Effect: "Ichorous Intensity", Effect Duration: 59, Last Available: "2008-12"
 3589	improved shaking sugar lime	0		Effect: "Spell Transfer Complete", Effect Duration: 16, Last Available: "2008-12"
@@ -3566,30 +3566,30 @@
 3600	blurry deadly speargun of chilblains	0		Weapon Damage: +5, Cold Damage: +25
 3601	narrow compass of the wise owl	0		Mysticality: +20
 3602	broken diving helmet	0		
-3603	maroon bouncing porthole	0		
+3603	bouncing maroon porthole	0		
 3604	rivet	0		
 3605	bouncing bubblin' stone	0		
 3606	tumbling stanky banded baleful diving helmet	0		Spell Damage: +25, Damage Absorption: +100, Stench Spell Damage: +25, Familiar Effect: "0.5xPotato"
 3607	yellow greedy ruddy aerated diving helmet of the blizzard	0		Maximum HP Percent: +40, Cold Spell Damage: +25, Meat Drop: +20, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	live nautical mine	0		
-3609	blue ghostly das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
+3609	ghostly blue das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	pulsating imitation whetstone	0		
 3611	frozen alkaline sea grease	0		Effect: "The Two-Prong Crown", Effect Duration: 24
 3612	sturdy Crimbo crate	0		Last Available: "2008-12"
-3613	cyan bouncing mirror battered Crimbo Crate	0		Last Available: "2008-12"
+3613	mirror cyan bouncing battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	flattened ionized unstable DNA	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 27, Last Available: "2008-12"
-3618	huge The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	huge The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	skewed lion tamer's parasitic claw	0		Experience (familiar): +2, Last Available: "2008-12"
-3625	ghostly arcane researcher's parasitic tentacles	0		Experience Percent (Mysticality): +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	ghostly Rosewater's parasitic headgnawer	0		Mysticality Percent: +30, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	ghostly arcane researcher's parasitic tentacles	0		Experience Percent (Mysticality): +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	ghostly Rosewater's parasitic headgnawer	0		Mysticality Percent: +30, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	squat blinking parasitic strangleworm of the businessman	0		Meat Drop: +50, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	twirling radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	mirror knitted elven socks of the wise owl	0		Mysticality: +20, Cold Resistance: +3, Last Available: "2008-12"
 3634	skewed rosewater-soaked asbestos-lined elven gloves	0		Hot Resistance: +5, Stench Resistance: +3, Last Available: "2008-12"
-3635	sage festive holiday hat of doom	0		Mysticality Percent: +10, Spooky Spell Damage: +50, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	sage festive holiday hat of doom	0		Mysticality Percent: +10, Spooky Spell Damage: +50, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	squat hardy patent shoes of temperance	0		Maximum HP: +50, Sleaze Resistance: +5, Last Available: "2008-12"
 3637	knitted slick gray bow tie	0		Moxie: +10, Cold Resistance: +3, Last Available: "2008-12"
 3638	therapeutic forbidden penguin thesaurus	0		Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-12"
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	normal toast with jam	4	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	lousy triple-distilled elven moonshine	7	decent	Last Available: "2008-12"
-3653	bland knuckle sandwich	3	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	bland knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	Usain Bolt's psycho sweater of the glutton	0		Food Drop: +100, Initiative: +80, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	experienced plastic Mob Penguin	0		Experience: +2, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	dangerous plastic strand of DNA	0		Weapon Damage: +10, Last Available: "2008-12"
 3660	twirling baleful plastic chunk of depleted Grimacite	0		Spell Damage: +25, Last Available: "2008-12"
 3661	fuchsia container of Putty	0		Last Available: "2009-01"
-3662	skewed spinning rosewater-soaked Putty mitre	0		Stench Resistance: +3, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	vibrating ruddy Putty leotard	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	skewed spinning rosewater-soaked Putty mitre	0		Stench Resistance: +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	vibrating ruddy Putty leotard	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	shaking Putty ball of Calamity Jane	0		Critical Hit Percent: +15, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	yellow blinking Van der Graaf clever supercharged Putty snake	0		Maximum MP Percent: +30, Maximum MP: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2009-01"
@@ -3635,7 +3635,7 @@
 3669	bouncing skewed greasy glow-in-the-dark dart gun	0		Sleaze Spell Damage: +10, Last Available: "2009-01"
 3670	twirling glow-in-the-dark burrowgrub of the brute	0		Muscle Percent: +30, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	moldy small can of franks 'n' beans	2	crappy	Last Available: "2010-12"
+3672	small moldy can of franks 'n' beans	2	crappy	Last Available: "2010-12"
 3673	smooth fancy bottle of peppermint schnapps	3	awesome	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 10, Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3647,13 +3647,13 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	flavorless huge tempura carrot	8	decent	
+3684	huge flavorless tempura carrot	8	decent	
 3685	decent shaking tempura cucumber	4	good	
 3686	rotten tempura avocado	3	crappy	
-3687	decent half-sized jittery sea broccoli	2	good	
+3687	half-sized decent jittery sea broccoli	2	good	
 3688	moldy sea cauliflower	4	crappy	
-3689	huge bland lime green tempura broccoli	9	decent	
-3690	moldy miniature cyan tempura cauliflower	2	crappy	
+3689	bland huge lime green tempura broccoli	9	decent	
+3690	miniature moldy cyan tempura cauliflower	2	crappy	
 3691	flavorless thick upside-down sea blueberry	5	decent	
 3692	rotten miniature sea persimmon	2	crappy	
 3693	concentrated twirling pressurized potion of perception	0		Effect: "Slimily Speedy", Effect Duration: 43
@@ -3661,7 +3661,7 @@
 3695	Van der Graaf Mer-kin digpick	0		MP Regen Min: 5, MP Regen Max: 7
 3696	upside-down anemone nematocyst	0		
 3697	fuchsia high-pressure seltzer bottle	0		
-3698	maroon bouncing velcro ore	0		
+3698	bouncing maroon velcro ore	0		
 3699	upside-down teflon ore	0		
 3700	vinyl ore	0		
 3701	map to Anemone Mine	0		
@@ -3714,25 +3714,25 @@
 3749	triple-adjusted concoction of clumsiness	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 46
 3750	resourceful vampire pearl earring	0		Maximum MP: +50, Single Equip
 3751	moldy chocolate chip brownies	3	crappy	
-3753	mirror Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	mirror Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	electrified love song of vague ambiguity	0		Effect: "Heart of White", Effect Duration: 37, Last Available: "2009-02"
 3755	polymerized love song of smoldering passion	0		Effect: "Wintry Breath", Effect Duration: 65, Last Available: "2009-02"
 3756	Vulcanized love song of icy revenge	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 13, Last Available: "2009-02"
 3757	deionized moist ionized blinking love song of sugary cuteness	0		Effect: "Sticky Hands", Effect Duration: 12, Last Available: "2009-02"
-3758	colloidal blurry olive love song of disturbing obsession	0		Effect: "Executive Greed", Effect Duration: 16, Last Available: "2009-02"
+3758	colloidal olive blurry love song of disturbing obsession	0		Effect: "Executive Greed", Effect Duration: 16, Last Available: "2009-02"
 3759	concentrated extra-quantum love song of naughty innuendo	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 18, Last Available: "2009-02"
 3760	altered ionized breath mint	0		Effect: "In the Limelight", Effect Duration: 32
 3761	arcane researcher's vampire pearl ring	0		Experience Percent (Mysticality): +10, Single Equip
 3762	twirling sharpshooter's vampire pearl necklace	0		Critical Hit Percent: +10, Single Equip
-3763	practically non-alcoholic hand-crafted ghostly slug of vodka	1	EPIC	
+3763	hand-crafted practically non-alcoholic ghostly slug of vodka	1	EPIC	
 3764	drinkable spinning blinking slug of rum	4	good	
-3765	practically non-alcoholic artisanal mirror slug of shochu	1	EPIC	
+3765	artisanal practically non-alcoholic mirror slug of shochu	1	EPIC	
 3766	lousy watered-down screwdiver	2	decent	
 3767	bad dew yoana lei	4	decent	
 3768	tolerable lychee chuhai	3	good	
 3769	tolerable salacious screwdiver	4	good	
 3770	mediocre purple jittery dew yoana salacious lei	3	decent	
-3771	tolerable blurry cyan salacious lychee chuhai	3	good	
+3771	tolerable cyan blurry salacious lychee chuhai	3	good	
 3772	boozy perfectly mixed Alewife&trade; Ale	5	EPIC	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
@@ -3747,8 +3747,8 @@
 3783	compressed upside-down bottle of extra-strength melodramamine	1		
 3784	paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
-3786	jittery cyan vampire glitter	0		Class: "Pastamancer"
-3787	jittery twirling wine-soaked bone chips	0		Class: "Pastamancer"
+3786	cyan jittery vampire glitter	0		Class: "Pastamancer"
+3787	twirling jittery wine-soaked bone chips	0		Class: "Pastamancer"
 3788	crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
@@ -3766,7 +3766,7 @@
 3811	Mer-kin stashbox	0		
 3812	flavorless chocolate-frosted king cake	3	decent	Last Available: "2009-06"
 3813	mansplainer's plastic baby	0		Monster Level: +15, Single Equip, Last Available: "2009-06"
-3815	squat jittery midget clownfish	0		
+3815	jittery squat midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
 3817	super-sized rotten sea radish	5	crappy	
 3818	padded grievous groovy halibut	0		Moxie Percent: +10, Weapon Damage Percent: +50, Damage Absorption: +20
@@ -3778,16 +3778,16 @@
 3824	skewed Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	Grandma's Chartreuse Yarn	0		
-3827	maroon blinking plastic oyster egg	0		
+3827	blinking maroon plastic oyster egg	0		
 3828	Grandma's Map	0		
 3829	massive moldy spinning tempura radish	7	crappy	
 3830	deadly water-polo cap	0		Weapon Damage: +5, Familiar Effect: "1xVolley, 1xBarrr"
-3831	high-proof acceptable pulsating mirror Typical Tavern swill	8	good	
-3832	artisanal practically non-alcoholic tropical swill	1	super ultra mega turbo EPIC	
+3831	high-proof acceptable mirror pulsating Typical Tavern swill	8	good	
+3832	practically non-alcoholic artisanal tropical swill	1	super ultra mega turbo EPIC	
 3833	drinkable gray fruity girl swill	3	good	
-3834	lousy high-proof blended swill	9	decent	
+3834	high-proof lousy blended swill	9	decent	
 3835	costume wardrobe	0		Softcore Only
-3836	ribald Jack Frost's wicked smooth Elvish sunglasses	0		Moxie: +15, Spell Damage: +5, Cold Spell Damage: +50, Sleaze Damage: +10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	ribald Jack Frost's wicked smooth Elvish sunglasses	0		Moxie: +15, Spell Damage: +5, Cold Spell Damage: +50, Sleaze Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	anniversary safety glass vest of the businessman	0		Meat Drop: +50
 3838	flame-retardant anniversary burlap belt	0		Hot Resistance: +1
 3839	yellow anniversary balsa wood socks of the sewer	0		Stench Damage: +25
@@ -3862,8 +3862,8 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	blurry imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	artisanal spirit-forward fancy blended swill with a fly in it	5	EPIC	Effect: "Yuletide Mutations", Effect Duration: 25
-3914	shaking wobbly turtle wax	0		
+3913	spirit-forward artisanal fancy blended swill with a fly in it	5	EPIC	Effect: "Yuletide Mutations", Effect Duration: 25
+3914	wobbly shaking turtle wax	0		
 3915	twirling wholesome turtle wax shield	0		Maximum HP Percent: +10, Damage Reduction: 2
 3916	cyan turtle wax helmet of doom	0		Spooky Spell Damage: +50, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
 3917	squat turtle wax greaves of the detective	0		Item Drop: +20, Familiar Effect: "atk, 3xBarrr, cap 10"
@@ -3883,7 +3883,7 @@
 3931	miser's severed flipper of the sewer	0		Stench Damage: +25, Meat Drop: +10, Class: "Seal Clubber"
 3932	fuchsia ingot of seal-iron	0		
 3933	fuchsia bad-ass club of the ox of the businessman	0		Muscle: +20, Meat Drop: +50, Class: "Seal Clubber"
-3934	spinning maroon sealbone	0		
+3934	maroon spinning sealbone	0		
 3935	nitrogenated hyperinflated seal lung	0		Effect: "Super Skill", Effect Duration: 12
 3936	galvanized ionized scrap of shadow	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 29
 3937	cold-filtered fustulent seal grulch	0		Effect: "Petit Force", Effect Duration: 41
@@ -3905,14 +3905,14 @@
 3953	mink	0		
 3954	teddy butler	0		
 3955	narrow martini	0		
-3956	upside-down huge crazy bastard sword	0		
+3956	huge upside-down crazy bastard sword	0		
 3957	tin of caviar	0		
 3958	dance instructor's bejeweled cufflinks	0		Experience Percent (Moxie): +10, Single Equip
 3959	spinning huge censurious garish pinky ring	0		Sleaze Resistance: +3
 3960	designer sunglasses of the blizzard	0		Cold Spell Damage: +25, Single Equip
 3961	wobbly squat stanky weightlifter's opera glasses	0		Muscle: +15, Stench Spell Damage: +25
 3962	designer handbag	0		
-3963	teal wobbly Clan pool table	0		Free Pull, Last Available: "2009-05"
+3963	wobbly teal Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	red cell phone	0		Familiar Weight: +10
 3965	concentrated alkaline blurry cube of billiard chalk	0		Effect: "Mer-kinny Flavor", Effect Duration: 35
 3966	zippy sinister hot-ass club of the early riser	0		Spell Damage: +10, Initiative: +20, Adventures: +7, Class: "Seal Clubber"
@@ -3922,7 +3922,7 @@
 3970	family-friendly healthy Abyssal ember	0		Maximum HP Percent: +20, Sleaze Resistance: +1, Class: "Seal Clubber"
 3971	quadruple-aerosolized activated frost-rimed seal hide	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 14
 3972	tumbling seal spine of the blizzard of courage	0		Cold Spell Damage: +25, Spooky Resistance: +3, Class: "Seal Clubber"
-3973	concentrated enhanced wobbly yellow seal lube	0		Effect: "Izchak's Blessing", Effect Duration: 56
+3973	concentrated enhanced yellow wobbly seal lube	0		Effect: "Izchak's Blessing", Effect Duration: 56
 3974	reassuring friendly mannequin leg	0		Familiar Weight: +3, Spooky Resistance: +1, Class: "Seal Clubber"
 3975	fuchsia huge reassuring padded tortoise of chilblains	0		Cold Damage: +25, Spooky Resistance: +1, Damage Reduction: 6
 3976	wobbly veiny brawny tortoboggan	0		Muscle Percent: +20, Maximum HP: +10, Single Equip
@@ -3935,7 +3935,7 @@
 3983	skewed dueling turtle	0		
 3984	narrow Van der Graaf educational dueling banjo	0		Experience: +1, MP Regen Min: 5, MP Regen Max: 7
 3985	soup turtle	0		
-3986	maroon ghostly samurai turtle	0		
+3986	ghostly maroon samurai turtle	0		
 3987	sharpshooter's samurai turtle helmet of chilblains	0		Critical Hit Percent: +10, Cold Damage: +25, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	turtle shell	0		
 3989	upside-down turtle shell powder	0		
@@ -3954,11 +3954,11 @@
 4002	pulsating miser's rosewater-soaked tortoboggan shield	0		Stench Resistance: +3, Meat Drop: +10, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	Fonzie's soup-chucks	0		Experience (Moxie): +1
-4005	altered energized ghostly squat ballast turtle	0		Effect: "Human-Hobo Hybrid", Effect Duration: 58
+4005	altered energized squat ghostly ballast turtle	0		Effect: "Human-Hobo Hybrid", Effect Duration: 58
 4006	memory of some amino acids	0		Last Available: "2009-06"
 4007	spinning memory of a C	0		Last Available: "2009-06"
 4008	memory of an A	0		Last Available: "2009-06"
-4009	purple blurry memory of a G	0		Last Available: "2009-06"
+4009	blurry purple memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
 4011	ghostly memory of a CA base pair	0		Last Available: "2009-06"
 4012	memory of a CG base pair	0		Last Available: "2009-06"
@@ -3984,21 +3984,21 @@
 4032	memory of half a stone circle	0		Last Available: "2009-06"
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
 4034	blurry memory of an iron key	0		Last Available: "2009-06"
-4035	squat jittery memory of a crystal	0		Last Available: "2009-06"
+4035	jittery squat memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	moldy super-sized purple slimy sweetbreads	5	crappy	
+4037	super-sized moldy purple slimy sweetbreads	5	crappy	
 4038	tolerable twirling slimy fermented bile bladder	4	good	
-4039	boiled narrow blinking slimy alveolus	1		
+4039	boiled blinking narrow slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	pig-iron helm of doom of the boozehound	0		Spooky Spell Damage: +50, Booze Drop: +100, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	stanky mansplainer's pig-iron shinguards	0		Monster Level: +15, Stench Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	pig-iron helm of doom of the boozehound	0		Spooky Spell Damage: +50, Booze Drop: +100, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	stanky mansplainer's pig-iron shinguards	0		Monster Level: +15, Stench Spell Damage: +25, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	Sherlock's pig-iron bracers of the glutton	0		Item Drop: +25, Food Drop: +100, Single Equip, Last Available: "2009-06"
 4044	lime green wumpus hair	0		Last Available: "2009-06"
 4045	wobbly wumpus-hair bolo	0		Last Available: "2009-06"
 4046	gray wumpus-hair net	0		Last Available: "2009-06"
 4047	steel-toed wumpus-hair whip	0		Damage Reduction: 9, Last Available: "2009-06"
-4048	gravedigger's Socratic wumpus-hair wig of the sweet-tooth	0		Experience (Mysticality): +1, Spooky Damage: +10, Candy Drop: +100, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	scorching wumpus-hair loincloth of Gandalf of courage	0		Spell Critical Percent: +20, Hot Damage: +25, Spooky Resistance: +3, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	gravedigger's Socratic wumpus-hair wig of the sweet-tooth	0		Experience (Mysticality): +1, Spooky Damage: +10, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	scorching wumpus-hair loincloth of Gandalf of courage	0		Spell Critical Percent: +20, Hot Damage: +25, Spooky Resistance: +3, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	tumbling censurious extremely unsafe wumpus-hair sweater	0		Weapon Damage Percent: +100, Sleaze Resistance: +3, Last Available: "2009-06"
 4051	ring of teleportation of Leguizamo	0		Monster Level: +20, Single Equip
 4052	ghostly glass of baboon milk	1	good	Last Available: "2009-06"
@@ -4032,9 +4032,9 @@
 4080	frosty sharpshooter's grisly shield	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Slime Hates It: +1, Damage Reduction: 13
 4081	corroded breeches of the brute of the overflowing toilet	0		Muscle Percent: +30, Stench Spell Damage: +50, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	double-paned MacGyver's pernicious cudgel	0		Maximum MP: +100, Cold Resistance: +5, Slime Hates It: +1
-4083	special normal jumbo ghostly olive cupcake-in-a-cup	5	good	Effect: "Weepy, Creepy", Effect Duration: 25, Last Available: "2009-06"
+4083	special jumbo normal ghostly olive cupcake-in-a-cup	5	good	Effect: "Weepy, Creepy", Effect Duration: 25, Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	rotten super-sized protein paste	5	crappy	Last Available: "2009-06"
+4085	super-sized rotten protein paste	5	crappy	Last Available: "2009-06"
 4086	fireproof healthy cyber-mattock	0		Maximum HP Percent: +20, Hot Resistance: +3, Last Available: "2009-06"
 4087	mirror facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	non-ionized diffused ghostly tempura air	0		Effect: "Incensed", Effect Duration: 56
 4134	anodized extra-concentrated pressurized potion of pneumaticity	0		Effect: "Superveiny 9000", Effect Duration: 12
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	cyan Sherlock's aromatic Jack Frost's Bag o' Tricks of the empath	0		Familiar Weight: +5, Cold Spell Damage: +50, Stench Resistance: +1, Item Drop: +25, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	cyan Sherlock's aromatic Jack Frost's Bag o' Tricks of the empath	0		Familiar Weight: +5, Cold Spell Damage: +50, Stench Resistance: +1, Item Drop: +25, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	blue a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4109,8 +4109,8 @@
 4157	spinning gravel	0		Last Available: "2009-09"
 4158	mirror rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	practically non-alcoholic acceptable pebblebr&auml;u	1	good	Last Available: "2009-09"
-4161	decent massive rocky road ice cream	7	good	Last Available: "2009-09"
+4160	acceptable practically non-alcoholic pebblebr&auml;u	1	good	Last Available: "2009-09"
+4161	massive decent rocky road ice cream	7	good	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	dry energized Vulcanized upside-down children of the candy corn	0		Effect: "Educated (Sorta)", Effect Duration: 60
 4164	enhanced Good 'n' Slimy	0		Effect: "Superhuman Sarcasm", Effect Duration: 20
@@ -4130,8 +4130,8 @@
 4178	Usain Bolt's sugar shotgun	0		Initiative: +80, Last Available: "2009-09"
 4179	hardened sugar shillelagh	0		Damage Reduction: 3, Last Available: "2009-09"
 4180	jittery executive sugar shank	0		Meat Drop: +40, Last Available: "2009-09"
-4181	sugar chapeau of the cougar of the overflowing toilet of horror	0		Moxie: +20, Stench Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	thinker's sugar shorts	0		Mysticality: +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	sugar chapeau of the cougar of the overflowing toilet of horror	0		Moxie: +20, Stench Spell Damage: +50, Spooky Spell Damage: +25, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	thinker's sugar shorts	0		Mysticality: +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	narrow slime convention flyers	0		
@@ -4139,7 +4139,7 @@
 4187	teal spinning chilly slime convention pin	0		Cold Damage: +5
 4188	slime convention t-shirt	0		
 4189	inverse geode	0		
-4190	blue spinning control crystal	0		Free Pull, Last Available: "2011-12"
+4190	spinning blue control crystal	0		Free Pull, Last Available: "2011-12"
 4191	lard-coated sugar shirt	0		Sleaze Spell Damage: +25, Last Available: "2009-09"
 4192	mirror sugar shard	0		Last Available: "2009-09"
 4193	jittery extremely unsafe rave visor	0		Weapon Damage Percent: +100, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
@@ -4153,7 +4153,7 @@
 4201	gill rings	0		Familiar Weight: +5
 4202	blue urchin roe	0		
 4203	yellow pet anemone	0		Familiar Weight: +5
-4204	shaking purple Mer-kin cheatsheet	0		
+4204	purple shaking Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
 4206	lime green strapping brand new key of the bloodbag	0		Muscle: +5, Maximum HP: +100
 4207	supercharged dorsal fin	0		Maximum MP Percent: +30, Damage Reduction: 13
@@ -4196,7 +4196,7 @@
 4244	flame-retardant leather-bound tome	0		Hot Resistance: +1
 4245	bookmark	0		
 4246	inspector's ivory cue ball	0		Item Drop: +15
-4247	weak mediocre decanter of fine Scotch	2	decent	
+4247	mediocre weak decanter of fine Scotch	2	decent	
 4248	dehydrated blurry expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4207,14 +4207,14 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	cold-filtered improved tumbling sap	0		Effect: "Oth-Jeal-O", Effect Duration: 58, Last Available: "2009-10"
 4257	blurry petrified wood	0		Last Available: "2009-10"
-4258	snack-sized stale chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
-4259	tolerable triple-distilled mulled cider	6	good	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4258	stale snack-sized chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
+4259	triple-distilled tolerable mulled cider	6	good	Last Available: "2009-10"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	vibrating bark boxers	0		Maximum MP Percent: +10, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	beefcake's bark beret	0		Muscle: +25, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	vibrating bark boxers	0		Maximum MP Percent: +10, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	beefcake's bark beret	0		Muscle: +25, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	huge steel-toed bark bracelet	0		Damage Reduction: 9, Single Equip
 4267	friendly electrified Krakrox's Loincloth	0		Familiar Weight: +3, MP Regen Min: 3, MP Regen Max: 5, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	dog trainer's shellacked Galapagosian Cuisses	0		Damage Reduction: 7, Experience (familiar): +1, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4290,7 +4290,7 @@
 4338	plastic Don Crimbo of the brute	0		Muscle Percent: +30, Last Available: "2009-12"
 4339	frightening plastic Crimbomination	0		Spooky Damage: +5, Last Available: "2009-12"
 4340	frozen dry Piddles	0		Effect: "Gummiskin", Effect Duration: 37, Last Available: "2009-12"
-4341	irradiated spinning jittery BitterSweetTarts	0		Effect: "Vented Spleen", Effect Duration: 55, Last Available: "2009-12"
+4341	irradiated jittery spinning BitterSweetTarts	0		Effect: "Vented Spleen", Effect Duration: 55, Last Available: "2009-12"
 4342	super-concentrated spinning Polka Pop	0		Effect: "Libra Rising", Effect Duration: 43, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
@@ -4298,11 +4298,11 @@
 4346	huge plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	blinking gingerbread house	0		Last Available: "2009-12"
 4348	yellow leftover Crimbo rations	0		Last Available: "2009-12"
-4349	tumbling snow hat of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	clever snow pants	0		Maximum MP: +20, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	tumbling snow hat of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	clever snow pants	0		Maximum MP: +20, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	lion tamer's snow belly	0		Experience (familiar): +2, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
-4353	green narrow Crimbough	0		Last Available: "2009-12"
+4353	narrow green Crimbough	0		Last Available: "2009-12"
 4354	A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	ghostly A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	skewed blinking A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
@@ -4310,7 +4310,7 @@
 4358	blinking A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	flavorless expired can of franks 'n' beans	4	decent	Last Available: "2009-12"
-4361	strong tolerable expired bottle of peppermint schnapps	5	good	Last Available: "2009-12"
+4361	tolerable strong expired bottle of peppermint schnapps	5	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	ghostly elf resistance button	0		Last Available: "2009-12"
 4364	non-chilled adjusted tumbling elven suicide capsule	0		Effect: "Uncaged Power", Effect Duration: 24, Last Available: "2009-12"
@@ -4322,7 +4322,7 @@
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	squat handful of wires	0		Last Available: "2009-12"
 4372	jittery chunk of cement	0		Last Available: "2009-12"
-4373	mirror pulsating grappling hook	0		Last Available: "2009-12"
+4373	pulsating mirror grappling hook	0		Last Available: "2009-12"
 4374	huge elf ear	0		Last Available: "2009-12"
 4375	huge spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	stylish pocketwatch on a chain of the sewer	0		Moxie: +25, Stench Damage: +25, Last Available: "2009-12"
 4386	blurry Jack Frost's cement sandals of the detective	0		Cold Spell Damage: +50, Item Drop: +20, Single Equip, Last Available: "2009-12"
 4387	blurry gravedigger's Sinatra's night-vision goggles	0		Experience (Moxie): +5, Spooky Damage: +10, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	sinister peanut brittle shield	0		Spell Damage: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	Jeselnik's Red Rover BB gun of incineration	0		Hot Spell Damage: +50, Sleaze Damage: +25, Last Available: "2009-12"
-4391	frightening red-and-green sweater	0		Spooky Damage: +5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	frightening red-and-green sweater	0		Spooky Damage: +5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	dry lime green Crimbo peppermint bark	0		Effect: "Tingly Wrists", Effect Duration: 49, Last Available: "2009-12"
 4394	denatured alkaline Crimbo fudge	0		Effect: "French Bronilla Brogueishness", Effect Duration: 25, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	mirror crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	spinning cheese ball	0		Last Available: "2010-01"
 4399	supercool cheese sword	0		Moxie Percent: +20, Softcore Only, Last Available: "2010-01"
-4400	forbidden cheese diaper	0		Spell Damage Percent: +50, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	forbidden cheese diaper	0		Spell Damage Percent: +50, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	shaking crafty cheese wheel	0		Maximum MP: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	Tesla cheese eye	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	Tesla cheese eye	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	jittery veiny groovy boxer's Staff of Queso Escusado	0		Muscle Percent: +10, Moxie Percent: +10, Maximum HP: +10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4379,12 +4379,12 @@
 4429	huge arcane researcher's candy necklace	0		Experience Percent (Mysticality): +10, Single Equip
 4430	bouncing cool teddybear backpack	0		Moxie: +5
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	nitrogenated anodized ghostly maroon invisibility potion	0		Effect: "Radiated and Grodiated", Effect Duration: 33, Last Available: "2011-08"
+4432	nitrogenated anodized maroon ghostly invisibility potion	0		Effect: "Radiated and Grodiated", Effect Duration: 33, Last Available: "2011-08"
 4433	adjusted triple-quantum irresistibility potion	0		Effect: "Orchid Blood", Effect Duration: 55, Last Available: "2011-08"
 4434	alkaline upside-down irritability potion	0		Effect: "Frog In Your Throat", Effect Duration: 67, Last Available: "2011-08"
 4436	shaking cube	0		Last Available: "2011-02"
 4438	huge hellseal whisker	0		
-4439	ghostly olive hellseal claw	0		
+4439	olive ghostly hellseal claw	0		
 4440	weightlifter's guard turtle shell	0		Muscle: +15, Familiar Effect: "atk, 1xFairy, cap 40"
 4441	cyan smooth crowbar	0		Moxie: +15
 4442	maroon gravedigger's spaghetti cult rosary	0		Spooky Damage: +10
@@ -4393,10 +4393,10 @@
 4445	mirror supercool spangly mariachi pants	0		Moxie Percent: +20, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	tumbling gravedigger's wizardly spangly mariachi vest	0		Mysticality: +25, Spooky Damage: +10
 4447	wholesome spangly sombrero	0		Maximum HP Percent: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	boiled tumbling purple Instant Karma	1	decent	
+4448	boiled purple tumbling Instant Karma	1	decent	
 4449	teal painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	smartaleck's pointy hat	0		Moxie Percent: +30, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	smartaleck's pointy hat	0		Moxie Percent: +30, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	narrow bouncing censurious machetito	0		Sleaze Resistance: +3, Last Available: "2010-04"
 4453	vibrating lawnmower blade	0		Maximum MP Percent: +10, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4412,19 +4412,19 @@
 4464	pressed non-nitrogenated chocolate pasta spoon	0		Effect: "Full-Body Tan", Effect Duration: 15
 4465	frozen warmed tumbling chocolate saucepan	0		Effect: "Phoenix, Right?", Effect Duration: 17
 4466	concentrated quantum spinning blue chocolate disco ball	0		Effect: "Omphalotus Omnipresence", Effect Duration: 67
-4467	altered jittery huge upside-down chocolate stolen accordion	0		Effect: "Winklered", Effect Duration: 53
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4467	altered huge upside-down jittery chocolate stolen accordion	0		Effect: "Winklered", Effect Duration: 53
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	blinking yellow BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	huge flame-retardant BRICKO hat	0		Hot Resistance: +1, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	stanky BRICKO pants	0		Stench Spell Damage: +25, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	huge flame-retardant BRICKO hat	0		Hot Resistance: +1, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	stanky BRICKO pants	0		Stench Spell Damage: +25, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	tumbling executive BRICKO sword	0		Meat Drop: +40, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	twirling BRICKO oyster	0		Last Available: "2010-02"
 4477	upside-down BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	twirling BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	blurry BRICKO airship	0		Last Available: "2010-02"
@@ -4437,7 +4437,7 @@
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	wobbly gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	BRICKO brick	0		Last Available: "2010-02"
-4492	twirling fuchsia BRICKO brick	0		Last Available: "2010-02"
+4492	fuchsia twirling BRICKO brick	0		Last Available: "2010-02"
 4493	tumbling broken BRICKO brick	0		Last Available: "2010-02"
 4494	BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
@@ -4453,23 +4453,23 @@
 4505	moist energized denatured Northern pemmican	0		Effect: "Incredibly Hulking", Effect Duration: 19
 4506	puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	triple-chilled oxidized bouncing spinning &quot;DRINK ME&quot; potion	0		Effect: "Cat-Alyzed", Effect Duration: 13, Last Available: "2010-03"
+4508	triple-chilled oxidized spinning bouncing &quot;DRINK ME&quot; potion	0		Effect: "Cat-Alyzed", Effect Duration: 13, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	low-calorie decent walrus ice cream	1	good	Last Available: "2010-03"
-4511	special spoiled snack-sized beautiful soup	2	crappy	Effect: "Spooky Blur", Effect Duration: 25, Last Available: "2010-03"
+4511	snack-sized spoiled special beautiful soup	2	crappy	Effect: "Spooky Blur", Effect Duration: 25, Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	twirling Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	bland Humpty Dumplings	4	decent	Last Available: "2010-03"
-4515	huge bland Lobster <i>qua</i> Grill	9	decent	Last Available: "2010-03"
-4516	drinkable weak missing wine	2	good	Last Available: "2010-03"
-4517	flavorless skewed blue jittery bouncing matter custard	3	decent	Last Available: "2010-03"
+4515	bland huge Lobster <i>qua</i> Grill	9	decent	Last Available: "2010-03"
+4516	weak drinkable missing wine	2	good	Last Available: "2010-03"
+4517	flavorless blue skewed jittery bouncing matter custard	3	decent	Last Available: "2010-03"
 4518	Vulcanized oxidized comfit?	0		Effect: "Weird Flavor", Effect Duration: 20, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	careful dance instructor's flamingo mallet	0		Experience Percent (Moxie): +10, Monster Level: -10, Last Available: "2010-03"
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	EPIC	Last Available: "2010-03"
 4523	blinking skewed scandalous eye of the Tiger-lily of chilblains	0		Cold Damage: +25, Sleaze Damage: +5, Last Available: "2010-03"
-4524	rosewater-soaked wig of the businessman	0		Stench Resistance: +3, Meat Drop: +50, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	rosewater-soaked wig of the businessman	0		Stench Resistance: +3, Meat Drop: +50, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	toothsome donut	3	awesome	Last Available: "2010-03"
 4526	normal jumbo bucket of honey	5	good	Last Available: "2010-03"
 4527	Sherlock's elephant stinger of the blizzard	0		Cold Spell Damage: +25, Item Drop: +25, Last Available: "2010-03"
@@ -4478,14 +4478,14 @@
 4530	skewed puff of smoke	0		Last Available: "2010-03"
 4531	tasty blue rook cookie	3	awesome	Last Available: "2010-03"
 4532	spoiled mirror bishop cookie	4	crappy	Last Available: "2010-03"
-4533	snack-sized adequate knight cookie	2	good	Last Available: "2010-03"
-4534	thick bland wobbly shaking purple king cookie	5	decent	Last Available: "2010-03"
+4533	adequate snack-sized knight cookie	2	good	Last Available: "2010-03"
+4534	thick bland shaking purple wobbly king cookie	5	decent	Last Available: "2010-03"
 4535	moldy queen cookie	3	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	smooth insane tophat	0		Moxie: +15, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	razor-sharp supercool helm of the knight	0		Moxie Percent: +20, Weapon Damage Percent: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	smooth insane tophat	0		Moxie: +15, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	razor-sharp supercool helm of the knight	0		Moxie Percent: +20, Weapon Damage Percent: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	wobbly spinning wristwatch of the knight of extreme caution of the overflowing toilet	0		Monster Level: -25, Stench Spell Damage: +50, Single Equip, Last Available: "2010-03"
-4540	skewed healthy brainy trousers of the knight	0		Mysticality: +5, Maximum HP Percent: +20, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	skewed healthy brainy trousers of the knight	0		Mysticality: +5, Maximum HP Percent: +20, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	gravedigger's tophat	0		Spooky Damage: +10, Familiar Effect: "1xBarrr, cap 25"
 4542	tie of horror	0		Spooky Spell Damage: +25, Single Equip
 4543	shaking greasy tuxedo pants	0		Sleaze Spell Damage: +10, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4510,29 +4510,29 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	lousy world's most unappetizing beverage	3	decent	Last Available: "2010-04"
 4564	tumbling Sinatra's slippery when wet shield	0		Experience (Moxie): +5, Damage Reduction: 6, Last Available: "2010-04"
-4565	stale big upside-down raisin	5	decent	Last Available: "2010-04"
+4565	big stale upside-down raisin	5	decent	Last Available: "2010-04"
 4566	shaking fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	wobbly Tesla flyest of shirts of the bloodbag	0		Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-04"
 4568	decent a dance upon the palate	4	good	Last Available: "2010-04"
-4569	stale bite-sized prehistoric meteorite jawbreaker	1	decent	Last Available: "2010-04"
+4569	bite-sized stale prehistoric meteorite jawbreaker	1	decent	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	moldy squirmy violent party snack	4	crappy	Last Available: "2010-04"
 4572	can-you-dig-it? of incineration	0		Hot Spell Damage: +50, Last Available: "2010-04"
 4573	gray The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4578	huge shaking meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4578	shaking huge meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	triple-wet concentrated teal Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Salamanderenity", Effect Duration: 29, Last Available: "2010-04"
 4580	blinking school Mafi<i>a kni</i>cke&frac12;&aelig; of temperance	0		Sleaze Resistance: +5, Last Available: "2010-04"
-4581	chaotic T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the glutton	0		Spell Critical Percent: +10, Food Drop: +100, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	chaotic T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the glutton	0		Spell Critical Percent: +10, Food Drop: +100, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	bouncing fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	bland spinning six wedges of goat cheese	3	decent	
 4585	collection of objects	0		
 4586	tumbling boulder	0		
-4587	blurry green goth	0		
+4587	green blurry goth	0		
 4588	brown pixel	0		
 4589	shellacked pixel whip	0		Damage Reduction: 7
 4590	maroon savvy pixel chain whip	0		Mysticality Percent: +20, Last Available: "2010-07"
@@ -4546,21 +4546,21 @@
 4598	cyan pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	mediocre watered-down jittery plastic cup of beer	2	decent	Last Available: "2010-06"
+4601	watered-down mediocre jittery plastic cup of beer	2	decent	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	olive bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	jittery smartaleck's bottle of Goldschn&ouml;ckered of Flo-Jo	0		Moxie Percent: +30, Initiative: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	jittery smartaleck's bottle of Goldschn&ouml;ckered of Flo-Jo	0		Moxie Percent: +30, Initiative: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	spoiled yellow sun-dried tofu	4	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	artisanal soyburger juice	3	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	purple respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
-4610	galvanized huge blurry essential soy	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2010-08"
+4610	galvanized blurry huge essential soy	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2010-08"
 4611	concentrated skewed essential cameraderie	0		Effect: "Springy Fusilli", Effect Duration: 42, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	clever Crown of Thrones	0		Maximum MP: +20, Softcore Only, Last Available: "2010-05"
-4615	practically non-alcoholic drinkable squat upside-down Cinco Mayo Lager	1	good	Last Available: "2010-05"
+4615	drinkable practically non-alcoholic squat upside-down Cinco Mayo Lager	1	good	Last Available: "2010-05"
 4616	pulsating Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4574,15 +4574,15 @@
 4626	huge superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	clever plastic spider ring	0		Maximum MP: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	clever plastic spider ring	0		Maximum MP: +20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	plastic kazoo of bravery	0		Spooky Resistance: +5, Last Available: "2010-06"
 4631	purple tumbling experienced inflatable baseball bat	0		Experience: +2, Last Available: "2010-06"
-4632	banded googly-star hat of courage	0		Damage Absorption: +100, Spooky Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk"
+4632	banded googly-star hat of courage	0		Damage Absorption: +100, Spooky Resistance: +3, Familiar Effect: "atk", Last Available: "2010-06"
 4633	reassuring Rosewater's googly-ball hat	0		Mysticality Percent: +30, Spooky Resistance: +1, Last Available: "2010-06"
 4634	jittery deadly sage googly-heart hat	0		Mysticality Percent: +10, Weapon Damage: +5, Last Available: "2010-06"
 4635	smelly vibrating super-sweet boom box	0		Maximum MP Percent: +10, Stench Spell Damage: +10, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	horrifying Tesla sage sinister demon mask	0		Mysticality Percent: +10, Spooky Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	horrifying Tesla sage sinister demon mask	0		Mysticality Percent: +10, Spooky Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	shaking wholesome Da Vinci's strapping streetfighting champion's belt	0		Muscle: +5, Experience (Mysticality): +5, Maximum HP Percent: +10, Single Equip, Last Available: "2010-06"
 4639	mirror asbestos-lined Socratic beefy Space Trip safety headphones	0		Muscle: +10, Experience (Mysticality): +1, Hot Resistance: +5, Single Equip, Last Available: "2010-06"
 4640	LARP carp of Calamity Jane	0		Critical Hit Percent: +15
@@ -4616,19 +4616,19 @@
 4668	red blinking observational glasses of mayonnaise	0		Sleaze Spell Damage: +50
 4669	sinister hilarious comedy prop	0		Spell Damage: +10
 4670	beer-scented teddy bear	0		
-4671	artisanal irresponsibly strong booze-soaked cherry	6	EPIC	
+4671	irresponsibly strong artisanal booze-soaked cherry	6	EPIC	
 4672	comfy pillow	0		
-4673	toothsome bite-sized marshmallow	1	awesome	
+4673	bite-sized toothsome marshmallow	1	awesome	
 4674	special normal gray sponge cake	3	good	Effect: "Celestial Body", Effect Duration: 5
 4675	triple-distilled smooth gin-soaked blotter paper	10	awesome	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	bouncing unearthed potsherd	0		
-4679	skewed red volcanic ash	0		
+4679	red skewed volcanic ash	0		
 4680	smoked potsherd	0		
 4681	pottery shield of dire peril	0		Weapon Damage: +20, Damage Reduction: 3, Last Available: "2010-09"
-4682	horrifying electrified pottery hat	0		Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	frosty pottery training pants of chilblains	0		Cold Damage: +25, Cold Spell Damage: +10, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	horrifying electrified pottery hat	0		Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	frosty pottery training pants of chilblains	0		Cold Damage: +25, Cold Spell Damage: +10, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	deadly pottery club	0		Weapon Damage: +5, Last Available: "2010-09"
 4685	shaking boxer's pottery yo-yo	0		Muscle Percent: +10, Last Available: "2010-09"
 4686	blinking pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,13 +4641,13 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	skewed affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	family-friendly hardy healthy Greatest American Pants	0		Maximum HP Percent: +20, Maximum HP: +50, Sleaze Resistance: +1, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	family-friendly hardy healthy Greatest American Pants	0		Maximum HP Percent: +20, Maximum HP: +50, Sleaze Resistance: +1, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	blurry greasy fossilized necklace	0		Sleaze Spell Damage: +10, Last Available: "2010-09"
 4698	wobbly imp air	0		
 4699	upside-down bus pass	0		
 4700	fossilized spike	0		Last Available: "2010-09"
 4701	red waterlogged crate	0		Last Available: "2011-12"
-4702	huge spinning archaeologing shovel	0		Last Available: "2011-12"
+4702	spinning huge archaeologing shovel	0		Last Available: "2011-12"
 4703	dance instructor's red-hot medallion	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2010-09"
 4704	tumbling tumbling fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
@@ -4661,19 +4661,19 @@
 4713	maroon popsicle stick	0		
 4714	adequate lemon popsicle	4	good	
 4715	stale popsicle	3	decent	
-4716	super-sized tasty upside-down strawberry popsicle	5	awesome	
-4717	low-calorie normal liver popsicle	1	good	
+4716	tasty super-sized upside-down strawberry popsicle	5	awesome	
+4717	normal low-calorie liver popsicle	1	good	
 4718	lightning-fast mariachi hat	0		Initiative: +40, Familiar Effect: "atk, cap 2"
 4719	smooth Hollandaise helmet	0		Moxie: +15, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	shaking microwave stogie	0		Last Available: "2011-12"
-4722	normal half-sized green liver and let pie	2	good	Last Available: "2010-10"
+4722	half-sized normal green liver and let pie	2	good	Last Available: "2010-10"
 4723	moldy jumbo wobbly badass pie	5	crappy	Last Available: "2010-10"
 4724	bland miniature shoo-fish pie	2	decent	Last Available: "2010-10"
 4725	rotten piping organ pie	3	crappy	Last Available: "2010-10"
 4726	flavorless skewed igloo pie	3	decent	Last Available: "2010-10"
 4727	moldy bite-sized pulsating stomach turnover	1	crappy	Last Available: "2010-10"
-4728	spoiled low-calorie upside-down dead lights pie	1	crappy	Last Available: "2010-10"
+4728	low-calorie spoiled upside-down dead lights pie	1	crappy	Last Available: "2010-10"
 4729	adequate thick throbbing organ pie	5	good	Last Available: "2010-10"
 4730	jittery chaotic stop shield	0		Spell Critical Percent: +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4684,7 +4684,7 @@
 4736	tangle of rat tails	0		
 4737	miser's beer-soaked mop	0		Meat Drop: +10
 4738	perfectly mixed jittery day-old beer	3	EPIC	
-4739	tolerable practically non-alcoholic plain beer	1	good	
+4739	practically non-alcoholic tolerable plain beer	1	good	
 4740	tolerable cyan jittery overpriced &quot;imported&quot; beer	4	good	
 4741	gray smiling rat	0		
 4742	skewed rat tooth polish	0		Familiar Weight: +5
@@ -4699,18 +4699,18 @@
 4751	experienced boning knife	0		Experience: +2, Last Available: "2010-10"
 4752	bone crusher of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-10"
 4753	arcane researcher's bone spurs	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2010-10"
-4754	upside-down forbidden bonedanna of Leguizamo	0		Spell Damage Percent: +50, Monster Level: +20, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	boneana hammock of the overflowing toilet of the boozehound	0		Stench Spell Damage: +50, Booze Drop: +100, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	upside-down forbidden bonedanna of Leguizamo	0		Spell Damage Percent: +50, Monster Level: +20, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	boneana hammock of the overflowing toilet of the boozehound	0		Stench Spell Damage: +50, Booze Drop: +100, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	nitrogenated wet candy skeleton	0		Effect: "Hoity Toity", Effect Duration: 14, Last Available: "2020-09"
 4759	squat Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
-4760	ghostly blinking packet of pumpkin seeds	0		Last Available: "2010-11"
+4760	blinking ghostly packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	yellow huge pumpkin	0		Last Available: "2010-11"
 4763	low-calorie flavorless bouncing pumpkin pie	1	decent	Last Available: "2010-11"
-4764	boozy hand-crafted blurry pumpkin beer	5	EPIC	Last Available: "2010-11"
-4765	enhanced skewed ghostly pumpkin juice	0		Effect: "Tingly Elbows", Effect Duration: 53, Last Available: "2010-11"
+4764	hand-crafted boozy blurry pumpkin beer	5	EPIC	Last Available: "2010-11"
+4765	enhanced ghostly skewed pumpkin juice	0		Effect: "Tingly Elbows", Effect Duration: 53, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	supercool beefcake's shin gourds	0		Muscle: +25, Moxie Percent: +20, Single Equip, Last Available: "2010-11"
 4768	flame-retardant hale Staff of the November Jack-O-Lantern of the sweet-tooth	0		Maximum HP: +20, Hot Resistance: +1, Candy Drop: +100, Last Available: "2010-11"
@@ -4724,9 +4724,9 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	bouncing huge Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	squat Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	miniature bland fancy CRIMBCOIDS mints	2	decent	Effect: "Tightly-Wound Spine", Effect Duration: 15, Last Available: "2011-01"
+4818	fancy miniature bland CRIMBCOIDS mints	2	decent	Effect: "Tightly-Wound Spine", Effect Duration: 15, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	adequate snack-sized CRIMBCOLOAF	2	good	Last Available: "2011-01"
+4820	snack-sized adequate CRIMBCOLOAF	2	good	Last Available: "2011-01"
 4821	stale circular CRIMBCOOKIE	3	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	squat clever plastic CRIMBCO HQ	0		Maximum MP: +20, Last Available: "2010-12"
 4823	grievous plastic fax machine	0		Weapon Damage Percent: +50, Last Available: "2010-12"
@@ -4743,7 +4743,7 @@
 4834	squat robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	spinning robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	tumbling pulsating robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	pulsating tumbling robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	yummy triangular CRIMBCOOKIE	3	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	rotten square CRIMBCOOKIE	3	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
@@ -4751,9 +4751,9 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	blurry The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	yellow supercharged wholesome Uncle Hobo's stocking cap	0		Maximum HP Percent: +10, Maximum MP Percent: +30, Last Available: "2010-12", Familiar Effect: "atk"
+4845	yellow supercharged wholesome Uncle Hobo's stocking cap	0		Maximum HP Percent: +10, Maximum MP Percent: +30, Familiar Effect: "atk", Last Available: "2010-12"
 4846	fuchsia asbestos-lined curative Uncle Hobo's epic beard	0		Hot Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2010-12"
-4847	bouncing energetic Uncle Hobo's gift baggy pants of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	bouncing energetic Uncle Hobo's gift baggy pants of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	upside-down blurry Annie Oakley's studded Uncle Hobo's fingerless tinsel gloves	0		Damage Absorption: +80, Critical Hit Percent: +20, Single Equip, Last Available: "2010-12"
 4849	aromatic Uncle Hobo's highest bough of the boozehound	0		Stench Resistance: +1, Booze Drop: +100, Last Available: "2010-12"
 4850	Van der Graaf medical-grade Uncle Hobo's belt	0		MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2010-12"
@@ -4773,10 +4773,10 @@
 4864	wobbly photocopier	0		Last Available: "2011-01"
 4865	deluxe fax machine	0		Last Available: "2011-01"
 4866	green Workytime Tea	0		Last Available: "2011-01"
-4867	mirror skewed paperclip sproinger	0		Last Available: "2011-01"
+4867	skewed mirror paperclip sproinger	0		Last Available: "2011-01"
 4868	hale steel-toed Socratic paperclip-on tie	0		Experience (Mysticality): +1, Damage Reduction: 9, Maximum HP: +20, Single Equip, Last Available: "2011-01"
-4869	blurry curative paperclip pants of courage	0		Spooky Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	huge censurious dangerous paperclip turban of extreme caution	0		Weapon Damage: +10, Monster Level: -25, Sleaze Resistance: +3, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	blurry curative paperclip pants of courage	0		Spooky Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	huge censurious dangerous paperclip turban of extreme caution	0		Weapon Damage: +10, Monster Level: -25, Sleaze Resistance: +3, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	occult paperclip cape	0		Spell Damage Percent: +25, Last Available: "2011-01"
 4872	upside-down glob of Blank-Out	0		Last Available: "2011-01"
 4873	ghostly photocopied monster	0		Last Available: "2011-01"
@@ -4792,14 +4792,14 @@
 4883	gray toe jam	0		Last Available: "2011-01"
 4884	big tasty shaking twirling purple toe jam toast	5	awesome	Last Available: "2011-01"
 4885	cyan traffic jam	0		Last Available: "2011-01"
-4886	rotten miniature traffic jam toast	2	crappy	Last Available: "2011-01"
+4886	miniature rotten traffic jam toast	2	crappy	Last Available: "2011-01"
 4887	wobbly space jam	0		Last Available: "2011-01"
 4888	decent snack-sized space jam toast	2	good	Last Available: "2011-01"
 4889	irradiated motivational poster	0		Effect: "Dilated Pupils", Effect Duration: 65, Last Available: "2011-01"
 4890	narrow sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	huge blinking slow jam collection	0		Last Available: "2011-01"
-4893	blinking narrow BGE shotglass	0		Last Available: "2010-12"
+4893	narrow blinking BGE shotglass	0		Last Available: "2010-12"
 4894	moldy festive sausage	3	crappy	Last Available: "2011-01"
 4895	normal narrow holiday cheese log	4	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
@@ -4841,7 +4841,7 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	tumbling time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	jittery arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	thick bland Knob jelly donut	5	decent	
+4941	bland thick Knob jelly donut	5	decent	
 4942	Knob cake	0		
 4943	Knob cake pan	0		
 4944	Knob batter	0		
@@ -4855,7 +4855,7 @@
 4952	denatured baggie of sugar	0		Effect: "Bilious Briskness", Effect Duration: 36
 4953	manspreader's whalebone corset of Gandalf	0		Spell Critical Percent: +20, Monster Level: +10, Single Equip
 4954	executive oven mitts	0		Meat Drop: +40, Single Equip
-4955	stale special yellow overcookie	3	decent	Effect: "Healthy Blue Glow", Effect Duration: 25
+4955	special stale yellow overcookie	3	decent	Effect: "Healthy Blue Glow", Effect Duration: 25
 4956	adequate philosopher's scone	3	good	
 4957	liquefied triple-wet improved half-baked potion	0		Effect: "Super-Charged", Effect Duration: 42
 4958	flame-retardant Knob Goblin deluxe scimitar	0		Hot Resistance: +1
@@ -4870,14 +4870,14 @@
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
-4970	yellow shaking Alice's Army Guard	0		Last Available: "2011-03"
+4970	shaking yellow Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
 4973	blinking Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
-4977	blurry jittery Alice's Army Nurse	0		Last Available: "2011-03"
+4977	jittery blurry Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	jittery wobbly Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
@@ -4907,13 +4907,13 @@
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
-5007	huge ghostly spinning Alice's Army Foil Martyr	0		Last Available: "2011-03"
+5007	spinning ghostly huge Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	red frightening card sleeve	0		Spooky Damage: +5, Last Available: "2011-03"
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	yummy big wasabi pocky	5	awesome	Last Available: "2011-03"
+5013	big yummy wasabi pocky	5	awesome	Last Available: "2011-03"
 5014	flavorless tobiko pocky	3	decent	Last Available: "2011-03"
 5015	flavorless small natto pocky	2	decent	Last Available: "2011-03"
 5016	extra-dry tolerable shaking wasabi-infused sake	5	good	Last Available: "2011-03"
@@ -4949,10 +4949,10 @@
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	jittery frightening therapeutic double-ice cap of Flo-Jo	0		Spooky Damage: +5, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	jittery frightening therapeutic double-ice cap of Flo-Jo	0		Spooky Damage: +5, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	knitted Oprah's beefcake's double-ice box	0		Muscle: +25, Maximum MP Percent: +50, Cold Resistance: +3, Last Available: "2011-04"
-5051	brawny double-ice britches of the cougar of dire peril	0		Moxie: +20, Muscle Percent: +20, Weapon Damage: +20, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
-5052	narrow shaking handful of numbers	0		Last Available: "2020-09"
+5051	brawny double-ice britches of the cougar of dire peril	0		Moxie: +20, Muscle Percent: +20, Weapon Damage: +20, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5052	shaking narrow handful of numbers	0		Last Available: "2020-09"
 5053	fuchsia Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	upside-down obnoxious riddle	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	lousy Russian Ice	3	decent	Last Available: "2011-04"
 5074	gray energetic clay ashtray	0		Maximum MP Percent: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	lion tamer's lanyard	0		Experience (familiar): +2, Single Equip, Last Available: "2011-05"
-5076	bouncing stanky monster pants	0		Stench Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	bouncing stanky monster pants	0		Stench Spell Damage: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	cyan box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	altered improved Pok&euml;mann band-aid	0		Effect: "Mistified", Effect Duration: 54, Last Available: "2011-05"
-5079	knitted Van der Graaf helmet of Leguizamo	0		Monster Level: +20, Cold Resistance: +3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	knitted Van der Graaf helmet of Leguizamo	0		Monster Level: +20, Cold Resistance: +3, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	squat resourceful crutch	0		Maximum MP: +50, Last Available: "2011-05"
 5081	spinning Samson's shock belt	0		Experience (Muscle): +5, Single Equip, Last Available: "2011-05"
-5082	wet tumbling blue Okee-Dokee soda	0		Effect: "Full of Vinegar", Effect Duration: 26, Last Available: "2011-05"
+5082	wet blue tumbling Okee-Dokee soda	0		Effect: "Full of Vinegar", Effect Duration: 26, Last Available: "2011-05"
 5083	fuchsia rubber band gun of the detective	0		Item Drop: +20, Last Available: "2011-05"
-5084	Usain Bolt's pin-stripe slacks	0		Initiative: +80, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	Usain Bolt's pin-stripe slacks	0		Initiative: +80, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	Lo Pan's gloves	0		Spell Critical Percent: +30, Single Equip, Last Available: "2011-05"
 5086	dry bouncing correction fluid	0		Effect: "Frost Tea", Effect Duration: 45, Last Available: "2011-05"
 5087	bouncing hardy Pok&euml;mann figurine: Porkachu	0		Maximum HP: +50, Single Equip, Last Available: "2011-05"
@@ -5007,9 +5007,9 @@
 5104	irradiated blinking fish juice box	0		Effect: "Heart of Green", Effect Duration: 36, Last Available: "2011-05"
 5105	red paint bomb	0		Last Available: "2011-05"
 5106	ghostly hideous egg	0		Last Available: "2011-05"
-5107	weak hand-crafted fancy Jeppson's Malort	2	super ultra mega turbo EPIC	Effect: "I See Everything Thrice!", Effect Duration: 20, Last Available: "2011-06"
+5107	hand-crafted weak fancy Jeppson's Malort	2	super ultra mega turbo EPIC	Effect: "I See Everything Thrice!", Effect Duration: 20, Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	Usain Bolt's stress ball	0		Initiative: +80, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	Usain Bolt's stress ball	0		Initiative: +80, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	huge smartaleck's Ultracolor&trade; shirt	0		Moxie Percent: +30, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,12 +5021,12 @@
 5118	bird brain	0		
 5119	spinning busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	pulsating twirling vibrating stiffened supercool Admiral's hat	0		Moxie Percent: +20, Damage Reduction: 1, Maximum MP Percent: +10, Last Available: "2011-05", Familiar Effect: "atk"
-5122	Jeselnik's coward's personal trainer's aviator's cap	0		Experience Percent (Muscle): +10, Monster Level: -20, Sleaze Damage: +25, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	pulsating twirling vibrating stiffened supercool Admiral's hat	0		Moxie Percent: +20, Damage Reduction: 1, Maximum MP Percent: +10, Familiar Effect: "atk", Last Available: "2011-05"
+5122	Jeselnik's coward's personal trainer's aviator's cap	0		Experience Percent (Muscle): +10, Monster Level: -20, Sleaze Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	tumbling curative mirrored aviator shades of Flo-Jo	0		Initiative: +100, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
-5126	mirror skewed Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
+5126	skewed mirror Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	huge Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	jittery Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
@@ -5040,19 +5040,19 @@
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	cyan E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
-5140	dried yellow twirling astral energy drink	1		
+5140	dried twirling yellow astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	jittery moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	blue handful of honey	0		
 5145	wet ionized honeypot	0		Effect: "Heart Aflame", Effect Duration: 11
 5146	decent wild honey pie	3	good	
-5147	enchanted bad cyan honey mead	3	decent	Effect: "New and Improved", Effect Duration: 5
+5147	bad enchanted cyan honey mead	3	decent	Effect: "New and Improved", Effect Duration: 5
 5148	ribald sharpshooter's cool honey dipper	0		Moxie: +5, Critical Hit Percent: +10, Sleaze Damage: +10
 5149	Usain Bolt's lightning-fast Sherlock's honeybritches	0		Item Drop: +25, Initiative: 120, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	flame-wreathed hardened honeycap of the brute	0		Muscle Percent: +30, Damage Reduction: 3, Hot Spell Damage: +10, Familiar Effect: "1xPotato, cap 43"
-5151	narrow cyan bouncing Newton's Moonthril Circlet	0		Experience (Mysticality): +3, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	Lo Pan's Moonthril Greaves	0		Spell Critical Percent: +30, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	narrow cyan bouncing Newton's Moonthril Circlet	0		Experience (Mysticality): +3, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	Lo Pan's Moonthril Greaves	0		Spell Critical Percent: +30, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	jittery Moonthril Flamberge of the glutton	0		Food Drop: +100, Last Available: "2011-06"
 5154	Moonthril Longbow of the boozehound	0		Booze Drop: +100, Last Available: "2011-06"
 5155	twirling supercool Moonthril Cuirass	0		Moxie Percent: +20, Softcore Only, Last Available: "2011-06"
@@ -5074,7 +5074,7 @@
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	squat Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	shaking elven magi-pack	0		Last Available: "2011-06"
-5174	delicious triple-distilled Saison du Lune	7	awesome	Last Available: "2011-06"
+5174	triple-distilled delicious Saison du Lune	7	awesome	Last Available: "2011-06"
 5175	mediocre irresponsibly strong squat Moonthril Schnapps	8	decent	Last Available: "2011-06"
 5176	triple-distilled artisanal Wrecked Generator	8	EPIC	Last Available: "2011-06"
 5177	flavorless ghostly Spaghetti with Moonballs	3	decent	Last Available: "2011-06"
@@ -5083,14 +5083,14 @@
 5180	quantum Comet Pop	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 66, Last Available: "2011-06"
 5181	super-unsweetened aerosolized bouncing Flan in the Moon	0		Effect: "High Blood Chocolate Content", Effect Duration: 64, Last Available: "2011-06"
 5182	oxidized warmed 1/6th Pound Cake	0		Effect: "Arabian Knighthood", Effect Duration: 46, Last Available: "2011-06"
-5183	purple bouncing spinning Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
+5183	purple spinning bouncing Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
-5185	wobbly teal Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
+5185	teal wobbly Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	narrow Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	quantum anodized honey stick	0		Effect: "Spell Transfer Complete", Effect Duration: 26
 5189	pickled double-ice gum	0		Effect: "Super Accuracy", Effect Duration: 35, Last Available: "2011-04"
-5190	pulsating supercharged thinker's Operation Patriot Shield of Leguizamo	0		Mysticality: +10, Maximum MP Percent: +30, Monster Level: +20, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	pulsating supercharged thinker's Operation Patriot Shield of Leguizamo	0		Mysticality: +10, Maximum MP Percent: +30, Monster Level: +20, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	dry tarnished ionized narrow blue corrupted data	0		Effect: "Strong Grip", Effect Duration: 50, Last Available: "2011-06"
 5193	huge 11-inch knob sausage	0		
@@ -5103,29 +5103,29 @@
 5200	denatured wobbly paste	1	EPIC	Effect: "Nut-Rition", Effect Duration: 50, Last Available: "2011-08"
 5201	vaporized ectoplasmic paste	1	EPIC	Last Available: "2011-08"
 5202	vaporized shaking greasy paste	1	crappy	Last Available: "2011-08"
-5203	dried wobbly blinking blinking bug paste	1	decent	Last Available: "2011-08"
+5203	dried blinking blinking wobbly bug paste	1	decent	Last Available: "2011-08"
 5204	denatured ghostly blurry hippy paste	1	crappy	Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2011-08"
 5205	boiled huge orc paste	1	awesome	Effect: "Preemptive Medicine", Effect Duration: 15, Last Available: "2011-08"
 5206	vaporized demonic paste	1	EPIC	Last Available: "2011-08"
-5207	mixed twirling huge indescribably horrible paste	1	decent	Effect: "Good Karma", Effect Duration: 25, Last Available: "2011-08"
+5207	mixed huge twirling indescribably horrible paste	1	decent	Effect: "Good Karma", Effect Duration: 25, Last Available: "2011-08"
 5208	powdered paste	1	decent	Effect: "Human-Humanoid Hybrid", Effect Duration: 20, Last Available: "2011-08"
 5209	distilled huge goblin paste	1	awesome	Effect: "Thick, Sick", Effect Duration: 15, Last Available: "2011-08"
 5210	altered blurry red pirate paste	1	good	Last Available: "2011-08"
 5211	distilled chlorophyll paste	1	good	Last Available: "2011-08"
-5212	dehydrated blurry skewed paste	1	EPIC	Last Available: "2011-08"
+5212	dehydrated skewed blurry paste	1	EPIC	Last Available: "2011-08"
 5213	twisted narrow Mer-kin paste	1	EPIC	Last Available: "2011-08"
 5214	diluted narrow upside-down slimy paste	1	decent	Last Available: "2011-08"
 5215	altered twirling penguin paste	1	awesome	Last Available: "2011-08"
-5216	powdered lime green pulsating elemental paste	1	EPIC	Effect: "Flambé-a-thon", Effect Duration: 50, Last Available: "2011-08"
+5216	powdered pulsating lime green elemental paste	1	EPIC	Effect: "Flambé-a-thon", Effect Duration: 50, Last Available: "2011-08"
 5217	vaporized twirling cosmic paste	1	good	Last Available: "2011-08"
 5218	altered jittery hobo paste	1	awesome	Last Available: "2011-08"
 5219	dried gray Crimbo paste	1	decent	Last Available: "2011-08"
 5220	fuchsia Teachings of the Fist	0		
 5221	twirling fat loot token	0		No Pull
 5222	squat yellow Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	rotten spinning Ur-Donut	4	crappy	Last Available: "2011-09"
-5225	twirling upside-down The Bomb	0		Last Available: "2011-09"
+5225	upside-down twirling The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	smooth bucket of wine	3	awesome	Last Available: "2011-09"
 5228	normal shaking ultrafondue	3	good	Last Available: "2011-09"
@@ -5143,19 +5143,19 @@
 5240	mediocre Temps Tempranillo	3	decent	Last Available: "2011-09"
 5241	smooth Bordeaux Marteaux	3	awesome	Last Available: "2011-09"
 5242	boozy mediocre Fromage Pinotage	5	decent	Last Available: "2011-09"
-5243	special irresponsibly strong acceptable Beignet Milgranet	9	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45, Last Available: "2011-09"
+5243	special acceptable irresponsibly strong Beignet Milgranet	9	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45, Last Available: "2011-09"
 5244	smooth Muschat	3	awesome	Last Available: "2011-09"
 5245	adequate cool jelly donut	4	good	Last Available: "2011-09"
 5246	adequate half-sized huge shrapnel jelly donut	2	good	Last Available: "2011-09"
-5247	small stale occult jelly donut	2	decent	Last Available: "2011-09"
-5248	massive yummy shaking pulsating thyme jelly donut	6	awesome	Last Available: "2011-09"
+5247	stale small occult jelly donut	2	decent	Last Available: "2011-09"
+5248	massive yummy pulsating shaking thyme jelly donut	6	awesome	Last Available: "2011-09"
 5249	moldy danish	3	crappy	Last Available: "2011-09"
 5250	low-calorie flavorless ghostly blinking smashed danish	1	decent	Last Available: "2011-09"
 5251	flavorless forbidden danish	4	decent	Last Available: "2011-09"
 5252	normal cool cat claw	4	good	Last Available: "2011-09"
-5253	flavorless huge special blunt cat claw	6	decent	Effect: "Human-Human Hybrid", Effect Duration: 5, Last Available: "2011-09"
-5254	miniature normal shadowy cat claw	2	good	Last Available: "2011-09"
-5255	jumbo rotten bouncing cheezburger	5	crappy	Last Available: "2011-09"
+5253	huge flavorless special blunt cat claw	6	decent	Effect: "Human-Human Hybrid", Effect Duration: 5, Last Available: "2011-09"
+5254	normal miniature shadowy cat claw	2	good	Last Available: "2011-09"
+5255	rotten jumbo bouncing cheezburger	5	crappy	Last Available: "2011-09"
 5256	delicious jumbo ghostly toasted brie	5	awesome	Last Available: "2011-09"
 5257	extra-energized triple-quantum shaking potion of the field gar	0		Effect: "Rosewater Mark", Effect Duration: 15, Last Available: "2011-09"
 5258	corrupted too legit potion	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 49, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	rosewater-soaked broken clock	0		Stench Resistance: +3, Last Available: "2011-09"
 5282	bouncing miser's dethklok	0		Meat Drop: +10, Last Available: "2011-09"
 5283	wobbly blurry avaricious glacial clock	0		Meat Drop: +30, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	normal half-sized phish stick	2	good	Last Available: "2011-09"
-5299	Tesla plastic vampire fangs of extreme caution of the glutton	0		Monster Level: -25, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	Tesla plastic vampire fangs of extreme caution of the glutton	0		Monster Level: -25, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	bouncing Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	skewed twirling your own heart	0		Last Available: "2011-10"
@@ -5211,7 +5211,7 @@
 5308	ghost trap	0		Last Available: "2011-10"
 5309	fuchsia chainsaw chain	0		Last Available: "2011-10"
 5310	pulsating lime green shotgun shell	0		Last Available: "2011-10"
-5311	ghostly yellow funhouse mirror	0		Last Available: "2011-10"
+5311	yellow ghostly funhouse mirror	0		Last Available: "2011-10"
 5312	quantum ghostly body paint	0		Effect: "Sweet and Green", Effect Duration: 18, Last Available: "2011-10"
 5313	irradiated alkaline cyan squat necrotizing body spray	0		Effect: "Egg Burps", Effect Duration: 33, Last Available: "2011-10"
 5314	pickled moist jittery bite-me-red lipstick	0		Effect: "Bone Homie", Effect Duration: 31, Last Available: "2011-10"
@@ -5219,7 +5219,7 @@
 5316	alkaline energized skewed press-on ribs	0		Effect: "Grumpy and Ornery", Effect Duration: 66, Last Available: "2011-10"
 5317	nitrogenated pickled Rattlin' Chains	0		Effect: "Gummi-Grin", Effect Duration: 21, Last Available: "2011-10"
 5318	tarnished Gummy Brains	0		Effect: "Fratty Flavor", Effect Duration: 58, Last Available: "2011-10"
-5319	vacuum-sealed modified spinning squat jittery Blood 'n' Plenty	0		Effect: "Sleazy Hands", Effect Duration: 35, Last Available: "2011-10"
+5319	vacuum-sealed modified squat jittery spinning Blood 'n' Plenty	0		Effect: "Sleazy Hands", Effect Duration: 35, Last Available: "2011-10"
 5320	irradiated diffused Lobos Mints	0		Effect: "Your Eyes are Peeled!", Effect Duration: 55, Last Available: "2011-10"
 5321	pressed oxidized Sweet Sword	0		Effect: "Superheroic", Effect Duration: 65, Last Available: "2011-10"
 5322	bad Ecto-Cooler	3	decent	Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	non-alkaline quantum red drum of pomade	0		Effect: "Pyromania", Effect Duration: 53, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extra-see-thru nightie of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-10"
-5333	auspicious nippy BRAINS shorts	0		Cold Damage: +10, Item Drop: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	auspicious nippy BRAINS shorts	0		Cold Damage: +10, Item Drop: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	beefcake's Mesmereyes&trade; contact lenses	0		Muscle: +25, Single Equip, Last Available: "2011-10"
 5335	flame-wreathed scrunchie	0		Hot Spell Damage: +10, Single Equip, Last Available: "2011-10"
-5336	chaotic quilted extremely skinny jeans	0		Damage Absorption: +40, Spell Critical Percent: +10, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	spinning thinker's The Necbromancer's Hat of dire peril	0		Mysticality: +10, Weapon Damage: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	chaotic quilted extremely skinny jeans	0		Damage Absorption: +40, Spell Critical Percent: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	spinning thinker's The Necbromancer's Hat of dire peril	0		Mysticality: +10, Weapon Damage: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	mirror Temple Grandin's Van der Graaf savvy The Necbromancer's Stein	0		Mysticality Percent: +20, Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-10"
-5339	ghostly red steel-toed smooth The Necbromancer's Shorts of courage	0		Moxie: +15, Damage Reduction: 9, Spooky Resistance: +3, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	ghostly red steel-toed smooth The Necbromancer's Shorts of courage	0		Moxie: +15, Damage Reduction: 9, Spooky Resistance: +3, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	censurious smelly The Necbromancer's Wizard Staff of incineration	0		Hot Spell Damage: +50, Stench Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	drinkable The Cooler Out of Space	3	good	Last Available: "2011-10"
@@ -5261,7 +5261,7 @@
 5358	spinning Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	blinking Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	cyan blinking Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
-5361	shaking wobbly skewed The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
+5361	shaking skewed wobbly The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	ghostly CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	fuchsia CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
@@ -5292,12 +5292,12 @@
 5389	diet adequate blinking ridiculous sandwich	1	good	Last Available: "2011-11"
 5390	artisanal ridiculous cocktail	3	EPIC	Last Available: "2011-11"
 5391	narrow narrow green chaotic strapping zombie monkey necklace	0		Muscle: +5, Spell Critical Percent: +10
-5392	jittery gray Thwaitgold butterfly statuette	0		
+5392	gray jittery Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
 5394	upside-down sandpaper	0		
 5395	skewed peppermint sprout	0		Last Available: "2011-11"
 5396	aerosolized energized blue peppermint twist	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 30, Last Available: "2011-11"
-5397	stale snack-sized peppermint patty	2	decent	Last Available: "2011-11"
+5397	snack-sized stale peppermint patty	2	decent	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5306,9 +5306,9 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	purple Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	knitted cane-mail shirt of extreme caution of the sweet-tooth	0		Monster Level: -25, Cold Resistance: +3, Candy Drop: +100, Last Available: "2011-12"
-5406	gravedigger's crafty cane-mail pants of horror	0		Maximum MP: +10, Spooky Damage: +10, Spooky Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	gravedigger's crafty cane-mail pants of horror	0		Maximum MP: +10, Spooky Damage: +10, Spooky Spell Damage: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	watered-down aged Vodka Matryoshka	2	awesome	Last Available: "2011-12"
-5408	smooth cyan twirling Gin Mint	3	awesome	Last Available: "2011-12"
+5408	smooth twirling cyan Gin Mint	3	awesome	Last Available: "2011-12"
 5409	drinkable Tequiz Navidad	4	good	Last Available: "2011-12"
 5410	aged high-proof narrow Mint Yulep	7	awesome	Last Available: "2011-12"
 5411	perfectly mixed Crimbojito	3	EPIC	Last Available: "2011-12"
@@ -5327,12 +5327,12 @@
 5424	Jim Carey's kumquartz ring	0		Monster Level: +25, Single Equip, Last Available: "2011-11"
 5425	shellacked strawberyl necklace	0		Damage Reduction: 7, Single Equip, Last Available: "2011-11"
 5426	Da Vinci's stylish sucker bucket	0		Moxie: +25, Experience (Mysticality): +5, Last Available: "2011-11"
-5427	Jeselnik's sucker hakama	0		Sleaze Damage: +25, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	mirror asbestos-lined sucker kabuto	0		Hot Resistance: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	Jeselnik's sucker hakama	0		Sleaze Damage: +25, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	mirror asbestos-lined sucker kabuto	0		Hot Resistance: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	bouncing blue stiffened sucker tachi	0		Damage Reduction: 1, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	maroon cinnamon troll doll	0		Last Available: "2011-11"
-5432	maroon upside-down twirling grape troll doll	0		Last Available: "2011-11"
+5432	upside-down maroon twirling grape troll doll	0		Last Available: "2011-11"
 5433	raspberry troll doll	0		Last Available: "2011-11"
 5434	squat pulsating DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
@@ -5340,12 +5340,12 @@
 5437	upside-down superheated fudge	0		Last Available: "2011-11"
 5438	double-denatured deionized pressed fluid of fudge-finding	0		Effect: "Sticky Hands", Effect Duration: 29, Last Available: "2011-11"
 5439	pulsating fudgepuck	0		Last Available: "2011-11"
-5440	spoiled miniature fudgesicle	2	crappy	Last Available: "2011-11"
+5440	miniature spoiled fudgesicle	2	crappy	Last Available: "2011-11"
 5441	narrow wand of fudge control	0		Last Available: "2011-11"
 5442	purple The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	jittery miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	galvanized quadruple-concentrated devilish folio	0		Effect: "Jingle Jangle Jingle", Effect Duration: 63, Last Available: "2012-12"
-5445	blinking green clumsiness bark	0		Last Available: "2012-12"
+5445	green blinking clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	jittery furious stone	0		Last Available: "2012-12"
@@ -5359,11 +5359,11 @@
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	wet quadruple-flattened Fudgie Roll	0		Effect: "Grrrrrrreat!", Effect Duration: 58, Last Available: "2011-11"
 5458	spoiled fudge bunny	3	crappy	Last Available: "2011-11"
-5459	bouncing twirling fudge spork	0		Last Available: "2011-11"
+5459	twirling bouncing fudge spork	0		Last Available: "2011-11"
 5460	executive family-friendly arcane researcher's fudgecycle	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +1, Meat Drop: +40, Single Equip, Last Available: "2011-11"
 5461	purple fudge cube	0		Last Available: "2011-11"
 5462	gray shaking blank fudge mold	0		Last Available: "2011-11"
-5463	gray Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	gray Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	double-deionized teal resolution: be wealthier	0		Effect: "Stuck That Way", Effect Duration: 13, Last Available: "2012-01"
 5465	quadruple-aerosolized alkaline flattened resolution: be happier	0		Effect: "Very Clean Teeth", Effect Duration: 55, Last Available: "2012-01"
 5466	non-enhanced double-Vulcanized resolution: be stronger	0		Effect: "Insulated Trousers", Effect Duration: 53, Last Available: "2012-01"
@@ -5376,13 +5376,13 @@
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	spinning gummi ingot	0		Last Available: "2011-11"
 5475	pulsating gummi ingot	0		Last Available: "2011-11"
-5476	alkaline quadruple-moist squat yellow gummi salamander	0		Effect: "Spooky Demeanor", Effect Duration: 42, Last Available: "2011-11"
+5476	alkaline quadruple-moist yellow squat gummi salamander	0		Effect: "Spooky Demeanor", Effect Duration: 42, Last Available: "2011-11"
 5477	ionized gummi snake	0		Effect: "Going Ape", Effect Duration: 15, Last Available: "2011-11"
 5478	denatured polarized activated yellow gummi canary	0		Effect: "Heightened Senses", Effect Duration: 64, Last Available: "2011-11"
-5479	flavorless half-sized gummi bear	2	decent	Last Available: "2011-11"
+5479	half-sized flavorless gummi bear	2	decent	Last Available: "2011-11"
 5480	adequate ghostly gummi bear	3	good	Last Available: "2011-11"
-5481	decent fancy gummi bear	4	good	Effect: "Castaway Physique", Effect Duration: 40, Last Available: "2011-11"
-5482	fancy bite-sized spoiled drunki-bear	1	crappy	Effect: "Moon-Eyed", Effect Duration: 20, Last Available: "2011-11"
+5481	fancy decent gummi bear	4	good	Effect: "Castaway Physique", Effect Duration: 40, Last Available: "2011-11"
+5482	bite-sized fancy spoiled drunki-bear	1	crappy	Effect: "Moon-Eyed", Effect Duration: 20, Last Available: "2011-11"
 5483	rotten miniature jittery drunki-bear	2	crappy	Last Available: "2011-11"
 5484	flavorless super-sized lime green drunki-bear	5	decent	Last Available: "2011-11"
 5485	gummi bowtie of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2011-11"
@@ -5394,12 +5394,12 @@
 5491	blue trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
-5494	tarnished pulsating squat gummi trilobite	0		Effect: "Itchy Trigger Finger", Effect Duration: 60, Last Available: "2011-11"
+5494	tarnished squat pulsating gummi trilobite	0		Effect: "Itchy Trigger Finger", Effect Duration: 60, Last Available: "2011-11"
 5495	improved blinking gummi ammonite	0		Effect: "Wintergreen Warmongery", Effect Duration: 19, Last Available: "2011-11"
 5496	nitrogenated gummi belemnite	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 12, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	blinking Newton's Big Candy's tophat of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	blinking Newton's Big Candy's tophat of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	narrow Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	spinning blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	normal jerky coins	4	good	Last Available: "2011-11"
-5507	strong drinkable Go-Wassail	5	good	Last Available: "2011-11"
+5507	drinkable strong Go-Wassail	5	good	Last Available: "2011-11"
 5508	alkaline warmed dry Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Become Superficially interested", Effect Duration: 12, Last Available: "2011-11"
 5509	vacuum-sealed ionized bouncing bottle of bubbles	0		Effect: "Orchid Blood", Effect Duration: 57, Last Available: "2011-11"
 5510	cold-filtered adjusted wind-up meatcar	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 26, Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	ionized moist Mortimer's nostrum	0		Effect: "Bootyliciousness", Effect Duration: 45, Last Available: "2012-12"
-5534	watered-down acceptable Barulio's bottle	2	good	Last Available: "2012-12"
+5534	acceptable watered-down Barulio's bottle	2	good	Last Available: "2012-12"
 5535	enhanced frozen ghostly Marvin's marvelous pill	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 23, Last Available: "2012-12"
 5536	upside-down Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5453,19 +5453,19 @@
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	shaking Clancy's lute	0		Last Available: "2012-12"
 5552	rock-hard Trusty	0		Damage Reduction: 5
-5553	narrow bouncing can of Rain-Doh	0		Last Available: "2012-02"
+5553	bouncing narrow can of Rain-Doh	0		Last Available: "2012-02"
 5554	empty Rain-Doh can	0		Last Available: "2012-02"
 5555	non-unsweetened diffused lime green shaking fireclutch	0		Effect: "Marbles in Your Mouth", Effect Duration: 53
 5556	asbestos-lined Rain-Doh wings of chilblains	0		Cold Damage: +25, Hot Resistance: +5, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	banded Rain-Doh laser gun of the pedagogue	0		Experience: +3, Damage Absorption: +100, Softcore Only, Last Available: "2012-02"
-5559	fortified Rain-Doh lantern of temperance	0		Damage Absorption: +60, Sleaze Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	fortified Rain-Doh lantern of temperance	0		Damage Absorption: +60, Sleaze Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	blinking Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	banded Rain-Doh violet bo of the detective	0		Damage Absorption: +100, Item Drop: +20, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	normal tumbling green PB&BP	3	good	
+5565	normal green tumbling PB&BP	3	good	
 5566	snack-sized adequate club sandwich	2	good	
 5567	adequate bouncing corned-beef Reuben	3	good	
 5568	frayed ninja rope	0		
@@ -5473,31 +5473,31 @@
 5570	blurry loose ninja carabiner	0		
 5571	shaking Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	lousy special Drac & Tan	4	decent	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2012-03"
+5573	special lousy Drac & Tan	4	decent	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2012-03"
 5574	delicious Transylvania Sling	3	awesome	Last Available: "2012-03"
 5575	acceptable mirror Shot of the Living Dead	4	good	Last Available: "2012-03"
-5576	weak lousy cyan shaking Buttery Knob	2	decent	Last Available: "2012-03"
+5576	lousy weak cyan shaking Buttery Knob	2	decent	Last Available: "2012-03"
 5577	acceptable watered-down fuchsia Slippery Knob	2	good	Last Available: "2012-03"
-5578	special perfectly mixed Flaming Knob	3	EPIC	Effect: "Impregnably Delicious", Effect Duration: 10, Last Available: "2012-03"
+5578	perfectly mixed special Flaming Knob	3	EPIC	Effect: "Impregnably Delicious", Effect Duration: 10, Last Available: "2012-03"
 5579	drinkable Grasshopper	4	good	Last Available: "2012-03"
 5580	delicious gray twirling Locust	3	awesome	Last Available: "2012-03"
 5581	drinkable Plague of Locusts	4	good	Last Available: "2012-03"
 5582	tolerable pulsating Red Dwarf	3	good	Last Available: "2012-03"
-5583	drinkable weak Golden Mean	2	good	Last Available: "2012-03"
+5583	weak drinkable Golden Mean	2	good	Last Available: "2012-03"
 5584	aged blurry Green Giant	3	awesome	Last Available: "2012-03"
 5585	artisanal Aye Aye	4	EPIC	Last Available: "2012-03"
-5586	lousy practically non-alcoholic Aye Aye, Captain	1	decent	Last Available: "2012-03"
+5586	practically non-alcoholic lousy Aye Aye, Captain	1	decent	Last Available: "2012-03"
 5587	watered-down lousy Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
-5588	perfectly mixed practically non-alcoholic mirror Humanitini	1	EPIC	Last Available: "2012-03"
-5589	triple-distilled acceptable More Humanitini than Humanitini	10	good	Last Available: "2012-03"
+5588	practically non-alcoholic perfectly mixed mirror Humanitini	1	EPIC	Last Available: "2012-03"
+5589	acceptable triple-distilled More Humanitini than Humanitini	10	good	Last Available: "2012-03"
 5590	watered-down fancy bad Oh, the Humanitini	2	decent	Effect: "Ripping, Dripping", Effect Duration: 40, Last Available: "2012-03"
 5591	bad extra-dry Great Older Fashioned	5	decent	Last Available: "2012-03"
-5592	practically non-alcoholic perfectly mixed gray Fuzzy Tentacle	1	EPIC	Last Available: "2012-03"
+5592	perfectly mixed practically non-alcoholic gray Fuzzy Tentacle	1	EPIC	Last Available: "2012-03"
 5593	perfectly mixed Crazymaker	3	EPIC	Last Available: "2012-03"
 5594	triple-distilled tolerable Zoodriver	7	good	Last Available: "2012-03"
-5595	weak drinkable Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
+5595	drinkable weak Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
 5596	tolerable Sloe Comfortable Zoo on Fire	3	good	Last Available: "2012-03"
-5597	distilled artisanal shaking Suffering Sinner	5	EPIC	Last Available: "2012-03"
+5597	artisanal distilled shaking Suffering Sinner	5	EPIC	Last Available: "2012-03"
 5598	artisanal pulsating Suppurating Sinner	4	EPIC	Last Available: "2012-03"
 5599	bad special Sizzling Sinner	3	decent	Effect: "L'instinct F&eacute;lin", Effect Duration: 25, Last Available: "2012-03"
 5600	bad skewed Firewater	3	decent	Last Available: "2012-03"
@@ -5505,37 +5505,37 @@
 5602	acceptable Earth, Wind and Firewater	3	good	Last Available: "2012-03"
 5603	hand-crafted skewed Slimosa	4	EPIC	Last Available: "2012-03"
 5604	lousy weak tumbling Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
-5605	fancy lousy watered-down Slimebite	2	decent	Effect: "Antsy in your Pantsy", Effect Duration: 10, Last Available: "2012-03"
-5606	practically non-alcoholic smooth Cement Mixer	1	awesome	Last Available: "2012-03"
+5605	lousy watered-down fancy Slimebite	2	decent	Effect: "Antsy in your Pantsy", Effect Duration: 10, Last Available: "2012-03"
+5606	smooth practically non-alcoholic Cement Mixer	1	awesome	Last Available: "2012-03"
 5607	tolerable Jackhammer	4	good	Last Available: "2012-03"
 5608	smooth Dump Truck	3	awesome	Last Available: "2012-03"
-5609	practically non-alcoholic acceptable pulsating Fauna Libre	1	good	Last Available: "2012-03"
+5609	acceptable practically non-alcoholic pulsating Fauna Libre	1	good	Last Available: "2012-03"
 5610	watered-down drinkable mirror Chakra Libre	2	good	Last Available: "2012-03"
 5611	special acceptable Aura Libre	3	good	Effect: "Tenacity of the Snapper", Effect Duration: 15, Last Available: "2012-03"
-5612	weak bad special Sazerorc	2	decent	Effect: "Chow Downed", Effect Duration: 35, Last Available: "2012-03"
-5613	perfectly mixed irresponsibly strong upside-down Sazuruk-hai	8	EPIC	Last Available: "2012-03"
+5612	bad weak special Sazerorc	2	decent	Effect: "Chow Downed", Effect Duration: 35, Last Available: "2012-03"
+5613	irresponsibly strong perfectly mixed upside-down Sazuruk-hai	8	EPIC	Last Available: "2012-03"
 5614	perfectly mixed Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	hand-crafted pulsating Green Velvet	4	EPIC	Last Available: "2012-03"
 5616	drinkable bouncing Green Muslin	3	good	Last Available: "2012-03"
 5617	bad bouncing Green Burlap	4	decent	Last Available: "2012-03"
 5618	drinkable shaking Mohobo	4	good	Last Available: "2012-03"
 5619	hand-crafted shaking Moonshine Mohobo	4	EPIC	Last Available: "2012-03"
-5620	mediocre twirling tumbling Flaming Mohobo	3	decent	Last Available: "2012-03"
-5621	practically non-alcoholic smooth wobbly Drunken Philosopher	1	awesome	Last Available: "2012-03"
+5620	mediocre tumbling twirling Flaming Mohobo	3	decent	Last Available: "2012-03"
+5621	smooth practically non-alcoholic wobbly Drunken Philosopher	1	awesome	Last Available: "2012-03"
 5622	fortified delicious Drunken Neurologist	5	awesome	Last Available: "2012-03"
-5623	practically non-alcoholic lousy jittery Drunken Astrophysicist	1	decent	Last Available: "2012-03"
-5624	artisanal bouncing ghostly Dark & Starry	4	EPIC	Last Available: "2012-03"
+5623	lousy practically non-alcoholic jittery Drunken Astrophysicist	1	decent	Last Available: "2012-03"
+5624	artisanal ghostly bouncing Dark & Starry	4	EPIC	Last Available: "2012-03"
 5625	hand-crafted blurry Black Hole	3	EPIC	Last Available: "2012-03"
 5626	delicious yellow twirling Event Horizon	4	awesome	Last Available: "2012-03"
 5627	artisanal practically non-alcoholic Herring Daiquiri	1	EPIC	Last Available: "2012-03"
 5628	bad Herring Wallbanger	3	decent	Last Available: "2012-03"
-5629	practically non-alcoholic perfectly mixed spinning Herringtini	1	super ultra EPIC	Last Available: "2012-03"
+5629	perfectly mixed practically non-alcoholic spinning Herringtini	1	super ultra EPIC	Last Available: "2012-03"
 5630	drinkable Lollipop Drop	3	good	Last Available: "2012-03"
 5631	lousy Candy Alexander	3	decent	Last Available: "2012-03"
 5632	watered-down bad Candicaine	2	decent	Last Available: "2012-03"
 5633	perfectly mixed mirror Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	smooth pulsating Flying Caipiranha	3	awesome	Last Available: "2012-03"
-5635	acceptable watered-down Flaming Caipiranha	2	good	Last Available: "2012-03"
+5635	watered-down acceptable Flaming Caipiranha	2	good	Last Available: "2012-03"
 5636	acceptable shaking Punchplanter	3	good	Last Available: "2012-03"
 5637	practically non-alcoholic lousy spinning Doublepunchplanter	1	decent	Last Available: "2012-03"
 5638	bad Haymaker	3	decent	Last Available: "2012-03"
@@ -5548,14 +5548,14 @@
 5645	upside-down the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	purple bouncing calendar of the wise owl	0		Mysticality: +20, Damage Reduction: 4
-5648	squat rosy-cheeked Boris's Helm of Gandalf	0		Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	squat rosy-cheeked Boris's Helm of Gandalf	0		Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	staph of homophones of James Dean of the early riser	0		Experience (Moxie): +3, Adventures: +7
-5650	rock-hard Da Vinci's Boris's Helm (askew) of Gandalf	0		Experience (Mysticality): +5, Damage Reduction: 5, Spell Critical Percent: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	rock-hard Da Vinci's Boris's Helm (askew) of Gandalf	0		Experience (Mysticality): +5, Damage Reduction: 5, Spell Critical Percent: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	mirror Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	rotten nailswurst	3	crappy	
-5655	mediocre watered-down green used beer	2	decent	
+5655	watered-down mediocre green used beer	2	decent	
 5656	Huggler Radio	0		Free Pull
 5657	wobbly fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	ghostly slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5568,21 +5568,21 @@
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	skewed How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
-5668	jittery teal bagged &quot;L&quot;	0		
+5668	teal jittery bagged &quot;L&quot;	0		
 5669	club	0		
 5670	yummy fettucini &eacute;pines Inconnu	3	awesome	
-5671	practically non-alcoholic perfectly mixed slap and slap again	1	EPIC	
+5671	perfectly mixed practically non-alcoholic slap and slap again	1	EPIC	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	green &quot;L&quot;	0		
 5675	mixed skewed watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	Ze&trade; goggles of Leguizamo	0		Monster Level: +20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	Ze&trade; goggles of Leguizamo	0		Monster Level: +20, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	bouncing upside-down supercharged stylish swimsuit of horror	0		Maximum MP Percent: +30, Spooky Spell Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	bouncing upside-down supercharged stylish swimsuit of horror	0		Maximum MP Percent: +30, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	stale P.B.L.T.	4	decent	
-5682	maroon squat squat note from Clancy	0		Skill: "Request Sandwich"
+5682	squat squat maroon note from Clancy	0		Skill: "Request Sandwich"
 5683	upside-down BURT	0		
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
@@ -5601,31 +5601,31 @@
 5698	friendly hardened The Lost Glasses	0		Damage Reduction: 3, Familiar Weight: +3, Single Equip
 5699	The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
-5701	tumbling huge Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
+5701	huge tumbling Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	cyan mannequin	0		Familiar Weight: +5
 5703	purple crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	huge foul-smelling wax hat of dire peril	0		Weapon Damage: +20, Stench Damage: +10, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	green greasy wholesome wax pants	0		Maximum HP Percent: +10, Sleaze Spell Damage: +10, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	huge foul-smelling wax hat of dire peril	0		Weapon Damage: +20, Stench Damage: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	green greasy wholesome wax pants	0		Maximum HP Percent: +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	altered drop of water-37	0		Effect: "Adrenaline Rush", Effect Duration: 12, Last Available: "2012-07"
-5709	greedy groovy fireman's helmet	0		Moxie Percent: +10, Meat Drop: +20, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	greedy groovy fireman's helmet	0		Moxie Percent: +10, Meat Drop: +20, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	blinking savvy fire axe	0		Mysticality Percent: +20, Last Available: "2012-07"
 5713	toasty rosy-cheeked fire extinguisher of the glutton	0		Maximum HP Percent: +30, Hot Damage: +5, Food Drop: +100, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	upside-down Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	fancy massive stale FDKOL hotcakes	7	decent	Effect: "Okee-Dokee Go!", Effect Duration: 20, Last Available: "2012-07"
+5717	stale massive fancy FDKOL hotcakes	7	decent	Effect: "Okee-Dokee Go!", Effect Duration: 20, Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	immense adequate fiery wing	10	good	Last Available: "2012-07"
+5720	adequate immense fiery wing	10	good	Last Available: "2012-07"
 5721	spinning Oprah's wings of fire of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Last Available: "2012-07"
 5722	squat FDKOL fire hose of the wise owl	0		Mysticality: +20, Last Available: "2012-07"
 5723	anodized oxidized bottle of fire	0		Effect: "Bottle in front of Me", Effect Duration: 19, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	hot daub bun of the sewer of the cheetah	0		Stench Damage: +25, Initiative: +60, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	Jack Frost's Samson's hot daub stand	0		Experience (Muscle): +5, Cold Spell Damage: +50, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	hot daub bun of the sewer of the cheetah	0		Stench Damage: +25, Initiative: +60, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	Jack Frost's Samson's hot daub stand	0		Experience (Muscle): +5, Cold Spell Damage: +50, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	Jeselnik's fortified foot-long hot daub	0		Damage Absorption: +60, Sleaze Damage: +25, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy angst burger	3	crappy	
@@ -5633,7 +5633,7 @@
 5732	ghostly blank note	0		
 5733	eerily silent box	0		
 5734	immense rotten forbidden sausage	6	crappy	
-5735	chilly Lord Flameface's cloak	0		Cold Damage: +5, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	chilly Lord Flameface's cloak	0		Cold Damage: +5, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	quadruple-irradiated pulsating Drizzlers&trade; Black Licorice	0		Effect: "Taurus Rising", Effect Duration: 23
 5737	deionized pickled daub-breaker	0		Effect: "Fishy", Effect Duration: 30, Last Available: "2020-09"
 5738	Jack Frost's Camp Scout backpack	0		Cold Spell Damage: +50, Softcore Only, Last Available: "2012-07"
@@ -5642,7 +5642,7 @@
 5741	weak acceptable shaking water purification pills	2	good	Last Available: "2012-07"
 5742	upside-down Camp Scout pup tent	0		Last Available: "2012-07"
 5743	lousy wobbly CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
-5744	small adequate bag of GORF	2	good	Last Available: "2012-07"
+5744	adequate small bag of GORF	2	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	stale bag of QWOP	4	decent	Last Available: "2012-07"
 5747	magnetized liquefied CSA bravery badge	0		Effect: "Eyes of the Dragon", Effect Duration: 23, Last Available: "2012-07"
@@ -5652,7 +5652,7 @@
 5751	Tales of the Word Realms	0		
 5752	rotten fancy tumbling twirling crappy brain	3	crappy	Effect: "Shamboozled", Effect Duration: 15
 5753	bland yellow decent brain	3	decent	
-5754	thick adequate good brain	5	good	
+5754	adequate thick good brain	5	good	
 5755	stale boss brain	3	decent	
 5756	flavorless hunter brain	3	decent	
 5758	Jeselnik's padded Staff of Holiday Sensations of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Sleaze Damage: +25, Last Available: "2011-11"
@@ -5665,13 +5665,13 @@
 5765	Tesla brainy fuzzy earmuffs	0		Mysticality: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5766	crafty wizardly fuzzy montera of the boozehound	0		Mysticality: +25, Maximum MP: +10, Booze Drop: +100, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	squat huge gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Familiar Effect: "underwater", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Familiar Effect: "block", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Familiar Effect: "damage", Last Available: "2012-08"
+5771	squat huge gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs", Last Available: "2012-08"
+5772	gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Familiar Effect: "delevel", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
-5774	narrow skewed talkative skull	0		
+5774	skewed narrow talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	Usain Bolt's lion tamer's Barney's rake	0		Experience (familiar): +2, Initiative: +80
 5778	moldy small wobbly idiot brain	2	crappy	
@@ -5687,12 +5687,12 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	red box of bear arms	0		Last Available: "2012-09"
-5791	Newton's right bear arm of horror	0		Experience (Mysticality): +3, Spooky Spell Damage: +25, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	rosy-cheeked strapping left bear arm of the cheetah	0		Muscle: +5, Maximum HP Percent: +30, Initiative: +60, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	Newton's right bear arm of horror	0		Experience (Mysticality): +3, Spooky Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	rosy-cheeked strapping left bear arm of the cheetah	0		Muscle: +5, Maximum HP Percent: +30, Initiative: +60, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	pulsating executive Hat O' Nine Tails	0		Meat Drop: +40
 5794	nitrogenated tumbling Enchanted Plunger	0		Effect: "Granolarrrgh", Effect Duration: 48
 5795	warmed vacuum-sealed skewed Enchanted Flyswatter	0		Effect: "The Power of LOV", Effect Duration: 42
-5796	anodized quadruple-magnetized upside-down narrow Gearhead Goo	0		Effect: "Spooky Demeanor", Effect Duration: 29
+5796	anodized quadruple-magnetized narrow upside-down Gearhead Goo	0		Effect: "Spooky Demeanor", Effect Duration: 29
 5797	anodized olive Missing Eye Simulation Device	0		Effect: "Infernal Thirst", Effect Duration: 38
 5798	diffused colloidal Gnollish Crossdress	0		Effect: "Mint-Condition Breath", Effect Duration: 62
 5799	energized jittery eldritch dough	0		Effect: "Voracious Gorging", Effect Duration: 60
@@ -5719,7 +5719,7 @@
 5820	adjusted teal bouncing bull blubber	0		Effect: "Old School Pompadour", Effect Duration: 32
 5821	polymerized non-adjusted bouncing frog lip-print	0		Effect: "Stregngth of the Gnome", Effect Duration: 39
 5822	concentrated corrupted skewed gazely stare	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 59
-5823	warmed ghostly cyan canopic jar	0		Effect: "Mucilaginous Muscle", Effect Duration: 26
+5823	warmed cyan ghostly canopic jar	0		Effect: "Mucilaginous Muscle", Effect Duration: 26
 5824	aerosolized narrow clove-flavored lip balm	0		Effect: "Blood-Gorged", Effect Duration: 45
 5825	electrified ionized gray Skullery Maid's Knee	0		Effect: "Mushroom Might", Effect Duration: 30
 5826	vacuum-sealed wet spinning zombie hollandaise	0		Effect: "Fungal Fortification", Effect Duration: 46
@@ -5758,7 +5758,7 @@
 5859	alkaline red booby trap	0		Effect: "Going Ape", Effect Duration: 31
 5860	aerosolized Agent Corrigan's cigarette	0		Effect: "Unusual Fashion Sense", Effect Duration: 40
 5861	alkaline irradiated good ash	0		Effect: "[1609]Dancin' Fool", Effect Duration: 32
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	spinning papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	quadruple-dry blurry squat papier-mochi	0		Effect: "Deadly Lampblade", Effect Duration: 56, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	jittery sizzling brawny papier-m&acirc;ch&eacute;te	0		Muscle Percent: +20, Hot Damage: +10, Last Available: "2012-09"
 5869	Jeselnik's Herculean papier-m&acirc;chine gun	0		Experience (Muscle): +1, Sleaze Damage: +25, Last Available: "2012-09"
 5870	lime green shaking papier-masque of James Dean of the boozehound	0		Experience (Moxie): +3, Booze Drop: +100, Single Equip, Last Available: "2012-09"
-5871	tumbling olive greasy curative papier-mitre	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	maroon forbidden papier-m&acirc;churidars of the early riser	0		Spell Damage Percent: +50, Adventures: +7, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	tumbling olive greasy curative papier-mitre	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	maroon forbidden papier-m&acirc;churidars of the early riser	0		Spell Damage Percent: +50, Adventures: +7, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	spinning papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	jittery skeleton	0		Last Available: "2012-10"
 5882	Jim Carey's stylish skeleton skis of the pedagogue	0		Moxie: +25, Experience: +3, Monster Level: +25, Single Equip, Last Available: "2012-10"
-5883	adequate immense pulsating skeleton quiche	8	good	Last Available: "2012-10"
+5883	immense adequate pulsating skeleton quiche	8	good	Last Available: "2012-10"
 5884	blurry skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	lion tamer's supercharged smooth brainy Bonestabber	0		Mysticality: +5, Moxie: +15, Maximum MP Percent: +30, Experience (familiar): +2, Last Available: "2012-10"
@@ -5789,7 +5789,7 @@
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	polymerized wet that gum you like	0		Effect: "Thanksgot", Effect Duration: 46
-5893	yellow bouncing dreaming Jung man	0		Free Pull, Last Available: "2013-12"
+5893	bouncing yellow dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
@@ -5799,7 +5799,7 @@
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	ghostly jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
-5903	red blinking jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
+5903	blinking red jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	pixel pill	0		
 5907	pixel energy tank	0		
@@ -5823,7 +5823,7 @@
 5925	ghostly ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	shaking BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	gray rock-hard brainwave-controlled unicorn horn	0		Damage Reduction: 5, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	gray rock-hard brainwave-controlled unicorn horn	0		Damage Reduction: 5, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	mirror smartaleck's plastic four-shadowed mime of dire peril of the brazier	0		Moxie Percent: +30, Weapon Damage: +20, Hot Spell Damage: +25, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	chaotic plastic Father McGruber	0		Spell Critical Percent: +10, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of bravery	0		Spooky Resistance: +5, Last Available: "2012-12"
 5962	nippy plastic blazing bat	0		Cold Damage: +10, Last Available: "2012-12"
-5963	zippy electronic dulcimer pants of the cheetah	0		Initiative: 80, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	zippy electronic dulcimer pants of the cheetah	0		Initiative: 80, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
 5964	huge A-Boo clue	0		
 5965	lightning-fast Frown Exerciser of the empath	0		Familiar Weight: +5, Initiative: +40, Single Equip, Last Available: "2012-12"
 5966	huge soul monocle	0		Single Equip
@@ -5867,7 +5867,7 @@
 5969	squat soul knife	0		
 5970	mirror clever soul mask	0		Maximum MP: +20, Single Equip
 5971	maroon record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
-5972	squat ghostly olive record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
+5972	ghostly squat olive record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
 5973	record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	narrow record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
@@ -5877,17 +5877,17 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	bouncing star	0		Last Available: "2013-02"
-5982	tolerable watered-down mirror jittery tankard of ale	2	good	Last Available: "2013-02"
+5982	watered-down tolerable jittery mirror tankard of ale	2	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	shaking auspicious veiny Samson's cloth cap	0		Experience (Muscle): +5, Maximum HP: +10, Item Drop: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	shaking auspicious veiny Samson's cloth cap	0		Experience (Muscle): +5, Maximum HP: +10, Item Drop: +10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	purple shaking Jack Frost's quilted iron dagger of temperance	0		Damage Absorption: +40, Cold Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2013-02"
-5986	diet normal hamburger	1	good	Last Available: "2013-02"
+5986	normal diet hamburger	1	good	Last Available: "2013-02"
 5987	jittery dollar-sign bag	0		Last Available: "2013-02"
 5988	narrow potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
 5990	bad bottle of wine	4	decent	Last Available: "2013-02"
 5991	jittery round bomb	0		Last Available: "2013-02"
-5992	Herculean supercool iron helmet	0		Moxie Percent: +20, Experience (Muscle): +1, Item Drop: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	Herculean supercool iron helmet	0		Moxie Percent: +20, Experience (Muscle): +1, Item Drop: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	upside-down mirror wool Jim Carey's stylish steel sword	0		Moxie: +25, Monster Level: +25, Cold Resistance: +1, Last Available: "2013-02"
 5994	stale whole roasted chicken	3	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	lousy skewed shining goblet	3	decent	Last Available: "2013-02"
 5999	squat fireball	0		Last Available: "2013-02"
-6000	reassuring supercharged therapeutic crown	0		Maximum MP Percent: +30, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	reassuring supercharged therapeutic crown	0		Maximum MP Percent: +30, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	cyan mirror sinister sword of wisdom of the storm	0		Mysticality: +15, Spell Damage: +10, Maximum MP Percent: +40, Last Available: "2013-02"
-6002	personal trainer's savvy Helm of the Scream Emperor of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Experience Percent (Muscle): +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	personal trainer's savvy Helm of the Scream Emperor of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Experience Percent (Muscle): +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	cyan double-paned thinker's Cloak of Dire Shadows of wisdom	0		Mysticality: 25, Cold Resistance: +5, Last Available: "2013-02"
 6004	reassuring asbestos-lined Tesla Sword of Dark Omens	0		Hot Resistance: +5, Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02"
 6005	zippy Shield of Icy Fate of chilblains of temperance	0		Cold Damage: +25, Sleaze Resistance: +5, Initiative: +20, Damage Reduction: 7, Last Available: "2013-02"
-6006	frightening curative Newton's Greaves of the Murk Lord	0		Experience (Mysticality): +3, Spooky Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	frightening curative Newton's Greaves of the Murk Lord	0		Experience (Mysticality): +3, Spooky Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	shaking Oprah's fortified Gauntlets of the Blood Moon of the businessman	0		Damage Absorption: +60, Maximum MP Percent: +50, Meat Drop: +50, Single Equip, Last Available: "2013-02"
 6008	scorching nippy Boots of Twilight Whispers of the businessman	0		Cold Damage: +10, Hot Damage: +25, Meat Drop: +50, Single Equip, Last Available: "2013-02"
 6009	scandalous Belt of Howling Anger of wisdom	0		Mysticality: +15, Sleaze Damage: +5, Item Drop: +5, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	wet extra-deionized orcish hand lotion	0		Effect: "Phairly Pheromonal", Effect Duration: 47
 6016	activated pulsating orcish rubber	0		Effect: "Fizzier Than Light", Effect Duration: 47
 6017	denatured corrupted orcish nailing lube	0		Effect: "Armored Innards", Effect Duration: 54
-6018	watered-down aged backwoods screwdriver	2	awesome	
+6018	aged watered-down backwoods screwdriver	2	awesome	
 6019	Oprah's loadstone	0		Maximum MP Percent: +50
 6020	Jeselnik's groovy Claybender glasses	0		Moxie Percent: +10, Sleaze Damage: +25, Single Equip
 6021	energetic Duskwalker fangs of the sewer	0		Maximum MP Percent: +20, Stench Damage: +25
@@ -5938,7 +5938,7 @@
 6040	blinking scorching clever oil lamp	0		Maximum MP: +20, Hot Damage: +25
 6041	grievous oil slacks	0		Weapon Damage Percent: +50, Familiar Effect: "1xPotato, cap 30"
 6042	frightening oil pan	0		Spooky Damage: +5
-6043	jittery gray blinking boid	0		
+6043	gray blinking jittery boid	0		
 6044	jittery woim	0		
 6045	Thwaitgold praying mantis statuette	0		
 6046	BittyCar SoulCar	0		Last Available: "2012-12"
@@ -5947,11 +5947,11 @@
 6049	executive Jim Carey's Misty Cape of temperance	0		Monster Level: +25, Sleaze Resistance: +5, Meat Drop: +40
 6050	pulsating woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	half-sized spoiled olive Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
+6052	spoiled half-sized olive Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
 6053	lousy tumbling Taco Dan's Taco Stand Chimichangarita	4	decent	Last Available: "2012-12"
 6054	polarized tarnished wobbly Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Pronounced Potency", Effect Duration: 46, Last Available: "2012-12"
 6055	tumbling yellow psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	Meatcleaver of the overflowing toilet of horror	0		Stench Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2013-12"
 6058	quilted Crimbo Elf bobble-head	0		Damage Absorption: +40, Last Available: "2012-12"
 6059	olive Crimbo stogie-scented room odorizer of wisdom	0		Mysticality: +15, Last Available: "2012-12"
@@ -5966,7 +5966,7 @@
 6068	loose blade	0		
 6069	jittery goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	dry anodized haggis-infused soap	0		Effect: "You Know When to Walk Away", Effect Duration: 17, Last Available: "2012-12"
 6074	electrified modified magicberry tablets	0		Effect: "Pasta Oneness", Effect Duration: 58, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	normal wobbly haggis-wrapped haggis-stuffed haggis	3	good	Last Available: "2012-12"
 6078	tumbling home robotics kit	0		Last Available: "2012-12"
 6079	blurry school calculator watch	0		Last Available: "2012-12"
-6080	frosty haggis socks	0		Cold Spell Damage: +10, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	cyan airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	frosty haggis socks	0		Cold Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	cyan airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6020,7 +6020,7 @@
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
-6125	ionized huge narrow bottle of limeade	0		Effect: "Oxygenated Blood", Effect Duration: 68, Last Available: "2013-12"
+6125	ionized narrow huge bottle of limeade	0		Effect: "Oxygenated Blood", Effect Duration: 68, Last Available: "2013-12"
 6126	fuchsia crafty dance instructor's novelty tattoo sleeves	0		Experience Percent (Moxie): +10, Maximum MP: +10, Single Equip, Last Available: "2013-12"
 6127	mirror pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	furry brown pillow	0		Last Available: "2013-12"
@@ -6037,10 +6037,10 @@
 6139	twirling jittery nasty rubber gloves	0		Stench Damage: +5, Last Available: "2013-12"
 6140	olive squat Chinese curse words	0		Last Available: "2013-12"
 6141	green triad summoning scroll	0		Last Available: "2013-12"
-6142	gigantic rotten roasted duck	8	crappy	Last Available: "2013-12"
+6142	rotten gigantic roasted duck	8	crappy	Last Available: "2013-12"
 6143	tasty twirling dead meat bun	3	awesome	Last Available: "2013-12"
 6144	jittery Socratic cat collar	0		Experience (Mysticality): +1, Single Equip, Last Available: "2013-12"
-6145	friendly personal trainer's suspicious-looking fedora	0		Experience Percent (Muscle): +10, Familiar Weight: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	friendly personal trainer's suspicious-looking fedora	0		Experience Percent (Muscle): +10, Familiar Weight: +3, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	twirling Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6052,14 +6052,14 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	censurious beefcake's Byte	0		Muscle: +25, Sleaze Resistance: +3, Last Available: "2013-12"
-6158	gray banded anger blaster	0		Damage Absorption: +100, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	mirror maroon doubt cannon of the businessman	0		Meat Drop: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	fear condenser of temperance	0		Sleaze Resistance: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	educational regret hose	0		Experience: +1, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	gray banded anger blaster	0		Damage Absorption: +100, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	mirror maroon doubt cannon of the businessman	0		Meat Drop: +50, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	fear condenser of temperance	0		Sleaze Resistance: +5, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	educational regret hose	0		Experience: +1, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	ghostly Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	resourceful Samson's commodore's hat	0		Experience (Muscle): +5, Maximum MP: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	naval trousers of the early riser	0		Adventures: +7, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	resourceful Samson's commodore's hat	0		Experience (Muscle): +5, Maximum MP: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	naval trousers of the early riser	0		Adventures: +7, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	cool deck cannon	0		Moxie: +5, Item Drop: +5, Last Available: "2013-12"
 6167	pulsating vibrating ornamental sextant	0		Maximum MP Percent: +10, Last Available: "2013-12"
 6168	Jack Frost's Bloodbath of the cougar	0		Moxie: +20, Cold Spell Damage: +50, Last Available: "2013-12"
@@ -6075,14 +6075,14 @@
 6178	cosmic vegetable	0		
 6179	upside-down cosmic cheese	0		
 6180	ghostly cosmic potted meat product	0		
-6181	olive bouncing cosmic potato	0		
+6181	bouncing olive cosmic potato	0		
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	stanky razor-sharp Da Vinci's Jarlsberg's hat	0		Experience (Mysticality): +5, Weapon Damage Percent: +25, Stench Spell Damage: +25
-6185	moldy special blurry consummate hard-boiled egg	3	crappy	Effect: "Here to Kick Ass", Effect Duration: 15
+6185	special moldy blurry consummate hard-boiled egg	3	crappy	Effect: "Here to Kick Ass", Effect Duration: 15
 6186	flavorless consummate fried egg	4	decent	
-6187	bite-sized spoiled wobbly consummate egg salad	1	crappy	
-6188	toothsome half-sized consummate bagel	2	awesome	
+6187	spoiled bite-sized wobbly consummate egg salad	1	crappy	
+6188	half-sized toothsome consummate bagel	2	awesome	
 6189	spoiled consummate sliced bread	4	crappy	
 6190	diet spoiled consummate hot dog bun	1	crappy	
 6191	spoiled miniature blue consummate brownie	2	crappy	
@@ -6094,23 +6094,23 @@
 6197	snack-sized rotten consummate salsa	2	crappy	
 6198	decent consummate sauerkraut	3	good	
 6199	delicious skewed consummate cheese slice	3	awesome	
-6200	spoiled jumbo fuchsia consummate melted cheese	5	crappy	
+6200	jumbo spoiled fuchsia consummate melted cheese	5	crappy	
 6201	moldy consummate bacon	3	crappy	
 6202	decent consummate meatloaf	3	good	
 6203	spoiled consummate steak	3	crappy	
 6204	tasty consummate cuts	4	awesome	
 6205	decent consummate frankfurter	4	good	
-6206	miniature bland consummate french fries	2	decent	
+6206	bland miniature consummate french fries	2	decent	
 6207	half-sized stale shaking consummate baked potato	2	decent	
 6208	watered-down mediocre acceptable vodka	2	decent	
 6209	spoiled consummate ice cream	4	crappy	
 6210	normal spinning consummate whipped cream	3	good	
-6211	flavorless gigantic cyan consummate cream	6	decent	
-6212	tasty jumbo consummate strawberries	5	awesome	
+6211	gigantic flavorless cyan consummate cream	6	decent	
+6212	jumbo tasty consummate strawberries	5	awesome	
 6213	diet moldy fancy consummate sorbet	1	crappy	Effect: "Charrrming", Effect Duration: 50
-6214	weak artisanal enchanted adequate rum	2	EPIC	Effect: "Egg on your Face", Effect Duration: 30
+6214	weak enchanted artisanal adequate rum	2	EPIC	Effect: "Egg on your Face", Effect Duration: 30
 6215	lousy weak mediocre lager	2	decent	
-6216	adequate shaking tumbling immaculate grilled cheese	3	good	
+6216	adequate tumbling shaking immaculate grilled cheese	3	good	
 6217	moldy spinning immaculate ice cream sandwich	4	crappy	
 6218	stale immaculate hot dog	4	decent	
 6219	normal immaculate egg salad sandwich	4	good	
@@ -6119,17 +6119,17 @@
 6222	spoiled bouncing perfect breakfast	3	crappy	
 6223	normal big sublime deluxe hot dog	5	good	
 6224	spoiled huge sublime stew	8	crappy	
-6225	tiny adequate olive sublime nachos	1	good	
+6225	adequate tiny olive sublime nachos	1	good	
 6226	toothsome huge Ultimate Breakfast Sandwich	4	awesome	
 6227	stale mirror Loaded Baked Potato	3	decent	
-6228	half-sized tasty Omega Sundae	2	awesome	
+6228	tasty half-sized Omega Sundae	2	awesome	
 6229	acceptable Das Sauerlager	4	good	
 6230	drinkable watered-down Bologna Lambic	2	good	
-6231	bad boozy Vodka Dog	5	decent	
+6231	boozy bad Vodka Dog	5	decent	
 6232	mediocre twirling Disappointed Russian	4	decent	
 6233	artisanal Chunky Mary	3	EPIC	
-6234	weak lousy Nachojito	2	decent	
-6235	tolerable high-proof Le Roi	9	good	
+6234	lousy weak Nachojito	2	decent	
+6235	high-proof tolerable Le Roi	9	good	
 6236	special weak lousy Over Easy Rider	2	decent	Effect: "Sweet and Red", Effect Duration: 5
 6237	wobbly huge cosmic six-pack	0		
 6239	modified jittery cube of ectoplasm	0		Effect: "Moose Wisdom", Effect Duration: 11
@@ -6148,7 +6148,7 @@
 6252	alkaline double-oxidized scroll of Puddingskin	0		Effect: "Orc Chops", Effect Duration: 18, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	tumbling blurry Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
-6255	pulsating ghostly Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
+6255	ghostly pulsating Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	blurry dried gelatinous cube	0		
 6257	maroon pile of dungeon junk	0		Familiar Weight: +5
 6258	greasy hardy smooth thinker's Staff of the Healthy Breakfast	0		Mysticality: +10, Moxie: +15, Maximum HP: +50, Sleaze Spell Damage: +10, Jiggle: "Recover Some HP"
@@ -6200,7 +6200,7 @@
 6304	squat lard-coated mansplainer's MacGyver's baleful educational Jarlsberg's pan (Cosmic portal mode)	0		Experience: +1, Spell Damage: +25, Maximum MP: +100, Monster Level: +15, Sleaze Spell Damage: +25, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	wholesome Sinatra's savvy Jarlsberg's pan of incineration	0		Mysticality Percent: +20, Experience (Moxie): +5, Maximum HP Percent: +10, Hot Spell Damage: +50, Item Drop: +5, Softcore Only, Free Pull, Last Available: "2013-03"
 6306	Cosmic Calorie	0		Last Available: "2013-03"
-6307	deionized narrow teal celestial olive oil	0		Effect: "Boschface", Effect Duration: 55, Last Available: "2013-03"
+6307	deionized teal narrow celestial olive oil	0		Effect: "Boschface", Effect Duration: 55, Last Available: "2013-03"
 6308	moist cold-filtered celestial carrot juice	0		Effect: "Hot Buttoned", Effect Duration: 50, Last Available: "2013-03"
 6309	denatured liquefied celestial au jus	0		Effect: "Initiative and Let Die", Effect Duration: 65, Last Available: "2013-03"
 6310	non-liquefied polarized skewed twirling celestial squid ink	0		Effect: "Drenched With Filth", Effect Duration: 14, Last Available: "2013-03"
@@ -6247,13 +6247,13 @@
 6351	narrow supercool Mer-kin finpaddle	0		Moxie Percent: +20
 6352	scorching Mer-kin stopwatch	0		Hot Damage: +25, Initiative: +50
 6353	red Mer-kin dreadscroll	0		
-6354	alkaline cyan skewed Mer-kin smartjuice	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 28
+6354	alkaline skewed cyan Mer-kin smartjuice	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 28
 6355	triple-irradiated nitrogenated lime green ghostly Mer-kin cooljuice	0		Effect: "Scorpio Rising", Effect Duration: 48
 6356	Mer-kin worktea	0		
 6357	narrow Mer-kin knucklebone	0		
 6358	wobbly Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	Mer-kin begsign of terror	0		Spooky Spell Damage: +10, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	super-flattened altered narrow pulled taffy	0		Effect: "Sugar Smacks", Effect Duration: 59, Last Available: "2013-04"
 6362	irradiated blurry olive pulled indigo taffy	0		Effect: "critical.enh", Effect Duration: 64, Last Available: "2013-04"
 6363	ionized ghostly pulled taffy	0		Effect: "Crud&eacute;", Effect Duration: 22, Last Available: "2013-04"
@@ -6264,9 +6264,9 @@
 6368	lime green Mer-kin hallpass	0		
 6369	red lump of clay	0		
 6370	twisted piece of wire	0		
-6371	fortified mediocre special can of the cheapest beer	5	decent	Effect: "Fancy Feasted", Effect Duration: 50
-6372	weak perfectly mixed bottle of fruity &quot;wine&quot;	2	EPIC	
-6373	enchanted drinkable single swig of vodka	3	good	Effect: "White Blooded", Effect Duration: 35
+6371	mediocre fortified special can of the cheapest beer	5	decent	Effect: "Fancy Feasted", Effect Duration: 50
+6372	perfectly mixed weak bottle of fruity &quot;wine&quot;	2	EPIC	
+6373	drinkable enchanted single swig of vodka	3	good	Effect: "White Blooded", Effect Duration: 35
 6374	red angry inch	0		
 6375	zippy testy toolbox	0		Initiative: +20
 6376	Jick-o-User	0		
@@ -6281,7 +6281,7 @@
 6386	squat balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
-6389	boiled dry green bouncing Mer-kin rocksalt	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 48
+6389	boiled dry bouncing green Mer-kin rocksalt	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 48
 6390	liquefied chilled Mer-kin saltmint	0		Effect: "The Moxie of LOV", Effect Duration: 18
 6391	unsweetened ionized yellow Mer-kin saltsquid	0		Effect: "Gummibrain", Effect Duration: 24
 6392	up-at-dawn avaricious scale-mail underwear	0		Meat Drop: +30, Adventures: +5, Familiar Effect: "2xVolley"
@@ -6314,7 +6314,7 @@
 6419	oxidized tumbling moth dust	0		Effect: "Heart of Lavender", Effect Duration: 46
 6420	frozen polymerized glob of spoiled mayo	0		Effect: "Mint-Condition Breath", Effect Duration: 46
 6421	tonic djinn	0		
-6422	moldy huge vampire chowder	9	crappy	
+6422	huge moldy vampire chowder	9	crappy	
 6423	green skewed Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	lime green ghostly Official Seal of Dreadsylvania	0		
@@ -6344,7 +6344,7 @@
 6449	stanky cool Great Wolf's right paw of the blizzard	0		Moxie: +5, Cold Spell Damage: +25, Stench Spell Damage: +25, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	prompt Great Wolf's rocket launcher of dire peril	0		Weapon Damage: +20, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	executive clever Great Wolf's beastly trousers of incineration	0		Maximum MP: +20, Hot Spell Damage: +50, Meat Drop: +40, Familiar Effect: "1xPotato, 1.5xWhelp"
-6452	blue mirror upside-down Great Wolf's lice	0		
+6452	upside-down blue mirror Great Wolf's lice	0		
 6453	double-adjusted olive Hunger&trade; Sauce	0		Effect: "Pork Power", Effect Duration: 56
 6454	lard-coated occult dangerous zombie mariachi hat	0		Weapon Damage: +10, Spell Damage Percent: +25, Sleaze Spell Damage: +25, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	sizzling zombie accordion of terror of the cheetah	0		Hot Damage: +10, Spooky Spell Damage: +10, Initiative: +60, Class: "Accordion Thief", Single Equip, Song Duration: 20
@@ -6375,7 +6375,7 @@
 6480	grievous Unkillable Skeleton's shield of the storm	0		Weapon Damage Percent: +50, Maximum MP Percent: +40, Damage Reduction: 23
 6481	squat miser's Unkillable Skeleton's restless leg of dire peril	0		Weapon Damage: +20, Meat Drop: +10
 6482	Temple Grandin's sinister smartaleck's Staff of the Roaring Hearth	0		Moxie Percent: +30, Spell Damage: +10, Familiar Weight: +7
-6483	bouncing mirror Kool-Aid	1	decent	
+6483	mirror bouncing Kool-Aid	1	decent	
 6484	dread tarragon	0		
 6485	bone flour	0		
 6486	dreadful roast	0		
@@ -6410,7 +6410,7 @@
 6515	reassuring eerie fetish	0		Spooky Resistance: +1, Single Equip
 6516	hand-crafted stinkwater	3	super ultra EPIC	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	decent diet accidental mutton	1	good	
+6518	diet decent accidental mutton	1	good	
 6519	stanky wicked drafty drawers	0		Spell Damage: +5, Stench Spell Damage: +25, Familiar Effect: "1.5xVolley"
 6520	vibrating wholesome wolfskull mask	0		Maximum HP Percent: +10, Maximum MP Percent: +10, Familiar Effect: "spooky atk, 1xBarrr"
 6521	Newton's guts necklace	0		Experience (Mysticality): +3, Single Equip
@@ -6429,7 +6429,7 @@
 6534	blinking coward's remorseless knife	0		Monster Level: -20
 6535	personal trainer's intimidating coiffure	0		Experience Percent (Muscle): +10, Familiar Effect: "hot afk, 1xPotato"
 6536	twirling groovy cod cape of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3
-6537	special normal blood sausage	3	good	Effect: "Third Based", Effect Duration: 45
+6537	normal special blood sausage	3	good	Effect: "Third Based", Effect Duration: 45
 6538	bouncing forbidden frying brainpan of the blizzard	0		Spell Damage Percent: +50, Cold Spell Damage: +25
 6539	Jeselnik's ball and chain of the sewer	0		Stench Damage: +25, Sleaze Damage: +25, Single Equip
 6540	maroon brainy dry bone	0		Mysticality: +5
@@ -6450,19 +6450,19 @@
 6556	concentrated bouncing phial of hotness	0		Effect: "EVISCERATE!", Effect Duration: 61
 6557	colloidal energized phial of coldness	0		Effect: "Be a Mind Master", Effect Duration: 29
 6558	oxidized skewed phial of spookiness	0		Effect: "Radiated and Grodiated", Effect Duration: 55
-6559	pressed wet oxidized bouncing twirling phial of stench	0		Effect: "Bolts about Candy", Effect Duration: 56
+6559	pressed wet oxidized twirling bouncing phial of stench	0		Effect: "Bolts about Candy", Effect Duration: 56
 6560	altered boiled spinning phial of sleaziness	0		Effect: "Serenity", Effect Duration: 57
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	squat mini-Mr. Accessory	0		Familiar Weight: +5
 6563	Oprah's hand of Mr. Cards	0		Maximum MP Percent: +50, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	tiny rotten Dreadsylvanian hot pocket	1	crappy	
+6564	rotten tiny Dreadsylvanian hot pocket	1	crappy	
 6565	bland tumbling Dreadsylvanian pocket	3	decent	
-6566	snack-sized spoiled Dreadsylvanian pocket	2	crappy	
-6567	flavorless miniature Dreadsylvanian stink pocket	2	decent	
-6568	decent thick blinking Dreadsylvanian sleaze pocket	5	good	
-6569	mediocre spirit-forward Dreadsylvanian hot toddy	5	decent	
-6570	mediocre watered-down Dreadsylvanian cold-fashioned	2	decent	
-6571	aged enchanted fuchsia Dreadsylvanian grimlet	3	awesome	Effect: "Cockroach Scurry", Effect Duration: 45
+6566	spoiled snack-sized Dreadsylvanian pocket	2	crappy	
+6567	miniature flavorless Dreadsylvanian stink pocket	2	decent	
+6568	thick decent blinking Dreadsylvanian sleaze pocket	5	good	
+6569	spirit-forward mediocre Dreadsylvanian hot toddy	5	decent	
+6570	watered-down mediocre Dreadsylvanian cold-fashioned	2	decent	
+6571	enchanted aged fuchsia Dreadsylvanian grimlet	3	awesome	Effect: "Cockroach Scurry", Effect Duration: 45
 6572	artisanal wobbly Dreadsylvanian dank and stormy	4	super ultra mega EPIC	
 6573	acceptable practically non-alcoholic Dreadsylvanian slithery nipple	1	good	
 6574	ghostly hot clusterbomb	0		
@@ -6507,7 +6507,7 @@
 6613	spinning clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	practically non-alcoholic artisanal Cold One	1	???	
-6616	bland super-sized spaghetti breakfast	5	???	
+6616	super-sized bland spaghetti breakfast	5	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	huge folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6515,7 +6515,7 @@
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	spinning folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	wobbly folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
-6624	jittery shaking folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
+6624	shaking jittery folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
@@ -6540,7 +6540,7 @@
 6648	Temple Grandin's slide rule of the brazier	0		Familiar Weight: +7, Hot Spell Damage: +25
 6649	liquefied Vulcanized pulsating Ogres and Oubliettes&trade; module	0		Effect: "Lemon Enlightenment", Effect Duration: 51
 6650	Mountain Stream Code Black Alert	0		
-6651	green spinning twisted-up wet towel	0		
+6651	spinning green twisted-up wet towel	0		
 6652	aged stepmom's booze	3	awesome	
 6653	shaking surgical tape	0		
 6654	jittery occult band T-shirt	0		Spell Damage Percent: +25
@@ -6566,10 +6566,10 @@
 6674	stinkbomb	0		
 6675	double-liquefied oxidized polarized narrow olive superwater	0		Effect: "Bats in the Belfry", Effect Duration: 40
 6676	Thwaitgold bookworm statuette	0		
-6677	blinking squat crude monster sculpture	0		
+6677	squat blinking crude monster sculpture	0		
 6678	narrow supercool Yearbook Club Camera	0		Moxie Percent: +20, Conditional Skill (Equipped): "Blinding Flash"
 6679	yellow huge toasty machete	0		Hot Damage: +5
-6680	boozy bad Cursed Punch	5	decent	
+6680	bad boozy Cursed Punch	5	decent	
 6681	hand-crafted bouncing Bowl of Scorpions	3	EPIC	
 6682	mediocre Fog Murderer	4	decent	
 6683	green skewed book of matches	0		
@@ -6589,7 +6589,7 @@
 6697	moss-covered stone sphere	0		
 6698	skewed dripping stone sphere	0		
 6699	crackling stone sphere	0		
-6700	ghostly gray tumbling scorched stone sphere	0		
+6700	tumbling ghostly gray scorched stone sphere	0		
 6701	twirling huge stone triangle	0		
 6702	bowler	0		
 6703	imitation White Russian	1	decent	
@@ -6634,32 +6634,32 @@
 6742	ghostly fortified junk band	0		Damage Absorption: +60
 6743	steel-toed junk trunks	0		Damage Reduction: 9, Familiar Effect: "cap 15"
 6744	electrified junk-mail shirt	0		MP Regen Min: 3, MP Regen Max: 5
-6745	flavorless low-calorie junk food	1	decent	
-6746	practically non-alcoholic lousy gray junk yard	1	decent	
+6745	low-calorie flavorless junk food	1	decent	
+6746	lousy practically non-alcoholic gray junk yard	1	decent	
 6747	brainy swordzall of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25
 6748	twirling auspicious arm buzzer	0		Item Drop: +10, Damage Reduction: 6
 6749	resourceful beefy boilgun	0		Muscle: +10, Maximum MP: +50
-6750	bouncing tumbling Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
+6750	tumbling bouncing Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
 6753	huge cluster of hops	0		
 6754	beer bottle	0		
-6755	huge skewed beer label	0		
+6755	skewed huge beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	acceptable practically non-alcoholic can of Br&uuml;talbr&auml;u	1	good	Last Available: "2013-09"
 6758	mediocre can of Drooling Monk	4	decent	Last Available: "2013-09"
 6759	tolerable bouncing can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	aged weak ghostly bottle of Old Pugilist	2	awesome	Last Available: "2013-09"
-6761	lousy practically non-alcoholic bottle of Professor Beer	1	decent	Last Available: "2013-09"
-6762	tolerable enchanted squat bottle of Rapier Witbier	3	good	Effect: "Mitre Cut", Effect Duration: 5, Last Available: "2013-09"
+6761	practically non-alcoholic lousy bottle of Professor Beer	1	decent	Last Available: "2013-09"
+6762	enchanted tolerable squat bottle of Rapier Witbier	3	good	Effect: "Mitre Cut", Effect Duration: 5, Last Available: "2013-09"
 6763	mediocre bottle of Race Car Red	3	decent	Last Available: "2013-09"
-6764	acceptable weak ghostly bottle of Greedy Dog	2	good	Last Available: "2013-09"
+6764	weak acceptable ghostly bottle of Greedy Dog	2	good	Last Available: "2013-09"
 6765	lousy bottle of Lambada Lambic	4	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
-6769	inspector's Jeselnik's forbidden tin tam	0		Spell Damage Percent: +50, Sleaze Damage: +25, Item Drop: +15, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
-6770	dry cyan shaking tin cup	0		Effect: "Human-Penguin Hybrid", Effect Duration: 26, Last Available: "2013-09"
+6769	inspector's Jeselnik's forbidden tin tam	0		Spell Damage Percent: +50, Sleaze Damage: +25, Item Drop: +15, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6770	dry shaking cyan tin cup	0		Effect: "Human-Penguin Hybrid", Effect Duration: 26, Last Available: "2013-09"
 6771	double-paned smelly manspreader's tin foil	0		Monster Level: +10, Stench Spell Damage: +10, Cold Resistance: +5, Last Available: "2013-09"
 6772	skewed perfumed tin drum of Calamity Jane of the boozehound	0		Critical Hit Percent: +15, Stench Resistance: +5, Booze Drop: +100, Last Available: "2013-09"
 6773	squat tin roof (rusted)	0		Last Available: "2013-09"
@@ -6673,7 +6673,7 @@
 6781	scandalous coward's scabrous seal epaulets	0		Monster Level: -20, Sleaze Damage: +5, Single Equip
 6782	abyssal battle plans	0		
 6783	squat Van der Graaf smartaleck's savvy seal medal	0		Mysticality Percent: +20, Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7
-6784	red upside-down deanimated reanimator's coffin	0		Free Pull
+6784	upside-down red deanimated reanimator's coffin	0		Free Pull
 6785	yellow flask of embalming fluid	0		
 6788	blank diary	0		
 6789	boot knife	0		
@@ -6746,16 +6746,16 @@
 6857	nippy Cajun accordion	0		Cold Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	shellacked quirky accordion	0		Damage Reduction: 7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	lime green avaricious manspreader's Skipper's accordion	0		Monster Level: +10, Meat Drop: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	frightening Jim Carey's Da Vinci's Herculean Pantsgiving	0		Experience (Muscle): +1, Experience (Mysticality): +5, Monster Level: +25, Spooky Damage: +5, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	frightening Jim Carey's Da Vinci's Herculean Pantsgiving	0		Experience (Muscle): +1, Experience (Mysticality): +5, Monster Level: +25, Spooky Damage: +5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
 6861	flavorless can of sardines	3	decent	Last Available: "2013-11"
 6862	tiny stale high-calorie sugar substitute	1	decent	Last Available: "2013-11"
 6863	flavorless pat of butter	4	decent	Last Available: "2013-11"
-6864	bland snack-sized jittery green dinner roll	2	decent	Last Available: "2013-11"
+6864	snack-sized bland jittery green dinner roll	2	decent	Last Available: "2013-11"
 6865	spoiled mashed potatoes	4	crappy	Last Available: "2013-11"
-6866	fancy snack-sized adequate teal whole turkey leg	2	good	Effect: "Disco Concentration", Effect Duration: 25, Last Available: "2013-11"
+6866	fancy adequate snack-sized teal whole turkey leg	2	good	Effect: "Disco Concentration", Effect Duration: 25, Last Available: "2013-11"
 6867	stale deviled egg	3	decent	Last Available: "2013-11"
 6868	polarized super-wet spinning finger exerciser	0		Effect: "Weepy, Creepy", Effect Duration: 31, Last Available: "2013-11"
-6869	altered blinking shaking dented spoon	0		Effect: "Unrunnable Face", Effect Duration: 36, Last Available: "2013-11"
+6869	altered shaking blinking dented spoon	0		Effect: "Unrunnable Face", Effect Duration: 36, Last Available: "2013-11"
 6870	tarnished vacuum-sealed love note	0		Effect: "Graham Crackling", Effect Duration: 14, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	dry nail file	0		Effect: "Flower Power", Effect Duration: 32, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	warmed deionized skewed nuts	0		Effect: "Sealed Brain", Effect Duration: 39, Last Available: "2013-12"
 6904	ionized blinking bolts	0		Effect: "El Vibrations", Effect Duration: 62, Last Available: "2013-12"
 6905	bland red ghostly gingerbread robot	4	decent	Last Available: "2013-12"
-6906	rotten small petit 4.1	2	crappy	Last Available: "2013-12"
+6906	small rotten petit 4.1	2	crappy	Last Available: "2013-12"
 6907	tiny flavorless nut-shaped Crimbo cookie	1	decent	Last Available: "2023-06"
 6908	mirror Oprah's plastic GORM-8	0		Maximum MP Percent: +50, Last Available: "2013-12"
 6909	electrified plastic warbear	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
@@ -6806,33 +6806,33 @@
 6917	warbear badge	0		Last Available: "2013-12"
 6918	non-aerosolized unsweetened upside-down warbear wardance potion	0		Effect: "Berry Statistical", Effect Duration: 22, Last Available: "2013-12"
 6919	dry warbear bearserker potion	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 51, Last Available: "2013-12"
-6920	wet shaking huge warbear liquid overcoat	0		Effect: "Sweet Incentive", Effect Duration: 27, Last Available: "2013-12"
-6921	spoiled super-sized warbear feasting bread	5	crappy	Last Available: "2013-12"
-6922	adequate tiny warbear warrior bread	1	good	Last Available: "2013-12"
+6920	wet huge shaking warbear liquid overcoat	0		Effect: "Sweet Incentive", Effect Duration: 27, Last Available: "2013-12"
+6921	super-sized spoiled warbear feasting bread	5	crappy	Last Available: "2013-12"
+6922	tiny adequate warbear warrior bread	1	good	Last Available: "2013-12"
 6923	adequate warbear thermoregulator bread	3	good	Last Available: "2013-12"
-6924	weak hand-crafted lime green warbear feasting mead	2	super EPIC	Last Available: "2013-12"
+6924	hand-crafted weak lime green warbear feasting mead	2	super EPIC	Last Available: "2013-12"
 6925	acceptable warbear bearserker mead	3	good	Last Available: "2013-12"
 6926	perfectly mixed warbear blizzard mead	3	EPIC	Last Available: "2013-12"
 6927	gray warbear helm fragment	0		Last Available: "2013-12"
-6928	yellow avaricious foul-smelling grievous warbear plain fedora	0		Weapon Damage Percent: +50, Stench Damage: +10, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	mansplainer's warbear feathered fedora	0		Monster Level: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	spinning knitted wool Tesla warbear fedora	0		Cold Resistance: 4, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	frosty manspreader's warbear plain helm of Flo-Jo	0		Monster Level: +10, Cold Spell Damage: +10, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	Van der Graaf warbear spiked helm	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	pulsating jittery smelly slick warbear electro-spiked helm of the dark arts	0		Moxie: +10, Spell Damage Percent: +100, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	blinking narrow miser's forbidden strapping warbear plain ushanka	0		Muscle: +5, Spell Damage Percent: +50, Meat Drop: +10, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	cyan deadly warbear lined ushanka	0		Weapon Damage: +5, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	reassuring dog trainer's supercool warbear heated ushanka	0		Moxie Percent: +20, Experience (familiar): +1, Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	yellow avaricious foul-smelling grievous warbear plain fedora	0		Weapon Damage Percent: +50, Stench Damage: +10, Meat Drop: +30, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	mansplainer's warbear feathered fedora	0		Monster Level: +15, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	spinning knitted wool Tesla warbear fedora	0		Cold Resistance: 4, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	frosty manspreader's warbear plain helm of Flo-Jo	0		Monster Level: +10, Cold Spell Damage: +10, Initiative: +100, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	Van der Graaf warbear spiked helm	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	pulsating jittery smelly slick warbear electro-spiked helm of the dark arts	0		Moxie: +10, Spell Damage Percent: +100, Stench Spell Damage: +10, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	blinking narrow miser's forbidden strapping warbear plain ushanka	0		Muscle: +5, Spell Damage Percent: +50, Meat Drop: +10, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	cyan deadly warbear lined ushanka	0		Weapon Damage: +5, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	reassuring dog trainer's supercool warbear heated ushanka	0		Moxie Percent: +20, Experience (familiar): +1, Spooky Resistance: +1, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	bouncing resourceful curative smartaleck's warbear party pants	0		Moxie Percent: +30, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	strapping warbear ceremonial party pants	0		Muscle: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	huge skewed toasty Newton's strapping warbear high festival pants	0		Muscle: +5, Experience (Mysticality): +3, Hot Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	Temple Grandin's wicked brainy warbear battle greaves	0		Mysticality: +5, Spell Damage: +5, Familiar Weight: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	jittery fireproof Van der Graaf brawny warbear bearserker greaves	0		Muscle Percent: +20, Hot Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	knitted Fonzie's warbear johns of vim and vigor	0		Experience (Moxie): +1, Maximum HP Percent: +50, Cold Resistance: +3, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	sizzling warbear fleece-lined johns	0		Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	maroon sinister groovy warbear johns of Leguizamo	0		Moxie Percent: +10, Spell Damage: +10, Monster Level: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	bouncing resourceful curative smartaleck's warbear party pants	0		Moxie Percent: +30, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	strapping warbear ceremonial party pants	0		Muscle: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	huge skewed toasty Newton's strapping warbear high festival pants	0		Muscle: +5, Experience (Mysticality): +3, Hot Damage: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	Temple Grandin's wicked brainy warbear battle greaves	0		Mysticality: +5, Spell Damage: +5, Familiar Weight: +7, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	jittery fireproof Van der Graaf brawny warbear bearserker greaves	0		Muscle Percent: +20, Hot Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	knitted Fonzie's warbear johns of vim and vigor	0		Experience (Moxie): +1, Maximum HP Percent: +50, Cold Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	sizzling warbear fleece-lined johns	0		Hot Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	maroon sinister groovy warbear johns of Leguizamo	0		Moxie Percent: +10, Spell Damage: +10, Monster Level: +20, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	pulsating avaricious greedy resourceful warbear goggles	0		Maximum MP: +50, Meat Drop: 50, Single Equip, Last Available: "2013-12"
 6949	warbear snowblindness goggles of the cougar	0		Moxie: +20, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	lard-coated vibrating warbear warscarf of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	warbear foil hat of the pedagogue	0		Experience: +3, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	warbear foil hat of the pedagogue	0		Experience: +3, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	lime green warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	foul-smelling grievous warbear oil pan	0		Weapon Damage Percent: +50, Stench Damage: +10, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	foul-smelling grievous warbear oil pan	0		Weapon Damage Percent: +50, Stench Damage: +10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	shaking blurry warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	spinning mansplainer's warbear exhaust manifold	0		Monster Level: +15, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	bouncing Van der Graaf rock-hard die-cast Don Crimbo	0		Damage Reduction: 5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
 7001	supercharged quilted die-cast Uncle Hobo	0		Damage Absorption: +40, Maximum MP Percent: +30, Last Available: "2013-12"
 7002	wobbly toasty die-cast Father Crimbo of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +5, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	quantum Flaskfull of Hollow	0		Effect: "Spooky Jellied", Effect Duration: 36, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	vaporized shaking handful of Smithereens	1	awesome	Effect: "Ogred and Oublietted", Effect Duration: 45, Last Available: "2013-12"
 7007	yummy mirror Every Day is Like This Sundae	4	awesome	Last Available: "2013-12"
-7008	decent fancy Miserable Pie	3	good	Effect: "Abyssal Sweat", Effect Duration: 15, Last Available: "2013-12"
-7009	big rotten fancy This Charming Flan	5	crappy	Effect: "Feelin' Philosophical", Effect Duration: 5, Last Available: "2013-12"
+7008	fancy decent Miserable Pie	3	good	Effect: "Abyssal Sweat", Effect Duration: 15, Last Available: "2013-12"
+7009	fancy big rotten This Charming Flan	5	crappy	Effect: "Feelin' Philosophical", Effect Duration: 5, Last Available: "2013-12"
 7010	artisanal Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
 7011	watered-down bad blinking Strikes Again Bigmouth	2	decent	Last Available: "2013-12"
-7012	hand-crafted high-proof Paint A Vulgar Pitcher	10	EPIC	Last Available: "2013-12"
+7012	high-proof hand-crafted Paint A Vulgar Pitcher	10	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	bouncing Louder Than Bomb	0		Last Available: "2013-12"
 7015	shaking Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	bouncing greasy wholesome dance instructor's Sheila Take a Crossbow of terror	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Spooky Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2013-12"
 7019	sizzling vibrating Socratic A Light that Never Goes Out of the scaredy-cat	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Monster Level: -15, Hot Damage: +10, Last Available: "2013-12"
 7020	lightning-fast Jeselnik's studded Half a Purse of the glutton	0		Damage Absorption: +80, Sleaze Damage: +25, Food Drop: +100, Initiative: +40, Last Available: "2013-12"
-7021	blue personal trainer's Hairpiece On Fire of Calamity Jane of the sweet-tooth of the early riser	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Candy Drop: +100, Adventures: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	mirror censurious groovy slick thinker's Vicar's Tutu	0		Mysticality: +10, Moxie: +10, Moxie Percent: +10, Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	blue personal trainer's Hairpiece On Fire of Calamity Jane of the sweet-tooth of the early riser	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Candy Drop: +100, Adventures: +7, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	mirror censurious groovy slick thinker's Vicar's Tutu	0		Mysticality: +10, Moxie: +10, Moxie Percent: +10, Sleaze Resistance: +3, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	spinning aromatic hale Hand in Glove of mayonnaise	0		Maximum HP: +20, Sleaze Spell Damage: +50, Stench Resistance: +1, Single Equip, Last Available: "2013-12"
 7024	chaotic Meat Tenderizer is Murder of dire peril of temperance	0		Weapon Damage: +20, Spell Critical Percent: +10, Sleaze Resistance: +5, Class: "Seal Clubber", Last Available: "2013-12"
 7025	ghostly foul-smelling Temple Grandin's smooth Ouija Board, Ouija Board	0		Moxie: +15, Familiar Weight: +7, Stench Damage: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6917,8 +6917,8 @@
 7028	foul-smelling Frankly Mr. Shank of wisdom of horror	0		Mysticality: +15, Stench Damage: +10, Spooky Spell Damage: +25, Class: "Disco Bandit", Last Available: "2013-12"
 7029	gravedigger's frightening nasty Shakespeare's Sister's Accordion	0		Stench Damage: +5, Spooky Damage: 15, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	wobbly fireproof third-hand lantern	0		Hot Resistance: +3
-7031	blue spinning loose purse strings	0		
-7032	delicious gigantic pickled egg	9	awesome	
+7031	spinning blue loose purse strings	0		
+7032	gigantic delicious pickled egg	9	awesome	
 7033	cup of lukewarm tea	1	good	
 7034	upside-down warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6946,7 +6946,7 @@
 7057	spoiled breakfast miracle	3	crappy	Last Available: "2013-12"
 7058	super-improved non-galvanized spinning Cloaca Cola Polar	0		Effect: "Spiro Gyro", Effect Duration: 23, Last Available: "2013-12"
 7059	olive narrow warbear soda machine	0		Last Available: "2013-12"
-7060	cyan upside-down festive warbear bank	0		Last Available: "2013-12"
+7060	upside-down cyan festive warbear bank	0		Last Available: "2013-12"
 7061	narrow grimstone mask	0		Last Available: "2014-12"
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	wobbly Grim Brothers' story book	0		Familiar Weight: +5
@@ -6958,18 +6958,18 @@
 7069	tumbling twirling Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
 7071	small decent skewed snow berries	2	good	Last Available: "2014-01"
-7072	spoiled super-sized ghostly ice harvest	5	crappy	Last Available: "2014-01"
+7072	super-sized spoiled ghostly ice harvest	5	crappy	Last Available: "2014-01"
 7073	double-deionized frost flower	0		Effect: "Sparkly!", Effect Duration: 58, Last Available: "2014-01"
 7074	polymerized enhanced snow cleats	0		Effect: "Powdered", Effect Duration: 48, Last Available: "2014-01"
 7075	electrified quadruple-electrified maroon liquid ice pack	0		Effect: "Jittery", Effect Duration: 36, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	fancy adequate tiny snow crab	1	good	Effect: "Mystically Oiled", Effect Duration: 40, Last Available: "2014-01"
+7077	fancy tiny adequate snow crab	1	good	Effect: "Mystically Oiled", Effect Duration: 40, Last Available: "2014-01"
 7078	watered-down perfectly mixed special Ice Island Long Tea	2	super ultra mega EPIC	Effect: "Preemptive Medicine", Effect Duration: 35, Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	mirror ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	blue snow machine	0		Last Available: "2014-01"
-7083	upside-down gray wholesome snow mobile	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	upside-down gray wholesome snow mobile	0		Maximum HP Percent: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	groovy ice bucket	0		Moxie Percent: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	studded slick snow shovel	0		Moxie: +10, Damage Absorption: +80, Lasts Until Rollover, Last Available: "2014-01"
 7086	occult Newton's bod-ice of courage	0		Experience (Mysticality): +3, Spell Damage Percent: +25, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	artisanal weak En Una Fila Tequila	2	EPIC	
 7091	Skully's hot chocolate	1	awesome	
-7092	ghostly ribald vibrating warbear dress helmet	0		Maximum MP Percent: +10, Sleaze Damage: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	ghostly ribald vibrating warbear dress helmet	0		Maximum MP Percent: +10, Sleaze Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	skewed curative smooth warbear dress bracers	0		Moxie: +15, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-12"
-7094	razor-sharp Da Vinci's warbear dress greaves	0		Experience (Mysticality): +5, Weapon Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	knitted sweatband of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +3, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	tumbling fortified sinister gym shorts	0		Spell Damage: +10, Damage Absorption: +60, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	razor-sharp Da Vinci's warbear dress greaves	0		Experience (Mysticality): +5, Weapon Damage Percent: +25, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	knitted sweatband of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +3, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	tumbling fortified sinister gym shorts	0		Spell Damage: +10, Damage Absorption: +60, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	ankleweights of the bloodbag of the cheetah	0		Maximum HP: +100, Initiative: +60, Single Equip, Last Available: "2014-12"
 7098	stanky rosy-cheeked sweat socks of vim and vigor of bravery	0		Maximum HP Percent: 80, Stench Spell Damage: +25, Spooky Resistance: +5, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -7003,13 +7003,13 @@
 7114	decent blurry candy carrot	3	good	Last Available: "2014-12"
 7115	snack-sized rotten candy carrot cake	2	crappy	Last Available: "2014-12"
 7116	censurious carrot-on-a-stick of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +3, Last Available: "2014-12"
-7117	Annie Oakley's weasel stomping pants of the cheetah	0		Critical Hit Percent: +20, Initiative: +60, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	Annie Oakley's weasel stomping pants of the cheetah	0		Critical Hit Percent: +20, Initiative: +60, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	decent maroon mulberry	4	good	Last Available: "2014-12"
 7119	tolerable extra-dry upside-down mulled berry wine	5	good	Last Available: "2014-12"
 7120	bouncing lemony scales	0		Last Available: "2014-12"
-7121	extremely unsafe lemon party hat	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	extremely unsafe lemon party hat	0		Weapon Damage Percent: +100, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	lemon shirt of doom	0		Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2014-12"
-7123	spinning rock-hard lemon drop trousers	0		Damage Reduction: 5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	spinning rock-hard lemon drop trousers	0		Damage Reduction: 5, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	polymerized concentrated lemonhead caviar	0		Effect: "Swimming Head", Effect Duration: 25, Last Available: "2014-12"
 7125	aromatic Fonzie's gummi sword	0		Experience (Moxie): +1, Stench Resistance: +1, Last Available: "2014-12"
 7126	modified small gummi fin	0		Effect: "All Branned Up", Effect Duration: 67, Last Available: "2014-12"
@@ -7020,7 +7020,7 @@
 7131	baleful cow creamer of the scaredy-cat of the empath	0		Spell Damage: +25, Monster Level: -15, Familiar Weight: +5, Last Available: "2014-12"
 7132	irradiated blinking Outer Wolf&trade; cologne	0		Effect: "Healthy Green Glow", Effect Duration: 49, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	upside-down Herculean wolf whistle of the overflowing toilet	0		Experience (Muscle): +1, Stench Spell Damage: +50, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	upside-down Herculean wolf whistle of the overflowing toilet	0		Experience (Muscle): +1, Stench Spell Damage: +50, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	moldy witch's bread	3	crappy	Last Available: "2014-12"
 7136	moist flattened enhanced twirling witch's brew	0		Effect: "Bestial Sympathy", Effect Duration: 57, Last Available: "2014-12"
 7137	red clever fortified witch's bra of mayonnaise	0		Damage Absorption: +60, Maximum MP: +20, Sleaze Spell Damage: +50, Last Available: "2014-12"
@@ -7032,9 +7032,9 @@
 7143	teal scandalous flame-wreathed hare pin	0		Hot Spell Damage: +10, Sleaze Damage: +5, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
 7145	super-sized toothsome cinnamon cannoli	5	awesome	Last Available: "2014-12"
-7146	tolerable special practically non-alcoholic expensive champagne	1	good	Effect: "Bolts about Candy", Effect Duration: 25, Last Available: "2014-12"
+7146	practically non-alcoholic special tolerable expensive champagne	1	good	Effect: "Bolts about Candy", Effect Duration: 25, Last Available: "2014-12"
 7147	activated warmed dry polo trophy	0		Effect: "Petit Force", Effect Duration: 63, Last Available: "2014-12"
-7148	tumbling blinking oil painting	0		Last Available: "2014-12"
+7148	blinking tumbling oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
 7150	skewed huge ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
@@ -7043,10 +7043,10 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	cyan lard-coated stanky Lo Pan's fire hose	0		Spell Critical Percent: +30, Stench Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	cyan lard-coated stanky Lo Pan's fire hose	0		Spell Critical Percent: +30, Stench Spell Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	yummy gigantic purple fireman's lunch	10	awesome	Last Available: "2014-12"
-7159	mansplainer's thinker's plain paper hat of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Monster Level: +15, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	half-sized stale ice cream sandwich	2	decent	Last Available: "2014-12"
+7159	mansplainer's thinker's plain paper hat of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Monster Level: +15, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7160	stale half-sized ice cream sandwich	2	decent	Last Available: "2014-12"
 7161	prompt flame-wreathed coward's &quot;honey&quot; dipper	0		Monster Level: -20, Hot Spell Damage: +10, Adventures: +3, Last Available: "2014-12"
 7162	adequate plumber's lunch	3	good	Last Available: "2014-12"
 7163	wobbly lard-coated personal trainer's skull gearshift knob of incineration	0		Experience Percent (Muscle): +10, Hot Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2014-12"
@@ -7088,27 +7088,27 @@
 7199	blowdart	0		
 7200	red arcane researcher's Buddy Bjorn	0		Experience Percent (Mysticality): +10, Softcore Only, Last Available: "2014-02"
 7201	perfumed Oprah's medical-grade The Nuge's favorite crossbow	0		Maximum MP Percent: +50, Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10
-7202	gigantic rotten sweet roll Alabama	9	crappy	
+7202	rotten gigantic sweet roll Alabama	9	crappy	
 7203	bouncing upside-down twirling ruddy Saturday Night Special	0		Maximum HP Percent: +40
 7204	lynyrd snare	0		
 7205	upside-down fleetwood chain of temperance	0		Sleaze Resistance: +5
 7206	drinkable extra-dry Green Manalishi	5	good	
 7207	blade of the dark arts	0		Spell Damage Percent: +100
 7208	fire of unknown origin	0		
-7209	wobbly skewed eagle's milk	1	awesome	
+7209	skewed wobbly eagle's milk	1	awesome	
 7210	corrupted eagle feather	0		Effect: "Mer-kindliness", Effect Duration: 21
 7211	unsweetened skewed one pill	0		Effect: "Scarysauce", Effect Duration: 69
 7212	steel-toed Jefferson wings	0		Damage Reduction: 9
 7213	fleetwood macaroni	0		
 7214	squat cheesy eagle sauce	0		
-7215	miniature moldy fleetwood mac 'n' cheese	2	crappy	
+7215	moldy miniature fleetwood mac 'n' cheese	2	crappy	
 7216	gray lynyrd skin	0		
 7217	lion tamer's lynyrdskin cap	0		Experience (familiar): +2, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	skewed jittery Jack Frost's lynyrdskin tunic	0		Cold Spell Damage: +50
 7219	MacGyver's lynyrdskin breeches	0		Maximum MP: +100, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
-7221	green twirling upside-down priceless diamond	0		
-7222	bad fancy triple-distilled Flamin' Whatshisname	6	decent	Effect: "Sauce Monocle", Effect Duration: 30
+7221	twirling upside-down green priceless diamond	0		
+7222	triple-distilled fancy bad Flamin' Whatshisname	6	decent	Effect: "Sauce Monocle", Effect Duration: 30
 7223	vacuum-sealed boiled lynyrd musk	0		Effect: "Patched In", Effect Duration: 63
 7224	Jeselnik's strapping Kashmir sweater	0		Muscle: +5, Sleaze Damage: +25
 7225	half-sized toothsome narrow spinning custard pie	2	awesome	
@@ -7118,7 +7118,7 @@
 7229	watered-down smooth wine	2	awesome	
 7230	artisanal rum	3	EPIC	
 7231	practically non-alcoholic smooth Murderer's Punch	1	awesome	
-7232	rotten gigantic velvet cake	9	crappy	
+7232	gigantic rotten velvet cake	9	crappy	
 7233	super-electrified letter	0		Effect: "Polka of Plenty", Effect Duration: 35
 7234	frosty book of the glutton	0		Cold Spell Damage: +10, Food Drop: +100
 7235	perfumed masque of wisdom	0		Mysticality: +15, Stench Resistance: +5, Single Equip
@@ -7131,7 +7131,7 @@
 7242	button	0		
 7243	button	0		
 7244	colloidal liquefied improved blood cells	0		Effect: "Scrappy, Shadowy", Effect Duration: 41
-7245	alkaline super-ionized unsweetened shaking ghostly eye	0		Effect: "Musky", Effect Duration: 33
+7245	alkaline super-ionized unsweetened ghostly shaking eye	0		Effect: "Musky", Effect Duration: 33
 7246	glark cable	0		
 7247	wobbly wool thinker's Red Fox glove	0		Mysticality: +10, Cold Resistance: +1, Attacks Can't Miss, Single Equip
 7248	oxidized foxglove	0		Effect: "Destructive Resolve", Effect Duration: 21
@@ -7145,12 +7145,12 @@
 7256	smoke grenade	0		
 7257	mixed wobbly ghostly molotov soda	1	EPIC	
 7258	irradiated cold-filtered pile of ashes	0		Effect: "Booze Goozles", Effect Duration: 59
-7259	huge twirling crate of firebombs	0		
+7259	twirling huge crate of firebombs	0		
 7260	blue firebomb	0		
 7261	shaking blinking Newton's savvy Sneaky Pete's basket of James Dean	0		Mysticality Percent: +20, Experience (Mysticality): +3, Experience (Moxie): +3
 7262	shaking &quot;I Love Me, Vol. I&quot;	0		
 7263	upside-down photograph of a dog	0		
-7264	jittery gray photograph of a nugget	0		
+7264	gray jittery photograph of a nugget	0		
 7265	jittery photograph of an ostrich egg	0		
 7266	disposable instant camera	0		
 7267	nasty educational boxer's Sneaky Pete's jacket (collar popped) of the businessman	0		Muscle Percent: +10, Experience: +1, Stench Damage: +5, Meat Drop: +50, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7176,16 +7176,16 @@
 7287	brawny Gary Claybender's Time Screwer of the businessman	0		Muscle Percent: +20, Meat Drop: +50, Single Equip, Lasts Until Rollover
 7288	squat huge nippy Space Tourist palmdoctor of the blizzard	0		Cold Damage: +10, Cold Spell Damage: +25, Lasts Until Rollover
 7289	up-at-dawn sharpshooter's veiny amok putter	0		Maximum HP: +10, Critical Hit Percent: +10, Adventures: +5
-7290	normal diet gray amok pudding	1	good	
+7290	diet normal gray amok pudding	1	good	
 7291	tumbling deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
-7293	denatured ionized gray blurry skewed can of V-11	0		Effect: "Kernel Panic!", Effect Duration: 14, Last Available: "2014-03"
+7293	denatured ionized skewed gray blurry can of V-11	0		Effect: "Kernel Panic!", Effect Duration: 14, Last Available: "2014-03"
 7294	Annie Oakley's elevennis shoes of extreme caution	0		Critical Hit Percent: +20, Monster Level: -25, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
 7296	twirling frosty sinister elevenderizing hammer	0		Spell Damage: +10, Cold Spell Damage: +10, Last Available: "2014-03"
 7297	knitted Professor What T-Shirt	0		Cold Resistance: +3
 7298	heavy-duty bendy straw	0		
-7299	jittery wobbly pellet of plant food	0		
+7299	wobbly jittery pellet of plant food	0		
 7300	spinning sewing kit	0		
 7301	tumbling Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
@@ -7217,14 +7217,14 @@
 7328	chilled denatured mirror funny bone	0		Effect: "Muddled", Effect Duration: 35
 7329	brainy strapping half-melted spoon	0		Muscle: +5, Mysticality: +5
 7330	dehydrated blinking the funk	1		
-7331	gigantic adequate gunky chicken	8	good	
+7331	adequate gigantic gunky chicken	8	good	
 7332	huge doll head of the wise owl	0		Mysticality: +20
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	ribald strapping paddle-ball	0		Muscle: +5, Sleaze Damage: +10
 7336	tarnished sound effects record	0		Effect: "Protection from Bad Stuff", Effect Duration: 63
 7337	ghostly alphabet block	0		
-7338	boiled blurry mirror yellow dancer	0		Effect: "Eyes of the Dragon", Effect Duration: 56
+7338	boiled yellow mirror blurry dancer	0		Effect: "Eyes of the Dragon", Effect Duration: 56
 7339	music box mechanism	0		
 7340	Sherlock's moose antlers	0		Item Drop: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	irradiated jittery moose thought	0		Effect: "You Know Where to Go", Effect Duration: 45
@@ -7235,7 +7235,7 @@
 7346	spinning doll-eye amulet	0		Single Equip
 7347	scandalous ghost toga of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +5
 7348	bland sheet cake	3	decent	
-7349	pulsating blurry ghost key	0		
+7349	blurry pulsating ghost key	0		
 7350	picture of you	0		
 7351	lard-coated Rosewater's Staff of the Electric Range of chilblains	0		Mysticality Percent: +30, Cold Damage: +25, Sleaze Spell Damage: +25
 7352	rotten deluxe layer cake	3	crappy	
@@ -7258,7 +7258,7 @@
 7369	dry nitrogenated mangled finger	0		Effect: "A Taste of Rainbow", Effect Duration: 65
 7370	mediocre Psychotic Train wine	4	decent	
 7371	crazy hobo notebook	0		
-7372	super-sized spoiled pie man was not meant to eat	5	crappy	
+7372	spoiled super-sized pie man was not meant to eat	5	crappy	
 7373	red razor-sharp sommelier's towel	0		Weapon Damage Percent: +25
 7374	healthy tarnished tastevin	0		Maximum HP Percent: +20, Single Equip
 7375	jumbo adequate actual tapas	5	good	
@@ -7310,7 +7310,7 @@
 7421	skewed pencil thin mushroom	0		Last Available: "2014-05"
 7422	Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	salty sailor salt	0		Last Available: "2014-05"
-7424	wobbly squat bike rental broupon	0		Last Available: "2014-05"
+7424	squat wobbly bike rental broupon	0		Last Available: "2014-05"
 7425	mirror Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	sprinkle shaker	0		Last Available: "2014-05"
 7427	nitrogenated sleight-of-hand mushroom	0		Effect: "On Pins and Needles", Effect Duration: 29, Last Available: "2014-05"
@@ -7323,24 +7323,24 @@
 7434	chilled ionized wet Helvella Haemophilia mushroom	0		Effect: "Purity of Spirit", Effect Duration: 28, Last Available: "2014-05"
 7435	improved cold-filtered Stemonitis Staticus mushroom	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 41, Last Available: "2014-05"
 7436	boiled Tremella Tarantella mushroom	0		Effect: "Booze Goozles", Effect Duration: 16, Last Available: "2014-05"
-7437	ghostly narrow bouncing Pastaco shell	0		Last Available: "2014-05"
+7437	bouncing narrow ghostly Pastaco shell	0		Last Available: "2014-05"
 7438	moldy squat Beefy Crunch Pastaco	3	crappy	Last Available: "2014-05"
-7439	adequate huge Brain Food Pastaco	7	good	Last Available: "2014-05"
+7439	huge adequate Brain Food Pastaco	7	good	Last Available: "2014-05"
 7440	bland Cool Brunch Pastaco	3	decent	Last Available: "2014-05"
-7441	special small delicious Medical Pastaco	2	awesome	Effect: "Cold as Ice", Effect Duration: 10, Last Available: "2014-05"
+7441	special delicious small Medical Pastaco	2	awesome	Effect: "Cold as Ice", Effect Duration: 10, Last Available: "2014-05"
 7442	yummy immense squat Energy Buzz Pastaco	10	awesome	Last Available: "2014-05"
 7443	flavorless bouncing spinning Ludovico Pastaco	4	decent	Last Available: "2014-05"
 7444	drinkable maroon overpowering mushroom wine	4	good	Last Available: "2014-05"
 7445	bad complex mushroom wine	4	decent	Last Available: "2014-05"
 7446	artisanal fortified smooth mushroom wine	5	EPIC	Last Available: "2014-05"
-7447	perfectly mixed triple-distilled spinning blood-red mushroom wine	10	EPIC	Last Available: "2014-05"
+7447	triple-distilled perfectly mixed spinning blood-red mushroom wine	10	EPIC	Last Available: "2014-05"
 7448	bad upside-down buzzing mushroom wine	3	decent	Last Available: "2014-05"
 7449	bad red swirling mushroom wine	4	decent	Last Available: "2014-05"
 7450	tasty narrow Taco Dan's Basic Taco Dan Taco	3	awesome	Last Available: "2014-05"
-7451	moldy blurry huge Taco Dan's Taco Fish Fish Taco	4	crappy	Last Available: "2014-05"
+7451	moldy huge blurry Taco Dan's Taco Fish Fish Taco	4	crappy	Last Available: "2014-05"
 7452	bouncing Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	drinkable regular-size brogurt	3	good	Last Available: "2014-05"
-7454	practically non-alcoholic mediocre super-size brogurt	1	decent	Last Available: "2014-05"
+7454	mediocre practically non-alcoholic super-size brogurt	1	decent	Last Available: "2014-05"
 7455	drinkable broberry brogurt	4	good	Last Available: "2014-05"
 7456	lousy watered-down squat brocolate brogurt	2	decent	Last Available: "2014-05"
 7457	perfectly mixed fortified French bronilla brogurt	5	EPIC	Last Available: "2014-05"
@@ -7348,13 +7348,13 @@
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	mirror industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	sage Brogre brorts	0		Mysticality Percent: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	sage Brogre brorts	0		Mysticality Percent: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	mirror maroon lard-coated Brogre brolo shirt	0		Sleaze Spell Damage: +25, Last Available: "2014-05"
-7464	Brogre bucket hat of horror	0		Spooky Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	Brogre bucket hat of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	skewed one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	fuchsia hardened educational Rosewater's 8-billed baseball cap	0		Mysticality Percent: +30, Experience: +1, Damage Reduction: 3, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	fuchsia hardened educational Rosewater's 8-billed baseball cap	0		Mysticality Percent: +30, Experience: +1, Damage Reduction: 3, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	zippy friendly extremely wet T-shirt of horror	0		Familiar Weight: +3, Spooky Spell Damage: +25, Initiative: +20, Last Available: "2014-05"
 7470	huge skewed foul-smelling Jack Frost's beefcake's shrimp fork	0		Muscle: +25, Cold Spell Damage: +50, Stench Damage: +10, Last Available: "2014-05"
 7471	dry BROS Energy Drink	0		Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2014-05"
@@ -7365,19 +7365,19 @@
 7476	bouncing Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	non-concentrated altered Meat-inflating powder	0		Effect: "Fortunate Resolve", Effect Duration: 28, Last Available: "2014-05"
 7478	blue bouncing possessed sugar cube	0		Last Available: "2014-05"
-7479	cold-filtered blurry green shaking sugar fairy	0		Effect: "Flame-Retardant Trousers", Effect Duration: 59, Last Available: "2014-05"
+7479	cold-filtered green shaking blurry sugar fairy	0		Effect: "Flame-Retardant Trousers", Effect Duration: 59, Last Available: "2014-05"
 7480	super-energized triple-tarnished sugar bunny	0		Effect: "Meadulla Oblongota", Effect Duration: 69, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	lousy irresponsibly strong Rompedores de Fantasmas	6	decent	
-7483	triple-distilled acceptable La Fantasma y La Oscuridad	9	good	
-7484	delicious weak blinking Fantasma en la M&aacute;quina	2	awesome	
+7483	acceptable triple-distilled La Fantasma y La Oscuridad	9	good	
+7484	weak delicious blinking Fantasma en la M&aacute;quina	2	awesome	
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	drain dissolver	0		
 7488	cyan triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	huge triatomaceous dust	0		
-7491	fortified lousy bottle of Chateau de Vinegar	5	decent	
+7491	lousy fortified bottle of Chateau de Vinegar	5	decent	
 7492	blasting soda	0		
 7493	teal tumbling unstable fulminate	0		
 7494	squat wine bomb	0		
@@ -7388,14 +7388,14 @@
 7499	vacuum-sealed Hot 'n' Scarys	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 46
 7500	tumbling map	0		
 7501	huge	0		
-7502	electrified polarized shaking huge Texas tea	0		Effect: "Conspiratory Eyes", Effect Duration: 44
+7502	electrified polarized huge shaking Texas tea	0		Effect: "Conspiratory Eyes", Effect Duration: 44
 7503	dark hamethyst ring of Flo-Jo	0		Initiative: +100
 7504	aromatic dark baconstone ring	0		Stench Resistance: +1
 7505	studded dark porquoise ring	0		Damage Absorption: +80
 7506	curative smartaleck's book	0		Moxie Percent: +30, HP Regen Min: 3, HP Regen Max: 5
 7507	maroon pulsating groovy cloak	0		Moxie Percent: +10
 7508	label	0		
-7509	gigantic spoiled upside-down Mornington crescent roll	7	crappy	
+7509	spoiled gigantic upside-down Mornington crescent roll	7	crappy	
 7510	triple-pressed cyan eye shadow	0		Effect: "Booooooze", Effect Duration: 43
 7511	pulsating crumbling wheel	0		
 7512	magnetized extra-corrupted teal poppy	0		Effect: "Mad at Science", Effect Duration: 47
@@ -7410,13 +7410,13 @@
 7521	small spoiled blinking government cheese	2	crappy	Last Available: "2014-05"
 7522	shaking green blurry pair of government shades of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
-7524	dry polarized tumbling upside-down government	0		Effect: "Patched In", Effect Duration: 36, Last Available: "2014-05"
+7524	dry polarized upside-down tumbling government	0		Effect: "Patched In", Effect Duration: 36, Last Available: "2014-05"
 7525	ionized ionized alien drugs	0		Effect: "Vitali Tea", Effect Duration: 65, Last Available: "2023-09"
 7526	blue weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	Temple Grandin's arcane researcher's government-issued night-vision goggles	0		Experience Percent (Mysticality): +10, Familiar Weight: +7, Single Equip, Last Available: "2014-05"
-7529	adequate fancy big loaf of alien bread	5	good	Effect: "Wings of the Grasshopper", Effect Duration: 50, Last Available: "2014-05"
-7530	massive special bland purple grilled cheese sandwich	8	decent	Effect: "Always In Motion", Effect Duration: 40, Last Available: "2014-05"
+7529	big adequate fancy loaf of alien bread	5	good	Effect: "Wings of the Grasshopper", Effect Duration: 50, Last Available: "2014-05"
+7530	bland special massive purple grilled cheese sandwich	8	decent	Effect: "Always In Motion", Effect Duration: 40, Last Available: "2014-05"
 7531	modified alien protein powder	1	crappy	Last Available: "2014-05"
 7532	weak acceptable cyan rocket fuel	2	good	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
@@ -7425,17 +7425,17 @@
 7536	squat space beast fur	0		Last Available: "2014-05"
 7537	wobbly twitching space egg	0		Last Available: "2014-05"
 7538	gray ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of doom	0		Spooky Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	red executive space beast fur pants	0		Meat Drop: +40, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	space beast fur hat of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	red executive space beast fur pants	0		Meat Drop: +40, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	lard-coated space beast fur whip	0		Sleaze Spell Damage: +25, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	manspreader's curative space heater	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	manspreader's curative space heater	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	skewed space bar	0		Last Available: "2014-05"
 7545	perfectly mixed bouncing space port	3	EPIC	Last Available: "2014-05"
 7546	upside-down stiffened slick space needle	0		Moxie: +10, Damage Reduction: 1, Last Available: "2014-05"
 7547	dry olive shaking buffed alien drugs	0		Effect: "You're High as a Crow, Marty", Effect Duration: 12, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
-7549	super-modified purple wobbly ash soda	0		Effect: "Sausage Festive", Effect Duration: 34, Last Available: "2014-06"
+7549	super-modified wobbly purple ash soda	0		Effect: "Sausage Festive", Effect Duration: 34, Last Available: "2014-06"
 7550	warmed polarized twirling liquid smoke	0		Effect: "From Nantucket", Effect Duration: 18, Last Available: "2014-06"
 7551	moist energized cyan dollop of barbecue sauce	0		Effect: "Milk Studly", Effect Duration: 12, Last Available: "2014-06"
 7552	polymerized bowl of marinade	0		Effect: "Buff as a Baobab", Effect Duration: 34, Last Available: "2014-06"
@@ -7445,7 +7445,7 @@
 7556	jittery elephant gift	0		
 7557	electrified blood cells	0		Effect: "Super Vision", Effect Duration: 15
 7558	smooth huge wine	4	awesome	
-7559	activated blinking tumbling gummi turtle	0		Effect: "Earthen Fist", Effect Duration: 28
+7559	activated tumbling blinking gummi turtle	0		Effect: "Earthen Fist", Effect Duration: 28
 7560	turtle-shaped rock	0		
 7561	electrified galvanized energized pulsating giraffe-necked turtle	0		Effect: "Super Speed", Effect Duration: 29
 7562	warmed narrow musk turtle	0		Effect: "Moose Wisdom", Effect Duration: 18
@@ -7458,13 +7458,13 @@
 7569	up-at-dawn scandalous Time Bandit Badge of Courage of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5, Adventures: +5
 7570	non-denatured activated Friendliness Beverage	0		Effect: "Armored Innards", Effect Duration: 51
 7571	padded grievous silent pea shooter	0		Weapon Damage Percent: +50, Damage Absorption: +20
-7572	moldy fancy D roll	4	crappy	Effect: "Full of Vinegar", Effect Duration: 45
+7572	fancy moldy D roll	4	crappy	Effect: "Full of Vinegar", Effect Duration: 45
 7573	tumbling gray inspector's chaotic kiwi beak	0		Spell Critical Percent: +10, Item Drop: +15
 7574	lousy New Zealand iced tea	3	decent	
 7575	shaking nippy wholesome droll monocle	0		Maximum HP Percent: +10, Cold Damage: +10, Single Equip
 7576	energized altered future drug: Muscularactum	0		Effect: "Compensatory Cruelness", Effect Duration: 69
 7577	electrified squat future drug: Smartinex	0		Effect: "Stinkybeard", Effect Duration: 32
-7578	vacuum-sealed narrow cyan future drug: Coolscaline	0		Effect: "Cautious Prowl", Effect Duration: 50
+7578	vacuum-sealed cyan narrow future drug: Coolscaline	0		Effect: "Cautious Prowl", Effect Duration: 50
 7579	twitching time capsule	0		
 7580	modified ghostly liquid shifting time weirdness	1		Effect: "Saucegoggles", Effect Duration: 50
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
@@ -7476,7 +7476,7 @@
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	upside-down Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	smooth narrow glass of &quot;milk&quot;	4	awesome	Last Available: "2014-07"
-7590	bad special maroon spinning upside-down cup of &quot;tea&quot;	4	decent	Effect: "Radiated and Grodiated", Effect Duration: 15, Last Available: "2014-07"
+7590	bad special spinning upside-down maroon cup of &quot;tea&quot;	4	decent	Effect: "Radiated and Grodiated", Effect Duration: 15, Last Available: "2014-07"
 7591	tolerable thermos of &quot;whiskey&quot;	4	good	Last Available: "2014-07"
 7592	drinkable Lucky Lindy	3	good	Last Available: "2014-07"
 7593	weak hand-crafted Bee's Knees	2	EPIC	Last Available: "2014-07"
@@ -7485,7 +7485,7 @@
 7596	mediocre wobbly Hot Socks	3	decent	Last Available: "2014-07"
 7597	triple-distilled drinkable spinning Phonus Balonus	10	good	Last Available: "2014-07"
 7598	drinkable lime green Flivver	3	good	Last Available: "2014-07"
-7599	acceptable watered-down Sloppy Jalopy	2	good	Last Available: "2014-07"
+7599	watered-down acceptable Sloppy Jalopy	2	good	Last Available: "2014-07"
 7600	frozen triple-flattened maroon twirling flame	0		Effect: "Jittery", Effect Duration: 65
 7601	anodized ionized polymerized pulsating temporary yak tattoo	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 40
 7602	alkaline diffused skewed Fitspiration&trade; poster	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 41
@@ -7495,7 +7495,7 @@
 7606	quadruple-boiled twirling steampunk potion	0		Effect: "Chain Chain Chains", Effect Duration: 58
 7607	ionized quantum vial of swamp vapors	0		Effect: "Goldentongue", Effect Duration: 11
 7608	irradiated upside-down turtle mud	0		Effect: "Hella Smooth", Effect Duration: 57
-7609	deionized maroon wobbly Redeye&trade; Eyedrops	0		Effect: "Eau de Tortue", Effect Duration: 33
+7609	deionized wobbly maroon Redeye&trade; Eyedrops	0		Effect: "Eau de Tortue", Effect Duration: 33
 7610	deionized tarnished Dweebisol&trade; inhaler	0		Effect: "Dexteri Tea", Effect Duration: 53
 7611	quantum Lewd Lemmy Hair Oil	0		Effect: "Sweet and Green", Effect Duration: 64
 7612	non-tarnished tarnished tomato soup poster	0		Effect: "Eagle Eyes", Effect Duration: 34
@@ -7512,7 +7512,7 @@
 7623	polarized corrupted Red Army camouflage kit	0		Effect: "Ten out of Ten", Effect Duration: 12
 7624	unsweetened lynyrd skinner toothblack	0		Effect: "You're High as a Crow, Marty", Effect Duration: 49
 7625	chilled Vulcanized gray flask of rainwater	0		Effect: "Thaumodynamic", Effect Duration: 25
-7626	deionized green pulsating oyster badge	0		Effect: "Stogied", Effect Duration: 21
+7626	deionized pulsating green oyster badge	0		Effect: "Stogied", Effect Duration: 21
 7627	enhanced anodized jittery plastic Jefferson wings	0		Effect: "Yet tea", Effect Duration: 45
 7628	super-improved pulsating dancing fan	0		Effect: "Mighty Shout", Effect Duration: 29
 7629	deionized concentrated page of the Necrohobocon	0		Effect: "Frog In Your Throat", Effect Duration: 61
@@ -7552,8 +7552,8 @@
 7663	scandalous Socratic Lord Soggyraven's Slippers of chilblains	0		Experience (Mysticality): +1, Cold Damage: +25, Sleaze Damage: +5, Single Equip
 7664	non-ionized liquefied Ancient Protector Soda	0		Effect: "Flower Power", Effect Duration: 21
 7665	irradiated liquid ice	0		Effect: "Spooky Weapon", Effect Duration: 58
-7666	perfectly mixed practically non-alcoholic tumbling Wet Russian	1	super ultra mega turbo EPIC	
-7667	special moldy jumbo filet of The Fish	5	crappy	Effect: "Stuck-Up Hair", Effect Duration: 20
+7666	practically non-alcoholic perfectly mixed tumbling Wet Russian	1	super ultra mega turbo EPIC	
+7667	moldy jumbo special filet of The Fish	5	crappy	Effect: "Stuck-Up Hair", Effect Duration: 20
 7668	Thwaitgold spider statuette	0		
 7669	dance instructor's educational thunder down underwear of the storm	0		Experience: +1, Experience Percent (Moxie): +10, Maximum MP Percent: +40, Lasts Until Rollover
 7670	ghostly bouncing red Annie Oakley's sharpshooter's wizardly famous raincoat	0		Mysticality: +25, Critical Hit Percent: 30, Lasts Until Rollover
@@ -7567,7 +7567,7 @@
 7678	flame-retardant 4-dimensional fez	0		Hot Resistance: +1, Familiar Effect: "atk, 1xLep, cap 12"
 7679	narrow throwing candy	0		
 7680	wobbly asbestos-lined super-absorbent tarp	0		Hot Resistance: +5
-7681	acceptable weak spinning unquiet spirits	2	good	
+7681	weak acceptable spinning unquiet spirits	2	good	
 7682	blue avaricious banjo kazoo mount	0		Meat Drop: +30, Single Equip
 7683	Vulcanized grass	0		Effect: "Moon'd", Effect Duration: 58
 7684	beefy Time Lord Participation Mug	0		Muscle: +10
@@ -7581,7 +7581,7 @@
 7692	prompt aromatic chilly hand whip	0		Cold Damage: +5, Stench Resistance: +1, Adventures: +3, Last Available: "2014-08"
 7693	blinking narrow Samson's cool strapping glow-in-the-dark necklace	0		Muscle: +5, Moxie: +5, Experience (Muscle): +5, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	bouncing electrified arcane researcher's cap gun of the detective	0		Experience Percent (Mysticality): +10, Item Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	bouncing electrified arcane researcher's cap gun of the detective	0		Experience Percent (Mysticality): +10, Item Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	ghostly squat Jim Carey's cassette player of dire peril	0		Weapon Damage: +20, Monster Level: +25, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	blurry rubber spider	0		Last Available: "2014-08"
@@ -7592,16 +7592,16 @@
 7703	ghostly LCD game: Food Eater	0		Last Available: "2014-08"
 7704	upside-down tumbling red LCD game: Garbage River	0		Last Available: "2014-08"
 7705	blurry LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	narrow The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	narrow The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	dry oxidized shaking rubber nubbin	0		Effect: "damage.enh", Effect Duration: 67, Last Available: "2014-08"
 7708	blurry lard-coated rubber cape of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2014-08"
-7709	reassuring horrifying scorching Thor's Pliers of the glutton	0		Hot Damage: +25, Spooky Damage: +25, Spooky Resistance: +1, Food Drop: +100, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	reassuring horrifying scorching Thor's Pliers of the glutton	0		Hot Damage: +25, Spooky Damage: +25, Spooky Resistance: +1, Food Drop: +100, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	quadruple-unsweetened flattened bouncing candy UFOs	0		Effect: "Icy Demeanor", Effect Duration: 69
 7711	crafty water wings for babies of the sweet-tooth	0		Maximum MP: +10, Candy Drop: +100
-7712	blurry mirror beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	mirror blurry beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	bland Strix stix	3	decent	
 7714	knitted resourceful medical-grade vampire pellet	0		Maximum MP: +50, Cold Resistance: +3, HP Regen Min: 7, HP Regen Max: 10
-7715	tolerable practically non-alcoholic non-aged vinegar	1	good	
+7715	practically non-alcoholic tolerable non-aged vinegar	1	good	
 7716	blurry unsanitized scalpel of extreme caution	0		Monster Level: -25
 7717	gray mirror savvy gladiator tunica	0		Mysticality Percent: +20
 7718	ghostly boxer's Roman sadnals	0		Muscle Percent: +10, Single Equip
@@ -7614,7 +7614,7 @@
 7725	denatured spinning Bruno's blessing of Mars	0		Effect: "Elemental Saucesphere", Effect Duration: 51
 7726	chilled non-altered gray Dennis's blessing of Minerva	0		Effect: "Leisurely Amblin'", Effect Duration: 49
 7727	improved Burt's blessing of Bacchus	0		Effect: "Hopped Up on Goofballs", Effect Duration: 65
-7728	modified quadruple-electrified unsweetened twirling yellow Freddie's blessing of Mercury	0		Effect: "Hypercubed", Effect Duration: 41
+7728	modified quadruple-electrified unsweetened yellow twirling Freddie's blessing of Mercury	0		Effect: "Hypercubed", Effect Duration: 41
 7729	Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
@@ -7639,10 +7639,10 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	knitted Xiblaxian xeno-detection goggles	0		Cold Resistance: +3, Single Equip, Last Available: "2014-09"
-7753	clever Xiblaxian stealth cowl of chilblains	0		Maximum MP: +20, Cold Damage: +25, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	clever Xiblaxian stealth cowl of chilblains	0		Maximum MP: +20, Cold Damage: +25, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	jittery rosewater-soaked dangerous Xiblaxian stealth trousers	0		Weapon Damage: +10, Stench Resistance: +3, Last Available: "2014-09"
 7755	greedy stiffened Xiblaxian stealth vest	0		Damage Reduction: 1, Meat Drop: +20, Last Available: "2014-09"
-7756	yummy green shaking tumbling Xiblaxian ultraburrito	4	awesome	Last Available: "2014-09"
+7756	yummy green tumbling shaking Xiblaxian ultraburrito	4	awesome	Last Available: "2014-09"
 7757	aged red Xiblaxian space-whiskey	4	awesome	Last Available: "2014-09"
 7758	tumbling Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	denatured flattened They liver	0		Effect: "Hardened Fabric", Effect Duration: 24, Last Available: "2014-09"
@@ -7668,12 +7668,12 @@
 7779	alkaline yellow experimental serum G-9	0		Effect: "Ooh, Sour!", Effect Duration: 54, Last Available: "2014-10"
 7780	narrow censurious heavy-duty clipboard of the blizzard of courage	0		Cold Spell Damage: +25, Spooky Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 8, Last Available: "2014-10"
 7781	family-friendly curative battery-powered drill of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Sleaze Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-10"
-7782	stale diet limp broccoli	1	decent	Last Available: "2014-10"
-7783	shellacked hardened boxer's hat	0		Muscle Percent: +10, Damage Reduction: 20, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	diet stale limp broccoli	1	decent	Last Available: "2014-10"
+7783	shellacked hardened boxer's hat	0		Muscle Percent: +10, Damage Reduction: 20, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	quadruple-galvanized super-modified monkey barf	0		Effect: "Goldentongue", Effect Duration: 29, Last Available: "2014-10"
 7785	polarized denatured gray candy	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 53, Last Available: "2014-10"
 7786	Jack Frost's sage jangly bracelet of Tarzan	0		Mysticality Percent: +10, Experience (Muscle): +3, Cold Spell Damage: +50, Last Available: "2014-10"
-7787	veiny cuddly teddy bear	0		Maximum HP: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	veiny cuddly teddy bear	0		Maximum HP: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	educational groovy first-aid pouch	0		Moxie Percent: +10, Experience: +1, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7682,10 +7682,10 @@
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	normal blue initiative shawarma	4	good	Last Available: "2014-10"
-7796	snack-sized flavorless enchanted bouncing warm war shawarma	2	decent	Effect: "Polka Face", Effect Duration: 40, Last Available: "2014-10"
+7796	snack-sized enchanted flavorless bouncing warm war shawarma	2	decent	Effect: "Polka Face", Effect Duration: 40, Last Available: "2014-10"
 7797	spoiled gigantic tumbling karma shawarma	7	crappy	Last Available: "2014-10"
 7798	drinkable Jungle Juice	3	good	Last Available: "2014-10"
-7799	weak hand-crafted squat Amnesiac Ale	2	EPIC	Last Available: "2014-10"
+7799	hand-crafted weak squat Amnesiac Ale	2	EPIC	Last Available: "2014-10"
 7800	bad weak Highest Bitter	2	decent	Last Available: "2014-10"
 7801	Sinatra's mercenary pistol of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +5, Last Available: "2014-10"
 7802	shaking huge inspector's mercenary rifle of courage	0		Spooky Resistance: +3, Item Drop: +15, Last Available: "2014-10"
@@ -7699,7 +7699,7 @@
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	toothsome snack-sized special seared dino steak	2	awesome	Effect: "On the Shoulders of Giants", Effect Duration: 45
+7813	special toothsome snack-sized seared dino steak	2	awesome	Effect: "On the Shoulders of Giants", Effect Duration: 45
 7814	triple-distilled tolerable bottle of drinkin' gas	6	good	
 7815	handful of napalm	0		
 7816	dove DNA	0		
@@ -7713,7 +7713,7 @@
 7824	supercharged wizardly iShield of the cougar	0		Mysticality: +25, Moxie: +20, Maximum MP Percent: +30, Damage Reduction: 6
 7825	Jack Frost's beefcake's earbuds of James Dean	0		Muscle: +25, Experience (Moxie): +3, Cold Spell Damage: +50, Single Equip
 7826	shaking flame-retardant stiffened iFlail of vim and vigor	0		Damage Reduction: 1, Maximum HP Percent: +50, Hot Resistance: +1
-7827	thick flavorless tumbling blinking unidentifiable dried fruit	5	decent	
+7827	flavorless thick tumbling blinking unidentifiable dried fruit	5	decent	
 7828	acceptable flat cider	4	good	
 7829	smelly slick trench lighter of the cheetah	0		Moxie: +10, Stench Spell Damage: +10, Initiative: +60, Last Available: "2014-10"
 7830	extra-corrupted ghostly experimental serum P-00	0		Effect: "Greasy Flavor", Effect Duration: 54, Last Available: "2014-10"
@@ -7743,8 +7743,8 @@
 7854	plastic Crimbot of the wise owl	0		Mysticality: +20, Last Available: "2014-12"
 7855	cool plastic Crimbomega	0		Moxie: +5, Last Available: "2014-12"
 7856	dry flask of mining oil	0		Effect: "Buzzard Breath", Effect Duration: 55, Last Available: "2014-12"
-7857	lime green cool radiation-resistant helmet	0		Moxie: +5, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	energetic servo-assisted exo-pants	0		Maximum MP Percent: +20, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	lime green cool radiation-resistant helmet	0		Moxie: +5, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	energetic servo-assisted exo-pants	0		Maximum MP Percent: +20, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	wobbly Oprah's supercool high-energy mining laser	0		Moxie Percent: +20, Maximum MP Percent: +50, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	jittery nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7758,7 +7758,7 @@
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	shaking Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	mirror Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
-7872	twirling ghostly squat Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
+7872	twirling squat ghostly Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
@@ -7810,9 +7810,9 @@
 7921	wobbly turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	aged Friendly Turkey	3	awesome	Last Available: "2014-11"
 7923	weak artisanal Agitated Turkey	2	EPIC	Last Available: "2014-11"
-7924	practically non-alcoholic drinkable wobbly Ambitious Turkey	1	good	Last Available: "2014-11"
+7924	drinkable practically non-alcoholic wobbly Ambitious Turkey	1	good	Last Available: "2014-11"
 7925	super-sized normal neutron lollipop	5	good	Last Available: "2014-12"
-7926	weak perfectly mixed gamma nog	2	EPIC	Last Available: "2014-12"
+7926	perfectly mixed weak gamma nog	2	EPIC	Last Available: "2014-12"
 7934	spinning sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	upside-down picky tweezers	0		Last Available: "2015-02"
@@ -7881,17 +7881,17 @@
 7999	flattened blue choco-Crimbot	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 38, Last Available: "2014-12"
 8000	extra-ionized enhanced smart watch	0		Effect: "Icy Demeanor", Effect Duration: 68, Last Available: "2014-12"
 8001	colloidal ghostly augmented-reality shades	0		Effect: "Disco Nirvana", Effect Duration: 33, Last Available: "2014-12"
-8002	personal trainer's toy Crimbot mega face	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
-8003	olive Tesla toy Crimbot power glove	0		MP Regen Min: 7, MP Regen Max: 10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	hale toy Crimbot super fist	0		Maximum HP: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	groovy toy Crimbot rocket legs	0		Moxie Percent: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	personal trainer's toy Crimbot mega face	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
+8003	olive Tesla toy Crimbot power glove	0		MP Regen Min: 7, MP Regen Max: 10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	hale toy Crimbot super fist	0		Maximum HP: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	groovy toy Crimbot rocket legs	0		Moxie Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	non-polymerized tarnished purple Crimbot battery	0		Effect: "Turtle Power", Effect Duration: 25, Last Available: "2014-12"
 8007	blurry Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	stanky resourceful stiffened Crimbomega drive chain	0		Damage Reduction: 1, Maximum MP: +50, Stench Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	stanky resourceful stiffened Crimbomega drive chain	0		Damage Reduction: 1, Maximum MP: +50, Stench Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	tumbling Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	pulsating Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7952,25 +7952,25 @@
 8071	warehouse inventory page	0		
 8072	upside-down janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	blinking sizzling nippy Spelunker's fedora of the sewer	0		Cold Damage: +10, Hot Damage: +10, Stench Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	blinking sizzling nippy Spelunker's fedora of the sewer	0		Cold Damage: +10, Hot Damage: +10, Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	shaking Usain Bolt's studded stylish Spelunker's whip	0		Moxie: +25, Damage Absorption: +80, Initiative: +80, Last Available: "2015-12"
-8076	reassuring ruddy steel-toed Spelunker's khakis	0		Damage Reduction: 9, Maximum HP Percent: +40, Spooky Resistance: +1, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	reassuring ruddy steel-toed Spelunker's khakis	0		Damage Reduction: 9, Maximum HP Percent: +40, Spooky Resistance: +1, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
-8084	mirror ghostly LOLmec statuette	0		Last Available: "2015-12"
+8084	ghostly mirror LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
 8088	ghostly jewel	0		
 8089	headless sparrow	0		
 8090	mangled squirrel	0		
-8091	skewed teal rat carcass	0		
+8091	teal skewed rat carcass	0		
 8092	Sherlock's wicker kickers of Tarzan	0		Experience (Muscle): +3, Item Drop: +25, Single Equip, Last Available: "2016-12"
 8093	brainy wicker slicker of the scaredy-cat	0		Mysticality: +5, Monster Level: -15, Last Available: "2016-12"
 8094	baleful wicker knickers of the ox	0		Muscle: +20, Spell Damage: +25, Last Available: "2016-12"
 8095	lime green Van der Graaf Herculean wicker ticker	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2016-12"
 8096	family-friendly wicker sticker of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2016-12"
 8097	ghostly nasty wicker clicker of mayonnaise	0		Stench Damage: +5, Sleaze Spell Damage: +50, Last Available: "2016-12"
-8098	pickled skewed ghostly wickerbits	1		Last Available: "2016-12"
+8098	pickled ghostly skewed wickerbits	1		Last Available: "2016-12"
 8099	smelly thinker's belt	0		Mysticality: +10, Stench Spell Damage: +10, Single Equip, Last Available: "2016-12"
 8100	prompt mansplainer's badge	0		Monster Level: +15, Adventures: +3, Single Equip, Last Available: "2016-12"
 8101	bouncing rock-hard razor-sharp bowl	0		Weapon Damage Percent: +25, Damage Reduction: 5, Last Available: "2016-12"
@@ -7996,7 +7996,7 @@
 8121	wool flame-wreathed garland	0		Hot Spell Damage: +10, Cold Resistance: +1, Single Equip, Last Available: "2018-12"
 8122	careful gunnysack of the storm	0		Maximum MP Percent: +40, Monster Level: -10, Last Available: "2018-12"
 8123	blue Sinatra's garibaldi of the cheetah	0		Experience (Moxie): +5, Initiative: +60, Last Available: "2018-12"
-8124	family-friendly flame-retardant girdle	0		Hot Resistance: +1, Sleaze Resistance: +1, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	family-friendly flame-retardant girdle	0		Hot Resistance: +1, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	Annie Oakley's fortified gloves	0		Damage Absorption: +60, Critical Hit Percent: +20, Single Equip, Last Available: "2018-12"
 8126	modified smithereens	1		Last Available: "2018-12"
 8127	cyan fiberglass fetish of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15, Last Available: "2018-12"
@@ -8047,7 +8047,7 @@
 8173	lime green energetic sewer snake	0		Maximum MP Percent: +20
 8174	miniature stale pigeon egg	2	decent	
 8175	nippy jaunty feather of Tarzan	0		Experience (Muscle): +3, Cold Damage: +10
-8176	irresponsibly strong lousy premium malt liquor	8	decent	
+8176	lousy irresponsibly strong premium malt liquor	8	decent	
 8177	blurry brown paper pants of James Dean of Leguizamo	0		Experience (Moxie): +3, Monster Level: +20
 8178	jittery upside-down lion tamer's brown paper bag mask of Leguizamo	0		Monster Level: +20, Experience (familiar): +2
 8179	rosewater-soaked ring of telling skeletons what to do	0		Stench Resistance: +3, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,16 +8056,16 @@
 8182	tumbling Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	bouncing tumbling baleful bread basket	0		Spell Damage: +25
 8184	Ed the Undying exhibit crate	0		
-8185	veiny The Crown of Ed the Undying of the brute	0		Muscle Percent: +30, Maximum HP: +10, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	veiny The Crown of Ed the Undying of the brute	0		Muscle Percent: +30, Maximum HP: +10, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	spirit-forward mediocre bouncing Cherrytastrophe wine cooler	5	decent	
-8189	mediocre twirling wobbly olive Radberry Rip wine cooler	3	decent	
+8189	mediocre twirling olive wobbly Radberry Rip wine cooler	3	decent	
 8190	tolerable watered-down Orangemageddon wine cooler	2	good	
 8191	perfectly mixed blurry Breakfast Blast wine cooler	4	EPIC	
 8192	bad Citrus Crush wine cooler	3	decent	
 8193	stale gigantic plain bagel	9	decent	
-8194	snack-sized rotten glob of cream cheese	2	crappy	
+8194	rotten snack-sized glob of cream cheese	2	crappy	
 8195	normal loaf of soda bread	3	good	
 8196	small moldy acceptable bagel	2	crappy	
 8197	rotten standard-issue cupcake	3	crappy	
@@ -8085,14 +8085,14 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	curative boxer's rigging rope	0		Muscle Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-04"
-8214	distilled blinking huge blue nasty snuff	1	crappy	Last Available: "2015-04"
-8215	blurry asbestos-lined horrifying sewage-clogged pistol	0		Spooky Damage: +25, Hot Resistance: +5, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8214	distilled huge blue blinking nasty snuff	1	crappy	Last Available: "2015-04"
+8215	blurry asbestos-lined horrifying sewage-clogged pistol	0		Spooky Damage: +25, Hot Resistance: +5, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	polarized enhanced pressed beard incense	0		Effect: "Fangs and Pangs", Effect Duration: 14, Last Available: "2015-04"
 8217	blurry perfume-soaked bandana of incineration of the overflowing toilet	0		Hot Spell Damage: +50, Stench Spell Damage: +50, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	jumbo decent twirling toxo	5	good	Last Available: "2015-04"
-8220	weak lousy Lemonade-235	2	decent	Last Available: "2015-04"
-8221	skewed curative weightlifter's isotophat	0		Muscle: +15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8220	lousy weak Lemonade-235	2	decent	Last Available: "2015-04"
+8221	skewed curative weightlifter's isotophat	0		Muscle: +15, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	Sherlock's slick Three Mile Island shorts	0		Moxie: +10, Item Drop: +25, Last Available: "2015-04"
 8223	huge zippy clever toxic mop	0		Maximum MP: +20, Initiative: +20, Last Available: "2015-04"
 8224	twirling inert sludgepuppy	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	maroon trash net	0		Last Available: "2015-04"
 8246	wobbly family-friendly lard-coated sharpshooter's Dinsey mascot mask	0		Critical Hit Percent: +10, Sleaze Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2015-04"
 8247	flavorless Dinsey food-cone	4	decent	Last Available: "2015-04"
-8248	acceptable weak tumbling Dinsey Whinskey	2	good	Last Available: "2015-04"
+8248	weak acceptable tumbling Dinsey Whinskey	2	good	Last Available: "2015-04"
 8249	oxidized vacuum-sealed Dinsey face paint	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 54, Last Available: "2015-04"
 8250	flame-retardant fannypack of wisdom	0		Mysticality: +15, Hot Resistance: +1, Last Available: "2015-04"
 8251	ruddy occult experienced brainy garbage sticker of chilblains of the detective	0		Mysticality: +5, Experience: +2, Spell Damage Percent: +25, Maximum HP Percent: +40, Cold Damage: +25, Item Drop: +20, Last Available: "2015-04"
@@ -8149,7 +8149,7 @@
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	pulsating Essence of Bear	0		Skill: "Bear Essence"
-8278	smooth special blurry Afternoon Delight	3	awesome	Effect: "Eyes for Miles", Effect Duration: 20, Last Available: "2015-04"
+8278	special smooth blurry Afternoon Delight	3	awesome	Effect: "Eyes for Miles", Effect Duration: 20, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	polarized spinning blue Kokomo Resort Brand Suntan Oil	0		Effect: "Egg-stra Arm", Effect Duration: 14, Last Available: "2015-04"
@@ -8157,7 +8157,7 @@
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	concentrated Kokomo Resort Pass	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 52, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
-8286	modified double-alkaline corrupted green skewed Mayo de Mayo&trade; mayo	0		Effect: "Bear Clawed", Effect Duration: 64
+8286	modified double-alkaline corrupted skewed green Mayo de Mayo&trade; mayo	0		Effect: "Bear Clawed", Effect Duration: 64
 8287	puck	0		Free Pull, Last Available: "2015-06"
 8288	ghostly kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	squat boxing gloves	0		Last Available: "2015-06"
@@ -8171,7 +8171,7 @@
 8297	triple-ionized wet warmed dice	0		Effect: "Mucilaginous Mentalism", Effect Duration: 55
 8298	pixel	0		Last Available: "2015-06"
 8299	huge pixel coin	0		Last Available: "2015-06"
-8300	diffused concentrated narrow tumbling power pill	0		Effect: "Optimist Primal", Effect Duration: 27, Last Available: "2015-06"
+8300	diffused concentrated tumbling narrow power pill	0		Effect: "Optimist Primal", Effect Duration: 27, Last Available: "2015-06"
 8301	frozen boiled jittery pixel star	0		Effect: "Stickler for Promptness", Effect Duration: 48, Last Available: "2015-06"
 8302	flavorless yellow skewed pixel banana	4	decent	Last Available: "2015-06"
 8303	aged pixel beer	4	awesome	Last Available: "2015-06"
@@ -8207,7 +8207,7 @@
 8333	corrupted anodized batarang	0		Effect: "Bureaucratized", Effect Duration: 47
 8334	pressed improved spare neck bolts	0		Effect: "Afternoon Insight", Effect Duration: 54
 8335	electrified grease trap	0		Effect: "Wintry Breath", Effect Duration: 41
-8336	polarized spinning ghostly shamanic ham	0		Effect: "Headstrong", Effect Duration: 50
+8336	polarized ghostly spinning shamanic ham	0		Effect: "Headstrong", Effect Duration: 50
 8337	adjusted quantum anodized porkpocket	0		Effect: "BOOsted", Effect Duration: 68
 8338	altered pressed skewed Leonard's glasses	0		Effect: "Thickest, Sickest", Effect Duration: 28
 8339	polarized cold-filtered warehouse walkie-talkie	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 17
@@ -8219,20 +8219,20 @@
 8345	liquefied crident	0		Effect: "Egg on your Face", Effect Duration: 41
 8346	energized ionized totally sweet mohawk helmet	0		Effect: "Holiday Bliss", Effect Duration: 33
 8347	moist red spray chrome	0		Effect: "Egg-stortionary Tactics", Effect Duration: 22
-8348	tarnished purple skewed filthy monkey head	0		Effect: "New and Improved", Effect Duration: 39
+8348	tarnished skewed purple filthy monkey head	0		Effect: "New and Improved", Effect Duration: 39
 8349	magnetized lime green hand of cards	0		Effect: "Shawarma Warm War", Effect Duration: 32
 8350	denatured red damp bar rag	0		Effect: "Purity of Spirit", Effect Duration: 43
 8351	quantum colloidal altered narrow lump of goofball ore	0		Effect: "Items Are Forever", Effect Duration: 19
 8352	dry enhanced skeleton beans	0		Effect: "Employee of the Month", Effect Duration: 59
 8353	Vulcanized lime green grimy lab coat	0		Effect: "Carol of the Bones", Effect Duration: 58
-8354	moist squat twirling nursery rhyme	0		Effect: "Full of Vinegar", Effect Duration: 18
+8354	moist twirling squat nursery rhyme	0		Effect: "Full of Vinegar", Effect Duration: 18
 8355	colloidal pressed squat iron torso box	0		Effect: "Wet Jaw", Effect Duration: 41
 8356	pressed polarized spinning mercenary headband	0		Effect: "Object Detection", Effect Duration: 61
 8357	energized alkaline irradiated teal radioactive spider venom	0		Effect: "Mystically Oiled", Effect Duration: 63
 8358	nitrogenated aerosolized x-ray mirror	0		Effect: "Human-Constellation Hybrid", Effect Duration: 25
 8359	moist dry mirror wrestling mask	0		Effect: "Pemmican't", Effect Duration: 50
 8360	aerosolized oxidized improved hawkface potion	0		Effect: "Well-Oiled", Effect Duration: 15
-8361	ionized adjusted twirling blue jittery child-sized dracula cloak	0		Effect: "Kissed By Fire", Effect Duration: 61
+8361	ionized adjusted jittery twirling blue child-sized dracula cloak	0		Effect: "Kissed By Fire", Effect Duration: 61
 8362	Vulcanized devil-summoning hat	0		Effect: "Boletus Swoletus", Effect Duration: 31
 8363	activated polarized shopkeeper beard	0		Effect: "Puddingskin", Effect Duration: 42
 8364	super-pickled blinking tumbling alien autoautopsy kit	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 37
@@ -8240,15 +8240,15 @@
 8366	denatured twirling invisibility cream	0		Effect: "Spooky Blur", Effect Duration: 34
 8367	colloidal ghostly handful of stubble	0		Effect: "Corruption of Wretched Wally", Effect Duration: 25
 8368	non-liquefied garbage juice slurpee	0		Effect: "Fustulent", Effect Duration: 53
-8369	galvanized diffused blinking fuchsia plunge-leg	0		Effect: "Bark of the Dog", Effect Duration: 58
-8370	alkaline bouncing purple spinning funky eyepatch	0		Effect: "So Fresh and So Clean", Effect Duration: 67
+8369	galvanized diffused fuchsia blinking plunge-leg	0		Effect: "Bark of the Dog", Effect Duration: 58
+8370	alkaline bouncing spinning purple funky eyepatch	0		Effect: "So Fresh and So Clean", Effect Duration: 67
 8371	moist red bucket of fish juice	0		Effect: "Polar Express", Effect Duration: 59
 8372	quadruple-cold-filtered alkaline adjusted flashy pirate dreadlocks	0		Effect: "Phairly Balanced", Effect Duration: 56
 8373	colloidal captured boozles	0		Effect: "The Smile of Mr. A.", Effect Duration: 64
 8374	magnetized drinks tray	0		Effect: "Takin' It Greasy", Effect Duration: 35
-8375	extra-alkaline mirror blurry eyebrow lifter	0		Effect: "Celestial Sheen", Effect Duration: 64
+8375	extra-alkaline blurry mirror eyebrow lifter	0		Effect: "Celestial Sheen", Effect Duration: 64
 8376	submarine	0		Last Available: "2015-06"
-8377	half-sized spoiled pixel lemon	2	crappy	Last Available: "2015-06"
+8377	spoiled half-sized pixel lemon	2	crappy	Last Available: "2015-06"
 8378	lousy pixel daiquiri	4	decent	Last Available: "2015-06"
 8379	dry shaking power pill	0		Effect: "Lemon Enlightenment", Effect Duration: 35, Last Available: "2015-06"
 8380	extra-nitrogenated magnetized cyan pixel potion	0		Effect: "How to Scam Tourists", Effect Duration: 30, Last Available: "2015-06"
@@ -8258,7 +8258,7 @@
 8384	bubblegum heart	0		Last Available: "2015-07"
 8385	fuchsia cubic zirconia	0		Last Available: "2015-07"
 8386	ghostly valuable coin	0		Last Available: "2015-07"
-8387	twirling blurry mana	0		Last Available: "2015-07"
+8387	blurry twirling mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
 8389	fuchsia mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
@@ -8278,12 +8278,12 @@
 8404	fuchsia 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	tasty snack-sized skewed pestopiary	2	awesome	
+8407	snack-sized tasty skewed pestopiary	2	awesome	
 8408	dry ectoplasmic orbs	0		Effect: "Employee of the Month", Effect Duration: 14
-8409	big stale crudles	5	decent	
-8410	snack-sized flavorless agnolotti arboli	2	decent	
-8411	decent fancy spaghetti with ghost balls	3	good	Effect: "Hyphemariffic", Effect Duration: 40
-8412	low-calorie normal succulent marrow	1	good	
+8409	stale big crudles	5	decent	
+8410	flavorless snack-sized agnolotti arboli	2	decent	
+8411	fancy decent spaghetti with ghost balls	3	good	Effect: "Hyphemariffic", Effect Duration: 40
+8412	normal low-calorie succulent marrow	1	good	
 8413	moldy ghostly salacious crumbs	3	crappy	
 8414	bland fusilli marrownarrow	4	decent	
 8415	tasty suggestive strozzapreti	3	awesome	
@@ -8327,32 +8327,32 @@
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	shaking LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
-8456	mirror pulsating crystalline light bulb	0		Last Available: "2015-08"
+8456	pulsating mirror crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	censurious perfumed high-temperature mining mask	0		Stench Resistance: +5, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	censurious perfumed high-temperature mining mask	0		Stench Resistance: +5, Sleaze Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	sage fireproof megaphone of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Last Available: "2015-08"
-8460	tasty super-sized mineapple	5	awesome	Last Available: "2015-08"
-8461	fancy bad Gold Velvet&trade; whiskey	3	decent	Effect: "20/20 Vision", Effect Duration: 25, Last Available: "2015-08"
+8460	super-sized tasty mineapple	5	awesome	Last Available: "2015-08"
+8461	bad fancy Gold Velvet&trade; whiskey	3	decent	Effect: "20/20 Vision", Effect Duration: 25, Last Available: "2015-08"
 8462	SMOOCH soda	1	crappy	Last Available: "2015-08"
-8463	flavorless small smelted roe	2	decent	Last Available: "2015-08"
+8463	small flavorless smelted roe	2	decent	Last Available: "2015-08"
 8464	lousy lavawater	4	decent	Last Available: "2015-08"
-8465	activated skewed spinning basaltamander tongue	0		Effect: "Cockroach Scurry", Effect Duration: 12, Last Available: "2015-08"
+8465	activated spinning skewed basaltamander tongue	0		Effect: "Cockroach Scurry", Effect Duration: 12, Last Available: "2015-08"
 8466	rosy-cheeked personal trainer's lavalarva of the ox	0		Muscle: +20, Experience Percent (Muscle): +10, Maximum HP Percent: +30, Last Available: "2015-08"
 8467	Sherlock's experienced lava balaclava of the ox	0		Muscle: +20, Experience: +2, Item Drop: +25, Last Available: "2015-08"
 8468	sinister personal trainer's basaltamander buckler of the cheetah	0		Experience Percent (Muscle): +10, Spell Damage: +10, Initiative: +60, Damage Reduction: 15, Last Available: "2015-08"
 8469	tarnished dry ghostly lava globs	0		Effect: "Smugness", Effect Duration: 43, Last Available: "2015-08"
-8470	moldy small gooey lava globs	2	crappy	Last Available: "2015-08"
+8470	small moldy gooey lava globs	2	crappy	Last Available: "2015-08"
 8471	jittery Jim Carey's lava-proof pants of the businessman	0		Monster Level: +25, Meat Drop: +50, Last Available: "2015-08"
 8472	upside-down toasty manspreader's heat-resistant necktie	0		Monster Level: +10, Hot Damage: +5, Single Equip, Last Available: "2015-08"
 8473	fireproof greasy ribald heat-resistant gloves	0		Sleaze Damage: +10, Sleaze Spell Damage: +10, Hot Resistance: +3, Single Equip, Last Available: "2015-08"
-8474	miniature rotten very hot lunch	2	crappy	Last Available: "2015-08"
-8475	high-proof drinkable enchanted jittery bouncing asbestos thermos	9	good	Effect: "Florid Cheeks", Effect Duration: 5, Last Available: "2015-08"
+8474	rotten miniature very hot lunch	2	crappy	Last Available: "2015-08"
+8475	enchanted drinkable high-proof jittery bouncing asbestos thermos	9	good	Effect: "Florid Cheeks", Effect Duration: 5, Last Available: "2015-08"
 8476	galvanized improved adjusted liquid rhinestones	0		Effect: "Hair on Your Chest", Effect Duration: 42, Last Available: "2015-08"
 8477	moldy disco biscuit	3	crappy	Last Available: "2015-08"
 8478	aged Quaatorade&trade;	4	awesome	Last Available: "2015-08"
-8479	mirror flame-wreathed hale smartaleck's biker's hat	0		Moxie Percent: +30, Maximum HP: +20, Hot Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
-8480	perfumed razor-sharp feathered headdress of doom	0		Weapon Damage Percent: +25, Spooky Spell Damage: +50, Stench Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	brainy electrician's hardhat of dire peril of terror	0		Mysticality: +5, Weapon Damage: +20, Spooky Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
+8479	mirror flame-wreathed hale smartaleck's biker's hat	0		Moxie Percent: +30, Maximum HP: +20, Hot Spell Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
+8480	perfumed razor-sharp feathered headdress of doom	0		Weapon Damage Percent: +25, Spooky Spell Damage: +50, Stench Resistance: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	brainy electrician's hardhat of dire peril of terror	0		Mysticality: +5, Weapon Damage: +20, Spooky Spell Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	teal Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	bouncing New Age hurting crystal	0		Last Available: "2015-08"
-8490	perfumed smooth velvet pants	0		Stench Resistance: +5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	perfumed smooth velvet pants	0		Stench Resistance: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	razor-sharp smooth velvet shirt	0		Weapon Damage Percent: +25, Last Available: "2015-08"
 8492	fuchsia stiffened smooth velvet hat	0		Damage Reduction: 1, Last Available: "2015-08"
 8493	scandalous smooth velvet pocket square	0		Sleaze Damage: +5, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	lime green padded SMOOCH bracers of Leguizamo	0		Damage Absorption: +20, Monster Level: +20, Single Equip, Last Available: "2015-08"
 8518	dog trainer's SMOOCH kneepads	0		Experience (familiar): +1, Single Equip, Last Available: "2015-08"
 8519	tumbling beefcake's SMOOCH spaulders	0		Muscle: +25, Single Equip, Last Available: "2015-08"
-8520	Rosewater's SMOOCH codpiece of the cougar	0		Moxie: +20, Mysticality Percent: +30, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	Rosewater's SMOOCH codpiece of the cougar	0		Moxie: +20, Mysticality Percent: +30, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	blinking steel-toed SMOOCH breastplate	0		Damage Reduction: 9, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8400,20 +8400,20 @@
 8526	rotten pink slime	4	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	jumbo adequate yellow blinking devil hair pasta	5	good	
-8530	rotten diet red spagecialetti	1	crappy	
+8529	adequate jumbo blinking yellow devil hair pasta	5	good	
+8530	diet rotten red spagecialetti	1	crappy	
 8531	mirror Salsa Libre	0		
 8532	blue good gravy	0		
 8533	wobbly illicit fish sauce	0		
 8534	tasty fancy libertagliatelle	4	awesome	Effect: "Coldfinger", Effect Duration: 40
-8535	rotten snack-sized teal turkish mostaccioli	2	crappy	
+8535	snack-sized rotten teal turkish mostaccioli	2	crappy	
 8536	rotten small linguini of the sea	2	crappy	
 8537	vacuum-sealed olive Hersey&trade; SMOOCH	0		Effect: "Trufflin'", Effect Duration: 45
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	fancy small rotten Fettris	2	crappy	Effect: "Twenty-three Squid, Ew", Effect Duration: 45
-8543	tiny toothsome fusillocybin	1	awesome	
+8542	rotten small fancy Fettris	2	crappy	Effect: "Twenty-three Squid, Ew", Effect Duration: 45
+8543	toothsome tiny fusillocybin	1	awesome	
 8544	adequate red prescription noodles	3	good	
 8545	modified blood-drive sticker	1	decent	
 8546	wet wobbly bag of grain	0		Effect: "Beastly Flavor", Effect Duration: 17
@@ -8421,9 +8421,9 @@
 8548	colloidal shady shades	0		Effect: "Arabian Knighthood", Effect Duration: 23
 8549	Vulcanized ionized huge squeaky toy rose	0		Effect: "Red Misty-Eyed", Effect Duration: 62
 8550	big delicious enchanted weird gazelle steak	5	awesome	Effect: "Human-Weird Thing Hybrid", Effect Duration: 35
-8551	diet flavorless sausage without a cause	1	decent	
+8551	flavorless diet sausage without a cause	1	decent	
 8552	galvanized face paint	0		Effect: "Human-Plant Hybrid", Effect Duration: 41
-8553	fortified tolerable emergency margarita	5	good	
+8553	tolerable fortified emergency margarita	5	good	
 8554	acceptable high-proof wobbly vintage smart drink	6	good	
 8555	purple a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8437,8 +8437,8 @@
 8564	upside-down shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	hardy studded barrel lid of the cougar	0		Moxie: +20, Damage Absorption: +80, Maximum HP: +50, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	fuchsia ribald dog trainer's experienced barrel hoop earring	0		Experience: +2, Experience (familiar): +1, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	smelly resourceful experienced bankruptcy barrel	0		Experience: +2, Maximum MP: +50, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
-8568	maroon twirling firkin	0		Last Available: "2015-09"
+8567	smelly resourceful experienced bankruptcy barrel	0		Experience: +2, Maximum MP: +50, Stench Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8568	twirling maroon firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	skewed tumbling tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
@@ -8451,7 +8451,7 @@
 8578	hand-crafted weak bottle of Amontillado	2	EPIC	Last Available: "2015-09"
 8579	watered-down perfectly mixed barrel-aged martini	2	EPIC	Last Available: "2015-09"
 8580	bland huge barrel pickle	3	decent	Last Available: "2015-09"
-8581	big moldy barrel cracker	5	crappy	Last Available: "2015-09"
+8581	moldy big barrel cracker	5	crappy	Last Available: "2015-09"
 8582	altered vibrating mushroom	1	awesome	Last Available: "2015-09"
 8583	vaporized bouncing purple mushroom	1	good	Last Available: "2015-09"
 8584	bouncing fuchsia Jim Carey's KoL Con 12-gauge	0		Monster Level: +25, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	huge gravedigger's barrel gun	0		Spooky Damage: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	moldy huge water log	7	crappy	Last Available: "2015-09"
+8589	huge moldy water log	7	crappy	Last Available: "2015-09"
 8590	huge Annie Oakley's steel-toed barrelhead	0		Damage Reduction: 9, Critical Hit Percent: +20, Last Available: "2015-09"
 8591	Rosewater's bottoms of the barrel of the detective	0		Mysticality Percent: +30, Item Drop: +20, Last Available: "2015-09"
 8592	lime green spinning scandalous chest barrel of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Last Available: "2015-09"
@@ -8479,7 +8479,7 @@
 8606	corrupted cuppa Frost tea	0		Effect: "Sugar Smacks", Effect Duration: 44, Last Available: "2015-09"
 8607	frozen cuppa Toast tea	0		Effect: "Filled with Magic", Effect Duration: 51, Last Available: "2015-09"
 8608	moist cold-filtered cuppa Net tea	0		Effect: "Flame-Retardant Trousers", Effect Duration: 37, Last Available: "2015-09"
-8609	warmed squat yellow spinning cuppa Proprie tea	0		Effect: "Good Motivator", Effect Duration: 42, Last Available: "2015-09"
+8609	warmed yellow squat spinning cuppa Proprie tea	0		Effect: "Good Motivator", Effect Duration: 42, Last Available: "2015-09"
 8610	diffused boiled blurry blurry cuppa Morbidi tea	0		Effect: "Warm Belly", Effect Duration: 46, Last Available: "2015-09"
 8611	quadruple-warmed huge blurry cuppa Chari tea	0		Effect: "Work For Hours a Week", Effect Duration: 66, Last Available: "2015-09"
 8612	vacuum-sealed modified electrified cuppa Serendipi tea	0		Effect: "Weird Flavor", Effect Duration: 65, Last Available: "2015-09"
@@ -8511,9 +8511,9 @@
 8638	beefy Royal scepter of temperance of the sweet-tooth	0		Muscle: +10, Sleaze Resistance: +5, Candy Drop: +100, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	special adequate big bowl of eyeballs	5	good	Effect: "Pork Power", Effect Duration: 5, Last Available: "2015-10"
-8642	flavorless spinning ghostly bowl of mummy guts	4	decent	Last Available: "2015-10"
-8643	enchanted delicious gigantic ghostly bowl of maggots	10	awesome	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2015-10"
+8641	adequate special big bowl of eyeballs	5	good	Effect: "Pork Power", Effect Duration: 5, Last Available: "2015-10"
+8642	flavorless ghostly spinning bowl of mummy guts	4	decent	Last Available: "2015-10"
+8643	delicious enchanted gigantic ghostly bowl of maggots	10	awesome	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2015-10"
 8644	bad blood and blood	4	decent	Last Available: "2015-10"
 8645	boozy tolerable Jack-O-Lantern beer	5	good	Last Available: "2015-10"
 8646	aged zombie	3	awesome	Last Available: "2015-10"
@@ -8529,7 +8529,7 @@
 8656	Temple Grandin's Othello's military jacket	0		Familiar Weight: +7
 8657	jittery supercharged Othello's dagger	0		Maximum MP Percent: +30, Single Equip
 8658	Othello's handkerchief of the businessman	0		Meat Drop: +50, Single Equip
-8659	frozen diffused bouncing pulsating bowl of Jeal-O	0		Effect: "Squid Squint", Effect Duration: 30
+8659	frozen diffused pulsating bouncing bowl of Jeal-O	0		Effect: "Squid Squint", Effect Duration: 30
 8660	grip key	0		
 8661	wobbly How to Play Othello	0		
 8662	tumbling blue stiffened strapping ghostly dagger of wisdom	0		Muscle: +5, Mysticality: +15, Damage Reduction: 1
@@ -8542,13 +8542,13 @@
 8669	tulip	0		
 8670	blurry tulip	0		
 8671	blurry tulip	0		
-8672	huge twirling Walford's bucket	0		Last Available: "2015-11"
+8672	twirling huge Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	tumbling one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	electrified ghostly blurry shoulder-warming lotion	0		Effect: "Think Win-Lose", Effect Duration: 55, Last Available: "2015-11"
+8676	electrified blurry ghostly shoulder-warming lotion	0		Effect: "Think Win-Lose", Effect Duration: 55, Last Available: "2015-11"
 8677	decent iceberg lettuce	4	good	Last Available: "2015-11"
-8678	enchanted acceptable ice wine	4	good	Effect: "Tea-hee", Effect Duration: 45, Last Available: "2015-11"
+8678	acceptable enchanted ice wine	4	good	Effect: "Tea-hee", Effect Duration: 45, Last Available: "2015-11"
 8679	squat wool energetic stiffened Wal-Mart snowglobe	0		Damage Reduction: 1, Maximum MP Percent: +20, Cold Resistance: +1, Last Available: "2015-11"
 8680	family-friendly Wal-Mart nametag of vim and vigor of horror	0		Maximum HP Percent: +50, Spooky Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2015-11"
 8681	ghostly gray Van der Graaf forbidden Wal-Mart overalls of the scaredy-cat	0		Spell Damage Percent: +50, Monster Level: -15, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-11"
@@ -8558,11 +8558,11 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	jittery perfect ice cube	0		Last Available: "2015-11"
 8687	yellow The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	tumbling bellhop's hat of dire peril	0		Weapon Damage: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	weak acceptable ice porter	2	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	tumbling bellhop's hat of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	acceptable weak ice porter	2	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	modified lime green exotic travel brochure	0		Effect: "Grrrrrrreat!", Effect Duration: 17, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
-8692	irradiated improved wobbly red bouncing shampoo-conditioner	0		Effect: "Morbidi Tea", Effect Duration: 41, Last Available: "2015-11"
+8692	irradiated improved bouncing wobbly red shampoo-conditioner	0		Effect: "Morbidi Tea", Effect Duration: 41, Last Available: "2015-11"
 8693	narrow hotel minibar key	0		Last Available: "2015-11"
 8694	blue mirror skewed ice hotel bell	0		Last Available: "2015-11"
 8695	mirror Martialest Arts trophy	0		Last Available: "2016-01"
@@ -8571,25 +8571,25 @@
 8698	triple-distilled lousy mirror iced plum wine	8	decent	Last Available: "2016-01"
 8699	blurry friendly boxer's strapping training belt	0		Muscle: +5, Muscle Percent: +10, Familiar Weight: +3, Single Equip, Last Available: "2016-01"
 8700	narrow rosy-cheeked experienced brawny training legwarmers	0		Muscle Percent: +20, Experience: +2, Maximum HP Percent: +30, Single Equip, Last Available: "2016-01"
-8701	careful resourceful baleful training helmet	0		Spell Damage: +25, Maximum MP: +50, Monster Level: -10, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	careful resourceful baleful training helmet	0		Spell Damage: +25, Maximum MP: +50, Monster Level: -10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	tumbling training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	pulsating training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	ghostly X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
-8706	blinking red machine elf capsule	0		Free Pull, Last Available: "2015-12"
+8706	red blinking machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	spinning self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	mixed twirling purple abstraction: action	1		Last Available: "2015-12"
 8709	dried narrow abstraction: thought	1		Last Available: "2015-12"
 8710	mixed mirror abstraction: sensation	1		Effect: "Poker Faced", Effect Duration: 30, Last Available: "2015-12"
 8711	diluted green abstraction: purpose	1		Last Available: "2015-12"
 8712	dehydrated purple bouncing abstraction: category	1		Last Available: "2015-12"
-8713	mixed wobbly blue wobbly abstraction: perception	1		Effect: "Like a Fish to Walter", Effect Duration: 30, Last Available: "2015-12"
+8713	mixed blue wobbly wobbly abstraction: perception	1		Effect: "Like a Fish to Walter", Effect Duration: 30, Last Available: "2015-12"
 8714	compressed abstraction: motion	1		Last Available: "2015-12"
 8715	vaporized blinking abstraction: joy	1		Effect: "Phairly Balanced", Effect Duration: 50, Last Available: "2015-12"
-8716	diluted blurry skewed abstraction: certainty	1		Effect: "Innately Truthy", Effect Duration: 35, Last Available: "2015-12"
+8716	diluted skewed blurry abstraction: certainty	1		Effect: "Innately Truthy", Effect Duration: 35, Last Available: "2015-12"
 8717	mixed abstraction: comprehension	1		Last Available: "2015-12"
 8718	narrow modern picture frame	0		Last Available: "2015-12"
-8719	adequate snack-sized squat VYKEA meatballs	2	good	Last Available: "2015-11"
+8719	snack-sized adequate squat VYKEA meatballs	2	good	Last Available: "2015-11"
 8720	smooth VYKEA mead	4	awesome	Last Available: "2015-11"
 8721	triple-unsweetened activated VYKEA woadpaint	0		Effect: "EVISCERATE!", Effect Duration: 62, Last Available: "2015-11"
 8722	wobbly VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8601,11 +8601,11 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	scorching rosy-cheeked smartaleck's VYKEA hex key	0		Moxie Percent: +30, Maximum HP Percent: +30, Hot Damage: +25, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	massive normal twirling tin of submardines	7	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	delicious strong bottle of norwhiskey	5	awesome	Last Available: "2015-11"
+8731	massive normal twirling tin of submardines	7	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	strong delicious bottle of norwhiskey	5	awesome	Last Available: "2015-11"
 8733	altered octolus oculus	1	crappy	Last Available: "2015-11"
 8734	arcane researcher's sardine can key of the blizzard of incineration	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +25, Hot Spell Damage: +50, Last Available: "2015-11"
-8735	shaking perfumed curative healthy norwhal helmet	0		Maximum HP Percent: +20, Stench Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	shaking perfumed curative healthy norwhal helmet	0		Maximum HP Percent: +20, Stench Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	shellacked brainy octolus-skin cloak of vim and vigor	0		Mysticality: +5, Damage Reduction: 7, Maximum HP Percent: +50, Last Available: "2015-11"
 8737	hand-crafted perfect cosmopolitan	3	EPIC	Last Available: "2015-11"
 8738	acceptable perfect negroni	3	good	Last Available: "2015-11"
@@ -8623,9 +8623,9 @@
 8750	Vulcanized Vulcanized hemp candy necklace	0		Effect: "All Branned Up", Effect Duration: 64, Last Available: "2015-12"
 8751	quantum pickled blinking communal gobstopper	0		Effect: "Rad-ish", Effect Duration: 34, Last Available: "2015-12"
 8752	bland Crimbo salad	3	decent	Last Available: "2015-12"
-8753	adequate huge bread line	10	good	Last Available: "2015-12"
+8753	huge adequate bread line	10	good	Last Available: "2015-12"
 8754	practically non-alcoholic acceptable bark rootbeer	1	good	Last Available: "2015-12"
-8755	mediocre weak bouncing ale	2	decent	Last Available: "2015-12"
+8755	weak mediocre bouncing ale	2	decent	Last Available: "2015-12"
 8756	executive plastic Tammy the Tambourine Elf	0		Meat Drop: +40, Last Available: "2015-12"
 8757	quilted plastic Rudolph the Red	0		Damage Absorption: +40, Last Available: "2015-12"
 8758	reassuring plastic Gaia'ajh-dsli Ak'lwej	0		Spooky Resistance: +1, Last Available: "2015-12"
@@ -8649,12 +8649,12 @@
 8777	maroon bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
-8780	ghostly skewed iron chain	0		Last Available: "2015-12"
+8780	skewed ghostly iron chain	0		Last Available: "2015-12"
 8781	purple Newton's pine cone necklace	0		Experience (Mysticality): +3, Last Available: "2015-12"
 8782	razor-sharp reindeer hammer	0		Weapon Damage Percent: +25, Last Available: "2015-12"
 8783	dance instructor's elf ploughshare	0		Experience Percent (Moxie): +10, Last Available: "2015-12"
 8784	narrow circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	mirror cyan faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8667,7 +8667,7 @@
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	huge plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
-8798	blurry red bat-jute	0		Last Available: "2017-01"
+8798	red blurry bat-jute	0		Last Available: "2017-01"
 8799	bat-o-mite	0		Last Available: "2017-01"
 8800	upside-down ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	blue tumbling incriminating evidence	0		Last Available: "2017-01"
@@ -8685,25 +8685,25 @@
 8813	squat glob of Bat-Glue	0		Last Available: "2017-01"
 8814	huge Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	tumbling bat-bearing	0		Last Available: "2017-01"
-8816	miniature rotten upside-down Kudzu salad	2	crappy	Last Available: "2016-12"
+8816	rotten miniature upside-down Kudzu salad	2	crappy	Last Available: "2016-12"
 8817	denatured Mansquito Serum	1		Last Available: "2016-12"
-8818	acceptable spirit-forward twirling Miss Graves' vermouth	5	good	Last Available: "2016-12"
+8818	spirit-forward acceptable twirling Miss Graves' vermouth	5	good	Last Available: "2016-12"
 8819	normal wobbly The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	mixed fuchsia shaking The Author's ink	1		Last Available: "2016-02"
 8821	artisanal bouncing The Mad Liquor	3	super EPIC	Last Available: "2016-12"
 8822	weak lousy Doc Clock's thyme cocktail	2	decent	Last Available: "2016-12"
 8823	decent Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	dehydrated The Inquisitor's unidentifiable object	1		Effect: "Broken Bone Nubs", Effect Duration: 25, Last Available: "2016-12"
-8825	spinning foul-smelling The Jokester's gun of Calamity Jane	0		Critical Hit Percent: +15, Stench Damage: +10, Item Drop: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	executive Sinatra's The Jokester's wig of the dark arts	0		Experience (Moxie): +5, Spell Damage Percent: +100, Meat Drop: +40, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	Sherlock's frosty dangerous The Jokester's pants	0		Weapon Damage: +10, Cold Spell Damage: +10, Item Drop: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	spinning foul-smelling The Jokester's gun of Calamity Jane	0		Critical Hit Percent: +15, Stench Damage: +10, Item Drop: +5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	executive Sinatra's The Jokester's wig of the dark arts	0		Experience (Moxie): +5, Spell Damage Percent: +100, Meat Drop: +40, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
+8827	Sherlock's frosty dangerous The Jokester's pants	0		Weapon Damage: +10, Cold Spell Damage: +10, Item Drop: +25, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	electrified Jokester makeup	0		Effect: "Jacked In", Effect Duration: 52, Last Available: "2016-12"
 8829	huge cyan replica bat-oomerang	0		Last Available: "2016-12"
-8830	mirror cyan battoo kit	0		Last Available: "2016-12"
+8830	cyan mirror battoo kit	0		Last Available: "2016-12"
 8831	gray basking robin	0		Free Pull, Last Available: "2016-12"
 8832	skewed domino mask	0		Familiar Weight: +5
 8833	improved tumbling robin's egg	0		Effect: "You Drank Fish Wine", Effect Duration: 44, Last Available: "2016-12"
-8834	rotten diet robin flan	1	crappy	Last Available: "2016-12"
+8834	diet rotten robin flan	1	crappy	Last Available: "2016-12"
 8835	tolerable shaking robin nog	3	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
@@ -8711,15 +8711,15 @@
 8839	root beer barrel	0		
 8840	quantum non-polymerized Kudzu slaw	0		Effect: "Yuletide Sappiness", Effect Duration: 23
 8841	super-corrupted polarized ghostly Mansquito's blood	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 29
-8842	anodized lime green skewed twirling infrablack lipstick	0		Effect: "Trufflin'", Effect Duration: 52
+8842	anodized skewed lime green twirling infrablack lipstick	0		Effect: "Trufflin'", Effect Duration: 52
 8843	polarized moist can of drain cleaner	0		Effect: "Crimbo Epiphany", Effect Duration: 64
 8844	wet huge The Author's inkwell	0		Effect: "Hobonic", Effect Duration: 12
-8845	aerosolized super-pressed ghostly blue bag of random words	0		Effect: "Disco Neuropathy", Effect Duration: 60
+8845	aerosolized super-pressed blue ghostly bag of random words	0		Effect: "Disco Neuropathy", Effect Duration: 60
 8846	electrified tube of pendulum lube	0		Effect: "Gemini Rising", Effect Duration: 45
 8847	ionized flattened red-hot jawbreaker	0		Effect: "Industrial Strength Starch", Effect Duration: 31
 8848	quadruple-oxidized aerosolized question juice	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 26
-8849	magnetized red blinking tube of villain	0		Effect: "Bats in the Belfry", Effect Duration: 37
-8850	cyan up-at-dawn your cowboy boots	0		Adventures: +5, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8849	magnetized blinking red tube of villain	0		Effect: "Bats in the Belfry", Effect Duration: 37
+8850	cyan up-at-dawn your cowboy boots	0		Adventures: +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	tumbling inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8745,21 +8745,21 @@
 8873	purple zippy Pork 'n' Pork 'n' Pork 'n' Beans	0		Initiative: +20, Last Available: "2016-02"
 8874	frosty occult Fonzie's Val-U Brand Every Bean Salad of Tarzan of the businessman	0		Experience (Muscle): +3, Experience (Moxie): +1, Spell Damage Percent: +25, Cold Spell Damage: +10, Meat Drop: +50, Last Available: "2016-02"
 8875	Jack Frost's wholesome Shrub's Premium Baked Beans of extreme caution	0		Maximum HP Percent: +10, Monster Level: -25, Cold Spell Damage: +50, Last Available: "2016-02"
-8876	enchanted normal big plate of Heimz Fortified Kidney Beans	5	good	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2016-02"
+8876	big normal enchanted plate of Heimz Fortified Kidney Beans	5	good	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2016-02"
 8877	moldy plate of Tesla's Electroplated Beans	3	crappy	Last Available: "2016-02"
 8878	massive decent plate of Mixed Garbanzos and Chickpeas	10	good	Last Available: "2016-02"
-8879	enchanted tasty gigantic plate of Hellfire Spicy Beans	7	awesome	Effect: "Human-Insect Hybrid", Effect Duration: 40, Last Available: "2016-02"
+8879	enchanted gigantic tasty plate of Hellfire Spicy Beans	7	awesome	Effect: "Human-Insect Hybrid", Effect Duration: 40, Last Available: "2016-02"
 8880	bland blurry plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
-8881	jumbo normal tumbling plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
-8882	jumbo decent ghostly plate of Trader Olaf's Exotic Stinkbeans	5	good	Last Available: "2016-02"
-8883	miniature spoiled skewed narrow purple plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
+8881	normal jumbo tumbling plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
+8882	decent jumbo ghostly plate of Trader Olaf's Exotic Stinkbeans	5	good	Last Available: "2016-02"
+8883	miniature spoiled narrow purple skewed plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
 8884	immense bland bouncing plate of Val-U Brand Every Bean Salad	6	decent	Last Available: "2016-02"
 8885	flavorless narrow plate of Shrub's Premium Baked Beans	3	decent	Last Available: "2016-02"
 8886	pulsating prompt Fancy Jeff's pocket square of chilblains	0		Cold Damage: +25, Adventures: +3, Last Available: "2016-02"
-8887	chilly medical-grade therapeutic Daisy's unclean bloomers	0		Cold Damage: +5, HP Regen Min: 12, HP Regen Max: 17, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	chilly medical-grade therapeutic Daisy's unclean bloomers	0		Cold Damage: +5, HP Regen Min: 12, HP Regen Max: 17, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	skewed Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	Amoon-Ra Cowtep's nemes of Tarzan of the bloodbag of mayonnaise	0		Experience (Muscle): +3, Maximum HP: +100, Sleaze Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
-8890	blinking skewed Glenn's dice	0		Last Available: "2016-02"
+8889	Amoon-Ra Cowtep's nemes of Tarzan of the bloodbag of mayonnaise	0		Experience (Muscle): +3, Maximum HP: +100, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8890	skewed blinking Glenn's dice	0		Last Available: "2016-02"
 8891	teal zippy sizzling Da Vinci's Former Sheriff Dan's tin star of wisdom of extreme caution	0		Mysticality: +15, Experience (Mysticality): +5, Monster Level: -25, Hot Damage: +10, Initiative: +20, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
 8893	ghostly Clara's bell	0		Last Available: "2016-02"
@@ -8771,7 +8771,7 @@
 8899	yellow tainted milk	1	good	Last Available: "2016-02"
 8900	olive gun parts	0		Last Available: "2016-02"
 8901	activated non-anodized triggerfingerbone	0		Effect: "Celestial Sheen", Effect Duration: 34, Last Available: "2016-02"
-8902	diffused dry yellow spinning twirling ghost bit	0		Effect: "Tomato Power", Effect Duration: 60, Last Available: "2016-02"
+8902	diffused dry spinning yellow twirling ghost bit	0		Effect: "Tomato Power", Effect Duration: 60, Last Available: "2016-02"
 8903	pickled buzzard feather	0		Effect: "Bandersnatched", Effect Duration: 63, Last Available: "2016-02"
 8904	extra-deionized tarnished bouncing lion musk	0		Effect: "Innately Wise", Effect Duration: 22, Last Available: "2016-02"
 8905	flavorless blinking bear claw	4	decent	Last Available: "2016-02"
@@ -8779,7 +8779,7 @@
 8907	modified blurry half-digested coal	0		Effect: "Leisurely Amblin'", Effect Duration: 46, Last Available: "2016-02"
 8908	colloidal ionized tightly-wound spine	0		Effect: "Papowerful", Effect Duration: 53, Last Available: "2016-02"
 8909	rotten gigantic rotting beefsteak	7	crappy	Last Available: "2016-02"
-8910	bad triple-distilled enchanted firemilk	8	decent	Effect: "Sensation", Effect Duration: 35, Last Available: "2016-02"
+8910	triple-distilled bad enchanted firemilk	8	decent	Effect: "Sensation", Effect Duration: 35, Last Available: "2016-02"
 8911	flattened spidercow eye-cluster	0		Effect: "Hot Hands", Effect Duration: 64, Last Available: "2016-02"
 8912	powdered moomy dust	1		Last Available: "2016-02"
 8913	blinking careful western-style skinning knife of doom	0		Monster Level: -10, Spooky Spell Damage: +50, Last Available: "2016-02"
@@ -8795,7 +8795,7 @@
 8923	maroon disc (white)	0		
 8924	disc (black)	0		
 8925	disc (red)	0		
-8926	blue bouncing disc (green)	0		
+8926	bouncing blue disc (green)	0		
 8927	disc (blue)	0		
 8928	ghostly disc (yellow)	0		
 8929	shaking red-hot knucklebone	0		Last Available: "2016-02"
@@ -8803,7 +8803,7 @@
 8931	bouncing mirror rinky-dink sixgun	0		Last Available: "2016-02"
 8932	skewed makeshift sixgun	0		Last Available: "2016-02"
 8933	wobbly custom sixgun	0		Last Available: "2016-02"
-8934	ghostly huge jittery baconstone-handled sixgun	0		Last Available: "2016-02"
+8934	jittery huge ghostly baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	bouncing green porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
@@ -8814,15 +8814,15 @@
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
 8944	jittery rhinestone cowhorn	0		Familiar Weight: +5
-8945	lime green shaking cow skull	0		Last Available: "2016-02"
+8945	shaking lime green cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
-8948	bouncing upside-down fuchsia thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
+8948	fuchsia upside-down bouncing thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
-8953	huge narrow ticksilver spurs	0		Last Available: "2016-02"
+8953	narrow huge ticksilver spurs	0		Last Available: "2016-02"
 8954	skewed special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
@@ -8847,12 +8847,12 @@
 8975	exclusive club	0		
 8976	aerosolized patent preventative tonic	0		Effect: "Salty Dogs", Effect Duration: 24
 8977	super-polymerized activated patent invisibility tonic	0		Effect: "Shoesauce", Effect Duration: 47
-8978	irradiated tumbling bouncing patent aggression tonic	0		Effect: "Bandersnatched", Effect Duration: 56
+8978	irradiated bouncing tumbling patent aggression tonic	0		Effect: "Bandersnatched", Effect Duration: 56
 8979	anodized patent sallowness tonic	0		Effect: "Eye of the Lihc", Effect Duration: 34
 8980	pickled patent avarice tonic	0		Effect: "Improved Candy Vision", Effect Duration: 62
-8981	dry huge teal wobbly patent alacrity tonic	0		Effect: "So Fresh and So Clean", Effect Duration: 23
+8981	dry teal wobbly huge patent alacrity tonic	0		Effect: "So Fresh and So Clean", Effect Duration: 23
 8982	frozen corrupted marrow	0		Effect: "Triangle, Man", Effect Duration: 21
-8983	watered-down hand-crafted skewed rodeo whiskey	2	EPIC	
+8983	hand-crafted watered-down skewed rodeo whiskey	2	EPIC	
 8984	Thwaitgold scorpion statuette	0		
 8985	crafty real cowboy hat	0		Maximum MP: +10
 8986	Memories of Cow Punching	0		Free Pull
@@ -8867,17 +8867,17 @@
 8995	magnetized Greek fire	0		Effect: "Cancer Rising", Effect Duration: 41, Last Available: "2016-03"
 8996	shaking friendly Lo Pan's vibrating studded smartaleck's ox-head shield	0		Moxie Percent: +30, Damage Absorption: +80, Maximum MP Percent: +10, Spell Critical Percent: +30, Familiar Weight: +3, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	fireproof careful steel-toed shellacked dented scepter of the brazier	0		Damage Reduction: 32, Monster Level: -10, Hot Spell Damage: +25, Hot Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	censurious medical-grade ruddy personal trainer's very pointy crown of Flo-Jo	0		Experience Percent (Muscle): +10, Maximum HP Percent: +40, Sleaze Resistance: +3, Initiative: +100, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	censurious medical-grade ruddy personal trainer's very pointy crown of Flo-Jo	0		Experience Percent (Muscle): +10, Maximum HP Percent: +40, Sleaze Resistance: +3, Initiative: +100, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	green foul-smelling coward's clever smooth beefcake's battle broom	0		Muscle: +25, Moxie: +15, Maximum MP: +20, Monster Level: -20, Stench Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	jittery yellow Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	jittery Temple Grandin's mansplainer's carpe of the scaredy-cat of the blizzard	0		Monster Level: 0, Familiar Weight: +7, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9002	squat censurious fortified Socratic codpiece of the blizzard	0		Experience (Mysticality): +1, Damage Absorption: +60, Cold Spell Damage: +25, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
-9003	greedy foul-smelling nippy slick troutsers	0		Moxie: +10, Cold Damage: +10, Stench Damage: +10, Meat Drop: +20, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	greedy foul-smelling nippy slick troutsers	0		Moxie: +10, Cold Damage: +10, Stench Damage: +10, Meat Drop: +20, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	scorching smartaleck's beefcake's bass clarinet of the dark arts	0		Muscle: +25, Moxie Percent: +30, Spell Damage Percent: +100, Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9005	teal healthy hardened fish hatchet of the dark arts of the boozehound	0		Spell Damage Percent: +100, Damage Reduction: 3, Maximum HP Percent: +20, Booze Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9006	blinking executive banded tunac of Tarzan of the blizzard	0		Experience (Muscle): +3, Damage Absorption: +100, Cold Spell Damage: +25, Meat Drop: +40, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
-9008	diffused narrow bouncing wriggling worm	0		Effect: "Permafrosty", Effect Duration: 49, Last Available: "2016-04"
+9008	diffused bouncing narrow wriggling worm	0		Effect: "Permafrosty", Effect Duration: 49, Last Available: "2016-04"
 9009	irresponsibly strong artisanal bottle of Fishhead 900-Day IPA	8	EPIC	Last Available: "2016-04"
 9010	oxidized high-test fishing line	0		Effect: "Barking Mad", Effect Duration: 67, Last Available: "2016-04"
 9011	fireproof fishin' hat	0		Hot Resistance: +3, Last Available: "2016-04"
@@ -8902,7 +8902,7 @@
 9030	delicious star salad	3	awesome	
 9031	Thwaitgold moth statuette	0		
 9032	normal bowl of Tastee-Wheet&trade;	3	good	
-9033	yellow mirror Source terminal	0		Free Pull, Last Available: "2016-06"
+9033	mirror yellow Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	flavorless browser cookie	3	decent	Last Available: "2016-06"
 9036	drinkable hacked gibson	3	good	Last Available: "2016-06"
@@ -8926,7 +8926,7 @@
 9054	blinking Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	mirror Source terminal file: compress.edu	0		Last Available: "2016-06"
-9057	spinning blinking Source terminal file: duplicate.edu	0		Last Available: "2016-06"
+9057	blinking spinning Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
@@ -8951,7 +8951,7 @@
 9079	bite-sized yummy hardboiled egg	1	awesome	Last Available: "2016-07"
 9080	jittery detective tattoo	0		Last Available: "2016-07"
 9081	pulsating DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	veiny wicked Da Vinci's smartaleck's wizardly protonic accelerator pack of horror	0		Mysticality: +25, Moxie Percent: +30, Experience (Mysticality): +5, Spell Damage: +5, Maximum HP: +10, Spooky Spell Damage: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	veiny wicked Da Vinci's smartaleck's wizardly protonic accelerator pack of horror	0		Mysticality: +25, Moxie Percent: +30, Experience (Mysticality): +5, Spell Damage: +5, Maximum HP: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	shaking rock-hard Adventurer bobblehead	0		Damage Reduction: 5, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	skewed Mr. Screege's spectacles of the detective	0		Item Drop: +20, Single Equip, Last Available: "2016-08"
 9092	mansplainer's Annie Oakley's Oprah's Spookyraven signet	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Monster Level: +15, Single Equip, Last Available: "2016-08"
 9093	wholesome tie-dyed fannypack of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Single Equip, Last Available: "2016-08"
-9094	blurry inspector's burnt snowpants of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	Herculean standards and practices guide	0		Experience (Muscle): +1, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	blurry inspector's burnt snowpants of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	Herculean standards and practices guide	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	veiny Carpathian longsword of the bloodbag of bravery	0		Maximum HP: 110, Spooky Resistance: +5, Last Available: "2016-08"
 9097	fireproof gravedigger's Liam's mail of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +10, Hot Resistance: +3, Last Available: "2016-08"
 9098	executive razor-sharp Unfortunato's foolscap of vim and vigor	0		Weapon Damage Percent: +25, Maximum HP Percent: +50, Meat Drop: +40, Last Available: "2016-08"
@@ -8991,11 +8991,11 @@
 9119	acceptable Shot of Kardashian Gin	3	good	Last Available: "2016-09"
 9120	clever Unstable Pointy Ears	0		Maximum MP: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	twirling Memory Disk, Alpha	0		Last Available: "2016-09"
-9122	bouncing twirling shaking Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
+9122	bouncing shaking twirling Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	watered-down lousy unidentified drink	2	decent	
+9126	lousy watered-down unidentified drink	2	decent	
 9127	asbestos-lined fireproof KoL Con 13 T-shirt	0		Hot Resistance: 8
 9128	executive baleful thinker's discarded swimming trunks	0		Mysticality: +10, Spell Damage: +25, Meat Drop: +40
 9129	frozen pulsating diluted makeup	0		Effect: "Infernal Thirst", Effect Duration: 60
@@ -9007,29 +9007,29 @@
 9135	lousy twirling very whiskey	4	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	blue li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	jittery li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	teal squat li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	wobbly li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	jittery li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	squat teal li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	wobbly li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	activated wobbly hoarded candy wad	0		Effect: "Cybernetic Muscles", Effect Duration: 68, Last Available: "2016-10"
 9147	alkaline huge Prunets	0		Effect: "Ready to Snap", Effect Duration: 27
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	frozen huge invisible string	0		Lasts Until Rollover, Effect: "Slimily Strong", Effect Duration: 67, Last Available: "2016-10"
 9151	alkaline liquefied invisible seam ripper	0		Lasts Until Rollover, Effect: "Aloofah", Effect Duration: 49, Last Available: "2016-10"
-9152	skewed li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	skewed li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	stale raw sweet potato	4	decent	Last Available: "2016-11"
 9154	bland raw beans	3	decent	Last Available: "2016-11"
 9155	adequate squat raw stuffing	3	good	Last Available: "2016-11"
-9156	immense normal raw cranberry sauce	8	good	Last Available: "2016-11"
+9156	normal immense raw cranberry sauce	8	good	Last Available: "2016-11"
 9157	half-sized bland raw turkey	2	decent	Last Available: "2016-11"
 9158	spoiled raw mincemeat	3	crappy	Last Available: "2016-11"
-9159	normal miniature raw potato	2	good	Last Available: "2016-11"
-9160	fancy adequate raw gravy	4	good	Effect: "Sated and Furious", Effect Duration: 45, Last Available: "2016-11"
+9159	miniature normal raw potato	2	good	Last Available: "2016-11"
+9160	adequate fancy raw gravy	4	good	Effect: "Sated and Furious", Effect Duration: 45, Last Available: "2016-11"
 9161	stale raw bread	4	decent	Last Available: "2016-11"
 9162	dog trainer's Temple Grandin's mini-marshmallow dispenser	0		Familiar Weight: +7, Experience (familiar): +1, Last Available: "2016-11"
 9163	blurry narrow hardened Rosewater's cool glass casserole dish	0		Moxie: +5, Mysticality Percent: +30, Damage Reduction: 3, Last Available: "2016-11"
@@ -9040,9 +9040,9 @@
 9168	careful stiffened potato masher	0		Damage Reduction: 1, Monster Level: -10, Last Available: "2016-11"
 9169	spinning gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	bland fancy sweet potatoes	3	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 30, Last Available: "2016-11"
+9171	fancy bland sweet potatoes	3	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 30, Last Available: "2016-11"
 9172	moldy bean casserole	3	crappy	Last Available: "2016-11"
-9173	decent thick baked stuffing	5	good	Last Available: "2016-11"
+9173	thick decent baked stuffing	5	good	Last Available: "2016-11"
 9174	delicious cranberry cylinder	3	awesome	Last Available: "2016-11"
 9175	moldy spinning thanksgiving turkey	4	crappy	Last Available: "2016-11"
 9176	normal mince pie	3	good	Last Available: "2016-11"
@@ -9061,16 +9061,16 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	concentrated denatured huge eldritch concentrate	0		Effect: "Super Structure", Effect Duration: 19, Last Available: "2016-11"
-9192	tolerable watered-down eldritch extract	2	good	Last Available: "2016-11"
+9192	watered-down tolerable eldritch extract	2	good	Last Available: "2016-11"
 9193	huge gray mansplainer's arcane researcher's Official Council Aide Pin	0		Experience Percent (Mysticality): +10, Monster Level: +15, Last Available: "2016-11"
 9194	watered-down mediocre eldritch distillate	2	decent	Last Available: "2016-11"
 9195	pickled eldritch essence	1		Last Available: "2016-11"
 9196	blurry foul-smelling Science Notebook	0		Stench Damage: +10
 9197	fuchsia jittery prompt aromatic steel-toed eldritch hat	0		Damage Reduction: 9, Stench Resistance: +1, Adventures: +3, Last Available: "2016-11"
 9198	fuchsia twirling fireproof smelly deadly eldritch pants	0		Weapon Damage: +5, Stench Spell Damage: +10, Hot Resistance: +3, Last Available: "2016-11"
-9199	bad watered-down blurry eldritch elixir	2	decent	Last Available: "2016-11"
+9199	watered-down bad blurry eldritch elixir	2	decent	Last Available: "2016-11"
 9200	sinister savvy Quartet of Flare Masters Jacket	0		Mysticality Percent: +20, Spell Damage: +10, Last Available: "2016-11"
-9201	red huge lump of not really wriggling eldritch matter	0		
+9201	huge red lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
 9203	mirror Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
@@ -9104,7 +9104,7 @@
 9232	banded quilted candy screwdriver	0		Damage Absorption: 140, Last Available: "2016-12"
 9233	gingerbread dog treat	0		Last Available: "2016-12"
 9234	zippy pumpkin spice candle	0		Initiative: +20, Lasts Until Rollover, Last Available: "2016-12"
-9235	corrupted super-liquefied squat maroon gingerbread spice latte	0		Effect: "The Wisdom... of the Future", Effect Duration: 52, Last Available: "2016-12"
+9235	corrupted super-liquefied maroon squat gingerbread spice latte	0		Effect: "The Wisdom... of the Future", Effect Duration: 52, Last Available: "2016-12"
 9236	pulsating nippy strapping gingerbread gavel	0		Muscle: +5, Cold Damage: +10, Last Available: "2016-12"
 9237	mirror gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
@@ -9119,10 +9119,10 @@
 9247	jittery plastic Your Brain of Tarzan	0		Experience (Muscle): +3, Last Available: "2016-12"
 9248	Fonzie's plastic Krampus	0		Experience (Moxie): +1, Last Available: "2016-12"
 9249	dry pickled Inner Wisdom	0		Effect: "Frisky Spirit", Effect Duration: 30, Last Available: "2016-12"
-9250	warmed blinking twirling Inner Strength	0		Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2016-12"
+9250	warmed twirling blinking Inner Strength	0		Effect: "Extra-Sharp Weapon", Effect Duration: 15, Last Available: "2016-12"
 9251	colloidal huge Inner Truth	0		Effect: "Night of the Nachos", Effect Duration: 19, Last Available: "2016-12"
 9252	decent miniature enchanted spiritual candy cane	2	good	Effect: "Squid Squint", Effect Duration: 10, Last Available: "2016-12"
-9253	triple-distilled special artisanal upside-down spiritual eggnog	6	EPIC	Effect: "Bastard!", Effect Duration: 40, Last Available: "2016-12"
+9253	triple-distilled artisanal special upside-down spiritual eggnog	6	EPIC	Effect: "Bastard!", Effect Duration: 40, Last Available: "2016-12"
 9254	decent spiritual fruitcake	4	good	Last Available: "2016-12"
 9255	decent blue spiritual gingerbread	4	good	Last Available: "2016-12"
 9256	huge chocolate puppy	0		Last Available: "2016-12"
@@ -9145,7 +9145,7 @@
 9273	green strapping Third Eye of the brazier	0		Muscle: +5, Hot Spell Damage: +25, Last Available: "2016-12"
 9274	prompt Krampus Horn of the sewer	0		Stench Damage: +25, Adventures: +3, Single Equip, Last Available: "2016-12"
 9275	tasty jittery blue hambrosier	4	awesome	Last Available: "2016-12"
-9276	hand-crafted weak chakra-mental wine	2	EPIC	Last Available: "2016-12"
+9276	weak hand-crafted chakra-mental wine	2	EPIC	Last Available: "2016-12"
 9277	warmed chakra malt	0		Effect: "Hammertime", Effect Duration: 68, Last Available: "2016-12"
 9278	toothsome skewed Black Angus blackburger	4	awesome	Last Available: "2016-12"
 9279	practically non-alcoholic mediocre brandy	1	decent	Last Available: "2016-12"
@@ -9160,17 +9160,17 @@
 9288	lime green twirling gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	spinning ribald stiffened Uncle Crimbo's hat of the brute	0		Muscle Percent: +30, Damage Reduction: 1, Sleaze Damage: +10, Last Available: "2016-12"
 9290	bland blurry Eldritch snap	3	decent	Last Available: "2017-01"
-9291	vaporized fuchsia wobbly hot jelly	1		Effect: "Coated Arms", Effect Duration: 45, Last Available: "2017-01"
+9291	vaporized wobbly fuchsia hot jelly	1		Effect: "Coated Arms", Effect Duration: 45, Last Available: "2017-01"
 9292	diluted lime green jelly	1		Last Available: "2017-01"
 9293	dehydrated shaking jelly	1		Last Available: "2017-01"
 9294	dried sleaze jelly	1		Last Available: "2017-01"
 9295	twisted blurry stench jelly	1		Last Available: "2017-01"
 9296	ghostly space planula	0		Free Pull, Last Available: "2017-01"
 9297	adequate fancy toast with hot jelly	3	good	Effect: "Frostbeard", Effect Duration: 35, Last Available: "2017-01"
-9298	massive flavorless toast with jelly	8	decent	Last Available: "2017-01"
-9299	enchanted moldy toast with jelly	4	crappy	Effect: "Raging Animal", Effect Duration: 5, Last Available: "2017-01"
+9298	flavorless massive toast with jelly	8	decent	Last Available: "2017-01"
+9299	moldy enchanted toast with jelly	4	crappy	Effect: "Raging Animal", Effect Duration: 5, Last Available: "2017-01"
 9300	moldy ghostly toast with sleaze jelly	3	crappy	Last Available: "2017-01"
-9301	normal massive fancy pulsating toast with stench jelly	8	good	Effect: "Prelude of Precision", Effect Duration: 20, Last Available: "2017-01"
+9301	massive fancy normal pulsating toast with stench jelly	8	good	Effect: "Prelude of Precision", Effect Duration: 20, Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	jittery pewter candlestick	0		Familiar Weight: +10
@@ -9178,10 +9178,10 @@
 9306	huge candle of the cougar of the sewer	0		Moxie: +20, Stench Damage: +25, Lasts Until Rollover, Last Available: "2017-01"
 9307	bland thick wax pancake	5	decent	Last Available: "2017-01"
 9308	crafty hardened wax face	0		Damage Reduction: 3, Maximum MP: +10, Last Available: "2017-01"
-9309	enchanted perfectly mixed watered-down wax booze	2	EPIC	Effect: "Bone Homie", Effect Duration: 5, Last Available: "2017-01"
+9309	watered-down perfectly mixed enchanted wax booze	2	EPIC	Effect: "Bone Homie", Effect Duration: 5, Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	mixed ghostly sea jelly	1		Effect: "Litterboxing", Effect Duration: 25, Last Available: "2017-01"
-9312	special tasty super-sized sea truffle	5	awesome	Effect: "Smugness", Effect Duration: 45, Last Available: "2017-01"
+9312	super-sized tasty special sea truffle	5	awesome	Effect: "Smugness", Effect Duration: 45, Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	recovered cufflinks of terror	0		Spooky Spell Damage: +10, Single Equip, Last Available: "2017-01"
@@ -9203,7 +9203,7 @@
 9331	squat shaking Lo Pan's stiffened smartaleck's eldritch hammer	0		Moxie Percent: +30, Damage Reduction: 1, Spell Critical Percent: +30, Last Available: "2017-01"
 9332	tasty eldritch mushroom	4	awesome	Last Available: "2017-03"
 9333	twirling fuchsia eldritch ichor	0		
-9334	spoiled diet blinking eldritch mushroom pizza	1	crappy	Last Available: "2017-03"
+9334	diet spoiled blinking eldritch mushroom pizza	1	crappy	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	squat eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	super-tarnished improved shaking eldritch rub	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 14, Last Available: "2017-02"
@@ -9231,16 +9231,16 @@
 9359	baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
-9362	yellow twirling shaking pile of dirt	0		Last Available: "2017-03"
+9362	yellow shaking twirling pile of dirt	0		Last Available: "2017-03"
 9363	bouncing slime shooter	0		Last Available: "2017-03"
 9364	squat imaginary lemon	0		Last Available: "2017-03"
-9365	delicious weak twirling lime green literal grasshopper	2	awesome	Last Available: "2017-03"
-9366	practically non-alcoholic special lousy yellow double entendre	1	decent	Effect: "New and Improved", Effect Duration: 25, Last Available: "2017-03"
+9365	delicious weak lime green twirling literal grasshopper	2	awesome	Last Available: "2017-03"
+9366	special lousy practically non-alcoholic yellow double entendre	1	decent	Effect: "New and Improved", Effect Duration: 25, Last Available: "2017-03"
 9367	artisanal Phlegethon	4	EPIC	Last Available: "2017-03"
 9368	hand-crafted lime green blurry Siberian sunrise	4	EPIC	Last Available: "2017-03"
 9369	hand-crafted blinking mentholated wine	3	EPIC	Last Available: "2017-03"
 9370	bad low tide martini	3	decent	Last Available: "2017-03"
-9371	artisanal weak upside-down shroomtini	2	EPIC	Last Available: "2017-03"
+9371	weak artisanal upside-down shroomtini	2	EPIC	Last Available: "2017-03"
 9372	artisanal morning dew	3	EPIC	Last Available: "2017-03"
 9373	artisanal purple jittery whiskey squeeze	4	EPIC	Last Available: "2017-03"
 9374	artisanal great fashioned	4	EPIC	Last Available: "2017-03"
@@ -9248,34 +9248,34 @@
 9376	bad vodka stinger	3	decent	Last Available: "2017-03"
 9377	mediocre mirror extremely slippery nipple	4	decent	Last Available: "2017-03"
 9378	acceptable piscatini	4	good	Last Available: "2017-03"
-9379	practically non-alcoholic hand-crafted Churchill	1	EPIC	Last Available: "2017-03"
-9380	triple-distilled hand-crafted soilzerac	8	EPIC	Last Available: "2017-03"
+9379	hand-crafted practically non-alcoholic Churchill	1	EPIC	Last Available: "2017-03"
+9380	hand-crafted triple-distilled soilzerac	8	EPIC	Last Available: "2017-03"
 9381	bad London frog	4	decent	Last Available: "2017-03"
 9382	delicious nothingtini	3	awesome	Last Available: "2017-03"
 9383	acceptable mirror eighth plague	4	good	Last Available: "2017-03"
 9384	drinkable single entendre	4	good	Last Available: "2017-03"
-9385	acceptable weak jittery reverse Tantalus	2	good	Last Available: "2017-03"
+9385	weak acceptable jittery reverse Tantalus	2	good	Last Available: "2017-03"
 9386	bad elemental caipiroska	3	decent	Last Available: "2017-03"
 9387	hand-crafted Feliz Navidad	4	EPIC	Last Available: "2017-03"
-9388	practically non-alcoholic perfectly mixed blinking olive Bloody Nora	1	EPIC	Last Available: "2017-03"
+9388	practically non-alcoholic perfectly mixed olive blinking Bloody Nora	1	EPIC	Last Available: "2017-03"
 9389	drinkable mirror moreltini	3	good	Last Available: "2017-03"
 9390	distilled artisanal bouncing hell in a bucket	5	EPIC	Last Available: "2017-03"
 9391	delicious upside-down Newark	3	awesome	Last Available: "2017-03"
 9392	artisanal triple-distilled R'lyeh	10	EPIC	Last Available: "2017-03"
-9393	weak mediocre enchanted Gnollish sangria	2	decent	Effect: "Uncucumbered", Effect Duration: 50, Last Available: "2017-03"
+9393	enchanted weak mediocre Gnollish sangria	2	decent	Effect: "Uncucumbered", Effect Duration: 50, Last Available: "2017-03"
 9394	mediocre vodka barracuda	4	decent	Last Available: "2017-03"
 9395	bad maroon ghostly Mysterious Island iced tea	3	decent	Last Available: "2017-03"
 9396	acceptable irresponsibly strong drive-by shooting	7	good	Last Available: "2017-03"
 9397	artisanal gunner's daughter	3	EPIC	Last Available: "2017-03"
 9398	lousy dirt julep	3	decent	Last Available: "2017-03"
-9399	lousy practically non-alcoholic Simepore slime	1	decent	Last Available: "2017-03"
-9400	high-proof perfectly mixed Phil Collins	9	EPIC	Last Available: "2017-03"
+9399	practically non-alcoholic lousy Simepore slime	1	decent	Last Available: "2017-03"
+9400	perfectly mixed high-proof Phil Collins	9	EPIC	Last Available: "2017-03"
 9401	blinking unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	spinning Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
-9406	ghostly pulsating exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
+9406	pulsating ghostly exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	skewed rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	blurry gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	mirror scorching clever medical-grade murderbot mask	0		Maximum MP: +20, Hot Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Avatar: "Murderbot", Last Available: "2017-04"
 9454	activated adjusted purple murderbot spring injector	0		Effect: "Burning Tongue", Effect Duration: 48, Last Available: "2017-04"
 9455	studded stylish murderbot whip	0		Moxie: +25, Damage Absorption: +80, Last Available: "2017-04"
-9456	greasy Temple Grandin's murderbot plasma rifle	0		Familiar Weight: +7, Sleaze Spell Damage: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	greasy Temple Grandin's murderbot plasma rifle	0		Familiar Weight: +7, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	mirror murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9362,11 +9362,11 @@
 9490	pickled extra-ionized Threatening Missive	0		Effect: "Spring Training", Effect Duration: 11
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	banded beefcake's Kremlin's Greatest Briefcase of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Damage Absorption: +100, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	bad watered-down basic martini	2	decent	Last Available: "2017-06"
-9495	fancy perfectly mixed practically non-alcoholic improved martini	1	EPIC	Effect: "Frigid Weapon", Effect Duration: 45, Last Available: "2017-06"
-9496	practically non-alcoholic acceptable bouncing splendid martini	1	good	Last Available: "2017-06"
-9497	narrow pulsating exploding cigar	0		Last Available: "2017-06"
+9493	banded beefcake's Kremlin's Greatest Briefcase of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Damage Absorption: +100, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	watered-down bad basic martini	2	decent	Last Available: "2017-06"
+9495	perfectly mixed fancy practically non-alcoholic improved martini	1	EPIC	Effect: "Frigid Weapon", Effect Duration: 45, Last Available: "2017-06"
+9496	acceptable practically non-alcoholic bouncing splendid martini	1	good	Last Available: "2017-06"
+9497	pulsating narrow exploding cigar	0		Last Available: "2017-06"
 9498	red can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	bouncing tattoo gun	0		Last Available: "2017-06"
 9500	cyan gun	0		Free Pull, Last Available: "2017-06"
@@ -9375,20 +9375,20 @@
 9503	License to Chill	0		Last Available: "2017-07"
 9504	Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	upside-down Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
-9506	narrow pulsating Lazenby's Life Lesson	0		Free Pull
+9506	pulsating narrow Lazenby's Life Lesson	0		Free Pull
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	twirling Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
-9509	huge spinning lime green L.I.M.P. Stock Certificate	0		
+9509	lime green huge spinning L.I.M.P. Stock Certificate	0		
 9510	green Dust bunny	0		
 9511	jittery Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	gray Meteorite-Ade	0		Last Available: "2017-08"
-9514	moldy bite-sized meteoreo	1	crappy	Last Available: "2017-08"
+9514	bite-sized moldy meteoreo	1	crappy	Last Available: "2017-08"
 9515	artisanal meadeorite	3	EPIC	Last Available: "2017-08"
 9516	upside-down meteoroid	0		Last Available: "2017-08"
 9517	manspreader's supercharged brawny meteortarboard	0		Muscle Percent: +20, Maximum MP Percent: +30, Monster Level: +10, Last Available: "2017-08"
 9518	medical-grade experienced meteorite guard of Flo-Jo	0		Experience: +2, Initiative: +100, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 9, Last Available: "2017-08"
-9519	gravedigger's coward's meteorb	0		Monster Level: -20, Spooky Damage: +10, Last Available: "2017-08", Lantern Element: "Hot"
+9519	gravedigger's coward's meteorb	0		Monster Level: -20, Spooky Damage: +10, Lantern Element: "Hot", Last Available: "2017-08"
 9520	grievous asteroid belt of the early riser	0		Weapon Damage Percent: +50, Adventures: +7, Single Equip, Last Available: "2017-08"
 9521	bouncing pulsating perfumed nippy meteorthopedic shoes of the glutton	0		Cold Damage: +10, Stench Resistance: +5, Food Drop: +100, Single Equip, Last Available: "2017-08"
 9522	rosewater-soaked sage shooting morning star of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Stench Resistance: +3, Single Equip, Last Available: "2017-08"
@@ -9416,14 +9416,14 @@
 9544	O	0		Last Available: "2017-10"
 9545	weak mediocre DUFRESNE Suds	2	decent	Last Available: "2017-09"
 9546	ruddy mafia pinky ring of the wise owl	0		Mysticality: +20, Maximum HP Percent: +40, Single Equip
-9547	delicious fortified flask of port	5	awesome	
+9547	fortified delicious flask of port	5	awesome	
 9548	pulsating censurious Herculean contract enforcement stick	0		Experience (Muscle): +1, Sleaze Resistance: +3
 9549	spoiled Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
 9550	watered-down lousy jug of booze	2	decent	Last Available: "2017-10"
 9551	Vulcanized Vulcanized narrow pair of candy glasses	0		Effect: "You're Rubber", Effect Duration: 45, Last Available: "2017-10"
 9552	liquefied non-electrified temporary X tattoos	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 11, Last Available: "2017-10"
 9553	modified skewed glyph of athleticism	1		Last Available: "2017-10"
-9554	blue jittery mirror pair of scissors	0		Last Available: "2017-10"
+9554	mirror blue jittery pair of scissors	0		Last Available: "2017-10"
 9555	quadruple-polymerized adjusted new habit	0		Effect: "Polar Express", Effect Duration: 50, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
 9557	bouncing Annie Oakley's Tesla pearl necklace of the wise owl	0		Mysticality: +20, Critical Hit Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2017-10"
@@ -9448,7 +9448,7 @@
 9576	mafia organizer badge of the glutton	0		Food Drop: +100, Single Equip
 9577	mafia filofax	0		
 9578	special pulsating transparent nog	1	good	Effect: "Chief Executive Optimism", Effect Duration: 50, Last Available: "2017-12"
-9579	bland snack-sized unfinished fruitcake	2	decent	Last Available: "2017-12"
+9579	snack-sized bland unfinished fruitcake	2	decent	Last Available: "2017-12"
 9580	Vulcanized polarized and cracker	0		Effect: "Powder Power", Effect Duration: 15, Last Available: "2017-12"
 9581	acceptable gray upside-down neg grog	3	good	Last Available: "2017-12"
 9582	adequate half double fruitcake	3	good	Last Available: "2017-12"
@@ -9464,10 +9464,10 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	awesome	Last Available: "2017-11"
 9594	warmed modified skewed wishbone	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 32, Last Available: "2017-11"
-9595	weak acceptable Racisto Ruidoso	2	good	Last Available: "2017-11"
+9595	acceptable weak Racisto Ruidoso	2	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	normal miniature bran muffin	2	good	
-9598	decent low-calorie blueberry muffin	1	good	
+9598	low-calorie decent blueberry muffin	1	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9476,14 +9476,14 @@
 9604	silent F	0		Last Available: "2017-12"
 9605	twirling silent G	0		Last Available: "2017-12"
 9606	ghostly jittery silent H	0		Last Available: "2017-12"
-9607	olive huge silent I	0		Last Available: "2017-12"
+9607	huge olive silent I	0		Last Available: "2017-12"
 9608	blue silent J	0		Last Available: "2017-12"
 9609	red silent K	0		Last Available: "2017-12"
 9610	silent L	0		Last Available: "2017-12"
 9611	silent M	0		Last Available: "2017-12"
 9612	silent N	0		Last Available: "2017-12"
 9613	upside-down teal silent O	0		Last Available: "2017-12"
-9614	olive pulsating silent P	0		Last Available: "2017-12"
+9614	pulsating olive silent P	0		Last Available: "2017-12"
 9615	blinking silent Q	0		Last Available: "2017-12"
 9616	green silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
@@ -9514,16 +9514,16 @@
 9642	The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	shaking The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
-9645	blurry bouncing yellow The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9645	yellow bouncing blurry The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	spinning mime eraser	0		Last Available: "2017-12"
 9648	tolerable huge pulsating executive mime flask	3	good	Last Available: "2017-12"
-9649	bland fancy nega-mushroom	3	decent	Effect: "Big Meat Big Prizes", Effect Duration: 30, Last Available: "2017-12"
-9650	irresponsibly strong artisanal nega-mushroom wine	8	EPIC	Last Available: "2017-12"
+9649	fancy bland nega-mushroom	3	decent	Effect: "Big Meat Big Prizes", Effect Duration: 30, Last Available: "2017-12"
+9650	artisanal irresponsibly strong nega-mushroom wine	8	EPIC	Last Available: "2017-12"
 9651	galvanized colloidal wet Cheer-Up soda	0		Effect: "Glittering Eyelashes", Effect Duration: 63, Last Available: "2017-12"
 9652	special bland bouncing mime army rations	4	decent	Effect: "Marinated", Effect Duration: 25, Last Available: "2017-12"
 9653	hand-crafted purple mime army wine	3	super ultra mega EPIC	Last Available: "2017-12"
-9654	dehydrated olive bouncing mime army superserum	1		Last Available: "2017-12"
+9654	dehydrated bouncing olive mime army superserum	1		Last Available: "2017-12"
 9655	ionized blurry mime army camouflage kit	0		Effect: "From Nantucket", Effect Duration: 54, Last Available: "2017-12"
 9656	baleful wicked miming beret	0		Spell Damage: 30, Last Available: "2017-12"
 9657	lime green dog trainer's miming shirt of the wise owl	0		Mysticality: +20, Experience (familiar): +1, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	lime green donated candy	0		
 9665	aerosolized chilled digital honeypot	0		Effect: "Vitali Tea", Effect Duration: 13, Last Available: "2025-12"
 9666	spinning mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	razor-sharp mime army insignia (infantry)	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	upside-down weightlifter's mime army insignia (intelligence)	0		Muscle: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	narrow mime army insignia (espionage) of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	razor-sharp mime army insignia (infantry)	0		Weapon Damage Percent: +25, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	upside-down weightlifter's mime army insignia (intelligence)	0		Muscle: +15, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	narrow mime army insignia (espionage) of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9571,7 +9571,7 @@
 9699	razor-sharp beefcake's makeshift garbage shirt of the overflowing toilet	0		Muscle: +25, Weapon Damage Percent: +25, Stench Spell Damage: +50, Last Available: "2018-01"
 9700	gravedigger's personal trainer's novelty monorail ticket	0		Experience Percent (Muscle): +10, Spooky Damage: +10
 9701	denatured narrow pills	1		
-9702	modified ghostly purple skewed furry pill	1		Effect: "Puddingface", Effect Duration: 15
+9702	modified ghostly skewed purple furry pill	1		Effect: "Puddingface", Effect Duration: 15
 9703	powdered lime green beefy pill	1		
 9704	powdered tumbling excitement pill	1		
 9705	powdered cyan vitamin G pill	1		
@@ -9583,7 +9583,7 @@
 9715	twirling Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	wobbly They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
-9718	twirling purple ghostly Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
+9718	ghostly twirling purple Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	cyan toasty genie's turbane of the storm	0		Maximum MP Percent: +40, Hot Damage: +5, Last Available: "2018-02"
 9720	wobbly dangerous stylish genie's scimitar	0		Moxie: +25, Weapon Damage: +10, Last Available: "2018-02"
 9721	tumbling cyan friendly chaotic genie's pants	0		Spell Critical Percent: +10, Familiar Weight: +3, Last Available: "2018-02"
@@ -9596,14 +9596,14 @@
 9728	bland narrow Swedish massage fish	3	decent	Last Available: "2018-02"
 9729	drinkable irresponsibly strong Third Base	7	good	Last Available: "2018-02"
 9730	hand-crafted olive Bustle Hustler	3	EPIC	Last Available: "2018-02"
-9731	activated concentrated purple squat Fabiotion	0		Effect: "Wasabi With You", Effect Duration: 19, Last Available: "2018-02"
+9731	activated concentrated squat purple Fabiotion	0		Effect: "Wasabi With You", Effect Duration: 19, Last Available: "2018-02"
 9732	tarnished green Bettie page	0		Effect: "Healthy Red Glow", Effect Duration: 33, Last Available: "2018-02"
 9733	extra-dry chilled magnetized tonic o' Banderas	0		Effect: "Capricorn Rising", Effect Duration: 46, Last Available: "2018-02"
 9734	double-ionized heather graham cracker	0		Effect: "Capricorn Rising", Effect Duration: 25, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
-9738	bouncing tumbling yellow personal graffiti kit	0		Last Available: "2018-02"
+9738	yellow bouncing tumbling personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	wobbly Mysterious Blue Box	0		Last Available: "2018-02"
@@ -9659,7 +9659,7 @@
 9791	tumbling Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	mirror Wullabye	0		Last Available: "2018-03"
-9794	mirror lime green Nursine	0		Last Available: "2018-03"
+9794	lime green mirror Nursine	0		Last Available: "2018-03"
 9795	upside-down Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
@@ -9711,10 +9711,10 @@
 9843	smelly wholesome &quot;Remember the Trees&quot; Shirt of the overflowing toilet	0		Maximum HP Percent: +10, Stench Spell Damage: 60
 9844	upside-down FantasyRealm key	0		Last Available: "2018-04"
 9845	tumbling plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
-9846	green twirling tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
+9846	twirling green tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
-9849	jittery mirror LyleCo premium rope	0		Last Available: "2018-04"
+9849	mirror jittery LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	squat faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9728,14 +9728,14 @@
 9860	yellow FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	spoiled shaking lime green FantasyRealm turkey leg	3	crappy	Last Available: "2018-04"
-9863	strong artisanal fancy FantasyRealm mead	5	EPIC	Effect: "Wintry Breath", Effect Duration: 50, Last Available: "2018-04"
+9863	strong fancy artisanal FantasyRealm mead	5	EPIC	Effect: "Wintry Breath", Effect Duration: 50, Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	jittery grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	adequate super-sized druidic s'more	5	good	Last Available: "2018-04"
-9870	mixed cyan upside-down sachet of powder	1		Last Available: "2018-04"
+9869	super-sized adequate druidic s'more	5	good	Last Available: "2018-04"
+9870	mixed upside-down cyan sachet of powder	1		Last Available: "2018-04"
 9871	hand-crafted weak mourning wine	2	EPIC	Last Available: "2018-04"
 9872	pulsating sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	tumbling map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	tasty jittery denastified haunch	3	awesome	Last Available: "2018-04"
-9879	mediocre weak squat bad rum and good cola	2	decent	Last Available: "2018-04"
+9879	weak mediocre squat bad rum and good cola	2	decent	Last Available: "2018-04"
 9880	diffused ionized Potion of Heroism	0		Effect: "Rotten Memories", Effect Duration: 40, Last Available: "2018-04"
 9881	aromatic Lo Pan's leggings of the Spider Queen of horror	0		Spell Critical Percent: +30, Spooky Spell Damage: +25, Stench Resistance: +1, Last Available: "2018-04"
 9882	scorching wizardly thinker's Master Thief's utility belt	0		Mysticality: 35, Hot Damage: +25, Single Equip, Last Available: "2018-04"
@@ -9762,17 +9762,17 @@
 9894	flame-retardant toasty Tesla Staff of Kitchen Royalty of bravery of Flo-Jo	0		Hot Damage: +5, Hot Resistance: +1, Spooky Resistance: +5, Initiative: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-04"
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
-9897	skewed ghostly notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	aged spirit-forward two meat muck	5	awesome	
-9899	diet adequate chocolate Ogre Chieftain	1	good	
+9897	ghostly skewed notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
+9898	spirit-forward aged two meat muck	5	awesome	
+9899	adequate diet chocolate Ogre Chieftain	1	good	
 9900	rotten chocolate &quot;Phoenix&quot;	3	crappy	
 9901	rotten miniature chocolate Spider Queen	2	crappy	
-9902	fancy acceptable watered-down hipster cocktail	2	good	Effect: "Super-Mega-Charged", Effect Duration: 5
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	yellow God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9902	acceptable fancy watered-down hipster cocktail	2	good	Effect: "Super-Mega-Charged", Effect Duration: 5
+9903	God Lobster's Scepter	0		Equips On: "God Lobster", Familiar Effect: "small fairy/lep", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Equips On: "God Lobster", Familiar Effect: "sombrero", Last Available: "2018-05"
+9905	God Lobster's Rod	0		Equips On: "God Lobster", Familiar Effect: "whelp", Last Available: "2018-05"
+9906	yellow God Lobster's Robe	0		Equips On: "God Lobster", Familiar Effect: "block", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Equips On: "God Lobster", Familiar Effect: "fairy", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	wobbly G	0		
 9910	Garland of Greatness	0		
@@ -9818,16 +9818,16 @@
 9950	huge deadly pentagram bandana of the businessman	0		Weapon Damage: +5, Meat Drop: +50, Last Available: "2018-09"
 9951	bouncing wobbly wholesome skull ring	0		Maximum HP Percent: +10, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	half-sized decent PB&J with the crusts cut off	2	good	Last Available: "2018-09"
+9953	decent half-sized PB&J with the crusts cut off	2	good	Last Available: "2018-09"
 9954	ribald dorky glasses of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +10, Single Equip, Last Available: "2018-09"
 9955	ghostly inspector's ponytail clip of the brazier	0		Hot Spell Damage: +25, Item Drop: +15, Last Available: "2018-09"
-9956	censurious paint palette	0		Sleaze Resistance: +3, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	censurious paint palette	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	maroon skewed unremarkable duffel bag	0		Last Available: "2018-09"
 9958	compressed teal Purple Beast energy drink	1		Last Available: "2018-09"
 9959	yellow cosmetic football of the scaredy-cat	0		Monster Level: -15, Last Available: "2018-09"
 9960	Jack Frost's shoe ad T-shirt of the brazier	0		Cold Spell Damage: +50, Hot Spell Damage: +25, Last Available: "2018-09"
 9961	cyan rock-hard pump-up high-tops	0		Damage Reduction: 5, Single Equip, Last Available: "2018-09"
-9962	altered teal mirror runproof mascara	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 14, Last Available: "2018-09"
+9962	altered mirror teal runproof mascara	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 14, Last Available: "2018-09"
 9963	very small dress	0		Last Available: "2018-09"
 9964	inspector's noticeable pumps of James Dean	0		Experience (Moxie): +3, Item Drop: +15, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	adequate blurry party platter for one	3	good	Last Available: "2018-09"
 9981	dehydrated teal Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	bouncing occult personal trainer's party crasher	0		Experience Percent (Muscle): +10, Spell Damage Percent: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	bouncing occult personal trainer's party crasher	0		Experience Percent (Muscle): +10, Spell Damage Percent: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	spinning party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	wobbly banded &quot;I Voted!&quot; sticker	0		Damage Absorption: +100, Lasts Until Rollover, Last Available: "2018-11"
@@ -9886,7 +9886,7 @@
 10020	drinkable twice-haunted screwdriver	4	good	Last Available: "2018-11"
 10021	stale bouncing candy cane	4	decent	Last Available: "2018-12"
 10022	artisanal extra-dry runny fermented egg	5	EPIC	Last Available: "2018-12"
-10023	low-calorie moldy oldcake	1	crappy	Last Available: "2018-12"
+10023	moldy low-calorie oldcake	1	crappy	Last Available: "2018-12"
 10024	flavorless massive shaking traditional Crimbo cookie	7	decent	Last Available: "2023-06"
 10025	plastic wild beaver of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-12"
 10026	lime green mirror scorching plastic reindeer	0		Hot Damage: +25, Last Available: "2018-12"
@@ -9895,14 +9895,14 @@
 10029	plastic Abuela Crimbo of the storm	0		Maximum MP Percent: +40, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
 10031	shaking Braindeer	0		Last Available: "2018-12"
-10032	blinking tumbling Crimbo dog sweater	0		Familiar Weight: +5
+10032	tumbling blinking Crimbo dog sweater	0		Familiar Weight: +5
 10033	twirling perfumed pristine walrus tusk of dire peril	0		Weapon Damage: +20, Stench Resistance: +5, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	mansplainer's medical-grade Socratic slick Staff of Frozen Lard	0		Moxie: +10, Experience (Mysticality): +1, Monster Level: +15, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-12"
 10036	upside-down bomb	0		Last Available: "2018-12"
 10037	teal plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	adequate snack-sized grilled mooseflank	2	good	Last Available: "2018-12"
+10039	snack-sized adequate grilled mooseflank	2	good	Last Available: "2018-12"
 10040	flavorless bite-sized moosemeat pie	1	decent	Last Available: "2018-12"
 10041	Sinatra's balanced antler	0		Experience (Moxie): +5, Last Available: "2018-12"
 10042	dam of the ox	0		Muscle: +20, Damage Reduction: 9, Last Available: "2018-12"
@@ -9923,23 +9923,23 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	huge chilly crafty forbidden brainy Kramco Sausage-o-Matic&trade; of the cougar	0		Mysticality: +5, Moxie: +20, Spell Damage Percent: +50, Maximum MP: +10, Cold Damage: +5, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	moldy special miniature mirror sausage	2	crappy	Effect: "Chief Executive Optimism", Effect Duration: 40, Last Available: "2019-01"
+10060	miniature moldy special mirror sausage	2	crappy	Effect: "Chief Executive Optimism", Effect Duration: 40, Last Available: "2019-01"
 10061	mirror wool sage red-hot sausage fork	0		Mysticality Percent: +10, Cold Resistance: +1, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	tumbling sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	practically non-alcoholic hand-crafted beer	1	super ultra mega turbo EPIC	Last Available: "2018-12"
-10067	stale special yule gruel	3	decent	Effect: "Sugar Smacks", Effect Duration: 40, Last Available: "2018-12"
+10066	hand-crafted practically non-alcoholic beer	1	super ultra mega turbo EPIC	Last Available: "2018-12"
+10067	special stale yule gruel	3	decent	Effect: "Sugar Smacks", Effect Duration: 40, Last Available: "2018-12"
 10068	delicious hot watered rum	3	awesome	Last Available: "2018-12"
 10069	bad pulsating yellow bottle of Crimbognac	3	decent	Last Available: "2018-12"
 10070	bland Crimboysters Rockefeller	3	decent	Last Available: "2018-12"
-10071	denatured jittery blurry Crimbeau de toilette	1		Last Available: "2018-12"
+10071	denatured blurry jittery Crimbeau de toilette	1		Last Available: "2018-12"
 10072	bouncing Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	cyan Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10076	purple wobbly Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10076	wobbly purple Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	jittery blinking Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	aromatic coward's energetic Crimbolex watch	0		Maximum MP Percent: +20, Monster Level: -20, Stench Resistance: +1, Single Equip, Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	smelly stiffened marble mariachi hat	0		Damage Reduction: 1, Stench Spell Damage: +10, Last Available: "2019-12"
 10096	twisted blurry marble molecules	1		Effect: "Fury of the Bells", Effect Duration: 50, Last Available: "2019-12"
 10097	concentrated mirror Mallomarbles	0		Effect: "Hammered", Effect Duration: 43
-10098	slick punching bag of the glutton	0		Moxie: +10, Food Drop: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	horrifying pith helmet of wisdom	0		Mysticality: +15, Spooky Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	energetic poncho of incineration	0		Maximum MP Percent: +20, Hot Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	extremely unsafe pendant of wisdom	0		Mysticality: +15, Weapon Damage Percent: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	spinning razor-sharp palazzos of temperance	0		Weapon Damage Percent: +25, Sleaze Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	resourceful pseudoaccordion of wisdom	0		Mysticality: +15, Maximum MP: +50, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	slick punching bag of the glutton	0		Moxie: +10, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	horrifying pith helmet of wisdom	0		Mysticality: +15, Spooky Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	energetic poncho of incineration	0		Maximum MP Percent: +20, Hot Spell Damage: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	extremely unsafe pendant of wisdom	0		Mysticality: +15, Weapon Damage Percent: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	spinning razor-sharp palazzos of temperance	0		Weapon Damage Percent: +25, Sleaze Resistance: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	resourceful pseudoaccordion of wisdom	0		Mysticality: +15, Maximum MP: +50, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	twisted maroon pieces	1		Effect: "Concentrated Concentration", Effect Duration: 25, Last Available: "2020-12"
 10105	frozen Para-Pop	0		Effect: "Human-Plant Hybrid", Effect Duration: 55
-10106	aromatic beefcake's terra cotta truss	0		Muscle: +25, Stench Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	Annie Oakley's terra cotta trousers of wisdom	0		Mysticality: +15, Critical Hit Percent: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	Tesla stylish terra cotta tongs	0		Moxie: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	scandalous stanky terra cotta train	0		Stench Spell Damage: +25, Sleaze Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	terra cotta tie tack of the overflowing toilet of temperance	0		Stench Spell Damage: +50, Sleaze Resistance: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	bouncing Da Vinci's terra cotta tambourine of Leguizamo	0		Experience (Mysticality): +5, Monster Level: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	aromatic beefcake's terra cotta truss	0		Muscle: +25, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	Annie Oakley's terra cotta trousers of wisdom	0		Mysticality: +15, Critical Hit Percent: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	Tesla stylish terra cotta tongs	0		Moxie: +25, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	scandalous stanky terra cotta train	0		Stench Spell Damage: +25, Sleaze Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	terra cotta tie tack of the overflowing toilet of temperance	0		Stench Spell Damage: +50, Sleaze Resistance: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	bouncing Da Vinci's terra cotta tambourine of Leguizamo	0		Experience (Mysticality): +5, Monster Level: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	diluted blurry terra cotta tidbits	1		Effect: "Twenty-three Squid, Ew", Effect Duration: 15, Last Available: "2020-12"
 10113	diffused improved lime green upside-down terra panna cotta	0		Effect: "Eyes of the Dragon", Effect Duration: 59
 10114	pulsating gravedigger's savvy velour voulge	0		Mysticality Percent: +20, Spooky Damage: +10, Last Available: "2021-12"
@@ -9993,22 +9993,22 @@
 10127	Sherlock's groovy glass serape	0		Moxie Percent: +10, Item Drop: +25, Last Available: "2021-12"
 10128	compressed glass shards	1		Effect: "Salamander In Your Stomach", Effect Duration: 45, Last Available: "2021-12"
 10129	warmed ionized maroon hard candy	0		Effect: "Hare-o-dynamic", Effect Duration: 48
-10130	curative loofah lumberjack's hat of the ox	0		Muscle: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	upside-down Sinatra's loofah lei of mayonnaise	0		Experience (Moxie): +5, Sleaze Spell Damage: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	squat loofah lederhosen of extreme caution	0		Monster Level: -25, Item Drop: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	vibrating boxer's loofah ladle	0		Muscle Percent: +10, Maximum MP Percent: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	twirling auspicious Lo Pan's loofah legwarmers	0		Spell Critical Percent: +30, Item Drop: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	wobbly Jim Carey's mansplainer's loofah lavalier	0		Monster Level: 40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	curative loofah lumberjack's hat of the ox	0		Muscle: +20, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	upside-down Sinatra's loofah lei of mayonnaise	0		Experience (Moxie): +5, Sleaze Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	squat loofah lederhosen of extreme caution	0		Monster Level: -25, Item Drop: +5, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	vibrating boxer's loofah ladle	0		Muscle Percent: +10, Maximum MP Percent: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	twirling auspicious Lo Pan's loofah legwarmers	0		Spell Critical Percent: +30, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	wobbly Jim Carey's mansplainer's loofah lavalier	0		Monster Level: 40, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	pickled loofah lumps	1		Last Available: "2022-12"
 10137	quadruple-pressed chocolate-covered loofah	0		Effect: "Employee of the Month", Effect Duration: 15
-10138	frightening flagstone flag of mayonnaise	0		Spooky Damage: +5, Sleaze Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	teal stylish flagstone flail of Flo-Jo	0		Moxie: +25, Initiative: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	yellow lightning-fast razor-sharp flagstone flip-flops	0		Weapon Damage Percent: +25, Initiative: +40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	narrow rock-hard flagstone fez	0		Damage Reduction: 5, Item Drop: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	tumbling flagstone fleece of the scaredy-cat of doom	0		Monster Level: -15, Spooky Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	inspector's flagstone fringe of vim and vigor	0		Maximum HP Percent: +50, Item Drop: +15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	frightening flagstone flag of mayonnaise	0		Spooky Damage: +5, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	teal stylish flagstone flail of Flo-Jo	0		Moxie: +25, Initiative: +100, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	yellow lightning-fast razor-sharp flagstone flip-flops	0		Weapon Damage Percent: +25, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	narrow rock-hard flagstone fez	0		Damage Reduction: 5, Item Drop: +5, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	tumbling flagstone fleece of the scaredy-cat of doom	0		Monster Level: -15, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	inspector's flagstone fringe of vim and vigor	0		Maximum HP Percent: +50, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	dehydrated bouncing flagstone flagments	1		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 10, Last Available: "2022-12"
-10145	unsweetened diffused blinking pulsating Flag by the Foot&trade;	0		Effect: "Flambé-a-thon", Effect Duration: 31
+10145	unsweetened diffused pulsating blinking Flag by the Foot&trade;	0		Effect: "Flambé-a-thon", Effect Duration: 31
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	huge red-and-green microcamera	0		Familiar Weight: +5
 10148	tumbling toasty cobbled-together Meat detector	0		Hot Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
@@ -10025,20 +10025,20 @@
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	non-polymerized licorice snake	0		Effect: "Creepin' Up on You", Effect Duration: 63
 10161	ionized jittery virgin jello shot	0		Effect: "Astral Shell", Effect Duration: 17
-10162	electrified frozen blue upside-down mutated candy lump	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 11
+10162	electrified frozen upside-down blue mutated candy lump	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 11
 10163	magnetized government-issued candy	0		Effect: "Arresistible", Effect Duration: 47
 10164	warmed blurry Pneumo bar	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 36
 10165	skewed mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	spinning Van der Graaf Lil' Doctor&trade; bag of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	spinning Van der Graaf Lil' Doctor&trade; bag of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	gigantic normal fuchsia bloodstick	8	good	
 10170	tolerable bottle of Sanguiovese	3	good	
-10171	spoiled super-sized actual blood sausage	5	crappy	
+10171	super-sized spoiled actual blood sausage	5	crappy	
 10172	mediocre mulled blood	3	decent	
 10173	huge tasty blood snowcone	8	awesome	
 10174	acceptable Red Russian	3	good	
 10175	snack-sized decent blood roll-up	2	good	
-10176	spirit-forward mediocre wobbly bottle of blood	5	decent	
+10176	mediocre spirit-forward wobbly bottle of blood	5	decent	
 10177	tasty blood-soaked sponge cake	3	awesome	
 10178	fortified tolerable vampagne	5	good	
 10179	small yummy pulsating plain snowcone	2	awesome	
@@ -10094,17 +10094,17 @@
 10229	gray ring	0		Single Equip, Last Available: "2019-04"
 10230	bouncing flame-retardant personal trainer's piratical blunderbuss	0		Experience Percent (Muscle): +10, Hot Resistance: +1, Last Available: "2019-04"
 10231	banded savvy PirateRealm party hat of Flo-Jo	0		Mysticality Percent: +20, Damage Absorption: +100, Initiative: +100, Last Available: "2019-04"
-10232	practically non-alcoholic hand-crafted Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10232	hand-crafted practically non-alcoholic Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10233	tolerable high-proof Island Thunderstorm	7	good	Last Available: "2019-04"
 10234	delicious practically non-alcoholic Island Hurricane	1	awesome	Last Available: "2019-04"
-10235	delicious triple-distilled Skull Punch	9	awesome	Last Available: "2019-04"
-10236	aged squat gray Electric Punch	4	awesome	Last Available: "2019-04"
+10235	triple-distilled delicious Skull Punch	9	awesome	Last Available: "2019-04"
+10236	aged gray squat Electric Punch	4	awesome	Last Available: "2019-04"
 10237	drinkable Smuggler's Punch	3	good	Last Available: "2019-04"
-10238	weak artisanal Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10238	artisanal weak Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10239	weak artisanal Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10240	drinkable watered-down Cobra Bowl	2	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	red upside-down therapeutic stiffened Sinatra's brawny strapping vampyric cloake	0		Muscle: +5, Muscle Percent: +20, Experience (Moxie): +5, Damage Reduction: 1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	red upside-down therapeutic stiffened Sinatra's brawny strapping vampyric cloake	0		Muscle: +5, Muscle Percent: +20, Experience (Moxie): +5, Damage Reduction: 1, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	oxidized spinning one piece of bubble gum	0		Effect: "Piratastic", Effect Duration: 63
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	twirling frightening sharpshooter's padded Fourth of May Cosplay Saber	0		Damage Absorption: +20, Critical Hit Percent: +10, Spooky Damage: +5, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	twirling frightening sharpshooter's padded Fourth of May Cosplay Saber	0		Damage Absorption: +20, Critical Hit Percent: +10, Spooky Damage: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	jittery squat Sherlock's horrifying foul-smelling curative shellacked dance instructor's Fonzie's beefy strapping hewn moon-rune spoon of incineration of courage	0		Muscle: 15, Experience (Moxie): +1, Experience Percent (Moxie): +10, Damage Reduction: 7, Hot Spell Damage: +50, Stench Damage: +10, Spooky Damage: +25, Spooky Resistance: +3, Item Drop: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	jittery squat Sherlock's horrifying foul-smelling curative shellacked dance instructor's Fonzie's beefy strapping hewn moon-rune spoon of incineration of courage	0		Muscle: 15, Experience (Moxie): +1, Experience Percent (Moxie): +10, Damage Reduction: 7, Hot Spell Damage: +50, Stench Damage: +10, Spooky Damage: +25, Spooky Resistance: +3, Item Drop: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	lime green cartoon harpoon	0		Last Available: "2019-06"
-10256	huge gray upside-down rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
+10256	gray huge upside-down rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	jittery blurry family-friendly smelly Temple Grandin's Beach Comb	0		Familiar Weight: +7, Stench Spell Damage: +10, Sleaze Resistance: +1, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	jittery blurry family-friendly smelly Temple Grandin's Beach Comb	0		Familiar Weight: +7, Stench Spell Damage: +10, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	green grain of sand	0		Last Available: "2019-07"
 10260	twirling small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	polymerized colloidal seashell	0		Effect: "Human-Penguin Hybrid", Effect Duration: 11, Last Available: "2019-07"
 10270	super-ionized seashell	0		Effect: "Cockroach Scurry", Effect Duration: 51, Last Available: "2019-07"
 10271	skewed bunch of sea grapes	0		Last Available: "2019-07"
-10272	drinkable practically non-alcoholic bottle of sea wine	1	good	Last Available: "2019-07"
+10272	practically non-alcoholic drinkable bottle of sea wine	1	good	Last Available: "2019-07"
 10273	denatured mirror kelp	1		Last Available: "2019-07"
 10274	scorching Annie Oakley's hardy ruddy wholesome stiffened driftwood hat of the pedagogue of chilblains of incineration	0		Experience: +3, Damage Reduction: 1, Maximum HP Percent: 50, Maximum HP: +50, Critical Hit Percent: +20, Cold Damage: +25, Hot Damage: +25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2019-07"
 10275	clever curative shellacked stiffened stylish cool driftwood pants of the pedagogue of courage	0		Moxie: 30, Experience: +3, Damage Reduction: 16, Maximum MP: +20, Spooky Resistance: +3, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-07"
@@ -10170,7 +10170,7 @@
 10305	moldy diet campfire s'more	1	crappy	Last Available: "2019-08"
 10306	moldy campfire beans	3	crappy	Last Available: "2019-08"
 10307	super-sized bland campfire stew	5	decent	Last Available: "2019-08"
-10308	fuchsia twirling campfire coffee	1	awesome	Last Available: "2019-08"
+10308	twirling fuchsia campfire coffee	1	awesome	Last Available: "2019-08"
 10309	liquefied quadruple-vacuum-sealed leftover chocolate bar	0		Effect: "Nigh-Invincible", Effect Duration: 44
 10310	rare Meat isotope	0		
 10311	spinning burnt stick	0		Last Available: "2019-08"
@@ -10185,7 +10185,7 @@
 10320	adequate low-calorie space chowder	1	good	
 10321	lousy space wine	3	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
-10323	mirror teal packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
+10323	teal mirror packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
@@ -10195,28 +10195,28 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	yummy bu&ntilde;uelos Jaliscos	3	awesome	Last Available: "2019-12"
 10338	normal flan del mar	4	good	Last Available: "2019-12"
-10339	small special moldy Baja sopapilla	2	crappy	Effect: "Scavengers Scavenging", Effect Duration: 35, Last Available: "2019-12"
+10339	small moldy special Baja sopapilla	2	crappy	Effect: "Scavengers Scavenging", Effect Duration: 35, Last Available: "2019-12"
 10340	plastic Mer-kin baker of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2019-12"
 10341	skewed Temple Grandin's plastic sea elf	0		Familiar Weight: +7, Last Available: "2019-12"
 10342	tumbling plastic yuleviathan of Leguizamo	0		Monster Level: +20, Last Available: "2019-12"
 10343	pulsating twirling auspicious plastic dolphin &quot;orphan&quot;	0		Item Drop: +10, Single Equip, Last Available: "2019-12"
 10344	yellow plastic Dolph Bossin of the brazier	0		Hot Spell Damage: +25, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	bite-sized rotten mana-coated yams	1	crappy	Last Available: "2019-11"
+10346	rotten bite-sized mana-coated yams	1	crappy	Last Available: "2019-11"
 10347	tiny moldy blinking mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
-10348	big bland mana-fortified cranberry sauce	5	decent	Last Available: "2019-11"
+10348	bland big mana-fortified cranberry sauce	5	decent	Last Available: "2019-11"
 10349	huge stale mana-stuffed herbal stuffing	8	decent	Last Available: "2019-11"
 10350	squat human musk	0		Last Available: "2019-12"
 10351	modified magnetized squat patch of extra-warm fur	0		Effect: "Make Meat FA$T!", Effect Duration: 69, Last Available: "2019-12"
 10352	modified industrial lubricant	1		Effect: "Inner Dog", Effect Duration: 50, Last Available: "2019-12"
 10353	moist non-galvanized non-altered unfinished pleasure	0		Effect: "Square to be Hip", Effect Duration: 41, Last Available: "2019-12"
-10354	dehydrated wobbly mirror vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	dehydrated mirror wobbly vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dried wobbly a bug's lymph	1		Last Available: "2019-12"
 10356	super-tarnished deionized olive organic potpourri	0		Effect: "Horrid, Torrid", Effect Duration: 58, Last Available: "2019-12"
 10357	practically non-alcoholic tolerable boot flask	1	good	Last Available: "2019-12"
 10358	colloidal maroon infernal snowball	0		Effect: "Favored by Lyle", Effect Duration: 66, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	modified huge ghostly gray fish sauce	1		Last Available: "2019-12"
+10360	modified ghostly gray huge fish sauce	1		Last Available: "2019-12"
 10361	tasty massive guffin	6	awesome	Last Available: "2019-12"
 10362	modified twirling teal Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
@@ -10258,7 +10258,7 @@
 10399	toothsome ojo de pez burrito	3	awesome	Last Available: "2019-12"
 10400	huge waterlogged wood	0		Last Available: "2019-12"
 10401	spinning waterlogged cloth	0		Last Available: "2019-12"
-10402	ghostly spinning waterlogged stuffing	0		Last Available: "2019-12"
+10402	spinning ghostly waterlogged stuffing	0		Last Available: "2019-12"
 10403	mirror waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
 10405	ghostly wool extremely unsafe nutcracker hat	0		Weapon Damage Percent: +100, Cold Resistance: +1, Last Available: "2019-12"
@@ -10271,9 +10271,9 @@
 10412	censurious nutcracker cape of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +3, Last Available: "2019-12"
 10413	lion tamer's supercool nutcracker epaulets	0		Moxie Percent: +20, Experience (familiar): +2, Single Equip, Last Available: "2019-12"
 10414	blue pulsating nutcracker figurine	0		Last Available: "2019-12"
-10415	normal low-calorie salt plum	1	good	Last Available: "2019-12"
+10415	low-calorie normal salt plum	1	good	Last Available: "2019-12"
 10416	blurry peppermint eel sauce	0		Last Available: "2019-12"
-10417	super-sized decent and bean	5	good	Last Available: "2019-12"
+10417	decent super-sized and bean	5	good	Last Available: "2019-12"
 10418	skewed double-paned Jim Carey's Tesla kelp-holly gun	0		Monster Level: +25, Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-12"
 10419	censurious experienced Yuleviathan necklace	0		Experience: +2, Sleaze Resistance: +3, Single Equip, Last Available: "2019-12"
 10420	perfumed peppermint spine of the boozehound	0		Stench Resistance: +5, Booze Drop: +100, Last Available: "2019-12"
@@ -10282,17 +10282,17 @@
 10423	avaricious kelp-holly drape of extreme caution	0		Monster Level: -25, Meat Drop: +30, Last Available: "2019-12"
 10424	miser's asbestos-lined friendly Newton's Staff of the Peppermint Twist	0		Experience (Mysticality): +3, Familiar Weight: +3, Hot Resistance: +5, Meat Drop: +10, Last Available: "2019-12"
 10425	delicious tempura and bean	4	awesome	Last Available: "2019-12"
-10426	extra-dry hand-crafted salt plum sake	5	EPIC	Last Available: "2019-12"
+10426	hand-crafted extra-dry salt plum sake	5	EPIC	Last Available: "2019-12"
 10427	non-ionized ionized pressurized potion of possessiveness	0		Effect: "Eyes All Black", Effect Duration: 16, Last Available: "2019-12"
 10428	vacuum-sealed dry olive almond	0		Effect: "Izchak's Blessing", Effect Duration: 43
 10429	double-enhanced handful of mixed nuts	0		Effect: "Very Clean Guns", Effect Duration: 47, Last Available: "2019-12"
 10430	nutcracking pliers	0		
-10431	skewed upside-down Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	nippy vibrating banded Retrospecs	0		Damage Absorption: +100, Maximum MP Percent: +10, Cold Damage: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10431	upside-down skewed Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
+10432	nippy vibrating banded Retrospecs	0		Damage Absorption: +100, Maximum MP Percent: +10, Cold Damage: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	narrow Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	vibrating baleful savvy Powerful Glove of the pedagogue of the dark arts	0		Mysticality Percent: +20, Experience: +3, Spell Damage: +25, Spell Damage Percent: +100, Maximum MP Percent: +10, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	vibrating baleful savvy Powerful Glove of the pedagogue of the dark arts	0		Mysticality Percent: +20, Experience: +3, Spell Damage: +25, Spell Damage Percent: +100, Maximum MP Percent: +10, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	green enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	family-friendly rock-hard personal trainer's Drip harness	0		Experience Percent (Muscle): +10, Damage Reduction: 5, Sleaze Resistance: +1
@@ -10318,7 +10318,7 @@
 10461	hammer	0		
 10462	fire flower	0		
 10463	twirling bonfire flower	0		
-10464	twirling pulsating work boots	0		Single Equip
+10464	pulsating twirling work boots	0		Single Equip
 10465	boots	0		Single Equip
 10466	therapeutic cape	0		HP Regen Min: 5, HP Regen Max: 7
 10467	flame-wreathed chilly back shell	0		Cold Damage: +5, Hot Spell Damage: +10
@@ -10330,7 +10330,7 @@
 10473	frosty button	0		Single Equip
 10474	vacuum-sealed upside-down blooper ink	0		Effect: "Alchemical, Brother", Effect Duration: 40
 10475	coin	0		
-10476	narrow olive rubber doll head	0		
+10476	olive narrow rubber doll head	0		
 10477	rubber doll body	0		
 10478	plastic doll arms	0		
 10479	green wobbly plastic doll legs	0		
@@ -10343,10 +10343,10 @@
 10486	huge free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	huge colossal free-range mushroom	0		Last Available: "2020-03"
-10489	delicious tiny gray mushroom filet	1	awesome	Last Available: "2020-03"
+10489	tiny delicious gray mushroom filet	1	awesome	Last Available: "2020-03"
 10490	maroon mushroom slab	0		Last Available: "2020-03"
 10491	boiled tumbling mushroom tea	1		Effect: "Improved Candy Vision", Effect Duration: 20, Last Available: "2020-03"
-10492	delicious triple-distilled tumbling mushroom whiskey	9	awesome	Last Available: "2020-03"
+10492	triple-distilled delicious tumbling mushroom whiskey	9	awesome	Last Available: "2020-03"
 10493	Jim Carey's Newton's mushroom cap of the cheetah	0		Experience (Mysticality): +3, Monster Level: +25, Initiative: +60, Last Available: "2020-03"
 10494	spinning steel-toed padded sinister mushroom shield of dire peril	0		Weapon Damage: +20, Spell Damage: +10, Damage Absorption: +20, Damage Reduction: 15, Last Available: "2020-03"
 10495	spinning smelly nippy fortified Herculean mushroom pants	0		Experience (Muscle): +1, Damage Absorption: +60, Cold Damage: +10, Stench Spell Damage: +10, Last Available: "2020-03"
@@ -10369,7 +10369,7 @@
 10512	nasty deadly chipped coffee mug	0		Weapon Damage: +5, Stench Damage: +5, Last Available: "2020-04"
 10513	Left-Hand Man action figure of wisdom	0		Mysticality: +15, Last Available: "2020-04"
 10514	drippy seed	0		
-10515	tumbling wobbly drippy grub	0		
+10515	wobbly tumbling drippy grub	0		
 10516	bouncing blurry drippy bezoar	0		
 10517	blurry Drip Institute petri dish	0		
 10518	mirror drippy ichor	0		
@@ -10379,7 +10379,7 @@
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	upside-down drippy stein	0		
-10525	lousy watered-down drippy pilsner	2	drippy	
+10525	watered-down lousy drippy pilsner	2	drippy	
 10526	ghostly drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	blurry drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10388,15 +10388,15 @@
 10532	Guzzlr application	0		Free Pull
 10533	Lo Pan's wholesome Guzzlr tablet	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Last Available: "2020-05"
 10534	shaking Guzzlr cocktail set	0		Last Available: "2020-05"
-10535	red skewed Guzzlrbuck	0		Last Available: "2020-05"
+10535	skewed red Guzzlrbuck	0		Last Available: "2020-05"
 10536	ghostly Guzzlr hat	0		Last Available: "2020-05"
 10537	bouncing Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
-10538	shaking blinking Guzzlr pants	0		Last Available: "2020-05"
+10538	blinking shaking Guzzlr pants	0		Last Available: "2020-05"
 10539	mirror dance instructor's Guzzlr souvenir stein	0		Experience Percent (Moxie): +10, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	aged fortified Ghiaccio Colada	5	awesome	Last Available: "2020-05"
 10542	smooth Sourfinger	4	awesome	Last Available: "2020-05"
-10543	mediocre enchanted practically non-alcoholic Nog-on-the-Cob	1	decent	Effect: "Preternatural Greed", Effect Duration: 45, Last Available: "2020-05"
+10543	practically non-alcoholic enchanted mediocre Nog-on-the-Cob	1	decent	Effect: "Preternatural Greed", Effect Duration: 45, Last Available: "2020-05"
 10544	mediocre blinking Steamboat	3	decent	Last Available: "2020-05"
 10545	aged mirror Buttery Boy	3	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10431,16 +10431,16 @@
 10575	drippy candy bar	0		
 10576	super-alkaline tumbling salty drippy candy bar	0		Effect: "Fungal Flambé", Effect Duration: 23
 10577	chilled enhanced polymerized writhing drippy candy bar	0		Effect: "Crocodile Tear", Effect Duration: 11
-10578	denatured cold-filtered huge twirling gooey drippy candy bar	0		Effect: "Tiki Temerity", Effect Duration: 55
+10578	denatured cold-filtered twirling huge gooey drippy candy bar	0		Effect: "Tiki Temerity", Effect Duration: 55
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	skewed dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	blurry SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	shaking flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	upside-down Jack Frost's birch battery of Gandalf	0		Spell Critical Percent: +20, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08"
-10585	Oprah's fortified forbidden ebony epee	0		Spell Damage Percent: +50, Damage Absorption: +60, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	rosewater-soaked wool steel-toed weeping willow wand	0		Damage Reduction: 9, Cold Resistance: +1, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	blinking nasty nippy beechwood blowgun of the overflowing toilet	0		Cold Damage: +10, Stench Damage: +5, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	Oprah's fortified forbidden ebony epee	0		Spell Damage Percent: +50, Damage Absorption: +60, Maximum MP Percent: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	rosewater-soaked wool steel-toed weeping willow wand	0		Damage Reduction: 9, Cold Resistance: +1, Stench Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	blinking nasty nippy beechwood blowgun of the overflowing toilet	0		Cold Damage: +10, Stench Damage: +5, Stench Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	supercharged healthy maple magnet of extreme caution	0		Maximum HP Percent: +20, Maximum MP Percent: +30, Monster Level: -25, Lasts Until Rollover, Last Available: "2020-08"
 10589	cyan Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	fuchsia supercool boxer's hemlock helm of the glutton	0		Muscle Percent: +10, Moxie Percent: +20, Food Drop: +100, Last Available: "2020-08"
@@ -10480,7 +10480,7 @@
 10624	onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
-10627	blinking blurry onyx knight	0		Last Available: "2020-09"
+10627	blurry blinking onyx knight	0		Last Available: "2020-09"
 10628	cyan onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
 10630	fuchsia alabaster queen	0		Last Available: "2020-09"
@@ -10566,19 +10566,19 @@
 10710	The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	yellow The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
-10713	olive skewed bouncing The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
+10713	bouncing skewed olive The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	red The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	snack-sized moldy and pepper (stale)	2	crappy	Last Available: "2020-12"
 10716	lousy pulsating cranberry margarita (brackish)	3	decent	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	drinkable weak barrel-aged eggnog	2	good	Last Available: "2020-12"
+10720	weak drinkable barrel-aged eggnog	2	good	Last Available: "2020-12"
 10721	rotten hand-crafted candy cane	4	crappy	Last Available: "2020-12"
 10722	miniature rotten drive-thru burger	2	crappy	Last Available: "2020-12"
 10723	perfectly mixed Boulevardier cocktail	3	EPIC	Last Available: "2020-12"
 10724	liquefied colloidal wobbly Hotwire&trade; brand candy rope	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 49, Last Available: "2020-12"
-10725	small spoiled bowl full of jelly	2	crappy	Last Available: "2020-12"
+10725	spoiled small bowl full of jelly	2	crappy	Last Available: "2020-12"
 10726	bad Eye and a Twist	3	decent	Last Available: "2020-12"
 10727	energized activated Chubby and Plump bar	0		Effect: "Human-Pirate Hybrid", Effect Duration: 35, Last Available: "2020-12"
 10728	ghostly digibritches	0		Last Available: "2025-12"
@@ -10586,8 +10586,8 @@
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	skewed fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	mirror spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	mirror spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	bouncing marshmallow	0		
 10747	hand-crafted marshmallow bomb	3	EPIC	Last Available: "2021-03"
 10748	narrow packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	twirling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	modified short beer	0		Effect: "Cake Caked", Effect Duration: 41, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	corrupted corrupted short	0		Effect: "Souper Vengeful", Effect Duration: 26, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	bouncing twirling toasty Samson's familiar scrapbook	0		Experience (Muscle): +5, Hot Damage: +5, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	bouncing twirling toasty Samson's familiar scrapbook	0		Experience (Muscle): +5, Hot Damage: +5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	teal packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	narrow double-paned smelly boxer's fedora-mounted fountain	0		Muscle Percent: +10, Stench Spell Damage: +10, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2021-07"
@@ -10630,8 +10630,8 @@
 10774	energized double-deionized Scent of a Human&trade; candle	0		Effect: "Alacri Tea", Effect Duration: 28, Last Available: "2021-08"
 10775	concentrated aerosolized liquefied The Beast Within&trade; candle	0		Effect: "Action", Effect Duration: 60, Last Available: "2021-08"
 10776	quadruple-altered enhanced wet Salsa Caliente&trade; candle	0		Effect: "Extra Terrestrial", Effect Duration: 35, Last Available: "2021-08"
-10777	polymerized diffused pulsating red Smoldering Clover&trade; candle	0		Effect: "Rampage!", Effect Duration: 62, Last Available: "2021-08"
-10778	moist mirror upside-down Napalm In The Morning&trade; candle	0		Effect: "Memories of Puppy Love", Effect Duration: 43, Last Available: "2021-08"
+10777	polymerized diffused red pulsating Smoldering Clover&trade; candle	0		Effect: "Rampage!", Effect Duration: 62, Last Available: "2021-08"
+10778	moist upside-down mirror Napalm In The Morning&trade; candle	0		Effect: "Memories of Puppy Love", Effect Duration: 43, Last Available: "2021-08"
 10779	wicked extra-large utility candle of the boozehound	0		Spell Damage: +5, Booze Drop: +100, Lasts Until Rollover, Last Available: "2021-08"
 10780	nasty sizzling runed taper candle	0		Hot Damage: +10, Stench Damage: +5, Lasts Until Rollover, Last Available: "2021-08"
 10781	zippy hardened novelty sparkling candle of the businessman	0		Damage Reduction: 3, Meat Drop: +50, Initiative: +20, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	mirror rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	ghostly prompt avaricious reassuring chilly industrial fire extinguisher of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Cold Damage: +5, Spooky Resistance: +1, Meat Drop: +30, Adventures: +3, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	ghostly prompt avaricious reassuring chilly industrial fire extinguisher of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Cold Damage: +5, Spooky Resistance: +1, Meat Drop: +30, Adventures: +3, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10661,7 +10661,7 @@
 10805	eggwater	1	awesome	Last Available: "2021-12"
 10806	toothsome blinking bread man	4	awesome	Last Available: "2021-12"
 10807	spoiled miniature blurry plain candy cane	2	crappy	Last Available: "2021-12"
-10808	big decent spinning flour cookie	5	good	Last Available: "2021-12"
+10808	decent big spinning flour cookie	5	good	Last Available: "2021-12"
 10809	sage plastic food lab	0		Mysticality Percent: +10, Single Equip, Last Available: "2021-12"
 10810	rosy-cheeked plastic nog lab	0		Maximum HP Percent: +30, Single Equip, Last Available: "2021-12"
 10811	olive fireproof plastic chem lab	0		Hot Resistance: +3, Single Equip, Last Available: "2021-12"
@@ -10675,25 +10675,25 @@
 10819	adequate tofu pop	3	good	Last Available: "2021-12"
 10820	bland bowl of prescription candy	4	decent	Last Available: "2021-12"
 10821	spoiled spinning fishcake	3	crappy	Last Available: "2021-12"
-10822	diet bland tumbling mirror bone broth	1	decent	Last Available: "2021-12"
+10822	bland diet mirror tumbling bone broth	1	decent	Last Available: "2021-12"
 10823	normal star pop	3	good	Last Available: "2021-12"
 10824	artisanal Doc's Fortifying Wine	4	EPIC	Last Available: "2021-12"
-10825	practically non-alcoholic hand-crafted jittery Doc's Smartifying Wine	1	EPIC	Last Available: "2021-12"
+10825	hand-crafted practically non-alcoholic jittery Doc's Smartifying Wine	1	EPIC	Last Available: "2021-12"
 10826	aged fortified Doc's Limbering Wine	5	awesome	Last Available: "2021-12"
 10827	lousy yellow Doc's Medical-Grade Wine	3	decent	Last Available: "2021-12"
 10828	dried Homebodyl&trade;	1		Effect: "Liquidy Smoky", Effect Duration: 20, Last Available: "2021-12"
 10829	powdered skewed Extrovermectin&trade;	1		Last Available: "2021-12"
-10830	vaporized ghostly blurry Breathitin&trade;	1		Last Available: "2021-12"
+10830	vaporized blurry ghostly Breathitin&trade;	1		Last Available: "2021-12"
 10831	distilled skewed Fleshazole&trade;	1		Last Available: "2021-12"
 10832	boiled warmed anti-burn cream	0		Effect: "Incensed", Effect Duration: 46, Last Available: "2021-12"
-10833	vacuum-sealed anodized pulsating maroon anti-freeze cream	0		Effect: "Gleaming White Teeth", Effect Duration: 30, Last Available: "2021-12"
+10833	vacuum-sealed anodized maroon pulsating anti-freeze cream	0		Effect: "Gleaming White Teeth", Effect Duration: 30, Last Available: "2021-12"
 10834	activated anti-goosebump cream	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 56, Last Available: "2021-12"
 10835	triple-quantum magnetized tumbling anti-odor cream	0		Effect: "Mental A-cue-ity", Effect Duration: 18, Last Available: "2021-12"
 10836	electrified upside-down anti-creep cream	0		Effect: "Disdain of the War Snapper", Effect Duration: 66, Last Available: "2021-12"
 10837	warmed vacuum-sealed ghostly anti-pain cream	0		Effect: "Superioreo", Effect Duration: 56, Last Available: "2021-12"
-10838	watered-down artisanal special pulsating Doc's Special Reserve Wine	2	EPIC	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 30, Last Available: "2021-12"
+10838	artisanal watered-down special pulsating Doc's Special Reserve Wine	2	EPIC	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 30, Last Available: "2021-12"
 10839	spoiled pulsating tumbling bread pie	3	crappy	Last Available: "2021-12"
-10840	irresponsibly strong artisanal clear Russian	6	EPIC	Last Available: "2021-12"
+10840	artisanal irresponsibly strong clear Russian	6	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	spinning Crimbo ball	0		Last Available: "2021-12"
 10843	upside-down Crimbo ball	0		Last Available: "2021-12"
@@ -10721,14 +10721,14 @@
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	groovy yule hatchet	0		Moxie Percent: +10, Last Available: "2021-12"
 10867	skewed potato alarm clock	0		Last Available: "2021-12"
-10868	stale super-sized lab-grown meat	5	decent	Last Available: "2021-12"
+10868	super-sized stale lab-grown meat	5	decent	Last Available: "2021-12"
 10869	fleece of Gandalf	0		Spell Critical Percent: +20, Last Available: "2021-12"
 10870	jittery boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
 10872	beefcake's pants	0		Muscle: +25, Last Available: "2021-12"
 10873	lard-coated studded razor-sharp can of mixed everything	0		Weapon Damage Percent: +25, Damage Absorption: +80, Sleaze Spell Damage: +25, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
-10875	blurry squat the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10875	squat blurry the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	yummy upside-down meatball	3	awesome	Last Available: "2021-12"
 10877	wobbly cloned monster	0		Last Available: "2021-12"
 10878	tumbling squat meatball machine	0		Last Available: "2021-12"
@@ -10745,12 +10745,12 @@
 10889	hardened sinister void shard of Leguizamo of courage	0		Spell Damage: +10, Damage Reduction: 3, Monster Level: +20, Spooky Resistance: +3, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	cosmic bowling ball	0		Last Available: "2022-01"
-10892	pulsating spinning combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
+10892	spinning pulsating combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	combat lover's locket of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2022-02"
 10894	blinking Thwaitgold protozoa statuette	0		
 10895	grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	grey down vest	0		Experience (familiar): +2
-10897	twirling purple trojan horseshoe	0		Last Available: "2025-12"
+10897	purple twirling trojan horseshoe	0		Last Available: "2025-12"
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	auspicious reassuring Tesla unbreakable umbrella (broken) of the boozehound	0		Spooky Resistance: +1, Item Drop: +10, Booze Drop: +100, MP Regen Min: 7, MP Regen Max: 10
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
@@ -10761,15 +10761,15 @@
 10905	gray headlamp of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2022-05"
 10906	narrow lard-coated foul-smelling quilted thermal blanket	0		Damage Absorption: +40, Stench Damage: +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-05"
 10907	teal stylish atlas of local maps	0		Moxie: +25, Lasts Until Rollover, Last Available: "2022-05"
-10908	moist moist mirror pulsating yellow spare battery	0		Effect: "Wolf's Bane", Effect Duration: 15, Last Available: "2022-05"
+10908	moist moist mirror yellow pulsating spare battery	0		Effect: "Wolf's Bane", Effect Duration: 15, Last Available: "2022-05"
 10909	upside-down space blanket	0		Last Available: "2022-05"
 10910	super-pickled wobbly single-use dust mask	0		Effect: "Mmmmmelon", Effect Duration: 33, Last Available: "2022-05"
 10911	Vulcanized dry bouncing gaffer's tape	0		Effect: "Vented Spleen", Effect Duration: 61, Last Available: "2022-05"
 10912	normal miniature 20-lb can of rice and beans	2	good	Last Available: "2022-05"
-10913	special bouncing purple bar of freeze-dried water	1	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35, Last Available: "2022-05"
-10914	decent immense expired MRE	8	good	Last Available: "2022-05"
+10913	special purple bouncing bar of freeze-dried water	1	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35, Last Available: "2022-05"
+10914	immense decent expired MRE	8	good	Last Available: "2022-05"
 10915	half-sized adequate cool mint precipice bar	2	good	Last Available: "2022-05"
-10916	diet normal wobbly carrot cake precipice bar	1	good	Last Available: "2022-05"
+10916	normal diet wobbly carrot cake precipice bar	1	good	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10782,14 +10782,14 @@
 10926	adjusted upside-down trampled ticket stub	0		Effect: "Stuck That Way", Effect Duration: 29, Last Available: "2022-06"
 10927	altered moist savings bond	0		Effect: "Greasy Visage", Effect Duration: 66, Last Available: "2022-06"
 10928	red designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
 10930	pickled sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	fuchsia pristine dinosaur feather	0		
-10936	purple twirling nasty dinosaur spike	0		
+10936	twirling purple nasty dinosaur spike	0		
 10937	upside-down squat pterodactyl rifle of doom	0		Spooky Spell Damage: +50, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	jittery birdseed hat	0		
 10939	pulsating flatusaur gasmask	0		
@@ -10805,7 +10805,7 @@
 10949	ribald dinosaur	0		Sleaze Damage: +10
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	wobbly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	therapeutic slick Jurassic Parka	0		Moxie: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	therapeutic slick Jurassic Parka	0		Moxie: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	boiled improved autumn leaf	0		Effect: "Oiled Skin", Effect Duration: 52, Last Available: "2022-10"
@@ -10815,7 +10815,7 @@
 10959	bland autumn-spice donut	4	decent	Last Available: "2022-10"
 10960	corrupted autumn dollar	0		Effect: "Flagrantly Fragrant", Effect Duration: 39, Last Available: "2022-10"
 10961	purple aromatic wholesome autumn leaf pendant of the ox	0		Muscle: +20, Maximum HP Percent: +10, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2022-10"
-10962	compressed blinking pulsating autumn breeze	1		Last Available: "2022-10"
+10962	compressed pulsating blinking autumn breeze	1		Last Available: "2022-10"
 10963	ionized autumn years wisdom	0		Effect: "Dreadful Smell", Effect Duration: 30, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	hand-crafted Oopsie IPA	3	EPIC	Last Available: "2022-10"
@@ -10827,32 +10827,32 @@
 10971	snack-sized moldy Jarlsberg's vegetable soup	2	crappy	Last Available: "2022-11"
 10972	spoiled huge ghostly roasted vegetable of Jarlsberg	4	crappy	Last Available: "2022-11"
 10973	decent bite-sized squat St. Pete's sneaky smoothie	1	good	Last Available: "2022-11"
-10974	rotten enchanted snack-sized Pete's wiley whey bar	2	crappy	Effect: "The Real Deal", Effect Duration: 25, Last Available: "2022-11"
-10975	miniature adequate Pete's rich ricotta	2	good	Last Available: "2022-11"
+10974	snack-sized enchanted rotten Pete's wiley whey bar	2	crappy	Effect: "The Real Deal", Effect Duration: 25, Last Available: "2022-11"
+10975	adequate miniature Pete's rich ricotta	2	good	Last Available: "2022-11"
 10976	acceptable watered-down Boris's beer	2	good	Last Available: "2022-11"
 10977	moldy honey bun of Boris	4	crappy	Last Available: "2022-11"
 10978	delicious Boris's bread	3	awesome	Last Available: "2022-11"
-10979	narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	upside-down Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	blurry Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	narrow blue Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	upside-down Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	blurry Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	blue narrow Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	normal tiny baked veggie ricotta casserole	1	good	Last Available: "2022-11"
 10989	toothsome big plain calzone	5	awesome	Last Available: "2022-11"
 10990	spoiled roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	decent snack-sized Pizza of Legend	2	good	Last Available: "2022-11"
 10992	big stale Calzone of Legend	5	decent	Last Available: "2022-11"
-10993	upside-down Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	wobbly Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	upside-down Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	wobbly Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	tumbling Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	tumbling Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	normal Deep Dish of Legend	3	good	Last Available: "2022-11"
 11001	yellow deed to Oliver's Place	0		Free Pull
 11002	cyan drink chit	0		
@@ -10869,16 +10869,16 @@
 11013	smooth Charleston Choo-Choo	3	awesome	
 11014	artisanal irresponsibly strong Velvet Veil	7	EPIC	
 11015	tolerable Marltini	3	good	
-11016	high-proof delicious squat Strong, Silent Type	8	awesome	
-11017	weak tolerable Mysterious Stranger	2	good	
+11016	delicious high-proof squat Strong, Silent Type	8	awesome	
+11017	tolerable weak Mysterious Stranger	2	good	
 11018	hand-crafted Champagne Shimmy	4	EPIC	
-11019	mirror spinning purple pulsating the Sot's parcel	0		
-11020	blue electrified boxer's ceramic cestus	0		Muscle Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	narrow greasy Fonzie's ceramic centurion shield of the detective	0		Experience (Moxie): +1, Sleaze Spell Damage: +10, Item Drop: +20, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	aromatic brawny ceramic celery grater	0		Muscle Percent: +20, Stench Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	blinking green mansplainer's ruddy dance instructor's ceramic celsiturometer	0		Experience Percent (Moxie): +10, Maximum HP Percent: +40, Monster Level: +15, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	fireproof Oprah's extremely unsafe ceramic cerecloth belt	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Hot Resistance: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	ribald medical-grade ceramic cenobite's robe of the pedagogue	0		Experience: +3, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11019	spinning purple pulsating mirror the Sot's parcel	0		
+11020	blue electrified boxer's ceramic cestus	0		Muscle Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	narrow greasy Fonzie's ceramic centurion shield of the detective	0		Experience (Moxie): +1, Sleaze Spell Damage: +10, Item Drop: +20, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	aromatic brawny ceramic celery grater	0		Muscle Percent: +20, Stench Resistance: +1, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	blinking green mansplainer's ruddy dance instructor's ceramic celsiturometer	0		Experience Percent (Moxie): +10, Maximum HP Percent: +40, Monster Level: +15, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	fireproof Oprah's extremely unsafe ceramic cerecloth belt	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	ribald medical-grade ceramic cenobite's robe of the pedagogue	0		Experience: +3, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	dried ceramic scree	1		Effect: "Oily Flavor", Effect Duration: 5, Last Available: "2023-12"
 11027	improved yellow bouncing extra-hard jawbreaker	0		Effect: "Compensatory Cruelness", Effect Duration: 47
 11028	squat shaking Socratic chiffon chevrons of the pedagogue of the empath	0		Experience: +3, Experience (Mysticality): +1, Familiar Weight: +5, Single Equip, Last Available: "2023-12"
@@ -10890,7 +10890,7 @@
 11034	diluted fuchsia jittery chiffon carbage	1		Effect: "Muddled", Effect Duration: 30, Last Available: "2023-12"
 11035	vacuum-sealed chiffon lemon	0		Effect: "Unusual Fashion Sense", Effect Duration: 43
 11036	decent bouncing chocomotive	3	good	Last Available: "2022-12"
-11037	snack-sized stale freightcake	2	decent	Last Available: "2022-12"
+11037	stale snack-sized freightcake	2	decent	Last Available: "2022-12"
 11038	drinkable cabooze	4	good	Last Available: "2022-12"
 11039	lime green plastic caboose	0		Last Available: "2022-12"
 11040	double-paned plastic passenger car	0		Cold Resistance: +5, Last Available: "2022-12"
@@ -10920,10 +10920,10 @@
 11064	shaking maroon perfumed asbestos-lined vibrating shoulder-mounted Trainbot	0		Maximum MP Percent: +10, Hot Resistance: +5, Stench Resistance: +5, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	weak perfectly mixed jittery dregs of a Crimbo cocktail	2	EPIC	
+11067	perfectly mixed weak jittery dregs of a Crimbo cocktail	2	EPIC	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	spoiled immense honey-drenched ham slice	9	crappy	
+11070	immense spoiled honey-drenched ham slice	9	crappy	
 11071	weak bad mostly-empty bottle of cookie wine	2	decent	
 11072	delicious Crimbo food scraps	4	awesome	
 11073	arm towel	0		Last Available: "2022-12"
@@ -10931,12 +10931,12 @@
 11075	table-scraper	0		Single Equip
 11076	huge Trainbot slag	0		
 11077	blinking industrially-crushed ice	0		Last Available: "2022-12"
-11078	thick toothsome mirror steamed oyster	5	awesome	
+11078	toothsome thick mirror steamed oyster	5	awesome	
 11079	pulsating really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	gray steam unit	0		Last Available: "2022-12"
 11082	blurry gray crystal Crimbo goblet	0		
-11083	ghostly spinning crystal Crimbo platter	0		
+11083	spinning ghostly crystal Crimbo platter	0		
 11084	bad spirit-forward Crimbosmopolitan	5	decent	Last Available: "2022-12"
 11085	bland Crimbo dinner	3	decent	Last Available: "2022-12"
 11086	upside-down overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
@@ -10952,7 +10952,7 @@
 11096	grubby wool beerwarmer	0		
 11097	artisanal nice warm beer	3	EPIC	
 11098	fuchsia pulsating grubby woolball	0		
-11099	squat wobbly Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
+11099	wobbly squat Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	tumbling groveling gravel	0		Last Available: "2023-01"
 11102	mixed fruity pebble	1		Last Available: "2023-01"
@@ -10974,14 +10974,14 @@
 11119	liquefied five-fingered fern resin	0		Effect: "The Dinsey Spirit", Effect Duration: 24, Last Available: "2023-02"
 11120	stale blinking super good fruit	3	decent	Last Available: "2023-02"
 11121	dried blinking energized spores	1		Effect: "Moon'd", Effect Duration: 40, Last Available: "2023-02"
-11122	vibrating beefy hot pepper	0		Muscle: +10, Maximum MP Percent: +10, Last Available: "2023-02", Lantern Element: "Hot"
+11122	vibrating beefy hot pepper	0		Muscle: +10, Maximum MP Percent: +10, Lantern Element: "Hot", Last Available: "2023-02"
 11123	colloidal upside-down out-of-work circus flea	0		Effect: "20-20 Second Sight", Effect Duration: 39, Last Available: "2023-02"
 11124	lime green extra-grubby grub	0		Last Available: "2023-02"
 11125	dry concentrated narrow fire ant pheromones	0		Effect: "Weather, Man", Effect Duration: 47, Last Available: "2023-02"
 11126	pickled flapper fly	0		Effect: "Abyssal Tears", Effect Duration: 23, Last Available: "2023-02"
-11127	drinkable watered-down blinking shot of wasp venom	2	good	Last Available: "2023-02"
+11127	watered-down drinkable blinking shot of wasp venom	2	good	Last Available: "2023-02"
 11128	dry deionized twirling filled mosquito	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 32, Last Available: "2023-02"
-11129	non-oxidized jittery purple spinning shim of shame shale	0		Effect: "Dweeby", Effect Duration: 28, Last Available: "2023-02"
+11129	non-oxidized purple spinning jittery shim of shame shale	0		Effect: "Dweeby", Effect Duration: 28, Last Available: "2023-02"
 11130	warmed super-concentrated pebble of proud pyrite	0		Effect: "Mercenary", Effect Duration: 39, Last Available: "2023-02"
 11131	liquefied modified vacuum-sealed squat pile of gritty sand	0		Effect: "Cold Blooded", Effect Duration: 29, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
@@ -10990,7 +10990,7 @@
 11135	normal spinning shadow sausage	3	good	Last Available: "2023-03"
 11136	huge sage shadow skin of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Last Available: "2023-03"
 11137	alkaline pressed upside-down shadow flame	0		Effect: "Slightly Mutated", Effect Duration: 37, Last Available: "2023-03"
-11138	yummy miniature blinking shadow bread	2	awesome	Last Available: "2023-03"
+11138	miniature yummy blinking shadow bread	2	awesome	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	enchanted practically non-alcoholic drinkable shadow fluid	1	good	Effect: "Notably Lovely", Effect Duration: 50, Last Available: "2023-03"
 11141	shaking upside-down shadow glass	0		Last Available: "2023-03"
@@ -11035,10 +11035,10 @@
 11180	family-friendly stanky strapping shadow monocle	0		Muscle: +5, Stench Spell Damage: +25, Sleaze Resistance: +1, Single Equip
 11181	blinking shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	decent shadow hot dog	4	good	
-11183	perfectly mixed watered-down shadow martini	2	EPIC	
+11183	watered-down perfectly mixed shadow martini	2	EPIC	
 11184	boiled twirling shadow pill	1		Effect: "Gummibrain", Effect Duration: 10
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	colloidal Vulcanized shadow candy	0		Effect: "The Magic of Sharing", Effect Duration: 25
 11189	pulsating maroon replica Mr. Accessory	0		
@@ -11047,7 +11047,7 @@
 11192	replica crimbo elfling	0		
 11193	pulsating replica pygmy bugbear shaman	0		
 11194	blue dedigitizer schematic: cyburger	0		Last Available: "2025-12"
-11195	cyan jittery replica gravy-covered maypole	0		Item Drop: +25
+11195	jittery cyan replica gravy-covered maypole	0		Item Drop: +25
 11196	pulsating replica wax lips	0		Experience: +3
 11197	maroon replica Tome of Snowcone Summoning	0		
 11198	wobbly dedigitizer schematic: cybeer	0		Last Available: "2025-12"
@@ -11062,7 +11062,7 @@
 11207	olive replica squamous polyp	0		
 11208	blinking replica stone sphere	0		
 11209	Usain Bolt's Socratic replica Greatest American Pants of incineration	0		Experience (Mysticality): +1, Hot Spell Damage: +50, Initiative: +80
-11210	green blurry replica organ grinder	0		
+11210	blurry green replica organ grinder	0		
 11211	shaking shaking Fonzie's stylish replica Juju Mojo Mask of the glutton	0		Moxie: +25, Experience (Moxie): +1, Food Drop: +100, Single Equip
 11212	huge ghostly Da Vinci's replica Operation Patriot Shield of extreme caution of Flo-Jo	0		Experience (Mysticality): +5, Monster Level: -25, Initiative: +100, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	replica Libram of Resolutions	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	blurry shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	twirling yellow bouncing Sherlock's padded beefcake's Cincho de Mayo of Tarzan	0		Muscle: +25, Experience (Muscle): +3, Damage Absorption: +20, Item Drop: +25, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	twirling yellow bouncing Sherlock's padded beefcake's Cincho de Mayo of Tarzan	0		Muscle: +25, Experience (Muscle): +3, Damage Absorption: +20, Item Drop: +25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	teal replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11112,13 +11112,13 @@
 11257	wobbly 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	jittery horrifying nasty careful groovy sage brainy &quot;I survived Y2K&quot; T-Shirt	0		Mysticality: +5, Mysticality Percent: +10, Moxie Percent: +10, Monster Level: -10, Stench Damage: +5, Spooky Damage: +25, Single Equip, Last Available: "2023-06"
 11259	narrow Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	censurious padded pro skateboard	0		Damage Absorption: +20, Sleaze Resistance: +3, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	censurious padded pro skateboard	0		Damage Absorption: +20, Sleaze Resistance: +3, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	mirror Mr. Accessaturday	0		Last Available: "2023-06"
 11262	bouncing Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	fuchsia Charter: Nellyville	0		Last Available: "2023-06"
-11265	skewed Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	blurry huge auspicious Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	skewed Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	blurry huge auspicious Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	asbestos-lined stiffened sage Amulet of Perpetual Darkness of the empath	0		Mysticality Percent: +10, Damage Reduction: 1, Familiar Weight: +5, Hot Resistance: +5, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11128,7 +11128,7 @@
 11273	olive Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	twirling Arrow (+1)	0		Last Available: "2023-06"
-11276	quantum mirror jittery scroll of protection from lycanthropes	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 48, Last Available: "2023-06"
+11276	quantum jittery mirror scroll of protection from lycanthropes	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 48, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	smooth upside-down Sexy Cosmo	4	awesome	Last Available: "2023-06"
 11283	huge Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	family-friendly rosewater-soaked Rosewater's red-soled high heels	0		Mysticality Percent: +30, Stench Resistance: +3, Sleaze Resistance: +1, Last Available: "2023-06"
-11285	stale super-sized cyburger	5	decent	Last Available: "2025-12"
+11285	super-sized stale cyburger	5	decent	Last Available: "2025-12"
 11286	bouncing ncle leg of Gandalf	0		Spell Critical Percent: +20
 11287	Temple Grandin's rutabuga bag of the blizzard	0		Familiar Weight: +7, Cold Spell Damage: +25
 11288	lard-coated mesquito proboscis	0		Sleaze Spell Damage: +25
@@ -11161,7 +11161,7 @@
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	adequate watermelon	4	good	
 11308	squat watermelon seed	0		
-11309	spinning blurry water balloon	0		
+11309	blurry spinning water balloon	0		
 11310	thriftshop coupon	0		
 11311	rotten waffle	3	crappy	
 11312	fixodent	0		
@@ -11174,8 +11174,8 @@
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	drinkable bottle of Cabernet Sauvignon	3	good	
 11321	wobbly baywatch of the cougar of dire peril of bravery	0		Moxie: +20, Weapon Damage: +20, Spooky Resistance: +5, Lasts Until Rollover
-11322	huge upside-down Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	huge gray Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	huge upside-down Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	gray huge Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11212,7 +11212,7 @@
 11357	electrified groovy smoldering drape	0		Moxie Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	red lard-coated Lo Pan's MacGyver's strapping leaf crown of horror of mayonnaise	0		Muscle: +5, Maximum MP: +100, Spell Critical Percent: +30, Spooky Spell Damage: +25, Sleaze Spell Damage: 75
-11360	snack-sized rotten leafy browns	2	crappy	
+11360	rotten snack-sized leafy browns	2	crappy	
 11361	pickled corrupted blurry autumnic balm	0		Effect: "Cold, Dead Hands", Effect Duration: 32
 11362	chilled tumbling coping juice	0		Effect: "The Real Deal", Effect Duration: 56
 11363	lard-coated clever rock-hard boxer's candy cane sword cane of the glutton	0		Muscle Percent: +10, Damage Reduction: 5, Maximum MP: +20, Sleaze Spell Damage: +25, Food Drop: +100, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11232,7 +11232,7 @@
 11377	pulsating housekeeping robot	0		
 11378	spoiled small lime green pickled bread	2	crappy	Last Available: "2023-12"
 11379	bite-sized toothsome salted mutton	1	awesome	Last Available: "2023-12"
-11380	bland special corned beet	3	decent	Effect: "Dexteri Tea", Effect Duration: 10, Last Available: "2023-12"
+11380	special bland corned beet	3	decent	Effect: "Dexteri Tea", Effect Duration: 10, Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11251,7 +11251,7 @@
 11396	mirror family-friendly Elf Guard insignia (private)	0		Sleaze Resistance: +1, Last Available: "2023-12"
 11397	narrow dog trainer's Crimbuccaneer fledges (mint)	0		Experience (familiar): +1, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
-11399	upside-down maroon bouncing Crimbuccaneer whale oil	0		Last Available: "2023-12"
+11399	bouncing upside-down maroon Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	perfectly mixed Crimbuccaneer mologrog cocktail	4	EPIC	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
@@ -11268,7 +11268,7 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	Sherlock's arcane researcher's Elf Guard officer's sidearm	0		Experience Percent (Mysticality): +10, Item Drop: +25, Last Available: "2023-12"
 11415	tumbling olive forbidden Elf Guard insignia (general) of incineration	0		Spell Damage Percent: +50, Hot Spell Damage: +50, Single Equip, Last Available: "2023-12"
-11416	aged practically non-alcoholic Crimbow Rainbo	1	awesome	Last Available: "2023-12"
+11416	practically non-alcoholic aged Crimbow Rainbo	1	awesome	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	Annie Oakley's Elf Guard broom of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: +25, Last Available: "2023-12"
@@ -11277,12 +11277,12 @@
 11422	extra-dry lousy old-school pirate grog	5	decent	Last Available: "2023-12"
 11423	diet moldy grog nuts	1	crappy	Last Available: "2023-12"
 11424	energetic veiny sawed-off blunderbuss of the ox	0		Muscle: +20, Maximum HP: +10, Maximum MP Percent: +20, Last Available: "2023-12"
-11425	aged fortified officer's nog	5	awesome	Last Available: "2023-12"
+11425	fortified aged officer's nog	5	awesome	Last Available: "2023-12"
 11426	twirling peppermint bomb	0		Last Available: "2023-12"
 11427	adequate sundae ration	3	good	Last Available: "2023-12"
 11428	toothsome huge peppermint tack	4	awesome	Last Available: "2023-12"
 11429	twirling Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	low-calorie rotten narrow whalesteak	1	crappy	Last Available: "2023-12"
+11430	rotten low-calorie narrow whalesteak	1	crappy	Last Available: "2023-12"
 11431	asbestos-lined sharpshooter's wicked whalegun	0		Spell Damage: +5, Critical Hit Percent: +10, Hot Resistance: +5, Last Available: "2023-12"
 11432	gray Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	stanky dog trainer's medical-grade forbidden brainy Elf dessert spoon of the detective	0		Mysticality: +5, Spell Damage Percent: +50, Experience (familiar): +1, Stench Spell Damage: +25, Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11453	dog trainer's Elf Guard SCUBA tank of James Dean	0		Experience (Moxie): +3, Experience (familiar): +1, Last Available: "2023-12"
 11454	maroon Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	squat Oprah's free boots of the pedagogue	0		Experience: +3, Maximum MP Percent: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	squat Oprah's free boots of the pedagogue	0		Experience: +3, Maximum MP Percent: +50, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	Sinatra's Elvish underarmor of mayonnaise of courage	0		Experience (Moxie): +5, Sleaze Spell Damage: +50, Spooky Resistance: +3, Single Equip, Last Available: "2023-12"
 11458	grievous Crimbuccaneer bombjacket of the cheetah	0		Weapon Damage Percent: +50, Initiative: +60, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	tiny yummy wobbly sugarplum ration	1	awesome	Last Available: "2023-12"
-11460	small moldy gingerbread nylons	2	crappy	Last Available: "2023-12"
+11460	moldy small gingerbread nylons	2	crappy	Last Available: "2023-12"
 11461	bland fuchsia rum-soaked fruitcake	3	decent	Last Available: "2023-12"
-11462	decent fancy lime	3	good	Effect: "Lit Up", Effect Duration: 45, Last Available: "2023-12"
+11462	fancy decent lime	3	good	Effect: "Lit Up", Effect Duration: 45, Last Available: "2023-12"
 11463	bland yellow gingerbread pirate	4	decent	Last Available: "2023-12"
-11464	tiny bland mirror spinning fruit-stuffed rumcake	1	decent	Last Available: "2023-12"
+11464	tiny bland spinning mirror fruit-stuffed rumcake	1	decent	Last Available: "2023-12"
 11465	practically non-alcoholic drinkable teal mulled wine	1	good	Last Available: "2023-12"
 11466	perfectly mixed Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	practically non-alcoholic perfectly mixed canteen of eggnog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11468	triple-distilled artisanal hot wine	7	EPIC	Last Available: "2023-12"
-11469	spirit-forward mediocre Jamaican coffee	5	decent	Last Available: "2023-12"
-11470	watered-down perfectly mixed flask of egggrog	2	super ultra mega EPIC	Last Available: "2023-12"
+11469	mediocre spirit-forward Jamaican coffee	5	decent	Last Available: "2023-12"
+11470	perfectly mixed watered-down flask of egggrog	2	super ultra mega EPIC	Last Available: "2023-12"
 11471	purple Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	upside-down Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	weak mediocre jittery yule grog	2	decent	Last Available: "2023-12"
 11475	rotten wet tack	4	crappy	Last Available: "2023-12"
 11476	delicious whalecake	4	awesome	Last Available: "2023-12"
-11477	olive knitted scandalous gunwale whalegun	0		Sleaze Damage: +5, Cold Resistance: +3, Item Drop: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	fancy delicious narrow and claret	4	awesome	Effect: "Frostbeard", Effect Duration: 10, Last Available: "2023-12"
-11479	mirror upside-down rigging knot	0		Familiar Weight: +5
+11477	olive knitted scandalous gunwale whalegun	0		Sleaze Damage: +5, Cold Resistance: +3, Item Drop: +5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	delicious fancy narrow and claret	4	awesome	Effect: "Frostbeard", Effect Duration: 10, Last Available: "2023-12"
+11479	upside-down mirror rigging knot	0		Familiar Weight: +5
 11480	jittery trick coin	0		Last Available: "2023-12"
-11481	bouncing gravedigger's Elf Guard squirtgun of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	bouncing gravedigger's Elf Guard squirtgun of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	steel-toed sequin-encrusted sweater	0		Damage Reduction: 9, Last Available: "2023-12"
 11484	blurry nippy manspreader's Oprah's replica Elf Guard medal	0		Maximum MP Percent: +50, Monster Level: +10, Cold Damage: +10, Last Available: "2023-12"
@@ -11348,7 +11348,7 @@
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	ghostly Elf Guard safety bear	0		Last Available: "2023-12"
 11495	shaking blurry kraken	0		Last Available: "2023-12"
-11496	blinking huge precision snowball	0		Last Available: "2023-12"
+11496	huge blinking precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	gray Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	pulsating Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	denatured quadruple-concentrated tarnished tumbling military candy cane	0		Effect: "Spiro Gyro", Effect Duration: 20
 11503	diffused triple-corrupted groggipop	0		Effect: "The Sweats", Effect Duration: 59
-11504	smelly medical-grade moss mace	0		Stench Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	fortified moss megaphone of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	executive veiny moss medal	0		Maximum HP: +10, Meat Drop: +40, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	electrified occult moss mitre	0		Spell Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	executive thinker's moss mantle	0		Mysticality: +10, Meat Drop: +40, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	smelly medical-grade moss mace	0		Stench Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	fortified moss megaphone of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	executive veiny moss medal	0		Maximum HP: +10, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	electrified occult moss mitre	0		Spell Damage Percent: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	executive thinker's moss mantle	0		Mysticality: +10, Meat Drop: +40, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	mirror avaricious groovy moss marlinspike	0		Moxie Percent: +10, Meat Drop: +30, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	dried narrow moss mulch	1		Effect: "Sepia Tan", Effect Duration: 20, Last Available: "2024-12"
 11511	Vulcanized magnetized moss floss	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 21
@@ -11372,33 +11372,33 @@
 11517	squat adobe abaya	0		Last Available: "2024-12"
 11518	dehydrated adobe assortment	1		Last Available: "2024-12"
 11519	warmed adobe brittle	0		Effect: "Notably Lovely", Effect Duration: 15
-11520	fuchsia blurry lard-coated energetic smooth crepe paper phrygian cap	0		Moxie: +15, Maximum MP Percent: +20, Sleaze Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	fuchsia blurry lard-coated energetic smooth crepe paper phrygian cap	0		Moxie: +15, Maximum MP Percent: +20, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	squat Usain Bolt's curative Herculean crepe paper parachute cape	0		Experience (Muscle): +1, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12"
-11522	huge vibrating quilted Rosewater's crepe paper pie clip	0		Mysticality Percent: +30, Damage Absorption: +40, Maximum MP Percent: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	ghostly medical-grade veiny grievous crepe paper puzzle cube	0		Weapon Damage Percent: +50, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	twirling fireproof veiny Newton's crepe paper plunge camisole	0		Experience (Mysticality): +3, Maximum HP: +10, Hot Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	wizardly brainy crepe paper polka charm of temperance	0		Mysticality: 30, Sleaze Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	huge vibrating quilted Rosewater's crepe paper pie clip	0		Mysticality Percent: +30, Damage Absorption: +40, Maximum MP Percent: +10, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	ghostly medical-grade veiny grievous crepe paper puzzle cube	0		Weapon Damage Percent: +50, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	twirling fireproof veiny Newton's crepe paper plunge camisole	0		Experience (Mysticality): +3, Maximum HP: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	wizardly brainy crepe paper polka charm of temperance	0		Mysticality: 30, Sleaze Resistance: +5, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	twisted crepe paper pared cuttings	1		Effect: "Jawin'", Effect Duration: 50, Last Available: "2025-12"
 11527	wet activated triple-warmed wobbly crepe paper peanut candy	0		Effect: "Rushin' Hands", Effect Duration: 48
 11528	squat resourceful Herculean petrified wood war pike	0		Experience (Muscle): +1, Maximum MP: +50, Last Available: "2025-12"
 11529	perfumed energetic petrified wood waist protector	0		Maximum MP Percent: +20, Stench Resistance: +5, Single Equip, Last Available: "2025-12"
-11530	manspreader's hardy petrified wood wizard's pouch	0		Maximum HP: +50, Monster Level: +10, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	quilted petrified wood water purifier of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	manspreader's hardy petrified wood wizard's pouch	0		Maximum HP: +50, Monster Level: +10, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	quilted petrified wood water purifier of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	lime green clever petrified wood whoopie panama of Gandalf	0		Maximum MP: +20, Spell Critical Percent: +20, Last Available: "2025-12"
 11533	purple greasy toasty petrified wood walking pants	0		Hot Damage: +5, Sleaze Spell Damage: +10, Last Available: "2025-12"
 11534	powdered blue pulsating jittery petrified wood waste parts	1		Last Available: "2025-12"
 11535	deionized red petrified wood wafer praline	0		Effect: "Flower Power", Effect Duration: 61
-11536	bad high-proof cybeer	7	decent	Last Available: "2025-12"
+11536	high-proof bad cybeer	7	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	shaking huge wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	huge shaking wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	upside-down pulsating googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	sizzling friendly Crimbuccaneer war standard	0		Familiar Weight: +3, Hot Damage: +10, Last Available: "2023-12"
 11544	Elf Guard war standard of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	veiny spring shoes of wisdom of extreme caution	0		Mysticality: +15, Maximum HP: +10, Monster Level: -25, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	veiny spring shoes of wisdom of extreme caution	0		Mysticality: +15, Maximum HP: +10, Monster Level: -25, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	dry ultra-soft ferns	0		Effect: "Ooh, Sour!", Effect Duration: 16, Last Available: "2024-02"
 11548	vacuum-sealed crunchy brush	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 33, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11407,12 +11407,12 @@
 11552	high-tension exoskeleton	0		
 11553	ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
-11555	blurry skewed quick-release belt pouch	0		Single Equip
+11555	skewed blurry quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
 11557	narrow quick-release utility belt	0		Single Equip
 11558	mirror chilly motion sensor	0		Cold Damage: +5, Single Equip
 11559	focused magnetron pistol	0		Single Equip
-11560	blue mirror packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
+11560	mirror blue packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	twirling wool Everfull Dart Holster of temperance	0		Cold Resistance: +1, Sleaze Resistance: +5, Single Equip, Last Available: "2024-03"
 11562	teal research fragment	0		
 11563	green Thwaitgold wolf spider statuette	0		
@@ -11439,7 +11439,7 @@
 11584	Jim Carey's hale sinister furry yam buckler	0		Spell Damage: +10, Maximum HP: +20, Monster Level: +25, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	upside-down auspicious greasy supercool yamtility belt	0		Moxie Percent: +20, Sleaze Spell Damage: +10, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-05"
-11587	massive adequate enchanted gray yam slider	7	good	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2024-05"
+11587	enchanted massive adequate gray yam slider	7	good	Effect: "Make Meat FA$T!", Effect Duration: 40, Last Available: "2024-05"
 11588	special tasty yam mayo	3	awesome	Effect: "Pill Power", Effect Duration: 5, Last Available: "2024-05"
 11589	tasty yam burrito	3	awesome	Last Available: "2024-05"
 11590	squat visual packet sniffer	0		Last Available: "2025-12"
@@ -11448,20 +11448,20 @@
 11593	wobbly wobbly cyan Thwaitgold Illinigina illinoiensis model	0		
 11594	tasty mini kiwi	3	awesome	Last Available: "2024-06"
 11595	huge wool chilly smartaleck's mini kiwi bikini	0		Moxie Percent: +30, Cold Damage: +5, Cold Resistance: +1, Last Available: "2024-06"
-11596	artisanal watered-down fancy mini kiwitini	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2024-06"
+11596	fancy watered-down artisanal mini kiwitini	2	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	flame-retardant hardened mini kiwi silicon tiepin of the storm	0		Damage Reduction: 3, Maximum MP Percent: +40, Hot Resistance: +1
 11600	mini kiwi tipi	0		
-11601	massive flavorless mini kiwi digitized cookies	9	decent	
-11602	weak lousy mini kiwi intoxicating spirits	2	decent	
+11601	flavorless massive mini kiwi digitized cookies	9	decent	
+11602	lousy weak mini kiwi intoxicating spirits	2	decent	
 11603	boiled cold-filtered irradiated fuchsia mini kiwi antimilitaristic hippy petition	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 41
 11604	irradiated colloidal mini kiwi illicit antibiotic	0		Effect: "Mushroom Moxiousness", Effect Duration: 36
 11605	hardy mini kiwi whipping stick of incineration	0		Maximum HP: +50, Hot Spell Damage: +50
 11606	savvy mini kiwi icepick	0		Mysticality Percent: +20
 11607	cold-filtered ionized mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Human-Demon Hybrid", Effect Duration: 38
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	twirling protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11470,13 +11470,13 @@
 11615	wholesome banded groovy messenger bag RNA	0		Moxie Percent: +10, Damage Absorption: +100, Maximum HP Percent: +10
 11616	flagellate flagon	0		
 11617	shaking proto-proto-protozoa	0		
-11618	fancy decent small twirling bacteria bisque	2	good	Effect: "Jungle Juiced", Effect Duration: 15
-11619	snack-sized special moldy ciliophora chowder	2	crappy	Effect: "Night of the Nachos", Effect Duration: 10
+11618	fancy small decent twirling bacteria bisque	2	good	Effect: "Jungle Juiced", Effect Duration: 15
+11619	moldy special snack-sized ciliophora chowder	2	crappy	Effect: "Night of the Nachos", Effect Duration: 10
 11620	normal cream of chloroplasts	3	good	
 11621	squat synaptic soup	0		
 11622	upside-down muscular soup	0		
 11623	flagellate soup	0		
-11624	jittery blinking elbow soup	0		
+11624	blinking jittery elbow soup	0		
 11625	lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	extra ooze	0		
@@ -11486,7 +11486,7 @@
 11631	baby bodyguard	0		
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
-11634	jittery upside-down green tattoo gun	0		
+11634	jittery green upside-down tattoo gun	0		
 11635	triple-distilled smooth Colera Peste Nebbiolo	7	awesome	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	shaking up-at-dawn Sinatra's bat wings of the cougar	0		Moxie: +20, Experience (Moxie): +5, Adventures: +5, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	shaking up-at-dawn Sinatra's bat wings of the cougar	0		Moxie: +20, Experience (Moxie): +5, Adventures: +5, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	wobbly careful veiny monocle on a stick	0		Maximum HP: +10, Monster Level: -10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	rosy-cheeked Sheriff badge of the boozehound	0		Maximum HP Percent: +30, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	reassuring weightlifter's Sheriff pistol	0		Muscle: +15, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2024-10"
 11670	Newton's Sheriff moustache of the businessman	0		Experience (Mysticality): +3, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	flame-retardant cool photo booth supply list	0		Moxie: +5, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	flame-retardant cool photo booth supply list	0		Moxie: +5, Hot Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	adequate skewed whirled peas	4	good	Last Available: "2024-11"
@@ -11541,11 +11541,11 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	family-friendly Sinatra's deft pirate hook	0		Experience (Moxie): +5, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2024-12"
-11689	upside-down rock-hard dangerous iron tricorn hat	0		Weapon Damage: +10, Damage Reduction: 5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	upside-down rock-hard dangerous iron tricorn hat	0		Weapon Damage: +10, Damage Reduction: 5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	razor-sharp jolly roger flag	0		Weapon Damage Percent: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	practically non-alcoholic bad fancy tankard of spiced rum	1	decent	Effect: "Full of Vinegar", Effect Duration: 5, Last Available: "2024-12"
+11693	fancy practically non-alcoholic bad tankard of spiced rum	1	decent	Effect: "Full of Vinegar", Effect Duration: 5, Last Available: "2024-12"
 11694	bad bouncing tankard of spiced Goldschlepper	3	decent	Last Available: "2024-12"
 11695	maroon wobbly packaged luxury garment	0		Last Available: "2024-12"
 11696	stanky governor's daughter's lace collar	0		Stench Spell Damage: +25, Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	blinking dog trainer's boxer's silky pirate drawers	0		Muscle Percent: +10, Experience (familiar): +1, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	concentrated improved peppermint pegleg	0		Effect: "Scrappy, Shadowy", Effect Duration: 14, Last Available: "2024-12"
-11710	artisanal triple-distilled hard cocoa	7	EPIC	Last Available: "2024-12"
+11710	triple-distilled artisanal hard cocoa	7	EPIC	Last Available: "2024-12"
 11711	massive adequate salmagumdi	10	good	Last Available: "2024-12"
 11712	sizzling plastic Easter Island Bunny	0		Hot Damage: +10, Last Available: "2024-12"
 11713	skewed narrow auspicious plastic St. Patrick	0		Item Drop: +10, Last Available: "2024-12"
@@ -11576,16 +11576,16 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	stale coney haunch	3	decent	Last Available: "2024-12"
 11723	galvanized quadruple-liquefied gray dark chocolate egg	0		Effect: "Cranberry Cordiality", Effect Duration: 30, Last Available: "2024-12"
-11724	irresponsibly strong acceptable fancy moai toai	9	good	Effect: "Rain Dancin'", Effect Duration: 10
+11724	fancy irresponsibly strong acceptable moai toai	9	good	Effect: "Rain Dancin'", Effect Duration: 10
 11725	ghostly cyan scandalous nasty occult moaiball	0		Spell Damage Percent: +25, Stench Damage: +5, Sleaze Damage: +5, Last Available: "2024-12"
 11726	ghostly half-digested rat	0		Last Available: "2024-12"
 11727	pickled chilled four-leaf potato sprout	0		Effect: "Venomous Weapon", Effect Duration: 33, Last Available: "2024-12"
 11728	hardy Sinatra's potato jacket of terror	0		Experience (Moxie): +5, Maximum HP: +50, Spooky Spell Damage: +10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Jim Carey's padded military orb	0		Damage Absorption: +20, Monster Level: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	Jim Carey's padded military orb	0		Damage Absorption: +20, Monster Level: +25, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	super-ionized electrified maroon pulsating rum ball	0		Effect: "Crusty Head", Effect Duration: 52
-11733	skewed lime green gravy skin	0		Last Available: "2024-12"
+11733	lime green skewed gravy skin	0		Last Available: "2024-12"
 11734	perfumed sinister gravyskin hat	0		Spell Damage: +10, Stench Resistance: +5, Last Available: "2024-12"
 11735	censurious gravyskin buckler of the early riser	0		Sleaze Resistance: +3, Adventures: +7, Damage Reduction: 7, Last Available: "2024-12"
 11736	mirror Jim Carey's Lo Pan's gravyskin skirt	0		Spell Critical Percent: +30, Monster Level: +25, Last Available: "2024-12"
@@ -11595,16 +11595,16 @@
 11740	upside-down fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	blurry horrifying personal trainer's perfect Christmas scarf of incineration	0		Experience Percent (Muscle): [+10*event(December)], Hot Spell Damage: [+50*event(December)], Spooky Damage: [+25*event(December)], Single Equip, Last Available: "2024-12"
-11743	blurry snowman-enchanting tophat of temperance of the early riser	0		Sleaze Resistance: +5, Adventures: +7, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	blurry snowman-enchanting tophat of temperance of the early riser	0		Sleaze Resistance: +5, Adventures: +7, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	irradiated LIDAR candle	0		Effect: "Lubed", Effect Duration: 28, Last Available: "2024-12"
 11745	mirror nippy baleful Congressional Medal of Insanity of wisdom	0		Mysticality: +15, Spell Damage: +25, Cold Damage: +10, Last Available: "2024-12"
 11746	blurry pumpkin spice whorl	0		Last Available: "2024-12"
-11747	hand-crafted fortified twirling Easter grasshopper	5	EPIC	Last Available: "2024-12"
+11747	fortified hand-crafted twirling Easter grasshopper	5	EPIC	Last Available: "2024-12"
 11748	acceptable Irish eggnog	4	good	Last Available: "2024-12"
 11749	delicious canteen of jungle juice	3	awesome	Last Available: "2024-12"
 11750	hand-crafted turchucken	3	EPIC	Last Available: "2024-12"
-11751	perfectly mixed irresponsibly strong jittery mechanically-mulled cider	6	EPIC	Last Available: "2024-12"
-11752	weak lousy holiday trip around the world	2	decent	Last Available: "2024-12"
+11751	irresponsibly strong perfectly mixed jittery mechanically-mulled cider	6	EPIC	Last Available: "2024-12"
+11752	lousy weak holiday trip around the world	2	decent	Last Available: "2024-12"
 11753	rotten lime green chocolate ostrich egg	4	crappy	Last Available: "2024-12"
 11754	bland beef and cabbage	3	decent	Last Available: "2024-12"
 11755	half-sized spoiled candy rations	2	crappy	Last Available: "2024-12"
@@ -11613,18 +11613,18 @@
 11758	stale spinning holiday smorgasbord	4	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	frosty bejazzled eyepatch	0		Cold Spell Damage: +10, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	shaking How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	blue How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	blurry Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	ghostly narrow Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	shaking How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	blue How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	blurry Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	ghostly narrow Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	mirror moai statuette	0		Last Available: "2024-12"
-11772	prompt lion tamer's curative baleful egg gun	0		Spell Damage: +25, Experience (familiar): +2, Adventures: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	prompt lion tamer's curative baleful egg gun	0		Spell Damage: +25, Experience (familiar): +2, Adventures: +3, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	blinking frightening resourceful steel-toed army helmet of the scaredy-cat	0		Damage Reduction: 9, Maximum MP: +50, Monster Level: -15, Spooky Damage: +5, Last Available: "2024-12"
 11774	huge blurry candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	magnetized red deviled candy egg	0		Effect: "Thanksgot", Effect Duration: 33, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	hardened McHugeLarge duffel bag of courage	0		Damage Reduction: 3, Spooky Resistance: +3, Last Available: "2025-01"
-11784	huge Annie Oakley's Socratic McHugeLarge left pole of Leguizamo	0		Experience (Mysticality): +1, Critical Hit Percent: +20, Monster Level: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	resourceful Oprah's banded McHugeLarge right pole	0		Damage Absorption: +100, Maximum MP Percent: +50, Maximum MP: +50, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	olive Jeselnik's weightlifter's McHugeLarge left ski	0		Muscle: +15, Sleaze Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	McHugeLarge right ski of the cougar of temperance	0		Moxie: +20, Sleaze Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	huge Annie Oakley's Socratic McHugeLarge left pole of Leguizamo	0		Experience (Mysticality): +1, Critical Hit Percent: +20, Monster Level: +20, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	resourceful Oprah's banded McHugeLarge right pole	0		Damage Absorption: +100, Maximum MP Percent: +50, Maximum MP: +50, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	olive Jeselnik's weightlifter's McHugeLarge left ski	0		Muscle: +15, Sleaze Damage: +25, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	McHugeLarge right ski of the cougar of temperance	0		Moxie: +20, Sleaze Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	wobbly 0	0		Last Available: "2025-12"
 11790	altered eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	pulsating dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	gray retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	gray CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	skewed insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	twirling hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	skewed geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11711,24 +11711,24 @@
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	glover liners	0		Pickpocket Chance: +10
-11859	blurry huge fuchsia mosquito speakers	0		Monster Level: +5
+11859	blurry fuchsia huge mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	twirling Leprecondo	0		Last Available: "2025-03"
 11862	boiled scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	narrow table tennis ball	0		Last Available: "2025-03"
 11864	hand-crafted pint of Leprechaun Stout	3	EPIC	Last Available: "2025-03"
-11865	distilled huge cyan phosphor traces	1		Effect: "Orc Chops", Effect Duration: 25, Last Available: "2025-03"
+11865	distilled cyan huge phosphor traces	1		Effect: "Orc Chops", Effect Duration: 25, Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
-11869	cyan spinning unironic knife	0		
+11869	spinning cyan unironic knife	0		
 11870	fuchsia bar dart	0		Last Available: "2025-03"
 11871	denatured blinking spinning leprechaun antidepressant pill	1		Effect: "Devil Inside", Effect Duration: 20, Last Available: "2025-03"
 11872	spoiled diet Heck ramen	1	crappy	Last Available: "2025-03"
 11873	delicious burrito	3	awesome	Last Available: "2025-03"
-11874	moldy low-calorie small beer brat	1	crappy	Last Available: "2025-03"
+11874	low-calorie moldy small beer brat	1	crappy	Last Available: "2025-03"
 11875	moldy miniature peach pie	2	crappy	Last Available: "2025-03"
-11876	normal snack-sized incredible mini-pizza	2	good	Last Available: "2025-03"
+11876	snack-sized normal incredible mini-pizza	2	good	Last Available: "2025-03"
 11877	perfectly mixed shaking Divine sidecar	3	EPIC	Last Available: "2025-03"
 11878	acceptable tangarita sidecar	4	good	Last Available: "2025-03"
 11879	tolerable gimlet sidecar	3	good	Last Available: "2025-03"
@@ -11741,7 +11741,7 @@
 11886	red spitball	0		Last Available: "2025-04"
 11887	wet modified corrupted twirling gray wet paper weights	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 67, Last Available: "2025-04"
 11888	tolerable Three Sheets to the Wind	4	good	Last Available: "2025-04"
-11889	super-sized decent pile of wet dates	5	good	Last Available: "2025-04"
+11889	decent super-sized pile of wet dates	5	good	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	bouncing wet blanket	0		Last Available: "2025-04"
 11892	toasty wet shower cap	0		Hot Damage: +5, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	stylish stylish bycocket	0		Moxie: +25
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	upside-down flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11797,14 +11797,14 @@
 11942	blinking M&ouml;bius ring	0		Last Available: "2025-08"
 11943	bone pacifier	0		Familiar Weight: +5
 11944	ghostly sizzling hardened Allied Forces insignia of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Hot Damage: +10, Single Equip
-11945	yellow blurry Allied Tattoo Kit	0		
+11945	blurry yellow Allied Tattoo Kit	0		
 11946	handheld Allied radio	0		
 11947	lime green Axis codebook	0		
 11948	dry Life Goals Pamphlet	0		Effect: "Fishy", Effect Duration: 27, Last Available: "2025-08"
 11949	purple foul-smelling bully badge	0		Stench Damage: +10, Lasts Until Rollover, Last Available: "2025-08"
 11950	scorching time cop top hat	0		Hot Damage: +25, Last Available: "2025-08"
 11951	red Stock Certificate	0		Last Available: "2025-08"
-11952	pickled cyan twirling mixed berry jelly	1		Effect: "Cletus's Canticle of Celerity", Effect Duration: 30, Last Available: "2025-08"
+11952	pickled twirling cyan mixed berry jelly	1		Effect: "Cletus's Canticle of Celerity", Effect Duration: 30, Last Available: "2025-08"
 11953	tasty toast with mixed berry jelly	3	awesome	Last Available: "2025-08"
 11954	rotten shaking bouncing cup of sugar	4	crappy	Last Available: "2025-08"
 11955	thick rotten mirror Susie's cupcake	5	crappy	Last Available: "2025-08"
@@ -11814,9 +11814,9 @@
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	supercharged undersea surveying goggles	0		Maximum MP Percent: +30, Lasts Until Rollover
-11963	delicious high-proof fuchsia Ocean-Touched Rum	7	awesome	
-11964	distilled green huge water-logged pill	1		
-11965	tiny moldy kelp puck	1	crappy	
+11963	high-proof delicious fuchsia Ocean-Touched Rum	7	awesome	
+11964	distilled huge green water-logged pill	1		
+11965	moldy tiny kelp puck	1	crappy	
 11966	scroll of sea strength	0		
 11967	blinking scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
@@ -11826,16 +11826,16 @@
 11972	durable dolphin whistle	0		
 11973	shaking Thwaitgold lobster statuette	0		
 11974	blinking packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	skewed unblemished pearl	0		
 11977	ribald dentadent	0		Sleaze Damage: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	Temple Grandin's manspreader's padded grievous experienced blood cubic zirconia of mayonnaise	0		Experience: +2, Weapon Damage Percent: +50, Damage Absorption: +20, Monster Level: +10, Familiar Weight: +7, Sleaze Spell Damage: +50, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	Temple Grandin's manspreader's padded grievous experienced blood cubic zirconia of mayonnaise	0		Experience: +2, Weapon Damage Percent: +50, Damage Absorption: +20, Monster Level: +10, Familiar Weight: +7, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	compressed blood thinner	1		Last Available: "2025-10"
 12045	tolerable pheromone cocktail	3	good	Last Available: "2025-10"
 12046	tasty immense spinal tapas	10	awesome	Last Available: "2025-10"
 12047	olive shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	narrow twirling sharpshooter's energetic savvy shrunken head	0		Mysticality Percent: +20, Maximum MP Percent: +20, Critical Hit Percent: +10, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	narrow twirling sharpshooter's energetic savvy shrunken head	0		Mysticality Percent: +20, Maximum MP Percent: +20, Critical Hit Percent: +10, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	ghostly small peppermint-flavored sugar walking crook	0		
 12051	jittery knucklebone	0		
@@ -11846,7 +11846,7 @@
 12056	practically non-alcoholic artisanal vodka cranberry sauce	1	super ultra mega turbo EPIC	Last Available: "2025-11"
 12057	aerosolized vacuum-sealed yammed candy	0		Effect: "Izchak's Blessing", Effect Duration: 57, Last Available: "2025-11"
 12058	normal shaking treasure chestnut	3	good	Last Available: "2025-12"
-12059	strong bad mulled butter rum	5	decent	Last Available: "2025-12"
+12059	bad strong mulled butter rum	5	decent	Last Available: "2025-12"
 12060	nitrogenated twirling cinnamon doubloon	0		Effect: "Dexteri Tea", Effect Duration: 25, Last Available: "2025-12"
 12061	ghostly groovy plastic left skeleton arm	0		Moxie Percent: +10, Last Available: "2025-12"
 12062	bouncing slick plastic left skeleton leg	0		Moxie: +10, Last Available: "2025-12"
@@ -11862,7 +11862,7 @@
 12072	perfumed angelbone dice	0		Stench Resistance: +5, Single Equip, Last Available: "2026-12"
 12073	mirror steel-toed angelbone halo of the scaredy-cat	0		Damage Reduction: 9, Monster Level: -15, Last Available: "2026-12"
 12074	boiled skewed wobbly angelbone fragments	1		Effect: "Shamboozled", Effect Duration: 45, Last Available: "2026-12"
-12075	activated nitrogenated purple jittery narrow biblically accurate gumdrops	0		Effect: "[800]Chocolate Reign", Effect Duration: 69
+12075	activated nitrogenated jittery purple narrow biblically accurate gumdrops	0		Effect: "[800]Chocolate Reign", Effect Duration: 69
 12076	Annie Oakley's devilbone helmet of vim and vigor	0		Maximum HP Percent: +50, Critical Hit Percent: +20, Last Available: "2026-12"
 12077	devilbone greaves of the detective	0		Item Drop: +20, Last Available: "2026-12"
 12078	blinking upside-down therapeutic devilbone shinguards of the bloodbag	0		Maximum HP: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2026-12"
@@ -11878,18 +11878,18 @@
 12120	tumbling burnt skull	0		Last Available: "2025-12"
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	skewed up-at-dawn extra-thick Crimbo sweater	0		Adventures: +5, Last Available: "2025-12"
-12123	bouncing purple The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	irresponsibly strong lousy special yellow Steve Abrams' Holiday Sampler Beer	6	decent	Effect: "Carol of the Bones", Effect Duration: 15, Last Available: "2025-12"
+12123	purple bouncing The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12124	lousy irresponsibly strong special yellow Steve Abrams' Holiday Sampler Beer	6	decent	Effect: "Carol of the Bones", Effect Duration: 15, Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	drinkable bottle of prize-winning rum	4	good	Last Available: "2025-12"
 12127	chilly shellacked razor-sharp Santa-Slayer medal	0		Weapon Damage Percent: +25, Damage Reduction: 7, Cold Damage: +5, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	flattened tarnished enhanced boiling bone marrow	0		Effect: "Briny Blood", Effect Duration: 12, Last Available: "2025-12"
-12130	deionized olive narrow wobbly boiling cerebrospinal fluid	0		Effect: "Swimming Head", Effect Duration: 15, Last Available: "2025-12"
+12130	deionized narrow olive wobbly boiling cerebrospinal fluid	0		Effect: "Swimming Head", Effect Duration: 15, Last Available: "2025-12"
 12131	ionized polarized cyan boiling synovial fluid	0		Effect: "Concentration", Effect Duration: 55, Last Available: "2025-12"
 12132	upside-down zippy miser's Jim Carey's smoldering vertebra	0		Monster Level: +25, Meat Drop: +10, Initiative: +20, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	wobbly volatile bone bomb	0		Last Available: "2025-12"
 12137	maroon Jack Frost's frosty hot boning knife of the storm	0		Maximum MP Percent: +40, Cold Spell Damage: 60, Single Equip, Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	horrifying Da Vinci's vermiculite shield	0		Experience (Mysticality): +5, Spooky Damage: +25, Damage Reduction: 9, Last Available: "2025-12"
 12169	ship's lantern of the pedagogue	0		Experience: +3, Last Available: "2025-12"
 12170	olive scorching arcane researcher's heat-resistant harpoon pistol	0		Experience Percent (Mysticality): +10, Hot Damage: +25, Last Available: "2025-12"
-12171	big decent blurry traditional gingerloaf	5	good	Last Available: "2025-12"
+12171	decent big blurry traditional gingerloaf	5	good	Last Available: "2025-12"
 12172	weak bad Scotch and eggnog	2	decent	Last Available: "2025-12"
 12173	improved twirling counterskeleton elixir	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 26, Last Available: "2025-12"
 12174	drinkable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	diffused spinning bouncing gummi fingerbone	0		Effect: "So You Can Work More...", Effect Duration: 16
 12179	hardy glimmering crystal of dire peril	0		Weapon Damage: +20, Maximum HP: +50, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	bouncing Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11951,7 +11951,7 @@
 12193	extra-vacuum-sealed Pork Elf mouthwash	0		Effect: "Patent Prevention", Effect Duration: 22, Last Available: "2026-03"
 12194	electrified enhanced pulsating mirror Pork Elf deodorant	0		Effect: "Man's Worst Enemy", Effect Duration: 47, Last Available: "2026-03"
 12195	denatured cold-filtered Pork Elf toothpaste	0		Effect: "Scarysauce", Effect Duration: 23, Last Available: "2026-03"
-12196	narrow pulsating bolt of fabric	0		Last Available: "2026-03"
+12196	pulsating narrow bolt of fabric	0		Last Available: "2026-03"
 12197	yellow electrified MacGyver's and dress	0		Maximum MP: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2026-03"
 12198	frightening and dress of the early riser	0		Spooky Damage: +5, Adventures: +7, Last Available: "2026-03"
 12199	enhanced polymerized ghostly dinosaur bone broth	0		Effect: "Bread Burps", Effect Duration: 41, Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	delicious half-sized fancy shaking rat pizza	2	awesome	Effect: "Yeah, It's Just Gasoline", Effect Duration: 20, Last Available: "2026-03"
+12209	half-sized delicious fancy shaking rat pizza	2	awesome	Effect: "Yeah, It's Just Gasoline", Effect Duration: 20, Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	rosy-cheeked Samson's hoverboard of Gandalf	0		Experience (Muscle): +5, Maximum HP Percent: +30, Spell Critical Percent: +20, Single Equip, Last Available: "2026-03"
 12212	double-paned mansplainer's Fonzie's left shark fin	0		Experience (Moxie): +1, Monster Level: +15, Cold Resistance: +5, Last Available: "2026-03"
@@ -11977,24 +11977,24 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	tumbling legendary noodles	0		Last Available: "2026-05"
-12226	half-sized toothsome can of tuna	2	awesome	
+12226	toothsome half-sized can of tuna	2	awesome	
 12227	normal alien salad	3	good	
 12228	spoiled ratbatatouille	4	crappy	
 12229	delicious cyan onigiri	4	awesome	
-12230	bland tiny crudit&eacute;s	1	decent	
+12230	tiny bland crudit&eacute;s	1	decent	
 12231	diet tasty sauced mutton	1	awesome	
 12232	flavorless hot honey ant	3	decent	
 12233	spoiled skewed tomb aspic	3	crappy	
 12234	immense flavorless yellow later tots	6	decent	
 12235	normal Frutti di Scatoletta	3	good	Last Available: "2026-05"
-12236	flavorless big narrow Pesto alla Marziano	5	decent	Last Available: "2026-05"
-12237	normal tiny Arrattabbattabiata	1	good	Last Available: "2026-05"
-12238	decent bite-sized Orzo di Riso	1	good	Last Available: "2026-05"
+12236	big flavorless narrow Pesto alla Marziano	5	decent	Last Available: "2026-05"
+12237	tiny normal Arrattabbattabiata	1	good	Last Available: "2026-05"
+12238	bite-sized decent Orzo di Riso	1	good	Last Available: "2026-05"
 12239	moldy Pasta Grimavera	3	crappy	Last Available: "2026-05"
 12240	rotten Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
 12241	stale Formica e Pepe	4	decent	Last Available: "2026-05"
 12242	moldy Tubetto Gelatto	4	crappy	Last Available: "2026-05"
-12243	adequate thick maroon pulsating Gnocci Domani	5	good	Last Available: "2026-05"
+12243	thick adequate maroon pulsating Gnocci Domani	5	good	Last Available: "2026-05"
 12244	red Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12017,7 +12017,7 @@
 12267	arcane researcher's flimsy plastic breastplate	0		Experience Percent (Mysticality): +10
 12268	gray Tesla flimsy plastic shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 3
 12269	cyan packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	Lo Pan's veiny personal trainer's Portable Laughing Stock	0		Experience Percent (Muscle): +10, Maximum HP: +10, Spell Critical Percent: +30, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	Lo Pan's veiny personal trainer's Portable Laughing Stock	0		Experience Percent (Muscle): +10, Maximum HP: +10, Spell Critical Percent: +30, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	greedy savvy Staff of Anachronistic Churning of the empath	0		Mysticality Percent: +20, Familiar Weight: +5, Meat Drop: +20
 12272	decent bouncing classic banana	4	good	Last Available: "2026-07"
 12273	delicious jittery watermelon	3	awesome	Last Available: "2026-07"
@@ -12025,7 +12025,7 @@
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	adequate classic banana pie	4	good	Last Available: "2026-07"
-12278	anodized dry blinking yellow essential banana decoction	0		Effect: "Brocolate Brostidigitation", Effect Duration: 20, Last Available: "2026-07"
+12278	anodized dry yellow blinking essential banana decoction	0		Effect: "Brocolate Brostidigitation", Effect Duration: 20, Last Available: "2026-07"
 12279	warmed polymerized purple banana quintessence	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 48, Last Available: "2026-07"
 12280	tolerable Aesop Daiquiri	3	good	Last Available: "2026-07"
 12281	hand-crafted watered-down Monkey Congress	2	super EPIC	Last Available: "2026-07"
@@ -12055,8 +12055,8 @@
 12305	electrified huge invisible hand	0		Effect: "Gunky Dory", Effect Duration: 52, Last Available: "2026-08"
 12306	adjusted circle of overdraft protection scroll	0		Effect: "Slightly Mutated", Effect Duration: 69, Last Available: "2026-08"
 12307	warmed mint	0		Effect: "Uncaged Power", Effect Duration: 57, Last Available: "2026-08"
-12308	mirror narrow savings bondo	0		Last Available: "2026-08"
-12309	blinking green homeowner's loam	0		Last Available: "2026-08"
+12308	narrow mirror savings bondo	0		Last Available: "2026-08"
+12309	green blinking homeowner's loam	0		Last Available: "2026-08"
 12310	diluted tumbling toxic asset	1		Last Available: "2026-08"
 12311	dried pulsating intangible asset	1		Last Available: "2026-08"
 12312	vaporized liquid asset	1		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Pastamancer_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Packrat_cafe_booze.txt
@@ -1,20 +1,20 @@
 -1	perfectly mixed Petite Porter	4	EPIC	
 -2	bad weak upside-down Scrawny Stout	2	decent	
--3	watered-down acceptable narrow Infinitesimal IPA	2	good	
+-3	acceptable watered-down narrow Infinitesimal IPA	2	good	
 -4	lousy eggnogtini	4	decent	
 -5	perfectly mixed mirror candycaine	3	EPIC	
 -6	triple-distilled perfectly mixed braincracker sweet	10	EPIC	
--16	triple-distilled acceptable fermented honey	6	good	
--17	lousy watered-down lime green upside-down moons-shine	2	decent	
+-16	acceptable triple-distilled fermented honey	6	good	
+-17	watered-down lousy upside-down lime green moons-shine	2	decent	
 -18	artisanal gin	4	EPIC	
 -19	perfectly mixed practically non-alcoholic ecto-nog	1	EPIC	
 -20	perfectly mixed boozy hot toady	5	EPIC	
 -21	lousy hot choculate	3	decent	
 -49	artisanal Cyder	4	EPIC	
--50	lousy strong fancy purple bouncing Oil Nog	5	decent	
--51	delicious irresponsibly strong Hi-Octane Peppermint Jet Fuel	7	awesome	
+-50	strong lousy fancy purple bouncing Oil Nog	5	decent	
+-51	irresponsibly strong delicious Hi-Octane Peppermint Jet Fuel	7	awesome	
 -58	lousy irresponsibly strong Grimacider	8	decent	
--59	distilled acceptable Isotope Nog	5	good	
+-59	acceptable distilled Isotope Nog	5	good	
 -60	drinkable pulsating Mutagin 'n' Tonic	4	good	
 -70	lousy Gin and Herring	3	decent	
 -71	artisanal extra-dry blurry Black and Tan and Red All Over	5	EPIC	
@@ -27,7 +27,7 @@
 -84	tolerable weak Desert Island Iced Tea	2	good	
 -88	hand-crafted Crimbo Saketini	3	EPIC	
 -89	mediocre triple-distilled Crimboku Drop	7	decent	
--90	bad weak Flaming Crimbo Log	2	decent	
+-90	weak bad Flaming Crimbo Log	2	decent	
 -107	bad triple-distilled shaking Fortified Eggnog Slurry	10	decent	
 -108	watered-down mediocre bouncing Hot Buttered Rum	2	decent	
 -109	bad Spicy Hot Chocolate	3	decent	

--- a/data/TCRS/TCRS_Pastamancer_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Packrat_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	delicious Peche a la Frog	4	awesome	
--2	snack-sized rotten upside-down As Jus Gezund Heit	2	crappy	
--3	half-sized bland narrow Bouillabaise Coucher Avec Moi	2	decent	
+-2	rotten snack-sized upside-down As Jus Gezund Heit	2	crappy	
+-3	bland half-sized narrow Bouillabaise Coucher Avec Moi	2	decent	
 -7	small decent gumdrop chow mein	2	good	
--8	stale miniature red candy cane pizza	2	decent	
+-8	miniature stale red candy cane pizza	2	decent	
 -9	stale fancy pulsating gingerbread stir-fry	4	decent	
--10	yummy huge fancy twigs and gravel	10	awesome	
+-10	fancy huge yummy twigs and gravel	10	awesome	
 -11	decent maroon shoots and leaves	4	good	
 -12	normal bowl of unidentifiable goo	4	good	
--13	stale teal squat gingerbread massacre	3	decent	
+-13	stale squat teal gingerbread massacre	3	decent	
 -14	toothsome It Came From Beyond Dessert	3	awesome	
 -15	adequate ghostly vampire cake	3	good	
 -52	spoiled special half-sized Soylent Red and Green	2	crappy	
--53	adequate bite-sized Disc-Shaped Nutrition Unit	1	good	
--54	snack-sized decent bouncing Gingerborg Hive	2	good	
+-53	bite-sized adequate Disc-Shaped Nutrition Unit	1	good	
+-54	decent snack-sized bouncing Gingerborg Hive	2	good	
 -61	tasty Candy Cane Surprise	3	awesome	
--62	special delicious blurry ghostly Grimdrop Chow Mein	3	awesome	
+-62	special delicious ghostly blurry Grimdrop Chow Mein	3	awesome	
 -63	bite-sized normal Grimgerbread House	1	good	
 -67	huge bland Caviar Carbonara	6	decent	
--68	gigantic spoiled Halibut Alfredo	6	crappy	
+-68	spoiled gigantic Halibut Alfredo	6	crappy	
 -69	decent Red Herring Velvet Cake	3	good	
--73	adequate big CRIMBCO Reconstituted Gruel	5	good	
+-73	big adequate CRIMBCO Reconstituted Gruel	5	good	
 -74	spoiled New and Improved CRIMBCO Reconstituted Gruel	4	crappy	
 -75	massive rotten pulsating CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	6	crappy	
 -79	bite-sized spoiled Brussels Sprout Stir-Fry	1	crappy	
--80	stale tiny Carrot, Cabbage, and Kale Pizza	1	decent	
+-80	tiny stale Carrot, Cabbage, and Kale Pizza	1	decent	
 -81	rotten Turnip and Rutabaga Pie	3	crappy	
 -85	massive bland Rainbow Spider Fun Roll	8	decent	
--86	bite-sized normal fuchsia Vegas Volcano Lava Roll	1	good	
--87	half-sized tasty lime green Crazy Dragon Shogun Buddha Roll	2	awesome	
--92	diet stale shaking narrow basic hot dog	1	decent	
--93	rotten ghostly jittery savage macho dog	3	crappy	
+-86	normal bite-sized fuchsia Vegas Volcano Lava Roll	1	good	
+-87	tasty half-sized lime green Crazy Dragon Shogun Buddha Roll	2	awesome	
+-92	stale diet narrow shaking basic hot dog	1	decent	
+-93	rotten jittery ghostly savage macho dog	3	crappy	
 -94	stale one with everything	3	decent	
 -95	normal sly dog	4	good	
--96	massive normal special devil dog	9	good	
+-96	special massive normal devil dog	9	good	
 -97	stale half-sized bouncing chilly dog	2	decent	
 -98	half-sized toothsome ghostly ghost dog	2	awesome	
--99	small spoiled junkyard dog	2	crappy	
--100	adequate special gigantic wet dog	9	good	
--101	low-calorie spoiled sleeping dog	1	crappy	
+-99	spoiled small junkyard dog	2	crappy	
+-100	special gigantic adequate wet dog	9	good	
+-101	spoiled low-calorie sleeping dog	1	crappy	
 -102	delicious narrow optimal dog	4	awesome	
 -103	flavorless jittery video games hot dog	4	decent	
 -104	adequate Peppermint Nutrition Block	4	good	
 -105	delicious Gingerbread Nutrition Block	3	awesome	
--106	jumbo spoiled Cinnamon Nutrition Block	5	crappy	
+-106	spoiled jumbo Cinnamon Nutrition Block	5	crappy	

--- a/data/TCRS/TCRS_Pastamancer_Platypus.txt
+++ b/data/TCRS/TCRS_Pastamancer_Platypus.txt
@@ -1,7 +1,7 @@
 1	seal-clubbing club	0		
 2	seal tooth	0		
 3	narrow chaotic helmet turtle	0		Spell Critical Percent: +10, Familiar Effect: "atk, cap 2"
-4	teal tumbling turtle totem	0		
+4	tumbling teal turtle totem	0		
 5	pasta spoon	0		
 6	wholesome ravioli hat	0		Maximum HP Percent: +10, Familiar Effect: "atk, cap 2"
 7	skewed saucepan	0		
@@ -43,7 +43,7 @@
 44	skewed worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	twirling figurine	0		
-47	toothsome snack-sized hot buttered roll	2	awesome	
+47	snack-sized toothsome hot buttered roll	2	awesome	
 48	heart of rock and roll	0		
 49	bland pulsating bowl of cottage cheese	3	decent	
 50	razor-sharp Rock and Roll Legend	0		Weapon Damage Percent: +25, Class: "Accordion Thief", Song Duration: 10
@@ -54,7 +54,7 @@
 55	jaba&ntilde;ero pepper	0		
 56	hot sauce	0		
 57	5-Alarm Saucepan of the boozehound	0		Booze Drop: +100, Class: "Sauceror"
-58	twirling green stone turtle	0		
+58	green twirling stone turtle	0		
 59	slingshot	0		
 60	Mace of the Tortoise of the ox	0		Muscle: +20, Class: "Turtle Tamer"
 61	thick decent fortune cookie	5	good	
@@ -82,13 +82,13 @@
 83	shaft	0		
 84	Orcish meat locker	0		
 85	tumbling unlocked meat locker	0		
-86	spinning blurry key	0		
+86	blurry spinning key	0		
 87	maroon upside-down wobbly meat from yesterday	0		
 88	meat stack	0		
 89	mirror sword hilt	0		
 90	helmet recipe	0		
 91	pants kit	0		
-92	spinning green meatsmithing guide	0		
+92	green spinning meatsmithing guide	0		
 93	vibrating basic meat sword	0		Maximum MP Percent: +10
 94	prompt basic meat pants	0		Adventures: +3, Familiar Effect: "atk, 2xPotato, cap 10"
 95	Annie Oakley's basic meat helmet	0		Critical Hit Percent: +20, Familiar Effect: "sleaze atk, 2xFairy, cap 10"
@@ -116,7 +116,7 @@
 117	Gnollish plunger	0		
 118	spring	0		
 119	sprocket	0		
-120	jittery mirror cog	0		
+120	mirror jittery cog	0		
 121	sprocket assembly	0		
 122	pulsating skewed cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
@@ -158,26 +158,26 @@
 159	wad of dough	0		
 160	red pie crust	0		
 161	normal ghuol egg	4	good	
-162	small adequate ghuol egg quiche	2	good	
+162	adequate small ghuol egg quiche	2	good	
 163	narrow brainy skeleton bone	0		Mysticality: +5
 164	smart skull	0		
 165	upside-down mirror skewer	0		
 166	ghuol ears	0		
-167	flavorless miniature skewed ghuol-ear kabob	2	decent	
+167	miniature flavorless skewed ghuol-ear kabob	2	decent	
 168	blue spinning Jim Carey's bone rattle	0		Monster Level: +25
 169	narrow narrow bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	stale special lihc eye pie	3	decent	Effect: "Sugar, Hello", Effect Duration: 40
+171	special stale lihc eye pie	3	decent	Effect: "Sugar, Hello", Effect Duration: 40
 172	tumbling gnoll lips	0		
-173	pulsating huge taco shell	0		
+173	huge pulsating taco shell	0		
 174	wobbly Gnollish casserole dish	0		
 175	bland uncooked chorizo	3	decent	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	small moldy chorizo taco	2	crappy	
-180	acceptable enchanted weak ice-cold fotie	2	good	Effect: "Prince of Seaside Town", Effect Duration: 20
-181	gray blinking baseball	0		
+179	moldy small chorizo taco	2	crappy	
+180	weak acceptable enchanted ice-cold fotie	2	good	Effect: "Prince of Seaside Town", Effect Duration: 20
+181	blinking gray baseball	0		
 182	batgut	0		
 183	spinning bat wing	0		
 184	briefcase	0		
@@ -195,7 +195,7 @@
 197	shaking rat whisker	0		
 198	rat appendix	0		
 199	flame-wreathed ring	0		Hot Spell Damage: +10
-200	decent massive blurry rat appendix kabob	9	good	
+200	massive decent blurry rat appendix kabob	9	good	
 201	half-sized decent pulsating bat wing kabob	2	good	
 202	flavorless carob chunks	3	decent	
 203	herbs	0		
@@ -220,7 +220,7 @@
 222	spinning phat turquoise bead	0		
 223	phat turquoise bracelet of Calamity Jane	0		Critical Hit Percent: +15
 224	strapping eyepatch	0		Muscle: +5, Familiar Effect: "3xBarrr, cap 6"
-225	stale immense tofu casserole	8	decent	
+225	immense stale tofu casserole	8	decent	
 226	distilled huge can of Red Minotaur	1	good	Effect: "Ponderous Potency", Effect Duration: 30
 227	shaking Jeselnik's Kentucky-fried meat sword	0		Sleaze Damage: +25
 228	Sherlock's Kentucky-fried meat staff	0		Item Drop: +25
@@ -231,42 +231,42 @@
 233	Doc Galaktik's Restorative Balm	0		
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	fuchsia bouncing avaricious banded Bigger Bugfinder Blade	0		Damage Absorption: +100, Meat Drop: +30
-236	jittery teal Queue Du Coq cocktailcrafting kit	0		
-237	weak artisanal fuchsia bottle of gin	2	EPIC	
+236	teal jittery Queue Du Coq cocktailcrafting kit	0		
+237	artisanal weak fuchsia bottle of gin	2	EPIC	
 238	lousy bottle of vodka	3	decent	
 239	Sinatra's sage Orcish baseball cap	0		Mysticality Percent: +10, Experience (Moxie): +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	gray crafty Orcish cargo shorts of James Dean	0		Experience (Moxie): +3, Maximum MP: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	smartaleck's Orcish frat-paddle	0		Moxie Percent: +30
 242	adequate	3	good	
 243	spoiled grapefruit	4	crappy	
-244	super-sized enchanted tasty grapes	5	awesome	Effect: "Cheered Up", Effect Duration: 15
-245	bland huge spinning olive	10	decent	
+244	tasty enchanted super-sized grapes	5	awesome	Effect: "Cheered Up", Effect Duration: 15
+245	huge bland spinning olive	10	decent	
 246	normal half-sized tomato	2	good	
 247	blinking fermenting powder	0		
-248	practically non-alcoholic delicious salty dog	1	awesome	
+248	delicious practically non-alcoholic salty dog	1	awesome	
 249	acceptable bloody mary	3	good	
-250	artisanal watered-down screwdriver	2	EPIC	
-251	bad fuchsia bouncing martini	3	decent	
-252	delicious watered-down squat bloody beer	2	awesome	
+250	watered-down artisanal screwdriver	2	EPIC	
+251	bad bouncing fuchsia martini	3	decent	
+252	watered-down delicious squat bloody beer	2	awesome	
 253	mediocre mirror shot of schnapps	4	decent	
 254	hand-crafted shot of grapefruit schnapps	4	EPIC	
-255	distilled artisanal fine wine	5	EPIC	
-256	fortified delicious shot of tomato schnapps	5	awesome	
+255	artisanal distilled fine wine	5	EPIC	
+256	delicious fortified shot of tomato schnapps	5	awesome	
 257	hand-crafted extra-spicy bloody mary	3	EPIC	
 258	shaking dense meat stack	0		
 259	snake skin	0		
 260	decent White Citadel fries	3	good	
-261	massive stale White Citadel burger	6	decent	
+261	stale massive White Citadel burger	6	decent	
 262	rotten massive piece of wedding cake	10	crappy	
-263	immense stale blurry blue chocolate chips	10	decent	
-264	normal spinning huge chocolate chip cookies	3	good	
+263	stale immense blue blurry chocolate chips	10	decent	
+264	normal huge spinning chocolate chip cookies	3	good	
 265	blurry Jack Frost's satin pants	0		Cold Spell Damage: +50, Familiar Effect: "atk, 2xPotato, cap 10"
 266	aged lightning	3	awesome	
 267	asbestos-lined mullet wig	0		Hot Resistance: +5, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	ruddy meat cowboy hat	0		Maximum HP Percent: +40, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	sword of the brute	0		Muscle Percent: +30
 270	upside-down picket fence	0		
-271	dehydrated wobbly jittery barbell	1		
+271	dehydrated jittery wobbly barbell	1		
 272	pickled skewed blinking concentrated magicalness pill	1		
 273	boiled moxie weed	1		
 274	huge Familiar-Gro&trade; Terrarium	0		
@@ -297,7 +297,7 @@
 299	oxidized spinning pickle-flavored chewing gum	0		Effect: "Permafrosty", Effect Duration: 34
 300	enhanced pressed jaba&ntilde;ero-flavored chewing gum	0		Effect: "Hagg-ard", Effect Duration: 38
 301	wobbly flat dough	0		
-302	low-calorie spoiled special Knob sausage	1	crappy	Effect: "Heart Aflame", Effect Duration: 15
+302	special spoiled low-calorie Knob sausage	1	crappy	Effect: "Heart Aflame", Effect Duration: 15
 303	diet normal Knob mushroom	1	good	
 304	dry noodles	0		
 305	dance instructor's Knob Goblin harem pants	0		Experience Percent (Moxie): +10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -309,18 +309,18 @@
 311	hill of beans	0		
 312	ghostly electrified Knob Goblin visor	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	pulsating groovy Crown of the Goblin King	0		Moxie Percent: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	normal bite-sized jittery bean burrito	1	good	
-315	jumbo yummy bean burrito	5	awesome	
+314	bite-sized normal jittery bean burrito	1	good	
+315	yummy jumbo bean burrito	5	awesome	
 316	bland twirling insanely bean burrito	3	decent	
 317	decent twirling bean burrito	3	good	
-318	thick moldy jittery bean burrito	5	crappy	
+318	moldy thick jittery bean burrito	5	crappy	
 319	decent tumbling insanely bean burrito	3	good	
 320	normal bat haggis	4	good	
 321	flavorless menudo	3	decent	
 322	adequate goat cheese	3	good	
 323	decent wobbly purple plain pizza	3	good	
-324	spoiled big purple sausage pizza	5	crappy	
-325	special rotten miniature goat cheese pizza	2	crappy	Effect: "Human-Hobo Hybrid", Effect Duration: 5
+324	big spoiled purple sausage pizza	5	crappy	
+325	special miniature rotten goat cheese pizza	2	crappy	Effect: "Human-Hobo Hybrid", Effect Duration: 5
 326	toothsome red mushroom pizza	3	awesome	
 327	narrow goat	0		
 328	lousy weak mirror bottle of whiskey	2	decent	
@@ -328,13 +328,13 @@
 330	glass of goat's milk	1	EPIC	
 331	fortified mediocre maroon Canadian	5	decent	
 332	spoiled yellow lemon	3	crappy	
-333	delicious maroon huge tumbling lime	4	awesome	
+333	delicious maroon tumbling huge lime	4	awesome	
 334	skewed padded sabre teeth	0		Damage Absorption: +20
 335	cyan sabre-toothed lime cub	0		
 336	squat consolation ribbon of Flo-Jo	0		Initiative: +100
 337	ol' trophy	0		
 338	red tenderizing hammer	0		
-339	wobbly jittery spinning Cobb's Knob lab key	0		
+339	spinning wobbly jittery Cobb's Knob lab key	0		
 340	quantum shaking Knob Goblin steroids	0		Effect: "Abyssal Tears", Effect Duration: 28
 341	diffused pressed energized red Knob Goblin love potion	0		Effect: "You Know When to Walk Away", Effect Duration: 35
 342	yellow Knob Goblin stink bomb	0		
@@ -402,7 +402,7 @@
 404	acoustic guitarrr of Gandalf	0		Spell Critical Percent: +20
 405	sunken chest	0		
 406	huge pirate pelvis	0		
-407	pulsating blurry green pirate skull	0		
+407	green blurry pulsating pirate skull	0		
 408	shaking pirate skeleton	0		
 409	blurry vial of patchouli oil	0		
 410	purple wobbly educational sk8board	0		Experience: +1
@@ -460,9 +460,9 @@
 462	pixel	0		
 463	narrow pixel	0		
 464	pixel potion	0		
-465	fuchsia ghostly squat pixel potion	0		
+465	ghostly squat fuchsia pixel potion	0		
 466	pixel potion	0		
-467	adequate half-sized pixel pie	2	good	
+467	half-sized adequate pixel pie	2	good	
 468	ruby W	0		
 469	wussiness potion	0		
 470	hand-crafted Imp Ale	4	EPIC	
@@ -498,7 +498,7 @@
 500	Elf Farm Raffle ticket	0		
 501	toothsome Elfin shortbread	4	awesome	
 502	pagoda plans	0		
-503	snack-sized stale skewered cat appendix	2	decent	
+503	stale snack-sized skewered cat appendix	2	decent	
 504	evil arches	0		
 505	lion tamer's supercool gnatwing earring	0		Moxie Percent: +20, Experience (familiar): +2
 506	delicious Hell broth	3	awesome	
@@ -508,7 +508,7 @@
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	spinning huge Sneaky Pete's key lime	0		
-513	stale yellow skewed Boris's key lime pie	4	decent	
+513	stale skewed yellow Boris's key lime pie	4	decent	
 514	spoiled twirling Jarlsberg's key lime pie	3	crappy	
 515	bland yellow Sneaky Pete's key lime pie	3	decent	
 516	olive Hey Deze map	0		
@@ -519,12 +519,12 @@
 521	lion tamer's kickback cookbook	0		Experience (familiar): +2
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	practically non-alcoholic artisanal papaya sling	1	EPIC	
+524	artisanal practically non-alcoholic papaya sling	1	EPIC	
 525	mirror grue egg	0		
 526	skewed Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
-529	upside-down skewed fertilized ghuol egg	0		
+529	skewed upside-down fertilized ghuol egg	0		
 530	concentrated spray paint	0		Effect: "Intimidating Mien", Effect Duration: 67
 531	inspector's special sauce glove	0		Item Drop: +15, Class: "Sauceror", Single Equip
 532	stanky ladle of mystery	0		Stench Spell Damage: +25, Class: "Sauceror"
@@ -534,13 +534,13 @@
 536	spinning dictionary	0		
 537	pr0n legs	0		
 538	deadly f3d0r4	0		Weapon Damage: +5, Familiar Effect: "atk, 1xLep, cap 27"
-539	jittery wobbly lowercase N	0		
+539	wobbly jittery lowercase N	0		
 540	aerosolized irradiated green Tasty Fun Good rice candy	0		Effect: "On the Shoulders of Giants", Effect Duration: 37
 541	rosewater-soaked experienced draggin' ball hat	0		Experience: +2, Stench Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 25"
 542	skewed medical-grade 1337 7r0uZ0RZ of the sweet-tooth	0		Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xPotato, cap 27"
 543	thick adequate Trollhouse cookies	5	good	
 544	rosewater-soaked talons of the ox	0		Muscle: +20, Stench Resistance: +3
-545	decent miniature spinning lime green Spam Witch sammich	2	good	
+545	decent miniature lime green spinning Spam Witch sammich	2	good	
 546	narrow meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -549,7 +549,7 @@
 551	64067 scroll	0		
 552	shaking 64735 scroll	0		
 553	twirling 31337 scroll	0		
-554	low-calorie bland pr0n cocktail	1	decent	
+554	bland low-calorie pr0n cocktail	1	decent	
 555	gravedigger's smelly drywall axe	0		Stench Spell Damage: +10, Spooky Damage: +10
 556	electrified Pine-Fresh air freshener	0		MP Regen Min: 3, MP Regen Max: 5
 557	practically non-alcoholic lousy whiskey and cola	1	decent	
@@ -564,21 +564,21 @@
 566	banded bum cheek	0		Damage Absorption: +100, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	diet delicious Double Bacon Beelzeburger	1	awesome	
-569	adequate half-sized huge Lord of the Flies-sized fries	2	good	
-570	snack-sized decent olive huge Chicken Sandwich	2	good	
+569	half-sized adequate huge Lord of the Flies-sized fries	2	good	
+570	decent snack-sized huge olive Chicken Sandwich	2	good	
 571	Jumbo Dr. Lucifer	1	good	
 572	big rotten twirling Children's Meal of the Damned	5	crappy	
-573	massive delicious noodles	10	awesome	
+573	delicious massive noodles	10	awesome	
 574	flavorless noodles	3	decent	
 575	decent skewed painful penne pasta	3	good	
 576	stale ravioli della hippy	3	decent	
-577	half-sized bland fuchsia pr0n m4nic0tti	2	decent	
+577	bland half-sized fuchsia pr0n m4nic0tti	2	decent	
 578	bland Hell ramen	4	decent	
 579	rotten shaking boring spaghetti	3	crappy	
 580	wobbly sauce of the ages	0		
 581	squat schmancy cheese sauce	0		
 582	blurry Himalayan Hidalgo sauce	0		
-583	enchanted flavorless snack-sized fettucini Inconnu	2	decent	Effect: "Innately Strong", Effect Duration: 40
+583	flavorless enchanted snack-sized fettucini Inconnu	2	decent	Effect: "Innately Strong", Effect Duration: 40
 584	normal spaghetti with Skullheads	3	good	
 585	adequate gnocchetti di Nietzsche	4	good	
 586	green skewed executive lion tamer's ridiculously huge sword	0		Experience (familiar): +2, Meat Drop: +40
@@ -588,7 +588,7 @@
 590	snack-sized decent squat cocoa eggshell fragment	2	good	
 591	wobbly cocoa egg	0		
 592	house	0		
-593	spinning huge phonics down	0		
+593	huge spinning phonics down	0		
 594	huge quilted amulet of extreme plot significance	0		Damage Absorption: +40
 595	scroll of drastic healing	0		
 596	tumbling titanium assault umbrella of the blizzard	0		Cold Spell Damage: +25
@@ -631,10 +631,10 @@
 633	ghostly energetic brainy wolf mask	0		Mysticality: +5, Maximum MP Percent: +20, Familiar Effect: "1xBarrr, HP regen, cap 37"
 634	cool whip	0		
 635	blinking sage paper umbrella	0		Mysticality Percent: +10
-636	huge blinking meat globe	0		
+636	blinking huge meat globe	0		
 637	green toaster	0		
 638	flame-retardant frightening asshat	0		Spooky Damage: +5, Hot Resistance: +1, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	small adequate tumbling abominable snowcone	2	good	
+639	adequate small tumbling abominable snowcone	2	good	
 640	Ent cider	1	EPIC	
 641	tasty toast	4	awesome	
 642	skeleton key	0		
@@ -644,13 +644,13 @@
 646	flavorless thick fruitcake	5	decent	
 647	blinking present	0		Last Available: "2004-11"
 648	ghostly coward's Crimbo sword	0		Monster Level: -20, Last Available: "2004-10"
-649	inspector's Crimbo hat	0		Item Drop: +15, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	rock-hard Crimbo pants	0		Damage Reduction: 5, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	inspector's Crimbo hat	0		Item Drop: +15, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	rock-hard Crimbo pants	0		Damage Reduction: 5, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	deadly exclusive ultra-rare item	0		Weapon Damage: +5
-652	spinning blue quantum egg	0		
+652	blue spinning quantum egg	0		
 653	purple intragalactic rowboat	0		
 654	star	0		
-655	twirling teal line	0		
+655	teal twirling line	0		
 656	upside-down star chart	0		
 657	shaking lime green wizardly star sword	0		Mysticality: +25
 658	gravedigger's star crossbow	0		Spooky Damage: +10
@@ -676,8 +676,8 @@
 678	chest of the Bonerdagon	0		
 679	watered-down artisanal roll in the hay	2	EPIC	
 680	watered-down hand-crafted special slap and tickle	2	EPIC	Effect: "Crud&eacute;", Effect Duration: 45
-681	weak hand-crafted slip 'n' slide	2	EPIC	
-682	tolerable watered-down a sump'm sump'm	2	good	
+681	hand-crafted weak slip 'n' slide	2	EPIC	
+682	watered-down tolerable a sump'm sump'm	2	good	
 683	acceptable lime green horizontal tango	3	good	
 684	artisanal olive pink pony	3	EPIC	
 685	personal trainer's Mr. Shirt of the brazier of temperance	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Sleaze Resistance: +5
@@ -716,7 +716,7 @@
 720	family-friendly ruddy porquoise necklace	0		Maximum HP Percent: +40, Sleaze Resistance: +1, Single Equip
 721	inspector's Temple Grandin's porquoise bracelet	0		Familiar Weight: +7, Item Drop: +15
 722	reassuring porquoise ring of chilblains of temperance	0		Cold Damage: +25, Spooky Resistance: +1, Sleaze Resistance: +5, Single Equip
-723	flavorless fancy twirling Knoll mushroom	3	decent	Effect: "Chorale of Companionship", Effect Duration: 45
+723	fancy flavorless twirling Knoll mushroom	3	decent	Effect: "Chorale of Companionship", Effect Duration: 45
 724	jumbo decent wobbly mushroom	5	good	
 725	one million meat pancakes	0		
 726	ribald huge mirror shard	0		Sleaze Damage: +10
@@ -735,28 +735,28 @@
 739	tambourine bells	0		
 740	tambourine of the wise owl	0		Mysticality: +20
 741	broken skull	0		
-742	delicious massive Knoll shroomkabob	7	awesome	
-743	massive bland mushroom	10	decent	
+742	massive delicious Knoll shroomkabob	7	awesome	
+743	bland massive mushroom	10	decent	
 744	aerosolized galvanized maroon ghostly hair spray	0		Effect: "Category", Effect Duration: 56
 746	stat script	0		
 747	squat Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	decent jumbo warm mushroom	5	good	
+749	jumbo decent warm mushroom	5	good	
 750	decent mushroom quesadilla	3	good	
 751	moldy cool mushroom	3	crappy	
-752	snack-sized tasty cool mushroom casserole	2	awesome	
+752	tasty snack-sized cool mushroom casserole	2	awesome	
 753	adequate massive pointy mushroom	9	good	
-754	bland miniature shaking cream of pointy mushroom soup	2	decent	
+754	miniature bland shaking cream of pointy mushroom soup	2	decent	
 755	moldy mushroom	3	crappy	
-756	rotten small mushroom	2	crappy	
+756	small rotten mushroom	2	crappy	
 757	bland mushroom	4	decent	
 758	stale jittery yellow ghost cucumber	3	decent	
 759	dill	0		
 760	vinegar	0		
 761	upside-down brine	0		
-762	acceptable fancy watered-down purple especially salty dog	2	good	Effect: "Snobby", Effect Duration: 50
+762	acceptable watered-down fancy purple especially salty dog	2	good	Effect: "Snobby", Effect Duration: 50
 763	upside-down ghostly pickling solution	0		
-764	moldy jumbo fancy squat spectral pickle	5	crappy	Effect: "Twinkly Weapon", Effect Duration: 15
+764	jumbo moldy fancy squat spectral pickle	5	crappy	Effect: "Twinkly Weapon", Effect Duration: 15
 765	twirling briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	enhanced skewed cologne of contempt	0		Effect: "Standard Cheer", Effect Duration: 62
@@ -773,13 +773,13 @@
 778	pulsating aromatic support cummerbund	0		Stench Resistance: +1
 779	spinning Mob Penguin cellular phone	0		
 780	upside-down scroll of pasta summoning	0		
-781	enhanced green pulsating mafia aria	0		Effect: "Rain Dancin'", Effect Duration: 24
+781	enhanced pulsating green mafia aria	0		Effect: "Rain Dancin'", Effect Duration: 24
 782	wobbly Mr. Exploiter	0		Last Available: "2009-12"
 783	spinning 'Villa' document	0		
 784	smooth cyan Acqua Del Piatto Merlot	3	awesome	Last Available: "2004-10"
 785	raffle ticket	0		
-786	bland gray squat pulsating strawberry	3	decent	
-787	watered-down acceptable bottle of rum	2	good	
+786	bland squat pulsating gray strawberry	3	decent	
+787	acceptable watered-down bottle of rum	2	good	
 788	hand-crafted strawberry daiquiri	3	EPIC	
 789	artisanal rum and cola	3	EPIC	
 790	mediocre olive grog	4	decent	
@@ -789,21 +789,21 @@
 794	irradiated nitrogenated oil of slipperiness	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 65
 795	mediocre Acque Luride Grezze Cabernet	4	decent	Last Available: "2004-10"
 796	jittery avaricious Annie Oakley's boxer's cement shoes	0		Muscle Percent: +10, Critical Hit Percent: +20, Meat Drop: +30, Last Available: "2004-10"
-797	watered-down hand-crafted rockin' wagon	2	EPIC	
+797	hand-crafted watered-down rockin' wagon	2	EPIC	
 798	lousy ocean motion	4	decent	
 799	weak perfectly mixed blinking fuzzbump	2	EPIC	
 800	yummy poutine	3	awesome	
-801	tasty tiny Knob stir-fry	1	awesome	
+801	tiny tasty Knob stir-fry	1	awesome	
 804	yummy Knoll stir-fry	3	awesome	
 805	flavorless bite-sized twirling stir-fry	1	decent	
 806	spoiled miniature ghostly asparagus stir-fry	2	crappy	
 807	stale olive stir-fry	3	decent	
 808	enchanted bland olive Knob sausage stir-fry	3	decent	Effect: "Unusual Perspective", Effect Duration: 40
-809	bite-sized flavorless bat wing stir-fry	1	decent	
-810	snack-sized spoiled rat appendix stir-fry	2	crappy	
-811	stale bouncing upside-down upside-down tofu stir-fry	4	decent	
-812	decent massive pr0n stir-fry	10	good	
-813	stale bite-sized Knob shells	1	decent	
+809	flavorless bite-sized bat wing stir-fry	1	decent	
+810	spoiled snack-sized rat appendix stir-fry	2	crappy	
+811	stale upside-down bouncing upside-down tofu stir-fry	4	decent	
+812	massive decent pr0n stir-fry	10	good	
+813	bite-sized stale Knob shells	1	decent	
 814	stale massive b&auml;tzle	10	decent	
 815	fancy adequate ratini	3	good	Effect: "Amorphous Cheer", Effect Duration: 45
 816	gigantic rotten Knob stroganoff	6	crappy	
@@ -826,14 +826,14 @@
 833	flame-retardant vorpal blade	0		Hot Resistance: +1
 834	flame-wreathed occult cornuthaum	0		Spell Damage Percent: +25, Hot Spell Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	inspector's ring of aggravate monster	0		Item Drop: +15
-836	low-calorie stale mind flayer corpse	1	decent	
+836	stale low-calorie mind flayer corpse	1	decent	
 837	perfectly mixed Uovo Marcio Shiraz	4	EPIC	Last Available: "2004-10"
 838	bouncing fireproof wholesome Mafia stogie	0		Maximum HP Percent: +10, Hot Resistance: +3, Last Available: "2004-10"
 839	hand-crafted spinning Maiali Sifilitici Pinot Noir	3	super EPIC	Last Available: "2004-10"
 840	Mafia violin case of extreme caution of the boozehound	0		Monster Level: -25, Booze Drop: +100, Last Available: "2004-10"
-841	practically non-alcoholic artisanal tomato daiquiri	1	EPIC	
-842	bad special beertini	4	decent	Effect: "The Q Is Talking To You", Effect Duration: 5
-843	mediocre irresponsibly strong twirling salty slug	9	decent	
+841	artisanal practically non-alcoholic tomato daiquiri	1	EPIC	
+842	special bad beertini	4	decent	Effect: "The Q Is Talking To You", Effect Duration: 5
+843	irresponsibly strong mediocre twirling salty slug	9	decent	
 844	smooth papaya slung	4	awesome	
 845	skewed sharpshooter's MAHI fez	0		Critical Hit Percent: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	maroon heteroerotic frat-paddle	0		
@@ -844,7 +844,7 @@
 852	shaker of salt	0		Familiar Weight: +5
 853	shaking blundarrrbus	0		Familiar Weight: +5
 854	ghostly sucky decal	0		Familiar Weight: +5
-855	shaking bouncing balloon knife	0		Familiar Weight: +5
+855	bouncing shaking balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
 857	moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
@@ -856,7 +856,7 @@
 864	twirling stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
-867	double-deionized twirling fuchsia pine tar	0		Effect: "Jawin'", Effect Duration: 66
+867	double-deionized fuchsia twirling pine tar	0		Effect: "Jawin'", Effect Duration: 66
 869	bouncing forest tears	0		
 870	stanky fetus-smashing club	0		Stench Spell Damage: +25
 871	meatcar model	0		Familiar Weight: +5
@@ -882,17 +882,17 @@
 891	Warehouse 23 bling of horror	0		Spooky Spell Damage: +25
 892	olive knitted Herculean bugbear-smiting sword of the empath	0		Experience (Muscle): +1, Familiar Weight: +5, Cold Resistance: +3
 893	perfectly mixed lumbering jack	4	EPIC	
-894	jittery spinning Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
+894	spinning jittery Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	jittery Sherlock's Ms. Accessory	0		Item Drop: +25, Softcore Only
 896	horrifying crafty Mr. Accessory Jr.	0		Maximum MP: +10, Spooky Damage: +25, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
-898	blinking cyan Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
+898	cyan blinking Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	olive espresso maker	0		Familiar Weight: +5
 902	squat 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	bad Spasmi Dolorosi Del Rene Champagne	3	decent	Last Available: "2004-10"
-904	narrow horrifying coward's school Mafia knickerbockers of extreme caution	0		Monster Level: -45, Spooky Damage: +25, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	narrow horrifying coward's school Mafia knickerbockers of extreme caution	0		Monster Level: -45, Spooky Damage: +25, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	deionized chilled jittery Yummy Tummy bean	0		Effect: "Prideful Strut", Effect Duration: 31
 906	cold-filtered double-frozen Rock Pops	0		Effect: "Permanent Halloween", Effect Duration: 12
 907	non-anodized irradiated alkaline Mr. Mediocrebar	0		Effect: "Heart of Yellow", Effect Duration: 56
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	nasty intergalactic pom poms of the sweet-tooth	0		Stench Damage: +5, Candy Drop: +100
 917	Mob Penguin protection contract	0		
-918	brainy Radio Free Baseball Cap	0		Mysticality: +5, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	mirror dance instructor's Radio Free Pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	brainy Radio Free Baseball Cap	0		Mysticality: +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	mirror dance instructor's Radio Free Pants	0		Experience Percent (Moxie): +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	wholesome Radio Free Foil	0		Maximum HP Percent: +10, Last Available: "2006-07"
 921	adequate narrow radio button candy	3	good	
 922	severed rocking horse head of the sewer	0		Stench Damage: +25
@@ -915,11 +915,11 @@
 924	huge crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	teal dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	alkaline Hawking's Elixir of Brilliance	0		Effect: "Slightly Larger Than Usual", Effect Duration: 57
-927	mediocre boozy Ferita Del Petto Zinfandel	5	decent	Last Available: "2006-12"
+927	boozy mediocre Ferita Del Petto Zinfandel	5	decent	Last Available: "2006-12"
 928	fireproof fuzzy bracelets	0		Hot Resistance: +3
 929	forbidden arse-shooting crossbow	0		Spell Damage Percent: +50
 931	acceptable spiced rum	3	good	
-932	irresponsibly strong tolerable eggnog	9	good	
+932	tolerable irresponsibly strong eggnog	9	good	
 933	miniature flavorless candy cane	2	decent	
 934	normal wobbly blinking gingerbread bugbear	3	good	
 935	baleful imitation nice watch	0		Spell Damage: +25, Single Equip, Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	olive small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	ghostly Crimbo stocking	0		Last Available: "2004-12"
-942	fireproof bowler	0		Hot Resistance: +3, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	fireproof bowler	0		Hot Resistance: +3, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	prompt ruddy bow staff	0		Maximum HP Percent: +40, Adventures: +3, Last Available: "2004-12"
-944	Tesla bowlegged pants	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	Tesla bowlegged pants	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	tumbling skewered jumbo olive	0		Last Available: "2004-12"
 946	skewed skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -945,7 +945,7 @@
 955	fez of etymology of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xLep, cap 30"
 956	spoiled miniature blurry carob chunk noodles	2	crappy	
 957	moldy chorizo brownies	4	crappy	
-958	enchanted flavorless wobbly chocolate and tomato pizza	3	decent	Effect: "Meat the Flintstones", Effect Duration: 10
+958	flavorless enchanted wobbly chocolate and tomato pizza	3	decent	Effect: "Meat the Flintstones", Effect Duration: 10
 959	fuchsia flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -989,26 +989,26 @@
 1002	savvy Xlyinia's notebook	0		Mysticality Percent: +20
 1003	soda water	0		
 1004	delicious bottle of tequila	3	awesome	
-1005	special artisanal mirror boxed wine	4	EPIC	Effect: "Yeah, It's Just Gasoline", Effect Duration: 15
+1005	artisanal special mirror boxed wine	4	EPIC	Effect: "Yeah, It's Just Gasoline", Effect Duration: 15
 1006	spoiled twirling cherry	3	crappy	
 1007	weightlifter's coconut shell	0		Muscle: +15, Familiar Effect: "1xFairy, cap 7"
 1008	upside-down Sherlock's ice cubes	0		Item Drop: +25
 1009	aged narrow vodka martini	4	awesome	
 1010	artisanal watered-down lime green whiskey and soda	2	EPIC	
-1011	practically non-alcoholic artisanal lime green monkey wrench	1	EPIC	
-1012	triple-distilled delicious blinking tequila sunrise	7	awesome	
+1011	artisanal practically non-alcoholic lime green monkey wrench	1	EPIC	
+1012	delicious triple-distilled blinking tequila sunrise	7	awesome	
 1013	smooth skewed margarita	4	awesome	
 1014	acceptable weak purple strawberry wine	2	good	
-1015	practically non-alcoholic drinkable wine spritzer	1	good	
+1015	drinkable practically non-alcoholic wine spritzer	1	good	
 1016	delicious perpendicular hula	3	awesome	
 1017	drinkable spinning ducha de oro	4	good	
 1018	artisanal calle de miel	4	EPIC	
-1019	hand-crafted weak mirror dry vodka martini	2	EPIC	
-1020	watered-down mediocre old-fashioned	2	decent	
-1021	high-proof artisanal blurry tequila with training wheels	8	EPIC	
+1019	weak hand-crafted mirror dry vodka martini	2	EPIC	
+1020	mediocre watered-down old-fashioned	2	decent	
+1021	artisanal high-proof blurry tequila with training wheels	8	EPIC	
 1022	lousy sangria	3	decent	
 1023	hand-crafted vesper	4	EPIC	Last Available: "2004-12"
-1024	weak perfectly mixed huge bodyslam	2	super ultra mega turbo EPIC	Last Available: "2004-12"
+1024	perfectly mixed weak huge bodyslam	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1025	extra-dry bad skewed sangria del diablo	5	decent	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	jittery whip kit	0		
@@ -1029,7 +1029,7 @@
 1043	mirror stiffened string of beads	0		Damage Reduction: 1
 1044	squat ruddy string of beads	0		Maximum HP Percent: +40
 1045	electrified plastic bottle opener	0		MP Regen Min: 3, MP Regen Max: 5
-1046	smooth traffic cone of the sewer	0		Moxie: +15, Stench Damage: +25, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	smooth traffic cone of the sewer	0		Moxie: +15, Stench Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	perfectly mixed N. O. Beer	3	EPIC	
 1048	pickled oyster egg	1		Effect: "Perception", Effect Duration: 40
 1049	distilled red oyster egg	1		
@@ -1043,8 +1043,8 @@
 1057	dried blurry jittery puce oyster egg	1		Effect: "Cautious Prowl", Effect Duration: 35
 1058	diluted mirror puce oyster egg	1		Effect: "Putting the Pro in Proletariat", Effect Duration: 20
 1059	puce plastic oyster egg	0		
-1060	distilled blinking ghostly green mauve oyster egg	1		
-1061	boiled tumbling upside-down mauve oyster egg	1		Effect: "Greedy Resolve", Effect Duration: 40
+1060	distilled green blinking ghostly mauve oyster egg	1		
+1061	boiled upside-down tumbling mauve oyster egg	1		Effect: "Greedy Resolve", Effect Duration: 40
 1062	distilled olive mauve oyster egg	1		
 1063	twirling mauve plastic oyster egg	0		
 1064	twisted oyster egg	1		
@@ -1054,7 +1054,7 @@
 1068	vaporized oyster egg	1		
 1069	dried oyster egg	1		
 1070	boiled maroon oyster egg	1		
-1071	twirling pulsating plastic oyster egg	0		
+1071	pulsating twirling plastic oyster egg	0		
 1072	diluted ghostly off-white oyster egg	1		Effect: "Briny Blood", Effect Duration: 15
 1073	modified off-white oyster egg	1		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 10
 1074	vaporized blue off-white oyster egg	1		
@@ -1075,7 +1075,7 @@
 1089	lime green clockwork spine	0		
 1090	upside-down clockwork rings	0		
 1091	pulsating clockwork claws	0		
-1092	tumbling blue clockwork sheet	0		
+1092	blue tumbling clockwork sheet	0		
 1093	clockwork counterclockwise dome	0		
 1094	clockwork sphere	0		
 1095	deactivated MicroMechaMech	0		
@@ -1124,27 +1124,27 @@
 1138	upside-down mushroom fermenting solution	0		
 1139	tolerable mushroom wine	4	good	
 1140	aged squat icy mushroom wine	3	awesome	
-1141	extra-dry artisanal mushroom wine	5	EPIC	
+1141	artisanal extra-dry mushroom wine	5	EPIC	
 1142	mediocre pointy mushroom wine	4	decent	
 1143	drinkable wobbly flat mushroom wine	4	good	
 1144	smooth jittery cool mushroom wine	4	awesome	
 1145	weak artisanal knob mushroom wine	2	EPIC	
 1146	mediocre triple-distilled mirror knoll mushroom wine	7	decent	
 1147	acceptable blurry mushroom wine	4	good	
-1148	mediocre boozy shot of flower schnapps	5	decent	
+1148	boozy mediocre shot of flower schnapps	5	decent	
 1149	adequate flower petal pie	3	good	
 1150	acceptable bottle of single-barrel whiskey	3	good	
 1151	mirror Temple Grandin's discarded plastic fork of the dark arts	0		Spell Damage Percent: +100, Familiar Weight: +7
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	delicious special Retenez L'Herbe Pat&eacute;	3	awesome	Effect: "Gobliny Flavor", Effect Duration: 10
-1154	distilled jittery narrow blurry Breathetastic&trade; Premium Canned Air	1	awesome	Effect: "Flexibili Tea", Effect Duration: 10
+1154	distilled jittery blurry narrow Breathetastic&trade; Premium Canned Air	1	awesome	Effect: "Flexibili Tea", Effect Duration: 10
 1155	blue letter from King Ralph XI	0		
 1157	stiffened wholeberd	0		Damage Reduction: 1
 1158	nitrogenated aerosolized pulsating shaking Meleegra&trade; pills	0		Effect: "Towering Strength", Effect Duration: 29
 1159	green mariachi G-string	0		
 1160	irate sombrero of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	twirling pile of candy	0		
-1162	cold-filtered wobbly gray handsomeness potion	0		Effect: "Sepia Tan", Effect Duration: 47
+1162	cold-filtered gray wobbly handsomeness potion	0		Effect: "Sepia Tan", Effect Duration: 47
 1163	extra-aerosolized diffused pulsating red marzipan skull	0		Effect: "Radiated and Grodiated", Effect Duration: 50
 1164	huge poultrygeist	0		
 1165	hovering sombrero	0		
@@ -1175,7 +1175,7 @@
 1190	bouncing dodecapede	0		
 1191	yellow ghuol whelp	0		
 1192	zmobie	0		
-1193	shaking skewed purple Raggedy Hippy doll	0		
+1193	skewed purple shaking Raggedy Hippy doll	0		
 1194	stab bat	0		
 1195	apathetic lizardman doll	0		
 1196	yeti	0		
@@ -1186,17 +1186,17 @@
 1201	rotten ghostly urinal cake	4	crappy	
 1202	adequate Happy Birthday, Claude! cake	4	good	
 1203	gigantic toothsome cyan personalized birthday cake	6	awesome	
-1204	gigantic tasty three-tiered wedding cake	7	awesome	
-1205	jumbo yummy babycakes	5	awesome	
+1204	tasty gigantic three-tiered wedding cake	7	awesome	
+1205	yummy jumbo babycakes	5	awesome	
 1206	special spoiled tiny shaking velvet cake	1	crappy	Effect: "Weather, Man", Effect Duration: 40
 1207	tasty twirling congratulatory cake	3	awesome	
 1208	small bland angel-food cake	2	decent	
 1209	half-sized rotten cyan tumbling devil's-food cake	2	crappy	
-1210	flavorless huge birthday party jellybean cheesecake	7	decent	
+1210	huge flavorless birthday party jellybean cheesecake	7	decent	
 1211	blinking balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
-1214	squat blue anniversary balloon	0		
+1214	blue squat anniversary balloon	0		
 1215	purple Mylar balloon	0		
 1216	Kevlar balloon	0		
 1217	mirror thought balloon	0		
@@ -1232,22 +1232,22 @@
 1248	lightning-fast smelly shellacked Bonerdagon necklace	0		Damage Reduction: 7, Stench Spell Damage: +10, Initiative: +40
 1249	Boss Bat britches of doom	0		Spooky Spell Damage: +50, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	strapping Boss Bat bling of the scaredy-cat	0		Muscle: +5, Monster Level: -15
-1251	delicious bite-sized Knob shroomkabob	1	awesome	
+1251	bite-sized delicious Knob shroomkabob	1	awesome	
 1252	toothsome small spinning shroomkabob	2	awesome	
 1253	lime green pile of jumping beans	0		
 1254	small yummy jumping bean burrito	2	awesome	
 1255	toothsome jumping bean burrito	3	awesome	
 1256	normal insanely jumping bean burrito	4	good	
-1257	snack-sized decent rat scrapple	2	good	
+1257	decent snack-sized rat scrapple	2	good	
 1258	pail of pretentious paint	0		
-1259	sizzling Tesla traffic cone	0		Hot Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	sizzling Tesla traffic cone	0		Hot Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	dehydrated Hatorade	1		Effect: "Stickler for Promptness", Effect Duration: 20
 1262	skewed prompt lightning-fast resourceful off-hand balloon	0		Maximum MP: +50, Initiative: +40, Adventures: +3
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	tiny flavorless blue gloomy mushroom	1	decent	
+1266	flavorless tiny blue gloomy mushroom	1	decent	
 1267	dead mimic	0		
 1268	bouncing pine wand	0		
 1269	ebony wand	0		
@@ -1287,7 +1287,7 @@
 1303	bouncing Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	shaking careful energetic traffic cone	0		Maximum MP Percent: +20, Monster Level: -10, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	shaking careful energetic traffic cone	0		Maximum MP Percent: +20, Monster Level: -10, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	pulsating yellow calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	delicious big skewed questionable taco	5	awesome	
 1321	twirling Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	wobbly deadly time helmet	0		Weapon Damage: +5, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	gray sharpshooter's time trousers	0		Critical Hit Percent: +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	wobbly deadly time helmet	0		Weapon Damage: +5, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	gray sharpshooter's time trousers	0		Critical Hit Percent: +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	dog trainer's time sword	0		Experience (familiar): +1, Last Available: "2005-10"
 1326	Sinatra's Dyspepsi-Cola helmet	0		Experience (Moxie): +5, Familiar Effect: "3xFairy, cap 7"
 1327	jittery avaricious Cloaca-Cola shield	0		Meat Drop: +30, Damage Reduction: 4
@@ -1313,7 +1313,7 @@
 1329	blurry dangerous Dyspepsi-Cola shield	0		Weapon Damage: +10, Damage Reduction: 4
 1330	shaking Dyspepsi-Cola fatigues of the wise owl	0		Mysticality: +20, Familiar Effect: "3.5xPotato, 3xVolley, cap 7"
 1331	forbidden Cloaca-Cola helmet	0		Spell Damage Percent: +50, Familiar Effect: "3xFairy, cap 7"
-1332	red upside-down Cloaca-Cola knapsack	0		
+1332	upside-down red Cloaca-Cola knapsack	0		
 1333	ghostly Dyspepsi-Cola knapsack	0		
 1334	Cloaca-Cola	0		
 1335	Dyspepsi grenade	0		
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	thick decent bowl of oriole's nest soup	5	good	
 1356	blinking bunny liver	0		
-1357	acceptable practically non-alcoholic enchanted tumbling Mt. Noob Pale Ale	1	good	Effect: "Inner Dog", Effect Duration: 20
+1357	practically non-alcoholic acceptable enchanted tumbling Mt. Noob Pale Ale	1	good	Effect: "Inner Dog", Effect Duration: 20
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	twirling pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,10 +1346,10 @@
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	moldy tofurkey leg	4	crappy	
-1366	moldy thick tofurkey gravy	5	crappy	
+1366	thick moldy tofurkey gravy	5	crappy	
 1367	adequate herbal stuffing	3	good	
 1368	stale can-shaped gelatinous cranberry sauce	4	decent	
-1369	spoiled enchanted ghostly spinning yams	3	crappy	Effect: "Tingly Elbows", Effect Duration: 15
+1369	spoiled enchanted spinning ghostly yams	3	crappy	Effect: "Tingly Elbows", Effect Duration: 15
 1370	rhinestone cowboy shirt of the sweet-tooth	0		Candy Drop: +100
 1371	razor-sharp gingham blouse	0		Weapon Damage Percent: +25
 1372	ghostly savvy souvenir ski t-shirt	0		Mysticality Percent: +20
@@ -1367,7 +1367,7 @@
 1385	blue stuffing	0		
 1386	felt	0		
 1387	gray block	0		
-1388	wobbly narrow toy wheel	0		
+1388	narrow wobbly toy wheel	0		
 1389	spinning yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
@@ -1384,14 +1384,14 @@
 1402	Jeselnik's rag doll	0		Sleaze Damage: +25, Last Available: "2005-12"
 1403	twirling miser's can of fake snow	0		Meat Drop: +10, Last Available: "2005-12"
 1404	greedy colored-light &quot;necklace&quot;	0		Meat Drop: +20, Last Available: "2005-12"
-1405	strapping tree skirt	0		Muscle: +5, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	strapping tree skirt	0		Muscle: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	rotten wreath-shaped Crimbo cookie	3	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	flavorless bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	stale narrow tree-shaped Crimbo cookie	4	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	maroon slick Unionize The Elves sign	0		Moxie: +10, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
-1412	cold-filtered improved blinking red snowcone	0		Effect: "Red-Shirted Escort", Effect Duration: 50, Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1412	cold-filtered improved red blinking snowcone	0		Effect: "Red-Shirted Escort", Effect Duration: 50, Last Available: "2006-01"
 1413	enhanced oxidized snowcone	0		Effect: "Surreally Buff", Effect Duration: 35, Last Available: "2006-01"
 1414	energized skewed snowcone	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 27, Last Available: "2006-01"
 1415	polymerized snowcone	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 55, Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	ionized snowcone	0		Effect: "Twinkly Weapon", Effect Duration: 59, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	coward's Jim Carey's traffic cone	0		Monster Level: 5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	coward's Jim Carey's traffic cone	0		Monster Level: 5, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	flame-wreathed ice sickle of the bloodbag	0		Maximum HP: +100, Hot Spell Damage: +10, Softcore Only, Last Available: "2006-02"
 1425	jittery ice baby of James Dean	0		Experience (Moxie): +3, Softcore Only, Last Available: "2006-02"
-1426	teal jittery flame-retardant ice pick	0		Hot Resistance: +1, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	teal jittery flame-retardant ice pick	0		Hot Resistance: +1, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	vibrating ice skates of the brazier	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	half-sized normal grue egg omelette	2	good	
 1429	yellow bouncing roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	big rotten red mushroom	5	crappy	
+1432	rotten big red mushroom	5	crappy	
 1433	fruit bowl	0		
 1434	upside-down fruit basket	0		
 1435	mirror hot pink lipstick	0		Familiar Weight: +5
@@ -1429,7 +1429,7 @@
 1447	unsweetened nuggets	0		Effect: "Ancestral Disapproval", Effect Duration: 60
 1448	super-colloidal super-moist fuchsia stench nuggets	0		Effect: "Old Time Hydration", Effect Duration: 62
 1449	frozen lime green sleaze nuggets	0		Effect: "Dancing Prowess", Effect Duration: 22
-1450	boiled mirror skewed twinkly wad	1		Effect: "damage.enh", Effect Duration: 15
+1450	boiled skewed mirror twinkly wad	1		Effect: "damage.enh", Effect Duration: 15
 1451	altered narrow hot wad	1		
 1452	powdered skewed wad	1		
 1453	compressed squat wad	1		Effect: "Memory of Resilience", Effect Duration: 40
@@ -1450,17 +1450,17 @@
 1468	two-handed depthsword	0		
 1469	bill bec-de-bardiche glaive-guisarme	0		
 1470	lead yo-yo	0		
-1471	shaking squat slightly peevedbow	0		
+1471	squat shaking slightly peevedbow	0		
 1472	sack of doorknobs	0		
 1473	ball-and-chain	0		
-1474	maroon blurry automatic catapult	0		
+1474	blurry maroon automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	narrow goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	huge plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	teal football helmet	0		Familiar Effect: "atk, cap 37"
 1480	purple chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
-1481	ghostly narrow union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
+1481	narrow ghostly union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
@@ -1474,10 +1474,10 @@
 1492	stanky ninja mop	0		Stench Spell Damage: +25
 1493	Lo Pan's ridiculously overelaborate ninja weapon of the sweet-tooth	0		Spell Critical Percent: +30, Candy Drop: +100
 1494	irradiated electrified shaking sugar-coated pine cone	0		Effect: "Inscrutable exoskeleton", Effect Duration: 13, Last Available: "2020-09"
-1495	ruddy traffic cone of the cheetah	0		Maximum HP Percent: +40, Initiative: +60, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	ruddy traffic cone of the cheetah	0		Maximum HP Percent: +40, Initiative: +60, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	tolerable gloomy mushroom wine	4	good	
 1497	hand-crafted watered-down mushroom wine	2	super EPIC	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	extra-concentrated flattened squat explosion-flavored chewing gum	0		Effect: "Fire Inside", Effect Duration: 60, Last Available: "2006-04"
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	gray joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	shaking diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Annie Oakley's cool corkscrew	0		Moxie: +5, Critical Hit Percent: +20, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	tumbling fake plastic grass	0		Last Available: "2011-01"
-1531	grass skirt of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	grass hat of Leguizamo	0		Monster Level: +20, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	grass skirt of incineration	0		Hot Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	grass hat of Leguizamo	0		Monster Level: +20, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	tumbling green Tesla grass blade	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-01"
 1534	red raffle prize box	0		
 1536	teal homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	ghostly sparkly engagement ring of the sweet-tooth	0		Candy Drop: +100, Single Equip
-1539	huge tumbling tumbling Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	miser's Rosewater's Grimacite goggles	0		Mysticality Percent: +30, Meat Drop: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1539	tumbling tumbling huge Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
+1540	miser's Rosewater's Grimacite goggles	0		Mysticality Percent: +30, Meat Drop: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	yellow double-paned Jeselnik's Grimacite glaive	0		Sleaze Damage: +25, Cold Resistance: +5, Last Available: "2008-10"
-1542	Grimacite greaves of Calamity Jane of the boozehound	0		Critical Hit Percent: +15, Booze Drop: +100, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	Grimacite greaves of Calamity Jane of the boozehound	0		Critical Hit Percent: +15, Booze Drop: +100, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	Sherlock's flame-retardant Grimacite garter	0		Hot Resistance: +1, Item Drop: +25, Last Available: "2008-10"
 1544	Sinatra's Grimacite galoshes of temperance	0		Experience (Moxie): +5, Sleaze Resistance: +5, Last Available: "2008-10"
 1545	Socratic Grimacite gorget of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Last Available: "2008-10"
@@ -1530,57 +1530,57 @@
 1550	lard-coated second-hand knockoff engagement ring	0		Sleaze Spell Damage: +25, Single Equip
 1551	mediocre bottle of Domesticated Turkey	3	decent	
 1552	boozy tolerable bottle of Definit	5	good	
-1553	practically non-alcoholic tolerable fancy maroon bottle of Calcutta Emerald	1	good	Effect: "Hypercubed", Effect Duration: 45
+1553	fancy tolerable practically non-alcoholic maroon bottle of Calcutta Emerald	1	good	Effect: "Hypercubed", Effect Duration: 45
 1554	practically non-alcoholic mediocre bottle of Lieutenant Freeman	1	decent	
 1555	special bad bottle of Jorge Sinsonte	3	decent	Effect: "Night of the Nachos", Effect Duration: 5
-1556	aged practically non-alcoholic boxed champagne	1	awesome	
-1557	spoiled big ghostly kumquat	5	crappy	
+1556	practically non-alcoholic aged boxed champagne	1	awesome	
+1557	big spoiled ghostly kumquat	5	crappy	
 1558	moldy half-sized huge tangerine	2	crappy	
-1559	shaking blurry tonic water	0		
-1560	normal special bite-sized cocktail onion	1	good	Effect: "Gamer Rage", Effect Duration: 5
+1559	blurry shaking tonic water	0		
+1560	special normal bite-sized cocktail onion	1	good	Effect: "Gamer Rage", Effect Duration: 5
 1561	huge normal tumbling raspberry	7	good	
 1562	immense yummy kiwi	10	awesome	
-1563	weak tolerable maroon whiskey bittersweet	2	good	
+1563	tolerable weak maroon whiskey bittersweet	2	good	
 1564	practically non-alcoholic mediocre green mimosette	1	decent	
 1565	mediocre tequila sunset	4	decent	
 1566	artisanal bouncing zmobie	4	EPIC	Wiki Name: "Zmobie (drink)"
 1567	strong hand-crafted cyan gin and tonic	5	EPIC	
 1568	mediocre skewed vodka and tonic	4	decent	
-1569	practically non-alcoholic bad vodka gibson	1	decent	
+1569	bad practically non-alcoholic vodka gibson	1	decent	
 1570	perfectly mixed wobbly gibson	3	EPIC	
 1571	watered-down perfectly mixed mirror parisian cathouse	2	EPIC	
 1572	artisanal rabbit punch	3	EPIC	
 1573	bad caipifruta	4	decent	
 1574	mediocre weak teqiwila	2	decent	
-1575	lousy weak Divine	2	decent	
+1575	weak lousy Divine	2	decent	
 1576	artisanal practically non-alcoholic pulsating Gordon Bennett	1	super ultra mega turbo EPIC	
 1577	weak tolerable squat tangarita	2	good	
 1578	smooth skewed mandarina colada	3	awesome	
-1579	bad enchanted yellow gimlet	3	decent	Effect: "Arabian Knighthood", Effect Duration: 30
+1579	enchanted bad yellow gimlet	3	decent	Effect: "Arabian Knighthood", Effect Duration: 30
 1580	high-proof acceptable brick road	9	good	
-1581	distilled hand-crafted blue narrow vodka stratocaster	5	EPIC	
+1581	distilled hand-crafted narrow blue vodka stratocaster	5	EPIC	
 1582	lousy Neuromancer	3	decent	
 1583	practically non-alcoholic hand-crafted prussian cathouse	1	super ultra mega turbo EPIC	
-1584	watered-down smooth Mae West	2	awesome	
+1584	smooth watered-down Mae West	2	awesome	
 1585	watered-down acceptable Mon Tiki	2	good	
 1586	perfectly mixed teqiwila slammer	4	EPIC	
 1587	moldy Knob lo mein	4	crappy	
 1588	stale asparagus lo mein	3	decent	
 1589	normal wobbly Knoll lo mein	3	good	
 1590	gigantic flavorless blurry lo mein	7	decent	
-1591	spoiled small ghostly olive lo mein	2	crappy	
+1591	small spoiled ghostly olive lo mein	2	crappy	
 1592	bland miniature green skewed hot hi mein	2	decent	
 1593	stale yellow hi mein	3	decent	
-1594	bite-sized toothsome hi mein	1	awesome	
-1595	half-sized spoiled hi mein	2	crappy	
+1594	toothsome bite-sized hi mein	1	awesome	
+1595	spoiled half-sized hi mein	2	crappy	
 1596	adequate sleazy hi mein	3	good	
 1597	squat wholesome Junior LAAAAME merit badge	0		Maximum HP Percent: +10, Last Available: "2006-05"
 1598	upside-down Senior LAAAAME merit badge of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2006-05"
 1599	lime green jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	special irresponsibly strong drinkable tangarita with a fly in it	7	good	Effect: "Meadulla Oblongota", Effect Duration: 10
+1600	irresponsibly strong special drinkable tangarita with a fly in it	7	good	Effect: "Meadulla Oblongota", Effect Duration: 10
 1601	lousy narrow mandarina colada with a fly in it	3	decent	
 1602	artisanal prussian cathouse with a fly in it	3	EPIC	
-1603	weak bad Mae West with a fly in it	2	decent	
+1603	bad weak Mae West with a fly in it	2	decent	
 1604	altered skewed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	altered ultimate wad	1		
@@ -1592,8 +1592,8 @@
 1612	dry concentrated cordial of concentration	0		Effect: "Thick, Sick", Effect Duration: 14
 1613	bouncing Sherlock's coffin lid	0		Item Drop: +25, Damage Reduction: 3
 1614	flame-wreathed satin shield	0		Hot Spell Damage: +10, Damage Reduction: 5
-1615	wobbly banded Cerebral Cloche	0		Damage Absorption: +100, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	double-paned Cerebral Culottes	0		Cold Resistance: +5, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	wobbly banded Cerebral Cloche	0		Damage Absorption: +100, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	double-paned Cerebral Culottes	0		Cold Resistance: +5, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	censurious coward's Cerebral Crossbow of bravery	0		Monster Level: -20, Spooky Resistance: +5, Sleaze Resistance: +3, Last Available: "2006-06"
 1618	teal ice stein	0		Last Available: "2006-06"
 1619	mirror munchies pill	0		Last Available: "2006-06"
@@ -1628,9 +1628,9 @@
 1648	sleazy and sauce	0		
 1649	pulsating brick	0		Free Pull
 1650	skewed milk of magnesium	0		
-1651	stale small tumbling foie gras	2	decent	
+1651	small stale tumbling foie gras	2	decent	
 1652	alkaline ionized jittery candy brain	0		Effect: "Lemon Enlightenment", Effect Duration: 43, Last Available: "2020-09"
-1653	purple supercharged rock-hard jewel-eyed wizard hat of the businessman	0		Damage Reduction: 5, Maximum MP Percent: +30, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	purple supercharged rock-hard jewel-eyed wizard hat of the businessman	0		Damage Reduction: 5, Maximum MP Percent: +30, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	Annie Oakley's hardy wad of Crovacite	0		Maximum HP: +50, Critical Hit Percent: +20
 1655	upside-down therapeutic collar of the ox	0		Muscle: +20, HP Regen Min: 5, HP Regen Max: 7
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	huge styrofoam ore	0		
 1677	jittery bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	Samson's cool sword	0		Moxie: +5, Experience (Muscle): +5
 1680	squat foul-smelling baleful staff	0		Spell Damage: +25, Stench Damage: +10
 1681	sizzling supercharged bubblewrap sword	0		Maximum MP Percent: +30, Hot Damage: +10
@@ -1675,10 +1675,10 @@
 1695	enhanced huge papotion of papower	0		Effect: "Greasy Peasy", Effect Duration: 57
 1696	normal yellow royal jelly taco	4	good	
 1697	decent huge tofu taco	3	good	
-1698	moldy enchanted shaking jumping bean taco	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 30
+1698	enchanted moldy shaking jumping bean taco	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 30
 1699	half-sized bland wobbly catgut taco	2	decent	
-1700	adequate half-sized olive goat cheese taco	2	good	
-1701	fancy yummy small red tumbling pr0n taco	2	awesome	Effect: "Mental A-cue-ity", Effect Duration: 45
+1700	half-sized adequate olive goat cheese taco	2	good	
+1701	yummy fancy small tumbling red pr0n taco	2	awesome	Effect: "Mental A-cue-ity", Effect Duration: 45
 1702	pickled pressed ghostly alphabet gum	0		Effect: "Shortened", Effect Duration: 42
 1703	fuchsia Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1750,11 +1750,11 @@
 1771	Lo Pan's butcherknife	0		Spell Critical Percent: +30
 1772	teal mirror rock-hard corn holder	0		Damage Reduction: 5
 1773	maroon rosewater-soaked eggbeater	0		Stench Resistance: +3
-1774	lousy practically non-alcoholic mirror bouncing bottle of popskull	1	decent	
+1774	practically non-alcoholic lousy mirror bouncing bottle of popskull	1	decent	
 1775	steel-toed dishrag	0		Damage Reduction: 9
-1776	snack-sized normal stale baguette	2	good	
+1776	normal snack-sized stale baguette	2	good	
 1777	leftovers of indeterminate origin	0		
-1778	moldy snack-sized yellow dinner	2	crappy	
+1778	snack-sized moldy yellow dinner	2	crappy	
 1779	stylish katana	0		Moxie: +25
 1780	steel-toed ram stick	0		Damage Reduction: 9
 1781	deadly enchantlers	0		Weapon Damage: +5, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1768,7 +1768,7 @@
 1789	pulsating Mob Penguin	0		
 1790	perfectly mixed practically non-alcoholic Ram's Face Lager	1	EPIC	
 1791	ram horns	0		
-1792	huge coward's cool Travoltan trousers of the cougar	0		Moxie: 25, Monster Level: -20, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	huge coward's cool Travoltan trousers of the cougar	0		Moxie: 25, Monster Level: -20, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	wool strapping pool cue	0		Muscle: +5, Cold Resistance: +1
 1794	improved chilled energized green handful of hand chalk	0		Effect: "Icy Demeanor", Effect Duration: 32
 1795	wobbly Counterclockwise Watch of vim and vigor	0		Maximum HP Percent: +50, Single Equip
@@ -1785,9 +1785,9 @@
 1806	fifth cervical vertebra	0		
 1807	twirling sixth cervical vertebra	0		
 1808	upside-down seventh cervical vertebra	0		
-1809	fuchsia skewed first thoracic vertebra	0		
+1809	skewed fuchsia first thoracic vertebra	0		
 1810	twirling second thoracic vertebra	0		
-1811	bouncing tumbling third thoracic vertebra	0		
+1811	tumbling bouncing third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
 1813	ghostly fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
@@ -1807,7 +1807,7 @@
 1828	pulsating sacral vertebrae	0		
 1829	first caudal vertebra	0		
 1830	huge second caudal vertebra	0		
-1831	bouncing gray third caudal vertebra	0		
+1831	gray bouncing third caudal vertebra	0		
 1832	mirror mirror fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
 1834	maroon sixth caudal vertebra	0		
@@ -1823,9 +1823,9 @@
 1844	huge left sixth rib	0		
 1845	olive left seventh rib	0		
 1846	red left eighth rib	0		
-1847	red jittery left ninth rib	0		
+1847	jittery red left ninth rib	0		
 1848	left tenth rib	0		
-1849	squat jittery left eleventh rib	0		
+1849	jittery squat left eleventh rib	0		
 1850	left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
@@ -1838,7 +1838,7 @@
 1859	right ninth rib	0		
 1860	right tenth rib	0		
 1861	wobbly right eleventh rib	0		
-1862	upside-down lime green right twelfth rib	0		
+1862	lime green upside-down right twelfth rib	0		
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	huge right scapula	0		
@@ -1870,7 +1870,7 @@
 1891	right thumb	0		
 1892	left first rear claw	0		
 1893	teal left second rear claw	0		
-1894	huge upside-down left third rear claw	0		
+1894	upside-down huge left third rear claw	0		
 1895	left fourth rear claw	0		
 1896	maroon right first rear claw	0		
 1897	right second rear claw	0		
@@ -1923,12 +1923,12 @@
 1946	narrow Usain Bolt's frosty accordion pin	0		Cold Spell Damage: +10, Initiative: +80, Class: "Accordion Thief", Single Equip
 1947	wobbly studded worn tophat of the sweet-tooth	0		Damage Absorption: +80, Candy Drop: +100, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	family-friendly tap shoes of the early riser	0		Sleaze Resistance: +1, Adventures: +7, Single Equip
-1949	huge fancy delicious bouncing Manetwich	6	awesome	Effect: "substats.enh", Effect Duration: 10
+1949	fancy huge delicious bouncing Manetwich	6	awesome	Effect: "substats.enh", Effect Duration: 10
 1950	bottle of Vangoghbitussin	0		
-1951	watered-down artisanal enchanted bottle of Pinot Renoir	2	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 25
+1951	artisanal enchanted watered-down bottle of Pinot Renoir	2	EPIC	Effect: "Like a Fish to Walter", Effect Duration: 25
 1952	adequate big desiccated apricot	5	good	
-1953	acceptable practically non-alcoholic squat flute of flat champagne	1	good	
-1954	half-sized spoiled dehydrated caviar	2	crappy	
+1953	practically non-alcoholic acceptable squat flute of flat champagne	1	good	
+1954	spoiled half-sized dehydrated caviar	2	crappy	
 1955	styrofoam peanuts	0		
 1956	tolerable tumbling snifter of thoroughly aged brandy	3	good	
 1957	quill pen	0		
@@ -1943,14 +1943,14 @@
 1966	pulsating Amulet of Yendor of the cougar of temperance	0		Moxie: +20, Sleaze Resistance: +5, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	upside-down bottle of perfume	0		Familiar Weight: +5
-1969	lime green twirling spoon!	0		Familiar Weight: +5
+1969	twirling lime green spoon!	0		Familiar Weight: +5
 1970	purple nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	tumbling plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	strapping shrimp fork of dire peril	0		Muscle: +5, Weapon Damage: +20
 1973	half of a memo	0		
 1974	blurry cocoabo	0		
-1975	yellow bouncing baby gravy fairy	0		
-1976	bouncing mirror gravy fairy	0		
+1975	bouncing yellow baby gravy fairy	0		
+1976	mirror bouncing gravy fairy	0		
 1977	blinking gravy fairy	0		
 1978	gravy fairy	0		
 1979	mirror gravy fairy	0		
@@ -1973,7 +1973,7 @@
 1996	shaking right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	pack of KWE trading card	0		
-1999	shaking pulsating stick of &quot;gum&quot;	0		
+1999	pulsating shaking stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
@@ -1988,21 +1988,21 @@
 2011	blinking Nayztameetjoo trading card	0		
 2012	twirling Arrrmetia trading card	0		
 2013	Serenity trading card	0		
-2014	ghostly blinking Inndya trading card	0		
+2014	blinking ghostly Inndya trading card	0		
 2015	wobbly Kitty the Zmobie Basher trading card	0		
 2016	diamond necklace	0		
 2017	squat spade necklace	0		
 2018	club necklace	0		
 2019	twirling cream pie	0		Free Pull
 2020	delicious half-sized cherry pie	2	awesome	
-2021	moldy diet fuchsia strawberry pie	1	crappy	
+2021	diet moldy fuchsia strawberry pie	1	crappy	
 2022	toothsome lemon meringue pie	3	awesome	
 2023	twirling Genalen&trade; Bottle	1	decent	
 2024	fancy normal mixed wildflower greens	3	good	Effect: "Spookyravin'", Effect Duration: 40
 2025	adequate handful of walnuts	4	good	
-2026	moldy special bite-sized nutty organic salad	1	crappy	Effect: "Boletus Swoletus", Effect Duration: 10
+2026	bite-sized moldy special nutty organic salad	1	crappy	Effect: "Boletus Swoletus", Effect Duration: 10
 2027	adequate super salad	3	good	
-2028	low-calorie flavorless tofu wonton	1	decent	
+2028	flavorless low-calorie tofu wonton	1	decent	
 2029	mirror hippy protest button	0		Single Equip
 2030	skewed inspector's savvy Lockenstock&trade; sandals	0		Mysticality Percent: +20, Item Drop: +15, Single Equip
 2031	didgeridooka of the cougar	0		Moxie: +20
@@ -2027,16 +2027,16 @@
 2051	sunken eyes	0		
 2052	wobbly reassembled blackbird	0		
 2053	wobbly bust of Pallas	0		Familiar Weight: +5
-2054	spinning narrow market map	0		
+2054	narrow spinning market map	0		
 2055	snake skin	0		
 2056	deionized adder bladder	0		Effect: "Bonelording", Effect Duration: 33
-2057	spinning mirror blurry pension check	0		
+2057	blurry spinning mirror pension check	0		
 2058	picnic basket	0		
 2059	tarnished enhanced dry olive Black No. 2	0		Effect: "Saucefingers", Effect Duration: 36
 2060	ghostly skewed stiffened quilted sword	0		Damage Absorption: +40, Damage Reduction: 1
 2061	blue helmet of the pedagogue	0		Experience: +3, Familiar Effect: "1xFairy, cap 40"
 2062	Rosewater's shield of the scaredy-cat	0		Mysticality Percent: +30, Monster Level: -15, Damage Reduction: 10
-2063	adequate super-sized blackberry	5	good	
+2063	super-sized adequate blackberry	5	good	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	yellow blurry padded kick-ass kicks of doom	0		Damage Absorption: +20, Spooky Spell Damage: +50, Single Equip
@@ -2064,7 +2064,7 @@
 2088	aerosolized pulsating Daffy Taffy	0		Effect: "From Nantucket", Effect Duration: 34
 2089	wobbly Crimboween memo	0		Last Available: "2006-10"
 2090	tumbling teal Temple Grandin's brawny pilgrim shield of James Dean of Gandalf of terror	0		Muscle Percent: +20, Experience (Moxie): +3, Spell Critical Percent: +20, Familiar Weight: +7, Spooky Spell Damage: +10, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
-2091	mirror skewed bath salts	0		
+2091	skewed mirror bath salts	0		
 2092	hand mirror	0		
 2093	twirling prompt hors d'oeuvre tray	0		Adventures: +3, Damage Reduction: 5
 2094	moldy narrow ballroom blintz	3	crappy	
@@ -2078,7 +2078,7 @@
 2102	greasy dreadlock	0		
 2103	vial of pirate sweat	0		
 2104	empty aftershave bottle	0		
-2105	wobbly jittery coal button	0		
+2105	jittery wobbly coal button	0		
 2106	burned-out arcanodiode	0		
 2107	spinning non-Euclidean hoof	0		
 2108	huge rock	0		
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	auspicious prehistoric spear	0		Item Drop: +10, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	gray sharpshooter's fire of the ox	0		Muscle: +20, Critical Hit Percent: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	gray sharpshooter's fire of the ox	0		Muscle: +20, Critical Hit Percent: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	twirling lit cigar	0		Last Available: "2011-12"
 2120	yellow beefy Grateful Undead T-shirt	0		Muscle: +10
@@ -2138,12 +2138,12 @@
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	twirling recursive spline reticulator	0		Last Available: "2011-12"
 2165	atomic vector plotter	0		Last Available: "2011-12"
-2166	blue blurry ion-pulse modulation stabilizer	0		Last Available: "2011-12"
+2166	blurry blue ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	mirror hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	smartaleck's savvy toy ray gun	0		Mysticality Percent: +20, Moxie Percent: +30, Last Available: "2006-12"
-2169	sizzling Annie Oakley's toy space helmet	0		Critical Hit Percent: +20, Hot Damage: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	sizzling Annie Oakley's toy space helmet	0		Critical Hit Percent: +20, Hot Damage: +10, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	blinking dog trainer's Herculean astronaut pants	0		Experience (Muscle): +1, Experience (familiar): +1, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	blinking dog trainer's Herculean astronaut pants	0		Experience (Muscle): +1, Experience (familiar): +1, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	frightening toy jet pack	0		Spooky Damage: +5, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,16 +2161,16 @@
 2186	blinking unlit birthday cake	0		
 2187	mirror lit birthday cake	0		
 2188	flask of peppermint oil	1	EPIC	Last Available: "2006-12"
-2189	delicious weak flask of peppermint schnapps	2	awesome	Last Available: "2006-12"
+2189	weak delicious flask of peppermint schnapps	2	awesome	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
-2192	blue ghostly sheet music	0		Last Available: "2006-12"
+2192	ghostly blue sheet music	0		Last Available: "2006-12"
 2193	stale candy stake	3	decent	Last Available: "2006-12"
 2194	mediocre eggnog	3	decent	Last Available: "2006-12"
 2195	moldy unspeakable fruitcake	3	crappy	Last Available: "2006-12"
 2196	bland huge gingerbread horror	4	decent	Last Available: "2006-12"
 2197	polarized anodized cyan but probably evil chocolate	0		Effect: "Broken Fast", Effect Duration: 29, Last Available: "2006-12"
-2198	spoiled bite-sized ghostly bat-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	bite-sized spoiled ghostly bat-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	spoiled miniature blurry skull-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	delicious low-calorie tombstone-shaped Crimboween cookie	1	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	bouncing wobbly wobbly plastic gift-wrapping vampire of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	electrified Crimbo tiki necklace	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12"
 2208	gray inspector's deadly bobble-hip hula elf doll	0		Weapon Damage: +5, Item Drop: +15, Last Available: "2006-12"
 2209	lard-coated Crimbo ukulele	0		Sleaze Spell Damage: +25, Last Available: "2006-12"
-2210	Tiki lighter of the scaredy-cat of courage	0		Monster Level: -15, Spooky Resistance: +3, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	smartaleck's deck of tropical cards of the pedagogue	0		Moxie Percent: +30, Experience: +3, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	Oprah's wicked tropical paperweight	0		Spell Damage: +5, Maximum MP Percent: +50, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	Tiki lighter of the scaredy-cat of courage	0		Monster Level: -15, Spooky Resistance: +3, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	smartaleck's deck of tropical cards of the pedagogue	0		Moxie Percent: +30, Experience: +3, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	Oprah's wicked tropical paperweight	0		Spell Damage: +5, Maximum MP Percent: +50, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	blinking tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	thinker's Tropical Crimbo Hat	0		Mysticality: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	Tropical Crimbo Shorts of the glutton	0		Food Drop: +100, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	thinker's Tropical Crimbo Hat	0		Mysticality: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	Tropical Crimbo Shorts of the glutton	0		Food Drop: +100, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	spoiled super ka-bob	4	crappy	
 2218	adequate enchanted beer basted brat	4	good	Effect: "Dilated Pupils", Effect Duration: 25
 2219	flame-retardant Tropical Crimbo Sword	0		Hot Resistance: +1, Last Available: "2006-12"
 2220	vacuum-sealed quantum dry and Crimboween candy	0		Effect: "Feet of Watermelon", Effect Duration: 54, Last Available: "2020-09"
 2221	blinking Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	shaking prompt Herculean liar's pants	0		Experience (Muscle): +1, Adventures: +3, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	shaking prompt Herculean liar's pants	0		Experience (Muscle): +1, Adventures: +3, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	juggler's balls of wisdom	0		Mysticality: +15, Item Drop: +5, Softcore Only, Last Available: "2007-01"
 2224	baleful pink shirt	0		Spell Damage: +25, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2229,25 +2229,25 @@
 2255	narrow maroon crafty furry turtle	0		Maximum MP: +10, Familiar Effect: "2xPotato, 2xFairy, cap 11"
 2256	furry earmuffs of wisdom	0		Mysticality: +15
 2257	wobbly frightening reinforced furry underpants of the sweet-tooth	0		Spooky Damage: +5, Candy Drop: +100
-2258	twirling squat &quot;I Love Me, Vol. I&quot;	0		
+2258	squat twirling &quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
 2260	blurry gray hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	jittery bird rib	0		
 2263	upside-down squat lion oil	0		
-2264	snack-sized delicious stunt nuts	2	awesome	
+2264	delicious snack-sized stunt nuts	2	awesome	
 2265	normal half-sized wet stew	2	good	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	avaricious Staff of Fats	0		Meat Drop: +30
 2269	normal sausage wonton	4	good	
 2270	skewed sinister belt of the businessman	0		Spell Damage: +10, Meat Drop: +50, Single Equip
-2271	artisanal boozy bottle of Merlot	5	EPIC	
+2271	boozy artisanal bottle of Merlot	5	EPIC	
 2272	special lousy bottle of Port	4	decent	Effect: "Tingly Elbows", Effect Duration: 40
 2273	bad purple bottle of Pinot Noir	4	decent	
 2274	watered-down smooth bottle of Zinfandel	2	awesome	
 2275	drinkable bottle of Marsala	3	good	
-2276	weak tolerable bottle of Muscat	2	good	
+2276	tolerable weak bottle of Muscat	2	good	
 2277	Fernswarthy's key	0		
 2278	purple Fernswarthy's letter	0		
 2279	jittery book	0		
@@ -2274,9 +2274,9 @@
 2300	fingerless hobo gloves	0		
 2301	cyan Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	upside-down Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	upside-down Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	pickled electrified teal candy heart	0		Effect: "Greasy Flavor", Effect Duration: 29, Last Available: "2007-02"
-2305	chilled anodized shaking wobbly pink candy heart	0		Effect: "Intimidating Mien", Effect Duration: 30, Last Available: "2007-02"
+2305	chilled anodized wobbly shaking pink candy heart	0		Effect: "Intimidating Mien", Effect Duration: 30, Last Available: "2007-02"
 2306	adjusted corrupted candy heart	0		Effect: "Your Eyes are Peeled!", Effect Duration: 22, Last Available: "2007-02"
 2307	concentrated candy heart	0		Effect: "Heavily Breathing", Effect Duration: 30, Last Available: "2007-02"
 2308	modified blinking candy heart	0		Effect: "Ack!  Barred!", Effect Duration: 32, Last Available: "2007-02"
@@ -2303,19 +2303,19 @@
 2329	green handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	massive rotten Better Than Cuddling Cake	10	crappy	
+2332	rotten massive Better Than Cuddling Cake	10	crappy	
 2333	ninja snowman	0		
 2334	shaking Holy MacGuffin	0		
 2335	blue rubber WWBBDD? bracelet	0		
 2336	forbidden pipe	0		Spell Damage Percent: +50, Item Drop: +5
 2337	aromatic reinforced beaded headband	0		Stench Resistance: +1, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	spoiled small jittery pudding	2	crappy	Wiki Name: "black pudding (food)"
-2339	practically non-alcoholic aged Blackfly Chardonnay	1	awesome	
+2338	small spoiled jittery pudding	2	crappy	Wiki Name: "black pudding (food)"
+2339	aged practically non-alcoholic Blackfly Chardonnay	1	awesome	
 2340	acceptable special & tan	4	good	Effect: "Orc Chops", Effect Duration: 35
 2341	pepper	0		
-2342	small stale forest cake	2	decent	
-2343	adequate thick jittery forest ham	5	good	
-2344	moist wobbly green filthworm hatchling scent gland	0		Effect: "Holiday Bliss", Effect Duration: 62
+2342	stale small forest cake	2	decent	
+2343	thick adequate jittery forest ham	5	good	
+2344	moist green wobbly filthworm hatchling scent gland	0		Effect: "Holiday Bliss", Effect Duration: 62
 2345	warmed filthworm drone scent gland	0		Effect: "Tightly-Wound Spine", Effect Duration: 19
 2346	energized quadruple-nitrogenated squat filthworm royal guard scent gland	0		Effect: "Human-Hippy Hybrid", Effect Duration: 48
 2347	heart of the filthworm queen	0		
@@ -2330,8 +2330,8 @@
 2356	diffused huge tube of dread wax	0		Effect: "Gleaming White Teeth", Effect Duration: 60
 2357	blue medical-grade Socratic Gaia beads	0		Experience (Mysticality): +1, HP Regen Min: 7, HP Regen Max: 10
 2358	pink clay bead	0		
-2359	ghostly pulsating clay bead	0		
-2360	bouncing cyan clay bead	0		
+2359	pulsating ghostly clay bead	0		
+2360	cyan bouncing clay bead	0		
 2361	skewed foul-smelling electrified hippy medical kit	0		Stench Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 2362	MacGyver's resourceful Slow Talkin' Elliot's dogtags	0		Maximum MP: 150
 2363	auspicious Lo Pan's longhaired hippy wig	0		Spell Critical Percent: +30, Item Drop: +10, Familiar Effect: "1xPotato, 1xGhuol"
@@ -2343,11 +2343,11 @@
 2369	filthy poultice	0		
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
-2372	blinking upside-down red bunch of bananas	0		
-2373	adequate bite-sized banana	1	good	
+2372	red upside-down blinking bunch of bananas	0		
+2373	bite-sized adequate banana	1	good	
 2374	wobbly banana peel	0		
 2375	stale banana cream pie	4	decent	
-2376	boozy tolerable ghostly banana daiquiri	5	good	
+2376	tolerable boozy ghostly banana daiquiri	5	good	
 2377	lousy olive bungle in the jungle	4	decent	
 2378	blue huge banana spritzer	0		
 2379	super-boiled energized banana smoothie	0		Effect: "Eldritch Concentration", Effect Duration: 69
@@ -2410,17 +2410,17 @@
 2436	unsweetened dry donkey flipbook	0		Effect: "Ice Packed", Effect Duration: 55
 2437	New Cloaca-Cola	0		
 2438	narrow scented massage oil	0		
-2439	blinking spinning poltergeist-in-the-jar-o	0		
+2439	spinning blinking poltergeist-in-the-jar-o	0		
 2440	bouncing unnatural gas	0		
 2441	ghostly Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	blinking ghostly Temple Grandin's chaotic pink glowstick	0		Spell Critical Percent: +10, Familiar Weight: +7, Last Available: "2007-03"
-2444	high-proof acceptable Supernova Champagne	6	good	
+2444	acceptable high-proof Supernova Champagne	6	good	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	green blurry hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
 2448	tumbling tasteful bow tie	0		Familiar Weight: +5
-2449	squat pulsating six-pack of New Cloaca-Cola	0		
+2449	pulsating squat six-pack of New Cloaca-Cola	0		
 2450	mirror empty Cloaca-Cola bottle	0		
 2451	scandalous goatskin umbrella	0		Sleaze Damage: +5
 2452	zippy flame-retardant wool hat	0		Hot Resistance: +1, Initiative: +20, Familiar Effect: "1xLep, cap 43"
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	yummy huge bowl of Bounty-Os	4	awesome	
-2465	tolerable practically non-alcoholic spinning Oreille Divis&eacute;e brandy	1	good	
+2465	practically non-alcoholic tolerable spinning Oreille Divis&eacute;e brandy	1	good	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	huge callused fingerbone	0		
@@ -2476,7 +2476,7 @@
 2503	skewed extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	necklace chain	0		
-2506	spinning yellow beach glass bead	0		
+2506	yellow spinning beach glass bead	0		
 2507	clay peace-sign bead	0		
 2508	olive beach glass necklace of vim and vigor	0		Maximum HP Percent: +50
 2509	peace-sign necklace of the sewer	0		Stench Damage: +25
@@ -2491,19 +2491,19 @@
 2518	tumbling fireproof sawblade shield	0		Hot Resistance: +3, Damage Reduction: 11
 2519	artisanal McMillicancuddy's Special Lager	3	EPIC	
 2520	hand-crafted cyan melted Jell-o shot	4	EPIC	
-2521	hand-crafted blinking ghostly teal cruelty-free wine	3	EPIC	
+2521	hand-crafted blinking teal ghostly cruelty-free wine	3	EPIC	
 2522	weak acceptable thistle wine	2	good	
-2523	gray mirror megatofu	0		
+2523	mirror gray megatofu	0		
 2524	displaced fish	0		
 2525	flavorless huge fish	9	decent	
 2526	bland fish casserole	4	decent	
 2527	moldy squat fish lasagna	3	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	enchanted thick adequate narrow gnatloaf	5	good	Effect: "Also Schmeckt Zarathustra", Effect Duration: 50
+2529	enchanted adequate thick narrow gnatloaf	5	good	Effect: "Also Schmeckt Zarathustra", Effect Duration: 50
 2530	spoiled half-sized gnatloaf casserole	2	crappy	
 2531	flavorless gnat lasagna	3	decent	
 2532	blinking pork	0		
-2533	huge rotten pork chop sandwiches	6	crappy	
+2533	rotten huge pork chop sandwiches	6	crappy	
 2534	gigantic moldy pork casserole	9	crappy	
 2535	stale thick pork lasagna	5	decent	
 2536	canopic jar	0		
@@ -2511,14 +2511,14 @@
 2538	blurry organs	0		
 2539	red upside-down Ankh of Badahnkadh of vim and vigor	0		Maximum HP Percent: +50, Single Equip
 2540	blurry tomb ratchet	0		
-2541	wobbly skewed Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
-2542	quantum altered jittery green lesser grodulated violet	0		Effect: "Red-Shirted Escort", Effect Duration: 31, Last Available: "2007-05"
+2541	skewed wobbly Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
+2542	quantum altered green jittery lesser grodulated violet	0		Effect: "Red-Shirted Escort", Effect Duration: 31, Last Available: "2007-05"
 2543	electrified fuchsia tin magnolia	0		Effect: "Heart of Orange", Effect Duration: 12, Last Available: "2007-05"
 2544	ionized begpwnia	0		Effect: "Frost Tea", Effect Duration: 52, Last Available: "2007-05"
 2545	irradiated squat upsy daisy	0		Effect: "Puddingskin", Effect Duration: 20, Last Available: "2007-05"
 2546	diffused half-orchid	0		Effect: "Hot Blooded", Effect Duration: 40, Last Available: "2007-05"
 2547	tumbling sinister tin star of the cheetah	0		Spell Damage: +10, Initiative: +60, Last Available: "2007-05"
-2548	studded outrageous sombrero of courage	0		Damage Absorption: +80, Spooky Resistance: +3, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	studded outrageous sombrero of courage	0		Damage Absorption: +80, Spooky Resistance: +3, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	blue miser's beefy &quot;Humorous&quot; T-shirt	0		Muscle: +10, Meat Drop: +10, Last Available: "2007-05"
 2550	spinning Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2542,7 +2542,7 @@
 2569	chilled blinking ant agonist	0		Effect: "critical.enh", Effect Duration: 54
 2570	narrow ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	wobbly ant rake	0		Familiar Effect: "hot damage, meat"
-2572	bouncing yellow ant pitchfork	0		Familiar Effect: "stench damage, meat"
+2572	yellow bouncing ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	huge ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
@@ -2590,7 +2590,7 @@
 2617	jittery boom	0		
 2618	foul-smelling Iiti Kitty phone charm	0		Stench Damage: +10, Single Equip
 2619	ghostly jar of swamp gas	0		Last Available: "2007-05"
-2620	thick rotten unidentified jerky	5	crappy	
+2620	rotten thick unidentified jerky	5	crappy	
 2621	Annie Oakley's electrified nasty rat mask	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	skewed mansplainer's energetic ratskin belt	0		Maximum MP Percent: +20, Monster Level: +15, Single Equip
 2623	chaotic therapeutic rattail whip	0		Spell Critical Percent: +10, HP Regen Min: 5, HP Regen Max: 7
@@ -2622,31 +2622,31 @@
 2649	spinning reassuring Lord Spookyraven's ear trumpet	0		Spooky Resistance: +1, Single Equip
 2650	shaking bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	stale snack-sized S.T.L.T.	2	decent	Last Available: "2007-06"
+2652	snack-sized stale S.T.L.T.	2	decent	Last Available: "2007-06"
 2653	normal jittery honey-dew	3	good	Last Available: "2007-06"
 2654	bad Xanadian	4	decent	Last Available: "2007-06"
 2655	chilled corrupted bottle of absinthe	0		Effect: "Gemini Rising", Effect Duration: 35, Last Available: "2007-06"
 2656	upside-down blinking rosewater-soaked vibrating Drowsy Sword	0		Maximum MP Percent: +10, Stench Resistance: +3
 2657	adequate huge escargotsicle	6	good	Last Available: "2007-06"
-2658	irresponsibly strong tolerable bottle of realpagne	7	good	Last Available: "2007-06"
+2658	tolerable irresponsibly strong bottle of realpagne	7	good	Last Available: "2007-06"
 2659	fuchsia tumbling albatross necklace of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2007-06"
 2660	powdered not-a-pipe	1	good	Last Available: "2007-06"
 2661	practically non-alcoholic delicious huge flask of Amontillado	1	awesome	Last Available: "2007-06"
-2662	ball mask of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	ribald Can-Can skirt	0		Sleaze Damage: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	ball mask of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	ribald Can-Can skirt	0		Sleaze Damage: +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	irradiated spinning sensitive poetry journal	0		Effect: "Eau de Tortue", Effect Duration: 53, Last Available: "2007-06"
-2665	galvanized tumbling jittery bottled inspiration	0		Effect: "Rotten Memories", Effect Duration: 20, Last Available: "2007-06"
+2665	galvanized jittery tumbling bottled inspiration	0		Effect: "Rotten Memories", Effect Duration: 20, Last Available: "2007-06"
 2666	unsweetened concentrated bellhop bell	0		Effect: "Spooky Hands", Effect Duration: 20, Last Available: "2007-06"
 2667	nitrogenated polymerized spiky collar	0		Effect: "Stogied", Effect Duration: 44, Last Available: "2007-06"
 2668	distilled huge twirling can-can-in-a-can	1		Last Available: "2007-06"
 2669	altered patent antipsychotics	1		Last Available: "2007-06"
 2670	dried Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	mediocre weak blurry pulsating shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
+2671	weak mediocre blurry pulsating shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
 2672	yellow library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
-2674	quantum mirror skewed bottle of cat tonic	0		Effect: "Concentration", Effect Duration: 41, Last Available: "2007-06"
+2674	quantum skewed mirror bottle of cat tonic	0		Effect: "Concentration", Effect Duration: 41, Last Available: "2007-06"
 2675	vaporized blurry handful of moss	1		
-2676	modified maroon blurry bit-o-cactus	1		
+2676	modified blurry maroon bit-o-cactus	1		
 2677	altered protein powder	1		
 2678	spectre scepter	0		
 2679	modified chilled shaking sparkler	0		Effect: "Triangle, Man", Effect Duration: 14
@@ -2665,7 +2665,7 @@
 2692	knitted frosty driftwood sculpture	0		Cold Spell Damage: +10, Cold Resistance: +3
 2693	family-friendly mansplainer's massive sitar	0		Monster Level: +15, Sleaze Resistance: +1
 2694	squat ribald Van der Graaf strapping stone baseball cap	0		Muscle: +5, Sleaze Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley, cap 48"
-2695	hand-crafted irresponsibly strong shaking cup of beer	6	EPIC	
+2695	irresponsibly strong hand-crafted shaking cup of beer	6	EPIC	
 2696	ovoid thing	0		
 2697	huge duct tape	0		
 2698	duct tape wallet	0		
@@ -2681,7 +2681,7 @@
 2708	moist irradiated bouncing funky dried mushroom	0		Effect: "Bone Chilling", Effect Duration: 23
 2709	exotic parrot egg	0		
 2710	shaking cracker	0		Familiar Weight: +15
-2711	enhanced double-ionized green skewed facepaint	0		Effect: "Celestial Body", Effect Duration: 11
+2711	enhanced double-ionized skewed green facepaint	0		Effect: "Celestial Body", Effect Duration: 11
 2712	quantum skewed sheepskin diploma	0		Effect: "Nightlit", Effect Duration: 13
 2713	galvanized quadruple-wet Black Body&trade; spray	0		Effect: "20-20 Second Sight", Effect Duration: 38
 2714	upside-down floorboard cruft	0		
@@ -2697,14 +2697,14 @@
 2724	small moldy bowl of rye sprouts	2	crappy	
 2725	rotten cob of corn	4	crappy	
 2726	toothsome juniper berries	4	awesome	
-2727	enchanted thick flavorless plum	5	decent	Effect: "Trufflin'", Effect Duration: 25
+2727	thick enchanted flavorless plum	5	decent	Effect: "Trufflin'", Effect Duration: 25
 2728	small bland pear	2	decent	
 2729	flavorless peach	3	decent	
 2730	tolerable plum wine	3	good	
 2731	mediocre shot of pear schnapps	3	decent	
-2732	bad extra-dry ghostly shot of peach schnapps	5	decent	
-2733	snack-sized spoiled wobbly bunch of square grapes	2	crappy	
-2734	spoiled snack-sized brown sugar cane	2	crappy	
+2732	extra-dry bad ghostly shot of peach schnapps	5	decent	
+2733	spoiled snack-sized wobbly bunch of square grapes	2	crappy	
+2734	snack-sized spoiled brown sugar cane	2	crappy	
 2735	spoiled tumbling sandwich of the gods	4	crappy	
 2736	watered-down mediocre Pan-Dimensional Gargle Blaster	2	decent	
 2737	vaporized leopard-print barbell	1	good	Effect: "Bear Clawed", Effect Duration: 40
@@ -2713,8 +2713,8 @@
 2740	therapeutic ruddy rock-hard Staff of the Walk-In Freezer	0		Damage Reduction: 5, Maximum HP Percent: +40, HP Regen Min: 5, HP Regen Max: 7
 2741	practically non-alcoholic delicious boilermaker	1	awesome	
 2742	miniature decent steel lasagna	2	quest	
-2743	special weak hand-crafted steel margarita	2	quest	Effect: "Cock of the Walk", Effect Duration: 35
-2744	compressed blurry twirling shaking green steel-scented air freshener	1		
+2743	special hand-crafted weak steel margarita	2	quest	Effect: "Cock of the Walk", Effect Duration: 35
+2744	compressed twirling shaking blurry green steel-scented air freshener	1		
 2745	chilled gremlin mutagen	0		Effect: "The Rich Get Richer", Effect Duration: 34
 2746	altered quantum extra-potent gremlin mutagen	0		Effect: "Stimulated Brain", Effect Duration: 42
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2738,7 +2738,7 @@
 2765	Harold's bell	0		
 2766	spinning bowling ball	0		
 2767	adequate spinning Crimbo pie	4	good	
-2768	massive spoiled pear tart	9	crappy	
+2768	spoiled massive pear tart	9	crappy	
 2769	bland peach pie	3	decent	
 2770	enhanced moist triple-diffused chunk of rock salt	0		Effect: "Bananas!", Effect Duration: 24
 2771	colloidal handful of pine needles	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 49
@@ -2789,9 +2789,9 @@
 2816	supercool wizardly brainy Boxers	0		Mysticality: 30, Moxie Percent: +20, Familiar Effect: "1xVolley, 1xLep"
 2817	jittery asbestos-lined medical-grade banded Brooch	0		Damage Absorption: +100, Hot Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 2818	rosewater-soaked friendly quilted Bracelet	0		Damage Absorption: +40, Familiar Weight: +3, Stench Resistance: +3, Single Equip
-2819	huge foul-smelling Sinatra's Grimacite gasmask	0		Experience (Moxie): +5, Stench Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	huge foul-smelling Sinatra's Grimacite gasmask	0		Experience (Moxie): +5, Stench Damage: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	shaking inspector's Grimacite gat of courage	0		Spooky Resistance: +3, Item Drop: +15, Last Available: "2008-11"
-2821	rosewater-soaked mansplainer's Grimacite gaiters	0		Monster Level: +15, Stench Resistance: +3, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	rosewater-soaked mansplainer's Grimacite gaiters	0		Monster Level: +15, Stench Resistance: +3, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	nippy Grimacite gauntlets of the blizzard	0		Cold Damage: +10, Cold Spell Damage: +25, Single Equip, Last Available: "2008-11"
 2823	ghostly nasty coward's Grimacite go-go boots	0		Monster Level: -20, Stench Damage: +5, Single Equip, Last Available: "2008-11"
 2824	rosewater-soaked Grimacite girdle of temperance	0		Stench Resistance: +3, Sleaze Resistance: +5, Single Equip, Last Available: "2008-11"
@@ -2806,7 +2806,7 @@
 2833	flavorless star key lime pie	3	decent	
 2834	nippy grievous bottle-rocket crossbow of wisdom	0		Mysticality: +15, Weapon Damage Percent: +50, Cold Damage: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	hardy indie comic hipster glasses	0		Maximum HP: +50, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
-2836	skewed olive wizard action figure	0		Free Pull, Last Available: "2011-12"
+2836	olive skewed wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	glowstick of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, Last Available: "2007-08"
 2839	supercharged Periodical Paintbrush	0		Maximum MP Percent: +30, Softcore Only
@@ -2815,7 +2815,7 @@
 2842	artisanal accidental cider	4	EPIC	
 2843	decent small ghostly dire fudgesicle	2	good	
 2844	twirling wool crafty experienced stylish navel ring of navel gazing	0		Moxie: +25, Experience: +2, Maximum MP: +10, Cold Resistance: +1, Single Equip, Softcore Only, Last Available: "2007-09"
-2845	blurry cyan class five ecto-larva	0		Free Pull, Last Available: "2011-12"
+2845	cyan blurry class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	green plastic bib	0		Last Available: "2011-12"
 2847	Jeselnik's Dallas Dynasty Falcon Crest shield	0		Sleaze Damage: +25, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
@@ -2830,7 +2830,7 @@
 2857	energized energized concentrated seegar butt	0		Effect: "Hammered", Effect Duration: 11
 2858	bottled swamp gas	0		
 2859	lime green hardy witch wart of extreme caution	0		Maximum HP: +50, Monster Level: -25
-2860	stale massive ghostly gray swamp muck	6	decent	
+2860	massive stale gray ghostly swamp muck	6	decent	
 2861	knitted ribald coward's leechknife	0		Monster Level: -20, Sleaze Damage: +10, Cold Resistance: +3
 2862	spinning decomposed boot	0		
 2863	activated double-corrupted dribbly candle	0		Effect: "Fancy Feasted", Effect Duration: 18
@@ -2838,7 +2838,7 @@
 2865	bouncing wool Tesla beaver spear	0		Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10
 2866	pulsating squat perfumed wholesome shamanic beads	0		Maximum HP Percent: +10, Stench Resistance: +5
 2867	ruddy Da Vinci's dilapidated wizard hat	0		Experience (Mysticality): +5, Maximum HP Percent: +40, Familiar Effect: "cap 31"
-2868	tarnished non-wet unsweetened bouncing upside-down gray pirate pamphlet	0		Effect: "Optimist Primal", Effect Duration: 68
+2868	tarnished non-wet unsweetened gray upside-down bouncing pirate pamphlet	0		Effect: "Optimist Primal", Effect Duration: 68
 2869	double-pickled anodized pirate brochure	0		Effect: "Full of Wist", Effect Duration: 15
 2870	vacuum-sealed flattened pirate tract	0		Effect: "The Moxie of LOV", Effect Duration: 63
 2871	burnt flower	0		
@@ -2912,7 +2912,7 @@
 2939	mirror unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	yummy jittery Surprise Egg	4	awesome	
 2941	nitrogenated purple Steal This Candy	0		Effect: "The Halls of Moxiousness", Effect Duration: 68
-2942	galvanized energized blinking maroon chocolate filthy lucre	0		Effect: "Amorous", Effect Duration: 25
+2942	galvanized energized maroon blinking chocolate filthy lucre	0		Effect: "Amorous", Effect Duration: 25
 2943	flattened liquefied Angry Farmer's Wife Candy	0		Effect: "Hella Tough", Effect Duration: 58
 2945	friendly party hat of the businessman	0		Familiar Weight: +3, Meat Drop: +50, Familiar Effect: "4xLep, cap 7"
 2946	scandalous supercharged V for Vivala mask	0		Maximum MP Percent: +30, Sleaze Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
@@ -2930,16 +2930,16 @@
 2958	special adequate tube of cranberry Go-Goo	3	good	Effect: "Papowerful", Effect Duration: 40
 2959	weightlifter's rum barrel charrrm bracelet	0		Muscle: +15
 2960	moldy single-serving herbal stuffing	4	crappy	
-2961	spoiled tiny packet of tofurkey gravy	1	crappy	
-2962	rotten huge tofurkey nugget	8	crappy	
+2961	tiny spoiled packet of tofurkey gravy	1	crappy	
+2962	huge rotten tofurkey nugget	8	crappy	
 2963	blurry rigging shampoo	0		
 2964	ball polish	0		
 2965	mizzenmast mop	0		
 2966	ghostly Tom's of the Spanish Main Toothpaste	0		
 2967	non-moist corrupted skewed skewed Swabbie&trade; swab	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 36
 2968	triple-dry non-ionized Oil of Parrrlay	0		Effect: "Indescribable Flavor", Effect Duration: 66
-2969	fancy snack-sized toothsome blue creamsicle	2	awesome	Effect: "No Worries", Effect Duration: 15
-2970	practically non-alcoholic drinkable cream stout	1	good	
+2969	snack-sized toothsome fancy blue creamsicle	2	awesome	Effect: "No Worries", Effect Duration: 15
+2970	drinkable practically non-alcoholic cream stout	1	good	
 2971	huge Sherlock's dangerous curmudgel	0		Weapon Damage: +10, Item Drop: +25
 2972	olive grumpy man charrrm	0		
 2973	Sherlock's grumpy man charrrm bracelet	0		Item Drop: +25, Single Equip
@@ -2963,7 +2963,7 @@
 2991	clingfilm slippers of the cougar	0		Moxie: +20, Single Equip
 2992	squat clingfilm tangle	0		
 2993	bland vinegar-soaked lemon slice	3	decent	
-2994	ionized energized wobbly blinking true grit	0		Effect: "Human-Penguin Hybrid", Effect Duration: 41
+2994	ionized energized blinking wobbly true grit	0		Effect: "Human-Penguin Hybrid", Effect Duration: 41
 2995	fuchsia avaricious greedy Herculean buoybottoms	0		Experience (Muscle): +1, Meat Drop: 50, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	censurious grungy flannel shirt	0		Sleaze Resistance: +3
 2997	dog trainer's baleful grungy bandana	0		Spell Damage: +25, Experience (familiar): +1, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
@@ -3001,7 +3001,7 @@
 3029	hand-crafted practically non-alcoholic red-headed corpse	1	super EPIC	
 3030	acceptable ghostly kamicorpse-ee	3	good	
 3031	acceptable pulsating corpsel	4	good	
-3032	drinkable high-proof squat corpsebite	6	good	
+3032	high-proof drinkable squat corpsebite	6	good	
 3033	electrified pirate fledges	0		MP Regen Min: 3, MP Regen Max: 5
 3034	piece of thirteen	0		
 3035	small spoiled pearl onion	2	crappy	
@@ -3013,8 +3013,8 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	wobbly metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	pulsating metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	moldy small nanite-infested gingerbread bugbear	2	crappy	Last Available: "2007-12"
+3044	pulsating metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	small moldy nanite-infested gingerbread bugbear	2	crappy	Last Available: "2007-12"
 3046	toothsome shaking nanite-infested candy cane	4	awesome	Last Available: "2020-09"
 3047	delicious tiny maroon nanite-infested fruitcake	1	awesome	Last Available: "2007-12"
 3048	hand-crafted upside-down nanite-infested eggnog	4	EPIC	Last Available: "2007-12"
@@ -3025,20 +3025,20 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	alkaline gray candy heart	0		Effect: "Billiards Belligerence", Effect Duration: 22, Last Available: "2007-02"
 3055	magnetized cymbal syrup	0		Free Pull, Effect: "Rave Nirvana", Effect Duration: 37, Last Available: "2007-02"
-3056	wobbly upside-down purple sinister metallic foil cat ears	0		Spell Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	wobbly upside-down purple sinister metallic foil cat ears	0		Spell Damage: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	spinning iGoogly	0		Last Available: "2007-12"
 3059	shaking theoretical string	0		Last Available: "2007-12"
 3060	synthetic stuffing	0		Last Available: "2007-12"
 3061	toy hoverpad	0		Last Available: "2007-12"
-3062	purple upside-down LED block	0		Last Available: "2007-12"
+3062	upside-down purple LED block	0		Last Available: "2007-12"
 3063	gyroscope	0		Last Available: "2010-12"
 3064	twirling sage cyborg doll	0		Mysticality Percent: +10, Last Available: "2007-12"
 3065	buckyball	0		Last Available: "2010-12"
 3066	Herculean toy maglev monorail	0		Experience (Muscle): +1, Single Equip, Last Available: "2007-12"
 3067	spinning skewed dollhive	0		Last Available: "2007-12"
 3068	toy deathbot	0		Last Available: "2007-12"
-3069	yellow squat wobbly laser cannon	0		Last Available: "2007-12"
+3069	squat wobbly yellow laser cannon	0		Last Available: "2007-12"
 3070	upside-down plexifoam chin strap	0		Last Available: "2007-12"
 3071	ghostly silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	narrow carbonite visor	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	blurry kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	mirror teddy borg	0		Last Available: "2007-12"
 3081	marionette collective of the early riser	0		Adventures: +7, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	family-friendly Lo Pan's roboduck-on-a-string	0		Spell Critical Percent: +30, Sleaze Resistance: +1, Last Available: "2007-12"
 3086	narrow mylar scout drone	0		Last Available: "2007-12"
 3087	upside-down teddy borg sewing kit	0		Last Available: "2007-12"
-3088	narrow biomechanical crimborg helmet of vim and vigor of the empath	0		Maximum HP Percent: +50, Familiar Weight: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	narrow biomechanical crimborg helmet of vim and vigor of the empath	0		Maximum HP Percent: +50, Familiar Weight: +5, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	arcane researcher's strapping C.B.F.G.	0		Muscle: +5, Experience Percent (Mysticality): +10, Last Available: "2007-12"
-3090	crafty hale biomechanical crimborg leg armor	0		Maximum HP: +20, Maximum MP: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	crafty hale biomechanical crimborg leg armor	0		Maximum HP: +20, Maximum MP: +10, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	irradiated tarnished blinking vitachoconutriment capsule	0		Effect: "Patience of the Tortoise", Effect Duration: 48, Last Available: "2007-12"
 3092	tumbling narrow beefcake's handmade hobby horse	0		Muscle: +25, Last Available: "2007-12"
 3093	mansplainer's ball-in-a-cup	0		Monster Level: +15, Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	upside-down Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	olive Hodgman	0		
-3117	fuchsia Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	fuchsia Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3144,23 +3144,23 @@
 3172	stiffened evil paper umbrella	0		Damage Reduction: 1
 3173	activated mirror evil vihuela	0		Effect: "Ode to Booze", Effect Duration: 34
 3174	normal evil boring spaghetti	3	good	
-3175	tiny spoiled purple evil noodles	1	crappy	
+3175	spoiled tiny purple evil noodles	1	crappy	
 3176	rotten evil noodles	3	crappy	
 3177	flavorless evil painful penne pasta	4	decent	
 3178	rotten tiny 3vi1 pr0n m4nic0tti	1	crappy	
 3179	half-sized tasty evil ravioli della hippy	2	awesome	
-3180	special low-calorie adequate shaking evil noodles	1	good	Effect: "Stinky Hands", Effect Duration: 45
+3180	low-calorie special adequate shaking evil noodles	1	good	Effect: "Stinky Hands", Effect Duration: 45
 3181	magnetized denatured evil potion of potency	0		Effect: "Frozen Shoulders", Effect Duration: 58
 3182	improved liquefied jittery evil libation of liveliness	0		Effect: "Impregnabili Tea", Effect Duration: 36
 3183	wet vacuum-sealed evil tomato juice of powerful power	0		Effect: "On a Roll", Effect Duration: 59
-3184	wet mirror lime green evil eyedrops of the ermine	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 21
+3184	wet lime green mirror evil eyedrops of the ermine	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 21
 3185	warmed non-corrupted evil ointment of the occult	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 54
 3186	quadruple-altered wet narrow evil serum of sarcasm	0		Effect: "Going Ape", Effect Duration: 11
 3187	electrified adjusted pickled evil philter of phorce	0		Effect: "Fire Inside", Effect Duration: 67
 3188	tolerable an evil sump'm sump'm	3	good	
 3189	tolerable evil ducha de oro	3	good	
 3190	mediocre green mirror evil horizontal tango	3	decent	
-3191	high-proof delicious evil roll in the hay	6	awesome	
+3191	delicious high-proof evil roll in the hay	6	awesome	
 3192	skewed naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	spinning origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3169,7 +3169,7 @@
 3197	gravedigger's Temple Grandin's dance instructor's origami riding crop	0		Experience Percent (Moxie): +10, Familiar Weight: +7, Spooky Damage: +10, Softcore Only, Last Available: "2008-02"
 3198	blue El Vibrato trapezoid	0		
 3199	maroon lump of coal	0		
-3200	squat blinking twirling lump of diamond	0		
+3200	twirling blinking squat lump of diamond	0		
 3201	thick padded envelope	0		
 3202	rock-hard KoL Con IV Pole of the dark arts of horror	0		Spell Damage Percent: +100, Damage Reduction: 5, Spooky Spell Damage: +25, Last Available: "2007-09"
 3203	dwarvish magazine	0		
@@ -3201,12 +3201,12 @@
 3229	decaying goldfish liver	0		
 3230	activated diffused oil of oiliness	0		Effect: "damage.enh", Effect Duration: 21
 3231	aromatic tattered paper crown	0		Stench Resistance: +1, Familiar Effect: "1xSombrero, cap 15"
-3232	massive stale vanilla-frosted king cake	8	decent	Last Available: "2008-03"
+3232	stale massive vanilla-frosted king cake	8	decent	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	shaking gray noodle	0		
 3236	twirling Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
-3237	olive blinking Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
+3237	blinking olive Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	squat Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
@@ -3232,9 +3232,9 @@
 3260	purple toasty Chester's moustache of James Dean of incineration	0		Experience (Moxie): +3, Hot Damage: +5, Hot Spell Damage: +50, Class: "Disco Bandit", Single Equip
 3261	rosy-cheeked beefy Chester's bag of candy	0		Muscle: +10, Maximum HP Percent: +30, Class: "Disco Bandit"
 3262	weightlifter's Chester's cutoffs of the sweet-tooth	0		Muscle: +15, Candy Drop: +100, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
-3265	skewed ghostly tumbling bag of Crotchety Pine saplings	0		
+3265	ghostly tumbling skewed bag of Crotchety Pine saplings	0		
 3266	purple bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	anodized handful of Crotchety Pine needles	0		Effect: "Big", Effect Duration: 32
@@ -3245,7 +3245,7 @@
 3273	upside-down chaotic willowy bonnet	0		Spell Critical Percent: +10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	blue flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
-3276	red tumbling black-and-blue light	0		Last Available: "2008-04"
+3276	tumbling red black-and-blue light	0		Last Available: "2008-04"
 3277	tumbling Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	mirror studded belt of the sweet-tooth	0		Candy Drop: +100, Last Available: "2008-04"
 3279	personal massager	0		Last Available: "2008-04"
@@ -3272,7 +3272,7 @@
 3300	farfalle bow tie	0		
 3301	jalape&ntilde;o slices	0		
 3302	blurry stick-on mini solar panels	0		
-3303	pulsating fuchsia pulsating sombrero	0		Sombrero Bonus: +10
+3303	pulsating pulsating fuchsia sombrero	0		Sombrero Bonus: +10
 3304	blurry Argarggagarg's fang	0		
 3305	Safari Jack's moustache	0		
 3306	Yakisoba's hat	0		
@@ -3296,7 +3296,7 @@
 3324	mirror Frosty's frosty mug	0		
 3325	perfectly mixed jar of fermented pickle juice	3	super ultra mega EPIC	
 3326	pickled narrow voodoo snuff	1	awesome	Effect: "Fit To Be Tide", Effect Duration: 25
-3327	jumbo adequate extra-greasy slider	5	good	
+3327	adequate jumbo extra-greasy slider	5	good	
 3328	mirror tumbling toasty hale crumpled felt fedora	0		Maximum HP: +20, Hot Damage: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	Samson's battered top-hat of bravery	0		Experience (Muscle): +5, Spooky Resistance: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	shapeless wide-brimmed hat of the cougar of James Dean	0		Moxie: +20, Experience (Moxie): +3, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3367,7 +3367,7 @@
 3395	family-friendly fortified Hodgman's porkpie hat	0		Damage Absorption: +60, Sleaze Resistance: +1, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	rock-hard Hodgman's lobsterskin pants of chilblains	0		Damage Reduction: 5, Cold Damage: +25, Familiar Effect: "atk, 1xPotato"
 3397	horrifying foul-smelling Hodgman's bow tie	0		Stench Damage: +10, Spooky Damage: +25, Single Equip
-3398	weak hand-crafted purple Hodgman's blanket	2	super ultra EPIC	
+3398	hand-crafted weak purple Hodgman's blanket	2	super ultra EPIC	
 3399	delicious jar of squeeze	3	awesome	
 3400	adequate bowl of fishysoisse	3	good	
 3401	boiled deadly lampshade	0		Effect: "Winklered", Effect Duration: 48
@@ -3398,13 +3398,13 @@
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
-3434	ghostly blurry rattling cigar box	0		Free Pull, Last Available: "2011-12"
+3434	blurry ghostly rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	greasy Socratic stirring stick	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10
 3436	tumbling nasty careful Tesla Staff of the Teapot Tempest	0		Monster Level: -10, Stench Damage: +5, MP Regen Min: 7, MP Regen Max: 10
 3437	olive Usain Bolt's double-paned shellacked Staff of the Black Kettle	0		Damage Reduction: 7, Cold Resistance: +5, Initiative: +80
 3438	resourceful vibrating occult Staff of the Well-Tempered Cauldron	0		Spell Damage Percent: +25, Maximum MP Percent: +10, Maximum MP: +50
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	compressed blurry maroon prismatic wad	1	EPIC	Last Available: "2008-07"
+3440	compressed maroon blurry prismatic wad	1	EPIC	Last Available: "2008-07"
 3441	squat club of the five seasons of Leguizamo	0		Monster Level: +20, Last Available: "2008-07"
 3442	curative rainbow crossbow	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-07"
 3443	kitten	0		
@@ -3423,13 +3423,13 @@
 3456	energetic trusty torch	0		Maximum MP Percent: +20, Last Available: "2011-12"
 3457	gray bouncing shaking Junior Adventurer's merit badge of incineration	0		Hot Spell Damage: +50
 3458	anodized super-electrified warmed STYX deodorant body spray	0		Effect: "New Zeal", Effect Duration: 26
-3459	perfectly mixed distilled white-label gin	5	EPIC	
+3459	distilled perfectly mixed white-label gin	5	EPIC	
 3460	stale enchanted tin rations	3	decent	Effect: "Antarctic Memories", Effect Duration: 5
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	mediocre practically non-alcoholic mirror bottle of sake	1	decent	
+3463	practically non-alcoholic mediocre mirror bottle of sake	1	decent	
 3464	supercool round pebble	0		Moxie Percent: +20
-3465	miniature toothsome yellow Bash-&#332;s cereal	2	awesome	Wiki Name: "Bash-Os cereal"
+3465	toothsome miniature yellow Bash-&#332;s cereal	2	awesome	Wiki Name: "Bash-Os cereal"
 3466	fortified beefcake's haiku katana of the brazier	0		Muscle: +25, Damage Absorption: +60, Hot Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	prompt plastic baby	0		Adventures: +3, Single Equip, Last Available: "2008-12"
@@ -3449,29 +3449,29 @@
 3482	olive passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	jittery psychedelic bubble wand	0		Familiar Weight: +5
 3484	upside-down eye 'n' horn shampoo	0		Familiar Weight: +5
-3485	boiled activated jittery fuchsia shaking glittery mascara	0		Effect: "Whitened Teeth", Effect Duration: 32
+3485	boiled activated shaking fuchsia jittery glittery mascara	0		Effect: "Whitened Teeth", Effect Duration: 32
 3486	dull fish scale	0		
 3487	green rough fish scale	0		
 3488	pristine fish scale	0		
-3489	decent diet beefy fish meat	1	good	Effect: "Fishy", Effect Duration: 5
-3490	huge spoiled maroon glistening fish meat	9	crappy	Effect: "Fishy", Effect Duration: 5
-3491	decent half-sized slick fish meat	2	good	Effect: "Fishy", Effect Duration: 5
+3489	diet decent beefy fish meat	1	good	Effect: "Fishy", Effect Duration: 5
+3490	spoiled huge maroon glistening fish meat	9	crappy	Effect: "Fishy", Effect Duration: 5
+3491	half-sized decent slick fish meat	2	good	Effect: "Fishy", Effect Duration: 5
 3492	spinning narrow aromatic razor-sharp fish scimitar	0		Weapon Damage Percent: +25, Stench Resistance: +1
 3493	Sherlock's electrified fish stick	0		Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5
 3494	narrow Rosewater's fish bazooka of the bloodbag	0		Mysticality Percent: +30, Maximum HP: +100
 3495	magnetized extra-oxidized yellow sea salt crystal	0		Effect: "Think Win-Lose", Effect Duration: 22
 3496	vacuum-sealed activated wobbly bazookafish bubble gum	0		Effect: "In Vino Vires", Effect Duration: 27
 3497	delicious shaking bottle of Pete's Sake	4	awesome	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	blurry witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	green beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	blurry witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	green beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	flavorless jumbo teal canap&eacute;s	5	decent	
-3502	compressed narrow bouncing thermos of brew	1	good	Last Available: "2011-12"
+3502	compressed bouncing narrow thermos of brew	1	good	Last Available: "2011-12"
 3503	artisanal pulsating glass of brandy	3	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	dog trainer's LWA ring	0		Experience (familiar): +1
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	huge blurry Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	blurry huge Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	red family-friendly scratch 'n' sniff sword	0		Sleaze Resistance: +1, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	depleted Grimacite gravy boat of the wise owl of the brute	0		Mysticality: +20, Muscle Percent: +30, Last Available: "2011-12"
 3544	Rosewater's depleted Grimacite weightlifting belt of dire peril	0		Mysticality Percent: +30, Weapon Damage: +20, Single Equip, Last Available: "2011-12"
 3545	Van der Graaf vibrating depleted Grimacite grappling hook	0		Maximum MP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-12"
-3546	Newton's depleted Grimacite ninja mask of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +3, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	fuchsia deadly depleted Grimacite shinguards of the sweet-tooth	0		Weapon Damage: +5, Candy Drop: +100, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	Newton's depleted Grimacite ninja mask of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +3, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	fuchsia deadly depleted Grimacite shinguards of the sweet-tooth	0		Weapon Damage: +5, Candy Drop: +100, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	blinking blurry perfumed depleted Grimacite astrolabe of courage	0		Spooky Resistance: +3, Stench Resistance: +5, Single Equip, Last Available: "2011-12"
 3549	double-paned wool KoL Con Cinco Pi&ntilde;ata Bat	0		Cold Resistance: 6, Softcore Only, Last Available: "2008-09"
 3550	supercharged propeller beanie	0		Maximum MP Percent: +30, Familiar Effect: "atk, cap 7"
@@ -3519,17 +3519,17 @@
 3552	cyan zippy reassuring octopus's spade of the pedagogue	0		Experience: +3, Spooky Resistance: +1, Initiative: +20
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	tasty diet sea carrot	1	awesome	
+3555	diet tasty sea carrot	1	awesome	
 3556	delicious sea cucumber	3	awesome	
-3557	stale enchanted gigantic sea avocado	9	decent	Effect: "Elemental Mastery", Effect Duration: 35
-3558	bite-sized decent sea lychee	1	good	
-3559	enchanted huge toothsome sea tangelo	6	awesome	Effect: "Altered Wavelengths", Effect Duration: 30
-3560	delicious low-calorie sea honeydew	1	awesome	
-3561	adjusted blue tumbling jittery pressurized potion of puissance	0		Effect: "Bear Clawed", Effect Duration: 31
+3557	gigantic stale enchanted sea avocado	9	decent	Effect: "Elemental Mastery", Effect Duration: 35
+3558	decent bite-sized sea lychee	1	good	
+3559	enchanted toothsome huge sea tangelo	6	awesome	Effect: "Altered Wavelengths", Effect Duration: 30
+3560	low-calorie delicious sea honeydew	1	awesome	
+3561	adjusted jittery blue tumbling pressurized potion of puissance	0		Effect: "Bear Clawed", Effect Duration: 31
 3562	double-irradiated wet huge pressurized potion of perspicacity	0		Effect: "Hare-o-dynamic", Effect Duration: 39
 3563	extra-dry boiled yellow jittery pressurized potion of pulchritude	0		Effect: "Creepypasted", Effect Duration: 63
 3564	lousy berry-infused sake	3	decent	
-3565	triple-distilled drinkable citrus-infused sake	10	good	
+3565	drinkable triple-distilled citrus-infused sake	10	good	
 3566	artisanal narrow melon-infused sake	3	EPIC	
 3567	slab of sponge	0		
 3568	cyan tumbling avaricious hale Samson's sponge helmet	0		Experience (Muscle): +5, Maximum HP: +20, Meat Drop: +30, Familiar Effect: "atk, 1xFairy"
@@ -3546,9 +3546,9 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	mirror wriggling flytrap pellet	0		
 3581	blinking sushi-rolling mat	0		
-3582	rotten miniature rice	2	crappy	
+3582	miniature rotten rice	2	crappy	
 3584	moldy cyan irradiated candy cane	3	crappy	Last Available: "2008-12"
-3585	rotten huge gingerbread mutant bugbear	9	crappy	Last Available: "2008-12"
+3585	huge rotten gingerbread mutant bugbear	9	crappy	Last Available: "2008-12"
 3586	bad oozenog	4	decent	Last Available: "2008-12"
 3587	extra-cold-filtered sugar plum	0		Effect: "Gingerbread Robust", Effect Duration: 47, Last Available: "2008-12"
 3588	deionized altered jittery sugar banana	0		Effect: "Prideful Strut", Effect Duration: 54, Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	ghostly gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	greasy parasitic claw	0		Sleaze Spell Damage: +10, Last Available: "2008-12"
-3625	ghostly Newton's parasitic tentacles	0		Experience (Mysticality): +3, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	parasitic headgnawer of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	ghostly Newton's parasitic tentacles	0		Experience (Mysticality): +3, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	parasitic headgnawer of temperance	0		Sleaze Resistance: +5, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	boxer's parasitic strangleworm	0		Muscle Percent: +10, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	shaking burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,12 +3598,12 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	grievous thinker's elven socks	0		Mysticality: +10, Weapon Damage Percent: +50, Last Available: "2008-12"
 3634	shaking dangerous elven gloves of the boozehound	0		Weapon Damage: +10, Booze Drop: +100, Last Available: "2008-12"
-3635	nasty slick festive holiday hat	0		Moxie: +10, Stench Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	nasty slick festive holiday hat	0		Moxie: +10, Stench Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	upside-down occult patent shoes of the dark arts	0		Spell Damage Percent: 125, Last Available: "2008-12"
 3637	jittery dog trainer's gray bow tie of Flo-Jo	0		Experience (familiar): +1, Initiative: +100, Last Available: "2008-12"
 3638	Sherlock's penguin thesaurus of temperance	0		Sleaze Resistance: +5, Item Drop: +25, Last Available: "2008-12"
 3639	half-sized flavorless blob-shaped Crimbo cookie	2	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
-3640	gray blinking squat seaweed	0		
+3640	blinking squat gray seaweed	0		
 3641	jamfish jam	0		
 3642	twirling jittery dragonfish caviar	0		
 3643	wobbly pufferfish spine	0		
@@ -3614,19 +3614,19 @@
 3648	yellow magic dragonfish fry	0		
 3649	twirling map to Madness Reef	0		
 3650	rotten toast with jam	3	crappy	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	watered-down acceptable elven moonshine	2	good	Last Available: "2008-12"
-3653	adequate knuckle sandwich	4	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	adequate knuckle sandwich	4	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	fortified psycho sweater of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10, Last Available: "2008-12"
-3655	squat fuchsia jittery fin-bit wax	0		Familiar Weight: +5
+3655	fuchsia squat jittery fin-bit wax	0		Familiar Weight: +5
 3656	dog trainer's plastic Mob Penguin	0		Experience (familiar): +1, Last Available: "2008-12"
 3657	plastic mutant elf of the businessman	0		Meat Drop: +50, Last Available: "2008-12"
 3658	weightlifter's plastic fat stack of cash	0		Muscle: +15, Last Available: "2008-12"
 3659	executive plastic strand of DNA	0		Meat Drop: +40, Last Available: "2008-12"
 3660	razor-sharp plastic chunk of depleted Grimacite	0		Weapon Damage Percent: +25, Last Available: "2008-12"
 3661	mirror container of Putty	0		Last Available: "2009-01"
-3662	gray mansplainer's Putty mitre	0		Monster Level: +15, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	bouncing cyan censurious Putty leotard of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	gray mansplainer's Putty mitre	0		Monster Level: +15, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	bouncing cyan censurious Putty leotard of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Socratic Putty ball	0		Experience (Mysticality): +1, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	skewed purple smartaleck's Putty snake of wisdom of horror	0		Mysticality: +15, Moxie Percent: +30, Spooky Spell Damage: +25, Softcore Only, Last Available: "2009-01"
@@ -3645,15 +3645,15 @@
 3679	ink bladder	0		
 3680	esca	0		
 3681	jittery bubbling tempura batter	0		
-3682	blinking bouncing spinning globe of Deep Sauce	0		
-3683	pulsating red mirror map to the Marinara Trench	0		
+3682	bouncing blinking spinning globe of Deep Sauce	0		
+3683	red pulsating mirror map to the Marinara Trench	0		
 3684	toothsome miniature tempura carrot	2	awesome	
 3685	adequate tempura cucumber	4	good	
-3686	yummy thick tempura avocado	5	awesome	
-3687	adequate gigantic special sea broccoli	6	good	Effect: "Cybernetic Muscles", Effect Duration: 10
+3686	thick yummy tempura avocado	5	awesome	
+3687	special adequate gigantic sea broccoli	6	good	Effect: "Cybernetic Muscles", Effect Duration: 10
 3688	diet normal yellow upside-down sea cauliflower	1	good	
 3689	spoiled tempura broccoli	4	crappy	
-3690	stale snack-sized yellow tempura cauliflower	2	decent	
+3690	snack-sized stale yellow tempura cauliflower	2	decent	
 3691	stale sea blueberry	3	decent	
 3692	flavorless sea persimmon	3	decent	
 3693	quantum tumbling pressurized potion of perception	0		Effect: "Twinklebritches", Effect Duration: 63
@@ -3690,7 +3690,7 @@
 3724	tumbling brittle plastic handle	0		
 3725	foggy glass globe	0		
 3726	jittery tumbling possessed tomato	0		
-3727	huge shaking blue Nardz energy beverage	0		
+3727	shaking huge blue Nardz energy beverage	0		
 3728	pile of coins	0		
 3729	hand grenegg	0		
 3730	twirling caret	0		
@@ -3704,7 +3704,7 @@
 3738	normal wobbly packet of beer nuts	3	good	
 3739	tumbling Boozehounds Anonymous token	0		
 3740	skewed handful of bees	0		
-3741	blinking tumbling lime green spectral jelly	0		
+3741	tumbling lime green blinking spectral jelly	0		
 3742	alkaline jellyfish gel	0		Effect: "Nuts about Candy", Effect Duration: 53
 3743	unstable quark	0		
 3744	software glitch	0		
@@ -3714,7 +3714,7 @@
 3749	anodized concoction of clumsiness	0		Effect: "Booze Goozles", Effect Duration: 31
 3750	vampire pearl earring of the sweet-tooth	0		Candy Drop: +100, Single Equip
 3751	flavorless chocolate chip brownies	3	decent	
-3753	squat Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	squat Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	magnetized huge love song of vague ambiguity	0		Effect: "Meat the Flintstones", Effect Duration: 23, Last Available: "2009-02"
 3755	triple-improved love song of smoldering passion	0		Effect: "There Wolf", Effect Duration: 60, Last Available: "2009-02"
 3756	cold-filtered olive love song of icy revenge	0		Effect: "You're Not Cooking", Effect Duration: 54, Last Available: "2009-02"
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	tumbling crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	teal charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	tumbling crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	teal charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	miser's Tesla Sinatra's Mer-kin roundshield	0		Experience (Moxie): +5, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 14
 3804	Oprah's beefy Mer-kin breastplate	0		Muscle: +10, Maximum MP Percent: +50
 3805	wicked strapping Mer-kin sneakmask	0		Muscle: +5, Spell Damage: +5, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3763,12 +3763,12 @@
 3808	Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
-3811	ghostly red tumbling Mer-kin stashbox	0		
-3812	huge moldy special squat chocolate-frosted king cake	6	crappy	Effect: "Cletus's Canticle of Celerity", Effect Duration: 45, Last Available: "2009-06"
+3811	tumbling red ghostly Mer-kin stashbox	0		
+3812	special huge moldy squat chocolate-frosted king cake	6	crappy	Effect: "Cletus's Canticle of Celerity", Effect Duration: 45, Last Available: "2009-06"
 3813	blinking shellacked plastic baby	0		Damage Reduction: 7, Single Equip, Last Available: "2009-06"
 3815	red midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	tiny adequate sea radish	1	good	
+3817	adequate tiny sea radish	1	good	
 3818	rosewater-soaked nippy banded halibut	0		Damage Absorption: +100, Cold Damage: +10, Stench Resistance: +3
 3819	upside-down blurry eel sauce	0		
 3820	weightlifter's water-polo mitt	0		Muscle: +15, Single Equip
@@ -3777,7 +3777,7 @@
 3823	double-chilled ghostly wad of cotton	0		Effect: "Slimed Stomach", Effect Duration: 55
 3824	Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
-3826	twirling skewed Grandma's Chartreuse Yarn	0		
+3826	skewed twirling Grandma's Chartreuse Yarn	0		
 3827	blinking plastic oyster egg	0		
 3828	jittery Grandma's Map	0		
 3829	rotten gigantic tempura radish	9	crappy	
@@ -3831,7 +3831,7 @@
 3877	burst hellseal brain	0		
 3878	blinking hellseal sinew	0		
 3879	torn hellseal sinew	0		
-3880	blue twirling hellseal disguise	0		
+3880	twirling blue hellseal disguise	0		
 3881	miser's smartaleck's fouet de tortue-dressage	0		Moxie Percent: +30, Meat Drop: +10, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
 3883	cult memo	0		
@@ -3841,7 +3841,7 @@
 3887	colloidal corrupted vial of slime	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 62
 3888	diffused double-diffused vial of slime	0		Effect: "Jacked In", Effect Duration: 58
 3889	ionized modified nitrogenated huge upside-down huge vial of slime	0		Effect: "BOOsted", Effect Duration: 37
-3890	non-dry improved mirror squat narrow vial of violet slime	0		Effect: "Buff as a Baobab", Effect Duration: 30
+3890	non-dry improved narrow mirror squat vial of violet slime	0		Effect: "Buff as a Baobab", Effect Duration: 30
 3891	double-modified vial of vermilion slime	0		Effect: "protect.enq", Effect Duration: 35
 3892	aerosolized cold-filtered vial of amber slime	0		Effect: "Hot Jellied", Effect Duration: 35
 3893	super-aerosolized teal vial of chartreuse slime	0		Effect: "Smugness", Effect Duration: 23
@@ -3868,7 +3868,7 @@
 3916	wobbly flame-wreathed turtle wax helmet	0		Hot Spell Damage: +10, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
 3917	shaking turtle wax greaves of the brute	0		Muscle Percent: +30, Familiar Effect: "atk, 3xBarrr, cap 10"
 3918	spinning Jack Frost's meat shield	0		Cold Spell Damage: +50, Damage Reduction: 3
-3919	blue blinking turtlemail bits	0		
+3919	blinking blue turtlemail bits	0		
 3920	twirling rosy-cheeked quilted turtlemail coif	0		Damage Absorption: +40, Maximum HP Percent: +30, Familiar Effect: "1xPotato, cap 20"
 3921	inspector's Fonzie's turtlemail breeches	0		Experience (Moxie): +1, Item Drop: +15, Familiar Effect: "3xBarrr, 1.5xFairy, cap 20"
 3922	stylish wizardly turtlemail hauberk	0		Mysticality: +25, Moxie: +25
@@ -3990,15 +3990,15 @@
 4038	hand-crafted strong blurry slimy fermented bile bladder	5	EPIC	
 4039	powdered slimy alveolus	1		Effect: "Slime Time", Effect Duration: 25
 4040	fuchsia memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	skewed blue Jack Frost's dangerous pig-iron helm	0		Weapon Damage: +10, Cold Spell Damage: +50, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	purple prompt rosewater-soaked pig-iron shinguards	0		Stench Resistance: +3, Adventures: +3, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	skewed blue Jack Frost's dangerous pig-iron helm	0		Weapon Damage: +10, Cold Spell Damage: +50, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	purple prompt rosewater-soaked pig-iron shinguards	0		Stench Resistance: +3, Adventures: +3, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	twirling rosy-cheeked pig-iron bracers of the cougar	0		Moxie: +20, Maximum HP Percent: +30, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
-4046	lime green squat wumpus-hair net	0		Last Available: "2009-06"
+4046	squat lime green wumpus-hair net	0		Last Available: "2009-06"
 4047	pulsating wumpus-hair whip of Leguizamo	0		Monster Level: +20, Last Available: "2009-06"
-4048	chaotic wholesome wumpus-hair wig of courage	0		Maximum HP Percent: +10, Spell Critical Percent: +10, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	blue squat double-paned MacGyver's slick wumpus-hair loincloth	0		Moxie: +10, Maximum MP: +100, Cold Resistance: +5, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	chaotic wholesome wumpus-hair wig of courage	0		Maximum HP Percent: +10, Spell Critical Percent: +10, Spooky Resistance: +3, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	blue squat double-paned MacGyver's slick wumpus-hair loincloth	0		Moxie: +10, Maximum MP: +100, Cold Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	extremely unsafe wumpus-hair sweater of the glutton	0		Weapon Damage Percent: +100, Food Drop: +100, Last Available: "2009-06"
 4051	brainy ring of teleportation	0		Mysticality: +5, Single Equip
 4052	wobbly glass of baboon milk	1	decent	Last Available: "2009-06"
@@ -4032,9 +4032,9 @@
 4080	asbestos-lined grisly shield of doom	0		Spooky Spell Damage: +50, Hot Resistance: +5, Slime Hates It: +1, Damage Reduction: 13
 4081	frosty grievous corroded breeches	0		Weapon Damage Percent: +50, Cold Spell Damage: +10, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	wobbly double-paned pernicious cudgel of the businessman	0		Cold Resistance: +5, Meat Drop: +50, Slime Hates It: +1
-4083	small moldy cupcake-in-a-cup	2	crappy	Last Available: "2009-06"
+4083	moldy small cupcake-in-a-cup	2	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	thick stale protein paste	5	decent	Last Available: "2009-06"
+4085	stale thick protein paste	5	decent	Last Available: "2009-06"
 4086	lard-coated Herculean cyber-mattock	0		Experience (Muscle): +1, Sleaze Spell Damage: +25, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4095,7 +4095,7 @@
 4143	lime green a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	ruddy funny paper hat	0		Maximum HP Percent: +40, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	diffused teal blinking sand	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 56
+4146	diffused blinking teal sand	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 56
 4147	boxer's charged magnet of Gandalf	0		Muscle Percent: +10, Spell Critical Percent: +20, Last Available: "2009-09"
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
@@ -4109,7 +4109,7 @@
 4157	teal gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	blinking rock lobster	0		Last Available: "2009-09"
-4160	weak perfectly mixed special pebblebr&auml;u	2	EPIC	Effect: "Deadly Flashing Blade", Effect Duration: 20, Last Available: "2009-09"
+4160	weak special perfectly mixed pebblebr&auml;u	2	EPIC	Effect: "Deadly Flashing Blade", Effect Duration: 20, Last Available: "2009-09"
 4161	stale rocky road ice cream	4	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	nitrogenated quadruple-modified children of the candy corn	0		Effect: "Ready to Snap", Effect Duration: 50
@@ -4120,7 +4120,7 @@
 4168	Voluminous Radio Sneakers of the businessman	0		Meat Drop: +50, Single Equip
 4169	4-d camera	0		
 4170	olive upside-down shaking 4-d camera	0		
-4171	blurry twirling crystallized memory	0		
+4171	twirling blurry crystallized memory	0		
 4172	blinking Newton's rock helmet	0		Experience (Mysticality): +3, Familiar Effect: "1xGhuol, cap 25"
 4173	spinning ruddy rock pants	0		Maximum HP Percent: +40, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
 4174	MacGyver's rock necklace	0		Maximum MP: +100, Single Equip
@@ -4130,8 +4130,8 @@
 4178	pulsating teal shellacked sugar shotgun	0		Damage Reduction: 7, Last Available: "2009-09"
 4179	lime green sugar shillelagh of the empath	0		Familiar Weight: +5, Last Available: "2009-09"
 4180	ribald sugar shank	0		Sleaze Damage: +10, Last Available: "2009-09"
-4181	auspicious sugar chapeau of the bloodbag of Gandalf	0		Maximum HP: +100, Spell Critical Percent: +20, Item Drop: +10, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	ribald sugar shorts	0		Sleaze Damage: +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	auspicious sugar chapeau of the bloodbag of Gandalf	0		Maximum HP: +100, Spell Critical Percent: +20, Item Drop: +10, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	ribald sugar shorts	0		Sleaze Damage: +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4147,9 +4147,9 @@
 4195	huge arcane researcher's pacifier necklace	0		Experience Percent (Mysticality): +10, Single Equip
 4196	sea cowbell	0		
 4197	sea	0		
-4198	pulsating bouncing sea lasso	0		
+4198	bouncing pulsating sea lasso	0		
 4199	tumbling censurious knitted hardened sea cowboy hat	0		Damage Reduction: 3, Cold Resistance: +3, Sleaze Resistance: +3, Familiar Effect: "1xLep"
-4200	skewed pulsating upside-down grouper fangirl	0		
+4200	upside-down skewed pulsating grouper fangirl	0		
 4201	blurry gill rings	0		Familiar Weight: +5
 4202	bouncing urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
@@ -4158,7 +4158,7 @@
 4206	cyan asbestos-lined personal trainer's brand new key	0		Experience Percent (Muscle): +10, Hot Resistance: +5
 4207	dorsal fin of the sewer	0		Stench Damage: +25, Damage Reduction: 13
 4208	skate skates	0		
-4209	spinning mirror skate skin	0		
+4209	mirror spinning skate skin	0		
 4210	roller skate decoy	0		
 4211	mermaid's purse	0		
 4212	underwater slingshot	0		
@@ -4171,14 +4171,14 @@
 4219	studded skate board of Leguizamo	0		Damage Absorption: +80, Monster Level: +20
 4220	S.A.V.E. flyer	0		
 4221	toasty yield shield	0		Hot Damage: +5, Damage Reduction: 6, Last Available: "2009-09"
-4222	purple upside-down map to the Skate Park	0		
+4222	upside-down purple map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	roller skate doll	0		
 4226	crafty Star of Bravery	0		Maximum MP: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	green perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	twirling bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	skewed ice skate doll	0		
@@ -4194,13 +4194,13 @@
 4242	thinker's sock garters	0		Mysticality: +10, Single Equip
 4243	warmed dry cyan mariachi toothpaste	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 59
 4244	twirling sinister leather-bound tome	0		Spell Damage: +10
-4245	skewed purple bookmark	0		
+4245	purple skewed bookmark	0		
 4246	ivory cue ball of extreme caution	0		Monster Level: -25
 4247	weak tolerable mirror decanter of fine Scotch	2	good	
 4248	modified maroon expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	cyan fisherman's sack	0		
-4251	red blinking fish-oil smoke bomb	0		
+4251	blinking red fish-oil smoke bomb	0		
 4252	concentrated squat vial of squid ink	0		Effect: "Flagrantly Fragrant", Effect Duration: 18
 4253	chilled potion of speed	0		Effect: "Joyful Resolve", Effect Duration: 39
 4254	bark	0		Last Available: "2009-10"
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	normal chocolate-covered scarab beetle	3	good	Last Available: "2009-10"
 4259	watered-down mediocre mulled cider	2	decent	Last Available: "2009-10"
-4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	occult bark boxers	0		Spell Damage Percent: +25, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	narrow huge cool bark beret	0		Moxie: +5, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	occult bark boxers	0		Spell Damage Percent: +25, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	narrow huge cool bark beret	0		Moxie: +5, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	gray groovy bark bracelet	0		Moxie Percent: +10, Single Equip
 4267	fireproof nasty Krakrox's Loincloth	0		Stench Damage: +5, Hot Resistance: +3, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	rosy-cheeked Galapagosian Cuisses of the glutton	0		Maximum HP Percent: +30, Food Drop: +100, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4223,7 +4223,7 @@
 4271	upside-down jittery tumbling Volartta's bellbottoms of wisdom of the brazier	0		Mysticality: +15, Hot Spell Damage: +25, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 4272	clever Lederhosen of the Night of the early riser	0		Maximum MP: +20, Adventures: +7, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
 4273	diffused ribbon candy	0		Effect: "Elvish", Effect Duration: 61, Last Available: "2020-09"
-4274	jittery upside-down Underworld acorn	0		Free Pull, Last Available: "2009-10"
+4274	upside-down jittery Underworld acorn	0		Free Pull, Last Available: "2009-10"
 4275	cyan Underworld trunk	0		Last Available: "2009-10"
 4276	shaking executive arcane researcher's educational Underworld truncheon	0		Experience: +1, Experience Percent (Mysticality): +10, Meat Drop: +40, Last Available: "2009-10"
 4277	perfumed rosewater-soaked mansplainer's Staff of the Woodfire	0		Monster Level: +15, Stench Resistance: 8, Last Available: "2009-10"
@@ -4279,8 +4279,8 @@
 4327	reassuring occult weightlifter's La Hebilla del Cintur&oacute;n de Lopez	0		Muscle: +15, Spell Damage Percent: +25, Spooky Resistance: +1, Class: "Accordion Thief", Single Equip
 4328	mirror suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	jumbo adequate enchanted candy kneecapping stick	5	good	Effect: "Sludgesick", Effect Duration: 5, Last Available: "2009-12"
-4331	moldy miniature shaking licorice garrote	2	crappy	Last Available: "2009-12"
+4330	enchanted jumbo adequate candy kneecapping stick	5	good	Effect: "Sludgesick", Effect Duration: 5, Last Available: "2009-12"
+4331	miniature moldy shaking licorice garrote	2	crappy	Last Available: "2009-12"
 4332	hale candy knuckles	0		Maximum HP: +20, Last Available: "2009-12"
 4333	massive adequate skewed jawbruiser	7	good	Last Available: "2010-12"
 4334	warmed chocolate car	0		Effect: "Cheered Up", Effect Duration: 26, Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat of the boozehound	0		Booze Drop: +100, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	Da Vinci's snow pants	0		Experience (Mysticality): +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	snow hat of the boozehound	0		Booze Drop: +100, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	Da Vinci's snow pants	0		Experience (Mysticality): +5, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	spinning snow belly of the detective	0		Item Drop: +20, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	blurry Crimbough	0		Last Available: "2009-12"
@@ -4310,13 +4310,13 @@
 4358	squat A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	jittery A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	big decent expired can of franks 'n' beans	5	good	Last Available: "2009-12"
-4361	watered-down artisanal green huge expired bottle of peppermint schnapps	2	EPIC	Last Available: "2009-12"
+4361	artisanal watered-down green huge expired bottle of peppermint schnapps	2	EPIC	Last Available: "2009-12"
 4362	narrow snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	non-flattened purple elven suicide capsule	0		Effect: "Pharmaceutically Cool", Effect Duration: 14, Last Available: "2009-12"
-4365	rotten low-calorie penguin focaccia bread	1	crappy	Last Available: "2009-12"
-4366	tolerable weak herringcello	2	good	Last Available: "2009-12"
-4367	watered-down lousy elven cellocello	2	decent	Last Available: "2009-12"
+4365	low-calorie rotten penguin focaccia bread	1	crappy	Last Available: "2009-12"
+4366	weak tolerable herringcello	2	good	Last Available: "2009-12"
+4367	lousy watered-down elven cellocello	2	decent	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	upside-down bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	Tesla wicked pocketwatch on a chain	0		Spell Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-12"
 4386	cyan shellacked beefy cement sandals	0		Muscle: +10, Damage Reduction: 7, Single Equip, Last Available: "2009-12"
 4387	padded smooth night-vision goggles	0		Moxie: +15, Damage Absorption: +20, Single Equip, Last Available: "2009-12"
-4388	mirror passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	mirror passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	blinking peanut brittle shield of mayonnaise	0		Sleaze Spell Damage: +50, Damage Reduction: 3, Last Available: "2009-12"
 4390	occult Herculean Red Rover BB gun	0		Experience (Muscle): +1, Spell Damage Percent: +25, Last Available: "2009-12"
 4391	Rosewater's red-and-green sweater	0		Mysticality Percent: +30, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	bouncing cheese ball	0		Last Available: "2010-01"
 4399	ghostly cheese sword	0		Item Drop: +5, Softcore Only, Last Available: "2010-01"
-4400	rosewater-soaked cheese diaper	0		Stench Resistance: +3, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	rosewater-soaked cheese diaper	0		Stench Resistance: +3, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	squat forbidden cheese wheel	0		Spell Damage Percent: +50, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	skewed chaotic cheese eye	0		Spell Critical Percent: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	huge chaotic supercharged Staff of Queso Escusado of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Spell Critical Percent: +10, Softcore Only, Last Available: "2010-01"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	flavorless quantum taco	0		Last Available: "2010-10"
-4413	high-proof perfectly mixed Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	perfectly mixed high-proof Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	blurry colorful plastic ball	0		Last Available: "2010-01"
 4415	olive smelly sealhide hood	0		Stench Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	twirling wobbly sealhide leggings of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xVolley, cap 40"
@@ -4396,7 +4396,7 @@
 4448	pickled blinking upside-down Instant Karma	1	awesome	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	dangerous pointy hat	0		Weapon Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	dangerous pointy hat	0		Weapon Damage: +10, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	healthy machetito	0		Maximum HP Percent: +20, Last Available: "2010-04"
 4453	scorching lawnmower blade	0		Hot Damage: +25, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	boiled triple-altered blurry chocolate saucepan	0		Effect: "Tingly Elbows", Effect Duration: 43
 4466	quadruple-boiled ionized double-colloidal upside-down chocolate disco ball	0		Effect: "Hood Ridin'", Effect Duration: 40
 4467	electrified double-deionized diffused wobbly chocolate stolen accordion	0		Effect: "Disco Neuropathy", Effect Duration: 41
-4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	blurry BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	lion tamer's BRICKO hat	0		Experience (familiar): +2, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	narrow frightening BRICKO pants	0		Spooky Damage: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	lion tamer's BRICKO hat	0		Experience (familiar): +2, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	narrow frightening BRICKO pants	0		Spooky Damage: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	spinning lard-coated BRICKO sword	0		Sleaze Spell Damage: +25, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	pulsating BRICKO bat	0		Last Available: "2010-02"
 4476	blurry mirror BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	skewed BRICKO elephant	0		Last Available: "2010-02"
-4479	maroon BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	maroon BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	blinking BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4455,11 +4455,11 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	tarnished quadruple-anodized squat &quot;DRINK ME&quot; potion	0		Effect: "Grrrrrrreat!", Effect Duration: 25, Last Available: "2010-03"
 4509	tumbling reflection of a map	0		Last Available: "2010-03"
-4510	snack-sized adequate huge purple walrus ice cream	2	good	Last Available: "2010-03"
+4510	adequate snack-sized huge purple walrus ice cream	2	good	Last Available: "2010-03"
 4511	normal half-sized beautiful soup	2	good	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	small adequate Humpty Dumplings	2	good	Last Available: "2010-03"
+4514	adequate small Humpty Dumplings	2	good	Last Available: "2010-03"
 4515	moldy Lobster <i>qua</i> Grill	4	crappy	Last Available: "2010-03"
 4516	delicious missing wine	4	awesome	Last Available: "2010-03"
 4517	yummy matter custard	4	awesome	Last Available: "2010-03"
@@ -4469,9 +4469,9 @@
 4521	jittery croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	foul-smelling eye of the Tiger-lily of horror	0		Stench Damage: +10, Spooky Spell Damage: +25, Last Available: "2010-03"
-4524	zippy wig of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +20, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	immense special flavorless blurry donut	10	decent	Effect: "You're Rubber", Effect Duration: 40, Last Available: "2010-03"
-4526	small normal fancy bucket of honey	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15, Last Available: "2010-03"
+4524	zippy wig of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +20, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	flavorless special immense blurry donut	10	decent	Effect: "You're Rubber", Effect Duration: 40, Last Available: "2010-03"
+4526	small fancy normal bucket of honey	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15, Last Available: "2010-03"
 4527	yellow shaking toasty Herculean elephant stinger	0		Experience (Muscle): +1, Hot Damage: +5, Last Available: "2010-03"
 4528	decent squat dragon snaps	4	good	Last Available: "2010-03"
 4529	huge Oprah's experienced snapdragon pistil	0		Experience: +2, Maximum MP Percent: +50, Last Available: "2010-03"
@@ -4479,13 +4479,13 @@
 4531	moldy rook cookie	4	crappy	Last Available: "2010-03"
 4532	rotten small bishop cookie	2	crappy	Last Available: "2010-03"
 4533	decent jumbo twirling knight cookie	5	good	Last Available: "2010-03"
-4534	thick adequate king cookie	5	good	Last Available: "2010-03"
+4534	adequate thick king cookie	5	good	Last Available: "2010-03"
 4535	moldy bouncing queen cookie	3	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	pulsating wobbly dangerous insane tophat	0		Weapon Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	wool padded helm of the knight	0		Damage Absorption: +20, Cold Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	pulsating wobbly dangerous insane tophat	0		Weapon Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	wool padded helm of the knight	0		Damage Absorption: +20, Cold Resistance: +1, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	deadly wristwatch of the knight of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Single Equip, Last Available: "2010-03"
-4540	bouncing spinning rock-hard trousers of the knight of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	bouncing spinning rock-hard trousers of the knight of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	cyan crafty tophat	0		Maximum MP: +10, Familiar Effect: "1xBarrr, cap 25"
 4542	personal trainer's tie	0		Experience Percent (Muscle): +10, Single Equip
 4543	strapping tuxedo pants	0		Muscle: +5, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4503,30 +4503,30 @@
 4555	left bracket	0		
 4556	right parenthesis	0		
 4557	dollar sign	0		
-4558	tumbling ghostly equal sign	0		
+4558	ghostly tumbling equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	purple can of depilatory cream	0		Last Available: "2010-04"
 4562	spinning hair of the calf	0		Last Available: "2010-04"
-4563	strong bad world's most unappetizing beverage	5	decent	Last Available: "2010-04"
+4563	bad strong world's most unappetizing beverage	5	decent	Last Available: "2010-04"
 4564	spinning yellow educational slippery when wet shield	0		Experience: +1, Damage Reduction: 6, Last Available: "2010-04"
 4565	adequate raisin	4	good	Last Available: "2010-04"
 4566	skewed fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	huge green toasty sharpshooter's flyest of shirts	0		Critical Hit Percent: +10, Hot Damage: +5, Last Available: "2010-04"
-4568	huge adequate wobbly olive narrow a dance upon the palate	6	good	Last Available: "2010-04"
+4568	huge adequate olive narrow wobbly a dance upon the palate	6	good	Last Available: "2010-04"
 4569	adequate prehistoric meteorite jawbreaker	3	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	snack-sized spoiled squirmy violent party snack	2	crappy	Last Available: "2010-04"
+4571	spoiled snack-sized squirmy violent party snack	2	crappy	Last Available: "2010-04"
 4572	deadly can-you-dig-it?	0		Weapon Damage: +5, Last Available: "2010-04"
 4573	mirror The Legendary Beat	0		Last Available: "2010-04"
 4574	blinking panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	tumbling bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	twirling bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	twirling bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	concentrated concentrated Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Transcendental Wind", Effect Duration: 54, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of the dark arts	0		Spell Damage Percent: +100, Last Available: "2010-04"
-4581	yellow frosty T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the bloodbag	0		Maximum HP: +100, Cold Spell Damage: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	yellow frosty T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the bloodbag	0		Maximum HP: +100, Cold Spell Damage: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	delicious six wedges of goat cheese	3	awesome	
@@ -4546,13 +4546,13 @@
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	spinning bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	practically non-alcoholic delicious red plastic cup of beer	1	awesome	Last Available: "2010-06"
+4601	delicious practically non-alcoholic red plastic cup of beer	1	awesome	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	skewed keg	0		Last Available: "2010-06"
 4605	rosewater-soaked grievous bottle of Goldschn&ouml;ckered	0		Weapon Damage Percent: +50, Stench Resistance: +3, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	moldy mirror sun-dried tofu	3	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	artisanal triple-distilled shaking blinking soyburger juice	10	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	triple-distilled artisanal shaking blinking soyburger juice	10	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	maroon essential tofu	0		Last Available: "2010-08"
 4610	oxidized essential soy	0		Effect: "Polar Express", Effect Duration: 27, Last Available: "2010-08"
@@ -4570,19 +4570,19 @@
 4622	blinking Game Grid ticket	0		Last Available: "2010-06"
 4623	concentrated diffused chocolate-covered caviar	0		Effect: "Fungal Flambé", Effect Duration: 56, Last Available: "2020-09"
 4624	adequate tiny pawn cookie	1	good	Last Available: "2010-06"
-4625	altered mirror ghostly coffee pixie stick	1	awesome	Last Available: "2010-06"
+4625	altered ghostly mirror coffee pixie stick	1	awesome	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
 4629	manspreader's plastic spider ring	0		Monster Level: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	smelly plastic kazoo	0		Stench Spell Damage: +10, Last Available: "2010-06"
 4631	wobbly greasy inflatable baseball bat	0		Sleaze Spell Damage: +10, Last Available: "2010-06"
-4632	foul-smelling thinker's googly-star hat	0		Mysticality: +10, Stench Damage: +10, Familiar Effect: "atk", Last Available: "2010-06"
+4632	foul-smelling thinker's googly-star hat	0		Mysticality: +10, Stench Damage: +10, Last Available: "2010-06", Familiar Effect: "atk"
 4633	lion tamer's brawny googly-ball hat	0		Muscle Percent: +20, Experience (familiar): +2, Last Available: "2010-06"
 4634	upside-down upside-down miser's boxer's googly-heart hat	0		Muscle Percent: +10, Meat Drop: +10, Last Available: "2010-06"
 4635	careful deadly super-sweet boom box	0		Weapon Damage: +5, Monster Level: -10, Four Songs, Last Available: "2010-06"
 4636	teal Game Grid valued membership card	0		Last Available: "2010-06"
-4637	perfumed knitted fortified sinister demon mask	0		Damage Absorption: +60, Cold Resistance: +3, Stench Resistance: +5, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	perfumed knitted fortified sinister demon mask	0		Damage Absorption: +60, Cold Resistance: +3, Stench Resistance: +5, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	squat lightning-fast Rosewater's streetfighting champion's belt of mayonnaise	0		Mysticality Percent: +30, Sleaze Spell Damage: +50, Initiative: +40, Single Equip, Last Available: "2010-06"
 4639	zippy auspicious frosty Space Trip safety headphones	0		Cold Spell Damage: +10, Item Drop: +10, Initiative: +20, Single Equip, Last Available: "2010-06"
 4640	rosy-cheeked LARP carp	0		Maximum HP Percent: +30
@@ -4594,8 +4594,8 @@
 4646	pulsating squat MacGyver's experienced Meteoid ice beam of dire peril	0		Experience: +2, Weapon Damage: +20, Maximum MP: +100, Last Available: "2011-12"
 4647	Jim Carey's arcane researcher's Dungeon Fist gauntlet of incineration	0		Experience Percent (Mysticality): +10, Monster Level: +25, Hot Spell Damage: +50, Last Available: "2011-06"
 4648	spinning Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	tumbling pulsating chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	pulsating tumbling chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	Annie Oakley's vibrating ironic knit cap	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	fortified blackberry galoshes	0		Damage Absorption: +60, Single Equip
 4660	trout fang of vim and vigor of courage	0		Maximum HP Percent: +50, Spooky Resistance: +3, Last Available: "2010-09"
-4661	moldy enchanted miniature wobbly poisonous caviar	2	crappy	Effect: "Quiet 'n' Good", Effect Duration: 35, Last Available: "2010-09"
+4661	moldy miniature enchanted wobbly poisonous caviar	2	crappy	Effect: "Quiet 'n' Good", Effect Duration: 35, Last Available: "2010-09"
 4662	aerosolized polymerized upside-down wet venom duct	0		Effect: "Crimbo Flavor", Effect Duration: 68, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	upside-down tumbling grievous Ellsbury's skull of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +50, Last Available: "2010-09"
@@ -4616,19 +4616,19 @@
 4668	savvy observational glasses	0		Mysticality Percent: +20
 4669	bouncing red extremely unsafe hilarious comedy prop	0		Weapon Damage Percent: +100
 4670	beer-scented teddy bear	0		
-4671	lousy boozy booze-soaked cherry	5	decent	
+4671	boozy lousy booze-soaked cherry	5	decent	
 4672	ghostly comfy pillow	0		
 4673	adequate purple marshmallow	4	good	
 4674	moldy sponge cake	4	crappy	
 4675	artisanal gin-soaked blotter paper	4	EPIC	
-4676	skewed fuchsia shaking tree-holed coin	0		
+4676	shaking skewed fuchsia tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	upside-down unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	ghostly smoked potsherd	0		
 4681	twirling up-at-dawn pottery shield	0		Adventures: +5, Damage Reduction: 3, Last Available: "2010-09"
-4682	smartaleck's pottery hat of the sweet-tooth	0		Moxie Percent: +30, Candy Drop: +100, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	greedy ruddy pottery training pants	0		Maximum HP Percent: +40, Meat Drop: +20, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	smartaleck's pottery hat of the sweet-tooth	0		Moxie Percent: +30, Candy Drop: +100, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	greedy ruddy pottery training pants	0		Maximum HP Percent: +40, Meat Drop: +20, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	greasy pottery club	0		Sleaze Spell Damage: +10, Last Available: "2010-09"
 4685	personal trainer's pottery yo-yo	0		Experience Percent (Muscle): +10, Last Available: "2010-09"
 4686	spinning pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4636,12 +4636,12 @@
 4688	fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
 4690	mirror skewed fossilized wyrm skull	0		Last Available: "2010-09"
-4691	mirror wobbly fossilized wing	0		Last Available: "2010-09"
+4691	wobbly mirror fossilized wing	0		Last Available: "2010-09"
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	pulsating affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	rosewater-soaked ribald Greatest American Pants of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10, Stench Resistance: +3, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	rosewater-soaked ribald Greatest American Pants of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +10, Stench Resistance: +3, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	clever fossilized necklace	0		Maximum MP: +20, Last Available: "2010-09"
 4698	tumbling imp air	0		
 4699	bus pass	0		
@@ -4662,7 +4662,7 @@
 4714	stale miniature lemon popsicle	2	decent	
 4715	flavorless popsicle	4	decent	
 4716	adequate strawberry popsicle	3	good	
-4717	bland gigantic liver popsicle	7	decent	
+4717	gigantic bland liver popsicle	7	decent	
 4718	narrow dog trainer's mariachi hat	0		Experience (familiar): +1, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of Leguizamo	0		Monster Level: +20, Familiar Effect: "atk, cap 2"
 4720	tumbling organ grinder	0		Free Pull, Last Available: "2011-12"
@@ -4673,8 +4673,8 @@
 4725	moldy snack-sized piping organ pie	2	crappy	Last Available: "2010-10"
 4726	delicious twirling igloo pie	4	awesome	Last Available: "2010-10"
 4727	adequate huge stomach turnover	6	good	Last Available: "2010-10"
-4728	yummy low-calorie dead lights pie	1	awesome	Last Available: "2010-10"
-4729	big flavorless throbbing organ pie	5	decent	Last Available: "2010-10"
+4728	low-calorie yummy dead lights pie	1	awesome	Last Available: "2010-10"
+4729	flavorless big throbbing organ pie	5	decent	Last Available: "2010-10"
 4730	prompt stop shield	0		Adventures: +3, Damage Reduction: 6, Last Available: "2009-12"
 4731	blurry nest egg	0		
 4732	gray sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,7 +4683,7 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	dance instructor's beer-soaked mop	0		Experience Percent (Moxie): +10
-4738	fancy watered-down drinkable tumbling day-old beer	2	good	Effect: "Good Karma", Effect Duration: 5
+4738	fancy drinkable watered-down tumbling day-old beer	2	good	Effect: "Good Karma", Effect Duration: 5
 4739	fortified tolerable plain beer	5	good	
 4740	mediocre weak cyan overpriced &quot;imported&quot; beer	2	decent	
 4741	smiling rat	0		
@@ -4691,16 +4691,16 @@
 4743	bone chips	0		Last Available: "2011-12"
 4744	moist denatured PlexiPips	0		Effect: "Eyes for Miles", Effect Duration: 64
 4745	energized skewed Wax Flask	0		Effect: "Sweet Incentive", Effect Duration: 35
-4746	boiled huge spinning Pain Dip	0		Effect: "Vanity Rage", Effect Duration: 29
-4747	gigantic moldy pulsating bone meal	9	crappy	Last Available: "2010-10"
-4748	strong perfectly mixed wobbly bone aperitif	5	EPIC	Last Available: "2010-10"
+4746	boiled spinning huge Pain Dip	0		Effect: "Vanity Rage", Effect Duration: 29
+4747	moldy gigantic pulsating bone meal	9	crappy	Last Available: "2010-10"
+4748	perfectly mixed strong wobbly bone aperitif	5	EPIC	Last Available: "2010-10"
 4749	fortified bonerang	0		Damage Absorption: +60, Last Available: "2010-10"
 4750	ghostly bone and arrows of the pedagogue	0		Experience: +3, Last Available: "2010-10"
 4751	supercool boning knife	0		Moxie Percent: +20, Last Available: "2010-10"
 4752	Socratic bone crusher	0		Experience (Mysticality): +1, Last Available: "2010-10"
 4753	MacGyver's bone spurs	0		Maximum MP: +100, Single Equip, Last Available: "2010-10"
-4754	mirror dangerous bonedanna of the cheetah	0		Weapon Damage: +10, Initiative: +60, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	narrow aromatic asbestos-lined boneana hammock	0		Hot Resistance: +5, Stench Resistance: +1, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	mirror dangerous bonedanna of the cheetah	0		Weapon Damage: +10, Initiative: +60, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	narrow aromatic asbestos-lined boneana hammock	0		Hot Resistance: +5, Stench Resistance: +1, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	pulsating bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	double-moist anodized shaking candy skeleton	0		Effect: "Weather, Man", Effect Duration: 60, Last Available: "2020-09"
@@ -4726,7 +4726,7 @@
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	flavorless CRIMBCOIDS mints	3	decent	Last Available: "2011-01"
 4819	twirling can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	toothsome low-calorie huge CRIMBCOLOAF	1	awesome	Last Available: "2011-01"
+4820	low-calorie toothsome huge CRIMBCOLOAF	1	awesome	Last Available: "2011-01"
 4821	bland special circular CRIMBCOOKIE	3	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	blurry manspreader's plastic CRIMBCO HQ	0		Monster Level: +10, Last Available: "2010-12"
 4823	twirling plastic fax machine of the dark arts	0		Spell Damage Percent: +100, Last Available: "2010-12"
@@ -4751,9 +4751,9 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	skewed Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	ghostly The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	smartaleck's Uncle Hobo's stocking cap of the brute	0		Muscle Percent: +30, Moxie Percent: +30, Familiar Effect: "atk", Last Available: "2010-12"
+4845	smartaleck's Uncle Hobo's stocking cap of the brute	0		Muscle Percent: +30, Moxie Percent: +30, Last Available: "2010-12", Familiar Effect: "atk"
 4846	tumbling wobbly wool friendly Uncle Hobo's epic beard	0		Familiar Weight: +3, Cold Resistance: +1, Single Equip, Last Available: "2010-12"
-4847	cyan frightening Uncle Hobo's gift baggy pants of courage	0		Spooky Damage: +5, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	cyan frightening Uncle Hobo's gift baggy pants of courage	0		Spooky Damage: +5, Spooky Resistance: +3, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	manspreader's strapping Uncle Hobo's fingerless tinsel gloves	0		Muscle: +5, Monster Level: +10, Single Equip, Last Available: "2010-12"
 4849	fireproof lard-coated Uncle Hobo's highest bough	0		Sleaze Spell Damage: +25, Hot Resistance: +3, Last Available: "2010-12"
 4850	foul-smelling banded Uncle Hobo's belt	0		Damage Absorption: +100, Stench Damage: +10, Single Equip, Last Available: "2010-12"
@@ -4775,32 +4775,32 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	ribald vibrating dance instructor's paperclip-on tie	0		Experience Percent (Moxie): +10, Maximum MP Percent: +10, Sleaze Damage: +10, Single Equip, Last Available: "2011-01"
-4869	twirling Jack Frost's hale paperclip pants	0		Maximum HP: +20, Cold Spell Damage: +50, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	up-at-dawn Annie Oakley's paperclip turban of Flo-Jo	0		Critical Hit Percent: +20, Initiative: +100, Adventures: +5, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	twirling Jack Frost's hale paperclip pants	0		Maximum HP: +20, Cold Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	up-at-dawn Annie Oakley's paperclip turban of Flo-Jo	0		Critical Hit Percent: +20, Initiative: +100, Adventures: +5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	banded paperclip cape	0		Damage Absorption: +100, Last Available: "2011-01"
 4872	squat glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
-4876	galvanized extra-moist twirling huge teal blurry chocolate bath ball	0		Effect: "Nightlit", Effect Duration: 37, Last Available: "2011-01"
+4876	galvanized extra-moist teal huge twirling blurry chocolate bath ball	0		Effect: "Nightlit", Effect Duration: 37, Last Available: "2011-01"
 4877	nitrogenated huge teal bacon bath ball	0		Effect: "French Bronilla Brogueishness", Effect Duration: 22, Last Available: "2011-01"
 4878	vacuum-sealed improved fuchsia incense bath ball	0		Effect: "Mathematically Precise", Effect Duration: 61, Last Available: "2011-01"
 4879	altered twirling myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Well Owl Be!", Effect Duration: 35, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	lousy watered-down ghostly CRIMBCO wine	2	decent	Last Available: "2011-01"
+4881	watered-down lousy ghostly CRIMBCO wine	2	decent	Last Available: "2011-01"
 4882	wobbly Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	maroon toe jam	0		Last Available: "2011-01"
 4884	tasty toe jam toast	3	awesome	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	moldy miniature traffic jam toast	2	crappy	Last Available: "2011-01"
-4887	jittery gray space jam	0		Last Available: "2011-01"
-4888	adequate low-calorie space jam toast	1	good	Last Available: "2011-01"
+4887	gray jittery space jam	0		Last Available: "2011-01"
+4888	low-calorie adequate space jam toast	1	good	Last Available: "2011-01"
 4889	activated modified wobbly motivational poster	0		Effect: "Space Cowboy", Effect Duration: 24, Last Available: "2011-01"
 4890	skewed sack lunch	0		Last Available: "2011-01"
 4891	squat bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	rotten jumbo maroon festive sausage	5	crappy	Last Available: "2011-01"
+4894	jumbo rotten maroon festive sausage	5	crappy	Last Available: "2011-01"
 4895	half-sized spoiled ghostly holiday cheese log	2	crappy	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	scandalous resourceful BGE 'ferocious fruit' shirt	0		Maximum MP: +50, Sleaze Damage: +5, Last Available: "2010-12"
@@ -4859,8 +4859,8 @@
 4956	miniature stale lime green philosopher's scone	2	decent	
 4957	pressed half-baked potion	0		Effect: "Eyes of the Dragon", Effect Duration: 44
 4958	mirror Jack Frost's Knob Goblin deluxe scimitar	0		Cold Spell Damage: +50
-4959	big rotten olive pulsating Knob nuts	5	crappy	
-4960	bad huge wobbly Cobb's Knob Wurstbrau	4	decent	
+4959	big rotten pulsating olive Knob nuts	5	crappy	
+4960	bad wobbly huge Cobb's Knob Wurstbrau	4	decent	
 4961	Subject 37 file	0		
 4962	Jim Carey's Annie Oakley's mysterious lapel pin	0		Critical Hit Percent: +20, Monster Level: +25, Single Equip
 4963	fuchsia state loom	0		Familiar Weight: +10
@@ -4875,7 +4875,7 @@
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	Alice's Army Page	0		Last Available: "2011-03"
-4975	bouncing lime green Alice's Army Shieldmaiden	0		Last Available: "2011-03"
+4975	lime green bouncing Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
@@ -4892,7 +4892,7 @@
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	skewed Alice's Army Foil Guard	0		Last Available: "2011-03"
-4992	blinking narrow Alice's Army Foil Wallman	0		Last Available: "2011-03"
+4992	narrow blinking Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	purple Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	maroon Alice's Army Foil Page	0		Last Available: "2011-03"
@@ -4905,7 +4905,7 @@
 5002	maroon Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
-5005	mirror upside-down Alice's Army Foil Sniper	0		Last Available: "2011-03"
+5005	upside-down mirror Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
 5007	yellow Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	fuchsia huge Single Alice's Army Foil	0		Last Available: "2011-03"
@@ -4944,14 +4944,14 @@
 5041	huge wobbly asbestos-lined sizzling astral shirt of bravery	0		Hot Damage: +10, Hot Resistance: +5, Spooky Resistance: +5
 5042	crafty astral belt of Flo-Jo	0		Maximum MP: +10, Initiative: +100
 5043	spoiled half-sized astral hot dog	2		
-5044	delicious practically non-alcoholic spinning astral pilsner	1		
+5044	practically non-alcoholic delicious spinning astral pilsner	1		
 5045	gray astral hot dog dinner	0		
 5046	skewed jittery astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	fireproof chilly Temple Grandin's double-ice cap	0		Familiar Weight: +7, Cold Damage: +5, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	fireproof chilly Temple Grandin's double-ice cap	0		Familiar Weight: +7, Cold Damage: +5, Hot Resistance: +3, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	rosewater-soaked double-paned smelly double-ice box	0		Stench Spell Damage: +10, Cold Resistance: +5, Stench Resistance: +3, Last Available: "2011-04"
-5051	Sherlock's double-ice britches of the pedagogue of Calamity Jane	0		Experience: +3, Critical Hit Percent: +15, Item Drop: +25, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	Sherlock's double-ice britches of the pedagogue of Calamity Jane	0		Experience: +3, Critical Hit Percent: +15, Item Drop: +25, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	yellow Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	weak aged Russian Ice	2	awesome	Last Available: "2011-04"
 5074	bouncing hale clay ashtray	0		Maximum HP: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	shaking lanyard of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2011-05"
-5076	monster pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	monster pants of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	concentrated jittery Pok&euml;mann band-aid	0		Effect: "The Dinsey Spirit", Effect Duration: 26, Last Available: "2011-05"
-5079	gray flame-wreathed experienced Van der Graaf helmet	0		Experience: +2, Hot Spell Damage: +10, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	gray flame-wreathed experienced Van der Graaf helmet	0		Experience: +2, Hot Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	blurry Samson's crutch	0		Experience (Muscle): +5, Last Available: "2011-05"
 5081	shock belt of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2011-05"
 5082	altered non-moist Okee-Dokee soda	0		Effect: "Shot in the Arse", Effect Duration: 16, Last Available: "2011-05"
 5083	dance instructor's rubber band gun	0		Experience Percent (Moxie): +10, Last Available: "2011-05"
-5084	cyan gravedigger's pin-stripe slacks	0		Spooky Damage: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	cyan gravedigger's pin-stripe slacks	0		Spooky Damage: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	cyan gloves of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2011-05"
 5086	extra-pickled alkaline correction fluid	0		Effect: "Scrappy, Shadowy", Effect Duration: 33, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of the early riser	0		Adventures: +7, Single Equip, Last Available: "2011-05"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	tumbling busted wings	0		
 5120	narrow Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	skewed spinning boxer's Admiral's hat of Tarzan of the empath	0		Muscle Percent: +10, Experience (Muscle): +3, Familiar Weight: +5, Familiar Effect: "atk", Last Available: "2011-05"
-5122	Jim Carey's aviator's cap of the scaredy-cat of the cheetah	0		Monster Level: 10, Initiative: +60, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	skewed spinning boxer's Admiral's hat of Tarzan of the empath	0		Muscle Percent: +10, Experience (Muscle): +3, Familiar Weight: +5, Last Available: "2011-05", Familiar Effect: "atk"
+5122	Jim Carey's aviator's cap of the scaredy-cat of the cheetah	0		Monster Level: 10, Initiative: +60, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	clever Newton's mirrored aviator shades	0		Experience (Mysticality): +3, Maximum MP: +20, Single Equip, Last Available: "2011-05"
 5124	red Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	wobbly Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5031,10 +5031,10 @@
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	upside-down Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	red Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
-5131	flattened dry green shaking Ultrasoldier Serum	0		Effect: "Artificially Sweet", Effect Duration: 64, Last Available: "2011-06"
+5131	flattened dry shaking green Ultrasoldier Serum	0		Effect: "Artificially Sweet", Effect Duration: 64, Last Available: "2011-06"
 5132	low-calorie adequate wobbly elven hardtack	1	good	Last Available: "2011-06"
 5133	mediocre watered-down elven squeeze	2	decent	Last Available: "2011-06"
-5134	blurry upside-down bouncing lunar isotope	0		Last Available: "2011-06"
+5134	blurry bouncing upside-down lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	jittery E.M.U. helmet	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	asbestos-lined medical-grade honey dipper of the sweet-tooth	0		Hot Resistance: +5, Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10
 5149	rosewater-soaked brawny honeybritches of the empath	0		Muscle Percent: +20, Familiar Weight: +5, Stench Resistance: +3, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	narrow baleful wicked wizardly honeycap	0		Mysticality: +25, Spell Damage: 30, Familiar Effect: "1xPotato, cap 43"
-5151	ghostly quilted Moonthril Circlet	0		Damage Absorption: +40, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	lime green crafty Moonthril Greaves	0		Maximum MP: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	ghostly quilted Moonthril Circlet	0		Damage Absorption: +40, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	lime green crafty Moonthril Greaves	0		Maximum MP: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	greedy Moonthril Flamberge	0		Meat Drop: +20, Last Available: "2011-06"
 5154	forbidden Moonthril Longbow	0		Spell Damage Percent: +50, Last Available: "2011-06"
 5155	fuchsia fireproof Moonthril Cuirass	0		Hot Resistance: +3, Softcore Only, Last Available: "2011-06"
@@ -5066,7 +5066,7 @@
 5163	experienced beefy plush mutated alielephant	0		Muscle: +10, Experience: +2, Last Available: "2011-06"
 5164	shaking mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	maroon spinning supercharged girl	0		Maximum MP Percent: +30, Last Available: "2011-06"
-5166	spinning tumbling top hat and cane	0		Last Available: "2011-06"
+5166	tumbling spinning top hat and cane	0		Last Available: "2011-06"
 5167	synthetic dog hair pill	0		Last Available: "2011-06"
 5168	fuchsia distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
@@ -5074,7 +5074,7 @@
 5171	tumbling Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	bouncing elven magi-pack	0		Last Available: "2011-06"
-5174	weak enchanted mediocre Saison du Lune	2	decent	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2011-06"
+5174	mediocre enchanted weak Saison du Lune	2	decent	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2011-06"
 5175	drinkable Moonthril Schnapps	3	good	Last Available: "2011-06"
 5176	watered-down perfectly mixed Wrecked Generator	2	super ultra mega turbo EPIC	Last Available: "2011-06"
 5177	stale Spaghetti with Moonballs	4	decent	Last Available: "2011-06"
@@ -5092,7 +5092,7 @@
 5189	tarnished fuchsia double-ice gum	0		Effect: "Inner Warmth", Effect Duration: 42, Last Available: "2011-04"
 5190	inspector's Operation Patriot Shield of the storm	0		Maximum MP Percent: +40, Item Drop: 20, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
-5192	ionized squat maroon corrupted data	0		Effect: "Icy Demeanor", Effect Duration: 43, Last Available: "2011-06"
+5192	ionized maroon squat corrupted data	0		Effect: "Icy Demeanor", Effect Duration: 43, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
 5194	exorcised sandwich	0		
 5195	shaking Banfoy's Boutique Order Form	0		Last Available: "2011-07"
@@ -5103,31 +5103,31 @@
 5200	diluted blurry paste	1	awesome	Effect: "Chain Chain Chains", Effect Duration: 35, Last Available: "2011-08"
 5201	powdered green ectoplasmic paste	1	decent	Effect: "Larger", Effect Duration: 30, Last Available: "2011-08"
 5202	distilled greasy paste	1	crappy	Last Available: "2011-08"
-5203	twisted shaking red skewed bug paste	1	decent	Last Available: "2011-08"
+5203	twisted skewed shaking red bug paste	1	decent	Last Available: "2011-08"
 5204	compressed skewed pulsating pulsating hippy paste	1	good	Last Available: "2011-08"
 5205	vaporized wobbly orc paste	1	EPIC	Effect: "Sappy Blood", Effect Duration: 30, Last Available: "2011-08"
 5206	boiled narrow twirling maroon demonic paste	1	decent	Last Available: "2011-08"
-5207	distilled wobbly huge indescribably horrible paste	1	good	Effect: "Colorful Gratitude", Effect Duration: 35, Last Available: "2011-08"
+5207	distilled huge wobbly indescribably horrible paste	1	good	Effect: "Colorful Gratitude", Effect Duration: 35, Last Available: "2011-08"
 5208	altered paste	1	good	Last Available: "2011-08"
 5209	mixed goblin paste	1	good	Last Available: "2011-08"
 5210	dehydrated olive mirror pirate paste	1	awesome	Effect: "Egg-stra Arm", Effect Duration: 10, Last Available: "2011-08"
 5211	mixed shaking chlorophyll paste	1	decent	Effect: "Make Meat FA$T!", Effect Duration: 10, Last Available: "2011-08"
-5212	powdered wobbly jittery paste	1	crappy	Last Available: "2011-08"
+5212	powdered jittery wobbly paste	1	crappy	Last Available: "2011-08"
 5213	twisted jittery Mer-kin paste	1	EPIC	Last Available: "2011-08"
 5214	twisted slimy paste	1	crappy	Last Available: "2011-08"
 5215	mixed wobbly penguin paste	1	good	Effect: "Compensatory Cruelness", Effect Duration: 50, Last Available: "2011-08"
 5216	mixed elemental paste	1	decent	Effect: "Drenched With Filth", Effect Duration: 45, Last Available: "2011-08"
 5217	dehydrated squat cosmic paste	1	awesome	Effect: "Wasabi With You", Effect Duration: 40, Last Available: "2011-08"
-5218	pickled skewed yellow hobo paste	1	good	Last Available: "2011-08"
+5218	pickled yellow skewed hobo paste	1	good	Last Available: "2011-08"
 5219	modified squat Crimbo paste	1	EPIC	Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	skewed fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	teal Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	tasty fancy ghostly Ur-Donut	3	awesome	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2011-09"
+5223	teal Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5224	fancy tasty ghostly Ur-Donut	3	awesome	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	fancy practically non-alcoholic bad bucket of wine	1	decent	Effect: "Muscle Unbound", Effect Duration: 25, Last Available: "2011-09"
+5227	fancy bad practically non-alcoholic bucket of wine	1	decent	Effect: "Muscle Unbound", Effect Duration: 25, Last Available: "2011-09"
 5228	flavorless squat ultrafondue	4	decent	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5138,27 +5138,27 @@
 5235	educational furry halo	0		Experience: +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	Herculean frosty halo	0		Experience (Muscle): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	sizzling time halo	0		Hot Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	perfectly mixed weak gray Lumineux Limnio	2	EPIC	Last Available: "2011-09"
-5239	strong tolerable skewed Morto Moreto	5	good	Last Available: "2011-09"
+5238	weak perfectly mixed gray Lumineux Limnio	2	EPIC	Last Available: "2011-09"
+5239	tolerable strong skewed Morto Moreto	5	good	Last Available: "2011-09"
 5240	lousy spinning Temps Tempranillo	3	decent	Last Available: "2011-09"
 5241	artisanal Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
 5242	hand-crafted Fromage Pinotage	3	EPIC	Last Available: "2011-09"
 5243	perfectly mixed Beignet Milgranet	3	EPIC	Last Available: "2011-09"
 5244	lousy Muschat	4	decent	Last Available: "2011-09"
-5245	flavorless massive cool jelly donut	6	decent	Last Available: "2011-09"
+5245	massive flavorless cool jelly donut	6	decent	Last Available: "2011-09"
 5246	enchanted normal shrapnel jelly donut	3	good	Effect: "Happy Trails", Effect Duration: 45, Last Available: "2011-09"
 5247	delicious occult jelly donut	4	awesome	Last Available: "2011-09"
 5248	normal thyme jelly donut	3	good	Last Available: "2011-09"
 5249	massive bland danish	7	decent	Last Available: "2011-09"
-5250	normal fancy smashed danish	3	good	Effect: "Fishy", Effect Duration: 30, Last Available: "2011-09"
+5250	fancy normal smashed danish	3	good	Effect: "Fishy", Effect Duration: 30, Last Available: "2011-09"
 5251	spoiled forbidden danish	3	crappy	Last Available: "2011-09"
-5252	bland blurry cyan pulsating cool cat claw	3	decent	Last Available: "2011-09"
-5253	rotten low-calorie spinning blunt cat claw	1	crappy	Last Available: "2011-09"
+5252	bland cyan blurry pulsating cool cat claw	3	decent	Last Available: "2011-09"
+5253	low-calorie rotten spinning blunt cat claw	1	crappy	Last Available: "2011-09"
 5254	adequate blinking shadowy cat claw	4	good	Last Available: "2011-09"
 5255	flavorless cheezburger	4	decent	Last Available: "2011-09"
 5256	rotten wobbly toasted brie	3	crappy	Last Available: "2011-09"
 5257	polarized shaking potion of the field gar	0		Effect: "Heart of Orange", Effect Duration: 28, Last Available: "2011-09"
-5258	anodized shaking ghostly too legit potion	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 15, Last Available: "2011-09"
+5258	anodized ghostly shaking too legit potion	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 15, Last Available: "2011-09"
 5259	alkaline tarnished bouncing Bright Water	0		Effect: "Jelly Combed", Effect Duration: 50, Last Available: "2011-09"
 5260	diffused olive cold-filtered water	0		Effect: "Cat Class, Cat Style", Effect Duration: 13, Last Available: "2011-09"
 5261	chilled graveyard snowglobe	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 40, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	shaking slick broken clock	0		Moxie: +10, Last Available: "2011-09"
 5282	spinning dethklok of Flo-Jo	0		Initiative: +100, Last Available: "2011-09"
 5283	greedy glacial clock	0		Meat Drop: +20, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	tumbling slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	gigantic rotten phish stick	9	crappy	Last Available: "2011-09"
+5298	rotten gigantic phish stick	9	crappy	Last Available: "2011-09"
 5299	ribald personal trainer's plastic vampire fangs of the empath	0		Experience Percent (Muscle): +10, Familiar Weight: +5, Sleaze Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	green Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5220,9 +5220,9 @@
 5317	deionized skewed Rattlin' Chains	0		Effect: "Angry Bone", Effect Duration: 22, Last Available: "2011-10"
 5318	chilled activated Gummy Brains	0		Effect: "Weasels Underfoot", Effect Duration: 47, Last Available: "2011-10"
 5319	ionized lime green Blood 'n' Plenty	0		Effect: "Mathematically Precise", Effect Duration: 60, Last Available: "2011-10"
-5320	polymerized bouncing upside-down Lobos Mints	0		Effect: "Bright!", Effect Duration: 24, Last Available: "2011-10"
+5320	polymerized upside-down bouncing Lobos Mints	0		Effect: "Bright!", Effect Duration: 24, Last Available: "2011-10"
 5321	double-dry ionized Sweet Sword	0		Effect: "Muscularrr", Effect Duration: 49, Last Available: "2011-10"
-5322	enchanted bad watered-down Ecto-Cooler	2	decent	Effect: "Heart of Yellow", Effect Duration: 50, Last Available: "2011-10"
+5322	bad enchanted watered-down Ecto-Cooler	2	decent	Effect: "Heart of Yellow", Effect Duration: 50, Last Available: "2011-10"
 5323	smooth huge Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
 5324	artisanal shaking cyan Blood Light	3	EPIC	Last Available: "2011-10"
 5325	acceptable fancy Silver Bullet beer	4	good	Effect: "Hagg-ard", Effect Duration: 15, Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	activated mirror drum of pomade	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 14, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	tumbling asbestos-lined extra-see-thru nightie	0		Hot Resistance: +5, Last Available: "2011-10"
-5333	upside-down greedy Lo Pan's BRAINS shorts	0		Spell Critical Percent: +30, Meat Drop: +20, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	upside-down greedy Lo Pan's BRAINS shorts	0		Spell Critical Percent: +30, Meat Drop: +20, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	crafty Mesmereyes&trade; contact lenses	0		Maximum MP: +10, Single Equip, Last Available: "2011-10"
 5335	dog trainer's scrunchie	0		Experience (familiar): +1, Single Equip, Last Available: "2011-10"
-5336	twirling Jack Frost's extremely skinny jeans of courage	0		Cold Spell Damage: +50, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	gray Newton's sage The Necbromancer's Hat	0		Mysticality Percent: +10, Experience (Mysticality): +3, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	twirling Jack Frost's extremely skinny jeans of courage	0		Cold Spell Damage: +50, Spooky Resistance: +3, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	gray Newton's sage The Necbromancer's Hat	0		Mysticality Percent: +10, Experience (Mysticality): +3, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	jittery spinning brainy The Necbromancer's Stein of the storm of horror	0		Mysticality: +5, Maximum MP Percent: +40, Spooky Spell Damage: +25, Last Available: "2011-10"
-5339	perfumed weightlifter's The Necbromancer's Shorts of the businessman	0		Muscle: +15, Stench Resistance: +5, Meat Drop: +50, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	perfumed weightlifter's The Necbromancer's Shorts of the businessman	0		Muscle: +15, Stench Resistance: +5, Meat Drop: +50, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	rosewater-soaked Jack Frost's quilted The Necbromancer's Wizard Staff	0		Damage Absorption: +40, Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	spirit-forward acceptable narrow The Cooler Out of Space	5	good	Last Available: "2011-10"
@@ -5261,7 +5261,7 @@
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	skewed Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
-5361	bouncing ghostly The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
+5361	ghostly bouncing The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	purple blinking CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
@@ -5289,7 +5289,7 @@
 5386	olive weightlifter's ridiculous belt	0		Muscle: +15, Last Available: "2011-11"
 5387	occult ridiculous earring	0		Spell Damage Percent: +25, Last Available: "2011-11"
 5388	spinning rock-hard ridiculous sunglasses	0		Damage Reduction: 5, Last Available: "2011-11"
-5389	bite-sized decent ridiculous sandwich	1	good	Last Available: "2011-11"
+5389	decent bite-sized ridiculous sandwich	1	good	Last Available: "2011-11"
 5390	artisanal narrow ridiculous cocktail	4	EPIC	Last Available: "2011-11"
 5391	scandalous lion tamer's zombie monkey necklace	0		Experience (familiar): +2, Sleaze Damage: +5
 5392	Thwaitgold butterfly statuette	0		
@@ -5306,10 +5306,10 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	shaking Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	Usain Bolt's Jim Carey's wicked cane-mail shirt	0		Spell Damage: +5, Monster Level: +25, Initiative: +80, Last Available: "2011-12"
-5406	horrifying chilly cane-mail pants of the sewer	0		Cold Damage: +5, Stench Damage: +25, Spooky Damage: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	horrifying chilly cane-mail pants of the sewer	0		Cold Damage: +5, Stench Damage: +25, Spooky Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	enchanted mediocre jittery Vodka Matryoshka	4	decent	Effect: "Fungal Fortification", Effect Duration: 15, Last Available: "2011-12"
 5408	tolerable Gin Mint	3	good	Last Available: "2011-12"
-5409	mediocre boozy Tequiz Navidad	5	decent	Last Available: "2011-12"
+5409	boozy mediocre Tequiz Navidad	5	decent	Last Available: "2011-12"
 5410	bad Mint Yulep	4	decent	Last Available: "2011-12"
 5411	hand-crafted Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	perfectly mixed Sangria de Menthe	4	EPIC	Last Available: "2011-12"
@@ -5327,11 +5327,11 @@
 5424	fuchsia cool kumquartz ring	0		Moxie: +5, Single Equip, Last Available: "2011-11"
 5425	strawberyl necklace of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2011-11"
 5426	dangerous sucker bucket of the pedagogue	0		Experience: +3, Weapon Damage: +10, Last Available: "2011-11"
-5427	fuchsia resourceful sucker hakama	0		Maximum MP: +50, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	toasty sucker kabuto	0		Hot Damage: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	fuchsia resourceful sucker hakama	0		Maximum MP: +50, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	toasty sucker kabuto	0		Hot Damage: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	studded sucker tachi	0		Damage Absorption: +80, Last Available: "2011-11"
 5430	narrow sucker scaffold	0		Last Available: "2011-11"
-5431	mirror twirling cinnamon troll doll	0		Last Available: "2011-11"
+5431	twirling mirror cinnamon troll doll	0		Last Available: "2011-11"
 5432	grape troll doll	0		Last Available: "2011-11"
 5433	raspberry troll doll	0		Last Available: "2011-11"
 5434	squat pulsating DNOTC Box	0		Last Available: "2017-12"
@@ -5363,7 +5363,7 @@
 5460	careful hardened fudgecycle	0		Damage Reduction: 3, Monster Level: -10, Item Drop: +5, Single Equip, Last Available: "2011-11"
 5461	blinking fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	colloidal twirling resolution: be wealthier	0		Effect: "Riboflavin'", Effect Duration: 16, Last Available: "2012-01"
 5465	chilled ionized resolution: be happier	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 65, Last Available: "2012-01"
 5466	irradiated resolution: be stronger	0		Effect: "Heart of White", Effect Duration: 54, Last Available: "2012-01"
@@ -5381,9 +5381,9 @@
 5478	chilled gummi canary	0		Effect: "Greasy Flavor", Effect Duration: 55, Last Available: "2011-11"
 5479	yummy gummi bear	3	awesome	Last Available: "2011-11"
 5480	moldy tumbling gummi bear	3	crappy	Last Available: "2011-11"
-5481	big adequate gummi bear	5	good	Last Available: "2011-11"
-5482	thick rotten green drunki-bear	5	crappy	Last Available: "2011-11"
-5483	jumbo spoiled drunki-bear	5	crappy	Last Available: "2011-11"
+5481	adequate big gummi bear	5	good	Last Available: "2011-11"
+5482	rotten thick green drunki-bear	5	crappy	Last Available: "2011-11"
+5483	spoiled jumbo drunki-bear	5	crappy	Last Available: "2011-11"
 5484	moldy drunki-bear	3	crappy	Last Available: "2011-11"
 5485	purple hardy gummi bowtie	0		Maximum HP: +50, Last Available: "2011-11"
 5486	narrow medical-grade fudge pocket square	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	corrupted vacuum-sealed bouncing gummi belemnite	0		Effect: "Rave Nirvana", Effect Duration: 32, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	Big Candy's tophat of wisdom of the brazier	0		Mysticality: +15, Hot Spell Damage: +25, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	Big Candy's tophat of wisdom of the brazier	0		Mysticality: +15, Hot Spell Damage: +25, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	skewed Jackass Plumber home game	0		Last Available: "2011-11"
 5502	huge Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5418,7 +5418,7 @@
 5515	pog #01 (spider)	0		Last Available: "2011-11"
 5516	pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	narrow pog #03 (warwelf)	0		Last Available: "2011-11"
-5518	jittery skewed pog #04 (skleleton)	0		Last Available: "2011-11"
+5518	skewed jittery pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	narrow pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	upside-down pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
@@ -5429,12 +5429,12 @@
 5526	vacuum-sealed shaking purple Atomic Pop	0		Effect: "Feeling No Pain", Effect Duration: 64, Last Available: "2020-09"
 5527	narrow do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	cyan whimpering willow bark	0		Last Available: "2012-12"
-5529	yummy diet berries of suffering	1	awesome	Last Available: "2012-12"
+5529	diet yummy berries of suffering	1	awesome	Last Available: "2012-12"
 5530	galvanized non-improved baobab sap	0		Effect: "Hobonic", Effect Duration: 64, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	denatured extra-pressed blinking Mortimer's nostrum	0		Effect: "Mint-Condition Breath", Effect Duration: 35, Last Available: "2012-12"
-5534	practically non-alcoholic perfectly mixed Barulio's bottle	1	super ultra mega turbo EPIC	Last Available: "2012-12"
+5534	perfectly mixed practically non-alcoholic Barulio's bottle	1	super ultra mega turbo EPIC	Last Available: "2012-12"
 5535	energized aerosolized enhanced gray Marvin's marvelous pill	0		Effect: "Spooky Jellied", Effect Duration: 45, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5444,7 +5444,7 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	quilted thinker's Leapin' Trousers	0		Mysticality: +10, Damage Absorption: +40
-5544	weak perfectly mixed spinning eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
+5544	perfectly mixed weak spinning eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
 5545	delicious snack-sized jittery hamhock	2	awesome	Last Available: "2012-12"
 5546	cyan The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	greedy aromatic Rain-Doh wings	0		Stench Resistance: +1, Meat Drop: +20, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	wobbly inspector's Rain-Doh laser gun of the cheetah	0		Item Drop: +15, Initiative: +60, Softcore Only, Last Available: "2012-02"
-5559	teal chilly wholesome Rain-Doh lantern	0		Maximum HP Percent: +10, Cold Damage: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	teal chilly wholesome Rain-Doh lantern	0		Maximum HP Percent: +10, Cold Damage: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	spinning Rain-Doh balls	0		Last Available: "2012-02"
 5561	blurry Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	razor-sharp Socratic Rain-Doh violet bo	0		Experience (Mysticality): +1, Weapon Damage Percent: +25, Softcore Only, Last Available: "2012-02"
@@ -5473,46 +5473,46 @@
 5570	loose ninja carabiner	0		
 5571	blue Groar's fur	0		
 5572	upside-down Thwaitgold stag beetle statuette	0		
-5573	delicious weak Drac & Tan	2	awesome	Last Available: "2012-03"
-5574	lousy extra-dry twirling Transylvania Sling	5	decent	Last Available: "2012-03"
+5573	weak delicious Drac & Tan	2	awesome	Last Available: "2012-03"
+5574	extra-dry lousy twirling Transylvania Sling	5	decent	Last Available: "2012-03"
 5575	acceptable Shot of the Living Dead	3	good	Last Available: "2012-03"
 5576	hand-crafted Buttery Knob	3	EPIC	Last Available: "2012-03"
-5577	special tolerable Slippery Knob	4	good	Effect: "Adorable Lookout", Effect Duration: 45, Last Available: "2012-03"
+5577	tolerable special Slippery Knob	4	good	Effect: "Adorable Lookout", Effect Duration: 45, Last Available: "2012-03"
 5578	delicious Flaming Knob	4	awesome	Last Available: "2012-03"
 5579	practically non-alcoholic drinkable Grasshopper	1	good	Last Available: "2012-03"
-5580	mediocre irresponsibly strong Locust	6	decent	Last Available: "2012-03"
+5580	irresponsibly strong mediocre Locust	6	decent	Last Available: "2012-03"
 5581	mediocre practically non-alcoholic squat Plague of Locusts	1	decent	Last Available: "2012-03"
-5582	tolerable practically non-alcoholic Red Dwarf	1	good	Last Available: "2012-03"
-5583	delicious boozy Golden Mean	5	awesome	Last Available: "2012-03"
-5584	distilled lousy Green Giant	5	decent	Last Available: "2012-03"
+5582	practically non-alcoholic tolerable Red Dwarf	1	good	Last Available: "2012-03"
+5583	boozy delicious Golden Mean	5	awesome	Last Available: "2012-03"
+5584	lousy distilled Green Giant	5	decent	Last Available: "2012-03"
 5585	artisanal Aye Aye	4	EPIC	Last Available: "2012-03"
 5586	perfectly mixed Aye Aye, Captain	4	EPIC	Last Available: "2012-03"
 5587	artisanal olive Aye Aye, Tooth Tooth	3	EPIC	Last Available: "2012-03"
 5588	fancy smooth Humanitini	3	awesome	Effect: "L'instinct F&eacute;lin", Effect Duration: 30, Last Available: "2012-03"
-5589	hand-crafted weak More Humanitini than Humanitini	2	EPIC	Last Available: "2012-03"
+5589	weak hand-crafted More Humanitini than Humanitini	2	EPIC	Last Available: "2012-03"
 5590	perfectly mixed practically non-alcoholic Oh, the Humanitini	1	super ultra EPIC	Last Available: "2012-03"
-5591	practically non-alcoholic hand-crafted yellow Great Older Fashioned	1	EPIC	Last Available: "2012-03"
+5591	hand-crafted practically non-alcoholic yellow Great Older Fashioned	1	EPIC	Last Available: "2012-03"
 5592	hand-crafted Fuzzy Tentacle	3	EPIC	Last Available: "2012-03"
-5593	watered-down bad Crazymaker	2	decent	Last Available: "2012-03"
-5594	high-proof smooth Zoodriver	7	awesome	Last Available: "2012-03"
+5593	bad watered-down Crazymaker	2	decent	Last Available: "2012-03"
+5594	smooth high-proof Zoodriver	7	awesome	Last Available: "2012-03"
 5595	tolerable shaking Sloe Comfortable Zoo	4	good	Last Available: "2012-03"
 5596	perfectly mixed special red Sloe Comfortable Zoo on Fire	3	EPIC	Effect: "Speed of the Internet", Effect Duration: 45, Last Available: "2012-03"
 5597	triple-distilled tolerable jittery Suffering Sinner	9	good	Last Available: "2012-03"
 5598	acceptable Suppurating Sinner	3	good	Last Available: "2012-03"
-5599	bad boozy skewed Sizzling Sinner	5	decent	Last Available: "2012-03"
+5599	boozy bad skewed Sizzling Sinner	5	decent	Last Available: "2012-03"
 5600	artisanal fuchsia Firewater	4	EPIC	Last Available: "2012-03"
-5601	mediocre high-proof Earth and Firewater	9	decent	Last Available: "2012-03"
-5602	distilled drinkable Earth, Wind and Firewater	5	good	Last Available: "2012-03"
+5601	high-proof mediocre Earth and Firewater	9	decent	Last Available: "2012-03"
+5602	drinkable distilled Earth, Wind and Firewater	5	good	Last Available: "2012-03"
 5603	perfectly mixed gray Slimosa	4	EPIC	Last Available: "2012-03"
 5604	hand-crafted Extra-slimy Slimosa	4	EPIC	Last Available: "2012-03"
 5605	watered-down drinkable Slimebite	2	good	Last Available: "2012-03"
-5606	mediocre triple-distilled Cement Mixer	6	decent	Last Available: "2012-03"
+5606	triple-distilled mediocre Cement Mixer	6	decent	Last Available: "2012-03"
 5607	practically non-alcoholic drinkable Jackhammer	1	good	Last Available: "2012-03"
-5608	strong lousy Dump Truck	5	decent	Last Available: "2012-03"
+5608	lousy strong Dump Truck	5	decent	Last Available: "2012-03"
 5609	hand-crafted Fauna Libre	4	EPIC	Last Available: "2012-03"
 5610	practically non-alcoholic hand-crafted Chakra Libre	1	EPIC	Last Available: "2012-03"
-5611	triple-distilled mediocre Aura Libre	10	decent	Last Available: "2012-03"
-5612	tolerable ghostly squat Sazerorc	3	good	Last Available: "2012-03"
+5611	mediocre triple-distilled Aura Libre	10	decent	Last Available: "2012-03"
+5612	tolerable squat ghostly Sazerorc	3	good	Last Available: "2012-03"
 5613	mediocre Sazuruk-hai	4	decent	Last Available: "2012-03"
 5614	watered-down delicious Flaming Sazerorc	2	awesome	Last Available: "2012-03"
 5615	mediocre practically non-alcoholic Green Velvet	1	decent	Last Available: "2012-03"
@@ -5522,9 +5522,9 @@
 5619	drinkable blinking Moonshine Mohobo	4	good	Last Available: "2012-03"
 5620	lousy olive Flaming Mohobo	3	decent	Last Available: "2012-03"
 5621	aged Drunken Philosopher	4	awesome	Last Available: "2012-03"
-5622	hand-crafted irresponsibly strong Drunken Neurologist	6	EPIC	Last Available: "2012-03"
+5622	irresponsibly strong hand-crafted Drunken Neurologist	6	EPIC	Last Available: "2012-03"
 5623	hand-crafted pulsating Drunken Astrophysicist	4	EPIC	Last Available: "2012-03"
-5624	perfectly mixed watered-down squat blurry Dark & Starry	2	EPIC	Last Available: "2012-03"
+5624	watered-down perfectly mixed blurry squat Dark & Starry	2	EPIC	Last Available: "2012-03"
 5625	special tolerable Black Hole	4	good	Effect: "Extra-Wet", Effect Duration: 50, Last Available: "2012-03"
 5626	mediocre jittery Event Horizon	4	decent	Last Available: "2012-03"
 5627	perfectly mixed blurry Herring Daiquiri	4	EPIC	Last Available: "2012-03"
@@ -5536,7 +5536,7 @@
 5633	irresponsibly strong mediocre ghostly Caipiranha	6	decent	Last Available: "2012-03"
 5634	perfectly mixed twirling shaking Flying Caipiranha	3	EPIC	Last Available: "2012-03"
 5635	watered-down tolerable spinning Flaming Caipiranha	2	good	Last Available: "2012-03"
-5636	drinkable spirit-forward Punchplanter	5	good	Last Available: "2012-03"
+5636	spirit-forward drinkable Punchplanter	5	good	Last Available: "2012-03"
 5637	weak mediocre mirror Doublepunchplanter	2	decent	Last Available: "2012-03"
 5638	artisanal olive skewed Haymaker	4	EPIC	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
@@ -5548,9 +5548,9 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	mansplainer's calendar	0		Monster Level: +15, Damage Reduction: 4
-5648	mirror skewed Boris's Helm of the wise owl of vim and vigor	0		Mysticality: +20, Maximum HP Percent: +50, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	mirror skewed Boris's Helm of the wise owl of vim and vigor	0		Mysticality: +20, Maximum HP Percent: +50, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	maroon groovy staph of homophones of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50
-5650	double-paned banded baleful Boris's Helm (askew)	0		Spell Damage: +25, Damage Absorption: +100, Cold Resistance: +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	double-paned banded baleful Boris's Helm (askew)	0		Spell Damage: +25, Damage Absorption: +100, Cold Resistance: +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	red mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	shaking key-o-tron	0		
@@ -5571,15 +5571,15 @@
 5668	bagged &quot;L&quot;	0		
 5669	tumbling club	0		
 5670	toothsome jumbo fettucini &eacute;pines Inconnu	5	awesome	
-5671	weak lousy slap and slap again	2	decent	
+5671	lousy weak slap and slap again	2	decent	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	powdered watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	Herculean Ze&trade; goggles	0		Experience (Muscle): +1, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	Herculean Ze&trade; goggles	0		Experience (Muscle): +1, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	ghostly blinking soggy used band-aid	0		Last Available: "2012-05"
-5679	forbidden educational stylish swimsuit	0		Experience: +1, Spell Damage Percent: +50, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	forbidden educational stylish swimsuit	0		Experience: +1, Spell Damage Percent: +50, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
 5681	stale P.B.L.T.	3	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	censurious double-paned wax hat	0		Cold Resistance: +5, Sleaze Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	scandalous wax pants of wisdom	0		Mysticality: +15, Sleaze Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	censurious double-paned wax hat	0		Cold Resistance: +5, Sleaze Resistance: +3, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	scandalous wax pants of wisdom	0		Mysticality: +15, Sleaze Damage: +5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	tumbling FDKOL commendation	0		Last Available: "2012-07"
 5708	extra-corrupted drop of water-37	0		Effect: "Eldritch Concentration", Effect Duration: 44, Last Available: "2012-07"
-5709	huge frosty arcane researcher's fireman's helmet	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +10, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	huge frosty arcane researcher's fireman's helmet	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +10, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	blinking smelly fire axe	0		Stench Spell Damage: +10, Last Available: "2012-07"
 5713	deadly weightlifter's fire extinguisher of the scaredy-cat	0		Muscle: +15, Weapon Damage: +5, Monster Level: -15, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5624,8 +5624,8 @@
 5723	dry non-oxidized bottle of fire	0		Effect: "Tapped In", Effect Duration: 52, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	twirling electrified stiffened hot daub bun	0		Damage Reduction: 1, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	blue hot daub stand of the cougar of the businessman	0		Moxie: +20, Meat Drop: +50, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	twirling electrified stiffened hot daub bun	0		Damage Reduction: 1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	blue hot daub stand of the cougar of the businessman	0		Moxie: +20, Meat Drop: +50, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	weightlifter's foot-long hot daub of the scaredy-cat	0		Muscle: +15, Monster Level: -15, Last Available: "2012-07"
 5729	twirling ballpark hot daub	0		Last Available: "2012-07"
 5730	normal fuchsia angst burger	4	good	
@@ -5634,24 +5634,24 @@
 5733	eerily silent box	0		
 5734	spoiled forbidden sausage	3	crappy	
 5735	beefcake's Lord Flameface's cloak	0		Muscle: +25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
-5736	colloidal shaking bouncing Drizzlers&trade; Black Licorice	0		Effect: "Shoesauce", Effect Duration: 28
+5736	colloidal bouncing shaking Drizzlers&trade; Black Licorice	0		Effect: "Shoesauce", Effect Duration: 28
 5737	irradiated ionized daub-breaker	0		Effect: "Mo' Hobo", Effect Duration: 20, Last Available: "2020-09"
 5738	Camp Scout backpack of temperance	0		Sleaze Resistance: +5, Softcore Only, Last Available: "2012-07"
 5739	blinking CSA fire-starting kit	0		Last Available: "2012-07"
 5740	flavorless super-sized bag of GORP	5	decent	Last Available: "2012-07"
 5741	mediocre water purification pills	4	decent	Last Available: "2012-07"
 5742	maroon Camp Scout pup tent	0		Last Available: "2012-07"
-5743	triple-distilled hand-crafted blinking CSA scoutmaster's &quot;water&quot;	8	EPIC	Last Available: "2012-07"
+5743	hand-crafted triple-distilled blinking CSA scoutmaster's &quot;water&quot;	8	EPIC	Last Available: "2012-07"
 5744	tasty bag of GORF	3	awesome	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	spoiled special bag of QWOP	3	crappy	Effect: "Patched In", Effect Duration: 20, Last Available: "2012-07"
+5746	special spoiled bag of QWOP	3	crappy	Effect: "Patched In", Effect Duration: 20, Last Available: "2012-07"
 5747	frozen blinking CSA bravery badge	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 48, Last Available: "2012-07"
 5748	tumbling CSA all-purpose soap	0		Last Available: "2012-07"
 5749	acceptable CSA cheerfulness ration	3	good	Last Available: "2012-07"
 5750	cyan CSA obedience grenade	0		Last Available: "2012-07"
 5751	wobbly Tales of the Word Realms	0		
 5752	flavorless crappy brain	3	decent	
-5753	diet decent blinking decent brain	1	good	
+5753	decent diet blinking decent brain	1	good	
 5754	normal blinking good brain	3	good	
 5755	stale boss brain	4	decent	
 5756	moldy hunter brain	3	crappy	
@@ -5665,11 +5665,11 @@
 5765	ribald rock-hard fuzzy earmuffs	0		Damage Reduction: 5, Sleaze Damage: +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	censurious sizzling hardened fuzzy montera	0		Damage Reduction: 3, Hot Damage: +10, Sleaze Resistance: +3, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	pulsating gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	pulsating gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	blurry Thwaitgold maggot statuette	0		
 5774	twirling talkative skull	0		
 5775	squat fronts	0		Familiar Weight: +5
@@ -5677,7 +5677,7 @@
 5778	rotten pulsating idiot brain	3	crappy	
 5779	ghostly upside-down wholesome keel-haulin' knife	0		Maximum HP Percent: +10
 5780	Fonzie's ice cream scoop	0		Experience (Moxie): +1
-5781	extra-dry acceptable soft echo eyedrop antidote martini	5	good	
+5781	acceptable extra-dry soft echo eyedrop antidote martini	5	good	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5685,7 +5685,7 @@
 5786	upside-down hard screw	0		
 5787	messy butt joint	0		
 5788	spinning smut orc keepsake box	0		
-5789	maroon ghostly bubblin' crude	0		
+5789	ghostly maroon bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
 5791	upside-down lightning-fast auspicious right bear arm	0		Item Drop: +10, Initiative: +40, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
 5792	mirror fireproof Sinatra's Herculean left bear arm	0		Experience (Muscle): +1, Experience (Moxie): +5, Hot Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
@@ -5710,7 +5710,7 @@
 5811	diffused shaking tube of lipstick	0		Effect: "Just Aged Enough", Effect Duration: 44
 5812	ionized skelelton spine	0		Effect: "Gyromitra Gymnastics", Effect Duration: 33
 5813	super-polarized nitrogenated smut orc sunglasses	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 63
-5814	ionized warmed upside-down cyan blob of acid	0		Effect: "Litterboxing", Effect Duration: 48
+5814	ionized warmed cyan upside-down blob of acid	0		Effect: "Litterboxing", Effect Duration: 48
 5815	adjusted flayed mind	0		Effect: "Jungle Juiced", Effect Duration: 52
 5816	corrupted denatured mirror kobold kibble	0		Effect: "Moon'd", Effect Duration: 51
 5817	non-corrupted electrified ghostly forest spirit rattle	0		Effect: "Bloody-minded", Effect Duration: 34
@@ -5722,11 +5722,11 @@
 5823	nitrogenated canopic jar	0		Effect: "Barking Mad", Effect Duration: 66
 5824	cold-filtered tarnished clove-flavored lip balm	0		Effect: "Bilious Briskness", Effect Duration: 41
 5825	adjusted super-quantum Skullery Maid's Knee	0		Effect: "5 Pounds Lighter", Effect Duration: 27
-5826	nitrogenated super-adjusted teal pulsating zombie hollandaise	0		Effect: "On Pins and Needles", Effect Duration: 53
+5826	nitrogenated super-adjusted pulsating teal zombie hollandaise	0		Effect: "On Pins and Needles", Effect Duration: 53
 5827	cold-filtered wet skeletal banana	0		Effect: "The Best a Pirate Can Get", Effect Duration: 11
 5828	super-anodized polymerized magnetized maroon gilt perfume bottle	0		Effect: "No Worries", Effect Duration: 16
 5829	frozen oxidized green janglin' bones	0		Effect: "Pumped Up", Effect Duration: 42
-5830	dry alkaline spinning pulsating pygmy papers	0		Effect: "Wise Spirit", Effect Duration: 16
+5830	dry alkaline pulsating spinning pygmy papers	0		Effect: "Wise Spirit", Effect Duration: 16
 5831	flattened tumbling red pygmy dart	0		Effect: "Butt-Rock Hair", Effect Duration: 13
 5832	cold-filtered secret mummy herbs and spices	0		Effect: "Cotton Mouthed", Effect Duration: 21
 5833	super-alkaline frozen triple-adjusted brigand brittle	0		Effect: "On the Trolley", Effect Duration: 66
@@ -5758,7 +5758,7 @@
 5859	dry shaking jittery booby trap	0		Effect: "On Pins and Needles", Effect Duration: 48
 5860	energized alkaline Agent Corrigan's cigarette	0		Effect: "Infernal Thirst", Effect Duration: 23
 5861	double-polymerized quantum good ash	0		Effect: "Neuroplastici Tea", Effect Duration: 64
-5862	huge jittery Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	jittery huge Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	red Rad Lib	0		Last Available: "2012-09"
 5864	squat papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	double-energized tarnished wobbly papier-mochi	0		Effect: "The Wisdom... of the Future", Effect Duration: 64, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	dance instructor's Samson's papier-m&acirc;ch&eacute;te	0		Experience (Muscle): +5, Experience Percent (Moxie): +10, Last Available: "2012-09"
 5869	double-paned therapeutic papier-m&acirc;chine gun	0		Cold Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-09"
 5870	censurious papier-masque of vim and vigor	0		Maximum HP Percent: +50, Sleaze Resistance: +3, Single Equip, Last Available: "2012-09"
-5871	squat flame-retardant shellacked papier-mitre	0		Damage Reduction: 7, Hot Resistance: +1, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	Jeselnik's Newton's papier-m&acirc;churidars	0		Experience (Mysticality): +3, Sleaze Damage: +25, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	squat flame-retardant shellacked papier-mitre	0		Damage Reduction: 7, Hot Resistance: +1, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	Jeselnik's Newton's papier-m&acirc;churidars	0		Experience (Mysticality): +3, Sleaze Damage: +25, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	red papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	squat papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5777,7 +5777,7 @@
 5878	wobbly ribald Rainbow Jello Mould	0		Sleaze Damage: +10
 5879	pulsating jittery Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
-5881	blinking skewed skeleton	0		Last Available: "2012-10"
+5881	skewed blinking skeleton	0		Last Available: "2012-10"
 5882	knitted Newton's skeleton skis of the businessman	0		Experience (Mysticality): +3, Cold Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2012-10"
 5883	rotten skeleton quiche	4	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	upside-down BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	Jack Frost's brainwave-controlled unicorn horn	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	Jack Frost's brainwave-controlled unicorn horn	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	spinning bubble-wrap simulator	0		Last Available: "2012-12"
 5930	huge blind-packed capsule toy	0		Last Available: "2012-12"
 5931	family-friendly reassuring chilly plastic four-shadowed mime	0		Cold Damage: +5, Spooky Resistance: +1, Sleaze Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,15 +5858,15 @@
 5960	aromatic plastic Father McGruber	0		Stench Resistance: +1, Last Available: "2012-12"
 5961	brainy plastic Hank North, Photojournalist	0		Mysticality: +5, Last Available: "2012-12"
 5962	double-paned plastic blazing bat	0		Cold Resistance: +5, Last Available: "2012-12"
-5963	blurry bouncing smelly electronic dulcimer pants of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
-5964	teal tumbling A-Boo clue	0		
+5963	blurry bouncing smelly electronic dulcimer pants of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5964	tumbling teal A-Boo clue	0		
 5965	reassuring banded Frown Exerciser	0		Damage Absorption: +100, Spooky Resistance: +1, Single Equip, Last Available: "2012-12"
 5966	huge soul monocle	0		Single Equip
 5967	soul doorbell	0		
 5968	soul coin	0		
 5969	soul knife	0		
 5970	Jack Frost's soul mask	0		Cold Spell Damage: +50, Single Equip
-5971	green upside-down record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
+5971	upside-down green record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
 5972	record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
 5973	jittery record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	maroon huge record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
@@ -5877,31 +5877,31 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	fortified hand-crafted ghostly tankard of ale	5	EPIC	Last Available: "2013-02"
+5982	hand-crafted fortified ghostly tankard of ale	5	EPIC	Last Available: "2013-02"
 5983	ghostly vial of holy water	0		Last Available: "2013-02"
-5984	manspreader's studded cloth cap of the brute	0		Muscle Percent: +30, Damage Absorption: +80, Monster Level: +10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	manspreader's studded cloth cap of the brute	0		Muscle Percent: +30, Damage Absorption: +80, Monster Level: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	up-at-dawn vibrating extremely unsafe iron dagger	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Adventures: +5, Last Available: "2013-02"
 5986	half-sized adequate tumbling hamburger	2	good	Last Available: "2013-02"
 5987	ghostly dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	watered-down drinkable bottle of wine	2	good	Last Available: "2013-02"
+5990	drinkable watered-down bottle of wine	2	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	greasy resourceful iron helmet	0		Maximum MP: +50, Sleaze Spell Damage: +10, Item Drop: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	greasy resourceful iron helmet	0		Maximum MP: +50, Sleaze Spell Damage: +10, Item Drop: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	squat gray savvy brainy steel sword of Gandalf	0		Mysticality: +5, Mysticality Percent: +20, Spell Critical Percent: +20, Last Available: "2013-02"
 5994	rotten whole roasted chicken	3	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	squat extra-strength potion	0		Last Available: "2013-02"
-5997	spinning squat potion	0		Last Available: "2013-02"
+5997	squat spinning potion	0		Last Available: "2013-02"
 5998	bad ghostly shining goblet	4	decent	Last Available: "2013-02"
 5999	spinning fireball	0		Last Available: "2013-02"
-6000	fireproof shellacked crown of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Hot Resistance: +3, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	fireproof shellacked crown of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Hot Resistance: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	skewed up-at-dawn reassuring sword of the ox	0		Muscle: +20, Spooky Resistance: +1, Adventures: +5, Last Available: "2013-02"
-6002	twirling strapping Helm of the Scream Emperor of the cougar of chilblains	0		Muscle: +5, Moxie: +20, Cold Damage: +25, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	twirling strapping Helm of the Scream Emperor of the cougar of chilblains	0		Muscle: +5, Moxie: +20, Cold Damage: +25, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	mirror skewed Jeselnik's Van der Graaf brawny Cloak of Dire Shadows	0		Muscle Percent: +20, Sleaze Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-02"
 6004	double-paned manspreader's baleful Sword of Dark Omens	0		Spell Damage: +25, Monster Level: +10, Cold Resistance: +5, Last Available: "2013-02"
 6005	sharpshooter's Fonzie's Shield of Icy Fate of the blizzard	0		Experience (Moxie): +1, Critical Hit Percent: +10, Cold Spell Damage: +25, Damage Reduction: 7, Last Available: "2013-02"
-6006	spinning zippy Jim Carey's Da Vinci's Greaves of the Murk Lord	0		Experience (Mysticality): +5, Monster Level: +25, Initiative: +20, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	spinning zippy Jim Carey's Da Vinci's Greaves of the Murk Lord	0		Experience (Mysticality): +5, Monster Level: +25, Initiative: +20, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	huge lard-coated fortified quilted Gauntlets of the Blood Moon	0		Damage Absorption: 100, Sleaze Spell Damage: +25, Single Equip, Last Available: "2013-02"
 6008	executive horrifying hardened Boots of Twilight Whispers	0		Damage Reduction: 3, Spooky Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2013-02"
 6009	manspreader's brawny Belt of Howling Anger of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, Monster Level: +10, Single Equip, Last Available: "2013-02"
@@ -5911,7 +5911,7 @@
 6013	stanky dangerous orcish stud-finder	0		Weapon Damage: +10, Stench Spell Damage: +25
 6014	chaotic screwing pooch	0		Spell Critical Percent: +10
 6015	pickled orcish hand lotion	0		Effect: "In a Lather", Effect Duration: 61
-6016	liquefied liquefied jittery huge orcish rubber	0		Effect: "Alpine Mintiness", Effect Duration: 28
+6016	liquefied liquefied huge jittery orcish rubber	0		Effect: "Alpine Mintiness", Effect Duration: 28
 6017	dry orcish nailing lube	0		Effect: "Pork Power", Effect Duration: 64
 6018	mediocre blinking backwoods screwdriver	3	decent	
 6019	loadstone of courage	0		Spooky Resistance: +3
@@ -5922,7 +5922,7 @@
 6024	fortified Whatsian Ionic Pliers	0		Damage Absorption: +60
 6025	frozen Polysniff Perfume	0		Effect: "Pretending to Pretend", Effect Duration: 53
 6026	shaking Duskwalker syringe	0		
-6027	upside-down shaking Space Tours Tripple	0		
+6027	shaking upside-down Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	olive T.U.R.D.S. Key	0		
 6030	squat nasty dress pants	0		Stench Damage: +5, Familiar Effect: "2xFairy, cap 28"
@@ -5947,11 +5947,11 @@
 6049	padded occult weightlifter's Misty Cape	0		Muscle: +15, Spell Damage Percent: +25, Damage Absorption: +20
 6050	cyan woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	half-sized decent Taco Dan's Taco Stand Taco	2	good	Last Available: "2012-12"
+6052	decent half-sized Taco Dan's Taco Stand Taco	2	good	Last Available: "2012-12"
 6053	artisanal practically non-alcoholic Taco Dan's Taco Stand Chimichangarita	1	EPIC	Last Available: "2012-12"
 6054	energized chilled modified Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Hopped Up on Goofballs", Effect Duration: 56, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	friendly supercool Meatcleaver	0		Moxie Percent: +20, Familiar Weight: +3, Last Available: "2013-12"
 6058	wobbly zippy Crimbo Elf bobble-head	0		Initiative: +20, Last Available: "2012-12"
 6059	huge Crimbo stogie-scented room odorizer of Tarzan	0		Experience (Muscle): +3, Last Available: "2012-12"
@@ -5963,10 +5963,10 @@
 6065	wad of spider silk	0		
 6066	jittery goblin collarbone	0		
 6067	stanky Newton's Truthsayer	0		Experience (Mysticality): +3, Stench Spell Damage: +25, Last Available: "2013-12"
-6068	olive upside-down loose blade	0		
+6068	upside-down olive loose blade	0		
 6069	ghostly goblin bone hilt	0		
 6070	sword blade	0		
-6071	red blurry Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	blurry red Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	shaking confusing LED clock	0		Last Available: "2012-12"
 6073	nitrogenated unsweetened upside-down haggis-infused soap	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 59, Last Available: "2012-12"
 6074	frozen magicberry tablets	0		Effect: "Radium Radicality", Effect Duration: 11, Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	high-proof tolerable Chinese beer	7	good	Last Available: "2013-12"
+6121	tolerable high-proof Chinese beer	7	good	Last Available: "2013-12"
 6122	teal cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6040,14 +6040,14 @@
 6142	tasty small roasted duck	2	awesome	Last Available: "2013-12"
 6143	delicious half-sized dead meat bun	2	awesome	Last Available: "2013-12"
 6144	blue blinking cat collar of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2013-12"
-6145	wool suspicious-looking fedora of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	wool suspicious-looking fedora of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	twirling MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	fuchsia carrot nose	0		Last Available: "2013-01"
-6152	thick flavorless carrot cake	5	decent	Last Available: "2013-01"
-6153	weak mediocre wobbly carrot claret	2	decent	Last Available: "2013-01"
+6152	flavorless thick carrot cake	5	decent	Last Available: "2013-01"
+6153	mediocre weak wobbly carrot claret	2	decent	Last Available: "2013-01"
 6154	pickled jittery carrot juice	1	EPIC	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	lime green flickering pixel	0		Last Available: "2013-12"
@@ -6058,15 +6058,15 @@
 6161	blurry regret hose of the storm	0		Maximum MP Percent: +40, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	occult wizardly commodore's hat	0		Mysticality: +25, Spell Damage Percent: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	mirror green arcane researcher's naval trousers	0		Experience Percent (Mysticality): +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	occult wizardly commodore's hat	0		Mysticality: +25, Spell Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	mirror green arcane researcher's naval trousers	0		Experience Percent (Mysticality): +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	huge blinking curative rock-hard deck cannon	0		Damage Reduction: 5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
 6167	narrow lion tamer's ornamental sextant	0		Experience (familiar): +2, Last Available: "2013-12"
 6168	rock-hard Bloodbath of the brute	0		Muscle Percent: +30, Damage Reduction: 5, Last Available: "2013-12"
 6169	drinkable Hundred Headed IPA	3	good	Last Available: "2013-12"
-6170	tasty teal huge chum	4	awesome	Last Available: "2013-12"
+6170	tasty huge teal chum	4	awesome	Last Available: "2013-12"
 6171	corrupted liquefied crude crudit&eacute;s	0		Effect: "One Very Clear Eye", Effect Duration: 66
-6172	vacuum-sealed activated ghostly blue shaking candy crayons	0		Effect: "Overstimulated", Effect Duration: 22, Last Available: "2020-09"
+6172	vacuum-sealed activated shaking blue ghostly candy crayons	0		Effect: "Overstimulated", Effect Duration: 22, Last Available: "2020-09"
 6173	olive double-paned Van der Graaf pixel grappling hook	0		Cold Resistance: +5, MP Regen Min: 5, MP Regen Max: 7
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6083,54 +6083,54 @@
 6186	massive normal wobbly consummate fried egg	7	good	
 6187	spoiled huge consummate egg salad	8	crappy	
 6188	adequate consummate bagel	3	good	
-6189	rotten super-sized consummate sliced bread	5	crappy	
+6189	super-sized rotten consummate sliced bread	5	crappy	
 6190	decent cyan spinning consummate hot dog bun	3	good	
-6191	half-sized rotten consummate brownie	2	crappy	
-6192	spoiled snack-sized cyan skewed consummate toast	2	crappy	
-6193	watered-down lousy passable stout	2	decent	
+6191	rotten half-sized consummate brownie	2	crappy	
+6192	snack-sized spoiled cyan skewed consummate toast	2	crappy	
+6193	lousy watered-down passable stout	2	decent	
 6194	flavorless consummate soup	4	decent	
 6195	flavorless miniature consummate corn chips	2	decent	
-6196	thick normal consummate salad	5	good	
+6196	normal thick consummate salad	5	good	
 6197	gigantic spoiled consummate salsa	6	crappy	
 6198	spoiled snack-sized consummate sauerkraut	2	crappy	
-6199	miniature tasty huge consummate cheese slice	2	awesome	
-6200	stale diet enchanted twirling consummate melted cheese	1	decent	Effect: "Wit Tea", Effect Duration: 5
+6199	tasty miniature huge consummate cheese slice	2	awesome	
+6200	enchanted stale diet twirling consummate melted cheese	1	decent	Effect: "Wit Tea", Effect Duration: 5
 6201	half-sized moldy consummate bacon	2	crappy	
-6202	spoiled small consummate meatloaf	2	crappy	
+6202	small spoiled consummate meatloaf	2	crappy	
 6203	flavorless immense consummate steak	8	decent	
 6204	flavorless blue consummate cuts	4	decent	
-6205	flavorless jumbo consummate frankfurter	5	decent	
-6206	moldy gigantic consummate french fries	9	crappy	
+6205	jumbo flavorless consummate frankfurter	5	decent	
+6206	gigantic moldy consummate french fries	9	crappy	
 6207	half-sized flavorless twirling consummate baked potato	2	decent	
 6208	hand-crafted acceptable vodka	3	EPIC	
-6209	decent small fancy teal shaking mirror consummate ice cream	2	good	Effect: "Shawarma Warm War", Effect Duration: 45
+6209	small decent fancy shaking mirror teal consummate ice cream	2	good	Effect: "Shawarma Warm War", Effect Duration: 45
 6210	enchanted bland consummate whipped cream	3	decent	Effect: "Amorous Avarice", Effect Duration: 50
-6211	thick moldy huge consummate cream	5	crappy	
+6211	moldy thick huge consummate cream	5	crappy	
 6212	moldy consummate strawberries	4	crappy	
 6213	small decent purple consummate sorbet	2	good	
-6214	weak hand-crafted green upside-down adequate rum	2	EPIC	
+6214	hand-crafted weak upside-down green adequate rum	2	EPIC	
 6215	enchanted watered-down bad mediocre lager	2	decent	Effect: "Fangs and Pangs", Effect Duration: 20
 6216	decent immaculate grilled cheese	4	good	
 6217	fancy yummy immaculate ice cream sandwich	3	awesome	Effect: "Arresistible", Effect Duration: 10
 6218	rotten jumbo immaculate hot dog	5	crappy	
 6219	big normal skewed immaculate egg salad sandwich	5	good	
-6220	flavorless immense teal perfect sandwich	8	decent	
+6220	immense flavorless teal perfect sandwich	8	decent	
 6221	adequate jumbo bouncing teal perfect chef salad	5	good	
 6222	decent blue shaking perfect breakfast	4	good	
-6223	bite-sized bland sublime deluxe hot dog	1	decent	
+6223	bland bite-sized sublime deluxe hot dog	1	decent	
 6224	decent enchanted gigantic sublime stew	8	good	Effect: "The Power of Positive Thinking", Effect Duration: 35
-6225	spoiled half-sized sublime nachos	2	crappy	
+6225	half-sized spoiled sublime nachos	2	crappy	
 6226	miniature spoiled Ultimate Breakfast Sandwich	2	crappy	
 6227	rotten wobbly Loaded Baked Potato	3	crappy	
 6228	jumbo stale Omega Sundae	5	decent	
 6229	smooth Das Sauerlager	3	awesome	
 6230	bad blinking Bologna Lambic	4	decent	
 6231	bad practically non-alcoholic Vodka Dog	1	decent	
-6232	acceptable practically non-alcoholic twirling squat Disappointed Russian	1	good	
+6232	practically non-alcoholic acceptable squat twirling Disappointed Russian	1	good	
 6233	aged Chunky Mary	3	awesome	
 6234	weak aged enchanted squat Nachojito	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10
 6235	delicious ghostly Le Roi	3	awesome	
-6236	weak mediocre Over Easy Rider	2	decent	
+6236	mediocre weak Over Easy Rider	2	decent	
 6237	cosmic six-pack	0		
 6239	nitrogenated cube of ectoplasm	0		Effect: "Heart of White", Effect Duration: 50
 6240	non-deionized denatured Illuminati earpiece	0		Effect: "No Vertigo", Effect Duration: 13
@@ -6138,7 +6138,7 @@
 6242	quadruple-anodized triple-alkaline shaking blinking ectoplasm <i>au jus</i>	0		Effect: "Nature's Bounty", Effect Duration: 67
 6243	energized the kindest cut	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 30
 6244	super-Vulcanized triple-diffused cat's paw	0		Effect: "Frost Tea", Effect Duration: 38
-6245	chilled magnetized magnetized skewed yellow ASCII fu manchu	0		Effect: "Voracious Gorging", Effect Duration: 62
+6245	chilled magnetized magnetized yellow skewed ASCII fu manchu	0		Effect: "Voracious Gorging", Effect Duration: 62
 6246	wet quantum demonic surgical gloves	0		Effect: "Hobo Flavor", Effect Duration: 52
 6247	liquefied ghostly clip-on ninja tie	0		Effect: "Always be Collecting", Effect Duration: 66
 6248	corrupted cold-filtered purple gamer slurry	0		Effect: "Disdain of She-Who-Was", Effect Duration: 53
@@ -6148,7 +6148,7 @@
 6252	boiled warmed scroll of Puddingskin	0		Effect: "Aided and Abetted", Effect Duration: 52, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	teal Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
-6255	skewed red Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
+6255	red skewed Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	tumbling dried gelatinous cube	0		
 6257	narrow pile of dungeon junk	0		Familiar Weight: +5
 6258	auspicious chilly thinker's Staff of the Healthy Breakfast of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Cold Damage: +5, Item Drop: +10, Jiggle: "Recover Some HP"
@@ -6160,7 +6160,7 @@
 6264	Jim Carey's groovy savvy Staff of Fruit Salad	0		Mysticality Percent: +20, Moxie Percent: +10, Monster Level: +25, Jiggle: "Deal Some Prismatic Damage"
 6265	nasty Temple Grandin's resourceful Staff of the Cream of the Cream	0		Maximum MP: +50, Familiar Weight: +7, Stench Damage: +5, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	decent snack-sized ghostly grain of protein powder	2	good	
+6267	snack-sized decent ghostly grain of protein powder	2	good	
 6268	energized improved upside-down pec oil	0		Effect: "Indescribable Flavor", Effect Duration: 58
 6269	stiffened gym membership card	0		Damage Reduction: 1
 6270	double-polymerized unsweetened moist pulsating purple Squat-Thrust Magazine	0		Effect: "Faboooo", Effect Duration: 26
@@ -6169,7 +6169,7 @@
 6273	polymerized shaking O'RLY manual	0		Effect: "Memories of Puppy Love", Effect Duration: 66
 6274	bad extra-dry open sauce	5	decent	
 6275	greasy MacGyver's turkey leg	0		Maximum MP: +100, Sleaze Spell Damage: +10
-6276	drinkable watered-down Ye Olde Meade	2	good	
+6276	watered-down drinkable Ye Olde Meade	2	good	
 6277	ionized chilled quadruple-colloidal Ye Olde Bawdy Limerick	0		Effect: "Well-Oiled", Effect Duration: 32
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of Tarzan	0		Experience (Muscle): +3
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	upside-down Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	olive banded Mer-kin begsign	0		Damage Absorption: +100, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	Vulcanized frozen pulled taffy	0		Effect: "Stickler for Promptness", Effect Duration: 16, Last Available: "2013-04"
 6362	warmed pulled indigo taffy	0		Effect: "Ticking Clock", Effect Duration: 36, Last Available: "2013-04"
 6363	alkaline pulled taffy	0		Effect: "Cautious Prowl", Effect Duration: 27, Last Available: "2013-04"
@@ -6265,15 +6265,15 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	lousy high-proof squat can of the cheapest beer	6	decent	
-6372	watered-down perfectly mixed bottle of fruity &quot;wine&quot;	2	EPIC	
-6373	drinkable enchanted spirit-forward blinking single swig of vodka	5	good	Effect: "Extra-Thick Blood", Effect Duration: 20
+6372	perfectly mixed watered-down bottle of fruity &quot;wine&quot;	2	EPIC	
+6373	enchanted drinkable spirit-forward blinking single swig of vodka	5	good	Effect: "Extra-Thick Blood", Effect Duration: 20
 6374	angry inch	0		
 6375	blue aromatic testy toolbox	0		Stench Resistance: +1
 6376	Jick-o-User	0		
 6378	eraser nubbin	0		
 6379	mirror chlorine crystal	0		
 6380	liquefied blinking ph balancer	0		Effect: "Kindly Resolve", Effect Duration: 51
-6381	oxidized blinking cyan mysterious chemical residue	0		Effect: "Fungal Flambé", Effect Duration: 36
+6381	oxidized cyan blinking mysterious chemical residue	0		Effect: "Fungal Flambé", Effect Duration: 36
 6382	teal nugget of sodium	0		
 6383	bouncing root beer	1	crappy	
 6384	jigsaw blade	0		
@@ -6282,7 +6282,7 @@
 6387	mirror blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	super-pickled galvanized skewed Mer-kin rocksalt	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 41
-6390	quadruple-frozen adjusted gray twirling Mer-kin saltmint	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 21
+6390	quadruple-frozen adjusted twirling gray Mer-kin saltmint	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 21
 6391	moist Mer-kin saltsquid	0		Effect: "Educated (Sorta)", Effect Duration: 46
 6392	fireproof ruddy scale-mail underwear	0		Maximum HP Percent: +40, Hot Resistance: +3, Familiar Effect: "2xVolley"
 6393	electrified ghostly comb jelly	0		Effect: "The Rich Get Richer", Effect Duration: 14
@@ -6300,7 +6300,7 @@
 6405	quadruple-corrupted frozen worst candy	0		Effect: "Flamingly Floral", Effect Duration: 69
 6406	galvanized upside-down fudge-shaped hole in space-time	0		Effect: "Thunderspell", Effect Duration: 29
 6407	huge greedy slick Pocket Square of Loathing of doom	0		Moxie: +10, Spooky Spell Damage: +50, Meat Drop: +20, Single Equip
-6408	spinning red corrupted stardust	0		
+6408	red spinning corrupted stardust	0		
 6409	blurry Star Spawn	0		
 6410	bow from beyond the stars	0		Familiar Weight: +5
 6411	KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
@@ -6308,7 +6308,7 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	normal flavorless gruel	3	good	
-6416	moldy snack-sized mana curds	2	crappy	
+6416	snack-sized moldy mana curds	2	crappy	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	improved squat moth dust	0		Effect: "Nothing Is Impossible", Effect Duration: 29
@@ -6328,7 +6328,7 @@
 6433	Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
 6435	wobbly Mark of the Werewolf	0		
-6436	blurry huge Mark of the Zombie	0		
+6436	huge blurry Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
 6438	squat Mark of the Vampire	0		
 6439	Mark of the Skeleton	0		
@@ -6345,7 +6345,7 @@
 6450	zippy flame-wreathed Great Wolf's rocket launcher	0		Hot Spell Damage: +10, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	narrow reassuring energetic Great Wolf's beastly trousers of the cougar	0		Moxie: +20, Maximum MP Percent: +20, Spooky Resistance: +1, Familiar Effect: "1xPotato, 1.5xWhelp"
 6452	Great Wolf's lice	0		
-6453	Vulcanized enhanced skewed shaking Hunger&trade; Sauce	0		Effect: "Papowerful", Effect Duration: 54
+6453	Vulcanized enhanced shaking skewed Hunger&trade; Sauce	0		Effect: "Papowerful", Effect Duration: 54
 6454	Rosewater's thinker's zombie mariachi hat of Tarzan	0		Mysticality: +10, Mysticality Percent: +30, Experience (Muscle): +3, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	narrow dog trainer's zombie accordion of incineration of the boozehound	0		Experience (familiar): +1, Hot Spell Damage: +50, Booze Drop: +100, Class: "Accordion Thief", Single Equip, Song Duration: 20
 6456	curative Newton's supercool zombie mariachi pants	0		Moxie Percent: +20, Experience (Mysticality): +3, HP Regen Min: 3, HP Regen Max: 5, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
@@ -6390,7 +6390,7 @@
 6495	Dreadsylvania Auditor's badge of James Dean	0		Experience (Moxie): +3, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
-6498	smooth practically non-alcoholic bloody kiwitini	1	awesome	
+6498	practically non-alcoholic smooth bloody kiwitini	1	awesome	
 6499	blue moon-amber	0		
 6500	polished moon-amber	0		
 6501	cyan rosewater-soaked aromatic steel-toed moon-amber necklace	0		Damage Reduction: 9, Stench Resistance: 4, Single Equip
@@ -6410,7 +6410,7 @@
 6515	eerie fetish of the cougar	0		Moxie: +20, Single Equip
 6516	bad practically non-alcoholic stinkwater	1	decent	
 6517	ghostly dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	moldy big blurry accidental mutton	5	crappy	
+6518	big moldy blurry accidental mutton	5	crappy	
 6519	zippy perfumed drafty drawers	0		Stench Resistance: +5, Initiative: +20, Familiar Effect: "1.5xVolley"
 6520	extremely unsafe wolfskull mask of courage	0		Weapon Damage Percent: +100, Spooky Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr"
 6521	gray guts necklace of the cougar	0		Moxie: +20, Single Equip
@@ -6429,7 +6429,7 @@
 6534	red skewed remorseless knife of Leguizamo	0		Monster Level: +20
 6535	flame-retardant intimidating coiffure	0		Hot Resistance: +1, Familiar Effect: "hot afk, 1xPotato"
 6536	hale shellacked cod cape	0		Damage Reduction: 7, Maximum HP: +20
-6537	adequate big blood sausage	5	good	
+6537	big adequate blood sausage	5	good	
 6538	frying brainpan of the empath of the blizzard	0		Familiar Weight: +5, Cold Spell Damage: +25
 6539	lightning-fast ball and chain of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +40, Single Equip
 6540	forbidden dry bone	0		Spell Damage Percent: +50
@@ -6447,24 +6447,24 @@
 6553	cluster	0		
 6554	stench cluster	0		
 6555	sleaze cluster	0		
-6556	triple-activated cyan skewed phial of hotness	0		Effect: "Pasta Oneness", Effect Duration: 44
+6556	triple-activated skewed cyan phial of hotness	0		Effect: "Pasta Oneness", Effect Duration: 44
 6557	polymerized phial of coldness	0		Effect: "Dragged Through the Coals", Effect Duration: 59
-6558	galvanized wobbly blinking phial of spookiness	0		Effect: "Dances with Tweedles", Effect Duration: 22
+6558	galvanized blinking wobbly phial of spookiness	0		Effect: "Dances with Tweedles", Effect Duration: 22
 6559	triple-ionized vacuum-sealed wobbly phial of stench	0		Effect: "Dweeby", Effect Duration: 44
 6560	super-warmed colloidal phial of sleaziness	0		Effect: "Eagle Eyes", Effect Duration: 52
-6561	tumbling blinking adventurer clone egg	0		Free Pull, Last Available: "2013-06"
+6561	blinking tumbling adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	hand of Mr. Cards of mayonnaise	0		Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	super-sized stale Dreadsylvanian hot pocket	5	decent	
-6565	thick bland Dreadsylvanian pocket	5	decent	
+6564	stale super-sized Dreadsylvanian hot pocket	5	decent	
+6565	bland thick Dreadsylvanian pocket	5	decent	
 6566	small bland Dreadsylvanian pocket	2	decent	
 6567	bland Dreadsylvanian stink pocket	3	decent	
 6568	decent huge Dreadsylvanian sleaze pocket	4	good	
 6569	acceptable Dreadsylvanian hot toddy	3	good	
-6570	bad high-proof huge mirror Dreadsylvanian cold-fashioned	10	decent	
+6570	high-proof bad huge mirror Dreadsylvanian cold-fashioned	10	decent	
 6571	acceptable watered-down Dreadsylvanian grimlet	2	good	
 6572	lousy weak spinning Dreadsylvanian dank and stormy	2	decent	
-6573	delicious watered-down Dreadsylvanian slithery nipple	2	awesome	
+6573	watered-down delicious Dreadsylvanian slithery nipple	2	awesome	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
@@ -6472,9 +6472,9 @@
 6578	sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
-6581	ghostly wobbly dreadful box	0		
+6581	wobbly ghostly dreadful box	0		
 6582	mirror Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	tumbling mirror olive vicious spiked collar	0		Familiar Damage: +20
+6583	mirror olive tumbling vicious spiked collar	0		Familiar Damage: +20
 6584	lard-coated hot dog wrapper	0		Sleaze Spell Damage: +25
 6585	squat mansplainer's supercharged debonair deboner	0		Maximum MP Percent: +30, Monster Level: +15
 6586	quantum double-anodized chicle de salchicha	0		Effect: "Your Eyes are Peeled!", Effect Duration: 51
@@ -6488,7 +6488,7 @@
 6594	pulsating hot Dreadsylvanian cocoa	0		
 6595	vaporized blurry epic cluster	1	EPIC	
 6596	clockwork egg	0		
-6597	mirror red clockwork birdhouse	0		
+6597	red mirror clockwork birdhouse	0		
 6598	clockwork disc	0		
 6599	clockwork hand	0		
 6600	clockwork hand	0		
@@ -6505,8 +6505,8 @@
 6611	wobbly clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
-6614	upside-down maroon cuckoo clock	0		
-6615	tolerable watered-down blurry Cold One	2	???	
+6614	maroon upside-down cuckoo clock	0		
+6615	watered-down tolerable blurry Cold One	2	???	
 6616	decent spaghetti breakfast	3	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	purple folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6549,7 +6549,7 @@
 6657	wholesome Samson's pickelhaube	0		Experience (Muscle): +5, Maximum HP Percent: +10, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	electrified hair oil	0		Effect: "Muscularrr", Effect Duration: 62
 6659	polarized adjusted scrap	0		Effect: "Saucegoggles", Effect Duration: 54
-6660	upside-down blurry school spirit socket set	0		
+6660	blurry upside-down school spirit socket set	0		
 6661	blinking suspension bridge	0		
 6662	upside-down rosewater-soaked wool mansplainer's Lo Pan's Staff of the Lunch Lady	0		Spell Critical Percent: +30, Monster Level: +15, Cold Resistance: +1, Stench Resistance: +3
 6663	universal key	0		
@@ -6563,15 +6563,15 @@
 6671	improved jittery sodium pentasomething	0		Effect: "Very Clean Guns", Effect Duration: 67
 6672	grains of salt	0		
 6673	bouncing yellowcake bomb	0		
-6674	mirror narrow stinkbomb	0		
+6674	narrow mirror stinkbomb	0		
 6675	dry pulsating superwater	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 41
 6676	Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	cyan sage Yearbook Club Camera	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Blinding Flash"
 6679	quilted machete	0		Damage Absorption: +40
-6680	weak artisanal Cursed Punch	2	EPIC	
+6680	artisanal weak Cursed Punch	2	EPIC	
 6681	acceptable enchanted blurry Bowl of Scorpions	3	good	Effect: "Adrenaline Rush", Effect Duration: 10
-6682	delicious irresponsibly strong Fog Murderer	9	awesome	
+6682	irresponsibly strong delicious Fog Murderer	9	awesome	
 6683	book of matches	0		
 6684	experienced surgical mask	0		Experience: +2, Surgeonosity: +1
 6685	manspreader's head mirror	0		Monster Level: +10, Surgeonosity: +1
@@ -6612,7 +6612,7 @@
 6720	polarized dry pill cup	0		Effect: "Spooky Demeanor", Effect Duration: 64
 6721	shaking up-at-dawn savvy water bottle of wisdom	0		Mysticality: +15, Mysticality Percent: +20, Adventures: +5, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	electrified improved blinking pygmy phone number	0		Effect: "Space Cowboy", Effect Duration: 14
-6723	shaking squat Boozehounds Anonymous token	0		
+6723	squat shaking Boozehounds Anonymous token	0		
 6724	adequate exotic jungle fruit	3	good	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	blue dude ranch souvenir crate	0		
@@ -6623,7 +6623,7 @@
 6731	Worse Homes and Gardens	0		
 6732	twirling claw-foot bathtub	0		
 6733	blurry clothesline pole	0		
-6734	twirling pulsating cigar sign	0		
+6734	pulsating twirling cigar sign	0		
 6735	bouncing junk junk	0		
 6736	Junk-Bond	0		
 6737	wobbly tangle of copper wire	0		
@@ -6646,19 +6646,19 @@
 6754	beer bottle	0		
 6755	wobbly beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	perfectly mixed practically non-alcoholic can of Br&uuml;talbr&auml;u	1	EPIC	Last Available: "2013-09"
+6757	practically non-alcoholic perfectly mixed can of Br&uuml;talbr&auml;u	1	EPIC	Last Available: "2013-09"
 6758	practically non-alcoholic acceptable can of Drooling Monk	1	good	Last Available: "2013-09"
 6759	delicious triple-distilled shaking can of Impetuous Scofflaw	10	awesome	Last Available: "2013-09"
 6760	perfectly mixed boozy squat twirling bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
 6761	artisanal practically non-alcoholic bottle of Professor Beer	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6762	drinkable wobbly bottle of Rapier Witbier	3	good	Last Available: "2013-09"
 6763	aged bottle of Race Car Red	3	awesome	Last Available: "2013-09"
-6764	practically non-alcoholic tolerable blinking bottle of Greedy Dog	1	good	Last Available: "2013-09"
+6764	tolerable practically non-alcoholic blinking bottle of Greedy Dog	1	good	Last Available: "2013-09"
 6765	aged bottle of Lambada Lambic	4	awesome	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	EPIC	Last Available: "2013-09"
-6769	energetic cool brainy tin tam	0		Mysticality: +5, Moxie: +5, Maximum MP Percent: +20, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	energetic cool brainy tin tam	0		Mysticality: +5, Moxie: +5, Maximum MP Percent: +20, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	altered tin cup	0		Effect: "Almost Cool", Effect Duration: 14, Last Available: "2013-09"
 6771	ghostly scandalous studded tin foil of the cougar	0		Moxie: +20, Damage Absorption: +80, Sleaze Damage: +5, Last Available: "2013-09"
 6772	skewed wool MacGyver's tin drum of bravery	0		Maximum MP: +100, Cold Resistance: +1, Spooky Resistance: +5, Last Available: "2013-09"
@@ -6714,7 +6714,7 @@
 6825	double-paned alarm accordion of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +5, Class: "Accordion Thief", Song Duration: 20
 6826	slick cool All-Hallow's Steve's fright wig of horror	0		Moxie: 15, Spooky Spell Damage: +25, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	rock-hard KoL Con X Treasure Map of the wise owl	0		Mysticality: +20, Damage Reduction: 5
-6828	practically non-alcoholic lousy discocktail	1	decent	
+6828	lousy practically non-alcoholic discocktail	1	decent	
 6829	foul-smelling KoL Con X Bingo Card	0		Stench Damage: +10
 6830	mirror Temporal Tempera Tube of the sweet-tooth	0		Candy Drop: +100
 6831	altered Tallowcreme Halloween Pumpkin	0		Effect: "Stinky Weapon", Effect Duration: 12
@@ -6730,7 +6730,7 @@
 6841	triple-enhanced 8-bit banana	0		Effect: "Riboflavin'", Effect Duration: 37
 6842	quadruple-aerosolized ionized boiled tumbling vial of blood simple syrup	0		Effect: "Aquarius Rising", Effect Duration: 33
 6843	oxidized pressed squat bone bons	0		Effect: "Jittery", Effect Duration: 25
-6844	aerosolized cyan shaking ironic mint	0		Effect: "Moon-Eyed", Effect Duration: 31
+6844	aerosolized shaking cyan ironic mint	0		Effect: "Moon-Eyed", Effect Duration: 31
 6845	unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
 6847	killing jar	0		
@@ -6746,9 +6746,9 @@
 6857	jittery rosy-cheeked Cajun accordion	0		Maximum HP Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	curative quirky accordion	0		HP Regen Min: 3, HP Regen Max: 5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	Temple Grandin's occult Skipper's accordion	0		Spell Damage Percent: +25, Familiar Weight: +7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	bouncing careful mansplainer's Da Vinci's Pantsgiving of terror	0		Experience (Mysticality): +5, Monster Level: 5, Spooky Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6860	bouncing careful mansplainer's Da Vinci's Pantsgiving of terror	0		Experience (Mysticality): +5, Monster Level: 5, Spooky Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	rotten can of sardines	3	crappy	Last Available: "2013-11"
-6862	moldy half-sized narrow high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
+6862	half-sized moldy narrow high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
 6863	yummy gigantic pat of butter	8	awesome	Last Available: "2013-11"
 6864	bland dinner roll	4	decent	Last Available: "2013-11"
 6865	adequate yellow mashed potatoes	3	good	Last Available: "2013-11"
@@ -6771,11 +6771,11 @@
 6882	resourceful arcane researcher's experienced power sock of the bloodbag	0		Experience: +2, Experience Percent (Mysticality): +10, Maximum HP: +100, Maximum MP: +50, Single Equip, Last Available: "2013-11"
 6883	wool sock of dire peril of Calamity Jane of chilblains of the overflowing toilet	0		Weapon Damage: +20, Critical Hit Percent: +15, Cold Damage: +25, Stench Spell Damage: +50, Single Equip, Last Available: "2013-11"
 6884	therapeutic Rosewater's moustache sock of the bloodbag of the glutton	0		Mysticality Percent: +30, Maximum HP: +100, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-11"
-6885	double-alkaline ionized oxidized fuchsia spinning spirit gum	0		Effect: "Black Lung", Effect Duration: 43
+6885	double-alkaline ionized oxidized spinning fuchsia spirit gum	0		Effect: "Black Lung", Effect Duration: 43
 6886	green spirit pillow	0		
 6887	spirit sheet	0		
-6888	olive ghostly spirit mattress	0		
-6889	huge wobbly spirit blanket	0		
+6888	ghostly olive spirit mattress	0		
+6889	wobbly huge spirit blanket	0		
 6890	spirit bed	0		
 6891	skewed lion tamer's mansplainer's savvy spirit bell	0		Mysticality Percent: +20, Monster Level: +15, Experience (familiar): +2, Class: "Turtle Tamer"
 6892	diffused magnetized ghostly spoonful of Linguine-Os	0		Effect: "Sugar Smacks", Effect Duration: 58, Last Available: "2013-11"
@@ -6783,14 +6783,14 @@
 6894	Vulcanized blob of Alphredo&trade;	0		Effect: "You Know Where to Go", Effect Duration: 64, Last Available: "2013-11"
 6895	ionized blinking handful of crafty noodles	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 37, Last Available: "2013-11"
 6896	double-denatured tangled mass of pasta	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 20, Last Available: "2013-11"
-6897	anodized ionized blurry spinning shaking Can of Spaghetto	0		Effect: "Raging Animal", Effect Duration: 24, Last Available: "2013-11"
+6897	anodized ionized spinning shaking blurry Can of Spaghetto	0		Effect: "Raging Animal", Effect Duration: 24, Last Available: "2013-11"
 6898	shaking Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	stanky Van der Graaf flask flops	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 6903	double-irradiated fuchsia nuts	0		Effect: "Elemental Saucesphere", Effect Duration: 67, Last Available: "2013-12"
-6904	ionized liquefied concentrated yellow wobbly bolts	0		Effect: "Pecan Pied Piper", Effect Duration: 60, Last Available: "2013-12"
+6904	ionized liquefied concentrated wobbly yellow bolts	0		Effect: "Pecan Pied Piper", Effect Duration: 60, Last Available: "2013-12"
 6905	bland gingerbread robot	4	decent	Last Available: "2013-12"
 6906	adequate petit 4.1	3	good	Last Available: "2013-12"
 6907	moldy lime green nut-shaped Crimbo cookie	3	crappy	Last Available: "2023-06"
@@ -6812,27 +6812,27 @@
 6923	snack-sized moldy jittery warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
 6924	drinkable lime green warbear feasting mead	4	good	Last Available: "2013-12"
 6925	drinkable watered-down narrow warbear bearserker mead	2	good	Last Available: "2013-12"
-6926	mediocre watered-down warbear blizzard mead	2	decent	Last Available: "2013-12"
+6926	watered-down mediocre warbear blizzard mead	2	decent	Last Available: "2013-12"
 6927	bouncing warbear helm fragment	0		Last Available: "2013-12"
-6928	tumbling family-friendly chaotic supercool warbear plain fedora	0		Moxie Percent: +20, Spell Critical Percent: +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	bouncing bouncing ruddy warbear feathered fedora	0		Maximum HP Percent: +40, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	nippy lion tamer's healthy warbear fedora	0		Maximum HP Percent: +20, Experience (familiar): +2, Cold Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	gray vibrating curative occult warbear plain helm	0		Spell Damage Percent: +25, Maximum MP Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	medical-grade warbear spiked helm	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	mirror flame-retardant Annie Oakley's supercharged warbear electro-spiked helm	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Hot Resistance: +1, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	tumbling foul-smelling thinker's strapping warbear plain ushanka	0		Muscle: +5, Mysticality: +10, Stench Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	twirling warbear lined ushanka of the pedagogue	0		Experience: +3, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	green executive wool warbear heated ushanka of dire peril	0		Weapon Damage: +20, Cold Resistance: +1, Meat Drop: +40, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	tumbling family-friendly chaotic supercool warbear plain fedora	0		Moxie Percent: +20, Spell Critical Percent: +10, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	bouncing bouncing ruddy warbear feathered fedora	0		Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	nippy lion tamer's healthy warbear fedora	0		Maximum HP Percent: +20, Experience (familiar): +2, Cold Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	gray vibrating curative occult warbear plain helm	0		Spell Damage Percent: +25, Maximum MP Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	medical-grade warbear spiked helm	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	mirror flame-retardant Annie Oakley's supercharged warbear electro-spiked helm	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	tumbling foul-smelling thinker's strapping warbear plain ushanka	0		Muscle: +5, Mysticality: +10, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	twirling warbear lined ushanka of the pedagogue	0		Experience: +3, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	green executive wool warbear heated ushanka of dire peril	0		Weapon Damage: +20, Cold Resistance: +1, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	medical-grade warbear party pants of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	squat warbear ceremonial party pants of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	wobbly zippy Oprah's warbear high festival pants of wisdom	0		Mysticality: +15, Maximum MP Percent: +50, Initiative: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	fortified Socratic Herculean warbear battle greaves	0		Experience (Muscle): +1, Experience (Mysticality): +1, Damage Absorption: +60, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	blinking lion tamer's warbear officer greaves	0		Experience (familiar): +2, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	teal blinking squat grievous Newton's warbear bearserker greaves of bravery	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Spooky Resistance: +5, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	ribald flame-wreathed studded warbear johns	0		Damage Absorption: +80, Hot Spell Damage: +10, Sleaze Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	blurry warbear fleece-lined johns of dire peril	0		Weapon Damage: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	flame-retardant manspreader's fortified warbear johns	0		Damage Absorption: +60, Monster Level: +10, Hot Resistance: +1, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	medical-grade warbear party pants of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	squat warbear ceremonial party pants of the blizzard	0		Cold Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	wobbly zippy Oprah's warbear high festival pants of wisdom	0		Mysticality: +15, Maximum MP Percent: +50, Initiative: +20, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	fortified Socratic Herculean warbear battle greaves	0		Experience (Muscle): +1, Experience (Mysticality): +1, Damage Absorption: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	blinking lion tamer's warbear officer greaves	0		Experience (familiar): +2, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	teal blinking squat grievous Newton's warbear bearserker greaves of bravery	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Spooky Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	ribald flame-wreathed studded warbear johns	0		Damage Absorption: +80, Hot Spell Damage: +10, Sleaze Damage: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	blurry warbear fleece-lined johns of dire peril	0		Weapon Damage: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	flame-retardant manspreader's fortified warbear johns	0		Damage Absorption: +60, Monster Level: +10, Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	bouncing sage beefy warbear goggles of the storm	0		Muscle: +10, Mysticality Percent: +10, Maximum MP Percent: +40, Single Equip, Last Available: "2013-12"
 6949	warbear snowblindness goggles of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	narrow stiffened extremely unsafe warbear warscarf of the sweet-tooth	0		Weapon Damage Percent: +100, Damage Reduction: 1, Candy Drop: +100, Single Equip, Last Available: "2013-12"
 6957	cyan warbear requisition box	0		Last Available: "2013-12"
 6958	mirror warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	warbear foil hat of terror	0		Spooky Spell Damage: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	warbear foil hat of terror	0		Spooky Spell Damage: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	olive manspreader's smooth warbear oil pan	0		Moxie: +15, Monster Level: +10, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	jittery asbestos-lined die-cast Don Crimbo of the detective	0		Hot Resistance: +5, Item Drop: +20, Last Available: "2013-12"
 7001	stanky die-cast Uncle Hobo of the overflowing toilet	0		Stench Spell Damage: 75, Last Available: "2013-12"
 7002	jittery hardened die-cast Father Crimbo of incineration	0		Damage Reduction: 3, Hot Spell Damage: +50, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
-7004	non-moist bouncing blue Flaskfull of Hollow	0		Effect: "Tenacity of the Snapper", Effect Duration: 45, Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7004	non-moist blue bouncing Flaskfull of Hollow	0		Effect: "Tenacity of the Snapper", Effect Duration: 45, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
-7006	distilled shaking purple shaking handful of Smithereens	1	awesome	Last Available: "2013-12"
-7007	decent immense Every Day is Like This Sundae	7	good	Last Available: "2013-12"
+7006	distilled purple shaking shaking handful of Smithereens	1	awesome	Last Available: "2013-12"
+7007	immense decent Every Day is Like This Sundae	7	good	Last Available: "2013-12"
 7008	fancy spoiled twirling Miserable Pie	3	crappy	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2013-12"
-7009	rotten tiny upside-down This Charming Flan	1	crappy	Last Available: "2013-12"
+7009	tiny rotten upside-down This Charming Flan	1	crappy	Last Available: "2013-12"
 7010	bad Irish Coffee, English Heart	4	decent	Last Available: "2013-12"
-7011	practically non-alcoholic bad Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
-7012	tolerable triple-distilled Paint A Vulgar Pitcher	9	good	Last Available: "2013-12"
+7011	bad practically non-alcoholic Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
+7012	triple-distilled tolerable Paint A Vulgar Pitcher	9	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	pulsating Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	twirling tumbling asbestos-lined stiffened Da Vinci's Sheila Take a Crossbow of the cougar	0		Moxie: +20, Experience (Mysticality): +5, Damage Reduction: 1, Hot Resistance: +5, Last Available: "2013-12"
 7019	lime green clever A Light that Never Goes Out of the ox of incineration of the early riser	0		Muscle: +20, Maximum MP: +20, Hot Spell Damage: +50, Adventures: +7, Last Available: "2013-12"
 7020	narrow executive wool slick Half a Purse of the ox	0		Muscle: +20, Moxie: +10, Cold Resistance: +1, Meat Drop: +40, Last Available: "2013-12"
-7021	pulsating shellacked baleful Newton's Hairpiece On Fire of the ox	0		Muscle: +20, Experience (Mysticality): +3, Spell Damage: +25, Damage Reduction: 7, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	wobbly MacGyver's Rosewater's Vicar's Tutu of the ox of extreme caution	0		Muscle: +20, Mysticality Percent: +30, Maximum MP: +100, Monster Level: -25, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	pulsating shellacked baleful Newton's Hairpiece On Fire of the ox	0		Muscle: +20, Experience (Mysticality): +3, Spell Damage: +25, Damage Reduction: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	wobbly MacGyver's Rosewater's Vicar's Tutu of the ox of extreme caution	0		Muscle: +20, Mysticality Percent: +30, Maximum MP: +100, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	inspector's personal trainer's Hand in Glove of courage	0		Experience Percent (Muscle): +10, Spooky Resistance: +3, Item Drop: +15, Single Equip, Last Available: "2013-12"
 7024	bouncing toasty savvy Meat Tenderizer is Murder of the glutton	0		Mysticality Percent: +20, Hot Damage: +5, Food Drop: +100, Class: "Seal Clubber", Last Available: "2013-12"
 7025	inspector's MacGyver's Ouija Board, Ouija Board of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Item Drop: +15, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,11 +6918,11 @@
 7029	tumbling Van der Graaf Shakespeare's Sister's Accordion of Leguizamo of the cheetah	0		Monster Level: +20, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	Annie Oakley's third-hand lantern	0		Critical Hit Percent: +20
 7031	loose purse strings	0		
-7032	bland super-sized enchanted blurry pickled egg	5	decent	Effect: "Bells in the Batfry", Effect Duration: 25
+7032	enchanted super-sized bland blurry pickled egg	5	decent	Effect: "Bells in the Batfry", Effect Duration: 25
 7033	blinking bouncing cup of lukewarm tea	1	awesome	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	blurry warbear box	0		Last Available: "2013-12"
-7036	blinking green warbear high-efficiency still	0		Last Available: "2013-12"
+7036	green blinking warbear high-efficiency still	0		Last Available: "2013-12"
 7037	wobbly warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	red warbear gyrocopter	0		Last Available: "2013-12"
 7039	cold-filtered magnetized quadruple-polymerized warbear robo-camouflage unit	0		Effect: "Broken Bone Nubs", Effect Duration: 63, Last Available: "2013-12"
@@ -6931,9 +6931,9 @@
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	blinking warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	pickled extra-chilled glass slipper	0		Effect: "Bells in the Batfry", Effect Duration: 13, Last Available: "2014-12"
-7045	pickled skewed teal antimatter wad	1	decent	Effect: "Can Has Cyborger", Effect Duration: 40, Last Available: "2013-12"
+7045	pickled teal skewed antimatter wad	1	decent	Effect: "Can Has Cyborger", Effect Duration: 40, Last Available: "2013-12"
 7046	colloidal dry green warbear superpotion	0		Effect: "Pisces in the Skyces", Effect Duration: 23, Last Available: "2013-12"
-7047	extra-polymerized unsweetened pulsating wobbly mirror fuchsia warbear liquid lasers	0		Effect: "Mana Tea", Effect Duration: 18, Last Available: "2013-12"
+7047	extra-polymerized unsweetened wobbly mirror fuchsia pulsating warbear liquid lasers	0		Effect: "Mana Tea", Effect Duration: 18, Last Available: "2013-12"
 7048	moist deionized warbear rejuvenation potion	0		Effect: "Cat Class, Cat Style", Effect Duration: 53, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	spoiled warbear gyro	4	crappy	Last Available: "2013-12"
@@ -6955,12 +6955,12 @@
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	energized single of Inigo's Incantation of Inspiration	0		Effect: "World's Shortest Giant", Effect Duration: 33, Last Available: "2010-02"
 7068	ionized quadruple-corrupted huge single of Donho's Bubbly Ballad	0		Effect: "BOOsted", Effect Duration: 56
-7069	upside-down green Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
+7069	green upside-down Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	diet bland snow berries	1	decent	Last Available: "2014-01"
+7071	bland diet snow berries	1	decent	Last Available: "2014-01"
 7072	stale ice harvest	3	decent	Last Available: "2014-01"
 7073	frozen concentrated flattened twirling frost flower	0		Effect: "The Halls of Mysticality", Effect Duration: 65, Last Available: "2014-01"
-7074	diffused wet jittery narrow snow cleats	0		Effect: "Elemental Mastery", Effect Duration: 58, Last Available: "2014-01"
+7074	diffused wet narrow jittery snow cleats	0		Effect: "Elemental Mastery", Effect Duration: 58, Last Available: "2014-01"
 7075	adjusted liquid ice pack	0		Effect: "Dweeby", Effect Duration: 24, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	rotten snow crab	3	crappy	Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	electrified snow mobile	0		MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	electrified snow mobile	0		MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	jittery scandalous ice bucket	0		Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
 7085	mirror scorching snow shovel of the glutton	0		Hot Damage: +25, Food Drop: +100, Lasts Until Rollover, Last Available: "2014-01"
 7086	executive horrifying dangerous bod-ice	0		Weapon Damage: +10, Spooky Damage: +25, Meat Drop: +40, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,14 +6978,14 @@
 7089	skewed snow fort	0		Last Available: "2014-01"
 7090	smooth narrow En Una Fila Tequila	3	awesome	
 7091	Skully's hot chocolate	1	good	
-7092	warbear dress helmet of the blizzard of the sewer	0		Cold Spell Damage: +25, Stench Damage: +25, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	warbear dress helmet of the blizzard of the sewer	0		Cold Spell Damage: +25, Stench Damage: +25, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	ribald forbidden warbear dress bracers	0		Spell Damage Percent: +50, Sleaze Damage: +10, Single Equip, Last Available: "2013-12"
-7094	supercharged Samson's warbear dress greaves	0		Experience (Muscle): +5, Maximum MP Percent: +30, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	tumbling sweatband of the brute of the sewer	0		Muscle Percent: +30, Stench Damage: +25, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	huge gym shorts of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	supercharged Samson's warbear dress greaves	0		Experience (Muscle): +5, Maximum MP Percent: +30, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	tumbling sweatband of the brute of the sewer	0		Muscle Percent: +30, Stench Damage: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	huge gym shorts of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Candy Drop: +100, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	skewed skewed Jack Frost's lion tamer's ankleweights	0		Experience (familiar): +2, Cold Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7098	scorching careful hardy groovy sweat socks	0		Moxie Percent: +10, Maximum HP: +50, Monster Level: -10, Hot Damage: +25, Last Available: "2014-12"
-7099	ghostly narrow pint of sweat	0		Last Available: "2014-12"
+7099	narrow ghostly pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	modified blue Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
@@ -6994,22 +6994,22 @@
 7105	shaking anise-flavored venom	0		Last Available: "2014-12"
 7106	delicious snakebite	3	awesome	Last Available: "2014-12"
 7107	foul-smelling mansplainer's candy stick	0		Monster Level: +15, Stench Damage: +10, Last Available: "2014-12"
-7108	stale big pecan	5	decent	Last Available: "2014-12"
+7108	big stale pecan	5	decent	Last Available: "2014-12"
 7109	rotten massive pecan pie	10	crappy	Last Available: "2014-12"
 7110	skewed chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	moldy gigantic enchanted green candy mountain oyster	7	crappy	Effect: "Healthy Blue Glow", Effect Duration: 50, Last Available: "2014-12"
-7112	perfectly mixed weak cyan chocotini	2	EPIC	Last Available: "2014-12"
+7111	moldy enchanted gigantic green candy mountain oyster	7	crappy	Effect: "Healthy Blue Glow", Effect Duration: 50, Last Available: "2014-12"
+7112	weak perfectly mixed cyan chocotini	2	EPIC	Last Available: "2014-12"
 7113	pulsating zippy nippy strapping chocolate rabbit's foot	0		Muscle: +5, Cold Damage: +10, Initiative: +20, Last Available: "2014-12"
 7114	bland bite-sized candy carrot	1	decent	Last Available: "2014-12"
-7115	spoiled snack-sized purple candy carrot cake	2	crappy	Last Available: "2014-12"
+7115	snack-sized spoiled purple candy carrot cake	2	crappy	Last Available: "2014-12"
 7116	clever carrot-on-a-stick of incineration	0		Maximum MP: +20, Hot Spell Damage: +50, Last Available: "2014-12"
-7117	executive wholesome weasel stomping pants	0		Maximum HP Percent: +10, Meat Drop: +40, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	executive wholesome weasel stomping pants	0		Maximum HP Percent: +10, Meat Drop: +40, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	normal spinning mulberry	4	good	Last Available: "2014-12"
 7119	lousy mulled berry wine	3	decent	Last Available: "2014-12"
 7120	maroon lemony scales	0		Last Available: "2014-12"
-7121	zippy lemon party hat	0		Initiative: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	zippy lemon party hat	0		Initiative: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	savvy lemon shirt	0		Mysticality Percent: +20, Lasts Until Rollover, Last Available: "2014-12"
-7123	narrow upside-down thinker's lemon drop trousers	0		Mysticality: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	narrow upside-down thinker's lemon drop trousers	0		Mysticality: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	oxidized irradiated ghostly lemonhead caviar	0		Effect: "Hella Smooth", Effect Duration: 12, Last Available: "2014-12"
 7125	blue gummi sword of extreme caution of the overflowing toilet	0		Monster Level: -25, Stench Spell Damage: +50, Last Available: "2014-12"
 7126	oxidized gray small gummi fin	0		Effect: "Ham-Fisted", Effect Duration: 33, Last Available: "2014-12"
@@ -7018,14 +7018,14 @@
 7129	adequate immense blinking leftover canap&eacute;s	6	good	Last Available: "2014-12"
 7130	acceptable magnum of champagne	3	good	Last Available: "2014-12"
 7131	nippy personal trainer's wizardly cow creamer	0		Mysticality: +25, Experience Percent (Muscle): +10, Cold Damage: +10, Last Available: "2014-12"
-7132	chilled double-wet cyan spinning Outer Wolf&trade; cologne	0		Effect: "Sugar High", Effect Duration: 58, Last Available: "2014-12"
+7132	chilled double-wet spinning cyan Outer Wolf&trade; cologne	0		Effect: "Sugar High", Effect Duration: 58, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	narrow frightening quilted wolf whistle	0		Damage Absorption: +40, Spooky Damage: +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	normal witch's bread	3	good	Last Available: "2014-12"
 7136	frozen frozen witch's brew	0		Effect: "Insulated Trousers", Effect Duration: 48, Last Available: "2014-12"
 7137	Sherlock's inspector's witch's bra of wisdom	0		Mysticality: +15, Item Drop: 40, Last Available: "2014-12"
-7138	triple-distilled lousy ghostly mid-level medieval mead	8	decent	Last Available: "2014-12"
-7139	dry twirling red R&uuml;mpelstiltz	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 37, Last Available: "2014-12"
+7138	lousy triple-distilled ghostly mid-level medieval mead	8	decent	Last Available: "2014-12"
+7139	dry red twirling R&uuml;mpelstiltz	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 37, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	dry triple-corrupted purple hi-octane carrot juice	0		Effect: "Buggy Flavor", Effect Duration: 69, Last Available: "2014-12"
 7142	denatured non-boiled shaking hare brush	0		Effect: "The Power of Positive Thinking", Effect Duration: 40, Last Available: "2014-12"
@@ -7043,9 +7043,9 @@
 7154	huge filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	rosewater-soaked foul-smelling fire hose of chilblains	0		Cold Damage: +25, Stench Damage: +10, Stench Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	rosewater-soaked foul-smelling fire hose of chilblains	0		Cold Damage: +25, Stench Damage: +10, Stench Resistance: +3, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	rotten blinking fireman's lunch	3	crappy	Last Available: "2014-12"
-7159	Fonzie's plain paper hat of Calamity Jane of the businessman	0		Experience (Moxie): +1, Critical Hit Percent: +15, Meat Drop: +50, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	Fonzie's plain paper hat of Calamity Jane of the businessman	0		Experience (Moxie): +1, Critical Hit Percent: +15, Meat Drop: +50, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	half-sized toothsome ice cream sandwich	2	awesome	Last Available: "2014-12"
 7161	therapeutic veiny smartaleck's &quot;honey&quot; dipper	0		Moxie Percent: +30, Maximum HP: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7162	moldy plumber's lunch	3	crappy	Last Available: "2014-12"
@@ -7055,7 +7055,7 @@
 7166	huge stale can of Adultwitch&trade;	8	decent	Last Available: "2014-12"
 7167	colloidal alkaline smudge stick	0		Effect: "Venomous Weapon", Effect Duration: 67, Last Available: "2014-12"
 7168	anodized galvanized wall	0		Effect: "Mutated", Effect Duration: 28, Last Available: "2014-12"
-7169	high-proof delicious tankard of ale	7	awesome	Last Available: "2014-12"
+7169	delicious high-proof tankard of ale	7	awesome	Last Available: "2014-12"
 7170	deionized scroll case	0		Effect: "Bells in the Batfry", Effect Duration: 49, Last Available: "2014-12"
 7171	dry skewed jug of &quot;wine&quot;	0		Effect: "Hammered", Effect Duration: 62, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7073,7 +7073,7 @@
 7184	bouncing The Shield of Brook	0		
 7185	tumbling Red Zeppelin ticket	0		
 7186	pulsating Copperhead Charm (rampant)	0		
-7187	artisanal watered-down jittery unnamed cocktail	2	EPIC	
+7187	watered-down artisanal jittery unnamed cocktail	2	EPIC	
 7188	handful of tips	0		
 7189	supercool unrequired jacket	0		Moxie Percent: +20
 7190	tommy gun of the pedagogue	0		Experience: +3, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7111,7 +7111,7 @@
 7222	lousy weak upside-down Flamin' Whatshisname	2	decent	
 7223	colloidal lynyrd musk	0		Effect: "Fratty Flavor", Effect Duration: 39
 7224	flame-retardant vibrating Kashmir sweater	0		Maximum MP Percent: +10, Hot Resistance: +1
-7225	stale low-calorie custard pie	1	decent	
+7225	low-calorie stale custard pie	1	decent	
 7226	skewed tea for one	1	decent	
 7227	high-proof acceptable bottle of Evermore	9	good	
 7228	box	0		
@@ -7131,7 +7131,7 @@
 7242	ghostly jittery button	0		
 7243	blue button	0		
 7244	wet dry blood cells	0		Effect: "Egg on your Face", Effect Duration: 60
-7245	super-modified dry blue blurry eye	0		Effect: "Busy Bein' Delicious", Effect Duration: 56
+7245	super-modified dry blurry blue eye	0		Effect: "Busy Bein' Delicious", Effect Duration: 56
 7246	tumbling glark cable	0		
 7247	savvy Red Fox glove of the brazier	0		Mysticality Percent: +20, Hot Spell Damage: +25, Attacks Can't Miss, Single Equip
 7248	magnetized foxglove	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 53
@@ -7141,11 +7141,11 @@
 7252	fuchsia shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	acceptable strong mini-martini	5	good	
+7255	strong acceptable mini-martini	5	good	
 7256	smoke grenade	0		
 7257	pickled skewed molotov soda	1	awesome	Effect: "Memory of Speed", Effect Duration: 25
 7258	irradiated ionized tumbling purple pile of ashes	0		Effect: "Can Has Cyborger", Effect Duration: 69
-7259	bouncing cyan crate of firebombs	0		
+7259	cyan bouncing crate of firebombs	0		
 7260	firebomb	0		
 7261	wobbly wobbly dog trainer's Samson's Sneaky Pete's basket of courage	0		Experience (Muscle): +5, Experience (familiar): +1, Spooky Resistance: +3
 7262	squat &quot;I Love Me, Vol. I&quot;	0		
@@ -7165,7 +7165,7 @@
 7276	shellacked plastic Captain Kerkard	0		Damage Reduction: 7
 7277	quadruple-pressed squat robot grease	0		Effect: "No Vertigo", Effect Duration: 13
 7278	returned Thinknerd package	0		
-7279	cold-filtered pulsating blue bouncing wind-up Whatsian robot	0		Effect: "Favored by Lyle", Effect Duration: 21
+7279	cold-filtered pulsating bouncing blue wind-up Whatsian robot	0		Effect: "Favored by Lyle", Effect Duration: 21
 7280	ionized wind-up vampire teeth	0		Effect: "Wet and Greedy", Effect Duration: 46
 7281	adjusted warmed wind-up navigation droid	0		Effect: "Cock of the Walk", Effect Duration: 52
 7282	oxidized ionized wind-up owl	0		Effect: "Feline Ferocity", Effect Duration: 26
@@ -7177,7 +7177,7 @@
 7288	crafty Space Tourist palmdoctor of the boozehound	0		Maximum MP: +10, Booze Drop: +100, Lasts Until Rollover
 7289	blurry blue up-at-dawn asbestos-lined Sinatra's amok putter	0		Experience (Moxie): +5, Hot Resistance: +5, Adventures: +5
 7290	rotten amok pudding	3	crappy	
-7291	twirling bouncing deactivated putty buddy	0		
+7291	bouncing twirling deactivated putty buddy	0		
 7292	maroon putty coat	0		Familiar Weight: +5
 7293	corrupted quantum blurry can of V-11	0		Effect: "Disco Nirvana", Effect Duration: 59, Last Available: "2014-03"
 7294	hardy elevennis shoes of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, Last Available: "2014-03"
@@ -7196,10 +7196,10 @@
 7307	mirror Lady Spookyraven's dancing shoes	0		
 7308	triple-alkaline mirror eyebrow pencil	0		Effect: "Thick, Sick", Effect Duration: 50
 7309	triple-alkaline tumbling rosewater cream	0		Effect: "Punchy, Murdery", Effect Duration: 36
-7310	cold-filtered blurry blue bronzer	0		Effect: "Wintergreen Warmongery", Effect Duration: 60
+7310	cold-filtered blue blurry bronzer	0		Effect: "Wintergreen Warmongery", Effect Duration: 60
 7311	avaricious asbestos-lined elegant nightstick	0		Hot Resistance: +5, Meat Drop: +30
 7312	jittery still grill	0		Free Pull, Last Available: "2014-06"
-7313	narrow spinning box of hickory chips	0		Familiar Weight: +5
+7313	spinning narrow box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	rickety rocking horse	0		
 7316	bouncing jack-in-the-box	0		
@@ -7211,18 +7211,18 @@
 7322	denatured huge Stephen's secret formula	0		Effect: "Insatiable Hunger", Effect Duration: 21
 7323	teal tumbling therapeutic occult Jacob's rung	0		Spell Damage Percent: +25, HP Regen Min: 5, HP Regen Max: 7
 7324	pickled shaking battery	1		
-7325	practically non-alcoholic lousy mirror snakebite	1	decent	
+7325	lousy practically non-alcoholic mirror snakebite	1	decent	
 7326	squat gray reassuring lion tamer's rubber ribcage	0		Experience (familiar): +2, Spooky Resistance: +1, Damage Reduction: 7
-7327	pickled huge bouncing synthetic marrow	1		
+7327	pickled bouncing huge synthetic marrow	1		
 7328	moist boiled spinning funny bone	0		Effect: "Worth Your Salt", Effect Duration: 39
 7329	manspreader's slick half-melted spoon	0		Moxie: +10, Monster Level: +10
 7330	vaporized squat the funk	1		Effect: "Tightly-Wound Spine", Effect Duration: 20
 7331	tasty gigantic gunky chicken	9	awesome	
 7332	doll head of horror	0		Spooky Spell Damage: +25
-7333	ghostly pulsating droopy doll eye	0		
+7333	pulsating ghostly droopy doll eye	0		
 7334	narrow voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	steel-toed stiffened paddle-ball	0		Damage Reduction: 20
-7336	polymerized red tumbling sound effects record	0		Effect: "Healthy Red Glow", Effect Duration: 24
+7336	polymerized tumbling red sound effects record	0		Effect: "Healthy Red Glow", Effect Duration: 24
 7337	alphabet block	0		
 7338	aerosolized ionized dancer	0		Effect: "You Read The Manual", Effect Duration: 44
 7339	music box mechanism	0		
@@ -7234,7 +7234,7 @@
 7345	ornate picture frame	0		
 7346	olive doll-eye amulet	0		Single Equip
 7347	mirror Annie Oakley's ghost toga of bravery	0		Critical Hit Percent: +20, Spooky Resistance: +5
-7348	spoiled snack-sized lime green sheet cake	2	crappy	
+7348	snack-sized spoiled lime green sheet cake	2	crappy	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	banded Da Vinci's Staff of the Electric Range of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5, Damage Absorption: +100
@@ -7254,9 +7254,9 @@
 7365	concentrated fabric hardener	0		Effect: "Grape Expectations", Effect Duration: 32
 7366	drinkable distilled maroon bottle of laundry sherry	5	good	
 7367	ionized activated wobbly industrial strength starch	0		Effect: "The Halls of Moxiousness", Effect Duration: 37, Wiki Name: "industrial strength starch"
-7368	adequate miniature extra-flat panini	2	good	
+7368	miniature adequate extra-flat panini	2	good	
 7369	triple-pressed mangled finger	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 15
-7370	extra-dry artisanal bouncing Psychotic Train wine	5	EPIC	
+7370	artisanal extra-dry bouncing Psychotic Train wine	5	EPIC	
 7371	teal crazy hobo notebook	0		
 7372	bland pie man was not meant to eat	4	decent	
 7373	twirling manspreader's sommelier's towel	0		Monster Level: +10
@@ -7278,7 +7278,7 @@
 7389	polymerized adjusted Gene Tonic: Insect	0		Effect: "Jacked In", Effect Duration: 12, Last Available: "2014-04"
 7390	ionized nitrogenated tumbling Gene Tonic: Hippy	0		Effect: "Pride of the Vampire", Effect Duration: 30, Last Available: "2014-04"
 7391	enhanced boiled pickled Gene Tonic: Orc	0		Effect: "Swordholder", Effect Duration: 65, Last Available: "2014-04"
-7392	energized jittery skewed Gene Tonic: Demon	0		Effect: "Ginger Snapped", Effect Duration: 57, Last Available: "2014-04"
+7392	energized skewed jittery Gene Tonic: Demon	0		Effect: "Ginger Snapped", Effect Duration: 57, Last Available: "2014-04"
 7393	cold-filtered Gene Tonic: Horror	0		Effect: "Strong Spirit", Effect Duration: 67, Last Available: "2014-04"
 7394	irradiated anodized bouncing Gene Tonic: Fish	0		Effect: "Warm Belly", Effect Duration: 56, Last Available: "2014-04"
 7395	improved teal Gene Tonic: Goblin	0		Effect: "Moon-Eyed", Effect Duration: 40, Last Available: "2014-04"
@@ -7303,7 +7303,7 @@
 7414	Steam Card: Meteoid (#3)	0		
 7415	blurry Steam Card: DemonStar (#1)	0		
 7416	fuchsia Steam Card: DemonStar (#2)	0		
-7417	upside-down tumbling Steam Card: DemonStar (#3)	0		
+7417	tumbling upside-down Steam Card: DemonStar (#3)	0		
 7418	blurry Steam Card: Jackass Plumber (#1)	0		
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	huge Steam Card: Jackass Plumber (#3)	0		
@@ -7315,7 +7315,7 @@
 7426	narrow sprinkle shaker	0		Last Available: "2014-05"
 7427	warmed triple-altered sleight-of-hand mushroom	0		Effect: "Boschface", Effect Duration: 67, Last Available: "2014-05"
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
-7429	mirror lime green Beach Buck	0		Last Available: "2014-05"
+7429	lime green mirror Beach Buck	0		Last Available: "2014-05"
 7430	frozen frozen double-altered twirling Fun-Guy spore	0		Effect: "Bananas!", Effect Duration: 43, Last Available: "2014-05"
 7431	chilled Boletus Broletus mushroom	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 39, Last Available: "2014-05"
 7432	quadruple-warmed bouncing Omphalotus Omphaloskepsis mushroom	0		Effect: "Spookyravin'", Effect Duration: 47, Last Available: "2014-05"
@@ -7324,37 +7324,37 @@
 7435	quadruple-concentrated spinning Stemonitis Staticus mushroom	0		Effect: "Mer-kindliness", Effect Duration: 65, Last Available: "2014-05"
 7436	frozen nitrogenated shaking Tremella Tarantella mushroom	0		Effect: "Educated (Sorta)", Effect Duration: 51, Last Available: "2014-05"
 7437	bouncing Pastaco shell	0		Last Available: "2014-05"
-7438	snack-sized adequate Beefy Crunch Pastaco	2	good	Last Available: "2014-05"
+7438	adequate snack-sized Beefy Crunch Pastaco	2	good	Last Available: "2014-05"
 7439	rotten snack-sized Brain Food Pastaco	2	crappy	Last Available: "2014-05"
 7440	half-sized adequate green skewed Cool Brunch Pastaco	2	good	Last Available: "2014-05"
 7441	decent ghostly Medical Pastaco	4	good	Last Available: "2014-05"
-7442	small rotten Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
+7442	rotten small Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
 7443	half-sized adequate twirling Ludovico Pastaco	2	good	Last Available: "2014-05"
 7444	lousy overpowering mushroom wine	4	decent	Last Available: "2014-05"
 7445	high-proof acceptable complex mushroom wine	9	good	Last Available: "2014-05"
-7446	practically non-alcoholic mediocre yellow smooth mushroom wine	1	decent	Last Available: "2014-05"
+7446	mediocre practically non-alcoholic yellow smooth mushroom wine	1	decent	Last Available: "2014-05"
 7447	aged blood-red mushroom wine	4	awesome	Last Available: "2014-05"
-7448	weak mediocre buzzing mushroom wine	2	decent	Last Available: "2014-05"
+7448	mediocre weak buzzing mushroom wine	2	decent	Last Available: "2014-05"
 7449	mediocre swirling mushroom wine	3	decent	Last Available: "2014-05"
 7450	decent Taco Dan's Basic Taco Dan Taco	4	good	Last Available: "2014-05"
-7451	bland small bouncing Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
+7451	small bland bouncing Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
 7452	mirror Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	mediocre regular-size brogurt	3	decent	Last Available: "2014-05"
 7454	hand-crafted super-size brogurt	4	EPIC	Last Available: "2014-05"
 7455	smooth broberry brogurt	4	awesome	Last Available: "2014-05"
-7456	fancy artisanal brocolate brogurt	3	EPIC	Effect: "Moose Wisdom", Effect Duration: 5, Last Available: "2014-05"
-7457	watered-down perfectly mixed French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7458	squat ghostly History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
+7456	artisanal fancy brocolate brogurt	3	EPIC	Effect: "Moose Wisdom", Effect Duration: 5, Last Available: "2014-05"
+7457	perfectly mixed watered-down French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7458	ghostly squat History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	rock-hard Brogre brorts	0		Damage Reduction: 5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	rock-hard Brogre brorts	0		Damage Reduction: 5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	Brogre brolo shirt of dire peril	0		Weapon Damage: +20, Last Available: "2014-05"
-7464	blinking educational Brogre bucket hat	0		Experience: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
-7465	green spinning Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
+7464	blinking educational Brogre bucket hat	0		Experience: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7465	spinning green Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	blinking airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	spinning one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	Socratic 8-billed baseball cap of extreme caution of the cheetah	0		Experience (Mysticality): +1, Monster Level: -25, Initiative: +60, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	Socratic 8-billed baseball cap of extreme caution of the cheetah	0		Experience (Mysticality): +1, Monster Level: -25, Initiative: +60, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	up-at-dawn aromatic energetic extremely wet T-shirt	0		Maximum MP Percent: +20, Stench Resistance: +1, Adventures: +5, Last Available: "2014-05"
 7470	boxer's shrimp fork of the brute of the glutton	0		Muscle Percent: 40, Food Drop: +100, Last Available: "2014-05"
 7471	alkaline corrupted BROS Energy Drink	0		Effect: "Izchak's Blessing", Effect Duration: 57, Last Available: "2014-05"
@@ -7365,9 +7365,9 @@
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	pressed modified Meat-inflating powder	0		Effect: "The Style... of the Future", Effect Duration: 61, Last Available: "2014-05"
 7478	upside-down possessed sugar cube	0		Last Available: "2014-05"
-7479	colloidal electrified olive bouncing sugar fairy	0		Effect: "Tingly Elbows", Effect Duration: 38, Last Available: "2014-05"
+7479	colloidal electrified bouncing olive sugar fairy	0		Effect: "Tingly Elbows", Effect Duration: 38, Last Available: "2014-05"
 7480	tarnished enhanced sugar bunny	0		Effect: "Holiday Bliss", Effect Duration: 27, Last Available: "2014-05"
-7481	cyan twirling sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	cyan twirling sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	aged lime green Rompedores de Fantasmas	4	awesome	
 7483	weak aged La Fantasma y La Oscuridad	2	awesome	
 7484	hand-crafted Fantasma en la M&aacute;quina	3	EPIC	
@@ -7395,7 +7395,7 @@
 7506	upside-down prompt Jeselnik's book	0		Sleaze Damage: +25, Adventures: +3
 7507	scandalous cloak	0		Sleaze Damage: +5
 7508	gray skewed label	0		
-7509	fancy rotten ghostly Mornington crescent roll	3	crappy	Effect: "init.enh", Effect Duration: 30
+7509	rotten fancy ghostly Mornington crescent roll	3	crappy	Effect: "init.enh", Effect Duration: 30
 7510	wet moist ghostly eye shadow	0		Effect: "Blackberry Politeness", Effect Duration: 27
 7511	tumbling crumbling wheel	0		
 7512	super-galvanized poppy	0		Effect: "Lubed", Effect Duration: 63
@@ -7415,18 +7415,18 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	bouncing alien force field disruptor bean	0		Last Available: "2014-05"
 7528	cyan jittery fortified boxer's government-issued night-vision goggles	0		Muscle Percent: +10, Damage Absorption: +60, Single Equip, Last Available: "2014-05"
-7529	adequate tiny loaf of alien bread	1	good	Last Available: "2014-05"
+7529	tiny adequate loaf of alien bread	1	good	Last Available: "2014-05"
 7530	low-calorie stale grilled cheese sandwich	1	decent	Last Available: "2014-05"
 7531	mixed shaking alien protein powder	1	good	Effect: "Covetous Robbery", Effect Duration: 15, Last Available: "2014-05"
-7532	tolerable practically non-alcoholic rocket fuel	1	good	Last Available: "2014-05"
+7532	practically non-alcoholic tolerable rocket fuel	1	good	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	mirror alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	practically non-alcoholic perfectly mixed stealth bomber	1	super ultra mega EPIC	Last Available: "2014-05"
+7535	perfectly mixed practically non-alcoholic stealth bomber	1	super ultra mega EPIC	Last Available: "2014-05"
 7536	gray space beast fur	0		Last Available: "2014-05"
 7537	lime green twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of wisdom	0		Mysticality: +15, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	space beast fur pants of the early riser	0		Adventures: +7, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	space beast fur hat of wisdom	0		Mysticality: +15, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	space beast fur pants of the early riser	0		Adventures: +7, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	quilted space beast fur whip	0		Damage Absorption: +40, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	bouncing inspector's supercharged space heater	0		Maximum MP Percent: +30, Item Drop: +15, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7451,7 +7451,7 @@
 7562	modified musk turtle	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 14
 7563	extra-irradiated wet mirror programmable turtle	0		Effect: "Bustle Hustlin'", Effect Duration: 25
 7564	deionized pressed jittery mocking turtle	0		Effect: "Fudgehound", Effect Duration: 25
-7565	jumbo decent ham steak	5	good	
+7565	decent jumbo ham steak	5	good	
 7566	upside-down sizzling time-twitching toolbelt	0		Hot Damage: +10, Single Equip, Free Pull
 7567	Chroner	0		
 7568	family-friendly MacGyver's Time Lord Badge of Honor of the pedagogue	0		Experience: +3, Maximum MP: +100, Sleaze Resistance: +1
@@ -7460,7 +7460,7 @@
 7571	medical-grade silent pea shooter of the glutton	0		Food Drop: +100, HP Regen Min: 7, HP Regen Max: 10
 7572	normal D roll	3	good	
 7573	shellacked quilted kiwi beak	0		Damage Absorption: +40, Damage Reduction: 7
-7574	practically non-alcoholic tolerable New Zealand iced tea	1	good	
+7574	tolerable practically non-alcoholic New Zealand iced tea	1	good	
 7575	skewed baleful droll monocle	0		Spell Damage: +25, Item Drop: +5, Single Equip
 7576	Vulcanized mirror red future drug: Muscularactum	0		Effect: "Rave Concentration", Effect Duration: 25
 7577	nitrogenated unsweetened shaking future drug: Smartinex	0		Effect: "Egg-headedness", Effect Duration: 28
@@ -7478,14 +7478,14 @@
 7589	bad huge glass of &quot;milk&quot;	3	decent	Last Available: "2014-07"
 7590	acceptable cup of &quot;tea&quot;	4	good	Last Available: "2014-07"
 7591	acceptable thermos of &quot;whiskey&quot;	4	good	Last Available: "2014-07"
-7592	weak bad pulsating Lucky Lindy	2	decent	Last Available: "2014-07"
+7592	bad weak pulsating Lucky Lindy	2	decent	Last Available: "2014-07"
 7593	tolerable watered-down Bee's Knees	2	good	Last Available: "2014-07"
 7594	hand-crafted Sockdollager	3	EPIC	Last Available: "2014-07"
 7595	tolerable huge Ish Kabibble	4	good	Last Available: "2014-07"
 7596	smooth Hot Socks	3	awesome	Last Available: "2014-07"
-7597	irresponsibly strong artisanal Phonus Balonus	10	EPIC	Last Available: "2014-07"
+7597	artisanal irresponsibly strong Phonus Balonus	10	EPIC	Last Available: "2014-07"
 7598	lousy huge Flivver	4	decent	Last Available: "2014-07"
-7599	hand-crafted special distilled wobbly Sloppy Jalopy	5	EPIC	Effect: "Scorpio Rising", Effect Duration: 25, Last Available: "2014-07"
+7599	hand-crafted distilled special wobbly Sloppy Jalopy	5	EPIC	Effect: "Scorpio Rising", Effect Duration: 25, Last Available: "2014-07"
 7600	quantum nitrogenated huge flame	0		Effect: "Pemmican't", Effect Duration: 26
 7601	warmed colloidal temporary yak tattoo	0		Effect: "Eye of the Lihc", Effect Duration: 55
 7602	wet double-concentrated tumbling Fitspiration&trade; poster	0		Effect: "Frost Tea", Effect Duration: 66
@@ -7516,11 +7516,11 @@
 7627	liquefied frozen pickled cyan plastic Jefferson wings	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 47
 7628	denatured red dancing fan	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 56
 7629	chilled page of the Necrohobocon	0		Effect: "Icy Composition", Effect Duration: 50
-7630	modified lime green blurry narrow magic powder	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 21
+7630	modified blurry narrow lime green magic powder	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 21
 7631	quadruple-pickled double-irradiated squat friar's tonsure	0		Effect: "Ghost Finger", Effect Duration: 49
 7632	energized energized blue government-issue identification badge	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 69
 7633	cold-filtered electrified upside-down alien hologram projector	0		Effect: "Bored Stiff", Effect Duration: 47
-7634	flattened super-energized blurry blinking irradiated turtle	0		Effect: "Meadulla Oblongota", Effect Duration: 67
+7634	flattened super-energized blinking blurry irradiated turtle	0		Effect: "Meadulla Oblongota", Effect Duration: 67
 7635	aerosolized colloidal quadruple-Vulcanized cigar box turtle	0		Effect: "Disco Nirvana", Effect Duration: 19
 7636	flame-retardant lard-coated shellacked shell	0		Sleaze Spell Damage: +25, Hot Resistance: +1, Class: "Turtle Tamer"
 7637	asbestos-lined pillow shell	0		Hot Resistance: +5, Class: "Turtle Tamer"
@@ -7567,7 +7567,7 @@
 7678	curative 4-dimensional fez	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xLep, cap 12"
 7679	bouncing wobbly throwing candy	0		
 7680	yellow padded super-absorbent tarp	0		Damage Absorption: +20
-7681	smooth irresponsibly strong unquiet spirits	8	awesome	
+7681	irresponsibly strong smooth unquiet spirits	8	awesome	
 7682	banjo kazoo mount of Flo-Jo	0		Initiative: +100, Single Equip
 7683	boiled vacuum-sealed grass	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 48
 7684	shaking Time Lord Participation Mug of the cougar	0		Moxie: +20
@@ -7583,25 +7583,25 @@
 7694	skewed Groll doll	0		Single Equip, Last Available: "2014-08"
 7695	knitted dangerous cap gun of the cheetah	0		Weapon Damage: +10, Cold Resistance: +3, Initiative: +60, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	pulsating MacGyver's cassette player of temperance	0		Maximum MP: +100, Sleaze Resistance: +5, Single Equip, Last Available: "2014-08"
-7697	ghostly green chewable paper	0		Free Pull, Last Available: "2014-08"
+7697	green ghostly chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	dry denatured anodized bouncing confiscated comic book	0		Effect: "Concentration", Effect Duration: 37, Last Available: "2014-08"
 7701	frozen squat confiscated cell phone	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 35, Last Available: "2014-08"
-7702	corrupted spinning blinking confiscated love note	0		Effect: "Adorable Lookout", Effect Duration: 12, Last Available: "2014-08"
+7702	corrupted blinking spinning confiscated love note	0		Effect: "Adorable Lookout", Effect Duration: 12, Last Available: "2014-08"
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	huge LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	wobbly The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	wobbly The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	cold-filtered alkaline rubber nubbin	0		Effect: "Is This Your Card?", Effect Duration: 59, Last Available: "2014-08"
 7708	olive tumbling Jeselnik's sinister rubber cape	0		Spell Damage: +10, Sleaze Damage: +25, Last Available: "2014-08"
 7709	ghostly Fonzie's supercool Thor's Pliers of the storm of terror	0		Moxie Percent: +20, Experience (Moxie): +1, Maximum MP Percent: +40, Spooky Spell Damage: +10, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	warmed diffused blue candy UFOs	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 57
 7711	avaricious stylish water wings for babies	0		Moxie: +25, Meat Drop: +30
-7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	diet decent Strix stix	1	good	
+7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7713	decent diet Strix stix	1	good	
 7714	lime green chilly vampire pellet of the cougar of the scaredy-cat	0		Moxie: +20, Monster Level: -15, Cold Damage: +5
-7715	aged high-proof non-aged vinegar	7	awesome	
+7715	high-proof aged non-aged vinegar	7	awesome	
 7716	bouncing spinning rosy-cheeked unsanitized scalpel	0		Maximum HP Percent: +30
 7717	chaotic gladiator tunica	0		Spell Critical Percent: +10
 7718	ghostly Roman sadnals of the blizzard	0		Cold Spell Damage: +25, Single Equip
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	squat red deadly Xiblaxian xeno-detection goggles	0		Weapon Damage: +5, Single Equip, Last Available: "2014-09"
-7753	medical-grade Xiblaxian stealth cowl of terror	0		Spooky Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	medical-grade Xiblaxian stealth cowl of terror	0		Spooky Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	greedy supercool Xiblaxian stealth trousers	0		Moxie Percent: +20, Meat Drop: +20, Last Available: "2014-09"
 7755	curative Xiblaxian stealth vest	0		Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-09"
-7756	spoiled enchanted huge Xiblaxian ultraburrito	8	crappy	Effect: "Standard Cheer", Effect Duration: 20, Last Available: "2014-09"
-7757	artisanal practically non-alcoholic Xiblaxian space-whiskey	1	super ultra mega turbo EPIC	Last Available: "2014-09"
+7756	enchanted spoiled huge Xiblaxian ultraburrito	8	crappy	Effect: "Standard Cheer", Effect Duration: 20, Last Available: "2014-09"
+7757	practically non-alcoholic artisanal Xiblaxian space-whiskey	1	super ultra mega turbo EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	tarnished They liver	0		Effect: "Spell Transfer Complete", Effect Duration: 52, Last Available: "2014-09"
-7760	decent gigantic They liver popsicle	8	good	Last Available: "2014-09"
+7760	gigantic decent They liver popsicle	8	good	Last Available: "2014-09"
 7761	ghostly holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	wobbly holo-platoon	0		Last Available: "2014-09"
@@ -7668,8 +7668,8 @@
 7779	triple-irradiated diffused experimental serum G-9	0		Effect: "Man's Worst Enemy", Effect Duration: 24, Last Available: "2014-10"
 7780	Jack Frost's resourceful dance instructor's heavy-duty clipboard	0		Experience Percent (Moxie): +10, Maximum MP: +50, Cold Spell Damage: +50, Damage Reduction: 8, Last Available: "2014-10"
 7781	blinking lard-coated wholesome smartaleck's smooth battery-powered drill	0		Moxie: +15, Moxie Percent: +30, Maximum HP Percent: +10, Sleaze Spell Damage: +25, Last Available: "2014-10"
-7782	toothsome enchanted miniature limp broccoli	2	awesome	Effect: "You Read The Manual", Effect Duration: 15, Last Available: "2014-10"
-7783	blue skewed quilted hat of the pedagogue of the sweet-tooth	0		Experience: +3, Damage Absorption: +40, Candy Drop: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7782	miniature enchanted toothsome limp broccoli	2	awesome	Effect: "You Read The Manual", Effect Duration: 15, Last Available: "2014-10"
+7783	blue skewed quilted hat of the pedagogue of the sweet-tooth	0		Experience: +3, Damage Absorption: +40, Candy Drop: +100, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	concentrated flattened monkey barf	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 68, Last Available: "2014-10"
 7785	tarnished candy	0		Effect: "Woad Warrior", Effect Duration: 22, Last Available: "2014-10"
 7786	auspicious chaotic jangly bracelet of the storm	0		Maximum MP Percent: +40, Spell Critical Percent: +10, Item Drop: +10, Last Available: "2014-10"
@@ -7681,11 +7681,11 @@
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	ghostly ghostly bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	miniature rotten initiative shawarma	2	crappy	Last Available: "2014-10"
+7795	rotten miniature initiative shawarma	2	crappy	Last Available: "2014-10"
 7796	adequate purple warm war shawarma	3	good	Last Available: "2014-10"
 7797	stale small karma shawarma	2	decent	Last Available: "2014-10"
 7798	smooth Jungle Juice	4	awesome	Last Available: "2014-10"
-7799	aged watered-down Amnesiac Ale	2	awesome	Last Available: "2014-10"
+7799	watered-down aged Amnesiac Ale	2	awesome	Last Available: "2014-10"
 7800	irresponsibly strong drinkable Highest Bitter	10	good	Last Available: "2014-10"
 7801	shaking wobbly educational mercenary pistol of terror	0		Experience: +1, Spooky Spell Damage: +10, Last Available: "2014-10"
 7802	nasty mercenary rifle of temperance	0		Stench Damage: +5, Sleaze Resistance: +5, Last Available: "2014-10"
@@ -7693,14 +7693,14 @@
 7804	Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	mirror Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
-7807	mirror maroon TI-9000 calculator	0		
+7807	maroon mirror TI-9000 calculator	0		
 7808	green unused soap	0		
 7809	impure gasoline	0		
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	special immense rotten seared dino steak	6	crappy	Effect: "Fireproof Lips", Effect Duration: 25
-7814	hand-crafted bouncing twirling bottle of drinkin' gas	3	EPIC	
+7813	immense rotten special seared dino steak	6	crappy	Effect: "Fireproof Lips", Effect Duration: 25
+7814	hand-crafted twirling bouncing bottle of drinkin' gas	3	EPIC	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7713,7 +7713,7 @@
 7824	squat gray brainy weightlifter's iShield of mayonnaise	0		Muscle: +15, Mysticality: +5, Sleaze Spell Damage: +50, Damage Reduction: 6
 7825	wicked earbuds of the empath of the brazier	0		Spell Damage: +5, Familiar Weight: +5, Hot Spell Damage: +25, Single Equip
 7826	wobbly nasty therapeutic sinister iFlail	0		Spell Damage: +10, Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7
-7827	tiny special bland blue unidentifiable dried fruit	1	decent	Effect: "Good with the Ladies", Effect Duration: 50
+7827	tiny bland special blue unidentifiable dried fruit	1	decent	Effect: "Good with the Ladies", Effect Duration: 50
 7828	perfectly mixed flat cider	4	EPIC	
 7829	frosty strapping trench lighter of Tarzan	0		Muscle: +5, Experience (Muscle): +3, Cold Spell Damage: +10, Last Available: "2014-10"
 7830	wet wet green experimental serum P-00	0		Effect: "Broken Fast", Effect Duration: 50, Last Available: "2014-10"
@@ -7735,7 +7735,7 @@
 7846	energized Fudge Fiber Armor Plating	0		Effect: "Wet and Greedy", Effect Duration: 53, Last Available: "2014-12"
 7847	non-ionized pickled jittery ruby on canes	0		Effect: "Weather, Man", Effect Duration: 49, Last Available: "2014-12"
 7848	adequate petit fortran	4	good	Last Available: "2014-12"
-7849	tiny enchanted flavorless java cookie	1	decent	Effect: "Square to be Hip", Effect Duration: 30, Last Available: "2014-12"
+7849	tiny flavorless enchanted java cookie	1	decent	Effect: "Square to be Hip", Effect Duration: 30, Last Available: "2014-12"
 7850	bland green cookie cookie	3	decent	Last Available: "2014-12"
 7851	pulsating gravedigger's plastic exo-suited miner	0		Spooky Damage: +10, Last Available: "2014-12"
 7852	grievous plastic semi-autonomous drill unit	0		Weapon Damage Percent: +50, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	toasty plastic Crimbot	0		Hot Damage: +5, Last Available: "2014-12"
 7855	Herculean plastic Crimbomega	0		Experience (Muscle): +1, Last Available: "2014-12"
 7856	super-frozen polarized mirror flask of mining oil	0		Effect: "Cancer Rising", Effect Duration: 28, Last Available: "2014-12"
-7857	narrow sinister radiation-resistant helmet	0		Spell Damage: +10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	shaking MacGyver's servo-assisted exo-pants	0		Maximum MP: +100, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	narrow sinister radiation-resistant helmet	0		Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	shaking MacGyver's servo-assisted exo-pants	0		Maximum MP: +100, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	twirling twirling lion tamer's high-energy mining laser of the brazier	0		Experience (familiar): +2, Hot Spell Damage: +25, Last Available: "2014-12"
 7860	yellow peppermint tailings	0		Last Available: "2014-12"
 7861	ghostly wobbly nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7785,7 +7785,7 @@
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	pulsating Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
-7899	tumbling blurry gray Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
+7899	gray blurry tumbling Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	gray Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
@@ -7798,7 +7798,7 @@
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	cyan recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	recovered elf photo album	0		Last Available: "2014-12"
-7912	blurry cyan recovered elf smartphone	0		Last Available: "2014-12"
+7912	cyan blurry recovered elf smartphone	0		Last Available: "2014-12"
 7913	rock-hard Size XI Wizard's Robe of extreme caution of temperance	0		Damage Reduction: 5, Monster Level: -25, Sleaze Resistance: +5, Last Available: "2014-09"
 7914	polarized double-tarnished Bit O' Quail Spleen	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 21
 7915	wet adjusted Take Eleven Bar	0		Effect: "Peppermint Bite", Effect Duration: 35
@@ -7810,12 +7810,12 @@
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	drinkable Friendly Turkey	4	good	Last Available: "2014-11"
 7923	perfectly mixed distilled blurry Agitated Turkey	5	EPIC	Last Available: "2014-11"
-7924	delicious practically non-alcoholic Ambitious Turkey	1	awesome	Last Available: "2014-11"
-7925	stale tiny narrow neutron lollipop	1	decent	Last Available: "2014-12"
-7926	strong special bad tumbling gamma nog	5	decent	Effect: "Powder Power", Effect Duration: 30, Last Available: "2014-12"
+7924	practically non-alcoholic delicious Ambitious Turkey	1	awesome	Last Available: "2014-11"
+7925	tiny stale narrow neutron lollipop	1	decent	Last Available: "2014-12"
+7926	strong bad special tumbling gamma nog	5	decent	Effect: "Powder Power", Effect Duration: 30, Last Available: "2014-12"
 7934	blue sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
-7936	shaking olive picky tweezers	0		Last Available: "2015-02"
+7936	olive shaking picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
 7938	vaporized gray single atom	1	EPIC	Effect: "Coated Arms", Effect Duration: 35, Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
@@ -7826,16 +7826,16 @@
 7944	tooth	0		
 7945	cyan table	0		
 7946	green skewed chilly healthy outlaw bandana of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +20, Cold Damage: +5
-7947	enchanted perfectly mixed skewed whiskey in a broken glass	3	EPIC	Effect: "Alchemical, Brother", Effect Duration: 25
+7947	perfectly mixed enchanted skewed whiskey in a broken glass	3	EPIC	Effect: "Alchemical, Brother", Effect Duration: 25
 7948	tolerable practically non-alcoholic ghostly shot of mescal	1	good	
-7949	watered-down bad glass of herbal tequila	2	decent	
+7949	bad watered-down glass of herbal tequila	2	decent	
 7950	twirling ghostly minin' dynamite	0		
 7951	shaking plaid cowboy hat of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-7952	red ghostly lasso	0		
+7952	ghostly red lasso	0		
 7953	scorching Rosewater's rusted-out shootin' iron	0		Mysticality Percent: +30, Hot Damage: +25, Item Drop: +5
 7954	rattler rattle	0		
 7955	bag of money	0		
-7956	fuchsia tumbling huge Crimbo sapling	0		Free Pull, Last Available: "2014-12"
+7956	fuchsia huge tumbling Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	pulsating even more tinsel	0		Familiar Weight: +5
 7958	narrow box of Crimbo decorations	0		
 7959	blinking letter to Ed the Undying	0		
@@ -7856,7 +7856,7 @@
 7974	vaporized mummified beef haunch	1	crappy	
 7975	linen bandages	0		
 7976	cotton bandages	0		
-7977	narrow pulsating silk bandages	0		
+7977	pulsating narrow silk bandages	0		
 7978	holy spring water	0		
 7979	spirit beer	0		
 7980	teal sacramental wine	0		
@@ -7881,7 +7881,7 @@
 7999	nitrogenated enhanced pressed shaking choco-Crimbot	0		Effect: "Insulated Trousers", Effect Duration: 34, Last Available: "2014-12"
 8000	enhanced green smart watch	0		Effect: "You Know Who to Call", Effect Duration: 18, Last Available: "2014-12"
 8001	super-dry irradiated augmented-reality shades	0		Effect: "Disco Concentration", Effect Duration: 41, Last Available: "2014-12"
-8002	smartaleck's toy Crimbot mega face	0		Moxie Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8002	smartaleck's toy Crimbot mega face	0		Moxie Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	toy Crimbot power glove of chilblains	0		Cold Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	toy Crimbot super fist of courage	0		Spooky Resistance: +3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	friendly toy Crimbot rocket legs	0		Familiar Weight: +3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7919,8 +7919,8 @@
 8037	small normal tumbling bowl of topioca	2	good	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
-8040	wobbly purple trusty whip	0		
-8041	squat blinking crumbling skull	0		
+8040	purple wobbly trusty whip	0		
+8041	blinking squat crumbling skull	0		
 8042	rock	0		
 8043	pot of horror	0		Spooky Spell Damage: +25
 8044	Newton's spelunking fedora	0		Experience (Mysticality): +3
@@ -7952,9 +7952,9 @@
 8071	cyan warehouse inventory page	0		
 8072	upside-down mirror janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	medical-grade healthy Spelunker's fedora of chilblains	0		Maximum HP Percent: +20, Cold Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	medical-grade healthy Spelunker's fedora of chilblains	0		Maximum HP Percent: +20, Cold Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	bouncing tumbling upside-down mansplainer's shellacked Socratic Spelunker's whip	0		Experience (Mysticality): +1, Damage Reduction: 7, Monster Level: +15, Last Available: "2015-12"
-8076	hardy ruddy banded Spelunker's khakis	0		Damage Absorption: +100, Maximum HP Percent: +40, Maximum HP: +50, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	hardy ruddy banded Spelunker's khakis	0		Damage Absorption: +100, Maximum HP Percent: +40, Maximum HP: +50, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	blurry Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7963,7 +7963,7 @@
 8088	jewel	0		
 8089	headless sparrow	0		
 8090	skewed mangled squirrel	0		
-8091	huge jittery rat carcass	0		
+8091	jittery huge rat carcass	0		
 8092	tumbling friendly wicker kickers of temperance	0		Familiar Weight: +3, Sleaze Resistance: +5, Single Equip, Last Available: "2016-12"
 8093	groovy stylish wicker slicker	0		Moxie: +25, Moxie Percent: +10, Last Available: "2016-12"
 8094	nasty razor-sharp wicker knickers	0		Weapon Damage Percent: +25, Stench Damage: +5, Last Available: "2016-12"
@@ -8042,12 +8042,12 @@
 8168	glob of icing	0		
 8169	modified maroon ginger snaps	0		Effect: "Cold Blooded", Effect Duration: 50
 8170	aerosolized skewed mostly-broken sunglasses	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 33
-8171	watered-down hand-crafted unflavored wine cooler	2	EPIC	
+8171	hand-crafted watered-down unflavored wine cooler	2	EPIC	
 8172	carton of snake milk	1	awesome	
 8173	occult sewer snake	0		Spell Damage Percent: +25
-8174	flavorless miniature narrow pigeon egg	2	decent	
+8174	miniature flavorless narrow pigeon egg	2	decent	
 8175	avaricious jaunty feather of the scaredy-cat	0		Monster Level: -15, Meat Drop: +30
-8176	practically non-alcoholic bad premium malt liquor	1	decent	
+8176	bad practically non-alcoholic premium malt liquor	1	decent	
 8177	ribald brown paper pants of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10
 8178	olive miser's Jim Carey's brown paper bag mask	0		Monster Level: +25, Meat Drop: +10
 8179	stanky ring of telling skeletons what to do	0		Stench Spell Damage: +25, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,20 +8056,20 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	blinking family-friendly bread basket	0		Sleaze Resistance: +1
 8184	twirling Ed the Undying exhibit crate	0		
-8185	executive arcane researcher's The Crown of Ed the Undying	0		Experience Percent (Mysticality): +10, Meat Drop: +40, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
-8186	pulsating upside-down Doc Galaktik's Invigorating Tonic	0		
+8185	executive arcane researcher's The Crown of Ed the Undying	0		Experience Percent (Mysticality): +10, Meat Drop: +40, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8186	upside-down pulsating Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	drinkable Cherrytastrophe wine cooler	4	good	
-8189	practically non-alcoholic acceptable blurry Radberry Rip wine cooler	1	good	
+8189	acceptable practically non-alcoholic blurry Radberry Rip wine cooler	1	good	
 8190	watered-down mediocre Orangemageddon wine cooler	2	decent	
-8191	drinkable weak blinking Breakfast Blast wine cooler	2	good	
+8191	weak drinkable blinking Breakfast Blast wine cooler	2	good	
 8192	perfectly mixed Citrus Crush wine cooler	3	EPIC	
-8193	immense tasty plain bagel	8	awesome	
-8194	big decent glob of cream cheese	5	good	
+8193	tasty immense plain bagel	8	awesome	
+8194	decent big glob of cream cheese	5	good	
 8195	adequate huge loaf of soda bread	4	good	
-8196	fancy flavorless big acceptable bagel	5	decent	Effect: "Rushtacean'", Effect Duration: 25
+8196	fancy big flavorless acceptable bagel	5	decent	Effect: "Rushtacean'", Effect Duration: 25
 8197	normal standard-issue cupcake	3	good	
-8198	huge tasty pulsating ultra-deluxe cupcake	6	awesome	
+8198	tasty huge pulsating ultra-deluxe cupcake	6	awesome	
 8199	hypnotic breadcrumbs	0		
 8200	adequate blinking popular tart	4	good	
 8201	no-handed pie	0		
@@ -8091,8 +8091,8 @@
 8217	stanky perfume-soaked bandana of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25, Single Equip, Last Available: "2015-04"
 8218	gray toxic globule	0		Last Available: "2015-04"
 8219	decent special shaking toxo	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 30, Last Available: "2015-04"
-8220	drinkable spirit-forward pulsating green skewed Lemonade-235	5	good	Last Available: "2015-04"
-8221	red isotophat of the ox of the bloodbag	0		Muscle: +20, Maximum HP: +100, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	spirit-forward drinkable skewed green pulsating Lemonade-235	5	good	Last Available: "2015-04"
+8221	red isotophat of the ox of the bloodbag	0		Muscle: +20, Maximum HP: +100, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	groovy Three Mile Island shorts of chilblains	0		Moxie Percent: +10, Cold Damage: +25, Last Available: "2015-04"
 8223	ghostly foul-smelling rosy-cheeked toxic mop	0		Maximum HP Percent: +30, Stench Damage: +10, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	lard-coated lube-shoes	0		Sleaze Spell Damage: +25, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	censurious slick Dinsey mascot mask of the blizzard	0		Moxie: +10, Cold Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2015-04"
-8247	normal snack-sized tumbling Dinsey food-cone	2	good	Last Available: "2015-04"
+8247	snack-sized normal tumbling Dinsey food-cone	2	good	Last Available: "2015-04"
 8248	bad watered-down upside-down Dinsey Whinskey	2	decent	Last Available: "2015-04"
 8249	chilled pressed super-modified upside-down Dinsey face paint	0		Effect: "Blood-Gorged", Effect Duration: 17, Last Available: "2015-04"
 8250	extremely unsafe experienced fannypack	0		Experience: +2, Weapon Damage Percent: +100, Last Available: "2015-04"
@@ -8143,8 +8143,8 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	spoiled ghostly unappetizing mayolus	3	crappy	Last Available: "2015-05"
 8271	moldy uninteresting mayolus	3	crappy	Last Available: "2015-05"
-8272	flavorless miniature acceptable mayolus	2	decent	Last Available: "2015-05"
-8273	bland bite-sized blurry enticing mayolus	1	decent	Last Available: "2015-05"
+8272	miniature flavorless acceptable mayolus	2	decent	Last Available: "2015-05"
+8273	bite-sized bland blurry enticing mayolus	1	decent	Last Available: "2015-05"
 8274	flavorless mouth-watering mayolus	3	decent	Last Available: "2015-05"
 8275	olive newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
@@ -8154,7 +8154,7 @@
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	altered pressed pickled huge Kokomo Resort Brand Suntan Oil	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 13, Last Available: "2015-04"
 8282	fuchsia Kokomo Resort Order Pad	0		Last Available: "2015-04"
-8283	jittery blurry The Cocktail Shaker	0		Last Available: "2015-04"
+8283	blurry jittery The Cocktail Shaker	0		Last Available: "2015-04"
 8284	ionized activated pulsating Kokomo Resort Pass	0		Effect: "Mucilaginous Mentalism", Effect Duration: 23, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	extra-flattened Mayo de Mayo&trade; mayo	0		Effect: "Sealed Brain", Effect Duration: 56
@@ -8168,19 +8168,19 @@
 8294	stylish dice-print do-rag	0		Moxie: +25
 8295	toasty dice sunglasses	0		Hot Damage: +5, Single Equip
 8296	Thwaitgold caterpillar statuette	0		
-8297	unsweetened shaking skewed dice	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
-8298	skewed mirror pixel	0		Last Available: "2015-06"
+8297	unsweetened skewed shaking dice	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
+8298	mirror skewed pixel	0		Last Available: "2015-06"
 8299	squat pixel coin	0		Last Available: "2015-06"
 8300	irradiated vacuum-sealed power pill	0		Effect: "Stuck That Way", Effect Duration: 58, Last Available: "2015-06"
 8301	moist alkaline fuchsia pixel star	0		Effect: "Proprie Tea", Effect Duration: 20, Last Available: "2015-06"
 8302	spoiled pixel banana	4	crappy	Last Available: "2015-06"
-8303	hand-crafted practically non-alcoholic pixel beer	1	super ultra mega EPIC	Last Available: "2015-06"
+8303	practically non-alcoholic hand-crafted pixel beer	1	super ultra mega EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	boiled bouncing sludgesicle	0		Effect: "Patent Avarice", Effect Duration: 20
-8307	magnetized ghostly bouncing &Uuml;berraschthexengebr&auml;u	0		Effect: "Frog In Your Throat", Effect Duration: 13
+8307	magnetized bouncing ghostly &Uuml;berraschthexengebr&auml;u	0		Effect: "Frog In Your Throat", Effect Duration: 13
 8308	liquefied spinning piggy tattoo	0		Effect: "Ocelot Eyes", Effect Duration: 34
-8309	boiled teal shaking baggie of regular-sized tardigrades	0		Effect: "Mana Tea", Effect Duration: 39
+8309	boiled shaking teal baggie of regular-sized tardigrades	0		Effect: "Mana Tea", Effect Duration: 39
 8310	aerosolized cold-filtered .epub file	0		Effect: "Crotchety, Pining", Effect Duration: 66
 8311	chilled BUBBLE GUM	0		Effect: "Hennaliciousness", Effect Duration: 27
 8312	alkaline tumbling hustler shades	0		Effect: "Cravin' for a Ravin'", Effect Duration: 62
@@ -8205,22 +8205,22 @@
 8331	modified filthy armor	0		Effect: "Frostbeard", Effect Duration: 32
 8332	diffused super-dry huge plague pie	0		Effect: "Human-Beast Hybrid", Effect Duration: 49
 8333	tarnished polarized batarang	0		Effect: "Vinegavotte", Effect Duration: 27
-8334	electrified activated blurry huge spare neck bolts	0		Effect: "How to Scam Tourists", Effect Duration: 27
+8334	electrified activated huge blurry spare neck bolts	0		Effect: "How to Scam Tourists", Effect Duration: 27
 8335	irradiated aerosolized grease trap	0		Effect: "Bone Homie", Effect Duration: 62
 8336	oxidized modified skewed shamanic ham	0		Effect: "Slimily Speedy", Effect Duration: 17
 8337	Vulcanized triple-frozen twirling porkpocket	0		Effect: "Lemon Enlightenment", Effect Duration: 18
-8338	double-dry red ghostly wobbly Leonard's glasses	0		Effect: "Strong Grip", Effect Duration: 29
+8338	double-dry red wobbly ghostly Leonard's glasses	0		Effect: "Strong Grip", Effect Duration: 29
 8339	liquefied non-improved lime green warehouse walkie-talkie	0		Effect: "Rampage!", Effect Duration: 36
 8340	liquefied modified janitor's mop	0		Effect: "Familial Ties", Effect Duration: 28
 8341	Vulcanized diffused warehouse clerk's glasses	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 31
 8342	cold-filtered baloney rotgut	0		Effect: "Bastard!", Effect Duration: 32
-8343	extra-aerosolized super-aerosolized jittery twirling carton of gaspers	0		Effect: "Techno Bliss", Effect Duration: 45
+8343	extra-aerosolized super-aerosolized twirling jittery carton of gaspers	0		Effect: "Techno Bliss", Effect Duration: 45
 8344	modified colloidal upside-down bronze polish	0		Effect: "Danish Cunning", Effect Duration: 58
 8345	deionized energized crident	0		Effect: "The Two-Prong Crown", Effect Duration: 55
 8346	colloidal twirling totally sweet mohawk helmet	0		Effect: "Tearful, Fearful", Effect Duration: 11
 8347	cold-filtered spray chrome	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 52
 8348	boiled filthy monkey head	0		Effect: "Glittering Eyelashes", Effect Duration: 12
-8349	non-moist boiled oxidized bouncing maroon hand of cards	0		Effect: "License to Punch", Effect Duration: 23
+8349	non-moist boiled oxidized maroon bouncing hand of cards	0		Effect: "License to Punch", Effect Duration: 23
 8350	double-energized squat damp bar rag	0		Effect: "Angry like the Wolf", Effect Duration: 68
 8351	energized activated shaking lump of goofball ore	0		Effect: "Greased-Up Familiar", Effect Duration: 22
 8352	quantum moist skeleton beans	0		Effect: "Gr8ness", Effect Duration: 16
@@ -8229,8 +8229,8 @@
 8355	cold-filtered warmed narrow iron torso box	0		Effect: "Takin' It Greasy", Effect Duration: 55
 8356	adjusted huge mercenary headband	0		Effect: "Blessing of Charcoatl", Effect Duration: 36
 8357	triple-diffused cyan ghostly radioactive spider venom	0		Effect: "Mental A-cue-ity", Effect Duration: 68
-8358	vacuum-sealed quadruple-pressed blurry gray shaking x-ray mirror	0		Effect: "Sugar Smacks", Effect Duration: 51
-8359	ionized liquefied purple blurry wrestling mask	0		Effect: "Surreally Buff", Effect Duration: 60
+8358	vacuum-sealed quadruple-pressed shaking gray blurry x-ray mirror	0		Effect: "Sugar Smacks", Effect Duration: 51
+8359	ionized liquefied blurry purple wrestling mask	0		Effect: "Surreally Buff", Effect Duration: 60
 8360	double-altered non-vacuum-sealed hawkface potion	0		Effect: "Weird Vibrations", Effect Duration: 67
 8361	deionized twirling child-sized dracula cloak	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 13
 8362	flattened twirling devil-summoning hat	0		Effect: "Jingle Jangle Jingle", Effect Duration: 48
@@ -8242,20 +8242,20 @@
 8368	frozen anodized garbage juice slurpee	0		Effect: "Tiki Thoughtfulness", Effect Duration: 61
 8369	moist maroon plunge-leg	0		Effect: "Macho, Macho Dog", Effect Duration: 25
 8370	dry funky eyepatch	0		Effect: "Reedy Pipes", Effect Duration: 29
-8371	chilled double-pickled extra-enhanced wobbly tumbling bucket of fish juice	0		Effect: "Blubbered Up", Effect Duration: 42
+8371	chilled double-pickled extra-enhanced tumbling wobbly bucket of fish juice	0		Effect: "Blubbered Up", Effect Duration: 42
 8372	polymerized nitrogenated bouncing flashy pirate dreadlocks	0		Effect: "Patent Prevention", Effect Duration: 23
 8373	altered quantum blinking captured boozles	0		Effect: "Hood Ridin'", Effect Duration: 14
 8374	liquefied teal drinks tray	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 17
 8375	irradiated chilled eyebrow lifter	0		Effect: "Wasabi With You", Effect Duration: 57
 8376	twirling submarine	0		Last Available: "2015-06"
-8377	toothsome gigantic special pixel lemon	9	awesome	Effect: "Mental A-cue-ity", Effect Duration: 5, Last Available: "2015-06"
-8378	special mediocre pixel daiquiri	3	decent	Effect: "Elemental Mastery", Effect Duration: 40, Last Available: "2015-06"
+8377	gigantic toothsome special pixel lemon	9	awesome	Effect: "Mental A-cue-ity", Effect Duration: 5, Last Available: "2015-06"
+8378	mediocre special pixel daiquiri	3	decent	Effect: "Elemental Mastery", Effect Duration: 40, Last Available: "2015-06"
 8379	moist double-vacuum-sealed shaking power pill	0		Effect: "Leash of Linguini", Effect Duration: 50, Last Available: "2015-06"
 8380	liquefied olive pulsating pixel potion	0		Effect: "Hyperoxygenated Blood", Effect Duration: 39, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
-8384	blue spinning bubblegum heart	0		Last Available: "2015-07"
+8384	spinning blue bubblegum heart	0		Last Available: "2015-07"
 8385	narrow cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
@@ -8264,7 +8264,7 @@
 8390	fuchsia mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	squat gift card	0		Last Available: "2015-07"
-8393	green narrow hermit factoid	0		Last Available: "2015-07"
+8393	narrow green hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	pulsating lion tamer's The Emperor's new hat	0		Experience (familiar): +2, Last Available: "2015-07"
 8396	The Emperor's new shirt of James Dean	0		Experience (Moxie): +3, Last Available: "2015-07"
@@ -8284,13 +8284,13 @@
 8410	tasty agnolotti arboli	4	awesome	
 8411	decent huge spaghetti with ghost balls	8	good	
 8412	flavorless succulent marrow	4	decent	
-8413	snack-sized decent salacious crumbs	2	good	
+8413	decent snack-sized salacious crumbs	2	good	
 8414	decent fusilli marrownarrow	4	good	
-8415	special spoiled gigantic suggestive strozzapreti	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35
+8415	spoiled special gigantic suggestive strozzapreti	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35
 8416	Mountain Stream gastrique	0		
-8417	miniature decent Mt. McLargeHuge oyster	2	good	
+8417	decent miniature Mt. McLargeHuge oyster	2	good	
 8418	oyster sauce	0		
-8419	snack-sized bland skewed linguini immondizia bianco	2	decent	
+8419	bland snack-sized skewed linguini immondizia bianco	2	decent	
 8420	delicious big shells a la shellfish	5	awesome	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8310,9 +8310,9 @@
 8436	Jeselnik's LavaCo Lamp&trade; of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +25, Last Available: "2015-08"
 8437	wobbly personal trainer's beefy LavaCo Lamp&trade;	0		Muscle: +10, Experience Percent (Muscle): +10, Last Available: "2015-08"
 8438	mirror thin wire	0		Last Available: "2015-08"
-8439	mirror olive insulated wire	0		Last Available: "2015-08"
+8439	olive mirror insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
-8441	upside-down maroon full lava bottle	0		Last Available: "2015-08"
+8441	maroon upside-down full lava bottle	0		Last Available: "2015-08"
 8442	viscous lava globs	0		Last Available: "2015-08"
 8443	blue lava globs	0		Last Available: "2015-08"
 8444	lava globs	0		Last Available: "2015-08"
@@ -8329,13 +8329,13 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	cyan broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	up-at-dawn Fonzie's high-temperature mining mask	0		Experience (Moxie): +1, Adventures: +5, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	up-at-dawn Fonzie's high-temperature mining mask	0		Experience (Moxie): +1, Adventures: +5, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	gravedigger's occult fireproof megaphone	0		Spell Damage Percent: +25, Spooky Damage: +10, Last Available: "2015-08"
 8460	yummy mineapple	3	awesome	Last Available: "2015-08"
-8461	strong enchanted artisanal green Gold Velvet&trade; whiskey	5	EPIC	Effect: "Video Game Hot Dog", Effect Duration: 50, Last Available: "2015-08"
+8461	strong artisanal enchanted green Gold Velvet&trade; whiskey	5	EPIC	Effect: "Video Game Hot Dog", Effect Duration: 50, Last Available: "2015-08"
 8462	bouncing SMOOCH soda	1	good	Last Available: "2015-08"
 8463	rotten smelted roe	4	crappy	Last Available: "2015-08"
-8464	fancy mediocre spinning lavawater	3	decent	Effect: "Witch's Brood", Effect Duration: 30, Last Available: "2015-08"
+8464	mediocre fancy spinning lavawater	3	decent	Effect: "Witch's Brood", Effect Duration: 30, Last Available: "2015-08"
 8465	altered tarnished olive basaltamander tongue	0		Effect: "Wit Tea", Effect Duration: 45, Last Available: "2015-08"
 8466	ghostly ruddy experienced lavalarva of Flo-Jo	0		Experience: +2, Maximum HP Percent: +40, Initiative: +100, Last Available: "2015-08"
 8467	scorching stiffened Fonzie's lava balaclava	0		Experience (Moxie): +1, Damage Reduction: 1, Hot Damage: +25, Last Available: "2015-08"
@@ -8349,10 +8349,10 @@
 8475	tolerable asbestos thermos	3	good	Last Available: "2015-08"
 8476	moist flattened shaking liquid rhinestones	0		Effect: "Superveiny 9000", Effect Duration: 63, Last Available: "2015-08"
 8477	tasty disco biscuit	4	awesome	Last Available: "2015-08"
-8478	bad spirit-forward enchanted Quaatorade&trade;	5	decent	Effect: "Proprie Tea", Effect Duration: 50, Last Available: "2015-08"
-8479	ghostly avaricious flame-retardant brainy biker's hat	0		Mysticality: +5, Hot Resistance: +1, Meat Drop: +30, Familiar Effect: "atk", Last Available: "2015-08"
-8480	cyan lightning-fast Temple Grandin's studded feathered headdress	0		Damage Absorption: +80, Familiar Weight: +7, Initiative: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	narrow upside-down auspicious sizzling wholesome electrician's hardhat	0		Maximum HP Percent: +10, Hot Damage: +10, Item Drop: +10, Familiar Effect: "atk", Last Available: "2015-08"
+8478	bad enchanted spirit-forward Quaatorade&trade;	5	decent	Effect: "Proprie Tea", Effect Duration: 50, Last Available: "2015-08"
+8479	ghostly avaricious flame-retardant brainy biker's hat	0		Mysticality: +5, Hot Resistance: +1, Meat Drop: +30, Last Available: "2015-08", Familiar Effect: "atk"
+8480	cyan lightning-fast Temple Grandin's studded feathered headdress	0		Damage Absorption: +80, Familiar Weight: +7, Initiative: +40, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	narrow upside-down auspicious sizzling wholesome electrician's hardhat	0		Maximum HP Percent: +10, Hot Damage: +10, Item Drop: +10, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	fuchsia Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	tumbling The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	cyan Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	squat smooth velvet pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	squat smooth velvet pants of the dark arts	0		Spell Damage Percent: +100, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	skewed smooth velvet shirt of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2015-08"
 8492	Jeselnik's smooth velvet hat	0		Sleaze Damage: +25, Last Available: "2015-08"
 8493	lime green smooth velvet pocket square of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2015-08"
@@ -8378,7 +8378,7 @@
 8504	Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
-8507	distilled green huge SMOOCH coffee cup	1	decent	Last Available: "2015-08"
+8507	distilled huge green SMOOCH coffee cup	1	decent	Last Available: "2015-08"
 8508	dry labrador cookie	0		Effect: "Preternatural Greed", Effect Duration: 20, Last Available: "2015-08"
 8509	Van der Graaf therapeutic shellacked Mr. Cheeng's spectacles	0		Damage Reduction: 7, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2015-08"
 8510	grease cannon of extreme caution of the boozehound	0		Monster Level: -25, Booze Drop: +100, Last Available: "2015-08"
@@ -8391,12 +8391,12 @@
 8517	Annie Oakley's SMOOCH bracers of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2015-08"
 8518	greasy SMOOCH kneepads	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8519	jittery wobbly personal trainer's SMOOCH spaulders	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2015-08"
-8520	clever Newton's SMOOCH codpiece	0		Experience (Mysticality): +3, Maximum MP: +20, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	clever Newton's SMOOCH codpiece	0		Experience (Mysticality): +3, Maximum MP: +20, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	wobbly steel-toed SMOOCH breastplate	0		Damage Reduction: 9, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	snack-sized normal jittery lava cake	2	good	Last Available: "2015-08"
+8525	normal snack-sized jittery lava cake	2	good	Last Available: "2015-08"
 8526	adequate pink slime	3	good	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
@@ -8405,26 +8405,26 @@
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	huge illicit fish sauce	0		
-8534	miniature delicious libertagliatelle	2	awesome	
+8534	delicious miniature libertagliatelle	2	awesome	
 8535	bland turkish mostaccioli	3	decent	
-8536	decent huge linguini of the sea	10	good	
+8536	huge decent linguini of the sea	10	good	
 8537	double-wet Hersey&trade; SMOOCH	0		Effect: "Incensed", Effect Duration: 60
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	low-calorie moldy Fettris	1	crappy	
+8542	moldy low-calorie Fettris	1	crappy	
 8543	moldy half-sized fusillocybin	2	crappy	
 8544	normal red prescription noodles	4	good	
 8545	altered blood-drive sticker	1	good	
 8546	electrified gray bag of grain	0		Effect: "Natural 20", Effect Duration: 38
-8547	polymerized non-Vulcanized purple jittery ghostly pocket maze	0		Effect: "New and Improved", Effect Duration: 17
+8547	polymerized non-Vulcanized purple ghostly jittery pocket maze	0		Effect: "New and Improved", Effect Duration: 17
 8548	frozen triple-altered shady shades	0		Effect: "No Vertigo", Effect Duration: 15
 8549	super-activated squeaky toy rose	0		Effect: "Scavengers Scavenging", Effect Duration: 28
-8550	flavorless fancy weird gazelle steak	4	decent	Effect: "Helping Comes Second", Effect Duration: 5
-8551	massive tasty sausage without a cause	8	awesome	
+8550	fancy flavorless weird gazelle steak	4	decent	Effect: "Helping Comes Second", Effect Duration: 5
+8551	tasty massive sausage without a cause	8	awesome	
 8552	modified face paint	0		Effect: "Strength of Ten Ettins", Effect Duration: 69
-8553	special lousy emergency margarita	3	decent	Effect: "Haunted Liver", Effect Duration: 15
-8554	irresponsibly strong mediocre wobbly vintage smart drink	9	decent	
+8553	lousy special emergency margarita	3	decent	Effect: "Haunted Liver", Effect Duration: 15
+8554	mediocre irresponsibly strong wobbly vintage smart drink	9	decent	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8437,8 +8437,8 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	bouncing aromatic scandalous MacGyver's barrel lid	0		Maximum MP: +100, Sleaze Damage: +5, Stench Resistance: +1, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	inspector's asbestos-lined barrel hoop earring of wisdom	0		Mysticality: +15, Hot Resistance: +5, Item Drop: +15, Lasts Until Rollover, Last Available: "2015-09"
-8567	stanky experienced bankruptcy barrel of the brute	0		Muscle Percent: +30, Experience: +2, Stench Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
-8568	tumbling shaking olive firkin	0		Last Available: "2015-09"
+8567	stanky experienced bankruptcy barrel of the brute	0		Muscle Percent: +30, Experience: +2, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8568	olive tumbling shaking firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	twirling weathered barrel	0		Last Available: "2015-09"
@@ -8453,7 +8453,7 @@
 8580	stale barrel pickle	3	decent	Last Available: "2015-09"
 8581	stale upside-down upside-down barrel cracker	4	decent	Last Available: "2015-09"
 8582	dried shaking vibrating mushroom	1	good	Last Available: "2015-09"
-8583	altered narrow blurry mushroom	1	good	Last Available: "2015-09"
+8583	altered blurry narrow mushroom	1	good	Last Available: "2015-09"
 8584	fuchsia jittery arcane researcher's KoL Con 12-gauge	0		Experience Percent (Mysticality): +10, Last Available: "2015-09"
 8585	up-at-dawn Golden Mr. Eh?	0		Adventures: +5, Last Available: "2015-09"
 8586	barrel gun of Gandalf	0		Spell Critical Percent: +20, Last Available: "2015-09"
@@ -8471,17 +8471,17 @@
 8598	wicked cool barrel beryl ring	0		Moxie: +5, Spell Damage: +5, Last Available: "2015-09"
 8599	shaking map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
-8601	energized pulsating blurry cuppa Flamibili tea	0		Effect: "Supafly", Effect Duration: 41, Last Available: "2015-09"
+8601	energized blurry pulsating cuppa Flamibili tea	0		Effect: "Supafly", Effect Duration: 41, Last Available: "2015-09"
 8602	dry vacuum-sealed cuppa Yet tea	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 35, Last Available: "2015-09"
-8603	magnetized anodized twirling mirror cuppa Boo tea	0		Effect: "Slimy Hands", Effect Duration: 37, Last Available: "2015-09"
+8603	magnetized anodized mirror twirling cuppa Boo tea	0		Effect: "Slimy Hands", Effect Duration: 37, Last Available: "2015-09"
 8604	pickled concentrated cuppa Nas tea	0		Effect: "Tingly Wrists", Effect Duration: 60, Last Available: "2015-09"
 8605	adjusted cuppa Improprie tea	0		Effect: "Pasta Oneness", Effect Duration: 59, Last Available: "2015-09"
 8606	deionized non-dry narrow cuppa Frost tea	0		Effect: "Omphalotus Omnipresence", Effect Duration: 46, Last Available: "2015-09"
 8607	quadruple-improved maroon cuppa Toast tea	0		Effect: "Fireproof Lips", Effect Duration: 33, Last Available: "2015-09"
-8608	diffused pulsating ghostly cuppa Net tea	0		Effect: "Polka of Plenty", Effect Duration: 55, Last Available: "2015-09"
+8608	diffused ghostly pulsating cuppa Net tea	0		Effect: "Polka of Plenty", Effect Duration: 55, Last Available: "2015-09"
 8609	nitrogenated vacuum-sealed gray cuppa Proprie tea	0		Effect: "Meadulla Oblongota", Effect Duration: 56, Last Available: "2015-09"
 8610	galvanized cuppa Morbidi tea	0		Effect: "Sweet and Yellow", Effect Duration: 69, Last Available: "2015-09"
-8611	nitrogenated shaking maroon cuppa Chari tea	0		Effect: "Cheered Up", Effect Duration: 22, Last Available: "2015-09"
+8611	nitrogenated maroon shaking cuppa Chari tea	0		Effect: "Cheered Up", Effect Duration: 22, Last Available: "2015-09"
 8612	polymerized purple cuppa Serendipi tea	0		Effect: "Sealed Brain", Effect Duration: 36, Last Available: "2015-09"
 8613	non-frozen Vulcanized skewed cuppa Feroci tea	0		Effect: "Healthy Blue Glow", Effect Duration: 39, Last Available: "2015-09"
 8614	ionized maroon cuppa Physicali tea	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2015-09"
@@ -8496,7 +8496,7 @@
 8623	irradiated Vulcanized wet blinking cuppa Loyal tea	0		Effect: "Alacri Tea", Effect Duration: 62, Last Available: "2015-09"
 8624	modified twirling cuppa Activi tea	1	decent	Last Available: "2015-09"
 8625	altered cuppa Cruel tea	1		Effect: "Curse of the Black Pearl Onion", Effect Duration: 35, Last Available: "2015-09"
-8626	ionized altered blurry wobbly upside-down cuppa Alacri tea	0		Effect: "Vitali Tea", Effect Duration: 42, Last Available: "2015-09"
+8626	ionized altered upside-down wobbly blurry cuppa Alacri tea	0		Effect: "Vitali Tea", Effect Duration: 42, Last Available: "2015-09"
 8627	electrified colloidal cuppa Vitali tea	0		Effect: "Full of Wist", Effect Duration: 37, Last Available: "2015-09"
 8628	pickled jittery cuppa Mana tea	0		Effect: "Melancholy Burden", Effect Duration: 57, Last Available: "2015-09"
 8629	enhanced narrow cuppa Monstrosi tea	0		Effect: "Sensation", Effect Duration: 46, Last Available: "2015-09"
@@ -8512,24 +8512,24 @@
 8639	gray doghouse	0		Free Pull, Last Available: "2015-10"
 8640	jittery Ghost Dog Chow	0		Last Available: "2015-10"
 8641	miniature bland bowl of eyeballs	2	decent	Last Available: "2015-10"
-8642	low-calorie normal bowl of mummy guts	1	good	Last Available: "2015-10"
+8642	normal low-calorie bowl of mummy guts	1	good	Last Available: "2015-10"
 8643	bland bowl of maggots	3	decent	Last Available: "2015-10"
 8644	drinkable extra-dry blood and blood	5	good	Last Available: "2015-10"
 8645	lousy Jack-O-Lantern beer	4	decent	Last Available: "2015-10"
-8646	triple-distilled drinkable zombie	7	good	Last Available: "2015-10"
+8646	drinkable triple-distilled zombie	7	good	Last Available: "2015-10"
 8647	mirror Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	wobbly plastic nightmare troll	0		Last Available: "2015-10"
 8650	blinking tennis ball	0		Last Available: "2015-10"
 8651	ribald gravedigger's Temple Grandin's crown	0		Familiar Weight: +7, Spooky Damage: +10, Sleaze Damage: +10, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	teal ear poison	0		
-8653	gray pulsating stink-penny	0		
+8653	pulsating gray stink-penny	0		
 8654	ruddy hawk of vim and vigor of the cheetah	0		Maximum HP Percent: 90, Initiative: +60
 8655	rotten half-sized hamlet sandwich	2	crappy	
 8656	greasy Othello's military jacket	0		Sleaze Spell Damage: +10
 8657	narrow twirling sharpshooter's Othello's dagger	0		Critical Hit Percent: +10, Single Equip
 8658	blinking experienced Othello's handkerchief	0		Experience: +2, Single Equip
-8659	irradiated squat blinking bowl of Jeal-O	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 57
+8659	irradiated blinking squat bowl of Jeal-O	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 57
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	scorching curative wicked ghostly dagger	0		Spell Damage: +5, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5
@@ -8547,8 +8547,8 @@
 8674	jittery airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	alkaline wet shoulder-warming lotion	0		Effect: "Painted-On Bikini", Effect Duration: 59, Last Available: "2015-11"
-8677	small moldy twirling iceberg lettuce	2	crappy	Last Available: "2015-11"
-8678	bad practically non-alcoholic ice wine	1	decent	Last Available: "2015-11"
+8677	moldy small twirling iceberg lettuce	2	crappy	Last Available: "2015-11"
+8678	practically non-alcoholic bad ice wine	1	decent	Last Available: "2015-11"
 8679	ghostly smelly steel-toed Wal-Mart snowglobe of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Stench Spell Damage: +10, Last Available: "2015-11"
 8680	foul-smelling personal trainer's Wal-Mart nametag of terror	0		Experience Percent (Muscle): +10, Stench Damage: +10, Spooky Spell Damage: +10, Last Available: "2015-11"
 8681	Temple Grandin's razor-sharp beefcake's Wal-Mart overalls	0		Muscle: +25, Weapon Damage Percent: +25, Familiar Weight: +7, Last Available: "2015-11"
@@ -8558,20 +8558,20 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	twirling The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	shaking jittery dog trainer's bellhop's hat	0		Experience (familiar): +1, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	tolerable ghostly ice porter	3	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	shaking jittery dog trainer's bellhop's hat	0		Experience (familiar): +1, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	tolerable ghostly ice porter	3	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	Vulcanized twirling exotic travel brochure	0		Effect: "Cool Spirit", Effect Duration: 17, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	galvanized polarized yellow shampoo-conditioner	0		Effect: "Faboooo", Effect Duration: 34, Last Available: "2015-11"
-8693	shaking blinking hotel minibar key	0		Last Available: "2015-11"
+8693	blinking shaking hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	twisted yellow medicinal herbs	1		Last Available: "2016-01"
-8697	moldy gigantic bouncing bouncing ice rice	6	crappy	Last Available: "2016-01"
-8698	practically non-alcoholic fancy aged iced plum wine	1	awesome	Effect: "Cool, Catlike", Effect Duration: 25, Last Available: "2016-01"
+8697	gigantic moldy bouncing bouncing ice rice	6	crappy	Last Available: "2016-01"
+8698	aged practically non-alcoholic fancy iced plum wine	1	awesome	Effect: "Cool, Catlike", Effect Duration: 25, Last Available: "2016-01"
 8699	jittery foul-smelling quilted training belt of the sweet-tooth	0		Damage Absorption: +40, Stench Damage: +10, Candy Drop: +100, Single Equip, Last Available: "2016-01"
 8700	greedy Temple Grandin's hardened training legwarmers	0		Damage Reduction: 3, Familiar Weight: +7, Meat Drop: +20, Single Equip, Last Available: "2016-01"
-8701	yellow quilted forbidden training helmet of Calamity Jane	0		Spell Damage Percent: +50, Damage Absorption: +40, Critical Hit Percent: +15, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	yellow quilted forbidden training helmet of Calamity Jane	0		Spell Damage Percent: +50, Damage Absorption: +40, Critical Hit Percent: +15, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	blurry training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8582,15 +8582,15 @@
 8709	mixed abstraction: thought	1		Last Available: "2015-12"
 8710	modified abstraction: sensation	1		Last Available: "2015-12"
 8711	denatured shaking abstraction: purpose	1		Last Available: "2015-12"
-8712	mixed wobbly squat squat abstraction: category	1		Effect: "Stuck-Up Hair", Effect Duration: 45, Last Available: "2015-12"
-8713	modified twirling blinking red abstraction: perception	1		Last Available: "2015-12"
+8712	mixed squat wobbly squat abstraction: category	1		Effect: "Stuck-Up Hair", Effect Duration: 45, Last Available: "2015-12"
+8713	modified red blinking twirling abstraction: perception	1		Last Available: "2015-12"
 8714	mixed abstraction: motion	1		Effect: "Frozen Hands", Effect Duration: 25, Last Available: "2015-12"
 8715	distilled abstraction: joy	1		Effect: "In Tuna", Effect Duration: 20, Last Available: "2015-12"
 8716	modified abstraction: certainty	1		Last Available: "2015-12"
 8717	distilled abstraction: comprehension	1		Effect: "Floundering", Effect Duration: 20, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	stale VYKEA meatballs	4	decent	Last Available: "2015-11"
-8720	irresponsibly strong delicious VYKEA mead	10	awesome	Last Available: "2015-11"
+8720	delicious irresponsibly strong VYKEA mead	10	awesome	Last Available: "2015-11"
 8721	dry squat VYKEA woadpaint	0		Effect: "Ermine Eyes", Effect Duration: 36, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,11 +8601,11 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	pulsating fortified padded VYKEA hex key of James Dean	0		Experience (Moxie): +3, Damage Absorption: 80, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	huge decent tin of submardines	8	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	huge decent tin of submardines	8	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	drinkable bottle of norwhiskey	3	good	Last Available: "2015-11"
 8733	boiled octolus oculus	1	decent	Last Available: "2015-11"
 8734	shaking bouncing perfumed mansplainer's medical-grade sardine can key	0		Monster Level: +15, Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-11"
-8735	manspreader's dance instructor's norwhal helmet of bravery	0		Experience Percent (Moxie): +10, Monster Level: +10, Spooky Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
+8735	manspreader's dance instructor's norwhal helmet of bravery	0		Experience Percent (Moxie): +10, Monster Level: +10, Spooky Resistance: +5, Last Available: "2015-11", Familiar Effect: "atk"
 8736	pulsating dog trainer's hale supercool octolus-skin cloak	0		Moxie Percent: +20, Maximum HP: +20, Experience (familiar): +1, Last Available: "2015-11"
 8737	drinkable extra-dry perfect cosmopolitan	5	good	Last Available: "2015-11"
 8738	drinkable boozy mirror perfect negroni	5	good	Last Available: "2015-11"
@@ -8624,7 +8624,7 @@
 8751	flattened oxidized ghostly communal gobstopper	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 13, Last Available: "2015-12"
 8752	snack-sized bland bouncing cyan Crimbo salad	2	decent	Last Available: "2015-12"
 8753	bland huge bread line	3	decent	Last Available: "2015-12"
-8754	fancy acceptable shaking red bark rootbeer	4	good	Effect: "Amorphous Cheer", Effect Duration: 50, Last Available: "2015-12"
+8754	acceptable fancy red shaking bark rootbeer	4	good	Effect: "Amorphous Cheer", Effect Duration: 50, Last Available: "2015-12"
 8755	delicious wobbly ale	4	awesome	Last Available: "2015-12"
 8756	Fonzie's plastic Tammy the Tambourine Elf	0		Experience (Moxie): +1, Last Available: "2015-12"
 8757	deadly plastic Rudolph the Red	0		Weapon Damage: +5, Last Available: "2015-12"
@@ -8638,9 +8638,9 @@
 8765	squat Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
 8766	lousy Gratitude chocolate (bourbon-filled)	4	decent	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
-8768	lime green wobbly wobbly Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
+8768	wobbly wobbly lime green Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	gray chocolate bowtie	0		Familiar Weight: +5
-8770	ionized wobbly pulsating pitted sheet	0		Effect: "Broberry Brotality", Effect Duration: 42, Last Available: "2015-12"
+8770	ionized pulsating wobbly pitted sheet	0		Effect: "Broberry Brotality", Effect Duration: 42, Last Available: "2015-12"
 8771	sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	squat aromatic reusable shopping bag of wisdom of James Dean	0		Mysticality: +15, Experience (Moxie): +3, Stench Resistance: +1, Last Available: "2015-12"
@@ -8649,12 +8649,12 @@
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
-8780	blue shaking iron chain	0		Last Available: "2015-12"
+8780	shaking blue iron chain	0		Last Available: "2015-12"
 8781	inspector's pine cone necklace	0		Item Drop: +15, Last Available: "2015-12"
 8782	banded reindeer hammer	0		Damage Absorption: +100, Last Available: "2015-12"
 8783	hale elf ploughshare	0		Maximum HP: +20, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	olive The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	olive The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	bouncing faded protest sign	0		Last Available: "2015-12"
 8787	gray faded protest sign	0		Last Available: "2015-12"
 8788	mirror red nasty-smelling moss	0		Last Available: "2015-12"
@@ -8689,17 +8689,17 @@
 8817	pickled blinking Mansquito Serum	1		Last Available: "2016-12"
 8818	acceptable jittery Miss Graves' vermouth	4	good	Last Available: "2016-12"
 8819	special toothsome small The Plumber's mushroom stew	2	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2016-12"
-8820	diluted spinning blue spinning The Author's ink	1		Last Available: "2016-02"
+8820	diluted blue spinning spinning The Author's ink	1		Last Available: "2016-02"
 8821	lousy bouncing The Mad Liquor	4	decent	Last Available: "2016-12"
 8822	bad huge Doc Clock's thyme cocktail	3	decent	Last Available: "2016-12"
 8823	fancy flavorless Mr. Burnsger	3	decent	Effect: "Cotton Mouthed", Effect Duration: 35, Last Available: "2016-12"
-8824	compressed wobbly spinning purple The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
+8824	compressed spinning purple wobbly The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	curative veiny arcane researcher's The Jokester's gun	0		Experience Percent (Mysticality): +10, Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	shaking dog trainer's Van der Graaf ruddy The Jokester's wig	0		Maximum HP Percent: +40, Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8826	shaking dog trainer's Van der Graaf ruddy The Jokester's wig	0		Maximum HP Percent: +40, Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	jittery prompt double-paned banded The Jokester's pants	0		Damage Absorption: +100, Cold Resistance: +5, Adventures: +3, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
-8828	pickled jittery huge Jokester makeup	0		Effect: "Faboooo", Effect Duration: 52, Last Available: "2016-12"
+8828	pickled huge jittery Jokester makeup	0		Effect: "Faboooo", Effect Duration: 52, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
-8830	twirling maroon battoo kit	0		Last Available: "2016-12"
+8830	maroon twirling battoo kit	0		Last Available: "2016-12"
 8831	pulsating basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	magnetized concentrated robin's egg	0		Effect: "Buggy Flavor", Effect Duration: 13, Last Available: "2016-12"
@@ -8745,20 +8745,20 @@
 8873	Samson's Pork 'n' Pork 'n' Pork 'n' Beans	0		Experience (Muscle): +5, Last Available: "2016-02"
 8874	tumbling ruddy steel-toed boxer's weightlifter's Val-U Brand Every Bean Salad of doom	0		Muscle: +15, Muscle Percent: +10, Damage Reduction: 9, Maximum HP Percent: +40, Spooky Spell Damage: +50, Last Available: "2016-02"
 8875	ghostly prompt ribald steel-toed Shrub's Premium Baked Beans	0		Damage Reduction: 9, Sleaze Damage: +10, Adventures: +3, Last Available: "2016-02"
-8876	flavorless jumbo plate of Heimz Fortified Kidney Beans	5	decent	Last Available: "2016-02"
-8877	tiny bland plate of Tesla's Electroplated Beans	1	decent	Last Available: "2016-02"
+8876	jumbo flavorless plate of Heimz Fortified Kidney Beans	5	decent	Last Available: "2016-02"
+8877	bland tiny plate of Tesla's Electroplated Beans	1	decent	Last Available: "2016-02"
 8878	half-sized stale plate of Mixed Garbanzos and Chickpeas	2	decent	Last Available: "2016-02"
-8879	delicious low-calorie blurry plate of Hellfire Spicy Beans	1	awesome	Last Available: "2016-02"
-8880	enchanted adequate plate of Frigid Northern Beans	4	good	Effect: "Jawin'", Effect Duration: 45, Last Available: "2016-02"
-8881	flavorless miniature plate of World's Blackest-Eyed Peas	2	decent	Last Available: "2016-02"
+8879	low-calorie delicious blurry plate of Hellfire Spicy Beans	1	awesome	Last Available: "2016-02"
+8880	adequate enchanted plate of Frigid Northern Beans	4	good	Effect: "Jawin'", Effect Duration: 45, Last Available: "2016-02"
+8881	miniature flavorless plate of World's Blackest-Eyed Peas	2	decent	Last Available: "2016-02"
 8882	adequate huge plate of Trader Olaf's Exotic Stinkbeans	4	good	Last Available: "2016-02"
 8883	spoiled plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	crappy	Last Available: "2016-02"
 8884	delicious snack-sized plate of Val-U Brand Every Bean Salad	2	awesome	Last Available: "2016-02"
-8885	diet rotten enchanted plate of Shrub's Premium Baked Beans	1	crappy	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 20, Last Available: "2016-02"
+8885	enchanted diet rotten plate of Shrub's Premium Baked Beans	1	crappy	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 20, Last Available: "2016-02"
 8886	spinning frightening stanky Fancy Jeff's pocket square	0		Stench Spell Damage: +25, Spooky Damage: +5, Last Available: "2016-02"
-8887	narrow censurious lard-coated resourceful Daisy's unclean bloomers	0		Maximum MP: +50, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	narrow censurious lard-coated resourceful Daisy's unclean bloomers	0		Maximum MP: +50, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	weightlifter's beefy Amoon-Ra Cowtep's nemes of incineration	0		Muscle: 25, Hot Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	weightlifter's beefy Amoon-Ra Cowtep's nemes of incineration	0		Muscle: 25, Hot Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	cyan inspector's auspicious stiffened banded smartaleck's Former Sheriff Dan's tin star	0		Moxie Percent: +30, Damage Absorption: +100, Damage Reduction: 1, Item Drop: 25, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8781,7 +8781,7 @@
 8909	bland special shaking rotting beefsteak	3	decent	Effect: "Boon of She-Who-Was", Effect Duration: 5, Last Available: "2016-02"
 8910	triple-distilled mediocre firemilk	9	decent	Last Available: "2016-02"
 8911	energized bouncing spidercow eye-cluster	0		Effect: "Elvish", Effect Duration: 45, Last Available: "2016-02"
-8912	denatured spinning bouncing moomy dust	1		Last Available: "2016-02"
+8912	denatured bouncing spinning moomy dust	1		Last Available: "2016-02"
 8913	lion tamer's wizardly western-style skinning knife	0		Mysticality: +25, Experience (familiar): +2, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	sinister steel knuckles	0		Spell Damage: +10, Last Available: "2016-02"
@@ -8791,7 +8791,7 @@
 8919	LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
-8922	narrow jittery Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
+8922	jittery narrow Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
 8924	disc (black)	0		
 8925	disc (red)	0		
@@ -8867,12 +8867,12 @@
 8995	pressed ionized cold-filtered Greek fire	0		Effect: "Bread-Lined", Effect Duration: 57, Last Available: "2016-03"
 8996	gray nasty sizzling padded smooth ox-head shield of Tarzan	0		Moxie: +15, Experience (Muscle): +3, Damage Absorption: +20, Hot Damage: +10, Stench Damage: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	friendly manspreader's hardened arcane researcher's dented scepter of the boozehound	0		Experience Percent (Mysticality): +10, Damage Reduction: 3, Monster Level: +10, Familiar Weight: +3, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	pulsating chilly crafty padded very pointy crown of the brute of horror	0		Muscle Percent: +30, Damage Absorption: +20, Maximum MP: +10, Cold Damage: +5, Spooky Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	pulsating chilly crafty padded very pointy crown of the brute of horror	0		Muscle Percent: +30, Damage Absorption: +20, Maximum MP: +10, Cold Damage: +5, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	upside-down healthy wholesome battle broom of the dark arts of the storm of the scaredy-cat	0		Spell Damage Percent: +100, Maximum HP Percent: 30, Maximum MP Percent: +40, Monster Level: -15, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	skewed Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	aromatic greasy curative Rosewater's carpe	0		Mysticality Percent: +30, Sleaze Spell Damage: +10, Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
 9002	stanky Van der Graaf ruddy fortified codpiece	0		Damage Absorption: +60, Maximum HP Percent: +40, Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
-9003	shaking yellow healthy Da Vinci's educational smartaleck's troutsers	0		Moxie Percent: +30, Experience: +1, Experience (Mysticality): +5, Maximum HP Percent: +20, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	shaking yellow healthy Da Vinci's educational smartaleck's troutsers	0		Moxie Percent: +30, Experience: +1, Experience (Mysticality): +5, Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	up-at-dawn gravedigger's electrified bass clarinet of the glutton	0		Spooky Damage: +10, Food Drop: +100, Adventures: +5, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
 9005	stanky Tesla resourceful wizardly fish hatchet	0		Mysticality: +25, Maximum MP: +50, Stench Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9006	flame-retardant Lo Pan's slick tunac of the storm	0		Moxie: +10, Maximum MP Percent: +40, Spell Critical Percent: +30, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	spinning meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	special adequate gallon of milk	3	good	Effect: "Deadly Lampblade", Effect Duration: 5, Last Available: "2016-05"
+9021	adequate special gallon of milk	3	good	Effect: "Deadly Lampblade", Effect Duration: 5, Last Available: "2016-05"
 9022	blurry print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8904,10 +8904,10 @@
 9032	delicious bowl of Tastee-Wheet&trade;	3	awesome	
 9033	mirror lime green spinning Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	lime green Source essence	0		Last Available: "2016-06"
-9035	adequate thick jittery browser cookie	5	good	Last Available: "2016-06"
+9035	thick adequate jittery browser cookie	5	good	Last Available: "2016-06"
 9036	artisanal hacked gibson	3	super EPIC	Last Available: "2016-06"
 9037	shaking groovy Source shades	0		Moxie Percent: +10, Last Available: "2016-06"
-9038	blurry wobbly blue software bug	0		Last Available: "2016-06"
+9038	wobbly blue blurry software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
 9040	mirror Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
@@ -8915,11 +8915,11 @@
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	squat Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	Source terminal TRAM chip	0		Last Available: "2016-06"
-9046	purple blurry Source terminal INGRAM chip	0		Last Available: "2016-06"
+9046	blurry purple Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	huge upside-down Source terminal SCRAM chip	0		Last Available: "2016-06"
-9050	blinking green Source terminal TRIGRAM chip	0		Last Available: "2016-06"
+9050	green blinking Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	jittery supercharged Mr. Screege's spectacles	0		Maximum MP Percent: +30, Single Equip, Last Available: "2016-08"
 9092	olive double-paned Socratic Spookyraven signet of terror	0		Experience (Mysticality): +1, Spooky Spell Damage: +10, Cold Resistance: +5, Single Equip, Last Available: "2016-08"
 9093	careful tie-dyed fannypack of the sewer	0		Monster Level: -10, Stench Damage: +25, Single Equip, Last Available: "2016-08"
-9094	skewed mirror vibrating Newton's burnt snowpants	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	skewed mirror vibrating Newton's burnt snowpants	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	occult standards and practices guide	0		Spell Damage Percent: +25, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	yellow scandalous friendly supercharged Carpathian longsword	0		Maximum MP Percent: +30, Familiar Weight: +3, Sleaze Damage: +5, Last Available: "2016-08"
 9097	blinking sizzling Rosewater's Liam's mail of terror	0		Mysticality Percent: +30, Hot Damage: +10, Spooky Spell Damage: +10, Last Available: "2016-08"
@@ -9006,31 +9006,31 @@
 9134	stale leftover pasty	3	decent	
 9135	perfectly mixed very whiskey	3	EPIC	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
-9137	bouncing cyan li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	green li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	shaking li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9137	cyan bouncing li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
+9138	green li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	shaking li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	concentrated non-electrified flattened tumbling hoarded candy wad	0		Effect: "Stop the Presses!", Effect Duration: 50, Last Available: "2016-10"
 9147	polarized Prunets	0		Effect: "Superioreo", Effect Duration: 47
 9148	red Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	unsweetened invisible string	0		Lasts Until Rollover, Effect: "Mistified", Effect Duration: 49, Last Available: "2016-10"
 9151	extra-liquefied polarized invisible seam ripper	0		Lasts Until Rollover, Effect: "Spiky Frozen Hair", Effect Duration: 39, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	decent raw sweet potato	4	good	Last Available: "2016-11"
 9154	adequate gray raw beans	3	good	Last Available: "2016-11"
 9155	normal olive raw stuffing	3	good	Last Available: "2016-11"
 9156	rotten red raw cranberry sauce	4	crappy	Last Available: "2016-11"
 9157	tiny moldy raw turkey	1	crappy	Last Available: "2016-11"
-9158	flavorless half-sized raw mincemeat	2	decent	Last Available: "2016-11"
+9158	half-sized flavorless raw mincemeat	2	decent	Last Available: "2016-11"
 9159	thick yummy raw potato	5	awesome	Last Available: "2016-11"
-9160	flavorless tiny raw gravy	1	decent	Last Available: "2016-11"
-9161	rotten low-calorie raw bread	1	crappy	Last Available: "2016-11"
+9160	tiny flavorless raw gravy	1	decent	Last Available: "2016-11"
+9161	low-calorie rotten raw bread	1	crappy	Last Available: "2016-11"
 9162	Temple Grandin's mini-marshmallow dispenser of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +7, Last Available: "2016-11"
 9163	chaotic slick cool glass casserole dish	0		Moxie: 15, Spell Critical Percent: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9041,21 +9041,21 @@
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	bland sweet potatoes	3	decent	Last Available: "2016-11"
-9172	stale small squat bean casserole	2	decent	Last Available: "2016-11"
+9172	small stale squat bean casserole	2	decent	Last Available: "2016-11"
 9173	decent blinking baked stuffing	4	good	Last Available: "2016-11"
 9174	spoiled cranberry cylinder	3	crappy	Last Available: "2016-11"
 9175	moldy snack-sized spinning thanksgiving turkey	2	crappy	Last Available: "2016-11"
 9176	spoiled half-sized fuchsia mince pie	2	crappy	Last Available: "2016-11"
 9177	decent mashed potatoes	4	good	Last Available: "2016-11"
-9178	diet moldy warm gravy	1	crappy	Last Available: "2016-11"
+9178	moldy diet warm gravy	1	crappy	Last Available: "2016-11"
 9179	moldy wobbly bread roll	4	crappy	Last Available: "2016-11"
 9180	huge rotten leftovers	9	crappy	Last Available: "2016-11"
-9181	fancy stale purple blinking leftovers sandwich	4	decent	Effect: "Thought", Effect Duration: 40, Last Available: "2016-11"
+9181	stale fancy blinking purple leftovers sandwich	4	decent	Effect: "Thought", Effect Duration: 40, Last Available: "2016-11"
 9182	blurry Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	blinking megacopia	0		Last Available: "2016-11"
 9185	blurry pilgrim hat	0		Last Available: "2016-11"
-9186	twirling blue packet of thanksgarden seeds	0		Last Available: "2016-11"
+9186	blue twirling packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	tumbling bomb of unknown origin	0		Last Available: "2016-11"
 9189	ghostly Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
@@ -9063,8 +9063,8 @@
 9191	Vulcanized altered narrow eldritch concentrate	0		Effect: "Fudge Headache", Effect Duration: 23, Last Available: "2016-11"
 9192	drinkable eldritch extract	4	good	Last Available: "2016-11"
 9193	banded Rosewater's Official Council Aide Pin	0		Mysticality Percent: +30, Damage Absorption: +100, Last Available: "2016-11"
-9194	practically non-alcoholic aged eldritch distillate	1	awesome	Last Available: "2016-11"
-9195	altered spinning pulsating eldritch essence	1		Last Available: "2016-11"
+9194	aged practically non-alcoholic eldritch distillate	1	awesome	Last Available: "2016-11"
+9195	altered pulsating spinning eldritch essence	1		Last Available: "2016-11"
 9196	forbidden Science Notebook	0		Spell Damage Percent: +50
 9197	zippy deadly eldritch hat of the scaredy-cat	0		Weapon Damage: +5, Monster Level: -15, Initiative: +20, Last Available: "2016-11"
 9198	Sherlock's Tesla eldritch pants of the storm	0		Maximum MP Percent: +40, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-11"
@@ -9085,15 +9085,15 @@
 9213	ghostly ribald gravedigger's hardy candy necktie	0		Maximum HP: +50, Spooky Damage: +10, Sleaze Damage: +10, Single Equip, Last Available: "2016-12"
 9214	upside-down ghostly Usain Bolt's asbestos-lined stylish chocolate pocketwatch	0		Moxie: +25, Hot Resistance: +5, Initiative: +80, Single Equip, Last Available: "2016-12"
 9215	teal broken chocolate pocketwatch	0		Last Available: "2016-12"
-9216	jittery skewed interesting clod of dirt	0		
+9216	skewed jittery interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	adequate massive tumbling animal part cracker	7	good	Last Available: "2016-12"
-9220	delicious watered-down ghostly red gingerbread wine	2	awesome	Last Available: "2016-12"
+9220	delicious watered-down red ghostly gingerbread wine	2	awesome	Last Available: "2016-12"
 9221	moldy gingerbread mug	3	crappy	Last Available: "2016-12"
 9222	mirror gingerbread mask of the bloodbag	0		Maximum HP: +100, Last Available: "2016-12"
 9223	stanky manspreader's gingerservo of the overflowing toilet	0		Monster Level: +10, Stench Spell Damage: 75, Single Equip, Last Available: "2016-12"
-9224	ionized skewed blurry tainted icing	0		Effect: "Broberry Brotality", Effect Duration: 62, Last Available: "2016-12"
+9224	ionized blurry skewed tainted icing	0		Effect: "Broberry Brotality", Effect Duration: 62, Last Available: "2016-12"
 9225	green perfumed gingerbeard	0		Stench Resistance: +5, Single Equip, Last Available: "2016-12"
 9226	lime green gingerbread smartphone	0		Last Available: "2016-12"
 9227	Samson's beefcake's gingerbread hoodie	0		Muscle: +25, Experience (Muscle): +5, Sprinkle Drop: +15, Last Available: "2016-12"
@@ -9111,7 +9111,7 @@
 9239	mediocre ginger beer	3	decent	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	irradiated narrow industrial frosting	0		Effect: "Once Bitten Twice Fried", Effect Duration: 52, Last Available: "2016-12"
-9242	denatured skewed shaking purple fake cocktail	0		Effect: "Helvella Health", Effect Duration: 12, Last Available: "2016-12"
+9242	denatured shaking skewed purple fake cocktail	0		Effect: "Helvella Health", Effect Duration: 12, Last Available: "2016-12"
 9243	drinkable high-end ginger wine	3	good	Last Available: "2016-12"
 9244	Lo Pan's plastic bad vibe	0		Spell Critical Percent: +30, Last Available: "2016-12"
 9245	wobbly scorching plastic angry vikings	0		Hot Damage: +25, Last Available: "2016-12"
@@ -9121,10 +9121,10 @@
 9249	double-cold-filtered ghostly Inner Wisdom	0		Effect: "The Q Is Talking To You", Effect Duration: 65, Last Available: "2016-12"
 9250	improved Inner Strength	0		Effect: "Unusual Fashion Sense", Effect Duration: 20, Last Available: "2016-12"
 9251	wet Inner Truth	0		Effect: "A Contender", Effect Duration: 50, Last Available: "2016-12"
-9252	half-sized moldy spiritual candy cane	2	crappy	Last Available: "2016-12"
-9253	practically non-alcoholic perfectly mixed enchanted spiritual eggnog	1	super EPIC	Effect: "Hairy Palms", Effect Duration: 25, Last Available: "2016-12"
-9254	half-sized fancy rotten spiritual fruitcake	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 15, Last Available: "2016-12"
-9255	spoiled miniature spinning spiritual gingerbread	2	crappy	Last Available: "2016-12"
+9252	moldy half-sized spiritual candy cane	2	crappy	Last Available: "2016-12"
+9253	perfectly mixed practically non-alcoholic enchanted spiritual eggnog	1	super EPIC	Effect: "Hairy Palms", Effect Duration: 25, Last Available: "2016-12"
+9254	rotten fancy half-sized spiritual fruitcake	2	crappy	Effect: "Glittering Eyelashes", Effect Duration: 15, Last Available: "2016-12"
+9255	miniature spoiled spinning spiritual gingerbread	2	crappy	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	pulsating chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	upside-down briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	wobbly teethpick	0		Last Available: "2016-12"
 9266	wet non-diffused red mirror rock candy	0		Effect: "Marinated", Effect Duration: 60, Last Available: "2016-12"
-9267	spoiled low-calorie purple green-iced sweet roll	1	crappy	Last Available: "2016-12"
+9267	low-calorie spoiled purple green-iced sweet roll	1	crappy	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	narrow no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9162,7 +9162,7 @@
 9290	normal Eldritch snap	3	good	Last Available: "2017-01"
 9291	modified yellow tumbling hot jelly	1		Last Available: "2017-01"
 9292	boiled purple mirror jelly	1		Last Available: "2017-01"
-9293	pickled wobbly mirror jelly	1		Last Available: "2017-01"
+9293	pickled mirror wobbly jelly	1		Last Available: "2017-01"
 9294	pickled sleaze jelly	1		Last Available: "2017-01"
 9295	modified stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
@@ -9176,7 +9176,7 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	resourceful extremely unsafe wax hand	0		Weapon Damage Percent: +100, Maximum MP: +50, Last Available: "2017-01"
 9306	yellow nasty rosy-cheeked candle	0		Maximum HP Percent: +30, Stench Damage: +5, Lasts Until Rollover, Last Available: "2017-01"
-9307	stale big fuchsia mirror wax pancake	5	decent	Last Available: "2017-01"
+9307	stale big mirror fuchsia wax pancake	5	decent	Last Available: "2017-01"
 9308	Newton's wax face of the scaredy-cat	0		Experience (Mysticality): +3, Monster Level: -15, Last Available: "2017-01"
 9309	drinkable shaking wax booze	3	good	Last Available: "2017-01"
 9310	gray glob of melted wax	0		Last Available: "2017-01"
@@ -9194,7 +9194,7 @@
 9322	lard-coated energetic Samson's LOV Earrings	0		Experience (Muscle): +5, Maximum MP Percent: +20, Sleaze Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
-9325	blurry bouncing LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
+9325	bouncing blurry LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	pickled mirror bouncing LOV Echinacea Bouquet	1		Effect: "Graham Crackling", Effect Duration: 5, Last Available: "2017-02"
 9327	hale LOV Elephant	0		Maximum HP: +20, Damage Reduction: 6, Last Available: "2017-02"
 9328	skewed twirling Jeselnik's eldritch scanner	0		Sleaze Damage: +25, Last Available: "2017-02"
@@ -9203,11 +9203,11 @@
 9331	blinking sharpshooter's electrified eldritch hammer of the businessman	0		Critical Hit Percent: +10, Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2017-01"
 9332	snack-sized moldy bouncing eldritch mushroom	2	crappy	Last Available: "2017-03"
 9333	narrow eldritch ichor	0		
-9334	miniature enchanted spoiled eldritch mushroom pizza	2	crappy	Effect: "Mer-kindliness", Effect Duration: 35, Last Available: "2017-03"
+9334	enchanted miniature spoiled eldritch mushroom pizza	2	crappy	Effect: "Mer-kindliness", Effect Duration: 35, Last Available: "2017-03"
 9335	shaking eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	blurry eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	boiled extra-vacuum-sealed jittery eldritch rub	0		Effect: "You Drank Fish Wine", Effect Duration: 58, Last Available: "2017-02"
-9338	wobbly narrow HP-35 Calculator	0		
+9338	narrow wobbly HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	blue Platinum HP-35 Calculator	0		
@@ -9222,7 +9222,7 @@
 9350	mirror elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
 9352	bouncing bottle of clam juice	0		Last Available: "2017-03"
-9353	green wobbly cocktail mushroom	0		Last Available: "2017-03"
+9353	wobbly green cocktail mushroom	0		Last Available: "2017-03"
 9354	shot of granola liqueur	0		Last Available: "2017-03"
 9355	can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	lump of ichor	0		Last Available: "2017-03"
@@ -9231,52 +9231,52 @@
 9359	baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
-9362	skewed olive spinning pile of dirt	0		Last Available: "2017-03"
+9362	spinning skewed olive pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	hand-crafted teal literal grasshopper	4	EPIC	Last Available: "2017-03"
 9366	lousy double entendre	3	decent	Last Available: "2017-03"
-9367	acceptable fortified fancy Phlegethon	5	good	Effect: "Wintry Breath", Effect Duration: 40, Last Available: "2017-03"
+9367	fancy acceptable fortified Phlegethon	5	good	Effect: "Wintry Breath", Effect Duration: 40, Last Available: "2017-03"
 9368	lousy Siberian sunrise	4	decent	Last Available: "2017-03"
 9369	bad fuchsia mentholated wine	4	decent	Last Available: "2017-03"
-9370	mediocre practically non-alcoholic low tide martini	1	decent	Last Available: "2017-03"
+9370	practically non-alcoholic mediocre low tide martini	1	decent	Last Available: "2017-03"
 9371	lousy narrow shroomtini	3	decent	Last Available: "2017-03"
 9372	lousy morning dew	3	decent	Last Available: "2017-03"
-9373	mediocre fancy whiskey squeeze	3	decent	Effect: "Altered Wavelengths", Effect Duration: 15, Last Available: "2017-03"
+9373	fancy mediocre whiskey squeeze	3	decent	Effect: "Altered Wavelengths", Effect Duration: 15, Last Available: "2017-03"
 9374	delicious great fashioned	4	awesome	Last Available: "2017-03"
 9375	hand-crafted Gnomish sagngria	3	EPIC	Last Available: "2017-03"
 9376	mediocre practically non-alcoholic vodka stinger	1	decent	Last Available: "2017-03"
 9377	drinkable mirror extremely slippery nipple	3	good	Last Available: "2017-03"
 9378	weak hand-crafted piscatini	2	EPIC	Last Available: "2017-03"
 9379	special bad skewed Churchill	3	decent	Effect: "Buttermilk Boogie", Effect Duration: 35, Last Available: "2017-03"
-9380	watered-down bad soilzerac	2	decent	Last Available: "2017-03"
+9380	bad watered-down soilzerac	2	decent	Last Available: "2017-03"
 9381	lousy jittery London frog	3	decent	Last Available: "2017-03"
 9382	acceptable nothingtini	3	good	Last Available: "2017-03"
-9383	boozy mediocre eighth plague	5	decent	Last Available: "2017-03"
-9384	hand-crafted high-proof narrow single entendre	8	EPIC	Last Available: "2017-03"
+9383	mediocre boozy eighth plague	5	decent	Last Available: "2017-03"
+9384	high-proof hand-crafted narrow single entendre	8	EPIC	Last Available: "2017-03"
 9385	tolerable reverse Tantalus	4	good	Last Available: "2017-03"
-9386	boozy bad enchanted elemental caipiroska	5	decent	Effect: "Hombre Muerto Caminando", Effect Duration: 40, Last Available: "2017-03"
+9386	boozy enchanted bad elemental caipiroska	5	decent	Effect: "Hombre Muerto Caminando", Effect Duration: 40, Last Available: "2017-03"
 9387	practically non-alcoholic smooth skewed Feliz Navidad	1	awesome	Last Available: "2017-03"
 9388	tolerable weak Bloody Nora	2	good	Last Available: "2017-03"
 9389	smooth triple-distilled moreltini	8	awesome	Last Available: "2017-03"
 9390	drinkable hell in a bucket	4	good	Last Available: "2017-03"
-9391	smooth irresponsibly strong twirling Newark	7	awesome	Last Available: "2017-03"
+9391	irresponsibly strong smooth twirling Newark	7	awesome	Last Available: "2017-03"
 9392	hand-crafted narrow R'lyeh	3	EPIC	Last Available: "2017-03"
 9393	hand-crafted Gnollish sangria	3	EPIC	Last Available: "2017-03"
-9394	delicious practically non-alcoholic vodka barracuda	1	awesome	Last Available: "2017-03"
-9395	bad mirror narrow Mysterious Island iced tea	4	decent	Last Available: "2017-03"
+9394	practically non-alcoholic delicious vodka barracuda	1	awesome	Last Available: "2017-03"
+9395	bad narrow mirror Mysterious Island iced tea	4	decent	Last Available: "2017-03"
 9396	weak smooth twirling shaking drive-by shooting	2	awesome	Last Available: "2017-03"
 9397	aged watered-down gunner's daughter	2	awesome	Last Available: "2017-03"
-9398	weak tolerable dirt julep	2	good	Last Available: "2017-03"
+9398	tolerable weak dirt julep	2	good	Last Available: "2017-03"
 9399	mediocre Simepore slime	3	decent	Last Available: "2017-03"
-9400	triple-distilled aged Phil Collins	9	awesome	Last Available: "2017-03"
+9400	aged triple-distilled Phil Collins	9	awesome	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	pulsating toggle switch (Bartend)	0		Familiar Weight: +5
 9403	teal toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
-9404	shaking teal Spacegate access badge	0		Free Pull, Last Available: "2017-04"
+9404	teal shaking Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
-9407	spinning ghostly rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
+9407	ghostly spinning rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	shaking gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	blinking high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	skewed Spacegate Research	0		Last Available: "2017-04"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	spoiled tiny ghostly edible alien plant bit	1	crappy	Last Available: "2017-04"
+9415	tiny spoiled ghostly edible alien plant bit	1	crappy	Last Available: "2017-04"
 9416	maroon alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	altered flattened pulsating alien medicine	0		Effect: "I See Everything Thrice!", Effect Duration: 31, Last Available: "2017-04"
-9433	stale olive blurry alien salad	3	decent	Last Available: "2017-04"
+9433	stale blurry olive alien salad	3	decent	Last Available: "2017-04"
 9434	tolerable alien booze	3	good	Last Available: "2017-04"
 9435	deadly Newton's alien mask of the sewer	0		Experience (Mysticality): +3, Weapon Damage: +5, Stench Damage: +25, Last Available: "2017-04"
 9436	bouncing dance instructor's smooth alien spear of the wise owl	0		Mysticality: +20, Moxie: +15, Experience Percent (Moxie): +10, Last Available: "2017-04"
@@ -9323,7 +9323,7 @@
 9451	adjusted murderbot shield unit	0		Effect: "Hair on Your Chest", Effect Duration: 66, Last Available: "2017-04"
 9452	pulsating murderbot live wire	0		Last Available: "2017-04"
 9453	narrow crafty murderbot mask of the cheetah of the early riser	0		Maximum MP: +10, Initiative: +60, Adventures: +7, Avatar: "Murderbot", Last Available: "2017-04"
-9454	diffused boiled squat purple murderbot spring injector	0		Effect: "Cold Hard Skin", Effect Duration: 32, Last Available: "2017-04"
+9454	diffused boiled purple squat murderbot spring injector	0		Effect: "Cold Hard Skin", Effect Duration: 32, Last Available: "2017-04"
 9455	personal trainer's murderbot whip of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Last Available: "2017-04"
 9456	fuchsia personal trainer's murderbot plasma rifle of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	blue murderbot memory chip	0		Last Available: "2017-04"
@@ -9369,7 +9369,7 @@
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
-9500	purple bouncing gun	0		Free Pull, Last Available: "2017-06"
+9500	bouncing purple gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	upside-down Socratic plastic gundam of the pedagogue of Tarzan	0		Experience: +3, Experience (Muscle): +3, Experience (Mysticality): +1, Last Available: "2017-06"
 9503	blinking License to Chill	0		Last Available: "2017-07"
@@ -9384,11 +9384,11 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	fuchsia Meteorite-Ade	0		Last Available: "2017-08"
 9514	fancy rotten meteoreo	3	crappy	Effect: "Sinuses For Miles", Effect Duration: 10, Last Available: "2017-08"
-9515	bad weak meadeorite	2	decent	Last Available: "2017-08"
+9515	weak bad meadeorite	2	decent	Last Available: "2017-08"
 9516	cyan meteoroid	0		Last Available: "2017-08"
 9517	up-at-dawn sharpshooter's medical-grade meteortarboard	0		Critical Hit Percent: +10, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-08"
 9518	stanky fortified Sinatra's meteorite guard	0		Experience (Moxie): +5, Damage Absorption: +60, Stench Spell Damage: +25, Damage Reduction: 9, Last Available: "2017-08"
-9519	gravedigger's meteorb of incineration	0		Hot Spell Damage: +50, Spooky Damage: +10, Lantern Element: "Hot", Last Available: "2017-08"
+9519	gravedigger's meteorb of incineration	0		Hot Spell Damage: +50, Spooky Damage: +10, Last Available: "2017-08", Lantern Element: "Hot"
 9520	squat electrified asteroid belt of the storm	0		Maximum MP Percent: +40, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2017-08"
 9521	maroon Van der Graaf medical-grade hardened meteorthopedic shoes	0		Damage Reduction: 3, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-08"
 9522	perfumed hardened Newton's shooting morning star	0		Experience (Mysticality): +3, Damage Reduction: 3, Stench Resistance: +5, Single Equip, Last Available: "2017-08"
@@ -9418,12 +9418,12 @@
 9546	hardy wholesome mafia pinky ring	0		Maximum HP Percent: +10, Maximum HP: +50, Single Equip
 9547	delicious weak squat flask of port	2	awesome	
 9548	foul-smelling Oprah's contract enforcement stick	0		Maximum MP Percent: +50, Stench Damage: +10
-9549	rotten huge green Hide-rox&trade; cookie	4	crappy	Last Available: "2017-10"
+9549	rotten green huge Hide-rox&trade; cookie	4	crappy	Last Available: "2017-10"
 9550	drinkable lime green jug of booze	3	good	Last Available: "2017-10"
 9551	pressed liquefied pair of candy glasses	0		Effect: "Is This Your Card?", Effect Duration: 40, Last Available: "2017-10"
 9552	flattened wet temporary X tattoos	0		Effect: "Pisces Rising", Effect Duration: 56, Last Available: "2017-10"
 9553	pickled upside-down glyph of athleticism	1		Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2017-10"
-9554	tumbling bouncing mirror pair of scissors	0		Last Available: "2017-10"
+9554	mirror bouncing tumbling pair of scissors	0		Last Available: "2017-10"
 9555	unsweetened vacuum-sealed vacuum-sealed lime green new habit	0		Effect: "Mucilaginous Muscle", Effect Duration: 21, Last Available: "2017-10"
 9556	blurry bridge truss	0		Last Available: "2017-10"
 9557	tumbling nippy hardy wizardly pearl necklace	0		Mysticality: +25, Maximum HP: +50, Cold Damage: +10, Single Equip, Last Available: "2017-10"
@@ -9452,9 +9452,9 @@
 9580	non-alkaline unsweetened purple and cracker	0		Effect: "Clyde's Blessing", Effect Duration: 16, Last Available: "2017-12"
 9581	weak drinkable neg grog	2	good	Last Available: "2017-12"
 9582	tiny spoiled half double fruitcake	1	crappy	Last Available: "2017-12"
-9583	miniature toothsome hushed puppy	2	awesome	Last Available: "2017-12"
+9583	toothsome miniature hushed puppy	2	awesome	Last Available: "2017-12"
 9584	adequate twirling muffled muffuletta	4	good	Last Available: "2017-12"
-9585	super-sized yummy shushed potatoes	5	awesome	Last Available: "2017-12"
+9585	yummy super-sized shushed potatoes	5	awesome	Last Available: "2017-12"
 9586	prompt plastic mime functionary	0		Adventures: +3, Last Available: "2017-12"
 9587	perfumed plastic mime scientist	0		Stench Resistance: +5, Last Available: "2017-12"
 9588	strapping plastic mime soldier	0		Muscle: +5, Last Available: "2017-12"
@@ -9472,7 +9472,7 @@
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
 9602	silent D	0		Last Available: "2017-12"
-9603	squat twirling silent E	0		Last Available: "2017-12"
+9603	twirling squat silent E	0		Last Available: "2017-12"
 9604	twirling silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
 9606	silent H	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	mediocre stale cheer wine	3	decent	Last Available: "2017-12"
-9630	normal bite-sized stale Cheer-E-Os	1	good	Last Available: "2017-12"
+9630	bite-sized normal stale Cheer-E-Os	1	good	Last Available: "2017-12"
 9631	jittery cheer-o-gram	0		Last Available: "2017-12"
 9632	horrifying cheerful antler hat of the storm	0		Maximum MP Percent: +40, Spooky Damage: +25, Last Available: "2017-12"
 9633	scandalous cheerful Crimbo sweater of the businessman	0		Sleaze Damage: +5, Meat Drop: +50, Last Available: "2017-12"
@@ -9511,17 +9511,17 @@
 9639	gray blurry The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9642	teal spinning The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9642	spinning teal The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	squat The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	lousy practically non-alcoholic executive mime flask	1	decent	Last Available: "2017-12"
-9649	bland diet upside-down nega-mushroom	1	decent	Last Available: "2017-12"
+9648	practically non-alcoholic lousy executive mime flask	1	decent	Last Available: "2017-12"
+9649	diet bland upside-down nega-mushroom	1	decent	Last Available: "2017-12"
 9650	perfectly mixed extra-dry nega-mushroom wine	5	EPIC	Last Available: "2017-12"
 9651	corrupted vacuum-sealed twirling blurry Cheer-Up soda	0		Effect: "Mushroom Samba", Effect Duration: 55, Last Available: "2017-12"
-9652	enchanted bland massive mime army rations	9	decent	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2017-12"
+9652	enchanted massive bland mime army rations	9	decent	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2017-12"
 9653	watered-down artisanal huge mime army wine	2	super ultra mega turbo EPIC	Last Available: "2017-12"
 9654	powdered squat mime army superserum	1		Last Available: "2017-12"
 9655	pickled squat mime army camouflage kit	0		Effect: "Sugary World View", Effect Duration: 16, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	energized vacuum-sealed digital honeypot	0		Effect: "Pyramid Power", Effect Duration: 67, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	therapeutic mime army insignia (infantry)	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	bouncing manspreader's mime army insignia (intelligence)	0		Monster Level: +10, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	padded mime army insignia (espionage)	0		Damage Absorption: +20, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	therapeutic mime army insignia (infantry)	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	bouncing manspreader's mime army insignia (intelligence)	0		Monster Level: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	padded mime army insignia (espionage)	0		Damage Absorption: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9571,9 +9571,9 @@
 9699	tumbling double-paned strapping makeshift garbage shirt of the ox	0		Muscle: 25, Cold Resistance: +5, Last Available: "2018-01"
 9700	Jack Frost's novelty monorail ticket of the sweet-tooth	0		Cold Spell Damage: +50, Candy Drop: +100
 9701	vaporized pills	1		
-9702	modified tumbling squat furry pill	1		
+9702	modified squat tumbling furry pill	1		
 9703	altered wobbly beefy pill	1		Effect: "Celestial Vision", Effect Duration: 30
-9704	altered spinning pulsating excitement pill	1		Effect: "You Can Really Taste the Dormouse", Effect Duration: 20
+9704	altered pulsating spinning excitement pill	1		Effect: "You Can Really Taste the Dormouse", Effect Duration: 20
 9705	compressed jittery lime green vitamin G pill	1		
 9706	dehydrated lucky-ish pill	1		
 9707	dried olive shaking dieting pill	1		
@@ -9592,14 +9592,14 @@
 9724	hale grievous psychic's crystal ball	0		Weapon Damage Percent: +50, Maximum HP: +20, Last Available: "2018-02"
 9725	psychic's pslacks of mayonnaise of Flo-Jo	0		Sleaze Spell Damage: +50, Initiative: +100, Last Available: "2018-02"
 9726	spinning bouncing maroon nippy quilted psychic's amulet	0		Damage Absorption: +40, Cold Damage: +10, Last Available: "2018-02"
-9727	spoiled small spinning heart-shaped candy whetstone	2	crappy	Last Available: "2018-02"
+9727	small spoiled spinning heart-shaped candy whetstone	2	crappy	Last Available: "2018-02"
 9728	adequate Swedish massage fish	3	good	Last Available: "2018-02"
 9729	tolerable jittery Third Base	3	good	Last Available: "2018-02"
 9730	mediocre Bustle Hustler	4	decent	Last Available: "2018-02"
 9731	unsweetened Fabiotion	0		Effect: "Chilblains of the Corn", Effect Duration: 13, Last Available: "2018-02"
-9732	cold-filtered nitrogenated triple-aerosolized squat huge mirror Bettie page	0		Effect: "Broberry Brotality", Effect Duration: 52, Last Available: "2018-02"
+9732	cold-filtered nitrogenated triple-aerosolized mirror huge squat Bettie page	0		Effect: "Broberry Brotality", Effect Duration: 52, Last Available: "2018-02"
 9733	alkaline non-nitrogenated extra-deionized purple tonic o' Banderas	0		Effect: "Elron's Explosive Etude", Effect Duration: 45, Last Available: "2018-02"
-9734	frozen teal huge heather graham cracker	0		Effect: "Squid Squint", Effect Duration: 36, Last Available: "2018-02"
+9734	frozen huge teal heather graham cracker	0		Effect: "Squid Squint", Effect Duration: 36, Last Available: "2018-02"
 9735	huge Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
@@ -9612,7 +9612,7 @@
 9744	vacuum-sealed lime green mystery lollipop	0		Effect: "Alpine Mintiness", Effect Duration: 63
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	altered wobbly rhinestone	0		Effect: "Heavily Breathing", Effect Duration: 58
-9747	narrow mirror 1,960 pok&eacute;dollar bill	0		
+9747	mirror narrow 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	riboflavin	0		
 9750	ghostly bronze	0		
@@ -9653,7 +9653,7 @@
 9785	Straypler	0		Last Available: "2018-03"
 9786	teal Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
-9788	jittery shaking huge Ched	0		Last Available: "2018-03"
+9788	huge jittery shaking Ched	0		Last Available: "2018-03"
 9789	twirling Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
@@ -9675,7 +9675,7 @@
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	skewed Stooper	0		Last Available: "2018-03"
 9809	squat Disgeist	0		Last Available: "2018-03"
-9810	upside-down squat yellow Bowlet	0		Last Available: "2018-03"
+9810	squat yellow upside-down Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	upside-down Mu	0		Last Available: "2018-03"
 9813	huge Glum berry	0		Last Available: "2018-03"
@@ -9725,7 +9725,7 @@
 9857	flattened universal antivenin	0		Lasts Until Rollover, Effect: "Some Cheese with Your Wine", Effect Duration: 58, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	ghostly LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9860	blinking bouncing FantasyRealm tattoo kit	0		Last Available: "2018-04"
+9860	bouncing blinking FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	stale FantasyRealm turkey leg	4	decent	Last Available: "2018-04"
 9863	artisanal watered-down FantasyRealm mead	2	EPIC	Last Available: "2018-04"
@@ -9735,7 +9735,7 @@
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	bouncing grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	super-sized spoiled druidic s'more	5	crappy	Last Available: "2018-04"
-9870	distilled blurry ghostly sachet of powder	1		Last Available: "2018-04"
+9870	distilled ghostly blurry sachet of powder	1		Last Available: "2018-04"
 9871	drinkable purple mourning wine	3	good	Last Available: "2018-04"
 9872	skewed sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9767,12 +9767,12 @@
 9899	rotten massive chocolate Ogre Chieftain	10	crappy	
 9900	small rotten chocolate &quot;Phoenix&quot;	2	crappy	
 9901	rotten massive chocolate Spider Queen	8	crappy	
-9902	lousy irresponsibly strong hipster cocktail	7	decent	
-9903	squat green God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	olive God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	blinking God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9902	irresponsibly strong lousy hipster cocktail	7	decent	
+9903	green squat God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	olive God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	blinking God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9781,14 +9781,14 @@
 9913	mirror glued A-Boo clue	0		
 9914	mirror crude oil congealer	0		
 9915	moldy good guava	3	crappy	
-9916	fortified fancy bad gin and ginger	5	decent	Effect: "Discomfited", Effect Duration: 35
+9916	fancy fortified bad gin and ginger	5	decent	Effect: "Discomfited", Effect Duration: 35
 9917	Thwaitgold chigger statuette	0		
-9918	dried yellow tumbling gaseous gravy	1		
+9918	dried tumbling yellow gaseous gravy	1		
 9919	fuchsia bouncing SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	blurry A Guide to Safari	0		Skill: "Experience Safari"
-9922	quadruple-anodized concentrated upside-down huge Shielding Potion	0		Effect: "Twinkly Weapon", Effect Duration: 49, Last Available: "2018-06"
-9923	anodized yellow ghostly blurry Punching Potion	0		Effect: "Ponderous Potency", Effect Duration: 34, Last Available: "2018-06"
+9922	quadruple-anodized concentrated huge upside-down Shielding Potion	0		Effect: "Twinkly Weapon", Effect Duration: 49, Last Available: "2018-06"
+9923	anodized blurry ghostly yellow Punching Potion	0		Effect: "Ponderous Potency", Effect Duration: 34, Last Available: "2018-06"
 9924	bouncing Special Seasoning	0		Last Available: "2018-06"
 9925	modified Nightmare Fuel	1		Effect: "Ponderous Potency", Effect Duration: 5, Last Available: "2018-06"
 9926	shaking teal Gathered Meat-Clip	0		Last Available: "2020-09"
@@ -9812,13 +9812,13 @@
 9944	scorching toasty PARTY HARD T-shirt of the empath	0		Familiar Weight: +5, Hot Damage: 30, Last Available: "2018-09"
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
-9947	wobbly jittery gas can	0		Last Available: "2018-09"
+9947	jittery wobbly gas can	0		Last Available: "2018-09"
 9948	drinkable Middle of the Road&trade; brand whiskey	3	good	Last Available: "2018-09"
 9949	shaking neverending wallet chain	0		Last Available: "2018-09"
 9950	avaricious nasty pentagram bandana	0		Stench Damage: +5, Meat Drop: +30, Last Available: "2018-09"
 9951	skewed lard-coated skull ring	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	enchanted spoiled jumbo mirror PB&J with the crusts cut off	5	crappy	Effect: "Squirming Like a Toad", Effect Duration: 40, Last Available: "2018-09"
+9953	enchanted jumbo spoiled mirror PB&J with the crusts cut off	5	crappy	Effect: "Squirming Like a Toad", Effect Duration: 40, Last Available: "2018-09"
 9954	weightlifter's dorky glasses of the storm	0		Muscle: +15, Maximum MP Percent: +40, Single Equip, Last Available: "2018-09"
 9955	sharpshooter's cool ponytail clip	0		Moxie: +5, Critical Hit Percent: +10, Last Available: "2018-09"
 9956	asbestos-lined paint palette	0		Hot Resistance: +5, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
@@ -9843,12 +9843,12 @@
 9976	deadly dance instructor's party pants	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Last Available: "2018-09"
 9977	narrow reassuring Temple Grandin's party whip of the ox	0		Muscle: +20, Familiar Weight: +7, Spooky Resistance: +1, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	aged weak special TRIO cup of beer	2	awesome	Effect: "Resilient Spirit", Effect Duration: 30, Last Available: "2018-09"
-9980	adequate small party platter for one	2	good	Last Available: "2018-09"
+9979	weak aged special TRIO cup of beer	2	awesome	Effect: "Resilient Spirit", Effect Duration: 30, Last Available: "2018-09"
+9980	small adequate party platter for one	2	good	Last Available: "2018-09"
 9981	powdered tumbling Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	Fonzie's strapping party crasher	0		Muscle: +5, Experience (Moxie): +1, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	purple Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9984	purple Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	twirling Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	blue party mouse hat	0		Familiar Weight: +5
 9987	fuchsia latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9873,19 +9873,19 @@
 10007	friendly wicked mutant arm of wisdom	0		Mysticality: +15, Spell Damage: +5, Familiar Weight: +3, Last Available: "2018-11"
 10008	auspicious mutant legs of doom of temperance	0		Spooky Spell Damage: +50, Sleaze Resistance: +5, Item Drop: +10, Last Available: "2018-11"
 10009	horrifying stylish mutant crown of incineration	0		Moxie: +25, Hot Spell Damage: +50, Spooky Damage: +25, Last Available: "2018-11"
-10010	spoiled snack-sized ghostly ectoplasm	2	crappy	Last Available: "2018-11"
-10011	miniature spoiled	2	crappy	Last Available: "2018-11"
+10010	snack-sized spoiled ghostly ectoplasm	2	crappy	Last Available: "2018-11"
+10011	spoiled miniature	2	crappy	Last Available: "2018-11"
 10012	drinkable spinning bottle of vodka	4	good	Last Available: "2018-11"
 10013	small normal bouncing pizza	2	good	Last Available: "2018-11"
 10014	artisanal martini	4	EPIC	Last Available: "2018-11"
-10015	yummy jumbo cherry pie	5	awesome	Last Available: "2018-11"
+10015	jumbo yummy cherry pie	5	awesome	Last Available: "2018-11"
 10016	hand-crafted spirit-forward spinning eggnog	5	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	stale miniature Hell ramen	2	decent	Last Available: "2018-11"
 10019	lousy huge gimlet	3	decent	Last Available: "2018-11"
 10020	practically non-alcoholic acceptable blurry twice-haunted screwdriver	1	good	Last Available: "2018-11"
 10021	bland candy cane	3	decent	Last Available: "2018-12"
-10022	mediocre high-proof fancy green runny fermented egg	10	decent	Effect: "Stickler for Promptness", Effect Duration: 50, Last Available: "2018-12"
+10022	high-proof mediocre fancy green runny fermented egg	10	decent	Effect: "Stickler for Promptness", Effect Duration: 50, Last Available: "2018-12"
 10023	huge flavorless narrow oldcake	10	decent	Last Available: "2018-12"
 10024	adequate shaking traditional Crimbo cookie	3	good	Last Available: "2023-06"
 10025	clever plastic wild beaver	0		Maximum MP: +20, Last Available: "2018-12"
@@ -9906,7 +9906,7 @@
 10040	flavorless moosemeat pie	3	decent	Last Available: "2018-12"
 10041	maroon balanced antler of the ox	0		Muscle: +20, Last Available: "2018-12"
 10042	yellow dam of courage	0		Spooky Resistance: +3, Damage Reduction: 9, Last Available: "2018-12"
-10043	perfectly mixed olive shaking beavermouth	4	EPIC	Last Available: "2018-12"
+10043	perfectly mixed shaking olive beavermouth	4	EPIC	Last Available: "2018-12"
 10044	special acceptable beaver punch (papaya)	3	good	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 30, Last Available: "2018-12"
 10045	tolerable tumbling beaver punch (peach)	4	good	Last Available: "2018-12"
 10046	aged pulsating beaver punch (cherry)	3	awesome	Last Available: "2018-12"
@@ -9927,13 +9927,13 @@
 10061	lion tamer's beefcake's red-hot sausage fork	0		Muscle: +25, Experience (familiar): +2, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
-10064	upside-down jittery jar of relish	0		Familiar Weight: +5
+10064	jittery upside-down jar of relish	0		Familiar Weight: +5
 10065	fuchsia Toyleporter	0		Last Available: "2018-12"
-10066	watered-down delicious squat tumbling beer	2	awesome	Last Available: "2018-12"
+10066	delicious watered-down tumbling squat beer	2	awesome	Last Available: "2018-12"
 10067	moldy squat yule gruel	3	crappy	Last Available: "2018-12"
 10068	smooth weak hot watered rum	2	awesome	Last Available: "2018-12"
-10069	high-proof tolerable bottle of Crimbognac	7	good	Last Available: "2018-12"
-10070	tiny rotten Crimboysters Rockefeller	1	crappy	Last Available: "2018-12"
+10069	tolerable high-proof bottle of Crimbognac	7	good	Last Available: "2018-12"
+10070	rotten tiny Crimboysters Rockefeller	1	crappy	Last Available: "2018-12"
 10071	dried Crimbeau de toilette	1		Effect: "No Vertigo", Effect Duration: 50, Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9951,7 +9951,7 @@
 10085	manspreader's shellacked chalk chinos	0		Damage Reduction: 7, Monster Level: +10, Last Available: "2019-12"
 10086	Oprah's chalk chapeau of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Last Available: "2019-12"
 10087	Newton's chalk choker of the dark arts	0		Experience (Mysticality): +3, Spell Damage Percent: +100, Single Equip, Last Available: "2019-12"
-10088	compressed squat spinning chalk chunks	1		Effect: "Inscrutable exoskeleton", Effect Duration: 50, Last Available: "2019-12"
+10088	compressed spinning squat chalk chunks	1		Effect: "Inscrutable exoskeleton", Effect Duration: 50, Last Available: "2019-12"
 10089	frozen flattened candy chalk	0		Effect: "Salty Mouth", Effect Duration: 67
 10090	stanky marble maebari of incineration	0		Hot Spell Damage: +50, Stench Spell Damage: +25, Last Available: "2019-12"
 10091	double-paned Fonzie's marble mantle	0		Experience (Moxie): +1, Cold Resistance: +5, Last Available: "2019-12"
@@ -9983,7 +9983,7 @@
 10117	lightning-fast Van der Graaf velour viscometer	0		Initiative: +40, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2021-12"
 10118	upside-down studded beefy velour valise	0		Muscle: +10, Damage Absorption: +80, Last Available: "2021-12"
 10119	foul-smelling energetic velour vaqueros	0		Maximum MP Percent: +20, Stench Damage: +10, Last Available: "2021-12"
-10120	altered tumbling upside-down velour veneer	1		Last Available: "2021-12"
+10120	altered upside-down tumbling velour veneer	1		Last Available: "2021-12"
 10121	flattened modified Velougats&trade;	0		Effect: "Innately Strong", Effect Duration: 69
 10122	cyan dance instructor's smartaleck's glass suspenders	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Single Equip, Last Available: "2021-12"
 10123	scandalous careful glass shield	0		Monster Level: -10, Sleaze Damage: +5, Damage Reduction: 7, Last Available: "2021-12"
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	shellacked elf army poncho	0		Damage Reduction: 7, Lasts Until Rollover, Last Available: "2019-12"
-10155	adequate immense elf army field rations	8	good	Last Available: "2019-12"
+10155	immense adequate elf army field rations	8	good	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	ghostly dog trainer's friendly discarded bowtie	0		Familiar Weight: +3, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2019-12"
 10158	enchanted drinkable squat red martiny	3	good	Effect: "Dreadful Heat", Effect Duration: 25, Last Available: "2019-12"
@@ -10034,14 +10034,14 @@
 10169	half-sized flavorless shaking bloodstick	2	decent	
 10170	weak mediocre ghostly bottle of Sanguiovese	2	decent	
 10171	adequate actual blood sausage	3	good	
-10172	fancy watered-down mediocre mulled blood	2	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5
-10173	adequate small blood snowcone	2	good	
+10172	mediocre fancy watered-down mulled blood	2	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5
+10173	small adequate blood snowcone	2	good	
 10174	bad Red Russian	3	decent	
 10175	normal upside-down blood roll-up	4	good	
 10176	acceptable bottle of blood	3	good	
 10177	stale yellow spinning blood-soaked sponge cake	3	decent	
-10178	weak lousy vampagne	2	decent	
-10179	half-sized special decent plain snowcone	2	good	Effect: "Jacked In", Effect Duration: 25
+10178	lousy weak vampagne	2	decent	
+10179	decent special half-sized plain snowcone	2	good	Effect: "Jacked In", Effect Duration: 25
 10180	fuchsia Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	skewed maroon money bag	0		
@@ -10061,11 +10061,11 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	thick delicious crabsicle	5	awesome	Last Available: "2019-04"
+10199	delicious thick crabsicle	5	awesome	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	acceptable bottle of dark rhum	4	good	Last Available: "2019-04"
 10202	drinkable bottle of extra-dark rhum	3	good	Last Available: "2019-04"
-10203	acceptable irresponsibly strong bottle of super-extra-dark rhum	6	good	Last Available: "2019-04"
+10203	irresponsibly strong acceptable bottle of super-extra-dark rhum	6	good	Last Available: "2019-04"
 10204	aerosolized bouncing pirate shaving cream	0		Effect: "Wintergreen Warmongery", Effect Duration: 34, Last Available: "2019-04"
 10205	yellow Annie Oakley's conquistador's breastplate of Gandalf	0		Critical Hit Percent: +20, Spell Critical Percent: +20, Last Available: "2019-04"
 10206	razor-sharp stylish pirate pantaloons	0		Moxie: +25, Weapon Damage Percent: +25, Last Available: "2019-04"
@@ -10075,7 +10075,7 @@
 10210	wholesome pirate radio ring of the sewer	0		Maximum HP Percent: +10, Stench Damage: +25, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	bland pineapple slab	3	decent	Last Available: "2019-04"
-10213	spoiled gigantic hibiscus petal	8	crappy	Last Available: "2019-04"
+10213	gigantic spoiled hibiscus petal	8	crappy	Last Available: "2019-04"
 10214	super-ionized liquefied huge mint leaf	0		Effect: "Aided and Abetted", Effect Duration: 13, Last Available: "2019-04"
 10215	gray cocoa of youth	0		Last Available: "2019-04"
 10216	pickled jittery ice molecule	1		Last Available: "2019-04"
@@ -10095,7 +10095,7 @@
 10230	Herculean piratical blunderbuss of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Last Available: "2019-04"
 10231	lime green chaotic Sinatra's PirateRealm party hat of the blizzard	0		Experience (Moxie): +5, Spell Critical Percent: +10, Cold Spell Damage: +25, Last Available: "2019-04"
 10232	drinkable pulsating Island Landslide	3	good	Last Available: "2019-04"
-10233	drinkable triple-distilled Island Thunderstorm	7	good	Last Available: "2019-04"
+10233	triple-distilled drinkable Island Thunderstorm	7	good	Last Available: "2019-04"
 10234	smooth Island Hurricane	3	awesome	Last Available: "2019-04"
 10235	spirit-forward bad Skull Punch	5	decent	Last Available: "2019-04"
 10236	watered-down drinkable Electric Punch	2	good	Last Available: "2019-04"
@@ -10134,8 +10134,8 @@
 10269	warmed frozen jittery green seashell	0		Effect: "Jerky, Boy", Effect Duration: 65, Last Available: "2019-07"
 10270	Vulcanized dry seashell	0		Effect: "Greasy Flavor", Effect Duration: 33, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	acceptable fancy tumbling bottle of sea wine	4	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 20, Last Available: "2019-07"
-10273	vaporized shaking squat kelp	1		Last Available: "2019-07"
+10272	fancy acceptable tumbling bottle of sea wine	4	good	Effect: "Mucilaginous Moxiousness", Effect Duration: 20, Last Available: "2019-07"
+10273	vaporized squat shaking kelp	1		Last Available: "2019-07"
 10274	Sherlock's lion tamer's ruddy stylish slick cool brainy driftwood hat of Leguizamo of the businessman	0		Mysticality: +5, Moxie: 40, Maximum HP Percent: +40, Monster Level: +20, Experience (familiar): +2, Item Drop: +25, Meat Drop: +50, Lasts Until Rollover, Last Available: "2019-07"
 10275	skewed nasty Temple Grandin's rosy-cheeked hardened dance instructor's cool thinker's driftwood pants of dire peril of temperance	0		Mysticality: +10, Moxie: +5, Experience Percent (Moxie): +10, Weapon Damage: +20, Damage Reduction: 3, Maximum HP Percent: +30, Familiar Weight: +7, Stench Damage: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2019-07"
 10276	pulsating family-friendly frosty Temple Grandin's Van der Graaf steel-toed shellacked extremely unsafe dangerous boxer's driftwood bracelet	0		Muscle Percent: +10, Weapon Damage: +10, Weapon Damage Percent: +100, Damage Reduction: 32, Familiar Weight: +7, Cold Spell Damage: +10, Sleaze Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10165,15 +10165,15 @@
 10300	Tesla hardy hardened whittled owl figurine	0		Damage Reduction: 3, Maximum HP: +50, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-08"
 10301	skewed avaricious nasty Newton's whittled fox figurine	0		Experience (Mysticality): +3, Stench Damage: +5, Meat Drop: +30, Single Equip, Last Available: "2019-08"
 10302	green lion tamer's electrified experienced whittled walking stick of the wise owl	0		Mysticality: +20, Experience: +2, Experience (familiar): +2, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-08"
-10303	normal immense mirror campfire hot dog	9	good	Last Available: "2019-08"
-10304	thick yummy campfire baked potato	5	awesome	Last Available: "2019-08"
+10303	immense normal mirror campfire hot dog	9	good	Last Available: "2019-08"
+10304	yummy thick campfire baked potato	5	awesome	Last Available: "2019-08"
 10305	bite-sized moldy upside-down campfire s'more	1	crappy	Last Available: "2019-08"
 10306	stale squat campfire beans	3	decent	Last Available: "2019-08"
 10307	yummy campfire stew	3	awesome	Last Available: "2019-08"
 10308	special campfire coffee	1	decent	Effect: "Wasabi With You", Effect Duration: 25, Last Available: "2019-08"
 10309	liquefied bouncing leftover chocolate bar	0		Effect: "Pyromania", Effect Duration: 66
-10310	wobbly shaking rare Meat isotope	0		
-10311	mirror lime green burnt stick	0		Last Available: "2019-08"
+10310	shaking wobbly rare Meat isotope	0		
+10311	lime green mirror burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
 10313	campfire smoke	0		
 10314	Murgatroyd diode	0		
@@ -10183,7 +10183,7 @@
 10318	blinking low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	decent space chowder	3	good	
-10321	bad high-proof teal space wine	7	decent	
+10321	high-proof bad teal space wine	7	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10194,8 +10194,8 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	yummy twirling bu&ntilde;uelos Jaliscos	4	awesome	Last Available: "2019-12"
-10338	decent small flan del mar	2	good	Last Available: "2019-12"
-10339	flavorless half-sized Baja sopapilla	2	decent	Last Available: "2019-12"
+10338	small decent flan del mar	2	good	Last Available: "2019-12"
+10339	half-sized flavorless Baja sopapilla	2	decent	Last Available: "2019-12"
 10340	plastic Mer-kin baker of the pedagogue	0		Experience: +3, Last Available: "2019-12"
 10341	plastic sea elf of the bloodbag	0		Maximum HP: +100, Last Available: "2019-12"
 10342	spinning beefcake's plastic yuleviathan	0		Muscle: +25, Last Available: "2019-12"
@@ -10204,8 +10204,8 @@
 10345	blinking red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	low-calorie moldy mana-coated yams	1	crappy	Last Available: "2019-11"
 10347	spoiled jumbo teal mana-basted tofurkey leg	5	crappy	Last Available: "2019-11"
-10348	yummy thick mana-fortified cranberry sauce	5	awesome	Last Available: "2019-11"
-10349	enchanted immense moldy mirror mana-stuffed herbal stuffing	9	crappy	Effect: "Experimental Effect G-9", Effect Duration: 10, Last Available: "2019-11"
+10348	thick yummy mana-fortified cranberry sauce	5	awesome	Last Available: "2019-11"
+10349	immense enchanted moldy mirror mana-stuffed herbal stuffing	9	crappy	Effect: "Experimental Effect G-9", Effect Duration: 10, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	vacuum-sealed non-pressed flattened blue patch of extra-warm fur	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 58, Last Available: "2019-12"
 10352	twisted wobbly skewed industrial lubricant	1		Effect: "Devil Inside", Effect Duration: 5, Last Available: "2019-12"
@@ -10255,7 +10255,7 @@
 10396	wobbly tinsel fin	0		Familiar Weight: +5
 10397	adequate bowl of mernudo	3	good	Last Available: "2019-12"
 10398	tolerable tumbling fishelada	3	good	Last Available: "2019-12"
-10399	spoiled low-calorie fuchsia ojo de pez burrito	1	crappy	Last Available: "2019-12"
+10399	low-calorie spoiled fuchsia ojo de pez burrito	1	crappy	Last Available: "2019-12"
 10400	blinking waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	shaking waterlogged stuffing	0		Last Available: "2019-12"
@@ -10281,8 +10281,8 @@
 10422	red hardy rock-hard Crimbylow-rise jeans	0		Damage Reduction: 5, Maximum HP: +50, Last Available: "2019-12"
 10423	deadly kelp-holly drape of doom	0		Weapon Damage: +5, Spooky Spell Damage: +50, Last Available: "2019-12"
 10424	executive flame-wreathed banded smartaleck's Staff of the Peppermint Twist	0		Moxie Percent: +30, Damage Absorption: +100, Hot Spell Damage: +10, Meat Drop: +40, Last Available: "2019-12"
-10425	delicious half-sized tempura and bean	2	awesome	Last Available: "2019-12"
-10426	practically non-alcoholic mediocre narrow salt plum sake	1	decent	Last Available: "2019-12"
+10425	half-sized delicious tempura and bean	2	awesome	Last Available: "2019-12"
+10426	mediocre practically non-alcoholic narrow salt plum sake	1	decent	Last Available: "2019-12"
 10427	colloidal pressurized potion of possessiveness	0		Effect: "Icy Composition", Effect Duration: 59, Last Available: "2019-12"
 10428	unsweetened tarnished galvanized almond	0		Effect: "Hopped Up on Goofballs", Effect Duration: 50
 10429	adjusted handful of mixed nuts	0		Effect: "Boletus Swoletus", Effect Duration: 68, Last Available: "2019-12"
@@ -10299,7 +10299,7 @@
 10442	drippy truncheon of the blizzard	0		Cold Spell Damage: +25, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
-10445	miniature stale fuchsia drippy nugget	2	drippy	
+10445	stale miniature fuchsia drippy nugget	2	drippy	
 10446	perfectly mixed spinning glass of drippy wine	3	drippy	
 10447	flavorless snack-sized bouncing drippy caviar	2	drippy	
 10448	rotten drippy plum(?)	4	drippy	
@@ -10395,8 +10395,8 @@
 10539	twirling family-friendly Guzzlr souvenir stein	0		Sleaze Resistance: +1, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	enchanted perfectly mixed Ghiaccio Colada	4	EPIC	Effect: "Dweeby", Effect Duration: 15, Last Available: "2020-05"
-10542	acceptable weak twirling Sourfinger	2	good	Last Available: "2020-05"
-10543	weak perfectly mixed Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
+10542	weak acceptable twirling Sourfinger	2	good	Last Available: "2020-05"
+10543	perfectly mixed weak Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
 10544	artisanal narrow Steamboat	4	EPIC	Last Available: "2020-05"
 10545	aged Buttery Boy	4	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10425,7 +10425,7 @@
 10569	Van der Graaf experienced discarded bike lock key	0		Experience: +2, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-08"
 10570	twirling Thwaitgold keyhole spider statuette	0		
 10571	wobbly Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	aerosolized narrow spinning marshroom	0		Effect: "Crotchety, Pining", Effect Duration: 51
+10572	aerosolized spinning narrow marshroom	0		Effect: "Crotchety, Pining", Effect Duration: 51
 10573	bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
@@ -10447,7 +10447,7 @@
 10591	sweaty balsam	0		Last Available: "2020-08"
 10592	skewed upside-down padded boxer's balsam barrel of the glutton	0		Muscle Percent: +10, Damage Absorption: +20, Food Drop: +100, Last Available: "2020-08"
 10593	redwood	0		Last Available: "2020-08"
-10594	super-vacuum-sealed denatured cyan upside-down redwood rain stick	0		Effect: "Natural 20", Effect Duration: 49, Last Available: "2020-08"
+10594	super-vacuum-sealed denatured upside-down cyan redwood rain stick	0		Effect: "Natural 20", Effect Duration: 49, Last Available: "2020-08"
 10595	purpleheart logs	0		Last Available: "2020-08"
 10596	Fonzie's smartaleck's purpleheart &quot;pants&quot; of the brazier	0		Moxie Percent: +30, Experience (Moxie): +1, Hot Spell Damage: +25, Last Available: "2020-08"
 10597	wormwood stick	0		Last Available: "2020-08"
@@ -10475,7 +10475,7 @@
 10619	blurry uncanny desk bell	0		Last Available: "2020-09"
 10620	nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
-10622	purple blurry chess set	0		Last Available: "2020-09"
+10622	blurry purple chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	sizzling energetic baleful smooth Cargo Cultist Shorts	0		Moxie: +15, Spell Damage: +25, Maximum MP Percent: +20, Hot Damage: +10, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	acceptable watered-down flask of moonshine	2	good	Last Available: "2020-09"
+10638	watered-down acceptable flask of moonshine	2	good	Last Available: "2020-09"
 10639	Jack Frost's hardy sea-worn candlestick of Tarzan	0		Experience (Muscle): +3, Maximum HP: +50, Cold Spell Damage: +50, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	deionized corrupted olive null-day exploit	0		Effect: "Sweet Incentive", Effect Duration: 52, Last Available: "2025-12"
@@ -10502,7 +10502,7 @@
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
-10649	tumbling ghostly gregarious ghostling	0		Free Pull, Last Available: "2020-12"
+10649	ghostly tumbling gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	upside-down greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
@@ -10563,31 +10563,31 @@
 10707	The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
-10710	fuchsia mirror The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10710	mirror fuchsia The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	thick toothsome and pepper (stale)	5	awesome	Last Available: "2020-12"
-10716	watered-down tolerable upside-down cranberry margarita (brackish)	2	good	Last Available: "2020-12"
+10716	tolerable watered-down upside-down cranberry margarita (brackish)	2	good	Last Available: "2020-12"
 10717	shaking fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	yellow goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	bad weak barrel-aged eggnog	2	decent	Last Available: "2020-12"
+10720	weak bad barrel-aged eggnog	2	decent	Last Available: "2020-12"
 10721	stale hand-crafted candy cane	4	decent	Last Available: "2020-12"
 10722	moldy drive-thru burger	4	crappy	Last Available: "2020-12"
-10723	watered-down acceptable Boulevardier cocktail	2	good	Last Available: "2020-12"
+10723	acceptable watered-down Boulevardier cocktail	2	good	Last Available: "2020-12"
 10724	anodized skewed shaking Hotwire&trade; brand candy rope	0		Effect: "Nigh-Invincible", Effect Duration: 37, Last Available: "2020-12"
-10725	big decent teal bowl full of jelly	5	good	Last Available: "2020-12"
+10725	decent big teal bowl full of jelly	5	good	Last Available: "2020-12"
 10726	smooth pulsating Eye and a Twist	4	awesome	Last Available: "2020-12"
 10727	non-cold-filtered Chubby and Plump bar	0		Effect: "It Didn't Kill You", Effect Duration: 32, Last Available: "2020-12"
 10728	blurry digibritches	0		Last Available: "2025-12"
-10729	upside-down gray packaged crystal ball	0		Free Pull, Last Available: "2021-01"
+10729	gray upside-down packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	ghostly fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	ghostly fuchsia emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	shaking spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	ghostly fuchsia emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	shaking spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	shaking robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	purple power seed	0		Free Pull, Last Available: "2021-03"
@@ -10639,7 +10639,7 @@
 10783	jittery extra-wide head candle of dire peril of the overflowing toilet	0		Weapon Damage: +20, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
 10784	alkaline natural magick candle	0		Effect: "Crimbo Flavor", Effect Duration: 41, Last Available: "2021-08"
 10785	colloidal rainbow glitter candle	0		Effect: "Elemental Flavor", Effect Duration: 36, Last Available: "2021-08"
-10786	electrified dry yellow huge banana candle	0		Effect: "Action", Effect Duration: 30, Last Available: "2021-08"
+10786	electrified dry huge yellow banana candle	0		Effect: "Action", Effect Duration: 30, Last Available: "2021-08"
 10787	pickled galvanized enhanced ear candle	0		Effect: "Eyes Wide Propped", Effect Duration: 57, Last Available: "2021-08"
 10788	aerosolized modified jittery votive of confidence	0		Effect: "Radiant Personality", Effect Duration: 23, Last Available: "2021-08"
 10789	spinning Da Vinci's water candle	0		Experience (Mysticality): +5, Water: 3, Lasts Until Rollover
@@ -10675,13 +10675,13 @@
 10819	moldy jittery tofu pop	4	crappy	Last Available: "2021-12"
 10820	spoiled pulsating bowl of prescription candy	4	crappy	Last Available: "2021-12"
 10821	bland fishcake	3	decent	Last Available: "2021-12"
-10822	flavorless bite-sized skewed bone broth	1	decent	Last Available: "2021-12"
+10822	bite-sized flavorless skewed bone broth	1	decent	Last Available: "2021-12"
 10823	adequate star pop	3	good	Last Available: "2021-12"
-10824	aged watered-down tumbling Doc's Fortifying Wine	2	awesome	Last Available: "2021-12"
+10824	watered-down aged tumbling Doc's Fortifying Wine	2	awesome	Last Available: "2021-12"
 10825	artisanal Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
-10826	drinkable special extra-dry Doc's Limbering Wine	5	good	Effect: "Scavengers Scavenging", Effect Duration: 30, Last Available: "2021-12"
+10826	drinkable extra-dry special Doc's Limbering Wine	5	good	Effect: "Scavengers Scavenging", Effect Duration: 30, Last Available: "2021-12"
 10827	perfectly mixed practically non-alcoholic bouncing Doc's Medical-Grade Wine	1	EPIC	Last Available: "2021-12"
-10828	mixed mirror squat Homebodyl&trade;	1		Last Available: "2021-12"
+10828	mixed squat mirror Homebodyl&trade;	1		Last Available: "2021-12"
 10829	powdered Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	distilled upside-down Breathitin&trade;	1		Last Available: "2021-12"
 10831	dehydrated teal Fleshazole&trade;	1		Last Available: "2021-12"
@@ -10706,7 +10706,7 @@
 10850	mirror goo magnet	0		Last Available: "2021-12"
 10851	twirling prompt cozy scarf	0		Adventures: +3, Last Available: "2021-12"
 10852	decent huge Crimbo cookie	4	good	Last Available: "2023-06"
-10853	triple-irradiated skewed twirling fleshy putty	0		Effect: "Boilermade", Effect Duration: 29, Last Available: "2021-12"
+10853	triple-irradiated twirling skewed fleshy putty	0		Effect: "Boilermade", Effect Duration: 29, Last Available: "2021-12"
 10854	teal quilted third ear	0		Damage Absorption: +40, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
@@ -10721,7 +10721,7 @@
 10865	blurry universal biscuit	0		Last Available: "2021-12"
 10866	Sinatra's yule hatchet	0		Experience (Moxie): +5, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
-10868	fancy spoiled small lab-grown meat	2	crappy	Effect: "Outer Wolf&trade;", Effect Duration: 50, Last Available: "2021-12"
+10868	small fancy spoiled lab-grown meat	2	crappy	Effect: "Outer Wolf&trade;", Effect Duration: 50, Last Available: "2021-12"
 10869	huge fleece of James Dean	0		Experience (Moxie): +3, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	cloning kit	0		Last Available: "2021-12"
@@ -10755,7 +10755,7 @@
 10899	chilly quilted baleful brawny unbreakable umbrella (broken)	0		Muscle Percent: +20, Spell Damage: +25, Damage Absorption: +40, Cold Damage: +5
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
 10901	spinning MayDay&trade; supply package	0		Last Available: "2022-05"
-10902	activated concentrated improved spinning mirror emergency glowstick	0		Effect: "Tea-hee", Effect Duration: 22, Last Available: "2022-05"
+10902	activated concentrated improved mirror spinning emergency glowstick	0		Effect: "Tea-hee", Effect Duration: 22, Last Available: "2022-05"
 10903	red survival knife of chilblains	0		Cold Damage: +25, Lasts Until Rollover, Last Available: "2022-05"
 10904	narrow Rosewater's crank-powered radio on a lanyard	0		Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2022-05"
 10905	healthy headlamp	0		Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2022-05"
@@ -10765,9 +10765,9 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	ionized extra-ionized single-use dust mask	0		Effect: "Proprie Tea", Effect Duration: 46, Last Available: "2022-05"
 10911	concentrated energized spinning gaffer's tape	0		Effect: "Radiated and Grodiated", Effect Duration: 41, Last Available: "2022-05"
-10912	rotten huge 20-lb can of rice and beans	8	crappy	Last Available: "2022-05"
+10912	huge rotten 20-lb can of rice and beans	8	crappy	Last Available: "2022-05"
 10913	blurry bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	fancy delicious expired MRE	4	awesome	Effect: "Pumped Up", Effect Duration: 20, Last Available: "2022-05"
+10914	delicious fancy expired MRE	4	awesome	Effect: "Pumped Up", Effect Duration: 20, Last Available: "2022-05"
 10915	rotten cool mint precipice bar	3	crappy	Last Available: "2022-05"
 10916	bland carrot cake precipice bar	3	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
@@ -10782,14 +10782,14 @@
 10926	aerosolized tarnished trampled ticket stub	0		Effect: "Sleazy Weapon", Effect Duration: 28, Last Available: "2022-06"
 10927	aerosolized quadruple-improved blurry savings bond	0		Effect: "You Liver", Effect Duration: 23, Last Available: "2022-06"
 10928	ghostly designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
-10930	vaporized mirror upside-down sweat-ade	1		Effect: "Empathy", Effect Duration: 45, Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10930	vaporized upside-down mirror sweat-ade	1		Effect: "Empathy", Effect Duration: 45, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	mirror stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	blue pristine dinosaur feather	0		
-10936	twirling fuchsia nasty dinosaur spike	0		
+10936	fuchsia twirling nasty dinosaur spike	0		
 10937	pterodactyl rifle of the early riser	0		Adventures: +7, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
 10939	flatusaur gasmask	0		
@@ -10809,7 +10809,7 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	teal autumn-aton	0		Last Available: "2022-10"
 10955	tarnished quadruple-moist aerosolized maroon shaking autumn leaf	0		Effect: "Burning Hands", Effect Duration: 21, Last Available: "2022-10"
-10956	lousy practically non-alcoholic AutumnFest ale	1	decent	Last Available: "2022-10"
+10956	practically non-alcoholic lousy AutumnFest ale	1	decent	Last Available: "2022-10"
 10957	jittery frightening Fonzie's autumn sweater-weather sweater of the wise owl	0		Mysticality: +20, Experience (Moxie): +1, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2022-10"
 10958	chilly Da Vinci's strapping autumn debris shield of the storm	0		Muscle: +5, Experience (Mysticality): +5, Maximum MP Percent: +40, Cold Damage: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	delicious autumn-spice donut	3	awesome	Last Available: "2022-10"
@@ -10817,42 +10817,42 @@
 10961	miser's smelly Oprah's autumn leaf pendant	0		Maximum MP Percent: +50, Stench Spell Damage: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2022-10"
 10962	altered jittery shaking autumn breeze	1		Last Available: "2022-10"
 10963	aerosolized frozen autumn years wisdom	0		Effect: "meat.enh", Effect Duration: 64, Last Available: "2022-10"
-10964	narrow olive familiar-in-the-middle wrapper	0		Last Available: "2025-12"
+10964	olive narrow familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	bad Oopsie IPA	4	decent	Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	teal St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	spoiled enchanted ratatouille de Jarlsberg	3	crappy	Effect: "Warm Belly", Effect Duration: 15, Last Available: "2022-11"
-10971	bland massive purple Jarlsberg's vegetable soup	10	decent	Last Available: "2022-11"
-10972	normal narrow wobbly roasted vegetable of Jarlsberg	3	good	Last Available: "2022-11"
-10973	rotten half-sized blinking St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
+10970	enchanted spoiled ratatouille de Jarlsberg	3	crappy	Effect: "Warm Belly", Effect Duration: 15, Last Available: "2022-11"
+10971	massive bland purple Jarlsberg's vegetable soup	10	decent	Last Available: "2022-11"
+10972	normal wobbly narrow roasted vegetable of Jarlsberg	3	good	Last Available: "2022-11"
+10973	half-sized rotten blinking St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
 10974	diet bland bouncing Pete's wiley whey bar	1	decent	Last Available: "2022-11"
-10975	flavorless fancy Pete's rich ricotta	4	decent	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 35, Last Available: "2022-11"
+10975	fancy flavorless Pete's rich ricotta	4	decent	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 35, Last Available: "2022-11"
 10976	tolerable Boris's beer	4	good	Last Available: "2022-11"
 10977	rotten maroon honey bun of Boris	4	crappy	Last Available: "2022-11"
 10978	toothsome Boris's bread	4	awesome	Last Available: "2022-11"
-10979	mirror Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	upside-down Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	spinning Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	shaking mirror Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	lime green Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	fuchsia Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	mirror Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	upside-down Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	spinning Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	shaking mirror Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	lime green Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	fuchsia Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	miniature moldy wobbly baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
 10989	adequate mirror plain calzone	3	good	Last Available: "2022-11"
 10990	toothsome roasted vegetable focaccia	3	awesome	Last Available: "2022-11"
-10991	moldy snack-sized Pizza of Legend	2	crappy	Last Available: "2022-11"
-10992	stale fancy narrow Calzone of Legend	4	decent	Effect: "Wintergreen Warmongery", Effect Duration: 50, Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	lime green Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10991	snack-sized moldy Pizza of Legend	2	crappy	Last Available: "2022-11"
+10992	fancy stale narrow Calzone of Legend	4	decent	Effect: "Wintergreen Warmongery", Effect Duration: 50, Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	lime green Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	toothsome Deep Dish of Legend	3	awesome	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	narrow drink chit	0		
@@ -10863,14 +10863,14 @@
 11007	narrow booze bindle	0		
 11008	asbestos-lined hardened rare oboe	0		Damage Reduction: 3, Hot Resistance: +5
 11009	lard-coated smartaleck's bullet necklace	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Single Equip
-11010	low-calorie fancy adequate swamp haunch	1	good	Effect: "Afternoon Insight", Effect Duration: 35
+11010	fancy low-calorie adequate swamp haunch	1	good	Effect: "Afternoon Insight", Effect Duration: 35
 11011	Newton's cool gator shades	0		Moxie: +5, Experience (Mysticality): +3, Single Equip
 11012	milk cap	0		
-11013	bad practically non-alcoholic twirling Charleston Choo-Choo	1	decent	
-11014	spirit-forward smooth Velvet Veil	5	awesome	
+11013	practically non-alcoholic bad twirling Charleston Choo-Choo	1	decent	
+11014	smooth spirit-forward Velvet Veil	5	awesome	
 11015	lousy Marltini	3	decent	
 11016	mediocre triple-distilled ghostly Strong, Silent Type	7	decent	
-11017	watered-down bad Mysterious Stranger	2	decent	
+11017	bad watered-down Mysterious Stranger	2	decent	
 11018	drinkable Champagne Shimmy	3	good	
 11019	upside-down the Sot's parcel	0		
 11020	shaking mirror inspector's experienced ceramic cestus	0		Experience: +2, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10890,7 +10890,7 @@
 11034	diluted chiffon carbage	1		Last Available: "2023-12"
 11035	extra-flattened chiffon lemon	0		Effect: "Bone Homie", Effect Duration: 42
 11036	stale bouncing chocomotive	3	decent	Last Available: "2022-12"
-11037	jumbo yummy freightcake	5	awesome	Last Available: "2022-12"
+11037	yummy jumbo freightcake	5	awesome	Last Available: "2022-12"
 11038	weak bad pulsating cabooze	2	decent	Last Available: "2022-12"
 11039	blinking plastic caboose	0		Last Available: "2022-12"
 11040	wobbly boxer's plastic passenger car	0		Muscle Percent: +10, Last Available: "2022-12"
@@ -10914,13 +10914,13 @@
 11058	flame-wreathed Trainbot harness	0		Hot Spell Damage: +10
 11059	ping-pong table	0		
 11060	Crimbo train emergency brake	0		
-11061	yellow mirror Trainbot autoassembly module	0		
+11061	mirror yellow Trainbot autoassembly module	0		
 11062	knitted head-mounted Trainbot of the storm of horror	0		Maximum MP Percent: +40, Spooky Spell Damage: +25, Cold Resistance: +3, Last Available: "2022-12"
 11063	narrow wizardly strapping leg-mounted Trainbots of horror	0		Muscle: +5, Mysticality: +25, Spooky Spell Damage: +25, Last Available: "2022-12"
 11064	blurry gravedigger's friendly Sinatra's shoulder-mounted Trainbot	0		Experience (Moxie): +5, Familiar Weight: +3, Spooky Damage: +10, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	weak acceptable bouncing dregs of a Crimbo cocktail	2	good	
+11067	acceptable weak bouncing dregs of a Crimbo cocktail	2	good	
 11068	teal lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	spoiled pulsating honey-drenched ham slice	4	crappy	
@@ -10969,25 +10969,25 @@
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
-11117	improved pulsating blurry glob of extra-green chlorophyll	0		Effect: "Influence of Sphere", Effect Duration: 53, Last Available: "2023-02"
+11117	improved blurry pulsating glob of extra-green chlorophyll	0		Effect: "Influence of Sphere", Effect Duration: 53, Last Available: "2023-02"
 11118	chilled upside-down mushroom	0		Effect: "Petit Force", Effect Duration: 65, Last Available: "2023-02"
 11119	nitrogenated liquefied wobbly five-fingered fern resin	0		Effect: "Heart of Orange", Effect Duration: 30, Last Available: "2023-02"
-11120	jumbo rotten super good fruit	5	crappy	Last Available: "2023-02"
+11120	rotten jumbo super good fruit	5	crappy	Last Available: "2023-02"
 11121	twisted energized spores	1		Last Available: "2023-02"
-11122	electrified brainy hot pepper	0		Mysticality: +5, MP Regen Min: 3, MP Regen Max: 5, Lantern Element: "Hot", Last Available: "2023-02"
+11122	electrified brainy hot pepper	0		Mysticality: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-02", Lantern Element: "Hot"
 11123	super-Vulcanized out-of-work circus flea	0		Effect: "Abominably Slippery", Effect Duration: 41, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	modified yellow fire ant pheromones	0		Effect: "Can Has Cyborger", Effect Duration: 11, Last Available: "2023-02"
 11126	alkaline nitrogenated improved flapper fly	0		Effect: "Healthy Blue Glow", Effect Duration: 47, Last Available: "2023-02"
-11127	watered-down artisanal shot of wasp venom	2	EPIC	Last Available: "2023-02"
+11127	artisanal watered-down shot of wasp venom	2	EPIC	Last Available: "2023-02"
 11128	irradiated improved filled mosquito	0		Effect: "It's Electric!", Effect Duration: 41, Last Available: "2023-02"
-11129	cold-filtered huge shaking shim of shame shale	0		Effect: "Libra Rising", Effect Duration: 47, Last Available: "2023-02"
+11129	cold-filtered shaking huge shim of shame shale	0		Effect: "Libra Rising", Effect Duration: 47, Last Available: "2023-02"
 11130	aerosolized lime green pebble of proud pyrite	0		Effect: "Disco Neuropathy", Effect Duration: 66, Last Available: "2023-02"
 11131	liquefied triple-wet lime green pile of gritty sand	0		Effect: "Mystically Oiled", Effect Duration: 28, Last Available: "2023-02"
 11132	blinking hollow rock	0		Last Available: "2023-02"
-11133	altered flattened purple tumbling angry agate	0		Effect: "Perfect Hair", Effect Duration: 55, Last Available: "2023-02"
+11133	altered flattened tumbling purple angry agate	0		Effect: "Perfect Hair", Effect Duration: 55, Last Available: "2023-02"
 11134	deionized lump of loyal latite	0		Effect: "Rushtacean'", Effect Duration: 21, Last Available: "2023-02"
-11135	super-sized bland blinking shadow sausage	5	decent	Last Available: "2023-03"
+11135	bland super-sized blinking shadow sausage	5	decent	Last Available: "2023-03"
 11136	twirling sharpshooter's thinker's shadow skin	0		Mysticality: +10, Critical Hit Percent: +10, Last Available: "2023-03"
 11137	dry aerosolized huge shadow flame	0		Effect: "Mental A-cue-ity", Effect Duration: 18, Last Available: "2023-03"
 11138	spoiled bite-sized shadow bread	1	crappy	Last Available: "2023-03"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	huge shadow brick	0		Last Available: "2023-03"
 11143	wobbly shadow sinew	0		Last Available: "2023-03"
-11144	weak mediocre shadow venom	2	decent	Last Available: "2023-03"
+11144	mediocre weak shadow venom	2	decent	Last Available: "2023-03"
 11145	powdered shadow nectar	1		Last Available: "2023-03"
 11146	executive censurious thinker's shadow stick	0		Mysticality: +10, Sleaze Resistance: +3, Meat Drop: +40, Last Available: "2023-03"
 11147	maroon skewed lightning-fast bat paw of the brazier	0		Hot Spell Damage: +25, Initiative: +40
@@ -11017,7 +11017,7 @@
 11162	slick uncursed medallion	0		Moxie: +10
 11163	Advanced Pig Skinning	0		
 11164	skewed The Cheese Wizard's Companion	0		
-11165	jittery purple Jazz Agent sheet music	0		
+11165	purple jittery Jazz Agent sheet music	0		
 11166	Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
@@ -11034,13 +11034,13 @@
 11179	olive shellacked shadow hammer of the ox	0		Muscle: +20, Damage Reduction: 7
 11180	miser's electrified rock-hard shadow monocle	0		Damage Reduction: 5, Meat Drop: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 11181	purple shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	normal enchanted gigantic shadow hot dog	10	good	Effect: "Fudgehound", Effect Duration: 20
+11182	gigantic normal enchanted shadow hot dog	10	good	Effect: "Fudgehound", Effect Duration: 20
 11183	watered-down artisanal shadow martini	2	EPIC	
 11184	powdered shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
-11188	double-tarnished improved mirror squat shadow candy	0		Effect: "Izchak's Blessing", Effect Duration: 39
+11188	double-tarnished improved squat mirror shadow candy	0		Effect: "Izchak's Blessing", Effect Duration: 39
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
@@ -11117,7 +11117,7 @@
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	healthy Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	family-friendly fireproof Amulet of Perpetual Darkness of the pedagogue	0		Experience: +3, Hot Resistance: +3, Sleaze Resistance: +1, Item Drop: +5, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	drinkable enchanted Sexy Cosmo	3	good	Effect: "Human-Elf Hybrid", Effect Duration: 10, Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	extremely unsafe Newton's red-soled high heels of terror	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Spooky Spell Damage: +10, Last Available: "2023-06"
-11285	adequate enchanted cyburger	3	good	Effect: "Goldentongue", Effect Duration: 40, Last Available: "2025-12"
+11285	enchanted adequate cyburger	3	good	Effect: "Goldentongue", Effect Duration: 40, Last Available: "2025-12"
 11286	olive arcane researcher's ncle leg	0		Experience Percent (Mysticality): +10
 11287	green blinking Van der Graaf rutabuga bag of the empath	0		Familiar Weight: +5, MP Regen Min: 5, MP Regen Max: 7
 11288	curative mesquito proboscis	0		HP Regen Min: 3, HP Regen Max: 5
@@ -11169,20 +11169,20 @@
 11314	up-at-dawn tooth cap of the glutton	0		Food Drop: +100, Adventures: +5
 11315	twirling perfumed forbidden toothy trousers	0		Spell Damage Percent: +50, Stench Resistance: +5
 11316	spoiled banana split	3	crappy	
-11317	ghostly maroon handful of toilet paper	0		
-11318	lime green skewed Mrs. Rush	0		
+11317	maroon ghostly handful of toilet paper	0		
+11318	skewed lime green Mrs. Rush	0		
 11319	blinking medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	bad bottle of Cabernet Sauvignon	3	decent	
 11321	teal personal trainer's baywatch of the pedagogue of the boozehound	0		Experience: +3, Experience Percent (Muscle): +10, Booze Drop: +100, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	spinning Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	denatured mirror cyan concentrated cooking	1		
-11329	mixed pulsating shaking meat	1		
-11330	denatured ghostly lime green sparkling orb	1		
+11328	denatured cyan mirror concentrated cooking	1		
+11329	mixed shaking pulsating meat	1		
+11330	denatured lime green ghostly sparkling orb	1		
 11331	compressed spinning wobbly hardening cream	1		Effect: "Super-Electrified", Effect Duration: 45
 11332	diluted twirling pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11212,7 +11212,7 @@
 11357	smooth smoldering drape of the cougar	0		Moxie: 35, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	squat aromatic frosty Van der Graaf vibrating leaf crown of the boozehound of the cheetah	0		Maximum MP Percent: +10, Cold Spell Damage: +10, Stench Resistance: +1, Booze Drop: +100, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7
-11360	enchanted snack-sized stale leafy browns	2	decent	Effect: "Can Has Cyborger", Effect Duration: 5
+11360	enchanted stale snack-sized leafy browns	2	decent	Effect: "Can Has Cyborger", Effect Duration: 5
 11361	Vulcanized autumnic balm	0		Effect: "Yes, Can Haz", Effect Duration: 67
 11362	oxidized irradiated spinning coping juice	0		Effect: "Cosmic Flavor", Effect Duration: 16
 11363	mansplainer's rosy-cheeked supercool candy cane sword cane of temperance	0		Moxie Percent: +20, Maximum HP Percent: +30, Monster Level: +15, Sleaze Resistance: +5, Item Drop: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11230,7 +11230,7 @@
 11375	green Boltsmann ID badge	0		
 11376	ghostly housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	decent massive pickled bread	8	good	Last Available: "2023-12"
+11378	massive decent pickled bread	8	good	Last Available: "2023-12"
 11379	enchanted moldy olive salted mutton	3	crappy	Effect: "Spooky Flavor", Effect Duration: 45, Last Available: "2023-12"
 11380	toothsome corned beet	4	awesome	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11265,7 +11265,7 @@
 11410	scorching Elf Guard commandeering gloves	0		Hot Damage: +25, Single Equip, Last Available: "2023-12"
 11411	corrupted Elf Guard eyedrops	0		Effect: "Devil Inside", Effect Duration: 60, Last Available: "2023-12"
 11412	Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
-11413	green tumbling Elf Guard honor present	0		Last Available: "2023-12"
+11413	tumbling green Elf Guard honor present	0		Last Available: "2023-12"
 11414	vibrating ruddy Elf Guard officer's sidearm	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Last Available: "2023-12"
 11415	bouncing ghostly Elf Guard insignia (general) of dire peril of the storm	0		Weapon Damage: +20, Maximum MP Percent: +40, Single Equip, Last Available: "2023-12"
 11416	lousy Crimbow Rainbo	4	decent	Last Available: "2023-12"
@@ -11277,7 +11277,7 @@
 11422	mediocre skewed old-school pirate grog	4	decent	Last Available: "2023-12"
 11423	delicious grog nuts	3	awesome	Last Available: "2023-12"
 11424	huge Oprah's grievous sawed-off blunderbuss of courage	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Spooky Resistance: +3, Last Available: "2023-12"
-11425	bad strong officer's nog	5	decent	Last Available: "2023-12"
+11425	strong bad officer's nog	5	decent	Last Available: "2023-12"
 11426	jittery purple peppermint bomb	0		Last Available: "2023-12"
 11427	toothsome sundae ration	3	awesome	Last Available: "2023-12"
 11428	moldy peppermint tack	3	crappy	Last Available: "2023-12"
@@ -11301,7 +11301,7 @@
 11446	rock-hard Elf Guard fuel tank	0		Damage Reduction: 5, Last Available: "2023-12"
 11447	foul-smelling wicked massive wrench of the glutton	0		Spell Damage: +5, Stench Damage: +10, Food Drop: +100, Last Available: "2023-12"
 11448	executive brown pirate pants of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +40, Last Available: "2023-12"
-11449	lime green shaking Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+11449	shaking lime green Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11450	The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11451	punching mirror	0		Last Available: "2023-12"
 11452	miser's fireproof nippy boxer's Elf dessert spoon of wisdom of Gandalf	0		Mysticality: +15, Muscle Percent: +10, Spell Critical Percent: +20, Cold Damage: +10, Hot Resistance: +3, Meat Drop: +10, Last Available: "2023-12"
@@ -11313,28 +11313,28 @@
 11458	Herculean strapping Crimbuccaneer bombjacket	0		Muscle: +5, Experience (Muscle): +1, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	bite-sized decent yellow sugarplum ration	1	good	Last Available: "2023-12"
 11460	flavorless jittery gingerbread nylons	3	decent	Last Available: "2023-12"
-11461	fancy toothsome rum-soaked fruitcake	3	awesome	Effect: "Super-Charged", Effect Duration: 5, Last Available: "2023-12"
+11461	toothsome fancy rum-soaked fruitcake	3	awesome	Effect: "Super-Charged", Effect Duration: 5, Last Available: "2023-12"
 11462	decent miniature spinning lime	2	good	Last Available: "2023-12"
 11463	moldy half-sized gingerbread pirate	2	crappy	Last Available: "2023-12"
 11464	delicious fruit-stuffed rumcake	3	awesome	Last Available: "2023-12"
 11465	artisanal mulled wine	3	EPIC	Last Available: "2023-12"
-11466	perfectly mixed watered-down special maroon Swedish coffee	2	EPIC	Effect: "Halloweeny", Effect Duration: 25, Last Available: "2023-12"
+11466	watered-down perfectly mixed special maroon Swedish coffee	2	EPIC	Effect: "Halloweeny", Effect Duration: 25, Last Available: "2023-12"
 11467	perfectly mixed canteen of eggnog	3	super EPIC	Last Available: "2023-12"
-11468	lousy fancy hot wine	4	decent	Effect: "Joyful Resolve", Effect Duration: 35, Last Available: "2023-12"
+11468	fancy lousy hot wine	4	decent	Effect: "Joyful Resolve", Effect Duration: 35, Last Available: "2023-12"
 11469	hand-crafted Jamaican coffee	3	EPIC	Last Available: "2023-12"
 11470	bad cyan flask of egggrog	3	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	upside-down pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	practically non-alcoholic perfectly mixed yule grog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
-11475	stale jumbo wet tack	5	decent	Last Available: "2023-12"
+11475	jumbo stale wet tack	5	decent	Last Available: "2023-12"
 11476	rotten maroon skewed whalecake	4	crappy	Last Available: "2023-12"
 11477	ghostly beefy gunwale whalegun of dire peril of the sweet-tooth	0		Muscle: +10, Weapon Damage: +20, Candy Drop: +100, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	drinkable and claret	3	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	blinking trick coin	0		Last Available: "2023-12"
 11481	boxer's Elf Guard squirtgun of the glutton	0		Muscle Percent: +10, Food Drop: +100, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
-11482	ghostly skewed chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
+11482	skewed ghostly chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	huge ghostly Sherlock's sequin-encrusted sweater	0		Item Drop: +25, Last Available: "2023-12"
 11484	skewed educational replica Elf Guard medal of temperance	0		Experience: +1, Sleaze Resistance: +5, Item Drop: +5, Last Available: "2023-12"
 11485	Lil' Snowball Factory	0		Last Available: "2023-12"
@@ -11351,7 +11351,7 @@
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
-11499	pulsating green Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+11499	green pulsating Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	wet cyan narrow military candy cane	0		Effect: "Grrrrrrreat!", Effect Duration: 23
@@ -11382,8 +11382,8 @@
 11527	anodized dry alkaline crepe paper peanut candy	0		Effect: "Fizzier Than Light", Effect Duration: 48
 11528	executive wicked petrified wood war pike	0		Spell Damage: +5, Meat Drop: +40, Last Available: "2025-12"
 11529	hardy beefy petrified wood waist protector	0		Muscle: +10, Maximum HP: +50, Single Equip, Last Available: "2025-12"
-11530	lime green scandalous vibrating petrified wood wizard's pouch	0		Maximum MP Percent: +10, Sleaze Damage: +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	upside-down up-at-dawn Rosewater's petrified wood water purifier	0		Mysticality Percent: +30, Adventures: +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	lime green scandalous vibrating petrified wood wizard's pouch	0		Maximum MP Percent: +10, Sleaze Damage: +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	upside-down up-at-dawn Rosewater's petrified wood water purifier	0		Mysticality Percent: +30, Adventures: +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	bouncing petrified wood whoopie panama of the brute of the boozehound	0		Muscle Percent: +30, Booze Drop: +100, Last Available: "2025-12"
 11533	spinning arcane researcher's petrified wood walking pants	0		Experience Percent (Mysticality): +10, Item Drop: +5, Last Available: "2025-12"
 11534	altered blinking jittery petrified wood waste parts	1		Last Available: "2025-12"
@@ -11408,7 +11408,7 @@
 11553	ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	shaking quick-release belt pouch	0		Single Equip
-11556	skewed squat quick-release fannypack	0		Single Equip
+11556	squat skewed quick-release fannypack	0		Single Equip
 11557	quick-release utility belt	0		Single Equip
 11558	blinking sharpshooter's motion sensor	0		Critical Hit Percent: +10, Single Equip
 11559	focused magnetron pistol	0		Single Equip
@@ -11425,13 +11425,13 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	half-sized moldy blinking yam	2	crappy	Last Available: "2024-05"
-11574	spirit-forward hand-crafted yam martini	5	EPIC	Last Available: "2024-05"
-11575	practically non-alcoholic tolerable sweet potato o' mine	1	good	Last Available: "2024-05"
-11576	irresponsibly strong artisanal squat twirling Southern yam	8	EPIC	Last Available: "2024-05"
-11577	drinkable watered-down mirror sweet potato punch	2	good	Last Available: "2024-05"
-11578	bite-sized rotten squat Mayam spinach	1	crappy	Last Available: "2024-05"
-11579	spoiled bite-sized jittery yam and swiss	1	crappy	Last Available: "2024-05"
+11573	moldy half-sized blinking yam	2	crappy	Last Available: "2024-05"
+11574	hand-crafted spirit-forward yam martini	5	EPIC	Last Available: "2024-05"
+11575	tolerable practically non-alcoholic sweet potato o' mine	1	good	Last Available: "2024-05"
+11576	artisanal irresponsibly strong twirling squat Southern yam	8	EPIC	Last Available: "2024-05"
+11577	watered-down drinkable mirror sweet potato punch	2	good	Last Available: "2024-05"
+11578	rotten bite-sized squat Mayam spinach	1	crappy	Last Available: "2024-05"
+11579	bite-sized spoiled jittery yam and swiss	1	crappy	Last Available: "2024-05"
 11580	frosty Tesla occult yam cannon	0		Spell Damage Percent: +25, Cold Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	blue yam battery	0		Last Available: "2024-05"
@@ -11441,14 +11441,14 @@
 11586	smartaleck's stylish yamtility belt of the scaredy-cat	0		Moxie: +25, Moxie Percent: +30, Monster Level: -15, Lasts Until Rollover, Last Available: "2024-05"
 11587	delicious yam slider	4	awesome	Last Available: "2024-05"
 11588	stale super-sized yam mayo	5	decent	Last Available: "2024-05"
-11589	stale massive yam burrito	7	decent	Last Available: "2024-05"
+11589	massive stale yam burrito	7	decent	Last Available: "2024-05"
 11590	spinning pulsating visual packet sniffer	0		Last Available: "2025-12"
-11591	ghostly fuchsia mini kiwi egg	0		Free Pull, Last Available: "2024-06"
+11591	fuchsia ghostly mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	tasty snack-sized mini kiwi	2	awesome	Last Available: "2024-06"
 11595	Tesla deadly Newton's mini kiwi bikini	0		Experience (Mysticality): +3, Weapon Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-06"
-11596	acceptable weak mini kiwitini	2	good	Last Available: "2024-06"
+11596	weak acceptable mini kiwitini	2	good	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	gray Jack Frost's nippy mini kiwi silicon tiepin of the glutton	0		Cold Damage: +10, Cold Spell Damage: +50, Food Drop: +100
@@ -11472,7 +11472,7 @@
 11617	proto-proto-protozoa	0		
 11618	snack-sized rotten bacteria bisque	2	crappy	
 11619	normal ciliophora chowder	4	good	
-11620	bland big cream of chloroplasts	5	decent	
+11620	big bland cream of chloroplasts	5	decent	
 11621	wobbly synaptic soup	0		
 11622	muscular soup	0		
 11623	cyan narrow flagellate soup	0		
@@ -11497,12 +11497,12 @@
 11642	pulsating lime green Sept-Ember Censer	0		Last Available: "2024-09"
 11643	huge stiffened blade of dismemberment	0		Damage Reduction: 1, Lasts Until Rollover, Last Available: "2024-09"
 11644	wobbly Embering Hulk	0		Last Available: "2024-09"
-11645	wobbly tumbling Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
+11645	tumbling wobbly Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
 11646	Septapus summoning charm	0		Last Available: "2024-09"
 11647	structural ember	0		Last Available: "2024-09"
 11648	mansplainer's steel-toed Rosewater's embers-only jacket	0		Mysticality Percent: +30, Damage Reduction: 9, Monster Level: +15, Lasts Until Rollover, Last Available: "2024-09"
 11649	bembershoot of Leguizamo	0		Monster Level: +20, Lasts Until Rollover, Last Available: "2024-09"
-11650	spoiled enchanted blurry wheel of camembert	3	crappy	Effect: "Warm Belly", Effect Duration: 25, Last Available: "2024-09"
+11650	enchanted spoiled blurry wheel of camembert	3	crappy	Effect: "Warm Belly", Effect Duration: 25, Last Available: "2024-09"
 11651	censurious supercool hat of remembering of wisdom	0		Mysticality: +15, Moxie Percent: +20, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-09"
 11652	ghostly throwin' ember	0		Last Available: "2024-09"
 11653	bouncing spinning head of emberg lettuce	0		Last Available: "2024-09"
@@ -11526,8 +11526,8 @@
 11671	smelly studded photo booth supply list	0		Damage Absorption: +80, Stench Spell Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	jittery blurry peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	narrow tie-dye headband	0		
-11674	yummy tiny whirled peas	1	awesome	Last Available: "2024-11"
-11675	half-sized decent peaza	2	good	Last Available: "2024-11"
+11674	tiny yummy whirled peas	1	awesome	Last Available: "2024-11"
+11675	decent half-sized peaza	2	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	powdered wobbly drenchrome 2.0	1		Last Available: "2025-12"
 11678	modified spinning Synapse Blaster	1		Effect: "Cotton Mouthed", Effect Duration: 15, Last Available: "2025-12"
@@ -11536,7 +11536,7 @@
 11681	quantized familiar experience	0		
 11682	denatured tarnished alkaline huge pea brittle	0		Effect: "Bureaucratized", Effect Duration: 29, Last Available: "2024-11"
 11683	acceptable jittery peasco	3	good	Last Available: "2024-11"
-11684	snack-sized spoiled piece of cake	2	crappy	Last Available: "2024-11"
+11684	spoiled snack-sized piece of cake	2	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11545,8 +11545,8 @@
 11690	purple scorching jolly roger flag	0		Hot Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	tumbling sleeping profane parrot	0		Last Available: "2024-12"
 11692	teal pirrrate's currrse	0		Last Available: "2024-12"
-11693	tolerable practically non-alcoholic tankard of spiced rum	1	good	Last Available: "2024-12"
-11694	distilled acceptable tankard of spiced Goldschlepper	5	good	Last Available: "2024-12"
+11693	practically non-alcoholic tolerable tankard of spiced rum	1	good	Last Available: "2024-12"
+11694	acceptable distilled tankard of spiced Goldschlepper	5	good	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	electrified governor's daughter's lace collar	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12"
 11697	Van der Graaf governor's daughter's petticoats	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12"
@@ -11574,9 +11574,9 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	bouncing pulsating Spirit of Christmas	0		Last Available: "2024-12"
-11722	decent upside-down huge coney haunch	4	good	Last Available: "2024-12"
+11722	decent huge upside-down coney haunch	4	good	Last Available: "2024-12"
 11723	magnetized huge dark chocolate egg	0		Effect: "Takin' It Greasy", Effect Duration: 16, Last Available: "2024-12"
-11724	enchanted extra-dry bad jittery moai toai	5	decent	Effect: "Neutered Nostrils", Effect Duration: 45
+11724	bad enchanted extra-dry jittery moai toai	5	decent	Effect: "Neutered Nostrils", Effect Duration: 45
 11725	nippy wholesome moaiball of the sweet-tooth	0		Maximum HP Percent: +10, Cold Damage: +10, Candy Drop: +100, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	quadruple-oxidized four-leaf potato sprout	0		Effect: "Leo Rising", Effect Duration: 55, Last Available: "2024-12"
@@ -11600,36 +11600,36 @@
 11745	friendly Congressional Medal of Insanity of the scaredy-cat of the early riser	0		Monster Level: -15, Familiar Weight: +3, Adventures: +7, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	acceptable Easter grasshopper	4	good	Last Available: "2024-12"
-11748	tolerable practically non-alcoholic special Irish eggnog	1	good	Effect: "Briny Blood", Effect Duration: 5, Last Available: "2024-12"
-11749	hand-crafted fortified canteen of jungle juice	5	EPIC	Last Available: "2024-12"
+11748	special practically non-alcoholic tolerable Irish eggnog	1	good	Effect: "Briny Blood", Effect Duration: 5, Last Available: "2024-12"
+11749	fortified hand-crafted canteen of jungle juice	5	EPIC	Last Available: "2024-12"
 11750	fancy lousy turchucken	3	decent	Effect: "Frog In Your Throat", Effect Duration: 50, Last Available: "2024-12"
 11751	artisanal mechanically-mulled cider	4	EPIC	Last Available: "2024-12"
-11752	hand-crafted special holiday trip around the world	4	super EPIC	Effect: "Enraged", Effect Duration: 40, Last Available: "2024-12"
+11752	special hand-crafted holiday trip around the world	4	super EPIC	Effect: "Enraged", Effect Duration: 40, Last Available: "2024-12"
 11753	half-sized delicious chocolate ostrich egg	2	awesome	Last Available: "2024-12"
-11754	normal miniature bouncing beef and cabbage	2	good	Last Available: "2024-12"
+11754	miniature normal bouncing beef and cabbage	2	good	Last Available: "2024-12"
 11755	decent super-sized jittery candy rations	5	good	Last Available: "2024-12"
 11756	tasty double-candied yams	3	awesome	Last Available: "2024-12"
 11757	rotten upside-down Christmas ham	3	crappy	Last Available: "2024-12"
 11758	enchanted moldy skewed holiday smorgasbord	3	crappy	Effect: "Deep-Seated Rage", Effect Duration: 15, Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	baleful bejazzled eyepatch	0		Spell Damage: +25, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	mirror How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	green blinking How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	mirror Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	upside-down Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	upside-down Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	fuchsia Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	mirror How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	green blinking How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	mirror Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	upside-down Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	upside-down Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	fuchsia Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	horrifying extremely unsafe dangerous egg gun of mayonnaise	0		Weapon Damage: +10, Weapon Damage Percent: +100, Spooky Damage: +25, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	purple Sherlock's thinker's army helmet of mayonnaise of the sweet-tooth	0		Mysticality: +10, Sleaze Spell Damage: +50, Item Drop: +25, Candy Drop: +100, Last Available: "2024-12"
 11774	blue candy egg deviler	0		Last Available: "2024-12"
 11775	olive napkin	0		Last Available: "2024-12"
-11776	special spoiled bite-sized pulsating Thanksgiving ration	1	crappy	Effect: "Puddingskin", Effect Duration: 35, Last Available: "2024-12"
-11777	artisanal distilled wobbly Easter eggnog	5	EPIC	Last Available: "2024-12"
+11776	spoiled special bite-sized pulsating Thanksgiving ration	1	crappy	Effect: "Puddingskin", Effect Duration: 35, Last Available: "2024-12"
+11777	distilled artisanal wobbly Easter eggnog	5	EPIC	Last Available: "2024-12"
 11778	mixed yellow clovermint	1		Last Available: "2024-12"
 11779	huge scandalous veiny savvy nylon Christmas stockings of incineration	0		Mysticality Percent: +20, Maximum HP: +10, Hot Spell Damage: +50, Sleaze Damage: +5, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11674,9 +11674,9 @@
 11819	squat dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	blue dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	squat SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
-11822	upside-down olive spinning OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
+11822	spinning upside-down olive OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	purple spinning STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
-11824	olive spinning insignificant bit	0		Last Available: "2025-12"
+11824	spinning olive insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
 11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
@@ -11688,11 +11688,11 @@
 11833	wet non-ionized purple wobbly synthetic coffee	0		Effect: "Rainbow Bright", Effect Duration: 62
 11834	non-chilled corrupted yellow iDrops	0		Effect: "Spooky Jellied", Effect Duration: 26
 11835	shame coil	0		
-11836	fuchsia jittery new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
+11836	jittery fuchsia new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	tumbling toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	blurry heat arc	0		
 11839	scrape	0		
-11840	wobbly twirling phantom digit	0		
+11840	twirling wobbly phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
@@ -11705,7 +11705,7 @@
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	fuchsia stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
-11853	yellow mirror foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
+11853	mirror yellow foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	skewed grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
@@ -11716,7 +11716,7 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	boiled upside-down scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	hand-crafted practically non-alcoholic pint of Leprechaun Stout	1	EPIC	Last Available: "2025-03"
+11864	practically non-alcoholic hand-crafted pint of Leprechaun Stout	1	EPIC	Last Available: "2025-03"
 11865	dehydrated jittery olive phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11729,7 +11729,7 @@
 11874	special miniature toothsome small beer brat	2	awesome	Effect: "Horrid, Torrid", Effect Duration: 40, Last Available: "2025-03"
 11875	spoiled peach pie	4	crappy	Last Available: "2025-03"
 11876	decent incredible mini-pizza	4	good	Last Available: "2025-03"
-11877	weak hand-crafted blurry tumbling Divine sidecar	2	EPIC	Last Available: "2025-03"
+11877	weak hand-crafted tumbling blurry Divine sidecar	2	EPIC	Last Available: "2025-03"
 11878	artisanal lime green tangarita sidecar	3	EPIC	Last Available: "2025-03"
 11879	tolerable watered-down gimlet sidecar	2	good	Last Available: "2025-03"
 11880	mediocre vodka stratocaster sidecar	4	decent	Last Available: "2025-03"
@@ -11739,7 +11739,7 @@
 11884	greedy vibrating April Shower Thoughts shield	0		Maximum MP Percent: +10, Meat Drop: +20, Damage Reduction: 6, Last Available: "2025-04"
 11885	squat glob of wet paper	0		Last Available: "2025-04"
 11886	squat spitball	0		Last Available: "2025-04"
-11887	dry jittery teal wet paper weights	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 48, Last Available: "2025-04"
+11887	dry teal jittery wet paper weights	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 48, Last Available: "2025-04"
 11888	triple-distilled bad Three Sheets to the Wind	8	decent	Last Available: "2025-04"
 11889	special adequate pile of wet dates	3	good	Effect: "Strawberry Alarm", Effect Duration: 35, Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
@@ -11748,7 +11748,7 @@
 11893	razor-sharp wet shower shoes	0		Weapon Damage Percent: +25, Last Available: "2025-04"
 11894	blurry wet shower shorts of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2025-04"
 11895	fuchsia wet paper tiger	0		Last Available: "2025-04"
-11896	skewed ghostly wet paper eye	0		Familiar Weight: +15
+11896	ghostly skewed wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
 11898	dry wet paper cup	0		Effect: "Ass Over Teakettle", Effect Duration: 23, Last Available: "2025-04"
 11899	alkaline oxidized wet paperback	0		Effect: "Just Aged Enough", Effect Duration: 19, Last Available: "2025-04"
@@ -11788,9 +11788,9 @@
 11933	blurry stiffened Allied Radio Backpack of the storm of the sweet-tooth	0		Damage Reduction: 1, Maximum MP Percent: +40, Candy Drop: +100, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	squat orphaned baby skeleton	0		
 11935	yellow ordnance magnet	0		Single Equip
-11936	green skewed confetti grenade	0		
+11936	skewed green confetti grenade	0		
 11937	spoiled Skeleton Wars rations	3	crappy	
-11938	high-proof hand-crafted cyan skeleton war fuel can	8	EPIC	
+11938	hand-crafted high-proof cyan skeleton war fuel can	8	EPIC	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	blurry M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,25 +11804,25 @@
 11949	bouncing supercharged bully badge	0		Maximum MP Percent: +30, Lasts Until Rollover, Last Available: "2025-08"
 11950	time cop top hat of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	modified narrow green mixed berry jelly	1		Last Available: "2025-08"
+11952	modified green narrow mixed berry jelly	1		Last Available: "2025-08"
 11953	moldy thick blinking toast with mixed berry jelly	5	crappy	Last Available: "2025-08"
-11954	adequate low-calorie tumbling cup of sugar	1	good	Last Available: "2025-08"
-11955	flavorless big Susie's cupcake	5	decent	Last Available: "2025-08"
+11954	low-calorie adequate tumbling cup of sugar	1	good	Last Available: "2025-08"
+11955	big flavorless Susie's cupcake	5	decent	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	Rosewater's smooth the gun of horror	0		Moxie: +15, Mysticality Percent: +30, Spooky Spell Damage: +25, Last Available: "2025-08"
 11958	tolerable triple-distilled wine	8	good	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
-11961	yellow shaking sand penny	0		
+11961	shaking yellow sand penny	0		
 11962	censurious undersea surveying goggles	0		Sleaze Resistance: +3, Lasts Until Rollover
 11963	hand-crafted practically non-alcoholic Ocean-Touched Rum	1	EPIC	
 11964	compressed cyan water-logged pill	1		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 10
-11965	small flavorless kelp puck	2	decent	
+11965	flavorless small kelp puck	2	decent	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	blurry scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	ghostly blurry sea gel	0		
-11971	double-improved deionized green upside-down octopus ink bladder	0		Effect: "Chief Executive Optimism", Effect Duration: 26
+11971	double-improved deionized upside-down green octopus ink bladder	0		Effect: "Chief Executive Optimism", Effect Duration: 26
 11972	narrow durable dolphin whistle	0		
 11973	fuchsia Thwaitgold lobster statuette	0		
 11974	blurry packaged Monodent of the Sea	0		Free Pull
@@ -11842,11 +11842,11 @@
 12052	bad weak red blurry Smoking Pope	2	decent	
 12053	fancy bland gray prize turkey	3	decent	Effect: "Carol of the Bones", Effect Duration: 10
 12054	diluted huge medicinal gruel	1		
-12055	flavorless snack-sized full-sized pumpkin pie	2	decent	Last Available: "2025-11"
+12055	snack-sized flavorless full-sized pumpkin pie	2	decent	Last Available: "2025-11"
 12056	lousy vodka cranberry sauce	4	decent	Last Available: "2025-11"
 12057	Vulcanized dry yammed candy	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 28, Last Available: "2025-11"
-12058	bland low-calorie treasure chestnut	1	decent	Last Available: "2025-12"
-12059	weak bad blinking mulled butter rum	2	decent	Last Available: "2025-12"
+12058	low-calorie bland treasure chestnut	1	decent	Last Available: "2025-12"
+12059	bad weak blinking mulled butter rum	2	decent	Last Available: "2025-12"
 12060	adjusted triple-pickled bouncing cinnamon doubloon	0		Effect: "Familial Ties", Effect Duration: 21, Last Available: "2025-12"
 12061	gray rock-hard plastic left skeleton arm	0		Damage Reduction: 5, Last Available: "2025-12"
 12062	olive wicked plastic left skeleton leg	0		Spell Damage: +5, Last Available: "2025-12"
@@ -11873,7 +11873,7 @@
 12083	pressed maroon Gehenna tattoo	0		Effect: "Soles of Glass", Effect Duration: 65
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
-12118	tumbling upside-down burnt radius	0		Last Available: "2025-12"
+12118	upside-down tumbling burnt radius	0		Last Available: "2025-12"
 12119	burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
 12121	Crymbocurrency	0		Last Available: "2025-12"
@@ -11898,7 +11898,7 @@
 12140	greedy scorched skull trophy	0		Meat Drop: +20, Last Available: "2025-12"
 12141	half-sized adequate wing bone	2	good	Last Available: "2025-12"
 12142	hand-crafted weak skeleton venom	4	EPIC	Last Available: "2025-12"
-12143	boiled squat teal twirling baked bone meal	1		Last Available: "2025-12"
+12143	boiled twirling teal squat baked bone meal	1		Last Available: "2025-12"
 12144	purple twirling ribald plastic skeleton rib cage	0		Sleaze Damage: +10, Last Available: "2025-12"
 12145	steel-toed plastic skeleton skull	0		Damage Reduction: 9, Last Available: "2025-12"
 12146	dangerous plastic skeleton Crimbo hat	0		Weapon Damage: +10, Last Available: "2025-12"
@@ -11919,14 +11919,14 @@
 12161	tumbling Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	tumbling Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	spinning Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
-12164	lime green shaking Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
+12164	shaking lime green Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12165	Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12166	upside-down Crymbocurrency tattoo	0		Last Available: "2025-12"
 12167	squat manspreader's fireproof bonesaw of the detective	0		Monster Level: +10, Item Drop: +20, Last Available: "2025-12"
 12168	frosty sage vermiculite shield	0		Mysticality Percent: +10, Cold Spell Damage: +10, Damage Reduction: 9, Last Available: "2025-12"
 12169	wobbly ship's lantern of the businessman	0		Meat Drop: +50, Last Available: "2025-12"
 12170	yellow narrow MacGyver's heat-resistant harpoon pistol of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Last Available: "2025-12"
-12171	snack-sized rotten traditional gingerloaf	2	crappy	Last Available: "2025-12"
+12171	rotten snack-sized traditional gingerloaf	2	crappy	Last Available: "2025-12"
 12172	smooth Scotch and eggnog	4	awesome	Last Available: "2025-12"
 12173	magnetized activated purple counterskeleton elixir	0		Effect: "Yuletide Mutations", Effect Duration: 16, Last Available: "2025-12"
 12174	lousy weak &quot;salvaged&quot; wine	2	decent	Last Available: "2025-12"
@@ -11942,7 +11942,7 @@
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	dinosaur bone fragment	0		Last Available: "2026-03"
-12187	fuchsia squat Pork Elf pottery shard	0		Last Available: "2026-03"
+12187	squat fuchsia Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	2015 landfill detritus	0		Last Available: "2026-03"
 12189	intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
@@ -11983,24 +11983,24 @@
 12229	normal spinning onigiri	4	good	
 12230	rotten crudit&eacute;s	4	crappy	
 12231	rotten teal sauced mutton	4	crappy	
-12232	decent miniature red hot honey ant	2	good	
+12232	miniature decent red hot honey ant	2	good	
 12233	rotten tomb aspic	4	crappy	
 12234	normal later tots	3	good	
 12235	yummy cyan Frutti di Scatoletta	4	awesome	Last Available: "2026-05"
-12236	flavorless small Pesto alla Marziano	2	decent	Last Available: "2026-05"
-12237	moldy small Arrattabbattabiata	2	crappy	Last Available: "2026-05"
+12236	small flavorless Pesto alla Marziano	2	decent	Last Available: "2026-05"
+12237	small moldy Arrattabbattabiata	2	crappy	Last Available: "2026-05"
 12238	decent fuchsia Orzo di Riso	4	good	Last Available: "2026-05"
 12239	rotten gigantic Pasta Grimavera	8	crappy	Last Available: "2026-05"
-12240	snack-sized special rotten Linguini Ubriacapa	2	crappy	Effect: "Feline Ferocity", Effect Duration: 50, Last Available: "2026-05"
+12240	snack-sized rotten special Linguini Ubriacapa	2	crappy	Effect: "Feline Ferocity", Effect Duration: 50, Last Available: "2026-05"
 12241	decent yellow Formica e Pepe	3	good	Last Available: "2026-05"
-12242	rotten half-sized Tubetto Gelatto	2	crappy	Last Available: "2026-05"
-12243	super-sized rotten pulsating Gnocci Domani	5	crappy	Last Available: "2026-05"
+12242	half-sized rotten Tubetto Gelatto	2	crappy	Last Available: "2026-05"
+12243	rotten super-sized pulsating Gnocci Domani	5	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	padded Space Soldier Helmet of wisdom	0		Mysticality: +15, Damage Absorption: +20
-12253	flavorless enchanted premium turkey leg	3	decent	Effect: "Spell Transfer Complete", Effect Duration: 20
+12253	enchanted flavorless premium turkey leg	3	decent	Effect: "Spell Transfer Complete", Effect Duration: 20
 12254	acceptable styrofoam cup of mead	4	good	
 12255	mirror toasty sword	0		Hot Damage: +5
 12256	skewed staff of Leguizamo	0		Monster Level: +20
@@ -12021,7 +12021,7 @@
 12271	blue greedy smelly arcane researcher's Staff of Anachronistic Churning	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +10, Meat Drop: +20
 12272	flavorless classic banana	3	decent	Last Available: "2026-07"
 12273	stale watermelon	3	decent	Last Available: "2026-07"
-12274	small adequate quince	2	good	Last Available: "2026-07"
+12274	adequate small quince	2	good	Last Available: "2026-07"
 12275	yellow Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	moldy bite-sized classic banana pie	1	crappy	Last Available: "2026-07"
@@ -12029,11 +12029,11 @@
 12279	Vulcanized pressed narrow banana quintessence	0		Effect: "Tiki Thoughtfulness", Effect Duration: 51, Last Available: "2026-07"
 12280	weak lousy Aesop Daiquiri	2	decent	Last Available: "2026-07"
 12281	lousy mirror Monkey Congress	4	decent	Last Available: "2026-07"
-12282	low-calorie decent watermelon pie	1	good	Last Available: "2026-07"
-12283	dry purple tumbling concentrated watermelon juice	0		Effect: "Bloody-minded", Effect Duration: 64, Last Available: "2026-07"
+12282	decent low-calorie watermelon pie	1	good	Last Available: "2026-07"
+12283	dry tumbling purple concentrated watermelon juice	0		Effect: "Bloody-minded", Effect Duration: 64, Last Available: "2026-07"
 12284	galvanized frozen spinning Aqua Citrulanatae	0		Effect: "Material Witness", Effect Duration: 27, Last Available: "2026-07"
-12285	special delicious watered-down Melonegroni	2	awesome	Effect: "Whitened Teeth", Effect Duration: 35, Last Available: "2026-07"
-12286	lousy irresponsibly strong Melonade Spritz	6	decent	Last Available: "2026-07"
+12285	special watered-down delicious Melonegroni	2	awesome	Effect: "Whitened Teeth", Effect Duration: 35, Last Available: "2026-07"
+12286	irresponsibly strong lousy Melonade Spritz	6	decent	Last Available: "2026-07"
 12287	moldy quince pie	3	crappy	Last Available: "2026-07"
 12288	magnetized ionized diffused quince quaff	0		Effect: "Mariachi Mood", Effect Duration: 19, Last Available: "2026-07"
 12289	aerosolized cold-filtered gray Quickquince	0		Effect: "Alacri Tea", Effect Duration: 12, Last Available: "2026-07"
@@ -12059,6 +12059,6 @@
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	diluted yellow toxic asset	1		Last Available: "2026-08"
 12311	modified spinning intangible asset	1		Last Available: "2026-08"
-12312	boiled jittery mirror liquid asset	1		Effect: "Thunderspell", Effect Duration: 5, Last Available: "2026-08"
+12312	boiled mirror jittery liquid asset	1		Effect: "Thunderspell", Effect Duration: 5, Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Pastamancer_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Platypus_cafe_booze.txt
@@ -3,28 +3,28 @@
 -3	aged shaking Infinitesimal IPA	4	awesome	
 -4	drinkable eggnogtini	3	good	
 -5	perfectly mixed watered-down candycaine	2	EPIC	
--6	lousy strong braincracker sweet	5	decent	
+-6	strong lousy braincracker sweet	5	decent	
 -16	delicious fermented honey	4	awesome	
 -17	bad weak purple moons-shine	2	decent	
--18	practically non-alcoholic bad gin	1	decent	
+-18	bad practically non-alcoholic gin	1	decent	
 -19	mediocre ecto-nog	3	decent	
 -20	acceptable hot toady	3	good	
 -21	hand-crafted hot choculate	4	EPIC	
 -49	artisanal enchanted Cyder	3	EPIC	
 -50	aged watered-down Oil Nog	2	awesome	
 -51	drinkable Hi-Octane Peppermint Jet Fuel	4	good	
--58	weak acceptable ghostly Grimacider	2	good	
+-58	acceptable weak ghostly Grimacider	2	good	
 -59	aged practically non-alcoholic Isotope Nog	1	awesome	
 -60	tolerable Mutagin 'n' Tonic	3	good	
--70	strong smooth Gin and Herring	5	awesome	
+-70	smooth strong Gin and Herring	5	awesome	
 -71	artisanal Black and Tan and Red All Over	4	EPIC	
 -72	tolerable high-proof lime green Antarctic Ice Tea	9	good	
--76	lousy upside-down shaking CRIMBCO Ribbon Candy Schnapps	4	decent	
+-76	lousy shaking upside-down CRIMBCO Ribbon Candy Schnapps	4	decent	
 -77	aged CRIMBCO Egg Substitute Nog Substitute	4	awesome	
--78	fortified tolerable CRIMBCO Extreme Braincracker Sour	5	good	
+-78	tolerable fortified CRIMBCO Extreme Braincracker Sour	5	good	
 -82	spirit-forward lousy Horseradish-infused Vodka	5	decent	
 -83	drinkable Jerkitini	4	good	
--84	mediocre irresponsibly strong Desert Island Iced Tea	10	decent	
+-84	irresponsibly strong mediocre Desert Island Iced Tea	10	decent	
 -88	bad blinking Crimbo Saketini	3	decent	
 -89	smooth Crimboku Drop	4	awesome	
 -90	perfectly mixed Flaming Crimbo Log	4	EPIC	

--- a/data/TCRS/TCRS_Pastamancer_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Platypus_cafe_food.txt
@@ -1,10 +1,10 @@
--1	special flavorless Peche a la Frog	4	decent	
+-1	flavorless special Peche a la Frog	4	decent	
 -2	spoiled As Jus Gezund Heit	3	crappy	
 -3	normal shaking Bouillabaise Coucher Avec Moi	4	good	
 -7	stale immense bouncing gumdrop chow mein	9	decent	
 -8	rotten mirror candy cane pizza	3	crappy	
--9	fancy rotten gingerbread stir-fry	3	crappy	
--10	bite-sized tasty twigs and gravel	1	awesome	
+-9	rotten fancy gingerbread stir-fry	3	crappy	
+-10	tasty bite-sized twigs and gravel	1	awesome	
 -11	stale shoots and leaves	3	decent	
 -12	thick spoiled bowl of unidentifiable goo	5	crappy	
 -13	stale gingerbread massacre	3	decent	
@@ -13,31 +13,31 @@
 -52	decent Soylent Red and Green	3	good	
 -53	spoiled super-sized shaking Disc-Shaped Nutrition Unit	5	crappy	
 -54	adequate Gingerborg Hive	4	good	
--61	tasty bite-sized Candy Cane Surprise	1	awesome	
--62	low-calorie decent Grimdrop Chow Mein	1	good	
+-61	bite-sized tasty Candy Cane Surprise	1	awesome	
+-62	decent low-calorie Grimdrop Chow Mein	1	good	
 -63	big bland Grimgerbread House	5	decent	
--67	diet stale wobbly Caviar Carbonara	1	decent	
--68	bite-sized decent Halibut Alfredo	1	good	
+-67	stale diet wobbly Caviar Carbonara	1	decent	
+-68	decent bite-sized Halibut Alfredo	1	good	
 -69	rotten Red Herring Velvet Cake	3	crappy	
 -73	adequate CRIMBCO Reconstituted Gruel	4	good	
 -74	big decent cyan New and Improved CRIMBCO Reconstituted Gruel	5	good	
 -75	rotten CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	crappy	
--79	low-calorie moldy Brussels Sprout Stir-Fry	1	crappy	
--80	fancy rotten super-sized Carrot, Cabbage, and Kale Pizza	5	crappy	
--81	half-sized normal olive Turnip and Rutabaga Pie	2	good	
+-79	moldy low-calorie Brussels Sprout Stir-Fry	1	crappy	
+-80	rotten super-sized fancy Carrot, Cabbage, and Kale Pizza	5	crappy	
+-81	normal half-sized olive Turnip and Rutabaga Pie	2	good	
 -85	toothsome lime green Rainbow Spider Fun Roll	4	awesome	
--86	enchanted miniature delicious squat wobbly Vegas Volcano Lava Roll	2	awesome	
+-86	miniature enchanted delicious squat wobbly Vegas Volcano Lava Roll	2	awesome	
 -87	tiny flavorless cyan Crazy Dragon Shogun Buddha Roll	1	decent	
 -92	bland basic hot dog	4	decent	
 -93	delicious savage macho dog	3	awesome	
--94	yummy snack-sized wobbly one with everything	2	awesome	
+-94	snack-sized yummy wobbly one with everything	2	awesome	
 -95	special normal miniature blue sly dog	2	good	
--96	tiny delicious devil dog	1	awesome	
+-96	delicious tiny devil dog	1	awesome	
 -97	rotten massive green chilly dog	7	crappy	
 -98	moldy ghost dog	4	crappy	
 -99	bland tumbling junkyard dog	3	decent	
 -100	decent tiny wet dog	1	good	
--101	massive adequate sleeping dog	8	good	
+-101	adequate massive sleeping dog	8	good	
 -102	flavorless optimal dog	3	decent	
 -103	bland thick video games hot dog	5	decent	
 -104	flavorless snack-sized Peppermint Nutrition Block	2	decent	

--- a/data/TCRS/TCRS_Pastamancer_Vole.txt
+++ b/data/TCRS/TCRS_Pastamancer_Vole.txt
@@ -29,7 +29,7 @@
 30	rock	0		
 31	seal-toothed rock	0		
 32	blinking blurry rosy-cheeked Bjorn's Hammer	0		Maximum HP Percent: +30, Class: "Seal Clubber"
-33	mirror squat snorkel	0		Familiar Effect: "atk, cap 2"
+33	squat mirror snorkel	0		Familiar Effect: "atk, cap 2"
 34	ghostly Dolphin King's crown of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "atk, 2xGhuol, cap 8"
 35	shaking rock-hard Knob Goblin scimitar	0		Damage Reduction: 5
 36	yellow Knob Goblin tongs of wisdom	0		Mysticality: +15
@@ -43,9 +43,9 @@
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	blurry figurine	0		
-47	miniature adequate hot buttered roll	2	good	
+47	adequate miniature hot buttered roll	2	good	
 48	narrow spinning heart of rock and roll	0		
-49	adequate miniature tumbling bowl of cottage cheese	2	good	
+49	miniature adequate tumbling bowl of cottage cheese	2	good	
 50	narrow strapping Rock and Roll Legend	0		Muscle: +5, Class: "Accordion Thief", Song Duration: 10
 51	ruddy Knob Goblin Uberpants	0		Maximum HP Percent: +40, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	blurry banjo strings	0		
@@ -66,7 +66,7 @@
 67	skewed spaghetti with rock-balls	0		
 68	wool Rosewater's Pasta Spoon of Peril	0		Mysticality Percent: +30, Cold Resistance: +1, Class: "Pastamancer"
 69	squat Newbiesport&trade; tent	0		
-70	spinning skewed bar skin	0		
+70	skewed spinning bar skin	0		
 71	stakes of the businessman	0		Meat Drop: +50
 72	lime green toasty barskin hat	0		Hot Damage: +5, Familiar Effect: "atk, 1xVolley, cap 13"
 73	barskin tent	0		
@@ -77,7 +77,7 @@
 78	pulsating bouncing pretty bouquet of the early riser	0		Adventures: +7
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	high-proof aged enchanted ice-cold Willer	7	awesome	Effect: "Gleaming White Teeth", Effect Duration: 40
+81	aged enchanted high-proof ice-cold Willer	7	awesome	Effect: "Gleaming White Teeth", Effect Duration: 40
 82	narrow ring	0		
 83	cyan ghostly shaft	0		
 84	Orcish meat locker	0		
@@ -101,9 +101,9 @@
 102	shaking shrunken head	0		
 103	staff of the pedagogue of dire peril	0		Experience: +3, Weapon Damage: +20
 104	scarecrow	0		
-105	special tasty super-sized bowl of charms	5	awesome	Effect: "Mer-kinny Flavor", Effect Duration: 30
+105	tasty special super-sized bowl of charms	5	awesome	Effect: "Mer-kinny Flavor", Effect Duration: 30
 106	ketchup	1	good	
-107	spinning cyan ghostly catsup	1	good	
+107	cyan ghostly spinning catsup	1	good	
 108	stick	0		
 109	shaking crossbow string	0		
 110	upside-down foul-smelling basic meat staff	0		Stench Damage: +10
@@ -167,7 +167,7 @@
 168	bone rattle of the sewer	0		Stench Damage: +25
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	pulsating lihc eye	0		
-171	normal half-sized lihc eye pie	2	good	
+171	half-sized normal lihc eye pie	2	good	
 172	red gnoll lips	0		
 173	squat taco shell	0		
 174	Gnollish casserole dish	0		
@@ -175,7 +175,7 @@
 176	disembodied brain	0		
 177	upside-down brainy skull	0		
 178	detective skull	0		
-179	miniature special spoiled blurry chorizo taco	2	crappy	Effect: "Radium Radicality", Effect Duration: 50
+179	special miniature spoiled blurry chorizo taco	2	crappy	Effect: "Radium Radicality", Effect Duration: 50
 180	lousy ice-cold fotie	4	decent	
 181	lime green baseball	0		
 182	batgut	0		
@@ -185,7 +185,7 @@
 186	bean	0		
 187	loose teeth	0		
 188	spinning bat guano	0		
-189	tumbling jittery guano coffee cup	0		
+189	jittery tumbling guano coffee cup	0		
 191	vibrating batskin belt	0		Maximum MP Percent: +10
 192	batskin belt	0		
 193	bouncing birthday candle	0		
@@ -196,12 +196,12 @@
 198	spinning jittery rat appendix	0		
 199	friendly ring	0		Familiar Weight: +3
 200	adequate small rat appendix kabob	2	good	
-201	spoiled enchanted super-sized bat wing kabob	5	crappy	Effect: "Aloofah", Effect Duration: 15
-202	big moldy carob chunks	5	crappy	
+201	enchanted spoiled super-sized bat wing kabob	5	crappy	Effect: "Aloofah", Effect Duration: 15
+202	moldy big carob chunks	5	crappy	
 203	narrow herbs	0		
-204	jumbo adequate carob chunk cookies	5	good	
+204	adequate jumbo carob chunk cookies	5	good	
 205	secret blend of herbs and spices	0		
-206	ghostly jittery piercing post	0		
+206	jittery ghostly piercing post	0		
 207	hippy herbal tea	1	good	
 208	blurry patchouli incense stick	0		
 209	wad of tofu	0		
@@ -232,47 +232,47 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	brainy Bigger Bugfinder Blade of wisdom	0		Mysticality: 20
 236	Queue Du Coq cocktailcrafting kit	0		
-237	lousy irresponsibly strong bottle of gin	8	decent	
+237	irresponsibly strong lousy bottle of gin	8	decent	
 238	bad blurry bottle of vodka	3	decent	
 239	gravedigger's stiffened Orcish baseball cap	0		Damage Reduction: 1, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	resourceful banded Orcish cargo shorts	0		Damage Absorption: +100, Maximum MP: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	inspector's Orcish frat-paddle	0		Item Drop: +15
 242	stale	4	decent	
-243	stale enchanted spinning grapefruit	3	decent	Effect: "Egg-cellent Vocabulary", Effect Duration: 50
+243	enchanted stale spinning grapefruit	3	decent	Effect: "Egg-cellent Vocabulary", Effect Duration: 50
 244	thick decent tumbling grapes	5	good	
 245	decent olive	3	good	
 246	spoiled thick tomato	5	crappy	
 247	fermenting powder	0		
 248	smooth salty dog	3	awesome	
 249	drinkable strong red bloody mary	5	good	
-250	watered-down lousy screwdriver	2	decent	
+250	lousy watered-down screwdriver	2	decent	
 251	delicious enchanted martini	3	awesome	Effect: "Jungle Juiced", Effect Duration: 45
-252	fancy mediocre weak bloody beer	2	decent	Effect: "Cotton Mouthed", Effect Duration: 15
+252	weak mediocre fancy bloody beer	2	decent	Effect: "Cotton Mouthed", Effect Duration: 15
 253	perfectly mixed boozy blinking shot of schnapps	5	EPIC	
-254	mediocre practically non-alcoholic shot of grapefruit schnapps	1	decent	
+254	practically non-alcoholic mediocre shot of grapefruit schnapps	1	decent	
 255	watered-down smooth fine wine	2	awesome	
 256	drinkable shot of tomato schnapps	3	good	
-257	artisanal watered-down extra-spicy bloody mary	2	EPIC	
+257	watered-down artisanal extra-spicy bloody mary	2	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
 260	rotten White Citadel fries	3	crappy	
 261	adequate White Citadel burger	3	good	
 262	spoiled piece of wedding cake	4	crappy	
 263	tasty chocolate chips	4	awesome	
-264	low-calorie adequate chocolate chip cookies	1	good	
+264	adequate low-calorie chocolate chip cookies	1	good	
 265	wicked satin pants	0		Spell Damage: +5, Familiar Effect: "atk, 2xPotato, cap 10"
 266	watered-down lousy wobbly lightning	2	decent	
 267	groovy mullet wig	0		Moxie Percent: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	wobbly personal trainer's meat cowboy hat	0		Experience Percent (Muscle): +10, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	hardy sword	0		Maximum HP: +50
 270	picket fence	0		
-271	dried gray mirror ghostly barbell	1		
+271	dried gray ghostly mirror barbell	1		
 272	dehydrated concentrated magicalness pill	1		Effect: "Spooky Jellied", Effect Duration: 15
 273	vaporized bouncing moxie weed	1		Effect: "Nightstalkin'", Effect Duration: 25
 274	blinking Familiar-Gro&trade; Terrarium	0		
 275	ghostly mosquito larva	0		
 276	maroon leprechaun hatchling	0		
-277	twisted bouncing narrow extra-strength strongness elixir	1		Effect: "Cancer Rising", Effect Duration: 35
+277	twisted narrow bouncing extra-strength strongness elixir	1		Effect: "Cancer Rising", Effect Duration: 35
 278	mixed spinning jug-o-magicalness	1		
 279	dried skewed suntan lotion of moxiousness	1		Effect: "Hiding in Plain Sight", Effect Duration: 5
 280	Pick-O-Matic lockpicks	0		
@@ -311,23 +311,23 @@
 313	squat smelly Crown of the Goblin King	0		Stench Spell Damage: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	decent huge bean burrito	3	good	
 315	moldy bean burrito	4	crappy	
-316	flavorless miniature insanely bean burrito	2	decent	
+316	miniature flavorless insanely bean burrito	2	decent	
 317	bland bean burrito	3	decent	
-318	diet moldy bean burrito	1	crappy	
+318	moldy diet bean burrito	1	crappy	
 319	moldy squat insanely bean burrito	4	crappy	
-320	jumbo toothsome bat haggis	5	awesome	
-321	half-sized flavorless menudo	2	decent	
+320	toothsome jumbo bat haggis	5	awesome	
+321	flavorless half-sized menudo	2	decent	
 322	super-sized bland goat cheese	5	decent	
-323	half-sized rotten plain pizza	2	crappy	
+323	rotten half-sized plain pizza	2	crappy	
 324	decent sausage pizza	4	good	
 325	bland goat cheese pizza	4	decent	
-326	immense moldy mushroom pizza	7	crappy	
+326	moldy immense mushroom pizza	7	crappy	
 327	goat	0		
 328	tolerable bottle of whiskey	3	good	
 329	goat beard of the cougar	0		Moxie: +20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
 331	bad pulsating Canadian	3	decent	
-332	rotten super-sized twirling lemon	5	crappy	
+332	super-sized rotten twirling lemon	5	crappy	
 333	flavorless lime	4	decent	
 334	smartaleck's sabre teeth	0		Moxie Percent: +30
 335	sabre-toothed lime cub	0		
@@ -345,16 +345,16 @@
 347	huge Dyspepsi-Cola	0		
 348	ninja mask of the early riser	0		Adventures: +7, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
-350	green upside-down hot katana blade	0		
+350	upside-down green hot katana blade	0		
 351	lion tamer's icy-hot katana of the cheetah	0		Experience (familiar): +2, Initiative: +60
 352	cyan rosewater-soaked ninja hot pants	0		Stench Resistance: +3, Familiar Effect: "hot atk, 3xPotato, cap 17"
 353	red ninja stars	0		
 354	skewed bouncing family-friendly manspreader's nunchaku	0		Monster Level: +10, Sleaze Resistance: +1
 355	blurry Temple Grandin's eXtreme scarf	0		Familiar Weight: +7, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	Jack Frost's snowboarder pants	0		Cold Spell Damage: +50, Familiar Effect: "1xPotato, cap 25"
-357	upside-down teal Mountain Stream soda	0		
+357	teal upside-down Mountain Stream soda	0		
 358	bland gr8ps	3	decent	
-359	flavorless immense t8r tots	9	decent	
+359	immense flavorless t8r tots	9	decent	
 360	miner's helmet of Leguizamo	0		Monster Level: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	groovy miner's pants	0		Moxie Percent: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	7-Foot Dwarven mattock of chilblains	0		Cold Damage: +25
@@ -407,7 +407,7 @@
 409	vial of patchouli oil	0		
 410	horrifying sk8board	0		Spooky Damage: +25
 411	Jolly Roger charrrm	0		
-412	pulsating jittery barrrnacle	0		
+412	jittery pulsating barrrnacle	0		
 413	Jolly Roger charrrm bracelet of Tarzan	0		Experience (Muscle): +3
 414	personal trainer's crowbarrr	0		Experience Percent (Muscle): +10
 415	mirror fireproof leotarrrd	0		Hot Resistance: +3, Familiar Effect: "2xVolley, 2xPotato, cap 22"
@@ -421,9 +421,9 @@
 423	unsweetened pulsating cordial of concentration	0		Effect: "Buff as a Baobab", Effect Duration: 18
 424	concentrated energized ointment of the occult	0		Effect: "Healthy Green Glow", Effect Duration: 39
 425	enhanced denatured oil of expertise	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 46
-426	electrified quadruple-unsweetened jittery olive potion of temporary gr8ness	0		Effect: "Nightlit", Effect Duration: 21
+426	electrified quadruple-unsweetened olive jittery potion of temporary gr8ness	0		Effect: "Nightlit", Effect Duration: 21
 427	huge narrow nippy box	0		Cold Damage: +10, Wiki Name: "box"
-428	blurry blue nothing-in-the-box	0		
+428	blue blurry nothing-in-the-box	0		
 429	upside-down beanbag chair	0		
 430	upside-down acid-squirting flower	0		Single Equip
 431	frightening clown shoes	0		Spooky Damage: +5, Clowniness: 25
@@ -431,13 +431,13 @@
 433	skinny balloon	0		
 434	steel-toed balloon helmet	0		Damage Reduction: 9, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	spinning mirror pulsating mansplainer's smooth balloon sword	0		Moxie: +15, Monster Level: +15, Clowniness: 50
-436	mirror upside-down balloon monkey	0		
+436	upside-down mirror balloon monkey	0		
 437	chef skull	0		
 438	tumbling chef-in-the-box	0		
 439	bartender skull	0		
 440	bartender-in-the-box	0		
 441	chef-skull-in-the-box	0		
-442	twirling gray bartender-skull-in-the-box	0		
+442	gray twirling bartender-skull-in-the-box	0		
 443	yellow mirror spinning beer lens	0		
 444	beer goggles	0		
 445	lion tamer's box-in-the-box	0		Experience (familiar): +2
@@ -445,24 +445,24 @@
 447	dance instructor's box-in-the-box-in-the-box	0		Experience Percent (Moxie): +10
 448	resourceful curative foolscap fool's cap	0		Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	razor-sharp clown nose	0		Weapon Damage Percent: +25, Clowniness: 25
-450	tumbling squat pretentious paintbrush	0		
+450	squat tumbling pretentious paintbrush	0		
 451	pretentious palette	0		
 452	disease	0		
 453	sober pill	0		
 454	spinning screwdriver	0		
-455	snack-sized tasty jumbo olive	2	awesome	
+455	tasty snack-sized jumbo olive	2	awesome	
 456	acceptable dry martini	3	good	
 457	blurry ghostly chilly ye olde golde frontes	0		Cold Damage: +5, Class: "Disco Bandit", Single Equip
 458	pulsating continuum transfunctioner	0		
 459	green pixel	0		
-460	wobbly upside-down pixel	0		
+460	upside-down wobbly pixel	0		
 461	jittery pixel	0		
 462	pixel	0		
 463	wobbly pixel	0		
 464	pixel potion	0		
 465	pixel potion	0		
 466	cyan pixel potion	0		
-467	bite-sized bland pixel pie	1	decent	
+467	bland bite-sized pixel pie	1	decent	
 468	ruby W	0		
 469	wussiness potion	0		
 470	hand-crafted bouncing Imp Ale	4	EPIC	
@@ -475,7 +475,7 @@
 477	therapeutic veiny infernal insoles	0		Maximum HP: +10, HP Regen Min: 5, HP Regen Max: 7
 478	skewed evil arch	0		
 479	narrow dodecagram	0		
-480	twirling yellow box of birthday candles	0		
+480	yellow twirling box of birthday candles	0		
 481	eldritch butterknife	0		
 482	beefy Mr. Container	0		Muscle: +10, Last Available: "2004-12"
 483	electrified Newbiesport&trade; backpack	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-12"
@@ -519,7 +519,7 @@
 521	occult kickback cookbook	0		Spell Damage Percent: +25
 522	spinning one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	artisanal fortified ghostly papaya sling	5	EPIC	
+524	fortified artisanal ghostly papaya sling	5	EPIC	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -540,12 +540,12 @@
 542	toasty nippy 1337 7r0uZ0RZ	0		Cold Damage: +10, Hot Damage: +5, Familiar Effect: "2xPotato, cap 27"
 543	flavorless Trollhouse cookies	4	decent	
 544	smelly sage talons	0		Mysticality Percent: +10, Stench Spell Damage: +10
-545	yummy bite-sized Spam Witch sammich	1	awesome	
+545	bite-sized yummy Spam Witch sammich	1	awesome	
 546	tumbling meat vortex	0		
 547	pulsating jittery 334 scroll	0		
 548	huge 668 scroll	0		
 549	30669 scroll	0		
-550	narrow fuchsia 33398 scroll	0		
+550	fuchsia narrow 33398 scroll	0		
 551	squat 64067 scroll	0		
 552	64735 scroll	0		
 553	shaking gray 31337 scroll	0		
@@ -556,7 +556,7 @@
 558	diet decent papaya taco	1	good	
 559	razor-sharp can lid	0		
 560	decent stalk of asparagus	3	good	
-561	squat huge pregnant mushroom	0		
+561	huge squat pregnant mushroom	0		
 562	squat ratgut	0		
 563	sonar-in-a-biscuit	0		
 564	hand-crafted Mad Train wine	3	EPIC	
@@ -578,9 +578,9 @@
 580	shaking sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	special bland blinking tumbling cyan fettucini Inconnu	3	decent	Effect: "Chow Downed", Effect Duration: 5
-584	delicious ghostly red spaghetti with Skullheads	3	awesome	
-585	adequate huge mirror gnocchetti di Nietzsche	4	good	
+583	bland special cyan tumbling blinking fettucini Inconnu	3	decent	Effect: "Chow Downed", Effect Duration: 5
+584	delicious red ghostly spaghetti with Skullheads	3	awesome	
+585	adequate mirror huge gnocchetti di Nietzsche	4	good	
 586	tumbling purple crafty hale ridiculously huge sword	0		Maximum HP: +20, Maximum MP: +10
 587	ionized irradiated yellow super-spiky hair gel	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 36
 588	maroon soft echo eyedrop antidote	0		
@@ -599,7 +599,7 @@
 601	squat Dr. Hobo's map	0		
 602	jittery Degrassi Knoll shopping list	0		
 603	Item #13	0		
-604	spinning pulsating Penultimate Fantasy chest	0		
+604	pulsating spinning Penultimate Fantasy chest	0		
 605	tumbling Tissue Paper Immateria	0		
 606	squat ghostly Tin Foil Immateria	0		
 607	Gauze Immateria	0		
@@ -608,7 +608,7 @@
 610	procrastination potion	0		
 611	D	0		
 612	skewed original G	0		
-613	mirror wobbly plot hole	0		
+613	wobbly mirror plot hole	0		
 614	frozen squat probability potion	0		Effect: "The Halls of Mysticality", Effect Duration: 54
 615	chaos butterfly	0		
 616	furry fur	0		
@@ -622,7 +622,7 @@
 624	NG	0		
 625	gray wang	0		
 626	mirror Wand of Nagamar	0		
-627	blinking spinning ND	0		
+627	spinning blinking ND	0		
 628	blurry metallic A	0		
 629	upside-down chaotic eye	0		Spell Critical Percent: +10
 630	photoprotoneutron torpedo	0		
@@ -634,7 +634,7 @@
 636	red meat globe	0		
 637	toaster	0		
 638	shaking occult asshat of the blizzard	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	rotten enchanted abominable snowcone	3	crappy	Effect: "Supafly", Effect Duration: 20
+639	enchanted rotten abominable snowcone	3	crappy	Effect: "Supafly", Effect Duration: 20
 640	shaking Ent cider	1	awesome	
 641	adequate toast	3	good	
 642	skeleton key	0		
@@ -644,8 +644,8 @@
 646	adequate wobbly fruitcake	3	good	
 647	present	0		Last Available: "2004-11"
 648	narrow Crimbo sword of bravery	0		Spooky Resistance: +5, Last Available: "2004-10"
-649	frosty Crimbo hat	0		Cold Spell Damage: +10, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	blinking scorching Crimbo pants	0		Hot Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	frosty Crimbo hat	0		Cold Spell Damage: +10, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	blinking scorching Crimbo pants	0		Hot Damage: +25, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	shaking exclusive ultra-rare item of the ox	0		Muscle: +20
 652	blurry quantum egg	0		
 653	intragalactic rowboat	0		
@@ -667,9 +667,9 @@
 669	bland snack-sized ghuol guolash	2	decent	
 670	lihc face of the empath	0		Familiar Weight: +5, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	occult thinker's grave robbing shovel	0		Mysticality: +10, Spell Damage Percent: +25
-672	rotten diet cranberries	1	crappy	
-673	lousy squat blue vodka and cranberry	3	decent	
-674	bad irresponsibly strong blurry whiskey	9	decent	
+672	diet rotten cranberries	1	crappy	
+673	lousy blue squat vodka and cranberry	3	decent	
+674	irresponsibly strong bad blurry whiskey	9	decent	
 675	shaking skull of the Bonerdagon of the brute	0		Muscle Percent: +30
 676	dragonbone belt buckle	0		
 677	energetic badass belt	0		Maximum MP Percent: +20
@@ -677,9 +677,9 @@
 679	bad roll in the hay	3	decent	
 680	lousy tumbling slap and tickle	3	decent	
 681	acceptable slip 'n' slide	3	good	
-682	drinkable distilled a sump'm sump'm	5	good	
+682	distilled drinkable a sump'm sump'm	5	good	
 683	drinkable practically non-alcoholic horizontal tango	1	good	
-684	irresponsibly strong perfectly mixed pink pony	6	EPIC	
+684	perfectly mixed irresponsibly strong pink pony	6	EPIC	
 685	gray MacGyver's energetic dangerous Mr. Shirt	0		Weapon Damage: +10, Maximum MP Percent: +20, Maximum MP: +100
 686	jittery teal jittery up-at-dawn knuckles	0		Adventures: +5
 687	concentrated corrupted wobbly blood of the Wereseal	0		Effect: "Armored Innards", Effect Duration: 40
@@ -698,7 +698,7 @@
 701	teal padded floral print shirt	0		Damage Absorption: +20
 702	ghostly baleful coconut bikini top	0		Spell Damage: +25
 703	cyan Socratic goth kid t-shirt	0		Experience (Mysticality): +1
-704	mirror lime green hamethyst	0		
+704	lime green mirror hamethyst	0		
 705	baconstone	0		
 706	porquoise	0		
 707	jittery pork elf goodies sack	0		
@@ -716,7 +716,7 @@
 720	lion tamer's brainy porquoise necklace	0		Mysticality: +5, Experience (familiar): +2, Single Equip
 721	chilly porquoise bracelet of the brute	0		Muscle Percent: +30, Cold Damage: +5
 722	blinking squat reassuring wicked smartaleck's porquoise ring	0		Moxie Percent: +30, Spell Damage: +5, Spooky Resistance: +1, Single Equip
-723	bland miniature olive Knoll mushroom	2	decent	
+723	miniature bland olive Knoll mushroom	2	decent	
 724	big spoiled mushroom	5	crappy	
 725	one million meat pancakes	0		
 726	narrow maroon supercharged huge mirror shard	0		Maximum MP Percent: +30
@@ -731,7 +731,7 @@
 735	narrow wicked easter egg balloon	0		Spell Damage: +5
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	tumbling mirror stone tablet (Really Evil Rhythm)	0		
+738	mirror tumbling stone tablet (Really Evil Rhythm)	0		
 739	tambourine bells	0		
 740	scandalous tambourine	0		Sleaze Damage: +5
 741	squat broken skull	0		
@@ -743,18 +743,18 @@
 748	gourd potion	0		
 749	toothsome warm mushroom	4	awesome	
 750	decent mushroom quesadilla	4	good	
-751	special moldy snack-sized bouncing cool mushroom	2	crappy	Effect: "Vitamin-Maxed", Effect Duration: 40
-752	rotten enchanted spinning cool mushroom casserole	4	crappy	Effect: "Izchak's Blessing", Effect Duration: 30
+751	snack-sized moldy special bouncing cool mushroom	2	crappy	Effect: "Vitamin-Maxed", Effect Duration: 40
+752	enchanted rotten spinning cool mushroom casserole	4	crappy	Effect: "Izchak's Blessing", Effect Duration: 30
 753	bland pointy mushroom	3	decent	
 754	yummy cream of pointy mushroom soup	3	awesome	
 755	spoiled mushroom	3	crappy	
 756	decent mushroom	4	good	
 757	flavorless twirling mushroom	3	decent	
-758	rotten huge fancy huge ghost cucumber	6	crappy	Effect: "Headstrong", Effect Duration: 15
+758	huge fancy rotten huge ghost cucumber	6	crappy	Effect: "Headstrong", Effect Duration: 15
 759	dill	0		
 760	vinegar	0		
 761	brine	0		
-762	mediocre watered-down especially salty dog	2	decent	
+762	watered-down mediocre especially salty dog	2	decent	
 763	maroon ghostly pickling solution	0		
 764	stale spectral pickle	4	decent	
 765	briny vinegar	0		
@@ -778,7 +778,7 @@
 783	'Villa' document	0		
 784	special tolerable watered-down purple Acqua Del Piatto Merlot	2	good	Effect: "Kernel Panic!", Effect Duration: 35, Last Available: "2004-10"
 785	upside-down raffle ticket	0		
-786	stale tumbling blurry red strawberry	4	decent	
+786	stale tumbling red blurry strawberry	4	decent	
 787	perfectly mixed wobbly bottle of rum	3	EPIC	
 788	acceptable strawberry daiquiri	4	good	
 789	artisanal rum and cola	3	EPIC	
@@ -792,35 +792,35 @@
 797	delicious rockin' wagon	3	awesome	
 798	mediocre ocean motion	4	decent	
 799	delicious fuzzbump	4	awesome	
-800	half-sized spoiled poutine	2	crappy	
-801	toothsome blinking bouncing Knob stir-fry	4	awesome	
+800	spoiled half-sized poutine	2	crappy	
+801	toothsome bouncing blinking Knob stir-fry	4	awesome	
 804	moldy bite-sized Knoll stir-fry	1	crappy	
 805	half-sized delicious blurry stir-fry	2	awesome	
 806	decent asparagus stir-fry	3	good	
 807	normal olive stir-fry	3	good	
-808	bite-sized bland Knob sausage stir-fry	1	decent	
+808	bland bite-sized Knob sausage stir-fry	1	decent	
 809	delicious gigantic narrow bat wing stir-fry	9	awesome	
 810	moldy shaking rat appendix stir-fry	4	crappy	
 811	stale thick blurry wobbly tofu stir-fry	5	decent	
-812	moldy massive pr0n stir-fry	6	crappy	
+812	massive moldy pr0n stir-fry	6	crappy	
 813	normal Knob shells	3	good	
 814	toothsome half-sized b&auml;tzle	2	awesome	
 815	spoiled jittery ratini	4	crappy	
 816	flavorless Knob stroganoff	3	decent	
 817	stale menudo ravioli	4	decent	
-818	tumbling squat plus sign	0		
+818	squat tumbling plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
 821	bubbly potion	0		
 822	mirror smoky potion	0		
 823	fuchsia cloudy potion	0		
-824	narrow ghostly effervescent potion	0		
-825	spinning blue fizzy potion	0		
+824	ghostly narrow effervescent potion	0		
+825	blue spinning fizzy potion	0		
 826	dark potion	0		
 827	murky potion	0		
 828	squat baby killer bee	0		
 829	anti-anti-antidote	0		
-830	miniature moldy royal jelly	2	crappy	
+830	moldy miniature royal jelly	2	crappy	
 831	small box	0		
 832	box	0		
 833	spinning resourceful vorpal blade	0		Maximum MP: +50
@@ -829,12 +829,12 @@
 836	toothsome mind flayer corpse	3	awesome	
 837	aged practically non-alcoholic Uovo Marcio Shiraz	1	awesome	Last Available: "2004-10"
 838	blue shaking twirling up-at-dawn ruddy Mafia stogie	0		Maximum HP Percent: +40, Adventures: +5, Last Available: "2004-10"
-839	spirit-forward bad skewed Maiali Sifilitici Pinot Noir	5	decent	Last Available: "2004-10"
+839	bad spirit-forward skewed Maiali Sifilitici Pinot Noir	5	decent	Last Available: "2004-10"
 840	perfumed groovy Mafia violin case	0		Moxie Percent: +10, Stench Resistance: +5, Last Available: "2004-10"
 841	aged tomato daiquiri	3	awesome	
-842	watered-down delicious beertini	2	awesome	
+842	delicious watered-down beertini	2	awesome	
 843	delicious purple salty slug	3	awesome	
-844	lousy enchanted boozy ghostly papaya slung	5	decent	Effect: "Quadrilled", Effect Duration: 35
+844	boozy lousy enchanted ghostly papaya slung	5	decent	Effect: "Quadrilled", Effect Duration: 35
 845	Usain Bolt's MAHI fez	0		Initiative: +80, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	pulsating heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -860,7 +860,7 @@
 869	red forest tears	0		
 870	fetus-smashing club of Flo-Jo	0		Initiative: +100
 871	meatcar model	0		Familiar Weight: +5
-872	yellow ghostly shaking Time Juice	0		Last Available: "2004-01"
+872	ghostly shaking yellow Time Juice	0		Last Available: "2004-01"
 873	lime green rolling pin	0		
 874	unrolling pin	0		
 875	twirling avaricious miser's crafty crazy bastard sword	0		Maximum MP: +10, Meat Drop: 40
@@ -881,7 +881,7 @@
 890	immense decent blurry blurry balaclava baklava	6	good	
 891	Van der Graaf Warehouse 23 bling	0		MP Regen Min: 5, MP Regen Max: 7
 892	curative wizardly bugbear-smiting sword of bravery	0		Mysticality: +25, Spooky Resistance: +5, HP Regen Min: 3, HP Regen Max: 5
-893	practically non-alcoholic bad lumbering jack	1	decent	
+893	bad practically non-alcoholic lumbering jack	1	decent	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	bouncing healthy Ms. Accessory	0		Maximum HP Percent: +20, Softcore Only
 896	tumbling double-paned Lo Pan's Mr. Accessory Jr.	0		Spell Critical Percent: +30, Cold Resistance: +5, Softcore Only
@@ -891,14 +891,14 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	mirror espresso maker	0		Familiar Weight: +5
 902	narrow 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	enchanted acceptable irresponsibly strong blurry Spasmi Dolorosi Del Rene Champagne	6	good	Effect: "Impregnably Delicious", Effect Duration: 15, Last Available: "2004-10"
-904	foul-smelling vibrating school Mafia knickerbockers of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +10, Stench Damage: +10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+903	irresponsibly strong acceptable enchanted blurry Spasmi Dolorosi Del Rene Champagne	6	good	Effect: "Impregnably Delicious", Effect Duration: 15, Last Available: "2004-10"
+904	foul-smelling vibrating school Mafia knickerbockers of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +10, Stench Damage: +10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	oxidized adjusted Yummy Tummy bean	0		Effect: "Nano-juiced", Effect Duration: 38
 906	non-wet Rock Pops	0		Effect: "Pockets of Fire", Effect Duration: 64
 907	energized Mr. Mediocrebar	0		Effect: "Pyromania", Effect Duration: 25
 908	frozen altered Cold Hots candy	0		Effect: "Chow Downed", Effect Duration: 19
-909	warmed bouncing twirling mirror Wint-O-Fresh mint	0		Effect: "Memory of Attractiveness", Effect Duration: 51
-910	stale squat twirling dwarf bread	3	decent	
+909	warmed mirror twirling bouncing Wint-O-Fresh mint	0		Effect: "Memory of Attractiveness", Effect Duration: 51
+910	stale twirling squat dwarf bread	3	decent	
 911	pickled dry cyan bouncing Senior Mints	0		Effect: "Ooh, Umami!", Effect Duration: 42
 912	energized pixellated candy heart	0		Effect: "Stick Emporium Membership", Effect Duration: 64
 913	double-polymerized liquefied kobold	0		Effect: "Lit Up", Effect Duration: 25
@@ -906,10 +906,10 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	pulsating Jack Frost's boxer's intergalactic pom poms	0		Muscle Percent: +10, Cold Spell Damage: +50
 917	Mob Penguin protection contract	0		
-918	banded Radio Free Baseball Cap	0		Damage Absorption: +100, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	extremely unsafe Radio Free Pants	0		Weapon Damage Percent: +100, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	banded Radio Free Baseball Cap	0		Damage Absorption: +100, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	extremely unsafe Radio Free Pants	0		Weapon Damage Percent: +100, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	spinning beefy Radio Free Foil	0		Muscle: +10, Last Available: "2006-07"
-921	small stale radio button candy	2	decent	
+921	stale small radio button candy	2	decent	
 922	mirror beefcake's severed rocking horse head	0		Muscle: +25
 923	jittery broken cellular phone	0		Last Available: "2004-01"
 924	pulsating crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -929,22 +929,22 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	bowler of wisdom	0		Mysticality: +15, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	bowler of wisdom	0		Mysticality: +15, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	censurious banded bow staff	0		Damage Absorption: +100, Sleaze Resistance: +3, Last Available: "2004-12"
-944	blinking bowlegged pants	0		Item Drop: +5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	blinking bowlegged pants	0		Item Drop: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewed skewered cherry	0		Last Available: "2004-12"
 948	lousy martini	4	decent	Last Available: "2004-12"
 949	aged practically non-alcoholic grogtini	1	awesome	Last Available: "2004-12"
-950	hand-crafted weak fancy cherry bomb	2	super ultra mega turbo EPIC	Effect: "Net Tea", Effect Duration: 15, Last Available: "2004-12"
+950	hand-crafted fancy weak cherry bomb	2	super ultra mega turbo EPIC	Effect: "Net Tea", Effect Duration: 15, Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	sizzling hockey mask of incineration	0		Hot Damage: +10, Hot Spell Damage: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	huge narrow penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	skewed quilted fez of etymology	0		Damage Absorption: +40, Familiar Effect: "1xLep, cap 30"
 956	spoiled small carob chunk noodles	2	crappy	
-957	bite-sized rotten chorizo brownies	1	crappy	
+957	rotten bite-sized chorizo brownies	1	crappy	
 958	spoiled squat chocolate and tomato pizza	4	crappy	
 959	flange	0		
 960	clockwork key	0		
@@ -993,21 +993,21 @@
 1006	yummy cherry	4	awesome	
 1007	MacGyver's coconut shell	0		Maximum MP: +100, Familiar Effect: "1xFairy, cap 7"
 1008	dangerous ice cubes	0		Weapon Damage: +10
-1009	perfectly mixed fortified vodka martini	5	EPIC	
+1009	fortified perfectly mixed vodka martini	5	EPIC	
 1010	drinkable blue whiskey and soda	4	good	
 1011	perfectly mixed practically non-alcoholic monkey wrench	1	EPIC	
 1012	practically non-alcoholic acceptable tequila sunrise	1	good	
-1013	practically non-alcoholic hand-crafted margarita	1	EPIC	
-1014	practically non-alcoholic hand-crafted strawberry wine	1	EPIC	
+1013	hand-crafted practically non-alcoholic margarita	1	EPIC	
+1014	hand-crafted practically non-alcoholic strawberry wine	1	EPIC	
 1015	hand-crafted wine spritzer	3	EPIC	
 1016	triple-distilled hand-crafted perpendicular hula	6	EPIC	
 1017	artisanal maroon ducha de oro	3	EPIC	
 1018	weak lousy calle de miel	2	decent	
 1019	mediocre dry vodka martini	4	decent	
 1020	hand-crafted red old-fashioned	4	EPIC	
-1021	weak mediocre tequila with training wheels	2	decent	
-1022	drinkable practically non-alcoholic sangria	1	good	
-1023	extra-dry acceptable vesper	5	good	Last Available: "2004-12"
+1021	mediocre weak tequila with training wheels	2	decent	
+1022	practically non-alcoholic drinkable sangria	1	good	
+1023	acceptable extra-dry vesper	5	good	Last Available: "2004-12"
 1024	artisanal bodyslam	3	super ultra EPIC	Last Available: "2004-12"
 1025	tolerable olive sangria del diablo	4	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
@@ -1029,11 +1029,11 @@
 1043	upside-down string of beads of terror	0		Spooky Spell Damage: +10
 1044	shaking perfumed string of beads	0		Stench Resistance: +5
 1045	spinning crafty plastic bottle opener	0		Maximum MP: +10
-1046	stylish traffic cone of the sewer	0		Moxie: +25, Stench Damage: +25, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	strong bad N. O. Beer	5	decent	
-1048	modified mirror bouncing oyster egg	1		
+1046	stylish traffic cone of the sewer	0		Moxie: +25, Stench Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
+1047	bad strong N. O. Beer	5	decent	
+1048	modified bouncing mirror oyster egg	1		
 1049	modified mirror oyster egg	1		
-1050	altered mirror upside-down oyster egg	1		Effect: "Balls of Ectoplasm", Effect Duration: 5
+1050	altered upside-down mirror oyster egg	1		Effect: "Balls of Ectoplasm", Effect Duration: 5
 1051	teal mirror plastic oyster egg	0		
 1052	altered oyster egg	1		
 1053	dehydrated huge oyster egg	1		
@@ -1058,7 +1058,7 @@
 1072	boiled tumbling off-white oyster egg	1		
 1073	altered off-white oyster egg	1		Effect: "Quaaaaaaa", Effect Duration: 35
 1074	diluted green off-white oyster egg	1		Effect: "Pasty", Effect Duration: 20
-1075	purple bouncing wobbly off-white plastic oyster egg	0		
+1075	bouncing wobbly purple off-white plastic oyster egg	0		
 1076	denatured mirror oyster egg	1		
 1077	pickled oyster egg	1		
 1078	denatured oyster egg	1		
@@ -1067,8 +1067,8 @@
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
-1084	blurry teal rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
-1085	tumbling blurry clockwork widget	0		
+1084	teal blurry rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
+1085	blurry tumbling clockwork widget	0		
 1086	wobbly clockwork thingamajig	0		
 1087	clockwork doohickey	0		
 1088	tumbling clockwork clockwise dome	0		
@@ -1122,21 +1122,21 @@
 1136	magnetized maroon lipstick	0		Effect: "Stone-Faced", Effect Duration: 39
 1137	studded Da Vinci's bicycle chain	0		Experience (Mysticality): +5, Damage Absorption: +80
 1138	skewed mushroom fermenting solution	0		
-1139	practically non-alcoholic mediocre mushroom wine	1	decent	
+1139	mediocre practically non-alcoholic mushroom wine	1	decent	
 1140	artisanal icy mushroom wine	3	EPIC	
-1141	hand-crafted strong mushroom wine	5	EPIC	
+1141	strong hand-crafted mushroom wine	5	EPIC	
 1142	practically non-alcoholic drinkable twirling shaking pointy mushroom wine	1	good	
 1143	lousy high-proof flat mushroom wine	6	decent	
-1144	special aged practically non-alcoholic cool mushroom wine	1	awesome	Effect: "Sharp Weapon", Effect Duration: 45
-1145	weak lousy knob mushroom wine	2	decent	
+1144	practically non-alcoholic aged special cool mushroom wine	1	awesome	Effect: "Sharp Weapon", Effect Duration: 45
+1145	lousy weak knob mushroom wine	2	decent	
 1146	artisanal knoll mushroom wine	3	EPIC	
 1147	delicious huge mushroom wine	4	awesome	
 1148	watered-down tolerable shaking shot of flower schnapps	2	good	
 1149	decent flower petal pie	4	good	
-1150	high-proof artisanal bottle of single-barrel whiskey	8	EPIC	
+1150	artisanal high-proof bottle of single-barrel whiskey	8	EPIC	
 1151	chaotic energetic discarded plastic fork	0		Maximum MP Percent: +20, Spell Critical Percent: +10
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	stale tiny Retenez L'Herbe Pat&eacute;	1	decent	
+1153	tiny stale Retenez L'Herbe Pat&eacute;	1	decent	
 1154	distilled Breathetastic&trade; Premium Canned Air	1	crappy	Effect: "Always be Collecting", Effect Duration: 35
 1155	letter from King Ralph XI	0		
 1157	dangerous wholeberd	0		Weapon Damage: +10
@@ -1183,13 +1183,13 @@
 1198	sabre-toothed lime	0		
 1199	shaking bugbear	0		
 1200	decent mugcake	3	good	
-1201	miniature fancy adequate urinal cake	2	good	Effect: "Mystically Oiled", Effect Duration: 15
+1201	fancy miniature adequate urinal cake	2	good	Effect: "Mystically Oiled", Effect Duration: 15
 1202	decent ghostly Happy Birthday, Claude! cake	4	good	
 1203	rotten yellow personalized birthday cake	3	crappy	
-1204	normal green jittery three-tiered wedding cake	3	good	
+1204	normal jittery green three-tiered wedding cake	3	good	
 1205	adequate small babycakes	2	good	
-1206	snack-sized stale velvet cake	2	decent	
-1207	special bland yellow congratulatory cake	3	decent	Effect: "The Sweats", Effect Duration: 20
+1206	stale snack-sized velvet cake	2	decent	
+1207	bland special yellow congratulatory cake	3	decent	Effect: "The Sweats", Effect Duration: 20
 1208	small stale angel-food cake	2	decent	
 1209	spoiled devil's-food cake	3	crappy	
 1210	stale birthday party jellybean cheesecake	4	decent	
@@ -1233,20 +1233,20 @@
 1249	Boss Bat britches of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	wicked Boss Bat bling of wisdom	0		Mysticality: +15, Spell Damage: +5
 1251	rotten Knob shroomkabob	3	crappy	
-1252	bland snack-sized shroomkabob	2	decent	
+1252	snack-sized bland shroomkabob	2	decent	
 1253	tumbling pile of jumping beans	0		
-1254	bite-sized normal green jumping bean burrito	1	good	
+1254	normal bite-sized green jumping bean burrito	1	good	
 1255	stale miniature jumping bean burrito	2	decent	
 1256	decent insanely jumping bean burrito	3	good	
-1257	bite-sized decent wobbly rat scrapple	1	good	
+1257	decent bite-sized wobbly rat scrapple	1	good	
 1258	pail of pretentious paint	0		
-1259	traffic cone of Tarzan of the blizzard	0		Experience (Muscle): +3, Cold Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	traffic cone of Tarzan of the blizzard	0		Experience (Muscle): +3, Cold Spell Damage: +25, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	cyan wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	distilled pulsating Hatorade	1		
 1262	sinister dance instructor's off-hand balloon of incineration	0		Experience Percent (Moxie): +10, Spell Damage: +10, Hot Spell Damage: +50
 1263	tumbling pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
-1265	twirling lime green box of sunshine	0		Free Pull
+1265	lime green twirling box of sunshine	0		Free Pull
 1266	bland half-sized blurry gloomy mushroom	2	decent	
 1267	yellow blurry dead mimic	0		
 1268	huge pine wand	0		
@@ -1271,7 +1271,7 @@
 1287	flame-wreathed furry kilt	0		Hot Spell Damage: +10, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 1288	avaricious gnauga hide skirt	0		Meat Drop: +30, Familiar Effect: "2.5xFairy, cap 20"
 1289	ghostly gnauga hide kilt	0		Item Drop: +5, Familiar Effect: "2.5xFairy, cap 20"
-1290	wet super-wet blue squat ghostly wind-up clock	0		Effect: "Frosty the Hitman", Effect Duration: 64
+1290	wet super-wet squat ghostly blue wind-up clock	0		Effect: "Frosty the Hitman", Effect Duration: 64
 1291	Jekyllin hide belt of the storm	0		Maximum MP Percent: +40, Softcore Only, Last Available: "2005-09"
 1292	skirt / kilt kit	0		
 1293	huge Herculean ring of adornment	0		Experience (Muscle): +1
@@ -1282,12 +1282,12 @@
 1298	wizardly ring of conflict	0		Mysticality: +25, Single Equip
 1299	pirate hook of the boozehound	0		Booze Drop: +100
 1300	red wobbly studded monster bait	0		Damage Absorption: +80, Single Equip
-1301	flattened ghostly green deodorant	0		Effect: "Thick, Sick", Effect Duration: 39
+1301	flattened green ghostly deodorant	0		Effect: "Thick, Sick", Effect Duration: 39
 1302	magnetized vacuum-sealed cold-filtered upside-down reodorant	0		Effect: "Egg-stortionary Tactics", Effect Duration: 40
 1303	tumbling Mjolnir Jr.	0		
 1304	mirror doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	spinning MacGyver's traffic cone of temperance	0		Maximum MP: +100, Sleaze Resistance: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	spinning MacGyver's traffic cone of temperance	0		Maximum MP: +100, Sleaze Resistance: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	blood flower	0		
 1318	squat lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	flavorless super-sized questionable taco	5	decent	
+1320	super-sized flavorless questionable taco	5	decent	
 1321	spinning Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	shaking petrified time	0		Last Available: "2005-10"
-1323	mirror time helmet of dire peril	0		Weapon Damage: +20, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	time trousers of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	mirror time helmet of dire peril	0		Weapon Damage: +20, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	time trousers of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	Newton's time sword	0		Experience (Mysticality): +3, Last Available: "2005-10"
 1326	miser's Dyspepsi-Cola helmet	0		Meat Drop: +10, Familiar Effect: "3xFairy, cap 7"
 1327	blurry dangerous Cloaca-Cola shield	0		Weapon Damage: +10, Damage Reduction: 4
@@ -1332,12 +1332,12 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	maroon 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	razor-sharp pinky ring	0		Weapon Damage Percent: +25, Single Equip
-1352	bad fancy redrum	4	decent	Effect: "Deeply Ironic", Effect Duration: 5
+1352	fancy bad redrum	4	decent	Effect: "Deeply Ironic", Effect Duration: 5
 1353	ninja pirate zombie robot	0		
-1354	upside-down twirling pile of pebbles	0		
+1354	twirling upside-down pile of pebbles	0		
 1355	tasty bowl of oriole's nest soup	3	awesome	
 1356	pulsating bunny liver	0		
-1357	artisanal fortified skewed Mt. Noob Pale Ale	5	EPIC	
+1357	fortified artisanal skewed Mt. Noob Pale Ale	5	EPIC	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	blinking pirate zombie robot head	0		Last Available: "2005-11"
@@ -1384,13 +1384,13 @@
 1402	rag doll of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2005-12"
 1403	shaking Tesla can of fake snow	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2005-12"
 1404	squat colored-light &quot;necklace&quot;	0		Item Drop: +5, Last Available: "2005-12"
-1405	jittery flame-wreathed tree skirt	0		Hot Spell Damage: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	jittery flame-wreathed tree skirt	0		Hot Spell Damage: +10, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	bite-sized rotten wreath-shaped Crimbo cookie	1	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	stale bell-shaped Crimbo cookie	4	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	jumbo bland tree-shaped Crimbo cookie	5	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	bland jumbo tree-shaped Crimbo cookie	5	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of the glutton	0		Food Drop: +100, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	ionized snowcone	0		Effect: "Held Closer", Effect Duration: 52, Last Available: "2006-01"
 1413	polarized snowcone	0		Effect: "Cranberry Cordiality", Effect Duration: 48, Last Available: "2006-01"
 1414	triple-modified unsweetened huge gray snowcone	0		Effect: "Superhuman Sarcasm", Effect Duration: 63, Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	polymerized mirror snowcone	0		Effect: "In Vino Vires", Effect Duration: 66, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	MacGyver's traffic cone of the ox	0		Muscle: +20, Maximum MP: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	MacGyver's traffic cone of the ox	0		Muscle: +20, Maximum MP: +100, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	energetic stiffened ice sickle	0		Damage Reduction: 1, Maximum MP Percent: +20, Softcore Only, Last Available: "2006-02"
 1425	fortified ice baby	0		Damage Absorption: +60, Softcore Only, Last Available: "2006-02"
-1426	tumbling Newton's ice pick	0		Experience (Mysticality): +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	tumbling Newton's ice pick	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	twirling ice skates of the cheetah of Flo-Jo	0		Initiative: 160, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	delicious grue egg omelette	3	awesome	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	stale upside-down pulsating mushroom	3	decent	
+1432	stale pulsating upside-down mushroom	3	decent	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	upside-down hot pink lipstick	0		Familiar Weight: +5
@@ -1425,27 +1425,27 @@
 1443	super-boiled energized jittery sleaze powder	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 56
 1444	liquefied twirling twinkly nuggets	0		Effect: "Industrial Strength Starch", Effect Duration: 47
 1445	quadruple-unsweetened activated pickled hot nuggets	0		Effect: "Spore-Wreathed", Effect Duration: 62
-1446	magnetized huge shaking red nuggets	0		Effect: "Sleazy Hands", Effect Duration: 44
+1446	magnetized shaking red huge nuggets	0		Effect: "Sleazy Hands", Effect Duration: 44
 1447	extra-unsweetened cold-filtered alkaline nuggets	0		Effect: "Analog Drunk", Effect Duration: 64
 1448	adjusted polarized yellow stench nuggets	0		Effect: "Human-Beast Hybrid", Effect Duration: 49
-1449	irradiated twirling narrow maroon sleaze nuggets	0		Effect: "Red Door Syndrome", Effect Duration: 49
+1449	irradiated maroon twirling narrow sleaze nuggets	0		Effect: "Red Door Syndrome", Effect Duration: 49
 1450	boiled twinkly wad	1		
 1451	modified blue hot wad	1		
 1452	distilled pulsating wad	1		
 1453	denatured wad	1		
-1454	altered pulsating wobbly stench wad	1		
-1455	dried yellow narrow sleaze wad	1		
+1454	altered wobbly pulsating stench wad	1		
+1455	dried narrow yellow sleaze wad	1		
 1456	double daisy	0		
 1457	jittery Goth Giant	0		
 1458	adequate spinning Valentine's Day cake	4	good	
-1459	blurry green arrow'd heart balloon	0		
+1459	green blurry arrow'd heart balloon	0		
 1460	purple velvet box	0		
 1461	squashed frog	0		
 1462	eye of newt	0		
 1463	salamander spleen	0		
 1464	huge sleazy fairy gravy	0		
 1465	suede shortsword	0		
-1466	fuchsia twirling bamboo bokuto	0		
+1466	twirling fuchsia bamboo bokuto	0		
 1467	25-meat staff	0		
 1468	spinning two-handed depthsword	0		
 1469	blurry bill bec-de-bardiche glaive-guisarme	0		
@@ -1474,19 +1474,19 @@
 1492	huge forbidden ninja mop	0		Spell Damage Percent: +50
 1493	mirror friendly dance instructor's ridiculously overelaborate ninja weapon	0		Experience Percent (Moxie): +10, Familiar Weight: +3
 1494	energized squat blurry sugar-coated pine cone	0		Effect: "Helping Comes Second", Effect Duration: 49, Last Available: "2020-09"
-1495	tumbling lion tamer's friendly traffic cone	0		Familiar Weight: +3, Experience (familiar): +2, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	tumbling lion tamer's friendly traffic cone	0		Familiar Weight: +3, Experience (familiar): +2, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	drinkable gloomy mushroom wine	3	good	
-1497	fortified hand-crafted mushroom wine	5	EPIC	
-1498	wobbly McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1497	hand-crafted fortified mushroom wine	5	EPIC	
+1498	wobbly McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	narrow fake fake vomit	0		Last Available: "2006-04"
-1501	pressed diffused huge twirling explosion-flavored chewing gum	0		Effect: "Adrenaline Rush", Effect Duration: 61, Last Available: "2006-04"
+1501	pressed diffused twirling huge explosion-flavored chewing gum	0		Effect: "Adrenaline Rush", Effect Duration: 61, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	blurry rubber emo roe	0		Last Available: "2006-04"
 1504	energized snowcone	0		Effect: "Nightlit", Effect Duration: 46, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	acceptable ghostly blurry calle de miel with a fly in it	3	good	Last Available: "2006-04"
-1507	triple-distilled lousy rockin' wagon with a fly in it	8	decent	Last Available: "2006-04"
+1506	acceptable blurry ghostly calle de miel with a fly in it	3	good	Last Available: "2006-04"
+1507	lousy triple-distilled rockin' wagon with a fly in it	8	decent	Last Available: "2006-04"
 1508	bad perpendicular hula with a fly in it	3	decent	Last Available: "2006-04"
 1509	tolerable slap and tickle with a fly in it	3	good	Last Available: "2006-04"
 1510	bouncing bag of airline peanuts	0		Last Available: "2006-04"
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	pulsating diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	prompt baleful corkscrew	0		Spell Damage: +25, Adventures: +3, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	pulsating fake plastic grass	0		Last Available: "2011-01"
-1531	grass skirt of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	pulsating cyan wool grass hat	0		Cold Resistance: +1, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	grass skirt of the bloodbag	0		Maximum HP: +100, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	pulsating cyan wool grass hat	0		Cold Resistance: +1, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	skewed grass blade of doom	0		Spooky Spell Damage: +50, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	spinning stylish sparkly engagement ring	0		Moxie: +25, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	flame-retardant ruddy Grimacite goggles	0		Maximum HP Percent: +40, Hot Resistance: +1, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	flame-retardant ruddy Grimacite goggles	0		Maximum HP Percent: +40, Hot Resistance: +1, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	squat nippy Temple Grandin's Grimacite glaive	0		Familiar Weight: +7, Cold Damage: +10, Last Available: "2008-10"
-1542	rosewater-soaked smelly Grimacite greaves	0		Stench Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	rosewater-soaked smelly Grimacite greaves	0		Stench Spell Damage: +10, Stench Resistance: +3, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	flame-retardant rock-hard Grimacite garter	0		Damage Reduction: 5, Hot Resistance: +1, Last Available: "2008-10"
 1544	upside-down resourceful Sinatra's Grimacite galoshes	0		Experience (Moxie): +5, Maximum MP: +50, Last Available: "2008-10"
 1545	lime green personal trainer's Grimacite gorget of mayonnaise	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +50, Last Available: "2008-10"
@@ -1529,45 +1529,45 @@
 1549	blinking MSG	0		
 1550	olive second-hand knockoff engagement ring of the boozehound	0		Booze Drop: +100, Single Equip
 1551	practically non-alcoholic perfectly mixed bottle of Domesticated Turkey	1	EPIC	
-1552	watered-down mediocre red bottle of Definit	2	decent	
+1552	mediocre watered-down red bottle of Definit	2	decent	
 1553	lousy bottle of Calcutta Emerald	4	decent	
-1554	weak tolerable bottle of Lieutenant Freeman	2	good	
+1554	tolerable weak bottle of Lieutenant Freeman	2	good	
 1555	artisanal bottle of Jorge Sinsonte	3	EPIC	
-1556	watered-down lousy huge boxed champagne	2	decent	
+1556	lousy watered-down huge boxed champagne	2	decent	
 1557	stale teal kumquat	3	decent	
-1558	bland enchanted tangerine	3	decent	Effect: "Orchid Blood", Effect Duration: 50
+1558	enchanted bland tangerine	3	decent	Effect: "Orchid Blood", Effect Duration: 50
 1559	tonic water	0		
 1560	moldy huge cocktail onion	7	crappy	
 1561	stale raspberry	4	decent	
 1562	stale immense kiwi	7	decent	
 1563	high-proof perfectly mixed whiskey bittersweet	7	EPIC	
-1564	watered-down acceptable wobbly purple mimosette	2	good	
+1564	watered-down acceptable purple wobbly mimosette	2	good	
 1565	acceptable wobbly tequila sunset	4	good	
-1566	bad extra-dry zmobie	5	decent	Wiki Name: "Zmobie (drink)"
+1566	extra-dry bad zmobie	5	decent	Wiki Name: "Zmobie (drink)"
 1567	lousy gin and tonic	3	decent	
 1568	mediocre gray vodka and tonic	3	decent	
 1569	acceptable vodka gibson	4	good	
 1570	drinkable squat gibson	4	good	
 1571	perfectly mixed blue parisian cathouse	3	EPIC	
 1572	acceptable rabbit punch	3	good	
-1573	triple-distilled special acceptable shaking caipifruta	10	good	Effect: "Empty Inside", Effect Duration: 20
+1573	triple-distilled acceptable special shaking caipifruta	10	good	Effect: "Empty Inside", Effect Duration: 20
 1574	tolerable upside-down teqiwila	3	good	
-1575	watered-down enchanted aged Divine	2	awesome	Effect: "Tingly Biceps", Effect Duration: 20
+1575	aged enchanted watered-down Divine	2	awesome	Effect: "Tingly Biceps", Effect Duration: 20
 1576	perfectly mixed triple-distilled skewed Gordon Bennett	6	EPIC	
 1577	strong tolerable tangarita	5	good	
-1578	irresponsibly strong lousy mandarina colada	9	decent	
-1579	watered-down hand-crafted gimlet	2	super ultra EPIC	
+1578	lousy irresponsibly strong mandarina colada	9	decent	
+1579	hand-crafted watered-down gimlet	2	super ultra EPIC	
 1580	tolerable brick road	3	good	
 1581	delicious vodka stratocaster	3	awesome	
 1582	acceptable wobbly Neuromancer	3	good	
 1583	practically non-alcoholic bad prussian cathouse	1	decent	
-1584	tolerable watered-down green Mae West	2	good	
-1585	triple-distilled drinkable Mon Tiki	9	good	
+1584	watered-down tolerable green Mae West	2	good	
+1585	drinkable triple-distilled Mon Tiki	9	good	
 1586	artisanal watered-down green teqiwila slammer	2	super ultra EPIC	
 1587	flavorless tiny Knob lo mein	1	decent	
 1588	rotten asparagus lo mein	3	crappy	
 1589	yummy Knoll lo mein	3	awesome	
-1590	half-sized rotten special lo mein	2	crappy	Effect: "Big Meat Big Prizes", Effect Duration: 40
+1590	special half-sized rotten lo mein	2	crappy	Effect: "Big Meat Big Prizes", Effect Duration: 40
 1591	normal olive lo mein	3	good	
 1592	huge flavorless hot hi mein	6	decent	
 1593	normal hi mein	4	good	
@@ -1577,14 +1577,14 @@
 1597	therapeutic Junior LAAAAME merit badge	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-05"
 1598	wobbly red Oprah's Senior LAAAAME merit badge	0		Maximum MP Percent: +50, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	lousy weak shaking tangarita with a fly in it	2	decent	
-1601	fancy artisanal boozy mandarina colada with a fly in it	5	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 45
+1600	weak lousy shaking tangarita with a fly in it	2	decent	
+1601	fancy boozy artisanal mandarina colada with a fly in it	5	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 45
 1602	perfectly mixed prussian cathouse with a fly in it	3	EPIC	
 1603	lousy weak blurry Mae West with a fly in it	2	decent	
 1604	denatured spinning teal astronaut ice-cream	1		Effect: "Memento Moir&eacute;", Effect Duration: 5, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	altered lime green ultimate wad	1		
-1607	chilled polarized huge twirling libation of liveliness	0		Effect: "New and Improved", Effect Duration: 66
+1607	chilled polarized twirling huge libation of liveliness	0		Effect: "New and Improved", Effect Duration: 66
 1608	triple-altered enhanced eyedrops of the ermine	0		Effect: "Turkey-Ambitious", Effect Duration: 25
 1609	quantum blinking red perfume of prejudice	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 65
 1610	cold-filtered nitrogenated eyedrops of the ocelot	0		Effect: "Very Clean Teeth", Effect Duration: 26
@@ -1592,12 +1592,12 @@
 1612	adjusted unsweetened jittery concentrated cordial of concentration	0		Effect: "Neutered Nostrils", Effect Duration: 12
 1613	coffin lid of horror	0		Spooky Spell Damage: +25, Damage Reduction: 3
 1614	satin shield of the empath	0		Familiar Weight: +5, Damage Reduction: 5
-1615	twirling mirror Jeselnik's Cerebral Cloche	0		Sleaze Damage: +25, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	energetic Cerebral Culottes	0		Maximum MP Percent: +20, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	twirling mirror Jeselnik's Cerebral Cloche	0		Sleaze Damage: +25, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	energetic Cerebral Culottes	0		Maximum MP Percent: +20, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	razor-sharp smartaleck's Cerebral Crossbow of mayonnaise	0		Moxie Percent: +30, Weapon Damage Percent: +25, Sleaze Spell Damage: +50, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
-1620	narrow wobbly homeopathic healing powder	0		Last Available: "2006-06"
+1620	wobbly narrow homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
 1622	quadruple-polarized modified shaking green astral mushroom	0		Effect: "Alacri Tea", Effect Duration: 29, Last Available: "2006-06"
 1623	badger badge	0		Last Available: "2006-06"
@@ -1611,10 +1611,10 @@
 1631	ghostly beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	ghostly Spanish fly	0		
-1634	watered-down bad around the world	2	decent	
+1634	bad watered-down around the world	2	decent	
 1635	ghostly scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
-1637	liquefied upside-down jittery lotion of hotness	0		Effect: "Human-Fish Hybrid", Effect Duration: 19
+1637	liquefied jittery upside-down lotion of hotness	0		Effect: "Human-Fish Hybrid", Effect Duration: 19
 1638	warmed altered tumbling lotion of coldness	0		Effect: "Extra-Wet", Effect Duration: 60
 1639	dry lotion of spookiness	0		Effect: "Cold Hands", Effect Duration: 62
 1640	triple-aerosolized moist spinning skewed lotion of stench	0		Effect: "Powder Power", Effect Duration: 54
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	toothsome foie gras	4	awesome	
 1652	pressed gray candy brain	0		Effect: "Ass Over Teakettle", Effect Duration: 56, Last Available: "2020-09"
-1653	double-paned crafty Fonzie's jewel-eyed wizard hat	0		Experience (Moxie): +1, Maximum MP: +10, Cold Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	double-paned crafty Fonzie's jewel-eyed wizard hat	0		Experience (Moxie): +1, Maximum MP: +10, Cold Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	personal trainer's wad of Crovacite	0		Experience Percent (Muscle): +10, Item Drop: +5
 1655	rosewater-soaked crafty collar	0		Maximum MP: +10, Stench Resistance: +3
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	mirror ore	0		
 1676	olive styrofoam ore	0		
 1677	tumbling bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	blinking wicked sword of the businessman	0		Spell Damage: +5, Meat Drop: +50
 1680	aromatic Jack Frost's staff	0		Cold Spell Damage: +50, Stench Resistance: +1
 1681	double-paned weightlifter's bubblewrap sword	0		Muscle: +15, Cold Resistance: +5
@@ -1681,7 +1681,7 @@
 1701	normal pr0n taco	4	good	
 1702	altered narrow alphabet gum	0		Effect: "Baconstoned", Effect Duration: 63
 1703	upside-down Comma Chameleon egg	0		Free Pull
-1704	mirror upside-down shingle	0		
+1704	upside-down mirror shingle	0		
 1705	flaregun	0		
 1706	manspreader's curative groovy sword	0		Moxie Percent: +10, Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5
 1707	jittery fuchsia blurry sinister flypaper staff of the bloodbag of mayonnaise	0		Spell Damage: +10, Maximum HP: +100, Sleaze Spell Damage: +50
@@ -1746,15 +1746,15 @@
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
 1769	flavorless fricasseed brains	4	decent	
-1770	massive yummy brains casserole	10	awesome	
+1770	yummy massive brains casserole	10	awesome	
 1771	shaking strapping butcherknife	0		Muscle: +5
 1772	forbidden corn holder	0		Spell Damage Percent: +50
 1773	wobbly friendly eggbeater	0		Familiar Weight: +3
 1774	hand-crafted bottle of popskull	3	EPIC	
 1775	ghostly jittery supercharged dishrag	0		Maximum MP Percent: +30
-1776	massive rotten blurry stale baguette	10	crappy	
+1776	rotten massive blurry stale baguette	10	crappy	
 1777	leftovers of indeterminate origin	0		
-1778	snack-sized bland gray dinner	2	decent	
+1778	bland snack-sized gray dinner	2	decent	
 1779	huge steel-toed katana	0		Damage Reduction: 9
 1780	mirror supercharged ram stick	0		Maximum MP Percent: +30
 1781	pulsating enchantlers of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	hand-crafted upside-down Ram's Face Lager	4	EPIC	
 1791	ram horns	0		
-1792	squat blurry Oprah's wholesome Samson's Travoltan trousers	0		Experience (Muscle): +5, Maximum HP Percent: +10, Maximum MP Percent: +50, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	squat blurry Oprah's wholesome Samson's Travoltan trousers	0		Experience (Muscle): +5, Maximum HP Percent: +10, Maximum MP Percent: +50, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	shaking fireproof Da Vinci's pool cue	0		Experience (Mysticality): +5, Hot Resistance: +3
 1794	vacuum-sealed handful of hand chalk	0		Effect: "Fan-Cooled", Effect Duration: 44
 1795	Sinatra's Counterclockwise Watch	0		Experience (Moxie): +5, Single Equip
@@ -1792,7 +1792,7 @@
 1813	fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
-1816	skewed ghostly eighth thoracic vertebra	0		
+1816	ghostly skewed eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	squat tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
@@ -1823,7 +1823,7 @@
 1844	skewed left sixth rib	0		
 1845	left seventh rib	0		
 1846	left eighth rib	0		
-1847	yellow narrow left ninth rib	0		
+1847	narrow yellow left ninth rib	0		
 1848	mirror left tenth rib	0		
 1849	left eleventh rib	0		
 1850	left twelfth rib	0		
@@ -1853,7 +1853,7 @@
 1874	left femur	0		
 1875	narrow right femur	0		
 1876	twirling left tibia	0		
-1877	tumbling narrow right tibia	0		
+1877	narrow tumbling right tibia	0		
 1878	pulsating left fibula	0		
 1879	right fibula	0		
 1880	left kneecap	0		
@@ -1872,7 +1872,7 @@
 1893	jittery left second rear claw	0		
 1894	left third rear claw	0		
 1895	upside-down left fourth rear claw	0		
-1896	blinking narrow right first rear claw	0		
+1896	narrow blinking right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
 1899	right fourth rear claw	0		
@@ -1923,10 +1923,10 @@
 1946	bouncing asbestos-lined accordion pin of Leguizamo	0		Monster Level: +20, Hot Resistance: +5, Class: "Accordion Thief", Single Equip
 1947	dangerous boxer's worn tophat	0		Muscle Percent: +10, Weapon Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	narrow greedy arcane researcher's tap shoes	0		Experience Percent (Mysticality): +10, Meat Drop: +20, Single Equip
-1949	spoiled small Manetwich	2	crappy	
+1949	small spoiled Manetwich	2	crappy	
 1950	ghostly bottle of Vangoghbitussin	0		
 1951	tolerable weak bottle of Pinot Renoir	2	good	
-1952	bite-sized delicious desiccated apricot	1	awesome	
+1952	delicious bite-sized desiccated apricot	1	awesome	
 1953	aged flute of flat champagne	3	awesome	
 1954	stale thick dehydrated caviar	5	decent	
 1955	styrofoam peanuts	0		
@@ -1986,7 +1986,7 @@
 2009	Woldo trading card	0		
 2010	The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
-2012	blue skewed Arrrmetia trading card	0		
+2012	skewed blue Arrrmetia trading card	0		
 2013	Serenity trading card	0		
 2014	Inndya trading card	0		
 2015	Kitty the Zmobie Basher trading card	0		
@@ -1995,13 +1995,13 @@
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
 2020	snack-sized spoiled cherry pie	2	crappy	
-2021	bite-sized adequate strawberry pie	1	good	
+2021	adequate bite-sized strawberry pie	1	good	
 2022	bland small lemon meringue pie	2	decent	
 2023	wobbly Genalen&trade; Bottle	1	good	
 2024	bland massive mixed wildflower greens	7	decent	
 2025	adequate handful of walnuts	4	good	
 2026	normal shaking nutty organic salad	4	good	
-2027	bland special super salad	4	decent	Effect: "Blessing of Charcoatl", Effect Duration: 10
+2027	special bland super salad	4	decent	Effect: "Blessing of Charcoatl", Effect Duration: 10
 2028	spoiled diet tofu wonton	1	crappy	
 2029	hippy protest button	0		Single Equip
 2030	ghostly wizardly Lockenstock&trade; sandals of mayonnaise	0		Mysticality: +25, Sleaze Spell Damage: +50, Single Equip
@@ -2019,16 +2019,16 @@
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	stale gigantic brain-meltingly-hot chicken wings	10	decent	
-2046	diet stale blinking shaking frat brats	1	decent	
+2045	gigantic stale brain-meltingly-hot chicken wings	10	decent	
+2046	stale diet shaking blinking frat brats	1	decent	
 2047	stale enchanted skewed knob ka-bobs	3	decent	Effect: "Abyssal Tears", Effect Duration: 15
-2049	weak hand-crafted can of Swiller	2	EPIC	
+2049	hand-crafted weak can of Swiller	2	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
-2055	wobbly ghostly snake skin	0		
+2055	ghostly wobbly snake skin	0		
 2056	triple-pickled energized adder bladder	0		Effect: "Nutrient-Rich", Effect Duration: 25
 2057	pension check	0		
 2058	picnic basket	0		
@@ -2061,7 +2061,7 @@
 2085	dried blurry bottle of ultravitamins	1		Effect: "Blessing of the Pervy Noodles", Effect Duration: 45
 2086	mixed huge spinning bottle of cough syrup	1		
 2087	dehydrated wobbly purple tube of hair oil	1		Effect: "Moon-Eyed", Effect Duration: 15
-2088	liquefied blinking pulsating Daffy Taffy	0		Effect: "Tiki Temerity", Effect Duration: 41
+2088	liquefied pulsating blinking Daffy Taffy	0		Effect: "Tiki Temerity", Effect Duration: 41
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	Lo Pan's banded baleful educational pilgrim shield of Tarzan	0		Experience: +1, Experience (Muscle): +3, Spell Damage: +25, Damage Absorption: +100, Spell Critical Percent: +30, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
@@ -2073,7 +2073,7 @@
 2097	17-ball of the early riser	0		Adventures: +7
 2098	filthy lucre	0		
 2099	blurry hobo gristle	0		
-2100	fuchsia narrow shredded can label	0		
+2100	narrow fuchsia shredded can label	0		
 2101	bloodstained briquette	0		
 2102	greasy dreadlock	0		
 2103	vial of pirate sweat	0		
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	supercharged prehistoric spear	0		Maximum MP Percent: +30, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	Socratic brawny fire	0		Muscle Percent: +20, Experience (Mysticality): +1, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	Socratic brawny fire	0		Muscle Percent: +20, Experience (Mysticality): +1, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	pulsating leaf tube	0		Last Available: "2006-12"
 2119	teal lit cigar	0		Last Available: "2011-12"
 2120	Grateful Undead T-shirt of the storm	0		Maximum MP Percent: +40
@@ -2123,7 +2123,7 @@
 2148	toothsome rock	0		
 2149	small normal frank	2	good	Last Available: "2011-12"
 2150	stale massive plate of franks and beans	8	decent	Last Available: "2011-12"
-2151	spirit-forward artisanal shot of blackberry schnapps	5	EPIC	
+2151	artisanal spirit-forward shot of blackberry schnapps	5	EPIC	
 2152	pulsating capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	green hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	tumbling family-friendly dangerous toy ray gun	0		Weapon Damage: +10, Sleaze Resistance: +1, Last Available: "2006-12"
-2169	hardened groovy toy space helmet	0		Moxie Percent: +10, Damage Reduction: 3, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	hardened groovy toy space helmet	0		Moxie Percent: +10, Damage Reduction: 3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	inspector's supercool astronaut pants	0		Moxie Percent: +20, Item Drop: +15, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	inspector's supercool astronaut pants	0		Moxie Percent: +20, Item Drop: +15, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	lime green toy jet pack of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	blurry mossy stone sphere	0		
@@ -2155,7 +2155,7 @@
 2180	blurry amulet	0		
 2181	mirror chocolate lump	0		Last Available: "2011-12"
 2182	narrow Harold's hammer head	0		
-2183	twirling spinning lime green Harold's hammer handle	0		
+2183	lime green spinning twirling Harold's hammer handle	0		
 2184	blinking Harold's hammer	0		
 2185	greasy Kiss the Knob apron	0		Sleaze Spell Damage: +10
 2186	unlit birthday cake	0		
@@ -2164,14 +2164,14 @@
 2189	acceptable flask of peppermint schnapps	4	good	Last Available: "2006-12"
 2190	maroon yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	yellow book of carols	0		Last Available: "2006-12"
-2192	blurry tumbling blinking sheet music	0		Last Available: "2006-12"
+2192	blinking tumbling blurry sheet music	0		Last Available: "2006-12"
 2193	decent massive narrow candy stake	10	good	Last Available: "2006-12"
 2194	tolerable blurry eggnog	4	good	Last Available: "2006-12"
 2195	yummy miniature red unspeakable fruitcake	2	awesome	Last Available: "2006-12"
 2196	adequate gingerbread horror	3	good	Last Available: "2006-12"
-2197	triple-pickled ghostly huge yellow but probably evil chocolate	0		Effect: "Powdered", Effect Duration: 24, Last Available: "2006-12"
-2198	spoiled snack-sized bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	adequate gigantic huge skull-shaped Crimboween cookie	10	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2197	triple-pickled huge ghostly yellow but probably evil chocolate	0		Effect: "Powdered", Effect Duration: 24, Last Available: "2006-12"
+2198	snack-sized spoiled bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2199	gigantic adequate huge skull-shaped Crimboween cookie	10	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	delicious snack-sized skewed tombstone-shaped Crimboween cookie	2	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	plastic gift-wrapping vampire of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2006-12"
 2202	prompt plastic yuletide troll	0		Adventures: +3, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	supercharged Crimbo tiki necklace	0		Maximum MP Percent: +30, Last Available: "2006-12"
 2208	maroon family-friendly hardened bobble-hip hula elf doll	0		Damage Reduction: 3, Sleaze Resistance: +1, Last Available: "2006-12"
 2209	slick Crimbo ukulele	0		Moxie: +10, Last Available: "2006-12"
-2210	bouncing avaricious rock-hard Tiki lighter	0		Damage Reduction: 5, Meat Drop: +30, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	bouncing Samson's deck of tropical cards of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	toasty tropical paperweight of bravery	0		Hot Damage: +5, Spooky Resistance: +5, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	bouncing avaricious rock-hard Tiki lighter	0		Damage Reduction: 5, Meat Drop: +30, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	bouncing Samson's deck of tropical cards of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	toasty tropical paperweight of bravery	0		Hot Damage: +5, Spooky Resistance: +5, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	studded Tropical Crimbo Hat	0		Damage Absorption: +80, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	maroon wobbly Tropical Crimbo Shorts of the bloodbag	0		Maximum HP: +100, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	special adequate low-calorie super ka-bob	1	good	Effect: "Think Win-Lose", Effect Duration: 30
+2215	studded Tropical Crimbo Hat	0		Damage Absorption: +80, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	maroon wobbly Tropical Crimbo Shorts of the bloodbag	0		Maximum HP: +100, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2217	adequate low-calorie special super ka-bob	1	good	Effect: "Think Win-Lose", Effect Duration: 30
 2218	rotten bite-sized beer basted brat	1	crappy	
 2219	Tropical Crimbo Sword of the glutton	0		Food Drop: +100, Last Available: "2006-12"
 2220	galvanized and Crimboween candy	0		Effect: "Ironclad", Effect Duration: 38, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	jittery frosty friendly liar's pants	0		Familiar Weight: +3, Cold Spell Damage: +10, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	jittery frosty friendly liar's pants	0		Familiar Weight: +3, Cold Spell Damage: +10, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	blue miser's slick juggler's balls	0		Moxie: +10, Meat Drop: +10, Softcore Only, Last Available: "2007-01"
 2224	tumbling forbidden pink shirt	0		Spell Damage Percent: +50, Softcore Only, Last Available: "2007-01"
 2225	twirling familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2235,7 +2235,7 @@
 2261	spinning hard-boiled ostrich egg	0		
 2262	maroon bird rib	0		
 2263	lion oil	0		
-2264	decent big stunt nuts	5	good	
+2264	big decent stunt nuts	5	good	
 2265	decent wet stew	4	good	
 2266	wet stunt nut stew	0		
 2267	shaking Mega Gem	0		
@@ -2245,7 +2245,7 @@
 2271	enchanted perfectly mixed bottle of Merlot	3	EPIC	Effect: "Haunted Liver", Effect Duration: 20
 2272	drinkable bottle of Port	4	good	
 2273	mediocre tumbling bottle of Pinot Noir	3	decent	
-2274	weak perfectly mixed bouncing bottle of Zinfandel	2	EPIC	
+2274	perfectly mixed weak bouncing bottle of Zinfandel	2	EPIC	
 2275	perfectly mixed fortified bottle of Marsala	5	EPIC	
 2276	bad bottle of Muscat	3	decent	
 2277	Fernswarthy's key	0		
@@ -2271,23 +2271,23 @@
 2297	blinking vial of ectoplasm	0		
 2298	boock of darck magicks	0		
 2299	blurry EZ-Play Harmonica Book	0		
-2300	yellow mirror fingerless hobo gloves	0		
+2300	mirror yellow fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	jittery skewed worm-riding hooks	0		
-2303	blurry Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	blurry Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	wet lime green candy heart	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 43, Last Available: "2007-02"
 2305	anodized pink candy heart	0		Effect: "All Is Forgiven", Effect Duration: 48, Last Available: "2007-02"
-2306	irradiated concentrated tumbling twirling candy heart	0		Effect: "Macho, Macho Dog", Effect Duration: 46, Last Available: "2007-02"
+2306	irradiated concentrated twirling tumbling candy heart	0		Effect: "Macho, Macho Dog", Effect Duration: 46, Last Available: "2007-02"
 2307	chilled triple-wet candy heart	0		Effect: "Ten out of Ten", Effect Duration: 14, Last Available: "2007-02"
 2308	ionized spinning candy heart	0		Effect: "Liquidy Smoky", Effect Duration: 44, Last Available: "2007-02"
-2309	anodized moist green bouncing candy heart	0		Effect: "[1701]Hip to the Jive", Effect Duration: 13, Last Available: "2007-02"
+2309	anodized moist bouncing green candy heart	0		Effect: "[1701]Hip to the Jive", Effect Duration: 13, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	gray blinking pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
 2313	purple candygram	0		Last Available: "2007-02"
 2314	red candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
-2316	pulsating ghostly broken carburetor	0		
+2316	ghostly pulsating broken carburetor	0		
 2317	lime green bronze token	0		
 2318	bomb	0		
 2319	carved wheel	0		
@@ -2303,14 +2303,14 @@
 2329	jittery handful of confetti	0		
 2330	ghostly chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	gigantic rotten upside-down Better Than Cuddling Cake	7	crappy	
+2332	rotten gigantic upside-down Better Than Cuddling Cake	7	crappy	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
 2336	toasty nippy pipe	0		Cold Damage: +10, Hot Damage: +5
 2337	reinforced beaded headband of Leguizamo	0		Monster Level: +20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	flavorless pudding	3	decent	Wiki Name: "black pudding (food)"
-2339	practically non-alcoholic tolerable Blackfly Chardonnay	1	good	
+2339	tolerable practically non-alcoholic Blackfly Chardonnay	1	good	
 2340	mediocre extra-dry & tan	5	decent	
 2341	pepper	0		
 2342	moldy snack-sized upside-down upside-down forest cake	2	crappy	
@@ -2322,7 +2322,7 @@
 2348	water pipe bomb	0		
 2349	gas balloon	0		
 2350	beer bomb	0		
-2351	blurry shaking superamplified boom box	0		
+2351	shaking blurry superamplified boom box	0		
 2352	dog trainer's healthy fire poi	0		Maximum HP Percent: +20, Experience (familiar): +1
 2353	bouncing narrow rosy-cheeked bejeweled pledge pin	0		Maximum HP Percent: +30, Single Equip
 2354	communications windchimes	0		
@@ -2340,7 +2340,7 @@
 2366	ghostly healthy peel hat	0		Maximum HP Percent: +20, Familiar Effect: "atk, 1xVolley"
 2367	carbonated soy milk	0		
 2368	horrifying healthy flowing hippy skirt	0		Maximum HP Percent: +20, Spooky Damage: +25, Familiar Effect: "stench atk, 1xFairy, cap 45"
-2369	teal pulsating filthy poultice	0		
+2369	pulsating teal filthy poultice	0		
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	ghostly squat bunch of bananas	0		
@@ -2400,14 +2400,14 @@
 2426	diffused irradiated fire flower	0		Effect: "PERL of Great Price", Effect Duration: 30
 2427	moist freezerburned ice cube	0		Effect: "Patent Alacrity", Effect Duration: 56
 2428	improved extra-unsweetened olive fake blood	0		Effect: "Stregngth of the Gnome", Effect Duration: 28
-2429	magnetized energized teal upside-down Eau de Guaneau	0		Effect: "Broken Fast", Effect Duration: 17
+2429	magnetized energized upside-down teal Eau de Guaneau	0		Effect: "Broken Fast", Effect Duration: 17
 2430	dry oxidized tumbling bag of lard	0		Effect: "Crusty Head", Effect Duration: 49
 2431	enhanced colloidal bottle of Mystic Shell	0		Effect: "Blessing of Charcoatl", Effect Duration: 36
 2432	tarnished double-chilled SPF 451 lip balm	0		Effect: "Concentration", Effect Duration: 62
 2433	triple-energized bouncing bottle of antifreeze	0		Effect: "Joyful Resolve", Effect Duration: 66
 2434	nitrogenated irradiated eyedrops	0		Effect: "Al Dente Inferno", Effect Duration: 22
 2435	denatured anodized pulsating Dogsgotnonoz pills	0		Effect: "Fit To Be Tide", Effect Duration: 47
-2436	enhanced blue narrow donkey flipbook	0		Effect: "Cold Blooded", Effect Duration: 68
+2436	enhanced narrow blue donkey flipbook	0		Effect: "Cold Blooded", Effect Duration: 68
 2437	tumbling New Cloaca-Cola	0		
 2438	blinking scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
@@ -2435,7 +2435,7 @@
 2462	teal odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	adequate bowl of Bounty-Os	4	good	
-2465	bad practically non-alcoholic squat Oreille Divis&eacute;e brandy	1	decent	
+2465	practically non-alcoholic bad squat Oreille Divis&eacute;e brandy	1	decent	
 2466	pompadour'd puppy	0		
 2467	gray suede shoes	0		Familiar Weight: +5
 2468	upside-down callused fingerbone	0		
@@ -2492,20 +2492,20 @@
 2519	acceptable McMillicancuddy's Special Lager	3	good	
 2520	triple-distilled drinkable melted Jell-o shot	10	good	
 2521	drinkable narrow cruelty-free wine	3	good	
-2522	bad triple-distilled lime green thistle wine	6	decent	
+2522	triple-distilled bad lime green thistle wine	6	decent	
 2523	megatofu	0		
 2524	narrow displaced fish	0		
-2525	moldy fancy lime green fish	4	crappy	Effect: "Make Meat FA$T!", Effect Duration: 45
+2525	fancy moldy lime green fish	4	crappy	Effect: "Make Meat FA$T!", Effect Duration: 45
 2526	fancy adequate fish casserole	3	good	Effect: "Comprehensively Nourished", Effect Duration: 5
 2527	decent snack-sized shaking fish lasagna	2	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	normal gnatloaf	4	good	
 2530	rotten gnatloaf casserole	4	crappy	
-2531	small moldy gnat lasagna	2	crappy	
+2531	moldy small gnat lasagna	2	crappy	
 2532	pork	0		
 2533	rotten pork chop sandwiches	4	crappy	
 2534	spoiled gigantic ghostly pork casserole	6	crappy	
-2535	flavorless enchanted low-calorie ghostly pork lasagna	1	decent	Effect: "Super Structure", Effect Duration: 25
+2535	flavorless low-calorie enchanted ghostly pork lasagna	1	decent	Effect: "Super Structure", Effect Duration: 25
 2536	canopic jar	0		
 2537	spice	0		
 2538	organs	0		
@@ -2516,9 +2516,9 @@
 2543	pressed moist tin magnolia	0		Effect: "Heart of Lavender", Effect Duration: 55, Last Available: "2007-05"
 2544	Vulcanized vacuum-sealed begpwnia	0		Effect: "Armor-Plated", Effect Duration: 57, Last Available: "2007-05"
 2545	ionized upsy daisy	0		Effect: "Pisces Rising", Effect Duration: 39, Last Available: "2007-05"
-2546	vacuum-sealed colloidal energized jittery bouncing half-orchid	0		Effect: "Space Cowboy", Effect Duration: 15, Last Available: "2007-05"
+2546	vacuum-sealed colloidal energized bouncing jittery half-orchid	0		Effect: "Space Cowboy", Effect Duration: 15, Last Available: "2007-05"
 2547	wobbly vibrating tin star of the storm	0		Maximum MP Percent: 50, Last Available: "2007-05"
-2548	scorching outrageous sombrero of the sewer	0		Hot Damage: +25, Stench Damage: +25, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	scorching outrageous sombrero of the sewer	0		Hot Damage: +25, Stench Damage: +25, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	ribald forbidden &quot;Humorous&quot; T-shirt	0		Spell Damage Percent: +50, Sleaze Damage: +10, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2560,8 +2560,8 @@
 2587	grievous Corporal Fennel's Lonely Clubs Club Jacket	0		Weapon Damage Percent: +50
 2588	Private Pepper's Lonely Hearts Club Jacket of dire peril	0		Weapon Damage: +20
 2589	spoiled hot date	4	crappy	
-2590	extra-dry perfectly mixed ghostly distilled fortified wine	5	EPIC	
-2591	low-calorie flavorless tasty tart	1	decent	
+2590	perfectly mixed extra-dry ghostly distilled fortified wine	5	EPIC	
+2591	flavorless low-calorie tasty tart	1	decent	
 2592	Knob Goblin lunchbox	0		
 2593	rotten Knob pasty	4	crappy	
 2594	mediocre shaking thermos full of Knob coffee	3	decent	
@@ -2587,7 +2587,7 @@
 2614	mojo filter	0		
 2615	tasty savoy truffle	3	awesome	
 2616	Magi-Wipes	0		
-2617	shaking teal skewed boom	0		
+2617	skewed teal shaking boom	0		
 2618	Iiti Kitty phone charm of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
 2620	half-sized adequate unidentified jerky	2	good	
@@ -2623,23 +2623,23 @@
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	huge flavorless S.T.L.T.	9	decent	Last Available: "2007-06"
-2653	spoiled miniature purple honey-dew	2	crappy	Last Available: "2007-06"
+2653	miniature spoiled purple honey-dew	2	crappy	Last Available: "2007-06"
 2654	acceptable Xanadian	4	good	Last Available: "2007-06"
 2655	altered aerosolized huge bottle of absinthe	0		Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2007-06"
 2656	bouncing Annie Oakley's Drowsy Sword of the empath	0		Critical Hit Percent: +20, Familiar Weight: +5
 2657	flavorless escargotsicle	3	decent	Last Available: "2007-06"
-2658	mediocre enchanted watered-down bottle of realpagne	2	decent	Effect: "Frozen Hands", Effect Duration: 50, Last Available: "2007-06"
+2658	watered-down mediocre enchanted bottle of realpagne	2	decent	Effect: "Frozen Hands", Effect Duration: 50, Last Available: "2007-06"
 2659	Sherlock's albatross necklace	0		Item Drop: +25, Single Equip, Last Available: "2007-06"
 2660	mixed purple not-a-pipe	1	good	Last Available: "2007-06"
-2661	perfectly mixed practically non-alcoholic tumbling flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
-2662	ball mask of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	wobbly Can-Can skirt of the cheetah	0		Initiative: +60, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2661	practically non-alcoholic perfectly mixed tumbling flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
+2662	ball mask of horror	0		Spooky Spell Damage: +25, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	wobbly Can-Can skirt of the cheetah	0		Initiative: +60, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	extra-galvanized sensitive poetry journal	0		Effect: "Disco Inferno", Effect Duration: 23, Last Available: "2007-06"
 2665	energized polymerized pickled bottled inspiration	0		Effect: "Eyes for Miles", Effect Duration: 62, Last Available: "2007-06"
 2666	vacuum-sealed bellhop bell	0		Effect: "Compensatory Cruelness", Effect Duration: 49, Last Available: "2007-06"
 2667	flattened spiky collar	0		Effect: "Guts Feeling", Effect Duration: 38, Last Available: "2007-06"
 2668	altered mirror can-can-in-a-can	1		Effect: "Disco Neuropathy", Effect Duration: 15, Last Available: "2007-06"
-2669	dehydrated blinking mirror patent antipsychotics	1		Last Available: "2007-06"
+2669	dehydrated mirror blinking patent antipsychotics	1		Last Available: "2007-06"
 2670	compressed Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	drinkable shot of nepenthe schnapps	4	good	Last Available: "2007-06"
 2672	cyan library card	0		Last Available: "2007-06"
@@ -2648,7 +2648,7 @@
 2675	powdered handful of moss	1		Effect: "Inner Dog", Effect Duration: 25
 2676	compressed bit-o-cactus	1		
 2677	boiled protein powder	1		Effect: "Is This Your Card?", Effect Duration: 45
-2678	shaking red spectre scepter	0		
+2678	red shaking spectre scepter	0		
 2679	modified polymerized modified sparkler	0		Effect: "Holiday Bliss", Effect Duration: 21
 2680	polymerized dry snake	0		Effect: "Astral Shell", Effect Duration: 35, Wiki Name: "snake"
 2681	quadruple-diffused M-242	0		Effect: "Heart of Yellow", Effect Duration: 69
@@ -2697,25 +2697,25 @@
 2724	half-sized toothsome bowl of rye sprouts	2	awesome	
 2725	moldy lime green cob of corn	4	crappy	
 2726	big moldy juniper berries	5	crappy	
-2727	massive flavorless plum	7	decent	
+2727	flavorless massive plum	7	decent	
 2728	moldy olive pear	4	crappy	
 2729	flavorless peach	3	decent	
 2730	acceptable weak plum wine	2	good	
-2731	fancy smooth shot of pear schnapps	3	awesome	Effect: "Always In Motion", Effect Duration: 20
+2731	smooth fancy shot of pear schnapps	3	awesome	Effect: "Always In Motion", Effect Duration: 20
 2732	watered-down bad purple shot of peach schnapps	2	decent	
 2733	spoiled bunch of square grapes	3	crappy	
 2734	decent upside-down brown sugar cane	3	good	
 2735	moldy sandwich of the gods	4	crappy	
-2736	tolerable weak skewed upside-down Pan-Dimensional Gargle Blaster	2	good	
-2737	vaporized mirror teal bouncing leopard-print barbell	1	decent	
+2736	weak tolerable upside-down skewed Pan-Dimensional Gargle Blaster	2	good	
+2737	vaporized teal mirror bouncing leopard-print barbell	1	decent	
 2738	skewed pile of smoking rags	0		
 2739	activated huge panty raider camouflage	0		Effect: "Ichorous Intensity", Effect Duration: 31
 2740	wobbly lard-coated vibrating extremely unsafe Staff of the Walk-In Freezer	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Sleaze Spell Damage: +25
 2741	hand-crafted boilermaker	3	EPIC	
 2742	rotten steel lasagna	3	quest	
 2743	boozy perfectly mixed olive steel margarita	5	quest	
-2744	powdered pulsating tumbling steel-scented air freshener	1		
-2745	colloidal aerosolized irradiated ghostly maroon gremlin mutagen	0		Effect: "French Bronilla Brogueishness", Effect Duration: 62
+2744	powdered tumbling pulsating steel-scented air freshener	1		
+2745	colloidal aerosolized irradiated maroon ghostly gremlin mutagen	0		Effect: "French Bronilla Brogueishness", Effect Duration: 62
 2746	modified alkaline extra-potent gremlin mutagen	0		Effect: "Sweetened and Fattened", Effect Duration: 25
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of dire peril	0		Weapon Damage: +20, Single Equip
@@ -2789,9 +2789,9 @@
 2816	purple Sherlock's sinister thinker's Boxers	0		Mysticality: +10, Spell Damage: +10, Item Drop: +25, Familiar Effect: "1xVolley, 1xLep"
 2817	executive smelly Brooch of doom	0		Stench Spell Damage: +10, Spooky Spell Damage: +50, Meat Drop: +40, Single Equip
 2818	Sherlock's foul-smelling flame-wreathed Bracelet	0		Hot Spell Damage: +10, Stench Damage: +10, Item Drop: +25, Single Equip
-2819	skewed Grimacite gasmask of the glutton of Flo-Jo	0		Food Drop: +100, Initiative: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	skewed Grimacite gasmask of the glutton of Flo-Jo	0		Food Drop: +100, Initiative: +100, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	gravedigger's experienced Grimacite gat	0		Experience: +2, Spooky Damage: +10, Last Available: "2008-11"
-2821	extremely unsafe Grimacite gaiters of Calamity Jane	0		Weapon Damage Percent: +100, Critical Hit Percent: +15, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	extremely unsafe Grimacite gaiters of Calamity Jane	0		Weapon Damage Percent: +100, Critical Hit Percent: +15, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	Usain Bolt's Grimacite gauntlets of the cougar	0		Moxie: +20, Initiative: +80, Single Equip, Last Available: "2008-11"
 2823	medical-grade Grimacite go-go boots of the boozehound	0		Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2008-11"
 2824	spinning prompt Grimacite girdle of Gandalf	0		Spell Critical Percent: +20, Adventures: +3, Single Equip, Last Available: "2008-11"
@@ -2803,7 +2803,7 @@
 2830	digital key lime	0		
 2831	huge star key lime	0		
 2832	stale bite-sized purple digital key lime pie	1	decent	
-2833	adequate super-sized star key lime pie	5	good	
+2833	super-sized adequate star key lime pie	5	good	
 2834	bouncing Usain Bolt's flame-wreathed bottle-rocket crossbow of doom	0		Hot Spell Damage: +10, Spooky Spell Damage: +50, Initiative: +80, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	lime green beefcake's indie comic hipster glasses	0		Muscle: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2811,7 +2811,7 @@
 2838	arcane researcher's Samson's glowstick	0		Experience (Muscle): +5, Experience Percent (Mysticality): +10, Last Available: "2007-08"
 2839	brawny Periodical Paintbrush	0		Muscle Percent: +20, Softcore Only
 2840	artisanal bottle of cooking sherry	4	EPIC	
-2841	stale huge jittery packet of ketchup	8	decent	
+2841	huge stale jittery packet of ketchup	8	decent	
 2842	acceptable watered-down blinking maroon accidental cider	2	good	
 2843	stale blue dire fudgesicle	3	decent	
 2844	careful resourceful padded Newton's navel ring of navel gazing	0		Experience (Mysticality): +3, Damage Absorption: +20, Maximum MP: +50, Monster Level: -10, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2830,18 +2830,18 @@
 2857	double-deionized galvanized seegar butt	0		Effect: "Drunk With Power", Effect Duration: 56
 2858	narrow bottled swamp gas	0		
 2859	toasty medical-grade witch wart	0		Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10
-2860	normal gigantic green swamp muck	9	good	
+2860	gigantic normal green swamp muck	9	good	
 2861	yellow steel-toed Da Vinci's leechknife of the glutton	0		Experience (Mysticality): +5, Damage Reduction: 9, Food Drop: +100
-2862	narrow huge decomposed boot	0		
+2862	huge narrow decomposed boot	0		
 2863	vacuum-sealed mirror dribbly candle	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 24
 2864	stolen meatpouch	0		
 2865	smartaleck's supercool beaver spear	0		Moxie Percent: 50
 2866	green resourceful shamanic beads of extreme caution	0		Maximum MP: +50, Monster Level: -25
 2867	squat sharpshooter's therapeutic dilapidated wizard hat	0		Critical Hit Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "cap 31"
 2868	anodized pirate pamphlet	0		Effect: "Badger Underfoot", Effect Duration: 18
-2869	irradiated pulsating twirling pirate brochure	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 68
+2869	irradiated twirling pulsating pirate brochure	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 68
 2870	denatured pirate tract	0		Effect: "Stemonitis Storm", Effect Duration: 40
-2871	pulsating bouncing burnt flower	0		
+2871	bouncing pulsating burnt flower	0		
 2872	cyan Jim Carey's plastic Naughty Sorceress of the glutton	0		Monster Level: +25, Food Drop: +100
 2873	maroon sharpshooter's plastic Ed the Undying of courage	0		Critical Hit Percent: +10, Spooky Resistance: +3
 2874	shaking nippy savvy plastic Lord Spookyraven	0		Mysticality Percent: +20, Cold Damage: +10
@@ -2909,7 +2909,7 @@
 2936	castagnets	0		Familiar Weight: +5
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	jittery Jacob's ladder	0		Familiar Weight: +5
-2939	red twirling unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
+2939	twirling red unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	bland immense Surprise Egg	7	decent	
 2941	unsweetened Steal This Candy	0		Effect: "Wise Spirit", Effect Duration: 54
 2942	colloidal irradiated chocolate filthy lucre	0		Effect: "Flashing Eyes", Effect Duration: 32
@@ -2929,8 +2929,8 @@
 2957	rum barrel charrrm	0		
 2958	bland tube of cranberry Go-Goo	3	decent	
 2959	spinning Annie Oakley's rum barrel charrrm bracelet	0		Critical Hit Percent: +20
-2960	spoiled small single-serving herbal stuffing	2	crappy	
-2961	half-sized moldy packet of tofurkey gravy	2	crappy	
+2960	small spoiled single-serving herbal stuffing	2	crappy	
+2961	moldy half-sized packet of tofurkey gravy	2	crappy	
 2962	decent tofurkey nugget	3	good	
 2963	bouncing rigging shampoo	0		
 2964	ball polish	0		
@@ -2938,17 +2938,17 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	deionized flattened huge Swabbie&trade; swab	0		Effect: "Nutrient-Rich", Effect Duration: 15
 2968	double-deionized tarnished twirling Oil of Parrrlay	0		Effect: "Haunted Stomach", Effect Duration: 29
-2969	tasty snack-sized creamsicle	2	awesome	
+2969	snack-sized tasty creamsicle	2	awesome	
 2970	watered-down perfectly mixed cream stout	2	EPIC	
 2971	narrow quilted smooth curmudgel	0		Moxie: +15, Damage Absorption: +40
 2972	pulsating pulsating grumpy man charrrm	0		
 2973	supercharged grumpy man charrrm bracelet	0		Maximum MP Percent: +30, Single Equip
 2974	tarrrnish charrrm	0		
 2975	mirror beefcake's tarrrnished charrrm bracelet of incineration	0		Muscle: +25, Hot Spell Damage: +50, Single Equip
-2976	triple-distilled bad bilge wine	7	decent	
+2976	bad triple-distilled bilge wine	7	decent	
 2977	witty rapier of bravery	0		Spooky Resistance: +5
 2978	clever yohohoyo of the brute	0		Muscle Percent: +30, Maximum MP: +20
-2979	polymerized spinning mirror fish-liver oil	0		Effect: "Pride of the Vampire", Effect Duration: 35
+2979	polymerized mirror spinning fish-liver oil	0		Effect: "Pride of the Vampire", Effect Duration: 35
 2980	booty chest charrrm	0		
 2981	blurry Temple Grandin's booty chest charrrm bracelet	0		Familiar Weight: +7, Single Equip
 2982	cannonball charrrm	0		
@@ -2962,7 +2962,7 @@
 2990	jittery personal trainer's Newton's clingfilm cap	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Familiar Effect: "1xVolley, cap 37"
 2991	maroon upside-down clingfilm slippers of the businessman	0		Meat Drop: +50, Single Equip
 2992	clingfilm tangle	0		
-2993	thick rotten tumbling vinegar-soaked lemon slice	5	crappy	
+2993	rotten thick tumbling vinegar-soaked lemon slice	5	crappy	
 2994	vacuum-sealed quantum true grit	0		Effect: "Nothing Is Impossible", Effect Duration: 25
 2995	ghostly careful hardened buoybottoms of the boozehound	0		Damage Reduction: 3, Monster Level: -10, Booze Drop: +100, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	wobbly educational grungy flannel shirt	0		Experience: +1
@@ -2974,7 +2974,7 @@
 3002	lam&eacute; pants of doom	0		Spooky Spell Damage: +50, Familiar Effect: "2xPotato, 1xLep, cap 25"
 3003	shaking supercharged enormous hoop earring	0		Maximum MP Percent: +30
 3004	huge MacGyver's costume sword of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100
-3005	ghostly narrow rainbow pearl	0		Last Available: "2007-12"
+3005	narrow ghostly rainbow pearl	0		Last Available: "2007-12"
 3006	rainbow pearl earring of the brute of courage	0		Muscle Percent: +30, Spooky Resistance: +3, Single Equip, Last Available: "2007-12"
 3007	pulsating scandalous fortified rainbow pearl necklace	0		Damage Absorption: +60, Sleaze Damage: +5, Single Equip, Last Available: "2007-12"
 3008	healthy rainbow pearl ring of vim and vigor	0		Maximum HP Percent: 70, Single Equip, Last Available: "2007-12"
@@ -2985,23 +2985,23 @@
 3013	narrow simple key	0		
 3014	blinking ornate key	0		
 3015	fuchsia gilded key	0		
-3016	bouncing blurry foot locker	0		
+3016	blurry bouncing foot locker	0		
 3017	ornate chest	0		
 3018	gilded chest	0		
-3019	teal wobbly all-purpose cleaner	0		
+3019	wobbly teal all-purpose cleaner	0		
 3020	handful of sawdust	0		
 3021	stone triangle	0		
 3022	pulsating medium stone triangle	0		
 3023	bouncing small stone triangle	0		
-3024	blinking skewed maroon stone pyramid	0		
+3024	skewed maroon blinking stone pyramid	0		
 3025	practically non-alcoholic lousy corpse on the beach	1	decent	
 3026	mediocre corpsetini	3	decent	
 3027	boozy mediocre corpsedriver	5	decent	
-3028	watered-down drinkable Corpse Island iced tea	2	good	
+3028	drinkable watered-down Corpse Island iced tea	2	good	
 3029	drinkable practically non-alcoholic red-headed corpse	1	good	
 3030	artisanal kamicorpse-ee	3	EPIC	
 3031	lousy pulsating corpsel	3	decent	
-3032	high-proof lousy squat corpsebite	6	decent	
+3032	lousy high-proof squat corpsebite	6	decent	
 3033	extremely unsafe pirate fledges	0		Weapon Damage Percent: +100
 3034	piece of thirteen	0		
 3035	moldy blinking pearl onion	3	crappy	
@@ -3013,10 +3013,10 @@
 3041	joke scroll	0		
 3042	maroon Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	twirling metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	purple metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	purple metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	toothsome nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
-3046	stale small nanite-infested candy cane	2	decent	Last Available: "2020-09"
-3047	normal super-sized nanite-infested fruitcake	5	good	Last Available: "2007-12"
+3046	small stale nanite-infested candy cane	2	decent	Last Available: "2020-09"
+3047	super-sized normal nanite-infested fruitcake	5	good	Last Available: "2007-12"
 3048	bad nanite-infested eggnog	3	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	electrified eyepatch	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	non-colloidal ghostly candy heart	0		Effect: "Dances with Tweedles", Effect Duration: 15, Last Available: "2007-02"
 3055	extra-enhanced nitrogenated huge cymbal syrup	0		Free Pull, Effect: "Toast Tea", Effect Duration: 18, Last Available: "2007-02"
-3056	Van der Graaf metallic foil cat ears	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	Van der Graaf metallic foil cat ears	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	yellow theoretical string	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	blurry perfumed beefy roboduck-on-a-string	0		Muscle: +10, Stench Resistance: +5, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	pulsating teddy borg sewing kit	0		Last Available: "2007-12"
-3088	blurry biomechanical crimborg helmet of the detective	0		Item Drop: 25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	blurry biomechanical crimborg helmet of the detective	0		Item Drop: 25, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	blinking hale wizardly C.B.F.G.	0		Mysticality: +25, Maximum HP: +20, Last Available: "2007-12"
-3090	shaking ribald biomechanical crimborg leg armor of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	shaking ribald biomechanical crimborg leg armor of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +10, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	chilled liquefied vitachoconutriment capsule	0		Effect: "Yes, Can Haz", Effect Duration: 44, Last Available: "2007-12"
 3092	mirror studded handmade hobby horse	0		Damage Absorption: +80, Last Available: "2007-12"
 3093	razor-sharp ball-in-a-cup	0		Weapon Damage Percent: +25, Last Available: "2007-12"
@@ -3079,14 +3079,14 @@
 3107	squat deactivated RoboGoose	0		Last Available: "2007-12"
 3108	blinking overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	yellow Miniborg stomper	0		Last Available: "2007-12"
-3110	squat maroon Miniborg strangler	0		Last Available: "2007-12"
-3111	upside-down fuchsia Miniborg laser	0		Last Available: "2007-12"
+3110	maroon squat Miniborg strangler	0		Last Available: "2007-12"
+3111	fuchsia upside-down Miniborg laser	0		Last Available: "2007-12"
 3112	huge Miniborg beeper	0		Last Available: "2007-12"
 3113	tumbling Miniborg hiveminder	0		Last Available: "2007-12"
-3114	skewed ghostly Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
+3114	ghostly skewed Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	cyan Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	cyan Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	shaking huge divine noisemaker	0		Last Available: "2008-01"
 3119	twirling divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3129,10 +3129,10 @@
 3157	El Vibrato drone	0		
 3158	sparking El Vibrato drone	0		
 3159	super-tarnished warm El Vibrato drone	0		Effect: "Your Favorite Flavor", Effect Duration: 69
-3160	magnetized pulsating maroon pulsating humming El Vibrato drone	0		Effect: "Sweet and Yellow", Effect Duration: 45
+3160	magnetized pulsating pulsating maroon humming El Vibrato drone	0		Effect: "Sweet and Yellow", Effect Duration: 45
 3161	liquefied warmed El Vibrato drone	0		Effect: "Electrolit Up", Effect Duration: 42
 3162	blinking El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
-3163	jittery tumbling El Vibrato energy spear	0		
+3163	tumbling jittery El Vibrato energy spear	0		
 3164	squat El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
@@ -3155,9 +3155,9 @@
 3183	quantum energized evil tomato juice of powerful power	0		Effect: "Tapped In", Effect Duration: 61
 3184	double-unsweetened huge evil eyedrops of the ermine	0		Effect: "Human-Elf Hybrid", Effect Duration: 44
 3185	enhanced concentrated huge evil ointment of the occult	0		Effect: "Mint-Condition Breath", Effect Duration: 58
-3186	denatured improved denatured pulsating blinking evil serum of sarcasm	0		Effect: "Wallflowering", Effect Duration: 18
+3186	denatured improved denatured blinking pulsating evil serum of sarcasm	0		Effect: "Wallflowering", Effect Duration: 18
 3187	boiled boiled evil philter of phorce	0		Effect: "In the Slimelight", Effect Duration: 12
-3188	hand-crafted maroon skewed an evil sump'm sump'm	3	EPIC	
+3188	hand-crafted skewed maroon an evil sump'm sump'm	3	EPIC	
 3189	smooth evil ducha de oro	4	awesome	
 3190	tolerable evil horizontal tango	3	good	
 3191	bad skewed evil roll in the hay	3	decent	
@@ -3192,11 +3192,11 @@
 3220	hobo code binder	0		Free Pull
 3221	gator skin	0		
 3222	dangerous gatorskin umbrella of horror	0		Weapon Damage: +10, Spooky Spell Damage: +25
-3223	blurry gray sewer nuggets	0		
+3223	gray blurry sewer nuggets	0		
 3224	sewer wad	0		
 3225	mediocre wobbly bottle of sewage schnapps	4	decent	
 3226	perfectly mixed bottle of Ooze-O	3	EPIC	
-3227	tiny tasty jittery C.H.U.M. chum	1	awesome	
+3227	tasty tiny jittery C.H.U.M. chum	1	awesome	
 3228	rotten olive narrow unfortunate dumplings	3	crappy	
 3229	decaying goldfish liver	0		
 3230	boiled double-Vulcanized oil of oiliness	0		Effect: "So You Can Work More...", Effect Duration: 53
@@ -3232,8 +3232,8 @@
 3260	purple nasty Da Vinci's Chester's moustache of the cougar	0		Moxie: +20, Experience (Mysticality): +5, Stench Damage: +5, Class: "Disco Bandit", Single Equip
 3261	scandalous hale Chester's bag of candy	0		Maximum HP: +20, Sleaze Damage: +5, Class: "Disco Bandit"
 3262	knitted crafty Chester's cutoffs	0		Maximum MP: +10, Cold Resistance: +3, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	wobbly Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
-3264	yellow pulsating candygram	0		Last Available: "2008-04"
+3263	wobbly Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3264	pulsating yellow candygram	0		Last Available: "2008-04"
 3265	pulsating bag of Crotchety Pine saplings	0		
 3266	shaking bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
@@ -3264,7 +3264,7 @@
 3292	red adorable seal larva	0		
 3293	untamable turtle	0		
 3294	macaroni duck	0		
-3295	tumbling blinking friendly cheez blob	0		
+3295	blinking tumbling friendly cheez blob	0		
 3296	unusual disco ball	0		
 3297	red stray chihuahua	0		
 3298	pretty pink bow	0		
@@ -3294,7 +3294,7 @@
 3322	green healthy mayfly bait necklace of the pedagogue	0		Experience: +3, Maximum HP Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	acceptable triple-distilled jar of fermented pickle juice	9	good	
+3325	triple-distilled acceptable jar of fermented pickle juice	9	good	
 3326	vaporized voodoo snuff	1	good	Effect: "Eyes of the Dragon", Effect Duration: 15
 3327	normal extra-greasy slider	4	good	
 3328	Annie Oakley's hardy crumpled felt fedora	0		Maximum HP: +50, Critical Hit Percent: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3303,11 +3303,11 @@
 3331	red foul-smelling savvy mostly rat-hide leggings	0		Mysticality Percent: +20, Stench Damage: +10, Familiar Effect: "stench atk, 1xPotato"
 3332	hobo dungarees of vim and vigor of the businessman	0		Maximum HP Percent: +50, Meat Drop: +50, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	tumbling narrow olive Sherlock's scorching patched suit-pants	0		Hot Damage: +25, Item Drop: +25, Familiar Effect: "1xPotato, 0.5xFairy"
-3334	jittery narrow wobbly hobo stogie	0		Single Equip
+3334	narrow jittery wobbly hobo stogie	0		Single Equip
 3335	fuchsia rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	dead guy's memento of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, Single Equip
-3338	miniature spoiled banquet	2	crappy	
+3338	spoiled miniature banquet	2	crappy	
 3339	sharpened hubcap	0		
 3340	skewed very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3332,13 +3332,13 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	toothsome special twirling mole mol&eacute;	3	awesome	Effect: "Eldritch Concentration", Effect Duration: 45, Last Available: "2008-06"
-3364	triple-distilled mediocre fancy twirling Morlock's Mark Bourbon	9	decent	Effect: "Abyssal Blood", Effect Duration: 40, Last Available: "2008-06"
+3363	special toothsome twirling mole mol&eacute;	3	awesome	Effect: "Eldritch Concentration", Effect Duration: 45, Last Available: "2008-06"
+3364	fancy mediocre triple-distilled twirling Morlock's Mark Bourbon	9	decent	Effect: "Abyssal Blood", Effect Duration: 40, Last Available: "2008-06"
 3365	vacuum-sealed Climate Colada	0		Effect: "Rad-ish", Effect Duration: 40, Last Available: "2008-06"
 3366	altered cyan digital underground potion	0		Effect: "Ghost Finger", Effect Duration: 29, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	vaporized glimmering roc feather	1	decent	Effect: "Human-Humanoid Hybrid", Effect Duration: 25, Last Available: "2008-06"
-3369	twisted jittery squat glimmering phoenix feather	1		Effect: "Speed of the Internet", Effect Duration: 15, Last Available: "2008-06"
+3369	twisted squat jittery glimmering phoenix feather	1		Effect: "Speed of the Internet", Effect Duration: 15, Last Available: "2008-06"
 3370	dried purple jittery glimmering penguin feather	1		Last Available: "2008-06"
 3371	dried mirror glimmering buzzard feather	1		Last Available: "2008-06"
 3372	modified glimmering raven feather	1		Effect: "Elvish", Effect Duration: 30, Last Available: "2008-06"
@@ -3369,7 +3369,7 @@
 3397	quilted Hodgman's bow tie of Leguizamo	0		Damage Absorption: +40, Monster Level: +20, Single Equip
 3398	mediocre Hodgman's blanket	3	decent	
 3399	acceptable shaking jar of squeeze	4	good	
-3400	small normal purple spinning bowl of fishysoisse	2	good	
+3400	normal small purple spinning bowl of fishysoisse	2	good	
 3401	modified ghostly deadly lampshade	0		Effect: "Strong Spirit", Effect Duration: 15
 3402	non-pressed corrupted teal concentrated garbage juice	0		Effect: "Frostbeard", Effect Duration: 39
 3403	lewd playing card	0		
@@ -3388,7 +3388,7 @@
 3416	hobo fortress blueprints	0		
 3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	vacuum-sealed boiled upside-down sterno-flavored Hob-O	0		Effect: "Eyes of the Dragon", Effect Duration: 55
-3423	galvanized modified gray blurry frostbite-flavored Hob-O	0		Effect: "Turkey-Agitated", Effect Duration: 22
+3423	galvanized modified blurry gray frostbite-flavored Hob-O	0		Effect: "Turkey-Agitated", Effect Duration: 22
 3424	alkaline aerosolized vacuum-sealed fry-oil-flavored Hob-O	0		Effect: "Fungal Fortification", Effect Duration: 61
 3425	deionized nitrogenated olive garbage-juice-flavored Hob-O	0		Effect: "The Power of Negative Thinking", Effect Duration: 14
 3426	cold-filtered diffused strawberry-flavored Hob-O	0		Effect: "Spiro Gyro", Effect Duration: 22
@@ -3396,7 +3396,7 @@
 3428	activated altered Everlasting Deckswabber	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 35
 3430	bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
-3432	tumbling purple cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
+3432	purple tumbling cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
 3434	wobbly rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	shaking nasty sizzling stirring stick	0		Hot Damage: +10, Stench Damage: +5
@@ -3427,7 +3427,7 @@
 3460	stale mirror blinking tin rations	3	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	watered-down drinkable enchanted bottle of sake	2	good	Effect: "Aries Rising", Effect Duration: 30
+3463	enchanted drinkable watered-down bottle of sake	2	good	Effect: "Aries Rising", Effect Duration: 30
 3464	huge lime green personal trainer's round pebble	0		Experience Percent (Muscle): +10
 3465	super-sized toothsome Bash-&#332;s cereal	5	awesome	Wiki Name: "Bash-Os cereal"
 3466	banded haiku katana of the empath of chilblains	0		Damage Absorption: +100, Familiar Weight: +5, Cold Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
@@ -3438,7 +3438,7 @@
 3471	damp boot	0		
 3472	Tesla baleful smooth Seasonal Beret	0		Moxie: +15, Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
-3474	irradiated dry improved teal shaking cranberry cordial	0		Effect: "Danish Cunning", Effect Duration: 15
+3474	irradiated dry improved shaking teal cranberry cordial	0		Effect: "Danish Cunning", Effect Duration: 15
 3475	extra-Vulcanized colloidal blackberry polite	0		Effect: "Stimulated Body", Effect Duration: 43
 3476	oxidized plum lozenge	0		Effect: "The Solution", Effect Duration: 35
 3477	pickled ionized pear lozenge	0		Effect: "Sweetened and Fattened", Effect Duration: 50
@@ -3450,28 +3450,28 @@
 3483	upside-down psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	extra-flattened non-liquefied tumbling glittery mascara	0		Effect: "In Vino Vires", Effect Duration: 31
-3486	blinking tumbling dull fish scale	0		
+3486	tumbling blinking dull fish scale	0		
 3487	narrow rough fish scale	0		
 3488	shaking pristine fish scale	0		
 3489	spoiled miniature yellow beefy fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3490	moldy glistening fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
-3491	fancy adequate super-sized slick fish meat	5	good	Effect: "Fishy", Effect Duration: 5
+3491	super-sized fancy adequate slick fish meat	5	good	Effect: "Fishy", Effect Duration: 5
 3492	thinker's fish scimitar of James Dean	0		Mysticality: +10, Experience (Moxie): +3
 3493	nasty healthy fish stick	0		Maximum HP Percent: +20, Stench Damage: +5
 3494	gravedigger's educational fish bazooka	0		Experience: +1, Spooky Damage: +10
 3495	quantum moist sea salt crystal	0		Effect: "Empathy", Effect Duration: 29
 3496	liquefied ionized twirling bazookafish bubble gum	0		Effect: "Smoky Third Eye", Effect Duration: 49
 3497	hand-crafted bottle of Pete's Sake	3	EPIC	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	decent green canap&eacute;s	3	good	
 3502	boiled thermos of brew	1	awesome	Last Available: "2011-12"
 3503	hand-crafted glass of brandy	4	EPIC	Last Available: "2011-12"
 3504	blurry French slippers	0		
 3505	nasty LWA ring	0		Stench Damage: +5
 3506	squat LARP membership card	0		Last Available: "2008-10"
-3507	jittery Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	jittery Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	Herculean scratch 'n' sniff sword	0		Experience (Muscle): +1, Last Available: "2008-11"
 3509	red scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3502,7 +3502,7 @@
 3535	green plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
-3538	cyan squat plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
+3538	squat cyan plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
 3540	plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
 3541	plans for depleted Grimacite astrolabe	0		Recipe: "depleted Grimacite astrolabe"
@@ -3510,8 +3510,8 @@
 3543	tumbling clever therapeutic depleted Grimacite gravy boat	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-12"
 3544	red upside-down narrow flame-wreathed depleted Grimacite weightlifting belt of the overflowing toilet	0		Hot Spell Damage: +10, Stench Spell Damage: +50, Single Equip, Last Available: "2011-12"
 3545	up-at-dawn smartaleck's depleted Grimacite grappling hook	0		Moxie Percent: +30, Adventures: +5, Single Equip, Last Available: "2011-12"
-3546	cyan lightning-fast censurious depleted Grimacite ninja mask	0		Sleaze Resistance: +3, Initiative: +40, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	tumbling depleted Grimacite shinguards of the ox of the early riser	0		Muscle: +20, Adventures: +7, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	cyan lightning-fast censurious depleted Grimacite ninja mask	0		Sleaze Resistance: +3, Initiative: +40, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	tumbling depleted Grimacite shinguards of the ox of the early riser	0		Muscle: +20, Adventures: +7, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	mirror flame-wreathed depleted Grimacite astrolabe of the ox	0		Muscle: +20, Hot Spell Damage: +10, Single Equip, Last Available: "2011-12"
 3549	KoL Con Cinco Pi&ntilde;ata Bat of mayonnaise of the detective	0		Sleaze Spell Damage: +50, Item Drop: +20, Softcore Only, Last Available: "2008-09"
 3550	shaking Jack Frost's propeller beanie	0		Cold Spell Damage: +50, Familiar Effect: "atk, cap 7"
@@ -3588,17 +3588,17 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	dance instructor's parasitic claw	0		Experience Percent (Moxie): +10, Last Available: "2008-12"
-3625	Tesla parasitic tentacles	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	extremely unsafe parasitic headgnawer	0		Weapon Damage Percent: +100, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	Tesla parasitic tentacles	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	extremely unsafe parasitic headgnawer	0		Weapon Damage Percent: +100, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	parasitic strangleworm of the ox	0		Muscle: +20, Last Available: "2008-12"
 3628	bouncing pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
-3630	narrow skewed blurry Crimbo crate	0		Last Available: "2008-12"
+3630	narrow blurry skewed Crimbo crate	0		Last Available: "2008-12"
 3631	moist nitrogenated Gummi-DNA	0		Effect: "Spirit of Alph", Effect Duration: 64, Last Available: "2020-09"
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	elven socks of the scaredy-cat	0		Monster Level: -15, Item Drop: +5, Last Available: "2008-12"
 3634	stanky brawny elven gloves	0		Muscle Percent: +20, Stench Spell Damage: +25, Last Available: "2008-12"
-3635	mirror baleful razor-sharp festive holiday hat	0		Weapon Damage Percent: +25, Spell Damage: +25, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	mirror baleful razor-sharp festive holiday hat	0		Weapon Damage Percent: +25, Spell Damage: +25, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	asbestos-lined strapping patent shoes	0		Muscle: +5, Hot Resistance: +5, Last Available: "2008-12"
 3637	reassuring fortified gray bow tie	0		Damage Absorption: +60, Spooky Resistance: +1, Last Available: "2008-12"
 3638	horrifying experienced penguin thesaurus	0		Experience: +2, Spooky Damage: +25, Last Available: "2008-12"
@@ -3609,14 +3609,14 @@
 3643	upside-down blinking pufferfish spine	0		
 3644	wool depleted Grimacite kneecapping stick	0		Cold Resistance: +1, Last Available: "2007-06"
 3645	bad canteen of wine	4	decent	Last Available: "2008-12"
-3646	bite-sized delicious elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
+3646	delicious bite-sized elven <i>limbos</i> gingerbread	1	awesome	Last Available: "2008-12"
 3647	spinning elven whittling knife	0		Last Available: "2008-12"
 3648	bouncing magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	miniature stale squat toast with jam	2	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	tolerable enchanted elven moonshine	3	good	Effect: "Polar Express", Effect Duration: 10, Last Available: "2008-12"
-3653	enchanted adequate immense knuckle sandwich	6	good	Effect: "Top Dog", Effect Duration: 30, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	adequate enchanted immense knuckle sandwich	6	good	Effect: "Top Dog", Effect Duration: 30, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	healthy psycho sweater of temperance	0		Maximum HP Percent: +20, Sleaze Resistance: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	blurry squat slick plastic Mob Penguin	0		Moxie: +10, Last Available: "2008-12"
@@ -3624,9 +3624,9 @@
 3658	flame-wreathed plastic fat stack of cash	0		Hot Spell Damage: +10, Last Available: "2008-12"
 3659	upside-down arcane researcher's plastic strand of DNA	0		Experience Percent (Mysticality): +10, Last Available: "2008-12"
 3660	blue chaotic plastic chunk of depleted Grimacite	0		Spell Critical Percent: +10, Last Available: "2008-12"
-3661	mirror twirling container of Putty	0		Last Available: "2009-01"
-3662	Putty mitre of doom	0		Spooky Spell Damage: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	greasy stiffened Putty leotard	0		Damage Reduction: 1, Sleaze Spell Damage: +10, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3661	twirling mirror container of Putty	0		Last Available: "2009-01"
+3662	Putty mitre of doom	0		Spooky Spell Damage: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	greasy stiffened Putty leotard	0		Damage Reduction: 1, Sleaze Spell Damage: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	nippy Putty ball	0		Cold Damage: +10, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	gravedigger's boxer's Putty snake of extreme caution	0		Muscle Percent: +10, Monster Level: -25, Spooky Damage: +10, Softcore Only, Last Available: "2009-01"
@@ -3635,7 +3635,7 @@
 3669	olive glow-in-the-dark dart gun of the dark arts	0		Spell Damage Percent: +100, Last Available: "2009-01"
 3670	flame-retardant glow-in-the-dark burrowgrub	0		Hot Resistance: +1, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	stale jumbo can of franks 'n' beans	5	decent	Last Available: "2010-12"
+3672	jumbo stale can of franks 'n' beans	5	decent	Last Available: "2010-12"
 3673	perfectly mixed wobbly bottle of peppermint schnapps	4	EPIC	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3647,15 +3647,15 @@
 3681	bubbling tempura batter	0		
 3682	blue globe of Deep Sauce	0		
 3683	red map to the Marinara Trench	0		
-3684	small normal blinking tempura carrot	2	good	
-3685	half-sized rotten tumbling ghostly tempura cucumber	2	crappy	
+3684	normal small blinking tempura carrot	2	good	
+3685	rotten half-sized ghostly tumbling tempura cucumber	2	crappy	
 3686	bland upside-down fuchsia tempura avocado	3	decent	
 3687	moldy sea broccoli	3	crappy	
 3688	stale purple sea cauliflower	3	decent	
-3689	enchanted flavorless tempura broccoli	4	decent	Effect: "Heart of Green", Effect Duration: 35
-3690	stale snack-sized skewed tempura cauliflower	2	decent	
-3691	tiny moldy maroon sea blueberry	1	crappy	
-3692	half-sized rotten sea persimmon	2	crappy	
+3689	flavorless enchanted tempura broccoli	4	decent	Effect: "Heart of Green", Effect Duration: 35
+3690	snack-sized stale skewed tempura cauliflower	2	decent	
+3691	moldy tiny maroon sea blueberry	1	crappy	
+3692	rotten half-sized sea persimmon	2	crappy	
 3693	anodized yellow pressurized potion of perception	0		Effect: "Flashing Eyes", Effect Duration: 39
 3694	corrupted corrupted pressurized potion of proficiency	0		Effect: "Provocative Perkiness", Effect Duration: 39
 3695	shaking greedy Mer-kin digpick	0		Meat Drop: +20
@@ -3664,7 +3664,7 @@
 3698	velcro ore	0		
 3699	teflon ore	0		
 3700	spinning vinyl ore	0		
-3701	bouncing ghostly map to Anemone Mine	0		
+3701	ghostly bouncing map to Anemone Mine	0		
 3702	marine aquamarine	0		
 3703	valve wheel	0		
 3704	waterlogged bootstraps	0		
@@ -3714,24 +3714,24 @@
 3749	pickled concoction of clumsiness	0		Effect: "Holiday Bliss", Effect Duration: 48
 3750	vampire pearl earring of Leguizamo	0		Monster Level: +20, Single Equip
 3751	moldy half-sized upside-down chocolate chip brownies	2	crappy	
-3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	polarized upside-down love song of vague ambiguity	0		Effect: "Neuroplastici Tea", Effect Duration: 69, Last Available: "2009-02"
 3755	adjusted unsweetened love song of smoldering passion	0		Effect: "Holiday Bliss", Effect Duration: 59, Last Available: "2009-02"
-3756	diffused concentrated wobbly lime green love song of icy revenge	0		Effect: "Motion", Effect Duration: 19, Last Available: "2009-02"
+3756	diffused concentrated lime green wobbly love song of icy revenge	0		Effect: "Motion", Effect Duration: 19, Last Available: "2009-02"
 3757	extra-oxidized love song of sugary cuteness	0		Effect: "substats.enh", Effect Duration: 25, Last Available: "2009-02"
 3758	moist super-enhanced love song of disturbing obsession	0		Effect: "Human-Horror Hybrid", Effect Duration: 64, Last Available: "2009-02"
 3759	colloidal non-chilled shaking love song of naughty innuendo	0		Effect: "Well Owl Be!", Effect Duration: 32, Last Available: "2009-02"
 3760	vacuum-sealed improved breath mint	0		Effect: "Object Detection", Effect Duration: 57
 3761	vampire pearl ring of the glutton	0		Food Drop: +100, Single Equip
 3762	huge rosewater-soaked vampire pearl necklace	0		Stench Resistance: +3, Single Equip
-3763	practically non-alcoholic acceptable ghostly slug of vodka	1	good	
+3763	acceptable practically non-alcoholic ghostly slug of vodka	1	good	
 3764	hand-crafted blinking slug of rum	4	EPIC	
 3765	hand-crafted slug of shochu	3	EPIC	
-3766	weak tolerable twirling screwdiver	2	good	
+3766	tolerable weak twirling screwdiver	2	good	
 3767	watered-down artisanal dew yoana lei	2	EPIC	
 3768	triple-distilled tolerable lychee chuhai	7	good	
 3769	drinkable salacious screwdiver	3	good	
-3770	aged weak dew yoana salacious lei	2	awesome	
+3770	weak aged dew yoana salacious lei	2	awesome	
 3771	bad high-proof teal salacious lychee chuhai	10	decent	
 3772	bad high-proof enchanted narrow Alewife&trade; Ale	9	decent	Effect: "Rampage!", Effect Duration: 25
 3773	teal seaode	0		
@@ -3744,17 +3744,17 @@
 3780	toasty nurse's hat of temperance of the cheetah	0		Hot Damage: +5, Sleaze Resistance: +5, Initiative: +60, Familiar Effect: "atk"
 3781	blank prescription sheet	0		
 3782	dehydrated bottle of melodramamine	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 35
-3783	twisted squat blurry bottle of extra-strength melodramamine	1		
+3783	twisted blurry squat bottle of extra-strength melodramamine	1		
 3784	blue bouncing paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
 3786	spinning vampire glitter	0		Class: "Pastamancer"
-3787	gray shaking wine-soaked bone chips	0		Class: "Pastamancer"
+3787	shaking gray wine-soaked bone chips	0		Class: "Pastamancer"
 3788	huge skewed crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	spinning crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	shaking charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	spinning crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	shaking charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	tumbling asbestos-lined mansplainer's rock-hard Mer-kin roundshield	0		Damage Reduction: 19, Monster Level: +15, Hot Resistance: +5
 3804	shaking pulsating forbidden Mer-kin breastplate of the storm	0		Spell Damage Percent: +50, Maximum MP Percent: +40
 3805	jittery pulsating perfumed forbidden Mer-kin sneakmask	0		Spell Damage Percent: +50, Stench Resistance: +5, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3764,15 +3764,15 @@
 3809	blurry Mer-kin healscroll	0		
 3810	ghostly Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	adequate low-calorie chocolate-frosted king cake	1	good	Last Available: "2009-06"
+3812	low-calorie adequate chocolate-frosted king cake	1	good	Last Available: "2009-06"
 3813	Annie Oakley's plastic baby	0		Critical Hit Percent: +20, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	flavorless small teal narrow sea radish	2	decent	
+3817	small flavorless narrow teal sea radish	2	decent	
 3818	spinning zippy greasy rosy-cheeked halibut	0		Maximum HP Percent: +30, Sleaze Spell Damage: +10, Initiative: +20
 3819	eel sauce	0		
 3820	sinister water-polo mitt	0		Spell Damage: +10, Single Equip
-3821	adjusted tarnished squat olive syringe	0		Effect: "Springy Fusilli", Effect Duration: 34
+3821	adjusted tarnished olive squat syringe	0		Effect: "Springy Fusilli", Effect Duration: 34
 3822	wand	0		Familiar Effect: "fishy spells"
 3823	improved upside-down wad of cotton	0		Effect: "Employee of the Month", Effect Duration: 23
 3824	narrow Grandma's Note	0		
@@ -3783,7 +3783,7 @@
 3829	decent jittery tempura radish	3	good	
 3830	weightlifter's water-polo cap	0		Muscle: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	bad fortified tumbling Typical Tavern swill	5	decent	
-3832	artisanal fancy squat tropical swill	3	EPIC	Effect: "Bandersnatched", Effect Duration: 50
+3832	fancy artisanal squat tropical swill	3	EPIC	Effect: "Bandersnatched", Effect Duration: 50
 3833	special drinkable fruity girl swill	4	good	Effect: "You Liver", Effect Duration: 30
 3834	enchanted watered-down artisanal blended swill	2	EPIC	Effect: "The Power of LOV", Effect Duration: 50
 3835	gray costume wardrobe	0		Softcore Only
@@ -3862,7 +3862,7 @@
 3910	pulsating pulsating figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	wobbly imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	acceptable spirit-forward maroon blended swill with a fly in it	5	good	
+3913	spirit-forward acceptable maroon blended swill with a fly in it	5	good	
 3914	turtle wax	0		
 3915	knitted turtle wax shield	0		Cold Resistance: +3, Damage Reduction: 2
 3916	cyan wobbly pulsating thinker's turtle wax helmet	0		Mysticality: +10, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3920,7 +3920,7 @@
 3968	cyan chilly Jim Carey's creepy-ass club of vim and vigor	0		Maximum HP Percent: +50, Monster Level: +25, Cold Damage: +5, Class: "Seal Clubber"
 3969	cold-filtered lime green pulsating sizzling seal fat	0		Effect: "No Worries", Effect Duration: 45
 3970	pulsating scorching Socratic Abyssal ember	0		Experience (Mysticality): +1, Hot Damage: +25, Class: "Seal Clubber"
-3971	colloidal tumbling yellow frost-rimed seal hide	0		Effect: "Grrrrrrreat!", Effect Duration: 41
+3971	colloidal yellow tumbling frost-rimed seal hide	0		Effect: "Grrrrrrreat!", Effect Duration: 41
 3972	aromatic brawny seal spine	0		Muscle Percent: +20, Stench Resistance: +1, Class: "Seal Clubber"
 3973	corrupted maroon seal lube	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 12
 3974	twirling frightening chilly mannequin leg	0		Cold Damage: +5, Spooky Damage: +5, Class: "Seal Clubber"
@@ -3944,7 +3944,7 @@
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	jittery slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
-3995	gray bouncing bundle of chamoix	0		
+3995	bouncing gray bundle of chamoix	0		
 3996	blurry boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	huge metrognome	0		Familiar Weight: +5
@@ -3954,7 +3954,7 @@
 4002	jittery manspreader's tortoboggan shield of the early riser	0		Monster Level: +10, Adventures: +7, Damage Reduction: 6
 4003	huge bottle of moontan lotion	0		
 4004	squat stanky soup-chucks	0		Stench Spell Damage: +25
-4005	non-warmed mirror fuchsia ballast turtle	0		Effect: "Grrrrrrreat!", Effect Duration: 29
+4005	non-warmed fuchsia mirror ballast turtle	0		Effect: "Grrrrrrreat!", Effect Duration: 29
 4006	memory of some amino acids	0		Last Available: "2009-06"
 4007	memory of a C	0		Last Available: "2009-06"
 4008	memory of an A	0		Last Available: "2009-06"
@@ -3985,20 +3985,20 @@
 4033	yellow memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
-4036	bouncing pulsating caustic slime nodule	0		
-4037	flavorless snack-sized slimy sweetbreads	2	decent	
-4038	aged weak upside-down slimy fermented bile bladder	2	awesome	
+4036	pulsating bouncing caustic slime nodule	0		
+4037	snack-sized flavorless slimy sweetbreads	2	decent	
+4038	weak aged upside-down slimy fermented bile bladder	2	awesome	
 4039	mixed slimy alveolus	1		
 4040	blurry memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	spinning Temple Grandin's Newton's pig-iron helm	0		Experience (Mysticality): +3, Familiar Weight: +7, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	cyan sharpshooter's sinister pig-iron shinguards	0		Spell Damage: +10, Critical Hit Percent: +10, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	spinning Temple Grandin's Newton's pig-iron helm	0		Experience (Mysticality): +3, Familiar Weight: +7, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	cyan sharpshooter's sinister pig-iron shinguards	0		Spell Damage: +10, Critical Hit Percent: +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	twirling reassuring knitted pig-iron bracers	0		Cold Resistance: +3, Spooky Resistance: +1, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	pulsating wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	wobbly vibrating wumpus-hair whip	0		Maximum MP Percent: +10, Last Available: "2009-06"
-4048	stiffened savvy wumpus-hair wig of the storm	0		Mysticality Percent: +20, Damage Reduction: 1, Maximum MP Percent: +40, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	double-paned Lo Pan's sharpshooter's wumpus-hair loincloth	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Cold Resistance: +5, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	stiffened savvy wumpus-hair wig of the storm	0		Mysticality Percent: +20, Damage Reduction: 1, Maximum MP Percent: +40, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	double-paned Lo Pan's sharpshooter's wumpus-hair loincloth	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Cold Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	jittery twirling wumpus-hair sweater of Tarzan of Calamity Jane	0		Experience (Muscle): +3, Critical Hit Percent: +15, Last Available: "2009-06"
 4051	mirror clever ring of teleportation	0		Maximum MP: +20, Single Equip
 4052	enchanted bouncing glass of baboon milk	1	awesome	Effect: "You Can Taste the Darkness", Effect Duration: 50, Last Available: "2009-06"
@@ -4032,9 +4032,9 @@
 4080	ghostly vibrating Newton's grisly shield	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Slime Hates It: +1, Damage Reduction: 13
 4081	corroded breeches of the wise owl of the glutton	0		Mysticality: +20, Food Drop: +100, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	Lo Pan's beefcake's pernicious cudgel	0		Muscle: +25, Spell Critical Percent: +30, Slime Hates It: +1
-4083	rotten thick green cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
+4083	thick rotten green cupcake-in-a-cup	5	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	spoiled enchanted protein paste	4	crappy	Effect: "Action", Effect Duration: 35, Last Available: "2009-06"
+4085	enchanted spoiled protein paste	4	crappy	Effect: "Action", Effect Duration: 35, Last Available: "2009-06"
 4086	rosewater-soaked cyber-mattock of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +3, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4095,7 +4095,7 @@
 4143	a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	funny paper hat of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	alkaline bouncing green sand	0		Effect: "Towering Strength", Effect Duration: 37
+4146	alkaline green bouncing sand	0		Effect: "Towering Strength", Effect Duration: 37
 4147	wobbly charged magnet of dire peril of the overflowing toilet	0		Weapon Damage: +20, Stench Spell Damage: +50, Last Available: "2009-09"
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
@@ -4130,8 +4130,8 @@
 4178	cyan boxer's sugar shotgun	0		Muscle Percent: +10, Last Available: "2009-09"
 4179	lion tamer's sugar shillelagh	0		Experience (familiar): +2, Last Available: "2009-09"
 4180	sinister sugar shank	0		Spell Damage: +10, Last Available: "2009-09"
-4181	spinning therapeutic sugar chapeau of chilblains of the blizzard	0		Cold Damage: +25, Cold Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	twirling stylish sugar shorts	0		Moxie: +25, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	spinning therapeutic sugar chapeau of chilblains of the blizzard	0		Cold Damage: +25, Cold Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	twirling stylish sugar shorts	0		Moxie: +25, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4141,7 +4141,7 @@
 4189	inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	bouncing supercharged sugar shirt	0		Maximum MP Percent: +30, Last Available: "2009-09"
-4192	yellow pulsating sugar shard	0		Last Available: "2009-09"
+4192	pulsating yellow sugar shard	0		Last Available: "2009-09"
 4193	Sherlock's rave visor	0		Item Drop: +25, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
 4194	ribald baggy rave pants	0		Sleaze Damage: +10, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 4195	olive lard-coated pacifier necklace	0		Sleaze Spell Damage: +25, Single Equip
@@ -4178,7 +4178,7 @@
 4226	tumbling upside-down inspector's Star of Bravery	0		Item Drop: +15, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	blurry perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	shaking blurry bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	fuchsia ice skate doll	0		
@@ -4196,25 +4196,25 @@
 4244	thinker's leather-bound tome	0		Mysticality: +10
 4245	pulsating bookmark	0		
 4246	flame-retardant ivory cue ball	0		Hot Resistance: +1
-4247	artisanal watered-down blurry decanter of fine Scotch	2	super ultra mega EPIC	
+4247	watered-down artisanal blurry decanter of fine Scotch	2	super ultra mega EPIC	
 4248	modified mirror expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	double-alkaline blinking vial of squid ink	0		Effect: "Memento Moir&eacute;", Effect Duration: 27
 4253	enhanced vacuum-sealed potion of speed	0		Effect: "Blackberry Politeness", Effect Duration: 60
-4254	lime green ghostly bark	0		Last Available: "2009-10"
+4254	ghostly lime green bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	quadruple-nitrogenated Vulcanized tarnished sap	0		Effect: "So Fresh and So Clean", Effect Duration: 66, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	flavorless chocolate-covered scarab beetle	3	decent	Last Available: "2009-10"
 4259	strong aged mulled cider	5	awesome	Last Available: "2009-10"
-4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	jittery pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	jittery pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	jittery Ax of L'rose	0		Last Available: "2009-10"
-4264	squat wicked bark boxers	0		Spell Damage: +5, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	wobbly mirror bark beret of chilblains	0		Cold Damage: +25, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	squat wicked bark boxers	0		Spell Damage: +5, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	wobbly mirror bark beret of chilblains	0		Cold Damage: +25, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	hardened bark bracelet	0		Damage Reduction: 3, Single Equip
 4267	wicked Krakrox's Loincloth of the sewer	0		Spell Damage: +5, Stench Damage: +25, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	up-at-dawn Usain Bolt's Galapagosian Cuisses	0		Initiative: +80, Adventures: +5, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4229,7 +4229,7 @@
 4277	chilly dance instructor's slick Staff of the Woodfire	0		Moxie: +10, Experience Percent (Moxie): +10, Cold Damage: +5, Last Available: "2009-10"
 4278	wholesome sinister Underworld flail of Flo-Jo	0		Spell Damage: +10, Maximum HP Percent: +10, Initiative: +100, Last Available: "2009-10"
 4279	Mer-kin cancerstick	0		
-4280	wobbly bouncing Mer-kin sawdust	0		
+4280	bouncing wobbly Mer-kin sawdust	0		
 4281	spinning yellow scorching Mer-kin bunwig of the detective	0		Hot Damage: +25, Item Drop: +20, Familiar Effect: "1xVolley"
 4282	wobbly greedy double-paned crappy Mer-kin mask of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +5, Meat Drop: +20, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
 4283	hale crappy Mer-kin tailpiece of bravery	0		Maximum HP: +20, Spooky Resistance: +5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -4277,12 +4277,12 @@
 4325	family-friendly Da Vinci's Gravyskin Belt of the Sauceblob of courage	0		Experience (Mysticality): +5, Spooky Resistance: +3, Sleaze Resistance: +1, Class: "Sauceror", Single Equip
 4326	executive Jim Carey's supercool Bling of the New Wave	0		Moxie Percent: +20, Monster Level: +25, Meat Drop: +40, Class: "Disco Bandit", Single Equip
 4327	ribald La Hebilla del Cintur&oacute;n de Lopez of wisdom of Calamity Jane	0		Mysticality: +15, Critical Hit Percent: +15, Sleaze Damage: +10, Class: "Accordion Thief", Single Equip
-4328	ghostly twirling suspicious stocking	0		Free Pull, Last Available: "2009-12"
+4328	twirling ghostly suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	big adequate candy kneecapping stick	5	good	Last Available: "2009-12"
+4330	adequate big candy kneecapping stick	5	good	Last Available: "2009-12"
 4331	normal licorice garrote	4	good	Last Available: "2009-12"
 4332	foul-smelling candy knuckles	0		Stench Damage: +10, Last Available: "2009-12"
-4333	yummy huge blinking jawbruiser	10	awesome	Last Available: "2010-12"
+4333	huge yummy blinking jawbruiser	10	awesome	Last Available: "2010-12"
 4334	Vulcanized irradiated moist chocolate car	0		Effect: "Sappy Blood", Effect Duration: 32, Last Available: "2009-12"
 4335	ruddy plastic 11 Dealer	0		Maximum HP Percent: +40, Last Available: "2009-12"
 4336	shaking lard-coated plastic Crimbo Casino	0		Sleaze Spell Damage: +25, Last Available: "2009-12"
@@ -4298,18 +4298,18 @@
 4346	twirling plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	blue leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat	0		Item Drop: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	miser's snow pants	0		Meat Drop: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	snow hat	0		Item Drop: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	miser's snow pants	0		Meat Drop: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	blue squat slick snow belly	0		Moxie: +10, Single Equip, Last Available: "2009-12"
 4352	wobbly pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
-4354	squat gray A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	gray squat A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	jittery A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	squat A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	upside-down jittery A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	mirror A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	decent bite-sized expired can of franks 'n' beans	1	good	Last Available: "2009-12"
+4360	bite-sized decent expired can of franks 'n' beans	1	good	Last Available: "2009-12"
 4361	artisanal expired bottle of peppermint schnapps	4	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	mirror supercool weightlifter's pocketwatch on a chain	0		Muscle: +15, Moxie Percent: +20, Last Available: "2009-12"
 4386	forbidden cement sandals of courage	0		Spell Damage Percent: +50, Spooky Resistance: +3, Single Equip, Last Available: "2009-12"
 4387	studded arcane researcher's night-vision goggles	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	huge baleful peanut brittle shield	0		Spell Damage: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	teal censurious frightening Red Rover BB gun	0		Spooky Damage: +5, Sleaze Resistance: +3, Last Available: "2009-12"
 4391	wholesome red-and-green sweater	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	blurry cheese ball	0		Last Available: "2010-01"
 4399	smooth cheese sword	0		Moxie: +15, Softcore Only, Last Available: "2010-01"
-4400	horrifying cheese diaper	0		Spooky Damage: +25, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	horrifying cheese diaper	0		Spooky Damage: +25, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	veiny cheese wheel	0		Maximum HP: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	red crafty cheese eye	0		Maximum MP: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	chaotic thinker's Staff of Queso Escusado of the wise owl	0		Mysticality: 30, Spell Critical Percent: +10, Softcore Only, Last Available: "2010-01"
@@ -4357,12 +4357,12 @@
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	shaking A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
-4409	spinning skewed Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
+4409	skewed spinning Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	teal The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	stale upside-down quantum taco	0		Last Available: "2010-10"
 4413	perfectly mixed weak Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
-4414	upside-down huge colorful plastic ball	0		Last Available: "2010-01"
+4414	huge upside-down colorful plastic ball	0		Last Available: "2010-01"
 4415	slick sealhide hood	0		Moxie: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	twirling supercharged sealhide leggings	0		Maximum MP Percent: +30, Familiar Effect: "1xVolley, cap 40"
 4417	weightlifter's sealhide cloak	0		Muscle: +15
@@ -4396,7 +4396,7 @@
 4448	boiled olive Instant Karma	1	crappy	Effect: "Super-Charged", Effect Duration: 35
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	fortified pointy hat	0		Damage Absorption: +60, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	fortified pointy hat	0		Damage Absorption: +60, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	savvy machetito	0		Mysticality Percent: +20, Last Available: "2010-04"
 4453	Herculean lawnmower blade	0		Experience (Muscle): +1, Last Available: "2010-04"
 4454	wobbly grass clippings	0		Last Available: "2023-12"
@@ -4413,11 +4413,11 @@
 4465	concentrated nitrogenated chocolate saucepan	0		Effect: "Analog Drunk", Effect Duration: 56
 4466	oxidized pulsating chocolate disco ball	0		Effect: "Floundering", Effect Duration: 63
 4467	non-anodized tumbling chocolate stolen accordion	0		Effect: "Heart of Green", Effect Duration: 12
-4468	blurry Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	blurry Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	pulsating BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	clever BRICKO hat	0		Maximum MP: +20, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	avaricious BRICKO pants	0		Meat Drop: +30, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	clever BRICKO hat	0		Maximum MP: +20, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	avaricious BRICKO pants	0		Meat Drop: +30, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	up-at-dawn BRICKO sword	0		Adventures: +5, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4434,7 +4434,7 @@
 4486	BRICKO pearl	0		Last Available: "2010-02"
 4487	BRICKO bulwark of the storm	0		Maximum MP Percent: +40, Damage Reduction: 3, Last Available: "2010-02"
 4488	BRICKO trunk	0		Last Available: "2010-02"
-4489	pulsating twirling gilded BRICKO brick	0		Last Available: "2010-02"
+4489	twirling pulsating gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	lime green BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
@@ -4442,7 +4442,7 @@
 4494	BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	narrow extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
-4497	activated diffused spinning tumbling yellow recording of The Ballad of Richie Thingfinder	0		Effect: "Egg-headedness", Effect Duration: 23
+4497	activated diffused yellow spinning tumbling recording of The Ballad of Richie Thingfinder	0		Effect: "Egg-headedness", Effect Duration: 23
 4498	magnetized recording of Benetton's Medley of Diversity	0		Effect: "High Blood Chocolate Content", Effect Duration: 17
 4499	corrupted altered mirror recording of Elron's Explosive Etude	0		Effect: "Walberg's Dim Bulb", Effect Duration: 24
 4500	dry boiled recording of Chorale of Companionship	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 18
@@ -4459,8 +4459,8 @@
 4511	stale spinning beautiful soup	3	decent	Last Available: "2010-03"
 4512	ghostly eggman noodles	0		Last Available: "2010-03"
 4513	tumbling Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	bland diet Humpty Dumplings	1	decent	Last Available: "2010-03"
-4515	spoiled half-sized Lobster <i>qua</i> Grill	2	crappy	Last Available: "2010-03"
+4514	diet bland Humpty Dumplings	1	decent	Last Available: "2010-03"
+4515	half-sized spoiled Lobster <i>qua</i> Grill	2	crappy	Last Available: "2010-03"
 4516	perfectly mixed mirror missing wine	3	EPIC	Last Available: "2010-03"
 4517	toothsome matter custard	4	awesome	Last Available: "2010-03"
 4518	altered colloidal denatured comfit?	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 32, Last Available: "2010-03"
@@ -4469,7 +4469,7 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	purple Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	pulsating spinning rosy-cheeked steel-toed eye of the Tiger-lily	0		Damage Reduction: 9, Maximum HP Percent: +30, Last Available: "2010-03"
-4524	greedy reassuring wig	0		Spooky Resistance: +1, Meat Drop: +20, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	greedy reassuring wig	0		Spooky Resistance: +1, Meat Drop: +20, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	adequate donut	3	good	Last Available: "2010-03"
 4526	bland bucket of honey	3	decent	Last Available: "2010-03"
 4527	bouncing healthy fortified elephant stinger	0		Damage Absorption: +60, Maximum HP Percent: +20, Last Available: "2010-03"
@@ -4482,10 +4482,10 @@
 4534	low-calorie rotten king cookie	1	crappy	Last Available: "2010-03"
 4535	adequate snack-sized queen cookie	2	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	upside-down stiffened insane tophat	0		Damage Reduction: 1, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	rosy-cheeked helm of the knight of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	upside-down stiffened insane tophat	0		Damage Reduction: 1, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	rosy-cheeked helm of the knight of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	experienced slick wristwatch of the knight	0		Moxie: +10, Experience: +2, Single Equip, Last Available: "2010-03"
-4540	twirling personal trainer's trousers of the knight of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	twirling personal trainer's trousers of the knight of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	tophat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "1xBarrr, cap 25"
 4542	grievous tie	0		Weapon Damage Percent: +50, Single Equip
 4543	jittery tuxedo pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4508,21 +4508,21 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	smooth weak world's most unappetizing beverage	2	awesome	Last Available: "2010-04"
+4563	weak smooth world's most unappetizing beverage	2	awesome	Last Available: "2010-04"
 4564	curative slippery when wet shield	0		HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 6, Last Available: "2010-04"
 4565	flavorless mirror teal raisin	3	decent	Last Available: "2010-04"
 4566	shaking blurry fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	sizzling supercharged flyest of shirts	0		Maximum MP Percent: +30, Hot Damage: +10, Last Available: "2010-04"
-4568	moldy snack-sized a dance upon the palate	2	crappy	Last Available: "2010-04"
-4569	low-calorie spoiled prehistoric meteorite jawbreaker	1	crappy	Last Available: "2010-04"
+4568	snack-sized moldy a dance upon the palate	2	crappy	Last Available: "2010-04"
+4569	spoiled low-calorie prehistoric meteorite jawbreaker	1	crappy	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	rotten big squirmy violent party snack	5	crappy	Last Available: "2010-04"
+4571	big rotten squirmy violent party snack	5	crappy	Last Available: "2010-04"
 4572	upside-down medical-grade can-you-dig-it?	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-04"
 4573	green The Legendary Beat	0		Last Available: "2010-04"
 4574	upside-down panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	anodized double-ionized Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 59, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of the scaredy-cat	0		Monster Level: -15, Last Available: "2010-04"
@@ -4551,7 +4551,7 @@
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	bottle of Goldschn&ouml;ckered of the blizzard of the boozehound	0		Cold Spell Damage: +25, Booze Drop: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	huge flavorless sun-dried tofu	6	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	flavorless huge sun-dried tofu	6	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	weak hand-crafted soyburger juice	2	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	upside-down shaking respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
@@ -4564,25 +4564,25 @@
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
-4619	narrow olive frisbee	0		Free Pull, Last Available: "2011-12"
+4619	olive narrow frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	quantum chocolate-covered caviar	0		Effect: "Wet Rub", Effect Duration: 55, Last Available: "2020-09"
 4624	moldy huge pawn cookie	3	crappy	Last Available: "2010-06"
-4625	pickled teal bouncing mirror coffee pixie stick	1	decent	Last Available: "2010-06"
+4625	pickled bouncing teal mirror coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	lime green superduperball	0		Last Available: "2010-06"
 4627	mirror finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
 4629	nasty plastic spider ring	0		Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	reassuring plastic kazoo	0		Spooky Resistance: +1, Last Available: "2010-06"
 4631	twirling vibrating inflatable baseball bat	0		Maximum MP Percent: +10, Last Available: "2010-06"
-4632	pulsating quilted googly-star hat of the sweet-tooth	0		Damage Absorption: +40, Candy Drop: +100, Familiar Effect: "atk", Last Available: "2010-06"
+4632	pulsating quilted googly-star hat of the sweet-tooth	0		Damage Absorption: +40, Candy Drop: +100, Last Available: "2010-06", Familiar Effect: "atk"
 4633	Lo Pan's Oprah's googly-ball hat	0		Maximum MP Percent: +50, Spell Critical Percent: +30, Last Available: "2010-06"
 4634	ribald googly-heart hat of incineration	0		Hot Spell Damage: +50, Sleaze Damage: +10, Last Available: "2010-06"
 4635	crafty super-sweet boom box of the brazier	0		Maximum MP: +10, Hot Spell Damage: +25, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	fireproof studded grievous sinister demon mask	0		Weapon Damage Percent: +50, Damage Absorption: +80, Hot Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	fireproof studded grievous sinister demon mask	0		Weapon Damage Percent: +50, Damage Absorption: +80, Hot Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	pulsating prompt stylish beefcake's streetfighting champion's belt	0		Muscle: +25, Moxie: +25, Adventures: +3, Single Equip, Last Available: "2010-06"
 4639	Space Trip safety headphones of the blizzard of temperance of the businessman	0		Cold Spell Damage: +25, Sleaze Resistance: +5, Meat Drop: +50, Single Equip, Last Available: "2010-06"
 4640	shaking thinker's LARP carp	0		Mysticality: +10
@@ -4594,9 +4594,9 @@
 4646	wobbly rock-hard personal trainer's Meteoid ice beam of Leguizamo	0		Experience Percent (Muscle): +10, Damage Reduction: 5, Monster Level: +20, Last Available: "2011-12"
 4647	ribald Sinatra's Dungeon Fist gauntlet of chilblains	0		Experience (Moxie): +5, Cold Damage: +25, Sleaze Damage: +10, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	green chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
-4651	twirling wobbly ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
+4649	green chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4651	wobbly twirling ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	flame-retardant ironic knit cap of the cougar	0		Moxie: +20, Hot Resistance: +1, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	twirling ironic sunglasses	0		Single Equip
 4654	bouncing yellow dog trainer's ironic battle spoon	0		Experience (familiar): +1
@@ -4616,10 +4616,10 @@
 4668	dance instructor's observational glasses	0		Experience Percent (Moxie): +10
 4669	baleful hilarious comedy prop	0		Spell Damage: +25
 4670	yellow beer-scented teddy bear	0		
-4671	extra-dry drinkable booze-soaked cherry	5	good	
+4671	drinkable extra-dry booze-soaked cherry	5	good	
 4672	comfy pillow	0		
-4673	small yummy marshmallow	2	awesome	
-4674	moldy thick sponge cake	5	crappy	
+4673	yummy small marshmallow	2	awesome	
+4674	thick moldy sponge cake	5	crappy	
 4675	aged gin-soaked blotter paper	3	awesome	
 4676	ghostly tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	ghostly smoked potsherd	0		
 4681	beefcake's pottery shield	0		Muscle: +25, Damage Reduction: 3, Last Available: "2010-09"
-4682	medical-grade personal trainer's pottery hat	0		Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	shaking lightning-fast flame-retardant pottery training pants	0		Hot Resistance: +1, Initiative: +40, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	medical-grade personal trainer's pottery hat	0		Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	shaking lightning-fast flame-retardant pottery training pants	0		Hot Resistance: +1, Initiative: +40, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	groovy pottery club	0		Moxie Percent: +10, Last Available: "2010-09"
 4685	red ruddy pottery yo-yo	0		Maximum HP Percent: +40, Last Available: "2010-09"
 4686	twirling pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4639,11 +4639,11 @@
 4691	fossilized wing	0		Last Available: "2010-09"
 4692	shaking fossilized limb	0		Last Available: "2010-09"
 4693	fossilized torso	0		Last Available: "2010-09"
-4694	blinking red fossilized spine	0		Last Available: "2010-09"
+4694	red blinking fossilized spine	0		Last Available: "2010-09"
 4695	upside-down affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	smelly Annie Oakley's clever Greatest American Pants	0		Maximum MP: +20, Critical Hit Percent: +20, Stench Spell Damage: +10, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	smelly Annie Oakley's clever Greatest American Pants	0		Maximum MP: +20, Critical Hit Percent: +20, Stench Spell Damage: +10, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	rosy-cheeked fossilized necklace	0		Maximum HP Percent: +30, Last Available: "2010-09"
-4698	jittery blurry imp air	0		
+4698	blurry jittery imp air	0		
 4699	bus pass	0		
 4700	fossilized spike	0		Last Available: "2010-09"
 4701	waterlogged crate	0		Last Available: "2011-12"
@@ -4657,9 +4657,9 @@
 4709	hippo tutu	0		Last Available: "2011-09"
 4710	blurry immense ballet shoes	0		Familiar Weight: +5
 4711	huge sweatpants	0		Familiar Effect: "8xPotato, cap 2"
-4712	wobbly skewed GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
+4712	skewed wobbly GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	massive bland lemon popsicle	7	decent	
+4714	bland massive lemon popsicle	7	decent	
 4715	enchanted adequate popsicle	3	good	Effect: "Toast Tea", Effect Duration: 5
 4716	spoiled low-calorie cyan strawberry popsicle	1	crappy	
 4717	moldy liver popsicle	3	crappy	
@@ -4670,9 +4670,9 @@
 4722	yummy liver and let pie	4	awesome	Last Available: "2010-10"
 4723	adequate gigantic badass pie	9	good	Last Available: "2010-10"
 4724	flavorless small shoo-fish pie	2	decent	Last Available: "2010-10"
-4725	half-sized rotten mirror piping organ pie	2	crappy	Last Available: "2010-10"
-4726	miniature normal igloo pie	2	good	Last Available: "2010-10"
-4727	miniature decent stomach turnover	2	good	Last Available: "2010-10"
+4725	rotten half-sized mirror piping organ pie	2	crappy	Last Available: "2010-10"
+4726	normal miniature igloo pie	2	good	Last Available: "2010-10"
+4727	decent miniature stomach turnover	2	good	Last Available: "2010-10"
 4728	adequate tumbling dead lights pie	3	good	Last Available: "2010-10"
 4729	spoiled throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	blue jittery thinker's stop shield	0		Mysticality: +10, Damage Reduction: 6, Last Available: "2009-12"
@@ -4683,7 +4683,7 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	tumbling medical-grade beer-soaked mop	0		HP Regen Min: 7, HP Regen Max: 10
-4738	enchanted tolerable triple-distilled lime green day-old beer	10	good	Effect: "Elron's Explosive Etude", Effect Duration: 20
+4738	triple-distilled enchanted tolerable lime green day-old beer	10	good	Effect: "Elron's Explosive Etude", Effect Duration: 20
 4739	hand-crafted high-proof plain beer	6	EPIC	
 4740	boozy hand-crafted pulsating blurry overpriced &quot;imported&quot; beer	5	EPIC	
 4741	huge smiling rat	0		
@@ -4693,14 +4693,14 @@
 4745	super-Vulcanized dry triple-oxidized blinking Wax Flask	0		Effect: "Comprehensively Nourished", Effect Duration: 31
 4746	magnetized dry bouncing Pain Dip	0		Effect: "Spiritually Awake", Effect Duration: 68
 4747	super-sized moldy bone meal	5	crappy	Last Available: "2010-10"
-4748	practically non-alcoholic enchanted artisanal bone aperitif	1	super ultra EPIC	Effect: "Pockets of Fire", Effect Duration: 45, Last Available: "2010-10"
+4748	enchanted artisanal practically non-alcoholic bone aperitif	1	super ultra EPIC	Effect: "Pockets of Fire", Effect Duration: 45, Last Available: "2010-10"
 4749	upside-down razor-sharp bonerang	0		Weapon Damage Percent: +25, Last Available: "2010-10"
 4750	inspector's bone and arrows	0		Item Drop: +15, Last Available: "2010-10"
 4751	ghostly jittery boning knife of terror	0		Spooky Spell Damage: +10, Last Available: "2010-10"
 4752	upside-down ghostly dance instructor's bone crusher	0		Experience Percent (Moxie): +10, Last Available: "2010-10"
 4753	pulsating crafty bone spurs	0		Maximum MP: +10, Single Equip, Last Available: "2010-10"
-4754	Tesla quilted bonedanna	0		Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	skewed shaking boxer's boneana hammock of the sewer	0		Muscle Percent: +10, Stench Damage: +25, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	Tesla quilted bonedanna	0		Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	skewed shaking boxer's boneana hammock of the sewer	0		Muscle Percent: +10, Stench Damage: +25, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	teal bag of bones	0		Last Available: "2010-10"
 4757	squat Stabonic scroll	0		Last Available: "2010-10"
 4758	cold-filtered pulsating candy skeleton	0		Effect: "Sizzling with Fury", Effect Duration: 66, Last Available: "2020-09"
@@ -4727,7 +4727,7 @@
 4818	spoiled bite-sized bouncing CRIMBCOIDS mints	1	crappy	Last Available: "2011-01"
 4819	squat can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	moldy CRIMBCOLOAF	3	crappy	Last Available: "2011-01"
-4821	adequate tumbling ghostly circular CRIMBCOOKIE	4	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	adequate ghostly tumbling circular CRIMBCOOKIE	4	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	plastic CRIMBCO HQ of the ox	0		Muscle: +20, Last Available: "2010-12"
 4823	slick plastic fax machine	0		Moxie: +10, Last Available: "2010-12"
 4824	twirling blurry Herculean plastic hobo elf	0		Experience (Muscle): +1, Last Available: "2010-12"
@@ -4741,19 +4741,19 @@
 4832	maroon robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
-4835	shaking blinking robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
+4835	blinking shaking robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	twirling robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	wobbly robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	super-sized normal triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	normal super-sized triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	moldy lime green square CRIMBCOOKIE	3	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	censurious boxer's bindlestocking of the ox	0		Muscle: +20, Muscle Percent: +10, Sleaze Resistance: +3, Last Available: "2010-12"
 4842	spinning sleeping stocking	0		Last Available: "2010-12"
 4843	mirror Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	teal The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	rock-hard smartaleck's Uncle Hobo's stocking cap	0		Moxie Percent: +30, Damage Reduction: 5, Familiar Effect: "atk", Last Available: "2010-12"
+4845	rock-hard smartaleck's Uncle Hobo's stocking cap	0		Moxie Percent: +30, Damage Reduction: 5, Last Available: "2010-12", Familiar Effect: "atk"
 4846	blurry yellow censurious Fonzie's Uncle Hobo's epic beard	0		Experience (Moxie): +1, Sleaze Resistance: +3, Single Equip, Last Available: "2010-12"
-4847	wobbly asbestos-lined wicked Uncle Hobo's gift baggy pants	0		Spell Damage: +5, Hot Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	wobbly asbestos-lined wicked Uncle Hobo's gift baggy pants	0		Spell Damage: +5, Hot Resistance: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	wobbly asbestos-lined Sinatra's Uncle Hobo's fingerless tinsel gloves	0		Experience (Moxie): +5, Hot Resistance: +5, Single Equip, Last Available: "2010-12"
 4849	pulsating resourceful beefcake's Uncle Hobo's highest bough	0		Muscle: +25, Maximum MP: +50, Last Available: "2010-12"
 4850	teal upside-down dance instructor's supercool Uncle Hobo's belt	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Single Equip, Last Available: "2010-12"
@@ -4763,20 +4763,20 @@
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	fuchsia Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
-4857	wobbly upside-down bottle of Blank-Out	0		Last Available: "2011-01"
+4857	upside-down wobbly bottle of Blank-Out	0		Last Available: "2011-01"
 4858	Jeselnik's CRIMBCO lanyard	0		Sleaze Damage: +25, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
-4862	shaking teal CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
+4862	teal shaking CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
-4864	yellow ghostly upside-down photocopier	0		Last Available: "2011-01"
+4864	upside-down yellow ghostly photocopier	0		Last Available: "2011-01"
 4865	red deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	frightening crafty Sinatra's paperclip-on tie	0		Experience (Moxie): +5, Maximum MP: +10, Spooky Damage: +5, Single Equip, Last Available: "2011-01"
-4869	slick cool paperclip pants	0		Moxie: 15, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	scorching mansplainer's Lo Pan's paperclip turban	0		Spell Critical Percent: +30, Monster Level: +15, Hot Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	slick cool paperclip pants	0		Moxie: 15, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	scorching mansplainer's Lo Pan's paperclip turban	0		Spell Critical Percent: +30, Monster Level: +15, Hot Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	coward's paperclip cape	0		Monster Level: -20, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	tumbling photocopied monster	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	blinking slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	miniature tasty festive sausage	2	awesome	Last Available: "2011-01"
-4895	gigantic normal holiday cheese log	10	good	Last Available: "2011-01"
+4895	normal gigantic holiday cheese log	10	good	Last Available: "2011-01"
 4896	twirling holiday log	0		Last Available: "2011-01"
 4897	up-at-dawn Sherlock's BGE 'ferocious fruit' shirt	0		Item Drop: +25, Adventures: +5, Last Available: "2010-12"
 4898	twirling Sinatra's boxer's BGE 'cuddly critter' shirt	0		Muscle Percent: +10, Experience (Moxie): +5, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	mirror quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	bite-sized stale Knob jelly donut	1	decent	
+4941	stale bite-sized Knob jelly donut	1	decent	
 4942	Knob cake	0		
 4943	Knob cake pan	0		
 4944	red Knob batter	0		
@@ -4860,7 +4860,7 @@
 4957	moist concentrated tumbling half-baked potion	0		Effect: "Saucefingers", Effect Duration: 55
 4958	cool Knob Goblin deluxe scimitar	0		Moxie: +5
 4959	rotten Knob nuts	4	crappy	
-4960	delicious triple-distilled Cobb's Knob Wurstbrau	8	awesome	
+4960	triple-distilled delicious Cobb's Knob Wurstbrau	8	awesome	
 4961	mirror Subject 37 file	0		
 4962	fortified savvy mysterious lapel pin	0		Mysticality Percent: +20, Damage Absorption: +60, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4918,15 +4918,15 @@
 5015	spoiled natto pocky	3	crappy	Last Available: "2011-03"
 5016	triple-distilled perfectly mixed narrow wasabi-infused sake	7	EPIC	Last Available: "2011-03"
 5017	drinkable tobiko-infused sake	4	good	Last Available: "2011-03"
-5018	aged practically non-alcoholic red natto-infused sake	1	awesome	Last Available: "2011-03"
+5018	practically non-alcoholic aged red natto-infused sake	1	awesome	Last Available: "2011-03"
 5019	super-colloidal diffused wasabi marble soda	0		Effect: "Celestial Body", Effect Duration: 34, Last Available: "2011-03"
 5020	ionized diffused fuchsia tobiko marble soda	0		Effect: "Fudgehound", Effect Duration: 23, Last Available: "2011-03"
 5021	activated ghostly natto marble soda	0		Effect: "Pop-eyed", Effect Duration: 54, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
-5023	double-boiled enhanced jittery blinking elderly jawbreaker	0		Effect: "Stands Alone", Effect Duration: 43, Last Available: "2020-09"
+5023	double-boiled enhanced blinking jittery elderly jawbreaker	0		Effect: "Stands Alone", Effect Duration: 43, Last Available: "2020-09"
 5024	watered-down mediocre marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
 5025	perfectly mixed watered-down cranberry schnapps	2	super ultra EPIC	Last Available: "2011-03"
-5026	practically non-alcoholic perfectly mixed twirling breaded beer	1	super ultra mega turbo EPIC	Last Available: "2011-03"
+5026	perfectly mixed practically non-alcoholic twirling breaded beer	1	super ultra mega turbo EPIC	Last Available: "2011-03"
 5027	lousy watered-down soy cordial	2	decent	Last Available: "2011-03"
 5028	sharpshooter's astral bludgeon of the ox of the cougar	0		Muscle: +20, Moxie: +20, Critical Hit Percent: +10
 5029	supercharged padded astral shield	0		Damage Absorption: +20, Maximum MP Percent: +30, Damage Reduction: 15
@@ -4943,15 +4943,15 @@
 5040	narrow astral pet sweater	0		Familiar Weight: +10
 5041	bouncing banded boxer's astral shirt of vim and vigor	0		Muscle Percent: +10, Damage Absorption: +100, Maximum HP Percent: +50
 5042	boxer's slick astral belt	0		Moxie: +10, Muscle Percent: +10
-5043	tasty jumbo astral hot dog	5		
-5044	drinkable yellow upside-down astral pilsner	3		
+5043	jumbo tasty astral hot dog	5		
+5044	drinkable upside-down yellow astral pilsner	3		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	huge Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	manspreader's Rosewater's brainy double-ice cap	0		Mysticality: +5, Mysticality Percent: +30, Monster Level: +10, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	manspreader's Rosewater's brainy double-ice cap	0		Mysticality: +5, Mysticality Percent: +30, Monster Level: +10, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	narrow rosewater-soaked hale double-ice box of temperance	0		Maximum HP: +20, Stench Resistance: +3, Sleaze Resistance: +5, Last Available: "2011-04"
-5051	tumbling sinister dance instructor's double-ice britches of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Spell Damage: +10, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	tumbling sinister dance instructor's double-ice britches of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Spell Damage: +10, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	gray skewed handful of numbers	0		Last Available: "2020-09"
 5053	teal Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	smooth watered-down Russian Ice	2	awesome	Last Available: "2011-04"
 5074	clay ashtray of Flo-Jo	0		Initiative: +100, Damage Reduction: 3, Last Available: "2011-05"
 5075	spinning lanyard of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-05"
-5076	aromatic monster pants	0		Stench Resistance: +1, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	aromatic monster pants	0		Stench Resistance: +1, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	denatured Pok&euml;mann band-aid	0		Effect: "Stinkybeard", Effect Duration: 46, Last Available: "2011-05"
-5079	pulsating spinning reassuring grievous Van der Graaf helmet	0		Weapon Damage Percent: +50, Spooky Resistance: +1, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	pulsating spinning reassuring grievous Van der Graaf helmet	0		Weapon Damage Percent: +50, Spooky Resistance: +1, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	upside-down smelly crutch	0		Stench Spell Damage: +10, Last Available: "2011-05"
 5081	wobbly chaotic shock belt	0		Spell Critical Percent: +10, Single Equip, Last Available: "2011-05"
 5082	double-ionized flattened Okee-Dokee soda	0		Effect: "All Is Forgiven", Effect Duration: 14, Last Available: "2011-05"
 5083	Jeselnik's rubber band gun	0		Sleaze Damage: +25, Last Available: "2011-05"
-5084	ribald pin-stripe slacks	0		Sleaze Damage: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	ribald pin-stripe slacks	0		Sleaze Damage: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	Tesla gloves	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-05"
 5086	quadruple-magnetized upside-down correction fluid	0		Effect: "Muddled", Effect Duration: 50, Last Available: "2011-05"
 5087	cyan up-at-dawn Pok&euml;mann figurine: Porkachu	0		Adventures: +5, Single Equip, Last Available: "2011-05"
@@ -5021,8 +5021,8 @@
 5118	yellow bird brain	0		
 5119	busted wings	0		
 5120	shaking Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	wool padded Admiral's hat of chilblains	0		Damage Absorption: +20, Cold Damage: +25, Cold Resistance: +1, Familiar Effect: "atk", Last Available: "2011-05"
-5122	red family-friendly stiffened beefcake's aviator's cap	0		Muscle: +25, Damage Reduction: 1, Sleaze Resistance: +1, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	wool padded Admiral's hat of chilblains	0		Damage Absorption: +20, Cold Damage: +25, Cold Resistance: +1, Last Available: "2011-05", Familiar Effect: "atk"
+5122	red family-friendly stiffened beefcake's aviator's cap	0		Muscle: +25, Damage Reduction: 1, Sleaze Resistance: +1, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	wool experienced mirrored aviator shades	0		Experience: +2, Cold Resistance: +1, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5039,7 +5039,7 @@
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
-5139	lime green shaking carton of astral energy drinks	0		
+5139	shaking lime green carton of astral energy drinks	0		
 5140	dehydrated blinking astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	spinning moon unit	0		Last Available: "2011-06"
@@ -5047,12 +5047,12 @@
 5144	handful of honey	0		
 5145	enhanced honeypot	0		Effect: "Salt Rockin'", Effect Duration: 28
 5146	flavorless upside-down wild honey pie	3	decent	
-5147	practically non-alcoholic hand-crafted blinking honey mead	1	EPIC	
+5147	hand-crafted practically non-alcoholic blinking honey mead	1	EPIC	
 5148	ghostly Annie Oakley's strapping honey dipper of Gandalf	0		Muscle: +5, Critical Hit Percent: +20, Spell Critical Percent: +20
 5149	up-at-dawn honeybritches of wisdom of the businessman	0		Mysticality: +15, Meat Drop: +50, Adventures: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	twirling therapeutic Herculean smooth honeycap	0		Moxie: +15, Experience (Muscle): +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, cap 43"
-5151	huge red horrifying Moonthril Circlet	0		Spooky Damage: +25, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	skewed ruddy Moonthril Greaves	0		Maximum HP Percent: +40, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	huge red horrifying Moonthril Circlet	0		Spooky Damage: +25, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	skewed ruddy Moonthril Greaves	0		Maximum HP Percent: +40, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	huge Oprah's Moonthril Flamberge	0		Maximum MP Percent: +50, Last Available: "2011-06"
 5154	blinking nippy Moonthril Longbow	0		Cold Damage: +10, Last Available: "2011-06"
 5155	olive tumbling Moonthril Cuirass of mayonnaise	0		Sleaze Spell Damage: +50, Softcore Only, Last Available: "2011-06"
@@ -5067,18 +5067,18 @@
 5164	gray mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	upside-down clever girl	0		Maximum MP: +20, Last Available: "2011-06"
 5166	ghostly top hat and cane	0		Last Available: "2011-06"
-5167	blue squat synthetic dog hair pill	0		Last Available: "2011-06"
+5167	squat blue synthetic dog hair pill	0		Last Available: "2011-06"
 5168	distention pill	0		Last Available: "2011-06"
 5169	spinning elven medi-pack	0		Last Available: "2011-06"
 5170	colloidal concentrated transporter transponder	0		Effect: "Nothing Is Impossible", Effect Duration: 22, Last Available: "2011-06"
-5171	teal ghostly Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
-5172	squat gray jittery Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
+5171	ghostly teal Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
+5172	jittery squat gray Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	jittery elven magi-pack	0		Last Available: "2011-06"
 5174	aged bouncing Saison du Lune	4	awesome	Last Available: "2011-06"
 5175	lousy Moonthril Schnapps	3	decent	Last Available: "2011-06"
 5176	perfectly mixed Wrecked Generator	3	super ultra mega EPIC	Last Available: "2011-06"
 5177	flavorless huge Spaghetti with Moonballs	8	decent	Last Available: "2011-06"
-5178	normal huge yellow Crepes a la Lune	7	good	Last Available: "2011-06"
+5178	huge normal yellow Crepes a la Lune	7	good	Last Available: "2011-06"
 5179	rotten pulsating Moon Pie	4	crappy	Last Available: "2011-06"
 5180	magnetized energized quadruple-tarnished Comet Pop	0		Effect: "Astral Shell", Effect Duration: 58, Last Available: "2011-06"
 5181	wet adjusted colloidal skewed Flan in the Moon	0		Effect: "Sticks and Stones", Effect Duration: 52, Last Available: "2011-06"
@@ -5105,12 +5105,12 @@
 5202	dried greasy paste	1	crappy	Last Available: "2011-08"
 5203	modified gray narrow bug paste	1	decent	Last Available: "2011-08"
 5204	dried hippy paste	1	crappy	Last Available: "2011-08"
-5205	twisted jittery yellow orc paste	1	good	Last Available: "2011-08"
+5205	twisted yellow jittery orc paste	1	good	Last Available: "2011-08"
 5206	dried demonic paste	1	good	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2011-08"
 5207	twisted teal indescribably horrible paste	1	awesome	Last Available: "2011-08"
 5208	diluted paste	1	decent	Last Available: "2011-08"
 5209	modified gray goblin paste	1	good	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40, Last Available: "2011-08"
-5210	modified red upside-down pirate paste	1	good	Effect: "Turkey-Friendly", Effect Duration: 10, Last Available: "2011-08"
+5210	modified upside-down red pirate paste	1	good	Effect: "Turkey-Friendly", Effect Duration: 10, Last Available: "2011-08"
 5211	distilled mirror chlorophyll paste	1	good	Last Available: "2011-08"
 5212	mixed green upside-down skewed paste	1	awesome	Last Available: "2011-08"
 5213	distilled mirror Mer-kin paste	1	EPIC	Last Available: "2011-08"
@@ -5123,11 +5123,11 @@
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	huge Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	huge Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	toothsome mirror Ur-Donut	3	awesome	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	hand-crafted triple-distilled bucket of wine	9	EPIC	Last Available: "2011-09"
+5227	triple-distilled hand-crafted bucket of wine	9	EPIC	Last Available: "2011-09"
 5228	flavorless ultrafondue	3	decent	Last Available: "2011-09"
 5229	teal unbearable light	0		Last Available: "2011-09"
 5230	purple snowflake	0		Last Available: "2011-09"
@@ -5145,16 +5145,16 @@
 5242	mediocre Fromage Pinotage	3	decent	Last Available: "2011-09"
 5243	tolerable spinning Beignet Milgranet	3	good	Last Available: "2011-09"
 5244	smooth Muschat	3	awesome	Last Available: "2011-09"
-5245	gigantic rotten cool jelly donut	9	crappy	Last Available: "2011-09"
+5245	rotten gigantic cool jelly donut	9	crappy	Last Available: "2011-09"
 5246	spoiled spinning shrapnel jelly donut	3	crappy	Last Available: "2011-09"
 5247	moldy huge occult jelly donut	3	crappy	Last Available: "2011-09"
 5248	stale thyme jelly donut	4	decent	Last Available: "2011-09"
-5249	bland diet danish	1	decent	Last Available: "2011-09"
+5249	diet bland danish	1	decent	Last Available: "2011-09"
 5250	flavorless lime green smashed danish	4	decent	Last Available: "2011-09"
 5251	normal skewed forbidden danish	3	good	Last Available: "2011-09"
 5252	adequate cool cat claw	4	good	Last Available: "2011-09"
 5253	spoiled blunt cat claw	4	crappy	Last Available: "2011-09"
-5254	spoiled jumbo shadowy cat claw	5	crappy	Last Available: "2011-09"
+5254	jumbo spoiled shadowy cat claw	5	crappy	Last Available: "2011-09"
 5255	rotten green cheezburger	3	crappy	Last Available: "2011-09"
 5256	decent green toasted brie	3	good	Last Available: "2011-09"
 5257	liquefied triple-anodized potion of the field gar	0		Effect: "Armored Innards", Effect Duration: 22, Last Available: "2011-09"
@@ -5184,12 +5184,12 @@
 5281	broken clock of dire peril	0		Weapon Damage: +20, Last Available: "2011-09"
 5282	deadly dethklok	0		Weapon Damage: +5, Last Available: "2011-09"
 5283	glacial clock of dire peril	0		Weapon Damage: +20, Last Available: "2011-09"
-5284	olive Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	olive Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
-5288	cyan squat d10	0		Last Available: "2011-09"
-5289	bouncing jittery maroon d12	0		Last Available: "2011-09"
+5288	squat cyan d10	0		Last Available: "2011-09"
+5289	maroon bouncing jittery d12	0		Last Available: "2011-09"
 5290	d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
@@ -5217,33 +5217,33 @@
 5314	adjusted aerosolized quantum bite-me-red lipstick	0		Effect: "Lemon Enlightenment", Effect Duration: 21, Last Available: "2011-10"
 5315	diffused huge green whisker pencil	0		Effect: "Very Clean Guns", Effect Duration: 14, Last Available: "2011-10"
 5316	Vulcanized deionized alkaline press-on ribs	0		Effect: "Staying Frosty", Effect Duration: 42, Last Available: "2011-10"
-5317	energized spinning bouncing Rattlin' Chains	0		Effect: "Prince of Seaside Town", Effect Duration: 20, Last Available: "2011-10"
+5317	energized bouncing spinning Rattlin' Chains	0		Effect: "Prince of Seaside Town", Effect Duration: 20, Last Available: "2011-10"
 5318	quadruple-pressed quantum Gummy Brains	0		Effect: "Berry Statistical", Effect Duration: 37, Last Available: "2011-10"
 5319	moist super-polymerized green Blood 'n' Plenty	0		Effect: "Spookyravin'", Effect Duration: 25, Last Available: "2011-10"
 5320	Vulcanized oxidized tumbling Lobos Mints	0		Effect: "Frosty the Hitman", Effect Duration: 12, Last Available: "2011-10"
 5321	quadruple-irradiated Sweet Sword	0		Effect: "PERL of Great Price", Effect Duration: 14, Last Available: "2011-10"
 5322	hand-crafted Ecto-Cooler	4	EPIC	Last Available: "2011-10"
-5323	irresponsibly strong acceptable Bartles and BRAAAINS wine cooler	9	good	Last Available: "2011-10"
+5323	acceptable irresponsibly strong Bartles and BRAAAINS wine cooler	9	good	Last Available: "2011-10"
 5324	acceptable practically non-alcoholic Blood Light	1	good	Last Available: "2011-10"
 5325	aged spinning Silver Bullet beer	3	awesome	Last Available: "2011-10"
-5326	weak smooth twirling jittery Bone's Farm &quot;wine&quot;	2	awesome	Last Available: "2011-10"
+5326	smooth weak twirling jittery Bone's Farm &quot;wine&quot;	2	awesome	Last Available: "2011-10"
 5327	upside-down ghost protocol	0		Last Available: "2011-10"
 5328	wet squat sorority brain	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 62, Last Available: "2011-10"
 5329	nitrogenated twirling Nightstalker perfume	0		Effect: "Army of One", Effect Duration: 37, Last Available: "2011-10"
 5330	triple-dry aerosolized narrow drum of pomade	0		Effect: "Retrograde Relaxation", Effect Duration: 49, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	skewed dance instructor's extra-see-thru nightie	0		Experience Percent (Moxie): +10, Last Available: "2011-10"
-5333	Socratic beefcake's BRAINS shorts	0		Muscle: +25, Experience (Mysticality): +1, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	Socratic beefcake's BRAINS shorts	0		Muscle: +25, Experience (Mysticality): +1, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	jittery weightlifter's Mesmereyes&trade; contact lenses	0		Muscle: +15, Single Equip, Last Available: "2011-10"
 5335	scrunchie of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-10"
-5336	mirror prompt Tesla extremely skinny jeans	0		Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	hardy The Necbromancer's Hat of mayonnaise	0		Maximum HP: +50, Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	mirror prompt Tesla extremely skinny jeans	0		Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	hardy The Necbromancer's Hat of mayonnaise	0		Maximum HP: +50, Sleaze Spell Damage: +50, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	blue curative veiny The Necbromancer's Stein of Gandalf	0		Maximum HP: +10, Spell Critical Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-10"
-5339	hardened dangerous experienced The Necbromancer's Shorts	0		Experience: +2, Weapon Damage: +10, Damage Reduction: 3, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	hardened dangerous experienced The Necbromancer's Shorts	0		Experience: +2, Weapon Damage: +10, Damage Reduction: 3, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	narrow Jack Frost's Van der Graaf cool The Necbromancer's Wizard Staff	0		Moxie: +5, Cold Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	watered-down bad The Cooler Out of Space	2	decent	Last Available: "2011-10"
-5343	blinking ghostly The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
+5342	bad watered-down The Cooler Out of Space	2	decent	Last Available: "2011-10"
+5343	ghostly blinking The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	tumbling sorority girl's box	0		Last Available: "2011-10"
 5345	super-quantum activated Necbro wafers	0		Effect: "Guts Feeling", Effect Duration: 68, Last Available: "2020-09"
 5346	shaking death blossom	0		
@@ -5290,15 +5290,15 @@
 5387	supercool ridiculous earring	0		Moxie Percent: +20, Last Available: "2011-11"
 5388	sharpshooter's ridiculous sunglasses	0		Critical Hit Percent: +10, Last Available: "2011-11"
 5389	adequate ridiculous sandwich	3	good	Last Available: "2011-11"
-5390	weak hand-crafted ridiculous cocktail	2	EPIC	Last Available: "2011-11"
+5390	hand-crafted weak ridiculous cocktail	2	EPIC	Last Available: "2011-11"
 5391	brawny zombie monkey necklace of terror	0		Muscle Percent: +20, Spooky Spell Damage: +10
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
 5394	sandpaper	0		
 5395	fuchsia peppermint sprout	0		Last Available: "2011-11"
 5396	concentrated deionized cyan peppermint twist	0		Effect: "Chock Full o' Nanites", Effect Duration: 30, Last Available: "2011-11"
-5397	stale miniature shaking peppermint patty	2	decent	Last Available: "2011-11"
-5398	lime green wobbly peppermint crook	0		Last Available: "2011-11"
+5397	miniature stale shaking peppermint patty	2	decent	Last Available: "2011-11"
+5398	wobbly lime green peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	lime green candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
@@ -5306,13 +5306,13 @@
 5403	narrow Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	therapeutic veiny cane-mail shirt of the brute	0		Muscle Percent: +30, Maximum HP: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-12"
-5406	blinking Usain Bolt's greedy frightening cane-mail pants	0		Spooky Damage: +5, Meat Drop: +20, Initiative: +80, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	blinking Usain Bolt's greedy frightening cane-mail pants	0		Spooky Damage: +5, Meat Drop: +20, Initiative: +80, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	artisanal gray Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
 5408	weak bad squat upside-down Gin Mint	2	decent	Last Available: "2011-12"
 5409	bad narrow Tequiz Navidad	4	decent	Last Available: "2011-12"
-5410	tolerable weak spinning Mint Yulep	2	good	Last Available: "2011-12"
+5410	weak tolerable spinning Mint Yulep	2	good	Last Available: "2011-12"
 5411	artisanal Crimbojito	3	EPIC	Last Available: "2011-12"
-5412	tolerable weak teal Sangria de Menthe	2	good	Last Available: "2011-12"
+5412	weak tolerable teal Sangria de Menthe	2	good	Last Available: "2011-12"
 5413	spinning candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	colloidal vacuum-sealed licorice root	0		Effect: "Corona de la Salsa", Effect Duration: 69, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	deadly kumquartz ring	0		Weapon Damage: +5, Single Equip, Last Available: "2011-11"
 5425	energetic strawberyl necklace	0		Maximum MP Percent: +20, Single Equip, Last Available: "2011-11"
 5426	gravedigger's ruddy sucker bucket	0		Maximum HP Percent: +40, Spooky Damage: +10, Last Available: "2011-11"
-5427	resourceful sucker hakama	0		Maximum MP: +50, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	jittery sage sucker kabuto	0		Mysticality Percent: +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	resourceful sucker hakama	0		Maximum MP: +50, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	jittery sage sucker kabuto	0		Mysticality Percent: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	miser's sucker tachi	0		Meat Drop: +10, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5348,12 +5348,12 @@
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
-5448	blurry yellow furious stone	0		Last Available: "2012-12"
+5448	yellow blurry furious stone	0		Last Available: "2012-12"
 5449	blurry vanity stone	0		Last Available: "2012-12"
 5450	mirror lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	twirling avarice stone	0		Last Available: "2012-12"
-5453	wobbly blue gluttonous stone	0		Last Available: "2012-12"
+5453	blue wobbly gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	fuchsia gummi ingot	0		Last Available: "2011-11"
@@ -5363,14 +5363,14 @@
 5460	baleful fudgecycle of extreme caution of the empath	0		Spell Damage: +25, Monster Level: -25, Familiar Weight: +5, Single Equip, Last Available: "2011-11"
 5461	pulsating fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	quantum quantum tumbling resolution: be wealthier	0		Effect: "Mushroom Might", Effect Duration: 63, Last Available: "2012-01"
 5465	oxidized polymerized ghostly resolution: be happier	0		Effect: "Inappropriate Spirit", Effect Duration: 46, Last Available: "2012-01"
 5466	galvanized extra-electrified resolution: be stronger	0		Effect: "Egg-stra Arm", Effect Duration: 33, Last Available: "2012-01"
 5467	frozen wet resolution: be smarter	0		Effect: "Cake Caked", Effect Duration: 36, Last Available: "2012-01"
 5468	chilled pressed red resolution: be sexier	0		Effect: "The Rich Get Richer", Effect Duration: 65, Last Available: "2012-01"
 5469	flattened resolution: be feistier	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 54, Last Available: "2012-01"
-5470	diffused ghostly wobbly resolution: be kinder	0		Effect: "Dreadful Fear", Effect Duration: 37, Last Available: "2012-01"
+5470	diffused wobbly ghostly resolution: be kinder	0		Effect: "Dreadful Fear", Effect Duration: 37, Last Available: "2012-01"
 5471	non-dry super-colloidal resolution: be more adventurous	0		Effect: "Jittery", Effect Duration: 46, Last Available: "2012-01"
 5472	pressed colloidal magnetized resolution: be luckier	0		Effect: "Work For Hours a Week", Effect Duration: 32, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
@@ -5380,11 +5380,11 @@
 5477	super-warmed concentrated improved gummi snake	0		Effect: "Bat Attitude", Effect Duration: 48, Last Available: "2011-11"
 5478	adjusted wet gummi canary	0		Effect: "Innately Strong", Effect Duration: 37, Last Available: "2011-11"
 5479	rotten gummi bear	3	crappy	Last Available: "2011-11"
-5480	massive normal red gummi bear	7	good	Last Available: "2011-11"
-5481	massive special decent gummi bear	6	good	Effect: "Angry like the Wolf", Effect Duration: 35, Last Available: "2011-11"
+5480	normal massive red gummi bear	7	good	Last Available: "2011-11"
+5481	special massive decent gummi bear	6	good	Effect: "Angry like the Wolf", Effect Duration: 35, Last Available: "2011-11"
 5482	spoiled skewed drunki-bear	4	crappy	Last Available: "2011-11"
-5483	normal jumbo spinning fuchsia drunki-bear	5	good	Last Available: "2011-11"
-5484	yummy snack-sized drunki-bear	2	awesome	Last Available: "2011-11"
+5483	jumbo normal spinning fuchsia drunki-bear	5	good	Last Available: "2011-11"
+5484	snack-sized yummy drunki-bear	2	awesome	Last Available: "2011-11"
 5485	Annie Oakley's gummi bowtie	0		Critical Hit Percent: +20, Last Available: "2011-11"
 5486	fudge pocket square of horror	0		Spooky Spell Damage: +25, Last Available: "2011-11"
 5487	aromatic lollipop cufflinks	0		Stench Resistance: +1, Last Available: "2011-11"
@@ -5392,14 +5392,14 @@
 5489	ammonite fossil	0		Last Available: "2011-11"
 5490	bouncing belemnite fossil	0		Last Available: "2011-11"
 5491	bouncing trilobite candy mold	0		Last Available: "2011-11"
-5492	shaking maroon ammonite candy mold	0		Last Available: "2011-11"
+5492	maroon shaking ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	energized modified green gummi trilobite	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 34, Last Available: "2011-11"
 5495	liquefied gummi ammonite	0		Effect: "Dreadful Heat", Effect Duration: 23, Last Available: "2011-11"
 5496	vacuum-sealed electrified mirror gummi belemnite	0		Effect: "Artificially Sweet", Effect Duration: 61, Last Available: "2011-11"
 5497	jittery all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	auspicious banded Big Candy's tophat	0		Damage Absorption: +100, Item Drop: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	auspicious banded Big Candy's tophat	0		Damage Absorption: +100, Item Drop: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	shaking maroon Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	tumbling blessed box	0		
 5505	wobbly pack of pogs	0		Last Available: "2011-11"
 5506	stale jerky coins	3	decent	Last Available: "2011-11"
-5507	lousy watered-down Go-Wassail	2	decent	Last Available: "2011-11"
+5507	watered-down lousy Go-Wassail	2	decent	Last Available: "2011-11"
 5508	extra-quantum electrified teal Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Elemental Saucesphere", Effect Duration: 25, Last Available: "2011-11"
 5509	oxidized triple-corrupted bottle of bubbles	0		Effect: "Spooky Blur", Effect Duration: 39, Last Available: "2011-11"
 5510	warmed chilled wind-up meatcar	0		Effect: "Sewer-Drenched", Effect Duration: 58, Last Available: "2011-11"
@@ -5426,7 +5426,7 @@
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	fuchsia pog #10 (hobo)	0		Last Available: "2011-11"
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
-5526	alkaline tarnished mirror green spinning Atomic Pop	0		Effect: "Comprehensively Nourished", Effect Duration: 13, Last Available: "2020-09"
+5526	alkaline tarnished spinning green mirror Atomic Pop	0		Effect: "Comprehensively Nourished", Effect Duration: 13, Last Available: "2020-09"
 5527	upside-down do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
 5529	rotten miniature gray skewed berries of suffering	2	crappy	Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	upside-down stanky dance instructor's Rain-Doh wings	0		Experience Percent (Moxie): +10, Stench Spell Damage: +25, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	hardy Fonzie's Rain-Doh laser gun	0		Experience (Moxie): +1, Maximum HP: +50, Softcore Only, Last Available: "2012-02"
-5559	supercharged personal trainer's Rain-Doh lantern	0		Experience Percent (Muscle): +10, Maximum MP Percent: +30, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	supercharged personal trainer's Rain-Doh lantern	0		Experience Percent (Muscle): +10, Maximum MP Percent: +30, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	spinning Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	stylish Rain-Doh violet bo of courage	0		Moxie: +25, Spooky Resistance: +3, Softcore Only, Last Available: "2012-02"
@@ -5474,7 +5474,7 @@
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	weak tolerable Drac & Tan	2	good	Last Available: "2012-03"
-5574	boozy perfectly mixed upside-down Transylvania Sling	5	EPIC	Last Available: "2012-03"
+5574	perfectly mixed boozy upside-down Transylvania Sling	5	EPIC	Last Available: "2012-03"
 5575	weak perfectly mixed Shot of the Living Dead	2	EPIC	Last Available: "2012-03"
 5576	mediocre fancy bouncing Buttery Knob	3	decent	Effect: "Ice Packed", Effect Duration: 45, Last Available: "2012-03"
 5577	drinkable blue Slippery Knob	3	good	Last Available: "2012-03"
@@ -5486,10 +5486,10 @@
 5583	bad purple Golden Mean	4	decent	Last Available: "2012-03"
 5584	bad huge Green Giant	3	decent	Last Available: "2012-03"
 5585	acceptable gray Aye Aye	4	good	Last Available: "2012-03"
-5586	hand-crafted weak wobbly Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
+5586	weak hand-crafted wobbly Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
 5587	acceptable mirror Aye Aye, Tooth Tooth	3	good	Last Available: "2012-03"
-5588	fancy acceptable extra-dry wobbly mirror Humanitini	5	good	Effect: "Slippery Tongue", Effect Duration: 40, Last Available: "2012-03"
-5589	high-proof drinkable cyan More Humanitini than Humanitini	9	good	Last Available: "2012-03"
+5588	extra-dry acceptable fancy mirror wobbly Humanitini	5	good	Effect: "Slippery Tongue", Effect Duration: 40, Last Available: "2012-03"
+5589	drinkable high-proof cyan More Humanitini than Humanitini	9	good	Last Available: "2012-03"
 5590	aged weak blurry Oh, the Humanitini	2	awesome	Last Available: "2012-03"
 5591	practically non-alcoholic drinkable Great Older Fashioned	1	good	Last Available: "2012-03"
 5592	tolerable purple Fuzzy Tentacle	4	good	Last Available: "2012-03"
@@ -5502,41 +5502,41 @@
 5599	mediocre Sizzling Sinner	4	decent	Last Available: "2012-03"
 5600	smooth extra-dry Firewater	5	awesome	Last Available: "2012-03"
 5601	acceptable Earth and Firewater	4	good	Last Available: "2012-03"
-5602	hand-crafted practically non-alcoholic green Earth, Wind and Firewater	1	super ultra EPIC	Last Available: "2012-03"
+5602	practically non-alcoholic hand-crafted green Earth, Wind and Firewater	1	super ultra EPIC	Last Available: "2012-03"
 5603	watered-down smooth Slimosa	2	awesome	Last Available: "2012-03"
 5604	perfectly mixed Extra-slimy Slimosa	4	EPIC	Last Available: "2012-03"
 5605	hand-crafted Slimebite	3	EPIC	Last Available: "2012-03"
-5606	practically non-alcoholic tolerable Cement Mixer	1	good	Last Available: "2012-03"
-5607	weak bad ghostly Jackhammer	2	decent	Last Available: "2012-03"
+5606	tolerable practically non-alcoholic Cement Mixer	1	good	Last Available: "2012-03"
+5607	bad weak ghostly Jackhammer	2	decent	Last Available: "2012-03"
 5608	hand-crafted olive Dump Truck	4	EPIC	Last Available: "2012-03"
 5609	distilled perfectly mixed Fauna Libre	5	EPIC	Last Available: "2012-03"
 5610	smooth fancy spinning Chakra Libre	4	awesome	Effect: "Thicker, Sicker", Effect Duration: 50, Last Available: "2012-03"
 5611	drinkable Aura Libre	4	good	Last Available: "2012-03"
 5612	bad Sazerorc	3	decent	Last Available: "2012-03"
 5613	hand-crafted spinning Sazuruk-hai	3	EPIC	Last Available: "2012-03"
-5614	delicious weak olive bouncing tumbling Flaming Sazerorc	2	awesome	Last Available: "2012-03"
+5614	weak delicious bouncing olive tumbling Flaming Sazerorc	2	awesome	Last Available: "2012-03"
 5615	lousy maroon Green Velvet	3	decent	Last Available: "2012-03"
 5616	aged Green Muslin	3	awesome	Last Available: "2012-03"
-5617	tolerable weak Green Burlap	2	good	Last Available: "2012-03"
+5617	weak tolerable Green Burlap	2	good	Last Available: "2012-03"
 5618	mediocre purple Mohobo	3	decent	Last Available: "2012-03"
 5619	mediocre strong Moonshine Mohobo	5	decent	Last Available: "2012-03"
 5620	perfectly mixed Flaming Mohobo	3	EPIC	Last Available: "2012-03"
-5621	smooth practically non-alcoholic Drunken Philosopher	1	awesome	Last Available: "2012-03"
-5622	strong drinkable Drunken Neurologist	5	good	Last Available: "2012-03"
-5623	spirit-forward hand-crafted tumbling Drunken Astrophysicist	5	EPIC	Last Available: "2012-03"
-5624	watered-down mediocre jittery Dark & Starry	2	decent	Last Available: "2012-03"
-5625	high-proof bad enchanted blinking Black Hole	7	decent	Effect: "Ooh, Umami!", Effect Duration: 20, Last Available: "2012-03"
+5621	practically non-alcoholic smooth Drunken Philosopher	1	awesome	Last Available: "2012-03"
+5622	drinkable strong Drunken Neurologist	5	good	Last Available: "2012-03"
+5623	hand-crafted spirit-forward tumbling Drunken Astrophysicist	5	EPIC	Last Available: "2012-03"
+5624	mediocre watered-down jittery Dark & Starry	2	decent	Last Available: "2012-03"
+5625	high-proof enchanted bad blinking Black Hole	7	decent	Effect: "Ooh, Umami!", Effect Duration: 20, Last Available: "2012-03"
 5626	smooth Event Horizon	3	awesome	Last Available: "2012-03"
 5627	artisanal Herring Daiquiri	4	EPIC	Last Available: "2012-03"
-5628	lousy watered-down wobbly Herring Wallbanger	2	decent	Last Available: "2012-03"
+5628	watered-down lousy wobbly Herring Wallbanger	2	decent	Last Available: "2012-03"
 5629	perfectly mixed Herringtini	3	EPIC	Last Available: "2012-03"
-5630	special artisanal watered-down Lollipop Drop	2	EPIC	Effect: "Red Around the Gills", Effect Duration: 45, Last Available: "2012-03"
+5630	special watered-down artisanal Lollipop Drop	2	EPIC	Effect: "Red Around the Gills", Effect Duration: 45, Last Available: "2012-03"
 5631	irresponsibly strong bad Candy Alexander	7	decent	Last Available: "2012-03"
 5632	weak bad Candicaine	2	decent	Last Available: "2012-03"
 5633	weak drinkable Caipiranha	2	good	Last Available: "2012-03"
 5634	perfectly mixed watered-down Flying Caipiranha	2	EPIC	Last Available: "2012-03"
 5635	practically non-alcoholic perfectly mixed Flaming Caipiranha	1	super ultra EPIC	Last Available: "2012-03"
-5636	watered-down drinkable purple upside-down Punchplanter	2	good	Last Available: "2012-03"
+5636	drinkable watered-down purple upside-down Punchplanter	2	good	Last Available: "2012-03"
 5637	hand-crafted extra-dry Doublepunchplanter	5	EPIC	Last Available: "2012-03"
 5638	hand-crafted huge Haymaker	3	EPIC	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
@@ -5548,17 +5548,17 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	red sharpshooter's calendar	0		Critical Hit Percent: +10, Damage Reduction: 4
-5648	supercharged Boris's Helm of the cheetah	0		Maximum MP Percent: +30, Initiative: +60, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	supercharged Boris's Helm of the cheetah	0		Maximum MP Percent: +30, Initiative: +60, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	avaricious staph of homophones of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +30
-5650	vibrating extremely unsafe Boris's Helm (askew) of chilblains	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Cold Damage: +25, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	vibrating extremely unsafe Boris's Helm (askew) of chilblains	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, Cold Damage: +25, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	miniature stale maroon nailswurst	2	decent	
+5654	stale miniature maroon nailswurst	2	decent	
 5655	spirit-forward drinkable used beer	5	good	
 5656	tumbling Huggler Radio	0		Free Pull
 5657	blinking fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
-5658	mirror jittery slap and slap again recipe	0		Recipe: "slap and slap again"
+5658	jittery mirror slap and slap again recipe	0		Recipe: "slap and slap again"
 5659	cyan insulting hat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "cap 2"
 5660	up-at-dawn offensive moustache	0		Adventures: +5, Single Equip
 5661	narrow asbestos-lined hairshirt	0		Hot Resistance: +5
@@ -5571,15 +5571,15 @@
 5668	bouncing bagged &quot;L&quot;	0		
 5669	cyan club	0		
 5670	flavorless fettucini &eacute;pines Inconnu	4	decent	
-5671	mediocre irresponsibly strong mirror slap and slap again	10	decent	
+5671	irresponsibly strong mediocre mirror slap and slap again	10	decent	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	modified blinking watered-down Red Minotaur	1		Effect: "A Contender", Effect Duration: 35
-5676	yellow ghostly pool torpedo	0		Last Available: "2012-05"
-5677	rosy-cheeked Ze&trade; goggles	0		Maximum HP Percent: +30, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5676	ghostly yellow pool torpedo	0		Last Available: "2012-05"
+5677	rosy-cheeked Ze&trade; goggles	0		Maximum HP Percent: +30, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	stylish stylish swimsuit of the pedagogue	0		Moxie: +25, Experience: +3, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	stylish stylish swimsuit of the pedagogue	0		Moxie: +25, Experience: +3, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
 5681	toothsome P.B.L.T.	3	awesome	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5591,25 +5591,25 @@
 5688	UV monocular of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
 5689	drone self-destruct chip	0		
 5690	cyan Jeff Goldblum larva	0		
-5691	skewed gray pacification grenade	0		
+5691	gray skewed pacification grenade	0		
 5692	quantum disintegrator pistol of the empath	0		Familiar Weight: +5
 5693	ghostly phase-tuned shield generator belt of courage	0		Spooky Resistance: +3, Single Equip
 5694	Thwaitgold woollybear statuette	0		
 5695	olive squat friendly bugbear detector	0		Familiar Weight: +3, Single Equip
-5696	yellow jittery bugbear purification pill	0		
+5696	jittery yellow bugbear purification pill	0		
 5697	gray 1 Meat	0		
 5698	energetic cool The Lost Glasses	0		Moxie: +5, Maximum MP Percent: +20, Single Equip
 5699	lime green The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	mannequin	0		Familiar Weight: +5
-5703	gray ghostly crayon shavings	0		Last Available: "2012-06"
+5703	ghostly gray crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	spinning foul-smelling curative wax hat	0		Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	upside-down smartaleck's wax pants of the detective	0		Moxie Percent: +30, Item Drop: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	spinning foul-smelling curative wax hat	0		Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	upside-down smartaleck's wax pants of the detective	0		Moxie Percent: +30, Item Drop: +20, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	altered tarnished drop of water-37	0		Effect: "Booing Radly", Effect Duration: 61, Last Available: "2012-07"
-5709	energetic curative fireman's helmet	0		Maximum MP Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	energetic curative fireman's helmet	0		Maximum MP Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	wizardly fire axe	0		Mysticality: +25, Last Available: "2012-07"
 5713	prompt smelly fire extinguisher of the cougar	0		Moxie: +20, Stench Spell Damage: +10, Adventures: +3, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,14 +5618,14 @@
 5717	normal FDKOL hotcakes	3	good	Last Available: "2012-07"
 5718	shaking blue hot egg	0		Last Available: "2012-07"
 5719	narrow smoking grass	0		Last Available: "2012-07"
-5720	massive adequate ghostly fiery wing	9	good	Last Available: "2012-07"
+5720	adequate massive ghostly fiery wing	9	good	Last Available: "2012-07"
 5721	horrifying wings of fire of the sewer	0		Stench Damage: +25, Spooky Damage: +25, Last Available: "2012-07"
 5722	blue Temple Grandin's FDKOL fire hose	0		Familiar Weight: +7, Last Available: "2012-07"
 5723	polymerized Vulcanized bottle of fire	0		Effect: "Elemental Saucesphere", Effect Duration: 48, Last Available: "2012-07"
 5724	huge molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	avaricious toasty hot daub bun	0		Hot Damage: +5, Meat Drop: +30, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	savvy hot daub stand of the glutton	0		Mysticality Percent: +20, Food Drop: +100, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	avaricious toasty hot daub bun	0		Hot Damage: +5, Meat Drop: +30, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	savvy hot daub stand of the glutton	0		Mysticality Percent: +20, Food Drop: +100, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	Annie Oakley's brainy foot-long hot daub	0		Mysticality: +5, Critical Hit Percent: +20, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	tasty angst burger	4	awesome	
@@ -5638,7 +5638,7 @@
 5737	aerosolized daub-breaker	0		Effect: "Perfect Hair", Effect Duration: 25, Last Available: "2020-09"
 5738	blurry greasy Camp Scout backpack	0		Sleaze Spell Damage: +10, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	delicious squat twirling bag of GORP	3	awesome	Last Available: "2012-07"
+5740	delicious twirling squat bag of GORP	3	awesome	Last Available: "2012-07"
 5741	triple-distilled hand-crafted water purification pills	10	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	acceptable CSA scoutmaster's &quot;water&quot;	4	good	Last Available: "2012-07"
@@ -5647,7 +5647,7 @@
 5746	decent bag of QWOP	4	good	Last Available: "2012-07"
 5747	Vulcanized oxidized enhanced CSA bravery badge	0		Effect: "Prelude of Precision", Effect Duration: 29, Last Available: "2012-07"
 5748	skewed CSA all-purpose soap	0		Last Available: "2012-07"
-5749	irresponsibly strong drinkable blinking CSA cheerfulness ration	7	good	Last Available: "2012-07"
+5749	drinkable irresponsibly strong blinking CSA cheerfulness ration	7	good	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	diet flavorless teal crappy brain	1	decent	
@@ -5665,11 +5665,11 @@
 5765	knitted fuzzy earmuffs of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +3, Familiar Effect: "1.5xVolley, cap 32"
 5766	crafty fuzzy montera of wisdom of temperance	0		Mysticality: +15, Maximum MP: +10, Sleaze Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	skewed lime green Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	tumbling gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	tumbling gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5695,7 +5695,7 @@
 5796	flattened cold-filtered Gearhead Goo	0		Effect: "Almost Cool", Effect Duration: 21
 5797	colloidal electrified bouncing Missing Eye Simulation Device	0		Effect: "Hot Blooded", Effect Duration: 36
 5798	non-corrupted irradiated altered Gnollish Crossdress	0		Effect: "Mushroom Samba", Effect Duration: 50
-5799	super-pressed jittery narrow eldritch dough	0		Effect: "Engorged Weapon", Effect Duration: 65
+5799	super-pressed narrow jittery eldritch dough	0		Effect: "Engorged Weapon", Effect Duration: 65
 5800	quantum squat Charity's choker	0		Effect: "Oiled Skin", Effect Duration: 53
 5801	unsweetened colloidal Smart Bone Dust	0		Effect: "Overstimulated", Effect Duration: 36
 5802	adjusted perpendicular guano	0		Effect: "Smelly Pants", Effect Duration: 30
@@ -5708,7 +5708,7 @@
 5809	adjusted activated Knob Goblin Mutagen	0		Effect: "Oxygenated Blood", Effect Duration: 49
 5810	double-wet super-nitrogenated upside-down Tears of the Quiet Healer	0		Effect: "Baconstoned", Effect Duration: 35
 5811	wet diffused blinking tube of lipstick	0		Effect: "Gleaming White Teeth", Effect Duration: 58
-5812	altered yellow ghostly skelelton spine	0		Effect: "Bastard!", Effect Duration: 46
+5812	altered ghostly yellow skelelton spine	0		Effect: "Bastard!", Effect Duration: 46
 5813	boiled ionized smut orc sunglasses	0		Effect: "Intimidating Mien", Effect Duration: 30
 5814	super-cold-filtered triple-magnetized enhanced blob of acid	0		Effect: "Poker Faced", Effect Duration: 24
 5815	warmed narrow mirror flayed mind	0		Effect: "Be a Mind Master", Effect Duration: 18
@@ -5725,7 +5725,7 @@
 5826	dry diffused zombie hollandaise	0		Effect: "Locks Like the Raven", Effect Duration: 65
 5827	double-chilled altered skeletal banana	0		Effect: "Down With Chow", Effect Duration: 24
 5828	flattened gilt perfume bottle	0		Effect: "Sharp Weapon", Effect Duration: 55
-5829	cold-filtered irradiated fuchsia shaking janglin' bones	0		Effect: "Boon of She-Who-Was", Effect Duration: 16
+5829	cold-filtered irradiated shaking fuchsia janglin' bones	0		Effect: "Boon of She-Who-Was", Effect Duration: 16
 5830	modified teal pygmy papers	0		Effect: "Raging Animal", Effect Duration: 24
 5831	adjusted pygmy dart	0		Effect: "Chain Chain Chains", Effect Duration: 43
 5832	moist tumbling secret mummy herbs and spices	0		Effect: "Far Out", Effect Duration: 29
@@ -5743,7 +5743,7 @@
 5844	polymerized dry ghostly una poca de gracia	0		Effect: "Chalky Hand", Effect Duration: 63
 5845	irradiated altered compressed air canister	0		Effect: "Creepypasted", Effect Duration: 16
 5846	quadruple-dry narrow upside-down salt water taffy	0		Effect: "Cotton Mouthed", Effect Duration: 25
-5847	colloidal olive blurry unholy water	0		Effect: "On a Roll", Effect Duration: 33
+5847	colloidal blurry olive unholy water	0		Effect: "On a Roll", Effect Duration: 33
 5848	irradiated pressed Bangyomaman battle juice	0		Effect: "On the Shoulders of Giants", Effect Duration: 65
 5849	dry energized handyman &quot;hand soap&quot;	0		Effect: "Mucilaginous Muscle", Effect Duration: 55
 5850	vacuum-sealed corrupted space marine flash grenade	0		Effect: "Heavily Breathing", Effect Duration: 14
@@ -5754,21 +5754,21 @@
 5855	oxidized activated pulsating Osk'r Chow	0		Effect: "Norwhalloped", Effect Duration: 52
 5856	denatured wobbly Scuba Snack	0		Effect: "Nasty, Nasty Breath", Effect Duration: 66
 5857	energized grey cube	0		Effect: "Clyde's Blessing", Effect Duration: 47
-5858	warmed cyan pulsating votive candle	0		Effect: "Pork Power", Effect Duration: 24
-5859	oxidized cyan tumbling booby trap	0		Effect: "Greased-Up Familiar", Effect Duration: 45
+5858	warmed pulsating cyan votive candle	0		Effect: "Pork Power", Effect Duration: 24
+5859	oxidized tumbling cyan booby trap	0		Effect: "Greased-Up Familiar", Effect Duration: 45
 5860	non-pickled Agent Corrigan's cigarette	0		Effect: "Cat Class, Cat Style", Effect Duration: 13
 5861	magnetized huge good ash	0		Effect: "Cold as Ice", Effect Duration: 33
-5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
-5864	spinning shaking papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
+5864	shaking spinning papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	altered jittery papier-mochi	0		Effect: "Lifted Spirits", Effect Duration: 44, Last Available: "2012-09"
 5866	deionized vacuum-sealed papier-m&acirc;chaeranthera	0		Effect: "Super Skill", Effect Duration: 32, Last Available: "2012-09"
 5867	non-magnetized flattened papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Your Favorite Flavor", Effect Duration: 67, Last Available: "2012-09"
 5868	maroon Tesla medical-grade papier-m&acirc;ch&eacute;te	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-09"
 5869	ghostly mansplainer's papier-m&acirc;chine gun of horror	0		Monster Level: +15, Spooky Spell Damage: +25, Last Available: "2012-09"
 5870	slick papier-masque of the cougar	0		Moxie: 30, Single Equip, Last Available: "2012-09"
-5871	arcane researcher's papier-mitre of the businessman	0		Experience Percent (Mysticality): +10, Meat Drop: +50, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	blue greasy boxer's papier-m&acirc;churidars	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	arcane researcher's papier-mitre of the businessman	0		Experience Percent (Mysticality): +10, Meat Drop: +50, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	blue greasy boxer's papier-m&acirc;churidars	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	blinking papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	wobbly papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	olive skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	baleful sinister cool brainy Bonestabber	0		Mysticality: +5, Moxie: +5, Spell Damage: 35, Last Available: "2012-10"
-5887	drinkable practically non-alcoholic crystal skeleton vodka	1	good	Last Available: "2012-10"
+5887	practically non-alcoholic drinkable crystal skeleton vodka	1	good	Last Available: "2012-10"
 5888	maroon Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	auxiliary backbone of James Dean	0		Experience (Moxie): +3, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5819,11 +5819,11 @@
 5921	plastic Uncle Crimboku of Gandalf	0		Spell Critical Percent: +20, Last Available: "2012-12"
 5922	twirling plastic MechaElf of the dark arts	0		Spell Damage Percent: +100, Last Available: "2012-12"
 5923	gray plastic ingot	0		Last Available: "2012-12"
-5924	jittery wobbly electrical thingamabob	0		Last Available: "2012-12"
+5924	wobbly jittery electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	lime green blurry BittyCar MeatCar	0		Last Available: "2012-12"
+5926	blurry lime green BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	Herculean brainwave-controlled unicorn horn	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	Herculean brainwave-controlled unicorn horn	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blurry blind-packed capsule toy	0		Last Available: "2012-12"
 5931	spinning jittery wool manspreader's fortified plastic four-shadowed mime	0		Damage Absorption: +60, Monster Level: +10, Cold Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	yellow hardy plastic Father McGruber	0		Maximum HP: +50, Last Available: "2012-12"
 5961	squat therapeutic plastic Hank North, Photojournalist	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-12"
 5962	dance instructor's plastic blazing bat	0		Experience Percent (Moxie): +10, Last Available: "2012-12"
-5963	tumbling wobbly deadly electronic dulcimer pants of the businessman	0		Weapon Damage: +5, Meat Drop: +50, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	tumbling wobbly deadly electronic dulcimer pants of the businessman	0		Weapon Damage: +5, Meat Drop: +50, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	careful Frown Exerciser of Gandalf	0		Spell Critical Percent: +20, Monster Level: -10, Single Equip, Last Available: "2012-12"
 5966	maroon soul monocle	0		Single Equip
@@ -5873,21 +5873,21 @@
 5975	jittery record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	teal record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	ghostly Da Vinci's silent beret of the empath of the sweet-tooth	0		Experience (Mysticality): +5, Familiar Weight: +5, Candy Drop: +100, Familiar Effect: "1xVolley, cap 3"
-5978	half-sized adequate wobbly slice of pizza	2	good	Last Available: "2013-02"
+5978	adequate half-sized wobbly slice of pizza	2	good	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	blinking skewed cartoon heart	0		Last Available: "2013-02"
 5981	huge star	0		Last Available: "2013-02"
-5982	tolerable triple-distilled tankard of ale	6	good	Last Available: "2013-02"
+5982	triple-distilled tolerable tankard of ale	6	good	Last Available: "2013-02"
 5983	narrow vial of holy water	0		Last Available: "2013-02"
-5984	mirror perfumed manspreader's cloth cap of Tarzan	0		Experience (Muscle): +3, Monster Level: +10, Stench Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	mirror perfumed manspreader's cloth cap of Tarzan	0		Experience (Muscle): +3, Monster Level: +10, Stench Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	spinning foul-smelling sharpshooter's hardy iron dagger	0		Maximum HP: +50, Critical Hit Percent: +10, Stench Damage: +10, Last Available: "2013-02"
-5986	thick stale huge hamburger	5	decent	Last Available: "2013-02"
+5986	stale thick huge hamburger	5	decent	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	mirror potion	0		Last Available: "2013-02"
-5990	enchanted artisanal cyan bottle of wine	4	EPIC	Effect: "Thunderheart", Effect Duration: 25, Last Available: "2013-02"
+5990	artisanal enchanted cyan bottle of wine	4	EPIC	Effect: "Thunderheart", Effect Duration: 25, Last Available: "2013-02"
 5991	purple round bomb	0		Last Available: "2013-02"
-5992	up-at-dawn nasty medical-grade iron helmet	0		Stench Damage: +5, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	up-at-dawn nasty medical-grade iron helmet	0		Stench Damage: +5, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	reassuring rosy-cheeked smooth steel sword	0		Moxie: +15, Maximum HP Percent: +30, Spooky Resistance: +1, Last Available: "2013-02"
 5994	moldy gigantic whole roasted chicken	8	crappy	Last Available: "2013-02"
 5995	jittery massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	mediocre shining goblet	3	decent	Last Available: "2013-02"
 5999	tumbling tumbling fireball	0		Last Available: "2013-02"
-6000	censurious crown of the pedagogue of vim and vigor	0		Experience: +3, Maximum HP Percent: +50, Sleaze Resistance: +3, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	censurious crown of the pedagogue of vim and vigor	0		Experience: +3, Maximum HP Percent: +50, Sleaze Resistance: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	family-friendly manspreader's Fonzie's sword	0		Experience (Moxie): +1, Monster Level: +10, Sleaze Resistance: +1, Last Available: "2013-02"
-6002	Lo Pan's clever Helm of the Scream Emperor of doom	0		Maximum MP: +20, Spell Critical Percent: +30, Spooky Spell Damage: +50, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	Lo Pan's clever Helm of the Scream Emperor of doom	0		Maximum MP: +20, Spell Critical Percent: +30, Spooky Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	spinning tumbling Usain Bolt's Cloak of Dire Shadows of horror of bravery	0		Spooky Spell Damage: +25, Spooky Resistance: +5, Initiative: +80, Last Available: "2013-02"
 6004	up-at-dawn Herculean Sword of Dark Omens of vim and vigor	0		Experience (Muscle): +1, Maximum HP Percent: +50, Adventures: +5, Last Available: "2013-02"
 6005	aromatic veiny sinister Shield of Icy Fate	0		Spell Damage: +10, Maximum HP: +10, Stench Resistance: +1, Damage Reduction: 7, Last Available: "2013-02"
-6006	wool gravedigger's scorching Greaves of the Murk Lord	0		Hot Damage: +25, Spooky Damage: +10, Cold Resistance: +1, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	wool gravedigger's scorching Greaves of the Murk Lord	0		Hot Damage: +25, Spooky Damage: +10, Cold Resistance: +1, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	deadly smartaleck's wizardly Gauntlets of the Blood Moon	0		Mysticality: +25, Moxie Percent: +30, Weapon Damage: +5, Single Equip, Last Available: "2013-02"
 6008	therapeutic dangerous Boots of Twilight Whispers of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-02"
 6009	prompt deadly supercool Belt of Howling Anger	0		Moxie Percent: +20, Weapon Damage: +5, Adventures: +3, Single Equip, Last Available: "2013-02"
@@ -5948,7 +5948,7 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	tumbling Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	decent small Taco Dan's Taco Stand Taco	2	good	Last Available: "2012-12"
-6053	weak hand-crafted special Taco Dan's Taco Stand Chimichangarita	2	EPIC	Effect: "Stinking Cloud", Effect Duration: 25, Last Available: "2012-12"
+6053	hand-crafted weak special Taco Dan's Taco Stand Chimichangarita	2	EPIC	Effect: "Stinking Cloud", Effect Duration: 25, Last Available: "2012-12"
 6054	alkaline Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Flower Power", Effect Duration: 34, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
@@ -5966,13 +5966,13 @@
 6068	loose blade	0		
 6069	squat gray goblin bone hilt	0		
 6070	narrow sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	ghostly confusing LED clock	0		Last Available: "2012-12"
 6073	double-cold-filtered upside-down haggis-infused soap	0		Effect: "Witch's Brood", Effect Duration: 17, Last Available: "2012-12"
 6074	dry boiled shaking magicberry tablets	0		Effect: "Shortened", Effect Duration: 18, Last Available: "2012-12"
 6075	concentrated magnetized skewed gray 37x37x37 puzzle cube	0		Effect: "Sweet and Yellow", Effect Duration: 12, Last Available: "2012-12"
 6076	drinkable McLeod's Hard Haggis-Ade	3	good	Last Available: "2012-12"
-6077	stale small skewed haggis-wrapped haggis-stuffed haggis	2	decent	Last Available: "2012-12"
+6077	small stale skewed haggis-wrapped haggis-stuffed haggis	2	decent	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	twirling maroon school calculator watch	0		Last Available: "2012-12"
 6080	therapeutic haggis socks	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	mirror goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	wobbly bonsai tree	0		Last Available: "2013-12"
-6121	practically non-alcoholic tolerable huge Chinese beer	1	good	Last Available: "2013-12"
+6121	tolerable practically non-alcoholic huge Chinese beer	1	good	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	mirror rhinoceros horn	0		Last Available: "2013-12"
 6124	red furry pink pillow	0		Last Available: "2013-12"
@@ -6037,10 +6037,10 @@
 6139	flame-wreathed rubber gloves	0		Hot Spell Damage: +10, Last Available: "2013-12"
 6140	lime green Chinese curse words	0		Last Available: "2013-12"
 6141	upside-down triad summoning scroll	0		Last Available: "2013-12"
-6142	snack-sized rotten roasted duck	2	crappy	Last Available: "2013-12"
+6142	rotten snack-sized roasted duck	2	crappy	Last Available: "2013-12"
 6143	spoiled miniature wobbly dead meat bun	2	crappy	Last Available: "2013-12"
 6144	scorching cat collar	0		Hot Damage: +25, Single Equip, Last Available: "2013-12"
-6145	Jim Carey's suspicious-looking fedora of the scaredy-cat	0		Monster Level: 10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	Jim Carey's suspicious-looking fedora of the scaredy-cat	0		Monster Level: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	olive Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,8 +6058,8 @@
 6161	supercool regret hose	0		Moxie Percent: +20, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	jittery Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	jittery aromatic commodore's hat of Calamity Jane	0		Critical Hit Percent: +15, Stench Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	narrow maroon reassuring naval trousers	0		Spooky Resistance: +1, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	jittery aromatic commodore's hat of Calamity Jane	0		Critical Hit Percent: +15, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	narrow maroon reassuring naval trousers	0		Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	wobbly thinker's deck cannon of wisdom	0		Mysticality: 25, Last Available: "2013-12"
 6167	ornamental sextant of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2013-12"
 6168	huge toasty fortified Bloodbath	0		Damage Absorption: +60, Hot Damage: +5, Last Available: "2013-12"
@@ -6077,30 +6077,30 @@
 6180	squat cosmic potted meat product	0		
 6181	cosmic potato	0		
 6182	cosmic cream	0		
-6183	twirling narrow yellow cosmic fruit	0		
+6183	yellow narrow twirling cosmic fruit	0		
 6184	perfumed double-paned Jarlsberg's hat of bravery	0		Cold Resistance: +5, Spooky Resistance: +5, Stench Resistance: +5
 6185	tasty tiny pulsating consummate hard-boiled egg	1	awesome	
 6186	enchanted moldy consummate fried egg	3	crappy	Effect: "Moose Wisdom", Effect Duration: 5
 6187	rotten consummate egg salad	3	crappy	
-6188	rotten small narrow blinking consummate bagel	2	crappy	
-6189	flavorless squat wobbly consummate sliced bread	4	decent	
+6188	rotten small blinking narrow consummate bagel	2	crappy	
+6189	flavorless wobbly squat consummate sliced bread	4	decent	
 6190	spoiled consummate hot dog bun	3	crappy	
 6191	adequate consummate brownie	4	good	
 6192	normal consummate toast	4	good	
 6193	artisanal passable stout	4	EPIC	
-6194	moldy jumbo consummate soup	5	crappy	
+6194	jumbo moldy consummate soup	5	crappy	
 6195	tasty consummate corn chips	3	awesome	
 6196	bland consummate salad	3	decent	
 6197	adequate half-sized upside-down consummate salsa	2	good	
 6198	enchanted normal consummate sauerkraut	4	good	Effect: "A Few Extra Pounds", Effect Duration: 20
 6199	spoiled consummate cheese slice	3	crappy	
 6200	flavorless consummate melted cheese	3	decent	
-6201	miniature moldy teal narrow upside-down consummate bacon	2	crappy	
+6201	miniature moldy teal upside-down narrow consummate bacon	2	crappy	
 6202	small bland consummate meatloaf	2	decent	
 6203	special rotten consummate steak	4	crappy	Effect: "Super Structure", Effect Duration: 15
 6204	super-sized tasty tumbling lime green consummate cuts	5	awesome	
-6205	rotten bite-sized fancy consummate frankfurter	1	crappy	Effect: "High Blood Chocolate Content", Effect Duration: 15
-6206	delicious big consummate french fries	5	awesome	
+6205	bite-sized fancy rotten consummate frankfurter	1	crappy	Effect: "High Blood Chocolate Content", Effect Duration: 15
+6206	big delicious consummate french fries	5	awesome	
 6207	half-sized decent lime green consummate baked potato	2	good	
 6208	watered-down lousy acceptable vodka	2	decent	
 6209	stale consummate ice cream	3	decent	
@@ -6109,36 +6109,36 @@
 6212	tasty consummate strawberries	3	awesome	
 6213	yummy spinning consummate sorbet	3	awesome	
 6214	tolerable adequate rum	3	good	
-6215	fancy lousy mediocre lager	4	decent	Effect: "Thunderheart", Effect Duration: 5
+6215	lousy fancy mediocre lager	4	decent	Effect: "Thunderheart", Effect Duration: 5
 6216	rotten diet immaculate grilled cheese	1	crappy	
 6217	flavorless miniature immaculate ice cream sandwich	2	decent	
 6218	bland immaculate hot dog	3	decent	
 6219	massive delicious immaculate egg salad sandwich	9	awesome	
-6220	normal snack-sized perfect sandwich	2	good	
+6220	snack-sized normal perfect sandwich	2	good	
 6221	adequate purple perfect chef salad	3	good	
 6222	immense moldy perfect breakfast	9	crappy	
 6223	spoiled sublime deluxe hot dog	3	crappy	
 6224	rotten sublime stew	4	crappy	
-6225	miniature adequate sublime nachos	2	good	
+6225	adequate miniature sublime nachos	2	good	
 6226	rotten Ultimate Breakfast Sandwich	3	crappy	
-6227	decent diet Loaded Baked Potato	1	good	
+6227	diet decent Loaded Baked Potato	1	good	
 6228	adequate Omega Sundae	3	good	
-6229	watered-down acceptable bouncing Das Sauerlager	2	good	
+6229	acceptable watered-down bouncing Das Sauerlager	2	good	
 6230	bad green Bologna Lambic	3	decent	
 6231	weak acceptable Vodka Dog	2	good	
 6232	watered-down bad Disappointed Russian	2	decent	
-6233	weak special acceptable blinking Chunky Mary	2	good	Effect: "Larger", Effect Duration: 25
-6234	weak smooth gray narrow Nachojito	2	awesome	
+6233	acceptable special weak blinking Chunky Mary	2	good	Effect: "Larger", Effect Duration: 25
+6234	smooth weak gray narrow Nachojito	2	awesome	
 6235	tolerable Le Roi	4	good	
-6236	fancy triple-distilled hand-crafted jittery Over Easy Rider	6	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 45
+6236	fancy hand-crafted triple-distilled jittery Over Easy Rider	6	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 45
 6237	green cosmic six-pack	0		
 6239	galvanized boiled cube of ectoplasm	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 15
-6240	altered corrupted huge olive Illuminati earpiece	0		Effect: "Video Game Hot Dog", Effect Duration: 35
+6240	altered corrupted olive huge Illuminati earpiece	0		Effect: "Video Game Hot Dog", Effect Duration: 35
 6241	moist dry quadruple-boiled tumbling censored can label	0		Effect: "Got Your Boots On", Effect Duration: 13
 6242	double-frozen skewed ectoplasm <i>au jus</i>	0		Effect: "Fever From the Flavor", Effect Duration: 20
 6243	activated colloidal blinking the kindest cut	0		Effect: "Fishy", Effect Duration: 53
-6244	energized huge maroon cat's paw	0		Effect: "Devil Inside", Effect Duration: 69
-6245	dry irradiated diffused olive ghostly wobbly ASCII fu manchu	0		Effect: "Moose Wisdom", Effect Duration: 38
+6244	energized maroon huge cat's paw	0		Effect: "Devil Inside", Effect Duration: 69
+6245	dry irradiated diffused wobbly ghostly olive ASCII fu manchu	0		Effect: "Moose Wisdom", Effect Duration: 38
 6246	flattened adjusted shaking teal demonic surgical gloves	0		Effect: "Smokin'", Effect Duration: 59
 6247	pickled clip-on ninja tie	0		Effect: "Dancing Prowess", Effect Duration: 69
 6248	galvanized warmed squat gamer slurry	0		Effect: "Fratty Flavor", Effect Duration: 35
@@ -6161,7 +6161,7 @@
 6265	clever rosy-cheeked Staff of the Cream of the Cream of the glutton	0		Maximum HP Percent: +30, Maximum MP: +20, Food Drop: +100, Jiggle: "Attune to Monster's Essence"
 6266	yellow jar of protein powder	0		
 6267	flavorless grain of protein powder	3	decent	
-6268	quadruple-nitrogenated gray skewed pec oil	0		Effect: "Cold Hands", Effect Duration: 31
+6268	quadruple-nitrogenated skewed gray pec oil	0		Effect: "Cold Hands", Effect Duration: 31
 6269	gym membership card of the businessman	0		Meat Drop: +50
 6270	concentrated Squat-Thrust Magazine	0		Effect: "Puzzle Fury", Effect Duration: 37
 6271	massive dumbbell	0		
@@ -6183,17 +6183,17 @@
 6287	chilly manspreader's chaotic electrified Mark III Steam-Hat	0		Spell Critical Percent: +10, Monster Level: +10, Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6288	asbestos-lined baleful arcane researcher's brawny Mark IV Steam-Hat	0		Muscle Percent: +20, Experience Percent (Mysticality): +10, Spell Damage: +25, Hot Resistance: +5, Item Drop: +5, Familiar Effect: "1xLep, cap 37"
 6289	nasty electrified stylish smooth Mark V Steam-Hat of Gandalf	0		Moxie: 40, Spell Critical Percent: +20, Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
-6290	tumbling teal steam-powered model rocketship	0		
+6290	teal tumbling steam-powered model rocketship	0		
 6291	careful manspreader's punk rock jacket	0		Monster Level: 0
 6292	nasty curative safety pin	0		Stench Damage: +5, HP Regen Min: 3, HP Regen Max: 5
-6293	snack-sized bland stolen sushi	2	decent	
+6293	bland snack-sized stolen sushi	2	decent	
 6294	very overdue library book	0		
 6295	olive drum 'n' bass 'n' drum 'n' bass record	0		
 6296	squat cosmic bucket	0		Free Pull
 6297	green fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	Thwaitgold firefly statuette	0		
 6299	ghostly model airship	0		
-6300	triple-diffused bouncing twirling Super Weight-Gain 9000	0		Effect: "Frisky Spirit", Effect Duration: 17
+6300	triple-diffused twirling bouncing Super Weight-Gain 9000	0		Effect: "Frisky Spirit", Effect Duration: 17
 6301	activated modified polarized possibility potion	0		Effect: "On Pins and Needles", Effect Duration: 34
 6302	eleven-foot pole	0		
 6303	ring of Detect Boring Doors	0		
@@ -6221,7 +6221,7 @@
 6325	twirling inspector's aromatic aquamariner's necklace of the brute	0		Muscle Percent: +30, Stench Resistance: +1, Item Drop: +15, Single Equip
 6326	narrow wholesome pearl diver's ring of the businessman	0		Maximum HP Percent: +10, Meat Drop: +50, Single Equip
 6327	Usain Bolt's sizzling pearl diver's necklace	0		Hot Damage: +10, Initiative: +80, Single Equip
-6328	tumbling upside-down sushi doily	0		
+6328	upside-down tumbling sushi doily	0		
 6329	scimitar cozy	0		
 6330	fish stick cozy	0		
 6331	bazooka cozy	0		
@@ -6238,8 +6238,8 @@
 6342	stanky scorching super-strong air freshener	0		Hot Damage: +25, Stench Spell Damage: +25
 6343	alkaline aerosolized blurry Mer-kin lipstick	0		Effect: "Flower Power", Effect Duration: 25
 6344	mirror Mer-kin mouthsoap	0		
-6345	warmed chilled jittery shaking narrow Mer-kin strongjuice	0		Effect: "Covetous Robbery", Effect Duration: 20
-6346	blurry maroon Mer-kin fitbrine	0		
+6345	warmed chilled narrow jittery shaking Mer-kin strongjuice	0		Effect: "Covetous Robbery", Effect Duration: 20
+6346	maroon blurry Mer-kin fitbrine	0		
 6347	ionized purple Mer-kin ragejuice	0		Effect: "Fortunate Resolve", Effect Duration: 46
 6348	brainy Mer-kin dragbelt	0		Mysticality: +5, Experience (Muscle): +20, Single Equip
 6349	spinning Mer-kin eyeglasses of the sewer	0		Stench Damage: +25, Experience (Mysticality): +20, Single Equip
@@ -6249,11 +6249,11 @@
 6353	shaking Mer-kin dreadscroll	0		
 6354	colloidal improved jittery Mer-kin smartjuice	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 38
 6355	oxidized Mer-kin cooljuice	0		Effect: "Incensed", Effect Duration: 44
-6356	red jittery narrow Mer-kin worktea	0		
+6356	red narrow jittery Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	jittery perfumed Mer-kin begsign	0		Stench Resistance: +5, Meat Drop: +40
-6360	bouncing Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	bouncing Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	cold-filtered purple pulled taffy	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 63, Last Available: "2013-04"
 6362	extra-deionized narrow pulled indigo taffy	0		Effect: "Always In Motion", Effect Duration: 40, Last Available: "2013-04"
 6363	flattened magnetized huge pulled taffy	0		Effect: "Aloofah", Effect Duration: 31, Last Available: "2013-04"
@@ -6265,7 +6265,7 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	perfectly mixed can of the cheapest beer	3	EPIC	
-6372	practically non-alcoholic artisanal squat bottle of fruity &quot;wine&quot;	1	EPIC	
+6372	artisanal practically non-alcoholic squat bottle of fruity &quot;wine&quot;	1	EPIC	
 6373	hand-crafted single swig of vodka	4	EPIC	
 6374	twirling angry inch	0		
 6375	blurry sage testy toolbox	0		Mysticality Percent: +10
@@ -6314,7 +6314,7 @@
 6419	non-quantum super-energized improved twirling moth dust	0		Effect: "Locks Like the Raven", Effect Duration: 24
 6420	concentrated mirror glob of spoiled mayo	0		Effect: "For Your Brain Only", Effect Duration: 35
 6421	tonic djinn	0		
-6422	half-sized toothsome vampire chowder	2	awesome	
+6422	toothsome half-sized vampire chowder	2	awesome	
 6423	narrow Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	twirling Official Seal of Dreadsylvania	0		
@@ -6360,7 +6360,7 @@
 6465	Usain Bolt's Annie Oakley's Mayor Ghost's gavel of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +20, Initiative: +80, Conditional Skill (Equipped): "Hammer Ghost"
 6466	MacGyver's brawny Mayor Ghost's sash of the scaredy-cat	0		Muscle Percent: +20, Maximum MP: +100, Monster Level: -15, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	miniature spoiled jittery ghost pepper	2	crappy	
+6468	spoiled miniature jittery ghost pepper	2	crappy	
 6469	lard-coated banded arcane researcher's Thunkula's drinking cap	0		Experience Percent (Mysticality): +10, Damage Absorption: +100, Sleaze Spell Damage: +25, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	fuchsia perfumed MacGyver's Drunkula's cape of the empath	0		Maximum MP: +100, Familiar Weight: +5, Stench Resistance: +5, Class: "Sauceror"
 6471	extremely unsafe cool Drunkula's silky pants of Gandalf	0		Moxie: +5, Weapon Damage Percent: +100, Spell Critical Percent: +20, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6380,13 +6380,13 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	low-calorie bland Dreadsylvanian shepherd's pie	1	decent	
+6488	bland low-calorie Dreadsylvanian shepherd's pie	1	decent	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
-6491	olive shaking tumbling tailfeathers	0		Familiar Weight: +5
+6491	olive tumbling shaking tailfeathers	0		Familiar Weight: +5
 6492	blinking wax banana	0		
 6493	complicated lock impression	0		
-6494	twirling fuchsia replica key	0		
+6494	fuchsia twirling replica key	0		
 6495	narrow cyan Dreadsylvania Auditor's badge of the pedagogue	0		Experience: +3, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
@@ -6394,7 +6394,7 @@
 6499	moon-amber	0		
 6500	olive polished moon-amber	0		
 6501	spinning sage moon-amber necklace of Calamity Jane of chilblains	0		Mysticality Percent: +10, Critical Hit Percent: +15, Cold Damage: +25, Single Equip
-6502	jittery huge Dreadsylvanian seed pod	0		
+6502	huge jittery Dreadsylvanian seed pod	0		
 6503	ghost pencil	0		
 6504	curative slick hangman's hood of James Dean	0		Moxie: +10, Experience (Moxie): +3, HP Regen Min: 3, HP Regen Max: 5
 6505	blue prompt vibrating veiny ring finger ring	0		Maximum HP: +10, Maximum MP Percent: +10, Adventures: +3, Single Equip
@@ -6408,9 +6408,9 @@
 6513	bouncing flame-retardant warm fur	0		Hot Resistance: +1
 6514	twirling Lo Pan's snowstick	0		Spell Critical Percent: +30
 6515	mansplainer's eerie fetish	0		Monster Level: +15, Single Equip
-6516	hand-crafted extra-dry olive jittery stinkwater	5	EPIC	
+6516	hand-crafted extra-dry jittery olive stinkwater	5	EPIC	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	spoiled snack-sized accidental mutton	2	crappy	
+6518	snack-sized spoiled accidental mutton	2	crappy	
 6519	dog trainer's wicked drafty drawers	0		Spell Damage: +5, Experience (familiar): +1, Familiar Effect: "1.5xVolley"
 6520	censurious electrified wolfskull mask	0		Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "spooky atk, 1xBarrr"
 6521	frightening guts necklace	0		Spooky Damage: +5, Single Equip
@@ -6458,14 +6458,14 @@
 6564	bland jumbo yellow Dreadsylvanian hot pocket	5	decent	
 6565	stale Dreadsylvanian pocket	3	decent	
 6566	stale Dreadsylvanian pocket	3	decent	
-6567	rotten diet Dreadsylvanian stink pocket	1	crappy	
+6567	diet rotten Dreadsylvanian stink pocket	1	crappy	
 6568	moldy Dreadsylvanian sleaze pocket	4	crappy	
-6569	irresponsibly strong fancy perfectly mixed Dreadsylvanian hot toddy	10	EPIC	Effect: "Feet of Grapefruit", Effect Duration: 5
-6570	hand-crafted enchanted Dreadsylvanian cold-fashioned	3	super ultra mega turbo EPIC	Effect: "Wise Spirit", Effect Duration: 20
-6571	drinkable practically non-alcoholic Dreadsylvanian grimlet	1	good	
+6569	fancy irresponsibly strong perfectly mixed Dreadsylvanian hot toddy	10	EPIC	Effect: "Feet of Grapefruit", Effect Duration: 5
+6570	enchanted hand-crafted Dreadsylvanian cold-fashioned	3	super ultra mega turbo EPIC	Effect: "Wise Spirit", Effect Duration: 20
+6571	practically non-alcoholic drinkable Dreadsylvanian grimlet	1	good	
 6572	acceptable Dreadsylvanian dank and stormy	4	good	
 6573	practically non-alcoholic bad Dreadsylvanian slithery nipple	1	decent	
-6574	blurry yellow hot clusterbomb	0		
+6574	yellow blurry hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
 6577	stench clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	healthy gnawed-up dog bone of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20
 6589	hardened Grey Guanon	0		Damage Reduction: 3
 6590	friendly curative Engorged Sausages and You of wisdom	0		Mysticality: +15, Familiar Weight: +3, HP Regen Min: 3, HP Regen Max: 5
-6591	weak hand-crafted dream of a dog	2	EPIC	
+6591	hand-crafted weak dream of a dog	2	EPIC	
 6592	medical-grade supercool optimal spreadsheet of James Dean	0		Moxie Percent: +20, Experience (Moxie): +3, HP Regen Min: 7, HP Regen Max: 10
 6593	defective Game Grid token	0		
 6594	blurry hot Dreadsylvanian cocoa	0		
@@ -6506,7 +6506,7 @@
 6612	yellow clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	lousy weak Cold One	2	???	
+6615	weak lousy Cold One	2	???	
 6616	normal spaghetti breakfast	4	???	
 6617	upside-down over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6522,7 +6522,7 @@
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	jittery folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
-6631	jittery tumbling folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
+6631	tumbling jittery folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	jittery folder (barbarian)	0		Last Available: "2013-08"
 6634	folder (rainbow unicorn)	0		Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	perfectly mixed high-proof stepmom's booze	10	EPIC	
 6653	pulsating surgical tape	0		
 6654	boxer's band T-shirt	0		Muscle Percent: +10
-6655	enchanted drinkable fountain 'soda'	3	good	Effect: "Eye of the Seal", Effect Duration: 35
+6655	drinkable enchanted fountain 'soda'	3	good	Effect: "Eye of the Seal", Effect Duration: 35
 6656	olive illegal firecracker	0		
 6657	blinking ruddy razor-sharp pickelhaube	0		Weapon Damage Percent: +25, Maximum HP Percent: +40, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	quadruple-vacuum-sealed super-modified hair oil	0		Effect: "Pumped Stomach", Effect Duration: 32
@@ -6616,14 +6616,14 @@
 6724	flavorless exotic jungle fruit	4	decent	
 6725	bouncing Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
-6727	squat teal spinning tropical island souvenir crate	0		
+6727	spinning squat teal tropical island souvenir crate	0		
 6728	blue ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
 6730	funky junk key	0		
 6731	narrow Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	spinning clothesline pole	0		
-6734	teal ghostly cigar sign	0		
+6734	ghostly teal cigar sign	0		
 6735	junk junk	0		
 6736	Junk-Bond	0		
 6737	tangle of copper wire	0		
@@ -6646,7 +6646,7 @@
 6754	tumbling beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	fancy delicious bouncing can of Br&uuml;talbr&auml;u	4	awesome	Effect: "Hyperoffended", Effect Duration: 30, Last Available: "2013-09"
+6757	delicious fancy bouncing can of Br&uuml;talbr&auml;u	4	awesome	Effect: "Hyperoffended", Effect Duration: 30, Last Available: "2013-09"
 6758	lousy can of Drooling Monk	3	decent	Last Available: "2013-09"
 6759	delicious can of Impetuous Scofflaw	3	awesome	Last Available: "2013-09"
 6760	lousy bottle of Old Pugilist	3	decent	Last Available: "2013-09"
@@ -6658,7 +6658,7 @@
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
-6769	olive ribald careful supercool tin tam	0		Moxie Percent: +20, Monster Level: -10, Sleaze Damage: +10, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	olive ribald careful supercool tin tam	0		Moxie Percent: +20, Monster Level: -10, Sleaze Damage: +10, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	aerosolized tin cup	0		Effect: "Jittery", Effect Duration: 34, Last Available: "2013-09"
 6771	lightning-fast sharpshooter's rock-hard tin foil	0		Damage Reduction: 5, Critical Hit Percent: +10, Initiative: +40, Last Available: "2013-09"
 6772	fireproof sage tin drum of the early riser	0		Mysticality Percent: +10, Hot Resistance: +3, Adventures: +7, Last Available: "2013-09"
@@ -6684,7 +6684,7 @@
 6795	polarized spinning disco horoscope (Aquarius)	0		Effect: "The Sweats", Effect Duration: 47
 6796	colloidal chilled narrow yellow disco horoscope (Pisces)	0		Effect: "Tiki Temerity", Effect Duration: 37
 6797	corrupted disco horoscope (Aries)	0		Effect: "Action", Effect Duration: 43
-6798	triple-concentrated chilled wobbly jittery disco horoscope (Taurus)	0		Effect: "Adorable Lookout", Effect Duration: 16
+6798	triple-concentrated chilled jittery wobbly disco horoscope (Taurus)	0		Effect: "Adorable Lookout", Effect Duration: 16
 6799	electrified disco horoscope (Gemini)	0		Effect: "Wings of the Grasshopper", Effect Duration: 12
 6800	triple-polymerized vacuum-sealed pressed bouncing disco horoscope (Cancer)	0		Effect: "Weather, Man", Effect Duration: 29
 6801	nitrogenated fuchsia disco horoscope (Leo)	0		Effect: "Knightlife", Effect Duration: 37
@@ -6694,7 +6694,7 @@
 6805	ionized double-polymerized deionized disco horoscope (Sagittarius)	0		Effect: "Sleazy Weapon", Effect Duration: 19
 6806	boiled modified altered blue disco horoscope (Capricorn)	0		Effect: "Tingly Elbows", Effect Duration: 33
 6807	perfumed The Sagittarian's leisure pants of the storm	0		Maximum MP Percent: +40, Stench Resistance: +5, Familiar Effect: "atk, cap 18"
-6808	shaking jittery toy accordion	0		Song Duration: 5
+6808	jittery shaking toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
 6810	upside-down coward's beer-battered accordion	0		Monster Level: -20, Class: "Accordion Thief", Song Duration: 6
 6811	blinking up-at-dawn baritone accordion	0		Adventures: +5, Class: "Accordion Thief", Song Duration: 7
@@ -6714,16 +6714,16 @@
 6825	dance instructor's alarm accordion of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Class: "Accordion Thief", Song Duration: 20
 6826	therapeutic All-Hallow's Steve's fright wig of Tarzan of incineration	0		Experience (Muscle): +3, Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	medical-grade forbidden KoL Con X Treasure Map	0		Spell Damage Percent: +50, HP Regen Min: 7, HP Regen Max: 10
-6828	bad irresponsibly strong wobbly discocktail	6	decent	
+6828	irresponsibly strong bad wobbly discocktail	6	decent	
 6829	aromatic KoL Con X Bingo Card	0		Stench Resistance: +1
 6830	rock-hard Temporal Tempera Tube	0		Damage Reduction: 5
 6831	concentrated squat Tallowcreme Halloween Pumpkin	0		Effect: "Berry Thorny", Effect Duration: 45
-6832	twirling ghostly Way More Tears&trade; pepper spray	0		
+6832	ghostly twirling Way More Tears&trade; pepper spray	0		
 6833	Vulcanized extra-tarnished Milk Studs	0		Effect: "Sleazy Jellied", Effect Duration: 64
 6834	modified cold-filtered yellow box of Dweebs	0		Effect: "Squirming Like a Toad", Effect Duration: 42
 6835	deionized blurry mirror bag of W&Ws	0		Effect: "Crimbo Epiphany", Effect Duration: 23
 6836	boiled quantum PEEZ dispenser	0		Effect: "Cookie Backup", Effect Duration: 55
-6837	super-quantum green bouncing Swizzler	0		Effect: "Coming Up Roses", Effect Duration: 35
+6837	super-quantum bouncing green Swizzler	0		Effect: "Coming Up Roses", Effect Duration: 35
 6838	irradiated Bugbearclaw Donut	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 38
 6839	moist cold-filtered ghostly jam	0		Effect: "Wise Spirit", Effect Duration: 33
 6840	diffused polymerized Whenchamacallit bar	0		Effect: "substats.enh", Effect Duration: 23
@@ -6733,7 +6733,7 @@
 6844	frozen ironic mint	0		Effect: "Snobby", Effect Duration: 61
 6845	unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
-6847	wobbly upside-down killing jar	0		
+6847	upside-down wobbly killing jar	0		
 6848	security flashlight of the glutton	0		Food Drop: +100
 6849	polarized ionized Effermint&trade; tablets	0		Effect: "Deadly Lampblade", Effect Duration: 24
 6850	upside-down upside-down veiny sturdy cane of courage of the businessman	0		Maximum HP: +10, Spooky Resistance: +3, Meat Drop: +50
@@ -6746,18 +6746,18 @@
 6857	blue scorching Cajun accordion	0		Hot Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	blue bouncing quirky accordion of extreme caution	0		Monster Level: -25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	nasty Skipper's accordion of the empath	0		Familiar Weight: +5, Stench Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	prompt energetic dance instructor's Pantsgiving of the detective	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20, Item Drop: +20, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
-6861	miniature stale upside-down can of sardines	2	decent	Last Available: "2013-11"
+6860	prompt energetic dance instructor's Pantsgiving of the detective	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20, Item Drop: +20, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	stale miniature upside-down can of sardines	2	decent	Last Available: "2013-11"
 6862	miniature normal narrow high-calorie sugar substitute	2	good	Last Available: "2013-11"
 6863	yummy bouncing pat of butter	3	awesome	Last Available: "2013-11"
-6864	enchanted bite-sized flavorless dinner roll	1	decent	Effect: "Shortened", Effect Duration: 5, Last Available: "2013-11"
+6864	flavorless bite-sized enchanted dinner roll	1	decent	Effect: "Shortened", Effect Duration: 5, Last Available: "2013-11"
 6865	spoiled mirror mashed potatoes	3	crappy	Last Available: "2013-11"
 6866	stale whole turkey leg	4	decent	Last Available: "2013-11"
 6867	rotten ghostly deviled egg	4	crappy	Last Available: "2013-11"
 6868	quantum finger exerciser	0		Effect: "Radium Radicality", Effect Duration: 61, Last Available: "2013-11"
 6869	pickled jittery dented spoon	0		Effect: "Hangdog", Effect Duration: 32, Last Available: "2013-11"
 6870	wet denatured olive love note	0		Effect: "Dreadful Sheen", Effect Duration: 16, Last Available: "2013-11"
-6871	ghostly cyan school beer pull tab	0		Last Available: "2013-11"
+6871	cyan ghostly school beer pull tab	0		Last Available: "2013-11"
 6872	boiled altered nail file	0		Effect: "Demonic Taint", Effect Duration: 51, Last Available: "2013-11"
 6873	chilled triple-pickled candy wrapper	0		Effect: "White-boy Angst", Effect Duration: 15, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
@@ -6791,7 +6791,7 @@
 6902	flask flops of extreme caution of temperance	0		Monster Level: -25, Sleaze Resistance: +5, Single Equip
 6903	extra-corrupted nuts	0		Effect: "Incredibly Hulking", Effect Duration: 38, Last Available: "2013-12"
 6904	oxidized extra-warmed maroon bolts	0		Effect: "Jammin'", Effect Duration: 41, Last Available: "2013-12"
-6905	immense rotten gingerbread robot	6	crappy	Last Available: "2013-12"
+6905	rotten immense gingerbread robot	6	crappy	Last Available: "2013-12"
 6906	bland petit 4.1	3	decent	Last Available: "2013-12"
 6907	thick moldy nut-shaped Crimbo cookie	5	crappy	Last Available: "2023-06"
 6908	arcane researcher's plastic GORM-8	0		Experience Percent (Mysticality): +10, Last Available: "2013-12"
@@ -6807,32 +6807,32 @@
 6918	energized enhanced warbear wardance potion	0		Effect: "Antsy in your Pantsy", Effect Duration: 15, Last Available: "2013-12"
 6919	pressed warbear bearserker potion	0		Effect: "Hoity Toity", Effect Duration: 47, Last Available: "2013-12"
 6920	irradiated gray warbear liquid overcoat	0		Effect: "Boo Tea", Effect Duration: 18, Last Available: "2013-12"
-6921	spoiled small special warbear feasting bread	2	crappy	Effect: "Meatwise", Effect Duration: 45, Last Available: "2013-12"
-6922	tasty fancy immense blinking warbear warrior bread	9	awesome	Effect: "Updated", Effect Duration: 10, Last Available: "2013-12"
-6923	snack-sized adequate warbear thermoregulator bread	2	good	Last Available: "2013-12"
+6921	special spoiled small warbear feasting bread	2	crappy	Effect: "Meatwise", Effect Duration: 45, Last Available: "2013-12"
+6922	fancy tasty immense blinking warbear warrior bread	9	awesome	Effect: "Updated", Effect Duration: 10, Last Available: "2013-12"
+6923	adequate snack-sized warbear thermoregulator bread	2	good	Last Available: "2013-12"
 6924	practically non-alcoholic bad cyan tumbling warbear feasting mead	1	decent	Last Available: "2013-12"
 6925	special practically non-alcoholic acceptable warbear bearserker mead	1	good	Effect: "[1609]Dancin' Fool", Effect Duration: 10, Last Available: "2013-12"
 6926	perfectly mixed mirror skewed warbear blizzard mead	3	EPIC	Last Available: "2013-12"
-6927	huge green warbear helm fragment	0		Last Available: "2013-12"
-6928	squat foul-smelling deadly arcane researcher's warbear plain fedora	0		Experience Percent (Mysticality): +10, Weapon Damage: +5, Stench Damage: +10, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	flame-retardant warbear feathered fedora	0		Hot Resistance: +1, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	huge chaotic Fonzie's thinker's warbear fedora	0		Mysticality: +10, Experience (Moxie): +1, Spell Critical Percent: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	pulsating zippy nippy therapeutic warbear plain helm	0		Cold Damage: +10, Initiative: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	teal auspicious warbear spiked helm	0		Item Drop: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	brawny warbear electro-spiked helm of Gandalf of incineration	0		Muscle Percent: +20, Spell Critical Percent: +20, Hot Spell Damage: +50, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	perfumed clever hardy warbear plain ushanka	0		Maximum HP: +50, Maximum MP: +20, Stench Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	narrow warbear lined ushanka of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	skewed ghostly careful Rosewater's warbear heated ushanka of doom	0		Mysticality Percent: +30, Monster Level: -10, Spooky Spell Damage: +50, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6927	green huge warbear helm fragment	0		Last Available: "2013-12"
+6928	squat foul-smelling deadly arcane researcher's warbear plain fedora	0		Experience Percent (Mysticality): +10, Weapon Damage: +5, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	flame-retardant warbear feathered fedora	0		Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	huge chaotic Fonzie's thinker's warbear fedora	0		Mysticality: +10, Experience (Moxie): +1, Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	pulsating zippy nippy therapeutic warbear plain helm	0		Cold Damage: +10, Initiative: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	teal auspicious warbear spiked helm	0		Item Drop: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	brawny warbear electro-spiked helm of Gandalf of incineration	0		Muscle Percent: +20, Spell Critical Percent: +20, Hot Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	perfumed clever hardy warbear plain ushanka	0		Maximum HP: +50, Maximum MP: +20, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	narrow warbear lined ushanka of Tarzan	0		Experience (Muscle): +3, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	skewed ghostly careful Rosewater's warbear heated ushanka of doom	0		Mysticality Percent: +30, Monster Level: -10, Spooky Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	aromatic shellacked warbear party pants of the early riser	0		Damage Reduction: 7, Stench Resistance: +1, Adventures: +7, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	warbear ceremonial party pants of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	healthy extremely unsafe thinker's warbear high festival pants	0		Mysticality: +10, Weapon Damage Percent: +100, Maximum HP Percent: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	Sherlock's experienced brainy warbear battle greaves	0		Mysticality: +5, Experience: +2, Item Drop: +25, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	warbear officer greaves of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	squat Jack Frost's grievous cool warbear bearserker greaves	0		Moxie: +5, Weapon Damage Percent: +50, Cold Spell Damage: +50, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	slick strapping warbear johns of Leguizamo	0		Muscle: +5, Moxie: +10, Monster Level: +20, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	wobbly reassuring warbear fleece-lined johns	0		Spooky Resistance: +1, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	energetic forbidden supercool warbear johns	0		Moxie Percent: +20, Spell Damage Percent: +50, Maximum MP Percent: +20, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	aromatic shellacked warbear party pants of the early riser	0		Damage Reduction: 7, Stench Resistance: +1, Adventures: +7, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	warbear ceremonial party pants of incineration	0		Hot Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	healthy extremely unsafe thinker's warbear high festival pants	0		Mysticality: +10, Weapon Damage Percent: +100, Maximum HP Percent: +20, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	Sherlock's experienced brainy warbear battle greaves	0		Mysticality: +5, Experience: +2, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	warbear officer greaves of incineration	0		Hot Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	squat Jack Frost's grievous cool warbear bearserker greaves	0		Moxie: +5, Weapon Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	slick strapping warbear johns of Leguizamo	0		Muscle: +5, Moxie: +10, Monster Level: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	wobbly reassuring warbear fleece-lined johns	0		Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	energetic forbidden supercool warbear johns	0		Moxie Percent: +20, Spell Damage Percent: +50, Maximum MP Percent: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	ghostly careful warbear goggles of the blizzard of the brazier	0		Monster Level: -10, Cold Spell Damage: +25, Hot Spell Damage: +25, Single Equip, Last Available: "2013-12"
 6949	deadly warbear snowblindness goggles	0		Weapon Damage: +5, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	up-at-dawn warbear warscarf of Gandalf of extreme caution	0		Spell Critical Percent: +20, Monster Level: -25, Adventures: +5, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	blinking warbear foil hat of the boozehound	0		Booze Drop: +100, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	blinking warbear foil hat of the boozehound	0		Booze Drop: +100, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	frightening boxer's warbear oil pan	0		Muscle Percent: +10, Spooky Damage: +5, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,13 +6889,13 @@
 7000	spinning die-cast Don Crimbo of the brazier of horror	0		Hot Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2013-12"
 7001	cyan Usain Bolt's shellacked die-cast Uncle Hobo	0		Damage Reduction: 7, Initiative: +80, Last Available: "2013-12"
 7002	tumbling red reassuring Temple Grandin's die-cast Father Crimbo	0		Familiar Weight: +7, Spooky Resistance: +1, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	warmed frozen Flaskfull of Hollow	0		Effect: "Mystic Circle", Effect Duration: 35, Last Available: "2013-12"
 7005	tumbling lump of Brituminous coal	0		Last Available: "2013-12"
-7006	compressed blinking wobbly handful of Smithereens	1	crappy	Last Available: "2013-12"
-7007	fancy bland tumbling Every Day is Like This Sundae	3	decent	Effect: "Stick Emporium Membership", Effect Duration: 25, Last Available: "2013-12"
+7006	compressed wobbly blinking handful of Smithereens	1	crappy	Last Available: "2013-12"
+7007	bland fancy tumbling Every Day is Like This Sundae	3	decent	Effect: "Stick Emporium Membership", Effect Duration: 25, Last Available: "2013-12"
 7008	special gigantic bland bouncing Miserable Pie	9	decent	Effect: "Fit To Be Tide", Effect Duration: 10, Last Available: "2013-12"
-7009	thick moldy upside-down This Charming Flan	5	crappy	Last Available: "2013-12"
+7009	moldy thick upside-down This Charming Flan	5	crappy	Last Available: "2013-12"
 7010	acceptable green Irish Coffee, English Heart	3	good	Last Available: "2013-12"
 7011	watered-down delicious Strikes Again Bigmouth	2	awesome	Last Available: "2013-12"
 7012	aged Paint A Vulgar Pitcher	4	awesome	Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	educational smooth strapping Sheila Take a Crossbow of the pedagogue	0		Muscle: +5, Moxie: +15, Experience: 4, Last Available: "2013-12"
 7019	yellow censurious educational A Light that Never Goes Out of the pedagogue of the blizzard	0		Experience: 4, Cold Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2013-12"
 7020	wicked extremely unsafe Half a Purse of vim and vigor of the brazier	0		Weapon Damage Percent: +100, Spell Damage: +5, Maximum HP Percent: +50, Hot Spell Damage: +25, Last Available: "2013-12"
-7021	studded wicked Hairpiece On Fire of the empath of courage	0		Spell Damage: +5, Damage Absorption: +80, Familiar Weight: +5, Spooky Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	ribald gravedigger's stylish Vicar's Tutu of the sweet-tooth	0		Moxie: +25, Spooky Damage: +10, Sleaze Damage: +10, Candy Drop: +100, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	studded wicked Hairpiece On Fire of the empath of courage	0		Spell Damage: +5, Damage Absorption: +80, Familiar Weight: +5, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	ribald gravedigger's stylish Vicar's Tutu of the sweet-tooth	0		Moxie: +25, Spooky Damage: +10, Sleaze Damage: +10, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	fireproof dog trainer's fortified Hand in Glove	0		Damage Absorption: +60, Experience (familiar): +1, Hot Resistance: +3, Single Equip, Last Available: "2013-12"
 7024	twirling frosty Jim Carey's Meat Tenderizer is Murder of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +25, Cold Spell Damage: +10, Class: "Seal Clubber", Last Available: "2013-12"
 7025	twirling chilly experienced brawny Ouija Board, Ouija Board	0		Muscle Percent: +20, Experience: +2, Cold Damage: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	Fonzie's Shakespeare's Sister's Accordion of extreme caution of courage	0		Experience (Moxie): +1, Monster Level: -25, Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	third-hand lantern of the glutton	0		Food Drop: +100
 7031	loose purse strings	0		
-7032	flavorless snack-sized pickled egg	2	decent	
+7032	snack-sized flavorless pickled egg	2	decent	
 7033	enchanted cup of lukewarm tea	1	awesome	Effect: "Punch Another Day", Effect Duration: 40
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	boiled shaking glass slipper	0		Effect: "Pork Power", Effect Duration: 42, Last Available: "2014-12"
-7045	twisted pulsating squat antimatter wad	1	EPIC	Effect: "Greased-Up Familiar", Effect Duration: 35, Last Available: "2013-12"
+7045	twisted squat pulsating antimatter wad	1	EPIC	Effect: "Greased-Up Familiar", Effect Duration: 35, Last Available: "2013-12"
 7046	Vulcanized ionized warbear superpotion	0		Effect: "Yuletide Sappiness", Effect Duration: 55, Last Available: "2013-12"
 7047	galvanized wobbly maroon warbear liquid lasers	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 62, Last Available: "2013-12"
 7048	nitrogenated nitrogenated warbear rejuvenation potion	0		Effect: "Healthy Red Glow", Effect Duration: 17, Last Available: "2013-12"
@@ -6954,22 +6954,22 @@
 7065	vaporized grim fairy tale	1	awesome	Last Available: "2014-12"
 7066	twirling grimstone galoshes	0		Familiar Weight: +5
 7067	quadruple-diffused single of Inigo's Incantation of Inspiration	0		Effect: "Hiding in Plain Sight", Effect Duration: 38, Last Available: "2010-02"
-7068	liquefied boiled activated jittery olive single of Donho's Bubbly Ballad	0		Effect: "It's Electric!", Effect Duration: 66
+7068	liquefied boiled activated olive jittery single of Donho's Bubbly Ballad	0		Effect: "It's Electric!", Effect Duration: 66
 7069	squat Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	tumbling packet of winter seeds	0		Last Available: "2014-01"
-7071	stale enchanted wobbly blinking snow berries	3	decent	Effect: "Mucilaginous Muscle", Effect Duration: 25, Last Available: "2014-01"
+7071	enchanted stale blinking wobbly snow berries	3	decent	Effect: "Mucilaginous Muscle", Effect Duration: 25, Last Available: "2014-01"
 7072	spoiled ice harvest	3	crappy	Last Available: "2014-01"
 7073	non-warmed pickled frost flower	0		Effect: "Magically Fingered", Effect Duration: 46, Last Available: "2014-01"
 7074	polymerized narrow ghostly snow cleats	0		Effect: "Minerva's Zen", Effect Duration: 19, Last Available: "2014-01"
 7075	double-electrified liquid ice pack	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2014-01"
 7076	skewed snow boards	0		Last Available: "2014-01"
-7077	toothsome wobbly twirling snow crab	3	awesome	Last Available: "2014-01"
-7078	acceptable practically non-alcoholic Ice Island Long Tea	1	good	Last Available: "2014-01"
+7077	toothsome twirling wobbly snow crab	3	awesome	Last Available: "2014-01"
+7078	practically non-alcoholic acceptable Ice Island Long Tea	1	good	Last Available: "2014-01"
 7079	tumbling unfinished ice sculpture	0		Last Available: "2014-01"
-7080	jittery ghostly ice sculpture	0		Last Available: "2014-01"
+7080	ghostly jittery ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	huge snow machine	0		Last Available: "2014-01"
-7083	gray wool snow mobile	0		Cold Resistance: +1, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	gray wool snow mobile	0		Cold Resistance: +1, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	ice bucket of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Last Available: "2014-01"
 7085	blurry sizzling snow shovel of the sweet-tooth	0		Hot Damage: +10, Candy Drop: +100, Lasts Until Rollover, Last Available: "2014-01"
 7086	squat stanky rock-hard sinister bod-ice	0		Spell Damage: +10, Damage Reduction: 5, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	shaking snow fort	0		Last Available: "2014-01"
 7090	acceptable bouncing En Una Fila Tequila	4	good	
 7091	Skully's hot chocolate	1	good	
-7092	experienced warbear dress helmet of the sweet-tooth	0		Experience: +2, Candy Drop: +100, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	experienced warbear dress helmet of the sweet-tooth	0		Experience: +2, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	energetic warbear dress bracers of Calamity Jane	0		Maximum MP Percent: +20, Critical Hit Percent: +15, Single Equip, Last Available: "2013-12"
-7094	curative forbidden warbear dress greaves	0		Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	sweatband of Leguizamo of the blizzard	0		Monster Level: +20, Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	blinking Tesla stylish gym shorts	0		Moxie: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	curative forbidden warbear dress greaves	0		Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	sweatband of Leguizamo of the blizzard	0		Monster Level: +20, Cold Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	blinking Tesla stylish gym shorts	0		Moxie: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	mirror executive beefy ankleweights	0		Muscle: +10, Meat Drop: +40, Single Equip, Last Available: "2014-12"
 7098	supercharged sweat socks of Tarzan of Leguizamo of the brazier	0		Experience (Muscle): +3, Maximum MP Percent: +30, Monster Level: +20, Hot Spell Damage: +25, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6994,43 +6994,43 @@
 7105	ghostly ghostly anise-flavored venom	0		Last Available: "2014-12"
 7106	bad fuchsia snakebite	3	decent	Last Available: "2014-12"
 7107	bouncing pulsating mansplainer's Sinatra's candy stick	0		Experience (Moxie): +5, Monster Level: +15, Last Available: "2014-12"
-7108	half-sized adequate pecan	2	good	Last Available: "2014-12"
-7109	rotten ghostly purple pecan pie	3	crappy	Last Available: "2014-12"
+7108	adequate half-sized pecan	2	good	Last Available: "2014-12"
+7109	rotten purple ghostly pecan pie	3	crappy	Last Available: "2014-12"
 7110	pulsating chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	spoiled candy mountain oyster	3	crappy	Last Available: "2014-12"
-7112	strong delicious fuchsia chocotini	5	awesome	Last Available: "2014-12"
+7112	delicious strong fuchsia chocotini	5	awesome	Last Available: "2014-12"
 7113	sizzling supercharged chocolate rabbit's foot of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +30, Hot Damage: +10, Last Available: "2014-12"
 7114	stale blinking candy carrot	3	decent	Last Available: "2014-12"
-7115	snack-sized bland wobbly red candy carrot cake	2	decent	Last Available: "2014-12"
+7115	bland snack-sized wobbly red candy carrot cake	2	decent	Last Available: "2014-12"
 7116	thinker's carrot-on-a-stick of the cougar	0		Mysticality: +10, Moxie: +20, Last Available: "2014-12"
-7117	pulsating dog trainer's slick weasel stomping pants	0		Moxie: +10, Experience (familiar): +1, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	pulsating dog trainer's slick weasel stomping pants	0		Moxie: +10, Experience (familiar): +1, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	stale mulberry	4	decent	Last Available: "2014-12"
-7119	artisanal fortified mulled berry wine	5	EPIC	Last Available: "2014-12"
+7119	fortified artisanal mulled berry wine	5	EPIC	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	supercharged lemon party hat	0		Maximum MP Percent: +30, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	supercharged lemon party hat	0		Maximum MP Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	stiffened lemon shirt	0		Damage Reduction: 1, Lasts Until Rollover, Last Available: "2014-12"
-7123	Sinatra's lemon drop trousers	0		Experience (Moxie): +5, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	Sinatra's lemon drop trousers	0		Experience (Moxie): +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	wet adjusted lemonhead caviar	0		Effect: "Feroci Tea", Effect Duration: 56, Last Available: "2014-12"
 7125	twirling wool gummi sword of the pedagogue	0		Experience: +3, Cold Resistance: +1, Last Available: "2014-12"
 7126	corrupted skewed bouncing small gummi fin	0		Effect: "Extra-Wet", Effect Duration: 53, Last Available: "2014-12"
 7127	red flame-wreathed chocolate cow bone	0		Hot Spell Damage: +10, Last Available: "2014-12"
 7128	magnetized gummi fang	0		Effect: "Chock Full o' Nanites", Effect Duration: 54, Last Available: "2014-12"
 7129	moldy leftover canap&eacute;s	4	crappy	Last Available: "2014-12"
-7130	tolerable fancy weak cyan magnum of champagne	2	good	Effect: "Abyssal Blood", Effect Duration: 40, Last Available: "2014-12"
+7130	tolerable weak fancy cyan magnum of champagne	2	good	Effect: "Abyssal Blood", Effect Duration: 40, Last Available: "2014-12"
 7131	Lo Pan's steel-toed cow creamer of vim and vigor	0		Damage Reduction: 9, Maximum HP Percent: +50, Spell Critical Percent: +30, Last Available: "2014-12"
 7132	nitrogenated Outer Wolf&trade; cologne	0		Effect: "Marinated", Effect Duration: 59, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	Tesla banded wolf whistle	0		Damage Absorption: +100, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	thick decent blue witch's bread	5	good	Last Available: "2014-12"
+7135	decent thick blue witch's bread	5	good	Last Available: "2014-12"
 7136	anodized quantum corrupted upside-down witch's brew	0		Effect: "Impregnably Delicious", Effect Duration: 30, Last Available: "2014-12"
 7137	blinking narrow auspicious witch's bra of temperance of the businessman	0		Sleaze Resistance: +5, Item Drop: +10, Meat Drop: +50, Last Available: "2014-12"
-7138	special mediocre mid-level medieval mead	4	decent	Effect: "Gunky Dory", Effect Duration: 40, Last Available: "2014-12"
+7138	mediocre special mid-level medieval mead	4	decent	Effect: "Gunky Dory", Effect Duration: 40, Last Available: "2014-12"
 7139	activated R&uuml;mpelstiltz	0		Effect: "In Tuna", Effect Duration: 53, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	ionized Vulcanized unsweetened olive hi-octane carrot juice	0		Effect: "Muscle Unbound", Effect Duration: 34, Last Available: "2014-12"
-7142	anodized upside-down gray hare brush	0		Effect: "Sleazy Weapon", Effect Duration: 68, Last Available: "2014-12"
+7142	anodized gray upside-down hare brush	0		Effect: "Sleazy Weapon", Effect Duration: 68, Last Available: "2014-12"
 7143	hare pin of the wise owl of Leguizamo	0		Mysticality: +20, Monster Level: +20, Single Equip, Last Available: "2014-12"
-7144	blue bouncing odd coin	0		Last Available: "2014-12"
+7144	bouncing blue odd coin	0		Last Available: "2014-12"
 7145	stale cinnamon cannoli	3	decent	Last Available: "2014-12"
 7146	perfectly mixed expensive champagne	3	EPIC	Last Available: "2014-12"
 7147	double-chilled Vulcanized triple-oxidized polo trophy	0		Effect: "Joyful Resolve", Effect Duration: 17, Last Available: "2014-12"
@@ -7043,26 +7043,26 @@
 7154	fuchsia filling	0		Last Available: "2014-12"
 7155	green parchment	0		Last Available: "2014-12"
 7156	twirling glass	0		Last Available: "2014-12"
-7157	healthy Da Vinci's fire hose of extreme caution	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Monster Level: -25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	healthy Da Vinci's fire hose of extreme caution	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Monster Level: -25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	tasty fireman's lunch	3	awesome	Last Available: "2014-12"
-7159	spinning sizzling toasty brainy plain paper hat	0		Mysticality: +5, Hot Damage: 15, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	spinning sizzling toasty brainy plain paper hat	0		Mysticality: +5, Hot Damage: 15, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	delicious shaking ice cream sandwich	3	awesome	Last Available: "2014-12"
 7161	tumbling smartaleck's boxer's &quot;honey&quot; dipper of Flo-Jo	0		Muscle Percent: +10, Moxie Percent: +30, Initiative: +100, Last Available: "2014-12"
 7162	normal plumber's lunch	4	good	Last Available: "2014-12"
 7163	knitted steel-toed skull gearshift knob of the glutton	0		Damage Reduction: 9, Cold Resistance: +3, Food Drop: +100, Last Available: "2014-12"
-7164	tiny toothsome twirling nachos of the night	1	awesome	Last Available: "2014-12"
+7164	toothsome tiny twirling nachos of the night	1	awesome	Last Available: "2014-12"
 7165	tumbling MacGyver's Sketcherz&trade; of the bloodbag of the detective	0		Maximum HP: +100, Maximum MP: +100, Item Drop: +20, Last Available: "2014-12"
 7166	snack-sized adequate can of Adultwitch&trade;	2	good	Last Available: "2014-12"
 7167	deionized moist denatured green smudge stick	0		Effect: "Updated", Effect Duration: 63, Last Available: "2014-12"
 7168	non-wet alkaline wall	0		Effect: "Orc Chops", Effect Duration: 50, Last Available: "2014-12"
-7169	mediocre spirit-forward tankard of ale	5	decent	Last Available: "2014-12"
+7169	spirit-forward mediocre tankard of ale	5	decent	Last Available: "2014-12"
 7170	wet blurry scroll case	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 33, Last Available: "2014-12"
 7171	corrupted triple-polymerized jug of &quot;wine&quot;	0		Effect: "Snobby", Effect Duration: 23, Last Available: "2014-12"
 7172	fuchsia huge juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	enchanted bland narrow humble pie	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45, Last Available: "2014-12"
-7175	mirror squat small golem	0		Last Available: "2014-12"
-7176	blurry tumbling shaking crappy camera	0		Last Available: "2014-12"
+7174	bland enchanted narrow humble pie	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45, Last Available: "2014-12"
+7175	squat mirror small golem	0		Last Available: "2014-12"
+7176	tumbling blurry shaking crappy camera	0		Last Available: "2014-12"
 7177	cold-filtered pickled bouncing crappy waiter disguise	0		Effect: "Sticks and Stones", Effect Duration: 64
 7178	Copperhead Charm	0		
 7179	twirling The First Pizza	0		
@@ -7073,7 +7073,7 @@
 7184	upside-down The Shield of Brook	0		
 7185	squat Red Zeppelin ticket	0		
 7186	skewed Copperhead Charm (rampant)	0		
-7187	watered-down artisanal blue squat unnamed cocktail	2	EPIC	
+7187	watered-down artisanal squat blue unnamed cocktail	2	EPIC	
 7188	handful of tips	0		
 7189	razor-sharp unrequired jacket	0		Weapon Damage Percent: +25
 7190	jittery tommy gun of wisdom	0		Mysticality: +15, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7101,7 +7101,7 @@
 7212	narrow wobbly flame-retardant Jefferson wings	0		Hot Resistance: +1
 7213	narrow jittery fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	moldy miniature fleetwood mac 'n' cheese	2	crappy	
+7215	miniature moldy fleetwood mac 'n' cheese	2	crappy	
 7216	blinking lynyrd skin	0		
 7217	upside-down rock-hard lynyrdskin cap	0		Damage Reduction: 5, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	beefy lynyrdskin tunic	0		Muscle: +10
@@ -7111,14 +7111,14 @@
 7222	practically non-alcoholic delicious Flamin' Whatshisname	1	awesome	
 7223	quadruple-unsweetened extra-nitrogenated ghostly lynyrd musk	0		Effect: "Tingly Wrists", Effect Duration: 14
 7224	Temple Grandin's vibrating Kashmir sweater	0		Maximum MP Percent: +10, Familiar Weight: +7
-7225	flavorless miniature custard pie	2	decent	
+7225	miniature flavorless custard pie	2	decent	
 7226	tea for one	1	good	
 7227	mediocre bottle of Evermore	3	decent	
 7228	box	0		
 7229	lousy blinking blinking wine	4	decent	
-7230	perfectly mixed bouncing pulsating rum	3	EPIC	
+7230	perfectly mixed pulsating bouncing rum	3	EPIC	
 7231	mediocre Murderer's Punch	3	decent	
-7232	special normal tiny velvet cake	1	good	Effect: "Helping Comes Second", Effect Duration: 50
+7232	normal special tiny velvet cake	1	good	Effect: "Helping Comes Second", Effect Duration: 50
 7233	polymerized unsweetened letter	0		Effect: "Boilermade", Effect Duration: 12
 7234	pulsating book of the cougar of temperance	0		Moxie: +20, Sleaze Resistance: +5
 7235	prompt masque of James Dean	0		Experience (Moxie): +3, Adventures: +3, Single Equip
@@ -7141,7 +7141,7 @@
 7252	squat gray shot of Sneaky Pete's Mojo	0		Free Pull
 7253	blinking Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	artisanal boozy olive bouncing mini-martini	5	EPIC	
+7255	boozy artisanal bouncing olive mini-martini	5	EPIC	
 7256	smoke grenade	0		
 7257	dried teal molotov soda	1	good	
 7258	adjusted pile of ashes	0		Effect: "Corruption of Wretched Wally", Effect Duration: 58
@@ -7194,12 +7194,12 @@
 7305	red Lady Spookyraven's powder puff	0		
 7306	Lady Spookyraven's finest gown	0		
 7307	squat Lady Spookyraven's dancing shoes	0		
-7308	activated adjusted bouncing jittery squat eyebrow pencil	0		Effect: "Rootin' Around", Effect Duration: 13
+7308	activated adjusted squat bouncing jittery eyebrow pencil	0		Effect: "Rootin' Around", Effect Duration: 13
 7309	triple-improved rosewater cream	0		Effect: "Gummiskin", Effect Duration: 52
 7310	anodized adjusted bronzer	0		Effect: "Spooky Jellied", Effect Duration: 30
 7311	scorching elegant nightstick of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +25
 7312	skewed still grill	0		Free Pull, Last Available: "2014-06"
-7313	wobbly twirling box of hickory chips	0		Familiar Weight: +5
+7313	twirling wobbly box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	huge rickety rocking horse	0		
 7316	cyan jack-in-the-box	0		
@@ -7229,12 +7229,12 @@
 7340	blue supercharged moose antlers	0		Maximum MP Percent: +30, Familiar Effect: "atk, 1xLep, cap 27"
 7341	corrupted maroon moose thought	0		Effect: "Celestial Sheen", Effect Duration: 40
 7342	thick rotten moose chocolate	5	crappy	
-7343	watered-down aged ghostly painting of a glass of wine	2	awesome	
+7343	aged watered-down ghostly painting of a glass of wine	2	awesome	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	lime green doll-eye amulet	0		Single Equip
 7347	fireproof ghost toga of mayonnaise	0		Sleaze Spell Damage: +50, Hot Resistance: +3
-7348	miniature adequate sheet cake	2	good	
+7348	adequate miniature sheet cake	2	good	
 7349	ghost key	0		
 7350	mirror picture of you	0		
 7351	beefcake's Staff of the Electric Range of Calamity Jane of the scaredy-cat	0		Muscle: +25, Critical Hit Percent: +15, Monster Level: -15
@@ -7253,12 +7253,12 @@
 7364	fabric softener	0		
 7365	chilled warmed fabric hardener	0		Effect: "Piratastic", Effect Duration: 18
 7366	acceptable bottle of laundry sherry	4	good	
-7367	extra-adjusted enhanced narrow bouncing industrial strength starch	0		Effect: "Experimental Effect G-9", Effect Duration: 53, Wiki Name: "industrial strength starch"
+7367	extra-adjusted enhanced bouncing narrow industrial strength starch	0		Effect: "Experimental Effect G-9", Effect Duration: 53, Wiki Name: "industrial strength starch"
 7368	normal extra-flat panini	4	good	
 7369	polymerized mangled finger	0		Effect: "Chalky White Pallor", Effect Duration: 38
-7370	watered-down aged Psychotic Train wine	2	awesome	
+7370	aged watered-down Psychotic Train wine	2	awesome	
 7371	crazy hobo notebook	0		
-7372	toothsome massive pie man was not meant to eat	8	awesome	
+7372	massive toothsome pie man was not meant to eat	8	awesome	
 7373	sommelier's towel of doom	0		Spooky Spell Damage: +50
 7374	coward's tarnished tastevin	0		Monster Level: -20, Single Equip
 7375	normal jumbo teal actual tapas	5	good	
@@ -7274,9 +7274,9 @@
 7385	ionized adjusted cyan Gene Tonic: Beast	0		Effect: "Protection from Bad Stuff", Effect Duration: 35, Last Available: "2014-04"
 7386	super-corrupted Gene Tonic: Construct	0		Effect: "Feet of Watermelon", Effect Duration: 52, Last Available: "2014-04"
 7387	unsweetened Gene Tonic: Undead	0		Effect: "Turtle Power", Effect Duration: 35, Last Available: "2014-04"
-7388	Vulcanized boiled boiled purple twirling Gene Tonic: Humanoid	0		Effect: "Bone Chilling", Effect Duration: 50, Last Available: "2014-04"
-7389	electrified pulsating blue Gene Tonic: Insect	0		Effect: "Tiki Temerity", Effect Duration: 11, Last Available: "2014-04"
-7390	activated altered pickled twirling spinning Gene Tonic: Hippy	0		Effect: "Flambé-a-thon", Effect Duration: 21, Last Available: "2014-04"
+7388	Vulcanized boiled boiled twirling purple Gene Tonic: Humanoid	0		Effect: "Bone Chilling", Effect Duration: 50, Last Available: "2014-04"
+7389	electrified blue pulsating Gene Tonic: Insect	0		Effect: "Tiki Temerity", Effect Duration: 11, Last Available: "2014-04"
+7390	activated altered pickled spinning twirling Gene Tonic: Hippy	0		Effect: "Flambé-a-thon", Effect Duration: 21, Last Available: "2014-04"
 7391	liquefied Gene Tonic: Orc	0		Effect: "Knightlife", Effect Duration: 16, Last Available: "2014-04"
 7392	vacuum-sealed alkaline Gene Tonic: Demon	0		Effect: "Full-Body Tan", Effect Duration: 65, Last Available: "2014-04"
 7393	pressed diffused liquefied upside-down Gene Tonic: Horror	0		Effect: "Helping Comes Second", Effect Duration: 11, Last Available: "2014-04"
@@ -7325,8 +7325,8 @@
 7436	extra-Vulcanized deionized polymerized Tremella Tarantella mushroom	0		Effect: "Pretending to Pretend", Effect Duration: 61, Last Available: "2014-05"
 7437	narrow Pastaco shell	0		Last Available: "2014-05"
 7438	adequate twirling Beefy Crunch Pastaco	3	good	Last Available: "2014-05"
-7439	gigantic decent Brain Food Pastaco	7	good	Last Available: "2014-05"
-7440	big decent Cool Brunch Pastaco	5	good	Last Available: "2014-05"
+7439	decent gigantic Brain Food Pastaco	7	good	Last Available: "2014-05"
+7440	decent big Cool Brunch Pastaco	5	good	Last Available: "2014-05"
 7441	bite-sized rotten special Medical Pastaco	1	crappy	Effect: "Wet Willied", Effect Duration: 15, Last Available: "2014-05"
 7442	bland Energy Buzz Pastaco	4	decent	Last Available: "2014-05"
 7443	rotten purple Ludovico Pastaco	4	crappy	Last Available: "2014-05"
@@ -7343,21 +7343,21 @@
 7454	boozy perfectly mixed super-size brogurt	5	EPIC	Last Available: "2014-05"
 7455	drinkable broberry brogurt	3	good	Last Available: "2014-05"
 7456	delicious brocolate brogurt	4	awesome	Last Available: "2014-05"
-7457	hand-crafted distilled mirror bouncing French bronilla brogurt	5	EPIC	Last Available: "2014-05"
+7457	hand-crafted distilled bouncing mirror French bronilla brogurt	5	EPIC	Last Available: "2014-05"
 7458	upside-down History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Annie Oakley's Brogre brorts	0		Critical Hit Percent: +20, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Annie Oakley's Brogre brorts	0		Critical Hit Percent: +20, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	spinning sinister Brogre brolo shirt	0		Spell Damage: +10, Last Available: "2014-05"
-7464	cool Brogre bucket hat	0		Moxie: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	cool Brogre bucket hat	0		Moxie: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	teal Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	spinning one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	jittery auspicious Annie Oakley's 8-billed baseball cap of mayonnaise	0		Critical Hit Percent: +20, Sleaze Spell Damage: +50, Item Drop: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	jittery auspicious Annie Oakley's 8-billed baseball cap of mayonnaise	0		Critical Hit Percent: +20, Sleaze Spell Damage: +50, Item Drop: +10, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	clever thinker's extremely wet T-shirt of the cheetah	0		Mysticality: +10, Maximum MP: +20, Initiative: +60, Last Available: "2014-05"
 7470	nasty supercool shrimp fork of the sweet-tooth	0		Moxie Percent: +20, Stench Damage: +5, Candy Drop: +100, Last Available: "2014-05"
-7471	quadruple-boiled pressed fuchsia narrow BROS Energy Drink	0		Effect: "Rat-Faced", Effect Duration: 23, Last Available: "2014-05"
+7471	quadruple-boiled pressed narrow fuchsia BROS Energy Drink	0		Effect: "Rat-Faced", Effect Duration: 23, Last Available: "2014-05"
 7472	double-aerosolized twirling go-go potion	0		Effect: "Clyde's Blessing", Effect Duration: 53, Last Available: "2014-05"
 7473	anodized jittery shrimp cocktail	0		Effect: "Puddingskin", Effect Duration: 66, Last Available: "2014-05"
 7474	quadruple-aerosolized galvanized Yolo&trade; chocolates	0		Effect: "Tingling Feeling", Effect Duration: 58, Last Available: "2020-09"
@@ -7368,16 +7368,16 @@
 7479	enhanced sugar fairy	0		Effect: "Mo' Hobo", Effect Duration: 49, Last Available: "2014-05"
 7480	diffused huge sugar bunny	0		Effect: "Certainty", Effect Duration: 51, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	tolerable distilled Rompedores de Fantasmas	5	good	
+7482	distilled tolerable Rompedores de Fantasmas	5	good	
 7483	mediocre watered-down blinking La Fantasma y La Oscuridad	2	decent	
-7484	tolerable weak Fantasma en la M&aacute;quina	2	good	
+7484	weak tolerable Fantasma en la M&aacute;quina	2	good	
 7485	huge loosening powder	0		
 7486	castoreum	0		
 7487	drain dissolver	0		
 7488	twirling triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	fancy strong tolerable twirling bouncing bottle of Chateau de Vinegar	5	good	Effect: "Magically Delicious", Effect Duration: 10
+7491	tolerable strong fancy bouncing twirling bottle of Chateau de Vinegar	5	good	Effect: "Magically Delicious", Effect Duration: 10
 7492	blasting soda	0		
 7493	squat unstable fulminate	0		
 7494	tumbling wine bomb	0		
@@ -7395,7 +7395,7 @@
 7506	huge aromatic vibrating book	0		Maximum MP Percent: +10, Stench Resistance: +1
 7507	smooth cloak	0		Moxie: +15
 7508	skewed label	0		
-7509	gigantic rotten Mornington crescent roll	7	crappy	
+7509	rotten gigantic Mornington crescent roll	7	crappy	
 7510	ionized flattened eye shadow	0		Effect: "Gyromitra Gymnastics", Effect Duration: 21
 7511	crumbling wheel	0		
 7512	pickled blinking poppy	0		Effect: "Appeteyes", Effect Duration: 53
@@ -7415,18 +7415,18 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	skewed alien force field disruptor bean	0		Last Available: "2014-05"
 7528	ghostly lion tamer's government-issued night-vision goggles of Calamity Jane	0		Critical Hit Percent: +15, Experience (familiar): +2, Single Equip, Last Available: "2014-05"
-7529	snack-sized normal enchanted loaf of alien bread	2	good	Effect: "Warm Shoulders", Effect Duration: 35, Last Available: "2014-05"
-7530	tiny flavorless grilled cheese sandwich	1	decent	Last Available: "2014-05"
+7529	snack-sized enchanted normal loaf of alien bread	2	good	Effect: "Warm Shoulders", Effect Duration: 35, Last Available: "2014-05"
+7530	flavorless tiny grilled cheese sandwich	1	decent	Last Available: "2014-05"
 7531	mixed alien protein powder	1	crappy	Effect: "Human-Horror Hybrid", Effect Duration: 40, Last Available: "2014-05"
-7532	mediocre watered-down pulsating rocket fuel	2	decent	Last Available: "2014-05"
+7532	watered-down mediocre pulsating rocket fuel	2	decent	Last Available: "2014-05"
 7533	shaking green alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	hand-crafted weak bouncing huge stealth bomber	2	EPIC	Last Available: "2014-05"
+7535	weak hand-crafted huge bouncing stealth bomber	2	EPIC	Last Available: "2014-05"
 7536	mirror space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	shaking grievous space beast fur hat	0		Weapon Damage Percent: +50, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	mirror lion tamer's space beast fur pants	0		Experience (familiar): +2, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	shaking grievous space beast fur hat	0		Weapon Damage Percent: +50, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	mirror lion tamer's space beast fur pants	0		Experience (familiar): +2, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	lard-coated space beast fur whip	0		Sleaze Spell Damage: +25, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	Jeselnik's space heater of the glutton	0		Sleaze Damage: +25, Food Drop: +100, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7450,7 +7450,7 @@
 7561	corrupted double-deionized giraffe-necked turtle	0		Effect: "Human-Insect Hybrid", Effect Duration: 19
 7562	activated frozen maroon musk turtle	0		Effect: "Rushin' Hands", Effect Duration: 46
 7563	denatured programmable turtle	0		Effect: "Alpine Mintiness", Effect Duration: 34
-7564	pressed energized gray blinking narrow mocking turtle	0		Effect: "The Living Hitpoints", Effect Duration: 51
+7564	pressed energized gray narrow blinking mocking turtle	0		Effect: "The Living Hitpoints", Effect Duration: 51
 7565	big bland ham steak	5	decent	
 7566	jittery sharpshooter's time-twitching toolbelt	0		Critical Hit Percent: +10, Single Equip, Free Pull
 7567	Chroner	0		
@@ -7458,9 +7458,9 @@
 7569	chilly wholesome personal trainer's Time Bandit Badge of Courage	0		Experience Percent (Muscle): +10, Maximum HP Percent: +10, Cold Damage: +5
 7570	ionized Friendliness Beverage	0		Effect: "Spirit Bubble", Effect Duration: 29
 7571	rock-hard silent pea shooter of courage	0		Damage Reduction: 5, Spooky Resistance: +3
-7572	gigantic adequate twirling D roll	6	good	
+7572	adequate gigantic twirling D roll	6	good	
 7573	teal dangerous slick kiwi beak	0		Moxie: +10, Weapon Damage: +10
-7574	triple-distilled bad New Zealand iced tea	10	decent	
+7574	bad triple-distilled New Zealand iced tea	10	decent	
 7575	gravedigger's supercharged droll monocle	0		Maximum MP Percent: +30, Spooky Damage: +10, Single Equip
 7576	liquefied future drug: Muscularactum	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 68
 7577	wet aerosolized twirling future drug: Smartinex	0		Effect: "Saucegoggles", Effect Duration: 67
@@ -7469,20 +7469,20 @@
 7580	boiled liquid shifting time weirdness	1		
 7581	cyan shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	fancy delicious skewed rack of dinosaur ribs	3	awesome	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25
-7583	perfectly mixed enchanted practically non-alcoholic scotch on the rocks	1	super ultra mega turbo EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15
+7583	perfectly mixed practically non-alcoholic enchanted scotch on the rocks	1	super ultra mega turbo EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15
 7584	clever Newton's yabba dabba doo rag	0		Experience (Mysticality): +3, Maximum MP: +20, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	spinning Oprah's Socratic wooly loincloth	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Familiar Effect: "atk, 1xVolley, cap 27"
-7586	bouncing blinking helix fossil	0		
+7586	blinking bouncing helix fossil	0		
 7587	narrow S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	practically non-alcoholic lousy glass of &quot;milk&quot;	1	decent	Last Available: "2014-07"
 7590	artisanal fancy twirling cup of &quot;tea&quot;	4	EPIC	Effect: "Wallflowering", Effect Duration: 10, Last Available: "2014-07"
-7591	hand-crafted watered-down thermos of &quot;whiskey&quot;	2	EPIC	Last Available: "2014-07"
+7591	watered-down hand-crafted thermos of &quot;whiskey&quot;	2	EPIC	Last Available: "2014-07"
 7592	lousy Lucky Lindy	4	decent	Last Available: "2014-07"
-7593	drinkable watered-down Bee's Knees	2	good	Last Available: "2014-07"
+7593	watered-down drinkable Bee's Knees	2	good	Last Available: "2014-07"
 7594	acceptable narrow Sockdollager	4	good	Last Available: "2014-07"
-7595	special lousy irresponsibly strong Ish Kabibble	8	decent	Effect: "Go-Gone", Effect Duration: 50, Last Available: "2014-07"
-7596	weak artisanal Hot Socks	2	EPIC	Last Available: "2014-07"
+7595	irresponsibly strong lousy special Ish Kabibble	8	decent	Effect: "Go-Gone", Effect Duration: 50, Last Available: "2014-07"
+7596	artisanal weak Hot Socks	2	EPIC	Last Available: "2014-07"
 7597	smooth skewed Phonus Balonus	3	awesome	Last Available: "2014-07"
 7598	perfectly mixed blue Flivver	3	EPIC	Last Available: "2014-07"
 7599	perfectly mixed Sloppy Jalopy	4	EPIC	Last Available: "2014-07"
@@ -7496,14 +7496,14 @@
 7607	electrified huge vial of swamp vapors	0		Effect: "Twen Tea", Effect Duration: 19
 7608	flattened turtle mud	0		Effect: "Booing Radly", Effect Duration: 63
 7609	warmed triple-aerosolized cyan pulsating Redeye&trade; Eyedrops	0		Effect: "The Sweats", Effect Duration: 60
-7610	colloidal squat olive jittery Dweebisol&trade; inhaler	0		Effect: "Dreadful Chill", Effect Duration: 62
+7610	colloidal jittery squat olive Dweebisol&trade; inhaler	0		Effect: "Dreadful Chill", Effect Duration: 62
 7611	warmed Lewd Lemmy Hair Oil	0		Effect: "Your Eyes are Peeled!", Effect Duration: 69
 7612	quadruple-deionized nitrogenated diffused tomato soup poster	0		Effect: "Emotion Sickness", Effect Duration: 25
-7613	ionized aerosolized maroon skewed tumbling bubblin' chemistry solution	0		Effect: "Eye of the Seal", Effect Duration: 63
+7613	ionized aerosolized maroon tumbling skewed bubblin' chemistry solution	0		Effect: "Eye of the Seal", Effect Duration: 63
 7614	extra-magnetized ionized energized upside-down voodoo glowskull	0		Effect: "There Is A Spoon", Effect Duration: 15
 7615	frozen pygmy adder oil	0		Effect: "Space Cadet", Effect Duration: 41
 7616	deionized pygmy witchhazel	0		Effect: "Muscle Unbound", Effect Duration: 26
-7617	corrupted concentrated spinning tumbling short deposition	0		Effect: "Disco Nirvana", Effect Duration: 18
+7617	corrupted concentrated tumbling spinning short deposition	0		Effect: "Disco Nirvana", Effect Duration: 18
 7618	polarized dry straw pole	0		Effect: "Fury of the Bells", Effect Duration: 58
 7619	galvanized non-dry pickled lime green copperhead potion	0		Effect: "Become Intensely interested", Effect Duration: 58
 7620	triple-denatured ninja fear powder	0		Effect: "Blackberry Politeness", Effect Duration: 27
@@ -7548,12 +7548,12 @@
 7659	shellacked neoprene skullcap	0		Damage Reduction: 7, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	quadruple-wet improved shaking goblin water	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 55
 7661	skewed dumb mud	0		
-7662	tiny rotten Sogg-Os	1	crappy	
+7662	rotten tiny Sogg-Os	1	crappy	
 7663	shaking clever weightlifter's Lord Soggyraven's Slippers of the pedagogue	0		Muscle: +15, Experience: +3, Maximum MP: +20, Single Equip
 7664	altered wet Ancient Protector Soda	0		Effect: "Greased-Up Familiar", Effect Duration: 37
 7665	denatured warmed liquid ice	0		Effect: "You Know When to Walk Away", Effect Duration: 24
 7666	perfectly mixed jittery Wet Russian	4	EPIC	
-7667	half-sized bland squat purple filet of The Fish	2	decent	
+7667	bland half-sized squat purple filet of The Fish	2	decent	
 7668	spinning Thwaitgold spider statuette	0		
 7669	tumbling miser's Jeselnik's quilted thunder down underwear	0		Damage Absorption: +40, Sleaze Damage: +25, Meat Drop: +10, Lasts Until Rollover
 7670	fortified personal trainer's famous raincoat of mayonnaise	0		Experience Percent (Muscle): +10, Damage Absorption: +60, Sleaze Spell Damage: +50, Lasts Until Rollover
@@ -7569,7 +7569,7 @@
 7680	curative super-absorbent tarp	0		HP Regen Min: 3, HP Regen Max: 5
 7681	drinkable teal unquiet spirits	4	good	
 7682	banjo kazoo mount of bravery	0		Spooky Resistance: +5, Single Equip
-7683	flattened energized tumbling narrow grass	0		Effect: "Litterboxing", Effect Duration: 12
+7683	flattened energized narrow tumbling grass	0		Effect: "Litterboxing", Effect Duration: 12
 7684	nasty Time Lord Participation Mug	0		Stench Damage: +5
 7685	upside-down knitted Time Bandit Time Towel	0		Cold Resistance: +3, Item Drop: +5
 7686	Lo Pan's occult smooth Caveman Dan's favorite rock	0		Moxie: +15, Spell Damage Percent: +25, Spell Critical Percent: +30, Single Equip
@@ -7592,13 +7592,13 @@
 7703	yellow LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
-7707	double-polymerized fuchsia upside-down huge rubber nubbin	0		Effect: "Strange Mental Acuity", Effect Duration: 12, Last Available: "2014-08"
+7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7707	double-polymerized huge fuchsia upside-down rubber nubbin	0		Effect: "Strange Mental Acuity", Effect Duration: 12, Last Available: "2014-08"
 7708	blurry avaricious rubber cape of the ox	0		Muscle: +20, Meat Drop: +30, Last Available: "2014-08"
 7709	jittery Usain Bolt's family-friendly crafty Thor's Pliers of the ox	0		Muscle: +20, Maximum MP: +10, Sleaze Resistance: +1, Initiative: +80, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	nitrogenated candy UFOs	0		Effect: "Icy Demeanor", Effect Duration: 23
 7711	gravedigger's Tesla water wings for babies	0		Spooky Damage: +10, MP Regen Min: 7, MP Regen Max: 10
-7712	spinning beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	spinning beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	spoiled Strix stix	3	crappy	
 7714	hardened stiffened vampire pellet of the businessman	0		Damage Reduction: 8, Meat Drop: +50
 7715	smooth tumbling non-aged vinegar	3	awesome	
@@ -7609,15 +7609,15 @@
 7720	sizzling radiator heater shield	0		Hot Damage: +10, Damage Reduction: 6
 7721	cold-filtered salt wages	0		Effect: "Ripping, Dripping", Effect Duration: 28
 7722	mirror coward's centurion helmet	0		Monster Level: -20, Familiar Effect: "1xFairy, atk, cap 25"
-7723	lime green twirling Chroner cross	0		
+7723	twirling lime green Chroner cross	0		
 7724	manspreader's pteruges	0		Monster Level: +10, Familiar Effect: "1xFairy, atk, cap 25"
 7725	extra-energized super-polarized Bruno's blessing of Mars	0		Effect: "Riboflavin'", Effect Duration: 63
 7726	aerosolized ionized Dennis's blessing of Minerva	0		Effect: "Almost Cool", Effect Duration: 69
 7727	colloidal ghostly Burt's blessing of Bacchus	0		Effect: "Yuletide Mutations", Effect Duration: 28
 7728	improved blurry Freddie's blessing of Mercury	0		Effect: "Shortened", Effect Duration: 28
-7729	tumbling blurry Chroner trigger	0		
+7729	blurry tumbling Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
-7731	wobbly narrow transmission from planet Xi	0		Last Available: "2014-09"
+7731	narrow wobbly transmission from planet Xi	0		Last Available: "2014-09"
 7732	Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	blurry Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	wobbly Xiblaxian polymer	0		Last Available: "2014-09"
@@ -7639,10 +7639,10 @@
 7750	narrow Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	green veiny Xiblaxian xeno-detection goggles	0		Maximum HP: +10, Single Equip, Last Available: "2014-09"
-7753	cool thinker's Xiblaxian stealth cowl	0		Mysticality: +10, Moxie: +5, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	cool thinker's Xiblaxian stealth cowl	0		Mysticality: +10, Moxie: +5, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	auspicious wicked Xiblaxian stealth trousers	0		Spell Damage: +5, Item Drop: +10, Last Available: "2014-09"
 7755	maroon upside-down executive rosy-cheeked Xiblaxian stealth vest	0		Maximum HP Percent: +30, Meat Drop: +40, Last Available: "2014-09"
-7756	big flavorless Xiblaxian ultraburrito	5	decent	Last Available: "2014-09"
+7756	flavorless big Xiblaxian ultraburrito	5	decent	Last Available: "2014-09"
 7757	mediocre distilled Xiblaxian space-whiskey	5	decent	Last Available: "2014-09"
 7758	twirling Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	activated They liver	0		Effect: "Thicker, Sicker", Effect Duration: 25, Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	squat Coinspiracy	0		Last Available: "2014-10"
 7770	Jim Carey's rosy-cheeked Personal Ventilation Unit of the storm	0		Maximum HP Percent: +30, Maximum MP Percent: +40, Monster Level: +25, Single Equip, Last Available: "2014-10"
 7771	boiled Vulcanized modified the most dangerous bait	0		Effect: "Deadly Lampblade", Effect Duration: 58, Last Available: "2014-10"
-7772	tiny adequate blinking &quot;meat&quot; stick	1	good	Last Available: "2014-10"
+7772	adequate tiny blinking &quot;meat&quot; stick	1	good	Last Available: "2014-10"
 7773	distilled pulsating transdermal smoke patch	1	awesome	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	vibrating dangerous pair of plants of the empath	0		Weapon Damage: +10, Maximum MP Percent: +10, Familiar Weight: +5, Last Available: "2014-10"
@@ -7668,25 +7668,25 @@
 7779	ionized blurry experimental serum G-9	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 55, Last Available: "2014-10"
 7780	asbestos-lined Samson's educational heavy-duty clipboard	0		Experience: +1, Experience (Muscle): +5, Hot Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	dog trainer's energetic studded Sinatra's battery-powered drill	0		Experience (Moxie): +5, Damage Absorption: +80, Maximum MP Percent: +20, Experience (familiar): +1, Last Available: "2014-10"
-7782	decent huge limp broccoli	6	good	Last Available: "2014-10"
-7783	lime green prompt beefy hat of the brute	0		Muscle: +10, Muscle Percent: +30, Adventures: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7782	huge decent limp broccoli	6	good	Last Available: "2014-10"
+7783	lime green prompt beefy hat of the brute	0		Muscle: +10, Muscle Percent: +30, Adventures: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	pressed tumbling monkey barf	0		Effect: "Slimy Hands", Effect Duration: 59, Last Available: "2014-10"
 7785	unsweetened non-Vulcanized pulsating candy	0		Effect: "Gummi-Grin", Effect Duration: 34, Last Available: "2014-10"
 7786	pulsating fireproof scandalous jangly bracelet of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +5, Hot Resistance: +3, Last Available: "2014-10"
 7787	cuddly teddy bear of the overflowing toilet	0		Stench Spell Damage: +50, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
-7788	fuchsia wobbly ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7788	wobbly fuchsia ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	jittery sharpshooter's hardened first-aid pouch	0		Damage Reduction: 3, Critical Hit Percent: +10, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	polarized polarized airborne mutagen	0		Effect: "Burning Tongue", Effect Duration: 33, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
-7794	cyan mirror Armory keycard	0		Last Available: "2014-10"
+7794	mirror cyan Armory keycard	0		Last Available: "2014-10"
 7795	bland initiative shawarma	4	decent	Last Available: "2014-10"
 7796	bland warm war shawarma	3	decent	Last Available: "2014-10"
 7797	huge spoiled spinning karma shawarma	8	crappy	Last Available: "2014-10"
 7798	drinkable triple-distilled blurry Jungle Juice	6	good	Last Available: "2014-10"
-7799	practically non-alcoholic tolerable jittery Amnesiac Ale	1	good	Last Available: "2014-10"
-7800	special bad weak Highest Bitter	2	decent	Effect: "Tearful, Fearful", Effect Duration: 50, Last Available: "2014-10"
+7799	tolerable practically non-alcoholic jittery Amnesiac Ale	1	good	Last Available: "2014-10"
+7800	bad special weak Highest Bitter	2	decent	Effect: "Tearful, Fearful", Effect Duration: 50, Last Available: "2014-10"
 7801	mercenary pistol of the ox of Flo-Jo	0		Muscle: +20, Initiative: +100, Last Available: "2014-10"
 7802	mercenary rifle of the bloodbag of terror	0		Maximum HP: +100, Spooky Spell Damage: +10, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7716,11 +7716,11 @@
 7827	tasty half-sized unidentifiable dried fruit	2	awesome	
 7828	hand-crafted flat cider	3	EPIC	
 7829	wobbly vibrating stylish trench lighter of the cougar	0		Moxie: 45, Maximum MP Percent: +10, Last Available: "2014-10"
-7830	pickled vacuum-sealed lime green tumbling experimental serum P-00	0		Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2014-10"
+7830	pickled vacuum-sealed tumbling lime green experimental serum P-00	0		Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2014-10"
 7831	ghostly military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	mirror encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	squat gore bucket	0		Last Available: "2014-10"
-7834	upside-down teal pack of smokes	0		Last Available: "2014-10"
+7834	teal upside-down pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	Project T. L. B.	0		Last Available: "2014-10"
@@ -7734,17 +7734,17 @@
 7845	flattened perl necklace	0		Effect: "Impregnabili Tea", Effect Duration: 53, Last Available: "2014-12"
 7846	corrupted Fudge Fiber Armor Plating	0		Effect: "Hairless and Airless", Effect Duration: 67, Last Available: "2014-12"
 7847	boiled ruby on canes	0		Effect: "Gummi Badass", Effect Duration: 66, Last Available: "2014-12"
-7848	bland huge petit fortran	9	decent	Last Available: "2014-12"
+7848	huge bland petit fortran	9	decent	Last Available: "2014-12"
 7849	stale java cookie	3	decent	Last Available: "2014-12"
-7850	half-sized spoiled cookie cookie	2	crappy	Last Available: "2014-12"
+7850	spoiled half-sized cookie cookie	2	crappy	Last Available: "2014-12"
 7851	red stylish plastic exo-suited miner	0		Moxie: +25, Last Available: "2014-12"
 7852	dangerous plastic semi-autonomous drill unit	0		Weapon Damage: +10, Last Available: "2014-12"
 7853	green rock-hard plastic ambulatory robo-minecart	0		Damage Reduction: 5, Last Available: "2014-12"
 7854	dance instructor's plastic Crimbot	0		Experience Percent (Moxie): +10, Last Available: "2014-12"
 7855	twirling plastic Crimbomega of the detective	0		Item Drop: +20, Last Available: "2014-12"
 7856	double-flattened shaking flask of mining oil	0		Effect: "Human-Pirate Hybrid", Effect Duration: 15, Last Available: "2014-12"
-7857	careful radiation-resistant helmet	0		Monster Level: -10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	wobbly ruddy servo-assisted exo-pants	0		Maximum HP Percent: +40, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	careful radiation-resistant helmet	0		Monster Level: -10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	wobbly ruddy servo-assisted exo-pants	0		Maximum HP Percent: +40, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	upside-down toasty clever high-energy mining laser	0		Maximum MP: +20, Hot Damage: +5, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7761,7 +7761,7 @@
 7872	green Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	upside-down Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
-7875	bouncing jittery green Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
+7875	jittery bouncing green Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
@@ -7771,7 +7771,7 @@
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	tumbling Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
-7885	shaking mirror Crimbot schematic: Power Arm	0		Last Available: "2014-12"
+7885	mirror shaking Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
 7887	Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
 7888	skewed Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
@@ -7788,7 +7788,7 @@
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	huge Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
-7902	ghostly wobbly Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
+7902	wobbly ghostly Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	recovered elf magazine	0		Last Available: "2014-12"
@@ -7802,16 +7802,16 @@
 7913	coward's baleful Rosewater's Size XI Wizard's Robe	0		Mysticality Percent: +30, Spell Damage: +25, Monster Level: -20, Last Available: "2014-09"
 7914	chilled nitrogenated frozen spinning green Bit O' Quail Spleen	0		Effect: "Optimist Primal", Effect Duration: 54
 7915	enhanced liquefied maroon tumbling Take Eleven Bar	0		Effect: "Slime Time", Effect Duration: 28
-7916	purple wobbly wobbly mimeplasm	0		
+7916	wobbly wobbly purple mimeplasm	0		
 7917	Vulcanized frozen BOOterfinger	0		Effect: "Orchid Blood", Effect Duration: 55
 7918	liquefied triple-cold-filtered teal Moonds	0		Effect: "Adorable Lookout", Effect Duration: 54
 7919	deionized energized Big Punk	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 42
 7920	gray pulsating fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	bouncing turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	practically non-alcoholic drinkable Friendly Turkey	1	good	Last Available: "2014-11"
+7922	drinkable practically non-alcoholic Friendly Turkey	1	good	Last Available: "2014-11"
 7923	bad Agitated Turkey	4	decent	Last Available: "2014-11"
-7924	lousy spirit-forward Ambitious Turkey	5	decent	Last Available: "2014-11"
-7925	bland blinking wobbly neutron lollipop	3	decent	Last Available: "2014-12"
+7924	spirit-forward lousy Ambitious Turkey	5	decent	Last Available: "2014-11"
+7925	bland wobbly blinking neutron lollipop	3	decent	Last Available: "2014-12"
 7926	drinkable gamma nog	4	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	cyan Thwaitgold nit statuette	0		
@@ -7827,8 +7827,8 @@
 7945	bouncing table	0		
 7946	knitted flame-wreathed grievous outlaw bandana	0		Weapon Damage Percent: +50, Hot Spell Damage: +10, Cold Resistance: +3
 7947	triple-distilled acceptable jittery whiskey in a broken glass	10	good	
-7948	lousy fortified narrow shot of mescal	5	decent	
-7949	watered-down hand-crafted glass of herbal tequila	2	EPIC	
+7948	fortified lousy narrow shot of mescal	5	decent	
+7949	hand-crafted watered-down glass of herbal tequila	2	EPIC	
 7950	shaking minin' dynamite	0		
 7951	bouncing gravedigger's foul-smelling plaid cowboy hat	0		Stench Damage: +10, Spooky Damage: +10, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	tumbling upside-down lasso	0		
@@ -7837,7 +7837,7 @@
 7955	maroon bag of money	0		
 7956	spinning maroon Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	ghostly even more tinsel	0		Familiar Weight: +5
-7958	blurry huge box of Crimbo decorations	0		
+7958	huge blurry box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	electrified hardy hale Staff of Ed of terror	0		Maximum HP: 70, Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5
@@ -7847,7 +7847,7 @@
 7965	twirling Holy MacGuffin	0		
 7966	lime green Ka coin	0		
 7967	World's Best Adventurer sash of mayonnaise	0		Sleaze Spell Damage: +50
-7968	huge fuchsia topiary nugglet	0		
+7968	fuchsia huge topiary nugglet	0		
 7969	blue beehive	0		
 7970	olive boning knife	0		
 7971	wobbly Aggressive Carrot	0		Free Pull
@@ -7859,7 +7859,7 @@
 7977	huge silk bandages	0		
 7978	blue holy spring water	0		
 7979	yellow spirit beer	0		
-7980	shaking mirror sacramental wine	0		
+7980	mirror shaking sacramental wine	0		
 7981	narrow talisman of Thoth	0		
 7982	cure-all	0		
 7983	scorching Jack Frost's Sister Accessory	0		Cold Spell Damage: +50, Hot Damage: +25, Softcore Only
@@ -7881,7 +7881,7 @@
 7999	pressed choco-Crimbot	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 12, Last Available: "2014-12"
 8000	extra-liquefied wet galvanized smart watch	0		Effect: "Eye of the Lihc", Effect Duration: 26, Last Available: "2014-12"
 8001	flattened polymerized blinking augmented-reality shades	0		Effect: "Medieval Mage Mayhem", Effect Duration: 40, Last Available: "2014-12"
-8002	upside-down auspicious toy Crimbot mega face	0		Item Drop: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8002	upside-down auspicious toy Crimbot mega face	0		Item Drop: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	toy Crimbot power glove of the sewer	0		Stench Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	quilted toy Crimbot super fist	0		Damage Absorption: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	sizzling toy Crimbot rocket legs	0		Hot Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7890,7 +7890,7 @@
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
-8011	green spinning heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
+8011	spinning green heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	Sherlock's MacGyver's deadly Crimbomega drive chain	0		Weapon Damage: +5, Maximum MP: +100, Item Drop: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	red Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
@@ -7900,7 +7900,7 @@
 8018	wet vacuum-sealed blurry and rain stick	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 61
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	toothsome maroon Choco-Mint patty	3	awesome	Last Available: "2015-01"
-8021	bad fortified hot mint schnocolate	5	decent	Last Available: "2015-01"
+8021	fortified bad hot mint schnocolate	5	decent	Last Available: "2015-01"
 8022	mixed ghostly blurry homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	fuchsia foreign language tapes	0		Last Available: "2015-01"
@@ -7944,17 +7944,17 @@
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	spinning banana	0		Familiar Weight: +5
-8066	pickled wobbly purple	1	decent	Last Available: "2015-12"
+8066	pickled purple wobbly	1	decent	Last Available: "2015-12"
 8067	spinning nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
-8069	wobbly purple Stembridge sidearm	0		Familiar Weight: +5
+8069	purple wobbly Stembridge sidearm	0		Familiar Weight: +5
 8070	pulsating bouncing warehouse map page	0		
 8071	warehouse inventory page	0		
 8072	tumbling janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	ruddy Spelunker's fedora of the bloodbag of the sewer	0		Maximum HP Percent: +40, Maximum HP: +100, Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	ruddy Spelunker's fedora of the bloodbag of the sewer	0		Maximum HP Percent: +40, Maximum HP: +100, Stench Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	mansplainer's groovy Spelunker's whip of the detective	0		Moxie Percent: +10, Monster Level: +15, Item Drop: +20, Last Available: "2015-12"
-8076	huge Oprah's baleful slick Spelunker's khakis	0		Moxie: +10, Spell Damage: +25, Maximum MP Percent: +50, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	huge Oprah's baleful slick Spelunker's khakis	0		Moxie: +10, Spell Damage: +25, Maximum MP Percent: +50, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	green huge Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7970,7 +7970,7 @@
 8095	squat wool sizzling wicker ticker	0		Hot Damage: +10, Cold Resistance: +1, Single Equip, Last Available: "2016-12"
 8096	greedy personal trainer's wicker sticker	0		Experience Percent (Muscle): +10, Meat Drop: +20, Last Available: "2016-12"
 8097	fuchsia gravedigger's Oprah's wicker clicker	0		Maximum MP Percent: +50, Spooky Damage: +10, Last Available: "2016-12"
-8098	boiled blue huge wickerbits	1		Last Available: "2016-12"
+8098	boiled huge blue wickerbits	1		Last Available: "2016-12"
 8099	gray mansplainer's veiny belt	0		Maximum HP: +10, Monster Level: +15, Single Equip, Last Available: "2016-12"
 8100	greedy rock-hard badge	0		Damage Reduction: 5, Meat Drop: +20, Single Equip, Last Available: "2016-12"
 8101	blurry knitted Rosewater's bowl	0		Mysticality Percent: +30, Cold Resistance: +3, Last Available: "2016-12"
@@ -8007,7 +8007,7 @@
 8132	Jeselnik's rosy-cheeked fiberglass fedora	0		Maximum HP Percent: +30, Sleaze Damage: +25, Last Available: "2018-12"
 8133	distilled spinning lime green fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
-8135	ghostly tumbling winged yeti fur	0		
+8135	tumbling ghostly winged yeti fur	0		
 8136	tumbling talisman of Renenutet	0		
 8138	dog trainer's rubber spatula	0		Experience (familiar): +1
 8139	upside-down experienced spoon	0		Experience: +2
@@ -8025,7 +8025,7 @@
 8151	liquefied super-cold-filtered Shrubble Bubble	0		Effect: "Ack!  Barred!", Effect Duration: 19
 8152	unsweetened polyeaster egg	0		Effect: "Sugar High", Effect Duration: 22
 8153	flattened wet candy dish	0		Effect: "Human-Penguin Hybrid", Effect Duration: 18
-8154	colloidal ghostly yellow pulsating Spechunky bar	0		Effect: "Sewer-Drenched", Effect Duration: 22
+8154	colloidal pulsating yellow ghostly Spechunky bar	0		Effect: "Sewer-Drenched", Effect Duration: 22
 8155	nitrogenated liquefied oxidized blue talisman of Horus	0		Effect: "Slimed Stomach", Effect Duration: 56
 8156	pulsating check to the Meatsmith	0		
 8157	blue Skeleton Store office key	0		
@@ -8047,7 +8047,7 @@
 8173	greasy sewer snake	0		Sleaze Spell Damage: +10
 8174	small bland pigeon egg	2	decent	
 8175	upside-down lion tamer's clever jaunty feather	0		Maximum MP: +20, Experience (familiar): +2
-8176	irresponsibly strong bad premium malt liquor	10	decent	
+8176	bad irresponsibly strong premium malt liquor	10	decent	
 8177	lime green squat squat brown paper pants of the dark arts of incineration	0		Spell Damage Percent: +100, Hot Spell Damage: +50
 8178	up-at-dawn stiffened brown paper bag mask	0		Damage Reduction: 1, Adventures: +5
 8179	huge tumbling auspicious ring of telling skeletons what to do	0		Item Drop: +10, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,18 +8056,18 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	nasty bread basket	0		Stench Damage: +5
 8184	narrow Ed the Undying exhibit crate	0		
-8185	healthy quilted The Crown of Ed the Undying	0		Damage Absorption: +40, Maximum HP Percent: +20, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	healthy quilted The Crown of Ed the Undying	0		Damage Absorption: +40, Maximum HP Percent: +20, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	narrow Doc Galaktik's Invigorating Tonic	0		
 8187	shaking map to a hidden booze cache	0		
 8188	bad Cherrytastrophe wine cooler	4	decent	
 8189	perfectly mixed Radberry Rip wine cooler	4	EPIC	
 8190	artisanal spinning Orangemageddon wine cooler	4	EPIC	
-8191	practically non-alcoholic delicious Breakfast Blast wine cooler	1	awesome	
-8192	perfectly mixed triple-distilled Citrus Crush wine cooler	8	EPIC	
+8191	delicious practically non-alcoholic Breakfast Blast wine cooler	1	awesome	
+8192	triple-distilled perfectly mixed Citrus Crush wine cooler	8	EPIC	
 8193	flavorless thick plain bagel	5	decent	
 8194	bland diet glob of cream cheese	1	decent	
 8195	rotten loaf of soda bread	3	crappy	
-8196	enchanted moldy acceptable bagel	3	crappy	Effect: "Eldritch Concentration", Effect Duration: 30
+8196	moldy enchanted acceptable bagel	3	crappy	Effect: "Eldritch Concentration", Effect Duration: 30
 8197	yummy standard-issue cupcake	3	awesome	
 8198	yummy shaking ultra-deluxe cupcake	3	awesome	
 8199	hypnotic breadcrumbs	0		
@@ -8089,10 +8089,10 @@
 8215	quilted sewage-clogged pistol of the storm	0		Damage Absorption: +40, Maximum MP Percent: +40, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	adjusted pulsating beard incense	0		Effect: "Superveiny 9000", Effect Duration: 48, Last Available: "2015-04"
 8217	vibrating Newton's perfume-soaked bandana	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Single Equip, Last Available: "2015-04"
-8218	cyan upside-down toxic globule	0		Last Available: "2015-04"
+8218	upside-down cyan toxic globule	0		Last Available: "2015-04"
 8219	stale jittery toxo	4	decent	Last Available: "2015-04"
-8220	weak hand-crafted Lemonade-235	2	EPIC	Last Available: "2015-04"
-8221	squat greasy isotophat of the sweet-tooth	0		Sleaze Spell Damage: +10, Candy Drop: +100, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	hand-crafted weak Lemonade-235	2	EPIC	Last Available: "2015-04"
+8221	squat greasy isotophat of the sweet-tooth	0		Sleaze Spell Damage: +10, Candy Drop: +100, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	educational Three Mile Island shorts of wisdom	0		Mysticality: +15, Experience: +1, Last Available: "2015-04"
 8223	brawny thinker's toxic mop	0		Mysticality: +10, Muscle Percent: +20, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8127,7 +8127,7 @@
 8253	Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	blurry Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
-8256	skewed blinking Dinsey tattoo kit	0		Last Available: "2015-04"
+8256	blinking skewed Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	modified nasty gum	0		Effect: "In Vino Vires", Effect Duration: 46
 8258	green Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	jittery twirling The Lot's engagement ring of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Propose To Your Opponent"
@@ -8144,12 +8144,12 @@
 8270	toothsome unappetizing mayolus	3	awesome	Last Available: "2015-05"
 8271	big bland uninteresting mayolus	5	decent	Last Available: "2015-05"
 8272	yummy acceptable mayolus	3	awesome	Last Available: "2015-05"
-8273	decent big enticing mayolus	5	good	Last Available: "2015-05"
+8273	big decent enticing mayolus	5	good	Last Available: "2015-05"
 8274	flavorless thick wobbly mouth-watering mayolus	5	decent	Last Available: "2015-05"
 8275	wobbly newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
-8277	bouncing huge twirling Essence of Bear	0		Skill: "Bear Essence"
-8278	watered-down special lousy Afternoon Delight	2	decent	Effect: "Executive Greed", Effect Duration: 40, Last Available: "2015-04"
+8277	huge bouncing twirling Essence of Bear	0		Skill: "Bear Essence"
+8278	lousy special watered-down Afternoon Delight	2	decent	Effect: "Executive Greed", Effect Duration: 40, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	shaking Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	enhanced pressed Kokomo Resort Brand Suntan Oil	0		Effect: "Triangle, Man", Effect Duration: 55, Last Available: "2015-04"
@@ -8157,7 +8157,7 @@
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	alkaline Kokomo Resort Pass	0		Effect: "Saucefingers", Effect Duration: 61, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
-8286	deionized blurry blue Mayo de Mayo&trade; mayo	0		Effect: "Mushroom Magicalness", Effect Duration: 55
+8286	deionized blue blurry Mayo de Mayo&trade; mayo	0		Effect: "Mushroom Magicalness", Effect Duration: 55
 8287	puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	twirling blurry boxing gloves	0		Last Available: "2015-06"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	triple-chilled alkaline concentrated power pill	0		Effect: "Witch Breaded", Effect Duration: 22, Last Available: "2015-06"
 8301	adjusted mirror pixel star	0		Effect: "Wreathed in Smoke", Effect Duration: 20, Last Available: "2015-06"
-8302	toothsome tiny pixel banana	1	awesome	Last Available: "2015-06"
+8302	tiny toothsome pixel banana	1	awesome	Last Available: "2015-06"
 8303	tolerable maroon pixel beer	4	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	blinking pumps	0		Last Available: "2015-06"
@@ -8222,7 +8222,7 @@
 8348	pickled concentrated pulsating filthy monkey head	0		Effect: "Mint-Condition Breath", Effect Duration: 38
 8349	non-diffused extra-warmed hand of cards	0		Effect: "Bricked-In", Effect Duration: 15
 8350	extra-adjusted ghostly damp bar rag	0		Effect: "Oleaginous Soles", Effect Duration: 56
-8351	vacuum-sealed electrified pulsating blinking lump of goofball ore	0		Effect: "Phorcefullness", Effect Duration: 28
+8351	vacuum-sealed electrified blinking pulsating lump of goofball ore	0		Effect: "Phorcefullness", Effect Duration: 28
 8352	ionized corrupted pickled skeleton beans	0		Effect: "Blubbered Up", Effect Duration: 12
 8353	quadruple-colloidal narrow blurry grimy lab coat	0		Effect: "Chunky", Effect Duration: 49
 8354	warmed unsweetened nursery rhyme	0		Effect: "Rave Concentration", Effect Duration: 45
@@ -8243,12 +8243,12 @@
 8369	deionized denatured plunge-leg	0		Effect: "Superheroic", Effect Duration: 36
 8370	frozen quadruple-chilled funky eyepatch	0		Effect: "Wet Rub", Effect Duration: 29
 8371	denatured super-energized bucket of fish juice	0		Effect: "The Living Hitpoints", Effect Duration: 57
-8372	dry bouncing blinking skewed flashy pirate dreadlocks	0		Effect: "Experimental Effect G-9", Effect Duration: 63
+8372	dry skewed bouncing blinking flashy pirate dreadlocks	0		Effect: "Experimental Effect G-9", Effect Duration: 63
 8373	warmed captured boozles	0		Effect: "Heart of Pink", Effect Duration: 21
 8374	alkaline drinks tray	0		Effect: "Ooh, Salty!", Effect Duration: 31
 8375	polymerized huge eyebrow lifter	0		Effect: "Chow Downed", Effect Duration: 42
 8376	cyan submarine	0		Last Available: "2015-06"
-8377	decent small spinning pixel lemon	2	good	Last Available: "2015-06"
+8377	small decent spinning pixel lemon	2	good	Last Available: "2015-06"
 8378	delicious blinking pixel daiquiri	3	awesome	Last Available: "2015-06"
 8379	modified power pill	0		Effect: "Dweeby", Effect Duration: 63, Last Available: "2015-06"
 8380	ionized pixel potion	0		Effect: "Limber as Mortimer", Effect Duration: 56, Last Available: "2015-06"
@@ -8280,15 +8280,15 @@
 8406	savory dry noodles	0		
 8407	special moldy pestopiary	4	crappy	Effect: "Walberg's Dim Bulb", Effect Duration: 35
 8408	extra-adjusted deionized pulsating fuchsia ectoplasmic orbs	0		Effect: "Spookyravin'", Effect Duration: 44
-8409	bland diet crudles	1	decent	
+8409	diet bland crudles	1	decent	
 8410	bland agnolotti arboli	3	decent	
-8411	fancy spoiled blinking spaghetti with ghost balls	4	crappy	Effect: "Spooky Weapon", Effect Duration: 30
-8412	decent miniature succulent marrow	2	good	
+8411	spoiled fancy blinking spaghetti with ghost balls	4	crappy	Effect: "Spooky Weapon", Effect Duration: 30
+8412	miniature decent succulent marrow	2	good	
 8413	adequate salacious crumbs	4	good	
 8414	snack-sized bland fusilli marrownarrow	2	decent	
-8415	decent half-sized suggestive strozzapreti	2	good	
+8415	half-sized decent suggestive strozzapreti	2	good	
 8416	olive Mountain Stream gastrique	0		
-8417	half-sized spoiled teal Mt. McLargeHuge oyster	2	crappy	
+8417	spoiled half-sized teal Mt. McLargeHuge oyster	2	crappy	
 8418	oyster sauce	0		
 8419	bland immense olive linguini immondizia bianco	8	decent	
 8420	flavorless shells a la shellfish	3	decent	
@@ -8329,7 +8329,7 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	olive broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	beefcake's high-temperature mining mask of Leguizamo	0		Muscle: +25, Monster Level: +20, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	beefcake's high-temperature mining mask of Leguizamo	0		Muscle: +25, Monster Level: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	inspector's fireproof megaphone of the dark arts	0		Spell Damage Percent: +100, Item Drop: +15, Last Available: "2015-08"
 8460	bland mineapple	3	decent	Last Available: "2015-08"
 8461	boozy hand-crafted upside-down Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
@@ -8345,23 +8345,23 @@
 8471	toasty lava-proof pants of temperance	0		Hot Damage: +5, Sleaze Resistance: +5, Last Available: "2015-08"
 8472	up-at-dawn steel-toed heat-resistant necktie	0		Damage Reduction: 9, Adventures: +5, Single Equip, Last Available: "2015-08"
 8473	nippy energetic steel-toed heat-resistant gloves	0		Damage Reduction: 9, Maximum MP Percent: +20, Cold Damage: +10, Single Equip, Last Available: "2015-08"
-8474	rotten half-sized very hot lunch	2	crappy	Last Available: "2015-08"
+8474	half-sized rotten very hot lunch	2	crappy	Last Available: "2015-08"
 8475	perfectly mixed asbestos thermos	4	EPIC	Last Available: "2015-08"
 8476	corrupted ghostly spinning liquid rhinestones	0		Effect: "Emotion Sickness", Effect Duration: 60, Last Available: "2015-08"
 8477	delicious blurry disco biscuit	3	awesome	Last Available: "2015-08"
 8478	lousy Quaatorade&trade;	4	decent	Last Available: "2015-08"
-8479	extremely unsafe Samson's savvy biker's hat	0		Mysticality Percent: +20, Experience (Muscle): +5, Weapon Damage Percent: +100, Familiar Effect: "atk", Last Available: "2015-08"
-8480	red smelly studded feathered headdress of temperance	0		Damage Absorption: +80, Stench Spell Damage: +10, Sleaze Resistance: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	jittery rock-hard electrician's hardhat of vim and vigor of the boozehound	0		Damage Reduction: 5, Maximum HP Percent: +50, Booze Drop: +100, Familiar Effect: "atk", Last Available: "2015-08"
+8479	extremely unsafe Samson's savvy biker's hat	0		Mysticality Percent: +20, Experience (Muscle): +5, Weapon Damage Percent: +100, Last Available: "2015-08", Familiar Effect: "atk"
+8480	red smelly studded feathered headdress of temperance	0		Damage Absorption: +80, Stench Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	jittery rock-hard electrician's hardhat of vim and vigor of the boozehound	0		Damage Reduction: 5, Maximum HP Percent: +50, Booze Drop: +100, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	narrow Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	teal &quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	huge one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	skewed blurry airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	blurry skewed airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	teal Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	razor-sharp smooth velvet pants	0		Weapon Damage Percent: +25, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	razor-sharp smooth velvet pants	0		Weapon Damage Percent: +25, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	mirror Lo Pan's smooth velvet shirt	0		Spell Critical Percent: +30, Last Available: "2015-08"
 8492	smooth velvet hat of Flo-Jo	0		Initiative: +100, Last Available: "2015-08"
 8493	slick smooth velvet pocket square	0		Moxie: +10, Single Equip, Last Available: "2015-08"
@@ -8391,13 +8391,13 @@
 8517	blurry fireproof electrified SMOOCH bracers	0		Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2015-08"
 8518	baleful SMOOCH kneepads	0		Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8519	huge ghostly rosy-cheeked SMOOCH spaulders	0		Maximum HP Percent: +30, Single Equip, Last Available: "2015-08"
-8520	beefcake's SMOOCH codpiece of the glutton	0		Muscle: +25, Food Drop: +100, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	beefcake's SMOOCH codpiece of the glutton	0		Muscle: +25, Food Drop: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	narrow resourceful SMOOCH breastplate	0		Maximum MP: +50, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	tumbling fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	rotten lava cake	3	crappy	Last Available: "2015-08"
-8526	immense normal fancy pink slime	6	good	Effect: "Hangdog", Effect Duration: 40
+8526	fancy normal immense pink slime	6	good	Effect: "Hangdog", Effect Duration: 40
 8527	upside-down Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	moldy small devil hair pasta	2	crappy	
@@ -8405,14 +8405,14 @@
 8531	Salsa Libre	0		
 8532	wobbly good gravy	0		
 8533	bouncing illicit fish sauce	0		
-8534	half-sized decent blinking blurry libertagliatelle	2	good	
+8534	half-sized decent blurry blinking libertagliatelle	2	good	
 8535	jumbo rotten turkish mostaccioli	5	crappy	
 8536	thick spoiled linguini of the sea	5	crappy	
 8537	ionized huge Hersey&trade; SMOOCH	0		Effect: "Beta Carotene Overdose", Effect Duration: 24
 8539	Alexy sauce	0		
 8540	twirling blurry rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	bite-sized stale Fettris	1	decent	
+8542	stale bite-sized Fettris	1	decent	
 8543	bland fusillocybin	3	decent	
 8544	rotten snack-sized prescription noodles	2	crappy	
 8545	denatured blood-drive sticker	1	good	Effect: "Improprie Tea", Effect Duration: 45
@@ -8424,7 +8424,7 @@
 8551	small yummy sausage without a cause	2	awesome	
 8552	anodized super-pickled face paint	0		Effect: "White Knuckles", Effect Duration: 66
 8553	practically non-alcoholic acceptable emergency margarita	1	good	
-8554	practically non-alcoholic artisanal vintage smart drink	1	super ultra mega turbo EPIC	
+8554	artisanal practically non-alcoholic vintage smart drink	1	super ultra mega turbo EPIC	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8437,7 +8437,7 @@
 8564	wobbly shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	maroon prompt scorching rock-hard barrel lid	0		Damage Reduction: 14, Hot Damage: +25, Adventures: +3, Lasts Until Rollover, Last Available: "2015-09"
 8566	blurry thinker's brainy barrel hoop earring of terror	0		Mysticality: 15, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	skewed asbestos-lined scandalous bankruptcy barrel of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Damage: +5, Hot Resistance: +5, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	skewed asbestos-lined scandalous bankruptcy barrel of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Damage: +5, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	blinking normal barrel	0		Last Available: "2015-09"
 8570	twirling tun	0		Last Available: "2015-09"
@@ -8449,17 +8449,17 @@
 8576	narrow mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	hand-crafted bottle of Amontillado	3	EPIC	Last Available: "2015-09"
-8579	drinkable weak upside-down barrel-aged martini	2	good	Last Available: "2015-09"
-8580	spoiled small barrel pickle	2	crappy	Last Available: "2015-09"
+8579	weak drinkable upside-down barrel-aged martini	2	good	Last Available: "2015-09"
+8580	small spoiled barrel pickle	2	crappy	Last Available: "2015-09"
 8581	rotten barrel cracker	4	crappy	Last Available: "2015-09"
 8582	diluted lime green vibrating mushroom	1	good	Last Available: "2015-09"
-8583	twisted squat mirror mushroom	1	good	Last Available: "2015-09"
+8583	twisted mirror squat mushroom	1	good	Last Available: "2015-09"
 8584	cyan huge KoL Con 12-gauge of the cougar	0		Moxie: +20, Last Available: "2015-09"
 8585	Golden Mr. Eh? of the empath	0		Familiar Weight: +5, Last Available: "2015-09"
 8586	barrel gun of Leguizamo	0		Monster Level: +20, Last Available: "2015-09"
 8587	blue barrel	0		Last Available: "2015-09"
 8588	mirror barrel beryl	0		Last Available: "2015-09"
-8589	enchanted rotten tumbling water log	3	crappy	Effect: "Pecan Pied Piper", Effect Duration: 10, Last Available: "2015-09"
+8589	rotten enchanted tumbling water log	3	crappy	Effect: "Pecan Pied Piper", Effect Duration: 10, Last Available: "2015-09"
 8590	shaking Fonzie's barrelhead of Gandalf	0		Experience (Moxie): +1, Spell Critical Percent: +20, Last Available: "2015-09"
 8591	upside-down Usain Bolt's lion tamer's bottoms of the barrel	0		Experience (familiar): +2, Initiative: +80, Last Available: "2015-09"
 8592	yellow reassuring stiffened chest barrel	0		Damage Reduction: 1, Spooky Resistance: +1, Last Available: "2015-09"
@@ -8493,9 +8493,9 @@
 8620	polymerized corrupted cuppa Obscuri tea	0		Effect: "Craft Tea", Effect Duration: 20, Last Available: "2015-09"
 8621	corrupted moist cuppa Irritabili tea	0		Effect: "Tennis Elbow-wow", Effect Duration: 43, Last Available: "2015-09"
 8622	concentrated triple-liquefied cuppa Mediocri tea	0		Effect: "Bottle in front of Me", Effect Duration: 59, Last Available: "2015-09"
-8623	super-corrupted purple spinning huge cuppa Loyal tea	0		Effect: "Ocelot Eyes", Effect Duration: 57, Last Available: "2015-09"
+8623	super-corrupted huge purple spinning cuppa Loyal tea	0		Effect: "Ocelot Eyes", Effect Duration: 57, Last Available: "2015-09"
 8624	powdered skewed narrow cuppa Activi tea	1	decent	Effect: "Smoky Third Eye", Effect Duration: 20, Last Available: "2015-09"
-8625	mixed red jittery cuppa Cruel tea	1		Last Available: "2015-09"
+8625	mixed jittery red cuppa Cruel tea	1		Last Available: "2015-09"
 8626	colloidal improved enhanced red cuppa Alacri tea	0		Effect: "Altered Wavelengths", Effect Duration: 63, Last Available: "2015-09"
 8627	dry cuppa Vitali tea	0		Effect: "Memory of Speed", Effect Duration: 29, Last Available: "2015-09"
 8628	moist altered cuppa Mana tea	0		Effect: "Weird Vibrations", Effect Duration: 46, Last Available: "2015-09"
@@ -8514,8 +8514,8 @@
 8641	stale bowl of eyeballs	4	decent	Last Available: "2015-10"
 8642	rotten miniature cyan bowl of mummy guts	2	crappy	Last Available: "2015-10"
 8643	spoiled bowl of maggots	3	crappy	Last Available: "2015-10"
-8644	watered-down aged blood and blood	2	awesome	Last Available: "2015-10"
-8645	irresponsibly strong tolerable Jack-O-Lantern beer	7	good	Last Available: "2015-10"
+8644	aged watered-down blood and blood	2	awesome	Last Available: "2015-10"
+8645	tolerable irresponsibly strong Jack-O-Lantern beer	7	good	Last Available: "2015-10"
 8646	mediocre practically non-alcoholic wobbly zombie	1	decent	Last Available: "2015-10"
 8647	skewed Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	gray wind-up spider	0		Last Available: "2015-10"
@@ -8530,7 +8530,7 @@
 8657	cool Othello's dagger	0		Moxie: +5, Single Equip
 8658	huge mansplainer's Othello's handkerchief	0		Monster Level: +15, Single Equip
 8659	super-tarnished Vulcanized diffused tumbling green bowl of Jeal-O	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 21
-8660	tumbling purple grip key	0		
+8660	purple tumbling grip key	0		
 8661	How to Play Othello	0		
 8662	educational ghostly dagger of Leguizamo of terror	0		Experience: +1, Monster Level: +20, Spooky Spell Damage: +10
 8663	perfectly mixed ghost beer	4	EPIC	
@@ -8548,7 +8548,7 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	dry wet teal shoulder-warming lotion	0		Effect: "Capricorn Rising", Effect Duration: 65, Last Available: "2015-11"
 8677	spoiled iceberg lettuce	3	crappy	Last Available: "2015-11"
-8678	artisanal strong ice wine	5	EPIC	Last Available: "2015-11"
+8678	strong artisanal ice wine	5	EPIC	Last Available: "2015-11"
 8679	gray narrow Jeselnik's foul-smelling Wal-Mart snowglobe of James Dean	0		Experience (Moxie): +3, Stench Damage: +10, Sleaze Damage: +25, Last Available: "2015-11"
 8680	stiffened boxer's Wal-Mart nametag of incineration	0		Muscle Percent: +10, Damage Reduction: 1, Hot Spell Damage: +50, Last Available: "2015-11"
 8681	extremely unsafe Wal-Mart overalls of the overflowing toilet of doom	0		Weapon Damage Percent: +100, Stench Spell Damage: +50, Spooky Spell Damage: +50, Last Available: "2015-11"
@@ -8558,7 +8558,7 @@
 8685	huge Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	blurry perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	green baleful bellhop's hat	0		Spell Damage: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8688	green baleful bellhop's hat	0		Spell Damage: +25, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
 8689	perfectly mixed ice porter	3	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	denatured exotic travel brochure	0		Effect: "Boschface", Effect Duration: 21, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
@@ -8571,7 +8571,7 @@
 8698	bad weak blinking iced plum wine	2	decent	Last Available: "2016-01"
 8699	censurious Herculean training belt of the dark arts	0		Experience (Muscle): +1, Spell Damage Percent: +100, Sleaze Resistance: +3, Single Equip, Last Available: "2016-01"
 8700	skewed wool ribald hardened training legwarmers	0		Damage Reduction: 3, Sleaze Damage: +10, Cold Resistance: +1, Single Equip, Last Available: "2016-01"
-8701	greasy educational training helmet of the detective	0		Experience: +1, Sleaze Spell Damage: +10, Item Drop: +20, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	greasy educational training helmet of the detective	0		Experience: +1, Sleaze Spell Damage: +10, Item Drop: +20, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8580,11 +8580,11 @@
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	mixed upside-down abstraction: action	1		Last Available: "2015-12"
 8709	dehydrated shaking abstraction: thought	1		Last Available: "2015-12"
-8710	compressed ghostly green abstraction: sensation	1		Last Available: "2015-12"
+8710	compressed green ghostly abstraction: sensation	1		Last Available: "2015-12"
 8711	dehydrated abstraction: purpose	1		Last Available: "2015-12"
 8712	pickled abstraction: category	1		Last Available: "2015-12"
 8713	pickled upside-down abstraction: perception	1		Last Available: "2015-12"
-8714	vaporized upside-down shaking abstraction: motion	1		Effect: "Danish Cunning", Effect Duration: 5, Last Available: "2015-12"
+8714	vaporized shaking upside-down abstraction: motion	1		Effect: "Danish Cunning", Effect Duration: 5, Last Available: "2015-12"
 8715	twisted abstraction: joy	1		Effect: "Supafly", Effect Duration: 25, Last Available: "2015-12"
 8716	pickled twirling abstraction: certainty	1		Effect: "Taurus Rising", Effect Duration: 35, Last Available: "2015-12"
 8717	dehydrated shaking abstraction: comprehension	1		Effect: "Frigid Weapon", Effect Duration: 25, Last Available: "2015-12"
@@ -8605,11 +8605,11 @@
 8732	delicious narrow bottle of norwhiskey	4	awesome	Last Available: "2015-11"
 8733	mixed octolus oculus	1	crappy	Effect: "Bilious Brawn", Effect Duration: 10, Last Available: "2015-11"
 8734	shaking rosewater-soaked curative smooth sardine can key	0		Moxie: +15, Stench Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11"
-8735	manspreader's grievous norwhal helmet of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +50, Monster Level: +10, Familiar Effect: "atk", Last Available: "2015-11"
+8735	manspreader's grievous norwhal helmet of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +50, Monster Level: +10, Last Available: "2015-11", Familiar Effect: "atk"
 8736	shaking sinister extremely unsafe groovy octolus-skin cloak	0		Moxie Percent: +10, Weapon Damage Percent: +100, Spell Damage: +10, Last Available: "2015-11"
-8737	watered-down aged upside-down perfect cosmopolitan	2	awesome	Last Available: "2015-11"
+8737	aged watered-down upside-down perfect cosmopolitan	2	awesome	Last Available: "2015-11"
 8738	hand-crafted perfect negroni	3	EPIC	Last Available: "2015-11"
-8739	irresponsibly strong drinkable perfect dark and stormy	10	good	Last Available: "2015-11"
+8739	drinkable irresponsibly strong perfect dark and stormy	10	good	Last Available: "2015-11"
 8740	delicious perfect mimosa	4	awesome	Last Available: "2015-11"
 8741	watered-down tolerable perfect old-fashioned	2	good	Last Available: "2015-11"
 8742	aged weak tumbling perfect paloma	2	awesome	Last Available: "2015-11"
@@ -8636,9 +8636,9 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	green box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	perfectly mixed high-proof Gratitude chocolate (bourbon-filled)	10	EPIC	Last Available: "2016-02"
+8766	high-proof perfectly mixed Gratitude chocolate (bourbon-filled)	10	EPIC	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
-8768	skewed squat gray Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
+8768	gray squat skewed Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	huge chocolate bowtie	0		Familiar Weight: +5
 8770	quadruple-wet pitted sheet	0		Effect: "Buggy Flavor", Effect Duration: 27, Last Available: "2015-12"
 8771	sparking robo-battery	0		Last Available: "2015-12"
@@ -8646,7 +8646,7 @@
 8773	ghostly sharpshooter's banded occult reusable shopping bag	0		Spell Damage Percent: +25, Damage Absorption: +100, Critical Hit Percent: +10, Last Available: "2015-12"
 8775	narrow upside-down arcane researcher's coarse hemp socks	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2015-12"
 8776	blinking armband of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2015-12"
-8777	blurry wobbly bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
+8777	wobbly blurry bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	reindeer hammer of the early riser	0		Adventures: +7, Last Available: "2015-12"
 8783	elf ploughshare of the sweet-tooth	0		Candy Drop: +100, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8685,17 +8685,17 @@
 8813	ghostly glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	normal small fuchsia Kudzu salad	2	good	Last Available: "2016-12"
+8816	small normal fuchsia Kudzu salad	2	good	Last Available: "2016-12"
 8817	modified cyan Mansquito Serum	1		Last Available: "2016-12"
-8818	extra-dry smooth ghostly Miss Graves' vermouth	5	awesome	Last Available: "2016-12"
+8818	smooth extra-dry ghostly Miss Graves' vermouth	5	awesome	Last Available: "2016-12"
 8819	flavorless super-sized The Plumber's mushroom stew	5	decent	Last Available: "2016-12"
 8820	modified upside-down The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed jittery The Mad Liquor	3	super EPIC	Last Available: "2016-12"
-8822	aged high-proof blue Doc Clock's thyme cocktail	10	awesome	Last Available: "2016-12"
-8823	diet adequate Mr. Burnsger	1	good	Last Available: "2016-12"
+8822	high-proof aged blue Doc Clock's thyme cocktail	10	awesome	Last Available: "2016-12"
+8823	adequate diet Mr. Burnsger	1	good	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	squat ruddy rosy-cheeked The Jokester's gun of the blizzard	0		Maximum HP Percent: 70, Cold Spell Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	spinning twirling ribald Samson's The Jokester's wig of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Sleaze Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8826	spinning twirling ribald Samson's The Jokester's wig of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Sleaze Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	mirror chaotic experienced stylish The Jokester's pants	0		Moxie: +25, Experience: +2, Spell Critical Percent: +10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	triple-ionized alkaline red Jokester makeup	0		Effect: "Empty Inside", Effect Duration: 13, Last Available: "2016-12"
 8829	wobbly replica bat-oomerang	0		Last Available: "2016-12"
@@ -8724,7 +8724,7 @@
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
 8854	blurry nugget of wicksilver	0		Last Available: "2016-02"
-8855	blurry fuchsia nugget of slicksilver	0		Last Available: "2016-02"
+8855	fuchsia blurry nugget of slicksilver	0		Last Available: "2016-02"
 8856	twirling nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
 8858	mirror nugget of ticksilver	0		Last Available: "2016-02"
@@ -8745,20 +8745,20 @@
 8873	bouncing grievous Pork 'n' Pork 'n' Pork 'n' Beans	0		Weapon Damage Percent: +50, Last Available: "2016-02"
 8874	family-friendly frightening sharpshooter's padded smartaleck's Val-U Brand Every Bean Salad	0		Moxie Percent: +30, Damage Absorption: +20, Critical Hit Percent: +10, Spooky Damage: +5, Sleaze Resistance: +1, Last Available: "2016-02"
 8875	sizzling beefcake's Shrub's Premium Baked Beans of extreme caution	0		Muscle: +25, Monster Level: -25, Hot Damage: +10, Last Available: "2016-02"
-8876	diet stale mirror plate of Heimz Fortified Kidney Beans	1	decent	Last Available: "2016-02"
-8877	rotten enchanted snack-sized plate of Tesla's Electroplated Beans	2	crappy	Effect: "Chunky", Effect Duration: 45, Last Available: "2016-02"
-8878	small tasty special narrow plate of Mixed Garbanzos and Chickpeas	2	awesome	Effect: "Seriously Mutated", Effect Duration: 45, Last Available: "2016-02"
+8876	stale diet mirror plate of Heimz Fortified Kidney Beans	1	decent	Last Available: "2016-02"
+8877	snack-sized enchanted rotten plate of Tesla's Electroplated Beans	2	crappy	Effect: "Chunky", Effect Duration: 45, Last Available: "2016-02"
+8878	small special tasty narrow plate of Mixed Garbanzos and Chickpeas	2	awesome	Effect: "Seriously Mutated", Effect Duration: 45, Last Available: "2016-02"
 8879	stale super-sized plate of Hellfire Spicy Beans	5	decent	Last Available: "2016-02"
 8880	moldy plate of Frigid Northern Beans	3	crappy	Last Available: "2016-02"
 8881	normal plate of World's Blackest-Eyed Peas	4	good	Last Available: "2016-02"
 8882	moldy teal blinking plate of Trader Olaf's Exotic Stinkbeans	4	crappy	Last Available: "2016-02"
-8883	diet special bland plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Goldentongue", Effect Duration: 25, Last Available: "2016-02"
+8883	special bland diet plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Goldentongue", Effect Duration: 25, Last Available: "2016-02"
 8884	rotten plate of Val-U Brand Every Bean Salad	3	crappy	Last Available: "2016-02"
 8885	flavorless tiny plate of Shrub's Premium Baked Beans	1	decent	Last Available: "2016-02"
 8886	shaking rosewater-soaked Fancy Jeff's pocket square of the wise owl	0		Mysticality: +20, Stench Resistance: +3, Last Available: "2016-02"
-8887	wobbly nippy Fonzie's Daisy's unclean bloomers	0		Experience (Moxie): +1, Cold Damage: +10, Item Drop: +5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	wobbly nippy Fonzie's Daisy's unclean bloomers	0		Experience (Moxie): +1, Cold Damage: +10, Item Drop: +5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	blurry Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	friendly thinker's Amoon-Ra Cowtep's nemes of mayonnaise	0		Mysticality: +10, Familiar Weight: +3, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	friendly thinker's Amoon-Ra Cowtep's nemes of mayonnaise	0		Mysticality: +10, Familiar Weight: +3, Sleaze Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	cyan Glenn's dice	0		Last Available: "2016-02"
 8891	Sherlock's nasty medical-grade smartaleck's Former Sheriff Dan's tin star of chilblains	0		Moxie Percent: +30, Cold Damage: +25, Stench Damage: +5, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8773,21 +8773,21 @@
 8901	anodized narrow triggerfingerbone	0		Effect: "Chow Downed", Effect Duration: 64, Last Available: "2016-02"
 8902	unsweetened improved spinning ghost bit	0		Effect: "Pisces in the Skyces", Effect Duration: 60, Last Available: "2016-02"
 8903	pressed unsweetened buzzard feather	0		Effect: "Rain Dancin'", Effect Duration: 23, Last Available: "2016-02"
-8904	dry squat gray lion musk	0		Effect: "Nasty, Nasty Breath", Effect Duration: 46, Last Available: "2016-02"
+8904	dry gray squat lion musk	0		Effect: "Nasty, Nasty Breath", Effect Duration: 46, Last Available: "2016-02"
 8905	stale bear claw	4	decent	Last Available: "2016-02"
 8906	liquefied altered jittery rattler gland	0		Effect: "You're Rubber", Effect Duration: 17, Last Available: "2016-02"
 8907	pickled irradiated pickled half-digested coal	0		Effect: "Fishily Speeding", Effect Duration: 37, Last Available: "2016-02"
 8908	altered irradiated jittery tightly-wound spine	0		Effect: "Brother Corsican's Blessing", Effect Duration: 21, Last Available: "2016-02"
 8909	flavorless jumbo rotting beefsteak	5	decent	Last Available: "2016-02"
-8910	triple-distilled smooth firemilk	8	awesome	Last Available: "2016-02"
+8910	smooth triple-distilled firemilk	8	awesome	Last Available: "2016-02"
 8911	altered vacuum-sealed spidercow eye-cluster	0		Effect: "Bolts about Candy", Effect Duration: 61, Last Available: "2016-02"
 8912	compressed moomy dust	1		Effect: "Mint-Condition Breath", Effect Duration: 5, Last Available: "2016-02"
 8913	mansplainer's weightlifter's western-style skinning knife	0		Muscle: +15, Monster Level: +15, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	bouncing knitted steel knuckles	0		Cold Resistance: +3, Last Available: "2016-02"
-8916	lime green shaking Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
+8916	shaking lime green Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
-8918	wobbly olive The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
+8918	olive wobbly The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
 8919	bouncing LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
@@ -8851,7 +8851,7 @@
 8979	pressed enhanced patent sallowness tonic	0		Effect: "Hairy Palms", Effect Duration: 34
 8980	altered magnetized patent avarice tonic	0		Effect: "Dwarven Hardiness", Effect Duration: 68
 8981	concentrated moist narrow purple narrow patent alacrity tonic	0		Effect: "Fungal Flambé", Effect Duration: 21
-8982	ionized quadruple-adjusted unsweetened fuchsia upside-down corrupted marrow	0		Effect: "Sausage Festive", Effect Duration: 58
+8982	ionized quadruple-adjusted unsweetened upside-down fuchsia corrupted marrow	0		Effect: "Sausage Festive", Effect Duration: 58
 8983	acceptable rodeo whiskey	3	good	
 8984	Thwaitgold scorpion statuette	0		
 8985	shaking rosy-cheeked real cowboy hat	0		Maximum HP Percent: +30
@@ -8863,16 +8863,16 @@
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	vaporized skewed armored prawn	1		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 35, Last Available: "2016-03"
 8993	rotten jumping horseradish	3	crappy	Last Available: "2016-03"
-8994	tolerable practically non-alcoholic Sacramento wine	1	good	Last Available: "2016-03"
+8994	practically non-alcoholic tolerable Sacramento wine	1	good	Last Available: "2016-03"
 8995	magnetized ghostly Greek fire	0		Effect: "Pasta Oneness", Effect Duration: 29, Last Available: "2016-03"
 8996	foul-smelling ox-head shield of dire peril of horror of courage of bravery	0		Weapon Damage: +20, Stench Damage: +10, Spooky Spell Damage: +25, Spooky Resistance: 8, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	Jeselnik's nippy Lo Pan's brawny cool dented scepter	0		Moxie: +5, Muscle Percent: +20, Spell Critical Percent: +30, Cold Damage: +10, Sleaze Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	red resourceful steel-toed hardened Samson's slick very pointy crown	0		Moxie: +10, Experience (Muscle): +5, Damage Reduction: 24, Maximum MP: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	red resourceful steel-toed hardened Samson's slick very pointy crown	0		Moxie: +10, Experience (Muscle): +5, Damage Reduction: 24, Maximum MP: +50, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	narrow scorching sharpshooter's sinister beefy strapping battle broom	0		Muscle: 15, Spell Damage: +10, Critical Hit Percent: +10, Hot Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	huge Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	clever Oprah's carpe of terror of the boozehound	0		Maximum MP Percent: +50, Maximum MP: +20, Spooky Spell Damage: +10, Booze Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9002	censurious Jack Frost's chaotic ruddy codpiece	0		Maximum HP Percent: +40, Spell Critical Percent: +10, Cold Spell Damage: +50, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
-9003	rosewater-soaked knitted Rosewater's troutsers of mayonnaise	0		Mysticality Percent: +30, Sleaze Spell Damage: +50, Cold Resistance: +3, Stench Resistance: +3, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	rosewater-soaked knitted Rosewater's troutsers of mayonnaise	0		Mysticality Percent: +30, Sleaze Spell Damage: +50, Cold Resistance: +3, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	tumbling upside-down greedy lion tamer's shellacked bass clarinet of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Experience (familiar): +2, Meat Drop: +20, Lasts Until Rollover, Last Available: "2016-04"
 9005	wobbly horrifying Tesla crafty fish hatchet of horror	0		Maximum MP: +10, Spooky Damage: +25, Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9006	jittery coward's clever forbidden stylish tunac	0		Moxie: +25, Spell Damage Percent: +50, Maximum MP: +20, Monster Level: -20, Lasts Until Rollover, Last Available: "2016-04"
@@ -8893,18 +8893,18 @@
 9021	adequate gallon of milk	4	good	Last Available: "2016-05"
 9022	blue print screen button	0		Last Available: "2016-05"
 9023	narrow screencapped monster	0		Last Available: "2016-05"
-9024	shaking spinning daily dungeon malware	0		Last Available: "2016-05"
+9024	spinning shaking daily dungeon malware	0		Last Available: "2016-05"
 9025	blurry infinite BACON machine	0		Last Available: "2016-05"
 9026	First Post shirt package	0		Last Available: "2016-05"
 9027	inspector's lion tamer's experienced First Post shirt - Cir Senam	0		Experience: +2, Experience (familiar): +2, Item Drop: +15, Last Available: "2016-05"
-9028	fuchsia narrow high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
-9029	fuchsia squat no spoon	0		
-9030	delicious enchanted gray star salad	4	awesome	Effect: "Ooh, Bitter!", Effect Duration: 45
+9028	narrow fuchsia high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
+9029	squat fuchsia no spoon	0		
+9030	enchanted delicious gray star salad	4	awesome	Effect: "Ooh, Bitter!", Effect Duration: 45
 9031	Thwaitgold moth statuette	0		
-9032	adequate low-calorie jittery bowl of Tastee-Wheet&trade;	1	good	
+9032	low-calorie adequate jittery bowl of Tastee-Wheet&trade;	1	good	
 9033	mirror Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	purple Source essence	0		Last Available: "2016-06"
-9035	moldy jumbo gray browser cookie	5	crappy	Last Available: "2016-06"
+9035	jumbo moldy gray browser cookie	5	crappy	Last Available: "2016-06"
 9036	hand-crafted hacked gibson	3	super EPIC	Last Available: "2016-06"
 9037	bouncing rosy-cheeked Source shades	0		Maximum HP Percent: +30, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8914,7 +8914,7 @@
 9042	shaking Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	pulsating Source terminal DRAM chip	0		Last Available: "2016-06"
-9045	jittery gray narrow Source terminal TRAM chip	0		Last Available: "2016-06"
+9045	narrow gray jittery Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	shaking Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	pulsating Source terminal ASHRAM chip	0		Last Available: "2016-06"
@@ -8963,7 +8963,7 @@
 9091	banded Mr. Screege's spectacles	0		Damage Absorption: +100, Single Equip, Last Available: "2016-08"
 9092	medical-grade Spookyraven signet of the cougar of the brute	0		Moxie: +20, Muscle Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2016-08"
 9093	sharpshooter's Newton's tie-dyed fannypack	0		Experience (Mysticality): +3, Critical Hit Percent: +10, Single Equip, Last Available: "2016-08"
-9094	auspicious supercool burnt snowpants	0		Moxie Percent: +20, Item Drop: +10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	auspicious supercool burnt snowpants	0		Moxie Percent: +20, Item Drop: +10, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	jittery banded standards and practices guide	0		Damage Absorption: +100, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	Van der Graaf Carpathian longsword of the ox of the empath	0		Muscle: +20, Familiar Weight: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-08"
 9097	fortified grievous Liam's mail of the sweet-tooth	0		Weapon Damage Percent: +50, Damage Absorption: +60, Candy Drop: +100, Last Available: "2016-08"
@@ -8981,14 +8981,14 @@
 9109	tarnished pulsating Shrieking Weasel holo-record	0		Effect: "Springy Fusilli", Effect Duration: 12
 9110	pressed aerosolized narrow Power-Guy 2000 holo-record	0		Effect: "Hennaliciousness", Effect Duration: 51
 9111	cold-filtered Lucky Strikes holo-record	0		Effect: "Punchy, Murdery", Effect Duration: 16
-9112	enhanced ghostly jittery EMD holo-record	0		Effect: "Shortened", Effect Duration: 62
+9112	enhanced jittery ghostly EMD holo-record	0		Effect: "Shortened", Effect Duration: 62
 9113	deionized colloidal skewed Superdrifter holo-record	0		Effect: "A View to Some Meat", Effect Duration: 14
 9114	double-anodized dry The Pigs holo-record	0		Effect: "Weird Flavor", Effect Duration: 29
 9115	modified modified fuchsia Drunk Uncles holo-record	0		Effect: "Wet and Greedy", Effect Duration: 33
 9116	cyan time residue	0		Last Available: "2016-09"
 9117	Jack Frost's repaid diaper	0		Cold Spell Damage: +50
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	perfectly mixed watered-down upside-down Shot of Kardashian Gin	2	EPIC	Last Available: "2016-09"
+9119	watered-down perfectly mixed upside-down Shot of Kardashian Gin	2	EPIC	Last Available: "2016-09"
 9120	occult Unstable Pointy Ears	0		Spell Damage Percent: +25, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
@@ -9004,27 +9004,27 @@
 9132	dog trainer's brawny pistol	0		Muscle Percent: +20, Experience (familiar): +1
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	normal fancy leftover pasty	4	good	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 15
-9135	drinkable boozy very whiskey	5	good	
+9135	boozy drinkable very whiskey	5	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	ghostly li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	jittery li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	jittery li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	blue li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	ghostly li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	jittery li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	jittery li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	blue li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	energized anodized hoarded candy wad	0		Effect: "Third Based", Effect Duration: 61, Last Available: "2016-10"
 9147	warmed Prunets	0		Effect: "Abyssal Tears", Effect Duration: 51
 9148	pulsating Twitching Television Tattoo	0		
 9149	huge baby scorpion	0		Familiar Weight: +10
 9150	quadruple-warmed extra-denatured invisible string	0		Lasts Until Rollover, Effect: "Disdain of She-Who-Was", Effect Duration: 58, Last Available: "2016-10"
 9151	ionized gray invisible seam ripper	0		Lasts Until Rollover, Effect: "Tiki Thoughtfulness", Effect Duration: 21, Last Available: "2016-10"
-9152	blinking li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	tiny decent pulsating raw sweet potato	1	good	Last Available: "2016-11"
+9152	blinking li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9153	decent tiny pulsating raw sweet potato	1	good	Last Available: "2016-11"
 9154	adequate raw beans	3	good	Last Available: "2016-11"
-9155	delicious snack-sized raw stuffing	2	awesome	Last Available: "2016-11"
+9155	snack-sized delicious raw stuffing	2	awesome	Last Available: "2016-11"
 9156	bland raw cranberry sauce	3	decent	Last Available: "2016-11"
 9157	decent raw turkey	4	good	Last Available: "2016-11"
 9158	decent raw mincemeat	3	good	Last Available: "2016-11"
@@ -9042,12 +9042,12 @@
 9170	spinning bread mold	0		Last Available: "2016-11"
 9171	small normal blurry sweet potatoes	2	good	Last Available: "2016-11"
 9172	bland bean casserole	4	decent	Last Available: "2016-11"
-9173	adequate half-sized baked stuffing	2	good	Last Available: "2016-11"
+9173	half-sized adequate baked stuffing	2	good	Last Available: "2016-11"
 9174	moldy cranberry cylinder	3	crappy	Last Available: "2016-11"
 9175	decent thanksgiving turkey	4	good	Last Available: "2016-11"
-9176	miniature bland mince pie	2	decent	Last Available: "2016-11"
+9176	bland miniature mince pie	2	decent	Last Available: "2016-11"
 9177	decent snack-sized mashed potatoes	2	good	Last Available: "2016-11"
-9178	diet bland enchanted fuchsia warm gravy	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15, Last Available: "2016-11"
+9178	enchanted bland diet fuchsia warm gravy	1	decent	Effect: "Experimental Effect G-9", Effect Duration: 15, Last Available: "2016-11"
 9179	moldy bread roll	4	crappy	Last Available: "2016-11"
 9180	normal leftovers	3	good	Last Available: "2016-11"
 9181	small delicious leftovers sandwich	2	awesome	Last Available: "2016-11"
@@ -9060,22 +9060,22 @@
 9188	blue bomb of unknown origin	0		Last Available: "2016-11"
 9189	mirror wobbly Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	huge eldritch effluvium	0		
-9191	warmed aerosolized teal blinking eldritch concentrate	0		Effect: "Sewer-Drenched", Effect Duration: 36, Last Available: "2016-11"
+9191	warmed aerosolized blinking teal eldritch concentrate	0		Effect: "Sewer-Drenched", Effect Duration: 36, Last Available: "2016-11"
 9192	extra-dry mediocre eldritch extract	5	decent	Last Available: "2016-11"
 9193	red miser's Official Council Aide Pin of the cougar	0		Moxie: +20, Meat Drop: +10, Last Available: "2016-11"
-9194	artisanal practically non-alcoholic eldritch distillate	1	super ultra mega EPIC	Last Available: "2016-11"
+9194	practically non-alcoholic artisanal eldritch distillate	1	super ultra mega EPIC	Last Available: "2016-11"
 9195	distilled blinking eldritch essence	1		Last Available: "2016-11"
 9196	wool Science Notebook	0		Cold Resistance: +1
 9197	flame-wreathed eldritch hat of courage of the detective	0		Hot Spell Damage: +10, Spooky Resistance: +3, Item Drop: +20, Last Available: "2016-11"
 9198	Herculean eldritch pants of Tarzan of Flo-Jo	0		Experience (Muscle): 4, Initiative: +100, Last Available: "2016-11"
-9199	tolerable watered-down purple eldritch elixir	2	good	Last Available: "2016-11"
+9199	watered-down tolerable purple eldritch elixir	2	good	Last Available: "2016-11"
 9200	inspector's Quartet of Flare Masters Jacket of dire peril	0		Weapon Damage: +20, Item Drop: +15, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	tumbling lime green Adventurer's Kit	0		
 9203	upside-down Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	jittery counterfeit city	0		Last Available: "2016-12"
 9205	sprinkles	0		Last Available: "2016-12"
-9206	shaking blurry The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
+9206	blurry shaking The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	upside-down ball and chain of horror	0		Spooky Spell Damage: +25, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	pulsating candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9209	shellacked gingerbread tophat	0		Damage Reduction: 7, Last Available: "2016-12"
@@ -9089,8 +9089,8 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	red sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	moldy animal part cracker	3	crappy	Last Available: "2016-12"
-9220	boozy acceptable enchanted twirling gingerbread wine	5	good	Effect: "Fishy Fortification", Effect Duration: 30, Last Available: "2016-12"
-9221	small adequate blue tumbling gingerbread mug	2	good	Last Available: "2016-12"
+9220	acceptable enchanted boozy twirling gingerbread wine	5	good	Effect: "Fishy Fortification", Effect Duration: 30, Last Available: "2016-12"
+9221	small adequate tumbling blue gingerbread mug	2	good	Last Available: "2016-12"
 9222	clever gingerbread mask	0		Maximum MP: +20, Last Available: "2016-12"
 9223	double-paned Lo Pan's wholesome gingerservo	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Cold Resistance: +5, Single Equip, Last Available: "2016-12"
 9224	quantum ionized skewed tainted icing	0		Effect: "Far Out", Effect Duration: 46, Last Available: "2016-12"
@@ -9123,7 +9123,7 @@
 9251	ionized Inner Truth	0		Effect: "The Power of Positive Thinking", Effect Duration: 64, Last Available: "2016-12"
 9252	half-sized adequate spiritual candy cane	2	good	Last Available: "2016-12"
 9253	acceptable weak spiritual eggnog	2	good	Last Available: "2016-12"
-9254	stale gigantic spiritual fruitcake	10	decent	Last Available: "2016-12"
+9254	gigantic stale spiritual fruitcake	10	decent	Last Available: "2016-12"
 9255	rotten jumbo green spiritual gingerbread	5	crappy	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	mirror chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	mediocre chakra-mental wine	3	decent	Last Available: "2016-12"
 9277	activated electrified chakra malt	0		Effect: "Sensation", Effect Duration: 35, Last Available: "2016-12"
 9278	jumbo decent Black Angus blackburger	5	good	Last Available: "2016-12"
-9279	bad weak brandy	2	decent	Last Available: "2016-12"
+9279	weak bad brandy	2	decent	Last Available: "2016-12"
 9280	alkaline nitrogenated potion of spiritual gunkifying	0		Effect: "Cheered Up", Effect Duration: 38, Last Available: "2016-12"
 9281	medical-grade bad vibroknife of the ox	0		Muscle: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12"
 9282	Jim Carey's groovy crystal belt buckle	0		Moxie Percent: +10, Monster Level: +25, Last Available: "2016-12"
@@ -9160,7 +9160,7 @@
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	bouncing sinister Uncle Crimbo's hat of courage of bravery	0		Spell Damage: +10, Spooky Resistance: 8, Last Available: "2016-12"
 9290	rotten narrow Eldritch snap	3	crappy	Last Available: "2017-01"
-9291	boiled fuchsia wobbly hot jelly	1		Last Available: "2017-01"
+9291	boiled wobbly fuchsia hot jelly	1		Last Available: "2017-01"
 9292	twisted skewed tumbling jelly	1		Last Available: "2017-01"
 9293	modified jelly	1		Last Available: "2017-01"
 9294	mixed sleaze jelly	1		Last Available: "2017-01"
@@ -9168,12 +9168,12 @@
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	rotten red toast with hot jelly	4	crappy	Last Available: "2017-01"
 9298	moldy super-sized toast with jelly	5	crappy	Last Available: "2017-01"
-9299	bite-sized rotten toast with jelly	1	crappy	Last Available: "2017-01"
+9299	rotten bite-sized toast with jelly	1	crappy	Last Available: "2017-01"
 9300	adequate toast with sleaze jelly	3	good	Last Available: "2017-01"
 9301	decent huge toast with stench jelly	6	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	lime green hopeful candle	0		Free Pull, Last Available: "2017-01"
-9304	olive twirling pewter candlestick	0		Familiar Weight: +10
+9304	twirling olive pewter candlestick	0		Familiar Weight: +10
 9305	ghostly sizzling dance instructor's wax hand	0		Experience Percent (Moxie): +10, Hot Damage: +10, Last Available: "2017-01"
 9306	steel-toed candle of bravery	0		Damage Reduction: 9, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	flavorless wax pancake	3	decent	Last Available: "2017-01"
@@ -9201,9 +9201,9 @@
 9329	modified chilled eldritch alignment spray	0		Effect: "Bananas!", Effect Duration: 28, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	shaking family-friendly Jeselnik's personal trainer's eldritch hammer	0		Experience Percent (Muscle): +10, Sleaze Damage: +25, Sleaze Resistance: +1, Last Available: "2017-01"
-9332	adequate diet eldritch mushroom	1	good	Last Available: "2017-03"
+9332	diet adequate eldritch mushroom	1	good	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	special rotten eldritch mushroom pizza	3	crappy	Effect: "Gutterminded", Effect Duration: 10, Last Available: "2017-03"
+9334	rotten special eldritch mushroom pizza	3	crappy	Effect: "Gutterminded", Effect Duration: 10, Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	improved irradiated upside-down twirling eldritch rub	0		Effect: "Filled with Magic", Effect Duration: 59, Last Available: "2017-02"
@@ -9225,7 +9225,7 @@
 9353	cocktail mushroom	0		Last Available: "2017-03"
 9354	shot of granola liqueur	0		Last Available: "2017-03"
 9355	can of cherry-flavored sterno	0		Last Available: "2017-03"
-9356	ghostly tumbling lump of ichor	0		Last Available: "2017-03"
+9356	tumbling ghostly lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	olive baby oil shooter	0		Last Available: "2017-03"
@@ -9234,17 +9234,17 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
-9365	lousy fancy weak literal grasshopper	2	decent	Effect: "Punch Another Day", Effect Duration: 30, Last Available: "2017-03"
+9365	weak lousy fancy literal grasshopper	2	decent	Effect: "Punch Another Day", Effect Duration: 30, Last Available: "2017-03"
 9366	aged double entendre	4	awesome	Last Available: "2017-03"
 9367	drinkable Phlegethon	4	good	Last Available: "2017-03"
 9368	distilled artisanal Siberian sunrise	5	EPIC	Last Available: "2017-03"
-9369	aged practically non-alcoholic mentholated wine	1	awesome	Last Available: "2017-03"
+9369	practically non-alcoholic aged mentholated wine	1	awesome	Last Available: "2017-03"
 9370	artisanal watered-down blue low tide martini	2	EPIC	Last Available: "2017-03"
 9371	acceptable shroomtini	3	good	Last Available: "2017-03"
 9372	perfectly mixed morning dew	4	EPIC	Last Available: "2017-03"
 9373	artisanal whiskey squeeze	3	EPIC	Last Available: "2017-03"
 9374	mediocre practically non-alcoholic great fashioned	1	decent	Last Available: "2017-03"
-9375	special acceptable Gnomish sagngria	4	good	Effect: "Indescribable Flavor", Effect Duration: 15, Last Available: "2017-03"
+9375	acceptable special Gnomish sagngria	4	good	Effect: "Indescribable Flavor", Effect Duration: 15, Last Available: "2017-03"
 9376	acceptable vodka stinger	3	good	Last Available: "2017-03"
 9377	mediocre extremely slippery nipple	3	decent	Last Available: "2017-03"
 9378	aged piscatini	4	awesome	Last Available: "2017-03"
@@ -9255,20 +9255,20 @@
 9383	lousy watered-down eighth plague	2	decent	Last Available: "2017-03"
 9384	mediocre single entendre	4	decent	Last Available: "2017-03"
 9385	drinkable upside-down reverse Tantalus	3	good	Last Available: "2017-03"
-9386	acceptable watered-down elemental caipiroska	2	good	Last Available: "2017-03"
-9387	hand-crafted irresponsibly strong Feliz Navidad	9	EPIC	Last Available: "2017-03"
-9388	mediocre watered-down wobbly Bloody Nora	2	decent	Last Available: "2017-03"
-9389	fancy tolerable moreltini	3	good	Effect: "Gamer Rage", Effect Duration: 15, Last Available: "2017-03"
+9386	watered-down acceptable elemental caipiroska	2	good	Last Available: "2017-03"
+9387	irresponsibly strong hand-crafted Feliz Navidad	9	EPIC	Last Available: "2017-03"
+9388	watered-down mediocre wobbly Bloody Nora	2	decent	Last Available: "2017-03"
+9389	tolerable fancy moreltini	3	good	Effect: "Gamer Rage", Effect Duration: 15, Last Available: "2017-03"
 9390	bad hell in a bucket	3	decent	Last Available: "2017-03"
 9391	drinkable Newark	3	good	Last Available: "2017-03"
 9392	mediocre upside-down R'lyeh	3	decent	Last Available: "2017-03"
 9393	tolerable fancy Gnollish sangria	4	good	Effect: "Well Owl Be!", Effect Duration: 10, Last Available: "2017-03"
 9394	perfectly mixed vodka barracuda	3	EPIC	Last Available: "2017-03"
-9395	hand-crafted extra-dry Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
+9395	extra-dry hand-crafted Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
 9396	lousy drive-by shooting	3	decent	Last Available: "2017-03"
 9397	practically non-alcoholic lousy gunner's daughter	1	decent	Last Available: "2017-03"
 9398	hand-crafted dirt julep	3	EPIC	Last Available: "2017-03"
-9399	watered-down artisanal Simepore slime	2	EPIC	Last Available: "2017-03"
+9399	artisanal watered-down Simepore slime	2	EPIC	Last Available: "2017-03"
 9400	tolerable spinning Phil Collins	4	good	Last Available: "2017-03"
 9401	shaking unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	blurry toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9284,7 +9284,7 @@
 9412	squat alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	low-calorie adequate edible alien plant bit	1	good	Last Available: "2017-04"
+9415	adequate low-calorie edible alien plant bit	1	good	Last Available: "2017-04"
 9416	spinning alien plant fibers	0		Last Available: "2017-04"
 9417	lime green alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9292,7 +9292,7 @@
 9420	denatured jittery alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	blue mirror zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	gigantic decent alien meat	10	good	Last Available: "2017-04"
+9423	decent gigantic alien meat	10	good	Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	upside-down alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9303,7 +9303,7 @@
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	cold-filtered pressed alien medicine	0		Effect: "Block-Rockin' Beet", Effect Duration: 51, Last Available: "2017-04"
 9433	jumbo tasty alien salad	5	awesome	Last Available: "2017-04"
-9434	watered-down tolerable alien booze	2	good	Last Available: "2017-04"
+9434	tolerable watered-down alien booze	2	good	Last Available: "2017-04"
 9435	mirror personal trainer's Samson's alien mask of the brazier	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Hot Spell Damage: +25, Last Available: "2017-04"
 9436	skewed Usain Bolt's chaotic alien spear of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +10, Initiative: +80, Last Available: "2017-04"
 9437	huge twirling clever curative stylish alien blowgun	0		Moxie: +25, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-04"
@@ -9348,12 +9348,12 @@
 9476	diffused Spant eggs	0		Effect: "Jammin'", Effect Duration: 63
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	huge New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	quantum squat narrow gray Daily Affirmation: Always be Collecting	0		Effect: "Sticky Fingers", Effect Duration: 55, Last Available: "2017-05"
+9479	quantum narrow squat gray Daily Affirmation: Always be Collecting	0		Effect: "Sticky Fingers", Effect Duration: 55, Last Available: "2017-05"
 9480	pressed Daily Affirmation: Think Win-Lose	0		Effect: "Go-Gone", Effect Duration: 47, Last Available: "2017-05"
 9481	unsweetened chilled squat Daily Affirmation: Be Superficially interested	0		Effect: "Good with the Ladies", Effect Duration: 14, Last Available: "2017-05"
 9482	concentrated skewed Daily Affirmation: Adapt to Change Eventually	0		Effect: "Aries Rising", Effect Duration: 54, Last Available: "2017-05"
 9483	dry quantum Daily Affirmation: Be a Mind Master	0		Effect: "Virgo Rising", Effect Duration: 12, Last Available: "2017-05"
-9484	warmed narrow blue Daily Affirmation: Work For Hours a Week	0		Effect: "Highland Sheen", Effect Duration: 45, Last Available: "2017-05"
+9484	warmed blue narrow Daily Affirmation: Work For Hours a Week	0		Effect: "Highland Sheen", Effect Duration: 45, Last Available: "2017-05"
 9485	altered anodized bouncing Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Dreadful Chill", Effect Duration: 13, Last Available: "2017-05"
 9486	bland Affirmation Cookie	3	decent	Last Available: "2017-05"
 9487	jittery License To Kill	0		
@@ -9363,9 +9363,9 @@
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	family-friendly strapping Kremlin's Greatest Briefcase of the bloodbag	0		Muscle: +5, Maximum HP: +100, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	watered-down mediocre basic martini	2	decent	Last Available: "2017-06"
+9494	mediocre watered-down basic martini	2	decent	Last Available: "2017-06"
 9495	drinkable practically non-alcoholic improved martini	1	good	Last Available: "2017-06"
-9496	weak bad maroon splendid martini	2	decent	Last Available: "2017-06"
+9496	bad weak maroon splendid martini	2	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	narrow tattoo gun	0		Last Available: "2017-06"
@@ -9379,7 +9379,7 @@
 9507	spinning LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
-9510	shaking lime green Dust bunny	0		
+9510	lime green shaking Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	narrow Meteorite-Ade	0		Last Available: "2017-08"
@@ -9388,7 +9388,7 @@
 9516	meteoroid	0		Last Available: "2017-08"
 9517	greasy slick meteortarboard of courage	0		Moxie: +10, Sleaze Spell Damage: +10, Spooky Resistance: +3, Last Available: "2017-08"
 9518	deadly Sinatra's meteorite guard of the storm	0		Experience (Moxie): +5, Weapon Damage: +5, Maximum MP Percent: +40, Damage Reduction: 9, Last Available: "2017-08"
-9519	chilly Fonzie's meteorb	0		Experience (Moxie): +1, Cold Damage: +5, Lantern Element: "Hot", Last Available: "2017-08"
+9519	chilly Fonzie's meteorb	0		Experience (Moxie): +1, Cold Damage: +5, Last Available: "2017-08", Lantern Element: "Hot"
 9520	veiny asteroid belt of the businessman	0		Maximum HP: +10, Meat Drop: +50, Single Equip, Last Available: "2017-08"
 9521	twirling baleful Newton's meteorthopedic shoes of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3, Spell Damage: +25, Single Equip, Last Available: "2017-08"
 9522	fireproof shooting morning star of chilblains of the cheetah	0		Cold Damage: +25, Hot Resistance: +3, Initiative: +60, Single Equip, Last Available: "2017-08"
@@ -9402,7 +9402,7 @@
 9530	healthy arcane researcher's blessed rustproof +2 gray dragon scale mail of temperance	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +20, Sleaze Resistance: +5, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	spinning pony: Shutterfly	0		Last Available: "2017-09"
-9533	pulsating huge pony: Pearjack	0		Last Available: "2017-09"
+9533	huge pulsating pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
 9535	cyan pony: Rosey Cake	0		Last Available: "2017-09"
 9536	blurry pony: Spectrum Dash	0		Last Available: "2017-09"
@@ -9410,15 +9410,15 @@
 9538	dropped scrap of paper	0		
 9539	hunk of granite	0		
 9540	shovelful of dirt	0		
-9541	upside-down shaking xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
+9541	shaking upside-down xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	huge X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	perfectly mixed watered-down ghostly DUFRESNE Suds	2	EPIC	Last Available: "2017-09"
+9545	watered-down perfectly mixed ghostly DUFRESNE Suds	2	EPIC	Last Available: "2017-09"
 9546	zippy mafia pinky ring of dire peril	0		Weapon Damage: +20, Initiative: +20, Single Equip
 9547	tolerable weak flask of port	2	good	
 9548	lime green asbestos-lined careful contract enforcement stick	0		Monster Level: -10, Hot Resistance: +5
-9549	miniature flavorless Hide-rox&trade; cookie	2	decent	Last Available: "2017-10"
+9549	flavorless miniature Hide-rox&trade; cookie	2	decent	Last Available: "2017-10"
 9550	practically non-alcoholic acceptable upside-down jug of booze	1	good	Last Available: "2017-10"
 9551	enhanced wet pair of candy glasses	0		Effect: "Booze Goozles", Effect Duration: 44, Last Available: "2017-10"
 9552	corrupted super-diffused temporary X tattoos	0		Effect: "Glo-Face", Effect Duration: 67, Last Available: "2017-10"
@@ -9448,13 +9448,13 @@
 9576	dog trainer's mafia organizer badge	0		Experience (familiar): +1, Single Equip
 9577	mafia filofax	0		
 9578	transparent nog	1	decent	Last Available: "2017-12"
-9579	normal small unfinished fruitcake	2	good	Last Available: "2017-12"
+9579	small normal unfinished fruitcake	2	good	Last Available: "2017-12"
 9580	unsweetened and cracker	0		Effect: "Unrunnable Face", Effect Duration: 40, Last Available: "2017-12"
-9581	perfectly mixed fancy neg grog	3	EPIC	Effect: "Texas Elegance", Effect Duration: 20, Last Available: "2017-12"
+9581	fancy perfectly mixed neg grog	3	EPIC	Effect: "Texas Elegance", Effect Duration: 20, Last Available: "2017-12"
 9582	enchanted normal half double fruitcake	4	good	Effect: "Healthy Blue Glow", Effect Duration: 15, Last Available: "2017-12"
-9583	normal gigantic hushed puppy	9	good	Last Available: "2017-12"
+9583	gigantic normal hushed puppy	9	good	Last Available: "2017-12"
 9584	big moldy muffled muffuletta	5	crappy	Last Available: "2017-12"
-9585	small stale wobbly shushed potatoes	2	decent	Last Available: "2017-12"
+9585	stale small wobbly shushed potatoes	2	decent	Last Available: "2017-12"
 9586	teal foul-smelling plastic mime functionary	0		Stench Damage: +10, Last Available: "2017-12"
 9587	tumbling steel-toed plastic mime scientist	0		Damage Reduction: 9, Last Available: "2017-12"
 9588	shaking toasty plastic mime soldier	0		Hot Damage: +5, Last Available: "2017-12"
@@ -9462,12 +9462,12 @@
 9590	upside-down tumbling up-at-dawn plastic The Silent Nightmare	0		Adventures: +5, Last Available: "2017-12"
 9591	locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	mumming trunk	0		Last Available: "2017-12"
-9593	shaking squat temperance whiskey	1	decent	Last Available: "2017-11"
+9593	squat shaking temperance whiskey	1	decent	Last Available: "2017-11"
 9594	ionized wishbone	0		Effect: "Adorable Lookout", Effect Duration: 29, Last Available: "2017-11"
-9595	watered-down drinkable lime green Racisto Ruidoso	2	good	Last Available: "2017-11"
+9595	drinkable watered-down lime green Racisto Ruidoso	2	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	enchanted delicious bran muffin	4	awesome	Effect: "Dreams and Lights", Effect Duration: 5
-9598	decent gigantic blueberry muffin	8	good	
+9598	gigantic decent blueberry muffin	8	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	skewed silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9498,7 +9498,7 @@
 9626	squat anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
-9629	fancy drinkable maroon stale cheer wine	4	good	Effect: "Granolarrrgh", Effect Duration: 10, Last Available: "2017-12"
+9629	drinkable fancy maroon stale cheer wine	4	good	Effect: "Granolarrrgh", Effect Duration: 10, Last Available: "2017-12"
 9630	adequate immense tumbling stale Cheer-E-Os	10	good	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	blurry therapeutic beefcake's cheerful antler hat	0		Muscle: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-12"
@@ -9517,11 +9517,11 @@
 9645	pulsating The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	boozy acceptable fancy upside-down executive mime flask	5	good	Effect: "Hyperoffended", Effect Duration: 40, Last Available: "2017-12"
+9648	acceptable fancy boozy upside-down executive mime flask	5	good	Effect: "Hyperoffended", Effect Duration: 40, Last Available: "2017-12"
 9649	toothsome ghostly nega-mushroom	3	awesome	Last Available: "2017-12"
-9650	aged fuchsia shaking bouncing nega-mushroom wine	3	awesome	Last Available: "2017-12"
+9650	aged bouncing shaking fuchsia nega-mushroom wine	3	awesome	Last Available: "2017-12"
 9651	modified electrified alkaline Cheer-Up soda	0		Effect: "Black Lung", Effect Duration: 54, Last Available: "2017-12"
-9652	half-sized adequate green mime army rations	2	good	Last Available: "2017-12"
+9652	adequate half-sized green mime army rations	2	good	Last Available: "2017-12"
 9653	bad triple-distilled mime army wine	6	decent	Last Available: "2017-12"
 9654	dehydrated wobbly mime army superserum	1		Last Available: "2017-12"
 9655	extra-deionized ghostly mime army camouflage kit	0		Effect: "Dweeby", Effect Duration: 16, Last Available: "2017-12"
@@ -9536,13 +9536,13 @@
 9664	donated candy	0		
 9665	chilled vacuum-sealed narrow spinning digital honeypot	0		Effect: "Heightened Senses", Effect Duration: 48, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	wobbly mime army insignia (infantry) of bravery	0		Spooky Resistance: +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	Temple Grandin's mime army insignia (intelligence)	0		Familiar Weight: +7, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	mime army insignia (espionage) of the sewer	0		Stench Damage: +25, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	wobbly mime army insignia (infantry) of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	Temple Grandin's mime army insignia (intelligence)	0		Familiar Weight: +7, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	mime army insignia (espionage) of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	jittery mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
-9673	blurry blinking mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
+9673	blinking blurry mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	tumbling mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	narrow chaotic mime army infiltration glove of the storm	0		Maximum MP Percent: +40, Spell Critical Percent: +10, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
@@ -9565,7 +9565,7 @@
 9693	jittery crafty tinsel tights of temperance	0		Maximum MP: +10, Sleaze Resistance: +5, Last Available: "2018-01"
 9694	red fireproof therapeutic experienced wad of used tape	0		Experience: +2, Hot Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-01"
 9695	narrow flame-retardant experienced slick cool silent nightlight	0		Moxie: 15, Experience: +2, Hot Resistance: +1
-9696	modified ghostly teal sweetened reindeer fat	0		Effect: "Loco Motives", Effect Duration: 54
+9696	modified teal ghostly sweetened reindeer fat	0		Effect: "Loco Motives", Effect Duration: 54
 9697	warmed Good 'n' Quiet	0		Effect: "Meadulla Oblongota", Effect Duration: 69
 9698	double-wet quadruple-wet cyan hot button candy	0		Effect: "Neutered Nostrils", Effect Duration: 38
 9699	bouncing frightening studded beefcake's makeshift garbage shirt	0		Muscle: +25, Damage Absorption: +80, Spooky Damage: +5, Last Available: "2018-01"
@@ -9574,7 +9574,7 @@
 9702	vaporized spinning furry pill	1		Effect: "Gutterminded", Effect Duration: 30
 9703	modified twirling beefy pill	1		
 9704	dehydrated blurry excitement pill	1		
-9705	powdered tumbling pulsating purple vitamin G pill	1		Effect: "Saucegoggles", Effect Duration: 30
+9705	powdered pulsating tumbling purple vitamin G pill	1		Effect: "Saucegoggles", Effect Duration: 30
 9706	modified lucky-ish pill	1		Effect: "New Zeal", Effect Duration: 10
 9707	dried squat squat dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
@@ -9623,7 +9623,7 @@
 9755	extremely unsafe Team Sloth cap	0		Weapon Damage Percent: +100, Combat Rate: -15
 9756	ghostly Team Wrath cap of dire peril	0		Weapon Damage: +20
 9757	cyan Mu cap	0		Item Drop: +5
-9758	huge jittery Thwaitgold metabug statuette	0		
+9758	jittery huge Thwaitgold metabug statuette	0		
 9759	shaking Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
 9760	blue packet of tall grass seeds	0		Last Available: "2018-03"
 9761	ghostly Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
@@ -9677,10 +9677,10 @@
 9809	jittery Disgeist	0		Last Available: "2018-03"
 9810	Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
-9812	fuchsia narrow Mu	0		Last Available: "2018-03"
+9812	narrow fuchsia Mu	0		Last Available: "2018-03"
 9813	bouncing Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
-9815	squat shaking blue Sitrep berry	0		Last Available: "2018-03"
+9815	shaking squat blue Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	skewed Jamocha berry	0		Last Available: "2018-03"
 9818	spinning squat spinning Tapioc berry	0		Last Available: "2018-03"
@@ -9697,7 +9697,7 @@
 9829	mixed blurry brilliant oyster egg	1		
 9830	denatured glistening oyster egg	1		
 9831	compressed scintillating oyster egg	1		Effect: "It's Soporiffic!", Effect Duration: 30
-9832	compressed blurry blue pearlescent oyster egg	1		
+9832	compressed blue blurry pearlescent oyster egg	1		
 9833	mixed bouncing lustrous oyster egg	1		Effect: "Salt Rockin'", Effect Duration: 25
 9834	dried gleaming oyster egg	1		Effect: "Hella Tough", Effect Duration: 25
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
@@ -9727,14 +9727,14 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	rotten huge bouncing FantasyRealm turkey leg	6	crappy	Last Available: "2018-04"
+9862	huge rotten bouncing FantasyRealm turkey leg	6	crappy	Last Available: "2018-04"
 9863	acceptable bouncing FantasyRealm mead	4	good	Last Available: "2018-04"
 9864	blurry nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	blinking shaking hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
-9868	lime green bouncing grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	decent big enchanted druidic s'more	5	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35, Last Available: "2018-04"
+9868	bouncing lime green grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
+9869	enchanted decent big druidic s'more	5	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35, Last Available: "2018-04"
 9870	vaporized blurry sachet of powder	1		Last Available: "2018-04"
 9871	artisanal practically non-alcoholic twirling mourning wine	1	EPIC	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9762,17 +9762,17 @@
 9894	red reassuring vibrating hardy brawny Staff of Kitchen Royalty of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Maximum HP: +50, Maximum MP Percent: +10, Spooky Resistance: +1, Last Available: "2018-04"
 9895	spinning charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	shaking dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
-9897	twirling tumbling notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
+9897	tumbling twirling notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	mediocre two meat muck	3	decent	
-9899	spoiled maroon tumbling chocolate Ogre Chieftain	3	crappy	
+9899	spoiled tumbling maroon chocolate Ogre Chieftain	3	crappy	
 9900	tasty chocolate &quot;Phoenix&quot;	3	awesome	
-9901	moldy small chocolate Spider Queen	2	crappy	
+9901	small moldy chocolate Spider Queen	2	crappy	
 9902	hand-crafted weak hipster cocktail	2	EPIC	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	upside-down God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	skewed God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	upside-down God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	skewed God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9817,7 +9817,7 @@
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	mirror rosewater-soaked pentagram bandana of temperance	0		Stench Resistance: +3, Sleaze Resistance: +5, Last Available: "2018-09"
 9951	strapping skull ring	0		Muscle: +5, Single Equip, Last Available: "2018-09"
-9952	pulsating green electronics kit	0		Last Available: "2018-09"
+9952	green pulsating electronics kit	0		Last Available: "2018-09"
 9953	decent PB&J with the crusts cut off	3	good	Last Available: "2018-09"
 9954	lightning-fast dorky glasses of the wise owl	0		Mysticality: +20, Initiative: +40, Single Equip, Last Available: "2018-09"
 9955	narrow flame-retardant ponytail clip of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +1, Last Available: "2018-09"
@@ -9848,7 +9848,7 @@
 9981	powdered tumbling Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	foul-smelling toasty party crasher	0		Hot Damage: +5, Stench Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	wobbly Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9984	wobbly Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9873,17 +9873,17 @@
 10007	shaking sizzling friendly mutant arm of the sewer	0		Familiar Weight: +3, Hot Damage: +10, Stench Damage: +25, Last Available: "2018-11"
 10008	mirror gravedigger's Herculean mutant legs of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Spooky Damage: +10, Last Available: "2018-11"
 10009	sharpshooter's curative savvy mutant crown	0		Mysticality Percent: +20, Critical Hit Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-11"
-10010	half-sized rotten tumbling ghostly ectoplasm	2	crappy	Last Available: "2018-11"
+10010	rotten half-sized tumbling ghostly ectoplasm	2	crappy	Last Available: "2018-11"
 10011	toothsome bouncing	4	awesome	Last Available: "2018-11"
-10012	artisanal watered-down purple bottle of vodka	2	EPIC	Last Available: "2018-11"
+10012	watered-down artisanal purple bottle of vodka	2	EPIC	Last Available: "2018-11"
 10013	toothsome red pizza	3	awesome	Last Available: "2018-11"
 10014	hand-crafted martini	3	EPIC	Last Available: "2018-11"
-10015	immense stale bouncing blinking cherry pie	10	decent	Last Available: "2018-11"
+10015	stale immense blinking bouncing cherry pie	10	decent	Last Available: "2018-11"
 10016	practically non-alcoholic bad eggnog	1	decent	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	small flavorless Hell ramen	2	decent	Last Available: "2018-11"
 10019	weak artisanal spinning gimlet	2	super ultra EPIC	Last Available: "2018-11"
-10020	hand-crafted boozy twice-haunted screwdriver	5	EPIC	Last Available: "2018-11"
+10020	boozy hand-crafted twice-haunted screwdriver	5	EPIC	Last Available: "2018-11"
 10021	adequate candy cane	4	good	Last Available: "2018-12"
 10022	tolerable runny fermented egg	3	good	Last Available: "2018-12"
 10023	normal oldcake	3	good	Last Available: "2018-12"
@@ -9902,20 +9902,20 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	jittery mooseflank	0		Last Available: "2018-12"
-10039	bite-sized moldy jittery grilled mooseflank	1	crappy	Last Available: "2018-12"
+10039	moldy bite-sized jittery grilled mooseflank	1	crappy	Last Available: "2018-12"
 10040	decent moosemeat pie	4	good	Last Available: "2018-12"
 10041	jittery experienced balanced antler	0		Experience: +2, Last Available: "2018-12"
 10042	Herculean dam	0		Experience (Muscle): +1, Damage Reduction: 9, Last Available: "2018-12"
 10043	bad bouncing beavermouth	4	decent	Last Available: "2018-12"
-10044	extra-dry tolerable pulsating beaver punch (papaya)	5	good	Last Available: "2018-12"
+10044	tolerable extra-dry pulsating beaver punch (papaya)	5	good	Last Available: "2018-12"
 10045	delicious beaver punch (peach)	3	awesome	Last Available: "2018-12"
 10046	bad tumbling fuchsia beaver punch (cherry)	3	decent	Last Available: "2018-12"
 10047	curative hardy Canadian lantern	0		Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
 10048	twirling yellow electrified muskox-skin cap	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	spoiled small glass of raw eggs	2	crappy	Last Available: "2018-12"
+10050	small spoiled glass of raw eggs	2	crappy	Last Available: "2018-12"
 10051	mediocre punch-drunk punch	3	decent	Last Available: "2018-12"
-10052	modified yellow tumbling body spradium	1		Last Available: "2018-12"
+10052	modified tumbling yellow body spradium	1		Last Available: "2018-12"
 10053	experienced bauxite beret	0		Experience: +2, Last Available: "2018-12"
 10054	toasty bauxite boxers	0		Hot Damage: +5, Last Available: "2018-12"
 10055	frightening bauxite bow-tie	0		Spooky Damage: +5, Single Equip, Last Available: "2018-12"
@@ -9967,7 +9967,7 @@
 10101	Lo Pan's sharpshooter's pendant	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10102	upside-down ghostly MacGyver's groovy palazzos	0		Moxie Percent: +10, Maximum MP: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10103	Jim Carey's educational pseudoaccordion	0		Experience: +1, Monster Level: +25, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10104	pickled huge squat pieces	1		Last Available: "2020-12"
+10104	pickled squat huge pieces	1		Last Available: "2020-12"
 10105	energized pickled maroon Para-Pop	0		Effect: "The Halls of Mysticality", Effect Duration: 61
 10106	prompt Sherlock's terra cotta truss	0		Item Drop: +25, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10107	spinning horrifying terra cotta trousers of the early riser	0		Spooky Damage: +25, Adventures: +7, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
@@ -10021,7 +10021,7 @@
 10155	moldy elf army field rations	4	crappy	Last Available: "2019-12"
 10156	narrow gingernade	0		Last Available: "2019-12"
 10157	perfumed discarded bowtie of incineration	0		Hot Spell Damage: +50, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2019-12"
-10158	hand-crafted fortified upside-down martiny	5	EPIC	Last Available: "2019-12"
+10158	fortified hand-crafted upside-down martiny	5	EPIC	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	energized alkaline licorice snake	0		Effect: "Frosty the Hitman", Effect Duration: 12
 10161	ionized huge virgin jello shot	0		Effect: "Bricked-In", Effect Duration: 57
@@ -10034,16 +10034,16 @@
 10169	small tasty bloodstick	2	awesome	
 10170	acceptable bottle of Sanguiovese	3	good	
 10171	low-calorie yummy spinning actual blood sausage	1	awesome	
-10172	weak tolerable mulled blood	2	good	
-10173	flavorless super-sized special jittery blood snowcone	5	decent	Effect: "Egg on your Face", Effect Duration: 45
+10172	tolerable weak mulled blood	2	good	
+10173	super-sized flavorless special jittery blood snowcone	5	decent	Effect: "Egg on your Face", Effect Duration: 45
 10174	perfectly mixed irresponsibly strong Red Russian	8	EPIC	
 10175	spoiled wobbly blood roll-up	3	crappy	
 10176	tolerable squat bottle of blood	4	good	
 10177	rotten blood-soaked sponge cake	4	crappy	
-10178	enchanted artisanal vampagne	3	super EPIC	Effect: "Scrappy, Shadowy", Effect Duration: 40
+10178	artisanal enchanted vampagne	3	super EPIC	Effect: "Scrappy, Shadowy", Effect Duration: 40
 10179	stale plain snowcone	3	decent	
 10180	Booke of Vampyric Knowledge	0		
-10181	narrow mirror money bag	0		
+10181	mirror narrow money bag	0		
 10182	shaking money bag	0		
 10183	blurry money bag	0		
 10184	Thwaitgold mosquito statuette	0		
@@ -10074,8 +10074,8 @@
 10209	windicle	0		Last Available: "2019-04"
 10210	twirling fuchsia scorching vibrating pirate radio ring	0		Maximum MP Percent: +10, Hot Damage: +25, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	special rotten pineapple slab	3	crappy	Effect: "Initiative and Let Die", Effect Duration: 35, Last Available: "2019-04"
-10213	yummy fancy bite-sized shaking shaking hibiscus petal	1	awesome	Effect: "Petit Force", Effect Duration: 5, Last Available: "2019-04"
+10212	rotten special pineapple slab	3	crappy	Effect: "Initiative and Let Die", Effect Duration: 35, Last Available: "2019-04"
+10213	bite-sized fancy yummy shaking shaking hibiscus petal	1	awesome	Effect: "Petit Force", Effect Duration: 5, Last Available: "2019-04"
 10214	flattened modified cold-filtered huge mint leaf	0		Effect: "Human-Horror Hybrid", Effect Duration: 23, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	modified red pulsating ice molecule	1		Last Available: "2019-04"
@@ -10095,14 +10095,14 @@
 10230	studded dangerous piratical blunderbuss	0		Weapon Damage: +10, Damage Absorption: +80, Last Available: "2019-04"
 10231	skewed stiffened groovy PirateRealm party hat of the brute	0		Muscle Percent: +30, Moxie Percent: +10, Damage Reduction: 1, Last Available: "2019-04"
 10232	practically non-alcoholic drinkable purple Island Landslide	1	good	Last Available: "2019-04"
-10233	acceptable blinking fuchsia Island Thunderstorm	4	good	Last Available: "2019-04"
+10233	acceptable fuchsia blinking Island Thunderstorm	4	good	Last Available: "2019-04"
 10234	hand-crafted jittery Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	enchanted mediocre pulsating Skull Punch	3	decent	Effect: "Some Cheese with Your Wine", Effect Duration: 50, Last Available: "2019-04"
 10236	fortified mediocre Electric Punch	5	decent	Last Available: "2019-04"
 10237	fancy tolerable upside-down Smuggler's Punch	4	good	Effect: "Raging Animal", Effect Duration: 35, Last Available: "2019-04"
-10238	aged irresponsibly strong teal Scorpion Bowl	8	awesome	Last Available: "2019-04"
+10238	irresponsibly strong aged teal Scorpion Bowl	8	awesome	Last Available: "2019-04"
 10239	acceptable Turtle Bowl	3	good	Last Available: "2019-04"
-10240	mediocre watered-down mirror Cobra Bowl	2	decent	Last Available: "2019-04"
+10240	watered-down mediocre mirror Cobra Bowl	2	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	prompt foul-smelling vampyric cloake of the scaredy-cat of the brazier of the overflowing toilet	0		Monster Level: -15, Hot Spell Damage: +25, Stench Damage: +10, Stench Spell Damage: +50, Adventures: +3, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
@@ -10111,7 +10111,7 @@
 10246	yellow shaking intact medium-wave antenna	0		
 10247	upside-down 18-picohertz resonator crystal	0		
 10248	blown-out speaker cone	0		
-10249	lime green jittery overloaded short-pulse transistor	0		
+10249	jittery lime green overloaded short-pulse transistor	0		
 10250	purple Fourth of May Cosplay Saber kit	0		Free Pull
 10251	purple stanky Fourth of May Cosplay Saber of the empath of doom	0		Familiar Weight: +5, Stench Spell Damage: +25, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
@@ -10131,7 +10131,7 @@
 10266	aerosolized nitrogenated magenta seashell	0		Effect: "Pork Power", Effect Duration: 11, Last Available: "2019-07"
 10267	magnetized cyan seashell	0		Effect: "Leash of Linguini", Effect Duration: 38, Last Available: "2019-07"
 10268	non-galvanized electrified pressed gray seashell	0		Effect: "Tingling Feeling", Effect Duration: 42, Last Available: "2019-07"
-10269	chilled upside-down upside-down fuchsia seashell	0		Effect: "Always be Collecting", Effect Duration: 24, Last Available: "2019-07"
+10269	chilled fuchsia upside-down upside-down seashell	0		Effect: "Always be Collecting", Effect Duration: 24, Last Available: "2019-07"
 10270	deionized seashell	0		Effect: "Piratastic", Effect Duration: 59, Last Available: "2019-07"
 10271	spinning bunch of sea grapes	0		Last Available: "2019-07"
 10272	mediocre pulsating bottle of sea wine	4	decent	Last Available: "2019-07"
@@ -10165,7 +10165,7 @@
 10300	lightning-fast groovy whittled owl figurine of Leguizamo	0		Moxie Percent: +10, Monster Level: +20, Initiative: +40, Single Equip, Last Available: "2019-08"
 10301	healthy grievous Samson's whittled fox figurine	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Maximum HP Percent: +20, Single Equip, Last Available: "2019-08"
 10302	energetic ruddy educational whittled walking stick of the bloodbag	0		Experience: +1, Maximum HP Percent: +40, Maximum HP: +100, Maximum MP Percent: +20, Last Available: "2019-08"
-10303	snack-sized delicious campfire hot dog	2	awesome	Last Available: "2019-08"
+10303	delicious snack-sized campfire hot dog	2	awesome	Last Available: "2019-08"
 10304	bland campfire baked potato	4	decent	Last Available: "2019-08"
 10305	small normal squat campfire s'more	2	good	Last Available: "2019-08"
 10306	adequate upside-down campfire beans	3	good	Last Available: "2019-08"
@@ -10193,7 +10193,7 @@
 10334	spinning unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	adequate fancy low-calorie twirling bu&ntilde;uelos Jaliscos	1	good	Effect: "Permafrosty", Effect Duration: 30, Last Available: "2019-12"
+10337	adequate low-calorie fancy twirling bu&ntilde;uelos Jaliscos	1	good	Effect: "Permafrosty", Effect Duration: 30, Last Available: "2019-12"
 10338	rotten flan del mar	3	crappy	Last Available: "2019-12"
 10339	decent Baja sopapilla	3	good	Last Available: "2019-12"
 10340	lime green ghostly plastic Mer-kin baker of the dark arts	0		Spell Damage Percent: +100, Last Available: "2019-12"
@@ -10203,28 +10203,28 @@
 10344	teal executive plastic Dolph Bossin	0		Meat Drop: +40, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	stale mana-coated yams	4	decent	Last Available: "2019-11"
-10347	decent enchanted mana-basted tofurkey leg	4	good	Effect: "The Grass...  Is Blue...", Effect Duration: 10, Last Available: "2019-11"
-10348	decent big pulsating mana-fortified cranberry sauce	5	good	Last Available: "2019-11"
-10349	gigantic delicious fancy shaking mana-stuffed herbal stuffing	10	awesome	Effect: "Gummiheart", Effect Duration: 20, Last Available: "2019-11"
+10347	enchanted decent mana-basted tofurkey leg	4	good	Effect: "The Grass...  Is Blue...", Effect Duration: 10, Last Available: "2019-11"
+10348	big decent pulsating mana-fortified cranberry sauce	5	good	Last Available: "2019-11"
+10349	delicious fancy gigantic shaking mana-stuffed herbal stuffing	10	awesome	Effect: "Gummiheart", Effect Duration: 20, Last Available: "2019-11"
 10350	mirror human musk	0		Last Available: "2019-12"
 10351	alkaline skewed patch of extra-warm fur	0		Effect: "Adventurer's Best Friendship", Effect Duration: 25, Last Available: "2019-12"
 10352	altered jittery industrial lubricant	1		Last Available: "2019-12"
 10353	ionized unfinished pleasure	0		Effect: "Snobby", Effect Duration: 68, Last Available: "2019-12"
 10354	pickled vial of humanoid growth hormone	1		Effect: "Neuroplastici Tea", Effect Duration: 15, Last Available: "2019-12"
-10355	pickled tumbling twirling fuchsia a bug's lymph	1		Last Available: "2019-12"
+10355	pickled twirling tumbling fuchsia a bug's lymph	1		Last Available: "2019-12"
 10356	dry magnetized twirling organic potpourri	0		Effect: "Your Interest is Peaked", Effect Duration: 69, Last Available: "2019-12"
-10357	strong artisanal huge boot flask	5	EPIC	Last Available: "2019-12"
+10357	artisanal strong huge boot flask	5	EPIC	Last Available: "2019-12"
 10358	ionized concentrated cyan infernal snowball	0		Effect: "Standard Cheer", Effect Duration: 14, Last Available: "2019-12"
 10359	huge mirror madness	0		Last Available: "2019-12"
 10360	distilled blurry spinning fish sauce	1		Last Available: "2019-12"
-10361	special normal tumbling guffin	4	good	Effect: "The Magical Mojomuscular Melody", Effect Duration: 40, Last Available: "2019-12"
+10361	normal special tumbling guffin	4	good	Effect: "The Magical Mojomuscular Melody", Effect Duration: 40, Last Available: "2019-12"
 10362	powdered bouncing Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	powdered spinning ghostly non-Euclidean angle	1		Last Available: "2019-12"
 10365	dry extra-tarnished peppermint syrup	0		Effect: "El Vibrations", Effect Duration: 17, Last Available: "2019-12"
 10366	chilled blurry Mer-kin eyedrops	0		Effect: "Super Structure", Effect Duration: 50, Last Available: "2019-12"
 10367	quantum polarized blinking extra-strength goo	0		Effect: "Vented Spleen", Effect Duration: 66, Last Available: "2019-12"
-10368	bouncing ghostly envelope full of Meat	0		Last Available: "2019-12"
+10368	ghostly bouncing envelope full of Meat	0		Last Available: "2019-12"
 10369	denatured livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
 10371	diluted huge beggin' cologne	1		Effect: "Gingerbread Robust", Effect Duration: 35, Last Available: "2019-12"
@@ -10254,8 +10254,8 @@
 10395	huge personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	wobbly blurry blinking tinsel fin	0		Familiar Weight: +5
 10397	spoiled red bowl of mernudo	3	crappy	Last Available: "2019-12"
-10398	artisanal special fishelada	4	EPIC	Effect: "Oleaginous Soles", Effect Duration: 35, Last Available: "2019-12"
-10399	low-calorie stale tumbling ojo de pez burrito	1	decent	Last Available: "2019-12"
+10398	special artisanal fishelada	4	EPIC	Effect: "Oleaginous Soles", Effect Duration: 35, Last Available: "2019-12"
+10399	stale low-calorie tumbling ojo de pez burrito	1	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	cyan waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10313,7 +10313,7 @@
 10456	maroon deluxe mushroom	0		
 10457	super deluxe mushroom	0		
 10458	anodized triple-altered squat fizzy soda	0		Effect: "Turtle Titters", Effect Duration: 39
-10459	extra-concentrated spinning pulsating healthy juice	0		Effect: "Just Aged Enough", Effect Duration: 29
+10459	extra-concentrated pulsating spinning healthy juice	0		Effect: "Just Aged Enough", Effect Duration: 29
 10460	hammer	0		
 10461	skewed hammer	0		
 10462	fire flower	0		
@@ -10343,10 +10343,10 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	huge immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	flavorless special mushroom filet	3	decent	Effect: "Mighty Shout", Effect Duration: 5, Last Available: "2020-03"
+10489	special flavorless mushroom filet	3	decent	Effect: "Mighty Shout", Effect Duration: 5, Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	dried mushroom tea	1		Last Available: "2020-03"
-10492	lousy triple-distilled mushroom whiskey	6	decent	Last Available: "2020-03"
+10492	triple-distilled lousy mushroom whiskey	6	decent	Last Available: "2020-03"
 10493	twirling miser's forbidden wicked mushroom cap	0		Spell Damage: +5, Spell Damage Percent: +50, Meat Drop: +10, Last Available: "2020-03"
 10494	squat electrified clever brainy mushroom shield of the blizzard	0		Mysticality: +5, Maximum MP: +20, Cold Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 6, Last Available: "2020-03"
 10495	censurious fireproof friendly hardened mushroom pants	0		Damage Reduction: 3, Familiar Weight: +3, Hot Resistance: +3, Sleaze Resistance: +3, Last Available: "2020-03"
@@ -10354,7 +10354,7 @@
 10497	house-sized mushroom	0		Last Available: "2020-03"
 10498	pristine piranha seed	0		Last Available: "2020-03"
 10499	skewed plastic piranha pot	0		Familiar Weight: +5
-10500	Vulcanized quantum maroon mirror piranha pollen	0		Effect: "Hyperoffended", Effect Duration: 39, Last Available: "2020-03"
+10500	Vulcanized quantum mirror maroon piranha pollen	0		Effect: "Hyperoffended", Effect Duration: 39, Last Available: "2020-03"
 10501	mirror plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
 10502	maroon sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	kettle bell of terror	0		Spooky Spell Damage: +10, Last Available: "2020-04"
@@ -10394,11 +10394,11 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	blinking dance instructor's Guzzlr souvenir stein	0		Experience Percent (Moxie): +10, Last Available: "2020-05"
 10540	pulsating Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	fortified delicious Ghiaccio Colada	5	awesome	Last Available: "2020-05"
-10542	delicious upside-down blue Sourfinger	3	awesome	Last Available: "2020-05"
+10541	delicious fortified Ghiaccio Colada	5	awesome	Last Available: "2020-05"
+10542	delicious blue upside-down Sourfinger	3	awesome	Last Available: "2020-05"
 10543	acceptable Nog-on-the-Cob	3	good	Last Available: "2020-05"
 10544	tolerable Steamboat	4	good	Last Available: "2020-05"
-10545	mediocre enchanted practically non-alcoholic yellow ghostly Buttery Boy	1	decent	Effect: "Crimbo Flavor", Effect Duration: 5, Last Available: "2020-05"
+10545	mediocre practically non-alcoholic enchanted yellow ghostly Buttery Boy	1	decent	Effect: "Crimbo Flavor", Effect Duration: 5, Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	ghostly chaotic Fonzie's clown car key	0		Experience (Moxie): +1, Spell Critical Percent: +10, Last Available: "2020-08"
 10548	tumbling Oprah's healthy batting cage key of the sweet-tooth	0		Maximum HP Percent: +20, Maximum MP Percent: +50, Candy Drop: +100, Last Available: "2020-08"
@@ -10424,7 +10424,7 @@
 10568	mirror rosy-cheeked wholesome deep-fried key of the overflowing toilet	0		Maximum HP Percent: 40, Stench Spell Damage: +50, Last Available: "2020-08"
 10569	pulsating zippy discarded bike lock key of the sweet-tooth	0		Candy Drop: +100, Initiative: +20, Last Available: "2020-08"
 10570	huge Thwaitgold keyhole spider statuette	0		
-10571	mirror blinking Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
+10571	blinking mirror Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	quadruple-irradiated upside-down marshroom	0		Effect: "Burnt 'n' Turnt", Effect Duration: 33
 10573	bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
@@ -10496,7 +10496,7 @@
 10640	skewed Universal Seasoning	0		
 10641	modified alkaline narrow fuchsia null-day exploit	0		Effect: "Musky", Effect Duration: 57, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	immense spoiled chocolate chip muffin	7	crappy	
+10643	spoiled immense chocolate chip muffin	7	crappy	
 10644	tumbling Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	twirling packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10567,14 +10567,14 @@
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	twirling The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10714	pulsating huge The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
+10714	huge pulsating The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	moldy green and pepper (stale)	3	crappy	Last Available: "2020-12"
-10716	lousy practically non-alcoholic cranberry margarita (brackish)	1	decent	Last Available: "2020-12"
+10716	practically non-alcoholic lousy cranberry margarita (brackish)	1	decent	Last Available: "2020-12"
 10717	blinking fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	mirror nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	mediocre wobbly barrel-aged eggnog	4	decent	Last Available: "2020-12"
-10721	decent special hand-crafted candy cane	3	good	Effect: "A Few Extra Pounds", Effect Duration: 50, Last Available: "2020-12"
+10721	special decent hand-crafted candy cane	3	good	Effect: "A Few Extra Pounds", Effect Duration: 50, Last Available: "2020-12"
 10722	bland drive-thru burger	4	decent	Last Available: "2020-12"
 10723	hand-crafted Boulevardier cocktail	4	EPIC	Last Available: "2020-12"
 10724	dry teal Hotwire&trade; brand candy rope	0		Effect: "Amorous", Effect Duration: 39, Last Available: "2020-12"
@@ -10583,11 +10583,11 @@
 10727	aerosolized moist pulsating Chubby and Plump bar	0		Effect: "Weasels Underfoot", Effect Duration: 53, Last Available: "2020-12"
 10728	bouncing digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
-10730	huge blue bouncing crystal ball	0		Initiative: +50, Last Available: "2021-01"
+10730	blue bouncing huge crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	narrow spinning fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	mirror spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	mirror spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	yellow power seed	0		Free Pull, Last Available: "2021-03"
@@ -10598,7 +10598,7 @@
 10742	quadruple-alkaline battery (9-Volt)	0		Effect: "Human-Horror Hybrid", Effect Duration: 39, Last Available: "2021-03"
 10743	energized pressed battery (lantern)	0		Effect: "Old School Pompadour", Effect Duration: 48, Last Available: "2021-03"
 10744	ionized battery (car)	0		Effect: "Rage of the Reindeer", Effect Duration: 17, Last Available: "2021-03"
-10745	spinning lime green blurry cryptocloak	0		Last Available: "2025-12"
+10745	blurry lime green spinning cryptocloak	0		Last Available: "2025-12"
 10746	gray marshmallow	0		
 10747	lousy weak marshmallow bomb	2	decent	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
@@ -10626,7 +10626,7 @@
 10770	greasy Catherine Wheel of the brazier	0		Hot Spell Damage: +25, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10771	family-friendly rocket boots of the pedagogue	0		Experience: +3, Sleaze Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	knitted gravedigger's sparkler	0		Spooky Damage: +10, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2021-07"
-10773	huge spinning Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
+10773	spinning huge Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	adjusted blinking Scent of a Human&trade; candle	0		Effect: "Human-Machine Hybrid", Effect Duration: 38, Last Available: "2021-08"
 10775	polarized The Beast Within&trade; candle	0		Effect: "Chock Full o' Nanites", Effect Duration: 18, Last Available: "2021-08"
 10776	improved dry Salsa Caliente&trade; candle	0		Effect: "Helping Comes Second", Effect Duration: 51, Last Available: "2021-08"
@@ -10677,21 +10677,21 @@
 10821	decent fishcake	3	good	Last Available: "2021-12"
 10822	stale squat bone broth	3	decent	Last Available: "2021-12"
 10823	toothsome super-sized star pop	5	awesome	Last Available: "2021-12"
-10824	enchanted hand-crafted weak skewed Doc's Fortifying Wine	2	EPIC	Effect: "Flaming Weapon", Effect Duration: 20, Last Available: "2021-12"
+10824	hand-crafted weak enchanted skewed Doc's Fortifying Wine	2	EPIC	Effect: "Flaming Weapon", Effect Duration: 20, Last Available: "2021-12"
 10825	artisanal Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
 10826	artisanal weak skewed Doc's Limbering Wine	2	EPIC	Last Available: "2021-12"
 10827	perfectly mixed gray squat Doc's Medical-Grade Wine	3	EPIC	Last Available: "2021-12"
 10828	distilled gray Homebodyl&trade;	1		Last Available: "2021-12"
 10829	denatured blinking bouncing Extrovermectin&trade;	1		Last Available: "2021-12"
-10830	modified narrow shaking Breathitin&trade;	1		Effect: "Tennis Elbow-wow", Effect Duration: 30, Last Available: "2021-12"
+10830	modified shaking narrow Breathitin&trade;	1		Effect: "Tennis Elbow-wow", Effect Duration: 30, Last Available: "2021-12"
 10831	denatured pulsating Fleshazole&trade;	1		Last Available: "2021-12"
 10832	polymerized aerosolized jittery anti-burn cream	0		Effect: "Ooh, Umami!", Effect Duration: 61, Last Available: "2021-12"
 10833	pickled super-enhanced energized anti-freeze cream	0		Effect: "Well-Lubed", Effect Duration: 28, Last Available: "2021-12"
 10834	moist spinning anti-goosebump cream	0		Effect: "Heal Thy Nanoself", Effect Duration: 57, Last Available: "2021-12"
 10835	aerosolized anodized anti-odor cream	0		Effect: "Elvish", Effect Duration: 50, Last Available: "2021-12"
 10836	wet tumbling anti-creep cream	0		Effect: "The Two-Prong Crown", Effect Duration: 42, Last Available: "2021-12"
-10837	warmed green spinning anti-pain cream	0		Effect: "Stinkybeard", Effect Duration: 38, Last Available: "2021-12"
-10838	watered-down delicious Doc's Special Reserve Wine	2	awesome	Last Available: "2021-12"
+10837	warmed spinning green anti-pain cream	0		Effect: "Stinkybeard", Effect Duration: 38, Last Available: "2021-12"
+10838	delicious watered-down Doc's Special Reserve Wine	2	awesome	Last Available: "2021-12"
 10839	small adequate bread pie	2	good	Last Available: "2021-12"
 10840	aged blue clear Russian	3	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
@@ -10705,17 +10705,17 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	scorching cozy scarf	0		Hot Damage: +25, Last Available: "2021-12"
-10852	yummy low-calorie huge Crimbo cookie	1	awesome	Last Available: "2023-06"
+10852	low-calorie yummy huge Crimbo cookie	1	awesome	Last Available: "2023-06"
 10853	ionized huge fleshy putty	0		Effect: "Cold Throat", Effect Duration: 54, Last Available: "2021-12"
 10854	up-at-dawn third ear	0		Adventures: +5, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
-10856	blue upside-down bouncing poisonsettia	0		Last Available: "2021-12"
+10856	bouncing blue upside-down poisonsettia	0		Last Available: "2021-12"
 10857	peppermint-scented socks of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2021-12"
 10858	bouncing the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	jittery avaricious depleted Crimbonium football helmet	0		Meat Drop: +30, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	massive normal &quot;caramel&quot;	6	good	Last Available: "2021-12"
+10862	normal massive &quot;caramel&quot;	6	good	Last Available: "2021-12"
 10863	olive flame-wreathed self-repairing earmuffs	0		Hot Spell Damage: +10, Last Available: "2021-12"
 10864	shaking ruddy carnivorous potted plant	0		Maximum HP Percent: +40, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
@@ -10768,13 +10768,13 @@
 10912	rotten 20-lb can of rice and beans	4	crappy	Last Available: "2022-05"
 10913	shaking bar of freeze-dried water	1	good	Last Available: "2022-05"
 10914	stale tumbling expired MRE	3	decent	Last Available: "2022-05"
-10915	moldy fancy wobbly cool mint precipice bar	3	crappy	Effect: "Empty Inside", Effect Duration: 5, Last Available: "2022-05"
-10916	thick rotten carrot cake precipice bar	5	crappy	Last Available: "2022-05"
+10915	fancy moldy wobbly cool mint precipice bar	3	crappy	Effect: "Empty Inside", Effect Duration: 5, Last Available: "2022-05"
+10916	rotten thick carrot cake precipice bar	5	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	ghostly Thwaitgold harvestman statuette	0		
 10919	green packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	hardy June cleaver of incineration of the early riser	0		Maximum HP: +50, Hot Spell Damage: +50, Adventures: +7, Attacks Can't Miss, Last Available: "2022-06"
-10921	enchanted tolerable shaking Dad's brandy	3	good	Effect: "In Tuna", Effect Duration: 40, Last Available: "2022-06"
+10921	tolerable enchanted shaking Dad's brandy	3	good	Effect: "In Tuna", Effect Duration: 40, Last Available: "2022-06"
 10922	spinning ruddy groovy teacher's pen	0		Moxie Percent: +10, Maximum HP Percent: +40, Last Available: "2022-06"
 10923	delicious fire-roasted lake trout	4	awesome	Last Available: "2022-06"
 10924	decent gray guilty sprout	3	good	Last Available: "2022-06"
@@ -10782,14 +10782,14 @@
 10926	flattened ionized trampled ticket stub	0		Effect: "Dancing Prowess", Effect Duration: 27, Last Available: "2022-06"
 10927	wet squat savings bond	0		Effect: "BOOsted", Effect Duration: 67, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	blurry designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	blurry designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	powdered spinning spinning sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
-10932	red twirling stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
+10932	twirling red stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	pristine dinosaur feather	0		
-10936	blurry gray nasty dinosaur spike	0		
+10936	gray blurry nasty dinosaur spike	0		
 10937	maroon supercharged pterodactyl rifle	0		Maximum MP Percent: +30, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
 10939	narrow flatusaur gasmask	0		
@@ -10812,7 +10812,7 @@
 10956	aged AutumnFest ale	4	awesome	Last Available: "2022-10"
 10957	Van der Graaf hale autumn sweater-weather sweater of horror	0		Maximum HP: +20, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2022-10"
 10958	skewed auspicious lard-coated dance instructor's slick autumn debris shield	0		Moxie: +10, Experience Percent (Moxie): +10, Sleaze Spell Damage: +25, Item Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	snack-sized normal maroon autumn-spice donut	2	good	Last Available: "2022-10"
+10959	normal snack-sized maroon autumn-spice donut	2	good	Last Available: "2022-10"
 10960	magnetized alkaline autumn dollar	0		Effect: "Frisky Spirit", Effect Duration: 18, Last Available: "2022-10"
 10961	blinking Tesla steel-toed autumn leaf pendant of the sewer	0		Damage Reduction: 9, Stench Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2022-10"
 10962	vaporized teal autumn breeze	1		Last Available: "2022-10"
@@ -10825,35 +10825,35 @@
 10969	huge Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	rotten half-sized ratatouille de Jarlsberg	2	crappy	Last Available: "2022-11"
 10971	spoiled Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
-10972	rotten super-sized narrow roasted vegetable of Jarlsberg	5	crappy	Last Available: "2022-11"
+10972	super-sized rotten narrow roasted vegetable of Jarlsberg	5	crappy	Last Available: "2022-11"
 10973	rotten St. Pete's sneaky smoothie	4	crappy	Last Available: "2022-11"
 10974	moldy narrow Pete's wiley whey bar	3	crappy	Last Available: "2022-11"
 10975	tiny normal cyan Pete's rich ricotta	1	good	Last Available: "2022-11"
-10976	mediocre practically non-alcoholic Boris's beer	1	decent	Last Available: "2022-11"
+10976	practically non-alcoholic mediocre Boris's beer	1	decent	Last Available: "2022-11"
 10977	spoiled honey bun of Boris	3	crappy	Last Available: "2022-11"
 10978	decent Boris's bread	3	good	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	blinking Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	green Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	shaking Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	fuchsia Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	blinking Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	green Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	shaking Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	fuchsia Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	rotten baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
-10989	adequate gigantic narrow lime green plain calzone	10	good	Last Available: "2022-11"
-10990	snack-sized flavorless roasted vegetable focaccia	2	decent	Last Available: "2022-11"
+10989	gigantic adequate lime green narrow plain calzone	10	good	Last Available: "2022-11"
+10990	flavorless snack-sized roasted vegetable focaccia	2	decent	Last Available: "2022-11"
 10991	bland miniature Pizza of Legend	2	decent	Last Available: "2022-11"
 10992	spoiled twirling Calzone of Legend	3	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	pulsating tumbling Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	blinking Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	tumbling pulsating Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	blinking Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	jumbo stale narrow Deep Dish of Legend	5	decent	Last Available: "2022-11"
+10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	stale jumbo narrow Deep Dish of Legend	5	decent	Last Available: "2022-11"
 11001	huge deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10863,15 +10863,15 @@
 11007	pulsating booze bindle	0		
 11008	occult rare oboe of the scaredy-cat	0		Spell Damage Percent: +25, Monster Level: -15
 11009	lime green razor-sharp weightlifter's bullet necklace	0		Muscle: +15, Weapon Damage Percent: +25, Single Equip
-11010	massive yummy swamp haunch	7	awesome	
+11010	yummy massive swamp haunch	7	awesome	
 11011	wobbly frightening extremely unsafe gator shades	0		Weapon Damage Percent: +100, Spooky Damage: +5, Single Equip
 11012	milk cap	0		
-11013	enchanted delicious Charleston Choo-Choo	4	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 30
-11014	irresponsibly strong drinkable Velvet Veil	10	good	
+11013	delicious enchanted Charleston Choo-Choo	4	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 30
+11014	drinkable irresponsibly strong Velvet Veil	10	good	
 11015	aged Marltini	3	awesome	
-11016	distilled drinkable Strong, Silent Type	5	good	
+11016	drinkable distilled Strong, Silent Type	5	good	
 11017	practically non-alcoholic delicious Mysterious Stranger	1	awesome	
-11018	drinkable watered-down blurry Champagne Shimmy	2	good	
+11018	watered-down drinkable blurry Champagne Shimmy	2	good	
 11019	the Sot's parcel	0		
 11020	reassuring veiny ceramic cestus	0		Maximum HP: +10, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
 11021	ghostly gray personal trainer's groovy ceramic centurion shield of the businessman	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Meat Drop: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
@@ -10888,8 +10888,8 @@
 11032	twirling reassuring MacGyver's Rosewater's chiffon chakram	0		Mysticality Percent: +30, Maximum MP: +100, Spooky Resistance: +1, Last Available: "2023-12"
 11033	stanky supercharged razor-sharp chiffon chaps	0		Weapon Damage Percent: +25, Maximum MP Percent: +30, Stench Spell Damage: +25, Last Available: "2023-12"
 11034	diluted chiffon carbage	1		Effect: "Healthy, Elfy, and Wise", Effect Duration: 50, Last Available: "2023-12"
-11035	frozen yellow mirror tumbling chiffon lemon	0		Effect: "Fastbreaker", Effect Duration: 16
-11036	tasty jumbo chocomotive	5	awesome	Last Available: "2022-12"
+11035	frozen mirror tumbling yellow chiffon lemon	0		Effect: "Fastbreaker", Effect Duration: 16
+11036	jumbo tasty chocomotive	5	awesome	Last Available: "2022-12"
 11037	special decent cyan freightcake	3	good	Effect: "Leo Rising", Effect Duration: 45, Last Available: "2022-12"
 11038	mediocre shaking cabooze	3	decent	Last Available: "2022-12"
 11039	green plastic caboose	0		Last Available: "2022-12"
@@ -10901,7 +10901,7 @@
 11045	model train set	0		Last Available: "2022-12"
 11046	Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
-11048	skewed blurry blurry Trainbot radar monocle	0		Single Equip
+11048	blurry skewed blurry Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
 11050	flattened wet pulsating Trainbot circuitry	0		Effect: "Electrolit Up", Effect Duration: 30
 11051	pickled vacuum-sealed shaking Trainbot tubing	0		Effect: "Net Tea", Effect Duration: 11
@@ -10923,7 +10923,7 @@
 11067	triple-distilled tolerable dregs of a Crimbo cocktail	7	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	tiny toothsome blinking honey-drenched ham slice	1	awesome	
+11070	toothsome tiny blinking honey-drenched ham slice	1	awesome	
 11071	bad blurry mostly-empty bottle of cookie wine	3	decent	
 11072	stale Crimbo food scraps	3	decent	
 11073	arm towel	0		Last Available: "2022-12"
@@ -10938,7 +10938,7 @@
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	acceptable practically non-alcoholic blinking Crimbosmopolitan	1	good	Last Available: "2022-12"
-11085	bite-sized delicious Crimbo dinner	1	awesome	Last Available: "2022-12"
+11085	delicious bite-sized Crimbo dinner	1	awesome	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10949,7 +10949,7 @@
 11093	thinker's grubby wool scarf of the sweet-tooth	0		Mysticality: +10, Candy Drop: +100, Single Equip
 11094	beefcake's grubby wool trousers of wisdom of the pedagogue	0		Muscle: +25, Mysticality: +15, Experience: +3
 11095	gravedigger's coward's medical-grade ruddy grubby wool gloves	0		Maximum HP Percent: +40, Monster Level: -20, Spooky Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-11096	twirling olive blinking grubby wool beerwarmer	0		
+11096	twirling blinking olive grubby wool beerwarmer	0		
 11097	lousy nice warm beer	3	decent	
 11098	grubby woolball	0		
 11099	jittery Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
@@ -10965,8 +10965,8 @@
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
 11112	toothsome pixel bread	3	awesome	
-11113	watered-down artisanal pixel whiskey	2	EPIC	
-11114	tumbling skewed pixel rock	0		
+11113	artisanal watered-down pixel whiskey	2	EPIC	
+11114	skewed tumbling pixel rock	0		
 11115	narrow S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	triple-flattened glob of extra-green chlorophyll	0		Effect: "Mercenary", Effect Duration: 59, Last Available: "2023-02"
@@ -10974,7 +10974,7 @@
 11119	activated deionized olive five-fingered fern resin	0		Effect: "Full-Body Tan", Effect Duration: 18, Last Available: "2023-02"
 11120	stale green super good fruit	3	decent	Last Available: "2023-02"
 11121	dehydrated gray pulsating energized spores	1		Effect: "Blessing of Squirtlcthulli", Effect Duration: 30, Last Available: "2023-02"
-11122	smelly scorching hot pepper	0		Hot Damage: +25, Stench Spell Damage: +10, Lantern Element: "Hot", Last Available: "2023-02"
+11122	smelly scorching hot pepper	0		Hot Damage: +25, Stench Spell Damage: +10, Last Available: "2023-02", Lantern Element: "Hot"
 11123	anodized pressed narrow out-of-work circus flea	0		Effect: "Fitter, Happier", Effect Duration: 41, Last Available: "2023-02"
 11124	red extra-grubby grub	0		Last Available: "2023-02"
 11125	polymerized narrow fire ant pheromones	0		Effect: "Nature's Bounty", Effect Duration: 58, Last Available: "2023-02"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	huge shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	weak perfectly mixed shadow venom	2	EPIC	Last Available: "2023-03"
+11144	perfectly mixed weak shadow venom	2	EPIC	Last Available: "2023-03"
 11145	dried shadow nectar	1		Last Available: "2023-03"
 11146	lime green scorching careful sharpshooter's shadow stick	0		Critical Hit Percent: +10, Monster Level: -10, Hot Damage: +25, Last Available: "2023-03"
 11147	purple huge baleful strapping bat paw	0		Muscle: +5, Spell Damage: +25
@@ -11035,8 +11035,8 @@
 11180	squat fuchsia Jim Carey's hale arcane researcher's shadow monocle	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Monster Level: +25, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	flavorless shadow hot dog	4	decent	
-11183	perfectly mixed practically non-alcoholic shadow martini	1	EPIC	
-11184	compressed huge gray shadow pill	1		Effect: "Just Aged Enough", Effect Duration: 50
+11183	practically non-alcoholic perfectly mixed shadow martini	1	EPIC	
+11184	compressed gray huge shadow pill	1		Effect: "Just Aged Enough", Effect Duration: 50
 11185	upside-down shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	blinking monkey glove	0		Free Pull, Last Available: "2023-04"
@@ -11079,7 +11079,7 @@
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
-11227	olive blurry replica Crimbo sapling	0		
+11227	blurry olive replica Crimbo sapling	0		
 11228	replica puck	0		
 11229	replica Chateau Mantegna room key	0		
 11230	replica Deck of Every Card	0		
@@ -11091,7 +11091,7 @@
 11236	replica unpowered Robortender	0		
 11237	replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
-11239	blue huge replica God Lobster Egg	0		
+11239	huge blue replica God Lobster Egg	0		
 11240	mirror purple careful rock-hard replica Fourth of May Cosplay Saber of the brazier	0		Damage Reduction: 5, Monster Level: -10, Hot Spell Damage: +25, Conditional Skill (Equipped): "Use the Force"
 11241	prompt lard-coated scorching banded slick replica Kramco Sausage-o-Matic&trade;	0		Moxie: +10, Damage Absorption: +100, Hot Damage: +25, Sleaze Spell Damage: +25, Adventures: +3
 11242	gray lightning-fast nippy friendly medical-grade curative sinister savvy replica hewn moon-rune spoon of James Dean of the bloodbag of terror of the sweet-tooth	0		Mysticality Percent: +20, Experience (Moxie): +3, Spell Damage: +10, Maximum HP: +100, Familiar Weight: +3, Cold Damage: +10, Spooky Spell Damage: +10, Candy Drop: +100, Initiative: +40, HP Regen Min: 10, HP Regen Max: 15, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
@@ -11117,7 +11117,7 @@
 11262	bouncing Meat Butler	0		Last Available: "2023-06"
 11263	bouncing Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	Temple Grandin's Flash Liquidizer Ultra Dousing Accessory	0		Familiar Weight: +7, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	maroon censurious flame-retardant smartaleck's slick Amulet of Perpetual Darkness	0		Moxie: +10, Moxie Percent: +30, Hot Resistance: +1, Sleaze Resistance: +3, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	mediocre Sexy Cosmo	4	decent	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	reassuring red-soled high heels of the wise owl of incineration	0		Mysticality: +20, Hot Spell Damage: +50, Spooky Resistance: +1, Last Available: "2023-06"
-11285	low-calorie yummy cyburger	1	awesome	Last Available: "2025-12"
+11285	yummy low-calorie cyburger	1	awesome	Last Available: "2025-12"
 11286	padded ncle leg	0		Damage Absorption: +20
 11287	olive Oprah's rutabuga bag of mayonnaise	0		Maximum MP Percent: +50, Sleaze Spell Damage: +50
 11288	mesquito proboscis of mayonnaise	0		Sleaze Spell Damage: +50
@@ -11171,20 +11171,20 @@
 11316	stale banana split	3	decent	
 11317	gray handful of toilet paper	0		
 11318	Mrs. Rush	0		
-11319	narrow skewed medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
+11319	skewed narrow medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	drinkable mirror bottle of Cabernet Sauvignon	3	good	
 11321	miser's ribald grievous baywatch	0		Weapon Damage Percent: +50, Sleaze Damage: +10, Meat Drop: +10, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11324	gray spinning consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
+11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11324	spinning gray consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	narrow residual chitin paste	0		Skill: "Chitinous Soul"
 11328	dehydrated concentrated cooking	1		
-11329	mixed mirror shaking wobbly meat	1		
+11329	mixed shaking mirror wobbly meat	1		
 11330	denatured shaking sparkling orb	1		Effect: "Boo Tea", Effect Duration: 40
 11331	denatured narrow hardening cream	1		
-11332	diluted skewed green pool shark hair oil	1		
+11332	diluted green skewed pool shark hair oil	1		
 11333	blinking book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11212,7 +11212,7 @@
 11357	censurious smoldering drape of the detective	0		Sleaze Resistance: +3, Item Drop: +20, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	asbestos-lined flame-wreathed vibrating Fonzie's Herculean leaf crown of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Experience (Moxie): +1, Maximum MP Percent: +10, Hot Spell Damage: +10, Hot Resistance: +5
-11360	half-sized toothsome enchanted twirling leafy browns	2	awesome	Effect: "Coming Up Roses", Effect Duration: 35
+11360	half-sized enchanted toothsome twirling leafy browns	2	awesome	Effect: "Coming Up Roses", Effect Duration: 35
 11361	non-anodized huge autumnic balm	0		Effect: "Slimed Stomach", Effect Duration: 61
 11362	alkaline liquefied coping juice	0		Effect: "Very Clean Guns", Effect Duration: 15
 11363	bouncing wobbly horrifying nippy lion tamer's Oprah's strapping candy cane sword cane	0		Muscle: +5, Maximum MP Percent: +50, Experience (familiar): +2, Cold Damage: +10, Spooky Damage: +25, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11230,7 +11230,7 @@
 11375	tumbling Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	wobbly housekeeping robot	0		
-11378	spoiled special massive pickled bread	8	crappy	Effect: "Discomfited", Effect Duration: 15, Last Available: "2023-12"
+11378	massive spoiled special pickled bread	8	crappy	Effect: "Discomfited", Effect Duration: 15, Last Available: "2023-12"
 11379	rotten salted mutton	4	crappy	Last Available: "2023-12"
 11380	normal fancy corned beet	4	good	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	upside-down crated wardrobe-o-matic	0		
-11395	decent half-sized enchanted wobbly peppermint donut	2	good	Effect: "Dance of the Sugar Fairy", Effect Duration: 50
+11395	enchanted decent half-sized wobbly peppermint donut	2	good	Effect: "Dance of the Sugar Fairy", Effect Duration: 50
 11396	Da Vinci's Elf Guard insignia (private)	0		Experience (Mysticality): +5, Last Available: "2023-12"
 11397	maroon wizardly Crimbuccaneer fledges (mint)	0		Mysticality: +25, Last Available: "2023-12"
 11398	maroon military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11280,7 +11280,7 @@
 11425	tolerable extra-dry officer's nog	5	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	spoiled sundae ration	3	crappy	Last Available: "2023-12"
-11428	moldy snack-sized fancy peppermint tack	2	crappy	Effect: "Stone-Faced", Effect Duration: 40, Last Available: "2023-12"
+11428	moldy fancy snack-sized peppermint tack	2	crappy	Effect: "Stone-Faced", Effect Duration: 40, Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	flavorless whalesteak	3	decent	Last Available: "2023-12"
 11431	skewed knitted electrified Herculean whalegun	0		Experience (Muscle): +1, Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
@@ -11308,20 +11308,20 @@
 11453	skewed Elf Guard SCUBA tank of the sewer of terror	0		Stench Damage: +25, Spooky Spell Damage: +10, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11455	Samson's free boots of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
-11456	shaking yellow upside-down baby rigging snake	0		Last Available: "2023-12"
+11456	upside-down yellow shaking baby rigging snake	0		Last Available: "2023-12"
 11457	blurry Usain Bolt's censurious frosty Elvish underarmor	0		Cold Spell Damage: +10, Sleaze Resistance: +3, Initiative: +80, Single Equip, Last Available: "2023-12"
 11458	bouncing Oprah's Crimbuccaneer bombjacket of the detective	0		Maximum MP Percent: +50, Item Drop: +20, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	decent miniature sugarplum ration	2	good	Last Available: "2023-12"
+11459	miniature decent sugarplum ration	2	good	Last Available: "2023-12"
 11460	normal gingerbread nylons	4	good	Last Available: "2023-12"
 11461	adequate rum-soaked fruitcake	3	good	Last Available: "2023-12"
-11462	toothsome half-sized special lime	2	awesome	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2023-12"
-11463	enchanted spoiled snack-sized gingerbread pirate	2	crappy	Effect: "Flower Power", Effect Duration: 15, Last Available: "2023-12"
+11462	special half-sized toothsome lime	2	awesome	Effect: "Gutterminded", Effect Duration: 15, Last Available: "2023-12"
+11463	snack-sized enchanted spoiled gingerbread pirate	2	crappy	Effect: "Flower Power", Effect Duration: 15, Last Available: "2023-12"
 11464	flavorless shaking fruit-stuffed rumcake	4	decent	Last Available: "2023-12"
 11465	strong bad mulled wine	5	decent	Last Available: "2023-12"
 11466	hand-crafted narrow Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	drinkable skewed canteen of eggnog	3	good	Last Available: "2023-12"
 11468	mediocre tumbling hot wine	3	decent	Last Available: "2023-12"
-11469	watered-down bad Jamaican coffee	2	decent	Last Available: "2023-12"
+11469	bad watered-down Jamaican coffee	2	decent	Last Available: "2023-12"
 11470	tolerable bouncing flask of egggrog	3	good	Last Available: "2023-12"
 11471	yellow squat Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	pulsating Black and White Apron Meal Kit	0		Last Available: "2024-12"
@@ -11334,12 +11334,12 @@
 11479	fuchsia rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	tumbling foul-smelling dance instructor's Elf Guard squirtgun	0		Experience Percent (Moxie): +10, Stench Damage: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
-11482	upside-down cyan chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
+11482	cyan upside-down chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	mirror inspector's sequin-encrusted sweater	0		Item Drop: +15, Last Available: "2023-12"
 11484	green auspicious wool replica Elf Guard medal of the brute	0		Muscle Percent: +30, Cold Resistance: +1, Item Drop: +10, Last Available: "2023-12"
 11485	Lil' Snowball Factory	0		Last Available: "2023-12"
 11486	Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
-11487	tumbling olive prank Crimbo card	0		Last Available: "2023-12"
+11487	olive tumbling prank Crimbo card	0		Last Available: "2023-12"
 11488	maroon boxer's brainy Crimbuccaneer squirtblunderbuss	0		Mysticality: +5, Muscle Percent: +10, Last Available: "2023-12"
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	wobbly Usain Bolt's reassuring horrifying barnacle-encrusted sweater	0		Spooky Damage: +25, Spooky Resistance: +1, Initiative: +80, Last Available: "2023-12"
@@ -11382,8 +11382,8 @@
 11527	irradiated crepe paper peanut candy	0		Effect: "Nutrient-Rich", Effect Duration: 26
 11528	lightning-fast extremely unsafe petrified wood war pike	0		Weapon Damage Percent: +100, Initiative: +40, Last Available: "2025-12"
 11529	asbestos-lined ribald petrified wood waist protector	0		Sleaze Damage: +10, Hot Resistance: +5, Single Equip, Last Available: "2025-12"
-11530	fireproof petrified wood wizard's pouch of the empath	0		Familiar Weight: +5, Hot Resistance: +3, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	petrified wood water purifier of courage of the businessman	0		Spooky Resistance: +3, Meat Drop: +50, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	fireproof petrified wood wizard's pouch of the empath	0		Familiar Weight: +5, Hot Resistance: +3, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	petrified wood water purifier of courage of the businessman	0		Spooky Resistance: +3, Meat Drop: +50, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	Samson's sage petrified wood whoopie panama	0		Mysticality Percent: +10, Experience (Muscle): +5, Last Available: "2025-12"
 11533	jittery stiffened arcane researcher's petrified wood walking pants	0		Experience Percent (Mysticality): +10, Damage Reduction: 1, Last Available: "2025-12"
 11534	twisted blue petrified wood waste parts	1		Effect: "Bureaucratized", Effect Duration: 30, Last Available: "2025-12"
@@ -11397,7 +11397,7 @@
 11542	mimic egg	0		
 11543	skewed censurious hale Crimbuccaneer war standard	0		Maximum HP: +20, Sleaze Resistance: +3, Last Available: "2023-12"
 11544	frosty sharpshooter's Elf Guard war standard	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Last Available: "2023-12"
-11545	yellow skewed in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
+11545	skewed yellow in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	fortified spring shoes of the scaredy-cat of horror	0		Damage Absorption: +60, Monster Level: -15, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	triple-diffused dry tarnished skewed ultra-soft ferns	0		Effect: "Wallflowering", Effect Duration: 56, Last Available: "2024-02"
 11548	quantum crunchy brush	0		Effect: "French Bronilla Brogueishness", Effect Duration: 60, Last Available: "2024-02"
@@ -11426,12 +11426,12 @@
 11571	pulsating boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	tasty yam	4	awesome	Last Available: "2024-05"
-11574	watered-down hand-crafted yam martini	2	EPIC	Last Available: "2024-05"
+11574	hand-crafted watered-down yam martini	2	EPIC	Last Available: "2024-05"
 11575	aged sweet potato o' mine	4	awesome	Last Available: "2024-05"
 11576	mediocre twirling Southern yam	3	decent	Last Available: "2024-05"
 11577	acceptable mirror sweet potato punch	3	good	Last Available: "2024-05"
 11578	bland half-sized Mayam spinach	2	decent	Last Available: "2024-05"
-11579	stale tiny yam and swiss	1	decent	Last Available: "2024-05"
+11579	tiny stale yam and swiss	1	decent	Last Available: "2024-05"
 11580	bouncing toasty cool yam cannon of the storm	0		Moxie: +5, Maximum MP Percent: +40, Hot Damage: +5, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	huge yam battery	0		Last Available: "2024-05"
@@ -11439,8 +11439,8 @@
 11584	lightning-fast aromatic furry yam buckler of the scaredy-cat	0		Monster Level: -15, Stench Resistance: +1, Initiative: +40, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	pulsating thanksgiving bomb	0		Last Available: "2024-05"
 11586	ghostly Tesla yamtility belt of the wise owl of vim and vigor	0		Mysticality: +20, Maximum HP Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-05"
-11587	tiny flavorless yam slider	1	decent	Last Available: "2024-05"
-11588	enchanted normal miniature yam mayo	2	good	Effect: "All Is Forgiven", Effect Duration: 20, Last Available: "2024-05"
+11587	flavorless tiny yam slider	1	decent	Last Available: "2024-05"
+11588	enchanted miniature normal yam mayo	2	good	Effect: "All Is Forgiven", Effect Duration: 20, Last Available: "2024-05"
 11589	yummy yam burrito	4	awesome	Last Available: "2024-05"
 11590	tumbling visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11448,13 +11448,13 @@
 11593	mirror Thwaitgold Illinigina illinoiensis model	0		
 11594	spoiled blinking mini kiwi	3	crappy	Last Available: "2024-06"
 11595	zippy frightening Da Vinci's mini kiwi bikini	0		Experience (Mysticality): +5, Spooky Damage: +5, Initiative: +20, Last Available: "2024-06"
-11596	weak mediocre enchanted teal mini kiwitini	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2024-06"
-11597	pulsating narrow mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
+11596	weak enchanted mediocre teal mini kiwitini	2	decent	Effect: "Hella Smart", Effect Duration: 10, Last Available: "2024-06"
+11597	narrow pulsating mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	narrow mini kiwi aioli	0		
 11599	tumbling sharpshooter's sage mini kiwi silicon tiepin of dire peril	0		Mysticality Percent: +10, Weapon Damage: +20, Critical Hit Percent: +10
 11600	pulsating mini kiwi tipi	0		
 11601	toothsome mini kiwi digitized cookies	4	awesome	
-11602	practically non-alcoholic tolerable mini kiwi intoxicating spirits	1	good	
+11602	tolerable practically non-alcoholic mini kiwi intoxicating spirits	1	good	
 11603	electrified polymerized mini kiwi antimilitaristic hippy petition	0		Effect: "The Style... of the Future", Effect Duration: 54
 11604	dry polymerized mini kiwi illicit antibiotic	0		Effect: "Taurus Rising", Effect Duration: 12
 11605	narrow blue extremely unsafe mini kiwi whipping stick of the dark arts	0		Weapon Damage Percent: +100, Spell Damage Percent: +100
@@ -11471,7 +11471,7 @@
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	normal bacteria bisque	3	good	
-11619	flavorless low-calorie mirror blinking fuchsia ciliophora chowder	1	decent	
+11619	low-calorie flavorless mirror blinking fuchsia ciliophora chowder	1	decent	
 11620	stale blinking cream of chloroplasts	3	decent	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11502,7 +11502,7 @@
 11647	cyan structural ember	0		Last Available: "2024-09"
 11648	teal censurious friendly embers-only jacket of the sewer	0		Familiar Weight: +3, Stench Damage: +25, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-09"
 11649	green bembershoot of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Last Available: "2024-09"
-11650	tasty gigantic wheel of camembert	7	awesome	Last Available: "2024-09"
+11650	gigantic tasty wheel of camembert	7	awesome	Last Available: "2024-09"
 11651	smelly nippy Oprah's hat of remembering	0		Maximum MP Percent: +50, Cold Damage: +10, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11527,7 +11527,7 @@
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	adequate thick mirror whirled peas	5	good	Last Available: "2024-11"
-11675	snack-sized normal narrow peaza	2	good	Last Available: "2024-11"
+11675	normal snack-sized narrow peaza	2	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	vaporized purple drenchrome 2.0	1		Effect: "Celestial Body", Effect Duration: 30, Last Available: "2025-12"
 11678	boiled blurry jittery Synapse Blaster	1		Effect: "Halloweeny", Effect Duration: 15, Last Available: "2025-12"
@@ -11535,7 +11535,7 @@
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	irradiated pea brittle	0		Effect: "Pyromania", Effect Duration: 46, Last Available: "2024-11"
-11683	tolerable weak peasco	2	good	Last Available: "2024-11"
+11683	weak tolerable peasco	2	good	Last Available: "2024-11"
 11684	normal small piece of cake	2	good	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
@@ -11561,8 +11561,8 @@
 11706	maroon anchor bomb	0		Last Available: "2024-12"
 11707	banded silky pirate drawers of wisdom	0		Mysticality: +15, Damage Absorption: +100, Last Available: "2024-12"
 11708	squat profane eye patch	0		Sleaze Damage: +3
-11709	aerosolized Vulcanized unsweetened upside-down pulsating peppermint pegleg	0		Effect: "Phorcefullness", Effect Duration: 29, Last Available: "2024-12"
-11710	artisanal high-proof hard cocoa	8	EPIC	Last Available: "2024-12"
+11709	aerosolized Vulcanized unsweetened pulsating upside-down peppermint pegleg	0		Effect: "Phorcefullness", Effect Duration: 29, Last Available: "2024-12"
+11710	high-proof artisanal hard cocoa	8	EPIC	Last Available: "2024-12"
 11711	spoiled salmagumdi	3	crappy	Last Available: "2024-12"
 11712	Sherlock's plastic Easter Island Bunny	0		Item Drop: +25, Last Available: "2024-12"
 11713	flame-wreathed plastic St. Patrick	0		Hot Spell Damage: +10, Last Available: "2024-12"
@@ -11571,18 +11571,18 @@
 11716	blinking avaricious plastic &quot;Santa Claus&quot;	0		Meat Drop: +30, Last Available: "2024-12"
 11717	cyan blinking Spirit of Easter	0		Last Available: "2024-12"
 11718	skewed Spirit of St. Patrick's Day	0		Last Available: "2024-12"
-11719	blinking mirror Spirit of Veteran's Day	0		Last Available: "2024-12"
+11719	mirror blinking Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	yummy coney haunch	3	awesome	Last Available: "2024-12"
 11723	electrified dark chocolate egg	0		Effect: "Whippin' It Good", Effect Duration: 57, Last Available: "2024-12"
-11724	bad weak moai toai	2	decent	
+11724	weak bad moai toai	2	decent	
 11725	narrow fuchsia savvy moaiball of Gandalf of the blizzard	0		Mysticality Percent: +20, Spell Critical Percent: +20, Cold Spell Damage: +25, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	enhanced wet jittery four-leaf potato sprout	0		Effect: "Hypercubed", Effect Duration: 22, Last Available: "2024-12"
 11728	tumbling wool baleful Herculean potato jacket	0		Experience (Muscle): +1, Spell Damage: +25, Cold Resistance: +1, Last Available: "2024-12"
 11729	ghostly traumatic holiday memory	0		Last Available: "2024-12"
-11730	olive blinking Brandonian footlocker key	0		Last Available: "2024-12"
+11730	blinking olive Brandonian footlocker key	0		Last Available: "2024-12"
 11731	squat blinking military orb of Gandalf of courage	0		Spell Critical Percent: +20, Spooky Resistance: +3, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	liquefied ghostly rum ball	0		Effect: "Vitamin-Maxed", Effect Duration: 32
 11733	wobbly gravy skin	0		Last Available: "2024-12"
@@ -11600,36 +11600,36 @@
 11745	jittery banded boxer's Congressional Medal of Insanity of Gandalf	0		Muscle Percent: +10, Damage Absorption: +100, Spell Critical Percent: +20, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	acceptable bouncing Easter grasshopper	3	good	Last Available: "2024-12"
-11748	tolerable triple-distilled Irish eggnog	10	good	Last Available: "2024-12"
+11748	triple-distilled tolerable Irish eggnog	10	good	Last Available: "2024-12"
 11749	hand-crafted canteen of jungle juice	4	EPIC	Last Available: "2024-12"
 11750	hand-crafted turchucken	4	EPIC	Last Available: "2024-12"
 11751	mediocre mechanically-mulled cider	3	decent	Last Available: "2024-12"
-11752	hand-crafted practically non-alcoholic yellow holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11752	practically non-alcoholic hand-crafted yellow holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11753	bland chocolate ostrich egg	4	decent	Last Available: "2024-12"
-11754	super-sized fancy rotten beef and cabbage	5	crappy	Effect: "Shredding, Sweating", Effect Duration: 20, Last Available: "2024-12"
+11754	super-sized rotten fancy beef and cabbage	5	crappy	Effect: "Shredding, Sweating", Effect Duration: 20, Last Available: "2024-12"
 11755	half-sized rotten candy rations	2	crappy	Last Available: "2024-12"
 11756	bland double-candied yams	3	decent	Last Available: "2024-12"
 11757	spoiled Christmas ham	3	crappy	Last Available: "2024-12"
 11758	decent holiday smorgasbord	3	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	Newton's bejazzled eyepatch	0		Experience (Mysticality): +3, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	skewed Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	blinking jittery How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	gray How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	fuchsia Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	mirror bouncing Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	huge Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	mirror twirling Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	skewed Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	blinking jittery How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	gray How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	fuchsia Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	bouncing mirror Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	huge Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	mirror twirling Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	Sherlock's asbestos-lined hale weightlifter's egg gun	0		Muscle: +15, Maximum HP: +20, Hot Resistance: +5, Item Drop: +25, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	toasty razor-sharp supercool boxer's army helmet	0		Muscle Percent: +10, Moxie Percent: +20, Weapon Damage Percent: +25, Hot Damage: +5, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	jittery napkin	0		Last Available: "2024-12"
 11776	small bland Thanksgiving ration	2	decent	Last Available: "2024-12"
-11777	enchanted high-proof bad Easter eggnog	9	decent	Effect: "Greasy Visage", Effect Duration: 15, Last Available: "2024-12"
+11777	enchanted bad high-proof Easter eggnog	9	decent	Effect: "Greasy Visage", Effect Duration: 15, Last Available: "2024-12"
 11778	mixed clovermint	1		Last Available: "2024-12"
 11779	wool friendly nylon Christmas stockings of James Dean of the businessman	0		Experience (Moxie): +3, Familiar Weight: +3, Cold Resistance: +1, Meat Drop: +50, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11670,7 +11670,7 @@
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
-11818	huge maroon dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
+11818	maroon huge dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	olive dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	twirling SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
@@ -11724,14 +11724,14 @@
 11869	unironic knife	0		
 11870	ghostly bar dart	0		Last Available: "2025-03"
 11871	compressed leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	immense rotten Heck ramen	6	crappy	Last Available: "2025-03"
+11872	rotten immense Heck ramen	6	crappy	Last Available: "2025-03"
 11873	delicious huge burrito	4	awesome	Last Available: "2025-03"
-11874	super-sized spoiled narrow small beer brat	5	crappy	Last Available: "2025-03"
+11874	spoiled super-sized narrow small beer brat	5	crappy	Last Available: "2025-03"
 11875	stale peach pie	3	decent	Last Available: "2025-03"
 11876	normal incredible mini-pizza	4	good	Last Available: "2025-03"
-11877	tolerable watered-down Divine sidecar	2	good	Last Available: "2025-03"
+11877	watered-down tolerable Divine sidecar	2	good	Last Available: "2025-03"
 11878	tolerable tangarita sidecar	3	good	Last Available: "2025-03"
-11879	delicious fortified gimlet sidecar	5	awesome	Last Available: "2025-03"
+11879	fortified delicious gimlet sidecar	5	awesome	Last Available: "2025-03"
 11880	bad vodka stratocaster sidecar	4	decent	Last Available: "2025-03"
 11881	bad prussian cathouse sidecar	3	decent	Last Available: "2025-03"
 11882	extra-dry artisanal blinking Mon Tiki sidecar	5	EPIC	Last Available: "2025-03"
@@ -11806,15 +11806,15 @@
 11951	mirror narrow Stock Certificate	0		Last Available: "2025-08"
 11952	denatured narrow mixed berry jelly	1		Last Available: "2025-08"
 11953	bland toast with mixed berry jelly	4	decent	Last Available: "2025-08"
-11954	tasty fancy purple huge cup of sugar	3	awesome	Effect: "Coming Up Roses", Effect Duration: 15, Last Available: "2025-08"
-11955	moldy bouncing purple Susie's cupcake	3	crappy	Last Available: "2025-08"
+11954	tasty fancy huge purple cup of sugar	3	awesome	Effect: "Coming Up Roses", Effect Duration: 15, Last Available: "2025-08"
+11955	moldy purple bouncing Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	maroon greedy gravedigger's coward's the gun	0		Monster Level: -20, Spooky Damage: +10, Meat Drop: +20, Last Available: "2025-08"
-11958	drinkable ghostly skewed wine	3	good	Last Available: "2025-08"
+11958	drinkable skewed ghostly wine	3	good	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	huge sand penny	0		
 11962	wobbly mansplainer's undersea surveying goggles	0		Monster Level: +15, Lasts Until Rollover
-11963	perfectly mixed triple-distilled Ocean-Touched Rum	8	EPIC	
+11963	triple-distilled perfectly mixed Ocean-Touched Rum	8	EPIC	
 11964	powdered water-logged pill	1		Effect: "Shredding, Sweating", Effect Duration: 35
 11965	huge decent spinning kelp puck	10	good	
 11966	scroll of sea strength	0		
@@ -11822,7 +11822,7 @@
 11968	scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	blinking sea gel	0		
-11971	double-improved narrow jittery octopus ink bladder	0		Effect: "Castaway Physique", Effect Duration: 48
+11971	double-improved jittery narrow octopus ink bladder	0		Effect: "Castaway Physique", Effect Duration: 48
 11972	durable dolphin whistle	0		
 11973	shaking wobbly Thwaitgold lobster statuette	0		
 11974	upside-down jittery packaged Monodent of the Sea	0		Free Pull
@@ -11831,7 +11831,7 @@
 11977	boxer's dentadent	0		Muscle Percent: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	upside-down clever banded Da Vinci's blood cubic zirconia of dire peril of the empath of the detective	0		Experience (Mysticality): +5, Weapon Damage: +20, Damage Absorption: +100, Maximum MP: +20, Familiar Weight: +5, Item Drop: +20, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
-12044	dried huge blinking blood thinner	1		Last Available: "2025-10"
+12044	dried blinking huge blood thinner	1		Last Available: "2025-10"
 12045	lousy pheromone cocktail	4	decent	Last Available: "2025-10"
 12046	adequate mirror spinal tapas	4	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
@@ -11840,10 +11840,10 @@
 12050	small peppermint-flavored sugar walking crook	0		
 12051	narrow knucklebone	0		
 12052	drinkable huge gray Smoking Pope	3	good	
-12053	tasty enchanted super-sized prize turkey	5	awesome	Effect: "La Bamba", Effect Duration: 20
+12053	tasty super-sized enchanted prize turkey	5	awesome	Effect: "La Bamba", Effect Duration: 20
 12054	diluted blinking medicinal gruel	1		Effect: "Spell Transfer Complete", Effect Duration: 15
 12055	rotten wobbly full-sized pumpkin pie	3	crappy	Last Available: "2025-11"
-12056	mediocre practically non-alcoholic vodka cranberry sauce	1	decent	Last Available: "2025-11"
+12056	practically non-alcoholic mediocre vodka cranberry sauce	1	decent	Last Available: "2025-11"
 12057	anodized oxidized yammed candy	0		Effect: "Gunky Dory", Effect Duration: 52, Last Available: "2025-11"
 12058	adequate twirling treasure chestnut	4	good	Last Available: "2025-12"
 12059	acceptable practically non-alcoholic mulled butter rum	1	good	Last Available: "2025-12"
@@ -11861,7 +11861,7 @@
 12071	squat avaricious angelbone mantle of the brute	0		Muscle Percent: +30, Meat Drop: +30, Last Available: "2026-12"
 12072	angelbone dice of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2026-12"
 12073	double-paned angelbone halo of the cheetah	0		Cold Resistance: +5, Initiative: +60, Last Available: "2026-12"
-12074	twisted yellow blinking angelbone fragments	1		Last Available: "2026-12"
+12074	twisted blinking yellow angelbone fragments	1		Last Available: "2026-12"
 12075	colloidal tarnished twirling biblically accurate gumdrops	0		Effect: "Hobo Flavor", Effect Duration: 18
 12076	personal trainer's groovy devilbone helmet	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Last Available: "2026-12"
 12077	arcane researcher's devilbone greaves	0		Experience Percent (Mysticality): +10, Last Available: "2026-12"
@@ -11869,19 +11869,19 @@
 12079	brainy devilbone corset	0		Mysticality: +5, Last Available: "2026-12"
 12080	arcane researcher's devilbone flute of temperance	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +5, Last Available: "2026-12"
 12081	tumbling knitted devilbone rosary	0		Cold Resistance: +3, Single Equip, Last Available: "2026-12"
-12082	mixed yellow huge devilbone chunks	1		Last Available: "2026-12"
+12082	mixed huge yellow devilbone chunks	1		Last Available: "2026-12"
 12083	anodized purple Gehenna tattoo	0		Effect: "Empathy", Effect Duration: 67
 12116	tumbling skewed burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
 12118	wobbly burnt radius	0		Last Available: "2025-12"
 12119	burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
-12121	upside-down purple Crymbocurrency	0		Last Available: "2025-12"
+12121	purple upside-down Crymbocurrency	0		Last Available: "2025-12"
 12122	red Jack Frost's extra-thick Crimbo sweater	0		Cold Spell Damage: +50, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	drinkable practically non-alcoholic Steve Abrams' Holiday Sampler Beer	1	good	Last Available: "2025-12"
+12124	practically non-alcoholic drinkable Steve Abrams' Holiday Sampler Beer	1	good	Last Available: "2025-12"
 12125	ghostly crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	enchanted practically non-alcoholic aged twirling bottle of prize-winning rum	1	awesome	Effect: "Full Bottle in front of Me", Effect Duration: 15, Last Available: "2025-12"
+12126	aged practically non-alcoholic enchanted twirling bottle of prize-winning rum	1	awesome	Effect: "Full Bottle in front of Me", Effect Duration: 15, Last Available: "2025-12"
 12127	Usain Bolt's cool Santa-Slayer medal of wisdom	0		Mysticality: +15, Moxie: +5, Initiative: +80, Single Equip, Last Available: "2025-12"
 12128	huge Skull of Claus	0		Last Available: "2025-12"
 12129	colloidal anodized boiling bone marrow	0		Effect: "Browbeaten", Effect Duration: 69, Last Available: "2025-12"
@@ -11890,7 +11890,7 @@
 12132	purple manspreader's Van der Graaf smoldering vertebra of the cheetah	0		Monster Level: +10, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
-12135	blurry green smoldering bone dust	0		Last Available: "2025-12"
+12135	green blurry smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	purple chaotic hale forbidden hot boning knife	0		Spell Damage Percent: +50, Maximum HP: +20, Spell Critical Percent: +10, Single Equip, Last Available: "2025-12"
 12138	reassuring wholesome occult fistbone	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Spooky Resistance: +1, Last Available: "2025-12"
@@ -11926,11 +11926,11 @@
 12168	scandalous Newton's vermiculite shield	0		Experience (Mysticality): +3, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2025-12"
 12169	ruddy ship's lantern	0		Maximum HP Percent: +40, Last Available: "2025-12"
 12170	frightening heat-resistant harpoon pistol of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Last Available: "2025-12"
-12171	diet rotten ghostly traditional gingerloaf	1	crappy	Last Available: "2025-12"
+12171	rotten diet ghostly traditional gingerloaf	1	crappy	Last Available: "2025-12"
 12172	artisanal spinning Scotch and eggnog	3	EPIC	Last Available: "2025-12"
-12173	double-Vulcanized ghostly maroon counterskeleton elixir	0		Effect: "Oiled Skin", Effect Duration: 32, Last Available: "2025-12"
+12173	double-Vulcanized maroon ghostly counterskeleton elixir	0		Effect: "Oiled Skin", Effect Duration: 32, Last Available: "2025-12"
 12174	artisanal &quot;salvaged&quot; wine	3	EPIC	Last Available: "2025-12"
-12175	skewed ghostly huge The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12175	skewed huge ghostly The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	shaking crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	toothsome wedge of prize-winning cheese	4	awesome	Last Available: "2025-12"
 12178	polymerized dry flattened gummi fingerbone	0		Effect: "Jammin'", Effect Duration: 33
@@ -11947,7 +11947,7 @@
 12189	huge intact dinosaur egg	0		Last Available: "2026-03"
 12190	upside-down fossilized cow femur	0		Familiar Weight: +5
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
-12192	tumbling shaking red Pork Elf toiletries kit	0		Last Available: "2026-03"
+12192	red tumbling shaking Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	polymerized modified red Pork Elf mouthwash	0		Effect: "Can't Smell Nothin'", Effect Duration: 46, Last Available: "2026-03"
 12194	liquefied non-pressed Pork Elf deodorant	0		Effect: "Hagg-ard", Effect Duration: 37, Last Available: "2026-03"
 12195	galvanized liquefied Pork Elf toothpaste	0		Effect: "Disdain of She-Who-Was", Effect Duration: 31, Last Available: "2026-03"
@@ -11959,17 +11959,17 @@
 12201	ghostly fortified dinosaur bone club	0		Damage Absorption: +60, Last Available: "2026-03"
 12202	lion tamer's healthy dinosaur skull helmet	0		Maximum HP Percent: +20, Experience (familiar): +2, Last Available: "2026-03"
 12203	olive dinosaur bone corset of the sewer of mayonnaise of the businessman	0		Stench Damage: +25, Sleaze Spell Damage: +50, Meat Drop: +50, Last Available: "2026-03"
-12204	high-proof mediocre Pork Elf cough syrup	9	decent	Last Available: "2026-03"
-12205	blinking blurry Pork Elf neti pot	0		Last Available: "2026-03"
+12204	mediocre high-proof Pork Elf cough syrup	9	decent	Last Available: "2026-03"
+12205	blurry blinking Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	huge flavorless rat pizza	8	decent	Last Available: "2026-03"
+12209	flavorless huge rat pizza	8	decent	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	perfumed electrified hardy hoverboard	0		Maximum HP: +50, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2026-03"
 12212	purple nippy chilly manspreader's left shark fin	0		Monster Level: +10, Cold Damage: 15, Last Available: "2026-03"
 12213	maroon huge dance instructor's fitness tracking bracelet	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2026-03"
-12214	mixed skewed pulsating candy bone	1		
+12214	mixed pulsating skewed candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	decent snack-sized discarded hot dog	2	good	Last Available: "2026-04"
@@ -11977,7 +11977,7 @@
 12222	ghostly pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	adequate gigantic can of tuna	7	good	
+12226	gigantic adequate can of tuna	7	good	
 12227	flavorless bouncing alien salad	4	decent	
 12228	rotten gigantic blurry ratbatatouille	10	crappy	
 12229	tiny stale pulsating onigiri	1	decent	
@@ -11986,11 +11986,11 @@
 12232	thick rotten hot honey ant	5	crappy	
 12233	stale tomb aspic	3	decent	
 12234	adequate later tots	3	good	
-12235	stale thick Frutti di Scatoletta	5	decent	Last Available: "2026-05"
+12235	thick stale Frutti di Scatoletta	5	decent	Last Available: "2026-05"
 12236	moldy bouncing Pesto alla Marziano	3	crappy	Last Available: "2026-05"
 12237	moldy Arrattabbattabiata	3	crappy	Last Available: "2026-05"
 12238	rotten Orzo di Riso	4	crappy	Last Available: "2026-05"
-12239	tiny adequate fancy Pasta Grimavera	1	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 15, Last Available: "2026-05"
+12239	adequate fancy tiny Pasta Grimavera	1	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 15, Last Available: "2026-05"
 12240	spoiled skewed Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
 12241	adequate miniature Formica e Pepe	2	good	Last Available: "2026-05"
 12242	tasty tiny Tubetto Gelatto	1	awesome	Last Available: "2026-05"
@@ -12000,7 +12000,7 @@
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	executive brainy Space Soldier Helmet	0		Mysticality: +5, Meat Drop: +40
-12253	stale massive premium turkey leg	9	decent	
+12253	massive stale premium turkey leg	9	decent	
 12254	mediocre cyan styrofoam cup of mead	4	decent	
 12255	banded sword	0		Damage Absorption: +100
 12256	staff of the empath	0		Familiar Weight: +5
@@ -12032,14 +12032,14 @@
 12282	massive normal twirling watermelon pie	7	good	Last Available: "2026-07"
 12283	aerosolized ghostly huge concentrated watermelon juice	0		Effect: "[800]Chocolate Reign", Effect Duration: 37, Last Available: "2026-07"
 12284	vacuum-sealed cyan Aqua Citrulanatae	0		Effect: "Fastbreaker", Effect Duration: 65, Last Available: "2026-07"
-12285	hand-crafted watered-down Melonegroni	2	EPIC	Last Available: "2026-07"
-12286	enchanted practically non-alcoholic drinkable Melonade Spritz	1	good	Effect: "Astral Shell", Effect Duration: 50, Last Available: "2026-07"
+12285	watered-down hand-crafted Melonegroni	2	EPIC	Last Available: "2026-07"
+12286	drinkable enchanted practically non-alcoholic Melonade Spritz	1	good	Effect: "Astral Shell", Effect Duration: 50, Last Available: "2026-07"
 12287	gigantic moldy quince pie	6	crappy	Last Available: "2026-07"
 12288	corrupted ghostly quince quaff	0		Effect: "Ticking Clock", Effect Duration: 21, Last Available: "2026-07"
 12289	frozen non-unsweetened deionized Quickquince	0		Effect: "Brother Corsican's Blessing", Effect Duration: 60, Last Available: "2026-07"
-12290	weak lousy Quiskey Sour	2	decent	Last Available: "2026-07"
+12290	lousy weak Quiskey Sour	2	decent	Last Available: "2026-07"
 12291	hand-crafted tumbling Quincea&ntilde;era Cooler	3	EPIC	Last Available: "2026-07"
-12292	high-proof mediocre Roth IPA	8	decent	Last Available: "2026-08"
+12292	mediocre high-proof Roth IPA	8	decent	Last Available: "2026-08"
 12293	crafty stiffened underdraft protection	0		Damage Reduction: 1, Maximum MP: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	bland soybean futures	3	decent	Last Available: "2026-08"

--- a/data/TCRS/TCRS_Pastamancer_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Vole_cafe_booze.txt
@@ -6,28 +6,28 @@
 -6	perfectly mixed weak braincracker sweet	2	EPIC	
 -16	triple-distilled bad teal fermented honey	9	decent	
 -17	artisanal enchanted moons-shine	3	EPIC	
--18	delicious fancy watered-down blinking gin	2	awesome	
+-18	delicious watered-down fancy blinking gin	2	awesome	
 -19	tolerable ecto-nog	4	good	
--20	artisanal watered-down hot toady	2	EPIC	
--21	smooth weak huge hot choculate	2	awesome	
+-20	watered-down artisanal hot toady	2	EPIC	
+-21	weak smooth huge hot choculate	2	awesome	
 -49	weak lousy Cyder	2	decent	
--50	weak tolerable huge Oil Nog	2	good	
+-50	tolerable weak huge Oil Nog	2	good	
 -51	hand-crafted Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	tolerable Grimacider	3	good	
 -59	lousy blue Isotope Nog	4	decent	
--60	bad weak Mutagin 'n' Tonic	2	decent	
--70	artisanal enchanted strong Gin and Herring	5	EPIC	
--71	fancy weak bad squat Black and Tan and Red All Over	2	decent	
+-60	weak bad Mutagin 'n' Tonic	2	decent	
+-70	artisanal strong enchanted Gin and Herring	5	EPIC	
+-71	weak fancy bad squat Black and Tan and Red All Over	2	decent	
 -72	fancy bad Antarctic Ice Tea	3	decent	
--76	fortified acceptable CRIMBCO Ribbon Candy Schnapps	5	good	
--77	watered-down perfectly mixed CRIMBCO Egg Substitute Nog Substitute	2	EPIC	
+-76	acceptable fortified CRIMBCO Ribbon Candy Schnapps	5	good	
+-77	perfectly mixed watered-down CRIMBCO Egg Substitute Nog Substitute	2	EPIC	
 -78	drinkable CRIMBCO Extreme Braincracker Sour	3	good	
--82	weak drinkable Horseradish-infused Vodka	2	good	
+-82	drinkable weak Horseradish-infused Vodka	2	good	
 -83	artisanal weak jittery Jerkitini	2	EPIC	
 -84	bad practically non-alcoholic Desert Island Iced Tea	1	decent	
 -88	lousy Crimbo Saketini	3	decent	
 -89	drinkable Crimboku Drop	3	good	
--90	enchanted acceptable pulsating Flaming Crimbo Log	3	good	
+-90	acceptable enchanted pulsating Flaming Crimbo Log	3	good	
 -107	mediocre bouncing Fortified Eggnog Slurry	3	decent	
 -108	lousy boozy Hot Buttered Rum	5	decent	
 -109	drinkable Spicy Hot Chocolate	3	good	

--- a/data/TCRS/TCRS_Pastamancer_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Vole_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	moldy Peche a la Frog	4	crappy	
--2	special miniature flavorless As Jus Gezund Heit	2	decent	
+-2	flavorless miniature special As Jus Gezund Heit	2	decent	
 -3	decent blurry Bouillabaise Coucher Avec Moi	3	good	
 -7	decent small gumdrop chow mein	2	good	
 -8	decent immense candy cane pizza	8	good	
 -9	jumbo stale gingerbread stir-fry	5	decent	
--10	rotten half-sized twigs and gravel	2	crappy	
+-10	half-sized rotten twigs and gravel	2	crappy	
 -11	adequate shoots and leaves	4	good	
--12	yummy enchanted jumbo bowl of unidentifiable goo	5	awesome	
--13	adequate miniature squat gingerbread massacre	2	good	
+-12	yummy jumbo enchanted bowl of unidentifiable goo	5	awesome	
+-13	miniature adequate squat gingerbread massacre	2	good	
 -14	adequate It Came From Beyond Dessert	3	good	
 -15	moldy small narrow vampire cake	2	crappy	
 -52	moldy low-calorie upside-down Soylent Red and Green	1	crappy	
 -53	toothsome Disc-Shaped Nutrition Unit	3	awesome	
--54	decent miniature Gingerborg Hive	2	good	
--61	rotten miniature Candy Cane Surprise	2	crappy	
+-54	miniature decent Gingerborg Hive	2	good	
+-61	miniature rotten Candy Cane Surprise	2	crappy	
 -62	adequate mirror Grimdrop Chow Mein	4	good	
 -63	decent miniature Grimgerbread House	2	good	
--67	moldy small tumbling Caviar Carbonara	2	crappy	
+-67	small moldy tumbling Caviar Carbonara	2	crappy	
 -68	bland Halibut Alfredo	3	decent	
 -69	adequate Red Herring Velvet Cake	4	good	
 -73	tasty CRIMBCO Reconstituted Gruel	3	awesome	
 -74	toothsome big purple New and Improved CRIMBCO Reconstituted Gruel	5	awesome	
--75	enchanted normal CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
+-75	normal enchanted CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
 -79	moldy Brussels Sprout Stir-Fry	3	crappy	
--80	flavorless snack-sized narrow shaking Carrot, Cabbage, and Kale Pizza	2	decent	
+-80	snack-sized flavorless narrow shaking Carrot, Cabbage, and Kale Pizza	2	decent	
 -81	stale big Turnip and Rutabaga Pie	5	decent	
 -85	stale green Rainbow Spider Fun Roll	3	decent	
 -86	rotten Vegas Volcano Lava Roll	4	crappy	
 -87	immense spoiled cyan Crazy Dragon Shogun Buddha Roll	9	crappy	
 -92	spoiled tiny basic hot dog	1	crappy	
--93	moldy small pulsating savage macho dog	2	crappy	
+-93	small moldy pulsating savage macho dog	2	crappy	
 -94	normal one with everything	4	good	
--95	flavorless miniature olive narrow sly dog	2	decent	
+-95	flavorless miniature narrow olive sly dog	2	decent	
 -96	moldy half-sized tumbling devil dog	2	crappy	
--97	flavorless tiny yellow bouncing chilly dog	1	decent	
--98	adequate thick narrow ghost dog	5	good	
+-97	tiny flavorless bouncing yellow chilly dog	1	decent	
+-98	thick adequate narrow ghost dog	5	good	
 -99	stale junkyard dog	3	decent	
 -100	adequate wet dog	3	good	
--101	rotten enchanted shaking sleeping dog	4	crappy	
+-101	enchanted rotten shaking sleeping dog	4	crappy	
 -102	normal super-sized optimal dog	5	good	
 -103	snack-sized flavorless video games hot dog	2	decent	
 -104	rotten spinning Peppermint Nutrition Block	3	crappy	
--105	flavorless small Gingerbread Nutrition Block	2	decent	
+-105	small flavorless Gingerbread Nutrition Block	2	decent	
 -106	rotten blinking Cinnamon Nutrition Block	3	crappy	

--- a/data/TCRS/TCRS_Pastamancer_Wallaby.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wallaby.txt
@@ -11,7 +11,7 @@
 11	maroon stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	pickled maroon moxie weed	1		
-15	modified shaking gray strongness elixir	1		
+15	modified gray shaking strongness elixir	1		
 16	distilled upside-down jittery magicalness-in-a-can	1		
 17	rotten noodles	4	crappy	
 18	tortoise's blessing	0		
@@ -42,10 +42,10 @@
 43	skewed worthless trinket	0		
 44	worthless gewgaw	0		
 45	mirror worthless knick-knack	0		
-46	purple wobbly figurine	0		
+46	wobbly purple figurine	0		
 47	normal hot buttered roll	3	good	
 48	heart of rock and roll	0		
-49	rotten special bowl of cottage cheese	3	crappy	Effect: "Become Superficially interested", Effect Duration: 45
+49	special rotten bowl of cottage cheese	3	crappy	Effect: "Become Superficially interested", Effect Duration: 45
 50	teal upside-down clever Rock and Roll Legend	0		Maximum MP: +20, Class: "Accordion Thief", Song Duration: 10
 51	manspreader's Knob Goblin Uberpants	0		Monster Level: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -62,7 +62,7 @@
 63	action figure body	0		
 64	action figure head	0		
 65	Mighty Bjorn action figure	0		
-66	huge bouncing twig	0		
+66	bouncing huge twig	0		
 67	spaghetti with rock-balls	0		
 68	bouncing frightening savvy Pasta Spoon of Peril	0		Mysticality Percent: +20, Spooky Damage: +5, Class: "Pastamancer"
 69	Newbiesport&trade; tent	0		
@@ -77,7 +77,7 @@
 78	ghostly Jim Carey's pretty bouquet	0		Monster Level: +25
 79	spinning bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	twirling fairy gravy boat	0		
-81	acceptable irresponsibly strong ice-cold Willer	7	good	
+81	irresponsibly strong acceptable ice-cold Willer	7	good	
 82	ring	0		
 83	bouncing shaft	0		
 84	huge Orcish meat locker	0		
@@ -113,7 +113,7 @@
 114	red coward's dripping meat staff	0		Monster Level: -20
 115	extremely unsafe dripping meat crossbow	0		Weapon Damage Percent: +100
 116	skewed beefcake's beefy Bugfinder Blade	0		Muscle: 35
-117	shaking olive Gnollish plunger	0		
+117	olive shaking Gnollish plunger	0		
 118	spring	0		
 119	lime green sprocket	0		
 120	cog	0		
@@ -122,7 +122,7 @@
 123	Gnollish flyswatter	0		
 124	tumbling empty meat tank	0		
 125	full meat tank	0		
-126	ghostly purple mirror meat engine	0		
+126	mirror ghostly purple meat engine	0		
 127	Gnollish autoplunger of bravery	0		Spooky Resistance: +5
 128	Jim Carey's meat pants	0		Monster Level: +25, Familiar Effect: "2xPotato, cap 11"
 129	Usain Bolt's third-hand nunchaku	0		Initiative: +80
@@ -130,10 +130,10 @@
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
 133	twirling purple Certificate of Participation	0		
-134	narrow shaking bitchin' meatcar	0		
+134	shaking narrow bitchin' meatcar	0		
 135	sweet rims	0		
-136	jittery squat tires	0		
-137	spinning yellow dope wheels	0		
+136	squat jittery tires	0		
+137	yellow spinning dope wheels	0		
 138	ice-cold six-pack	0		
 139	skewed valuable trinket	0		
 140	jittery dingy planks	0		
@@ -162,16 +162,16 @@
 163	skeleton bone of the sewer	0		Stench Damage: +25
 164	jittery wobbly smart skull	0		
 165	skewer	0		
-166	spinning lime green ghuol ears	0		
+166	lime green spinning ghuol ears	0		
 167	decent ghuol-ear kabob	4	good	
 168	blinking lion tamer's bone rattle	0		Experience (familiar): +2
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	bouncing lihc eye	0		
 171	small bland lihc eye pie	2	decent	
-172	green upside-down gnoll lips	0		
+172	upside-down green gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
-175	miniature adequate bouncing uncooked chorizo	2	good	
+175	adequate miniature bouncing uncooked chorizo	2	good	
 176	disembodied brain	0		
 177	spinning cyan brainy skull	0		
 178	bouncing twirling detective skull	0		
@@ -196,7 +196,7 @@
 198	rat appendix	0		
 199	Jeselnik's ring	0		Sleaze Damage: +25
 200	decent rat appendix kabob	4	good	
-201	flavorless half-sized skewed bat wing kabob	2	decent	
+201	half-sized flavorless skewed bat wing kabob	2	decent	
 202	flavorless huge carob chunks	4	decent	
 203	herbs	0		
 204	adequate carob chunk cookies	3	good	
@@ -229,11 +229,11 @@
 231	Doc Galaktik's Pungent Unguent	0		
 232	blinking Doc Galaktik's Ailment Ointment	0		
 233	Doc Galaktik's Restorative Balm	0		
-234	ghostly pulsating Doc Galaktik's Homeopathic Elixir	0		
+234	pulsating ghostly Doc Galaktik's Homeopathic Elixir	0		
 235	perfumed Bigger Bugfinder Blade of Gandalf	0		Spell Critical Percent: +20, Stench Resistance: +5
 236	Queue Du Coq cocktailcrafting kit	0		
-237	lousy high-proof bottle of gin	10	decent	
-238	hand-crafted boozy bottle of vodka	5	EPIC	
+237	high-proof lousy bottle of gin	10	decent	
+238	boozy hand-crafted bottle of vodka	5	EPIC	
 239	forbidden baleful Orcish baseball cap	0		Spell Damage: +25, Spell Damage Percent: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	ribald Orcish cargo shorts of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Oprah's Orcish frat-paddle	0		Maximum MP Percent: +50
@@ -244,17 +244,17 @@
 246	adequate bite-sized tomato	1	good	
 247	fermenting powder	0		
 248	drinkable salty dog	4	good	
-249	special bad bloody mary	4	decent	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 15
+249	bad special bloody mary	4	decent	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 15
 250	practically non-alcoholic acceptable screwdriver	1	good	
-251	bad practically non-alcoholic martini	1	decent	
+251	practically non-alcoholic bad martini	1	decent	
 252	tolerable triple-distilled bloody beer	10	good	
 253	hand-crafted extra-dry olive shot of schnapps	5	EPIC	
-254	lousy practically non-alcoholic narrow shot of grapefruit schnapps	1	decent	
+254	practically non-alcoholic lousy narrow shot of grapefruit schnapps	1	decent	
 255	hand-crafted upside-down fine wine	3	EPIC	
 256	drinkable shot of tomato schnapps	4	good	
 257	mediocre extra-spicy bloody mary	3	decent	
 258	shaking dense meat stack	0		
-259	purple blinking snake skin	0		
+259	blinking purple snake skin	0		
 260	toothsome White Citadel fries	3	awesome	
 261	adequate White Citadel burger	3	good	
 262	super-sized stale piece of wedding cake	5	decent	
@@ -273,7 +273,7 @@
 275	bouncing mosquito larva	0		
 276	ghostly leprechaun hatchling	0		
 277	compressed pulsating extra-strength strongness elixir	1		
-278	powdered olive tumbling jug-o-magicalness	1		
+278	powdered tumbling olive jug-o-magicalness	1		
 279	compressed red suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	wizardly gasmask	0		Mysticality: +25, Familiar Effect: "1xBarrr, cap 12"
@@ -294,7 +294,7 @@
 296	jittery Jim Carey's dungeoneer's dungarees	0		Monster Level: +25, Familiar Effect: "stench atk, 4xPotato, cap 7"
 297	irradiated purple tamarind-flavored chewing gum	0		Effect: "Inner Dog", Effect Duration: 50
 298	frozen dry lime-and-chile-flavored chewing gum	0		Effect: "Sweet Nostalgia", Effect Duration: 16
-299	diffused super-colloidal shaking lime green pickle-flavored chewing gum	0		Effect: "Flashing Eyes", Effect Duration: 67
+299	diffused super-colloidal lime green shaking pickle-flavored chewing gum	0		Effect: "Flashing Eyes", Effect Duration: 67
 300	double-ionized oxidized green jaba&ntilde;ero-flavored chewing gum	0		Effect: "Preemptive Medicine", Effect Duration: 58
 301	flat dough	0		
 302	normal Knob sausage	3	good	
@@ -306,24 +306,24 @@
 308	maroon hale Knob Goblin elite helm	0		Maximum HP: +20, Familiar Effect: "2xFairy, cap 15"
 309	strapping Knob Goblin elite pants	0		Muscle: +5, Familiar Effect: "2xBarrr, cap 15"
 310	wool Knob Goblin elite polearm	0		Cold Resistance: +1
-311	narrow yellow hill of beans	0		
+311	yellow narrow hill of beans	0		
 312	coward's Knob Goblin visor	0		Monster Level: -20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	boxer's Crown of the Goblin King	0		Muscle Percent: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	delicious bite-sized twirling bean burrito	1	awesome	
 315	normal bouncing bean burrito	3	good	
 316	decent insanely bean burrito	3	good	
 317	toothsome bean burrito	3	awesome	
-318	decent spinning spinning mirror bean burrito	3	good	
-319	tiny stale green insanely bean burrito	1	decent	
+318	decent mirror spinning spinning bean burrito	3	good	
+319	stale tiny green insanely bean burrito	1	decent	
 320	adequate bat haggis	3	good	
 321	tiny decent menudo	1	good	
 322	stale goat cheese	4	decent	
 323	normal fuchsia plain pizza	4	good	
 324	stale blue sausage pizza	4	decent	
-325	bland half-sized shaking goat cheese pizza	2	decent	
-326	low-calorie stale mushroom pizza	1	decent	
-327	cyan tumbling goat	0		
-328	lousy special bottle of whiskey	4	decent	Effect: "Weird Vibrations", Effect Duration: 15
+325	half-sized bland shaking goat cheese pizza	2	decent	
+326	stale low-calorie mushroom pizza	1	decent	
+327	tumbling cyan goat	0		
+328	special lousy bottle of whiskey	4	decent	Effect: "Weird Vibrations", Effect Duration: 15
 329	thinker's goat beard	0		Mysticality: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	EPIC	
 331	artisanal practically non-alcoholic pulsating Canadian	1	EPIC	
@@ -404,7 +404,7 @@
 406	tumbling pirate pelvis	0		
 407	shaking pirate skull	0		
 408	pirate skeleton	0		
-409	twirling fuchsia vial of patchouli oil	0		
+409	fuchsia twirling vial of patchouli oil	0		
 410	sk8board of the overflowing toilet	0		Stench Spell Damage: +50
 411	Jolly Roger charrrm	0		
 412	squat barrrnacle	0		
@@ -432,7 +432,7 @@
 434	green arcane researcher's balloon helmet	0		Experience Percent (Mysticality): +10, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	groovy balloon sword of the early riser	0		Moxie Percent: +10, Adventures: +7, Clowniness: 50
 436	bouncing green balloon monkey	0		
-437	skewed tumbling chef skull	0		
+437	tumbling skewed chef skull	0		
 438	blurry chef-in-the-box	0		
 439	blurry bartender skull	0		
 440	bartender-in-the-box	0		
@@ -455,17 +455,17 @@
 457	wobbly steel-toed ye olde golde frontes	0		Damage Reduction: 9, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
-460	skewed mirror pixel	0		
+460	mirror skewed pixel	0		
 461	pixel	0		
 462	pixel	0		
 463	pixel	0		
 464	pixel potion	0		
-465	ghostly narrow maroon pixel potion	0		
+465	narrow ghostly maroon pixel potion	0		
 466	pixel potion	0		
 467	flavorless pixel pie	3	decent	
 468	ghostly blurry ruby W	0		
 469	wussiness potion	0		
-470	spirit-forward acceptable huge Imp Ale	5	good	
+470	acceptable spirit-forward huge Imp Ale	5	good	
 471	super-sized decent pulsating hot wing	5	good	
 472	Samson's diamond-studded cane	0		Experience (Muscle): +5, Class: "Disco Bandit"
 473	crutch of bravery	0		Spooky Resistance: +5
@@ -475,7 +475,7 @@
 477	blinking Tesla wicked infernal insoles	0		Spell Damage: +5, MP Regen Min: 7, MP Regen Max: 10
 478	evil arch	0		
 479	dodecagram	0		
-480	upside-down mirror box of birthday candles	0		
+480	mirror upside-down box of birthday candles	0		
 481	red eldritch butterknife	0		
 482	Rosewater's Mr. Container	0		Mysticality Percent: +30, Last Available: "2004-12"
 483	rosy-cheeked Newbiesport&trade; backpack	0		Maximum HP Percent: +30, Last Available: "2004-12"
@@ -496,20 +496,20 @@
 498	enchanted flavorless papaya	4	decent	Effect: "No Worries", Effect Duration: 30
 499	cool denim axe of the sweet-tooth	0		Moxie: +5, Candy Drop: +100
 500	Elf Farm Raffle ticket	0		
-501	adequate half-sized upside-down purple Elfin shortbread	2	good	
+501	adequate half-sized purple upside-down Elfin shortbread	2	good	
 502	pagoda plans	0		
 503	stale snack-sized tumbling skewered cat appendix	2	decent	
 504	evil arches	0		
 505	asbestos-lined gnatwing earring of mayonnaise	0		Sleaze Spell Damage: +50, Hot Resistance: +5
-506	flavorless massive fancy Hell broth	7	decent	Effect: "Celestial Vision", Effect Duration: 35
+506	fancy flavorless massive Hell broth	7	decent	Effect: "Celestial Vision", Effect Duration: 35
 507	tumbling beefcake's thunderrr guitarrr	0		Muscle: +25
 508	sonata	0		
 509	blinking Hey Deze nuts	0		
-510	narrow pulsating Boris's key lime	0		
+510	pulsating narrow Boris's key lime	0		
 511	mirror Jarlsberg's key lime	0		
 512	jittery Sneaky Pete's key lime	0		
 513	moldy massive maroon Boris's key lime pie	10	crappy	
-514	diet decent Jarlsberg's key lime pie	1	good	
+514	decent diet Jarlsberg's key lime pie	1	good	
 515	stale Sneaky Pete's key lime pie	3	decent	
 516	Hey Deze map	0		
 517	blurry shaking Fonzie's bejeweled accordion strap	0		Experience (Moxie): +1, Class: "Accordion Thief"
@@ -519,7 +519,7 @@
 521	skewed blinking flame-retardant kickback cookbook	0		Hot Resistance: +1
 522	one-winged stab bat	0		
 523	olive rewinged stab bat	0		
-524	drinkable triple-distilled papaya sling	6	good	
+524	triple-distilled drinkable papaya sling	6	good	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -544,7 +544,7 @@
 546	meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
-549	jittery teal bouncing 30669 scroll	0		
+549	teal jittery bouncing 30669 scroll	0		
 550	33398 scroll	0		
 551	64067 scroll	0		
 552	64735 scroll	0		
@@ -552,27 +552,27 @@
 554	toothsome tiny lime green pr0n cocktail	1	awesome	
 555	jittery razor-sharp cool drywall axe	0		Moxie: +5, Weapon Damage Percent: +25
 556	arcane researcher's Pine-Fresh air freshener	0		Experience Percent (Mysticality): +10
-557	watered-down perfectly mixed gray whiskey and cola	2	EPIC	
-558	normal diet papaya taco	1	good	
+557	perfectly mixed watered-down gray whiskey and cola	2	EPIC	
+558	diet normal papaya taco	1	good	
 559	razor-sharp can lid	0		
 560	spoiled shaking stalk of asparagus	4	crappy	
 561	twirling pregnant mushroom	0		
 562	teal ratgut	0		
-563	green twirling sonar-in-a-biscuit	0		
+563	twirling green sonar-in-a-biscuit	0		
 564	lousy Mad Train wine	4	decent	
 565	hobo gloves of courage	0		Spooky Resistance: +3, Single Equip
 566	lime green mirror bum cheek of wisdom	0		Mysticality: +15, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	delicious red Double Bacon Beelzeburger	4	awesome	
-569	massive moldy Lord of the Flies-sized fries	8	crappy	
-570	diet stale Chicken Sandwich	1	decent	
+569	moldy massive Lord of the Flies-sized fries	8	crappy	
+570	stale diet Chicken Sandwich	1	decent	
 571	fancy bouncing Jumbo Dr. Lucifer	1	awesome	Effect: "Heart of Orange", Effect Duration: 40
 572	moldy mirror Children's Meal of the Damned	3	crappy	
-573	half-sized rotten noodles	2	crappy	
-574	massive rotten spinning noodles	6	crappy	
-575	big bland painful penne pasta	5	decent	
-576	stale jumbo ravioli della hippy	5	decent	
-577	delicious fancy pulsating pr0n m4nic0tti	3	awesome	Effect: "Night Vision", Effect Duration: 15
+573	rotten half-sized noodles	2	crappy	
+574	rotten massive spinning noodles	6	crappy	
+575	bland big painful penne pasta	5	decent	
+576	jumbo stale ravioli della hippy	5	decent	
+577	fancy delicious pulsating pr0n m4nic0tti	3	awesome	Effect: "Night Vision", Effect Duration: 15
 578	normal lime green Hell ramen	3	good	
 579	moldy boring spaghetti	3	crappy	
 580	sauce of the ages	0		
@@ -583,7 +583,7 @@
 585	normal gnocchetti di Nietzsche	4	good	
 586	Usain Bolt's deadly ridiculously huge sword	0		Weapon Damage: +5, Initiative: +80
 587	frozen modified warmed super-spiky hair gel	0		Effect: "The Strength...  of the Future", Effect Duration: 69
-588	wobbly blinking soft echo eyedrop antidote	0		
+588	blinking wobbly soft echo eyedrop antidote	0		
 589	adequate small cocoa eggshell fragment	2	good	
 590	rotten cocoa eggshell fragment	4	crappy	
 591	cocoa egg	0		
@@ -636,18 +636,18 @@
 638	medical-grade studded asshat	0		Damage Absorption: +80, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	flavorless abominable snowcone	3	decent	
 640	Ent cider	1	good	
-641	stale snack-sized toast	2	decent	
+641	snack-sized stale toast	2	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	lime green Crimbo pressie	0		Last Available: "2003-12"
 645	bouncing wrapping paper	0		Last Available: "2003-12"
-646	flavorless small fruitcake	2	decent	
+646	small flavorless fruitcake	2	decent	
 647	shaking present	0		Last Available: "2004-11"
 648	purple deadly Crimbo sword	0		Weapon Damage: +5, Last Available: "2004-10"
 649	Crimbo hat of the glutton	0		Food Drop: +100, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
 650	blinking curative Crimbo pants	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	green lard-coated exclusive ultra-rare item	0		Sleaze Spell Damage: +25
-652	spinning shaking quantum egg	0		
+652	shaking spinning quantum egg	0		
 653	intragalactic rowboat	0		
 654	star	0		
 655	line	0		
@@ -721,7 +721,7 @@
 725	one million meat pancakes	0		
 726	blinking Oprah's huge mirror shard	0		Maximum MP Percent: +50
 727	hedge maze puzzle	0		
-728	blurry skewed hedge maze key	0		
+728	skewed blurry hedge maze key	0		
 729	fishbowl	0		
 730	fishtank	0		
 731	tumbling fish hose	0		
@@ -735,22 +735,22 @@
 739	tambourine bells	0		
 740	boxer's tambourine	0		Muscle Percent: +10
 741	broken skull	0		
-742	miniature rotten Knoll shroomkabob	2	crappy	
+742	rotten miniature Knoll shroomkabob	2	crappy	
 743	normal mushroom	3	good	
 744	flattened frozen hair spray	0		Effect: "Bone Chilling", Effect Duration: 58
 746	stat script	0		
 747	spinning Knob Goblin firecracker	0		
 748	teal gourd potion	0		
 749	huge spoiled warm mushroom	6	crappy	
-750	spoiled small blurry mushroom quesadilla	2	crappy	
-751	immense moldy maroon cool mushroom	7	crappy	
+750	small spoiled blurry mushroom quesadilla	2	crappy	
+751	moldy immense maroon cool mushroom	7	crappy	
 752	enchanted adequate snack-sized tumbling cool mushroom casserole	2	good	Effect: "Tingly Wrists", Effect Duration: 5
 753	fancy rotten pointy mushroom	3	crappy	Effect: "All Branned Up", Effect Duration: 10
 754	delicious cream of pointy mushroom soup	3	awesome	
 755	enchanted spoiled mushroom	4	crappy	Effect: "Pemmican't", Effect Duration: 20
-756	huge adequate mushroom	7	good	
+756	adequate huge mushroom	7	good	
 757	spoiled mushroom	4	crappy	
-758	normal thick fancy ghost cucumber	5	good	Effect: "Favored by Lyle", Effect Duration: 40
+758	fancy thick normal ghost cucumber	5	good	Effect: "Favored by Lyle", Effect Duration: 40
 759	squat dill	0		
 760	vinegar	0		
 761	brine	0		
@@ -778,10 +778,10 @@
 783	'Villa' document	0		
 784	aged gray Acqua Del Piatto Merlot	3	awesome	Last Available: "2004-10"
 785	raffle ticket	0		
-786	delicious small mirror strawberry	2	awesome	
-787	perfectly mixed watered-down bottle of rum	2	EPIC	
+786	small delicious mirror strawberry	2	awesome	
+787	watered-down perfectly mixed bottle of rum	2	EPIC	
 788	fancy artisanal strawberry daiquiri	3	EPIC	Effect: "Icy Demeanor", Effect Duration: 15
-789	fancy tolerable twirling rum and cola	3	good	Effect: "Charrrming", Effect Duration: 10
+789	tolerable fancy twirling rum and cola	3	good	Effect: "Charrrming", Effect Duration: 10
 790	smooth grog	3	awesome	
 791	olive tumbling ghostly pulsating smelly sharpshooter's Mafia bow tie	0		Critical Hit Percent: +10, Stench Spell Damage: +10, Last Available: "2004-10"
 792	smartaleck's Golden Mr. Accessory	0		Moxie Percent: +30, Softcore Only
@@ -789,27 +789,27 @@
 794	non-pressed concentrated oil of slipperiness	0		Effect: "Human-Human Hybrid", Effect Duration: 33
 795	artisanal mirror Acque Luride Grezze Cabernet	3	super EPIC	Last Available: "2004-10"
 796	maroon wholesome smooth cement shoes of terror	0		Moxie: +15, Maximum HP Percent: +10, Spooky Spell Damage: +10, Last Available: "2004-10"
-797	irresponsibly strong acceptable rockin' wagon	6	good	
+797	acceptable irresponsibly strong rockin' wagon	6	good	
 798	drinkable ocean motion	3	good	
 799	aged fuzzbump	4	awesome	
 800	adequate poutine	4	good	
 801	rotten Knob stir-fry	3	crappy	
 804	miniature rotten Knoll stir-fry	2	crappy	
-805	fancy tiny toothsome stir-fry	1	awesome	Effect: "Thunderspell", Effect Duration: 15
+805	toothsome tiny fancy stir-fry	1	awesome	Effect: "Thunderspell", Effect Duration: 15
 806	thick flavorless asparagus stir-fry	5	decent	
-807	snack-sized tasty olive stir-fry	2	awesome	
+807	tasty snack-sized olive stir-fry	2	awesome	
 808	flavorless blinking Knob sausage stir-fry	4	decent	
 809	normal pulsating bat wing stir-fry	4	good	
-810	miniature decent shaking rat appendix stir-fry	2	good	
-811	stale big upside-down twirling tofu stir-fry	5	decent	
+810	decent miniature shaking rat appendix stir-fry	2	good	
+811	stale big twirling upside-down tofu stir-fry	5	decent	
 812	bland snack-sized pr0n stir-fry	2	decent	
-813	miniature normal mirror twirling Knob shells	2	good	
+813	miniature normal twirling mirror Knob shells	2	good	
 814	adequate purple b&auml;tzle	3	good	
-815	big stale ratini	5	decent	
+815	stale big ratini	5	decent	
 816	stale Knob stroganoff	4	decent	
 817	adequate menudo ravioli	3	good	
 818	narrow plus sign	0		
-819	fuchsia twirling milky potion	0		
+819	twirling fuchsia milky potion	0		
 820	bouncing swirly potion	0		
 821	bubbly potion	0		
 822	fuchsia smoky potion	0		
@@ -820,20 +820,20 @@
 827	shaking yellow murky potion	0		
 828	tumbling baby killer bee	0		
 829	anti-anti-antidote	0		
-830	flavorless massive royal jelly	10	decent	
+830	massive flavorless royal jelly	10	decent	
 831	small box	0		
 832	box	0		
 833	green ghostly vorpal blade of wisdom	0		Mysticality: +15
 834	family-friendly Jim Carey's cornuthaum	0		Monster Level: +25, Sleaze Resistance: +1, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	quilted ring of aggravate monster	0		Damage Absorption: +40
 836	decent fancy mind flayer corpse	3	good	Effect: "Pretending to Pretend", Effect Duration: 20
-837	weak artisanal special shaking twirling Uovo Marcio Shiraz	2	super ultra mega EPIC	Effect: "Leash of Linguini", Effect Duration: 40, Last Available: "2004-10"
+837	special weak artisanal shaking twirling Uovo Marcio Shiraz	2	super ultra mega EPIC	Effect: "Leash of Linguini", Effect Duration: 40, Last Available: "2004-10"
 838	flame-retardant cool Mafia stogie	0		Moxie: +5, Hot Resistance: +1, Last Available: "2004-10"
 839	delicious Maiali Sifilitici Pinot Noir	4	awesome	Last Available: "2004-10"
 840	prompt Mafia violin case of the empath	0		Familiar Weight: +5, Adventures: +3, Last Available: "2004-10"
 841	mediocre tomato daiquiri	4	decent	
 842	tolerable beertini	3	good	
-843	watered-down artisanal salty slug	2	EPIC	
+843	artisanal watered-down salty slug	2	EPIC	
 844	artisanal papaya slung	3	EPIC	
 845	resourceful MAHI fez	0		Maximum MP: +50, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -845,7 +845,7 @@
 853	blundarrrbus	0		Familiar Weight: +5
 854	mirror sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
-856	shaking purple shock collar	0		
+856	purple shaking shock collar	0		
 857	jittery moonglasses	0		
 858	wobbly palm-frond toupee	0		Familiar Weight: +5
 859	knife and fork	0		Familiar Weight: +5
@@ -889,7 +889,7 @@
 898	Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
-901	pulsating red espresso maker	0		Familiar Weight: +5
+901	red pulsating espresso maker	0		Familiar Weight: +5
 902	red 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	watered-down lousy spinning Spasmi Dolorosi Del Rene Champagne	2	decent	Last Available: "2004-10"
 904	wobbly Lo Pan's school Mafia knickerbockers of the sewer of the sweet-tooth	0		Spell Critical Percent: +30, Stench Damage: +25, Candy Drop: +100, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
@@ -909,16 +909,16 @@
 918	Radio Free Baseball Cap of the early riser	0		Adventures: +7, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	Radio Free Pants of horror	0		Spooky Spell Damage: +25, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	asbestos-lined Radio Free Foil	0		Hot Resistance: +5, Last Available: "2006-07"
-921	stale miniature radio button candy	2	decent	
+921	miniature stale radio button candy	2	decent	
 922	lightning-fast severed rocking horse head	0		Initiative: +40
 923	broken cellular phone	0		Last Available: "2004-01"
-924	red mirror mirror crimbo elfling	0		Free Pull, Last Available: "2011-12"
+924	mirror red mirror crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	tarnished twirling Hawking's Elixir of Brilliance	0		Effect: "Wallflowering", Effect Duration: 19
 927	acceptable spirit-forward Ferita Del Petto Zinfandel	5	good	Last Available: "2006-12"
 928	mansplainer's fuzzy bracelets	0		Monster Level: +15
 929	energetic arse-shooting crossbow	0		Maximum MP Percent: +20
-931	tolerable weak narrow spiced rum	2	good	
+931	weak tolerable narrow spiced rum	2	good	
 932	hand-crafted extra-dry eggnog	5	EPIC	
 933	flavorless blinking candy cane	4	decent	
 934	adequate gingerbread bugbear	3	good	
@@ -944,7 +944,7 @@
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	blurry Temple Grandin's fez of etymology	0		Familiar Weight: +7, Familiar Effect: "1xLep, cap 30"
 956	spoiled mirror carob chunk noodles	4	crappy	
-957	decent special big twirling maroon chorizo brownies	5	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 15
+957	special decent big twirling maroon chorizo brownies	5	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 15
 958	moldy chocolate and tomato pizza	4	crappy	
 959	flange	0		
 960	gray clockwork key	0		
@@ -988,28 +988,28 @@
 1000	Meat maid	0		
 1002	frightening Xlyinia's notebook	0		Spooky Damage: +5
 1003	twirling soda water	0		
-1004	hand-crafted high-proof bottle of tequila	10	EPIC	
+1004	high-proof hand-crafted bottle of tequila	10	EPIC	
 1005	acceptable boxed wine	4	good	
-1006	immense stale cherry	10	decent	
+1006	stale immense cherry	10	decent	
 1007	experienced coconut shell	0		Experience: +2, Familiar Effect: "1xFairy, cap 7"
 1008	jittery reassuring ice cubes	0		Spooky Resistance: +1
 1009	drinkable weak blinking vodka martini	2	good	
 1010	drinkable whiskey and soda	3	good	
-1011	strong bad blurry monkey wrench	5	decent	
+1011	bad strong blurry monkey wrench	5	decent	
 1012	acceptable tequila sunrise	4	good	
-1013	perfectly mixed practically non-alcoholic margarita	1	EPIC	
+1013	practically non-alcoholic perfectly mixed margarita	1	EPIC	
 1014	mediocre watered-down tumbling strawberry wine	2	decent	
 1015	tolerable wine spritzer	3	good	
 1016	acceptable lime green perpendicular hula	3	good	
-1017	practically non-alcoholic bad ducha de oro	1	decent	
-1018	practically non-alcoholic bad fuchsia calle de miel	1	decent	
+1017	bad practically non-alcoholic ducha de oro	1	decent	
+1018	bad practically non-alcoholic fuchsia calle de miel	1	decent	
 1019	hand-crafted dry vodka martini	3	EPIC	
 1020	drinkable old-fashioned	4	good	
 1021	mediocre tumbling tequila with training wheels	4	decent	
-1022	triple-distilled drinkable twirling sangria	6	good	
+1022	drinkable triple-distilled twirling sangria	6	good	
 1023	artisanal vesper	3	super ultra EPIC	Last Available: "2004-12"
 1024	perfectly mixed bodyslam	3	super ultra EPIC	Last Available: "2004-12"
-1025	fortified delicious jittery sangria del diablo	5	awesome	Last Available: "2004-12"
+1025	delicious fortified jittery sangria del diablo	5	awesome	Last Available: "2004-12"
 1026	twirling Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1032,9 +1032,9 @@
 1046	wobbly scorching dog trainer's traffic cone	0		Experience (familiar): +1, Hot Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	aged yellow N. O. Beer	3	awesome	
 1048	compressed oyster egg	1		
-1049	vaporized blinking huge oyster egg	1		Effect: "Corruption of Wretched Wally", Effect Duration: 50
+1049	vaporized huge blinking oyster egg	1		Effect: "Corruption of Wretched Wally", Effect Duration: 50
 1050	denatured blurry blurry oyster egg	1		Effect: "5 Pounds Lighter", Effect Duration: 20
-1051	upside-down twirling plastic oyster egg	0		
+1051	twirling upside-down plastic oyster egg	0		
 1052	dried oyster egg	1		
 1053	distilled squat oyster egg	1		
 1054	diluted maroon oyster egg	1		Effect: "Fishy", Effect Duration: 45
@@ -1044,7 +1044,7 @@
 1058	mixed mirror puce oyster egg	1		
 1059	skewed puce plastic oyster egg	0		
 1060	distilled squat mauve oyster egg	1		Effect: "Big Ol' Glass of Rum", Effect Duration: 45
-1061	compressed squat blurry mauve oyster egg	1		
+1061	compressed blurry squat mauve oyster egg	1		
 1062	powdered mauve oyster egg	1		Effect: "Gyromitra Gymnastics", Effect Duration: 25
 1063	mauve plastic oyster egg	0		
 1064	boiled huge oyster egg	1		
@@ -1053,7 +1053,7 @@
 1067	plastic oyster egg	0		
 1068	altered upside-down oyster egg	1		
 1069	modified wobbly oyster egg	1		
-1070	denatured jittery blue oyster egg	1		
+1070	denatured blue jittery oyster egg	1		
 1071	plastic oyster egg	0		
 1072	boiled off-white oyster egg	1		
 1073	altered wobbly off-white oyster egg	1		
@@ -1096,7 +1096,7 @@
 1110	blurry clockwork chef-head-in-the-box	0		
 1111	twirling clockwork bartender-in-the-box	0		
 1112	jittery clockwork chef-in-the-box	0		
-1113	spinning bouncing upside-down clockwork maid	0		
+1113	spinning upside-down bouncing clockwork maid	0		
 1114	tisket	0		
 1115	tasket	0		
 1116	annoying pitchfork	0		Monster Level: +5
@@ -1128,15 +1128,15 @@
 1142	bad pointy mushroom wine	4	decent	
 1143	mediocre flat mushroom wine	4	decent	
 1144	drinkable triple-distilled cool mushroom wine	6	good	
-1145	watered-down perfectly mixed knob mushroom wine	2	EPIC	
-1146	watered-down acceptable green twirling knoll mushroom wine	2	good	
+1145	perfectly mixed watered-down knob mushroom wine	2	EPIC	
+1146	acceptable watered-down twirling green knoll mushroom wine	2	good	
 1147	perfectly mixed blurry mushroom wine	3	EPIC	
-1148	mediocre strong shot of flower schnapps	5	decent	
-1149	decent miniature fuchsia flower petal pie	2	good	
-1150	practically non-alcoholic lousy bottle of single-barrel whiskey	1	decent	
+1148	strong mediocre shot of flower schnapps	5	decent	
+1149	miniature decent fuchsia flower petal pie	2	good	
+1150	lousy practically non-alcoholic bottle of single-barrel whiskey	1	decent	
 1151	cyan Annie Oakley's supercharged discarded plastic fork	0		Maximum MP Percent: +30, Critical Hit Percent: +20
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	tasty small Retenez L'Herbe Pat&eacute;	2	awesome	
+1153	small tasty Retenez L'Herbe Pat&eacute;	2	awesome	
 1154	compressed blinking wobbly Breathetastic&trade; Premium Canned Air	1	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 10
 1155	skewed letter from King Ralph XI	0		
 1157	wholeberd of the businessman	0		Meat Drop: +50
@@ -1176,15 +1176,15 @@
 1191	ghuol whelp	0		
 1192	zmobie	0		
 1193	Raggedy Hippy doll	0		
-1194	upside-down ghostly purple stab bat	0		
+1194	purple upside-down ghostly stab bat	0		
 1195	apathetic lizardman doll	0		
 1196	yeti	0		
 1197	Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	stale mugcake	3	decent	
-1201	snack-sized spoiled urinal cake	2	crappy	
-1202	gigantic rotten narrow Happy Birthday, Claude! cake	9	crappy	
+1201	spoiled snack-sized urinal cake	2	crappy	
+1202	rotten gigantic narrow Happy Birthday, Claude! cake	9	crappy	
 1203	normal diet upside-down personalized birthday cake	1	good	
 1204	spoiled small three-tiered wedding cake	2	crappy	
 1205	flavorless tumbling babycakes	3	decent	
@@ -1224,7 +1224,7 @@
 1240	limburger biker boots	0		Familiar Weight: +5
 1241	upside-down carton of clove cigarettes	0		Familiar Weight: +5
 1242	deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
-1243	wobbly twirling toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
+1243	twirling wobbly toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
 1244	energetic Glass Balls of the Goblin King	0		Maximum MP Percent: +20
 1245	wool Codpiece of the Goblin King	0		Cold Resistance: +1, Single Equip
 1246	skewed mirror scandalous mansplainer's grievous rib of the Bonerdagon	0		Weapon Damage Percent: +50, Monster Level: +15, Sleaze Damage: +5
@@ -1232,14 +1232,14 @@
 1248	cyan asbestos-lined sage Bonerdagon necklace of the cheetah	0		Mysticality Percent: +10, Hot Resistance: +5, Initiative: +60
 1249	Boss Bat britches of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	scorching Lo Pan's Boss Bat bling	0		Spell Critical Percent: +30, Hot Damage: +25
-1251	toothsome snack-sized fuchsia Knob shroomkabob	2	awesome	
+1251	snack-sized toothsome fuchsia Knob shroomkabob	2	awesome	
 1252	low-calorie spoiled shroomkabob	1	crappy	
 1253	pile of jumping beans	0		
 1254	bland fancy jittery jumping bean burrito	3	decent	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20
 1255	stale jumping bean burrito	3	decent	
 1256	adequate upside-down insanely jumping bean burrito	4	good	
 1257	adequate rat scrapple	3	good	
-1258	narrow blurry pail of pretentious paint	0		
+1258	blurry narrow pail of pretentious paint	0		
 1259	aromatic careful traffic cone	0		Monster Level: -10, Stench Resistance: +1, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	denatured spinning narrow Hatorade	1		
@@ -1332,10 +1332,10 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	blinking quilted pinky ring	0		Damage Absorption: +40, Single Equip
-1352	lousy enchanted practically non-alcoholic redrum	1	decent	Effect: "Weather, Man", Effect Duration: 30
+1352	enchanted practically non-alcoholic lousy redrum	1	decent	Effect: "Weather, Man", Effect Duration: 30
 1353	ninja pirate zombie robot	0		
 1354	mirror pile of pebbles	0		
-1355	adequate tiny bowl of oriole's nest soup	1	good	
+1355	tiny adequate bowl of oriole's nest soup	1	good	
 1356	skewed bunny liver	0		
 1357	acceptable Mt. Noob Pale Ale	4	good	
 1358	pirate zombie head	0		Last Available: "2005-11"
@@ -1386,7 +1386,7 @@
 1404	colored-light &quot;necklace&quot; of the dark arts	0		Spell Damage Percent: +100, Last Available: "2005-12"
 1405	narrow razor-sharp tree skirt	0		Weapon Damage Percent: +25, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	yummy wreath-shaped Crimbo cookie	4	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	delicious lime green squat bell-shaped Crimbo cookie	3	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	delicious squat lime green bell-shaped Crimbo cookie	3	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	rotten jumbo tree-shaped Crimbo cookie	5	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	spinning censurious Unionize The Elves sign	0		Sleaze Resistance: +3, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
@@ -1407,11 +1407,11 @@
 1425	skewed quilted ice baby	0		Damage Absorption: +40, Softcore Only, Last Available: "2006-02"
 1426	twirling Jeselnik's ice pick	0		Sleaze Damage: +25, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	gravedigger's ice skates of the cougar	0		Moxie: +20, Spooky Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	special half-sized decent grue egg omelette	2	good	Effect: "Booooooze", Effect Duration: 15
+1428	half-sized special decent grue egg omelette	2	good	Effect: "Booooooze", Effect Duration: 15
 1429	pulsating roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	adequate snack-sized bouncing mirror mushroom	2	good	
+1432	snack-sized adequate bouncing mirror mushroom	2	good	
 1433	fruit bowl	0		
 1434	wobbly fruit basket	0		
 1435	olive jittery hot pink lipstick	0		Familiar Weight: +5
@@ -1422,7 +1422,7 @@
 1440	galvanized pressed powder	0		Effect: "Enraged", Effect Duration: 58
 1441	alkaline yellow powder	0		Effect: "Headstrong", Effect Duration: 28
 1442	alkaline tumbling stench powder	0		Effect: "Pisces Rising", Effect Duration: 23
-1443	denatured pressed huge upside-down sleaze powder	0		Effect: "Feline Ferocity", Effect Duration: 39
+1443	denatured pressed upside-down huge sleaze powder	0		Effect: "Feline Ferocity", Effect Duration: 39
 1444	liquefied activated twinkly nuggets	0		Effect: "Void Between the Stars", Effect Duration: 44
 1445	concentrated hot nuggets	0		Effect: "Pumped Up", Effect Duration: 36
 1446	oxidized nuggets	0		Effect: "You Know What's Up", Effect Duration: 17
@@ -1430,10 +1430,10 @@
 1448	triple-adjusted activated warmed stench nuggets	0		Effect: "Stinkybeard", Effect Duration: 15
 1449	activated wobbly sleaze nuggets	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 52
 1450	altered skewed twinkly wad	1		Effect: "Fireproof Lips", Effect Duration: 15
-1451	dried twirling blurry twirling hot wad	1		Effect: "Steroid Boost", Effect Duration: 15
+1451	dried twirling twirling blurry hot wad	1		Effect: "Steroid Boost", Effect Duration: 15
 1452	denatured narrow wad	1		
 1453	powdered wad	1		Effect: "Toothy Grin", Effect Duration: 30
-1454	mixed upside-down bouncing stench wad	1		
+1454	mixed bouncing upside-down stench wad	1		
 1455	vaporized upside-down tumbling red sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
@@ -1480,14 +1480,14 @@
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	upside-down whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
-1501	activated fuchsia skewed explosion-flavored chewing gum	0		Effect: "Red Misty-Eyed", Effect Duration: 38, Last Available: "2006-04"
+1501	activated skewed fuchsia explosion-flavored chewing gum	0		Effect: "Red Misty-Eyed", Effect Duration: 38, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	jittery mirror rubber emo roe	0		Last Available: "2006-04"
 1504	dry anodized snowcone	0		Effect: "Human-Elf Hybrid", Effect Duration: 42, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	drinkable extra-dry calle de miel with a fly in it	5	good	Last Available: "2006-04"
+1506	extra-dry drinkable calle de miel with a fly in it	5	good	Last Available: "2006-04"
 1507	drinkable rockin' wagon with a fly in it	4	good	Last Available: "2006-04"
-1508	acceptable twirling pulsating perpendicular hula with a fly in it	4	good	Last Available: "2006-04"
+1508	acceptable pulsating twirling perpendicular hula with a fly in it	4	good	Last Available: "2006-04"
 1509	bad slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
 1510	yellow bag of airline peanuts	0		Last Available: "2006-04"
 1511	perfumed fake hand	0		Stench Resistance: +5, Last Available: "2006-04"
@@ -1503,7 +1503,7 @@
 1522	skewed perfumed scandalous Radio Free Jersey	0		Sleaze Damage: +5, Stench Resistance: +5
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	twirling joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	twirling joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	mirror ruddy corkscrew of the blizzard	0		Maximum HP Percent: +40, Cold Spell Damage: +25, Last Available: "2006-04"
@@ -1532,22 +1532,22 @@
 1552	watered-down drinkable bouncing bottle of Definit	2	good	
 1553	hand-crafted spinning bottle of Calcutta Emerald	3	EPIC	
 1554	hand-crafted irresponsibly strong bottle of Lieutenant Freeman	9	EPIC	
-1555	drinkable weak spinning bottle of Jorge Sinsonte	2	good	
+1555	weak drinkable spinning bottle of Jorge Sinsonte	2	good	
 1556	bad boxed champagne	4	decent	
 1557	small adequate kumquat	2	good	
-1558	bite-sized decent purple tangerine	1	good	
+1558	decent bite-sized purple tangerine	1	good	
 1559	squat tonic water	0		
 1560	decent cocktail onion	3	good	
 1561	toothsome raspberry	3	awesome	
 1562	spoiled narrow kiwi	3	crappy	
-1563	irresponsibly strong artisanal whiskey bittersweet	9	EPIC	
+1563	artisanal irresponsibly strong whiskey bittersweet	9	EPIC	
 1564	acceptable practically non-alcoholic mimosette	1	good	
 1565	smooth tequila sunset	3	awesome	
 1566	bad red spinning zmobie	4	decent	Wiki Name: "Zmobie (drink)"
 1567	drinkable gray gin and tonic	4	good	
-1568	lousy fortified vodka and tonic	5	decent	
+1568	fortified lousy vodka and tonic	5	decent	
 1569	acceptable wobbly vodka gibson	3	good	
-1570	aged spirit-forward gibson	5	awesome	
+1570	spirit-forward aged gibson	5	awesome	
 1571	perfectly mixed parisian cathouse	3	EPIC	
 1572	delicious fancy ghostly rabbit punch	3	awesome	Effect: "Full of Vinegar", Effect Duration: 40
 1573	smooth squat caipifruta	3	awesome	
@@ -1559,32 +1559,32 @@
 1579	artisanal gimlet	4	EPIC	
 1580	perfectly mixed brick road	3	EPIC	
 1581	hand-crafted vodka stratocaster	4	EPIC	
-1582	mediocre weak Neuromancer	2	decent	
+1582	weak mediocre Neuromancer	2	decent	
 1583	aged spirit-forward prussian cathouse	5	awesome	
-1584	irresponsibly strong tolerable bouncing Mae West	9	good	
-1585	weak lousy shaking Mon Tiki	2	decent	
-1586	special acceptable narrow teqiwila slammer	3	good	Effect: "Hot Buttoned", Effect Duration: 10
+1584	tolerable irresponsibly strong bouncing Mae West	9	good	
+1585	lousy weak shaking Mon Tiki	2	decent	
+1586	acceptable special narrow teqiwila slammer	3	good	Effect: "Hot Buttoned", Effect Duration: 10
 1587	stale Knob lo mein	4	decent	
 1588	normal huge asparagus lo mein	4	good	
 1589	snack-sized moldy twirling Knoll lo mein	2	crappy	
 1590	moldy thick lo mein	5	crappy	
 1591	stale olive lo mein	3	decent	
-1592	jumbo rotten fancy spinning hot hi mein	5	crappy	Effect: "Bread-Lined", Effect Duration: 5
+1592	fancy jumbo rotten spinning hot hi mein	5	crappy	Effect: "Bread-Lined", Effect Duration: 5
 1593	tasty mirror hi mein	3	awesome	
 1594	decent hi mein	4	good	
-1595	bland half-sized hi mein	2	decent	
-1596	special spoiled small sleazy hi mein	2	crappy	Effect: "Tasting the Rainbow", Effect Duration: 20
+1595	half-sized bland hi mein	2	decent	
+1596	spoiled small special sleazy hi mein	2	crappy	Effect: "Tasting the Rainbow", Effect Duration: 20
 1597	resourceful Junior LAAAAME merit badge	0		Maximum MP: +50, Last Available: "2006-05"
 1598	blurry Senior LAAAAME merit badge of bravery	0		Spooky Resistance: +5, Last Available: "2006-05"
 1599	pulsating jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	delicious weak tangarita with a fly in it	2	awesome	
+1600	weak delicious tangarita with a fly in it	2	awesome	
 1601	bad mandarina colada with a fly in it	4	decent	
 1602	lousy triple-distilled prussian cathouse with a fly in it	6	decent	
 1603	hand-crafted Mae West with a fly in it	3	EPIC	
 1604	powdered astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	denatured ultimate wad	1		
-1607	dry dry ghostly jittery libation of liveliness	0		Effect: "Well Owl Be!", Effect Duration: 61
+1607	dry dry jittery ghostly libation of liveliness	0		Effect: "Well Owl Be!", Effect Duration: 61
 1608	non-ionized energized altered eyedrops of the ermine	0		Effect: "What's That Smell?", Effect Duration: 23
 1609	quantum perfume of prejudice	0		Effect: "Voracious Gorging", Effect Duration: 41
 1610	enhanced warmed eyedrops of the ocelot	0		Effect: "Adorable Lookout", Effect Duration: 19
@@ -1609,7 +1609,7 @@
 1629	ribald raspberry beret	0		Sleaze Damage: +10, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	pixel shield of the brazier	0		Hot Spell Damage: +25, Damage Reduction: 3
 1631	beer cartilage	0		
-1632	narrow ghostly Spanish fly trap	0		
+1632	ghostly narrow Spanish fly trap	0		
 1633	Spanish fly	0		
 1634	mediocre jittery around the world	3	decent	
 1635	scrumdiddlyumptious solution	0		
@@ -1620,7 +1620,7 @@
 1640	anodized corrupted lotion of stench	0		Effect: "Swordholder", Effect Duration: 26
 1641	activated lotion of sleaziness	0		Effect: "[800]Chocolate Reign", Effect Duration: 63
 1642	aged Grimacite Bock	3	awesome	Last Available: "2008-11"
-1643	decent special wedge of gray cheese	3	good	Effect: "Slimy Flavor", Effect Duration: 25, Last Available: "2008-11"
+1643	special decent wedge of gray cheese	3	good	Effect: "Slimy Flavor", Effect Duration: 25, Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	squat and sauce	0		
 1646	blurry and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	bland foie gras	3	decent	
 1652	enhanced shaking twirling candy brain	0		Effect: "Antarctic Memories", Effect Duration: 47, Last Available: "2020-09"
-1653	Temple Grandin's steel-toed jewel-eyed wizard hat of the sweet-tooth	0		Damage Reduction: 9, Familiar Weight: +7, Candy Drop: +100, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1653	Temple Grandin's steel-toed jewel-eyed wizard hat of the sweet-tooth	0		Damage Reduction: 9, Familiar Weight: +7, Candy Drop: +100, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	wobbly avaricious extremely unsafe wad of Crovacite	0		Weapon Damage Percent: +100, Meat Drop: +30
 1655	upside-down frightening wholesome collar	0		Maximum HP Percent: +10, Spooky Damage: +5
 1656	squat White Citadel Satisfaction Satchel	0		
@@ -1702,7 +1702,7 @@
 1722	wool dog trainer's glistening staff	0		Experience (familiar): +1, Cold Resistance: +1
 1723	bouncing auspicious repeating crossbow	0		Item Drop: 15
 1725	mirror bigger stick	0		
-1726	cyan skewed sinewy crossbow string	0		
+1726	skewed cyan sinewy crossbow string	0		
 1727	gray sturdy sword hilt	0		
 1728	wobbly Usain Bolt's dense meat sword	0		Initiative: +80
 1729	narrow frosty dense meat staff	0		Cold Spell Damage: +10
@@ -1725,7 +1725,7 @@
 1746	pulsating reassuring Jack Frost's energetic Super Magic Power Sword X	0		Maximum MP Percent: +20, Cold Spell Damage: +50, Spooky Resistance: +1
 1747	dog trainer's energetic soylent staff	0		Maximum MP Percent: +20, Experience (familiar): +1
 1748	Herculean goulauncher of the wise owl	0		Mysticality: +20, Experience (Muscle): +1
-1749	blue squat defective skull	0		Last Available: "2011-12"
+1749	squat blue defective skull	0		Last Available: "2011-12"
 1750	deadly Gnollish pie server	0		Weapon Damage: +5
 1751	huge sage Gnollish slotted spoon	0		Mysticality Percent: +10
 1752	cyan foul-smelling Knob Goblin spatula	0		Stench Damage: +10
@@ -1745,7 +1745,7 @@
 1766	blue Spookyraven ballroom key	0		
 1767	upside-down pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	small rotten twirling fricasseed brains	2	crappy	
+1769	rotten small twirling fricasseed brains	2	crappy	
 1770	flavorless brains casserole	4	decent	
 1771	red butcherknife of Tarzan	0		Experience (Muscle): +3
 1772	narrow friendly corn holder	0		Familiar Weight: +3
@@ -1777,19 +1777,19 @@
 1798	pile of animal bones	0		
 1799	teal animal skull	0		
 1800	shaking animal cranium	0		
-1801	purple squat animal jawbone	0		
+1801	squat purple animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	blinking fourth cervical vertebra	0		
 1806	jittery fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
-1808	red upside-down seventh cervical vertebra	0		
-1809	lime green blurry first thoracic vertebra	0		
+1808	upside-down red seventh cervical vertebra	0		
+1809	blurry lime green first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
 1811	third thoracic vertebra	0		
 1812	mirror fourth thoracic vertebra	0		
-1813	teal pulsating fifth thoracic vertebra	0		
+1813	pulsating teal fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
@@ -1808,7 +1808,7 @@
 1829	first caudal vertebra	0		
 1830	blurry second caudal vertebra	0		
 1831	huge third caudal vertebra	0		
-1832	upside-down green fourth caudal vertebra	0		
+1832	green upside-down fourth caudal vertebra	0		
 1833	blinking shaking fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
@@ -1826,7 +1826,7 @@
 1847	blue left ninth rib	0		
 1848	left tenth rib	0		
 1849	left eleventh rib	0		
-1850	skewed bouncing left twelfth rib	0		
+1850	bouncing skewed left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
 1853	right third rib	0		
@@ -1853,7 +1853,7 @@
 1874	left femur	0		
 1875	right femur	0		
 1876	left tibia	0		
-1877	tumbling mirror right tibia	0		
+1877	mirror tumbling right tibia	0		
 1878	blinking left fibula	0		
 1879	right fibula	0		
 1880	purple left kneecap	0		
@@ -1875,7 +1875,7 @@
 1896	ghostly ghostly right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
-1899	red narrow shaking right fourth rear claw	0		
+1899	narrow red shaking right fourth rear claw	0		
 1900	blurry Sinatra's 1-ball	0		Experience (Moxie): +5
 1901	skewed Jeselnik's smartaleck's 2-ball	0		Moxie Percent: +30, Sleaze Damage: +25
 1902	Jack Frost's Fonzie's 3-ball	0		Experience (Moxie): +1, Cold Spell Damage: +50
@@ -1896,7 +1896,7 @@
 1919	English to A. F. U. E. Dictionary	0		
 1920	bizarre illegible sheet music	0		
 1921	brawny wakizashi	0		Muscle Percent: +20
-1922	twirling blue gob of wet hair	0		
+1922	blue twirling gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
 1924	tattered wolf standard	0		
 1925	tattered snake standard	0		
@@ -1930,7 +1930,7 @@
 1953	acceptable flute of flat champagne	3	good	
 1954	spoiled half-sized dehydrated caviar	2	crappy	
 1955	styrofoam peanuts	0		
-1956	lousy watered-down cyan snifter of thoroughly aged brandy	2	decent	
+1956	watered-down lousy cyan snifter of thoroughly aged brandy	2	decent	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	tattered scrap of paper	0		
@@ -2002,7 +2002,7 @@
 2025	bland immense handful of walnuts	9	decent	
 2026	rotten nutty organic salad	3	crappy	
 2027	rotten small skewed super salad	2	crappy	
-2028	tasty miniature tofu wonton	2	awesome	
+2028	miniature tasty tofu wonton	2	awesome	
 2029	blinking hippy protest button	0		Single Equip
 2030	maroon Lockenstock&trade; sandals of the wise owl of dire peril	0		Mysticality: +20, Weapon Damage: +20, Single Equip
 2031	fireproof didgeridooka	0		Hot Resistance: +3
@@ -2027,9 +2027,9 @@
 2051	tumbling sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
-2054	olive tumbling market map	0		
+2054	tumbling olive market map	0		
 2055	snake skin	0		
-2056	diffused tumbling wobbly adder bladder	0		Effect: "On a Roll", Effect Duration: 51
+2056	diffused wobbly tumbling adder bladder	0		Effect: "On a Roll", Effect Duration: 51
 2057	pension check	0		
 2058	ghostly picnic basket	0		
 2059	irradiated blurry Black No. 2	0		Effect: "Incredibly Hulking", Effect Duration: 20
@@ -2122,8 +2122,8 @@
 2147	evil teddy bear sewing kit	0		
 2148	squat toothsome rock	0		
 2149	yummy half-sized squat frank	2	awesome	Last Available: "2011-12"
-2150	low-calorie bland plate of franks and beans	1	decent	Last Available: "2011-12"
-2151	special irresponsibly strong drinkable bouncing shot of blackberry schnapps	7	good	Effect: "Hombre Muerto Caminando", Effect Duration: 30
+2150	bland low-calorie plate of franks and beans	1	decent	Last Available: "2011-12"
+2151	irresponsibly strong special drinkable bouncing shot of blackberry schnapps	7	good	Effect: "Hombre Muerto Caminando", Effect Duration: 30
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	fuchsia ion grid	0		Last Available: "2011-12"
@@ -2168,10 +2168,10 @@
 2193	stale candy stake	4	decent	Last Available: "2006-12"
 2194	artisanal eggnog	4	EPIC	Last Available: "2006-12"
 2195	tasty bouncing unspeakable fruitcake	3	awesome	Last Available: "2006-12"
-2196	normal miniature blurry gingerbread horror	2	good	Last Available: "2006-12"
+2196	miniature normal blurry gingerbread horror	2	good	Last Available: "2006-12"
 2197	ionized but probably evil chocolate	0		Effect: "Heart of Lavender", Effect Duration: 40, Last Available: "2006-12"
 2198	diet decent bat-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	spoiled huge skull-shaped Crimboween cookie	8	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2199	huge spoiled skull-shaped Crimboween cookie	8	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	bland tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	wobbly medical-grade plastic gift-wrapping vampire	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2006-12"
 2202	prompt plastic yuletide troll	0		Adventures: +3, Last Available: "2006-12"
@@ -2200,7 +2200,7 @@
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	shaking wizardly evil eyeball pendant of the scaredy-cat	0		Mysticality: +25, Monster Level: -15, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	diffused galvanized corrupted arse-a'fire elixir	0		Effect: "You Drank Fish Wine", Effect Duration: 54, Last Available: "2007-01"
-2228	dry activated cyan bouncing cosmic lemonade	0		Effect: "Low on the Hog", Effect Duration: 34, Last Available: "2007-01"
+2228	dry activated bouncing cyan cosmic lemonade	0		Effect: "Low on the Hog", Effect Duration: 34, Last Available: "2007-01"
 2229	activated quantum toad horn	0		Effect: "The Strength...  of the Future", Effect Duration: 36, Last Available: "2007-01"
 2230	spinning fuchsia icicle katana	0		Familiar Weight: +5
 2231	mote	0		
@@ -2235,27 +2235,27 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	blue lion oil	0		
-2264	half-sized special yummy jittery stunt nuts	2	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 20
-2265	normal small wet stew	2	good	
+2264	yummy half-sized special jittery stunt nuts	2	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 20
+2265	small normal wet stew	2	good	
 2266	spinning wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	avaricious Staff of Fats	0		Meat Drop: +30
 2269	rotten mirror sausage wonton	3	crappy	
 2270	double-paned educational belt	0		Experience: +1, Cold Resistance: +5, Single Equip
-2271	artisanal high-proof red bottle of Merlot	8	EPIC	
+2271	high-proof artisanal red bottle of Merlot	8	EPIC	
 2272	tolerable practically non-alcoholic wobbly upside-down bottle of Port	1	good	
 2273	acceptable blue bottle of Pinot Noir	4	good	
 2274	drinkable watered-down bottle of Zinfandel	2	good	
-2275	perfectly mixed high-proof bottle of Marsala	7	EPIC	
+2275	high-proof perfectly mixed bottle of Marsala	7	EPIC	
 2276	tolerable bottle of Muscat	4	good	
 2277	purple twirling Fernswarthy's key	0		
-2278	mirror blurry tumbling Fernswarthy's letter	0		
+2278	blurry tumbling mirror Fernswarthy's letter	0		
 2279	ghostly book	0		
 2280	Manual of Labor	0		
 2281	green Manual of Transmission	0		
 2282	jittery Manual of Dexterity	0		
 2283	seal-skull helmet of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "atk, cap 2"
-2284	blue tumbling jittery petrified noodles	0		
+2284	jittery tumbling blue petrified noodles	0		
 2285	chisel	0		
 2286	gray Eye of Ed	0		
 2287	glowstick of the pedagogue of incineration	0		Experience: +3, Hot Spell Damage: +50, Last Available: "2007-01"
@@ -2266,7 +2266,7 @@
 2292	wine vinaigrette	0		
 2293	twirling cyan cup of strong herbal tea	0		
 2294	skewed Curiously Shiny Ancient Evil-Bashing Axe	0		
-2295	huge fuchsia marinated stakes	0		
+2295	fuchsia huge marinated stakes	0		
 2296	knob butter	0		
 2297	upside-down vial of ectoplasm	0		
 2298	bouncing boock of darck magicks	0		
@@ -2277,7 +2277,7 @@
 2303	huge Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	super-tarnished warmed jittery candy heart	0		Effect: "Fire Inside", Effect Duration: 54, Last Available: "2007-02"
 2305	extra-colloidal bouncing pink candy heart	0		Effect: "Gemini Rising", Effect Duration: 53, Last Available: "2007-02"
-2306	dry blue upside-down candy heart	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 65, Last Available: "2007-02"
+2306	dry upside-down blue candy heart	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 65, Last Available: "2007-02"
 2307	deionized polymerized candy heart	0		Effect: "Space Cadet", Effect Duration: 40, Last Available: "2007-02"
 2308	vacuum-sealed candy heart	0		Effect: "Memories of Puppy Love", Effect Duration: 54, Last Available: "2007-02"
 2309	electrified dry narrow candy heart	0		Effect: "New and Improved", Effect Duration: 39, Last Available: "2007-02"
@@ -2299,9 +2299,9 @@
 2325	Staff of Ed	0		
 2326	green stone rose	0		
 2327	flattened triple-chilled blinking can of paint	0		Effect: "Flambé-a-thon", Effect Duration: 66
-2328	spinning mirror drum machine	0		
+2328	mirror spinning drum machine	0		
 2329	handful of confetti	0		
-2330	shaking cyan twirling chocolate-covered diamond-studded roses	0		
+2330	shaking twirling cyan chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
 2332	flavorless Better Than Cuddling Cake	3	decent	
 2333	skewed ninja snowman	0		
@@ -2309,12 +2309,12 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	pulsating twirling Jack Frost's pipe of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10
 2337	lime green reinforced beaded headband of the wise owl	0		Mysticality: +20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	immense decent pudding	7	good	Wiki Name: "black pudding (food)"
-2339	hand-crafted watered-down wobbly Blackfly Chardonnay	2	EPIC	
+2338	decent immense pudding	7	good	Wiki Name: "black pudding (food)"
+2339	watered-down hand-crafted wobbly Blackfly Chardonnay	2	EPIC	
 2340	mediocre lime green & tan	3	decent	
 2341	pepper	0		
 2342	delicious squat forest cake	4	awesome	
-2343	moldy small forest ham	2	crappy	
+2343	small moldy forest ham	2	crappy	
 2344	liquefied pressed filthworm hatchling scent gland	0		Effect: "Strong Grip", Effect Duration: 14
 2345	galvanized shaking mirror filthworm drone scent gland	0		Effect: "Sleazy Jellied", Effect Duration: 52
 2346	ionized non-concentrated filthworm royal guard scent gland	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 11
@@ -2331,7 +2331,7 @@
 2357	blinking healthy Gaia beads of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20
 2358	pink clay bead	0		
 2359	pulsating clay bead	0		
-2360	twirling blurry clay bead	0		
+2360	blurry twirling clay bead	0		
 2361	shaking medical-grade quilted hippy medical kit	0		Damage Absorption: +40, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 2362	nippy Socratic Slow Talkin' Elliot's dogtags	0		Experience (Mysticality): +1, Cold Damage: +10
 2363	experienced longhaired hippy wig of the bloodbag	0		Experience: +2, Maximum HP: +100, Familiar Effect: "1xPotato, 1xGhuol"
@@ -2347,8 +2347,8 @@
 2373	spoiled banana	3	crappy	
 2374	huge banana peel	0		
 2375	bland wobbly banana cream pie	4	decent	
-2376	irresponsibly strong artisanal pulsating blinking banana daiquiri	7	EPIC	
-2377	lousy practically non-alcoholic bungle in the jungle	1	decent	
+2376	irresponsibly strong artisanal blinking pulsating banana daiquiri	7	EPIC	
+2377	practically non-alcoholic lousy bungle in the jungle	1	decent	
 2378	blinking banana spritzer	0		
 2379	deionized warmed dry tumbling banana smoothie	0		Effect: "You're High as a Crow, Marty", Effect Duration: 14
 2380	ghostly dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2386,7 +2386,7 @@
 2412	sammich crust	0		
 2413	teal triffid bark	0		
 2414	lint	0		
-2415	blinking mirror discarded pacifier	0		
+2415	mirror blinking discarded pacifier	0		
 2416	olive toasty bounty-hunting helmet	0		Hot Damage: +5, Familiar Effect: "1.5xFairy, cap 25"
 2417	skewed razor-sharp bounty-hunting rifle	0		Weapon Damage Percent: +25
 2418	teal banded bounty-hunting pants	0		Damage Absorption: +100, Familiar Effect: "1xPotato, 2xFairy, cap 25"
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	spoiled half-sized bowl of Bounty-Os	2	crappy	
-2465	mediocre distilled Oreille Divis&eacute;e brandy	5	decent	
+2465	distilled mediocre Oreille Divis&eacute;e brandy	5	decent	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2490,17 +2490,17 @@
 2517	scorching sizzling chain necklace	0		Hot Damage: 35
 2518	squat miser's sawblade shield	0		Meat Drop: +10, Damage Reduction: 11
 2519	bad McMillicancuddy's Special Lager	3	decent	
-2520	weak bad melted Jell-o shot	2	decent	
-2521	aged enchanted bouncing squat cruelty-free wine	3	awesome	Effect: "Spookypants", Effect Duration: 30
-2522	artisanal practically non-alcoholic squat yellow thistle wine	1	EPIC	
+2520	bad weak melted Jell-o shot	2	decent	
+2521	enchanted aged bouncing squat cruelty-free wine	3	awesome	Effect: "Spookypants", Effect Duration: 30
+2522	practically non-alcoholic artisanal yellow squat thistle wine	1	EPIC	
 2523	squat megatofu	0		
 2524	displaced fish	0		
-2525	bland huge red huge fish	7	decent	
+2525	bland huge huge red fish	7	decent	
 2526	snack-sized flavorless fish casserole	2	decent	
 2527	moldy diet fish lasagna	1	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	decent massive gnatloaf	10	good	
-2530	miniature stale gnatloaf casserole	2	decent	
+2530	stale miniature gnatloaf casserole	2	decent	
 2531	yummy gnat lasagna	3	awesome	
 2532	pork	0		
 2533	moldy half-sized pork chop sandwiches	2	crappy	
@@ -2543,7 +2543,7 @@
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
-2573	fuchsia tumbling upside-down ant sickle	0		Familiar Effect: "spooky damage, meat"
+2573	upside-down fuchsia tumbling ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
 2575	pulsating bronzed locust	0		
 2576	honey-dipped locust	0		
@@ -2553,14 +2553,14 @@
 2580	upside-down wool brawny scorpion whip	0		Muscle Percent: +20, Cold Resistance: +1
 2581	green handful of sand	0		
 2582	skewed brick of sand	0		
-2583	normal skewed lime green centipede eggs	3	good	
+2583	normal lime green skewed centipede eggs	3	good	
 2584	Tesla wonderwall shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 12
 2585	upside-down Colonel Mustard's Lonely Spades Club Jacket of the storm	0		Maximum MP Percent: +40
 2586	wobbly General Sage's Lonely Diamonds Club Jacket of the wise owl	0		Mysticality: +20
 2587	aromatic Corporal Fennel's Lonely Clubs Club Jacket	0		Stench Resistance: +1
 2588	wholesome Private Pepper's Lonely Hearts Club Jacket	0		Maximum HP Percent: +10
 2589	tiny decent hot date	1	good	
-2590	lousy triple-distilled distilled fortified wine	6	decent	
+2590	triple-distilled lousy distilled fortified wine	6	decent	
 2591	rotten tasty tart	3	crappy	
 2592	Knob Goblin lunchbox	0		
 2593	half-sized delicious special Knob pasty	2	awesome	Effect: "Night of the Nachos", Effect Duration: 15
@@ -2583,9 +2583,9 @@
 2610	squat Samson's extra-large palm-frond toupee	0		Experience (Muscle): +5, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 2611	Newton's palm-frond cloak	0		Experience (Mysticality): +3
 2612	skewed vinyl coin purse	0		
-2613	narrow blinking lime green rocky raccoon	0		
+2613	narrow lime green blinking rocky raccoon	0		
 2614	teal mojo filter	0		
-2615	enchanted low-calorie toothsome savoy truffle	1	awesome	Effect: "Slimily Speedy", Effect Duration: 45
+2615	toothsome low-calorie enchanted savoy truffle	1	awesome	Effect: "Slimily Speedy", Effect Duration: 45
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	stiffened Iiti Kitty phone charm	0		Damage Reduction: 1, Single Equip
@@ -2625,13 +2625,13 @@
 2652	flavorless S.T.L.T.	3	decent	Last Available: "2007-06"
 2653	rotten honey-dew	3	crappy	Last Available: "2007-06"
 2654	lousy blinking Xanadian	3	decent	Last Available: "2007-06"
-2655	polymerized purple blurry bottle of absinthe	0		Effect: "Stinkybeard", Effect Duration: 61, Last Available: "2007-06"
+2655	polymerized blurry purple bottle of absinthe	0		Effect: "Stinkybeard", Effect Duration: 61, Last Available: "2007-06"
 2656	horrifying foul-smelling Drowsy Sword	0		Stench Damage: +10, Spooky Damage: +25
 2657	rotten escargotsicle	3	crappy	Last Available: "2007-06"
-2658	high-proof acceptable shaking olive bottle of realpagne	9	good	Last Available: "2007-06"
+2658	acceptable high-proof shaking olive bottle of realpagne	9	good	Last Available: "2007-06"
 2659	strapping albatross necklace	0		Muscle: +5, Single Equip, Last Available: "2007-06"
 2660	altered squat bouncing not-a-pipe	1	good	Effect: "Corona de la Salsa", Effect Duration: 35, Last Available: "2007-06"
-2661	fancy perfectly mixed weak jittery flask of Amontillado	2	EPIC	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2007-06"
+2661	fancy weak perfectly mixed jittery flask of Amontillado	2	EPIC	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2007-06"
 2662	huge green Jim Carey's ball mask	0		Monster Level: +25, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 2663	nasty Can-Can skirt	0		Stench Damage: +5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	moist sensitive poetry journal	0		Effect: "Broberry Brotality", Effect Duration: 22, Last Available: "2007-06"
@@ -2641,12 +2641,12 @@
 2668	twisted can-can-in-a-can	1		Effect: "Chalked-Up Teeth", Effect Duration: 5, Last Available: "2007-06"
 2669	distilled maroon patent antipsychotics	1		Effect: "The Q Is Talking To You", Effect Duration: 35, Last Available: "2007-06"
 2670	compressed narrow Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	practically non-alcoholic drinkable shot of nepenthe schnapps	1	good	Last Available: "2007-06"
+2671	drinkable practically non-alcoholic shot of nepenthe schnapps	1	good	Last Available: "2007-06"
 2672	twirling library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	Vulcanized tarnished bottle of cat tonic	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 16, Last Available: "2007-06"
 2675	dehydrated skewed handful of moss	1		
-2676	altered green tumbling bit-o-cactus	1		
+2676	altered tumbling green bit-o-cactus	1		
 2677	distilled protein powder	1		
 2678	spectre scepter	0		
 2679	ionized sparkler	0		Effect: "White Blooded", Effect Duration: 47
@@ -2696,24 +2696,24 @@
 2723	tumbling aromatic gravedigger's Staff of the Grand Flamb&eacute; of incineration	0		Hot Spell Damage: +50, Spooky Damage: +10, Stench Resistance: +1
 2724	gigantic yummy bowl of rye sprouts	6	awesome	
 2725	spoiled huge cob of corn	3	crappy	
-2726	bite-sized flavorless juniper berries	1	decent	
+2726	flavorless bite-sized juniper berries	1	decent	
 2727	moldy blinking plum	3	crappy	
 2728	yummy pear	3	awesome	
 2729	stale teal peach	3	decent	
-2730	aged practically non-alcoholic twirling plum wine	1	awesome	
-2731	fancy lousy watered-down shot of pear schnapps	2	decent	Effect: "Muscularrr", Effect Duration: 45
+2730	practically non-alcoholic aged twirling plum wine	1	awesome	
+2731	lousy watered-down fancy shot of pear schnapps	2	decent	Effect: "Muscularrr", Effect Duration: 45
 2732	lousy triple-distilled pulsating shot of peach schnapps	8	decent	
-2733	moldy half-sized yellow bunch of square grapes	2	crappy	
-2734	flavorless low-calorie bouncing brown sugar cane	1	decent	
+2733	half-sized moldy yellow bunch of square grapes	2	crappy	
+2734	low-calorie flavorless bouncing brown sugar cane	1	decent	
 2735	adequate sandwich of the gods	4	good	
-2736	artisanal weak Pan-Dimensional Gargle Blaster	2	super ultra mega turbo EPIC	
+2736	weak artisanal Pan-Dimensional Gargle Blaster	2	super ultra mega turbo EPIC	
 2737	twisted narrow leopard-print barbell	1	good	Effect: "Adorable Lookout", Effect Duration: 5
 2738	pile of smoking rags	0		
 2739	wet adjusted purple panty raider camouflage	0		Effect: "Hairy Palms", Effect Duration: 55
 2740	fireproof energetic Fonzie's Staff of the Walk-In Freezer	0		Experience (Moxie): +1, Maximum MP Percent: +20, Hot Resistance: +3
 2741	practically non-alcoholic aged boilermaker	1	awesome	
 2742	moldy upside-down steel lasagna	3	quest	
-2743	bad irresponsibly strong steel margarita	9	quest	
+2743	irresponsibly strong bad steel margarita	9	quest	
 2744	distilled huge steel-scented air freshener	1		
 2745	tarnished electrified gremlin mutagen	0		Effect: "Bottle in front of Me", Effect Duration: 45
 2746	quantum extra-potent gremlin mutagen	0		Effect: "Jittery", Effect Duration: 17
@@ -2739,9 +2739,9 @@
 2766	bowling ball	0		
 2767	rotten red Crimbo pie	4	crappy	
 2768	adequate miniature blinking pear tart	2	good	
-2769	jumbo adequate peach pie	5	good	
+2769	adequate jumbo peach pie	5	good	
 2770	alkaline activated tumbling chunk of rock salt	0		Effect: "Meat the Flintstones", Effect Duration: 43
-2771	frozen bouncing narrow handful of pine needles	0		Effect: "Astral Shell", Effect Duration: 20
+2771	frozen narrow bouncing handful of pine needles	0		Effect: "Astral Shell", Effect Duration: 20
 2772	bouncing steamy ruby	0		
 2773	tumbling glacial sapphire	0		
 2774	olive unearthly onyx	0		
@@ -2803,15 +2803,15 @@
 2830	digital key lime	0		
 2831	mirror star key lime	0		
 2832	stale shaking digital key lime pie	3	decent	
-2833	small stale star key lime pie	2	decent	
-2834	Oprah's extremely unsafe bottle-rocket crossbow of the boozehound	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Booze Drop: +100, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2833	stale small star key lime pie	2	decent	
+2834	Oprah's extremely unsafe bottle-rocket crossbow of the boozehound	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Booze Drop: +100, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	indie comic hipster glasses of Leguizamo	0		Monster Level: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	blurry wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	reassuring glowstick of courage	0		Spooky Resistance: 4, Last Available: "2007-08"
 2839	banded Periodical Paintbrush	0		Damage Absorption: +100, Softcore Only
-2840	bad high-proof teal ghostly bottle of cooking sherry	7	decent	
-2841	low-calorie decent packet of ketchup	1	good	
+2840	bad high-proof ghostly teal bottle of cooking sherry	7	decent	
+2841	decent low-calorie packet of ketchup	1	good	
 2842	acceptable blurry accidental cider	3	good	
 2843	flavorless dire fudgesicle	3	decent	
 2844	quilted brawny slick brainy navel ring of navel gazing	0		Mysticality: +5, Moxie: +10, Muscle Percent: +20, Damage Absorption: +40, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2819,7 +2819,7 @@
 2846	plastic bib	0		Last Available: "2011-12"
 2847	Dallas Dynasty Falcon Crest shield of the wise owl	0		Mysticality: +20, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
-2849	wobbly spinning shrunken navigator head	0		
+2849	spinning wobbly shrunken navigator head	0		
 2850	hand-crafted moonberry wine cooler	3	EPIC	
 2851	adequate fine aged cheddarwurst	3	good	
 2852	branch from the Great Tree	0		
@@ -2911,11 +2911,11 @@
 2938	shaking Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	normal Surprise Egg	3	good	
-2941	flattened adjusted maroon pulsating Steal This Candy	0		Effect: "Sweet Incentive", Effect Duration: 38
+2941	flattened adjusted pulsating maroon Steal This Candy	0		Effect: "Sweet Incentive", Effect Duration: 38
 2942	magnetized chocolate filthy lucre	0		Effect: "Astral Shell", Effect Duration: 35
 2943	nitrogenated dry Angry Farmer's Wife Candy	0		Effect: "Vinegavotte", Effect Duration: 32
 2945	dance instructor's party hat of the ox	0		Muscle: +20, Experience Percent (Moxie): +10, Familiar Effect: "4xLep, cap 7"
-2946	wobbly blurry olive toasty V for Vivala mask of doom	0		Hot Damage: +5, Spooky Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	wobbly blurry olive toasty V for Vivala mask of doom	0		Hot Damage: +5, Spooky Spell Damage: +50, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	smooth shot of rotgut	3	awesome	
 2949	ionized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Pasty", Effect Duration: 54
@@ -2925,20 +2925,20 @@
 2953	charrrm bracelet	0		
 2954	tip jar of the cheetah	0		Initiative: +60
 2955	rotten narrow yam candy	4	crappy	
-2956	green twirling cocktail napkin	0		
+2956	twirling green cocktail napkin	0		
 2957	skewed rum barrel charrrm	0		
 2958	moldy tube of cranberry Go-Goo	3	crappy	
 2959	wobbly jittery stanky rum barrel charrrm bracelet	0		Stench Spell Damage: +25
-2960	low-calorie spoiled single-serving herbal stuffing	1	crappy	
-2961	tiny rotten fancy packet of tofurkey gravy	1	crappy	Effect: "Fangs and Pangs", Effect Duration: 10
+2960	spoiled low-calorie single-serving herbal stuffing	1	crappy	
+2961	fancy tiny rotten packet of tofurkey gravy	1	crappy	Effect: "Fangs and Pangs", Effect Duration: 10
 2962	spoiled gray tofurkey nugget	3	crappy	
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	gray mizzenmast mop	0		
 2966	upside-down Tom's of the Spanish Main Toothpaste	0		
 2967	ionized blurry Swabbie&trade; swab	0		Effect: "Crimbo Epiphany", Effect Duration: 28
-2968	boiled yellow shaking Oil of Parrrlay	0		Effect: "Stone-Faced", Effect Duration: 59
-2969	flavorless huge creamsicle	6	decent	
+2968	boiled shaking yellow Oil of Parrrlay	0		Effect: "Stone-Faced", Effect Duration: 59
+2969	huge flavorless creamsicle	6	decent	
 2970	practically non-alcoholic perfectly mixed cream stout	1	EPIC	
 2971	nippy personal trainer's curmudgel	0		Experience Percent (Muscle): +10, Cold Damage: +10
 2972	grumpy man charrrm	0		
@@ -2953,7 +2953,7 @@
 2981	wool booty chest charrrm bracelet	0		Cold Resistance: +1, Single Equip
 2982	spinning cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
-2984	mirror maroon copper ha'penny charrrm	0		
+2984	maroon mirror copper ha'penny charrrm	0		
 2985	squat vibrating copper ha'penny charrrm bracelet	0		Maximum MP Percent: +10
 2986	spinning tongue charrrm	0		
 2987	scorching tongue charrrm bracelet of the wise owl	0		Mysticality: +20, Hot Damage: +25, Single Equip
@@ -2994,12 +2994,12 @@
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
 3024	stone pyramid	0		
-3025	fancy artisanal corpse on the beach	4	EPIC	Effect: "Dilated Pupils", Effect Duration: 30
-3026	drinkable enchanted corpsetini	3	good	Effect: "Celestial Body", Effect Duration: 15
-3027	mediocre strong corpsedriver	5	decent	
+3025	artisanal fancy corpse on the beach	4	EPIC	Effect: "Dilated Pupils", Effect Duration: 30
+3026	enchanted drinkable corpsetini	3	good	Effect: "Celestial Body", Effect Duration: 15
+3027	strong mediocre corpsedriver	5	decent	
 3028	lousy fortified Corpse Island iced tea	5	decent	
 3029	watered-down lousy upside-down red-headed corpse	2	decent	
-3030	watered-down hand-crafted maroon kamicorpse-ee	2	EPIC	
+3030	hand-crafted watered-down maroon kamicorpse-ee	2	EPIC	
 3031	drinkable corpsel	3	good	
 3032	practically non-alcoholic drinkable upside-down corpsebite	1	good	
 3033	Samson's pirate fledges	0		Experience (Muscle): +5
@@ -3013,7 +3013,7 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	jittery gray metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	gray jittery metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	decent nanite-infested gingerbread bugbear	3	good	Last Available: "2007-12"
 3046	bland nanite-infested candy cane	3	decent	Last Available: "2020-09"
 3047	moldy nanite-infested fruitcake	3	crappy	Last Available: "2007-12"
@@ -3038,11 +3038,11 @@
 3066	toy maglev monorail of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2007-12"
 3067	dollhive	0		Last Available: "2007-12"
 3068	toy deathbot	0		Last Available: "2007-12"
-3069	skewed jittery laser cannon	0		Last Available: "2007-12"
+3069	jittery skewed laser cannon	0		Last Available: "2007-12"
 3070	wobbly plexifoam chin strap	0		Last Available: "2007-12"
 3071	silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	shaking carbonite visor	0		Last Available: "2007-12"
-3073	skewed blurry red set of Unobtainium straps	0		Last Available: "2007-12"
+3073	red skewed blurry set of Unobtainium straps	0		Last Available: "2007-12"
 3074	polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	laser targeting chip	0		Last Available: "2007-12"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	normal squat roasted marshmallow	4	good	
 3130	narrow disc	0		Last Available: "2008-01"
-3131	bite-sized enchanted toothsome tin cup of mulligan stew	1	awesome	Effect: "Over-Familiar With Dactyls", Effect Duration: 25
+3131	bite-sized toothsome enchanted tin cup of mulligan stew	1	awesome	Effect: "Over-Familiar With Dactyls", Effect Duration: 25
 3132	scandalous coward's flamin' bindle	0		Monster Level: -20, Sleaze Damage: +5
 3133	clever crafty freezin' bindle	0		Maximum MP: 30
 3134	twirling censurious flame-wreathed stinkin' bindle	0		Hot Spell Damage: +10, Sleaze Resistance: +3
@@ -3135,12 +3135,12 @@
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	broken El Vibrato drone	0		
-3166	narrow spinning repaired El Vibrato drone	0		
+3166	spinning narrow repaired El Vibrato drone	0		
 3167	huge augmented El Vibrato drone	0		
 3168	super-pickled ghostly seal eyeball	0		Effect: "Prideful Strut", Effect Duration: 22
 3169	flavorless jittery turtle soup	3	decent	Effect: "[598]A Little Bit Evil"
 3170	teal evil noodles	0		
-3171	tumbling narrow nauseating reagent	0		
+3171	narrow tumbling nauseating reagent	0		
 3172	groovy evil paper umbrella	0		Moxie Percent: +10
 3173	triple-modified chilled pulsating evil vihuela	0		Effect: "Busy Bein' Delicious", Effect Duration: 26
 3174	yummy evil boring spaghetti	3	awesome	
@@ -3148,18 +3148,18 @@
 3176	moldy evil noodles	3	crappy	
 3177	adequate evil painful penne pasta	4	good	
 3178	adequate small 3vi1 pr0n m4nic0tti	2	good	
-3179	stale low-calorie wobbly evil ravioli della hippy	1	decent	
-3180	small delicious fuchsia pulsating evil noodles	2	awesome	
+3179	low-calorie stale wobbly evil ravioli della hippy	1	decent	
+3180	delicious small fuchsia pulsating evil noodles	2	awesome	
 3181	irradiated evil potion of potency	0		Effect: "Stinky Weapon", Effect Duration: 17
 3182	quadruple-dry deionized evil libation of liveliness	0		Effect: "Concentration", Effect Duration: 16
 3183	Vulcanized boiled narrow evil tomato juice of powerful power	0		Effect: "Full-Body Tan", Effect Duration: 37
 3184	double-adjusted modified wobbly evil eyedrops of the ermine	0		Effect: "Hair on Your Chest", Effect Duration: 39
 3185	liquefied evil ointment of the occult	0		Effect: "Ancestral Disapproval", Effect Duration: 33
 3186	dry ghostly evil serum of sarcasm	0		Effect: "Human-Penguin Hybrid", Effect Duration: 24
-3187	ionized energized red pulsating evil philter of phorce	0		Effect: "Coal-Powered", Effect Duration: 27
+3187	ionized energized pulsating red evil philter of phorce	0		Effect: "Coal-Powered", Effect Duration: 27
 3188	practically non-alcoholic bad an evil sump'm sump'm	1	decent	
-3189	tolerable watered-down evil ducha de oro	2	good	
-3190	watered-down bad enchanted evil horizontal tango	2	decent	Effect: "Egg-stortionary Tactics", Effect Duration: 20
+3189	watered-down tolerable evil ducha de oro	2	good	
+3190	bad watered-down enchanted evil horizontal tango	2	decent	Effect: "Egg-stortionary Tactics", Effect Duration: 20
 3191	smooth evil roll in the hay	4	awesome	
 3192	squat naughty origami kit	0		Last Available: "2008-02"
 3193	lime green naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3179,7 +3179,7 @@
 3207	dwarvish punchcard	0		
 3208	maroon small laminated card	0		
 3209	laminated card	0		
-3210	teal blinking notbig laminated card	0		
+3210	blinking teal notbig laminated card	0		
 3211	wobbly unlarge laminated card	0		
 3212	dwarvish document	0		
 3213	dwarvish paper	0		
@@ -3190,7 +3190,7 @@
 3218	smooth glowstick of the glutton	0		Moxie: +15, Food Drop: +100, Last Available: "2008-02"
 3219	blurry sane hatrack	0		Free Pull, Last Available: "2011-12"
 3220	shaking hobo code binder	0		Free Pull
-3221	cyan skewed gator skin	0		
+3221	skewed cyan gator skin	0		
 3222	quilted Rosewater's gatorskin umbrella	0		Mysticality Percent: +30, Damage Absorption: +40
 3223	sewer nuggets	0		
 3224	sewer wad	0		
@@ -3239,10 +3239,10 @@
 3267	upside-down blurry bag of Laughing Willow saplings	0		
 3268	diffused alkaline Vulcanized spinning spinning handful of Crotchety Pine needles	0		Effect: "Vanity Rage", Effect Duration: 15
 3269	pickled pressed twirling lump of Saccharine Maple sap	0		Effect: "Healthy Red Glow", Effect Duration: 11
-3270	pickled electrified squat fuchsia handful of Laughing Willow bark	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 50
-3271	brainy crotchety pants	0		Mysticality: +5, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3270	pickled electrified fuchsia squat handful of Laughing Willow bark	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 50
+3271	brainy crotchety pants	0		Mysticality: +5, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	crafty Saccharine Maple pendant	0		Maximum MP: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	supercool willowy bonnet	0		Moxie Percent: +20, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	supercool willowy bonnet	0		Moxie Percent: +20, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	twirling plasma ball	0		Last Available: "2008-04"
 3282	stick-on eyebrow piercing of the cougar	0		Moxie: +20, Last Available: "2008-04"
-3283	low-calorie delicious spinning salad	1	awesome	
+3283	delicious low-calorie spinning salad	1	awesome	
 3284	Temple Grandin's veiny C.H.U.M. lantern	0		Maximum HP: +10, Familiar Weight: +7
 3285	C.H.U.M. knife of incineration	0		Hot Spell Damage: +50
 3286	Sherlock's Frosty's snowball sack	0		Item Drop: +25
@@ -3291,7 +3291,7 @@
 3319	maroon Rosewater's Mr. Joe's bangles	0		Mysticality Percent: +30, Single Equip
 3320	experienced frayed rope belt	0		Experience: +2, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	blue inspector's mayfly bait necklace of Leguizamo	0		Monster Level: +20, Item Drop: +15, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	blue inspector's mayfly bait necklace of Leguizamo	0		Monster Level: +20, Item Drop: +15, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	gray Ol' Scratch's salad fork	0		
 3324	bouncing Frosty's frosty mug	0		
 3325	mediocre watered-down jar of fermented pickle juice	2	decent	
@@ -3342,11 +3342,11 @@
 3370	pickled jittery glimmering penguin feather	1		Effect: "Tin, Man", Effect Duration: 10, Last Available: "2008-06"
 3371	diluted wobbly glimmering buzzard feather	1		Last Available: "2008-06"
 3372	boiled spinning bouncing glimmering raven feather	1		Effect: "Vitamin-Maxed", Effect Duration: 15, Last Available: "2008-06"
-3373	pickled olive twirling glimmering great tit feather	1		Last Available: "2008-06"
+3373	pickled twirling olive glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
-3377	jittery gray Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
+3377	gray jittery Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	Chorale of Companionship	0		Skill: "Chorale of Companionship"
 3379	Prelude of Precision	0		Skill: "Prelude of Precision"
 3380	curative Ol' Scratch's infernal pitchfork of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5
@@ -3367,9 +3367,9 @@
 3395	wobbly greedy MacGyver's Hodgman's porkpie hat	0		Maximum MP: +100, Meat Drop: +20, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	aromatic rock-hard Hodgman's lobsterskin pants	0		Damage Reduction: 5, Stench Resistance: +1, Familiar Effect: "atk, 1xPotato"
 3397	rosy-cheeked weightlifter's Hodgman's bow tie	0		Muscle: +15, Maximum HP Percent: +30, Single Equip
-3398	bad weak squat Hodgman's blanket	2	decent	
+3398	weak bad squat Hodgman's blanket	2	decent	
 3399	delicious fancy jar of squeeze	3	awesome	Effect: "Rainbow Bright", Effect Duration: 30
-3400	moldy tiny wobbly bowl of fishysoisse	1	crappy	
+3400	tiny moldy wobbly bowl of fishysoisse	1	crappy	
 3401	chilled jittery deadly lampshade	0		Effect: "Gummiskin", Effect Duration: 32
 3402	moist frozen concentrated garbage juice	0		Effect: "Dexteri Tea", Effect Duration: 18
 3403	cyan lewd playing card	0		
@@ -3386,7 +3386,7 @@
 3414	gray Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	purple Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	activated adjusted galvanized mirror sterno-flavored Hob-O	0		Effect: "Mariachi Mood", Effect Duration: 62
 3423	aerosolized frostbite-flavored Hob-O	0		Effect: "Seriously Mutated", Effect Duration: 12
 3424	activated alkaline fry-oil-flavored Hob-O	0		Effect: "Really Deep Breath", Effect Duration: 62
@@ -3394,7 +3394,7 @@
 3426	adjusted anodized strawberry-flavored Hob-O	0		Effect: "Meat the Flintstones", Effect Duration: 53
 3427	huge roll of Hob-Os	0		
 3428	cold-filtered wet bouncing Everlasting Deckswabber	0		Effect: "Crimbo Nostalgia", Effect Duration: 63
-3430	upside-down mirror bindle of joy	0		
+3430	mirror upside-down bindle of joy	0		
 3431	spinning upside-down cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	teal cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
@@ -3423,14 +3423,14 @@
 3456	dog trainer's trusty torch	0		Experience (familiar): +1, Last Available: "2011-12"
 3457	fuchsia ghostly Junior Adventurer's merit badge of wisdom	0		Mysticality: +15
 3458	non-diffused galvanized STYX deodorant body spray	0		Effect: "Leash of Linguini", Effect Duration: 38
-3459	weak aged narrow white-label gin	2	awesome	
+3459	aged weak narrow white-label gin	2	awesome	
 3460	toothsome tin rations	4	awesome	
 3461	fuchsia haiku challenge map	0		
 3462	terrible poem	0		
-3463	tolerable mirror upside-down bottle of sake	3	good	
+3463	tolerable upside-down mirror bottle of sake	3	good	
 3464	sage round pebble	0		Mysticality Percent: +10
 3465	spoiled diet Bash-&#332;s cereal	1	crappy	Wiki Name: "Bash-Os cereal"
-3466	narrow scorching Newton's supercool haiku katana	0		Moxie Percent: +20, Experience (Mysticality): +3, Hot Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	narrow scorching Newton's supercool haiku katana	0		Moxie Percent: +20, Experience (Mysticality): +3, Hot Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	plastic baby of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2008-12"
 3469	delicious blueberry-frosted king cake	3	awesome	Last Available: "2008-12"
@@ -3440,7 +3440,7 @@
 3473	teal Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	anodized denatured shaking cranberry cordial	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 25
 3475	corrupted tumbling blackberry polite	0		Effect: "Red Around the Gills", Effect Duration: 33
-3476	energized Vulcanized yellow tumbling plum lozenge	0		Effect: "Loco Motives", Effect Duration: 64
+3476	energized Vulcanized tumbling yellow plum lozenge	0		Effect: "Loco Motives", Effect Duration: 64
 3477	activated alkaline pear lozenge	0		Effect: "Pumped Up", Effect Duration: 52
 3478	diffused wobbly peach lozenge	0		Effect: "It's Electric!", Effect Duration: 55
 3479	mirror balloon shield	0		Damage Reduction: 3
@@ -3471,7 +3471,7 @@
 3504	French slippers	0		
 3505	LWA ring of the empath	0		Familiar Weight: +5
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	huge jittery Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	jittery huge Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	hale scratch 'n' sniff sword	0		Maximum HP: +20, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3491,7 +3491,7 @@
 3524	dry corrupted eel battery	0		Effect: "Can Has Cyborger", Effect Duration: 60
 3525	vacuum-sealed squat temporary teardrop tattoo	0		Effect: "Demonic Taint", Effect Duration: 56
 3526	greedy scratch 'n' sniff crossbow	0		Meat Drop: +20, Last Available: "2008-11"
-3527	mirror skewed mutant rattlesnake egg	0		
+3527	skewed mirror mutant rattlesnake egg	0		
 3528	skewed mutant fire ant egg	0		
 3529	mutant cactus bud	0		
 3530	mutant gila monster egg	0		
@@ -3500,7 +3500,7 @@
 3533	huge twirling cactus monocle	0		Familiar Weight: +5
 3534	blue Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	maroon plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
-3536	pulsating olive plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
+3536	olive pulsating plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	skewed plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
@@ -3520,15 +3520,15 @@
 3553	jittery soggy seed packet	0		
 3554	red glob of slime	0		
 3555	normal miniature narrow sea carrot	2	good	
-3556	flavorless fancy big ghostly sea cucumber	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5
-3557	gigantic normal narrow sea avocado	8	good	
-3558	spoiled enchanted small sea lychee	2	crappy	Effect: "Nut-Rition", Effect Duration: 40
+3556	fancy flavorless big ghostly sea cucumber	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5
+3557	normal gigantic narrow sea avocado	8	good	
+3558	spoiled small enchanted sea lychee	2	crappy	Effect: "Nut-Rition", Effect Duration: 40
 3559	normal sea tangelo	3	good	
 3560	stale sea honeydew	3	decent	
 3561	wet boiled bouncing pressurized potion of puissance	0		Effect: "Memory of Smarts", Effect Duration: 28
-3562	warmed concentrated flattened bouncing cyan pressurized potion of perspicacity	0		Effect: "You Know When to Walk Away", Effect Duration: 33
+3562	warmed concentrated flattened cyan bouncing pressurized potion of perspicacity	0		Effect: "You Know When to Walk Away", Effect Duration: 33
 3563	wet diffused pressurized potion of pulchritude	0		Effect: "Greasy Peasy", Effect Duration: 42
-3564	weak tolerable berry-infused sake	2	good	
+3564	tolerable weak berry-infused sake	2	good	
 3565	tolerable citrus-infused sake	3	good	
 3566	drinkable pulsating melon-infused sake	4	good	
 3567	shaking slab of sponge	0		
@@ -3552,7 +3552,7 @@
 3586	fancy drinkable green blurry oozenog	3	good	Effect: "Dreadful Chill", Effect Duration: 45, Last Available: "2008-12"
 3587	chilled huge squat sugar plum	0		Effect: "Space Cadet", Effect Duration: 63, Last Available: "2008-12"
 3588	cold-filtered sugar banana	0		Effect: "Oleaginous Soles", Effect Duration: 44, Last Available: "2008-12"
-3589	moist huge gray sugar lime	0		Effect: "Well-Swabbed Ear", Effect Duration: 26, Last Available: "2008-12"
+3589	moist gray huge sugar lime	0		Effect: "Well-Swabbed Ear", Effect Duration: 26, Last Available: "2008-12"
 3590	altered sugar cherry	0		Effect: "Hippy Flavor", Effect Duration: 23, Last Available: "2008-12"
 3591	Oprah's beefcake's Mer-kin hookspear	0		Muscle: +25, Maximum MP Percent: +50
 3592	Mer-kin takebag	0		Item Drop: +5
@@ -3581,7 +3581,7 @@
 3615	pulsating rigid carapace	0		Last Available: "2008-12"
 3616	blinking pulsing flesh	0		Last Available: "2008-12"
 3617	aerosolized wet unstable DNA	0		Effect: "The Two-Prong Crown", Effect Duration: 22, Last Available: "2008-12"
-3618	shaking The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	shaking The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	tumbling wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
@@ -3593,7 +3593,7 @@
 3627	brainy parasitic strangleworm	0		Mysticality: +5, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
-3630	spinning huge green Crimbo crate	0		Last Available: "2008-12"
+3630	green huge spinning Crimbo crate	0		Last Available: "2008-12"
 3631	triple-denatured concentrated jittery Gummi-DNA	0		Effect: "Mint-Condition Breath", Effect Duration: 47, Last Available: "2020-09"
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	blue Van der Graaf savvy elven socks	0		Mysticality Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-12"
@@ -3602,21 +3602,21 @@
 3636	supercool patent shoes of the cheetah	0		Moxie Percent: +20, Initiative: +60, Last Available: "2008-12"
 3637	auspicious vibrating gray bow tie	0		Maximum MP Percent: +10, Item Drop: +10, Last Available: "2008-12"
 3638	upside-down personal trainer's penguin thesaurus of extreme caution	0		Experience Percent (Muscle): +10, Monster Level: -25, Last Available: "2008-12"
-3639	normal super-sized bouncing lime green blob-shaped Crimbo cookie	5	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	normal super-sized lime green bouncing blob-shaped Crimbo cookie	5	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	narrow pufferfish spine	0		
 3644	depleted Grimacite kneecapping stick of the sweet-tooth	0		Candy Drop: +100, Last Available: "2007-06"
 3645	enchanted lousy squat canteen of wine	3	decent	Effect: "You Read The Manual", Effect Duration: 50, Last Available: "2008-12"
-3646	stale massive elven <i>limbos</i> gingerbread	8	decent	Last Available: "2008-12"
+3646	massive stale elven <i>limbos</i> gingerbread	8	decent	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	spinning magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	huge enchanted adequate toast with jam	8	good	Effect: "Abyssal Tears", Effect Duration: 40, Last Available: "2008-12"
-3651	twirling antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	twirling antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	smooth wobbly blue elven moonshine	4	awesome	Last Available: "2008-12"
-3653	snack-sized spoiled knuckle sandwich	2	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	spoiled snack-sized knuckle sandwich	2	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	aromatic dog trainer's psycho sweater	0		Experience (familiar): +1, Stench Resistance: +1, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	zippy plastic Mob Penguin	0		Initiative: +20, Last Available: "2008-12"
@@ -3642,21 +3642,21 @@
 3676	Mer-kin foodbucket	0		
 3677	boxer's diving muff	0		Muscle Percent: +10, Single Equip
 3678	hand-crafted jittery salinated mint julep	3	EPIC	
-3679	cyan squat ink bladder	0		
+3679	squat cyan ink bladder	0		
 3680	twirling maroon esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	snack-sized yummy tempura carrot	2	awesome	
-3685	adequate big tempura cucumber	5	good	
-3686	small tasty tempura avocado	2	awesome	
-3687	snack-sized normal shaking sea broccoli	2	good	
-3688	snack-sized rotten sea cauliflower	2	crappy	
+3684	yummy snack-sized tempura carrot	2	awesome	
+3685	big adequate tempura cucumber	5	good	
+3686	tasty small tempura avocado	2	awesome	
+3687	normal snack-sized shaking sea broccoli	2	good	
+3688	rotten snack-sized sea cauliflower	2	crappy	
 3689	fancy bland tiny yellow tempura broccoli	1	decent	Effect: "Goldentongue", Effect Duration: 25
-3690	half-sized flavorless fancy tempura cauliflower	2	decent	Effect: "Fitter, Happier", Effect Duration: 50
-3691	moldy special sea blueberry	4	crappy	Effect: "So You Can Work More...", Effect Duration: 30
+3690	flavorless half-sized fancy tempura cauliflower	2	decent	Effect: "Fitter, Happier", Effect Duration: 50
+3691	special moldy sea blueberry	4	crappy	Effect: "So You Can Work More...", Effect Duration: 30
 3692	decent huge sea persimmon	3	good	
-3693	wet jittery blurry blurry pressurized potion of perception	0		Effect: "Marbles in Your Mouth", Effect Duration: 65
+3693	wet blurry jittery blurry pressurized potion of perception	0		Effect: "Marbles in Your Mouth", Effect Duration: 65
 3694	double-anodized pressurized potion of proficiency	0		Effect: "Arresistible", Effect Duration: 55
 3695	friendly Mer-kin digpick	0		Familiar Weight: +3
 3696	wobbly anemone nematocyst	0		
@@ -3689,7 +3689,7 @@
 3723	tumbling tarnished rod	0		
 3724	brittle plastic handle	0		
 3725	foggy glass globe	0		
-3726	jittery squat red possessed tomato	0		
+3726	squat red jittery possessed tomato	0		
 3727	Nardz energy beverage	0		
 3728	pile of coins	0		
 3729	hand grenegg	0		
@@ -3719,13 +3719,13 @@
 3755	liquefied warmed flattened love song of smoldering passion	0		Effect: "Blackberry Politeness", Effect Duration: 54, Last Available: "2009-02"
 3756	modified love song of icy revenge	0		Effect: "Super Skill", Effect Duration: 29, Last Available: "2009-02"
 3757	double-dry tumbling love song of sugary cuteness	0		Effect: "Bilious Brains", Effect Duration: 56, Last Available: "2009-02"
-3758	deionized tarnished twirling spinning tumbling love song of disturbing obsession	0		Effect: "Black Lung", Effect Duration: 46, Last Available: "2009-02"
+3758	deionized tarnished twirling tumbling spinning love song of disturbing obsession	0		Effect: "Black Lung", Effect Duration: 46, Last Available: "2009-02"
 3759	cold-filtered liquefied squat love song of naughty innuendo	0		Effect: "Saucemastery", Effect Duration: 25, Last Available: "2009-02"
 3760	pickled colloidal breath mint	0		Effect: "All Blued Up", Effect Duration: 15
 3761	fuchsia double-paned vampire pearl ring	0		Cold Resistance: +5, Single Equip
 3762	frightening vampire pearl necklace	0		Spooky Damage: +5, Single Equip
-3763	watered-down mediocre slug of vodka	2	decent	
-3764	fortified aged slug of rum	5	awesome	
+3763	mediocre watered-down slug of vodka	2	decent	
+3764	aged fortified slug of rum	5	awesome	
 3765	weak mediocre slug of shochu	2	decent	
 3766	watered-down mediocre screwdiver	2	decent	
 3767	hand-crafted twirling dew yoana lei	3	EPIC	
@@ -3734,7 +3734,7 @@
 3770	acceptable dew yoana salacious lei	3	good	
 3771	perfectly mixed lime green salacious lychee chuhai	3	EPIC	
 3772	watered-down artisanal Alewife&trade; Ale	2	EPIC	
-3773	shaking pulsating seaode	0		
+3773	pulsating shaking seaode	0		
 3774	map to the Dive Bar	0		
 3775	shaking Mer-kin pinkslip	0		
 3776	wobbly Temple Grandin's pink pinkslip slip of wisdom	0		Mysticality: +15, Familiar Weight: +7, Familiar Effect: "1xVolley, 1xBarrr"
@@ -3780,14 +3780,14 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	huge Grandma's Map	0		
-3829	snack-sized toothsome ghostly tempura radish	2	awesome	
+3829	toothsome snack-sized ghostly tempura radish	2	awesome	
 3830	blinking Jim Carey's water-polo cap	0		Monster Level: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	smooth Typical Tavern swill	3	awesome	
 3832	weak delicious tropical swill	2	awesome	
 3833	acceptable upside-down fruity girl swill	3	good	
-3834	lousy twirling blurry blended swill	3	decent	
+3834	lousy blurry twirling blended swill	3	decent	
 3835	costume wardrobe	0		Softcore Only
-3836	miser's greasy Temple Grandin's energetic Elvish sunglasses	0		Maximum MP Percent: +20, Familiar Weight: +7, Sleaze Spell Damage: +10, Meat Drop: +10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	miser's greasy Temple Grandin's energetic Elvish sunglasses	0		Maximum MP Percent: +20, Familiar Weight: +7, Sleaze Spell Damage: +10, Meat Drop: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	twirling Samson's anniversary safety glass vest	0		Experience (Muscle): +5
 3838	bouncing banded anniversary burlap belt	0		Damage Absorption: +100
 3839	blue shellacked anniversary balsa wood socks	0		Damage Reduction: 7
@@ -3833,19 +3833,19 @@
 3879	torn hellseal sinew	0		
 3880	hellseal disguise	0		
 3881	supercharged fouet de tortue-dressage of chilblains	0		Maximum MP Percent: +30, Cold Damage: +25, Conditional Skill (Equipped): "Apprivoisez la tortue"
-3882	ghostly squat encoded cult documents	0		
+3882	squat ghostly encoded cult documents	0		
 3883	tumbling cult memo	0		
 3884	narrow decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	triple-altered yellow vial of slime	0		Effect: "Grape Expectations", Effect Duration: 65
 3886	moist pickled vial of slime	0		Effect: "Wet Rub", Effect Duration: 60
-3887	nitrogenated cold-filtered twirling ghostly vial of slime	0		Effect: "Bells in the Batfry", Effect Duration: 61
+3887	nitrogenated cold-filtered ghostly twirling vial of slime	0		Effect: "Bells in the Batfry", Effect Duration: 61
 3888	triple-liquefied triple-polymerized vial of slime	0		Effect: "Antibiotic Saucesphere", Effect Duration: 67
 3889	Vulcanized moist liquefied vial of slime	0		Effect: "Fudge Headache", Effect Duration: 12
 3890	improved polarized bouncing vial of violet slime	0		Effect: "Crotchety, Pining", Effect Duration: 38
 3891	moist cold-filtered narrow vial of vermilion slime	0		Effect: "Booing Radly", Effect Duration: 30
 3892	altered frozen upside-down vial of amber slime	0		Effect: "Liquid Luck", Effect Duration: 42
 3893	improved vial of chartreuse slime	0		Effect: "Wolf's Bane", Effect Duration: 21
-3894	wet alkaline double-pressed spinning jittery vial of teal slime	0		Effect: "Turtle Power", Effect Duration: 54
+3894	wet alkaline double-pressed jittery spinning vial of teal slime	0		Effect: "Turtle Power", Effect Duration: 54
 3895	galvanized boiled vial of indigo slime	0		Effect: "Balls of Ectoplasm", Effect Duration: 12
 3896	non-modified fuchsia vial of slime	0		Effect: "Chalked-Up Teeth", Effect Duration: 21
 3897	Vulcanized irradiated nitrogenated shaking vial of brown slime	0		Effect: "Lit Up", Effect Duration: 67
@@ -3897,7 +3897,7 @@
 3945	oyster egg balloon of the empath	0		Familiar Weight: +5
 3946	Clan VIP Lounge invitation	0		Free Pull
 3947	skewed Clan VIP Lounge key	0		Free Pull
-3948	narrow jittery Meat	0		
+3948	jittery narrow Meat	0		
 3949	treasure chest	0		
 3950	narrow key	0		
 3951	upside-down Baron von Ratsworth	0		
@@ -3988,7 +3988,7 @@
 4036	caustic slime nodule	0		
 4037	adequate blue slimy sweetbreads	4	good	
 4038	smooth slimy fermented bile bladder	3	awesome	
-4039	compressed narrow green slimy alveolus	1		Effect: "Ironclad", Effect Duration: 5
+4039	compressed green narrow slimy alveolus	1		Effect: "Ironclad", Effect Duration: 5
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	studded quilted pig-iron helm	0		Damage Absorption: 120, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
 4042	blinking auspicious pig-iron shinguards of terror	0		Spooky Spell Damage: +10, Item Drop: +10, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
@@ -4022,7 +4022,7 @@
 4070	essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	blurry essence of	0		Last Available: "2009-06"
-4073	green bouncing Supreme Being Glossary	0		Last Available: "2009-06"
+4073	bouncing green Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
 4075	rosewater-soaked beefcake's villainous scythe	0		Muscle: +25, Stench Resistance: +3, Slime Hates It: +2
 4076	olive blurry crafty medical-grade baneful bandolier	0		Maximum MP: +10, HP Regen Min: 7, HP Regen Max: 10, Slime Hates It: +1
@@ -4064,7 +4064,7 @@
 4112	blurry family-friendly slick bitter bowtie	0		Moxie: +10, Sleaze Resistance: +1, Last Available: "2009-06"
 4113	blurry red Temple Grandin's bewitching boots	0		Familiar Weight: +7, Last Available: "2009-06"
 4114	secret from the future	0		Last Available: "2009-06"
-4115	skewed gray moist sack	0		
+4115	gray skewed moist sack	0		
 4116	huge ruddy occult rickety unicycle of the blizzard	0		Spell Damage Percent: +25, Maximum HP Percent: +40, Cold Spell Damage: +25, Single Equip
 4117	blinking greedy censurious crusty hula hoop of temperance	0		Sleaze Resistance: 8, Meat Drop: +20, Single Equip
 4118	huge deadly Da Vinci's Newton's Coily&trade;	0		Experience (Mysticality): 8, Weapon Damage: +5
@@ -4080,16 +4080,16 @@
 4128	electrified Rosewater's brawny hardened slime pants	0		Muscle Percent: +20, Mysticality Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xPotato"
 4129	wobbly clever smooth hardened slime belt of Flo-Jo	0		Moxie: +15, Maximum MP: +20, Initiative: +100, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
-4131	twisted red pulsating twirling boot plant	1	good	Effect: "Pemmican't", Effect Duration: 20, Last Available: "2009-06"
+4131	twisted red twirling pulsating boot plant	1	good	Effect: "Pemmican't", Effect Duration: 20, Last Available: "2009-06"
 4132	hand-crafted sham champagne	3	EPIC	Last Available: "2009-06"
-4133	Vulcanized bouncing maroon tempura air	0		Effect: "Altered Wavelengths", Effect Duration: 26
+4133	Vulcanized maroon bouncing tempura air	0		Effect: "Altered Wavelengths", Effect Duration: 26
 4134	pressed yellow pressurized potion of pneumaticity	0		Effect: "Human-Slime Hybrid", Effect Duration: 56
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	tumbling smelly razor-sharp dance instructor's Bag o' Tricks of the scaredy-cat	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Monster Level: -15, Stench Spell Damage: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	tumbling smelly razor-sharp dance instructor's Bag o' Tricks of the scaredy-cat	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Monster Level: -15, Stench Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	huge a rumpled paper strip	0		
 4139	a creased paper strip	0		
-4140	blurry huge narrow a folded paper strip	0		
+4140	huge blurry narrow a folded paper strip	0		
 4141	a crinkled paper strip	0		
 4142	teal a crumpled paper strip	0		
 4143	a ragged paper strip	0		
@@ -4104,12 +4104,12 @@
 4152	adjusted aerosolized spinning gray Elvish delight	0		Effect: "Trash-Wrapped", Effect Duration: 37
 4153	rockfish stomach	0		Last Available: "2009-09"
 4154	live lobster	0		Last Available: "2011-12"
-4155	yellow tumbling wok lobster	0		Last Available: "2011-12"
+4155	tumbling yellow wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
 4157	cyan gravel	0		Last Available: "2009-09"
 4158	mirror rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	fancy weak delicious pebblebr&auml;u	2	awesome	Effect: "Patent Prevention", Effect Duration: 45, Last Available: "2009-09"
+4160	weak fancy delicious pebblebr&auml;u	2	awesome	Effect: "Patent Prevention", Effect Duration: 45, Last Available: "2009-09"
 4161	tasty miniature spinning rocky road ice cream	2	awesome	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	wet children of the candy corn	0		Effect: "Glittering Eyelashes", Effect Duration: 11
@@ -4199,7 +4199,7 @@
 4247	bad decanter of fine Scotch	3	decent	
 4248	diluted pulsating expensive cigar	1		Effect: "Petit Forbearance", Effect Duration: 50
 4249	jittery tophat	0		Familiar Weight: +5
-4250	mirror bouncing fisherman's sack	0		
+4250	bouncing mirror fisherman's sack	0		
 4251	red fish-oil smoke bomb	0		
 4252	pickled vial of squid ink	0		Effect: "Thicker, Sicker", Effect Duration: 27
 4253	wet vacuum-sealed potion of speed	0		Effect: "Thanksgot", Effect Duration: 43
@@ -4222,7 +4222,7 @@
 4270	wholesome sinister Newman's Own Trousers	0		Spell Damage: +10, Maximum HP Percent: +10, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato, cap 31"
 4271	skewed narrow hale Volartta's bellbottoms of Tarzan	0		Experience (Muscle): +3, Maximum HP: +20, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 4272	maroon avaricious medical-grade Lederhosen of the Night	0		Meat Drop: +30, HP Regen Min: 7, HP Regen Max: 10, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
-4273	magnetized energized tarnished spinning shaking purple ribbon candy	0		Effect: "Healthy Blue Glow", Effect Duration: 46, Last Available: "2020-09"
+4273	magnetized energized tarnished purple shaking spinning ribbon candy	0		Effect: "Healthy Blue Glow", Effect Duration: 46, Last Available: "2020-09"
 4274	upside-down Underworld acorn	0		Free Pull, Last Available: "2009-10"
 4275	blurry Underworld trunk	0		Last Available: "2009-10"
 4276	gravedigger's crafty beefcake's Underworld truncheon	0		Muscle: +25, Maximum MP: +10, Spooky Damage: +10, Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	scorching Ass-Stompers of Violence of the bloodbag of the scaredy-cat	0		Maximum HP: +100, Monster Level: -15, Hot Damage: +25, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	up-at-dawn MacGyver's Brand of Violence of the businessman	0		Maximum MP: +100, Meat Drop: +50, Adventures: +5, Conditional Skill (Equipped): "Brand"
 4299	wizardly brainy Novelty Belt Buckle of Violence of extreme caution	0		Mysticality: 30, Monster Level: -25, Single Equip
-4300	curative stylish strapping Lens of Violence	0		Muscle: +5, Moxie: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	curative stylish strapping Lens of Violence	0		Muscle: +5, Moxie: +25, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	twirling reassuring double-paned thinker's Pigsticker of Violence	0		Mysticality: +10, Cold Resistance: +5, Spooky Resistance: +1
-4302	wholesome dance instructor's Jodhpurs of Violence of bravery	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Spooky Resistance: +5, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	wholesome dance instructor's Jodhpurs of Violence of bravery	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	reassuring manspreader's boxer's Cold Stone of Hatred	0		Muscle Percent: +10, Monster Level: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Chilling Grip"
 4304	chilly extremely unsafe Girdle of Hatred of horror	0		Weapon Damage Percent: +100, Cold Damage: +5, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	rock-hard Staff of Simmering Hatred of James Dean of bravery	0		Experience (Moxie): +3, Damage Reduction: 5, Spooky Resistance: +5
-4306	prompt rosewater-soaked Lo Pan's Pantaloons of Hatred	0		Spell Critical Percent: +30, Stench Resistance: +3, Adventures: +3, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	prompt rosewater-soaked Lo Pan's Pantaloons of Hatred	0		Spell Critical Percent: +30, Stench Resistance: +3, Adventures: +3, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	executive electrified Fuzzy Slippers of Hatred of the detective	0		Item Drop: +20, Meat Drop: +40, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-4308	aromatic Lens of Hatred of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Stench Resistance: +1, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	aromatic Lens of Hatred of the dark arts of Calamity Jane	0		Spell Damage Percent: +100, Critical Hit Percent: +15, Stench Resistance: +1, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	tumbling rosewater-soaked Treads of Loathing of bravery of temperance	0		Spooky Resistance: +5, Stench Resistance: +3, Sleaze Resistance: +5, Single Equip
 4310	blurry prompt friendly Scepter of Loathing of the sewer	0		Familiar Weight: +3, Stench Damage: +25, Adventures: +3
 4311	red mirror fireproof thinker's weightlifter's Belt of Loathing	0		Muscle: +15, Mysticality: +10, Hot Resistance: +3, Single Equip
@@ -4293,9 +4293,9 @@
 4341	ionized BitterSweetTarts	0		Effect: "Stemonitis Storm", Effect Duration: 45, Last Available: "2009-12"
 4342	dry Polka Pop	0		Effect: "Colorful Gratitude", Effect Duration: 15, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
-4344	jittery purple squat Crimbo wreath	0		Last Available: "2009-12"
+4344	squat jittery purple Crimbo wreath	0		Last Available: "2009-12"
 4345	blinking string of Crimbo lights	0		Last Available: "2009-12"
-4346	green spinning plastic Crimbo reindeer	0		Last Available: "2009-12"
+4346	spinning green plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
 4349	upside-down snow hat of the wise owl	0		Mysticality: +20, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	double-paned peanut brittle shield	0		Cold Resistance: +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	groovy Red Rover BB gun of Flo-Jo	0		Moxie Percent: +10, Initiative: +100, Last Available: "2009-12"
-4391	scorching red-and-green sweater	0		Hot Damage: +25, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	scorching red-and-green sweater	0		Hot Damage: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	squat Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	denatured colloidal twirling Crimbo peppermint bark	0		Effect: "Strong Spirit", Effect Duration: 19, Last Available: "2009-12"
 4394	galvanized narrow Crimbo fudge	0		Effect: "Bloody-minded", Effect Duration: 53, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	huge Sinatra's cheese sword	0		Experience (Moxie): +5, Softcore Only, Last Available: "2010-01"
 4400	electrified cheese diaper	0		MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	green cheese wheel of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	upside-down careful cheese eye	0		Monster Level: -10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	upside-down careful cheese eye	0		Monster Level: -10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	huge perfumed Samson's Staff of Queso Escusado of Leguizamo	0		Experience (Muscle): +5, Monster Level: +20, Stench Resistance: +5, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4359,7 +4359,7 @@
 4408	A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
-4411	squat squat wobbly teal Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
+4411	wobbly squat teal squat Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	spoiled quantum taco	0		Last Available: "2010-10"
 4413	acceptable Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
@@ -4378,8 +4378,8 @@
 4428	healthy glowstick on a string	0		Maximum HP Percent: +20
 4429	gray huge avaricious candy necklace	0		Meat Drop: +30, Single Equip
 4430	bouncing friendly teddybear backpack	0		Familiar Weight: +3
-4431	ghostly blurry NPZR chemistry set	0		Last Available: "2011-08"
-4432	ionized maroon narrow invisibility potion	0		Effect: "Cotton Mouthed", Effect Duration: 40, Last Available: "2011-08"
+4431	blurry ghostly NPZR chemistry set	0		Last Available: "2011-08"
+4432	ionized narrow maroon invisibility potion	0		Effect: "Cotton Mouthed", Effect Duration: 40, Last Available: "2011-08"
 4433	colloidal denatured narrow irresistibility potion	0		Effect: "Red Around the Gills", Effect Duration: 11, Last Available: "2011-08"
 4434	super-aerosolized pickled irritability potion	0		Effect: "Powdered", Effect Duration: 35, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
@@ -4450,17 +4450,17 @@
 4502	vacuum-sealed huge recording of Donho's Bubbly Ballad	0		Effect: "Shamboozled", Effect Duration: 21
 4503	super-boiled warmed skewed tumbling recording of Inigo's Incantation of Inspiration	0		Effect: "Sewer-Drenched", Effect Duration: 28, Last Available: "2010-02"
 4504	flame-wreathed scorching heart of the volcano	0		Hot Damage: +25, Hot Spell Damage: +10
-4505	Vulcanized warmed bouncing wobbly Northern pemmican	0		Effect: "Charrrming", Effect Duration: 36
+4505	Vulcanized warmed wobbly bouncing Northern pemmican	0		Effect: "Charrrming", Effect Duration: 36
 4506	puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	aerosolized chilled narrow &quot;DRINK ME&quot; potion	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 22, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	moldy walrus ice cream	3	crappy	Last Available: "2010-03"
-4511	diet delicious beautiful soup	1	awesome	Last Available: "2010-03"
+4511	delicious diet beautiful soup	1	awesome	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	rotten snack-sized Humpty Dumplings	2	crappy	Last Available: "2010-03"
-4515	rotten special blurry Lobster <i>qua</i> Grill	3	crappy	Effect: "Moon'd", Effect Duration: 45, Last Available: "2010-03"
+4514	snack-sized rotten Humpty Dumplings	2	crappy	Last Available: "2010-03"
+4515	special rotten blurry Lobster <i>qua</i> Grill	3	crappy	Effect: "Moon'd", Effect Duration: 45, Last Available: "2010-03"
 4516	bad weak missing wine	2	decent	Last Available: "2010-03"
 4517	small bland matter custard	2	decent	Last Available: "2010-03"
 4518	energized vacuum-sealed irradiated mirror comfit?	0		Effect: "Patent Avarice", Effect Duration: 25, Last Available: "2010-03"
@@ -4476,11 +4476,11 @@
 4528	moldy dragon snaps	3	crappy	Last Available: "2010-03"
 4529	upside-down veiny Socratic snapdragon pistil	0		Experience (Mysticality): +1, Maximum HP: +10, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	flavorless enchanted rook cookie	4	decent	Effect: "Unusual Fashion Sense", Effect Duration: 35, Last Available: "2010-03"
+4531	enchanted flavorless rook cookie	4	decent	Effect: "Unusual Fashion Sense", Effect Duration: 35, Last Available: "2010-03"
 4532	decent spinning bishop cookie	3	good	Last Available: "2010-03"
-4533	moldy spinning squat knight cookie	3	crappy	Last Available: "2010-03"
+4533	moldy squat spinning knight cookie	3	crappy	Last Available: "2010-03"
 4534	adequate king cookie	4	good	Last Available: "2010-03"
-4535	diet rotten spinning queen cookie	1	crappy	Effect: "Towering Strength", Last Available: "2010-03"
+4535	rotten diet spinning queen cookie	1	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	shaking fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	purple insane tophat of bravery	0		Spooky Resistance: +5, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 4538	Oprah's energetic helm of the knight	0		Maximum MP Percent: 70, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
@@ -4518,7 +4518,7 @@
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	flavorless squirmy violent party snack	4	decent	Last Available: "2010-04"
 4572	smooth can-you-dig-it?	0		Moxie: +15, Last Available: "2010-04"
-4573	tumbling jittery The Legendary Beat	0		Last Available: "2010-04"
+4573	jittery tumbling The Legendary Beat	0		Last Available: "2010-04"
 4574	huge panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	blurry bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
@@ -4538,7 +4538,7 @@
 4590	ghostly stylish pixel chain whip	0		Moxie: +25, Last Available: "2010-07"
 4591	narrow pixel morning star of temperance	0		Sleaze Resistance: +5, Last Available: "2010-07"
 4592	bouncing pixel orb	0		Last Available: "2010-07"
-4593	cyan twirling pixellated moneybag	0		Last Available: "2010-07"
+4593	twirling cyan pixellated moneybag	0		Last Available: "2010-07"
 4594	pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
@@ -4550,9 +4550,9 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	bouncing keg	0		Last Available: "2010-06"
-4605	studded quilted bottle of Goldschn&ouml;ckered	0		Damage Absorption: 120, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	low-calorie adequate sun-dried tofu	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	mediocre special soyburger juice	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	studded quilted bottle of Goldschn&ouml;ckered	0		Damage Absorption: 120, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4606	adequate low-calorie sun-dried tofu	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	special mediocre soyburger juice	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	squat respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	super-modified essential soy	0		Effect: "Whitened Teeth", Effect Duration: 67, Last Available: "2010-08"
@@ -4563,7 +4563,7 @@
 4615	hand-crafted Cinco Mayo Lager	3	EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
-4618	mirror yellow plastic cup of flat beer	0		
+4618	yellow mirror plastic cup of flat beer	0		
 4619	upside-down frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
@@ -4574,14 +4574,14 @@
 4626	bouncing superduperball	0		Last Available: "2010-06"
 4627	spinning finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	plastic spider ring of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	plastic spider ring of Tarzan	0		Experience (Muscle): +3, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	knitted plastic kazoo	0		Cold Resistance: +3, Last Available: "2010-06"
 4631	smartaleck's inflatable baseball bat	0		Moxie Percent: +30, Last Available: "2010-06"
 4632	tumbling reassuring vibrating googly-star hat	0		Maximum MP Percent: +10, Spooky Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk"
 4633	ghostly shaking healthy googly-ball hat of the blizzard	0		Maximum HP Percent: +20, Cold Spell Damage: +25, Last Available: "2010-06"
 4634	fuchsia sizzling manspreader's googly-heart hat	0		Monster Level: +10, Hot Damage: +10, Last Available: "2010-06"
 4635	coward's super-sweet boom box of the early riser	0		Monster Level: -20, Adventures: +7, Four Songs, Last Available: "2010-06"
-4636	cyan blurry Game Grid valued membership card	0		Last Available: "2010-06"
+4636	blurry cyan Game Grid valued membership card	0		Last Available: "2010-06"
 4637	savvy wizardly sinister demon mask of the bloodbag	0		Mysticality: +25, Mysticality Percent: +20, Maximum HP: +100, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	ghostly streetfighting champion's belt of the dark arts of the empath of horror	0		Spell Damage Percent: +100, Familiar Weight: +5, Spooky Spell Damage: +25, Single Equip, Last Available: "2010-06"
 4639	reassuring stylish Space Trip safety headphones of the wise owl	0		Mysticality: +20, Moxie: +25, Spooky Resistance: +1, Single Equip, Last Available: "2010-06"
@@ -4616,7 +4616,7 @@
 4668	wobbly frosty observational glasses	0		Cold Spell Damage: +10
 4669	red Fonzie's hilarious comedy prop	0		Experience (Moxie): +1
 4670	beer-scented teddy bear	0		
-4671	mediocre irresponsibly strong special booze-soaked cherry	9	decent	Effect: "Blessing of Squirtlcthulli", Effect Duration: 15
+4671	special mediocre irresponsibly strong booze-soaked cherry	9	decent	Effect: "Blessing of Squirtlcthulli", Effect Duration: 15
 4672	comfy pillow	0		
 4673	moldy diet bouncing marshmallow	1	crappy	
 4674	bite-sized bland sponge cake	1	decent	
@@ -4658,10 +4658,10 @@
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	bouncing sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	blue GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
-4713	twirling narrow popsicle stick	0		
+4713	narrow twirling popsicle stick	0		
 4714	stale lemon popsicle	3	decent	
-4715	flavorless fancy mirror popsicle	4	decent	Effect: "The Smeezingtons", Effect Duration: 10
-4716	half-sized bland strawberry popsicle	2	decent	
+4715	fancy flavorless mirror popsicle	4	decent	Effect: "The Smeezingtons", Effect Duration: 10
+4716	bland half-sized strawberry popsicle	2	decent	
 4717	yummy liver popsicle	4	awesome	
 4718	bouncing Da Vinci's mariachi hat	0		Experience (Mysticality): +5, Familiar Effect: "atk, cap 2"
 4719	wobbly razor-sharp Hollandaise helmet	0		Weapon Damage Percent: +25, Familiar Effect: "atk, cap 2"
@@ -4670,11 +4670,11 @@
 4722	stale liver and let pie	3	decent	Last Available: "2010-10"
 4723	fancy decent ghostly badass pie	3	good	Effect: "Tremella Tremens", Effect Duration: 10, Last Available: "2010-10"
 4724	super-sized moldy blurry shoo-fish pie	5	crappy	Last Available: "2010-10"
-4725	jumbo tasty piping organ pie	5	awesome	Last Available: "2010-10"
+4725	tasty jumbo piping organ pie	5	awesome	Last Available: "2010-10"
 4726	spoiled igloo pie	3	crappy	Last Available: "2010-10"
 4727	moldy stomach turnover	3	crappy	Last Available: "2010-10"
-4728	moldy bite-sized dead lights pie	1	crappy	Last Available: "2010-10"
-4729	spoiled massive throbbing organ pie	8	crappy	Last Available: "2010-10"
+4728	bite-sized moldy dead lights pie	1	crappy	Last Available: "2010-10"
+4729	massive spoiled throbbing organ pie	8	crappy	Last Available: "2010-10"
 4730	skewed teal Jack Frost's stop shield	0		Cold Spell Damage: +50, Damage Reduction: 6, Last Available: "2009-12"
 4731	fuchsia nest egg	0		
 4732	twirling sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4685,14 +4685,14 @@
 4737	Newton's beer-soaked mop	0		Experience (Mysticality): +3
 4738	aged day-old beer	3	awesome	
 4739	drinkable plain beer	3	good	
-4740	practically non-alcoholic aged overpriced &quot;imported&quot; beer	1	awesome	
+4740	aged practically non-alcoholic overpriced &quot;imported&quot; beer	1	awesome	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
-4743	narrow shaking bone chips	0		Last Available: "2011-12"
+4743	shaking narrow bone chips	0		Last Available: "2011-12"
 4744	tarnished deionized PlexiPips	0		Effect: "Smoky Third Eye", Effect Duration: 13
 4745	irradiated Wax Flask	0		Effect: "Jerky, Boy", Effect Duration: 13
 4746	Vulcanized Pain Dip	0		Effect: "Well-Swabbed Ear", Effect Duration: 65
-4747	diet spoiled squat purple bone meal	1	crappy	Last Available: "2010-10"
+4747	diet spoiled purple squat bone meal	1	crappy	Last Available: "2010-10"
 4748	drinkable boozy bone aperitif	5	good	Last Available: "2010-10"
 4749	bonerang of chilblains	0		Cold Damage: +25, Last Available: "2010-10"
 4750	blurry Jack Frost's bone and arrows	0		Cold Spell Damage: +50, Last Available: "2010-10"
@@ -4708,8 +4708,8 @@
 4760	red packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	gigantic adequate mirror pumpkin pie	6	good	Last Available: "2010-11"
-4764	spirit-forward aged pulsating pumpkin beer	5	awesome	Last Available: "2010-11"
+4763	adequate gigantic mirror pumpkin pie	6	good	Last Available: "2010-11"
+4764	aged spirit-forward pulsating pumpkin beer	5	awesome	Last Available: "2010-11"
 4765	galvanized ionized pumpkin juice	0		Effect: "Sugary World View", Effect Duration: 39, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	friendly smooth shin gourds	0		Moxie: +15, Familiar Weight: +3, Single Equip, Last Available: "2010-11"
@@ -4722,12 +4722,12 @@
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	bouncing shaking Unmotivator: Crashed Meat Car	0		Free Pull
 4810	blinking Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	bouncing huge Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	huge bouncing Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	spoiled bouncing CRIMBCOIDS mints	4	crappy	Last Available: "2011-01"
-4819	shaking jittery can of CRIMBCOLA	0		Last Available: "2010-12"
+4819	jittery shaking can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	normal jittery CRIMBCOLOAF	3	good	Last Available: "2011-01"
-4821	snack-sized moldy squat circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	moldy snack-sized squat circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	supercharged plastic CRIMBCO HQ	0		Maximum MP Percent: +30, Last Available: "2010-12"
 4823	pulsating cyan avaricious plastic fax machine	0		Meat Drop: +30, Last Available: "2010-12"
 4824	mirror plastic hobo elf of the storm	0		Maximum MP Percent: +40, Last Available: "2010-12"
@@ -4771,7 +4771,7 @@
 4862	blurry upside-down CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	skewed photocopier	0		Last Available: "2011-01"
-4865	lime green pulsating deluxe fax machine	0		Last Available: "2011-01"
+4865	pulsating lime green deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	aromatic knitted Van der Graaf paperclip-on tie	0		Cold Resistance: +3, Stench Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-01"
@@ -4781,7 +4781,7 @@
 4872	tumbling glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
-4875	shaking cyan BGE merchandise order form	0		Last Available: "2010-12"
+4875	cyan shaking BGE merchandise order form	0		Last Available: "2010-12"
 4876	diffused squat chocolate bath ball	0		Effect: "Bandersnatched", Effect Duration: 11, Last Available: "2011-01"
 4877	dry cold-filtered bacon bath ball	0		Effect: "Patience of the Tortoise", Effect Duration: 55, Last Available: "2011-01"
 4878	ionized warmed incense bath ball	0		Effect: "Spirit Bubble", Effect Duration: 36, Last Available: "2011-01"
@@ -4795,12 +4795,12 @@
 4886	toothsome traffic jam toast	3	awesome	Last Available: "2011-01"
 4887	blinking space jam	0		Last Available: "2011-01"
 4888	diet flavorless jittery space jam toast	1	decent	Last Available: "2011-01"
-4889	irradiated quadruple-dry maroon blinking motivational poster	0		Effect: "Chunky", Effect Duration: 21, Last Available: "2011-01"
+4889	irradiated quadruple-dry blinking maroon motivational poster	0		Effect: "Chunky", Effect Duration: 21, Last Available: "2011-01"
 4890	gray squat sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	cyan slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	toothsome small festive sausage	2	awesome	Last Available: "2011-01"
+4894	small toothsome festive sausage	2	awesome	Last Available: "2011-01"
 4895	normal holiday cheese log	3	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	squat Fonzie's BGE 'ferocious fruit' shirt of Gandalf	0		Experience (Moxie): +1, Spell Critical Percent: +20, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	huge quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	spoiled snack-sized Knob jelly donut	2	crappy	
+4941	snack-sized spoiled Knob jelly donut	2	crappy	
 4942	blurry Knob cake	0		
 4943	Knob cake pan	0		
 4944	Knob batter	0		
@@ -4859,7 +4859,7 @@
 4956	toothsome philosopher's scone	3	awesome	
 4957	aerosolized corrupted super-deionized yellow huge half-baked potion	0		Effect: "Innately Strong", Effect Duration: 41
 4958	Knob Goblin deluxe scimitar of Gandalf	0		Spell Critical Percent: +20
-4959	snack-sized tasty Knob nuts	2	awesome	
+4959	tasty snack-sized Knob nuts	2	awesome	
 4960	drinkable fancy Cobb's Knob Wurstbrau	3	good	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 40
 4961	Subject 37 file	0		
 4962	double-paned flame-wreathed mysterious lapel pin	0		Hot Spell Damage: +10, Cold Resistance: +5, Single Equip
@@ -4905,13 +4905,13 @@
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
-5005	narrow gray squat Alice's Army Foil Sniper	0		Last Available: "2011-03"
+5005	gray narrow squat Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
 5007	twirling Alice's Army Foil Martyr	0		Last Available: "2011-03"
-5008	blurry yellow Single Alice's Army Foil	0		Last Available: "2011-03"
+5008	yellow blurry Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	censurious card sleeve	0		Sleaze Resistance: +3, Last Available: "2011-03"
 5010	skewed evil eye	0		
-5011	shaking spinning Alice's Army Foil tattoo	0		Last Available: "2011-03"
+5011	spinning shaking Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	moldy blinking wasabi pocky	4	crappy	Last Available: "2011-03"
 5014	tasty tobiko pocky	3	awesome	Last Available: "2011-03"
@@ -4925,9 +4925,9 @@
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	galvanized lime green elderly jawbreaker	0		Effect: "Feelin' Philosophical", Effect Duration: 41, Last Available: "2020-09"
 5024	weak drinkable marshmallow flamb&eacute;	2	good	Last Available: "2011-03"
-5025	artisanal fancy watered-down cranberry schnapps	2	super ultra EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2011-03"
-5026	artisanal practically non-alcoholic breaded beer	1	super ultra mega turbo EPIC	Last Available: "2011-03"
-5027	mediocre watered-down soy cordial	2	decent	Last Available: "2011-03"
+5025	watered-down fancy artisanal cranberry schnapps	2	super ultra EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2011-03"
+5026	practically non-alcoholic artisanal breaded beer	1	super ultra mega turbo EPIC	Last Available: "2011-03"
+5027	watered-down mediocre soy cordial	2	decent	Last Available: "2011-03"
 5028	lard-coated friendly groovy astral bludgeon	0		Moxie Percent: +10, Familiar Weight: +3, Sleaze Spell Damage: +25
 5029	Sinatra's astral shield of Gandalf	0		Experience (Moxie): +5, Spell Critical Percent: +20, Damage Reduction: 15
 5030	supercharged Samson's astral chapeau of bravery	0		Experience (Muscle): +5, Maximum MP Percent: +30, Spooky Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4944,7 +4944,7 @@
 5041	Jeselnik's vibrating savvy astral shirt	0		Mysticality Percent: +20, Maximum MP Percent: +10, Sleaze Damage: +25
 5042	mirror smelly astral belt of the cougar	0		Moxie: +20, Stench Spell Damage: +10
 5043	spoiled astral hot dog	3		
-5044	boozy acceptable astral pilsner	5		
+5044	acceptable boozy astral pilsner	5		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	drinkable Jeppson's Malort	3	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	grievous stress ball	0		Weapon Damage Percent: +50, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	grievous stress ball	0		Weapon Damage Percent: +50, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	bouncing Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	crafty Ultracolor&trade; shirt	0		Maximum MP: +10, Last Available: "2011-05"
 5112	maroon My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5029,7 +5029,7 @@
 5126	bouncing jittery Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
-5129	huge tumbling Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
+5129	tumbling huge Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	upside-down Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	anodized wet bouncing Ultrasoldier Serum	0		Effect: "Boschface", Effect Duration: 69, Last Available: "2011-06"
 5132	bland snack-sized narrow elven hardtack	2	decent	Last Available: "2011-06"
@@ -5044,10 +5044,10 @@
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
-5144	green upside-down handful of honey	0		
+5144	upside-down green handful of honey	0		
 5145	frozen corrupted tumbling teal squat honeypot	0		Effect: "Super-Mega-Charged", Effect Duration: 62
-5146	decent special diet huge wild honey pie	1	good	Effect: "Buzzard Breath", Effect Duration: 5
-5147	special practically non-alcoholic delicious honey mead	1	awesome	Effect: "Blackberry Politeness", Effect Duration: 35
+5146	special diet decent huge wild honey pie	1	good	Effect: "Buzzard Breath", Effect Duration: 5
+5147	special delicious practically non-alcoholic honey mead	1	awesome	Effect: "Blackberry Politeness", Effect Duration: 35
 5148	inspector's shellacked brainy honey dipper	0		Mysticality: +5, Damage Reduction: 7, Item Drop: +15
 5149	scandalous fortified beefy honeybritches	0		Muscle: +10, Damage Absorption: +60, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	groovy honeycap of James Dean of horror	0		Moxie Percent: +10, Experience (Moxie): +3, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, cap 43"
@@ -5072,13 +5072,13 @@
 5169	shaking elven medi-pack	0		Last Available: "2011-06"
 5170	galvanized corrupted dry mirror transporter transponder	0		Effect: "Old Time Hydration", Effect Duration: 24, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
-5172	wobbly yellow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
+5172	yellow wobbly Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	narrow elven magi-pack	0		Last Available: "2011-06"
 5174	bad Saison du Lune	4	decent	Last Available: "2011-06"
 5175	hand-crafted tumbling Moonthril Schnapps	4	EPIC	Last Available: "2011-06"
-5176	practically non-alcoholic drinkable upside-down Wrecked Generator	1	good	Last Available: "2011-06"
-5177	huge normal special Spaghetti with Moonballs	7	good	Effect: "Unrunnable Face", Effect Duration: 5, Last Available: "2011-06"
-5178	flavorless small Crepes a la Lune	2	decent	Last Available: "2011-06"
+5176	drinkable practically non-alcoholic upside-down Wrecked Generator	1	good	Last Available: "2011-06"
+5177	normal special huge Spaghetti with Moonballs	7	good	Effect: "Unrunnable Face", Effect Duration: 5, Last Available: "2011-06"
+5178	small flavorless Crepes a la Lune	2	decent	Last Available: "2011-06"
 5179	moldy Moon Pie	4	crappy	Last Available: "2011-06"
 5180	modified double-adjusted Comet Pop	0		Effect: "All Glory To the Toad", Effect Duration: 35, Last Available: "2011-06"
 5181	polarized teal Flan in the Moon	0		Effect: "Whitened Teeth", Effect Duration: 27, Last Available: "2011-06"
@@ -5090,9 +5090,9 @@
 5187	mirror Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	aerosolized chilled bouncing honey stick	0		Effect: "Staying Frosty", Effect Duration: 16
 5189	Vulcanized narrow double-ice gum	0		Effect: "Ghostly Shell", Effect Duration: 14, Last Available: "2011-04"
-5190	jittery avaricious inspector's ribald Operation Patriot Shield	0		Sleaze Damage: +10, Item Drop: +15, Meat Drop: +30, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	jittery avaricious inspector's ribald Operation Patriot Shield	0		Sleaze Damage: +10, Item Drop: +15, Meat Drop: +30, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
-5192	energized blinking jittery corrupted data	0		Effect: "Took Eleven", Effect Duration: 34, Last Available: "2011-06"
+5192	energized jittery blinking corrupted data	0		Effect: "Took Eleven", Effect Duration: 34, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
 5194	pulsating exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
@@ -5109,7 +5109,7 @@
 5206	dehydrated wobbly demonic paste	1	crappy	Last Available: "2011-08"
 5207	powdered mirror green indescribably horrible paste	1	decent	Last Available: "2011-08"
 5208	compressed blurry mirror paste	1	crappy	Last Available: "2011-08"
-5209	pickled tumbling spinning goblin paste	1	crappy	Last Available: "2011-08"
+5209	pickled spinning tumbling goblin paste	1	crappy	Last Available: "2011-08"
 5210	diluted jittery pirate paste	1	good	Last Available: "2011-08"
 5211	modified blinking chlorophyll paste	1	decent	Last Available: "2011-08"
 5212	boiled bouncing paste	1	good	Last Available: "2011-08"
@@ -5126,9 +5126,9 @@
 5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	decent Ur-Donut	3	good	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
-5226	blue squat bouncing box of Familiar Jacks	0		Last Available: "2011-09"
+5226	squat bouncing blue box of Familiar Jacks	0		Last Available: "2011-09"
 5227	lousy weak bucket of wine	2	decent	Last Available: "2011-09"
-5228	adequate blurry purple ultrafondue	3	good	Last Available: "2011-09"
+5228	adequate purple blurry ultrafondue	3	good	Last Available: "2011-09"
 5229	huge unbearable light	0		Last Available: "2011-09"
 5230	mirror snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5138,33 +5138,33 @@
 5235	lard-coated furry halo	0		Sleaze Spell Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	ghostly frosty halo of the ox	0		Muscle: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	Herculean time halo	0		Experience (Muscle): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	practically non-alcoholic drinkable lime green Lumineux Limnio	1	good	Last Available: "2011-09"
-5239	acceptable green skewed shaking Morto Moreto	4	good	Last Available: "2011-09"
+5238	drinkable practically non-alcoholic lime green Lumineux Limnio	1	good	Last Available: "2011-09"
+5239	acceptable skewed shaking green Morto Moreto	4	good	Last Available: "2011-09"
 5240	mediocre tumbling Temps Tempranillo	3	decent	Last Available: "2011-09"
 5241	aged bouncing Bordeaux Marteaux	4	awesome	Last Available: "2011-09"
 5242	drinkable triple-distilled Fromage Pinotage	9	good	Last Available: "2011-09"
 5243	tolerable bouncing Beignet Milgranet	3	good	Last Available: "2011-09"
 5244	watered-down acceptable Muschat	2	good	Last Available: "2011-09"
 5245	adequate cool jelly donut	3	good	Last Available: "2011-09"
-5246	diet toothsome shrapnel jelly donut	1	awesome	Last Available: "2011-09"
+5246	toothsome diet shrapnel jelly donut	1	awesome	Last Available: "2011-09"
 5247	adequate occult jelly donut	4	good	Last Available: "2011-09"
-5248	stale super-sized thyme jelly donut	5	decent	Last Available: "2011-09"
+5248	super-sized stale thyme jelly donut	5	decent	Last Available: "2011-09"
 5249	gigantic stale lime green danish	6	decent	Last Available: "2011-09"
-5250	special rotten lime green smashed danish	3	crappy	Effect: "Spiky Hair", Effect Duration: 30, Last Available: "2011-09"
-5251	decent bite-sized forbidden danish	1	good	Last Available: "2011-09"
+5250	rotten special lime green smashed danish	3	crappy	Effect: "Spiky Hair", Effect Duration: 30, Last Available: "2011-09"
+5251	bite-sized decent forbidden danish	1	good	Last Available: "2011-09"
 5252	spoiled cool cat claw	3	crappy	Last Available: "2011-09"
 5253	decent fancy blunt cat claw	4	good	Effect: "Supafly", Effect Duration: 45, Last Available: "2011-09"
 5254	stale pulsating shadowy cat claw	3	decent	Last Available: "2011-09"
-5255	small moldy cheezburger	2	crappy	Last Available: "2011-09"
+5255	moldy small cheezburger	2	crappy	Last Available: "2011-09"
 5256	decent toasted brie	3	good	Last Available: "2011-09"
 5257	modified alkaline denatured tumbling skewed potion of the field gar	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 65, Last Available: "2011-09"
 5258	denatured extra-quantum polarized too legit potion	0		Effect: "Pla-see-bo", Effect Duration: 47, Last Available: "2011-09"
 5259	energized anodized Bright Water	0		Effect: "Just Aged Enough", Effect Duration: 57, Last Available: "2011-09"
 5260	quadruple-polarized quantum Vulcanized cold-filtered water	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 54, Last Available: "2011-09"
-5261	vacuum-sealed pulsating maroon skewed graveyard snowglobe	0		Effect: "Cranberry Cordiality", Effect Duration: 46, Last Available: "2011-09"
+5261	vacuum-sealed maroon skewed pulsating graveyard snowglobe	0		Effect: "Cranberry Cordiality", Effect Duration: 46, Last Available: "2011-09"
 5262	ionized wet cool cat elixir	0		Effect: "Elron's Explosive Etude", Effect Duration: 47, Last Available: "2011-09"
 5263	improved diffused potion of the captain's hammer	0		Effect: "Blackberry Politeness", Effect Duration: 15, Last Available: "2011-09"
-5264	double-concentrated warmed blinking blurry potion of X-ray vision	0		Effect: "Shredding, Sweating", Effect Duration: 31, Last Available: "2011-09"
+5264	double-concentrated warmed blurry blinking potion of X-ray vision	0		Effect: "Shredding, Sweating", Effect Duration: 31, Last Available: "2011-09"
 5265	extra-polarized deionized magnetized potion of the litterbox	0		Effect: "Hella Tough", Effect Duration: 50, Last Available: "2011-09"
 5266	adjusted frozen potion of animal rage	0		Effect: "El Vibrations", Effect Duration: 69, Last Available: "2011-09"
 5267	warmed wobbly potion of punctual companionship	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 28, Last Available: "2011-09"
@@ -5192,14 +5192,14 @@
 5289	yellow d12	0		Last Available: "2011-09"
 5290	narrow d20	0		Last Available: "2011-09"
 5291	blinking generic healing potion	0		Last Available: "2011-09"
-5292	squat fuchsia generic mana potion	0		Last Available: "2011-09"
+5292	fuchsia squat generic mana potion	0		Last Available: "2011-09"
 5293	generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
 5295	teal newborn kobold	0		Last Available: "2011-09"
 5296	twirling slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	adequate mirror phish stick	3	good	Last Available: "2011-09"
-5299	chaotic veiny baleful plastic vampire fangs	0		Spell Damage: +25, Maximum HP: +10, Spell Critical Percent: +10, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	chaotic veiny baleful plastic vampire fangs	0		Spell Damage: +25, Maximum HP: +10, Spell Critical Percent: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5207,7 +5207,7 @@
 5304	Jeselnik's Herculean Chalice of the Malkovich Prince of Leguizamo	0		Experience (Muscle): +1, Monster Level: +20, Sleaze Damage: +25, Last Available: "2011-10"
 5305	miser's Sceptre of the Torremolinos Prince	0		Meat Drop: +10, Last Available: "2011-10"
 5306	ruddy Medallion of the Ventrilo Prince	0		Maximum HP Percent: +40, Last Available: "2011-10"
-5307	skewed bouncing Haunted Sorority House staff guide	0		Last Available: "2011-10"
+5307	bouncing skewed Haunted Sorority House staff guide	0		Last Available: "2011-10"
 5308	ghost trap	0		Last Available: "2011-10"
 5309	mirror chainsaw chain	0		Last Available: "2011-10"
 5310	shotgun shell	0		Last Available: "2011-10"
@@ -5215,7 +5215,7 @@
 5312	corrupted huge ghostly body paint	0		Effect: "Egg-stra Arm", Effect Duration: 22, Last Available: "2011-10"
 5313	extra-electrified necrotizing body spray	0		Effect: "Mistified", Effect Duration: 54, Last Available: "2011-10"
 5314	alkaline bouncing bite-me-red lipstick	0		Effect: "Fiery Spirit", Effect Duration: 33, Last Available: "2011-10"
-5315	improved fuchsia upside-down squat whisker pencil	0		Effect: "BOOsted", Effect Duration: 40, Last Available: "2011-10"
+5315	improved fuchsia squat upside-down whisker pencil	0		Effect: "BOOsted", Effect Duration: 40, Last Available: "2011-10"
 5316	electrified press-on ribs	0		Effect: "Bone Chilling", Effect Duration: 67, Last Available: "2011-10"
 5317	alkaline nitrogenated concentrated Rattlin' Chains	0		Effect: "Bestial Sympathy", Effect Duration: 63, Last Available: "2011-10"
 5318	ionized anodized narrow Gummy Brains	0		Effect: "Pumped Up", Effect Duration: 31, Last Available: "2011-10"
@@ -5224,7 +5224,7 @@
 5321	aerosolized wet upside-down Sweet Sword	0		Effect: "Berry Statistical", Effect Duration: 20, Last Available: "2011-10"
 5322	mediocre spirit-forward Ecto-Cooler	5	decent	Last Available: "2011-10"
 5323	mediocre Bartles and BRAAAINS wine cooler	3	decent	Last Available: "2011-10"
-5324	triple-distilled drinkable skewed Blood Light	8	good	Last Available: "2011-10"
+5324	drinkable triple-distilled skewed Blood Light	8	good	Last Available: "2011-10"
 5325	bad practically non-alcoholic wobbly Silver Bullet beer	1	decent	Last Available: "2011-10"
 5326	triple-distilled perfectly mixed Bone's Farm &quot;wine&quot;	7	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
@@ -5241,13 +5241,13 @@
 5338	family-friendly veiny The Necbromancer's Stein of the early riser	0		Maximum HP: +10, Sleaze Resistance: +1, Adventures: +7, Last Available: "2011-10"
 5339	reassuring chilly shellacked The Necbromancer's Shorts	0		Damage Reduction: 7, Cold Damage: +5, Spooky Resistance: +1, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	sizzling deadly The Necbromancer's Wizard Staff of doom	0		Weapon Damage: +5, Hot Damage: +10, Spooky Spell Damage: +50, Last Available: "2011-10"
-5341	squat spinning twirling The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
+5341	twirling spinning squat The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	extra-dry perfectly mixed pulsating The Cooler Out of Space	5	EPIC	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	frozen moist boiled Necbro wafers	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 37, Last Available: "2020-09"
 5346	death blossom	0		
-5347	skewed fuchsia twirling A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+5347	twirling fuchsia skewed A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
@@ -5255,7 +5255,7 @@
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
-5355	blurry mirror Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+5355	mirror blurry Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
@@ -5290,7 +5290,7 @@
 5387	twirling hale ridiculous earring	0		Maximum HP: +20, Last Available: "2011-11"
 5388	beefy ridiculous sunglasses	0		Muscle: +10, Last Available: "2011-11"
 5389	rotten diet ridiculous sandwich	1	crappy	Last Available: "2011-11"
-5390	watered-down delicious olive ridiculous cocktail	2	awesome	Last Available: "2011-11"
+5390	delicious watered-down olive ridiculous cocktail	2	awesome	Last Available: "2011-11"
 5391	nasty zombie monkey necklace of the glutton	0		Stench Damage: +5, Food Drop: +100
 5392	blinking Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5310,12 +5310,12 @@
 5407	mediocre Vodka Matryoshka	3	decent	Last Available: "2011-12"
 5408	tolerable Gin Mint	3	good	Last Available: "2011-12"
 5409	high-proof aged Tequiz Navidad	9	awesome	Last Available: "2011-12"
-5410	irresponsibly strong perfectly mixed green Mint Yulep	6	EPIC	Last Available: "2011-12"
+5410	perfectly mixed irresponsibly strong green Mint Yulep	6	EPIC	Last Available: "2011-12"
 5411	perfectly mixed Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	bad Sangria de Menthe	3	decent	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
-5415	concentrated adjusted chilled upside-down blue licorice root	0		Effect: "Elron's Explosive Etude", Effect Duration: 64, Last Available: "2011-12"
+5415	concentrated adjusted chilled blue upside-down licorice root	0		Effect: "Elron's Explosive Etude", Effect Duration: 64, Last Available: "2011-12"
 5416	improved banana supersucker	0		Effect: "Trivia Master", Effect Duration: 56, Last Available: "2011-11"
 5417	triple-altered diffused ionized pear supersucker	0		Effect: "Fortunate Resolve", Effect Duration: 40, Last Available: "2011-11"
 5418	non-activated oxidized pulsating lime supersucker	0		Effect: "Gummi Badass", Effect Duration: 14, Last Available: "2011-11"
@@ -5358,7 +5358,7 @@
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	frozen moist altered twirling Fudgie Roll	0		Effect: "Dilated Pupils", Effect Duration: 67, Last Available: "2011-11"
-5458	special moldy low-calorie blinking fudge bunny	1	crappy	Effect: "Swordholder", Effect Duration: 10, Last Available: "2011-11"
+5458	low-calorie special moldy blinking fudge bunny	1	crappy	Effect: "Swordholder", Effect Duration: 10, Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	avaricious energetic Rosewater's fudgecycle	0		Mysticality Percent: +30, Maximum MP Percent: +20, Meat Drop: +30, Single Equip, Last Available: "2011-11"
 5461	mirror fudge cube	0		Last Available: "2011-11"
@@ -5375,16 +5375,16 @@
 5472	energized narrow resolution: be luckier	0		Effect: "Black Lung", Effect Duration: 14, Last Available: "2012-01"
 5473	shaking gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
-5475	cyan blurry gummi ingot	0		Last Available: "2011-11"
+5475	blurry cyan gummi ingot	0		Last Available: "2011-11"
 5476	boiled blinking gummi salamander	0		Effect: "Carrion' On", Effect Duration: 50, Last Available: "2011-11"
 5477	tarnished activated double-polymerized jittery gummi snake	0		Effect: "Grumpy and Ornery", Effect Duration: 41, Last Available: "2011-11"
 5478	ionized blue gummi canary	0		Effect: "Your Interest is Peaked", Effect Duration: 18, Last Available: "2011-11"
 5479	big flavorless gummi bear	5	decent	Last Available: "2011-11"
-5480	low-calorie rotten huge jittery squat gummi bear	1	crappy	Last Available: "2011-11"
+5480	rotten low-calorie jittery huge squat gummi bear	1	crappy	Last Available: "2011-11"
 5481	spoiled upside-down gummi bear	3	crappy	Last Available: "2011-11"
 5482	spoiled drunki-bear	4	crappy	Last Available: "2011-11"
 5483	spoiled spinning drunki-bear	3	crappy	Last Available: "2011-11"
-5484	bland low-calorie drunki-bear	1	decent	Last Available: "2011-11"
+5484	low-calorie bland drunki-bear	1	decent	Last Available: "2011-11"
 5485	gummi bowtie of the ox	0		Muscle: +20, Last Available: "2011-11"
 5486	red stanky fudge pocket square	0		Stench Spell Damage: +25, Last Available: "2011-11"
 5487	wizardly lollipop cufflinks	0		Mysticality: +25, Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blinking blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	rotten half-sized shaking jerky coins	2	crappy	Last Available: "2011-11"
-5507	weak acceptable Go-Wassail	2	good	Last Available: "2011-11"
+5507	acceptable weak Go-Wassail	2	good	Last Available: "2011-11"
 5508	activated aerosolized narrow blinking Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Drenched With Filth", Effect Duration: 37, Last Available: "2011-11"
 5509	ionized magnetized fuchsia bottle of bubbles	0		Effect: "Dances with Tweedles", Effect Duration: 15, Last Available: "2011-11"
 5510	Vulcanized wind-up meatcar	0		Effect: "Tasting the Rainbow", Effect Duration: 61, Last Available: "2011-11"
@@ -5424,12 +5424,12 @@
 5521	narrow pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	olive pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
-5524	skewed huge pog #10 (hobo)	0		Last Available: "2011-11"
+5524	huge skewed pog #10 (hobo)	0		Last Available: "2011-11"
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	unsweetened magnetized Atomic Pop	0		Effect: "Alacri Tea", Effect Duration: 26, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	diet decent maroon berries of suffering	1	good	Last Available: "2012-12"
+5529	decent diet maroon berries of suffering	1	good	Last Available: "2012-12"
 5530	aerosolized denatured altered baobab sap	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 68, Last Available: "2012-12"
 5531	jittery cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
@@ -5444,8 +5444,8 @@
 5541	squat Vivian's Vitamin	0		Last Available: "2012-12"
 5542	bouncing pink-belly slapper	0		Last Available: "2012-12"
 5543	upside-down jittery frosty Leapin' Trousers of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50
-5544	practically non-alcoholic tolerable eggnog	1	good	Last Available: "2012-12"
-5545	jumbo flavorless wobbly hamhock	5	decent	Last Available: "2012-12"
+5544	tolerable practically non-alcoholic eggnog	1	good	Last Available: "2012-12"
+5545	flavorless jumbo wobbly hamhock	5	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	lime green Clancy's sackbut	0		Last Available: "2012-12"
 5548	blue spinning Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5460,13 +5460,13 @@
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	spinning nippy shellacked Rain-Doh laser gun	0		Damage Reduction: 7, Cold Damage: +10, Softcore Only, Last Available: "2012-02"
 5559	wobbly ghostly fortified strapping Rain-Doh lantern	0		Muscle: +5, Damage Absorption: +60, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
-5560	fuchsia squat Rain-Doh balls	0		Last Available: "2012-02"
+5560	squat fuchsia Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	spinning maroon Jack Frost's Rain-Doh violet bo of extreme caution	0		Monster Level: -25, Cold Spell Damage: +50, Softcore Only, Last Available: "2012-02"
-5563	huge spinning Rain-Doh box	0		Last Available: "2012-02"
+5563	spinning huge Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	delicious PB&BP	4	awesome	
-5566	half-sized decent club sandwich	2	good	
+5566	decent half-sized club sandwich	2	good	
 5567	delicious corned-beef Reuben	3	awesome	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
@@ -5474,24 +5474,24 @@
 5571	tumbling Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	hand-crafted Drac & Tan	3	EPIC	Last Available: "2012-03"
-5574	smooth triple-distilled Transylvania Sling	7	awesome	Last Available: "2012-03"
+5574	triple-distilled smooth Transylvania Sling	7	awesome	Last Available: "2012-03"
 5575	fortified artisanal special Shot of the Living Dead	5	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 10, Last Available: "2012-03"
 5576	acceptable Buttery Knob	3	good	Last Available: "2012-03"
-5577	drinkable practically non-alcoholic Slippery Knob	1	good	Last Available: "2012-03"
+5577	practically non-alcoholic drinkable Slippery Knob	1	good	Last Available: "2012-03"
 5578	watered-down drinkable Flaming Knob	2	good	Last Available: "2012-03"
 5579	mediocre Grasshopper	4	decent	Last Available: "2012-03"
 5580	bad weak Locust	2	decent	Last Available: "2012-03"
 5581	mediocre Plague of Locusts	3	decent	Last Available: "2012-03"
 5582	artisanal Red Dwarf	4	EPIC	Last Available: "2012-03"
 5583	aged skewed Golden Mean	3	awesome	Last Available: "2012-03"
-5584	acceptable weak Green Giant	2	good	Last Available: "2012-03"
-5585	watered-down hand-crafted Aye Aye	2	EPIC	Last Available: "2012-03"
+5584	weak acceptable Green Giant	2	good	Last Available: "2012-03"
+5585	hand-crafted watered-down Aye Aye	2	EPIC	Last Available: "2012-03"
 5586	drinkable Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	drinkable weak Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
 5588	weak smooth olive Humanitini	2	awesome	Last Available: "2012-03"
-5589	lousy triple-distilled More Humanitini than Humanitini	7	decent	Last Available: "2012-03"
+5589	triple-distilled lousy More Humanitini than Humanitini	7	decent	Last Available: "2012-03"
 5590	drinkable Oh, the Humanitini	4	good	Last Available: "2012-03"
-5591	special drinkable Great Older Fashioned	3	good	Effect: "Texas Elegance", Effect Duration: 50, Last Available: "2012-03"
+5591	drinkable special Great Older Fashioned	3	good	Effect: "Texas Elegance", Effect Duration: 50, Last Available: "2012-03"
 5592	practically non-alcoholic tolerable huge Fuzzy Tentacle	1	good	Last Available: "2012-03"
 5593	acceptable Crazymaker	3	good	Last Available: "2012-03"
 5594	aged distilled Zoodriver	5	awesome	Last Available: "2012-03"
@@ -5499,26 +5499,26 @@
 5596	tolerable Sloe Comfortable Zoo on Fire	3	good	Last Available: "2012-03"
 5597	bad cyan Suffering Sinner	3	decent	Last Available: "2012-03"
 5598	weak mediocre Suppurating Sinner	2	decent	Last Available: "2012-03"
-5599	aged extra-dry special Sizzling Sinner	5	awesome	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2012-03"
+5599	special extra-dry aged Sizzling Sinner	5	awesome	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2012-03"
 5600	smooth fuchsia Firewater	3	awesome	Last Available: "2012-03"
 5601	perfectly mixed weak Earth and Firewater	2	EPIC	Last Available: "2012-03"
-5602	smooth practically non-alcoholic wobbly Earth, Wind and Firewater	1	awesome	Last Available: "2012-03"
+5602	practically non-alcoholic smooth wobbly Earth, Wind and Firewater	1	awesome	Last Available: "2012-03"
 5603	weak bad Slimosa	2	decent	Last Available: "2012-03"
 5604	mediocre Extra-slimy Slimosa	4	decent	Last Available: "2012-03"
 5605	bad Slimebite	4	decent	Last Available: "2012-03"
-5606	practically non-alcoholic lousy gray Cement Mixer	1	decent	Last Available: "2012-03"
-5607	weak bad Jackhammer	2	decent	Last Available: "2012-03"
+5606	lousy practically non-alcoholic gray Cement Mixer	1	decent	Last Available: "2012-03"
+5607	bad weak Jackhammer	2	decent	Last Available: "2012-03"
 5608	smooth Dump Truck	4	awesome	Last Available: "2012-03"
 5609	delicious Fauna Libre	4	awesome	Last Available: "2012-03"
-5610	high-proof hand-crafted mirror Chakra Libre	6	EPIC	Last Available: "2012-03"
+5610	hand-crafted high-proof mirror Chakra Libre	6	EPIC	Last Available: "2012-03"
 5611	artisanal skewed Aura Libre	3	EPIC	Last Available: "2012-03"
 5612	bad bouncing Sazerorc	3	decent	Last Available: "2012-03"
 5613	acceptable irresponsibly strong Sazuruk-hai	10	good	Last Available: "2012-03"
 5614	watered-down tolerable Flaming Sazerorc	2	good	Last Available: "2012-03"
-5615	perfectly mixed triple-distilled huge jittery Green Velvet	7	EPIC	Last Available: "2012-03"
+5615	triple-distilled perfectly mixed huge jittery Green Velvet	7	EPIC	Last Available: "2012-03"
 5616	delicious Green Muslin	4	awesome	Last Available: "2012-03"
 5617	hand-crafted triple-distilled Green Burlap	8	EPIC	Last Available: "2012-03"
-5618	enchanted acceptable watered-down Mohobo	2	good	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25, Last Available: "2012-03"
+5618	acceptable enchanted watered-down Mohobo	2	good	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25, Last Available: "2012-03"
 5619	acceptable Moonshine Mohobo	3	good	Last Available: "2012-03"
 5620	lousy Flaming Mohobo	3	decent	Last Available: "2012-03"
 5621	watered-down drinkable Drunken Philosopher	2	good	Last Available: "2012-03"
@@ -5530,15 +5530,15 @@
 5627	enchanted bad squat spinning Herring Daiquiri	3	decent	Effect: "The Moxie of LOV", Effect Duration: 35, Last Available: "2012-03"
 5628	bad Herring Wallbanger	3	decent	Last Available: "2012-03"
 5629	acceptable Herringtini	4	good	Last Available: "2012-03"
-5630	mediocre fortified blurry jittery Lollipop Drop	5	decent	Last Available: "2012-03"
-5631	enchanted lousy irresponsibly strong Candy Alexander	6	decent	Effect: "Abyssal Sweat", Effect Duration: 5, Last Available: "2012-03"
-5632	extra-dry tolerable spinning Candicaine	5	good	Last Available: "2012-03"
+5630	mediocre fortified jittery blurry Lollipop Drop	5	decent	Last Available: "2012-03"
+5631	lousy enchanted irresponsibly strong Candy Alexander	6	decent	Effect: "Abyssal Sweat", Effect Duration: 5, Last Available: "2012-03"
+5632	tolerable extra-dry spinning Candicaine	5	good	Last Available: "2012-03"
 5633	lousy Caipiranha	3	decent	Last Available: "2012-03"
 5634	tolerable cyan Flying Caipiranha	3	good	Last Available: "2012-03"
 5635	practically non-alcoholic aged purple blurry Flaming Caipiranha	1	awesome	Last Available: "2012-03"
 5636	acceptable Punchplanter	3	good	Last Available: "2012-03"
-5637	acceptable weak Doublepunchplanter	2	good	Last Available: "2012-03"
-5638	irresponsibly strong tolerable Haymaker	9	good	Last Available: "2012-03"
+5637	weak acceptable Doublepunchplanter	2	good	Last Available: "2012-03"
+5638	tolerable irresponsibly strong Haymaker	9	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	half-sized adequate wobbly fungus	2	good	
@@ -5553,7 +5553,7 @@
 5650	hardy occult Boris's Helm (askew) of the glutton	0		Spell Damage Percent: +25, Maximum HP: +50, Food Drop: +100, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
-5653	jittery narrow key-o-tron	0		
+5653	narrow jittery key-o-tron	0		
 5654	rotten nailswurst	4	crappy	
 5655	tolerable cyan used beer	4	good	
 5656	Huggler Radio	0		Free Pull
@@ -5612,17 +5612,17 @@
 5709	zippy Jeselnik's fireman's helmet	0		Sleaze Damage: +25, Initiative: +20, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	skewed fire axe of Leguizamo	0		Monster Level: +20, Last Available: "2012-07"
 5713	squat fireproof electrified fire extinguisher of the businessman	0		Hot Resistance: +3, Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-07"
-5714	blinking twirling FDKOL tattoo	0		
+5714	twirling blinking FDKOL tattoo	0		
 5715	jittery Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	rotten FDKOL hotcakes	3	crappy	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
-5719	olive blurry smoking grass	0		Last Available: "2012-07"
+5719	blurry olive smoking grass	0		Last Available: "2012-07"
 5720	bland half-sized fiery wing	2	decent	Last Available: "2012-07"
 5721	up-at-dawn savvy wings of fire	0		Mysticality Percent: +20, Adventures: +5, Last Available: "2012-07"
 5722	skewed deadly FDKOL fire hose	0		Weapon Damage: +5, Last Available: "2012-07"
 5723	unsweetened bottle of fire	0		Effect: "Fratty Flavor", Effect Duration: 15, Last Available: "2012-07"
-5724	tumbling upside-down molten brick	0		Last Available: "2012-07"
+5724	upside-down tumbling molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
 5726	narrow Lo Pan's slick hot daub bun	0		Moxie: +10, Spell Critical Percent: +30, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5727	wool Da Vinci's hot daub stand	0		Experience (Mysticality): +5, Cold Resistance: +1, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
@@ -5632,17 +5632,17 @@
 5731	aged 5-hour acrimony	4	awesome	
 5732	blank note	0		
 5733	eerily silent box	0		
-5734	bite-sized bland forbidden sausage	1	decent	
-5735	tumbling frightening Lord Flameface's cloak	0		Spooky Damage: +5, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5734	bland bite-sized forbidden sausage	1	decent	
+5735	tumbling frightening Lord Flameface's cloak	0		Spooky Damage: +5, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	ionized flattened Drizzlers&trade; Black Licorice	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 13
 5737	wet denatured deionized daub-breaker	0		Effect: "Chalked Weapon", Effect Duration: 48, Last Available: "2020-09"
 5738	wobbly studded Camp Scout backpack	0		Damage Absorption: +80, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	stale miniature shaking bag of GORP	2	decent	Last Available: "2012-07"
+5740	miniature stale shaking bag of GORP	2	decent	Last Available: "2012-07"
 5741	mediocre water purification pills	3	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	mediocre CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
-5744	super-sized stale bag of GORF	5	decent	Last Available: "2012-07"
+5744	stale super-sized bag of GORF	5	decent	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	stale low-calorie bag of QWOP	1	decent	Last Available: "2012-07"
 5747	cold-filtered deionized jittery CSA bravery badge	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 58, Last Available: "2012-07"
@@ -5650,7 +5650,7 @@
 5749	tolerable CSA cheerfulness ration	4	good	Last Available: "2012-07"
 5750	huge CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	super-sized bland gray crappy brain	5	decent	
+5752	bland super-sized gray crappy brain	5	decent	
 5753	bland decent brain	4	decent	
 5754	special moldy tumbling good brain	3	crappy	Effect: "Radiated and Grodiated", Effect Duration: 5
 5755	bite-sized decent blurry boss brain	1	good	
@@ -5672,7 +5672,7 @@
 5772	blinking gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	spinning talkative skull	0		
-5775	tumbling fuchsia fronts	0		Familiar Weight: +5
+5775	fuchsia tumbling fronts	0		Familiar Weight: +5
 5776	aromatic ruddy Barney's rake	0		Maximum HP Percent: +40, Stench Resistance: +1
 5778	snack-sized normal idiot brain	2	good	
 5779	reassuring keel-haulin' knife	0		Spooky Resistance: +1
@@ -5687,8 +5687,8 @@
 5788	mirror smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	wobbly narrow prompt Annie Oakley's right bear arm	0		Critical Hit Percent: +20, Adventures: +3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	forbidden arcane researcher's left bear arm of the scaredy-cat	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Monster Level: -15, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	wobbly narrow prompt Annie Oakley's right bear arm	0		Critical Hit Percent: +20, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	forbidden arcane researcher's left bear arm of the scaredy-cat	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +50, Monster Level: -15, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	Oprah's Hat O' Nine Tails	0		Maximum MP Percent: +50
 5794	electrified Enchanted Plunger	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
 5795	chilled Enchanted Flyswatter	0		Effect: "Big", Effect Duration: 17
@@ -5757,7 +5757,7 @@
 5858	dry votive candle	0		Effect: "A Few Extra Pounds", Effect Duration: 14
 5859	frozen booby trap	0		Effect: "You Read The Manual", Effect Duration: 28
 5860	pickled electrified bouncing Agent Corrigan's cigarette	0		Effect: "Swordholder", Effect Duration: 20
-5861	chilled dry blurry jittery narrow good ash	0		Effect: "Bilious Briskness", Effect Duration: 31
+5861	chilled dry blurry narrow jittery good ash	0		Effect: "Bilious Briskness", Effect Duration: 31
 5862	lime green Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	huge Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	gray skeletal skiff	0		Last Available: "2012-10"
 5886	zippy hale rosy-cheeked Bonestabber of the storm	0		Maximum HP Percent: +30, Maximum HP: +20, Maximum MP Percent: +40, Initiative: +20, Last Available: "2012-10"
-5887	aged extra-dry crystal skeleton vodka	5	awesome	Last Available: "2012-10"
+5887	extra-dry aged crystal skeleton vodka	5	awesome	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	beefy auxiliary backbone	0		Muscle: +10, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5806,7 +5806,7 @@
 5908	ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	Usain Bolt's wedding ring of the brute	0		Muscle Percent: +30, Initiative: +80, Single Equip
 5910	blurry deactivated nanobots	0		Free Pull, Last Available: "2012-11"
-5911	red shaking nanorhino credit card	0		Last Available: "2012-11"
+5911	shaking red nanorhino credit card	0		Last Available: "2012-11"
 5912	jittery lion tamer's Herculean Solstice Shield	0		Experience (Muscle): +1, Experience (familiar): +2
 5913	quantum pickled spinning candy sushi set	0		Effect: "Graham Crackling", Effect Duration: 66, Last Available: "2012-12"
 5914	dry sweet mochi ball	0		Effect: "Strength of Ten Ettins", Effect Duration: 49, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	blue jittery ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	olive brainwave-controlled unicorn horn of the bloodbag	0		Maximum HP: +100, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	olive brainwave-controlled unicorn horn of the bloodbag	0		Maximum HP: +100, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	ruddy quilted plastic four-shadowed mime of temperance	0		Damage Absorption: +40, Maximum HP Percent: +40, Sleaze Resistance: +5, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	supercool plastic Father McGruber	0		Moxie Percent: +20, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of Leguizamo	0		Monster Level: +20, Last Available: "2012-12"
 5962	personal trainer's plastic blazing bat	0		Experience Percent (Muscle): +10, Last Available: "2012-12"
-5963	green bouncing electronic dulcimer pants of Tarzan of the brazier	0		Experience (Muscle): +3, Hot Spell Damage: +25, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	green bouncing electronic dulcimer pants of Tarzan of the brazier	0		Experience (Muscle): +3, Hot Spell Damage: +25, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	cyan A-Boo clue	0		
 5965	twirling Tesla Frown Exerciser of Leguizamo	0		Monster Level: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5894,7 +5894,7 @@
 5996	cyan extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	delicious watered-down shining goblet	2	awesome	Last Available: "2013-02"
-5999	gray upside-down fireball	0		Last Available: "2013-02"
+5999	upside-down gray fireball	0		Last Available: "2013-02"
 6000	censurious nippy experienced crown	0		Experience: +2, Cold Damage: +10, Sleaze Resistance: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	razor-sharp Socratic sword of vim and vigor	0		Experience (Mysticality): +1, Weapon Damage Percent: +25, Maximum HP Percent: +50, Last Available: "2013-02"
 6002	Helm of the Scream Emperor of terror of the cheetah of the early riser	0		Spooky Spell Damage: +10, Initiative: +60, Adventures: +7, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
@@ -5913,7 +5913,7 @@
 6015	concentrated liquefied orcish hand lotion	0		Effect: "Perception", Effect Duration: 41
 6016	aerosolized orcish rubber	0		Effect: "Pyramid Power", Effect Duration: 23
 6017	super-polarized orcish nailing lube	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 15
-6018	watered-down smooth backwoods screwdriver	2	awesome	
+6018	smooth watered-down backwoods screwdriver	2	awesome	
 6019	pulsating loadstone	0		Item Drop: +5
 6020	brawny Claybender glasses of vim and vigor	0		Muscle Percent: +20, Maximum HP Percent: +50, Single Equip
 6021	brainy Duskwalker fangs of the dark arts	0		Mysticality: +5, Spell Damage Percent: +100
@@ -5931,7 +5931,7 @@
 6033	avaricious dance instructor's stolen necklace	0		Experience Percent (Moxie): +10, Meat Drop: +30
 6034	asbestos-lined troll britches of the detective	0		Hot Resistance: +5, Item Drop: +20, Familiar Effect: "1.5xPotato, cap 28"
 6035	dry quadruple-altered magnetized vial of The Glistening	0		Effect: "Disco Nirvana", Effect Duration: 27
-6036	fortified lousy artisanal limoncello	5	decent	
+6036	lousy fortified artisanal limoncello	5	decent	
 6037	ginger ale	0		
 6038	normal big incredible pizza	5	good	
 6039	nippy oil cap of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +10, Familiar Effect: "cap 28"
@@ -5971,12 +5971,12 @@
 6073	triple-deionized red haggis-infused soap	0		Effect: "Ginger Snapped", Effect Duration: 52, Last Available: "2012-12"
 6074	polymerized cold-filtered upside-down magicberry tablets	0		Effect: "Heart of Green", Effect Duration: 27, Last Available: "2012-12"
 6075	dry magnetized lime green 37x37x37 puzzle cube	0		Effect: "Tiki Thoughtfulness", Effect Duration: 53, Last Available: "2012-12"
-6076	weak aged McLeod's Hard Haggis-Ade	2	awesome	Last Available: "2012-12"
-6077	rotten enchanted wobbly haggis-wrapped haggis-stuffed haggis	3	crappy	Effect: "Sweet and Green", Effect Duration: 5, Last Available: "2012-12"
+6076	aged weak McLeod's Hard Haggis-Ade	2	awesome	Last Available: "2012-12"
+6077	enchanted rotten wobbly haggis-wrapped haggis-stuffed haggis	3	crappy	Effect: "Sweet and Green", Effect Duration: 5, Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	fireproof haggis socks	0		Hot Resistance: +3, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	fireproof haggis socks	0		Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	mirror goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	delicious watered-down olive Chinese beer	2	awesome	Last Available: "2013-12"
+6121	watered-down delicious olive Chinese beer	2	awesome	Last Available: "2013-12"
 6122	lime green skewed cat statue	0		Last Available: "2013-12"
 6123	fuchsia rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6027,7 +6027,7 @@
 6129	smooth makeshift yakuza mask	0		Moxie: +15, Last Available: "2013-12"
 6130	piece	0		Last Available: "2013-12"
 6131	blurry toy taijijian	0		Last Available: "2013-12"
-6132	upside-down blinking battery	0		Last Available: "2013-12"
+6132	blinking upside-down battery	0		Last Available: "2013-12"
 6133	stanky toasty strapping White Dragon Fang	0		Muscle: +5, Hot Damage: +5, Stench Spell Damage: +25, Last Available: "2013-12"
 6134	healthy butterfly knife	0		Maximum HP Percent: +20, Last Available: "2013-12"
 6135	bouncing tube of herbal ointment	0		Last Available: "2013-12"
@@ -6037,8 +6037,8 @@
 6139	nasty rubber gloves	0		Stench Damage: +5, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	enchanted decent roasted duck	3	good	Effect: "[800]Chocolate Reign", Effect Duration: 15, Last Available: "2013-12"
-6143	immense toothsome dead meat bun	6	awesome	Last Available: "2013-12"
+6142	decent enchanted roasted duck	3	good	Effect: "[800]Chocolate Reign", Effect Duration: 15, Last Available: "2013-12"
+6143	toothsome immense dead meat bun	6	awesome	Last Available: "2013-12"
 6144	jittery stanky cat collar	0		Stench Spell Damage: +25, Single Equip, Last Available: "2013-12"
 6145	shaking stiffened suspicious-looking fedora of the scaredy-cat	0		Damage Reduction: 1, Monster Level: -15, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6047,15 +6047,15 @@
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	stale spinning spinning carrot cake	4	decent	Last Available: "2013-01"
-6153	strong drinkable shaking spinning carrot claret	5	good	Last Available: "2013-01"
+6153	drinkable strong shaking spinning carrot claret	5	good	Last Available: "2013-01"
 6154	twisted squat carrot juice	1	EPIC	Last Available: "2013-01"
 6155	gray pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	huge maroon frightening Annie Oakley's Byte	0		Critical Hit Percent: +20, Spooky Damage: +5, Last Available: "2013-12"
-6158	yellow lion tamer's anger blaster	0		Experience (familiar): +2, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	purple doubt cannon of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	up-at-dawn fear condenser	0		Adventures: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	Da Vinci's regret hose	0		Experience (Mysticality): +5, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	yellow lion tamer's anger blaster	0		Experience (familiar): +2, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	purple doubt cannon of the overflowing toilet	0		Stench Spell Damage: +50, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	up-at-dawn fear condenser	0		Adventures: +5, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	Da Vinci's regret hose	0		Experience (Mysticality): +5, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	flame-retardant smooth commodore's hat	0		Moxie: +15, Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
@@ -6063,8 +6063,8 @@
 6166	slick deck cannon of the detective	0		Moxie: +10, Item Drop: +20, Last Available: "2013-12"
 6167	ornamental sextant of the cheetah	0		Initiative: +60, Last Available: "2013-12"
 6168	lightning-fast healthy Bloodbath	0		Maximum HP Percent: +20, Initiative: +40, Last Available: "2013-12"
-6169	spirit-forward drinkable huge Hundred Headed IPA	5	good	Last Available: "2013-12"
-6170	adequate special chum	3	good	Effect: "critical.enh", Effect Duration: 25, Last Available: "2013-12"
+6169	drinkable spirit-forward huge Hundred Headed IPA	5	good	Last Available: "2013-12"
+6170	special adequate chum	3	good	Effect: "critical.enh", Effect Duration: 25, Last Available: "2013-12"
 6171	frozen galvanized olive crude crudit&eacute;s	0		Effect: "Kissed By Fire", Effect Duration: 11
 6172	cold-filtered ionized double-colloidal mirror candy crayons	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 27, Last Available: "2020-09"
 6173	yellow chilly cool pixel grappling hook	0		Moxie: +5, Cold Damage: +5
@@ -6082,54 +6082,54 @@
 6185	normal diet gray pulsating consummate hard-boiled egg	1	good	
 6186	stale consummate fried egg	4	decent	
 6187	adequate blurry blurry consummate egg salad	4	good	
-6188	thick adequate upside-down wobbly consummate bagel	5	good	
+6188	adequate thick upside-down wobbly consummate bagel	5	good	
 6189	rotten consummate sliced bread	3	crappy	
-6190	decent massive ghostly consummate hot dog bun	10	good	
+6190	massive decent ghostly consummate hot dog bun	10	good	
 6191	rotten consummate brownie	4	crappy	
-6192	spoiled gigantic bouncing consummate toast	8	crappy	
-6193	weak artisanal passable stout	2	EPIC	
+6192	gigantic spoiled bouncing consummate toast	8	crappy	
+6193	artisanal weak passable stout	2	EPIC	
 6194	thick bland huge consummate soup	5	decent	
-6195	low-calorie enchanted decent consummate corn chips	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
-6196	snack-sized spoiled consummate salad	2	crappy	
+6195	enchanted low-calorie decent consummate corn chips	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
+6196	spoiled snack-sized consummate salad	2	crappy	
 6197	bland consummate salsa	3	decent	
 6198	stale consummate sauerkraut	3	decent	
-6199	jumbo moldy squat consummate cheese slice	5	crappy	
+6199	moldy jumbo squat consummate cheese slice	5	crappy	
 6200	jumbo bland consummate melted cheese	5	decent	
-6201	decent gigantic wobbly upside-down consummate bacon	6	good	
+6201	gigantic decent wobbly upside-down consummate bacon	6	good	
 6202	bland huge consummate meatloaf	3	decent	
-6203	flavorless half-sized pulsating consummate steak	2	decent	
-6204	special small normal green consummate cuts	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40
+6203	half-sized flavorless pulsating consummate steak	2	decent	
+6204	special normal small green consummate cuts	2	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40
 6205	spoiled consummate frankfurter	4	crappy	
 6206	bite-sized flavorless ghostly consummate french fries	1	decent	
 6207	delicious enchanted consummate baked potato	3	awesome	Effect: "Spooky Blur", Effect Duration: 45
-6208	perfectly mixed high-proof blurry acceptable vodka	6	EPIC	
-6209	spoiled gigantic consummate ice cream	9	crappy	
+6208	high-proof perfectly mixed blurry acceptable vodka	6	EPIC	
+6209	gigantic spoiled consummate ice cream	9	crappy	
 6210	normal small consummate whipped cream	2	good	
 6211	decent skewed twirling consummate cream	4	good	
 6212	spoiled upside-down consummate strawberries	4	crappy	
-6213	small adequate consummate sorbet	2	good	
-6214	practically non-alcoholic hand-crafted adequate rum	1	EPIC	
+6213	adequate small consummate sorbet	2	good	
+6214	hand-crafted practically non-alcoholic adequate rum	1	EPIC	
 6215	acceptable tumbling mediocre lager	4	good	
 6216	rotten immaculate grilled cheese	3	crappy	
 6217	bland upside-down blurry immaculate ice cream sandwich	4	decent	
-6218	tasty jumbo spinning immaculate hot dog	5	awesome	
+6218	jumbo tasty spinning immaculate hot dog	5	awesome	
 6219	yummy immaculate egg salad sandwich	3	awesome	
-6220	stale jittery shaking perfect sandwich	3	decent	
+6220	stale shaking jittery perfect sandwich	3	decent	
 6221	bite-sized adequate perfect chef salad	1	good	
 6222	diet decent perfect breakfast	1	good	
 6223	bland spinning sublime deluxe hot dog	4	decent	
 6224	adequate huge blurry skewed sublime stew	9	good	
 6225	flavorless sublime nachos	4	decent	
 6226	decent Ultimate Breakfast Sandwich	3	good	
-6227	miniature adequate huge Loaded Baked Potato	2	good	
-6228	adequate fancy teal Omega Sundae	4	good	Effect: "Pygmy Drinking Buddy", Effect Duration: 45
+6227	adequate miniature huge Loaded Baked Potato	2	good	
+6228	fancy adequate teal Omega Sundae	4	good	Effect: "Pygmy Drinking Buddy", Effect Duration: 45
 6229	bad blue Das Sauerlager	3	decent	
 6230	perfectly mixed Bologna Lambic	4	EPIC	
 6231	acceptable Vodka Dog	4	good	
-6232	lousy watered-down Disappointed Russian	2	decent	
+6232	watered-down lousy Disappointed Russian	2	decent	
 6233	lousy Chunky Mary	3	decent	
-6234	practically non-alcoholic mediocre Nachojito	1	decent	
-6235	watered-down perfectly mixed Le Roi	2	EPIC	
+6234	mediocre practically non-alcoholic Nachojito	1	decent	
+6235	perfectly mixed watered-down Le Roi	2	EPIC	
 6236	bad huge Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
 6239	moist fuchsia cube of ectoplasm	0		Effect: "Busy Bein' Delicious", Effect Duration: 63
@@ -6182,12 +6182,12 @@
 6286	executive hale extremely unsafe Mark II Steam-Hat	0		Weapon Damage Percent: +100, Maximum HP: +20, Meat Drop: +40, Familiar Effect: "1xLep, cap 37"
 6287	ghostly sharpshooter's ruddy banded Mark III Steam-Hat of the sweet-tooth	0		Damage Absorption: +100, Maximum HP Percent: +40, Critical Hit Percent: +10, Candy Drop: +100, Familiar Effect: "1xLep, cap 37"
 6288	gray blinking Sherlock's wool Newton's groovy brainy Mark IV Steam-Hat	0		Mysticality: +5, Moxie Percent: +10, Experience (Mysticality): +3, Cold Resistance: +1, Item Drop: +25, Familiar Effect: "1xLep, cap 37"
-6289	sizzling chilly therapeutic hardened forbidden Mark V Steam-Hat	0		Spell Damage Percent: +50, Damage Reduction: 3, Cold Damage: +5, Hot Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	sizzling chilly therapeutic hardened forbidden Mark V Steam-Hat	0		Spell Damage Percent: +50, Damage Reduction: 3, Cold Damage: +5, Hot Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	bouncing steam-powered model rocketship	0		
 6291	bouncing energetic punk rock jacket of the wise owl	0		Mysticality: +20, Maximum MP Percent: +20
 6292	sharpshooter's wholesome safety pin	0		Maximum HP Percent: +10, Critical Hit Percent: +10
-6293	huge decent stolen sushi	10	good	
-6294	bouncing wobbly very overdue library book	0		
+6293	decent huge stolen sushi	10	good	
+6294	wobbly bouncing very overdue library book	0		
 6295	bouncing drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	blurry fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
@@ -6214,7 +6214,7 @@
 6318	cyan experienced sea holster of dire peril of vim and vigor	0		Experience: +2, Weapon Damage: +20, Maximum HP Percent: +50, Single Equip
 6319	enhanced lime green shavin' razor	0		Effect: "You're High as a Crow, Marty", Effect Duration: 15
 6320	lime green Socratic long-forgotten necklace	0		Experience (Mysticality): +1
-6321	twirling squat twirling pearl	0		
+6321	squat twirling twirling pearl	0		
 6322	wobbly sea lace	0		
 6323	upside-down sinister jam band of the bloodbag of the boozehound	0		Spell Damage: +10, Maximum HP: +100, Booze Drop: +100
 6324	wool scorching razor-sharp aquamariner's ring	0		Weapon Damage Percent: +25, Hot Damage: +25, Cold Resistance: +1, Single Equip
@@ -6256,17 +6256,17 @@
 6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	magnetized aerosolized twirling pulled taffy	0		Effect: "Tingly Elbows", Effect Duration: 51, Last Available: "2013-04"
 6362	pressed adjusted mirror squat pulled indigo taffy	0		Effect: "Amplified Fabulousness", Effect Duration: 60, Last Available: "2013-04"
-6363	quadruple-deionized vacuum-sealed double-ionized bouncing fuchsia mirror pulled taffy	0		Effect: "Slime Time", Effect Duration: 62, Last Available: "2013-04"
-6364	electrified shaking upside-down pulled taffy	0		Effect: "Morbidi Tea", Effect Duration: 28, Last Available: "2013-04"
+6363	quadruple-deionized vacuum-sealed double-ionized mirror bouncing fuchsia pulled taffy	0		Effect: "Slime Time", Effect Duration: 62, Last Available: "2013-04"
+6364	electrified upside-down shaking pulled taffy	0		Effect: "Morbidi Tea", Effect Duration: 28, Last Available: "2013-04"
 6365	magnetized unsweetened pulsating pulled taffy	0		Effect: "Carrrsmic", Effect Duration: 43, Last Available: "2013-04"
 6366	flattened deionized pulled violet taffy	0		Effect: "[1609]Dancin' Fool", Effect Duration: 13, Last Available: "2013-04"
 6367	diffused concentrated energized pulled taffy	0		Effect: "Berry Experiential", Effect Duration: 40, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	watered-down smooth can of the cheapest beer	2	awesome	
+6371	smooth watered-down can of the cheapest beer	2	awesome	
 6372	tolerable tumbling bottle of fruity &quot;wine&quot;	4	good	
-6373	acceptable purple shaking single swig of vodka	4	good	
+6373	acceptable shaking purple single swig of vodka	4	good	
 6374	squat twirling angry inch	0		
 6375	tumbling Sherlock's testy toolbox	0		Item Drop: +25
 6376	Jick-o-User	0		
@@ -6302,7 +6302,7 @@
 6407	Jeselnik's frosty stylish Pocket Square of Loathing	0		Moxie: +25, Cold Spell Damage: +10, Sleaze Damage: +25, Single Equip
 6408	corrupted stardust	0		
 6409	fuchsia Star Spawn	0		
-6410	blurry twirling bow from beyond the stars	0		Familiar Weight: +5
+6410	twirling blurry bow from beyond the stars	0		Familiar Weight: +5
 6411	KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	red shaking skull	0		No Pull
 6413	huge Order of the Green Thumb Order Form	0		Free Pull
@@ -6345,7 +6345,7 @@
 6450	smelly brawny Great Wolf's rocket launcher	0		Muscle Percent: +20, Stench Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	mirror reassuring experienced Great Wolf's beastly trousers of wisdom	0		Mysticality: +15, Experience: +2, Spooky Resistance: +1, Familiar Effect: "1xPotato, 1.5xWhelp"
 6452	Great Wolf's lice	0		
-6453	pressed tumbling jittery huge Hunger&trade; Sauce	0		Effect: "Stemonitis Storm", Effect Duration: 24
+6453	pressed jittery tumbling huge Hunger&trade; Sauce	0		Effect: "Stemonitis Storm", Effect Duration: 24
 6454	toasty wholesome zombie mariachi hat of the brute	0		Muscle Percent: +30, Maximum HP Percent: +10, Hot Damage: +5, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	cyan pulsating lion tamer's therapeutic forbidden zombie accordion	0		Spell Damage Percent: +50, Experience (familiar): +2, HP Regen Min: 5, HP Regen Max: 7, Class: "Accordion Thief", Single Equip, Song Duration: 20
 6456	lard-coated personal trainer's cool zombie mariachi pants	0		Moxie: +5, Experience Percent (Muscle): +10, Sleaze Spell Damage: +25, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	diet moldy Dreadsylvanian shepherd's pie	1	crappy	
+6488	moldy diet Dreadsylvanian shepherd's pie	1	crappy	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6399,7 +6399,7 @@
 6504	greasy Lo Pan's hangman's hood of dire peril	0		Weapon Damage: +20, Spell Critical Percent: +30, Sleaze Spell Damage: +10
 6505	wobbly lightning-fast studded beefcake's ring finger ring	0		Muscle: +25, Damage Absorption: +80, Initiative: +40, Single Equip
 6506	Dreadsylvanian clockwork key	0		
-6507	blurry tumbling cool iron ingot	0		
+6507	tumbling blurry cool iron ingot	0		
 6508	clever beefy cool iron helmet	0		Muscle: +10, Maximum MP: +20, Familiar Effect: "atk, 1xFairy"
 6509	spinning mirror frosty wholesome cool iron breastplate	0		Maximum HP Percent: +10, Cold Spell Damage: +10
 6510	stiffened sinister cool iron greaves	0		Spell Damage: +10, Damage Reduction: 1, Familiar Effect: "atk, 1xBarrr"
@@ -6408,7 +6408,7 @@
 6513	wholesome warm fur	0		Maximum HP Percent: +10
 6514	gravedigger's snowstick	0		Spooky Damage: +10
 6515	upside-down hardened eerie fetish	0		Damage Reduction: 3, Single Equip
-6516	special lousy blinking stinkwater	4	decent	Effect: "Rat-Faced", Effect Duration: 25
+6516	lousy special blinking stinkwater	4	decent	Effect: "Rat-Faced", Effect Duration: 25
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	spoiled ghostly jittery accidental mutton	4	crappy	
 6519	cyan lion tamer's sinister drafty drawers	0		Spell Damage: +10, Experience (familiar): +2, Familiar Effect: "1.5xVolley"
@@ -6429,7 +6429,7 @@
 6534	maroon remorseless knife of the early riser	0		Adventures: +7
 6535	cyan inspector's intimidating coiffure	0		Item Drop: +15, Familiar Effect: "hot afk, 1xPotato"
 6536	vibrating Socratic cod cape	0		Experience (Mysticality): +1, Maximum MP Percent: +10
-6537	yummy miniature olive blood sausage	2	awesome	
+6537	miniature yummy olive blood sausage	2	awesome	
 6538	bouncing ghostly fuchsia banded frying brainpan of chilblains	0		Damage Absorption: +100, Cold Damage: +25
 6539	tumbling avaricious ball and chain of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +30, Single Equip
 6540	flame-retardant dry bone	0		Hot Resistance: +1
@@ -6458,17 +6458,17 @@
 6564	toothsome Dreadsylvanian hot pocket	3	awesome	
 6565	spoiled Dreadsylvanian pocket	3	crappy	
 6566	bland Dreadsylvanian pocket	3	decent	
-6567	spoiled miniature bouncing Dreadsylvanian stink pocket	2	crappy	
+6567	miniature spoiled bouncing Dreadsylvanian stink pocket	2	crappy	
 6568	spoiled shaking Dreadsylvanian sleaze pocket	3	crappy	
 6569	hand-crafted huge Dreadsylvanian hot toddy	3	super ultra mega turbo EPIC	
-6570	acceptable watered-down Dreadsylvanian cold-fashioned	2	good	
+6570	watered-down acceptable Dreadsylvanian cold-fashioned	2	good	
 6571	smooth blurry Dreadsylvanian grimlet	3	awesome	
 6572	lousy Dreadsylvanian dank and stormy	4	decent	
 6573	watered-down lousy blurry Dreadsylvanian slithery nipple	2	decent	
 6574	maroon hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
-6577	skewed skewed maroon stench clusterbomb	0		
+6577	skewed maroon skewed stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
@@ -6477,7 +6477,7 @@
 6583	vicious spiked collar	0		Familiar Damage: +20
 6584	bouncing squat yellow lightning-fast hot dog wrapper	0		Initiative: +40
 6585	razor-sharp brawny debonair deboner	0		Muscle Percent: +20, Weapon Damage Percent: +25
-6586	improved tumbling twirling chicle de salchicha	0		Effect: "Liquid Luck", Effect Duration: 66
+6586	improved twirling tumbling chicle de salchicha	0		Effect: "Liquid Luck", Effect Duration: 66
 6587	jar of frostigkraut of the wise owl	0		Mysticality: +20
 6588	cool gnawed-up dog bone of incineration	0		Moxie: +5, Hot Spell Damage: +50
 6589	squat wholesome Grey Guanon	0		Maximum HP Percent: +10
@@ -6494,7 +6494,7 @@
 6600	bouncing clockwork hand	0		
 6601	clockwork numeral I	0		
 6602	clockwork numeral II	0		
-6603	jittery maroon clockwork numeral III	0		
+6603	maroon jittery clockwork numeral III	0		
 6604	red clockwork numeral IV	0		
 6605	mirror clockwork numeral V	0		
 6606	gray squat clockwork numeral VI	0		
@@ -6513,7 +6513,7 @@
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
-6622	pulsating red folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
+6622	red pulsating folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	bouncing shaking folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
@@ -6569,8 +6569,8 @@
 6677	crude monster sculpture	0		
 6678	spinning strapping Yearbook Club Camera	0		Muscle: +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	blue groovy machete	0		Moxie Percent: +10
-6680	tolerable weak Cursed Punch	2	good	
-6681	lousy boozy Bowl of Scorpions	5	decent	
+6680	weak tolerable Cursed Punch	2	good	
+6681	boozy lousy Bowl of Scorpions	5	decent	
 6682	artisanal twirling Fog Murderer	3	EPIC	
 6683	mirror book of matches	0		
 6684	sizzling surgical mask	0		Hot Damage: +10, Surgeonosity: +1
@@ -6590,8 +6590,8 @@
 6698	jittery dripping stone sphere	0		
 6699	crackling stone sphere	0		
 6700	upside-down scorched stone sphere	0		
-6701	blinking shaking upside-down stone triangle	0		
-6702	squat wobbly bowler	0		
+6701	shaking blinking upside-down stone triangle	0		
+6702	wobbly squat bowler	0		
 6703	wobbly imitation White Russian	1	crappy	
 6704	gravedigger's extremely unsafe short-handled mop	0		Weapon Damage Percent: +100, Spooky Damage: +10
 6705	moldy jungle floor wax	4	crappy	
@@ -6613,7 +6613,7 @@
 6721	Jeselnik's groovy water bottle of incineration	0		Moxie Percent: +10, Hot Spell Damage: +50, Sleaze Damage: +25, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	adjusted pygmy phone number	0		Effect: "Bestial Sympathy", Effect Duration: 58
 6723	teal Boozehounds Anonymous token	0		
-6724	massive delicious exotic jungle fruit	7	awesome	
+6724	delicious massive exotic jungle fruit	7	awesome	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6649,7 +6649,7 @@
 6757	tolerable pulsating can of Br&uuml;talbr&auml;u	3	good	Last Available: "2013-09"
 6758	drinkable fancy can of Drooling Monk	4	good	Effect: "Chilblains of the Corn", Effect Duration: 40, Last Available: "2013-09"
 6759	delicious can of Impetuous Scofflaw	4	awesome	Last Available: "2013-09"
-6760	special weak acceptable narrow bottle of Old Pugilist	2	good	Effect: "Human-Humanoid Hybrid", Effect Duration: 35, Last Available: "2013-09"
+6760	weak acceptable special narrow bottle of Old Pugilist	2	good	Effect: "Human-Humanoid Hybrid", Effect Duration: 35, Last Available: "2013-09"
 6761	watered-down delicious cyan squat bottle of Professor Beer	2	awesome	Last Available: "2013-09"
 6762	perfectly mixed weak bottle of Rapier Witbier	2	EPIC	Last Available: "2013-09"
 6763	acceptable bottle of Race Car Red	4	good	Last Available: "2013-09"
@@ -6671,7 +6671,7 @@
 6779	crystalline seal eye	0		Single Equip
 6780	purple hardy studded sealhide shield of Calamity Jane	0		Maximum HP: +50, Critical Hit Percent: +15, Damage Reduction: 7
 6781	scabrous seal epaulets of incineration of the businessman	0		Hot Spell Damage: +50, Meat Drop: +50, Single Equip
-6782	twirling jittery abyssal battle plans	0		
+6782	jittery twirling abyssal battle plans	0		
 6783	greasy coward's seal medal of Flo-Jo	0		Monster Level: -20, Sleaze Spell Damage: +10, Initiative: +100
 6784	deanimated reanimator's coffin	0		Free Pull
 6785	upside-down flask of embalming fluid	0		
@@ -6722,7 +6722,7 @@
 6833	Vulcanized Milk Studs	0		Effect: "Human-Beast Hybrid", Effect Duration: 49
 6834	nitrogenated bouncing box of Dweebs	0		Effect: "Prelude of Precision", Effect Duration: 65
 6835	pickled moist skewed bag of W&Ws	0		Effect: "Dancing Prowess", Effect Duration: 57
-6836	galvanized wobbly mirror PEEZ dispenser	0		Effect: "Permanent Halloween", Effect Duration: 16
+6836	galvanized mirror wobbly PEEZ dispenser	0		Effect: "Permanent Halloween", Effect Duration: 16
 6837	colloidal purple Swizzler	0		Effect: "Well-Swabbed Ear", Effect Duration: 19
 6838	warmed spinning Bugbearclaw Donut	0		Effect: "Disco Concentration", Effect Duration: 24
 6839	anodized diffused electrified jam	0		Effect: "Polar Express", Effect Duration: 18
@@ -6732,7 +6732,7 @@
 6843	alkaline polymerized bone bons	0		Effect: "Ancient Protected", Effect Duration: 38
 6844	pickled ionized blurry blurry ironic mint	0		Effect: "The Dinsey Spirit", Effect Duration: 41
 6845	unused walkie-talkie	0		Free Pull
-6846	red upside-down walkie-talkie	0		Free Pull
+6846	upside-down red walkie-talkie	0		Free Pull
 6847	killing jar	0		
 6848	zippy security flashlight	0		Initiative: +20
 6849	altered narrow Effermint&trade; tablets	0		Effect: "Human-Undead Hybrid", Effect Duration: 50
@@ -6746,12 +6746,12 @@
 6857	dangerous Cajun accordion	0		Weapon Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	smartaleck's quirky accordion	0		Moxie Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	ghostly healthy smartaleck's Skipper's accordion	0		Moxie Percent: +30, Maximum HP Percent: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	ghostly greasy crafty Samson's Pantsgiving of doom	0		Experience (Muscle): +5, Maximum MP: +10, Spooky Spell Damage: +50, Sleaze Spell Damage: +10, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	fancy tasty can of sardines	4	awesome	Effect: "Chain Chain Chains", Effect Duration: 10, Last Available: "2013-11"
+6860	ghostly greasy crafty Samson's Pantsgiving of doom	0		Experience (Muscle): +5, Maximum MP: +10, Spooky Spell Damage: +50, Sleaze Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	tasty fancy can of sardines	4	awesome	Effect: "Chain Chain Chains", Effect Duration: 10, Last Available: "2013-11"
 6862	decent high-calorie sugar substitute	3	good	Last Available: "2013-11"
-6863	adequate special pat of butter	4	good	Effect: "Innately Truthy", Effect Duration: 35, Last Available: "2013-11"
-6864	tasty super-sized dinner roll	5	awesome	Last Available: "2013-11"
-6865	adequate immense mashed potatoes	8	good	Last Available: "2013-11"
+6863	special adequate pat of butter	4	good	Effect: "Innately Truthy", Effect Duration: 35, Last Available: "2013-11"
+6864	super-sized tasty dinner roll	5	awesome	Last Available: "2013-11"
+6865	immense adequate mashed potatoes	8	good	Last Available: "2013-11"
 6866	rotten whole turkey leg	3	crappy	Last Available: "2013-11"
 6867	snack-sized moldy tumbling cyan deviled egg	2	crappy	Last Available: "2013-11"
 6868	tarnished extra-moist finger exerciser	0		Effect: "Bilious Brains", Effect Duration: 13, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	activated improved flattened tumbling nuts	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 42, Last Available: "2013-12"
 6904	improved bolts	0		Effect: "Punchy, Murdery", Effect Duration: 45, Last Available: "2013-12"
 6905	stale gingerbread robot	4	decent	Last Available: "2013-12"
-6906	snack-sized toothsome petit 4.1	2	awesome	Last Available: "2013-12"
+6906	toothsome snack-sized petit 4.1	2	awesome	Last Available: "2013-12"
 6907	delicious diet nut-shaped Crimbo cookie	1	awesome	Last Available: "2023-06"
 6908	family-friendly plastic GORM-8	0		Sleaze Resistance: +1, Last Available: "2013-12"
 6909	plastic warbear of the boozehound	0		Booze Drop: +100, Last Available: "2013-12"
@@ -6805,15 +6805,15 @@
 6916	tumbling gray warbear battery	0		Last Available: "2013-12"
 6917	squat warbear badge	0		Last Available: "2013-12"
 6918	cold-filtered yellow warbear wardance potion	0		Effect: "Graham Crackling", Effect Duration: 46, Last Available: "2013-12"
-6919	galvanized bouncing teal warbear bearserker potion	0		Effect: "Sugar, Hello", Effect Duration: 48, Last Available: "2013-12"
+6919	galvanized teal bouncing warbear bearserker potion	0		Effect: "Sugar, Hello", Effect Duration: 48, Last Available: "2013-12"
 6920	dry electrified warbear liquid overcoat	0		Effect: "OMG WTF", Effect Duration: 61, Last Available: "2013-12"
 6921	decent warbear feasting bread	4	good	Last Available: "2013-12"
-6922	thick moldy warbear warrior bread	5	crappy	Last Available: "2013-12"
+6922	moldy thick warbear warrior bread	5	crappy	Last Available: "2013-12"
 6923	snack-sized rotten shaking warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
 6924	mediocre upside-down warbear feasting mead	3	decent	Last Available: "2013-12"
 6925	irresponsibly strong mediocre warbear bearserker mead	10	decent	Last Available: "2013-12"
-6926	acceptable watered-down jittery tumbling warbear blizzard mead	2	good	Last Available: "2013-12"
-6927	blinking huge warbear helm fragment	0		Last Available: "2013-12"
+6926	acceptable watered-down tumbling jittery warbear blizzard mead	2	good	Last Available: "2013-12"
+6927	huge blinking warbear helm fragment	0		Last Available: "2013-12"
 6928	lion tamer's medical-grade dangerous warbear plain fedora	0		Weapon Damage: +10, Experience (familiar): +2, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	brawny warbear feathered fedora	0		Muscle Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
 6930	bouncing greedy curative warbear fedora of the storm	0		Maximum MP Percent: +40, Meat Drop: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
@@ -6847,7 +6847,7 @@
 6958	bouncing warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	warbear foil hat of dire peril	0		Weapon Damage: +20, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	purple warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	zippy warbear oil pan of courage	0		Spooky Resistance: +3, Initiative: +20, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	zippy warbear oil pan of courage	0		Spooky Resistance: +3, Initiative: +20, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	warbear exhaust manifold of extreme caution	0		Monster Level: -25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6893,12 +6893,12 @@
 7004	unsweetened bouncing Flaskfull of Hollow	0		Effect: "Taurus Rising", Effect Duration: 59, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	mixed spinning handful of Smithereens	1	EPIC	Effect: "Angry like the Wolf", Effect Duration: 10, Last Available: "2013-12"
-7007	decent immense Every Day is Like This Sundae	6	good	Last Available: "2013-12"
+7007	immense decent Every Day is Like This Sundae	6	good	Last Available: "2013-12"
 7008	spoiled miniature green Miserable Pie	2	crappy	Last Available: "2013-12"
 7009	diet tasty purple This Charming Flan	1	awesome	Last Available: "2013-12"
 7010	acceptable narrow Irish Coffee, English Heart	3	good	Last Available: "2013-12"
-7011	boozy acceptable spinning Strikes Again Bigmouth	5	good	Last Available: "2013-12"
-7012	special tolerable watered-down skewed Paint A Vulgar Pitcher	2	good	Effect: "Impregnably Delicious", Effect Duration: 40, Last Available: "2013-12"
+7011	acceptable boozy spinning Strikes Again Bigmouth	5	good	Last Available: "2013-12"
+7012	watered-down tolerable special skewed Paint A Vulgar Pitcher	2	good	Effect: "Impregnably Delicious", Effect Duration: 40, Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	olive Handsome Devil	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	occult Shakespeare's Sister's Accordion of mayonnaise of the early riser	0		Spell Damage Percent: +25, Sleaze Spell Damage: +50, Adventures: +7, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	friendly third-hand lantern	0		Familiar Weight: +3
 7031	fuchsia loose purse strings	0		
-7032	tasty tiny tumbling pickled egg	1	awesome	
+7032	tiny tasty tumbling pickled egg	1	awesome	
 7033	cup of lukewarm tea	1	good	
 7034	tumbling warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6936,14 +6936,14 @@
 7047	anodized quantum spinning warbear liquid lasers	0		Effect: "Bilious Brawn", Effect Duration: 24, Last Available: "2013-12"
 7048	colloidal spinning warbear rejuvenation potion	0		Effect: "Bright!", Effect Duration: 47, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	huge toothsome wobbly warbear gyro	8	awesome	Last Available: "2013-12"
+7050	toothsome huge wobbly warbear gyro	8	awesome	Last Available: "2013-12"
 7051	cold-filtered extra-vacuum-sealed pressed recording of Rolando's Rondo of Resisto	0		Effect: "Sealed Brain", Effect Duration: 14, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
 7055	moldy spinning breakfast mess	4	crappy	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	gigantic flavorless breakfast miracle	7	decent	Last Available: "2013-12"
+7057	flavorless gigantic breakfast miracle	7	decent	Last Available: "2013-12"
 7058	activated energized purple Cloaca Cola Polar	0		Effect: "Chalk Outline", Effect Duration: 11, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6959,7 +6959,7 @@
 7070	packet of winter seeds	0		Last Available: "2014-01"
 7071	rotten huge blurry snow berries	6	crappy	Last Available: "2014-01"
 7072	flavorless yellow ice harvest	3	decent	Last Available: "2014-01"
-7073	enhanced boiled twirling teal frost flower	0		Effect: "Morbidi Tea", Effect Duration: 55, Last Available: "2014-01"
+7073	enhanced boiled teal twirling frost flower	0		Effect: "Morbidi Tea", Effect Duration: 55, Last Available: "2014-01"
 7074	extra-diffused dry blinking upside-down snow cleats	0		Effect: "Okee-Dokee Go!", Effect Duration: 16, Last Available: "2014-01"
 7075	extra-pressed modified galvanized liquid ice pack	0		Effect: "Neutered Nostrils", Effect Duration: 55, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
@@ -6967,7 +6967,7 @@
 7078	hand-crafted weak Ice Island Long Tea	2	super ultra mega EPIC	Last Available: "2014-01"
 7079	upside-down unfinished ice sculpture	0		Last Available: "2014-01"
 7080	spinning ice sculpture	0		Last Available: "2014-01"
-7081	spinning pulsating ice house	0		Last Available: "2014-01"
+7081	pulsating spinning ice house	0		Last Available: "2014-01"
 7082	red snow machine	0		Last Available: "2014-01"
 7083	snow mobile of the pedagogue	0		Experience: +3, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	weightlifter's ice bucket	0		Muscle: +15, Lasts Until Rollover, Last Available: "2014-01"
@@ -6998,14 +6998,14 @@
 7109	toothsome huge pecan pie	7	awesome	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	diet stale candy mountain oyster	1	decent	Last Available: "2014-12"
-7112	watered-down perfectly mixed chocotini	2	EPIC	Last Available: "2014-12"
+7112	perfectly mixed watered-down chocotini	2	EPIC	Last Available: "2014-12"
 7113	Usain Bolt's chaotic supercool chocolate rabbit's foot	0		Moxie Percent: +20, Spell Critical Percent: +10, Initiative: +80, Last Available: "2014-12"
-7114	adequate diet candy carrot	1	good	Last Available: "2014-12"
+7114	diet adequate candy carrot	1	good	Last Available: "2014-12"
 7115	decent miniature candy carrot cake	2	good	Last Available: "2014-12"
 7116	resourceful cool carrot-on-a-stick	0		Moxie: +5, Maximum MP: +50, Last Available: "2014-12"
 7117	vibrating weasel stomping pants of the wise owl	0		Mysticality: +20, Maximum MP Percent: +10, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	stale blurry mulberry	3	decent	Last Available: "2014-12"
-7119	artisanal extra-dry mulled berry wine	5	EPIC	Last Available: "2014-12"
+7119	extra-dry artisanal mulled berry wine	5	EPIC	Last Available: "2014-12"
 7120	mirror lemony scales	0		Last Available: "2014-12"
 7121	shaking ghostly slick lemon party hat	0		Moxie: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	yellow rock-hard lemon shirt	0		Damage Reduction: 5, Lasts Until Rollover, Last Available: "2014-12"
@@ -7015,13 +7015,13 @@
 7126	dry small gummi fin	0		Effect: "Muddled", Effect Duration: 40, Last Available: "2014-12"
 7127	maroon nippy chocolate cow bone	0		Cold Damage: +10, Last Available: "2014-12"
 7128	altered ionized aerosolized shaking gummi fang	0		Effect: "Robocamo", Effect Duration: 33, Last Available: "2014-12"
-7129	normal special leftover canap&eacute;s	3	good	Effect: "Tea-hee", Effect Duration: 10, Last Available: "2014-12"
+7129	special normal leftover canap&eacute;s	3	good	Effect: "Tea-hee", Effect Duration: 10, Last Available: "2014-12"
 7130	smooth practically non-alcoholic magnum of champagne	1	awesome	Last Available: "2014-12"
 7131	groovy cow creamer of horror of the glutton	0		Moxie Percent: +10, Spooky Spell Damage: +25, Food Drop: +100, Last Available: "2014-12"
 7132	corrupted ionized Outer Wolf&trade; cologne	0		Effect: "Can Has Cyborger", Effect Duration: 59, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	pulsating double-paned wolf whistle of horror	0		Spooky Spell Damage: +25, Cold Resistance: +5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	yummy tiny mirror witch's bread	1	awesome	Last Available: "2014-12"
+7134	pulsating double-paned wolf whistle of horror	0		Spooky Spell Damage: +25, Cold Resistance: +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	tiny yummy mirror witch's bread	1	awesome	Last Available: "2014-12"
 7136	modified super-cold-filtered lime green witch's brew	0		Effect: "You Read The Manual", Effect Duration: 12, Last Available: "2014-12"
 7137	foul-smelling witch's bra of Leguizamo of terror	0		Monster Level: +20, Stench Damage: +10, Spooky Spell Damage: +10, Last Available: "2014-12"
 7138	drinkable extra-dry gray mid-level medieval mead	5	good	Last Available: "2014-12"
@@ -7032,7 +7032,7 @@
 7143	Sherlock's hare pin of Gandalf	0		Spell Critical Percent: +20, Item Drop: +25, Single Equip, Last Available: "2014-12"
 7144	jittery odd coin	0		Last Available: "2014-12"
 7145	normal cinnamon cannoli	3	good	Last Available: "2014-12"
-7146	practically non-alcoholic hand-crafted expensive champagne	1	EPIC	Last Available: "2014-12"
+7146	hand-crafted practically non-alcoholic expensive champagne	1	EPIC	Last Available: "2014-12"
 7147	dry blinking polo trophy	0		Effect: "Leash of Linguini", Effect Duration: 44, Last Available: "2014-12"
 7148	narrow green oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7048,14 +7048,14 @@
 7159	ghostly nasty careful plain paper hat of James Dean	0		Experience (Moxie): +3, Monster Level: -10, Stench Damage: +5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	stale ice cream sandwich	3	decent	Last Available: "2014-12"
 7161	ribald coward's brainy &quot;honey&quot; dipper	0		Mysticality: +5, Monster Level: -20, Sleaze Damage: +10, Last Available: "2014-12"
-7162	rotten small plumber's lunch	2	crappy	Last Available: "2014-12"
+7162	small rotten plumber's lunch	2	crappy	Last Available: "2014-12"
 7163	gravedigger's resourceful energetic skull gearshift knob	0		Maximum MP Percent: +20, Maximum MP: +50, Spooky Damage: +10, Last Available: "2014-12"
 7164	rotten huge nachos of the night	4	crappy	Last Available: "2014-12"
 7165	wobbly greedy careful Sketcherz&trade; of the pedagogue	0		Experience: +3, Monster Level: -10, Meat Drop: +20, Last Available: "2014-12"
-7166	half-sized normal narrow teal can of Adultwitch&trade;	2	good	Last Available: "2014-12"
+7166	normal half-sized narrow teal can of Adultwitch&trade;	2	good	Last Available: "2014-12"
 7167	activated activated electrified pulsating smudge stick	0		Effect: "5 Pounds Lighter", Effect Duration: 42, Last Available: "2014-12"
 7168	galvanized pulsating wall	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 24, Last Available: "2014-12"
-7169	watered-down tolerable tankard of ale	2	good	Last Available: "2014-12"
+7169	tolerable watered-down tankard of ale	2	good	Last Available: "2014-12"
 7170	non-alkaline dry scroll case	0		Effect: "Chalked Weapon", Effect Duration: 28, Last Available: "2014-12"
 7171	moist cold-filtered jug of &quot;wine&quot;	0		Effect: "Human-Goblin Hybrid", Effect Duration: 23, Last Available: "2014-12"
 7172	blue juggling ball	0		Last Available: "2014-12"
@@ -7101,7 +7101,7 @@
 7212	Jeselnik's Jefferson wings	0		Sleaze Damage: +25
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	fancy half-sized decent fleetwood mac 'n' cheese	2	good	Effect: "Ermine Eyes", Effect Duration: 25
+7215	half-sized decent fancy fleetwood mac 'n' cheese	2	good	Effect: "Ermine Eyes", Effect Duration: 25
 7216	lynyrd skin	0		
 7217	bouncing veiny lynyrdskin cap	0		Maximum HP: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	blinking shaking personal trainer's lynyrdskin tunic	0		Experience Percent (Muscle): +10
@@ -7118,7 +7118,7 @@
 7229	lousy teal wine	3	decent	
 7230	drinkable rum	4	good	
 7231	delicious Murderer's Punch	3	awesome	
-7232	stale super-sized velvet cake	5	decent	
+7232	super-sized stale velvet cake	5	decent	
 7233	chilled alkaline red bouncing letter	0		Effect: "Buff as a Baobab", Effect Duration: 50
 7234	bouncing Usain Bolt's mansplainer's book	0		Monster Level: +15, Initiative: +80
 7235	tumbling vibrating savvy masque	0		Mysticality Percent: +20, Maximum MP Percent: +10, Single Equip
@@ -7167,7 +7167,7 @@
 7278	returned Thinknerd package	0		
 7279	adjusted anodized mirror twirling wind-up Whatsian robot	0		Effect: "Badger Underfoot", Effect Duration: 53
 7280	cold-filtered wind-up vampire teeth	0		Effect: "Mana Tea", Effect Duration: 16
-7281	improved nitrogenated jittery narrow fuchsia wind-up navigation droid	0		Effect: "The Magic of LOV", Effect Duration: 46
+7281	improved nitrogenated narrow fuchsia jittery wind-up navigation droid	0		Effect: "The Magic of LOV", Effect Duration: 46
 7282	activated denatured extra-Vulcanized wind-up owl	0		Effect: "Comprehensively Nourished", Effect Duration: 30
 7283	deionized wind-up ensign	0		Effect: "Human-Demon Hybrid", Effect Duration: 16
 7284	wicked crying statue earrings of the bloodbag	0		Spell Damage: +5, Maximum HP: +100, Single Equip, Lasts Until Rollover
@@ -7185,7 +7185,7 @@
 7296	Temple Grandin's elevenderizing hammer of the empath	0		Familiar Weight: 12, Last Available: "2014-03"
 7297	prompt Professor What T-Shirt	0		Adventures: +3
 7298	heavy-duty bendy straw	0		
-7299	huge ghostly pellet of plant food	0		
+7299	ghostly huge pellet of plant food	0		
 7300	sewing kit	0		
 7301	Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
@@ -7196,7 +7196,7 @@
 7307	shaking Lady Spookyraven's dancing shoes	0		
 7308	electrified colloidal spinning eyebrow pencil	0		Effect: "You Can Taste the Darkness", Effect Duration: 58
 7309	electrified energized squat tumbling rosewater cream	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 24
-7310	pressed galvanized jittery squat bronzer	0		Effect: "Mathematically Precise", Effect Duration: 17
+7310	pressed galvanized squat jittery bronzer	0		Effect: "Mathematically Precise", Effect Duration: 17
 7311	sharpshooter's elegant nightstick of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +10
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	box of hickory chips	0		Familiar Weight: +5
@@ -7213,7 +7213,7 @@
 7324	mixed huge battery	1		
 7325	fortified drinkable snakebite	5	good	
 7326	rubber ribcage of the sewer of the early riser	0		Stench Damage: +25, Adventures: +7, Damage Reduction: 7
-7327	diluted cyan blinking upside-down synthetic marrow	1		Effect: "Antibiotic Saucesphere", Effect Duration: 35
+7327	diluted upside-down blinking cyan synthetic marrow	1		Effect: "Antibiotic Saucesphere", Effect Duration: 35
 7328	altered quantum funny bone	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 37
 7329	mansplainer's half-melted spoon of the sweet-tooth	0		Monster Level: +15, Candy Drop: +100
 7330	dried the funk	1		
@@ -7229,7 +7229,7 @@
 7340	fireproof moose antlers	0		Hot Resistance: +3, Familiar Effect: "atk, 1xLep, cap 27"
 7341	galvanized activated skewed moose thought	0		Effect: "Heart Aflame", Effect Duration: 41
 7342	stale moose chocolate	3	decent	
-7343	perfectly mixed watered-down painting of a glass of wine	2	EPIC	
+7343	watered-down perfectly mixed painting of a glass of wine	2	EPIC	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7238,9 +7238,9 @@
 7349	spinning olive ghost key	0		
 7350	blurry picture of you	0		
 7351	Jeselnik's Lo Pan's rosy-cheeked Staff of the Electric Range	0		Maximum HP Percent: +30, Spell Critical Percent: +30, Sleaze Damage: +25
-7352	immense tasty pulsating deluxe layer cake	9	awesome	
+7352	tasty immense pulsating deluxe layer cake	9	awesome	
 7353	chunk of hot iron	0		
-7354	weak acceptable red-hot boilermaker	2	good	
+7354	acceptable weak red-hot boilermaker	2	good	
 7355	tumbling avaricious coal shovel	0		Meat Drop: +30, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	energized fuchsia hot coal	0		Effect: "You Drank Fish Wine", Effect Duration: 31
 7357	modified polymerized coal dust	0		Effect: "Frigid Weapon", Effect Duration: 13
@@ -7252,7 +7252,7 @@
 7363	deionized galvanized red bloodstain stick	0		Effect: "Feelin' Philosophical", Effect Duration: 45
 7364	pulsating blue fabric softener	0		
 7365	ionized vacuum-sealed fabric hardener	0		Effect: "Pisces Rising", Effect Duration: 41
-7366	artisanal practically non-alcoholic bottle of laundry sherry	1	super EPIC	
+7366	practically non-alcoholic artisanal bottle of laundry sherry	1	super EPIC	
 7367	alkaline industrial strength starch	0		Effect: "Slightly Larger Than Usual", Effect Duration: 61, Wiki Name: "industrial strength starch"
 7368	normal extra-flat panini	3	good	
 7369	activated denatured mangled finger	0		Effect: "Egg-stra Arm", Effect Duration: 22
@@ -7270,7 +7270,7 @@
 7381	Pendant of Gargalesis of temperance	0		Sleaze Resistance: +5
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	pulsating DNA extraction syringe	0		Last Available: "2014-04"
-7384	dry activated concentrated blinking blue Gene Tonic: Dude	0		Effect: "Dragged Through the Coals", Effect Duration: 63, Last Available: "2014-04"
+7384	dry activated concentrated blue blinking Gene Tonic: Dude	0		Effect: "Dragged Through the Coals", Effect Duration: 63, Last Available: "2014-04"
 7385	pickled frozen Gene Tonic: Beast	0		Effect: "Preemptive Medicine", Effect Duration: 34, Last Available: "2014-04"
 7386	moist diffused Gene Tonic: Construct	0		Effect: "Memory of Attractiveness", Effect Duration: 43, Last Available: "2014-04"
 7387	diffused ghostly Gene Tonic: Undead	0		Effect: "Mad at Science", Effect Duration: 34, Last Available: "2014-04"
@@ -7300,7 +7300,7 @@
 7411	wobbly blurry Steam Card: Space Trip (#3)	0		
 7412	squat Steam Card: Meteoid (#1)	0		
 7413	twirling squat Steam Card: Meteoid (#2)	0		
-7414	squat blinking Steam Card: Meteoid (#3)	0		
+7414	blinking squat Steam Card: Meteoid (#3)	0		
 7415	jittery Steam Card: DemonStar (#1)	0		
 7416	Steam Card: DemonStar (#2)	0		
 7417	Steam Card: DemonStar (#3)	0		
@@ -7325,18 +7325,18 @@
 7436	warmed Tremella Tarantella mushroom	0		Effect: "Tiki Toughness", Effect Duration: 26, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	moldy Beefy Crunch Pastaco	3	crappy	Last Available: "2014-05"
-7439	half-sized delicious bouncing Brain Food Pastaco	2	awesome	Last Available: "2014-05"
+7439	delicious half-sized bouncing Brain Food Pastaco	2	awesome	Last Available: "2014-05"
 7440	huge yummy Cool Brunch Pastaco	8	awesome	Last Available: "2014-05"
-7441	spoiled fancy Medical Pastaco	4	crappy	Effect: "Overstimulated", Effect Duration: 25, Last Available: "2014-05"
+7441	fancy spoiled Medical Pastaco	4	crappy	Effect: "Overstimulated", Effect Duration: 25, Last Available: "2014-05"
 7442	moldy huge Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
-7443	miniature moldy Ludovico Pastaco	2	crappy	Last Available: "2014-05"
-7444	watered-down artisanal overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7443	moldy miniature Ludovico Pastaco	2	crappy	Last Available: "2014-05"
+7444	artisanal watered-down overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7445	acceptable squat complex mushroom wine	4	good	Last Available: "2014-05"
 7446	extra-dry acceptable smooth mushroom wine	5	good	Last Available: "2014-05"
 7447	delicious blood-red mushroom wine	3	awesome	Last Available: "2014-05"
 7448	weak artisanal buzzing mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7449	mediocre swirling mushroom wine	3	decent	Last Available: "2014-05"
-7450	spoiled diet Taco Dan's Basic Taco Dan Taco	1	crappy	Last Available: "2014-05"
+7450	diet spoiled Taco Dan's Basic Taco Dan Taco	1	crappy	Last Available: "2014-05"
 7451	yummy Taco Dan's Taco Fish Fish Taco	3	awesome	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	bad regular-size brogurt	3	decent	Last Available: "2014-05"
@@ -7369,8 +7369,8 @@
 7480	double-moist activated fuchsia sugar bunny	0		Effect: "Sugar, Hello", Effect Duration: 39, Last Available: "2014-05"
 7481	lime green sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	smooth tumbling Rompedores de Fantasmas	3	awesome	
-7483	hand-crafted extra-dry yellow La Fantasma y La Oscuridad	5	EPIC	
-7484	irresponsibly strong artisanal green Fantasma en la M&aacute;quina	9	EPIC	
+7483	extra-dry hand-crafted yellow La Fantasma y La Oscuridad	5	EPIC	
+7484	artisanal irresponsibly strong green Fantasma en la M&aacute;quina	9	EPIC	
 7485	loosening powder	0		
 7486	blinking castoreum	0		
 7487	drain dissolver	0		
@@ -7405,15 +7405,15 @@
 7516	witch's spare house key	0		
 7517	Jeselnik's spider leg of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +25
 7518	wand of pigification	0		
-7519	watered-down hand-crafted glass of bourbon	2	EPIC	
+7519	hand-crafted watered-down glass of bourbon	2	EPIC	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	decent government cheese	3	good	Last Available: "2014-05"
 7522	razor-sharp pair of government shades	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2014-05"
-7523	tumbling spinning space junk	0		Last Available: "2014-05"
+7523	spinning tumbling space junk	0		Last Available: "2014-05"
 7524	unsweetened deionized skewed government	0		Effect: "Adventurer's Best Friendship", Effect Duration: 65, Last Available: "2014-05"
 7525	quantum extra-irradiated narrow jittery alien drugs	0		Effect: "Crimbo Nostalgia", Effect Duration: 52, Last Available: "2023-09"
 7526	skewed weird space book	0		Last Available: "2014-05"
-7527	skewed pulsating alien force field disruptor bean	0		Last Available: "2014-05"
+7527	pulsating skewed alien force field disruptor bean	0		Last Available: "2014-05"
 7528	dog trainer's government-issued night-vision goggles of horror	0		Experience (familiar): +1, Spooky Spell Damage: +25, Single Equip, Last Available: "2014-05"
 7529	adequate twirling loaf of alien bread	4	good	Last Available: "2014-05"
 7530	adequate grilled cheese sandwich	3	good	Last Available: "2014-05"
@@ -7429,11 +7429,11 @@
 7540	space beast fur pants of Gandalf	0		Spell Critical Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	huge space beast fur whip of the early riser	0		Adventures: +7, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	greasy space heater of the dark arts	0		Spell Damage Percent: +100, Sleaze Spell Damage: +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	greasy space heater of the dark arts	0		Spell Damage Percent: +100, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	mirror space bar	0		Last Available: "2014-05"
 7545	lousy watered-down space port	2	decent	Last Available: "2014-05"
 7546	mirror Samson's space needle	0		Experience (Muscle): +5, Item Drop: +5, Last Available: "2014-05"
-7547	pickled tumbling upside-down buffed alien drugs	0		Effect: "Raging Animal", Effect Duration: 18, Last Available: "2014-05"
+7547	pickled upside-down tumbling buffed alien drugs	0		Effect: "Raging Animal", Effect Duration: 18, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
 7549	enhanced cold-filtered squat ash soda	0		Effect: "Knightlife", Effect Duration: 23, Last Available: "2014-06"
 7550	energized quantum enhanced liquid smoke	0		Effect: "Human-Fish Hybrid", Effect Duration: 38, Last Available: "2014-06"
@@ -7451,7 +7451,7 @@
 7562	improved flattened musk turtle	0		Effect: "Booze Goozles", Effect Duration: 63
 7563	alkaline aerosolized programmable turtle	0		Effect: "Pwnd", Effect Duration: 54
 7564	quantum super-ionized mocking turtle	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 40
-7565	diet enchanted spoiled ham steak	1	crappy	Effect: "Human-Goblin Hybrid", Effect Duration: 50
+7565	spoiled enchanted diet ham steak	1	crappy	Effect: "Human-Goblin Hybrid", Effect Duration: 50
 7566	time-twitching toolbelt of the detective	0		Item Drop: +20, Single Equip, Free Pull
 7567	blinking Chroner	0		
 7568	electrified Time Lord Badge of Honor of the ox of the empath	0		Muscle: +20, Familiar Weight: +5, MP Regen Min: 3, MP Regen Max: 5
@@ -7469,7 +7469,7 @@
 7580	compressed liquid shifting time weirdness	1		Effect: "Tremella Tremens", Effect Duration: 10
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	stale rack of dinosaur ribs	3	decent	
-7583	watered-down aged scotch on the rocks	2	awesome	
+7583	aged watered-down scotch on the rocks	2	awesome	
 7584	hardy dangerous yabba dabba doo rag	0		Weapon Damage: +10, Maximum HP: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	upside-down nasty personal trainer's wooly loincloth	0		Experience Percent (Muscle): +10, Stench Damage: +5, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
@@ -7478,12 +7478,12 @@
 7589	mediocre glass of &quot;milk&quot;	3	decent	Last Available: "2014-07"
 7590	artisanal cup of &quot;tea&quot;	4	EPIC	Last Available: "2014-07"
 7591	tolerable thermos of &quot;whiskey&quot;	4	good	Last Available: "2014-07"
-7592	practically non-alcoholic lousy squat Lucky Lindy	1	decent	Last Available: "2014-07"
+7592	lousy practically non-alcoholic squat Lucky Lindy	1	decent	Last Available: "2014-07"
 7593	mediocre Bee's Knees	3	decent	Last Available: "2014-07"
-7594	distilled perfectly mixed Sockdollager	5	EPIC	Last Available: "2014-07"
+7594	perfectly mixed distilled Sockdollager	5	EPIC	Last Available: "2014-07"
 7595	delicious Ish Kabibble	3	awesome	Last Available: "2014-07"
-7596	special weak aged pulsating blurry Hot Socks	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2014-07"
-7597	irresponsibly strong perfectly mixed blue Phonus Balonus	10	EPIC	Last Available: "2014-07"
+7596	weak aged special blurry pulsating Hot Socks	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2014-07"
+7597	perfectly mixed irresponsibly strong blue Phonus Balonus	10	EPIC	Last Available: "2014-07"
 7598	mediocre teal Flivver	3	decent	Last Available: "2014-07"
 7599	perfectly mixed watered-down huge Sloppy Jalopy	2	super ultra mega EPIC	Last Available: "2014-07"
 7600	corrupted tumbling flame	0		Effect: "Locks Like the Raven", Effect Duration: 51
@@ -7497,7 +7497,7 @@
 7608	liquefied non-anodized turtle mud	0		Effect: "Berry Elemental", Effect Duration: 43
 7609	super-energized Redeye&trade; Eyedrops	0		Effect: "Egg on your Face", Effect Duration: 27
 7610	flattened moist blurry Dweebisol&trade; inhaler	0		Effect: "Demonic Flavor", Effect Duration: 12
-7611	magnetized bouncing squat spinning Lewd Lemmy Hair Oil	0		Effect: "Extra-Thick Blood", Effect Duration: 61
+7611	magnetized squat bouncing spinning Lewd Lemmy Hair Oil	0		Effect: "Extra-Thick Blood", Effect Duration: 61
 7612	cold-filtered modified tomato soup poster	0		Effect: "Ooh, Bitter!", Effect Duration: 64
 7613	unsweetened pulsating bubblin' chemistry solution	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 64
 7614	wet voodoo glowskull	0		Effect: "Buggy Flavor", Effect Duration: 54
@@ -7534,9 +7534,9 @@
 7645	jittery life preserver	0		
 7646	blinking lightning milk	0		
 7647	lime green aquaconda brain	0		
-7648	shaking wobbly thunder thigh	0		
+7648	wobbly shaking thunder thigh	0		
 7649	altered twirling gourmet gourami oil	0		Effect: "Discomfited", Effect Duration: 14
-7650	ionized ionized narrow wobbly catfish whiskers	0		Effect: "Frisky Spirit", Effect Duration: 45
+7650	ionized ionized wobbly narrow catfish whiskers	0		Effect: "Frisky Spirit", Effect Duration: 45
 7651	bouncing freshwater fishbone	0		
 7652	jittery fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7548,7 +7548,7 @@
 7659	neoprene skullcap of Leguizamo	0		Monster Level: +20, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	electrified nitrogenated irradiated pulsating goblin water	0		Effect: "Weird Flavor", Effect Duration: 38
 7661	wobbly blinking dumb mud	0		
-7662	snack-sized special bland upside-down Sogg-Os	2	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 30
+7662	snack-sized bland special upside-down Sogg-Os	2	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 30
 7663	resourceful vibrating Lord Soggyraven's Slippers of the overflowing toilet	0		Maximum MP Percent: +10, Maximum MP: +50, Stench Spell Damage: +50, Single Equip
 7664	quadruple-ionized modified Ancient Protector Soda	0		Effect: "meat.enh", Effect Duration: 64
 7665	deionized liquid ice	0		Effect: "Bloodstain-Resistant", Effect Duration: 21
@@ -7567,13 +7567,13 @@
 7678	twirling zippy 4-dimensional fez	0		Initiative: +20, Familiar Effect: "atk, 1xLep, cap 12"
 7679	spinning throwing candy	0		
 7680	huge Fonzie's super-absorbent tarp	0		Experience (Moxie): +1
-7681	mediocre practically non-alcoholic unquiet spirits	1	decent	
+7681	practically non-alcoholic mediocre unquiet spirits	1	decent	
 7682	scorching banjo kazoo mount	0		Hot Damage: +25, Single Equip
 7683	irradiated blue grass	0		Effect: "The Halls of Moxiousness", Effect Duration: 51
 7684	padded Time Lord Participation Mug	0		Damage Absorption: +20
 7685	tumbling maroon flame-wreathed scorching Time Bandit Time Towel	0		Hot Damage: +25, Hot Spell Damage: +10
 7686	extremely unsafe sage Caveman Dan's favorite rock of mayonnaise	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Sleaze Spell Damage: +50, Single Equip
-7687	non-dry irradiated blinking purple dog ointment	0		Effect: "Ginger Snapped", Effect Duration: 12
+7687	non-dry irradiated purple blinking dog ointment	0		Effect: "Ginger Snapped", Effect Duration: 12
 7688	Oprah's personal trainer's gumshoes	0		Experience Percent (Muscle): +10, Maximum MP Percent: +50, Single Equip
 7689	tumbling healthy flapper floppers of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Single Equip
 7690	Usain Bolt's sizzling sneakeasies	0		Hot Damage: +10, Initiative: +80, Single Equip
@@ -7581,7 +7581,7 @@
 7692	jittery huge smelly wizardly hand whip of courage	0		Mysticality: +25, Stench Spell Damage: +10, Spooky Resistance: +3, Last Available: "2014-08"
 7693	wool nasty glow-in-the-dark necklace of the scaredy-cat	0		Monster Level: -15, Stench Damage: +5, Cold Resistance: +1, Last Available: "2014-08"
 7694	gray Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	Jeselnik's Da Vinci's cap gun of terror	0		Experience (Mysticality): +5, Spooky Spell Damage: +10, Sleaze Damage: +25, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	Jeselnik's Da Vinci's cap gun of terror	0		Experience (Mysticality): +5, Spooky Spell Damage: +10, Sleaze Damage: +25, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	blinking double-paned cassette player of doom	0		Spooky Spell Damage: +50, Cold Resistance: +5, Single Equip, Last Available: "2014-08"
 7697	tumbling chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7589,17 +7589,17 @@
 7700	altered altered confiscated comic book	0		Effect: "Jammin'", Effect Duration: 28, Last Available: "2014-08"
 7701	triple-Vulcanized quantum red confiscated cell phone	0		Effect: "Analog Drunk", Effect Duration: 11, Last Available: "2014-08"
 7702	liquefied ionized confiscated love note	0		Effect: "Salty Dogs", Effect Duration: 57, Last Available: "2014-08"
-7703	mirror blue LCD game: Food Eater	0		Last Available: "2014-08"
+7703	blue mirror LCD game: Food Eater	0		Last Available: "2014-08"
 7704	tumbling LCD game: Garbage River	0		Last Available: "2014-08"
 7705	fuchsia LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	teal The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	altered enhanced rubber nubbin	0		Effect: "Elbow Sauce", Effect Duration: 57, Last Available: "2014-08"
 7708	Jim Carey's rubber cape of dire peril	0		Weapon Damage: +20, Monster Level: +25, Last Available: "2014-08"
-7709	tumbling ghostly olive censurious Van der Graaf wholesome Thor's Pliers of vim and vigor	0		Maximum HP Percent: 60, Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	tumbling ghostly olive censurious Van der Graaf wholesome Thor's Pliers of vim and vigor	0		Maximum HP Percent: 60, Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	modified ionized tumbling candy UFOs	0		Effect: "Guts Feeling", Effect Duration: 33
 7711	ribald water wings for babies of Gandalf	0		Spell Critical Percent: +20, Sleaze Damage: +10
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	miniature stale spinning shaking Strix stix	2	decent	
+7713	miniature stale shaking spinning Strix stix	2	decent	
 7714	Annie Oakley's vampire pellet of terror of doom	0		Critical Hit Percent: +20, Spooky Spell Damage: 60
 7715	mediocre ghostly non-aged vinegar	3	decent	
 7716	yellow spinning auspicious unsanitized scalpel	0		Item Drop: +10
@@ -7623,7 +7623,7 @@
 7734	maroon Xiblaxian polymer	0		Last Available: "2014-09"
 7735	Xiblaxian alloy	0		Last Available: "2014-09"
 7736	shaking Xiblaxian crystal	0		Last Available: "2014-09"
-7737	bouncing fuchsia Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
+7737	fuchsia bouncing Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
 7738	Xiblaxian cache locator simcode	0		Last Available: "2014-09"
 7739	bouncing Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
@@ -7642,15 +7642,15 @@
 7753	red energetic Xiblaxian stealth cowl of the ox	0		Muscle: +20, Maximum MP Percent: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	Jack Frost's quilted Xiblaxian stealth trousers	0		Damage Absorption: +40, Cold Spell Damage: +50, Last Available: "2014-09"
 7755	brainy Xiblaxian stealth vest of Flo-Jo	0		Mysticality: +5, Initiative: +100, Last Available: "2014-09"
-7756	rotten jumbo Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
+7756	jumbo rotten Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
 7757	tolerable bouncing Xiblaxian space-whiskey	4	good	Last Available: "2014-09"
 7758	squat Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	quadruple-vacuum-sealed triple-adjusted They liver	0		Effect: "Human-Human Hybrid", Effect Duration: 60, Last Available: "2014-09"
-7760	stale jumbo They liver popsicle	5	decent	Last Available: "2014-09"
+7760	jumbo stale They liver popsicle	5	decent	Last Available: "2014-09"
 7761	ghostly holo-tank	0		Last Available: "2014-09"
 7762	spinning holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
-7764	twisted squat mirror lime green residual zeal	1		Effect: "Tin, Man", Effect Duration: 15, Last Available: "2014-09"
+7764	twisted mirror lime green squat residual zeal	1		Effect: "Tin, Man", Effect Duration: 15, Last Available: "2014-09"
 7765	shaking Xiblaxian holo-wrist-puter of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2014-09"
 7766	tumbling shellacked defective Golden Mr. Accessory of Calamity Jane of the boozehound	0		Damage Reduction: 7, Critical Hit Percent: +15, Booze Drop: +100
 7767	airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7658,8 +7658,8 @@
 7769	narrow Coinspiracy	0		Last Available: "2014-10"
 7770	studded Personal Ventilation Unit of the cougar of the brute	0		Moxie: +20, Muscle Percent: +30, Damage Absorption: +80, Single Equip, Last Available: "2014-10"
 7771	Vulcanized colloidal the most dangerous bait	0		Effect: "Just Aged Enough", Effect Duration: 28, Last Available: "2014-10"
-7772	enchanted moldy massive spinning &quot;meat&quot; stick	10	crappy	Effect: "Just the Brown Ones", Effect Duration: 45, Last Available: "2014-10"
-7773	distilled wobbly huge transdermal smoke patch	1	good	Effect: "Human-Hobo Hybrid", Effect Duration: 10, Last Available: "2014-10"
+7772	massive enchanted moldy spinning &quot;meat&quot; stick	10	crappy	Effect: "Just the Brown Ones", Effect Duration: 45, Last Available: "2014-10"
+7773	distilled huge wobbly transdermal smoke patch	1	good	Effect: "Human-Hobo Hybrid", Effect Duration: 10, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	wobbly spinning greasy pair of plants of the scaredy-cat of bravery	0		Monster Level: -15, Sleaze Spell Damage: +10, Spooky Resistance: +5, Last Available: "2014-10"
 7776	studded groovy beefy Sasq&trade; watch	0		Muscle: +10, Moxie Percent: +10, Damage Absorption: +80, Single Equip, Last Available: "2014-10"
@@ -7673,7 +7673,7 @@
 7784	frozen yellow monkey barf	0		Effect: "Cheered Up", Effect Duration: 62, Last Available: "2014-10"
 7785	colloidal denatured squat olive candy	0		Effect: "Simulation Stimulation", Effect Duration: 57, Last Available: "2014-10"
 7786	ghostly foul-smelling crafty arcane researcher's jangly bracelet	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Stench Damage: +10, Last Available: "2014-10"
-7787	rosy-cheeked cuddly teddy bear	0		Maximum HP Percent: +30, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	rosy-cheeked cuddly teddy bear	0		Maximum HP Percent: +30, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	cyan ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	shellacked dangerous first-aid pouch	0		Weapon Damage: +10, Damage Reduction: 7, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7682,11 +7682,11 @@
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	ghostly Armory keycard	0		Last Available: "2014-10"
 7795	toothsome initiative shawarma	3	awesome	Last Available: "2014-10"
-7796	normal special warm war shawarma	3	good	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2014-10"
-7797	stale diet bouncing gray karma shawarma	1	decent	Last Available: "2014-10"
+7796	special normal warm war shawarma	3	good	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2014-10"
+7797	diet stale gray bouncing karma shawarma	1	decent	Last Available: "2014-10"
 7798	bad Jungle Juice	4	decent	Last Available: "2014-10"
 7799	drinkable upside-down Amnesiac Ale	4	good	Last Available: "2014-10"
-7800	fancy aged Highest Bitter	3	awesome	Effect: "A Contender", Effect Duration: 45, Last Available: "2014-10"
+7800	aged fancy Highest Bitter	3	awesome	Effect: "A Contender", Effect Duration: 45, Last Available: "2014-10"
 7801	blinking blinking rosy-cheeked mercenary pistol of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +30, Last Available: "2014-10"
 7802	Oprah's beefy mercenary rifle	0		Muscle: +10, Maximum MP Percent: +50, Last Available: "2014-10"
 7803	twirling Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7695,7 +7695,7 @@
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
-7809	mirror red upside-down impure gasoline	0		
+7809	upside-down red mirror impure gasoline	0		
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
@@ -7713,7 +7713,7 @@
 7824	stanky stylish strapping iShield	0		Muscle: +5, Moxie: +25, Stench Spell Damage: +25, Damage Reduction: 6
 7825	hardened extremely unsafe earbuds of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Damage Reduction: 3, Single Equip
 7826	rosewater-soaked Newton's iFlail of the cheetah	0		Experience (Mysticality): +3, Stench Resistance: +3, Initiative: +60
-7827	immense enchanted flavorless unidentifiable dried fruit	9	decent	Effect: "Eldritch Concentration", Effect Duration: 40
+7827	immense flavorless enchanted unidentifiable dried fruit	9	decent	Effect: "Eldritch Concentration", Effect Duration: 40
 7828	tolerable gray flat cider	4	good	
 7829	olive narrow executive foul-smelling trench lighter of courage	0		Stench Damage: +10, Spooky Resistance: +3, Meat Drop: +40, Last Available: "2014-10"
 7830	aerosolized dry mirror upside-down experimental serum P-00	0		Effect: "The Grass...  Is Blue...", Effect Duration: 29, Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	electrified aerosolized twirling perl necklace	0		Effect: "Adventurer's Best Friendship", Effect Duration: 18, Last Available: "2014-12"
 7846	pickled skewed Fudge Fiber Armor Plating	0		Effect: "How to Scam Tourists", Effect Duration: 65, Last Available: "2014-12"
 7847	activated jittery ruby on canes	0		Effect: "Oily Flavor", Effect Duration: 15, Last Available: "2014-12"
-7848	fancy stale ghostly petit fortran	3	decent	Effect: "Crusty Head", Effect Duration: 45, Last Available: "2014-12"
+7848	stale fancy ghostly petit fortran	3	decent	Effect: "Crusty Head", Effect Duration: 45, Last Available: "2014-12"
 7849	stale bouncing java cookie	4	decent	Last Available: "2014-12"
 7850	half-sized toothsome cookie cookie	2	awesome	Last Available: "2014-12"
 7851	weightlifter's plastic exo-suited miner	0		Muscle: +15, Last Available: "2014-12"
@@ -7750,7 +7750,7 @@
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
 7862	cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
-7864	twirling jittery olive Petite Paintbrush	0		Adventures: +1
+7864	jittery twirling olive Petite Paintbrush	0		Adventures: +1
 7865	skewed Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
@@ -7774,11 +7774,11 @@
 7885	narrow Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
 7887	Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
-7888	ghostly shaking Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
+7888	shaking ghostly Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	twirling twirling Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
-7892	ghostly huge Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
+7892	huge ghostly Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	narrow Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
@@ -7809,7 +7809,7 @@
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	narrow turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	artisanal Friendly Turkey	4	EPIC	Last Available: "2014-11"
-7923	lousy irresponsibly strong narrow Agitated Turkey	7	decent	Last Available: "2014-11"
+7923	irresponsibly strong lousy narrow Agitated Turkey	7	decent	Last Available: "2014-11"
 7924	perfectly mixed Ambitious Turkey	3	EPIC	Last Available: "2014-11"
 7925	rotten neutron lollipop	4	crappy	Last Available: "2014-12"
 7926	mediocre green gamma nog	3	decent	Last Available: "2014-12"
@@ -7827,11 +7827,11 @@
 7945	table	0		
 7946	padded outlaw bandana of the storm of doom	0		Damage Absorption: +20, Maximum MP Percent: +40, Spooky Spell Damage: +50
 7947	smooth whiskey in a broken glass	4	awesome	
-7948	high-proof special drinkable pulsating shot of mescal	7	good	Effect: "Chalky Hand", Effect Duration: 40
+7948	drinkable high-proof special pulsating shot of mescal	7	good	Effect: "Chalky Hand", Effect Duration: 40
 7949	artisanal glass of herbal tequila	3	EPIC	
 7950	minin' dynamite	0		
 7951	skewed reassuring wool plaid cowboy hat	0		Cold Resistance: +1, Spooky Resistance: +1, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-7952	ghostly maroon lasso	0		
+7952	maroon ghostly lasso	0		
 7953	skewed vibrating Newton's wizardly rusted-out shootin' iron	0		Mysticality: +25, Experience (Mysticality): +3, Maximum MP Percent: +10
 7954	pulsating ghostly rattler rattle	0		
 7955	shaking bag of money	0		
@@ -7852,7 +7852,7 @@
 7970	boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
 7972	modified mummified fig	1	crappy	
-7973	vaporized narrow cyan blinking mummified loaf of bread	1	decent	
+7973	vaporized blinking narrow cyan mummified loaf of bread	1	decent	
 7974	modified mummified beef haunch	1	good	Effect: "Salsa Satanica", Effect Duration: 40
 7975	purple linen bandages	0		
 7976	shaking cotton bandages	0		
@@ -7881,17 +7881,17 @@
 7999	vacuum-sealed skewed choco-Crimbot	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 62, Last Available: "2014-12"
 8000	cold-filtered smart watch	0		Effect: "Provocative Perkiness", Effect Duration: 37, Last Available: "2014-12"
 8001	polarized electrified augmented-reality shades	0		Effect: "Mucilaginous Mentalism", Effect Duration: 19, Last Available: "2014-12"
-8002	huge studded toy Crimbot mega face	0		Damage Absorption: +80, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
-8003	wobbly hardened toy Crimbot power glove	0		Damage Reduction: 3, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	asbestos-lined toy Crimbot super fist	0		Hot Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	aromatic toy Crimbot rocket legs	0		Stench Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	huge studded toy Crimbot mega face	0		Damage Absorption: +80, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	wobbly hardened toy Crimbot power glove	0		Damage Reduction: 3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	asbestos-lined toy Crimbot super fist	0		Hot Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	aromatic toy Crimbot rocket legs	0		Stench Resistance: +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	oxidized green Crimbot battery	0		Effect: "Sweet and Yellow", Effect Duration: 31, Last Available: "2014-12"
 8007	squat Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	fuchsia Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	tumbling heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	crafty extremely unsafe Crimbomega drive chain of the empath	0		Weapon Damage Percent: +100, Maximum MP: +10, Familiar Weight: +5, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	crafty extremely unsafe Crimbomega drive chain of the empath	0		Weapon Damage Percent: +100, Maximum MP: +10, Familiar Weight: +5, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	squat Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,8 +7899,8 @@
 8017	galvanized vacuum-sealed mirror flask of tainted mining oil	0		Effect: "Educated (Kinda)", Effect Duration: 37, Last Available: "2014-12"
 8018	deionized aerosolized tumbling and rain stick	0		Effect: "Demonic Flavor", Effect Duration: 27
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	big rotten spinning Choco-Mint patty	5	crappy	Last Available: "2015-01"
-8021	drinkable spirit-forward hot mint schnocolate	5	good	Last Available: "2015-01"
+8020	rotten big spinning Choco-Mint patty	5	crappy	Last Available: "2015-01"
+8021	spirit-forward drinkable hot mint schnocolate	5	good	Last Available: "2015-01"
 8022	distilled green homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	cyan ghostly muscle stimulator	0		Last Available: "2015-01"
 8024	green foreign language tapes	0		Last Available: "2015-01"
@@ -7919,7 +7919,7 @@
 8037	toothsome immense squat bowl of topioca	8	awesome	
 8038	topiary skunk	0		
 8039	mirror topiary noseplugs	0		Familiar Weight: +5
-8040	skewed fuchsia trusty whip	0		
+8040	fuchsia skewed trusty whip	0		
 8041	pulsating tumbling crumbling skull	0		
 8042	rock	0		
 8043	pot of the early riser	0		Adventures: +7
@@ -7940,7 +7940,7 @@
 8059	Bananubis's Staff	0		Luck: -6
 8060	sizzling friendly The Joke Book of the Dead	0		Familiar Weight: +3, Hot Damage: +10, Luck: -6
 8061	bouncing The Clown Crown	0		Luck: -6
-8062	lime green wobbly huge coffee cup	0		Luck: -2
+8062	lime green huge wobbly coffee cup	0		Luck: -2
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	wobbly banana	0		Familiar Weight: +5
@@ -7996,7 +7996,7 @@
 8121	miser's garland of terror	0		Spooky Spell Damage: +10, Meat Drop: +10, Single Equip, Last Available: "2018-12"
 8122	vibrating gunnysack of the ox	0		Muscle: +20, Maximum MP Percent: +10, Last Available: "2018-12"
 8123	nippy Annie Oakley's garibaldi	0		Critical Hit Percent: +20, Cold Damage: +10, Last Available: "2018-12"
-8124	girdle of chilblains of the glutton	0		Cold Damage: +25, Food Drop: +100, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	girdle of chilblains of the glutton	0		Cold Damage: +25, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	blurry careful fortified gloves	0		Damage Absorption: +60, Monster Level: -10, Single Equip, Last Available: "2018-12"
 8126	compressed smithereens	1		Effect: "Human-Demon Hybrid", Effect Duration: 35, Last Available: "2018-12"
 8127	razor-sharp fiberglass fetish of horror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +25, Last Available: "2018-12"
@@ -8042,12 +8042,12 @@
 8168	glob of icing	0		
 8169	nitrogenated triple-alkaline ginger snaps	0		Effect: "The Magic of LOV", Effect Duration: 63
 8170	boiled narrow mostly-broken sunglasses	0		Effect: "Wasabi With You", Effect Duration: 60
-8171	aged watered-down unflavored wine cooler	2	awesome	
+8171	watered-down aged unflavored wine cooler	2	awesome	
 8172	carton of snake milk	1	EPIC	
 8173	Jim Carey's sewer snake	0		Monster Level: +25
 8174	bland pigeon egg	3	decent	
 8175	dog trainer's studded jaunty feather	0		Damage Absorption: +80, Experience (familiar): +1
-8176	acceptable enchanted ghostly premium malt liquor	3	good	Effect: "Earthen Fist", Effect Duration: 50
+8176	enchanted acceptable ghostly premium malt liquor	3	good	Effect: "Earthen Fist", Effect Duration: 50
 8177	skewed Newton's brown paper pants of doom	0		Experience (Mysticality): +3, Spooky Spell Damage: +50
 8178	gray inspector's weightlifter's brown paper bag mask	0		Muscle: +15, Item Drop: +15
 8179	blinking spinning skewed ring of telling skeletons what to do of temperance	0		Sleaze Resistance: +5, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8069,7 +8069,7 @@
 8195	stale loaf of soda bread	3	decent	
 8196	flavorless acceptable bagel	3	decent	
 8197	bland standard-issue cupcake	4	decent	
-8198	bite-sized decent ultra-deluxe cupcake	1	good	
+8198	decent bite-sized ultra-deluxe cupcake	1	good	
 8199	twirling hypnotic breadcrumbs	0		
 8200	huge bland popular tart	9	decent	
 8201	no-handed pie	0		
@@ -8086,16 +8086,16 @@
 8212	pulsating grogpagne	0		Last Available: "2021-07"
 8213	strapping rigging rope of the ox	0		Muscle: 25, Last Available: "2015-04"
 8214	mixed blinking nasty snuff	1	awesome	Last Available: "2015-04"
-8215	sewage-clogged pistol of the ox of chilblains	0		Muscle: +20, Cold Damage: +25, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	sewage-clogged pistol of the ox of chilblains	0		Muscle: +20, Cold Damage: +25, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	ionized alkaline mirror beard incense	0		Effect: "Arse-a'fire", Effect Duration: 63, Last Available: "2015-04"
 8217	nasty perfume-soaked bandana of the sewer	0		Stench Damage: 30, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	spoiled bite-sized toxo	1	crappy	Last Available: "2015-04"
+8219	bite-sized spoiled toxo	1	crappy	Last Available: "2015-04"
 8220	weak acceptable upside-down Lemonade-235	2	good	Last Available: "2015-04"
 8221	ghostly lime green lightning-fast stiffened isotophat	0		Damage Reduction: 1, Initiative: +40, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	reassuring sage Three Mile Island shorts	0		Mysticality Percent: +10, Spooky Resistance: +1, Last Available: "2015-04"
 8223	baleful toxic mop of the scaredy-cat	0		Spell Damage: +25, Monster Level: -15, Last Available: "2015-04"
-8224	yellow spinning narrow inert sludgepuppy	0		Last Available: "2015-04"
+8224	yellow narrow spinning inert sludgepuppy	0		Last Available: "2015-04"
 8225	bouncing lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	jar of swamp honey	0		Last Available: "2015-04"
 8227	blinking crafty veiny Samson's backwoods banjo	0		Experience (Muscle): +5, Maximum HP: +10, Maximum MP: +10, Last Available: "2015-04"
@@ -8131,7 +8131,7 @@
 8257	energized nasty gum	0		Effect: "Baconstoned", Effect Duration: 18
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	purple chilly The Lot's engagement ring	0		Cold Damage: +5, Conditional Skill (Equipped): "Propose To Your Opponent"
-8260	squat yellow Mayo Clinic	0		Last Available: "2015-05"
+8260	yellow squat Mayo Clinic	0		Last Available: "2015-05"
 8261	twirling Mayonex	0		Last Available: "2015-05"
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	teal Mayostat	0		Last Available: "2015-05"
@@ -8141,9 +8141,9 @@
 8267	Jim Carey's sphygmayomanometer	0		Monster Level: +25, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	thick bland bouncing unappetizing mayolus	5	decent	Last Available: "2015-05"
+8270	bland thick bouncing unappetizing mayolus	5	decent	Last Available: "2015-05"
 8271	stale skewed uninteresting mayolus	3	decent	Last Available: "2015-05"
-8272	snack-sized stale acceptable mayolus	2	decent	Last Available: "2015-05"
+8272	stale snack-sized acceptable mayolus	2	decent	Last Available: "2015-05"
 8273	stale half-sized enticing mayolus	2	decent	Last Available: "2015-05"
 8274	adequate mouth-watering mayolus	3	good	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8154,7 +8154,7 @@
 8280	huge ghostly Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	dry altered energized narrow Kokomo Resort Brand Suntan Oil	0		Effect: "Extra-Thick Blood", Effect Duration: 68, Last Available: "2015-04"
 8282	upside-down Kokomo Resort Order Pad	0		Last Available: "2015-04"
-8283	red ghostly The Cocktail Shaker	0		Last Available: "2015-04"
+8283	ghostly red The Cocktail Shaker	0		Last Available: "2015-04"
 8284	super-enhanced Kokomo Resort Pass	0		Effect: "Smoky Third Eye", Effect Duration: 12, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	moist skewed Mayo de Mayo&trade; mayo	0		Effect: "Pasta Oneness", Effect Duration: 46
@@ -8265,7 +8265,7 @@
 8391	mana	0		Last Available: "2015-07"
 8392	spinning gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
-8394	tumbling ghostly The Emperor's dry cleaning	0		Last Available: "2015-07"
+8394	ghostly tumbling The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	savvy The Emperor's new hat	0		Mysticality Percent: +20, Last Available: "2015-07"
 8396	avaricious The Emperor's new shirt	0		Meat Drop: +30, Last Available: "2015-07"
 8397	smooth The Emperor's new pants	0		Moxie: +15, Last Available: "2015-07"
@@ -8281,7 +8281,7 @@
 8407	moldy spinning pestopiary	3	crappy	
 8408	ionized activated skewed ectoplasmic orbs	0		Effect: "Human-Constellation Hybrid", Effect Duration: 68
 8409	half-sized fancy flavorless crudles	2	decent	Effect: "Glittering Eyelashes", Effect Duration: 10
-8410	enchanted decent lime green bouncing agnolotti arboli	3	good	Effect: "Patent Alacrity", Effect Duration: 25
+8410	enchanted decent bouncing lime green agnolotti arboli	3	good	Effect: "Patent Alacrity", Effect Duration: 25
 8411	rotten spaghetti with ghost balls	4	crappy	
 8412	moldy snack-sized succulent marrow	2	crappy	
 8413	bland salacious crumbs	3	decent	
@@ -8290,7 +8290,7 @@
 8416	wobbly Mountain Stream gastrique	0		
 8417	spoiled Mt. McLargeHuge oyster	4	crappy	
 8418	narrow oyster sauce	0		
-8419	delicious miniature linguini immondizia bianco	2	awesome	
+8419	miniature delicious linguini immondizia bianco	2	awesome	
 8420	stale diet jittery shells a la shellfish	1	decent	
 8421	huge Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8334,13 +8334,13 @@
 8460	spoiled teal mineapple	4	crappy	Last Available: "2015-08"
 8461	lousy Gold Velvet&trade; whiskey	3	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	good	Last Available: "2015-08"
-8463	fancy adequate smelted roe	3	good	Effect: "Rotten Memories", Effect Duration: 30, Last Available: "2015-08"
+8463	adequate fancy smelted roe	3	good	Effect: "Rotten Memories", Effect Duration: 30, Last Available: "2015-08"
 8464	delicious weak fuchsia lavawater	2	awesome	Last Available: "2015-08"
 8465	non-ionized purple tumbling basaltamander tongue	0		Effect: "Compensatory Cruelness", Effect Duration: 36, Last Available: "2015-08"
 8466	olive rock-hard Socratic strapping lavalarva	0		Muscle: +5, Experience (Mysticality): +1, Damage Reduction: 5, Last Available: "2015-08"
 8467	razor-sharp lava balaclava of Tarzan of the cheetah	0		Experience (Muscle): +3, Weapon Damage Percent: +25, Initiative: +60, Last Available: "2015-08"
 8468	reassuring occult sinister basaltamander buckler	0		Spell Damage: +10, Spell Damage Percent: +25, Spooky Resistance: +1, Damage Reduction: 15, Last Available: "2015-08"
-8469	galvanized blurry jittery lava globs	0		Effect: "Wolf's Bane", Effect Duration: 14, Last Available: "2015-08"
+8469	galvanized jittery blurry lava globs	0		Effect: "Wolf's Bane", Effect Duration: 14, Last Available: "2015-08"
 8470	decent mirror gooey lava globs	3	good	Last Available: "2015-08"
 8471	Annie Oakley's lava-proof pants of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +20, Last Available: "2015-08"
 8472	twirling spinning fortified heat-resistant necktie of Leguizamo	0		Damage Absorption: +60, Monster Level: +20, Single Equip, Last Available: "2015-08"
@@ -8348,8 +8348,8 @@
 8474	decent very hot lunch	3	good	Last Available: "2015-08"
 8475	irresponsibly strong perfectly mixed asbestos thermos	8	EPIC	Last Available: "2015-08"
 8476	non-polarized liquid rhinestones	0		Effect: "Polar Express", Effect Duration: 32, Last Available: "2015-08"
-8477	special snack-sized spoiled disco biscuit	2	crappy	Effect: "Deeply Ironic", Effect Duration: 10, Last Available: "2015-08"
-8478	lousy practically non-alcoholic Quaatorade&trade;	1	decent	Last Available: "2015-08"
+8477	snack-sized special spoiled disco biscuit	2	crappy	Effect: "Deeply Ironic", Effect Duration: 10, Last Available: "2015-08"
+8478	practically non-alcoholic lousy Quaatorade&trade;	1	decent	Last Available: "2015-08"
 8479	Jack Frost's educational biker's hat of extreme caution	0		Experience: +1, Monster Level: -25, Cold Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "atk"
 8480	squat censurious clever educational feathered headdress	0		Experience: +1, Maximum MP: +20, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	coward's hardy razor-sharp electrician's hardhat	0		Weapon Damage Percent: +25, Maximum HP: +50, Monster Level: -20, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8379,7 +8379,7 @@
 8505	twirling lime green half-melted hula girl	0		Last Available: "2015-08"
 8506	twirling glass ceiling fragments	0		Last Available: "2015-08"
 8507	dried SMOOCH coffee cup	1	decent	Last Available: "2015-08"
-8508	tarnished anodized fuchsia ghostly labrador cookie	0		Effect: "Ooh, Bitter!", Effect Duration: 17, Last Available: "2015-08"
+8508	tarnished anodized ghostly fuchsia labrador cookie	0		Effect: "Ooh, Bitter!", Effect Duration: 17, Last Available: "2015-08"
 8509	blinking green energetic arcane researcher's Mr. Cheeng's spectacles of horror	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Spooky Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8510	pulsating Usain Bolt's smooth grease cannon	0		Moxie: +15, Initiative: +80, Last Available: "2015-08"
 8511	Vulcanized frozen demon makeup kit	0		Effect: "Permafrosty", Effect Duration: 60, Last Available: "2015-08"
@@ -8393,21 +8393,21 @@
 8519	SMOOCH spaulders of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2015-08"
 8520	MacGyver's groovy SMOOCH codpiece	0		Moxie Percent: +10, Maximum MP: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	jittery SMOOCH breastplate of the wise owl	0		Mysticality: +20, Last Available: "2015-08"
-8522	olive mirror superduperheated	0		Last Available: "2015-08"
+8522	mirror olive superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	adequate enchanted green lava cake	3	good	Effect: "Electrolit Up", Effect Duration: 15, Last Available: "2015-08"
-8526	stale half-sized pink slime	2	decent	
+8525	enchanted adequate green lava cake	3	good	Effect: "Electrolit Up", Effect Duration: 15, Last Available: "2015-08"
+8526	half-sized stale pink slime	2	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	bland low-calorie devil hair pasta	1	decent	
+8529	low-calorie bland devil hair pasta	1	decent	
 8530	bland spagecialetti	4	decent	
 8531	Salsa Libre	0		
 8532	mirror good gravy	0		
 8533	illicit fish sauce	0		
-8534	fancy spoiled libertagliatelle	4	crappy	Effect: "Amplified Fabulousness", Effect Duration: 15
+8534	spoiled fancy libertagliatelle	4	crappy	Effect: "Amplified Fabulousness", Effect Duration: 15
 8535	enchanted yummy turkish mostaccioli	4	awesome	Effect: "Disco State of Mind", Effect Duration: 30
-8536	miniature spoiled yellow twirling linguini of the sea	2	crappy	
+8536	spoiled miniature twirling yellow linguini of the sea	2	crappy	
 8537	super-denatured blinking Hersey&trade; SMOOCH	0		Effect: "Human-Horror Hybrid", Effect Duration: 24
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
@@ -8424,22 +8424,22 @@
 8551	miniature decent sausage without a cause	2	good	
 8552	energized face paint	0		Effect: "Snobby", Effect Duration: 40
 8553	irresponsibly strong perfectly mixed emergency margarita	8	EPIC	
-8554	mediocre extra-dry vintage smart drink	5	decent	
+8554	extra-dry mediocre vintage smart drink	5	decent	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	quantum wobbly jittery Wickers bar	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 38
+8558	quantum jittery wobbly Wickers bar	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 38
 8559	polymerized pulsating bakelite-covered bacon	0		Effect: "Cancer Rising", Effect Duration: 49
 8560	magnetized wet huge Aerheads	0		Effect: "Sparkling Consciousness", Effect Duration: 40
 8561	Vulcanized anodized oxidized upside-down Wrotz	0		Effect: "Bread-Lined", Effect Duration: 51
-8562	Vulcanized Vulcanized upside-down blinking Gabarbar	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 32
+8562	Vulcanized Vulcanized blinking upside-down Gabarbar	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 32
 8563	modified fiberglass insulation	0		Effect: "Chief Executive Optimism", Effect Duration: 11
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	gray family-friendly reassuring dog trainer's barrel lid	0		Experience (familiar): +1, Spooky Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	maroon squat Jack Frost's sharpshooter's wholesome barrel hoop earring	0		Maximum HP Percent: +10, Critical Hit Percent: +10, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2015-09"
 8567	ghostly sharpshooter's supercool weightlifter's bankruptcy barrel	0		Muscle: +15, Moxie Percent: +20, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
-8569	upside-down maroon normal barrel	0		Last Available: "2015-09"
+8569	maroon upside-down normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
@@ -8448,10 +8448,10 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	distilled hand-crafted bottle of Amontillado	5	EPIC	Last Available: "2015-09"
+8578	hand-crafted distilled bottle of Amontillado	5	EPIC	Last Available: "2015-09"
 8579	hand-crafted teal barrel-aged martini	3	EPIC	Last Available: "2015-09"
 8580	stale barrel pickle	3	decent	Last Available: "2015-09"
-8581	big spoiled blurry barrel cracker	5	crappy	Last Available: "2015-09"
+8581	spoiled big blurry barrel cracker	5	crappy	Last Available: "2015-09"
 8582	compressed vibrating mushroom	1	EPIC	Last Available: "2015-09"
 8583	compressed blurry mushroom	1	crappy	Last Available: "2015-09"
 8584	Jim Carey's KoL Con 12-gauge	0		Monster Level: +25, Last Available: "2015-09"
@@ -8471,20 +8471,20 @@
 8598	flame-wreathed wicked barrel beryl ring	0		Spell Damage: +5, Hot Spell Damage: +10, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
-8601	quadruple-liquefied enhanced narrow yellow cuppa Flamibili tea	0		Effect: "Sludgesick", Effect Duration: 67, Last Available: "2015-09"
+8601	quadruple-liquefied enhanced yellow narrow cuppa Flamibili tea	0		Effect: "Sludgesick", Effect Duration: 67, Last Available: "2015-09"
 8602	dry cuppa Yet tea	0		Effect: "Berry Elemental", Effect Duration: 57, Last Available: "2015-09"
 8603	wet dry cuppa Boo tea	0		Effect: "Dexteri Tea", Effect Duration: 42, Last Available: "2015-09"
 8604	galvanized adjusted unsweetened shaking cuppa Nas tea	0		Effect: "Human-Hobo Hybrid", Effect Duration: 53, Last Available: "2015-09"
 8605	irradiated corrupted cuppa Improprie tea	0		Effect: "Rootin' Around", Effect Duration: 57, Last Available: "2015-09"
 8606	polymerized pickled cuppa Frost tea	0		Effect: "Creepypasted", Effect Duration: 59, Last Available: "2015-09"
-8607	concentrated boiled narrow blurry olive cuppa Toast tea	0		Effect: "Thick-Skinned", Effect Duration: 17, Last Available: "2015-09"
+8607	concentrated boiled blurry olive narrow cuppa Toast tea	0		Effect: "Thick-Skinned", Effect Duration: 17, Last Available: "2015-09"
 8608	unsweetened activated squat cuppa Net tea	0		Effect: "Helvella Health", Effect Duration: 12, Last Available: "2015-09"
 8609	dry polarized upside-down cuppa Proprie tea	0		Effect: "Lobos Fresh", Effect Duration: 16, Last Available: "2015-09"
 8610	vacuum-sealed frozen cuppa Morbidi tea	0		Effect: "Cold Jellied", Effect Duration: 15, Last Available: "2015-09"
 8611	altered polarized adjusted lime green cuppa Chari tea	0		Effect: "No Vertigo", Effect Duration: 31, Last Available: "2015-09"
 8612	altered cuppa Serendipi tea	0		Effect: "In Tuna", Effect Duration: 66, Last Available: "2015-09"
 8613	polymerized dry cuppa Feroci tea	0		Effect: "Disdain of the War Snapper", Effect Duration: 19, Last Available: "2015-09"
-8614	dry wet pulsating spinning cuppa Physicali tea	0		Effect: "Elron's Explosive Etude", Effect Duration: 18, Last Available: "2015-09"
+8614	dry wet spinning pulsating cuppa Physicali tea	0		Effect: "Elron's Explosive Etude", Effect Duration: 18, Last Available: "2015-09"
 8615	extra-tarnished fuchsia cuppa Wit tea	0		Effect: "Frosty the Hitman", Effect Duration: 62, Last Available: "2015-09"
 8616	Vulcanized concentrated cuppa Neuroplastici tea	0		Effect: "All Glory To the Toad", Effect Duration: 45, Last Available: "2015-09"
 8617	unsweetened triple-cold-filtered cuppa Dexteri tea	0		Effect: "Thaumodynamic", Effect Duration: 67, Last Available: "2015-09"
@@ -8499,37 +8499,37 @@
 8626	chilled jittery cuppa Alacri tea	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 55, Last Available: "2015-09"
 8627	pickled cuppa Vitali tea	0		Effect: "Simulation Stimulation", Effect Duration: 26, Last Available: "2015-09"
 8628	ionized colloidal bouncing tumbling cuppa Mana tea	0		Effect: "Orc Chops", Effect Duration: 58, Last Available: "2015-09"
-8629	improved polarized irradiated lime green pulsating cuppa Monstrosi tea	0		Effect: "Influence of Sphere", Effect Duration: 60, Last Available: "2015-09"
+8629	improved polarized irradiated pulsating lime green cuppa Monstrosi tea	0		Effect: "Influence of Sphere", Effect Duration: 60, Last Available: "2015-09"
 8630	liquefied energized dry cuppa Twen tea	0		Effect: "Robocamo", Effect Duration: 67, Last Available: "2015-09"
 8631	moist ionized maroon cuppa Gill tea	0		Effect: "Marinated", Effect Duration: 65, Last Available: "2015-09"
 8632	electrified electrified cuppa Uncertain tea	0		Effect: "Crud&eacute;", Effect Duration: 50, Last Available: "2015-09"
-8633	tumbling bouncing cuppa Voraci tea	0		Last Available: "2015-09"
+8633	bouncing tumbling cuppa Voraci tea	0		Last Available: "2015-09"
 8634	maroon cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
 8636	corrupted cuppa Craft tea	0		Effect: "Loco Motives", Effect Duration: 15, Last Available: "2015-09"
 8637	dry electrified spinning cuppa Insani tea	0		Effect: "Concentrated Concentration", Effect Duration: 52, Last Available: "2015-09"
 8638	fuchsia prompt therapeutic hardy Royal scepter	0		Maximum HP: +50, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-09"
-8639	upside-down twirling doghouse	0		Free Pull, Last Available: "2015-10"
+8639	twirling upside-down doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	normal spinning bowl of eyeballs	3	good	Last Available: "2015-10"
 8642	decent bowl of mummy guts	4	good	Last Available: "2015-10"
-8643	tiny flavorless twirling bowl of maggots	1	decent	Last Available: "2015-10"
+8643	flavorless tiny twirling bowl of maggots	1	decent	Last Available: "2015-10"
 8644	drinkable weak ghostly blood and blood	2	good	Last Available: "2015-10"
 8645	mediocre wobbly Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
-8646	mediocre practically non-alcoholic shaking zombie	1	decent	Last Available: "2015-10"
+8646	practically non-alcoholic mediocre shaking zombie	1	decent	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
 8650	tennis ball	0		Last Available: "2015-10"
 8651	wool dance instructor's strapping crown	0		Muscle: +5, Experience Percent (Moxie): +10, Cold Resistance: +1, Familiar Effect: "atk, 1xGhuol, cap 27"
-8652	twirling fuchsia ear poison	0		
+8652	fuchsia twirling ear poison	0		
 8653	mirror stink-penny	0		
 8654	healthy hawk of Gandalf of the blizzard	0		Maximum HP Percent: +20, Spell Critical Percent: +20, Cold Spell Damage: +25
 8655	stale fuchsia hamlet sandwich	3	decent	
 8656	frightening Othello's military jacket	0		Spooky Damage: +5
 8657	Othello's dagger of the scaredy-cat	0		Monster Level: -15, Single Equip
 8658	shaking lime green steel-toed Othello's handkerchief	0		Damage Reduction: 9, Single Equip
-8659	enhanced tumbling lime green bowl of Jeal-O	0		Effect: "Stogied", Effect Duration: 32
+8659	enhanced lime green tumbling bowl of Jeal-O	0		Effect: "Stogied", Effect Duration: 32
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	ribald sharpshooter's smooth ghostly dagger	0		Moxie: +15, Critical Hit Percent: +10, Sleaze Damage: +10
@@ -8542,18 +8542,18 @@
 8669	jittery tulip	0		
 8670	blinking tulip	0		
 8671	blurry tulip	0		
-8672	shaking gray Walford's bucket	0		Last Available: "2015-11"
+8672	gray shaking Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	skewed one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	denatured blue shoulder-warming lotion	0		Effect: "Mitre Cut", Effect Duration: 28, Last Available: "2015-11"
 8677	half-sized delicious iceberg lettuce	2	awesome	Last Available: "2015-11"
-8678	hand-crafted extra-dry ice wine	5	EPIC	Last Available: "2015-11"
+8678	extra-dry hand-crafted ice wine	5	EPIC	Last Available: "2015-11"
 8679	blurry Socratic Rosewater's sage Wal-Mart snowglobe	0		Mysticality Percent: 40, Experience (Mysticality): +1, Last Available: "2015-11"
 8680	stanky Van der Graaf Wal-Mart nametag of Flo-Jo	0		Stench Spell Damage: +25, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-11"
 8681	olive rock-hard studded Wal-Mart overalls of extreme caution	0		Damage Absorption: +80, Damage Reduction: 5, Monster Level: -25, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
-8683	ghostly tumbling The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
+8683	tumbling ghostly The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	ghostly Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	huge Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	red perfect ice cube	0		Last Available: "2015-11"
@@ -8568,7 +8568,7 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	dried tumbling medicinal herbs	1		Last Available: "2016-01"
 8697	bland ice rice	3	decent	Last Available: "2016-01"
-8698	perfectly mixed high-proof iced plum wine	9	EPIC	Last Available: "2016-01"
+8698	high-proof perfectly mixed iced plum wine	9	EPIC	Last Available: "2016-01"
 8699	huge lion tamer's resourceful cool training belt	0		Moxie: +5, Maximum MP: +50, Experience (familiar): +2, Single Equip, Last Available: "2016-01"
 8700	therapeutic smooth training legwarmers of the boozehound	0		Moxie: +15, Booze Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2016-01"
 8701	shellacked padded brainy training helmet	0		Mysticality: +5, Damage Absorption: +20, Damage Reduction: 7, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
@@ -8582,12 +8582,12 @@
 8709	pickled bouncing abstraction: thought	1		Effect: "Gyromitra Gymnastics", Effect Duration: 5, Last Available: "2015-12"
 8710	diluted abstraction: sensation	1		Last Available: "2015-12"
 8711	dried abstraction: purpose	1		Last Available: "2015-12"
-8712	powdered narrow shaking blinking abstraction: category	1		Last Available: "2015-12"
+8712	powdered shaking narrow blinking abstraction: category	1		Last Available: "2015-12"
 8713	pickled abstraction: perception	1		Last Available: "2015-12"
 8714	dried shaking abstraction: motion	1		Effect: "Coal-Powered", Effect Duration: 5, Last Available: "2015-12"
 8715	vaporized abstraction: joy	1		Last Available: "2015-12"
 8716	denatured abstraction: certainty	1		Last Available: "2015-12"
-8717	pickled ghostly green abstraction: comprehension	1		Last Available: "2015-12"
+8717	pickled green ghostly abstraction: comprehension	1		Last Available: "2015-12"
 8718	shaking modern picture frame	0		Last Available: "2015-12"
 8719	tasty VYKEA meatballs	3	awesome	Last Available: "2015-11"
 8720	triple-distilled delicious VYKEA mead	7	awesome	Last Available: "2015-11"
@@ -8612,7 +8612,7 @@
 8739	drinkable perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	extra-dry perfectly mixed perfect mimosa	5	EPIC	Last Available: "2015-11"
 8741	lousy strong perfect old-fashioned	5	decent	Last Available: "2015-11"
-8742	enchanted boozy bad wobbly perfect paloma	5	decent	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2015-11"
+8742	bad enchanted boozy wobbly perfect paloma	5	decent	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2015-11"
 8743	oxidized That 70s Cologne	0		Effect: "Nas Tea", Effect Duration: 35, Last Available: "2015-11"
 8744	frozen adjusted improved Wal-Mart &quot;diamond&quot; ring	0		Effect: "Ancestral Disapproval", Effect Duration: 21, Last Available: "2015-11"
 8745	polymerized diffused triple-dry Puffstone cigar	0		Effect: "Held Closer", Effect Duration: 16, Last Available: "2015-11"
@@ -8623,8 +8623,8 @@
 8750	dry hemp candy necklace	0		Effect: "Work For Hours a Week", Effect Duration: 65, Last Available: "2015-12"
 8751	adjusted magnetized huge purple communal gobstopper	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 31, Last Available: "2015-12"
 8752	spoiled half-sized Crimbo salad	2	crappy	Last Available: "2015-12"
-8753	delicious miniature bread line	2	awesome	Last Available: "2015-12"
-8754	drinkable ghostly gray bark rootbeer	3	good	Last Available: "2015-12"
+8753	miniature delicious bread line	2	awesome	Last Available: "2015-12"
+8754	drinkable gray ghostly bark rootbeer	3	good	Last Available: "2015-12"
 8755	acceptable ale	3	good	Last Available: "2015-12"
 8756	twirling plastic Tammy the Tambourine Elf of the brute	0		Muscle Percent: +30, Last Available: "2015-12"
 8757	skewed tumbling narrow dog trainer's plastic Rudolph the Red	0		Experience (familiar): +1, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	mirror BACON	0		Last Available: "2016-05"
 8764	green box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	twirling Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	aged practically non-alcoholic upside-down Gratitude chocolate (bourbon-filled)	1	awesome	Last Available: "2016-02"
+8766	practically non-alcoholic aged upside-down Gratitude chocolate (bourbon-filled)	1	awesome	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	shaking Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8657,15 +8657,15 @@
 8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	olive faded protest sign	0		Last Available: "2015-12"
 8787	lime green faded protest sign	0		Last Available: "2015-12"
-8788	blurry maroon nasty-smelling moss	0		Last Available: "2015-12"
+8788	maroon blurry nasty-smelling moss	0		Last Available: "2015-12"
 8789	book	0		Last Available: "2015-12"
 8790	pulsating fireproof elven tambourine	0		Hot Resistance: +3, Last Available: "2015-12"
 8791	shaking avaricious reindeer sickle	0		Meat Drop: +30, Last Available: "2015-12"
 8792	face paint	0		Free Pull, Last Available: "2015-12"
 8793	face paint	0		Free Pull, Last Available: "2015-12"
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
-8795	twirling green Batfellow comic	0		Free Pull, Last Available: "2016-12"
-8796	squat red plastic spoiler	0		
+8795	green twirling Batfellow comic	0		Free Pull, Last Available: "2016-12"
+8796	red squat plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
 8799	blurry bat-o-mite	0		Last Available: "2017-01"
@@ -8690,15 +8690,15 @@
 8818	artisanal Miss Graves' vermouth	3	EPIC	Last Available: "2016-12"
 8819	adequate The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	distilled fuchsia spinning The Author's ink	1		Last Available: "2016-02"
-8821	watered-down artisanal upside-down The Mad Liquor	2	super ultra mega turbo EPIC	Last Available: "2016-12"
+8821	artisanal watered-down upside-down The Mad Liquor	2	super ultra mega turbo EPIC	Last Available: "2016-12"
 8822	aged blinking Doc Clock's thyme cocktail	4	awesome	Last Available: "2016-12"
 8823	normal blinking Mr. Burnsger	3	good	Last Available: "2016-12"
-8824	boiled wobbly narrow tumbling The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	Jeselnik's Sinatra's The Jokester's gun of the businessman	0		Experience (Moxie): +5, Sleaze Damage: +25, Meat Drop: +50, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	mirror flame-retardant Tesla Da Vinci's The Jokester's wig	0		Experience (Mysticality): +5, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	shaking studded fortified The Jokester's pants of Leguizamo	0		Damage Absorption: 140, Monster Level: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8824	boiled tumbling wobbly narrow The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
+8825	Jeselnik's Sinatra's The Jokester's gun of the businessman	0		Experience (Moxie): +5, Sleaze Damage: +25, Meat Drop: +50, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	mirror flame-retardant Tesla Da Vinci's The Jokester's wig	0		Experience (Mysticality): +5, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	shaking studded fortified The Jokester's pants of Leguizamo	0		Damage Absorption: 140, Monster Level: +20, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	denatured flattened Jokester makeup	0		Effect: "Cockroach Scurry", Effect Duration: 54, Last Available: "2016-12"
-8829	teal shaking replica bat-oomerang	0		Last Available: "2016-12"
+8829	shaking teal replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
@@ -8719,7 +8719,7 @@
 8847	super-denatured irradiated red-hot jawbreaker	0		Effect: "Tasting the Rainbow", Effect Duration: 29
 8848	magnetized wobbly question juice	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 48
 8849	pressed tube of villain	0		Effect: "Puddingface", Effect Duration: 35
-8850	Sinatra's your cowboy boots	0		Experience (Moxie): +5, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	Sinatra's your cowboy boots	0		Experience (Moxie): +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	jittery ghostly nugget of thicksilver	0		Last Available: "2016-02"
@@ -8749,15 +8749,15 @@
 8877	normal snack-sized mirror plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
 8878	delicious plate of Mixed Garbanzos and Chickpeas	4	awesome	Last Available: "2016-02"
 8879	bland plate of Hellfire Spicy Beans	4	decent	Last Available: "2016-02"
-8880	enchanted jumbo flavorless plate of Frigid Northern Beans	5	decent	Effect: "Sweet and Green", Effect Duration: 45, Last Available: "2016-02"
+8880	flavorless jumbo enchanted plate of Frigid Northern Beans	5	decent	Effect: "Sweet and Green", Effect Duration: 45, Last Available: "2016-02"
 8881	rotten plate of World's Blackest-Eyed Peas	4	crappy	Last Available: "2016-02"
 8882	half-sized bland plate of Trader Olaf's Exotic Stinkbeans	2	decent	Last Available: "2016-02"
 8883	delicious ghostly plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	awesome	Last Available: "2016-02"
-8884	massive stale plate of Val-U Brand Every Bean Salad	8	decent	Last Available: "2016-02"
+8884	stale massive plate of Val-U Brand Every Bean Salad	8	decent	Last Available: "2016-02"
 8885	stale immense yellow plate of Shrub's Premium Baked Beans	8	decent	Last Available: "2016-02"
 8886	olive scandalous Fancy Jeff's pocket square of extreme caution	0		Monster Level: -25, Sleaze Damage: +5, Last Available: "2016-02"
 8887	avaricious clever hardy Daisy's unclean bloomers	0		Maximum HP: +50, Maximum MP: +20, Meat Drop: +30, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
-8888	lime green tumbling narrow Pecos Dave's sixgun	0		Last Available: "2016-02"
+8888	narrow lime green tumbling Pecos Dave's sixgun	0		Last Available: "2016-02"
 8889	huge mirror Usain Bolt's horrifying wholesome Amoon-Ra Cowtep's nemes	0		Maximum HP Percent: +10, Spooky Damage: +25, Initiative: +80, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	skewed rosewater-soaked greasy Former Sheriff Dan's tin star of the wise owl of vim and vigor of the sweet-tooth	0		Mysticality: +20, Maximum HP Percent: +50, Sleaze Spell Damage: +10, Stench Resistance: +3, Candy Drop: +100, Last Available: "2016-02"
@@ -8805,7 +8805,7 @@
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	cyan baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
-8936	huge tumbling hamethyst-handled sixgun	0		Last Available: "2016-02"
+8936	tumbling huge hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	blurry diamondback skin	0		Last Available: "2016-02"
@@ -8845,7 +8845,7 @@
 8973	dry unusual oil	0		Effect: "Oth-Jeal-O", Effect Duration: 37
 8974	pressed blurry eldritch oil	0		Effect: "Brain Freeze", Effect Duration: 61
 8975	gray exclusive club	0		
-8976	improved teal upside-down patent preventative tonic	0		Effect: "Empty Inside", Effect Duration: 43
+8976	improved upside-down teal patent preventative tonic	0		Effect: "Empty Inside", Effect Duration: 43
 8977	pressed dry quantum patent invisibility tonic	0		Effect: "The Halls of Muscularity", Effect Duration: 18
 8978	flattened patent aggression tonic	0		Effect: "Clyde's Blessing", Effect Duration: 65
 8979	improved extra-Vulcanized quadruple-galvanized bouncing red patent sallowness tonic	0		Effect: "Human-Slime Hybrid", Effect Duration: 59
@@ -8864,7 +8864,7 @@
 8992	compressed fuchsia armored prawn	1		Last Available: "2016-03"
 8993	spoiled jumping horseradish	4	crappy	Last Available: "2016-03"
 8994	acceptable Sacramento wine	3	good	Last Available: "2016-03"
-8995	polymerized Vulcanized pickled gray jittery Greek fire	0		Effect: "Omphalotus Omnipresence", Effect Duration: 69, Last Available: "2016-03"
+8995	polymerized Vulcanized pickled jittery gray Greek fire	0		Effect: "Omphalotus Omnipresence", Effect Duration: 69, Last Available: "2016-03"
 8996	lime green flame-wreathed ruddy steel-toed Rosewater's ox-head shield of the blizzard	0		Mysticality Percent: +30, Damage Reduction: 25, Maximum HP Percent: +40, Cold Spell Damage: +25, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-03"
 8997	stanky lion tamer's supercharged beefcake's dented scepter of bravery	0		Muscle: +25, Maximum MP Percent: +30, Experience (familiar): +2, Stench Spell Damage: +25, Spooky Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 8998	greedy clever supercharged dance instructor's very pointy crown of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Maximum MP Percent: +30, Maximum MP: +20, Meat Drop: +20, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
@@ -8878,7 +8878,7 @@
 9006	purple scorching clever Sinatra's tunac of the early riser	0		Experience (Moxie): +5, Maximum MP: +20, Hot Damage: +25, Adventures: +7, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	diffused adjusted tumbling wriggling worm	0		Effect: "Fungal Fortification", Effect Duration: 18, Last Available: "2016-04"
-9009	practically non-alcoholic mediocre bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
+9009	mediocre practically non-alcoholic bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
 9010	electrified alkaline spinning high-test fishing line	0		Effect: "Wings of the Grasshopper", Effect Duration: 61, Last Available: "2016-04"
 9011	Herculean fishin' hat	0		Experience (Muscle): +1, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8886,7 +8886,7 @@
 9014	mirror luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	wobbly tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
-9017	red huge viral video	0		Last Available: "2016-05"
+9017	huge red viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	gray meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
@@ -8901,13 +8901,13 @@
 9029	no spoon	0		
 9030	moldy star salad	4	crappy	
 9031	Thwaitgold moth statuette	0		
-9032	adequate special tumbling bowl of Tastee-Wheet&trade;	3	good	Effect: "Leisurely Amblin'", Effect Duration: 10
+9032	special adequate tumbling bowl of Tastee-Wheet&trade;	3	good	Effect: "Leisurely Amblin'", Effect Duration: 10
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
-9034	maroon shaking narrow Source essence	0		Last Available: "2016-06"
+9034	narrow maroon shaking Source essence	0		Last Available: "2016-06"
 9035	jumbo toothsome mirror browser cookie	5	awesome	Last Available: "2016-06"
 9036	hand-crafted hacked gibson	3	super EPIC	Last Available: "2016-06"
 9037	Source shades of the scaredy-cat	0		Monster Level: -15, Last Available: "2016-06"
-9038	mirror lime green software bug	0		Last Available: "2016-06"
+9038	lime green mirror software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
@@ -8948,10 +8948,10 @@
 9076	narrow asbestos-lined noir fedora of the brazier of bravery	0		Hot Spell Damage: +25, Hot Resistance: +5, Spooky Resistance: +5, Last Available: "2016-07"
 9077	flame-retardant supercool strapping trench coat	0		Muscle: +5, Moxie Percent: +20, Hot Resistance: +1, Last Available: "2016-07"
 9078	delicious Falcon&trade; Maltese Liquor	4	awesome	Last Available: "2016-07"
-9079	decent enchanted hardboiled egg	3	good	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2016-07"
+9079	enchanted decent hardboiled egg	3	good	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
-9081	wobbly lime green ghostly DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	prompt foul-smelling scorching crafty energetic groovy protonic accelerator pack	0		Moxie Percent: +10, Maximum MP Percent: +20, Maximum MP: +10, Hot Damage: +25, Stench Damage: +10, Adventures: +3, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9081	lime green ghostly wobbly DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
+9082	prompt foul-smelling scorching crafty energetic groovy protonic accelerator pack	0		Moxie Percent: +10, Maximum MP Percent: +20, Maximum MP: +10, Hot Damage: +25, Stench Damage: +10, Adventures: +3, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	spinning ribald Adventurer bobblehead	0		Sleaze Damage: +10, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	skewed tumbling Sherlock's electrified weightlifter's Spookyraven signet	0		Muscle: +15, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-08"
 9093	curative tie-dyed fannypack of the pedagogue	0		Experience: +3, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2016-08"
 9094	Jim Carey's burnt snowpants of the dark arts	0		Spell Damage Percent: +100, Monster Level: +25, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	tumbling standards and practices guide of the cheetah	0		Initiative: +60, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	tumbling standards and practices guide of the cheetah	0		Initiative: +60, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	blinking mirror Oprah's razor-sharp beefy Carpathian longsword	0		Muscle: +10, Weapon Damage Percent: +25, Maximum MP Percent: +50, Last Available: "2016-08"
 9097	healthy rock-hard Socratic Liam's mail	0		Experience (Mysticality): +1, Damage Reduction: 5, Maximum HP Percent: +20, Last Available: "2016-08"
 9098	up-at-dawn flame-retardant supercool Unfortunato's foolscap	0		Moxie Percent: +20, Hot Resistance: +1, Adventures: +5, Last Available: "2016-08"
@@ -8988,11 +8988,11 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	chilly repaid diaper	0		Cold Damage: +5
 9118	pulsating Riker's Search History	0		Last Available: "2016-09"
-9119	fortified perfectly mixed Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
+9119	perfectly mixed fortified Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
 9120	jittery gray wholesome Unstable Pointy Ears	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2016-09"
 9121	green Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
-9123	blinking mirror pulsating School of Hard Knocks Diploma	0		
+9123	mirror pulsating blinking School of Hard Knocks Diploma	0		
 9124	jittery baby bark scorpion	0		
 9125	shaking droppable microphone	0		
 9126	mediocre unidentified drink	3	decent	
@@ -9004,7 +9004,7 @@
 9132	vibrating pistol of Gandalf	0		Maximum MP Percent: +10, Spell Critical Percent: +20
 9133	mirror KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	flavorless leftover pasty	3	decent	
-9135	practically non-alcoholic hand-crafted mirror very whiskey	1	super ultra mega turbo EPIC	
+9135	hand-crafted practically non-alcoholic mirror very whiskey	1	super ultra mega turbo EPIC	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	twirling li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9022,12 +9022,12 @@
 9150	enhanced invisible string	0		Lasts Until Rollover, Effect: "Hustlin'", Effect Duration: 23, Last Available: "2016-10"
 9151	magnetized dry invisible seam ripper	0		Lasts Until Rollover, Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9153	decent small raw sweet potato	2	good	Last Available: "2016-11"
+9153	small decent raw sweet potato	2	good	Last Available: "2016-11"
 9154	delicious raw beans	4	awesome	Last Available: "2016-11"
 9155	jumbo stale raw stuffing	5	decent	Last Available: "2016-11"
-9156	decent small raw cranberry sauce	2	good	Last Available: "2016-11"
+9156	small decent raw cranberry sauce	2	good	Last Available: "2016-11"
 9157	tasty raw turkey	3	awesome	Last Available: "2016-11"
-9158	special miniature flavorless raw mincemeat	2	decent	Effect: "Slightly Mutated", Effect Duration: 15, Last Available: "2016-11"
+9158	flavorless special miniature raw mincemeat	2	decent	Effect: "Slightly Mutated", Effect Duration: 15, Last Available: "2016-11"
 9159	enchanted delicious big teal raw potato	5	awesome	Effect: "Stickler for Promptness", Effect Duration: 20, Last Available: "2016-11"
 9160	normal super-sized raw gravy	5	good	Last Available: "2016-11"
 9161	rotten raw bread	3	crappy	Last Available: "2016-11"
@@ -9041,16 +9041,16 @@
 9169	pulsating gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	spoiled sweet potatoes	3	crappy	Last Available: "2016-11"
-9172	yummy enchanted bean casserole	3	awesome	Effect: "Don't Step to Your Stepmother", Effect Duration: 20, Last Available: "2016-11"
-9173	spoiled jumbo twirling baked stuffing	5	crappy	Last Available: "2016-11"
+9172	enchanted yummy bean casserole	3	awesome	Effect: "Don't Step to Your Stepmother", Effect Duration: 20, Last Available: "2016-11"
+9173	jumbo spoiled twirling baked stuffing	5	crappy	Last Available: "2016-11"
 9174	jumbo stale cranberry cylinder	5	decent	Last Available: "2016-11"
 9175	stale thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	moldy jittery mince pie	4	crappy	Last Available: "2016-11"
-9177	flavorless half-sized mashed potatoes	2	decent	Last Available: "2016-11"
+9177	half-sized flavorless mashed potatoes	2	decent	Last Available: "2016-11"
 9178	rotten half-sized shaking bouncing warm gravy	2	crappy	Last Available: "2016-11"
 9179	bland bread roll	3	decent	Last Available: "2016-11"
-9180	miniature decent blinking blurry leftovers	2	good	Last Available: "2016-11"
-9181	super-sized delicious leftovers sandwich	5	awesome	Last Available: "2016-11"
+9180	decent miniature blurry blinking leftovers	2	good	Last Available: "2016-11"
+9181	delicious super-sized leftovers sandwich	5	awesome	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	bouncing megacopia	0		Last Available: "2016-11"
@@ -9061,7 +9061,7 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	aerosolized bouncing eldritch concentrate	0		Effect: "Powder Power", Effect Duration: 12, Last Available: "2016-11"
-9192	perfectly mixed enchanted eldritch extract	3	EPIC	Effect: "Locks Like the Raven", Effect Duration: 5, Last Available: "2016-11"
+9192	enchanted perfectly mixed eldritch extract	3	EPIC	Effect: "Locks Like the Raven", Effect Duration: 5, Last Available: "2016-11"
 9193	teal ribald sizzling Official Council Aide Pin	0		Hot Damage: +10, Sleaze Damage: +10, Last Available: "2016-11"
 9194	mediocre eldritch distillate	3	decent	Last Available: "2016-11"
 9195	altered eldritch essence	1		Last Available: "2016-11"
@@ -9089,11 +9089,11 @@
 9217	red gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	half-sized decent animal part cracker	2	good	Last Available: "2016-12"
-9220	watered-down drinkable gingerbread wine	2	good	Last Available: "2016-12"
+9220	drinkable watered-down gingerbread wine	2	good	Last Available: "2016-12"
 9221	half-sized bland gingerbread mug	2	decent	Last Available: "2016-12"
 9222	crafty gingerbread mask	0		Maximum MP: +10, Last Available: "2016-12"
 9223	yellow supercharged arcane researcher's gingerservo of Gandalf	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Single Equip, Last Available: "2016-12"
-9224	corrupted ghostly green tainted icing	0		Effect: "The Magic of LOV", Effect Duration: 33, Last Available: "2016-12"
+9224	corrupted green ghostly tainted icing	0		Effect: "The Magic of LOV", Effect Duration: 33, Last Available: "2016-12"
 9225	lime green lard-coated gingerbeard	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2016-12"
 9226	gingerbread smartphone	0		Last Available: "2016-12"
 9227	rock-hard cool gingerbread hoodie	0		Moxie: +5, Damage Reduction: 5, Sprinkle Drop: +15, Last Available: "2016-12"
@@ -9111,7 +9111,7 @@
 9239	smooth ginger beer	4	awesome	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	vacuum-sealed narrow industrial frosting	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 34, Last Available: "2016-12"
-9242	activated skewed yellow fake cocktail	0		Effect: "Pie in the Sky", Effect Duration: 54, Last Available: "2016-12"
+9242	activated yellow skewed fake cocktail	0		Effect: "Pie in the Sky", Effect Duration: 54, Last Available: "2016-12"
 9243	smooth high-end ginger wine	4	awesome	Last Available: "2016-12"
 9244	razor-sharp plastic bad vibe	0		Weapon Damage Percent: +25, Last Available: "2016-12"
 9245	twirling plastic angry vikings of the sweet-tooth	0		Candy Drop: +100, Last Available: "2016-12"
@@ -9129,7 +9129,7 @@
 9257	blinking chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	blurry My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
-9260	huge blinking No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
+9260	blinking huge No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	spinning Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	red gingerbread blackmail photos	0		Last Available: "2016-12"
@@ -9141,14 +9141,14 @@
 9269	skewed chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	twirling chakra sludge	0		
-9272	upside-down ghostly negative lump	0		
+9272	ghostly upside-down negative lump	0		
 9273	huge lightning-fast Third Eye of the wise owl	0		Mysticality: +20, Initiative: +40, Last Available: "2016-12"
 9274	squat mansplainer's Krampus Horn of the scaredy-cat	0		Monster Level: 0, Single Equip, Last Available: "2016-12"
 9275	delicious hambrosier	3	awesome	Last Available: "2016-12"
 9276	drinkable chakra-mental wine	4	good	Last Available: "2016-12"
 9277	irradiated corrupted chakra malt	0		Effect: "OMG WTF", Effect Duration: 16, Last Available: "2016-12"
-9278	adequate small Black Angus blackburger	2	good	Last Available: "2016-12"
-9279	irresponsibly strong drinkable shaking brandy	9	good	Last Available: "2016-12"
+9278	small adequate Black Angus blackburger	2	good	Last Available: "2016-12"
+9279	drinkable irresponsibly strong shaking brandy	9	good	Last Available: "2016-12"
 9280	ionized colloidal gray shaking potion of spiritual gunkifying	0		Effect: "Patent Alacrity", Effect Duration: 57, Last Available: "2016-12"
 9281	upside-down aromatic Fonzie's bad vibroknife	0		Experience (Moxie): +1, Stench Resistance: +1, Last Available: "2016-12"
 9282	blue wool dangerous crystal belt buckle	0		Weapon Damage: +10, Cold Resistance: +1, Last Available: "2016-12"
@@ -9159,29 +9159,29 @@
 9287	skewed pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	gravedigger's mansplainer's hale Uncle Crimbo's hat	0		Maximum HP: +20, Monster Level: +15, Spooky Damage: +10, Last Available: "2016-12"
-9290	big spoiled Eldritch snap	5	crappy	Last Available: "2017-01"
+9290	spoiled big Eldritch snap	5	crappy	Last Available: "2017-01"
 9291	mixed spinning hot jelly	1		Effect: "Deeply Ironic", Effect Duration: 20, Last Available: "2017-01"
 9292	altered jelly	1		Effect: "Pumped Stomach", Effect Duration: 10, Last Available: "2017-01"
 9293	modified jelly	1		Last Available: "2017-01"
 9294	denatured green ghostly sleaze jelly	1		Last Available: "2017-01"
 9295	distilled pulsating stench jelly	1		Effect: "Serendipi Tea", Effect Duration: 35, Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	low-calorie delicious toast with hot jelly	1	awesome	Last Available: "2017-01"
-9298	rotten bite-sized toast with jelly	1	crappy	Last Available: "2017-01"
+9297	delicious low-calorie toast with hot jelly	1	awesome	Last Available: "2017-01"
+9298	bite-sized rotten toast with jelly	1	crappy	Last Available: "2017-01"
 9299	gigantic tasty toast with jelly	10	awesome	Last Available: "2017-01"
-9300	snack-sized bland twirling mirror cyan toast with sleaze jelly	2	decent	Last Available: "2017-01"
+9300	bland snack-sized mirror cyan twirling toast with sleaze jelly	2	decent	Last Available: "2017-01"
 9301	big moldy toast with stench jelly	5	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	jittery hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	red avaricious Rosewater's wax hand	0		Mysticality Percent: +30, Meat Drop: +30, Last Available: "2017-01"
 9306	chaotic studded candle	0		Damage Absorption: +80, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2017-01"
-9307	flavorless small upside-down wax pancake	2	decent	Last Available: "2017-01"
+9307	small flavorless upside-down wax pancake	2	decent	Last Available: "2017-01"
 9308	rosy-cheeked Herculean wax face	0		Experience (Muscle): +1, Maximum HP Percent: +30, Last Available: "2017-01"
 9309	weak drinkable twirling olive wax booze	2	good	Last Available: "2017-01"
 9310	teal glob of melted wax	0		Last Available: "2017-01"
 9311	modified upside-down sea jelly	1		Last Available: "2017-01"
-9312	adequate half-sized sea truffle	2	good	Last Available: "2017-01"
+9312	half-sized adequate sea truffle	2	good	Last Available: "2017-01"
 9313	tumbling tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	smooth recovered cufflinks	0		Moxie: +15, Single Equip, Last Available: "2017-01"
@@ -9195,11 +9195,11 @@
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	diluted skewed squat LOV Echinacea Bouquet	1		Last Available: "2017-02"
+9326	diluted squat skewed LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	Jack Frost's LOV Elephant	0		Cold Spell Damage: +50, Damage Reduction: 6, Last Available: "2017-02"
 9328	eldritch scanner of the scaredy-cat	0		Monster Level: -15, Last Available: "2017-02"
 9329	modified liquefied vacuum-sealed eldritch alignment spray	0		Effect: "Dirty Pear", Effect Duration: 33, Last Available: "2017-02"
-9330	upside-down yellow LOV Entrance Pass	0		Last Available: "2017-02"
+9330	yellow upside-down LOV Entrance Pass	0		Last Available: "2017-02"
 9331	miser's foul-smelling crafty eldritch hammer	0		Maximum MP: +10, Stench Damage: +10, Meat Drop: +10, Last Available: "2017-01"
 9332	stale miniature eldritch mushroom	2	decent	Last Available: "2017-03"
 9333	shaking eldritch ichor	0		
@@ -9210,7 +9210,7 @@
 9338	bouncing HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
-9341	wobbly blinking Platinum HP-35 Calculator	0		
+9341	blinking wobbly Platinum HP-35 Calculator	0		
 9342	green Diamond HP-35 Calculator	0		
 9343	squat bottlecap	0		
 9344	blinking upside-down discarded button	0		
@@ -9238,7 +9238,7 @@
 9366	mediocre double entendre	4	decent	Last Available: "2017-03"
 9367	tolerable special Phlegethon	3	good	Effect: "Eldritch Concentration", Effect Duration: 15, Last Available: "2017-03"
 9368	bad Siberian sunrise	3	decent	Last Available: "2017-03"
-9369	distilled aged mentholated wine	5	awesome	Last Available: "2017-03"
+9369	aged distilled mentholated wine	5	awesome	Last Available: "2017-03"
 9370	lousy fancy low tide martini	3	decent	Effect: "Alpine Mintiness", Effect Duration: 50, Last Available: "2017-03"
 9371	drinkable triple-distilled shroomtini	7	good	Last Available: "2017-03"
 9372	acceptable jittery morning dew	4	good	Last Available: "2017-03"
@@ -9247,28 +9247,28 @@
 9375	aged fortified Gnomish sagngria	5	awesome	Last Available: "2017-03"
 9376	distilled artisanal shaking vodka stinger	5	EPIC	Last Available: "2017-03"
 9377	lousy extremely slippery nipple	4	decent	Last Available: "2017-03"
-9378	hand-crafted special piscatini	4	EPIC	Effect: "Thought", Effect Duration: 15, Last Available: "2017-03"
+9378	special hand-crafted piscatini	4	EPIC	Effect: "Thought", Effect Duration: 15, Last Available: "2017-03"
 9379	mediocre Churchill	3	decent	Last Available: "2017-03"
 9380	smooth spirit-forward soilzerac	5	awesome	Last Available: "2017-03"
 9381	artisanal London frog	3	EPIC	Last Available: "2017-03"
-9382	triple-distilled smooth nothingtini	10	awesome	Last Available: "2017-03"
-9383	enchanted bad eighth plague	3	decent	Effect: "Super-Charged", Effect Duration: 45, Last Available: "2017-03"
+9382	smooth triple-distilled nothingtini	10	awesome	Last Available: "2017-03"
+9383	bad enchanted eighth plague	3	decent	Effect: "Super-Charged", Effect Duration: 45, Last Available: "2017-03"
 9384	tolerable weak single entendre	2	good	Last Available: "2017-03"
 9385	bad reverse Tantalus	4	decent	Last Available: "2017-03"
 9386	acceptable elemental caipiroska	4	good	Last Available: "2017-03"
 9387	bad spinning Feliz Navidad	4	decent	Last Available: "2017-03"
 9388	perfectly mixed fancy Bloody Nora	4	EPIC	Effect: "Punch Another Day", Effect Duration: 15, Last Available: "2017-03"
-9389	mediocre spirit-forward moreltini	5	decent	Last Available: "2017-03"
+9389	spirit-forward mediocre moreltini	5	decent	Last Available: "2017-03"
 9390	acceptable enchanted mirror hell in a bucket	3	good	Effect: "Feroci Tea", Effect Duration: 40, Last Available: "2017-03"
 9391	smooth weak Newark	2	awesome	Last Available: "2017-03"
-9392	tolerable strong shaking R'lyeh	5	good	Last Available: "2017-03"
+9392	strong tolerable shaking R'lyeh	5	good	Last Available: "2017-03"
 9393	hand-crafted extra-dry gray Gnollish sangria	5	EPIC	Last Available: "2017-03"
 9394	drinkable vodka barracuda	3	good	Last Available: "2017-03"
 9395	bad maroon Mysterious Island iced tea	4	decent	Last Available: "2017-03"
-9396	enchanted mediocre ghostly drive-by shooting	3	decent	Effect: "Walberg's Dim Bulb", Effect Duration: 30, Last Available: "2017-03"
+9396	mediocre enchanted ghostly drive-by shooting	3	decent	Effect: "Walberg's Dim Bulb", Effect Duration: 30, Last Available: "2017-03"
 9397	mediocre watered-down gunner's daughter	2	decent	Last Available: "2017-03"
 9398	delicious wobbly dirt julep	4	awesome	Last Available: "2017-03"
-9399	delicious watered-down Simepore slime	2	awesome	Last Available: "2017-03"
+9399	watered-down delicious Simepore slime	2	awesome	Last Available: "2017-03"
 9400	bad Phil Collins	3	decent	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9277,19 +9277,19 @@
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
-9408	mirror shaking gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9408	shaking mirror gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	blue Spacegate Research	0		Last Available: "2017-04"
 9411	alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	snack-sized spoiled enchanted edible alien plant bit	2	crappy	Effect: "Sauce Monocle", Effect Duration: 15, Last Available: "2017-04"
+9415	spoiled snack-sized enchanted edible alien plant bit	2	crappy	Effect: "Sauce Monocle", Effect Duration: 15, Last Available: "2017-04"
 9416	blinking alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	mirror fascinating alien plant sample	0		Last Available: "2017-04"
-9420	dehydrated skewed shaking alien plant goo	1		Effect: "Disdain of the War Snapper", Effect Duration: 20, Last Available: "2017-04"
+9420	dehydrated shaking skewed alien plant goo	1		Effect: "Disdain of the War Snapper", Effect Duration: 20, Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	rotten enchanted alien meat	4	crappy	Effect: "Nightstalkin'", Effect Duration: 45, Last Available: "2017-04"
@@ -9323,9 +9323,9 @@
 9451	irradiated murderbot shield unit	0		Effect: "Pecan Pied Piper", Effect Duration: 46, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	scandalous flame-wreathed murderbot mask of extreme caution	0		Monster Level: -25, Hot Spell Damage: +10, Sleaze Damage: +5, Avatar: "Murderbot", Last Available: "2017-04"
-9454	tarnished mirror narrow murderbot spring injector	0		Effect: "Ironclad", Effect Duration: 43, Last Available: "2017-04"
+9454	tarnished narrow mirror murderbot spring injector	0		Effect: "Ironclad", Effect Duration: 43, Last Available: "2017-04"
 9455	cyan blinking aromatic mansplainer's murderbot whip	0		Monster Level: +15, Stench Resistance: +1, Last Available: "2017-04"
-9456	executive quilted murderbot plasma rifle	0		Damage Absorption: +40, Meat Drop: +40, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	executive quilted murderbot plasma rifle	0		Damage Absorption: +40, Meat Drop: +40, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	wobbly space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9336,8 +9336,8 @@
 9464	blinking Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	bland skewed spinning Aldebaran sardines	3	decent	Last Available: "2017-04"
-9467	lousy watered-down squat Centauri fish wine	2	decent	Last Available: "2017-04"
-9468	dehydrated tumbling olive oxygen	1		Last Available: "2017-04"
+9467	watered-down lousy squat Centauri fish wine	2	decent	Last Available: "2017-04"
+9468	dehydrated olive tumbling oxygen	1		Last Available: "2017-04"
 9469	veiny arcane researcher's Spacegate scientist's insignia	0		Experience Percent (Mysticality): +10, Maximum HP: +10, Single Equip, Last Available: "2017-04"
 9470	Jeselnik's veiny Spacegate military insignia	0		Maximum HP: +10, Sleaze Damage: +25, Single Equip, Last Available: "2017-04"
 9471	Sherlock's razor-sharp experienced Spacegate diplomat's insignia	0		Experience: +2, Weapon Damage Percent: +25, Item Drop: +25, Single Equip, Last Available: "2017-04"
@@ -9362,7 +9362,7 @@
 9490	oxidized narrow Threatening Missive	0		Effect: "Neutered Nostrils", Effect Duration: 45
 9491	Targeted Plague Vector	0		
 9492	fuchsia mirror suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	banded savvy Kremlin's Greatest Briefcase of temperance	0		Mysticality Percent: +20, Damage Absorption: +100, Sleaze Resistance: +5, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	banded savvy Kremlin's Greatest Briefcase of temperance	0		Mysticality Percent: +20, Damage Absorption: +100, Sleaze Resistance: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	irresponsibly strong hand-crafted mirror basic martini	6	EPIC	Last Available: "2017-06"
 9495	perfectly mixed improved martini	4	EPIC	Last Available: "2017-06"
 9496	smooth high-proof splendid martini	7	awesome	Last Available: "2017-06"
@@ -9383,7 +9383,7 @@
 9511	wobbly Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	mirror mirror Meteorite-Ade	0		Last Available: "2017-08"
-9514	miniature rotten wobbly meteoreo	2	crappy	Last Available: "2017-08"
+9514	rotten miniature wobbly meteoreo	2	crappy	Last Available: "2017-08"
 9515	bad twirling meadeorite	3	decent	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	olive manspreader's rock-hard grievous meteortarboard	0		Weapon Damage Percent: +50, Damage Reduction: 5, Monster Level: +10, Last Available: "2017-08"
@@ -9403,7 +9403,7 @@
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	mirror pony: Shutterfly	0		Last Available: "2017-09"
 9533	mirror pony: Pearjack	0		Last Available: "2017-09"
-9534	cyan mirror pony: Uniquity	0		Last Available: "2017-09"
+9534	mirror cyan pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
 9536	tumbling pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
@@ -9430,7 +9430,7 @@
 9558	amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
 9560	O	0		Last Available: "2017-11"
-9561	wobbly huge amorphous blob	0		Last Available: "2017-11"
+9561	huge wobbly amorphous blob	0		Last Available: "2017-11"
 9562	stiffened savvy brainy protection stick of courage	0		Mysticality: +5, Mysticality Percent: +20, Damage Reduction: 1, Spooky Resistance: +3
 9563	anodized tarnished pressed roll of meat	0		Effect: "Magically Delicious", Effect Duration: 45
 9564	Rosewater's mafia thumb ring of the sweet-tooth	0		Mysticality Percent: +30, Candy Drop: +100, Single Equip
@@ -9451,7 +9451,7 @@
 9579	normal jittery unfinished fruitcake	4	good	Last Available: "2017-12"
 9580	cold-filtered energized flattened and cracker	0		Effect: "Earthen Fist", Effect Duration: 50, Last Available: "2017-12"
 9581	spirit-forward hand-crafted squat cyan neg grog	5	EPIC	Last Available: "2017-12"
-9582	normal tiny half double fruitcake	1	good	Last Available: "2017-12"
+9582	tiny normal half double fruitcake	1	good	Last Available: "2017-12"
 9583	flavorless low-calorie skewed hushed puppy	1	decent	Last Available: "2017-12"
 9584	bland diet blinking muffled muffuletta	1	decent	Last Available: "2017-12"
 9585	stale shushed potatoes	4	decent	Last Available: "2017-12"
@@ -9486,7 +9486,7 @@
 9614	silent P	0		Last Available: "2017-12"
 9615	twirling silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
-9617	skewed blue squat silent S	0		Last Available: "2017-12"
+9617	blue skewed squat silent S	0		Last Available: "2017-12"
 9618	lime green twirling silent T	0		Last Available: "2017-12"
 9619	teal silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
@@ -9497,8 +9497,8 @@
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	yellow anti-earplugs	0		Last Available: "2017-12"
 9627	upside-down warehouse key	0		Last Available: "2017-12"
-9628	wobbly jittery mime pocket probe	0		Last Available: "2017-12"
-9629	lousy fancy stale cheer wine	3	decent	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2017-12"
+9628	jittery wobbly mime pocket probe	0		Last Available: "2017-12"
+9629	fancy lousy stale cheer wine	3	decent	Effect: "Mental A-cue-ity", Effect Duration: 10, Last Available: "2017-12"
 9630	adequate stale Cheer-E-Os	3	good	Last Available: "2017-12"
 9631	squat cheer-o-gram	0		Last Available: "2017-12"
 9632	manspreader's cheerful antler hat of the bloodbag	0		Maximum HP: +100, Monster Level: +10, Last Available: "2017-12"
@@ -9521,8 +9521,8 @@
 9649	half-sized bland nega-mushroom	2	decent	Last Available: "2017-12"
 9650	irresponsibly strong lousy nega-mushroom wine	7	decent	Last Available: "2017-12"
 9651	denatured spinning Cheer-Up soda	0		Effect: "Mint-Condition Breath", Effect Duration: 31, Last Available: "2017-12"
-9652	decent low-calorie mime army rations	1	good	Last Available: "2017-12"
-9653	mediocre high-proof green mime army wine	10	decent	Last Available: "2017-12"
+9652	low-calorie decent mime army rations	1	good	Last Available: "2017-12"
+9653	high-proof mediocre green mime army wine	10	decent	Last Available: "2017-12"
 9654	dehydrated squat mime army superserum	1		Effect: "Memories of Puppy Love", Effect Duration: 45, Last Available: "2017-12"
 9655	nitrogenated upside-down mime army camouflage kit	0		Effect: "Got Your Boots On", Effect Duration: 65, Last Available: "2017-12"
 9656	wicked miming beret of terror	0		Spell Damage: +5, Spooky Spell Damage: +10, Last Available: "2017-12"
@@ -9534,7 +9534,7 @@
 9662	upside-down ghostly donated booze	0		
 9663	donated food	0		
 9664	donated candy	0		
-9665	cold-filtered ionized gray blinking digital honeypot	0		Effect: "Aided and Abetted", Effect Duration: 56, Last Available: "2025-12"
+9665	cold-filtered ionized blinking gray digital honeypot	0		Effect: "Aided and Abetted", Effect Duration: 56, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
 9667	twirling mime army insignia (infantry) of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
 9668	mime army insignia (intelligence) of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
@@ -9545,7 +9545,7 @@
 9673	spinning mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	gray wholesome brawny mime army infiltration glove	0		Muscle Percent: +20, Maximum HP Percent: +10, Single Equip, Last Available: "2017-12"
-9676	upside-down pulsating mime army shotglass	0		Last Available: "2017-12"
+9676	pulsating upside-down mime army shotglass	0		Last Available: "2017-12"
 9677	mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
@@ -9594,8 +9594,8 @@
 9726	prompt auspicious psychic's amulet	0		Item Drop: +10, Adventures: +3, Last Available: "2018-02"
 9727	rotten upside-down heart-shaped candy whetstone	4	crappy	Last Available: "2018-02"
 9728	tiny normal Swedish massage fish	1	good	Last Available: "2018-02"
-9729	lousy practically non-alcoholic teal upside-down Third Base	1	decent	Last Available: "2018-02"
-9730	watered-down mediocre Bustle Hustler	2	decent	Last Available: "2018-02"
+9729	practically non-alcoholic lousy upside-down teal Third Base	1	decent	Last Available: "2018-02"
+9730	mediocre watered-down Bustle Hustler	2	decent	Last Available: "2018-02"
 9731	galvanized enhanced pulsating Fabiotion	0		Effect: "Covetous Robbery", Effect Duration: 29, Last Available: "2018-02"
 9732	polymerized tumbling Bettie page	0		Effect: "Litterboxing", Effect Duration: 48, Last Available: "2018-02"
 9733	diffused skewed bouncing tonic o' Banderas	0		Effect: "Orchid Blood", Effect Duration: 64, Last Available: "2018-02"
@@ -9606,7 +9606,7 @@
 9738	personal graffiti kit	0		Last Available: "2018-02"
 9739	jittery Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
-9741	squat yellow Mysterious Blue Box	0		Last Available: "2018-02"
+9741	yellow squat Mysterious Blue Box	0		Last Available: "2018-02"
 9742	Mysterious Black Box	0		Last Available: "2018-02"
 9743	cold-filtered ionized blinking rainbow jellybean	0		Effect: "Whole Latte Love", Effect Duration: 58
 9744	tarnished quantum mirror mystery lollipop	0		Effect: "Extra Backbone", Effect Duration: 14
@@ -9697,7 +9697,7 @@
 9829	distilled shaking brilliant oyster egg	1		Effect: "Pisces in the Skyces", Effect Duration: 20
 9830	mixed glistening oyster egg	1		Effect: "Mad at Science", Effect Duration: 5
 9831	pickled blue scintillating oyster egg	1		Effect: "Ancient Protected", Effect Duration: 30
-9832	boiled shaking maroon pearlescent oyster egg	1		
+9832	boiled maroon shaking pearlescent oyster egg	1		
 9833	modified blinking green blinking lustrous oyster egg	1		
 9834	dried wobbly gleaming oyster egg	1		Effect: "Berry Berry Cold", Effect Duration: 25
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
@@ -9721,7 +9721,7 @@
 9853	gray narrow poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	ghostly spinning to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	cyan skewed flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9856	skewed cyan flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	deionized tarnished universal antivenin	0		Lasts Until Rollover, Effect: "Updated", Effect Duration: 53, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
@@ -9735,7 +9735,7 @@
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	blurry grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	moldy druidic s'more	3	crappy	Last Available: "2018-04"
-9870	powdered narrow spinning sachet of powder	1		Effect: "Mushroom Magicalness", Effect Duration: 35, Last Available: "2018-04"
+9870	powdered spinning narrow sachet of powder	1		Effect: "Mushroom Magicalness", Effect Duration: 35, Last Available: "2018-04"
 9871	perfectly mixed mourning wine	3	EPIC	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9765,7 +9765,7 @@
 9897	squat notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	perfectly mixed two meat muck	4	EPIC	
 9899	gigantic adequate chocolate Ogre Chieftain	9	good	
-9900	bite-sized adequate chocolate &quot;Phoenix&quot;	1	good	
+9900	adequate bite-sized chocolate &quot;Phoenix&quot;	1	good	
 9901	tasty chocolate Spider Queen	3	awesome	
 9902	watered-down tolerable hipster cocktail	2	good	
 9903	shaking God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
@@ -9813,7 +9813,7 @@
 9945	lime green squat Neverending Party favor	0		Last Available: "2018-09"
 9946	blinking jittery deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	jittery gas can	0		Last Available: "2018-09"
-9948	irresponsibly strong bad Middle of the Road&trade; brand whiskey	6	decent	Last Available: "2018-09"
+9948	bad irresponsibly strong Middle of the Road&trade; brand whiskey	6	decent	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	pentagram bandana of the brute of the detective	0		Muscle Percent: +30, Item Drop: +20, Last Available: "2018-09"
 9951	quilted skull ring	0		Damage Absorption: +40, Single Equip, Last Available: "2018-09"
@@ -9821,13 +9821,13 @@
 9953	decent skewed PB&J with the crusts cut off	4	good	Last Available: "2018-09"
 9954	purple lard-coated stiffened dorky glasses	0		Damage Reduction: 1, Sleaze Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9955	blurry up-at-dawn groovy ponytail clip	0		Moxie Percent: +10, Adventures: +5, Last Available: "2018-09"
-9956	shaking yellow auspicious paint palette	0		Item Drop: +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	shaking yellow auspicious paint palette	0		Item Drop: +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	dried upside-down Purple Beast energy drink	1		Effect: "Deadly Lampblade", Effect Duration: 40, Last Available: "2018-09"
 9959	hardy cosmetic football	0		Maximum HP: +50, Last Available: "2018-09"
 9960	frosty curative shoe ad T-shirt	0		Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-09"
 9961	pump-up high-tops of the early riser	0		Adventures: +7, Single Equip, Last Available: "2018-09"
-9962	dry red ghostly blurry runproof mascara	0		Effect: "Superheroic", Effect Duration: 20, Last Available: "2018-09"
+9962	dry ghostly red blurry runproof mascara	0		Effect: "Superheroic", Effect Duration: 20, Last Available: "2018-09"
 9963	very small dress	0		Last Available: "2018-09"
 9964	gray noticeable pumps of the empath of courage	0		Familiar Weight: +5, Spooky Resistance: +3, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9844,14 +9844,14 @@
 9977	lime green wobbly hale party whip of James Dean of terror	0		Experience (Moxie): +3, Maximum HP: +20, Spooky Spell Damage: +10, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	lousy fuchsia TRIO cup of beer	4	decent	Last Available: "2018-09"
-9980	stale super-sized party platter for one	5	decent	Last Available: "2018-09"
+9980	super-sized stale party platter for one	5	decent	Last Available: "2018-09"
 9981	diluted narrow Party-in-a-Can&trade;	1		Effect: "Night Vision", Effect Duration: 50, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	twirling lightning-fast party crasher of the glutton	0		Food Drop: +100, Initiative: +40, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	twirling lightning-fast party crasher of the glutton	0		Food Drop: +100, Initiative: +40, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	pulsating latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	pulsating latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	maroon voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	wizardly &quot;I Voted!&quot; sticker	0		Mysticality: +25, Lasts Until Rollover, Last Available: "2018-11"
@@ -9877,14 +9877,14 @@
 10011	snack-sized rotten	2	crappy	Last Available: "2018-11"
 10012	delicious bottle of vodka	3	awesome	Last Available: "2018-11"
 10013	diet stale tumbling pizza	1	decent	Last Available: "2018-11"
-10014	acceptable weak yellow jittery martini	2	good	Last Available: "2018-11"
+10014	acceptable weak jittery yellow martini	2	good	Last Available: "2018-11"
 10015	jumbo bland blinking cherry pie	5	decent	Last Available: "2018-11"
 10016	perfectly mixed watered-down eggnog	2	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	flavorless small Hell ramen	2	decent	Last Available: "2018-11"
+10018	small flavorless Hell ramen	2	decent	Last Available: "2018-11"
 10019	weak acceptable lime green gimlet	2	good	Last Available: "2018-11"
 10020	artisanal twice-haunted screwdriver	3	EPIC	Last Available: "2018-11"
-10021	bland immense special upside-down candy cane	8	decent	Effect: "Libra Rising", Effect Duration: 25, Last Available: "2018-12"
+10021	bland special immense upside-down candy cane	8	decent	Effect: "Libra Rising", Effect Duration: 25, Last Available: "2018-12"
 10022	special drinkable runny fermented egg	4	good	Effect: "Seriously Mutated", Effect Duration: 30, Last Available: "2018-12"
 10023	moldy oldcake	3	crappy	Last Available: "2018-12"
 10024	diet normal traditional Crimbo cookie	1	good	Last Available: "2023-06"
@@ -9895,7 +9895,7 @@
 10029	therapeutic plastic Abuela Crimbo	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
 10031	blurry Braindeer	0		Last Available: "2018-12"
-10032	yellow blinking Crimbo dog sweater	0		Familiar Weight: +5
+10032	blinking yellow Crimbo dog sweater	0		Familiar Weight: +5
 10033	blurry sharpshooter's pristine walrus tusk of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +10, Last Available: "2018-12"
 10034	squat thick walrus blubber	0		Last Available: "2018-12"
 10035	mirror reassuring Jim Carey's brainy Staff of Frozen Lard of the bloodbag	0		Mysticality: +5, Maximum HP: +100, Monster Level: +25, Spooky Resistance: +1, Last Available: "2018-12"
@@ -9903,13 +9903,13 @@
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	normal pulsating grilled mooseflank	4	good	Last Available: "2018-12"
-10040	half-sized rotten moosemeat pie	2	crappy	Last Available: "2018-12"
+10040	rotten half-sized moosemeat pie	2	crappy	Last Available: "2018-12"
 10041	twirling Jim Carey's balanced antler	0		Monster Level: +25, Last Available: "2018-12"
 10042	forbidden dam	0		Spell Damage Percent: +50, Damage Reduction: 9, Last Available: "2018-12"
 10043	perfectly mixed cyan beavermouth	3	EPIC	Last Available: "2018-12"
 10044	bad beaver punch (papaya)	3	decent	Last Available: "2018-12"
 10045	lousy beaver punch (peach)	3	decent	Last Available: "2018-12"
-10046	practically non-alcoholic smooth beaver punch (cherry)	1	awesome	Last Available: "2018-12"
+10046	smooth practically non-alcoholic beaver punch (cherry)	1	awesome	Last Available: "2018-12"
 10047	cyan family-friendly Jack Frost's Canadian lantern	0		Cold Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2018-12"
 10048	mirror dance instructor's muskox-skin cap	0		Experience Percent (Moxie): +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9961,21 +9961,21 @@
 10095	lion tamer's arcane researcher's marble mariachi hat	0		Experience Percent (Mysticality): +10, Experience (familiar): +2, Last Available: "2019-12"
 10096	compressed fuchsia marble molecules	1		Last Available: "2019-12"
 10097	galvanized double-altered electrified Mallomarbles	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 33
-10098	curative punching bag of the businessman	0		Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	scorching pith helmet of the wise owl	0		Mysticality: +20, Hot Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	olive Jeselnik's stanky poncho	0		Stench Spell Damage: +25, Sleaze Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	skewed bouncing Fonzie's pendant of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	bouncing jittery hardy palazzos of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	mirror perfumed curative pseudoaccordion	0		Stench Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	curative punching bag of the businessman	0		Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	scorching pith helmet of the wise owl	0		Mysticality: +20, Hot Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	olive Jeselnik's stanky poncho	0		Stench Spell Damage: +25, Sleaze Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	skewed bouncing Fonzie's pendant of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	bouncing jittery hardy palazzos of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	mirror perfumed curative pseudoaccordion	0		Stench Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	altered wobbly pieces	1		Effect: "Mystically Oiled", Effect Duration: 50, Last Available: "2020-12"
 10105	polarized extra-improved twirling Para-Pop	0		Effect: "Flagrantly Fragrant", Effect Duration: 14
-10106	skewed clever therapeutic terra cotta truss	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	stanky Oprah's terra cotta trousers	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	family-friendly terra cotta tongs	0		Sleaze Resistance: +1, Item Drop: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	cyan toasty energetic terra cotta train	0		Maximum MP Percent: +20, Hot Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	squat knitted Temple Grandin's terra cotta tie tack	0		Familiar Weight: +7, Cold Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	spinning Rosewater's terra cotta tambourine of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10112	boiled wobbly jittery terra cotta tidbits	1		Last Available: "2020-12"
+10106	skewed clever therapeutic terra cotta truss	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	stanky Oprah's terra cotta trousers	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	family-friendly terra cotta tongs	0		Sleaze Resistance: +1, Item Drop: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	cyan toasty energetic terra cotta train	0		Maximum MP Percent: +20, Hot Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	squat knitted Temple Grandin's terra cotta tie tack	0		Familiar Weight: +7, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	spinning Rosewater's terra cotta tambourine of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10112	boiled jittery wobbly terra cotta tidbits	1		Last Available: "2020-12"
 10113	extra-activated liquefied terra panna cotta	0		Effect: "You Know Where to Go", Effect Duration: 30
 10114	horrifying shellacked velour voulge	0		Damage Reduction: 7, Spooky Damage: +25, Last Available: "2021-12"
 10115	medical-grade Rosewater's velour vambraces	0		Mysticality Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2021-12"
@@ -9983,7 +9983,7 @@
 10117	energetic velour viscometer of the empath	0		Maximum MP Percent: +20, Familiar Weight: +5, Single Equip, Last Available: "2021-12"
 10118	miser's velour valise of Leguizamo	0		Monster Level: +20, Meat Drop: +10, Last Available: "2021-12"
 10119	scandalous velour vaqueros of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Last Available: "2021-12"
-10120	compressed blue blurry bouncing velour veneer	1		Last Available: "2021-12"
+10120	compressed bouncing blue blurry velour veneer	1		Last Available: "2021-12"
 10121	improved dry Velougats&trade;	0		Effect: "Abyssal Tears", Effect Duration: 32
 10122	executive smartaleck's glass suspenders	0		Moxie Percent: +30, Meat Drop: +40, Single Equip, Last Available: "2021-12"
 10123	zippy glass shield of wisdom	0		Mysticality: +15, Initiative: +20, Damage Reduction: 7, Last Available: "2021-12"
@@ -9993,21 +9993,21 @@
 10127	green occult glass serape of wisdom	0		Mysticality: +15, Spell Damage Percent: +25, Last Available: "2021-12"
 10128	compressed spinning maroon glass shards	1		Last Available: "2021-12"
 10129	boiled twirling hard candy	0		Effect: "Deeply Ironic", Effect Duration: 28
-10130	blinking scandalous lion tamer's loofah lumberjack's hat	0		Experience (familiar): +2, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	quilted dance instructor's loofah lei	0		Experience Percent (Moxie): +10, Damage Absorption: +40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	blue reassuring stanky loofah lederhosen	0		Stench Spell Damage: +25, Spooky Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	greasy Newton's loofah ladle	0		Experience (Mysticality): +3, Sleaze Spell Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	blinking ribald occult loofah legwarmers	0		Spell Damage Percent: +25, Sleaze Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	purple curative loofah lavalier of mayonnaise	0		Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	distilled jittery shaking blue loofah lumps	1		Last Available: "2022-12"
+10130	blinking scandalous lion tamer's loofah lumberjack's hat	0		Experience (familiar): +2, Sleaze Damage: +5, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	quilted dance instructor's loofah lei	0		Experience Percent (Moxie): +10, Damage Absorption: +40, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	blue reassuring stanky loofah lederhosen	0		Stench Spell Damage: +25, Spooky Resistance: +1, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	greasy Newton's loofah ladle	0		Experience (Mysticality): +3, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	blinking ribald occult loofah legwarmers	0		Spell Damage Percent: +25, Sleaze Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	purple curative loofah lavalier of mayonnaise	0		Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10136	distilled shaking blue jittery loofah lumps	1		Last Available: "2022-12"
 10137	extra-colloidal vacuum-sealed unsweetened chocolate-covered loofah	0		Effect: "The Power of Negative Thinking", Effect Duration: 67
-10138	Jeselnik's Lo Pan's flagstone flag	0		Spell Critical Percent: +30, Sleaze Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	gravedigger's hardy flagstone flail	0		Maximum HP: +50, Spooky Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	veiny fortified flagstone flip-flops	0		Damage Absorption: +60, Maximum HP: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	zippy wholesome flagstone fez	0		Maximum HP Percent: +10, Initiative: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	bouncing scandalous padded flagstone fleece	0		Damage Absorption: +20, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	steel-toed flagstone fringe of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	denatured olive ghostly flagstone flagments	1		Last Available: "2022-12"
+10138	Jeselnik's Lo Pan's flagstone flag	0		Spell Critical Percent: +30, Sleaze Damage: +25, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	gravedigger's hardy flagstone flail	0		Maximum HP: +50, Spooky Damage: +10, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	veiny fortified flagstone flip-flops	0		Damage Absorption: +60, Maximum HP: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	zippy wholesome flagstone fez	0		Maximum HP Percent: +10, Initiative: +20, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	bouncing scandalous padded flagstone fleece	0		Damage Absorption: +20, Sleaze Damage: +5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	steel-toed flagstone fringe of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10144	denatured ghostly olive flagstone flagments	1		Last Available: "2022-12"
 10145	dry concentrated lime green Flag by the Foot&trade;	0		Effect: "Rampage!", Effect Duration: 36
 10146	wobbly blurry elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	squat red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,7 +10018,7 @@
 10152	olive sew-on bandage	0		Last Available: "2019-12"
 10153	wobbly really nice net	0		Last Available: "2019-12"
 10154	pulsating elf army poncho of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Last Available: "2019-12"
-10155	fancy toothsome half-sized elf army field rations	2	awesome	Effect: "Broberry Brotality", Effect Duration: 5, Last Available: "2019-12"
+10155	toothsome half-sized fancy elf army field rations	2	awesome	Effect: "Broberry Brotality", Effect Duration: 5, Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	ghostly smelly weightlifter's discarded bowtie	0		Muscle: +15, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
 10158	lousy watered-down martiny	2	decent	Last Available: "2019-12"
@@ -10029,14 +10029,14 @@
 10163	aerosolized government-issued candy	0		Effect: "Super Vision", Effect Duration: 40
 10164	nitrogenated pressed maroon Pneumo bar	0		Effect: "Joy", Effect Duration: 29
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	vibrating padded Lil' Doctor&trade; bag	0		Damage Absorption: +20, Maximum MP Percent: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	vibrating padded Lil' Doctor&trade; bag	0		Damage Absorption: +20, Maximum MP Percent: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	upside-down blood bag	0		
-10169	adequate miniature bloodstick	2	good	
+10169	miniature adequate bloodstick	2	good	
 10170	aged bottle of Sanguiovese	3	awesome	
 10171	moldy actual blood sausage	3	crappy	
-10172	weak tolerable mulled blood	2	good	
+10172	tolerable weak mulled blood	2	good	
 10173	spoiled bite-sized blood snowcone	1	crappy	
-10174	lousy triple-distilled fancy mirror Red Russian	9	decent	Effect: "Hypercubed", Effect Duration: 30
+10174	triple-distilled fancy lousy mirror Red Russian	9	decent	Effect: "Hypercubed", Effect Duration: 30
 10175	flavorless wobbly blood roll-up	4	decent	
 10176	drinkable bottle of blood	3	good	
 10177	half-sized normal blood-soaked sponge cake	2	good	
@@ -10061,10 +10061,10 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	upside-down Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	normal big shaking crabsicle	5	good	Last Available: "2019-04"
+10199	big normal shaking crabsicle	5	good	Last Available: "2019-04"
 10200	tumbling melty plastic grenade	0		Last Available: "2019-04"
 10201	high-proof drinkable bottle of dark rhum	9	good	Last Available: "2019-04"
-10202	bad fancy spirit-forward bottle of extra-dark rhum	5	decent	Effect: "Paging Betty", Effect Duration: 20, Last Available: "2019-04"
+10202	spirit-forward fancy bad bottle of extra-dark rhum	5	decent	Effect: "Paging Betty", Effect Duration: 20, Last Available: "2019-04"
 10203	practically non-alcoholic hand-crafted blurry bottle of super-extra-dark rhum	1	EPIC	Last Available: "2019-04"
 10204	flattened colloidal narrow pirate shaving cream	0		Effect: "What's That Smell?", Effect Duration: 60, Last Available: "2019-04"
 10205	narrow fireproof hardened conquistador's breastplate	0		Damage Reduction: 3, Hot Resistance: +3, Last Available: "2019-04"
@@ -10074,11 +10074,11 @@
 10209	windicle	0		Last Available: "2019-04"
 10210	frightening pirate radio ring of the wise owl	0		Mysticality: +20, Spooky Damage: +5, Single Equip, Last Available: "2019-04"
 10211	olive Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	half-sized delicious pineapple slab	2	awesome	Last Available: "2019-04"
+10212	delicious half-sized pineapple slab	2	awesome	Last Available: "2019-04"
 10213	decent hibiscus petal	4	good	Last Available: "2019-04"
 10214	galvanized huge mint leaf	0		Effect: "You Drank Fish Wine", Effect Duration: 54, Last Available: "2019-04"
 10215	narrow cocoa of youth	0		Last Available: "2019-04"
-10216	powdered pulsating tumbling ice molecule	1		Last Available: "2019-04"
+10216	powdered tumbling pulsating ice molecule	1		Last Available: "2019-04"
 10217	ghostly red Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
@@ -10095,16 +10095,16 @@
 10230	piratical blunderbuss of the wise owl of terror	0		Mysticality: +20, Spooky Spell Damage: +10, Last Available: "2019-04"
 10231	scorching therapeutic PirateRealm party hat of Tarzan	0		Experience (Muscle): +3, Hot Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-04"
 10232	lousy Island Landslide	3	decent	Last Available: "2019-04"
-10233	weak drinkable Island Thunderstorm	2	good	Last Available: "2019-04"
+10233	drinkable weak Island Thunderstorm	2	good	Last Available: "2019-04"
 10234	perfectly mixed maroon Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	artisanal red Skull Punch	4	EPIC	Last Available: "2019-04"
-10236	bad weak Electric Punch	2	decent	Last Available: "2019-04"
+10236	weak bad Electric Punch	2	decent	Last Available: "2019-04"
 10237	aged pulsating Smuggler's Punch	4	awesome	Last Available: "2019-04"
 10238	tolerable wobbly Scorpion Bowl	4	good	Last Available: "2019-04"
-10239	triple-distilled mediocre Turtle Bowl	9	decent	Last Available: "2019-04"
-10240	perfectly mixed triple-distilled Cobra Bowl	8	EPIC	Last Available: "2019-04"
-10241	yellow ghostly vampyric cloake pattern	0		Free Pull
-10242	inspector's Jeselnik's chaotic resourceful vampyric cloake of courage	0		Maximum MP: +50, Spell Critical Percent: +10, Sleaze Damage: +25, Spooky Resistance: +3, Item Drop: +15, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10239	mediocre triple-distilled Turtle Bowl	9	decent	Last Available: "2019-04"
+10240	triple-distilled perfectly mixed Cobra Bowl	8	EPIC	Last Available: "2019-04"
+10241	ghostly yellow vampyric cloake pattern	0		Free Pull
+10242	inspector's Jeselnik's chaotic resourceful vampyric cloake of courage	0		Maximum MP: +50, Spell Critical Percent: +10, Sleaze Damage: +25, Spooky Resistance: +3, Item Drop: +15, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	narrow plastic pirate hat	0		Familiar Weight: +5
 10244	tarnished pickled ionized narrow one piece of bubble gum	0		Effect: "Flambé-a-thon", Effect Duration: 44
 10245	teal arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	blinking lion tamer's stiffened Fourth of May Cosplay Saber of the ox	0		Muscle: +20, Damage Reduction: 1, Experience (familiar): +2, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	blinking lion tamer's stiffened Fourth of May Cosplay Saber of the ox	0		Muscle: +20, Damage Reduction: 1, Experience (familiar): +2, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	up-at-dawn foul-smelling manspreader's Lo Pan's Annie Oakley's therapeutic shellacked dance instructor's Fonzie's experienced brainy hewn moon-rune spoon	0		Mysticality: +5, Experience: +2, Experience (Moxie): +1, Experience Percent (Moxie): +10, Damage Reduction: 7, Critical Hit Percent: +20, Spell Critical Percent: +30, Monster Level: +10, Stench Damage: +10, Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	up-at-dawn foul-smelling manspreader's Lo Pan's Annie Oakley's therapeutic shellacked dance instructor's Fonzie's experienced brainy hewn moon-rune spoon	0		Mysticality: +5, Experience: +2, Experience (Moxie): +1, Experience Percent (Moxie): +10, Damage Reduction: 7, Critical Hit Percent: +20, Spell Critical Percent: +30, Monster Level: +10, Stench Damage: +10, Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	shaking Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	lion tamer's savvy Beach Comb of the scaredy-cat	0		Mysticality Percent: +20, Monster Level: -15, Experience (familiar): +2, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	lion tamer's savvy Beach Comb of the scaredy-cat	0		Mysticality Percent: +20, Monster Level: -15, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	teal tumbling grain of sand	0		Last Available: "2019-07"
 10260	wobbly small pile of sand	0		Last Available: "2019-07"
 10261	olive pile of sand	0		Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	oxidized non-denatured concentrated seashell	0		Effect: "Tasting the Rainbow", Effect Duration: 41, Last Available: "2019-07"
 10270	energized unsweetened seashell	0		Effect: "Preternatural Greed", Effect Duration: 34, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	lousy fortified bottle of sea wine	5	decent	Last Available: "2019-07"
+10272	fortified lousy bottle of sea wine	5	decent	Last Available: "2019-07"
 10273	distilled kelp	1		Last Available: "2019-07"
 10274	wobbly chilly Tesla clever hardy ruddy wholesome rock-hard weightlifter's driftwood hat of terror	0		Muscle: +15, Damage Reduction: 5, Maximum HP Percent: 50, Maximum HP: +50, Maximum MP: +20, Cold Damage: +5, Spooky Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10275	blurry miser's reassuring foul-smelling scorching nippy curative shellacked sage driftwood pants of the detective	0		Mysticality Percent: +10, Damage Reduction: 7, Cold Damage: +10, Hot Damage: +25, Stench Damage: +10, Spooky Resistance: +1, Item Drop: +20, Meat Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-07"
@@ -10151,7 +10151,7 @@
 10286	blurry up-at-dawn nasty meteorite earring of the blizzard	0		Cold Spell Damage: +25, Stench Damage: +5, Adventures: +5, Single Equip, Last Available: "2019-07"
 10287	sage wizardly meteorite necklace	0		Mysticality: +25, Mysticality Percent: +10, Item Drop: +5, Single Equip, Last Available: "2019-07"
 10288	blurry purple avaricious gravedigger's rock-hard meteorite ring	0		Damage Reduction: 5, Spooky Damage: +10, Meat Drop: +30, Single Equip, Last Available: "2019-07"
-10289	liquefied yellow wobbly Finnish Fish	0		Effect: "Bloody-minded", Effect Duration: 22
+10289	liquefied wobbly yellow Finnish Fish	0		Effect: "Bloody-minded", Effect Duration: 22
 10290	polarized energized bouncing chocolate doubloon	0		Effect: "Hiding in Plain Sight", Effect Duration: 30
 10291	yellow Temple Grandin's Fonzie's driftwood beach comb of the storm	0		Experience (Moxie): +1, Maximum MP Percent: +40, Familiar Weight: +7, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
@@ -10166,8 +10166,8 @@
 10301	bouncing knitted flame-wreathed healthy whittled fox figurine	0		Maximum HP Percent: +20, Hot Spell Damage: +10, Cold Resistance: +3, Single Equip, Last Available: "2019-08"
 10302	frightening cool brainy whittled walking stick of vim and vigor	0		Mysticality: +5, Moxie: +5, Maximum HP Percent: +50, Spooky Damage: +5, Last Available: "2019-08"
 10303	moldy blurry campfire hot dog	4	crappy	Last Available: "2019-08"
-10304	yummy bite-sized fuchsia mirror campfire baked potato	1	awesome	Last Available: "2019-08"
-10305	thick stale mirror narrow campfire s'more	5	decent	Last Available: "2019-08"
+10304	bite-sized yummy fuchsia mirror campfire baked potato	1	awesome	Last Available: "2019-08"
+10305	stale thick mirror narrow campfire s'more	5	decent	Last Available: "2019-08"
 10306	adequate campfire beans	4	good	Last Available: "2019-08"
 10307	bland shaking campfire stew	4	decent	Last Available: "2019-08"
 10308	ghostly campfire coffee	1	good	Last Available: "2019-08"
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	bland space chowder	4	decent	
-10321	tolerable special watered-down space wine	2	good	Effect: "Purity of Spirit", Effect Duration: 15
+10321	watered-down tolerable special space wine	2	good	Effect: "Purity of Spirit", Effect Duration: 15
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	twirling packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10202,13 +10202,13 @@
 10343	shaking studded plastic dolphin &quot;orphan&quot;	0		Damage Absorption: +80, Single Equip, Last Available: "2019-12"
 10344	thinker's plastic Dolph Bossin	0		Mysticality: +10, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	decent snack-sized mana-coated yams	2	good	Last Available: "2019-11"
-10347	bland miniature huge mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
+10346	snack-sized decent mana-coated yams	2	good	Last Available: "2019-11"
+10347	miniature bland huge mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
 10348	adequate mana-fortified cranberry sauce	3	good	Last Available: "2019-11"
-10349	moldy tiny pulsating mana-stuffed herbal stuffing	1	crappy	Last Available: "2019-11"
-10350	lime green bouncing human musk	0		Last Available: "2019-12"
+10349	tiny moldy pulsating mana-stuffed herbal stuffing	1	crappy	Last Available: "2019-11"
+10350	bouncing lime green human musk	0		Last Available: "2019-12"
 10351	altered wobbly patch of extra-warm fur	0		Effect: "Spring Training", Effect Duration: 44, Last Available: "2019-12"
-10352	powdered blinking lime green industrial lubricant	1		Effect: "Tasting the Rainbow", Effect Duration: 45, Last Available: "2019-12"
+10352	powdered lime green blinking industrial lubricant	1		Effect: "Tasting the Rainbow", Effect Duration: 45, Last Available: "2019-12"
 10353	polarized spinning unfinished pleasure	0		Effect: "Triangle, Man", Effect Duration: 45, Last Available: "2019-12"
 10354	twisted purple vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	powdered narrow a bug's lymph	1		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	family-friendly razor-sharp nutcracker cape	0		Weapon Damage Percent: +25, Sleaze Resistance: +1, Last Available: "2019-12"
 10413	steel-toed wicked nutcracker epaulets	0		Spell Damage: +5, Damage Reduction: 9, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	moldy fancy salt plum	4	crappy	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2019-12"
+10415	fancy moldy salt plum	4	crappy	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	bland and bean	3	decent	Last Available: "2019-12"
 10418	prompt healthy groovy kelp-holly gun	0		Moxie Percent: +10, Maximum HP Percent: +20, Adventures: +3, Last Available: "2019-12"
@@ -10286,13 +10286,13 @@
 10427	super-chilled deionized pressurized potion of possessiveness	0		Effect: "Pill Power", Effect Duration: 11, Last Available: "2019-12"
 10428	super-corrupted chilled almond	0		Effect: "Phorcefullness", Effect Duration: 64
 10429	ionized dry modified lime green blurry handful of mixed nuts	0		Effect: "Altered Wavelengths", Effect Duration: 44, Last Available: "2019-12"
-10430	tumbling upside-down nutcracking pliers	0		
+10430	upside-down tumbling nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	teal squat Jim Carey's crafty smartaleck's Retrospecs	0		Moxie Percent: +30, Maximum MP: +10, Monster Level: +25, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	teal squat Jim Carey's crafty smartaleck's Retrospecs	0		Moxie Percent: +30, Maximum MP: +10, Monster Level: +25, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	lime green unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	executive Jeselnik's Da Vinci's experienced Powerful Glove of the ox	0		Muscle: +20, Experience: +2, Experience (Mysticality): +5, Sleaze Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	executive Jeselnik's Da Vinci's experienced Powerful Glove of the ox	0		Muscle: +20, Experience: +2, Experience (Mysticality): +5, Sleaze Damage: +25, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	lightning-fast therapeutic wizardly Drip harness	0		Mysticality: +25, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7
@@ -10390,8 +10390,8 @@
 10534	gray Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	fuchsia Guzzlrbuck	0		Last Available: "2020-05"
 10536	blinking Guzzlr hat	0		Last Available: "2020-05"
-10537	lime green shaking Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
-10538	bouncing wobbly lime green Guzzlr pants	0		Last Available: "2020-05"
+10537	shaking lime green Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
+10538	lime green wobbly bouncing Guzzlr pants	0		Last Available: "2020-05"
 10539	spinning ghostly steel-toed Guzzlr souvenir stein	0		Damage Reduction: 9, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	tolerable Ghiaccio Colada	3	good	Last Available: "2020-05"
@@ -10431,22 +10431,22 @@
 10575	drippy candy bar	0		
 10576	polymerized altered boiled salty drippy candy bar	0		Effect: "Muscularrr", Effect Duration: 22
 10577	triple-energized writhing drippy candy bar	0		Effect: "Mucilaginous Muscle", Effect Duration: 64
-10578	pickled jittery fuchsia gooey drippy candy bar	0		Effect: "Expert Vacationer", Effect Duration: 41
+10578	pickled fuchsia jittery gooey drippy candy bar	0		Effect: "Expert Vacationer", Effect Duration: 41
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	upside-down SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	mirror flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	blurry birch battery of James Dean of the bloodbag	0		Experience (Moxie): +3, Maximum HP: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	ghostly steel-toed occult Socratic ebony epee	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	blue Jeselnik's nasty chilly weeping willow wand	0		Cold Damage: +5, Stench Damage: +5, Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	zippy smartaleck's beechwood blowgun of the early riser	0		Moxie Percent: +30, Initiative: +20, Adventures: +7, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	ghostly steel-toed occult Socratic ebony epee	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Damage Reduction: 9, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	blue Jeselnik's nasty chilly weeping willow wand	0		Cold Damage: +5, Stench Damage: +5, Sleaze Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	zippy smartaleck's beechwood blowgun of the early riser	0		Moxie Percent: +30, Initiative: +20, Adventures: +7, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	medical-grade rosy-cheeked shellacked maple magnet	0		Damage Reduction: 7, Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08"
 10589	cyan blurry Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	aromatic Oprah's hemlock helm of the businessman	0		Maximum MP Percent: +50, Stench Resistance: +1, Meat Drop: +50, Last Available: "2020-08"
 10591	sweaty balsam	0		Last Available: "2020-08"
 10592	spinning foul-smelling hardy ruddy balsam barrel	0		Maximum HP Percent: +40, Maximum HP: +50, Stench Damage: +10, Last Available: "2020-08"
-10593	huge gray redwood	0		Last Available: "2020-08"
+10593	gray huge redwood	0		Last Available: "2020-08"
 10594	dry super-vacuum-sealed adjusted bouncing redwood rain stick	0		Effect: "Vital", Effect Duration: 56, Last Available: "2020-08"
 10595	blurry purpleheart logs	0		Last Available: "2020-08"
 10596	twirling frightening medical-grade hardy purpleheart &quot;pants&quot;	0		Maximum HP: +50, Spooky Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-08"
@@ -10459,12 +10459,12 @@
 10603	fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
-10606	oxidized dry spinning pulsating Yeg's Motel toothbrush	0		Effect: "Surreally Buff", Effect Duration: 30, Last Available: "2020-09"
+10606	oxidized dry pulsating spinning Yeg's Motel toothbrush	0		Effect: "Surreally Buff", Effect Duration: 30, Last Available: "2020-09"
 10607	energized altered Yeg's Motel hand soap	0		Effect: "Some Cheese with Your Wine", Effect Duration: 67, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	normal jittery Yeg's Motel pillow mint	3	good	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	modified colloidal warmed spinning blurry Yeg's Motel mouthwash	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2020-09"
+10611	modified colloidal warmed blurry spinning Yeg's Motel mouthwash	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2020-09"
 10612	huge skewed energetic sinister Yeg's Motel shower cap	0		Spell Damage: +10, Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2020-09"
 10613	yellow executive Yeg's Motel bathrobe of Leguizamo	0		Monster Level: +20, Meat Drop: +40, Lasts Until Rollover, Last Available: "2020-09"
 10614	tumbling auspicious frightening Yeg's Motel slippers	0		Spooky Damage: +5, Item Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
@@ -10474,12 +10474,12 @@
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	nasty desk bell	0		Last Available: "2020-09"
-10621	olive ghostly greasy desk bell	0		Last Available: "2020-09"
+10621	ghostly olive greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	skewed onyx king	0		Last Available: "2020-09"
 10624	green onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
-10626	mirror squat onyx bishop	0		Last Available: "2020-09"
+10626	squat mirror onyx bishop	0		Last Available: "2020-09"
 10627	teal onyx knight	0		Last Available: "2020-09"
 10628	blue onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	gray greedy aromatic Cargo Cultist Shorts of the bloodbag of the detective	0		Maximum HP: +100, Stench Resistance: +1, Item Drop: +20, Meat Drop: +20, Last Available: "2020-09"
 10637	blinking complicated device	0		Last Available: "2020-09"
-10638	boozy aged flask of moonshine	5	awesome	Last Available: "2020-09"
+10638	aged boozy flask of moonshine	5	awesome	Last Available: "2020-09"
 10639	chaotic experienced sea-worn candlestick of the glutton	0		Experience: +2, Spell Critical Percent: +10, Food Drop: +100, Last Available: "2020-09"
 10640	squat Universal Seasoning	0		
 10641	boiled cold-filtered null-day exploit	0		Effect: "Red-Shirted Escort", Effect Duration: 15, Last Available: "2025-12"
@@ -10548,7 +10548,7 @@
 10692	booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
-10695	skewed tumbling booze mailing list	0		Last Available: "2020-12"
+10695	tumbling skewed booze mailing list	0		Last Available: "2020-12"
 10696	candy mailing list	0		Last Available: "2020-12"
 10697	stanky weightlifter's fruit bat	0		Muscle: +15, Stench Spell Damage: +25, Class: "Seal Clubber", Single Equip, Last Available: "2020-12"
 10698	squat sage cool tinsel orb	0		Moxie: +5, Mysticality Percent: +10, Class: "Turtle Tamer", Last Available: "2020-12"
@@ -10568,7 +10568,7 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	delicious immense spinning fuchsia and pepper (stale)	10	awesome	Last Available: "2020-12"
+10715	delicious immense fuchsia spinning and pepper (stale)	10	awesome	Last Available: "2020-12"
 10716	tolerable cranberry margarita (brackish)	3	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
@@ -10578,8 +10578,8 @@
 10722	bite-sized bland upside-down blue drive-thru burger	1	decent	Last Available: "2020-12"
 10723	mediocre purple Boulevardier cocktail	4	decent	Last Available: "2020-12"
 10724	moist huge Hotwire&trade; brand candy rope	0		Effect: "Low on the Hog", Effect Duration: 36, Last Available: "2020-12"
-10725	diet rotten twirling fuchsia bowl full of jelly	1	crappy	Last Available: "2020-12"
-10726	bad special watered-down blue Eye and a Twist	2	decent	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2020-12"
+10725	rotten diet fuchsia twirling bowl full of jelly	1	crappy	Last Available: "2020-12"
+10726	special watered-down bad blue Eye and a Twist	2	decent	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2020-12"
 10727	denatured magnetized red jittery shaking Chubby and Plump bar	0		Effect: "Papowerful", Effect Duration: 67, Last Available: "2020-12"
 10728	wobbly digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10588,7 +10588,7 @@
 10732	fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 10734	mirror spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
-10735	tumbling green robo-battery	0		
+10735	green tumbling robo-battery	0		
 10736	jittery Thwaitgold listening bug statuette	0		
 10737	lime green bouncing power seed	0		Free Pull, Last Available: "2021-03"
 10738	blurry potted power plant	0		Last Available: "2021-03"
@@ -10600,19 +10600,19 @@
 10744	alkaline vacuum-sealed squat battery (car)	0		Effect: "Yet tea", Effect Duration: 65, Last Available: "2021-03"
 10745	upside-down cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	special drinkable ghostly marshmallow bomb	4	good	Effect: "Metal Speed", Effect Duration: 30, Last Available: "2021-03"
+10747	drinkable special ghostly marshmallow bomb	4	good	Effect: "Metal Speed", Effect Duration: 30, Last Available: "2021-03"
 10748	spinning packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	tumbling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	deionized mirror short beer	0		Effect: "Outer Wolf&trade;", Effect Duration: 59, Last Available: "2021-05"
 10753	polarized short stack of pancakes	0		Effect: "Mushroom Magicalness", Effect Duration: 43, Last Available: "2021-05"
 10754	electrified short stick of butter	0		Effect: "Overstimulated", Effect Duration: 63, Last Available: "2021-05"
-10755	enhanced concentrated mirror skewed short glass of water	0		Effect: "Polar Express", Effect Duration: 21, Last Available: "2021-05"
+10755	enhanced concentrated skewed mirror short glass of water	0		Effect: "Polar Express", Effect Duration: 21, Last Available: "2021-05"
 10756	energized flattened short	0		Effect: "Here's Mud in Your Eye", Effect Duration: 25, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	aromatic familiar scrapbook of the storm	0		Maximum MP Percent: +40, Stench Resistance: +1, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	aromatic familiar scrapbook of the storm	0		Maximum MP Percent: +40, Stench Resistance: +1, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	skewed packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	wobbly clan underground fireworks shop	0		Last Available: "2021-07"
 10762	supercharged educational fedora-mounted fountain of vim and vigor	0		Experience: +1, Maximum HP Percent: +50, Maximum MP Percent: +30, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	twirling gray rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	wobbly packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	ribald Jack Frost's coward's Annie Oakley's industrial fire extinguisher of the dark arts of incineration	0		Spell Damage Percent: +100, Critical Hit Percent: +20, Monster Level: -20, Cold Spell Damage: +50, Hot Spell Damage: +50, Sleaze Damage: +10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	ribald Jack Frost's coward's Annie Oakley's industrial fire extinguisher of the dark arts of incineration	0		Spell Damage Percent: +100, Critical Hit Percent: +20, Monster Level: -20, Cold Spell Damage: +50, Hot Spell Damage: +50, Sleaze Damage: +10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	squat The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10675,14 +10675,14 @@
 10819	toothsome tofu pop	3	awesome	Last Available: "2021-12"
 10820	normal jittery bowl of prescription candy	3	good	Last Available: "2021-12"
 10821	decent enchanted shaking fishcake	3	good	Effect: "Pasty", Effect Duration: 20, Last Available: "2021-12"
-10822	tiny toothsome bone broth	1	awesome	Last Available: "2021-12"
+10822	toothsome tiny bone broth	1	awesome	Last Available: "2021-12"
 10823	rotten fancy star pop	3	crappy	Effect: "Sleazy Jellied", Effect Duration: 25, Last Available: "2021-12"
 10824	hand-crafted Doc's Fortifying Wine	4	EPIC	Last Available: "2021-12"
 10825	perfectly mixed Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
 10826	smooth Doc's Limbering Wine	3	awesome	Last Available: "2021-12"
 10827	hand-crafted Doc's Medical-Grade Wine	4	EPIC	Last Available: "2021-12"
 10828	dehydrated Homebodyl&trade;	1		Last Available: "2021-12"
-10829	denatured green tumbling Extrovermectin&trade;	1		Effect: "Pygmy Drinking Buddy", Effect Duration: 35, Last Available: "2021-12"
+10829	denatured tumbling green Extrovermectin&trade;	1		Effect: "Pygmy Drinking Buddy", Effect Duration: 35, Last Available: "2021-12"
 10830	distilled teal Breathitin&trade;	1		Last Available: "2021-12"
 10831	dried Fleshazole&trade;	1		Effect: "Berry Defensive", Effect Duration: 30, Last Available: "2021-12"
 10832	energized colloidal anti-burn cream	0		Effect: "Dragged Through the Coals", Effect Duration: 21, Last Available: "2021-12"
@@ -10691,8 +10691,8 @@
 10835	galvanized non-tarnished jittery anti-odor cream	0		Effect: "Egg Burps", Effect Duration: 35, Last Available: "2021-12"
 10836	wet fuchsia anti-creep cream	0		Effect: "So Fresh and So Clean", Effect Duration: 15, Last Available: "2021-12"
 10837	ionized twirling anti-pain cream	0		Effect: "Heart Aflame", Effect Duration: 15, Last Available: "2021-12"
-10838	artisanal strong jittery Doc's Special Reserve Wine	5	EPIC	Last Available: "2021-12"
-10839	diet delicious bread pie	1	awesome	Last Available: "2021-12"
+10838	strong artisanal jittery Doc's Special Reserve Wine	5	EPIC	Last Available: "2021-12"
+10839	delicious diet bread pie	1	awesome	Last Available: "2021-12"
 10840	hand-crafted high-proof clear Russian	6	EPIC	Last Available: "2021-12"
 10841	twirling zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	teal narrow goo magnet	0		Last Available: "2021-12"
 10851	cozy scarf of the empath	0		Familiar Weight: +5, Last Available: "2021-12"
-10852	super-sized bland bouncing huge Crimbo cookie	5	decent	Last Available: "2023-06"
+10852	bland super-sized bouncing huge Crimbo cookie	5	decent	Last Available: "2023-06"
 10853	vacuum-sealed maroon narrow squat fleshy putty	0		Effect: "Stuck-Up Hair", Effect Duration: 58, Last Available: "2021-12"
 10854	mirror foul-smelling third ear	0		Stench Damage: +10, Single Equip, Last Available: "2021-12"
 10855	spinning festive egg sac	0		Last Available: "2021-12"
@@ -10714,7 +10714,7 @@
 10858	wobbly the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	lion tamer's depleted Crimbonium football helmet	0		Experience (familiar): +2, Last Available: "2021-12"
-10861	jittery spinning synthetic rock	0		Last Available: "2021-12"
+10861	spinning jittery synthetic rock	0		Last Available: "2021-12"
 10862	adequate &quot;caramel&quot;	3	good	Last Available: "2021-12"
 10863	self-repairing earmuffs of the pedagogue	0		Experience: +3, Last Available: "2021-12"
 10864	carnivorous potted plant of dire peril	0		Weapon Damage: +20, Last Available: "2021-12"
@@ -10754,7 +10754,7 @@
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	huge Oprah's supercool unbreakable umbrella (broken) of the ox of Gandalf	0		Muscle: +20, Moxie Percent: +20, Maximum MP Percent: +50, Spell Critical Percent: +20
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
-10901	skewed twirling MayDay&trade; supply package	0		Last Available: "2022-05"
+10901	twirling skewed MayDay&trade; supply package	0		Last Available: "2022-05"
 10902	triple-oxidized tumbling emergency glowstick	0		Effect: "Sweet Tooth", Effect Duration: 54, Last Available: "2022-05"
 10903	huge spinning coward's survival knife	0		Monster Level: -20, Lasts Until Rollover, Last Available: "2022-05"
 10904	frosty crank-powered radio on a lanyard	0		Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2022-05"
@@ -10781,8 +10781,8 @@
 10925	mother's necklace of the wise owl of courage	0		Mysticality: +20, Spooky Resistance: +3, Last Available: "2022-06"
 10926	quantum irradiated shaking trampled ticket stub	0		Effect: "Spirit of Alph", Effect Duration: 25, Last Available: "2022-06"
 10927	colloidal triple-deionized ghostly savings bond	0		Effect: "Optimist Primal", Effect Duration: 45, Last Available: "2022-06"
-10928	tumbling squat designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10928	squat tumbling designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	boiled maroon ghostly sweat-ade	1		Effect: "You Know What's Up", Effect Duration: 10, Last Available: "2022-07"
 10931	upside-down unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	squat tumbling stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10799,20 +10799,20 @@
 10943	smartaleck's camouflage vest	0		Moxie Percent: +30
 10944	Dinodollar	0		
 10945	valuable dinosaur droppings	0		
-10946	squat wobbly dinosaur pheromone kit	0		
+10946	wobbly squat dinosaur pheromone kit	0		
 10947	Jim Carey's MacGyver's awkward dinosaur research harness of the brute	0		Muscle Percent: +30, Maximum MP: +100, Monster Level: +25
 10948	beefy reflective vest	0		Muscle: +10
 10949	family-friendly dinosaur	0		Sleaze Resistance: +1
 10950	ghostly Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	thinker's Jurassic Parka of the sweet-tooth	0		Mysticality: +10, Candy Drop: +100, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	thinker's Jurassic Parka of the sweet-tooth	0		Mysticality: +10, Candy Drop: +100, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	electrified enhanced jittery autumn leaf	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 38, Last Available: "2022-10"
-10956	weak aged AutumnFest ale	2	awesome	Last Available: "2022-10"
+10956	aged weak AutumnFest ale	2	awesome	Last Available: "2022-10"
 10957	smartaleck's groovy autumn sweater-weather sweater of wisdom	0		Mysticality: +15, Moxie Percent: 40, Lasts Until Rollover, Last Available: "2022-10"
 10958	Jack Frost's rock-hard Fonzie's autumn debris shield of the bloodbag	0		Experience (Moxie): +1, Damage Reduction: 14, Maximum HP: +100, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2022-10"
-10959	bland snack-sized autumn-spice donut	2	decent	Last Available: "2022-10"
+10959	snack-sized bland autumn-spice donut	2	decent	Last Available: "2022-10"
 10960	alkaline autumn dollar	0		Effect: "Slimily Speedy", Effect Duration: 67, Last Available: "2022-10"
 10961	zippy educational autumn leaf pendant of Calamity Jane	0		Experience: +1, Critical Hit Percent: +15, Initiative: +20, Lasts Until Rollover, Last Available: "2022-10"
 10962	distilled teal autumn breeze	1		Last Available: "2022-10"
@@ -10824,12 +10824,12 @@
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	yummy jittery ratatouille de Jarlsberg	4	awesome	Last Available: "2022-11"
-10971	small stale Jarlsberg's vegetable soup	2	decent	Last Available: "2022-11"
-10972	fancy normal roasted vegetable of Jarlsberg	3	good	Effect: "Pisces Rising", Effect Duration: 30, Last Available: "2022-11"
-10973	special super-sized tasty tumbling St. Pete's sneaky smoothie	5	awesome	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2022-11"
+10971	stale small Jarlsberg's vegetable soup	2	decent	Last Available: "2022-11"
+10972	normal fancy roasted vegetable of Jarlsberg	3	good	Effect: "Pisces Rising", Effect Duration: 30, Last Available: "2022-11"
+10973	super-sized tasty special tumbling St. Pete's sneaky smoothie	5	awesome	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2022-11"
 10974	bland wobbly Pete's wiley whey bar	4	decent	Last Available: "2022-11"
 10975	bland Pete's rich ricotta	4	decent	Last Available: "2022-11"
-10976	irresponsibly strong acceptable green Boris's beer	10	good	Last Available: "2022-11"
+10976	acceptable irresponsibly strong green Boris's beer	10	good	Last Available: "2022-11"
 10977	flavorless honey bun of Boris	4	decent	Last Available: "2022-11"
 10978	spoiled Boris's bread	3	crappy	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
@@ -10840,10 +10840,10 @@
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
 10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	jittery green Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10987	green jittery Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	adequate baked veggie ricotta casserole	4	good	Last Available: "2022-11"
 10989	delicious plain calzone	3	awesome	Last Available: "2022-11"
-10990	fancy bland roasted vegetable focaccia	3	decent	Effect: "You Know When to Walk Away", Effect Duration: 5, Last Available: "2022-11"
+10990	bland fancy roasted vegetable focaccia	3	decent	Effect: "You Know When to Walk Away", Effect Duration: 5, Last Available: "2022-11"
 10991	flavorless Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	immense spoiled twirling Calzone of Legend	10	crappy	Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
@@ -10860,26 +10860,26 @@
 11004	supercool prohie's hat	0		Moxie Percent: +20
 11005	alkaline dry imported taffy	0		Effect: "Mad at Science", Effect Duration: 42
 11006	flame-retardant ribald Charleston shoes	0		Sleaze Damage: +10, Hot Resistance: +1, Single Equip
-11007	blurry squat booze bindle	0		
+11007	squat blurry booze bindle	0		
 11008	scorching dance instructor's rare oboe	0		Experience Percent (Moxie): +10, Hot Damage: +25
 11009	aromatic stylish bullet necklace	0		Moxie: +25, Stench Resistance: +1, Single Equip
 11010	moldy swamp haunch	3	crappy	
 11011	gravedigger's gator shades of incineration	0		Hot Spell Damage: +50, Spooky Damage: +10, Single Equip
 11012	upside-down milk cap	0		
 11013	lousy narrow Charleston Choo-Choo	3	decent	
-11014	perfectly mixed high-proof Velvet Veil	7	EPIC	
+11014	high-proof perfectly mixed Velvet Veil	7	EPIC	
 11015	acceptable teal Marltini	4	good	
 11016	perfectly mixed Strong, Silent Type	4	EPIC	
 11017	perfectly mixed Mysterious Stranger	4	EPIC	
 11018	drinkable huge Champagne Shimmy	3	good	
 11019	gray the Sot's parcel	0		
-11020	dangerous ceramic cestus of the pedagogue	0		Experience: +3, Weapon Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	curative strapping ceramic centurion shield of the sewer	0		Muscle: +5, Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	bouncing upside-down healthy ceramic celery grater of doom	0		Maximum HP Percent: +20, Spooky Spell Damage: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	blurry MacGyver's ceramic celsiturometer of the pedagogue of the businessman	0		Experience: +3, Maximum MP: +100, Meat Drop: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	auspicious curative supercool ceramic cerecloth belt	0		Moxie Percent: +20, Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	wobbly knitted wizardly ceramic cenobite's robe of Leguizamo	0		Mysticality: +25, Monster Level: +20, Cold Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
-11026	dehydrated blue huge tumbling ceramic scree	1		Effect: "Thunderspell", Effect Duration: 35, Last Available: "2023-12"
+11020	dangerous ceramic cestus of the pedagogue	0		Experience: +3, Weapon Damage: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	curative strapping ceramic centurion shield of the sewer	0		Muscle: +5, Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	bouncing upside-down healthy ceramic celery grater of doom	0		Maximum HP Percent: +20, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	blurry MacGyver's ceramic celsiturometer of the pedagogue of the businessman	0		Experience: +3, Maximum MP: +100, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	auspicious curative supercool ceramic cerecloth belt	0		Moxie Percent: +20, Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	wobbly knitted wizardly ceramic cenobite's robe of Leguizamo	0		Mysticality: +25, Monster Level: +20, Cold Resistance: +3, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11026	dehydrated tumbling blue huge ceramic scree	1		Effect: "Thunderspell", Effect Duration: 35, Last Available: "2023-12"
 11027	non-warmed moist bouncing extra-hard jawbreaker	0		Effect: "Colorful Gratitude", Effect Duration: 61
 11028	MacGyver's extremely unsafe chiffon chevrons of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100, Maximum MP: +100, Single Equip, Last Available: "2023-12"
 11029	mirror skewed inspector's asbestos-lined brainy chiffon chapeau	0		Mysticality: +5, Hot Resistance: +5, Item Drop: +15, Last Available: "2023-12"
@@ -10887,7 +10887,7 @@
 11031	chilly medical-grade veiny chiffon chemise	0		Maximum HP: +10, Cold Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11032	foul-smelling arcane researcher's chiffon chakram of incineration	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +50, Stench Damage: +10, Last Available: "2023-12"
 11033	up-at-dawn sage chiffon chaps of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3, Adventures: +5, Last Available: "2023-12"
-11034	vaporized spinning wobbly shaking chiffon carbage	1		Last Available: "2023-12"
+11034	vaporized shaking wobbly spinning chiffon carbage	1		Last Available: "2023-12"
 11035	colloidal unsweetened jittery chiffon lemon	0		Effect: "Okee-Dokee Go!", Effect Duration: 32
 11036	moldy chocomotive	4	crappy	Last Available: "2022-12"
 11037	normal freightcake	3	good	Last Available: "2022-12"
@@ -10903,7 +10903,7 @@
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
-11050	energized ionized mirror teal Trainbot circuitry	0		Effect: "Three Days Slow", Effect Duration: 12
+11050	energized ionized teal mirror Trainbot circuitry	0		Effect: "Three Days Slow", Effect Duration: 12
 11051	tarnished Trainbot tubing	0		Effect: "You Can Taste the Darkness", Effect Duration: 61
 11052	cold-filtered unsweetened chilled shaking Trainbot plating	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 32
 11053	modified alkaline adjusted Trainbot optics	0		Effect: "Vanity Rage", Effect Duration: 25
@@ -10923,24 +10923,24 @@
 11067	perfectly mixed gray narrow dregs of a Crimbo cocktail	3	EPIC	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	snack-sized spoiled special pulsating honey-drenched ham slice	2	crappy	Effect: "Lifted Spirits", Effect Duration: 50
+11070	special spoiled snack-sized pulsating honey-drenched ham slice	2	crappy	Effect: "Lifted Spirits", Effect Duration: 50
 11071	bad mostly-empty bottle of cookie wine	3	decent	
-11072	yummy massive Crimbo food scraps	8	awesome	
+11072	massive yummy Crimbo food scraps	8	awesome	
 11073	blurry arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	mirror shaking table-scraper	0		Single Equip
 11076	bouncing Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	gigantic rotten steamed oyster	6	crappy	
+11078	rotten gigantic steamed oyster	6	crappy	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	artisanal upside-down Crimbosmopolitan	4	EPIC	Last Available: "2022-12"
-11085	decent half-sized narrow Crimbo dinner	2	good	Last Available: "2022-12"
+11085	half-sized decent narrow Crimbo dinner	2	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
-11087	pulsating bouncing train whistle	0		Last Available: "2022-12"
+11087	bouncing pulsating train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	maroon unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	half-height cigar	0		Familiar Weight: +5
@@ -10957,29 +10957,29 @@
 11101	twirling groveling gravel	0		Last Available: "2023-01"
 11102	compressed blurry blinking fruity pebble	1		Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
-11104	upside-down wobbly purple milestone	0		Last Available: "2023-01"
+11104	purple wobbly upside-down milestone	0		Last Available: "2023-01"
 11105	bouncing bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
 11107	tumbling whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	pulsating stalagmite	0		Last Available: "2023-01"
 11110	huge chocolate covered ping-pong ball	0		
-11112	gigantic adequate pixel bread	8	good	
+11112	adequate gigantic pixel bread	8	good	
 11113	enchanted hand-crafted pixel whiskey	3	EPIC	Effect: "Leo Rising", Effect Duration: 30
 11114	red pixel rock	0		
 11115	mirror jittery S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	electrified alkaline fuchsia glob of extra-green chlorophyll	0		Effect: "Thunderheart", Effect Duration: 24, Last Available: "2023-02"
-11118	dry ionized skewed pulsating mushroom	0		Effect: "Hennaliciousness", Effect Duration: 14, Last Available: "2023-02"
+11118	dry ionized pulsating skewed mushroom	0		Effect: "Hennaliciousness", Effect Duration: 14, Last Available: "2023-02"
 11119	ionized quantum five-fingered fern resin	0		Effect: "Permanent Halloween", Effect Duration: 63, Last Available: "2023-02"
-11120	normal miniature super good fruit	2	good	Last Available: "2023-02"
+11120	miniature normal super good fruit	2	good	Last Available: "2023-02"
 11121	modified energized spores	1		Last Available: "2023-02"
 11122	upside-down smooth hot pepper of the sewer	0		Moxie: +15, Stench Damage: +25, Last Available: "2023-02", Lantern Element: "Hot"
 11123	modified altered pressed out-of-work circus flea	0		Effect: "Weapon of Mass Destruction", Effect Duration: 31, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	non-diffused flattened pulsating fire ant pheromones	0		Effect: "Macho, Macho Dog", Effect Duration: 37, Last Available: "2023-02"
 11126	quantum wobbly flapper fly	0		Effect: "Hoity Toity", Effect Duration: 62, Last Available: "2023-02"
-11127	watered-down artisanal purple shot of wasp venom	2	EPIC	Last Available: "2023-02"
+11127	artisanal watered-down purple shot of wasp venom	2	EPIC	Last Available: "2023-02"
 11128	aerosolized filled mosquito	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 49, Last Available: "2023-02"
 11129	polymerized shim of shame shale	0		Effect: "No Vertigo", Effect Duration: 51, Last Available: "2023-02"
 11130	aerosolized pebble of proud pyrite	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 34, Last Available: "2023-02"
@@ -11025,7 +11025,7 @@
 11170	red shadow lighter	0		
 11171	huge shadow heptahedron	0		
 11172	spinning shadow snowflake	0		
-11173	squat yellow shadow heart	0		
+11173	yellow squat shadow heart	0		
 11174	spinning shadow bucket	0		
 11175	shadow wave	0		
 11176	Rufus's shadow lodestone	0		
@@ -11038,7 +11038,7 @@
 11183	bad watered-down shadow martini	2	decent	
 11184	mixed lime green shadow pill	1		Effect: "Wise Spirit", Effect Duration: 25
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	warmed huge shadow candy	0		Effect: "Knightlife", Effect Duration: 61
 11189	replica Mr. Accessory	0		
@@ -11048,7 +11048,7 @@
 11193	replica pygmy bugbear shaman	0		
 11194	mirror dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
-11196	jittery narrow replica wax lips	0		Experience: +3
+11196	narrow jittery replica wax lips	0		Experience: +3
 11197	ghostly replica Tome of Snowcone Summoning	0		
 11198	maroon dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	huge wobbly sizzling brainy replica jewel-eyed wizard hat of chilblains	0		Mysticality: +5, Cold Damage: +25, Hot Damage: +10, Conditional Skill (Equipped): "Magic Missile"
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	up-at-dawn healthy hardened Cincho de Mayo of the brazier	0		Damage Reduction: 3, Maximum HP Percent: +20, Hot Spell Damage: +25, Adventures: +5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	up-at-dawn healthy hardened Cincho de Mayo of the brazier	0		Damage Reduction: 3, Maximum HP Percent: +20, Hot Spell Damage: +25, Adventures: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	mirror dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	blurry replica still grill	0		
@@ -11089,7 +11089,7 @@
 11234	mirror replica genie bottle	0		
 11235	skewed replica space planula	0		
 11236	blurry replica unpowered Robortender	0		
-11237	spinning green ghostly replica Neverending Party invitation envelope	0		
+11237	spinning ghostly green replica Neverending Party invitation envelope	0		
 11238	tumbling replica January's Garbage Tote	0		
 11239	teal replica God Lobster Egg	0		
 11240	baleful Socratic replica Fourth of May Cosplay Saber of the pedagogue	0		Experience: +3, Experience (Mysticality): +1, Spell Damage: +25, Conditional Skill (Equipped): "Use the Force"
@@ -11102,8 +11102,8 @@
 11247	replica crystal ball	0		Initiative: +50
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	fuchsia double-paned Jim Carey's replica Jurassic Parka	0		Monster Level: +25, Cold Resistance: +5
-11250	mirror spinning replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11250	spinning mirror replica grey gosling	0		
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	tumbling replica Ten Dollars	0		
 11254	Annie Oakley's brawny slick replica Cincho de Mayo of extreme caution	0		Moxie: +10, Muscle Percent: +20, Critical Hit Percent: +20, Monster Level: -25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	skewed blinking lion tamer's curative wholesome &quot;I survived Y2K&quot; T-Shirt of the wise owl of the dark arts of the empath	0		Mysticality: +20, Spell Damage Percent: +100, Maximum HP Percent: +10, Familiar Weight: +5, Experience (familiar): +2, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	Herculean pro skateboard of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	Herculean pro skateboard of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	spinning Meat Butler	0		Last Available: "2023-06"
 11263	fuchsia Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	squat yellow Flash Liquidizer Ultra Dousing Accessory of the storm	0		Maximum MP Percent: +40, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	squat yellow Flash Liquidizer Ultra Dousing Accessory of the storm	0		Maximum MP Percent: +40, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	olive lion tamer's supercharged smartaleck's Amulet of Perpetual Darkness of the ox	0		Muscle: +20, Moxie Percent: +30, Maximum MP Percent: +30, Experience (familiar): +2, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	ghostly red Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	acceptable Sexy Cosmo	4	good	Last Available: "2023-06"
 11283	blurry Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	fortified red-soled high heels of the cougar of the sewer	0		Moxie: +20, Damage Absorption: +60, Stench Damage: +25, Last Available: "2023-06"
-11285	normal blinking upside-down cyburger	3	good	Last Available: "2025-12"
+11285	normal upside-down blinking cyburger	3	good	Last Available: "2025-12"
 11286	fortified ncle leg	0		Damage Absorption: +60
 11287	pulsating rutabuga bag of the brute of the brazier	0		Muscle Percent: +30, Hot Spell Damage: +25
 11288	upside-down occult mesquito proboscis	0		Spell Damage Percent: +25
@@ -11146,7 +11146,7 @@
 11291	spider leg of the early riser	0		Adventures: +7
 11292	Sinatra's beetle antenna	0		Experience (Moxie): +5
 11293	mantis skull of the early riser	0		Adventures: +7
-11294	dry aerosolized ionized narrow mirror bouncing chitin powder	0		Effect: "Painted-On Bikini", Effect Duration: 33
+11294	dry aerosolized ionized narrow bouncing mirror chitin powder	0		Effect: "Painted-On Bikini", Effect Duration: 33
 11295	Temple Grandin's daddy shortlegs leg of the cheetah	0		Familiar Weight: +7, Initiative: +60
 11296	upside-down spinning gravedigger's brainy birdybug antenna	0		Mysticality: +5, Spooky Damage: +10
 11297	tumbling nippy wholesome kilopede skull	0		Maximum HP Percent: +10, Cold Damage: +10
@@ -11180,7 +11180,7 @@
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	tumbling residual chitin paste	0		Skill: "Chitinous Soul"
-11328	vaporized skewed twirling lime green concentrated cooking	1		Effect: "Fungal Fortification", Effect Duration: 40
+11328	vaporized twirling lime green skewed concentrated cooking	1		Effect: "Fungal Fortification", Effect Duration: 40
 11329	modified maroon narrow meat	1		Effect: "French Bronilla Brogueishness", Effect Duration: 15
 11330	altered olive sparkling orb	1		
 11331	compressed purple hardening cream	1		
@@ -11196,7 +11196,7 @@
 11341	inflammable leaf	0		
 11342	green rake	0		Item Drop: +1
 11343	red huge shellacked rake	0		Damage Reduction: 7
-11344	blinking upside-down autumnic bomb	0		
+11344	upside-down blinking autumnic bomb	0		
 11345	forest canopy bed	0		
 11346	day shortener	0		
 11347	skewed extra time	0		
@@ -11250,7 +11250,7 @@
 11395	bland peppermint donut	3	decent	
 11396	Elf Guard insignia (private) of the brazier	0		Hot Spell Damage: +25, Last Available: "2023-12"
 11397	reassuring Crimbuccaneer fledges (mint)	0		Spooky Resistance: +1, Last Available: "2023-12"
-11398	green huge military-grade peppermint oil	0		Last Available: "2023-12"
+11398	huge green military-grade peppermint oil	0		Last Available: "2023-12"
 11399	blurry Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	skewed lime green Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	hand-crafted weak Crimbuccaneer mologrog cocktail	2	EPIC	Last Available: "2023-12"
@@ -11260,7 +11260,7 @@
 11405	tumbling olive Crimbuccaneer flotsam	0		Last Available: "2023-12"
 11406	Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	wobbly Crimbuccaneer shirt of the overflowing toilet	0		Stench Spell Damage: [+50*event(December)], Last Available: "2023-12"
-11408	blinking shaking Elf Guard MPC	0		Last Available: "2023-12"
+11408	shaking blinking Elf Guard MPC	0		Last Available: "2023-12"
 11409	Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	hale Elf Guard commandeering gloves	0		Maximum HP: +20, Single Equip, Last Available: "2023-12"
 11411	denatured cold-filtered Elf Guard eyedrops	0		Effect: "Eyes Wide Propped", Effect Duration: 65, Last Available: "2023-12"
@@ -11274,12 +11274,12 @@
 11419	therapeutic personal trainer's Elf Guard broom	0		Experience Percent (Muscle): +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-12"
 11420	fireproof groovy Crimbuccaneer tavern swab	0		Moxie Percent: +10, Hot Resistance: +3, Item Drop: +5, Last Available: "2023-12"
 11421	twirling Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	artisanal high-proof old-school pirate grog	6	EPIC	Last Available: "2023-12"
+11422	high-proof artisanal old-school pirate grog	6	EPIC	Last Available: "2023-12"
 11423	moldy grog nuts	3	crappy	Last Available: "2023-12"
 11424	coward's Da Vinci's sawed-off blunderbuss of the glutton	0		Experience (Mysticality): +5, Monster Level: -20, Food Drop: +100, Last Available: "2023-12"
 11425	drinkable officer's nog	4	good	Last Available: "2023-12"
 11426	blinking peppermint bomb	0		Last Available: "2023-12"
-11427	adequate huge upside-down sundae ration	6	good	Last Available: "2023-12"
+11427	huge adequate upside-down sundae ration	6	good	Last Available: "2023-12"
 11428	decent peppermint tack	3	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	half-sized stale whalesteak	2	decent	Last Available: "2023-12"
@@ -11307,18 +11307,18 @@
 11452	flame-retardant manspreader's healthy Elf dessert spoon of the ox of the storm of the sweet-tooth	0		Muscle: +20, Maximum HP Percent: +20, Maximum MP Percent: +40, Monster Level: +10, Hot Resistance: +1, Candy Drop: +100, Last Available: "2023-12"
 11453	sinister Elf Guard SCUBA tank of horror	0		Spell Damage: +10, Spooky Spell Damage: +25, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	rock-hard Herculean free boots	0		Experience (Muscle): +1, Damage Reduction: 5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
-11456	jittery huge baby rigging snake	0		Last Available: "2023-12"
+11455	rock-hard Herculean free boots	0		Experience (Muscle): +1, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11456	huge jittery baby rigging snake	0		Last Available: "2023-12"
 11457	yellow miser's Elvish underarmor of the brute of the cheetah	0		Muscle Percent: +30, Meat Drop: +10, Initiative: +60, Single Equip, Last Available: "2023-12"
 11458	up-at-dawn Crimbuccaneer bombjacket of the blizzard	0		Cold Spell Damage: +25, Adventures: +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	fancy miniature bland sugarplum ration	2	decent	Effect: "Cranberry Cordiality", Effect Duration: 10, Last Available: "2023-12"
-11460	massive stale special gingerbread nylons	9	decent	Effect: "Human-Undead Hybrid", Effect Duration: 30, Last Available: "2023-12"
+11459	bland miniature fancy sugarplum ration	2	decent	Effect: "Cranberry Cordiality", Effect Duration: 10, Last Available: "2023-12"
+11460	special massive stale gingerbread nylons	9	decent	Effect: "Human-Undead Hybrid", Effect Duration: 30, Last Available: "2023-12"
 11461	decent yellow rum-soaked fruitcake	3	good	Last Available: "2023-12"
 11462	bland lime	3	decent	Last Available: "2023-12"
 11463	normal spinning gingerbread pirate	3	good	Last Available: "2023-12"
 11464	moldy fruit-stuffed rumcake	3	crappy	Last Available: "2023-12"
 11465	lousy mulled wine	3	decent	Last Available: "2023-12"
-11466	aged irresponsibly strong twirling Swedish coffee	7	awesome	Last Available: "2023-12"
+11466	irresponsibly strong aged twirling Swedish coffee	7	awesome	Last Available: "2023-12"
 11467	smooth upside-down canteen of eggnog	3	awesome	Last Available: "2023-12"
 11468	lousy high-proof hot wine	8	decent	Last Available: "2023-12"
 11469	mediocre Jamaican coffee	3	decent	Last Available: "2023-12"
@@ -11329,11 +11329,11 @@
 11474	bad fancy yule grog	3	decent	Effect: "Scavengers Scavenging", Effect Duration: 45, Last Available: "2023-12"
 11475	stale wet tack	3	decent	Last Available: "2023-12"
 11476	adequate jumbo whalecake	5	good	Last Available: "2023-12"
-11477	blue greedy Jeselnik's occult gunwale whalegun	0		Spell Damage Percent: +25, Sleaze Damage: +25, Meat Drop: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	blue greedy Jeselnik's occult gunwale whalegun	0		Spell Damage Percent: +25, Sleaze Damage: +25, Meat Drop: +20, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	watered-down lousy and claret	2	decent	Last Available: "2023-12"
-11479	purple wobbly rigging knot	0		Familiar Weight: +5
+11479	wobbly purple rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	blinking thinker's Elf Guard squirtgun of the bloodbag	0		Mysticality: +10, Maximum HP: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	blinking thinker's Elf Guard squirtgun of the bloodbag	0		Mysticality: +10, Maximum HP: +100, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	twirling chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	scorching sequin-encrusted sweater	0		Hot Damage: +25, Last Available: "2023-12"
 11484	wobbly smelly rosy-cheeked replica Elf Guard medal of the early riser	0		Maximum HP Percent: +30, Stench Spell Damage: +10, Adventures: +7, Last Available: "2023-12"
@@ -11346,7 +11346,7 @@
 11491	executive toasty Van der Graaf Crimbuccaneer nose ring	0		Hot Damage: +5, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	pulsating twirling Elf Guard safety bear	0		Last Available: "2023-12"
+11494	twirling pulsating Elf Guard safety bear	0		Last Available: "2023-12"
 11495	bouncing kraken	0		Last Available: "2023-12"
 11496	ghostly precision snowball	0		Last Available: "2023-12"
 11497	twirling jittery Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11354,13 +11354,13 @@
 11499	spinning Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	mirror The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	spinning squat Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11502	non-liquefied squat twirling military candy cane	0		Effect: "Creepypasted", Effect Duration: 58
+11502	non-liquefied twirling squat military candy cane	0		Effect: "Creepypasted", Effect Duration: 58
 11503	nitrogenated purple groggipop	0		Effect: "Papowerful", Effect Duration: 34
-11504	narrow mansplainer's moss mace of the overflowing toilet	0		Monster Level: +15, Stench Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	miser's rosewater-soaked moss megaphone	0		Stench Resistance: +3, Meat Drop: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	flame-wreathed deadly moss medal	0		Weapon Damage: +5, Hot Spell Damage: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	Jim Carey's moss mitre of Gandalf	0		Spell Critical Percent: +20, Monster Level: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	jittery olive prompt friendly moss mantle	0		Familiar Weight: +3, Adventures: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	narrow mansplainer's moss mace of the overflowing toilet	0		Monster Level: +15, Stench Spell Damage: +50, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	miser's rosewater-soaked moss megaphone	0		Stench Resistance: +3, Meat Drop: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	flame-wreathed deadly moss medal	0		Weapon Damage: +5, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	Jim Carey's moss mitre of Gandalf	0		Spell Critical Percent: +20, Monster Level: +25, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	jittery olive prompt friendly moss mantle	0		Familiar Weight: +3, Adventures: +3, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	frosty moss marlinspike of horror	0		Cold Spell Damage: +10, Spooky Spell Damage: +25, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	vaporized wobbly moss mulch	1		Effect: "Blessing of Squirtlcthulli", Effect Duration: 40, Last Available: "2024-12"
 11511	colloidal moss floss	0		Effect: "stats.enq", Effect Duration: 21
@@ -11372,12 +11372,12 @@
 11517	maroon adobe abaya	0		Last Available: "2024-12"
 11518	mixed adobe assortment	1		Last Available: "2024-12"
 11519	concentrated polymerized adobe brittle	0		Effect: "Surreally Buff", Effect Duration: 25
-11520	scandalous flame-wreathed stiffened crepe paper phrygian cap	0		Damage Reduction: 1, Hot Spell Damage: +10, Sleaze Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	scandalous flame-wreathed stiffened crepe paper phrygian cap	0		Damage Reduction: 1, Hot Spell Damage: +10, Sleaze Damage: +5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	gray narrow sizzling shellacked grievous crepe paper parachute cape	0		Weapon Damage Percent: +50, Damage Reduction: 7, Hot Damage: +10, Last Available: "2025-12"
-11522	skewed miser's chilly crepe paper pie clip of the glutton	0		Cold Damage: +5, Meat Drop: +10, Food Drop: +100, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	olive horrifying studded occult crepe paper puzzle cube	0		Spell Damage Percent: +25, Damage Absorption: +80, Spooky Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	medical-grade brawny crepe paper plunge camisole of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	gravedigger's lion tamer's crepe paper polka charm of extreme caution	0		Monster Level: -25, Experience (familiar): +2, Spooky Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	skewed miser's chilly crepe paper pie clip of the glutton	0		Cold Damage: +5, Meat Drop: +10, Food Drop: +100, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	olive horrifying studded occult crepe paper puzzle cube	0		Spell Damage Percent: +25, Damage Absorption: +80, Spooky Damage: +25, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	medical-grade brawny crepe paper plunge camisole of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	gravedigger's lion tamer's crepe paper polka charm of extreme caution	0		Monster Level: -25, Experience (familiar): +2, Spooky Damage: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	powdered crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	super-pickled skewed crepe paper peanut candy	0		Effect: "Hiding in Plain Sight", Effect Duration: 62
 11528	red lion tamer's petrified wood war pike of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Last Available: "2025-12"
@@ -11386,26 +11386,26 @@
 11531	spinning rosy-cheeked deadly petrified wood water purifier	0		Weapon Damage: +5, Maximum HP Percent: +30, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	mirror censurious knitted petrified wood whoopie panama	0		Cold Resistance: +3, Sleaze Resistance: +3, Last Available: "2025-12"
 11533	jittery yellow MacGyver's petrified wood walking pants of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +100, Last Available: "2025-12"
-11534	modified squat pulsating teal blinking petrified wood waste parts	1		Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2025-12"
+11534	modified pulsating teal squat blinking petrified wood waste parts	1		Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2025-12"
 11535	moist magnetized altered petrified wood wafer praline	0		Effect: "Hombre Muerto Caminando", Effect Duration: 52
 11536	mediocre jittery cybeer	4	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	cyan encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	cyan encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	green baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	Lo Pan's steel-toed Crimbuccaneer war standard	0		Damage Reduction: 9, Spell Critical Percent: +30, Last Available: "2023-12"
 11544	gravedigger's Newton's Elf Guard war standard	0		Experience (Mysticality): +3, Spooky Damage: +10, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	narrow medical-grade occult Sinatra's spring shoes	0		Experience (Moxie): +5, Spell Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
-11547	cold-filtered blue tumbling ultra-soft ferns	0		Effect: "Gummiskin", Effect Duration: 20, Last Available: "2024-02"
+11546	narrow medical-grade occult Sinatra's spring shoes	0		Experience (Moxie): +5, Spell Damage Percent: +25, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11547	cold-filtered tumbling blue ultra-soft ferns	0		Effect: "Gummiskin", Effect Duration: 20, Last Available: "2024-02"
 11548	oxidized crunchy brush	0		Effect: "Pill Power", Effect Duration: 35, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
-11553	blue skewed squat ultra-high-tension exoskeleton	0		
+11553	blue squat skewed ultra-high-tension exoskeleton	0		
 11554	mirror irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
 11556	upside-down quick-release fannypack	0		Single Equip
@@ -11425,12 +11425,12 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	skewed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	half-sized moldy yam	2	crappy	Last Available: "2024-05"
+11573	moldy half-sized yam	2	crappy	Last Available: "2024-05"
 11574	mediocre yam martini	4	decent	Last Available: "2024-05"
 11575	tolerable sweet potato o' mine	3	good	Last Available: "2024-05"
 11576	hand-crafted huge Southern yam	3	EPIC	Last Available: "2024-05"
 11577	aged sweet potato punch	3	awesome	Last Available: "2024-05"
-11578	special toothsome blurry Mayam spinach	4	awesome	Effect: "Sharp Weapon", Effect Duration: 25, Last Available: "2024-05"
+11578	toothsome special blurry Mayam spinach	4	awesome	Effect: "Sharp Weapon", Effect Duration: 25, Last Available: "2024-05"
 11579	rotten yam and swiss	3	crappy	Last Available: "2024-05"
 11580	family-friendly lard-coated beefy yam cannon	0		Muscle: +10, Sleaze Spell Damage: +25, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2024-05"
 11581	upside-down yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11448,20 +11448,20 @@
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	adequate mini kiwi	4	good	Last Available: "2024-06"
 11595	aromatic lard-coated mini kiwi bikini	0		Sleaze Spell Damage: +25, Stench Resistance: +1, Item Drop: +5, Last Available: "2024-06"
-11596	watered-down mediocre mini kiwitini	2	decent	Last Available: "2024-06"
+11596	mediocre watered-down mini kiwitini	2	decent	Last Available: "2024-06"
 11597	green mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	fuchsia Oprah's wicked mini kiwi silicon tiepin of Flo-Jo	0		Spell Damage: +5, Maximum MP Percent: +50, Initiative: +100
-11600	shaking narrow mini kiwi tipi	0		
-11601	enchanted small adequate mini kiwi digitized cookies	2	good	Effect: "Orc Chops", Effect Duration: 50
-11602	strong tolerable mini kiwi intoxicating spirits	5	good	
+11600	narrow shaking mini kiwi tipi	0		
+11601	adequate small enchanted mini kiwi digitized cookies	2	good	Effect: "Orc Chops", Effect Duration: 50
+11602	tolerable strong mini kiwi intoxicating spirits	5	good	
 11603	altered mini kiwi antimilitaristic hippy petition	0		Effect: "Slimily Speedy", Effect Duration: 28
 11604	pressed pressed super-galvanized twirling mini kiwi illicit antibiotic	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 30
 11605	slick mini kiwi whipping stick of mayonnaise	0		Moxie: +10, Sleaze Spell Damage: +50
 11606	spinning Jeselnik's mini kiwi icepick	0		Sleaze Damage: +25
 11607	alkaline mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 14
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11478,7 +11478,7 @@
 11623	upside-down flagellate soup	0		
 11624	elbow soup	0		
 11625	green lip soup	0		
-11626	spinning wobbly unevolved organism	0		Free Pull
+11626	wobbly spinning unevolved organism	0		Free Pull
 11627	extra ooze	0		
 11628	extra DNA	0		Experience (familiar): +1
 11629	teal untorn tearaway pants package	0		Free Pull
@@ -11502,7 +11502,7 @@
 11647	red structural ember	0		Last Available: "2024-09"
 11648	jittery sharpshooter's sinister embers-only jacket of the brute	0		Muscle Percent: +30, Spell Damage: +10, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2024-09"
 11649	tumbling huge hardy bembershoot	0		Maximum HP: +50, Lasts Until Rollover, Last Available: "2024-09"
-11650	jumbo bland wheel of camembert	5	decent	Last Available: "2024-09"
+11650	bland jumbo wheel of camembert	5	decent	Last Available: "2024-09"
 11651	crafty Newton's hat of remembering of the brazier	0		Experience (Mysticality): +3, Maximum MP: +10, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11510,9 +11510,9 @@
 11655	fuchsia jittery soft cap of diminishing returns	0		
 11656	olive photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	miser's Jeselnik's occult bat wings	0		Spell Damage Percent: +25, Sleaze Damage: +25, Meat Drop: +10, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	miser's Jeselnik's occult bat wings	0		Spell Damage Percent: +25, Sleaze Damage: +25, Meat Drop: +10, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	blinking ember egg	0		Last Available: "2024-09"
-11660	upside-down twirling ember	0		Cold Resistance: +1
+11660	twirling upside-down ember	0		Cold Resistance: +1
 11661	squat Newton's monocle on a stick of vim and vigor	0		Experience (Mysticality): +3, Maximum HP Percent: +50, Lasts Until Rollover, Last Available: "2024-10"
 11662	zippy plastic pipe of Tarzan	0		Experience (Muscle): +3, Initiative: +20, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11663	squat Samson's fake arrow-through-the-head of bravery	0		Experience (Muscle): +5, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,10 +11523,10 @@
 11668	Sheriff badge of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	upside-down jittery nasty dance instructor's Sheriff pistol	0		Experience Percent (Moxie): +10, Stench Damage: +5, Lasts Until Rollover, Last Available: "2024-10"
 11670	lard-coated Sheriff moustache of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	fuchsia Newton's photo booth supply list of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	fuchsia Newton's photo booth supply list of the storm	0		Experience (Mysticality): +3, Maximum MP Percent: +40, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
-11673	twirling purple tie-dye headband	0		
-11674	spoiled snack-sized whirled peas	2	crappy	Last Available: "2024-11"
+11673	purple twirling tie-dye headband	0		
+11674	snack-sized spoiled whirled peas	2	crappy	Last Available: "2024-11"
 11675	flavorless gigantic maroon peaza	10	decent	Last Available: "2024-11"
 11676	spinning gray peace shooter	0		Last Available: "2024-11"
 11677	dried twirling ghostly drenchrome 2.0	1		Effect: "Uncanny Shot", Effect Duration: 45, Last Available: "2025-12"
@@ -11541,12 +11541,12 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	shaking TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	pulsating aromatic deft pirate hook of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-12"
-11689	tumbling skewed scorching iron tricorn hat of the scaredy-cat	0		Monster Level: -15, Hot Damage: +25, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	tumbling skewed scorching iron tricorn hat of the scaredy-cat	0		Monster Level: -15, Hot Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	bouncing gravedigger's jolly roger flag	0		Spooky Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 11691	blurry sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
 11693	hand-crafted blinking tankard of spiced rum	4	EPIC	Last Available: "2024-12"
-11694	mediocre enchanted extra-dry tankard of spiced Goldschlepper	5	decent	Effect: "Super Accuracy", Effect Duration: 35, Last Available: "2024-12"
+11694	mediocre extra-dry enchanted tankard of spiced Goldschlepper	5	decent	Effect: "Super Accuracy", Effect Duration: 35, Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	slick governor's daughter's lace collar	0		Moxie: +10, Last Available: "2024-12"
 11697	sinister governor's daughter's petticoats	0		Spell Damage: +10, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	pulsating profane eye patch	0		Sleaze Damage: +3
 11709	warmed lime green jittery peppermint pegleg	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 56, Last Available: "2024-12"
 11710	artisanal hard cocoa	3	EPIC	Last Available: "2024-12"
-11711	bland small maroon salmagumdi	2	decent	Last Available: "2024-12"
+11711	small bland maroon salmagumdi	2	decent	Last Available: "2024-12"
 11712	upside-down plastic Easter Island Bunny	0		Item Drop: +5, Last Available: "2024-12"
 11713	jittery plastic St. Patrick of chilblains	0		Cold Damage: +25, Last Available: "2024-12"
 11714	scorching plastic Colonel Brando of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Last Available: "2024-12"
@@ -11574,16 +11574,16 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	adequate huge special coney haunch	7	good	Effect: "Sharp Weapon", Effect Duration: 40, Last Available: "2024-12"
+11722	huge special adequate coney haunch	7	good	Effect: "Sharp Weapon", Effect Duration: 40, Last Available: "2024-12"
 11723	quantum energized dark chocolate egg	0		Effect: "Neuromancy", Effect Duration: 55, Last Available: "2024-12"
-11724	triple-distilled lousy moai toai	8	decent	
+11724	lousy triple-distilled moai toai	8	decent	
 11725	wobbly friendly moaiball of the scaredy-cat of the glutton	0		Monster Level: -15, Familiar Weight: +3, Food Drop: +100, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	ionized quantum four-leaf potato sprout	0		Effect: "items.enh", Effect Duration: 55, Last Available: "2024-12"
 11728	teal executive gravedigger's potato jacket of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Meat Drop: +40, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Van der Graaf military orb of the wise owl	0		Mysticality: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	Van der Graaf military orb of the wise owl	0		Mysticality: +20, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	oxidized rum ball	0		Effect: "Coldfinger", Effect Duration: 35
 11733	gravy skin	0		Last Available: "2024-12"
 11734	frightening gravyskin hat of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Last Available: "2024-12"
@@ -11595,16 +11595,16 @@
 11740	blurry fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	tumbling zippy foul-smelling toasty perfect Christmas scarf	0		Hot Damage: [+5*event(December)], Stench Damage: [+10*event(December)], Initiative: [+20*event(December)], Single Equip, Last Available: "2024-12"
-11743	flame-wreathed snowman-enchanting tophat of the dark arts	0		Spell Damage Percent: +100, Hot Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	flame-wreathed snowman-enchanting tophat of the dark arts	0		Spell Damage Percent: +100, Hot Spell Damage: +10, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	chilled LIDAR candle	0		Effect: "Fancy Feasted", Effect Duration: 49, Last Available: "2024-12"
 11745	wobbly inspector's MacGyver's fortified Congressional Medal of Insanity	0		Damage Absorption: +60, Maximum MP: +100, Item Drop: +15, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	delicious ghostly Easter grasshopper	4	awesome	Last Available: "2024-12"
 11748	perfectly mixed Irish eggnog	4	EPIC	Last Available: "2024-12"
 11749	artisanal practically non-alcoholic canteen of jungle juice	1	super ultra mega turbo EPIC	Last Available: "2024-12"
-11750	delicious watered-down turchucken	2	awesome	Last Available: "2024-12"
+11750	watered-down delicious turchucken	2	awesome	Last Available: "2024-12"
 11751	mediocre mechanically-mulled cider	3	decent	Last Available: "2024-12"
-11752	weak tolerable holiday trip around the world	2	good	Last Available: "2024-12"
+11752	tolerable weak holiday trip around the world	2	good	Last Available: "2024-12"
 11753	decent chocolate ostrich egg	4	good	Last Available: "2024-12"
 11754	enchanted tasty shaking olive beef and cabbage	3	awesome	Effect: "Cranberry Cordiality", Effect Duration: 10, Last Available: "2024-12"
 11755	big flavorless candy rations	5	decent	Last Available: "2024-12"
@@ -11624,7 +11624,7 @@
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	tumbling narrow Sherlock's smelly beefcake's egg gun	0		Muscle: +25, Stench Spell Damage: +10, Item Drop: 30, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	tumbling narrow Sherlock's smelly beefcake's egg gun	0		Muscle: +25, Stench Spell Damage: +10, Item Drop: 30, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	narrow toasty studded stylish army helmet of wisdom	0		Mysticality: +15, Moxie: +25, Damage Absorption: +80, Hot Damage: +5, Last Available: "2024-12"
 11774	pulsating candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11633,17 +11633,17 @@
 11778	boiled maroon clovermint	1		Effect: "Emotion Sickness", Effect Duration: 10, Last Available: "2024-12"
 11779	executive ribald Fonzie's nylon Christmas stockings of wisdom	0		Mysticality: +15, Experience (Moxie): +1, Sleaze Damage: +10, Meat Drop: +40, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
-11781	chilled quadruple-polymerized blinking narrow green deviled candy egg	0		Effect: "Artificially Sweet", Effect Duration: 65, Last Available: "2024-12"
+11781	chilled quadruple-polymerized narrow green blinking deviled candy egg	0		Effect: "Artificially Sweet", Effect Duration: 65, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	McHugeLarge duffel bag of doom of Flo-Jo	0		Spooky Spell Damage: +50, Initiative: +100, Last Available: "2025-01"
-11784	spinning crafty dangerous McHugeLarge left pole of the early riser	0		Weapon Damage: +10, Maximum MP: +10, Adventures: +7, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	flame-retardant dog trainer's McHugeLarge right pole of Calamity Jane	0		Critical Hit Percent: +15, Experience (familiar): +1, Hot Resistance: +1, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	shellacked McHugeLarge left ski of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	huge Da Vinci's McHugeLarge right ski of courage	0		Experience (Mysticality): +5, Spooky Resistance: +3, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	spinning crafty dangerous McHugeLarge left pole of the early riser	0		Weapon Damage: +10, Maximum MP: +10, Adventures: +7, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	flame-retardant dog trainer's McHugeLarge right pole of Calamity Jane	0		Critical Hit Percent: +15, Experience (familiar): +1, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	shellacked McHugeLarge left ski of the overflowing toilet	0		Damage Reduction: 7, Stench Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	huge Da Vinci's McHugeLarge right ski of courage	0		Experience (Mysticality): +5, Spooky Resistance: +3, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	boiled pulsating eXpand	1		Effect: "You're Rubber", Effect Duration: 40, Last Available: "2025-12"
-11791	olive brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	olive brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	blue dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	purple retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11666,7 +11666,7 @@
 11811	pulsating ghostly logic grenade	0		Last Available: "2025-12"
 11812	boiled shaking psilocyber mushroom	1		Last Available: "2025-12"
 11813	cyan dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
-11814	ghostly green narrow dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
+11814	ghostly narrow green dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	spinning dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	cyan dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
@@ -11679,20 +11679,20 @@
 11824	spinning insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
-11829	ghostly pulsating virtual cybertattoo	0		Last Available: "2025-12"
+11829	pulsating ghostly virtual cybertattoo	0		Last Available: "2025-12"
 11830	twirling ninja rope	0		
 11831	ninja crampons	0		
 11832	ninja carabiner	0		
-11833	ionized altered ghostly huge synthetic coffee	0		Effect: "Strange Mental Acuity", Effect Duration: 39
+11833	ionized altered huge ghostly synthetic coffee	0		Effect: "Strange Mental Acuity", Effect Duration: 39
 11834	non-vacuum-sealed iDrops	0		Effect: "Faboooo", Effect Duration: 43
 11835	yellow shame coil	0		
 11836	ghostly new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
 11839	pulsating scrape	0		
-11840	skewed huge gray phantom digit	0		
+11840	gray huge skewed phantom digit	0		
 11841	foul line	0		
 11842	narrow dark manioc	0		
 11843	Observer source code	0		
@@ -11704,7 +11704,7 @@
 11849	heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	bouncing mirror stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
-11852	twirling blue phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
+11852	blue twirling phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
@@ -11724,16 +11724,16 @@
 11869	spinning unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	modified pulsating leprechaun antidepressant pill	1		Effect: "Blessing of the Hot Linguine", Effect Duration: 35, Last Available: "2025-03"
-11872	huge normal Heck ramen	9	good	Last Available: "2025-03"
-11873	rotten special tiny burrito	1	crappy	Effect: "Morninja", Effect Duration: 30, Last Available: "2025-03"
+11872	normal huge Heck ramen	9	good	Last Available: "2025-03"
+11873	rotten tiny special burrito	1	crappy	Effect: "Morninja", Effect Duration: 30, Last Available: "2025-03"
 11874	stale tumbling small beer brat	4	decent	Last Available: "2025-03"
 11875	spoiled peach pie	3	crappy	Last Available: "2025-03"
 11876	normal incredible mini-pizza	3	good	Last Available: "2025-03"
 11877	lousy tumbling Divine sidecar	4	decent	Last Available: "2025-03"
 11878	practically non-alcoholic tolerable upside-down skewed tangarita sidecar	1	good	Last Available: "2025-03"
 11879	aged gimlet sidecar	3	awesome	Last Available: "2025-03"
-11880	hand-crafted practically non-alcoholic vodka stratocaster sidecar	1	super ultra EPIC	Last Available: "2025-03"
-11881	fortified lousy prussian cathouse sidecar	5	decent	Last Available: "2025-03"
+11880	practically non-alcoholic hand-crafted vodka stratocaster sidecar	1	super ultra EPIC	Last Available: "2025-03"
+11881	lousy fortified prussian cathouse sidecar	5	decent	Last Available: "2025-03"
 11882	lousy jittery Mon Tiki sidecar	3	decent	Last Available: "2025-03"
 11883	spinning Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	quilted deadly April Shower Thoughts shield	0		Weapon Damage: +5, Damage Absorption: +40, Damage Reduction: 6, Last Available: "2025-04"
@@ -11741,9 +11741,9 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	triple-energized boiled pulsating wet paper weights	0		Effect: "Mercenary", Effect Duration: 28, Last Available: "2025-04"
 11888	aged Three Sheets to the Wind	4	awesome	Last Available: "2025-04"
-11889	bite-sized toothsome jittery pile of wet dates	1	awesome	Last Available: "2025-04"
+11889	toothsome bite-sized jittery pile of wet dates	1	awesome	Last Available: "2025-04"
 11890	blurry papier Mach 1 airplane	0		Last Available: "2025-04"
-11891	yellow mirror wet blanket	0		Last Available: "2025-04"
+11891	mirror yellow wet blanket	0		Last Available: "2025-04"
 11892	stanky wet shower cap	0		Stench Spell Damage: +25, Last Available: "2025-04"
 11893	dog trainer's wet shower shoes	0		Experience (familiar): +1, Last Available: "2025-04"
 11894	weightlifter's wet shower shorts	0		Muscle: +15, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	weightlifter's stylish bycocket	0		Muscle: +15
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	huge spinning Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11786,7 +11786,7 @@
 11931	bouncing nice nylon stockings	0		
 11932	gray Allied Radio Backpack Pack	0		Free Pull
 11933	dance instructor's supercool stylish Allied Radio Backpack	0		Moxie: +25, Moxie Percent: +20, Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Call in an Airstrike"
-11934	twirling yellow orphaned baby skeleton	0		
+11934	yellow twirling orphaned baby skeleton	0		
 11935	narrow ordnance magnet	0		Single Equip
 11936	purple confetti grenade	0		
 11937	immense flavorless Skeleton Wars rations	6	decent	
@@ -11810,7 +11810,7 @@
 11955	rotten Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	scandalous toasty energetic the gun	0		Maximum MP Percent: +20, Hot Damage: +5, Sleaze Damage: +5, Last Available: "2025-08"
-11958	spirit-forward mediocre jittery red wine	5	decent	Last Available: "2025-08"
+11958	mediocre spirit-forward red jittery wine	5	decent	Last Available: "2025-08"
 11960	shaking olive mirror really, really nice swimming trunks	0		
 11961	twirling sand penny	0		
 11962	cyan skewed stylish undersea surveying goggles	0		Moxie: +25, Lasts Until Rollover
@@ -11822,20 +11822,20 @@
 11968	mirror scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	upside-down sea gel	0		
-11971	pressed quadruple-polymerized olive blinking octopus ink bladder	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 11
+11971	pressed quadruple-polymerized blinking olive octopus ink bladder	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 11
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	mirror packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	dentadent of dire peril	0		Weapon Damage: +20
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	up-at-dawn knitted nasty energetic blood cubic zirconia of the pedagogue of Tarzan	0		Experience: +3, Experience (Muscle): +3, Maximum MP Percent: +20, Stench Damage: +5, Cold Resistance: +3, Adventures: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	up-at-dawn knitted nasty energetic blood cubic zirconia of the pedagogue of Tarzan	0		Experience: +3, Experience (Muscle): +3, Maximum MP Percent: +20, Stench Damage: +5, Cold Resistance: +3, Adventures: +5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	twisted blinking blood thinner	1		Effect: "Pharmaceutically Cool", Effect Duration: 20, Last Available: "2025-10"
 12045	mediocre pheromone cocktail	4	decent	Last Available: "2025-10"
 12046	normal squat spinal tapas	4	good	Last Available: "2025-10"
 12047	teal shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	cyan Annie Oakley's brainy shrunken head of chilblains	0		Mysticality: +5, Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	cyan Annie Oakley's brainy shrunken head of chilblains	0		Mysticality: +5, Critical Hit Percent: +20, Cold Damage: +25, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	twirling small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
@@ -11861,7 +11861,7 @@
 12071	cyan clever wholesome angelbone mantle	0		Maximum HP Percent: +10, Maximum MP: +20, Last Available: "2026-12"
 12072	angelbone dice of extreme caution	0		Monster Level: -25, Single Equip, Last Available: "2026-12"
 12073	toasty angelbone halo of the wise owl	0		Mysticality: +20, Hot Damage: +5, Last Available: "2026-12"
-12074	vaporized shaking purple angelbone fragments	1		Effect: "EVISCERATE!", Effect Duration: 50, Last Available: "2026-12"
+12074	vaporized purple shaking angelbone fragments	1		Effect: "EVISCERATE!", Effect Duration: 50, Last Available: "2026-12"
 12075	extra-pickled upside-down biblically accurate gumdrops	0		Effect: "Sweetened and Fattened", Effect Duration: 21
 12076	careful extremely unsafe devilbone helmet	0		Weapon Damage Percent: +100, Monster Level: -10, Last Available: "2026-12"
 12077	lime green devilbone greaves of the businessman	0		Meat Drop: +50, Last Available: "2026-12"
@@ -11889,14 +11889,14 @@
 12131	diffused aerosolized wet green boiling synovial fluid	0		Effect: "Memory of Speed", Effect Duration: 55, Last Available: "2025-12"
 12132	mirror Van der Graaf crafty strapping smoldering vertebra	0		Muscle: +5, Maximum MP: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	red smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	MacGyver's deadly thinker's hot boning knife	0		Mysticality: +10, Weapon Damage: +5, Maximum MP: +100, Single Equip, Last Available: "2025-12"
 12138	lightning-fast electrified stiffened fistbone	0		Damage Reduction: 1, Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-12"
 12139	scandalous deadly dance instructor's burnt bone belt	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Sleaze Damage: +5, Single Equip, Last Available: "2025-12"
 12140	wobbly scorching scorched skull trophy	0		Hot Damage: +25, Last Available: "2025-12"
-12141	spoiled huge wing bone	6	crappy	Last Available: "2025-12"
+12141	huge spoiled wing bone	6	crappy	Last Available: "2025-12"
 12142	triple-distilled lousy bouncing weak skeleton venom	8	decent	Last Available: "2025-12"
 12143	dried baked bone meal	1		Last Available: "2025-12"
 12144	twirling plastic skeleton rib cage of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2025-12"
@@ -11912,7 +11912,7 @@
 12154	messenger parrot egg	0		Last Available: "2025-12"
 12155	blurry buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
-12157	green upside-down skewed Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
+12157	upside-down green skewed Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	narrow Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	huge Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	lime green Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
@@ -11929,14 +11929,14 @@
 12171	stale traditional gingerloaf	3	decent	Last Available: "2025-12"
 12172	practically non-alcoholic mediocre Scotch and eggnog	1	decent	Last Available: "2025-12"
 12173	activated super-concentrated red counterskeleton elixir	0		Effect: "[1701]Hip to the Jive", Effect Duration: 58, Last Available: "2025-12"
-12174	weak perfectly mixed tumbling gray &quot;salvaged&quot; wine	2	EPIC	Last Available: "2025-12"
+12174	perfectly mixed weak gray tumbling &quot;salvaged&quot; wine	2	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	blinking shaking olive crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	miniature special tasty wedge of prize-winning cheese	2	awesome	Effect: "Melancholy Burden", Effect Duration: 50, Last Available: "2025-12"
+12177	miniature tasty special wedge of prize-winning cheese	2	awesome	Effect: "Melancholy Burden", Effect Duration: 50, Last Available: "2025-12"
 12178	dry gummi fingerbone	0		Effect: "Preemptive Medicine", Effect Duration: 49
 12179	mirror friendly glimmering crystal of the brute	0		Muscle Percent: +30, Familiar Weight: +3, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	gray Thwaitgold meat bee statuette	0		
 12183	twirling loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11948,7 +11948,7 @@
 12190	fossilized cow femur	0		Familiar Weight: +5
 12191	unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
-12193	warmed lime green twirling Pork Elf mouthwash	0		Effect: "Weather, Man", Effect Duration: 59, Last Available: "2026-03"
+12193	warmed twirling lime green Pork Elf mouthwash	0		Effect: "Weather, Man", Effect Duration: 59, Last Available: "2026-03"
 12194	vacuum-sealed energized purple mirror Pork Elf deodorant	0		Effect: "Engorged Weapon", Effect Duration: 60, Last Available: "2026-03"
 12195	oxidized electrified Pork Elf toothpaste	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 12, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
@@ -11961,7 +11961,7 @@
 12203	purple frosty Tesla dinosaur bone corset of the pedagogue	0		Experience: +3, Cold Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2026-03"
 12204	acceptable watered-down Pork Elf cough syrup	2	good	Last Available: "2026-03"
 12205	green Pork Elf neti pot	0		Last Available: "2026-03"
-12206	red skewed Pork Elf medicine cabinet	0		Last Available: "2026-03"
+12206	skewed red Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	jittery Pork Elf toilet	0		Last Available: "2026-03"
 12209	bland tumbling rat pizza	3	decent	Last Available: "2026-03"
@@ -11969,31 +11969,31 @@
 12211	Rosewater's hoverboard of the storm of the detective	0		Mysticality Percent: +30, Maximum MP Percent: +40, Item Drop: +20, Single Equip, Last Available: "2026-03"
 12212	vibrating Fonzie's left shark fin of mayonnaise	0		Experience (Moxie): +1, Maximum MP Percent: +10, Sleaze Spell Damage: +50, Last Available: "2026-03"
 12213	wobbly vibrating fitness tracking bracelet	0		Maximum MP Percent: +10, Single Equip, Last Available: "2026-03"
-12214	compressed blue blinking mirror candy bone	1		Effect: "Frigid Weapon", Effect Duration: 35
+12214	compressed blinking mirror blue candy bone	1		Effect: "Frigid Weapon", Effect Duration: 35
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	bland gigantic shaking discarded hot dog	9	decent	Last Available: "2026-04"
+12217	gigantic bland shaking discarded hot dog	9	decent	Last Available: "2026-04"
 12218	practically non-alcoholic perfectly mixed most of a beer	1	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
-12225	skewed blurry legendary noodles	0		Last Available: "2026-05"
+12225	blurry skewed legendary noodles	0		Last Available: "2026-05"
 12226	decent big can of tuna	5	good	
 12227	flavorless alien salad	3	decent	
-12228	bite-sized delicious green upside-down ratbatatouille	1	awesome	
+12228	delicious bite-sized upside-down green ratbatatouille	1	awesome	
 12229	gigantic moldy onigiri	9	crappy	
 12230	decent super-sized crudit&eacute;s	5	good	
-12231	bland olive twirling sauced mutton	3	decent	
-12232	snack-sized flavorless upside-down hot honey ant	2	decent	
-12233	thick stale tomb aspic	5	decent	
+12231	bland twirling olive sauced mutton	3	decent	
+12232	flavorless snack-sized upside-down hot honey ant	2	decent	
+12233	stale thick tomb aspic	5	decent	
 12234	big bland later tots	5	decent	
 12235	moldy Frutti di Scatoletta	3	crappy	Last Available: "2026-05"
 12236	adequate tiny Pesto alla Marziano	1	good	Last Available: "2026-05"
 12237	rotten Arrattabbattabiata	3	crappy	Last Available: "2026-05"
 12238	normal super-sized Orzo di Riso	5	good	Last Available: "2026-05"
-12239	moldy massive enchanted spinning bouncing Pasta Grimavera	9	crappy	Effect: "Heart of Orange", Effect Duration: 20, Last Available: "2026-05"
+12239	enchanted moldy massive spinning bouncing Pasta Grimavera	9	crappy	Effect: "Heart of Orange", Effect Duration: 20, Last Available: "2026-05"
 12240	tasty mirror Linguini Ubriacapa	4	awesome	Last Available: "2026-05"
 12241	massive bland Formica e Pepe	9	decent	Last Available: "2026-05"
-12242	delicious miniature Tubetto Gelatto	2	awesome	Last Available: "2026-05"
+12242	miniature delicious Tubetto Gelatto	2	awesome	Last Available: "2026-05"
 12243	normal Gnocci Domani	3	good	Last Available: "2026-05"
 12244	shaking Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12017,9 +12017,9 @@
 12267	squat wool flimsy plastic breastplate	0		Cold Resistance: +1
 12268	lard-coated flimsy plastic shield	0		Sleaze Spell Damage: +25, Damage Reduction: 3
 12269	huge packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	curative extremely unsafe Sinatra's Portable Laughing Stock	0		Experience (Moxie): +5, Weapon Damage Percent: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	curative extremely unsafe Sinatra's Portable Laughing Stock	0		Experience (Moxie): +5, Weapon Damage Percent: +100, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	green scandalous Oprah's shellacked Staff of Anachronistic Churning	0		Damage Reduction: 7, Maximum MP Percent: +50, Sleaze Damage: +5
-12272	rotten massive classic banana	6	crappy	Last Available: "2026-07"
+12272	massive rotten classic banana	6	crappy	Last Available: "2026-07"
 12273	decent watermelon	3	good	Last Available: "2026-07"
 12274	moldy quince	4	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
@@ -12028,14 +12028,14 @@
 12278	ionized shaking essential banana decoction	0		Effect: "Coated Arms", Effect Duration: 23, Last Available: "2026-07"
 12279	tarnished oxidized teal banana quintessence	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 54, Last Available: "2026-07"
 12280	bad ghostly Aesop Daiquiri	3	decent	Last Available: "2026-07"
-12281	spirit-forward bad upside-down gray blurry Monkey Congress	5	decent	Last Available: "2026-07"
+12281	bad spirit-forward upside-down gray blurry Monkey Congress	5	decent	Last Available: "2026-07"
 12282	normal yellow watermelon pie	3	good	Last Available: "2026-07"
-12283	boiled chilled blue spinning concentrated watermelon juice	0		Effect: "Wreathed in Smoke", Effect Duration: 19, Last Available: "2026-07"
+12283	boiled chilled spinning blue concentrated watermelon juice	0		Effect: "Wreathed in Smoke", Effect Duration: 19, Last Available: "2026-07"
 12284	ionized diffused Aqua Citrulanatae	0		Effect: "Thickest, Sickest", Effect Duration: 27, Last Available: "2026-07"
 12285	lousy Melonegroni	3	decent	Last Available: "2026-07"
 12286	artisanal enchanted Melonade Spritz	3	EPIC	Effect: "Human-Constellation Hybrid", Effect Duration: 20, Last Available: "2026-07"
-12287	spoiled small blurry quince pie	2	crappy	Last Available: "2026-07"
-12288	polarized ionized blurry spinning purple quince quaff	0		Effect: "Ancestral Disapproval", Effect Duration: 34, Last Available: "2026-07"
+12287	small spoiled blurry quince pie	2	crappy	Last Available: "2026-07"
+12288	polarized ionized spinning purple blurry quince quaff	0		Effect: "Ancestral Disapproval", Effect Duration: 34, Last Available: "2026-07"
 12289	non-energized tarnished Quickquince	0		Effect: "Slimy Hands", Effect Duration: 57, Last Available: "2026-07"
 12290	artisanal bouncing Quiskey Sour	3	EPIC	Last Available: "2026-07"
 12291	perfectly mixed pulsating upside-down Quincea&ntilde;era Cooler	3	EPIC	Last Available: "2026-07"
@@ -12059,6 +12059,6 @@
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	twisted toxic asset	1		Last Available: "2026-08"
 12311	dehydrated gray narrow intangible asset	1		Effect: "Whippin' It Good", Effect Duration: 40, Last Available: "2026-08"
-12312	distilled narrow upside-down mirror liquid asset	1		Last Available: "2026-08"
+12312	distilled mirror upside-down narrow liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	wobbly cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Pastamancer_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wallaby_cafe_booze.txt
@@ -9,9 +9,9 @@
 -18	irresponsibly strong tolerable gin	6	good	
 -19	acceptable ghostly ecto-nog	3	good	
 -20	smooth practically non-alcoholic hot toady	1	awesome	
--21	lousy practically non-alcoholic hot choculate	1	decent	
+-21	practically non-alcoholic lousy hot choculate	1	decent	
 -49	drinkable jittery Cyder	3	good	
--50	artisanal enchanted practically non-alcoholic green Oil Nog	1	EPIC	
+-50	artisanal practically non-alcoholic enchanted green Oil Nog	1	EPIC	
 -51	acceptable Hi-Octane Peppermint Jet Fuel	3	good	
 -58	hand-crafted Grimacider	4	EPIC	
 -59	tolerable Isotope Nog	3	good	
@@ -21,13 +21,13 @@
 -72	artisanal Antarctic Ice Tea	3	EPIC	
 -76	smooth CRIMBCO Ribbon Candy Schnapps	4	awesome	
 -77	hand-crafted CRIMBCO Egg Substitute Nog Substitute	3	EPIC	
--78	acceptable narrow blinking blue CRIMBCO Extreme Braincracker Sour	3	good	
+-78	acceptable blinking narrow blue CRIMBCO Extreme Braincracker Sour	3	good	
 -82	lousy Horseradish-infused Vodka	3	decent	
 -83	lousy yellow Jerkitini	4	decent	
 -84	artisanal Desert Island Iced Tea	3	EPIC	
 -88	watered-down mediocre Crimbo Saketini	2	decent	
--89	special practically non-alcoholic drinkable maroon Crimboku Drop	1	good	
+-89	practically non-alcoholic special drinkable maroon Crimboku Drop	1	good	
 -90	lousy spinning Flaming Crimbo Log	4	decent	
--107	high-proof mediocre Fortified Eggnog Slurry	8	decent	
+-107	mediocre high-proof Fortified Eggnog Slurry	8	decent	
 -108	lousy Hot Buttered Rum	4	decent	
 -109	artisanal Spicy Hot Chocolate	4	EPIC	

--- a/data/TCRS/TCRS_Pastamancer_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wallaby_cafe_food.txt
@@ -1,44 +1,44 @@
 -1	adequate Peche a la Frog	3	good	
 -2	stale As Jus Gezund Heit	3	decent	
 -3	rotten Bouillabaise Coucher Avec Moi	3	crappy	
--7	rotten snack-sized gumdrop chow mein	2	crappy	
--8	super-sized flavorless candy cane pizza	5	decent	
--9	stale special wobbly gingerbread stir-fry	4	decent	
+-7	snack-sized rotten gumdrop chow mein	2	crappy	
+-8	flavorless super-sized candy cane pizza	5	decent	
+-9	special stale wobbly gingerbread stir-fry	4	decent	
 -10	moldy twigs and gravel	3	crappy	
 -11	moldy shoots and leaves	4	crappy	
 -12	miniature bland bowl of unidentifiable goo	2	decent	
 -13	rotten gingerbread massacre	3	crappy	
--14	delicious small It Came From Beyond Dessert	2	awesome	
+-14	small delicious It Came From Beyond Dessert	2	awesome	
 -15	decent narrow vampire cake	4	good	
 -52	special bland Soylent Red and Green	3	decent	
 -53	moldy Disc-Shaped Nutrition Unit	3	crappy	
--54	special snack-sized stale Gingerborg Hive	2	decent	
--61	bite-sized normal Candy Cane Surprise	1	good	
--62	spoiled big Grimdrop Chow Mein	5	crappy	
+-54	snack-sized special stale Gingerborg Hive	2	decent	
+-61	normal bite-sized Candy Cane Surprise	1	good	
+-62	big spoiled Grimdrop Chow Mein	5	crappy	
 -63	moldy Grimgerbread House	3	crappy	
 -67	delicious Caviar Carbonara	4	awesome	
--68	rotten jumbo Halibut Alfredo	5	crappy	
+-68	jumbo rotten Halibut Alfredo	5	crappy	
 -69	adequate Red Herring Velvet Cake	3	good	
--73	fancy decent CRIMBCO Reconstituted Gruel	4	good	
+-73	decent fancy CRIMBCO Reconstituted Gruel	4	good	
 -74	tasty New and Improved CRIMBCO Reconstituted Gruel	3	awesome	
 -75	decent gigantic CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	good	
 -79	flavorless Brussels Sprout Stir-Fry	4	decent	
--80	diet moldy blurry green Carrot, Cabbage, and Kale Pizza	1	crappy	
+-80	moldy diet blurry green Carrot, Cabbage, and Kale Pizza	1	crappy	
 -81	bland cyan Turnip and Rutabaga Pie	4	decent	
 -85	rotten big twirling Rainbow Spider Fun Roll	5	crappy	
--86	stale big Vegas Volcano Lava Roll	5	decent	
+-86	big stale Vegas Volcano Lava Roll	5	decent	
 -87	bland half-sized Crazy Dragon Shogun Buddha Roll	2	decent	
--92	bland small basic hot dog	2	decent	
+-92	small bland basic hot dog	2	decent	
 -93	snack-sized spoiled gray savage macho dog	2	crappy	
 -94	normal purple one with everything	3	good	
--95	stale enchanted sly dog	3	decent	
--96	diet moldy special devil dog	1	crappy	
--97	moldy gigantic chilly dog	10	crappy	
+-95	enchanted stale sly dog	3	decent	
+-96	moldy special diet devil dog	1	crappy	
+-97	gigantic moldy chilly dog	10	crappy	
 -98	tasty ghost dog	3	awesome	
 -99	toothsome blurry junkyard dog	3	awesome	
 -100	decent wet dog	3	good	
 -101	adequate gigantic sleeping dog	10	good	
--102	immense adequate optimal dog	9	good	
+-102	adequate immense optimal dog	9	good	
 -103	spoiled video games hot dog	3	crappy	
 -104	rotten ghostly Peppermint Nutrition Block	4	crappy	
 -105	adequate super-sized ghostly Gingerbread Nutrition Block	5	good	

--- a/data/TCRS/TCRS_Pastamancer_Wombat.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wombat.txt
@@ -13,7 +13,7 @@
 14	modified upside-down moxie weed	1		Effect: "Tingly Elbows", Effect Duration: 35
 15	powdered twirling upside-down strongness elixir	1		Effect: "Hippy Flavor", Effect Duration: 10
 16	mixed bouncing magicalness-in-a-can	1		
-17	immense moldy noodles	10	crappy	
+17	moldy immense noodles	10	crappy	
 18	upside-down tortoise's blessing	0		
 19	asbestos-lined asparagus knife	0		Hot Resistance: +5
 20	fuchsia Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -26,7 +26,7 @@
 27	spider web	0		
 28	bouncing really spider web	0		
 29	really really spider web	0		
-30	lime green narrow rock	0		
+30	narrow lime green rock	0		
 31	seal-toothed rock	0		
 32	Bjorn's Hammer of the sewer	0		Stench Damage: +25, Class: "Seal Clubber"
 33	snorkel	0		Familiar Effect: "atk, cap 2"
@@ -57,7 +57,7 @@
 58	upside-down stone turtle	0		
 59	slingshot	0		
 60	wool Mace of the Tortoise	0		Cold Resistance: +1, Class: "Turtle Tamer"
-61	delicious huge cyan fortune cookie	7	awesome	
+61	huge delicious cyan fortune cookie	7	awesome	
 62	extremely unsafe oriole-feather headdress	0		Weapon Damage Percent: +100, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	ghostly action figure head	0		
@@ -136,7 +136,7 @@
 137	dope wheels	0		
 138	ice-cold six-pack	0		
 139	valuable trinket	0		
-140	upside-down mirror dingy planks	0		
+140	mirror upside-down dingy planks	0		
 141	bouncing dingy dinghy	0		
 142	upside-down anticheese	0		
 143	cottage	0		
@@ -171,7 +171,7 @@
 172	ghostly gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
-175	tasty huge uncooked chorizo	8	awesome	
+175	huge tasty uncooked chorizo	8	awesome	
 176	disembodied brain	0		
 177	brainy skull	0		
 178	blurry tumbling detective skull	0		
@@ -181,7 +181,7 @@
 182	skewed batgut	0		
 183	bat wing	0		
 184	squat briefcase	0		
-185	narrow red fat stacks of cash	0		
+185	red narrow fat stacks of cash	0		
 186	bean	0		
 187	loose teeth	0		
 188	bat guano	0		
@@ -196,7 +196,7 @@
 198	huge rat appendix	0		
 199	skewed Herculean ring	0		Experience (Muscle): +1
 200	special decent rat appendix kabob	3	good	Effect: "Sparkly!", Effect Duration: 10
-201	fancy half-sized moldy bat wing kabob	2	crappy	Effect: "Amorous Avarice", Effect Duration: 5
+201	moldy fancy half-sized bat wing kabob	2	crappy	Effect: "Amorous Avarice", Effect Duration: 5
 202	yummy carob chunks	3	awesome	
 203	herbs	0		
 204	special normal yellow carob chunk cookies	3	good	Effect: "Chauve-Souris Merde Fou", Effect Duration: 50
@@ -212,21 +212,21 @@
 214	curative filthy knitted dread sack	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	twirling Uncle Jick's Brownie Mix	0		
 216	rotten huge carob brownies	9	crappy	
-217	toothsome small twirling herb brownies	2	awesome	
+217	small toothsome twirling herb brownies	2	awesome	
 218	ghostly hemp string	0		
-219	narrow wobbly necklace chain	0		
+219	wobbly narrow necklace chain	0		
 220	gnoll teeth	0		
 221	beefcake's gnoll-tooth necklace	0		Muscle: +25
 222	phat turquoise bead	0		
 223	greedy phat turquoise bracelet	0		Meat Drop: +20
 224	maroon slick eyepatch	0		Moxie: +10, Familiar Effect: "3xBarrr, cap 6"
 225	adequate tofu casserole	4	good	
-226	pickled twirling maroon narrow can of Red Minotaur	1	good	
+226	pickled narrow twirling maroon can of Red Minotaur	1	good	
 227	ghostly personal trainer's Kentucky-fried meat sword	0		Experience Percent (Muscle): +10
 228	chilly Kentucky-fried meat staff	0		Cold Damage: +5
 229	huge jittery hale Kentucky-fried meat crossbow	0		Maximum HP: +20
 230	ruddy dead guy's watch	0		Maximum HP Percent: +40, Single Equip
-231	red upside-down Doc Galaktik's Pungent Unguent	0		
+231	upside-down red Doc Galaktik's Pungent Unguent	0		
 232	shaking Doc Galaktik's Ailment Ointment	0		
 233	Doc Galaktik's Restorative Balm	0		
 234	skewed Doc Galaktik's Homeopathic Elixir	0		
@@ -237,21 +237,21 @@
 239	red jittery smelly Orcish baseball cap of bravery	0		Stench Spell Damage: +10, Spooky Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	avaricious inspector's Orcish cargo shorts	0		Item Drop: +15, Meat Drop: +30, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	wobbly energetic Orcish frat-paddle	0		Maximum MP Percent: +20
-242	massive moldy	8	crappy	
+242	moldy massive	8	crappy	
 243	rotten grapefruit	4	crappy	
 244	decent grapes	3	good	
 245	flavorless olive	3	decent	
 246	rotten ghostly tomato	3	crappy	
 247	wobbly fermenting powder	0		
-248	hand-crafted practically non-alcoholic bouncing lime green salty dog	1	EPIC	
-249	lousy practically non-alcoholic bloody mary	1	decent	
+248	practically non-alcoholic hand-crafted lime green bouncing salty dog	1	EPIC	
+249	practically non-alcoholic lousy bloody mary	1	decent	
 250	bad watered-down huge screwdriver	2	decent	
 251	drinkable ghostly martini	4	good	
 252	lousy bloody beer	3	decent	
 253	fancy mediocre shot of schnapps	3	decent	Effect: "Wallflowering", Effect Duration: 15
 254	bad shot of grapefruit schnapps	3	decent	
-255	fortified acceptable bouncing fine wine	5	good	
-256	boozy tolerable green shot of tomato schnapps	5	good	
+255	acceptable fortified bouncing fine wine	5	good	
+256	tolerable boozy green shot of tomato schnapps	5	good	
 257	lousy extra-spicy bloody mary	3	decent	
 258	pulsating dense meat stack	0		
 259	tumbling snake skin	0		
@@ -273,7 +273,7 @@
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
 277	compressed maroon shaking extra-strength strongness elixir	1		
-278	twisted pulsating skewed fuchsia jug-o-magicalness	1		Effect: "Man's Worst Enemy", Effect Duration: 5
+278	twisted skewed fuchsia pulsating jug-o-magicalness	1		Effect: "Man's Worst Enemy", Effect Duration: 5
 279	pickled spinning suntan lotion of moxiousness	1		
 280	huge Pick-O-Matic lockpicks	0		
 281	gasmask of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xBarrr, cap 12"
@@ -310,20 +310,20 @@
 312	therapeutic Knob Goblin visor	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	miser's Crown of the Goblin King	0		Meat Drop: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	spoiled yellow bean burrito	3	crappy	
-315	rotten snack-sized bean burrito	2	crappy	
+315	snack-sized rotten bean burrito	2	crappy	
 316	rotten insanely bean burrito	3	crappy	
-317	massive normal bean burrito	10	good	
+317	normal massive bean burrito	10	good	
 318	flavorless bean burrito	3	decent	
-319	tasty blue shaking insanely bean burrito	3	awesome	
+319	tasty shaking blue insanely bean burrito	3	awesome	
 320	delicious bat haggis	4	awesome	
 321	toothsome menudo	4	awesome	
 322	enchanted rotten ghostly goat cheese	3	crappy	Effect: "Almost Cool", Effect Duration: 35
-323	tasty diet plain pizza	1	awesome	
+323	diet tasty plain pizza	1	awesome	
 324	special yummy sausage pizza	4	awesome	Effect: "Squatting and Thrusting", Effect Duration: 5
 325	normal twirling goat cheese pizza	3	good	
 326	normal jumbo mushroom pizza	5	good	
 327	goat	0		
-328	spirit-forward bad bottle of whiskey	5	decent	
+328	bad spirit-forward bottle of whiskey	5	decent	
 329	skewed studded goat beard	0		Damage Absorption: +80, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	good	
 331	acceptable triple-distilled Canadian	7	good	
@@ -383,7 +383,7 @@
 385	aromatic chrome staff of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1
 386	studded chrome crossbow of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50
 387	fuzzy dice	0		
-388	twirling fuchsia yeti fur	0		
+388	fuchsia twirling yeti fur	0		
 389	spinning strapping meaty helmet turtle	0		Muscle: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 17"
 390	Da Vinci's asbestos helmet turtle	0		Experience (Mysticality): +5, Familiar Effect: "hot atk, 1xFairy, cap 20"
 391	jittery extremely unsafe linoleum helmet turtle	0		Weapon Damage Percent: +100, Familiar Effect: "stench atk, 1xFairy, cap 25"
@@ -417,7 +417,7 @@
 419	ionized ghostly serum of sarcasm	0		Effect: "Human-Hippy Hybrid", Effect Duration: 26
 420	activated dry tomato juice of powerful power	0		Effect: "Liquidy Smoky", Effect Duration: 23
 421	warmed polymerized philter of phorce	0		Effect: "Barbecue Saucy", Effect Duration: 62
-422	super-liquefied blurry spinning potion of potency	0		Effect: "Whole Latte Love", Effect Duration: 28
+422	super-liquefied spinning blurry potion of potency	0		Effect: "Whole Latte Love", Effect Duration: 28
 423	galvanized irradiated cordial of concentration	0		Effect: "Hood Ridin'", Effect Duration: 48
 424	tarnished ointment of the occult	0		Effect: "Held Closer", Effect Duration: 35
 425	extra-nitrogenated quadruple-colloidal olive oil of expertise	0		Effect: "Ocelot Eyes", Effect Duration: 57
@@ -431,15 +431,15 @@
 433	skewed skinny balloon	0		
 434	crafty balloon helmet	0		Maximum MP: +10, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	chilly balloon sword of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +5, Clowniness: 50
-436	ghostly bouncing balloon monkey	0		
+436	bouncing ghostly balloon monkey	0		
 437	chef skull	0		
 438	chef-in-the-box	0		
-439	upside-down teal bartender skull	0		
+439	teal upside-down bartender skull	0		
 440	bartender-in-the-box	0		
 441	chef-skull-in-the-box	0		
 442	bartender-skull-in-the-box	0		
 443	beer lens	0		
-444	squat wobbly beer goggles	0		
+444	wobbly squat beer goggles	0		
 445	box-in-the-box of Tarzan	0		Experience (Muscle): +3
 446	twirling tumbling nothing-in-the-box-in-the-box	0		
 447	medical-grade box-in-the-box-in-the-box	0		HP Regen Min: 7, HP Regen Max: 10
@@ -462,7 +462,7 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	small flavorless pixel pie	2	decent	
+467	flavorless small pixel pie	2	decent	
 468	upside-down ruby W	0		
 469	cyan wussiness potion	0		
 470	high-proof lousy Imp Ale	10	decent	
@@ -493,12 +493,12 @@
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	miniature spoiled papaya	2	crappy	
+498	spoiled miniature papaya	2	crappy	
 499	hardy beefy denim axe	0		Muscle: +10, Maximum HP: +50
 500	Elf Farm Raffle ticket	0		
 501	normal skewed Elfin shortbread	4	good	
 502	wobbly pagoda plans	0		
-503	huge moldy skewered cat appendix	6	crappy	
+503	moldy huge skewered cat appendix	6	crappy	
 504	evil arches	0		
 505	Annie Oakley's vibrating gnatwing earring	0		Maximum MP Percent: +10, Critical Hit Percent: +20
 506	adequate massive Hell broth	10	good	
@@ -509,11 +509,11 @@
 511	purple Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	fancy decent miniature Boris's key lime pie	2	good	Effect: "Earthen Fist", Effect Duration: 30
-514	special spoiled bouncing Jarlsberg's key lime pie	4	crappy	Effect: "Tingling Feeling", Effect Duration: 20
+514	spoiled special bouncing Jarlsberg's key lime pie	4	crappy	Effect: "Tingling Feeling", Effect Duration: 20
 515	rotten Sneaky Pete's key lime pie	4	crappy	
 516	Hey Deze map	0		
 517	forbidden bejeweled accordion strap	0		Spell Damage Percent: +50, Class: "Accordion Thief"
-518	gray squat mystery juice	0		
+518	squat gray mystery juice	0		
 519	moxie magnet	0		
 520	leaflet	0		
 521	Tesla kickback cookbook	0		MP Regen Min: 7, MP Regen Max: 10
@@ -528,7 +528,7 @@
 530	polarized spray paint	0		Effect: "Bricked-In", Effect Duration: 11
 531	teal friendly special sauce glove	0		Familiar Weight: +3, Class: "Sauceror", Single Equip
 532	jittery studded ladle of mystery	0		Damage Absorption: +80, Class: "Sauceror"
-533	blinking fuchsia Gnollish toolbox	0		
+533	fuchsia blinking Gnollish toolbox	0		
 534	bouncing abridged dictionary	0		
 535	bridge	0		
 536	dictionary	0		
@@ -540,7 +540,7 @@
 542	zippy forbidden 1337 7r0uZ0RZ	0		Spell Damage Percent: +50, Initiative: +20, Familiar Effect: "2xPotato, cap 27"
 543	rotten blurry Trollhouse cookies	4	crappy	
 544	dog trainer's talons of extreme caution	0		Monster Level: -25, Experience (familiar): +1
-545	yummy jumbo blue Spam Witch sammich	5	awesome	
+545	jumbo yummy blue Spam Witch sammich	5	awesome	
 546	meat vortex	0		
 547	blinking 334 scroll	0		
 548	mirror 668 scroll	0		
@@ -549,42 +549,42 @@
 551	64067 scroll	0		
 552	64735 scroll	0		
 553	jittery jittery 31337 scroll	0		
-554	adequate massive ghostly pr0n cocktail	8	good	
+554	massive adequate ghostly pr0n cocktail	8	good	
 555	upside-down scorching wicked drywall axe	0		Spell Damage: +5, Hot Damage: +25
 556	Pine-Fresh air freshener of James Dean	0		Experience (Moxie): +3
-557	distilled lousy upside-down whiskey and cola	5	decent	
-558	super-sized adequate wobbly narrow papaya taco	5	good	
+557	lousy distilled upside-down whiskey and cola	5	decent	
+558	adequate super-sized narrow wobbly papaya taco	5	good	
 559	razor-sharp can lid	0		
-560	bland snack-sized upside-down teal stalk of asparagus	2	decent	
+560	snack-sized bland upside-down teal stalk of asparagus	2	decent	
 561	skewed pregnant mushroom	0		
 562	squat ratgut	0		
 563	ghostly sonar-in-a-biscuit	0		
 564	watered-down hand-crafted shaking blinking Mad Train wine	2	EPIC	
 565	greasy hobo gloves	0		Sleaze Spell Damage: +10, Single Equip
 566	greedy bum cheek	0		Meat Drop: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
-567	pulsating green hermit script	0		
-568	moldy enchanted Double Bacon Beelzeburger	3	crappy	Effect: "Ocelot Eyes", Effect Duration: 30
-569	decent immense upside-down Lord of the Flies-sized fries	7	good	
-570	jumbo adequate pulsating Chicken Sandwich	5	good	
+567	green pulsating hermit script	0		
+568	enchanted moldy Double Bacon Beelzeburger	3	crappy	Effect: "Ocelot Eyes", Effect Duration: 30
+569	immense decent upside-down Lord of the Flies-sized fries	7	good	
+570	adequate jumbo pulsating Chicken Sandwich	5	good	
 571	wobbly Jumbo Dr. Lucifer	1	awesome	
 572	normal Children's Meal of the Damned	4	good	
 573	bite-sized rotten noodles	1	crappy	
 574	decent maroon noodles	3	good	
-575	super-sized bland green painful penne pasta	5	decent	
+575	bland super-sized green painful penne pasta	5	decent	
 576	adequate diet ravioli della hippy	1	good	
-577	fancy decent pr0n m4nic0tti	4	good	Effect: "Infernal Thirst", Effect Duration: 15
-578	special stale snack-sized Hell ramen	2	decent	Effect: "Well-preserved", Effect Duration: 10
-579	tiny tasty boring spaghetti	1	awesome	
+577	decent fancy pr0n m4nic0tti	4	good	Effect: "Infernal Thirst", Effect Duration: 15
+578	special snack-sized stale Hell ramen	2	decent	Effect: "Well-preserved", Effect Duration: 10
+579	tasty tiny boring spaghetti	1	awesome	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	rotten yellow fettucini Inconnu	3	crappy	
 584	normal spaghetti with Skullheads	3	good	
-585	gigantic decent gnocchetti di Nietzsche	7	good	
+585	decent gigantic gnocchetti di Nietzsche	7	good	
 586	Tesla ridiculously huge sword of dire peril	0		Weapon Damage: +20, MP Regen Min: 7, MP Regen Max: 10
 587	moist vacuum-sealed modified wobbly wobbly super-spiky hair gel	0		Effect: "Barking Mad", Effect Duration: 59
 588	soft echo eyedrop antidote	0		
-589	tasty immense cocoa eggshell fragment	7	awesome	
+589	immense tasty cocoa eggshell fragment	7	awesome	
 590	bland cocoa eggshell fragment	3	decent	
 591	cocoa egg	0		
 592	blinking yellow house	0		
@@ -613,7 +613,7 @@
 615	chaos butterfly	0		
 616	furry fur	0		
 617	anodized tumbling Angry Farmer candy	0		Effect: "Certainty", Effect Duration: 25
-618	cold-filtered electrified wobbly fuchsia Mick's IcyVapoHotness Rub	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 18
+618	cold-filtered electrified fuchsia wobbly Mick's IcyVapoHotness Rub	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 18
 619	skewed perfumed needle	0		Stench Resistance: +5
 620	chilled thin candle	0		Effect: "Fungal Flambé", Effect Duration: 45
 621	ghostly Warm Subject gift certificate	0		
@@ -667,19 +667,19 @@
 669	delicious snack-sized jittery ghuol guolash	2	awesome	
 670	upside-down huge savvy lihc face	0		Mysticality Percent: +20, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	blue avaricious dog trainer's grave robbing shovel	0		Experience (familiar): +1, Meat Drop: +30
-672	stale half-sized cranberries	2	decent	
+672	half-sized stale cranberries	2	decent	
 673	perfectly mixed vodka and cranberry	4	EPIC	
-674	enchanted delicious whiskey	3	awesome	Effect: "Go Get 'Em, Tiger!", Effect Duration: 35
+674	delicious enchanted whiskey	3	awesome	Effect: "Go Get 'Em, Tiger!", Effect Duration: 35
 675	supercool skull of the Bonerdagon	0		Moxie Percent: +20
 676	bouncing dragonbone belt buckle	0		
 677	maroon badass belt of the pedagogue	0		Experience: +3
 678	chest of the Bonerdagon	0		
-679	artisanal spirit-forward mirror roll in the hay	5	EPIC	
+679	spirit-forward artisanal mirror roll in the hay	5	EPIC	
 680	drinkable weak slap and tickle	2	good	
 681	tolerable slip 'n' slide	3	good	
 682	weak tolerable a sump'm sump'm	2	good	
 683	smooth horizontal tango	3	awesome	
-684	lousy triple-distilled pink pony	7	decent	
+684	triple-distilled lousy pink pony	7	decent	
 685	studded deadly Mr. Shirt of chilblains	0		Weapon Damage: +5, Damage Absorption: +80, Cold Damage: +25
 686	savvy knuckles	0		Mysticality Percent: +20
 687	liquefied energized blood of the Wereseal	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 45
@@ -717,7 +717,7 @@
 721	up-at-dawn porquoise bracelet of the cheetah	0		Initiative: +60, Adventures: +5
 722	squat smelly smartaleck's porquoise ring of temperance	0		Moxie Percent: +30, Stench Spell Damage: +10, Sleaze Resistance: +5, Single Equip
 723	stale pulsating Knoll mushroom	3	decent	
-724	massive normal blurry mushroom	9	good	
+724	normal massive blurry mushroom	9	good	
 725	upside-down one million meat pancakes	0		
 726	foul-smelling huge mirror shard	0		Stench Damage: +10
 727	hedge maze puzzle	0		
@@ -743,20 +743,20 @@
 748	gourd potion	0		
 749	snack-sized adequate warm mushroom	2	good	
 750	delicious mushroom quesadilla	3	awesome	
-751	immense spoiled cool mushroom	6	crappy	
+751	spoiled immense cool mushroom	6	crappy	
 752	flavorless cool mushroom casserole	3	decent	
 753	snack-sized stale yellow pointy mushroom	2	decent	
-754	bland super-sized blurry cream of pointy mushroom soup	5	decent	
+754	super-sized bland blurry cream of pointy mushroom soup	5	decent	
 755	normal mushroom	4	good	
-756	tiny decent skewed mushroom	1	good	
+756	decent tiny skewed mushroom	1	good	
 757	half-sized flavorless mushroom	2	decent	
-758	big rotten huge ghost cucumber	5	crappy	
+758	rotten big huge ghost cucumber	5	crappy	
 759	dill	0		
 760	upside-down vinegar	0		
-761	fuchsia shaking brine	0		
+761	shaking fuchsia brine	0		
 762	lousy especially salty dog	3	decent	
 763	ghostly pickling solution	0		
-764	stale gigantic gray spectral pickle	10	decent	
+764	gigantic stale gray spectral pickle	10	decent	
 765	red briny vinegar	0		
 766	squat ghost pickle on a stick	0		
 767	diffused cologne of contempt	0		Effect: "Human-Insect Hybrid", Effect Duration: 49
@@ -789,7 +789,7 @@
 794	enhanced anodized blinking oil of slipperiness	0		Effect: "Weapon of Mass Destruction", Effect Duration: 23
 795	perfectly mixed Acque Luride Grezze Cabernet	3	super EPIC	Last Available: "2004-10"
 796	jittery squat greasy sinister dangerous cement shoes	0		Weapon Damage: +10, Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2004-10"
-797	weak lousy rockin' wagon	2	decent	
+797	lousy weak rockin' wagon	2	decent	
 798	irresponsibly strong lousy gray ocean motion	10	decent	
 799	mediocre spirit-forward fuzzbump	5	decent	
 800	small spoiled poutine	2	crappy	
@@ -797,16 +797,16 @@
 804	decent Knoll stir-fry	3	good	
 805	moldy stir-fry	4	crappy	
 806	moldy yellow asparagus stir-fry	3	crappy	
-807	stale tiny olive stir-fry	1	decent	
+807	tiny stale olive stir-fry	1	decent	
 808	flavorless snack-sized blurry purple Knob sausage stir-fry	2	decent	
 809	yummy bat wing stir-fry	3	awesome	
 810	decent rat appendix stir-fry	3	good	
 811	stale green tofu stir-fry	4	decent	
 812	moldy twirling pr0n stir-fry	4	crappy	
-813	enchanted adequate skewed Knob shells	4	good	Effect: "New Zeal", Effect Duration: 15
-814	spoiled enchanted pulsating skewed b&auml;tzle	4	crappy	Effect: "Heart of Lavender", Effect Duration: 20
+813	adequate enchanted skewed Knob shells	4	good	Effect: "New Zeal", Effect Duration: 15
+814	spoiled enchanted skewed pulsating b&auml;tzle	4	crappy	Effect: "Heart of Lavender", Effect Duration: 20
 815	decent big yellow ratini	5	good	
-816	bland half-sized bouncing Knob stroganoff	2	decent	
+816	half-sized bland bouncing Knob stroganoff	2	decent	
 817	normal menudo ravioli	3	good	
 818	plus sign	0		
 819	yellow huge milky potion	0		
@@ -820,21 +820,21 @@
 827	huge skewed murky potion	0		
 828	baby killer bee	0		
 829	anti-anti-antidote	0		
-830	thick decent royal jelly	5	good	
+830	decent thick royal jelly	5	good	
 831	maroon small box	0		
-832	cyan huge box	0		
+832	huge cyan box	0		
 833	sizzling vorpal blade	0		Hot Damage: +10
 834	shaking slick cornuthaum of dire peril	0		Moxie: +10, Weapon Damage: +20, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	ring of aggravate monster of the brazier	0		Hot Spell Damage: +25
 836	adequate twirling mind flayer corpse	4	good	
-837	practically non-alcoholic artisanal Uovo Marcio Shiraz	1	super ultra mega turbo EPIC	Last Available: "2004-10"
+837	artisanal practically non-alcoholic Uovo Marcio Shiraz	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 838	toasty supercharged Mafia stogie	0		Maximum MP Percent: +30, Hot Damage: +5, Last Available: "2004-10"
 839	bad weak Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
 840	rosewater-soaked double-paned Mafia violin case	0		Cold Resistance: +5, Stench Resistance: +3, Last Available: "2004-10"
 841	hand-crafted blurry yellow tomato daiquiri	3	EPIC	
 842	tolerable beertini	3	good	
 843	lousy salty slug	3	decent	
-844	hand-crafted distilled spinning papaya slung	5	EPIC	
+844	distilled hand-crafted spinning papaya slung	5	EPIC	
 845	pulsating blue foul-smelling MAHI fez	0		Stench Damage: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	huge hypodermic needle	0		Familiar Weight: +5
@@ -843,7 +843,7 @@
 851	prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
 853	squat blundarrrbus	0		Familiar Weight: +5
-854	lime green spinning sucky decal	0		Familiar Weight: +5
+854	spinning lime green sucky decal	0		Familiar Weight: +5
 855	huge balloon knife	0		Familiar Weight: +5
 856	shaking lime green shock collar	0		
 857	wobbly moonglasses	0		
@@ -878,10 +878,10 @@
 887	shaking leaf	0		
 888	maple leaf	0		
 889	upside-down wicked balaclava	0		Spell Damage: +5, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	bite-sized decent balaclava baklava	1	good	
+890	decent bite-sized balaclava baklava	1	good	
 891	Jack Frost's Warehouse 23 bling	0		Cold Spell Damage: +50
 892	prompt MacGyver's thinker's bugbear-smiting sword	0		Mysticality: +10, Maximum MP: +100, Adventures: +3
-893	practically non-alcoholic tolerable bouncing lumbering jack	1	good	
+893	tolerable practically non-alcoholic bouncing lumbering jack	1	good	
 894	shaking Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	spinning Ms. Accessory of the boozehound	0		Booze Drop: +100, Softcore Only
 896	tumbling Temple Grandin's energetic Mr. Accessory Jr.	0		Maximum MP Percent: +20, Familiar Weight: +7, Softcore Only
@@ -891,7 +891,7 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	ghostly espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	practically non-alcoholic drinkable Spasmi Dolorosi Del Rene Champagne	1	good	Last Available: "2004-10"
+903	drinkable practically non-alcoholic Spasmi Dolorosi Del Rene Champagne	1	good	Last Available: "2004-10"
 904	Van der Graaf steel-toed fortified school Mafia knickerbockers	0		Damage Absorption: +60, Damage Reduction: 9, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	anodized pickled Yummy Tummy bean	0		Effect: "The Real Deal", Effect Duration: 25
 906	double-quantum electrified nitrogenated Rock Pops	0		Effect: "Berry Critical", Effect Duration: 33
@@ -914,14 +914,14 @@
 923	broken cellular phone	0		Last Available: "2004-01"
 924	tumbling crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
-926	diffused mirror tumbling Hawking's Elixir of Brilliance	0		Effect: "Electrolit Up", Effect Duration: 64
-927	perfectly mixed watered-down Ferita Del Petto Zinfandel	2	EPIC	Last Available: "2006-12"
+926	diffused tumbling mirror Hawking's Elixir of Brilliance	0		Effect: "Electrolit Up", Effect Duration: 64
+927	watered-down perfectly mixed Ferita Del Petto Zinfandel	2	EPIC	Last Available: "2006-12"
 928	spinning fuzzy bracelets of doom	0		Spooky Spell Damage: +50
 929	arse-shooting crossbow of the brazier	0		Hot Spell Damage: +25
 931	drinkable spiced rum	3	good	
 932	lousy eggnog	3	decent	
 933	bland candy cane	3	decent	
-934	normal diet upside-down gingerbread bugbear	1	good	
+934	diet normal upside-down gingerbread bugbear	1	good	
 935	nasty imitation nice watch	0		Stench Damage: +5, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -935,7 +935,7 @@
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	jittery skewered cherry	0		Last Available: "2004-12"
-948	watered-down acceptable ghostly martini	2	good	Last Available: "2004-12"
+948	acceptable watered-down ghostly martini	2	good	Last Available: "2004-12"
 949	smooth weak fancy tumbling grogtini	2	awesome	Effect: "Hopped Up on Goofballs", Effect Duration: 20, Last Available: "2004-12"
 950	drinkable cherry bomb	4	good	Last Available: "2004-12"
 951	gray extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -943,9 +943,9 @@
 953	yellow penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	mirror Socratic fez of etymology	0		Experience (Mysticality): +1, Familiar Effect: "1xLep, cap 30"
-956	jumbo rotten carob chunk noodles	5	crappy	
-957	moldy small chorizo brownies	2	crappy	
-958	enchanted adequate chocolate and tomato pizza	3	good	Effect: "Chief Executive Optimism", Effect Duration: 15
+956	rotten jumbo carob chunk noodles	5	crappy	
+957	small moldy chorizo brownies	2	crappy	
+958	adequate enchanted chocolate and tomato pizza	3	good	Effect: "Chief Executive Optimism", Effect Duration: 15
 959	flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -982,13 +982,13 @@
 992	skewed plastic Jarlsberg of the wise owl of vim and vigor of the brazier	0		Mysticality: +20, Maximum HP Percent: +50, Hot Spell Damage: +25
 993	zippy curative plastic Sneaky Pete of the detective	0		Item Drop: +20, Initiative: +20, HP Regen Min: 3, HP Regen Max: 5
 994	purple Socratic plastic Susie	0		Experience (Mysticality): +1
-995	decent super-sized Lucky Surprise Egg	5	good	
+995	super-sized decent Lucky Surprise Egg	5	good	
 998	maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	wobbly maid head	0		
 1000	Meat maid	0		
 1002	narrow Xlyinia's notebook of dire peril	0		Weapon Damage: +20
 1003	soda water	0		
-1004	drinkable extra-dry spinning bottle of tequila	5	good	
+1004	extra-dry drinkable spinning bottle of tequila	5	good	
 1005	irresponsibly strong smooth olive boxed wine	10	awesome	
 1006	spoiled snack-sized cherry	2	crappy	
 1007	blinking asbestos-lined coconut shell	0		Hot Resistance: +5, Familiar Effect: "1xFairy, cap 7"
@@ -996,8 +996,8 @@
 1009	distilled smooth vodka martini	5	awesome	
 1010	delicious wobbly whiskey and soda	4	awesome	
 1011	acceptable monkey wrench	3	good	
-1012	lousy fancy watered-down tequila sunrise	2	decent	Effect: "Weepy, Creepy", Effect Duration: 50
-1013	delicious practically non-alcoholic enchanted huge margarita	1	awesome	Effect: "Salamander In Your Stomach", Effect Duration: 5
+1012	fancy watered-down lousy tequila sunrise	2	decent	Effect: "Weepy, Creepy", Effect Duration: 50
+1013	enchanted practically non-alcoholic delicious huge margarita	1	awesome	Effect: "Salamander In Your Stomach", Effect Duration: 5
 1014	mediocre strawberry wine	4	decent	
 1015	artisanal wine spritzer	3	EPIC	
 1016	bad watered-down perpendicular hula	2	decent	
@@ -1007,7 +1007,7 @@
 1020	tolerable old-fashioned	4	good	
 1021	irresponsibly strong acceptable tequila with training wheels	6	good	
 1022	artisanal blurry sangria	4	EPIC	
-1023	watered-down drinkable lime green vesper	2	good	Last Available: "2004-12"
+1023	drinkable watered-down lime green vesper	2	good	Last Available: "2004-12"
 1024	smooth blinking bodyslam	3	awesome	Last Available: "2004-12"
 1025	drinkable sangria del diablo	3	good	Last Available: "2004-12"
 1026	jittery Valentine	0		Free Pull
@@ -1060,13 +1060,13 @@
 1074	powdered mirror olive off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	vaporized yellow oyster egg	1		Effect: "Can't Be a Chooser", Effect Duration: 35
-1077	modified blue skewed oyster egg	1		Effect: "The Halls of Muscularity", Effect Duration: 45
+1077	modified skewed blue oyster egg	1		Effect: "The Halls of Muscularity", Effect Duration: 45
 1078	distilled oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
 1081	blinking emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
-1083	green upside-down twirling personal raindrop	0		Free Pull, Last Available: "2005-04"
+1083	twirling upside-down green personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	narrow rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	clockwork widget	0		
 1086	clockwork thingamajig	0		
@@ -1104,10 +1104,10 @@
 1118	pregnant mushroom	0		
 1119	pregnant mushroom	0		
 1120	pregnant mushroom	0		
-1121	bouncing mirror inexplicably rock	0		
+1121	mirror bouncing inexplicably rock	0		
 1122	bouncing fairy gravy	0		
 1123	experienced halfberd	0		Experience: +2
-1124	blurry red small glove	0		
+1124	red blurry small glove	0		
 1125	careful dance instructor's glove of the sewer	0		Experience Percent (Moxie): +10, Monster Level: -10, Stench Damage: +25
 1126	flame-wreathed toothpick	0		Hot Spell Damage: +10, Single Equip
 1127	savvy ninja sword	0		Mysticality Percent: +20
@@ -1124,19 +1124,19 @@
 1138	mushroom fermenting solution	0		
 1139	aged mushroom wine	3	awesome	
 1140	lousy blinking icy mushroom wine	4	decent	
-1141	weak bad mushroom wine	2	decent	
-1142	practically non-alcoholic acceptable pointy mushroom wine	1	good	
-1143	tolerable fancy purple mirror flat mushroom wine	3	good	Effect: "Berry Statistical", Effect Duration: 10
+1141	bad weak mushroom wine	2	decent	
+1142	acceptable practically non-alcoholic pointy mushroom wine	1	good	
+1143	fancy tolerable mirror purple flat mushroom wine	3	good	Effect: "Berry Statistical", Effect Duration: 10
 1144	hand-crafted practically non-alcoholic blue cool mushroom wine	1	super ultra mega turbo EPIC	
 1145	artisanal practically non-alcoholic blinking knob mushroom wine	1	super ultra mega turbo EPIC	
-1146	irresponsibly strong artisanal knoll mushroom wine	6	EPIC	
+1146	artisanal irresponsibly strong knoll mushroom wine	6	EPIC	
 1147	drinkable weak gray mushroom wine	2	good	
-1148	drinkable watered-down shot of flower schnapps	2	good	
+1148	watered-down drinkable shot of flower schnapps	2	good	
 1149	small adequate flower petal pie	2	good	
-1150	aged enchanted irresponsibly strong bottle of single-barrel whiskey	9	awesome	Effect: "Thunderspell", Effect Duration: 15
+1150	irresponsibly strong enchanted aged bottle of single-barrel whiskey	9	awesome	Effect: "Thunderspell", Effect Duration: 15
 1151	twirling crafty discarded plastic fork of terror	0		Maximum MP: +10, Spooky Spell Damage: +10
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	normal fancy massive Retenez L'Herbe Pat&eacute;	8	good	Effect: "The Grass...  Is Blue...", Effect Duration: 15
+1153	fancy normal massive Retenez L'Herbe Pat&eacute;	8	good	Effect: "The Grass...  Is Blue...", Effect Duration: 15
 1154	dried gray Breathetastic&trade; Premium Canned Air	1	decent	Effect: "Rage of the Reindeer", Effect Duration: 45
 1155	letter from King Ralph XI	0		
 1157	Temple Grandin's wholeberd	0		Familiar Weight: +7
@@ -1186,13 +1186,13 @@
 1201	adequate mirror urinal cake	3	good	
 1202	stale Happy Birthday, Claude! cake	4	decent	
 1203	stale narrow personalized birthday cake	4	decent	
-1204	rotten special bouncing three-tiered wedding cake	4	crappy	Effect: "Almost Cool", Effect Duration: 15
+1204	special rotten bouncing three-tiered wedding cake	4	crappy	Effect: "Almost Cool", Effect Duration: 15
 1205	adequate babycakes	3	good	
 1206	spoiled small velvet cake	2	crappy	
 1207	adequate congratulatory cake	3	good	
 1208	toothsome angel-food cake	4	awesome	
 1209	bland devil's-food cake	4	decent	
-1210	huge flavorless fancy lime green birthday party jellybean cheesecake	6	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 35
+1210	fancy flavorless huge lime green birthday party jellybean cheesecake	6	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 35
 1211	balloon	0		
 1212	blurry balloon	0		
 1213	bouncing heart-shaped balloon	0		
@@ -1234,8 +1234,8 @@
 1250	healthy Socratic Boss Bat bling	0		Experience (Mysticality): +1, Maximum HP Percent: +20
 1251	delicious blurry blurry Knob shroomkabob	3	awesome	
 1252	flavorless fancy tumbling shroomkabob	4	decent	Effect: "Nigh-Invincible", Effect Duration: 10
-1253	huge jittery blurry pile of jumping beans	0		
-1254	small normal jumping bean burrito	2	good	
+1253	huge blurry jittery pile of jumping beans	0		
+1254	normal small jumping bean burrito	2	good	
 1255	moldy half-sized jumping bean burrito	2	crappy	
 1256	decent insanely jumping bean burrito	3	good	
 1257	normal low-calorie rat scrapple	1	good	
@@ -1253,7 +1253,7 @@
 1269	ebony wand	0		
 1270	hexagonal wand	0		
 1271	aluminum wand	0		
-1272	spinning maroon blinking marble wand	0		
+1272	blinking spinning maroon marble wand	0		
 1273	forbidden magic lamp	0		Spell Damage Percent: +50
 1274	boiled huge olive Medicinal Herb's medicinal herbs	1		Effect: "Squatting and Thrusting", Effect Duration: 20
 1275	ghostly Tesla basic meat skirt	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
@@ -1289,8 +1289,8 @@
 1305	bouncing makeup kit	0		Familiar Weight: +15
 1306	Jim Carey's hardy traffic cone	0		Maximum HP: +50, Monster Level: +25, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	skewed calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
-1308	red blurry unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
-1309	narrow olive attention spanner	0		Familiar Weight: +5
+1308	blurry red unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
+1309	olive narrow attention spanner	0		Familiar Weight: +5
 1310	narrow funky fez	0		Familiar Weight: +5
 1311	ghostly comfy blanket	0		Last Available: "2005-10"
 1312	horrifying Baron von Ratsworth's monocle	0		Spooky Damage: +25, Single Equip
@@ -1332,7 +1332,7 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	nasty pinky ring	0		Stench Damage: +5, Single Equip
-1352	weak hand-crafted redrum	2	EPIC	
+1352	hand-crafted weak redrum	2	EPIC	
 1353	fuchsia ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	tiny rotten bowl of oriole's nest soup	1	crappy	
@@ -1365,7 +1365,7 @@
 1383	length of string	0		
 1384	googly eye	0		
 1385	stuffing	0		
-1386	green huge felt	0		
+1386	huge green felt	0		
 1387	block	0		
 1388	toy wheel	0		
 1389	pulsating yo-yo	0		Last Available: "2010-12"
@@ -1374,7 +1374,7 @@
 1392	kite	0		Last Available: "2005-12"
 1393	pet rock	0		Last Available: "2005-12"
 1394	mirror doppelshifter	0		Last Available: "2005-12"
-1395	pulsating huge teddy bear	0		Last Available: "2005-12"
+1395	huge pulsating teddy bear	0		Last Available: "2005-12"
 1396	rosewater-soaked Annie Oakley's duck-on-a-string	0		Critical Hit Percent: +20, Stench Resistance: +3, Last Available: "2005-12"
 1397	mirror toy soldier	0		Last Available: "2005-12"
 1398	doll house	0		Last Available: "2005-12"
@@ -1385,7 +1385,7 @@
 1403	squat twirling can of fake snow	0		Item Drop: +5, Last Available: "2005-12"
 1404	squat hardy colored-light &quot;necklace&quot;	0		Maximum HP: +50, Last Available: "2005-12"
 1405	spinning sizzling tree skirt	0		Hot Damage: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	big bland wreath-shaped Crimbo cookie	5	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	bland big wreath-shaped Crimbo cookie	5	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	bland bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	flavorless tree-shaped Crimbo cookie	3	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Annie Oakley's Unionize The Elves sign	0		Critical Hit Percent: +20, Last Available: "2005-12"
@@ -1395,7 +1395,7 @@
 1413	vacuum-sealed warmed snowcone	0		Effect: "White-boy Angst", Effect Duration: 55, Last Available: "2006-01"
 1414	quantum maroon shaking snowcone	0		Effect: "The Power of LOV", Effect Duration: 14, Last Available: "2006-01"
 1415	magnetized quadruple-colloidal tumbling snowcone	0		Effect: "Human-Plant Hybrid", Effect Duration: 45, Last Available: "2006-01"
-1416	altered Vulcanized blurry twirling snowcone	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 58, Last Available: "2006-01"
+1416	altered Vulcanized twirling blurry snowcone	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 58, Last Available: "2006-01"
 1417	dry dry pulsating snowcone	0		Effect: "Eyes Wide Propped", Effect Duration: 69, Last Available: "2006-01"
 1418	narrow Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	bouncing teddy bear sewing kit	0		Last Available: "2006-01"
@@ -1424,7 +1424,7 @@
 1442	pickled triple-frozen stench powder	0		Effect: "Whole Latte Love", Effect Duration: 60
 1443	aerosolized warmed squat sleaze powder	0		Effect: "Toast Tea", Effect Duration: 53
 1444	pressed denatured twinkly nuggets	0		Effect: "The Magic of Sharing", Effect Duration: 52
-1445	quadruple-wet upside-down blinking hot nuggets	0		Effect: "Retrograde Relaxation", Effect Duration: 65
+1445	quadruple-wet blinking upside-down hot nuggets	0		Effect: "Retrograde Relaxation", Effect Duration: 65
 1446	liquefied improved nuggets	0		Effect: "Educated (Sorta)", Effect Duration: 48
 1447	extra-tarnished magnetized denatured huge nuggets	0		Effect: "Christmessy", Effect Duration: 11
 1448	super-vacuum-sealed ionized stench nuggets	0		Effect: "Abominably Slippery", Effect Duration: 33
@@ -1434,10 +1434,10 @@
 1452	powdered red wad	1		
 1453	boiled shaking blinking wad	1		Effect: "Inappropriate Spirit", Effect Duration: 35
 1454	twisted stench wad	1		
-1455	dried red twirling jittery sleaze wad	1		Effect: "Make Meat FA$T!", Effect Duration: 30
+1455	dried twirling jittery red sleaze wad	1		Effect: "Make Meat FA$T!", Effect Duration: 30
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	delicious massive Valentine's Day cake	9	awesome	
+1458	massive delicious Valentine's Day cake	9	awesome	
 1459	squat arrow'd heart balloon	0		
 1460	jittery velvet box	0		
 1461	squashed frog	0		
@@ -1475,7 +1475,7 @@
 1493	spinning razor-sharp ridiculously overelaborate ninja weapon of doom	0		Weapon Damage Percent: +25, Spooky Spell Damage: +50
 1494	adjusted sugar-coated pine cone	0		Effect: "Berry Experiential", Effect Duration: 51, Last Available: "2020-09"
 1495	narrow forbidden experienced traffic cone	0		Experience: +2, Spell Damage Percent: +50, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	weak bad gloomy mushroom wine	2	decent	
+1496	bad weak gloomy mushroom wine	2	decent	
 1497	lousy purple mushroom wine	4	decent	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1485,10 +1485,10 @@
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	electrified skewed snowcone	0		Effect: "Hypercubed", Effect Duration: 28, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	weak lousy calle de miel with a fly in it	2	decent	Last Available: "2006-04"
+1506	lousy weak calle de miel with a fly in it	2	decent	Last Available: "2006-04"
 1507	special artisanal rockin' wagon with a fly in it	4	EPIC	Effect: "Jittery", Effect Duration: 5, Last Available: "2006-04"
 1508	enchanted mediocre perpendicular hula with a fly in it	4	decent	Effect: "Boletus Swoletus", Effect Duration: 15, Last Available: "2006-04"
-1509	perfectly mixed boozy huge slap and tickle with a fly in it	5	EPIC	Last Available: "2006-04"
+1509	boozy perfectly mixed huge slap and tickle with a fly in it	5	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	family-friendly fake hand	0		Sleaze Resistance: +1, Last Available: "2006-04"
 1512	denatured tumbling Knob Goblin pet-buffing spray	1		
@@ -1532,7 +1532,7 @@
 1552	mediocre bottle of Definit	3	decent	
 1553	mediocre wobbly jittery bottle of Calcutta Emerald	4	decent	
 1554	artisanal blinking bottle of Lieutenant Freeman	3	EPIC	
-1555	triple-distilled delicious bottle of Jorge Sinsonte	6	awesome	
+1555	delicious triple-distilled bottle of Jorge Sinsonte	6	awesome	
 1556	mediocre boxed champagne	3	decent	
 1557	miniature normal ghostly kumquat	2	good	
 1558	stale tangerine	3	decent	
@@ -1540,12 +1540,12 @@
 1560	snack-sized normal cocktail onion	2	good	
 1561	normal raspberry	3	good	
 1562	bland special kiwi	3	decent	Effect: "You Drank Fish Wine", Effect Duration: 50
-1563	enchanted acceptable fortified whiskey bittersweet	5	good	Effect: "Slimy Hands", Effect Duration: 25
+1563	fortified enchanted acceptable whiskey bittersweet	5	good	Effect: "Slimy Hands", Effect Duration: 25
 1564	artisanal mimosette	3	EPIC	
 1565	hand-crafted extra-dry tequila sunset	5	EPIC	
 1566	weak acceptable zmobie	2	good	Wiki Name: "Zmobie (drink)"
-1567	weak mediocre gin and tonic	2	decent	
-1568	triple-distilled tolerable ghostly vodka and tonic	8	good	
+1567	mediocre weak gin and tonic	2	decent	
+1568	tolerable triple-distilled ghostly vodka and tonic	8	good	
 1569	hand-crafted pulsating vodka gibson	3	EPIC	
 1570	bad gibson	3	decent	
 1571	fancy drinkable parisian cathouse	4	good	Effect: "It Tickles!  It Tickles!", Effect Duration: 5
@@ -1554,14 +1554,14 @@
 1574	weak smooth teqiwila	2	awesome	
 1575	lousy weak Divine	2	decent	
 1576	triple-distilled drinkable Gordon Bennett	10	good	
-1577	watered-down lousy tangarita	2	decent	
+1577	lousy watered-down tangarita	2	decent	
 1578	lousy mandarina colada	4	decent	
-1579	fancy practically non-alcoholic smooth gimlet	1	awesome	Effect: "One For Tea", Effect Duration: 10
+1579	smooth practically non-alcoholic fancy gimlet	1	awesome	Effect: "One For Tea", Effect Duration: 10
 1580	perfectly mixed boozy skewed brick road	5	EPIC	
-1581	smooth practically non-alcoholic vodka stratocaster	1	awesome	
+1581	practically non-alcoholic smooth vodka stratocaster	1	awesome	
 1582	lousy ghostly Neuromancer	4	decent	
 1583	weak perfectly mixed maroon prussian cathouse	2	super ultra EPIC	
-1584	spirit-forward smooth Mae West	5	awesome	
+1584	smooth spirit-forward Mae West	5	awesome	
 1585	acceptable distilled Mon Tiki	5	good	
 1586	bad teqiwila slammer	3	decent	
 1587	decent Knob lo mein	4	good	
@@ -1570,14 +1570,14 @@
 1590	spoiled immense narrow lo mein	10	crappy	
 1591	stale olive lo mein	4	decent	
 1592	adequate huge hot hi mein	3	good	
-1593	tiny toothsome mirror hi mein	1	awesome	
-1594	tiny bland hi mein	1	decent	
+1593	toothsome tiny mirror hi mein	1	awesome	
+1594	bland tiny hi mein	1	decent	
 1595	snack-sized flavorless hi mein	2	decent	
-1596	super-sized rotten sleazy hi mein	5	crappy	
+1596	rotten super-sized sleazy hi mein	5	crappy	
 1597	crafty Junior LAAAAME merit badge	0		Maximum MP: +10, Last Available: "2006-05"
 1598	spinning pulsating supercool Senior LAAAAME merit badge	0		Moxie Percent: +20, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	fortified bad tangarita with a fly in it	5	decent	
+1600	bad fortified tangarita with a fly in it	5	decent	
 1601	artisanal skewed mandarina colada with a fly in it	3	EPIC	
 1602	smooth weak prussian cathouse with a fly in it	2	awesome	
 1603	mediocre upside-down Mae West with a fly in it	4	decent	
@@ -1596,7 +1596,7 @@
 1616	red supercool Cerebral Culottes	0		Moxie Percent: +20, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	mirror bouncing asbestos-lined educational Cerebral Crossbow of the ox	0		Muscle: +20, Experience: +1, Hot Resistance: +5, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
-1619	upside-down green munchies pill	0		Last Available: "2006-06"
+1619	green upside-down munchies pill	0		Last Available: "2006-06"
 1620	homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
 1622	liquefied astral mushroom	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 27, Last Available: "2006-06"
@@ -1610,12 +1610,12 @@
 1630	scorching pixel shield	0		Hot Damage: +25, Damage Reduction: 3
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
-1633	pulsating huge Spanish fly	0		
+1633	huge pulsating Spanish fly	0		
 1634	acceptable around the world	3	good	
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	dry blurry lotion of hotness	0		Effect: "Flame-Retardant Trousers", Effect Duration: 67
-1638	double-modified magnetized huge fuchsia lotion of coldness	0		Effect: "Lit Up", Effect Duration: 64
+1638	double-modified magnetized fuchsia huge lotion of coldness	0		Effect: "Lit Up", Effect Duration: 64
 1639	alkaline aerosolized lotion of spookiness	0		Effect: "Angry like the Wolf", Effect Duration: 27
 1640	pressed twirling lotion of stench	0		Effect: "Bilious Brawn", Effect Duration: 45
 1641	deionized tumbling lotion of sleaziness	0		Effect: "Sausage Festive", Effect Duration: 61
@@ -1674,10 +1674,10 @@
 1694	aerosolized denatured Frogade	0		Effect: "Stinking Cloud", Effect Duration: 55
 1695	corrupted vacuum-sealed pulsating skewed papotion of papower	0		Effect: "Bestial Sympathy", Effect Duration: 39
 1696	tasty royal jelly taco	4	awesome	
-1697	special rotten gigantic tofu taco	6	crappy	Effect: "Tingly Wrists", Effect Duration: 40
+1697	special gigantic rotten tofu taco	6	crappy	Effect: "Tingly Wrists", Effect Duration: 40
 1698	miniature rotten mirror jumping bean taco	2	crappy	
 1699	adequate catgut taco	4	good	
-1700	jumbo flavorless green goat cheese taco	5	decent	
+1700	flavorless jumbo green goat cheese taco	5	decent	
 1701	small toothsome pr0n taco	2	awesome	
 1702	diffused alphabet gum	0		Effect: "Crud&eacute;", Effect Duration: 11
 1703	pulsating Comma Chameleon egg	0		Free Pull
@@ -1745,12 +1745,12 @@
 1766	huge Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	super-sized moldy fricasseed brains	5	crappy	
+1769	moldy super-sized fricasseed brains	5	crappy	
 1770	stale brains casserole	3	decent	
 1771	dog trainer's butcherknife	0		Experience (familiar): +1
 1772	jittery fortified corn holder	0		Damage Absorption: +60
 1773	ribald eggbeater	0		Sleaze Damage: +10
-1774	tolerable enchanted weak upside-down bottle of popskull	2	good	Effect: "Mayeaugh", Effect Duration: 35
+1774	tolerable weak enchanted upside-down bottle of popskull	2	good	Effect: "Mayeaugh", Effect Duration: 35
 1775	wobbly vibrating dishrag	0		Maximum MP Percent: +10
 1776	stale olive stale baguette	4	decent	
 1777	blinking leftovers of indeterminate origin	0		
@@ -1759,7 +1759,7 @@
 1780	narrow ram stick of the sweet-tooth	0		Candy Drop: +100
 1781	forbidden enchantlers	0		Spell Damage Percent: +50, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	green shaking sharpshooter's arcane researcher's ram-battering staff	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +10
-1783	adequate half-sized crazy Turkish delight	2	good	
+1783	half-sized adequate crazy Turkish delight	2	good	
 1784	Da Vinci's Snow Queen Crown of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	inspector's Rosewater's ga-ga radio of the businessman	0		Mysticality Percent: +30, Item Drop: +15, Meat Drop: +50
 1786	spinning six pack of Mountain Stream	0		
@@ -1777,22 +1777,22 @@
 1798	pile of animal bones	0		
 1799	pulsating animal skull	0		
 1800	blinking animal cranium	0		
-1801	squat shaking skewed animal jawbone	0		
+1801	shaking squat skewed animal jawbone	0		
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	mirror fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
-1808	wobbly huge seventh cervical vertebra	0		
-1809	mirror squat first thoracic vertebra	0		
+1808	huge wobbly seventh cervical vertebra	0		
+1809	squat mirror first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
 1811	squat third thoracic vertebra	0		
 1812	upside-down fourth thoracic vertebra	0		
-1813	green shaking fifth thoracic vertebra	0		
+1813	shaking green fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	pulsating seventh thoracic vertebra	0		
-1816	blue skewed eighth thoracic vertebra	0		
+1816	skewed blue eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	maroon tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
@@ -1842,16 +1842,16 @@
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
-1866	jittery cyan left clavicle	0		
+1866	cyan jittery left clavicle	0		
 1867	right clavicle	0		
 1868	left humerus	0		
-1869	huge yellow right humerus	0		
+1869	yellow huge right humerus	0		
 1870	left radius	0		
 1871	spinning right radius	0		
-1872	mirror maroon left ulna	0		
+1872	maroon mirror left ulna	0		
 1873	maroon right ulna	0		
 1874	left femur	0		
-1875	teal blinking right femur	0		
+1875	blinking teal right femur	0		
 1876	wobbly left tibia	0		
 1877	right tibia	0		
 1878	left fibula	0		
@@ -1874,7 +1874,7 @@
 1895	left fourth rear claw	0		
 1896	teal right first rear claw	0		
 1897	right second rear claw	0		
-1898	olive skewed right third rear claw	0		
+1898	skewed olive right third rear claw	0		
 1899	shaking right fourth rear claw	0		
 1900	chaotic 1-ball	0		Spell Critical Percent: +10
 1901	toasty beefcake's 2-ball	0		Muscle: +25, Hot Damage: +5
@@ -1925,12 +1925,12 @@
 1948	blurry censurious Rosewater's tap shoes	0		Mysticality Percent: +30, Sleaze Resistance: +3, Single Equip
 1949	small tasty Manetwich	2	awesome	
 1950	bottle of Vangoghbitussin	0		
-1951	lousy practically non-alcoholic bottle of Pinot Renoir	1	decent	
-1952	toothsome half-sized desiccated apricot	2	awesome	
-1953	practically non-alcoholic artisanal flute of flat champagne	1	EPIC	
+1951	practically non-alcoholic lousy bottle of Pinot Renoir	1	decent	
+1952	half-sized toothsome desiccated apricot	2	awesome	
+1953	artisanal practically non-alcoholic flute of flat champagne	1	EPIC	
 1954	bland dehydrated caviar	4	decent	
 1955	teal styrofoam peanuts	0		
-1956	artisanal fancy distilled olive snifter of thoroughly aged brandy	5	EPIC	Effect: "Rotten Memories", Effect Duration: 10
+1956	fancy artisanal distilled olive snifter of thoroughly aged brandy	5	EPIC	Effect: "Rotten Memories", Effect Duration: 10
 1957	quill pen	0		
 1958	inkwell	0		
 1959	gray tattered scrap of paper	0		
@@ -1950,7 +1950,7 @@
 1973	bouncing half of a memo	0		
 1974	upside-down cocoabo	0		
 1975	huge baby gravy fairy	0		
-1976	bouncing ghostly gravy fairy	0		
+1976	ghostly bouncing gravy fairy	0		
 1977	gravy fairy	0		
 1978	fuchsia gravy fairy	0		
 1979	gravy fairy	0		
@@ -1991,17 +1991,17 @@
 2014	Inndya trading card	0		
 2015	Kitty the Zmobie Basher trading card	0		
 2016	diamond necklace	0		
-2017	tumbling teal spade necklace	0		
+2017	teal tumbling spade necklace	0		
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
 2020	normal upside-down cherry pie	3	good	
 2021	super-sized moldy blue strawberry pie	5	crappy	
 2022	tasty spinning lemon meringue pie	3	awesome	
 2023	fancy Genalen&trade; Bottle	1	decent	Effect: "Human-Humanoid Hybrid", Effect Duration: 15
-2024	fancy decent mixed wildflower greens	3	good	Effect: "Analog Drunk", Effect Duration: 40
+2024	decent fancy mixed wildflower greens	3	good	Effect: "Analog Drunk", Effect Duration: 40
 2025	flavorless handful of walnuts	4	decent	
-2026	delicious super-sized nutty organic salad	5	awesome	
-2027	bite-sized moldy green super salad	1	crappy	
+2026	super-sized delicious nutty organic salad	5	awesome	
+2027	moldy bite-sized green super salad	1	crappy	
 2028	thick adequate cyan tofu wonton	5	good	
 2029	gray hippy protest button	0		Single Equip
 2030	Lockenstock&trade; sandals of Tarzan of the glutton	0		Experience (Muscle): +3, Food Drop: +100, Single Equip
@@ -2011,7 +2011,7 @@
 2034	wobbly ghostly stylish wicker shield	0		Moxie: +25, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
 2036	concentrated pickled twirling radium-flavored potato chips	0		Effect: "Human-Orc Hybrid", Effect Duration: 23
-2037	super-tarnished flattened extra-colloidal jittery blue ghostly wintergreen-flavored potato chips	0		Effect: "Always be Collecting", Effect Duration: 50
+2037	super-tarnished flattened extra-colloidal jittery ghostly blue wintergreen-flavored potato chips	0		Effect: "Always be Collecting", Effect Duration: 50
 2038	corrupted ennui-flavored potato chips	0		Effect: "Witch Breaded", Effect Duration: 50
 2039	jittery x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
@@ -2022,7 +2022,7 @@
 2045	flavorless brain-meltingly-hot chicken wings	4	decent	
 2046	decent jumbo frat brats	5	good	
 2047	yummy green knob ka-bobs	3	awesome	
-2049	drinkable irresponsibly strong can of Swiller	8	good	
+2049	irresponsibly strong drinkable can of Swiller	8	good	
 2050	blinking olive broken wings	0		
 2051	sunken eyes	0		
 2052	ghostly reassembled blackbird	0		
@@ -2061,13 +2061,13 @@
 2085	altered green bottle of ultravitamins	1		
 2086	vaporized bottle of cough syrup	1		
 2087	modified twirling tube of hair oil	1		Effect: "Make Meat FA$T!", Effect Duration: 40
-2088	electrified dry dry pulsating maroon Daffy Taffy	0		Effect: "Raging Animal", Effect Duration: 31
+2088	electrified dry dry maroon pulsating Daffy Taffy	0		Effect: "Raging Animal", Effect Duration: 31
 2089	cyan Crimboween memo	0		Last Available: "2006-10"
 2090	family-friendly resourceful vibrating smooth pilgrim shield of Flo-Jo	0		Moxie: +15, Maximum MP Percent: +10, Maximum MP: +50, Sleaze Resistance: +1, Initiative: +100, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	blurry bath salts	0		
 2092	hand mirror	0		
 2093	green savvy hors d'oeuvre tray	0		Mysticality Percent: +20, Damage Reduction: 5
-2094	super-sized adequate ballroom blintz	5	good	
+2094	adequate super-sized ballroom blintz	5	good	
 2095	towel	0		
 2096	twisted pulsating guy made of bee pollen	1		
 2097	blurry 17-ball of the sweet-tooth	0		Candy Drop: +100
@@ -2091,7 +2091,7 @@
 2115	stanky prehistoric spear	0		Stench Spell Damage: +25, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
 2117	bouncing prompt fire of Tarzan	0		Experience (Muscle): +3, Adventures: +3, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
-2118	purple upside-down leaf tube	0		Last Available: "2006-12"
+2118	upside-down purple leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	Grateful Undead T-shirt of Calamity Jane	0		Critical Hit Percent: +15
 2121	blurry huge rosy-cheeked ASCII shirt	0		Maximum HP Percent: +30
@@ -2119,11 +2119,11 @@
 2144	evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
 2146	evil teddy bear	0		Last Available: "2006-12"
-2147	skewed tumbling evil teddy bear sewing kit	0		
+2147	tumbling skewed evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	tasty frank	4	awesome	Last Available: "2011-12"
 2150	miniature stale plate of franks and beans	2	decent	Last Available: "2011-12"
-2151	delicious spirit-forward spinning mirror shot of blackberry schnapps	5	awesome	
+2151	spirit-forward delicious spinning mirror shot of blackberry schnapps	5	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	maroon carbon nanotube frame	0		Last Available: "2011-12"
 2154	skewed ion grid	0		Last Available: "2011-12"
@@ -2134,12 +2134,12 @@
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
-2162	blinking upside-down reverse-oscillating klystron	0		Last Available: "2011-12"
+2162	upside-down blinking reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	mirror red recursive spline reticulator	0		Last Available: "2011-12"
 2165	skewed atomic vector plotter	0		Last Available: "2011-12"
 2166	pulsating ion-pulse modulation stabilizer	0		Last Available: "2011-12"
-2167	jittery shaking hyperbolic plasma focuser	0		Last Available: "2011-12"
+2167	shaking jittery hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	narrow inspector's sinister toy ray gun	0		Spell Damage: +10, Item Drop: +15, Last Available: "2006-12"
 2169	blue mirror sharpshooter's crafty toy space helmet	0		Maximum MP: +10, Critical Hit Percent: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
@@ -2161,16 +2161,16 @@
 2186	unlit birthday cake	0		
 2187	huge lit birthday cake	0		
 2188	flask of peppermint oil	1	awesome	Last Available: "2006-12"
-2189	distilled perfectly mixed green flask of peppermint schnapps	5	EPIC	Last Available: "2006-12"
+2189	perfectly mixed distilled green flask of peppermint schnapps	5	EPIC	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
-2191	tumbling olive book of carols	0		Last Available: "2006-12"
+2191	olive tumbling book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	small normal candy stake	2	good	Last Available: "2006-12"
 2194	smooth eggnog	3	awesome	Last Available: "2006-12"
-2195	small decent shaking unspeakable fruitcake	2	good	Last Available: "2006-12"
+2195	decent small shaking unspeakable fruitcake	2	good	Last Available: "2006-12"
 2196	moldy gingerbread horror	3	crappy	Last Available: "2006-12"
 2197	frozen moist but probably evil chocolate	0		Effect: "Salt Rockin'", Effect Duration: 12, Last Available: "2006-12"
-2198	half-sized spoiled bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	spoiled half-sized bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	rotten skull-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	stale squat tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	narrow spinning deadly plastic gift-wrapping vampire	0		Weapon Damage: +5, Last Available: "2006-12"
@@ -2186,13 +2186,13 @@
 2211	squat deck of tropical cards of the wise owl of the overflowing toilet	0		Mysticality: +20, Stench Spell Damage: +50, Stat Tuning: "Mysticality", Last Available: "2006-12"
 2212	purple pulsating wobbly medical-grade slick tropical paperweight	0		Moxie: +10, HP Regen Min: 7, HP Regen Max: 10, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	pulsating tropical Crimbo pressie	0		Last Available: "2006-12"
-2214	spinning jittery tropical wrapping paper	0		Last Available: "2006-12"
+2214	jittery spinning tropical wrapping paper	0		Last Available: "2006-12"
 2215	hardy Tropical Crimbo Hat	0		Maximum HP: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	baleful Tropical Crimbo Shorts	0		Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	rotten super ka-bob	4	crappy	
-2218	immense enchanted adequate beer basted brat	7	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 25
+2218	immense adequate enchanted beer basted brat	7	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 25
 2219	gravedigger's Tropical Crimbo Sword	0		Spooky Damage: +10, Last Available: "2006-12"
-2220	polarized tarnished ghostly huge and Crimboween candy	0		Effect: "Gyromitra Gymnastics", Effect Duration: 18, Last Available: "2020-09"
+2220	polarized tarnished huge ghostly and Crimboween candy	0		Effect: "Gyromitra Gymnastics", Effect Duration: 18, Last Available: "2020-09"
 2221	blurry Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	liar's pants of the storm of the brazier	0		Maximum MP Percent: +40, Hot Spell Damage: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	quilted juggler's balls of chilblains	0		Damage Absorption: +40, Cold Damage: +25, Softcore Only, Last Available: "2007-01"
@@ -2236,20 +2236,20 @@
 2262	bird rib	0		
 2263	lion oil	0		
 2264	flavorless tumbling stunt nuts	3	decent	
-2265	spoiled low-calorie wet stew	1	crappy	
+2265	low-calorie spoiled wet stew	1	crappy	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	wizardly Staff of Fats	0		Mysticality: +25
-2269	rotten maroon shaking sausage wonton	3	crappy	
+2269	rotten shaking maroon sausage wonton	3	crappy	
 2270	skewed lightning-fast scandalous belt	0		Sleaze Damage: +5, Initiative: +40, Single Equip
-2271	hand-crafted high-proof bottle of Merlot	9	EPIC	
+2271	high-proof hand-crafted bottle of Merlot	9	EPIC	
 2272	tolerable bottle of Port	4	good	
-2273	extra-dry artisanal bottle of Pinot Noir	5	EPIC	
+2273	artisanal extra-dry bottle of Pinot Noir	5	EPIC	
 2274	artisanal bottle of Zinfandel	4	EPIC	
 2275	aged jittery bottle of Marsala	3	awesome	
 2276	bad bottle of Muscat	3	decent	
 2277	Fernswarthy's key	0		
-2278	narrow bouncing Fernswarthy's letter	0		
+2278	bouncing narrow Fernswarthy's letter	0		
 2279	book	0		
 2280	Manual of Labor	0		
 2281	Manual of Transmission	0		
@@ -2309,19 +2309,19 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	blurry Van der Graaf beefy pipe	0		Muscle: +10, MP Regen Min: 5, MP Regen Max: 7
 2337	blue ghostly coward's reinforced beaded headband	0		Monster Level: -20, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	tasty bouncing yellow pudding	3	awesome	Wiki Name: "black pudding (food)"
+2338	tasty yellow bouncing pudding	3	awesome	Wiki Name: "black pudding (food)"
 2339	practically non-alcoholic acceptable Blackfly Chardonnay	1	good	
 2340	aged & tan	4	awesome	
 2341	pepper	0		
-2342	jumbo decent special forest cake	5	good	Effect: "Browbeaten", Effect Duration: 40
+2342	decent special jumbo forest cake	5	good	Effect: "Browbeaten", Effect Duration: 40
 2343	delicious cyan forest ham	3	awesome	
 2344	warmed filthworm hatchling scent gland	0		Effect: "Mystic Circle", Effect Duration: 67
 2345	super-quantum super-dry huge filthworm drone scent gland	0		Effect: "Super-Charged", Effect Duration: 62
 2346	boiled super-vacuum-sealed filthworm royal guard scent gland	0		Effect: "Spookyravin'", Effect Duration: 60
 2347	pulsating blurry heart of the filthworm queen	0		
 2348	water pipe bomb	0		
-2349	tumbling red blurry gas balloon	0		
-2350	cyan skewed beer bomb	0		
+2349	blurry red tumbling gas balloon	0		
+2350	skewed cyan beer bomb	0		
 2351	superamplified boom box	0		
 2352	Annie Oakley's deadly fire poi	0		Weapon Damage: +5, Critical Hit Percent: +20
 2353	grievous bejeweled pledge pin	0		Weapon Damage Percent: +50, Single Equip
@@ -2344,15 +2344,15 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	fuchsia bunch of bananas	0		
-2373	tasty massive banana	9	awesome	
+2373	massive tasty banana	9	awesome	
 2374	huge banana peel	0		
 2375	huge adequate banana cream pie	6	good	
-2376	drinkable distilled purple banana daiquiri	5	good	
+2376	distilled drinkable purple banana daiquiri	5	good	
 2377	lousy narrow bungle in the jungle	3	decent	
-2378	spinning blue banana spritzer	0		
+2378	blue spinning banana spritzer	0		
 2379	unsweetened colloidal bouncing banana smoothie	0		Effect: "Yuletide Sappiness", Effect Duration: 27
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
-2381	pulsating mirror jittery maroon woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
+2381	mirror maroon pulsating jittery woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	class ring	0		
 2384	tumbling class ring	0		
@@ -2374,7 +2374,7 @@
 2400	molotov cocktail cocktail	0		
 2401	pulsating bouncing smooth beer bong of the sweet-tooth	0		Moxie: +15, Candy Drop: +100
 2402	gauze garter	0		
-2403	upside-down spinning barrel of gunpowder	0		
+2403	spinning upside-down barrel of gunpowder	0		
 2404	jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
@@ -2397,7 +2397,7 @@
 2423	enhanced dry Mick's IcyVapoHotness Inhaler	0		Effect: "Motion", Effect Duration: 42
 2424	frozen mirror cyclops eyedrops	0		Effect: "Elemental Mastery", Effect Duration: 26
 2425	double-frozen double-tarnished can of spinach	0		Effect: "Black Eyes", Effect Duration: 37
-2426	warmed vacuum-sealed purple blurry fire flower	0		Effect: "Joyful Resolve", Effect Duration: 18
+2426	warmed vacuum-sealed blurry purple fire flower	0		Effect: "Joyful Resolve", Effect Duration: 18
 2427	vacuum-sealed freezerburned ice cube	0		Effect: "Izchak's Blessing", Effect Duration: 50
 2428	Vulcanized fake blood	0		Effect: "Filled with Magic", Effect Duration: 33
 2429	energized dry Eau de Guaneau	0		Effect: "Greedy Resolve", Effect Duration: 69
@@ -2421,7 +2421,7 @@
 2447	bad penguin egg	0		Free Pull
 2448	skewed tasteful bow tie	0		Familiar Weight: +5
 2449	shaking six-pack of New Cloaca-Cola	0		
-2450	narrow fuchsia empty Cloaca-Cola bottle	0		
+2450	fuchsia narrow empty Cloaca-Cola bottle	0		
 2451	tumbling scandalous goatskin umbrella	0		Sleaze Damage: +5
 2452	wool hat of the bloodbag of horror	0		Maximum HP: +100, Spooky Spell Damage: +25, Familiar Effect: "1xLep, cap 43"
 2453	Goodfella contract	0		Last Available: "2011-12"
@@ -2434,8 +2434,8 @@
 2460	yak toupee of the brute	0		Muscle Percent: +30, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	moldy small jittery bowl of Bounty-Os	2	crappy	
-2465	mediocre blinking ghostly Oreille Divis&eacute;e brandy	3	decent	
+2464	small moldy jittery bowl of Bounty-Os	2	crappy	
+2465	mediocre ghostly blinking Oreille Divis&eacute;e brandy	3	decent	
 2466	teal pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2469,7 +2469,7 @@
 2496	boxer's Sinful Desires of the sweet-tooth	0		Muscle Percent: +10, Candy Drop: +100
 2497	wobbly molybdenum magnet	0		
 2498	molybdenum hammer	0		
-2499	upside-down red molybdenum screwdriver	0		
+2499	red upside-down molybdenum screwdriver	0		
 2500	molybdenum pliers	0		
 2501	ghostly molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
@@ -2489,19 +2489,19 @@
 2516	Da Vinci's slick wrench bracelet	0		Moxie: +10, Experience (Mysticality): +5
 2517	avaricious chain necklace of Tarzan	0		Experience (Muscle): +3, Meat Drop: +30
 2518	pulsating greasy sawblade shield	0		Sleaze Spell Damage: +10, Damage Reduction: 11
-2519	delicious triple-distilled McMillicancuddy's Special Lager	8	awesome	
-2520	spirit-forward fancy hand-crafted melted Jell-o shot	5	EPIC	Effect: "Army of One", Effect Duration: 15
+2519	triple-distilled delicious McMillicancuddy's Special Lager	8	awesome	
+2520	hand-crafted fancy spirit-forward melted Jell-o shot	5	EPIC	Effect: "Army of One", Effect Duration: 15
 2521	perfectly mixed cruelty-free wine	3	EPIC	
-2522	distilled mediocre ghostly thistle wine	5	decent	
+2522	mediocre distilled ghostly thistle wine	5	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	decent fish	3	good	
-2526	tasty miniature fish casserole	2	awesome	
+2526	miniature tasty fish casserole	2	awesome	
 2527	toothsome immense blue fish lasagna	6	awesome	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	rotten half-sized gnatloaf	2	crappy	
 2530	yummy gnatloaf casserole	4	awesome	
-2531	decent fancy gnat lasagna	3	good	Effect: "Pill Power", Effect Duration: 15
+2531	fancy decent gnat lasagna	3	good	Effect: "Pill Power", Effect Duration: 15
 2532	pork	0		
 2533	spoiled spinning pork chop sandwiches	3	crappy	
 2534	adequate pork casserole	3	good	
@@ -2535,7 +2535,7 @@
 2562	half-rotten brain	0		
 2563	wobbly bonesaw	0		
 2564	teal plus-sized phylactery	0		
-2565	jittery blurry can of Ghuol-B-Gone&trade;	0		
+2565	blurry jittery can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
 2568	pulsating Azazel's tutu	0		
@@ -2563,7 +2563,7 @@
 2590	perfectly mixed distilled fortified wine	3	EPIC	
 2591	delicious ghostly tasty tart	3	awesome	
 2592	gray Knob Goblin lunchbox	0		
-2593	special super-sized adequate Knob pasty	5	good	Effect: "Celestial Vision", Effect Duration: 25
+2593	super-sized special adequate Knob pasty	5	good	Effect: "Celestial Vision", Effect Duration: 25
 2594	artisanal mirror thermos full of Knob coffee	4	EPIC	
 2595	concentrated quadruple-tarnished green Ben-Gal&trade; Balm	0		Effect: "Weepy, Creepy", Effect Duration: 30
 2596	leathery cat skin	0		
@@ -2628,7 +2628,7 @@
 2655	improved narrow lime green bottle of absinthe	0		Effect: "Angry Bone", Effect Duration: 12, Last Available: "2007-06"
 2656	huge Drowsy Sword of the storm of the overflowing toilet	0		Maximum MP Percent: +40, Stench Spell Damage: +50
 2657	bite-sized bland maroon escargotsicle	1	decent	Last Available: "2007-06"
-2658	perfectly mixed watered-down bouncing bottle of realpagne	2	EPIC	Last Available: "2007-06"
+2658	watered-down perfectly mixed bouncing bottle of realpagne	2	EPIC	Last Available: "2007-06"
 2659	gray nasty albatross necklace	0		Stench Damage: +5, Single Equip, Last Available: "2007-06"
 2660	dried not-a-pipe	1	awesome	Last Available: "2007-06"
 2661	perfectly mixed flask of Amontillado	3	EPIC	Last Available: "2007-06"
@@ -2646,8 +2646,8 @@
 2673	mirror Bohemian rhapsody	0		Last Available: "2007-06"
 2674	pressed shaking bottle of cat tonic	0		Effect: "Poker Faced", Effect Duration: 23, Last Available: "2007-06"
 2675	altered mirror handful of moss	1		Effect: "Saucefingers", Effect Duration: 15
-2676	powdered blurry pulsating bit-o-cactus	1		Effect: "Human-Humanoid Hybrid", Effect Duration: 50
-2677	dried lime green blinking protein powder	1		
+2676	powdered pulsating blurry bit-o-cactus	1		Effect: "Human-Humanoid Hybrid", Effect Duration: 50
+2677	dried blinking lime green protein powder	1		
 2678	spectre scepter	0		
 2679	pressed blue sparkler	0		Effect: "Innately Wise", Effect Duration: 49
 2680	polymerized Vulcanized snake	0		Effect: "Cybernetic Muscles", Effect Duration: 36, Wiki Name: "snake"
@@ -2661,11 +2661,11 @@
 2688	gray Sherlock's MacGyver's wholesome dreadlock whip	0		Maximum HP Percent: +10, Maximum MP: +100, Item Drop: +25
 2689	beer-a-pult of Calamity Jane of Gandalf	0		Critical Hit Percent: +15, Spell Critical Percent: +20
 2690	cast-iron legacy paddle of extreme caution of the empath	0		Monster Level: -25, Familiar Weight: +5
-2691	stale gigantic lime green handful of nuts and berries	8	decent	
+2691	gigantic stale lime green handful of nuts and berries	8	decent	
 2692	blurry mansplainer's driftwood sculpture of the glutton	0		Monster Level: +15, Food Drop: +100
 2693	occult massive sitar of the cougar	0		Moxie: +20, Spell Damage Percent: +25
 2694	Da Vinci's stone baseball cap of the bloodbag of bravery	0		Experience (Mysticality): +5, Maximum HP: +100, Spooky Resistance: +5, Familiar Effect: "1xVolley, cap 48"
-2695	mediocre special olive cup of beer	4	decent	Effect: "Moose Wisdom", Effect Duration: 10
+2695	special mediocre olive cup of beer	4	decent	Effect: "Moose Wisdom", Effect Duration: 10
 2696	mirror ovoid thing	0		
 2697	duct tape	0		
 2698	skewed duct tape wallet	0		
@@ -2694,27 +2694,27 @@
 2721	asbestos-lined energetic dangerous hand-carved staff	0		Weapon Damage: +10, Maximum MP Percent: +20, Hot Resistance: +5
 2722	wobbly censurious reassuring foul-smelling Socratic Staff of the Greasefire	0		Experience (Mysticality): +1, Stench Damage: +10, Spooky Resistance: +1, Sleaze Resistance: +3
 2723	foul-smelling stiffened Staff of the Grand Flamb&eacute; of Gandalf	0		Damage Reduction: 1, Spell Critical Percent: +20, Stench Damage: +10
-2724	toothsome low-calorie bowl of rye sprouts	1	awesome	
-2725	small tasty blinking cob of corn	2	awesome	
+2724	low-calorie toothsome bowl of rye sprouts	1	awesome	
+2725	tasty small blinking cob of corn	2	awesome	
 2726	toothsome juniper berries	3	awesome	
 2727	delicious plum	3	awesome	
 2728	decent bouncing pear	4	good	
-2729	rotten narrow red peach	4	crappy	
+2729	rotten red narrow peach	4	crappy	
 2730	smooth plum wine	4	awesome	
 2731	bad boozy shot of pear schnapps	5	decent	
 2732	distilled lousy shot of peach schnapps	5	decent	
-2733	rotten miniature bunch of square grapes	2	crappy	
-2734	stale snack-sized brown sugar cane	2	decent	
+2733	miniature rotten bunch of square grapes	2	crappy	
+2734	snack-sized stale brown sugar cane	2	decent	
 2735	decent sandwich of the gods	4	good	
-2736	watered-down delicious blue Pan-Dimensional Gargle Blaster	2	awesome	
+2736	delicious watered-down blue Pan-Dimensional Gargle Blaster	2	awesome	
 2737	pickled leopard-print barbell	1	EPIC	Effect: "Sleazy Hands", Effect Duration: 10
 2738	pile of smoking rags	0		
 2739	galvanized colloidal upside-down panty raider camouflage	0		Effect: "The Wisdom... of the Future", Effect Duration: 30
 2740	gravedigger's Da Vinci's brawny Staff of the Walk-In Freezer	0		Muscle Percent: +20, Experience (Mysticality): +5, Spooky Damage: +10
-2741	triple-distilled mediocre boilermaker	6	decent	
-2742	small bland yellow steel lasagna	2	quest	
+2741	mediocre triple-distilled boilermaker	6	decent	
+2742	bland small yellow steel lasagna	2	quest	
 2743	bad steel margarita	3	quest	
-2744	dried ghostly skewed steel-scented air freshener	1		Effect: "Updated", Effect Duration: 35
+2744	dried skewed ghostly steel-scented air freshener	1		Effect: "Updated", Effect Duration: 35
 2745	deionized super-improved gremlin mutagen	0		Effect: "In Vino Vires", Effect Duration: 43
 2746	galvanized wet extra-potent gremlin mutagen	0		Effect: "The Halls of Moxiousness", Effect Duration: 60
 2747	narrow chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2738,7 +2738,7 @@
 2765	wobbly Harold's bell	0		
 2766	mirror bowling ball	0		
 2767	bland Crimbo pie	3	decent	
-2768	half-sized flavorless pear tart	2	decent	
+2768	flavorless half-sized pear tart	2	decent	
 2769	decent huge peach pie	7	good	
 2770	alkaline alkaline maroon chunk of rock salt	0		Effect: "Mitre Cut", Effect Duration: 35
 2771	extra-tarnished tumbling upside-down handful of pine needles	0		Effect: "Wintry Breath", Effect Duration: 68
@@ -2802,7 +2802,7 @@
 2829	narrow really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
-2832	flavorless immense wobbly digital key lime pie	6	decent	
+2832	immense flavorless wobbly digital key lime pie	6	decent	
 2833	gigantic bland star key lime pie	6	decent	
 2834	smooth bottle-rocket crossbow of the brazier of mayonnaise	0		Moxie: +15, Hot Spell Damage: +25, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	squat Da Vinci's indie comic hipster glasses	0		Experience (Mysticality): +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -2810,7 +2810,7 @@
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	horrifying clever glowstick	0		Maximum MP: +20, Spooky Damage: +25, Last Available: "2007-08"
 2839	twirling brainy Periodical Paintbrush	0		Mysticality: +5, Softcore Only
-2840	acceptable enchanted bottle of cooking sherry	3	good	Effect: "No Vertigo", Effect Duration: 50
+2840	enchanted acceptable bottle of cooking sherry	3	good	Effect: "No Vertigo", Effect Duration: 50
 2841	rotten packet of ketchup	3	crappy	
 2842	mediocre accidental cider	3	decent	
 2843	toothsome low-calorie dire fudgesicle	1	awesome	
@@ -2838,9 +2838,9 @@
 2865	fuchsia wicked beaver spear of horror	0		Spell Damage: +5, Spooky Spell Damage: +25
 2866	red lion tamer's healthy shamanic beads	0		Maximum HP Percent: +20, Experience (familiar): +2
 2867	slick dilapidated wizard hat of doom	0		Moxie: +10, Spooky Spell Damage: +50, Familiar Effect: "cap 31"
-2868	wet blurry shaking pirate pamphlet	0		Effect: "Fireproof Lips", Effect Duration: 29
+2868	wet shaking blurry pirate pamphlet	0		Effect: "Fireproof Lips", Effect Duration: 29
 2869	improved irradiated pulsating pirate brochure	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 65
-2870	energized upside-down ghostly twirling pirate tract	0		Effect: "Bread Burps", Effect Duration: 49
+2870	energized ghostly twirling upside-down pirate tract	0		Effect: "Bread Burps", Effect Duration: 49
 2871	jittery burnt flower	0		
 2872	wobbly yellow frosty plastic Naughty Sorceress of the boozehound	0		Cold Spell Damage: +10, Booze Drop: +100
 2873	crafty padded plastic Ed the Undying	0		Damage Absorption: +20, Maximum MP: +10
@@ -2910,9 +2910,9 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	diet moldy blinking Surprise Egg	1	crappy	
+2940	moldy diet blinking Surprise Egg	1	crappy	
 2941	improved Steal This Candy	0		Effect: "Notably Lovely", Effect Duration: 31
-2942	pressed flattened jittery shaking chocolate filthy lucre	0		Effect: "Nut-Rition", Effect Duration: 55
+2942	pressed flattened shaking jittery chocolate filthy lucre	0		Effect: "Nut-Rition", Effect Duration: 55
 2943	denatured Angry Farmer's Wife Candy	0		Effect: "Sausage Festive", Effect Duration: 30
 2945	lard-coated curative party hat	0		Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "4xLep, cap 7"
 2946	chaotic V for Vivala mask of Flo-Jo	0		Spell Critical Percent: +10, Initiative: +100, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
@@ -2929,27 +2929,27 @@
 2957	spinning rum barrel charrrm	0		
 2958	tasty thick tube of cranberry Go-Goo	5	awesome	
 2959	lime green sinister rum barrel charrrm bracelet	0		Spell Damage: +10
-2960	moldy massive single-serving herbal stuffing	9	crappy	
-2961	super-sized decent packet of tofurkey gravy	5	good	
-2962	super-sized stale narrow tofurkey nugget	5	decent	
+2960	massive moldy single-serving herbal stuffing	9	crappy	
+2961	decent super-sized packet of tofurkey gravy	5	good	
+2962	stale super-sized narrow tofurkey nugget	5	decent	
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	mizzenmast mop	0		
 2966	mirror Tom's of the Spanish Main Toothpaste	0		
 2967	non-denatured warmed concentrated Swabbie&trade; swab	0		Effect: "Meatwise", Effect Duration: 22
 2968	altered Oil of Parrrlay	0		Effect: "Gonna Get You, Sucker", Effect Duration: 23
-2969	delicious snack-sized bouncing mirror creamsicle	2	awesome	
+2969	snack-sized delicious mirror bouncing creamsicle	2	awesome	
 2970	drinkable weak upside-down cream stout	2	good	
 2971	banded curmudgel of incineration	0		Damage Absorption: +100, Hot Spell Damage: +50
 2972	grumpy man charrrm	0		
 2973	jittery skewed olive scorching grumpy man charrrm bracelet	0		Hot Damage: +25, Single Equip
 2974	huge tarrrnish charrrm	0		
 2975	tarrrnished charrrm bracelet of doom of the detective	0		Spooky Spell Damage: +50, Item Drop: +20, Single Equip
-2976	perfectly mixed practically non-alcoholic bilge wine	1	EPIC	
+2976	practically non-alcoholic perfectly mixed bilge wine	1	EPIC	
 2977	lightning-fast witty rapier	0		Initiative: +40
 2978	frightening smooth yohohoyo	0		Moxie: +15, Spooky Damage: +5
 2979	flattened aerosolized fish-liver oil	0		Effect: "Deadly Lampblade", Effect Duration: 21
-2980	shaking skewed booty chest charrrm	0		
+2980	skewed shaking booty chest charrrm	0		
 2981	weightlifter's booty chest charrrm bracelet	0		Muscle: +15, Single Equip
 2982	cannonball charrrm	0		
 2983	twirling cannonball charrrm bracelet	0		Single Equip
@@ -2962,7 +2962,7 @@
 2990	curative rosy-cheeked clingfilm cap	0		Maximum HP Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, cap 37"
 2991	teal thinker's clingfilm slippers	0		Mysticality: +10, Single Equip
 2992	clingfilm tangle	0		
-2993	small flavorless wobbly vinegar-soaked lemon slice	2	decent	
+2993	flavorless small wobbly vinegar-soaked lemon slice	2	decent	
 2994	adjusted pickled super-pressed true grit	0		Effect: "Smoking like a Bandit", Effect Duration: 12
 2995	toasty hale buoybottoms of terror	0		Maximum HP: +20, Hot Damage: +5, Spooky Spell Damage: +10, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	greasy grungy flannel shirt	0		Sleaze Spell Damage: +10
@@ -2998,32 +2998,32 @@
 3026	acceptable corpsetini	3	good	
 3027	acceptable corpsedriver	4	good	
 3028	bad huge Corpse Island iced tea	3	decent	
-3029	fortified tolerable red-headed corpse	5	good	
-3030	lousy watered-down cyan twirling kamicorpse-ee	2	decent	
+3029	tolerable fortified red-headed corpse	5	good	
+3030	watered-down lousy twirling cyan kamicorpse-ee	2	decent	
 3031	perfectly mixed corpsel	3	EPIC	
-3032	smooth practically non-alcoholic corpsebite	1	awesome	
+3032	practically non-alcoholic smooth corpsebite	1	awesome	
 3033	skewed frosty pirate fledges	0		Cold Spell Damage: +10
 3034	piece of thirteen	0		
-3035	bland huge mirror pearl onion	9	decent	
+3035	huge bland mirror pearl onion	9	decent	
 3036	fancy bland sea biscuit	3	decent	Effect: "Smelly Pants", Effect Duration: 35
 3037	tolerable bottle of rum	3	good	
 3038	artisanal spinning bottle of black-label rum	3	EPIC	
 3039	pulsating cannonball	0		
 3040	wobbly voodoo skull	0		
 3041	red joke scroll	0		
-3042	gray narrow wobbly narrow Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
+3042	narrow narrow gray wobbly Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	skewed metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	decent super-sized wobbly mirror nanite-infested gingerbread bugbear	5	good	Last Available: "2007-12"
-3046	flavorless half-sized nanite-infested candy cane	2	decent	Last Available: "2020-09"
-3047	fancy yummy nanite-infested fruitcake	3	awesome	Effect: "Moon'd", Effect Duration: 15, Last Available: "2007-12"
+3045	super-sized decent mirror wobbly nanite-infested gingerbread bugbear	5	good	Last Available: "2007-12"
+3046	half-sized flavorless nanite-infested candy cane	2	decent	Last Available: "2020-09"
+3047	yummy fancy nanite-infested fruitcake	3	awesome	Effect: "Moon'd", Effect Duration: 15, Last Available: "2007-12"
 3048	mediocre fortified skewed nanite-infested eggnog	5	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	blurry hale eyepatch	0		Maximum HP: +20, Familiar Effect: "spooky atk, 1xBarrr"
 3051	Jeselnik's cutlass	0		Sleaze Damage: +25
 3052	blue Samson's breeches	0		Experience (Muscle): +5, Familiar Effect: "stench atk, 1xPotato"
 3053	mood ring	0		Last Available: "2007-02"
-3054	super-dry alkaline jittery blinking candy heart	0		Effect: "Patent Avarice", Effect Duration: 21, Last Available: "2007-02"
+3054	super-dry alkaline blinking jittery candy heart	0		Effect: "Patent Avarice", Effect Duration: 21, Last Available: "2007-02"
 3055	dry wobbly cymbal syrup	0		Free Pull, Effect: "Power Ballad of the Arrowsmith", Effect Duration: 19, Last Available: "2007-02"
 3056	jittery red upside-down rosy-cheeked metallic foil cat ears	0		Maximum HP Percent: +30, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
@@ -3069,7 +3069,7 @@
 3097	skewed jittery fish scaler	0		Last Available: "2007-12"
 3098	huge killing feather	0		Last Available: "2007-12"
 3099	ring	0		Last Available: "2007-12"
-3100	huge skewed robotronic egg	0		Last Available: "2007-12"
+3100	skewed huge robotronic egg	0		Last Available: "2007-12"
 3101	fuchsia rogue swarmer	0		Last Available: "2007-12"
 3102	teal sawblade fragment	0		Last Available: "2007-12"
 3103	unstable laser battery	0		Last Available: "2007-12"
@@ -3098,9 +3098,9 @@
 3126	twirling hobo nickel	0		
 3127	blurry sandcastle	0		
 3128	jittery marshmallow	0		
-3129	toothsome big roasted marshmallow	5	awesome	
+3129	big toothsome roasted marshmallow	5	awesome	
 3130	disc	0		Last Available: "2008-01"
-3131	normal gigantic cyan huge tin cup of mulligan stew	6	good	
+3131	normal gigantic huge cyan tin cup of mulligan stew	6	good	
 3132	upside-down up-at-dawn resourceful flamin' bindle	0		Maximum MP: +50, Adventures: +5
 3133	blinking blurry brawny weightlifter's freezin' bindle	0		Muscle: +15, Muscle Percent: +20
 3134	mirror cyan wobbly Jeselnik's stinkin' bindle of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100
@@ -3118,7 +3118,7 @@
 3146	El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
 3148	skewed El Vibrato punchcard (129 holes)	0		
-3149	bouncing bouncing skewed El Vibrato punchcard (213 holes)	0		
+3149	bouncing skewed bouncing El Vibrato punchcard (213 holes)	0		
 3150	El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
 3152	wobbly El Vibrato punchcard (216 holes)	0		
@@ -3145,7 +3145,7 @@
 3173	alkaline energized fuchsia evil vihuela	0		Effect: "Fustulent", Effect Duration: 41
 3174	super-sized fancy delicious bouncing evil boring spaghetti	5	awesome	Effect: "Chalky Hand", Effect Duration: 50
 3175	decent evil noodles	3	good	
-3176	fancy moldy miniature evil noodles	2	crappy	Effect: "Sharp Weapon", Effect Duration: 5
+3176	fancy miniature moldy evil noodles	2	crappy	Effect: "Sharp Weapon", Effect Duration: 5
 3177	rotten evil painful penne pasta	3	crappy	
 3178	small moldy 3vi1 pr0n m4nic0tti	2	crappy	
 3179	adequate evil ravioli della hippy	4	good	
@@ -3160,7 +3160,7 @@
 3188	lousy triple-distilled spinning an evil sump'm sump'm	10	decent	
 3189	hand-crafted strong evil ducha de oro	5	EPIC	
 3190	drinkable evil horizontal tango	3	good	
-3191	lousy watered-down enchanted evil roll in the hay	2	decent	Effect: "Cletus's Canticle of Celerity", Effect Duration: 25
+3191	watered-down lousy enchanted evil roll in the hay	2	decent	Effect: "Cletus's Canticle of Celerity", Effect Duration: 25
 3192	maroon naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3201,7 +3201,7 @@
 3229	decaying goldfish liver	0		
 3230	colloidal dry olive oil of oiliness	0		Effect: "Deadly Lampblade", Effect Duration: 35
 3231	cool tattered paper crown	0		Moxie: +5, Familiar Effect: "1xSombrero, cap 15"
-3232	tiny spoiled vanilla-frosted king cake	1	crappy	Last Available: "2008-03"
+3232	spoiled tiny vanilla-frosted king cake	1	crappy	Last Available: "2008-03"
 3233	ghostly inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3237,7 +3237,7 @@
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
-3268	super-electrified dry twirling narrow handful of Crotchety Pine needles	0		Effect: "Permafrosty", Effect Duration: 34
+3268	super-electrified dry narrow twirling handful of Crotchety Pine needles	0		Effect: "Permafrosty", Effect Duration: 34
 3269	triple-warmed magnetized maroon lump of Saccharine Maple sap	0		Effect: "Crimbo Epiphany", Effect Duration: 30
 3270	vacuum-sealed adjusted super-improved handful of Laughing Willow bark	0		Effect: "Antibiotic Saucesphere", Effect Duration: 36
 3271	Samson's crotchety pants	0		Experience (Muscle): +5, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
@@ -3250,9 +3250,9 @@
 3278	studded belt of chilblains	0		Cold Damage: +25, Last Available: "2008-04"
 3279	upside-down personal massager	0		Last Available: "2008-04"
 3280	purple personalized coffee mug	0		Free Pull, Last Available: "2008-04"
-3281	cyan tumbling skewed plasma ball	0		Last Available: "2008-04"
+3281	tumbling skewed cyan plasma ball	0		Last Available: "2008-04"
 3282	beefcake's stick-on eyebrow piercing	0		Muscle: +25, Last Available: "2008-04"
-3283	decent huge squat salad	3	good	
+3283	decent squat huge salad	3	good	
 3284	nasty Lo Pan's C.H.U.M. lantern	0		Spell Critical Percent: +30, Stench Damage: +5
 3285	chilly C.H.U.M. knife	0		Cold Damage: +5
 3286	Frosty's snowball sack of chilblains	0		Cold Damage: +25
@@ -3296,7 +3296,7 @@
 3324	Frosty's frosty mug	0		
 3325	artisanal olive jar of fermented pickle juice	4	super EPIC	
 3326	diluted ghostly voodoo snuff	1	decent	
-3327	thick yummy tumbling extra-greasy slider	5	awesome	
+3327	yummy thick tumbling extra-greasy slider	5	awesome	
 3328	narrow blurry Sherlock's savvy crumpled felt fedora	0		Mysticality Percent: +20, Item Drop: +25, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	purple scandalous battered top-hat of temperance	0		Sleaze Damage: +5, Sleaze Resistance: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	banded shapeless wide-brimmed hat of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3321,7 +3321,7 @@
 3349	twirling dinged-up triangle	0		
 3350	tolerable weak Ralph IX cognac	2	good	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
-3352	lime green narrow zen motorcycle	0		Last Available: "2008-06"
+3352	narrow lime green zen motorcycle	0		Last Available: "2008-06"
 3353	dry llama lama gong	0		Effect: "Broken Bone Nubs", Effect Duration: 27, Last Available: "2008-06"
 3354	rotten low-calorie banana-frosted king cake	1	crappy	Last Available: "2008-08"
 3355	fuchsia brown plastic baby of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2008-08"
@@ -3333,14 +3333,14 @@
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	bland mole mol&eacute;	4	decent	Last Available: "2008-06"
-3364	special mediocre Morlock's Mark Bourbon	3	decent	Effect: "The Dinsey Spirit", Effect Duration: 45, Last Available: "2008-06"
+3364	mediocre special Morlock's Mark Bourbon	3	decent	Effect: "The Dinsey Spirit", Effect Duration: 45, Last Available: "2008-06"
 3365	flattened spinning Climate Colada	0		Effect: "Hammered", Effect Duration: 29, Last Available: "2008-06"
 3366	dry frozen digital underground potion	0		Effect: "Ocelot Eyes", Effect Duration: 41, Last Available: "2008-06"
 3367	twirling interesting-looking twig	0		Last Available: "2008-06"
 3368	altered squat glimmering roc feather	1	EPIC	Effect: "Slightly Mutated", Effect Duration: 15, Last Available: "2008-06"
-3369	diluted bouncing blurry glimmering phoenix feather	1		Effect: "Gr8ness", Effect Duration: 5, Last Available: "2008-06"
+3369	diluted blurry bouncing glimmering phoenix feather	1		Effect: "Gr8ness", Effect Duration: 5, Last Available: "2008-06"
 3370	pickled glimmering penguin feather	1		Effect: "Hopped Up on Goofballs", Effect Duration: 40, Last Available: "2008-06"
-3371	modified narrow bouncing glimmering buzzard feather	1		Effect: "Squid Squint", Effect Duration: 35, Last Available: "2008-06"
+3371	modified bouncing narrow glimmering buzzard feather	1		Effect: "Squid Squint", Effect Duration: 35, Last Available: "2008-06"
 3372	dehydrated glimmering raven feather	1		Effect: "Hella Tough", Effect Duration: 15, Last Available: "2008-06"
 3373	compressed glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
@@ -3367,7 +3367,7 @@
 3395	auspicious groovy Hodgman's porkpie hat	0		Moxie Percent: +10, Item Drop: +10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	asbestos-lined Samson's Hodgman's lobsterskin pants	0		Experience (Muscle): +5, Hot Resistance: +5, Familiar Effect: "atk, 1xPotato"
 3397	avaricious Tesla Hodgman's bow tie	0		Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-3398	bad enchanted Hodgman's blanket	3	decent	Effect: "Holiday Bliss", Effect Duration: 30
+3398	enchanted bad Hodgman's blanket	3	decent	Effect: "Holiday Bliss", Effect Duration: 30
 3399	mediocre boozy squat jar of squeeze	5	decent	
 3400	bland pulsating bowl of fishysoisse	4	decent	
 3401	aerosolized denatured upside-down deadly lampshade	0		Effect: "Cake Caked", Effect Duration: 67
@@ -3418,29 +3418,29 @@
 3451	twirling cotton candy smidgen	0		Last Available: "2008-08"
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	shaking cotton candy plug	0		Last Available: "2008-08"
-3454	tumbling wobbly cotton candy pillow	0		Last Available: "2008-08"
+3454	wobbly tumbling cotton candy pillow	0		Last Available: "2008-08"
 3455	teal cotton candy bale	0		Last Available: "2008-08"
 3456	blinking flame-wreathed trusty torch	0		Hot Spell Damage: +10, Last Available: "2011-12"
 3457	toasty Junior Adventurer's merit badge	0		Hot Damage: +5
 3458	polymerized aerosolized polymerized STYX deodorant body spray	0		Effect: "Barking Mad", Effect Duration: 36
 3459	bad white-label gin	3	decent	
-3460	bland small bouncing tumbling tin rations	2	decent	
+3460	small bland tumbling bouncing tin rations	2	decent	
 3461	haiku challenge map	0		
 3462	shaking terrible poem	0		
 3463	acceptable bottle of sake	3	good	
 3464	aromatic round pebble	0		Stench Resistance: +1
-3465	flavorless half-sized Bash-&#332;s cereal	2	decent	Wiki Name: "Bash-Os cereal"
+3465	half-sized flavorless Bash-&#332;s cereal	2	decent	Wiki Name: "Bash-Os cereal"
 3466	haiku katana of the ox of wisdom of chilblains	0		Muscle: +20, Mysticality: +15, Cold Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	sharpshooter's plastic baby	0		Critical Hit Percent: +10, Single Equip, Last Available: "2008-12"
-3469	gigantic toothsome maroon blueberry-frosted king cake	6	awesome	Last Available: "2008-12"
+3469	toothsome gigantic maroon blueberry-frosted king cake	6	awesome	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	extremely unsafe Fonzie's Seasonal Beret of the brazier	0		Experience (Moxie): +1, Weapon Damage Percent: +100, Hot Spell Damage: +25, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	concentrated cranberry cordial	0		Effect: "Memories of Puppy Love", Effect Duration: 48
 3475	warmed moist narrow blackberry polite	0		Effect: "Very Clean Teeth", Effect Duration: 54
-3476	pressed deionized tumbling blue plum lozenge	0		Effect: "Hombre Muerto Caminando", Effect Duration: 13
+3476	pressed deionized blue tumbling plum lozenge	0		Effect: "Hombre Muerto Caminando", Effect Duration: 13
 3477	nitrogenated nitrogenated teal pear lozenge	0		Effect: "Magically Delicious", Effect Duration: 13
 3478	flattened peach lozenge	0		Effect: "Good Karma", Effect Duration: 40
 3479	huge balloon shield	0		Damage Reduction: 3
@@ -3449,7 +3449,7 @@
 3482	upside-down passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	shaking psychedelic bubble wand	0		Familiar Weight: +5
 3484	tumbling eye 'n' horn shampoo	0		Familiar Weight: +5
-3485	oxidized moist twirling bouncing glittery mascara	0		Effect: "Spooky Jellied", Effect Duration: 49
+3485	oxidized moist bouncing twirling glittery mascara	0		Effect: "Spooky Jellied", Effect Duration: 49
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	bouncing pristine fish scale	0		
@@ -3465,7 +3465,7 @@
 3498	twirling invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	lime green witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	huge beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	miniature stale special canap&eacute;s	2	decent	Effect: "Chorale of Companionship", Effect Duration: 40
+3501	stale special miniature canap&eacute;s	2	decent	Effect: "Chorale of Companionship", Effect Duration: 40
 3502	modified upside-down thermos of brew	1	EPIC	Last Available: "2011-12"
 3503	bad spinning glass of brandy	3	decent	Last Available: "2011-12"
 3504	French slippers	0		
@@ -3523,7 +3523,7 @@
 3556	immense special rotten sea cucumber	7	crappy	Effect: "Coated Arms", Effect Duration: 30
 3557	adequate sea avocado	3	good	
 3558	moldy sea lychee	3	crappy	
-3559	half-sized toothsome sea tangelo	2	awesome	
+3559	toothsome half-sized sea tangelo	2	awesome	
 3560	stale sea honeydew	3	decent	
 3561	pickled pressurized potion of puissance	0		Effect: "Liquid Courage", Effect Duration: 32
 3562	adjusted squat pressurized potion of perspicacity	0		Effect: "Buzzard Breath", Effect Duration: 64
@@ -3536,11 +3536,11 @@
 3569	avaricious beefcake's spongy shield of the bloodbag	0		Muscle: +25, Maximum HP: +100, Meat Drop: +30, Damage Reduction: 14
 3570	lightning-fast nasty frosty square sponge pants	0		Cold Spell Damage: +10, Stench Damage: +5, Initiative: +40, Familiar Effect: "hot atk, 1xPotato"
 3571	wobbly flytrap pellet	0		
-3572	bouncing purple baby cuddlefish	0		
+3572	purple bouncing baby cuddlefish	0		
 3573	pulsating six-armed sweater	0		Familiar Weight: +5
 3574	upside-down slimy chest	0		
 3575	maroon sand dollar	0		
-3576	twirling olive flytrap bezoar	0		
+3576	olive twirling flytrap bezoar	0		
 3577	bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ghostly ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
@@ -3549,7 +3549,7 @@
 3582	decent rice	4	good	
 3584	flavorless blurry irradiated candy cane	4	decent	Last Available: "2008-12"
 3585	low-calorie flavorless gingerbread mutant bugbear	1	decent	Last Available: "2008-12"
-3586	artisanal boozy oozenog	5	EPIC	Last Available: "2008-12"
+3586	boozy artisanal oozenog	5	EPIC	Last Available: "2008-12"
 3587	polarized sugar plum	0		Effect: "Bilious Brawn", Effect Duration: 28, Last Available: "2008-12"
 3588	adjusted ionized sugar banana	0		Effect: "You Drank Fish Wine", Effect Duration: 39, Last Available: "2008-12"
 3589	unsweetened oxidized tumbling tumbling sugar lime	0		Effect: "Well-preserved", Effect Duration: 40, Last Available: "2008-12"
@@ -3591,9 +3591,9 @@
 3625	mirror Van der Graaf parasitic tentacles	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
 3626	Jeselnik's parasitic headgnawer	0		Sleaze Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	gray parasitic strangleworm of bravery	0		Spooky Resistance: +5, Last Available: "2008-12"
-3628	maroon tumbling pair of ragged claws	0		Last Available: "2008-12"
+3628	tumbling maroon pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
-3630	cyan wobbly Crimbo crate	0		Last Available: "2008-12"
+3630	wobbly cyan Crimbo crate	0		Last Available: "2008-12"
 3631	flattened jittery Gummi-DNA	0		Effect: "Red Around the Gills", Effect Duration: 51, Last Available: "2020-09"
 3632	upside-down radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	sage elven socks of the blizzard	0		Mysticality Percent: +10, Cold Spell Damage: +25, Last Available: "2008-12"
@@ -3609,13 +3609,13 @@
 3643	pufferfish spine	0		
 3644	spinning coward's depleted Grimacite kneecapping stick	0		Monster Level: -20, Last Available: "2007-06"
 3645	lousy canteen of wine	3	decent	Last Available: "2008-12"
-3646	small decent elven <i>limbos</i> gingerbread	2	good	Last Available: "2008-12"
+3646	decent small elven <i>limbos</i> gingerbread	2	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	flavorless narrow wobbly toast with jam	4	decent	Last Available: "2008-12"
-3651	pulsating antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	lousy spirit-forward elven moonshine	5	decent	Last Available: "2008-12"
+3651	pulsating antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	spirit-forward lousy elven moonshine	5	decent	Last Available: "2008-12"
 3653	flavorless olive knuckle sandwich	3	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	blurry Herculean stylish psycho sweater	0		Moxie: +25, Experience (Muscle): +1, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
@@ -3647,14 +3647,14 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	tasty big tempura carrot	5	awesome	
+3684	big tasty tempura carrot	5	awesome	
 3685	adequate big tempura cucumber	5	good	
 3686	moldy tempura avocado	3	crappy	
-3687	moldy half-sized sea broccoli	2	crappy	
-3688	thick enchanted tasty blinking lime green sea cauliflower	5	awesome	Effect: "Paging Betty", Effect Duration: 20
+3687	half-sized moldy sea broccoli	2	crappy	
+3688	enchanted thick tasty blinking lime green sea cauliflower	5	awesome	Effect: "Paging Betty", Effect Duration: 20
 3689	flavorless tempura broccoli	4	decent	
 3690	toothsome tempura cauliflower	3	awesome	
-3691	snack-sized rotten sea blueberry	2	crappy	
+3691	rotten snack-sized sea blueberry	2	crappy	
 3692	super-sized normal blurry sea persimmon	5	good	
 3693	galvanized twirling pressurized potion of perception	0		Effect: "Antarctic Memories", Effect Duration: 60
 3694	denatured vacuum-sealed spinning shaking pressurized potion of proficiency	0		Effect: "Bonelording", Effect Duration: 36
@@ -3662,7 +3662,7 @@
 3696	anemone nematocyst	0		
 3697	high-pressure seltzer bottle	0		
 3698	wobbly velcro ore	0		
-3699	twirling shaking blue teflon ore	0		
+3699	shaking blue twirling teflon ore	0		
 3700	vinyl ore	0		
 3701	skewed map to Anemone Mine	0		
 3702	marine aquamarine	0		
@@ -3708,14 +3708,14 @@
 3742	triple-corrupted jellyfish gel	0		Effect: "Outer Wolf&trade;", Effect Duration: 46
 3743	unstable quark	0		
 3744	software glitch	0		
-3745	mirror huge fumble formula	0		Recipe: "concoction of clumsiness"
-3746	yellow blinking vampire pearl	0		
+3745	huge mirror fumble formula	0		Recipe: "concoction of clumsiness"
+3746	blinking yellow vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	wet concoction of clumsiness	0		Effect: "Pwnd", Effect Duration: 64
 3750	Fonzie's vampire pearl earring	0		Experience (Moxie): +1, Single Equip
 3751	bland blurry chocolate chip brownies	3	decent	
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
-3754	magnetized alkaline spinning yellow love song of vague ambiguity	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 36, Last Available: "2009-02"
+3754	magnetized alkaline yellow spinning love song of vague ambiguity	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 36, Last Available: "2009-02"
 3755	diffused frozen polymerized blurry wobbly love song of smoldering passion	0		Effect: "Mighty Shout", Effect Duration: 69, Last Available: "2009-02"
 3756	dry blinking love song of icy revenge	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 32, Last Available: "2009-02"
 3757	magnetized energized wobbly love song of sugary cuteness	0		Effect: "Hobo Flavor", Effect Duration: 22, Last Available: "2009-02"
@@ -3724,23 +3724,23 @@
 3760	Vulcanized Vulcanized purple breath mint	0		Effect: "Briny Blood", Effect Duration: 52
 3761	Fonzie's vampire pearl ring	0		Experience (Moxie): +1, Single Equip
 3762	tumbling quilted vampire pearl necklace	0		Damage Absorption: +40, Single Equip
-3763	practically non-alcoholic tolerable slug of vodka	1	good	
+3763	tolerable practically non-alcoholic slug of vodka	1	good	
 3764	artisanal wobbly slug of rum	3	EPIC	
-3765	practically non-alcoholic mediocre bouncing slug of shochu	1	decent	
+3765	mediocre practically non-alcoholic bouncing slug of shochu	1	decent	
 3766	mediocre irresponsibly strong shaking screwdiver	8	decent	
-3767	strong mediocre skewed dew yoana lei	5	decent	
+3767	mediocre strong skewed dew yoana lei	5	decent	
 3768	perfectly mixed lychee chuhai	4	EPIC	
 3769	artisanal salacious screwdiver	3	EPIC	
 3770	delicious upside-down dew yoana salacious lei	4	awesome	
 3771	hand-crafted salacious lychee chuhai	3	EPIC	
-3772	tolerable weak wobbly Alewife&trade; Ale	2	good	
+3772	weak tolerable wobbly Alewife&trade; Ale	2	good	
 3773	squat seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
 3776	teal pink pinkslip slip of the sewer of the glutton	0		Stench Damage: +25, Food Drop: +100, Familiar Effect: "1xVolley, 1xBarrr"
 3777	tumbling wool studded sea salt scrubs	0		Damage Absorption: +80, Cold Resistance: +1
 3778	bouncing amber aviator shades of vim and vigor of incineration of mayonnaise	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Sleaze Spell Damage: +50, Single Equip
-3779	warmed blinking cyan hair of the fish	0		Effect: "Mad at Science", Effect Duration: 28
+3779	warmed cyan blinking hair of the fish	0		Effect: "Mad at Science", Effect Duration: 28
 3780	careful therapeutic educational nurse's hat	0		Experience: +1, Monster Level: -10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk"
 3781	blank prescription sheet	0		
 3782	dehydrated squat yellow bottle of melodramamine	1		Effect: "Egg-stortionary Tactics", Effect Duration: 25
@@ -3764,7 +3764,7 @@
 3809	pulsating Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	tiny decent chocolate-frosted king cake	1	good	Last Available: "2009-06"
+3812	decent tiny chocolate-frosted king cake	1	good	Last Available: "2009-06"
 3813	scorching plastic baby	0		Hot Damage: +25, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	pulsating half-height unicycle	0		Familiar Weight: +5
@@ -3782,10 +3782,10 @@
 3828	Grandma's Map	0		
 3829	enchanted normal tempura radish	3	good	Effect: "Clyde's Blessing", Effect Duration: 50
 3830	spinning skewed energetic water-polo cap	0		Maximum MP Percent: +20, Familiar Effect: "1xVolley, 1xBarrr"
-3831	weak delicious Typical Tavern swill	2	awesome	
-3832	smooth irresponsibly strong tropical swill	8	awesome	
+3831	delicious weak Typical Tavern swill	2	awesome	
+3832	irresponsibly strong smooth tropical swill	8	awesome	
 3833	acceptable maroon fruity girl swill	4	good	
-3834	bad fortified blended swill	5	decent	
+3834	fortified bad blended swill	5	decent	
 3835	red costume wardrobe	0		Softcore Only
 3836	lard-coated Elvish sunglasses of the ox of dire peril of the glutton	0		Muscle: +20, Weapon Damage: +20, Sleaze Spell Damage: +25, Food Drop: +100, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	stiffened anniversary safety glass vest	0		Damage Reduction: 1
@@ -3844,7 +3844,7 @@
 3890	deionized vial of violet slime	0		Effect: "Quiet 'n' Good", Effect Duration: 22
 3891	extra-wet triple-alkaline blurry vial of vermilion slime	0		Effect: "Standard Cheer", Effect Duration: 41
 3892	galvanized extra-anodized ghostly vial of amber slime	0		Effect: "Dance Interpreter", Effect Duration: 19
-3893	frozen quadruple-quantum pulsating maroon vial of chartreuse slime	0		Effect: "Colorful Gratitude", Effect Duration: 40
+3893	frozen quadruple-quantum maroon pulsating vial of chartreuse slime	0		Effect: "Colorful Gratitude", Effect Duration: 40
 3894	quadruple-pickled triple-quantum warmed vial of teal slime	0		Effect: "Arabian Knighthood", Effect Duration: 56
 3895	pickled vial of indigo slime	0		Effect: "Uncanny Shot", Effect Duration: 38
 3896	Vulcanized vial of slime	0		Effect: "Buff as a Baobab", Effect Duration: 44
@@ -3922,7 +3922,7 @@
 3970	wobbly family-friendly nasty Abyssal ember	0		Stench Damage: +5, Sleaze Resistance: +1, Class: "Seal Clubber"
 3971	triple-deionized cyan frost-rimed seal hide	0		Effect: "Graham Crackling", Effect Duration: 50
 3972	jittery Jeselnik's seal spine of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +25, Class: "Seal Clubber"
-3973	triple-quantum skewed fuchsia seal lube	0		Effect: "Material Witness", Effect Duration: 23
+3973	triple-quantum fuchsia skewed seal lube	0		Effect: "Material Witness", Effect Duration: 23
 3974	green knitted brainy mannequin leg	0		Mysticality: +5, Cold Resistance: +3, Class: "Seal Clubber"
 3975	therapeutic padded tortoise of the empath	0		Familiar Weight: +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 6
 3976	ghostly jittery Temple Grandin's quilted tortoboggan	0		Damage Absorption: +40, Familiar Weight: +7, Single Equip
@@ -3938,13 +3938,13 @@
 3986	samurai turtle	0		
 3987	blinking Jeselnik's samurai turtle helmet	0		Sleaze Damage: +25, Item Drop: +5, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	narrow turtle shell	0		
-3989	teal shaking turtle shell powder	0		
+3989	shaking teal turtle shell powder	0		
 3990	Rosewater's turtle shell helmet	0		Mysticality Percent: +30, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	squat tumbling slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
-3995	squat purple bundle of chamoix	0		
+3995	purple squat bundle of chamoix	0		
 3996	tumbling boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	metrognome	0		Familiar Weight: +5
@@ -4019,7 +4019,7 @@
 4067	yellow essence of heat	0		Last Available: "2009-06"
 4068	maroon essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
-4070	twirling shaking essence of stench	0		Last Available: "2009-06"
+4070	shaking twirling essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	yellow Supreme Being Glossary	0		Last Available: "2009-06"
@@ -4034,7 +4034,7 @@
 4082	arcane researcher's experienced pernicious cudgel	0		Experience: +2, Experience Percent (Mysticality): +10, Slime Hates It: +1
 4083	stale cupcake-in-a-cup	3	decent	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	gigantic tasty jittery squat protein paste	6	awesome	Last Available: "2009-06"
+4085	tasty gigantic jittery squat protein paste	6	awesome	Last Available: "2009-06"
 4086	chilly groovy cyber-mattock	0		Moxie Percent: +10, Cold Damage: +5, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	skewed X-37 gun	0		Last Available: "2009-06"
@@ -4082,16 +4082,16 @@
 4130	squat empty agua de vida bottle	0		Last Available: "2009-06"
 4131	modified boot plant	1	awesome	Last Available: "2009-06"
 4132	acceptable fancy sham champagne	3	good	Effect: "Shoesauce", Effect Duration: 35, Last Available: "2009-06"
-4133	ionized blue shaking tempura air	0		Effect: "No Worries", Effect Duration: 56
+4133	ionized shaking blue tempura air	0		Effect: "No Worries", Effect Duration: 56
 4134	polarized pressurized potion of pneumaticity	0		Effect: "Expert Vacationer", Effect Duration: 27
-4135	twirling olive moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
+4135	olive twirling moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	green lion tamer's Bag o' Tricks of the cougar of the sewer of doom	0		Moxie: +20, Experience (familiar): +2, Stench Damage: +25, Spooky Spell Damage: +50, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	slime stack	0		
 4138	ghostly a rumpled paper strip	0		
 4139	bouncing a creased paper strip	0		
 4140	shaking a folded paper strip	0		
 4141	a crinkled paper strip	0		
-4142	jittery bouncing teal a crumpled paper strip	0		
+4142	bouncing teal jittery a crumpled paper strip	0		
 4143	a ragged paper strip	0		
 4144	pulsating a ripped paper strip	0		
 4145	brawny funny paper hat	0		Muscle Percent: +20, Familiar Effect: "1xVolley, 1xLep, cap 2"
@@ -4109,11 +4109,11 @@
 4157	blinking gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	watered-down delicious pebblebr&auml;u	2	awesome	Last Available: "2009-09"
+4160	delicious watered-down pebblebr&auml;u	2	awesome	Last Available: "2009-09"
 4161	bland immense rocky road ice cream	10	decent	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	dry huge children of the candy corn	0		Effect: "Seeing Colors", Effect Duration: 69
-4164	cold-filtered magnetized pulsating yellow Good 'n' Slimy	0		Effect: "Sinuses For Miles", Effect Duration: 55
+4164	cold-filtered magnetized yellow pulsating Good 'n' Slimy	0		Effect: "Sinuses For Miles", Effect Duration: 55
 4165	mirror friendly experienced Staff of the Soupbone of the overflowing toilet	0		Experience: +2, Familiar Weight: +3, Stench Spell Damage: +50
 4166	blurry bouncing Voluminous Radio Pants of chilblains	0		Cold Damage: +25, Familiar Effect: "2xGhoul, cap 37"
 4167	beefcake's Voluminous Radio Hat	0		Muscle: +25, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4189,7 +4189,7 @@
 4237	maroon shaking educational cheese-slicer	0		Experience: +1
 4238	stale squat beef jerky	3	decent	
 4239	huge jittery flame-wreathed pipe wrench	0		Hot Spell Damage: +10
-4240	frozen upside-down narrow gun cleaning kit	0		Effect: "Happy Trails", Effect Duration: 28
+4240	frozen narrow upside-down gun cleaning kit	0		Effect: "Happy Trails", Effect Duration: 28
 4241	narrow supercharged sleep mask	0		Maximum MP Percent: +30, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	blinking savvy sock garters	0		Mysticality Percent: +20, Single Equip
 4243	tarnished mariachi toothpaste	0		Effect: "Bat Attitude", Effect Duration: 42
@@ -4316,7 +4316,7 @@
 4364	oxidized purple elven suicide capsule	0		Effect: "Cotton Mouthed", Effect Duration: 55, Last Available: "2009-12"
 4365	bland penguin focaccia bread	3	decent	Last Available: "2009-12"
 4366	lousy herringcello	3	decent	Last Available: "2009-12"
-4367	bad high-proof elven cellocello	6	decent	Last Available: "2009-12"
+4367	high-proof bad elven cellocello	6	decent	Last Available: "2009-12"
 4368	shaking wrench handle	0		Last Available: "2009-12"
 4369	maroon handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4374,7 +4374,7 @@
 4423	sealhide snare	0		
 4424	puzzling trophy	0		
 4425	super-tarnished sealhide seal doll	0		Effect: "Flamingly Floral", Effect Duration: 54
-4426	twirling lime green hymnal	0		Skill: "Canticle of Carboloading"
+4426	lime green twirling hymnal	0		Skill: "Canticle of Carboloading"
 4428	glowstick on a string of the businessman	0		Meat Drop: +50
 4429	huge auspicious candy necklace	0		Item Drop: +10, Single Equip
 4430	jittery teddybear backpack of mayonnaise	0		Sleaze Spell Damage: +50
@@ -4408,7 +4408,7 @@
 4460	Jim Carey's rosy-cheeked snailmail hauberk	0		Maximum HP Percent: +30, Monster Level: +25
 4461	quantum corrupted seal-brain elixir	0		Effect: "I See Everything Thrice!", Effect Duration: 49
 4462	dry wet liquefied shaking chocolate seal-clubbing club	0		Effect: "Balls of Ectoplasm", Effect Duration: 11
-4463	energized wet upside-down spinning chocolate turtle totem	0		Effect: "Boon of the War Snapper", Effect Duration: 43
+4463	energized wet spinning upside-down chocolate turtle totem	0		Effect: "Boon of the War Snapper", Effect Duration: 43
 4464	deionized unsweetened mirror chocolate pasta spoon	0		Effect: "Disdain of the War Snapper", Effect Duration: 21
 4465	tarnished shaking chocolate saucepan	0		Effect: "Going Ape", Effect Duration: 43
 4466	enhanced unsweetened pulsating chocolate disco ball	0		Effect: "Frostbeard", Effect Duration: 55
@@ -4460,7 +4460,7 @@
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	decent skewed yellow Humpty Dumplings	4	good	Last Available: "2010-03"
-4515	stale big maroon mirror Lobster <i>qua</i> Grill	5	decent	Last Available: "2010-03"
+4515	stale big mirror maroon Lobster <i>qua</i> Grill	5	decent	Last Available: "2010-03"
 4516	drinkable twirling missing wine	4	good	Last Available: "2010-03"
 4517	gigantic moldy gray matter custard	6	crappy	Last Available: "2010-03"
 4518	pressed energized comfit?	0		Effect: "Danish Cunning", Effect Duration: 36, Last Available: "2010-03"
@@ -4470,14 +4470,14 @@
 4522	special spinning teal Tiger-lily's milk	1	good	Effect: "Berry Berry Cold", Effect Duration: 25, Last Available: "2010-03"
 4523	spinning sizzling slick eye of the Tiger-lily	0		Moxie: +10, Hot Damage: +10, Last Available: "2010-03"
 4524	fortified Rosewater's wig	0		Mysticality Percent: +30, Damage Absorption: +60, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	spoiled tumbling gray donut	4	crappy	Last Available: "2010-03"
+4525	spoiled gray tumbling donut	4	crappy	Last Available: "2010-03"
 4526	flavorless bucket of honey	4	decent	Last Available: "2010-03"
 4527	cyan toasty Sinatra's elephant stinger	0		Experience (Moxie): +5, Hot Damage: +5, Last Available: "2010-03"
-4528	small rotten ghostly dragon snaps	2	crappy	Last Available: "2010-03"
+4528	rotten small ghostly dragon snaps	2	crappy	Last Available: "2010-03"
 4529	energetic boxer's snapdragon pistil	0		Muscle Percent: +10, Maximum MP Percent: +20, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	tasty massive rook cookie	6	awesome	Last Available: "2010-03"
-4532	flavorless jumbo enchanted bishop cookie	5	decent	Effect: "Destructive Resolve", Effect Duration: 5, Last Available: "2010-03"
+4532	jumbo enchanted flavorless bishop cookie	5	decent	Effect: "Destructive Resolve", Effect Duration: 5, Last Available: "2010-03"
 4533	bland upside-down knight cookie	3	decent	Last Available: "2010-03"
 4534	decent king cookie	4	good	Last Available: "2010-03"
 4535	decent shaking queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
@@ -4495,7 +4495,7 @@
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
 4549	wobbly carpenter	0		Last Available: "2010-03"
-4550	tumbling maroon dodo	0		Last Available: "2010-03"
+4550	maroon tumbling dodo	0		Last Available: "2010-03"
 4551	upside-down detour shield of the cheetah	0		Initiative: +60, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
 4553	lowercase a	0		
@@ -4514,7 +4514,7 @@
 4566	teal fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	prompt lightning-fast flyest of shirts	0		Initiative: +40, Adventures: +3, Last Available: "2010-04"
 4568	bland a dance upon the palate	3	decent	Last Available: "2010-04"
-4569	massive normal prehistoric meteorite jawbreaker	10	good	Last Available: "2010-04"
+4569	normal massive prehistoric meteorite jawbreaker	10	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	tiny spoiled squirmy violent party snack	1	crappy	Last Available: "2010-04"
 4572	squat studded can-you-dig-it?	0		Damage Absorption: +80, Last Available: "2010-04"
@@ -4527,7 +4527,7 @@
 4579	cold-filtered pickled Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Third Based", Effect Duration: 66, Last Available: "2010-04"
 4580	baleful school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Spell Damage: +25, Last Available: "2010-04"
 4581	Van der Graaf educational T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience: +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-04", Wiki Name: "Bugged baio"
-4582	jittery blinking fat bottom quark	0		Last Available: "2010-05"
+4582	blinking jittery fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	small normal six wedges of goat cheese	2	good	
 4585	teal collection of objects	0		
@@ -4547,12 +4547,12 @@
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	smooth fortified plastic cup of beer	5	awesome	Last Available: "2010-06"
-4602	maroon wobbly orquette's phone number	0		Last Available: "2010-06"
+4602	wobbly maroon orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	ribald supercool bottle of Goldschn&ouml;ckered	0		Moxie Percent: +20, Sleaze Damage: +10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	adequate miniature sun-dried tofu	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	hand-crafted strong spinning soyburger juice	5	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	strong hand-crafted spinning soyburger juice	5	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	pulsating respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	non-quantum squat essential soy	0		Effect: "Barking Mad", Effect Duration: 12, Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	spinning map to the Magic Commune	0		Last Available: "2010-08"
 4614	nippy Crown of Thrones	0		Cold Damage: +10, Softcore Only, Last Available: "2010-05"
-4615	bad special watered-down jittery Cinco Mayo Lager	2	decent	Effect: "Saucegoggles", Effect Duration: 10, Last Available: "2010-05"
+4615	special bad watered-down jittery Cinco Mayo Lager	2	decent	Effect: "Saucegoggles", Effect Duration: 10, Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4616,7 +4616,7 @@
 4668	observational glasses of the boozehound	0		Booze Drop: +100
 4669	blurry scandalous hilarious comedy prop	0		Sleaze Damage: +5
 4670	upside-down beer-scented teddy bear	0		
-4671	drinkable irresponsibly strong special squat booze-soaked cherry	8	good	Effect: "Dreadful Heat", Effect Duration: 30
+4671	special drinkable irresponsibly strong squat booze-soaked cherry	8	good	Effect: "Dreadful Heat", Effect Duration: 30
 4672	comfy pillow	0		
 4673	snack-sized moldy marshmallow	2	crappy	
 4674	normal mirror sponge cake	4	good	
@@ -4639,7 +4639,7 @@
 4691	skewed fossilized wing	0		Last Available: "2010-09"
 4692	mirror fossilized limb	0		Last Available: "2010-09"
 4693	gray fossilized torso	0		Last Available: "2010-09"
-4694	huge red fossilized spine	0		Last Available: "2010-09"
+4694	red huge fossilized spine	0		Last Available: "2010-09"
 4695	shaking affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
 4696	lion tamer's Greatest American Pants of wisdom of chilblains	0		Mysticality: +15, Experience (familiar): +2, Cold Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	friendly fossilized necklace	0		Familiar Weight: +3, Last Available: "2010-09"
@@ -4657,10 +4657,10 @@
 4709	hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	narrow sweatpants	0		Familiar Effect: "8xPotato, cap 2"
-4712	upside-down blinking mirror GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
+4712	mirror blinking upside-down GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	moldy lemon popsicle	4	crappy	
-4715	gigantic decent tumbling popsicle	10	good	
+4715	decent gigantic tumbling popsicle	10	good	
 4716	snack-sized rotten mirror strawberry popsicle	2	crappy	
 4717	rotten liver popsicle	4	crappy	
 4718	steel-toed mariachi hat	0		Damage Reduction: 9, Familiar Effect: "atk, cap 2"
@@ -4668,15 +4668,15 @@
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	jumbo spoiled liver and let pie	5	crappy	Last Available: "2010-10"
-4723	half-sized tasty badass pie	2	awesome	Last Available: "2010-10"
+4723	tasty half-sized badass pie	2	awesome	Last Available: "2010-10"
 4724	flavorless shoo-fish pie	3	decent	Last Available: "2010-10"
 4725	normal miniature piping organ pie	2	good	Last Available: "2010-10"
-4726	normal enchanted igloo pie	3	good	Effect: "Frostbeard", Effect Duration: 25, Last Available: "2010-10"
+4726	enchanted normal igloo pie	3	good	Effect: "Frostbeard", Effect Duration: 25, Last Available: "2010-10"
 4727	moldy stomach turnover	3	crappy	Last Available: "2010-10"
 4728	stale dead lights pie	3	decent	Last Available: "2010-10"
 4729	flavorless throbbing organ pie	3	decent	Last Available: "2010-10"
 4730	stop shield of temperance	0		Sleaze Resistance: +5, Damage Reduction: 6, Last Available: "2009-12"
-4731	cyan shaking nest egg	0		
+4731	shaking cyan nest egg	0		
 4732	fuchsia sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	kitty sheet music	0		Familiar Weight: +5
 4734	mirror rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
@@ -4685,13 +4685,13 @@
 4737	bouncing Jeselnik's beer-soaked mop	0		Sleaze Damage: +25
 4738	practically non-alcoholic mediocre day-old beer	1	decent	
 4739	delicious special plain beer	4	awesome	Effect: "Ghost Finger", Effect Duration: 20
-4740	weak smooth overpriced &quot;imported&quot; beer	2	awesome	
+4740	smooth weak overpriced &quot;imported&quot; beer	2	awesome	
 4741	shaking smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	wet liquefied PlexiPips	0		Effect: "Meatwise", Effect Duration: 34
 4745	alkaline denatured narrow Wax Flask	0		Effect: "Hella Smooth", Effect Duration: 50
-4746	activated double-quantum spinning skewed Pain Dip	0		Effect: "Brother Corsican's Blessing", Effect Duration: 34
+4746	activated double-quantum skewed spinning Pain Dip	0		Effect: "Brother Corsican's Blessing", Effect Duration: 34
 4747	adequate bone meal	4	good	Last Available: "2010-10"
 4748	delicious mirror bone aperitif	3	awesome	Last Available: "2010-10"
 4749	bonerang of the cougar	0		Moxie: +20, Last Available: "2010-10"
@@ -4709,7 +4709,7 @@
 4761	jittery pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	rotten wobbly pumpkin pie	3	crappy	Last Available: "2010-11"
-4764	watered-down aged teal ghostly pumpkin beer	2	awesome	Last Available: "2010-11"
+4764	aged watered-down ghostly teal pumpkin beer	2	awesome	Last Available: "2010-11"
 4765	double-denatured enhanced alkaline maroon pumpkin juice	0		Effect: "Stimulated Body", Effect Duration: 23, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	tumbling clever padded shin gourds	0		Damage Absorption: +20, Maximum MP: +20, Single Equip, Last Available: "2010-11"
@@ -4737,7 +4737,7 @@
 4828	S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	narrow robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
-4831	huge upside-down robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
+4831	upside-down huge robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	cyan blurry robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	mirror robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
@@ -4745,7 +4745,7 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	rotten gray pulsating triangular CRIMBCOOKIE	3	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	rotten pulsating gray triangular CRIMBCOOKIE	3	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	bland square CRIMBCOOKIE	3	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	upside-down veiny supercool bindlestocking of the empath	0		Moxie Percent: +20, Maximum HP: +10, Familiar Weight: +5, Last Available: "2010-12"
 4842	olive sleeping stocking	0		Last Available: "2010-12"
@@ -4757,7 +4757,7 @@
 4848	pulsating Samson's Uncle Hobo's fingerless tinsel gloves of the brazier	0		Experience (Muscle): +5, Hot Spell Damage: +25, Single Equip, Last Available: "2010-12"
 4849	ribald toasty Uncle Hobo's highest bough	0		Hot Damage: +5, Sleaze Damage: +10, Last Available: "2010-12"
 4850	Jack Frost's padded Uncle Hobo's belt	0		Damage Absorption: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2010-12"
-4851	dry moist alkaline lime green pulsating chocolate cigar	0		Effect: "Sausage Festive", Effect Duration: 60, Last Available: "2010-12"
+4851	dry moist alkaline pulsating lime green chocolate cigar	0		Effect: "Sausage Festive", Effect Duration: 60, Last Available: "2010-12"
 4852	fortified gift-a-pult	0		Damage Absorption: +60, Last Available: "2010-12"
 4853	energized holly-flavored Hob-O	0		Effect: "Omphalotus Omnipresence", Effect Duration: 45, Last Available: "2020-09"
 4854	red CRIMBCO scrip	0		Last Available: "2011-01"
@@ -4794,7 +4794,7 @@
 4885	blinking traffic jam	0		Last Available: "2011-01"
 4886	moldy spinning traffic jam toast	3	crappy	Last Available: "2011-01"
 4887	shaking space jam	0		Last Available: "2011-01"
-4888	small stale teal space jam toast	2	decent	Last Available: "2011-01"
+4888	stale small teal space jam toast	2	decent	Last Available: "2011-01"
 4889	cold-filtered narrow motivational poster	0		Effect: "Moon'd", Effect Duration: 21, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
@@ -4855,11 +4855,11 @@
 4952	dry vacuum-sealed baggie of sugar	0		Effect: "Phorcefullness", Effect Duration: 59
 4953	Sherlock's wool whalebone corset	0		Cold Resistance: +1, Item Drop: +25, Single Equip
 4954	frosty oven mitts	0		Cold Spell Damage: +10, Single Equip
-4955	normal tiny tumbling overcookie	1	good	
+4955	tiny normal tumbling overcookie	1	good	
 4956	bland diet philosopher's scone	1	decent	
 4957	oxidized colloidal half-baked potion	0		Effect: "Sappy Blood", Effect Duration: 58
 4958	chaotic Knob Goblin deluxe scimitar	0		Spell Critical Percent: +10
-4959	decent gigantic Knob nuts	8	good	
+4959	gigantic decent Knob nuts	8	good	
 4960	high-proof mediocre Cobb's Knob Wurstbrau	7	decent	
 4961	tumbling Subject 37 file	0		
 4962	bouncing horrifying padded mysterious lapel pin	0		Damage Absorption: +20, Spooky Damage: +25, Single Equip
@@ -4869,7 +4869,7 @@
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	huge blinking Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
-4969	maroon skewed Alice's Army Halberder	0		Last Available: "2011-03"
+4969	skewed maroon Alice's Army Halberder	0		Last Available: "2011-03"
 4970	bouncing Alice's Army Guard	0		Last Available: "2011-03"
 4971	shaking Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
@@ -4907,7 +4907,7 @@
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
-5007	skewed red Alice's Army Foil Martyr	0		Last Available: "2011-03"
+5007	red skewed Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	ghostly prompt card sleeve	0		Adventures: +3, Last Available: "2011-03"
 5010	evil eye	0		
@@ -4955,7 +4955,7 @@
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
-5055	cyan bouncing obnoxious riddle	0		Last Available: "2011-04"
+5055	bouncing cyan obnoxious riddle	0		Last Available: "2011-04"
 5056	spinning best joke ever	0		Last Available: "2011-04"
 5057	altered chilled maroon Atomic Comic	0		Effect: "Night of the Nachos", Effect Duration: 41, Last Available: "2011-04"
 5058	polymerized quadruple-adjusted ghostly Red Pill	0		Effect: "Just Aged Enough", Effect Duration: 60, Last Available: "2011-04"
@@ -4964,11 +4964,11 @@
 5061	blinking boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
-5064	cyan wobbly Salsa de las Epocas	0		Last Available: "2011-04"
-5065	snack-sized flavorless skewed spaghetti con calaveras	2	decent	Last Available: "2011-04"
+5064	wobbly cyan Salsa de las Epocas	0		Last Available: "2011-04"
+5065	flavorless snack-sized skewed spaghetti con calaveras	2	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	adequate mirror ghostly popcorn	3	good	Last Available: "2011-04"
-5068	delicious bite-sized chaos popcorn	1	awesome	Last Available: "2011-04"
+5067	adequate ghostly mirror popcorn	3	good	Last Available: "2011-04"
+5068	bite-sized delicious chaos popcorn	1	awesome	Last Available: "2011-04"
 5069	squat sizzling ruddy hole of the brazier	0		Maximum HP Percent: +40, Hot Damage: +10, Hot Spell Damage: +25, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	bland fancy s'more	0	decent	Effect: "Nothing Is Impossible", Effect Duration: 20, Last Available: "2011-04"
@@ -5003,7 +5003,7 @@
 5100	boxer's Pok&euml;mann figurine: Frank	0		Muscle Percent: +10, Single Equip, Last Available: "2011-05"
 5101	lard-coated Pok&euml;mann figurine: Moog	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2011-05"
 5102	electrified willyweed	0		Effect: "Cake Caked", Effect Duration: 59, Last Available: "2011-05"
-5103	non-polarized irradiated pulsating green Nuclear Blastball	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 69, Last Available: "2011-05"
+5103	non-polarized irradiated green pulsating Nuclear Blastball	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 69, Last Available: "2011-05"
 5104	Vulcanized fish juice box	0		Effect: "The Power of Negative Thinking", Effect Duration: 41, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	blurry hideous egg	0		Last Available: "2011-05"
@@ -5020,7 +5020,7 @@
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
 5119	busted wings	0		
-5120	narrow red Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
+5120	red narrow Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	auspicious coward's Rosewater's Admiral's hat	0		Mysticality Percent: +30, Monster Level: -20, Item Drop: +10, Familiar Effect: "atk", Last Available: "2011-05"
 5122	shaking fuchsia shaking energetic aviator's cap of mayonnaise of the sweet-tooth	0		Maximum MP Percent: +20, Sleaze Spell Damage: +50, Candy Drop: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	asbestos-lined Samson's mirrored aviator shades	0		Experience (Muscle): +5, Hot Resistance: +5, Single Equip, Last Available: "2011-05"
@@ -5032,8 +5032,8 @@
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	tarnished narrow Ultrasoldier Serum	0		Effect: "Hombre Muerto Caminando", Effect Duration: 63, Last Available: "2011-06"
-5132	spoiled half-sized huge squat fuchsia elven hardtack	2	crappy	Last Available: "2011-06"
-5133	mediocre twirling skewed jittery elven squeeze	3	decent	Last Available: "2011-06"
+5132	spoiled half-sized fuchsia huge squat elven hardtack	2	crappy	Last Available: "2011-06"
+5133	mediocre jittery twirling skewed elven squeeze	3	decent	Last Available: "2011-06"
 5134	upside-down lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5046,7 +5046,7 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	triple-galvanized modified twirling honeypot	0		Effect: "Abyssal Blood", Effect Duration: 46
-5146	decent immense wild honey pie	6	good	
+5146	immense decent wild honey pie	6	good	
 5147	watered-down mediocre honey mead	2	decent	
 5148	tumbling foul-smelling stiffened honey dipper of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Stench Damage: +10
 5149	hardy honeybritches of the bloodbag of mayonnaise	0		Maximum HP: 150, Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5075,7 +5075,7 @@
 5172	yellow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	mediocre Saison du Lune	3	decent	Last Available: "2011-06"
-5175	tolerable weak skewed Moonthril Schnapps	2	good	Last Available: "2011-06"
+5175	weak tolerable skewed Moonthril Schnapps	2	good	Last Available: "2011-06"
 5176	watered-down delicious huge Wrecked Generator	2	awesome	Last Available: "2011-06"
 5177	flavorless squat Spaghetti with Moonballs	4	decent	Last Available: "2011-06"
 5178	snack-sized bland Crepes a la Lune	2	decent	Last Available: "2011-06"
@@ -5093,7 +5093,7 @@
 5190	avaricious wicked Operation Patriot Shield of chilblains	0		Spell Damage: +5, Cold Damage: +25, Meat Drop: +30, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	ghostly squirming egg sac	0		Last Available: "2011-06"
 5192	quadruple-modified ionized blinking corrupted data	0		Effect: "Disco Concentration", Effect Duration: 52, Last Available: "2011-06"
-5193	tumbling shaking 11-inch knob sausage	0		
+5193	shaking tumbling 11-inch knob sausage	0		
 5194	exorcised sandwich	0		
 5195	blue Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	smelly Great S-Cape	0		Stench Spell Damage: +10, Softcore Only, Last Available: "2011-07"
@@ -5106,7 +5106,7 @@
 5203	vaporized bug paste	1	awesome	Last Available: "2011-08"
 5204	diluted bouncing hippy paste	1	decent	Last Available: "2011-08"
 5205	modified orc paste	1	EPIC	Last Available: "2011-08"
-5206	boiled mirror spinning demonic paste	1	decent	Last Available: "2011-08"
+5206	boiled spinning mirror demonic paste	1	decent	Last Available: "2011-08"
 5207	denatured skewed upside-down indescribably horrible paste	1	good	Last Available: "2011-08"
 5208	powdered spinning paste	1	decent	Last Available: "2011-08"
 5209	dried goblin paste	1	decent	Last Available: "2011-08"
@@ -5120,11 +5120,11 @@
 5217	distilled fuchsia cosmic paste	1	good	Effect: "Red Misty-Eyed", Effect Duration: 15, Last Available: "2011-08"
 5218	vaporized blurry hobo paste	1	EPIC	Last Available: "2011-08"
 5219	boiled pulsating Crimbo paste	1	crappy	Last Available: "2011-08"
-5220	yellow shaking skewed Teachings of the Fist	0		
+5220	skewed yellow shaking Teachings of the Fist	0		
 5221	spinning fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	stale miniature Ur-Donut	2	decent	Last Available: "2011-09"
+5224	miniature stale Ur-Donut	2	decent	Last Available: "2011-09"
 5225	blurry The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	tolerable bucket of wine	3	good	Last Available: "2011-09"
@@ -5139,26 +5139,26 @@
 5236	gravedigger's frosty halo	0		Spooky Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of vim and vigor	0		Maximum HP Percent: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	bad Lumineux Limnio	3	decent	Last Available: "2011-09"
-5239	practically non-alcoholic bad Morto Moreto	1	decent	Last Available: "2011-09"
-5240	drinkable high-proof Temps Tempranillo	9	good	Last Available: "2011-09"
+5239	bad practically non-alcoholic Morto Moreto	1	decent	Last Available: "2011-09"
+5240	high-proof drinkable Temps Tempranillo	9	good	Last Available: "2011-09"
 5241	tolerable irresponsibly strong Bordeaux Marteaux	7	good	Last Available: "2011-09"
-5242	smooth weak ghostly Fromage Pinotage	2	awesome	Last Available: "2011-09"
+5242	weak smooth ghostly Fromage Pinotage	2	awesome	Last Available: "2011-09"
 5243	delicious Beignet Milgranet	4	awesome	Last Available: "2011-09"
 5244	hand-crafted Muschat	3	EPIC	Last Available: "2011-09"
-5245	moldy special cool jelly donut	3	crappy	Effect: "Crimbo Nostalgia", Effect Duration: 15, Last Available: "2011-09"
+5245	special moldy cool jelly donut	3	crappy	Effect: "Crimbo Nostalgia", Effect Duration: 15, Last Available: "2011-09"
 5246	diet delicious shrapnel jelly donut	1	awesome	Last Available: "2011-09"
 5247	tasty shaking occult jelly donut	3	awesome	Last Available: "2011-09"
 5248	bland thyme jelly donut	3	decent	Last Available: "2011-09"
 5249	spoiled massive danish	6	crappy	Last Available: "2011-09"
 5250	fancy rotten smashed danish	3	crappy	Effect: "Your Favorite Flavor", Effect Duration: 40, Last Available: "2011-09"
-5251	bland small fuchsia forbidden danish	2	decent	Last Available: "2011-09"
+5251	small bland fuchsia forbidden danish	2	decent	Last Available: "2011-09"
 5252	decent cool cat claw	3	good	Last Available: "2011-09"
-5253	bland bite-sized blunt cat claw	1	decent	Last Available: "2011-09"
+5253	bite-sized bland blunt cat claw	1	decent	Last Available: "2011-09"
 5254	decent shadowy cat claw	3	good	Last Available: "2011-09"
-5255	toothsome half-sized cheezburger	2	awesome	Last Available: "2011-09"
+5255	half-sized toothsome cheezburger	2	awesome	Last Available: "2011-09"
 5256	spoiled wobbly toasted brie	4	crappy	Last Available: "2011-09"
 5257	tarnished potion of the field gar	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 63, Last Available: "2011-09"
-5258	dry dry huge upside-down bouncing too legit potion	0		Effect: "Turkey-Friendly", Effect Duration: 45, Last Available: "2011-09"
+5258	dry dry upside-down bouncing huge too legit potion	0		Effect: "Turkey-Friendly", Effect Duration: 45, Last Available: "2011-09"
 5259	energized modified blinking Bright Water	0		Effect: "Memento Moir&eacute;", Effect Duration: 28, Last Available: "2011-09"
 5260	chilled cold-filtered water	0		Effect: "You Know Where to Go", Effect Duration: 25, Last Available: "2011-09"
 5261	triple-moist diffused red graveyard snowglobe	0		Effect: "Ironclad", Effect Duration: 49, Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	mirror slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	super-sized toothsome spinning phish stick	5	awesome	Last Available: "2011-09"
+5298	toothsome super-sized spinning phish stick	5	awesome	Last Available: "2011-09"
 5299	gray asbestos-lined mansplainer's resourceful plastic vampire fangs	0		Maximum MP: +50, Monster Level: +15, Hot Resistance: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	skewed Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5211,24 +5211,24 @@
 5308	ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
 5310	shotgun shell	0		Last Available: "2011-10"
-5311	bouncing mirror funhouse mirror	0		Last Available: "2011-10"
+5311	mirror bouncing funhouse mirror	0		Last Available: "2011-10"
 5312	dry ionized ghostly body paint	0		Effect: "Egg-stra Arm", Effect Duration: 41, Last Available: "2011-10"
 5313	ionized quadruple-moist necrotizing body spray	0		Effect: "How to Scam Tourists", Effect Duration: 59, Last Available: "2011-10"
 5314	ionized galvanized skewed bite-me-red lipstick	0		Effect: "Wallflowering", Effect Duration: 69, Last Available: "2011-10"
 5315	warmed wobbly whisker pencil	0		Effect: "Starry-Eyed", Effect Duration: 26, Last Available: "2011-10"
 5316	alkaline corrupted diffused spinning press-on ribs	0		Effect: "Good with the Ladies", Effect Duration: 16, Last Available: "2011-10"
 5317	liquefied quadruple-adjusted Rattlin' Chains	0		Effect: "Wintry Breath", Effect Duration: 21, Last Available: "2011-10"
-5318	colloidal ghostly wobbly tumbling Gummy Brains	0		Effect: "Bats in the Belfry", Effect Duration: 49, Last Available: "2011-10"
+5318	colloidal ghostly tumbling wobbly Gummy Brains	0		Effect: "Bats in the Belfry", Effect Duration: 49, Last Available: "2011-10"
 5319	enhanced enhanced ionized blurry Blood 'n' Plenty	0		Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2011-10"
 5320	corrupted pressed Lobos Mints	0		Effect: "Haunted Liver", Effect Duration: 69, Last Available: "2011-10"
 5321	extra-wet irradiated ghostly Sweet Sword	0		Effect: "Resilient Spirit", Effect Duration: 59, Last Available: "2011-10"
-5322	watered-down acceptable Ecto-Cooler	2	good	Last Available: "2011-10"
-5323	delicious spirit-forward special Bartles and BRAAAINS wine cooler	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 25, Last Available: "2011-10"
-5324	weak perfectly mixed upside-down red Blood Light	2	EPIC	Last Available: "2011-10"
+5322	acceptable watered-down Ecto-Cooler	2	good	Last Available: "2011-10"
+5323	spirit-forward special delicious Bartles and BRAAAINS wine cooler	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 25, Last Available: "2011-10"
+5324	weak perfectly mixed red upside-down Blood Light	2	EPIC	Last Available: "2011-10"
 5325	smooth fortified Silver Bullet beer	5	awesome	Last Available: "2011-10"
 5326	perfectly mixed mirror Bone's Farm &quot;wine&quot;	4	EPIC	Last Available: "2011-10"
 5327	red ghost protocol	0		Last Available: "2011-10"
-5328	alkaline skewed fuchsia sorority brain	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 49, Last Available: "2011-10"
+5328	alkaline fuchsia skewed sorority brain	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 49, Last Available: "2011-10"
 5329	frozen anodized tumbling Nightstalker perfume	0		Effect: "Protection from Bad Stuff", Effect Duration: 60, Last Available: "2011-10"
 5330	ionized activated ghostly drum of pomade	0		Effect: "Slimily Speedy", Effect Duration: 63, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
@@ -5283,7 +5283,7 @@
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	wobbly bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
-5383	pulsating wobbly tourmalime	0		Last Available: "2011-11"
+5383	wobbly pulsating tourmalime	0		Last Available: "2011-11"
 5384	kumquartz	0		Last Available: "2011-11"
 5385	bouncing strawberyl	0		Last Available: "2011-11"
 5386	Da Vinci's ridiculous belt	0		Experience (Mysticality): +5, Last Available: "2011-11"
@@ -5308,18 +5308,18 @@
 5405	maroon miser's clever brainy cane-mail shirt	0		Mysticality: +5, Maximum MP: +20, Meat Drop: +10, Last Available: "2011-12"
 5406	horrifying rock-hard brawny cane-mail pants	0		Muscle Percent: +20, Damage Reduction: 5, Spooky Damage: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	drinkable jittery Vodka Matryoshka	3	good	Last Available: "2011-12"
-5408	watered-down artisanal green Gin Mint	2	EPIC	Last Available: "2011-12"
-5409	weak acceptable cyan shaking Tequiz Navidad	2	good	Last Available: "2011-12"
+5408	artisanal watered-down green Gin Mint	2	EPIC	Last Available: "2011-12"
+5409	weak acceptable shaking cyan Tequiz Navidad	2	good	Last Available: "2011-12"
 5410	weak delicious green Mint Yulep	2	awesome	Last Available: "2011-12"
 5411	delicious gray Crimbojito	4	awesome	Last Available: "2011-12"
 5412	extra-dry drinkable maroon Sangria de Menthe	5	good	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	ionized wobbly licorice root	0		Effect: "Feroci Tea", Effect Duration: 50, Last Available: "2011-12"
-5416	altered energized ghostly jittery banana supersucker	0		Effect: "Graham Crackling", Effect Duration: 45, Last Available: "2011-11"
+5416	altered energized jittery ghostly banana supersucker	0		Effect: "Graham Crackling", Effect Duration: 45, Last Available: "2011-11"
 5417	flattened alkaline pear supersucker	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 21, Last Available: "2011-11"
 5418	triple-vacuum-sealed lime supersucker	0		Effect: "Lobos Fresh", Effect Duration: 46, Last Available: "2011-11"
-5419	moist upside-down green kumquat supersucker	0		Effect: "Red-Shirted Escort", Effect Duration: 47, Last Available: "2011-11"
+5419	moist green upside-down kumquat supersucker	0		Effect: "Red-Shirted Escort", Effect Duration: 47, Last Available: "2011-11"
 5420	colloidal nitrogenated cyan strawberry supersucker	0		Effect: "Sated and Furious", Effect Duration: 29, Last Available: "2011-11"
 5421	rosy-cheeked bananarama bangle	0		Maximum HP Percent: +30, Single Equip, Last Available: "2011-11"
 5422	manspreader's pair of pearidot earrings	0		Monster Level: +10, Single Equip, Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	yellow blurry superheated fudge	0		Last Available: "2011-11"
 5438	non-nitrogenated improved fluid of fudge-finding	0		Effect: "Mariachi Mood", Effect Duration: 28, Last Available: "2011-11"
 5439	upside-down fudgepuck	0		Last Available: "2011-11"
-5440	spoiled snack-sized fudgesicle	2	crappy	Last Available: "2011-11"
+5440	snack-sized spoiled fudgesicle	2	crappy	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5379,11 +5379,11 @@
 5476	frozen gummi salamander	0		Effect: "Healthy Green Glow", Effect Duration: 56, Last Available: "2011-11"
 5477	alkaline gummi snake	0		Effect: "Serenity", Effect Duration: 53, Last Available: "2011-11"
 5478	tarnished polarized gummi canary	0		Effect: "Void Between the Stars", Effect Duration: 54, Last Available: "2011-11"
-5479	super-sized spoiled shaking squat gummi bear	5	crappy	Last Available: "2011-11"
+5479	spoiled super-sized shaking squat gummi bear	5	crappy	Last Available: "2011-11"
 5480	jumbo moldy gummi bear	5	crappy	Last Available: "2011-11"
 5481	normal mirror gummi bear	3	good	Last Available: "2011-11"
 5482	moldy spinning skewed drunki-bear	4	crappy	Last Available: "2011-11"
-5483	adequate upside-down maroon drunki-bear	4	good	Last Available: "2011-11"
+5483	adequate maroon upside-down drunki-bear	4	good	Last Available: "2011-11"
 5484	bland drunki-bear	3	decent	Last Available: "2011-11"
 5485	gummi bowtie of incineration	0		Hot Spell Damage: +50, Last Available: "2011-11"
 5486	yellow coward's fudge pocket square	0		Monster Level: -20, Last Available: "2011-11"
@@ -5396,7 +5396,7 @@
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	enhanced quadruple-wet mirror gummi trilobite	0		Effect: "Jerky, Boy", Effect Duration: 57, Last Available: "2011-11"
 5495	moist mirror spinning gummi ammonite	0		Effect: "Peppermint Bite", Effect Duration: 58, Last Available: "2011-11"
-5496	modified super-ionized pulsating shaking gummi belemnite	0		Effect: "Berry Experiential", Effect Duration: 37, Last Available: "2011-11"
+5496	modified super-ionized shaking pulsating gummi belemnite	0		Effect: "Berry Experiential", Effect Duration: 37, Last Available: "2011-11"
 5497	lime green all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
 5499	flame-wreathed Big Candy's tophat of the ox	0		Muscle: +20, Hot Spell Damage: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
@@ -5412,7 +5412,7 @@
 5509	tarnished ionized squat bottle of bubbles	0		Effect: "Wolf's Bane", Effect Duration: 58, Last Available: "2011-11"
 5510	adjusted super-anodized non-ionized wind-up meatcar	0		Effect: "Work For Hours a Week", Effect Duration: 25, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
-5512	spinning ghostly Trivial Avocations Card: When?	0		Last Available: "2011-11"
+5512	ghostly spinning Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	skewed Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	maroon pog #01 (spider)	0		Last Available: "2011-11"
@@ -5433,7 +5433,7 @@
 5530	flattened spinning baobab sap	0		Effect: "Unrunnable Face", Effect Duration: 61, Last Available: "2012-12"
 5531	squat cup of hickory chicory	0		Last Available: "2012-12"
 5532	wobbly magnolia blossom	0		Last Available: "2012-12"
-5533	Vulcanized squat twirling Mortimer's nostrum	0		Effect: "Hobo Flavor", Effect Duration: 49, Last Available: "2012-12"
+5533	Vulcanized twirling squat Mortimer's nostrum	0		Effect: "Hobo Flavor", Effect Duration: 49, Last Available: "2012-12"
 5534	acceptable enchanted Barulio's bottle	4	good	Effect: "Healthy Bronze Glow", Effect Duration: 5, Last Available: "2012-12"
 5535	ionized Marvin's marvelous pill	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 32, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
@@ -5465,7 +5465,7 @@
 5562	olive grievous Rain-Doh violet bo of the bloodbag	0		Weapon Damage Percent: +50, Maximum HP: +100, Softcore Only, Last Available: "2012-02"
 5563	bouncing Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	yummy diet PB&BP	1	awesome	
+5565	diet yummy PB&BP	1	awesome	
 5566	decent club sandwich	3	good	
 5567	snack-sized spoiled bouncing corned-beef Reuben	2	crappy	
 5568	frayed ninja rope	0		
@@ -5473,26 +5473,26 @@
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	gray Thwaitgold stag beetle statuette	0		
-5573	mediocre fortified Drac & Tan	5	decent	Last Available: "2012-03"
+5573	fortified mediocre Drac & Tan	5	decent	Last Available: "2012-03"
 5574	practically non-alcoholic tolerable Transylvania Sling	1	good	Last Available: "2012-03"
 5575	drinkable watered-down Shot of the Living Dead	2	good	Last Available: "2012-03"
 5576	perfectly mixed blurry Buttery Knob	4	EPIC	Last Available: "2012-03"
 5577	aged Slippery Knob	3	awesome	Last Available: "2012-03"
-5578	artisanal fortified Flaming Knob	5	EPIC	Last Available: "2012-03"
+5578	fortified artisanal Flaming Knob	5	EPIC	Last Available: "2012-03"
 5579	perfectly mixed Grasshopper	3	EPIC	Last Available: "2012-03"
 5580	lousy fancy Locust	4	decent	Effect: "Headstrong", Effect Duration: 5, Last Available: "2012-03"
 5581	aged Plague of Locusts	4	awesome	Last Available: "2012-03"
 5582	aged skewed Red Dwarf	4	awesome	Last Available: "2012-03"
 5583	lousy Golden Mean	4	decent	Last Available: "2012-03"
 5584	bad wobbly Green Giant	3	decent	Last Available: "2012-03"
-5585	lousy practically non-alcoholic skewed shaking Aye Aye	1	decent	Last Available: "2012-03"
+5585	lousy practically non-alcoholic shaking skewed Aye Aye	1	decent	Last Available: "2012-03"
 5586	lousy Aye Aye, Captain	4	decent	Last Available: "2012-03"
 5587	triple-distilled mediocre Aye Aye, Tooth Tooth	8	decent	Last Available: "2012-03"
 5588	lousy wobbly Humanitini	3	decent	Last Available: "2012-03"
-5589	tolerable irresponsibly strong cyan More Humanitini than Humanitini	8	good	Last Available: "2012-03"
+5589	irresponsibly strong tolerable cyan More Humanitini than Humanitini	8	good	Last Available: "2012-03"
 5590	tolerable Oh, the Humanitini	3	good	Last Available: "2012-03"
-5591	delicious distilled Great Older Fashioned	5	awesome	Last Available: "2012-03"
-5592	watered-down perfectly mixed Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5591	distilled delicious Great Older Fashioned	5	awesome	Last Available: "2012-03"
+5592	perfectly mixed watered-down Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	hand-crafted Crazymaker	3	EPIC	Last Available: "2012-03"
 5594	lousy Zoodriver	3	decent	Last Available: "2012-03"
 5595	bad skewed Sloe Comfortable Zoo	4	decent	Last Available: "2012-03"
@@ -5501,43 +5501,43 @@
 5598	mediocre Suppurating Sinner	4	decent	Last Available: "2012-03"
 5599	artisanal Sizzling Sinner	3	EPIC	Last Available: "2012-03"
 5600	mediocre weak Firewater	2	decent	Last Available: "2012-03"
-5601	watered-down mediocre Earth and Firewater	2	decent	Last Available: "2012-03"
-5602	lousy special watered-down olive Earth, Wind and Firewater	2	decent	Effect: "Disco Inferno", Effect Duration: 10, Last Available: "2012-03"
+5601	mediocre watered-down Earth and Firewater	2	decent	Last Available: "2012-03"
+5602	special lousy watered-down olive Earth, Wind and Firewater	2	decent	Effect: "Disco Inferno", Effect Duration: 10, Last Available: "2012-03"
 5603	weak acceptable Slimosa	2	good	Last Available: "2012-03"
-5604	delicious watered-down special twirling Extra-slimy Slimosa	2	awesome	Effect: "Gamer Rage", Effect Duration: 50, Last Available: "2012-03"
+5604	special delicious watered-down twirling Extra-slimy Slimosa	2	awesome	Effect: "Gamer Rage", Effect Duration: 50, Last Available: "2012-03"
 5605	weak tolerable narrow Slimebite	2	good	Last Available: "2012-03"
 5606	hand-crafted Cement Mixer	3	EPIC	Last Available: "2012-03"
-5607	practically non-alcoholic bad Jackhammer	1	decent	Last Available: "2012-03"
-5608	drinkable distilled red Dump Truck	5	good	Last Available: "2012-03"
-5609	practically non-alcoholic hand-crafted Fauna Libre	1	EPIC	Last Available: "2012-03"
+5607	bad practically non-alcoholic Jackhammer	1	decent	Last Available: "2012-03"
+5608	distilled drinkable red Dump Truck	5	good	Last Available: "2012-03"
+5609	hand-crafted practically non-alcoholic Fauna Libre	1	EPIC	Last Available: "2012-03"
 5610	hand-crafted Chakra Libre	3	EPIC	Last Available: "2012-03"
 5611	artisanal Aura Libre	4	EPIC	Last Available: "2012-03"
 5612	artisanal Sazerorc	3	EPIC	Last Available: "2012-03"
 5613	hand-crafted red Sazuruk-hai	4	EPIC	Last Available: "2012-03"
 5614	artisanal tumbling Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	hand-crafted Green Velvet	3	EPIC	Last Available: "2012-03"
-5616	watered-down acceptable Green Muslin	2	good	Last Available: "2012-03"
+5616	acceptable watered-down Green Muslin	2	good	Last Available: "2012-03"
 5617	practically non-alcoholic bad Green Burlap	1	decent	Last Available: "2012-03"
 5618	smooth blurry Mohobo	4	awesome	Last Available: "2012-03"
-5619	tolerable blinking red Moonshine Mohobo	3	good	Last Available: "2012-03"
+5619	tolerable red blinking Moonshine Mohobo	3	good	Last Available: "2012-03"
 5620	delicious Flaming Mohobo	3	awesome	Last Available: "2012-03"
 5621	weak acceptable Drunken Philosopher	2	good	Last Available: "2012-03"
 5622	artisanal weak Drunken Neurologist	2	EPIC	Last Available: "2012-03"
-5623	acceptable practically non-alcoholic wobbly Drunken Astrophysicist	1	good	Last Available: "2012-03"
-5624	watered-down mediocre Dark & Starry	2	decent	Last Available: "2012-03"
+5623	practically non-alcoholic acceptable wobbly Drunken Astrophysicist	1	good	Last Available: "2012-03"
+5624	mediocre watered-down Dark & Starry	2	decent	Last Available: "2012-03"
 5625	hand-crafted Black Hole	4	EPIC	Last Available: "2012-03"
 5626	aged Event Horizon	4	awesome	Last Available: "2012-03"
-5627	special tolerable blurry tumbling Herring Daiquiri	3	good	Effect: "Just Aged Enough", Effect Duration: 5, Last Available: "2012-03"
+5627	special tolerable tumbling blurry Herring Daiquiri	3	good	Effect: "Just Aged Enough", Effect Duration: 5, Last Available: "2012-03"
 5628	acceptable Herring Wallbanger	3	good	Last Available: "2012-03"
 5629	hand-crafted Herringtini	3	EPIC	Last Available: "2012-03"
 5630	hand-crafted Lollipop Drop	4	EPIC	Last Available: "2012-03"
 5631	bad Candy Alexander	3	decent	Last Available: "2012-03"
-5632	lousy boozy Candicaine	5	decent	Last Available: "2012-03"
+5632	boozy lousy Candicaine	5	decent	Last Available: "2012-03"
 5633	perfectly mixed Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	practically non-alcoholic drinkable Flying Caipiranha	1	good	Last Available: "2012-03"
-5635	high-proof perfectly mixed gray Flaming Caipiranha	9	EPIC	Last Available: "2012-03"
-5636	acceptable twirling ghostly tumbling Punchplanter	4	good	Last Available: "2012-03"
-5637	special acceptable Doublepunchplanter	4	good	Effect: "Transcendental Wind", Effect Duration: 20, Last Available: "2012-03"
+5635	perfectly mixed high-proof gray Flaming Caipiranha	9	EPIC	Last Available: "2012-03"
+5636	acceptable ghostly twirling tumbling Punchplanter	4	good	Last Available: "2012-03"
+5637	acceptable special Doublepunchplanter	4	good	Effect: "Transcendental Wind", Effect Duration: 20, Last Available: "2012-03"
 5638	tolerable Haymaker	4	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	spinning crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
@@ -5575,7 +5575,7 @@
 5672	twirling gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	skewed skewed &quot;L&quot;	0		
-5675	vaporized ghostly red spinning watered-down Red Minotaur	1		
+5675	vaporized red spinning ghostly watered-down Red Minotaur	1		
 5676	wobbly pool torpedo	0		Last Available: "2012-05"
 5677	foul-smelling Ze&trade; goggles	0		Stench Damage: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	red soggy used band-aid	0		Last Available: "2012-05"
@@ -5590,14 +5590,14 @@
 5687	red bugbear autopsy tweezers	0		
 5688	deadly UV monocular	0		Weapon Damage: +5, Single Equip
 5689	drone self-destruct chip	0		
-5690	huge bouncing Jeff Goldblum larva	0		
+5690	bouncing huge Jeff Goldblum larva	0		
 5691	jittery pacification grenade	0		
 5692	jittery quantum disintegrator pistol of the pedagogue	0		Experience: +3
 5693	pulsating cyan blurry phase-tuned shield generator belt of temperance	0		Sleaze Resistance: +5, Single Equip
 5694	Thwaitgold woollybear statuette	0		
 5695	hardened bugbear detector	0		Damage Reduction: 3, Single Equip
 5696	bouncing bugbear purification pill	0		
-5697	cyan blurry 1 Meat	0		
+5697	blurry cyan 1 Meat	0		
 5698	wizardly The Lost Glasses of chilblains	0		Mysticality: +25, Cold Damage: +25, Single Equip
 5699	squat The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
@@ -5618,7 +5618,7 @@
 5717	normal super-sized narrow FDKOL hotcakes	5	good	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	spoiled twirling blue fiery wing	3	crappy	Last Available: "2012-07"
+5720	spoiled blue twirling fiery wing	3	crappy	Last Available: "2012-07"
 5721	thinker's beefcake's wings of fire	0		Muscle: +25, Mysticality: +10, Last Available: "2012-07"
 5722	energetic FDKOL fire hose	0		Maximum MP Percent: +20, Last Available: "2012-07"
 5723	extra-improved triple-dry bottle of fire	0		Effect: "Salad Days", Effect Duration: 67, Last Available: "2012-07"
@@ -5629,17 +5629,17 @@
 5728	shaking Fonzie's slick foot-long hot daub	0		Moxie: +10, Experience (Moxie): +1, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	rotten mirror angst burger	3	crappy	
-5731	artisanal watered-down squat 5-hour acrimony	2	EPIC	
+5731	watered-down artisanal squat 5-hour acrimony	2	EPIC	
 5732	blank note	0		
 5733	fuchsia eerily silent box	0		
-5734	spoiled jumbo spinning forbidden sausage	5	crappy	
+5734	jumbo spoiled spinning forbidden sausage	5	crappy	
 5735	Lord Flameface's cloak of the early riser	0		Adventures: +7, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	pickled ghostly Drizzlers&trade; Black Licorice	0		Effect: "Crocodile Tear", Effect Duration: 30
 5737	extra-liquefied enhanced electrified daub-breaker	0		Effect: "Strawberry Alarm", Effect Duration: 45, Last Available: "2020-09"
 5738	red grievous Camp Scout backpack	0		Weapon Damage Percent: +50, Softcore Only, Last Available: "2012-07"
 5739	narrow CSA fire-starting kit	0		Last Available: "2012-07"
 5740	normal bag of GORP	4	good	Last Available: "2012-07"
-5741	artisanal enchanted water purification pills	4	EPIC	Effect: "Memory of Attractiveness", Effect Duration: 10, Last Available: "2012-07"
+5741	enchanted artisanal water purification pills	4	EPIC	Effect: "Memory of Attractiveness", Effect Duration: 10, Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	acceptable spirit-forward squat CSA scoutmaster's &quot;water&quot;	5	good	Last Available: "2012-07"
 5744	rotten bag of GORF	3	crappy	Last Available: "2012-07"
@@ -5651,10 +5651,10 @@
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	red narrow Tales of the Word Realms	0		
 5752	tasty squat gray crappy brain	3	awesome	
-5753	special toothsome decent brain	4	awesome	Effect: "Carrion' On", Effect Duration: 50
-5754	tiny toothsome good brain	1	awesome	
+5753	toothsome special decent brain	4	awesome	Effect: "Carrion' On", Effect Duration: 50
+5754	toothsome tiny good brain	1	awesome	
 5755	tasty thick boss brain	5	awesome	
-5756	flavorless diet hunter brain	1	decent	
+5756	diet flavorless hunter brain	1	decent	
 5758	greedy clever Staff of Holiday Sensations of the cougar	0		Moxie: +20, Maximum MP: +20, Meat Drop: +20, Last Available: "2011-11"
 5759	cool staff of the dark arts	0		Moxie: +5, Spell Damage Percent: +100
 5760	friendly rock-hard staff of Calamity Jane	0		Damage Reduction: 5, Critical Hit Percent: +15, Familiar Weight: +3
@@ -5668,13 +5668,13 @@
 5768	mirror gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	yellow shaking gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	shaking yellow gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	frightening rock-hard Barney's rake	0		Damage Reduction: 5, Spooky Damage: +5
-5778	spoiled miniature cyan idiot brain	2	crappy	
+5778	miniature spoiled cyan idiot brain	2	crappy	
 5779	keel-haulin' knife of wisdom	0		Mysticality: +15
 5780	ice cream scoop of the glutton	0		Food Drop: +100
 5781	acceptable distilled soft echo eyedrop antidote martini	5	good	
@@ -5717,7 +5717,7 @@
 5818	anodized adjusted spinning Stone Golem pebbles	0		Effect: "From Nantucket", Effect Duration: 67
 5819	cold-filtered gravy fairy warlock hat	0		Effect: "Adventurer's Best Friendship", Effect Duration: 43
 5820	denatured ionized quadruple-pressed mirror shaking bull blubber	0		Effect: "Well-Oiled", Effect Duration: 64
-5821	colloidal nitrogenated jittery wobbly frog lip-print	0		Effect: "The Living Hitpoints", Effect Duration: 11
+5821	colloidal nitrogenated wobbly jittery frog lip-print	0		Effect: "The Living Hitpoints", Effect Duration: 11
 5822	corrupted galvanized squat gazely stare	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 17
 5823	vacuum-sealed unsweetened canopic jar	0		Effect: "Crimbo Epiphany", Effect Duration: 13
 5824	boiled purple clove-flavored lip balm	0		Effect: "Pyromania", Effect Duration: 36
@@ -5727,7 +5727,7 @@
 5828	pressed lime green gilt perfume bottle	0		Effect: "Castaway Physique", Effect Duration: 30
 5829	chilled unsweetened janglin' bones	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 62
 5830	moist pickled pygmy papers	0		Effect: "Yuletide Mutations", Effect Duration: 32
-5831	vacuum-sealed tarnished twirling jittery pygmy dart	0		Effect: "Busy Bein' Delicious", Effect Duration: 57
+5831	vacuum-sealed tarnished jittery twirling pygmy dart	0		Effect: "Busy Bein' Delicious", Effect Duration: 57
 5832	quadruple-cold-filtered wet energized spinning secret mummy herbs and spices	0		Effect: "Memory of Strength", Effect Duration: 66
 5833	activated pulsating brigand brittle	0		Effect: "White-boy Angst", Effect Duration: 54
 5834	vacuum-sealed double-activated skewed holistic headache remedy	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 66
@@ -5740,7 +5740,7 @@
 5841	diffused A muse-bouche	0		Effect: "The Grass...  Is Blue...", Effect Duration: 14
 5842	unsweetened denatured toothbrush	0		Effect: "Frog In Your Throat", Effect Duration: 31
 5843	colloidal triple-denatured ghostly pirate cream pie	0		Effect: "EVISCERATE!", Effect Duration: 48
-5844	warmed teal mirror una poca de gracia	0		Effect: "Celestial Sheen", Effect Duration: 65
+5844	warmed mirror teal una poca de gracia	0		Effect: "Celestial Sheen", Effect Duration: 65
 5845	moist teal jittery compressed air canister	0		Effect: "Broken Bone Nubs", Effect Duration: 13
 5846	quantum colloidal tumbling salt water taffy	0		Effect: "Icy Demeanor", Effect Duration: 29
 5847	triple-boiled improved unholy water	0		Effect: "Well-Swabbed Ear", Effect Duration: 12
@@ -5753,7 +5753,7 @@
 5854	diffused BRICKO stud	0		Effect: "Speed of the Internet", Effect Duration: 30
 5855	alkaline wet frozen bouncing cyan Osk'r Chow	0		Effect: "Tingly Wrists", Effect Duration: 33
 5856	ionized frozen tumbling Scuba Snack	0		Effect: "Intimidating Mien", Effect Duration: 49
-5857	warmed alkaline polymerized green shaking narrow grey cube	0		Effect: "El Vibrations", Effect Duration: 32
+5857	warmed alkaline polymerized narrow green shaking grey cube	0		Effect: "El Vibrations", Effect Duration: 32
 5858	warmed extra-energized votive candle	0		Effect: "Patent Alacrity", Effect Duration: 63
 5859	oxidized tumbling booby trap	0		Effect: "Punchy, Murdery", Effect Duration: 36
 5860	wet alkaline wet teal Agent Corrigan's cigarette	0		Effect: "Loyal Tea", Effect Duration: 30
@@ -5762,7 +5762,7 @@
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	corrupted unsweetened narrow papier-mochi	0		Effect: "Punchy, Murdery", Effect Duration: 40, Last Available: "2012-09"
-5866	improved galvanized blue blinking papier-m&acirc;chaeranthera	0		Effect: "The Strength...  of the Future", Effect Duration: 22, Last Available: "2012-09"
+5866	improved galvanized blinking blue papier-m&acirc;chaeranthera	0		Effect: "The Strength...  of the Future", Effect Duration: 22, Last Available: "2012-09"
 5867	double-unsweetened papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Hustlin'", Effect Duration: 68, Last Available: "2012-09"
 5868	miser's studded papier-m&acirc;ch&eacute;te	0		Damage Absorption: +80, Meat Drop: +10, Last Available: "2012-09"
 5869	gray chilly dance instructor's papier-m&acirc;chine gun	0		Experience Percent (Moxie): +10, Cold Damage: +5, Last Available: "2012-09"
@@ -5779,11 +5779,11 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	yellow skeleton	0		Last Available: "2012-10"
 5882	prompt avaricious wicked skeleton skis	0		Spell Damage: +5, Meat Drop: +30, Adventures: +3, Single Equip, Last Available: "2012-10"
-5883	rotten small jittery skeleton quiche	2	crappy	Last Available: "2012-10"
+5883	small rotten jittery skeleton quiche	2	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	rosy-cheeked healthy padded Bonestabber of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +20, Maximum HP Percent: 50, Last Available: "2012-10"
-5887	bad pulsating mirror crystal skeleton vodka	4	decent	Last Available: "2012-10"
+5887	bad mirror pulsating crystal skeleton vodka	4	decent	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	fuchsia huge flame-retardant auxiliary backbone	0		Hot Resistance: +1, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5863,7 +5863,7 @@
 5965	Frown Exerciser of extreme caution of doom	0		Monster Level: -25, Spooky Spell Damage: +50, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	soul doorbell	0		
-5968	cyan shaking soul coin	0		
+5968	shaking cyan soul coin	0		
 5969	soul knife	0		
 5970	squat tumbling energetic soul mask	0		Maximum MP Percent: +20, Single Equip
 5971	record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5885,11 +5885,11 @@
 5987	skewed dollar-sign bag	0		Last Available: "2013-02"
 5988	twirling potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	watered-down artisanal bottle of wine	2	EPIC	Last Available: "2013-02"
+5990	artisanal watered-down bottle of wine	2	EPIC	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
 5992	wobbly greedy iron helmet of the overflowing toilet of Flo-Jo	0		Stench Spell Damage: +50, Meat Drop: +20, Initiative: +100, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	maroon jittery inspector's forbidden supercool steel sword	0		Moxie Percent: +20, Spell Damage Percent: +50, Item Drop: +15, Last Available: "2013-02"
-5994	small normal enchanted fuchsia whole roasted chicken	2	good	Effect: "Frisky Spirit", Effect Duration: 35, Last Available: "2013-02"
+5994	enchanted normal small fuchsia whole roasted chicken	2	good	Effect: "Frisky Spirit", Effect Duration: 35, Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	ghostly potion	0		Last Available: "2013-02"
@@ -5912,7 +5912,7 @@
 6014	gray screwing pooch of bravery	0		Spooky Resistance: +5
 6015	adjusted denatured purple orcish hand lotion	0		Effect: "Ogred and Oublietted", Effect Duration: 34
 6016	corrupted orcish rubber	0		Effect: "Ironclad", Effect Duration: 62
-6017	liquefied spinning mirror orcish nailing lube	0		Effect: "Yuletide Industry", Effect Duration: 45
+6017	liquefied mirror spinning orcish nailing lube	0		Effect: "Yuletide Industry", Effect Duration: 45
 6018	bad weak blurry lime green backwoods screwdriver	2	decent	
 6019	twirling reassuring loadstone	0		Spooky Resistance: +1
 6020	mirror flame-retardant steel-toed Claybender glasses	0		Damage Reduction: 9, Hot Resistance: +1, Single Equip
@@ -5931,7 +5931,7 @@
 6033	coward's therapeutic stolen necklace	0		Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7
 6034	purple resourceful crafty troll britches	0		Maximum MP: 60, Familiar Effect: "1.5xPotato, cap 28"
 6035	dry squat vial of The Glistening	0		Effect: "Notably Lovely", Effect Duration: 12
-6036	high-proof mediocre purple artisanal limoncello	6	decent	
+6036	mediocre high-proof purple artisanal limoncello	6	decent	
 6037	upside-down ginger ale	0		
 6038	huge flavorless incredible pizza	8	decent	
 6039	MacGyver's oil cap of the businessman	0		Maximum MP: +100, Meat Drop: +50, Familiar Effect: "cap 28"
@@ -5977,7 +5977,7 @@
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	resourceful haggis socks	0		Maximum MP: +50, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
 6081	ghostly airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
-6082	wobbly purple Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
+6082	purple wobbly Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
@@ -6004,7 +6004,7 @@
 6106	upside-down Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	ghostly zippy Ginsu&trade; of Leguizamo	0		Monster Level: +20, Initiative: +20, Last Available: "2013-12"
-6109	spinning gray jittery bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
+6109	spinning jittery gray bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
 6110	bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	huge bouncing bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	zaibatsu lobby card	0		Last Available: "2013-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	narrow bonsai tree	0		Last Available: "2013-12"
-6121	lousy irresponsibly strong Chinese beer	6	decent	Last Available: "2013-12"
+6121	irresponsibly strong lousy Chinese beer	6	decent	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	upside-down furry pink pillow	0		Last Available: "2013-12"
@@ -6038,7 +6038,7 @@
 6140	twirling Chinese curse words	0		Last Available: "2013-12"
 6141	teal triad summoning scroll	0		Last Available: "2013-12"
 6142	moldy roasted duck	4	crappy	Last Available: "2013-12"
-6143	adequate bite-sized green dead meat bun	1	good	Last Available: "2013-12"
+6143	bite-sized adequate green dead meat bun	1	good	Last Available: "2013-12"
 6144	jittery narrow cat collar of the early riser	0		Adventures: +7, Single Equip, Last Available: "2013-12"
 6145	green rosy-cheeked suspicious-looking fedora of temperance	0		Maximum HP Percent: +30, Sleaze Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	blinking Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6063,7 +6063,7 @@
 6166	deck cannon of Gandalf of the boozehound	0		Spell Critical Percent: +20, Booze Drop: +100, Last Available: "2013-12"
 6167	Samson's ornamental sextant	0		Experience (Muscle): +5, Last Available: "2013-12"
 6168	jittery wicked Bloodbath of the cougar	0		Moxie: +20, Spell Damage: +5, Last Available: "2013-12"
-6169	delicious fortified Hundred Headed IPA	5	awesome	Last Available: "2013-12"
+6169	fortified delicious Hundred Headed IPA	5	awesome	Last Available: "2013-12"
 6170	gigantic yummy blue chum	9	awesome	Last Available: "2013-12"
 6171	polymerized flattened colloidal crude crudit&eacute;s	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 66
 6172	Vulcanized quantum candy crayons	0		Effect: "Big Meat Big Prizes", Effect Duration: 59, Last Available: "2020-09"
@@ -6077,35 +6077,35 @@
 6180	cosmic potted meat product	0		
 6181	cosmic potato	0		
 6182	cosmic cream	0		
-6183	narrow bouncing cosmic fruit	0		
+6183	bouncing narrow cosmic fruit	0		
 6184	tumbling experienced slick Jarlsberg's hat of the sewer	0		Moxie: +10, Experience: +2, Stench Damage: +25
 6185	tasty consummate hard-boiled egg	3	awesome	
 6186	spoiled consummate fried egg	3	crappy	
-6187	adequate small blue consummate egg salad	2	good	
-6188	bite-sized stale special consummate bagel	1	decent	Effect: "Weird Flavor", Effect Duration: 30
+6187	small adequate blue consummate egg salad	2	good	
+6188	special bite-sized stale consummate bagel	1	decent	Effect: "Weird Flavor", Effect Duration: 30
 6189	half-sized rotten red consummate sliced bread	2	crappy	
 6190	delicious snack-sized consummate hot dog bun	2	awesome	
 6191	spoiled consummate brownie	4	crappy	
 6192	decent fuchsia consummate toast	3	good	
-6193	watered-down tolerable passable stout	2	good	
-6194	snack-sized spoiled consummate soup	2	crappy	
+6193	tolerable watered-down passable stout	2	good	
+6194	spoiled snack-sized consummate soup	2	crappy	
 6195	bland massive consummate corn chips	10	decent	
-6196	bland bite-sized consummate salad	1	decent	
+6196	bite-sized bland consummate salad	1	decent	
 6197	bland snack-sized consummate salsa	2	decent	
 6198	big rotten cyan consummate sauerkraut	5	crappy	
 6199	low-calorie rotten consummate cheese slice	1	crappy	
-6200	stale special squat consummate melted cheese	4	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 45
+6200	special stale squat consummate melted cheese	4	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 45
 6201	bland consummate bacon	3	decent	
-6202	gigantic adequate consummate meatloaf	6	good	
+6202	adequate gigantic consummate meatloaf	6	good	
 6203	tasty consummate steak	3	awesome	
 6204	stale consummate cuts	3	decent	
-6205	stale diet consummate frankfurter	1	decent	
+6205	diet stale consummate frankfurter	1	decent	
 6206	bland blinking consummate french fries	3	decent	
 6207	moldy consummate baked potato	3	crappy	
 6208	delicious acceptable vodka	3	awesome	
 6209	bland wobbly consummate ice cream	4	decent	
 6210	adequate consummate whipped cream	4	good	
-6211	half-sized moldy consummate cream	2	crappy	
+6211	moldy half-sized consummate cream	2	crappy	
 6212	jumbo bland consummate strawberries	5	decent	
 6213	enchanted normal consummate sorbet	4	good	Effect: "Fastbreaker", Effect Duration: 10
 6214	perfectly mixed shaking adequate rum	4	EPIC	
@@ -6113,24 +6113,24 @@
 6216	thick normal gray immaculate grilled cheese	5	good	
 6217	big stale special immaculate ice cream sandwich	5	decent	Effect: "damage.enh", Effect Duration: 40
 6218	moldy immaculate hot dog	3	crappy	
-6219	special decent tiny immaculate egg salad sandwich	1	good	Effect: "Sensation", Effect Duration: 30
-6220	moldy snack-sized ghostly perfect sandwich	2	crappy	
+6219	decent special tiny immaculate egg salad sandwich	1	good	Effect: "Sensation", Effect Duration: 30
+6220	snack-sized moldy ghostly perfect sandwich	2	crappy	
 6221	stale perfect chef salad	4	decent	
 6222	flavorless narrow perfect breakfast	4	decent	
 6223	stale sublime deluxe hot dog	3	decent	
-6224	adequate miniature blurry sublime stew	2	good	
-6225	bite-sized decent shaking sublime nachos	1	good	
-6226	huge toothsome Ultimate Breakfast Sandwich	6	awesome	
+6224	miniature adequate blurry sublime stew	2	good	
+6225	decent bite-sized shaking sublime nachos	1	good	
+6226	toothsome huge Ultimate Breakfast Sandwich	6	awesome	
 6227	small decent narrow Loaded Baked Potato	2	good	
-6228	half-sized adequate Omega Sundae	2	good	
+6228	adequate half-sized Omega Sundae	2	good	
 6229	bad weak Das Sauerlager	2	decent	
 6230	artisanal twirling Bologna Lambic	3	EPIC	
 6231	delicious ghostly Vodka Dog	4	awesome	
 6232	high-proof lousy Disappointed Russian	6	decent	
 6233	artisanal Chunky Mary	3	EPIC	
-6234	lousy fancy Nachojito	3	decent	Effect: "Frozen Hands", Effect Duration: 40
-6235	delicious watered-down Le Roi	2	awesome	
-6236	artisanal watered-down Over Easy Rider	2	EPIC	
+6234	fancy lousy Nachojito	3	decent	Effect: "Frozen Hands", Effect Duration: 40
+6235	watered-down delicious Le Roi	2	awesome	
+6236	watered-down artisanal Over Easy Rider	2	EPIC	
 6237	skewed cosmic six-pack	0		
 6239	extra-vacuum-sealed enhanced tarnished blue cube of ectoplasm	0		Effect: "The Rich Get Richer", Effect Duration: 41
 6240	unsweetened vacuum-sealed Illuminati earpiece	0		Effect: "Nutrient-Rich", Effect Duration: 50
@@ -6150,7 +6150,7 @@
 6254	jittery Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	teal dried gelatinous cube	0		
-6257	maroon twirling pile of dungeon junk	0		Familiar Weight: +5
+6257	twirling maroon pile of dungeon junk	0		Familiar Weight: +5
 6258	narrow scorching clever dangerous Staff of the Healthy Breakfast of the brazier	0		Weapon Damage: +10, Maximum MP: +20, Hot Damage: +25, Hot Spell Damage: +25, Jiggle: "Recover Some HP"
 6259	jittery ribald smelly Lo Pan's Staff of the Staff of Life of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +30, Stench Spell Damage: +10, Sleaze Damage: +10, Jiggle: "Full HP Recovery"
 6260	Jim Carey's weightlifter's Staff of the Light Lunch of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Monster Level: +25, Jiggle: "Deal Some Cold Damage"
@@ -6161,9 +6161,9 @@
 6265	Jack Frost's therapeutic Sinatra's Staff of the Cream of the Cream	0		Experience (Moxie): +5, Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
 6267	fancy decent grain of protein powder	4	good	Effect: "Blubbered Up", Effect Duration: 35
-6268	super-enhanced ionized huge upside-down pec oil	0		Effect: "Inebriate Pride", Effect Duration: 54
+6268	super-enhanced ionized upside-down huge pec oil	0		Effect: "Inebriate Pride", Effect Duration: 54
 6269	gym membership card of the ox	0		Muscle: +20
-6270	modified vacuum-sealed deionized olive huge Squat-Thrust Magazine	0		Effect: "Puzzle Fury", Effect Duration: 60
+6270	modified vacuum-sealed deionized huge olive Squat-Thrust Magazine	0		Effect: "Puzzle Fury", Effect Duration: 60
 6271	massive dumbbell	0		
 6272	coward's careful penguin keychain	0		Monster Level: -30, Damage Reduction: 10
 6273	modified O'RLY manual	0		Effect: "Faboooo", Effect Duration: 15
@@ -6174,7 +6174,7 @@
 6278	twirling Ye Olde Medieval Insult	0		
 6279	skewed ruddy pewter claymore	0		Maximum HP Percent: +40
 6280	manspreader's artisanal rice peeler	0		Monster Level: +10
-6281	gigantic flavorless heirloom grape tomato	8	decent	
+6281	flavorless gigantic heirloom grape tomato	8	decent	
 6282	chipotle wasabi cilantro aioli	0		
 6283	curative brown felt tophat	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6247,13 +6247,13 @@
 6351	wobbly Mer-kin finpaddle of terror	0		Spooky Spell Damage: +10
 6352	banded Mer-kin stopwatch	0		Damage Absorption: +100, Initiative: +50
 6353	purple Mer-kin dreadscroll	0		
-6354	altered spinning narrow Mer-kin smartjuice	0		Effect: "Human-Plant Hybrid", Effect Duration: 26
+6354	altered narrow spinning Mer-kin smartjuice	0		Effect: "Human-Plant Hybrid", Effect Duration: 26
 6355	alkaline triple-modified gray Mer-kin cooljuice	0		Effect: "Spooky Flavor", Effect Duration: 26
 6356	green Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
-6358	green squat Mer-kin darkbook	0		Skill: "Deep Dark Visions"
+6358	squat green Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	forbidden Mer-kin begsign	0		Spell Damage Percent: +50, Meat Drop: +40
-6360	shaking tumbling Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	tumbling shaking Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	alkaline pulled taffy	0		Effect: "Retrograde Relaxation", Effect Duration: 49, Last Available: "2013-04"
 6362	non-chilled pulled indigo taffy	0		Effect: "Berry Critical", Effect Duration: 51, Last Available: "2013-04"
 6363	colloidal pulled taffy	0		Effect: "Sealed Brain", Effect Duration: 24, Last Available: "2013-04"
@@ -6281,7 +6281,7 @@
 6386	twirling balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
-6389	extra-warmed Vulcanized Vulcanized red pulsating Mer-kin rocksalt	0		Effect: "Bright!", Effect Duration: 60
+6389	extra-warmed Vulcanized Vulcanized pulsating red Mer-kin rocksalt	0		Effect: "Bright!", Effect Duration: 60
 6390	pressed double-flattened pulsating Mer-kin saltmint	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 44
 6391	energized tumbling Mer-kin saltsquid	0		Effect: "Reedy Pipes", Effect Duration: 62
 6392	tumbling horrifying scorching scale-mail underwear	0		Hot Damage: +25, Spooky Damage: +25, Familiar Effect: "2xVolley"
@@ -6307,7 +6307,7 @@
 6412	shaking skull	0		No Pull
 6413	skewed gray Order of the Green Thumb Order Form	0		Free Pull
 6414	purple twirling clutch of dodecapede eggs	0		
-6415	small rotten flavorless gruel	2	crappy	
+6415	rotten small flavorless gruel	2	crappy	
 6416	moldy mana curds	3	crappy	
 6417	twist of lime	0		
 6418	pencil stub	0		
@@ -6318,9 +6318,9 @@
 6423	skewed Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	upside-down Official Seal of Dreadsylvania	0		
-6426	adequate snack-sized fuchsia Dreadsylvanian stew	2	good	
+6426	snack-sized adequate fuchsia Dreadsylvanian stew	2	good	
 6427	aged Dreadsylvanian	4	awesome	
-6428	double-quantum squat purple Dreadsylvanian flask	0		Effect: "Pronounced Potency", Effect Duration: 27
+6428	double-quantum purple squat Dreadsylvanian flask	0		Effect: "Pronounced Potency", Effect Duration: 27
 6429	unsweetened irradiated Dreadsylvanian flask	0		Effect: "Fortunate Resolve", Effect Duration: 48
 6430	MacGyver's dreadful fedora of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	skewed dreadful sweater of the boozehound	0		Booze Drop: +100, Kruegerand Drop: 5
@@ -6338,7 +6338,7 @@
 6443	upside-down curative Helps-You-Sleep of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 6444	electrified Quiets-Your-Steps of the storm of the businessman	0		Maximum MP Percent: +40, Meat Drop: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 6445	squat ruddy Protects-Your-Junk of terror	0		Maximum HP Percent: +40, Spooky Spell Damage: +10, Single Equip
-6446	bad high-proof Gets-You-Drunk	6	decent	
+6446	high-proof bad Gets-You-Drunk	6	decent	
 6447	horrifying groovy sage Great Wolf's headband	0		Mysticality Percent: +10, Moxie Percent: +10, Spooky Damage: +25, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	inspector's sharpshooter's boxer's Great Wolf's left paw	0		Muscle Percent: +10, Critical Hit Percent: +10, Item Drop: +15, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	ribald mansplainer's boxer's Great Wolf's right paw	0		Muscle Percent: +10, Monster Level: +15, Sleaze Damage: +10, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6360,14 +6360,14 @@
 6465	pulsating scandalous supercool Mayor Ghost's gavel of Calamity Jane	0		Moxie Percent: +20, Critical Hit Percent: +15, Sleaze Damage: +5, Conditional Skill (Equipped): "Hammer Ghost"
 6466	family-friendly rosewater-soaked Sinatra's Mayor Ghost's sash	0		Experience (Moxie): +5, Stench Resistance: +3, Sleaze Resistance: +1, Single Equip
 6467	wobbly Mayor Ghost's scissors	0		
-6468	tiny flavorless enchanted lime green ghostly ghost pepper	1	decent	Effect: "Cockroach Scurry", Effect Duration: 5
+6468	tiny enchanted flavorless ghostly lime green ghost pepper	1	decent	Effect: "Cockroach Scurry", Effect Duration: 5
 6469	gravedigger's curative Thunkula's drinking cap of the scaredy-cat	0		Monster Level: -15, Spooky Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	wool horrifying Newton's Drunkula's cape	0		Experience (Mysticality): +3, Spooky Damage: +25, Cold Resistance: +1, Class: "Sauceror"
 6471	Drunkula's silky pants of the cougar of the overflowing toilet of the detective	0		Moxie: +20, Stench Spell Damage: +50, Item Drop: +20, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 6472	Drunkula's bell	0		
 6473	skewed shellacked extremely unsafe smartaleck's Drunkula's ring of haze	0		Moxie Percent: +30, Weapon Damage Percent: +100, Damage Reduction: 7, Avoid Attack: 1, Single Equip
 6474	Drunkula's wineglass of chilblains	0		Cold Damage: +25
-6475	hand-crafted watered-down bottle of Bloodweiser	2	EPIC	
+6475	watered-down hand-crafted bottle of Bloodweiser	2	EPIC	
 6476	aromatic Fonzie's Unkillable Skeleton's skullcap of the empath	0		Experience (Moxie): +1, Familiar Weight: +5, Stench Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	jittery yellow groovy boxer's Unkillable Skeleton's breastplate of the blizzard	0		Muscle Percent: +10, Moxie Percent: +10, Cold Spell Damage: +25, Class: "Turtle Tamer"
 6478	horrifying Jim Carey's Unkillable Skeleton's shinguards of the businessman	0		Monster Level: +25, Spooky Damage: +25, Meat Drop: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6382,11 +6382,11 @@
 6487	stinking agaricus	0		
 6488	moldy Dreadsylvanian shepherd's pie	3	crappy	
 6489	bouncing music box parts	0		
-6490	huge teal unwound mechanical songbird	0		
+6490	teal huge unwound mechanical songbird	0		
 6491	blurry tailfeathers	0		Familiar Weight: +5
 6492	mirror wax banana	0		
 6493	complicated lock impression	0		
-6494	blurry tumbling replica key	0		
+6494	tumbling blurry replica key	0		
 6495	dance instructor's Dreadsylvania Auditor's badge	0		Experience Percent (Moxie): +10, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	maroon eau de mort	0		
@@ -6408,9 +6408,9 @@
 6513	pulsating groovy warm fur	0		Moxie Percent: +10
 6514	red upside-down Samson's snowstick	0		Experience (Muscle): +5
 6515	reassuring eerie fetish	0		Spooky Resistance: +1, Single Equip
-6516	practically non-alcoholic acceptable ghostly stinkwater	1	good	
+6516	acceptable practically non-alcoholic ghostly stinkwater	1	good	
 6517	yellow dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	big rotten bouncing accidental mutton	5	crappy	
+6518	rotten big bouncing accidental mutton	5	crappy	
 6519	razor-sharp drafty drawers of the brazier	0		Weapon Damage Percent: +25, Hot Spell Damage: +25, Familiar Effect: "1.5xVolley"
 6520	ghostly reassuring careful wolfskull mask	0		Monster Level: -10, Spooky Resistance: +1, Familiar Effect: "spooky atk, 1xBarrr"
 6521	vibrating guts necklace	0		Maximum MP Percent: +10, Single Equip
@@ -6421,7 +6421,7 @@
 6526	medical-grade arcane researcher's bag of unfinished business	0		Experience Percent (Mysticality): +10, HP Regen Min: 7, HP Regen Max: 10
 6527	olive greedy transparent pants of James Dean	0		Experience (Moxie): +3, Meat Drop: +20, Familiar Effect: "sleaze atk, 1xPotato"
 6528	Sherlock's hothammer	0		Item Drop: +25
-6529	bad high-proof fancy mirror shaking Thriller Ice	9	decent	Effect: "Salsa Satanica", Effect Duration: 45
+6529	high-proof fancy bad mirror shaking Thriller Ice	9	decent	Effect: "Salsa Satanica", Effect Duration: 45
 6530	fortified grandfather watch	0		Damage Absorption: +60, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	greedy extremely unsafe spyglass	0		Weapon Damage Percent: +100, Meat Drop: +20
@@ -6448,7 +6448,7 @@
 6554	stench cluster	0		
 6555	sleaze cluster	0		
 6556	deionized flattened wobbly phial of hotness	0		Effect: "Drenched With Filth", Effect Duration: 25
-6557	modified super-oxidized purple ghostly phial of coldness	0		Effect: "The Moxie of LOV", Effect Duration: 30
+6557	modified super-oxidized ghostly purple phial of coldness	0		Effect: "The Moxie of LOV", Effect Duration: 30
 6558	quantum purple phial of spookiness	0		Effect: "Norwhalloped", Effect Duration: 13
 6559	cold-filtered phial of stench	0		Effect: "Electrolit Up", Effect Duration: 29
 6560	tarnished enhanced phial of sleaziness	0		Effect: "Headstrong", Effect Duration: 58
@@ -6456,13 +6456,13 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	Jim Carey's hand of Mr. Cards	0		Monster Level: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	toothsome jumbo Dreadsylvanian hot pocket	5	awesome	
-6565	gigantic decent Dreadsylvanian pocket	6	good	
-6566	flavorless massive enchanted blue Dreadsylvanian pocket	6	decent	Effect: "Favored by Lyle", Effect Duration: 5
+6565	decent gigantic Dreadsylvanian pocket	6	good	
+6566	enchanted massive flavorless blue Dreadsylvanian pocket	6	decent	Effect: "Favored by Lyle", Effect Duration: 5
 6567	enchanted stale gigantic Dreadsylvanian stink pocket	9	decent	Effect: "familiar.enq", Effect Duration: 45
 6568	bland snack-sized Dreadsylvanian sleaze pocket	2	decent	
 6569	hand-crafted spirit-forward squat Dreadsylvanian hot toddy	5	super EPIC	
 6570	enchanted aged Dreadsylvanian cold-fashioned	4	awesome	Effect: "For Your Brain Only", Effect Duration: 45
-6571	special mediocre wobbly Dreadsylvanian grimlet	3	decent	Effect: "Stickler for Promptness", Effect Duration: 20
+6571	mediocre special wobbly Dreadsylvanian grimlet	3	decent	Effect: "Stickler for Promptness", Effect Duration: 20
 6572	drinkable Dreadsylvanian dank and stormy	3	good	
 6573	drinkable spirit-forward Dreadsylvanian slithery nipple	5	good	
 6574	hot clusterbomb	0		
@@ -6526,7 +6526,7 @@
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	narrow folder (barbarian)	0		Last Available: "2013-08"
 6634	folder (rainbow unicorn)	0		Last Available: "2013-08"
-6635	skewed narrow folder (Seawolf)	0		Last Available: "2013-08"
+6635	narrow skewed folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
@@ -6538,8 +6538,8 @@
 6644	skewed folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	fortified quilted slide rule	0		Damage Absorption: 100
-6649	ionized quantum quadruple-modified red squat Ogres and Oubliettes&trade; module	0		Effect: "Seriously Mutated", Effect Duration: 27
-6650	cyan shaking Mountain Stream Code Black Alert	0		
+6649	ionized quantum quadruple-modified squat red Ogres and Oubliettes&trade; module	0		Effect: "Seriously Mutated", Effect Duration: 27
+6650	shaking cyan Mountain Stream Code Black Alert	0		
 6651	tumbling twisted-up wet towel	0		
 6652	artisanal stepmom's booze	3	EPIC	
 6653	narrow surgical tape	0		
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	skewed blinking imitation White Russian	1	good	
 6704	educational short-handled mop of the sewer	0		Experience: +1, Stench Damage: +25
-6705	fancy decent immense lime green jittery jungle floor wax	7	good	Effect: "Violent Night", Effect Duration: 15
+6705	immense decent fancy lime green jittery jungle floor wax	7	good	Effect: "Violent Night", Effect Duration: 15
 6706	smirking shrunken head	0		
 6707	double-improved altered adjusted colorful toad	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 27
 6708	yellow crude voodoo doll	0		
@@ -6613,7 +6613,7 @@
 6721	gravedigger's therapeutic water bottle of the glutton	0		Spooky Damage: +10, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	non-ionized improved pygmy phone number	0		Effect: "Fitter, Happier", Effect Duration: 13
 6723	Boozehounds Anonymous token	0		
-6724	stale bouncing spinning exotic jungle fruit	3	decent	
+6724	stale spinning bouncing exotic jungle fruit	3	decent	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6624,7 +6624,7 @@
 6732	bouncing claw-foot bathtub	0		
 6733	clothesline pole	0		
 6734	upside-down cigar sign	0		
-6735	bouncing jittery olive junk junk	0		
+6735	bouncing olive jittery junk junk	0		
 6736	wobbly Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	jagged scrap	0		
@@ -6648,11 +6648,11 @@
 6756	artisanal homebrew sampler	0		
 6757	aged can of Br&uuml;talbr&auml;u	3	awesome	Last Available: "2013-09"
 6758	perfectly mixed triple-distilled can of Drooling Monk	6	EPIC	Last Available: "2013-09"
-6759	mediocre practically non-alcoholic can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
+6759	practically non-alcoholic mediocre can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
 6760	strong drinkable squat bottle of Old Pugilist	5	good	Last Available: "2013-09"
 6761	watered-down hand-crafted bottle of Professor Beer	2	EPIC	Last Available: "2013-09"
 6762	weak smooth bottle of Rapier Witbier	2	awesome	Last Available: "2013-09"
-6763	mediocre practically non-alcoholic mirror wobbly lime green bottle of Race Car Red	1	decent	Last Available: "2013-09"
+6763	practically non-alcoholic mediocre mirror wobbly lime green bottle of Race Car Red	1	decent	Last Available: "2013-09"
 6764	tolerable bottle of Greedy Dog	4	good	Last Available: "2013-09"
 6765	smooth olive bottle of Lambada Lambic	4	awesome	Last Available: "2013-09"
 6766	shaking tin beer can	0		
@@ -6673,7 +6673,7 @@
 6781	inspector's groovy scabrous seal epaulets	0		Moxie Percent: +10, Item Drop: +15, Single Equip
 6782	pulsating abyssal battle plans	0		
 6783	stanky crafty hardened seal medal	0		Damage Reduction: 3, Maximum MP: +10, Stench Spell Damage: +25
-6784	lime green blurry deanimated reanimator's coffin	0		Free Pull
+6784	blurry lime green deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
 6788	blank diary	0		
 6789	squat boot knife	0		
@@ -6747,16 +6747,16 @@
 6858	gray Rosewater's quirky accordion	0		Mysticality Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	smelly vibrating Skipper's accordion	0		Maximum MP Percent: +10, Stench Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6860	frosty mansplainer's quilted slick Pantsgiving	0		Moxie: +10, Damage Absorption: +40, Monster Level: +15, Cold Spell Damage: +10, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	spoiled small can of sardines	2	crappy	Last Available: "2013-11"
+6861	small spoiled can of sardines	2	crappy	Last Available: "2013-11"
 6862	gigantic decent high-calorie sugar substitute	10	good	Last Available: "2013-11"
 6863	bland diet pat of butter	1	decent	Last Available: "2013-11"
-6864	fancy stale miniature dinner roll	2	decent	Effect: "Nutrient-Rich", Effect Duration: 20, Last Available: "2013-11"
+6864	miniature stale fancy dinner roll	2	decent	Effect: "Nutrient-Rich", Effect Duration: 20, Last Available: "2013-11"
 6865	spoiled half-sized mashed potatoes	2	crappy	Last Available: "2013-11"
 6866	decent wobbly whole turkey leg	3	good	Last Available: "2013-11"
-6867	thick stale deviled egg	5	decent	Last Available: "2013-11"
+6867	stale thick deviled egg	5	decent	Last Available: "2013-11"
 6868	non-enhanced finger exerciser	0		Effect: "Well-preserved", Effect Duration: 16, Last Available: "2013-11"
 6869	frozen warmed dented spoon	0		Effect: "Badger Underfoot", Effect Duration: 42, Last Available: "2013-11"
-6870	triple-electrified triple-adjusted spinning cyan love note	0		Effect: "Sharp Weapon", Effect Duration: 63, Last Available: "2013-11"
+6870	triple-electrified triple-adjusted cyan spinning love note	0		Effect: "Sharp Weapon", Effect Duration: 63, Last Available: "2013-11"
 6871	ghostly wobbly school beer pull tab	0		Last Available: "2013-11"
 6872	irradiated denatured skewed nail file	0		Effect: "Salt Rockin'", Effect Duration: 43, Last Available: "2013-11"
 6873	pressed candy wrapper	0		Effect: "Fishily Speeding", Effect Duration: 39, Last Available: "2013-11"
@@ -6793,7 +6793,7 @@
 6904	pickled shaking bolts	0		Effect: "Elemental Flavor", Effect Duration: 60, Last Available: "2013-12"
 6905	decent snack-sized gingerbread robot	2	good	Last Available: "2013-12"
 6906	tasty jittery petit 4.1	3	awesome	Last Available: "2013-12"
-6907	small stale nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
+6907	stale small nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
 6908	teal veiny plastic GORM-8	0		Maximum HP: +10, Last Available: "2013-12"
 6909	twirling Oprah's plastic warbear	0		Maximum MP Percent: +50, Last Available: "2013-12"
 6910	plastic Toybot of extreme caution	0		Monster Level: -25, Last Available: "2013-12"
@@ -6802,16 +6802,16 @@
 6913	warbear whosit	0		Last Available: "2013-12"
 6914	bouncing warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	bouncing warbear hoverbelt of James Dean of chilblains of temperance	0		Experience (Moxie): +3, Cold Damage: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2013-12"
-6916	fuchsia huge warbear battery	0		Last Available: "2013-12"
+6916	huge fuchsia warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
 6918	electrified improved blue warbear wardance potion	0		Effect: "Floundering", Effect Duration: 12, Last Available: "2013-12"
 6919	vacuum-sealed anodized warbear bearserker potion	0		Effect: "Sticky Fingers", Effect Duration: 18, Last Available: "2013-12"
 6920	altered skewed olive warbear liquid overcoat	0		Effect: "Flashing Eyes", Effect Duration: 14, Last Available: "2013-12"
 6921	special flavorless warbear feasting bread	4	decent	Effect: "Newt Gets In Your Eyes", Effect Duration: 5, Last Available: "2013-12"
 6922	super-sized rotten squat warbear warrior bread	5	crappy	Last Available: "2013-12"
-6923	decent half-sized warbear thermoregulator bread	2	good	Last Available: "2013-12"
-6924	lousy watered-down warbear feasting mead	2	decent	Last Available: "2013-12"
-6925	delicious weak cyan warbear bearserker mead	2	awesome	Last Available: "2013-12"
+6923	half-sized decent warbear thermoregulator bread	2	good	Last Available: "2013-12"
+6924	watered-down lousy warbear feasting mead	2	decent	Last Available: "2013-12"
+6925	weak delicious cyan warbear bearserker mead	2	awesome	Last Available: "2013-12"
 6926	tolerable warbear blizzard mead	3	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
 6928	nasty Fonzie's cool warbear plain fedora	0		Moxie: +5, Experience (Moxie): +1, Stench Damage: +5, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
@@ -6846,7 +6846,7 @@
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	ruddy warbear foil hat	0		Maximum HP Percent: +40, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
-6960	squat gray warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
+6960	gray squat warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	purple toasty forbidden warbear oil pan	0		Spell Damage Percent: +50, Hot Damage: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	blinking smartaleck's warbear exhaust manifold	0		Moxie Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
@@ -6893,11 +6893,11 @@
 7004	aerosolized Flaskfull of Hollow	0		Effect: "Extra Terrestrial", Effect Duration: 41, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	powdered upside-down handful of Smithereens	1	good	Last Available: "2013-12"
-7007	miniature flavorless Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
+7007	flavorless miniature Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
 7008	normal Miserable Pie	3	good	Last Available: "2013-12"
 7009	low-calorie toothsome blurry This Charming Flan	1	awesome	Last Available: "2013-12"
 7010	acceptable Irish Coffee, English Heart	3	good	Last Available: "2013-12"
-7011	watered-down perfectly mixed Strikes Again Bigmouth	2	EPIC	Last Available: "2013-12"
+7011	perfectly mixed watered-down Strikes Again Bigmouth	2	EPIC	Last Available: "2013-12"
 7012	triple-distilled artisanal Paint A Vulgar Pitcher	9	EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	bouncing warbear drone codes	0		Last Available: "2013-12"
-7055	decent huge blurry breakfast mess	8	good	Last Available: "2013-12"
+7055	huge decent blurry breakfast mess	8	good	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	decent breakfast miracle	3	good	Last Available: "2013-12"
 7058	colloidal quantum Cloaca Cola Polar	0		Effect: "X-Ray Vision", Effect Duration: 61, Last Available: "2013-12"
@@ -6950,7 +6950,7 @@
 7061	grimstone mask	0		Last Available: "2014-12"
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
-7064	twirling lime green hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
+7064	lime green twirling hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	boiled tumbling fuchsia grim fairy tale	1	decent	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	anodized energized single of Inigo's Incantation of Inspiration	0		Effect: "Cool Spirit", Effect Duration: 40, Last Available: "2010-02"
@@ -6959,16 +6959,16 @@
 7070	blurry packet of winter seeds	0		Last Available: "2014-01"
 7071	small stale tumbling snow berries	2	decent	Last Available: "2014-01"
 7072	toothsome ghostly huge ice harvest	3	awesome	Last Available: "2014-01"
-7073	polarized pressed ghostly blue frost flower	0		Effect: "Partially Ghosted", Effect Duration: 13, Last Available: "2014-01"
-7074	quadruple-ionized oxidized super-moist blurry squat snow cleats	0		Effect: "Robocamo", Effect Duration: 31, Last Available: "2014-01"
+7073	polarized pressed blue ghostly frost flower	0		Effect: "Partially Ghosted", Effect Duration: 13, Last Available: "2014-01"
+7074	quadruple-ionized oxidized super-moist squat blurry snow cleats	0		Effect: "Robocamo", Effect Duration: 31, Last Available: "2014-01"
 7075	pickled liquid ice pack	0		Effect: "Medieval Mage Mayhem", Effect Duration: 26, Last Available: "2014-01"
 7076	spinning snow boards	0		Last Available: "2014-01"
 7077	normal blinking snow crab	3	good	Last Available: "2014-01"
-7078	tolerable practically non-alcoholic cyan Ice Island Long Tea	1	good	Last Available: "2014-01"
+7078	practically non-alcoholic tolerable cyan Ice Island Long Tea	1	good	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
-7082	upside-down tumbling snow machine	0		Last Available: "2014-01"
+7082	tumbling upside-down snow machine	0		Last Available: "2014-01"
 7083	hale snow mobile	0		Maximum HP: +20, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	miser's ice bucket	0		Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	blurry extremely unsafe Socratic snow shovel	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-01"
@@ -6992,16 +6992,16 @@
 7103	concentrated flattened twirling powder	0		Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2014-12"
 7104	licorice whip of the detective	0		Item Drop: +20, Last Available: "2014-12"
 7105	ghostly anise-flavored venom	0		Last Available: "2014-12"
-7106	watered-down perfectly mixed upside-down maroon snakebite	2	EPIC	Last Available: "2014-12"
+7106	perfectly mixed watered-down maroon upside-down snakebite	2	EPIC	Last Available: "2014-12"
 7107	dog trainer's dangerous candy stick	0		Weapon Damage: +10, Experience (familiar): +1, Last Available: "2014-12"
-7108	flavorless immense pecan	7	decent	Last Available: "2014-12"
-7109	yummy teal twirling pecan pie	3	awesome	Last Available: "2014-12"
+7108	immense flavorless pecan	7	decent	Last Available: "2014-12"
+7109	yummy twirling teal pecan pie	3	awesome	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	decent big candy mountain oyster	5	good	Last Available: "2014-12"
+7111	big decent candy mountain oyster	5	good	Last Available: "2014-12"
 7112	mediocre fancy twirling chocotini	4	decent	Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2014-12"
 7113	greedy dog trainer's Newton's chocolate rabbit's foot	0		Experience (Mysticality): +3, Experience (familiar): +1, Meat Drop: +20, Last Available: "2014-12"
 7114	diet rotten candy carrot	1	crappy	Last Available: "2014-12"
-7115	stale miniature lime green candy carrot cake	2	decent	Last Available: "2014-12"
+7115	miniature stale lime green candy carrot cake	2	decent	Last Available: "2014-12"
 7116	cool carrot-on-a-stick of the empath	0		Moxie: +5, Familiar Weight: +5, Last Available: "2014-12"
 7117	resourceful weasel stomping pants of Flo-Jo	0		Maximum MP: +50, Initiative: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	normal mulberry	4	good	Last Available: "2014-12"
@@ -7022,7 +7022,7 @@
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	electrified wolf whistle of the scaredy-cat	0		Monster Level: -15, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	rotten pulsating witch's bread	4	crappy	Last Available: "2014-12"
-7136	cold-filtered shaking squat witch's brew	0		Effect: "Human-Demon Hybrid", Effect Duration: 68, Last Available: "2014-12"
+7136	cold-filtered squat shaking witch's brew	0		Effect: "Human-Demon Hybrid", Effect Duration: 68, Last Available: "2014-12"
 7137	witch's bra of vim and vigor of the empath of chilblains	0		Maximum HP Percent: +50, Familiar Weight: +5, Cold Damage: +25, Last Available: "2014-12"
 7138	triple-distilled mediocre bouncing mid-level medieval mead	8	decent	Last Available: "2014-12"
 7139	galvanized nitrogenated R&uuml;mpelstiltz	0		Effect: "Slimed Stomach", Effect Duration: 26, Last Available: "2014-12"
@@ -7031,7 +7031,7 @@
 7142	activated unsweetened quantum hare brush	0		Effect: "Hair on Your Chest", Effect Duration: 18, Last Available: "2014-12"
 7143	Van der Graaf hare pin of temperance	0		Sleaze Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	tiny stale cinnamon cannoli	1	decent	Last Available: "2014-12"
+7145	stale tiny cinnamon cannoli	1	decent	Last Available: "2014-12"
 7146	acceptable expensive champagne	4	good	Last Available: "2014-12"
 7147	adjusted bouncing polo trophy	0		Effect: "Crying, Dying", Effect Duration: 33, Last Available: "2014-12"
 7148	blurry oil painting	0		Last Available: "2014-12"
@@ -7050,10 +7050,10 @@
 7161	Usain Bolt's shellacked baleful &quot;honey&quot; dipper	0		Spell Damage: +25, Damage Reduction: 7, Initiative: +80, Last Available: "2014-12"
 7162	flavorless huge plumber's lunch	4	decent	Last Available: "2014-12"
 7163	foul-smelling hardy skull gearshift knob of the storm	0		Maximum HP: +50, Maximum MP Percent: +40, Stench Damage: +10, Last Available: "2014-12"
-7164	thick normal nachos of the night	5	good	Last Available: "2014-12"
+7164	normal thick nachos of the night	5	good	Last Available: "2014-12"
 7165	spinning boxer's Sketcherz&trade; of the ox of the blizzard	0		Muscle: +20, Muscle Percent: +10, Cold Spell Damage: +25, Last Available: "2014-12"
 7166	bland miniature jittery can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
-7167	ionized deionized mirror bouncing smudge stick	0		Effect: "Prelude of Precision", Effect Duration: 34, Last Available: "2014-12"
+7167	ionized deionized bouncing mirror smudge stick	0		Effect: "Prelude of Precision", Effect Duration: 34, Last Available: "2014-12"
 7168	alkaline wall	0		Effect: "X-Ray Vision", Effect Duration: 30, Last Available: "2014-12"
 7169	extra-dry lousy tankard of ale	5	decent	Last Available: "2014-12"
 7170	colloidal scroll case	0		Effect: "Crocodile Tear", Effect Duration: 11, Last Available: "2014-12"
@@ -7061,7 +7061,7 @@
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
 7174	stale humble pie	4	decent	Last Available: "2014-12"
-7175	skewed blurry small golem	0		Last Available: "2014-12"
+7175	blurry skewed small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	polymerized concentrated crappy waiter disguise	0		Effect: "Tea-hee", Effect Duration: 53
 7178	Copperhead Charm	0		
@@ -7088,11 +7088,11 @@
 7199	blurry blowdart	0		
 7200	Buddy Bjorn of the overflowing toilet	0		Stench Spell Damage: +50, Softcore Only, Last Available: "2014-02"
 7201	squat rosewater-soaked chilly sinister The Nuge's favorite crossbow	0		Spell Damage: +10, Cold Damage: +5, Stench Resistance: +3
-7202	massive moldy sweet roll Alabama	6	crappy	
+7202	moldy massive sweet roll Alabama	6	crappy	
 7203	Saturday Night Special of doom	0		Spooky Spell Damage: +50
 7204	lynyrd snare	0		
 7205	jittery purple fleetwood chain of the dark arts	0		Spell Damage Percent: +100
-7206	hand-crafted weak olive Green Manalishi	2	EPIC	
+7206	weak hand-crafted olive Green Manalishi	2	EPIC	
 7207	blade of the cheetah	0		Initiative: +60
 7208	ghostly fire of unknown origin	0		
 7209	eagle's milk	1	crappy	
@@ -7100,8 +7100,8 @@
 7211	energized red one pill	0		Effect: "Hot Blooded", Effect Duration: 57
 7212	maroon steel-toed Jefferson wings	0		Damage Reduction: 9
 7213	fleetwood macaroni	0		
-7214	wobbly skewed cheesy eagle sauce	0		
-7215	half-sized yummy fleetwood mac 'n' cheese	2	awesome	
+7214	skewed wobbly cheesy eagle sauce	0		
+7215	yummy half-sized fleetwood mac 'n' cheese	2	awesome	
 7216	lynyrd skin	0		
 7217	padded lynyrdskin cap	0		Damage Absorption: +20, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	friendly lynyrdskin tunic	0		Familiar Weight: +3
@@ -7111,14 +7111,14 @@
 7222	smooth shaking Flamin' Whatshisname	3	awesome	
 7223	concentrated cold-filtered lynyrd musk	0		Effect: "Hood Ridin'", Effect Duration: 29
 7224	shaking zippy educational Kashmir sweater	0		Experience: +1, Initiative: +20
-7225	bland skewed blurry huge custard pie	3	decent	
+7225	bland blurry skewed huge custard pie	3	decent	
 7226	tea for one	1	good	
-7227	delicious boozy jittery bottle of Evermore	5	awesome	
+7227	boozy delicious jittery bottle of Evermore	5	awesome	
 7228	box	0		
 7229	practically non-alcoholic mediocre wine	1	decent	
 7230	lousy rum	3	decent	
 7231	hand-crafted Murderer's Punch	3	EPIC	
-7232	adequate low-calorie blinking velvet cake	1	good	
+7232	low-calorie adequate blinking velvet cake	1	good	
 7233	alkaline wobbly letter	0		Effect: "Wet and Greedy", Effect Duration: 44
 7234	pulsating miser's rosewater-soaked book	0		Stench Resistance: +3, Meat Drop: +10
 7235	zippy experienced masque	0		Experience: +2, Initiative: +20, Single Equip
@@ -7181,7 +7181,7 @@
 7292	putty coat	0		Familiar Weight: +5
 7293	liquefied ionized maroon blinking can of V-11	0		Effect: "Twinklebritches", Effect Duration: 43, Last Available: "2014-03"
 7294	spinning spinning fireproof greasy elevennis shoes	0		Sleaze Spell Damage: +10, Hot Resistance: +3, Last Available: "2014-03"
-7295	ghostly upside-down elevent	0		Last Available: "2014-03"
+7295	upside-down ghostly elevent	0		Last Available: "2014-03"
 7296	nasty elevenderizing hammer of Leguizamo	0		Monster Level: +20, Stench Damage: +5, Last Available: "2014-03"
 7297	steel-toed Professor What T-Shirt	0		Damage Reduction: 9
 7298	heavy-duty bendy straw	0		
@@ -7210,14 +7210,14 @@
 7321	greasy brainy Stephen's lab coat	0		Mysticality: +5, Sleaze Spell Damage: +10
 7322	triple-aerosolized cyan Stephen's secret formula	0		Effect: "Scorpio Rising", Effect Duration: 21
 7323	nippy Jacob's rung of incineration	0		Cold Damage: +10, Hot Spell Damage: +50
-7324	altered spinning ghostly gray battery	1		
-7325	fancy acceptable snakebite	3	good	Effect: "Sparkly!", Effect Duration: 10
+7324	altered ghostly gray spinning battery	1		
+7325	acceptable fancy snakebite	3	good	Effect: "Sparkly!", Effect Duration: 10
 7326	Van der Graaf wizardly rubber ribcage	0		Mysticality: +25, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 7
 7327	compressed purple synthetic marrow	1		
 7328	liquefied electrified mirror funny bone	0		Effect: "Resilient Spirit", Effect Duration: 35
 7329	flame-wreathed medical-grade half-melted spoon	0		Hot Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10
-7330	pickled skewed lime green wobbly the funk	1		Effect: "Sugar High", Effect Duration: 15
-7331	toothsome gigantic gray gunky chicken	10	awesome	
+7330	pickled wobbly lime green skewed the funk	1		Effect: "Sugar High", Effect Duration: 15
+7331	gigantic toothsome gray gunky chicken	10	awesome	
 7332	bouncing baleful doll head	0		Spell Damage: +25
 7333	droopy doll eye	0		
 7334	huge voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7234,7 +7234,7 @@
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	pulsating energetic sinister ghost toga	0		Spell Damage: +10, Maximum MP Percent: +20
-7348	stale gigantic special sheet cake	10	decent	Effect: "Muddled", Effect Duration: 5
+7348	stale special gigantic sheet cake	10	decent	Effect: "Muddled", Effect Duration: 5
 7349	ghost key	0		
 7350	spinning picture of you	0		
 7351	upside-down crafty Staff of the Electric Range of the ox of the boozehound	0		Muscle: +20, Maximum MP: +10, Booze Drop: +100
@@ -7261,7 +7261,7 @@
 7372	decent skewed pie man was not meant to eat	4	good	
 7373	wobbly green grievous sommelier's towel	0		Weapon Damage Percent: +50
 7374	tumbling tarnished tastevin of the cheetah	0		Initiative: +60, Single Equip
-7375	adequate half-sized actual tapas	2	good	
+7375	half-sized adequate actual tapas	2	good	
 7376	ghast iron ingot	0		
 7377	family-friendly ghast iron cleaver of mayonnaise	0		Sleaze Spell Damage: +50, Sleaze Resistance: +1
 7378	mansplainer's sinister ghast iron Garibaldi	0		Spell Damage: +10, Monster Level: +15, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7311,7 +7311,7 @@
 7422	pulsating Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
-7425	blurry lime green Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
+7425	lime green blurry Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	bouncing sprinkle shaker	0		Last Available: "2014-05"
 7427	modified tumbling sleight-of-hand mushroom	0		Effect: "Night Vision", Effect Duration: 52, Last Available: "2014-05"
 7428	green jittery Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
@@ -7323,18 +7323,18 @@
 7434	aerosolized Helvella Haemophilia mushroom	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 35, Last Available: "2014-05"
 7435	denatured Stemonitis Staticus mushroom	0		Effect: "Ponderous Potency", Effect Duration: 45, Last Available: "2014-05"
 7436	cold-filtered spinning jittery Tremella Tarantella mushroom	0		Effect: "A Few Extra Pounds", Effect Duration: 48, Last Available: "2014-05"
-7437	blurry wobbly Pastaco shell	0		Last Available: "2014-05"
-7438	fancy decent Beefy Crunch Pastaco	3	good	Effect: "Celestial Vision", Effect Duration: 20, Last Available: "2014-05"
-7439	moldy snack-sized Brain Food Pastaco	2	crappy	Last Available: "2014-05"
-7440	half-sized rotten Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
+7437	wobbly blurry Pastaco shell	0		Last Available: "2014-05"
+7438	decent fancy Beefy Crunch Pastaco	3	good	Effect: "Celestial Vision", Effect Duration: 20, Last Available: "2014-05"
+7439	snack-sized moldy Brain Food Pastaco	2	crappy	Last Available: "2014-05"
+7440	rotten half-sized Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
 7441	moldy fancy Medical Pastaco	3	crappy	Effect: "Memory of Attractiveness", Effect Duration: 50, Last Available: "2014-05"
 7442	spoiled Energy Buzz Pastaco	4	crappy	Last Available: "2014-05"
 7443	stale red Ludovico Pastaco	3	decent	Last Available: "2014-05"
 7444	tolerable overpowering mushroom wine	4	good	Last Available: "2014-05"
-7445	acceptable purple narrow complex mushroom wine	3	good	Last Available: "2014-05"
+7445	acceptable narrow purple complex mushroom wine	3	good	Last Available: "2014-05"
 7446	mediocre smooth mushroom wine	4	decent	Last Available: "2014-05"
 7447	weak lousy blood-red mushroom wine	2	decent	Last Available: "2014-05"
-7448	acceptable weak buzzing mushroom wine	2	good	Last Available: "2014-05"
+7448	weak acceptable buzzing mushroom wine	2	good	Last Available: "2014-05"
 7449	watered-down acceptable swirling mushroom wine	2	good	Last Available: "2014-05"
 7450	bite-sized flavorless Taco Dan's Basic Taco Dan Taco	1	decent	Last Available: "2014-05"
 7451	moldy Taco Dan's Taco Fish Fish Taco	4	crappy	Last Available: "2014-05"
@@ -7343,11 +7343,11 @@
 7454	irresponsibly strong bad super-size brogurt	7	decent	Last Available: "2014-05"
 7455	bad broberry brogurt	3	decent	Last Available: "2014-05"
 7456	lousy brocolate brogurt	3	decent	Last Available: "2014-05"
-7457	practically non-alcoholic mediocre French bronilla brogurt	1	decent	Last Available: "2014-05"
+7457	mediocre practically non-alcoholic French bronilla brogurt	1	decent	Last Available: "2014-05"
 7458	squat History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	twirling Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	spinning Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
-7461	twirling fuchsia industrial strength anti-fungal spray	0		Last Available: "2014-05"
+7461	fuchsia twirling industrial strength anti-fungal spray	0		Last Available: "2014-05"
 7462	skewed Brogre brorts of terror	0		Spooky Spell Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	squat Jack Frost's Brogre brolo shirt	0		Cold Spell Damage: +50, Last Available: "2014-05"
 7464	blue sage Brogre bucket hat	0		Mysticality Percent: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
@@ -7359,7 +7359,7 @@
 7470	flame-wreathed mansplainer's Herculean shrimp fork	0		Experience (Muscle): +1, Monster Level: +15, Hot Spell Damage: +10, Last Available: "2014-05"
 7471	alkaline triple-modified lime green BROS Energy Drink	0		Effect: "Filled with Magic", Effect Duration: 67, Last Available: "2014-05"
 7472	modified go-go potion	0		Effect: "Good Karma", Effect Duration: 45, Last Available: "2014-05"
-7473	extra-aerosolized teal ghostly shrimp cocktail	0		Effect: "Ass Over Teakettle", Effect Duration: 42, Last Available: "2014-05"
+7473	extra-aerosolized ghostly teal shrimp cocktail	0		Effect: "Ass Over Teakettle", Effect Duration: 42, Last Available: "2014-05"
 7474	magnetized blurry Yolo&trade; chocolates	0		Effect: "Patent Prevention", Effect Duration: 50, Last Available: "2020-09"
 7475	maroon beefcake's string of moist beads	0		Muscle: +25, Last Available: "2014-05"
 7476	huge Ultimate Mind Destroyer	0		Last Available: "2014-05"
@@ -7368,7 +7368,7 @@
 7479	diffused bouncing sugar fairy	0		Effect: "Cranberry Cordiality", Effect Duration: 24, Last Available: "2014-05"
 7480	deionized sugar bunny	0		Effect: "Influence of Sphere", Effect Duration: 61, Last Available: "2014-05"
 7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	weak tolerable Rompedores de Fantasmas	2	good	
+7482	tolerable weak Rompedores de Fantasmas	2	good	
 7483	lousy triple-distilled wobbly La Fantasma y La Oscuridad	8	decent	
 7484	bad distilled upside-down Fantasma en la M&aacute;quina	5	decent	
 7485	tumbling loosening powder	0		
@@ -7420,7 +7420,7 @@
 7531	dehydrated gray alien protein powder	1	awesome	Effect: "Twenty-three Squid, Ew", Effect Duration: 15, Last Available: "2014-05"
 7532	acceptable triple-distilled rocket fuel	6	good	Last Available: "2014-05"
 7533	pulsating alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7534	twirling bouncing alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7534	bouncing twirling alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	bad teal stealth bomber	4	decent	Last Available: "2014-05"
 7536	shaking space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
@@ -7433,18 +7433,18 @@
 7544	space bar	0		Last Available: "2014-05"
 7545	drinkable space port	4	good	Last Available: "2014-05"
 7546	clever arcane researcher's space needle	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Last Available: "2014-05"
-7547	improved altered unsweetened spinning blinking green buffed alien drugs	0		Effect: "Cold, Dead Hands", Effect Duration: 54, Last Available: "2014-05"
+7547	improved altered unsweetened spinning green blinking buffed alien drugs	0		Effect: "Cold, Dead Hands", Effect Duration: 54, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
 7549	flattened irradiated ash soda	0		Effect: "Gyromitra Gymnastics", Effect Duration: 24, Last Available: "2014-06"
 7550	boiled liquid smoke	0		Effect: "Memory of Attractiveness", Effect Duration: 62, Last Available: "2014-06"
 7551	moist teal dollop of barbecue sauce	0		Effect: "Frozen Shoulders", Effect Duration: 62, Last Available: "2014-06"
 7552	pressed bowl of marinade	0		Effect: "Extra Terrestrial", Effect Duration: 51, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
-7554	liquefied pulsating blue bottle of lighter fluid	0		Effect: "Object Detection", Effect Duration: 65, Last Available: "2014-06"
+7554	liquefied blue pulsating bottle of lighter fluid	0		Effect: "Object Detection", Effect Duration: 65, Last Available: "2014-06"
 7555	blurry page	0		
 7556	elephant gift	0		
 7557	quadruple-dry blood cells	0		Effect: "The Solution", Effect Duration: 12
-7558	perfectly mixed fortified wine	5	EPIC	
+7558	fortified perfectly mixed wine	5	EPIC	
 7559	anodized narrow gummi turtle	0		Effect: "Cookie Backup", Effect Duration: 44
 7560	turtle-shaped rock	0		
 7561	extra-improved alkaline squat giraffe-necked turtle	0		Effect: "Leash of Linguini", Effect Duration: 68
@@ -7458,7 +7458,7 @@
 7569	wool gravedigger's experienced Time Bandit Badge of Courage	0		Experience: +2, Spooky Damage: +10, Cold Resistance: +1
 7570	dry Friendliness Beverage	0		Effect: "Cotton Mouthed", Effect Duration: 66
 7571	coward's shellacked silent pea shooter	0		Damage Reduction: 7, Monster Level: -20
-7572	snack-sized toothsome D roll	2	awesome	
+7572	toothsome snack-sized D roll	2	awesome	
 7573	Annie Oakley's kiwi beak of Leguizamo	0		Critical Hit Percent: +20, Monster Level: +20
 7574	irresponsibly strong lousy fuchsia New Zealand iced tea	10	decent	
 7575	bouncing blinking Jeselnik's droll monocle of the boozehound	0		Sleaze Damage: +25, Booze Drop: +100, Single Equip
@@ -7477,15 +7477,15 @@
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	triple-distilled acceptable glass of &quot;milk&quot;	9	good	Last Available: "2014-07"
 7590	acceptable shaking olive cup of &quot;tea&quot;	4	good	Last Available: "2014-07"
-7591	acceptable watered-down thermos of &quot;whiskey&quot;	2	good	Last Available: "2014-07"
-7592	perfectly mixed weak Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
+7591	watered-down acceptable thermos of &quot;whiskey&quot;	2	good	Last Available: "2014-07"
+7592	weak perfectly mixed Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	smooth Bee's Knees	4	awesome	Last Available: "2014-07"
-7594	hand-crafted practically non-alcoholic Sockdollager	1	super EPIC	Last Available: "2014-07"
+7594	practically non-alcoholic hand-crafted Sockdollager	1	super EPIC	Last Available: "2014-07"
 7595	aged skewed Ish Kabibble	3	awesome	Last Available: "2014-07"
 7596	bad Hot Socks	4	decent	Last Available: "2014-07"
 7597	smooth Phonus Balonus	4	awesome	Last Available: "2014-07"
-7598	tolerable weak Flivver	2	good	Last Available: "2014-07"
-7599	acceptable special weak wobbly Sloppy Jalopy	2	good	Effect: "Berry Critical", Effect Duration: 40, Last Available: "2014-07"
+7598	weak tolerable Flivver	2	good	Last Available: "2014-07"
+7599	acceptable weak special wobbly Sloppy Jalopy	2	good	Effect: "Berry Critical", Effect Duration: 40, Last Available: "2014-07"
 7600	enhanced dry flame	0		Effect: "Memory of Attractiveness", Effect Duration: 23
 7601	Vulcanized temporary yak tattoo	0		Effect: "Slimy Flavor", Effect Duration: 49
 7602	concentrated triple-aerosolized Fitspiration&trade; poster	0		Effect: "Fishy", Effect Duration: 46
@@ -7504,7 +7504,7 @@
 7615	ionized triple-wet warmed pygmy adder oil	0		Effect: "Loco Motives", Effect Duration: 38
 7616	anodized quantum mirror pygmy witchhazel	0		Effect: "Weird Flavor", Effect Duration: 42
 7617	dry wet short deposition	0		Effect: "A Taste of Rainbow", Effect Duration: 43
-7618	aerosolized warmed huge huge red straw pole	0		Effect: "Rainbow Bright", Effect Duration: 52
+7618	aerosolized warmed red huge huge straw pole	0		Effect: "Rainbow Bright", Effect Duration: 52
 7619	double-warmed copperhead potion	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 67
 7620	super-concentrated cold-filtered blurry ninja fear powder	0		Effect: "The Moxie of LOV", Effect Duration: 12
 7621	improved warmed ninja eyeblack	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 12
@@ -7548,7 +7548,7 @@
 7659	lime green neoprene skullcap of extreme caution	0		Monster Level: -25, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	colloidal irradiated goblin water	0		Effect: "Like a Fish to Walter", Effect Duration: 35
 7661	dumb mud	0		
-7662	special flavorless Sogg-Os	4	decent	Effect: "Flower Power", Effect Duration: 5
+7662	flavorless special Sogg-Os	4	decent	Effect: "Flower Power", Effect Duration: 5
 7663	huge flame-retardant curative smooth Lord Soggyraven's Slippers	0		Moxie: +15, Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 7664	ionized Ancient Protector Soda	0		Effect: "Mortarfied", Effect Duration: 54
 7665	ionized colloidal liquid ice	0		Effect: "No Vertigo", Effect Duration: 37
@@ -7613,8 +7613,8 @@
 7724	pteruges of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xFairy, atk, cap 25"
 7725	adjusted shaking Bruno's blessing of Mars	0		Effect: "Sweet Tooth", Effect Duration: 61
 7726	anodized magnetized enhanced Dennis's blessing of Minerva	0		Effect: "Yet tea", Effect Duration: 66
-7727	unsweetened magnetized wobbly red Burt's blessing of Bacchus	0		Effect: "Down With Chow", Effect Duration: 28
-7728	irradiated galvanized activated purple blinking tumbling Freddie's blessing of Mercury	0		Effect: "All Is Forgiven", Effect Duration: 28
+7727	unsweetened magnetized red wobbly Burt's blessing of Bacchus	0		Effect: "Down With Chow", Effect Duration: 28
+7728	irradiated galvanized activated tumbling purple blinking Freddie's blessing of Mercury	0		Effect: "All Is Forgiven", Effect Duration: 28
 7729	Chroner trigger	0		
 7730	mirror Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
@@ -7642,11 +7642,11 @@
 7753	wobbly cyan baleful experienced Xiblaxian stealth cowl	0		Experience: +2, Spell Damage: +25, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	skewed Xiblaxian stealth trousers of Gandalf of extreme caution	0		Spell Critical Percent: +20, Monster Level: -25, Last Available: "2014-09"
 7755	lard-coated Xiblaxian stealth vest of the brazier	0		Hot Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2014-09"
-7756	immense stale Xiblaxian ultraburrito	8	decent	Last Available: "2014-09"
+7756	stale immense Xiblaxian ultraburrito	8	decent	Last Available: "2014-09"
 7757	hand-crafted Xiblaxian space-whiskey	4	EPIC	Last Available: "2014-09"
 7758	narrow Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	cold-filtered anodized They liver	0		Effect: "Nutrient-Rich", Effect Duration: 44, Last Available: "2014-09"
-7760	big yummy They liver popsicle	5	awesome	Last Available: "2014-09"
+7760	yummy big They liver popsicle	5	awesome	Last Available: "2014-09"
 7761	pulsating holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7668,9 +7668,9 @@
 7779	quantum experimental serum G-9	0		Effect: "All Branned Up", Effect Duration: 31, Last Available: "2014-10"
 7780	MacGyver's hardened heavy-duty clipboard of the pedagogue	0		Experience: +3, Damage Reduction: 11, Maximum MP: +100, Last Available: "2014-10"
 7781	tumbling manspreader's Sinatra's Herculean sage battery-powered drill	0		Mysticality Percent: +10, Experience (Muscle): +1, Experience (Moxie): +5, Monster Level: +10, Last Available: "2014-10"
-7782	adequate small limp broccoli	2	good	Last Available: "2014-10"
+7782	small adequate limp broccoli	2	good	Last Available: "2014-10"
 7783	prompt greasy razor-sharp hat	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10, Adventures: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
-7784	double-adjusted energized purple skewed monkey barf	0		Effect: "Walberg's Dim Bulb", Effect Duration: 68, Last Available: "2014-10"
+7784	double-adjusted energized skewed purple monkey barf	0		Effect: "Walberg's Dim Bulb", Effect Duration: 68, Last Available: "2014-10"
 7785	non-nitrogenated polarized candy	0		Effect: "Well-preserved", Effect Duration: 26, Last Available: "2014-10"
 7786	steel-toed educational jangly bracelet of the detective	0		Experience: +1, Damage Reduction: 9, Item Drop: +20, Last Available: "2014-10"
 7787	tumbling rock-hard cuddly teddy bear	0		Damage Reduction: 5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
@@ -7681,10 +7681,10 @@
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	upside-down Armory keycard	0		Last Available: "2014-10"
-7795	jumbo adequate initiative shawarma	5	good	Last Available: "2014-10"
+7795	adequate jumbo initiative shawarma	5	good	Last Available: "2014-10"
 7796	spoiled warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	super-sized yummy karma shawarma	5	awesome	Last Available: "2014-10"
-7798	watered-down artisanal Jungle Juice	2	EPIC	Last Available: "2014-10"
+7798	artisanal watered-down Jungle Juice	2	EPIC	Last Available: "2014-10"
 7799	bad Amnesiac Ale	3	decent	Last Available: "2014-10"
 7800	acceptable Highest Bitter	4	good	Last Available: "2014-10"
 7801	wobbly veiny mercenary pistol of the glutton	0		Maximum HP: +10, Food Drop: +100, Last Available: "2014-10"
@@ -7700,7 +7700,7 @@
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	rotten seared dino steak	3	crappy	
-7814	tolerable weak bottle of drinkin' gas	2	good	
+7814	weak tolerable bottle of drinkin' gas	2	good	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	blue gelatinous meat mass	0		
@@ -7714,11 +7714,11 @@
 7825	lard-coated Jack Frost's MacGyver's earbuds	0		Maximum MP: +100, Cold Spell Damage: +50, Sleaze Spell Damage: +25, Single Equip
 7826	red electrified baleful iFlail of bravery	0		Spell Damage: +25, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5
 7827	yummy unidentifiable dried fruit	4	awesome	
-7828	weak acceptable flat cider	2	good	
+7828	acceptable weak flat cider	2	good	
 7829	zippy coward's crafty trench lighter	0		Maximum MP: +10, Monster Level: -20, Initiative: +20, Last Available: "2014-10"
 7830	flattened experimental serum P-00	0		Effect: "Barking Mad", Effect Duration: 25, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
-7832	teal ghostly encrypted micro-cassette recorder	0		Last Available: "2014-10"
+7832	ghostly teal encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	jittery gore bucket	0		Last Available: "2014-10"
 7834	pack of smokes	0		Last Available: "2014-10"
 7835	ghostly ESP suppression collar	0		Last Available: "2014-10"
@@ -7731,12 +7731,12 @@
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
-7845	dry non-denatured skewed blurry twirling teal perl necklace	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 56, Last Available: "2014-12"
+7845	dry non-denatured skewed twirling blurry teal perl necklace	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 56, Last Available: "2014-12"
 7846	anodized teal twirling Fudge Fiber Armor Plating	0		Effect: "White-boy Angst", Effect Duration: 15, Last Available: "2014-12"
 7847	altered dry enhanced purple ruby on canes	0		Effect: "Void Between the Stars", Effect Duration: 15, Last Available: "2014-12"
 7848	jumbo bland petit fortran	5	decent	Last Available: "2014-12"
 7849	bland squat java cookie	3	decent	Last Available: "2014-12"
-7850	rotten tiny cookie cookie	1	crappy	Last Available: "2014-12"
+7850	tiny rotten cookie cookie	1	crappy	Last Available: "2014-12"
 7851	chaotic plastic exo-suited miner	0		Spell Critical Percent: +10, Last Available: "2014-12"
 7852	nippy plastic semi-autonomous drill unit	0		Cold Damage: +10, Last Available: "2014-12"
 7853	Newton's plastic ambulatory robo-minecart	0		Experience (Mysticality): +3, Last Available: "2014-12"
@@ -7779,7 +7779,7 @@
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	blinking Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
-7893	teal mirror Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
+7893	mirror teal Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	shaking Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	wobbly shaking Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	green Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
@@ -7793,7 +7793,7 @@
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	wobbly recovered elf magazine	0		Last Available: "2014-12"
 7906	pulsating recovered elf toothbrush	0		Last Available: "2014-12"
-7907	tumbling red recovered elf sleeping pills	0		Last Available: "2014-12"
+7907	red tumbling recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	skewed recovered elf underpants	0		Last Available: "2014-12"
 7909	wobbly recovered elf wallet	0		Last Available: "2014-12"
 7910	recovered elf pocketwatch	0		Last Available: "2014-12"
@@ -7808,10 +7808,10 @@
 7919	altered pulsating Big Punk	0		Effect: "Serendipi Tea", Effect Duration: 25
 7920	bouncing fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	watered-down drinkable narrow purple Friendly Turkey	2	good	Last Available: "2014-11"
-7923	weak aged Agitated Turkey	2	awesome	Last Available: "2014-11"
+7922	drinkable watered-down purple narrow Friendly Turkey	2	good	Last Available: "2014-11"
+7923	aged weak Agitated Turkey	2	awesome	Last Available: "2014-11"
 7924	practically non-alcoholic artisanal bouncing Ambitious Turkey	1	EPIC	Last Available: "2014-11"
-7925	enchanted normal neutron lollipop	4	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 35, Last Available: "2014-12"
+7925	normal enchanted neutron lollipop	4	good	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 35, Last Available: "2014-12"
 7926	acceptable watered-down gamma nog	2	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7826,9 +7826,9 @@
 7944	tooth	0		
 7945	blinking table	0		
 7946	tumbling smelly Annie Oakley's cool outlaw bandana	0		Moxie: +5, Critical Hit Percent: +20, Stench Spell Damage: +10
-7947	high-proof smooth blinking gray whiskey in a broken glass	8	awesome	
+7947	smooth high-proof gray blinking whiskey in a broken glass	8	awesome	
 7948	lousy shot of mescal	3	decent	
-7949	watered-down lousy glass of herbal tequila	2	decent	
+7949	lousy watered-down glass of herbal tequila	2	decent	
 7950	mirror minin' dynamite	0		
 7951	shaking coward's plaid cowboy hat of Gandalf	0		Spell Critical Percent: +20, Monster Level: -20, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7879,7 +7879,7 @@
 7997	dried polyesterene powder	1		Last Available: "2015-12"
 7998	distilled powder	1		Last Available: "2015-12"
 7999	pickled choco-Crimbot	0		Effect: "Squatting and Thrusting", Effect Duration: 18, Last Available: "2014-12"
-8000	quadruple-adjusted pickled ghostly blinking smart watch	0		Effect: "Wreathed in Smoke", Effect Duration: 25, Last Available: "2014-12"
+8000	quadruple-adjusted pickled blinking ghostly smart watch	0		Effect: "Wreathed in Smoke", Effect Duration: 25, Last Available: "2014-12"
 8001	super-energized quantum red tumbling augmented-reality shades	0		Effect: "Moon-Eyed", Effect Duration: 55, Last Available: "2014-12"
 8002	Sherlock's toy Crimbot mega face	0		Item Drop: +25, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
 8003	wobbly personal trainer's toy Crimbot power glove	0		Experience Percent (Muscle): +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
@@ -7899,7 +7899,7 @@
 8017	warmed aerosolized flask of tainted mining oil	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 16, Last Available: "2014-12"
 8018	pressed unsweetened enhanced gray and rain stick	0		Effect: "Total Protonic Reversal", Effect Duration: 17
 8019	fuchsia Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	normal miniature spinning Choco-Mint patty	2	good	Last Available: "2015-01"
+8020	miniature normal spinning Choco-Mint patty	2	good	Last Available: "2015-01"
 8021	acceptable hot mint schnocolate	3	good	Last Available: "2015-01"
 8022	diluted gray homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	jittery muscle stimulator	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	ghostly twirling rosy-cheeked stylish tope&eacute;	0		Moxie: +25, Maximum HP Percent: +30, Familiar Effect: "3xBarrr, cap 12"
 8035	topiary tights of Tarzan of the detective	0		Experience (Muscle): +3, Item Drop: +20
 8036	spinning topiary necktie of bravery	0		Spooky Resistance: +5
-8037	decent miniature bowl of topioca	2	good	
+8037	miniature decent bowl of topioca	2	good	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	huge trusty whip	0		
@@ -7937,7 +7937,7 @@
 8056	torch	0		
 8057	hale [spelunking test kit] of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20
 8058	plasma rifle of the pedagogue	0		Experience: +3
-8059	squat narrow Bananubis's Staff	0		Luck: -6
+8059	narrow squat Bananubis's Staff	0		Luck: -6
 8060	The Joke Book of the Dead of James Dean of the glutton	0		Experience (Moxie): +3, Food Drop: +100, Luck: -6
 8061	The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
@@ -7963,7 +7963,7 @@
 8088	jewel	0		
 8089	headless sparrow	0		
 8090	mangled squirrel	0		
-8091	ghostly bouncing rat carcass	0		
+8091	bouncing ghostly rat carcass	0		
 8092	blue wicker kickers of Leguizamo of horror	0		Monster Level: +20, Spooky Spell Damage: +25, Single Equip, Last Available: "2016-12"
 8093	gravedigger's wicker slicker of vim and vigor	0		Maximum HP Percent: +50, Spooky Damage: +10, Last Available: "2016-12"
 8094	wizardly beefy wicker knickers	0		Muscle: +10, Mysticality: +25, Last Available: "2016-12"
@@ -8007,7 +8007,7 @@
 8132	fireproof supercharged fiberglass fedora	0		Maximum MP Percent: +30, Hot Resistance: +3, Last Available: "2018-12"
 8133	altered gray fiberglass fibers	1		Last Available: "2018-12"
 8134	spinning bottle of lovebug pheromones	0		Free Pull
-8135	cyan shaking winged yeti fur	0		
+8135	shaking cyan winged yeti fur	0		
 8136	talisman of Renenutet	0		
 8138	blue rubber spatula of incineration	0		Hot Spell Damage: +50
 8139	spoon of the businessman	0		Meat Drop: +50
@@ -8020,7 +8020,7 @@
 8146	tarnished anodized invisible potion	0		Effect: "Afternoon Insight", Effect Duration: 13
 8147	time shuriken	0		
 8148	upside-down stiffened grievous supercool ninjammies	0		Moxie Percent: +20, Weapon Damage Percent: +50, Damage Reduction: 1, Familiar Effect: "atk, 0.5xPotato, cap 25"
-8149	modified skewed yellow Glo-Pop	0		Effect: "Bright!", Effect Duration: 59
+8149	modified yellow skewed Glo-Pop	0		Effect: "Bright!", Effect Duration: 59
 8150	quadruple-enhanced sugar sphere	0		Effect: "Berry Thorny", Effect Duration: 31
 8151	tarnished Shrubble Bubble	0		Effect: "Fishy Fortification", Effect Duration: 54
 8152	triple-ionized polyeaster egg	0		Effect: "Patent Avarice", Effect Duration: 34
@@ -8038,14 +8038,14 @@
 8164	blue perfumed smooth remaindered axe	0		Moxie: +15, Stench Resistance: +5
 8165	huge low-budget shield	0		Damage Reduction: 3
 8166	resourceful cr&ecirc;epy mask of the sweet-tooth	0		Maximum MP: +50, Candy Drop: +100, Familiar Effect: "spooky atk, cap 5"
-8167	special low-calorie decent baguette	1	good	Effect: "Chalky White Pallor", Effect Duration: 25
+8167	low-calorie special decent baguette	1	good	Effect: "Chalky White Pallor", Effect Duration: 25
 8168	yellow glob of icing	0		
 8169	enhanced triple-electrified fuchsia squat ginger snaps	0		Effect: "Pasta Oneness", Effect Duration: 36
 8170	warmed squat mostly-broken sunglasses	0		Effect: "Gummibrain", Effect Duration: 56
 8171	artisanal unflavored wine cooler	3	EPIC	
 8172	carton of snake milk	1	decent	
 8173	knitted sewer snake	0		Cold Resistance: +3
-8174	small rotten blurry pigeon egg	2	crappy	
+8174	rotten small blurry pigeon egg	2	crappy	
 8175	gray skewed wobbly slick jaunty feather of wisdom	0		Mysticality: +15, Moxie: +10
 8176	lousy irresponsibly strong premium malt liquor	9	decent	
 8177	tumbling green miser's brown paper pants of bravery	0		Spooky Resistance: +5, Meat Drop: +10
@@ -8062,13 +8062,13 @@
 8188	mediocre twirling Cherrytastrophe wine cooler	3	decent	
 8189	bad practically non-alcoholic jittery Radberry Rip wine cooler	1	decent	
 8190	high-proof artisanal squat Orangemageddon wine cooler	7	EPIC	
-8191	tolerable practically non-alcoholic tumbling Breakfast Blast wine cooler	1	good	
+8191	practically non-alcoholic tolerable tumbling Breakfast Blast wine cooler	1	good	
 8192	triple-distilled tolerable twirling Citrus Crush wine cooler	10	good	
-8193	jumbo bland plain bagel	5	decent	
-8194	huge normal glob of cream cheese	10	good	
-8195	fancy immense delicious loaf of soda bread	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35
+8193	bland jumbo plain bagel	5	decent	
+8194	normal huge glob of cream cheese	10	good	
+8195	delicious fancy immense loaf of soda bread	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35
 8196	flavorless acceptable bagel	3	decent	
-8197	miniature yummy squat standard-issue cupcake	2	awesome	
+8197	yummy miniature squat standard-issue cupcake	2	awesome	
 8198	huge decent ultra-deluxe cupcake	7	good	
 8199	hypnotic breadcrumbs	0		
 8200	stale huge popular tart	3	decent	
@@ -8119,7 +8119,7 @@
 8245	trash net	0		Last Available: "2015-04"
 8246	Da Vinci's groovy Dinsey mascot mask of bravery	0		Moxie Percent: +10, Experience (Mysticality): +5, Spooky Resistance: +5, Last Available: "2015-04"
 8247	spoiled wobbly Dinsey food-cone	3	crappy	Last Available: "2015-04"
-8248	artisanal enchanted Dinsey Whinskey	4	EPIC	Effect: "On the Trolley", Effect Duration: 25, Last Available: "2015-04"
+8248	enchanted artisanal Dinsey Whinskey	4	EPIC	Effect: "On the Trolley", Effect Duration: 25, Last Available: "2015-04"
 8249	anodized double-frozen Dinsey face paint	0		Effect: "Well Owl Be!", Effect Duration: 43, Last Available: "2015-04"
 8250	sage fannypack of the overflowing toilet	0		Mysticality Percent: +10, Stench Spell Damage: +50, Last Available: "2015-04"
 8251	tumbling narrow zippy scandalous toasty Tesla Socratic garbage sticker of the cheetah	0		Experience (Mysticality): +1, Hot Damage: +5, Sleaze Damage: +5, Initiative: 80, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-04"
@@ -8141,15 +8141,15 @@
 8267	squat spinning knitted sphygmayomanometer	0		Cold Resistance: +3, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	tumbling mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	small stale special blurry unappetizing mayolus	2	decent	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50, Last Available: "2015-05"
+8270	special stale small blurry unappetizing mayolus	2	decent	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50, Last Available: "2015-05"
 8271	rotten skewed uninteresting mayolus	4	crappy	Last Available: "2015-05"
-8272	stale miniature acceptable mayolus	2	decent	Last Available: "2015-05"
-8273	flavorless immense huge wobbly enticing mayolus	9	decent	Last Available: "2015-05"
-8274	flavorless fancy mouth-watering mayolus	3	decent	Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2015-05"
+8272	miniature stale acceptable mayolus	2	decent	Last Available: "2015-05"
+8273	immense flavorless huge wobbly enticing mayolus	9	decent	Last Available: "2015-05"
+8274	fancy flavorless mouth-watering mayolus	3	decent	Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2015-05"
 8275	blinking newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	pulsating Essence of Bear	0		Skill: "Bear Essence"
-8278	artisanal strong Afternoon Delight	5	EPIC	Last Available: "2015-04"
+8278	strong artisanal Afternoon Delight	5	EPIC	Last Available: "2015-04"
 8279	skewed Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	bouncing Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	pickled warmed activated Kokomo Resort Brand Suntan Oil	0		Effect: "The Real Deal", Effect Duration: 16, Last Available: "2015-04"
@@ -8174,7 +8174,7 @@
 8300	irradiated quantum power pill	0		Effect: "Thicker, Sicker", Effect Duration: 12, Last Available: "2015-06"
 8301	liquefied diffused nitrogenated pixel star	0		Effect: "Bear Clawed", Effect Duration: 29, Last Available: "2015-06"
 8302	immense decent pixel banana	6	good	Last Available: "2015-06"
-8303	artisanal irresponsibly strong pixel beer	7	EPIC	Last Available: "2015-06"
+8303	irresponsibly strong artisanal pixel beer	7	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	cyan pumps	0		Last Available: "2015-06"
 8306	quantum sludgesicle	0		Effect: "Mana Tea", Effect Duration: 28
@@ -8198,7 +8198,7 @@
 8324	alkaline colloidal huge disposable lighter	0		Effect: "Limber as Mortimer", Effect Duration: 45
 8325	cold-filtered dry coal contact lenses	0		Effect: "Spore-Wreathed", Effect Duration: 49
 8326	unsweetened enhanced green conjured ice cream	0		Effect: "All Blued Up", Effect Duration: 33
-8327	ionized narrow upside-down Iceberglar scarf	0		Effect: "Physicali Tea", Effect Duration: 23
+8327	ionized upside-down narrow Iceberglar scarf	0		Effect: "Physicali Tea", Effect Duration: 23
 8328	aerosolized wet icy hairspray	0		Effect: "Antibiotic Saucesphere", Effect Duration: 53
 8329	vacuum-sealed boiled smellbook	0		Effect: "Extra Backbone", Effect Duration: 57
 8330	anodized oxidized yellow assassin's cheese knife	0		Effect: "Tapped In", Effect Duration: 21
@@ -8220,7 +8220,7 @@
 8346	magnetized dry totally sweet mohawk helmet	0		Effect: "Smoking like a Bandit", Effect Duration: 66
 8347	deionized pickled upside-down spray chrome	0		Effect: "Simulation Stimulation", Effect Duration: 69
 8348	frozen ionized blue filthy monkey head	0		Effect: "Hustlin'", Effect Duration: 61
-8349	alkaline dry pulsating shaking cyan hand of cards	0		Effect: "Flambé-a-thon", Effect Duration: 64
+8349	alkaline dry shaking cyan pulsating hand of cards	0		Effect: "Flambé-a-thon", Effect Duration: 64
 8350	dry damp bar rag	0		Effect: "In Vino Vires", Effect Duration: 14
 8351	dry gray lump of goofball ore	0		Effect: "Pyramid Power", Effect Duration: 18
 8352	colloidal twirling skeleton beans	0		Effect: "The Smeezingtons", Effect Duration: 13
@@ -8241,7 +8241,7 @@
 8367	magnetized modified handful of stubble	0		Effect: "Wistfully Nostalgic", Effect Duration: 59
 8368	colloidal Vulcanized quadruple-wet garbage juice slurpee	0		Effect: "Space Cowboy", Effect Duration: 66
 8369	polarized pulsating plunge-leg	0		Effect: "Deadly Lampblade", Effect Duration: 23
-8370	triple-concentrated bouncing jittery funky eyepatch	0		Effect: "Smoking like a Bandit", Effect Duration: 53
+8370	triple-concentrated jittery bouncing funky eyepatch	0		Effect: "Smoking like a Bandit", Effect Duration: 53
 8371	ionized enhanced boiled tumbling bucket of fish juice	0		Effect: "Become Intensely interested", Effect Duration: 50
 8372	triple-colloidal chilled flashy pirate dreadlocks	0		Effect: "On the Trolley", Effect Duration: 32
 8373	ionized electrified fuchsia narrow captured boozles	0		Effect: "Spooky Jellied", Effect Duration: 40
@@ -8254,7 +8254,7 @@
 8380	polymerized irradiated pulsating pixel potion	0		Effect: "Go-Gone", Effect Duration: 30, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	fuchsia Deck of Every Card	0		Last Available: "2015-07"
-8383	cyan tumbling popular part	0		
+8383	tumbling cyan popular part	0		
 8384	bubblegum heart	0		Last Available: "2015-07"
 8385	spinning cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
@@ -8281,16 +8281,16 @@
 8407	spoiled pestopiary	3	crappy	
 8408	flattened huge ectoplasmic orbs	0		Effect: "Sweetened and Fattened", Effect Duration: 60
 8409	flavorless enchanted crudles	4	decent	Effect: "Super Structure", Effect Duration: 45
-8410	moldy gigantic agnolotti arboli	10	crappy	
+8410	gigantic moldy agnolotti arboli	10	crappy	
 8411	adequate blinking spaghetti with ghost balls	3	good	
 8412	tasty miniature succulent marrow	2	awesome	
 8413	flavorless salacious crumbs	3	decent	
 8414	rotten pulsating fusilli marrownarrow	4	crappy	
 8415	miniature decent suggestive strozzapreti	2	good	
 8416	jittery Mountain Stream gastrique	0		
-8417	half-sized stale Mt. McLargeHuge oyster	2	decent	
-8418	blurry yellow oyster sauce	0		
-8419	miniature decent linguini immondizia bianco	2	good	
+8417	stale half-sized Mt. McLargeHuge oyster	2	decent	
+8418	yellow blurry oyster sauce	0		
+8419	decent miniature linguini immondizia bianco	2	good	
 8420	half-sized spoiled upside-down shells a la shellfish	2	crappy	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8305,17 +8305,17 @@
 8431	blinking mirror spore pod	0		
 8432	bouncing hot spore pod	0		
 8433	cool spore pod	0		
-8434	upside-down blurry bouncing jingling spore pod	0		
+8434	bouncing blurry upside-down jingling spore pod	0		
 8435	greasy frightening LavaCo Lamp&trade;	0		Spooky Damage: +5, Sleaze Spell Damage: +10, Last Available: "2015-08"
 8436	squat double-paned cool LavaCo Lamp&trade;	0		Moxie: +5, Cold Resistance: +5, Last Available: "2015-08"
 8437	Oprah's hardy LavaCo Lamp&trade;	0		Maximum HP: +50, Maximum MP Percent: +50, Last Available: "2015-08"
 8438	thin wire	0		Last Available: "2015-08"
 8439	insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
-8441	skewed olive full lava bottle	0		Last Available: "2015-08"
+8441	olive skewed full lava bottle	0		Last Available: "2015-08"
 8442	jittery viscous lava globs	0		Last Available: "2015-08"
 8443	lime green lava globs	0		Last Available: "2015-08"
-8444	narrow gray lava globs	0		Last Available: "2015-08"
+8444	gray narrow lava globs	0		Last Available: "2015-08"
 8445	squat lava globs	0		Last Available: "2015-08"
 8446	SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8323,7 +8323,7 @@
 8449	uncapped lava bottle	0		Last Available: "2015-08"
 8450	ghostly capped lava bottle	0		Last Available: "2015-08"
 8451	capped lava bottle	0		Last Available: "2015-08"
-8452	spinning pulsating capped lava bottle	0		Last Available: "2015-08"
+8452	pulsating spinning capped lava bottle	0		Last Available: "2015-08"
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	blurry New Age crystal	0		Last Available: "2015-08"
@@ -8331,17 +8331,17 @@
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	purple slick high-temperature mining mask of the cougar	0		Moxie: 30, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	wobbly veiny fireproof megaphone of the ox	0		Muscle: +20, Maximum HP: +10, Last Available: "2015-08"
-8460	fancy normal tumbling mineapple	3	good	Effect: "Disdain of She-Who-Was", Effect Duration: 5, Last Available: "2015-08"
+8460	normal fancy tumbling mineapple	3	good	Effect: "Disdain of She-Who-Was", Effect Duration: 5, Last Available: "2015-08"
 8461	bad huge Gold Velvet&trade; whiskey	3	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	crappy	Last Available: "2015-08"
-8463	yummy thick smelted roe	5	awesome	Last Available: "2015-08"
-8464	triple-distilled tolerable lavawater	8	good	Last Available: "2015-08"
+8463	thick yummy smelted roe	5	awesome	Last Available: "2015-08"
+8464	tolerable triple-distilled lavawater	8	good	Last Available: "2015-08"
 8465	quantum altered basaltamander tongue	0		Effect: "Dreadful Smell", Effect Duration: 50, Last Available: "2015-08"
 8466	twirling fireproof flame-wreathed educational lavalarva	0		Experience: +1, Hot Spell Damage: +10, Hot Resistance: +3, Last Available: "2015-08"
 8467	fireproof lava balaclava of incineration of Flo-Jo	0		Hot Spell Damage: +50, Hot Resistance: +3, Initiative: +100, Last Available: "2015-08"
 8468	squat miser's lard-coated occult basaltamander buckler	0		Spell Damage Percent: +25, Sleaze Spell Damage: +25, Meat Drop: +10, Damage Reduction: 15, Last Available: "2015-08"
 8469	colloidal shaking lava globs	0		Effect: "Haunted Stomach", Effect Duration: 21, Last Available: "2015-08"
-8470	flavorless miniature gooey lava globs	2	decent	Last Available: "2015-08"
+8470	miniature flavorless gooey lava globs	2	decent	Last Available: "2015-08"
 8471	up-at-dawn baleful lava-proof pants	0		Spell Damage: +25, Adventures: +5, Last Available: "2015-08"
 8472	deadly heat-resistant necktie of the dark arts	0		Weapon Damage: +5, Spell Damage Percent: +100, Single Equip, Last Available: "2015-08"
 8473	jittery dog trainer's vibrating heat-resistant gloves of the boozehound	0		Maximum MP Percent: +10, Experience (familiar): +1, Booze Drop: +100, Single Equip, Last Available: "2015-08"
@@ -8349,7 +8349,7 @@
 8475	acceptable asbestos thermos	4	good	Last Available: "2015-08"
 8476	electrified liquid rhinestones	0		Effect: "Fishy Fortification", Effect Duration: 63, Last Available: "2015-08"
 8477	huge adequate disco biscuit	9	good	Last Available: "2015-08"
-8478	delicious watered-down ghostly Quaatorade&trade;	2	awesome	Last Available: "2015-08"
+8478	watered-down delicious ghostly Quaatorade&trade;	2	awesome	Last Available: "2015-08"
 8479	up-at-dawn perfumed biker's hat of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +5, Adventures: +5, Familiar Effect: "atk", Last Available: "2015-08"
 8480	squat healthy feathered headdress of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Item Drop: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
 8481	chilly razor-sharp groovy electrician's hardhat	0		Moxie Percent: +10, Weapon Damage Percent: +25, Cold Damage: +5, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8375,7 +8375,7 @@
 8501	fuchsia Raul's guitar pick	0		Last Available: "2015-08"
 8502	Pener's crisps	0		Last Available: "2015-08"
 8503	signed deuce	0		Last Available: "2015-08"
-8504	ghostly skewed gray Lavalos core	0		Last Available: "2015-08"
+8504	skewed gray ghostly Lavalos core	0		Last Available: "2015-08"
 8505	huge half-melted hula girl	0		Last Available: "2015-08"
 8506	maroon glass ceiling fragments	0		Last Available: "2015-08"
 8507	twisted SMOOCH coffee cup	1	EPIC	Last Available: "2015-08"
@@ -8394,9 +8394,9 @@
 8520	bouncing bouncing experienced SMOOCH codpiece of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	careful SMOOCH breastplate	0		Monster Level: -10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
-8523	bouncing pulsating tumbling fused fuse	0		Last Available: "2015-08"
+8523	tumbling bouncing pulsating fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	gigantic adequate lava cake	10	good	Last Available: "2015-08"
+8525	adequate gigantic lava cake	10	good	Last Available: "2015-08"
 8526	normal pink slime	3	good	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
@@ -8405,7 +8405,7 @@
 8531	Salsa Libre	0		
 8532	wobbly good gravy	0		
 8533	illicit fish sauce	0		
-8534	bland jumbo libertagliatelle	5	decent	
+8534	jumbo bland libertagliatelle	5	decent	
 8535	adequate turkish mostaccioli	3	good	
 8536	moldy linguini of the sea	4	crappy	
 8537	altered boiled Hersey&trade; SMOOCH	0		Effect: "Thick-Skinned", Effect Duration: 29
@@ -8414,16 +8414,16 @@
 8541	narrow drug cocktail sauce	0		
 8542	adequate half-sized Fettris	2	good	
 8543	stale half-sized huge fusillocybin	2	decent	
-8544	small toothsome prescription noodles	2	awesome	
+8544	toothsome small prescription noodles	2	awesome	
 8545	powdered cyan blood-drive sticker	1	good	Effect: "Space Cowboy", Effect Duration: 40
-8546	unsweetened corrupted blue tumbling bag of grain	0		Effect: "Altered Wavelengths", Effect Duration: 23
+8546	unsweetened corrupted tumbling blue bag of grain	0		Effect: "Altered Wavelengths", Effect Duration: 23
 8547	dry extra-ionized pocket maze	0		Effect: "Fitter, Happier", Effect Duration: 37
 8548	flattened diffused shady shades	0		Effect: "Cat-Alyzed", Effect Duration: 40
 8549	irradiated squeaky toy rose	0		Effect: "Always In Motion", Effect Duration: 64
 8550	yummy spinning weird gazelle steak	3	awesome	
 8551	miniature decent upside-down sausage without a cause	2	good	
 8552	adjusted face paint	0		Effect: "Antsy in your Pantsy", Effect Duration: 57
-8553	mediocre triple-distilled special emergency margarita	7	decent	Effect: "Bilious Briskness", Effect Duration: 30
+8553	special triple-distilled mediocre emergency margarita	7	decent	Effect: "Bilious Briskness", Effect Duration: 30
 8554	aged shaking maroon vintage smart drink	4	awesome	
 8555	narrow a ten-percent bonus	0		
 8556	fuchsia skewed Thwaitgold termite statuette	0		
@@ -8495,7 +8495,7 @@
 8622	ionized spinning cuppa Mediocri tea	0		Effect: "Human-Slime Hybrid", Effect Duration: 28, Last Available: "2015-09"
 8623	energized jittery cuppa Loyal tea	0		Effect: "Gummi-Grin", Effect Duration: 13, Last Available: "2015-09"
 8624	altered maroon upside-down cuppa Activi tea	1	crappy	Last Available: "2015-09"
-8625	denatured jittery yellow squat narrow cuppa Cruel tea	1		Effect: "Greased-Up Familiar", Effect Duration: 15, Last Available: "2015-09"
+8625	denatured yellow squat jittery narrow cuppa Cruel tea	1		Effect: "Greased-Up Familiar", Effect Duration: 15, Last Available: "2015-09"
 8626	enhanced cuppa Alacri tea	0		Effect: "Quadrilled", Effect Duration: 29, Last Available: "2015-09"
 8627	concentrated cold-filtered mirror cuppa Vitali tea	0		Effect: "Burnt 'n' Turnt", Effect Duration: 43, Last Available: "2015-09"
 8628	double-irradiated narrow cuppa Mana tea	0		Effect: "Old School Pompadour", Effect Duration: 44, Last Available: "2015-09"
@@ -8511,11 +8511,11 @@
 8638	tumbling electrified banded Royal scepter	0		Damage Absorption: +100, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	decent miniature bowl of eyeballs	2	good	Last Available: "2015-10"
-8642	moldy special mirror lime green bowl of mummy guts	4	crappy	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2015-10"
+8641	miniature decent bowl of eyeballs	2	good	Last Available: "2015-10"
+8642	special moldy mirror lime green bowl of mummy guts	4	crappy	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2015-10"
 8643	moldy bowl of maggots	3	crappy	Last Available: "2015-10"
 8644	lousy teal blood and blood	3	decent	Last Available: "2015-10"
-8645	drinkable weak Jack-O-Lantern beer	2	good	Last Available: "2015-10"
+8645	weak drinkable Jack-O-Lantern beer	2	good	Last Available: "2015-10"
 8646	tolerable enchanted olive zombie	4	good	Effect: "Tiki Toughness", Effect Duration: 20, Last Available: "2015-10"
 8647	olive Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	maroon wind-up spider	0		Last Available: "2015-10"
@@ -8545,21 +8545,21 @@
 8672	Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
-8675	jittery tumbling one-day ticket to The Glaciest	0		Last Available: "2015-11"
+8675	tumbling jittery one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	Vulcanized shoulder-warming lotion	0		Effect: "Takin' It Greasy", Effect Duration: 17, Last Available: "2015-11"
-8677	adequate massive iceberg lettuce	8	good	Last Available: "2015-11"
+8677	massive adequate iceberg lettuce	8	good	Last Available: "2015-11"
 8678	delicious huge ice wine	3	awesome	Last Available: "2015-11"
 8679	inspector's nasty baleful Wal-Mart snowglobe	0		Spell Damage: +25, Stench Damage: +5, Item Drop: +15, Last Available: "2015-11"
 8680	prompt horrifying sharpshooter's Wal-Mart nametag	0		Critical Hit Percent: +10, Spooky Damage: +25, Adventures: +3, Last Available: "2015-11"
 8681	crafty hardened Wal-Mart overalls of bravery	0		Damage Reduction: 3, Maximum MP: +10, Spooky Resistance: +5, Last Available: "2015-11"
-8682	lime green pulsating To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
+8682	pulsating lime green To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	skewed Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	wobbly perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	slick bellhop's hat	0		Moxie: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	practically non-alcoholic tolerable ice porter	1	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	tolerable practically non-alcoholic ice porter	1	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	magnetized cold-filtered exotic travel brochure	0		Effect: "Old School Pompadour", Effect Duration: 37, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	diffused colloidal cold-filtered spinning shampoo-conditioner	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 56, Last Available: "2015-11"
@@ -8580,7 +8580,7 @@
 8707	maroon self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	pickled abstraction: action	1		Effect: "Scavengers Scavenging", Effect Duration: 40, Last Available: "2015-12"
 8709	dehydrated shaking abstraction: thought	1		Last Available: "2015-12"
-8710	denatured narrow skewed abstraction: sensation	1		Last Available: "2015-12"
+8710	denatured skewed narrow abstraction: sensation	1		Last Available: "2015-12"
 8711	denatured huge abstraction: purpose	1		Last Available: "2015-12"
 8712	mixed upside-down squat abstraction: category	1		Effect: "Snobby", Effect Duration: 5, Last Available: "2015-12"
 8713	powdered jittery abstraction: perception	1		Last Available: "2015-12"
@@ -8608,13 +8608,13 @@
 8735	Jack Frost's steel-toed norwhal helmet of incineration	0		Damage Reduction: 9, Cold Spell Damage: +50, Hot Spell Damage: +50, Familiar Effect: "atk", Last Available: "2015-11"
 8736	zippy sharpshooter's dance instructor's octolus-skin cloak	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Initiative: +20, Last Available: "2015-11"
 8737	irresponsibly strong delicious shaking perfect cosmopolitan	7	awesome	Last Available: "2015-11"
-8738	practically non-alcoholic smooth perfect negroni	1	awesome	Last Available: "2015-11"
-8739	weak hand-crafted perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
+8738	smooth practically non-alcoholic perfect negroni	1	awesome	Last Available: "2015-11"
+8739	hand-crafted weak perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
 8740	lousy perfect mimosa	4	decent	Last Available: "2015-11"
-8741	drinkable weak perfect old-fashioned	2	good	Last Available: "2015-11"
+8741	weak drinkable perfect old-fashioned	2	good	Last Available: "2015-11"
 8742	artisanal perfect paloma	4	EPIC	Last Available: "2015-11"
 8743	denatured That 70s Cologne	0		Effect: "Ready to Snap", Effect Duration: 67, Last Available: "2015-11"
-8744	extra-flattened warmed concentrated spinning teal Wal-Mart &quot;diamond&quot; ring	0		Effect: "White Knuckles", Effect Duration: 32, Last Available: "2015-11"
+8744	extra-flattened warmed concentrated teal spinning Wal-Mart &quot;diamond&quot; ring	0		Effect: "White Knuckles", Effect Duration: 32, Last Available: "2015-11"
 8745	galvanized ionized Puffstone cigar	0		Effect: "Sauce Monocle", Effect Duration: 38, Last Available: "2015-11"
 8746	nitrogenated Conspiracy&trade; mascara	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 24, Last Available: "2015-11"
 8747	chilled wobbly Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Hardened Fabric", Effect Duration: 33, Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	nitrogenated altered hemp candy necklace	0		Effect: "Sappy Blood", Effect Duration: 67, Last Available: "2015-12"
 8751	energized dry purple communal gobstopper	0		Effect: "Impregnabili Tea", Effect Duration: 67, Last Available: "2015-12"
 8752	stale Crimbo salad	3	decent	Last Available: "2015-12"
-8753	snack-sized toothsome bread line	2	awesome	Last Available: "2015-12"
+8753	toothsome snack-sized bread line	2	awesome	Last Available: "2015-12"
 8754	weak perfectly mixed bark rootbeer	2	EPIC	Last Available: "2015-12"
 8755	aged ale	4	awesome	Last Available: "2015-12"
 8756	blurry plastic Tammy the Tambourine Elf of dire peril	0		Weapon Damage: +20, Last Available: "2015-12"
@@ -8641,7 +8641,7 @@
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
 8770	polymerized tumbling pitted sheet	0		Effect: "Barbecue Saucy", Effect Duration: 41, Last Available: "2015-12"
-8771	wobbly teal sparking robo-battery	0		Last Available: "2015-12"
+8771	teal wobbly sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	pulsating mansplainer's sinister reusable shopping bag of the scaredy-cat	0		Spell Damage: +10, Monster Level: 0, Last Available: "2015-12"
 8775	fuchsia gravedigger's coarse hemp socks	0		Spooky Damage: +10, Single Equip, Last Available: "2015-12"
@@ -8666,7 +8666,7 @@
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
-8797	spinning yellow bat-oomerang	0		Last Available: "2017-01"
+8797	yellow spinning bat-oomerang	0		Last Available: "2017-01"
 8798	purple bat-jute	0		Last Available: "2017-01"
 8799	bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
@@ -8690,7 +8690,7 @@
 8818	enchanted mediocre boozy Miss Graves' vermouth	5	decent	Effect: "Cat-Alyzed", Effect Duration: 15, Last Available: "2016-12"
 8819	adequate The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	dehydrated narrow The Author's ink	1		Last Available: "2016-02"
-8821	hand-crafted extra-dry tumbling The Mad Liquor	5	EPIC	Last Available: "2016-12"
+8821	extra-dry hand-crafted tumbling The Mad Liquor	5	EPIC	Last Available: "2016-12"
 8822	weak lousy mirror Doc Clock's thyme cocktail	2	decent	Last Available: "2016-12"
 8823	bland immense Mr. Burnsger	7	decent	Last Available: "2016-12"
 8824	diluted jittery jittery The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
@@ -8701,13 +8701,13 @@
 8829	spinning replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
-8832	bouncing tumbling domino mask	0		Familiar Weight: +5
+8832	tumbling bouncing domino mask	0		Familiar Weight: +5
 8833	polarized robin's egg	0		Effect: "Big Flaming Whip", Effect Duration: 20, Last Available: "2016-12"
 8834	normal shaking robin flan	3	good	Last Available: "2016-12"
 8835	lousy robin nog	4	decent	Last Available: "2016-12"
 8836	mirror upside-down LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
-8838	wobbly ghostly exploding gum	0		
+8838	ghostly wobbly exploding gum	0		
 8839	root beer barrel	0		
 8840	enhanced Kudzu slaw	0		Effect: "Flagrantly Fragrant", Effect Duration: 15
 8841	irradiated cyan Mansquito's blood	0		Effect: "Less Pervious", Effect Duration: 68
@@ -8747,14 +8747,14 @@
 8875	deadly savvy Shrub's Premium Baked Beans of the detective	0		Mysticality Percent: +20, Weapon Damage: +5, Item Drop: +20, Last Available: "2016-02"
 8876	miniature normal twirling plate of Heimz Fortified Kidney Beans	2	good	Last Available: "2016-02"
 8877	miniature flavorless plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
-8878	rotten immense upside-down plate of Mixed Garbanzos and Chickpeas	9	crappy	Last Available: "2016-02"
-8879	half-sized bland plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
+8878	immense rotten upside-down plate of Mixed Garbanzos and Chickpeas	9	crappy	Last Available: "2016-02"
+8879	bland half-sized plate of Hellfire Spicy Beans	2	decent	Last Available: "2016-02"
 8880	decent wobbly plate of Frigid Northern Beans	4	good	Last Available: "2016-02"
 8881	flavorless plate of World's Blackest-Eyed Peas	4	decent	Last Available: "2016-02"
-8882	moldy bite-sized plate of Trader Olaf's Exotic Stinkbeans	1	crappy	Last Available: "2016-02"
+8882	bite-sized moldy plate of Trader Olaf's Exotic Stinkbeans	1	crappy	Last Available: "2016-02"
 8883	thick decent plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	good	Last Available: "2016-02"
 8884	moldy plate of Val-U Brand Every Bean Salad	3	crappy	Last Available: "2016-02"
-8885	moldy small enchanted plate of Shrub's Premium Baked Beans	2	crappy	Effect: "Human-Penguin Hybrid", Effect Duration: 50, Last Available: "2016-02"
+8885	moldy enchanted small plate of Shrub's Premium Baked Beans	2	crappy	Effect: "Human-Penguin Hybrid", Effect Duration: 50, Last Available: "2016-02"
 8886	blue auspicious Sinatra's Fancy Jeff's pocket square	0		Experience (Moxie): +5, Item Drop: +10, Last Available: "2016-02"
 8887	olive spinning fireproof foul-smelling Daisy's unclean bloomers of James Dean	0		Experience (Moxie): +3, Stench Damage: +10, Hot Resistance: +3, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	adjusted modified rattler gland	0		Effect: "Bilious Brawn", Effect Duration: 63, Last Available: "2016-02"
 8907	altered cold-filtered flattened yellow half-digested coal	0		Effect: "Cravin' for a Ravin'", Effect Duration: 50, Last Available: "2016-02"
 8908	anodized purple tightly-wound spine	0		Effect: "Gingerbread Robust", Effect Duration: 15, Last Available: "2016-02"
-8909	yummy yellow narrow rotting beefsteak	3	awesome	Last Available: "2016-02"
+8909	yummy narrow yellow rotting beefsteak	3	awesome	Last Available: "2016-02"
 8910	perfectly mixed firemilk	3	EPIC	Last Available: "2016-02"
 8911	concentrated spidercow eye-cluster	0		Effect: "Just the Brown Ones", Effect Duration: 55, Last Available: "2016-02"
 8912	mixed moomy dust	1		Last Available: "2016-02"
@@ -8798,7 +8798,7 @@
 8926	red disc (green)	0		
 8927	disc (blue)	0		
 8928	narrow disc (yellow)	0		
-8929	upside-down wobbly red-hot knucklebone	0		Last Available: "2016-02"
+8929	wobbly upside-down red-hot knucklebone	0		Last Available: "2016-02"
 8930	diffused adjusted demonic cow's blood	0		Effect: "Seeing Colors", Effect Duration: 55, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
 8932	makeshift sixgun	0		Last Available: "2016-02"
@@ -8811,7 +8811,7 @@
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
-8942	purple blurry rotting cowskin	0		Last Available: "2016-02"
+8942	blurry purple rotting cowskin	0		Last Available: "2016-02"
 8943	wobbly shuddering cow skull	0		Last Available: "2016-02"
 8944	pulsating rhinestone cowhorn	0		Familiar Weight: +5
 8945	shaking cow skull	0		Last Available: "2016-02"
@@ -8823,7 +8823,7 @@
 8951	sicksilver spurs	0		Last Available: "2016-02"
 8952	mirror nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
-8954	huge gray special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
+8954	gray huge special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	huge Tales of the West: Cow Punching	0		
 8956	red Tales of the West: Beanslinging	0		
 8957	Tales of the West: Snake Oiling	0		
@@ -8845,7 +8845,7 @@
 8973	dry double-improved twirling unusual oil	0		Effect: "You're High as a Crow, Marty", Effect Duration: 44
 8974	tarnished oxidized yellow eldritch oil	0		Effect: "Wise Spirit", Effect Duration: 13
 8975	tumbling exclusive club	0		
-8976	denatured mirror maroon patent preventative tonic	0		Effect: "Pork Power", Effect Duration: 58
+8976	denatured maroon mirror patent preventative tonic	0		Effect: "Pork Power", Effect Duration: 58
 8977	colloidal patent invisibility tonic	0		Effect: "Nas Tea", Effect Duration: 32
 8978	super-warmed pulsating patent aggression tonic	0		Effect: "Tingly Biceps", Effect Duration: 62
 8979	activated patent sallowness tonic	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 63
@@ -8857,7 +8857,7 @@
 8985	double-paned real cowboy hat	0		Cold Resistance: +5
 8986	Memories of Cow Punching	0		Free Pull
 8987	narrow Memories of Beanslinging	0		Free Pull
-8988	spinning pulsating Memories of Snake Oiling	0		Free Pull
+8988	pulsating spinning Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	ghostly electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
@@ -8886,7 +8886,7 @@
 9014	luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
-9017	upside-down spinning viral video	0		Last Available: "2016-05"
+9017	spinning upside-down viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	pulsating plus one	0		Last Available: "2016-05"
@@ -8904,7 +8904,7 @@
 9032	normal bowl of Tastee-Wheet&trade;	4	good	
 9033	mirror Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	shaking Source essence	0		Last Available: "2016-06"
-9035	snack-sized delicious tumbling browser cookie	2	awesome	Last Available: "2016-06"
+9035	delicious snack-sized tumbling browser cookie	2	awesome	Last Available: "2016-06"
 9036	acceptable hacked gibson	3	good	Last Available: "2016-06"
 9037	up-at-dawn Source shades	0		Adventures: +5, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8980,7 +8980,7 @@
 9108	mirror blurry lead umbrella	0		
 9109	polarized ionized Shrieking Weasel holo-record	0		Effect: "Good Motivator", Effect Duration: 50
 9110	chilled Power-Guy 2000 holo-record	0		Effect: "Tremella Tremens", Effect Duration: 43
-9111	vacuum-sealed fuchsia bouncing Lucky Strikes holo-record	0		Effect: "Chow Downed", Effect Duration: 18
+9111	vacuum-sealed bouncing fuchsia Lucky Strikes holo-record	0		Effect: "Chow Downed", Effect Duration: 18
 9112	deionized huge huge EMD holo-record	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 57
 9113	concentrated upside-down gray Superdrifter holo-record	0		Effect: "Coldfinger", Effect Duration: 45
 9114	oxidized wobbly The Pigs holo-record	0		Effect: "Big Punkin'", Effect Duration: 42
@@ -9004,14 +9004,14 @@
 9132	energetic fortified pistol	0		Damage Absorption: +60, Maximum MP Percent: +20
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	normal leftover pasty	4	good	
-9135	extra-dry bad jittery very whiskey	5	decent	
+9135	bad extra-dry jittery very whiskey	5	decent	
 9136	ghostly li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	bouncing li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9139	narrow li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	ghostly skewed li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	skewed ghostly li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9143	lime green li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9145	olive li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
@@ -9023,13 +9023,13 @@
 9151	chilled adjusted invisible seam ripper	0		Lasts Until Rollover, Effect: "Chilblains of the Corn", Effect Duration: 14, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	spoiled raw sweet potato	3	crappy	Last Available: "2016-11"
-9154	moldy half-sized narrow raw beans	2	crappy	Last Available: "2016-11"
+9154	half-sized moldy narrow raw beans	2	crappy	Last Available: "2016-11"
 9155	normal raw stuffing	3	good	Last Available: "2016-11"
-9156	spoiled small twirling raw cranberry sauce	2	crappy	Last Available: "2016-11"
-9157	moldy miniature special spinning raw turkey	2	crappy	Effect: "Hella Tough", Effect Duration: 40, Last Available: "2016-11"
+9156	small spoiled twirling raw cranberry sauce	2	crappy	Last Available: "2016-11"
+9157	moldy special miniature spinning raw turkey	2	crappy	Effect: "Hella Tough", Effect Duration: 40, Last Available: "2016-11"
 9158	bland raw mincemeat	3	decent	Last Available: "2016-11"
 9159	bland tumbling raw potato	3	decent	Last Available: "2016-11"
-9160	decent small maroon raw gravy	2	good	Last Available: "2016-11"
+9160	small decent maroon raw gravy	2	good	Last Available: "2016-11"
 9161	stale enchanted narrow mirror raw bread	4	decent	Effect: "Cockroach Scurry", Effect Duration: 15, Last Available: "2016-11"
 9162	pulsating mini-marshmallow dispenser of the scaredy-cat of terror	0		Monster Level: -15, Spooky Spell Damage: +10, Last Available: "2016-11"
 9163	medical-grade steel-toed grievous glass casserole dish	0		Weapon Damage Percent: +50, Damage Reduction: 9, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-11"
@@ -9041,18 +9041,18 @@
 9169	spinning gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	stale sweet potatoes	4	decent	Last Available: "2016-11"
-9172	yummy thick bean casserole	5	awesome	Last Available: "2016-11"
+9172	thick yummy bean casserole	5	awesome	Last Available: "2016-11"
 9173	stale super-sized huge baked stuffing	5	decent	Last Available: "2016-11"
-9174	special spoiled low-calorie cranberry cylinder	1	crappy	Effect: "You're Rubber", Effect Duration: 30, Last Available: "2016-11"
+9174	spoiled special low-calorie cranberry cylinder	1	crappy	Effect: "You're Rubber", Effect Duration: 30, Last Available: "2016-11"
 9175	adequate thanksgiving turkey	3	good	Last Available: "2016-11"
 9176	flavorless mince pie	3	decent	Last Available: "2016-11"
-9177	half-sized delicious mashed potatoes	2	awesome	Last Available: "2016-11"
+9177	delicious half-sized mashed potatoes	2	awesome	Last Available: "2016-11"
 9178	bland warm gravy	4	decent	Last Available: "2016-11"
 9179	normal bread roll	3	good	Last Available: "2016-11"
 9180	spoiled maroon leftovers	3	crappy	Last Available: "2016-11"
 9181	big delicious leftovers sandwich	5	awesome	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
-9183	pulsating ghostly cornucopia	0		Last Available: "2016-11"
+9183	ghostly pulsating cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	wobbly pilgrim hat	0		Last Available: "2016-11"
 9186	tumbling packet of thanksgarden seeds	0		Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	quantum vacuum-sealed mirror shaking eldritch concentrate	0		Effect: "Bureaucratized", Effect Duration: 29, Last Available: "2016-11"
-9192	practically non-alcoholic aged eldritch extract	1	awesome	Last Available: "2016-11"
+9192	aged practically non-alcoholic eldritch extract	1	awesome	Last Available: "2016-11"
 9193	blue skewed Official Council Aide Pin of the brute of the sweet-tooth	0		Muscle Percent: +30, Candy Drop: +100, Last Available: "2016-11"
-9194	watered-down acceptable yellow tumbling eldritch distillate	2	good	Last Available: "2016-11"
+9194	acceptable watered-down tumbling yellow eldritch distillate	2	good	Last Available: "2016-11"
 9195	diluted eldritch essence	1		Last Available: "2016-11"
 9196	wobbly boxer's Science Notebook	0		Muscle Percent: +10
 9197	miser's ribald frosty eldritch hat	0		Cold Spell Damage: +10, Sleaze Damage: +10, Meat Drop: +10, Last Available: "2016-11"
@@ -9089,8 +9089,8 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	pulsating sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	rotten animal part cracker	3	crappy	Last Available: "2016-12"
-9220	perfectly mixed practically non-alcoholic special pulsating gingerbread wine	1	super ultra EPIC	Effect: "stats.enq", Effect Duration: 40, Last Available: "2016-12"
-9221	flavorless jumbo fancy gingerbread mug	5	decent	Effect: "Oth-Jeal-O", Effect Duration: 15, Last Available: "2016-12"
+9220	practically non-alcoholic special perfectly mixed pulsating gingerbread wine	1	super ultra EPIC	Effect: "stats.enq", Effect Duration: 40, Last Available: "2016-12"
+9221	fancy flavorless jumbo gingerbread mug	5	decent	Effect: "Oth-Jeal-O", Effect Duration: 15, Last Available: "2016-12"
 9222	olive wholesome gingerbread mask	0		Maximum HP Percent: +10, Last Available: "2016-12"
 9223	sizzling veiny gingerservo of mayonnaise	0		Maximum HP: +10, Hot Damage: +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2016-12"
 9224	denatured colloidal upside-down tainted icing	0		Effect: "Gummiheart", Effect Duration: 23, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	flattened vacuum-sealed tarnished wobbly industrial frosting	0		Effect: "Weepy, Creepy", Effect Duration: 49, Last Available: "2016-12"
 9242	non-electrified denatured colloidal fake cocktail	0		Effect: "Big Meat Big Prizes", Effect Duration: 39, Last Available: "2016-12"
-9243	artisanal watered-down high-end ginger wine	2	EPIC	Last Available: "2016-12"
+9243	watered-down artisanal high-end ginger wine	2	EPIC	Last Available: "2016-12"
 9244	blinking plastic bad vibe of the sweet-tooth	0		Candy Drop: +100, Last Available: "2016-12"
 9245	narrow plastic angry vikings of Gandalf	0		Spell Critical Percent: +20, Last Available: "2016-12"
 9246	plastic Knows About Chakras of James Dean	0		Experience (Moxie): +3, Last Available: "2016-12"
@@ -9122,20 +9122,20 @@
 9250	quantum modified Inner Strength	0		Effect: "There Is A Spoon", Effect Duration: 67, Last Available: "2016-12"
 9251	wet Inner Truth	0		Effect: "Stickler for Promptness", Effect Duration: 45, Last Available: "2016-12"
 9252	rotten spiritual candy cane	3	crappy	Last Available: "2016-12"
-9253	perfectly mixed cyan narrow spiritual eggnog	4	EPIC	Last Available: "2016-12"
+9253	perfectly mixed narrow cyan spiritual eggnog	4	EPIC	Last Available: "2016-12"
 9254	spoiled jittery spiritual fruitcake	3	crappy	Last Available: "2016-12"
-9255	adequate immense spiritual gingerbread	8	good	Last Available: "2016-12"
+9255	immense adequate spiritual gingerbread	8	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	teal squat My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
-9261	olive twirling Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
+9261	twirling olive Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	blinking yellow briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	fuchsia teethpick	0		Last Available: "2016-12"
-9266	ionized wobbly ghostly rock candy	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 27, Last Available: "2016-12"
+9266	ionized ghostly wobbly rock candy	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 27, Last Available: "2016-12"
 9267	spoiled green-iced sweet roll	3	crappy	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
@@ -9144,12 +9144,12 @@
 9272	lime green negative lump	0		
 9273	electrified hale Third Eye	0		Maximum HP: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9274	purple blinking toasty hale Krampus Horn	0		Maximum HP: +20, Hot Damage: +5, Single Equip, Last Available: "2016-12"
-9275	miniature spoiled hambrosier	2	crappy	Last Available: "2016-12"
+9275	spoiled miniature hambrosier	2	crappy	Last Available: "2016-12"
 9276	drinkable chakra-mental wine	4	good	Last Available: "2016-12"
 9277	denatured vacuum-sealed irradiated bouncing chakra malt	0		Effect: "Ack!  Barred!", Effect Duration: 16, Last Available: "2016-12"
 9278	flavorless Black Angus blackburger	3	decent	Last Available: "2016-12"
-9279	boozy aged brandy	5	awesome	Last Available: "2016-12"
-9280	unsweetened blinking ghostly potion of spiritual gunkifying	0		Effect: "Jittery", Effect Duration: 15, Last Available: "2016-12"
+9279	aged boozy brandy	5	awesome	Last Available: "2016-12"
+9280	unsweetened ghostly blinking potion of spiritual gunkifying	0		Effect: "Jittery", Effect Duration: 15, Last Available: "2016-12"
 9281	upside-down family-friendly sizzling bad vibroknife	0		Hot Damage: +10, Sleaze Resistance: +1, Last Available: "2016-12"
 9282	grievous Fonzie's crystal belt buckle	0		Experience (Moxie): +1, Weapon Damage Percent: +50, Last Available: "2016-12"
 9283	knitted Newton's saffron antaravasaka	0		Experience (Mysticality): +3, Cold Resistance: +3, Last Available: "2016-12"
@@ -9168,7 +9168,7 @@
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal blinking toast with hot jelly	3	good	Last Available: "2017-01"
 9298	stale toast with jelly	4	decent	Last Available: "2017-01"
-9299	half-sized decent toast with jelly	2	good	Last Available: "2017-01"
+9299	decent half-sized toast with jelly	2	good	Last Available: "2017-01"
 9300	bland toast with sleaze jelly	4	decent	Last Available: "2017-01"
 9301	spoiled red toast with stench jelly	3	crappy	Last Available: "2017-01"
 9302	skewed space jellybicycle	0		Familiar Weight: +5
@@ -9201,7 +9201,7 @@
 9329	polarized colloidal huge eldritch alignment spray	0		Effect: "Fudgehound", Effect Duration: 53, Last Available: "2017-02"
 9330	tumbling LOV Entrance Pass	0		Last Available: "2017-02"
 9331	inspector's lard-coated therapeutic eldritch hammer	0		Sleaze Spell Damage: +25, Item Drop: +15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-01"
-9332	immense spoiled eldritch mushroom	9	crappy	Last Available: "2017-03"
+9332	spoiled immense eldritch mushroom	9	crappy	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	adequate big narrow eldritch mushroom pizza	5	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9223,7 +9223,7 @@
 9351	purple peppermint sprig	0		Last Available: "2017-03"
 9352	green bottle of clam juice	0		Last Available: "2017-03"
 9353	cocktail mushroom	0		Last Available: "2017-03"
-9354	huge wobbly shot of granola liqueur	0		Last Available: "2017-03"
+9354	wobbly huge shot of granola liqueur	0		Last Available: "2017-03"
 9355	bouncing can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	purple lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
@@ -9237,35 +9237,35 @@
 9365	tolerable watered-down literal grasshopper	2	good	Last Available: "2017-03"
 9366	bad narrow double entendre	4	decent	Last Available: "2017-03"
 9367	weak mediocre Phlegethon	2	decent	Last Available: "2017-03"
-9368	lousy irresponsibly strong Siberian sunrise	7	decent	Last Available: "2017-03"
-9369	mediocre narrow blinking mentholated wine	3	decent	Last Available: "2017-03"
+9368	irresponsibly strong lousy Siberian sunrise	7	decent	Last Available: "2017-03"
+9369	mediocre blinking narrow mentholated wine	3	decent	Last Available: "2017-03"
 9370	watered-down drinkable low tide martini	2	good	Last Available: "2017-03"
-9371	delicious strong shroomtini	5	awesome	Last Available: "2017-03"
-9372	hand-crafted weak morning dew	2	EPIC	Last Available: "2017-03"
+9371	strong delicious shroomtini	5	awesome	Last Available: "2017-03"
+9372	weak hand-crafted morning dew	2	EPIC	Last Available: "2017-03"
 9373	delicious whiskey squeeze	3	awesome	Last Available: "2017-03"
 9374	acceptable great fashioned	4	good	Last Available: "2017-03"
 9375	perfectly mixed Gnomish sagngria	4	EPIC	Last Available: "2017-03"
-9376	watered-down acceptable vodka stinger	2	good	Last Available: "2017-03"
+9376	acceptable watered-down vodka stinger	2	good	Last Available: "2017-03"
 9377	mediocre pulsating extremely slippery nipple	3	decent	Last Available: "2017-03"
-9378	practically non-alcoholic artisanal piscatini	1	EPIC	Last Available: "2017-03"
+9378	artisanal practically non-alcoholic piscatini	1	EPIC	Last Available: "2017-03"
 9379	hand-crafted Churchill	3	EPIC	Last Available: "2017-03"
 9380	perfectly mixed tumbling soilzerac	4	EPIC	Last Available: "2017-03"
-9381	triple-distilled acceptable London frog	6	good	Last Available: "2017-03"
-9382	smooth boozy blinking nothingtini	5	awesome	Last Available: "2017-03"
+9381	acceptable triple-distilled London frog	6	good	Last Available: "2017-03"
+9382	boozy smooth blinking nothingtini	5	awesome	Last Available: "2017-03"
 9383	acceptable irresponsibly strong eighth plague	6	good	Last Available: "2017-03"
 9384	hand-crafted single entendre	3	EPIC	Last Available: "2017-03"
 9385	hand-crafted watered-down maroon reverse Tantalus	2	EPIC	Last Available: "2017-03"
 9386	aged watered-down bouncing elemental caipiroska	2	awesome	Last Available: "2017-03"
-9387	triple-distilled tolerable wobbly Feliz Navidad	8	good	Last Available: "2017-03"
+9387	tolerable triple-distilled wobbly Feliz Navidad	8	good	Last Available: "2017-03"
 9388	mediocre Bloody Nora	4	decent	Last Available: "2017-03"
 9389	artisanal moreltini	3	EPIC	Last Available: "2017-03"
 9390	perfectly mixed hell in a bucket	4	EPIC	Last Available: "2017-03"
 9391	perfectly mixed Newark	3	EPIC	Last Available: "2017-03"
 9392	lousy R'lyeh	4	decent	Last Available: "2017-03"
-9393	mediocre distilled Gnollish sangria	5	decent	Last Available: "2017-03"
+9393	distilled mediocre Gnollish sangria	5	decent	Last Available: "2017-03"
 9394	artisanal vodka barracuda	3	EPIC	Last Available: "2017-03"
 9395	drinkable Mysterious Island iced tea	3	good	Last Available: "2017-03"
-9396	weak tolerable drive-by shooting	2	good	Last Available: "2017-03"
+9396	tolerable weak drive-by shooting	2	good	Last Available: "2017-03"
 9397	tolerable gunner's daughter	4	good	Last Available: "2017-03"
 9398	triple-distilled aged dirt julep	8	awesome	Last Available: "2017-03"
 9399	bad Simepore slime	4	decent	Last Available: "2017-03"
@@ -9282,9 +9282,9 @@
 9410	Spacegate Research	0		Last Available: "2017-04"
 9411	lime green alien rock sample	0		Last Available: "2017-04"
 9412	upside-down alien gemstone	0		Last Available: "2017-04"
-9413	mirror mirror green geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9413	mirror green mirror geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	blinking botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	super-sized spoiled blinking edible alien plant bit	5	crappy	Last Available: "2017-04"
+9415	spoiled super-sized blinking edible alien plant bit	5	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9292,7 +9292,7 @@
 9420	denatured bouncing alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	jumbo toothsome blurry alien meat	5	awesome	Last Available: "2017-04"
+9423	toothsome jumbo blurry alien meat	5	awesome	Last Available: "2017-04"
 9424	ghostly alien toenails	0		Last Available: "2017-04"
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9328,16 +9328,16 @@
 9456	fuchsia sharpshooter's occult murderbot plasma rifle	0		Spell Damage Percent: +25, Critical Hit Percent: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
-9459	bouncing upside-down Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
+9459	upside-down bouncing Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	squat squat Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	ghostly Procrastinator locker key	0		Last Available: "2017-04"
-9463	blurry upside-down Space Baby children's book	0		Last Available: "2017-04"
+9463	upside-down blurry Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	mirror Spacegate	0		Last Available: "2017-04"
 9466	rotten Aldebaran sardines	4	crappy	Last Available: "2017-04"
 9467	high-proof delicious Centauri fish wine	6	awesome	Last Available: "2017-04"
-9468	distilled narrow cyan oxygen	1		Last Available: "2017-04"
+9468	distilled cyan narrow oxygen	1		Last Available: "2017-04"
 9469	upside-down Spacegate scientist's insignia of the storm of mayonnaise	0		Maximum MP Percent: +40, Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-04"
 9470	smooth Spacegate military insignia of the detective	0		Moxie: +15, Item Drop: +20, Single Equip, Last Available: "2017-04"
 9471	extremely unsafe Fonzie's Spacegate diplomat's insignia of mayonnaise	0		Experience (Moxie): +1, Weapon Damage Percent: +100, Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-04"
@@ -9354,16 +9354,16 @@
 9482	unsweetened electrified Daily Affirmation: Adapt to Change Eventually	0		Effect: "substats.enh", Effect Duration: 27, Last Available: "2017-05"
 9483	frozen blurry Daily Affirmation: Be a Mind Master	0		Effect: "Chunky", Effect Duration: 19, Last Available: "2017-05"
 9484	alkaline Daily Affirmation: Work For Hours a Week	0		Effect: "Bone Chilling", Effect Duration: 62, Last Available: "2017-05"
-9485	unsweetened spinning skewed Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Electrolit Up", Effect Duration: 23, Last Available: "2017-05"
+9485	unsweetened skewed spinning Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Electrolit Up", Effect Duration: 23, Last Available: "2017-05"
 9486	moldy miniature Affirmation Cookie	2	crappy	Last Available: "2017-05"
 9487	License To Kill	0		
-9488	skewed huge Thwaitgold bug statuette	0		
+9488	huge skewed Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	ionized Threatening Missive	0		Effect: "Macho, Macho Dog", Effect Duration: 27
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	ruddy Kremlin's Greatest Briefcase of Tarzan of Leguizamo	0		Experience (Muscle): +3, Maximum HP Percent: +40, Monster Level: +20, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	mediocre high-proof jittery basic martini	6	decent	Last Available: "2017-06"
+9494	high-proof mediocre jittery basic martini	6	decent	Last Available: "2017-06"
 9495	tolerable improved martini	3	good	Last Available: "2017-06"
 9496	boozy hand-crafted blurry splendid martini	5	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
@@ -9379,12 +9379,12 @@
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
-9510	cyan spinning Dust bunny	0		
+9510	spinning cyan Dust bunny	0		
 9511	wobbly Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	wobbly Meteorite-Ade	0		Last Available: "2017-08"
 9514	normal meteoreo	3	good	Last Available: "2017-08"
-9515	mediocre fancy meadeorite	3	decent	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2017-08"
+9515	fancy mediocre meadeorite	3	decent	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	skewed nippy rosy-cheeked personal trainer's meteortarboard	0		Experience Percent (Muscle): +10, Maximum HP Percent: +30, Cold Damage: +10, Last Available: "2017-08"
 9518	scandalous personal trainer's meteorite guard of Flo-Jo	0		Experience Percent (Muscle): +10, Sleaze Damage: +5, Initiative: +100, Damage Reduction: 9, Last Available: "2017-08"
@@ -9464,17 +9464,17 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	maroon temperance whiskey	1	good	Last Available: "2017-11"
 9594	irradiated wet moist wishbone	0		Effect: "Burnt 'n' Turnt", Effect Duration: 69, Last Available: "2017-11"
-9595	practically non-alcoholic tolerable blue Racisto Ruidoso	1	good	Last Available: "2017-11"
+9595	tolerable practically non-alcoholic blue Racisto Ruidoso	1	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	flavorless fuchsia bran muffin	4	decent	
-9598	stale super-sized special blueberry muffin	5	decent	Effect: "Tingly Biceps", Effect Duration: 5
+9598	super-sized special stale blueberry muffin	5	decent	Effect: "Tingly Biceps", Effect Duration: 5
 9599	silent A	0		Last Available: "2017-12"
 9600	yellow squat silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
 9602	silent D	0		Last Available: "2017-12"
 9603	silent E	0		Last Available: "2017-12"
 9604	silent F	0		Last Available: "2017-12"
-9605	maroon mirror silent G	0		Last Available: "2017-12"
+9605	mirror maroon silent G	0		Last Available: "2017-12"
 9606	teal silent H	0		Last Available: "2017-12"
 9607	silent I	0		Last Available: "2017-12"
 9608	upside-down silent J	0		Last Available: "2017-12"
@@ -9560,7 +9560,7 @@
 9688	bouncing flame-retardant forbidden Fonzie's burning paper crane	0		Experience (Moxie): +1, Spell Damage Percent: +50, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2018-12"
 9689	squat January's Garbage Tote (unopened)	0		Free Pull, Last Available: "2018-01"
 9690	January's Garbage Tote	0		Last Available: "2018-01"
-9691	ghostly blinking deceased crimbo tree	0		Last Available: "2018-01"
+9691	blinking ghostly deceased crimbo tree	0		Last Available: "2018-01"
 9692	grievous broken champagne bottle of horror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +25, Last Available: "2018-01"
 9693	twirling savvy tinsel tights of the cougar	0		Moxie: +20, Mysticality Percent: +20, Last Available: "2018-01"
 9694	bouncing tumbling fireproof nippy MacGyver's wad of used tape	0		Maximum MP: +100, Cold Damage: +10, Hot Resistance: +3, Last Available: "2018-01"
@@ -9640,7 +9640,7 @@
 9772	shaking ghostly Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
-9775	pulsating lime green Turtive	0		Last Available: "2018-03"
+9775	lime green pulsating Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
@@ -9671,7 +9671,7 @@
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
-9806	shaking skewed Glamare	0		Last Available: "2018-03"
+9806	skewed shaking Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
@@ -9726,7 +9726,7 @@
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	maroon FantasyRealm tattoo kit	0		Last Available: "2018-04"
-9861	pulsating upside-down maroon LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+9861	upside-down maroon pulsating LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	decent gigantic FantasyRealm turkey leg	10	good	Last Available: "2018-04"
 9863	drinkable green FantasyRealm mead	4	good	Last Available: "2018-04"
 9864	fuchsia nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9734,7 +9734,7 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	upside-down hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	squat gray grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	bite-sized normal druidic s'more	1	good	Last Available: "2018-04"
+9869	normal bite-sized druidic s'more	1	good	Last Available: "2018-04"
 9870	vaporized sachet of powder	1		Last Available: "2018-04"
 9871	artisanal mourning wine	4	EPIC	Last Available: "2018-04"
 9872	tumbling sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9763,7 +9763,7 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	blinking notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	spirit-forward delicious two meat muck	5	awesome	
+9898	delicious spirit-forward two meat muck	5	awesome	
 9899	adequate tiny chocolate Ogre Chieftain	1	good	
 9900	bland chocolate &quot;Phoenix&quot;	4	decent	
 9901	bland chocolate Spider Queen	4	decent	
@@ -9780,7 +9780,7 @@
 9912	A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	squat crude oil congealer	0		
-9915	normal snack-sized special blue good guava	2	good	Effect: "Larger", Effect Duration: 35
+9915	snack-sized normal special blue good guava	2	good	Effect: "Larger", Effect Duration: 35
 9916	aged gin and ginger	3	awesome	
 9917	Thwaitgold chigger statuette	0		
 9918	twisted bouncing gaseous gravy	1		
@@ -9797,7 +9797,7 @@
 9929	mansplainer's banded Brutal brogues of the cougar of the storm	0		Moxie: +20, Damage Absorption: +100, Maximum MP Percent: +40, Monster Level: +15, Lasts Until Rollover, Last Available: "2018-07"
 9930	prompt executive double-paned ruddy Draftsman's driving gloves	0		Maximum HP Percent: +40, Cold Resistance: +5, Meat Drop: +40, Adventures: +3, Lasts Until Rollover, Last Available: "2018-07"
 9931	wobbly Tesla rock-hard dangerous Nouveau nosering of Tarzan	0		Experience (Muscle): +3, Weapon Damage: +10, Damage Reduction: 5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-07"
-9932	polarized purple mirror sharkfin gumbo	0		Effect: "Orc Chops", Effect Duration: 40, Last Available: "2018-07"
+9932	polarized mirror purple sharkfin gumbo	0		Effect: "Orc Chops", Effect Duration: 40, Last Available: "2018-07"
 9933	altered pulsating huge boiling broth	0		Effect: "Astral Shell", Effect Duration: 58, Last Available: "2018-07"
 9934	chilled interrogative elixir	0		Effect: "Penguinny Flavor", Effect Duration: 18, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
@@ -9838,12 +9838,12 @@
 9970	lime green Oprah's Sinatra's ratty knitted cap	0		Experience (Moxie): +5, Maximum MP Percent: +50, Last Available: "2018-09"
 9972	twirling quilted intimidating chainsaw of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-09"
 9973	lousy party beer bomb	4	decent	Last Available: "2018-09"
-9974	big spoiled sweet party mix	5	crappy	Last Available: "2018-09"
+9974	spoiled big sweet party mix	5	crappy	Last Available: "2018-09"
 9975	twisted gray party balloon	1		Last Available: "2018-09"
 9976	rock-hard hardened party pants	0		Damage Reduction: 16, Last Available: "2018-09"
 9977	prompt nasty party whip of the bloodbag	0		Maximum HP: +100, Stench Damage: +5, Adventures: +3, Last Available: "2018-09"
 9978	green Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	enchanted weak lousy TRIO cup of beer	2	decent	Effect: "Strange Mental Acuity", Effect Duration: 5, Last Available: "2018-09"
+9979	weak lousy enchanted TRIO cup of beer	2	decent	Effect: "Strange Mental Acuity", Effect Duration: 5, Last Available: "2018-09"
 9980	small normal party platter for one	2	good	Last Available: "2018-09"
 9981	diluted ghostly Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
@@ -9874,20 +9874,20 @@
 10008	zippy miser's supercool mutant legs	0		Moxie Percent: +20, Meat Drop: +10, Initiative: +20, Last Available: "2018-11"
 10009	Jeselnik's sizzling mutant crown of the sewer	0		Hot Damage: +10, Stench Damage: +25, Sleaze Damage: +25, Last Available: "2018-11"
 10010	stale ghostly ectoplasm	3	decent	Last Available: "2018-11"
-10011	bland jumbo	5	decent	Last Available: "2018-11"
+10011	jumbo bland	5	decent	Last Available: "2018-11"
 10012	drinkable blurry bottle of vodka	3	good	Last Available: "2018-11"
-10013	flavorless immense fancy tumbling pizza	9	decent	Effect: "Okee-Dokee Computer", Effect Duration: 15, Last Available: "2018-11"
+10013	immense flavorless fancy tumbling pizza	9	decent	Effect: "Okee-Dokee Computer", Effect Duration: 15, Last Available: "2018-11"
 10014	boozy lousy shaking martini	5	decent	Last Available: "2018-11"
-10015	adequate gigantic cherry pie	7	good	Last Available: "2018-11"
-10016	fancy drinkable blinking olive eggnog	3	good	Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 15, Last Available: "2018-11"
+10015	gigantic adequate cherry pie	7	good	Last Available: "2018-11"
+10016	fancy drinkable olive blinking eggnog	3	good	Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 15, Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	adequate miniature Hell ramen	2	good	Last Available: "2018-11"
+10018	miniature adequate Hell ramen	2	good	Last Available: "2018-11"
 10019	tolerable gimlet	3	good	Last Available: "2018-11"
 10020	hand-crafted twice-haunted screwdriver	4	EPIC	Last Available: "2018-11"
 10021	rotten candy cane	3	crappy	Last Available: "2018-12"
-10022	hand-crafted weak wobbly runny fermented egg	2	EPIC	Last Available: "2018-12"
+10022	weak hand-crafted wobbly runny fermented egg	2	EPIC	Last Available: "2018-12"
 10023	flavorless tumbling oldcake	4	decent	Last Available: "2018-12"
-10024	spoiled immense green traditional Crimbo cookie	7	crappy	Last Available: "2023-06"
+10024	immense spoiled green traditional Crimbo cookie	7	crappy	Last Available: "2023-06"
 10025	Annie Oakley's plastic wild beaver	0		Critical Hit Percent: +20, Last Available: "2018-12"
 10026	shaking sage plastic reindeer	0		Mysticality Percent: +10, Last Available: "2018-12"
 10027	executive plastic Caf&eacute; Elf	0		Meat Drop: +40, Last Available: "2018-12"
@@ -9909,31 +9909,31 @@
 10043	bad beavermouth	4	decent	Last Available: "2018-12"
 10044	triple-distilled hand-crafted mirror beaver punch (papaya)	9	EPIC	Last Available: "2018-12"
 10045	delicious beaver punch (peach)	3	awesome	Last Available: "2018-12"
-10046	acceptable watered-down beaver punch (cherry)	2	good	Last Available: "2018-12"
+10046	watered-down acceptable beaver punch (cherry)	2	good	Last Available: "2018-12"
 10047	narrow miser's smooth Canadian lantern	0		Moxie: +15, Meat Drop: +10, Last Available: "2018-12"
 10048	reassuring muskox-skin cap	0		Spooky Resistance: +1, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	adequate glass of raw eggs	3	good	Last Available: "2018-12"
-10051	watered-down lousy enchanted punch-drunk punch	2	decent	Effect: "Fudgehound", Effect Duration: 35, Last Available: "2018-12"
+10051	enchanted watered-down lousy punch-drunk punch	2	decent	Effect: "Fudgehound", Effect Duration: 35, Last Available: "2018-12"
 10052	distilled blue body spradium	1		Effect: "Category", Effect Duration: 10, Last Available: "2018-12"
 10053	bauxite beret of the bloodbag	0		Maximum HP: +100, Last Available: "2018-12"
 10054	tumbling jittery bauxite boxers of the detective	0		Item Drop: +20, Last Available: "2018-12"
 10055	jittery fortified bauxite bow-tie	0		Damage Absorption: +60, Single Equip, Last Available: "2018-12"
-10056	twirling skewed Boxing Day Pass	0		Last Available: "2018-12"
+10056	skewed twirling Boxing Day Pass	0		Last Available: "2018-12"
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	sizzling nippy curative wizardly strapping Kramco Sausage-o-Matic&trade;	0		Muscle: +5, Mysticality: +25, Cold Damage: +10, Hot Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-01"
 10059	spinning sausage casing	0		Last Available: "2019-01"
-10060	half-sized stale sausage	2	decent	Last Available: "2019-01"
+10060	stale half-sized sausage	2	decent	Last Available: "2019-01"
 10061	skewed asbestos-lined lard-coated red-hot sausage fork	0		Sleaze Spell Damage: +25, Hot Resistance: +5, Last Available: "2019-01"
-10062	pulsating shaking bag of sausage links	0		Last Available: "2019-01"
+10062	shaking pulsating bag of sausage links	0		Last Available: "2019-01"
 10063	squat sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	spinning Toyleporter	0		Last Available: "2018-12"
-10066	special fortified perfectly mixed twirling beer	5	EPIC	Effect: "Big Punkin'", Effect Duration: 35, Last Available: "2018-12"
+10066	special perfectly mixed fortified twirling beer	5	EPIC	Effect: "Big Punkin'", Effect Duration: 35, Last Available: "2018-12"
 10067	normal wobbly twirling mirror yule gruel	4	good	Last Available: "2018-12"
 10068	enchanted acceptable hot watered rum	3	good	Effect: "Puzzle Fury", Effect Duration: 35, Last Available: "2018-12"
-10069	practically non-alcoholic fancy artisanal bottle of Crimbognac	1	super ultra mega turbo EPIC	Effect: "Destructive Resolve", Effect Duration: 35, Last Available: "2018-12"
-10070	moldy snack-sized Crimboysters Rockefeller	2	crappy	Last Available: "2018-12"
+10069	practically non-alcoholic artisanal fancy bottle of Crimbognac	1	super ultra mega turbo EPIC	Effect: "Destructive Resolve", Effect Duration: 35, Last Available: "2018-12"
+10070	snack-sized moldy Crimboysters Rockefeller	2	crappy	Last Available: "2018-12"
 10071	vaporized Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	jittery Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9951,7 +9951,7 @@
 10085	squat padded smooth chalk chinos	0		Moxie: +15, Damage Absorption: +20, Last Available: "2019-12"
 10086	chalk chapeau of the cougar of Leguizamo	0		Moxie: +20, Monster Level: +20, Last Available: "2019-12"
 10087	wicked beefy chalk choker	0		Muscle: +10, Spell Damage: +5, Single Equip, Last Available: "2019-12"
-10088	dehydrated narrow lime green chalk chunks	1		Effect: "Carrrsmic", Effect Duration: 15, Last Available: "2019-12"
+10088	dehydrated lime green narrow chalk chunks	1		Effect: "Carrrsmic", Effect Duration: 15, Last Available: "2019-12"
 10089	anodized polymerized pickled jittery candy chalk	0		Effect: "Familial Ties", Effect Duration: 48
 10090	hardened marble maebari of the businessman	0		Damage Reduction: 3, Meat Drop: +50, Last Available: "2019-12"
 10091	auspicious rosy-cheeked marble mantle	0		Maximum HP Percent: +30, Item Drop: +10, Last Available: "2019-12"
@@ -9999,7 +9999,7 @@
 10133	zippy loofah ladle	0		Item Drop: +5, Initiative: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
 10134	electrified savvy loofah legwarmers	0		Mysticality Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
 10135	skewed narrow vibrating Da Vinci's loofah lavalier	0		Experience (Mysticality): +5, Maximum MP Percent: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	mixed gray skewed loofah lumps	1		Last Available: "2022-12"
+10136	mixed skewed gray loofah lumps	1		Last Available: "2022-12"
 10137	aerosolized denatured maroon chocolate-covered loofah	0		Effect: "Seriously Mutated", Effect Duration: 43
 10138	blue Tesla flagstone flag of James Dean	0		Experience (Moxie): +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
 10139	narrow lion tamer's energetic flagstone flail	0		Maximum MP Percent: +20, Experience (familiar): +2, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	green really nice net	0		Last Available: "2019-12"
 10154	aromatic elf army poncho	0		Stench Resistance: +1, Lasts Until Rollover, Last Available: "2019-12"
-10155	bite-sized delicious elf army field rations	1	awesome	Last Available: "2019-12"
+10155	delicious bite-sized elf army field rations	1	awesome	Last Available: "2019-12"
 10156	lime green gingernade	0		Last Available: "2019-12"
 10157	purple nippy arcane researcher's discarded bowtie	0		Experience Percent (Mysticality): +10, Cold Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
 10158	special hand-crafted martiny	3	EPIC	Effect: "Polka of Plenty", Effect Duration: 50, Last Available: "2019-12"
@@ -10031,14 +10031,14 @@
 10165	narrow mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	chaotic Oprah's Lil' Doctor&trade; bag	0		Maximum MP Percent: +50, Spell Critical Percent: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	special diet normal bloodstick	1	good	Effect: "Hypercubed", Effect Duration: 35
+10169	normal diet special bloodstick	1	good	Effect: "Hypercubed", Effect Duration: 35
 10170	high-proof drinkable bottle of Sanguiovese	10	good	
-10171	special stale gigantic actual blood sausage	9	decent	Effect: "Faboooo", Effect Duration: 25
-10172	artisanal practically non-alcoholic teal mulled blood	1	super ultra mega turbo EPIC	
+10171	special gigantic stale actual blood sausage	9	decent	Effect: "Faboooo", Effect Duration: 25
+10172	practically non-alcoholic artisanal teal mulled blood	1	super ultra mega turbo EPIC	
 10173	stale blood snowcone	4	decent	
 10174	drinkable twirling Red Russian	3	good	
 10175	normal half-sized blood roll-up	2	good	
-10176	perfectly mixed enchanted bottle of blood	4	EPIC	Effect: "Super-Electrified", Effect Duration: 50
+10176	enchanted perfectly mixed bottle of blood	4	EPIC	Effect: "Super-Electrified", Effect Duration: 50
 10177	spoiled blood-soaked sponge cake	3	crappy	
 10178	perfectly mixed fancy squat vampagne	3	super EPIC	Effect: "Spring Training", Effect Duration: 5
 10179	adequate plain snowcone	3	good	
@@ -10050,7 +10050,7 @@
 10185	skewed bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
-10188	mirror pulsating PirateRealm guest pass	0		Last Available: "2019-04"
+10188	pulsating mirror PirateRealm guest pass	0		Last Available: "2019-04"
 10189	nippy educational cool PirateRealm eyepatch	0		Moxie: +5, Experience: +1, Cold Damage: +10, Lasts Until Rollover, Last Available: "2019-04"
 10190	pulsating bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	blurry spinning compass	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10063,7 +10063,7 @@
 10198	blinking Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	snack-sized flavorless ghostly crabsicle	2	decent	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	distilled mediocre bottle of dark rhum	5	decent	Last Available: "2019-04"
+10201	mediocre distilled bottle of dark rhum	5	decent	Last Available: "2019-04"
 10202	watered-down acceptable bottle of extra-dark rhum	2	good	Last Available: "2019-04"
 10203	tolerable pulsating bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
 10204	corrupted pirate shaving cream	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 68, Last Available: "2019-04"
@@ -10073,35 +10073,35 @@
 10208	jittery signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	huge ribald pirate radio ring of bravery	0		Sleaze Damage: +10, Spooky Resistance: +5, Single Equip, Last Available: "2019-04"
-10211	twirling ghostly Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
+10211	ghostly twirling Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	tasty pineapple slab	3	awesome	Last Available: "2019-04"
 10213	flavorless bouncing hibiscus petal	3	decent	Last Available: "2019-04"
 10214	denatured huge mint leaf	0		Effect: "Polar Express", Effect Duration: 69, Last Available: "2019-04"
 10215	blurry cocoa of youth	0		Last Available: "2019-04"
 10216	boiled ghostly ice molecule	1		Last Available: "2019-04"
-10217	twirling blurry purple Red Roger's reliquary	0		Last Available: "2019-04"
+10217	blurry purple twirling Red Roger's reliquary	0		Last Available: "2019-04"
 10218	mirror Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	twirling Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	lime green Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
-10223	mixed wobbly cyan tumbling pewter shavings	1		Last Available: "2019-04"
+10223	mixed cyan tumbling wobbly pewter shavings	1		Last Available: "2019-04"
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	shaking plush sea serpent of terror	0		Spooky Spell Damage: +10, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	moldy bite-sized pirate fork	1		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
-10229	olive narrow ring	0		Single Equip, Last Available: "2019-04"
+10229	narrow olive ring	0		Single Equip, Last Available: "2019-04"
 10230	clever beefy piratical blunderbuss	0		Muscle: +10, Maximum MP: +20, Last Available: "2019-04"
 10231	upside-down spinning chaotic PirateRealm party hat of wisdom of the sweet-tooth	0		Mysticality: +15, Spell Critical Percent: +10, Candy Drop: +100, Last Available: "2019-04"
 10232	mediocre Island Landslide	3	decent	Last Available: "2019-04"
 10233	watered-down lousy Island Thunderstorm	2	decent	Last Available: "2019-04"
 10234	drinkable spinning Island Hurricane	3	good	Last Available: "2019-04"
-10235	drinkable fancy Skull Punch	4	good	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2019-04"
+10235	fancy drinkable Skull Punch	4	good	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2019-04"
 10236	delicious Electric Punch	3	awesome	Last Available: "2019-04"
-10237	special artisanal purple Smuggler's Punch	3	super EPIC	Effect: "Overstimulated", Effect Duration: 50, Last Available: "2019-04"
-10238	practically non-alcoholic perfectly mixed Scorpion Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
-10239	watered-down lousy special Turtle Bowl	2	decent	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2019-04"
+10237	artisanal special purple Smuggler's Punch	3	super EPIC	Effect: "Overstimulated", Effect Duration: 50, Last Available: "2019-04"
+10238	perfectly mixed practically non-alcoholic Scorpion Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10239	special watered-down lousy Turtle Bowl	2	decent	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2019-04"
 10240	artisanal Cobra Bowl	4	EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	perfumed asbestos-lined dog trainer's Sinatra's vampyric cloake of Calamity Jane	0		Experience (Moxie): +5, Critical Hit Percent: +15, Experience (familiar): +1, Hot Resistance: +5, Stench Resistance: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
@@ -10128,7 +10128,7 @@
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	bouncing hourglass	0		Last Available: "2019-07"
 10265	pulsating etched hourglass	0		Last Available: "2019-07"
-10266	adjusted mirror twirling magenta seashell	0		Effect: "Sweetened and Fattened", Effect Duration: 43, Last Available: "2019-07"
+10266	adjusted twirling mirror magenta seashell	0		Effect: "Sweetened and Fattened", Effect Duration: 43, Last Available: "2019-07"
 10267	galvanized activated jittery cyan seashell	0		Effect: "Brother Corsican's Blessing", Effect Duration: 16, Last Available: "2019-07"
 10268	quantum jittery shaking upside-down gray seashell	0		Effect: "Melancholy Burden", Effect Duration: 50, Last Available: "2019-07"
 10269	dry twirling seashell	0		Effect: "Eyes Wide Propped", Effect Duration: 23, Last Available: "2019-07"
@@ -10166,10 +10166,10 @@
 10301	teal family-friendly therapeutic whittled fox figurine of chilblains	0		Cold Damage: +25, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-08"
 10302	wobbly spinning clever steel-toed occult brawny whittled walking stick	0		Muscle Percent: +20, Spell Damage Percent: +25, Damage Reduction: 9, Maximum MP: +20, Last Available: "2019-08"
 10303	normal campfire hot dog	3	good	Last Available: "2019-08"
-10304	stale immense campfire baked potato	7	decent	Last Available: "2019-08"
+10304	immense stale campfire baked potato	7	decent	Last Available: "2019-08"
 10305	delicious huge campfire s'more	7	awesome	Last Available: "2019-08"
 10306	stale campfire beans	4	decent	Last Available: "2019-08"
-10307	snack-sized moldy campfire stew	2	crappy	Last Available: "2019-08"
+10307	moldy snack-sized campfire stew	2	crappy	Last Available: "2019-08"
 10308	twirling campfire coffee	1	awesome	Last Available: "2019-08"
 10309	dry leftover chocolate bar	0		Effect: "Fan-Cooled", Effect Duration: 34
 10310	rare Meat isotope	0		
@@ -10183,9 +10183,9 @@
 10318	upside-down low-pressure oxygen tank	0		Single Equip
 10319	blurry Thwaitgold bombardier beetle statuette	0		
 10320	decent pulsating space chowder	3	good	
-10321	irresponsibly strong drinkable space wine	10	good	
+10321	drinkable irresponsibly strong space wine	10	good	
 10322	The Imploded World	0		Skill: "Implode Universe"
-10323	ghostly maroon packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
+10323	maroon ghostly packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
@@ -10237,7 +10237,7 @@
 10378	bouncing Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	upside-down yellow greedy arcane researcher's strapping Dolph Bossin's Crimbo hat	0		Muscle: +5, Experience Percent (Mysticality): +10, Meat Drop: +20, Last Available: "2019-12"
 10380	The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
-10381	twirling purple The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
+10381	purple twirling The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
 10384	quantum salty gumdrop	0		Effect: "Mmmmmelon", Effect Duration: 63, Last Available: "2019-12"
@@ -10249,17 +10249,17 @@
 10390	twisted super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	Jim Carey's resourceful forbidden icing poncho	0		Spell Damage Percent: +50, Maximum MP: +50, Monster Level: +25, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
-10393	triple-adjusted skewed maroon glob of salty molasses	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2019-12"
+10393	triple-adjusted maroon skewed glob of salty molasses	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2019-12"
 10394	bouncing Temple Grandin's brawny Mer-kin rollpin	0		Muscle Percent: +20, Familiar Weight: +7, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	narrow tinsel fin	0		Familiar Weight: +5
-10397	normal small blinking bowl of mernudo	2	good	Last Available: "2019-12"
+10397	small normal blinking bowl of mernudo	2	good	Last Available: "2019-12"
 10398	acceptable fishelada	3	good	Last Available: "2019-12"
 10399	adequate ojo de pez burrito	3	good	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	huge squat waterlogged stuffing	0		Last Available: "2019-12"
-10403	tumbling blinking waterlogged	0		Last Available: "2019-12"
+10403	blinking tumbling waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
 10405	padded nutcracker hat of Calamity Jane	0		Damage Absorption: +20, Critical Hit Percent: +15, Last Available: "2019-12"
 10406	huge narrow miser's stylish nutcracker waistcoat	0		Moxie: +25, Meat Drop: +10, Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	stale salt plum	3	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	toothsome miniature and bean	2	awesome	Last Available: "2019-12"
+10417	miniature toothsome and bean	2	awesome	Last Available: "2019-12"
 10418	rosy-cheeked kelp-holly gun of the blizzard of temperance	0		Maximum HP Percent: +30, Cold Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2019-12"
 10419	fireproof scorching Yuleviathan necklace	0		Hot Damage: +25, Hot Resistance: +3, Single Equip, Last Available: "2019-12"
 10420	nasty peppermint spine of extreme caution	0		Monster Level: -25, Stench Damage: +5, Last Available: "2019-12"
@@ -10281,7 +10281,7 @@
 10422	ribald Crimbylow-rise jeans of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +10, Last Available: "2019-12"
 10423	skewed auspicious double-paned kelp-holly drape	0		Cold Resistance: +5, Item Drop: +10, Last Available: "2019-12"
 10424	cyan double-paned medical-grade rosy-cheeked Staff of the Peppermint Twist	0		Maximum HP Percent: +30, Cold Resistance: +5, Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-12"
-10425	stale jumbo tempura and bean	5	decent	Last Available: "2019-12"
+10425	jumbo stale tempura and bean	5	decent	Last Available: "2019-12"
 10426	mediocre wobbly salt plum sake	3	decent	Last Available: "2019-12"
 10427	extra-concentrated alkaline quadruple-vacuum-sealed pressurized potion of possessiveness	0		Effect: "Disdain of the War Snapper", Effect Duration: 20, Last Available: "2019-12"
 10428	chilled polymerized cyan almond	0		Effect: "Frozen Shoulders", Effect Duration: 59
@@ -10299,10 +10299,10 @@
 10442	brawny drippy truncheon	0		Muscle Percent: +20, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
-10445	decent diet drippy nugget	1	drippy	
+10445	diet decent drippy nugget	1	drippy	
 10446	hand-crafted glass of drippy wine	3	drippy	
 10447	decent drippy caviar	3	drippy	
-10448	normal miniature drippy plum(?)	2	drippy	
+10448	miniature normal drippy plum(?)	2	drippy	
 10449	weightlifter's drippy stake	0		Muscle: +15, Single Equip
 10450	blurry The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10332,7 +10332,7 @@
 10475	coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
-10478	fuchsia spinning plastic doll arms	0		
+10478	spinning fuchsia plastic doll arms	0		
 10479	plastic doll legs	0		
 10480	rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
@@ -10355,7 +10355,7 @@
 10498	pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	electrified nitrogenated spinning piranha pollen	0		Effect: "Transcendental Wind", Effect Duration: 57, Last Available: "2020-03"
-10501	maroon skewed plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
+10501	skewed maroon plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
 10502	sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	kettle bell of temperance	0		Sleaze Resistance: +5, Last Available: "2020-04"
 10504	glued-together crystal ball of extreme caution	0		Monster Level: -25, Last Available: "2020-04"
@@ -10396,7 +10396,7 @@
 10540	ghostly Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	lousy Ghiaccio Colada	3	decent	Last Available: "2020-05"
 10542	watered-down lousy Sourfinger	2	decent	Last Available: "2020-05"
-10543	artisanal weak Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
+10543	weak artisanal Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
 10544	lousy Steamboat	3	decent	Last Available: "2020-05"
 10545	watered-down lousy Buttery Boy	2	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10427,11 +10427,11 @@
 10571	shaking Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	magnetized liquefied marshroom	0		Effect: "Aries Rising", Effect Duration: 44
 10573	yellow bag of Iunion stones	0		Free Pull
-10574	ghostly pulsating teal Iunion Crown	0		Last Available: "2020-06"
+10574	teal ghostly pulsating Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	Vulcanized boiled salty drippy candy bar	0		Effect: "Spirit of Alph", Effect Duration: 63
 10577	quadruple-denatured writhing drippy candy bar	0		Effect: "Tomato Power", Effect Duration: 49
-10578	quantum oxidized pulsating upside-down gooey drippy candy bar	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 14
+10578	quantum oxidized upside-down pulsating gooey drippy candy bar	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 14
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	olive packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
@@ -10478,7 +10478,7 @@
 10622	chess set	0		Last Available: "2020-09"
 10623	shaking onyx king	0		Last Available: "2020-09"
 10624	cyan blinking onyx queen	0		Last Available: "2020-09"
-10625	olive squat onyx rook	0		Last Available: "2020-09"
+10625	squat olive onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
 10627	maroon onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	energetic deadly Herculean Cargo Cultist Shorts of the cougar	0		Moxie: +20, Experience (Muscle): +1, Weapon Damage: +5, Maximum MP Percent: +20, Last Available: "2020-09"
 10637	twirling complicated device	0		Last Available: "2020-09"
-10638	fortified tolerable blinking wobbly flask of moonshine	5	good	Last Available: "2020-09"
+10638	tolerable fortified blinking wobbly flask of moonshine	5	good	Last Available: "2020-09"
 10639	gravedigger's sea-worn candlestick of wisdom of temperance	0		Mysticality: +15, Spooky Damage: +10, Sleaze Resistance: +5, Last Available: "2020-09"
 10640	wobbly Universal Seasoning	0		
 10641	tarnished null-day exploit	0		Effect: "stats.enq", Effect Duration: 16, Last Available: "2025-12"
@@ -10516,7 +10516,7 @@
 10660	dangerous Crimbo smile	0		Weapon Damage: [+10*event(December)], Last Available: "2020-12"
 10661	red blinking Socratic SalesCo sample kit	0		Experience (Mysticality): [+1*event(December)], Last Available: "2020-12"
 10662	corrupted candy harmonica	0		Effect: "Hangdog", Effect Duration: 60, Last Available: "2020-12"
-10663	quantum triple-moist cyan bouncing sugar	0		Effect: "Warm Belly", Effect Duration: 41, Last Available: "2020-12"
+10663	quantum triple-moist bouncing cyan sugar	0		Effect: "Warm Belly", Effect Duration: 41, Last Available: "2020-12"
 10664	activated multi-level marzipan	0		Effect: "Concentrated Concentration", Effect Duration: 26, Last Available: "2020-12"
 10665	sizzling plastic Crimbo caroler	0		Hot Damage: +10, Last Available: "2020-12"
 10666	Jack Frost's plastic multi-level marketer	0		Cold Spell Damage: +50, Last Available: "2020-12"
@@ -10536,7 +10536,7 @@
 10680	skewed lion tamer's wine carrier	0		Experience (familiar): +2, Lasts Until Rollover, Last Available: "2020-12"
 10681	careful candy bucket	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2020-12"
 10682	pressed tarnished vacuum-sealed prescription teeth whitener	0		Effect: "Highland Sheen", Effect Duration: 11, Last Available: "2020-12"
-10683	frozen moist huge gray imported lemon lozenge	0		Effect: "Well Owl Be!", Effect Duration: 35, Last Available: "2020-12"
+10683	frozen moist gray huge imported lemon lozenge	0		Effect: "Well Owl Be!", Effect Duration: 35, Last Available: "2020-12"
 10684	electrified hermedisiac cologne	0		Effect: "Salsa Satanica", Effect Duration: 55, Last Available: "2020-12"
 10685	mirror government food shipment	0		Last Available: "2020-12"
 10686	upside-down government booze shipment	0		Last Available: "2020-12"
@@ -10568,18 +10568,18 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	blue pulsating The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	flavorless small and pepper (stale)	2	decent	Last Available: "2020-12"
+10715	small flavorless and pepper (stale)	2	decent	Last Available: "2020-12"
 10716	drinkable cranberry margarita (brackish)	3	good	Last Available: "2020-12"
 10717	blurry fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	ghostly nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	lousy maroon barrel-aged eggnog	3	decent	Last Available: "2020-12"
-10721	diet spoiled hand-crafted candy cane	1	crappy	Last Available: "2020-12"
-10722	fancy moldy drive-thru burger	3	crappy	Effect: "Sweet and Yellow", Effect Duration: 25, Last Available: "2020-12"
-10723	tolerable gray pulsating Boulevardier cocktail	3	good	Last Available: "2020-12"
+10721	spoiled diet hand-crafted candy cane	1	crappy	Last Available: "2020-12"
+10722	moldy fancy drive-thru burger	3	crappy	Effect: "Sweet and Yellow", Effect Duration: 25, Last Available: "2020-12"
+10723	tolerable pulsating gray Boulevardier cocktail	3	good	Last Available: "2020-12"
 10724	vacuum-sealed alkaline Hotwire&trade; brand candy rope	0		Effect: "Buff as a Baobab", Effect Duration: 61, Last Available: "2020-12"
 10725	rotten pulsating bowl full of jelly	4	crappy	Last Available: "2020-12"
-10726	artisanal extra-dry Eye and a Twist	5	EPIC	Last Available: "2020-12"
+10726	extra-dry artisanal Eye and a Twist	5	EPIC	Last Available: "2020-12"
 10727	wet liquefied pulsating Chubby and Plump bar	0		Effect: "Ruby-ous", Effect Duration: 65, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	purple packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10606,7 +10606,7 @@
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	ghostly plate	0		Familiar Weight: +5
 10752	pickled anodized wobbly short beer	0		Effect: "Chalk Outline", Effect Duration: 12, Last Available: "2021-05"
-10753	moist shaking maroon short stack of pancakes	0		Effect: "Fireproof Lips", Effect Duration: 46, Last Available: "2021-05"
+10753	moist maroon shaking short stack of pancakes	0		Effect: "Fireproof Lips", Effect Duration: 46, Last Available: "2021-05"
 10754	energized ionized short stick of butter	0		Effect: "Like a Fish to Walter", Effect Duration: 39, Last Available: "2021-05"
 10755	liquefied short glass of water	0		Effect: "Block-Rockin' Beet", Effect Duration: 42, Last Available: "2021-05"
 10756	pickled polymerized activated short	0		Effect: "Yet tea", Effect Duration: 51, Last Available: "2021-05"
@@ -10621,7 +10621,7 @@
 10765	mirror huge rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	narrow rocket	0		Last Available: "2021-07"
-10768	enchanted thick flavorless narrow fire crackers	5	decent	Effect: "Eyes for Miles", Effect Duration: 50, Last Available: "2021-07"
+10768	flavorless thick enchanted narrow fire crackers	5	decent	Effect: "Eyes for Miles", Effect Duration: 50, Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	greasy Jack Frost's Catherine Wheel	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10771	gray vibrating rocket boots of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10649,7 +10649,7 @@
 10793	literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
-10796	yellow blurry packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
+10796	blurry yellow packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	stanky Jack Frost's ruddy Fonzie's industrial fire extinguisher of Calamity Jane of mayonnaise	0		Experience (Moxie): +1, Maximum HP Percent: +40, Critical Hit Percent: +15, Cold Spell Damage: +50, Stench Spell Damage: +25, Sleaze Spell Damage: +50, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	fuchsia The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
@@ -10677,7 +10677,7 @@
 10821	decent fishcake	4	good	Last Available: "2021-12"
 10822	stale bone broth	3	decent	Last Available: "2021-12"
 10823	super-sized normal huge star pop	5	good	Last Available: "2021-12"
-10824	weak bad Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
+10824	bad weak Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
 10825	hand-crafted watered-down Doc's Smartifying Wine	2	EPIC	Last Available: "2021-12"
 10826	delicious huge Doc's Limbering Wine	3	awesome	Last Available: "2021-12"
 10827	mediocre Doc's Medical-Grade Wine	4	decent	Last Available: "2021-12"
@@ -10693,7 +10693,7 @@
 10837	anodized galvanized anti-pain cream	0		Effect: "A Taste of Rainbow", Effect Duration: 56, Last Available: "2021-12"
 10838	drinkable Doc's Special Reserve Wine	4	good	Last Available: "2021-12"
 10839	normal snack-sized blurry bread pie	2	good	Last Available: "2021-12"
-10840	artisanal extra-dry clear Russian	5	EPIC	Last Available: "2021-12"
+10840	extra-dry artisanal clear Russian	5	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	wobbly goo magnet	0		Last Available: "2021-12"
 10851	squat Herculean cozy scarf	0		Experience (Muscle): +1, Last Available: "2021-12"
-10852	tiny flavorless blue huge Crimbo cookie	1	decent	Last Available: "2023-06"
+10852	flavorless tiny blue huge Crimbo cookie	1	decent	Last Available: "2023-06"
 10853	magnetized liquefied purple fleshy putty	0		Effect: "Beastly Flavor", Effect Duration: 25, Last Available: "2021-12"
 10854	personal trainer's third ear	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	tumbling projectile chemistry set	0		Last Available: "2021-12"
 10860	spinning pulsating depleted Crimbonium football helmet of the ox	0		Muscle: +20, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	immense yummy &quot;caramel&quot;	6	awesome	Last Available: "2021-12"
+10862	yummy immense &quot;caramel&quot;	6	awesome	Last Available: "2021-12"
 10863	Rosewater's self-repairing earmuffs	0		Mysticality Percent: +30, Last Available: "2021-12"
 10864	chilly carnivorous potted plant	0		Cold Damage: +5, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	forbidden yule hatchet	0		Spell Damage Percent: +50, Last Available: "2021-12"
 10867	spinning potato alarm clock	0		Last Available: "2021-12"
-10868	diet normal lab-grown meat	1	good	Last Available: "2021-12"
+10868	normal diet lab-grown meat	1	good	Last Available: "2021-12"
 10869	Annie Oakley's fleece	0		Critical Hit Percent: +20, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	twirling cloning kit	0		Last Available: "2021-12"
@@ -10732,11 +10732,11 @@
 10876	decent meatball	4	good	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
-10879	pulsating blurry refurbished air fryer	0		Last Available: "2021-12"
+10879	blurry pulsating refurbished air fryer	0		Last Available: "2021-12"
 10880	mixed fried air	1		Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2021-12"
 10881	jittery 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	twisted huge gray pulsating astral energy drink	1		Effect: "Muscle Unbound", Effect Duration: 35
+10883	twisted huge pulsating gray astral energy drink	1		Effect: "Muscle Unbound", Effect Duration: 35
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	fuchsia scandalous strapping magnifying glass of the businessman	0		Muscle: +5, Sleaze Damage: +5, Meat Drop: +50, Last Available: "2022-12"
 10886	hand-crafted cyan void lager	4	EPIC	Last Available: "2022-12"
@@ -10764,22 +10764,22 @@
 10908	altered adjusted spare battery	0		Effect: "Hagg-ard", Effect Duration: 24, Last Available: "2022-05"
 10909	squat space blanket	0		Last Available: "2022-05"
 10910	dry single-use dust mask	0		Effect: "Stogied", Effect Duration: 60, Last Available: "2022-05"
-10911	moist huge olive gaffer's tape	0		Effect: "Well-Lubed", Effect Duration: 43, Last Available: "2022-05"
+10911	moist olive huge gaffer's tape	0		Effect: "Well-Lubed", Effect Duration: 43, Last Available: "2022-05"
 10912	adequate bouncing 20-lb can of rice and beans	4	good	Last Available: "2022-05"
 10913	skewed bar of freeze-dried water	1	awesome	Last Available: "2022-05"
-10914	fancy toothsome jumbo expired MRE	5	awesome	Effect: "Fishy", Effect Duration: 10, Last Available: "2022-05"
+10914	jumbo fancy toothsome expired MRE	5	awesome	Effect: "Fishy", Effect Duration: 10, Last Available: "2022-05"
 10915	normal cool mint precipice bar	3	good	Last Available: "2022-05"
 10916	tasty carrot cake precipice bar	3	awesome	Last Available: "2022-05"
 10917	huge The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	shaking packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	Sherlock's Van der Graaf June cleaver of dire peril	0		Weapon Damage: +20, Item Drop: +25, MP Regen Min: 5, MP Regen Max: 7, Attacks Can't Miss, Last Available: "2022-06"
-10921	weak drinkable shaking Dad's brandy	2	good	Last Available: "2022-06"
+10921	drinkable weak shaking Dad's brandy	2	good	Last Available: "2022-06"
 10922	wobbly Van der Graaf extremely unsafe teacher's pen	0		Weapon Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-06"
-10923	big rotten bouncing narrow fire-roasted lake trout	5	crappy	Last Available: "2022-06"
+10923	rotten big bouncing narrow fire-roasted lake trout	5	crappy	Last Available: "2022-06"
 10924	spoiled guilty sprout	3	crappy	Last Available: "2022-06"
 10925	shellacked dangerous mother's necklace	0		Weapon Damage: +10, Damage Reduction: 7, Last Available: "2022-06"
-10926	chilled tumbling skewed trampled ticket stub	0		Effect: "Disco Neuropathy", Effect Duration: 57, Last Available: "2022-06"
+10926	chilled skewed tumbling trampled ticket stub	0		Effect: "Disco Neuropathy", Effect Duration: 57, Last Available: "2022-06"
 10927	nitrogenated aerosolized narrow savings bond	0		Effect: "Tingly Wrists", Effect Duration: 16, Last Available: "2022-06"
 10928	wobbly designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
 10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
@@ -10824,15 +10824,15 @@
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	adequate ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
-10971	decent miniature purple Jarlsberg's vegetable soup	2	good	Last Available: "2022-11"
-10972	enchanted decent roasted vegetable of Jarlsberg	4	good	Effect: "Stenchtastic", Effect Duration: 40, Last Available: "2022-11"
+10971	miniature decent purple Jarlsberg's vegetable soup	2	good	Last Available: "2022-11"
+10972	decent enchanted roasted vegetable of Jarlsberg	4	good	Effect: "Stenchtastic", Effect Duration: 40, Last Available: "2022-11"
 10973	adequate St. Pete's sneaky smoothie	3	good	Last Available: "2022-11"
-10974	spoiled huge Pete's wiley whey bar	7	crappy	Last Available: "2022-11"
+10974	huge spoiled Pete's wiley whey bar	7	crappy	Last Available: "2022-11"
 10975	adequate Pete's rich ricotta	4	good	Last Available: "2022-11"
-10976	lousy triple-distilled Boris's beer	9	decent	Last Available: "2022-11"
+10976	triple-distilled lousy Boris's beer	9	decent	Last Available: "2022-11"
 10977	moldy blinking honey bun of Boris	4	crappy	Last Available: "2022-11"
-10978	tiny spoiled Boris's bread	1	crappy	Last Available: "2022-11"
-10979	ghostly blurry Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10978	spoiled tiny Boris's bread	1	crappy	Last Available: "2022-11"
+10979	blurry ghostly Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	green ghostly Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
@@ -10842,7 +10842,7 @@
 10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	stale half-sized lime green baked veggie ricotta casserole	2	decent	Last Available: "2022-11"
-10989	massive stale bouncing plain calzone	6	decent	Last Available: "2022-11"
+10989	stale massive bouncing plain calzone	6	decent	Last Available: "2022-11"
 10990	flavorless roasted vegetable focaccia	4	decent	Last Available: "2022-11"
 10991	small moldy wobbly Pizza of Legend	2	crappy	Last Available: "2022-11"
 10992	bite-sized bland blurry Calzone of Legend	1	decent	Last Available: "2022-11"
@@ -10858,7 +10858,7 @@
 11002	drink chit	0		
 11003	government per-diem	0		
 11004	yellow blinking cool prohie's hat	0		Moxie: +5
-11005	super-alkaline green narrow jittery imported taffy	0		Effect: "You Know Who to Call", Effect Duration: 38
+11005	super-alkaline jittery narrow green imported taffy	0		Effect: "You Know Who to Call", Effect Duration: 38
 11006	rosy-cheeked Charleston shoes of vim and vigor	0		Maximum HP Percent: 80, Single Equip
 11007	red booze bindle	0		
 11008	rare oboe of Calamity Jane of terror	0		Critical Hit Percent: +15, Spooky Spell Damage: +10
@@ -10923,17 +10923,17 @@
 11067	aged dregs of a Crimbo cocktail	4	awesome	
 11068	lost elf luggage	0		
 11069	olive Trainbot luggage hook	0		Single Equip
-11070	moldy miniature honey-drenched ham slice	2	crappy	
+11070	miniature moldy honey-drenched ham slice	2	crappy	
 11071	bad mostly-empty bottle of cookie wine	3	decent	
-11072	toothsome jumbo Crimbo food scraps	5	awesome	
+11072	jumbo toothsome Crimbo food scraps	5	awesome	
 11073	huge arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	upside-down Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	small normal steamed oyster	2	good	
+11078	normal small steamed oyster	2	good	
 11079	pulsating twirling really nice lump of coal	0		
-11080	maroon upside-down deactivated mini-Trainbot	0		Last Available: "2022-12"
+11080	upside-down maroon deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	mirror crystal Crimbo platter	0		
@@ -10951,21 +10951,21 @@
 11095	cyan knitted occult strapping grubby wool gloves of the scaredy-cat	0		Muscle: +5, Spell Damage Percent: +25, Monster Level: -15, Cold Resistance: +3, Single Equip
 11096	grubby wool beerwarmer	0		
 11097	bad maroon nice warm beer	3	decent	
-11098	cyan bouncing huge grubby woolball	0		
+11098	bouncing huge cyan grubby woolball	0		
 11099	blue Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	upside-down packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
 11102	compressed fruity pebble	1		Effect: "Big Meat Big Prizes", Effect Duration: 10, Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
-11105	skewed blurry bolder boulder	0		Last Available: "2023-01"
+11105	blurry skewed bolder boulder	0		Last Available: "2023-01"
 11106	blurry molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	adequate super-sized fancy pixel bread	5	good	Effect: "Total Protonic Reversal", Effect Duration: 10
-11113	weak hand-crafted pixel whiskey	2	EPIC	
+11112	adequate fancy super-sized pixel bread	5	good	Effect: "Total Protonic Reversal", Effect Duration: 10
+11113	hand-crafted weak pixel whiskey	2	EPIC	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	blinking S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10978,21 +10978,21 @@
 11123	electrified cold-filtered out-of-work circus flea	0		Effect: "The Solution", Effect Duration: 28, Last Available: "2023-02"
 11124	blurry extra-grubby grub	0		Last Available: "2023-02"
 11125	ionized concentrated wobbly fire ant pheromones	0		Effect: "Ogred and Oublietted", Effect Duration: 36, Last Available: "2023-02"
-11126	nitrogenated triple-polymerized spinning skewed flapper fly	0		Effect: "Savage Beast Inside", Effect Duration: 42, Last Available: "2023-02"
-11127	enchanted lousy shot of wasp venom	4	decent	Effect: "Full-Body Tan", Effect Duration: 50, Last Available: "2023-02"
+11126	nitrogenated triple-polymerized skewed spinning flapper fly	0		Effect: "Savage Beast Inside", Effect Duration: 42, Last Available: "2023-02"
+11127	lousy enchanted shot of wasp venom	4	decent	Effect: "Full-Body Tan", Effect Duration: 50, Last Available: "2023-02"
 11128	ionized filled mosquito	0		Effect: "Pyromania", Effect Duration: 41, Last Available: "2023-02"
 11129	ionized wobbly shim of shame shale	0		Effect: "Sourpuss", Effect Duration: 11, Last Available: "2023-02"
 11130	pressed pebble of proud pyrite	0		Effect: "Eye of the Lihc", Effect Duration: 21, Last Available: "2023-02"
 11131	tarnished pile of gritty sand	0		Effect: "Analog Drunk", Effect Duration: 36, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
-11133	frozen jittery shaking angry agate	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 22, Last Available: "2023-02"
+11133	frozen shaking jittery angry agate	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 22, Last Available: "2023-02"
 11134	boiled irradiated fuchsia lump of loyal latite	0		Effect: "Well-preserved", Effect Duration: 32, Last Available: "2023-02"
 11135	rotten shadow sausage	3	crappy	Last Available: "2023-03"
 11136	chaotic crafty shadow skin	0		Maximum MP: +10, Spell Critical Percent: +10, Last Available: "2023-03"
 11137	alkaline pulsating shadow flame	0		Effect: "Trufflin'", Effect Duration: 27, Last Available: "2023-03"
 11138	adequate shadow bread	4	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	watered-down drinkable shadow fluid	2	good	Last Available: "2023-03"
+11140	drinkable watered-down shadow fluid	2	good	Last Available: "2023-03"
 11141	bouncing shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11035,7 +11035,7 @@
 11180	purple squat clever crafty shadow monocle of Leguizamo	0		Maximum MP: 30, Monster Level: +20, Single Equip
 11181	twirling skewed shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	spoiled skewed gray shadow hot dog	3	crappy	
-11183	triple-distilled mediocre shadow martini	9	decent	
+11183	mediocre triple-distilled shadow martini	9	decent	
 11184	vaporized tumbling shadow pill	1		Effect: "Ack!  Barred!", Effect Duration: 45
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
@@ -11103,7 +11103,7 @@
 11248	squat replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	dog trainer's Newton's replica Jurassic Parka	0		Experience (Mysticality): +3, Experience (familiar): +1
 11250	gray replica grey gosling	0		
-11251	bouncing narrow replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	narrow bouncing replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	mirror replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	Temple Grandin's Van der Graaf sinister replica Cincho de Mayo of the empath	0		Spell Damage: +10, Familiar Weight: 12, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11114,7 +11114,7 @@
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
 11260	upside-down rock-hard occult pro skateboard	0		Spell Damage Percent: +25, Damage Reduction: 5, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	olive Mr. Accessaturday	0		Last Available: "2023-06"
-11262	pulsating fuchsia Meat Butler	0		Last Available: "2023-06"
+11262	fuchsia pulsating Meat Butler	0		Last Available: "2023-06"
 11263	jittery Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	squat Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
@@ -11128,7 +11128,7 @@
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
-11276	dry extra-activated fuchsia spinning scroll of protection from lycanthropes	0		Effect: "Pill Power", Effect Duration: 17, Last Available: "2023-06"
+11276	dry extra-activated spinning fuchsia scroll of protection from lycanthropes	0		Effect: "Pill Power", Effect Duration: 17, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	blinking Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
@@ -11153,13 +11153,13 @@
 11298	super-dry galvanized skewed haemolymphnode	0		Effect: "Helvella Health", Effect Duration: 15
 11299	pickled chitin powder paste	0		Effect: "Brain Freeze", Effect Duration: 53
 11300	sleeping patriotic eagle	0		Free Pull
-11301	squat upside-down shaking claw-held flag	0		Familiar Weight: +5
+11301	shaking upside-down squat claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
 11303	olive name change form	0		
 11304	replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	diet flavorless watermelon	1	decent	
+11307	flavorless diet watermelon	1	decent	
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
@@ -11176,30 +11176,30 @@
 11321	ribald groovy baywatch of the cougar	0		Moxie: +20, Moxie Percent: +10, Sleaze Damage: +10, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11324	jittery tumbling teal consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
+11324	jittery teal tumbling consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
-11327	blue pulsating residual chitin paste	0		Skill: "Chitinous Soul"
+11327	pulsating blue residual chitin paste	0		Skill: "Chitinous Soul"
 11328	modified ghostly teal concentrated cooking	1		
 11329	mixed meat	1		
 11330	modified sparkling orb	1		
 11331	compressed squat hardening cream	1		
 11332	twisted skewed pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
-11334	wobbly pulsating book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
+11334	pulsating wobbly book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
 11337	map to a candy-rich block	0		Last Available: "2023-10"
-11338	adjusted tumbling spinning red sampler size toothpaste	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 35
+11338	adjusted red spinning tumbling sampler size toothpaste	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 35
 11339	Franken Stein	0		Conditional Skill (Equipped): "Toast your enemy"
-11340	tumbling wobbly A Guide to Burning Leaves	0		Free Pull
+11340	wobbly tumbling A Guide to Burning Leaves	0		Free Pull
 11341	inflammable leaf	0		
 11342	rake	0		Item Drop: +1
 11343	sinister rake	0		Spell Damage: +10
 11344	autumnic bomb	0		
 11345	narrow forest canopy bed	0		
 11346	squat day shortener	0		
-11347	huge tumbling pulsating extra time	0		
+11347	tumbling pulsating huge extra time	0		
 11348	therapeutic strapping autumnal aegis	0		Muscle: +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 9
 11349	polymerized aerosolized bouncing distilled resin	0		Effect: "Spooky Hands", Effect Duration: 54
 11350	twirling super-heated leaf	0		
@@ -11218,7 +11218,7 @@
 11363	family-friendly Jeselnik's nasty coward's wizardly candy cane sword cane	0		Mysticality: +25, Monster Level: -20, Stench Damage: +5, Sleaze Damage: +25, Sleaze Resistance: +1, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	twirling wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
-11366	blue ghostly Elf Guard hotpants	0		Last Available: "2023-12"
+11366	ghostly blue Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	mirror automa-bot parts	0		
@@ -11230,7 +11230,7 @@
 11375	teal Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	adequate snack-sized pickled bread	2	good	Last Available: "2023-12"
+11378	snack-sized adequate pickled bread	2	good	Last Available: "2023-12"
 11379	stale small salted mutton	2	decent	Last Available: "2023-12"
 11380	decent corned beet	3	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	purple crated wardrobe-o-matic	0		
-11395	flavorless snack-sized bouncing peppermint donut	2	decent	
+11395	snack-sized flavorless bouncing peppermint donut	2	decent	
 11396	arcane researcher's Elf Guard insignia (private)	0		Experience Percent (Mysticality): +10, Last Available: "2023-12"
 11397	wobbly Fonzie's Crimbuccaneer fledges (mint)	0		Experience (Moxie): +1, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11263,7 +11263,7 @@
 11408	Elf Guard MPC	0		Last Available: "2023-12"
 11409	tumbling Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	Rosewater's Elf Guard commandeering gloves	0		Mysticality Percent: +30, Single Equip, Last Available: "2023-12"
-11411	magnetized pulsating purple Elf Guard eyedrops	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 33, Last Available: "2023-12"
+11411	magnetized purple pulsating Elf Guard eyedrops	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 33, Last Available: "2023-12"
 11412	Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	narrow Elf Guard honor present	0		Last Available: "2023-12"
 11414	red Temple Grandin's chaotic Elf Guard officer's sidearm	0		Spell Critical Percent: +10, Familiar Weight: +7, Last Available: "2023-12"
@@ -11275,7 +11275,7 @@
 11420	wobbly Jack Frost's grievous beefy Crimbuccaneer tavern swab	0		Muscle: +10, Weapon Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2023-12"
 11421	olive blurry Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	tolerable enchanted old-school pirate grog	3	good	Effect: "Norwhalloped", Effect Duration: 25, Last Available: "2023-12"
-11423	special normal immense wobbly grog nuts	8	good	Effect: "Super Structure", Effect Duration: 15, Last Available: "2023-12"
+11423	normal immense special wobbly grog nuts	8	good	Effect: "Super Structure", Effect Duration: 15, Last Available: "2023-12"
 11424	toasty hale sawed-off blunderbuss of the sewer	0		Maximum HP: +20, Hot Damage: +5, Stench Damage: +25, Last Available: "2023-12"
 11425	watered-down lousy officer's nog	2	decent	Last Available: "2023-12"
 11426	purple peppermint bomb	0		Last Available: "2023-12"
@@ -11295,7 +11295,7 @@
 11440	spinning censurious sinister Kelflar vest of the sweet-tooth	0		Spell Damage: +10, Sleaze Resistance: +3, Candy Drop: +100, Last Available: "2023-12"
 11441	quadruple-flattened non-pickled narrow whale cerebrospinal fluid	0		Effect: "Salsa Satanica", Effect Duration: 18, Last Available: "2023-12"
 11442	censurious deadly Crimbuccaneer runebone	0		Weapon Damage: +5, Sleaze Resistance: +3, Single Equip, Last Available: "2023-12"
-11443	upside-down squat cannonbomb	0		Last Available: "2023-12"
+11443	squat upside-down cannonbomb	0		Last Available: "2023-12"
 11444	purple wool brainy Elf Guard mouthknife	0		Mysticality: +5, Cold Resistance: +1, Last Available: "2023-12"
 11445	blue Usain Bolt's hardened Crimbuccaneer fledges (disintegrating)	0		Damage Reduction: 3, Initiative: +80, Single Equip, Last Available: "2023-12"
 11446	twirling frightening Elf Guard fuel tank	0		Spooky Damage: +5, Last Available: "2023-12"
@@ -11315,14 +11315,14 @@
 11460	stale squat gingerbread nylons	4	decent	Last Available: "2023-12"
 11461	stale rum-soaked fruitcake	4	decent	Last Available: "2023-12"
 11462	normal lime	4	good	Last Available: "2023-12"
-11463	moldy half-sized cyan gingerbread pirate	2	crappy	Last Available: "2023-12"
-11464	snack-sized normal fruit-stuffed rumcake	2	good	Last Available: "2023-12"
+11463	half-sized moldy cyan gingerbread pirate	2	crappy	Last Available: "2023-12"
+11464	normal snack-sized fruit-stuffed rumcake	2	good	Last Available: "2023-12"
 11465	tolerable blinking mulled wine	3	good	Last Available: "2023-12"
-11466	weak aged Swedish coffee	2	awesome	Last Available: "2023-12"
-11467	hand-crafted triple-distilled mirror canteen of eggnog	10	EPIC	Last Available: "2023-12"
+11466	aged weak Swedish coffee	2	awesome	Last Available: "2023-12"
+11467	triple-distilled hand-crafted mirror canteen of eggnog	10	EPIC	Last Available: "2023-12"
 11468	smooth hot wine	4	awesome	Last Available: "2023-12"
-11469	drinkable weak Jamaican coffee	2	good	Last Available: "2023-12"
-11470	mediocre practically non-alcoholic flask of egggrog	1	decent	Last Available: "2023-12"
+11469	weak drinkable Jamaican coffee	2	good	Last Available: "2023-12"
+11470	practically non-alcoholic mediocre flask of egggrog	1	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	green mirror Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	spinning pirate encryption key (complete)	0		Last Available: "2023-12"
@@ -11345,7 +11345,7 @@
 11490	blurry banded dangerous cool barnacle-encrusted sweater	0		Moxie: +5, Weapon Damage: +10, Damage Absorption: +100, Last Available: "2023-12"
 11491	hardy Fonzie's Crimbuccaneer nose ring of Flo-Jo	0		Experience (Moxie): +1, Maximum HP: +50, Initiative: +100, Last Available: "2023-12"
 11492	tumbling pet anchor	0		Last Available: "2023-12"
-11493	blurry blurry red Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
+11493	blurry red blurry Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
 11496	upside-down precision snowball	0		Last Available: "2023-12"
@@ -11362,7 +11362,7 @@
 11507	narrow lightning-fast hardened moss mitre	0		Damage Reduction: 3, Initiative: +40, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
 11508	up-at-dawn veiny moss mantle	0		Maximum HP: +10, Adventures: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	mansplainer's steel-toed moss marlinspike	0		Damage Reduction: 9, Monster Level: +15, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	mixed skewed skewed lime green moss mulch	1		Last Available: "2024-12"
+11510	mixed lime green skewed skewed moss mulch	1		Last Available: "2024-12"
 11511	pickled purple moss floss	0		Effect: "Nano-juiced", Effect Duration: 69
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	olive twirling adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11370,7 +11370,7 @@
 11515	adobe ayam	0		Last Available: "2024-12"
 11516	narrow adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	shaking adobe abaya	0		Last Available: "2024-12"
-11518	modified upside-down pulsating huge adobe assortment	1		Last Available: "2024-12"
+11518	modified pulsating huge upside-down adobe assortment	1		Last Available: "2024-12"
 11519	warmed twirling adobe brittle	0		Effect: "Gingerbread Robust", Effect Duration: 44
 11520	narrow flame-retardant greasy Socratic crepe paper phrygian cap	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10, Hot Resistance: +1, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	friendly supercool crepe paper parachute cape of the blizzard	0		Moxie Percent: +20, Familiar Weight: +3, Cold Spell Damage: +25, Last Available: "2025-12"
@@ -11414,7 +11414,7 @@
 11559	focused magnetron pistol	0		Single Equip
 11560	packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	fuchsia scorching rosy-cheeked Everfull Dart Holster	0		Maximum HP Percent: +30, Hot Damage: +25, Single Equip, Last Available: "2024-03"
-11562	ghostly wobbly research fragment	0		
+11562	wobbly ghostly research fragment	0		
 11563	blurry Thwaitgold wolf spider statuette	0		
 11564	pulsating boxed Apriling band helmet	0		Free Pull, Last Available: "2024-04"
 11565	miser's lard-coated MacGyver's cool brainy Apriling band helmet	0		Mysticality: +5, Moxie: +5, Maximum MP: +100, Sleaze Spell Damage: +25, Meat Drop: +10
@@ -11425,10 +11425,10 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	small rotten blinking yam	2	crappy	Last Available: "2024-05"
-11574	weak hand-crafted cyan yam martini	2	EPIC	Last Available: "2024-05"
-11575	artisanal irresponsibly strong sweet potato o' mine	10	EPIC	Last Available: "2024-05"
-11576	delicious special Southern yam	4	awesome	Effect: "Fishy Fortification", Effect Duration: 35, Last Available: "2024-05"
+11573	rotten small blinking yam	2	crappy	Last Available: "2024-05"
+11574	hand-crafted weak cyan yam martini	2	EPIC	Last Available: "2024-05"
+11575	irresponsibly strong artisanal sweet potato o' mine	10	EPIC	Last Available: "2024-05"
+11576	special delicious Southern yam	4	awesome	Effect: "Fishy Fortification", Effect Duration: 35, Last Available: "2024-05"
 11577	hand-crafted wobbly sweet potato punch	4	EPIC	Last Available: "2024-05"
 11578	tiny bland Mayam spinach	1	decent	Last Available: "2024-05"
 11579	flavorless yam and swiss	3	decent	Last Available: "2024-05"
@@ -11441,12 +11441,12 @@
 11586	reassuring gravedigger's yamtility belt of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2024-05"
 11587	snack-sized bland mirror yam slider	2	decent	Last Available: "2024-05"
 11588	flavorless yam mayo	4	decent	Last Available: "2024-05"
-11589	special decent bouncing yam burrito	3	good	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2024-05"
+11589	decent special bouncing yam burrito	3	good	Effect: "Heart of Green", Effect Duration: 10, Last Available: "2024-05"
 11590	blurry visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
-11592	blurry huge aviator goggles	0		
+11592	huge blurry aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	rotten massive mini kiwi	7	crappy	Last Available: "2024-06"
+11594	massive rotten mini kiwi	7	crappy	Last Available: "2024-06"
 11595	skewed dog trainer's rosy-cheeked mini kiwi bikini of the sewer	0		Maximum HP Percent: +30, Experience (familiar): +1, Stench Damage: +25, Last Available: "2024-06"
 11596	hand-crafted bouncing mini kiwitini	3	EPIC	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11470,10 +11470,10 @@
 11615	narrow lightning-fast messenger bag RNA of Flo-Jo	0		Item Drop: +5, Initiative: 140
 11616	spinning flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	super-sized moldy bacteria bisque	5	crappy	
+11618	moldy super-sized bacteria bisque	5	crappy	
 11619	delicious ciliophora chowder	3	awesome	
 11620	stale blurry cream of chloroplasts	3	decent	
-11621	narrow shaking yellow synaptic soup	0		
+11621	yellow narrow shaking synaptic soup	0		
 11622	blurry muscular soup	0		
 11623	squat flagellate soup	0		
 11624	elbow soup	0		
@@ -11504,7 +11504,7 @@
 11649	skewed tumbling MacGyver's bembershoot	0		Maximum MP: +100, Lasts Until Rollover, Last Available: "2024-09"
 11650	flavorless yellow wheel of camembert	4	decent	Last Available: "2024-09"
 11651	shaking auspicious knitted hardened hat of remembering	0		Damage Reduction: 3, Cold Resistance: +3, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-09"
-11652	maroon jittery throwin' ember	0		Last Available: "2024-09"
+11652	jittery maroon throwin' ember	0		Last Available: "2024-09"
 11653	tumbling blinking head of emberg lettuce	0		Last Available: "2024-09"
 11654	embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
@@ -11526,8 +11526,8 @@
 11671	narrow educational photo booth supply list of the early riser	0		Experience: +1, Adventures: +7, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	flavorless big whirled peas	5	decent	Last Available: "2024-11"
-11675	decent massive peaza	9	good	Last Available: "2024-11"
+11674	big flavorless whirled peas	5	decent	Last Available: "2024-11"
+11675	massive decent peaza	9	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	dehydrated drenchrome 2.0	1		Effect: "Kindly Resolve", Effect Duration: 30, Last Available: "2025-12"
 11678	pickled tumbling blurry Synapse Blaster	1		Last Available: "2025-12"
@@ -11553,7 +11553,7 @@
 11698	Jeselnik's governor's daughter's pearl hairpin	0		Sleaze Damage: +25, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	squat wizardly chili powder cutlass	0		Mysticality: +25, Last Available: "2024-12"
-11701	stale enchanted narrow Aztec tamale	3	decent	Effect: "PERL of Great Price", Effect Duration: 15, Last Available: "2024-12"
+11701	enchanted stale narrow Aztec tamale	3	decent	Effect: "PERL of Great Price", Effect Duration: 15, Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	shaking pet rock	0		Last Available: "2024-12"
 11704	flame-wreathed groggles	0		Hot Spell Damage: +10, Last Available: "2024-12"
@@ -11574,9 +11574,9 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	flavorless gigantic spinning coney haunch	10	decent	Last Available: "2024-12"
+11722	gigantic flavorless spinning coney haunch	10	decent	Last Available: "2024-12"
 11723	quantum extra-ionized dark chocolate egg	0		Effect: "Cat-Alyzed", Effect Duration: 21, Last Available: "2024-12"
-11724	watered-down hand-crafted moai toai	2	EPIC	
+11724	hand-crafted watered-down moai toai	2	EPIC	
 11725	Van der Graaf smooth moaiball of Tarzan	0		Moxie: +15, Experience (Muscle): +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12"
 11726	upside-down half-digested rat	0		Last Available: "2024-12"
 11727	corrupted quantum four-leaf potato sprout	0		Effect: "Space Cowboy", Effect Duration: 45, Last Available: "2024-12"
@@ -11593,7 +11593,7 @@
 11738	denatured irradiated chilled crystallized pumpkin spice	0		Effect: "Just the Brown Ones", Effect Duration: 17, Last Available: "2024-12"
 11739	small stale room scale bean casserole	2	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
-11741	narrow teal ragged wool yarn	0		Last Available: "2024-12"
+11741	teal narrow ragged wool yarn	0		Last Available: "2024-12"
 11742	bouncing prompt censurious sizzling perfect Christmas scarf	0		Hot Damage: [+10*event(December)], Sleaze Resistance: [+3*event(December)], Adventures: [+3*event(December)], Single Equip, Last Available: "2024-12"
 11743	teal stylish strapping snowman-enchanting tophat	0		Muscle: +5, Moxie: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	dry LIDAR candle	0		Effect: "Gummibrain", Effect Duration: 48, Last Available: "2024-12"
@@ -11601,13 +11601,13 @@
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	acceptable Easter grasshopper	3	good	Last Available: "2024-12"
 11748	tolerable Irish eggnog	4	good	Last Available: "2024-12"
-11749	enchanted tolerable canteen of jungle juice	4	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2024-12"
+11749	tolerable enchanted canteen of jungle juice	4	good	Effect: "Clyde's Blessing", Effect Duration: 35, Last Available: "2024-12"
 11750	hand-crafted turchucken	3	EPIC	Last Available: "2024-12"
-11751	fortified smooth mechanically-mulled cider	5	awesome	Last Available: "2024-12"
-11752	lousy extra-dry holiday trip around the world	5	decent	Last Available: "2024-12"
+11751	smooth fortified mechanically-mulled cider	5	awesome	Last Available: "2024-12"
+11752	extra-dry lousy holiday trip around the world	5	decent	Last Available: "2024-12"
 11753	rotten ghostly chocolate ostrich egg	4	crappy	Last Available: "2024-12"
 11754	moldy beef and cabbage	4	crappy	Last Available: "2024-12"
-11755	spoiled diet candy rations	1	crappy	Last Available: "2024-12"
+11755	diet spoiled candy rations	1	crappy	Last Available: "2024-12"
 11756	rotten massive double-candied yams	8	crappy	Last Available: "2024-12"
 11757	spoiled Christmas ham	3	crappy	Last Available: "2024-12"
 11758	snack-sized moldy holiday smorgasbord	2	crappy	Last Available: "2024-12"
@@ -11656,7 +11656,7 @@
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	pulsating cybervisor	0		Last Available: "2025-12"
-11804	blinking blue wobbly retro floppy disk	0		Last Available: "2025-12"
+11804	wobbly blue blinking retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
 11806	wobbly malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	wobbly CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
@@ -11671,7 +11671,7 @@
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
-11819	maroon narrow dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
+11819	narrow maroon dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	mirror dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	red SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
@@ -11680,8 +11680,8 @@
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
 11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
-11828	upside-down shaking geofencing shield	0		Last Available: "2025-12"
-11829	purple twirling virtual cybertattoo	0		Last Available: "2025-12"
+11828	shaking upside-down geofencing shield	0		Last Available: "2025-12"
+11829	twirling purple virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	olive ninja crampons	0		
 11832	ninja carabiner	0		
@@ -11691,14 +11691,14 @@
 11836	new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	pulsating toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
-11839	olive blurry scrape	0		
+11839	blurry olive scrape	0		
 11840	phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
 11844	chill gherkin	0		
 11845	pulsating childrens' stapler	0		
-11846	blue upside-down plover's egg	0		
+11846	upside-down blue plover's egg	0		
 11847	narrow flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	cyan heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11710,11 +11710,11 @@
 11855	rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
-11858	tumbling jittery glover liners	0		Pickpocket Chance: +10
+11858	jittery tumbling glover liners	0		Pickpocket Chance: +10
 11859	jittery mosquito speakers	0		Monster Level: +5
 11860	huge assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
-11862	pickled skewed blue scoop of pre-workout powder	1		Last Available: "2025-03"
+11862	pickled blue skewed scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	bad pint of Leprechaun Stout	3	decent	Last Available: "2025-03"
 11865	powdered phosphor traces	1		Effect: "Turkey-Friendly", Effect Duration: 5, Last Available: "2025-03"
@@ -11722,7 +11722,7 @@
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	unironic knife	0		
-11870	blue wobbly bar dart	0		Last Available: "2025-03"
+11870	wobbly blue bar dart	0		Last Available: "2025-03"
 11871	altered blurry leprechaun antidepressant pill	1		Effect: "Berry Critical", Effect Duration: 15, Last Available: "2025-03"
 11872	stale Heck ramen	3	decent	Last Available: "2025-03"
 11873	decent green burrito	4	good	Last Available: "2025-03"
@@ -11730,7 +11730,7 @@
 11875	moldy peach pie	4	crappy	Last Available: "2025-03"
 11876	immense spoiled fancy incredible mini-pizza	6	crappy	Effect: "Stopping to Smell the Flowers", Effect Duration: 15, Last Available: "2025-03"
 11877	tolerable skewed Divine sidecar	3	good	Last Available: "2025-03"
-11878	fancy bad tangarita sidecar	4	decent	Effect: "Chow Downed", Effect Duration: 20, Last Available: "2025-03"
+11878	bad fancy tangarita sidecar	4	decent	Effect: "Chow Downed", Effect Duration: 20, Last Available: "2025-03"
 11879	hand-crafted gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	spirit-forward drinkable vodka stratocaster sidecar	5	good	Last Available: "2025-03"
 11881	practically non-alcoholic bad prussian cathouse sidecar	1	decent	Last Available: "2025-03"
@@ -11740,7 +11740,7 @@
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	double-altered enhanced extra-irradiated wet paper weights	0		Effect: "Well-Lubed", Effect Duration: 25, Last Available: "2025-04"
-11888	high-proof bad Three Sheets to the Wind	6	decent	Last Available: "2025-04"
+11888	bad high-proof Three Sheets to the Wind	6	decent	Last Available: "2025-04"
 11889	bland pile of wet dates	4	decent	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11804,9 +11804,9 @@
 11949	experienced bully badge	0		Experience: +2, Lasts Until Rollover, Last Available: "2025-08"
 11950	lion tamer's time cop top hat	0		Experience (familiar): +2, Last Available: "2025-08"
 11951	ghostly Stock Certificate	0		Last Available: "2025-08"
-11952	diluted blue skewed mixed berry jelly	1		Last Available: "2025-08"
-11953	small bland special shaking toast with mixed berry jelly	2	decent	Effect: "Hypercubed", Effect Duration: 15, Last Available: "2025-08"
-11954	miniature moldy cup of sugar	2	crappy	Last Available: "2025-08"
+11952	diluted skewed blue mixed berry jelly	1		Last Available: "2025-08"
+11953	bland special small shaking toast with mixed berry jelly	2	decent	Effect: "Hypercubed", Effect Duration: 15, Last Available: "2025-08"
+11954	moldy miniature cup of sugar	2	crappy	Last Available: "2025-08"
 11955	rotten Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	baleful dance instructor's experienced the gun	0		Experience: +2, Experience Percent (Moxie): +10, Spell Damage: +25, Last Available: "2025-08"
@@ -11815,7 +11815,7 @@
 11961	sand penny	0		
 11962	dance instructor's undersea surveying goggles	0		Experience Percent (Moxie): +10, Lasts Until Rollover
 11963	delicious Ocean-Touched Rum	3	awesome	
-11964	mixed upside-down mirror water-logged pill	1		
+11964	mixed mirror upside-down water-logged pill	1		
 11965	decent kelp puck	4	good	
 11966	scroll of sea strength	0		
 11967	squat scroll of sea smarts	0		
@@ -11825,7 +11825,7 @@
 11971	enhanced twirling octopus ink bladder	0		Effect: "Sourpuss", Effect Duration: 43
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
-11974	blue ghostly packaged Monodent of the Sea	0		Free Pull
+11974	ghostly blue packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	wobbly frightening dentadent	0		Spooky Damage: +5
@@ -11843,9 +11843,9 @@
 12053	rotten prize turkey	3	crappy	
 12054	dried medicinal gruel	1		
 12055	bland full-sized pumpkin pie	3	decent	Last Available: "2025-11"
-12056	mediocre weak skewed vodka cranberry sauce	2	decent	Last Available: "2025-11"
+12056	weak mediocre skewed vodka cranberry sauce	2	decent	Last Available: "2025-11"
 12057	liquefied denatured yammed candy	0		Effect: "Heart of Pink", Effect Duration: 20, Last Available: "2025-11"
-12058	adequate small treasure chestnut	2	good	Last Available: "2025-12"
+12058	small adequate treasure chestnut	2	good	Last Available: "2025-12"
 12059	perfectly mixed blinking red mulled butter rum	3	EPIC	Last Available: "2025-12"
 12060	ionized cinnamon doubloon	0		Effect: "Arabian Knighthood", Effect Duration: 16, Last Available: "2025-12"
 12061	spinning deadly plastic left skeleton arm	0		Weapon Damage: +5, Last Available: "2025-12"
@@ -11861,8 +11861,8 @@
 12071	bouncing brawny angelbone mantle of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Last Available: "2026-12"
 12072	angelbone dice of the ox	0		Muscle: +20, Single Equip, Last Available: "2026-12"
 12073	deadly angelbone halo of the cougar	0		Moxie: +20, Weapon Damage: +5, Last Available: "2026-12"
-12074	boiled twirling squat angelbone fragments	1		Last Available: "2026-12"
-12075	activated narrow bouncing biblically accurate gumdrops	0		Effect: "Eye of the Seal", Effect Duration: 14
+12074	boiled squat twirling angelbone fragments	1		Last Available: "2026-12"
+12075	activated bouncing narrow biblically accurate gumdrops	0		Effect: "Eye of the Seal", Effect Duration: 14
 12076	devilbone helmet of wisdom of the early riser	0		Mysticality: +15, Adventures: +7, Last Available: "2026-12"
 12077	devilbone greaves of the storm	0		Maximum MP Percent: +40, Last Available: "2026-12"
 12078	zippy devilbone shinguards of the scaredy-cat	0		Monster Level: -15, Initiative: +20, Single Equip, Last Available: "2026-12"
@@ -11896,7 +11896,7 @@
 12138	pulsating ghostly auspicious grievous strapping fistbone	0		Muscle: +5, Weapon Damage Percent: +50, Item Drop: +10, Last Available: "2025-12"
 12139	auspicious chaotic Annie Oakley's burnt bone belt	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Item Drop: +10, Single Equip, Last Available: "2025-12"
 12140	skewed greedy scorched skull trophy	0		Meat Drop: +20, Last Available: "2025-12"
-12141	moldy huge wing bone	8	crappy	Last Available: "2025-12"
+12141	huge moldy wing bone	8	crappy	Last Available: "2025-12"
 12142	perfectly mixed weak skeleton venom	3	EPIC	Last Available: "2025-12"
 12143	boiled huge baked bone meal	1		Last Available: "2025-12"
 12144	careful plastic skeleton rib cage	0		Monster Level: -10, Last Available: "2025-12"
@@ -11910,7 +11910,7 @@
 12152	tumbling reassuring scorched skeleton shirt of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, Last Available: "2025-12"
 12153	blinking spinning savvy scorched skeleton pants of the boozehound	0		Mysticality Percent: +20, Booze Drop: +100, Last Available: "2025-12"
 12154	messenger parrot egg	0		Last Available: "2025-12"
-12155	purple narrow buryable chest	0		Last Available: "2025-12"
+12155	narrow purple buryable chest	0		Last Available: "2025-12"
 12156	blinking Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	spinning bouncing Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	jittery Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
@@ -11926,13 +11926,13 @@
 12168	Usain Bolt's auspicious vermiculite shield	0		Item Drop: +10, Initiative: +80, Damage Reduction: 9, Last Available: "2025-12"
 12169	zippy ship's lantern	0		Initiative: +20, Last Available: "2025-12"
 12170	upside-down Sinatra's heat-resistant harpoon pistol of the early riser	0		Experience (Moxie): +5, Adventures: +7, Last Available: "2025-12"
-12171	enchanted miniature bland traditional gingerloaf	2	decent	Effect: "Shawarma Initiative", Effect Duration: 25, Last Available: "2025-12"
+12171	enchanted bland miniature traditional gingerloaf	2	decent	Effect: "Shawarma Initiative", Effect Duration: 25, Last Available: "2025-12"
 12172	perfectly mixed watered-down blurry Scotch and eggnog	2	super ultra EPIC	Last Available: "2025-12"
 12173	extra-alkaline deionized counterskeleton elixir	0		Effect: "Inner Dog", Effect Duration: 11, Last Available: "2025-12"
-12174	bad irresponsibly strong blinking narrow &quot;salvaged&quot; wine	6	decent	Last Available: "2025-12"
+12174	bad irresponsibly strong narrow blinking &quot;salvaged&quot; wine	6	decent	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	skewed crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	huge spoiled wedge of prize-winning cheese	6	crappy	Last Available: "2025-12"
+12177	spoiled huge wedge of prize-winning cheese	6	crappy	Last Available: "2025-12"
 12178	wet corrupted gummi fingerbone	0		Effect: "Takin' It Greasy", Effect Duration: 66
 12179	mirror stanky nippy glimmering crystal	0		Cold Damage: +10, Stench Spell Damage: +25, Last Available: "2025-12"
 12180	jittery boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11964,7 +11964,7 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	moldy special small tumbling wobbly rat pizza	2	crappy	Effect: "Chalk Outline", Effect Duration: 15, Last Available: "2026-03"
+12209	small special moldy tumbling wobbly rat pizza	2	crappy	Effect: "Chalk Outline", Effect Duration: 15, Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	tumbling smooth hoverboard of Gandalf of incineration	0		Moxie: +15, Spell Critical Percent: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2026-03"
 12212	spinning rosewater-soaked baleful left shark fin of the boozehound	0		Spell Damage: +25, Stench Resistance: +3, Booze Drop: +100, Last Available: "2026-03"
@@ -11972,7 +11972,7 @@
 12214	powdered mirror gray candy bone	1		
 12215	narrow wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	adequate big discarded hot dog	5	good	Last Available: "2026-04"
+12217	big adequate discarded hot dog	5	good	Last Available: "2026-04"
 12218	lousy most of a beer	4	decent	Last Available: "2026-04"
 12222	tumbling pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
@@ -11981,19 +11981,19 @@
 12227	moldy immense huge alien salad	9	crappy	
 12228	stale ratbatatouille	3	decent	
 12229	adequate onigiri	4	good	
-12230	flavorless big mirror crudit&eacute;s	5	decent	
+12230	big flavorless mirror crudit&eacute;s	5	decent	
 12231	tasty sauced mutton	3	awesome	
 12232	spoiled wobbly hot honey ant	4	crappy	
 12233	toothsome half-sized cyan tomb aspic	2	awesome	
-12234	half-sized toothsome later tots	2	awesome	
-12235	yummy super-sized Frutti di Scatoletta	5	awesome	Last Available: "2026-05"
-12236	gigantic adequate Pesto alla Marziano	7	good	Last Available: "2026-05"
+12234	toothsome half-sized later tots	2	awesome	
+12235	super-sized yummy Frutti di Scatoletta	5	awesome	Last Available: "2026-05"
+12236	adequate gigantic Pesto alla Marziano	7	good	Last Available: "2026-05"
 12237	flavorless Arrattabbattabiata	3	decent	Last Available: "2026-05"
 12238	spoiled narrow Orzo di Riso	3	crappy	Last Available: "2026-05"
-12239	rotten huge Pasta Grimavera	6	crappy	Last Available: "2026-05"
-12240	flavorless small Linguini Ubriacapa	2	decent	Last Available: "2026-05"
-12241	yummy massive Formica e Pepe	8	awesome	Last Available: "2026-05"
-12242	normal fuchsia skewed Tubetto Gelatto	3	good	Last Available: "2026-05"
+12239	huge rotten Pasta Grimavera	6	crappy	Last Available: "2026-05"
+12240	small flavorless Linguini Ubriacapa	2	decent	Last Available: "2026-05"
+12241	massive yummy Formica e Pepe	8	awesome	Last Available: "2026-05"
+12242	normal skewed fuchsia Tubetto Gelatto	3	good	Last Available: "2026-05"
 12243	immense normal tumbling Gnocci Domani	6	good	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	squat scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12001,7 +12001,7 @@
 12248	mega helmet	0		
 12252	medical-grade Space Soldier Helmet of the ox	0		Muscle: +20, HP Regen Min: 7, HP Regen Max: 10
 12253	bland premium turkey leg	3	decent	
-12254	extra-dry tolerable styrofoam cup of mead	5	good	
+12254	tolerable extra-dry styrofoam cup of mead	5	good	
 12255	Tesla sword	0		MP Regen Min: 7, MP Regen Max: 10
 12256	lime green rosewater-soaked staff	0		Stench Resistance: +3
 12257	Temple Grandin's lute	0		Familiar Weight: +7
@@ -12011,7 +12011,7 @@
 12261	flash paperwad	0		
 12262	juggling ball	0		
 12263	Usain Bolt's cool tactical jester's cap	0		Moxie: +5, Initiative: +80, Combat Item Damage Percent: 50
-12264	twirling blurry single-use sword	0		
+12264	blurry twirling single-use sword	0		
 12265	dangerous flimsy plastic helmet	0		Weapon Damage: +10
 12266	flimsy plastic greaves of horror	0		Spooky Spell Damage: +25
 12267	wobbly banded flimsy plastic breastplate	0		Damage Absorption: +100
@@ -12024,22 +12024,22 @@
 12274	rotten bite-sized pulsating quince	1	crappy	Last Available: "2026-07"
 12275	green tumbling tumbling Interesting Coin	0		Last Available: "2026-08"
 12276	cyan Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	normal half-sized classic banana pie	2	good	Last Available: "2026-07"
+12277	half-sized normal classic banana pie	2	good	Last Available: "2026-07"
 12278	denatured galvanized essential banana decoction	0		Effect: "Rage of the Reindeer", Effect Duration: 61, Last Available: "2026-07"
 12279	quantum jittery banana quintessence	0		Effect: "Ass Over Teakettle", Effect Duration: 47, Last Available: "2026-07"
-12280	acceptable high-proof Aesop Daiquiri	6	good	Last Available: "2026-07"
+12280	high-proof acceptable Aesop Daiquiri	6	good	Last Available: "2026-07"
 12281	delicious Monkey Congress	3	awesome	Last Available: "2026-07"
 12282	decent huge watermelon pie	4	good	Last Available: "2026-07"
-12283	chilled energized non-dry bouncing jittery concentrated watermelon juice	0		Effect: "Human-Undead Hybrid", Effect Duration: 65, Last Available: "2026-07"
+12283	chilled energized non-dry jittery bouncing concentrated watermelon juice	0		Effect: "Human-Undead Hybrid", Effect Duration: 65, Last Available: "2026-07"
 12284	cold-filtered Aqua Citrulanatae	0		Effect: "Memory of Strength", Effect Duration: 21, Last Available: "2026-07"
-12285	irresponsibly strong lousy Melonegroni	8	decent	Last Available: "2026-07"
+12285	lousy irresponsibly strong Melonegroni	8	decent	Last Available: "2026-07"
 12286	artisanal Melonade Spritz	3	EPIC	Last Available: "2026-07"
-12287	flavorless special quince pie	3	decent	Effect: "Burning Hands", Effect Duration: 25, Last Available: "2026-07"
+12287	special flavorless quince pie	3	decent	Effect: "Burning Hands", Effect Duration: 25, Last Available: "2026-07"
 12288	tarnished tarnished squat quince quaff	0		Effect: "Far Out", Effect Duration: 62, Last Available: "2026-07"
 12289	quadruple-anodized dry squat Quickquince	0		Effect: "Creepin' Up on You", Effect Duration: 29, Last Available: "2026-07"
-12290	delicious irresponsibly strong Quiskey Sour	9	awesome	Last Available: "2026-07"
-12291	watered-down tolerable fancy Quincea&ntilde;era Cooler	2	good	Effect: "Human-Human Hybrid", Effect Duration: 40, Last Available: "2026-07"
-12292	bad watered-down Roth IPA	2	decent	Last Available: "2026-08"
+12290	irresponsibly strong delicious Quiskey Sour	9	awesome	Last Available: "2026-07"
+12291	tolerable fancy watered-down Quincea&ntilde;era Cooler	2	good	Effect: "Human-Human Hybrid", Effect Duration: 40, Last Available: "2026-07"
+12292	watered-down bad Roth IPA	2	decent	Last Available: "2026-08"
 12293	double-paned curative underdraft protection	0		Cold Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	stale soybean futures	4	decent	Last Available: "2026-08"
@@ -12048,17 +12048,17 @@
 12298	blinking lion tamer's Da Vinci's financial instrument	0		Experience (Mysticality): +5, Experience (familiar): +2, Last Available: "2026-08"
 12299	Sherlock's sinister hedge fund clippers	0		Spell Damage: +10, Item Drop: +25, Last Available: "2026-08"
 12300	experienced selling shorts	0		Experience: +2, Last Available: "2026-08"
-12301	spinning narrow bear tattoo	0		Last Available: "2026-08"
+12301	narrow spinning bear tattoo	0		Last Available: "2026-08"
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	401k ring of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Last Available: "2026-08"
-12304	upside-down narrow balance sheet	0		Last Available: "2026-08"
+12304	narrow upside-down balance sheet	0		Last Available: "2026-08"
 12305	chilled electrified invisible hand	0		Effect: "The Living Hitpoints", Effect Duration: 23, Last Available: "2026-08"
 12306	non-polarized magnetized jittery circle of overdraft protection scroll	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 18, Last Available: "2026-08"
 12307	improved skewed mint	0		Effect: "Stick Emporium Membership", Effect Duration: 22, Last Available: "2026-08"
 12308	cyan savings bondo	0		Last Available: "2026-08"
 12309	blurry homeowner's loam	0		Last Available: "2026-08"
 12310	boiled cyan toxic asset	1		Effect: "Blessing of the Pervy Noodles", Effect Duration: 25, Last Available: "2026-08"
-12311	powdered blue skewed skewed intangible asset	1		Effect: "Bastard!", Effect Duration: 45, Last Available: "2026-08"
+12311	powdered skewed skewed blue intangible asset	1		Effect: "Bastard!", Effect Duration: 45, Last Available: "2026-08"
 12312	distilled teal liquid asset	1		Effect: "Super Structure", Effect Duration: 50, Last Available: "2026-08"
 12313	green wobbly gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Pastamancer_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wombat_cafe_booze.txt
@@ -1,25 +1,25 @@
--1	watered-down hand-crafted Petite Porter	2	EPIC	
--2	drinkable watered-down Scrawny Stout	2	good	
+-1	hand-crafted watered-down Petite Porter	2	EPIC	
+-2	watered-down drinkable Scrawny Stout	2	good	
 -3	aged Infinitesimal IPA	3	awesome	
 -4	lousy eggnogtini	3	decent	
 -5	enchanted mediocre blue candycaine	3	decent	
 -6	lousy braincracker sweet	3	decent	
 -16	hand-crafted fermented honey	4	EPIC	
 -17	artisanal moons-shine	4	EPIC	
--18	lousy bouncing mirror gin	3	decent	
--19	mediocre watered-down teal ecto-nog	2	decent	
+-18	lousy mirror bouncing gin	3	decent	
+-19	watered-down mediocre teal ecto-nog	2	decent	
 -20	bad pulsating hot toady	3	decent	
 -21	tolerable tumbling hot choculate	3	good	
--49	weak hand-crafted Cyder	2	EPIC	
+-49	hand-crafted weak Cyder	2	EPIC	
 -50	lousy Oil Nog	3	decent	
--51	bad weak olive Hi-Octane Peppermint Jet Fuel	2	decent	
--58	perfectly mixed practically non-alcoholic special Grimacider	1	EPIC	
+-51	weak bad olive Hi-Octane Peppermint Jet Fuel	2	decent	
+-58	perfectly mixed special practically non-alcoholic Grimacider	1	EPIC	
 -59	delicious triple-distilled Isotope Nog	8	awesome	
 -60	acceptable pulsating Mutagin 'n' Tonic	3	good	
 -70	perfectly mixed Gin and Herring	4	EPIC	
 -71	lousy Black and Tan and Red All Over	3	decent	
--72	extra-dry drinkable Antarctic Ice Tea	5	good	
--76	acceptable watered-down CRIMBCO Ribbon Candy Schnapps	2	good	
+-72	drinkable extra-dry Antarctic Ice Tea	5	good	
+-76	watered-down acceptable CRIMBCO Ribbon Candy Schnapps	2	good	
 -77	delicious CRIMBCO Egg Substitute Nog Substitute	4	awesome	
 -78	tolerable weak ghostly CRIMBCO Extreme Braincracker Sour	2	good	
 -82	acceptable weak Horseradish-infused Vodka	2	good	
@@ -27,7 +27,7 @@
 -84	drinkable watered-down Desert Island Iced Tea	2	good	
 -88	boozy mediocre Crimbo Saketini	5	decent	
 -89	perfectly mixed strong Crimboku Drop	5	EPIC	
--90	delicious practically non-alcoholic teal jittery Flaming Crimbo Log	1	awesome	
--107	artisanal practically non-alcoholic Fortified Eggnog Slurry	1	EPIC	
+-90	practically non-alcoholic delicious jittery teal Flaming Crimbo Log	1	awesome	
+-107	practically non-alcoholic artisanal Fortified Eggnog Slurry	1	EPIC	
 -108	watered-down aged Hot Buttered Rum	2	awesome	
 -109	delicious Spicy Hot Chocolate	3	awesome	

--- a/data/TCRS/TCRS_Pastamancer_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Pastamancer_Wombat_cafe_food.txt
@@ -1,45 +1,45 @@
--1	miniature yummy Peche a la Frog	2	awesome	
+-1	yummy miniature Peche a la Frog	2	awesome	
 -2	miniature stale As Jus Gezund Heit	2	decent	
 -3	normal Bouillabaise Coucher Avec Moi	3	good	
 -7	adequate super-sized gumdrop chow mein	5	good	
 -8	moldy candy cane pizza	3	crappy	
 -9	super-sized decent gingerbread stir-fry	5	good	
--10	bite-sized bland twigs and gravel	1	decent	
--11	bland mirror tumbling shoots and leaves	4	decent	
+-10	bland bite-sized twigs and gravel	1	decent	
+-11	bland tumbling mirror shoots and leaves	4	decent	
 -12	normal fuchsia bowl of unidentifiable goo	4	good	
--13	massive adequate ghostly gingerbread massacre	10	good	
--14	decent massive It Came From Beyond Dessert	6	good	
+-13	adequate massive ghostly gingerbread massacre	10	good	
+-14	massive decent It Came From Beyond Dessert	6	good	
 -15	flavorless mirror vampire cake	3	decent	
 -52	moldy pulsating spinning Soylent Red and Green	4	crappy	
--53	bite-sized normal pulsating Disc-Shaped Nutrition Unit	1	good	
--54	yummy half-sized yellow Gingerborg Hive	2	awesome	
+-53	normal bite-sized pulsating Disc-Shaped Nutrition Unit	1	good	
+-54	half-sized yummy yellow Gingerborg Hive	2	awesome	
 -61	adequate small Candy Cane Surprise	2	good	
 -62	moldy squat Grimdrop Chow Mein	3	crappy	
 -63	decent Grimgerbread House	4	good	
 -67	stale Caviar Carbonara	3	decent	
 -68	bland Halibut Alfredo	3	decent	
 -69	big decent wobbly Red Herring Velvet Cake	5	good	
--73	tiny decent cyan CRIMBCO Reconstituted Gruel	1	good	
--74	diet spoiled New and Improved CRIMBCO Reconstituted Gruel	1	crappy	
+-73	decent tiny cyan CRIMBCO Reconstituted Gruel	1	good	
+-74	spoiled diet New and Improved CRIMBCO Reconstituted Gruel	1	crappy	
 -75	bland fancy CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
 -79	small bland mirror Brussels Sprout Stir-Fry	2	decent	
--80	fancy huge stale huge Carrot, Cabbage, and Kale Pizza	7	decent	
+-80	huge stale fancy huge Carrot, Cabbage, and Kale Pizza	7	decent	
 -81	snack-sized stale Turnip and Rutabaga Pie	2	decent	
--85	immense spoiled Rainbow Spider Fun Roll	7	crappy	
--86	snack-sized adequate Vegas Volcano Lava Roll	2	good	
+-85	spoiled immense Rainbow Spider Fun Roll	7	crappy	
+-86	adequate snack-sized Vegas Volcano Lava Roll	2	good	
 -87	super-sized spoiled Crazy Dragon Shogun Buddha Roll	5	crappy	
 -92	adequate basic hot dog	3	good	
 -93	moldy savage macho dog	3	crappy	
--94	miniature spoiled one with everything	2	crappy	
+-94	spoiled miniature one with everything	2	crappy	
 -95	normal sly dog	3	good	
 -96	spoiled squat devil dog	4	crappy	
--97	moldy enchanted purple chilly dog	4	crappy	
+-97	enchanted moldy purple chilly dog	4	crappy	
 -98	delicious ghost dog	4	awesome	
--99	adequate mirror pulsating junkyard dog	3	good	
+-99	adequate pulsating mirror junkyard dog	3	good	
 -100	yummy wet dog	3	awesome	
 -101	rotten half-sized sleeping dog	2	crappy	
 -102	spoiled immense optimal dog	8	crappy	
--103	yummy snack-sized video games hot dog	2	awesome	
+-103	snack-sized yummy video games hot dog	2	awesome	
 -104	tasty huge Peppermint Nutrition Block	3	awesome	
 -105	special toothsome Gingerbread Nutrition Block	3	awesome	
--106	gigantic normal Cinnamon Nutrition Block	8	good	
+-106	normal gigantic Cinnamon Nutrition Block	8	good	

--- a/data/TCRS/TCRS_Sauceror_Blender.txt
+++ b/data/TCRS/TCRS_Sauceror_Blender.txt
@@ -13,11 +13,11 @@
 14	dried cyan moxie weed	1		
 15	altered strongness elixir	1		
 16	dried twirling mirror magicalness-in-a-can	1		Effect: "Super Structure", Effect Duration: 25
-17	small tasty upside-down noodles	2	awesome	
+17	tasty small upside-down noodles	2	awesome	
 18	tortoise's blessing	0		
 19	upside-down upside-down blue asparagus knife of chilblains	0		Cold Damage: +25
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
-21	ghostly yellow sweet ninja sword	0		
+21	yellow ghostly sweet ninja sword	0		
 22	bouncing studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	huge chewing gum on a string	0		
 24	ghostly ten-leaf clover	0		
@@ -43,9 +43,9 @@
 44	worthless gewgaw	0		
 45	purple worthless knick-knack	0		
 46	blue narrow figurine	0		
-47	flavorless half-sized hot buttered roll	2	decent	
+47	half-sized flavorless hot buttered roll	2	decent	
 48	huge heart of rock and roll	0		
-49	thick spoiled bowl of cottage cheese	5	crappy	
+49	spoiled thick bowl of cottage cheese	5	crappy	
 50	flame-wreathed Rock and Roll Legend	0		Hot Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10
 51	sinister Knob Goblin Uberpants	0		Spell Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	cyan banjo strings	0		
@@ -70,7 +70,7 @@
 71	curative stakes	0		HP Regen Min: 3, HP Regen Max: 5
 72	supercool barskin hat	0		Moxie Percent: +20, Familiar Effect: "atk, 1xVolley, cap 13"
 73	barskin tent	0		
-74	shaking shaking yellow Temple map	0		
+74	shaking yellow shaking Temple map	0		
 75	sapling	0		
 76	Spooky-Gro fertilizer	0		
 77	MacGyver's stick	0		Maximum MP: +100
@@ -158,25 +158,25 @@
 159	wad of dough	0		
 160	pie crust	0		
 161	decent ghuol egg	3	good	
-162	stale bite-sized ghuol egg quiche	1	decent	
+162	bite-sized stale ghuol egg quiche	1	decent	
 163	upside-down Jim Carey's skeleton bone	0		Monster Level: +25
 164	shaking smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	miniature flavorless ghuol-ear kabob	2	decent	
+167	flavorless miniature ghuol-ear kabob	2	decent	
 168	rosy-cheeked bone rattle	0		Maximum HP Percent: +30
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	shaking lihc eye	0		
 171	decent gigantic squat lihc eye pie	10	good	
 172	shaking gnoll lips	0		
 173	wobbly taco shell	0		
-174	maroon jittery Gnollish casserole dish	0		
-175	decent massive enchanted uncooked chorizo	10	good	Effect: "Shawarma Initiative", Effect Duration: 50
+174	jittery maroon Gnollish casserole dish	0		
+175	enchanted massive decent uncooked chorizo	10	good	Effect: "Shawarma Initiative", Effect Duration: 50
 176	bouncing disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
 179	rotten chorizo taco	4	crappy	
-180	practically non-alcoholic acceptable gray ice-cold fotie	1	good	
+180	acceptable practically non-alcoholic gray ice-cold fotie	1	good	
 181	baseball	0		
 182	yellow batgut	0		
 183	bat wing	0		
@@ -195,11 +195,11 @@
 197	rat whisker	0		
 198	bouncing rat appendix	0		
 199	blurry upside-down yellow Temple Grandin's ring	0		Familiar Weight: +7
-200	big normal cyan rat appendix kabob	5	good	
+200	normal big cyan rat appendix kabob	5	good	
 201	low-calorie normal bat wing kabob	1	good	
 202	snack-sized flavorless carob chunks	2	decent	
 203	herbs	0		
-204	normal massive carob chunk cookies	6	good	
+204	massive normal carob chunk cookies	6	good	
 205	gray secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	awesome	
@@ -215,7 +215,7 @@
 217	stale herb brownies	3	decent	
 218	hemp string	0		
 219	necklace chain	0		
-220	olive spinning gnoll teeth	0		
+220	spinning olive gnoll teeth	0		
 221	Jack Frost's gnoll-tooth necklace	0		Cold Spell Damage: +50
 222	phat turquoise bead	0		
 223	banded phat turquoise bracelet	0		Damage Absorption: +100
@@ -237,20 +237,20 @@
 239	rock-hard beefy Orcish baseball cap	0		Muscle: +10, Damage Reduction: 5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	blurry scorching Orcish cargo shorts of the brazier	0		Hot Damage: +25, Hot Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	greasy Orcish frat-paddle	0		Sleaze Spell Damage: +10
-242	bland half-sized	2	decent	
+242	half-sized bland	2	decent	
 243	moldy grapefruit	3	crappy	
 244	decent shaking grapes	4	good	
-245	half-sized spoiled teal olive	2	crappy	
+245	spoiled half-sized teal olive	2	crappy	
 246	flavorless tomato	3	decent	
 247	fermenting powder	0		
-248	distilled bad salty dog	5	decent	
+248	bad distilled salty dog	5	decent	
 249	practically non-alcoholic tolerable bloody mary	1	good	
-250	practically non-alcoholic lousy screwdriver	1	decent	
+250	lousy practically non-alcoholic screwdriver	1	decent	
 251	mediocre martini	3	decent	
 252	weak perfectly mixed bloody beer	2	EPIC	
 253	mediocre enchanted shot of schnapps	4	decent	Effect: "Piratey Flavor", Effect Duration: 20
 254	hand-crafted shot of grapefruit schnapps	4	EPIC	
-255	distilled fancy drinkable pulsating fine wine	5	good	Effect: "Compensatory Cruelness", Effect Duration: 5
+255	fancy drinkable distilled pulsating fine wine	5	good	Effect: "Compensatory Cruelness", Effect Duration: 5
 256	perfectly mixed shot of tomato schnapps	3	EPIC	
 257	lousy extra-spicy bloody mary	3	decent	
 258	dense meat stack	0		
@@ -258,10 +258,10 @@
 260	moldy miniature mirror White Citadel fries	2	crappy	
 261	stale White Citadel burger	3	decent	
 262	rotten half-sized piece of wedding cake	2	crappy	
-263	low-calorie stale chocolate chips	1	decent	
+263	stale low-calorie chocolate chips	1	decent	
 264	adequate chocolate chip cookies	4	good	
 265	rosewater-soaked satin pants	0		Stench Resistance: +3, Familiar Effect: "atk, 2xPotato, cap 10"
-266	hand-crafted weak fancy red lightning	2	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 5
+266	hand-crafted fancy weak red lightning	2	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 5
 267	blue greedy mullet wig	0		Meat Drop: +20, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	healthy meat cowboy hat	0		Maximum HP Percent: +20, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	energetic sword	0		Maximum MP Percent: +20
@@ -273,7 +273,7 @@
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
 277	dehydrated bouncing extra-strength strongness elixir	1		
-278	mixed huge upside-down jug-o-magicalness	1		Effect: "The Magic of Sharing", Effect Duration: 35
+278	mixed upside-down huge jug-o-magicalness	1		Effect: "The Magic of Sharing", Effect Duration: 35
 279	pickled suntan lotion of moxiousness	1		
 280	bouncing Pick-O-Matic lockpicks	0		
 281	beefcake's gasmask	0		Muscle: +25, Familiar Effect: "1xBarrr, cap 12"
@@ -315,20 +315,20 @@
 317	spoiled thick pulsating bean burrito	5	crappy	
 318	diet bland bean burrito	1	decent	
 319	super-sized normal olive insanely bean burrito	5	good	
-320	flavorless jumbo bat haggis	5	decent	
+320	jumbo flavorless bat haggis	5	decent	
 321	flavorless twirling skewed menudo	3	decent	
 322	moldy goat cheese	3	crappy	
 323	decent squat plain pizza	3	good	
-324	huge rotten sausage pizza	7	crappy	
+324	rotten huge sausage pizza	7	crappy	
 325	spoiled goat cheese pizza	3	crappy	
-326	flavorless fancy jumbo squat skewed mushroom pizza	5	decent	Effect: "Whippin' It Good", Effect Duration: 20
+326	fancy jumbo flavorless squat skewed mushroom pizza	5	decent	Effect: "Whippin' It Good", Effect Duration: 20
 327	upside-down goat	0		
 328	aged bottle of whiskey	3	awesome	
 329	upside-down resourceful goat beard	0		Maximum MP: +50, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	EPIC	
 331	mediocre Canadian	3	decent	
-332	yummy huge lemon	6	awesome	
-333	snack-sized stale lime	2	decent	
+332	huge yummy lemon	6	awesome	
+333	stale snack-sized lime	2	decent	
 334	upside-down sabre teeth of vim and vigor	0		Maximum HP Percent: +50
 335	sabre-toothed lime cub	0		
 336	flame-retardant consolation ribbon	0		Hot Resistance: +1
@@ -353,19 +353,19 @@
 355	auspicious eXtreme scarf	0		Item Drop: +10, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	family-friendly snowboarder pants	0		Sleaze Resistance: +1, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	adequate low-calorie squat gr8ps	1	good	
+358	low-calorie adequate squat gr8ps	1	good	
 359	flavorless jumbo t8r tots	5	decent	
 360	upside-down slick miner's helmet	0		Moxie: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	knitted miner's pants	0		Cold Resistance: +3, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	7-Foot Dwarven mattock of the overflowing toilet	0		Stench Spell Damage: +50
 363	linoleum ore	0		
-364	blurry narrow asbestos ore	0		
+364	narrow blurry asbestos ore	0		
 365	chrome ore	0		
 366	blue linoleum sword hilt	0		
 367	pulsating linoleum stick	0		
 368	linoleum crossbow string	0		
 369	gray asbestos sword hilt	0		
-370	fuchsia bouncing asbestos stick	0		
+370	bouncing fuchsia asbestos stick	0		
 371	jittery asbestos crossbow string	0		
 372	chrome sword hilt	0		
 373	chrome stick	0		
@@ -407,15 +407,15 @@
 409	vial of patchouli oil	0		
 410	zippy sk8board	0		Initiative: +20
 411	Jolly Roger charrrm	0		
-412	narrow blinking barrrnacle	0		
+412	blinking narrow barrrnacle	0		
 413	healthy Jolly Roger charrrm bracelet	0		Maximum HP Percent: +20
 414	wizardly crowbarrr	0		Mysticality: +25
 415	jittery upside-down inspector's leotarrrd	0		Item Drop: +15, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	mansplainer's safarrri hat	0		Monster Level: +15, Familiar Effect: "2xVolley, cap 22"
 417	concentrated henna tattoo	0		Effect: "Hood Ridin'", Effect Duration: 28
-418	alkaline pulsating purple Ferrigno's Elixir of Power	0		Effect: "Healthy Green Glow", Effect Duration: 40
+418	alkaline purple pulsating Ferrigno's Elixir of Power	0		Effect: "Healthy Green Glow", Effect Duration: 40
 419	activated pickled serum of sarcasm	0		Effect: "Gingerbread Robust", Effect Duration: 12
-420	flattened blinking jittery tomato juice of powerful power	0		Effect: "Cute Vision", Effect Duration: 63
+420	flattened jittery blinking tomato juice of powerful power	0		Effect: "Cute Vision", Effect Duration: 63
 421	quantum quadruple-concentrated polymerized philter of phorce	0		Effect: "Cold as Ice", Effect Duration: 69
 422	warmed potion of potency	0		Effect: "The Style... of the Future", Effect Duration: 12
 423	improved modified cordial of concentration	0		Effect: "Shredding, Sweating", Effect Duration: 23
@@ -438,18 +438,18 @@
 440	bartender-in-the-box	0		
 441	upside-down chef-skull-in-the-box	0		
 442	maroon bartender-skull-in-the-box	0		
-443	twirling ghostly beer lens	0		
+443	ghostly twirling beer lens	0		
 444	beer goggles	0		
 445	dangerous box-in-the-box	0		Weapon Damage: +10
 446	nothing-in-the-box-in-the-box	0		
 447	twirling stylish box-in-the-box-in-the-box	0		Moxie: +25
 448	foolscap fool's cap of the bloodbag of the cheetah	0		Maximum HP: +100, Initiative: +60, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	clown nose of the cougar	0		Moxie: +20, Clowniness: 25
-450	blurry blinking pretentious paintbrush	0		
+450	blinking blurry pretentious paintbrush	0		
 451	pretentious palette	0		
 452	disease	0		
 453	sober pill	0		
-454	jittery wobbly lime green screwdriver	0		
+454	lime green jittery wobbly screwdriver	0		
 455	bland upside-down jumbo olive	3	decent	
 456	drinkable spinning dry martini	3	good	
 457	pulsating brainy ye olde golde frontes	0		Mysticality: +5, Class: "Disco Bandit", Single Equip
@@ -465,7 +465,7 @@
 467	moldy super-sized pixel pie	5	crappy	
 468	twirling ruby W	0		
 469	wussiness potion	0		
-470	acceptable watered-down Imp Ale	2	good	
+470	watered-down acceptable Imp Ale	2	good	
 471	yummy super-sized hot wing	5	awesome	
 472	Fonzie's diamond-studded cane	0		Experience (Moxie): +1, Class: "Disco Bandit"
 473	lime green savvy crutch	0		Mysticality Percent: +20
@@ -492,14 +492,14 @@
 494	olive deadly batblade	0		Weapon Damage: +5
 495	purple catgut	0		
 496	cat appendix	0		
-497	purple skewed gnatwing	0		
-498	moldy big papaya	5	crappy	
+497	skewed purple gnatwing	0		
+498	big moldy papaya	5	crappy	
 499	flame-wreathed denim axe of the wise owl	0		Mysticality: +20, Hot Spell Damage: +10
 500	blinking Elf Farm Raffle ticket	0		
 501	delicious small Elfin shortbread	2	awesome	
 502	pagoda plans	0		
 503	rotten shaking skewered cat appendix	3	crappy	
-504	twirling red evil arches	0		
+504	red twirling evil arches	0		
 505	skewed manspreader's brainy gnatwing earring	0		Mysticality: +5, Monster Level: +10
 506	adequate immense Hell broth	9	good	
 507	spinning thunderrr guitarrr of the sewer	0		Stench Damage: +25
@@ -509,7 +509,7 @@
 511	ghostly Jarlsberg's key lime	0		
 512	ghostly Sneaky Pete's key lime	0		
 513	stale blinking Boris's key lime pie	4	decent	
-514	decent olive mirror Jarlsberg's key lime pie	3	good	
+514	decent mirror olive Jarlsberg's key lime pie	3	good	
 515	spoiled Sneaky Pete's key lime pie	3	crappy	
 516	blinking Hey Deze map	0		
 517	blurry friendly bejeweled accordion strap	0		Familiar Weight: +3, Class: "Accordion Thief"
@@ -517,11 +517,11 @@
 519	tumbling moxie magnet	0		
 520	leaflet	0		
 521	kickback cookbook of temperance	0		Sleaze Resistance: +5
-522	spinning spinning fuchsia one-winged stab bat	0		
+522	spinning fuchsia spinning one-winged stab bat	0		
 523	rewinged stab bat	0		
 524	tolerable papaya sling	4	good	
 525	jittery grue egg	0		
-526	mirror blinking olive Frobozz Real-Estate Company Instant House (TM)	0		
+526	olive mirror blinking Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
@@ -542,7 +542,7 @@
 544	mirror grievous stylish talons	0		Moxie: +25, Weapon Damage Percent: +50
 545	stale Spam Witch sammich	3	decent	
 546	purple meat vortex	0		
-547	cyan jittery 334 scroll	0		
+547	jittery cyan 334 scroll	0		
 548	668 scroll	0		
 549	teal blurry 30669 scroll	0		
 550	wobbly 33398 scroll	0		
@@ -552,7 +552,7 @@
 554	stale yellow pr0n cocktail	3	decent	
 555	spinning drywall axe of Gandalf of the cheetah	0		Spell Critical Percent: +20, Initiative: +60
 556	coward's Pine-Fresh air freshener	0		Monster Level: -20
-557	boozy perfectly mixed whiskey and cola	5	EPIC	
+557	perfectly mixed boozy whiskey and cola	5	EPIC	
 558	flavorless immense papaya taco	7	decent	
 559	razor-sharp can lid	0		
 560	adequate gigantic stalk of asparagus	10	good	
@@ -568,11 +568,11 @@
 570	decent blinking Chicken Sandwich	3	good	
 571	fuchsia Jumbo Dr. Lucifer	1	good	
 572	rotten Children's Meal of the Damned	4	crappy	
-573	fancy delicious noodles	4	awesome	Effect: "Broken Bone Nubs", Effect Duration: 5
+573	delicious fancy noodles	4	awesome	Effect: "Broken Bone Nubs", Effect Duration: 5
 574	spoiled noodles	4	crappy	
 575	stale huge painful penne pasta	3	decent	
 576	flavorless small ravioli della hippy	2	decent	
-577	enchanted decent pulsating pr0n m4nic0tti	4	good	Effect: "Toothy Grin", Effect Duration: 40
+577	decent enchanted pulsating pr0n m4nic0tti	4	good	Effect: "Toothy Grin", Effect Duration: 40
 578	rotten Hell ramen	3	crappy	
 579	rotten boring spaghetti	4	crappy	
 580	squat sauce of the ages	0		
@@ -584,7 +584,7 @@
 586	clever ridiculously huge sword of terror	0		Maximum MP: +20, Spooky Spell Damage: +10
 587	tarnished aerosolized lime green super-spiky hair gel	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 52
 588	jittery soft echo eyedrop antidote	0		
-589	immense stale cocoa eggshell fragment	10	decent	
+589	stale immense cocoa eggshell fragment	10	decent	
 590	decent cocoa eggshell fragment	3	good	
 591	narrow cocoa egg	0		
 592	wobbly house	0		
@@ -664,19 +664,19 @@
 666	flame-retardant ruddy Newton's steaming evil	0		Experience (Mysticality): +3, Maximum HP Percent: +40, Hot Resistance: +1
 667	castle map	0		
 668	savvy spiked femur	0		Mysticality Percent: +20
-669	adequate enchanted snack-sized ghuol guolash	2	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 10
+669	snack-sized enchanted adequate ghuol guolash	2	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 10
 670	squat cyan sharpshooter's lihc face	0		Critical Hit Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	fireproof toasty grave robbing shovel	0		Hot Damage: +5, Hot Resistance: +3
 672	miniature bland enchanted cranberries	2	decent	Effect: "Superhuman Sarcasm", Effect Duration: 5
-673	hand-crafted watered-down vodka and cranberry	2	EPIC	
-674	drinkable special whiskey	3	good	Effect: "Ice Packed", Effect Duration: 20
+673	watered-down hand-crafted vodka and cranberry	2	EPIC	
+674	special drinkable whiskey	3	good	Effect: "Ice Packed", Effect Duration: 20
 675	cyan Rosewater's skull of the Bonerdagon	0		Mysticality Percent: +30
 676	dragonbone belt buckle	0		
 677	blinking badass belt of the ox	0		Muscle: +20
 678	chest of the Bonerdagon	0		
 679	lousy roll in the hay	3	decent	
 680	tolerable slap and tickle	3	good	
-681	fortified delicious blinking slip 'n' slide	5	awesome	
+681	delicious fortified blinking slip 'n' slide	5	awesome	
 682	perfectly mixed a sump'm sump'm	3	EPIC	
 683	bad weak horizontal tango	2	decent	
 684	lousy pink pony	3	decent	
@@ -717,12 +717,12 @@
 721	lightning-fast educational porquoise bracelet	0		Experience: +1, Initiative: +40
 722	jittery shaking banded forbidden porquoise ring of Gandalf	0		Spell Damage Percent: +50, Damage Absorption: +100, Spell Critical Percent: +20, Single Equip
 723	bland Knoll mushroom	3	decent	
-724	moldy super-sized mushroom	5	crappy	
+724	super-sized moldy mushroom	5	crappy	
 725	blurry one million meat pancakes	0		
 726	blinking family-friendly huge mirror shard	0		Sleaze Resistance: +1
 727	hedge maze puzzle	0		
 728	blinking hedge maze key	0		
-729	spinning blurry fishbowl	0		
+729	blurry spinning fishbowl	0		
 730	shaking fishtank	0		
 731	fish hose	0		
 732	gray hosed tank	0		
@@ -748,8 +748,8 @@
 753	decent blinking pointy mushroom	4	good	
 754	moldy gigantic blurry cream of pointy mushroom soup	6	crappy	
 755	bland mushroom	3	decent	
-756	immense flavorless mushroom	8	decent	
-757	special snack-sized moldy mushroom	2	crappy	Effect: "Grape Expectations", Effect Duration: 30
+756	flavorless immense mushroom	8	decent	
+757	snack-sized moldy special mushroom	2	crappy	Effect: "Grape Expectations", Effect Duration: 30
 758	spoiled spinning ghost cucumber	4	crappy	
 759	dill	0		
 760	ghostly vinegar	0		
@@ -786,26 +786,26 @@
 791	shaking mansplainer's Fonzie's Mafia bow tie	0		Experience (Moxie): +1, Monster Level: +15, Last Available: "2004-10"
 792	upside-down educational Golden Mr. Accessory	0		Experience: +1, Softcore Only
 793	tarnished shaking oil of stability	0		Effect: "Bandersnatched", Effect Duration: 21
-794	pickled pickled blinking mirror oil of slipperiness	0		Effect: "Thunderspell", Effect Duration: 28
-795	weak acceptable upside-down Acque Luride Grezze Cabernet	2	good	Last Available: "2004-10"
+794	pickled pickled mirror blinking oil of slipperiness	0		Effect: "Thunderspell", Effect Duration: 28
+795	acceptable weak upside-down Acque Luride Grezze Cabernet	2	good	Last Available: "2004-10"
 796	hardy brainy cement shoes of the scaredy-cat	0		Mysticality: +5, Maximum HP: +50, Monster Level: -15, Last Available: "2004-10"
-797	mediocre triple-distilled green pulsating rockin' wagon	7	decent	
+797	triple-distilled mediocre pulsating green rockin' wagon	7	decent	
 798	artisanal ocean motion	4	EPIC	
 799	lousy upside-down fuzzbump	3	decent	
 800	flavorless poutine	3	decent	
-801	huge stale Knob stir-fry	8	decent	
-804	fancy bland gray Knoll stir-fry	4	decent	Effect: "Sweet Incentive", Effect Duration: 15
+801	stale huge Knob stir-fry	8	decent	
+804	bland fancy gray Knoll stir-fry	4	decent	Effect: "Sweet Incentive", Effect Duration: 15
 805	decent skewed stir-fry	3	good	
-806	adequate fancy asparagus stir-fry	3	good	Effect: "Shortened", Effect Duration: 35
+806	fancy adequate asparagus stir-fry	3	good	Effect: "Shortened", Effect Duration: 35
 807	yummy olive stir-fry	4	awesome	
 808	adequate gigantic tumbling Knob sausage stir-fry	8	good	
 809	adequate bat wing stir-fry	4	good	
 810	huge flavorless yellow rat appendix stir-fry	10	decent	
 811	normal tumbling shaking tofu stir-fry	3	good	
-812	special adequate lime green blurry pr0n stir-fry	3	good	Effect: "Techno Bliss", Effect Duration: 15
+812	adequate special lime green blurry pr0n stir-fry	3	good	Effect: "Techno Bliss", Effect Duration: 15
 813	adequate big Knob shells	5	good	
-814	moldy gigantic b&auml;tzle	9	crappy	
-815	massive bland ratini	8	decent	
+814	gigantic moldy b&auml;tzle	9	crappy	
+815	bland massive ratini	8	decent	
 816	rotten skewed Knob stroganoff	4	crappy	
 817	normal snack-sized menudo ravioli	2	good	
 818	mirror plus sign	0		
@@ -822,19 +822,19 @@
 829	anti-anti-antidote	0		
 830	massive flavorless royal jelly	7	decent	
 831	purple small box	0		
-832	huge squat box	0		
+832	squat huge box	0		
 833	vorpal blade of the brazier	0		Hot Spell Damage: +25
 834	Tesla cornuthaum of James Dean	0		Experience (Moxie): +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	nippy ring of aggravate monster	0		Cold Damage: +10
 836	stale mind flayer corpse	4	decent	
-837	weak drinkable Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
+837	drinkable weak Uovo Marcio Shiraz	2	good	Last Available: "2004-10"
 838	stanky slick Mafia stogie	0		Moxie: +10, Stench Spell Damage: +25, Last Available: "2004-10"
 839	high-proof lousy Maiali Sifilitici Pinot Noir	6	decent	Last Available: "2004-10"
 840	bouncing Van der Graaf electrified Mafia violin case	0		MP Regen Min: 8, MP Regen Max: 12, Last Available: "2004-10"
-841	perfectly mixed strong tomato daiquiri	5	EPIC	
+841	strong perfectly mixed tomato daiquiri	5	EPIC	
 842	artisanal beertini	4	EPIC	
 843	hand-crafted salty slug	4	EPIC	
-844	practically non-alcoholic perfectly mixed papaya slung	1	EPIC	
+844	perfectly mixed practically non-alcoholic papaya slung	1	EPIC	
 845	twirling vibrating MAHI fez	0		Maximum MP Percent: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	cyan blinking heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -851,7 +851,7 @@
 859	knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
-862	huge squat magnifying glass	0		Familiar Weight: +5
+862	squat huge magnifying glass	0		Familiar Weight: +5
 863	lime green skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
@@ -897,11 +897,11 @@
 906	unsweetened pressed blinking Rock Pops	0		Effect: "Ooh, Umami!", Effect Duration: 36
 907	anodized extra-ionized Mr. Mediocrebar	0		Effect: "Slightly Larger Than Usual", Effect Duration: 35
 908	ionized ionized altered squat Cold Hots candy	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 62
-909	energized diffused modified olive blurry Wint-O-Fresh mint	0		Effect: "Thunderheart", Effect Duration: 64
-910	decent enchanted shaking twirling dwarf bread	4	good	Effect: "Educated (Kinda)", Effect Duration: 45
+909	energized diffused modified blurry olive Wint-O-Fresh mint	0		Effect: "Thunderheart", Effect Duration: 64
+910	decent enchanted twirling shaking dwarf bread	4	good	Effect: "Educated (Kinda)", Effect Duration: 45
 911	liquefied magnetized Senior Mints	0		Effect: "Super Skill", Effect Duration: 39
 912	triple-deionized frozen wobbly pixellated candy heart	0		Effect: "Blubbered Up", Effect Duration: 22
-913	non-ionized galvanized blurry twirling kobold	0		Effect: "Educated (Sorta)", Effect Duration: 18
+913	non-ionized galvanized twirling blurry kobold	0		Effect: "Educated (Sorta)", Effect Duration: 18
 914	squat hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fireproof intergalactic pom poms of dire peril	0		Weapon Damage: +20, Hot Resistance: +3
@@ -915,13 +915,13 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	tumbling dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	denatured huge Hawking's Elixir of Brilliance	0		Effect: "Infernal Thirst", Effect Duration: 63
-927	spirit-forward aged teal pulsating Ferita Del Petto Zinfandel	5	awesome	Last Available: "2006-12"
+927	spirit-forward aged pulsating teal Ferita Del Petto Zinfandel	5	awesome	Last Available: "2006-12"
 928	fuzzy bracelets of the detective	0		Item Drop: +20
 929	brainy arse-shooting crossbow	0		Mysticality: +5
 931	smooth blue spiced rum	3	awesome	
 932	bad eggnog	4	decent	
 933	normal gigantic spinning candy cane	9	good	
-934	fancy stale narrow huge gingerbread bugbear	4	decent	Effect: "Capricorn Rising", Effect Duration: 15
+934	stale fancy huge narrow gingerbread bugbear	4	decent	Effect: "Capricorn Rising", Effect Duration: 15
 935	cyan Lo Pan's imitation nice watch	0		Spell Critical Percent: +30, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	maroon menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -935,17 +935,17 @@
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	fancy irresponsibly strong artisanal martini	7	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 5, Last Available: "2004-12"
+948	artisanal irresponsibly strong fancy martini	7	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 5, Last Available: "2004-12"
 949	artisanal twirling grogtini	3	super ultra EPIC	Last Available: "2004-12"
 950	tolerable cherry bomb	4	good	Last Available: "2004-12"
-951	cyan skewed extra special Crimbo stocking	0		Last Available: "2004-12"
+951	skewed cyan extra special Crimbo stocking	0		Last Available: "2004-12"
 952	narrow hockey mask of the wise owl of the businessman	0		Mysticality: +20, Meat Drop: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	yellow penguin-smacking club	0		Familiar Damage: +15
 954	green orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	razor-sharp fez of etymology	0		Weapon Damage Percent: +25, Familiar Effect: "1xLep, cap 30"
 956	decent carob chunk noodles	4	good	
 957	bland pulsating chorizo brownies	3	decent	
-958	bland enchanted twirling chocolate and tomato pizza	4	decent	Effect: "Amorous Avarice", Effect Duration: 20
+958	enchanted bland twirling chocolate and tomato pizza	4	decent	Effect: "Amorous Avarice", Effect Duration: 20
 959	flange	0		
 960	clockwork key	0		
 961	ghostly silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -982,13 +982,13 @@
 992	jittery Usain Bolt's ribald scorching plastic Jarlsberg	0		Hot Damage: +25, Sleaze Damage: +10, Initiative: +80
 993	teal frosty sage plastic Sneaky Pete of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3, Cold Spell Damage: +10
 994	upside-down ribald plastic Susie	0		Sleaze Damage: +10
-995	normal big squat Lucky Surprise Egg	5	good	
+995	big normal squat Lucky Surprise Egg	5	good	
 998	maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	maid head	0		
 1000	mirror Meat maid	0		
 1002	narrow fuchsia horrifying Xlyinia's notebook	0		Spooky Damage: +25
-1003	cyan jittery soda water	0		
-1004	bad boozy blue bottle of tequila	5	decent	
+1003	jittery cyan soda water	0		
+1004	boozy bad blue bottle of tequila	5	decent	
 1005	watered-down artisanal boxed wine	2	EPIC	
 1006	half-sized stale pulsating cherry	2	decent	
 1007	boxer's coconut shell	0		Muscle Percent: +10, Familiar Effect: "1xFairy, cap 7"
@@ -996,13 +996,13 @@
 1009	irresponsibly strong hand-crafted vodka martini	9	EPIC	
 1010	lousy whiskey and soda	3	decent	
 1011	acceptable monkey wrench	4	good	
-1012	drinkable distilled tequila sunrise	5	good	
-1013	watered-down artisanal margarita	2	EPIC	
-1014	bad practically non-alcoholic upside-down strawberry wine	1	decent	
-1015	artisanal high-proof shaking wine spritzer	7	EPIC	
-1016	bad fortified ghostly perpendicular hula	5	decent	
-1017	acceptable watered-down ducha de oro	2	good	
-1018	watered-down mediocre calle de miel	2	decent	
+1012	distilled drinkable tequila sunrise	5	good	
+1013	artisanal watered-down margarita	2	EPIC	
+1014	practically non-alcoholic bad upside-down strawberry wine	1	decent	
+1015	high-proof artisanal shaking wine spritzer	7	EPIC	
+1016	fortified bad ghostly perpendicular hula	5	decent	
+1017	watered-down acceptable ducha de oro	2	good	
+1018	mediocre watered-down calle de miel	2	decent	
 1019	acceptable dry vodka martini	3	good	
 1020	tolerable old-fashioned	4	good	
 1021	mediocre strong twirling tequila with training wheels	5	decent	
@@ -1053,14 +1053,14 @@
 1067	plastic oyster egg	0		
 1068	twisted jittery blinking oyster egg	1		Effect: "On the Shoulders of Giants", Effect Duration: 15
 1069	altered oyster egg	1		Effect: "Full-Body Tan", Effect Duration: 30
-1070	mixed skewed maroon oyster egg	1		
+1070	mixed maroon skewed oyster egg	1		
 1071	pulsating plastic oyster egg	0		
 1072	altered red off-white oyster egg	1		
 1073	twisted jittery wobbly off-white oyster egg	1		
 1074	dried huge huge off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	diluted green oyster egg	1		Effect: "Can't Be a Chooser", Effect Duration: 35
-1077	dried ghostly narrow oyster egg	1		Effect: "Slimy Hands", Effect Duration: 30
+1077	dried narrow ghostly oyster egg	1		Effect: "Slimy Hands", Effect Duration: 30
 1078	denatured fuchsia oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
@@ -1126,10 +1126,10 @@
 1140	perfectly mixed wobbly icy mushroom wine	3	EPIC	
 1141	acceptable mushroom wine	4	good	
 1142	perfectly mixed pointy mushroom wine	4	EPIC	
-1143	smooth triple-distilled flat mushroom wine	8	awesome	
+1143	triple-distilled smooth flat mushroom wine	8	awesome	
 1144	mediocre cool mushroom wine	4	decent	
 1145	lousy squat knob mushroom wine	4	decent	
-1146	spirit-forward mediocre knoll mushroom wine	5	decent	
+1146	mediocre spirit-forward knoll mushroom wine	5	decent	
 1147	bad triple-distilled mushroom wine	10	decent	
 1148	lousy green shot of flower schnapps	4	decent	
 1149	decent narrow flower petal pie	3	good	
@@ -1141,7 +1141,7 @@
 1155	letter from King Ralph XI	0		
 1157	horrifying wholeberd	0		Spooky Damage: +25
 1158	ionized frozen yellow Meleegra&trade; pills	0		Effect: "Spring Training", Effect Duration: 68
-1159	huge twirling mariachi G-string	0		
+1159	twirling huge mariachi G-string	0		
 1160	irate sombrero of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	blurry pile of candy	0		
 1162	pickled polymerized handsomeness potion	0		Effect: "Sugar, Hello", Effect Duration: 39
@@ -1153,7 +1153,7 @@
 1168	less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
 1170	jittery cyan chocolate box	0		
-1171	spinning spinning skewed coffin	0		
+1171	spinning skewed spinning coffin	0		
 1172	squat asbestos box	0		
 1173	blurry linoleum box	0		
 1174	chrome box	0		
@@ -1173,7 +1173,7 @@
 1188	lotus	0		
 1189	can of asparagus	0		
 1190	dodecapede	0		
-1191	cyan upside-down ghuol whelp	0		
+1191	upside-down cyan ghuol whelp	0		
 1192	zmobie	0		
 1193	Raggedy Hippy doll	0		
 1194	stab bat	0		
@@ -1182,17 +1182,17 @@
 1197	wobbly Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
-1200	rotten enchanted jumbo mugcake	5	crappy	Effect: "Net Tea", Effect Duration: 5
-1201	adequate low-calorie urinal cake	1	good	
+1200	jumbo enchanted rotten mugcake	5	crappy	Effect: "Net Tea", Effect Duration: 5
+1201	low-calorie adequate urinal cake	1	good	
 1202	bland Happy Birthday, Claude! cake	3	decent	
 1203	normal personalized birthday cake	3	good	
-1204	spoiled half-sized jittery squat three-tiered wedding cake	2	crappy	
-1205	low-calorie decent babycakes	1	good	
-1206	stale miniature velvet cake	2	decent	
+1204	spoiled half-sized squat jittery three-tiered wedding cake	2	crappy	
+1205	decent low-calorie babycakes	1	good	
+1206	miniature stale velvet cake	2	decent	
 1207	stale congratulatory cake	3	decent	
 1208	normal angel-food cake	4	good	
 1209	snack-sized flavorless huge devil's-food cake	2	decent	
-1210	stale low-calorie birthday party jellybean cheesecake	1	decent	
+1210	low-calorie stale birthday party jellybean cheesecake	1	decent	
 1211	balloon	0		
 1212	twirling balloon	0		
 1213	heart-shaped balloon	0		
@@ -1232,30 +1232,30 @@
 1248	double-paned studded Bonerdagon necklace of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +80, Cold Resistance: +5
 1249	auspicious Boss Bat britches	0		Item Drop: +10, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	blue friendly razor-sharp Boss Bat bling	0		Weapon Damage Percent: +25, Familiar Weight: +3
-1251	super-sized special stale shaking upside-down Knob shroomkabob	5	decent	Effect: "Shamboozled", Effect Duration: 35
+1251	stale special super-sized shaking upside-down Knob shroomkabob	5	decent	Effect: "Shamboozled", Effect Duration: 35
 1252	toothsome ghostly shroomkabob	3	awesome	
 1253	pile of jumping beans	0		
 1254	rotten jumping bean burrito	3	crappy	
-1255	rotten mirror ghostly jumping bean burrito	4	crappy	
+1255	rotten ghostly mirror jumping bean burrito	4	crappy	
 1256	rotten insanely jumping bean burrito	3	crappy	
 1257	adequate small rat scrapple	2	good	
 1258	mirror pail of pretentious paint	0		
 1259	greedy healthy traffic cone	0		Maximum HP Percent: +20, Meat Drop: +20, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	mixed skewed upside-down maroon Hatorade	1		
+1261	mixed maroon upside-down skewed Hatorade	1		
 1262	family-friendly boxer's off-hand balloon of Gandalf	0		Muscle Percent: +10, Spell Critical Percent: +20, Sleaze Resistance: +1
 1263	fuchsia pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
 1266	yummy gloomy mushroom	3	awesome	
 1267	blurry dead mimic	0		
-1268	skewed maroon pine wand	0		
+1268	maroon skewed pine wand	0		
 1269	ebony wand	0		
 1270	hexagonal wand	0		
 1271	aluminum wand	0		
 1272	marble wand	0		
 1273	Jack Frost's magic lamp	0		Cold Spell Damage: +50
-1274	compressed gray blinking twirling Medicinal Herb's medicinal herbs	1		
+1274	compressed twirling blinking gray Medicinal Herb's medicinal herbs	1		
 1275	blurry stanky basic meat skirt	0		Stench Spell Damage: +25, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	hand-crafted Otorian Battle Scar	3	EPIC	
 1277	MacGyver's basic meat kilt	0		Maximum MP: +100, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1335,9 +1335,9 @@
 1352	acceptable redrum	3	good	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	decent thick cyan pulsating bowl of oriole's nest soup	5	good	
-1356	upside-down skewed bunny liver	0		
-1357	practically non-alcoholic perfectly mixed Mt. Noob Pale Ale	1	EPIC	
+1355	thick decent pulsating cyan bowl of oriole's nest soup	5	good	
+1356	skewed upside-down bunny liver	0		
+1357	perfectly mixed practically non-alcoholic Mt. Noob Pale Ale	1	EPIC	
 1358	twirling pirate zombie head	0		Last Available: "2005-11"
 1359	narrow ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,10 +1346,10 @@
 1363	clockwork pirate skull	0		
 1364	spinning rhesus monkey	0		Familiar Weight: +5
 1365	moldy tofurkey leg	3	crappy	
-1366	normal small tofurkey gravy	2	good	
+1366	small normal tofurkey gravy	2	good	
 1367	flavorless special herbal stuffing	3	decent	Effect: "Busy Bein' Delicious", Effect Duration: 10
-1368	jumbo bland squat can-shaped gelatinous cranberry sauce	5	decent	
-1369	stale super-sized yams	5	decent	
+1368	bland jumbo squat can-shaped gelatinous cranberry sauce	5	decent	
+1369	super-sized stale yams	5	decent	
 1370	spinning rhinestone cowboy shirt of wisdom	0		Mysticality: +15
 1371	dog trainer's gingham blouse	0		Experience (familiar): +1
 1372	shellacked souvenir ski t-shirt	0		Damage Reduction: 7
@@ -1363,7 +1363,7 @@
 1381	twirling aspirin	0		Last Available: "2005-12"
 1382	colloidal chocolate	0		Effect: "Proprie Tea", Effect Duration: 32, Last Available: "2015-11"
 1383	twirling length of string	0		
-1384	yellow skewed googly eye	0		
+1384	skewed yellow googly eye	0		
 1385	stuffing	0		
 1386	felt	0		
 1387	block	0		
@@ -1376,7 +1376,7 @@
 1394	huge doppelshifter	0		Last Available: "2005-12"
 1395	skewed teddy bear	0		Last Available: "2005-12"
 1396	tumbling Sherlock's arcane researcher's duck-on-a-string	0		Experience Percent (Mysticality): +10, Item Drop: +25, Last Available: "2005-12"
-1397	jittery lime green toy soldier	0		Last Available: "2005-12"
+1397	lime green jittery toy soldier	0		Last Available: "2005-12"
 1398	doll house	0		Last Available: "2005-12"
 1399	reassuring toy train	0		Spooky Resistance: +1, Single Equip, Last Available: "2005-12"
 1400	electrified marionette	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2005-12"
@@ -1390,7 +1390,7 @@
 1408	normal tree-shaped Crimbo cookie	4	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	teal pulsating Newton's Unionize The Elves sign	0		Experience (Mysticality): +3, Last Available: "2005-12"
 1410	spinning sleeping snowy owl	0		Last Available: "2005-12"
-1411	pulsating skewed Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	skewed pulsating Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	energized snowcone	0		Effect: "Sauce Monocle", Effect Duration: 51, Last Available: "2006-01"
 1413	quantum nitrogenated wobbly snowcone	0		Effect: "Witch Breaded", Effect Duration: 11, Last Available: "2006-01"
 1414	concentrated narrow shaking snowcone	0		Effect: "Some Cheese with Your Wine", Effect Duration: 44, Last Available: "2006-01"
@@ -1420,7 +1420,7 @@
 1438	liquefied twinkly powder	0		Effect: "Hairless and Airless", Effect Duration: 67
 1439	polymerized double-wet deionized hot powder	0		Effect: "Knightlife", Effect Duration: 61
 1440	dry double-liquefied huge powder	0		Effect: "The Magic of LOV", Effect Duration: 33
-1441	corrupted adjusted mirror upside-down twirling powder	0		Effect: "Heart of Green", Effect Duration: 58
+1441	corrupted adjusted upside-down twirling mirror powder	0		Effect: "Heart of Green", Effect Duration: 58
 1442	aerosolized triple-alkaline oxidized ghostly red stench powder	0		Effect: "Full Bottle in front of Me", Effect Duration: 68
 1443	concentrated upside-down sleaze powder	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 53
 1444	corrupted super-moist twinkly nuggets	0		Effect: "Sensation", Effect Duration: 24
@@ -1434,7 +1434,7 @@
 1452	denatured wad	1		Effect: "Dreams and Lights", Effect Duration: 35
 1453	compressed twirling wad	1		
 1454	denatured lime green stench wad	1		
-1455	mixed red jittery sleaze wad	1		Effect: "Sweet and Yellow", Effect Duration: 40
+1455	mixed jittery red sleaze wad	1		Effect: "Sweet and Yellow", Effect Duration: 40
 1456	double daisy	0		
 1457	yellow Goth Giant	0		
 1458	spoiled Valentine's Day cake	4	crappy	
@@ -1463,7 +1463,7 @@
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	upside-down paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	ghostly troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
-1484	mirror gray alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
+1484	gray mirror alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	energetic rabbit's foot of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +20
 1486	bouncing massive bag of catnip	0		
 1487	upside-down hang glider	0		
@@ -1473,9 +1473,9 @@
 1491	lard-coated rice bowl	0		Sleaze Spell Damage: +25
 1492	ninja mop of the businessman	0		Meat Drop: +50
 1493	huge twirling Usain Bolt's ridiculously overelaborate ninja weapon of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +80
-1494	quadruple-polarized unsweetened ghostly skewed sugar-coated pine cone	0		Effect: "Strong Spirit", Effect Duration: 17, Last Available: "2020-09"
+1494	quadruple-polarized unsweetened skewed ghostly sugar-coated pine cone	0		Effect: "Strong Spirit", Effect Duration: 17, Last Available: "2020-09"
 1495	green traffic cone of the brute of the early riser	0		Muscle Percent: +30, Adventures: +7, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	acceptable weak gloomy mushroom wine	2	good	
+1496	weak acceptable gloomy mushroom wine	2	good	
 1497	weak drinkable mushroom wine	2	good	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	green whoopie cushion	0		Last Available: "2006-04"
@@ -1487,13 +1487,13 @@
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	bad narrow calle de miel with a fly in it	4	decent	Last Available: "2006-04"
 1507	practically non-alcoholic drinkable squat rockin' wagon with a fly in it	1	good	Last Available: "2006-04"
-1508	watered-down lousy perpendicular hula with a fly in it	2	decent	Last Available: "2006-04"
+1508	lousy watered-down perpendicular hula with a fly in it	2	decent	Last Available: "2006-04"
 1509	bad tumbling slap and tickle with a fly in it	4	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	shellacked fake hand	0		Damage Reduction: 7, Last Available: "2006-04"
 1512	diluted twirling Knob Goblin pet-buffing spray	1		Effect: "Holiday Disappointment", Effect Duration: 5
 1513	altered blinking Knob Goblin learning pill	1		
-1514	compressed blurry ghostly Knob Goblin eyedrops	1		Effect: "Pop-eyed", Effect Duration: 15
+1514	compressed ghostly blurry Knob Goblin eyedrops	1		Effect: "Pop-eyed", Effect Duration: 15
 1515	modified yellow skewed Knob Goblin nasal spray	1		Effect: "Standard Cheer", Effect Duration: 40
 1516	KWE-brand transistor radio	0		
 1518	tumbling vampire heart	0		
@@ -1501,7 +1501,7 @@
 1520	reassuring therapeutic Radio KoL Coffee Mug	0		Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 1521	Frank Gorshin trophy	0		
 1522	mirror Samson's Radio Free Jersey of the storm	0		Experience (Muscle): +5, Maximum MP Percent: +40
-1523	narrow jittery bottle of used blood	0		
+1523	jittery narrow bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	ghostly pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
@@ -1512,7 +1512,7 @@
 1531	grass skirt of doom	0		Spooky Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
 1532	brainy grass hat	0		Mysticality: +5, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	grass blade of the pedagogue	0		Experience: +3, Last Available: "2011-01"
-1534	huge upside-down raffle prize box	0		
+1534	upside-down huge raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	upside-down weegee sqouija	0		Last Available: "2011-12"
 1538	huge curative sparkly engagement ring	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
@@ -1528,28 +1528,28 @@
 1548	clever stylish Gazpacho's Glacial Grimoire	0		Moxie: +25, Maximum MP: +20
 1549	MSG	0		
 1550	wobbly cyan greedy second-hand knockoff engagement ring	0		Meat Drop: +20, Single Equip
-1551	hand-crafted weak bottle of Domesticated Turkey	2	EPIC	
-1552	practically non-alcoholic acceptable wobbly cyan jittery bottle of Definit	1	good	
+1551	weak hand-crafted bottle of Domesticated Turkey	2	EPIC	
+1552	practically non-alcoholic acceptable jittery wobbly cyan bottle of Definit	1	good	
 1553	aged bottle of Calcutta Emerald	3	awesome	
-1554	drinkable watered-down bottle of Lieutenant Freeman	2	good	
+1554	watered-down drinkable bottle of Lieutenant Freeman	2	good	
 1555	fortified drinkable bottle of Jorge Sinsonte	5	good	
 1556	lousy yellow shaking boxed champagne	3	decent	
 1557	yummy kumquat	3	awesome	
 1558	rotten massive tangerine	10	crappy	
-1559	twirling tumbling tonic water	0		
+1559	tumbling twirling tonic water	0		
 1560	spoiled special mirror cocktail onion	4	crappy	Effect: "Human-Undead Hybrid", Effect Duration: 40
 1561	rotten raspberry	3	crappy	
-1562	fancy spoiled small kiwi	2	crappy	Effect: "Putting the Pro in Proletariat", Effect Duration: 45
+1562	fancy small spoiled kiwi	2	crappy	Effect: "Putting the Pro in Proletariat", Effect Duration: 45
 1563	acceptable cyan whiskey bittersweet	3	good	
 1564	mediocre practically non-alcoholic mimosette	1	decent	
 1565	acceptable tequila sunset	4	good	
-1566	acceptable triple-distilled blue zmobie	10	good	Wiki Name: "Zmobie (drink)"
+1566	triple-distilled acceptable blue zmobie	10	good	Wiki Name: "Zmobie (drink)"
 1567	hand-crafted gin and tonic	3	EPIC	
 1568	lousy vodka and tonic	4	decent	
 1569	acceptable jittery vodka gibson	4	good	
 1570	drinkable gibson	4	good	
 1571	mediocre watered-down parisian cathouse	2	decent	
-1572	watered-down bad rabbit punch	2	decent	
+1572	bad watered-down rabbit punch	2	decent	
 1573	fancy tolerable pulsating caipifruta	3	good	Effect: "Blessing of Pikachutlotal", Effect Duration: 50
 1574	drinkable teqiwila	3	good	
 1575	drinkable Divine	4	good	
@@ -1557,39 +1557,39 @@
 1577	lousy tangarita	3	decent	
 1578	artisanal mandarina colada	3	EPIC	
 1579	lousy gimlet	3	decent	
-1580	enchanted drinkable brick road	3	good	Effect: "Loco Motives", Effect Duration: 45
+1580	drinkable enchanted brick road	3	good	Effect: "Loco Motives", Effect Duration: 45
 1581	practically non-alcoholic hand-crafted vodka stratocaster	1	super ultra mega turbo EPIC	
 1582	triple-distilled mediocre Neuromancer	6	decent	
 1583	lousy prussian cathouse	4	decent	
-1584	watered-down bad fuchsia huge Mae West	2	decent	
-1585	boozy acceptable Mon Tiki	5	good	
+1584	watered-down bad huge fuchsia Mae West	2	decent	
+1585	acceptable boozy Mon Tiki	5	good	
 1586	artisanal twirling teqiwila slammer	4	EPIC	
 1587	spoiled ghostly blurry Knob lo mein	4	crappy	
 1588	normal half-sized asparagus lo mein	2	good	
-1589	thick toothsome lime green Knoll lo mein	5	awesome	
-1590	stale enchanted lo mein	4	decent	Effect: "Ripping, Dripping", Effect Duration: 25
+1589	toothsome thick lime green Knoll lo mein	5	awesome	
+1590	enchanted stale lo mein	4	decent	Effect: "Ripping, Dripping", Effect Duration: 25
 1591	rotten big olive lo mein	5	crappy	
 1592	rotten hot hi mein	4	crappy	
 1593	stale hi mein	3	decent	
-1594	rotten immense maroon hi mein	10	crappy	
-1595	thick delicious hi mein	5	awesome	
-1596	small decent yellow sleazy hi mein	2	good	
+1594	immense rotten maroon hi mein	10	crappy	
+1595	delicious thick hi mein	5	awesome	
+1596	decent small yellow sleazy hi mein	2	good	
 1597	narrow Junior LAAAAME merit badge of courage	0		Spooky Resistance: +3, Last Available: "2006-05"
 1598	huge gray ghostly razor-sharp Senior LAAAAME merit badge	0		Weapon Damage Percent: +25, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	drinkable spirit-forward special tangarita with a fly in it	5	good	Effect: "Spring Training", Effect Duration: 25
+1600	special drinkable spirit-forward tangarita with a fly in it	5	good	Effect: "Spring Training", Effect Duration: 25
 1601	acceptable bouncing mandarina colada with a fly in it	4	good	
 1602	weak bad green prussian cathouse with a fly in it	2	decent	
 1603	acceptable Mae West with a fly in it	4	good	
 1604	dehydrated bouncing astronaut ice-cream	1		Last Available: "2006-05"
 1605	blinking squat delectable catalyst	0		
 1606	dried fuchsia ultimate wad	1		
-1607	triple-improved double-vacuum-sealed denatured lime green narrow twirling libation of liveliness	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 43
+1607	triple-improved double-vacuum-sealed denatured lime green twirling narrow libation of liveliness	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 43
 1608	boiled altered eyedrops of the ermine	0		Effect: "Greasy Peasy", Effect Duration: 45
-1609	activated squat gray perfume of prejudice	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 43
+1609	activated gray squat perfume of prejudice	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 43
 1610	activated quadruple-quantum eyedrops of the ocelot	0		Effect: "Hyphemariffic", Effect Duration: 65
 1611	flattened ionized moist potent potion of potency	0		Effect: "White-boy Angst", Effect Duration: 66
-1612	chilled blurry purple concentrated cordial of concentration	0		Effect: "Brain Freeze", Effect Duration: 57
+1612	chilled purple blurry concentrated cordial of concentration	0		Effect: "Brain Freeze", Effect Duration: 57
 1613	MacGyver's coffin lid	0		Maximum MP: +100, Damage Reduction: 3
 1614	boxer's satin shield	0		Muscle Percent: +10, Damage Reduction: 5
 1615	up-at-dawn Cerebral Cloche	0		Adventures: +5, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
@@ -1620,7 +1620,7 @@
 1640	activated modified huge lotion of stench	0		Effect: "Healthy Blue Glow", Effect Duration: 58
 1641	corrupted cold-filtered teal lotion of sleaziness	0		Effect: "Spookypants", Effect Duration: 45
 1642	mediocre Grimacite Bock	4	decent	Last Available: "2008-11"
-1643	rotten gigantic wedge of gray cheese	10	crappy	Last Available: "2008-11"
+1643	gigantic rotten wedge of gray cheese	10	crappy	Last Available: "2008-11"
 1644	skewed hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
@@ -1672,12 +1672,12 @@
 1692	tarnished skewed salamander slurry	0		Effect: "Scorpio Rising", Effect Duration: 41
 1693	quantum quadruple-polarized eyedrops of newt	0		Effect: "Sticky Fingers", Effect Duration: 64
 1694	improved Frogade	0		Effect: "Ginger Snapped", Effect Duration: 11
-1695	enhanced energized blue spinning papotion of papower	0		Effect: "Insulated Trousers", Effect Duration: 62
-1696	enchanted super-sized spoiled royal jelly taco	5	crappy	Effect: "Inappropriate Spirit", Effect Duration: 20
+1695	enhanced energized spinning blue papotion of papower	0		Effect: "Insulated Trousers", Effect Duration: 62
+1696	spoiled enchanted super-sized royal jelly taco	5	crappy	Effect: "Inappropriate Spirit", Effect Duration: 20
 1697	adequate super-sized tofu taco	5	good	
 1698	half-sized rotten jumping bean taco	2	crappy	
 1699	decent spinning catgut taco	3	good	
-1700	flavorless half-sized goat cheese taco	2	decent	
+1700	half-sized flavorless goat cheese taco	2	decent	
 1701	adequate olive pr0n taco	4	good	
 1702	liquefied frozen improved alphabet gum	0		Effect: "Heart of Yellow", Effect Duration: 69
 1703	tumbling Comma Chameleon egg	0		Free Pull
@@ -1750,11 +1750,11 @@
 1771	healthy butcherknife	0		Maximum HP Percent: +20
 1772	corn holder of the bloodbag	0		Maximum HP: +100
 1773	blinking smooth eggbeater	0		Moxie: +15
-1774	lousy practically non-alcoholic bottle of popskull	1	decent	
+1774	practically non-alcoholic lousy bottle of popskull	1	decent	
 1775	quilted dishrag	0		Damage Absorption: +40
-1776	bite-sized toothsome stale baguette	1	awesome	
+1776	toothsome bite-sized stale baguette	1	awesome	
 1777	spinning leftovers of indeterminate origin	0		
-1778	decent massive dinner	8	good	
+1778	massive decent dinner	8	good	
 1779	green katana of the ox	0		Muscle: +20
 1780	Jim Carey's ram stick	0		Monster Level: +25
 1781	ghostly toasty enchantlers	0		Hot Damage: +5, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1765,9 +1765,9 @@
 1786	six pack of Mountain Stream	0		
 1787	pickled anodized magnetized bag of Cheat-Os	0		Effect: "Piratey Flavor", Effect Duration: 23
 1788	ghostly skewed unrefined Mountain Stream syrup	0		
-1789	skewed ghostly Mob Penguin	0		
+1789	ghostly skewed Mob Penguin	0		
 1790	high-proof artisanal Ram's Face Lager	9	EPIC	
-1791	fuchsia squat ram horns	0		
+1791	squat fuchsia ram horns	0		
 1792	Jeselnik's therapeutic Travoltan trousers of the ox	0		Muscle: +20, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	censurious sizzling pool cue	0		Hot Damage: +10, Sleaze Resistance: +3
 1794	corrupted improved wobbly shaking handful of hand chalk	0		Effect: "Amplified Fabulousness", Effect Duration: 50
@@ -1810,7 +1810,7 @@
 1831	maroon wobbly third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
 1833	blinking fifth caudal vertebra	0		
-1834	twirling maroon sixth caudal vertebra	0		
+1834	maroon twirling sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
 1836	eighth caudal vertebra	0		
 1837	blue ninth caudal vertebra	0		
@@ -1834,7 +1834,7 @@
 1855	right fifth rib	0		
 1856	skewed huge right sixth rib	0		
 1857	right seventh rib	0		
-1858	jittery purple right eighth rib	0		
+1858	purple jittery right eighth rib	0		
 1859	teal right ninth rib	0		
 1860	jittery right tenth rib	0		
 1861	squat right eleventh rib	0		
@@ -1874,7 +1874,7 @@
 1895	fuchsia left fourth rear claw	0		
 1896	right first rear claw	0		
 1897	pulsating right second rear claw	0		
-1898	cyan wobbly right third rear claw	0		
+1898	wobbly cyan right third rear claw	0		
 1899	right fourth rear claw	0		
 1900	stylish 1-ball	0		Moxie: +25
 1901	rock-hard personal trainer's 2-ball	0		Experience Percent (Muscle): +10, Damage Reduction: 5
@@ -1961,24 +1961,24 @@
 1984	snowy owl	0		
 1985	skewed scary death orb	0		
 1986	green mind flayer	0		
-1987	pulsating purple undead elbow macaroni	0		
+1987	purple pulsating undead elbow macaroni	0		
 1988	angry cow	0		
 1989	Cheshire bitten	0		
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
 1992	fuchsia rubber WWBD? bracelet	0		
 1993	rubber WWSPD? bracelet	0		
-1994	narrow green upside-down rubber WWtNSD? bracelet	0		
+1994	upside-down green narrow rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
 1996	right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	bouncing pack of KWE trading card	0		
-1999	bouncing wobbly stick of &quot;gum&quot;	0		
-2000	upside-down spinning Das &Uuml;berk&uuml;hlraum trading card	0		
-2001	pulsating purple blinking Vaso De Agua trading card	0		
+1999	wobbly bouncing stick of &quot;gum&quot;	0		
+2000	spinning upside-down Das &Uuml;berk&uuml;hlraum trading card	0		
+2001	blinking pulsating purple Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	Thorny Toad trading card	0		
-2004	wobbly narrow Chori Zo trading card	0		
+2004	narrow wobbly Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	jittery Poison Oak trading card	0		
 2007	Princess Rutabaga trading card	0		
@@ -1994,15 +1994,15 @@
 2017	spade necklace	0		
 2018	maroon club necklace	0		
 2019	cream pie	0		Free Pull
-2020	normal super-sized cherry pie	5	good	
+2020	super-sized normal cherry pie	5	good	
 2021	big spoiled strawberry pie	5	crappy	
 2022	moldy miniature twirling lemon meringue pie	2	crappy	
 2023	tumbling Genalen&trade; Bottle	1	decent	
-2024	fancy bland huge mixed wildflower greens	6	decent	Effect: "Demonic Taint", Effect Duration: 25
+2024	fancy huge bland mixed wildflower greens	6	decent	Effect: "Demonic Taint", Effect Duration: 25
 2025	half-sized tasty green handful of walnuts	2	awesome	
 2026	spoiled nutty organic salad	3	crappy	
 2027	stale super salad	4	decent	
-2028	toothsome blinking green tofu wonton	3	awesome	
+2028	toothsome green blinking tofu wonton	3	awesome	
 2029	hippy protest button	0		Single Equip
 2030	double-paned dog trainer's Lockenstock&trade; sandals	0		Experience (familiar): +1, Cold Resistance: +5, Single Equip
 2031	didgeridooka of bravery	0		Spooky Resistance: +5
@@ -2020,9 +2020,9 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	adequate miniature brain-meltingly-hot chicken wings	2	good	
-2046	decent enchanted shaking frat brats	4	good	Effect: "Crusty Head", Effect Duration: 10
+2046	enchanted decent shaking frat brats	4	good	Effect: "Crusty Head", Effect Duration: 10
 2047	adequate knob ka-bobs	4	good	
-2049	fancy hand-crafted can of Swiller	3	EPIC	Effect: "Berry Experiential", Effect Duration: 45
+2049	hand-crafted fancy can of Swiller	3	EPIC	Effect: "Berry Experiential", Effect Duration: 45
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	pulsating reassembled blackbird	0		
@@ -2060,14 +2060,14 @@
 2084	can of starch	0		
 2085	powdered twirling bottle of ultravitamins	1		Effect: "Motion", Effect Duration: 20
 2086	boiled cyan bottle of cough syrup	1		
-2087	compressed blinking jittery tube of hair oil	1		Effect: "EVISCERATE!", Effect Duration: 50
+2087	compressed jittery blinking tube of hair oil	1		Effect: "EVISCERATE!", Effect Duration: 50
 2088	nitrogenated polymerized Daffy Taffy	0		Effect: "Blessing of Charcoatl", Effect Duration: 36
 2089	shaking Crimboween memo	0		Last Available: "2006-10"
 2090	sharpshooter's MacGyver's quilted forbidden pilgrim shield of the storm	0		Spell Damage Percent: +50, Damage Absorption: +40, Maximum MP Percent: +40, Maximum MP: +100, Critical Hit Percent: +10, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	huge bath salts	0		
 2092	ghostly hand mirror	0		
 2093	ghostly lightning-fast hors d'oeuvre tray	0		Initiative: +40, Damage Reduction: 5
-2094	stale gigantic ballroom blintz	10	decent	
+2094	gigantic stale ballroom blintz	10	decent	
 2095	towel	0		
 2096	mixed shaking guy made of bee pollen	1		
 2097	perfumed 17-ball	0		Stench Resistance: +5
@@ -2100,7 +2100,7 @@
 2125	occult Ye Olde Navy Fleece	0		Spell Damage Percent: +25
 2126	jittery extremely unsafe Fonzie's bronze breastplate	0		Experience (Moxie): +1, Weapon Damage Percent: +100
 2127	blinking Usain Bolt's medical-grade hat hacker T-shirt	0		Initiative: +80, HP Regen Min: 7, HP Regen Max: 10
-2128	bouncing gray vampire collar	0		Single Equip
+2128	gray bouncing vampire collar	0		Single Equip
 2129	possessed top	0		Last Available: "2010-12"
 2130	killer rag doll of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12"
 2131	shaking tree-eating kite	0		Last Available: "2006-12"
@@ -2121,7 +2121,7 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	blue toothsome rock	0		
-2149	small bland blinking blurry frank	2	decent	Last Available: "2011-12"
+2149	bland small blurry blinking frank	2	decent	Last Available: "2011-12"
 2150	delicious super-sized plate of franks and beans	5	awesome	Last Available: "2011-12"
 2151	drinkable shot of blackberry schnapps	4	good	
 2152	capacitor relay	0		Last Available: "2011-12"
@@ -2161,16 +2161,16 @@
 2186	unlit birthday cake	0		
 2187	tumbling red lit birthday cake	0		
 2188	pulsating flask of peppermint oil	1	good	Last Available: "2006-12"
-2189	weak drinkable flask of peppermint schnapps	2	good	Last Available: "2006-12"
+2189	drinkable weak flask of peppermint schnapps	2	good	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	squat book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	enchanted adequate narrow ghostly candy stake	3	good	Effect: "The Q Is Talking To You", Effect Duration: 30, Last Available: "2006-12"
+2193	adequate enchanted narrow ghostly candy stake	3	good	Effect: "The Q Is Talking To You", Effect Duration: 30, Last Available: "2006-12"
 2194	aged wobbly eggnog	4	awesome	Last Available: "2006-12"
-2195	flavorless low-calorie jittery unspeakable fruitcake	1	decent	Last Available: "2006-12"
+2195	low-calorie flavorless jittery unspeakable fruitcake	1	decent	Last Available: "2006-12"
 2196	normal super-sized bouncing gingerbread horror	5	good	Last Available: "2006-12"
 2197	quantum maroon tumbling but probably evil chocolate	0		Effect: "Twen Tea", Effect Duration: 55, Last Available: "2006-12"
-2198	rotten special jittery bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	special rotten jittery bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	toothsome miniature skull-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	stale tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	wicked plastic gift-wrapping vampire	0		Spell Damage: +5, Last Available: "2006-12"
@@ -2178,7 +2178,7 @@
 2203	up-at-dawn plastic skeletal reindeer	0		Adventures: +5, Single Equip, Last Available: "2006-12"
 2204	curative plastic Crimboween pentagram	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2006-12"
 2205	mirror chaotic plastic Scream Queen	0		Spell Critical Percent: +10, Last Available: "2006-12"
-2206	jittery blurry time sleigh	0		Free Pull, Last Available: "2006-12"
+2206	blurry jittery time sleigh	0		Free Pull, Last Available: "2006-12"
 2207	steel-toed Crimbo tiki necklace	0		Damage Reduction: 9, Last Available: "2006-12"
 2208	nasty clever bobble-hip hula elf doll	0		Maximum MP: +20, Stench Damage: +5, Last Available: "2006-12"
 2209	Rosewater's Crimbo ukulele	0		Mysticality Percent: +30, Last Available: "2006-12"
@@ -2240,12 +2240,12 @@
 2266	spinning wet stunt nut stew	0		
 2267	narrow Mega Gem	0		
 2268	Staff of Fats of the storm	0		Maximum MP Percent: +40
-2269	half-sized normal sausage wonton	2	good	
+2269	normal half-sized sausage wonton	2	good	
 2270	deadly Fonzie's belt	0		Experience (Moxie): +1, Weapon Damage: +5, Single Equip
 2271	tolerable bottle of Merlot	4	good	
 2272	drinkable skewed purple bottle of Port	3	good	
 2273	mediocre bottle of Pinot Noir	3	decent	
-2274	mediocre triple-distilled bottle of Zinfandel	6	decent	
+2274	triple-distilled mediocre bottle of Zinfandel	6	decent	
 2275	lousy practically non-alcoholic bottle of Marsala	1	decent	
 2276	bad bottle of Muscat	4	decent	
 2277	twirling blinking Fernswarthy's key	0		
@@ -2257,7 +2257,7 @@
 2283	huge Lo Pan's seal-skull helmet	0		Spell Critical Percent: +30, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
 2285	huge chisel	0		
-2286	olive bouncing Eye of Ed	0		
+2286	bouncing olive Eye of Ed	0		
 2287	bouncing Annie Oakley's padded glowstick	0		Damage Absorption: +20, Critical Hit Percent: +20, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
 2289	paperclip	0		
@@ -2275,7 +2275,7 @@
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
 2303	skewed Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
-2304	non-deionized deionized huge yellow candy heart	0		Effect: "Creepin' Up on You", Effect Duration: 11, Last Available: "2007-02"
+2304	non-deionized deionized yellow huge candy heart	0		Effect: "Creepin' Up on You", Effect Duration: 11, Last Available: "2007-02"
 2305	altered improved warmed pink candy heart	0		Effect: "Bilious Brains", Effect Duration: 18, Last Available: "2007-02"
 2306	chilled enhanced candy heart	0		Effect: "Net Tea", Effect Duration: 60, Last Available: "2007-02"
 2307	concentrated super-chilled candy heart	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 43, Last Available: "2007-02"
@@ -2287,7 +2287,7 @@
 2313	wobbly candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
-2316	blurry blue broken carburetor	0		
+2316	blue blurry broken carburetor	0		
 2317	bronze token	0		
 2318	bomb	0		
 2319	pulsating carved wheel	0		
@@ -2311,8 +2311,8 @@
 2337	wizardly reinforced beaded headband	0		Mysticality: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	flavorless pudding	3	decent	Wiki Name: "black pudding (food)"
 2339	lousy tumbling Blackfly Chardonnay	3	decent	
-2340	watered-down lousy wobbly & tan	2	decent	
-2341	bouncing huge pepper	0		
+2340	lousy watered-down wobbly & tan	2	decent	
+2341	huge bouncing pepper	0		
 2342	diet normal forest cake	1	good	
 2343	spoiled forest ham	4	crappy	
 2344	nitrogenated filthworm hatchling scent gland	0		Effect: "Ripping, Dripping", Effect Duration: 57
@@ -2344,11 +2344,11 @@
 2370	natural fennel soda	0		
 2371	red smoke bomb	0		
 2372	bunch of bananas	0		
-2373	spoiled ghostly spinning banana	3	crappy	
+2373	spoiled spinning ghostly banana	3	crappy	
 2374	banana peel	0		
 2375	bland banana cream pie	3	decent	
 2376	acceptable banana daiquiri	3	good	
-2377	artisanal weak bungle in the jungle	2	super EPIC	
+2377	weak artisanal bungle in the jungle	2	super EPIC	
 2378	twirling banana spritzer	0		
 2379	polymerized enhanced spinning banana smoothie	0		Effect: "Holiday Disappointment", Effect Duration: 32
 2380	spinning dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2390,7 +2390,7 @@
 2416	teal bounty-hunting helmet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1.5xFairy, cap 25"
 2417	narrow weightlifter's bounty-hunting rifle	0		Muscle: +15
 2418	dog trainer's bounty-hunting pants	0		Experience (familiar): +1, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	warmed super-liquefied blurry ghostly yellow bottle of rhinoceros hormones	0		Effect: "Sweet Taste", Effect Duration: 20
+2419	warmed super-liquefied blurry yellow ghostly bottle of rhinoceros hormones	0		Effect: "Sweet Taste", Effect Duration: 20
 2420	concentrated blurry teeny-tiny magic scroll	0		Effect: "Booing Radly", Effect Duration: 29
 2421	deionized extra-oxidized bottle of pirate juice	0		Effect: "For Your Brain Only", Effect Duration: 24
 2422	frozen flattened irradiated pet snacks	0		Effect: "Coated Arms", Effect Duration: 32
@@ -2434,7 +2434,7 @@
 2460	cool yak toupee	0		Moxie: +5, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	blurry odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	miniature tasty bouncing bowl of Bounty-Os	2	awesome	
+2464	tasty miniature bouncing bowl of Bounty-Os	2	awesome	
 2465	artisanal Oreille Divis&eacute;e brandy	3	EPIC	
 2466	pompadour'd puppy	0		
 2467	twirling suede shoes	0		Familiar Weight: +5
@@ -2470,7 +2470,7 @@
 2497	ghostly gray molybdenum magnet	0		
 2498	skewed blinking molybdenum hammer	0		
 2499	huge molybdenum screwdriver	0		
-2500	lime green shaking molybdenum pliers	0		
+2500	shaking lime green molybdenum pliers	0		
 2501	narrow molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
@@ -2495,11 +2495,11 @@
 2522	tolerable thistle wine	4	good	
 2523	blue megatofu	0		
 2524	displaced fish	0		
-2525	decent diet fish	1	good	
-2526	big bland spinning fish casserole	5	decent	
+2525	diet decent fish	1	good	
+2526	bland big spinning fish casserole	5	decent	
 2527	bite-sized special flavorless fish lasagna	1	decent	Effect: "The Solution", Effect Duration: 40
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	flavorless bite-sized blinking maroon gnatloaf	1	decent	
+2529	flavorless bite-sized maroon blinking gnatloaf	1	decent	
 2530	delicious gnatloaf casserole	4	awesome	
 2531	snack-sized adequate yellow gnat lasagna	2	good	
 2532	squat pork	0		
@@ -2535,7 +2535,7 @@
 2562	upside-down half-rotten brain	0		
 2563	bonesaw	0		
 2564	maroon plus-sized phylactery	0		
-2565	blinking mirror can of Ghuol-B-Gone&trade;	0		
+2565	mirror blinking can of Ghuol-B-Gone&trade;	0		
 2566	squat teal Azazel's unicorn	0		
 2567	ghostly Azazel's lollipop	0		
 2568	Azazel's tutu	0		
@@ -2553,7 +2553,7 @@
 2580	shaking blinking perfumed scorpion whip of terror	0		Spooky Spell Damage: +10, Stench Resistance: +5
 2581	handful of sand	0		
 2582	upside-down brick of sand	0		
-2583	bite-sized normal centipede eggs	1	good	
+2583	normal bite-sized centipede eggs	1	good	
 2584	wonderwall shield of dire peril	0		Weapon Damage: +20, Damage Reduction: 12
 2585	twirling greedy Colonel Mustard's Lonely Spades Club Jacket	0		Meat Drop: +20
 2586	horrifying General Sage's Lonely Diamonds Club Jacket	0		Spooky Damage: +25
@@ -2566,8 +2566,8 @@
 2593	snack-sized stale squat Knob pasty	2	decent	
 2594	bad blinking thermos full of Knob coffee	3	decent	
 2595	colloidal super-irradiated Ben-Gal&trade; Balm	0		Effect: "Proprie Tea", Effect Duration: 51
-2596	blue pulsating leathery cat skin	0		
-2597	bouncing yellow leathery bat skin	0		
+2596	pulsating blue leathery cat skin	0		
+2597	yellow bouncing leathery bat skin	0		
 2598	leathery rat skin	0		
 2599	pulsating Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
@@ -2575,7 +2575,7 @@
 2602	tumbling nippy educational Staff of Blood and Pudding of the sweet-tooth	0		Experience: +1, Cold Damage: +10, Candy Drop: +100
 2603	cyan smoldering box	0		
 2604	smartaleck's Tuesday's ruby	0		Moxie Percent: +30
-2605	narrow lime green palm frond	0		
+2605	lime green narrow palm frond	0		
 2606	palm-frond fan	0		
 2607	Jim Carey's palm-frond whip	0		Monster Level: +25
 2608	palm-frond net	0		
@@ -2602,7 +2602,7 @@
 2629	tumbling gray zippy nasty tail o' nine cats	0		Stench Damage: +5, Initiative: +20
 2630	upside-down Hugo's Weaving Manual	0		
 2631	frozen quantum shaking gremlin juice	0		Effect: "Crotchety, Pining", Effect Duration: 32
-2632	deionized extra-galvanized double-boiled blue spinning mother's helper	0		Effect: "Sepia Tan", Effect Duration: 40
+2632	deionized extra-galvanized double-boiled spinning blue mother's helper	0		Effect: "Sepia Tan", Effect Duration: 40
 2633	lime green pat-a-cake pendant of the pedagogue of courage	0		Experience: +3, Spooky Resistance: +3
 2634	ghostly mummy wrapping	0		
 2635	twirling really thick bandage	0		
@@ -2622,13 +2622,13 @@
 2649	jittery Lord Spookyraven's ear trumpet of James Dean	0		Experience (Moxie): +3, Single Equip
 2650	tumbling bottled pixie	0		Free Pull
 2651	spinning pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	jumbo delicious fuchsia upside-down S.T.L.T.	5	awesome	Last Available: "2007-06"
+2652	delicious jumbo fuchsia upside-down S.T.L.T.	5	awesome	Last Available: "2007-06"
 2653	bland special honey-dew	4	decent	Effect: "Human-Machine Hybrid", Effect Duration: 15, Last Available: "2007-06"
 2654	hand-crafted Xanadian	4	EPIC	Last Available: "2007-06"
 2655	galvanized triple-tarnished anodized wobbly bottle of absinthe	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 45, Last Available: "2007-06"
 2656	coward's sinister Drowsy Sword	0		Spell Damage: +10, Monster Level: -20
 2657	small normal escargotsicle	2	good	Last Available: "2007-06"
-2658	drinkable weak ghostly bottle of realpagne	2	good	Last Available: "2007-06"
+2658	weak drinkable ghostly bottle of realpagne	2	good	Last Available: "2007-06"
 2659	chaotic albatross necklace	0		Spell Critical Percent: +10, Single Equip, Last Available: "2007-06"
 2660	diluted blurry not-a-pipe	1	good	Last Available: "2007-06"
 2661	artisanal weak flask of Amontillado	2	EPIC	Last Available: "2007-06"
@@ -2642,15 +2642,15 @@
 2669	boiled wobbly patent antipsychotics	1		Last Available: "2007-06"
 2670	denatured Mariner's Friend cough drops	1		Effect: "Nasty, Nasty Breath", Effect Duration: 45, Last Available: "2007-06"
 2671	drinkable shot of nepenthe schnapps	3	good	Last Available: "2007-06"
-2672	skewed mirror library card	0		Last Available: "2007-06"
+2672	mirror skewed library card	0		Last Available: "2007-06"
 2673	upside-down Bohemian rhapsody	0		Last Available: "2007-06"
-2674	electrified warmed spinning mirror teal bottle of cat tonic	0		Effect: "Spookypants", Effect Duration: 13, Last Available: "2007-06"
+2674	electrified warmed spinning teal mirror bottle of cat tonic	0		Effect: "Spookypants", Effect Duration: 13, Last Available: "2007-06"
 2675	twisted handful of moss	1		
 2676	twisted ghostly bit-o-cactus	1		
 2677	compressed jittery protein powder	1		
 2678	spectre scepter	0		
 2679	activated anodized ghostly sparkler	0		Effect: "Surreally Buff", Effect Duration: 28
-2680	denatured polarized lime green upside-down snake	0		Effect: "Disco Inferno", Effect Duration: 23, Wiki Name: "snake"
+2680	denatured polarized upside-down lime green snake	0		Effect: "Disco Inferno", Effect Duration: 23, Wiki Name: "snake"
 2681	modified deionized maroon M-242	0		Effect: "Cookie Backup", Effect Duration: 19
 2682	ghostly detuned radio	0		
 2683	huge pulsating Warehouse 23 crate	0		
@@ -2695,14 +2695,14 @@
 2722	energetic medical-grade strapping Staff of the Greasefire of temperance	0		Muscle: +5, Maximum MP Percent: +20, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10
 2723	dangerous boxer's Staff of the Grand Flamb&eacute; of the cheetah	0		Muscle Percent: +10, Weapon Damage: +10, Initiative: +60
 2724	tasty bowl of rye sprouts	3	awesome	
-2725	rotten miniature cob of corn	2	crappy	
+2725	miniature rotten cob of corn	2	crappy	
 2726	stale juniper berries	4	decent	
-2727	tiny spoiled bouncing plum	1	crappy	
+2727	spoiled tiny bouncing plum	1	crappy	
 2728	enchanted bland pear	3	decent	Effect: "Macho, Macho Dog", Effect Duration: 20
 2729	bland huge peach	3	decent	
 2730	watered-down artisanal plum wine	2	EPIC	
 2731	hand-crafted irresponsibly strong jittery shot of pear schnapps	8	EPIC	
-2732	drinkable strong shot of peach schnapps	5	good	
+2732	strong drinkable shot of peach schnapps	5	good	
 2733	stale bunch of square grapes	3	decent	
 2734	jumbo adequate twirling fuchsia brown sugar cane	5	good	
 2735	decent sandwich of the gods	3	good	
@@ -2803,7 +2803,7 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	enchanted bland digital key lime pie	3	decent	Effect: "Sparkly!", Effect Duration: 50
-2833	immense moldy star key lime pie	8	crappy	
+2833	moldy immense star key lime pie	8	crappy	
 2834	aromatic stiffened deadly bottle-rocket crossbow	0		Weapon Damage: +5, Damage Reduction: 1, Stench Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	bouncing smelly indie comic hipster glasses	0		Stench Spell Damage: +10, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2812,8 +2812,8 @@
 2839	ghostly frosty Periodical Paintbrush	0		Cold Spell Damage: +10, Softcore Only
 2840	drinkable bottle of cooking sherry	3	good	
 2841	spoiled huge packet of ketchup	3	crappy	
-2842	boozy bad purple accidental cider	5	decent	
-2843	stale thick dire fudgesicle	5	decent	
+2842	bad boozy purple accidental cider	5	decent	
+2843	thick stale dire fudgesicle	5	decent	
 2844	narrow veiny extremely unsafe supercool navel ring of navel gazing of the pedagogue	0		Moxie Percent: +20, Experience: +3, Weapon Damage Percent: +100, Maximum HP: +10, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	jittery class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2828,7 +2828,7 @@
 2855	pulsating dog trainer's huge mosquito proboscis of the brazier	0		Experience (familiar): +1, Hot Spell Damage: +25
 2856	nitrogenated double-aerosolized swamp lolly	0		Effect: "Virgo Rising", Effect Duration: 46
 2857	quantum shaking seegar butt	0		Effect: "Stimulated Brain", Effect Duration: 20
-2858	fuchsia pulsating bottled swamp gas	0		
+2858	pulsating fuchsia bottled swamp gas	0		
 2859	family-friendly veiny witch wart	0		Maximum HP: +10, Sleaze Resistance: +1
 2860	normal swamp muck	4	good	
 2861	flame-retardant scandalous coward's leechknife	0		Monster Level: -20, Sleaze Damage: +5, Hot Resistance: +1
@@ -2910,7 +2910,7 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	spinning Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	super-sized flavorless blurry Surprise Egg	5	decent	
+2940	flavorless super-sized blurry Surprise Egg	5	decent	
 2941	vacuum-sealed bouncing Steal This Candy	0		Effect: "Violent Night", Effect Duration: 18
 2942	oxidized ghostly upside-down chocolate filthy lucre	0		Effect: "Witch Breaded", Effect Duration: 44
 2943	super-altered fuchsia ghostly Angry Farmer's Wife Candy	0		Effect: "Fruited", Effect Duration: 50
@@ -2924,18 +2924,18 @@
 2952	skewed rosewater-soaked reassuring glowstick	0		Spooky Resistance: +1, Stench Resistance: +3, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	shellacked tip jar	0		Damage Reduction: 7
-2955	adequate half-sized yam candy	2	good	
+2955	half-sized adequate yam candy	2	good	
 2956	huge cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	huge rotten tube of cranberry Go-Goo	8	crappy	
+2958	rotten huge tube of cranberry Go-Goo	8	crappy	
 2959	skewed tumbling rum barrel charrrm bracelet of the empath	0		Familiar Weight: +5
-2960	rotten jumbo shaking single-serving herbal stuffing	5	crappy	
+2960	jumbo rotten shaking single-serving herbal stuffing	5	crappy	
 2961	thick normal tumbling packet of tofurkey gravy	5	good	
 2962	stale huge tofurkey nugget	4	decent	
 2963	mirror rigging shampoo	0		
 2964	ball polish	0		
 2965	gray mizzenmast mop	0		
-2966	gray skewed tumbling blinking Tom's of the Spanish Main Toothpaste	0		
+2966	gray blinking skewed tumbling Tom's of the Spanish Main Toothpaste	0		
 2967	flattened flattened Swabbie&trade; swab	0		Effect: "Boletus Swoletus", Effect Duration: 23
 2968	liquefied lime green Oil of Parrrlay	0		Effect: "Hennaliciousness", Effect Duration: 64
 2969	adequate snack-sized wobbly creamsicle	2	good	
@@ -2962,7 +2962,7 @@
 2990	blinking studded experienced clingfilm cap	0		Experience: +2, Damage Absorption: +80, Familiar Effect: "1xVolley, cap 37"
 2991	green chaotic clingfilm slippers	0		Spell Critical Percent: +10, Single Equip
 2992	clingfilm tangle	0		
-2993	snack-sized normal vinegar-soaked lemon slice	2	good	
+2993	normal snack-sized vinegar-soaked lemon slice	2	good	
 2994	enhanced vacuum-sealed true grit	0		Effect: "Feroci Tea", Effect Duration: 11
 2995	upside-down wizardly buoybottoms of the ox of mayonnaise	0		Muscle: +20, Mysticality: +25, Sleaze Spell Damage: +50, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	tumbling energetic grungy flannel shirt	0		Maximum MP Percent: +20
@@ -2984,7 +2984,7 @@
 3012	shimmering rainbow sand	0		
 3013	simple key	0		
 3014	ornate key	0		
-3015	pulsating spinning gilded key	0		
+3015	spinning pulsating gilded key	0		
 3016	foot locker	0		
 3017	bouncing ornate chest	0		
 3018	mirror gilded chest	0		
@@ -2999,26 +2999,26 @@
 3027	lousy corpsedriver	3	decent	
 3028	delicious narrow Corpse Island iced tea	3	awesome	
 3029	weak bad red-headed corpse	2	decent	
-3030	artisanal practically non-alcoholic kamicorpse-ee	1	super EPIC	
+3030	practically non-alcoholic artisanal kamicorpse-ee	1	super EPIC	
 3031	tolerable green corpsel	4	good	
-3032	artisanal watered-down fancy jittery corpsebite	2	EPIC	Effect: "Wet Rub", Effect Duration: 30
+3032	watered-down fancy artisanal jittery corpsebite	2	EPIC	Effect: "Wet Rub", Effect Duration: 30
 3033	blinking flame-retardant pirate fledges	0		Hot Resistance: +1
-3034	tumbling narrow piece of thirteen	0		
-3035	spoiled miniature pearl onion	2	crappy	
-3036	big adequate sea biscuit	5	good	
-3037	high-proof perfectly mixed bottle of rum	9	EPIC	
-3038	lousy practically non-alcoholic tumbling blinking bottle of black-label rum	1	decent	
+3034	narrow tumbling piece of thirteen	0		
+3035	miniature spoiled pearl onion	2	crappy	
+3036	adequate big sea biscuit	5	good	
+3037	perfectly mixed high-proof bottle of rum	9	EPIC	
+3038	practically non-alcoholic lousy blinking tumbling bottle of black-label rum	1	decent	
 3039	narrow cannonball	0		
 3040	voodoo skull	0		
 3041	twirling joke scroll	0		
 3042	shaking Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	spinning cyan metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	cyan spinning metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	moldy nanite-infested gingerbread bugbear	4	crappy	Last Available: "2007-12"
-3046	big special adequate nanite-infested candy cane	5	good	Effect: "Bolts about Candy", Effect Duration: 15, Last Available: "2020-09"
-3047	rotten fancy bite-sized nanite-infested fruitcake	1	crappy	Effect: "Dreadful Fear", Effect Duration: 45, Last Available: "2007-12"
-3048	practically non-alcoholic perfectly mixed mirror nanite-infested eggnog	1	super EPIC	Last Available: "2007-12"
-3049	fuchsia spinning El Vibrato power sphere	0		
+3046	special adequate big nanite-infested candy cane	5	good	Effect: "Bolts about Candy", Effect Duration: 15, Last Available: "2020-09"
+3047	rotten bite-sized fancy nanite-infested fruitcake	1	crappy	Effect: "Dreadful Fear", Effect Duration: 45, Last Available: "2007-12"
+3048	perfectly mixed practically non-alcoholic mirror nanite-infested eggnog	1	super EPIC	Last Available: "2007-12"
+3049	spinning fuchsia El Vibrato power sphere	0		
 3050	medical-grade eyepatch	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, 1xBarrr"
 3051	blurry sinister cutlass	0		Spell Damage: +10
 3052	breeches of wisdom	0		Mysticality: +15, Familiar Effect: "stench atk, 1xPotato"
@@ -3064,7 +3064,7 @@
 3092	arcane researcher's handmade hobby horse	0		Experience Percent (Mysticality): +10, Last Available: "2007-12"
 3093	ball-in-a-cup of the ox	0		Muscle: +20, Last Available: "2007-12"
 3094	fuchsia mirror set of jacks	0		Item Drop: +5, Last Available: "2007-12"
-3095	bite-sized toothsome laser-broiled pear	1	awesome	Last Available: "2007-12"
+3095	toothsome bite-sized laser-broiled pear	1	awesome	Last Available: "2007-12"
 3096	spinning wobbly auspicious lion tamer's polyalloy shield	0		Experience (familiar): +2, Item Drop: +10, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	gray killing feather	0		Last Available: "2007-12"
@@ -3087,7 +3087,7 @@
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	huge Hodgman	0		
 3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
-3118	jittery shaking maroon divine noisemaker	0		Last Available: "2008-01"
+3118	shaking maroon jittery divine noisemaker	0		Last Available: "2008-01"
 3119	blinking blinking divine can of silly string	0		Last Available: "2008-01"
 3120	twirling divine blowout	0		Last Available: "2008-01"
 3121	tumbling divine champagne popper	0		Last Available: "2008-01"
@@ -3135,9 +3135,9 @@
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	broken El Vibrato drone	0		
-3166	blurry shaking repaired El Vibrato drone	0		
+3166	shaking blurry repaired El Vibrato drone	0		
 3167	wobbly augmented El Vibrato drone	0		
-3168	galvanized ghostly squat shaking seal eyeball	0		Effect: "Cockroach Scurry", Effect Duration: 13
+3168	galvanized ghostly shaking squat seal eyeball	0		Effect: "Cockroach Scurry", Effect Duration: 13
 3169	stale twirling turtle soup	4	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
@@ -3146,20 +3146,20 @@
 3174	snack-sized moldy evil boring spaghetti	2	crappy	
 3175	spoiled maroon evil noodles	3	crappy	
 3176	flavorless evil noodles	4	decent	
-3177	half-sized flavorless evil painful penne pasta	2	decent	
+3177	flavorless half-sized evil painful penne pasta	2	decent	
 3178	adequate snack-sized 3vi1 pr0n m4nic0tti	2	good	
 3179	yummy mirror evil ravioli della hippy	4	awesome	
 3180	moldy evil noodles	3	crappy	
 3181	diffused activated modified olive evil potion of potency	0		Effect: "Disdain of She-Who-Was", Effect Duration: 29
-3182	chilled tumbling maroon evil libation of liveliness	0		Effect: "Wax On Your Shoes", Effect Duration: 19
+3182	chilled maroon tumbling evil libation of liveliness	0		Effect: "Wax On Your Shoes", Effect Duration: 19
 3183	Vulcanized narrow purple evil tomato juice of powerful power	0		Effect: "Phairly Balanced", Effect Duration: 11
 3184	pressed alkaline huge evil eyedrops of the ermine	0		Effect: "meat.enh", Effect Duration: 31
 3185	moist cyan evil ointment of the occult	0		Effect: "Stenchtastic", Effect Duration: 35
 3186	triple-moist magnetized spinning blurry evil serum of sarcasm	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 46
 3187	ionized triple-ionized evil philter of phorce	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 42
-3188	spirit-forward lousy an evil sump'm sump'm	5	decent	
+3188	lousy spirit-forward an evil sump'm sump'm	5	decent	
 3189	hand-crafted evil ducha de oro	3	EPIC	
-3190	fancy perfectly mixed extra-dry evil horizontal tango	5	EPIC	Effect: "Carrion' On", Effect Duration: 50
+3190	perfectly mixed extra-dry fancy evil horizontal tango	5	EPIC	Effect: "Carrion' On", Effect Duration: 50
 3191	extra-dry drinkable evil roll in the hay	5	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3181,7 +3181,7 @@
 3209	laminated card	0		
 3210	notbig laminated card	0		
 3211	unlarge laminated card	0		
-3212	pulsating mirror dwarvish document	0		
+3212	mirror pulsating dwarvish document	0		
 3213	dwarvish paper	0		
 3214	dwarvish parchment	0		
 3215	overcharged El Vibrato power sphere	0		
@@ -3211,7 +3211,7 @@
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	huge huge Travels with Jerry	0		Skill: "Mudbath"
-3242	twirling twirling wobbly Let Me Be!	0		Skill: "Raise Backup Dancer"
+3242	wobbly twirling twirling Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	upside-down Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	Summer Nights	0		Skill: "Grease Lightning"
 3245	Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
@@ -3235,7 +3235,7 @@
 3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	bouncing candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
-3266	squat twirling bag of Saccharine Maple saplings	0		
+3266	twirling squat bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	polymerized skewed handful of Crotchety Pine needles	0		Effect: "It's Electric!", Effect Duration: 39
 3269	denatured ionized enhanced huge lump of Saccharine Maple sap	0		Effect: "Feeling No Pain", Effect Duration: 53
@@ -3295,7 +3295,7 @@
 3323	ghostly Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	smooth jar of fermented pickle juice	3	awesome	
-3326	modified olive bouncing voodoo snuff	1	decent	Effect: "Total Protonic Reversal", Effect Duration: 15
+3326	modified bouncing olive voodoo snuff	1	decent	Effect: "Total Protonic Reversal", Effect Duration: 15
 3327	half-sized toothsome bouncing extra-greasy slider	2	awesome	
 3328	toasty smartaleck's crumpled felt fedora	0		Moxie Percent: +30, Hot Damage: +5, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	manspreader's fortified battered top-hat	0		Damage Absorption: +60, Monster Level: +10, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3318,7 +3318,7 @@
 3346	filth-encrusted futon	0		
 3347	comfy coffin	0		
 3348	mattress	0		
-3349	squat narrow dinged-up triangle	0		
+3349	narrow squat dinged-up triangle	0		
 3350	acceptable weak Ralph IX cognac	2	good	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
@@ -3333,7 +3333,7 @@
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	spoiled small mole mol&eacute;	2	crappy	Last Available: "2008-06"
-3364	distilled delicious skewed Morlock's Mark Bourbon	5	awesome	Last Available: "2008-06"
+3364	delicious distilled skewed Morlock's Mark Bourbon	5	awesome	Last Available: "2008-06"
 3365	triple-magnetized nitrogenated magnetized blue Climate Colada	0		Effect: "Certainty", Effect Duration: 21, Last Available: "2008-06"
 3366	adjusted denatured ghostly digital underground potion	0		Effect: "Disco Nirvana", Effect Duration: 31, Last Available: "2008-06"
 3367	narrow interesting-looking twig	0		Last Available: "2008-06"
@@ -3367,7 +3367,7 @@
 3395	spinning curative rosy-cheeked Hodgman's porkpie hat	0		Maximum HP Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	scorching careful Hodgman's lobsterskin pants	0		Monster Level: -10, Hot Damage: +25, Familiar Effect: "atk, 1xPotato"
 3397	Hodgman's bow tie of Tarzan of the storm	0		Experience (Muscle): +3, Maximum MP Percent: +40, Single Equip
-3398	perfectly mixed wobbly squat Hodgman's blanket	4	EPIC	
+3398	perfectly mixed squat wobbly Hodgman's blanket	4	EPIC	
 3399	hand-crafted tumbling jar of squeeze	3	super ultra EPIC	
 3400	snack-sized normal bowl of fishysoisse	2	good	
 3401	extra-corrupted deadly lampshade	0		Effect: "Musky", Effect Duration: 52
@@ -3382,7 +3382,7 @@
 3410	zippy Hodgman's detector	0		Initiative: +20
 3411	wobbly Fonzie's Hodgman's cane	0		Experience (Moxie): +1
 3412	Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
-3413	shaking olive mirror Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
+3413	mirror olive shaking Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
@@ -3424,10 +3424,10 @@
 3457	Junior Adventurer's merit badge of the sweet-tooth	0		Candy Drop: +100
 3458	corrupted cold-filtered blurry STYX deodorant body spray	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 48
 3459	bad white-label gin	3	decent	
-3460	bite-sized spoiled tin rations	1	crappy	
+3460	spoiled bite-sized tin rations	1	crappy	
 3461	blinking gray haiku challenge map	0		
 3462	terrible poem	0		
-3463	drinkable wobbly ghostly bottle of sake	4	good	
+3463	drinkable ghostly wobbly bottle of sake	4	good	
 3464	grievous round pebble	0		Weapon Damage Percent: +50
 3465	moldy Bash-&#332;s cereal	4	crappy	Wiki Name: "Bash-Os cereal"
 3466	vibrating smartaleck's sage haiku katana	0		Mysticality Percent: +10, Moxie Percent: +30, Maximum MP Percent: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
@@ -3441,7 +3441,7 @@
 3474	colloidal cranberry cordial	0		Effect: "Flame-Retardant Trousers", Effect Duration: 69
 3475	colloidal dry blackberry polite	0		Effect: "Heightened Senses", Effect Duration: 29
 3476	flattened blinking plum lozenge	0		Effect: "White Blooded", Effect Duration: 37
-3477	quadruple-dry triple-improved bouncing jittery pear lozenge	0		Effect: "Tightly-Wound Spine", Effect Duration: 26
+3477	quadruple-dry triple-improved jittery bouncing pear lozenge	0		Effect: "Tightly-Wound Spine", Effect Duration: 26
 3478	extra-irradiated peach lozenge	0		Effect: "Hopped Up on Goofballs", Effect Duration: 50
 3479	balloon shield	0		Damage Reduction: 3
 3480	spot	0		
@@ -3453,7 +3453,7 @@
 3486	squat dull fish scale	0		
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
-3489	enchanted normal beefy fish meat	4	good	Effect: "Fishy", Effect Duration: 5
+3489	normal enchanted beefy fish meat	4	good	Effect: "Fishy", Effect Duration: 5
 3490	miniature moldy skewed glistening fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3491	adequate slick fish meat	4	good	Effect: "Fishy", Effect Duration: 5
 3492	grievous fish scimitar of vim and vigor	0		Weapon Damage Percent: +50, Maximum HP Percent: +50
@@ -3484,7 +3484,7 @@
 3517	mirror gray gravedigger's eelskin hat	0		Spooky Damage: +10, Familiar Effect: "atk"
 3518	Rosewater's eelskin pants	0		Mysticality Percent: +30, Familiar Effect: "1xPotato, MP regen"
 3519	twirling eelskin shield of courage	0		Spooky Resistance: +3, Damage Reduction: 13
-3520	bouncing huge shark tooth	0		
+3520	huge bouncing shark tooth	0		
 3521	MacGyver's shark tooth necklace of the wise owl	0		Mysticality: +20, Maximum MP: +100, Single Equip
 3522	skewed forbidden shark jumper of incineration	0		Spell Damage Percent: +50, Hot Spell Damage: +50
 3523	quadruple-oxidized moist blurry lime green shark cartilage	0		Effect: "Woad Warrior", Effect Duration: 19
@@ -3530,12 +3530,12 @@
 3563	adjusted pressurized potion of pulchritude	0		Effect: "Vented Spleen", Effect Duration: 36
 3564	bad berry-infused sake	3	decent	
 3565	acceptable triple-distilled citrus-infused sake	6	good	
-3566	practically non-alcoholic aged huge melon-infused sake	1	awesome	
+3566	aged practically non-alcoholic huge melon-infused sake	1	awesome	
 3567	gray slab of sponge	0		
 3568	fireproof lion tamer's manspreader's sponge helmet	0		Monster Level: +10, Experience (familiar): +2, Hot Resistance: +3, Familiar Effect: "atk, 1xFairy"
 3569	wool smartaleck's spongy shield of the sewer	0		Moxie Percent: +30, Stench Damage: +25, Cold Resistance: +1, Damage Reduction: 14
 3570	mirror red baleful square sponge pants of the cheetah of the early riser	0		Spell Damage: +25, Initiative: +60, Adventures: +7, Familiar Effect: "hot atk, 1xPotato"
-3571	wobbly tumbling flytrap pellet	0		
+3571	tumbling wobbly flytrap pellet	0		
 3572	baby cuddlefish	0		
 3573	twirling six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
@@ -3557,7 +3557,7 @@
 3591	yellow shaking supercharged energetic Mer-kin hookspear	0		Maximum MP Percent: 50
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	blurry Mer-kin thingpouch	0		
-3594	spinning blue Mer-kin killscroll	0		
+3594	blue spinning Mer-kin killscroll	0		
 3595	concentrated Mer-kin fastjuice	0		Effect: "Uncaged Power", Effect Duration: 55
 3596	imitation crab crate	0		
 3597	imitation crab meat	0		
@@ -3585,7 +3585,7 @@
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	cyan pair of twitching claws	0		Last Available: "2008-12"
-3622	wobbly maroon gnashing teeth	0		Last Available: "2008-12"
+3622	maroon wobbly gnashing teeth	0		Last Available: "2008-12"
 3623	skewed chitinous pod	0		Last Available: "2008-12"
 3624	Herculean parasitic claw	0		Experience (Muscle): +1, Last Available: "2008-12"
 3625	flame-wreathed parasitic tentacles	0		Hot Spell Damage: +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
@@ -3608,13 +3608,13 @@
 3642	dragonfish caviar	0		
 3643	wobbly pufferfish spine	0		
 3644	bouncing manspreader's depleted Grimacite kneecapping stick	0		Monster Level: +10, Last Available: "2007-06"
-3645	drinkable practically non-alcoholic twirling canteen of wine	1	good	Last Available: "2008-12"
+3645	practically non-alcoholic drinkable twirling canteen of wine	1	good	Last Available: "2008-12"
 3646	normal mirror elven <i>limbos</i> gingerbread	4	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	purple map to Madness Reef	0		
 3650	bland toast with jam	3	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	tolerable elven moonshine	3	good	Last Available: "2008-12"
 3653	spoiled knuckle sandwich	3	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	tumbling lion tamer's psycho sweater of bravery	0		Experience (familiar): +2, Spooky Resistance: +5, Last Available: "2008-12"
@@ -3635,7 +3635,7 @@
 3669	fuchsia fortified glow-in-the-dark dart gun	0		Damage Absorption: +60, Last Available: "2009-01"
 3670	maroon wholesome glow-in-the-dark burrowgrub	0		Maximum HP Percent: +10, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	normal small narrow can of franks 'n' beans	2	good	Last Available: "2010-12"
+3672	small normal narrow can of franks 'n' beans	2	good	Last Available: "2010-12"
 3673	artisanal irresponsibly strong twirling bottle of peppermint schnapps	10	EPIC	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3647,15 +3647,15 @@
 3681	bubbling tempura batter	0		
 3682	upside-down globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	rotten small shaking pulsating tempura carrot	2	crappy	
+3684	rotten small pulsating shaking tempura carrot	2	crappy	
 3685	decent tempura cucumber	3	good	
-3686	super-sized rotten tempura avocado	5	crappy	
-3687	toothsome purple mirror sea broccoli	4	awesome	
+3686	rotten super-sized tempura avocado	5	crappy	
+3687	toothsome mirror purple sea broccoli	4	awesome	
 3688	spoiled snack-sized green sea cauliflower	2	crappy	
 3689	spoiled purple tempura broccoli	3	crappy	
-3690	huge stale squat tempura cauliflower	6	decent	
-3691	massive flavorless ghostly sea blueberry	10	decent	
-3692	spoiled low-calorie tumbling sea persimmon	1	crappy	
+3690	stale huge squat tempura cauliflower	6	decent	
+3691	flavorless massive ghostly sea blueberry	10	decent	
+3692	low-calorie spoiled tumbling sea persimmon	1	crappy	
 3693	double-improved blinking pressurized potion of perception	0		Effect: "Feline Ferocity", Effect Duration: 21
 3694	altered green pressurized potion of proficiency	0		Effect: "Blackberry Politeness", Effect Duration: 24
 3695	wobbly beefy Mer-kin digpick	0		Muscle: +10
@@ -3728,10 +3728,10 @@
 3764	hand-crafted slug of rum	4	EPIC	
 3765	triple-distilled aged slug of shochu	8	awesome	
 3766	drinkable screwdiver	3	good	
-3767	tolerable triple-distilled tumbling dew yoana lei	7	good	
+3767	triple-distilled tolerable tumbling dew yoana lei	7	good	
 3768	drinkable huge lychee chuhai	3	good	
 3769	hand-crafted triple-distilled huge salacious screwdiver	8	EPIC	
-3770	perfectly mixed practically non-alcoholic blinking dew yoana salacious lei	1	super ultra mega turbo EPIC	
+3770	practically non-alcoholic perfectly mixed blinking dew yoana salacious lei	1	super ultra mega turbo EPIC	
 3771	perfectly mixed salacious lychee chuhai	3	EPIC	
 3772	mediocre ghostly Alewife&trade; Ale	4	decent	
 3773	squat seaode	0		
@@ -3749,7 +3749,7 @@
 3785	smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
 3787	blinking wine-soaked bone chips	0		Class: "Pastamancer"
-3788	blurry maroon crumbling rat skull	0		Class: "Pastamancer"
+3788	maroon blurry crumbling rat skull	0		Class: "Pastamancer"
 3789	cyan spinning twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	skewed aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
@@ -3759,14 +3759,14 @@
 3804	tumbling prompt Samson's Mer-kin breastplate	0		Experience (Muscle): +5, Adventures: +3
 3805	skewed Lo Pan's Mer-kin sneakmask of chilblains	0		Spell Critical Percent: +30, Cold Damage: +25, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
-3807	corrupted pulsating mirror Mer-kin hidepaint	0		Effect: "Good with the Ladies", Effect Duration: 62
+3807	corrupted mirror pulsating Mer-kin hidepaint	0		Effect: "Good with the Ladies", Effect Duration: 62
 3808	spinning Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
 3812	low-calorie spoiled chocolate-frosted king cake	1	crappy	Last Available: "2009-06"
 3813	beefcake's plastic baby	0		Muscle: +25, Single Equip, Last Available: "2009-06"
-3815	tumbling blurry midget clownfish	0		
+3815	blurry tumbling midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
 3817	adequate jumbo sea radish	5	good	
 3818	blurry lightning-fast dog trainer's resourceful halibut	0		Maximum MP: +50, Experience (familiar): +1, Initiative: +40
@@ -3776,16 +3776,16 @@
 3822	huge tumbling wand	0		Familiar Effect: "fishy spells"
 3823	vacuum-sealed ghostly wad of cotton	0		Effect: "You Read The Manual", Effect Duration: 27
 3824	Grandma's Note	0		
-3825	ghostly fuchsia Grandma's Fuchsia Yarn	0		
+3825	fuchsia ghostly Grandma's Fuchsia Yarn	0		
 3826	mirror ghostly Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	flavorless huge tempura radish	8	decent	
+3829	huge flavorless tempura radish	8	decent	
 3830	water-polo cap of wisdom	0		Mysticality: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable watered-down Typical Tavern swill	2	good	
 3832	bad teal tropical swill	3	decent	
-3833	boozy enchanted delicious blurry fruity girl swill	5	awesome	Effect: "Libra Rising", Effect Duration: 50
-3834	lousy weak blended swill	2	decent	
+3833	enchanted boozy delicious blurry fruity girl swill	5	awesome	Effect: "Libra Rising", Effect Duration: 50
+3834	weak lousy blended swill	2	decent	
 3835	costume wardrobe	0		Softcore Only
 3836	steel-toed Elvish sunglasses of the storm of courage of the boozehound	0		Damage Reduction: 9, Maximum MP Percent: +40, Spooky Resistance: +3, Booze Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	Socratic anniversary safety glass vest	0		Experience (Mysticality): +1
@@ -3843,10 +3843,10 @@
 3889	pickled enhanced wobbly gray blinking vial of slime	0		Effect: "Dragged Through the Coals", Effect Duration: 49
 3890	triple-galvanized colloidal narrow vial of violet slime	0		Effect: "Incredibly Hulking", Effect Duration: 49
 3891	tarnished vial of vermilion slime	0		Effect: "Jungle Juiced", Effect Duration: 16
-3892	aerosolized fuchsia bouncing vial of amber slime	0		Effect: "Super-Electrified", Effect Duration: 68
+3892	aerosolized bouncing fuchsia vial of amber slime	0		Effect: "Super-Electrified", Effect Duration: 68
 3893	energized jittery vial of chartreuse slime	0		Effect: "Hoity Toity", Effect Duration: 60
 3894	triple-modified vial of teal slime	0		Effect: "Brain Freeze", Effect Duration: 27
-3895	galvanized maroon skewed ghostly vial of indigo slime	0		Effect: "Inner Dog", Effect Duration: 17
+3895	galvanized ghostly skewed maroon vial of indigo slime	0		Effect: "Inner Dog", Effect Duration: 17
 3896	corrupted electrified squat vial of slime	0		Effect: "Really Deep Breath", Effect Duration: 27
 3897	double-cold-filtered enhanced vial of brown slime	0		Effect: "Well-preserved", Effect Duration: 21
 3898	bottle of G&uuml;-Gone	0		
@@ -3854,7 +3854,7 @@
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
-3905	squat blinking lime green figurine of an seal	0		Class: "Seal Clubber"
+3905	lime green blinking squat figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	blurry figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	wobbly figurine of a stinking seal	0		Class: "Seal Clubber"
@@ -3885,7 +3885,7 @@
 3933	extremely unsafe bad-ass club of the overflowing toilet	0		Weapon Damage Percent: +100, Stench Spell Damage: +50, Class: "Seal Clubber"
 3934	squat sealbone	0		
 3935	modified chilled hyperinflated seal lung	0		Effect: "Full of Vinegar", Effect Duration: 35
-3936	super-boiled enhanced maroon squat scrap of shadow	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 23
+3936	super-boiled enhanced squat maroon scrap of shadow	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 23
 3937	ionized squat squat fustulent seal grulch	0		Effect: "Barking Mad", Effect Duration: 22
 3938	chilly club of corruption	0		Cold Damage: +5, Class: "Seal Clubber"
 3939	corrupt club of corruption of the wise owl	0		Mysticality: +20, Class: "Seal Clubber"
@@ -3946,7 +3946,7 @@
 3994	security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
 3996	narrow boxcar turtle	0		
-3997	maroon spinning dolphin whistle	0		
+3997	spinning maroon dolphin whistle	0		
 3998	metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -3962,7 +3962,7 @@
 4010	memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	memory of a CG base pair	0		Last Available: "2009-06"
-4013	squat shaking memory of a CT base pair	0		Last Available: "2009-06"
+4013	shaking squat memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	bouncing memory of an AT base pair	0		Last Available: "2009-06"
 4016	ghostly memory of a GT base pair	0		Last Available: "2009-06"
@@ -3980,13 +3980,13 @@
 4028	frosty Van der Graaf club of Flo-Jo	0		Cold Spell Damage: +10, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7
 4029	shaking memory of a grappling hook	0		Last Available: "2009-06"
 4030	memory of a small stone block	0		Last Available: "2009-06"
-4031	spinning narrow memory of a stone block	0		Last Available: "2009-06"
+4031	narrow spinning memory of a stone block	0		Last Available: "2009-06"
 4032	upside-down memory of half a stone circle	0		Last Available: "2009-06"
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	shaking memory of a crystal	0		Last Available: "2009-06"
 4036	pulsating caustic slime nodule	0		
-4037	huge decent slimy sweetbreads	6	good	
+4037	decent huge slimy sweetbreads	6	good	
 4038	bad irresponsibly strong mirror slimy fermented bile bladder	10	decent	
 4039	altered slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
@@ -4015,7 +4015,7 @@
 4063	tumbling Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
-4066	fuchsia tumbling Ruby Rod	0		Last Available: "2009-06"
+4066	tumbling fuchsia Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	ghostly essence of kink	0		Last Available: "2009-06"
 4069	spinning essence of	0		Last Available: "2009-06"
@@ -4109,7 +4109,7 @@
 4157	gravel	0		Last Available: "2009-09"
 4158	skewed rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	practically non-alcoholic enchanted tolerable pebblebr&auml;u	1	good	Effect: "Starry-Eyed", Effect Duration: 20, Last Available: "2009-09"
+4160	enchanted practically non-alcoholic tolerable pebblebr&auml;u	1	good	Effect: "Starry-Eyed", Effect Duration: 20, Last Available: "2009-09"
 4161	rotten rocky road ice cream	3	crappy	Last Available: "2009-09"
 4162	wobbly extra-strength rubber bands	0		Familiar Weight: +5
 4163	warmed warmed skewed children of the candy corn	0		Effect: "Super Accuracy", Effect Duration: 58
@@ -4132,7 +4132,7 @@
 4180	sizzling sugar shank	0		Hot Damage: +10, Last Available: "2009-09"
 4181	auspicious curative sugar chapeau of James Dean	0		Experience (Moxie): +3, Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
 4182	baleful sugar shorts	0		Spell Damage: +25, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
-4183	fuchsia twirling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4183	twirling fuchsia sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	squat slime convention flyers	0		
 4186	slime convention coupons	0		
@@ -4166,7 +4166,7 @@
 4214	spinning spangly unitard	0		
 4215	squat zippy lion tamer's collapsible baton	0		Experience (familiar): +2, Initiative: +20
 4216	groupie lipstick	0		
-4217	yellow mirror groupie bra	0		
+4217	mirror yellow groupie bra	0		
 4218	tarnished ionized red groupie spangles	0		Effect: "Hippy Flavor", Effect Duration: 62
 4219	asbestos-lined dog trainer's skate board	0		Experience (familiar): +1, Hot Resistance: +5
 4220	S.A.V.E. flyer	0		
@@ -4187,17 +4187,17 @@
 4235	salt-shaker	0		
 4236	pulsating can of sterno	0		
 4237	cyan cheese-slicer of the detective	0		Item Drop: +20
-4238	spoiled super-sized beef jerky	5	crappy	
+4238	super-sized spoiled beef jerky	5	crappy	
 4239	miser's pipe wrench	0		Meat Drop: +10
-4240	extra-quantum boiled blue tumbling gun cleaning kit	0		Effect: "Slippery Tongue", Effect Duration: 30
+4240	extra-quantum boiled tumbling blue gun cleaning kit	0		Effect: "Slippery Tongue", Effect Duration: 30
 4241	baleful sleep mask	0		Spell Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	greedy sock garters	0		Meat Drop: +20, Single Equip
 4243	ionized bouncing mariachi toothpaste	0		Effect: "Inebriate Pride", Effect Duration: 13
 4244	jittery spinning leather-bound tome of Calamity Jane	0		Critical Hit Percent: +15
 4245	narrow bookmark	0		
 4246	electrified ivory cue ball	0		MP Regen Min: 3, MP Regen Max: 5
-4247	delicious weak maroon tumbling decanter of fine Scotch	2	awesome	
-4248	diluted squat spinning red expensive cigar	1		Effect: "Macho Profundo", Effect Duration: 35
+4247	delicious weak tumbling maroon decanter of fine Scotch	2	awesome	
+4248	diluted red spinning squat expensive cigar	1		Effect: "Macho Profundo", Effect Duration: 35
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
@@ -4207,7 +4207,7 @@
 4255	bouncing Wolfman Nardz	0		Last Available: "2009-10"
 4256	boiled sap	0		Effect: "Brother Corsican's Blessing", Effect Duration: 27, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	massive yummy upside-down chocolate-covered scarab beetle	9	awesome	Last Available: "2009-10"
+4258	yummy massive upside-down chocolate-covered scarab beetle	9	awesome	Last Available: "2009-10"
 4259	practically non-alcoholic smooth tumbling mulled cider	1	awesome	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4282,7 +4282,7 @@
 4330	decent narrow green candy kneecapping stick	3	good	Last Available: "2009-12"
 4331	rotten licorice garrote	4	crappy	Last Available: "2009-12"
 4332	brawny candy knuckles	0		Muscle Percent: +20, Last Available: "2009-12"
-4333	diet moldy green jawbruiser	1	crappy	Last Available: "2010-12"
+4333	moldy diet green jawbruiser	1	crappy	Last Available: "2010-12"
 4334	ionized wobbly jittery chocolate car	0		Effect: "damage.enh", Effect Duration: 48, Last Available: "2009-12"
 4335	squat plastic 11 Dealer of incineration	0		Hot Spell Damage: +50, Last Available: "2009-12"
 4336	chaotic plastic Crimbo Casino	0		Spell Critical Percent: +10, Last Available: "2009-12"
@@ -4294,7 +4294,7 @@
 4342	energized liquefied Polka Pop	0		Effect: "Burning Tongue", Effect Duration: 53, Last Available: "2009-12"
 4343	upside-down Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
-4345	green blinking string of Crimbo lights	0		Last Available: "2009-12"
+4345	blinking green string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	squat gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
@@ -4309,11 +4309,11 @@
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	upside-down A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	adequate fancy half-sized pulsating tumbling expired can of franks 'n' beans	2	good	Effect: "Barbecue Saucy", Effect Duration: 45, Last Available: "2009-12"
+4360	half-sized fancy adequate pulsating tumbling expired can of franks 'n' beans	2	good	Effect: "Barbecue Saucy", Effect Duration: 45, Last Available: "2009-12"
 4361	distilled artisanal expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
 4362	squat snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
-4364	concentrated blinking red elven suicide capsule	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2009-12"
+4364	concentrated red blinking elven suicide capsule	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2009-12"
 4365	thick tasty penguin focaccia bread	5	awesome	Last Available: "2009-12"
 4366	smooth weak herringcello	2	awesome	Last Available: "2009-12"
 4367	mediocre huge elven cellocello	3	decent	Last Available: "2009-12"
@@ -4342,7 +4342,7 @@
 4390	rosewater-soaked double-paned Red Rover BB gun	0		Cold Resistance: +5, Stench Resistance: +3, Last Available: "2009-12"
 4391	red-and-green sweater of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
-4393	concentrated adjusted ghostly squat Crimbo peppermint bark	0		Effect: "Analog Drunk", Effect Duration: 11, Last Available: "2009-12"
+4393	concentrated adjusted squat ghostly Crimbo peppermint bark	0		Effect: "Analog Drunk", Effect Duration: 11, Last Available: "2009-12"
 4394	vacuum-sealed Crimbo fudge	0		Effect: "Egged On", Effect Duration: 68, Last Available: "2009-12"
 4395	adjusted quadruple-altered triple-wet spinning Crimbo pecan	0		Effect: "Bone Chilling", Effect Duration: 34, Last Available: "2009-12"
 4396	bouncing Jack-in-the-box	0		Last Available: "2009-12"
@@ -4384,7 +4384,7 @@
 4434	energized dry irritability potion	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 18, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	mirror hellseal whisker	0		
-4439	spinning yellow hellseal claw	0		
+4439	yellow spinning hellseal claw	0		
 4440	cyan upside-down wholesome guard turtle shell	0		Maximum HP Percent: +10, Familiar Effect: "atk, 1xFairy, cap 40"
 4441	lime green lightning-fast crowbar	0		Initiative: +40
 4442	up-at-dawn spaghetti cult rosary	0		Adventures: +5
@@ -4393,7 +4393,7 @@
 4445	mirror occult spangly mariachi pants	0		Spell Damage Percent: +25, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	brainy spangly mariachi vest of Gandalf	0		Mysticality: +5, Spell Critical Percent: +20
 4447	blurry baleful spangly sombrero	0		Spell Damage: +25, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	mixed fuchsia twirling huge Instant Karma	1	decent	
+4448	mixed twirling huge fuchsia Instant Karma	1	decent	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	skewed map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	thinker's pointy hat	0		Mysticality: +10, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
@@ -4425,7 +4425,7 @@
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	twirling BRICKO elephant	0		Last Available: "2010-02"
 4479	pulsating blinking BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
-4480	spinning blurry BRICKO python	0		Last Available: "2010-02"
+4480	blurry spinning BRICKO python	0		Last Available: "2010-02"
 4481	twirling BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
 4483	lime green BRICKO cathedral	0		Last Available: "2010-02"
@@ -4437,7 +4437,7 @@
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	twirling BRICKO brick	0		Last Available: "2010-02"
-4492	upside-down lime green BRICKO brick	0		Last Available: "2010-02"
+4492	lime green upside-down BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
 4494	skewed BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
@@ -4445,7 +4445,7 @@
 4497	quantum improved lime green recording of The Ballad of Richie Thingfinder	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 60
 4498	altered moist recording of Benetton's Medley of Diversity	0		Effect: "Adventurer's Best Friendship", Effect Duration: 67
 4499	activated recording of Elron's Explosive Etude	0		Effect: "The Grass...  Is Blue...", Effect Duration: 21
-4500	alkaline alkaline huge blinking recording of Chorale of Companionship	0		Effect: "Human-Fish Hybrid", Effect Duration: 40
+4500	alkaline alkaline blinking huge recording of Chorale of Companionship	0		Effect: "Human-Fish Hybrid", Effect Duration: 40
 4501	cold-filtered polarized mirror recording of Prelude of Precision	0		Effect: "Meat the Flintstones", Effect Duration: 45
 4502	denatured shaking recording of Donho's Bubbly Ballad	0		Effect: "Fungal Fortification", Effect Duration: 50
 4503	dry wet squat recording of Inigo's Incantation of Inspiration	0		Effect: "Phairly Balanced", Effect Duration: 56, Last Available: "2010-02"
@@ -4453,7 +4453,7 @@
 4505	magnetized ionized upside-down Northern pemmican	0		Effect: "Square to be Hip", Effect Duration: 63
 4506	puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	Vulcanized activated narrow blue &quot;DRINK ME&quot; potion	0		Effect: "Bilious Brawn", Effect Duration: 44, Last Available: "2010-03"
+4508	Vulcanized activated blue narrow &quot;DRINK ME&quot; potion	0		Effect: "Bilious Brawn", Effect Duration: 44, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	decent walrus ice cream	4	good	Last Available: "2010-03"
 4511	delicious half-sized beautiful soup	2	awesome	Last Available: "2010-03"
@@ -4470,15 +4470,15 @@
 4522	Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	upside-down hardy grievous eye of the Tiger-lily	0		Weapon Damage Percent: +50, Maximum HP: +50, Last Available: "2010-03"
 4524	steel-toed educational wig	0		Experience: +1, Damage Reduction: 9, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	adequate thick blue twirling donut	5	good	Last Available: "2010-03"
-4526	bland miniature bucket of honey	2	decent	Last Available: "2010-03"
+4525	adequate thick twirling blue donut	5	good	Last Available: "2010-03"
+4526	miniature bland bucket of honey	2	decent	Last Available: "2010-03"
 4527	purple mirror chaotic hardy elephant stinger	0		Maximum HP: +50, Spell Critical Percent: +10, Last Available: "2010-03"
-4528	stale low-calorie dragon snaps	1	decent	Last Available: "2010-03"
+4528	low-calorie stale dragon snaps	1	decent	Last Available: "2010-03"
 4529	Socratic boxer's snapdragon pistil	0		Muscle Percent: +10, Experience (Mysticality): +1, Last Available: "2010-03"
 4530	twirling puff of smoke	0		Last Available: "2010-03"
-4531	snack-sized moldy squat rook cookie	2	crappy	Last Available: "2010-03"
-4532	super-sized enchanted adequate bishop cookie	5	good	Effect: "Celestial Body", Effect Duration: 50, Last Available: "2010-03"
-4533	super-sized yummy knight cookie	5	awesome	Last Available: "2010-03"
+4531	moldy snack-sized squat rook cookie	2	crappy	Last Available: "2010-03"
+4532	super-sized adequate enchanted bishop cookie	5	good	Effect: "Celestial Body", Effect Duration: 50, Last Available: "2010-03"
+4533	yummy super-sized knight cookie	5	awesome	Last Available: "2010-03"
 4534	rotten gigantic skewed skewed king cookie	7	crappy	Last Available: "2010-03"
 4535	flavorless queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	mirror fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4513,7 +4513,7 @@
 4565	stale huge raisin	8	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	squat twirling careful Annie Oakley's flyest of shirts	0		Critical Hit Percent: +20, Monster Level: -10, Last Available: "2010-04"
-4568	moldy jumbo a dance upon the palate	5	crappy	Last Available: "2010-04"
+4568	jumbo moldy a dance upon the palate	5	crappy	Last Available: "2010-04"
 4569	huge spoiled prehistoric meteorite jawbreaker	7	crappy	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	bland squirmy violent party snack	4	decent	Last Available: "2010-04"
@@ -4531,7 +4531,7 @@
 4583	olive glob of skin	0		
 4584	moldy six wedges of goat cheese	4	crappy	
 4585	collection of objects	0		
-4586	wobbly shaking boulder	0		
+4586	shaking wobbly boulder	0		
 4587	goth	0		
 4588	brown pixel	0		
 4589	up-at-dawn pixel whip	0		Adventures: +5
@@ -4551,9 +4551,9 @@
 4603	blurry bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	arcane researcher's bottle of Goldschn&ouml;ckered of vim and vigor	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +50, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	bland tiny sun-dried tofu	1	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	tiny bland sun-dried tofu	1	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	perfectly mixed spinning soyburger juice	3	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4608	narrow mirror respected companion biscuit	0		Last Available: "2010-08"
+4608	mirror narrow respected companion biscuit	0		Last Available: "2010-08"
 4609	lime green essential tofu	0		Last Available: "2010-08"
 4610	corrupted quantum double-frozen essential soy	0		Effect: "Wax On Your Shoes", Effect Duration: 34, Last Available: "2010-08"
 4611	nitrogenated alkaline quadruple-energized essential cameraderie	0		Effect: "Cute Vision", Effect Duration: 41, Last Available: "2010-08"
@@ -4563,15 +4563,15 @@
 4615	perfectly mixed practically non-alcoholic blinking Cinco Mayo Lager	1	super ultra mega turbo EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
-4618	spinning mirror plastic cup of flat beer	0		
-4619	teal spinning frisbee	0		Free Pull, Last Available: "2011-12"
+4618	mirror spinning plastic cup of flat beer	0		
+4619	spinning teal frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	boiled polarized chocolate-covered caviar	0		Effect: "Enraged", Effect Duration: 34, Last Available: "2020-09"
 4624	moldy purple pawn cookie	4	crappy	Last Available: "2010-06"
 4625	modified coffee pixie stick	1	good	Last Available: "2010-06"
-4626	lime green twirling mirror superduperball	0		Last Available: "2010-06"
+4626	mirror twirling lime green superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	squat parachute guy	0		Last Available: "2010-06"
 4629	scandalous plastic spider ring	0		Sleaze Damage: +5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
@@ -4595,7 +4595,7 @@
 4647	lime green crafty Samson's groovy Dungeon Fist gauntlet	0		Moxie Percent: +10, Experience (Muscle): +5, Maximum MP: +10, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
 4649	blurry chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	mirror gray fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4650	gray mirror fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	brainy ironic knit cap of the overflowing toilet	0		Mysticality: +5, Stench Spell Damage: +50, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	purple ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	blue blackberry galoshes of the scaredy-cat	0		Monster Level: -15, Single Equip
 4660	squat savvy strapping trout fang	0		Muscle: +5, Mysticality Percent: +20, Last Available: "2010-09"
-4661	thick adequate poisonous caviar	5	good	Last Available: "2010-09"
+4661	adequate thick poisonous caviar	5	good	Last Available: "2010-09"
 4662	ionized tumbling wet venom duct	0		Effect: "Dexteri Tea", Effect Duration: 66, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	brainy Ellsbury's skull of courage	0		Mysticality: +5, Spooky Resistance: +3, Last Available: "2010-09"
@@ -4615,7 +4615,7 @@
 4667	clever Victor, the Insult Comic Hellhound Puppet	0		Maximum MP: +20
 4668	coward's observational glasses	0		Monster Level: -20
 4669	healthy hilarious comedy prop	0		Maximum HP Percent: +20
-4670	blinking mirror beer-scented teddy bear	0		
+4670	mirror blinking beer-scented teddy bear	0		
 4671	practically non-alcoholic drinkable booze-soaked cherry	1	good	
 4672	comfy pillow	0		
 4673	adequate low-calorie marshmallow	1	good	
@@ -4659,15 +4659,15 @@
 4711	lime green sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	half-sized decent lemon popsicle	2	good	
+4714	decent half-sized lemon popsicle	2	good	
 4715	yummy spinning popsicle	4	awesome	
-4716	snack-sized normal strawberry popsicle	2	good	
+4716	normal snack-sized strawberry popsicle	2	good	
 4717	adequate super-sized liver popsicle	5	good	
 4718	wholesome mariachi hat	0		Maximum HP Percent: +10, Familiar Effect: "atk, cap 2"
 4719	mansplainer's Hollandaise helmet	0		Monster Level: +15, Familiar Effect: "atk, cap 2"
 4720	wobbly organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	snack-sized enchanted flavorless liver and let pie	2	decent	Effect: "Salamander In Your Stomach", Effect Duration: 25, Last Available: "2010-10"
+4722	flavorless enchanted snack-sized liver and let pie	2	decent	Effect: "Salamander In Your Stomach", Effect Duration: 25, Last Available: "2010-10"
 4723	normal ghostly badass pie	3	good	Last Available: "2010-10"
 4724	bland shoo-fish pie	3	decent	Last Available: "2010-10"
 4725	normal diet piping organ pie	1	good	Last Available: "2010-10"
@@ -4678,13 +4678,13 @@
 4730	weightlifter's stop shield	0		Muscle: +15, Damage Reduction: 6, Last Available: "2009-12"
 4731	jittery pulsating nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
-4733	wobbly jittery kitty sheet music	0		Familiar Weight: +5
+4733	jittery wobbly kitty sheet music	0		Familiar Weight: +5
 4734	rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	twirling prop sword	0		Familiar Weight: +5
 4736	twirling tangle of rat tails	0		
 4737	lime green upside-down fireproof beer-soaked mop	0		Hot Resistance: +3
-4738	watered-down acceptable day-old beer	2	good	
-4739	extra-dry delicious bouncing plain beer	5	awesome	
+4738	acceptable watered-down day-old beer	2	good	
+4739	delicious extra-dry bouncing plain beer	5	awesome	
 4740	delicious overpriced &quot;imported&quot; beer	3	awesome	
 4741	smiling rat	0		
 4742	spinning rat tooth polish	0		Familiar Weight: +5
@@ -4708,7 +4708,7 @@
 4760	shaking packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	mirror huge pumpkin	0		Last Available: "2010-11"
-4763	snack-sized moldy blurry pumpkin pie	2	crappy	Last Available: "2010-11"
+4763	moldy snack-sized blurry pumpkin pie	2	crappy	Last Available: "2010-11"
 4764	mediocre pumpkin beer	3	decent	Last Available: "2010-11"
 4765	tarnished modified ghostly pumpkin juice	0		Effect: "Mayeaugh", Effect Duration: 52, Last Available: "2010-11"
 4766	blinking pumpkin bomb	0		Last Available: "2010-11"
@@ -4726,7 +4726,7 @@
 4812	blinking Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	moldy spinning shaking CRIMBCOIDS mints	4	crappy	Last Available: "2011-01"
 4819	blinking can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	super-sized spoiled CRIMBCOLOAF	5	crappy	Last Available: "2011-01"
+4820	spoiled super-sized CRIMBCOLOAF	5	crappy	Last Available: "2011-01"
 4821	decent narrow circular CRIMBCOOKIE	4	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	blue thinker's plastic CRIMBCO HQ	0		Mysticality: +10, Last Available: "2010-12"
 4823	red ghostly coward's plastic fax machine	0		Monster Level: -20, Last Available: "2010-12"
@@ -4736,14 +4736,14 @@
 4827	hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
-4830	bouncing shaking robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
+4830	shaking bouncing robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	bouncing robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	blurry robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	upside-down squat robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	squat upside-down robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	wobbly robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	bland triangular CRIMBCOOKIE	4	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	decent low-calorie jittery square CRIMBCOOKIE	1	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
@@ -4761,7 +4761,7 @@
 4852	stiffened gift-a-pult	0		Damage Reduction: 1, Last Available: "2010-12"
 4853	vacuum-sealed liquefied holly-flavored Hob-O	0		Effect: "Gutterminded", Effect Duration: 21, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
-4855	mirror tumbling Toot Oriole care package	0		
+4855	tumbling mirror Toot Oriole care package	0		
 4856	pulsating paperclip	0		Last Available: "2011-01"
 4857	huge bottle of Blank-Out	0		Last Available: "2011-01"
 4858	squat censurious CRIMBCO lanyard	0		Sleaze Resistance: +3, Single Equip, Last Available: "2011-01"
@@ -4781,23 +4781,23 @@
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	mirror twirling photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
-4875	narrow olive BGE merchandise order form	0		Last Available: "2010-12"
+4875	olive narrow BGE merchandise order form	0		Last Available: "2010-12"
 4876	polarized liquefied chocolate bath ball	0		Effect: "Yes, Can Haz", Effect Duration: 40, Last Available: "2011-01"
 4877	colloidal bacon bath ball	0		Effect: "Cookie Backup", Effect Duration: 61, Last Available: "2011-01"
 4878	polymerized incense bath ball	0		Effect: "Moose Wisdom", Effect Duration: 61, Last Available: "2011-01"
 4879	pickled twirling myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Intimidating Mien", Effect Duration: 55, Last Available: "2011-01"
 4880	squat CRIMBCO mug	0		Last Available: "2011-01"
-4881	mediocre enchanted irresponsibly strong CRIMBCO wine	10	decent	Effect: "Uncanny Shot", Effect Duration: 5, Last Available: "2011-01"
+4881	mediocre irresponsibly strong enchanted CRIMBCO wine	10	decent	Effect: "Uncanny Shot", Effect Duration: 5, Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	spoiled miniature bouncing toe jam toast	2	crappy	Last Available: "2011-01"
+4884	miniature spoiled bouncing toe jam toast	2	crappy	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	thick moldy traffic jam toast	5	crappy	Last Available: "2011-01"
+4886	moldy thick traffic jam toast	5	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	decent super-sized space jam toast	5	good	Last Available: "2011-01"
 4889	moist narrow motivational poster	0		Effect: "Browbeaten", Effect Duration: 52, Last Available: "2011-01"
 4890	bouncing sack lunch	0		Last Available: "2011-01"
-4891	lime green twirling bath ball gift set	0		Last Available: "2011-01"
+4891	twirling lime green bath ball gift set	0		Last Available: "2011-01"
 4892	narrow slow jam collection	0		Last Available: "2011-01"
 4893	squat BGE shotglass	0		Last Available: "2010-12"
 4894	toothsome festive sausage	3	awesome	Last Available: "2011-01"
@@ -4841,7 +4841,7 @@
 4938	bouncing quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	fancy immense spoiled Knob jelly donut	6	crappy	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
+4941	spoiled immense fancy Knob jelly donut	6	crappy	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
 4942	Knob cake	0		
 4943	skewed blurry Knob cake pan	0		
 4944	Knob batter	0		
@@ -4856,10 +4856,10 @@
 4953	manspreader's Da Vinci's whalebone corset	0		Experience (Mysticality): +5, Monster Level: +10, Single Equip
 4954	Tesla oven mitts	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 4955	half-sized normal overcookie	2	good	
-4956	thick normal cyan philosopher's scone	5	good	
+4956	normal thick cyan philosopher's scone	5	good	
 4957	triple-ionized aerosolized half-baked potion	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 52
 4958	ghostly sizzling Knob Goblin deluxe scimitar	0		Hot Damage: +10
-4959	huge stale Knob nuts	6	decent	
+4959	stale huge Knob nuts	6	decent	
 4960	acceptable distilled huge Cobb's Knob Wurstbrau	5	good	
 4961	blinking Subject 37 file	0		
 4962	blurry veiny mysterious lapel pin of incineration	0		Maximum HP: +10, Hot Spell Damage: +50, Single Equip
@@ -4888,7 +4888,7 @@
 4985	Alice's Army Dervish	0		Last Available: "2011-03"
 4986	yellow Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
-4988	narrow maroon Alice's Army Foil Swordsman	0		Last Available: "2011-03"
+4988	maroon narrow Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	upside-down Alice's Army Foil Guard	0		Last Available: "2011-03"
@@ -4915,19 +4915,19 @@
 5012	olive Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	normal narrow wasabi pocky	3	good	Last Available: "2011-03"
 5014	stale fuchsia tobiko pocky	4	decent	Last Available: "2011-03"
-5015	toothsome special half-sized natto pocky	2	awesome	Effect: "Bricked-In", Effect Duration: 45, Last Available: "2011-03"
+5015	half-sized toothsome special natto pocky	2	awesome	Effect: "Bricked-In", Effect Duration: 45, Last Available: "2011-03"
 5016	lousy wasabi-infused sake	3	decent	Last Available: "2011-03"
 5017	tolerable tobiko-infused sake	3	good	Last Available: "2011-03"
 5018	mediocre natto-infused sake	4	decent	Last Available: "2011-03"
 5019	Vulcanized unsweetened adjusted wasabi marble soda	0		Effect: "Very Clean Teeth", Effect Duration: 18, Last Available: "2011-03"
-5020	alkaline upside-down jittery tobiko marble soda	0		Effect: "Blessing of Charcoatl", Effect Duration: 34, Last Available: "2011-03"
+5020	alkaline jittery upside-down tobiko marble soda	0		Effect: "Blessing of Charcoatl", Effect Duration: 34, Last Available: "2011-03"
 5021	ionized extra-improved teal natto marble soda	0		Effect: "Fratty Flavor", Effect Duration: 51, Last Available: "2011-03"
 5022	bouncing Alice's Army booster box	0		Last Available: "2011-03"
 5023	extra-deionized elderly jawbreaker	0		Effect: "Sweet Tooth", Effect Duration: 68, Last Available: "2020-09"
 5024	mediocre marshmallow flamb&eacute;	3	decent	Last Available: "2011-03"
 5025	delicious cranberry schnapps	3	awesome	Last Available: "2011-03"
 5026	distilled artisanal mirror breaded beer	5	EPIC	Last Available: "2011-03"
-5027	weak perfectly mixed twirling soy cordial	2	super ultra mega turbo EPIC	Last Available: "2011-03"
+5027	perfectly mixed weak twirling soy cordial	2	super ultra mega turbo EPIC	Last Available: "2011-03"
 5028	twirling Herculean brainy astral bludgeon of Gandalf	0		Mysticality: +5, Experience (Muscle): +1, Spell Critical Percent: +20
 5029	bouncing jittery scandalous weightlifter's astral shield	0		Muscle: +15, Sleaze Damage: +5, Damage Reduction: 15
 5030	wholesome astral chapeau of extreme caution of incineration	0		Maximum HP Percent: +10, Monster Level: -25, Hot Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4943,7 +4943,7 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	twirling miser's frightening beefcake's astral shirt	0		Muscle: +25, Spooky Damage: +5, Meat Drop: +10
 5042	banded astral belt of the pedagogue	0		Experience: +3, Damage Absorption: +100
-5043	massive moldy shaking astral hot dog	9		
+5043	moldy massive shaking astral hot dog	9		
 5044	hand-crafted astral pilsner	4		
 5045	twirling astral hot dog dinner	0		
 5046	astral six-pack	0		
@@ -4955,7 +4955,7 @@
 5052	huge handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
-5055	olive spinning obnoxious riddle	0		Last Available: "2011-04"
+5055	spinning olive obnoxious riddle	0		Last Available: "2011-04"
 5056	huge best joke ever	0		Last Available: "2011-04"
 5057	pressed galvanized blurry Atomic Comic	0		Effect: "Cute Vision", Effect Duration: 11, Last Available: "2011-04"
 5058	quadruple-moist Red Pill	0		Effect: "Resilient Spirit", Effect Duration: 39, Last Available: "2011-04"
@@ -4965,7 +4965,7 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	green Salsa de las Epocas	0		Last Available: "2011-04"
-5065	delicious special huge spaghetti con calaveras	7	awesome	Effect: "It's Soporiffic!", Effect Duration: 35, Last Available: "2011-04"
+5065	huge delicious special spaghetti con calaveras	7	awesome	Effect: "It's Soporiffic!", Effect Duration: 35, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	super-sized bland popcorn	5	decent	Last Available: "2011-04"
 5068	small rotten chaos popcorn	2	crappy	Last Available: "2011-04"
@@ -4973,7 +4973,7 @@
 5070	jittery innuendo	0		Last Available: "2011-04"
 5071	stale upside-down s'more	0	decent	Last Available: "2011-04"
 5072	skewed diamond ring	0		Last Available: "2011-04"
-5073	watered-down acceptable upside-down Russian Ice	2	good	Last Available: "2011-04"
+5073	acceptable watered-down upside-down Russian Ice	2	good	Last Available: "2011-04"
 5074	blurry reassuring clay ashtray	0		Spooky Resistance: +1, Damage Reduction: 3, Last Available: "2011-05"
 5075	bouncing lanyard of the ox	0		Muscle: +20, Single Equip, Last Available: "2011-05"
 5076	stanky monster pants	0		Stench Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
@@ -5007,7 +5007,7 @@
 5104	energized quadruple-energized squat fish juice box	0		Effect: "Can't Smell Nothin'", Effect Duration: 65, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	spinning hideous egg	0		Last Available: "2011-05"
-5107	triple-distilled tolerable twirling Jeppson's Malort	8	good	Last Available: "2011-06"
+5107	tolerable triple-distilled twirling Jeppson's Malort	8	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	stress ball of doom	0		Spooky Spell Damage: +50, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	gray Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5033,10 +5033,10 @@
 5130	jittery Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	triple-boiled spinning Ultrasoldier Serum	0		Effect: "Heart of Green", Effect Duration: 32, Last Available: "2011-06"
 5132	bland elven hardtack	3	decent	Last Available: "2011-06"
-5133	smooth boozy spinning elven squeeze	5	awesome	Last Available: "2011-06"
-5134	wobbly blurry lunar isotope	0		Last Available: "2011-06"
+5133	boozy smooth spinning elven squeeze	5	awesome	Last Available: "2011-06"
+5134	blurry wobbly lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
-5136	ghostly skewed E.M.U. rocket thrusters	0		Last Available: "2011-06"
+5136	skewed ghostly E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
 5139	ghostly carton of astral energy drinks	0		
@@ -5046,7 +5046,7 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	pickled pressed honeypot	0		Effect: "Locks Like the Raven", Effect Duration: 33
-5146	fancy decent wild honey pie	4	good	Effect: "5 Pounds Lighter", Effect Duration: 5
+5146	decent fancy wild honey pie	4	good	Effect: "5 Pounds Lighter", Effect Duration: 5
 5147	bad honey mead	3	decent	
 5148	chaotic steel-toed hardened honey dipper	0		Damage Reduction: 24, Spell Critical Percent: +10
 5149	twirling curative hardy honeybritches	0		Maximum HP: +50, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5078,8 +5078,8 @@
 5175	aged boozy Moonthril Schnapps	5	awesome	Last Available: "2011-06"
 5176	enchanted drinkable Wrecked Generator	3	good	Effect: "Paging Betty", Effect Duration: 25, Last Available: "2011-06"
 5177	delicious Spaghetti with Moonballs	3	awesome	Last Available: "2011-06"
-5178	flavorless immense twirling Crepes a la Lune	9	decent	Last Available: "2011-06"
-5179	adequate huge shaking Moon Pie	6	good	Last Available: "2011-06"
+5178	immense flavorless twirling Crepes a la Lune	9	decent	Last Available: "2011-06"
+5179	huge adequate shaking Moon Pie	6	good	Last Available: "2011-06"
 5180	vacuum-sealed super-galvanized blurry Comet Pop	0		Effect: "Twinkly Weapon", Effect Duration: 51, Last Available: "2011-06"
 5181	extra-concentrated dry extra-enhanced narrow Flan in the Moon	0		Effect: "Heart of Pink", Effect Duration: 42, Last Available: "2011-06"
 5182	flattened diffused boiled spinning 1/6th Pound Cake	0		Effect: "The Power of LOV", Effect Duration: 31, Last Available: "2011-06"
@@ -5102,8 +5102,8 @@
 5199	altered bouncing beastly paste	1	decent	Last Available: "2011-08"
 5200	pickled paste	1	crappy	Last Available: "2011-08"
 5201	twisted yellow jittery ectoplasmic paste	1	EPIC	Last Available: "2011-08"
-5202	pickled blinking jittery greasy paste	1	EPIC	Last Available: "2011-08"
-5203	dehydrated tumbling blinking squat bug paste	1	good	Effect: "Uncaged Power", Effect Duration: 10, Last Available: "2011-08"
+5202	pickled jittery blinking greasy paste	1	EPIC	Last Available: "2011-08"
+5203	dehydrated blinking tumbling squat bug paste	1	good	Effect: "Uncaged Power", Effect Duration: 10, Last Available: "2011-08"
 5204	distilled blurry hippy paste	1	crappy	Effect: "Wise Spirit", Effect Duration: 35, Last Available: "2011-08"
 5205	altered upside-down orc paste	1	crappy	Last Available: "2011-08"
 5206	dried tumbling wobbly demonic paste	1	good	Effect: "substats.enh", Effect Duration: 40, Last Available: "2011-08"
@@ -5116,7 +5116,7 @@
 5213	modified pulsating yellow Mer-kin paste	1	good	Last Available: "2011-08"
 5214	altered ghostly slimy paste	1	EPIC	Effect: "Slimily Sagacious", Effect Duration: 40, Last Available: "2011-08"
 5215	distilled jittery penguin paste	1	decent	Effect: "Stands Alone", Effect Duration: 30, Last Available: "2011-08"
-5216	altered spinning twirling lime green blurry elemental paste	1	crappy	Last Available: "2011-08"
+5216	altered blurry twirling lime green spinning elemental paste	1	crappy	Last Available: "2011-08"
 5217	compressed yellow narrow upside-down cosmic paste	1	EPIC	Last Available: "2011-08"
 5218	powdered maroon hobo paste	1	good	Last Available: "2011-08"
 5219	modified skewed purple twirling Crimbo paste	1	good	Effect: "Hyperoxygenated Blood", Effect Duration: 40, Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	twirling fat loot token	0		No Pull
 5222	upside-down Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	super-sized flavorless Ur-Donut	5	decent	Last Available: "2011-09"
+5224	flavorless super-sized Ur-Donut	5	decent	Last Available: "2011-09"
 5225	shaking The Bomb	0		Last Available: "2011-09"
 5226	spinning box of Familiar Jacks	0		Last Available: "2011-09"
 5227	bad bucket of wine	3	decent	Last Available: "2011-09"
@@ -5140,16 +5140,16 @@
 5237	foul-smelling time halo	0		Stench Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	weak drinkable huge Lumineux Limnio	2	good	Last Available: "2011-09"
 5239	triple-distilled mediocre Morto Moreto	8	decent	Last Available: "2011-09"
-5240	watered-down drinkable Temps Tempranillo	2	good	Last Available: "2011-09"
+5240	drinkable watered-down Temps Tempranillo	2	good	Last Available: "2011-09"
 5241	tolerable Bordeaux Marteaux	4	good	Last Available: "2011-09"
-5242	practically non-alcoholic drinkable tumbling Fromage Pinotage	1	good	Last Available: "2011-09"
+5242	drinkable practically non-alcoholic tumbling Fromage Pinotage	1	good	Last Available: "2011-09"
 5243	bad weak Beignet Milgranet	2	decent	Last Available: "2011-09"
-5244	weak special lousy Muschat	2	decent	Effect: "Kissed By Fire", Effect Duration: 40, Last Available: "2011-09"
+5244	lousy special weak Muschat	2	decent	Effect: "Kissed By Fire", Effect Duration: 40, Last Available: "2011-09"
 5245	rotten cool jelly donut	3	crappy	Last Available: "2011-09"
-5246	super-sized fancy moldy blurry shrapnel jelly donut	5	crappy	Effect: "Bureaucratized", Effect Duration: 30, Last Available: "2011-09"
+5246	moldy super-sized fancy blurry shrapnel jelly donut	5	crappy	Effect: "Bureaucratized", Effect Duration: 30, Last Available: "2011-09"
 5247	decent spinning occult jelly donut	4	good	Last Available: "2011-09"
-5248	rotten snack-sized wobbly blurry thyme jelly donut	2	crappy	Last Available: "2011-09"
-5249	bland big danish	5	decent	Last Available: "2011-09"
+5248	rotten snack-sized blurry wobbly thyme jelly donut	2	crappy	Last Available: "2011-09"
+5249	big bland danish	5	decent	Last Available: "2011-09"
 5250	spoiled narrow smashed danish	3	crappy	Last Available: "2011-09"
 5251	normal forbidden danish	4	good	Last Available: "2011-09"
 5252	stale cool cat claw	3	decent	Last Available: "2011-09"
@@ -5157,8 +5157,8 @@
 5254	yummy blurry shadowy cat claw	3	awesome	Last Available: "2011-09"
 5255	decent cheezburger	4	good	Last Available: "2011-09"
 5256	yummy huge toasted brie	3	awesome	Last Available: "2011-09"
-5257	ionized activated flattened wobbly twirling olive potion of the field gar	0		Effect: "Woad Warrior", Effect Duration: 68, Last Available: "2011-09"
-5258	cold-filtered cyan upside-down huge too legit potion	0		Effect: "Mushroom Magicalness", Effect Duration: 60, Last Available: "2011-09"
+5257	ionized activated flattened olive twirling wobbly potion of the field gar	0		Effect: "Woad Warrior", Effect Duration: 68, Last Available: "2011-09"
+5258	cold-filtered huge upside-down cyan too legit potion	0		Effect: "Mushroom Magicalness", Effect Duration: 60, Last Available: "2011-09"
 5259	concentrated polymerized Bright Water	0		Effect: "Ripping, Dripping", Effect Duration: 49, Last Available: "2011-09"
 5260	Vulcanized quadruple-frozen flattened cold-filtered water	0		Effect: "Sweet Tooth", Effect Duration: 19, Last Available: "2011-09"
 5261	ionized graveyard snowglobe	0		Effect: "Concentrated Concentration", Effect Duration: 50, Last Available: "2011-09"
@@ -5224,8 +5224,8 @@
 5321	frozen oxidized shaking Sweet Sword	0		Effect: "Well-preserved", Effect Duration: 65, Last Available: "2011-10"
 5322	delicious Ecto-Cooler	4	awesome	Last Available: "2011-10"
 5323	delicious Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
-5324	artisanal weak Blood Light	2	EPIC	Last Available: "2011-10"
-5325	mediocre skewed spinning Silver Bullet beer	4	decent	Last Available: "2011-10"
+5324	weak artisanal Blood Light	2	EPIC	Last Available: "2011-10"
+5325	mediocre spinning skewed Silver Bullet beer	4	decent	Last Available: "2011-10"
 5326	artisanal watered-down Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	triple-boiled frozen narrow sorority brain	0		Effect: "Spookypants", Effect Duration: 68, Last Available: "2011-10"
@@ -5297,7 +5297,7 @@
 5394	sandpaper	0		
 5395	blurry peppermint sprout	0		Last Available: "2011-11"
 5396	enhanced peppermint twist	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 49, Last Available: "2011-11"
-5397	decent bite-sized peppermint patty	1	good	Last Available: "2011-11"
+5397	bite-sized decent peppermint patty	1	good	Last Available: "2011-11"
 5398	blurry peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5307,8 +5307,8 @@
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	twirling horrifying hardy cane-mail shirt of terror	0		Maximum HP: +50, Spooky Damage: +25, Spooky Spell Damage: +10, Last Available: "2011-12"
 5406	inspector's educational wizardly cane-mail pants	0		Mysticality: +25, Experience: +1, Item Drop: +15, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	artisanal watered-down Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
-5408	lousy triple-distilled skewed Gin Mint	7	decent	Last Available: "2011-12"
+5407	watered-down artisanal Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
+5408	triple-distilled lousy skewed Gin Mint	7	decent	Last Available: "2011-12"
 5409	tolerable Tequiz Navidad	4	good	Last Available: "2011-12"
 5410	acceptable Mint Yulep	3	good	Last Available: "2011-12"
 5411	hand-crafted jittery Crimbojito	3	EPIC	Last Available: "2011-12"
@@ -5338,7 +5338,7 @@
 5435	tumbling fudgecule	0		Last Available: "2011-11"
 5436	dry teal fudge lily	0		Effect: "White Blooded", Effect Duration: 45, Last Available: "2011-11"
 5437	ghostly superheated fudge	0		Last Available: "2011-11"
-5438	alkaline purple huge fluid of fudge-finding	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 65, Last Available: "2011-11"
+5438	alkaline huge purple fluid of fudge-finding	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 65, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	adequate fudgesicle	4	good	Last Available: "2011-11"
 5441	tumbling wand of fudge control	0		Last Available: "2011-11"
@@ -5352,7 +5352,7 @@
 5449	teal vanity stone	0		Last Available: "2012-12"
 5450	ghostly lecherous stone	0		Last Available: "2012-12"
 5451	tumbling jealousy stone	0		Last Available: "2012-12"
-5452	ghostly wobbly avarice stone	0		Last Available: "2012-12"
+5452	wobbly ghostly avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	gummi ingot	0		Last Available: "2011-11"
 5455	gummi ingot	0		Last Available: "2011-11"
@@ -5373,18 +5373,18 @@
 5470	concentrated resolution: be kinder	0		Effect: "In the Limelight", Effect Duration: 69, Last Available: "2012-01"
 5471	denatured blurry resolution: be more adventurous	0		Effect: "Halloweeny", Effect Duration: 65, Last Available: "2012-01"
 5472	triple-Vulcanized aerosolized dry huge resolution: be luckier	0		Effect: "Wolf's Bane", Effect Duration: 66, Last Available: "2012-01"
-5473	cyan mirror gummi ingot	0		Last Available: "2011-11"
+5473	mirror cyan gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	polymerized gummi salamander	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 33, Last Available: "2011-11"
 5477	tarnished ghostly gummi snake	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 25, Last Available: "2011-11"
 5478	cold-filtered irradiated deionized gummi canary	0		Effect: "Nothing Is Impossible", Effect Duration: 69, Last Available: "2011-11"
-5479	small spoiled gummi bear	2	crappy	Last Available: "2011-11"
+5479	spoiled small gummi bear	2	crappy	Last Available: "2011-11"
 5480	decent gummi bear	4	good	Last Available: "2011-11"
-5481	rotten immense gummi bear	6	crappy	Last Available: "2011-11"
+5481	immense rotten gummi bear	6	crappy	Last Available: "2011-11"
 5482	adequate maroon drunki-bear	4	good	Last Available: "2011-11"
 5483	super-sized spoiled drunki-bear	5	crappy	Last Available: "2011-11"
-5484	diet toothsome drunki-bear	1	awesome	Last Available: "2011-11"
+5484	toothsome diet drunki-bear	1	awesome	Last Available: "2011-11"
 5485	mirror lime green boxer's gummi bowtie	0		Muscle Percent: +10, Last Available: "2011-11"
 5486	olive huge brawny fudge pocket square	0		Muscle Percent: +20, Last Available: "2011-11"
 5487	olive wool lollipop cufflinks	0		Cold Resistance: +1, Last Available: "2011-11"
@@ -5406,10 +5406,10 @@
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	blinking pack of pogs	0		Last Available: "2011-11"
-5506	thick stale upside-down tumbling jerky coins	5	decent	Last Available: "2011-11"
+5506	stale thick tumbling upside-down jerky coins	5	decent	Last Available: "2011-11"
 5507	hand-crafted purple Go-Wassail	3	EPIC	Last Available: "2011-11"
 5508	irradiated tarnished tumbling Uncle Greenspan's Bathroom Finance Guide	0		Effect: "It's Electric!", Effect Duration: 47, Last Available: "2011-11"
-5509	tarnished pulsating blurry spinning bottle of bubbles	0		Effect: "Moon-Eyed", Effect Duration: 23, Last Available: "2011-11"
+5509	tarnished blurry pulsating spinning bottle of bubbles	0		Effect: "Moon-Eyed", Effect Duration: 23, Last Available: "2011-11"
 5510	altered activated bouncing wind-up meatcar	0		Effect: "Protection from Bad Stuff", Effect Duration: 50, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	mirror Trivial Avocations Card: When?	0		Last Available: "2011-11"
@@ -5425,7 +5425,7 @@
 5522	upside-down pog #08 (hellion)	0		Last Available: "2011-11"
 5523	narrow olive pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
-5525	yellow shaking pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
+5525	shaking yellow pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	polymerized flattened blue Atomic Pop	0		Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2020-09"
 5527	pulsating do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	huge whimpering willow bark	0		Last Available: "2012-12"
@@ -5445,7 +5445,7 @@
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	resourceful Socratic Leapin' Trousers	0		Experience (Mysticality): +1, Maximum MP: +50
 5544	bad eggnog	3	decent	Last Available: "2012-12"
-5545	stale half-sized hamhock	2	decent	Last Available: "2012-12"
+5545	half-sized stale hamhock	2	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	mirror Clancy's sackbut	0		Last Available: "2012-12"
 5548	spinning Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5455,7 +5455,7 @@
 5552	fuchsia wholesome Trusty	0		Maximum HP Percent: +10
 5553	spinning can of Rain-Doh	0		Last Available: "2012-02"
 5554	empty Rain-Doh can	0		Last Available: "2012-02"
-5555	extra-pressed pressed vacuum-sealed yellow ghostly wobbly fireclutch	0		Effect: "Virgo Rising", Effect Duration: 16
+5555	extra-pressed pressed vacuum-sealed wobbly ghostly yellow fireclutch	0		Effect: "Virgo Rising", Effect Duration: 16
 5556	smelly Rain-Doh wings of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +10, Softcore Only, Last Available: "2012-02"
 5557	blurry Rain-Doh agent	0		Last Available: "2012-02"
 5558	beefy Rain-Doh laser gun of chilblains	0		Muscle: +10, Cold Damage: +25, Softcore Only, Last Available: "2012-02"
@@ -5467,7 +5467,7 @@
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	tiny normal bouncing PB&BP	1	good	
 5566	adequate club sandwich	3	good	
-5567	low-calorie flavorless corned-beef Reuben	1	decent	
+5567	flavorless low-calorie corned-beef Reuben	1	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	spinning blinking loose ninja carabiner	0		
@@ -5476,9 +5476,9 @@
 5573	drinkable weak upside-down Drac & Tan	2	good	Last Available: "2012-03"
 5574	tolerable Transylvania Sling	3	good	Last Available: "2012-03"
 5575	tolerable Shot of the Living Dead	3	good	Last Available: "2012-03"
-5576	smooth fortified skewed blurry Buttery Knob	5	awesome	Last Available: "2012-03"
+5576	fortified smooth skewed blurry Buttery Knob	5	awesome	Last Available: "2012-03"
 5577	acceptable narrow Slippery Knob	4	good	Last Available: "2012-03"
-5578	drinkable watered-down jittery Flaming Knob	2	good	Last Available: "2012-03"
+5578	watered-down drinkable jittery Flaming Knob	2	good	Last Available: "2012-03"
 5579	drinkable Grasshopper	4	good	Last Available: "2012-03"
 5580	weak bad Locust	2	decent	Last Available: "2012-03"
 5581	lousy watered-down Plague of Locusts	2	decent	Last Available: "2012-03"
@@ -5488,47 +5488,47 @@
 5585	hand-crafted practically non-alcoholic Aye Aye	1	EPIC	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	4	decent	Last Available: "2012-03"
 5587	smooth spinning Aye Aye, Tooth Tooth	4	awesome	Last Available: "2012-03"
-5588	tolerable high-proof Humanitini	6	good	Last Available: "2012-03"
+5588	high-proof tolerable Humanitini	6	good	Last Available: "2012-03"
 5589	tolerable fortified fancy More Humanitini than Humanitini	5	good	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2012-03"
-5590	spirit-forward mediocre squat blinking Oh, the Humanitini	5	decent	Last Available: "2012-03"
+5590	mediocre spirit-forward squat blinking Oh, the Humanitini	5	decent	Last Available: "2012-03"
 5591	drinkable Great Older Fashioned	4	good	Last Available: "2012-03"
 5592	tolerable Fuzzy Tentacle	4	good	Last Available: "2012-03"
 5593	drinkable narrow Crazymaker	3	good	Last Available: "2012-03"
-5594	mediocre fancy Zoodriver	3	decent	Effect: "The Moxie of LOV", Effect Duration: 5, Last Available: "2012-03"
-5595	watered-down drinkable tumbling blurry Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
-5596	special hand-crafted Sloe Comfortable Zoo on Fire	4	EPIC	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2012-03"
+5594	fancy mediocre Zoodriver	3	decent	Effect: "The Moxie of LOV", Effect Duration: 5, Last Available: "2012-03"
+5595	watered-down drinkable blurry tumbling Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
+5596	hand-crafted special Sloe Comfortable Zoo on Fire	4	EPIC	Effect: "The Magic of LOV", Effect Duration: 40, Last Available: "2012-03"
 5597	delicious extra-dry mirror Suffering Sinner	5	awesome	Last Available: "2012-03"
 5598	lousy fortified Suppurating Sinner	5	decent	Last Available: "2012-03"
-5599	perfectly mixed fancy Sizzling Sinner	3	EPIC	Effect: "Appeteyes", Effect Duration: 40, Last Available: "2012-03"
-5600	weak delicious Firewater	2	awesome	Last Available: "2012-03"
-5601	acceptable fortified Earth and Firewater	5	good	Last Available: "2012-03"
-5602	enchanted boozy bad Earth, Wind and Firewater	5	decent	Effect: "Space Tripping", Effect Duration: 45, Last Available: "2012-03"
+5599	fancy perfectly mixed Sizzling Sinner	3	EPIC	Effect: "Appeteyes", Effect Duration: 40, Last Available: "2012-03"
+5600	delicious weak Firewater	2	awesome	Last Available: "2012-03"
+5601	fortified acceptable Earth and Firewater	5	good	Last Available: "2012-03"
+5602	boozy bad enchanted Earth, Wind and Firewater	5	decent	Effect: "Space Tripping", Effect Duration: 45, Last Available: "2012-03"
 5603	acceptable Slimosa	3	good	Last Available: "2012-03"
-5604	distilled artisanal Extra-slimy Slimosa	5	EPIC	Last Available: "2012-03"
+5604	artisanal distilled Extra-slimy Slimosa	5	EPIC	Last Available: "2012-03"
 5605	smooth Slimebite	3	awesome	Last Available: "2012-03"
 5606	watered-down hand-crafted Cement Mixer	2	EPIC	Last Available: "2012-03"
-5607	perfectly mixed high-proof Jackhammer	9	EPIC	Last Available: "2012-03"
-5608	irresponsibly strong tolerable enchanted blurry twirling Dump Truck	7	good	Effect: "So Fresh and So Clean", Effect Duration: 45, Last Available: "2012-03"
+5607	high-proof perfectly mixed Jackhammer	9	EPIC	Last Available: "2012-03"
+5608	irresponsibly strong tolerable enchanted twirling blurry Dump Truck	7	good	Effect: "So Fresh and So Clean", Effect Duration: 45, Last Available: "2012-03"
 5609	acceptable Fauna Libre	3	good	Last Available: "2012-03"
-5610	boozy smooth green ghostly upside-down Chakra Libre	5	awesome	Last Available: "2012-03"
+5610	smooth boozy upside-down ghostly green Chakra Libre	5	awesome	Last Available: "2012-03"
 5611	hand-crafted Aura Libre	4	EPIC	Last Available: "2012-03"
-5612	watered-down acceptable huge blue pulsating Sazerorc	2	good	Last Available: "2012-03"
-5613	acceptable fortified Sazuruk-hai	5	good	Last Available: "2012-03"
+5612	acceptable watered-down pulsating huge blue Sazerorc	2	good	Last Available: "2012-03"
+5613	fortified acceptable Sazuruk-hai	5	good	Last Available: "2012-03"
 5614	artisanal Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	aged Green Velvet	3	awesome	Last Available: "2012-03"
-5616	weak hand-crafted Green Muslin	2	EPIC	Last Available: "2012-03"
-5617	special lousy blurry Green Burlap	3	decent	Effect: "critical.enh", Effect Duration: 40, Last Available: "2012-03"
+5616	hand-crafted weak Green Muslin	2	EPIC	Last Available: "2012-03"
+5617	lousy special blurry Green Burlap	3	decent	Effect: "critical.enh", Effect Duration: 40, Last Available: "2012-03"
 5618	bad Mohobo	3	decent	Last Available: "2012-03"
-5619	perfectly mixed special Moonshine Mohobo	4	EPIC	Effect: "Ghost Finger", Effect Duration: 10, Last Available: "2012-03"
+5619	special perfectly mixed Moonshine Mohobo	4	EPIC	Effect: "Ghost Finger", Effect Duration: 10, Last Available: "2012-03"
 5620	tolerable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	tolerable huge Drunken Philosopher	3	good	Last Available: "2012-03"
-5622	hand-crafted practically non-alcoholic shaking Drunken Neurologist	1	EPIC	Last Available: "2012-03"
+5622	practically non-alcoholic hand-crafted shaking Drunken Neurologist	1	EPIC	Last Available: "2012-03"
 5623	hand-crafted Drunken Astrophysicist	4	EPIC	Last Available: "2012-03"
 5624	tolerable Dark & Starry	4	good	Last Available: "2012-03"
 5625	hand-crafted Black Hole	4	EPIC	Last Available: "2012-03"
-5626	strong aged Event Horizon	5	awesome	Last Available: "2012-03"
+5626	aged strong Event Horizon	5	awesome	Last Available: "2012-03"
 5627	high-proof lousy Herring Daiquiri	10	decent	Last Available: "2012-03"
-5628	drinkable weak Herring Wallbanger	2	good	Last Available: "2012-03"
+5628	weak drinkable Herring Wallbanger	2	good	Last Available: "2012-03"
 5629	artisanal bouncing Herringtini	4	EPIC	Last Available: "2012-03"
 5630	bad blinking cyan Lollipop Drop	4	decent	Last Available: "2012-03"
 5631	bad Candy Alexander	4	decent	Last Available: "2012-03"
@@ -5538,7 +5538,7 @@
 5635	drinkable bouncing Flaming Caipiranha	3	good	Last Available: "2012-03"
 5636	delicious spinning Punchplanter	4	awesome	Last Available: "2012-03"
 5637	tolerable mirror Doublepunchplanter	4	good	Last Available: "2012-03"
-5638	tolerable irresponsibly strong Haymaker	9	good	Last Available: "2012-03"
+5638	irresponsibly strong tolerable Haymaker	9	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	blue crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	delicious narrow fungus	4	awesome	
@@ -5554,7 +5554,7 @@
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	blinking Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	low-calorie stale nailswurst	1	decent	
+5654	stale low-calorie nailswurst	1	decent	
 5655	perfectly mixed used beer	3	EPIC	
 5656	bouncing Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5570,18 +5570,18 @@
 5667	upside-down puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	skewed club	0		
-5670	adequate half-sized fettucini &eacute;pines Inconnu	2	good	
+5670	half-sized adequate fettucini &eacute;pines Inconnu	2	good	
 5671	artisanal narrow tumbling slap and slap again	3	EPIC	
 5672	huge gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
-5675	mixed tumbling wobbly gray watered-down Red Minotaur	1		Effect: "Gemini Rising", Effect Duration: 45
+5675	mixed gray tumbling wobbly watered-down Red Minotaur	1		Effect: "Gemini Rising", Effect Duration: 45
 5676	yellow pool torpedo	0		Last Available: "2012-05"
 5677	ghostly hardened Ze&trade; goggles	0		Damage Reduction: 3, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	huge soggy used band-aid	0		Last Available: "2012-05"
 5679	chilly hardened stylish swimsuit	0		Damage Reduction: 3, Cold Damage: +5, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
-5681	bland squat huge P.B.L.T.	3	decent	
+5681	bland huge squat P.B.L.T.	3	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	purple BURT	0		
 5684	handful of juicy garbage	0		
@@ -5589,7 +5589,7 @@
 5686	bouncing ghostly quantum nanopolymer spider web	0		
 5687	bugbear autopsy tweezers	0		
 5688	tumbling reassuring UV monocular	0		Spooky Resistance: +1, Single Equip
-5689	skewed olive drone self-destruct chip	0		
+5689	olive skewed drone self-destruct chip	0		
 5690	blurry Jeff Goldblum larva	0		
 5691	spinning pacification grenade	0		
 5692	thinker's quantum disintegrator pistol	0		Mysticality: +10
@@ -5629,7 +5629,7 @@
 5728	mirror up-at-dawn foot-long hot daub of the detective	0		Item Drop: +20, Adventures: +5, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy olive angst burger	4	crappy	
-5731	practically non-alcoholic delicious 5-hour acrimony	1	awesome	
+5731	delicious practically non-alcoholic 5-hour acrimony	1	awesome	
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	bland forbidden sausage	4	decent	
@@ -5665,7 +5665,7 @@
 5765	hardy extremely unsafe fuzzy earmuffs	0		Weapon Damage Percent: +100, Maximum HP: +50, Familiar Effect: "1.5xVolley, cap 32"
 5766	hardy rock-hard hardened fuzzy montera	0		Damage Reduction: 16, Maximum HP: +50, Familiar Effect: "1.5xVolley, cap 32"
 5767	narrow Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	mirror spinning gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5768	spinning mirror gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
 5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
 5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
 5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
@@ -5674,7 +5674,7 @@
 5774	bouncing talkative skull	0		
 5775	spinning fronts	0		Familiar Weight: +5
 5776	toasty Barney's rake of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +5
-5778	snack-sized bland idiot brain	2	decent	
+5778	bland snack-sized idiot brain	2	decent	
 5779	green wool keel-haulin' knife	0		Cold Resistance: +1
 5780	personal trainer's ice cream scoop	0		Experience Percent (Muscle): +10
 5781	mediocre soft echo eyedrop antidote martini	3	decent	
@@ -5690,12 +5690,12 @@
 5791	toasty crafty right bear arm	0		Maximum MP: +10, Hot Damage: +5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
 5792	jittery wobbly arcane researcher's left bear arm of Flo-Jo	0		Experience Percent (Mysticality): +10, Item Drop: +5, Initiative: +100, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	blurry Hat O' Nine Tails	0		Item Drop: +5
-5794	oxidized pickled shaking fuchsia Enchanted Plunger	0		Effect: "Just the Brown Ones", Effect Duration: 65
+5794	oxidized pickled fuchsia shaking Enchanted Plunger	0		Effect: "Just the Brown Ones", Effect Duration: 65
 5795	boiled oxidized Enchanted Flyswatter	0		Effect: "Flamingly Floral", Effect Duration: 12
 5796	chilled improved warmed maroon Gearhead Goo	0		Effect: "Tightly-Wound Spine", Effect Duration: 30
 5797	non-altered concentrated tumbling pulsating Missing Eye Simulation Device	0		Effect: "Patience of the Tortoise", Effect Duration: 36
 5798	ionized electrified teal Gnollish Crossdress	0		Effect: "Happy Salamander", Effect Duration: 43
-5799	ionized maroon ghostly eldritch dough	0		Effect: "OMG WTF", Effect Duration: 24
+5799	ionized ghostly maroon eldritch dough	0		Effect: "OMG WTF", Effect Duration: 24
 5800	ionized Charity's choker	0		Effect: "Woad Warrior", Effect Duration: 59
 5801	irradiated oxidized squat Smart Bone Dust	0		Effect: "Work For Hours a Week", Effect Duration: 12
 5802	wet colloidal olive blurry perpendicular guano	0		Effect: "Superheroic", Effect Duration: 67
@@ -5709,7 +5709,7 @@
 5810	cold-filtered extra-warmed blinking Tears of the Quiet Healer	0		Effect: "Vanity Rage", Effect Duration: 32
 5811	alkaline oxidized ghostly tube of lipstick	0		Effect: "Tingly Elbows", Effect Duration: 46
 5812	energized skelelton spine	0		Effect: "Gummiheart", Effect Duration: 20
-5813	pressed ionized squat red shaking smut orc sunglasses	0		Effect: "Spooky Demeanor", Effect Duration: 46
+5813	pressed ionized red squat shaking smut orc sunglasses	0		Effect: "Spooky Demeanor", Effect Duration: 46
 5814	enhanced anodized diffused wobbly fuchsia blob of acid	0		Effect: "Polar Express", Effect Duration: 55
 5815	tarnished quadruple-boiled skewed flayed mind	0		Effect: "Pecan Pied Piper", Effect Duration: 26
 5816	improved kobold kibble	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 13
@@ -5736,20 +5736,20 @@
 5837	oxidized moist cyan Fu Manchu Wax	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 23
 5838	corrupted spinning yellow Iiti Kitty Gumdrop	0		Effect: "Quiet 'n' Good", Effect Duration: 67
 5839	non-alkaline ravenous eye	0		Effect: "Feelin' Philosophical", Effect Duration: 42
-5840	super-adjusted pressed fuchsia huge Rogue Windmill Rouge	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 55
+5840	super-adjusted pressed huge fuchsia Rogue Windmill Rouge	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 55
 5841	diffused A muse-bouche	0		Effect: "No Vertigo", Effect Duration: 29
 5842	anodized altered mirror toothbrush	0		Effect: "Certainty", Effect Duration: 43
 5843	adjusted activated altered pirate cream pie	0		Effect: "Pie in the Sky", Effect Duration: 63
 5844	corrupted alkaline chilled blurry una poca de gracia	0		Effect: "Dilated Pupils", Effect Duration: 33
 5845	altered flattened compressed air canister	0		Effect: "Banono", Effect Duration: 54
-5846	aerosolized dry bouncing squat salt water taffy	0		Effect: "Eyes Wide Propped", Effect Duration: 51
+5846	aerosolized dry squat bouncing salt water taffy	0		Effect: "Eyes Wide Propped", Effect Duration: 51
 5847	quantum unholy water	0		Effect: "Space Cadet", Effect Duration: 57
 5848	corrupted diffused tumbling Bangyomaman battle juice	0		Effect: "Turkey-Agitated", Effect Duration: 47
 5849	altered wobbly green handyman &quot;hand soap&quot;	0		Effect: "Chunky", Effect Duration: 25
 5850	ionized quadruple-Vulcanized space marine flash grenade	0		Effect: "Medieval Mage Mayhem", Effect Duration: 40
 5851	warmed quadruple-dry squat temporary tribal tattoo	0		Effect: "Physicali Tea", Effect Duration: 24
 5852	extra-irradiated triple-ionized oil-filled donut	0		Effect: "Gummi-Grin", Effect Duration: 66
-5853	non-cold-filtered energized skewed pulsating stick-on gnome beard	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 11
+5853	non-cold-filtered energized pulsating skewed stick-on gnome beard	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 11
 5854	activated BRICKO stud	0		Effect: "Conspiratory Eyes", Effect Duration: 42
 5855	cold-filtered Osk'r Chow	0		Effect: "Mmmmmelon", Effect Duration: 45
 5856	galvanized Scuba Snack	0		Effect: "Limber as Mortimer", Effect Duration: 15
@@ -5773,7 +5773,7 @@
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	wobbly papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
 5876	papier-m&acirc;ch&eacute; bowl	0		Last Available: "2012-09"
-5877	mirror tumbling papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
+5877	tumbling mirror papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	fuchsia pulsating chilly Rainbow Jello Mould	0		Cold Damage: +5
 5879	Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
@@ -5794,7 +5794,7 @@
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	ghostly canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	dried spinning Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
-5898	bouncing mirror jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
+5898	mirror bouncing jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	twirling jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	wobbly jar of psychoses (The Old Man)	0		Last Available: "2013-12"
@@ -5863,7 +5863,7 @@
 5965	Frown Exerciser of Calamity Jane of Gandalf	0		Critical Hit Percent: +15, Spell Critical Percent: +20, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	soul doorbell	0		
-5968	blurry shaking soul coin	0		
+5968	shaking blurry soul coin	0		
 5969	soul knife	0		
 5970	twirling soul mask of terror	0		Spooky Spell Damage: +10, Single Equip
 5971	teal shaking record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5873,11 +5873,11 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	yellow pulsating record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	manspreader's clever razor-sharp silent beret	0		Weapon Damage Percent: +25, Maximum MP: +20, Monster Level: +10, Familiar Effect: "1xVolley, cap 3"
-5978	huge tasty slice of pizza	7	awesome	Last Available: "2013-02"
+5978	tasty huge slice of pizza	7	awesome	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	tumbling cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	practically non-alcoholic tolerable tankard of ale	1	good	Last Available: "2013-02"
+5982	tolerable practically non-alcoholic tankard of ale	1	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	wool hardy cloth cap of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Cold Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	mirror yellow auspicious chilly iron dagger of the bloodbag	0		Maximum HP: +100, Cold Damage: +5, Item Drop: +10, Last Available: "2013-02"
@@ -5911,13 +5911,13 @@
 6013	bouncing scorching orcish stud-finder of bravery	0		Hot Damage: +25, Spooky Resistance: +5
 6014	screwing pooch of the sewer	0		Stench Damage: +25
 6015	galvanized jittery orcish hand lotion	0		Effect: "Minerva's Zen", Effect Duration: 44
-6016	pickled dry spinning squat orcish rubber	0		Effect: "Hyphemariffic", Effect Duration: 29
+6016	pickled dry squat spinning orcish rubber	0		Effect: "Hyphemariffic", Effect Duration: 29
 6017	electrified ionized lime green orcish nailing lube	0		Effect: "Cool, Catlike", Effect Duration: 27
 6018	lousy backwoods screwdriver	3	decent	
 6019	loadstone	0		Item Drop: +5
 6020	chaotic padded Claybender glasses	0		Damage Absorption: +20, Spell Critical Percent: +10, Single Equip
 6021	supercharged sage Duskwalker fangs	0		Mysticality Percent: +10, Maximum MP Percent: +30
-6022	pulsating maroon Space Tourist Phaser	0		
+6022	maroon pulsating Space Tourist Phaser	0		
 6023	zippy beefy Whoompa Fur Pants	0		Muscle: +10, Initiative: +20, Familiar Effect: "atk, cap 27"
 6024	spinning savvy Whatsian Ionic Pliers	0		Mysticality Percent: +20
 6025	adjusted denatured ionized fuchsia Polysniff Perfume	0		Effect: "Gummi-Grin", Effect Duration: 50
@@ -5932,7 +5932,7 @@
 6034	mirror cyan deadly troll britches of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Familiar Effect: "1.5xPotato, cap 28"
 6035	liquefied quantum skewed vial of The Glistening	0		Effect: "Fancy Feasted", Effect Duration: 44
 6036	aged high-proof artisanal limoncello	9	awesome	
-6037	huge olive narrow ginger ale	0		
+6037	huge narrow olive ginger ale	0		
 6038	normal incredible pizza	3	good	
 6039	ghostly coward's clever oil cap	0		Maximum MP: +20, Monster Level: -20, Familiar Effect: "cap 28"
 6040	perfumed extremely unsafe oil lamp	0		Weapon Damage Percent: +100, Stench Resistance: +5
@@ -5974,7 +5974,7 @@
 6076	triple-distilled mediocre McLeod's Hard Haggis-Ade	6	decent	Last Available: "2012-12"
 6077	flavorless haggis-wrapped haggis-stuffed haggis	4	decent	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
-6079	lime green shaking school calculator watch	0		Last Available: "2012-12"
+6079	shaking lime green school calculator watch	0		Last Available: "2012-12"
 6080	tumbling stanky haggis socks	0		Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
 6081	bouncing airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
@@ -6038,7 +6038,7 @@
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	normal bite-sized blinking teal roasted duck	1	good	Last Available: "2013-12"
-6143	massive delicious dead meat bun	10	awesome	Last Available: "2013-12"
+6143	delicious massive dead meat bun	10	awesome	Last Available: "2013-12"
 6144	cat collar of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2013-12"
 6145	shellacked forbidden suspicious-looking fedora	0		Spell Damage Percent: +50, Damage Reduction: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6047,7 +6047,7 @@
 6150	shaking Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	twirling carrot nose	0		Last Available: "2013-01"
 6152	adequate carrot cake	4	good	Last Available: "2013-01"
-6153	tolerable watered-down teal carrot claret	2	good	Last Available: "2013-01"
+6153	watered-down tolerable teal carrot claret	2	good	Last Available: "2013-01"
 6154	vaporized red carrot juice	1	crappy	Effect: "Corruption of Wretched Wally", Effect Duration: 25, Last Available: "2013-01"
 6155	tumbling yellow pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
@@ -6063,8 +6063,8 @@
 6166	fuchsia dangerous beefy deck cannon	0		Muscle: +10, Weapon Damage: +10, Last Available: "2013-12"
 6167	flame-wreathed ornamental sextant	0		Hot Spell Damage: +10, Last Available: "2013-12"
 6168	curative wicked Bloodbath	0		Spell Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
-6169	bad practically non-alcoholic narrow purple Hundred Headed IPA	1	decent	Last Available: "2013-12"
-6170	enchanted bland chum	3	decent	Effect: "Joy", Effect Duration: 30, Last Available: "2013-12"
+6169	practically non-alcoholic bad narrow purple Hundred Headed IPA	1	decent	Last Available: "2013-12"
+6170	bland enchanted chum	3	decent	Effect: "Joy", Effect Duration: 30, Last Available: "2013-12"
 6171	quadruple-cold-filtered alkaline crude crudit&eacute;s	0		Effect: "Space Tripping", Effect Duration: 36
 6172	Vulcanized candy crayons	0		Effect: "Slimed Stomach", Effect Duration: 45, Last Available: "2020-09"
 6173	Tesla pixel grappling hook of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 7, MP Regen Max: 10
@@ -6079,56 +6079,56 @@
 6182	cosmic cream	0		
 6183	pulsating ghostly cosmic fruit	0		
 6184	rosewater-soaked chilly Herculean Jarlsberg's hat	0		Experience (Muscle): +1, Cold Damage: +5, Stench Resistance: +3
-6185	half-sized moldy enchanted mirror consummate hard-boiled egg	2	crappy	Effect: "Once Bitten Twice Fried", Effect Duration: 5
+6185	moldy enchanted half-sized mirror consummate hard-boiled egg	2	crappy	Effect: "Once Bitten Twice Fried", Effect Duration: 5
 6186	rotten gigantic consummate fried egg	7	crappy	
 6187	flavorless diet consummate egg salad	1	decent	
-6188	special flavorless squat consummate bagel	3	decent	Effect: "Vanity Rage", Effect Duration: 50
+6188	flavorless special squat consummate bagel	3	decent	Effect: "Vanity Rage", Effect Duration: 50
 6189	flavorless consummate sliced bread	3	decent	
-6190	small moldy enchanted consummate hot dog bun	2	crappy	Effect: "Cotton Mouthed", Effect Duration: 25
+6190	enchanted small moldy consummate hot dog bun	2	crappy	Effect: "Cotton Mouthed", Effect Duration: 25
 6191	stale consummate brownie	4	decent	
-6192	adequate jumbo consummate toast	5	good	
+6192	jumbo adequate consummate toast	5	good	
 6193	aged gray passable stout	3	awesome	
 6194	tasty consummate soup	3	awesome	
 6195	moldy consummate corn chips	3	crappy	
-6196	stale huge consummate salad	8	decent	
-6197	immense stale consummate salsa	10	decent	
+6196	huge stale consummate salad	8	decent	
+6197	stale immense consummate salsa	10	decent	
 6198	flavorless consummate sauerkraut	4	decent	
 6199	adequate massive consummate cheese slice	7	good	
 6200	normal consummate melted cheese	3	good	
-6201	low-calorie decent huge consummate bacon	1	good	
+6201	decent low-calorie huge consummate bacon	1	good	
 6202	adequate consummate meatloaf	4	good	
 6203	bland consummate steak	3	decent	
 6204	rotten consummate cuts	3	crappy	
 6205	decent huge consummate frankfurter	7	good	
-6206	small adequate teal consummate french fries	2	good	
-6207	bite-sized moldy consummate baked potato	1	crappy	
+6206	adequate small teal consummate french fries	2	good	
+6207	moldy bite-sized consummate baked potato	1	crappy	
 6208	weak hand-crafted acceptable vodka	2	EPIC	
-6209	half-sized normal consummate ice cream	2	good	
-6210	huge enchanted flavorless consummate whipped cream	6	decent	Effect: "Compensatory Cruelness", Effect Duration: 45
+6209	normal half-sized consummate ice cream	2	good	
+6210	enchanted flavorless huge consummate whipped cream	6	decent	Effect: "Compensatory Cruelness", Effect Duration: 45
 6211	normal consummate cream	3	good	
 6212	normal consummate strawberries	3	good	
-6213	flavorless miniature bouncing maroon consummate sorbet	2	decent	
+6213	miniature flavorless bouncing maroon consummate sorbet	2	decent	
 6214	tolerable lime green adequate rum	3	good	
-6215	special perfectly mixed mediocre lager	4	EPIC	Effect: "Gr8ness", Effect Duration: 40
-6216	delicious half-sized fancy immaculate grilled cheese	2	awesome	Effect: "Ten out of Ten", Effect Duration: 10
+6215	perfectly mixed special mediocre lager	4	EPIC	Effect: "Gr8ness", Effect Duration: 40
+6216	fancy half-sized delicious immaculate grilled cheese	2	awesome	Effect: "Ten out of Ten", Effect Duration: 10
 6217	half-sized bland immaculate ice cream sandwich	2	decent	
 6218	toothsome snack-sized immaculate hot dog	2	awesome	
 6219	flavorless immaculate egg salad sandwich	3	decent	
 6220	flavorless perfect sandwich	3	decent	
 6221	decent wobbly perfect chef salad	4	good	
 6222	flavorless half-sized perfect breakfast	2	decent	
-6223	yummy special sublime deluxe hot dog	3	awesome	Effect: "Always be Collecting", Effect Duration: 20
-6224	normal small sublime stew	2	good	
-6225	flavorless squat blue sublime nachos	3	decent	
+6223	special yummy sublime deluxe hot dog	3	awesome	Effect: "Always be Collecting", Effect Duration: 20
+6224	small normal sublime stew	2	good	
+6225	flavorless blue squat sublime nachos	3	decent	
 6226	decent enchanted Ultimate Breakfast Sandwich	3	good	Effect: "Like a Fish to Walter", Effect Duration: 15
 6227	adequate Loaded Baked Potato	3	good	
 6228	rotten Omega Sundae	4	crappy	
 6229	mediocre boozy spinning Das Sauerlager	5	decent	
 6230	tolerable Bologna Lambic	3	good	
 6231	practically non-alcoholic bad Vodka Dog	1	decent	
-6232	practically non-alcoholic artisanal upside-down Disappointed Russian	1	super ultra EPIC	
-6233	fancy aged gray Chunky Mary	4	awesome	Effect: "Just the Brown Ones", Effect Duration: 10
-6234	practically non-alcoholic mediocre Nachojito	1	decent	
+6232	artisanal practically non-alcoholic upside-down Disappointed Russian	1	super ultra EPIC	
+6233	aged fancy gray Chunky Mary	4	awesome	Effect: "Just the Brown Ones", Effect Duration: 10
+6234	mediocre practically non-alcoholic Nachojito	1	decent	
 6235	tolerable Le Roi	4	good	
 6236	fancy perfectly mixed Over Easy Rider	3	EPIC	Effect: "Gummiskin", Effect Duration: 30
 6237	cosmic six-pack	0		
@@ -6174,7 +6174,7 @@
 6278	Ye Olde Medieval Insult	0		
 6279	Fonzie's pewter claymore	0		Experience (Moxie): +1
 6280	wobbly up-at-dawn artisanal rice peeler	0		Adventures: +5
-6281	spoiled thick heirloom grape tomato	5	crappy	
+6281	thick spoiled heirloom grape tomato	5	crappy	
 6282	yellow huge chipotle wasabi cilantro aioli	0		
 6283	Annie Oakley's brown felt tophat	0		Critical Hit Percent: +20, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6186,7 +6186,7 @@
 6290	steam-powered model rocketship	0		
 6291	crafty medical-grade punk rock jacket	0		Maximum MP: +10, HP Regen Min: 7, HP Regen Max: 10
 6292	lime green dangerous safety pin	0		Weapon Damage: +10, Item Drop: +5
-6293	miniature delicious stolen sushi	2	awesome	
+6293	delicious miniature stolen sushi	2	awesome	
 6294	huge very overdue library book	0		
 6295	tumbling drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6264,12 +6264,12 @@
 6368	Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	mediocre extra-dry huge can of the cheapest beer	5	decent	
+6371	extra-dry mediocre huge can of the cheapest beer	5	decent	
 6372	tolerable triple-distilled bottle of fruity &quot;wine&quot;	7	good	
-6373	high-proof drinkable spinning single swig of vodka	7	good	
+6373	drinkable high-proof spinning single swig of vodka	7	good	
 6374	narrow gray angry inch	0		
 6375	jittery testy toolbox of incineration	0		Hot Spell Damage: +50
-6376	shaking ghostly Jick-o-User	0		
+6376	ghostly shaking Jick-o-User	0		
 6378	skewed eraser nubbin	0		
 6379	wobbly chlorine crystal	0		
 6380	moist ph balancer	0		Effect: "There Is A Spoon", Effect Duration: 68
@@ -6312,14 +6312,14 @@
 6417	twist of lime	0		
 6418	squat pencil stub	0		
 6419	electrified deionized blinking cyan moth dust	0		Effect: "Hot Blooded", Effect Duration: 20
-6420	magnetized maroon huge glob of spoiled mayo	0		Effect: "The Smeezingtons", Effect Duration: 20
+6420	magnetized huge maroon glob of spoiled mayo	0		Effect: "The Smeezingtons", Effect Duration: 20
 6421	tonic djinn	0		
 6422	snack-sized spoiled vampire chowder	2	crappy	
 6423	Tales of Dread	0		Free Pull
 6424	blurry Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	immense moldy Dreadsylvanian stew	6	crappy	
-6427	artisanal special irresponsibly strong Dreadsylvanian	10	EPIC	Effect: "Emotion Sickness", Effect Duration: 15
+6426	moldy immense Dreadsylvanian stew	6	crappy	
+6427	special irresponsibly strong artisanal Dreadsylvanian	10	EPIC	Effect: "Emotion Sickness", Effect Duration: 15
 6428	enhanced Dreadsylvanian flask	0		Effect: "Creepin' Up on You", Effect Duration: 63
 6429	double-moist Dreadsylvanian flask	0		Effect: "Ripping, Dripping", Effect Duration: 23
 6430	ruddy Rosewater's dreadful fedora	0		Mysticality Percent: +30, Maximum HP Percent: +40, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6360,7 +6360,7 @@
 6465	inspector's friendly Mayor Ghost's gavel of the overflowing toilet	0		Familiar Weight: +3, Stench Spell Damage: +50, Item Drop: +15, Conditional Skill (Equipped): "Hammer Ghost"
 6466	ghostly auspicious curative Mayor Ghost's sash of the sewer	0		Stench Damage: +25, Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 6467	pulsating ghostly Mayor Ghost's scissors	0		
-6468	immense bland ghost pepper	9	decent	
+6468	bland immense ghost pepper	9	decent	
 6469	spinning sizzling electrified Thunkula's drinking cap of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	hardy hardened wicked Drunkula's cape	0		Spell Damage: +5, Damage Reduction: 3, Maximum HP: +50, Class: "Sauceror"
 6471	bouncing supercharged fortified wicked Drunkula's silky pants	0		Spell Damage: +5, Damage Absorption: +60, Maximum MP Percent: +30, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6384,9 +6384,9 @@
 6489	music box parts	0		
 6490	tumbling unwound mechanical songbird	0		
 6491	wobbly tailfeathers	0		Familiar Weight: +5
-6492	tumbling skewed wax banana	0		
+6492	skewed tumbling wax banana	0		
 6493	complicated lock impression	0		
-6494	blue blurry replica key	0		
+6494	blurry blue replica key	0		
 6495	banded Dreadsylvania Auditor's badge	0		Damage Absorption: +100, Kruegerand Drop: 5, Single Equip
 6496	pulsating blood kiwi	0		
 6497	spinning eau de mort	0		
@@ -6410,7 +6410,7 @@
 6515	flame-wreathed eerie fetish	0		Hot Spell Damage: +10, Single Equip
 6516	acceptable practically non-alcoholic bouncing stinkwater	1	good	
 6517	spinning dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	snack-sized stale accidental mutton	2	decent	
+6518	stale snack-sized accidental mutton	2	decent	
 6519	double-paned dangerous drafty drawers	0		Weapon Damage: +10, Cold Resistance: +5, Familiar Effect: "1.5xVolley"
 6520	hale wolfskull mask of bravery	0		Maximum HP: +20, Spooky Resistance: +5, Familiar Effect: "spooky atk, 1xBarrr"
 6521	purple knitted guts necklace	0		Cold Resistance: +3, Single Equip
@@ -6421,7 +6421,7 @@
 6526	vibrating occult bag of unfinished business	0		Spell Damage Percent: +25, Maximum MP Percent: +10
 6527	chilly transparent pants of wisdom	0		Mysticality: +15, Cold Damage: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	mirror razor-sharp hothammer	0		Weapon Damage Percent: +25
-6529	hand-crafted extra-dry green Thriller Ice	5	EPIC	
+6529	extra-dry hand-crafted green Thriller Ice	5	EPIC	
 6530	upside-down bouncing MacGyver's grandfather watch	0		Maximum MP: +100, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	toasty spyglass of horror	0		Hot Damage: +5, Spooky Spell Damage: +25
@@ -6441,7 +6441,7 @@
 6547	pulsating Thwaitgold Goliath beetle statuette	0		
 6548	cooling iron helmet	0		
 6549	cooling iron breastplate	0		
-6550	ghostly purple cooling iron greaves	0		
+6550	purple ghostly cooling iron greaves	0		
 6551	bouncing hot cluster	0		
 6552	cluster	0		
 6553	bouncing cluster	0		
@@ -6451,14 +6451,14 @@
 6557	chilled phial of coldness	0		Effect: "Raging Animal", Effect Duration: 44
 6558	cold-filtered dry phial of spookiness	0		Effect: "Boletus Swoletus", Effect Duration: 11
 6559	liquefied polymerized dry upside-down phial of stench	0		Effect: "Bread Burps", Effect Duration: 63
-6560	chilled aerosolized wobbly squat phial of sleaziness	0		Effect: "Egg-stra Arm", Effect Duration: 21
+6560	chilled aerosolized squat wobbly phial of sleaziness	0		Effect: "Egg-stra Arm", Effect Duration: 21
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	blue shaking lion tamer's hand of Mr. Cards	0		Experience (familiar): +2, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	snack-sized decent Dreadsylvanian hot pocket	2	good	
 6565	rotten thick Dreadsylvanian pocket	5	crappy	
 6566	tasty wobbly Dreadsylvanian pocket	3	awesome	
-6567	flavorless super-sized Dreadsylvanian stink pocket	5	decent	
+6567	super-sized flavorless Dreadsylvanian stink pocket	5	decent	
 6568	moldy Dreadsylvanian sleaze pocket	3	crappy	
 6569	tolerable enchanted Dreadsylvanian hot toddy	3	good	Effect: "Dilated Pupils", Effect Duration: 20
 6570	lousy Dreadsylvanian cold-fashioned	3	decent	
@@ -6467,7 +6467,7 @@
 6573	weak lousy Dreadsylvanian slithery nipple	2	decent	
 6574	bouncing hot clusterbomb	0		
 6575	clusterbomb	0		
-6576	huge fuchsia clusterbomb	0		
+6576	fuchsia huge clusterbomb	0		
 6577	stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	tumbling Dreadsylvanian Almanac page	0		
@@ -6512,7 +6512,7 @@
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	squat folder (green)	0		Moxie: +20, Last Available: "2013-08"
-6621	twirling blurry folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
+6621	blurry twirling folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	frozen flattened blurry Ogres and Oubliettes&trade; module	0		Effect: "Pumped Stomach", Effect Duration: 59
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	watered-down acceptable wobbly stepmom's booze	2	good	
+6652	acceptable watered-down wobbly stepmom's booze	2	good	
 6653	blinking surgical tape	0		
 6654	extremely unsafe band T-shirt	0		Weapon Damage Percent: +100
 6655	hand-crafted fountain 'soda'	4	EPIC	
@@ -6557,9 +6557,9 @@
 6665	knitted deathchucks of extreme caution	0		Monster Level: -25, Cold Resistance: +3
 6666	eraser	0		
 6667	wobbly quasireligious sculpture	0		
-6668	red huge Faraday cage	0		
+6668	huge red Faraday cage	0		
 6669	modeling claymore	0		
-6670	green jittery clay homunculus	0		
+6670	jittery green clay homunculus	0		
 6671	energized moist non-vacuum-sealed purple sodium pentasomething	0		Effect: "Aided and Abetted", Effect Duration: 23
 6672	green grains of salt	0		
 6673	narrow yellowcake bomb	0		
@@ -6571,7 +6571,7 @@
 6679	spinning fireproof machete	0		Hot Resistance: +3
 6680	hand-crafted Cursed Punch	4	EPIC	
 6681	acceptable Bowl of Scorpions	4	good	
-6682	weak mediocre tumbling Fog Murderer	2	decent	
+6682	mediocre weak tumbling Fog Murderer	2	decent	
 6683	green book of matches	0		
 6684	ribald surgical mask	0		Sleaze Damage: +10, Surgeonosity: +1
 6685	blue spinning head mirror of Tarzan	0		Experience (Muscle): +3, Surgeonosity: +1
@@ -6589,7 +6589,7 @@
 6697	moss-covered stone sphere	0		
 6698	jittery dripping stone sphere	0		
 6699	crackling stone sphere	0		
-6700	blurry lime green scorched stone sphere	0		
+6700	lime green blurry scorched stone sphere	0		
 6701	stone triangle	0		
 6702	bowler	0		
 6703	imitation White Russian	1	crappy	
@@ -6613,10 +6613,10 @@
 6721	up-at-dawn auspicious Temple Grandin's water bottle	0		Familiar Weight: +7, Item Drop: +10, Adventures: +5, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	adjusted Vulcanized shaking pygmy phone number	0		Effect: "Muscularrr", Effect Duration: 43
 6723	Boozehounds Anonymous token	0		
-6724	miniature flavorless blue exotic jungle fruit	2	decent	
+6724	flavorless miniature blue exotic jungle fruit	2	decent	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
-6727	gray blurry tropical island souvenir crate	0		
+6727	blurry gray tropical island souvenir crate	0		
 6728	olive ski resort souvenir crate	0		
 6729	tumbling UV-resistant compass	0		
 6730	funky junk key	0		
@@ -6650,12 +6650,12 @@
 6758	acceptable fancy can of Drooling Monk	4	good	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 30, Last Available: "2013-09"
 6759	acceptable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	bad bottle of Old Pugilist	4	decent	Last Available: "2013-09"
-6761	delicious fortified teal bottle of Professor Beer	5	awesome	Last Available: "2013-09"
+6761	fortified delicious teal bottle of Professor Beer	5	awesome	Last Available: "2013-09"
 6762	mediocre red bottle of Rapier Witbier	4	decent	Last Available: "2013-09"
 6763	smooth bottle of Race Car Red	4	awesome	Last Available: "2013-09"
-6764	aged high-proof gray bottle of Greedy Dog	8	awesome	Last Available: "2013-09"
+6764	high-proof aged gray bottle of Greedy Dog	8	awesome	Last Available: "2013-09"
 6765	drinkable high-proof tumbling bottle of Lambada Lambic	7	good	Last Available: "2013-09"
-6766	maroon jittery huge upside-down tin beer can	0		
+6766	huge upside-down jittery maroon tin beer can	0		
 6767	ghostly artisanal homebrew gift package	0		
 6768	liquid bread	1	awesome	Last Available: "2013-09"
 6769	therapeutic dance instructor's Herculean tin tam	0		Experience (Muscle): +1, Experience Percent (Moxie): +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
@@ -6719,7 +6719,7 @@
 6830	Temporal Tempera Tube of the scaredy-cat	0		Monster Level: -15
 6831	dry Tallowcreme Halloween Pumpkin	0		Effect: "Stick Emporium Membership", Effect Duration: 33
 6832	skewed Way More Tears&trade; pepper spray	0		
-6833	moist yellow skewed Milk Studs	0		Effect: "Bastard!", Effect Duration: 68
+6833	moist skewed yellow Milk Studs	0		Effect: "Bastard!", Effect Duration: 68
 6834	altered unsweetened ionized box of Dweebs	0		Effect: "There Wolf", Effect Duration: 32
 6835	non-colloidal super-unsweetened huge bag of W&Ws	0		Effect: "Booing Radly", Effect Duration: 37
 6836	nitrogenated PEEZ dispenser	0		Effect: "Thickest, Sickest", Effect Duration: 36
@@ -6728,7 +6728,7 @@
 6839	colloidal corrupted skewed jam	0		Effect: "Dance Interpreter", Effect Duration: 27
 6840	pickled squat Whenchamacallit bar	0		Effect: "Egged On", Effect Duration: 16
 6841	extra-diffused blinking cyan 8-bit banana	0		Effect: "Armored Innards", Effect Duration: 30
-6842	energized deionized non-concentrated bouncing skewed vial of blood simple syrup	0		Effect: "The Moxious Madrigal", Effect Duration: 12
+6842	energized deionized non-concentrated skewed bouncing vial of blood simple syrup	0		Effect: "The Moxious Madrigal", Effect Duration: 12
 6843	magnetized tumbling bone bons	0		Effect: "Rampage!", Effect Duration: 69
 6844	vacuum-sealed polymerized adjusted blinking ironic mint	0		Effect: "Witch's Brood", Effect Duration: 32
 6845	unused walkie-talkie	0		Free Pull
@@ -6750,16 +6750,16 @@
 6861	yummy can of sardines	3	awesome	Last Available: "2013-11"
 6862	moldy skewed high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
 6863	stale diet skewed pat of butter	1	decent	Last Available: "2013-11"
-6864	bland immense dinner roll	9	decent	Last Available: "2013-11"
+6864	immense bland dinner roll	9	decent	Last Available: "2013-11"
 6865	miniature spoiled huge mashed potatoes	2	crappy	Last Available: "2013-11"
-6866	adequate snack-sized skewed whole turkey leg	2	good	Last Available: "2013-11"
+6866	snack-sized adequate skewed whole turkey leg	2	good	Last Available: "2013-11"
 6867	decent wobbly deviled egg	3	good	Last Available: "2013-11"
 6868	liquefied alkaline finger exerciser	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 35, Last Available: "2013-11"
 6869	alkaline dented spoon	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 28, Last Available: "2013-11"
 6870	double-alkaline altered gray love note	0		Effect: "Rootin' Around", Effect Duration: 17, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	quantum non-galvanized skewed nail file	0		Effect: "Fustulent", Effect Duration: 44, Last Available: "2013-11"
-6873	frozen dry polarized maroon mirror candy wrapper	0		Effect: "Spooky Jellied", Effect Duration: 65, Last Available: "2013-11"
+6873	frozen dry polarized mirror maroon candy wrapper	0		Effect: "Spooky Jellied", Effect Duration: 65, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	quadruple-moist post-holiday sale coupon	0		Effect: "Weepy, Creepy", Effect Duration: 59, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
@@ -6791,7 +6791,7 @@
 6902	twirling gravedigger's dance instructor's flask flops	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Single Equip
 6903	non-colloidal wobbly nuts	0		Effect: "Elron's Explosive Etude", Effect Duration: 24, Last Available: "2013-12"
 6904	boiled frozen bolts	0		Effect: "Punch Another Day", Effect Duration: 46, Last Available: "2013-12"
-6905	flavorless special super-sized gingerbread robot	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 20, Last Available: "2013-12"
+6905	flavorless super-sized special gingerbread robot	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 20, Last Available: "2013-12"
 6906	normal jumbo petit 4.1	5	good	Last Available: "2013-12"
 6907	diet stale nut-shaped Crimbo cookie	1	decent	Last Available: "2023-06"
 6908	nasty plastic GORM-8	0		Stench Damage: +5, Last Available: "2013-12"
@@ -6808,7 +6808,7 @@
 6919	super-pressed ghostly upside-down warbear bearserker potion	0		Effect: "Familial Ties", Effect Duration: 22, Last Available: "2013-12"
 6920	quantum cold-filtered maroon warbear liquid overcoat	0		Effect: "Coated Arms", Effect Duration: 49, Last Available: "2013-12"
 6921	small spoiled warbear feasting bread	2	crappy	Last Available: "2013-12"
-6922	tasty fancy blurry warbear warrior bread	3	awesome	Effect: "Can't Smell Nothin'", Effect Duration: 45, Last Available: "2013-12"
+6922	fancy tasty blurry warbear warrior bread	3	awesome	Effect: "Can't Smell Nothin'", Effect Duration: 45, Last Available: "2013-12"
 6923	bite-sized moldy shaking shaking warbear thermoregulator bread	1	crappy	Last Available: "2013-12"
 6924	bad pulsating warbear feasting mead	4	decent	Last Available: "2013-12"
 6925	watered-down tolerable fuchsia warbear bearserker mead	2	good	Last Available: "2013-12"
@@ -6856,9 +6856,9 @@
 6967	upside-down warbear chemistry lab	0		Last Available: "2013-12"
 6968	warbear officer requisition box	0		Last Available: "2013-12"
 6969	warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
-6970	jittery huge warbear drone assembler	0		Last Available: "2013-12"
+6970	huge jittery warbear drone assembler	0		Last Available: "2013-12"
 6971	warbear breakfast machine assembler	0		Last Available: "2013-12"
-6972	upside-down mirror blind-packed die-cast toy	0		Last Available: "2013-12"
+6972	mirror upside-down blind-packed die-cast toy	0		Last Available: "2013-12"
 6973	spinning savvy die-cast Bashful the Reindeer	0		Mysticality Percent: +20, Last Available: "2013-12"
 6974	mirror Rosewater's die-cast Doc the Reindeer	0		Mysticality Percent: +30, Last Available: "2013-12"
 6975	skewed zippy die-cast Dopey the Reindeer	0		Initiative: +20, Last Available: "2013-12"
@@ -6895,10 +6895,10 @@
 7006	dried blue handful of Smithereens	1	EPIC	Last Available: "2013-12"
 7007	big decent Every Day is Like This Sundae	5	good	Last Available: "2013-12"
 7008	adequate Miserable Pie	3	good	Last Available: "2013-12"
-7009	huge delicious This Charming Flan	6	awesome	Last Available: "2013-12"
+7009	delicious huge This Charming Flan	6	awesome	Last Available: "2013-12"
 7010	practically non-alcoholic perfectly mixed Irish Coffee, English Heart	1	EPIC	Last Available: "2013-12"
 7011	artisanal Strikes Again Bigmouth	3	EPIC	Last Available: "2013-12"
-7012	watered-down artisanal Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
+7012	artisanal watered-down Paint A Vulgar Pitcher	2	EPIC	Last Available: "2013-12"
 7013	skewed Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	upside-down Handsome Devil	0		Last Available: "2013-12"
@@ -6945,7 +6945,7 @@
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	adequate wobbly breakfast miracle	4	good	Last Available: "2013-12"
 7058	extra-liquefied warmed Cloaca Cola Polar	0		Effect: "Healthy Blue Glow", Effect Duration: 17, Last Available: "2013-12"
-7059	maroon tumbling warbear soda machine	0		Last Available: "2013-12"
+7059	tumbling maroon warbear soda machine	0		Last Available: "2013-12"
 7060	huge twirling festive warbear bank	0		Last Available: "2013-12"
 7061	huge grimstone mask	0		Last Available: "2014-12"
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
@@ -6976,7 +6976,7 @@
 7087	snow belt of the wise owl of extreme caution of horror	0		Mysticality: +20, Monster Level: -25, Spooky Spell Damage: +25, Item Drop: +5, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	squat squat scandalous dance instructor's supercool ice nine of temperance	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Sleaze Damage: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	fortified hand-crafted En Una Fila Tequila	5	EPIC	
+7090	hand-crafted fortified En Una Fila Tequila	5	EPIC	
 7091	Skully's hot chocolate	1	decent	
 7092	blurry razor-sharp cool warbear dress helmet	0		Moxie: +5, Weapon Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	Tesla sage warbear dress bracers	0		Mysticality Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-12"
@@ -6986,8 +6986,8 @@
 7097	fireproof deadly ankleweights	0		Weapon Damage: +5, Hot Resistance: +3, Single Equip, Last Available: "2014-12"
 7098	fireproof Oprah's dance instructor's sweat socks of the empath	0		Experience Percent (Moxie): +10, Maximum MP Percent: +50, Familiar Weight: +5, Hot Resistance: +3, Last Available: "2014-12"
 7099	blinking blinking pint of sweat	0		Last Available: "2014-12"
-7100	upside-down ghostly Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	modified wobbly huge gray Five Second Energy&trade;	1		Effect: "Strength of Ten Ettins", Effect Duration: 20, Last Available: "2014-12"
+7100	ghostly upside-down Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
+7101	modified gray wobbly huge Five Second Energy&trade;	1		Effect: "Strength of Ten Ettins", Effect Duration: 20, Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
 7103	extra-warmed non-pickled powder	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 14, Last Available: "2014-12"
 7104	blinking lightning-fast licorice whip	0		Initiative: +40, Last Available: "2014-12"
@@ -6997,15 +6997,15 @@
 7108	adequate pecan	3	good	Last Available: "2014-12"
 7109	normal small pecan pie	2	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	half-sized tasty jittery candy mountain oyster	2	awesome	Last Available: "2014-12"
+7111	tasty half-sized jittery candy mountain oyster	2	awesome	Last Available: "2014-12"
 7112	hand-crafted spinning chocotini	4	EPIC	Last Available: "2014-12"
 7113	supercharged hale dance instructor's chocolate rabbit's foot	0		Experience Percent (Moxie): +10, Maximum HP: +20, Maximum MP Percent: +30, Last Available: "2014-12"
-7114	bland super-sized candy carrot	5	decent	Last Available: "2014-12"
+7114	super-sized bland candy carrot	5	decent	Last Available: "2014-12"
 7115	normal candy carrot cake	3	good	Last Available: "2014-12"
 7116	huge red flame-wreathed smartaleck's carrot-on-a-stick	0		Moxie Percent: +30, Hot Spell Damage: +10, Last Available: "2014-12"
 7117	shellacked weasel stomping pants of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 7, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	bite-sized flavorless special mulberry	1	decent	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 45, Last Available: "2014-12"
-7119	practically non-alcoholic acceptable mulled berry wine	1	good	Last Available: "2014-12"
+7119	acceptable practically non-alcoholic mulled berry wine	1	good	Last Available: "2014-12"
 7120	huge lemony scales	0		Last Available: "2014-12"
 7121	Sherlock's lemon party hat	0		Item Drop: +25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	forbidden lemon shirt	0		Spell Damage Percent: +50, Lasts Until Rollover, Last Available: "2014-12"
@@ -7016,12 +7016,12 @@
 7127	Temple Grandin's chocolate cow bone	0		Familiar Weight: +7, Last Available: "2014-12"
 7128	extra-concentrated tarnished gummi fang	0		Effect: "Weird Flavor", Effect Duration: 16, Last Available: "2014-12"
 7129	bland leftover canap&eacute;s	4	decent	Last Available: "2014-12"
-7130	fortified bad magnum of champagne	5	decent	Last Available: "2014-12"
+7130	bad fortified magnum of champagne	5	decent	Last Available: "2014-12"
 7131	teal rosewater-soaked beefcake's cow creamer of James Dean	0		Muscle: +25, Experience (Moxie): +3, Stench Resistance: +3, Last Available: "2014-12"
 7132	extra-vacuum-sealed skewed Outer Wolf&trade; cologne	0		Effect: "Phorcefullness", Effect Duration: 62, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	wobbly resourceful wolf whistle of the blizzard	0		Maximum MP: +50, Cold Spell Damage: +25, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	half-sized bland enchanted witch's bread	2	decent	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2014-12"
+7135	bland half-sized enchanted witch's bread	2	decent	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2014-12"
 7136	liquefied polymerized witch's brew	0		Effect: "Arresistible", Effect Duration: 11, Last Available: "2014-12"
 7137	double-paned Annie Oakley's witch's bra of the pedagogue	0		Experience: +3, Critical Hit Percent: +20, Cold Resistance: +5, Last Available: "2014-12"
 7138	smooth mid-level medieval mead	4	awesome	Last Available: "2014-12"
@@ -7044,13 +7044,13 @@
 7155	bouncing parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	gray sage brawny fire hose of the ox	0		Muscle: +20, Muscle Percent: +20, Mysticality Percent: +10, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	stale thick fireman's lunch	5	decent	Last Available: "2014-12"
+7158	thick stale fireman's lunch	5	decent	Last Available: "2014-12"
 7159	Temple Grandin's resourceful steel-toed plain paper hat	0		Damage Reduction: 9, Maximum MP: +50, Familiar Weight: +7, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	spoiled ice cream sandwich	4	crappy	Last Available: "2014-12"
 7161	knitted Van der Graaf &quot;honey&quot; dipper of the early riser	0		Cold Resistance: +3, Adventures: +7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7162	fancy stale plumber's lunch	3	decent	Effect: "Strong Grip", Effect Duration: 30, Last Available: "2014-12"
 7163	ribald hardened thinker's skull gearshift knob	0		Mysticality: +10, Damage Reduction: 3, Sleaze Damage: +10, Last Available: "2014-12"
-7164	flavorless miniature enchanted nachos of the night	2	decent	Effect: "Concentrated Concentration", Effect Duration: 40, Last Available: "2014-12"
+7164	miniature enchanted flavorless nachos of the night	2	decent	Effect: "Concentrated Concentration", Effect Duration: 40, Last Available: "2014-12"
 7165	frightening therapeutic padded Sketcherz&trade;	0		Damage Absorption: +20, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7166	toothsome low-calorie special can of Adultwitch&trade;	1	awesome	Effect: "Fastbreaker", Effect Duration: 20, Last Available: "2014-12"
 7167	ionized warmed smudge stick	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 64, Last Available: "2014-12"
@@ -7059,7 +7059,7 @@
 7170	warmed nitrogenated scroll case	0		Effect: "Saucefingers", Effect Duration: 11, Last Available: "2014-12"
 7171	pressed jug of &quot;wine&quot;	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 38, Last Available: "2014-12"
 7172	lime green juggling ball	0		Last Available: "2014-12"
-7173	blinking spinning crappy camera	0		Last Available: "2014-12"
+7173	spinning blinking crappy camera	0		Last Available: "2014-12"
 7174	bland small humble pie	2	decent	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	maroon shaking crappy camera	0		Last Available: "2014-12"
@@ -7071,9 +7071,9 @@
 7182	The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	tumbling shaking wobbly The Shield of Brook	0		
-7185	jittery blurry Red Zeppelin ticket	0		
+7185	blurry jittery Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	artisanal distilled wobbly bouncing unnamed cocktail	5	EPIC	
+7187	distilled artisanal wobbly bouncing unnamed cocktail	5	EPIC	
 7188	handful of tips	0		
 7189	pulsating censurious unrequired jacket	0		Sleaze Resistance: +3
 7190	deadly tommy gun	0		Weapon Damage: +5, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7082,7 +7082,7 @@
 7193	throwing spoon	0		
 7194	throwing fork	0		
 7195	hale rosy-cheeked breadchucks	0		Maximum HP Percent: +30, Maximum HP: +20
-7196	blurry olive shuriken salad	0		
+7196	olive blurry shuriken salad	0		
 7197	teal blurry coward's combat fan	0		Monster Level: -20
 7198	silk skirt of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, Familiar Effect: "atk, 1xFairy, cap 38"
 7199	bouncing blowdart	0		
@@ -7101,7 +7101,7 @@
 7212	hardy Jefferson wings	0		Maximum HP: +50
 7213	narrow fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	fancy spoiled fleetwood mac 'n' cheese	4	crappy	Effect: "Colorful Gratitude", Effect Duration: 25
+7215	spoiled fancy fleetwood mac 'n' cheese	4	crappy	Effect: "Colorful Gratitude", Effect Duration: 25
 7216	lynyrd skin	0		
 7217	spinning steel-toed lynyrdskin cap	0		Damage Reduction: 9, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	pulsating mirror lynyrdskin tunic of mayonnaise	0		Sleaze Spell Damage: +50
@@ -7111,7 +7111,7 @@
 7222	acceptable weak bouncing Flamin' Whatshisname	2	good	
 7223	denatured dry lynyrd musk	0		Effect: "Alchemical, Brother", Effect Duration: 49
 7224	hardened sage Kashmir sweater	0		Mysticality Percent: +10, Damage Reduction: 3
-7225	immense decent custard pie	8	good	
+7225	decent immense custard pie	8	good	
 7226	tumbling tea for one	1	decent	
 7227	lousy bottle of Evermore	3	decent	
 7228	box	0		
@@ -7119,7 +7119,7 @@
 7230	tolerable rum	4	good	
 7231	smooth Murderer's Punch	3	awesome	
 7232	stale velvet cake	3	decent	
-7233	denatured polymerized olive skewed letter	0		Effect: "Tingly Biceps", Effect Duration: 31
+7233	denatured polymerized skewed olive letter	0		Effect: "Tingly Biceps", Effect Duration: 31
 7234	greasy quilted book	0		Damage Absorption: +40, Sleaze Spell Damage: +10
 7235	teal Samson's brainy masque	0		Mysticality: +5, Experience (Muscle): +5, Single Equip
 7236	ribald red-hot poker	0		Sleaze Damage: +10
@@ -7130,8 +7130,8 @@
 7241	toasty shoe of the brute	0		Muscle Percent: +30, Hot Damage: +5, Single Equip
 7242	button	0		
 7243	button	0		
-7244	energized boiled shaking blinking blood cells	0		Effect: "Educated (Kinda)", Effect Duration: 44
-7245	concentrated ghostly lime green eye	0		Effect: "Libra Rising", Effect Duration: 39
+7244	energized boiled blinking shaking blood cells	0		Effect: "Educated (Kinda)", Effect Duration: 44
+7245	concentrated lime green ghostly eye	0		Effect: "Libra Rising", Effect Duration: 39
 7246	glark cable	0		
 7247	narrow ruddy Herculean Red Fox glove	0		Experience (Muscle): +1, Maximum HP Percent: +40, Attacks Can't Miss, Single Equip
 7248	liquefied polymerized foxglove	0		Effect: "Snobby", Effect Duration: 18
@@ -7141,14 +7141,14 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	triple-distilled lousy mini-martini	8	decent	
+7255	lousy triple-distilled mini-martini	8	decent	
 7256	blinking smoke grenade	0		
 7257	distilled molotov soda	1	decent	
 7258	ionized teal pile of ashes	0		Effect: "Heart of White", Effect Duration: 49
 7259	crate of firebombs	0		
 7260	firebomb	0		
 7261	greedy Herculean Rosewater's Sneaky Pete's basket	0		Mysticality Percent: +30, Experience (Muscle): +1, Meat Drop: +20
-7262	red shaking &quot;I Love Me, Vol. I&quot;	0		
+7262	shaking red &quot;I Love Me, Vol. I&quot;	0		
 7263	red photograph of a dog	0		
 7264	red photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
@@ -7156,7 +7156,7 @@
 7267	wool toasty nippy Sneaky Pete's jacket (collar popped) of extreme caution	0		Monster Level: -25, Cold Damage: +10, Hot Damage: +5, Cold Resistance: +1, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	narrow Professor What garment	0		
-7270	mirror squat &quot;2 Love Me, Vol. 2&quot;	0		
+7270	squat mirror &quot;2 Love Me, Vol. 2&quot;	0		
 7271	Thinknerd Blind-Packed Toy	0		
 7272	tumbling double-paned plastic Professor What	0		Cold Resistance: +5
 7273	pulsating therapeutic plastic Jared the Duskwalker	0		HP Regen Min: 5, HP Regen Max: 7
@@ -7176,7 +7176,7 @@
 7287	aromatic frosty Gary Claybender's Time Screwer	0		Cold Spell Damage: +10, Stench Resistance: +1, Single Equip, Lasts Until Rollover
 7288	Sherlock's Annie Oakley's Space Tourist palmdoctor	0		Critical Hit Percent: +20, Item Drop: +25, Lasts Until Rollover
 7289	shellacked extremely unsafe groovy amok putter	0		Moxie Percent: +10, Weapon Damage Percent: +100, Damage Reduction: 7
-7290	normal bite-sized narrow amok pudding	1	good	
+7290	bite-sized normal narrow amok pudding	1	good	
 7291	green deactivated putty buddy	0		
 7292	lime green putty coat	0		Familiar Weight: +5
 7293	boiled huge squat can of V-11	0		Effect: "init.enh", Effect Duration: 34, Last Available: "2014-03"
@@ -7211,12 +7211,12 @@
 7322	extra-Vulcanized modified shaking Stephen's secret formula	0		Effect: "Leisurely Amblin'", Effect Duration: 33
 7323	nippy Jacob's rung of chilblains	0		Cold Damage: 35
 7324	powdered jittery battery	1		
-7325	hand-crafted strong snakebite	5	EPIC	
+7325	strong hand-crafted snakebite	5	EPIC	
 7326	twirling gravedigger's rubber ribcage of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +10, Damage Reduction: 7
 7327	powdered synthetic marrow	1		
 7328	warmed pulsating funny bone	0		Effect: "Innately Wise", Effect Duration: 32
 7329	brawny half-melted spoon of the wise owl	0		Mysticality: +20, Muscle Percent: +20
-7330	pickled shaking yellow blurry the funk	1		
+7330	pickled shaking blurry yellow the funk	1		
 7331	decent gunky chicken	3	good	
 7332	groovy doll head	0		Moxie Percent: +10
 7333	droopy doll eye	0		
@@ -7224,7 +7224,7 @@
 7335	huge Jim Carey's paddle-ball of courage	0		Monster Level: +25, Spooky Resistance: +3
 7336	warmed liquefied ghostly sound effects record	0		Effect: "Oxygenated Blood", Effect Duration: 67
 7337	maroon alphabet block	0		
-7338	double-unsweetened blinking yellow dancer	0		Effect: "Antibiotic Saucesphere", Effect Duration: 66
+7338	double-unsweetened yellow blinking dancer	0		Effect: "Antibiotic Saucesphere", Effect Duration: 66
 7339	blurry music box mechanism	0		
 7340	lightning-fast moose antlers	0		Initiative: +40, Familiar Effect: "atk, 1xLep, cap 27"
 7341	ionized upside-down moose thought	0		Effect: "Meat the Flintstones", Effect Duration: 46
@@ -7240,7 +7240,7 @@
 7351	Annie Oakley's rock-hard fortified Staff of the Electric Range	0		Damage Absorption: +60, Damage Reduction: 5, Critical Hit Percent: +20
 7352	decent bite-sized narrow deluxe layer cake	1	good	
 7353	chunk of hot iron	0		
-7354	tolerable weak red-hot boilermaker	2	good	
+7354	weak tolerable red-hot boilermaker	2	good	
 7355	razor-sharp coal shovel	0		Weapon Damage Percent: +25, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	vacuum-sealed dry tarnished hot coal	0		Effect: "French Bronilla Brogueishness", Effect Duration: 24
 7357	modified coal dust	0		Effect: "Springy Fusilli", Effect Duration: 47
@@ -7258,7 +7258,7 @@
 7369	dry corrupted pulsating mangled finger	0		Effect: "Tea-hee", Effect Duration: 58
 7370	bad ghostly Psychotic Train wine	4	decent	
 7371	crazy hobo notebook	0		
-7372	rotten tiny blurry pie man was not meant to eat	1	crappy	
+7372	tiny rotten blurry pie man was not meant to eat	1	crappy	
 7373	wholesome sommelier's towel	0		Maximum HP Percent: +10
 7374	nippy tarnished tastevin	0		Cold Damage: +10, Single Equip
 7375	moldy miniature actual tapas	2	crappy	
@@ -7278,16 +7278,16 @@
 7389	pressed extra-irradiated Gene Tonic: Insect	0		Effect: "Warm Belly", Effect Duration: 28, Last Available: "2014-04"
 7390	double-colloidal pickled Gene Tonic: Hippy	0		Effect: "Meadulla Oblongota", Effect Duration: 34, Last Available: "2014-04"
 7391	quadruple-concentrated Gene Tonic: Orc	0		Effect: "Ocelot Eyes", Effect Duration: 40, Last Available: "2014-04"
-7392	polymerized irradiated tumbling tumbling wobbly Gene Tonic: Demon	0		Effect: "The Strength...  of the Future", Effect Duration: 34, Last Available: "2014-04"
+7392	polymerized irradiated tumbling wobbly tumbling Gene Tonic: Demon	0		Effect: "The Strength...  of the Future", Effect Duration: 34, Last Available: "2014-04"
 7393	quantum blurry Gene Tonic: Horror	0		Effect: "Ass Over Teakettle", Effect Duration: 53, Last Available: "2014-04"
 7394	adjusted Gene Tonic: Fish	0		Effect: "Nigh-Invincible", Effect Duration: 66, Last Available: "2014-04"
 7395	enhanced ghostly Gene Tonic: Goblin	0		Effect: "Turkey-Friendly", Effect Duration: 47, Last Available: "2014-04"
 7396	double-dry denatured shaking Gene Tonic: Pirate	0		Effect: "The Spy Who Loved XP", Effect Duration: 40, Last Available: "2014-04"
-7397	unsweetened moist wobbly jittery Gene Tonic: Plant	0		Effect: "Educated (Sorta)", Effect Duration: 12, Last Available: "2014-04"
+7397	unsweetened moist jittery wobbly Gene Tonic: Plant	0		Effect: "Educated (Sorta)", Effect Duration: 12, Last Available: "2014-04"
 7398	improved wobbly Gene Tonic: Weird	0		Effect: "Hammertime", Effect Duration: 47, Last Available: "2014-04"
 7399	denatured improved Gene Tonic: Elf	0		Effect: "Jungle Juiced", Effect Duration: 55, Last Available: "2014-04"
 7400	activated Gene Tonic: Mer-kin	0		Effect: "Nightstalkin'", Effect Duration: 51, Last Available: "2014-04"
-7401	diffused wobbly olive Gene Tonic: Slime	0		Effect: "Muscle Unbound", Effect Duration: 69, Last Available: "2014-04"
+7401	diffused olive wobbly Gene Tonic: Slime	0		Effect: "Muscle Unbound", Effect Duration: 69, Last Available: "2014-04"
 7402	galvanized liquefied ghostly Gene Tonic: Penguin	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 47, Last Available: "2014-04"
 7403	vacuum-sealed huge pulsating Gene Tonic: Elemental	0		Effect: "Bananas!", Effect Duration: 33, Last Available: "2014-04"
 7404	modified nitrogenated Gene Tonic: Constellation	0		Effect: "Briny Blood", Effect Duration: 51, Last Available: "2014-04"
@@ -7295,9 +7295,9 @@
 7406	tumbling Steam Card: Dungeon Fist (#1)	0		
 7407	narrow Steam Card: Dungeon Fist (#2)	0		
 7408	Steam Card: Dungeon Fist (#3)	0		
-7409	teal pulsating Steam Card: Space Trip (#1)	0		
+7409	pulsating teal Steam Card: Space Trip (#1)	0		
 7410	Steam Card: Space Trip (#2)	0		
-7411	mirror fuchsia Steam Card: Space Trip (#3)	0		
+7411	fuchsia mirror Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
 7413	Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
@@ -7324,28 +7324,28 @@
 7435	altered Stemonitis Staticus mushroom	0		Effect: "Capricorn Rising", Effect Duration: 57, Last Available: "2014-05"
 7436	deionized huge Tremella Tarantella mushroom	0		Effect: "Fungal Fortification", Effect Duration: 29, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	spoiled gigantic lime green Beefy Crunch Pastaco	10	crappy	Last Available: "2014-05"
+7438	gigantic spoiled lime green Beefy Crunch Pastaco	10	crappy	Last Available: "2014-05"
 7439	spoiled Brain Food Pastaco	3	crappy	Last Available: "2014-05"
 7440	adequate Cool Brunch Pastaco	3	good	Last Available: "2014-05"
 7441	decent big Medical Pastaco	5	good	Last Available: "2014-05"
-7442	spoiled half-sized blinking Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
-7443	delicious half-sized Ludovico Pastaco	2	awesome	Last Available: "2014-05"
-7444	extra-dry acceptable upside-down overpowering mushroom wine	5	good	Last Available: "2014-05"
+7442	half-sized spoiled blinking Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
+7443	half-sized delicious Ludovico Pastaco	2	awesome	Last Available: "2014-05"
+7444	acceptable extra-dry upside-down overpowering mushroom wine	5	good	Last Available: "2014-05"
 7445	bad complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	acceptable smooth mushroom wine	3	good	Last Available: "2014-05"
-7447	watered-down lousy blood-red mushroom wine	2	decent	Last Available: "2014-05"
-7448	artisanal practically non-alcoholic buzzing mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7447	lousy watered-down blood-red mushroom wine	2	decent	Last Available: "2014-05"
+7448	practically non-alcoholic artisanal buzzing mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7449	distilled mediocre maroon swirling mushroom wine	5	decent	Last Available: "2014-05"
-7450	decent miniature purple Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
-7451	moldy small Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
+7450	miniature decent purple Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
+7451	small moldy Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
 7452	narrow Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	lousy regular-size brogurt	4	decent	Last Available: "2014-05"
 7454	aged super-size brogurt	3	awesome	Last Available: "2014-05"
 7455	drinkable broberry brogurt	3	good	Last Available: "2014-05"
 7456	watered-down drinkable brocolate brogurt	2	good	Last Available: "2014-05"
-7457	strong smooth upside-down French bronilla brogurt	5	awesome	Last Available: "2014-05"
+7457	smooth strong upside-down French bronilla brogurt	5	awesome	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
-7459	shaking huge Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
+7459	huge shaking Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	lime green Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
 7462	baleful Brogre brorts	0		Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
@@ -7365,11 +7365,11 @@
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	activated cold-filtered red Meat-inflating powder	0		Effect: "Litterboxing", Effect Duration: 54, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
-7479	oxidized blinking upside-down sugar fairy	0		Effect: "Hare-o-dynamic", Effect Duration: 43, Last Available: "2014-05"
+7479	oxidized upside-down blinking sugar fairy	0		Effect: "Hare-o-dynamic", Effect Duration: 43, Last Available: "2014-05"
 7480	boiled gray sugar bunny	0		Effect: "Dirty Pear", Effect Duration: 64, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	perfectly mixed narrow Rompedores de Fantasmas	3	EPIC	
-7483	delicious watered-down La Fantasma y La Oscuridad	2	awesome	
+7483	watered-down delicious La Fantasma y La Oscuridad	2	awesome	
 7484	aged weak wobbly Fantasma en la M&aacute;quina	2	awesome	
 7485	spinning loosening powder	0		
 7486	bouncing castoreum	0		
@@ -7388,7 +7388,7 @@
 7499	galvanized ionized modified narrow Hot 'n' Scarys	0		Effect: "Yet tea", Effect Duration: 68
 7500	olive map	0		
 7501	ghostly	0		
-7502	vacuum-sealed polymerized wobbly narrow red Texas tea	0		Effect: "Well-Oiled", Effect Duration: 55
+7502	vacuum-sealed polymerized wobbly red narrow Texas tea	0		Effect: "Well-Oiled", Effect Duration: 55
 7503	brainy dark hamethyst ring	0		Mysticality: +5
 7504	red dark baconstone ring of the pedagogue	0		Experience: +3
 7505	fortified dark porquoise ring	0		Damage Absorption: +60
@@ -7406,8 +7406,8 @@
 7517	huge nasty MacGyver's spider leg	0		Maximum MP: +100, Stench Damage: +5
 7518	wand of pigification	0		
 7519	tolerable jittery cyan glass of bourbon	3	good	
-7520	shaking maroon burned government manual fragment	0		Last Available: "2014-05"
-7521	big flavorless government cheese	5	decent	Last Available: "2014-05"
+7520	maroon shaking burned government manual fragment	0		Last Available: "2014-05"
+7521	flavorless big government cheese	5	decent	Last Available: "2014-05"
 7522	twirling Van der Graaf pair of government shades	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2014-05"
 7523	narrow space junk	0		Last Available: "2014-05"
 7524	Vulcanized boiled spinning government	0		Effect: "Greedy Resolve", Effect Duration: 46, Last Available: "2014-05"
@@ -7415,14 +7415,14 @@
 7526	blurry squat weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	purple blurry stanky chilly government-issued night-vision goggles	0		Cold Damage: +5, Stench Spell Damage: +25, Single Equip, Last Available: "2014-05"
-7529	miniature flavorless loaf of alien bread	2	decent	Last Available: "2014-05"
+7529	flavorless miniature loaf of alien bread	2	decent	Last Available: "2014-05"
 7530	flavorless miniature grilled cheese sandwich	2	decent	Last Available: "2014-05"
 7531	distilled blinking narrow alien protein powder	1	decent	Effect: "Wintergreen Warmongery", Effect Duration: 40, Last Available: "2014-05"
-7532	perfectly mixed practically non-alcoholic rocket fuel	1	super ultra EPIC	Last Available: "2014-05"
+7532	practically non-alcoholic perfectly mixed rocket fuel	1	super ultra EPIC	Last Available: "2014-05"
 7533	narrow alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	perfectly mixed watered-down jittery maroon stealth bomber	2	EPIC	Last Available: "2014-05"
-7536	wobbly bouncing space beast fur	0		Last Available: "2014-05"
+7535	perfectly mixed watered-down maroon jittery stealth bomber	2	EPIC	Last Available: "2014-05"
+7536	bouncing wobbly space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	shaking ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
 7539	friendly space beast fur hat	0		Familiar Weight: +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
@@ -7438,7 +7438,7 @@
 7549	galvanized ash soda	0		Effect: "Arse-a'fire", Effect Duration: 47, Last Available: "2014-06"
 7550	wet polymerized liquid smoke	0		Effect: "Booing Radly", Effect Duration: 26, Last Available: "2014-06"
 7551	irradiated dollop of barbecue sauce	0		Effect: "Thunderspell", Effect Duration: 22, Last Available: "2014-06"
-7552	chilled flattened spinning blurry skewed bowl of marinade	0		Effect: "Livin' Large", Effect Duration: 68, Last Available: "2014-06"
+7552	chilled flattened blurry spinning skewed bowl of marinade	0		Effect: "Livin' Large", Effect Duration: 68, Last Available: "2014-06"
 7553	huge jittery shaker of dry rub	0		Last Available: "2014-06"
 7554	enhanced bottle of lighter fluid	0		Effect: "Ermine Eyes", Effect Duration: 27, Last Available: "2014-06"
 7555	page	0		
@@ -7448,7 +7448,7 @@
 7559	denatured adjusted gummi turtle	0		Effect: "Human-Horror Hybrid", Effect Duration: 42
 7560	ghostly turtle-shaped rock	0		
 7561	quantum giraffe-necked turtle	0		Effect: "Liquid Courage", Effect Duration: 39
-7562	irradiated huge shaking musk turtle	0		Effect: "Magically Fingered", Effect Duration: 44
+7562	irradiated shaking huge musk turtle	0		Effect: "Magically Fingered", Effect Duration: 44
 7563	triple-moist programmable turtle	0		Effect: "Three Days Slow", Effect Duration: 16
 7564	quadruple-enhanced pickled boiled red mocking turtle	0		Effect: "Total Protonic Reversal", Effect Duration: 47
 7565	tasty special shaking ham steak	3	awesome	Effect: "Expert Vacationer", Effect Duration: 20
@@ -7464,18 +7464,18 @@
 7575	mirror aromatic Jeselnik's droll monocle	0		Sleaze Damage: +25, Stench Resistance: +1, Single Equip
 7576	moist tumbling future drug: Muscularactum	0		Effect: "Red Misty-Eyed", Effect Duration: 14
 7577	altered dry future drug: Smartinex	0		Effect: "Craft Tea", Effect Duration: 62
-7578	oxidized wet narrow skewed future drug: Coolscaline	0		Effect: "Slimy Hands", Effect Duration: 35
+7578	oxidized wet skewed narrow future drug: Coolscaline	0		Effect: "Slimy Hands", Effect Duration: 35
 7579	twirling twitching time capsule	0		
 7580	mixed liquid shifting time weirdness	1		Effect: "Spooky Blur", Effect Duration: 40
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	toothsome rack of dinosaur ribs	4	awesome	
-7583	mediocre narrow yellow scotch on the rocks	4	decent	
+7583	mediocre yellow narrow scotch on the rocks	4	decent	
 7584	up-at-dawn grievous yabba dabba doo rag	0		Weapon Damage Percent: +50, Adventures: +5, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	baleful razor-sharp wooly loincloth	0		Weapon Damage Percent: +25, Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	drinkable spirit-forward glass of &quot;milk&quot;	5	good	Last Available: "2014-07"
+7589	spirit-forward drinkable glass of &quot;milk&quot;	5	good	Last Available: "2014-07"
 7590	artisanal cyan cup of &quot;tea&quot;	4	EPIC	Last Available: "2014-07"
 7591	hand-crafted thermos of &quot;whiskey&quot;	3	EPIC	Last Available: "2014-07"
 7592	mediocre Lucky Lindy	3	decent	Last Available: "2014-07"
@@ -7506,10 +7506,10 @@
 7617	corrupted ionized short deposition	0		Effect: "Comic Violence", Effect Duration: 21
 7618	colloidal irradiated straw pole	0		Effect: "Cosmic Flavor", Effect Duration: 17
 7619	anodized extra-pressed twirling copperhead potion	0		Effect: "Hennaliciousness", Effect Duration: 33
-7620	oxidized Vulcanized blinking narrow ninja fear powder	0		Effect: "Bat Attitude", Effect Duration: 45
+7620	oxidized Vulcanized narrow blinking ninja fear powder	0		Effect: "Bat Attitude", Effect Duration: 45
 7621	denatured flattened ninja eyeblack	0		Effect: "Prideful Strut", Effect Duration: 40
-7622	frozen oxidized purple squat button rouge	0		Effect: "Fancy Feasted", Effect Duration: 55
-7623	triple-quantum spinning upside-down Red Army camouflage kit	0		Effect: "Saucefingers", Effect Duration: 28
+7622	frozen oxidized squat purple button rouge	0		Effect: "Fancy Feasted", Effect Duration: 55
+7623	triple-quantum upside-down spinning Red Army camouflage kit	0		Effect: "Saucefingers", Effect Duration: 28
 7624	liquefied Vulcanized lynyrd skinner toothblack	0		Effect: "Radium Radicality", Effect Duration: 23
 7625	adjusted green flask of rainwater	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 32
 7626	dry energized twirling oyster badge	0		Effect: "Headstrong", Effect Duration: 61
@@ -7537,7 +7537,7 @@
 7648	thunder thigh	0		
 7649	altered flattened gourmet gourami oil	0		Effect: "The Smeezingtons", Effect Duration: 14
 7650	pickled catfish whiskers	0		Effect: "Thunderspell", Effect Duration: 23
-7651	upside-down bouncing freshwater fishbone	0		
+7651	bouncing upside-down freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
@@ -7551,7 +7551,7 @@
 7662	toothsome Sogg-Os	3	awesome	
 7663	wobbly foul-smelling scorching Lord Soggyraven's Slippers of horror	0		Hot Damage: +25, Stench Damage: +10, Spooky Spell Damage: +25, Single Equip
 7664	electrified adjusted Ancient Protector Soda	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 15
-7665	electrified ionized moist blue narrow liquid ice	0		Effect: "Soles of Glass", Effect Duration: 52
+7665	electrified ionized moist narrow blue liquid ice	0		Effect: "Soles of Glass", Effect Duration: 52
 7666	hand-crafted weak Wet Russian	2	super EPIC	
 7667	flavorless snack-sized filet of The Fish	2	decent	
 7668	Thwaitgold spider statuette	0		
@@ -7573,7 +7573,7 @@
 7684	narrow greasy Time Lord Participation Mug	0		Sleaze Spell Damage: +10
 7685	Lo Pan's Time Bandit Time Towel of the glutton	0		Spell Critical Percent: +30, Food Drop: +100
 7686	scorching dog trainer's Caveman Dan's favorite rock of the brazier	0		Experience (familiar): +1, Hot Damage: +25, Hot Spell Damage: +25, Single Equip
-7687	aerosolized pulsating green dog ointment	0		Effect: "Moon'd", Effect Duration: 32
+7687	aerosolized green pulsating dog ointment	0		Effect: "Moon'd", Effect Duration: 32
 7688	olive hardy forbidden gumshoes	0		Spell Damage Percent: +50, Maximum HP: +50, Single Equip
 7689	energetic arcane researcher's flapper floppers	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Single Equip
 7690	mirror educational sneakeasies of the scaredy-cat	0		Experience: +1, Monster Level: -15, Single Equip
@@ -7598,7 +7598,7 @@
 7709	Jeselnik's flame-wreathed lion tamer's smooth Thor's Pliers	0		Moxie: +15, Experience (familiar): +2, Hot Spell Damage: +10, Sleaze Damage: +25, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	alkaline twirling candy UFOs	0		Effect: "Stemonitis Storm", Effect Duration: 34
 7711	lime green family-friendly experienced water wings for babies	0		Experience: +2, Sleaze Resistance: +1
-7712	huge maroon beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	maroon huge beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	spoiled immense Strix stix	6	crappy	
 7714	frosty personal trainer's cool vampire pellet	0		Moxie: +5, Experience Percent (Muscle): +10, Cold Spell Damage: +10
 7715	delicious extra-dry enchanted non-aged vinegar	5	awesome	Effect: "Cat-Alyzed", Effect Duration: 15
@@ -7668,22 +7668,22 @@
 7779	magnetized concentrated experimental serum G-9	0		Effect: "Adrenaline Rush", Effect Duration: 58, Last Available: "2014-10"
 7780	up-at-dawn nasty heavy-duty clipboard of the overflowing toilet	0		Stench Damage: +5, Stench Spell Damage: +50, Adventures: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	green Usain Bolt's inspector's lard-coated brainy battery-powered drill	0		Mysticality: +5, Sleaze Spell Damage: +25, Item Drop: +15, Initiative: +80, Last Available: "2014-10"
-7782	super-sized fancy normal lime green pulsating limp broccoli	5	good	Effect: "It's Soporiffic!", Effect Duration: 15, Last Available: "2014-10"
+7782	fancy normal super-sized lime green pulsating limp broccoli	5	good	Effect: "It's Soporiffic!", Effect Duration: 15, Last Available: "2014-10"
 7783	blinking chaotic hat of bravery of the detective	0		Spell Critical Percent: +10, Spooky Resistance: +5, Item Drop: +20, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	deionized extra-denatured boiled monkey barf	0		Effect: "Wet and Greedy", Effect Duration: 17, Last Available: "2014-10"
 7785	boiled candy	0		Effect: "Jerky, Boy", Effect Duration: 33, Last Available: "2014-10"
 7786	lard-coated jangly bracelet of Tarzan of mayonnaise	0		Experience (Muscle): +3, Sleaze Spell Damage: 75, Last Available: "2014-10"
 7787	knitted cuddly teddy bear	0		Cold Resistance: +3, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
-7788	bouncing spinning ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7788	spinning bouncing ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	gray mansplainer's supercharged first-aid pouch	0		Maximum MP Percent: +30, Monster Level: +15, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	concentrated anodized maroon airborne mutagen	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 25, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	big tasty initiative shawarma	5	awesome	Last Available: "2014-10"
+7795	tasty big initiative shawarma	5	awesome	Last Available: "2014-10"
 7796	moldy warm war shawarma	3	crappy	Last Available: "2014-10"
-7797	flavorless super-sized karma shawarma	5	decent	Last Available: "2014-10"
+7797	super-sized flavorless karma shawarma	5	decent	Last Available: "2014-10"
 7798	mediocre Jungle Juice	3	decent	Last Available: "2014-10"
 7799	acceptable spinning Amnesiac Ale	3	good	Last Available: "2014-10"
 7800	fancy smooth Highest Bitter	3	awesome	Effect: "Slightly Mutated", Effect Duration: 5, Last Available: "2014-10"
@@ -7713,7 +7713,7 @@
 7824	prompt deadly sage iShield	0		Mysticality Percent: +10, Weapon Damage: +5, Adventures: +3, Damage Reduction: 6
 7825	greasy scorching Herculean earbuds	0		Experience (Muscle): +1, Hot Damage: +25, Sleaze Spell Damage: +10, Single Equip
 7826	blue quilted Samson's strapping iFlail	0		Muscle: +5, Experience (Muscle): +5, Damage Absorption: +40
-7827	jumbo flavorless spinning unidentifiable dried fruit	5	decent	
+7827	flavorless jumbo spinning unidentifiable dried fruit	5	decent	
 7828	lousy high-proof flat cider	8	decent	
 7829	wool hale trench lighter of the scaredy-cat	0		Maximum HP: +20, Monster Level: -15, Cold Resistance: +1, Last Available: "2014-10"
 7830	nitrogenated experimental serum P-00	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 50, Last Available: "2014-10"
@@ -7735,8 +7735,8 @@
 7846	moist triple-corrupted pressed blinking Fudge Fiber Armor Plating	0		Effect: "Well-Lubed", Effect Duration: 37, Last Available: "2014-12"
 7847	activated vacuum-sealed ruby on canes	0		Effect: "Filled with Magic", Effect Duration: 43, Last Available: "2014-12"
 7848	super-sized bland petit fortran	5	decent	Last Available: "2014-12"
-7849	fancy moldy miniature shaking java cookie	2	crappy	Effect: "No Vertigo", Effect Duration: 10, Last Available: "2014-12"
-7850	low-calorie yummy cookie cookie	1	awesome	Last Available: "2014-12"
+7849	miniature fancy moldy shaking java cookie	2	crappy	Effect: "No Vertigo", Effect Duration: 10, Last Available: "2014-12"
+7850	yummy low-calorie cookie cookie	1	awesome	Last Available: "2014-12"
 7851	plastic exo-suited miner of bravery	0		Spooky Resistance: +5, Last Available: "2014-12"
 7852	fireproof plastic semi-autonomous drill unit	0		Hot Resistance: +3, Last Available: "2014-12"
 7853	shaking fuchsia plastic ambulatory robo-minecart of bravery	0		Spooky Resistance: +5, Last Available: "2014-12"
@@ -7800,16 +7800,16 @@
 7911	recovered elf photo album	0		Last Available: "2014-12"
 7912	blinking recovered elf smartphone	0		Last Available: "2014-12"
 7913	Sherlock's Size XI Wizard's Robe of the wise owl of the scaredy-cat	0		Mysticality: +20, Monster Level: -15, Item Drop: +25, Last Available: "2014-09"
-7914	improved pulsating mirror mirror Bit O' Quail Spleen	0		Effect: "Barbecue Saucy", Effect Duration: 56
+7914	improved mirror pulsating mirror Bit O' Quail Spleen	0		Effect: "Barbecue Saucy", Effect Duration: 56
 7915	tarnished blinking Take Eleven Bar	0		Effect: "Tiki Temerity", Effect Duration: 43
 7916	mimeplasm	0		
 7917	warmed olive blurry BOOterfinger	0		Effect: "Crusty Head", Effect Duration: 40
 7918	wet flattened Moonds	0		Effect: "Space Cowboy", Effect Duration: 32
 7919	alkaline Big Punk	0		Effect: "Wise Spirit", Effect Duration: 48
-7920	huge blinking fist turkey outline	0		Free Pull, Last Available: "2014-11"
+7920	blinking huge fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	jittery turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	artisanal fortified skewed shaking Friendly Turkey	5	EPIC	Last Available: "2014-11"
-7923	watered-down artisanal Agitated Turkey	2	EPIC	Last Available: "2014-11"
+7923	artisanal watered-down Agitated Turkey	2	EPIC	Last Available: "2014-11"
 7924	hand-crafted weak Ambitious Turkey	2	EPIC	Last Available: "2014-11"
 7925	adequate special super-sized maroon skewed neutron lollipop	5	good	Effect: "Go-Gone", Effect Duration: 35, Last Available: "2014-12"
 7926	lousy gamma nog	3	decent	Last Available: "2014-12"
@@ -7833,7 +7833,7 @@
 7951	hardened beefy plaid cowboy hat	0		Muscle: +10, Damage Reduction: 3, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	green pulsating lasso	0		
 7953	scandalous Fonzie's rusted-out shootin' iron of the early riser	0		Experience (Moxie): +1, Sleaze Damage: +5, Adventures: +7
-7954	yellow pulsating rattler rattle	0		
+7954	pulsating yellow rattler rattle	0		
 7955	bag of money	0		
 7956	ghostly Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	even more tinsel	0		Familiar Weight: +5
@@ -7847,7 +7847,7 @@
 7965	Holy MacGuffin	0		
 7966	Ka coin	0		
 7967	Jeselnik's World's Best Adventurer sash	0		Sleaze Damage: +25
-7968	squat yellow topiary nugglet	0		
+7968	yellow squat topiary nugglet	0		
 7969	beehive	0		
 7970	pulsating boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
@@ -7889,7 +7889,7 @@
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8010	purple wobbly Mini-Crimbot crate	0		Last Available: "2014-12"
+8010	wobbly purple Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	resourceful deadly Crimbomega drive chain of the sweet-tooth	0		Weapon Damage: +5, Maximum MP: +50, Candy Drop: +100, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	skewed Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
@@ -7905,7 +7905,7 @@
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	wobbly foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
-8026	wobbly maroon ghostly ceiling fan	0		Last Available: "2015-01"
+8026	maroon wobbly ghostly ceiling fan	0		Last Available: "2015-01"
 8027	green antler chandelier	0		Last Available: "2015-01"
 8028	artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
@@ -7958,11 +7958,11 @@
 8077	shaking Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
-8086	pulsating blurry still-beating spleen	0		
+8086	blurry pulsating still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
 8088	bouncing jewel	0		
 8089	ghostly headless sparrow	0		
-8090	cyan blinking mangled squirrel	0		
+8090	blinking cyan mangled squirrel	0		
 8091	shaking rat carcass	0		
 8092	blinking therapeutic wicker kickers of Gandalf	0		Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2016-12"
 8093	blinking mirror nippy wicker slicker of extreme caution	0		Monster Level: -25, Cold Damage: +10, Last Available: "2016-12"
@@ -8008,7 +8008,7 @@
 8133	mixed huge fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	red winged yeti fur	0		
-8136	twirling blurry talisman of Renenutet	0		
+8136	blurry twirling talisman of Renenutet	0		
 8138	tumbling MacGyver's rubber spatula	0		Maximum MP: +100
 8139	mirror forbidden spoon	0		Spell Damage Percent: +50
 8140	squat Da Vinci's crystalline reamer	0		Experience (Mysticality): +5
@@ -8023,7 +8023,7 @@
 8149	adjusted jittery Glo-Pop	0		Effect: "Healthy Green Glow", Effect Duration: 59
 8150	electrified activated sugar sphere	0		Effect: "Berry Critical", Effect Duration: 33
 8151	double-tarnished olive Shrubble Bubble	0		Effect: "Heightened Senses", Effect Duration: 54
-8152	ionized pressed green shaking polyeaster egg	0		Effect: "Tingly Biceps", Effect Duration: 28
+8152	ionized pressed shaking green polyeaster egg	0		Effect: "Tingly Biceps", Effect Duration: 28
 8153	non-corrupted polarized candy dish	0		Effect: "Spiritually Awake", Effect Duration: 48
 8154	aerosolized Spechunky bar	0		Effect: "Inner Dog", Effect Duration: 40
 8155	pressed polymerized squat squat talisman of Horus	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 23
@@ -8038,11 +8038,11 @@
 8164	dog trainer's wholesome remaindered axe	0		Maximum HP Percent: +10, Experience (familiar): +1
 8165	blurry low-budget shield	0		Damage Reduction: 3
 8166	hale smartaleck's cr&ecirc;epy mask	0		Moxie Percent: +30, Maximum HP: +20, Familiar Effect: "spooky atk, cap 5"
-8167	enchanted normal blinking huge baguette	3	good	Effect: "Standard Cheer", Effect Duration: 25
+8167	normal enchanted huge blinking baguette	3	good	Effect: "Standard Cheer", Effect Duration: 25
 8168	glob of icing	0		
 8169	polymerized Vulcanized shaking ginger snaps	0		Effect: "Rave Nirvana", Effect Duration: 66
 8170	frozen electrified mostly-broken sunglasses	0		Effect: "Wolf's Bane", Effect Duration: 46
-8171	weak bad unflavored wine cooler	2	decent	
+8171	bad weak unflavored wine cooler	2	decent	
 8172	green carton of snake milk	1	good	
 8173	quilted sewer snake	0		Damage Absorption: +40
 8174	normal super-sized huge pigeon egg	5	good	
@@ -8061,17 +8061,17 @@
 8187	map to a hidden booze cache	0		
 8188	lousy Cherrytastrophe wine cooler	4	decent	
 8189	lousy squat Radberry Rip wine cooler	3	decent	
-8190	weak tolerable Orangemageddon wine cooler	2	good	
+8190	tolerable weak Orangemageddon wine cooler	2	good	
 8191	acceptable squat Breakfast Blast wine cooler	3	good	
-8192	acceptable special Citrus Crush wine cooler	3	good	Effect: "Baconstoned", Effect Duration: 20
+8192	special acceptable Citrus Crush wine cooler	3	good	Effect: "Baconstoned", Effect Duration: 20
 8193	normal plain bagel	3	good	
-8194	small spoiled tumbling glob of cream cheese	2	crappy	
+8194	spoiled small tumbling glob of cream cheese	2	crappy	
 8195	bland squat upside-down loaf of soda bread	3	decent	
 8196	spoiled acceptable bagel	4	crappy	
-8197	miniature toothsome mirror standard-issue cupcake	2	awesome	
+8197	toothsome miniature mirror standard-issue cupcake	2	awesome	
 8198	flavorless red blurry ultra-deluxe cupcake	3	decent	
 8199	hypnotic breadcrumbs	0		
-8200	bland snack-sized tumbling popular tart	2	decent	
+8200	snack-sized bland tumbling popular tart	2	decent	
 8201	no-handed pie	0		
 8202	galvanized spinning Doc Galaktik's Vitality Serum	0		Effect: "Limber as Mortimer", Effect Duration: 66
 8203	blinking shaking airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8090,14 +8090,14 @@
 8216	pickled beard incense	0		Effect: "World's Shortest Giant", Effect Duration: 48, Last Available: "2015-04"
 8217	skewed stiffened Rosewater's perfume-soaked bandana	0		Mysticality Percent: +30, Damage Reduction: 1, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	decent spinning maroon toxo	3	good	Last Available: "2015-04"
+8219	decent maroon spinning toxo	3	good	Last Available: "2015-04"
 8220	perfectly mixed Lemonade-235	3	EPIC	Last Available: "2015-04"
 8221	Rosewater's strapping isotophat	0		Muscle: +5, Mysticality Percent: +30, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	stanky MacGyver's Three Mile Island shorts	0		Maximum MP: +100, Stench Spell Damage: +25, Last Available: "2015-04"
 8223	inspector's toxic mop of bravery	0		Spooky Resistance: +5, Item Drop: +15, Last Available: "2015-04"
-8224	twirling teal inert sludgepuppy	0		Last Available: "2015-04"
+8224	teal twirling inert sludgepuppy	0		Last Available: "2015-04"
 8225	lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
-8226	olive pulsating jar of swamp honey	0		Last Available: "2015-04"
+8226	pulsating olive jar of swamp honey	0		Last Available: "2015-04"
 8227	shaking zippy backwoods banjo of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5, Initiative: +20, Last Available: "2015-04"
 8228	tumbling grody jug	0		Last Available: "2015-04"
 8229	purple friendly Oprah's brainy ratskin pajama pants	0		Mysticality: +5, Maximum MP Percent: +50, Familiar Weight: +3, Last Available: "2015-04"
@@ -8110,10 +8110,10 @@
 8236	auspicious clever Dinsey's glove	0		Maximum MP: +20, Item Drop: +10, Single Equip, Last Available: "2015-04"
 8237	family-friendly Dinsey's pants of the storm	0		Maximum MP Percent: +40, Sleaze Resistance: +1, Last Available: "2015-04"
 8238	jittery gray brain preservation fluid	0		Last Available: "2015-04"
-8239	blinking bouncing keycard &alpha;	0		Last Available: "2015-04"
+8239	bouncing blinking keycard &alpha;	0		Last Available: "2015-04"
 8240	keycard &beta;	0		Last Available: "2015-04"
 8241	keycard &gamma;	0		Last Available: "2015-04"
-8242	ghostly wobbly keycard &delta;	0		Last Available: "2015-04"
+8242	wobbly ghostly keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	arcane researcher's lube-shoes	0		Experience Percent (Mysticality): +10, Last Available: "2015-04"
 8245	mirror trash net	0		Last Available: "2015-04"
@@ -8132,7 +8132,7 @@
 8258	teal Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	blinking beefcake's The Lot's engagement ring	0		Muscle: +25, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	maroon Mayo Clinic	0		Last Available: "2015-05"
-8261	maroon twirling Mayonex	0		Last Available: "2015-05"
+8261	twirling maroon Mayonex	0		Last Available: "2015-05"
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	Mayostat	0		Last Available: "2015-05"
 8264	Mayozapine	0		Last Available: "2015-05"
@@ -8142,7 +8142,7 @@
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	low-calorie rotten unappetizing mayolus	1	crappy	Last Available: "2015-05"
-8271	decent gigantic wobbly uninteresting mayolus	9	good	Last Available: "2015-05"
+8271	gigantic decent wobbly uninteresting mayolus	9	good	Last Available: "2015-05"
 8272	normal blinking acceptable mayolus	3	good	Last Available: "2015-05"
 8273	normal massive enticing mayolus	7	good	Last Available: "2015-05"
 8274	stale mouth-watering mayolus	4	decent	Last Available: "2015-05"
@@ -8173,8 +8173,8 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	non-Vulcanized ionized gray power pill	0		Effect: "Strawberry Alarm", Effect Duration: 39, Last Available: "2015-06"
 8301	boiled wobbly pixel star	0		Effect: "Slimily Speedy", Effect Duration: 68, Last Available: "2015-06"
-8302	spoiled snack-sized pixel banana	2	crappy	Last Available: "2015-06"
-8303	distilled special artisanal pixel beer	5	EPIC	Effect: "Elemental Flavor", Effect Duration: 5, Last Available: "2015-06"
+8302	snack-sized spoiled pixel banana	2	crappy	Last Available: "2015-06"
+8303	special distilled artisanal pixel beer	5	EPIC	Effect: "Elemental Flavor", Effect Duration: 5, Last Available: "2015-06"
 8304	skewed puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	narrow twirling lime green pumps	0		Last Available: "2015-06"
 8306	ionized moist dry sludgesicle	0		Effect: "Frigid Weapon", Effect Duration: 36
@@ -8221,7 +8221,7 @@
 8347	extra-oxidized aerosolized liquefied teal spray chrome	0		Effect: "Craft Tea", Effect Duration: 65
 8348	liquefied mirror filthy monkey head	0		Effect: "Berry Elemental", Effect Duration: 52
 8349	galvanized hand of cards	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 39
-8350	nitrogenated energized maroon spinning damp bar rag	0		Effect: "Whole Latte Love", Effect Duration: 49
+8350	nitrogenated energized spinning maroon damp bar rag	0		Effect: "Whole Latte Love", Effect Duration: 49
 8351	frozen lump of goofball ore	0		Effect: "Poker Faced", Effect Duration: 59
 8352	improved oxidized skeleton beans	0		Effect: "Bananas!", Effect Duration: 18
 8353	altered warmed grimy lab coat	0		Effect: "Mint-Condition Breath", Effect Duration: 58
@@ -8242,7 +8242,7 @@
 8368	tarnished garbage juice slurpee	0		Effect: "Simulation Stimulation", Effect Duration: 23
 8369	dry mirror plunge-leg	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 58
 8370	boiled funky eyepatch	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 68
-8371	Vulcanized lime green shaking bucket of fish juice	0		Effect: "critical.enh", Effect Duration: 54
+8371	Vulcanized shaking lime green bucket of fish juice	0		Effect: "critical.enh", Effect Duration: 54
 8372	chilled boiled ghostly flashy pirate dreadlocks	0		Effect: "Comprehensively Nourished", Effect Duration: 48
 8373	double-concentrated colloidal blue captured boozles	0		Effect: "Sweet and Red", Effect Duration: 57
 8374	ionized blinking drinks tray	0		Effect: "Old School Pompadour", Effect Duration: 26
@@ -8253,10 +8253,10 @@
 8379	ionized non-colloidal mirror power pill	0		Effect: "Super-Charged", Effect Duration: 11, Last Available: "2015-06"
 8380	oxidized polymerized blinking pixel potion	0		Effect: "Thicker, Sicker", Effect Duration: 58, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
-8382	green pulsating Deck of Every Card	0		Last Available: "2015-07"
+8382	pulsating green Deck of Every Card	0		Last Available: "2015-07"
 8383	gray popular part	0		
 8384	blurry bubblegum heart	0		Last Available: "2015-07"
-8385	blurry spinning cubic zirconia	0		Last Available: "2015-07"
+8385	spinning blurry cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	purple mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
@@ -8281,11 +8281,11 @@
 8407	adequate pulsating spinning pestopiary	3	good	
 8408	ionized diffused shaking ectoplasmic orbs	0		Effect: "Preemptive Medicine", Effect Duration: 21
 8409	diet spoiled crudles	1	crappy	
-8410	normal half-sized agnolotti arboli	2	good	
+8410	half-sized normal agnolotti arboli	2	good	
 8411	moldy spaghetti with ghost balls	3	crappy	
 8412	flavorless succulent marrow	3	decent	
 8413	spoiled salacious crumbs	4	crappy	
-8414	normal small skewed fusilli marrownarrow	2	good	
+8414	small normal skewed fusilli marrownarrow	2	good	
 8415	bland huge suggestive strozzapreti	6	decent	
 8416	upside-down Mountain Stream gastrique	0		
 8417	moldy Mt. McLargeHuge oyster	3	crappy	
@@ -8310,7 +8310,7 @@
 8436	deadly slick LavaCo Lamp&trade;	0		Moxie: +10, Weapon Damage: +5, Last Available: "2015-08"
 8437	zippy frosty LavaCo Lamp&trade;	0		Cold Spell Damage: +10, Initiative: +20, Last Available: "2015-08"
 8438	yellow thin wire	0		Last Available: "2015-08"
-8439	upside-down blurry insulated wire	0		Last Available: "2015-08"
+8439	blurry upside-down insulated wire	0		Last Available: "2015-08"
 8440	empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	viscous lava globs	0		Last Available: "2015-08"
@@ -8334,22 +8334,22 @@
 8460	delicious mineapple	4	awesome	Last Available: "2015-08"
 8461	perfectly mixed Gold Velvet&trade; whiskey	3	EPIC	Last Available: "2015-08"
 8462	fuchsia SMOOCH soda	1	awesome	Last Available: "2015-08"
-8463	delicious miniature wobbly squat teal smelted roe	2	awesome	Last Available: "2015-08"
+8463	delicious miniature teal squat wobbly smelted roe	2	awesome	Last Available: "2015-08"
 8464	smooth lavawater	3	awesome	Last Available: "2015-08"
 8465	ionized enhanced basaltamander tongue	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 61, Last Available: "2015-08"
 8466	groovy thinker's lavalarva of the empath	0		Mysticality: +10, Moxie Percent: +10, Familiar Weight: +5, Last Available: "2015-08"
 8467	spinning family-friendly asbestos-lined Fonzie's lava balaclava	0		Experience (Moxie): +1, Hot Resistance: +5, Sleaze Resistance: +1, Last Available: "2015-08"
 8468	maroon huge gravedigger's cool basaltamander buckler	0		Moxie: +5, Spooky Damage: +10, Item Drop: +5, Damage Reduction: 15, Last Available: "2015-08"
 8469	ionized energized lava globs	0		Effect: "Conspiratory Eyes", Effect Duration: 17, Last Available: "2015-08"
-8470	half-sized tasty pulsating shaking gooey lava globs	2	awesome	Last Available: "2015-08"
+8470	half-sized tasty shaking pulsating gooey lava globs	2	awesome	Last Available: "2015-08"
 8471	steel-toed lava-proof pants of Gandalf	0		Damage Reduction: 9, Spell Critical Percent: +20, Last Available: "2015-08"
 8472	Jack Frost's banded heat-resistant necktie	0		Damage Absorption: +100, Cold Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8473	zippy gravedigger's vibrating heat-resistant gloves	0		Maximum MP Percent: +10, Spooky Damage: +10, Initiative: +20, Single Equip, Last Available: "2015-08"
-8474	bland special super-sized lime green very hot lunch	5	decent	Effect: "Dirge of Dreadfulness", Effect Duration: 25, Last Available: "2015-08"
-8475	fortified artisanal asbestos thermos	5	EPIC	Last Available: "2015-08"
+8474	bland super-sized special lime green very hot lunch	5	decent	Effect: "Dirge of Dreadfulness", Effect Duration: 25, Last Available: "2015-08"
+8475	artisanal fortified asbestos thermos	5	EPIC	Last Available: "2015-08"
 8476	double-polymerized liquid rhinestones	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 36, Last Available: "2015-08"
 8477	bite-sized delicious disco biscuit	1	awesome	Last Available: "2015-08"
-8478	enchanted mediocre Quaatorade&trade;	3	decent	Effect: "Nothing Is Impossible", Effect Duration: 40, Last Available: "2015-08"
+8478	mediocre enchanted Quaatorade&trade;	3	decent	Effect: "Nothing Is Impossible", Effect Duration: 40, Last Available: "2015-08"
 8479	auspicious coward's biker's hat of the boozehound	0		Monster Level: -20, Item Drop: +10, Booze Drop: +100, Last Available: "2015-08", Familiar Effect: "atk"
 8480	greasy dance instructor's feathered headdress of the storm	0		Experience Percent (Moxie): +10, Maximum MP Percent: +40, Sleaze Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	hale fortified razor-sharp electrician's hardhat	0		Weapon Damage Percent: +25, Damage Absorption: +60, Maximum HP: +20, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8397,33 +8397,33 @@
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	moldy lava cake	3	crappy	Last Available: "2015-08"
-8526	spoiled immense pink slime	9	crappy	
+8526	immense spoiled pink slime	9	crappy	
 8527	bouncing Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	bland small squat devil hair pasta	2	decent	
+8529	small bland squat devil hair pasta	2	decent	
 8530	miniature yummy ghostly spagecialetti	2	awesome	
 8531	Salsa Libre	0		
-8532	wobbly blue good gravy	0		
+8532	blue wobbly good gravy	0		
 8533	illicit fish sauce	0		
-8534	rotten tiny narrow libertagliatelle	1	crappy	
-8535	small adequate turkish mostaccioli	2	good	
-8536	stale massive blurry linguini of the sea	7	decent	
+8534	tiny rotten narrow libertagliatelle	1	crappy	
+8535	adequate small turkish mostaccioli	2	good	
+8536	massive stale blurry linguini of the sea	7	decent	
 8537	dry blinking Hersey&trade; SMOOCH	0		Effect: "Uncanny Shot", Effect Duration: 59
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	purple drug cocktail sauce	0		
 8542	adequate skewed Fettris	4	good	
-8543	spoiled jumbo fusillocybin	5	crappy	
+8543	jumbo spoiled fusillocybin	5	crappy	
 8544	stale twirling blurry prescription noodles	3	decent	
 8545	pickled lime green blood-drive sticker	1	good	
 8546	chilled flattened pickled mirror bag of grain	0		Effect: "No Vertigo", Effect Duration: 24
 8547	anodized denatured pocket maze	0		Effect: "Phairly Pheromonal", Effect Duration: 14
 8548	alkaline polymerized shady shades	0		Effect: "Neuromancy", Effect Duration: 44
 8549	dry anodized squat squeaky toy rose	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 69
-8550	small bland weird gazelle steak	2	decent	
-8551	decent fancy snack-sized sausage without a cause	2	good	Effect: "One For Tea", Effect Duration: 10
+8550	bland small weird gazelle steak	2	decent	
+8551	fancy decent snack-sized sausage without a cause	2	good	Effect: "One For Tea", Effect Duration: 10
 8552	pickled face paint	0		Effect: "Ghostly Shell", Effect Duration: 37
-8553	watered-down tolerable ghostly narrow emergency margarita	2	good	
+8553	tolerable watered-down narrow ghostly emergency margarita	2	good	
 8554	watered-down tolerable vintage smart drink	2	good	
 8555	yellow a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8448,7 +8448,7 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	watered-down artisanal bottle of Amontillado	2	EPIC	Last Available: "2015-09"
+8578	artisanal watered-down bottle of Amontillado	2	EPIC	Last Available: "2015-09"
 8579	hand-crafted extra-dry barrel-aged martini	5	EPIC	Last Available: "2015-09"
 8580	stale barrel pickle	3	decent	Last Available: "2015-09"
 8581	moldy teal barrel cracker	3	crappy	Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	olive deadly barrel gun	0		Weapon Damage: +5, Last Available: "2015-09"
 8587	jittery blinking barrel	0		Last Available: "2015-09"
 8588	red barrel beryl	0		Last Available: "2015-09"
-8589	decent huge water log	8	good	Last Available: "2015-09"
+8589	huge decent water log	8	good	Last Available: "2015-09"
 8590	greedy family-friendly barrelhead	0		Sleaze Resistance: +1, Meat Drop: +20, Last Available: "2015-09"
 8591	asbestos-lined shellacked bottoms of the barrel	0		Damage Reduction: 7, Hot Resistance: +5, Last Available: "2015-09"
 8592	jittery veiny chest barrel of the blizzard	0		Maximum HP: +10, Cold Spell Damage: +25, Last Available: "2015-09"
@@ -8489,10 +8489,10 @@
 8616	boiled pickled cuppa Neuroplastici tea	0		Effect: "Covetous Robbery", Effect Duration: 67, Last Available: "2015-09"
 8617	boiled altered improved cuppa Dexteri tea	0		Effect: "Eyes for Miles", Effect Duration: 22, Last Available: "2015-09"
 8618	quadruple-chilled colloidal cuppa Flexibili tea	0		Effect: "Pork Power", Effect Duration: 41, Last Available: "2015-09"
-8619	quadruple-ionized triple-enhanced twirling maroon cuppa Impregnabili tea	0		Effect: "Bandersnatched", Effect Duration: 13, Last Available: "2015-09"
+8619	quadruple-ionized triple-enhanced maroon twirling cuppa Impregnabili tea	0		Effect: "Bandersnatched", Effect Duration: 13, Last Available: "2015-09"
 8620	super-tarnished olive cuppa Obscuri tea	0		Effect: "Cold as Ice", Effect Duration: 23, Last Available: "2015-09"
 8621	altered squat cuppa Irritabili tea	0		Effect: "Antsy in your Pantsy", Effect Duration: 55, Last Available: "2015-09"
-8622	non-concentrated pulsating fuchsia cuppa Mediocri tea	0		Effect: "Wolf's Bane", Effect Duration: 48, Last Available: "2015-09"
+8622	non-concentrated fuchsia pulsating cuppa Mediocri tea	0		Effect: "Wolf's Bane", Effect Duration: 48, Last Available: "2015-09"
 8623	enhanced cuppa Loyal tea	0		Effect: "Eau de Tortue", Effect Duration: 15, Last Available: "2015-09"
 8624	vaporized cuppa Activi tea	1	decent	Effect: "Old School Pompadour", Effect Duration: 35, Last Available: "2015-09"
 8625	dried cuppa Cruel tea	1		Last Available: "2015-09"
@@ -8502,7 +8502,7 @@
 8629	non-frozen cuppa Monstrosi tea	0		Effect: "Infernal Thirst", Effect Duration: 39, Last Available: "2015-09"
 8630	adjusted bouncing cuppa Twen tea	0		Effect: "Tasting the Rainbow", Effect Duration: 32, Last Available: "2015-09"
 8631	pressed energized altered wobbly cuppa Gill tea	0		Effect: "Eye of the Lihc", Effect Duration: 34, Last Available: "2015-09"
-8632	super-dry blinking blue cuppa Uncertain tea	0		Effect: "Shawarma Warm War", Effect Duration: 51, Last Available: "2015-09"
+8632	super-dry blue blinking cuppa Uncertain tea	0		Effect: "Shawarma Warm War", Effect Duration: 51, Last Available: "2015-09"
 8633	gray cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
@@ -8513,8 +8513,8 @@
 8640	jittery Ghost Dog Chow	0		Last Available: "2015-10"
 8641	adequate bowl of eyeballs	3	good	Last Available: "2015-10"
 8642	moldy bowl of mummy guts	3	crappy	Last Available: "2015-10"
-8643	thick spoiled bowl of maggots	5	crappy	Last Available: "2015-10"
-8644	enchanted practically non-alcoholic hand-crafted blood and blood	1	super ultra EPIC	Effect: "Comprehensively Nourished", Effect Duration: 45, Last Available: "2015-10"
+8643	spoiled thick bowl of maggots	5	crappy	Last Available: "2015-10"
+8644	hand-crafted enchanted practically non-alcoholic blood and blood	1	super ultra EPIC	Effect: "Comprehensively Nourished", Effect Duration: 45, Last Available: "2015-10"
 8645	bad Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
 8646	artisanal zombie	3	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
@@ -8525,15 +8525,15 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	jittery Jim Carey's quilted hawk of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40, Monster Level: +25
-8655	rotten enchanted tiny hamlet sandwich	1	crappy	Effect: "Human-Hippy Hybrid", Effect Duration: 30
+8655	tiny rotten enchanted hamlet sandwich	1	crappy	Effect: "Human-Hippy Hybrid", Effect Duration: 30
 8656	dog trainer's Othello's military jacket	0		Experience (familiar): +1
 8657	educational Othello's dagger	0		Experience: +1, Single Equip
 8658	blinking supercharged Othello's handkerchief	0		Maximum MP Percent: +30, Single Equip
 8659	ionized twirling bowl of Jeal-O	0		Effect: "Stemonitis Storm", Effect Duration: 42
 8660	grip key	0		
-8661	olive skewed How to Play Othello	0		
+8661	skewed olive How to Play Othello	0		
 8662	brawny thinker's ghostly dagger of incineration	0		Mysticality: +10, Muscle Percent: +20, Hot Spell Damage: +50
-8663	triple-distilled drinkable ghost beer	7	good	
+8663	drinkable triple-distilled ghost beer	7	good	
 8664	blinking supercool Othello set	0		Moxie Percent: +20
 8665	blinking rotten tomato	0		
 8666	squat Twelve Night Energy	0		
@@ -8547,7 +8547,7 @@
 8674	upside-down airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	olive one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	concentrated super-dry activated shoulder-warming lotion	0		Effect: "Sweet, Nuts", Effect Duration: 43, Last Available: "2015-11"
-8677	low-calorie moldy iceberg lettuce	1	crappy	Last Available: "2015-11"
+8677	moldy low-calorie iceberg lettuce	1	crappy	Last Available: "2015-11"
 8678	watered-down hand-crafted ice wine	2	EPIC	Last Available: "2015-11"
 8679	MacGyver's Wal-Mart snowglobe of the wise owl of the empath	0		Mysticality: +20, Maximum MP: +100, Familiar Weight: +5, Last Available: "2015-11"
 8680	mansplainer's fortified Wal-Mart nametag of the blizzard	0		Damage Absorption: +60, Monster Level: +15, Cold Spell Damage: +25, Last Available: "2015-11"
@@ -8587,14 +8587,14 @@
 8714	vaporized abstraction: motion	1		Last Available: "2015-12"
 8715	distilled jittery abstraction: joy	1		Effect: "New and Improved", Effect Duration: 30, Last Available: "2015-12"
 8716	pickled shaking abstraction: certainty	1		Last Available: "2015-12"
-8717	twisted upside-down blue abstraction: comprehension	1		Last Available: "2015-12"
+8717	twisted blue upside-down abstraction: comprehension	1		Last Available: "2015-12"
 8718	squat modern picture frame	0		Last Available: "2015-12"
 8719	toothsome VYKEA meatballs	4	awesome	Last Available: "2015-11"
 8720	watered-down smooth VYKEA mead	2	awesome	Last Available: "2015-11"
 8721	vacuum-sealed pickled VYKEA woadpaint	0		Effect: "Berry Defensive", Effect Duration: 11, Last Available: "2015-11"
 8722	purple VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
-8724	wobbly jittery VYKEA lightning rune	0		Last Available: "2015-11"
+8724	jittery wobbly VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	squat VYKEA rail	0		Last Available: "2015-11"
 8727	blinking VYKEA bracket	0		Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	dry non-cold-filtered triple-alkaline lime green hemp candy necklace	0		Effect: "Broberry Brotality", Effect Duration: 27, Last Available: "2015-12"
 8751	altered alkaline communal gobstopper	0		Effect: "Healthy Blue Glow", Effect Duration: 24, Last Available: "2015-12"
 8752	delicious Crimbo salad	3	awesome	Last Available: "2015-12"
-8753	diet normal bread line	1	good	Last Available: "2015-12"
+8753	normal diet bread line	1	good	Last Available: "2015-12"
 8754	tolerable wobbly bark rootbeer	4	good	Last Available: "2015-12"
 8755	smooth tumbling ale	3	awesome	Last Available: "2015-12"
 8756	pulsating plastic Tammy the Tambourine Elf of Leguizamo	0		Monster Level: +20, Last Available: "2015-12"
@@ -8647,7 +8647,7 @@
 8775	coarse hemp socks of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2015-12"
 8776	smartaleck's armband	0		Moxie Percent: +30, Single Equip, Last Available: "2015-12"
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
-8778	gray jittery blinking nuclear stockpile	0		Last Available: "2015-12"
+8778	jittery gray blinking nuclear stockpile	0		Last Available: "2015-12"
 8779	lime green pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
 8781	pine cone necklace of Gandalf	0		Spell Critical Percent: +20, Last Available: "2015-12"
@@ -8663,7 +8663,7 @@
 8791	gravedigger's reindeer sickle	0		Spooky Damage: +10, Last Available: "2015-12"
 8792	face paint	0		Free Pull, Last Available: "2015-12"
 8793	pulsating face paint	0		Free Pull, Last Available: "2015-12"
-8794	blinking cyan The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
+8794	cyan blinking The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	tumbling shaking bat-oomerang	0		Last Available: "2017-01"
@@ -8677,16 +8677,16 @@
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
 8807	skewed experimental gene therapy	0		Last Available: "2017-01"
-8808	ghostly huge cyan ghostly ultracoagulator	0		Last Available: "2017-01"
+8808	huge cyan ghostly ghostly ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	wobbly confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
-8815	twirling mirror bat-bearing	0		Last Available: "2017-01"
+8815	mirror twirling bat-bearing	0		Last Available: "2017-01"
 8816	normal blurry Kudzu salad	4	good	Last Available: "2016-12"
-8817	twisted squat upside-down Mansquito Serum	1		Last Available: "2016-12"
+8817	twisted upside-down squat Mansquito Serum	1		Last Available: "2016-12"
 8818	bad triple-distilled Miss Graves' vermouth	8	decent	Last Available: "2016-12"
 8819	rotten The Plumber's mushroom stew	3	crappy	Last Available: "2016-12"
 8820	altered twirling The Author's ink	1		Last Available: "2016-02"
@@ -8710,7 +8710,7 @@
 8838	exploding gum	0		
 8839	root beer barrel	0		
 8840	irradiated altered Kudzu slaw	0		Effect: "Chlorophyll Flavor", Effect Duration: 39
-8841	pressed corrupted shaking yellow Mansquito's blood	0		Effect: "Sweet and Yellow", Effect Duration: 25
+8841	pressed corrupted yellow shaking Mansquito's blood	0		Effect: "Sweet and Yellow", Effect Duration: 25
 8842	pressed adjusted infrablack lipstick	0		Effect: "Frozen Hands", Effect Duration: 60
 8843	dry super-anodized squat jittery can of drain cleaner	0		Effect: "Cold Hard Skin", Effect Duration: 25
 8844	cold-filtered dry spinning The Author's inkwell	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 26
@@ -8723,7 +8723,7 @@
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
-8854	tumbling cyan nugget of wicksilver	0		Last Available: "2016-02"
+8854	cyan tumbling nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	narrow nugget of sicksilver	0		Last Available: "2016-02"
 8857	maroon nugget of nicksilver	0		Last Available: "2016-02"
@@ -8750,8 +8750,8 @@
 8878	rotten twirling plate of Mixed Garbanzos and Chickpeas	3	crappy	Last Available: "2016-02"
 8879	decent plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
 8880	stale bouncing plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
-8881	jumbo enchanted adequate plate of World's Blackest-Eyed Peas	5	good	Effect: "Held Closer", Effect Duration: 45, Last Available: "2016-02"
-8882	enchanted normal plate of Trader Olaf's Exotic Stinkbeans	4	good	Effect: "Tasting the Rainbow", Effect Duration: 5, Last Available: "2016-02"
+8881	enchanted jumbo adequate plate of World's Blackest-Eyed Peas	5	good	Effect: "Held Closer", Effect Duration: 45, Last Available: "2016-02"
+8882	normal enchanted plate of Trader Olaf's Exotic Stinkbeans	4	good	Effect: "Tasting the Rainbow", Effect Duration: 5, Last Available: "2016-02"
 8883	normal squat plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	good	Last Available: "2016-02"
 8884	stale plate of Val-U Brand Every Bean Salad	3	decent	Last Available: "2016-02"
 8885	adequate plate of Shrub's Premium Baked Beans	4	good	Last Available: "2016-02"
@@ -8759,7 +8759,7 @@
 8887	therapeutic dance instructor's thinker's Daisy's unclean bloomers	0		Mysticality: +10, Experience Percent (Moxie): +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
 8889	Jeselnik's supercharged savvy Amoon-Ra Cowtep's nemes	0		Mysticality Percent: +20, Maximum MP Percent: +30, Sleaze Damage: +25, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
-8890	shaking wobbly Glenn's dice	0		Last Available: "2016-02"
+8890	wobbly shaking Glenn's dice	0		Last Available: "2016-02"
 8891	shaking executive greasy educational wizardly Former Sheriff Dan's tin star of vim and vigor	0		Mysticality: +25, Experience: +1, Maximum HP Percent: +50, Sleaze Spell Damage: +10, Meat Drop: +40, Last Available: "2016-02"
 8892	purple El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
@@ -8773,7 +8773,7 @@
 8901	oxidized triggerfingerbone	0		Effect: "Quadrilled", Effect Duration: 39, Last Available: "2016-02"
 8902	nitrogenated ghost bit	0		Effect: "Fortunate Resolve", Effect Duration: 67, Last Available: "2016-02"
 8903	quadruple-electrified bouncing buzzard feather	0		Effect: "Brain Freeze", Effect Duration: 19, Last Available: "2016-02"
-8904	flattened huge bouncing lion musk	0		Effect: "Vinegavotte", Effect Duration: 49, Last Available: "2016-02"
+8904	flattened bouncing huge lion musk	0		Effect: "Vinegavotte", Effect Duration: 49, Last Available: "2016-02"
 8905	spoiled bear claw	4	crappy	Last Available: "2016-02"
 8906	aerosolized purple rattler gland	0		Effect: "Become Intensely interested", Effect Duration: 16, Last Available: "2016-02"
 8907	oxidized triple-denatured tumbling half-digested coal	0		Effect: "The Dinsey Spirit", Effect Duration: 31, Last Available: "2016-02"
@@ -8810,7 +8810,7 @@
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	coal snakeskin	0		Last Available: "2016-02"
-8941	blue huge frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
+8941	huge blue frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	narrow rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
 8944	blinking pulsating rhinestone cowhorn	0		Familiar Weight: +5
@@ -8841,11 +8841,11 @@
 8969	boxer's brainy eleven-gallon hat	0		Mysticality: +5, Muscle Percent: +10
 8970	toy sixgun	0		
 8971	snake oil	0		
-8972	alkaline pulsating red skin oil	0		Effect: "Mint-Condition Breath", Effect Duration: 40
+8972	alkaline red pulsating skin oil	0		Effect: "Mint-Condition Breath", Effect Duration: 40
 8973	polarized ionized unusual oil	0		Effect: "Serenity", Effect Duration: 46
-8974	warmed huge wobbly eldritch oil	0		Effect: "Warm Belly", Effect Duration: 51
+8974	warmed wobbly huge eldritch oil	0		Effect: "Warm Belly", Effect Duration: 51
 8975	exclusive club	0		
-8976	adjusted ghostly blue patent preventative tonic	0		Effect: "Oxygenated Blood", Effect Duration: 22
+8976	adjusted blue ghostly patent preventative tonic	0		Effect: "Oxygenated Blood", Effect Duration: 22
 8977	pickled double-colloidal upside-down patent invisibility tonic	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 15
 8978	galvanized polarized wobbly patent aggression tonic	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 17
 8979	dry nitrogenated patent sallowness tonic	0		Effect: "Abyssal Blood", Effect Duration: 29
@@ -8862,8 +8862,8 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	pulsating do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	mixed armored prawn	1		Effect: "The Wisdom... of the Future", Effect Duration: 20, Last Available: "2016-03"
-8993	miniature moldy maroon jumping horseradish	2	crappy	Last Available: "2016-03"
-8994	watered-down perfectly mixed Sacramento wine	2	EPIC	Last Available: "2016-03"
+8993	moldy miniature maroon jumping horseradish	2	crappy	Last Available: "2016-03"
+8994	perfectly mixed watered-down Sacramento wine	2	EPIC	Last Available: "2016-03"
 8995	colloidal triple-wet blurry twirling wobbly Greek fire	0		Effect: "Holiday Bliss", Effect Duration: 11, Last Available: "2016-03"
 8996	scorching lion tamer's ruddy banded ox-head shield of Leguizamo	0		Damage Absorption: +100, Maximum HP Percent: +40, Monster Level: +20, Experience (familiar): +2, Hot Damage: +25, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	scandalous Jack Frost's medical-grade boxer's dented scepter of wisdom	0		Mysticality: +15, Muscle Percent: +10, Cold Spell Damage: +50, Sleaze Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8878,7 +8878,7 @@
 9006	ruddy brawny tunac of the ox of the storm	0		Muscle: +20, Muscle Percent: +20, Maximum HP Percent: +40, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2016-04"
 9007	upside-down fishin' pole	0		Last Available: "2016-04"
 9008	super-cold-filtered double-Vulcanized wriggling worm	0		Effect: "Gutterminded", Effect Duration: 59, Last Available: "2016-04"
-9009	irresponsibly strong delicious bottle of Fishhead 900-Day IPA	6	awesome	Last Available: "2016-04"
+9009	delicious irresponsibly strong bottle of Fishhead 900-Day IPA	6	awesome	Last Available: "2016-04"
 9010	quantum maroon high-test fishing line	0		Effect: "Compensatory Cruelness", Effect Duration: 55, Last Available: "2016-04"
 9011	spinning Socratic fishin' hat	0		Experience (Mysticality): +1, Last Available: "2016-04"
 9012	shaking Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8886,7 +8886,7 @@
 9014	luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	spinning tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	bouncing huge disconnected intergnat	0		Free Pull, Last Available: "2016-05"
-9017	narrow teal viral video	0		Last Available: "2016-05"
+9017	teal narrow viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
@@ -8907,7 +8907,7 @@
 9035	rotten browser cookie	4	crappy	Last Available: "2016-06"
 9036	drinkable hacked gibson	4	good	Last Available: "2016-06"
 9037	mirror Annie Oakley's Source shades	0		Critical Hit Percent: +20, Last Available: "2016-06"
-9038	twirling cyan software bug	0		Last Available: "2016-06"
+9038	cyan twirling software bug	0		Last Available: "2016-06"
 9039	skewed missing semicolon	0		Familiar Weight: +11
 9040	lime green Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	blurry Source terminal GRAM chip	0		Last Available: "2016-06"
@@ -8954,7 +8954,7 @@
 9082	aromatic asbestos-lined knitted friendly boxer's protonic accelerator pack of Calamity Jane	0		Muscle Percent: +10, Critical Hit Percent: +15, Familiar Weight: +3, Cold Resistance: +3, Hot Resistance: +5, Stench Resistance: +1, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	experienced Adventurer bobblehead	0		Experience: +2, Last Available: "2016-11"
-9085	pulsating twirling psychokinetic energy blob	0		Last Available: "2016-08"
+9085	twirling pulsating psychokinetic energy blob	0		Last Available: "2016-08"
 9086	teal executive bindle of James Dean	0		Experience (Moxie): +3, Meat Drop: +40, Last Available: "2016-08"
 9087	olive spinning upside-down hardened smartaleck's fleshy lump	0		Moxie Percent: +30, Damage Reduction: 6, Last Available: "2016-08"
 9088	sharpshooter's smoldering bagel punch of the cougar	0		Moxie: +20, Critical Hit Percent: +10, Last Available: "2016-08"
@@ -8974,18 +8974,18 @@
 9102	narrow cyan Wrist-Boy of the ox	0		Muscle: +20
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
-9105	bouncing purple compounded experience	0		Last Available: "2016-09"
+9105	purple bouncing compounded experience	0		Last Available: "2016-09"
 9106	pulsating Rad-B-Gone (1 lb.)	0		
 9107	quadruple-concentrated enhanced blinking Rad-Pro (1 oz.)	0		Effect: "Preternatural Greed", Effect Duration: 64
 9108	lead umbrella	0		
 9109	colloidal blinking Shrieking Weasel holo-record	0		Effect: "Wet and Greedy", Effect Duration: 36
 9110	anodized activated liquefied Power-Guy 2000 holo-record	0		Effect: "Inscrutable exoskeleton", Effect Duration: 55
 9111	enhanced flattened Lucky Strikes holo-record	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 24
-9112	pickled spinning tumbling EMD holo-record	0		Effect: "Dancing Prowess", Effect Duration: 40
+9112	pickled tumbling spinning EMD holo-record	0		Effect: "Dancing Prowess", Effect Duration: 40
 9113	pickled Vulcanized Superdrifter holo-record	0		Effect: "Ice Packed", Effect Duration: 14
 9114	triple-concentrated galvanized spinning The Pigs holo-record	0		Effect: "Toast Tea", Effect Duration: 18
 9115	galvanized squat Drunk Uncles holo-record	0		Effect: "The Smile of Mr. A.", Effect Duration: 37
-9116	teal blurry time residue	0		Last Available: "2016-09"
+9116	blurry teal time residue	0		Last Available: "2016-09"
 9117	strapping repaid diaper	0		Muscle: +5
 9118	pulsating Riker's Search History	0		Last Available: "2016-09"
 9119	aged Shot of Kardashian Gin	3	awesome	Last Available: "2016-09"
@@ -8995,10 +8995,10 @@
 9123	mirror School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	artisanal watered-down unidentified drink	2	EPIC	
+9126	watered-down artisanal unidentified drink	2	EPIC	
 9127	miser's KoL Con 13 T-shirt of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +10
 9128	huge coward's hale fortified discarded swimming trunks	0		Damage Absorption: +60, Maximum HP: +20, Monster Level: -20
-9129	extra-oxidized improved jittery wobbly diluted makeup	0		Effect: "Irresistible Resolve", Effect Duration: 41
+9129	extra-oxidized improved wobbly jittery diluted makeup	0		Effect: "Irresistible Resolve", Effect Duration: 41
 9130	boiled shaking charisma potion	0		Effect: "Wreathed in Smoke", Effect Duration: 67
 9131	extremely confusing manual	0		
 9132	educational thinker's pistol	0		Mysticality: +10, Experience: +1
@@ -9024,29 +9024,29 @@
 9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	stale pulsating raw sweet potato	3	decent	Last Available: "2016-11"
 9154	bland raw beans	4	decent	Last Available: "2016-11"
-9155	normal half-sized raw stuffing	2	good	Last Available: "2016-11"
-9156	stale immense teal raw cranberry sauce	6	decent	Last Available: "2016-11"
-9157	massive adequate red raw turkey	10	good	Last Available: "2016-11"
+9155	half-sized normal raw stuffing	2	good	Last Available: "2016-11"
+9156	immense stale teal raw cranberry sauce	6	decent	Last Available: "2016-11"
+9157	adequate massive red raw turkey	10	good	Last Available: "2016-11"
 9158	rotten pulsating raw mincemeat	3	crappy	Last Available: "2016-11"
 9159	toothsome immense blinking raw potato	8	awesome	Last Available: "2016-11"
 9160	miniature rotten raw gravy	2	crappy	Last Available: "2016-11"
 9161	yummy twirling yellow raw bread	4	awesome	Last Available: "2016-11"
 9162	up-at-dawn coward's mini-marshmallow dispenser	0		Monster Level: -20, Adventures: +5, Last Available: "2016-11"
 9163	knitted supercharged glass casserole dish of mayonnaise	0		Maximum MP Percent: +30, Sleaze Spell Damage: +50, Cold Resistance: +3, Last Available: "2016-11"
-9164	blurry lime green stuffing fluffer	0		Last Available: "2016-11"
+9164	lime green blurry stuffing fluffer	0		Last Available: "2016-11"
 9165	can opener of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Last Available: "2016-11"
 9166	dehydrated squat turkey blaster	1		Last Available: "2016-11"
 9167	lime green blinking Annie Oakley's Van der Graaf glass pie plate	0		Critical Hit Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 7, Last Available: "2016-11"
 9168	Sherlock's asbestos-lined potato masher	0		Hot Resistance: +5, Item Drop: +25, Last Available: "2016-11"
 9169	spinning gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	fancy huge adequate tumbling sweet potatoes	9	good	Effect: "Hopped Up on Goofballs", Effect Duration: 10, Last Available: "2016-11"
-9172	bland miniature bean casserole	2	decent	Last Available: "2016-11"
-9173	bland half-sized fuchsia baked stuffing	2	decent	Last Available: "2016-11"
+9171	adequate fancy huge tumbling sweet potatoes	9	good	Effect: "Hopped Up on Goofballs", Effect Duration: 10, Last Available: "2016-11"
+9172	miniature bland bean casserole	2	decent	Last Available: "2016-11"
+9173	half-sized bland fuchsia baked stuffing	2	decent	Last Available: "2016-11"
 9174	adequate special jittery cranberry cylinder	3	good	Effect: "Feroci Tea", Effect Duration: 5, Last Available: "2016-11"
-9175	huge flavorless thanksgiving turkey	8	decent	Last Available: "2016-11"
+9175	flavorless huge thanksgiving turkey	8	decent	Last Available: "2016-11"
 9176	snack-sized adequate mince pie	2	good	Last Available: "2016-11"
-9177	adequate big wobbly mashed potatoes	5	good	Last Available: "2016-11"
+9177	big adequate wobbly mashed potatoes	5	good	Last Available: "2016-11"
 9178	flavorless warm gravy	3	decent	Last Available: "2016-11"
 9179	bland small bread roll	2	decent	Last Available: "2016-11"
 9180	bland leftovers	4	decent	Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	squat upside-down Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	corrupted eldritch concentrate	0		Effect: "Wax On Your Shoes", Effect Duration: 21, Last Available: "2016-11"
-9192	acceptable twirling shaking eldritch extract	4	good	Last Available: "2016-11"
+9192	acceptable shaking twirling eldritch extract	4	good	Last Available: "2016-11"
 9193	flame-retardant beefy Official Council Aide Pin	0		Muscle: +10, Hot Resistance: +1, Last Available: "2016-11"
-9194	strong lousy eldritch distillate	5	decent	Last Available: "2016-11"
+9194	lousy strong eldritch distillate	5	decent	Last Available: "2016-11"
 9195	altered mirror eldritch essence	1		Last Available: "2016-11"
 9196	huge Science Notebook of chilblains	0		Cold Damage: +25
 9197	blue spinning avaricious Van der Graaf steel-toed eldritch hat	0		Damage Reduction: 9, Meat Drop: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-11"
@@ -9077,7 +9077,7 @@
 9205	sprinkles	0		Last Available: "2016-12"
 9206	bouncing The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	Sherlock's ball and chain	0		Item Drop: +25, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
-9208	wobbly narrow candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
+9208	narrow wobbly candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9209	blinking therapeutic gingerbread tophat	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-12"
 9210	squat lard-coated gingerbread waistcoat	0		Sleaze Spell Damage: +25, Last Available: "2016-12"
 9211	electrified gingerbread trousers	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
@@ -9088,9 +9088,9 @@
 9216	huge interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	ghostly sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	delicious miniature animal part cracker	2	awesome	Last Available: "2016-12"
-9220	bad special gingerbread wine	4	decent	Effect: "Wise Spirit", Effect Duration: 40, Last Available: "2016-12"
-9221	decent half-sized purple upside-down gingerbread mug	2	good	Last Available: "2016-12"
+9219	miniature delicious animal part cracker	2	awesome	Last Available: "2016-12"
+9220	special bad gingerbread wine	4	decent	Effect: "Wise Spirit", Effect Duration: 40, Last Available: "2016-12"
+9221	half-sized decent upside-down purple gingerbread mug	2	good	Last Available: "2016-12"
 9222	flame-retardant gingerbread mask	0		Hot Resistance: +1, Last Available: "2016-12"
 9223	tumbling sizzling gingerservo of the wise owl of the empath	0		Mysticality: +20, Familiar Weight: +5, Hot Damage: +10, Single Equip, Last Available: "2016-12"
 9224	denatured wet teal tainted icing	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 59, Last Available: "2016-12"
@@ -9102,7 +9102,7 @@
 9230	mirror creme brulee torch of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Last Available: "2016-12"
 9231	candy crowbar of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2016-12"
 9232	wobbly nippy manspreader's candy screwdriver	0		Monster Level: +10, Cold Damage: +10, Last Available: "2016-12"
-9233	upside-down blurry gingerbread dog treat	0		Last Available: "2016-12"
+9233	blurry upside-down gingerbread dog treat	0		Last Available: "2016-12"
 9234	pumpkin spice candle	0		Item Drop: +5, Lasts Until Rollover, Last Available: "2016-12"
 9235	nitrogenated gingerbread spice latte	0		Effect: "Crimbo Nostalgia", Effect Duration: 32, Last Available: "2016-12"
 9236	maroon blurry miser's supercool gingerbread gavel	0		Moxie Percent: +20, Meat Drop: +10, Last Available: "2016-12"
@@ -9124,7 +9124,7 @@
 9252	bland half-sized blue spiritual candy cane	2	decent	Last Available: "2016-12"
 9253	aged olive spiritual eggnog	3	awesome	Last Available: "2016-12"
 9254	adequate huge spiritual fruitcake	9	good	Last Available: "2016-12"
-9255	jumbo spoiled spiritual gingerbread	5	crappy	Last Available: "2016-12"
+9255	spoiled jumbo spiritual gingerbread	5	crappy	Last Available: "2016-12"
 9256	blinking chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	upside-down My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9136,19 +9136,19 @@
 9264	shaking briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	super-galvanized blurry rock candy	0		Effect: "Oriental Mysticism", Effect Duration: 42, Last Available: "2016-12"
-9267	rotten bite-sized green-iced sweet roll	1	crappy	Last Available: "2016-12"
+9267	bite-sized rotten green-iced sweet roll	1	crappy	Last Available: "2016-12"
 9268	wobbly sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
-9270	huge fuchsia ghostly no hat	0		Lasts Until Rollover, Last Available: "2016-12"
+9270	huge ghostly fuchsia no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	wobbly chakra sludge	0		
 9272	negative lump	0		
 9273	scandalous Third Eye of horror	0		Spooky Spell Damage: +25, Sleaze Damage: +5, Last Available: "2016-12"
 9274	red frosty Krampus Horn of temperance	0		Cold Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2016-12"
-9275	adequate fancy half-sized hambrosier	2	good	Effect: "Pretending to Pretend", Effect Duration: 10, Last Available: "2016-12"
+9275	half-sized adequate fancy hambrosier	2	good	Effect: "Pretending to Pretend", Effect Duration: 10, Last Available: "2016-12"
 9276	watered-down drinkable chakra-mental wine	2	good	Last Available: "2016-12"
 9277	quadruple-polymerized enhanced adjusted wobbly chakra malt	0		Effect: "High Blood Chocolate Content", Effect Duration: 56, Last Available: "2016-12"
 9278	adequate Black Angus blackburger	3	good	Last Available: "2016-12"
-9279	watered-down lousy blinking gray brandy	2	decent	Last Available: "2016-12"
+9279	lousy watered-down gray blinking brandy	2	decent	Last Available: "2016-12"
 9280	super-warmed moist potion of spiritual gunkifying	0		Effect: "Dancing Prowess", Effect Duration: 47, Last Available: "2016-12"
 9281	flame-retardant Temple Grandin's bad vibroknife	0		Familiar Weight: +7, Hot Resistance: +1, Last Available: "2016-12"
 9282	Temple Grandin's Van der Graaf crystal belt buckle	0		Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12"
@@ -9159,16 +9159,16 @@
 9287	pulsating pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	huge greasy padded dance instructor's Uncle Crimbo's hat	0		Experience Percent (Moxie): +10, Damage Absorption: +20, Sleaze Spell Damage: +10, Last Available: "2016-12"
-9290	enchanted delicious Eldritch snap	3	awesome	Effect: "Bootyliciousness", Effect Duration: 10, Last Available: "2017-01"
-9291	mixed wobbly olive hot jelly	1		Effect: "Down With Chow", Effect Duration: 5, Last Available: "2017-01"
+9290	delicious enchanted Eldritch snap	3	awesome	Effect: "Bootyliciousness", Effect Duration: 10, Last Available: "2017-01"
+9291	mixed olive wobbly hot jelly	1		Effect: "Down With Chow", Effect Duration: 5, Last Available: "2017-01"
 9292	dehydrated pulsating jelly	1		Effect: "Going Ape", Effect Duration: 5, Last Available: "2017-01"
 9293	modified jelly	1		Last Available: "2017-01"
 9294	dehydrated mirror sleaze jelly	1		Last Available: "2017-01"
-9295	dried blurry skewed stench jelly	1		Last Available: "2017-01"
+9295	dried skewed blurry stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	toothsome toast with hot jelly	3	awesome	Last Available: "2017-01"
 9298	moldy green toast with jelly	4	crappy	Last Available: "2017-01"
-9299	miniature flavorless toast with jelly	2	decent	Last Available: "2017-01"
+9299	flavorless miniature toast with jelly	2	decent	Last Available: "2017-01"
 9300	thick flavorless mirror toast with sleaze jelly	5	decent	Last Available: "2017-01"
 9301	delicious blinking toast with stench jelly	3	awesome	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
@@ -9178,7 +9178,7 @@
 9306	perfumed wizardly candle	0		Mysticality: +25, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	stale ghostly wax pancake	4	decent	Last Available: "2017-01"
 9308	wax face of Gandalf of the detective	0		Spell Critical Percent: +20, Item Drop: +20, Last Available: "2017-01"
-9309	practically non-alcoholic delicious wax booze	1	awesome	Last Available: "2017-01"
+9309	delicious practically non-alcoholic wax booze	1	awesome	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	modified sea jelly	1		Last Available: "2017-01"
 9312	rotten mirror sea truffle	4	crappy	Last Available: "2017-01"
@@ -9203,7 +9203,7 @@
 9331	ruddy eldritch hammer of the dark arts of terror	0		Spell Damage Percent: +100, Maximum HP Percent: +40, Spooky Spell Damage: +10, Last Available: "2017-01"
 9332	normal eldritch mushroom	4	good	Last Available: "2017-03"
 9333	jittery eldritch ichor	0		
-9334	stale miniature eldritch mushroom pizza	2	decent	Last Available: "2017-03"
+9334	miniature stale eldritch mushroom pizza	2	decent	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	irradiated nitrogenated cyan eldritch rub	0		Effect: "Greedy Resolve", Effect Duration: 54, Last Available: "2017-02"
@@ -9236,34 +9236,34 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	hand-crafted practically non-alcoholic literal grasshopper	1	EPIC	Last Available: "2017-03"
 9366	perfectly mixed double entendre	3	EPIC	Last Available: "2017-03"
-9367	lousy enchanted weak Phlegethon	2	decent	Effect: "Cold Hands", Effect Duration: 50, Last Available: "2017-03"
-9368	boozy drinkable Siberian sunrise	5	good	Last Available: "2017-03"
-9369	tolerable practically non-alcoholic mentholated wine	1	good	Last Available: "2017-03"
+9367	lousy weak enchanted Phlegethon	2	decent	Effect: "Cold Hands", Effect Duration: 50, Last Available: "2017-03"
+9368	drinkable boozy Siberian sunrise	5	good	Last Available: "2017-03"
+9369	practically non-alcoholic tolerable mentholated wine	1	good	Last Available: "2017-03"
 9370	lousy extra-dry low tide martini	5	decent	Last Available: "2017-03"
 9371	acceptable shroomtini	3	good	Last Available: "2017-03"
 9372	delicious enchanted morning dew	4	awesome	Effect: "Electrolit Up", Effect Duration: 30, Last Available: "2017-03"
-9373	weak mediocre whiskey squeeze	2	decent	Last Available: "2017-03"
+9373	mediocre weak whiskey squeeze	2	decent	Last Available: "2017-03"
 9374	drinkable great fashioned	3	good	Last Available: "2017-03"
-9375	perfectly mixed practically non-alcoholic Gnomish sagngria	1	EPIC	Last Available: "2017-03"
-9376	hand-crafted lime green jittery vodka stinger	4	EPIC	Last Available: "2017-03"
+9375	practically non-alcoholic perfectly mixed Gnomish sagngria	1	EPIC	Last Available: "2017-03"
+9376	hand-crafted jittery lime green vodka stinger	4	EPIC	Last Available: "2017-03"
 9377	perfectly mixed extremely slippery nipple	3	EPIC	Last Available: "2017-03"
 9378	hand-crafted piscatini	4	EPIC	Last Available: "2017-03"
 9379	extra-dry bad Churchill	5	decent	Last Available: "2017-03"
-9380	perfectly mixed weak soilzerac	2	EPIC	Last Available: "2017-03"
+9380	weak perfectly mixed soilzerac	2	EPIC	Last Available: "2017-03"
 9381	irresponsibly strong aged gray London frog	7	awesome	Last Available: "2017-03"
 9382	hand-crafted blinking nothingtini	4	EPIC	Last Available: "2017-03"
-9383	delicious practically non-alcoholic eighth plague	1	awesome	Last Available: "2017-03"
+9383	practically non-alcoholic delicious eighth plague	1	awesome	Last Available: "2017-03"
 9384	lousy single entendre	3	decent	Last Available: "2017-03"
 9385	lousy practically non-alcoholic reverse Tantalus	1	decent	Last Available: "2017-03"
 9386	weak delicious elemental caipiroska	2	awesome	Last Available: "2017-03"
 9387	aged Feliz Navidad	4	awesome	Last Available: "2017-03"
 9388	tolerable Bloody Nora	3	good	Last Available: "2017-03"
-9389	practically non-alcoholic hand-crafted squat moreltini	1	EPIC	Last Available: "2017-03"
-9390	watered-down acceptable hell in a bucket	2	good	Last Available: "2017-03"
+9389	hand-crafted practically non-alcoholic squat moreltini	1	EPIC	Last Available: "2017-03"
+9390	acceptable watered-down hell in a bucket	2	good	Last Available: "2017-03"
 9391	lousy spinning Newark	4	decent	Last Available: "2017-03"
 9392	bad R'lyeh	4	decent	Last Available: "2017-03"
 9393	perfectly mixed Gnollish sangria	3	EPIC	Last Available: "2017-03"
-9394	acceptable irresponsibly strong vodka barracuda	6	good	Last Available: "2017-03"
+9394	irresponsibly strong acceptable vodka barracuda	6	good	Last Available: "2017-03"
 9395	practically non-alcoholic smooth lime green Mysterious Island iced tea	1	awesome	Last Available: "2017-03"
 9396	bad drive-by shooting	3	decent	Last Available: "2017-03"
 9397	smooth gunner's daughter	4	awesome	Last Available: "2017-03"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	moldy miniature edible alien plant bit	2	crappy	Last Available: "2017-04"
+9415	miniature moldy edible alien plant bit	2	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9335,15 +9335,15 @@
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
-9466	half-sized decent Aldebaran sardines	2	good	Last Available: "2017-04"
+9466	decent half-sized Aldebaran sardines	2	good	Last Available: "2017-04"
 9467	hand-crafted twirling Centauri fish wine	4	EPIC	Last Available: "2017-04"
-9468	pickled blinking olive oxygen	1		Last Available: "2017-04"
+9468	pickled olive blinking oxygen	1		Last Available: "2017-04"
 9469	lime green executive ribald Spacegate scientist's insignia	0		Sleaze Damage: +10, Meat Drop: +40, Single Equip, Last Available: "2017-04"
 9470	huge supercharged Spacegate military insignia of the brute	0		Muscle Percent: +30, Maximum MP Percent: +30, Single Equip, Last Available: "2017-04"
 9471	rosewater-soaked coward's veiny Spacegate diplomat's insignia	0		Maximum HP: +10, Monster Level: -20, Stench Resistance: +3, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	massive normal alien sandwich	6	good	Last Available: "2017-04"
+9474	normal massive alien sandwich	6	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	polymerized Spant eggs	0		Effect: "Purity of Spirit", Effect Duration: 21
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9393,7 +9393,7 @@
 9521	squat huge stanky groovy meteorthopedic shoes of the boozehound	0		Moxie Percent: +10, Stench Spell Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2017-08"
 9522	rock-hard brawny shooting morning star of vim and vigor	0		Muscle Percent: +20, Damage Reduction: 5, Maximum HP Percent: +50, Single Equip, Last Available: "2017-08"
 9523	meteoroid	0		Last Available: "2017-08"
-9524	huge yellow meteor shower cap	0		Familiar Weight: +5
+9524	yellow huge meteor shower cap	0		Familiar Weight: +5
 9525	Thwaitgold time fly statuette	0		
 9526	perfectly fair coin	0		Last Available: "2017-11"
 9527	red Horsery contract	0		Free Pull, Last Available: "2018-08"
@@ -9401,10 +9401,10 @@
 9529	bouncing genie bottle	0		Last Available: "2017-09"
 9530	wobbly twirling asbestos-lined crafty razor-sharp blessed rustproof +2 gray dragon scale mail	0		Weapon Damage Percent: +25, Maximum MP: +10, Hot Resistance: +5, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
-9532	shaking olive pony: Shutterfly	0		Last Available: "2017-09"
+9532	olive shaking pony: Shutterfly	0		Last Available: "2017-09"
 9533	upside-down pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
-9535	jittery gray pony: Rosey Cake	0		Last Available: "2017-09"
+9535	gray jittery pony: Rosey Cake	0		Last Available: "2017-09"
 9536	wobbly pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	tumbling pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
@@ -9413,10 +9413,10 @@
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	gray X	0		Last Available: "2017-10"
-9544	blue shaking O	0		Last Available: "2017-10"
+9544	shaking blue O	0		Last Available: "2017-10"
 9545	artisanal gray DUFRESNE Suds	3	EPIC	Last Available: "2017-09"
 9546	personal trainer's mafia pinky ring of the pedagogue	0		Experience: +3, Experience Percent (Muscle): +10, Single Equip
-9547	bad triple-distilled flask of port	7	decent	
+9547	triple-distilled bad flask of port	7	decent	
 9548	personal trainer's strapping contract enforcement stick	0		Muscle: +5, Experience Percent (Muscle): +10
 9549	flavorless blurry Hide-rox&trade; cookie	3	decent	Last Available: "2017-10"
 9550	lousy practically non-alcoholic jug of booze	1	decent	Last Available: "2017-10"
@@ -9434,7 +9434,7 @@
 9562	electrified deadly arcane researcher's protection stick of the overflowing toilet	0		Experience Percent (Mysticality): +10, Weapon Damage: +5, Stench Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5
 9563	modified galvanized roll of meat	0		Effect: "Lifted Spirits", Effect Duration: 49
 9564	forbidden mafia thumb ring of the early riser	0		Spell Damage Percent: +50, Adventures: +7, Single Equip
-9565	non-anodized ghostly blue cocoa chondrule	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 44, Last Available: "2020-09"
+9565	non-anodized blue ghostly cocoa chondrule	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 44, Last Available: "2020-09"
 9566	Herculean mafia middle finger ring of the glutton	0		Experience (Muscle): +1, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	wobbly Jeselnik's frightening foul-smelling Sinatra's steel drivin' hammer	0		Experience (Moxie): +5, Stench Damage: +10, Spooky Damage: +5, Sleaze Damage: +25
 9568	piece of steel	0		
@@ -9450,7 +9450,7 @@
 9578	transparent nog	1	awesome	Last Available: "2017-12"
 9579	flavorless squat unfinished fruitcake	4	decent	Last Available: "2017-12"
 9580	altered energized twirling and cracker	0		Effect: "Flagrantly Fragrant", Effect Duration: 22, Last Available: "2017-12"
-9581	bad practically non-alcoholic neg grog	1	decent	Last Available: "2017-12"
+9581	practically non-alcoholic bad neg grog	1	decent	Last Available: "2017-12"
 9582	rotten half double fruitcake	4	crappy	Last Available: "2017-12"
 9583	decent hushed puppy	3	good	Last Available: "2017-12"
 9584	bland huge wobbly muffled muffuletta	3	decent	Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	polarized adjusted blinking wishbone	0		Effect: "On the Shoulders of Giants", Effect Duration: 46, Last Available: "2017-11"
 9595	tolerable Racisto Ruidoso	3	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	tiny moldy bran muffin	1	crappy	
+9597	moldy tiny bran muffin	1	crappy	
 9598	spoiled fancy blueberry muffin	4	crappy	Effect: "Blessing of the Creepy Pasta", Effect Duration: 50
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
@@ -9500,7 +9500,7 @@
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	lousy spinning stale cheer wine	3	decent	Last Available: "2017-12"
 9630	delicious bouncing stale Cheer-E-Os	3	awesome	Last Available: "2017-12"
-9631	yellow narrow cheer-o-gram	0		Last Available: "2017-12"
+9631	narrow yellow cheer-o-gram	0		Last Available: "2017-12"
 9632	cheerful antler hat of the brazier of doom	0		Hot Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2017-12"
 9633	squat blinking sage cheerful Crimbo sweater of the sewer	0		Mysticality Percent: +10, Stench Damage: +25, Last Available: "2017-12"
 9634	gravedigger's cheerful pajama pants of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +10, Last Available: "2017-12"
@@ -9514,16 +9514,16 @@
 9642	huge The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	purple The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
-9645	pulsating olive The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9645	olive pulsating The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	bouncing The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	shaking teal mime eraser	0		Last Available: "2017-12"
 9648	delicious twirling executive mime flask	4	awesome	Last Available: "2017-12"
-9649	tiny spoiled nega-mushroom	1	crappy	Last Available: "2017-12"
-9650	tolerable special strong nega-mushroom wine	5	good	Effect: "Sludgesick", Effect Duration: 40, Last Available: "2017-12"
+9649	spoiled tiny nega-mushroom	1	crappy	Last Available: "2017-12"
+9650	strong tolerable special nega-mushroom wine	5	good	Effect: "Sludgesick", Effect Duration: 40, Last Available: "2017-12"
 9651	pressed corrupted moist Cheer-Up soda	0		Effect: "Full of Wist", Effect Duration: 49, Last Available: "2017-12"
 9652	bland mime army rations	3	decent	Last Available: "2017-12"
-9653	hand-crafted weak mime army wine	2	super ultra mega turbo EPIC	Last Available: "2017-12"
-9654	distilled tumbling upside-down green mime army superserum	1		Last Available: "2017-12"
+9653	weak hand-crafted mime army wine	2	super ultra mega turbo EPIC	Last Available: "2017-12"
+9654	distilled green tumbling upside-down mime army superserum	1		Last Available: "2017-12"
 9655	unsweetened mime army camouflage kit	0		Effect: "Can Has Cyborger", Effect Duration: 39, Last Available: "2017-12"
 9656	lard-coated cool miming beret	0		Moxie: +5, Sleaze Spell Damage: +25, Last Available: "2017-12"
 9657	jittery medical-grade miming shirt of the blizzard	0		Cold Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-12"
@@ -9575,7 +9575,7 @@
 9703	boiled beefy pill	1		Effect: "Twinklebritches", Effect Duration: 20
 9704	denatured twirling excitement pill	1		Effect: "Kindly Resolve", Effect Duration: 40
 9705	twisted vitamin G pill	1		
-9706	distilled spinning maroon lucky-ish pill	1		Effect: "Banono", Effect Duration: 25
+9706	distilled maroon spinning lucky-ish pill	1		Effect: "Banono", Effect Duration: 25
 9707	mixed dieting pill	1		Effect: "Cookie Backup", Effect Duration: 35
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
@@ -9593,7 +9593,7 @@
 9725	avaricious perfumed psychic's pslacks	0		Stench Resistance: +5, Meat Drop: +30, Last Available: "2018-02"
 9726	electrified veiny psychic's amulet	0		Maximum HP: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-02"
 9727	flavorless ghostly heart-shaped candy whetstone	4	decent	Last Available: "2018-02"
-9728	low-calorie normal Swedish massage fish	1	good	Last Available: "2018-02"
+9728	normal low-calorie Swedish massage fish	1	good	Last Available: "2018-02"
 9729	fortified perfectly mixed Third Base	5	EPIC	Last Available: "2018-02"
 9730	acceptable squat ghostly Bustle Hustler	3	good	Last Available: "2018-02"
 9731	flattened boiled shaking Fabiotion	0		Effect: "Wit Tea", Effect Duration: 28, Last Available: "2018-02"
@@ -9607,8 +9607,8 @@
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
-9742	yellow bouncing Mysterious Black Box	0		Last Available: "2018-02"
-9743	concentrated vacuum-sealed blinking wobbly pulsating rainbow jellybean	0		Effect: "So You Can Work More...", Effect Duration: 24
+9742	bouncing yellow Mysterious Black Box	0		Last Available: "2018-02"
+9743	concentrated vacuum-sealed wobbly blinking pulsating rainbow jellybean	0		Effect: "So You Can Work More...", Effect Duration: 24
 9744	electrified mystery lollipop	0		Effect: "Hopped Up on Goofballs", Effect Duration: 25
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	denatured flattened twirling wobbly rhinestone	0		Effect: "Cybernetic Muscles", Effect Duration: 24
@@ -9632,10 +9632,10 @@
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	cyan bouncing Pimpsqueak	0		Last Available: "2018-03"
-9767	cyan bouncing Pillowbug	0		Last Available: "2018-03"
+9767	bouncing cyan Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
-9770	twirling fuchsia Carpricorn	0		Last Available: "2018-03"
+9770	fuchsia twirling Carpricorn	0		Last Available: "2018-03"
 9771	Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
@@ -9662,7 +9662,7 @@
 9794	maroon Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
-9797	squat shaking Caramel	0		Last Available: "2018-03"
+9797	shaking squat Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
 9799	spinning Amanitee	0		Last Available: "2018-03"
 9800	green Smashmoth	0		Last Available: "2018-03"
@@ -9671,11 +9671,11 @@
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
 9805	twirling Shudder	0		Last Available: "2018-03"
-9806	jittery wobbly Glamare	0		Last Available: "2018-03"
+9806	wobbly jittery Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
-9808	blinking narrow Stooper	0		Last Available: "2018-03"
+9808	narrow blinking Stooper	0		Last Available: "2018-03"
 9809	lime green Disgeist	0		Last Available: "2018-03"
-9810	lime green wobbly Bowlet	0		Last Available: "2018-03"
+9810	wobbly lime green Bowlet	0		Last Available: "2018-03"
 9811	skewed Cornbeefadon	0		Last Available: "2018-03"
 9812	purple Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
@@ -9683,7 +9683,7 @@
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
-9818	upside-down cyan Tapioc berry	0		Last Available: "2018-03"
+9818	cyan upside-down Tapioc berry	0		Last Available: "2018-03"
 9819	twirling Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
 9821	red luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
@@ -9693,7 +9693,7 @@
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	teal rocket	0		
-9828	compressed tumbling upside-down skewed magnificent oyster egg	1		Effect: "Human-Orc Hybrid", Effect Duration: 40
+9828	compressed upside-down tumbling skewed magnificent oyster egg	1		Effect: "Human-Orc Hybrid", Effect Duration: 40
 9829	diluted blurry brilliant oyster egg	1		
 9830	boiled blurry glistening oyster egg	1		Effect: "Rushin' Hands", Effect Duration: 50
 9831	pickled green scintillating oyster egg	1		Effect: "You Read The Manual", Effect Duration: 35
@@ -9710,7 +9710,7 @@
 9842	olive lump of bauxite	0		Last Available: "2018-12"
 9843	upside-down maroon knitted hale &quot;Remember the Trees&quot; Shirt of Calamity Jane	0		Maximum HP: +20, Critical Hit Percent: +15, Cold Resistance: +3
 9844	FantasyRealm key	0		Last Available: "2018-04"
-9845	jittery spinning blue plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
+9845	spinning blue jittery plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	yellow blurry spinning Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
@@ -9721,7 +9721,7 @@
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	jittery blinking druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	blinking to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	wobbly skewed flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9856	skewed wobbly flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	deionized gray universal antivenin	0		Lasts Until Rollover, Effect: "Haunted Stomach", Effect Duration: 37, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	upside-down LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
@@ -9735,7 +9735,7 @@
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	purple grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	moldy druidic s'more	3	crappy	Last Available: "2018-04"
-9870	mixed teal wobbly sachet of powder	1		Effect: "Spirit of Alph", Effect Duration: 10, Last Available: "2018-04"
+9870	mixed wobbly teal sachet of powder	1		Effect: "Spirit of Alph", Effect Duration: 10, Last Available: "2018-04"
 9871	practically non-alcoholic smooth mourning wine	1	awesome	Last Available: "2018-04"
 9872	twirling sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	narrow blinking map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	ghostly map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	adequate denastified haunch	4	good	Last Available: "2018-04"
-9879	tolerable fortified green bad rum and good cola	5	good	Last Available: "2018-04"
+9879	fortified tolerable green bad rum and good cola	5	good	Last Available: "2018-04"
 9880	polymerized warmed bouncing teal Potion of Heroism	0		Effect: "Low on the Hog", Effect Duration: 60, Last Available: "2018-04"
 9881	wobbly prompt therapeutic leggings of the Spider Queen of the empath	0		Familiar Weight: +5, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-04"
 9882	hale healthy cool Master Thief's utility belt	0		Moxie: +5, Maximum HP Percent: +20, Maximum HP: +20, Single Equip, Last Available: "2018-04"
@@ -9790,7 +9790,7 @@
 9922	energized green Shielding Potion	0		Effect: "Ooh, Bitter!", Effect Duration: 15, Last Available: "2018-06"
 9923	colloidal diffused polarized ghostly Punching Potion	0		Effect: "Really Deep Breath", Effect Duration: 56, Last Available: "2018-06"
 9924	teal Special Seasoning	0		Last Available: "2018-06"
-9925	mixed shaking gray squat Nightmare Fuel	1		Effect: "Aloofah", Effect Duration: 35, Last Available: "2018-06"
+9925	mixed squat shaking gray Nightmare Fuel	1		Effect: "Aloofah", Effect Duration: 35, Last Available: "2018-06"
 9926	narrow Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9799,7 +9799,7 @@
 9931	experienced weightlifter's Nouveau nosering of the ox of dire peril	0		Muscle: 35, Experience: +2, Weapon Damage: +20, Lasts Until Rollover, Last Available: "2018-07"
 9932	non-energized sharkfin gumbo	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 18, Last Available: "2018-07"
 9933	corrupted boiling broth	0		Effect: "Polka of Plenty", Effect Duration: 30, Last Available: "2018-07"
-9934	flattened cold-filtered ghostly cyan interrogative elixir	0		Effect: "Pockets of Fire", Effect Duration: 51, Last Available: "2018-07"
+9934	flattened cold-filtered cyan ghostly interrogative elixir	0		Effect: "Pockets of Fire", Effect Duration: 51, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	skewed Bastille Battalion cheese wheel	0		Last Available: "2018-07"
@@ -9818,7 +9818,7 @@
 9950	pentagram bandana of Tarzan of Leguizamo	0		Experience (Muscle): +3, Monster Level: +20, Last Available: "2018-09"
 9951	lime green steel-toed skull ring	0		Damage Reduction: 9, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	normal bite-sized squat spinning PB&J with the crusts cut off	1	good	Last Available: "2018-09"
+9953	normal bite-sized spinning squat PB&J with the crusts cut off	1	good	Last Available: "2018-09"
 9954	narrow rosy-cheeked dorky glasses	0		Maximum HP Percent: +30, Item Drop: +5, Single Equip, Last Available: "2018-09"
 9955	MacGyver's resourceful ponytail clip	0		Maximum MP: 150, Last Available: "2018-09"
 9956	green upside-down sage paint palette	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
@@ -9837,19 +9837,19 @@
 9969	lightning-fast coward's denim jacket	0		Monster Level: -20, Initiative: +40, Last Available: "2018-09"
 9970	ratty knitted cap of the empath of bravery	0		Familiar Weight: +5, Spooky Resistance: +5, Last Available: "2018-09"
 9972	greasy vibrating intimidating chainsaw	0		Maximum MP Percent: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2018-09"
-9973	fancy acceptable blurry olive party beer bomb	3	good	Effect: "Mayeaugh", Effect Duration: 25, Last Available: "2018-09"
+9973	acceptable fancy blurry olive party beer bomb	3	good	Effect: "Mayeaugh", Effect Duration: 25, Last Available: "2018-09"
 9974	spoiled sweet party mix	3	crappy	Last Available: "2018-09"
 9975	pickled party balloon	1		Last Available: "2018-09"
 9976	sinister party pants of Calamity Jane	0		Spell Damage: +10, Critical Hit Percent: +15, Last Available: "2018-09"
 9977	jittery zippy nasty Samson's party whip	0		Experience (Muscle): +5, Stench Damage: +5, Initiative: +20, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	acceptable ghostly TRIO cup of beer	4	good	Last Available: "2018-09"
-9980	fancy adequate snack-sized party platter for one	2	good	Effect: "Biologically Shocked", Effect Duration: 20, Last Available: "2018-09"
+9980	fancy snack-sized adequate party platter for one	2	good	Effect: "Biologically Shocked", Effect Duration: 20, Last Available: "2018-09"
 9981	modified Party-in-a-Can&trade;	1		Last Available: "2018-09"
-9982	tumbling squat party pup	0		Last Available: "2018-09"
+9982	squat tumbling party pup	0		Last Available: "2018-09"
 9983	beefy party crasher of the overflowing toilet	0		Muscle: +10, Stench Spell Damage: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
-9985	mirror jittery Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
+9985	jittery mirror Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	blurry latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
@@ -9877,15 +9877,15 @@
 10011	normal	4	good	Last Available: "2018-11"
 10012	drinkable bottle of vodka	4	good	Last Available: "2018-11"
 10013	rotten snack-sized ghostly pizza	2	crappy	Last Available: "2018-11"
-10014	weak tolerable martini	2	good	Last Available: "2018-11"
+10014	tolerable weak martini	2	good	Last Available: "2018-11"
 10015	stale cherry pie	3	decent	Last Available: "2018-11"
 10016	lousy spirit-forward eggnog	5	decent	Last Available: "2018-11"
 10017	skewed squat glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	decent huge spinning Hell ramen	9	good	Last Available: "2018-11"
+10018	huge decent spinning Hell ramen	9	good	Last Available: "2018-11"
 10019	high-proof mediocre gimlet	10	decent	Last Available: "2018-11"
 10020	hand-crafted tumbling twice-haunted screwdriver	3	EPIC	Last Available: "2018-11"
-10021	bland jumbo candy cane	5	decent	Last Available: "2018-12"
-10022	bad irresponsibly strong runny fermented egg	8	decent	Last Available: "2018-12"
+10021	jumbo bland candy cane	5	decent	Last Available: "2018-12"
+10022	irresponsibly strong bad runny fermented egg	8	decent	Last Available: "2018-12"
 10023	rotten big oldcake	5	crappy	Last Available: "2018-12"
 10024	adequate huge traditional Crimbo cookie	4	good	Last Available: "2023-06"
 10025	up-at-dawn plastic wild beaver	0		Adventures: +5, Last Available: "2018-12"
@@ -9899,7 +9899,7 @@
 10033	Rosewater's thinker's pristine walrus tusk	0		Mysticality: +10, Mysticality Percent: +30, Last Available: "2018-12"
 10034	mirror thick walrus blubber	0		Last Available: "2018-12"
 10035	spinning censurious careful sinister sage Staff of Frozen Lard	0		Mysticality Percent: +10, Spell Damage: +10, Monster Level: -10, Sleaze Resistance: +3, Last Available: "2018-12"
-10036	red twirling bomb	0		Last Available: "2018-12"
+10036	twirling red bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	rotten gigantic lime green grilled mooseflank	6	crappy	Last Available: "2018-12"
@@ -9907,8 +9907,8 @@
 10041	purple balanced antler of extreme caution	0		Monster Level: -25, Last Available: "2018-12"
 10042	mirror manspreader's dam	0		Monster Level: +10, Damage Reduction: 9, Last Available: "2018-12"
 10043	tolerable squat squat beavermouth	4	good	Last Available: "2018-12"
-10044	fancy artisanal high-proof ghostly beaver punch (papaya)	8	EPIC	Effect: "Radiant Personality", Effect Duration: 5, Last Available: "2018-12"
-10045	practically non-alcoholic acceptable beaver punch (peach)	1	good	Last Available: "2018-12"
+10044	high-proof artisanal fancy ghostly beaver punch (papaya)	8	EPIC	Effect: "Radiant Personality", Effect Duration: 5, Last Available: "2018-12"
+10045	acceptable practically non-alcoholic beaver punch (peach)	1	good	Last Available: "2018-12"
 10046	artisanal beaver punch (cherry)	3	EPIC	Last Available: "2018-12"
 10047	upside-down family-friendly energetic Canadian lantern	0		Maximum MP Percent: +20, Sleaze Resistance: +1, Last Available: "2018-12"
 10048	padded muskox-skin cap	0		Damage Absorption: +20, Last Available: "2018-12"
@@ -9931,12 +9931,12 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	smooth green beer	3	awesome	Last Available: "2018-12"
 10067	spoiled yule gruel	4	crappy	Last Available: "2018-12"
-10068	tolerable watered-down fancy hot watered rum	2	good	Effect: "Egg-headedness", Effect Duration: 20, Last Available: "2018-12"
+10068	fancy tolerable watered-down hot watered rum	2	good	Effect: "Egg-headedness", Effect Duration: 20, Last Available: "2018-12"
 10069	mediocre green bottle of Crimbognac	4	decent	Last Available: "2018-12"
-10070	flavorless diet twirling twirling Crimboysters Rockefeller	1	decent	Last Available: "2018-12"
-10071	vaporized blinking huge Crimbeau de toilette	1		Last Available: "2018-12"
+10070	diet flavorless twirling twirling Crimboysters Rockefeller	1	decent	Last Available: "2018-12"
+10071	vaporized huge blinking Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
-10073	upside-down tumbling Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
+10073	tumbling upside-down Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	narrow Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
@@ -9975,7 +9975,7 @@
 10109	brainy terra cotta train of the wise owl	0		Mysticality: 25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10110	family-friendly clever terra cotta tie tack	0		Maximum MP: +20, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10111	upside-down wobbly hardened savvy terra cotta tambourine	0		Mysticality Percent: +20, Damage Reduction: 3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10112	denatured blinking lime green ghostly terra cotta tidbits	1		Last Available: "2020-12"
+10112	denatured lime green blinking ghostly terra cotta tidbits	1		Last Available: "2020-12"
 10113	concentrated nitrogenated blinking terra panna cotta	0		Effect: "Wise Spirit", Effect Duration: 21
 10114	boxer's velour voulge of the brazier	0		Muscle Percent: +10, Hot Spell Damage: +25, Last Available: "2021-12"
 10115	maroon careful wholesome velour vambraces	0		Maximum HP Percent: +10, Monster Level: -10, Single Equip, Last Available: "2021-12"
@@ -10019,31 +10019,31 @@
 10153	yellow really nice net	0		Last Available: "2019-12"
 10154	elf army poncho of Tarzan	0		Experience (Muscle): +3, Lasts Until Rollover, Last Available: "2019-12"
 10155	bland blinking elf army field rations	3	decent	Last Available: "2019-12"
-10156	blue spinning gingernade	0		Last Available: "2019-12"
+10156	spinning blue gingernade	0		Last Available: "2019-12"
 10157	prompt discarded bowtie of the sewer	0		Stench Damage: +25, Adventures: +3, Lasts Until Rollover, Last Available: "2019-12"
 10158	perfectly mixed fancy martiny	4	EPIC	Effect: "The Solution", Effect Duration: 5, Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	polarized licorice snake	0		Effect: "Salad Days", Effect Duration: 66
-10161	Vulcanized double-improved huge ghostly virgin jello shot	0		Effect: "Ghostly Shell", Effect Duration: 62
+10161	Vulcanized double-improved ghostly huge virgin jello shot	0		Effect: "Ghostly Shell", Effect Duration: 62
 10162	non-ionized blinking mutated candy lump	0		Effect: "Lobos Fresh", Effect Duration: 39
 10163	polarized government-issued candy	0		Effect: "Mana Tea", Effect Duration: 11
-10164	unsweetened gray narrow Pneumo bar	0		Effect: "Rampage!", Effect Duration: 13
+10164	unsweetened narrow gray Pneumo bar	0		Effect: "Rampage!", Effect Duration: 13
 10165	wobbly mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	teal ribald stanky Lil' Doctor&trade; bag	0		Stench Spell Damage: +25, Sleaze Damage: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	skewed ghostly blood bag	0		
-10169	big flavorless narrow bloodstick	5	decent	
+10169	flavorless big narrow bloodstick	5	decent	
 10170	practically non-alcoholic bad tumbling bottle of Sanguiovese	1	decent	
-10171	tasty snack-sized special spinning actual blood sausage	2	awesome	Effect: "Hood Ridin'", Effect Duration: 10
+10171	special tasty snack-sized spinning actual blood sausage	2	awesome	Effect: "Hood Ridin'", Effect Duration: 10
 10172	drinkable upside-down mulled blood	3	good	
 10173	huge spoiled blood snowcone	7	crappy	
 10174	mediocre Red Russian	3	decent	
 10175	spoiled blood roll-up	3	crappy	
-10176	watered-down lousy bottle of blood	2	decent	
+10176	lousy watered-down bottle of blood	2	decent	
 10177	decent huge blood-soaked sponge cake	4	good	
 10178	artisanal weak vampagne	2	super ultra mega turbo EPIC	
 10179	fancy flavorless plain snowcone	4	decent	Effect: "Kernel Panic!", Effect Duration: 15
 10180	skewed upside-down Booke of Vampyric Knowledge	0		
-10181	yellow pulsating money bag	0		
+10181	pulsating yellow money bag	0		
 10182	money bag	0		
 10183	bouncing money bag	0		
 10184	Thwaitgold mosquito statuette	0		
@@ -10074,8 +10074,8 @@
 10209	teal windicle	0		Last Available: "2019-04"
 10210	huge hardy pirate radio ring of dire peril	0		Weapon Damage: +20, Maximum HP: +50, Single Equip, Last Available: "2019-04"
 10211	gray Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	special rotten red pineapple slab	3	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 15, Last Available: "2019-04"
-10213	snack-sized flavorless hibiscus petal	2	decent	Last Available: "2019-04"
+10212	rotten special red pineapple slab	3	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 15, Last Available: "2019-04"
+10213	flavorless snack-sized hibiscus petal	2	decent	Last Available: "2019-04"
 10214	aerosolized jittery huge mint leaf	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 49, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	modified ice molecule	1		Last Available: "2019-04"
@@ -10094,11 +10094,11 @@
 10229	twirling ring	0		Single Equip, Last Available: "2019-04"
 10230	tumbling rosy-cheeked arcane researcher's piratical blunderbuss	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +30, Last Available: "2019-04"
 10231	PirateRealm party hat of James Dean of chilblains of terror	0		Experience (Moxie): +3, Cold Damage: +25, Spooky Spell Damage: +10, Last Available: "2019-04"
-10232	weak artisanal Island Landslide	2	super EPIC	Last Available: "2019-04"
+10232	artisanal weak Island Landslide	2	super EPIC	Last Available: "2019-04"
 10233	aged Island Thunderstorm	4	awesome	Last Available: "2019-04"
 10234	aged Island Hurricane	4	awesome	Last Available: "2019-04"
 10235	drinkable fortified Skull Punch	5	good	Last Available: "2019-04"
-10236	lousy practically non-alcoholic Electric Punch	1	decent	Last Available: "2019-04"
+10236	practically non-alcoholic lousy Electric Punch	1	decent	Last Available: "2019-04"
 10237	perfectly mixed purple Smuggler's Punch	3	super EPIC	Last Available: "2019-04"
 10238	tolerable Scorpion Bowl	3	good	Last Available: "2019-04"
 10239	watered-down hand-crafted shaking bouncing Turtle Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
@@ -10167,7 +10167,7 @@
 10302	blurry sizzling hardy steel-toed occult whittled walking stick	0		Spell Damage Percent: +25, Damage Reduction: 9, Maximum HP: +50, Hot Damage: +10, Last Available: "2019-08"
 10303	spoiled ghostly campfire hot dog	3	crappy	Last Available: "2019-08"
 10304	moldy campfire baked potato	3	crappy	Last Available: "2019-08"
-10305	tasty skewed squat campfire s'more	3	awesome	Last Available: "2019-08"
+10305	tasty squat skewed campfire s'more	3	awesome	Last Available: "2019-08"
 10306	moldy campfire beans	4	crappy	Last Available: "2019-08"
 10307	bland campfire stew	4	decent	Last Available: "2019-08"
 10308	ghostly campfire coffee	1	decent	Last Available: "2019-08"
@@ -10188,7 +10188,7 @@
 10323	wobbly packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	squat twirling Law of Averages	0		
-10332	squat tumbling Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
+10332	tumbling squat Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	teal spinning greasy educational Eight Days a Week Pill Keeper of terror	0		Experience: +1, Spooky Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2019-10"
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
@@ -10202,14 +10202,14 @@
 10343	wobbly shaking plastic dolphin &quot;orphan&quot; of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2019-12"
 10344	plastic Dolph Bossin of the storm	0		Maximum MP Percent: +40, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	normal immense teal skewed mana-coated yams	10	good	Last Available: "2019-11"
+10346	immense normal skewed teal mana-coated yams	10	good	Last Available: "2019-11"
 10347	rotten diet olive mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
-10348	normal diet special mana-fortified cranberry sauce	1	good	Effect: "Fungal Fortification", Effect Duration: 35, Last Available: "2019-11"
-10349	snack-sized normal bouncing mana-stuffed herbal stuffing	2	good	Last Available: "2019-11"
+10348	diet special normal mana-fortified cranberry sauce	1	good	Effect: "Fungal Fortification", Effect Duration: 35, Last Available: "2019-11"
+10349	normal snack-sized bouncing mana-stuffed herbal stuffing	2	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	polymerized frozen Vulcanized wobbly patch of extra-warm fur	0		Effect: "Whole Latte Love", Effect Duration: 21, Last Available: "2019-12"
 10352	compressed jittery industrial lubricant	1		Last Available: "2019-12"
-10353	double-altered gray shaking unfinished pleasure	0		Effect: "Boon of She-Who-Was", Effect Duration: 41, Last Available: "2019-12"
+10353	double-altered shaking gray unfinished pleasure	0		Effect: "Boon of She-Who-Was", Effect Duration: 41, Last Available: "2019-12"
 10354	distilled vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	compressed tumbling a bug's lymph	1		Last Available: "2019-12"
 10356	flattened polymerized shaking organic potpourri	0		Effect: "Arcane in the Brain", Effect Duration: 20, Last Available: "2019-12"
@@ -10217,8 +10217,8 @@
 10358	anodized ghostly blinking infernal snowball	0		Effect: "Faboooo", Effect Duration: 13, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	dehydrated fish sauce	1		Effect: "Broken Bone Nubs", Effect Duration: 30, Last Available: "2019-12"
-10361	massive stale guffin	7	decent	Last Available: "2019-12"
-10362	pickled bouncing skewed Shantix&trade;	1		Last Available: "2019-12"
+10361	stale massive guffin	7	decent	Last Available: "2019-12"
+10362	pickled skewed bouncing Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	dried fuchsia non-Euclidean angle	1		Last Available: "2019-12"
 10365	Vulcanized dry wet peppermint syrup	0		Effect: "Simulation Stimulation", Effect Duration: 50, Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	brainy strapping nutcracker cape	0		Muscle: +5, Mysticality: +5, Last Available: "2019-12"
 10413	family-friendly healthy nutcracker epaulets	0		Maximum HP Percent: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	half-sized decent mirror salt plum	2	good	Last Available: "2019-12"
+10415	decent half-sized mirror salt plum	2	good	Last Available: "2019-12"
 10416	skewed peppermint eel sauce	0		Last Available: "2019-12"
 10417	bland and bean	3	decent	Last Available: "2019-12"
 10418	avaricious reassuring kelp-holly gun of the brute	0		Muscle Percent: +30, Spooky Resistance: +1, Meat Drop: +30, Last Available: "2019-12"
@@ -10302,11 +10302,11 @@
 10445	rotten jittery drippy nugget	3	drippy	
 10446	hand-crafted shaking glass of drippy wine	4	drippy	
 10447	toothsome tiny drippy caviar	1	drippy	
-10448	low-calorie spoiled tumbling drippy plum(?)	1	drippy	
+10448	spoiled low-calorie tumbling drippy plum(?)	1	drippy	
 10449	double-paned drippy stake	0		Cold Resistance: +5, Single Equip
 10450	huge The Eye of the Thing in the Basement	0		
 10451	skewed drippy khakis	0		
-10452	ghostly huge drippy shield	0		
+10452	huge ghostly drippy shield	0		
 10453	gray The Fingernail of the Thing in the Basement	0		
 10454	cyan coin	0		
 10455	shaking mushroom	0		
@@ -10395,7 +10395,7 @@
 10539	Guzzlr souvenir stein of the scaredy-cat	0		Monster Level: -15, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	extra-dry bad Ghiaccio Colada	5	decent	Last Available: "2020-05"
-10542	drinkable strong Sourfinger	5	good	Last Available: "2020-05"
+10542	strong drinkable Sourfinger	5	good	Last Available: "2020-05"
 10543	lousy Nog-on-the-Cob	3	decent	Last Available: "2020-05"
 10544	delicious spirit-forward Steamboat	5	awesome	Last Available: "2020-05"
 10545	smooth twirling Buttery Boy	4	awesome	Last Available: "2020-05"
@@ -10480,7 +10480,7 @@
 10624	bouncing onyx queen	0		Last Available: "2020-09"
 10625	twirling onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
-10627	shaking skewed onyx knight	0		Last Available: "2020-09"
+10627	skewed shaking onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
 10630	bouncing alabaster queen	0		Last Available: "2020-09"
@@ -10508,7 +10508,7 @@
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	colloidal double-boiled super-colloidal fortifying hot cocoa	0		Effect: "Flamingly Floral", Effect Duration: 43, Last Available: "2020-12"
 10654	altered boiling hot cocoa	0		Effect: "Mushroom Melody", Effect Duration: 55, Last Available: "2020-12"
-10655	diffused blinking squat cool hot cocoa	0		Effect: "Turkey-Ambitious", Effect Duration: 26, Last Available: "2020-12"
+10655	diffused squat blinking cool hot cocoa	0		Effect: "Turkey-Ambitious", Effect Duration: 26, Last Available: "2020-12"
 10656	galvanized polarized shaking overly-fancy hot cocoa	0		Effect: "Dreams and Lights", Effect Duration: 26, Last Available: "2020-12"
 10657	moist electrified teal ghostly hot cocoa au beurre	0		Effect: "Orc Chops", Effect Duration: 40, Last Available: "2020-12"
 10658	galvanized electrified irradiated hot cocoa with rainbow marshmallows	0		Effect: "Provocative Perkiness", Effect Duration: 32, Last Available: "2020-12"
@@ -10562,14 +10562,14 @@
 10706	tumbling The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
-10709	lime green shaking The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10709	shaking lime green The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10710	ghostly The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	stale bite-sized and pepper (stale)	1	decent	Last Available: "2020-12"
-10716	practically non-alcoholic delicious narrow cranberry margarita (brackish)	1	awesome	Last Available: "2020-12"
+10715	bite-sized stale and pepper (stale)	1	decent	Last Available: "2020-12"
+10716	delicious practically non-alcoholic narrow cranberry margarita (brackish)	1	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	ghostly nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
@@ -10606,7 +10606,7 @@
 10750	shaking shaking shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	blue plate	0		Familiar Weight: +5
 10752	frozen short beer	0		Effect: "Hyperoffended", Effect Duration: 34, Last Available: "2021-05"
-10753	pressed alkaline narrow blue short stack of pancakes	0		Effect: "Far Out", Effect Duration: 64, Last Available: "2021-05"
+10753	pressed alkaline blue narrow short stack of pancakes	0		Effect: "Far Out", Effect Duration: 64, Last Available: "2021-05"
 10754	concentrated purple short stick of butter	0		Effect: "Meat the Flintstones", Effect Duration: 60, Last Available: "2021-05"
 10755	colloidal short glass of water	0		Effect: "Triangle, Man", Effect Duration: 13, Last Available: "2021-05"
 10756	warmed liquefied quantum short	0		Effect: "Discomfited", Effect Duration: 67, Last Available: "2021-05"
@@ -10621,16 +10621,16 @@
 10765	rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	squat rocket	0		Last Available: "2021-07"
-10768	adequate huge fire crackers	7	good	Last Available: "2021-07"
+10768	huge adequate fire crackers	7	good	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	wool coward's Catherine Wheel	0		Monster Level: -20, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2021-07"
 10771	huge supercharged healthy rocket boots	0		Maximum HP Percent: +20, Maximum MP Percent: +30, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	wobbly sparkler of the brute of the brazier	0		Muscle Percent: +30, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
 10773	blue Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	Vulcanized red Scent of a Human&trade; candle	0		Effect: "Steroid Boost", Effect Duration: 35, Last Available: "2021-08"
-10775	diffused upside-down bouncing teal The Beast Within&trade; candle	0		Effect: "Red Around the Gills", Effect Duration: 19, Last Available: "2021-08"
+10775	diffused upside-down teal bouncing The Beast Within&trade; candle	0		Effect: "Red Around the Gills", Effect Duration: 19, Last Available: "2021-08"
 10776	flattened diffused Salsa Caliente&trade; candle	0		Effect: "Fancy Feasted", Effect Duration: 44, Last Available: "2021-08"
-10777	ionized unsweetened shaking maroon spinning Smoldering Clover&trade; candle	0		Effect: "Dreams and Lights", Effect Duration: 23, Last Available: "2021-08"
+10777	ionized unsweetened spinning shaking maroon Smoldering Clover&trade; candle	0		Effect: "Dreams and Lights", Effect Duration: 23, Last Available: "2021-08"
 10778	corrupted anodized mirror Napalm In The Morning&trade; candle	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 60, Last Available: "2021-08"
 10779	crafty extra-large utility candle of the blizzard	0		Maximum MP: +10, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
 10780	nasty runed taper candle of horror	0		Stench Damage: +5, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
@@ -10659,8 +10659,8 @@
 10803	ghostly packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	flame-retardant Daylight Shavings Helmet of horror of temperance	0		Spooky Spell Damage: +25, Hot Resistance: +1, Sleaze Resistance: +5, Last Available: "2021-11"
 10805	eggwater	1	decent	Last Available: "2021-12"
-10806	small flavorless twirling upside-down bread man	2	decent	Last Available: "2021-12"
-10807	flavorless tiny huge plain candy cane	1	decent	Last Available: "2021-12"
+10806	flavorless small upside-down twirling bread man	2	decent	Last Available: "2021-12"
+10807	tiny flavorless huge plain candy cane	1	decent	Last Available: "2021-12"
 10808	adequate flour cookie	4	good	Last Available: "2021-12"
 10809	coward's plastic food lab	0		Monster Level: -20, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2021-12"
@@ -10674,15 +10674,15 @@
 10818	double-paned veiny Rosewater's ice wrap	0		Mysticality Percent: +30, Maximum HP: +10, Cold Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	bite-sized moldy tofu pop	1	crappy	Last Available: "2021-12"
 10820	decent bowl of prescription candy	3	good	Last Available: "2021-12"
-10821	flavorless thick pulsating fishcake	5	decent	Last Available: "2021-12"
+10821	thick flavorless pulsating fishcake	5	decent	Last Available: "2021-12"
 10822	decent low-calorie bone broth	1	good	Last Available: "2021-12"
 10823	decent star pop	3	good	Last Available: "2021-12"
 10824	bad lime green Doc's Fortifying Wine	3	decent	Last Available: "2021-12"
-10825	triple-distilled perfectly mixed upside-down ghostly Doc's Smartifying Wine	10	EPIC	Last Available: "2021-12"
+10825	perfectly mixed triple-distilled upside-down ghostly Doc's Smartifying Wine	10	EPIC	Last Available: "2021-12"
 10826	fortified aged Doc's Limbering Wine	5	awesome	Last Available: "2021-12"
 10827	drinkable Doc's Medical-Grade Wine	3	good	Last Available: "2021-12"
 10828	mixed squat Homebodyl&trade;	1		Last Available: "2021-12"
-10829	altered shaking blurry Extrovermectin&trade;	1		Last Available: "2021-12"
+10829	altered blurry shaking Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	compressed blinking Breathitin&trade;	1		Last Available: "2021-12"
 10831	dehydrated Fleshazole&trade;	1		Last Available: "2021-12"
 10832	non-dry alkaline tarnished anti-burn cream	0		Effect: "Reptilian Fortitude", Effect Duration: 12, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	polymerized flattened denatured jittery anti-creep cream	0		Effect: "Video Game Hot Dog", Effect Duration: 14, Last Available: "2021-12"
 10837	pickled ionized anti-pain cream	0		Effect: "Eyes of the Dragon", Effect Duration: 42, Last Available: "2021-12"
 10838	lousy Doc's Special Reserve Wine	4	decent	Last Available: "2021-12"
-10839	adequate half-sized bread pie	2	good	Last Available: "2021-12"
+10839	half-sized adequate bread pie	2	good	Last Available: "2021-12"
 10840	bad clear Russian	4	decent	Last Available: "2021-12"
 10841	pulsating zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
@@ -10712,10 +10712,10 @@
 10856	squat poisonsettia	0		Last Available: "2021-12"
 10857	brainy peppermint-scented socks	0		Mysticality: +5, Last Available: "2021-12"
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10859	blue skewed projectile chemistry set	0		Last Available: "2021-12"
+10859	skewed blue projectile chemistry set	0		Last Available: "2021-12"
 10860	tumbling cool depleted Crimbonium football helmet	0		Moxie: +5, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	normal half-sized purple &quot;caramel&quot;	2	good	Last Available: "2021-12"
+10862	half-sized normal purple &quot;caramel&quot;	2	good	Last Available: "2021-12"
 10863	shaking self-repairing earmuffs of the ox	0		Muscle: +20, Last Available: "2021-12"
 10864	Newton's carnivorous potted plant	0		Experience (Mysticality): +3, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
@@ -10737,7 +10737,7 @@
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	pickled red astral energy drink	1		
-10884	narrow ghostly mint condition magnifying glass	0		Last Available: "2022-12"
+10884	ghostly narrow mint condition magnifying glass	0		Last Available: "2022-12"
 10885	perfumed wool toasty magnifying glass	0		Hot Damage: +5, Cold Resistance: +1, Stench Resistance: +5, Last Available: "2022-12"
 10886	lousy void lager	3	decent	Last Available: "2022-12"
 10887	flavorless void burger	3	decent	Last Available: "2022-12"
@@ -10748,7 +10748,7 @@
 10892	blinking combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	grievous combat lover's locket	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2022-02"
 10894	blinking Thwaitgold protozoa statuette	0		
-10895	green tumbling grey gosling	0		Free Pull, Last Available: "2022-03"
+10895	tumbling green grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	fuchsia grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	gray undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
@@ -10769,14 +10769,14 @@
 10913	special bar of freeze-dried water	1	decent	Effect: "Mad at Science", Effect Duration: 40, Last Available: "2022-05"
 10914	miniature normal expired MRE	2	good	Last Available: "2022-05"
 10915	decent low-calorie cool mint precipice bar	1	good	Last Available: "2022-05"
-10916	snack-sized toothsome carrot cake precipice bar	2	awesome	Last Available: "2022-05"
+10916	toothsome snack-sized carrot cake precipice bar	2	awesome	Last Available: "2022-05"
 10917	twirling The Big Book of Every Skill	0		
 10918	squat Thwaitgold harvestman statuette	0		
 10919	wobbly packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	Tesla quilted wicked June cleaver	0		Spell Damage: +5, Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10, Attacks Can't Miss, Last Available: "2022-06"
 10921	hand-crafted Dad's brandy	3	EPIC	Last Available: "2022-06"
 10922	flame-wreathed teacher's pen of the empath	0		Familiar Weight: +5, Hot Spell Damage: +10, Last Available: "2022-06"
-10923	flavorless immense fire-roasted lake trout	7	decent	Last Available: "2022-06"
+10923	immense flavorless fire-roasted lake trout	7	decent	Last Available: "2022-06"
 10924	jumbo decent huge mirror guilty sprout	5	good	Last Available: "2022-06"
 10925	knitted mother's necklace of chilblains	0		Cold Damage: +25, Cold Resistance: +3, Last Available: "2022-06"
 10926	non-tarnished trampled ticket stub	0		Effect: "Sealed Brain", Effect Duration: 12, Last Available: "2022-06"
@@ -10804,10 +10804,10 @@
 10948	shaking fuchsia Newton's reflective vest	0		Experience (Mysticality): +3
 10949	jittery wicked dinosaur	0		Spell Damage: +5
 10950	huge Thwaitgold mosquito-in-amber statuette	0		
-10951	red ghostly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
+10951	ghostly red packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
 10952	up-at-dawn Jurassic Parka of the blizzard	0		Cold Spell Damage: +25, Adventures: +5, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	ghostly boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
-10954	blinking upside-down autumn-aton	0		Last Available: "2022-10"
+10954	upside-down blinking autumn-aton	0		Last Available: "2022-10"
 10955	chilled lime green autumn leaf	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 19, Last Available: "2022-10"
 10956	acceptable practically non-alcoholic fuchsia mirror AutumnFest ale	1	good	Last Available: "2022-10"
 10957	hale occult autumn sweater-weather sweater of the empath	0		Spell Damage Percent: +25, Maximum HP: +20, Familiar Weight: +5, Lasts Until Rollover, Last Available: "2022-10"
@@ -10822,22 +10822,22 @@
 10966	twirling mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	blurry St. Sneaky Pete's Whey	0		Last Available: "2022-11"
-10969	tumbling wobbly Vegetable of Jarlsberg	0		Last Available: "2022-11"
+10969	wobbly tumbling Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	rotten ratatouille de Jarlsberg	4	crappy	Last Available: "2022-11"
 10971	half-sized bland Jarlsberg's vegetable soup	2	decent	Last Available: "2022-11"
 10972	small normal mirror roasted vegetable of Jarlsberg	2	good	Last Available: "2022-11"
 10973	stale squat St. Pete's sneaky smoothie	4	decent	Last Available: "2022-11"
-10974	moldy diet bouncing yellow Pete's wiley whey bar	1	crappy	Last Available: "2022-11"
-10975	stale small Pete's rich ricotta	2	decent	Last Available: "2022-11"
-10976	mediocre special Boris's beer	3	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 40, Last Available: "2022-11"
-10977	bland twirling jittery honey bun of Boris	3	decent	Last Available: "2022-11"
-10978	adequate wobbly ghostly Boris's bread	3	good	Last Available: "2022-11"
+10974	diet moldy yellow bouncing Pete's wiley whey bar	1	crappy	Last Available: "2022-11"
+10975	small stale Pete's rich ricotta	2	decent	Last Available: "2022-11"
+10976	special mediocre Boris's beer	3	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 40, Last Available: "2022-11"
+10977	bland jittery twirling honey bun of Boris	3	decent	Last Available: "2022-11"
+10978	adequate ghostly wobbly Boris's bread	3	good	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	spinning Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	mirror spinning Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10981	spinning mirror Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
 10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	pulsating huge Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10984	huge pulsating Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
 10985	ghostly Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
 10986	twirling Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	green spinning Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
@@ -10852,8 +10852,8 @@
 10996	gray Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	twirling jittery Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	half-sized rotten Deep Dish of Legend	2	crappy	Last Available: "2022-11"
+10999	jittery twirling Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	rotten half-sized Deep Dish of Legend	2	crappy	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	tumbling drink chit	0		
 11003	government per-diem	0		
@@ -10863,11 +10863,11 @@
 11007	booze bindle	0		
 11008	censurious rare oboe of the storm	0		Maximum MP Percent: +40, Sleaze Resistance: +3
 11009	supercool bullet necklace of the sewer	0		Moxie Percent: +20, Stench Damage: +25, Single Equip
-11010	yummy small huge swamp haunch	2	awesome	
+11010	small yummy huge swamp haunch	2	awesome	
 11011	twirling sizzling Socratic gator shades	0		Experience (Mysticality): +1, Hot Damage: +10, Single Equip
 11012	milk cap	0		
 11013	watered-down smooth Charleston Choo-Choo	2	awesome	
-11014	irresponsibly strong bad skewed Velvet Veil	10	decent	
+11014	bad irresponsibly strong skewed Velvet Veil	10	decent	
 11015	delicious high-proof Marltini	9	awesome	
 11016	perfectly mixed watered-down Strong, Silent Type	2	EPIC	
 11017	tolerable Mysterious Stranger	4	good	
@@ -10879,7 +10879,7 @@
 11023	vibrating Samson's ceramic celsiturometer of vim and vigor	0		Experience (Muscle): +5, Maximum HP Percent: +50, Maximum MP Percent: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
 11024	friendly ceramic cerecloth belt of James Dean of Leguizamo	0		Experience (Moxie): +3, Monster Level: +20, Familiar Weight: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
 11025	executive shellacked personal trainer's ceramic cenobite's robe	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Meat Drop: +40, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
-11026	vaporized gray twirling ceramic scree	1		Last Available: "2023-12"
+11026	vaporized twirling gray ceramic scree	1		Last Available: "2023-12"
 11027	dry extra-hard jawbreaker	0		Effect: "Cock of the Walk", Effect Duration: 54
 11028	pulsating flame-retardant dance instructor's Samson's chiffon chevrons	0		Experience (Muscle): +5, Experience Percent (Moxie): +10, Hot Resistance: +1, Single Equip, Last Available: "2023-12"
 11029	upside-down huge resourceful ruddy chiffon chapeau of the boozehound	0		Maximum HP Percent: +40, Maximum MP: +50, Booze Drop: +100, Last Available: "2023-12"
@@ -10908,7 +10908,7 @@
 11052	enhanced flattened Trainbot plating	0		Effect: "Headstrong", Effect Duration: 66
 11053	vacuum-sealed boiled twirling Trainbot optics	0		Effect: "Powder Power", Effect Duration: 36
 11054	triple-electrified pressed Trainbot servomotors	0		Effect: "Using Protection", Effect Duration: 24
-11055	nitrogenated triple-flattened huge mirror Trainbot linkages	0		Effect: "Dancing Prowess", Effect Duration: 30
+11055	nitrogenated triple-flattened mirror huge Trainbot linkages	0		Effect: "Dancing Prowess", Effect Duration: 30
 11056	ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	greedy Trainbot harness	0		Meat Drop: +20
@@ -10920,10 +10920,10 @@
 11064	asbestos-lined horrifying Samson's shoulder-mounted Trainbot	0		Experience (Muscle): +5, Spooky Damage: +25, Hot Resistance: +5, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	tumbling Crimbo crystal shards	0		
-11067	drinkable practically non-alcoholic dregs of a Crimbo cocktail	1	good	
+11067	practically non-alcoholic drinkable dregs of a Crimbo cocktail	1	good	
 11068	pulsating lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	gigantic spoiled honey-drenched ham slice	10	crappy	
+11070	spoiled gigantic honey-drenched ham slice	10	crappy	
 11071	watered-down delicious mostly-empty bottle of cookie wine	2	awesome	
 11072	diet decent Crimbo food scraps	1	good	
 11073	spinning arm towel	0		Last Available: "2022-12"
@@ -10937,8 +10937,8 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	acceptable watered-down Crimbosmopolitan	2	good	Last Available: "2022-12"
-11085	normal fancy super-sized spinning Crimbo dinner	5	good	Effect: "protect.enq", Effect Duration: 40, Last Available: "2022-12"
+11084	watered-down acceptable Crimbosmopolitan	2	good	Last Available: "2022-12"
+11085	normal super-sized fancy spinning Crimbo dinner	5	good	Effect: "protect.enq", Effect Duration: 40, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10953,9 +10953,9 @@
 11097	bad nice warm beer	4	decent	
 11098	grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
-11100	pulsating mirror packet of rock seeds	0		Last Available: "2023-01"
+11100	mirror pulsating packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	powdered twirling blurry fruity pebble	1		Effect: "Clean-Shaven", Effect Duration: 10, Last Available: "2023-01"
+11102	powdered blurry twirling fruity pebble	1		Effect: "Clean-Shaven", Effect Duration: 10, Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	shaking bouncing milestone	0		Last Available: "2023-01"
 11105	gray bolder boulder	0		Last Available: "2023-01"
@@ -10964,7 +10964,7 @@
 11108	upside-down hard rock	0		Last Available: "2023-01"
 11109	mirror stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	decent enchanted pulsating pixel bread	3	good	Effect: "Hare-o-dynamic", Effect Duration: 5
+11112	enchanted decent pulsating pixel bread	3	good	Effect: "Hare-o-dynamic", Effect Duration: 5
 11113	tolerable pixel whiskey	3	good	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10978,7 +10978,7 @@
 11123	polymerized tarnished out-of-work circus flea	0		Effect: "Salty Mouth", Effect Duration: 52, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	warmed energized fire ant pheromones	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 49, Last Available: "2023-02"
-11126	enhanced chilled pulsating blurry flapper fly	0		Effect: "Red-Shirted Escort", Effect Duration: 35, Last Available: "2023-02"
+11126	enhanced chilled blurry pulsating flapper fly	0		Effect: "Red-Shirted Escort", Effect Duration: 35, Last Available: "2023-02"
 11127	artisanal shot of wasp venom	4	EPIC	Last Available: "2023-02"
 11128	polymerized filled mosquito	0		Effect: "Irresistible Resolve", Effect Duration: 59, Last Available: "2023-02"
 11129	diffused green shim of shame shale	0		Effect: "Omphalotus Omnipresence", Effect Duration: 42, Last Available: "2023-02"
@@ -10990,9 +10990,9 @@
 11135	adequate shadow sausage	4	good	Last Available: "2023-03"
 11136	rock-hard hardened shadow skin	0		Damage Reduction: 16, Last Available: "2023-03"
 11137	frozen Vulcanized shadow flame	0		Effect: "Chilblains of the Corn", Effect Duration: 37, Last Available: "2023-03"
-11138	flavorless massive shadow bread	6	decent	Last Available: "2023-03"
+11138	massive flavorless shadow bread	6	decent	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	strong acceptable shadow fluid	5	good	Last Available: "2023-03"
+11140	acceptable strong shadow fluid	5	good	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	gray shadow brick	0		Last Available: "2023-03"
 11143	yellow shadow sinew	0		Last Available: "2023-03"
@@ -11049,7 +11049,7 @@
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	replica wax lips	0		Experience: +3
-11197	shaking upside-down replica Tome of Snowcone Summoning	0		
+11197	upside-down shaking replica Tome of Snowcone Summoning	0		
 11198	ghostly dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	wholesome steel-toed beefy replica jewel-eyed wizard hat	0		Muscle: +10, Damage Reduction: 9, Maximum HP Percent: +10, Conditional Skill (Equipped): "Magic Missile"
 11200	wool supercool replica bottle-rocket crossbow of Tarzan	0		Moxie Percent: +20, Experience (Muscle): +3, Cold Resistance: +1, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
@@ -11074,7 +11074,7 @@
 11219	twirling replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
-11222	blinking twirling shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
+11222	twirling blinking shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	blue therapeutic stiffened Cincho de Mayo of the sewer of terror	0		Damage Reduction: 1, Stench Damage: +25, Spooky Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
@@ -11090,7 +11090,7 @@
 11235	huge replica space planula	0		
 11236	replica unpowered Robortender	0		
 11237	fuchsia replica Neverending Party invitation envelope	0		
-11238	teal tumbling replica January's Garbage Tote	0		
+11238	tumbling teal replica January's Garbage Tote	0		
 11239	replica God Lobster Egg	0		
 11240	lightning-fast cool replica Fourth of May Cosplay Saber of wisdom	0		Mysticality: +15, Moxie: +5, Initiative: +40, Conditional Skill (Equipped): "Use the Force"
 11241	scorching Annie Oakley's sage replica Kramco Sausage-o-Matic&trade; of doom of the early riser	0		Mysticality Percent: +10, Critical Hit Percent: +20, Hot Damage: +25, Spooky Spell Damage: +50, Adventures: +7
@@ -11127,15 +11127,15 @@
 11272	Lapis Lazuli	0		Last Available: "2023-06"
 11273	narrow Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
-11275	upside-down blurry maroon Arrow (+1)	0		Last Available: "2023-06"
+11275	maroon upside-down blurry Arrow (+1)	0		Last Available: "2023-06"
 11276	non-pickled pulsating scroll of protection from lycanthropes	0		Effect: "Can't Be a Chooser", Effect Duration: 35, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
-11279	gray shaking blinking Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
+11279	gray blinking shaking Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
 11282	lousy high-proof Sexy Cosmo	10	decent	Last Available: "2023-06"
-11283	red bouncing Souvenir Chopsticks	0		Last Available: "2023-06"
+11283	bouncing red Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	blue upside-down double-paned careful Newton's red-soled high heels	0		Experience (Mysticality): +3, Monster Level: -10, Cold Resistance: +5, Last Available: "2023-06"
 11285	yummy gray cyburger	3	awesome	Last Available: "2025-12"
 11286	Fonzie's ncle leg	0		Experience (Moxie): +1
@@ -11239,14 +11239,14 @@
 11384	tiny Crimbuccaneer Foundry	0		Initiative: +3
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
-11387	fuchsia squat pirate encryption key bravo	0		Last Available: "2023-12"
+11387	squat fuchsia pirate encryption key bravo	0		Last Available: "2023-12"
 11388	huge pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
 11390	shaking wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
-11394	squat red crated wardrobe-o-matic	0		
+11394	red squat crated wardrobe-o-matic	0		
 11395	immense stale peppermint donut	7	decent	
 11396	veiny Elf Guard insignia (private)	0		Maximum HP: +10, Last Available: "2023-12"
 11397	stiffened Crimbuccaneer fledges (mint)	0		Damage Reduction: 1, Last Available: "2023-12"
@@ -11258,7 +11258,7 @@
 11403	wobbly Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	banded Crimbuccaneer lantern of Tarzan of the blizzard	0		Experience (Muscle): +3, Damage Absorption: +100, Cold Spell Damage: +25, Last Available: "2023-12"
 11405	Crimbuccaneer flotsam	0		Last Available: "2023-12"
-11406	bouncing pulsating Crimbuccaneer invasion map	0		Last Available: "2023-12"
+11406	pulsating bouncing Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	blinking lightning-fast Crimbuccaneer shirt	0		Initiative: [+40*event(December)], Last Available: "2023-12"
 11408	Elf Guard MPC	0		Last Available: "2023-12"
 11409	skewed Crimbuccaneer piece of 12	0		Last Available: "2023-12"
@@ -11274,12 +11274,12 @@
 11419	sharpshooter's groovy Elf Guard broom	0		Moxie Percent: +10, Critical Hit Percent: +10, Last Available: "2023-12"
 11420	sharpshooter's Crimbuccaneer tavern swab of Calamity Jane of extreme caution	0		Critical Hit Percent: 25, Monster Level: -25, Last Available: "2023-12"
 11421	twirling teal Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	smooth spirit-forward old-school pirate grog	5	awesome	Last Available: "2023-12"
-11423	stale super-sized special grog nuts	5	decent	Effect: "Items Are Forever", Effect Duration: 10, Last Available: "2023-12"
+11422	spirit-forward smooth old-school pirate grog	5	awesome	Last Available: "2023-12"
+11423	super-sized stale special grog nuts	5	decent	Effect: "Items Are Forever", Effect Duration: 10, Last Available: "2023-12"
 11424	sharpshooter's Samson's sawed-off blunderbuss of Leguizamo	0		Experience (Muscle): +5, Critical Hit Percent: +10, Monster Level: +20, Last Available: "2023-12"
 11425	tolerable blurry officer's nog	3	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	gigantic rotten sundae ration	8	crappy	Last Available: "2023-12"
+11427	rotten gigantic sundae ration	8	crappy	Last Available: "2023-12"
 11428	decent peppermint tack	3	good	Last Available: "2023-12"
 11429	huge Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten bite-sized whalesteak	1	crappy	Last Available: "2023-12"
@@ -11303,7 +11303,7 @@
 11448	deadly sage brown pirate pants	0		Mysticality Percent: +10, Weapon Damage: +5, Last Available: "2023-12"
 11449	Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11450	The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
-11451	pulsating spinning punching mirror	0		Last Available: "2023-12"
+11451	spinning pulsating punching mirror	0		Last Available: "2023-12"
 11452	gray bouncing Usain Bolt's lard-coated vibrating hardy rock-hard Elf dessert spoon of incineration	0		Damage Reduction: 5, Maximum HP: +50, Maximum MP Percent: +10, Hot Spell Damage: +50, Sleaze Spell Damage: +25, Initiative: +80, Last Available: "2023-12"
 11453	scandalous Elf Guard SCUBA tank of the businessman	0		Sleaze Damage: +5, Meat Drop: +50, Last Available: "2023-12"
 11454	yellow Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
@@ -11313,31 +11313,31 @@
 11458	Usain Bolt's Crimbuccaneer bombjacket of the cheetah	0		Initiative: 140, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	miniature bland sugarplum ration	2	decent	Last Available: "2023-12"
 11460	rotten gingerbread nylons	3	crappy	Last Available: "2023-12"
-11461	snack-sized normal rum-soaked fruitcake	2	good	Last Available: "2023-12"
+11461	normal snack-sized rum-soaked fruitcake	2	good	Last Available: "2023-12"
 11462	moldy immense lime	8	crappy	Last Available: "2023-12"
 11463	normal gingerbread pirate	4	good	Last Available: "2023-12"
 11464	rotten small fruit-stuffed rumcake	2	crappy	Last Available: "2023-12"
 11465	acceptable olive mulled wine	3	good	Last Available: "2023-12"
 11466	mediocre Swedish coffee	3	decent	Last Available: "2023-12"
-11467	practically non-alcoholic bad canteen of eggnog	1	decent	Last Available: "2023-12"
-11468	artisanal practically non-alcoholic mirror hot wine	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11467	bad practically non-alcoholic canteen of eggnog	1	decent	Last Available: "2023-12"
+11468	practically non-alcoholic artisanal mirror hot wine	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11469	irresponsibly strong tolerable Jamaican coffee	8	good	Last Available: "2023-12"
-11470	perfectly mixed strong flask of egggrog	5	EPIC	Last Available: "2023-12"
+11470	strong perfectly mixed flask of egggrog	5	EPIC	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	practically non-alcoholic artisanal yule grog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11474	artisanal practically non-alcoholic yule grog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11475	enchanted flavorless wet tack	3	decent	Effect: "Buff as a Baobab", Effect Duration: 45, Last Available: "2023-12"
-11476	tasty enchanted miniature olive whalecake	2	awesome	Effect: "Sharp Weapon", Effect Duration: 35, Last Available: "2023-12"
+11476	enchanted tasty miniature olive whalecake	2	awesome	Effect: "Sharp Weapon", Effect Duration: 35, Last Available: "2023-12"
 11477	pulsating vibrating arcane researcher's Socratic gunwale whalegun	0		Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Maximum MP Percent: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	special perfectly mixed and claret	3	super EPIC	Effect: "Unrunnable Face", Effect Duration: 15, Last Available: "2023-12"
-11479	upside-down blurry rigging knot	0		Familiar Weight: +5
+11479	blurry upside-down rigging knot	0		Familiar Weight: +5
 11480	shaking trick coin	0		Last Available: "2023-12"
 11481	mirror nasty sizzling Elf Guard squirtgun	0		Hot Damage: +10, Stench Damage: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	wobbly Da Vinci's sequin-encrusted sweater	0		Experience (Mysticality): +5, Last Available: "2023-12"
 11484	auspicious wool replica Elf Guard medal of the cheetah	0		Cold Resistance: +1, Item Drop: +10, Initiative: +60, Last Available: "2023-12"
-11485	spinning yellow Lil' Snowball Factory	0		Last Available: "2023-12"
+11485	yellow spinning Lil' Snowball Factory	0		Last Available: "2023-12"
 11486	Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
 11487	blinking prank Crimbo card	0		Last Available: "2023-12"
 11488	Oprah's Crimbuccaneer squirtblunderbuss of incineration	0		Maximum MP Percent: +50, Hot Spell Damage: +50, Last Available: "2023-12"
@@ -11399,17 +11399,17 @@
 11544	sharpshooter's Elf Guard war standard of incineration	0		Critical Hit Percent: +10, Hot Spell Damage: +50, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	horrifying chilly spring shoes of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +5, Spooky Damage: +25, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
-11547	galvanized Vulcanized huge narrow ultra-soft ferns	0		Effect: "Object Detection", Effect Duration: 32, Last Available: "2024-02"
+11547	galvanized Vulcanized narrow huge ultra-soft ferns	0		Effect: "Object Detection", Effect Duration: 32, Last Available: "2024-02"
 11548	nitrogenated deionized cold-filtered pulsating crunchy brush	0		Effect: "Always be Collecting", Effect Duration: 50, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	huge triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
-11553	shaking mirror ultra-high-tension exoskeleton	0		
+11553	mirror shaking ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
 11556	mirror quick-release fannypack	0		Single Equip
-11557	red squat quick-release utility belt	0		Single Equip
+11557	squat red quick-release utility belt	0		Single Equip
 11558	wholesome motion sensor	0		Maximum HP Percent: +10, Single Equip
 11559	focused magnetron pistol	0		Single Equip
 11560	packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
@@ -11428,10 +11428,10 @@
 11573	flavorless yam	4	decent	Last Available: "2024-05"
 11574	artisanal narrow yam martini	3	EPIC	Last Available: "2024-05"
 11575	hand-crafted sweet potato o' mine	3	EPIC	Last Available: "2024-05"
-11576	drinkable weak Southern yam	2	good	Last Available: "2024-05"
+11576	weak drinkable Southern yam	2	good	Last Available: "2024-05"
 11577	hand-crafted weak special sweet potato punch	2	EPIC	Effect: "Filled with Magic", Effect Duration: 35, Last Available: "2024-05"
-11578	diet bland ghostly Mayam spinach	1	decent	Last Available: "2024-05"
-11579	low-calorie tasty blurry yam and swiss	1	awesome	Last Available: "2024-05"
+11578	bland diet ghostly Mayam spinach	1	decent	Last Available: "2024-05"
+11579	tasty low-calorie blurry yam and swiss	1	awesome	Last Available: "2024-05"
 11580	clever grievous brawny yam cannon	0		Muscle Percent: +20, Weapon Damage Percent: +50, Maximum MP: +20, Lasts Until Rollover, Last Available: "2024-05"
 11581	shaking yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11448,13 +11448,13 @@
 11593	green Thwaitgold Illinigina illinoiensis model	0		
 11594	flavorless mini kiwi	4	decent	Last Available: "2024-06"
 11595	double-paned scorching stiffened mini kiwi bikini	0		Damage Reduction: 1, Hot Damage: +25, Cold Resistance: +5, Last Available: "2024-06"
-11596	triple-distilled delicious blurry mini kiwitini	7	awesome	Last Available: "2024-06"
+11596	delicious triple-distilled blurry mini kiwitini	7	awesome	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
-11598	maroon squat mini kiwi aioli	0		
+11598	squat maroon mini kiwi aioli	0		
 11599	avaricious knitted coward's mini kiwi silicon tiepin	0		Monster Level: -20, Cold Resistance: +3, Meat Drop: +30
 11600	mini kiwi tipi	0		
 11601	normal mini kiwi digitized cookies	3	good	
-11602	perfectly mixed irresponsibly strong mirror mini kiwi intoxicating spirits	10	EPIC	
+11602	irresponsibly strong perfectly mixed mirror mini kiwi intoxicating spirits	10	EPIC	
 11603	modified wet cyan mini kiwi antimilitaristic hippy petition	0		Effect: "Think Win-Lose", Effect Duration: 13
 11604	alkaline mini kiwi illicit antibiotic	0		Effect: "Human-Plant Hybrid", Effect Duration: 64
 11605	lion tamer's curative mini kiwi whipping stick	0		Experience (familiar): +2, HP Regen Min: 3, HP Regen Max: 5
@@ -11463,16 +11463,16 @@
 11608	packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
-11611	squat ghostly spinning protogenetic chunklet (muscle)	0		
+11611	ghostly squat spinning protogenetic chunklet (muscle)	0		
 11612	teal protogenetic chunklet (flagellum)	0		
 11613	protogenetic chunklet (elbow)	0		
 11614	jittery protogenetic chunklet (lips)	0		
 11615	teal scorching deadly messenger bag RNA of temperance	0		Weapon Damage: +5, Hot Damage: +25, Sleaze Resistance: +5
-11616	mirror ghostly flagellate flagon	0		
-11617	ghostly jittery jittery proto-proto-protozoa	0		
-11618	big flavorless bacteria bisque	5	decent	
+11616	ghostly mirror flagellate flagon	0		
+11617	jittery jittery ghostly proto-proto-protozoa	0		
+11618	flavorless big bacteria bisque	5	decent	
 11619	huge decent ciliophora chowder	8	good	
-11620	tasty fancy cream of chloroplasts	3	awesome	Effect: "Conspiratory Eyes", Effect Duration: 30
+11620	fancy tasty cream of chloroplasts	3	awesome	Effect: "Conspiratory Eyes", Effect Duration: 30
 11621	synaptic soup	0		
 11622	blurry muscular soup	0		
 11623	olive flagellate soup	0		
@@ -11488,7 +11488,7 @@
 11633	blurry Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
 11635	hand-crafted mirror Colera Peste Nebbiolo	3	EPIC	
-11636	spinning cyan squat longbox of Batfellow comics	0		
+11636	cyan squat spinning longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	tumbling Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
@@ -11526,17 +11526,17 @@
 11671	resourceful dance instructor's photo booth supply list	0		Experience Percent (Moxie): +10, Maximum MP: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	tumbling peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	huge fuchsia tie-dye headband	0		
-11674	rotten ghostly bouncing whirled peas	3	crappy	Last Available: "2024-11"
+11674	rotten bouncing ghostly whirled peas	3	crappy	Last Available: "2024-11"
 11675	enchanted normal peaza	3	good	Effect: "Knightlife", Effect Duration: 30, Last Available: "2024-11"
 11676	olive peace shooter	0		Last Available: "2024-11"
 11677	modified bouncing drenchrome 2.0	1		Effect: "Night of the Nachos", Effect Duration: 35, Last Available: "2025-12"
-11678	compressed yellow upside-down Synapse Blaster	1		Last Available: "2025-12"
+11678	compressed upside-down yellow Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
-11682	altered wobbly squat squat pea brittle	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 38, Last Available: "2024-11"
+11682	altered squat squat wobbly pea brittle	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 38, Last Available: "2024-11"
 11683	watered-down hand-crafted peasco	2	EPIC	Last Available: "2024-11"
-11684	bite-sized yummy piece of cake	1	awesome	Last Available: "2024-11"
+11684	yummy bite-sized piece of cake	1	awesome	Last Available: "2024-11"
 11685	squat handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11555,7 +11555,7 @@
 11700	chili powder cutlass of courage	0		Spooky Resistance: +3, Last Available: "2024-12"
 11701	spoiled Aztec tamale	3	crappy	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
-11703	bouncing maroon pet rock	0		Last Available: "2024-12"
+11703	maroon bouncing pet rock	0		Last Available: "2024-12"
 11704	blinking steel-toed groggles	0		Damage Reduction: 9, Last Available: "2024-12"
 11705	tumbling pirate dinghy	0		Last Available: "2024-12"
 11706	jittery anchor bomb	0		Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	corrupted peppermint pegleg	0		Effect: "Updated", Effect Duration: 25, Last Available: "2024-12"
 11710	tolerable hard cocoa	3	good	Last Available: "2024-12"
-11711	thick normal salmagumdi	5	good	Last Available: "2024-12"
+11711	normal thick salmagumdi	5	good	Last Available: "2024-12"
 11712	educational plastic Easter Island Bunny	0		Experience: +1, Last Available: "2024-12"
 11713	blinking clever plastic St. Patrick	0		Maximum MP: +20, Last Available: "2024-12"
 11714	knitted Jim Carey's plastic Colonel Brando	0		Monster Level: +25, Cold Resistance: +3, Last Available: "2024-12"
@@ -11571,11 +11571,11 @@
 11716	supercool plastic &quot;Santa Claus&quot;	0		Moxie Percent: +20, Last Available: "2024-12"
 11717	Spirit of Easter	0		Last Available: "2024-12"
 11718	ghostly Spirit of St. Patrick's Day	0		Last Available: "2024-12"
-11719	mirror yellow Spirit of Veteran's Day	0		Last Available: "2024-12"
+11719	yellow mirror Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	bland coney haunch	3	decent	Last Available: "2024-12"
-11723	colloidal triple-nitrogenated twirling shaking dark chocolate egg	0		Effect: "Triangle, Man", Effect Duration: 47, Last Available: "2024-12"
+11723	colloidal triple-nitrogenated shaking twirling dark chocolate egg	0		Effect: "Triangle, Man", Effect Duration: 47, Last Available: "2024-12"
 11724	tolerable high-proof moai toai	8	good	
 11725	flame-retardant forbidden moaiball of Tarzan	0		Experience (Muscle): +3, Spell Damage Percent: +50, Hot Resistance: +1, Last Available: "2024-12"
 11726	gray half-digested rat	0		Last Available: "2024-12"
@@ -11603,14 +11603,14 @@
 11748	weak lousy Irish eggnog	2	decent	Last Available: "2024-12"
 11749	special bad canteen of jungle juice	4	decent	Effect: "Uncucumbered", Effect Duration: 30, Last Available: "2024-12"
 11750	hand-crafted weak mirror cyan turchucken	2	EPIC	Last Available: "2024-12"
-11751	strong special bad mechanically-mulled cider	5	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 50, Last Available: "2024-12"
-11752	practically non-alcoholic artisanal holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
-11753	spoiled enchanted big chocolate ostrich egg	5	crappy	Effect: "Go-Gone", Effect Duration: 30, Last Available: "2024-12"
-11754	toothsome massive skewed beef and cabbage	8	awesome	Last Available: "2024-12"
+11751	special bad strong mechanically-mulled cider	5	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 50, Last Available: "2024-12"
+11752	artisanal practically non-alcoholic holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11753	big spoiled enchanted chocolate ostrich egg	5	crappy	Effect: "Go-Gone", Effect Duration: 30, Last Available: "2024-12"
+11754	massive toothsome skewed beef and cabbage	8	awesome	Last Available: "2024-12"
 11755	miniature toothsome candy rations	2	awesome	Last Available: "2024-12"
 11756	flavorless narrow blurry double-candied yams	3	decent	Last Available: "2024-12"
-11757	toothsome enchanted jumbo blue Christmas ham	5	awesome	Effect: "Is This Your Card?", Effect Duration: 50, Last Available: "2024-12"
-11758	stale low-calorie holiday smorgasbord	1	decent	Last Available: "2024-12"
+11757	toothsome jumbo enchanted blue Christmas ham	5	awesome	Effect: "Is This Your Card?", Effect Duration: 50, Last Available: "2024-12"
+11758	low-calorie stale holiday smorgasbord	1	decent	Last Available: "2024-12"
 11759	ghostly Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bejazzled eyepatch of the early riser	0		Adventures: +7, Last Available: "2024-12"
 11761	spinning Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11628,7 +11628,7 @@
 11773	avaricious family-friendly rock-hard smartaleck's army helmet	0		Moxie Percent: +30, Damage Reduction: 5, Sleaze Resistance: +1, Meat Drop: +30, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
-11776	normal jumbo squat Thanksgiving ration	5	good	Last Available: "2024-12"
+11776	jumbo normal squat Thanksgiving ration	5	good	Last Available: "2024-12"
 11777	perfectly mixed Easter eggnog	3	super ultra EPIC	Last Available: "2024-12"
 11778	diluted upside-down clovermint	1		Last Available: "2024-12"
 11779	foul-smelling banded slick nylon Christmas stockings of the ox	0		Muscle: +20, Moxie: +10, Damage Absorption: +100, Stench Damage: +10, Single Equip, Last Available: "2024-12"
@@ -11698,7 +11698,7 @@
 11843	Observer source code	0		
 11844	blinking chill gherkin	0		
 11845	childrens' stapler	0		
-11846	pulsating olive bouncing plover's egg	0		
+11846	olive pulsating bouncing plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	yellow spinning heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11719,13 +11719,13 @@
 11864	hand-crafted pint of Leprechaun Stout	3	EPIC	Last Available: "2025-03"
 11865	compressed yellow skewed squat phosphor traces	1		Last Available: "2025-03"
 11866	tumbling crafting plans	0		Last Available: "2025-03"
-11867	green squat Book of Irony	0		Skill: "Generate Irony"
+11867	squat green Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	unironic knife	0		
 11870	olive bar dart	0		Last Available: "2025-03"
-11871	pickled huge tumbling pulsating leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	normal low-calorie wobbly Heck ramen	1	good	Last Available: "2025-03"
-11873	normal snack-sized burrito	2	good	Last Available: "2025-03"
+11871	pickled tumbling pulsating huge leprechaun antidepressant pill	1		Last Available: "2025-03"
+11872	low-calorie normal wobbly Heck ramen	1	good	Last Available: "2025-03"
+11873	snack-sized normal burrito	2	good	Last Available: "2025-03"
 11874	adequate mirror small beer brat	3	good	Last Available: "2025-03"
 11875	diet moldy peach pie	1	crappy	Last Available: "2025-03"
 11876	rotten incredible mini-pizza	3	crappy	Last Available: "2025-03"
@@ -11733,7 +11733,7 @@
 11878	hand-crafted spirit-forward tangarita sidecar	5	EPIC	Last Available: "2025-03"
 11879	lousy blurry gimlet sidecar	4	decent	Last Available: "2025-03"
 11880	bad wobbly vodka stratocaster sidecar	4	decent	Last Available: "2025-03"
-11881	artisanal strong prussian cathouse sidecar	5	EPIC	Last Available: "2025-03"
+11881	strong artisanal prussian cathouse sidecar	5	EPIC	Last Available: "2025-03"
 11882	boozy acceptable yellow Mon Tiki sidecar	5	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	ghostly therapeutic Samson's April Shower Thoughts shield	0		Experience (Muscle): +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 6, Last Available: "2025-04"
@@ -11741,7 +11741,7 @@
 11886	spitball	0		Last Available: "2025-04"
 11887	ionized anodized corrupted wet paper weights	0		Effect: "Wet Rub", Effect Duration: 11, Last Available: "2025-04"
 11888	acceptable Three Sheets to the Wind	4	good	Last Available: "2025-04"
-11889	miniature tasty green pile of wet dates	2	awesome	Last Available: "2025-04"
+11889	tasty miniature green pile of wet dates	2	awesome	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	tumbling wet blanket	0		Last Available: "2025-04"
 11892	jittery vibrating wet shower cap	0		Maximum MP Percent: +10, Last Available: "2025-04"
@@ -11804,10 +11804,10 @@
 11949	yellow wholesome bully badge	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2025-08"
 11950	time cop top hat of the sewer	0		Stench Damage: +25, Last Available: "2025-08"
 11951	blue shaking Stock Certificate	0		Last Available: "2025-08"
-11952	compressed tumbling shaking mixed berry jelly	1		Last Available: "2025-08"
-11953	decent half-sized toast with mixed berry jelly	2	good	Last Available: "2025-08"
+11952	compressed shaking tumbling mixed berry jelly	1		Last Available: "2025-08"
+11953	half-sized decent toast with mixed berry jelly	2	good	Last Available: "2025-08"
 11954	normal cup of sugar	3	good	Last Available: "2025-08"
-11955	special flavorless squat Susie's cupcake	4	decent	Effect: "Concentrated Concentration", Effect Duration: 10, Last Available: "2025-08"
+11955	flavorless special squat Susie's cupcake	4	decent	Effect: "Concentrated Concentration", Effect Duration: 10, Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	coward's the gun of James Dean of the cheetah	0		Experience (Moxie): +3, Monster Level: -20, Initiative: +60, Last Available: "2025-08"
 11958	perfectly mixed wine	4	EPIC	Last Available: "2025-08"
@@ -11840,14 +11840,14 @@
 12050	small peppermint-flavored sugar walking crook	0		
 12051	shaking knucklebone	0		
 12052	enchanted lousy maroon Smoking Pope	3	decent	Effect: "Carrion' On", Effect Duration: 20
-12053	diet flavorless wobbly prize turkey	1	decent	
+12053	flavorless diet wobbly prize turkey	1	decent	
 12054	modified medicinal gruel	1		Effect: "Granolarrrgh", Effect Duration: 10
 12055	flavorless special ghostly full-sized pumpkin pie	4	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 15, Last Available: "2025-11"
 12056	bad vodka cranberry sauce	3	decent	Last Available: "2025-11"
 12057	chilled energized yammed candy	0		Effect: "Jawin'", Effect Duration: 23, Last Available: "2025-11"
 12058	bland treasure chestnut	3	decent	Last Available: "2025-12"
-12059	weak artisanal mulled butter rum	2	EPIC	Last Available: "2025-12"
-12060	ionized huge tumbling cinnamon doubloon	0		Effect: "Cool, Catlike", Effect Duration: 23, Last Available: "2025-12"
+12059	artisanal weak mulled butter rum	2	EPIC	Last Available: "2025-12"
+12060	ionized tumbling huge cinnamon doubloon	0		Effect: "Cool, Catlike", Effect Duration: 23, Last Available: "2025-12"
 12061	jittery Van der Graaf plastic left skeleton arm	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-12"
 12062	spinning padded plastic left skeleton leg	0		Damage Absorption: +20, Last Available: "2025-12"
 12063	shellacked plastic right skeleton arm	0		Damage Reduction: 7, Last Available: "2025-12"
@@ -11870,7 +11870,7 @@
 12080	jittery mansplainer's devilbone flute of mayonnaise	0		Monster Level: +15, Sleaze Spell Damage: +50, Last Available: "2026-12"
 12081	cyan mansplainer's devilbone rosary	0		Monster Level: +15, Single Equip, Last Available: "2026-12"
 12082	boiled devilbone chunks	1		Last Available: "2026-12"
-12083	polymerized concentrated tarnished squat green Gehenna tattoo	0		Effect: "Disco Neuropathy", Effect Duration: 59
+12083	polymerized concentrated tarnished green squat Gehenna tattoo	0		Effect: "Disco Neuropathy", Effect Duration: 59
 12116	blinking burnt incisor	0		Last Available: "2025-12"
 12117	bouncing burnt phalange	0		Last Available: "2025-12"
 12118	burnt radius	0		Last Available: "2025-12"
@@ -11890,14 +11890,14 @@
 12132	Temple Grandin's smoldering vertebra of vim and vigor of Gandalf	0		Maximum HP Percent: +50, Spell Critical Percent: +20, Familiar Weight: +7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
-12135	mirror purple smoldering bone dust	0		Last Available: "2025-12"
+12135	purple mirror smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	wobbly supercool hot boning knife of dire peril of the early riser	0		Moxie Percent: +20, Weapon Damage: +20, Adventures: +7, Single Equip, Last Available: "2025-12"
 12138	blurry lion tamer's Oprah's fistbone of the sewer	0		Maximum MP Percent: +50, Experience (familiar): +2, Stench Damage: +25, Last Available: "2025-12"
 12139	tumbling wicked thinker's burnt bone belt of Gandalf	0		Mysticality: +10, Spell Damage: +5, Spell Critical Percent: +20, Single Equip, Last Available: "2025-12"
 12140	cyan hale scorched skull trophy	0		Maximum HP: +20, Last Available: "2025-12"
-12141	enchanted bland massive bouncing wing bone	8	decent	Effect: "Rainbow Bright", Effect Duration: 35, Last Available: "2025-12"
-12142	mediocre strong weak skeleton venom	5	decent	Last Available: "2025-12"
+12141	bland enchanted massive bouncing wing bone	8	decent	Effect: "Rainbow Bright", Effect Duration: 35, Last Available: "2025-12"
+12142	strong mediocre weak skeleton venom	5	decent	Last Available: "2025-12"
 12143	diluted mirror baked bone meal	1		Last Available: "2025-12"
 12144	ghostly maroon dance instructor's plastic skeleton rib cage	0		Experience Percent (Moxie): +10, Last Available: "2025-12"
 12145	plastic skeleton skull of the cougar	0		Moxie: +20, Last Available: "2025-12"
@@ -11926,13 +11926,13 @@
 12168	mirror reassuring hardened vermiculite shield	0		Damage Reduction: 12, Spooky Resistance: +1, Last Available: "2025-12"
 12169	sizzling ship's lantern	0		Hot Damage: +10, Last Available: "2025-12"
 12170	olive nippy Da Vinci's heat-resistant harpoon pistol	0		Experience (Mysticality): +5, Cold Damage: +10, Last Available: "2025-12"
-12171	huge flavorless blinking skewed traditional gingerloaf	10	decent	Last Available: "2025-12"
+12171	huge flavorless skewed blinking traditional gingerloaf	10	decent	Last Available: "2025-12"
 12172	triple-distilled acceptable Scotch and eggnog	8	good	Last Available: "2025-12"
 12173	aerosolized quantum counterskeleton elixir	0		Effect: "Dances with Tweedles", Effect Duration: 42, Last Available: "2025-12"
 12174	drinkable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	blurry crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	decent miniature spinning wedge of prize-winning cheese	2	good	Last Available: "2025-12"
+12177	miniature decent spinning wedge of prize-winning cheese	2	good	Last Available: "2025-12"
 12178	deionized gummi fingerbone	0		Effect: "Leash of Linguini", Effect Duration: 15
 12179	MacGyver's wicked glimmering crystal	0		Spell Damage: +5, Maximum MP: +100, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11942,7 +11942,7 @@
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	pulsating boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	huge dinosaur bone fragment	0		Last Available: "2026-03"
-12187	narrow gray squat Pork Elf pottery shard	0		Last Available: "2026-03"
+12187	narrow squat gray Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	2015 landfill detritus	0		Last Available: "2026-03"
 12189	shaking intact dinosaur egg	0		Last Available: "2026-03"
 12190	skewed fossilized cow femur	0		Familiar Weight: +5
@@ -11954,17 +11954,17 @@
 12196	shaking bolt of fabric	0		Last Available: "2026-03"
 12197	foul-smelling and dress of terror	0		Stench Damage: +10, Spooky Spell Damage: +10, Last Available: "2026-03"
 12198	reassuring chaotic and dress	0		Spell Critical Percent: +10, Spooky Resistance: +1, Last Available: "2026-03"
-12199	dry warmed gray wobbly jittery dinosaur bone broth	0		Effect: "Human-Pirate Hybrid", Effect Duration: 43, Last Available: "2026-03"
+12199	dry warmed wobbly jittery gray dinosaur bone broth	0		Effect: "Human-Pirate Hybrid", Effect Duration: 43, Last Available: "2026-03"
 12200	gnawing bone	0		Last Available: "2026-03"
 12201	narrow horrifying dinosaur bone club	0		Spooky Damage: +25, Last Available: "2026-03"
 12202	medical-grade banded dinosaur skull helmet	0		Damage Absorption: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2026-03"
 12203	lime green bouncing double-paned electrified dinosaur bone corset of courage	0		Cold Resistance: +5, Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2026-03"
-12204	drinkable irresponsibly strong Pork Elf cough syrup	10	good	Last Available: "2026-03"
+12204	irresponsibly strong drinkable Pork Elf cough syrup	10	good	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	pulsating Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	rotten thick rat pizza	5	crappy	Last Available: "2026-03"
+12209	thick rotten rat pizza	5	crappy	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	Oprah's energetic hoverboard of bravery	0		Maximum MP Percent: 70, Spooky Resistance: +5, Single Equip, Last Available: "2026-03"
 12212	rock-hard smartaleck's weightlifter's left shark fin	0		Muscle: +15, Moxie Percent: +30, Damage Reduction: 5, Last Available: "2026-03"
@@ -11984,24 +11984,24 @@
 12230	spoiled crudit&eacute;s	3	crappy	
 12231	rotten sauced mutton	4	crappy	
 12232	decent snack-sized narrow hot honey ant	2	good	
-12233	flavorless massive tomb aspic	6	decent	
+12233	massive flavorless tomb aspic	6	decent	
 12234	toothsome red later tots	3	awesome	
-12235	adequate thick Frutti di Scatoletta	5	good	Last Available: "2026-05"
+12235	thick adequate Frutti di Scatoletta	5	good	Last Available: "2026-05"
 12236	toothsome twirling olive Pesto alla Marziano	4	awesome	Last Available: "2026-05"
 12237	bland big huge Arrattabbattabiata	5	decent	Last Available: "2026-05"
 12238	rotten shaking Orzo di Riso	3	crappy	Last Available: "2026-05"
 12239	spoiled green Pasta Grimavera	3	crappy	Last Available: "2026-05"
 12240	flavorless Linguini Ubriacapa	4	decent	Last Available: "2026-05"
-12241	tiny spoiled enchanted Formica e Pepe	1	crappy	Effect: "Protection from Bad Stuff", Effect Duration: 50, Last Available: "2026-05"
+12241	enchanted spoiled tiny Formica e Pepe	1	crappy	Effect: "Protection from Bad Stuff", Effect Duration: 50, Last Available: "2026-05"
 12242	toothsome Tubetto Gelatto	3	awesome	Last Available: "2026-05"
 12243	bland Gnocci Domani	3	decent	Last Available: "2026-05"
 12244	spinning Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	huge second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
-12248	blurry mirror mega helmet	0		
+12248	mirror blurry mega helmet	0		
 12252	stiffened deadly Space Soldier Helmet	0		Weapon Damage: +5, Damage Reduction: 1
 12253	decent pulsating premium turkey leg	4	good	
-12254	artisanal special watered-down styrofoam cup of mead	2	EPIC	Effect: "Healthy Blue Glow", Effect Duration: 25
+12254	special watered-down artisanal styrofoam cup of mead	2	EPIC	Effect: "Healthy Blue Glow", Effect Duration: 25
 12255	hardy sword	0		Maximum HP: +50
 12256	twirling dance instructor's staff	0		Experience Percent (Moxie): +10
 12257	thinker's lute	0		Mysticality: +10
@@ -12025,15 +12025,15 @@
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	purple Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	half-sized rotten classic banana pie	2	crappy	Last Available: "2026-07"
-12278	warmed enhanced olive wobbly shaking essential banana decoction	0		Effect: "Sagittarius Rising", Effect Duration: 58, Last Available: "2026-07"
+12278	warmed enhanced olive shaking wobbly essential banana decoction	0		Effect: "Sagittarius Rising", Effect Duration: 58, Last Available: "2026-07"
 12279	triple-aerosolized extra-magnetized banana quintessence	0		Effect: "Cold, Dead Hands", Effect Duration: 29, Last Available: "2026-07"
 12280	bad tumbling Aesop Daiquiri	3	decent	Last Available: "2026-07"
-12281	tolerable spirit-forward pulsating upside-down Monkey Congress	5	good	Last Available: "2026-07"
+12281	spirit-forward tolerable pulsating upside-down Monkey Congress	5	good	Last Available: "2026-07"
 12282	yummy super-sized watermelon pie	5	awesome	Last Available: "2026-07"
 12283	irradiated concentrated watermelon juice	0		Effect: "Blackberry Politeness", Effect Duration: 66, Last Available: "2026-07"
 12284	triple-quantum anodized shaking Aqua Citrulanatae	0		Effect: "Tiki Temerity", Effect Duration: 19, Last Available: "2026-07"
-12285	lousy special practically non-alcoholic Melonegroni	1	decent	Effect: "The Rich Get Richer", Effect Duration: 15, Last Available: "2026-07"
-12286	fancy weak artisanal Melonade Spritz	2	super EPIC	Effect: "Gummibrain", Effect Duration: 20, Last Available: "2026-07"
+12285	special lousy practically non-alcoholic Melonegroni	1	decent	Effect: "The Rich Get Richer", Effect Duration: 15, Last Available: "2026-07"
+12286	weak fancy artisanal Melonade Spritz	2	super EPIC	Effect: "Gummibrain", Effect Duration: 20, Last Available: "2026-07"
 12287	big rotten blue quince pie	5	crappy	Last Available: "2026-07"
 12288	frozen super-warmed twirling twirling quince quaff	0		Effect: "Muscularrr", Effect Duration: 47, Last Available: "2026-07"
 12289	altered altered pickled Quickquince	0		Effect: "Weasels Underfoot", Effect Duration: 69, Last Available: "2026-07"
@@ -12042,7 +12042,7 @@
 12292	bad Roth IPA	4	decent	Last Available: "2026-08"
 12293	up-at-dawn careful underdraft protection	0		Monster Level: -10, Adventures: +5, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	huge normal soybean futures	9	good	Last Available: "2026-08"
+12295	normal huge soybean futures	9	good	Last Available: "2026-08"
 12296	corrupted tarnished housing bubble	0		Effect: "Fury of the Bells", Effect Duration: 69, Last Available: "2026-08"
 12297	adjusted colloidal fuchsia squat Pixie-Swordz	0		Effect: "Almost Cool", Effect Duration: 60
 12298	financial instrument of chilblains of the early riser	0		Cold Damage: +25, Adventures: +7, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Blender_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	bad high-proof Petite Porter	8	decent	
 -2	perfectly mixed Scrawny Stout	4	EPIC	
 -3	delicious Infinitesimal IPA	4	awesome	
--4	mediocre high-proof fancy eggnogtini	10	decent	
--5	hand-crafted irresponsibly strong lime green upside-down candycaine	8	EPIC	
+-4	high-proof fancy mediocre eggnogtini	10	decent	
+-5	irresponsibly strong hand-crafted lime green upside-down candycaine	8	EPIC	
 -6	artisanal boozy fuchsia braincracker sweet	5	EPIC	
--16	weak drinkable tumbling fermented honey	2	good	
+-16	drinkable weak tumbling fermented honey	2	good	
 -17	perfectly mixed moons-shine	4	EPIC	
 -18	hand-crafted spirit-forward gin	5	EPIC	
 -19	perfectly mixed fuchsia ecto-nog	3	EPIC	
 -20	smooth hot toady	3	awesome	
--21	high-proof mediocre purple hot choculate	7	decent	
+-21	mediocre high-proof purple hot choculate	7	decent	
 -49	hand-crafted Cyder	3	EPIC	
 -50	artisanal upside-down Oil Nog	4	EPIC	
 -51	lousy Hi-Octane Peppermint Jet Fuel	4	decent	
--58	irresponsibly strong bad Grimacider	6	decent	
+-58	bad irresponsibly strong Grimacider	6	decent	
 -59	aged weak wobbly Isotope Nog	2	awesome	
 -60	smooth twirling Mutagin 'n' Tonic	3	awesome	
 -70	tolerable Gin and Herring	3	good	
 -71	acceptable Black and Tan and Red All Over	4	good	
--72	practically non-alcoholic lousy ghostly Antarctic Ice Tea	1	decent	
+-72	lousy practically non-alcoholic ghostly Antarctic Ice Tea	1	decent	
 -76	lousy practically non-alcoholic spinning CRIMBCO Ribbon Candy Schnapps	1	decent	
 -77	distilled lousy blinking CRIMBCO Egg Substitute Nog Substitute	5	decent	
 -78	perfectly mixed lime green CRIMBCO Extreme Braincracker Sour	3	EPIC	
 -82	strong drinkable spinning Horseradish-infused Vodka	5	good	
 -83	perfectly mixed weak skewed Jerkitini	2	EPIC	
--84	practically non-alcoholic lousy Desert Island Iced Tea	1	decent	
+-84	lousy practically non-alcoholic Desert Island Iced Tea	1	decent	
 -88	delicious weak Crimbo Saketini	2	awesome	
 -89	acceptable Crimboku Drop	3	good	
 -90	practically non-alcoholic mediocre upside-down Flaming Crimbo Log	1	decent	
 -107	artisanal Fortified Eggnog Slurry	4	EPIC	
 -108	artisanal practically non-alcoholic Hot Buttered Rum	1	EPIC	
--109	strong drinkable Spicy Hot Chocolate	5	good	
+-109	drinkable strong Spicy Hot Chocolate	5	good	

--- a/data/TCRS/TCRS_Sauceror_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Blender_cafe_food.txt
@@ -4,7 +4,7 @@
 -7	normal super-sized fancy shaking cyan gumdrop chow mein	5	good	
 -8	bland half-sized squat candy cane pizza	2	decent	
 -9	flavorless gingerbread stir-fry	4	decent	
--10	decent half-sized twigs and gravel	2	good	
+-10	half-sized decent twigs and gravel	2	good	
 -11	rotten shoots and leaves	4	crappy	
 -12	normal blurry bowl of unidentifiable goo	4	good	
 -13	decent gingerbread massacre	3	good	
@@ -12,15 +12,15 @@
 -15	spoiled vampire cake	4	crappy	
 -52	spoiled snack-sized fuchsia Soylent Red and Green	2	crappy	
 -53	spoiled bite-sized Disc-Shaped Nutrition Unit	1	crappy	
--54	big adequate wobbly bouncing Gingerborg Hive	5	good	
+-54	adequate big bouncing wobbly Gingerborg Hive	5	good	
 -61	rotten super-sized Candy Cane Surprise	5	crappy	
 -62	rotten lime green Grimdrop Chow Mein	3	crappy	
 -63	rotten Grimgerbread House	3	crappy	
 -67	yummy Caviar Carbonara	3	awesome	
 -68	enchanted decent Halibut Alfredo	3	good	
 -69	moldy purple Red Herring Velvet Cake	4	crappy	
--73	small spoiled upside-down CRIMBCO Reconstituted Gruel	2	crappy	
--74	massive flavorless ghostly New and Improved CRIMBCO Reconstituted Gruel	9	decent	
+-73	spoiled small upside-down CRIMBCO Reconstituted Gruel	2	crappy	
+-74	flavorless massive ghostly New and Improved CRIMBCO Reconstituted Gruel	9	decent	
 -75	low-calorie adequate CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	good	
 -79	moldy purple Brussels Sprout Stir-Fry	3	crappy	
 -80	decent bite-sized fuchsia Carrot, Cabbage, and Kale Pizza	1	good	
@@ -29,16 +29,16 @@
 -86	rotten Vegas Volcano Lava Roll	3	crappy	
 -87	stale miniature Crazy Dragon Shogun Buddha Roll	2	decent	
 -92	low-calorie stale shaking basic hot dog	1	decent	
--93	immense normal shaking savage macho dog	8	good	
+-93	normal immense shaking savage macho dog	8	good	
 -94	small adequate one with everything	2	good	
 -95	miniature rotten mirror sly dog	2	crappy	
 -96	miniature adequate devil dog	2	good	
 -97	stale gray chilly dog	4	decent	
 -98	yummy huge purple ghost dog	6	awesome	
 -99	flavorless narrow junkyard dog	4	decent	
--100	decent wobbly huge wet dog	4	good	
+-100	decent huge wobbly wet dog	4	good	
 -101	snack-sized stale sleeping dog	2	decent	
--102	flavorless snack-sized upside-down upside-down optimal dog	2	decent	
+-102	snack-sized flavorless upside-down upside-down optimal dog	2	decent	
 -103	adequate gigantic video games hot dog	10	good	
 -104	bland Peppermint Nutrition Block	4	decent	
 -105	flavorless big Gingerbread Nutrition Block	5	decent	

--- a/data/TCRS/TCRS_Sauceror_Marmot.txt
+++ b/data/TCRS/TCRS_Sauceror_Marmot.txt
@@ -4,7 +4,7 @@
 4	turtle totem	0		
 5	pasta spoon	0		
 6	gray censurious ravioli hat	0		Sleaze Resistance: +3, Familiar Effect: "atk, cap 2"
-7	maroon spinning blurry saucepan	0		
+7	spinning blurry maroon saucepan	0		
 8	narrow spices	0		
 9	red flame-retardant disco mask	0		Hot Resistance: +1, Familiar Effect: "atk, cap 2"
 10	disco ball	0		
@@ -16,7 +16,7 @@
 17	spoiled pulsating noodles	3	crappy	
 18	tortoise's blessing	0		
 19	skewed aromatic asparagus knife	0		Stench Resistance: +1
-20	red twirling Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
+20	twirling red Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	upside-down sweet ninja sword	0		
 22	green studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
@@ -55,9 +55,9 @@
 56	gray hot sauce	0		
 57	Temple Grandin's 5-Alarm Saucepan	0		Familiar Weight: +7, Class: "Sauceror"
 58	stone turtle	0		
-59	blue squat slingshot	0		
+59	squat blue slingshot	0		
 60	censurious Mace of the Tortoise	0		Sleaze Resistance: +3, Class: "Turtle Tamer"
-61	bland super-sized fortune cookie	5	decent	
+61	super-sized bland fortune cookie	5	decent	
 62	Tesla oriole-feather headdress	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -81,7 +81,7 @@
 82	green ring	0		
 83	red mirror shaft	0		
 84	Orcish meat locker	0		
-85	skewed cyan unlocked meat locker	0		
+85	cyan skewed unlocked meat locker	0		
 86	key	0		
 87	maroon meat from yesterday	0		
 88	meat stack	0		
@@ -119,7 +119,7 @@
 120	cog	0		
 121	shaking teal sprocket assembly	0		
 122	cog and sprocket assembly	0		
-123	blinking squat Gnollish flyswatter	0		
+123	squat blinking Gnollish flyswatter	0		
 124	empty meat tank	0		
 125	tumbling full meat tank	0		
 126	narrow meat engine	0		
@@ -129,7 +129,7 @@
 130	Sinatra's eyepatch	0		Experience (Moxie): +5, Familiar Effect: "4xBarrr, cap 8"
 131	skewed frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	teal Meat maid body	0		
-133	blurry bouncing narrow Certificate of Participation	0		
+133	blurry narrow bouncing Certificate of Participation	0		
 134	gray bitchin' meatcar	0		
 135	sweet rims	0		
 136	upside-down tires	0		
@@ -157,13 +157,13 @@
 158	Gnollish pie tin	0		
 159	wad of dough	0		
 160	mirror pie crust	0		
-161	gigantic spoiled ghuol egg	10	crappy	
+161	spoiled gigantic ghuol egg	10	crappy	
 162	stale jittery ghuol egg quiche	3	decent	
 163	huge skeleton bone of the businessman	0		Meat Drop: +50
 164	olive smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	adequate teal bouncing ghuol-ear kabob	3	good	
+167	adequate bouncing teal ghuol-ear kabob	3	good	
 168	bone rattle	0		Item Drop: +5
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -176,7 +176,7 @@
 177	brainy skull	0		
 178	detective skull	0		
 179	adequate chorizo taco	3	good	
-180	watered-down artisanal blue ice-cold fotie	2	EPIC	
+180	artisanal watered-down blue ice-cold fotie	2	EPIC	
 181	baseball	0		
 182	green batgut	0		
 183	bat wing	0		
@@ -195,15 +195,15 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	huge fireproof ring	0		Hot Resistance: +3
-200	huge bland mirror rat appendix kabob	10	decent	
+200	bland huge mirror rat appendix kabob	10	decent	
 201	flavorless bat wing kabob	3	decent	
-202	normal low-calorie carob chunks	1	good	
+202	low-calorie normal carob chunks	1	good	
 203	jittery herbs	0		
 204	yummy carob chunk cookies	4	awesome	
 205	pulsating secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	awesome	
-208	bouncing green patchouli incense stick	0		
+208	green bouncing patchouli incense stick	0		
 209	wad of tofu	0		
 210	green Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
@@ -211,7 +211,7 @@
 213	blue manspreader's weightlifter's filthy corduroys	0		Muscle: +15, Monster Level: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	grievous filthy knitted dread sack	0		Weapon Damage Percent: +50, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	stale diet purple carob brownies	1	decent	
+216	diet stale purple carob brownies	1	decent	
 217	adequate purple herb brownies	4	good	
 218	hemp string	0		
 219	necklace chain	0		
@@ -220,7 +220,7 @@
 222	phat turquoise bead	0		
 223	bouncing huge electrified phat turquoise bracelet	0		MP Regen Min: 3, MP Regen Max: 5
 224	ribald eyepatch	0		Sleaze Damage: +10, Familiar Effect: "3xBarrr, cap 6"
-225	huge stale tofu casserole	8	decent	
+225	stale huge tofu casserole	8	decent	
 226	compressed twirling can of Red Minotaur	1	decent	
 227	wicked Kentucky-fried meat sword	0		Spell Damage: +5
 228	shaking Kentucky-fried meat staff of Tarzan	0		Experience (Muscle): +3
@@ -232,8 +232,8 @@
 234	maroon Doc Galaktik's Homeopathic Elixir	0		
 235	Sherlock's sharpshooter's Bigger Bugfinder Blade	0		Critical Hit Percent: +10, Item Drop: +25
 236	squat Queue Du Coq cocktailcrafting kit	0		
-237	high-proof bad bottle of gin	6	decent	
-238	watered-down bad squat ghostly bottle of vodka	2	decent	
+237	bad high-proof bottle of gin	6	decent	
+238	watered-down bad ghostly squat bottle of vodka	2	decent	
 239	squat maroon miser's greasy Orcish baseball cap	0		Sleaze Spell Damage: +10, Meat Drop: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	blue MacGyver's thinker's Orcish cargo shorts	0		Mysticality: +10, Maximum MP: +100, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	sizzling Orcish frat-paddle	0		Hot Damage: +10
@@ -241,21 +241,21 @@
 243	huge bland grapefruit	8	decent	
 244	spoiled grapes	4	crappy	
 245	small moldy olive	2	crappy	
-246	small enchanted yummy tomato	2	awesome	Effect: "Tingly Wrists", Effect Duration: 50
+246	small yummy enchanted tomato	2	awesome	Effect: "Tingly Wrists", Effect Duration: 50
 247	fermenting powder	0		
 248	drinkable salty dog	4	good	
 249	artisanal bloody mary	4	EPIC	
 250	perfectly mixed skewed screwdriver	3	EPIC	
-251	watered-down bad martini	2	decent	
-252	artisanal watered-down bloody beer	2	EPIC	
+251	bad watered-down martini	2	decent	
+252	watered-down artisanal bloody beer	2	EPIC	
 253	weak lousy jittery shot of schnapps	2	decent	
-254	bad practically non-alcoholic enchanted shot of grapefruit schnapps	1	decent	Effect: "Coal-Powered", Effect Duration: 45
-255	enchanted practically non-alcoholic bad tumbling fine wine	1	decent	Effect: "Really Deep Breath", Effect Duration: 35
+254	bad enchanted practically non-alcoholic shot of grapefruit schnapps	1	decent	Effect: "Coal-Powered", Effect Duration: 45
+255	bad practically non-alcoholic enchanted tumbling fine wine	1	decent	Effect: "Really Deep Breath", Effect Duration: 35
 256	lousy shot of tomato schnapps	3	decent	
 257	perfectly mixed extra-spicy bloody mary	3	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
-260	toothsome immense jittery White Citadel fries	8	awesome	
+260	immense toothsome jittery White Citadel fries	8	awesome	
 261	decent White Citadel burger	3	good	
 262	adequate piece of wedding cake	3	good	
 263	bland fancy squat chocolate chips	4	decent	Effect: "Glo-Face", Effect Duration: 20
@@ -310,23 +310,23 @@
 312	Knob Goblin visor of the sewer	0		Stench Damage: +25, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	green miser's Crown of the Goblin King	0		Meat Drop: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	bland bean burrito	3	decent	
-315	massive normal bean burrito	9	good	
+315	normal massive bean burrito	9	good	
 316	spoiled insanely bean burrito	3	crappy	
 317	toothsome bean burrito	4	awesome	
 318	adequate bean burrito	3	good	
-319	jumbo bland bouncing insanely bean burrito	5	decent	
+319	bland jumbo bouncing insanely bean burrito	5	decent	
 320	rotten bat haggis	4	crappy	
 321	bland menudo	4	decent	
-322	thick bland wobbly goat cheese	5	decent	
+322	bland thick wobbly goat cheese	5	decent	
 323	flavorless immense plain pizza	6	decent	
-324	enchanted flavorless blue sausage pizza	4	decent	Effect: "Macho Profundo", Effect Duration: 15
+324	flavorless enchanted blue sausage pizza	4	decent	Effect: "Macho Profundo", Effect Duration: 15
 325	flavorless massive goat cheese pizza	9	decent	
 326	big bland upside-down mushroom pizza	5	decent	
 327	twirling goat	0		
 328	artisanal enchanted shaking bottle of whiskey	3	EPIC	Effect: "Vinegavotte", Effect Duration: 40
 329	ribald goat beard	0		Sleaze Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	EPIC	
-331	practically non-alcoholic artisanal ghostly maroon Canadian	1	EPIC	
+331	practically non-alcoholic artisanal maroon ghostly Canadian	1	EPIC	
 332	stale blinking skewed lemon	4	decent	
 333	adequate huge lime	3	good	
 334	extremely unsafe sabre teeth	0		Weapon Damage Percent: +100
@@ -339,7 +339,7 @@
 341	anodized altered upside-down Knob Goblin love potion	0		Effect: "Sappy Blood", Effect Duration: 26
 342	Knob Goblin stink bomb	0		
 343	triple-pressed corrupted green Knob Goblin sharpening spray	0		Effect: "Wit Tea", Effect Duration: 59
-344	purple shaking Knob Goblin seltzer	0		
+344	shaking purple Knob Goblin seltzer	0		
 345	blinking Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
@@ -361,7 +361,7 @@
 363	tumbling linoleum ore	0		
 364	red asbestos ore	0		
 365	chrome ore	0		
-366	ghostly narrow linoleum sword hilt	0		
+366	narrow ghostly linoleum sword hilt	0		
 367	linoleum stick	0		
 368	linoleum crossbow string	0		
 369	asbestos sword hilt	0		
@@ -441,7 +441,7 @@
 443	tumbling beer lens	0		
 444	beer goggles	0		
 445	spinning Herculean box-in-the-box	0		Experience (Muscle): +1
-446	wobbly upside-down nothing-in-the-box-in-the-box	0		
+446	upside-down wobbly nothing-in-the-box-in-the-box	0		
 447	huge smooth box-in-the-box-in-the-box	0		Moxie: +15
 448	executive foolscap fool's cap of the detective	0		Item Drop: +20, Meat Drop: +40, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	nippy clown nose	0		Cold Damage: +10, Clowniness: 25
@@ -450,11 +450,11 @@
 452	ghostly disease	0		
 453	sober pill	0		
 454	tumbling screwdriver	0		
-455	small flavorless jumbo olive	2	decent	
-456	special artisanal dry martini	3	EPIC	Effect: "Big Meat Big Prizes", Effect Duration: 45
+455	flavorless small jumbo olive	2	decent	
+456	artisanal special dry martini	3	EPIC	Effect: "Big Meat Big Prizes", Effect Duration: 45
 457	mirror ye olde golde frontes of the ox	0		Muscle: +20, Class: "Disco Bandit", Single Equip
-458	yellow narrow upside-down continuum transfunctioner	0		
-459	skewed twirling pixel	0		
+458	upside-down yellow narrow continuum transfunctioner	0		
+459	twirling skewed pixel	0		
 460	yellow pixel	0		
 461	skewed pixel	0		
 462	pixel	0		
@@ -462,7 +462,7 @@
 464	blue pixel potion	0		
 465	mirror pixel potion	0		
 466	pixel potion	0		
-467	normal snack-sized pixel pie	2	good	
+467	snack-sized normal pixel pie	2	good	
 468	ruby W	0		
 469	blue wussiness potion	0		
 470	mediocre fuchsia Imp Ale	3	decent	
@@ -486,17 +486,17 @@
 488	guitar pick	0		
 489	drab sonata	0		
 490	ghostly Lo Pan's wicked mesh cap	0		Spell Damage: +5, Spell Critical Percent: +30, Familiar Effect: "atk, 1xVolley, cap 41"
-491	blurry pulsating cyan enormous belt buckle	0		
+491	pulsating blurry cyan enormous belt buckle	0		
 492	executive chaps of the ox	0		Muscle: +20, Meat Drop: +40, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	blurry ketchup hound	0		
 494	batblade of the brazier	0		Hot Spell Damage: +25
 495	upside-down catgut	0		
 496	green cat appendix	0		
 497	gnatwing	0		
-498	special delicious big papaya	5	awesome	Effect: "Devil Inside", Effect Duration: 45
+498	big delicious special papaya	5	awesome	Effect: "Devil Inside", Effect Duration: 45
 499	narrow nasty Samson's denim axe	0		Experience (Muscle): +5, Stench Damage: +5
 500	Elf Farm Raffle ticket	0		
-501	miniature bland Elfin shortbread	2	decent	
+501	bland miniature Elfin shortbread	2	decent	
 502	pagoda plans	0		
 503	moldy skewered cat appendix	3	crappy	
 504	pulsating evil arches	0		
@@ -525,7 +525,7 @@
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
-530	dry ionized denatured skewed yellow spray paint	0		Effect: "Spooky Flavor", Effect Duration: 50
+530	dry ionized denatured yellow skewed spray paint	0		Effect: "Spooky Flavor", Effect Duration: 50
 531	special sauce glove of the businessman	0		Meat Drop: +50, Class: "Sauceror", Single Equip
 532	shellacked ladle of mystery	0		Damage Reduction: 7, Class: "Sauceror"
 533	jittery Gnollish toolbox	0		
@@ -538,7 +538,7 @@
 540	polymerized unsweetened Tasty Fun Good rice candy	0		Effect: "Sweetened and Fattened", Effect Duration: 45
 541	draggin' ball hat of James Dean	0		Experience (Moxie): +3, Item Drop: +5, Familiar Effect: "atk, 1xVolley, cap 25"
 542	hardy steel-toed 1337 7r0uZ0RZ	0		Damage Reduction: 9, Maximum HP: +50, Familiar Effect: "2xPotato, cap 27"
-543	spoiled super-sized Trollhouse cookies	5	crappy	
+543	super-sized spoiled Trollhouse cookies	5	crappy	
 544	aromatic talons of horror	0		Spooky Spell Damage: +25, Stench Resistance: +1
 545	low-calorie tasty Spam Witch sammich	1	awesome	
 546	jittery meat vortex	0		
@@ -549,7 +549,7 @@
 551	mirror 64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	bland thick pr0n cocktail	5	decent	
+554	thick bland pr0n cocktail	5	decent	
 555	blurry drywall axe of horror of the cheetah	0		Spooky Spell Damage: +25, Initiative: +60
 556	toasty Pine-Fresh air freshener	0		Hot Damage: +5
 557	mediocre distilled whiskey and cola	5	decent	
@@ -559,21 +559,21 @@
 561	teal pregnant mushroom	0		
 562	ratgut	0		
 563	ghostly sonar-in-a-biscuit	0		
-564	enchanted weak smooth spinning Mad Train wine	2	awesome	Effect: "Go-Gone", Effect Duration: 25
+564	smooth weak enchanted spinning Mad Train wine	2	awesome	Effect: "Go-Gone", Effect Duration: 25
 565	blinking squat quilted hobo gloves	0		Damage Absorption: +40, Single Equip
 566	reassuring bum cheek	0		Spooky Resistance: +1, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	normal tiny special Double Bacon Beelzeburger	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10
-569	rotten half-sized yellow Lord of the Flies-sized fries	2	crappy	
+568	normal special tiny Double Bacon Beelzeburger	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10
+569	half-sized rotten yellow Lord of the Flies-sized fries	2	crappy	
 570	tasty special shaking Chicken Sandwich	4	awesome	Effect: "Happy Salamander", Effect Duration: 10
 571	Jumbo Dr. Lucifer	1	crappy	
 572	rotten low-calorie Children's Meal of the Damned	1	crappy	
 573	decent noodles	3	good	
-574	toothsome bite-sized noodles	1	awesome	
-575	fancy spoiled painful penne pasta	3	crappy	Effect: "Jungle Juiced", Effect Duration: 40
+574	bite-sized toothsome noodles	1	awesome	
+575	spoiled fancy painful penne pasta	3	crappy	Effect: "Jungle Juiced", Effect Duration: 40
 576	spoiled ravioli della hippy	4	crappy	
 577	tasty pr0n m4nic0tti	3	awesome	
-578	delicious special thick cyan Hell ramen	5	awesome	Effect: "On a Roll", Effect Duration: 50
+578	thick special delicious cyan Hell ramen	5	awesome	Effect: "On a Roll", Effect Duration: 50
 579	toothsome jumbo boring spaghetti	5	awesome	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
@@ -584,7 +584,7 @@
 586	tumbling ridiculously huge sword of the ox of temperance	0		Muscle: +20, Sleaze Resistance: +5
 587	unsweetened pickled tumbling tumbling super-spiky hair gel	0		Effect: "stats.enq", Effect Duration: 39
 588	soft echo eyedrop antidote	0		
-589	half-sized normal cocoa eggshell fragment	2	good	
+589	normal half-sized cocoa eggshell fragment	2	good	
 590	rotten cocoa eggshell fragment	3	crappy	
 591	narrow cocoa egg	0		
 592	spinning gray house	0		
@@ -598,14 +598,14 @@
 600	bouncing frightening Dr. Hobo's scalpel of the detective	0		Spooky Damage: +5, Item Drop: +20
 601	spinning Dr. Hobo's map	0		
 602	blinking Degrassi Knoll shopping list	0		
-603	fuchsia tumbling Item #13	0		
+603	tumbling fuchsia Item #13	0		
 604	Penultimate Fantasy chest	0		
 605	Tissue Paper Immateria	0		
 606	pulsating Tin Foil Immateria	0		
 607	jittery Gauze Immateria	0		
 608	twirling Plastic Wrap Immateria	0		
 609	squat spinning S.O.C.K.	0		
-610	squat ghostly procrastination potion	0		
+610	ghostly squat procrastination potion	0		
 611	blinking D	0		
 612	original G	0		
 613	plot hole	0		
@@ -636,7 +636,7 @@
 638	narrow brawny asshat of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	normal tiny abominable snowcone	1	good	
 640	Ent cider	1	good	
-641	delicious small cyan toast	2	awesome	
+641	small delicious cyan toast	2	awesome	
 642	ghostly squat skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
@@ -644,14 +644,14 @@
 646	yummy miniature twirling green fruitcake	2	awesome	
 647	present	0		Last Available: "2004-11"
 648	Crimbo sword of temperance	0		Sleaze Resistance: +5, Last Available: "2004-10"
-649	Herculean Crimbo hat	0		Experience (Muscle): +1, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	thinker's Crimbo pants	0		Mysticality: +10, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	Herculean Crimbo hat	0		Experience (Muscle): +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	thinker's Crimbo pants	0		Mysticality: +10, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	upside-down ghostly greedy exclusive ultra-rare item	0		Meat Drop: +20
 652	lime green quantum egg	0		
 653	intragalactic rowboat	0		
 654	star	0		
 655	narrow line	0		
-656	pulsating yellow star chart	0		
+656	yellow pulsating star chart	0		
 657	smartaleck's star sword	0		Moxie Percent: +30
 658	prompt star crossbow	0		Adventures: +3
 659	aromatic star staff	0		Stench Resistance: +1
@@ -664,20 +664,20 @@
 666	Lo Pan's Herculean steaming evil of the empath	0		Experience (Muscle): +1, Spell Critical Percent: +30, Familiar Weight: +5
 667	castle map	0		
 668	bouncing Van der Graaf spiked femur	0		MP Regen Min: 5, MP Regen Max: 7
-669	snack-sized enchanted adequate ghuol guolash	2	good	Effect: "Rotten Memories", Effect Duration: 25
+669	adequate enchanted snack-sized ghuol guolash	2	good	Effect: "Rotten Memories", Effect Duration: 25
 670	razor-sharp lihc face	0		Weapon Damage Percent: +25, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	squat banded grave robbing shovel of the pedagogue	0		Experience: +3, Damage Absorption: +100
 672	small spoiled cranberries	2	crappy	
 673	acceptable vodka and cranberry	3	good	
-674	fancy weak lousy whiskey	2	decent	Effect: "Human-Beast Hybrid", Effect Duration: 15
+674	fancy lousy weak whiskey	2	decent	Effect: "Human-Beast Hybrid", Effect Duration: 15
 675	spinning lion tamer's skull of the Bonerdagon	0		Experience (familiar): +2
 676	dragonbone belt buckle	0		
 677	educational badass belt	0		Experience: +1
 678	chest of the Bonerdagon	0		
 679	delicious roll in the hay	3	awesome	
-680	triple-distilled smooth slap and tickle	10	awesome	
+680	smooth triple-distilled slap and tickle	10	awesome	
 681	boozy hand-crafted slip 'n' slide	5	EPIC	
-682	acceptable blinking blue a sump'm sump'm	3	good	
+682	acceptable blue blinking a sump'm sump'm	3	good	
 683	smooth horizontal tango	3	awesome	
 684	lousy ghostly pink pony	3	decent	
 685	rosy-cheeked dance instructor's smartaleck's Mr. Shirt	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Maximum HP Percent: +30
@@ -716,11 +716,11 @@
 720	ghostly manspreader's thinker's porquoise necklace	0		Mysticality: +10, Monster Level: +10, Single Equip
 721	twirling red careful porquoise bracelet of dire peril	0		Weapon Damage: +20, Monster Level: -10
 722	jittery zippy savvy porquoise ring of wisdom	0		Mysticality: +15, Mysticality Percent: +20, Initiative: +20, Single Equip
-723	decent immense Knoll mushroom	9	good	
+723	immense decent Knoll mushroom	9	good	
 724	stale mushroom	3	decent	
 725	one million meat pancakes	0		
 726	huge mirror shard of Leguizamo	0		Monster Level: +20
-727	fuchsia blurry hedge maze puzzle	0		
+727	blurry fuchsia hedge maze puzzle	0		
 728	hedge maze key	0		
 729	fishbowl	0		
 730	teal fishtank	0		
@@ -732,25 +732,25 @@
 736	stone tablet (Sinister Strumming)	0		
 737	skewed stone tablet (Squeezings of Woe)	0		
 738	yellow stone tablet (Really Evil Rhythm)	0		
-739	blurry cyan tambourine bells	0		
+739	cyan blurry tambourine bells	0		
 740	spinning tambourine of the dark arts	0		Spell Damage Percent: +100
 741	pulsating broken skull	0		
-742	bite-sized toothsome Knoll shroomkabob	1	awesome	
-743	toothsome small mushroom	2	awesome	
+742	toothsome bite-sized Knoll shroomkabob	1	awesome	
+743	small toothsome mushroom	2	awesome	
 744	oxidized aerosolized hair spray	0		Effect: "Sugar Smacks", Effect Duration: 20
 746	pulsating stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	bland warm mushroom	4	decent	
 750	bite-sized stale teal mushroom quesadilla	1	decent	
-751	huge toothsome cool mushroom	7	awesome	
-752	moldy half-sized cool mushroom casserole	2	crappy	
+751	toothsome huge cool mushroom	7	awesome	
+752	half-sized moldy cool mushroom casserole	2	crappy	
 753	bland tumbling pointy mushroom	4	decent	
 754	delicious cream of pointy mushroom soup	4	awesome	
-755	miniature adequate mushroom	2	good	
-756	enchanted bland mushroom	3	decent	Effect: "Scavengers Scavenging", Effect Duration: 20
-757	jumbo yummy tumbling mushroom	5	awesome	
-758	jumbo decent pulsating ghost cucumber	5	good	
+755	adequate miniature mushroom	2	good	
+756	bland enchanted mushroom	3	decent	Effect: "Scavengers Scavenging", Effect Duration: 20
+757	yummy jumbo tumbling mushroom	5	awesome	
+758	decent jumbo pulsating ghost cucumber	5	good	
 759	dill	0		
 760	purple vinegar	0		
 761	tumbling brine	0		
@@ -771,13 +771,13 @@
 776	kneecapping stick of the ox	0		Muscle: +20
 777	narrow pulsating boxer's iron pasta spoon	0		Muscle Percent: +10
 778	huge support cummerbund of terror	0		Spooky Spell Damage: +10
-779	tumbling ghostly Mob Penguin cellular phone	0		
+779	ghostly tumbling Mob Penguin cellular phone	0		
 780	scroll of pasta summoning	0		
 781	denatured mafia aria	0		Effect: "Impregnably Delicious", Effect Duration: 20
 782	Mr. Exploiter	0		Last Available: "2009-12"
-783	bouncing gray 'Villa' document	0		
+783	gray bouncing 'Villa' document	0		
 784	weak artisanal Acqua Del Piatto Merlot	2	super ultra mega EPIC	Last Available: "2004-10"
-785	olive twirling raffle ticket	0		
+785	twirling olive raffle ticket	0		
 786	toothsome wobbly strawberry	4	awesome	
 787	watered-down hand-crafted pulsating bottle of rum	2	EPIC	
 788	aged strawberry daiquiri	4	awesome	
@@ -790,21 +790,21 @@
 795	fortified perfectly mixed Acque Luride Grezze Cabernet	5	EPIC	Last Available: "2004-10"
 796	asbestos-lined hardened razor-sharp cement shoes	0		Weapon Damage Percent: +25, Damage Reduction: 3, Hot Resistance: +5, Last Available: "2004-10"
 797	drinkable rockin' wagon	3	good	
-798	weak hand-crafted ocean motion	2	EPIC	
+798	hand-crafted weak ocean motion	2	EPIC	
 799	perfectly mixed practically non-alcoholic purple fuzzbump	1	super ultra mega turbo EPIC	
 800	stale miniature bouncing poutine	2	decent	
-801	thick bland Knob stir-fry	5	decent	
-804	snack-sized rotten maroon Knoll stir-fry	2	crappy	
+801	bland thick Knob stir-fry	5	decent	
+804	rotten snack-sized maroon Knoll stir-fry	2	crappy	
 805	rotten wobbly stir-fry	3	crappy	
 806	delicious purple asparagus stir-fry	3	awesome	
-807	moldy half-sized olive stir-fry	2	crappy	
+807	half-sized moldy olive stir-fry	2	crappy	
 808	normal Knob sausage stir-fry	3	good	
-809	miniature flavorless tumbling bat wing stir-fry	2	decent	
+809	flavorless miniature tumbling bat wing stir-fry	2	decent	
 810	enchanted yummy rat appendix stir-fry	3	awesome	Effect: "Funky Coal Patina", Effect Duration: 5
 811	tasty gigantic tofu stir-fry	6	awesome	
 812	moldy pr0n stir-fry	3	crappy	
-813	normal big fancy Knob shells	5	good	Effect: "Far Out", Effect Duration: 25
-814	small adequate huge b&auml;tzle	2	good	
+813	big normal fancy Knob shells	5	good	Effect: "Far Out", Effect Duration: 25
+814	adequate small huge b&auml;tzle	2	good	
 815	bland ratini	3	decent	
 816	snack-sized normal shaking Knob stroganoff	2	good	
 817	spoiled tumbling menudo ravioli	4	crappy	
@@ -820,7 +820,7 @@
 827	jittery murky potion	0		
 828	baby killer bee	0		
 829	anti-anti-antidote	0		
-830	bland tiny royal jelly	1	decent	
+830	tiny bland royal jelly	1	decent	
 831	green small box	0		
 832	box	0		
 833	blue avaricious vorpal blade	0		Meat Drop: +30
@@ -832,7 +832,7 @@
 839	tolerable Maiali Sifilitici Pinot Noir	3	good	Last Available: "2004-10"
 840	jittery greedy family-friendly Mafia violin case	0		Sleaze Resistance: +1, Meat Drop: +20, Last Available: "2004-10"
 841	lousy blue tomato daiquiri	3	decent	
-842	weak tolerable beertini	2	good	
+842	tolerable weak beertini	2	good	
 843	mediocre blurry salty slug	3	decent	
 844	delicious papaya slung	3	awesome	
 845	dangerous MAHI fez	0		Weapon Damage: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -840,10 +840,10 @@
 848	hypodermic needle	0		Familiar Weight: +5
 849	Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
-851	tumbling blinking prosthetic forehead	0		Familiar Weight: +5
+851	blinking tumbling prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
 853	blundarrrbus	0		Familiar Weight: +5
-854	squat yellow sucky decal	0		Familiar Weight: +5
+854	yellow squat sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	blurry huge shock collar	0		
 857	moonglasses	0		
@@ -878,7 +878,7 @@
 887	leaf	0		
 888	maple leaf	0		
 889	pulsating blue wholesome balaclava	0		Maximum HP Percent: +10, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	huge moldy balaclava baklava	6	crappy	
+890	moldy huge balaclava baklava	6	crappy	
 891	skewed Sinatra's Warehouse 23 bling	0		Experience (Moxie): +5
 892	jittery savvy bugbear-smiting sword of the sewer of horror	0		Mysticality Percent: +20, Stench Damage: +25, Spooky Spell Damage: +25
 893	lousy lumbering jack	3	decent	
@@ -892,7 +892,7 @@
 901	pulsating espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	spirit-forward drinkable jittery Spasmi Dolorosi Del Rene Champagne	5	good	Last Available: "2004-10"
-904	Oprah's school Mafia knickerbockers of the storm of the scaredy-cat	0		Maximum MP Percent: 90, Monster Level: -15, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	Oprah's school Mafia knickerbockers of the storm of the scaredy-cat	0		Maximum MP Percent: 90, Monster Level: -15, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	ionized narrow Yummy Tummy bean	0		Effect: "Aries Rising", Effect Duration: 15
 906	super-flattened vacuum-sealed Rock Pops	0		Effect: "White Blooded", Effect Duration: 18
 907	enhanced cold-filtered Mr. Mediocrebar	0		Effect: "Electrolit Up", Effect Duration: 31
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	aromatic cool intergalactic pom poms	0		Moxie: +5, Stench Resistance: +1
 917	huge Mob Penguin protection contract	0		
-918	tumbling Radio Free Baseball Cap of the early riser	0		Adventures: +7, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	upside-down Radio Free Pants of courage	0		Spooky Resistance: +3, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	tumbling Radio Free Baseball Cap of the early riser	0		Adventures: +7, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	upside-down Radio Free Pants of courage	0		Spooky Resistance: +3, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	wobbly occult Radio Free Foil	0		Spell Damage Percent: +25, Last Available: "2006-07"
 921	flavorless spinning radio button candy	3	decent	
 922	tumbling flame-wreathed severed rocking horse head	0		Hot Spell Damage: +10
@@ -918,9 +918,9 @@
 927	delicious Ferita Del Petto Zinfandel	4	awesome	Last Available: "2006-12"
 928	fuzzy bracelets of the dark arts	0		Spell Damage Percent: +100
 929	ghostly Van der Graaf arse-shooting crossbow	0		MP Regen Min: 5, MP Regen Max: 7
-931	special smooth cyan spiced rum	4	awesome	Effect: "Block-Rockin' Beet", Effect Duration: 45
+931	smooth special cyan spiced rum	4	awesome	Effect: "Block-Rockin' Beet", Effect Duration: 45
 932	lousy special olive eggnog	3	decent	Effect: "Hot Hands", Effect Duration: 45
-933	huge adequate candy cane	6	good	
+933	adequate huge candy cane	6	good	
 934	bland fancy upside-down gingerbread bugbear	3	decent	Effect: "Berry Berry Cold", Effect Duration: 40
 935	huge zippy imitation nice watch	0		Initiative: +20, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,13 +929,13 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	yellow Crimbo stocking	0		Last Available: "2004-12"
-942	jittery auspicious bowler	0		Item Drop: +10, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	jittery auspicious bowler	0		Item Drop: +10, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	yellow blinking forbidden slick bow staff	0		Moxie: +10, Spell Damage Percent: +50, Last Available: "2004-12"
-944	bowlegged pants of extreme caution	0		Monster Level: -25, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	bowlegged pants of extreme caution	0		Monster Level: -25, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewed skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	bouncing skewered cherry	0		Last Available: "2004-12"
-948	practically non-alcoholic artisanal martini	1	super ultra mega turbo EPIC	Last Available: "2004-12"
+948	artisanal practically non-alcoholic martini	1	super ultra mega turbo EPIC	Last Available: "2004-12"
 949	bad watered-down grogtini	2	decent	Last Available: "2004-12"
 950	smooth watered-down cherry bomb	2	awesome	Last Available: "2004-12"
 951	blue extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -944,7 +944,7 @@
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	twirling green fez of etymology of the pedagogue	0		Experience: +3, Familiar Effect: "1xLep, cap 30"
 956	normal carob chunk noodles	3	good	
-957	massive tasty jittery chorizo brownies	7	awesome	
+957	tasty massive jittery chorizo brownies	7	awesome	
 958	stale low-calorie chocolate and tomato pizza	1	decent	
 959	flange	0		
 960	clockwork key	0		
@@ -989,26 +989,26 @@
 1002	coward's Xlyinia's notebook	0		Monster Level: -20
 1003	soda water	0		
 1004	tolerable watered-down bottle of tequila	2	good	
-1005	hand-crafted watered-down boxed wine	2	EPIC	
-1006	bite-sized tasty cherry	1	awesome	
+1005	watered-down hand-crafted boxed wine	2	EPIC	
+1006	tasty bite-sized cherry	1	awesome	
 1007	beefcake's coconut shell	0		Muscle: +25, Familiar Effect: "1xFairy, cap 7"
 1008	ice cubes	0		Item Drop: +5
-1009	watered-down perfectly mixed vodka martini	2	EPIC	
-1010	watered-down aged whiskey and soda	2	awesome	
-1011	bad extra-dry ghostly monkey wrench	5	decent	
-1012	smooth irresponsibly strong tequila sunrise	10	awesome	
+1009	perfectly mixed watered-down vodka martini	2	EPIC	
+1010	aged watered-down whiskey and soda	2	awesome	
+1011	extra-dry bad ghostly monkey wrench	5	decent	
+1012	irresponsibly strong smooth tequila sunrise	10	awesome	
 1013	hand-crafted triple-distilled margarita	6	EPIC	
-1014	tolerable high-proof strawberry wine	10	good	
+1014	high-proof tolerable strawberry wine	10	good	
 1015	lousy tumbling wine spritzer	3	decent	
 1016	perfectly mixed perpendicular hula	4	EPIC	
 1017	bad ducha de oro	3	decent	
-1018	hand-crafted weak calle de miel	2	EPIC	
+1018	weak hand-crafted calle de miel	2	EPIC	
 1019	aged watered-down dry vodka martini	2	awesome	
 1020	tolerable old-fashioned	3	good	
-1021	fancy perfectly mixed watered-down tequila with training wheels	2	EPIC	Effect: "Man's Worst Enemy", Effect Duration: 10
-1022	drinkable fancy high-proof sangria	8	good	Effect: "On the Shoulders of Giants", Effect Duration: 20
+1021	fancy watered-down perfectly mixed tequila with training wheels	2	EPIC	Effect: "Man's Worst Enemy", Effect Duration: 10
+1022	fancy drinkable high-proof sangria	8	good	Effect: "On the Shoulders of Giants", Effect Duration: 20
 1023	perfectly mixed vesper	3	super ultra EPIC	Last Available: "2004-12"
-1024	special smooth bodyslam	3	awesome	Effect: "Berry Defensive", Effect Duration: 20, Last Available: "2004-12"
+1024	smooth special bodyslam	3	awesome	Effect: "Berry Defensive", Effect Duration: 20, Last Available: "2004-12"
 1025	acceptable sangria del diablo	4	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
@@ -1017,7 +1017,7 @@
 1030	boxer's penguin whip	0		Muscle Percent: +10
 1031	teal electrified yak whip	0		MP Regen Min: 3, MP Regen Max: 5
 1032	skewed wobbly groovy gnauga hide whip	0		Moxie Percent: +10
-1033	wobbly blurry gnauga hide	0		
+1033	blurry wobbly gnauga hide	0		
 1034	hippo skin buckler of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 5
 1035	tumbling knitted penguin skin buckler	0		Cold Resistance: +3, Damage Reduction: 5
 1036	upside-down pulsating stiffened yakskin buckler	0		Damage Reduction: 6
@@ -1029,11 +1029,11 @@
 1043	savvy string of beads	0		Mysticality Percent: +20
 1044	string of beads of vim and vigor	0		Maximum HP Percent: +50
 1045	sizzling plastic bottle opener	0		Hot Damage: +10
-1046	mirror blinking greedy traffic cone of courage	0		Spooky Resistance: +3, Meat Drop: +20, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	watered-down artisanal N. O. Beer	2	EPIC	
-1048	diluted shaking blinking oyster egg	1		
+1046	mirror blinking greedy traffic cone of courage	0		Spooky Resistance: +3, Meat Drop: +20, Familiar Effect: "cap 15", Last Available: "2005-03"
+1047	artisanal watered-down N. O. Beer	2	EPIC	
+1048	diluted blinking shaking oyster egg	1		
 1049	mixed ghostly oyster egg	1		
-1050	dehydrated huge pulsating oyster egg	1		
+1050	dehydrated pulsating huge oyster egg	1		
 1051	upside-down plastic oyster egg	0		
 1052	diluted wobbly blinking oyster egg	1		
 1053	denatured wobbly oyster egg	1		
@@ -1051,7 +1051,7 @@
 1065	dehydrated blinking oyster egg	1		
 1066	vaporized skewed oyster egg	1		Effect: "Cruisin' for a Bruisin'", Effect Duration: 50
 1067	skewed squat plastic oyster egg	0		
-1068	altered wobbly narrow oyster egg	1		
+1068	altered narrow wobbly oyster egg	1		
 1069	pickled pulsating oyster egg	1		
 1070	vaporized upside-down oyster egg	1		Effect: "Fungal Flambé", Effect Duration: 10
 1071	plastic oyster egg	0		
@@ -1123,13 +1123,13 @@
 1137	bouncing slick bicycle chain of the blizzard	0		Moxie: +10, Cold Spell Damage: +25
 1138	mushroom fermenting solution	0		
 1139	acceptable mushroom wine	4	good	
-1140	drinkable practically non-alcoholic icy mushroom wine	1	good	
-1141	bad practically non-alcoholic mushroom wine	1	decent	
+1140	practically non-alcoholic drinkable icy mushroom wine	1	good	
+1141	practically non-alcoholic bad mushroom wine	1	decent	
 1142	artisanal pointy mushroom wine	3	EPIC	
 1143	perfectly mixed huge flat mushroom wine	4	EPIC	
-1144	acceptable practically non-alcoholic cool mushroom wine	1	good	
+1144	practically non-alcoholic acceptable cool mushroom wine	1	good	
 1145	weak fancy tolerable knob mushroom wine	2	good	Effect: "Cockroach Scurry", Effect Duration: 5
-1146	mediocre practically non-alcoholic knoll mushroom wine	1	decent	
+1146	practically non-alcoholic mediocre knoll mushroom wine	1	decent	
 1147	mediocre squat mushroom wine	4	decent	
 1148	delicious practically non-alcoholic shot of flower schnapps	1	awesome	
 1149	spoiled flower petal pie	4	crappy	
@@ -1144,7 +1144,7 @@
 1159	spinning mariachi G-string	0		
 1160	narrow smartaleck's irate sombrero	0		Moxie Percent: +30, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	shaking pile of candy	0		
-1162	colloidal improved purple narrow handsomeness potion	0		Effect: "Taurus Rising", Effect Duration: 26
+1162	colloidal improved narrow purple handsomeness potion	0		Effect: "Taurus Rising", Effect Duration: 26
 1163	modified ionized marzipan skull	0		Effect: "Swordholder", Effect Duration: 51
 1164	poultrygeist	0		
 1165	wobbly twirling hovering sombrero	0		
@@ -1183,13 +1183,13 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	huge flavorless mugcake	10	decent	
-1201	spoiled small urinal cake	2	crappy	
+1201	small spoiled urinal cake	2	crappy	
 1202	small stale Happy Birthday, Claude! cake	2	decent	
 1203	moldy personalized birthday cake	3	crappy	
 1204	rotten thick three-tiered wedding cake	5	crappy	
-1205	snack-sized spoiled babycakes	2	crappy	
-1206	fancy delicious velvet cake	3	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 10
-1207	normal tiny blinking purple jittery congratulatory cake	1	good	
+1205	spoiled snack-sized babycakes	2	crappy	
+1206	delicious fancy velvet cake	3	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 10
+1207	tiny normal purple jittery blinking congratulatory cake	1	good	
 1208	rotten gigantic maroon skewed angel-food cake	7	crappy	
 1209	flavorless blurry devil's-food cake	3	decent	
 1210	thick rotten birthday party jellybean cheesecake	5	crappy	
@@ -1238,9 +1238,9 @@
 1254	rotten jumping bean burrito	4	crappy	
 1255	rotten small green jumping bean burrito	2	crappy	
 1256	flavorless insanely jumping bean burrito	3	decent	
-1257	small normal rat scrapple	2	good	
+1257	normal small rat scrapple	2	good	
 1258	pail of pretentious paint	0		
-1259	spinning sizzling sinister traffic cone	0		Spell Damage: +10, Hot Damage: +10, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	spinning sizzling sinister traffic cone	0		Spell Damage: +10, Hot Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	yellow wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	powdered Hatorade	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 5
 1262	greasy sage off-hand balloon of incineration	0		Mysticality Percent: +10, Hot Spell Damage: +50, Sleaze Spell Damage: +10
@@ -1257,7 +1257,7 @@
 1273	quilted magic lamp	0		Damage Absorption: +40
 1274	altered bouncing Medicinal Herb's medicinal herbs	1		
 1275	jittery slick basic meat skirt	0		Moxie: +10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	distilled tolerable Otorian Battle Scar	5	good	
+1276	tolerable distilled Otorian Battle Scar	5	good	
 1277	purple spinning Lo Pan's basic meat kilt	0		Spell Critical Percent: +30, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	mirror rosewater-soaked meat skirt	0		Stench Resistance: +3, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	hardy meat kilt	0		Maximum HP: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1282,12 +1282,12 @@
 1298	ring of conflict of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 1299	rosy-cheeked pirate hook	0		Maximum HP Percent: +30
 1300	personal trainer's monster bait	0		Experience Percent (Muscle): +10, Single Equip
-1301	polarized polymerized dry narrow gray deodorant	0		Effect: "In a Lather", Effect Duration: 15
+1301	polarized polymerized dry gray narrow deodorant	0		Effect: "In a Lather", Effect Duration: 15
 1302	deionized reodorant	0		Effect: "Happy Trails", Effect Duration: 32
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	pulsating Samson's traffic cone of chilblains	0		Experience (Muscle): +5, Cold Damage: +25, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	pulsating Samson's traffic cone of chilblains	0		Experience (Muscle): +5, Cold Damage: +25, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	blue blood flower	0		
 1318	wobbly lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	decent half-sized questionable taco	2	good	
+1320	half-sized decent questionable taco	2	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	lime green petrified time	0		Last Available: "2005-10"
-1323	reassuring time helmet	0		Spooky Resistance: +1, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	skewed stiffened time trousers	0		Damage Reduction: 1, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	reassuring time helmet	0		Spooky Resistance: +1, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	skewed stiffened time trousers	0		Damage Reduction: 1, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	green shellacked time sword	0		Damage Reduction: 7, Last Available: "2005-10"
 1326	chaotic Dyspepsi-Cola helmet	0		Spell Critical Percent: +10, Familiar Effect: "3xFairy, cap 7"
 1327	Samson's Cloaca-Cola shield	0		Experience (Muscle): +5, Damage Reduction: 4
@@ -1332,22 +1332,22 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	upside-down 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	clever pinky ring	0		Maximum MP: +20, Single Equip
-1352	bad fortified redrum	5	decent	
+1352	fortified bad redrum	5	decent	
 1353	upside-down ninja pirate zombie robot	0		
 1354	blinking pile of pebbles	0		
 1355	adequate bowl of oriole's nest soup	4	good	
 1356	bunny liver	0		
-1357	practically non-alcoholic hand-crafted mirror Mt. Noob Pale Ale	1	EPIC	
+1357	hand-crafted practically non-alcoholic mirror Mt. Noob Pale Ale	1	EPIC	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	avaricious disembodied smile	0		Meat Drop: +30, Single Equip
-1362	upside-down blurry sausage	0		
+1362	blurry upside-down sausage	0		
 1363	bouncing clockwork pirate skull	0		
 1364	narrow rhesus monkey	0		Familiar Weight: +5
-1365	bite-sized fancy adequate tofurkey leg	1	good	Effect: "The Solution", Effect Duration: 30
+1365	adequate fancy bite-sized tofurkey leg	1	good	Effect: "The Solution", Effect Duration: 30
 1366	flavorless immense yellow tofurkey gravy	10	decent	
-1367	rotten diet olive herbal stuffing	1	crappy	
+1367	diet rotten olive herbal stuffing	1	crappy	
 1368	normal can-shaped gelatinous cranberry sauce	3	good	
 1369	bland yams	3	decent	
 1370	crafty rhinestone cowboy shirt	0		Maximum MP: +10
@@ -1367,7 +1367,7 @@
 1385	stuffing	0		
 1386	felt	0		
 1387	squat block	0		
-1388	skewed huge toy wheel	0		
+1388	huge skewed toy wheel	0		
 1389	yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
@@ -1384,13 +1384,13 @@
 1402	ghostly yellow slick rag doll	0		Moxie: +10, Last Available: "2005-12"
 1403	studded can of fake snow	0		Damage Absorption: +80, Last Available: "2005-12"
 1404	upside-down blinking colored-light &quot;necklace&quot; of the empath	0		Familiar Weight: +5, Last Available: "2005-12"
-1405	manspreader's tree skirt	0		Monster Level: +10, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	manspreader's tree skirt	0		Monster Level: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	gigantic flavorless wreath-shaped Crimbo cookie	6	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	fancy adequate blinking bell-shaped Crimbo cookie	3	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	adequate fancy blinking bell-shaped Crimbo cookie	3	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	rotten tree-shaped Crimbo cookie	3	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of the boozehound	0		Booze Drop: +100, Last Available: "2005-12"
 1410	spinning sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	irradiated snowcone	0		Effect: "Red-Shirted Escort", Effect Duration: 69, Last Available: "2006-01"
 1413	ionized ionized teal snowcone	0		Effect: "Eyes of the Dragon", Effect Duration: 11, Last Available: "2006-01"
 1414	activated aerosolized gray snowcone	0		Effect: "Clean-Shaven", Effect Duration: 31, Last Available: "2006-01"
@@ -1399,22 +1399,22 @@
 1417	aerosolized mirror snowcone	0		Effect: "Grumpy and Ornery", Effect Duration: 32, Last Available: "2006-01"
 1418	pulsating Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	gray teddy bear sewing kit	0		Last Available: "2006-01"
-1420	ghostly resourceful hardened traffic cone	0		Damage Reduction: 3, Maximum MP: +50, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	ghostly resourceful hardened traffic cone	0		Damage Reduction: 3, Maximum MP: +50, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	huge Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	yellow iceberglet	0		Last Available: "2006-02"
 1424	yellow gravedigger's ice sickle of the wise owl	0		Mysticality: +20, Spooky Damage: +10, Softcore Only, Last Available: "2006-02"
 1425	thinker's ice baby	0		Mysticality: +10, Softcore Only, Last Available: "2006-02"
-1426	Newton's ice pick	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	Newton's ice pick	0		Experience (Mysticality): +3, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	auspicious ice skates of the brute	0		Muscle Percent: +30, Item Drop: +10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	moldy half-sized pulsating grue egg omelette	2	crappy	
+1428	half-sized moldy pulsating grue egg omelette	2	crappy	
 1429	roll of drink tickets	0		
 1430	blinking pregnant gloomy mushroom	0		
 1431	narrow pregnant mushroom	0		
 1432	rotten yellow mushroom	4	crappy	
 1433	fruit bowl	0		
 1434	fruit basket	0		
-1435	bouncing ghostly gray hot pink lipstick	0		Familiar Weight: +5
+1435	ghostly gray bouncing hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
 1437	useless powder	0		
 1438	vacuum-sealed nitrogenated pickled twinkly powder	0		Effect: "Human-Demon Hybrid", Effect Duration: 35
@@ -1425,7 +1425,7 @@
 1443	aerosolized cyan sleaze powder	0		Effect: "Frog In Your Throat", Effect Duration: 37
 1444	non-Vulcanized twinkly nuggets	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 23
 1445	frozen ionized upside-down hot nuggets	0		Effect: "Bark of the Dog", Effect Duration: 56
-1446	warmed blue skewed nuggets	0		Effect: "Stemonitis Storm", Effect Duration: 50
+1446	warmed skewed blue nuggets	0		Effect: "Stemonitis Storm", Effect Duration: 50
 1447	warmed adjusted oxidized nuggets	0		Effect: "Disco Nirvana", Effect Duration: 26
 1448	polymerized double-cold-filtered adjusted skewed stench nuggets	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 62
 1449	alkaline corrupted sleaze nuggets	0		Effect: "Oxygenated Blood", Effect Duration: 38
@@ -1437,7 +1437,7 @@
 1455	mixed upside-down sleaze wad	1		
 1456	yellow double daisy	0		
 1457	Goth Giant	0		
-1458	fancy rotten Valentine's Day cake	3	crappy	Effect: "White-boy Angst", Effect Duration: 25
+1458	rotten fancy Valentine's Day cake	3	crappy	Effect: "White-boy Angst", Effect Duration: 25
 1459	arrow'd heart balloon	0		
 1460	upside-down velvet box	0		
 1461	fuchsia squashed frog	0		
@@ -1474,10 +1474,10 @@
 1492	narrow experienced ninja mop	0		Experience: +2
 1493	wobbly Oprah's ridiculously overelaborate ninja weapon of the cougar	0		Moxie: +20, Maximum MP Percent: +50
 1494	magnetized yellow sugar-coated pine cone	0		Effect: "Baconstoned", Effect Duration: 58, Last Available: "2020-09"
-1495	Sherlock's sinister traffic cone	0		Spell Damage: +10, Item Drop: +25, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	watered-down bad gloomy mushroom wine	2	decent	
+1495	Sherlock's sinister traffic cone	0		Spell Damage: +10, Item Drop: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1496	bad watered-down gloomy mushroom wine	2	decent	
 1497	lousy weak mushroom wine	2	decent	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	tumbling fake fake vomit	0		Last Available: "2006-04"
 1501	flattened yellow explosion-flavored chewing gum	0		Effect: "Stinky Hands", Effect Duration: 47, Last Available: "2006-04"
@@ -1503,23 +1503,23 @@
 1522	narrow stanky clever Radio Free Jersey	0		Maximum MP: +20, Stench Spell Damage: +25
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	purple joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	wobbly spinning pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	purple joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	spinning wobbly pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	spinning occult corkscrew of the pedagogue	0		Experience: +3, Spell Damage Percent: +25, Last Available: "2006-04"
 1529	shaking St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	mansplainer's grass skirt	0		Monster Level: +15, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	spinning steel-toed grass hat	0		Damage Reduction: 9, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	mansplainer's grass skirt	0		Monster Level: +15, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	spinning steel-toed grass hat	0		Damage Reduction: 9, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	asbestos-lined grass blade	0		Hot Resistance: +5, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	shaking homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	pulsating weegee sqouija	0		Last Available: "2011-12"
 1538	sparkly engagement ring of the early riser	0		Adventures: +7, Single Equip
 1539	pulsating Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	ribald Grimacite goggles of the sewer	0		Stench Damage: +25, Sleaze Damage: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	ribald Grimacite goggles of the sewer	0		Stench Damage: +25, Sleaze Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	huge Grimacite glaive of the blizzard of temperance	0		Cold Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2008-10"
-1542	twirling narrow Annie Oakley's Van der Graaf Grimacite greaves	0		Critical Hit Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	twirling narrow Annie Oakley's Van der Graaf Grimacite greaves	0		Critical Hit Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	Sinatra's Grimacite garter of the bloodbag	0		Experience (Moxie): +5, Maximum HP: +100, Last Available: "2008-10"
 1544	Grimacite galoshes of Leguizamo of horror	0		Monster Level: +20, Spooky Spell Damage: +25, Last Available: "2008-10"
 1545	hardened wizardly Grimacite gorget	0		Mysticality: +25, Damage Reduction: 3, Last Available: "2008-10"
@@ -1538,29 +1538,29 @@
 1558	rotten tangerine	3	crappy	
 1559	blinking tonic water	0		
 1560	normal miniature cocktail onion	2	good	
-1561	flavorless fancy pulsating raspberry	3	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 30
+1561	fancy flavorless pulsating raspberry	3	decent	Effect: "Extra-Sharp Weapon", Effect Duration: 30
 1562	yummy kiwi	4	awesome	
-1563	fancy drinkable whiskey bittersweet	4	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 45
+1563	drinkable fancy whiskey bittersweet	4	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 45
 1564	artisanal ghostly mimosette	3	EPIC	
-1565	distilled lousy fancy purple tequila sunset	5	decent	Effect: "Pisces in the Skyces", Effect Duration: 15
+1565	fancy distilled lousy purple tequila sunset	5	decent	Effect: "Pisces in the Skyces", Effect Duration: 15
 1566	aged zmobie	4	awesome	Wiki Name: "Zmobie (drink)"
 1567	tolerable wobbly gin and tonic	4	good	
 1568	watered-down bad fuchsia vodka and tonic	2	decent	
 1569	acceptable twirling vodka gibson	3	good	
-1570	hand-crafted strong shaking gibson	5	EPIC	
+1570	strong hand-crafted shaking gibson	5	EPIC	
 1571	lousy parisian cathouse	4	decent	
 1572	lousy rabbit punch	3	decent	
 1573	extra-dry bad caipifruta	5	decent	
 1574	practically non-alcoholic bad jittery teqiwila	1	decent	
 1575	hand-crafted Divine	4	EPIC	
-1576	watered-down perfectly mixed Gordon Bennett	2	super ultra EPIC	
+1576	perfectly mixed watered-down Gordon Bennett	2	super ultra EPIC	
 1577	drinkable tangarita	3	good	
 1578	lousy mandarina colada	3	decent	
-1579	hand-crafted watered-down gimlet	2	super ultra EPIC	
-1580	acceptable practically non-alcoholic brick road	1	good	
-1581	tolerable high-proof vodka stratocaster	10	good	
-1582	weak perfectly mixed Neuromancer	2	super ultra EPIC	
-1583	hand-crafted narrow upside-down prussian cathouse	3	EPIC	
+1579	watered-down hand-crafted gimlet	2	super ultra EPIC	
+1580	practically non-alcoholic acceptable brick road	1	good	
+1581	high-proof tolerable vodka stratocaster	10	good	
+1582	perfectly mixed weak Neuromancer	2	super ultra EPIC	
+1583	hand-crafted upside-down narrow prussian cathouse	3	EPIC	
 1584	hand-crafted weak Mae West	2	super ultra EPIC	
 1585	artisanal jittery Mon Tiki	3	EPIC	
 1586	perfectly mixed tumbling teqiwila slammer	4	EPIC	
@@ -1569,19 +1569,19 @@
 1589	spoiled mirror Knoll lo mein	3	crappy	
 1590	moldy lo mein	3	crappy	
 1591	enchanted rotten jittery olive lo mein	4	crappy	Effect: "Tea-hee", Effect Duration: 30
-1592	normal massive hot hi mein	9	good	
+1592	massive normal hot hi mein	9	good	
 1593	decent hi mein	4	good	
 1594	miniature normal red hi mein	2	good	
-1595	tiny stale lime green hi mein	1	decent	
-1596	stale thick sleazy hi mein	5	decent	
+1595	stale tiny lime green hi mein	1	decent	
+1596	thick stale sleazy hi mein	5	decent	
 1597	upside-down Fonzie's Junior LAAAAME merit badge	0		Experience (Moxie): +1, Last Available: "2006-05"
 1598	blue mansplainer's Senior LAAAAME merit badge	0		Monster Level: +15, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	delicious weak tangarita with a fly in it	2	awesome	
-1601	practically non-alcoholic drinkable special mandarina colada with a fly in it	1	good	Effect: "Cringle's Curative Carol", Effect Duration: 25
-1602	perfectly mixed watered-down prussian cathouse with a fly in it	2	EPIC	
-1603	aged fancy Mae West with a fly in it	4	awesome	Effect: "Morninja", Effect Duration: 50
-1604	dried wobbly spinning astronaut ice-cream	1		Effect: "Very Clean Guns", Effect Duration: 40, Last Available: "2006-05"
+1601	special drinkable practically non-alcoholic mandarina colada with a fly in it	1	good	Effect: "Cringle's Curative Carol", Effect Duration: 25
+1602	watered-down perfectly mixed prussian cathouse with a fly in it	2	EPIC	
+1603	fancy aged Mae West with a fly in it	4	awesome	Effect: "Morninja", Effect Duration: 50
+1604	dried spinning wobbly astronaut ice-cream	1		Effect: "Very Clean Guns", Effect Duration: 40, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	vaporized tumbling ultimate wad	1		
 1607	frozen galvanized pressed upside-down bouncing libation of liveliness	0		Effect: "Using Protection", Effect Duration: 19
@@ -1592,8 +1592,8 @@
 1612	dry galvanized concentrated cordial of concentration	0		Effect: "It Didn't Kill You", Effect Duration: 23
 1613	jittery double-paned coffin lid	0		Cold Resistance: +5, Damage Reduction: 3
 1614	blurry frosty satin shield	0		Cold Spell Damage: +10, Damage Reduction: 5
-1615	gray Van der Graaf Cerebral Cloche	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	curative Cerebral Culottes	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	gray Van der Graaf Cerebral Cloche	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	curative Cerebral Culottes	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	reassuring Newton's Cerebral Crossbow of the businessman	0		Experience (Mysticality): +3, Spooky Resistance: +1, Meat Drop: +50, Last Available: "2006-06"
 1618	twirling ice stein	0		Last Available: "2006-06"
 1619	shaking munchies pill	0		Last Available: "2006-06"
@@ -1601,7 +1601,7 @@
 1621	teal astral badger	0		Free Pull, Last Available: "2006-06"
 1622	colloidal squat astral mushroom	0		Effect: "Adventurer's Best Friendship", Effect Duration: 23, Last Available: "2006-06"
 1623	squat badger badge	0		Last Available: "2006-06"
-1624	modified upside-down yellow blue-frosted astral cupcake	0		Effect: "All Glory To the Toad", Effect Duration: 21, Last Available: "2006-06"
+1624	modified yellow upside-down blue-frosted astral cupcake	0		Effect: "All Glory To the Toad", Effect Duration: 21, Last Available: "2006-06"
 1625	energized double-enhanced green-frosted astral cupcake	0		Effect: "All Branned Up", Effect Duration: 38, Last Available: "2006-06"
 1626	improved orange-frosted astral cupcake	0		Effect: "Shawarma Warm War", Effect Duration: 61, Last Available: "2006-06"
 1627	activated purple-frosted astral cupcake	0		Effect: "Flambé-a-thon", Effect Duration: 65, Last Available: "2006-06"
@@ -1614,12 +1614,12 @@
 1634	artisanal blurry around the world	4	EPIC	
 1635	bouncing scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
-1637	polarized quantum mirror lime green lotion of hotness	0		Effect: "Smelly Pants", Effect Duration: 24
+1637	polarized quantum lime green mirror lotion of hotness	0		Effect: "Smelly Pants", Effect Duration: 24
 1638	warmed lotion of coldness	0		Effect: "Tomato Power", Effect Duration: 21
 1639	ionized wet ghostly lotion of spookiness	0		Effect: "Adrenaline Rush", Effect Duration: 35
 1640	quadruple-colloidal dry lotion of stench	0		Effect: "20/20 Vision", Effect Duration: 45
 1641	ionized upside-down lotion of sleaziness	0		Effect: "Wit Tea", Effect Duration: 65
-1642	mediocre weak red Grimacite Bock	2	decent	Last Available: "2008-11"
+1642	weak mediocre red Grimacite Bock	2	decent	Last Available: "2008-11"
 1643	adequate wedge of gray cheese	3	good	Last Available: "2008-11"
 1644	jittery hot and sauce	0		
 1645	upside-down and sauce	0		
@@ -1627,10 +1627,10 @@
 1647	stench and sauce	0		
 1648	purple sleazy and sauce	0		
 1649	skewed brick	0		Free Pull
-1650	maroon shaking milk of magnesium	0		
-1651	super-sized rotten foie gras	5	crappy	
+1650	shaking maroon milk of magnesium	0		
+1651	rotten super-sized foie gras	5	crappy	
 1652	vacuum-sealed chilled chilled candy brain	0		Effect: "Infernal Thirst", Effect Duration: 26, Last Available: "2020-09"
-1653	pulsating blue stanky scorching shellacked jewel-eyed wizard hat	0		Damage Reduction: 7, Hot Damage: +25, Stench Spell Damage: +25, Softcore Only, Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	pulsating blue stanky scorching shellacked jewel-eyed wizard hat	0		Damage Reduction: 7, Hot Damage: +25, Stench Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	lightning-fast toasty wad of Crovacite	0		Hot Damage: +5, Initiative: +40
 1655	arcane researcher's stylish collar	0		Moxie: +25, Experience Percent (Mysticality): +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1669,11 +1669,11 @@
 1689	ribbon of the scaredy-cat	0		Monster Level: -15, Last Available: "2006-07"
 1690	bouncing clever discarded bottlecap of the pedagogue	0		Experience: +3, Maximum MP: +20, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	frightening veiny discarded torn-up glove	0		Maximum HP: +10, Spooky Damage: +5, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	pickled skewed wobbly salamander slurry	0		Effect: "Third Based", Effect Duration: 45
+1692	pickled wobbly skewed salamander slurry	0		Effect: "Third Based", Effect Duration: 45
 1693	ionized eyedrops of newt	0		Effect: "The Real Deal", Effect Duration: 16
 1694	corrupted magnetized Frogade	0		Effect: "Celestial Vision", Effect Duration: 67
 1695	oxidized papotion of papower	0		Effect: "Petit Forbearance", Effect Duration: 22
-1696	super-sized moldy royal jelly taco	5	crappy	
+1696	moldy super-sized royal jelly taco	5	crappy	
 1697	diet decent fancy tofu taco	1	good	Effect: "Gemini Rising", Effect Duration: 45
 1698	rotten red jumping bean taco	4	crappy	
 1699	normal blurry gray catgut taco	3	good	
@@ -1759,16 +1759,16 @@
 1780	ram stick of Tarzan	0		Experience (Muscle): +3
 1781	enchantlers of the brute	0		Muscle Percent: +30, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	upside-down pulsating frosty brainy ram-battering staff	0		Mysticality: +5, Cold Spell Damage: +10
-1783	moldy half-sized crazy Turkish delight	2	crappy	
+1783	half-sized moldy crazy Turkish delight	2	crappy	
 1784	shaking aromatic Snow Queen Crown of extreme caution	0		Monster Level: -25, Stench Resistance: +1, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	Jack Frost's ga-ga radio of the cougar of the bloodbag	0		Moxie: +20, Maximum HP: +100, Cold Spell Damage: +50
 1786	green six pack of Mountain Stream	0		
 1787	denatured quadruple-tarnished wobbly bag of Cheat-Os	0		Effect: "Concentrated Concentration", Effect Duration: 44
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	drinkable triple-distilled Ram's Face Lager	6	good	
+1790	triple-distilled drinkable Ram's Face Lager	6	good	
 1791	ram horns	0		
-1792	rock-hard dangerous slick Travoltan trousers	0		Moxie: +10, Weapon Damage: +10, Damage Reduction: 5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	rock-hard dangerous slick Travoltan trousers	0		Moxie: +10, Weapon Damage: +10, Damage Reduction: 5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	spinning Usain Bolt's curative pool cue	0		Initiative: +80, HP Regen Min: 3, HP Regen Max: 5
 1794	galvanized handful of hand chalk	0		Effect: "Innately Strong", Effect Duration: 52
 1795	stanky Counterclockwise Watch	0		Stench Spell Damage: +25, Single Equip
@@ -1781,7 +1781,7 @@
 1802	first cervical vertebra	0		
 1803	second cervical vertebra	0		
 1804	jittery third cervical vertebra	0		
-1805	huge ghostly fourth cervical vertebra	0		
+1805	ghostly huge fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	blinking seventh cervical vertebra	0		
@@ -1825,10 +1825,10 @@
 1846	left eighth rib	0		
 1847	mirror left ninth rib	0		
 1848	left tenth rib	0		
-1849	lime green narrow left eleventh rib	0		
+1849	narrow lime green left eleventh rib	0		
 1850	left twelfth rib	0		
 1851	squat right first rib	0		
-1852	narrow cyan right second rib	0		
+1852	cyan narrow right second rib	0		
 1853	right third rib	0		
 1854	right fourth rib	0		
 1855	right fifth rib	0		
@@ -1845,7 +1845,7 @@
 1866	shaking left clavicle	0		
 1867	spinning right clavicle	0		
 1868	left humerus	0		
-1869	blinking blurry right humerus	0		
+1869	blurry blinking right humerus	0		
 1870	left radius	0		
 1871	right radius	0		
 1872	left ulna	0		
@@ -1899,8 +1899,8 @@
 1922	bouncing gob of wet hair	0		
 1923	jittery roll of toilet paper	0		Free Pull
 1924	tattered wolf standard	0		
-1925	tumbling bouncing tattered snake standard	0		
-1926	huge jittery KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1925	bouncing tumbling tattered snake standard	0		
+1926	jittery huge KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	bouncing scary death orb	0		
 1928	tuning fork	0		
 1929	greaves of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xBarrr"
@@ -1926,8 +1926,8 @@
 1949	yummy Manetwich	3	awesome	
 1950	twirling bottle of Vangoghbitussin	0		
 1951	extra-dry acceptable purple bottle of Pinot Renoir	5	good	
-1952	rotten gray mirror desiccated apricot	3	crappy	
-1953	acceptable triple-distilled flute of flat champagne	8	good	
+1952	rotten mirror gray desiccated apricot	3	crappy	
+1953	triple-distilled acceptable flute of flat champagne	8	good	
 1954	huge decent blinking dehydrated caviar	10	good	
 1955	skewed styrofoam peanuts	0		
 1956	hand-crafted purple snifter of thoroughly aged brandy	4	EPIC	
@@ -1953,7 +1953,7 @@
 1976	gravy fairy	0		
 1977	green gravy fairy	0		
 1978	gravy fairy	0		
-1979	shaking mirror gravy fairy	0		
+1979	mirror shaking gravy fairy	0		
 1980	twirling sleazy gravy fairy	0		
 1981	astral badger	0		
 1982	MagiMechTech MicroMechaMech	0		
@@ -1996,12 +1996,12 @@
 2019	cream pie	0		Free Pull
 2020	rotten cherry pie	4	crappy	
 2021	adequate strawberry pie	3	good	
-2022	normal half-sized wobbly lemon meringue pie	2	good	
+2022	half-sized normal wobbly lemon meringue pie	2	good	
 2023	fuchsia Genalen&trade; Bottle	1	good	
 2024	delicious huge mixed wildflower greens	3	awesome	
-2025	flavorless miniature handful of walnuts	2	decent	
+2025	miniature flavorless handful of walnuts	2	decent	
 2026	moldy green nutty organic salad	4	crappy	
-2027	bite-sized adequate super salad	1	good	
+2027	adequate bite-sized super salad	1	good	
 2028	adequate tofu wonton	3	good	
 2029	blinking hippy protest button	0		Single Equip
 2030	avaricious Oprah's Lockenstock&trade; sandals	0		Maximum MP Percent: +50, Meat Drop: +30, Single Equip
@@ -2017,12 +2017,12 @@
 2040	jittery patchouli oil bomb	0		
 2041	ferret bait	0		
 2042	ghostly exploding hacky-sack	0		
-2043	blurry narrow hemp net	0		
+2043	narrow blurry hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	decent brain-meltingly-hot chicken wings	4	good	
 2046	stale cyan frat brats	4	decent	
-2047	stale big knob ka-bobs	5	decent	
-2049	spirit-forward hand-crafted pulsating can of Swiller	5	EPIC	
+2047	big stale knob ka-bobs	5	decent	
+2049	hand-crafted spirit-forward pulsating can of Swiller	5	EPIC	
 2050	broken wings	0		
 2051	squat sunken eyes	0		
 2052	wobbly reassembled blackbird	0		
@@ -2057,19 +2057,19 @@
 2081	gray frightening makeshift skirt	0		Spooky Damage: +5, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 2082	teal toothbrush	0		
 2083	upside-down makeshift crane	0		
-2084	upside-down lime green can of starch	0		
+2084	lime green upside-down can of starch	0		
 2085	mixed mirror upside-down bottle of ultravitamins	1		
 2086	powdered bottle of cough syrup	1		
 2087	vaporized skewed tube of hair oil	1		
 2088	flattened Daffy Taffy	0		Effect: "Really Deep Breath", Effect Duration: 36
-2089	spinning red Crimboween memo	0		Last Available: "2006-10"
+2089	red spinning Crimboween memo	0		Last Available: "2006-10"
 2090	maroon censurious family-friendly electrified sinister pilgrim shield of mayonnaise	0		Spell Damage: +10, Sleaze Spell Damage: +50, Sleaze Resistance: 4, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	skewed bath salts	0		
 2092	hand mirror	0		
 2093	teal squat razor-sharp hors d'oeuvre tray	0		Weapon Damage Percent: +25, Damage Reduction: 5
 2094	rotten ballroom blintz	3	crappy	
 2095	towel	0		
-2096	twisted shaking lime green guy made of bee pollen	1		
+2096	twisted lime green shaking guy made of bee pollen	1		
 2097	17-ball of the dark arts	0		Spell Damage Percent: +100
 2098	mirror filthy lucre	0		
 2099	squat hobo gristle	0		
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	blinking strapping prehistoric spear	0		Muscle: +5, Last Available: "2006-12"
 2116	squat stick-on-a-string	0		Last Available: "2006-12"
-2117	miser's fire of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	miser's fire of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	chilly Grateful Undead T-shirt	0		Cold Damage: +5
@@ -2127,7 +2127,7 @@
 2152	purple capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
-2155	huge cyan Feynman gate	0		Last Available: "2011-12"
+2155	cyan huge Feynman gate	0		Last Available: "2011-12"
 2156	skewed logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	teal servomechanical torsion facilitator	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	upside-down maroon hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	skewed toy ray gun of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: +50, Last Available: "2006-12"
-2169	ghostly family-friendly reassuring toy space helmet	0		Spooky Resistance: +1, Sleaze Resistance: +1, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	ghostly family-friendly reassuring toy space helmet	0		Spooky Resistance: +1, Sleaze Resistance: +1, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	tumbling Jeselnik's astronaut pants of temperance	0		Sleaze Damage: +25, Sleaze Resistance: +5, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	tumbling Jeselnik's astronaut pants of temperance	0		Sleaze Damage: +25, Sleaze Resistance: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	stylish toy jet pack	0		Moxie: +25, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,13 +2161,13 @@
 2186	unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	fancy cyan flask of peppermint oil	1	good	Effect: "Amorous Avarice", Effect Duration: 15, Last Available: "2006-12"
-2189	weak perfectly mixed shaking flask of peppermint schnapps	2	EPIC	Last Available: "2006-12"
-2190	twirling narrow yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
+2189	perfectly mixed weak shaking flask of peppermint schnapps	2	EPIC	Last Available: "2006-12"
+2190	narrow twirling yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	spinning book of carols	0		Last Available: "2006-12"
 2192	wobbly sheet music	0		Last Available: "2006-12"
 2193	half-sized spoiled candy stake	2	crappy	Last Available: "2006-12"
-2194	mediocre watered-down eggnog	2	decent	Last Available: "2006-12"
-2195	toothsome diet unspeakable fruitcake	1	awesome	Last Available: "2006-12"
+2194	watered-down mediocre eggnog	2	decent	Last Available: "2006-12"
+2195	diet toothsome unspeakable fruitcake	1	awesome	Last Available: "2006-12"
 2196	bland squat gingerbread horror	3	decent	Last Available: "2006-12"
 2197	ionized but probably evil chocolate	0		Effect: "Gemini Rising", Effect Duration: 29, Last Available: "2006-12"
 2198	toothsome huge twirling bat-shaped Crimboween cookie	10	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
@@ -2182,25 +2182,25 @@
 2207	upside-down Temple Grandin's Crimbo tiki necklace	0		Familiar Weight: +7, Last Available: "2006-12"
 2208	tumbling olive lard-coated Samson's bobble-hip hula elf doll	0		Experience (Muscle): +5, Sleaze Spell Damage: +25, Last Available: "2006-12"
 2209	Rosewater's Crimbo ukulele	0		Mysticality Percent: +30, Last Available: "2006-12"
-2210	olive dog trainer's shellacked Tiki lighter	0		Damage Reduction: 7, Experience (familiar): +1, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	mirror MacGyver's deck of tropical cards of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	stanky smooth tropical paperweight	0		Moxie: +15, Stench Spell Damage: +25, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	olive dog trainer's shellacked Tiki lighter	0		Damage Reduction: 7, Experience (familiar): +1, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	mirror MacGyver's deck of tropical cards of Tarzan	0		Experience (Muscle): +3, Maximum MP: +100, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	stanky smooth tropical paperweight	0		Moxie: +15, Stench Spell Damage: +25, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	purple fireproof Tropical Crimbo Hat	0		Hot Resistance: +3, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	twirling Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
-2217	flavorless half-sized blurry super ka-bob	2	decent	
-2218	small moldy beer basted brat	2	crappy	
+2215	purple fireproof Tropical Crimbo Hat	0		Hot Resistance: +3, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	twirling Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2217	half-sized flavorless blurry super ka-bob	2	decent	
+2218	moldy small beer basted brat	2	crappy	
 2219	smooth Tropical Crimbo Sword	0		Moxie: +15, Last Available: "2006-12"
 2220	dry chilled and Crimboween candy	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 69, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	frightening sinister liar's pants	0		Spell Damage: +10, Spooky Damage: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	frightening sinister liar's pants	0		Spell Damage: +10, Spooky Damage: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	squat executive occult juggler's balls	0		Spell Damage Percent: +25, Meat Drop: +40, Softcore Only, Last Available: "2007-01"
 2224	ghostly scorching pink shirt	0		Hot Damage: +25, Softcore Only, Last Available: "2007-01"
 2225	teal familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	Sinatra's Fonzie's evil eyeball pendant	0		Experience (Moxie): 6, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	quadruple-alkaline polymerized wobbly arse-a'fire elixir	0		Effect: "Oleaginous Soles", Effect Duration: 54, Last Available: "2007-01"
-2228	alkaline bouncing upside-down cosmic lemonade	0		Effect: "Seeing Colors", Effect Duration: 68, Last Available: "2007-01"
+2228	alkaline upside-down bouncing cosmic lemonade	0		Effect: "Seeing Colors", Effect Duration: 68, Last Available: "2007-01"
 2229	extra-anodized super-enhanced toad horn	0		Effect: "damage.enh", Effect Duration: 13, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	mote	0		
@@ -2240,14 +2240,14 @@
 2266	wet stunt nut stew	0		
 2267	red Mega Gem	0		
 2268	twirling gray shellacked Staff of Fats	0		Damage Reduction: 7
-2269	super-sized decent fancy sausage wonton	5	good	Effect: "Hair on Your Chest", Effect Duration: 20
+2269	fancy decent super-sized sausage wonton	5	good	Effect: "Hair on Your Chest", Effect Duration: 20
 2270	shellacked belt of the wise owl	0		Mysticality: +20, Damage Reduction: 7, Single Equip
 2271	artisanal bottle of Merlot	3	EPIC	
 2272	bad extra-dry bottle of Port	5	decent	
-2273	bad fancy cyan bottle of Pinot Noir	3	decent	Effect: "Kernel Panic!", Effect Duration: 45
+2273	fancy bad cyan bottle of Pinot Noir	3	decent	Effect: "Kernel Panic!", Effect Duration: 45
 2274	acceptable bottle of Zinfandel	3	good	
 2275	delicious bottle of Marsala	3	awesome	
-2276	triple-distilled hand-crafted bottle of Muscat	8	EPIC	
+2276	hand-crafted triple-distilled bottle of Muscat	8	EPIC	
 2277	Fernswarthy's key	0		
 2278	huge Fernswarthy's letter	0		
 2279	book	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	lime green Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	yellow Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	galvanized frozen candy heart	0		Effect: "Gobliny Flavor", Effect Duration: 17, Last Available: "2007-02"
 2305	deionized double-oxidized yellow skewed pink candy heart	0		Effect: "Heart of Green", Effect Duration: 30, Last Available: "2007-02"
 2306	extra-pressed candy heart	0		Effect: "Elemental Flavor", Effect Duration: 34, Last Available: "2007-02"
@@ -2351,7 +2351,7 @@
 2377	drinkable tumbling bungle in the jungle	3	good	
 2378	banana spritzer	0		
 2379	chilled corrupted banana smoothie	0		Effect: "familiar.enq", Effect Duration: 69
-2380	mirror ghostly dandy lion cub	0		Free Pull, Last Available: "2007-03"
+2380	ghostly mirror dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	tumbling woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	blurry class ring	0		
@@ -2419,7 +2419,7 @@
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	mirror hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
-2448	wobbly huge tasteful bow tie	0		Familiar Weight: +5
+2448	huge wobbly tasteful bow tie	0		Familiar Weight: +5
 2449	jittery six-pack of New Cloaca-Cola	0		
 2450	huge empty Cloaca-Cola bottle	0		
 2451	bouncing dangerous goatskin umbrella	0		Weapon Damage: +10
@@ -2434,8 +2434,8 @@
 2460	shaking smelly yak toupee	0		Stench Spell Damage: +10, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	fancy flavorless wobbly bowl of Bounty-Os	4	decent	Effect: "Favored by Lyle", Effect Duration: 30
-2465	practically non-alcoholic bad shaking Oreille Divis&eacute;e brandy	1	decent	
+2464	flavorless fancy wobbly bowl of Bounty-Os	4	decent	Effect: "Favored by Lyle", Effect Duration: 30
+2465	bad practically non-alcoholic shaking Oreille Divis&eacute;e brandy	1	decent	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	huge callused fingerbone	0		
@@ -2470,14 +2470,14 @@
 2497	molybdenum magnet	0		
 2498	spinning molybdenum hammer	0		
 2499	skewed molybdenum screwdriver	0		
-2500	bouncing ghostly molybdenum pliers	0		
+2500	ghostly bouncing molybdenum pliers	0		
 2501	blue molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
 2504	purple precious piercing post	0		
 2505	necklace chain	0		
 2506	tumbling beach glass bead	0		
-2507	huge shaking clay peace-sign bead	0		
+2507	shaking huge clay peace-sign bead	0		
 2508	beach glass necklace of the ox	0		Muscle: +20
 2509	forbidden peace-sign necklace	0		Spell Damage Percent: +50
 2510	smartaleck's round sunglasses of the storm	0		Moxie Percent: +30, Maximum MP Percent: +40, Single Equip
@@ -2489,21 +2489,21 @@
 2516	twirling gravedigger's wrench bracelet of chilblains	0		Cold Damage: +25, Spooky Damage: +10
 2517	chain necklace of the brute of chilblains	0		Muscle Percent: +30, Cold Damage: +25
 2518	asbestos-lined sawblade shield	0		Hot Resistance: +5, Damage Reduction: 11
-2519	bad distilled McMillicancuddy's Special Lager	5	decent	
+2519	distilled bad McMillicancuddy's Special Lager	5	decent	
 2520	mediocre melted Jell-o shot	3	decent	
 2521	bad cruelty-free wine	3	decent	
 2522	acceptable thistle wine	4	good	
 2523	megatofu	0		
 2524	jittery displaced fish	0		
 2525	bite-sized flavorless fish	1	decent	
-2526	big moldy fish casserole	5	crappy	
+2526	moldy big fish casserole	5	crappy	
 2527	normal ghostly fish lasagna	4	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	jumbo rotten mirror blurry gnatloaf	5	crappy	
-2530	jumbo moldy gnatloaf casserole	5	crappy	
+2529	rotten jumbo mirror blurry gnatloaf	5	crappy	
+2530	moldy jumbo gnatloaf casserole	5	crappy	
 2531	yummy gnat lasagna	3	awesome	
 2532	spinning pork	0		
-2533	moldy fancy teal pork chop sandwiches	3	crappy	Effect: "Human-Machine Hybrid", Effect Duration: 30
+2533	fancy moldy teal pork chop sandwiches	3	crappy	Effect: "Human-Machine Hybrid", Effect Duration: 30
 2534	toothsome huge pork casserole	6	awesome	
 2535	stale massive pork lasagna	9	decent	
 2536	spinning canopic jar	0		
@@ -2513,12 +2513,12 @@
 2540	pulsating tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	ionized double-ionized lesser grodulated violet	0		Effect: "Chain Chain Chains", Effect Duration: 65, Last Available: "2007-05"
-2543	oxidized ionized purple upside-down narrow tin magnolia	0		Effect: "Trash-Wrapped", Effect Duration: 45, Last Available: "2007-05"
+2543	oxidized ionized purple narrow upside-down tin magnolia	0		Effect: "Trash-Wrapped", Effect Duration: 45, Last Available: "2007-05"
 2544	extra-diffused liquefied quadruple-concentrated lime green skewed begpwnia	0		Effect: "Starry-Eyed", Effect Duration: 54, Last Available: "2007-05"
 2545	ionized modified upside-down pulsating upsy daisy	0		Effect: "Abominably Slippery", Effect Duration: 35, Last Available: "2007-05"
 2546	polymerized shaking tumbling green half-orchid	0		Effect: "Items Are Forever", Effect Duration: 44, Last Available: "2007-05"
 2547	auspicious electrified tin star	0		Item Drop: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-05"
-2548	quilted extremely unsafe outrageous sombrero	0		Weapon Damage Percent: +100, Damage Absorption: +40, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	quilted extremely unsafe outrageous sombrero	0		Weapon Damage Percent: +100, Damage Absorption: +40, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	tumbling sinister &quot;Humorous&quot; T-shirt of James Dean	0		Experience (Moxie): +3, Spell Damage: +10, Last Available: "2007-05"
 2550	bouncing Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2585,12 +2585,12 @@
 2612	fuchsia vinyl coin purse	0		
 2613	pulsating rocky raccoon	0		
 2614	squat mojo filter	0		
-2615	spoiled jumbo fancy bouncing savoy truffle	5	crappy	Effect: "Loyal Tea", Effect Duration: 35
+2615	fancy spoiled jumbo bouncing savoy truffle	5	crappy	Effect: "Loyal Tea", Effect Duration: 35
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	quilted Iiti Kitty phone charm	0		Damage Absorption: +40, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	bland gigantic unidentified jerky	6	decent	
+2620	gigantic bland unidentified jerky	6	decent	
 2621	jittery MacGyver's nasty rat mask of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	twirling boxer's smooth ratskin belt	0		Moxie: +15, Muscle Percent: +10, Single Equip
 2623	inspector's scandalous rattail whip	0		Sleaze Damage: +5, Item Drop: +15
@@ -2622,18 +2622,18 @@
 2649	Lord Spookyraven's ear trumpet of Tarzan	0		Experience (Muscle): +3, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	purple pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	snack-sized moldy mirror S.T.L.T.	2	crappy	Last Available: "2007-06"
+2652	moldy snack-sized mirror S.T.L.T.	2	crappy	Last Available: "2007-06"
 2653	adequate honey-dew	3	good	Last Available: "2007-06"
 2654	tolerable watered-down blurry Xanadian	2	good	Last Available: "2007-06"
 2655	dry boiled pulsating bottle of absinthe	0		Effect: "Strawberry Alarm", Effect Duration: 64, Last Available: "2007-06"
 2656	gravedigger's Drowsy Sword of the scaredy-cat	0		Monster Level: -15, Spooky Damage: +10
-2657	bite-sized flavorless escargotsicle	1	decent	Last Available: "2007-06"
-2658	mediocre triple-distilled bottle of realpagne	9	decent	Last Available: "2007-06"
+2657	flavorless bite-sized escargotsicle	1	decent	Last Available: "2007-06"
+2658	triple-distilled mediocre bottle of realpagne	9	decent	Last Available: "2007-06"
 2659	albatross necklace of the glutton	0		Food Drop: +100, Single Equip, Last Available: "2007-06"
 2660	dehydrated blinking wobbly not-a-pipe	1	decent	Last Available: "2007-06"
-2661	perfectly mixed spinning skewed flask of Amontillado	4	EPIC	Last Available: "2007-06"
-2662	sinister ball mask	0		Spell Damage: +10, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	wobbly Can-Can skirt of Flo-Jo	0		Initiative: +100, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2661	perfectly mixed skewed spinning flask of Amontillado	4	EPIC	Last Available: "2007-06"
+2662	sinister ball mask	0		Spell Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	wobbly Can-Can skirt of Flo-Jo	0		Initiative: +100, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	colloidal concentrated wobbly sensitive poetry journal	0		Effect: "Memory of Strength", Effect Duration: 39, Last Available: "2007-06"
 2665	enhanced non-concentrated magnetized wobbly bottled inspiration	0		Effect: "Okee-Dokee Computer", Effect Duration: 51, Last Available: "2007-06"
 2666	double-irradiated bellhop bell	0		Effect: "Human-Plant Hybrid", Effect Duration: 13, Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	mixed spinning can-can-in-a-can	1		Last Available: "2007-06"
 2669	altered blinking patent antipsychotics	1		Effect: "Winklered", Effect Duration: 15, Last Available: "2007-06"
 2670	dried spinning Mariner's Friend cough drops	1		Effect: "Lemony Goodness", Effect Duration: 45, Last Available: "2007-06"
-2671	watered-down bad shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
+2671	bad watered-down shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	nitrogenated corrupted tarnished bottle of cat tonic	0		Effect: "The Magic of LOV", Effect Duration: 37, Last Available: "2007-06"
@@ -2649,7 +2649,7 @@
 2676	altered bit-o-cactus	1		
 2677	dehydrated maroon protein powder	1		Effect: "Heart of Green", Effect Duration: 40
 2678	spectre scepter	0		
-2679	diffused alkaline magnetized mirror teal sparkler	0		Effect: "Ruby-ous", Effect Duration: 54
+2679	diffused alkaline magnetized teal mirror sparkler	0		Effect: "Ruby-ous", Effect Duration: 54
 2680	activated extra-altered upside-down snake	0		Effect: "Waxing", Effect Duration: 46, Wiki Name: "snake"
 2681	anodized M-242	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 60
 2682	pulsating detuned radio	0		
@@ -2657,7 +2657,7 @@
 2684	aromatic armgun of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1
 2685	seashell necklace	0		
 2686	red commemorative war stein	0		
-2687	pulsating blurry red stone frisbee	0		
+2687	pulsating red blurry stone frisbee	0		
 2688	dangerous Newton's dreadlock whip of Gandalf	0		Experience (Mysticality): +3, Weapon Damage: +10, Spell Critical Percent: +20
 2689	manspreader's razor-sharp beer-a-pult	0		Weapon Damage Percent: +25, Monster Level: +10
 2690	Sherlock's stylish cast-iron legacy paddle	0		Moxie: +25, Item Drop: +25
@@ -2684,7 +2684,7 @@
 2711	colloidal diffused pulsating facepaint	0		Effect: "No Vertigo", Effect Duration: 28
 2712	activated extra-unsweetened ghostly sheepskin diploma	0		Effect: "Marinated", Effect Duration: 46
 2713	dry yellow Black Body&trade; spray	0		Effect: "One Very Clear Eye", Effect Duration: 51
-2714	huge ghostly floorboard cruft	0		
+2714	ghostly huge floorboard cruft	0		
 2715	wobbly sausage bomb	0		
 2716	therapeutic healthy battered hubcap of Gandalf	0		Maximum HP Percent: +20, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 14
 2717	spinning twirling Newton's strapping hood ornament of the cheetah	0		Muscle: +5, Experience (Mysticality): +3, Initiative: +60
@@ -2694,26 +2694,26 @@
 2721	huge huge aromatic hand-carved staff of doom	0		Spooky Spell Damage: +50, Stench Resistance: +1, Item Drop: +5
 2722	toasty manspreader's stiffened Rosewater's Staff of the Greasefire	0		Mysticality Percent: +30, Damage Reduction: 1, Monster Level: +10, Hot Damage: +5
 2723	family-friendly MacGyver's wholesome Staff of the Grand Flamb&eacute;	0		Maximum HP Percent: +10, Maximum MP: +100, Sleaze Resistance: +1
-2724	small tasty bowl of rye sprouts	2	awesome	
+2724	tasty small bowl of rye sprouts	2	awesome	
 2725	low-calorie flavorless cob of corn	1	decent	
-2726	miniature normal juniper berries	2	good	
-2727	flavorless thick blurry plum	5	decent	
+2726	normal miniature juniper berries	2	good	
+2727	thick flavorless blurry plum	5	decent	
 2728	moldy pear	3	crappy	
-2729	bland jumbo bouncing peach	5	decent	
+2729	jumbo bland bouncing peach	5	decent	
 2730	bad practically non-alcoholic wobbly plum wine	1	decent	
-2731	strong acceptable shot of pear schnapps	5	good	
+2731	acceptable strong shot of pear schnapps	5	good	
 2732	drinkable upside-down shot of peach schnapps	4	good	
 2733	flavorless enchanted gigantic wobbly blue bunch of square grapes	9	decent	Effect: "Stinky Weapon", Effect Duration: 50
-2734	spoiled miniature brown sugar cane	2	crappy	
+2734	miniature spoiled brown sugar cane	2	crappy	
 2735	miniature decent sandwich of the gods	2	good	
 2736	acceptable Pan-Dimensional Gargle Blaster	3	good	
-2737	vaporized tumbling shaking leopard-print barbell	1	awesome	Effect: "Purpose", Effect Duration: 50
+2737	vaporized shaking tumbling leopard-print barbell	1	awesome	Effect: "Purpose", Effect Duration: 50
 2738	pile of smoking rags	0		
 2739	warmed magnetized panty raider camouflage	0		Effect: "Bat Attitude", Effect Duration: 14
 2740	spinning Samson's brainy Staff of the Walk-In Freezer	0		Mysticality: +5, Experience (Muscle): +5, Item Drop: +5
-2741	lousy high-proof boilermaker	10	decent	
-2742	moldy narrow spinning steel lasagna	4	quest	
-2743	bad practically non-alcoholic jittery steel margarita	1	quest	
+2741	high-proof lousy boilermaker	10	decent	
+2742	moldy spinning narrow steel lasagna	4	quest	
+2743	practically non-alcoholic bad jittery steel margarita	1	quest	
 2744	vaporized steel-scented air freshener	1		Effect: "Human-Undead Hybrid", Effect Duration: 30
 2745	diffused upside-down mirror gremlin mutagen	0		Effect: "Polar Express", Effect Duration: 41
 2746	ionized extra-potent gremlin mutagen	0		Effect: "Spooky Flavor", Effect Duration: 47
@@ -2739,7 +2739,7 @@
 2766	bowling ball	0		
 2767	miniature flavorless Crimbo pie	2	decent	
 2768	normal thick blinking skewed pear tart	5	good	
-2769	super-sized rotten peach pie	5	crappy	
+2769	rotten super-sized peach pie	5	crappy	
 2770	galvanized chunk of rock salt	0		Effect: "Sweet and Green", Effect Duration: 56
 2771	improved galvanized handful of pine needles	0		Effect: "Healthy Blue Glow", Effect Duration: 47
 2772	steamy ruby	0		
@@ -2789,9 +2789,9 @@
 2816	ruddy occult sinister Boxers	0		Spell Damage: +10, Spell Damage Percent: +25, Maximum HP Percent: +40, Familiar Effect: "1xVolley, 1xLep"
 2817	reassuring coward's Brooch of Gandalf	0		Spell Critical Percent: +20, Monster Level: -20, Spooky Resistance: +1, Single Equip
 2818	executive Jeselnik's Rosewater's Bracelet	0		Mysticality Percent: +30, Sleaze Damage: +25, Meat Drop: +40, Single Equip
-2819	twirling double-paned Grimacite gasmask of temperance	0		Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	twirling double-paned Grimacite gasmask of temperance	0		Cold Resistance: +5, Sleaze Resistance: +5, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	forbidden cool Grimacite gat	0		Moxie: +5, Spell Damage Percent: +50, Last Available: "2008-11"
-2821	olive nasty energetic Grimacite gaiters	0		Maximum MP Percent: +20, Stench Damage: +5, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	olive nasty energetic Grimacite gaiters	0		Maximum MP Percent: +20, Stench Damage: +5, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	bouncing Tesla occult Grimacite gauntlets	0		Spell Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2008-11"
 2823	Grimacite go-go boots of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25, Single Equip, Last Available: "2008-11"
 2824	red Grimacite girdle of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Single Equip, Last Available: "2008-11"
@@ -2804,7 +2804,7 @@
 2831	gray star key lime	0		
 2832	moldy fancy spinning digital key lime pie	4	crappy	Effect: "Phairly Balanced", Effect Duration: 10
 2833	flavorless star key lime pie	4	decent	
-2834	Jeselnik's dog trainer's bottle-rocket crossbow of Leguizamo	0		Monster Level: +20, Experience (familiar): +1, Sleaze Damage: +25, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	Jeselnik's dog trainer's bottle-rocket crossbow of Leguizamo	0		Monster Level: +20, Experience (familiar): +1, Sleaze Damage: +25, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	bouncing skewed weightlifter's indie comic hipster glasses	0		Muscle: +15, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	olive mint-condition magic wand	0		Last Available: "2011-12"
@@ -2820,7 +2820,7 @@
 2847	spinning Dallas Dynasty Falcon Crest shield of horror	0		Spooky Spell Damage: +25, Damage Reduction: 15
 2848	twirling Gnomitronic Hyperspatial Demodulizer	0		
 2849	huge shrunken navigator head	0		
-2850	perfectly mixed spirit-forward ghostly moonberry wine cooler	5	EPIC	
+2850	spirit-forward perfectly mixed ghostly moonberry wine cooler	5	EPIC	
 2851	normal fine aged cheddarwurst	3	good	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2830,7 +2830,7 @@
 2857	quadruple-ionized energized seegar butt	0		Effect: "Heart of Yellow", Effect Duration: 36
 2858	skewed bottled swamp gas	0		
 2859	wobbly jittery auspicious lion tamer's witch wart	0		Experience (familiar): +2, Item Drop: +10
-2860	moldy half-sized swamp muck	2	crappy	
+2860	half-sized moldy swamp muck	2	crappy	
 2861	ghostly Van der Graaf rosy-cheeked arcane researcher's leechknife	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +30, MP Regen Min: 5, MP Regen Max: 7
 2862	twirling decomposed boot	0		
 2863	diffused boiled quadruple-wet pulsating dribbly candle	0		Effect: "Carrrsmic", Effect Duration: 30
@@ -2915,9 +2915,9 @@
 2942	quadruple-modified electrified bouncing chocolate filthy lucre	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 26
 2943	Vulcanized Angry Farmer's Wife Candy	0		Effect: "Here to Kick Ass", Effect Duration: 25
 2945	Temple Grandin's party hat of dire peril	0		Weapon Damage: +20, Familiar Weight: +7, Familiar Effect: "4xLep, cap 7"
-2946	foul-smelling Temple Grandin's V for Vivala mask	0		Familiar Weight: +7, Stench Damage: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	foul-smelling Temple Grandin's V for Vivala mask	0		Familiar Weight: +7, Stench Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	high-proof delicious shot of rotgut	9	awesome	
+2948	delicious high-proof shot of rotgut	9	awesome	
 2949	deionized polymerized triple-colloidal jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Intimidating Mien", Effect Duration: 57
 2950	jittery red Cap'm Caronch's Map	0		
 2951	bouncing Orcish Frat House blueprints	0		
@@ -2933,13 +2933,13 @@
 2961	bland packet of tofurkey gravy	3	decent	
 2962	flavorless tofurkey nugget	3	decent	
 2963	rigging shampoo	0		
-2964	spinning lime green ball polish	0		
+2964	lime green spinning ball polish	0		
 2965	mizzenmast mop	0		
 2966	Tom's of the Spanish Main Toothpaste	0		
-2967	energized narrow shaking Swabbie&trade; swab	0		Effect: "Squatting and Thrusting", Effect Duration: 37
+2967	energized shaking narrow Swabbie&trade; swab	0		Effect: "Squatting and Thrusting", Effect Duration: 37
 2968	aerosolized pulsating Oil of Parrrlay	0		Effect: "Impregnabili Tea", Effect Duration: 26
 2969	decent huge creamsicle	8	good	
-2970	weak acceptable skewed cream stout	2	good	
+2970	acceptable weak skewed cream stout	2	good	
 2971	purple slick curmudgel of Leguizamo	0		Moxie: +10, Monster Level: +20
 2972	grumpy man charrrm	0		
 2973	resourceful grumpy man charrrm bracelet	0		Maximum MP: +50, Single Equip
@@ -3006,26 +3006,26 @@
 3034	piece of thirteen	0		
 3035	adequate pearl onion	3	good	
 3036	moldy snack-sized sea biscuit	2	crappy	
-3037	tolerable irresponsibly strong bottle of rum	7	good	
+3037	irresponsibly strong tolerable bottle of rum	7	good	
 3038	lousy fortified bouncing bottle of black-label rum	5	decent	
 3039	cannonball	0		
 3040	mirror voodoo skull	0		
 3041	jittery joke scroll	0		
-3042	huge blue shaking Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
+3042	shaking blue huge Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	pulsating metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	jumbo spoiled green nanite-infested gingerbread bugbear	5	crappy	Last Available: "2007-12"
 3046	spoiled mirror nanite-infested candy cane	4	crappy	Last Available: "2020-09"
-3047	stale big nanite-infested fruitcake	5	decent	Last Available: "2007-12"
-3048	practically non-alcoholic tolerable nanite-infested eggnog	1	good	Last Available: "2007-12"
+3047	big stale nanite-infested fruitcake	5	decent	Last Available: "2007-12"
+3048	tolerable practically non-alcoholic nanite-infested eggnog	1	good	Last Available: "2007-12"
 3049	fuchsia El Vibrato power sphere	0		
 3050	upside-down horrifying eyepatch	0		Spooky Damage: +25, Familiar Effect: "spooky atk, 1xBarrr"
 3051	jittery teal cutlass of chilblains	0		Cold Damage: +25
 3052	savvy breeches	0		Mysticality Percent: +20, Familiar Effect: "stench atk, 1xPotato"
-3053	gray narrow mood ring	0		Last Available: "2007-02"
+3053	narrow gray mood ring	0		Last Available: "2007-02"
 3054	nitrogenated galvanized spinning candy heart	0		Effect: "Dreadful Fear", Effect Duration: 49, Last Available: "2007-02"
 3055	polarized quadruple-vacuum-sealed cymbal syrup	0		Free Pull, Effect: "Stop and Smell the Fudge", Effect Duration: 22, Last Available: "2007-02"
-3056	extremely unsafe metallic foil cat ears	0		Weapon Damage Percent: +100, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	extremely unsafe metallic foil cat ears	0		Weapon Damage Percent: +100, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	huge theoretical string	0		Last Available: "2007-12"
@@ -3043,12 +3043,12 @@
 3071	blinking silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	carbonite visor	0		Last Available: "2007-12"
 3073	narrow set of Unobtainium straps	0		Last Available: "2007-12"
-3074	maroon bouncing polymorphic fastening apparatus	0		Last Available: "2007-12"
+3074	bouncing maroon polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	blinking squat cyan laser targeting chip	0		Last Available: "2007-12"
 3077	mirror hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	clever marionette collective	0		Maximum MP: +20, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,18 +3057,18 @@
 3085	avaricious banded roboduck-on-a-string	0		Damage Absorption: +100, Meat Drop: +30, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	horrifying biomechanical crimborg helmet of the empath	0		Familiar Weight: +5, Spooky Damage: +25, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	horrifying biomechanical crimborg helmet of the empath	0		Familiar Weight: +5, Spooky Damage: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	brawny C.B.F.G. of dire peril	0		Muscle Percent: +20, Weapon Damage: +20, Last Available: "2007-12"
-3090	up-at-dawn zippy biomechanical crimborg leg armor	0		Initiative: +20, Adventures: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	up-at-dawn zippy biomechanical crimborg leg armor	0		Initiative: +20, Adventures: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	modified vitachoconutriment capsule	0		Effect: "Spiro Gyro", Effect Duration: 25, Last Available: "2007-12"
 3092	yellow handmade hobby horse of the storm	0		Maximum MP Percent: +40, Last Available: "2007-12"
 3093	smooth ball-in-a-cup	0		Moxie: +15, Last Available: "2007-12"
 3094	razor-sharp set of jacks	0		Weapon Damage Percent: +25, Last Available: "2007-12"
-3095	rotten miniature laser-broiled pear	2	crappy	Last Available: "2007-12"
+3095	miniature rotten laser-broiled pear	2	crappy	Last Available: "2007-12"
 3096	toasty careful polyalloy shield	0		Monster Level: -10, Hot Damage: +5, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
-3099	teal blinking ring	0		Last Available: "2007-12"
+3099	blinking teal ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	ghostly rogue swarmer	0		Last Available: "2007-12"
 3102	sawblade fragment	0		Last Available: "2007-12"
@@ -3086,11 +3086,11 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	pulsating divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	purple divine blowout	0		Last Available: "2008-01"
-3121	blinking upside-down maroon divine champagne popper	0		Last Available: "2008-01"
+3121	upside-down blinking maroon divine champagne popper	0		Last Available: "2008-01"
 3122	blurry divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	warmed colloidal liquefied fruitfilm	0		Effect: "Memories of Puppy Love", Effect Duration: 48
@@ -3098,7 +3098,7 @@
 3126	hobo nickel	0		
 3127	tumbling sandcastle	0		
 3128	marshmallow	0		
-3129	bite-sized stale roasted marshmallow	1	decent	
+3129	stale bite-sized roasted marshmallow	1	decent	
 3130	disc	0		Last Available: "2008-01"
 3131	moldy olive tin cup of mulligan stew	4	crappy	
 3132	avaricious lard-coated flamin' bindle	0		Sleaze Spell Damage: +25, Meat Drop: +30
@@ -3131,14 +3131,14 @@
 3159	extra-altered activated bouncing warm El Vibrato drone	0		Effect: "Quantum of Moxie", Effect Duration: 61
 3160	super-electrified deionized humming El Vibrato drone	0		Effect: "Pharmaceutically Cool", Effect Duration: 69
 3161	colloidal boiled El Vibrato drone	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 54
-3162	blurry pulsating El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
+3162	pulsating blurry El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
-3167	blurry fuchsia augmented El Vibrato drone	0		
+3167	fuchsia blurry augmented El Vibrato drone	0		
 3168	concentrated ghostly seal eyeball	0		Effect: "Celestial Sheen", Effect Duration: 40
-3169	stale snack-sized turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	snack-sized stale turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	Samson's evil paper umbrella	0		Experience (Muscle): +5
@@ -3147,9 +3147,9 @@
 3175	stale ghostly evil noodles	3	decent	
 3176	delicious evil noodles	4	awesome	
 3177	spoiled fancy evil painful penne pasta	3	crappy	Effect: "Influence of Sphere", Effect Duration: 45
-3178	moldy diet 3vi1 pr0n m4nic0tti	1	crappy	
+3178	diet moldy 3vi1 pr0n m4nic0tti	1	crappy	
 3179	delicious wobbly evil ravioli della hippy	3	awesome	
-3180	miniature tasty enchanted evil noodles	2	awesome	Effect: "Feroci Tea", Effect Duration: 25
+3180	enchanted miniature tasty evil noodles	2	awesome	Effect: "Feroci Tea", Effect Duration: 25
 3181	denatured electrified pulsating evil potion of potency	0		Effect: "Square to be Hip", Effect Duration: 54
 3182	non-Vulcanized evil libation of liveliness	0		Effect: "Penguinny Flavor", Effect Duration: 31
 3183	colloidal moist evil tomato juice of powerful power	0		Effect: "Chorale of Companionship", Effect Duration: 33
@@ -3158,7 +3158,7 @@
 3186	warmed denatured evil serum of sarcasm	0		Effect: "Memory of Attractiveness", Effect Duration: 55
 3187	unsweetened evil philter of phorce	0		Effect: "The Power of LOV", Effect Duration: 67
 3188	smooth boozy an evil sump'm sump'm	5	awesome	
-3189	lousy irresponsibly strong special evil ducha de oro	8	decent	Effect: "Witch Breaded", Effect Duration: 10
+3189	special irresponsibly strong lousy evil ducha de oro	8	decent	Effect: "Witch Breaded", Effect Duration: 10
 3190	smooth evil horizontal tango	3	awesome	
 3191	drinkable jittery evil roll in the hay	3	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3183,10 +3183,10 @@
 3211	huge unlarge laminated card	0		
 3212	dwarvish document	0		
 3213	dwarvish paper	0		
-3214	ghostly blurry dwarvish parchment	0		
+3214	blurry ghostly dwarvish parchment	0		
 3215	lime green overcharged El Vibrato power sphere	0		
 3216	ghostly Fly-By-Knight Heraldry form	0		Free Pull
-3217	squat ghostly skewed El Vibrato Megadrone	0		
+3217	skewed squat ghostly El Vibrato Megadrone	0		
 3218	skewed spinning rosewater-soaked glowstick of James Dean	0		Experience (Moxie): +3, Stench Resistance: +3, Last Available: "2008-02"
 3219	skewed sane hatrack	0		Free Pull, Last Available: "2011-12"
 3220	hobo code binder	0		Free Pull
@@ -3232,7 +3232,7 @@
 3260	fortified experienced Chester's moustache of the brute	0		Muscle Percent: +30, Experience: +2, Damage Absorption: +60, Class: "Disco Bandit", Single Equip
 3261	Temple Grandin's Sinatra's Chester's bag of candy	0		Experience (Moxie): +5, Familiar Weight: +7, Class: "Disco Bandit"
 3262	family-friendly razor-sharp Chester's cutoffs	0		Weapon Damage Percent: +25, Sleaze Resistance: +1, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	blurry Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	blurry Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3291,12 +3291,12 @@
 3319	stiffened Mr. Joe's bangles	0		Damage Reduction: 1, Single Equip
 3320	frayed rope belt of the ox	0		Muscle: +20, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	brainy strapping mayfly bait necklace	0		Muscle: +5, Mysticality: +5, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	brainy strapping mayfly bait necklace	0		Muscle: +5, Mysticality: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	watered-down tolerable jar of fermented pickle juice	2	good	
+3325	tolerable watered-down jar of fermented pickle juice	2	good	
 3326	diluted gray voodoo snuff	1	awesome	
-3327	special delicious extra-greasy slider	4	awesome	Effect: "Super Speed", Effect Duration: 5
+3327	delicious special extra-greasy slider	4	awesome	Effect: "Super Speed", Effect Duration: 5
 3328	ribald mansplainer's crumpled felt fedora	0		Monster Level: +15, Sleaze Damage: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	mansplainer's cool battered top-hat	0		Moxie: +5, Monster Level: +15, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	lightning-fast executive shapeless wide-brimmed hat	0		Meat Drop: +40, Initiative: +40, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3323,26 +3323,26 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	pressed modified llama lama gong	0		Effect: "Billiards Belligerence", Effect Duration: 59, Last Available: "2008-06"
-3354	rotten tiny maroon banana-frosted king cake	1	crappy	Last Available: "2008-08"
+3354	tiny rotten maroon banana-frosted king cake	1	crappy	Last Available: "2008-08"
 3355	clever brown plastic baby	0		Maximum MP: +20, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
-3357	squat wobbly shimmering moth	0		Last Available: "2008-06"
+3357	wobbly squat shimmering moth	0		Last Available: "2008-06"
 3358	squat delectable fire ant	0		Last Available: "2008-06"
 3359	bouncing scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	huge yummy mole mol&eacute;	6	awesome	Last Available: "2008-06"
+3363	yummy huge mole mol&eacute;	6	awesome	Last Available: "2008-06"
 3364	bad Morlock's Mark Bourbon	4	decent	Last Available: "2008-06"
 3365	activated huge Climate Colada	0		Effect: "Icy Composition", Effect Duration: 64, Last Available: "2008-06"
 3366	denatured blinking digital underground potion	0		Effect: "Headstrong", Effect Duration: 43, Last Available: "2008-06"
 3367	huge interesting-looking twig	0		Last Available: "2008-06"
 3368	twisted spinning glimmering roc feather	1	crappy	Last Available: "2008-06"
-3369	boiled fuchsia wobbly glimmering phoenix feather	1		Last Available: "2008-06"
-3370	diluted spinning fuchsia glimmering penguin feather	1		Effect: "Adapt to Change Eventually", Effect Duration: 40, Last Available: "2008-06"
+3369	boiled wobbly fuchsia glimmering phoenix feather	1		Last Available: "2008-06"
+3370	diluted fuchsia spinning glimmering penguin feather	1		Effect: "Adapt to Change Eventually", Effect Duration: 40, Last Available: "2008-06"
 3371	modified blurry ghostly glimmering buzzard feather	1		Effect: "Twenty-three Squid, Ew", Effect Duration: 30, Last Available: "2008-06"
 3372	diluted glimmering raven feather	1		Effect: "Impregnably Delicious", Effect Duration: 50, Last Available: "2008-06"
-3373	dehydrated shaking skewed glimmering great tit feather	1		Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2008-06"
+3373	dehydrated skewed shaking glimmering great tit feather	1		Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3371,7 +3371,7 @@
 3399	lousy jar of squeeze	3	decent	
 3400	normal bouncing bowl of fishysoisse	3	good	
 3401	denatured deadly lampshade	0		Effect: "[800]Chocolate Reign", Effect Duration: 30
-3402	ionized warmed liquefied maroon blinking concentrated garbage juice	0		Effect: "Sepia Tan", Effect Duration: 25
+3402	ionized warmed liquefied blinking maroon concentrated garbage juice	0		Effect: "Sepia Tan", Effect Duration: 25
 3403	lewd playing card	0		
 3404	gravedigger's Lo Pan's smooth deck of lewd playing cards	0		Moxie: +15, Spell Critical Percent: +30, Spooky Damage: +10
 3405	cool Hodgman's sock	0		Moxie: +5, Single Equip
@@ -3385,8 +3385,8 @@
 3413	Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
-3416	ghostly jittery hobo fortress blueprints	0		
-3421	blinking mirror red box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3416	jittery ghostly hobo fortress blueprints	0		
+3421	mirror red blinking box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	tarnished frozen sterno-flavored Hob-O	0		Effect: "stats.enq", Effect Duration: 58
 3423	quadruple-warmed tarnished frostbite-flavored Hob-O	0		Effect: "Hyphemariffic", Effect Duration: 65
 3424	wet bouncing fry-oil-flavored Hob-O	0		Effect: "Biologically Shocked", Effect Duration: 49
@@ -3419,7 +3419,7 @@
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
 3454	cotton candy pillow	0		Last Available: "2008-08"
-3455	skewed squat cotton candy bale	0		Last Available: "2008-08"
+3455	squat skewed cotton candy bale	0		Last Available: "2008-08"
 3456	huge trusty torch of the pedagogue	0		Experience: +3, Last Available: "2011-12"
 3457	brainy Junior Adventurer's merit badge	0		Mysticality: +5
 3458	electrified cold-filtered STYX deodorant body spray	0		Effect: "Knightlife", Effect Duration: 43
@@ -3430,10 +3430,10 @@
 3463	hand-crafted bottle of sake	3	EPIC	
 3464	lime green round pebble of the early riser	0		Adventures: +7
 3465	spoiled purple Bash-&#332;s cereal	3	crappy	Wiki Name: "Bash-Os cereal"
-3466	crafty healthy sinister haiku katana	0		Spell Damage: +10, Maximum HP Percent: +20, Maximum MP: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	crafty healthy sinister haiku katana	0		Spell Damage: +10, Maximum HP Percent: +20, Maximum MP: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	pulsating bargain flash powder	0		
 3468	Usain Bolt's plastic baby	0		Initiative: +80, Single Equip, Last Available: "2008-12"
-3469	moldy diet blueberry-frosted king cake	1	crappy	Last Available: "2008-12"
+3469	diet moldy blueberry-frosted king cake	1	crappy	Last Available: "2008-12"
 3470	shaking lime green bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	blinking damp boot	0		
 3472	flame-retardant Seasonal Beret of the brute of the brazier	0		Muscle Percent: +30, Hot Spell Damage: +25, Hot Resistance: +1, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3462,16 +3462,16 @@
 3495	galvanized polymerized narrow sea salt crystal	0		Effect: "Tearful, Fearful", Effect Duration: 58
 3496	irradiated improved pulsating bazookafish bubble gum	0		Effect: "Booze Goozles", Effect Duration: 27
 3497	distilled bad bottle of Pete's Sake	5	decent	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	huge witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	mirror beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	huge witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	mirror beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	moldy fancy canap&eacute;s	3	crappy	Effect: "You Know Who to Call", Effect Duration: 45
 3502	twisted red thermos of brew	1	decent	Last Available: "2011-12"
 3503	acceptable tumbling wobbly glass of brandy	3	good	Last Available: "2011-12"
 3504	French slippers	0		
 3505	hale LWA ring	0		Maximum HP: +20
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	prompt scratch 'n' sniff sword	0		Adventures: +3, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3480,14 +3480,14 @@
 3513	narrow scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	blurry stanky ganger bandana of the pedagogue	0		Experience: +3, Stench Spell Damage: +25, Familiar Effect: "atk"
-3516	gray skewed eel skin	0		
+3516	skewed gray eel skin	0		
 3517	rosewater-soaked eelskin hat	0		Stench Resistance: +3, Familiar Effect: "atk"
 3518	mirror censurious eelskin pants	0		Sleaze Resistance: +3, Familiar Effect: "1xPotato, MP regen"
 3519	eelskin shield of the sewer	0		Stench Damage: +25, Damage Reduction: 13
 3520	shark tooth	0		
 3521	resourceful educational shark tooth necklace	0		Experience: +1, Maximum MP: +50, Single Equip
 3522	narrow lard-coated nippy shark jumper	0		Cold Damage: +10, Sleaze Spell Damage: +25
-3523	anodized galvanized twirling green shark cartilage	0		Effect: "Radiant Personality", Effect Duration: 13
+3523	anodized galvanized green twirling shark cartilage	0		Effect: "Radiant Personality", Effect Duration: 13
 3524	concentrated quadruple-deionized activated eel battery	0		Effect: "Hairless and Airless", Effect Duration: 48
 3525	concentrated wobbly temporary teardrop tattoo	0		Effect: "Bananas!", Effect Duration: 34
 3526	mirror scratch 'n' sniff crossbow of chilblains	0		Cold Damage: +25, Last Available: "2008-11"
@@ -3499,7 +3499,7 @@
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	blurry cactus monocle	0		Familiar Weight: +5
 3534	shaking Jawmaster 2000&trade;	0		Familiar Weight: +5
-3535	squat pulsating plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
+3535	pulsating squat plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	pulsating plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	fuchsia plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
@@ -3510,8 +3510,8 @@
 3543	purple twirling rosy-cheeked sage depleted Grimacite gravy boat	0		Mysticality Percent: +10, Maximum HP Percent: +30, Last Available: "2011-12"
 3544	experienced depleted Grimacite weightlifting belt of Tarzan	0		Experience: +2, Experience (Muscle): +3, Single Equip, Last Available: "2011-12"
 3545	Jeselnik's depleted Grimacite grappling hook of courage	0		Sleaze Damage: +25, Spooky Resistance: +3, Single Equip, Last Available: "2011-12"
-3546	olive medical-grade depleted Grimacite ninja mask of the detective	0		Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	therapeutic Samson's depleted Grimacite shinguards	0		Experience (Muscle): +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	olive medical-grade depleted Grimacite ninja mask of the detective	0		Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	therapeutic Samson's depleted Grimacite shinguards	0		Experience (Muscle): +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	Jack Frost's curative depleted Grimacite astrolabe	0		Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-12"
 3549	dog trainer's deadly KoL Con Cinco Pi&ntilde;ata Bat	0		Weapon Damage: +5, Experience (familiar): +1, Softcore Only, Last Available: "2008-09"
 3550	huge Socratic propeller beanie	0		Experience (Mysticality): +1, Familiar Effect: "atk, cap 7"
@@ -3522,9 +3522,9 @@
 3555	toothsome small sea carrot	2	awesome	
 3556	diet stale sea cucumber	1	decent	
 3557	moldy sea avocado	3	crappy	
-3558	tiny decent huge sea lychee	1	good	
+3558	decent tiny huge sea lychee	1	good	
 3559	super-sized normal sea tangelo	5	good	
-3560	normal low-calorie sea honeydew	1	good	
+3560	low-calorie normal sea honeydew	1	good	
 3561	activated yellow spinning pressurized potion of puissance	0		Effect: "Purity of Spirit", Effect Duration: 68
 3562	frozen warmed blinking fuchsia pressurized potion of perspicacity	0		Effect: "Cold Throat", Effect Duration: 34
 3563	triple-ionized twirling pressurized potion of pulchritude	0		Effect: "Crimbo Nostalgia", Effect Duration: 69
@@ -3550,7 +3550,7 @@
 3584	bite-sized decent narrow irradiated candy cane	1	good	Last Available: "2008-12"
 3585	low-calorie bland gingerbread mutant bugbear	1	decent	Last Available: "2008-12"
 3586	tolerable wobbly oozenog	3	good	Last Available: "2008-12"
-3587	improved super-activated green upside-down skewed pulsating sugar plum	0		Effect: "Chlorophyll Flavor", Effect Duration: 48, Last Available: "2008-12"
+3587	improved super-activated upside-down pulsating green skewed sugar plum	0		Effect: "Chlorophyll Flavor", Effect Duration: 48, Last Available: "2008-12"
 3588	quantum oxidized sugar banana	0		Effect: "Ancient Protected", Effect Duration: 52, Last Available: "2008-12"
 3589	colloidal extra-alkaline upside-down sugar lime	0		Effect: "Painted-On Bikini", Effect Duration: 39, Last Available: "2008-12"
 3590	dry cold-filtered sugar cherry	0		Effect: "Prideful Strut", Effect Duration: 33, Last Available: "2008-12"
@@ -3578,18 +3578,18 @@
 3612	upside-down sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	squat battered Crimbo Crate	0		Last Available: "2008-12"
 3614	blinking twitching claw	0		Last Available: "2008-12"
-3615	wobbly skewed maroon rigid carapace	0		Last Available: "2008-12"
+3615	maroon skewed wobbly rigid carapace	0		Last Available: "2008-12"
 3616	blinking pulsing flesh	0		Last Available: "2008-12"
 3617	ionized diffused blue unstable DNA	0		Effect: "Funky Coal Patina", Effect Duration: 58, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	fuchsia gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	dangerous parasitic claw	0		Weapon Damage: +10, Last Available: "2008-12"
-3625	ruddy parasitic tentacles	0		Maximum HP Percent: +40, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	careful parasitic headgnawer	0		Monster Level: -10, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	ruddy parasitic tentacles	0		Maximum HP Percent: +40, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	careful parasitic headgnawer	0		Monster Level: -10, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	parasitic strangleworm of the brazier	0		Hot Spell Damage: +25, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,35 +3598,35 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	rosewater-soaked supercharged elven socks	0		Maximum MP Percent: +30, Stench Resistance: +3, Last Available: "2008-12"
 3634	squat vibrating elven gloves of the early riser	0		Maximum MP Percent: +10, Adventures: +7, Last Available: "2008-12"
-3635	blinking blinking gravedigger's dance instructor's festive holiday hat	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	blinking blinking gravedigger's dance instructor's festive holiday hat	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	supercharged patent shoes of the ox	0		Muscle: +20, Maximum MP Percent: +30, Last Available: "2008-12"
 3637	blurry spinning gray bow tie of the ox of the cheetah	0		Muscle: +20, Initiative: +60, Last Available: "2008-12"
 3638	Usain Bolt's banded penguin thesaurus	0		Damage Absorption: +100, Initiative: +80, Last Available: "2008-12"
-3639	snack-sized decent bouncing blob-shaped Crimbo cookie	2	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	decent snack-sized bouncing blob-shaped Crimbo cookie	2	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	yellow jamfish jam	0		
 3642	ghostly dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	sharpshooter's depleted Grimacite kneecapping stick	0		Critical Hit Percent: +10, Last Available: "2007-06"
 3645	perfectly mixed canteen of wine	4	EPIC	Last Available: "2008-12"
-3646	yummy huge blinking elven <i>limbos</i> gingerbread	9	awesome	Last Available: "2008-12"
+3646	huge yummy blinking elven <i>limbos</i> gingerbread	9	awesome	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
-3648	ghostly twirling magic dragonfish fry	0		
+3648	twirling ghostly magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	small tasty toast with jam	2	awesome	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	mediocre irresponsibly strong elven moonshine	9	decent	Last Available: "2008-12"
-3653	moldy knuckle sandwich	3	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3650	tasty small toast with jam	2	awesome	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	irresponsibly strong mediocre elven moonshine	9	decent	Last Available: "2008-12"
+3653	moldy knuckle sandwich	3	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	blinking greedy brawny psycho sweater	0		Muscle Percent: +20, Meat Drop: +20, Last Available: "2008-12"
-3655	fuchsia huge fin-bit wax	0		Familiar Weight: +5
+3655	huge fuchsia fin-bit wax	0		Familiar Weight: +5
 3656	Jim Carey's plastic Mob Penguin	0		Monster Level: +25, Last Available: "2008-12"
 3657	twirling stylish plastic mutant elf	0		Moxie: +25, Last Available: "2008-12"
 3658	plastic fat stack of cash of Leguizamo	0		Monster Level: +20, Last Available: "2008-12"
 3659	plastic strand of DNA of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2008-12"
 3660	plastic chunk of depleted Grimacite of courage	0		Spooky Resistance: +3, Last Available: "2008-12"
 3661	teal container of Putty	0		Last Available: "2009-01"
-3662	twirling smooth Putty mitre	0		Moxie: +15, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	family-friendly friendly Putty leotard	0		Familiar Weight: +3, Sleaze Resistance: +1, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	twirling smooth Putty mitre	0		Moxie: +15, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	family-friendly friendly Putty leotard	0		Familiar Weight: +3, Sleaze Resistance: +1, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	skewed horrifying Putty ball	0		Spooky Damage: +25, Softcore Only, Last Available: "2009-01"
 3665	huge Putty sheet	0		Last Available: "2009-01"
 3666	flame-wreathed coward's clever Putty snake	0		Maximum MP: +20, Monster Level: -20, Hot Spell Damage: +10, Softcore Only, Last Available: "2009-01"
@@ -3647,12 +3647,12 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	teal map to the Marinara Trench	0		
-3684	bite-sized yummy twirling tempura carrot	1	awesome	
-3685	stale massive tempura cucumber	6	decent	
-3686	small rotten tempura avocado	2	crappy	
+3684	yummy bite-sized twirling tempura carrot	1	awesome	
+3685	massive stale tempura cucumber	6	decent	
+3686	rotten small tempura avocado	2	crappy	
 3687	adequate sea broccoli	4	good	
 3688	small stale sea cauliflower	2	decent	
-3689	stale big tempura broccoli	5	decent	
+3689	big stale tempura broccoli	5	decent	
 3690	low-calorie normal green tempura cauliflower	1	good	
 3691	spoiled immense upside-down sea blueberry	9	crappy	
 3692	flavorless pulsating sea persimmon	3	decent	
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	narrow sharpshooter's handwarmer of the detective	0		Critical Hit Percent: +10, Item Drop: +20, Single Equip
 3737	blurry stanky lighter of the storm	0		Maximum MP Percent: +40, Stench Spell Damage: +25
-3738	flavorless gigantic packet of beer nuts	6	decent	
+3738	gigantic flavorless packet of beer nuts	6	decent	
 3739	jittery skewed Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	upside-down upside-down spectral jelly	0		
@@ -3714,7 +3714,7 @@
 3749	modified concoction of clumsiness	0		Effect: "Phorcefullness", Effect Duration: 64
 3750	shaking vampire pearl earring of the bloodbag	0		Maximum HP: +100, Single Equip
 3751	fancy stale chocolate chip brownies	3	decent	Effect: "Cletus's Canticle of Celerity", Effect Duration: 15
-3753	ghostly Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	ghostly Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	extra-polymerized wobbly love song of vague ambiguity	0		Effect: "Okee-Dokee Go!", Effect Duration: 56, Last Available: "2009-02"
 3755	unsweetened love song of smoldering passion	0		Effect: "Preemptive Medicine", Effect Duration: 29, Last Available: "2009-02"
 3756	wet yellow love song of icy revenge	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 20, Last Available: "2009-02"
@@ -3727,8 +3727,8 @@
 3763	delicious weak upside-down slug of vodka	2	awesome	
 3764	smooth huge slug of rum	3	awesome	
 3765	delicious huge slug of shochu	3	awesome	
-3766	practically non-alcoholic hand-crafted screwdiver	1	EPIC	
-3767	weak acceptable dew yoana lei	2	good	
+3766	hand-crafted practically non-alcoholic screwdiver	1	EPIC	
+3767	acceptable weak dew yoana lei	2	good	
 3768	hand-crafted squat lychee chuhai	3	EPIC	
 3769	aged salacious screwdiver	3	awesome	
 3770	drinkable pulsating dew yoana salacious lei	3	good	
@@ -3751,10 +3751,10 @@
 3787	tumbling wine-soaked bone chips	0		Class: "Pastamancer"
 3788	mirror jittery crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
-3799	gray bouncing Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
+3799	bouncing gray Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	huge crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	twirling charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	huge crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	twirling charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	reassuring padded Mer-kin roundshield of dire peril	0		Weapon Damage: +20, Damage Absorption: +20, Spooky Resistance: +1, Damage Reduction: 14
 3804	resourceful deadly Mer-kin breastplate	0		Weapon Damage: +5, Maximum MP: +50
 3805	dog trainer's Mer-kin sneakmask of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +1, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3783,11 +3783,11 @@
 3829	adequate tempura radish	4	good	
 3830	fortified water-polo cap	0		Damage Absorption: +60, Familiar Effect: "1xVolley, 1xBarrr"
 3831	hand-crafted watered-down upside-down Typical Tavern swill	2	EPIC	
-3832	tolerable practically non-alcoholic tropical swill	1	good	
-3833	special artisanal distilled blue fruity girl swill	5	EPIC	Effect: "Bilious Brains", Effect Duration: 50
+3832	practically non-alcoholic tolerable tropical swill	1	good	
+3833	artisanal special distilled blue fruity girl swill	5	EPIC	Effect: "Bilious Brains", Effect Duration: 50
 3834	artisanal weak blended swill	2	EPIC	
 3835	skewed costume wardrobe	0		Softcore Only
-3836	auspicious Newton's Elvish sunglasses of Leguizamo of the overflowing toilet	0		Experience (Mysticality): +3, Monster Level: +20, Stench Spell Damage: +50, Item Drop: +10, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	auspicious Newton's Elvish sunglasses of Leguizamo of the overflowing toilet	0		Experience (Mysticality): +3, Monster Level: +20, Stench Spell Damage: +50, Item Drop: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	jittery personal trainer's anniversary safety glass vest	0		Experience Percent (Muscle): +10
 3838	medical-grade anniversary burlap belt	0		HP Regen Min: 7, HP Regen Max: 10
 3839	anniversary balsa wood socks of the businessman	0		Meat Drop: +50
@@ -3827,7 +3827,7 @@
 3873	lightning-fast rave whistle of vim and vigor	0		Maximum HP Percent: +50, Initiative: +40
 3874	hellseal hide	0		
 3875	shredded hellseal hide	0		
-3876	mirror blinking hellseal brain	0		
+3876	blinking mirror hellseal brain	0		
 3877	twirling burst hellseal brain	0		
 3878	hellseal sinew	0		
 3879	upside-down torn hellseal sinew	0		
@@ -3836,7 +3836,7 @@
 3882	encoded cult documents	0		
 3883	cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
-3885	quadruple-irradiated blurry fuchsia vial of slime	0		Effect: "critical.enh", Effect Duration: 57
+3885	quadruple-irradiated fuchsia blurry vial of slime	0		Effect: "critical.enh", Effect Duration: 57
 3886	wet liquefied vial of slime	0		Effect: "Antarctic Memories", Effect Duration: 42
 3887	chilled twirling twirling vial of slime	0		Effect: "White Knuckles", Effect Duration: 29
 3888	ionized vial of slime	0		Effect: "Comic Violence", Effect Duration: 18
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	purple imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	bad triple-distilled blended swill with a fly in it	9	decent	
+3913	triple-distilled bad blended swill with a fly in it	9	decent	
 3914	turtle wax	0		
 3915	spinning wicked turtle wax shield	0		Spell Damage: +5, Damage Reduction: 2
 3916	twirling turtle wax helmet of the storm	0		Maximum MP Percent: +40, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3879,7 +3879,7 @@
 3927	skewed turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
 3929	pulsating grinning turtle	0		
-3930	triple-aerosolized wobbly fuchsia wobbly tainted seal's blood	0		Effect: "Bolts about Candy", Effect Duration: 42
+3930	triple-aerosolized fuchsia wobbly wobbly tainted seal's blood	0		Effect: "Bolts about Candy", Effect Duration: 42
 3931	blurry purple bouncing perfumed occult severed flipper	0		Spell Damage Percent: +25, Stench Resistance: +5, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
 3933	teal huge Newton's bad-ass club	0		Experience (Mysticality): +3, Item Drop: +5, Class: "Seal Clubber"
@@ -3929,7 +3929,7 @@
 3977	painted turtle	0		
 3978	shaking Lo Pan's experienced painted shield	0		Experience: +2, Spell Critical Percent: +30, Damage Reduction: 7
 3979	sleeping wereturtle	0		
-3980	mirror huge shell	0		
+3980	huge mirror shell	0		
 3981	torquoise	0		
 3982	beefcake's torquoise ring of Gandalf	0		Muscle: +25, Spell Critical Percent: +20, Single Equip
 3983	dueling turtle	0		
@@ -3946,8 +3946,8 @@
 3994	security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
 3996	boxcar turtle	0		
-3997	jittery shaking dolphin whistle	0		
-3998	blinking blue metrognome	0		Familiar Weight: +5
+3997	shaking jittery dolphin whistle	0		
+3998	blue blinking metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	mixed agua de vida	1	decent	Effect: "Amorphous Cheer", Effect Duration: 5, Last Available: "2009-06"
@@ -3985,20 +3985,20 @@
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
-4036	huge bouncing caustic slime nodule	0		
+4036	bouncing huge caustic slime nodule	0		
 4037	yummy slimy sweetbreads	4	awesome	
 4038	lousy slimy fermented bile bladder	3	decent	
 4039	compressed jittery lime green slimy alveolus	1		
 4040	squat memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	vibrating educational pig-iron helm	0		Experience: +1, Maximum MP Percent: +10, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	Oprah's pig-iron shinguards of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	vibrating educational pig-iron helm	0		Experience: +1, Maximum MP Percent: +10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	Oprah's pig-iron shinguards of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	olive lard-coated pig-iron bracers of the early riser	0		Sleaze Spell Damage: +25, Adventures: +7, Single Equip, Last Available: "2009-06"
-4044	mirror lime green wumpus hair	0		Last Available: "2009-06"
+4044	lime green mirror wumpus hair	0		Last Available: "2009-06"
 4045	squat wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	tumbling nippy wumpus-hair whip	0		Cold Damage: +10, Last Available: "2009-06"
-4048	wobbly red inspector's chaotic wizardly wumpus-hair wig	0		Mysticality: +25, Spell Critical Percent: +10, Item Drop: +15, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	spinning Fonzie's supercool beefcake's wumpus-hair loincloth	0		Muscle: +25, Moxie Percent: +20, Experience (Moxie): +1, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	wobbly red inspector's chaotic wizardly wumpus-hair wig	0		Mysticality: +25, Spell Critical Percent: +10, Item Drop: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	spinning Fonzie's supercool beefcake's wumpus-hair loincloth	0		Muscle: +25, Moxie Percent: +20, Experience (Moxie): +1, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	twirling teal Tesla weightlifter's wumpus-hair sweater	0		Muscle: +15, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-06"
 4051	blurry ring of teleportation	0		Item Drop: +5, Single Equip
 4052	special mirror glass of baboon milk	1	decent	Effect: "Spiky Frozen Hair", Effect Duration: 20, Last Available: "2009-06"
@@ -4022,7 +4022,7 @@
 4070	essence of stench	0		Last Available: "2009-06"
 4071	huge essence of fright	0		Last Available: "2009-06"
 4072	shaking essence of	0		Last Available: "2009-06"
-4073	green twirling Supreme Being Glossary	0		Last Available: "2009-06"
+4073	twirling green Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
 4075	olive huge friendly Annie Oakley's villainous scythe	0		Critical Hit Percent: +20, Familiar Weight: +3, Slime Hates It: +2
 4076	sage baneful bandolier of the overflowing toilet	0		Mysticality Percent: +10, Stench Spell Damage: +50, Slime Hates It: +1
@@ -4042,7 +4042,7 @@
 4090	polarized quantum physiostim pill	0		Effect: "Filled with Magic", Effect Duration: 43, Last Available: "2009-06"
 4091	skewed slimy cyst	0		
 4092	small slimy cyst	0		
-4093	bouncing narrow medium slimy cyst	0		
+4093	narrow bouncing medium slimy cyst	0		
 4094	slimy cyst	0		
 4095	narrow inspector's peawee marble	0		Item Drop: +15
 4096	boxer's brown crock marble	0		Muscle Percent: +10
@@ -4081,11 +4081,11 @@
 4129	huge lion tamer's hardened slime belt of dire peril of the sweet-tooth	0		Weapon Damage: +20, Experience (familiar): +2, Candy Drop: +100, Single Equip
 4130	wobbly empty agua de vida bottle	0		Last Available: "2009-06"
 4131	modified boot plant	1	EPIC	Last Available: "2009-06"
-4132	special weak bad green sham champagne	2	decent	Effect: "Memories of Puppy Love", Effect Duration: 25, Last Available: "2009-06"
+4132	weak special bad green sham champagne	2	decent	Effect: "Memories of Puppy Love", Effect Duration: 25, Last Available: "2009-06"
 4133	denatured enhanced tempura air	0		Effect: "Spiky Frozen Hair", Effect Duration: 38
 4134	irradiated pressurized potion of pneumaticity	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 41
 4135	spinning moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	censurious horrifying beefcake's Bag o' Tricks of temperance	0		Muscle: +25, Spooky Damage: +25, Sleaze Resistance: 8, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	censurious horrifying beefcake's Bag o' Tricks of temperance	0		Muscle: +25, Spooky Damage: +25, Sleaze Resistance: 8, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	shaking slime stack	0		
 4138	a rumpled paper strip	0		
 4139	huge a creased paper strip	0		
@@ -4106,11 +4106,11 @@
 4154	live lobster	0		Last Available: "2011-12"
 4155	bouncing wok lobster	0		Last Available: "2011-12"
 4156	mirror pebbles	0		Last Available: "2009-09"
-4157	cyan narrow gravel	0		Last Available: "2009-09"
+4157	narrow cyan gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	acceptable irresponsibly strong pebblebr&auml;u	10	good	Last Available: "2009-09"
-4161	enchanted tasty ghostly rocky road ice cream	3	awesome	Effect: "Saucegoggles", Effect Duration: 50, Last Available: "2009-09"
+4161	tasty enchanted ghostly rocky road ice cream	3	awesome	Effect: "Saucegoggles", Effect Duration: 50, Last Available: "2009-09"
 4162	twirling extra-strength rubber bands	0		Familiar Weight: +5
 4163	ionized warmed bouncing children of the candy corn	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 18
 4164	moist Good 'n' Slimy	0		Effect: "Impregnably Delicious", Effect Duration: 64
@@ -4130,15 +4130,15 @@
 4178	sizzling sugar shotgun	0		Hot Damage: +10, Last Available: "2009-09"
 4179	curative sugar shillelagh	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09"
 4180	sugar shank of the sweet-tooth	0		Candy Drop: +100, Last Available: "2009-09"
-4181	sugar chapeau of the brazier of horror of the boozehound	0		Hot Spell Damage: +25, Spooky Spell Damage: +25, Booze Drop: +100, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	purple rock-hard sugar shorts	0		Damage Reduction: 5, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	sugar chapeau of the brazier of horror of the boozehound	0		Hot Spell Damage: +25, Spooky Spell Damage: +25, Booze Drop: +100, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	purple rock-hard sugar shorts	0		Damage Reduction: 5, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	blinking slime convention swag bag	0		
 4185	teal slime convention flyers	0		
 4186	slime convention coupons	0		
 4187	skewed shaking slime convention pin of the pedagogue	0		Experience: +3
 4188	bouncing slime convention t-shirt	0		
-4189	ghostly red inverse geode	0		
+4189	red ghostly inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	perfumed sugar shirt	0		Stench Resistance: +5, Last Available: "2009-09"
 4192	twirling sugar shard	0		Last Available: "2009-09"
@@ -4163,7 +4163,7 @@
 4211	mermaid's purse	0		
 4212	underwater slingshot	0		
 4213	Lo Pan's clever skate blade	0		Maximum MP: +20, Spell Critical Percent: +30
-4214	jittery lime green tumbling spangly unitard	0		
+4214	lime green jittery tumbling spangly unitard	0		
 4215	arcane researcher's collapsible baton of the overflowing toilet	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +50
 4216	narrow groupie lipstick	0		
 4217	lime green groupie bra	0		
@@ -4178,7 +4178,7 @@
 4226	narrow electrified Star of Bravery	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 4227	twirling hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	skewed ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	blinking salt-shaker	0		
 4236	can of sterno	0		
 4237	cheese-slicer of doom	0		Spooky Spell Damage: +50
-4238	moldy miniature beef jerky	2	crappy	
+4238	miniature moldy beef jerky	2	crappy	
 4239	Jim Carey's pipe wrench	0		Monster Level: +25
 4240	vacuum-sealed galvanized maroon gun cleaning kit	0		Effect: "Aloofah", Effect Duration: 66
 4241	sleep mask of Leguizamo	0		Monster Level: +20, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4197,24 +4197,24 @@
 4245	bookmark	0		
 4246	olive rosewater-soaked ivory cue ball	0		Stench Resistance: +3
 4247	tolerable special decanter of fine Scotch	3	good	Effect: "Serendipi Tea", Effect Duration: 5
-4248	dried green ghostly expensive cigar	1		
+4248	dried ghostly green expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	wet tarnished vial of squid ink	0		Effect: "Scrappy, Shadowy", Effect Duration: 53
-4253	diffused squat blurry cyan potion of speed	0		Effect: "Baconstoned", Effect Duration: 57
+4253	diffused blurry squat cyan potion of speed	0		Effect: "Baconstoned", Effect Duration: 57
 4254	blinking bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	flattened corrupted sap	0		Effect: "Buggy Flavor", Effect Duration: 43, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	delicious blinking chocolate-covered scarab beetle	4	awesome	Last Available: "2009-10"
 4259	hand-crafted mulled cider	3	EPIC	Last Available: "2009-10"
-4260	gray wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	gray wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	lard-coated bark boxers	0		Sleaze Spell Damage: +25, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	squat cyan wool bark beret	0		Cold Resistance: +1, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	lard-coated bark boxers	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	squat cyan wool bark beret	0		Cold Resistance: +1, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	purple electrified bark bracelet	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 4267	foul-smelling Krakrox's Loincloth of bravery	0		Stench Damage: +10, Spooky Resistance: +5, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	ruddy brainy Galapagosian Cuisses	0		Mysticality: +5, Maximum HP Percent: +40, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4297,12 +4297,12 @@
 4345	string of Crimbo lights	0		Last Available: "2009-12"
 4346	twirling plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	blurry gingerbread house	0		Last Available: "2009-12"
-4348	bouncing wobbly leftover Crimbo rations	0		Last Available: "2009-12"
-4349	yellow Socratic snow hat	0		Experience (Mysticality): +1, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	mirror beefy snow pants	0		Muscle: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4348	wobbly bouncing leftover Crimbo rations	0		Last Available: "2009-12"
+4349	yellow Socratic snow hat	0		Experience (Mysticality): +1, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	mirror beefy snow pants	0		Muscle: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	jittery Annie Oakley's snow belly	0		Critical Hit Percent: +20, Single Equip, Last Available: "2009-12"
 4352	huge pile of loose snow	0		Last Available: "2009-12"
-4353	squat green Crimbough	0		Last Available: "2009-12"
+4353	green squat Crimbough	0		Last Available: "2009-12"
 4354	tumbling A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
@@ -4324,7 +4324,7 @@
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	huge grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
-4375	narrow maroon spiraling shape	0		Last Available: "2009-12"
+4375	maroon narrow spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
 4377	skewed deadly throwing wrench	0		Weapon Damage: +5, Last Available: "2009-12"
 4378	pair of bolt cutters of the bloodbag	0		Maximum HP: +100, Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	squat avaricious Sinatra's pocketwatch on a chain	0		Experience (Moxie): +5, Meat Drop: +30, Last Available: "2009-12"
 4386	jittery maroon Lo Pan's chaotic cement sandals	0		Spell Critical Percent: 40, Single Equip, Last Available: "2009-12"
 4387	jittery wholesome night-vision goggles of the boozehound	0		Maximum HP Percent: +10, Booze Drop: +100, Single Equip, Last Available: "2009-12"
-4388	squat passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	squat passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	wobbly Tesla peanut brittle shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 3, Last Available: "2009-12"
 4390	Sherlock's hale Red Rover BB gun	0		Maximum HP: +20, Item Drop: +25, Last Available: "2009-12"
-4391	weightlifter's red-and-green sweater	0		Muscle: +15, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	weightlifter's red-and-green sweater	0		Muscle: +15, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	wet improved adjusted Crimbo peppermint bark	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 54, Last Available: "2009-12"
 4394	oxidized green Crimbo fudge	0		Effect: "Triangle, Man", Effect Duration: 58, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	Herculean cheese sword	0		Experience (Muscle): +1, Softcore Only, Last Available: "2010-01"
-4400	MacGyver's cheese diaper	0		Maximum MP: +100, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	MacGyver's cheese diaper	0		Maximum MP: +100, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	narrow cheese wheel of the empath	0		Familiar Weight: +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	narrow huge padded cheese eye	0		Damage Absorption: +20, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	narrow huge padded cheese eye	0		Damage Absorption: +20, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	clever grievous Staff of Queso Escusado of Gandalf	0		Weapon Damage Percent: +50, Maximum MP: +20, Spell Critical Percent: +20, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	red blurry The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4360,7 +4360,7 @@
 4409	gray Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	moldy low-calorie quantum taco	0		Last Available: "2010-10"
+4412	low-calorie moldy quantum taco	0		Last Available: "2010-10"
 4413	perfectly mixed weak Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	red upside-down smooth sealhide hood	0		Moxie: +15, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4379,8 +4379,8 @@
 4429	zippy candy necklace	0		Initiative: +20, Single Equip
 4430	wizardly teddybear backpack	0		Mysticality: +25
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	electrified double-energized bouncing mirror invisibility potion	0		Effect: "Concentrated Concentration", Effect Duration: 69, Last Available: "2011-08"
-4433	enhanced red shaking spinning irresistibility potion	0		Effect: "Stuck-Up Hair", Effect Duration: 39, Last Available: "2011-08"
+4432	electrified double-energized mirror bouncing invisibility potion	0		Effect: "Concentrated Concentration", Effect Duration: 69, Last Available: "2011-08"
+4433	enhanced shaking red spinning irresistibility potion	0		Effect: "Stuck-Up Hair", Effect Duration: 39, Last Available: "2011-08"
 4434	ionized wobbly irritability potion	0		Effect: "Material Witness", Effect Duration: 23, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
@@ -4396,7 +4396,7 @@
 4448	twisted blinking red Instant Karma	1	good	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	baleful pointy hat	0		Spell Damage: +25, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	baleful pointy hat	0		Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	ghostly sinister machetito	0		Spell Damage: +10, Last Available: "2010-04"
 4453	padded lawnmower blade	0		Damage Absorption: +20, Last Available: "2010-04"
 4454	narrow grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	double-irradiated oxidized chocolate saucepan	0		Effect: "Turkey-Agitated", Effect Duration: 37
 4466	flattened chocolate disco ball	0		Effect: "Earthen Fist", Effect Duration: 27
 4467	energized tumbling chocolate stolen accordion	0		Effect: "Purpose", Effect Duration: 15
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	twirling huge BRICKO eye brick	0		Last Available: "2010-02"
-4471	spinning BRICKO hat of horror	0		Spooky Spell Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	BRICKO pants of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	spinning BRICKO hat of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	BRICKO pants of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	frosty BRICKO sword	0		Cold Spell Damage: +10, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	tumbling BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	tumbling BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	gray BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4451,7 +4451,7 @@
 4503	super-colloidal vacuum-sealed recording of Inigo's Incantation of Inspiration	0		Effect: "The Living Hitpoints", Effect Duration: 67, Last Available: "2010-02"
 4504	green wool heart of the volcano of James Dean	0		Experience (Moxie): +3, Cold Resistance: +1
 4505	frozen Northern pemmican	0		Effect: "Spirit of Alph", Effect Duration: 37
-4506	tumbling bouncing puzzling ribbon	0		
+4506	bouncing tumbling puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	polymerized modified &quot;DRINK ME&quot; potion	0		Effect: "Rushtacean'", Effect Duration: 59, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
@@ -4460,8 +4460,8 @@
 4512	jittery eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	yummy Humpty Dumplings	3	awesome	Last Available: "2010-03"
-4515	rotten fancy jittery skewed Lobster <i>qua</i> Grill	4	crappy	Effect: "Bone Chilling", Effect Duration: 5, Last Available: "2010-03"
-4516	smooth fancy blinking missing wine	4	awesome	Effect: "Fishily Speeding", Effect Duration: 30, Last Available: "2010-03"
+4515	fancy rotten skewed jittery Lobster <i>qua</i> Grill	4	crappy	Effect: "Bone Chilling", Effect Duration: 5, Last Available: "2010-03"
+4516	fancy smooth blinking missing wine	4	awesome	Effect: "Fishily Speeding", Effect Duration: 30, Last Available: "2010-03"
 4517	normal upside-down matter custard	4	good	Last Available: "2010-03"
 4518	alkaline super-cold-filtered frozen huge comfit?	0		Effect: "From Nantucket", Effect Duration: 53, Last Available: "2010-03"
 4519	spinning ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	narrow croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	awesome	Last Available: "2010-03"
 4523	manspreader's eye of the Tiger-lily of extreme caution	0		Monster Level: -15, Last Available: "2010-03"
-4524	blinking reassuring smartaleck's wig	0		Moxie Percent: +30, Spooky Resistance: +1, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	blinking reassuring smartaleck's wig	0		Moxie Percent: +30, Spooky Resistance: +1, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	thick stale donut	5	decent	Last Available: "2010-03"
 4526	low-calorie rotten bucket of honey	1	crappy	Last Available: "2010-03"
 4527	inspector's Newton's elephant stinger	0		Experience (Mysticality): +3, Item Drop: +15, Last Available: "2010-03"
 4528	normal special dragon snaps	3	good	Effect: "Heart of Yellow", Effect Duration: 5, Last Available: "2010-03"
 4529	dog trainer's chaotic snapdragon pistil	0		Spell Critical Percent: +10, Experience (familiar): +1, Last Available: "2010-03"
 4530	gray puff of smoke	0		Last Available: "2010-03"
-4531	toothsome olive tumbling jittery rook cookie	4	awesome	Last Available: "2010-03"
+4531	toothsome jittery tumbling olive rook cookie	4	awesome	Last Available: "2010-03"
 4532	moldy half-sized bishop cookie	2	crappy	Last Available: "2010-03"
 4533	moldy knight cookie	3	crappy	Last Available: "2010-03"
 4534	rotten low-calorie king cookie	1	crappy	Last Available: "2010-03"
 4535	bland queen cookie	4	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	shaking wobbly insane tophat of terror	0		Spooky Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	shaking flame-wreathed beefcake's helm of the knight	0		Muscle: +25, Hot Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	shaking wobbly insane tophat of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	shaking flame-wreathed beefcake's helm of the knight	0		Muscle: +25, Hot Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	scorching wristwatch of the knight of doom	0		Hot Damage: +25, Spooky Spell Damage: +50, Single Equip, Last Available: "2010-03"
-4540	vibrating trousers of the knight of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	vibrating trousers of the knight of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	olive studded tophat	0		Damage Absorption: +80, Familiar Effect: "1xBarrr, cap 25"
 4542	blurry spinning boxer's tie	0		Muscle Percent: +10, Single Equip
 4543	dog trainer's tuxedo pants	0		Experience (familiar): +1, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4508,7 +4508,7 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	green can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	drinkable triple-distilled world's most unappetizing beverage	6	good	Last Available: "2010-04"
+4563	triple-distilled drinkable world's most unappetizing beverage	6	good	Last Available: "2010-04"
 4564	Samson's slippery when wet shield	0		Experience (Muscle): +5, Damage Reduction: 6, Last Available: "2010-04"
 4565	yummy tumbling raisin	4	awesome	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4526,14 +4526,14 @@
 4578	red meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	triple-magnetized quantum double-adjusted Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 61, Last Available: "2010-04"
 4580	huge stanky school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Stench Spell Damage: +25, Last Available: "2010-04"
-4581	strapping T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of courage	0		Muscle: +5, Spooky Resistance: +3, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	strapping T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of courage	0		Muscle: +5, Spooky Resistance: +3, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	delicious six wedges of goat cheese	3	awesome	
 4585	teal collection of objects	0		
 4586	boulder	0		
 4587	blurry goth	0		
-4588	bouncing wobbly brown pixel	0		
+4588	wobbly bouncing brown pixel	0		
 4589	fireproof pixel whip	0		Hot Resistance: +3
 4590	bouncing MacGyver's pixel chain whip	0		Maximum MP: +100, Last Available: "2010-07"
 4591	maroon lard-coated pixel morning star	0		Sleaze Spell Damage: +25, Last Available: "2010-07"
@@ -4550,7 +4550,7 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	upside-down Newton's bottle of Goldschn&ouml;ckered of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	upside-down Newton's bottle of Goldschn&ouml;ckered of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	delicious snack-sized sun-dried tofu	2	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	lousy bouncing soyburger juice	4	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	skewed respected companion biscuit	0		Last Available: "2010-08"
@@ -4560,8 +4560,8 @@
 4612	twirling souvenir drawing	0		Last Available: "2010-08"
 4613	skewed map to the Magic Commune	0		Last Available: "2010-08"
 4614	shaking studded Crown of Thrones	0		Damage Absorption: +80, Softcore Only, Last Available: "2010-05"
-4615	bad enchanted jittery skewed Cinco Mayo Lager	3	decent	Effect: "Gummi Badass", Effect Duration: 30, Last Available: "2010-05"
-4616	blinking bouncing Underworld sapling	0		Last Available: "2009-10"
+4615	bad enchanted skewed jittery Cinco Mayo Lager	3	decent	Effect: "Gummi Badass", Effect Duration: 30, Last Available: "2010-05"
+4616	bouncing blinking Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	purple plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
@@ -4569,20 +4569,20 @@
 4621	purple skewed Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	adjusted twirling chocolate-covered caviar	0		Effect: "Weird Vibrations", Effect Duration: 52, Last Available: "2020-09"
-4624	tiny decent pawn cookie	1	good	Last Available: "2010-06"
+4624	decent tiny pawn cookie	1	good	Last Available: "2010-06"
 4625	powdered maroon coffee pixie stick	1	awesome	Last Available: "2010-06"
 4626	blue superduperball	0		Last Available: "2010-06"
 4627	upside-down finger cuffs	0		Last Available: "2010-06"
 4628	narrow parachute guy	0		Last Available: "2010-06"
-4629	stanky plastic spider ring	0		Stench Spell Damage: +25, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	stanky plastic spider ring	0		Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	cyan Lo Pan's plastic kazoo	0		Spell Critical Percent: +30, Last Available: "2010-06"
 4631	sage inflatable baseball bat	0		Mysticality Percent: +10, Last Available: "2010-06"
-4632	stanky slick googly-star hat	0		Moxie: +10, Stench Spell Damage: +25, Last Available: "2010-06", Familiar Effect: "atk"
+4632	stanky slick googly-star hat	0		Moxie: +10, Stench Spell Damage: +25, Familiar Effect: "atk", Last Available: "2010-06"
 4633	upside-down miser's flame-retardant googly-ball hat	0		Hot Resistance: +1, Meat Drop: +10, Last Available: "2010-06"
 4634	toasty groovy googly-heart hat	0		Moxie Percent: +10, Hot Damage: +5, Last Available: "2010-06"
 4635	clever super-sweet boom box of terror	0		Maximum MP: +20, Spooky Spell Damage: +10, Four Songs, Last Available: "2010-06"
 4636	shaking Game Grid valued membership card	0		Last Available: "2010-06"
-4637	jittery lion tamer's padded brawny sinister demon mask	0		Muscle Percent: +20, Damage Absorption: +20, Experience (familiar): +2, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	jittery lion tamer's padded brawny sinister demon mask	0		Muscle Percent: +20, Damage Absorption: +20, Experience (familiar): +2, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	careful manspreader's streetfighting champion's belt of the detective	0		Monster Level: 0, Item Drop: +20, Single Equip, Last Available: "2010-06"
 4639	blurry Sherlock's gravedigger's sizzling Space Trip safety headphones	0		Hot Damage: +10, Spooky Damage: +10, Item Drop: +25, Single Equip, Last Available: "2010-06"
 4640	bouncing LARP carp of the storm	0		Maximum MP Percent: +40
@@ -4594,8 +4594,8 @@
 4646	pulsating prompt toasty quilted Meteoid ice beam	0		Damage Absorption: +40, Hot Damage: +5, Adventures: +3, Last Available: "2011-12"
 4647	shellacked Dungeon Fist gauntlet of Tarzan of the scaredy-cat	0		Experience (Muscle): +3, Damage Reduction: 7, Monster Level: -15, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	bouncing chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	bouncing chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	nippy sharpshooter's ironic knit cap	0		Critical Hit Percent: +10, Cold Damage: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4603,11 +4603,11 @@
 4655	frosty chaotic ironic jogging shorts of the ox	0		Muscle: +20, Spell Critical Percent: +10, Cold Spell Damage: +10, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	ghostly ruddy mole skin notebook	0		Maximum HP Percent: +40
 4657	pair of jeans	0		Last Available: "2010-09"
-4658	spinning teal map to Ellsbury's Claim	0		Last Available: "2010-09"
+4658	teal spinning map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	shaking blackberry galoshes of the glutton	0		Food Drop: +100, Single Equip
 4660	wobbly medical-grade trout fang of the early riser	0		Adventures: +7, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-09"
-4661	bland diet poisonous caviar	1	decent	Last Available: "2010-09"
-4662	modified galvanized ghostly blurry wet venom duct	0		Effect: "Perception", Effect Duration: 38, Last Available: "2010-09"
+4661	diet bland poisonous caviar	1	decent	Last Available: "2010-09"
+4662	modified galvanized blurry ghostly wet venom duct	0		Effect: "Perception", Effect Duration: 38, Last Available: "2010-09"
 4663	jittery Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	smelly Ellsbury's skull of the storm	0		Maximum MP Percent: +40, Stench Spell Damage: +10, Last Available: "2010-09"
 4665	upside-down pulsating fireproof hot plate	0		Hot Resistance: +3, Damage Reduction: 3
@@ -4618,30 +4618,30 @@
 4670	beer-scented teddy bear	0		
 4671	lousy booze-soaked cherry	3	decent	
 4672	comfy pillow	0		
-4673	stale jumbo pulsating marshmallow	5	decent	
+4673	jumbo stale pulsating marshmallow	5	decent	
 4674	normal sponge cake	3	good	
-4675	fancy acceptable gin-soaked blotter paper	3	good	Effect: "Billiards Belligerence", Effect Duration: 40
+4675	acceptable fancy gin-soaked blotter paper	3	good	Effect: "Billiards Belligerence", Effect Duration: 40
 4676	squat tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	gray smoked potsherd	0		
 4681	resourceful pottery shield	0		Maximum MP: +50, Damage Reduction: 3, Last Available: "2010-09"
-4682	narrow steel-toed sage pottery hat	0		Mysticality Percent: +10, Damage Reduction: 9, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	Temple Grandin's pottery training pants of the blizzard	0		Familiar Weight: +7, Cold Spell Damage: +25, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	narrow steel-toed sage pottery hat	0		Mysticality Percent: +10, Damage Reduction: 9, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	Temple Grandin's pottery training pants of the blizzard	0		Familiar Weight: +7, Cold Spell Damage: +25, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	gray hardy pottery club	0		Maximum HP: +50, Last Available: "2010-09"
 4685	blue lard-coated pottery yo-yo	0		Sleaze Spell Damage: +25, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
 4688	spinning fossilized serpent skull	0		Last Available: "2010-09"
 4689	bouncing bouncing fossilized baboon skull	0		Last Available: "2010-09"
-4690	gray bouncing fossilized wyrm skull	0		Last Available: "2010-09"
-4691	lime green mirror bouncing fossilized wing	0		Last Available: "2010-09"
+4690	bouncing gray fossilized wyrm skull	0		Last Available: "2010-09"
+4691	bouncing lime green mirror fossilized wing	0		Last Available: "2010-09"
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	blinking fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	medical-grade hale Greatest American Pants of temperance	0		Maximum HP: +20, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	medical-grade hale Greatest American Pants of temperance	0		Maximum HP: +20, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	auspicious fossilized necklace	0		Item Drop: +10, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4659,20 +4659,20 @@
 4711	squat sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	flavorless jittery upside-down lemon popsicle	3	decent	
+4714	flavorless upside-down jittery lemon popsicle	3	decent	
 4715	decent half-sized popsicle	2	good	
 4716	rotten blinking strawberry popsicle	3	crappy	
-4717	yummy miniature liver popsicle	2	awesome	
+4717	miniature yummy liver popsicle	2	awesome	
 4718	ruddy mariachi hat	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 2"
 4719	sizzling Hollandaise helmet	0		Hot Damage: +10, Familiar Effect: "atk, cap 2"
 4720	skewed organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	snack-sized delicious liver and let pie	2	awesome	Last Available: "2010-10"
 4723	spoiled badass pie	4	crappy	Last Available: "2010-10"
-4724	normal diet shoo-fish pie	1	good	Last Available: "2010-10"
+4724	diet normal shoo-fish pie	1	good	Last Available: "2010-10"
 4725	moldy tiny piping organ pie	1	crappy	Last Available: "2010-10"
 4726	delicious snack-sized bouncing igloo pie	2	awesome	Last Available: "2010-10"
-4727	spoiled small stomach turnover	2	crappy	Last Available: "2010-10"
+4727	small spoiled stomach turnover	2	crappy	Last Available: "2010-10"
 4728	rotten blue dead lights pie	3	crappy	Last Available: "2010-10"
 4729	moldy throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	stop shield of the early riser	0		Adventures: +7, Damage Reduction: 6, Last Available: "2009-12"
@@ -4689,7 +4689,7 @@
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	green bone chips	0		Last Available: "2011-12"
-4744	concentrated wet pulsating twirling PlexiPips	0		Effect: "The Dinsey Spirit", Effect Duration: 55
+4744	concentrated wet twirling pulsating PlexiPips	0		Effect: "The Dinsey Spirit", Effect Duration: 55
 4745	magnetized cold-filtered blinking twirling Wax Flask	0		Effect: "Tightly-Wound Spine", Effect Duration: 23
 4746	chilled spinning Pain Dip	0		Effect: "Snobby", Effect Duration: 47
 4747	adequate small bone meal	2	good	Last Available: "2010-10"
@@ -4699,8 +4699,8 @@
 4751	boxer's boning knife	0		Muscle Percent: +10, Last Available: "2010-10"
 4752	reassuring bone crusher	0		Spooky Resistance: +1, Last Available: "2010-10"
 4753	cyan Samson's bone spurs	0		Experience (Muscle): +5, Single Equip, Last Available: "2010-10"
-4754	baleful beefcake's bonedanna	0		Muscle: +25, Spell Damage: +25, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	frightening hale boneana hammock	0		Maximum HP: +20, Spooky Damage: +5, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	baleful beefcake's bonedanna	0		Muscle: +25, Spell Damage: +25, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	frightening hale boneana hammock	0		Maximum HP: +20, Spooky Damage: +5, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	yellow mirror bag of bones	0		Last Available: "2010-10"
 4757	jittery Stabonic scroll	0		Last Available: "2010-10"
 4758	dry alkaline blurry candy skeleton	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 25, Last Available: "2020-09"
@@ -4708,7 +4708,7 @@
 4760	upside-down packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	rotten tiny pumpkin pie	1	crappy	Last Available: "2010-11"
+4763	tiny rotten pumpkin pie	1	crappy	Last Available: "2010-11"
 4764	perfectly mixed blinking pumpkin beer	3	EPIC	Last Available: "2010-11"
 4765	chilled ghostly pumpkin juice	0		Effect: "Just the Brown Ones", Effect Duration: 37, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4727,7 +4727,7 @@
 4818	flavorless blurry CRIMBCOIDS mints	4	decent	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	bland narrow bouncing CRIMBCOLOAF	3	decent	Last Available: "2011-01"
-4821	half-sized stale circular CRIMBCOOKIE	2	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	stale half-sized circular CRIMBCOOKIE	2	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	avaricious plastic CRIMBCO HQ	0		Meat Drop: +30, Last Available: "2010-12"
 4823	miser's plastic fax machine	0		Meat Drop: +10, Last Available: "2010-12"
 4824	blinking plastic hobo elf of the pedagogue	0		Experience: +3, Last Available: "2010-12"
@@ -4751,23 +4751,23 @@
 4842	twirling sleeping stocking	0		Last Available: "2010-12"
 4843	blinking Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	narrow experienced Uncle Hobo's stocking cap of Calamity Jane	0		Experience: +2, Critical Hit Percent: +15, Last Available: "2010-12", Familiar Effect: "atk"
+4845	narrow experienced Uncle Hobo's stocking cap of Calamity Jane	0		Experience: +2, Critical Hit Percent: +15, Familiar Effect: "atk", Last Available: "2010-12"
 4846	grievous dance instructor's Uncle Hobo's epic beard	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +50, Single Equip, Last Available: "2010-12"
-4847	narrow tumbling coward's Uncle Hobo's gift baggy pants of temperance	0		Monster Level: -20, Sleaze Resistance: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	narrow tumbling coward's Uncle Hobo's gift baggy pants of temperance	0		Monster Level: -20, Sleaze Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	Sherlock's Annie Oakley's Uncle Hobo's fingerless tinsel gloves	0		Critical Hit Percent: +20, Item Drop: +25, Single Equip, Last Available: "2010-12"
 4849	Jack Frost's Newton's Uncle Hobo's highest bough	0		Experience (Mysticality): +3, Cold Spell Damage: +50, Last Available: "2010-12"
 4850	toasty brainy Uncle Hobo's belt	0		Mysticality: +5, Hot Damage: +5, Single Equip, Last Available: "2010-12"
 4851	ionized Vulcanized gray bouncing chocolate cigar	0		Effect: "Dreadful Smell", Effect Duration: 35, Last Available: "2010-12"
 4852	wizardly gift-a-pult	0		Mysticality: +25, Last Available: "2010-12"
-4853	denatured purple shaking holly-flavored Hob-O	0		Effect: "Action", Effect Duration: 44, Last Available: "2020-09"
+4853	denatured shaking purple holly-flavored Hob-O	0		Effect: "Action", Effect Duration: 44, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
 4857	wobbly bottle of Blank-Out	0		Last Available: "2011-01"
 4858	CRIMBCO lanyard of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2011-01"
 4859	narrow CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
-4860	jittery huge green CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-4861	mirror blurry CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
+4860	green jittery huge CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
+4861	blurry mirror CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	blinking CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	purple photocopier	0		Last Available: "2011-01"
@@ -4775,15 +4775,15 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	MacGyver's hardened Samson's paperclip-on tie	0		Experience (Muscle): +5, Damage Reduction: 3, Maximum MP: +100, Single Equip, Last Available: "2011-01"
-4869	scandalous paperclip pants	0		Sleaze Damage: +5, Item Drop: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	wobbly blue nasty rosy-cheeked paperclip turban of mayonnaise	0		Maximum HP Percent: +30, Stench Damage: +5, Sleaze Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	scandalous paperclip pants	0		Sleaze Damage: +5, Item Drop: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	wobbly blue nasty rosy-cheeked paperclip turban of mayonnaise	0		Maximum HP Percent: +30, Stench Damage: +5, Sleaze Spell Damage: +50, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	blue ribald paperclip cape	0		Sleaze Damage: +10, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	jittery gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	wet colloidal polarized olive chocolate bath ball	0		Effect: "Bubblin' Rage", Effect Duration: 35, Last Available: "2011-01"
-4877	extra-polymerized teal upside-down bacon bath ball	0		Effect: "Human-Penguin Hybrid", Effect Duration: 57, Last Available: "2011-01"
+4877	extra-polymerized upside-down teal bacon bath ball	0		Effect: "Human-Penguin Hybrid", Effect Duration: 57, Last Available: "2011-01"
 4878	altered incense bath ball	0		Effect: "Feet of Watermelon", Effect Duration: 48, Last Available: "2011-01"
 4879	polarized polarized jittery myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Big Flaming Whip", Effect Duration: 68, Last Available: "2011-01"
 4880	mirror CRIMBCO mug	0		Last Available: "2011-01"
@@ -4794,15 +4794,15 @@
 4885	traffic jam	0		Last Available: "2011-01"
 4886	bite-sized yummy huge traffic jam toast	1	awesome	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	special moldy space jam toast	3	crappy	Effect: "Antibiotic Saucesphere", Effect Duration: 20, Last Available: "2011-01"
+4888	moldy special space jam toast	3	crappy	Effect: "Antibiotic Saucesphere", Effect Duration: 20, Last Available: "2011-01"
 4889	super-electrified blurry motivational poster	0		Effect: "Turtle Power", Effect Duration: 42, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	huge bath ball gift set	0		Last Available: "2011-01"
 4892	wobbly slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	spoiled low-calorie festive sausage	1	crappy	Last Available: "2011-01"
-4895	stale small holiday cheese log	2	decent	Last Available: "2011-01"
-4896	skewed yellow holiday log	0		Last Available: "2011-01"
+4894	low-calorie spoiled festive sausage	1	crappy	Last Available: "2011-01"
+4895	small stale holiday cheese log	2	decent	Last Available: "2011-01"
+4896	yellow skewed holiday log	0		Last Available: "2011-01"
 4897	frightening beefy BGE 'ferocious fruit' shirt	0		Muscle: +10, Spooky Damage: +5, Last Available: "2010-12"
 4898	scandalous fortified BGE 'cuddly critter' shirt	0		Damage Absorption: +60, Sleaze Damage: +5, Last Available: "2010-12"
 4899	frosty BGE pocket calendar	0		Cold Spell Damage: +10, Single Equip, Last Available: "2010-12"
@@ -4856,7 +4856,7 @@
 4953	squat resourceful whalebone corset of mayonnaise	0		Maximum MP: +50, Sleaze Spell Damage: +50, Single Equip
 4954	wobbly padded oven mitts	0		Damage Absorption: +20, Single Equip
 4955	toothsome immense overcookie	10	awesome	
-4956	fancy jumbo adequate skewed philosopher's scone	5	good	Effect: "Purpose", Effect Duration: 25
+4956	adequate fancy jumbo skewed philosopher's scone	5	good	Effect: "Purpose", Effect Duration: 25
 4957	quantum half-baked potion	0		Effect: "Concentrated Concentration", Effect Duration: 56
 4958	shaking green Knob Goblin deluxe scimitar of the detective	0		Item Drop: +20
 4959	normal Knob nuts	4	good	
@@ -4914,7 +4914,7 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	tumbling Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	adequate wasabi pocky	3	good	Last Available: "2011-03"
-5014	rotten half-sized tobiko pocky	2	crappy	Last Available: "2011-03"
+5014	half-sized rotten tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	normal natto pocky	3	good	Last Available: "2011-03"
 5016	smooth wasabi-infused sake	3	awesome	Last Available: "2011-03"
 5017	high-proof hand-crafted tobiko-infused sake	6	EPIC	Last Available: "2011-03"
@@ -4924,8 +4924,8 @@
 5021	improved Vulcanized boiled huge natto marble soda	0		Effect: "Full Bottle in front of Me", Effect Duration: 38, Last Available: "2011-03"
 5022	twirling Alice's Army booster box	0		Last Available: "2011-03"
 5023	alkaline shaking elderly jawbreaker	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 31, Last Available: "2020-09"
-5024	weak enchanted tolerable marshmallow flamb&eacute;	2	good	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2011-03"
-5025	distilled artisanal upside-down cranberry schnapps	5	EPIC	Last Available: "2011-03"
+5024	tolerable enchanted weak marshmallow flamb&eacute;	2	good	Effect: "Gingerbread Robust", Effect Duration: 10, Last Available: "2011-03"
+5025	artisanal distilled upside-down cranberry schnapps	5	EPIC	Last Available: "2011-03"
 5026	weak drinkable maroon breaded beer	2	good	Last Available: "2011-03"
 5027	tolerable narrow soy cordial	3	good	Last Available: "2011-03"
 5028	avaricious curative boxer's astral bludgeon	0		Muscle Percent: +10, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5
@@ -4949,9 +4949,9 @@
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	upside-down smelly padded deadly double-ice cap	0		Weapon Damage: +5, Damage Absorption: +20, Stench Spell Damage: +10, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	upside-down smelly padded deadly double-ice cap	0		Weapon Damage: +5, Damage Absorption: +20, Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	ghostly censurious nasty strapping double-ice box	0		Muscle: +5, Stench Damage: +5, Sleaze Resistance: +3, Last Available: "2011-04"
-5051	yellow blurry extremely unsafe double-ice britches of Tarzan of the storm	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Maximum MP Percent: +40, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	yellow blurry extremely unsafe double-ice britches of Tarzan of the storm	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Maximum MP Percent: +40, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	lime green handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	blurry intriguing puzzle box	0		Last Available: "2011-04"
@@ -4971,22 +4971,22 @@
 5068	adequate chaos popcorn	4	good	Last Available: "2011-04"
 5069	upside-down medical-grade hole of dire peril of the bloodbag	0		Weapon Damage: +20, Maximum HP: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-04"
 5070	olive innuendo	0		Last Available: "2011-04"
-5071	decent diet teal s'more	0	good	Last Available: "2011-04"
+5071	diet decent teal s'more	0	good	Last Available: "2011-04"
 5072	shaking diamond ring	0		Last Available: "2011-04"
-5073	weak hand-crafted ghostly Russian Ice	2	EPIC	Last Available: "2011-04"
+5073	hand-crafted weak ghostly Russian Ice	2	EPIC	Last Available: "2011-04"
 5074	clay ashtray of chilblains	0		Cold Damage: +25, Damage Reduction: 3, Last Available: "2011-05"
 5075	blinking blurry Da Vinci's lanyard	0		Experience (Mysticality): +5, Single Equip, Last Available: "2011-05"
-5076	bouncing pulsating maroon chaotic monster pants	0		Spell Critical Percent: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	bouncing pulsating maroon chaotic monster pants	0		Spell Critical Percent: +10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	non-galvanized colloidal mirror Pok&euml;mann band-aid	0		Effect: "Night of the Nachos", Effect Duration: 38, Last Available: "2011-05"
-5079	blurry manspreader's Van der Graaf helmet of mayonnaise	0		Monster Level: +10, Sleaze Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	blurry manspreader's Van der Graaf helmet of mayonnaise	0		Monster Level: +10, Sleaze Spell Damage: +50, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	wicked crutch	0		Spell Damage: +5, Last Available: "2011-05"
 5081	huge foul-smelling shock belt	0		Stench Damage: +10, Single Equip, Last Available: "2011-05"
 5082	aerosolized deionized Okee-Dokee soda	0		Effect: "Armored Innards", Effect Duration: 40, Last Available: "2011-05"
 5083	nasty rubber band gun	0		Stench Damage: +5, Last Available: "2011-05"
-5084	steel-toed pin-stripe slacks	0		Damage Reduction: 9, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	steel-toed pin-stripe slacks	0		Damage Reduction: 9, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	fuchsia Usain Bolt's gloves	0		Initiative: +80, Single Equip, Last Available: "2011-05"
-5086	extra-deionized galvanized ghostly narrow correction fluid	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 29, Last Available: "2011-05"
+5086	extra-deionized galvanized narrow ghostly correction fluid	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 29, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5088	cyan zippy Pok&euml;mann figurine: Magikrap	0		Initiative: +20, Single Equip, Last Available: "2011-05"
 5089	Pok&euml;mann figurine: Vegemite of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2011-05"
@@ -5003,13 +5003,13 @@
 5100	greedy Pok&euml;mann figurine: Frank	0		Meat Drop: +20, Single Equip, Last Available: "2011-05"
 5101	tumbling narrow mansplainer's Pok&euml;mann figurine: Moog	0		Monster Level: +15, Single Equip, Last Available: "2011-05"
 5102	warmed willyweed	0		Effect: "damage.enh", Effect Duration: 66, Last Available: "2011-05"
-5103	anodized oxidized spinning bouncing Nuclear Blastball	0		Effect: "Mayeaugh", Effect Duration: 45, Last Available: "2011-05"
+5103	anodized oxidized bouncing spinning Nuclear Blastball	0		Effect: "Mayeaugh", Effect Duration: 45, Last Available: "2011-05"
 5104	galvanized vacuum-sealed fish juice box	0		Effect: "Ancient Protected", Effect Duration: 23, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	mirror hideous egg	0		Last Available: "2011-05"
 5107	irresponsibly strong perfectly mixed Jeppson's Malort	6	EPIC	Last Available: "2011-06"
 5108	squat fistful of ashes	0		
-5109	wobbly banded stress ball	0		Damage Absorption: +100, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	wobbly banded stress ball	0		Damage Absorption: +100, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	jittery steel-toed Ultracolor&trade; shirt	0		Damage Reduction: 9, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	blue busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	cyan Admiral's hat of the wise owl of the brute of the pedagogue	0		Mysticality: +20, Muscle Percent: +30, Experience: +3, Last Available: "2011-05", Familiar Effect: "atk"
-5122	nippy banded wizardly aviator's cap	0		Mysticality: +25, Damage Absorption: +100, Cold Damage: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	cyan Admiral's hat of the wise owl of the brute of the pedagogue	0		Mysticality: +20, Muscle Percent: +30, Experience: +3, Familiar Effect: "atk", Last Available: "2011-05"
+5122	nippy banded wizardly aviator's cap	0		Mysticality: +25, Damage Absorption: +100, Cold Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	reassuring educational mirrored aviator shades	0		Experience: +1, Spooky Resistance: +1, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	maroon Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5033,7 +5033,7 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	cold-filtered unsweetened jittery Ultrasoldier Serum	0		Effect: "Smokin'", Effect Duration: 21, Last Available: "2011-06"
 5132	moldy blinking elven hardtack	3	crappy	Last Available: "2011-06"
-5133	extra-dry tolerable elven squeeze	5	good	Last Available: "2011-06"
+5133	tolerable extra-dry elven squeeze	5	good	Last Available: "2011-06"
 5134	ghostly lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	pulsating E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	sinister sage honey dipper of Calamity Jane	0		Mysticality Percent: +10, Spell Damage: +10, Critical Hit Percent: +15
 5149	skewed executive careful weightlifter's honeybritches	0		Muscle: +15, Monster Level: -10, Meat Drop: +40, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	cyan prompt dance instructor's groovy honeycap	0		Moxie Percent: +10, Experience Percent (Moxie): +10, Adventures: +3, Familiar Effect: "1xPotato, cap 43"
-5151	wobbly smartaleck's Moonthril Circlet	0		Moxie Percent: +30, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	miser's Moonthril Greaves	0		Meat Drop: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	wobbly smartaleck's Moonthril Circlet	0		Moxie Percent: +30, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	miser's Moonthril Greaves	0		Meat Drop: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	toasty Moonthril Flamberge	0		Hot Damage: +5, Last Available: "2011-06"
 5154	skewed sizzling Moonthril Longbow	0		Hot Damage: +10, Last Available: "2011-06"
 5155	razor-sharp Moonthril Cuirass	0		Weapon Damage Percent: +25, Softcore Only, Last Available: "2011-06"
@@ -5073,10 +5073,10 @@
 5170	flattened irradiated transporter transponder	0		Effect: "BOOsted", Effect Duration: 30, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
-5173	shaking pulsating elven magi-pack	0		Last Available: "2011-06"
+5173	pulsating shaking elven magi-pack	0		Last Available: "2011-06"
 5174	hand-crafted Saison du Lune	3	EPIC	Last Available: "2011-06"
 5175	perfectly mixed watered-down Moonthril Schnapps	2	EPIC	Last Available: "2011-06"
-5176	drinkable distilled Wrecked Generator	5	good	Last Available: "2011-06"
+5176	distilled drinkable Wrecked Generator	5	good	Last Available: "2011-06"
 5177	normal spinning Spaghetti with Moonballs	3	good	Last Available: "2011-06"
 5178	miniature normal narrow jittery Crepes a la Lune	2	good	Last Available: "2011-06"
 5179	flavorless purple Moon Pie	3	decent	Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	boiled honey stick	0		Effect: "Just Aged Enough", Effect Duration: 38
 5189	deionized double-colloidal cyan double-ice gum	0		Effect: "Greedy Resolve", Effect Duration: 57, Last Available: "2011-04"
-5190	shaking censurious Herculean brawny Operation Patriot Shield	0		Muscle Percent: +20, Experience (Muscle): +1, Sleaze Resistance: +3, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	shaking censurious Herculean brawny Operation Patriot Shield	0		Muscle Percent: +20, Experience (Muscle): +1, Sleaze Resistance: +3, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	Vulcanized corrupted data	0		Effect: "Stick Emporium Membership", Effect Duration: 39, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5101,7 +5101,7 @@
 5198	diluted bouncing gooey paste	1	awesome	Effect: "critical.enh", Effect Duration: 15, Last Available: "2011-08"
 5199	denatured mirror beastly paste	1	good	Last Available: "2011-08"
 5200	pickled gray paste	1	awesome	Effect: "Really Deep Breath", Effect Duration: 30, Last Available: "2011-08"
-5201	vaporized jittery shaking ectoplasmic paste	1	decent	Effect: "Carrion' On", Effect Duration: 15, Last Available: "2011-08"
+5201	vaporized shaking jittery ectoplasmic paste	1	decent	Effect: "Carrion' On", Effect Duration: 15, Last Available: "2011-08"
 5202	dried tumbling greasy paste	1	decent	Last Available: "2011-08"
 5203	compressed bug paste	1	EPIC	Last Available: "2011-08"
 5204	powdered shaking hippy paste	1	good	Last Available: "2011-08"
@@ -5111,24 +5111,24 @@
 5208	vaporized spinning paste	1	good	Last Available: "2011-08"
 5209	diluted ghostly goblin paste	1	decent	Last Available: "2011-08"
 5210	modified blinking pirate paste	1	decent	Effect: "Well-preserved", Effect Duration: 35, Last Available: "2011-08"
-5211	boiled shaking red chlorophyll paste	1	decent	Effect: "You Know Who to Call", Effect Duration: 10, Last Available: "2011-08"
+5211	boiled red shaking chlorophyll paste	1	decent	Effect: "You Know Who to Call", Effect Duration: 10, Last Available: "2011-08"
 5212	twisted blurry paste	1	good	Last Available: "2011-08"
 5213	boiled Mer-kin paste	1	EPIC	Last Available: "2011-08"
 5214	modified upside-down slimy paste	1	decent	Last Available: "2011-08"
-5215	denatured purple twirling skewed penguin paste	1	good	Effect: "Turtle Titters", Effect Duration: 45, Last Available: "2011-08"
+5215	denatured skewed purple twirling penguin paste	1	good	Effect: "Turtle Titters", Effect Duration: 45, Last Available: "2011-08"
 5216	powdered elemental paste	1	EPIC	Last Available: "2011-08"
 5217	altered ghostly cosmic paste	1	good	Last Available: "2011-08"
 5218	pickled upside-down hobo paste	1	EPIC	Last Available: "2011-08"
-5219	vaporized spinning squat Crimbo paste	1	good	Effect: "Hyperoffended", Effect Duration: 50, Last Available: "2011-08"
+5219	vaporized squat spinning Crimbo paste	1	good	Effect: "Hyperoffended", Effect Duration: 50, Last Available: "2011-08"
 5220	shaking Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	shaking Thwaitgold grasshopper statuette	0		
-5223	blue Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	normal blurry purple Ur-Donut	3	good	Last Available: "2011-09"
+5223	blue Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5224	normal purple blurry Ur-Donut	3	good	Last Available: "2011-09"
 5225	tumbling The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	practically non-alcoholic mediocre blurry bucket of wine	1	decent	Last Available: "2011-09"
-5228	normal spinning squat ultrafondue	4	good	Last Available: "2011-09"
+5227	mediocre practically non-alcoholic blurry bucket of wine	1	decent	Last Available: "2011-09"
+5228	normal squat spinning ultrafondue	4	good	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	tumbling crystal skull	0		Last Available: "2011-09"
@@ -5139,23 +5139,23 @@
 5236	scandalous frosty halo	0		Sleaze Damage: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	bouncing Newton's time halo	0		Experience (Mysticality): +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	bad practically non-alcoholic Lumineux Limnio	1	decent	Last Available: "2011-09"
-5239	enchanted perfectly mixed spirit-forward huge Morto Moreto	5	EPIC	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2011-09"
+5239	spirit-forward enchanted perfectly mixed huge Morto Moreto	5	EPIC	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2011-09"
 5240	tolerable distilled Temps Tempranillo	5	good	Last Available: "2011-09"
 5241	delicious Bordeaux Marteaux	4	awesome	Last Available: "2011-09"
 5242	watered-down hand-crafted Fromage Pinotage	2	EPIC	Last Available: "2011-09"
 5243	lousy wobbly Beignet Milgranet	4	decent	Last Available: "2011-09"
 5244	hand-crafted Muschat	3	EPIC	Last Available: "2011-09"
 5245	normal half-sized cool jelly donut	2	good	Last Available: "2011-09"
-5246	bite-sized adequate shrapnel jelly donut	1	good	Last Available: "2011-09"
+5246	adequate bite-sized shrapnel jelly donut	1	good	Last Available: "2011-09"
 5247	normal tiny occult jelly donut	1	good	Last Available: "2011-09"
 5248	spoiled thyme jelly donut	3	crappy	Last Available: "2011-09"
 5249	snack-sized yummy danish	2	awesome	Last Available: "2011-09"
 5250	bland small twirling smashed danish	2	decent	Last Available: "2011-09"
-5251	low-calorie adequate forbidden danish	1	good	Last Available: "2011-09"
+5251	adequate low-calorie forbidden danish	1	good	Last Available: "2011-09"
 5252	special delicious cool cat claw	3	awesome	Effect: "Hot Hands", Effect Duration: 10, Last Available: "2011-09"
 5253	adequate fuchsia blunt cat claw	4	good	Last Available: "2011-09"
 5254	normal shadowy cat claw	3	good	Last Available: "2011-09"
-5255	miniature flavorless cheezburger	2	decent	Last Available: "2011-09"
+5255	flavorless miniature cheezburger	2	decent	Last Available: "2011-09"
 5256	spoiled toasted brie	4	crappy	Last Available: "2011-09"
 5257	enhanced chilled potion of the field gar	0		Effect: "Bubblin' Rage", Effect Duration: 63, Last Available: "2011-09"
 5258	triple-aerosolized wet too legit potion	0		Effect: "Chalk Outline", Effect Duration: 35, Last Available: "2011-09"
@@ -5172,7 +5172,7 @@
 5269	blinking bobcat grenade	0		Last Available: "2011-09"
 5270	squat chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
-5272	twirling fuchsia noxious gas grenade	0		Last Available: "2011-09"
+5272	fuchsia twirling noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	hardened hammerus	0		Damage Reduction: 3, Last Available: "2011-09"
@@ -5184,12 +5184,12 @@
 5281	strapping broken clock	0		Muscle: +5, Last Available: "2011-09"
 5282	gray boxer's dethklok	0		Muscle Percent: +10, Last Available: "2011-09"
 5283	huge blurry energetic glacial clock	0		Maximum MP Percent: +20, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	upside-down d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
-5289	fuchsia ghostly d12	0		Last Available: "2011-09"
+5289	ghostly fuchsia d12	0		Last Available: "2011-09"
 5290	upside-down d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	jittery slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	squat dungeon dragon chest	0		Last Available: "2011-09"
 5298	fancy stale phish stick	4	decent	Effect: "Fangs and Pangs", Effect Duration: 5, Last Available: "2011-09"
-5299	inspector's nippy chaotic plastic vampire fangs	0		Spell Critical Percent: +10, Cold Damage: +10, Item Drop: +15, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	inspector's nippy chaotic plastic vampire fangs	0		Spell Critical Percent: +10, Cold Damage: +10, Item Drop: +15, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5224,22 +5224,22 @@
 5321	super-warmed super-tarnished jittery Sweet Sword	0		Effect: "Bootyliciousness", Effect Duration: 37, Last Available: "2011-10"
 5322	aged Ecto-Cooler	4	awesome	Last Available: "2011-10"
 5323	drinkable wobbly Bartles and BRAAAINS wine cooler	3	good	Last Available: "2011-10"
-5324	spirit-forward mediocre Blood Light	5	decent	Last Available: "2011-10"
-5325	special tolerable Silver Bullet beer	3	good	Effect: "Barking Mad", Effect Duration: 40, Last Available: "2011-10"
-5326	fancy drinkable upside-down Bone's Farm &quot;wine&quot;	4	good	Effect: "Stogied", Effect Duration: 5, Last Available: "2011-10"
+5324	mediocre spirit-forward Blood Light	5	decent	Last Available: "2011-10"
+5325	tolerable special Silver Bullet beer	3	good	Effect: "Barking Mad", Effect Duration: 40, Last Available: "2011-10"
+5326	drinkable fancy upside-down Bone's Farm &quot;wine&quot;	4	good	Effect: "Stogied", Effect Duration: 5, Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	super-dry sorority brain	0		Effect: "Deadly Flashing Blade", Effect Duration: 35, Last Available: "2011-10"
 5329	non-liquefied Nightstalker perfume	0		Effect: "Ancient Protected", Effect Duration: 32, Last Available: "2011-10"
 5330	unsweetened liquefied mirror drum of pomade	0		Effect: "Good Karma", Effect Duration: 56, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	perfumed extra-see-thru nightie	0		Stench Resistance: +5, Last Available: "2011-10"
-5333	upside-down prompt BRAINS shorts of the brute	0		Muscle Percent: +30, Adventures: +3, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	upside-down prompt BRAINS shorts of the brute	0		Muscle Percent: +30, Adventures: +3, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	MacGyver's Mesmereyes&trade; contact lenses	0		Maximum MP: +100, Single Equip, Last Available: "2011-10"
 5335	baleful scrunchie	0		Spell Damage: +25, Single Equip, Last Available: "2011-10"
-5336	skewed baleful dance instructor's extremely skinny jeans	0		Experience Percent (Moxie): +10, Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	gravedigger's The Necbromancer's Hat of Calamity Jane	0		Critical Hit Percent: +15, Spooky Damage: +10, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	skewed baleful dance instructor's extremely skinny jeans	0		Experience Percent (Moxie): +10, Spell Damage: +25, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	gravedigger's The Necbromancer's Hat of Calamity Jane	0		Critical Hit Percent: +15, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	Temple Grandin's Van der Graaf wizardly The Necbromancer's Stein	0		Mysticality: +25, Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-10"
-5339	green Jack Frost's sinister The Necbromancer's Shorts of the empath	0		Spell Damage: +10, Familiar Weight: +5, Cold Spell Damage: +50, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	green Jack Frost's sinister The Necbromancer's Shorts of the empath	0		Spell Damage: +10, Familiar Weight: +5, Cold Spell Damage: +50, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	flame-retardant supercool strapping The Necbromancer's Wizard Staff	0		Muscle: +5, Moxie Percent: +20, Hot Resistance: +1, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	perfectly mixed ghostly The Cooler Out of Space	3	EPIC	Last Available: "2011-10"
@@ -5247,10 +5247,10 @@
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	moist nitrogenated shaking Necbro wafers	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 37, Last Available: "2020-09"
 5346	wobbly death blossom	0		
-5347	tumbling twirling blinking A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
-5348	tumbling jittery A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
+5347	blinking twirling tumbling A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+5348	jittery tumbling A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	green A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
-5350	squat upside-down red A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
+5350	red squat upside-down A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
@@ -5271,7 +5271,7 @@
 5368	Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	dangerous KoL Con 8-Bit power bracelet	0		Weapon Damage: +10, Last Available: "2011-09"
 5370	pulsating boiler	0		
-5371	narrow shaking stuffed-shirt scarecrow	0		Free Pull, Last Available: "2011-11"
+5371	shaking narrow stuffed-shirt scarecrow	0		Free Pull, Last Available: "2011-11"
 5372	fuchsia manspreader's plastic trollipop	0		Monster Level: +10, Last Available: "2011-12"
 5373	nippy plastic Fudge Wizard	0		Cold Damage: +10, Last Available: "2011-12"
 5374	bouncing mirror grievous plastic abominable fudgeman	0		Weapon Damage Percent: +50, Last Available: "2011-12"
@@ -5279,10 +5279,10 @@
 5376	vibrating fortified plastic Big Candy	0		Damage Absorption: +60, Maximum MP Percent: +10, Last Available: "2011-12"
 5377	The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	blinking spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	powdered pulsating blue ghostly groose grease	1	awesome	Last Available: "2012-12"
-5380	bouncing purple lollipop stick	0		Last Available: "2011-11"
+5379	powdered blue pulsating ghostly groose grease	1	awesome	Last Available: "2012-12"
+5380	purple bouncing lollipop stick	0		Last Available: "2011-11"
 5381	jittery pulsating bananagate	0		Last Available: "2011-11"
-5382	narrow olive pearidot	0		Last Available: "2011-11"
+5382	olive narrow pearidot	0		Last Available: "2011-11"
 5383	tourmalime	0		Last Available: "2011-11"
 5384	pulsating kumquartz	0		Last Available: "2011-11"
 5385	maroon strawberyl	0		Last Available: "2011-11"
@@ -5301,16 +5301,16 @@
 5398	blurry peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
-5401	pulsating tumbling bouncing peppermint parasol	0		Last Available: "2011-11"
+5401	tumbling pulsating bouncing peppermint parasol	0		Last Available: "2011-11"
 5402	blinking blue Jeselnik's candy cane	0		Sleaze Damage: +25, Last Available: "2011-12"
 5403	blurry Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	friendly razor-sharp brawny cane-mail shirt	0		Muscle Percent: +20, Weapon Damage Percent: +25, Familiar Weight: +3, Last Available: "2011-12"
-5406	stanky occult supercool cane-mail pants	0		Moxie Percent: +20, Spell Damage Percent: +25, Stench Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	stanky occult supercool cane-mail pants	0		Moxie Percent: +20, Spell Damage Percent: +25, Stench Spell Damage: +25, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	lousy gray Vodka Matryoshka	3	decent	Last Available: "2011-12"
 5408	weak drinkable jittery Gin Mint	2	good	Last Available: "2011-12"
 5409	watered-down aged Tequiz Navidad	2	awesome	Last Available: "2011-12"
-5410	triple-distilled tolerable mirror Mint Yulep	8	good	Last Available: "2011-12"
+5410	tolerable triple-distilled mirror Mint Yulep	8	good	Last Available: "2011-12"
 5411	bad Crimbojito	3	decent	Last Available: "2011-12"
 5412	drinkable weak twirling Sangria de Menthe	2	good	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
@@ -5319,7 +5319,7 @@
 5416	oxidized banana supersucker	0		Effect: "Memories of Puppy Love", Effect Duration: 41, Last Available: "2011-11"
 5417	improved pear supersucker	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 49, Last Available: "2011-11"
 5418	super-improved energized lime supersucker	0		Effect: "Buff as a Baobab", Effect Duration: 25, Last Available: "2011-11"
-5419	oxidized pulsating red kumquat supersucker	0		Effect: "Reptilian Fortitude", Effect Duration: 44, Last Available: "2011-11"
+5419	oxidized red pulsating kumquat supersucker	0		Effect: "Reptilian Fortitude", Effect Duration: 44, Last Available: "2011-11"
 5420	flattened maroon strawberry supersucker	0		Effect: "Bark of the Dog", Effect Duration: 56, Last Available: "2011-11"
 5421	shaking personal trainer's bananarama bangle	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2011-11"
 5422	banded pair of pearidot earrings	0		Damage Absorption: +100, Single Equip, Last Available: "2011-11"
@@ -5327,29 +5327,29 @@
 5424	blinking shellacked kumquartz ring	0		Damage Reduction: 7, Single Equip, Last Available: "2011-11"
 5425	huge huge Da Vinci's strawberyl necklace	0		Experience (Mysticality): +5, Single Equip, Last Available: "2011-11"
 5426	sucker bucket of doom of the cheetah	0		Spooky Spell Damage: +50, Initiative: +60, Last Available: "2011-11"
-5427	blurry censurious sucker hakama	0		Sleaze Resistance: +3, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	mansplainer's sucker kabuto	0		Monster Level: +15, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	blurry censurious sucker hakama	0		Sleaze Resistance: +3, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	mansplainer's sucker kabuto	0		Monster Level: +15, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	Da Vinci's sucker tachi	0		Experience (Mysticality): +5, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
 5432	grape troll doll	0		Last Available: "2011-11"
 5433	raspberry troll doll	0		Last Available: "2011-11"
-5434	pulsating green DNOTC Box	0		Last Available: "2017-12"
+5434	green pulsating DNOTC Box	0		Last Available: "2017-12"
 5435	blurry fudgecule	0		Last Available: "2011-11"
 5436	quantum pressed fudge lily	0		Effect: "Blood-Gorged", Effect Duration: 26, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	aerosolized super-irradiated fluid of fudge-finding	0		Effect: "Goldentongue", Effect Duration: 38, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	flavorless miniature fudgesicle	2	decent	Last Available: "2011-11"
+5440	miniature flavorless fudgesicle	2	decent	Last Available: "2011-11"
 5441	cyan wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	jittery miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	ionized green devilish folio	0		Effect: "Mushroom Might", Effect Duration: 48, Last Available: "2012-12"
-5445	shaking tumbling clumsiness bark	0		Last Available: "2012-12"
+5445	tumbling shaking clumsiness bark	0		Last Available: "2012-12"
 5446	jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
-5449	wobbly cyan vanity stone	0		Last Available: "2012-12"
+5449	cyan wobbly vanity stone	0		Last Available: "2012-12"
 5450	blinking lecherous stone	0		Last Available: "2012-12"
 5451	jealousy stone	0		Last Available: "2012-12"
 5452	avarice stone	0		Last Available: "2012-12"
@@ -5358,12 +5358,12 @@
 5455	narrow gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	electrified cold-filtered bouncing Fudgie Roll	0		Effect: "Jungle Juiced", Effect Duration: 47, Last Available: "2011-11"
-5458	moldy low-calorie fudge bunny	1	crappy	Last Available: "2011-11"
+5458	low-calorie moldy fudge bunny	1	crappy	Last Available: "2011-11"
 5459	pulsating fudge spork	0		Last Available: "2011-11"
 5460	mansplainer's fudgecycle of Gandalf of Leguizamo	0		Spell Critical Percent: +20, Monster Level: 35, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	lime green Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	lime green Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	tarnished polarized resolution: be wealthier	0		Effect: "Salsa Satanica", Effect Duration: 69, Last Available: "2012-01"
 5465	denatured resolution: be happier	0		Effect: "Salsa Satanica", Effect Duration: 18, Last Available: "2012-01"
 5466	activated galvanized resolution: be stronger	0		Effect: "Sweet and Red", Effect Duration: 18, Last Available: "2012-01"
@@ -5379,8 +5379,8 @@
 5476	denatured spinning gummi salamander	0		Effect: "Hypercubed", Effect Duration: 40, Last Available: "2011-11"
 5477	non-dry quadruple-altered teal gummi snake	0		Effect: "Afternoon Insight", Effect Duration: 19, Last Available: "2011-11"
 5478	electrified diffused gummi canary	0		Effect: "Human-Elemental Hybrid", Effect Duration: 24, Last Available: "2011-11"
-5479	rotten diet gummi bear	1	crappy	Last Available: "2011-11"
-5480	small rotten lime green gummi bear	2	crappy	Last Available: "2011-11"
+5479	diet rotten gummi bear	1	crappy	Last Available: "2011-11"
+5480	rotten small lime green gummi bear	2	crappy	Last Available: "2011-11"
 5481	stale gummi bear	3	decent	Last Available: "2011-11"
 5482	decent drunki-bear	3	good	Last Available: "2011-11"
 5483	decent drunki-bear	4	good	Last Available: "2011-11"
@@ -5394,12 +5394,12 @@
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	huge belemnite candy mold	0		Last Available: "2011-11"
-5494	pressed vacuum-sealed wobbly upside-down lime green gummi trilobite	0		Effect: "Uncanny Shot", Effect Duration: 27, Last Available: "2011-11"
+5494	pressed vacuum-sealed upside-down wobbly lime green gummi trilobite	0		Effect: "Uncanny Shot", Effect Duration: 27, Last Available: "2011-11"
 5495	pressed warmed gummi ammonite	0		Effect: "Inebriate Pride", Effect Duration: 59, Last Available: "2011-11"
 5496	liquefied deionized gummi belemnite	0		Effect: "Weepy, Creepy", Effect Duration: 49, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	blinking heart of dark chocolate	0		Last Available: "2011-11"
-5499	gravedigger's Big Candy's tophat of the sweet-tooth	0		Spooky Damage: +10, Candy Drop: +100, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	gravedigger's Big Candy's tophat of the sweet-tooth	0		Spooky Damage: +10, Candy Drop: +100, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	bouncing Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	moldy jerky coins	4	crappy	Last Available: "2011-11"
-5507	weak tolerable Go-Wassail	2	good	Last Available: "2011-11"
+5507	tolerable weak Go-Wassail	2	good	Last Available: "2011-11"
 5508	double-boiled cold-filtered Uncle Greenspan's Bathroom Finance Guide	0		Effect: "5 Pounds Lighter", Effect Duration: 28, Last Available: "2011-11"
 5509	concentrated adjusted bottle of bubbles	0		Effect: "Smelly Pants", Effect Duration: 51, Last Available: "2011-11"
 5510	unsweetened wind-up meatcar	0		Effect: "Piratastic", Effect Duration: 67, Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	ionized red skewed Atomic Pop	0		Effect: "Eyes All Black", Effect Duration: 62, Last Available: "2020-09"
 5527	blurry huge do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	jittery whimpering willow bark	0		Last Available: "2012-12"
-5529	adequate diet berries of suffering	1	good	Last Available: "2012-12"
+5529	diet adequate berries of suffering	1	good	Last Available: "2012-12"
 5530	ionized colloidal baobab sap	0		Effect: "Spooky Demeanor", Effect Duration: 38, Last Available: "2012-12"
 5531	jittery cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
@@ -5444,8 +5444,8 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	twirling inspector's knitted Leapin' Trousers	0		Cold Resistance: +3, Item Drop: +15
-5544	delicious watered-down enchanted eggnog	2	awesome	Effect: "Rat-Faced", Effect Duration: 45, Last Available: "2012-12"
-5545	flavorless miniature special bouncing hamhock	2	decent	Effect: "Ogred and Oublietted", Effect Duration: 5, Last Available: "2012-12"
+5544	delicious enchanted watered-down eggnog	2	awesome	Effect: "Rat-Faced", Effect Duration: 45, Last Available: "2012-12"
+5545	miniature flavorless special bouncing hamhock	2	decent	Effect: "Ogred and Oublietted", Effect Duration: 5, Last Available: "2012-12"
 5546	narrow The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	jittery Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	bouncing perfumed hardened Rain-Doh wings	0		Damage Reduction: 3, Stench Resistance: +5, Softcore Only, Last Available: "2012-02"
 5557	shaking huge Rain-Doh agent	0		Last Available: "2012-02"
 5558	vibrating personal trainer's Rain-Doh laser gun	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Softcore Only, Last Available: "2012-02"
-5559	teal executive scandalous Rain-Doh lantern	0		Sleaze Damage: +5, Meat Drop: +40, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	teal executive scandalous Rain-Doh lantern	0		Sleaze Damage: +5, Meat Drop: +40, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	wobbly Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	knitted Rain-Doh violet bo of vim and vigor	0		Maximum HP Percent: +50, Cold Resistance: +3, Softcore Only, Last Available: "2012-02"
@@ -5467,7 +5467,7 @@
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	bland fuchsia PB&BP	4	decent	
 5566	rotten super-sized teal club sandwich	5	crappy	
-5567	special half-sized rotten corned-beef Reuben	2	crappy	Effect: "Riboflavin'", Effect Duration: 40
+5567	half-sized special rotten corned-beef Reuben	2	crappy	Effect: "Riboflavin'", Effect Duration: 40
 5568	frayed ninja rope	0		
 5569	maroon dull ninja crampons	0		
 5570	loose ninja carabiner	0		
@@ -5475,13 +5475,13 @@
 5572	Thwaitgold stag beetle statuette	0		
 5573	weak drinkable Drac & Tan	2	good	Last Available: "2012-03"
 5574	special drinkable Transylvania Sling	4	good	Effect: "Held Closer", Effect Duration: 15, Last Available: "2012-03"
-5575	watered-down bad Shot of the Living Dead	2	decent	Last Available: "2012-03"
+5575	bad watered-down Shot of the Living Dead	2	decent	Last Available: "2012-03"
 5576	practically non-alcoholic acceptable Buttery Knob	1	good	Last Available: "2012-03"
-5577	smooth watered-down Slippery Knob	2	awesome	Last Available: "2012-03"
+5577	watered-down smooth Slippery Knob	2	awesome	Last Available: "2012-03"
 5578	perfectly mixed mirror Flaming Knob	4	EPIC	Last Available: "2012-03"
-5579	lousy weak narrow pulsating Grasshopper	2	decent	Last Available: "2012-03"
+5579	weak lousy pulsating narrow Grasshopper	2	decent	Last Available: "2012-03"
 5580	fancy bad boozy shaking Locust	5	decent	Effect: "Rampage!", Effect Duration: 50, Last Available: "2012-03"
-5581	mediocre irresponsibly strong fancy Plague of Locusts	7	decent	Effect: "Wet Jaw", Effect Duration: 15, Last Available: "2012-03"
+5581	fancy irresponsibly strong mediocre Plague of Locusts	7	decent	Effect: "Wet Jaw", Effect Duration: 15, Last Available: "2012-03"
 5582	aged Red Dwarf	3	awesome	Last Available: "2012-03"
 5583	drinkable weak spinning Golden Mean	2	good	Last Available: "2012-03"
 5584	aged Green Giant	3	awesome	Last Available: "2012-03"
@@ -5489,52 +5489,52 @@
 5586	triple-distilled lousy red Aye Aye, Captain	10	decent	Last Available: "2012-03"
 5587	hand-crafted Aye Aye, Tooth Tooth	3	EPIC	Last Available: "2012-03"
 5588	bad Humanitini	3	decent	Last Available: "2012-03"
-5589	mediocre special More Humanitini than Humanitini	3	decent	Effect: "Preemptive Medicine", Effect Duration: 40, Last Available: "2012-03"
+5589	special mediocre More Humanitini than Humanitini	3	decent	Effect: "Preemptive Medicine", Effect Duration: 40, Last Available: "2012-03"
 5590	acceptable Oh, the Humanitini	3	good	Last Available: "2012-03"
 5591	mediocre watered-down Great Older Fashioned	2	decent	Last Available: "2012-03"
 5592	acceptable high-proof green Fuzzy Tentacle	10	good	Last Available: "2012-03"
 5593	hand-crafted Crazymaker	4	EPIC	Last Available: "2012-03"
-5594	drinkable irresponsibly strong Zoodriver	9	good	Last Available: "2012-03"
-5595	strong acceptable lime green Sloe Comfortable Zoo	5	good	Last Available: "2012-03"
-5596	fancy weak lousy Sloe Comfortable Zoo on Fire	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2012-03"
+5594	irresponsibly strong drinkable Zoodriver	9	good	Last Available: "2012-03"
+5595	acceptable strong lime green Sloe Comfortable Zoo	5	good	Last Available: "2012-03"
+5596	fancy lousy weak Sloe Comfortable Zoo on Fire	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2012-03"
 5597	hand-crafted boozy Suffering Sinner	5	EPIC	Last Available: "2012-03"
-5598	irresponsibly strong lousy pulsating gray Suppurating Sinner	7	decent	Last Available: "2012-03"
+5598	lousy irresponsibly strong gray pulsating Suppurating Sinner	7	decent	Last Available: "2012-03"
 5599	aged Sizzling Sinner	3	awesome	Last Available: "2012-03"
 5600	hand-crafted Firewater	4	EPIC	Last Available: "2012-03"
 5601	irresponsibly strong bad Earth and Firewater	10	decent	Last Available: "2012-03"
-5602	fancy artisanal Earth, Wind and Firewater	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25, Last Available: "2012-03"
+5602	artisanal fancy Earth, Wind and Firewater	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25, Last Available: "2012-03"
 5603	hand-crafted upside-down Slimosa	4	EPIC	Last Available: "2012-03"
-5604	smooth jittery maroon Extra-slimy Slimosa	4	awesome	Last Available: "2012-03"
+5604	smooth maroon jittery Extra-slimy Slimosa	4	awesome	Last Available: "2012-03"
 5605	lousy Slimebite	3	decent	Last Available: "2012-03"
 5606	weak mediocre Cement Mixer	2	decent	Last Available: "2012-03"
 5607	lousy Jackhammer	3	decent	Last Available: "2012-03"
 5608	mediocre Dump Truck	4	decent	Last Available: "2012-03"
 5609	artisanal Fauna Libre	3	EPIC	Last Available: "2012-03"
-5610	strong hand-crafted wobbly Chakra Libre	5	EPIC	Last Available: "2012-03"
+5610	hand-crafted strong wobbly Chakra Libre	5	EPIC	Last Available: "2012-03"
 5611	bad bouncing Aura Libre	4	decent	Last Available: "2012-03"
-5612	extra-dry mediocre Sazerorc	5	decent	Last Available: "2012-03"
-5613	mediocre irresponsibly strong bouncing Sazuruk-hai	10	decent	Last Available: "2012-03"
-5614	watered-down perfectly mixed Flaming Sazerorc	2	EPIC	Last Available: "2012-03"
-5615	weak mediocre Green Velvet	2	decent	Last Available: "2012-03"
-5616	lousy special Green Muslin	3	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35, Last Available: "2012-03"
-5617	spirit-forward hand-crafted Green Burlap	5	EPIC	Last Available: "2012-03"
+5612	mediocre extra-dry Sazerorc	5	decent	Last Available: "2012-03"
+5613	irresponsibly strong mediocre bouncing Sazuruk-hai	10	decent	Last Available: "2012-03"
+5614	perfectly mixed watered-down Flaming Sazerorc	2	EPIC	Last Available: "2012-03"
+5615	mediocre weak Green Velvet	2	decent	Last Available: "2012-03"
+5616	special lousy Green Muslin	3	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35, Last Available: "2012-03"
+5617	hand-crafted spirit-forward Green Burlap	5	EPIC	Last Available: "2012-03"
 5618	aged Mohobo	4	awesome	Last Available: "2012-03"
 5619	strong mediocre Moonshine Mohobo	5	decent	Last Available: "2012-03"
 5620	lousy shaking Flaming Mohobo	3	decent	Last Available: "2012-03"
 5621	smooth ghostly Drunken Philosopher	3	awesome	Last Available: "2012-03"
 5622	tolerable Drunken Neurologist	3	good	Last Available: "2012-03"
-5623	enchanted perfectly mixed irresponsibly strong huge Drunken Astrophysicist	8	EPIC	Effect: "Moose Wisdom", Effect Duration: 30, Last Available: "2012-03"
+5623	irresponsibly strong perfectly mixed enchanted huge Drunken Astrophysicist	8	EPIC	Effect: "Moose Wisdom", Effect Duration: 30, Last Available: "2012-03"
 5624	bad Dark & Starry	3	decent	Last Available: "2012-03"
-5625	extra-dry acceptable upside-down Black Hole	5	good	Last Available: "2012-03"
+5625	acceptable extra-dry upside-down Black Hole	5	good	Last Available: "2012-03"
 5626	mediocre Event Horizon	3	decent	Last Available: "2012-03"
 5627	lousy Herring Daiquiri	4	decent	Last Available: "2012-03"
 5628	perfectly mixed Herring Wallbanger	3	EPIC	Last Available: "2012-03"
-5629	artisanal weak Herringtini	2	EPIC	Last Available: "2012-03"
+5629	weak artisanal Herringtini	2	EPIC	Last Available: "2012-03"
 5630	mediocre upside-down Lollipop Drop	3	decent	Last Available: "2012-03"
-5631	distilled aged skewed Candy Alexander	5	awesome	Last Available: "2012-03"
-5632	high-proof drinkable fancy Candicaine	8	good	Effect: "Nasty, Nasty Breath", Effect Duration: 45, Last Available: "2012-03"
-5633	drinkable weak Caipiranha	2	good	Last Available: "2012-03"
-5634	distilled tolerable Flying Caipiranha	5	good	Last Available: "2012-03"
+5631	aged distilled skewed Candy Alexander	5	awesome	Last Available: "2012-03"
+5632	fancy high-proof drinkable Candicaine	8	good	Effect: "Nasty, Nasty Breath", Effect Duration: 45, Last Available: "2012-03"
+5633	weak drinkable Caipiranha	2	good	Last Available: "2012-03"
+5634	tolerable distilled Flying Caipiranha	5	good	Last Available: "2012-03"
 5635	distilled lousy squat Flaming Caipiranha	5	decent	Last Available: "2012-03"
 5636	delicious Punchplanter	3	awesome	Last Available: "2012-03"
 5637	lousy Doublepunchplanter	4	decent	Last Available: "2012-03"
@@ -5548,9 +5548,9 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	lime green foul-smelling calendar	0		Stench Damage: +10, Damage Reduction: 4
-5648	upside-down miser's wool Boris's Helm	0		Cold Resistance: +1, Meat Drop: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	upside-down miser's wool Boris's Helm	0		Cold Resistance: +1, Meat Drop: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	spinning quilted staph of homophones of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40
-5650	rosewater-soaked Tesla Boris's Helm (askew) of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	rosewater-soaked Tesla Boris's Helm (askew) of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	twirling mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
@@ -5577,9 +5577,9 @@
 5674	&quot;L&quot;	0		
 5675	altered watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	gray horrifying Ze&trade; goggles	0		Spooky Damage: +25, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	gray horrifying Ze&trade; goggles	0		Spooky Damage: +25, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	red lightning-fast scorching stylish swimsuit	0		Hot Damage: +25, Initiative: +40, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	red lightning-fast scorching stylish swimsuit	0		Hot Damage: +25, Initiative: +40, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	fancy spoiled P.B.L.T.	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 5
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5587,7 +5587,7 @@
 5684	red handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	blurry quantum nanopolymer spider web	0		
-5687	huge blue bugbear autopsy tweezers	0		
+5687	blue huge bugbear autopsy tweezers	0		
 5688	olive Socratic UV monocular	0		Experience (Mysticality): +1, Single Equip
 5689	drone self-destruct chip	0		
 5690	Jeff Goldblum larva	0		
@@ -5605,16 +5605,16 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	rosewater-soaked Temple Grandin's wax hat	0		Familiar Weight: +7, Stench Resistance: +3, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	censurious Lo Pan's wax pants	0		Spell Critical Percent: +30, Sleaze Resistance: +3, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	rosewater-soaked Temple Grandin's wax hat	0		Familiar Weight: +7, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	censurious Lo Pan's wax pants	0		Spell Critical Percent: +30, Sleaze Resistance: +3, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	bouncing FDKOL commendation	0		Last Available: "2012-07"
 5708	ionized electrified drop of water-37	0		Effect: "Busy Bein' Delicious", Effect Duration: 16, Last Available: "2012-07"
-5709	huge vibrating fireman's helmet of the pedagogue	0		Experience: +3, Maximum MP Percent: +10, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	huge vibrating fireman's helmet of the pedagogue	0		Experience: +3, Maximum MP Percent: +10, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	shaking flame-retardant fire axe	0		Hot Resistance: +1, Last Available: "2012-07"
 5713	banded experienced beefy fire extinguisher	0		Muscle: +10, Experience: +2, Damage Absorption: +100, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5716	red skewed Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
+5716	skewed red Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	moldy FDKOL hotcakes	3	crappy	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
@@ -5624,8 +5624,8 @@
 5723	boiled bottle of fire	0		Effect: "Block-Rockin' Beet", Effect Duration: 58, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	greedy Oprah's hot daub bun	0		Maximum MP Percent: +50, Meat Drop: +20, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	up-at-dawn frosty hot daub stand	0		Cold Spell Damage: +10, Adventures: +5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	greedy Oprah's hot daub bun	0		Maximum MP Percent: +50, Meat Drop: +20, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	up-at-dawn frosty hot daub stand	0		Cold Spell Damage: +10, Adventures: +5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	red mirror mansplainer's foot-long hot daub of incineration	0		Monster Level: +15, Hot Spell Damage: +50, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	normal huge angst burger	7	good	
@@ -5633,15 +5633,15 @@
 5732	cyan tumbling blank note	0		
 5733	teal eerily silent box	0		
 5734	bland forbidden sausage	3	decent	
-5735	Lord Flameface's cloak of the glutton	0		Food Drop: +100, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Lord Flameface's cloak of the glutton	0		Food Drop: +100, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	quadruple-frozen pulsating Drizzlers&trade; Black Licorice	0		Effect: "Crimbo Epiphany", Effect Duration: 31
 5737	super-corrupted moist daub-breaker	0		Effect: "Reedy Pipes", Effect Duration: 16, Last Available: "2020-09"
 5738	frosty Camp Scout backpack	0		Cold Spell Damage: +10, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	flavorless bag of GORP	3	decent	Last Available: "2012-07"
-5741	lousy weak skewed water purification pills	2	decent	Last Available: "2012-07"
+5741	weak lousy skewed water purification pills	2	decent	Last Available: "2012-07"
 5742	mirror Camp Scout pup tent	0		Last Available: "2012-07"
-5743	watered-down enchanted perfectly mixed CSA scoutmaster's &quot;water&quot;	2	EPIC	Effect: "Jelly Combed", Effect Duration: 40, Last Available: "2012-07"
+5743	enchanted perfectly mixed watered-down CSA scoutmaster's &quot;water&quot;	2	EPIC	Effect: "Jelly Combed", Effect Duration: 40, Last Available: "2012-07"
 5744	half-sized decent bag of GORF	2	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	normal cyan bag of QWOP	4	good	Last Available: "2012-07"
@@ -5650,10 +5650,10 @@
 5749	bad strong CSA cheerfulness ration	5	decent	Last Available: "2012-07"
 5750	blue CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	bland miniature shaking crappy brain	2	decent	
-5753	miniature decent fancy decent brain	2	good	Effect: "X-Ray Vision", Effect Duration: 25
+5752	miniature bland shaking crappy brain	2	decent	
+5753	fancy decent miniature decent brain	2	good	Effect: "X-Ray Vision", Effect Duration: 25
 5754	normal good brain	3	good	
-5755	spoiled miniature boss brain	2	crappy	
+5755	miniature spoiled boss brain	2	crappy	
 5756	decent purple hunter brain	3	good	
 5758	steel-toed forbidden Staff of Holiday Sensations of the sewer	0		Spell Damage Percent: +50, Damage Reduction: 9, Stench Damage: +25, Last Available: "2011-11"
 5759	pulsating scandalous electrified staff	0		Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5
@@ -5665,11 +5665,11 @@
 5765	therapeutic fuzzy earmuffs of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1.5xVolley, cap 32"
 5766	foul-smelling crafty fuzzy montera of the storm	0		Maximum MP Percent: +40, Maximum MP: +10, Stench Damage: +10, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "damage"
-5771	spinning gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "gain advs"
-5772	fuchsia ghostly gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	spinning gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	fuchsia ghostly gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	lime green Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	skewed huge fronts	0		Familiar Weight: +5
@@ -5677,7 +5677,7 @@
 5778	bland idiot brain	3	decent	
 5779	curative keel-haulin' knife	0		HP Regen Min: 3, HP Regen Max: 5
 5780	flame-wreathed ice cream scoop	0		Hot Spell Damage: +10
-5781	extra-dry perfectly mixed soft echo eyedrop antidote martini	5	EPIC	
+5781	perfectly mixed extra-dry soft echo eyedrop antidote martini	5	EPIC	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5687,20 +5687,20 @@
 5788	smut orc keepsake box	0		
 5789	pulsating bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	shaking cyan fortified grievous right bear arm	0		Weapon Damage Percent: +50, Damage Absorption: +60, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	double-paned brawny left bear arm of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, Cold Resistance: +5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	shaking cyan fortified grievous right bear arm	0		Weapon Damage Percent: +50, Damage Absorption: +60, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	double-paned brawny left bear arm of the bloodbag	0		Muscle Percent: +20, Maximum HP: +100, Cold Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	narrow clever Hat O' Nine Tails	0		Maximum MP: +20
 5794	boiled altered Enchanted Plunger	0		Effect: "Bilious Briskness", Effect Duration: 25
 5795	extra-polymerized denatured skewed Enchanted Flyswatter	0		Effect: "Floundering", Effect Duration: 24
 5796	diffused olive Gearhead Goo	0		Effect: "Comic Violence", Effect Duration: 29
-5797	diffused ionized mirror skewed Missing Eye Simulation Device	0		Effect: "Video Game Hot Dog", Effect Duration: 11
+5797	diffused ionized skewed mirror Missing Eye Simulation Device	0		Effect: "Video Game Hot Dog", Effect Duration: 11
 5798	wet chilled wobbly Gnollish Crossdress	0		Effect: "Wet Jaw", Effect Duration: 21
 5799	concentrated eldritch dough	0		Effect: "Trufflin'", Effect Duration: 33
 5800	improved electrified Charity's choker	0		Effect: "Oth-Jeal-O", Effect Duration: 40
 5801	diffused cold-filtered Smart Bone Dust	0		Effect: "Educated (Kinda)", Effect Duration: 31
 5802	magnetized modified squat perpendicular guano	0		Effect: "Space Cowboy", Effect Duration: 54
 5803	quadruple-irradiated enhanced ionized skewed White Chocolate Golem Seeds	0		Effect: "Superhuman Sarcasm", Effect Duration: 26
-5804	anodized squat huge Shivering Ch&egrave;vre	0		Effect: "Hobo Flavor", Effect Duration: 44
+5804	anodized huge squat Shivering Ch&egrave;vre	0		Effect: "Hobo Flavor", Effect Duration: 44
 5805	triple-magnetized squat breath mint	0		Effect: "Buzzard Breath", Effect Duration: 69
 5806	flattened magnetized olive muesli	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 18
 5807	pressed extra-wet glass of warm milk	0		Effect: "Hammered", Effect Duration: 34
@@ -5713,11 +5713,11 @@
 5814	flattened blob of acid	0		Effect: "Muscle Unbound", Effect Duration: 27
 5815	unsweetened anodized flayed mind	0		Effect: "Eyes for Miles", Effect Duration: 33
 5816	concentrated activated kobold kibble	0		Effect: "Broken Fast", Effect Duration: 39
-5817	Vulcanized twirling narrow blurry forest spirit rattle	0		Effect: "Cake Caked", Effect Duration: 54
+5817	Vulcanized blurry twirling narrow forest spirit rattle	0		Effect: "Cake Caked", Effect Duration: 54
 5818	oxidized Stone Golem pebbles	0		Effect: "Unrunnable Face", Effect Duration: 11
 5819	triple-pickled jittery gravy fairy warlock hat	0		Effect: "Magically Fingered", Effect Duration: 46
-5820	diffused liquefied upside-down squat bull blubber	0		Effect: "Resilient Spirit", Effect Duration: 13
-5821	vacuum-sealed unsweetened wobbly gray blinking frog lip-print	0		Effect: "Icy Demeanor", Effect Duration: 51
+5820	diffused liquefied squat upside-down bull blubber	0		Effect: "Resilient Spirit", Effect Duration: 13
+5821	vacuum-sealed unsweetened blinking gray wobbly frog lip-print	0		Effect: "Icy Demeanor", Effect Duration: 51
 5822	double-Vulcanized blue gazely stare	0		Effect: "Scrappy, Shadowy", Effect Duration: 23
 5823	aerosolized altered teal canopic jar	0		Effect: "Optimist Primal", Effect Duration: 37
 5824	colloidal spinning clove-flavored lip balm	0		Effect: "Filled with Magic", Effect Duration: 33
@@ -5733,9 +5733,9 @@
 5834	flattened oxidized blurry holistic headache remedy	0		Effect: "Human-Penguin Hybrid", Effect Duration: 64
 5835	ionized scrunchie tourniquet	0		Effect: "Beta Carotene Overdose", Effect Duration: 48
 5836	enhanced improved concentrated pulsating embezzler's oil	0		Effect: "Stenchtastic", Effect Duration: 49
-5837	Vulcanized blinking wobbly shaking Fu Manchu Wax	0		Effect: "Chock Full o' Nanites", Effect Duration: 32
+5837	Vulcanized shaking blinking wobbly Fu Manchu Wax	0		Effect: "Chock Full o' Nanites", Effect Duration: 32
 5838	galvanized Iiti Kitty Gumdrop	0		Effect: "Red Misty-Eyed", Effect Duration: 43
-5839	vacuum-sealed anodized unsweetened bouncing tumbling ravenous eye	0		Effect: "Object Detection", Effect Duration: 49
+5839	vacuum-sealed anodized unsweetened tumbling bouncing ravenous eye	0		Effect: "Object Detection", Effect Duration: 49
 5840	anodized magnetized Rogue Windmill Rouge	0		Effect: "Cinnamouth", Effect Duration: 35
 5841	denatured energized A muse-bouche	0		Effect: "You Know When to Walk Away", Effect Duration: 41
 5842	altered ionized toothbrush	0		Effect: "Think Win-Lose", Effect Duration: 34
@@ -5755,20 +5755,20 @@
 5856	galvanized Scuba Snack	0		Effect: "Patience of the Tortoise", Effect Duration: 18
 5857	activated moist tumbling spinning grey cube	0		Effect: "Gobliny Flavor", Effect Duration: 31
 5858	quadruple-aerosolized wobbly votive candle	0		Effect: "Stogied", Effect Duration: 16
-5859	double-anodized yellow upside-down booby trap	0		Effect: "Down With Chow", Effect Duration: 42
+5859	double-anodized upside-down yellow booby trap	0		Effect: "Down With Chow", Effect Duration: 42
 5860	dry ionized squat Agent Corrigan's cigarette	0		Effect: "Inebriate Pride", Effect Duration: 57
 5861	chilled double-dry maroon good ash	0		Effect: "Chief Executive Optimism", Effect Duration: 16
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	quantum papier-mochi	0		Effect: "Magically Fingered", Effect Duration: 68, Last Available: "2012-09"
-5866	extra-vacuum-sealed moist narrow maroon papier-m&acirc;chaeranthera	0		Effect: "Papowerful", Effect Duration: 27, Last Available: "2012-09"
+5866	extra-vacuum-sealed moist maroon narrow papier-m&acirc;chaeranthera	0		Effect: "Papowerful", Effect Duration: 27, Last Available: "2012-09"
 5867	colloidal vacuum-sealed papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 23, Last Available: "2012-09"
 5868	nasty Jack Frost's papier-m&acirc;ch&eacute;te	0		Cold Spell Damage: +50, Stench Damage: +5, Last Available: "2012-09"
 5869	auspicious aromatic papier-m&acirc;chine gun	0		Stench Resistance: +1, Item Drop: +10, Last Available: "2012-09"
 5870	upside-down tumbling Annie Oakley's Herculean papier-masque	0		Experience (Muscle): +1, Critical Hit Percent: +20, Single Equip, Last Available: "2012-09"
-5871	gray Sinatra's papier-mitre of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	padded dangerous papier-m&acirc;churidars	0		Weapon Damage: +10, Damage Absorption: +20, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	gray Sinatra's papier-mitre of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	padded dangerous papier-m&acirc;churidars	0		Weapon Damage: +10, Damage Absorption: +20, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	jittery papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5776,14 +5776,14 @@
 5877	papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	Rainbow Jello Mould of Tarzan	0		Experience (Muscle): +3
 5879	spinning Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
-5880	bouncing fuchsia packet of dragon's teeth	0		Last Available: "2012-10"
+5880	fuchsia bouncing packet of dragon's teeth	0		Last Available: "2012-10"
 5881	upside-down skeleton	0		Last Available: "2012-10"
 5882	upside-down lightning-fast greedy sage skeleton skis	0		Mysticality Percent: +10, Meat Drop: +20, Initiative: +40, Single Equip, Last Available: "2012-10"
-5883	spoiled gigantic skeleton quiche	9	crappy	Last Available: "2012-10"
+5883	gigantic spoiled skeleton quiche	9	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	ribald veiny steel-toed Bonestabber of James Dean	0		Experience (Moxie): +3, Damage Reduction: 9, Maximum HP: +10, Sleaze Damage: +10, Last Available: "2012-10"
-5887	boozy perfectly mixed crystal skeleton vodka	5	EPIC	Last Available: "2012-10"
+5887	perfectly mixed boozy crystal skeleton vodka	5	EPIC	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	fuchsia veiny auxiliary backbone	0		Maximum HP: +10, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	blinking BittyCar HotCar	0		Last Available: "2012-12"
-5928	blinking miser's brainwave-controlled unicorn horn	0		Meat Drop: +10, Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	blinking miser's brainwave-controlled unicorn horn	0		Meat Drop: +10, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	inspector's ruddy thinker's plastic four-shadowed mime	0		Mysticality: +10, Maximum HP Percent: +40, Item Drop: +15, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	dance instructor's plastic Father McGruber	0		Experience Percent (Moxie): +10, Last Available: "2012-12"
 5961	razor-sharp plastic Hank North, Photojournalist	0		Weapon Damage Percent: +25, Last Available: "2012-12"
 5962	chilly plastic blazing bat	0		Cold Damage: +5, Last Available: "2012-12"
-5963	narrow Usain Bolt's electronic dulcimer pants of courage	0		Spooky Resistance: +3, Initiative: +80, Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2"
+5963	narrow Usain Bolt's electronic dulcimer pants of courage	0		Spooky Resistance: +3, Initiative: +80, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	educational Frown Exerciser of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5875,11 +5875,11 @@
 5977	quilted Socratic silent beret of courage	0		Experience (Mysticality): +1, Damage Absorption: +40, Spooky Resistance: +3, Familiar Effect: "1xVolley, cap 3"
 5978	rotten huge slice of pizza	3	crappy	Last Available: "2013-02"
 5979	pulsating purple huge coin	0		Last Available: "2013-02"
-5980	twirling blue cartoon heart	0		Last Available: "2013-02"
+5980	blue twirling cartoon heart	0		Last Available: "2013-02"
 5981	mirror star	0		Last Available: "2013-02"
 5982	perfectly mixed fortified tankard of ale	5	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	slick cloth cap of the dark arts of vim and vigor	0		Moxie: +10, Spell Damage Percent: +100, Maximum HP Percent: +50, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	slick cloth cap of the dark arts of vim and vigor	0		Moxie: +10, Spell Damage Percent: +100, Maximum HP Percent: +50, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	wicked iron dagger of the empath of the cheetah	0		Spell Damage: +5, Familiar Weight: +5, Initiative: +60, Last Available: "2013-02"
 5986	adequate blinking hamburger	4	good	Last Available: "2013-02"
 5987	wobbly blue dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,7 +5887,7 @@
 5989	blinking potion	0		Last Available: "2013-02"
 5990	hand-crafted spinning bottle of wine	4	EPIC	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	lime green stylish iron helmet of temperance of Flo-Jo	0		Moxie: +25, Sleaze Resistance: +5, Initiative: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	lime green stylish iron helmet of temperance of Flo-Jo	0		Moxie: +25, Sleaze Resistance: +5, Initiative: +100, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	Jeselnik's coward's steel sword of the brazier	0		Monster Level: -20, Hot Spell Damage: +25, Sleaze Damage: +25, Last Available: "2013-02"
 5994	massive tasty whole roasted chicken	8	awesome	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	narrow potion	0		Last Available: "2013-02"
 5998	lousy practically non-alcoholic teal shining goblet	1	decent	Last Available: "2013-02"
 5999	narrow fireball	0		Last Available: "2013-02"
-6000	studded Herculean groovy crown	0		Moxie Percent: +10, Experience (Muscle): +1, Damage Absorption: +80, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	studded Herculean groovy crown	0		Moxie Percent: +10, Experience (Muscle): +1, Damage Absorption: +80, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	Annie Oakley's crafty sword of the glutton	0		Maximum MP: +10, Critical Hit Percent: +20, Food Drop: +100, Last Available: "2013-02"
-6002	greedy greasy Helm of the Scream Emperor of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +10, Meat Drop: +20, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	greedy greasy Helm of the Scream Emperor of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +10, Meat Drop: +20, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	aromatic dog trainer's healthy Cloak of Dire Shadows	0		Maximum HP Percent: +20, Experience (familiar): +1, Stench Resistance: +1, Last Available: "2013-02"
 6004	jittery fireproof lard-coated extremely unsafe Sword of Dark Omens	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Hot Resistance: +3, Last Available: "2013-02"
 6005	narrow energetic vibrating beefcake's Shield of Icy Fate	0		Muscle: +25, Maximum MP Percent: 30, Damage Reduction: 7, Last Available: "2013-02"
-6006	ruddy Fonzie's Da Vinci's Greaves of the Murk Lord	0		Experience (Mysticality): +5, Experience (Moxie): +1, Maximum HP Percent: +40, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	ruddy Fonzie's Da Vinci's Greaves of the Murk Lord	0		Experience (Mysticality): +5, Experience (Moxie): +1, Maximum HP Percent: +40, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	twirling electrified rock-hard Herculean Gauntlets of the Blood Moon	0		Experience (Muscle): +1, Damage Reduction: 5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2013-02"
 6008	blurry scandalous resourceful savvy Boots of Twilight Whispers	0		Mysticality Percent: +20, Maximum MP: +50, Sleaze Damage: +5, Single Equip, Last Available: "2013-02"
 6009	sharpshooter's wholesome Belt of Howling Anger of vim and vigor	0		Maximum HP Percent: 60, Critical Hit Percent: +10, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	modified modified galvanized pulsating orcish hand lotion	0		Effect: "Salt Rockin'", Effect Duration: 68
 6016	improved pressed twirling orcish rubber	0		Effect: "Unusual Perspective", Effect Duration: 25
 6017	quadruple-chilled cold-filtered orcish nailing lube	0		Effect: "Dances with Tweedles", Effect Duration: 26
-6018	tolerable practically non-alcoholic backwoods screwdriver	1	good	
+6018	practically non-alcoholic tolerable backwoods screwdriver	1	good	
 6019	hale loadstone	0		Maximum HP: +20
 6020	olive greedy Claybender glasses of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +20, Single Equip
 6021	Duskwalker fangs of the dark arts	0		Spell Damage Percent: +100, Item Drop: +5
@@ -5949,9 +5949,9 @@
 6051	blurry Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	normal Taco Dan's Taco Stand Taco	4	good	Last Available: "2012-12"
 6053	mediocre Taco Dan's Taco Stand Chimichangarita	3	decent	Last Available: "2012-12"
-6054	pickled oxidized yellow ghostly mirror squat Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Leo Rising", Effect Duration: 20, Last Available: "2012-12"
+6054	pickled oxidized mirror ghostly squat yellow Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Leo Rising", Effect Duration: 20, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	blinking yellow The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	yellow blinking The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	gray squat knitted Lo Pan's Meatcleaver	0		Spell Critical Percent: +30, Cold Resistance: +3, Last Available: "2013-12"
 6058	twirling foul-smelling Crimbo Elf bobble-head	0		Stench Damage: +10, Last Available: "2012-12"
 6059	personal trainer's Crimbo stogie-scented room odorizer	0		Experience Percent (Muscle): +10, Last Available: "2012-12"
@@ -5964,19 +5964,19 @@
 6066	goblin collarbone	0		
 6067	teal Annie Oakley's beefcake's Truthsayer	0		Muscle: +25, Critical Hit Percent: +20, Last Available: "2013-12"
 6068	loose blade	0		
-6069	jittery shaking goblin bone hilt	0		
+6069	shaking jittery goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	boiled haggis-infused soap	0		Effect: "Uncucumbered", Effect Duration: 25, Last Available: "2012-12"
 6074	liquefied magicberry tablets	0		Effect: "Pwnd", Effect Duration: 28, Last Available: "2012-12"
-6075	aerosolized extra-quantum squat blue 37x37x37 puzzle cube	0		Effect: "Haunted Liver", Effect Duration: 33, Last Available: "2012-12"
+6075	aerosolized extra-quantum blue squat 37x37x37 puzzle cube	0		Effect: "Haunted Liver", Effect Duration: 33, Last Available: "2012-12"
 6076	bad shaking McLeod's Hard Haggis-Ade	4	decent	Last Available: "2012-12"
 6077	stale haggis-wrapped haggis-stuffed haggis	3	decent	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	Van der Graaf haggis socks	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	Van der Graaf haggis socks	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	blinking Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6009,7 +6009,7 @@
 6111	bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	zaibatsu lobby card	0		Last Available: "2013-12"
 6113	zaibatsu level 1 card	0		Last Available: "2013-12"
-6114	wobbly skewed zaibatsu level 2 card	0		Last Available: "2013-12"
+6114	skewed wobbly zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	jittery zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	narrow CEO office card	0		Last Available: "2013-12"
 6117	test site key	0		Last Available: "2013-12"
@@ -6020,7 +6020,7 @@
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
-6125	non-denatured activated jittery lime green bottle of limeade	0		Effect: "Elemental Saucesphere", Effect Duration: 63, Last Available: "2013-12"
+6125	non-denatured activated lime green jittery bottle of limeade	0		Effect: "Elemental Saucesphere", Effect Duration: 63, Last Available: "2013-12"
 6126	beefy novelty tattoo sleeves of bravery	0		Muscle: +10, Spooky Resistance: +5, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	squat furry brown pillow	0		Last Available: "2013-12"
@@ -6040,7 +6040,7 @@
 6142	decent immense roasted duck	8	good	Last Available: "2013-12"
 6143	moldy dead meat bun	4	crappy	Last Available: "2013-12"
 6144	cat collar of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2013-12"
-6145	narrow dog trainer's groovy suspicious-looking fedora	0		Moxie Percent: +10, Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	narrow dog trainer's groovy suspicious-looking fedora	0		Moxie Percent: +10, Experience (familiar): +1, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	spinning Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6048,18 +6048,18 @@
 6151	carrot nose	0		Last Available: "2013-01"
 6152	bland carrot cake	3	decent	Last Available: "2013-01"
 6153	bad weak twirling carrot claret	2	decent	Last Available: "2013-01"
-6154	dried bouncing teal carrot juice	1	good	Last Available: "2013-01"
+6154	dried teal bouncing carrot juice	1	good	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
-6156	ghostly spinning flickering pixel	0		Last Available: "2013-12"
+6156	spinning ghostly flickering pixel	0		Last Available: "2013-12"
 6157	lion tamer's rock-hard Byte	0		Damage Reduction: 5, Experience (familiar): +2, Last Available: "2013-12"
-6158	strapping anger blaster	0		Muscle: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	brainy doubt cannon	0		Mysticality: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	twirling flame-retardant fear condenser	0		Hot Resistance: +1, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	regret hose of the businessman	0		Meat Drop: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	strapping anger blaster	0		Muscle: +5, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	brainy doubt cannon	0		Mysticality: +5, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	twirling flame-retardant fear condenser	0		Hot Resistance: +1, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	regret hose of the businessman	0		Meat Drop: +50, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	tumbling Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	huge Jeselnik's commodore's hat of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	upside-down baleful naval trousers	0		Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	huge Jeselnik's commodore's hat of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	upside-down baleful naval trousers	0		Spell Damage: +25, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	spinning Tesla thinker's deck cannon	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 6167	cyan pulsating sizzling ornamental sextant	0		Hot Damage: +10, Last Available: "2013-12"
 6168	ghostly smooth Bloodbath of the scaredy-cat	0		Moxie: +15, Monster Level: -15, Last Available: "2013-12"
@@ -6075,31 +6075,31 @@
 6178	cosmic vegetable	0		
 6179	fuchsia cosmic cheese	0		
 6180	teal cosmic potted meat product	0		
-6181	narrow blue upside-down cosmic potato	0		
+6181	upside-down narrow blue cosmic potato	0		
 6182	narrow jittery cosmic cream	0		
 6183	cosmic fruit	0		
 6184	fireproof fortified Da Vinci's Jarlsberg's hat	0		Experience (Mysticality): +5, Damage Absorption: +60, Hot Resistance: +3
-6185	bland fancy consummate hard-boiled egg	3	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 5
+6185	fancy bland consummate hard-boiled egg	3	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 5
 6186	flavorless olive consummate fried egg	4	decent	
-6187	half-sized decent consummate egg salad	2	good	
+6187	decent half-sized consummate egg salad	2	good	
 6188	half-sized decent consummate bagel	2	good	
-6189	normal bouncing jittery consummate sliced bread	4	good	
+6189	normal jittery bouncing consummate sliced bread	4	good	
 6190	moldy massive consummate hot dog bun	8	crappy	
 6191	flavorless blue consummate brownie	4	decent	
 6192	enchanted spoiled consummate toast	3	crappy	Effect: "Total Protonic Reversal", Effect Duration: 20
 6193	irresponsibly strong mediocre upside-down passable stout	10	decent	
 6194	flavorless yellow consummate soup	3	decent	
 6195	bland immense consummate corn chips	7	decent	
-6196	special stale consummate salad	4	decent	Effect: "Sleazy Hands", Effect Duration: 5
-6197	thick adequate narrow consummate salsa	5	good	
-6198	snack-sized spoiled consummate sauerkraut	2	crappy	
+6196	stale special consummate salad	4	decent	Effect: "Sleazy Hands", Effect Duration: 5
+6197	adequate thick narrow consummate salsa	5	good	
+6198	spoiled snack-sized consummate sauerkraut	2	crappy	
 6199	moldy consummate cheese slice	4	crappy	
 6200	adequate red consummate melted cheese	4	good	
 6201	small rotten consummate bacon	2	crappy	
-6202	gigantic decent consummate meatloaf	8	good	
+6202	decent gigantic consummate meatloaf	8	good	
 6203	bland consummate steak	4	decent	
 6204	flavorless bite-sized consummate cuts	1	decent	
-6205	stale snack-sized enchanted jittery spinning consummate frankfurter	2	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 5
+6205	snack-sized enchanted stale spinning jittery consummate frankfurter	2	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 5
 6206	normal low-calorie upside-down consummate french fries	1	good	
 6207	moldy purple consummate baked potato	3	crappy	
 6208	artisanal acceptable vodka	4	EPIC	
@@ -6107,28 +6107,28 @@
 6210	gigantic delicious consummate whipped cream	8	awesome	
 6211	normal consummate cream	4	good	
 6212	bland consummate strawberries	3	decent	
-6213	adequate snack-sized consummate sorbet	2	good	
+6213	snack-sized adequate consummate sorbet	2	good	
 6214	lousy adequate rum	4	decent	
-6215	special bad shaking mediocre lager	3	decent	Effect: "Stimulated Body", Effect Duration: 50
-6216	moldy massive fuchsia immaculate grilled cheese	9	crappy	
-6217	jumbo toothsome immaculate ice cream sandwich	5	awesome	
-6218	huge stale blurry immaculate hot dog	7	decent	
+6215	bad special shaking mediocre lager	3	decent	Effect: "Stimulated Body", Effect Duration: 50
+6216	massive moldy fuchsia immaculate grilled cheese	9	crappy	
+6217	toothsome jumbo immaculate ice cream sandwich	5	awesome	
+6218	stale huge blurry immaculate hot dog	7	decent	
 6219	yummy half-sized immaculate egg salad sandwich	2	awesome	
 6220	stale huge huge perfect sandwich	7	decent	
 6221	tasty huge jittery perfect chef salad	10	awesome	
-6222	half-sized bland skewed red perfect breakfast	2	decent	
-6223	snack-sized adequate sublime deluxe hot dog	2	good	
+6222	bland half-sized skewed red perfect breakfast	2	decent	
+6223	adequate snack-sized sublime deluxe hot dog	2	good	
 6224	normal sublime stew	3	good	
-6225	bland bite-sized special wobbly sublime nachos	1	decent	Effect: "Adapt to Change Eventually", Effect Duration: 30
+6225	special bland bite-sized wobbly sublime nachos	1	decent	Effect: "Adapt to Change Eventually", Effect Duration: 30
 6226	rotten half-sized Ultimate Breakfast Sandwich	2	crappy	
 6227	small moldy Loaded Baked Potato	2	crappy	
 6228	spoiled Omega Sundae	3	crappy	
 6229	perfectly mixed Das Sauerlager	4	EPIC	
 6230	artisanal Bologna Lambic	4	EPIC	
 6231	strong acceptable Vodka Dog	5	good	
-6232	watered-down tolerable Disappointed Russian	2	good	
-6233	watered-down artisanal Chunky Mary	2	EPIC	
-6234	tolerable watered-down Nachojito	2	good	
+6232	tolerable watered-down Disappointed Russian	2	good	
+6233	artisanal watered-down Chunky Mary	2	EPIC	
+6234	watered-down tolerable Nachojito	2	good	
 6235	acceptable olive Le Roi	4	good	
 6236	bad Over Easy Rider	4	decent	
 6237	cosmic six-pack	0		
@@ -6146,8 +6146,8 @@
 6250	asbestos-lined electrified rock-hard stiffened Newton's numberwang of Flo-Jo	0		Experience (Mysticality): +3, Damage Reduction: 12, Hot Resistance: +5, Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 6251	deionized skewed scroll of Protection from Bad Stuff	0		Effect: "Eagle Eyes", Effect Duration: 61, Last Available: "2013-02"
 6252	aerosolized dry scroll of Puddingskin	0		Effect: "The Magic of Sharing", Effect Duration: 50, Last Available: "2013-02"
-6253	upside-down huge Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
-6254	blinking blue Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
+6253	huge upside-down Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
+6254	blue blinking Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	blurry spinning Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	dried gelatinous cube	0		
 6257	pile of dungeon junk	0		Familiar Weight: +5
@@ -6167,14 +6167,14 @@
 6271	narrow massive dumbbell	0		
 6272	pulsating perfumed strapping penguin keychain	0		Muscle: +5, Stench Resistance: +5, Damage Reduction: 10
 6273	denatured non-tarnished O'RLY manual	0		Effect: "Happy Trails", Effect Duration: 48
-6274	high-proof drinkable open sauce	8	good	
+6274	drinkable high-proof open sauce	8	good	
 6275	spinning Lo Pan's turkey leg of the scaredy-cat	0		Spell Critical Percent: +30, Monster Level: -15
 6276	mediocre Ye Olde Meade	4	decent	
 6277	oxidized Ye Olde Bawdy Limerick	0		Effect: "Gobliny Flavor", Effect Duration: 68
-6278	twirling cyan Ye Olde Medieval Insult	0		
+6278	cyan twirling Ye Olde Medieval Insult	0		
 6279	Fonzie's pewter claymore	0		Experience (Moxie): +1
 6280	ghostly chilly artisanal rice peeler	0		Cold Damage: +5
-6281	special decent heirloom grape tomato	3	good	Effect: "Hot Hands", Effect Duration: 20
+6281	decent special heirloom grape tomato	3	good	Effect: "Hot Hands", Effect Duration: 20
 6282	chipotle wasabi cilantro aioli	0		
 6283	pulsating sinister brown felt tophat	0		Spell Damage: +10, Familiar Effect: "1xLep, cap 37"
 6284	mirror gear	0		
@@ -6205,7 +6205,7 @@
 6309	colloidal celestial au jus	0		Effect: "Feet of Grapefruit", Effect Duration: 42, Last Available: "2013-03"
 6310	triple-frozen celestial squid ink	0		Effect: "Mer-kindliness", Effect Duration: 23, Last Available: "2013-03"
 6311	experienced Uncle Buck	0		Experience: +2, Softcore Only
-6312	cyan blurry squat crate of fish meat	0		
+6312	squat blurry cyan crate of fish meat	0		
 6313	damp wallet	0		
 6314	pipe	0		Effect: "Fishy", Effect Duration: 10
 6315	SCUBA tank of dire peril of the blizzard	0		Weapon Damage: +20, Cold Spell Damage: +25, Adventure Underwater
@@ -6214,7 +6214,7 @@
 6318	clever banded boxer's sea holster	0		Muscle Percent: +10, Damage Absorption: +100, Maximum MP: +20, Single Equip
 6319	boiled twirling shavin' razor	0		Effect: "Yuletide Sappiness", Effect Duration: 66
 6320	hardened long-forgotten necklace	0		Damage Reduction: 3
-6321	pulsating upside-down pearl	0		
+6321	upside-down pulsating pearl	0		
 6322	sea lace	0		
 6323	nippy deadly jam band of the bloodbag	0		Weapon Damage: +5, Maximum HP: +100, Cold Damage: +10
 6324	spinning lightning-fast clever aquamariner's ring of the blizzard	0		Maximum MP: +20, Cold Spell Damage: +25, Initiative: +40, Single Equip
@@ -6224,7 +6224,7 @@
 6328	lime green sushi doily	0		
 6329	scimitar cozy	0		
 6330	fish stick cozy	0		
-6331	blinking skewed bazooka cozy	0		
+6331	skewed blinking bazooka cozy	0		
 6332	healthy wholesome cozy scimitar of the sewer	0		Maximum HP Percent: 30, Stench Damage: +25
 6333	narrow mirror electrified hardy rosy-cheeked Staff of the Cozy Fish	0		Maximum HP Percent: +30, Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5
 6334	stanky personal trainer's groovy cozy bazooka	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Stench Spell Damage: +25
@@ -6238,7 +6238,7 @@
 6342	perfumed friendly super-strong air freshener	0		Familiar Weight: +3, Stench Resistance: +5
 6343	enhanced anodized denatured Mer-kin lipstick	0		Effect: "The Power of Positive Thinking", Effect Duration: 34
 6344	Mer-kin mouthsoap	0		
-6345	triple-altered alkaline adjusted ghostly blinking Mer-kin strongjuice	0		Effect: "Prince of Seaside Town", Effect Duration: 54
+6345	triple-altered alkaline adjusted blinking ghostly Mer-kin strongjuice	0		Effect: "Prince of Seaside Town", Effect Duration: 54
 6346	jittery Mer-kin fitbrine	0		
 6347	aerosolized double-colloidal Mer-kin ragejuice	0		Effect: "Floundering", Effect Duration: 15
 6348	shaking greedy Mer-kin dragbelt	0		Meat Drop: +20, Experience (Muscle): +20, Single Equip
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	maroon Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	dangerous Mer-kin begsign	0		Weapon Damage: +10, Meat Drop: +40
-6360	shaking Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	shaking Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	unsweetened double-deionized non-polarized squat pulled taffy	0		Effect: "Loyal Tea", Effect Duration: 54, Last Available: "2013-04"
 6362	pickled pulled indigo taffy	0		Effect: "Simulation Stimulation", Effect Duration: 31, Last Available: "2013-04"
 6363	pressed aerosolized mirror pulled taffy	0		Effect: "Mushroom Magicalness", Effect Duration: 55, Last Available: "2013-04"
@@ -6265,7 +6265,7 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	tolerable can of the cheapest beer	3	good	
-6372	delicious practically non-alcoholic jittery bottle of fruity &quot;wine&quot;	1	awesome	
+6372	practically non-alcoholic delicious jittery bottle of fruity &quot;wine&quot;	1	awesome	
 6373	tolerable watered-down single swig of vodka	2	good	
 6374	angry inch	0		
 6375	blinking testy toolbox of horror	0		Spooky Spell Damage: +25
@@ -6308,7 +6308,7 @@
 6413	narrow Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	decent flavorless gruel	3	good	
-6416	enchanted adequate shaking mana curds	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 45
+6416	adequate enchanted shaking mana curds	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 45
 6417	jittery twist of lime	0		
 6418	pulsating pencil stub	0		
 6419	super-altered upside-down purple moth dust	0		Effect: "Stogied", Effect Duration: 60
@@ -6318,14 +6318,14 @@
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	adequate half-sized bouncing Dreadsylvanian stew	2	good	
+6426	half-sized adequate bouncing Dreadsylvanian stew	2	good	
 6427	tolerable Dreadsylvanian	3	good	
 6428	corrupted wobbly Dreadsylvanian flask	0		Effect: "Ponderous Potency", Effect Duration: 44
 6429	cold-filtered Dreadsylvanian flask	0		Effect: "Polar Express", Effect Duration: 34
 6430	nippy lion tamer's dreadful fedora	0		Experience (familiar): +2, Cold Damage: +10, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	ruddy dreadful sweater	0		Maximum HP Percent: +40, Kruegerand Drop: 5
 6432	jittery dreadful glove of temperance	0		Sleaze Resistance: +5, Kruegerand Drop: 5
-6433	bouncing squat Freddy Kruegerand	0		
+6433	squat bouncing Freddy Kruegerand	0		
 6434	red Mark of the Bugbear	0		
 6435	Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
@@ -6367,7 +6367,7 @@
 6472	upside-down Drunkula's bell	0		
 6473	supercharged therapeutic arcane researcher's Drunkula's ring of haze	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Avoid Attack: 1, Single Equip
 6474	grievous Drunkula's wineglass	0		Weapon Damage Percent: +50
-6475	fancy mediocre bottle of Bloodweiser	3	decent	Effect: "Oh Snap", Effect Duration: 50
+6475	mediocre fancy bottle of Bloodweiser	3	decent	Effect: "Oh Snap", Effect Duration: 50
 6476	lard-coated Unkillable Skeleton's skullcap of horror	0		Spooky Spell Damage: +25, Sleaze Spell Damage: +25, Item Drop: +5, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	shellacked cool Unkillable Skeleton's breastplate of courage	0		Moxie: +5, Damage Reduction: 7, Spooky Resistance: +3, Class: "Turtle Tamer"
 6478	censurious therapeutic arcane researcher's Unkillable Skeleton's shinguards	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6379,8 +6379,8 @@
 6484	dread tarragon	0		
 6485	gray bone flour	0		
 6486	dreadful roast	0		
-6487	bouncing wobbly stinking agaricus	0		
-6488	toothsome diet ghostly Dreadsylvanian shepherd's pie	1	awesome	
+6487	wobbly bouncing stinking agaricus	0		
+6488	diet toothsome ghostly Dreadsylvanian shepherd's pie	1	awesome	
 6489	shaking music box parts	0		
 6490	ghostly unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6398,7 +6398,7 @@
 6503	purple ghost pencil	0		
 6504	aromatic Sinatra's hangman's hood of the cheetah	0		Experience (Moxie): +5, Stench Resistance: +1, Initiative: +60
 6505	zippy wool sizzling ring finger ring	0		Hot Damage: +10, Cold Resistance: +1, Initiative: +20, Single Equip
-6506	squat red Dreadsylvanian clockwork key	0		
+6506	red squat Dreadsylvanian clockwork key	0		
 6507	tumbling huge cool iron ingot	0		
 6508	cool iron helmet of dire peril of the sewer	0		Weapon Damage: +20, Stench Damage: +25, Familiar Effect: "atk, 1xFairy"
 6509	flame-retardant groovy cool iron breastplate	0		Moxie Percent: +10, Hot Resistance: +1
@@ -6408,16 +6408,16 @@
 6513	wicked warm fur	0		Spell Damage: +5
 6514	scorching snowstick	0		Hot Damage: +25
 6515	electrified eerie fetish	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
-6516	drinkable fancy practically non-alcoholic stinkwater	1	good	Effect: "Happy Salamander", Effect Duration: 30
+6516	practically non-alcoholic fancy drinkable stinkwater	1	good	Effect: "Happy Salamander", Effect Duration: 30
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	spoiled big narrow accidental mutton	5	crappy	
+6518	big spoiled narrow accidental mutton	5	crappy	
 6519	supercharged occult drafty drawers	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Familiar Effect: "1.5xVolley"
 6520	studded Herculean wolfskull mask	0		Experience (Muscle): +1, Damage Absorption: +80, Familiar Effect: "spooky atk, 1xBarrr"
 6521	guts necklace of the dark arts	0		Spell Damage Percent: +100, Single Equip
 6522	aromatic flame-wreathed groping claw	0		Hot Spell Damage: +10, Stench Resistance: +1
 6523	baleful vengeful spirit	0		Spell Damage: +25
 6524	BOOtonniere of the sweet-tooth	0		Candy Drop: +100, Single Equip
-6525	non-energized liquefied spinning cyan spinning ghost thread	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 42
+6525	non-energized liquefied spinning spinning cyan ghost thread	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 42
 6526	mirror educational bag of unfinished business of mayonnaise	0		Experience: +1, Sleaze Spell Damage: +50
 6527	Sherlock's dance instructor's transparent pants	0		Experience Percent (Moxie): +10, Item Drop: +25, Familiar Effect: "sleaze atk, 1xPotato"
 6528	yellow hothammer of the pedagogue	0		Experience: +3
@@ -6429,7 +6429,7 @@
 6534	zippy remorseless knife	0		Initiative: +20
 6535	yellow crafty intimidating coiffure	0		Maximum MP: +10, Familiar Effect: "hot afk, 1xPotato"
 6536	fortified wizardly cod cape	0		Mysticality: +25, Damage Absorption: +60
-6537	big bland blood sausage	5	decent	
+6537	bland big blood sausage	5	decent	
 6538	rock-hard sinister frying brainpan	0		Spell Damage: +10, Damage Reduction: 5
 6539	blurry scandalous hale ball and chain	0		Maximum HP: +20, Sleaze Damage: +5, Single Equip
 6540	boxer's dry bone	0		Muscle Percent: +10
@@ -6460,9 +6460,9 @@
 6566	moldy Dreadsylvanian pocket	4	crappy	
 6567	spoiled Dreadsylvanian stink pocket	4	crappy	
 6568	flavorless gigantic Dreadsylvanian sleaze pocket	8	decent	
-6569	tolerable triple-distilled Dreadsylvanian hot toddy	10	good	
+6569	triple-distilled tolerable Dreadsylvanian hot toddy	10	good	
 6570	drinkable upside-down Dreadsylvanian cold-fashioned	3	good	
-6571	artisanal high-proof twirling Dreadsylvanian grimlet	7	EPIC	
+6571	high-proof artisanal twirling Dreadsylvanian grimlet	7	EPIC	
 6572	acceptable shaking Dreadsylvanian dank and stormy	3	good	
 6573	acceptable jittery Dreadsylvanian slithery nipple	4	good	
 6574	tumbling hot clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	skewed knitted sharpshooter's gnawed-up dog bone	0		Critical Hit Percent: +10, Cold Resistance: +3
 6589	twirling brawny Grey Guanon	0		Muscle Percent: +20
 6590	blurry scandalous electrified Engorged Sausages and You of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5
-6591	artisanal weak dream of a dog	2	EPIC	
+6591	weak artisanal dream of a dog	2	EPIC	
 6592	nippy sinister groovy optimal spreadsheet	0		Moxie Percent: +10, Spell Damage: +10, Cold Damage: +10
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
@@ -6541,7 +6541,7 @@
 6649	frozen ghostly Ogres and Oubliettes&trade; module	0		Effect: "The Power of Positive Thinking", Effect Duration: 49
 6650	narrow Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	high-proof drinkable stepmom's booze	9	good	
+6652	drinkable high-proof stepmom's booze	9	good	
 6653	surgical tape	0		
 6654	shaking groovy band T-shirt	0		Moxie Percent: +10
 6655	artisanal fountain 'soda'	3	EPIC	
@@ -6560,7 +6560,7 @@
 6668	Faraday cage	0		
 6669	pulsating modeling claymore	0		
 6670	blurry clay homunculus	0		
-6671	electrified triple-pressed tumbling red sodium pentasomething	0		Effect: "Fratty Flavor", Effect Duration: 62
+6671	electrified triple-pressed red tumbling sodium pentasomething	0		Effect: "Fratty Flavor", Effect Duration: 62
 6672	teal skewed grains of salt	0		
 6673	ghostly yellowcake bomb	0		
 6674	olive stinkbomb	0		
@@ -6569,9 +6569,9 @@
 6677	crude monster sculpture	0		
 6678	hardened Yearbook Club Camera	0		Damage Reduction: 3, Conditional Skill (Equipped): "Blinding Flash"
 6679	reassuring machete	0		Spooky Resistance: +1
-6680	drinkable triple-distilled spinning Cursed Punch	10	good	
+6680	triple-distilled drinkable spinning Cursed Punch	10	good	
 6681	high-proof drinkable Bowl of Scorpions	9	good	
-6682	delicious weak upside-down Fog Murderer	2	awesome	
+6682	weak delicious upside-down Fog Murderer	2	awesome	
 6683	huge book of matches	0		
 6684	squat manspreader's surgical mask	0		Monster Level: +10, Surgeonosity: +1
 6685	upside-down hardened head mirror	0		Damage Reduction: 3, Surgeonosity: +1
@@ -6645,30 +6645,30 @@
 6753	ghostly cluster of hops	0		
 6754	beer bottle	0		
 6755	beer label	0		
-6756	narrow jittery artisanal homebrew sampler	0		
+6756	jittery narrow artisanal homebrew sampler	0		
 6757	lousy can of Br&uuml;talbr&auml;u	4	decent	Last Available: "2013-09"
-6758	tolerable high-proof can of Drooling Monk	6	good	Last Available: "2013-09"
+6758	high-proof tolerable can of Drooling Monk	6	good	Last Available: "2013-09"
 6759	hand-crafted ghostly can of Impetuous Scofflaw	4	EPIC	Last Available: "2013-09"
 6760	mediocre bottle of Old Pugilist	4	decent	Last Available: "2013-09"
-6761	irresponsibly strong tolerable cyan bottle of Professor Beer	8	good	Last Available: "2013-09"
+6761	tolerable irresponsibly strong cyan bottle of Professor Beer	8	good	Last Available: "2013-09"
 6762	mediocre bottle of Rapier Witbier	3	decent	Last Available: "2013-09"
 6763	hand-crafted squat bottle of Race Car Red	4	EPIC	Last Available: "2013-09"
 6764	spirit-forward artisanal bottle of Greedy Dog	5	EPIC	Last Available: "2013-09"
-6765	hand-crafted fancy practically non-alcoholic teal huge bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Effect: "Helvella Health", Effect Duration: 30, Last Available: "2013-09"
+6765	practically non-alcoholic fancy hand-crafted teal huge bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Effect: "Helvella Health", Effect Duration: 30, Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	upside-down liquid bread	1	decent	Last Available: "2013-09"
-6769	greedy frightening tin tam of the early riser	0		Spooky Damage: +5, Meat Drop: +20, Adventures: +7, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	greedy frightening tin tam of the early riser	0		Spooky Damage: +5, Meat Drop: +20, Adventures: +7, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	pickled cyan tin cup	0		Effect: "Just the Brown Ones", Effect Duration: 23, Last Available: "2013-09"
 6771	fortified smartaleck's tin foil of vim and vigor	0		Moxie Percent: +30, Damage Absorption: +60, Maximum HP Percent: +50, Last Available: "2013-09"
 6772	stiffened occult strapping tin drum	0		Muscle: +5, Spell Damage Percent: +25, Damage Reduction: 1, Last Available: "2013-09"
-6773	huge ghostly tin roof (rusted)	0		Last Available: "2013-09"
+6773	ghostly huge tin roof (rusted)	0		Last Available: "2013-09"
 6774	upside-down tin snips	0		Last Available: "2013-09"
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	colloidal foetid seal tear	0		Effect: "Mad at Science", Effect Duration: 58
-6777	warmed ghostly mirror seal sweat	0		Effect: "Lemon Enlightenment", Effect Duration: 30
+6777	warmed mirror ghostly seal sweat	0		Effect: "Lemon Enlightenment", Effect Duration: 30
 6778	irradiated dry boiling seal blood	0		Effect: "Bloody-minded", Effect Duration: 17
-6779	lime green mirror crystalline seal eye	0		Single Equip
+6779	mirror lime green crystalline seal eye	0		Single Equip
 6780	careful studded sealhide shield of the ox	0		Muscle: +20, Monster Level: -10, Damage Reduction: 7
 6781	spinning up-at-dawn family-friendly scabrous seal epaulets	0		Sleaze Resistance: +1, Adventures: +5, Single Equip
 6782	bouncing abyssal battle plans	0		
@@ -6724,13 +6724,13 @@
 6835	nitrogenated chilled bag of W&Ws	0		Effect: "Army of One", Effect Duration: 39
 6836	dry spinning PEEZ dispenser	0		Effect: "Truly Gritty", Effect Duration: 63
 6837	flattened Swizzler	0		Effect: "Crimbo Flavor", Effect Duration: 34
-6838	chilled teal twirling Bugbearclaw Donut	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 34
+6838	chilled twirling teal Bugbearclaw Donut	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 34
 6839	altered wet improved jam	0		Effect: "Worth Your Salt", Effect Duration: 67
 6840	polymerized polarized Whenchamacallit bar	0		Effect: "Pemmican't", Effect Duration: 50
 6841	activated liquefied spinning ghostly 8-bit banana	0		Effect: "Sweet Taste", Effect Duration: 43
 6842	chilled vacuum-sealed vial of blood simple syrup	0		Effect: "Squirming Like a Toad", Effect Duration: 64
 6843	flattened bone bons	0		Effect: "The Power of Negative Thinking", Effect Duration: 62
-6844	alkaline spinning purple ironic mint	0		Effect: "Memory of Resilience", Effect Duration: 29
+6844	alkaline purple spinning ironic mint	0		Effect: "Memory of Resilience", Effect Duration: 29
 6845	unused walkie-talkie	0		Free Pull
 6846	cyan walkie-talkie	0		Free Pull
 6847	twirling killing jar	0		
@@ -6746,22 +6746,22 @@
 6857	Cajun accordion of terror	0		Spooky Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	Oprah's quirky accordion	0		Maximum MP Percent: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	chilly slick Skipper's accordion	0		Moxie: +10, Cold Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	flame-retardant wholesome supercool Pantsgiving of wisdom	0		Mysticality: +15, Moxie Percent: +20, Maximum HP Percent: +10, Hot Resistance: +1, Softcore Only, Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25"
+6860	flame-retardant wholesome supercool Pantsgiving of wisdom	0		Mysticality: +15, Moxie Percent: +20, Maximum HP Percent: +10, Hot Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
 6861	half-sized yummy squat can of sardines	2	awesome	Last Available: "2013-11"
 6862	adequate low-calorie high-calorie sugar substitute	1	good	Last Available: "2013-11"
-6863	thick spoiled huge pulsating pat of butter	5	crappy	Last Available: "2013-11"
-6864	immense adequate twirling dinner roll	7	good	Last Available: "2013-11"
-6865	bland big cyan mashed potatoes	5	decent	Last Available: "2013-11"
+6863	spoiled thick huge pulsating pat of butter	5	crappy	Last Available: "2013-11"
+6864	adequate immense twirling dinner roll	7	good	Last Available: "2013-11"
+6865	big bland cyan mashed potatoes	5	decent	Last Available: "2013-11"
 6866	stale blue whole turkey leg	4	decent	Last Available: "2013-11"
 6867	toothsome deviled egg	4	awesome	Last Available: "2013-11"
-6868	colloidal upside-down tumbling finger exerciser	0		Effect: "Slimed Stomach", Effect Duration: 16, Last Available: "2013-11"
+6868	colloidal tumbling upside-down finger exerciser	0		Effect: "Slimed Stomach", Effect Duration: 16, Last Available: "2013-11"
 6869	liquefied shaking dented spoon	0		Effect: "Arcane in the Brain", Effect Duration: 28, Last Available: "2013-11"
 6870	nitrogenated pressed love note	0		Effect: "Springy Fusilli", Effect Duration: 60, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	tarnished adjusted chilled squat teal nail file	0		Effect: "Wet and Greedy", Effect Duration: 26, Last Available: "2013-11"
 6873	activated modified candy wrapper	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 20, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
-6875	activated double-energized narrow blurry tumbling post-holiday sale coupon	0		Effect: "The Smeezingtons", Effect Duration: 55, Last Available: "2013-11"
+6875	activated double-energized blurry narrow tumbling post-holiday sale coupon	0		Effect: "The Smeezingtons", Effect Duration: 55, Last Available: "2013-11"
 6876	dry cleaning receipt	0		Last Available: "2013-11"
 6877	skewed pocket lint (blue)	0		Last Available: "2013-11"
 6878	blinking pocket lint (green)	0		Last Available: "2013-11"
@@ -6804,36 +6804,36 @@
 6915	up-at-dawn Jack Frost's medical-grade warbear hoverbelt	0		Cold Spell Damage: +50, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
-6918	polarized dry ghostly wobbly warbear wardance potion	0		Effect: "Ghostly Shell", Effect Duration: 15, Last Available: "2013-12"
+6918	polarized dry wobbly ghostly warbear wardance potion	0		Effect: "Ghostly Shell", Effect Duration: 15, Last Available: "2013-12"
 6919	super-quantum gray warbear bearserker potion	0		Effect: "Flexibili Tea", Effect Duration: 52, Last Available: "2013-12"
 6920	electrified warbear liquid overcoat	0		Effect: "Dance Interpreter", Effect Duration: 59, Last Available: "2013-12"
 6921	spoiled jittery warbear feasting bread	4	crappy	Last Available: "2013-12"
 6922	spoiled warbear warrior bread	3	crappy	Last Available: "2013-12"
-6923	half-sized spoiled yellow spinning narrow warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
+6923	spoiled half-sized spinning yellow narrow warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
 6924	hand-crafted enchanted twirling warbear feasting mead	4	EPIC	Effect: "Human-Elf Hybrid", Effect Duration: 50, Last Available: "2013-12"
 6925	tolerable blinking warbear bearserker mead	3	good	Last Available: "2013-12"
 6926	artisanal warbear blizzard mead	3	EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	zippy friendly warbear plain fedora of the blizzard	0		Familiar Weight: +3, Cold Spell Damage: +25, Initiative: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	manspreader's warbear feathered fedora	0		Monster Level: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	lion tamer's razor-sharp warbear fedora of Flo-Jo	0		Weapon Damage Percent: +25, Experience (familiar): +2, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	coward's hardy Newton's warbear plain helm	0		Experience (Mysticality): +3, Maximum HP: +50, Monster Level: -20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	warbear spiked helm	0		Item Drop: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	greasy MacGyver's personal trainer's warbear electro-spiked helm	0		Experience Percent (Muscle): +10, Maximum MP: +100, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	shaking aromatic Temple Grandin's occult warbear plain ushanka	0		Spell Damage Percent: +25, Familiar Weight: +7, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	scorching warbear lined ushanka	0		Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	Tesla steel-toed brainy warbear heated ushanka	0		Mysticality: +5, Damage Reduction: 9, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	zippy friendly warbear plain fedora of the blizzard	0		Familiar Weight: +3, Cold Spell Damage: +25, Initiative: +20, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	manspreader's warbear feathered fedora	0		Monster Level: +10, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	lion tamer's razor-sharp warbear fedora of Flo-Jo	0		Weapon Damage Percent: +25, Experience (familiar): +2, Initiative: +100, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	coward's hardy Newton's warbear plain helm	0		Experience (Mysticality): +3, Maximum HP: +50, Monster Level: -20, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	warbear spiked helm	0		Item Drop: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	greasy MacGyver's personal trainer's warbear electro-spiked helm	0		Experience Percent (Muscle): +10, Maximum MP: +100, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	shaking aromatic Temple Grandin's occult warbear plain ushanka	0		Spell Damage Percent: +25, Familiar Weight: +7, Stench Resistance: +1, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	scorching warbear lined ushanka	0		Hot Damage: +25, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	Tesla steel-toed brainy warbear heated ushanka	0		Mysticality: +5, Damage Reduction: 9, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	ghostly warbear trouser fragment	0		Last Available: "2013-12"
-6938	prompt sizzling warbear party pants of the cougar	0		Moxie: +20, Hot Damage: +10, Adventures: +3, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	weightlifter's warbear ceremonial party pants	0		Muscle: +15, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	forbidden occult thinker's warbear high festival pants	0		Mysticality: +10, Spell Damage Percent: 75, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	family-friendly rock-hard warbear battle greaves of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	flame-retardant Rosewater's warbear bearserker greaves of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	baleful warbear johns of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	maroon wicked warbear fleece-lined johns	0		Spell Damage: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	fuchsia auspicious asbestos-lined arcane researcher's warbear johns	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
-6947	pulsating twirling warbear accoutrements chunk	0		Last Available: "2013-12"
+6938	prompt sizzling warbear party pants of the cougar	0		Moxie: +20, Hot Damage: +10, Adventures: +3, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	weightlifter's warbear ceremonial party pants	0		Muscle: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	forbidden occult thinker's warbear high festival pants	0		Mysticality: +10, Spell Damage Percent: 75, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	family-friendly rock-hard warbear battle greaves of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Sleaze Resistance: +1, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	flame-retardant Rosewater's warbear bearserker greaves of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Hot Resistance: +1, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	baleful warbear johns of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	maroon wicked warbear fleece-lined johns	0		Spell Damage: +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	fuchsia auspicious asbestos-lined arcane researcher's warbear johns	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Item Drop: +10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6947	twirling pulsating warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	manspreader's dangerous brainy warbear goggles	0		Mysticality: +5, Weapon Damage: +10, Monster Level: +10, Single Equip, Last Available: "2013-12"
 6949	warbear snowblindness goggles of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2013-12"
 6950	upside-down smooth warbear polarized goggles of the bloodbag of the businessman	0		Moxie: +15, Maximum HP: +100, Meat Drop: +50, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	knitted sinister deadly warbear warscarf	0		Weapon Damage: +5, Spell Damage: +10, Cold Resistance: +3, Single Equip, Last Available: "2013-12"
 6957	blurry warbear requisition box	0		Last Available: "2013-12"
 6958	blinking red warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	hardy warbear foil hat	0		Maximum HP: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	hardy warbear foil hat	0		Maximum HP: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	resourceful warbear oil pan of the bloodbag	0		Maximum HP: +100, Maximum MP: +50, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	resourceful warbear oil pan of the bloodbag	0		Maximum HP: +100, Maximum MP: +50, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	green warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	tumbling thinker's warbear exhaust manifold	0		Mysticality: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	yellow warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,9 +6889,9 @@
 7000	aromatic scandalous die-cast Don Crimbo	0		Sleaze Damage: +5, Stench Resistance: +1, Last Available: "2013-12"
 7001	Tesla stiffened die-cast Uncle Hobo	0		Damage Reduction: 1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 7002	fireproof die-cast Father Crimbo of the sweet-tooth	0		Hot Resistance: +3, Candy Drop: +100, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
-7004	cold-filtered boiled modified twirling narrow Flaskfull of Hollow	0		Effect: "Seriously Mutated", Effect Duration: 29, Last Available: "2013-12"
-7005	blinking ghostly lump of Brituminous coal	0		Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7004	cold-filtered boiled modified narrow twirling Flaskfull of Hollow	0		Effect: "Seriously Mutated", Effect Duration: 29, Last Available: "2013-12"
+7005	ghostly blinking lump of Brituminous coal	0		Last Available: "2013-12"
 7006	powdered handful of Smithereens	1	awesome	Effect: "Chorale of Companionship", Effect Duration: 25, Last Available: "2013-12"
 7007	bland olive Every Day is Like This Sundae	3	decent	Last Available: "2013-12"
 7008	gigantic bland pulsating Miserable Pie	7	decent	Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	censurious banded Da Vinci's sage Sheila Take a Crossbow	0		Mysticality Percent: +10, Experience (Mysticality): +5, Damage Absorption: +100, Sleaze Resistance: +3, Last Available: "2013-12"
 7019	upside-down electrified Herculean A Light that Never Goes Out of the dark arts of Flo-Jo	0		Experience (Muscle): +1, Spell Damage Percent: +100, Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 7020	rosy-cheeked banded Half a Purse of vim and vigor of the brazier	0		Damage Absorption: +100, Maximum HP Percent: 80, Hot Spell Damage: +25, Last Available: "2013-12"
-7021	family-friendly Jack Frost's dog trainer's resourceful Hairpiece On Fire	0		Maximum MP: +50, Experience (familiar): +1, Cold Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	gravedigger's Vicar's Tutu of Gandalf of the empath of the overflowing toilet	0		Spell Critical Percent: +20, Familiar Weight: +5, Stench Spell Damage: +50, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	family-friendly Jack Frost's dog trainer's resourceful Hairpiece On Fire	0		Maximum MP: +50, Experience (familiar): +1, Cold Spell Damage: +50, Sleaze Resistance: +1, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	gravedigger's Vicar's Tutu of Gandalf of the empath of the overflowing toilet	0		Spell Critical Percent: +20, Familiar Weight: +5, Stench Spell Damage: +50, Spooky Damage: +10, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	friendly savvy Hand in Glove of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Familiar Weight: +3, Single Equip, Last Available: "2013-12"
 7024	upside-down scorching frosty Meat Tenderizer is Murder of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Hot Damage: +25, Class: "Seal Clubber", Last Available: "2013-12"
 7025	nippy fortified strapping Ouija Board, Ouija Board	0		Muscle: +5, Damage Absorption: +60, Cold Damage: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6969,7 +6969,7 @@
 7080	skewed ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	spinning occult snow mobile	0		Spell Damage Percent: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	spinning occult snow mobile	0		Spell Damage Percent: +25, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	bouncing blinking lard-coated ice bucket	0		Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
 7085	coward's extremely unsafe snow shovel	0		Weapon Damage Percent: +100, Monster Level: -20, Lasts Until Rollover, Last Available: "2014-01"
 7086	olive squat executive stiffened bod-ice of Calamity Jane	0		Damage Reduction: 1, Critical Hit Percent: +15, Meat Drop: +40, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	hand-crafted En Una Fila Tequila	4	EPIC	
 7091	Skully's hot chocolate	1	decent	
-7092	inspector's gravedigger's warbear dress helmet	0		Spooky Damage: +10, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	inspector's gravedigger's warbear dress helmet	0		Spooky Damage: +10, Item Drop: +15, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	bouncing spinning hale warbear dress bracers of mayonnaise	0		Maximum HP: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2013-12"
-7094	hale healthy warbear dress greaves	0		Maximum HP Percent: +20, Maximum HP: +20, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	blinking studded quilted sweatband	0		Damage Absorption: 120, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	narrow deadly Sinatra's gym shorts	0		Experience (Moxie): +5, Weapon Damage: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	hale healthy warbear dress greaves	0		Maximum HP Percent: +20, Maximum HP: +20, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	blinking studded quilted sweatband	0		Damage Absorption: 120, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	narrow deadly Sinatra's gym shorts	0		Experience (Moxie): +5, Weapon Damage: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	rosewater-soaked experienced ankleweights	0		Experience: +2, Stench Resistance: +3, Single Equip, Last Available: "2014-12"
 7098	executive scorching hardy studded sweat socks	0		Damage Absorption: +80, Maximum HP: +50, Hot Damage: +25, Meat Drop: +40, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6997,30 +6997,30 @@
 7108	normal pulsating pecan	3	good	Last Available: "2014-12"
 7109	decent shaking pecan pie	4	good	Last Available: "2014-12"
 7110	mirror chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	stale huge purple candy mountain oyster	8	decent	Last Available: "2014-12"
+7111	huge stale purple candy mountain oyster	8	decent	Last Available: "2014-12"
 7112	weak artisanal chocotini	2	EPIC	Last Available: "2014-12"
 7113	miser's family-friendly chocolate rabbit's foot of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +1, Meat Drop: +10, Last Available: "2014-12"
 7114	normal candy carrot	3	good	Last Available: "2014-12"
-7115	normal miniature candy carrot cake	2	good	Last Available: "2014-12"
+7115	miniature normal candy carrot cake	2	good	Last Available: "2014-12"
 7116	energetic Socratic carrot-on-a-stick	0		Experience (Mysticality): +1, Maximum MP Percent: +20, Last Available: "2014-12"
-7117	skewed wholesome baleful weasel stomping pants	0		Spell Damage: +25, Maximum HP Percent: +10, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	immense moldy special bouncing mulberry	7	crappy	Effect: "Surreally Buff", Effect Duration: 20, Last Available: "2014-12"
-7119	smooth fuchsia ghostly mulled berry wine	3	awesome	Last Available: "2014-12"
+7117	skewed wholesome baleful weasel stomping pants	0		Spell Damage: +25, Maximum HP Percent: +10, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7118	moldy immense special bouncing mulberry	7	crappy	Effect: "Surreally Buff", Effect Duration: 20, Last Available: "2014-12"
+7119	smooth ghostly fuchsia mulled berry wine	3	awesome	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of terror	0		Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	lemon party hat of terror	0		Spooky Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	Tesla lemon shirt	0		MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2014-12"
-7123	twirling ruddy lemon drop trousers	0		Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	twirling ruddy lemon drop trousers	0		Maximum HP Percent: +40, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	liquefied pressed boiled jittery lemonhead caviar	0		Effect: "The Wisdom... of the Future", Effect Duration: 61, Last Available: "2014-12"
 7125	horrifying brawny gummi sword	0		Muscle Percent: +20, Spooky Damage: +25, Last Available: "2014-12"
 7126	pressed activated small gummi fin	0		Effect: "Yet tea", Effect Duration: 34, Last Available: "2014-12"
 7127	auspicious chocolate cow bone	0		Item Drop: +10, Last Available: "2014-12"
 7128	electrified ionized jittery squat gummi fang	0		Effect: "Berry Statistical", Effect Duration: 19, Last Available: "2014-12"
-7129	spoiled ghostly mirror leftover canap&eacute;s	3	crappy	Last Available: "2014-12"
+7129	spoiled mirror ghostly leftover canap&eacute;s	3	crappy	Last Available: "2014-12"
 7130	high-proof hand-crafted magnum of champagne	9	EPIC	Last Available: "2014-12"
 7131	nippy veiny groovy cow creamer	0		Moxie Percent: +10, Maximum HP: +10, Cold Damage: +10, Last Available: "2014-12"
 7132	frozen activated olive Outer Wolf&trade; cologne	0		Effect: "Oily Flavor", Effect Duration: 62, Last Available: "2014-12"
 7133	mirror lupine appetite hormones	0		Last Available: "2014-12"
-7134	blurry Jeselnik's wolf whistle of the early riser	0		Sleaze Damage: +25, Adventures: +7, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	blurry Jeselnik's wolf whistle of the early riser	0		Sleaze Damage: +25, Adventures: +7, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	yummy twirling witch's bread	3	awesome	Last Available: "2014-12"
 7136	polymerized colloidal twirling shaking witch's brew	0		Effect: "Techno Bliss", Effect Duration: 33, Last Available: "2014-12"
 7137	chilly clever Samson's witch's bra	0		Experience (Muscle): +5, Maximum MP: +20, Cold Damage: +5, Last Available: "2014-12"
@@ -7032,27 +7032,27 @@
 7143	Annie Oakley's energetic hare pin	0		Maximum MP Percent: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2014-12"
 7144	blue odd coin	0		Last Available: "2014-12"
 7145	normal half-sized teal cinnamon cannoli	2	good	Last Available: "2014-12"
-7146	extra-dry smooth expensive champagne	5	awesome	Last Available: "2014-12"
+7146	smooth extra-dry expensive champagne	5	awesome	Last Available: "2014-12"
 7147	double-liquefied improved super-Vulcanized narrow polo trophy	0		Effect: "Super Skill", Effect Duration: 54, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
 7152		0		Last Available: "2014-12"
-7153	red pulsating clay	0		Last Available: "2014-12"
+7153	pulsating red clay	0		Last Available: "2014-12"
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	upside-down glass	0		Last Available: "2014-12"
-7157	mirror fire hose of the pedagogue of vim and vigor of the blizzard	0		Experience: +3, Maximum HP Percent: +50, Cold Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	diet flavorless squat fireman's lunch	1	decent	Last Available: "2014-12"
-7159	mirror ghostly fireproof gravedigger's plain paper hat of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Hot Resistance: +3, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	rotten enchanted narrow ice cream sandwich	4	crappy	Effect: "Mucilaginous Mentalism", Effect Duration: 15, Last Available: "2014-12"
+7157	mirror fire hose of the pedagogue of vim and vigor of the blizzard	0		Experience: +3, Maximum HP Percent: +50, Cold Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7158	flavorless diet squat fireman's lunch	1	decent	Last Available: "2014-12"
+7159	mirror ghostly fireproof gravedigger's plain paper hat of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Hot Resistance: +3, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7160	enchanted rotten narrow ice cream sandwich	4	crappy	Effect: "Mucilaginous Mentalism", Effect Duration: 15, Last Available: "2014-12"
 7161	stanky dog trainer's &quot;honey&quot; dipper of mayonnaise	0		Experience (familiar): +1, Stench Spell Damage: +25, Sleaze Spell Damage: +50, Last Available: "2014-12"
-7162	decent big plumber's lunch	5	good	Last Available: "2014-12"
+7162	big decent plumber's lunch	5	good	Last Available: "2014-12"
 7163	toasty slick skull gearshift knob of Leguizamo	0		Moxie: +10, Monster Level: +20, Hot Damage: +5, Last Available: "2014-12"
-7164	big decent nachos of the night	5	good	Last Available: "2014-12"
+7164	decent big nachos of the night	5	good	Last Available: "2014-12"
 7165	quilted Newton's educational Sketcherz&trade;	0		Experience: +1, Experience (Mysticality): +3, Damage Absorption: +40, Last Available: "2014-12"
-7166	miniature moldy can of Adultwitch&trade;	2	crappy	Last Available: "2014-12"
+7166	moldy miniature can of Adultwitch&trade;	2	crappy	Last Available: "2014-12"
 7167	ionized cyan smudge stick	0		Effect: "Pemmican't", Effect Duration: 19, Last Available: "2014-12"
 7168	super-energized wet wall	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 51, Last Available: "2014-12"
 7169	tolerable weak tankard of ale	2	good	Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	triple-pickled colloidal ionized jug of &quot;wine&quot;	0		Effect: "Hypercubed", Effect Duration: 31, Last Available: "2014-12"
 7172	ghostly juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	gigantic fancy decent humble pie	9	good	Effect: "Coated Arms", Effect Duration: 15, Last Available: "2014-12"
+7174	fancy gigantic decent humble pie	9	good	Effect: "Coated Arms", Effect Duration: 15, Last Available: "2014-12"
 7175	yellow shaking small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	moist crappy waiter disguise	0		Effect: "Triangle, Man", Effect Duration: 33
@@ -7074,7 +7074,7 @@
 7185	blinking Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
 7187	drinkable unnamed cocktail	4	good	
-7188	spinning wobbly handful of tips	0		
+7188	wobbly spinning handful of tips	0		
 7189	steel-toed unrequired jacket	0		Damage Reduction: 9
 7190	flame-wreathed tommy gun	0		Hot Spell Damage: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	drum of tommy ammo	0		
@@ -7101,7 +7101,7 @@
 7212	red friendly Jefferson wings	0		Familiar Weight: +3
 7213	cyan fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	adequate special thick fleetwood mac 'n' cheese	5	good	Effect: "Hyperoxygenated Blood", Effect Duration: 30
+7215	adequate thick special fleetwood mac 'n' cheese	5	good	Effect: "Hyperoxygenated Blood", Effect Duration: 30
 7216	twirling lynyrd skin	0		
 7217	flame-wreathed lynyrdskin cap	0		Hot Spell Damage: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	wobbly hardy lynyrdskin tunic	0		Maximum HP: +50
@@ -7118,7 +7118,7 @@
 7229	smooth huge wine	3	awesome	
 7230	perfectly mixed blurry rum	3	EPIC	
 7231	hand-crafted wobbly Murderer's Punch	3	EPIC	
-7232	rotten snack-sized velvet cake	2	crappy	
+7232	snack-sized rotten velvet cake	2	crappy	
 7233	liquefied letter	0		Effect: "Egg-stortionary Tactics", Effect Duration: 61
 7234	lime green skewed MacGyver's book of James Dean	0		Experience (Moxie): +3, Maximum MP: +100
 7235	inspector's Tesla masque	0		Item Drop: +15, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -7137,11 +7137,11 @@
 7248	unsweetened shaking foxglove	0		Effect: "Salty Mouth", Effect Duration: 50
 7249	blinking Thwaitgold dragonfly statuette	0		
 7250	tumbling electrified banded wicked Sneaky Pete's jacket of horror	0		Spell Damage: +5, Damage Absorption: +100, Spooky Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Free Pull, Last Available: "2014-03"
-7251	shaking upside-down jug of Sneaky Pete's Mojo	0		Free Pull
+7251	upside-down shaking jug of Sneaky Pete's Mojo	0		Free Pull
 7252	blinking shot of Sneaky Pete's Mojo	0		Free Pull
-7253	huge cyan Anniversary Miniature Sword & Martini Guy	0		
+7253	cyan huge Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	practically non-alcoholic aged special tumbling mini-martini	1	awesome	Effect: "Smelly Pants", Effect Duration: 50
+7255	practically non-alcoholic special aged tumbling mini-martini	1	awesome	Effect: "Smelly Pants", Effect Duration: 50
 7256	smoke grenade	0		
 7257	boiled yellow molotov soda	1	decent	Effect: "Strength of Ten Ettins", Effect Duration: 35
 7258	modified triple-pressed pile of ashes	0		Effect: "Big Flaming Whip", Effect Duration: 39
@@ -7168,7 +7168,7 @@
 7279	quantum concentrated gray wind-up Whatsian robot	0		Effect: "Heart Aflame", Effect Duration: 53
 7280	corrupted anodized wind-up vampire teeth	0		Effect: "Appeteyes", Effect Duration: 31
 7281	wet dry mirror spinning wind-up navigation droid	0		Effect: "Ruthlessly Efficient", Effect Duration: 63
-7282	moist shaking cyan wind-up owl	0		Effect: "A View to Some Meat", Effect Duration: 68
+7282	moist cyan shaking wind-up owl	0		Effect: "A View to Some Meat", Effect Duration: 68
 7283	unsweetened triple-pickled wind-up ensign	0		Effect: "Celestial Body", Effect Duration: 68
 7284	deadly smooth crying statue earrings	0		Moxie: +15, Weapon Damage: +5, Single Equip, Lasts Until Rollover
 7285	miser's smelly plastic Duskwalker necklace	0		Stench Spell Damage: +10, Meat Drop: +10, Single Equip, Lasts Until Rollover
@@ -7176,7 +7176,7 @@
 7287	Sinatra's educational Gary Claybender's Time Screwer	0		Experience: +1, Experience (Moxie): +5, Single Equip, Lasts Until Rollover
 7288	shaking Lo Pan's Space Tourist palmdoctor of the businessman	0		Spell Critical Percent: +30, Meat Drop: +50, Lasts Until Rollover
 7289	Lo Pan's Tesla sage amok putter	0		Mysticality Percent: +10, Spell Critical Percent: +30, MP Regen Min: 7, MP Regen Max: 10
-7290	jumbo moldy amok pudding	5	crappy	
+7290	moldy jumbo amok pudding	5	crappy	
 7291	deactivated putty buddy	0		
 7292	red blinking putty coat	0		Familiar Weight: +5
 7293	frozen gray can of V-11	0		Effect: "Fishy Fortification", Effect Duration: 26, Last Available: "2014-03"
@@ -7200,23 +7200,23 @@
 7311	dance instructor's elegant nightstick of the bloodbag	0		Experience Percent (Moxie): +10, Maximum HP: +100
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	blue mirror mirror box of hickory chips	0		Familiar Weight: +5
-7314	narrow skewed poppet	0		
+7314	skewed narrow poppet	0		
 7315	rickety rocking horse	0		
 7316	jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	miser's supercool beefcake's ghost of a necklace	0		Muscle: +25, Moxie Percent: +20, Meat Drop: +10
 7319	tumbling wizardly Elizabeth's Dollie of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100
-7320	double-deionized shaking mirror Elizabeth's paintbrush	0		Effect: "Crud&eacute;", Effect Duration: 23
+7320	double-deionized mirror shaking Elizabeth's paintbrush	0		Effect: "Crud&eacute;", Effect Duration: 23
 7321	wobbly auspicious energetic Stephen's lab coat	0		Maximum MP Percent: +20, Item Drop: +10
 7322	super-boiled upside-down Stephen's secret formula	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 19
 7323	veiny Jacob's rung of Gandalf	0		Maximum HP: +10, Spell Critical Percent: +20
 7324	compressed battery	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 15
-7325	hand-crafted weak skewed snakebite	2	EPIC	
+7325	weak hand-crafted skewed snakebite	2	EPIC	
 7326	pulsating dance instructor's rubber ribcage of horror	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +25, Damage Reduction: 7
 7327	twisted bouncing synthetic marrow	1		
-7328	triple-warmed vacuum-sealed twirling spinning funny bone	0		Effect: "Venomous Weapon", Effect Duration: 50
+7328	triple-warmed vacuum-sealed spinning twirling funny bone	0		Effect: "Venomous Weapon", Effect Duration: 50
 7329	squat horrifying half-melted spoon of bravery	0		Spooky Damage: +25, Spooky Resistance: +5
-7330	boiled narrow maroon the funk	1		
+7330	boiled maroon narrow the funk	1		
 7331	yummy lime green gunky chicken	4	awesome	
 7332	squat shaking dangerous doll head	0		Weapon Damage: +10
 7333	droopy doll eye	0		
@@ -7234,7 +7234,7 @@
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	olive Usain Bolt's lion tamer's ghost toga	0		Experience (familiar): +2, Initiative: +80
-7348	tiny spoiled blurry sheet cake	1	crappy	
+7348	spoiled tiny blurry sheet cake	1	crappy	
 7349	ghost key	0		
 7350	jittery picture of you	0		
 7351	flame-retardant quilted Herculean Staff of the Electric Range	0		Experience (Muscle): +1, Damage Absorption: +40, Hot Resistance: +1
@@ -7251,7 +7251,7 @@
 7362	blue slick weightlifter's plaid skirt	0		Muscle: +15, Moxie: +10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	boiled wobbly bloodstain stick	0		Effect: "Joyful Resolve", Effect Duration: 36
 7364	mirror fabric softener	0		
-7365	irradiated deionized narrow ghostly fabric hardener	0		Effect: "Oiled Skin", Effect Duration: 65
+7365	irradiated deionized ghostly narrow fabric hardener	0		Effect: "Oiled Skin", Effect Duration: 65
 7366	practically non-alcoholic tolerable jittery bottle of laundry sherry	1	good	
 7367	super-warmed narrow industrial strength starch	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 61, Wiki Name: "industrial strength starch"
 7368	adequate extra-flat panini	3	good	
@@ -7269,7 +7269,7 @@
 7380	fireproof Jim Carey's ghast iron codpiece	0		Monster Level: +25, Hot Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 42"
 7381	Pendant of Gargalesis of the cheetah	0		Initiative: +60
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
-7383	wobbly spinning DNA extraction syringe	0		Last Available: "2014-04"
+7383	spinning wobbly DNA extraction syringe	0		Last Available: "2014-04"
 7384	polarized Gene Tonic: Dude	0		Effect: "Crusty Head", Effect Duration: 64, Last Available: "2014-04"
 7385	cold-filtered Gene Tonic: Beast	0		Effect: "New Zeal", Effect Duration: 42, Last Available: "2014-04"
 7386	electrified quantum huge Gene Tonic: Construct	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 45, Last Available: "2014-04"
@@ -7277,14 +7277,14 @@
 7388	improved corrupted Gene Tonic: Humanoid	0		Effect: "Insulated Trousers", Effect Duration: 24, Last Available: "2014-04"
 7389	triple-aerosolized olive Gene Tonic: Insect	0		Effect: "Adapt to Change Eventually", Effect Duration: 55, Last Available: "2014-04"
 7390	dry vacuum-sealed blue Gene Tonic: Hippy	0		Effect: "Gummibrain", Effect Duration: 11, Last Available: "2014-04"
-7391	cold-filtered energized shaking skewed Gene Tonic: Orc	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2014-04"
+7391	cold-filtered energized skewed shaking Gene Tonic: Orc	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2014-04"
 7392	boiled Gene Tonic: Demon	0		Effect: "Witch's Brood", Effect Duration: 56, Last Available: "2014-04"
 7393	quantum Gene Tonic: Horror	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 11, Last Available: "2014-04"
 7394	diffused Gene Tonic: Fish	0		Effect: "Tiki Toughness", Effect Duration: 33, Last Available: "2014-04"
 7395	unsweetened triple-improved Gene Tonic: Goblin	0		Effect: "Egg on your Face", Effect Duration: 32, Last Available: "2014-04"
 7396	super-polymerized moist lime green pulsating Gene Tonic: Pirate	0		Effect: "Gemini Rising", Effect Duration: 63, Last Available: "2014-04"
 7397	activated quadruple-aerosolized huge blue Gene Tonic: Plant	0		Effect: "Egged On", Effect Duration: 33, Last Available: "2014-04"
-7398	activated huge wobbly Gene Tonic: Weird	0		Effect: "Prelude of Precision", Effect Duration: 27, Last Available: "2014-04"
+7398	activated wobbly huge Gene Tonic: Weird	0		Effect: "Prelude of Precision", Effect Duration: 27, Last Available: "2014-04"
 7399	electrified tarnished flattened Gene Tonic: Elf	0		Effect: "Pretending to Pretend", Effect Duration: 27, Last Available: "2014-04"
 7400	deionized ionized Gene Tonic: Mer-kin	0		Effect: "Chalked Weapon", Effect Duration: 11, Last Available: "2014-04"
 7401	extra-corrupted Gene Tonic: Slime	0		Effect: "The Magic of Sharing", Effect Duration: 16, Last Available: "2014-04"
@@ -7292,7 +7292,7 @@
 7403	quadruple-enhanced Gene Tonic: Elemental	0		Effect: "Devil Inside", Effect Duration: 33, Last Available: "2014-04"
 7404	super-alkaline moist huge Gene Tonic: Constellation	0		Effect: "Squirming Like a Toad", Effect Duration: 65, Last Available: "2014-04"
 7405	adjusted Gene Tonic: Hobo	0		Effect: "Feet of Watermelon", Effect Duration: 58, Last Available: "2014-04"
-7406	squat narrow purple Steam Card: Dungeon Fist (#1)	0		
+7406	purple narrow squat Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
 7408	red Steam Card: Dungeon Fist (#3)	0		
 7409	huge Steam Card: Space Trip (#1)	0		
@@ -7302,7 +7302,7 @@
 7413	blinking Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
 7415	squat Steam Card: DemonStar (#1)	0		
-7416	ghostly skewed Steam Card: DemonStar (#2)	0		
+7416	skewed ghostly Steam Card: DemonStar (#2)	0		
 7417	Steam Card: DemonStar (#3)	0		
 7418	Steam Card: Jackass Plumber (#1)	0		
 7419	Steam Card: Jackass Plumber (#2)	0		
@@ -7326,35 +7326,35 @@
 7437	teal blurry Pastaco shell	0		Last Available: "2014-05"
 7438	immense normal Beefy Crunch Pastaco	10	good	Last Available: "2014-05"
 7439	moldy half-sized blinking Brain Food Pastaco	2	crappy	Last Available: "2014-05"
-7440	decent snack-sized bouncing Cool Brunch Pastaco	2	good	Last Available: "2014-05"
-7441	adequate snack-sized tumbling Medical Pastaco	2	good	Last Available: "2014-05"
+7440	snack-sized decent bouncing Cool Brunch Pastaco	2	good	Last Available: "2014-05"
+7441	snack-sized adequate tumbling Medical Pastaco	2	good	Last Available: "2014-05"
 7442	jumbo normal bouncing Energy Buzz Pastaco	5	good	Last Available: "2014-05"
 7443	spoiled huge Ludovico Pastaco	3	crappy	Last Available: "2014-05"
 7444	mediocre shaking overpowering mushroom wine	3	decent	Last Available: "2014-05"
 7445	drinkable complex mushroom wine	4	good	Last Available: "2014-05"
-7446	weak hand-crafted teal huge smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7446	weak hand-crafted huge teal smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	lousy blood-red mushroom wine	3	decent	Last Available: "2014-05"
 7448	hand-crafted buzzing mushroom wine	4	EPIC	Last Available: "2014-05"
 7449	aged mirror swirling mushroom wine	3	awesome	Last Available: "2014-05"
 7450	normal squat Taco Dan's Basic Taco Dan Taco	3	good	Last Available: "2014-05"
-7451	jumbo stale Taco Dan's Taco Fish Fish Taco	5	decent	Last Available: "2014-05"
+7451	stale jumbo Taco Dan's Taco Fish Fish Taco	5	decent	Last Available: "2014-05"
 7452	upside-down Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	perfectly mixed regular-size brogurt	3	EPIC	Last Available: "2014-05"
-7454	hand-crafted triple-distilled super-size brogurt	8	EPIC	Last Available: "2014-05"
+7454	triple-distilled hand-crafted super-size brogurt	8	EPIC	Last Available: "2014-05"
 7455	tolerable distilled broberry brogurt	5	good	Last Available: "2014-05"
-7456	triple-distilled tolerable brocolate brogurt	7	good	Last Available: "2014-05"
-7457	spirit-forward perfectly mixed French bronilla brogurt	5	EPIC	Last Available: "2014-05"
+7456	tolerable triple-distilled brocolate brogurt	7	good	Last Available: "2014-05"
+7457	perfectly mixed spirit-forward French bronilla brogurt	5	EPIC	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	nippy Brogre brorts	0		Cold Damage: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	nippy Brogre brorts	0		Cold Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	upside-down manspreader's Brogre brolo shirt	0		Monster Level: +10, Last Available: "2014-05"
-7464	fireproof Brogre bucket hat	0		Hot Resistance: +3, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	fireproof Brogre bucket hat	0		Hot Resistance: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	mirror yellow Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	yellow one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	red zippy auspicious Sinatra's 8-billed baseball cap	0		Experience (Moxie): +5, Item Drop: +10, Initiative: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	red zippy auspicious Sinatra's 8-billed baseball cap	0		Experience (Moxie): +5, Item Drop: +10, Initiative: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	pulsating dog trainer's ruddy extremely wet T-shirt of wisdom	0		Mysticality: +15, Maximum HP Percent: +40, Experience (familiar): +1, Last Available: "2014-05"
 7470	tumbling curative fortified shrimp fork of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-05"
 7471	improved BROS Energy Drink	0		Effect: "Saucefingers", Effect Duration: 12, Last Available: "2014-05"
@@ -7367,10 +7367,10 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	quadruple-diffused sugar fairy	0		Effect: "Al Dente Inferno", Effect Duration: 33, Last Available: "2014-05"
 7480	extra-altered sugar bunny	0		Effect: "Disco Concentration", Effect Duration: 30, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	mediocre practically non-alcoholic upside-down Rompedores de Fantasmas	1	decent	
-7483	irresponsibly strong mediocre La Fantasma y La Oscuridad	9	decent	
-7484	artisanal weak Fantasma en la M&aacute;quina	2	EPIC	
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	practically non-alcoholic mediocre upside-down Rompedores de Fantasmas	1	decent	
+7483	mediocre irresponsibly strong La Fantasma y La Oscuridad	9	decent	
+7484	weak artisanal Fantasma en la M&aacute;quina	2	EPIC	
 7485	loosening powder	0		
 7486	shaking castoreum	0		
 7487	drain dissolver	0		
@@ -7380,7 +7380,7 @@
 7491	lousy bottle of Chateau de Vinegar	3	decent	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
-7494	olive twirling wine bomb	0		
+7494	twirling olive wine bomb	0		
 7495	lime green recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
@@ -7397,8 +7397,8 @@
 7508	skewed label	0		
 7509	super-sized flavorless upside-down Mornington crescent roll	5	decent	
 7510	electrified eye shadow	0		Effect: "Vented Spleen", Effect Duration: 61
-7511	wobbly wobbly yellow crumbling wheel	0		
-7512	cold-filtered ionized galvanized narrow teal poppy	0		Effect: "Nutrient-Rich", Effect Duration: 48
+7511	yellow wobbly wobbly crumbling wheel	0		
+7512	cold-filtered ionized galvanized teal narrow poppy	0		Effect: "Nutrient-Rich", Effect Duration: 48
 7513	upside-down opium grenade	0		
 7514	forbidden cool duonoculars	0		Moxie: +5, Spell Damage Percent: +50, Single Equip
 7515	tumbling plastic rock	0		
@@ -7425,11 +7425,11 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of the early riser	0		Adventures: +7, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	electrified space beast fur pants	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	space beast fur hat of the early riser	0		Adventures: +7, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	electrified space beast fur pants	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	pulsating Annie Oakley's space beast fur whip	0		Critical Hit Percent: +20, Last Available: "2014-05"
 7542	spinning space invader	0		Last Available: "2014-05"
-7543	forbidden space heater of the boozehound	0		Spell Damage Percent: +50, Booze Drop: +100, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	forbidden space heater of the boozehound	0		Spell Damage Percent: +50, Booze Drop: +100, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
 7545	lousy shaking space port	3	decent	Last Available: "2014-05"
 7546	stiffened grievous space needle	0		Weapon Damage Percent: +50, Damage Reduction: 1, Last Available: "2014-05"
@@ -7444,14 +7444,14 @@
 7555	pulsating page	0		
 7556	elephant gift	0		
 7557	double-quantum tumbling blood cells	0		Effect: "Prince of Seaside Town", Effect Duration: 38
-7558	high-proof hand-crafted wine	6	EPIC	
+7558	hand-crafted high-proof wine	6	EPIC	
 7559	denatured spinning gummi turtle	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 40
 7560	spinning turtle-shaped rock	0		
 7561	magnetized quadruple-concentrated spinning giraffe-necked turtle	0		Effect: "Stands Alone", Effect Duration: 56
 7562	ionized dry musk turtle	0		Effect: "Muscle Unbound", Effect Duration: 36
 7563	vacuum-sealed anodized cyan programmable turtle	0		Effect: "I See Everything Thrice!", Effect Duration: 53
 7564	frozen ionized colloidal mocking turtle	0		Effect: "Scarysauce", Effect Duration: 24
-7565	fancy low-calorie decent ham steak	1	good	Effect: "Nano-juiced", Effect Duration: 40
+7565	fancy decent low-calorie ham steak	1	good	Effect: "Nano-juiced", Effect Duration: 40
 7566	healthy time-twitching toolbelt	0		Maximum HP Percent: +20, Single Equip, Free Pull
 7567	Chroner	0		
 7568	tumbling green Jim Carey's deadly strapping Time Lord Badge of Honor	0		Muscle: +5, Weapon Damage: +5, Monster Level: +25
@@ -7463,7 +7463,7 @@
 7574	artisanal teal New Zealand iced tea	3	EPIC	
 7575	yellow droll monocle of the brazier of horror	0		Hot Spell Damage: +25, Spooky Spell Damage: +25, Single Equip
 7576	tarnished modified future drug: Muscularactum	0		Effect: "Blackberry Politeness", Effect Duration: 22
-7577	frozen upside-down maroon future drug: Smartinex	0		Effect: "Analog Drunk", Effect Duration: 46
+7577	frozen maroon upside-down future drug: Smartinex	0		Effect: "Analog Drunk", Effect Duration: 46
 7578	alkaline activated future drug: Coolscaline	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 54
 7579	twitching time capsule	0		
 7580	diluted liquid shifting time weirdness	1		Effect: "Donho's Bubbly Ballad", Effect Duration: 5
@@ -7475,17 +7475,17 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	jittery Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	aged spirit-forward glass of &quot;milk&quot;	5	awesome	Last Available: "2014-07"
-7590	delicious strong cup of &quot;tea&quot;	5	awesome	Last Available: "2014-07"
+7589	spirit-forward aged glass of &quot;milk&quot;	5	awesome	Last Available: "2014-07"
+7590	strong delicious cup of &quot;tea&quot;	5	awesome	Last Available: "2014-07"
 7591	tolerable thermos of &quot;whiskey&quot;	4	good	Last Available: "2014-07"
 7592	smooth Lucky Lindy	4	awesome	Last Available: "2014-07"
 7593	tolerable Bee's Knees	4	good	Last Available: "2014-07"
 7594	aged wobbly Sockdollager	3	awesome	Last Available: "2014-07"
-7595	hand-crafted triple-distilled ghostly Ish Kabibble	8	EPIC	Last Available: "2014-07"
+7595	triple-distilled hand-crafted ghostly Ish Kabibble	8	EPIC	Last Available: "2014-07"
 7596	lousy Hot Socks	4	decent	Last Available: "2014-07"
 7597	irresponsibly strong smooth pulsating Phonus Balonus	7	awesome	Last Available: "2014-07"
 7598	artisanal watered-down Flivver	2	EPIC	Last Available: "2014-07"
-7599	lousy watered-down Sloppy Jalopy	2	decent	Last Available: "2014-07"
+7599	watered-down lousy Sloppy Jalopy	2	decent	Last Available: "2014-07"
 7600	anodized magnetized flame	0		Effect: "It's Electric!", Effect Duration: 58
 7601	enhanced temporary yak tattoo	0		Effect: "Disco Neuropathy", Effect Duration: 45
 7602	electrified concentrated Fitspiration&trade; poster	0		Effect: "Cold Blooded", Effect Duration: 40
@@ -7517,7 +7517,7 @@
 7628	polarized yellow narrow dancing fan	0		Effect: "Rat-Faced", Effect Duration: 33
 7629	liquefied shaking page of the Necrohobocon	0		Effect: "Glittering Eyelashes", Effect Duration: 23
 7630	corrupted magic powder	0		Effect: "Smugness", Effect Duration: 40
-7631	modified shaking pulsating friar's tonsure	0		Effect: "Browbeaten", Effect Duration: 66
+7631	modified pulsating shaking friar's tonsure	0		Effect: "Browbeaten", Effect Duration: 66
 7632	aerosolized government-issue identification badge	0		Effect: "New and Improved", Effect Duration: 21
 7633	cold-filtered concentrated narrow alien hologram projector	0		Effect: "Space Cowboy", Effect Duration: 54
 7634	double-liquefied modified irradiated turtle	0		Effect: "Can Has Cyborger", Effect Duration: 55
@@ -7528,7 +7528,7 @@
 7639	banded oil shell	0		Damage Absorption: +100, Class: "Turtle Tamer"
 7640	sizzling MacGyver's dance instructor's turtle shell	0		Experience Percent (Moxie): +10, Maximum MP: +100, Hot Damage: +10, Class: "Turtle Tamer"
 7641	blurry shocked shell	0		Class: "Turtle Tamer"
-7642	jittery cyan ingot turtle	0		
+7642	cyan jittery ingot turtle	0		
 7643	duty umbrella	0		
 7644	pool skimmer	0		
 7645	life preserver	0		
@@ -7553,7 +7553,7 @@
 7664	polarized extra-oxidized Ancient Protector Soda	0		Effect: "Cold, Dead Hands", Effect Duration: 41
 7665	oxidized colloidal pressed liquid ice	0		Effect: "Squid Squint", Effect Duration: 47
 7666	tolerable weak Wet Russian	2	good	
-7667	yummy enchanted filet of The Fish	3	awesome	Effect: "Infernal Thirst", Effect Duration: 10
+7667	enchanted yummy filet of The Fish	3	awesome	Effect: "Infernal Thirst", Effect Duration: 10
 7668	Thwaitgold spider statuette	0		
 7669	blinking lard-coated energetic Sinatra's thunder down underwear	0		Experience (Moxie): +5, Maximum MP Percent: +20, Sleaze Spell Damage: +25, Lasts Until Rollover
 7670	razor-sharp famous raincoat of wisdom of the blizzard	0		Mysticality: +15, Weapon Damage Percent: +25, Cold Spell Damage: +25, Lasts Until Rollover
@@ -7567,7 +7567,7 @@
 7678	4-dimensional fez of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	deadly super-absorbent tarp	0		Weapon Damage: +5
-7681	practically non-alcoholic mediocre pulsating unquiet spirits	1	decent	
+7681	mediocre practically non-alcoholic pulsating unquiet spirits	1	decent	
 7682	auspicious banjo kazoo mount	0		Item Drop: +10, Single Equip
 7683	ionized skewed grass	0		Effect: "Swordholder", Effect Duration: 33
 7684	lightning-fast Time Lord Participation Mug	0		Initiative: +40
@@ -7581,27 +7581,27 @@
 7692	ghostly friendly hand whip of the bloodbag of the brazier	0		Maximum HP: +100, Familiar Weight: +3, Hot Spell Damage: +25, Last Available: "2014-08"
 7693	zippy lion tamer's groovy glow-in-the-dark necklace	0		Moxie Percent: +10, Experience (familiar): +2, Initiative: +20, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	vibrating hale cap gun of the empath	0		Maximum HP: +20, Maximum MP Percent: +10, Familiar Weight: +5, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	vibrating hale cap gun of the empath	0		Maximum HP: +20, Maximum MP Percent: +10, Familiar Weight: +5, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	shaking dangerous cassette player of the dark arts	0		Weapon Damage: +10, Spell Damage Percent: +100, Single Equip, Last Available: "2014-08"
-7697	olive twirling chewable paper	0		Free Pull, Last Available: "2014-08"
+7697	twirling olive chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
-7700	vacuum-sealed tarnished gray squat confiscated comic book	0		Effect: "Corruption of Wretched Wally", Effect Duration: 50, Last Available: "2014-08"
+7700	vacuum-sealed tarnished squat gray confiscated comic book	0		Effect: "Corruption of Wretched Wally", Effect Duration: 50, Last Available: "2014-08"
 7701	quantum super-moist narrow confiscated cell phone	0		Effect: "Fudge Headache", Effect Duration: 30, Last Available: "2014-08"
 7702	tarnished enhanced confiscated love note	0		Effect: "Stone-Faced", Effect Duration: 33, Last Available: "2014-08"
 7703	yellow LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	wet extra-pickled rubber nubbin	0		Effect: "Engorged Weapon", Effect Duration: 57, Last Available: "2014-08"
 7708	mirror personal trainer's rubber cape of the cheetah	0		Experience Percent (Muscle): +10, Initiative: +60, Last Available: "2014-08"
-7709	lime green bouncing nippy steel-toed forbidden Thor's Pliers of chilblains	0		Spell Damage Percent: +50, Damage Reduction: 9, Cold Damage: 35, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	lime green bouncing nippy steel-toed forbidden Thor's Pliers of chilblains	0		Spell Damage Percent: +50, Damage Reduction: 9, Cold Damage: 35, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	extra-unsweetened blinking candy UFOs	0		Effect: "Sharp Weapon", Effect Duration: 55
 7711	padded stylish water wings for babies	0		Moxie: +25, Damage Absorption: +20
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	gigantic moldy lime green Strix stix	10	crappy	
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7713	moldy gigantic lime green Strix stix	10	crappy	
 7714	jittery aromatic Jim Carey's vampire pellet of dire peril	0		Weapon Damage: +20, Monster Level: +25, Stench Resistance: +1
-7715	watered-down lousy non-aged vinegar	2	decent	
+7715	lousy watered-down non-aged vinegar	2	decent	
 7716	horrifying unsanitized scalpel	0		Spooky Damage: +25
 7717	gladiator tunica of terror	0		Spooky Spell Damage: +10
 7718	Samson's Roman sadnals	0		Experience (Muscle): +5, Single Equip
@@ -7639,11 +7639,11 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	purple Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	pulsating Xiblaxian xeno-detection goggles of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2014-09"
-7753	ghostly flame-wreathed thinker's Xiblaxian stealth cowl	0		Mysticality: +10, Hot Spell Damage: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	ghostly flame-wreathed thinker's Xiblaxian stealth cowl	0		Mysticality: +10, Hot Spell Damage: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	nasty stylish Xiblaxian stealth trousers	0		Moxie: +25, Stench Damage: +5, Last Available: "2014-09"
 7755	green censurious slick Xiblaxian stealth vest	0		Moxie: +10, Sleaze Resistance: +3, Last Available: "2014-09"
 7756	yummy Xiblaxian ultraburrito	3	awesome	Last Available: "2014-09"
-7757	aged special weak Xiblaxian space-whiskey	2	awesome	Effect: "Shawarma Warm War", Effect Duration: 10, Last Available: "2014-09"
+7757	weak aged special Xiblaxian space-whiskey	2	awesome	Effect: "Shawarma Warm War", Effect Duration: 10, Last Available: "2014-09"
 7758	narrow Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	anodized They liver	0		Effect: "Crying, Dying", Effect Duration: 63, Last Available: "2014-09"
 7760	flavorless They liver popsicle	3	decent	Last Available: "2014-09"
@@ -7668,12 +7668,12 @@
 7779	vacuum-sealed blue experimental serum G-9	0		Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2014-10"
 7780	ghostly jittery greedy Tesla heavy-duty clipboard of terror	0		Spooky Spell Damage: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 8, Last Available: "2014-10"
 7781	twirling teal asbestos-lined greasy banded razor-sharp battery-powered drill	0		Weapon Damage Percent: +25, Damage Absorption: +100, Sleaze Spell Damage: +10, Hot Resistance: +5, Last Available: "2014-10"
-7782	half-sized normal lime green limp broccoli	2	good	Last Available: "2014-10"
-7783	spinning ghostly toasty Da Vinci's supercool hat	0		Moxie Percent: +20, Experience (Mysticality): +5, Hot Damage: +5, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	normal half-sized lime green limp broccoli	2	good	Last Available: "2014-10"
+7783	spinning ghostly toasty Da Vinci's supercool hat	0		Moxie Percent: +20, Experience (Mysticality): +5, Hot Damage: +5, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	ionized ionized ghostly monkey barf	0		Effect: "Cautious Prowl", Effect Duration: 20, Last Available: "2014-10"
 7785	dry quadruple-ionized skewed candy	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 61, Last Available: "2014-10"
 7786	executive jangly bracelet of the blizzard of the businessman	0		Cold Spell Damage: +25, Meat Drop: 90, Last Available: "2014-10"
-7787	tumbling huge cyan foul-smelling cuddly teddy bear	0		Stench Damage: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	tumbling huge cyan foul-smelling cuddly teddy bear	0		Stench Damage: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	reassuring nippy first-aid pouch	0		Cold Damage: +10, Spooky Resistance: +1, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7703,8 +7703,8 @@
 7814	tolerable skewed bottle of drinkin' gas	4	good	
 7815	maroon handful of napalm	0		
 7816	lime green dove DNA	0		
-7817	jittery shaking gelatinous meat mass	0		
-7818	twirling purple 99.44% pure math	0		
+7817	shaking jittery gelatinous meat mass	0		
+7818	purple twirling 99.44% pure math	0		
 7819	narrow simple AI	0		
 7820	corrupted bird DNA	0		
 7821	sentient meat mass	0		
@@ -7713,7 +7713,7 @@
 7824	bouncing Jeselnik's wicked iShield of the storm	0		Spell Damage: +5, Maximum MP Percent: +40, Sleaze Damage: +25, Damage Reduction: 6
 7825	sizzling dangerous earbuds of bravery	0		Weapon Damage: +10, Hot Damage: +10, Spooky Resistance: +5, Single Equip
 7826	prompt razor-sharp dance instructor's iFlail	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Adventures: +3
-7827	moldy super-sized gray unidentifiable dried fruit	5	crappy	
+7827	super-sized moldy gray unidentifiable dried fruit	5	crappy	
 7828	artisanal flat cider	3	EPIC	
 7829	therapeutic studded Da Vinci's trench lighter	0		Experience (Mysticality): +5, Damage Absorption: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-10"
 7830	pressed maroon experimental serum P-00	0		Effect: "Human-Hobo Hybrid", Effect Duration: 18, Last Available: "2014-10"
@@ -7726,7 +7726,7 @@
 7837	Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	mirror special clip: tracers	0		Last Available: "2014-10"
-7840	gray huge tumbling special clip: wailers	0		Last Available: "2014-10"
+7840	tumbling gray huge special clip: wailers	0		Last Available: "2014-10"
 7841	special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
@@ -7735,7 +7735,7 @@
 7846	chilled upside-down Fudge Fiber Armor Plating	0		Effect: "Whippin' It Good", Effect Duration: 26, Last Available: "2014-12"
 7847	energized polymerized ruby on canes	0		Effect: "Spell Transfer Complete", Effect Duration: 39, Last Available: "2014-12"
 7848	flavorless diet petit fortran	1	decent	Last Available: "2014-12"
-7849	big normal skewed java cookie	5	good	Last Available: "2014-12"
+7849	normal big skewed java cookie	5	good	Last Available: "2014-12"
 7850	delicious cookie cookie	3	awesome	Last Available: "2014-12"
 7851	chaotic plastic exo-suited miner	0		Spell Critical Percent: +10, Last Available: "2014-12"
 7852	Da Vinci's plastic semi-autonomous drill unit	0		Experience (Mysticality): +5, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	MacGyver's plastic Crimbot	0		Maximum MP: +100, Last Available: "2014-12"
 7855	quilted plastic Crimbomega	0		Damage Absorption: +40, Last Available: "2014-12"
 7856	enhanced wobbly flask of mining oil	0		Effect: "Human-Slime Hybrid", Effect Duration: 32, Last Available: "2014-12"
-7857	twirling radiation-resistant helmet of the brute	0		Muscle Percent: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	studded servo-assisted exo-pants	0		Damage Absorption: +80, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	twirling radiation-resistant helmet of the brute	0		Muscle Percent: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	studded servo-assisted exo-pants	0		Damage Absorption: +80, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	therapeutic studded high-energy mining laser	0		Damage Absorption: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	squat fuchsia nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7788,7 +7788,7 @@
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	twirling Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	squat Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
-7902	green squat Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
+7902	squat green Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	recovered elf magazine	0		Last Available: "2014-12"
@@ -7804,13 +7804,13 @@
 7915	vacuum-sealed wobbly Take Eleven Bar	0		Effect: "Hyperoffended", Effect Duration: 24
 7916	mimeplasm	0		
 7917	triple-concentrated vacuum-sealed liquefied wobbly BOOterfinger	0		Effect: "Liquidy Smoky", Effect Duration: 49
-7918	non-oxidized alkaline pulsating lime green Moonds	0		Effect: "Larger", Effect Duration: 55
+7918	non-oxidized alkaline lime green pulsating Moonds	0		Effect: "Larger", Effect Duration: 55
 7919	anodized Big Punk	0		Effect: "Jammin'", Effect Duration: 49
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	squat turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	drinkable Friendly Turkey	3	good	Last Available: "2014-11"
 7923	perfectly mixed Agitated Turkey	4	EPIC	Last Available: "2014-11"
-7924	practically non-alcoholic acceptable squat Ambitious Turkey	1	good	Last Available: "2014-11"
+7924	acceptable practically non-alcoholic squat Ambitious Turkey	1	good	Last Available: "2014-11"
 7925	immense adequate narrow neutron lollipop	9	good	Last Available: "2014-12"
 7926	mediocre olive gamma nog	3	decent	Last Available: "2014-12"
 7934	jittery sneaky wrapping paper	0		Last Available: "2014-12"
@@ -7827,8 +7827,8 @@
 7945	table	0		
 7946	miser's chilly beefcake's outlaw bandana	0		Muscle: +25, Cold Damage: +5, Meat Drop: +10
 7947	extra-dry smooth whiskey in a broken glass	5	awesome	
-7948	distilled lousy shot of mescal	5	decent	
-7949	special hand-crafted glass of herbal tequila	3	EPIC	Effect: "Phairly Pheromonal", Effect Duration: 20
+7948	lousy distilled shot of mescal	5	decent	
+7949	hand-crafted special glass of herbal tequila	3	EPIC	Effect: "Phairly Pheromonal", Effect Duration: 20
 7950	shaking minin' dynamite	0		
 7951	Da Vinci's plaid cowboy hat of vim and vigor	0		Experience (Mysticality): +5, Maximum HP Percent: +50, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7845,7 +7845,7 @@
 7963	amulet	0		
 7964	Sherlock's Staff of Fats	0		Item Drop: +25
 7965	Holy MacGuffin	0		
-7966	twirling squat Ka coin	0		
+7966	squat twirling Ka coin	0		
 7967	extremely unsafe World's Best Adventurer sash	0		Weapon Damage Percent: +100
 7968	topiary nugglet	0		
 7969	beehive	0		
@@ -7853,9 +7853,9 @@
 7971	Aggressive Carrot	0		Free Pull
 7972	altered jittery mummified fig	1	decent	
 7973	modified mummified loaf of bread	1	awesome	Effect: "Action", Effect Duration: 20
-7974	vaporized blinking ghostly mummified beef haunch	1	good	Effect: "Liquid Courage", Effect Duration: 15
+7974	vaporized ghostly blinking mummified beef haunch	1	good	Effect: "Liquid Courage", Effect Duration: 15
 7975	linen bandages	0		
-7976	pulsating yellow cotton bandages	0		
+7976	yellow pulsating cotton bandages	0		
 7977	jittery silk bandages	0		
 7978	huge holy spring water	0		
 7979	spirit beer	0		
@@ -7877,28 +7877,28 @@
 7995	vibrating rock-hard pelerine	0		Damage Reduction: 5, Maximum MP Percent: +10, Last Available: "2015-12"
 7996	padded slick phantom mask	0		Moxie: +10, Damage Absorption: +20, Single Equip, Last Available: "2015-12"
 7997	mixed green polyesterene powder	1		Effect: "Whole Latte Love", Effect Duration: 50, Last Available: "2015-12"
-7998	boiled maroon blurry narrow powder	1		Last Available: "2015-12"
+7998	boiled blurry narrow maroon powder	1		Last Available: "2015-12"
 7999	magnetized extra-frozen narrow choco-Crimbot	0		Effect: "Stenchtastic", Effect Duration: 43, Last Available: "2014-12"
 8000	dry chilled extra-moist smart watch	0		Effect: "Swimming Head", Effect Duration: 42, Last Available: "2014-12"
 8001	extra-pickled super-electrified mirror augmented-reality shades	0		Effect: "Joy", Effect Duration: 21, Last Available: "2014-12"
-8002	Sherlock's toy Crimbot mega face	0		Item Drop: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12"
-8003	mirror toy Crimbot power glove of the bloodbag	0		Maximum HP: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	weightlifter's toy Crimbot super fist	0		Muscle: +15, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of the sweet-tooth	0		Candy Drop: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	Sherlock's toy Crimbot mega face	0		Item Drop: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8003	mirror toy Crimbot power glove of the bloodbag	0		Maximum HP: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	weightlifter's toy Crimbot super fist	0		Muscle: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of the sweet-tooth	0		Candy Drop: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	liquefied spinning Crimbot battery	0		Effect: "Starry-Eyed", Effect Duration: 58, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	mirror huge heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	cyan Temple Grandin's Crimbomega drive chain of the scaredy-cat of the brazier	0		Monster Level: -15, Familiar Weight: +7, Hot Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	cyan Temple Grandin's Crimbomega drive chain of the scaredy-cat of the brazier	0		Monster Level: -15, Familiar Weight: +7, Hot Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	skewed Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	activated fitness wristband	0		Effect: "Ancestral Disapproval", Effect Duration: 42, Last Available: "2014-12"
 8017	quadruple-anodized twirling flask of tainted mining oil	0		Effect: "Spiky Hair", Effect Duration: 25, Last Available: "2014-12"
 8018	quantum polarized and rain stick	0		Effect: "Hobo Flavor", Effect Duration: 58
-8019	blue blurry Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
+8019	blurry blue Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	moldy Choco-Mint patty	4	crappy	Last Available: "2015-01"
 8021	watered-down perfectly mixed hot mint schnocolate	2	EPIC	Last Available: "2015-01"
 8022	altered twirling homeopathic mint tea	1	good	Effect: "Yuletide Sappiness", Effect Duration: 30, Last Available: "2015-01"
@@ -7939,10 +7939,10 @@
 8058	plasma rifle	0		Item Drop: +5
 8059	skewed Bananubis's Staff	0		Luck: -6
 8060	dog trainer's The Joke Book of the Dead of the sewer	0		Experience (familiar): +1, Stench Damage: +25, Luck: -6
-8061	blue shaking The Clown Crown	0		Luck: -6
+8061	shaking blue The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
 8063	Tales of Spelunking	0		Last Available: "2015-12"
-8064	jittery yellow monkey statuette	0		Free Pull, Last Available: "2015-12"
+8064	yellow jittery monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	squat banana	0		Familiar Weight: +5
 8066	powdered	1	good	Last Available: "2015-12"
 8067	nuggets	0		
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	fuchsia Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	ghostly strapping Spelunker's fedora of the bloodbag of the scaredy-cat	0		Muscle: +5, Maximum HP: +100, Monster Level: -15, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	ghostly strapping Spelunker's fedora of the bloodbag of the scaredy-cat	0		Muscle: +5, Maximum HP: +100, Monster Level: -15, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	frosty hale Spelunker's whip of Leguizamo	0		Maximum HP: +20, Monster Level: +20, Cold Spell Damage: +10, Last Available: "2015-12"
-8076	cyan wobbly curative quilted Spelunker's khakis of the ox	0		Muscle: +20, Damage Absorption: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	cyan wobbly curative quilted Spelunker's khakis of the ox	0		Muscle: +20, Damage Absorption: +40, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	teal Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	mirror LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7996,7 +7996,7 @@
 8121	blurry Sinatra's garland of the brute	0		Muscle Percent: +30, Experience (Moxie): +5, Single Equip, Last Available: "2018-12"
 8122	bouncing flame-wreathed hardy gunnysack	0		Maximum HP: +50, Hot Spell Damage: +10, Last Available: "2018-12"
 8123	fuchsia nasty hardened garibaldi	0		Damage Reduction: 3, Stench Damage: +5, Last Available: "2018-12"
-8124	brainy girdle of the pedagogue	0		Mysticality: +5, Experience: +3, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	brainy girdle of the pedagogue	0		Mysticality: +5, Experience: +3, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	upside-down bouncing therapeutic thinker's gloves	0		Mysticality: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-12"
 8126	distilled smithereens	1		Last Available: "2018-12"
 8127	frightening fiberglass fetish of the businessman	0		Spooky Damage: +5, Meat Drop: +50, Last Available: "2018-12"
@@ -8042,7 +8042,7 @@
 8168	glob of icing	0		
 8169	super-denatured boiled ginger snaps	0		Effect: "Industrial Strength Starch", Effect Duration: 66
 8170	aerosolized extra-energized narrow mostly-broken sunglasses	0		Effect: "Ooh, Umami!", Effect Duration: 22
-8171	irresponsibly strong bad unflavored wine cooler	7	decent	
+8171	bad irresponsibly strong unflavored wine cooler	7	decent	
 8172	maroon carton of snake milk	1	crappy	
 8173	blinking sewer snake of dire peril	0		Weapon Damage: +20
 8174	decent pulsating pigeon egg	3	good	
@@ -8056,18 +8056,18 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	pulsating blurry bread basket of mayonnaise	0		Sleaze Spell Damage: +50
 8184	Ed the Undying exhibit crate	0		
-8185	purple lard-coated The Crown of Ed the Undying of James Dean	0		Experience (Moxie): +3, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	purple lard-coated The Crown of Ed the Undying of James Dean	0		Experience (Moxie): +3, Sleaze Spell Damage: +25, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	huge Doc Galaktik's Invigorating Tonic	0		
 8187	upside-down map to a hidden booze cache	0		
 8188	bad Cherrytastrophe wine cooler	3	decent	
 8189	lousy weak Radberry Rip wine cooler	2	decent	
 8190	bad Orangemageddon wine cooler	3	decent	
-8191	artisanal watered-down narrow Breakfast Blast wine cooler	2	EPIC	
-8192	aged enchanted Citrus Crush wine cooler	4	awesome	Effect: "Mucilaginous Moxiousness", Effect Duration: 50
+8191	watered-down artisanal narrow Breakfast Blast wine cooler	2	EPIC	
+8192	enchanted aged Citrus Crush wine cooler	4	awesome	Effect: "Mucilaginous Moxiousness", Effect Duration: 50
 8193	adequate pulsating plain bagel	4	good	
 8194	snack-sized moldy glob of cream cheese	2	crappy	
-8195	miniature stale loaf of soda bread	2	decent	
-8196	enchanted decent acceptable bagel	4	good	Effect: "Superhuman Sarcasm", Effect Duration: 10
+8195	stale miniature loaf of soda bread	2	decent	
+8196	decent enchanted acceptable bagel	4	good	Effect: "Superhuman Sarcasm", Effect Duration: 10
 8197	moldy standard-issue cupcake	3	crappy	
 8198	decent ultra-deluxe cupcake	4	good	
 8199	wobbly hypnotic breadcrumbs	0		
@@ -8085,14 +8085,14 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	huge steel-toed rigging rope of doom	0		Damage Reduction: 9, Spooky Spell Damage: +50, Last Available: "2015-04"
-8214	denatured cyan pulsating nasty snuff	1	awesome	Last Available: "2015-04"
-8215	ghostly forbidden Da Vinci's sewage-clogged pistol	0		Experience (Mysticality): +5, Spell Damage Percent: +50, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8214	denatured pulsating cyan nasty snuff	1	awesome	Last Available: "2015-04"
+8215	ghostly forbidden Da Vinci's sewage-clogged pistol	0		Experience (Mysticality): +5, Spell Damage Percent: +50, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	modified moist cyan beard incense	0		Effect: "A Taste of Rainbow", Effect Duration: 22, Last Available: "2015-04"
 8217	blurry fuchsia censurious manspreader's perfume-soaked bandana	0		Monster Level: +10, Sleaze Resistance: +3, Single Equip, Last Available: "2015-04"
 8218	pulsating toxic globule	0		Last Available: "2015-04"
-8219	bland snack-sized ghostly toxo	2	decent	Last Available: "2015-04"
+8219	snack-sized bland ghostly toxo	2	decent	Last Available: "2015-04"
 8220	bad Lemonade-235	3	decent	Last Available: "2015-04"
-8221	jittery foul-smelling ruddy isotophat	0		Maximum HP Percent: +40, Stench Damage: +10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8221	jittery foul-smelling ruddy isotophat	0		Maximum HP Percent: +40, Stench Damage: +10, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	ghostly huge Van der Graaf Sinatra's Three Mile Island shorts	0		Experience (Moxie): +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-04"
 8223	scorching thinker's toxic mop	0		Mysticality: +10, Hot Damage: +25, Last Available: "2015-04"
 8224	squat olive inert sludgepuppy	0		Last Available: "2015-04"
@@ -8128,13 +8128,13 @@
 8254	wobbly shaking Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	wobbly Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	bouncing Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	dry lime green blurry nasty gum	0		Effect: "Pemmican't", Effect Duration: 53
+8257	dry blurry lime green nasty gum	0		Effect: "Pemmican't", Effect Duration: 53
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	Sherlock's The Lot's engagement ring	0		Item Drop: +25, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	gray Mayo Clinic	0		Last Available: "2015-05"
 8261	Mayonex	0		Last Available: "2015-05"
 8262	maroon Mayodiol	0		Last Available: "2015-05"
-8263	shaking skewed Mayostat	0		Last Available: "2015-05"
+8263	skewed shaking Mayostat	0		Last Available: "2015-05"
 8264	Mayozapine	0		Last Available: "2015-05"
 8265	Mayoflex	0		Last Available: "2015-05"
 8266	Tesla miracle whip of dire peril of the detective of the cheetah	0		Weapon Damage: +20, Item Drop: +20, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-05"
@@ -8149,8 +8149,8 @@
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	practically non-alcoholic hand-crafted Afternoon Delight	1	super ultra mega turbo EPIC	Last Available: "2015-04"
-8279	narrow blurry narrow Kokomo Resort Chip	0		Last Available: "2015-04"
+8278	hand-crafted practically non-alcoholic Afternoon Delight	1	super ultra mega turbo EPIC	Last Available: "2015-04"
+8279	narrow narrow blurry Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	pressed Kokomo Resort Brand Suntan Oil	0		Effect: "Earthen Fist", Effect Duration: 45, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
@@ -8174,12 +8174,12 @@
 8300	dry moist power pill	0		Effect: "Stenchtastic", Effect Duration: 55, Last Available: "2015-06"
 8301	electrified Vulcanized yellow ghostly pixel star	0		Effect: "World's Shortest Giant", Effect Duration: 53, Last Available: "2015-06"
 8302	adequate blurry pixel banana	3	good	Last Available: "2015-06"
-8303	perfectly mixed practically non-alcoholic special skewed pixel beer	1	super ultra mega EPIC	Effect: "Scorpio Rising", Effect Duration: 20, Last Available: "2015-06"
+8303	perfectly mixed special practically non-alcoholic skewed pixel beer	1	super ultra mega EPIC	Effect: "Scorpio Rising", Effect Duration: 20, Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	fuchsia pumps	0		Last Available: "2015-06"
 8306	pickled polarized sludgesicle	0		Effect: "Optimist Primal", Effect Duration: 23
-8307	non-chilled ionized spinning shaking &Uuml;berraschthexengebr&auml;u	0		Effect: "A View to Some Meat", Effect Duration: 28
-8308	warmed maroon squat piggy tattoo	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 59
+8307	non-chilled ionized shaking spinning &Uuml;berraschthexengebr&auml;u	0		Effect: "A View to Some Meat", Effect Duration: 28
+8308	warmed squat maroon piggy tattoo	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 59
 8309	extra-galvanized altered baggie of regular-sized tardigrades	0		Effect: "Granolarrrgh", Effect Duration: 49
 8310	electrified deionized .epub file	0		Effect: "Pemmican't", Effect Duration: 17
 8311	double-oxidized BUBBLE GUM	0		Effect: "On Pins and Needles", Effect Duration: 60
@@ -8193,10 +8193,10 @@
 8319	oxidized unsweetened bouncing jazzy cigarette holder	0		Effect: "Chalky Hand", Effect Duration: 35
 8320	ionized frozen pulsating one glove	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 23
 8321	flattened frozen jittery glove	0		Effect: "Knightlife", Effect Duration: 45
-8322	aerosolized triple-nitrogenated tumbling skewed handful of fire	0		Effect: "The Real Deal", Effect Duration: 69
-8323	dry extra-polarized shaking blinking Cracklin' Oat Bran	0		Effect: "Psalm of Pointiness", Effect Duration: 46
+8322	aerosolized triple-nitrogenated skewed tumbling handful of fire	0		Effect: "The Real Deal", Effect Duration: 69
+8323	dry extra-polarized blinking shaking Cracklin' Oat Bran	0		Effect: "Psalm of Pointiness", Effect Duration: 46
 8324	activated disposable lighter	0		Effect: "Itchy Trigger Finger", Effect Duration: 22
-8325	vacuum-sealed tumbling teal coal contact lenses	0		Effect: "You Know Where to Go", Effect Duration: 43
+8325	vacuum-sealed teal tumbling coal contact lenses	0		Effect: "You Know Where to Go", Effect Duration: 43
 8326	modified bouncing conjured ice cream	0		Effect: "The Moxious Madrigal", Effect Duration: 23
 8327	double-diffused dry Iceberglar scarf	0		Effect: "On a Roll", Effect Duration: 52
 8328	liquefied tumbling olive icy hairspray	0		Effect: "Mystic Circle", Effect Duration: 58
@@ -8206,7 +8206,7 @@
 8332	chilled double-anodized plague pie	0		Effect: "Flaming Weapon", Effect Duration: 56
 8333	altered wet wobbly batarang	0		Effect: "Morninja", Effect Duration: 44
 8334	quantum quantum narrow spare neck bolts	0		Effect: "Buff as a Baobab", Effect Duration: 52
-8335	polarized pulsating tumbling grease trap	0		Effect: "Wolf's Bane", Effect Duration: 24
+8335	polarized tumbling pulsating grease trap	0		Effect: "Wolf's Bane", Effect Duration: 24
 8336	extra-nitrogenated non-concentrated shamanic ham	0		Effect: "Frigid Weapon", Effect Duration: 57
 8337	concentrated porkpocket	0		Effect: "Oleaginous Soles", Effect Duration: 51
 8338	double-nitrogenated spinning Leonard's glasses	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 50
@@ -8216,16 +8216,16 @@
 8342	pressed baloney rotgut	0		Effect: "Kindly Resolve", Effect Duration: 47
 8343	energized nitrogenated purple carton of gaspers	0		Effect: "Inscrutable exoskeleton", Effect Duration: 19
 8344	dry enhanced Vulcanized mirror huge bronze polish	0		Effect: "Blackberry Politeness", Effect Duration: 17
-8345	quadruple-altered mirror wobbly crident	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
+8345	quadruple-altered wobbly mirror crident	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 37
 8346	energized totally sweet mohawk helmet	0		Effect: "Ponderous Potency", Effect Duration: 38
 8347	tarnished dry spray chrome	0		Effect: "Net Tea", Effect Duration: 22
 8348	liquefied filthy monkey head	0		Effect: "Dilated Pupils", Effect Duration: 63
-8349	triple-galvanized boiled frozen teal mirror hand of cards	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 34
+8349	triple-galvanized boiled frozen mirror teal hand of cards	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 34
 8350	galvanized squat damp bar rag	0		Effect: "Saucefingers", Effect Duration: 43
 8351	corrupted tarnished wobbly lump of goofball ore	0		Effect: "Broken Bone Nubs", Effect Duration: 22
 8352	concentrated skeleton beans	0		Effect: "Nature's Bounty", Effect Duration: 55
 8353	double-electrified polymerized grimy lab coat	0		Effect: "Block-Rockin' Beet", Effect Duration: 38
-8354	liquefied super-liquefied olive jittery huge nursery rhyme	0		Effect: "Spooky Flavor", Effect Duration: 43
+8354	liquefied super-liquefied olive huge jittery nursery rhyme	0		Effect: "Spooky Flavor", Effect Duration: 43
 8355	non-quantum deionized iron torso box	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 36
 8356	vacuum-sealed twirling mercenary headband	0		Effect: "From Nantucket", Effect Duration: 32
 8357	moist twirling radioactive spider venom	0		Effect: "The Magic of Sharing", Effect Duration: 48
@@ -8245,10 +8245,10 @@
 8371	adjusted diffused teal bucket of fish juice	0		Effect: "Blackberry Politeness", Effect Duration: 55
 8372	cold-filtered lime green flashy pirate dreadlocks	0		Effect: "Top Dog", Effect Duration: 18
 8373	vacuum-sealed captured boozles	0		Effect: "Fruited", Effect Duration: 39
-8374	corrupted nitrogenated pulsating narrow yellow drinks tray	0		Effect: "Sticky Hands", Effect Duration: 50
+8374	corrupted nitrogenated yellow pulsating narrow drinks tray	0		Effect: "Sticky Hands", Effect Duration: 50
 8375	polymerized pickled mirror eyebrow lifter	0		Effect: "Rampage!", Effect Duration: 30
 8376	submarine	0		Last Available: "2015-06"
-8377	fancy normal diet huge pixel lemon	1	good	Effect: "Donho's Bubbly Ballad", Effect Duration: 40, Last Available: "2015-06"
+8377	normal diet fancy huge pixel lemon	1	good	Effect: "Donho's Bubbly Ballad", Effect Duration: 40, Last Available: "2015-06"
 8378	acceptable pixel daiquiri	4	good	Last Available: "2015-06"
 8379	warmed power pill	0		Effect: "Updated", Effect Duration: 49, Last Available: "2015-06"
 8380	irradiated jittery pixel potion	0		Effect: "Strength of Ten Ettins", Effect Duration: 34, Last Available: "2015-06"
@@ -8259,7 +8259,7 @@
 8385	blinking cubic zirconia	0		Last Available: "2015-07"
 8386	maroon valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
-8388	narrow teal mana	0		Last Available: "2015-07"
+8388	teal narrow mana	0		Last Available: "2015-07"
 8389	mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
@@ -8283,14 +8283,14 @@
 8409	normal thick crudles	5	good	
 8410	spoiled bouncing squat agnolotti arboli	3	crappy	
 8411	bland jittery spaghetti with ghost balls	4	decent	
-8412	enchanted moldy miniature succulent marrow	2	crappy	Effect: "Pronounced Potency", Effect Duration: 25
-8413	bland low-calorie cyan jittery salacious crumbs	1	decent	
+8412	moldy enchanted miniature succulent marrow	2	crappy	Effect: "Pronounced Potency", Effect Duration: 25
+8413	bland low-calorie jittery cyan salacious crumbs	1	decent	
 8414	super-sized moldy fusilli marrownarrow	5	crappy	
-8415	bland huge fuchsia suggestive strozzapreti	7	decent	
+8415	huge bland fuchsia suggestive strozzapreti	7	decent	
 8416	Mountain Stream gastrique	0		
-8417	miniature yummy Mt. McLargeHuge oyster	2	awesome	
+8417	yummy miniature Mt. McLargeHuge oyster	2	awesome	
 8418	oyster sauce	0		
-8419	bland tiny linguini immondizia bianco	1	decent	
+8419	tiny bland linguini immondizia bianco	1	decent	
 8420	adequate pulsating shells a la shellfish	3	good	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8311,7 +8311,7 @@
 8437	frosty therapeutic LavaCo Lamp&trade;	0		Cold Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-08"
 8438	spinning thin wire	0		Last Available: "2015-08"
 8439	green insulated wire	0		Last Available: "2015-08"
-8440	squat blue empty lava bottle	0		Last Available: "2015-08"
+8440	blue squat empty lava bottle	0		Last Available: "2015-08"
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	twirling viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
@@ -8325,11 +8325,11 @@
 8451	capped lava bottle	0		Last Available: "2015-08"
 8452	capped lava bottle	0		Last Available: "2015-08"
 8453	heat-resistant sheet	0		Last Available: "2015-08"
-8454	tumbling spinning LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
+8454	spinning tumbling LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	ghostly crystalline light bulb	0		Last Available: "2015-08"
 8457	shaking broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	ghostly greedy fireproof high-temperature mining mask	0		Hot Resistance: +3, Meat Drop: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	ghostly greedy fireproof high-temperature mining mask	0		Hot Resistance: +3, Meat Drop: +20, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	double-paned smelly fireproof megaphone	0		Stench Spell Damage: +10, Cold Resistance: +5, Last Available: "2015-08"
 8460	normal small mineapple	2	good	Last Available: "2015-08"
 8461	distilled acceptable squat Gold Velvet&trade; whiskey	5	good	Last Available: "2015-08"
@@ -8341,18 +8341,18 @@
 8467	scorching rock-hard lava balaclava of courage	0		Damage Reduction: 5, Hot Damage: +25, Spooky Resistance: +3, Last Available: "2015-08"
 8468	occult savvy basaltamander buckler of the cheetah	0		Mysticality Percent: +20, Spell Damage Percent: +25, Initiative: +60, Damage Reduction: 15, Last Available: "2015-08"
 8469	double-tarnished irradiated cold-filtered lava globs	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 54, Last Available: "2015-08"
-8470	small decent special gooey lava globs	2	good	Effect: "Items Are Forever", Effect Duration: 40, Last Available: "2015-08"
+8470	special decent small gooey lava globs	2	good	Effect: "Items Are Forever", Effect Duration: 40, Last Available: "2015-08"
 8471	occult lava-proof pants of Flo-Jo	0		Spell Damage Percent: +25, Initiative: +100, Last Available: "2015-08"
 8472	bouncing teal Usain Bolt's reassuring heat-resistant necktie	0		Spooky Resistance: +1, Initiative: +80, Single Equip, Last Available: "2015-08"
 8473	Van der Graaf heat-resistant gloves of Tarzan of chilblains	0		Experience (Muscle): +3, Cold Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2015-08"
-8474	rotten half-sized very hot lunch	2	crappy	Last Available: "2015-08"
-8475	weak tolerable blue asbestos thermos	2	good	Last Available: "2015-08"
+8474	half-sized rotten very hot lunch	2	crappy	Last Available: "2015-08"
+8475	tolerable weak blue asbestos thermos	2	good	Last Available: "2015-08"
 8476	enhanced bouncing liquid rhinestones	0		Effect: "[1609]Dancin' Fool", Effect Duration: 54, Last Available: "2015-08"
-8477	normal jumbo disco biscuit	5	good	Last Available: "2015-08"
+8477	jumbo normal disco biscuit	5	good	Last Available: "2015-08"
 8478	bad Quaatorade&trade;	4	decent	Last Available: "2015-08"
-8479	friendly Newton's Socratic biker's hat	0		Experience (Mysticality): 4, Familiar Weight: +3, Last Available: "2015-08", Familiar Effect: "atk"
-8480	maroon executive asbestos-lined gravedigger's feathered headdress	0		Spooky Damage: +10, Hot Resistance: +5, Meat Drop: +40, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	jittery shaking yellow scorching electrician's hardhat of Gandalf of Flo-Jo	0		Spell Critical Percent: +20, Hot Damage: +25, Initiative: +100, Last Available: "2015-08", Familiar Effect: "atk"
+8479	friendly Newton's Socratic biker's hat	0		Experience (Mysticality): 4, Familiar Weight: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8480	maroon executive asbestos-lined gravedigger's feathered headdress	0		Spooky Damage: +10, Hot Resistance: +5, Meat Drop: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	jittery shaking yellow scorching electrician's hardhat of Gandalf of Flo-Jo	0		Spell Critical Percent: +20, Hot Damage: +25, Initiative: +100, Familiar Effect: "atk", Last Available: "2015-08"
 8482	skewed Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	shaking The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	squat Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	steel-toed smooth velvet pants	0		Damage Reduction: 9, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	steel-toed smooth velvet pants	0		Damage Reduction: 9, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	Tesla smooth velvet shirt	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-08"
 8492	slick smooth velvet hat	0		Moxie: +10, Last Available: "2015-08"
 8493	tumbling brainy smooth velvet pocket square	0		Mysticality: +5, Single Equip, Last Available: "2015-08"
@@ -8371,7 +8371,7 @@
 8497	Mr. Choch's bone	0		Last Available: "2015-08"
 8498	huge Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	Saturday Night thermometer	0		Last Available: "2015-08"
-8500	pulsating blurry the tongue of Smimmons	0		Last Available: "2015-08"
+8500	blurry pulsating the tongue of Smimmons	0		Last Available: "2015-08"
 8501	Raul's guitar pick	0		Last Available: "2015-08"
 8502	jittery Pener's crisps	0		Last Available: "2015-08"
 8503	signed deuce	0		Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	twirling lard-coated SMOOCH bracers of the blizzard	0		Cold Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8518	nippy SMOOCH kneepads	0		Cold Damage: +10, Single Equip, Last Available: "2015-08"
 8519	wholesome SMOOCH spaulders	0		Maximum HP Percent: +10, Single Equip, Last Available: "2015-08"
-8520	blurry Van der Graaf slick SMOOCH codpiece	0		Moxie: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	blurry Van der Graaf slick SMOOCH codpiece	0		Moxie: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	bouncing prompt SMOOCH breastplate	0		Adventures: +3, Last Available: "2015-08"
 8522	skewed superduperheated	0		Last Available: "2015-08"
 8523	bouncing fused fuse	0		Last Available: "2015-08"
@@ -8400,31 +8400,31 @@
 8526	decent pink slime	3	good	
 8527	shaking Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	normal tiny skewed devil hair pasta	1	good	
+8529	tiny normal skewed devil hair pasta	1	good	
 8530	thick rotten spagecialetti	5	crappy	
 8531	Salsa Libre	0		
 8532	huge good gravy	0		
 8533	illicit fish sauce	0		
 8534	adequate mirror libertagliatelle	3	good	
-8535	stale tiny turkish mostaccioli	1	decent	
-8536	huge moldy huge linguini of the sea	8	crappy	
+8535	tiny stale turkish mostaccioli	1	decent	
+8536	moldy huge huge linguini of the sea	8	crappy	
 8537	denatured blinking Hersey&trade; SMOOCH	0		Effect: "Heart of Lavender", Effect Duration: 29
 8539	Alexy sauce	0		
 8540	yellow blinking rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	normal Fettris	3	good	
-8543	gigantic fancy flavorless maroon fusillocybin	7	decent	Effect: "Sparkling Consciousness", Effect Duration: 45
+8543	fancy gigantic flavorless maroon fusillocybin	7	decent	Effect: "Sparkling Consciousness", Effect Duration: 45
 8544	spoiled big blurry prescription noodles	5	crappy	
 8545	powdered blood-drive sticker	1	decent	
 8546	pickled adjusted bag of grain	0		Effect: "Bone Chilling", Effect Duration: 52
 8547	improved skewed pocket maze	0		Effect: "Adapt to Change Eventually", Effect Duration: 31
 8548	ionized blurry shady shades	0		Effect: "Seriously Mutated", Effect Duration: 23
 8549	moist quadruple-aerosolized squeaky toy rose	0		Effect: "Beta Carotene Overdose", Effect Duration: 35
-8550	super-sized decent weird gazelle steak	5	good	
+8550	decent super-sized weird gazelle steak	5	good	
 8551	massive bland sausage without a cause	8	decent	
-8552	deionized bouncing jittery red face paint	0		Effect: "Saucegoggles", Effect Duration: 41
+8552	deionized jittery bouncing red face paint	0		Effect: "Saucegoggles", Effect Duration: 41
 8553	mediocre purple emergency margarita	3	decent	
-8554	practically non-alcoholic drinkable blue vintage smart drink	1	good	
+8554	drinkable practically non-alcoholic blue vintage smart drink	1	good	
 8555	blinking a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	shaking The Emperor's new cookie	0		
@@ -8437,7 +8437,7 @@
 8564	fuchsia shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	jittery Tesla vibrating extremely unsafe barrel lid	0		Weapon Damage Percent: +100, Maximum MP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	shaking hale Newton's barrel hoop earring of the detective	0		Experience (Mysticality): +3, Maximum HP: +20, Item Drop: +20, Lasts Until Rollover, Last Available: "2015-09"
-8567	family-friendly coward's bankruptcy barrel of the scaredy-cat	0		Monster Level: -35, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	family-friendly coward's bankruptcy barrel of the scaredy-cat	0		Monster Level: -35, Sleaze Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	lime green firkin	0		Last Available: "2015-09"
 8569	teal spinning normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8448,7 +8448,7 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	skewed wobbly mouldering barrel	0		Last Available: "2015-09"
 8577	twirling barnacled barrel	0		Last Available: "2015-09"
-8578	lousy watered-down bottle of Amontillado	2	decent	Last Available: "2015-09"
+8578	watered-down lousy bottle of Amontillado	2	decent	Last Available: "2015-09"
 8579	artisanal gray barrel-aged martini	3	EPIC	Last Available: "2015-09"
 8580	special tasty barrel pickle	3	awesome	Effect: "Dances with Tweedles", Effect Duration: 40, Last Available: "2015-09"
 8581	big bland spinning barrel cracker	5	decent	Last Available: "2015-09"
@@ -8470,7 +8470,7 @@
 8597	frosty baleful barrel beryl nose ring	0		Spell Damage: +25, Cold Spell Damage: +10, Last Available: "2015-09"
 8598	narrow rosy-cheeked barrel beryl ring of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +30, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
-8600	ghostly spinning potted tea tree	0		Last Available: "2015-09"
+8600	spinning ghostly potted tea tree	0		Last Available: "2015-09"
 8601	corrupted pulsating cuppa Flamibili tea	0		Effect: "Puzzle Fury", Effect Duration: 46, Last Available: "2015-09"
 8602	electrified galvanized green cuppa Yet tea	0		Effect: "Super Speed", Effect Duration: 26, Last Available: "2015-09"
 8603	cold-filtered wobbly cuppa Boo tea	0		Effect: "Burning Hands", Effect Duration: 24, Last Available: "2015-09"
@@ -8482,7 +8482,7 @@
 8609	pickled cuppa Proprie tea	0		Effect: "Toothy Grin", Effect Duration: 17, Last Available: "2015-09"
 8610	super-concentrated super-pressed upside-down cuppa Morbidi tea	0		Effect: "Here to Kick Ass", Effect Duration: 13, Last Available: "2015-09"
 8611	extra-irradiated irradiated cuppa Chari tea	0		Effect: "Bilious Briskness", Effect Duration: 33, Last Available: "2015-09"
-8612	polarized tarnished skewed cyan cuppa Serendipi tea	0		Effect: "Notably Lovely", Effect Duration: 33, Last Available: "2015-09"
+8612	polarized tarnished cyan skewed cuppa Serendipi tea	0		Effect: "Notably Lovely", Effect Duration: 33, Last Available: "2015-09"
 8613	polarized liquefied alkaline cuppa Feroci tea	0		Effect: "Salty Mouth", Effect Duration: 43, Last Available: "2015-09"
 8614	vacuum-sealed chilled aerosolized cuppa Physicali tea	0		Effect: "Feline Ferocity", Effect Duration: 38, Last Available: "2015-09"
 8615	non-colloidal jittery cuppa Wit tea	0		Effect: "[1701]Hip to the Jive", Effect Duration: 14, Last Available: "2015-09"
@@ -8501,9 +8501,9 @@
 8628	double-electrified cuppa Mana tea	0		Effect: "Browbeaten", Effect Duration: 18, Last Available: "2015-09"
 8629	extra-enhanced vacuum-sealed cuppa Monstrosi tea	0		Effect: "Third Based", Effect Duration: 65, Last Available: "2015-09"
 8630	wet jittery cuppa Twen tea	0		Effect: "Cautious Prowl", Effect Duration: 27, Last Available: "2015-09"
-8631	extra-energized modified polymerized bouncing purple cuppa Gill tea	0		Effect: "Seeing Colors", Effect Duration: 61, Last Available: "2015-09"
+8631	extra-energized modified polymerized purple bouncing cuppa Gill tea	0		Effect: "Seeing Colors", Effect Duration: 61, Last Available: "2015-09"
 8632	concentrated cuppa Uncertain tea	0		Effect: "Going Ape", Effect Duration: 50, Last Available: "2015-09"
-8633	blinking blurry cuppa Voraci tea	0		Last Available: "2015-09"
+8633	blurry blinking cuppa Voraci tea	0		Last Available: "2015-09"
 8634	wobbly cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
 8636	unsweetened pressed frozen ghostly cuppa Craft tea	0		Effect: "Phairly Pheromonal", Effect Duration: 37, Last Available: "2015-09"
@@ -8513,11 +8513,11 @@
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	decent bowl of eyeballs	4	good	Last Available: "2015-10"
 8642	yummy half-sized bowl of mummy guts	2	awesome	Last Available: "2015-10"
-8643	moldy super-sized bowl of maggots	5	crappy	Last Available: "2015-10"
+8643	super-sized moldy bowl of maggots	5	crappy	Last Available: "2015-10"
 8644	hand-crafted blood and blood	4	EPIC	Last Available: "2015-10"
 8645	special bad practically non-alcoholic Jack-O-Lantern beer	1	decent	Effect: "Certainty", Effect Duration: 25, Last Available: "2015-10"
 8646	perfectly mixed zombie	4	EPIC	Last Available: "2015-10"
-8647	wobbly gray Telltale&trade; rubber heart	0		Last Available: "2015-10"
+8647	gray wobbly Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	narrow plastic nightmare troll	0		Last Available: "2015-10"
 8650	spinning tennis ball	0		Last Available: "2015-10"
@@ -8547,8 +8547,8 @@
 8674	huge airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	bouncing one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	ionized polarized skewed shoulder-warming lotion	0		Effect: "Ghostly Shell", Effect Duration: 58, Last Available: "2015-11"
-8677	spoiled special snack-sized narrow iceberg lettuce	2	crappy	Effect: "Chalky Hand", Effect Duration: 30, Last Available: "2015-11"
-8678	bad fortified ice wine	5	decent	Last Available: "2015-11"
+8677	spoiled snack-sized special narrow iceberg lettuce	2	crappy	Effect: "Chalky Hand", Effect Duration: 30, Last Available: "2015-11"
+8678	fortified bad ice wine	5	decent	Last Available: "2015-11"
 8679	narrow Jack Frost's clever Wal-Mart snowglobe of the glutton	0		Maximum MP: +20, Cold Spell Damage: +50, Food Drop: +100, Last Available: "2015-11"
 8680	greedy Wal-Mart nametag of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Meat Drop: +20, Candy Drop: +100, Last Available: "2015-11"
 8681	electrified Wal-Mart overalls of the sewer of bravery	0		Stench Damage: +25, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
@@ -8557,43 +8557,43 @@
 8684	shaking Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	skewed Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
-8687	lime green wobbly squat The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	narrow bellhop's hat of the pedagogue	0		Experience: +3, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	tolerable spinning ice porter	3	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8687	wobbly lime green squat The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
+8688	narrow bellhop's hat of the pedagogue	0		Experience: +3, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	tolerable spinning ice porter	3	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	improved electrified blinking exotic travel brochure	0		Effect: "Sealed Brain", Effect Duration: 50, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
-8692	pressed quantum bouncing tumbling shampoo-conditioner	0		Effect: "Granolarrrgh", Effect Duration: 51, Last Available: "2015-11"
+8692	pressed quantum tumbling bouncing shampoo-conditioner	0		Effect: "Granolarrrgh", Effect Duration: 51, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	pickled blue skewed spinning medicinal herbs	1		Effect: "Unusual Perspective", Effect Duration: 40, Last Available: "2016-01"
 8697	adequate pulsating ice rice	3	good	Last Available: "2016-01"
-8698	hand-crafted weak maroon iced plum wine	2	EPIC	Last Available: "2016-01"
+8698	weak hand-crafted maroon iced plum wine	2	EPIC	Last Available: "2016-01"
 8699	shaking blurry experienced training belt of wisdom	0		Mysticality: +15, Experience: +2, Item Drop: +5, Single Equip, Last Available: "2016-01"
 8700	steel-toed training legwarmers of extreme caution of the empath	0		Damage Reduction: 9, Monster Level: -25, Familiar Weight: +5, Single Equip, Last Available: "2016-01"
-8701	rosewater-soaked wizardly beefy training helmet	0		Muscle: +10, Mysticality: +25, Stench Resistance: +3, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	rosewater-soaked wizardly beefy training helmet	0		Muscle: +10, Mysticality: +25, Stench Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	twirling training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	jittery machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	gray self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
-8708	denatured spinning shaking wobbly red abstraction: action	1		Effect: "Human-Demon Hybrid", Effect Duration: 10, Last Available: "2015-12"
+8708	denatured wobbly spinning red shaking abstraction: action	1		Effect: "Human-Demon Hybrid", Effect Duration: 10, Last Available: "2015-12"
 8709	dried mirror abstraction: thought	1		Effect: "Deadly Lampblade", Effect Duration: 50, Last Available: "2015-12"
 8710	vaporized abstraction: sensation	1		Last Available: "2015-12"
 8711	altered abstraction: purpose	1		Last Available: "2015-12"
 8712	distilled blinking abstraction: category	1		Last Available: "2015-12"
 8713	vaporized ghostly abstraction: perception	1		Effect: "Antibiotic Saucesphere", Effect Duration: 45, Last Available: "2015-12"
 8714	compressed abstraction: motion	1		Last Available: "2015-12"
-8715	altered bouncing red abstraction: joy	1		Effect: "Trash-Wrapped", Effect Duration: 10, Last Available: "2015-12"
-8716	diluted jittery teal abstraction: certainty	1		Last Available: "2015-12"
+8715	altered red bouncing abstraction: joy	1		Effect: "Trash-Wrapped", Effect Duration: 10, Last Available: "2015-12"
+8716	diluted teal jittery abstraction: certainty	1		Last Available: "2015-12"
 8717	modified mirror abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	rotten blinking VYKEA meatballs	4	crappy	Last Available: "2015-11"
-8720	delicious watered-down VYKEA mead	2	awesome	Last Available: "2015-11"
+8720	watered-down delicious VYKEA mead	2	awesome	Last Available: "2015-11"
 8721	polymerized bouncing VYKEA woadpaint	0		Effect: "Hangdog", Effect Duration: 67, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
-8723	shaking huge VYKEA blood rune	0		Last Available: "2015-11"
+8723	huge shaking VYKEA blood rune	0		Last Available: "2015-11"
 8724	shaking VYKEA lightning rune	0		Last Available: "2015-11"
 8725	lime green VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
@@ -8601,17 +8601,17 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	squat family-friendly razor-sharp personal trainer's VYKEA hex key	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +25, Sleaze Resistance: +1, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	jumbo fancy flavorless tin of submardines	5	decent	Effect: "Shoesauce", Effect Duration: 45, Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	drinkable yellow blinking bottle of norwhiskey	4	good	Last Available: "2015-11"
+8731	jumbo flavorless fancy tin of submardines	5	decent	Effect: "Shoesauce", Effect Duration: 45, Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	drinkable blinking yellow bottle of norwhiskey	4	good	Last Available: "2015-11"
 8733	vaporized twirling octolus oculus	1	good	Last Available: "2015-11"
 8734	dangerous smartaleck's sardine can key of the boozehound	0		Moxie Percent: +30, Weapon Damage: +10, Booze Drop: +100, Last Available: "2015-11"
-8735	coward's sharpshooter's supercharged norwhal helmet	0		Maximum MP Percent: +30, Critical Hit Percent: +10, Monster Level: -20, Last Available: "2015-11", Familiar Effect: "atk"
+8735	coward's sharpshooter's supercharged norwhal helmet	0		Maximum MP Percent: +30, Critical Hit Percent: +10, Monster Level: -20, Familiar Effect: "atk", Last Available: "2015-11"
 8736	Jeselnik's energetic octolus-skin cloak of chilblains	0		Maximum MP Percent: +20, Cold Damage: +25, Sleaze Damage: +25, Last Available: "2015-11"
 8737	mediocre perfect cosmopolitan	3	decent	Last Available: "2015-11"
 8738	hand-crafted perfect negroni	4	EPIC	Last Available: "2015-11"
 8739	mediocre perfect dark and stormy	4	decent	Last Available: "2015-11"
 8740	mediocre perfect mimosa	4	decent	Last Available: "2015-11"
-8741	drinkable distilled skewed mirror perfect old-fashioned	5	good	Last Available: "2015-11"
+8741	distilled drinkable skewed mirror perfect old-fashioned	5	good	Last Available: "2015-11"
 8742	hand-crafted lime green perfect paloma	4	EPIC	Last Available: "2015-11"
 8743	galvanized altered That 70s Cologne	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 68, Last Available: "2015-11"
 8744	moist Wal-Mart &quot;diamond&quot; ring	0		Effect: "Stop the Presses!", Effect Duration: 21, Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	extra-deionized hemp candy necklace	0		Effect: "Truly Gritty", Effect Duration: 21, Last Available: "2015-12"
 8751	warmed tarnished skewed communal gobstopper	0		Effect: "Wet Willied", Effect Duration: 56, Last Available: "2015-12"
 8752	thick normal Crimbo salad	5	good	Last Available: "2015-12"
-8753	spoiled small yellow bread line	2	crappy	Last Available: "2015-12"
+8753	small spoiled yellow bread line	2	crappy	Last Available: "2015-12"
 8754	lousy weak mirror bark rootbeer	2	decent	Last Available: "2015-12"
 8755	acceptable ale	4	good	Last Available: "2015-12"
 8756	Samson's plastic Tammy the Tambourine Elf	0		Experience (Muscle): +5, Last Available: "2015-12"
@@ -8631,7 +8631,7 @@
 8758	flame-wreathed plastic Gaia'ajh-dsli Ak'lwej	0		Hot Spell Damage: +10, Last Available: "2015-12"
 8759	studded plastic Crimborgatron	0		Damage Absorption: +80, Last Available: "2015-12"
 8760	red twirling personal trainer's plastic Crimbodhisattva	0		Experience Percent (Muscle): +10, Last Available: "2015-12"
-8761	squat lime green bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
+8761	lime green squat bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	upside-down stack of communist leaflets	0		Last Available: "2015-12"
 8763	squat BACON	0		Last Available: "2016-05"
 8764	narrow box of Gratitude chocolates	0		Last Available: "2016-02"
@@ -8654,7 +8654,7 @@
 8782	olive hardy reindeer hammer	0		Maximum HP: +50, Last Available: "2015-12"
 8783	shaking up-at-dawn elf ploughshare	0		Adventures: +5, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	upside-down purple faded protest sign	0		Last Available: "2015-12"
 8787	wobbly faded protest sign	0		Last Available: "2015-12"
 8788	wobbly blue nasty-smelling moss	0		Last Available: "2015-12"
@@ -8671,7 +8671,7 @@
 8799	jittery bat-o-mite	0		Last Available: "2017-01"
 8800	teal ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	red wobbly incriminating evidence	0		Last Available: "2017-01"
-8802	yellow upside-down dangerous chemicals	0		Last Available: "2017-01"
+8802	upside-down yellow dangerous chemicals	0		Last Available: "2017-01"
 8803	ghostly lime green kidnapped orphan	0		Last Available: "2017-01"
 8804	blue ghostly high-grade	0		Last Available: "2017-01"
 8805	twirling high-tensile-strength fibers	0		Last Available: "2017-01"
@@ -8685,18 +8685,18 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	olive Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	blurry bat-bearing	0		Last Available: "2017-01"
-8816	moldy tiny Kudzu salad	1	crappy	Last Available: "2016-12"
+8816	tiny moldy Kudzu salad	1	crappy	Last Available: "2016-12"
 8817	distilled upside-down Mansquito Serum	1		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 20, Last Available: "2016-12"
-8818	artisanal special Miss Graves' vermouth	3	EPIC	Effect: "Robocamo", Effect Duration: 15, Last Available: "2016-12"
-8819	rotten thick The Plumber's mushroom stew	5	crappy	Last Available: "2016-12"
+8818	special artisanal Miss Graves' vermouth	3	EPIC	Effect: "Robocamo", Effect Duration: 15, Last Available: "2016-12"
+8819	thick rotten The Plumber's mushroom stew	5	crappy	Last Available: "2016-12"
 8820	pickled The Author's ink	1		Effect: "Warm Belly", Effect Duration: 20, Last Available: "2016-02"
 8821	hand-crafted The Mad Liquor	3	super EPIC	Last Available: "2016-12"
-8822	acceptable practically non-alcoholic Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
+8822	practically non-alcoholic acceptable Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
 8823	normal Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	altered tumbling The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	auspicious Temple Grandin's Van der Graaf The Jokester's gun	0		Familiar Weight: +7, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	gray fireproof nippy The Jokester's wig of the boozehound	0		Cold Damage: +10, Hot Resistance: +3, Booze Drop: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol"
-8827	Tesla The Jokester's pants of extreme caution of horror	0		Monster Level: -25, Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	auspicious Temple Grandin's Van der Graaf The Jokester's gun	0		Familiar Weight: +7, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	gray fireproof nippy The Jokester's wig of the boozehound	0		Cold Damage: +10, Hot Resistance: +3, Booze Drop: +100, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8827	Tesla The Jokester's pants of extreme caution of horror	0		Monster Level: -25, Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	triple-polarized blinking Jokester makeup	0		Effect: "Quadrilled", Effect Duration: 30, Last Available: "2016-12"
 8829	olive shaking twirling replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8719,7 +8719,7 @@
 8847	corrupted aerosolized electrified blue blinking red-hot jawbreaker	0		Effect: "Radiant Personality", Effect Duration: 13
 8848	enhanced frozen blurry question juice	0		Effect: "From Nantucket", Effect Duration: 29
 8849	chilled aerosolized pulsating tumbling tube of villain	0		Effect: "Tremella Tremens", Effect Duration: 39
-8850	Newton's your cowboy boots	0		Experience (Mysticality): +3, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	Newton's your cowboy boots	0		Experience (Mysticality): +3, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8747,7 +8747,7 @@
 8875	wool lion tamer's veiny Shrub's Premium Baked Beans	0		Maximum HP: +10, Experience (familiar): +2, Cold Resistance: +1, Last Available: "2016-02"
 8876	flavorless plate of Heimz Fortified Kidney Beans	3	decent	Last Available: "2016-02"
 8877	huge normal huge plate of Tesla's Electroplated Beans	8	good	Last Available: "2016-02"
-8878	bland teal bouncing plate of Mixed Garbanzos and Chickpeas	4	decent	Last Available: "2016-02"
+8878	bland bouncing teal plate of Mixed Garbanzos and Chickpeas	4	decent	Last Available: "2016-02"
 8879	toothsome plate of Hellfire Spicy Beans	4	awesome	Last Available: "2016-02"
 8880	rotten narrow plate of Frigid Northern Beans	4	crappy	Last Available: "2016-02"
 8881	adequate plate of World's Blackest-Eyed Peas	4	good	Last Available: "2016-02"
@@ -8756,9 +8756,9 @@
 8884	low-calorie moldy cyan plate of Val-U Brand Every Bean Salad	1	crappy	Last Available: "2016-02"
 8885	adequate huge plate of Shrub's Premium Baked Beans	9	good	Last Available: "2016-02"
 8886	careful occult Fancy Jeff's pocket square	0		Spell Damage Percent: +25, Monster Level: -10, Last Available: "2016-02"
-8887	lard-coated Jeselnik's Daisy's unclean bloomers of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +25, Sleaze Spell Damage: +25, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	lard-coated Jeselnik's Daisy's unclean bloomers of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	tumbling educational thinker's Amoon-Ra Cowtep's nemes of the overflowing toilet	0		Mysticality: +10, Experience: +1, Stench Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	tumbling educational thinker's Amoon-Ra Cowtep's nemes of the overflowing toilet	0		Mysticality: +10, Experience: +1, Stench Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	squat ruddy padded extremely unsafe sage Former Sheriff Dan's tin star of the glutton	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Damage Absorption: +20, Maximum HP Percent: +40, Food Drop: +100, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8774,7 +8774,7 @@
 8902	non-flattened boiled ghost bit	0		Effect: "Fancy Feasted", Effect Duration: 12, Last Available: "2016-02"
 8903	pickled buzzard feather	0		Effect: "Sweet and Green", Effect Duration: 57, Last Available: "2016-02"
 8904	pressed blurry lion musk	0		Effect: "Gamer Rage", Effect Duration: 64, Last Available: "2016-02"
-8905	big bland fancy bear claw	5	decent	Effect: "Larger", Effect Duration: 30, Last Available: "2016-02"
+8905	big fancy bland bear claw	5	decent	Effect: "Larger", Effect Duration: 30, Last Available: "2016-02"
 8906	non-ionized adjusted denatured fuchsia rattler gland	0		Effect: "On the Trolley", Effect Duration: 40, Last Available: "2016-02"
 8907	Vulcanized denatured mirror half-digested coal	0		Effect: "Joyful Resolve", Effect Duration: 35, Last Available: "2016-02"
 8908	Vulcanized tightly-wound spine	0		Effect: "Favored by Lyle", Effect Duration: 37, Last Available: "2016-02"
@@ -8807,19 +8807,19 @@
 8935	squat porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mirror mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
-8938	squat gray grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
+8938	gray squat grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	bouncing shuddering cow skull	0		Last Available: "2016-02"
-8944	ghostly upside-down rhinestone cowhorn	0		Familiar Weight: +5
+8944	upside-down ghostly rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	jittery jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
-8950	lime green squat slicksilver spurs	0		Last Available: "2016-02"
+8950	squat lime green slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
 8952	fuchsia nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
@@ -8860,19 +8860,19 @@
 8988	lime green bouncing Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
-8991	gray narrow do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
+8991	narrow gray do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	denatured armored prawn	1		Last Available: "2016-03"
 8993	moldy jumping horseradish	4	crappy	Last Available: "2016-03"
 8994	artisanal Sacramento wine	3	EPIC	Last Available: "2016-03"
 8995	energized Greek fire	0		Effect: "Video Game Hot Dog", Effect Duration: 26, Last Available: "2016-03"
 8996	Usain Bolt's knitted healthy sinister beefcake's ox-head shield	0		Muscle: +25, Spell Damage: +10, Maximum HP Percent: +20, Cold Resistance: +3, Initiative: +80, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	upside-down huge asbestos-lined chilly slick dented scepter of the boozehound of Flo-Jo	0		Moxie: +10, Cold Damage: +5, Hot Resistance: +5, Booze Drop: +100, Initiative: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	manspreader's Lo Pan's MacGyver's very pointy crown of the cougar of the brazier	0		Moxie: +20, Maximum MP: +100, Spell Critical Percent: +30, Monster Level: +10, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	manspreader's Lo Pan's MacGyver's very pointy crown of the cougar of the brazier	0		Moxie: +20, Maximum MP: +100, Spell Critical Percent: +30, Monster Level: +10, Hot Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	auspicious friendly Jim Carey's fortified experienced battle broom	0		Experience: +2, Damage Absorption: +60, Monster Level: +25, Familiar Weight: +3, Item Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-9000	jittery skewed Clan Floundry	0		Free Pull, Last Available: "2016-04"
+9000	skewed jittery Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	lightning-fast hale stiffened weightlifter's carpe	0		Muscle: +15, Damage Reduction: 1, Maximum HP: +20, Initiative: +40, Lasts Until Rollover, Last Available: "2016-04"
 9002	stanky dance instructor's codpiece of Calamity Jane of the overflowing toilet	0		Experience Percent (Moxie): +10, Critical Hit Percent: +15, Stench Spell Damage: 75, Lasts Until Rollover, Last Available: "2016-04"
-9003	purple Usain Bolt's inspector's resourceful troutsers of James Dean	0		Experience (Moxie): +3, Maximum MP: +50, Item Drop: +15, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	purple Usain Bolt's inspector's resourceful troutsers of James Dean	0		Experience (Moxie): +3, Maximum MP: +50, Item Drop: +15, Initiative: +80, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	pulsating mansplainer's Tesla grievous Newton's bass clarinet	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Monster Level: +15, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-04"
 9005	fireproof frosty Jim Carey's sinister fish hatchet	0		Spell Damage: +10, Monster Level: +25, Cold Spell Damage: +10, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9006	huge executive double-paned wool baleful tunac	0		Spell Damage: +25, Cold Resistance: 6, Meat Drop: +40, Lasts Until Rollover, Last Available: "2016-04"
@@ -8883,7 +8883,7 @@
 9011	narrow blinking fishin' hat of temperance	0		Sleaze Resistance: +5, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
 9013	slick sonar fishfinder	0		Moxie: +10, Last Available: "2016-04"
-9014	tumbling pulsating luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
+9014	pulsating tumbling luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	huge disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	viral video	0		Last Available: "2016-05"
@@ -8905,7 +8905,7 @@
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	normal browser cookie	3	good	Last Available: "2016-06"
-9036	triple-distilled smooth hacked gibson	7	awesome	Last Available: "2016-06"
+9036	smooth triple-distilled hacked gibson	7	awesome	Last Available: "2016-06"
 9037	blurry Source shades of the sewer	0		Stench Damage: +25, Last Available: "2016-06"
 9038	fuchsia software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8931,7 +8931,7 @@
 9059	Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	Source terminal file: pram.ext	0		Last Available: "2016-06"
-9062	twirling yellow Source terminal file: gram.ext	0		Last Available: "2016-06"
+9062	yellow twirling Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	narrow Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	shaking Source terminal file: dram.ext	0		Last Available: "2016-06"
@@ -8951,10 +8951,10 @@
 9079	tiny spoiled hardboiled egg	1	crappy	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	gray DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	greasy nasty toasty experienced groovy protonic accelerator pack of the boozehound	0		Moxie Percent: +10, Experience: +2, Hot Damage: +5, Stench Damage: +5, Sleaze Spell Damage: +10, Booze Drop: +100, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	greasy nasty toasty experienced groovy protonic accelerator pack of the boozehound	0		Moxie Percent: +10, Experience: +2, Hot Damage: +5, Stench Damage: +5, Sleaze Spell Damage: +10, Booze Drop: +100, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	ghostly red almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	Adventurer bobblehead of the dark arts	0		Spell Damage Percent: +100, Last Available: "2016-11"
-9085	narrow cyan psychokinetic energy blob	0		Last Available: "2016-08"
+9085	cyan narrow psychokinetic energy blob	0		Last Available: "2016-08"
 9086	squat careful bindle of the scaredy-cat	0		Monster Level: -25, Last Available: "2016-08"
 9087	nasty fleshy lump of the pedagogue	0		Experience: +3, Stench Damage: +5, Damage Reduction: 3, Last Available: "2016-08"
 9088	smoldering bagel punch of the boozehound	0		Item Drop: +5, Booze Drop: +100, Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	toasty Mr. Screege's spectacles	0		Hot Damage: +5, Single Equip, Last Available: "2016-08"
 9092	skewed up-at-dawn wholesome Spookyraven signet of the ox	0		Muscle: +20, Maximum HP Percent: +10, Adventures: +5, Single Equip, Last Available: "2016-08"
 9093	extremely unsafe tie-dyed fannypack of chilblains	0		Weapon Damage Percent: +100, Cold Damage: +25, Single Equip, Last Available: "2016-08"
-9094	Jack Frost's forbidden burnt snowpants	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	Samson's standards and practices guide	0		Experience (Muscle): +5, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	Jack Frost's forbidden burnt snowpants	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	Samson's standards and practices guide	0		Experience (Muscle): +5, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	tumbling up-at-dawn censurious energetic Carpathian longsword	0		Maximum MP Percent: +20, Sleaze Resistance: +3, Adventures: +5, Last Available: "2016-08"
 9097	sharpshooter's fortified Liam's mail of courage	0		Damage Absorption: +60, Critical Hit Percent: +10, Spooky Resistance: +3, Last Available: "2016-08"
 9098	bouncing squat hale groovy sage Unfortunato's foolscap	0		Mysticality Percent: +10, Moxie Percent: +10, Maximum HP: +20, Last Available: "2016-08"
@@ -8980,9 +8980,9 @@
 9108	skewed lead umbrella	0		
 9109	irradiated boiled twirling pulsating olive Shrieking Weasel holo-record	0		Effect: "Elemental Saucesphere", Effect Duration: 51
 9110	concentrated Power-Guy 2000 holo-record	0		Effect: "Human-Plant Hybrid", Effect Duration: 29
-9111	warmed blue narrow Lucky Strikes holo-record	0		Effect: "The Sweats", Effect Duration: 21
+9111	warmed narrow blue Lucky Strikes holo-record	0		Effect: "The Sweats", Effect Duration: 21
 9112	vacuum-sealed irradiated electrified twirling EMD holo-record	0		Effect: "Cold, Dead Hands", Effect Duration: 64
-9113	diffused quadruple-activated triple-adjusted upside-down blinking upside-down Superdrifter holo-record	0		Effect: "Fungal Fortification", Effect Duration: 59
+9113	diffused quadruple-activated triple-adjusted blinking upside-down upside-down Superdrifter holo-record	0		Effect: "Fungal Fortification", Effect Duration: 59
 9114	boiled The Pigs holo-record	0		Effect: "Fratty Flavor", Effect Duration: 47
 9115	pickled upside-down Drunk Uncles holo-record	0		Effect: "Boilermade", Effect Duration: 66
 9116	time residue	0		Last Available: "2016-09"
@@ -8995,7 +8995,7 @@
 9123	tumbling School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	hand-crafted spirit-forward spinning unidentified drink	5	EPIC	
+9126	spirit-forward hand-crafted spinning unidentified drink	5	EPIC	
 9127	gray tumbling smelly chilly KoL Con 13 T-shirt	0		Cold Damage: +5, Stench Spell Damage: +10
 9128	flame-wreathed vibrating banded discarded swimming trunks	0		Damage Absorption: +100, Maximum MP Percent: +10, Hot Spell Damage: +10
 9129	activated frozen moist diluted makeup	0		Effect: "Action", Effect Duration: 14
@@ -9003,7 +9003,7 @@
 9131	blinking extremely confusing manual	0		
 9132	huge aromatic nippy pistol	0		Cold Damage: +10, Stench Resistance: +1
 9133	cyan skewed KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	miniature bland ghostly leftover pasty	2	decent	
+9134	bland miniature ghostly leftover pasty	2	decent	
 9135	tolerable watered-down spinning very whiskey	2	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	maroon li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9020,15 +9020,15 @@
 9148	Twitching Television Tattoo	0		
 9149	cyan baby scorpion	0		Familiar Weight: +10
 9150	quadruple-cold-filtered squat invisible string	0		Lasts Until Rollover, Effect: "Twen Tea", Effect Duration: 17, Last Available: "2016-10"
-9151	moist blue shaking invisible seam ripper	0		Lasts Until Rollover, Effect: "Flimsy Shield of the Pastalord", Effect Duration: 32, Last Available: "2016-10"
+9151	moist shaking blue invisible seam ripper	0		Lasts Until Rollover, Effect: "Flimsy Shield of the Pastalord", Effect Duration: 32, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	delicious raw sweet potato	3	awesome	Last Available: "2016-11"
-9154	spoiled tiny raw beans	1	crappy	Last Available: "2016-11"
+9154	tiny spoiled raw beans	1	crappy	Last Available: "2016-11"
 9155	normal special raw stuffing	4	good	Effect: "Full-Body Tan", Effect Duration: 50, Last Available: "2016-11"
 9156	decent raw cranberry sauce	4	good	Last Available: "2016-11"
 9157	adequate raw turkey	3	good	Last Available: "2016-11"
-9158	immense decent raw mincemeat	9	good	Last Available: "2016-11"
-9159	tiny rotten raw potato	1	crappy	Last Available: "2016-11"
+9158	decent immense raw mincemeat	9	good	Last Available: "2016-11"
+9159	rotten tiny raw potato	1	crappy	Last Available: "2016-11"
 9160	moldy raw gravy	3	crappy	Last Available: "2016-11"
 9161	delicious olive raw bread	3	awesome	Last Available: "2016-11"
 9162	fireproof mini-marshmallow dispenser of horror	0		Spooky Spell Damage: +25, Hot Resistance: +3, Last Available: "2016-11"
@@ -9040,16 +9040,16 @@
 9168	sage potato masher of the detective	0		Mysticality Percent: +10, Item Drop: +20, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	yummy special sweet potatoes	3	awesome	Effect: "Superveiny 9000", Effect Duration: 35, Last Available: "2016-11"
-9172	stale tiny yellow upside-down bean casserole	1	decent	Last Available: "2016-11"
-9173	immense moldy baked stuffing	8	crappy	Last Available: "2016-11"
-9174	snack-sized decent shaking cranberry cylinder	2	good	Last Available: "2016-11"
-9175	decent huge red shaking thanksgiving turkey	10	good	Last Available: "2016-11"
+9171	special yummy sweet potatoes	3	awesome	Effect: "Superveiny 9000", Effect Duration: 35, Last Available: "2016-11"
+9172	tiny stale upside-down yellow bean casserole	1	decent	Last Available: "2016-11"
+9173	moldy immense baked stuffing	8	crappy	Last Available: "2016-11"
+9174	decent snack-sized shaking cranberry cylinder	2	good	Last Available: "2016-11"
+9175	huge decent shaking red thanksgiving turkey	10	good	Last Available: "2016-11"
 9176	yummy miniature gray mince pie	2	awesome	Last Available: "2016-11"
 9177	half-sized stale mashed potatoes	2	decent	Last Available: "2016-11"
 9178	delicious thick lime green warm gravy	5	awesome	Last Available: "2016-11"
 9179	bite-sized stale narrow bread roll	1	decent	Last Available: "2016-11"
-9180	toothsome gigantic upside-down skewed leftovers	6	awesome	Last Available: "2016-11"
+9180	toothsome gigantic skewed upside-down leftovers	6	awesome	Last Available: "2016-11"
 9181	snack-sized spoiled bouncing leftovers sandwich	2	crappy	Last Available: "2016-11"
 9182	purple Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	teal cornucopia	0		Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	denatured adjusted huge eldritch concentrate	0		Effect: "Improved Candy Vision", Effect Duration: 62, Last Available: "2016-11"
-9192	mediocre watered-down enchanted eldritch extract	2	decent	Effect: "Black Lung", Effect Duration: 45, Last Available: "2016-11"
+9192	enchanted mediocre watered-down eldritch extract	2	decent	Effect: "Black Lung", Effect Duration: 45, Last Available: "2016-11"
 9193	wicked Official Council Aide Pin of the sewer	0		Spell Damage: +5, Stench Damage: +25, Last Available: "2016-11"
-9194	spirit-forward mediocre eldritch distillate	5	decent	Last Available: "2016-11"
+9194	mediocre spirit-forward eldritch distillate	5	decent	Last Available: "2016-11"
 9195	modified jittery eldritch essence	1		Last Available: "2016-11"
 9196	wizardly Science Notebook	0		Mysticality: +25
 9197	wool lard-coated gravedigger's eldritch hat	0		Spooky Damage: +10, Sleaze Spell Damage: +25, Cold Resistance: +1, Last Available: "2016-11"
@@ -9071,7 +9071,7 @@
 9199	distilled hand-crafted eldritch elixir	5	EPIC	Last Available: "2016-11"
 9200	ghostly banded sinister Quartet of Flare Masters Jacket	0		Spell Damage: +10, Damage Absorption: +100, Last Available: "2016-11"
 9201	yellow lump of not really wriggling eldritch matter	0		
-9202	teal jittery Adventurer's Kit	0		
+9202	jittery teal Adventurer's Kit	0		
 9203	Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
 9205	sprinkles	0		Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	dry skewed industrial frosting	0		Effect: "Blood-Gorged", Effect Duration: 16, Last Available: "2016-12"
 9242	tarnished tarnished chilled fuchsia fake cocktail	0		Effect: "Partially Ghosted", Effect Duration: 53, Last Available: "2016-12"
-9243	special artisanal squat high-end ginger wine	3	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 5, Last Available: "2016-12"
+9243	artisanal special squat high-end ginger wine	3	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 5, Last Available: "2016-12"
 9244	blurry clever plastic bad vibe	0		Maximum MP: +20, Last Available: "2016-12"
 9245	sinister plastic angry vikings	0		Spell Damage: +10, Last Available: "2016-12"
 9246	blurry prompt plastic Knows About Chakras	0		Adventures: +3, Last Available: "2016-12"
@@ -9123,8 +9123,8 @@
 9251	enhanced ionized Inner Truth	0		Effect: "Berry Berry Cold", Effect Duration: 67, Last Available: "2016-12"
 9252	moldy ghostly spiritual candy cane	4	crappy	Last Available: "2016-12"
 9253	tolerable spiritual eggnog	4	good	Last Available: "2016-12"
-9254	fancy moldy spiritual fruitcake	3	crappy	Effect: "Sweet Tooth", Effect Duration: 50, Last Available: "2016-12"
-9255	small moldy spiritual gingerbread	2	crappy	Last Available: "2016-12"
+9254	moldy fancy spiritual fruitcake	3	crappy	Effect: "Sweet Tooth", Effect Duration: 50, Last Available: "2016-12"
+9255	moldy small spiritual gingerbread	2	crappy	Last Available: "2016-12"
 9256	maroon chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	ghostly My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9140,7 +9140,7 @@
 9268	huge sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
-9271	mirror ghostly chakra sludge	0		
+9271	ghostly mirror chakra sludge	0		
 9272	negative lump	0		
 9273	blinking friendly Third Eye of Gandalf	0		Spell Critical Percent: +20, Familiar Weight: +3, Last Available: "2016-12"
 9274	tumbling twirling rosewater-soaked Temple Grandin's Krampus Horn	0		Familiar Weight: +7, Stench Resistance: +3, Single Equip, Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	tolerable weak squat chakra-mental wine	2	good	Last Available: "2016-12"
 9277	activated galvanized tumbling chakra malt	0		Effect: "Chow Downed", Effect Duration: 54, Last Available: "2016-12"
 9278	tasty blinking Black Angus blackburger	3	awesome	Last Available: "2016-12"
-9279	tolerable weak brandy	2	good	Last Available: "2016-12"
+9279	weak tolerable brandy	2	good	Last Available: "2016-12"
 9280	altered potion of spiritual gunkifying	0		Effect: "Can Has Cyborger", Effect Duration: 59, Last Available: "2016-12"
 9281	huge ghostly crafty brawny bad vibroknife	0		Muscle Percent: +20, Maximum MP: +10, Last Available: "2016-12"
 9282	double-paned supercool crystal belt buckle	0		Moxie Percent: +20, Cold Resistance: +5, Last Available: "2016-12"
@@ -9159,17 +9159,17 @@
 9287	pet bad vibe	0		Last Available: "2016-12"
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	blinking stiffened educational supercool Uncle Crimbo's hat	0		Moxie Percent: +20, Experience: +1, Damage Reduction: 1, Last Available: "2016-12"
-9290	flavorless miniature spinning Eldritch snap	2	decent	Last Available: "2017-01"
+9290	miniature flavorless spinning Eldritch snap	2	decent	Last Available: "2017-01"
 9291	distilled maroon hot jelly	1		Last Available: "2017-01"
 9292	dehydrated jelly	1		Last Available: "2017-01"
 9293	vaporized upside-down jelly	1		Effect: "Broberry Brotality", Effect Duration: 35, Last Available: "2017-01"
-9294	denatured skewed jittery olive sleaze jelly	1		Last Available: "2017-01"
+9294	denatured jittery olive skewed sleaze jelly	1		Last Available: "2017-01"
 9295	pickled fuchsia stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	stale upside-down toast with hot jelly	3	decent	Last Available: "2017-01"
 9298	massive adequate skewed toast with jelly	10	good	Last Available: "2017-01"
 9299	moldy toast with jelly	3	crappy	Last Available: "2017-01"
-9300	massive moldy toast with sleaze jelly	10	crappy	Last Available: "2017-01"
+9300	moldy massive toast with sleaze jelly	10	crappy	Last Available: "2017-01"
 9301	bland teal toast with stench jelly	4	decent	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	maroon hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9181,7 +9181,7 @@
 9309	perfectly mixed wax booze	3	EPIC	Last Available: "2017-01"
 9310	tumbling glob of melted wax	0		Last Available: "2017-01"
 9311	twisted pulsating sea jelly	1		Last Available: "2017-01"
-9312	snack-sized decent sea truffle	2	good	Last Available: "2017-01"
+9312	decent snack-sized sea truffle	2	good	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	recovered cufflinks	0		Item Drop: +5, Single Equip, Last Available: "2017-01"
@@ -9201,9 +9201,9 @@
 9329	dry tumbling eldritch alignment spray	0		Effect: "Human-Horror Hybrid", Effect Duration: 22, Last Available: "2017-02"
 9330	ghostly LOV Entrance Pass	0		Last Available: "2017-02"
 9331	horrifying Socratic eldritch hammer of bravery	0		Experience (Mysticality): +1, Spooky Damage: +25, Spooky Resistance: +5, Last Available: "2017-01"
-9332	half-sized moldy eldritch mushroom	2	crappy	Last Available: "2017-03"
+9332	moldy half-sized eldritch mushroom	2	crappy	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	enchanted bite-sized moldy eldritch mushroom pizza	1	crappy	Effect: "Funky Coal Patina", Effect Duration: 40, Last Available: "2017-03"
+9334	moldy enchanted bite-sized eldritch mushroom pizza	1	crappy	Effect: "Funky Coal Patina", Effect Duration: 40, Last Available: "2017-03"
 9335	jittery eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	deionized blurry eldritch rub	0		Effect: "Mutated", Effect Duration: 48, Last Available: "2017-02"
@@ -9241,40 +9241,40 @@
 9369	lousy weak mentholated wine	2	decent	Last Available: "2017-03"
 9370	mediocre lime green low tide martini	3	decent	Last Available: "2017-03"
 9371	lousy shroomtini	3	decent	Last Available: "2017-03"
-9372	weak acceptable shaking morning dew	2	good	Last Available: "2017-03"
+9372	acceptable weak shaking morning dew	2	good	Last Available: "2017-03"
 9373	hand-crafted weak huge whiskey squeeze	2	EPIC	Last Available: "2017-03"
 9374	lousy great fashioned	3	decent	Last Available: "2017-03"
 9375	acceptable narrow Gnomish sagngria	3	good	Last Available: "2017-03"
-9376	lousy practically non-alcoholic vodka stinger	1	decent	Last Available: "2017-03"
+9376	practically non-alcoholic lousy vodka stinger	1	decent	Last Available: "2017-03"
 9377	lousy fancy weak extremely slippery nipple	2	decent	Effect: "Mighty Shout", Effect Duration: 50, Last Available: "2017-03"
-9378	acceptable ghostly blinking twirling piscatini	4	good	Last Available: "2017-03"
+9378	acceptable ghostly twirling blinking piscatini	4	good	Last Available: "2017-03"
 9379	tolerable upside-down Churchill	3	good	Last Available: "2017-03"
 9380	acceptable maroon soilzerac	3	good	Last Available: "2017-03"
 9381	watered-down lousy London frog	2	decent	Last Available: "2017-03"
 9382	high-proof acceptable upside-down nothingtini	7	good	Last Available: "2017-03"
 9383	hand-crafted eighth plague	4	EPIC	Last Available: "2017-03"
-9384	extra-dry artisanal single entendre	5	EPIC	Last Available: "2017-03"
+9384	artisanal extra-dry single entendre	5	EPIC	Last Available: "2017-03"
 9385	spirit-forward acceptable narrow reverse Tantalus	5	good	Last Available: "2017-03"
 9386	tolerable elemental caipiroska	3	good	Last Available: "2017-03"
 9387	artisanal Feliz Navidad	3	EPIC	Last Available: "2017-03"
 9388	drinkable Bloody Nora	3	good	Last Available: "2017-03"
 9389	perfectly mixed moreltini	3	EPIC	Last Available: "2017-03"
-9390	weak drinkable yellow hell in a bucket	2	good	Last Available: "2017-03"
+9390	drinkable weak yellow hell in a bucket	2	good	Last Available: "2017-03"
 9391	watered-down perfectly mixed Newark	2	EPIC	Last Available: "2017-03"
 9392	boozy lousy R'lyeh	5	decent	Last Available: "2017-03"
 9393	hand-crafted practically non-alcoholic blue Gnollish sangria	1	EPIC	Last Available: "2017-03"
 9394	bad high-proof vodka barracuda	9	decent	Last Available: "2017-03"
 9395	weak tolerable Mysterious Island iced tea	2	good	Last Available: "2017-03"
-9396	weak tolerable drive-by shooting	2	good	Last Available: "2017-03"
+9396	tolerable weak drive-by shooting	2	good	Last Available: "2017-03"
 9397	artisanal teal gunner's daughter	3	EPIC	Last Available: "2017-03"
-9398	weak hand-crafted dirt julep	2	EPIC	Last Available: "2017-03"
+9398	hand-crafted weak dirt julep	2	EPIC	Last Available: "2017-03"
 9399	bad Simepore slime	3	decent	Last Available: "2017-03"
-9400	special mediocre Phil Collins	4	decent	Effect: "Heart of Lavender", Effect Duration: 30, Last Available: "2017-03"
+9400	mediocre special Phil Collins	4	decent	Effect: "Heart of Lavender", Effect Duration: 30, Last Available: "2017-03"
 9401	upside-down unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	shaking toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	spinning tumbling Spacegate access badge	0		Free Pull, Last Available: "2017-04"
-9405	ghostly blinking filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
+9405	blinking ghostly filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	squat huge gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9289,10 +9289,10 @@
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	vaporized skewed twirling alien plant goo	1		Last Available: "2017-04"
+9420	vaporized twirling skewed alien plant goo	1		Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
-9422	spinning yellow zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	rotten special super-sized wobbly alien meat	5	crappy	Effect: "Charrrming", Effect Duration: 35, Last Available: "2017-04"
+9422	yellow spinning zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9423	super-sized special rotten wobbly alien meat	5	crappy	Effect: "Charrrming", Effect Duration: 35, Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	skewed spant egg casing	0		Last Available: "2017-04"
 9431	blue murderbot data core	0		Last Available: "2017-04"
 9432	polymerized ionized mirror alien medicine	0		Effect: "On the Shoulders of Giants", Effect Duration: 19, Last Available: "2017-04"
-9433	stale thick twirling alien salad	5	decent	Last Available: "2017-04"
+9433	thick stale twirling alien salad	5	decent	Last Available: "2017-04"
 9434	bad alien booze	4	decent	Last Available: "2017-04"
 9435	pulsating Sherlock's ruddy Da Vinci's alien mask	0		Experience (Mysticality): +5, Maximum HP Percent: +40, Item Drop: +25, Last Available: "2017-04"
 9436	hardy fortified alien spear of James Dean	0		Experience (Moxie): +3, Damage Absorption: +60, Maximum HP: +50, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	twirling tumbling reassuring smelly murderbot mask of James Dean	0		Experience (Moxie): +3, Stench Spell Damage: +10, Spooky Resistance: +1, Avatar: "Murderbot", Last Available: "2017-04"
 9454	ionized polarized murderbot spring injector	0		Effect: "Nasty, Nasty Breath", Effect Duration: 15, Last Available: "2017-04"
 9455	maroon executive groovy murderbot whip	0		Moxie Percent: +10, Meat Drop: +40, Last Available: "2017-04"
-9456	cool murderbot plasma rifle of the sweet-tooth	0		Moxie: +5, Candy Drop: +100, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	cool murderbot plasma rifle of the sweet-tooth	0		Moxie: +5, Candy Drop: +100, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	squat murderbot memory chip	0		Last Available: "2017-04"
 9458	red space pirate treasure map	0		Last Available: "2017-04"
 9459	maroon Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9337,7 +9337,7 @@
 9465	Spacegate	0		Last Available: "2017-04"
 9466	stale jittery Aldebaran sardines	3	decent	Last Available: "2017-04"
 9467	hand-crafted jittery Centauri fish wine	3	EPIC	Last Available: "2017-04"
-9468	compressed tumbling blue oxygen	1		Last Available: "2017-04"
+9468	compressed blue tumbling oxygen	1		Last Available: "2017-04"
 9469	twirling chilly personal trainer's Spacegate scientist's insignia	0		Experience Percent (Muscle): +10, Cold Damage: +5, Single Equip, Last Available: "2017-04"
 9470	skewed Jack Frost's beefcake's Spacegate military insignia	0		Muscle: +25, Cold Spell Damage: +50, Single Equip, Last Available: "2017-04"
 9471	Temple Grandin's vibrating personal trainer's Spacegate diplomat's insignia	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Familiar Weight: +7, Single Equip, Last Available: "2017-04"
@@ -9351,20 +9351,20 @@
 9479	irradiated vacuum-sealed extra-anodized Daily Affirmation: Always be Collecting	0		Effect: "Video Game Hot Dog", Effect Duration: 29, Last Available: "2017-05"
 9480	flattened blurry Daily Affirmation: Think Win-Lose	0		Effect: "Ancestral Disapproval", Effect Duration: 13, Last Available: "2017-05"
 9481	oxidized upside-down Daily Affirmation: Be Superficially interested	0		Effect: "Ruthlessly Efficient", Effect Duration: 31, Last Available: "2017-05"
-9482	non-polymerized upside-down blue Daily Affirmation: Adapt to Change Eventually	0		Effect: "A Contender", Effect Duration: 45, Last Available: "2017-05"
+9482	non-polymerized blue upside-down Daily Affirmation: Adapt to Change Eventually	0		Effect: "A Contender", Effect Duration: 45, Last Available: "2017-05"
 9483	magnetized adjusted pulsating bouncing Daily Affirmation: Be a Mind Master	0		Effect: "Sourpuss", Effect Duration: 20, Last Available: "2017-05"
 9484	chilled wet fuchsia Daily Affirmation: Work For Hours a Week	0		Effect: "Certainty", Effect Duration: 67, Last Available: "2017-05"
 9485	energized warmed tumbling squat Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "High Blood Chocolate Content", Effect Duration: 28, Last Available: "2017-05"
-9486	low-calorie normal shaking Affirmation Cookie	1	good	Last Available: "2017-05"
+9486	normal low-calorie shaking Affirmation Cookie	1	good	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	wobbly Victor's Spoils	0		
 9490	denatured Threatening Missive	0		Effect: "Just Aged Enough", Effect Duration: 30
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	perfumed smelly Kremlin's Greatest Briefcase of the wise owl	0		Mysticality: +20, Stench Spell Damage: +10, Stench Resistance: +5, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	perfumed smelly Kremlin's Greatest Briefcase of the wise owl	0		Mysticality: +20, Stench Spell Damage: +10, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	artisanal basic martini	4	EPIC	Last Available: "2017-06"
-9495	perfectly mixed weak narrow improved martini	2	EPIC	Last Available: "2017-06"
+9495	weak perfectly mixed narrow improved martini	2	EPIC	Last Available: "2017-06"
 9496	smooth splendid martini	4	awesome	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9380,15 +9380,15 @@
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	upside-down L.I.M.P. Stock Certificate	0		
 9510	cyan Dust bunny	0		
-9511	shaking cyan Pocket Meteor Guide	0		Last Available: "2017-08"
+9511	cyan shaking Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	shaking Meteorite-Ade	0		Last Available: "2017-08"
-9514	spoiled small tumbling meteoreo	2	crappy	Last Available: "2017-08"
-9515	weak perfectly mixed purple meadeorite	2	EPIC	Last Available: "2017-08"
+9514	small spoiled tumbling meteoreo	2	crappy	Last Available: "2017-08"
+9515	perfectly mixed weak purple meadeorite	2	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	Jack Frost's meteortarboard of wisdom of the brazier	0		Mysticality: +15, Cold Spell Damage: +50, Hot Spell Damage: +25, Last Available: "2017-08"
 9518	gray occult sinister extremely unsafe meteorite guard	0		Weapon Damage Percent: +100, Spell Damage: +10, Spell Damage Percent: +25, Damage Reduction: 9, Last Available: "2017-08"
-9519	Sherlock's meteorb of the early riser	0		Item Drop: +25, Adventures: +7, Last Available: "2017-08", Lantern Element: "Hot"
+9519	Sherlock's meteorb of the early riser	0		Item Drop: +25, Adventures: +7, Lantern Element: "Hot", Last Available: "2017-08"
 9520	veiny Newton's asteroid belt	0		Experience (Mysticality): +3, Maximum HP: +10, Single Equip, Last Available: "2017-08"
 9521	pulsating blinking prompt meteorthopedic shoes of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Adventures: +3, Single Equip, Last Available: "2017-08"
 9522	lime green flame-wreathed grievous Samson's shooting morning star	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Hot Spell Damage: +10, Single Equip, Last Available: "2017-08"
@@ -9419,7 +9419,7 @@
 9547	smooth flask of port	3	awesome	
 9548	flame-retardant Tesla contract enforcement stick	0		Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10
 9549	stale Hide-rox&trade; cookie	3	decent	Last Available: "2017-10"
-9550	lousy weak fancy jug of booze	2	decent	Effect: "Dexteri Tea", Effect Duration: 20, Last Available: "2017-10"
+9550	fancy lousy weak jug of booze	2	decent	Effect: "Dexteri Tea", Effect Duration: 20, Last Available: "2017-10"
 9551	galvanized activated Vulcanized pair of candy glasses	0		Effect: "Ten out of Ten", Effect Duration: 50, Last Available: "2017-10"
 9552	moist narrow temporary X tattoos	0		Effect: "Gamer Rage", Effect Duration: 32, Last Available: "2017-10"
 9553	diluted mirror glyph of athleticism	1		Last Available: "2017-10"
@@ -9437,7 +9437,7 @@
 9565	diffused corrupted cocoa chondrule	0		Effect: "Venomous Weapon", Effect Duration: 15, Last Available: "2020-09"
 9566	reassuring wool mafia middle finger ring	0		Cold Resistance: +1, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	purple greedy experienced sage steel drivin' hammer of the bloodbag	0		Mysticality Percent: +10, Experience: +2, Maximum HP: +100, Meat Drop: +20
-9568	ghostly skewed piece of steel	0		
+9568	skewed ghostly piece of steel	0		
 9569	wobbly scandalous foul-smelling mafia pointer finger ring	0		Stench Damage: +10, Sleaze Damage: +5, Single Equip
 9570	tumbling avaricious worksite credentials	0		Meat Drop: +30, Single Equip
 9571	huge family-friendly horrifying sizzling steel-toed negotiatin' hammer	0		Damage Reduction: 9, Hot Damage: +10, Spooky Damage: +25, Sleaze Resistance: +1
@@ -9452,8 +9452,8 @@
 9580	quadruple-tarnished pulsating and cracker	0		Effect: "Mercenary", Effect Duration: 30, Last Available: "2017-12"
 9581	bad weak neg grog	2	decent	Last Available: "2017-12"
 9582	small rotten half double fruitcake	2	crappy	Last Available: "2017-12"
-9583	miniature toothsome hushed puppy	2	awesome	Last Available: "2017-12"
-9584	miniature adequate upside-down muffled muffuletta	2	good	Last Available: "2017-12"
+9583	toothsome miniature hushed puppy	2	awesome	Last Available: "2017-12"
+9584	adequate miniature upside-down muffled muffuletta	2	good	Last Available: "2017-12"
 9585	miniature adequate shushed potatoes	2	good	Last Available: "2017-12"
 9586	pulsating huge chaotic plastic mime functionary	0		Spell Critical Percent: +10, Last Available: "2017-12"
 9587	upside-down cyan extremely unsafe plastic mime scientist	0		Weapon Damage Percent: +100, Last Available: "2017-12"
@@ -9464,9 +9464,9 @@
 9592	huge mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	decent	Last Available: "2017-11"
 9594	ionized spinning wishbone	0		Effect: "Material Witness", Effect Duration: 15, Last Available: "2017-11"
-9595	fortified lousy special spinning Racisto Ruidoso	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2017-11"
+9595	fortified special lousy spinning Racisto Ruidoso	5	decent	Effect: "One Very Clear Eye", Effect Duration: 40, Last Available: "2017-11"
 9596	red earthenware muffin tin	0		
-9597	enchanted bite-sized adequate bran muffin	1	good	Effect: "Weasels Underfoot", Effect Duration: 30
+9597	bite-sized enchanted adequate bran muffin	1	good	Effect: "Weasels Underfoot", Effect Duration: 30
 9598	stale blueberry muffin	4	decent	
 9599	huge silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
@@ -9521,7 +9521,7 @@
 9649	stale nega-mushroom	4	decent	Last Available: "2017-12"
 9650	artisanal nega-mushroom wine	3	EPIC	Last Available: "2017-12"
 9651	frozen Cheer-Up soda	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 45, Last Available: "2017-12"
-9652	moldy diet mime army rations	1	crappy	Last Available: "2017-12"
+9652	diet moldy mime army rations	1	crappy	Last Available: "2017-12"
 9653	practically non-alcoholic lousy mime army wine	1	decent	Last Available: "2017-12"
 9654	dried twirling mime army superserum	1		Last Available: "2017-12"
 9655	irradiated upside-down mime army camouflage kit	0		Effect: "Violent Night", Effect Duration: 61, Last Available: "2017-12"
@@ -9536,13 +9536,13 @@
 9664	pulsating fuchsia donated candy	0		
 9665	deionized denatured digital honeypot	0		Effect: "Hella Smooth", Effect Duration: 33, Last Available: "2025-12"
 9666	blurry mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	blurry wicked mime army insignia (infantry)	0		Spell Damage: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	narrow gray banded mime army insignia (intelligence)	0		Damage Absorption: +100, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	zippy mime army insignia (espionage)	0		Initiative: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	blurry wicked mime army insignia (infantry)	0		Spell Damage: +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	narrow gray banded mime army insignia (intelligence)	0		Damage Absorption: +100, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	zippy mime army insignia (espionage)	0		Initiative: +20, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	bouncing mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
-9673	pulsating spinning blurry mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
+9673	spinning blurry pulsating mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	lime green squat Jack Frost's mime army infiltration glove of Gandalf	0		Spell Critical Percent: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	ghostly fireproof skip lid	0		Familiar Weight: +5
-9681	jumbo normal purple spinning extra-toasted half sandwich	5	good	Last Available: "2018-12"
+9681	jumbo normal spinning purple extra-toasted half sandwich	5	good	Last Available: "2018-12"
 9682	lousy skewed mulled hobo wine	4	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	smelly burning paper hat of the wise owl of bravery	0		Mysticality: +20, Stench Spell Damage: +10, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2018-12"
@@ -9566,7 +9566,7 @@
 9694	ribald wad of used tape of extreme caution of courage	0		Monster Level: -25, Sleaze Damage: +10, Spooky Resistance: +3, Last Available: "2018-01"
 9695	Newton's supercool silent nightlight of extreme caution of the cheetah	0		Moxie Percent: +20, Experience (Mysticality): +3, Monster Level: -25, Initiative: +60
 9696	triple-anodized enhanced spinning sweetened reindeer fat	0		Effect: "Fit To Be Tide", Effect Duration: 34
-9697	dry ionized skewed tumbling Good 'n' Quiet	0		Effect: "Berry Defensive", Effect Duration: 64
+9697	dry ionized tumbling skewed Good 'n' Quiet	0		Effect: "Berry Defensive", Effect Duration: 64
 9698	pickled bouncing hot button candy	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 38
 9699	Jeselnik's nasty friendly makeshift garbage shirt	0		Familiar Weight: +3, Stench Damage: +5, Sleaze Damage: +25, Last Available: "2018-01"
 9700	skewed aromatic sizzling novelty monorail ticket	0		Hot Damage: +10, Stench Resistance: +1
@@ -9575,7 +9575,7 @@
 9703	modified ghostly beefy pill	1		
 9704	dried squat excitement pill	1		
 9705	diluted jittery vitamin G pill	1		
-9706	powdered wobbly huge lucky-ish pill	1		
+9706	powdered huge wobbly lucky-ish pill	1		
 9707	powdered jittery dieting pill	1		Effect: "It Tickles!  It Tickles!", Effect Duration: 25
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
@@ -9592,10 +9592,10 @@
 9724	fireproof baleful psychic's crystal ball	0		Spell Damage: +25, Hot Resistance: +3, Last Available: "2018-02"
 9725	horrifying Jack Frost's psychic's pslacks	0		Cold Spell Damage: +50, Spooky Damage: +25, Last Available: "2018-02"
 9726	wool scandalous psychic's amulet	0		Sleaze Damage: +5, Cold Resistance: +1, Last Available: "2018-02"
-9727	rotten diet heart-shaped candy whetstone	1	crappy	Last Available: "2018-02"
+9727	diet rotten heart-shaped candy whetstone	1	crappy	Last Available: "2018-02"
 9728	flavorless Swedish massage fish	4	decent	Last Available: "2018-02"
 9729	acceptable Third Base	4	good	Last Available: "2018-02"
-9730	enchanted smooth shaking Bustle Hustler	3	awesome	Effect: "Adorable Lookout", Effect Duration: 25, Last Available: "2018-02"
+9730	smooth enchanted shaking Bustle Hustler	3	awesome	Effect: "Adorable Lookout", Effect Duration: 25, Last Available: "2018-02"
 9731	quadruple-electrified maroon Fabiotion	0		Effect: "Castaway Physique", Effect Duration: 52, Last Available: "2018-02"
 9732	boiled ionized narrow Bettie page	0		Effect: "Ninja, Please", Effect Duration: 28, Last Available: "2018-02"
 9733	dry aerosolized wobbly tonic o' Banderas	0		Effect: "Musky", Effect Duration: 21, Last Available: "2018-02"
@@ -9623,7 +9623,7 @@
 9755	steel-toed Team Sloth cap	0		Damage Reduction: 9, Combat Rate: -15
 9756	ghostly Team Wrath cap of temperance	0		Sleaze Resistance: +5
 9757	avaricious Mu cap	0		Meat Drop: +30
-9758	narrow upside-down Thwaitgold metabug statuette	0		
+9758	upside-down narrow Thwaitgold metabug statuette	0		
 9759	shaking tumbling Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
 9760	packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
@@ -9664,7 +9664,7 @@
 9796	fuchsia Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	bouncing Oppossum	0		Last Available: "2018-03"
-9799	blinking blurry Amanitee	0		Last Available: "2018-03"
+9799	blurry blinking Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	Vulgure	0		Last Available: "2018-03"
 9802	Squib	0		Last Available: "2018-03"
@@ -9675,14 +9675,14 @@
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	squat Stooper	0		Last Available: "2018-03"
 9809	Disgeist	0		Last Available: "2018-03"
-9810	red ghostly Bowlet	0		Last Available: "2018-03"
+9810	ghostly red Bowlet	0		Last Available: "2018-03"
 9811	tumbling Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	tumbling Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
-9817	green ghostly Jamocha berry	0		Last Available: "2018-03"
+9817	ghostly green Jamocha berry	0		Last Available: "2018-03"
 9818	mirror Tapioc berry	0		Last Available: "2018-03"
 9819	Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	dehydrated magnificent oyster egg	1		
 9829	diluted brilliant oyster egg	1		Effect: "Whippin' It Good", Effect Duration: 25
 9830	vaporized glistening oyster egg	1		
-9831	powdered jittery skewed scintillating oyster egg	1		Effect: "Super Accuracy", Effect Duration: 40
+9831	powdered skewed jittery scintillating oyster egg	1		Effect: "Super Accuracy", Effect Duration: 40
 9832	altered pearlescent oyster egg	1		Effect: "Greasy Peasy", Effect Duration: 50
 9833	compressed spinning lustrous oyster egg	1		
 9834	altered gleaming oyster egg	1		
@@ -9727,8 +9727,8 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	miniature rotten FantasyRealm turkey leg	2	crappy	Last Available: "2018-04"
-9863	tolerable boozy FantasyRealm mead	5	good	Last Available: "2018-04"
+9862	rotten miniature FantasyRealm turkey leg	2	crappy	Last Available: "2018-04"
+9863	boozy tolerable FantasyRealm mead	5	good	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	huge Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	shaking arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	jittery charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	olive notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	fortified acceptable two meat muck	5	good	
+9898	acceptable fortified two meat muck	5	good	
 9899	delicious squat chocolate Ogre Chieftain	3	awesome	
 9900	flavorless spinning chocolate &quot;Phoenix&quot;	3	decent	
 9901	bite-sized normal chocolate Spider Queen	1	good	
 9902	perfectly mixed ghostly hipster cocktail	4	EPIC	
-9903	God Lobster's Scepter	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,10 +9780,10 @@
 9912	A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	spoiled miniature good guava	2	crappy	
-9916	bad watered-down bouncing jittery shaking gin and ginger	2	decent	
+9915	miniature spoiled good guava	2	crappy	
+9916	watered-down bad jittery bouncing shaking gin and ginger	2	decent	
 9917	maroon Thwaitgold chigger statuette	0		
-9918	compressed maroon tumbling gaseous gravy	1		
+9918	compressed tumbling maroon gaseous gravy	1		
 9919	upside-down ghostly SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
@@ -9793,7 +9793,7 @@
 9925	dried Nightmare Fuel	1		Effect: "Berry Berry Cold", Effect Duration: 40, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
-9928	pulsating ghostly Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
+9928	ghostly pulsating Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	Newton's savvy wizardly Brutal brogues of wisdom	0		Mysticality: 40, Mysticality Percent: +20, Experience (Mysticality): +3, Lasts Until Rollover, Last Available: "2018-07"
 9930	educational weightlifter's beefy Draftsman's driving gloves of extreme caution	0		Muscle: 25, Experience: +1, Monster Level: -25, Lasts Until Rollover, Last Available: "2018-07"
 9931	olive shaking zippy brainy Nouveau nosering of wisdom of Tarzan	0		Mysticality: 20, Experience (Muscle): +3, Initiative: +20, Lasts Until Rollover, Last Available: "2018-07"
@@ -9808,7 +9808,7 @@
 9940	burglar/sleep mask	0		Last Available: "2018-07"
 9941	Thwaitgold masked hunter statuette	0		
 9942	Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
-9943	mirror teal Neverending Party guest pass	0		Last Available: "2018-09"
+9943	teal mirror Neverending Party guest pass	0		Last Available: "2018-09"
 9944	chaotic rock-hard PARTY HARD T-shirt of the pedagogue	0		Experience: +3, Damage Reduction: 5, Spell Critical Percent: +10, Last Available: "2018-09"
 9945	olive Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
@@ -9821,7 +9821,7 @@
 9953	tiny spoiled twirling PB&J with the crusts cut off	1	crappy	Last Available: "2018-09"
 9954	huge coward's beefcake's dorky glasses	0		Muscle: +25, Monster Level: -20, Single Equip, Last Available: "2018-09"
 9955	rock-hard ponytail clip of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40, Last Available: "2018-09"
-9956	wobbly paint palette of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	wobbly paint palette of vim and vigor	0		Maximum HP Percent: +50, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	modified spinning Purple Beast energy drink	1		Last Available: "2018-09"
 9959	jittery narrow cosmetic football of the bloodbag	0		Maximum HP: +100, Last Available: "2018-09"
@@ -9831,7 +9831,7 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	weightlifter's noticeable pumps of the overflowing toilet	0		Muscle: +15, Stench Spell Damage: +50, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	perfectly mixed weak everfull glass	2		Last Available: "2018-09"
+9966	weak perfectly mixed everfull glass	2		Last Available: "2018-09"
 9967	skewed van key	0		Last Available: "2018-09"
 9968	jam band bootleg	0		Last Available: "2018-09"
 9969	blurry extremely unsafe denim jacket of chilblains	0		Weapon Damage Percent: +100, Cold Damage: +25, Last Available: "2018-09"
@@ -9847,45 +9847,45 @@
 9980	flavorless party platter for one	3	decent	Last Available: "2018-09"
 9981	boiled upside-down Party-in-a-Can&trade;	1		Effect: "Vented Spleen", Effect Duration: 25, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	Jeselnik's Annie Oakley's party crasher	0		Critical Hit Percent: +20, Sleaze Damage: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	Jeselnik's Annie Oakley's party crasher	0		Critical Hit Percent: +20, Sleaze Damage: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	blue Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	yellow &quot;I Voted!&quot; sticker of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2018-11"
-9991	narrow tumbling gray absentee voter ballot	0		Last Available: "2018-11"
+9991	gray narrow tumbling absentee voter ballot	0		Last Available: "2018-11"
 9992	teal snake skin	0		Last Available: "2018-11"
 9993	snakeskin thighboots of extreme caution of temperance	0		Monster Level: -25, Sleaze Resistance: +5, Last Available: "2018-11"
 9994	pulsating censurious groovy snakeskin cowboy hat	0		Moxie Percent: +10, Sleaze Resistance: +3, Last Available: "2018-11"
 9995	Rosewater's beefy snakeskin jacket	0		Muscle: +10, Mysticality Percent: +30, Last Available: "2018-11"
 9996	slime glob	0		Last Available: "2018-11"
-9997	squat fuchsia slime glob	0		Last Available: "2018-11"
+9997	fuchsia squat slime glob	0		Last Available: "2018-11"
 9998	blinking slime glob	0		Last Available: "2018-11"
 9999	flame-wreathed Lo Pan's slime waders of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Hot Spell Damage: +10, Last Available: "2018-11"
 10001	Jeselnik's Tesla slime fedora of the glutton	0		Sleaze Damage: +25, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-11"
 10002	vibrating banded dance instructor's slime knuckles	0		Experience Percent (Moxie): +10, Damage Absorption: +100, Maximum MP Percent: +10, Last Available: "2018-11"
-10003	red blinking government requisition form	0		Last Available: "2018-11"
+10003	blinking red government requisition form	0		Last Available: "2018-11"
 10004	yellow rock-hard Herculean supercool government-issued slacks	0		Moxie Percent: +20, Experience (Muscle): +1, Damage Reduction: 5, Last Available: "2018-11"
 10005	lime green wicked government-issued eyeshade of the blizzard of doom	0		Spell Damage: +5, Cold Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2018-11"
 10006	skewed sharpshooter's hardy strapping government-issued necktie	0		Muscle: +5, Maximum HP: +50, Critical Hit Percent: +10, Single Equip, Last Available: "2018-11"
 10007	Sherlock's inspector's Newton's mutant arm	0		Experience (Mysticality): +3, Item Drop: 40, Last Available: "2018-11"
 10008	narrow Temple Grandin's padded smartaleck's mutant legs	0		Moxie Percent: +30, Damage Absorption: +20, Familiar Weight: +7, Last Available: "2018-11"
 10009	cyan twirling greedy hale rosy-cheeked mutant crown	0		Maximum HP Percent: +30, Maximum HP: +20, Meat Drop: +20, Last Available: "2018-11"
-10010	snack-sized decent ghostly ectoplasm	2	good	Last Available: "2018-11"
+10010	decent snack-sized ghostly ectoplasm	2	good	Last Available: "2018-11"
 10011	decent wobbly	3	good	Last Available: "2018-11"
-10012	hand-crafted watered-down bottle of vodka	2	EPIC	Last Available: "2018-11"
+10012	watered-down hand-crafted bottle of vodka	2	EPIC	Last Available: "2018-11"
 10013	decent pizza	3	good	Last Available: "2018-11"
 10014	smooth martini	4	awesome	Last Available: "2018-11"
 10015	spoiled cherry pie	4	crappy	Last Available: "2018-11"
 10016	lousy eggnog	3	decent	Last Available: "2018-11"
 10017	squat glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	moldy massive Hell ramen	10	crappy	Last Available: "2018-11"
-10019	perfectly mixed practically non-alcoholic gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
-10020	weak acceptable twice-haunted screwdriver	2	good	Last Available: "2018-11"
+10018	massive moldy Hell ramen	10	crappy	Last Available: "2018-11"
+10019	practically non-alcoholic perfectly mixed gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
+10020	acceptable weak twice-haunted screwdriver	2	good	Last Available: "2018-11"
 10021	yummy candy cane	4	awesome	Last Available: "2018-12"
-10022	high-proof tolerable runny fermented egg	6	good	Last Available: "2018-12"
+10022	tolerable high-proof runny fermented egg	6	good	Last Available: "2018-12"
 10023	spoiled oldcake	3	crappy	Last Available: "2018-12"
 10024	miniature decent blinking traditional Crimbo cookie	2	good	Last Available: "2023-06"
 10025	tumbling wicked plastic wild beaver	0		Spell Damage: +5, Last Available: "2018-12"
@@ -9908,7 +9908,7 @@
 10042	family-friendly dam	0		Sleaze Resistance: +1, Damage Reduction: 9, Last Available: "2018-12"
 10043	lousy beavermouth	3	decent	Last Available: "2018-12"
 10044	lousy yellow beaver punch (papaya)	3	decent	Last Available: "2018-12"
-10045	acceptable fortified beaver punch (peach)	5	good	Last Available: "2018-12"
+10045	fortified acceptable beaver punch (peach)	5	good	Last Available: "2018-12"
 10046	drinkable spirit-forward beaver punch (cherry)	5	good	Last Available: "2018-12"
 10047	prompt Socratic Canadian lantern	0		Experience (Mysticality): +1, Adventures: +3, Last Available: "2018-12"
 10048	cyan lard-coated muskox-skin cap	0		Sleaze Spell Damage: +25, Last Available: "2018-12"
@@ -9930,7 +9930,7 @@
 10064	jar of relish	0		Familiar Weight: +5
 10065	upside-down Toyleporter	0		Last Available: "2018-12"
 10066	weak lousy beer	2	decent	Last Available: "2018-12"
-10067	delicious low-calorie yule gruel	1	awesome	Last Available: "2018-12"
+10067	low-calorie delicious yule gruel	1	awesome	Last Available: "2018-12"
 10068	bad purple hot watered rum	4	decent	Last Available: "2018-12"
 10069	mediocre bottle of Crimbognac	3	decent	Last Available: "2018-12"
 10070	moldy cyan Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
@@ -9940,7 +9940,7 @@
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	pulsating twirling Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10077	jittery gray Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
+10077	gray jittery Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	pulsating rosewater-soaked Jim Carey's Socratic Crimbolex watch	0		Experience (Mysticality): +1, Monster Level: +25, Stench Resistance: +3, Single Equip, Last Available: "2018-12"
 10080	Crimbo tattoo kit	0		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	sharpshooter's Samson's marble mariachi hat	0		Experience (Muscle): +5, Critical Hit Percent: +10, Last Available: "2019-12"
 10096	boiled ghostly marble molecules	1		Last Available: "2019-12"
 10097	wet twirling Mallomarbles	0		Effect: "Bat Attitude", Effect Duration: 48
-10098	supercharged boxer's punching bag	0		Muscle Percent: +10, Maximum MP Percent: +30, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	hardy beefy pith helmet	0		Muscle: +10, Maximum HP: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	sinister groovy poncho	0		Moxie Percent: +10, Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	spinning upside-down blinking rosewater-soaked smooth pendant	0		Moxie: +15, Stench Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	asbestos-lined foul-smelling palazzos	0		Stench Damage: +10, Hot Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	sage pseudoaccordion of the brazier	0		Mysticality Percent: +10, Hot Spell Damage: +25, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10104	altered yellow pulsating pieces	1		Last Available: "2020-12"
+10098	supercharged boxer's punching bag	0		Muscle Percent: +10, Maximum MP Percent: +30, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	hardy beefy pith helmet	0		Muscle: +10, Maximum HP: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	sinister groovy poncho	0		Moxie Percent: +10, Spell Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	spinning upside-down blinking rosewater-soaked smooth pendant	0		Moxie: +15, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	asbestos-lined foul-smelling palazzos	0		Stench Damage: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	sage pseudoaccordion of the brazier	0		Mysticality Percent: +10, Hot Spell Damage: +25, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10104	altered pulsating yellow pieces	1		Last Available: "2020-12"
 10105	improved blinking Para-Pop	0		Effect: "Ermine Eyes", Effect Duration: 59
-10106	smelly sizzling terra cotta truss	0		Hot Damage: +10, Stench Spell Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	auspicious asbestos-lined terra cotta trousers	0		Hot Resistance: +5, Item Drop: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	spinning manspreader's terra cotta tongs of the overflowing toilet	0		Monster Level: +10, Stench Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	teal perfumed sinister terra cotta train	0		Spell Damage: +10, Stench Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	terra cotta tie tack of the ox of the blizzard	0		Muscle: +20, Cold Spell Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	chilly Socratic terra cotta tambourine	0		Experience (Mysticality): +1, Cold Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	smelly sizzling terra cotta truss	0		Hot Damage: +10, Stench Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	auspicious asbestos-lined terra cotta trousers	0		Hot Resistance: +5, Item Drop: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	spinning manspreader's terra cotta tongs of the overflowing toilet	0		Monster Level: +10, Stench Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	teal perfumed sinister terra cotta train	0		Spell Damage: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	terra cotta tie tack of the ox of the blizzard	0		Muscle: +20, Cold Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	chilly Socratic terra cotta tambourine	0		Experience (Mysticality): +1, Cold Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	twisted pulsating terra cotta tidbits	1		Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2020-12"
 10113	improved Vulcanized terra panna cotta	0		Effect: "Hardened Fabric", Effect Duration: 49
 10114	upside-down nippy Newton's velour voulge	0		Experience (Mysticality): +3, Cold Damage: +10, Last Available: "2021-12"
@@ -9984,7 +9984,7 @@
 10118	green perfumed velour valise of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +5, Last Available: "2021-12"
 10119	red scandalous nippy velour vaqueros	0		Cold Damage: +10, Sleaze Damage: +5, Last Available: "2021-12"
 10120	powdered velour veneer	1		Effect: "Tennis Elbow-wow", Effect Duration: 30, Last Available: "2021-12"
-10121	unsweetened skewed ghostly Velougats&trade;	0		Effect: "Gemini Rising", Effect Duration: 51
+10121	unsweetened ghostly skewed Velougats&trade;	0		Effect: "Gemini Rising", Effect Duration: 51
 10122	blinking Sherlock's scorching glass suspenders	0		Hot Damage: +25, Item Drop: +25, Single Equip, Last Available: "2021-12"
 10123	shaking foul-smelling curative glass shield	0		Stench Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 7, Last Available: "2021-12"
 10124	Newton's glass stetson of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	clever boxer's glass serape	0		Muscle Percent: +10, Maximum MP: +20, Last Available: "2021-12"
 10128	denatured glass shards	1		Last Available: "2021-12"
 10129	flattened ionized hard candy	0		Effect: "Eagle Eyes", Effect Duration: 14
-10130	blinking loofah lumberjack's hat of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	loofah lei of Tarzan of James Dean	0		Experience (Muscle): +3, Experience (Moxie): +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	sinister stylish loofah lederhosen	0		Moxie: +25, Spell Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	skewed wobbly vibrating veiny loofah ladle	0		Maximum HP: +10, Maximum MP Percent: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	huge cyan spinning loofah legwarmers of wisdom of the sewer	0		Mysticality: +15, Stench Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	blinking jittery loofah lavalier of dire peril of Calamity Jane	0		Weapon Damage: +20, Critical Hit Percent: +15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	blinking loofah lumberjack's hat of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	loofah lei of Tarzan of James Dean	0		Experience (Muscle): +3, Experience (Moxie): +3, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	sinister stylish loofah lederhosen	0		Moxie: +25, Spell Damage: +10, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	skewed wobbly vibrating veiny loofah ladle	0		Maximum HP: +10, Maximum MP Percent: +10, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	huge cyan spinning loofah legwarmers of wisdom of the sewer	0		Mysticality: +15, Stench Damage: +25, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	blinking jittery loofah lavalier of dire peril of Calamity Jane	0		Weapon Damage: +20, Critical Hit Percent: +15, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	boiled blurry loofah lumps	1		Effect: "Held Closer", Effect Duration: 40, Last Available: "2022-12"
 10137	super-Vulcanized jittery chocolate-covered loofah	0		Effect: "Twinkly Weapon", Effect Duration: 39
-10138	olive dangerous flagstone flag of the brazier	0		Weapon Damage: +10, Hot Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	blurry crafty flagstone flail of doom	0		Maximum MP: +10, Spooky Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	avaricious resourceful flagstone flip-flops	0		Maximum MP: +50, Meat Drop: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	Herculean flagstone fez of the blizzard	0		Experience (Muscle): +1, Cold Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	lion tamer's flagstone fleece of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	spinning studded thinker's flagstone fringe	0		Mysticality: +10, Damage Absorption: +80, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	olive dangerous flagstone flag of the brazier	0		Weapon Damage: +10, Hot Spell Damage: +25, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	blurry crafty flagstone flail of doom	0		Maximum MP: +10, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	avaricious resourceful flagstone flip-flops	0		Maximum MP: +50, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	Herculean flagstone fez of the blizzard	0		Experience (Muscle): +1, Cold Spell Damage: +25, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	lion tamer's flagstone fleece of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	spinning studded thinker's flagstone fringe	0		Mysticality: +10, Damage Absorption: +80, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	vaporized flagstone flagments	1		Last Available: "2022-12"
 10145	boiled gray Flag by the Foot&trade;	0		Effect: "Provocative Perkiness", Effect Duration: 23
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	fuchsia sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	spinning personal trainer's elf army poncho	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2019-12"
-10155	massive stale elf army field rations	10	decent	Last Available: "2019-12"
+10155	stale massive elf army field rations	10	decent	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	gray flame-wreathed discarded bowtie of incineration	0		Hot Spell Damage: 60, Lasts Until Rollover, Last Available: "2019-12"
 10158	perfectly mixed martiny	4	EPIC	Last Available: "2019-12"
@@ -10029,14 +10029,14 @@
 10163	double-deionized government-issued candy	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 13
 10164	magnetized pickled purple Pneumo bar	0		Effect: "Comic Violence", Effect Duration: 22
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	greasy Lil' Doctor&trade; bag of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	greasy Lil' Doctor&trade; bag of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	delicious ghostly bloodstick	4	awesome	
 10170	perfectly mixed bottle of Sanguiovese	3	EPIC	
-10171	decent tiny actual blood sausage	1	good	
+10171	tiny decent actual blood sausage	1	good	
 10172	lousy huge mulled blood	3	decent	
-10173	fancy stale blood snowcone	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15
-10174	artisanal distilled skewed Red Russian	5	EPIC	
+10173	stale fancy blood snowcone	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15
+10174	distilled artisanal skewed Red Russian	5	EPIC	
 10175	huge bland blood roll-up	8	decent	
 10176	artisanal spirit-forward bottle of blood	5	EPIC	
 10177	normal teal bouncing blood-soaked sponge cake	3	good	
@@ -10064,7 +10064,7 @@
 10199	normal fancy crabsicle	4	good	Effect: "Shrimpin' Ain't Easy", Effect Duration: 40, Last Available: "2019-04"
 10200	tumbling melty plastic grenade	0		Last Available: "2019-04"
 10201	lousy spirit-forward bottle of dark rhum	5	decent	Last Available: "2019-04"
-10202	delicious watered-down bottle of extra-dark rhum	2	awesome	Last Available: "2019-04"
+10202	watered-down delicious bottle of extra-dark rhum	2	awesome	Last Available: "2019-04"
 10203	tolerable shaking bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
 10204	flattened unsweetened blinking pirate shaving cream	0		Effect: "X-Ray Vision", Effect Duration: 50, Last Available: "2019-04"
 10205	wholesome conquistador's breastplate of the cougar	0		Moxie: +20, Maximum HP Percent: +10, Last Available: "2019-04"
@@ -10098,13 +10098,13 @@
 10233	tolerable Island Thunderstorm	3	good	Last Available: "2019-04"
 10234	artisanal twirling Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	aged huge Skull Punch	3	awesome	Last Available: "2019-04"
-10236	watered-down tolerable twirling Electric Punch	2	good	Last Available: "2019-04"
+10236	tolerable watered-down twirling Electric Punch	2	good	Last Available: "2019-04"
 10237	perfectly mixed blinking Smuggler's Punch	4	EPIC	Last Available: "2019-04"
-10238	watered-down bad Scorpion Bowl	2	decent	Last Available: "2019-04"
+10238	bad watered-down Scorpion Bowl	2	decent	Last Available: "2019-04"
 10239	watered-down drinkable Turtle Bowl	2	good	Last Available: "2019-04"
 10240	delicious Cobra Bowl	3	awesome	Last Available: "2019-04"
 10241	mirror vampyric cloake pattern	0		Free Pull
-10242	twirling narrow mansplainer's padded boxer's beefcake's vampyric cloake of the sweet-tooth	0		Muscle: +25, Muscle Percent: +10, Damage Absorption: +20, Monster Level: +15, Candy Drop: +100, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	twirling narrow mansplainer's padded boxer's beefcake's vampyric cloake of the sweet-tooth	0		Muscle: +25, Muscle Percent: +10, Damage Absorption: +20, Monster Level: +15, Candy Drop: +100, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	quadruple-concentrated adjusted super-quantum huge one piece of bubble gum	0		Effect: "In the Saucestream", Effect Duration: 44
 10245	upside-down arcanoferric housing	0		
@@ -10113,15 +10113,15 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	grievous educational weightlifter's Fourth of May Cosplay Saber	0		Muscle: +15, Experience: +1, Weapon Damage Percent: +50, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	grievous educational weightlifter's Fourth of May Cosplay Saber	0		Muscle: +15, Experience: +1, Weapon Damage Percent: +50, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	family-friendly double-paned ribald Jack Frost's sharpshooter's therapeutic wholesome extremely unsafe supercool hewn moon-rune spoon of the empath of the glutton	0		Moxie Percent: +20, Weapon Damage Percent: +100, Maximum HP Percent: +10, Critical Hit Percent: +10, Familiar Weight: +5, Cold Spell Damage: +50, Sleaze Damage: +10, Cold Resistance: +5, Sleaze Resistance: +1, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	family-friendly double-paned ribald Jack Frost's sharpshooter's therapeutic wholesome extremely unsafe supercool hewn moon-rune spoon of the empath of the glutton	0		Moxie Percent: +20, Weapon Damage Percent: +100, Maximum HP Percent: +10, Critical Hit Percent: +10, Familiar Weight: +5, Cold Spell Damage: +50, Sleaze Damage: +10, Cold Resistance: +5, Sleaze Resistance: +1, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	upside-down cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	mirror blinking fireproof vibrating Beach Comb of Calamity Jane	0		Maximum MP Percent: +10, Critical Hit Percent: +15, Hot Resistance: +3, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
-10259	shaking tumbling grain of sand	0		Last Available: "2019-07"
+10258	mirror blinking fireproof vibrating Beach Comb of Calamity Jane	0		Maximum MP Percent: +10, Critical Hit Percent: +15, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10259	tumbling shaking grain of sand	0		Last Available: "2019-07"
 10260	purple small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	spinning pile of sand	0		Last Available: "2019-07"
@@ -10169,7 +10169,7 @@
 10304	spoiled campfire baked potato	3	crappy	Last Available: "2019-08"
 10305	normal narrow campfire s'more	3	good	Last Available: "2019-08"
 10306	spoiled campfire beans	3	crappy	Last Available: "2019-08"
-10307	stale massive campfire stew	10	decent	Last Available: "2019-08"
+10307	massive stale campfire stew	10	decent	Last Available: "2019-08"
 10308	squat campfire coffee	1	good	Last Available: "2019-08"
 10309	polymerized activated leftover chocolate bar	0		Effect: "Impregnably Delicious", Effect Duration: 46
 10310	rare Meat isotope	0		
@@ -10187,7 +10187,7 @@
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	huge ghostly packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
-10325	teal pulsating huge Law of Averages	0		
+10325	pulsating huge teal Law of Averages	0		
 10332	shaking Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	greasy slick strapping Eight Days a Week Pill Keeper	0		Muscle: +5, Moxie: +10, Sleaze Spell Damage: +10, Last Available: "2019-10"
 10334	huge unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
@@ -10203,20 +10203,20 @@
 10344	curative plastic Dolph Bossin	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	rotten mana-coated yams	3	crappy	Last Available: "2019-11"
-10347	low-calorie rotten ghostly mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
-10348	stale enchanted snack-sized mana-fortified cranberry sauce	2	decent	Effect: "Chalky White Pallor", Effect Duration: 10, Last Available: "2019-11"
+10347	rotten low-calorie ghostly mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
+10348	snack-sized enchanted stale mana-fortified cranberry sauce	2	decent	Effect: "Chalky White Pallor", Effect Duration: 10, Last Available: "2019-11"
 10349	stale wobbly mana-stuffed herbal stuffing	3	decent	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	electrified cold-filtered bouncing patch of extra-warm fur	0		Effect: "White Blooded", Effect Duration: 49, Last Available: "2019-12"
 10352	powdered blurry industrial lubricant	1		Effect: "Hobo Flavor", Effect Duration: 50, Last Available: "2019-12"
 10353	altered spinning unfinished pleasure	0		Effect: "Heart Aflame", Effect Duration: 45, Last Available: "2019-12"
 10354	vaporized vial of humanoid growth hormone	1		Last Available: "2019-12"
-10355	vaporized skewed bouncing a bug's lymph	1		Last Available: "2019-12"
+10355	vaporized bouncing skewed a bug's lymph	1		Last Available: "2019-12"
 10356	wet galvanized upside-down organic potpourri	0		Effect: "Colorful Gratitude", Effect Duration: 11, Last Available: "2019-12"
 10357	mediocre boot flask	3	decent	Last Available: "2019-12"
 10358	extra-deionized narrow infernal snowball	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 38, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	dehydrated ghostly pulsating fish sauce	1		Last Available: "2019-12"
+10360	dehydrated pulsating ghostly fish sauce	1		Last Available: "2019-12"
 10361	stale guffin	4	decent	Last Available: "2019-12"
 10362	diluted Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
@@ -10227,9 +10227,9 @@
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	boiled livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	boiled spinning mirror beggin' cologne	1		Effect: "Human-Slime Hybrid", Effect Duration: 5, Last Available: "2019-12"
+10371	boiled mirror spinning beggin' cologne	1		Effect: "Human-Slime Hybrid", Effect Duration: 5, Last Available: "2019-12"
 10372	lime green oxygenated eggnog helmet of the pedagogue of courage	0		Experience: +3, Spooky Resistance: +3, Adventure Underwater, Last Available: "2019-12"
-10373	fuchsia ghostly hand-knitted diving booties	0		Last Available: "2019-12"
+10373	ghostly fuchsia hand-knitted diving booties	0		Last Available: "2019-12"
 10374	squat peppermint harpoon gun	0		Last Available: "2019-12"
 10375	unsweetened wobbly concentrated fish broth	0		Effect: "Human-Slime Hybrid", Effect Duration: 31, Last Available: "2019-12"
 10376	denatured squat liquid SONAR	0		Effect: "Reedy Pipes", Effect Duration: 45, Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	shaking Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	dry blinking huge salty gumdrop	0		Effect: "Okee-Dokee Computer", Effect Duration: 54, Last Available: "2019-12"
+10384	dry huge blinking salty gumdrop	0		Effect: "Okee-Dokee Computer", Effect Duration: 54, Last Available: "2019-12"
 10385	skewed zippy boxer's ribbon candy ascot	0		Muscle Percent: +10, Initiative: +20, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
@@ -10288,12 +10288,12 @@
 10429	quantum wet mirror handful of mixed nuts	0		Effect: "Eye of the Seal", Effect Duration: 69, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	narrow wool ruddy Retrospecs of the sweet-tooth	0		Maximum HP Percent: +40, Cold Resistance: +1, Candy Drop: +100, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	narrow wool ruddy Retrospecs of the sweet-tooth	0		Maximum HP Percent: +40, Cold Resistance: +1, Candy Drop: +100, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	pulsating blinking nasty sizzling Temple Grandin's sage beefcake's Powerful Glove	0		Muscle: +25, Mysticality Percent: +10, Familiar Weight: +7, Hot Damage: +10, Stench Damage: +5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
-10439	jittery green enhanced signal receiver	0		
+10438	pulsating blinking nasty sizzling Temple Grandin's sage beefcake's Powerful Glove	0		Muscle: +25, Mysticality Percent: +10, Familiar Weight: +7, Hot Damage: +10, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10439	green jittery enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	resourceful Sinatra's Socratic Drip harness	0		Experience (Mysticality): +1, Experience (Moxie): +5, Maximum MP: +50
 10442	narrow steel-toed drippy truncheon	0		Damage Reduction: 9, Single Equip
@@ -10302,7 +10302,7 @@
 10445	bland drippy nugget	4	drippy	
 10446	mediocre glass of drippy wine	3	drippy	
 10447	rotten green drippy caviar	3	drippy	
-10448	rotten diet jittery maroon drippy plum(?)	1	drippy	
+10448	rotten diet maroon jittery drippy plum(?)	1	drippy	
 10449	chaotic drippy stake	0		Spell Critical Percent: +10, Single Equip
 10450	green wobbly The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10333,10 +10333,10 @@
 10476	rubber doll head	0		
 10477	tumbling rubber doll body	0		
 10478	plastic doll arms	0		
-10479	olive pulsating plastic doll legs	0		
+10479	pulsating olive plastic doll legs	0		
 10480	rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
-10482	huge shaking packet of mushroom spores	0		Last Available: "2020-03"
+10482	shaking huge packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
@@ -10376,7 +10376,7 @@
 10519	drippy enzyme	0		
 10520	drippy salt	0		
 10521	blinking drippy pigment	0		
-10522	upside-down teal blurry drippy bromide	0		
+10522	teal blurry upside-down drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
 10525	acceptable drippy pilsner	3	drippy	
@@ -10387,19 +10387,19 @@
 10531	annealed drippy orb	0		
 10532	bouncing Guzzlr application	0		Free Pull
 10533	foul-smelling Guzzlr tablet of chilblains	0		Cold Damage: +25, Stench Damage: +10, Last Available: "2020-05"
-10534	tumbling gray huge Guzzlr cocktail set	0		Last Available: "2020-05"
+10534	huge gray tumbling Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
 10536	Guzzlr hat	0		Last Available: "2020-05"
 10537	shaking Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	mirror Guzzlr pants	0		Last Available: "2020-05"
 10539	teal squat arcane researcher's Guzzlr souvenir stein	0		Experience Percent (Mysticality): +10, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	drinkable weak Ghiaccio Colada	2	good	Last Available: "2020-05"
+10541	weak drinkable Ghiaccio Colada	2	good	Last Available: "2020-05"
 10542	artisanal Sourfinger	4	EPIC	Last Available: "2020-05"
-10543	tolerable irresponsibly strong squat huge Nog-on-the-Cob	10	good	Last Available: "2020-05"
+10543	irresponsibly strong tolerable squat huge Nog-on-the-Cob	10	good	Last Available: "2020-05"
 10544	lousy Steamboat	4	decent	Last Available: "2020-05"
-10545	practically non-alcoholic special bad Buttery Boy	1	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2020-05"
-10546	narrow huge Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
+10545	special practically non-alcoholic bad Buttery Boy	1	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30, Last Available: "2020-05"
+10546	huge narrow Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	curative clown car key of terror	0		Spooky Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2020-08"
 10548	narrow greedy knitted grievous batting cage key	0		Weapon Damage Percent: +50, Cold Resistance: +3, Meat Drop: +20, Last Available: "2020-08"
 10549	scandalous smooth cool aqu&iacute;	0		Moxie: 20, Sleaze Damage: +5, Last Available: "2020-08"
@@ -10438,9 +10438,9 @@
 10582	twirling SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	upside-down scandalous deadly birch battery	0		Weapon Damage: +5, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2020-08"
-10585	crafty dance instructor's ebony epee of chilblains	0		Experience Percent (Moxie): +10, Maximum MP: +10, Cold Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	green gravedigger's padded baleful weeping willow wand	0		Spell Damage: +25, Damage Absorption: +20, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	cool beechwood blowgun of the pedagogue of the cheetah	0		Moxie: +5, Experience: +3, Initiative: +60, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	crafty dance instructor's ebony epee of chilblains	0		Experience Percent (Moxie): +10, Maximum MP: +10, Cold Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	green gravedigger's padded baleful weeping willow wand	0		Spell Damage: +25, Damage Absorption: +20, Spooky Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	cool beechwood blowgun of the pedagogue of the cheetah	0		Moxie: +5, Experience: +3, Initiative: +60, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	chaotic padded Fonzie's maple magnet	0		Experience (Moxie): +1, Damage Absorption: +20, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2020-08"
 10589	cyan Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	supercharged studded wizardly hemlock helm	0		Mysticality: +25, Damage Absorption: +80, Maximum MP Percent: +30, Last Available: "2020-08"
@@ -10461,8 +10461,8 @@
 10605	cyan ghostly Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	frozen skewed blinking Yeg's Motel toothbrush	0		Effect: "For Your Brain Only", Effect Duration: 62, Last Available: "2020-09"
 10607	polymerized irradiated Yeg's Motel hand soap	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 31, Last Available: "2020-09"
-10608	skewed maroon Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	thick tasty Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
+10608	maroon skewed Yeg's Motel sewing kit	0		Last Available: "2020-09"
+10609	tasty thick Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	boiled Yeg's Motel mouthwash	0		Effect: "Dancing Prowess", Effect Duration: 54, Last Available: "2020-09"
 10612	Annie Oakley's padded Yeg's Motel shower cap	0		Damage Absorption: +20, Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2020-09"
@@ -10498,7 +10498,7 @@
 10642	flame orb	0		Last Available: "2020-09"
 10643	tasty chocolate chip muffin	3	awesome	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
-10645	fuchsia mirror Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
+10645	mirror fuchsia Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
@@ -10508,7 +10508,7 @@
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	adjusted fortifying hot cocoa	0		Effect: "Spiky Frozen Hair", Effect Duration: 67, Last Available: "2020-12"
 10654	improved dry boiling hot cocoa	0		Effect: "Chalky White Pallor", Effect Duration: 34, Last Available: "2020-12"
-10655	ionized modified narrow spinning olive cool hot cocoa	0		Effect: "Morninja", Effect Duration: 44, Last Available: "2020-12"
+10655	ionized modified spinning narrow olive cool hot cocoa	0		Effect: "Morninja", Effect Duration: 44, Last Available: "2020-12"
 10656	nitrogenated twirling overly-fancy hot cocoa	0		Effect: "Virgo Rising", Effect Duration: 54, Last Available: "2020-12"
 10657	flattened quantum hot cocoa au beurre	0		Effect: "Coated Arms", Effect Duration: 29, Last Available: "2020-12"
 10658	ionized hot cocoa with rainbow marshmallows	0		Effect: "Expert Vacationer", Effect Duration: 20, Last Available: "2020-12"
@@ -10535,7 +10535,7 @@
 10679	executive &quot;reusable&quot; grocery bag	0		Meat Drop: +40, Lasts Until Rollover, Last Available: "2020-12"
 10680	fuchsia boxer's wine carrier	0		Muscle Percent: +10, Lasts Until Rollover, Last Available: "2020-12"
 10681	candy bucket of the ox	0		Muscle: +20, Lasts Until Rollover, Last Available: "2020-12"
-10682	moist oxidized skewed lime green prescription teeth whitener	0		Effect: "Frozen Hands", Effect Duration: 66, Last Available: "2020-12"
+10682	moist oxidized lime green skewed prescription teeth whitener	0		Effect: "Frozen Hands", Effect Duration: 66, Last Available: "2020-12"
 10683	double-cold-filtered corrupted imported lemon lozenge	0		Effect: "Yuletide Industry", Effect Duration: 21, Last Available: "2020-12"
 10684	liquefied energized twirling hermedisiac cologne	0		Effect: "Ruthlessly Efficient", Effect Duration: 19, Last Available: "2020-12"
 10685	government food shipment	0		Last Available: "2020-12"
@@ -10563,36 +10563,36 @@
 10707	tumbling The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	ghostly The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
-10710	gray blinking The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10710	blinking gray The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	blinking The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	gray The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	adequate fancy fuchsia and pepper (stale)	4	good	Effect: "Ninja, Please", Effect Duration: 40, Last Available: "2020-12"
+10715	fancy adequate fuchsia and pepper (stale)	4	good	Effect: "Ninja, Please", Effect Duration: 40, Last Available: "2020-12"
 10716	acceptable cranberry margarita (brackish)	3	good	Last Available: "2020-12"
 10717	skewed fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	yellow goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	watered-down drinkable huge spinning barrel-aged eggnog	2	good	Last Available: "2020-12"
+10720	watered-down drinkable spinning huge barrel-aged eggnog	2	good	Last Available: "2020-12"
 10721	moldy hand-crafted candy cane	3	crappy	Last Available: "2020-12"
 10722	half-sized bland drive-thru burger	2	decent	Last Available: "2020-12"
-10723	tolerable weak huge purple Boulevardier cocktail	2	good	Last Available: "2020-12"
+10723	tolerable weak purple huge Boulevardier cocktail	2	good	Last Available: "2020-12"
 10724	denatured modified yellow Hotwire&trade; brand candy rope	0		Effect: "Bottle in front of Me", Effect Duration: 56, Last Available: "2020-12"
 10725	spoiled upside-down bowl full of jelly	3	crappy	Last Available: "2020-12"
 10726	delicious watered-down Eye and a Twist	2	awesome	Last Available: "2020-12"
 10727	super-enhanced Chubby and Plump bar	0		Effect: "Bloody-minded", Effect Duration: 48, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
-10729	upside-down blurry packaged crystal ball	0		Free Pull, Last Available: "2021-01"
+10729	blurry upside-down packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	blurry crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	blurry emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	blurry emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	ghostly robo-battery	0		
 10736	skewed Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
-10739	triple-aerosolized olive wobbly twirling battery (AAA)	0		Effect: "Extra Terrestrial", Effect Duration: 11, Last Available: "2021-03"
+10739	triple-aerosolized twirling olive wobbly battery (AAA)	0		Effect: "Extra Terrestrial", Effect Duration: 11, Last Available: "2021-03"
 10740	quadruple-chilled unsweetened battery (AA)	0		Effect: "Make Meat FA$T!", Effect Duration: 43, Last Available: "2021-03"
 10741	deionized battery (D)	0		Effect: "Chorale of Companionship", Effect Duration: 24, Last Available: "2021-03"
 10742	nitrogenated pickled spinning battery (9-Volt)	0		Effect: "Incredibly Hulking", Effect Duration: 35, Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	narrow marshmallow	0		
 10747	tolerable marshmallow bomb	4	good	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	skewed shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	liquefied short beer	0		Effect: "Smelly Pants", Effect Duration: 32, Last Available: "2021-05"
@@ -10612,9 +10612,9 @@
 10756	extra-dry quantum short	0		Effect: "Slimily Sagacious", Effect Duration: 30, Last Available: "2021-05"
 10757	narrow Thwaitgold quantum bug statuette	0		
 10758	narrow quantum of familiar	0		
-10759	frosty beefy familiar scrapbook	0		Muscle: +10, Cold Spell Damage: +10, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	frosty beefy familiar scrapbook	0		Muscle: +10, Cold Spell Damage: +10, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	twirling packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
-10761	shaking narrow clan underground fireworks shop	0		Last Available: "2021-07"
+10761	narrow shaking clan underground fireworks shop	0		Last Available: "2021-07"
 10762	smelly chaotic supercharged fedora-mounted fountain	0		Maximum MP Percent: +30, Spell Critical Percent: +10, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10763	Usain Bolt's Herculean sombrero-mounted sparkler of the glutton	0		Experience (Muscle): +1, Food Drop: +100, Initiative: +80, Lasts Until Rollover, Last Available: "2021-07"
 10764	lightning-fast Tesla porkpie-mounted popper of the detective	0		Item Drop: +20, Initiative: +40, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	squat rainproof barrel caulk	0		
 10795	teal pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	lion tamer's medical-grade wholesome stiffened deadly industrial fire extinguisher of the businessman	0		Weapon Damage: +5, Damage Reduction: 1, Maximum HP Percent: +10, Experience (familiar): +2, Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	lion tamer's medical-grade wholesome stiffened deadly industrial fire extinguisher of the businessman	0		Weapon Damage: +5, Damage Reduction: 1, Maximum HP Percent: +10, Experience (familiar): +2, Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	jittery The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10672,28 +10672,28 @@
 10816	pulsating bouncing scandalous deadly brainy ice crown	0		Mysticality: +5, Weapon Damage: +5, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2021-12"
 10817	bouncing resourceful brawny jeans of temperance	0		Muscle Percent: +20, Maximum MP: +50, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2021-12"
 10818	gravedigger's sinister ice wrap of the bloodbag	0		Spell Damage: +10, Maximum HP: +100, Spooky Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	jumbo fancy bland gray tofu pop	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 20, Last Available: "2021-12"
+10819	bland fancy jumbo gray tofu pop	5	decent	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 20, Last Available: "2021-12"
 10820	bland jittery bowl of prescription candy	3	decent	Last Available: "2021-12"
 10821	stale jumbo lime green fishcake	5	decent	Last Available: "2021-12"
-10822	adequate small bone broth	2	good	Last Available: "2021-12"
-10823	normal miniature star pop	2	good	Last Available: "2021-12"
-10824	bad watered-down Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
-10825	aged jittery squat upside-down Doc's Smartifying Wine	3	awesome	Last Available: "2021-12"
-10826	lousy weak Doc's Limbering Wine	2	decent	Last Available: "2021-12"
-10827	perfectly mixed high-proof Doc's Medical-Grade Wine	8	EPIC	Last Available: "2021-12"
+10822	small adequate bone broth	2	good	Last Available: "2021-12"
+10823	miniature normal star pop	2	good	Last Available: "2021-12"
+10824	watered-down bad Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
+10825	aged jittery upside-down squat Doc's Smartifying Wine	3	awesome	Last Available: "2021-12"
+10826	weak lousy Doc's Limbering Wine	2	decent	Last Available: "2021-12"
+10827	high-proof perfectly mixed Doc's Medical-Grade Wine	8	EPIC	Last Available: "2021-12"
 10828	dehydrated Homebodyl&trade;	1		Last Available: "2021-12"
 10829	powdered skewed Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	boiled Breathitin&trade;	1		Effect: "From Nantucket", Effect Duration: 35, Last Available: "2021-12"
-10831	diluted squat fuchsia Fleshazole&trade;	1		Last Available: "2021-12"
+10831	diluted fuchsia squat Fleshazole&trade;	1		Last Available: "2021-12"
 10832	extra-energized blue anti-burn cream	0		Effect: "Coated Arms", Effect Duration: 62, Last Available: "2021-12"
 10833	warmed dry anti-freeze cream	0		Effect: "Alchemical, Brother", Effect Duration: 19, Last Available: "2021-12"
 10834	moist anti-goosebump cream	0		Effect: "Aided and Abetted", Effect Duration: 25, Last Available: "2021-12"
 10835	altered diffused anti-odor cream	0		Effect: "Oxygenated Blood", Effect Duration: 16, Last Available: "2021-12"
-10836	Vulcanized jittery pulsating anti-creep cream	0		Effect: "Certainty", Effect Duration: 16, Last Available: "2021-12"
+10836	Vulcanized pulsating jittery anti-creep cream	0		Effect: "Certainty", Effect Duration: 16, Last Available: "2021-12"
 10837	colloidal polarized ghostly anti-pain cream	0		Effect: "Tingling Feeling", Effect Duration: 59, Last Available: "2021-12"
 10838	extra-dry mediocre Doc's Special Reserve Wine	5	decent	Last Available: "2021-12"
 10839	moldy bread pie	4	crappy	Last Available: "2021-12"
-10840	acceptable weak blinking red clear Russian	2	good	Last Available: "2021-12"
+10840	weak acceptable red blinking clear Russian	2	good	Last Available: "2021-12"
 10841	teal zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10715,13 +10715,13 @@
 10859	teal projectile chemistry set	0		Last Available: "2021-12"
 10860	vibrating depleted Crimbonium football helmet	0		Maximum MP Percent: +10, Last Available: "2021-12"
 10861	red synthetic rock	0		Last Available: "2021-12"
-10862	massive rotten &quot;caramel&quot;	7	crappy	Last Available: "2021-12"
+10862	rotten massive &quot;caramel&quot;	7	crappy	Last Available: "2021-12"
 10863	frosty self-repairing earmuffs	0		Cold Spell Damage: +10, Last Available: "2021-12"
 10864	carnivorous potted plant of wisdom	0		Mysticality: +15, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
 10866	squat zippy yule hatchet	0		Initiative: +20, Last Available: "2021-12"
 10867	jittery potato alarm clock	0		Last Available: "2021-12"
-10868	stale gigantic wobbly lab-grown meat	6	decent	Last Available: "2021-12"
+10868	gigantic stale wobbly lab-grown meat	6	decent	Last Available: "2021-12"
 10869	beefcake's fleece	0		Muscle: +25, Last Available: "2021-12"
 10870	mirror boxed gumball machine	0		Last Available: "2021-12"
 10871	blinking cloning kit	0		Last Available: "2021-12"
@@ -10729,18 +10729,18 @@
 10873	Lo Pan's wicked can of mixed everything of the cougar	0		Moxie: +20, Spell Damage: +5, Spell Critical Percent: +30, Last Available: "2021-12"
 10874	blinking Site Alpha ID badge	0		Familiar Weight: +5
 10875	tumbling jittery the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	bland super-sized huge meatball	5	decent	Last Available: "2021-12"
+10876	super-sized bland huge meatball	5	decent	Last Available: "2021-12"
 10877	blurry cloned monster	0		Last Available: "2021-12"
 10878	pulsating meatball machine	0		Last Available: "2021-12"
 10879	ghostly refurbished air fryer	0		Last Available: "2021-12"
 10880	altered blue fried air	1		Last Available: "2021-12"
 10881	gray tumbling 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	altered twirling pulsating astral energy drink	1		
+10883	altered pulsating twirling astral energy drink	1		
 10884	blurry mint condition magnifying glass	0		Last Available: "2022-12"
 10885	pulsating veiny magnifying glass of Gandalf of the boozehound	0		Maximum HP: +10, Spell Critical Percent: +20, Booze Drop: +100, Last Available: "2022-12"
 10886	lousy void lager	4	decent	Last Available: "2022-12"
-10887	rotten diet void burger	1	crappy	Last Available: "2022-12"
+10887	diet rotten void burger	1	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	blue Usain Bolt's dog trainer's deadly brainy void shard	0		Mysticality: +5, Weapon Damage: +5, Experience (familiar): +1, Initiative: +80, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10765,7 +10765,7 @@
 10909	upside-down space blanket	0		Last Available: "2022-05"
 10910	tarnished liquefied blurry single-use dust mask	0		Effect: "Be a Mind Master", Effect Duration: 26, Last Available: "2022-05"
 10911	double-galvanized gaffer's tape	0		Effect: "Abyssal Sweat", Effect Duration: 62, Last Available: "2022-05"
-10912	jumbo normal 20-lb can of rice and beans	5	good	Last Available: "2022-05"
+10912	normal jumbo 20-lb can of rice and beans	5	good	Last Available: "2022-05"
 10913	blinking bar of freeze-dried water	1	good	Last Available: "2022-05"
 10914	miniature toothsome blue expired MRE	2	awesome	Last Available: "2022-05"
 10915	toothsome diet cool mint precipice bar	1	awesome	Last Available: "2022-05"
@@ -10782,7 +10782,7 @@
 10926	boiled double-magnetized trampled ticket stub	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 15, Last Available: "2022-06"
 10927	diffused extra-frozen huge savings bond	0		Effect: "Night of the Nachos", Effect Duration: 22, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	compressed olive sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10805,14 +10805,14 @@
 10949	curative dinosaur	0		HP Regen Min: 3, HP Regen Max: 5
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	wobbly Jurassic Parka of wisdom of incineration	0		Mysticality: +15, Hot Spell Damage: +50, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	wobbly Jurassic Parka of wisdom of incineration	0		Mysticality: +15, Hot Spell Damage: +50, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	jittery boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	energized autumn leaf	0		Effect: "Sticky Hands", Effect Duration: 27, Last Available: "2022-10"
-10956	drinkable weak AutumnFest ale	2	good	Last Available: "2022-10"
+10956	weak drinkable AutumnFest ale	2	good	Last Available: "2022-10"
 10957	wobbly nippy veiny autumn sweater-weather sweater of incineration	0		Maximum HP: +10, Cold Damage: +10, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2022-10"
 10958	zippy Herculean boxer's wizardly autumn debris shield	0		Mysticality: +25, Muscle Percent: +10, Experience (Muscle): +1, Initiative: +20, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	spoiled huge autumn-spice donut	10	crappy	Last Available: "2022-10"
+10959	huge spoiled autumn-spice donut	10	crappy	Last Available: "2022-10"
 10960	extra-modified nitrogenated ghostly autumn dollar	0		Effect: "Rushtacean'", Effect Duration: 16, Last Available: "2022-10"
 10961	family-friendly forbidden autumn leaf pendant of the pedagogue	0		Experience: +3, Spell Damage Percent: +50, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2022-10"
 10962	distilled yellow autumn breeze	1		Last Available: "2022-10"
@@ -10822,39 +10822,39 @@
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	pulsating St. Sneaky Pete's Whey	0		Last Available: "2022-11"
-10969	blinking blue Vegetable of Jarlsberg	0		Last Available: "2022-11"
+10969	blue blinking Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	miniature rotten ratatouille de Jarlsberg	2	crappy	Last Available: "2022-11"
-10971	adequate jumbo enchanted Jarlsberg's vegetable soup	5	good	Effect: "You Can Really Taste the Dormouse", Effect Duration: 30, Last Available: "2022-11"
+10971	jumbo adequate enchanted Jarlsberg's vegetable soup	5	good	Effect: "You Can Really Taste the Dormouse", Effect Duration: 30, Last Available: "2022-11"
 10972	gigantic stale roasted vegetable of Jarlsberg	9	decent	Last Available: "2022-11"
 10973	spoiled big St. Pete's sneaky smoothie	5	crappy	Last Available: "2022-11"
 10974	super-sized spoiled Pete's wiley whey bar	5	crappy	Last Available: "2022-11"
 10975	decent purple pulsating Pete's rich ricotta	3	good	Last Available: "2022-11"
-10976	perfectly mixed mirror red Boris's beer	4	EPIC	Last Available: "2022-11"
-10977	bland gigantic blue honey bun of Boris	9	decent	Last Available: "2022-11"
-10978	delicious tiny bouncing upside-down Boris's bread	1	awesome	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	green Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	twirling Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	huge Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	tumbling Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	huge Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10976	perfectly mixed red mirror Boris's beer	4	EPIC	Last Available: "2022-11"
+10977	gigantic bland blue honey bun of Boris	9	decent	Last Available: "2022-11"
+10978	tiny delicious upside-down bouncing Boris's bread	1	awesome	Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	green Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	twirling Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	huge Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	tumbling Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	huge Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	moldy baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
 10989	bite-sized stale plain calzone	1	decent	Last Available: "2022-11"
 10990	enchanted flavorless roasted vegetable focaccia	3	decent	Effect: "In the Slimelight", Effect Duration: 20, Last Available: "2022-11"
-10991	stale bite-sized Pizza of Legend	1	decent	Last Available: "2022-11"
-10992	jumbo adequate Calzone of Legend	5	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	tumbling skewed Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	blinking Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	wobbly Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10991	bite-sized stale Pizza of Legend	1	decent	Last Available: "2022-11"
+10992	adequate jumbo Calzone of Legend	5	good	Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	skewed tumbling Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	blinking Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	wobbly Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	flavorless jittery Deep Dish of Legend	4	decent	Last Available: "2022-11"
-11001	pulsating shaking deed to Oliver's Place	0		Free Pull
+11001	shaking pulsating deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
 11004	nippy prohie's hat	0		Cold Damage: +10
@@ -10869,16 +10869,16 @@
 11013	watered-down perfectly mixed fuchsia jittery Charleston Choo-Choo	2	EPIC	
 11014	bad Velvet Veil	3	decent	
 11015	hand-crafted teal Marltini	4	EPIC	
-11016	tolerable watered-down Strong, Silent Type	2	good	
+11016	watered-down tolerable Strong, Silent Type	2	good	
 11017	mediocre Mysterious Stranger	4	decent	
 11018	hand-crafted narrow Champagne Shimmy	3	EPIC	
 11019	fuchsia the Sot's parcel	0		
-11020	green smelly ceramic cestus of temperance	0		Stench Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	upside-down frosty resourceful studded ceramic centurion shield	0		Damage Absorption: +80, Maximum MP: +50, Cold Spell Damage: +10, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	Annie Oakley's Rosewater's ceramic celery grater	0		Mysticality Percent: +30, Critical Hit Percent: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	healthy Sinatra's ceramic celsiturometer of the detective	0		Experience (Moxie): +5, Maximum HP Percent: +20, Item Drop: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	Temple Grandin's manspreader's supercool ceramic cerecloth belt	0		Moxie Percent: +20, Monster Level: +10, Familiar Weight: +7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	spinning manspreader's ceramic cenobite's robe of extreme caution	0		Monster Level: -15, Item Drop: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	green smelly ceramic cestus of temperance	0		Stench Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	upside-down frosty resourceful studded ceramic centurion shield	0		Damage Absorption: +80, Maximum MP: +50, Cold Spell Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	Annie Oakley's Rosewater's ceramic celery grater	0		Mysticality Percent: +30, Critical Hit Percent: +20, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	healthy Sinatra's ceramic celsiturometer of the detective	0		Experience (Moxie): +5, Maximum HP Percent: +20, Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	Temple Grandin's manspreader's supercool ceramic cerecloth belt	0		Moxie Percent: +20, Monster Level: +10, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	spinning manspreader's ceramic cenobite's robe of extreme caution	0		Monster Level: -15, Item Drop: +5, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	modified tumbling ceramic scree	1		Last Available: "2023-12"
 11027	nitrogenated extra-hard jawbreaker	0		Effect: "Hardened Fabric", Effect Duration: 48
 11028	frosty stiffened chiffon chevrons of doom	0		Damage Reduction: 1, Cold Spell Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2023-12"
@@ -10887,9 +10887,9 @@
 11031	perfumed hardy padded chiffon chemise	0		Damage Absorption: +20, Maximum HP: +50, Stench Resistance: +5, Last Available: "2023-12"
 11032	tumbling Socratic brawny chiffon chakram of doom	0		Muscle Percent: +20, Experience (Mysticality): +1, Spooky Spell Damage: +50, Last Available: "2023-12"
 11033	curative chiffon chaps of Calamity Jane of the sweet-tooth	0		Critical Hit Percent: +15, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
-11034	distilled wobbly lime green spinning chiffon carbage	1		Last Available: "2023-12"
+11034	distilled lime green spinning wobbly chiffon carbage	1		Last Available: "2023-12"
 11035	double-chilled chiffon lemon	0		Effect: "Mushroom Samba", Effect Duration: 47
-11036	enchanted small spoiled chocomotive	2	crappy	Effect: "Aided and Abetted", Effect Duration: 50, Last Available: "2022-12"
+11036	enchanted spoiled small chocomotive	2	crappy	Effect: "Aided and Abetted", Effect Duration: 50, Last Available: "2022-12"
 11037	bland jumbo freightcake	5	decent	Last Available: "2022-12"
 11038	triple-distilled drinkable blurry cabooze	7	good	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10903,7 +10903,7 @@
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	bouncing green pile of Trainbot parts	0		
-11050	polymerized bouncing wobbly Trainbot circuitry	0		Effect: "Armor-Plated", Effect Duration: 24
+11050	polymerized wobbly bouncing Trainbot circuitry	0		Effect: "Armor-Plated", Effect Duration: 24
 11051	chilled boiled Trainbot tubing	0		Effect: "Human-Hobo Hybrid", Effect Duration: 68
 11052	flattened Trainbot plating	0		Effect: "Eyes of the Dragon", Effect Duration: 66
 11053	cold-filtered twirling mirror Trainbot optics	0		Effect: "Mushroom Magicalness", Effect Duration: 14
@@ -10923,7 +10923,7 @@
 11067	tolerable distilled dregs of a Crimbo cocktail	5	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	big bland honey-drenched ham slice	5	decent	
+11070	bland big honey-drenched ham slice	5	decent	
 11071	hand-crafted cyan mostly-empty bottle of cookie wine	3	EPIC	
 11072	stale Crimbo food scraps	4	decent	
 11073	cyan arm towel	0		Last Available: "2022-12"
@@ -10940,7 +10940,7 @@
 11084	artisanal Crimbosmopolitan	3	super EPIC	Last Available: "2022-12"
 11085	decent bouncing Crimbo dinner	3	good	Last Available: "2022-12"
 11086	lime green overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
-11087	cyan tumbling train whistle	0		Last Available: "2022-12"
+11087	tumbling cyan train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	half-height cigar	0		Familiar Weight: +5
@@ -10956,7 +10956,7 @@
 11100	cyan packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
 11102	pickled fruity pebble	1		Last Available: "2023-01"
-11103	wobbly upside-down lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
+11103	upside-down wobbly lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
@@ -10964,7 +10964,7 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	immense stale pixel bread	9	decent	
+11112	stale immense pixel bread	9	decent	
 11113	perfectly mixed maroon pixel whiskey	4	EPIC	
 11114	pixel rock	0		
 11115	pulsating S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10974,12 +10974,12 @@
 11119	polarized flattened lime green five-fingered fern resin	0		Effect: "Spooky Jellied", Effect Duration: 42, Last Available: "2023-02"
 11120	miniature moldy super good fruit	2	crappy	Last Available: "2023-02"
 11121	denatured jittery energized spores	1		Effect: "Egg Burps", Effect Duration: 15, Last Available: "2023-02"
-11122	skewed Oprah's vibrating hot pepper	0		Maximum MP Percent: 60, Last Available: "2023-02", Lantern Element: "Hot"
+11122	skewed Oprah's vibrating hot pepper	0		Maximum MP Percent: 60, Lantern Element: "Hot", Last Available: "2023-02"
 11123	unsweetened out-of-work circus flea	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 37, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	boiled olive fire ant pheromones	0		Effect: "Sauce Monocle", Effect Duration: 55, Last Available: "2023-02"
 11126	boiled unsweetened flapper fly	0		Effect: "Saucemastery", Effect Duration: 61, Last Available: "2023-02"
-11127	strong lousy shot of wasp venom	5	decent	Last Available: "2023-02"
+11127	lousy strong shot of wasp venom	5	decent	Last Available: "2023-02"
 11128	ionized frozen narrow filled mosquito	0		Effect: "Shortened", Effect Duration: 55, Last Available: "2023-02"
 11129	dry shim of shame shale	0		Effect: "Oleaginous Soles", Effect Duration: 39, Last Available: "2023-02"
 11130	altered dry energized spinning pebble of proud pyrite	0		Effect: "Favored by Lyle", Effect Duration: 38, Last Available: "2023-02"
@@ -10992,7 +10992,7 @@
 11137	polarized super-pickled upside-down bouncing shadow flame	0		Effect: "Cool Spirit", Effect Duration: 41, Last Available: "2023-03"
 11138	normal narrow shadow bread	3	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	hand-crafted irresponsibly strong shaking mirror shadow fluid	6	EPIC	Last Available: "2023-03"
+11140	hand-crafted irresponsibly strong mirror shaking shadow fluid	6	EPIC	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	twirling shadow brick	0		Last Available: "2023-03"
 11143	bouncing shadow sinew	0		Last Available: "2023-03"
@@ -11018,11 +11018,11 @@
 11163	Advanced Pig Skinning	0		
 11164	The Cheese Wizard's Companion	0		
 11165	pulsating Jazz Agent sheet music	0		
-11166	squat jittery Thwaitgold anti-moth statuette	0		
-11167	tumbling pulsating shadowy cheat sheet	0		Free Pull
+11166	jittery squat Thwaitgold anti-moth statuette	0		
+11167	pulsating tumbling shadowy cheat sheet	0		Free Pull
 11168	ghostly closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
-11170	blinking maroon shadow lighter	0		
+11170	maroon blinking shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	huge shadow snowflake	0		
 11173	shadow heart	0		
@@ -11038,7 +11038,7 @@
 11183	mediocre watered-down bouncing shadow martini	2	decent	
 11184	powdered wobbly shadow pill	1		Effect: "Amorous Avarice", Effect Duration: 5
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	flattened shadow candy	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 57
 11189	jittery replica Mr. Accessory	0		
@@ -11075,7 +11075,7 @@
 11220	cyan replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	Sherlock's stanky chaotic electrified Cincho de Mayo	0		Spell Critical Percent: +10, Stench Spell Damage: +25, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	Sherlock's stanky chaotic electrified Cincho de Mayo	0		Spell Critical Percent: +10, Stench Spell Damage: +25, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	twirling dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11112,13 +11112,13 @@
 11257	tumbling 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	chaotic Tesla crafty Da Vinci's &quot;I survived Y2K&quot; T-Shirt of James Dean of the storm	0		Experience (Mysticality): +5, Experience (Moxie): +3, Maximum MP Percent: +40, Maximum MP: +10, Spell Critical Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	scorching supercool pro skateboard	0		Moxie Percent: +20, Hot Damage: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	scorching supercool pro skateboard	0		Moxie Percent: +20, Hot Damage: +25, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	fuchsia Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	mirror Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	Flash Liquidizer Ultra Dousing Accessory of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	Flash Liquidizer Ultra Dousing Accessory of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	upside-down scorching padded Samson's Amulet of Perpetual Darkness of temperance	0		Experience (Muscle): +5, Damage Absorption: +20, Hot Damage: +25, Sleaze Resistance: +5, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	narrow Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11171,20 +11171,20 @@
 11316	bland skewed banana split	3	decent	
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
-11319	blurry skewed medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
+11319	skewed blurry medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	weak delicious bottle of Cabernet Sauvignon	2	awesome	
 11321	avaricious frightening nasty baywatch	0		Stench Damage: +5, Spooky Damage: +5, Meat Drop: +30, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	gray skewed Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	gray skewed Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	skewed residual chitin paste	0		Skill: "Chitinous Soul"
 11328	dried narrow concentrated cooking	1		
-11329	denatured narrow upside-down squat meat	1		
-11330	mixed mirror squat red sparkling orb	1		Effect: "Fit To Be Tide", Effect Duration: 10
+11329	denatured upside-down narrow squat meat	1		
+11330	mixed squat mirror red sparkling orb	1		Effect: "Fit To Be Tide", Effect Duration: 10
 11331	distilled spinning hardening cream	1		Effect: "Pie in the Sky", Effect Duration: 45
-11332	mixed bouncing olive blurry pool shark hair oil	1		
+11332	mixed blurry olive bouncing pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11213,7 +11213,7 @@
 11358	blinking smoldering leafcutter ant egg	0		
 11359	scandalous wicked boxer's cool leaf crown of vim and vigor of the sweet-tooth	0		Moxie: +5, Muscle Percent: +10, Spell Damage: +5, Maximum HP Percent: +50, Sleaze Damage: +5, Candy Drop: +100
 11360	bland blurry leafy browns	3	decent	
-11361	chilled squat fuchsia autumnic balm	0		Effect: "Wreathed in Merriment", Effect Duration: 22
+11361	chilled fuchsia squat autumnic balm	0		Effect: "Wreathed in Merriment", Effect Duration: 22
 11362	irradiated fuchsia pulsating coping juice	0		Effect: "Crying, Dying", Effect Duration: 61
 11363	lightning-fast fireproof ribald nasty candy cane sword cane of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Sleaze Damage: +10, Hot Resistance: +3, Initiative: +40, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
@@ -11229,9 +11229,9 @@
 11374	Spring Bros. ID badge	0		
 11375	bouncing Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
-11377	fuchsia squat housekeeping robot	0		
+11377	squat fuchsia housekeeping robot	0		
 11378	rotten shaking pickled bread	4	crappy	Last Available: "2023-12"
-11379	tiny flavorless salted mutton	1	decent	Last Available: "2023-12"
+11379	flavorless tiny salted mutton	1	decent	Last Available: "2023-12"
 11380	normal olive corned beet	3	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11280,7 +11280,7 @@
 11425	tolerable officer's nog	3	good	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	delicious skewed sundae ration	4	awesome	Last Available: "2023-12"
-11428	jumbo flavorless enchanted peppermint tack	5	decent	Effect: "Jungle Juiced", Effect Duration: 5, Last Available: "2023-12"
+11428	enchanted flavorless jumbo peppermint tack	5	decent	Effect: "Jungle Juiced", Effect Duration: 5, Last Available: "2023-12"
 11429	blue Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	spoiled huge whalesteak	4	crappy	Last Available: "2023-12"
 11431	wool extremely unsafe whalegun of the blizzard	0		Weapon Damage Percent: +100, Cold Spell Damage: +25, Cold Resistance: +1, Last Available: "2023-12"
@@ -11288,14 +11288,14 @@
 11433	cyan Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	purple resourceful Elf Guard clipboard of the dark arts of vim and vigor	0		Spell Damage Percent: +100, Maximum HP Percent: +50, Maximum MP: +50, Last Available: "2023-12"
 11435	wool pegfinger	0		Cold Resistance: +1, Single Equip, Last Available: "2023-12"
-11436	distilled tolerable teal and claret	5	good	Last Available: "2023-12"
+11436	tolerable distilled teal and claret	5	good	Last Available: "2023-12"
 11437	up-at-dawn Elf Guard and beret	0		Adventures: [+5*event(December)], Last Available: "2023-12"
 11438	gray shaking razor-sharp dangerous savvy shipwright's hammer	0		Mysticality Percent: +20, Weapon Damage: +10, Weapon Damage Percent: +25, Last Available: "2023-12"
 11439	perfumed reassuring ruddy gunwale	0		Maximum HP Percent: +40, Spooky Resistance: +1, Stench Resistance: +5, Damage Reduction: 9, Last Available: "2023-12"
 11440	mirror baleful sinister Kelflar vest of the bloodbag	0		Spell Damage: 35, Maximum HP: +100, Last Available: "2023-12"
 11441	vacuum-sealed whale cerebrospinal fluid	0		Effect: "Smoky Third Eye", Effect Duration: 28, Last Available: "2023-12"
 11442	coward's supercharged Crimbuccaneer runebone	0		Maximum MP Percent: +30, Monster Level: -20, Single Equip, Last Available: "2023-12"
-11443	upside-down wobbly upside-down cannonbomb	0		Last Available: "2023-12"
+11443	wobbly upside-down upside-down cannonbomb	0		Last Available: "2023-12"
 11444	Oprah's strapping Elf Guard mouthknife	0		Muscle: +5, Maximum MP Percent: +50, Last Available: "2023-12"
 11445	boxer's Crimbuccaneer fledges (disintegrating) of the pedagogue	0		Muscle Percent: +10, Experience: +3, Single Equip, Last Available: "2023-12"
 11446	gray Tesla Elf Guard fuel tank	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	ghostly Usain Bolt's careful banded studded experienced Elf dessert spoon of terror	0		Experience: +2, Damage Absorption: 180, Monster Level: -10, Spooky Spell Damage: +10, Initiative: +80, Last Available: "2023-12"
 11453	studded experienced Elf Guard SCUBA tank	0		Experience: +2, Damage Absorption: +80, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	lightning-fast coward's free boots	0		Monster Level: -20, Initiative: +40, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	lightning-fast coward's free boots	0		Monster Level: -20, Initiative: +40, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	blurry baby rigging snake	0		Last Available: "2023-12"
 11457	squat frosty dangerous deadly Elvish underarmor	0		Weapon Damage: 15, Cold Spell Damage: +10, Single Equip, Last Available: "2023-12"
 11458	squat twirling gravedigger's Van der Graaf Crimbuccaneer bombjacket	0		Spooky Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	jumbo adequate wobbly sugarplum ration	5	good	Last Available: "2023-12"
+11459	adequate jumbo wobbly sugarplum ration	5	good	Last Available: "2023-12"
 11460	stale gingerbread nylons	4	decent	Last Available: "2023-12"
 11461	enchanted bland rum-soaked fruitcake	4	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2023-12"
 11462	spoiled lime	3	crappy	Last Available: "2023-12"
 11463	toothsome gingerbread pirate	3	awesome	Last Available: "2023-12"
 11464	bland miniature fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
-11465	artisanal extra-dry mulled wine	5	EPIC	Last Available: "2023-12"
-11466	lousy fancy Swedish coffee	3	decent	Effect: "Aries Rising", Effect Duration: 20, Last Available: "2023-12"
-11467	special drinkable pulsating canteen of eggnog	3	good	Effect: "Wings of the Grasshopper", Effect Duration: 20, Last Available: "2023-12"
-11468	lousy distilled hot wine	5	decent	Last Available: "2023-12"
-11469	extra-dry bad lime green Jamaican coffee	5	decent	Last Available: "2023-12"
+11465	extra-dry artisanal mulled wine	5	EPIC	Last Available: "2023-12"
+11466	fancy lousy Swedish coffee	3	decent	Effect: "Aries Rising", Effect Duration: 20, Last Available: "2023-12"
+11467	drinkable special pulsating canteen of eggnog	3	good	Effect: "Wings of the Grasshopper", Effect Duration: 20, Last Available: "2023-12"
+11468	distilled lousy hot wine	5	decent	Last Available: "2023-12"
+11469	bad extra-dry lime green Jamaican coffee	5	decent	Last Available: "2023-12"
 11470	irresponsibly strong perfectly mixed narrow flask of egggrog	8	EPIC	Last Available: "2023-12"
-11471	gray shaking Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
+11471	shaking gray Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	shaking Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	spirit-forward smooth ghostly yule grog	5	awesome	Last Available: "2023-12"
+11474	smooth spirit-forward ghostly yule grog	5	awesome	Last Available: "2023-12"
 11475	big normal wet tack	5	good	Last Available: "2023-12"
-11476	thick decent whalecake	5	good	Last Available: "2023-12"
-11477	green shaking smelly coward's forbidden gunwale whalegun	0		Spell Damage Percent: +50, Monster Level: -20, Stench Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11476	decent thick whalecake	5	good	Last Available: "2023-12"
+11477	green shaking smelly coward's forbidden gunwale whalegun	0		Spell Damage Percent: +50, Monster Level: -20, Stench Spell Damage: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	tolerable spirit-forward and claret	5	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	tumbling tumbling trick coin	0		Last Available: "2023-12"
-11481	squat hale Fonzie's Elf Guard squirtgun	0		Experience (Moxie): +1, Maximum HP: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	squat hale Fonzie's Elf Guard squirtgun	0		Experience (Moxie): +1, Maximum HP: +20, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	blurry scorching sequin-encrusted sweater	0		Hot Damage: +25, Last Available: "2023-12"
 11484	narrow Sherlock's gravedigger's coward's replica Elf Guard medal	0		Monster Level: -20, Spooky Damage: +10, Item Drop: +25, Last Available: "2023-12"
@@ -11354,13 +11354,13 @@
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11502	liquefied oxidized bouncing blinking military candy cane	0		Effect: "Dwarven Hardiness", Effect Duration: 67
+11502	liquefied oxidized blinking bouncing military candy cane	0		Effect: "Dwarven Hardiness", Effect Duration: 67
 11503	chilled tumbling tumbling groggipop	0		Effect: "Mushroom Magicalness", Effect Duration: 62
-11504	zippy moss mace of the businessman	0		Meat Drop: +50, Initiative: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	mirror moss megaphone of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	purple chaotic Herculean moss medal	0		Experience (Muscle): +1, Spell Critical Percent: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	blurry ruddy healthy moss mitre	0		Maximum HP Percent: 60, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	flame-retardant extremely unsafe moss mantle	0		Weapon Damage Percent: +100, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	zippy moss mace of the businessman	0		Meat Drop: +50, Initiative: +20, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	mirror moss megaphone of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	purple chaotic Herculean moss medal	0		Experience (Muscle): +1, Spell Critical Percent: +10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	blurry ruddy healthy moss mitre	0		Maximum HP Percent: 60, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	flame-retardant extremely unsafe moss mantle	0		Weapon Damage Percent: +100, Hot Resistance: +1, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	double-paned moss marlinspike of the glutton	0		Cold Resistance: +5, Food Drop: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	twisted fuchsia moss mulch	1		Last Available: "2024-12"
 11511	triple-liquefied pulsating moss floss	0		Effect: "Phairly Pheromonal", Effect Duration: 19
@@ -11372,33 +11372,33 @@
 11517	upside-down adobe abaya	0		Last Available: "2024-12"
 11518	vaporized maroon squat adobe assortment	1		Last Available: "2024-12"
 11519	activated blue adobe brittle	0		Effect: "Weasels Underfoot", Effect Duration: 55
-11520	ruddy weightlifter's crepe paper phrygian cap of the empath	0		Muscle: +15, Maximum HP Percent: +40, Familiar Weight: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	ruddy weightlifter's crepe paper phrygian cap of the empath	0		Muscle: +15, Maximum HP Percent: +40, Familiar Weight: +5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	reassuring crepe paper parachute cape of extreme caution of the early riser	0		Monster Level: -25, Spooky Resistance: +1, Adventures: +7, Last Available: "2025-12"
-11522	mirror blurry crafty baleful crepe paper pie clip of bravery	0		Spell Damage: +25, Maximum MP: +10, Spooky Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	nippy manspreader's Rosewater's crepe paper puzzle cube	0		Mysticality Percent: +30, Monster Level: +10, Cold Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	Usain Bolt's lightning-fast Tesla crepe paper plunge camisole	0		Initiative: 120, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	nasty healthy crepe paper polka charm of the storm	0		Maximum HP Percent: +20, Maximum MP Percent: +40, Stench Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	mirror blurry crafty baleful crepe paper pie clip of bravery	0		Spell Damage: +25, Maximum MP: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	nippy manspreader's Rosewater's crepe paper puzzle cube	0		Mysticality Percent: +30, Monster Level: +10, Cold Damage: +10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	Usain Bolt's lightning-fast Tesla crepe paper plunge camisole	0		Initiative: 120, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	nasty healthy crepe paper polka charm of the storm	0		Maximum HP Percent: +20, Maximum MP Percent: +40, Stench Damage: +5, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	denatured lime green mirror crepe paper pared cuttings	1		Effect: "Putting the Pro in Proletariat", Effect Duration: 25, Last Available: "2025-12"
 11527	quadruple-moist crepe paper peanut candy	0		Effect: "All Branned Up", Effect Duration: 14
 11528	veiny petrified wood war pike of horror	0		Maximum HP: +10, Spooky Spell Damage: +25, Last Available: "2025-12"
 11529	MacGyver's petrified wood waist protector of bravery	0		Maximum MP: +100, Spooky Resistance: +5, Single Equip, Last Available: "2025-12"
-11530	twirling up-at-dawn supercharged petrified wood wizard's pouch	0		Maximum MP Percent: +30, Adventures: +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	up-at-dawn petrified wood water purifier of James Dean	0		Experience (Moxie): +3, Adventures: +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	twirling up-at-dawn supercharged petrified wood wizard's pouch	0		Maximum MP Percent: +30, Adventures: +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	up-at-dawn petrified wood water purifier of James Dean	0		Experience (Moxie): +3, Adventures: +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	crafty boxer's petrified wood whoopie panama	0		Muscle Percent: +10, Maximum MP: +10, Last Available: "2025-12"
 11533	chaotic slick petrified wood walking pants	0		Moxie: +10, Spell Critical Percent: +10, Last Available: "2025-12"
 11534	distilled petrified wood waste parts	1		Last Available: "2025-12"
 11535	aerosolized tumbling petrified wood wafer praline	0		Effect: "Morninja", Effect Duration: 66
-11536	mediocre boozy cybeer	5	decent	Last Available: "2025-12"
+11536	boozy mediocre cybeer	5	decent	Last Available: "2025-12"
 11537	blinking ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	upside-down encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	upside-down encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	shaking baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	spinning stylish Crimbuccaneer war standard of the storm	0		Moxie: +25, Maximum MP Percent: +40, Last Available: "2023-12"
 11544	energetic hardy Elf Guard war standard	0		Maximum HP: +50, Maximum MP Percent: +20, Last Available: "2023-12"
 11545	olive in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	inspector's razor-sharp spring shoes of the empath	0		Weapon Damage Percent: +25, Familiar Weight: +5, Item Drop: +15, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	inspector's razor-sharp spring shoes of the empath	0		Weapon Damage Percent: +25, Familiar Weight: +5, Item Drop: +15, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	colloidal ultra-soft ferns	0		Effect: "Super Structure", Effect Duration: 30, Last Available: "2024-02"
 11548	moist upside-down crunchy brush	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 66, Last Available: "2024-02"
 11549	jittery huge smashed scientific equipment	0		
@@ -11424,12 +11424,12 @@
 11569	purple mansplainer's Lo Pan's sharpshooter's supercool Rosewater's Apriling band staff of wisdom	0		Mysticality: +15, Mysticality Percent: +30, Moxie Percent: +20, Critical Hit Percent: +10, Spell Critical Percent: +30, Monster Level: +15, Lasts Until Rollover
 11570	tumbling Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	wobbly boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11572	squat green Mayam Calendar	0		Free Pull, Last Available: "2024-05"
+11572	green squat Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	flavorless diet yam	1	decent	Last Available: "2024-05"
 11574	mediocre yam martini	3	decent	Last Available: "2024-05"
 11575	mediocre spinning sweet potato o' mine	3	decent	Last Available: "2024-05"
-11576	weak acceptable Southern yam	2	good	Last Available: "2024-05"
-11577	delicious weak sweet potato punch	2	awesome	Last Available: "2024-05"
+11576	acceptable weak Southern yam	2	good	Last Available: "2024-05"
+11577	weak delicious sweet potato punch	2	awesome	Last Available: "2024-05"
 11578	moldy Mayam spinach	3	crappy	Last Available: "2024-05"
 11579	normal yam and swiss	4	good	Last Available: "2024-05"
 11580	censurious reassuring Herculean yam cannon	0		Experience (Muscle): +1, Spooky Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,7 +11439,7 @@
 11584	spinning narrow perfumed sharpshooter's furry yam buckler of Leguizamo	0		Critical Hit Percent: +10, Monster Level: +20, Stench Resistance: +5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	curative stylish strapping yamtility belt	0		Muscle: +5, Moxie: +25, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-05"
-11587	spoiled diet yam slider	1	crappy	Last Available: "2024-05"
+11587	diet spoiled yam slider	1	crappy	Last Available: "2024-05"
 11588	yummy yam mayo	3	awesome	Last Available: "2024-05"
 11589	normal yam burrito	3	good	Last Available: "2024-05"
 11590	gray visual packet sniffer	0		Last Available: "2025-12"
@@ -11460,8 +11460,8 @@
 11605	inspector's nasty mini kiwi whipping stick	0		Stench Damage: +5, Item Drop: +15
 11606	sinister mini kiwi icepick	0		Spell Damage: +10
 11607	electrified mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 57
-11608	bouncing upside-down packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11608	upside-down bouncing packaged Roman Candelabra	0		Free Pull
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	tumbling protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11472,7 +11472,7 @@
 11617	purple proto-proto-protozoa	0		
 11618	adequate bouncing bacteria bisque	3	good	
 11619	stale ciliophora chowder	3	decent	
-11620	tiny delicious olive narrow cream of chloroplasts	1	awesome	
+11620	tiny delicious narrow olive cream of chloroplasts	1	awesome	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11506,11 +11506,11 @@
 11651	wholesome personal trainer's educational hat of remembering	0		Experience: +1, Experience Percent (Muscle): +10, Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
-11654	red twirling embering hunk	0		Last Available: "2024-09"
+11654	twirling red embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	auspicious resourceful sinister bat wings	0		Spell Damage: +10, Maximum MP: +50, Item Drop: +10, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	auspicious resourceful sinister bat wings	0		Spell Damage: +10, Maximum MP: +50, Item Drop: +10, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ghostly ember egg	0		Last Available: "2024-09"
 11660	mirror ember	0		Cold Resistance: +1
 11661	avaricious savvy monocle on a stick	0		Mysticality Percent: +20, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	jittery stanky Sheriff badge of extreme caution	0		Monster Level: -25, Stench Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	executive Sheriff pistol of the cheetah	0		Meat Drop: +40, Initiative: +60, Lasts Until Rollover, Last Available: "2024-10"
 11670	vibrating studded Sheriff moustache	0		Damage Absorption: +80, Maximum MP Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	weightlifter's photo booth supply list of courage	0		Muscle: +15, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	weightlifter's photo booth supply list of courage	0		Muscle: +15, Spooky Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	yummy whirled peas	3	awesome	Last Available: "2024-11"
@@ -11532,7 +11532,7 @@
 11677	powdered drenchrome 2.0	1		Last Available: "2025-12"
 11678	twisted squat Synapse Blaster	1		Last Available: "2025-12"
 11679	skewed quantized familiar	0		
-11680	blinking upside-down quantum watch	0		Adventures: +2
+11680	upside-down blinking quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	enhanced extra-cold-filtered Vulcanized olive pea brittle	0		Effect: "Insatiable Hunger", Effect Duration: 19, Last Available: "2024-11"
 11683	weak drinkable teal peasco	2	good	Last Available: "2024-11"
@@ -11541,7 +11541,7 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	lard-coated dance instructor's deft pirate hook	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
-11689	spinning beefcake's iron tricorn hat of the wise owl	0		Muscle: +25, Mysticality: +20, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	spinning beefcake's iron tricorn hat of the wise owl	0		Muscle: +25, Mysticality: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	shaking upside-down therapeutic jolly roger flag	0		HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
@@ -11569,21 +11569,21 @@
 11714	twirling greedy plastic Colonel Brando of Leguizamo	0		Monster Level: +20, Meat Drop: +20, Last Available: "2024-12"
 11715	jittery wobbly nasty plastic Jedediah and Boiling Cloud	0		Stench Damage: +5, Last Available: "2024-12"
 11716	blurry prompt plastic &quot;Santa Claus&quot;	0		Adventures: +3, Last Available: "2024-12"
-11717	squat blinking Spirit of Easter	0		Last Available: "2024-12"
+11717	blinking squat Spirit of Easter	0		Last Available: "2024-12"
 11718	skewed narrow Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	skewed Spirit of Christmas	0		Last Available: "2024-12"
-11722	huge moldy mirror coney haunch	8	crappy	Last Available: "2024-12"
+11722	moldy huge mirror coney haunch	8	crappy	Last Available: "2024-12"
 11723	extra-quantum huge dark chocolate egg	0		Effect: "Pretending to Pretend", Effect Duration: 19, Last Available: "2024-12"
-11724	delicious weak moai toai	2	awesome	
+11724	weak delicious moai toai	2	awesome	
 11725	blue dangerous moaiball of Tarzan of the empath	0		Experience (Muscle): +3, Weapon Damage: +10, Familiar Weight: +5, Last Available: "2024-12"
 11726	mirror half-digested rat	0		Last Available: "2024-12"
 11727	aerosolized bouncing four-leaf potato sprout	0		Effect: "Greasy Visage", Effect Duration: 57, Last Available: "2024-12"
 11728	ghostly asbestos-lined Lo Pan's potato jacket of temperance	0		Spell Critical Percent: +30, Hot Resistance: +5, Sleaze Resistance: +5, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
-11730	wobbly spinning Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Sherlock's military orb of the boozehound	0		Item Drop: +25, Booze Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11730	spinning wobbly Brandonian footlocker key	0		Last Available: "2024-12"
+11731	Sherlock's military orb of the boozehound	0		Item Drop: +25, Booze Drop: +100, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	ionized twirling rum ball	0		Effect: "Spirit of Alph", Effect Duration: 29
 11733	gravy skin	0		Last Available: "2024-12"
 11734	upside-down reassuring strapping gravyskin hat	0		Muscle: +5, Spooky Resistance: +1, Last Available: "2024-12"
@@ -11591,64 +11591,64 @@
 11736	narrow horrifying Rosewater's gravyskin skirt	0		Mysticality Percent: +30, Spooky Damage: +25, Last Available: "2024-12"
 11737	occult gravyskin pants of the glutton	0		Spell Damage Percent: +25, Food Drop: +100, Last Available: "2024-12"
 11738	colloidal crystallized pumpkin spice	0		Effect: "Sugar Smacks", Effect Duration: 56, Last Available: "2024-12"
-11739	gigantic flavorless room scale bean casserole	9	decent	Last Available: "2024-12"
+11739	flavorless gigantic room scale bean casserole	9	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	skewed perfect Christmas scarf of extreme caution of bravery of temperance	0		Monster Level: [-25*event(December)], Spooky Resistance: [+5*event(December)], Sleaze Resistance: [+5*event(December)], Single Equip, Last Available: "2024-12"
-11743	mirror Usain Bolt's snowman-enchanting tophat of the cougar	0		Moxie: +20, Initiative: +80, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	mirror Usain Bolt's snowman-enchanting tophat of the cougar	0		Moxie: +20, Initiative: +80, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	polarized LIDAR candle	0		Effect: "Punch Another Day", Effect Duration: 66, Last Available: "2024-12"
 11745	green miser's fortified forbidden Congressional Medal of Insanity	0		Spell Damage Percent: +50, Damage Absorption: +60, Meat Drop: +10, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	artisanal watered-down spinning Easter grasshopper	2	EPIC	Last Available: "2024-12"
 11748	drinkable blinking Irish eggnog	3	good	Last Available: "2024-12"
-11749	practically non-alcoholic artisanal canteen of jungle juice	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11749	artisanal practically non-alcoholic canteen of jungle juice	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11750	practically non-alcoholic acceptable turchucken	1	good	Last Available: "2024-12"
-11751	hand-crafted practically non-alcoholic lime green bouncing mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11751	practically non-alcoholic hand-crafted lime green bouncing mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11752	artisanal strong red holiday trip around the world	5	EPIC	Last Available: "2024-12"
 11753	immense moldy blinking chocolate ostrich egg	9	crappy	Last Available: "2024-12"
 11754	diet moldy teal beef and cabbage	1	crappy	Last Available: "2024-12"
 11755	yummy candy rations	3	awesome	Last Available: "2024-12"
 11756	half-sized bland double-candied yams	2	decent	Last Available: "2024-12"
-11757	decent immense Christmas ham	7	good	Last Available: "2024-12"
+11757	immense decent Christmas ham	7	good	Last Available: "2024-12"
 11758	decent upside-down holiday smorgasbord	4	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	hardened bejazzled eyepatch	0		Damage Reduction: 3, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	fuchsia Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	wobbly Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	fuchsia Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	wobbly Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	flame-retardant educational sage egg gun of the blizzard	0		Mysticality Percent: +10, Experience: +1, Cold Spell Damage: +25, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	flame-retardant educational sage egg gun of the blizzard	0		Mysticality Percent: +10, Experience: +1, Cold Spell Damage: +25, Hot Resistance: +1, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	occult wicked weightlifter's army helmet of the ox	0		Muscle: 35, Spell Damage: +5, Spell Damage Percent: +25, Last Available: "2024-12"
 11774	shaking candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
 11776	moldy Thanksgiving ration	3	crappy	Last Available: "2024-12"
-11777	special bad Easter eggnog	3	decent	Effect: "The Moxious Madrigal", Effect Duration: 10, Last Available: "2024-12"
+11777	bad special Easter eggnog	3	decent	Effect: "The Moxious Madrigal", Effect Duration: 10, Last Available: "2024-12"
 11778	dried clovermint	1		Effect: "Stop and Smell the Fudge", Effect Duration: 35, Last Available: "2024-12"
 11779	Jim Carey's steel-toed extremely unsafe grievous nylon Christmas stockings	0		Weapon Damage Percent: 150, Damage Reduction: 9, Monster Level: +25, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	moist deviled candy egg	0		Effect: "Thick-Skinned", Effect Duration: 45, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	twirling crafty savvy McHugeLarge duffel bag	0		Mysticality Percent: +20, Maximum MP: +10, Last Available: "2025-01"
-11784	red smelly resourceful supercool McHugeLarge left pole	0		Moxie Percent: +20, Maximum MP: +50, Stench Spell Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	energetic McHugeLarge right pole of the sewer of courage	0		Maximum MP Percent: +20, Stench Damage: +25, Spooky Resistance: +3, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	blinking Samson's Rosewater's McHugeLarge left ski	0		Mysticality Percent: +30, Experience (Muscle): +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	healthy McHugeLarge right ski of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	red smelly resourceful supercool McHugeLarge left pole	0		Moxie Percent: +20, Maximum MP: +50, Stench Spell Damage: +10, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	energetic McHugeLarge right pole of the sewer of courage	0		Maximum MP Percent: +20, Stench Damage: +25, Spooky Resistance: +3, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	blinking Samson's Rosewater's McHugeLarge left ski	0		Mysticality Percent: +30, Experience (Muscle): +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	healthy McHugeLarge right ski of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
-11790	distilled jittery blurry eXpand	1		Last Available: "2025-12"
-11791	narrow brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11790	distilled blurry jittery eXpand	1		Last Available: "2025-12"
+11791	narrow brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	narrow dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	skewed dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
-11796	tumbling fuchsia dedigitizer schematic: digibritches	0		Last Available: "2025-12"
+11796	fuchsia tumbling dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	tumbling dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	jittery dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	upside-down cybervisor	0		Last Available: "2025-12"
 11804	fuchsia retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	wobbly server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	blurry insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	skewed ghostly hashing vise	0		Last Available: "2025-12"
-11827	squat geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	squat geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	bouncing geofencing shield	0		Last Available: "2025-12"
 11829	upside-down virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11716,33 +11716,33 @@
 11861	Leprecondo	0		Last Available: "2025-03"
 11862	twisted mirror scoop of pre-workout powder	1		Effect: "Fury of the Bells", Effect Duration: 35, Last Available: "2025-03"
 11863	shaking olive table tennis ball	0		Last Available: "2025-03"
-11864	weak artisanal enchanted bouncing huge pint of Leprechaun Stout	2	EPIC	Effect: "Cold Throat", Effect Duration: 45, Last Available: "2025-03"
+11864	enchanted weak artisanal bouncing huge pint of Leprechaun Stout	2	EPIC	Effect: "Cold Throat", Effect Duration: 45, Last Available: "2025-03"
 11865	mixed squat phosphor traces	1		Last Available: "2025-03"
 11866	ghostly crafting plans	0		Last Available: "2025-03"
 11867	ghostly Book of Irony	0		Skill: "Generate Irony"
 11868	twirling spoon	0		
 11869	wobbly unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
-11871	dehydrated maroon pulsating blinking leprechaun antidepressant pill	1		Effect: "Hairy Palms", Effect Duration: 15, Last Available: "2025-03"
-11872	spoiled miniature Heck ramen	2	crappy	Last Available: "2025-03"
+11871	dehydrated maroon blinking pulsating leprechaun antidepressant pill	1		Effect: "Hairy Palms", Effect Duration: 15, Last Available: "2025-03"
+11872	miniature spoiled Heck ramen	2	crappy	Last Available: "2025-03"
 11873	bland burrito	3	decent	Last Available: "2025-03"
 11874	half-sized rotten small beer brat	2	crappy	Last Available: "2025-03"
 11875	spoiled peach pie	3	crappy	Last Available: "2025-03"
 11876	adequate tumbling incredible mini-pizza	3	good	Last Available: "2025-03"
 11877	lousy Divine sidecar	4	decent	Last Available: "2025-03"
-11878	triple-distilled drinkable tangarita sidecar	7	good	Last Available: "2025-03"
-11879	high-proof acceptable gimlet sidecar	6	good	Last Available: "2025-03"
+11878	drinkable triple-distilled tangarita sidecar	7	good	Last Available: "2025-03"
+11879	acceptable high-proof gimlet sidecar	6	good	Last Available: "2025-03"
 11880	triple-distilled bad vodka stratocaster sidecar	7	decent	Last Available: "2025-03"
 11881	smooth teal prussian cathouse sidecar	4	awesome	Last Available: "2025-03"
-11882	watered-down lousy Mon Tiki sidecar	2	decent	Last Available: "2025-03"
+11882	lousy watered-down Mon Tiki sidecar	2	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	spinning flame-wreathed forbidden April Shower Thoughts shield	0		Spell Damage Percent: +50, Hot Spell Damage: +10, Damage Reduction: 6, Last Available: "2025-04"
-11885	cyan spinning glob of wet paper	0		Last Available: "2025-04"
+11885	spinning cyan glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	cold-filtered spinning wet paper weights	0		Effect: "Tin, Man", Effect Duration: 66, Last Available: "2025-04"
 11888	lousy Three Sheets to the Wind	3	decent	Last Available: "2025-04"
-11889	enchanted stale huge pile of wet dates	6	decent	Effect: "Wasabi With You", Effect Duration: 5, Last Available: "2025-04"
-11890	jittery blurry papier Mach 1 airplane	0		Last Available: "2025-04"
+11889	stale enchanted huge pile of wet dates	6	decent	Effect: "Wasabi With You", Effect Duration: 5, Last Available: "2025-04"
+11890	blurry jittery papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	tumbling wet blanket	0		Last Available: "2025-04"
 11892	squat wet shower cap of bravery	0		Spooky Resistance: +5, Last Available: "2025-04"
 11893	energetic wet shower shoes	0		Maximum MP Percent: +20, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	wool stylish bycocket	0		Cold Resistance: +1
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	bouncing green flak shield	0		Damage Reduction: 9
 11921	purple Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11788,9 +11788,9 @@
 11933	gray lightning-fast stiffened educational Allied Radio Backpack	0		Experience: +1, Damage Reduction: 1, Initiative: +40, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	upside-down orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
-11936	twirling wobbly confetti grenade	0		
-11937	spoiled immense special upside-down huge Skeleton Wars rations	8	crappy	Effect: "Egg-stortionary Tactics", Effect Duration: 15
-11938	high-proof mediocre maroon skeleton war fuel can	10	decent	
+11936	wobbly twirling confetti grenade	0		
+11937	spoiled special immense upside-down huge Skeleton Wars rations	8	crappy	Effect: "Egg-stortionary Tactics", Effect Duration: 15
+11938	mediocre high-proof maroon skeleton war fuel can	10	decent	
 11939	huge skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,9 +11804,9 @@
 11949	gray resourceful bully badge	0		Maximum MP: +50, Lasts Until Rollover, Last Available: "2025-08"
 11950	MacGyver's time cop top hat	0		Maximum MP: +100, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	boiled pulsating green mixed berry jelly	1		Last Available: "2025-08"
+11952	boiled green pulsating mixed berry jelly	1		Last Available: "2025-08"
 11953	decent toast with mixed berry jelly	3	good	Last Available: "2025-08"
-11954	normal small cup of sugar	2	good	Last Available: "2025-08"
+11954	small normal cup of sugar	2	good	Last Available: "2025-08"
 11955	spoiled Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	ghostly frightening supercharged Sinatra's the gun	0		Experience (Moxie): +5, Maximum MP Percent: +30, Spooky Damage: +5, Last Available: "2025-08"
@@ -11814,7 +11814,7 @@
 11960	green really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	foul-smelling undersea surveying goggles	0		Stench Damage: +10, Lasts Until Rollover
-11963	practically non-alcoholic tolerable shaking Ocean-Touched Rum	1	good	
+11963	tolerable practically non-alcoholic shaking Ocean-Touched Rum	1	good	
 11964	diluted water-logged pill	1		Effect: "Springy Fusilli", Effect Duration: 25
 11965	thick moldy spinning kelp puck	5	crappy	
 11966	spinning scroll of sea strength	0		
@@ -11826,34 +11826,34 @@
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	red packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	maroon unblemished pearl	0		
 11977	dentadent of Calamity Jane	0		Critical Hit Percent: +15
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	medical-grade hardened occult experienced strapping blood cubic zirconia of wisdom	0		Muscle: +5, Mysticality: +15, Experience: +2, Spell Damage Percent: +25, Damage Reduction: 3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	medical-grade hardened occult experienced strapping blood cubic zirconia of wisdom	0		Muscle: +5, Mysticality: +15, Experience: +2, Spell Damage Percent: +25, Damage Reduction: 3, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	distilled blood thinner	1		Effect: "Items Are Forever", Effect Duration: 30, Last Available: "2025-10"
 12045	smooth pheromone cocktail	4	awesome	Last Available: "2025-10"
 12046	yummy spinal tapas	4	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	squat mansplainer's smartaleck's stylish shrunken head	0		Moxie: +25, Moxie Percent: +30, Monster Level: +15, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	squat mansplainer's smartaleck's stylish shrunken head	0		Moxie: +25, Moxie Percent: +30, Monster Level: +15, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	lousy enchanted Smoking Pope	3	decent	Effect: "Incredibly Hulking", Effect Duration: 45
-12053	snack-sized rotten mirror prize turkey	2	crappy	
+12052	enchanted lousy Smoking Pope	3	decent	Effect: "Incredibly Hulking", Effect Duration: 45
+12053	rotten snack-sized mirror prize turkey	2	crappy	
 12054	altered medicinal gruel	1		
 12055	spoiled full-sized pumpkin pie	4	crappy	Last Available: "2025-11"
-12056	delicious triple-distilled tumbling vodka cranberry sauce	6	awesome	Last Available: "2025-11"
+12056	triple-distilled delicious tumbling vodka cranberry sauce	6	awesome	Last Available: "2025-11"
 12057	tarnished yammed candy	0		Effect: "Wax On Your Shoes", Effect Duration: 17, Last Available: "2025-11"
 12058	adequate treasure chestnut	4	good	Last Available: "2025-12"
 12059	drinkable spinning mulled butter rum	3	good	Last Available: "2025-12"
-12060	triple-pickled concentrated maroon pulsating cinnamon doubloon	0		Effect: "Oth-Jeal-O", Effect Duration: 48, Last Available: "2025-12"
+12060	triple-pickled concentrated pulsating maroon cinnamon doubloon	0		Effect: "Oth-Jeal-O", Effect Duration: 48, Last Available: "2025-12"
 12061	bouncing careful plastic left skeleton arm	0		Monster Level: -10, Last Available: "2025-12"
 12062	twirling rosy-cheeked plastic left skeleton leg	0		Maximum HP Percent: +30, Last Available: "2025-12"
 12063	gray chilly plastic right skeleton arm	0		Cold Damage: +5, Last Available: "2025-12"
 12064	wobbly squat resourceful plastic right skeleton leg	0		Maximum MP: +50, Last Available: "2025-12"
 12065	lime green plastic skeleton pelvis of incineration	0		Hot Spell Damage: +50, Last Available: "2025-12"
-12066	skewed ghostly narrow discreetly-wrapped Eternity Codpiece	0		Free Pull, Last Available: "2026-12"
+12066	ghostly skewed narrow discreetly-wrapped Eternity Codpiece	0		Free Pull, Last Available: "2026-12"
 12067	The Eternity Codpiece	0		Muscle: +5, Mysticality: +5, Moxie: +5, Single Equip, Last Available: "2026-12"
 12068	veiny banded angelbone kilt	0		Damage Absorption: +100, Maximum HP: +10, Last Available: "2026-12"
 12069	Newton's angelbone totem	0		Experience (Mysticality): +3, Single Equip, Last Available: "2026-12"
@@ -11869,7 +11869,7 @@
 12079	fortified devilbone corset	0		Damage Absorption: +60, Last Available: "2026-12"
 12080	Annie Oakley's devilbone flute of Tarzan	0		Experience (Muscle): +3, Critical Hit Percent: +20, Last Available: "2026-12"
 12081	padded devilbone rosary	0		Damage Absorption: +20, Single Equip, Last Available: "2026-12"
-12082	diluted teal blinking devilbone chunks	1		Last Available: "2026-12"
+12082	diluted blinking teal devilbone chunks	1		Last Available: "2026-12"
 12083	boiled vacuum-sealed Gehenna tattoo	0		Effect: "Human-Machine Hybrid", Effect Duration: 56
 12116	purple mirror burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	unsweetened triple-magnetized boiling synovial fluid	0		Effect: "Hammertime", Effect Duration: 55, Last Available: "2025-12"
 12132	lime green frightening smoldering vertebra of chilblains of the sweet-tooth	0		Cold Damage: +25, Spooky Damage: +5, Candy Drop: +100, Single Equip, Last Available: "2025-12"
 12133	maroon seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	shaking lightning-fast energetic hot boning knife of the scaredy-cat	0		Maximum MP Percent: +20, Monster Level: -15, Initiative: +40, Single Equip, Last Available: "2025-12"
@@ -11928,7 +11928,7 @@
 12170	manspreader's forbidden heat-resistant harpoon pistol	0		Spell Damage Percent: +50, Monster Level: +10, Last Available: "2025-12"
 12171	immense stale traditional gingerloaf	8	decent	Last Available: "2025-12"
 12172	artisanal blue Scotch and eggnog	4	EPIC	Last Available: "2025-12"
-12173	activated magnetized twirling bouncing counterskeleton elixir	0		Effect: "Chalked Weapon", Effect Duration: 40, Last Available: "2025-12"
+12173	activated magnetized bouncing twirling counterskeleton elixir	0		Effect: "Chalked Weapon", Effect Duration: 40, Last Available: "2025-12"
 12174	hand-crafted &quot;salvaged&quot; wine	4	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	energized magnetized vacuum-sealed gummi fingerbone	0		Effect: "Flagrantly Fragrant", Effect Duration: 45
 12179	spinning fireproof glimmering crystal of bravery	0		Hot Resistance: +3, Spooky Resistance: +5, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	ghostly Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11946,7 +11946,7 @@
 12188	wobbly 2015 landfill detritus	0		Last Available: "2026-03"
 12189	yellow intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
-12191	red narrow unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
+12191	narrow red unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	diffused Pork Elf mouthwash	0		Effect: "Improved Candy Vision", Effect Duration: 69, Last Available: "2026-03"
 12194	liquefied bouncing Pork Elf deodorant	0		Effect: "Bark of the Dog", Effect Duration: 12, Last Available: "2026-03"
@@ -11969,7 +11969,7 @@
 12211	smelly Annie Oakley's supercool hoverboard	0		Moxie Percent: +20, Critical Hit Percent: +20, Stench Spell Damage: +10, Single Equip, Last Available: "2026-03"
 12212	narrow Fonzie's educational Rosewater's left shark fin	0		Mysticality Percent: +30, Experience: +1, Experience (Moxie): +1, Last Available: "2026-03"
 12213	rock-hard fitness tracking bracelet	0		Damage Reduction: 5, Single Equip, Last Available: "2026-03"
-12214	denatured gray blinking narrow candy bone	1		Effect: "Stop and Smell the Fudge", Effect Duration: 25
+12214	denatured gray narrow blinking candy bone	1		Effect: "Stop and Smell the Fudge", Effect Duration: 25
 12215	ghostly olive wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	tasty huge discarded hot dog	4	awesome	Last Available: "2026-04"
@@ -11979,16 +11979,16 @@
 12225	lime green legendary noodles	0		Last Available: "2026-05"
 12226	stale can of tuna	4	decent	
 12227	spoiled alien salad	3	crappy	
-12228	moldy half-sized ratbatatouille	2	crappy	
+12228	half-sized moldy ratbatatouille	2	crappy	
 12229	normal fancy jittery onigiri	3	good	Effect: "Memento Moir&eacute;", Effect Duration: 35
 12230	spoiled crudit&eacute;s	3	crappy	
 12231	small spoiled blinking sauced mutton	2	crappy	
-12232	tiny bland skewed hot honey ant	1	decent	
+12232	bland tiny skewed hot honey ant	1	decent	
 12233	stale snack-sized bouncing tomb aspic	2	decent	
 12234	adequate squat later tots	4	good	
 12235	spoiled tumbling Frutti di Scatoletta	4	crappy	Last Available: "2026-05"
 12236	gigantic flavorless Pesto alla Marziano	8	decent	Last Available: "2026-05"
-12237	moldy special Arrattabbattabiata	3	crappy	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2026-05"
+12237	special moldy Arrattabbattabiata	3	crappy	Effect: "Tiki Thoughtfulness", Effect Duration: 15, Last Available: "2026-05"
 12238	rotten jittery Orzo di Riso	3	crappy	Last Available: "2026-05"
 12239	spoiled cyan Pasta Grimavera	3	crappy	Last Available: "2026-05"
 12240	moldy enchanted Linguini Ubriacapa	4	crappy	Effect: "Stands Alone", Effect Duration: 5, Last Available: "2026-05"
@@ -12017,14 +12017,14 @@
 12267	lime green flimsy plastic breastplate of wisdom	0		Mysticality: +15
 12268	huge thinker's flimsy plastic shield	0		Mysticality: +10, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	squat Sherlock's stylish Portable Laughing Stock of the bloodbag	0		Moxie: +25, Maximum HP: +100, Item Drop: +25, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	squat Sherlock's stylish Portable Laughing Stock of the bloodbag	0		Moxie: +25, Maximum HP: +100, Item Drop: +25, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	greasy careful strapping Staff of Anachronistic Churning	0		Muscle: +5, Monster Level: -10, Sleaze Spell Damage: +10
 12272	miniature rotten classic banana	2	crappy	Last Available: "2026-07"
 12273	flavorless tumbling watermelon	3	decent	Last Available: "2026-07"
-12274	low-calorie rotten jittery quince	1	crappy	Last Available: "2026-07"
+12274	rotten low-calorie jittery quince	1	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	yummy squat olive classic banana pie	3	awesome	Last Available: "2026-07"
+12277	yummy olive squat classic banana pie	3	awesome	Last Available: "2026-07"
 12278	boiled essential banana decoction	0		Effect: "Vitamin-Maxed", Effect Duration: 56, Last Available: "2026-07"
 12279	polymerized double-improved irradiated purple banana quintessence	0		Effect: "Drunk With Power", Effect Duration: 38, Last Available: "2026-07"
 12280	drinkable Aesop Daiquiri	3	good	Last Available: "2026-07"
@@ -12042,7 +12042,7 @@
 12292	artisanal bouncing Roth IPA	4	EPIC	Last Available: "2026-08"
 12293	squat underdraft protection of the cougar of the empath	0		Moxie: +20, Familiar Weight: +5, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	moldy huge soybean futures	6	crappy	Last Available: "2026-08"
+12295	huge moldy soybean futures	6	crappy	Last Available: "2026-08"
 12296	galvanized huge housing bubble	0		Effect: "Well-preserved", Effect Duration: 20, Last Available: "2026-08"
 12297	magnetized blurry Pixie-Swordz	0		Effect: "Ironclad", Effect Duration: 44
 12298	healthy financial instrument of courage	0		Maximum HP Percent: +20, Spooky Resistance: +3, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Marmot_cafe_booze.txt
@@ -1,11 +1,11 @@
 -1	drinkable huge Petite Porter	3	good	
--2	perfectly mixed spirit-forward Scrawny Stout	5	EPIC	
+-2	spirit-forward perfectly mixed Scrawny Stout	5	EPIC	
 -3	bad Infinitesimal IPA	4	decent	
--4	acceptable weak eggnogtini	2	good	
--5	watered-down tolerable special candycaine	2	good	
+-4	weak acceptable eggnogtini	2	good	
+-5	special tolerable watered-down candycaine	2	good	
 -6	acceptable braincracker sweet	3	good	
--16	perfectly mixed weak fermented honey	2	EPIC	
--17	artisanal fortified skewed moons-shine	5	EPIC	
+-16	weak perfectly mixed fermented honey	2	EPIC	
+-17	fortified artisanal skewed moons-shine	5	EPIC	
 -18	delicious gin	3	awesome	
 -19	bad ecto-nog	3	decent	
 -20	tolerable watered-down hot toady	2	good	
@@ -13,21 +13,21 @@
 -49	aged mirror Cyder	3	awesome	
 -50	hand-crafted blurry Oil Nog	4	EPIC	
 -51	bad Hi-Octane Peppermint Jet Fuel	3	decent	
--58	weak acceptable Grimacider	2	good	
+-58	acceptable weak Grimacider	2	good	
 -59	weak hand-crafted Isotope Nog	2	EPIC	
 -60	acceptable Mutagin 'n' Tonic	3	good	
--70	hand-crafted weak Gin and Herring	2	EPIC	
--71	practically non-alcoholic aged mirror Black and Tan and Red All Over	1	awesome	
+-70	weak hand-crafted Gin and Herring	2	EPIC	
+-71	aged practically non-alcoholic mirror Black and Tan and Red All Over	1	awesome	
 -72	bad Antarctic Ice Tea	3	decent	
 -76	tolerable CRIMBCO Ribbon Candy Schnapps	3	good	
 -77	artisanal CRIMBCO Egg Substitute Nog Substitute	4	EPIC	
 -78	artisanal weak olive CRIMBCO Extreme Braincracker Sour	2	EPIC	
 -82	practically non-alcoholic mediocre blue Horseradish-infused Vodka	1	decent	
 -83	artisanal maroon Jerkitini	4	EPIC	
--84	drinkable irresponsibly strong Desert Island Iced Tea	7	good	
+-84	irresponsibly strong drinkable Desert Island Iced Tea	7	good	
 -88	hand-crafted Crimbo Saketini	3	EPIC	
 -89	smooth Crimboku Drop	4	awesome	
--90	practically non-alcoholic drinkable narrow Flaming Crimbo Log	1	good	
+-90	drinkable practically non-alcoholic narrow Flaming Crimbo Log	1	good	
 -107	acceptable Fortified Eggnog Slurry	4	good	
 -108	hand-crafted weak Hot Buttered Rum	2	EPIC	
 -109	tolerable Spicy Hot Chocolate	4	good	

--- a/data/TCRS/TCRS_Sauceror_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Marmot_cafe_food.txt
@@ -8,35 +8,35 @@
 -11	rotten snack-sized gray shoots and leaves	2	crappy	
 -12	special flavorless bowl of unidentifiable goo	4	decent	
 -13	spoiled red gingerbread massacre	3	crappy	
--14	tasty maroon blurry It Came From Beyond Dessert	4	awesome	
+-14	tasty blurry maroon It Came From Beyond Dessert	4	awesome	
 -15	spoiled gray vampire cake	3	crappy	
--52	special normal Soylent Red and Green	3	good	
+-52	normal special Soylent Red and Green	3	good	
 -53	tasty gigantic upside-down Disc-Shaped Nutrition Unit	9	awesome	
 -54	toothsome narrow Gingerborg Hive	3	awesome	
 -61	stale Candy Cane Surprise	4	decent	
--62	stale half-sized blinking Grimdrop Chow Mein	2	decent	
+-62	half-sized stale blinking Grimdrop Chow Mein	2	decent	
 -63	normal huge Grimgerbread House	3	good	
--67	flavorless half-sized Caviar Carbonara	2	decent	
+-67	half-sized flavorless Caviar Carbonara	2	decent	
 -68	fancy decent bouncing Halibut Alfredo	3	good	
--69	bland tiny Red Herring Velvet Cake	1	decent	
+-69	tiny bland Red Herring Velvet Cake	1	decent	
 -73	tasty mirror CRIMBCO Reconstituted Gruel	3	awesome	
 -74	immense moldy New and Improved CRIMBCO Reconstituted Gruel	6	crappy	
 -75	decent CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
--79	toothsome low-calorie upside-down Brussels Sprout Stir-Fry	1	awesome	
+-79	low-calorie toothsome upside-down Brussels Sprout Stir-Fry	1	awesome	
 -80	snack-sized rotten Carrot, Cabbage, and Kale Pizza	2	crappy	
 -81	normal Turnip and Rutabaga Pie	3	good	
 -85	adequate bite-sized Rainbow Spider Fun Roll	1	good	
 -86	stale Vegas Volcano Lava Roll	3	decent	
--87	half-sized decent Crazy Dragon Shogun Buddha Roll	2	good	
+-87	decent half-sized Crazy Dragon Shogun Buddha Roll	2	good	
 -92	flavorless basic hot dog	3	decent	
 -93	bland savage macho dog	4	decent	
 -94	stale one with everything	4	decent	
 -95	moldy sly dog	4	crappy	
--96	tiny normal fuchsia devil dog	1	good	
--97	rotten big chilly dog	5	crappy	
--98	big rotten pulsating ghost dog	5	crappy	
--99	adequate pulsating narrow junkyard dog	4	good	
--100	rotten tiny blinking fuchsia wet dog	1	crappy	
+-96	normal tiny fuchsia devil dog	1	good	
+-97	big rotten chilly dog	5	crappy	
+-98	rotten big pulsating ghost dog	5	crappy	
+-99	adequate narrow pulsating junkyard dog	4	good	
+-100	tiny rotten blinking fuchsia wet dog	1	crappy	
 -101	super-sized spoiled sleeping dog	5	crappy	
 -102	normal massive optimal dog	10	good	
 -103	stale immense video games hot dog	8	decent	

--- a/data/TCRS/TCRS_Sauceror_Mongoose.txt
+++ b/data/TCRS/TCRS_Sauceror_Mongoose.txt
@@ -39,13 +39,13 @@
 40	casino pass	0		
 41	aged ice-cold Sir Schlitz	3	awesome	
 42	maroon bouncing hermit permit	0		
-43	tumbling spinning worthless trinket	0		
+43	spinning tumbling worthless trinket	0		
 44	worthless gewgaw	0		
 45	huge worthless knick-knack	0		
 46	pulsating figurine	0		
 47	half-sized rotten hot buttered roll	2	crappy	
 48	heart of rock and roll	0		
-49	decent diet bowl of cottage cheese	1	good	
+49	diet decent bowl of cottage cheese	1	good	
 50	Rock and Roll Legend of the glutton	0		Food Drop: +100, Class: "Accordion Thief", Song Duration: 10
 51	ghostly green blinking pulsating energetic Knob Goblin Uberpants	0		Maximum MP Percent: +20, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	blurry banjo strings	0		
@@ -59,7 +59,7 @@
 60	asbestos-lined Mace of the Tortoise	0		Hot Resistance: +5, Class: "Turtle Tamer"
 61	normal fortune cookie	4	good	
 62	deadly oriole-feather headdress	0		Weapon Damage: +5, Familiar Effect: "atk, 3xVolley, cap 3"
-63	lime green bouncing action figure body	0		
+63	bouncing lime green action figure body	0		
 64	action figure head	0		
 65	blurry mirror Mighty Bjorn action figure	0		
 66	twig	0		
@@ -157,21 +157,21 @@
 158	Gnollish pie tin	0		
 159	bouncing wad of dough	0		
 160	wobbly pie crust	0		
-161	jumbo stale ghuol egg	5	decent	
+161	stale jumbo ghuol egg	5	decent	
 162	adequate half-sized narrow ghuol egg quiche	2	good	
 163	grievous skeleton bone	0		Weapon Damage Percent: +50
 164	smart skull	0		
 165	blue skewer	0		
-166	cyan jittery ghuol ears	0		
+166	jittery cyan ghuol ears	0		
 167	bland ghuol-ear kabob	4	decent	
 168	experienced bone rattle	0		Experience: +2
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
 171	flavorless lihc eye pie	3	decent	
-172	cyan squat gnoll lips	0		
+172	squat cyan gnoll lips	0		
 173	taco shell	0		
 174	huge squat Gnollish casserole dish	0		
-175	enchanted toothsome uncooked chorizo	3	awesome	Effect: "Action", Effect Duration: 40
+175	toothsome enchanted uncooked chorizo	3	awesome	Effect: "Action", Effect Duration: 40
 176	blinking disembodied brain	0		
 177	skewed brainy skull	0		
 178	detective skull	0		
@@ -205,7 +205,7 @@
 207	special hippy herbal tea	1	decent	Effect: "Abominably Slippery", Effect Duration: 35
 208	patchouli incense stick	0		
 209	wad of tofu	0		
-210	upside-down red Feng Shui for Big Dumb Idiots	0		
+210	red upside-down Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
 212	windchimes	0		
 213	Temple Grandin's filthy corduroys of terror	0		Familiar Weight: +7, Spooky Spell Damage: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
@@ -214,7 +214,7 @@
 216	rotten carob brownies	3	crappy	
 217	normal herb brownies	4	good	
 218	green spinning hemp string	0		
-219	ghostly yellow necklace chain	0		
+219	yellow ghostly necklace chain	0		
 220	red gnoll teeth	0		
 221	arcane researcher's gnoll-tooth necklace	0		Experience Percent (Mysticality): +10
 222	narrow phat turquoise bead	0		
@@ -240,14 +240,14 @@
 242	small rotten huge	2	crappy	
 243	small spoiled grapefruit	2	crappy	
 244	decent gigantic grapes	6	good	
-245	small moldy blinking olive	2	crappy	
+245	moldy small blinking olive	2	crappy	
 246	moldy thick tomato	5	crappy	
 247	pulsating fermenting powder	0		
 248	tolerable ghostly salty dog	3	good	
 249	tolerable ghostly teal bloody mary	3	good	
 250	bad screwdriver	3	decent	
-251	triple-distilled hand-crafted martini	10	EPIC	
-252	practically non-alcoholic tolerable bloody beer	1	good	
+251	hand-crafted triple-distilled martini	10	EPIC	
+252	tolerable practically non-alcoholic bloody beer	1	good	
 253	practically non-alcoholic hand-crafted shot of schnapps	1	EPIC	
 254	perfectly mixed extra-dry shot of grapefruit schnapps	5	EPIC	
 255	smooth fine wine	3	awesome	
@@ -272,7 +272,7 @@
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	shaking leprechaun hatchling	0		
-277	diluted blurry shaking extra-strength strongness elixir	1		
+277	diluted shaking blurry extra-strength strongness elixir	1		
 278	altered jug-o-magicalness	1		
 279	mixed spinning suntan lotion of moxiousness	1		Effect: "Crimbo Flavor", Effect Duration: 50
 280	Pick-O-Matic lockpicks	0		
@@ -311,12 +311,12 @@
 313	Crown of the Goblin King of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	tasty squat bean burrito	4	awesome	
 315	tiny rotten bean burrito	1	crappy	
-316	spoiled special thick insanely bean burrito	5	crappy	Effect: "Stimulated Body", Effect Duration: 20
+316	spoiled thick special insanely bean burrito	5	crappy	Effect: "Stimulated Body", Effect Duration: 20
 317	rotten special bean burrito	3	crappy	Effect: "The Solution", Effect Duration: 40
 318	normal bean burrito	4	good	
-319	immense tasty wobbly insanely bean burrito	6	awesome	
+319	tasty immense wobbly insanely bean burrito	6	awesome	
 320	spoiled red bat haggis	4	crappy	
-321	decent bite-sized pulsating menudo	1	good	
+321	bite-sized decent pulsating menudo	1	good	
 322	moldy red goat cheese	3	crappy	
 323	special rotten plain pizza	4	crappy	Effect: "Spore-Wreathed", Effect Duration: 35
 324	bland sausage pizza	3	decent	
@@ -365,7 +365,7 @@
 367	linoleum stick	0		
 368	gray linoleum crossbow string	0		
 369	asbestos sword hilt	0		
-370	pulsating spinning asbestos stick	0		
+370	spinning pulsating asbestos stick	0		
 371	asbestos crossbow string	0		
 372	chrome sword hilt	0		
 373	olive chrome stick	0		
@@ -417,18 +417,18 @@
 419	cold-filtered wet lime green serum of sarcasm	0		Effect: "Appeteyes", Effect Duration: 68
 420	modified dry tomato juice of powerful power	0		Effect: "Chalk Outline", Effect Duration: 19
 421	super-electrified philter of phorce	0		Effect: "Turkey-Friendly", Effect Duration: 13
-422	improved pulsating gray potion of potency	0		Effect: "It's Soporiffic!", Effect Duration: 64
+422	improved gray pulsating potion of potency	0		Effect: "It's Soporiffic!", Effect Duration: 64
 423	chilled triple-anodized shaking yellow cordial of concentration	0		Effect: "Updated", Effect Duration: 25
 424	denatured teal pulsating ointment of the occult	0		Effect: "Sourpuss", Effect Duration: 24
 425	improved activated ionized blurry oil of expertise	0		Effect: "Weird Flavor", Effect Duration: 46
 426	triple-altered potion of temporary gr8ness	0		Effect: "Once Bitten Twice Fried", Effect Duration: 59
 427	studded box	0		Damage Absorption: +80, Wiki Name: "box"
 428	upside-down nothing-in-the-box	0		
-429	yellow spinning ghostly beanbag chair	0		
+429	spinning yellow ghostly beanbag chair	0		
 430	mirror acid-squirting flower	0		Single Equip
 431	clever clown shoes	0		Maximum MP: +20, Clowniness: 25
 432	bouncing Newton's bloody clown pants	0		Experience (Mysticality): +3, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
-433	ghostly spinning teal skinny balloon	0		
+433	spinning ghostly teal skinny balloon	0		
 434	occult balloon helmet	0		Spell Damage Percent: +25, Clowniness: 25, Familiar Effect: "3xFairy, cap 12"
 435	manspreader's healthy balloon sword	0		Maximum HP Percent: +20, Monster Level: +10, Clowniness: 50
 436	balloon monkey	0		
@@ -462,11 +462,11 @@
 464	teal pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	decent miniature enchanted pixel pie	2	good	Effect: "Tingly Wrists", Effect Duration: 5
+467	miniature enchanted decent pixel pie	2	good	Effect: "Tingly Wrists", Effect Duration: 5
 468	ruby W	0		
 469	wussiness potion	0		
 470	artisanal extra-dry Imp Ale	5	EPIC	
-471	snack-sized adequate hot wing	2	good	
+471	adequate snack-sized hot wing	2	good	
 472	pulsating huge squat diamond-studded cane of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Disco Bandit"
 473	squat crutch of bravery	0		Spooky Resistance: +5
 474	cast	0		
@@ -484,7 +484,7 @@
 486	hardy Talisman o' Namsilat	0		Maximum HP: +50, Single Equip
 487	ghostly chilly arrrgyle socks	0		Cold Damage: +5
 488	gray guitar pick	0		
-489	shaking blue drab sonata	0		
+489	blue shaking drab sonata	0		
 490	upside-down fortified razor-sharp mesh cap	0		Weapon Damage Percent: +25, Damage Absorption: +60, Familiar Effect: "atk, 1xVolley, cap 41"
 491	teal enormous belt buckle	0		
 492	weightlifter's chaps of Leguizamo	0		Muscle: +15, Monster Level: +20, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
@@ -496,19 +496,19 @@
 498	rotten papaya	3	crappy	
 499	wool denim axe of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1
 500	skewed Elf Farm Raffle ticket	0		
-501	massive spoiled Elfin shortbread	6	crappy	
-502	cyan twirling pagoda plans	0		
-503	miniature normal skewered cat appendix	2	good	
+501	spoiled massive Elfin shortbread	6	crappy	
+502	twirling cyan pagoda plans	0		
+503	normal miniature skewered cat appendix	2	good	
 504	evil arches	0		
 505	spinning lightning-fast gnatwing earring of courage	0		Spooky Resistance: +3, Initiative: +40
 506	low-calorie toothsome red Hell broth	1	awesome	
 507	thunderrr guitarrr of dire peril	0		Weapon Damage: +20
 508	green sonata	0		
 509	Hey Deze nuts	0		
-510	shaking cyan Boris's key lime	0		
-511	purple shaking Jarlsberg's key lime	0		
+510	cyan shaking Boris's key lime	0		
+511	shaking purple Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	spoiled fancy teal Boris's key lime pie	4	crappy	Effect: "The Magic of LOV", Effect Duration: 25
+513	fancy spoiled teal Boris's key lime pie	4	crappy	Effect: "The Magic of LOV", Effect Duration: 25
 514	toothsome yellow bouncing Jarlsberg's key lime pie	4	awesome	
 515	low-calorie spoiled Sneaky Pete's key lime pie	1	crappy	
 516	olive Hey Deze map	0		
@@ -522,7 +522,7 @@
 524	smooth papaya sling	4	awesome	
 525	jittery wobbly grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
-527	squat spinning volleyball	0		
+527	spinning squat volleyball	0		
 528	purple blood-faced volleyball	0		
 529	fuchsia fertilized ghuol egg	0		
 530	warmed green upside-down spray paint	0		Effect: "Incredibly Hulking", Effect Duration: 35
@@ -538,7 +538,7 @@
 540	modified Tasty Fun Good rice candy	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 20
 541	bouncing Sherlock's banded draggin' ball hat	0		Damage Absorption: +100, Item Drop: +25, Familiar Effect: "atk, 1xVolley, cap 25"
 542	spinning zippy horrifying 1337 7r0uZ0RZ	0		Spooky Damage: +25, Initiative: +20, Familiar Effect: "2xPotato, cap 27"
-543	tiny decent tumbling Trollhouse cookies	1	good	
+543	decent tiny tumbling Trollhouse cookies	1	good	
 544	lightning-fast talons of temperance	0		Sleaze Resistance: +5, Initiative: +40
 545	moldy Spam Witch sammich	3	crappy	
 546	meat vortex	0		
@@ -549,13 +549,13 @@
 551	64067 scroll	0		
 552	ghostly 64735 scroll	0		
 553	mirror 31337 scroll	0		
-554	immense adequate pr0n cocktail	9	good	
+554	adequate immense pr0n cocktail	9	good	
 555	twirling purple zippy scandalous drywall axe	0		Sleaze Damage: +5, Initiative: +20
 556	stiffened Pine-Fresh air freshener	0		Damage Reduction: 1
 557	mediocre whiskey and cola	4	decent	
-558	normal small papaya taco	2	good	
+558	small normal papaya taco	2	good	
 559	razor-sharp can lid	0		
-560	rotten special shaking stalk of asparagus	4	crappy	Effect: "Ooh, Sweet!", Effect Duration: 50
+560	special rotten shaking stalk of asparagus	4	crappy	Effect: "Ooh, Sweet!", Effect Duration: 50
 561	pregnant mushroom	0		
 562	narrow ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -565,10 +565,10 @@
 567	hermit script	0		
 568	stale Double Bacon Beelzeburger	4	decent	
 569	decent Lord of the Flies-sized fries	4	good	
-570	spoiled miniature Chicken Sandwich	2	crappy	
+570	miniature spoiled Chicken Sandwich	2	crappy	
 571	jittery Jumbo Dr. Lucifer	1	EPIC	
 572	stale Children's Meal of the Damned	4	decent	
-573	diet adequate bouncing noodles	1	good	
+573	adequate diet bouncing noodles	1	good	
 574	bland noodles	3	decent	
 575	spoiled painful penne pasta	3	crappy	
 576	delicious upside-down ravioli della hippy	4	awesome	
@@ -579,13 +579,13 @@
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	flavorless fettucini Inconnu	3	decent	
-584	big rotten spaghetti with Skullheads	5	crappy	
-585	miniature rotten gnocchetti di Nietzsche	2	crappy	
+584	rotten big spaghetti with Skullheads	5	crappy	
+585	rotten miniature gnocchetti di Nietzsche	2	crappy	
 586	Jeselnik's crafty ridiculously huge sword	0		Maximum MP: +10, Sleaze Damage: +25
 587	corrupted concentrated diffused twirling super-spiky hair gel	0		Effect: "The Real Deal", Effect Duration: 58
 588	soft echo eyedrop antidote	0		
-589	low-calorie spoiled cocoa eggshell fragment	1	crappy	
-590	stale small wobbly cocoa eggshell fragment	2	decent	
+589	spoiled low-calorie cocoa eggshell fragment	1	crappy	
+590	small stale wobbly cocoa eggshell fragment	2	decent	
 591	cocoa egg	0		
 592	house	0		
 593	phonics down	0		
@@ -593,7 +593,7 @@
 595	purple scroll of drastic healing	0		
 596	wobbly Jack Frost's titanium assault umbrella	0		Cold Spell Damage: +50
 597	fuchsia Jack Frost's Mohawk wig	0		Cold Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
-598	spinning fuchsia the Slug Lord's map	0		
+598	fuchsia spinning the Slug Lord's map	0		
 599	jittery pants of the Slug Lord of temperance	0		Sleaze Resistance: +5, Familiar Effect: "stench atk, 3xPotato, cap 8"
 600	Dr. Hobo's scalpel of chilblains of the brazier	0		Cold Damage: +25, Hot Spell Damage: +25
 601	Dr. Hobo's map	0		
@@ -604,7 +604,7 @@
 606	Tin Foil Immateria	0		
 607	Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
-609	huge narrow S.O.C.K.	0		
+609	narrow huge S.O.C.K.	0		
 610	procrastination potion	0		
 611	D	0		
 612	tumbling original G	0		
@@ -617,7 +617,7 @@
 619	needle of the ox	0		Muscle: +20
 620	enhanced pickled thin candle	0		Effect: "Petit Force", Effect Duration: 57
 621	spinning Warm Subject gift certificate	0		
-622	cyan narrow awful poetry journal	0		
+622	narrow cyan awful poetry journal	0		
 623	maroon WA	0		
 624	spinning NG	0		
 625	wang	0		
@@ -629,23 +629,23 @@
 631	hardened furry pants	0		Damage Reduction: 3, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
 632	ghostly vibrating disturbing fanfic	0		Maximum MP Percent: +10
 633	tumbling knitted Annie Oakley's wolf mask	0		Critical Hit Percent: +20, Cold Resistance: +3, Familiar Effect: "1xBarrr, HP regen, cap 37"
-634	spinning maroon cool whip	0		
+634	maroon spinning cool whip	0		
 635	ghostly chaotic paper umbrella	0		Spell Critical Percent: +10
 636	meat globe	0		
 637	huge toaster	0		
 638	Usain Bolt's asshat of the empath	0		Familiar Weight: +5, Initiative: +80, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	half-sized bland green abominable snowcone	2	decent	
-640	mirror narrow Ent cider	1	good	
-641	spoiled half-sized toast	2	crappy	
+640	narrow mirror Ent cider	1	good	
+641	half-sized spoiled toast	2	crappy	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	jittery Crimbo pressie	0		Last Available: "2003-12"
 645	ghostly wrapping paper	0		Last Available: "2003-12"
-646	snack-sized rotten fruitcake	2	crappy	
+646	rotten snack-sized fruitcake	2	crappy	
 647	present	0		Last Available: "2004-11"
 648	dance instructor's Crimbo sword	0		Experience Percent (Moxie): +10, Last Available: "2004-10"
-649	Van der Graaf Crimbo hat	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	purple family-friendly Crimbo pants	0		Sleaze Resistance: +1, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	Van der Graaf Crimbo hat	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	purple family-friendly Crimbo pants	0		Sleaze Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	exclusive ultra-rare item of extreme caution	0		Monster Level: -25
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,7 +664,7 @@
 666	inspector's Jeselnik's resourceful steaming evil	0		Maximum MP: +50, Sleaze Damage: +25, Item Drop: +15
 667	castle map	0		
 668	spiked femur of the brute	0		Muscle Percent: +30
-669	flavorless fancy blurry ghuol guolash	3	decent	Effect: "Je Ne Sais Porquoise", Effect Duration: 5
+669	fancy flavorless blurry ghuol guolash	3	decent	Effect: "Je Ne Sais Porquoise", Effect Duration: 5
 670	crafty lihc face	0		Maximum MP: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	upside-down beefy grave robbing shovel of the empath	0		Muscle: +10, Familiar Weight: +5
 672	decent mirror cranberries	3	good	
@@ -675,9 +675,9 @@
 677	Jack Frost's badass belt	0		Cold Spell Damage: +50
 678	chest of the Bonerdagon	0		
 679	drinkable irresponsibly strong roll in the hay	8	good	
-680	weak artisanal slap and tickle	2	EPIC	
+680	artisanal weak slap and tickle	2	EPIC	
 681	hand-crafted triple-distilled slip 'n' slide	9	EPIC	
-682	practically non-alcoholic tolerable a sump'm sump'm	1	good	
+682	tolerable practically non-alcoholic a sump'm sump'm	1	good	
 683	distilled acceptable bouncing horizontal tango	5	good	
 684	lousy pink pony	3	decent	
 685	MacGyver's razor-sharp Mr. Shirt of the detective	0		Weapon Damage Percent: +25, Maximum MP: +100, Item Drop: +20
@@ -716,7 +716,7 @@
 720	reassuring flame-retardant porquoise necklace	0		Hot Resistance: +1, Spooky Resistance: +1, Single Equip
 721	squat manspreader's studded porquoise bracelet	0		Damage Absorption: +80, Monster Level: +10
 722	deadly porquoise ring of Calamity Jane of the empath	0		Weapon Damage: +5, Critical Hit Percent: +15, Familiar Weight: +5, Single Equip
-723	normal small Knoll mushroom	2	good	
+723	small normal Knoll mushroom	2	good	
 724	normal purple mushroom	4	good	
 725	huge one million meat pancakes	0		
 726	huge mirror shard of Gandalf	0		Spell Critical Percent: +20
@@ -725,7 +725,7 @@
 729	pulsating fishbowl	0		
 730	fishtank	0		
 731	fish hose	0		
-732	tumbling pulsating hosed tank	0		
+732	pulsating tumbling hosed tank	0		
 733	hosed fishbowl	0		
 734	squat ribald dog trainer's makeshift SCUBA gear	0		Experience (familiar): +1, Sleaze Damage: +10, Item Drop: +5, Adventure Underwater
 735	narrow savvy easter egg balloon	0		Mysticality Percent: +20
@@ -736,20 +736,20 @@
 740	beefy tambourine	0		Muscle: +10
 741	broken skull	0		
 742	stale Knoll shroomkabob	3	decent	
-743	adequate small gray mushroom	2	good	
+743	small adequate gray mushroom	2	good	
 744	cold-filtered hair spray	0		Effect: "Weepy, Creepy", Effect Duration: 17
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	big decent warm mushroom	5	good	
-750	bland thick mushroom quesadilla	5	decent	
+749	decent big warm mushroom	5	good	
+750	thick bland mushroom quesadilla	5	decent	
 751	rotten spinning cool mushroom	4	crappy	
 752	adequate lime green huge cool mushroom casserole	4	good	
 753	yummy special pointy mushroom	4	awesome	Effect: "Raging Animal", Effect Duration: 10
 754	bland miniature blue cream of pointy mushroom soup	2	decent	
-755	gigantic flavorless mushroom	6	decent	
-756	adequate half-sized mushroom	2	good	
-757	diet flavorless ghostly green mushroom	1	decent	
+755	flavorless gigantic mushroom	6	decent	
+756	half-sized adequate mushroom	2	good	
+757	flavorless diet ghostly green mushroom	1	decent	
 758	diet flavorless ghost cucumber	1	decent	
 759	ghostly dill	0		
 760	jittery vinegar	0		
@@ -771,7 +771,7 @@
 776	boxer's kneecapping stick	0		Muscle Percent: +10
 777	iron pasta spoon of temperance	0		Sleaze Resistance: +5
 778	tumbling huge educational support cummerbund	0		Experience: +1
-779	blurry ghostly bouncing Mob Penguin cellular phone	0		
+779	ghostly bouncing blurry Mob Penguin cellular phone	0		
 780	scroll of pasta summoning	0		
 781	boiled shaking mafia aria	0		Effect: "Drunk With Power", Effect Duration: 50
 782	mirror Mr. Exploiter	0		Last Available: "2009-12"
@@ -779,10 +779,10 @@
 784	drinkable Acqua Del Piatto Merlot	3	good	Last Available: "2004-10"
 785	raffle ticket	0		
 786	flavorless half-sized strawberry	2	decent	
-787	practically non-alcoholic perfectly mixed bottle of rum	1	EPIC	
-788	irresponsibly strong tolerable squat mirror strawberry daiquiri	8	good	
-789	acceptable weak fuchsia rum and cola	2	good	
-790	aged special cyan shaking grog	3	awesome	Effect: "Mighty Shout", Effect Duration: 35
+787	perfectly mixed practically non-alcoholic bottle of rum	1	EPIC	
+788	tolerable irresponsibly strong mirror squat strawberry daiquiri	8	good	
+789	weak acceptable fuchsia rum and cola	2	good	
+790	aged special shaking cyan grog	3	awesome	Effect: "Mighty Shout", Effect Duration: 35
 791	Herculean boxer's Mafia bow tie	0		Muscle Percent: +10, Experience (Muscle): +1, Last Available: "2004-10"
 792	vibrating Golden Mr. Accessory	0		Maximum MP Percent: +10, Softcore Only
 793	ionized super-chilled bouncing oil of stability	0		Effect: "Berry Experiential", Effect Duration: 43
@@ -791,23 +791,23 @@
 796	cement shoes of Tarzan of chilblains of the detective	0		Experience (Muscle): +3, Cold Damage: +25, Item Drop: +20, Last Available: "2004-10"
 797	lousy squat rockin' wagon	4	decent	
 798	bad ocean motion	4	decent	
-799	perfectly mixed high-proof fuzzbump	9	EPIC	
+799	high-proof perfectly mixed fuzzbump	9	EPIC	
 800	massive stale fuchsia poutine	9	decent	
 801	decent twirling Knob stir-fry	4	good	
-804	delicious bite-sized Knoll stir-fry	1	awesome	
+804	bite-sized delicious Knoll stir-fry	1	awesome	
 805	adequate stir-fry	4	good	
 806	flavorless asparagus stir-fry	4	decent	
-807	normal jumbo wobbly olive stir-fry	5	good	
-808	stale half-sized Knob sausage stir-fry	2	decent	
-809	adequate miniature bat wing stir-fry	2	good	
-810	normal jumbo rat appendix stir-fry	5	good	
+807	jumbo normal wobbly olive stir-fry	5	good	
+808	half-sized stale Knob sausage stir-fry	2	decent	
+809	miniature adequate bat wing stir-fry	2	good	
+810	jumbo normal rat appendix stir-fry	5	good	
 811	stale miniature tofu stir-fry	2	decent	
 812	delicious big pr0n stir-fry	5	awesome	
 813	toothsome teal Knob shells	3	awesome	
 814	super-sized bland b&auml;tzle	5	decent	
-815	bite-sized spoiled ratini	1	crappy	
+815	spoiled bite-sized ratini	1	crappy	
 816	adequate Knob stroganoff	3	good	
-817	moldy huge menudo ravioli	7	crappy	
+817	huge moldy menudo ravioli	7	crappy	
 818	purple plus sign	0		
 819	skewed milky potion	0		
 820	ghostly swirly potion	0		
@@ -832,7 +832,7 @@
 839	bad Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
 840	aromatic cool Mafia violin case	0		Moxie: +5, Stench Resistance: +1, Last Available: "2004-10"
 841	acceptable watered-down tomato daiquiri	2	good	
-842	tolerable practically non-alcoholic beertini	1	good	
+842	practically non-alcoholic tolerable beertini	1	good	
 843	bad maroon salty slug	3	decent	
 844	tolerable ghostly papaya slung	3	good	
 845	blue quilted MAHI fez	0		Damage Absorption: +40, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -878,7 +878,7 @@
 887	teal leaf	0		
 888	narrow maple leaf	0		
 889	Herculean balaclava	0		Experience (Muscle): +1, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	tiny adequate balaclava baklava	1	good	
+890	adequate tiny balaclava baklava	1	good	
 891	blinking smelly Warehouse 23 bling	0		Stench Spell Damage: +10
 892	family-friendly friendly Da Vinci's bugbear-smiting sword	0		Experience (Mysticality): +5, Familiar Weight: +3, Sleaze Resistance: +1
 893	practically non-alcoholic bad lumbering jack	1	decent	
@@ -892,24 +892,24 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	lousy mirror upside-down Spasmi Dolorosi Del Rene Champagne	4	decent	Last Available: "2004-10"
-904	spinning wool steel-toed boxer's school Mafia knickerbockers	0		Muscle Percent: +10, Damage Reduction: 9, Cold Resistance: +1, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	spinning wool steel-toed boxer's school Mafia knickerbockers	0		Muscle Percent: +10, Damage Reduction: 9, Cold Resistance: +1, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	modified liquefied Yummy Tummy bean	0		Effect: "Tennis Elbow-wow", Effect Duration: 59
 906	energized adjusted wobbly Rock Pops	0		Effect: "Initiative and Let Die", Effect Duration: 16
 907	improved denatured enhanced cyan Mr. Mediocrebar	0		Effect: "Quantum of Moxie", Effect Duration: 39
 908	triple-improved chilled Cold Hots candy	0		Effect: "Nutrient-Rich", Effect Duration: 22
 909	tarnished Wint-O-Fresh mint	0		Effect: "License to Punch", Effect Duration: 30
-910	low-calorie bland dwarf bread	1	decent	
+910	bland low-calorie dwarf bread	1	decent	
 911	diffused Senior Mints	0		Effect: "Certainty", Effect Duration: 21
 912	dry mirror blurry pixellated candy heart	0		Effect: "Wasabi With You", Effect Duration: 53
-913	oxidized jittery gray kobold	0		Effect: "Spookyravin'", Effect Duration: 34
+913	oxidized gray jittery kobold	0		Effect: "Spookyravin'", Effect Duration: 34
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	Annie Oakley's electrified intergalactic pom poms	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5
 917	upside-down Mob Penguin protection contract	0		
-918	upside-down fireproof Radio Free Baseball Cap	0		Hot Resistance: +3, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	fuchsia dance instructor's Radio Free Pants	0		Experience Percent (Moxie): +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	upside-down fireproof Radio Free Baseball Cap	0		Hot Resistance: +3, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	fuchsia dance instructor's Radio Free Pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	Fonzie's Radio Free Foil	0		Experience (Moxie): +1, Last Available: "2006-07"
-921	normal pulsating cyan radio button candy	3	good	
+921	normal cyan pulsating radio button candy	3	good	
 922	shaking tumbling rock-hard severed rocking horse head	0		Damage Reduction: 5
 923	tumbling broken cellular phone	0		Last Available: "2004-01"
 924	shaking crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -918,9 +918,9 @@
 927	artisanal Ferita Del Petto Zinfandel	3	EPIC	Last Available: "2006-12"
 928	skewed fuzzy bracelets of courage	0		Spooky Resistance: +3
 929	blinking banded arse-shooting crossbow	0		Damage Absorption: +100
-931	drinkable blue narrow spiced rum	3	good	
+931	drinkable narrow blue spiced rum	3	good	
 932	acceptable squat eggnog	4	good	
-933	normal snack-sized candy cane	2	good	
+933	snack-sized normal candy cane	2	good	
 934	toothsome miniature gingerbread bugbear	2	awesome	
 935	Samson's imitation nice watch	0		Experience (Muscle): +5, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,13 +929,13 @@
 939	maroon small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	mirror fireproof bowler	0		Hot Resistance: +3, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	mirror fireproof bowler	0		Hot Resistance: +3, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	spinning Usain Bolt's shellacked bow staff	0		Damage Reduction: 7, Initiative: +80, Last Available: "2004-12"
-944	wobbly educational bowlegged pants	0		Experience: +1, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	wobbly educational bowlegged pants	0		Experience: +1, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
-948	practically non-alcoholic acceptable martini	1	good	Last Available: "2004-12"
+948	acceptable practically non-alcoholic martini	1	good	Last Available: "2004-12"
 949	watered-down drinkable grogtini	2	good	Last Available: "2004-12"
 950	weak smooth cherry bomb	2	awesome	Last Available: "2004-12"
 951	blue extra special Crimbo stocking	0		Last Available: "2004-12"
@@ -944,7 +944,7 @@
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	Van der Graaf fez of etymology	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xLep, cap 30"
 956	moldy carob chunk noodles	3	crappy	
-957	stale snack-sized chorizo brownies	2	decent	
+957	snack-sized stale chorizo brownies	2	decent	
 958	diet normal teal shaking chocolate and tomato pizza	1	good	
 959	gray flange	0		
 960	clockwork key	0		
@@ -990,24 +990,24 @@
 1003	soda water	0		
 1004	acceptable high-proof spinning bottle of tequila	6	good	
 1005	aged upside-down boxed wine	4	awesome	
-1006	low-calorie flavorless cherry	1	decent	
+1006	flavorless low-calorie cherry	1	decent	
 1007	wobbly sinister coconut shell	0		Spell Damage: +10, Familiar Effect: "1xFairy, cap 7"
 1008	frosty ice cubes	0		Cold Spell Damage: +10
-1009	drinkable watered-down fancy vodka martini	2	good	Effect: "Frigid Weapon", Effect Duration: 35
-1010	distilled acceptable upside-down whiskey and soda	5	good	
+1009	watered-down drinkable fancy vodka martini	2	good	Effect: "Frigid Weapon", Effect Duration: 35
+1010	acceptable distilled upside-down whiskey and soda	5	good	
 1011	artisanal tumbling monkey wrench	3	EPIC	
 1012	tolerable tequila sunrise	3	good	
-1013	hand-crafted fortified margarita	5	EPIC	
+1013	fortified hand-crafted margarita	5	EPIC	
 1014	hand-crafted strawberry wine	4	EPIC	
 1015	lousy wine spritzer	3	decent	
 1016	artisanal spinning skewed perpendicular hula	3	EPIC	
-1017	hand-crafted green blurry ducha de oro	3	EPIC	
-1018	bad triple-distilled calle de miel	6	decent	
+1017	hand-crafted blurry green ducha de oro	3	EPIC	
+1018	triple-distilled bad calle de miel	6	decent	
 1019	bad practically non-alcoholic dry vodka martini	1	decent	
 1020	hand-crafted fuchsia old-fashioned	3	EPIC	
 1021	hand-crafted watered-down tequila with training wheels	2	EPIC	
 1022	perfectly mixed sangria	3	EPIC	
-1023	artisanal practically non-alcoholic vesper	1	super ultra mega turbo EPIC	Last Available: "2004-12"
+1023	practically non-alcoholic artisanal vesper	1	super ultra mega turbo EPIC	Last Available: "2004-12"
 1024	distilled mediocre upside-down maroon bodyslam	5	decent	Last Available: "2004-12"
 1025	delicious sangria del diablo	4	awesome	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
@@ -1029,14 +1029,14 @@
 1043	Usain Bolt's string of beads	0		Initiative: +80
 1044	hardy string of beads	0		Maximum HP: +50
 1045	mirror wool plastic bottle opener	0		Cold Resistance: +1
-1046	hardy studded traffic cone	0		Damage Absorption: +80, Maximum HP: +50, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	hardy studded traffic cone	0		Damage Absorption: +80, Maximum HP: +50, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	delicious N. O. Beer	4	awesome	
 1048	distilled huge oyster egg	1		
-1049	boiled bouncing blurry oyster egg	1		
+1049	boiled blurry bouncing oyster egg	1		
 1050	diluted wobbly spinning oyster egg	1		
-1051	squat mirror plastic oyster egg	0		
+1051	mirror squat plastic oyster egg	0		
 1052	modified oyster egg	1		
-1053	dehydrated twirling upside-down shaking oyster egg	1		Effect: "A Contender", Effect Duration: 35
+1053	dehydrated upside-down shaking twirling oyster egg	1		Effect: "A Contender", Effect Duration: 35
 1054	compressed squat shaking oyster egg	1		Effect: "Well Owl Be!", Effect Duration: 25
 1055	shaking plastic oyster egg	0		
 1056	dehydrated puce oyster egg	1		Effect: "Improprie Tea", Effect Duration: 30
@@ -1047,7 +1047,7 @@
 1061	diluted shaking tumbling mauve oyster egg	1		
 1062	twisted mirror mauve oyster egg	1		
 1063	spinning mauve plastic oyster egg	0		
-1064	vaporized shaking twirling oyster egg	1		
+1064	vaporized twirling shaking oyster egg	1		
 1065	boiled jittery oyster egg	1		Effect: "Can't Smell Nothin'", Effect Duration: 35
 1066	compressed fuchsia oyster egg	1		Effect: "Al Dente Inferno", Effect Duration: 45
 1067	plastic oyster egg	0		
@@ -1093,7 +1093,7 @@
 1107	clockwork maid head	0		
 1108	clockwork detective skull	0		
 1109	fuchsia clockwork bartender-head-in-the-box	0		
-1110	jittery mirror clockwork chef-head-in-the-box	0		
+1110	mirror jittery clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
 1112	clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
@@ -1107,7 +1107,7 @@
 1121	inexplicably rock	0		
 1122	fairy gravy	0		
 1123	Lo Pan's halfberd	0		Spell Critical Percent: +30
-1124	upside-down blinking small glove	0		
+1124	blinking upside-down small glove	0		
 1125	arcane researcher's strapping glove of the overflowing toilet	0		Muscle: +5, Experience Percent (Mysticality): +10, Stench Spell Damage: +50
 1126	Da Vinci's toothpick	0		Experience (Mysticality): +5, Single Equip
 1127	ninja sword of the sewer	0		Stench Damage: +25
@@ -1115,24 +1115,24 @@
 1129	blurry ghostly energetic sequined fez	0		Maximum MP Percent: +20, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
 1131	beet	0		Last Available: "2005-12"
-1132	red narrow Totally Gay Claymore	0		
+1132	narrow red Totally Gay Claymore	0		
 1133	shaking cyan knitted star shirt	0		Cold Resistance: +3
 1134	blurry cosmetics bag	0		
 1135	diffused improved eyeliner	0		Effect: "Blessing of Charcoatl", Effect Duration: 56
 1136	extra-ionized upside-down lipstick	0		Effect: "Sugar High", Effect Duration: 41
 1137	hardened brainy bicycle chain	0		Mysticality: +5, Damage Reduction: 3
 1138	mushroom fermenting solution	0		
-1139	drinkable weak tumbling upside-down mushroom wine	2	good	
-1140	tolerable fortified icy mushroom wine	5	good	
+1139	weak drinkable upside-down tumbling mushroom wine	2	good	
+1140	fortified tolerable icy mushroom wine	5	good	
 1141	aged pulsating mushroom wine	3	awesome	
 1142	mediocre watered-down pointy mushroom wine	2	decent	
 1143	watered-down aged flat mushroom wine	2	awesome	
 1144	hand-crafted cool mushroom wine	4	EPIC	
-1145	irresponsibly strong hand-crafted fancy knob mushroom wine	9	EPIC	Effect: "Egg-stortionary Tactics", Effect Duration: 25
+1145	fancy irresponsibly strong hand-crafted knob mushroom wine	9	EPIC	Effect: "Egg-stortionary Tactics", Effect Duration: 25
 1146	artisanal knoll mushroom wine	4	EPIC	
 1147	spirit-forward drinkable mushroom wine	5	good	
-1148	watered-down tolerable shot of flower schnapps	2	good	
-1149	super-sized rotten flower petal pie	5	crappy	
+1148	tolerable watered-down shot of flower schnapps	2	good	
+1149	rotten super-sized flower petal pie	5	crappy	
 1150	watered-down bad upside-down bottle of single-barrel whiskey	2	decent	
 1151	teal family-friendly Temple Grandin's discarded plastic fork	0		Familiar Weight: +7, Sleaze Resistance: +1
 1152	skewed gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1144,8 +1144,8 @@
 1159	tumbling mariachi G-string	0		
 1160	upside-down shaking fuchsia auspicious irate sombrero	0		Item Drop: +10, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	squat pile of candy	0		
-1162	ionized ionized yellow blinking squat handsomeness potion	0		Effect: "Alpine Mintiness", Effect Duration: 28
-1163	tarnished frozen flattened teal shaking spinning marzipan skull	0		Effect: "Cock of the Walk", Effect Duration: 59
+1162	ionized ionized blinking yellow squat handsomeness potion	0		Effect: "Alpine Mintiness", Effect Duration: 28
+1163	tarnished frozen flattened shaking spinning teal marzipan skull	0		Effect: "Cock of the Walk", Effect Duration: 59
 1164	narrow poultrygeist	0		
 1165	wobbly hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
@@ -1164,7 +1164,7 @@
 1179	daisy	0		
 1180	teal potted fern	0		
 1181	tulip	0		
-1182	gray spinning Venus flytrap	0		
+1182	spinning gray Venus flytrap	0		
 1183	all-purpose flower	0		
 1184	exotic orchid	0		
 1185	long-stemmed rose	0		
@@ -1187,10 +1187,10 @@
 1202	normal Happy Birthday, Claude! cake	3	good	
 1203	adequate twirling personalized birthday cake	3	good	
 1204	rotten wobbly three-tiered wedding cake	4	crappy	
-1205	normal snack-sized babycakes	2	good	
-1206	thick toothsome velvet cake	5	awesome	
+1205	snack-sized normal babycakes	2	good	
+1206	toothsome thick velvet cake	5	awesome	
 1207	tiny spoiled blinking congratulatory cake	1	crappy	
-1208	normal teal shaking angel-food cake	3	good	
+1208	normal shaking teal angel-food cake	3	good	
 1209	flavorless devil's-food cake	3	decent	
 1210	spoiled birthday party jellybean cheesecake	3	crappy	
 1211	wobbly balloon	0		
@@ -1238,22 +1238,22 @@
 1254	miniature stale mirror jumping bean burrito	2	decent	
 1255	stale huge jumping bean burrito	3	decent	
 1256	spoiled tiny ghostly insanely jumping bean burrito	1	crappy	
-1257	moldy thick rat scrapple	5	crappy	
+1257	thick moldy rat scrapple	5	crappy	
 1258	pail of pretentious paint	0		
-1259	blue shellacked thinker's traffic cone	0		Mysticality: +10, Damage Reduction: 7, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	blue shellacked thinker's traffic cone	0		Mysticality: +10, Damage Reduction: 7, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	lime green wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	altered Hatorade	1		
 1262	fireproof mansplainer's sinister off-hand balloon	0		Spell Damage: +10, Monster Level: +15, Hot Resistance: +3
-1263	narrow gray ghostly pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
+1263	ghostly gray narrow pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	squat nose-bone fetish	0		Last Available: "2011-12"
 1265	upside-down box of sunshine	0		Free Pull
-1266	bite-sized flavorless gloomy mushroom	1	decent	
+1266	flavorless bite-sized gloomy mushroom	1	decent	
 1267	dead mimic	0		
-1268	blinking red pine wand	0		
+1268	red blinking pine wand	0		
 1269	ebony wand	0		
 1270	twirling hexagonal wand	0		
 1271	aluminum wand	0		
-1272	blinking green huge marble wand	0		
+1272	blinking huge green marble wand	0		
 1273	auspicious magic lamp	0		Item Drop: +10
 1274	denatured Medicinal Herb's medicinal herbs	1		
 1275	Usain Bolt's basic meat skirt	0		Initiative: +80, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
@@ -1273,7 +1273,7 @@
 1289	twirling veiny gnauga hide kilt	0		Maximum HP: +10, Familiar Effect: "2.5xFairy, cap 20"
 1290	colloidal quadruple-corrupted wind-up clock	0		Effect: "Appeteyes", Effect Duration: 24
 1291	upside-down up-at-dawn Jekyllin hide belt	0		Adventures: +5, Softcore Only, Last Available: "2005-09"
-1292	olive wobbly skirt / kilt kit	0		
+1292	wobbly olive skirt / kilt kit	0		
 1293	ring of adornment of the bloodbag	0		Maximum HP: +100
 1294	rock-hard ring of increase damage of incineration	0		Damage Reduction: 5, Hot Spell Damage: +50
 1295	fireproof ring of gain strength	0		Hot Resistance: +3
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	wobbly makeup kit	0		Familiar Weight: +15
-1306	pulsating beefcake's traffic cone of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	pulsating beefcake's traffic cone of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	spoiled yellow questionable taco	4	crappy	
 1321	huge Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	thinker's time helmet	0		Mysticality: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	spinning Jeselnik's time trousers	0		Sleaze Damage: +25, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	thinker's time helmet	0		Mysticality: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	spinning Jeselnik's time trousers	0		Sleaze Damage: +25, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	time sword of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2005-10"
 1326	ghostly Dyspepsi-Cola helmet of the businessman	0		Meat Drop: +50, Familiar Effect: "3xFairy, cap 7"
 1327	Sinatra's Cloaca-Cola shield	0		Experience (Moxie): +5, Damage Reduction: 4
@@ -1348,12 +1348,12 @@
 1365	tasty miniature tofurkey leg	2	awesome	
 1366	toothsome tofurkey gravy	4	awesome	
 1367	moldy herbal stuffing	3	crappy	
-1368	snack-sized spoiled can-shaped gelatinous cranberry sauce	2	crappy	
+1368	spoiled snack-sized can-shaped gelatinous cranberry sauce	2	crappy	
 1369	rotten yams	4	crappy	
 1370	toasty rhinestone cowboy shirt	0		Hot Damage: +5
 1371	weightlifter's gingham blouse	0		Muscle: +15
 1372	jittery perfumed souvenir ski t-shirt	0		Stench Resistance: +5
-1373	upside-down teal sweet nutcracker	0		Free Pull, Last Available: "2005-12"
+1373	teal upside-down sweet nutcracker	0		Free Pull, Last Available: "2005-12"
 1374	mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	Van der Graaf plastic Crimbo wreath	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2005-12"
 1376	blinking Jack Frost's plastic Uncle Crimbo	0		Cold Spell Damage: +50, Last Available: "2005-12"
@@ -1371,7 +1371,7 @@
 1389	yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
-1392	pulsating squat kite	0		Last Available: "2005-12"
+1392	squat pulsating kite	0		Last Available: "2005-12"
 1393	bouncing yellow pet rock	0		Last Available: "2005-12"
 1394	tumbling doppelshifter	0		Last Available: "2005-12"
 1395	teddy bear	0		Last Available: "2005-12"
@@ -1384,13 +1384,13 @@
 1402	Usain Bolt's rag doll	0		Initiative: +80, Last Available: "2005-12"
 1403	double-paned can of fake snow	0		Cold Resistance: +5, Last Available: "2005-12"
 1404	wizardly colored-light &quot;necklace&quot;	0		Mysticality: +25, Last Available: "2005-12"
-1405	tree skirt of the empath	0		Familiar Weight: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	small spoiled upside-down wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	tree skirt of the empath	0		Familiar Weight: +5, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1406	spoiled small upside-down wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	stale bell-shaped Crimbo cookie	4	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	jumbo toothsome tree-shaped Crimbo cookie	5	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Jim Carey's Unionize The Elves sign	0		Monster Level: +25, Last Available: "2005-12"
-1410	huge teal sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1410	teal huge sleeping snowy owl	0		Last Available: "2005-12"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	energized snowcone	0		Effect: "Petit Forbearance", Effect Duration: 69, Last Available: "2006-01"
 1413	anodized narrow snowcone	0		Effect: "Cat-Alyzed", Effect Duration: 21, Last Available: "2006-01"
 1414	alkaline pressed yellow snowcone	0		Effect: "Boo Tea", Effect Duration: 36, Last Available: "2006-01"
@@ -1399,19 +1399,19 @@
 1417	moist magnetized pulsating snowcone	0		Effect: "The Wisdom... of the Future", Effect Duration: 62, Last Available: "2006-01"
 1418	olive Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	traffic cone of the dark arts of the boozehound	0		Spell Damage Percent: +100, Booze Drop: +100, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	traffic cone of the dark arts of the boozehound	0		Spell Damage Percent: +100, Booze Drop: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	wobbly Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	spinning iceberglet	0		Last Available: "2006-02"
 1424	twirling Tesla experienced ice sickle	0		Experience: +2, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2006-02"
 1425	nasty ice baby	0		Stench Damage: +5, Softcore Only, Last Available: "2006-02"
-1426	ice pick of dire peril	0		Weapon Damage: +20, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	ice pick of dire peril	0		Weapon Damage: +20, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	bouncing nasty curative ice skates	0		Stench Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	flavorless grue egg omelette	4	decent	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	moldy jumbo mushroom	5	crappy	
+1432	jumbo moldy mushroom	5	crappy	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1433,8 +1433,8 @@
 1451	modified squat hot wad	1		
 1452	boiled skewed purple wad	1		
 1453	compressed twirling wad	1		
-1454	dried mirror spinning stench wad	1		Effect: "Yet tea", Effect Duration: 15
-1455	modified purple blinking bouncing sleaze wad	1		
+1454	dried spinning mirror stench wad	1		Effect: "Yet tea", Effect Duration: 15
+1455	modified blinking bouncing purple sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
 1458	normal miniature yellow blinking Valentine's Day cake	2	good	
@@ -1447,7 +1447,7 @@
 1465	suede shortsword	0		
 1466	bamboo bokuto	0		
 1467	huge 25-meat staff	0		
-1468	jittery shaking two-handed depthsword	0		
+1468	shaking jittery two-handed depthsword	0		
 1469	squat bill bec-de-bardiche glaive-guisarme	0		
 1470	wobbly lead yo-yo	0		
 1471	slightly peevedbow	0		
@@ -1465,7 +1465,7 @@
 1483	huge troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	ghostly alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	upside-down mirror aromatic rabbit's foot of the wise owl	0		Mysticality: +20, Stench Resistance: +1
-1486	huge bouncing ghostly massive bag of catnip	0		
+1486	ghostly huge bouncing massive bag of catnip	0		
 1487	mirror hang glider	0		
 1488	March hat	0		Free Pull
 1489	gray dormouse	0		
@@ -1474,13 +1474,13 @@
 1492	stylish ninja mop	0		Moxie: +25
 1493	Usain Bolt's sage ridiculously overelaborate ninja weapon	0		Mysticality Percent: +10, Initiative: +80
 1494	oxidized sugar-coated pine cone	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 55, Last Available: "2020-09"
-1495	blue shellacked traffic cone of Calamity Jane	0		Damage Reduction: 7, Critical Hit Percent: +15, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	enchanted smooth watered-down gloomy mushroom wine	2	awesome	Effect: "Bat Attitude", Effect Duration: 5
+1495	blue shellacked traffic cone of Calamity Jane	0		Damage Reduction: 7, Critical Hit Percent: +15, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1496	smooth enchanted watered-down gloomy mushroom wine	2	awesome	Effect: "Bat Attitude", Effect Duration: 5
 1497	smooth mushroom wine	4	awesome	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
-1501	unsweetened adjusted olive blurry explosion-flavored chewing gum	0		Effect: "Gummiskin", Effect Duration: 65, Last Available: "2006-04"
+1501	unsweetened adjusted blurry olive explosion-flavored chewing gum	0		Effect: "Gummiskin", Effect Duration: 65, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	quantum corrupted irradiated snowcone	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 50, Last Available: "2006-04"
@@ -1491,7 +1491,7 @@
 1509	mediocre upside-down slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
 1510	blue bag of airline peanuts	0		Last Available: "2006-04"
 1511	frosty fake hand	0		Cold Spell Damage: +10, Last Available: "2006-04"
-1512	diluted green wobbly spinning Knob Goblin pet-buffing spray	1		Effect: "Stone-Faced", Effect Duration: 25
+1512	diluted green spinning wobbly Knob Goblin pet-buffing spray	1		Effect: "Stone-Faced", Effect Duration: 25
 1513	modified Knob Goblin learning pill	1		
 1514	compressed bouncing Knob Goblin eyedrops	1		Effect: "Buff as a Baobab", Effect Duration: 45
 1515	pickled squat Knob Goblin nasal spray	1		Effect: "Your Eyes are Peeled!", Effect Duration: 5
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	occult corkscrew of chilblains	0		Spell Damage Percent: +25, Cold Damage: +25, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	wobbly fake plastic grass	0		Last Available: "2011-01"
-1531	fortified grass skirt	0		Damage Absorption: +60, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	spinning medical-grade grass hat	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	fortified grass skirt	0		Damage Absorption: +60, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	spinning medical-grade grass hat	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	grass blade of the storm	0		Maximum MP Percent: +40, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	jittery weegee sqouija	0		Last Available: "2011-12"
 1538	green dangerous sparkly engagement ring	0		Weapon Damage: +10, Single Equip
 1539	blurry Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	blurry ghostly miser's fireproof Grimacite goggles	0		Hot Resistance: +3, Meat Drop: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	blurry ghostly miser's fireproof Grimacite goggles	0		Hot Resistance: +3, Meat Drop: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	skewed scandalous Grimacite glaive of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Last Available: "2008-10"
-1542	gravedigger's Grimacite greaves of dire peril	0		Weapon Damage: +20, Spooky Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	gravedigger's Grimacite greaves of dire peril	0		Weapon Damage: +20, Spooky Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	pulsating Herculean wizardly Grimacite garter	0		Mysticality: +25, Experience (Muscle): +1, Last Available: "2008-10"
 1544	scorching lion tamer's Grimacite galoshes	0		Experience (familiar): +2, Hot Damage: +25, Last Available: "2008-10"
 1545	bouncing wool frightening Grimacite gorget	0		Spooky Damage: +5, Cold Resistance: +1, Last Available: "2008-10"
@@ -1529,24 +1529,24 @@
 1549	green MSG	0		
 1550	flame-wreathed second-hand knockoff engagement ring	0		Hot Spell Damage: +10, Single Equip
 1551	aged practically non-alcoholic bottle of Domesticated Turkey	1	awesome	
-1552	hand-crafted extra-dry fancy bottle of Definit	5	EPIC	Effect: "Night Vision", Effect Duration: 35
-1553	weak mediocre bottle of Calcutta Emerald	2	decent	
-1554	watered-down perfectly mixed shaking bottle of Lieutenant Freeman	2	EPIC	
+1552	fancy extra-dry hand-crafted bottle of Definit	5	EPIC	Effect: "Night Vision", Effect Duration: 35
+1553	mediocre weak bottle of Calcutta Emerald	2	decent	
+1554	perfectly mixed watered-down shaking bottle of Lieutenant Freeman	2	EPIC	
 1555	bad twirling bottle of Jorge Sinsonte	4	decent	
 1556	perfectly mixed boxed champagne	4	EPIC	
 1557	moldy kumquat	3	crappy	
 1558	jumbo yummy wobbly tangerine	5	awesome	
-1559	squat jittery tonic water	0		
-1560	bite-sized stale cocktail onion	1	decent	
+1559	jittery squat tonic water	0		
+1560	stale bite-sized cocktail onion	1	decent	
 1561	bland raspberry	4	decent	
-1562	massive yummy wobbly cyan kiwi	8	awesome	
+1562	yummy massive wobbly cyan kiwi	8	awesome	
 1563	drinkable whiskey bittersweet	3	good	
 1564	lousy fuchsia mimosette	3	decent	
-1565	acceptable special tequila sunset	4	good	Effect: "Whole Latte Love", Effect Duration: 10
-1566	bad watered-down zmobie	2	decent	Wiki Name: "Zmobie (drink)"
-1567	hand-crafted distilled narrow gin and tonic	5	EPIC	
+1565	special acceptable tequila sunset	4	good	Effect: "Whole Latte Love", Effect Duration: 10
+1566	watered-down bad zmobie	2	decent	Wiki Name: "Zmobie (drink)"
+1567	distilled hand-crafted narrow gin and tonic	5	EPIC	
 1568	lousy weak vodka and tonic	2	decent	
-1569	weak acceptable shaking red vodka gibson	2	good	
+1569	acceptable weak shaking red vodka gibson	2	good	
 1570	smooth gibson	3	awesome	
 1571	fortified perfectly mixed parisian cathouse	5	EPIC	
 1572	bad weak rabbit punch	2	decent	
@@ -1556,9 +1556,9 @@
 1576	lousy Gordon Bennett	3	decent	
 1577	artisanal tumbling tangarita	4	EPIC	
 1578	hand-crafted lime green mandarina colada	3	EPIC	
-1579	hand-crafted weak gimlet	2	super ultra EPIC	
+1579	weak hand-crafted gimlet	2	super ultra EPIC	
 1580	perfectly mixed brick road	4	EPIC	
-1581	lousy watered-down vodka stratocaster	2	decent	
+1581	watered-down lousy vodka stratocaster	2	decent	
 1582	hand-crafted watered-down Neuromancer	2	super ultra EPIC	
 1583	perfectly mixed prussian cathouse	3	EPIC	
 1584	triple-distilled hand-crafted twirling Mae West	7	EPIC	
@@ -1566,21 +1566,21 @@
 1586	hand-crafted teqiwila slammer	3	EPIC	
 1587	flavorless super-sized Knob lo mein	5	decent	
 1588	bland massive asparagus lo mein	6	decent	
-1589	jumbo tasty Knoll lo mein	5	awesome	
-1590	small special flavorless lo mein	2	decent	Effect: "No Vertigo", Effect Duration: 10
-1591	special stale mirror olive lo mein	3	decent	Effect: "Held Closer", Effect Duration: 15
-1592	decent spinning upside-down hot hi mein	4	good	
+1589	tasty jumbo Knoll lo mein	5	awesome	
+1590	special small flavorless lo mein	2	decent	Effect: "No Vertigo", Effect Duration: 10
+1591	stale special mirror olive lo mein	3	decent	Effect: "Held Closer", Effect Duration: 15
+1592	decent upside-down spinning hot hi mein	4	good	
 1593	miniature delicious wobbly hi mein	2	awesome	
 1594	stale mirror hi mein	3	decent	
 1595	half-sized rotten hi mein	2	crappy	
 1596	delicious sleazy hi mein	3	awesome	
 1597	Junior LAAAAME merit badge of James Dean	0		Experience (Moxie): +3, Last Available: "2006-05"
 1598	wobbly cool Senior LAAAAME merit badge	0		Moxie: +5, Last Available: "2006-05"
-1599	upside-down ghostly jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	practically non-alcoholic artisanal tangarita with a fly in it	1	EPIC	
-1601	mediocre special weak mandarina colada with a fly in it	2	decent	Effect: "Hairless and Airless", Effect Duration: 20
-1602	bad watered-down prussian cathouse with a fly in it	2	decent	
-1603	weak tolerable Mae West with a fly in it	2	good	
+1599	ghostly upside-down jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
+1600	artisanal practically non-alcoholic tangarita with a fly in it	1	EPIC	
+1601	special mediocre weak mandarina colada with a fly in it	2	decent	Effect: "Hairless and Airless", Effect Duration: 20
+1602	watered-down bad prussian cathouse with a fly in it	2	decent	
+1603	tolerable weak Mae West with a fly in it	2	good	
 1604	distilled shaking astronaut ice-cream	1		Last Available: "2006-05"
 1605	bouncing delectable catalyst	0		
 1606	dehydrated jittery ultimate wad	1		
@@ -1592,8 +1592,8 @@
 1612	Vulcanized colloidal denatured shaking concentrated cordial of concentration	0		Effect: "Super-Charged", Effect Duration: 56
 1613	coffin lid of courage	0		Spooky Resistance: +3, Damage Reduction: 3
 1614	supercharged satin shield	0		Maximum MP Percent: +30, Damage Reduction: 5
-1615	fortified Cerebral Cloche	0		Damage Absorption: +60, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	blurry Herculean Cerebral Culottes	0		Experience (Muscle): +1, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	fortified Cerebral Cloche	0		Damage Absorption: +60, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	blurry Herculean Cerebral Culottes	0		Experience (Muscle): +1, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	hardy personal trainer's slick Cerebral Crossbow	0		Moxie: +10, Experience Percent (Muscle): +10, Maximum HP: +50, Last Available: "2006-06"
 1618	red ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1603,7 +1603,7 @@
 1623	shaking badger badge	0		Last Available: "2006-06"
 1624	anodized energized blue-frosted astral cupcake	0		Effect: "Burning Ears", Effect Duration: 29, Last Available: "2006-06"
 1625	magnetized altered blinking fuchsia green-frosted astral cupcake	0		Effect: "Fudge Headache", Effect Duration: 16, Last Available: "2006-06"
-1626	alkaline olive pulsating orange-frosted astral cupcake	0		Effect: "Pork Power", Effect Duration: 40, Last Available: "2006-06"
+1626	alkaline pulsating olive orange-frosted astral cupcake	0		Effect: "Pork Power", Effect Duration: 40, Last Available: "2006-06"
 1627	ionized magnetized blinking purple-frosted astral cupcake	0		Effect: "Cold Jellied", Effect Duration: 33, Last Available: "2006-06"
 1628	diffused tumbling pink-frosted astral cupcake	0		Effect: "Twinklebritches", Effect Duration: 11, Last Available: "2006-06"
 1629	Samson's raspberry beret	0		Experience (Muscle): +5, Familiar Effect: "2xPotato, 2xLep, cap 12"
@@ -1616,7 +1616,7 @@
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	vacuum-sealed energized lotion of hotness	0		Effect: "What's That Smell?", Effect Duration: 68
 1638	colloidal double-corrupted jittery lotion of coldness	0		Effect: "Grumpy and Ornery", Effect Duration: 53
-1639	liquefied Vulcanized purple upside-down lotion of spookiness	0		Effect: "Wings of the Grasshopper", Effect Duration: 69
+1639	liquefied Vulcanized upside-down purple lotion of spookiness	0		Effect: "Wings of the Grasshopper", Effect Duration: 69
 1640	vacuum-sealed lotion of stench	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 48
 1641	dry enhanced blinking lotion of sleaziness	0		Effect: "Prideful Strut", Effect Duration: 54
 1642	acceptable Grimacite Bock	3	good	Last Available: "2008-11"
@@ -1630,7 +1630,7 @@
 1650	blurry milk of magnesium	0		
 1651	decent yellow foie gras	4	good	
 1652	dry frozen candy brain	0		Effect: "Alpine Mintiness", Effect Duration: 56, Last Available: "2020-09"
-1653	teal resourceful rock-hard occult jewel-eyed wizard hat	0		Spell Damage Percent: +25, Damage Reduction: 5, Maximum MP: +50, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	teal resourceful rock-hard occult jewel-eyed wizard hat	0		Spell Damage Percent: +25, Damage Reduction: 5, Maximum MP: +50, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	quilted wad of Crovacite of the sweet-tooth	0		Damage Absorption: +40, Candy Drop: +100
 1655	coward's curative collar	0		Monster Level: -20, HP Regen Min: 3, HP Regen Max: 5
 1656	tumbling White Citadel Satisfaction Satchel	0		
@@ -1648,14 +1648,14 @@
 1668	green quilted star boomerang	0		Damage Absorption: +40
 1669	chaotic star stiletto	0		Spell Critical Percent: +10
 1670	tumbling fraudwort	0		
-1671	shaking spinning mirror shysterweed	0		
+1671	mirror shaking spinning shysterweed	0		
 1672	tumbling swindleblossom	0		
 1673	huge foul-smelling manspreader's grave robbing shovel	0		Monster Level: +10, Stench Damage: +10
 1674	cool superhero mask	0		Moxie: +5, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
-1675	bouncing purple mirror ore	0		
+1675	mirror purple bouncing ore	0		
 1676	skewed styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	flame-retardant Rosewater's sword	0		Mysticality Percent: +30, Hot Resistance: +1
 1680	Oprah's staff of the businessman	0		Maximum MP Percent: +50, Meat Drop: +50
 1681	bouncing frosty banded bubblewrap sword	0		Damage Absorption: +100, Cold Spell Damage: +10
@@ -1674,11 +1674,11 @@
 1694	improved Frogade	0		Effect: "Graham Crackling", Effect Duration: 44
 1695	moist pressed yellow papotion of papower	0		Effect: "Fruited", Effect Duration: 51
 1696	super-sized decent royal jelly taco	5	good	
-1697	snack-sized spoiled tofu taco	2	crappy	
-1698	special normal teal blinking jumping bean taco	4	good	Effect: "Slimy Flavor", Effect Duration: 20
-1699	moldy snack-sized catgut taco	2	crappy	
-1700	adequate half-sized upside-down goat cheese taco	2	good	
-1701	adequate skewed teal pr0n taco	3	good	
+1697	spoiled snack-sized tofu taco	2	crappy	
+1698	normal special blinking teal jumping bean taco	4	good	Effect: "Slimy Flavor", Effect Duration: 20
+1699	snack-sized moldy catgut taco	2	crappy	
+1700	half-sized adequate upside-down goat cheese taco	2	good	
+1701	adequate teal skewed pr0n taco	3	good	
 1702	quantum alphabet gum	0		Effect: "Stickler for Promptness", Effect Duration: 65
 1703	Comma Chameleon egg	0		Free Pull
 1704	huge cyan shingle	0		
@@ -1745,8 +1745,8 @@
 1766	blurry wobbly Spookyraven ballroom key	0		
 1767	pulsating pack of chewing gum	0		
 1768	bouncing Gnomish toolbox	0		
-1769	bland diet bouncing fricasseed brains	1	decent	
-1770	stale huge spinning narrow brains casserole	10	decent	
+1769	diet bland bouncing fricasseed brains	1	decent	
+1770	huge stale narrow spinning brains casserole	10	decent	
 1771	butcherknife of the bloodbag	0		Maximum HP: +100
 1772	rock-hard corn holder	0		Damage Reduction: 5
 1773	fireproof eggbeater	0		Hot Resistance: +3
@@ -1754,7 +1754,7 @@
 1775	bouncing lime green dishrag of the ox	0		Muscle: +20
 1776	normal miniature stale baguette	2	good	
 1777	leftovers of indeterminate origin	0		
-1778	gigantic adequate blue dinner	10	good	
+1778	adequate gigantic blue dinner	10	good	
 1779	katana of the overflowing toilet	0		Stench Spell Damage: +50
 1780	tumbling yellow smelly ram stick	0		Stench Spell Damage: +10
 1781	upside-down smelly enchantlers	0		Stench Spell Damage: +10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1766,9 +1766,9 @@
 1787	deionized blurry bag of Cheat-Os	0		Effect: "Bark of the Dog", Effect Duration: 57
 1788	gray unrefined Mountain Stream syrup	0		
 1789	mirror Mob Penguin	0		
-1790	aged distilled Ram's Face Lager	5	awesome	
+1790	distilled aged Ram's Face Lager	5	awesome	
 1791	ram horns	0		
-1792	MacGyver's baleful brainy Travoltan trousers	0		Mysticality: +5, Spell Damage: +25, Maximum MP: +100, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	MacGyver's baleful brainy Travoltan trousers	0		Mysticality: +5, Spell Damage: +25, Maximum MP: +100, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	pool cue of the cougar of the detective	0		Moxie: +20, Item Drop: +20
 1794	enhanced handful of hand chalk	0		Effect: "Violent Night", Effect Duration: 46
 1795	yellow smartaleck's Counterclockwise Watch	0		Moxie Percent: +30, Single Equip
@@ -1786,9 +1786,9 @@
 1807	sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
 1809	pulsating first thoracic vertebra	0		
-1810	bouncing cyan narrow second thoracic vertebra	0		
+1810	narrow cyan bouncing second thoracic vertebra	0		
 1811	pulsating third thoracic vertebra	0		
-1812	pulsating lime green mirror fourth thoracic vertebra	0		
+1812	lime green mirror pulsating fourth thoracic vertebra	0		
 1813	narrow fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
@@ -1825,7 +1825,7 @@
 1846	purple left eighth rib	0		
 1847	left ninth rib	0		
 1848	red left tenth rib	0		
-1849	narrow gray left eleventh rib	0		
+1849	gray narrow left eleventh rib	0		
 1850	left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
@@ -1845,13 +1845,13 @@
 1866	left clavicle	0		
 1867	skewed narrow right clavicle	0		
 1868	left humerus	0		
-1869	fuchsia jittery right humerus	0		
+1869	jittery fuchsia right humerus	0		
 1870	tumbling left radius	0		
 1871	squat right radius	0		
 1872	left ulna	0		
 1873	squat right ulna	0		
 1874	left femur	0		
-1875	bouncing pulsating right femur	0		
+1875	pulsating bouncing right femur	0		
 1876	jittery left tibia	0		
 1877	blinking right tibia	0		
 1878	purple left fibula	0		
@@ -1928,7 +1928,7 @@
 1951	perfectly mixed huge bottle of Pinot Renoir	3	EPIC	
 1952	spoiled desiccated apricot	4	crappy	
 1953	hand-crafted twirling flute of flat champagne	3	EPIC	
-1954	tiny spoiled dehydrated caviar	1	crappy	
+1954	spoiled tiny dehydrated caviar	1	crappy	
 1955	styrofoam peanuts	0		
 1956	acceptable snifter of thoroughly aged brandy	3	good	
 1957	quill pen	0		
@@ -1972,7 +1972,7 @@
 1995	wobbly heart necklace	0		Free Pull
 1996	yellow right half of a heart necklace	0		
 1997	spinning mirror left half of a heart necklace	0		
-1998	blinking narrow yellow pack of KWE trading card	0		
+1998	yellow blinking narrow pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
 2000	shaking shaking Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	huge Vaso De Agua trading card	0		
@@ -1981,7 +1981,7 @@
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	Poison Oak trading card	0		
-2007	tumbling huge Princess Rutabaga trading card	0		
+2007	huge tumbling Princess Rutabaga trading card	0		
 2008	spinning Roo trading card	0		
 2009	Woldo trading card	0		
 2010	spinning The Snake trading card	0		
@@ -1990,18 +1990,18 @@
 2013	purple Serenity trading card	0		
 2014	Inndya trading card	0		
 2015	Kitty the Zmobie Basher trading card	0		
-2016	shaking fuchsia diamond necklace	0		
+2016	fuchsia shaking diamond necklace	0		
 2017	spade necklace	0		
 2018	mirror club necklace	0		
 2019	cream pie	0		Free Pull
 2020	adequate cherry pie	4	good	
 2021	rotten enchanted cyan strawberry pie	3	crappy	Effect: "The Dinsey Spirit", Effect Duration: 5
-2022	moldy jumbo lemon meringue pie	5	crappy	
+2022	jumbo moldy lemon meringue pie	5	crappy	
 2023	special Genalen&trade; Bottle	1	decent	Effect: "Thickest, Sickest", Effect Duration: 30
 2024	bland mixed wildflower greens	3	decent	
 2025	rotten handful of walnuts	4	crappy	
 2026	super-sized moldy nutty organic salad	5	crappy	
-2027	spoiled half-sized super salad	2	crappy	
+2027	half-sized spoiled super salad	2	crappy	
 2028	delicious tofu wonton	3	awesome	
 2029	hippy protest button	0		Single Equip
 2030	mirror cyan stylish beefy Lockenstock&trade; sandals	0		Muscle: +10, Moxie: +25, Single Equip
@@ -2016,11 +2016,11 @@
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
 2041	ferret bait	0		
-2042	spinning ghostly exploding hacky-sack	0		
+2042	ghostly spinning exploding hacky-sack	0		
 2043	hemp net	0		
 2044	spinning your father's MacGuffin diary	0		
 2045	yummy brain-meltingly-hot chicken wings	4	awesome	
-2046	snack-sized bland frat brats	2	decent	
+2046	bland snack-sized frat brats	2	decent	
 2047	flavorless immense knob ka-bobs	8	decent	
 2049	artisanal mirror wobbly can of Swiller	3	EPIC	
 2050	broken wings	0		
@@ -2032,11 +2032,11 @@
 2056	triple-improved bouncing skewed adder bladder	0		Effect: "Warm Belly", Effect Duration: 47
 2057	pension check	0		
 2058	picnic basket	0		
-2059	galvanized ionized moist upside-down narrow teal Black No. 2	0		Effect: "Browbeaten", Effect Duration: 58
+2059	galvanized ionized moist upside-down teal narrow Black No. 2	0		Effect: "Browbeaten", Effect Duration: 58
 2060	fuchsia narrow pulsating knitted greasy sword	0		Sleaze Spell Damage: +10, Cold Resistance: +3
 2061	green mansplainer's helmet	0		Monster Level: +15, Familiar Effect: "1xFairy, cap 40"
 2062	blurry wholesome shield of courage	0		Maximum HP Percent: +10, Spooky Resistance: +3, Damage Reduction: 10
-2063	half-sized moldy narrow blackberry	2	crappy	
+2063	moldy half-sized narrow blackberry	2	crappy	
 2064	upside-down forged identification documents	0		
 2065	PADL Phone	0		
 2066	baleful Da Vinci's kick-ass kicks	0		Experience (Mysticality): +5, Spell Damage: +25, Single Equip
@@ -2057,17 +2057,17 @@
 2081	studded makeshift skirt	0		Damage Absorption: +80, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 2082	toothbrush	0		
 2083	makeshift crane	0		
-2084	mirror lime green can of starch	0		
+2084	lime green mirror can of starch	0		
 2085	twisted bottle of ultravitamins	1		
 2086	altered huge bottle of cough syrup	1		Effect: "Tiki Thoughtfulness", Effect Duration: 25
-2087	distilled skewed fuchsia tube of hair oil	1		
+2087	distilled fuchsia skewed tube of hair oil	1		
 2088	unsweetened Daffy Taffy	0		Effect: "Armor-Plated", Effect Duration: 14
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	cyan Tesla electrified educational sage pilgrim shield of temperance	0		Mysticality Percent: +10, Experience: +1, Sleaze Resistance: +5, MP Regen Min: 10, MP Regen Max: 15, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	aromatic hors d'oeuvre tray	0		Stench Resistance: +1, Damage Reduction: 5
-2094	bland special super-sized ballroom blintz	5	decent	Effect: "Think Win-Lose", Effect Duration: 10
+2094	bland super-sized special ballroom blintz	5	decent	Effect: "Think Win-Lose", Effect Duration: 10
 2095	towel	0		
 2096	altered guy made of bee pollen	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 20
 2097	stanky 17-ball	0		Stench Spell Damage: +25
@@ -2090,7 +2090,7 @@
 2114	gray yo	0		Last Available: "2006-12"
 2115	grievous prehistoric spear	0		Weapon Damage Percent: +50, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	ghostly family-friendly fortified fire	0		Damage Absorption: +60, Sleaze Resistance: +1, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	ghostly family-friendly fortified fire	0		Damage Absorption: +60, Sleaze Resistance: +1, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	narrow lit cigar	0		Last Available: "2011-12"
 2120	prompt Grateful Undead T-shirt	0		Adventures: +3
@@ -2121,9 +2121,9 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	bouncing toothsome rock	0		
-2149	tiny moldy squat frank	1	crappy	Last Available: "2011-12"
-2150	spoiled miniature teal plate of franks and beans	2	crappy	Last Available: "2011-12"
-2151	weak smooth gray shot of blackberry schnapps	2	awesome	
+2149	moldy tiny squat frank	1	crappy	Last Available: "2011-12"
+2150	miniature spoiled teal plate of franks and beans	2	crappy	Last Available: "2011-12"
+2151	smooth weak gray shot of blackberry schnapps	2	awesome	
 2152	spinning capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	upside-down ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	wool strapping toy ray gun	0		Muscle: +5, Cold Resistance: +1, Last Available: "2006-12"
-2169	pulsating toy space helmet of the overflowing toilet of the cheetah	0		Stench Spell Damage: +50, Initiative: +60, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	pulsating toy space helmet of the overflowing toilet of the cheetah	0		Stench Spell Damage: +50, Initiative: +60, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	purple chilly astronaut pants of chilblains	0		Cold Damage: 30, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	purple chilly astronaut pants of chilblains	0		Cold Damage: 30, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	brainy toy jet pack	0		Mysticality: +5, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2182,26 +2182,26 @@
 2207	stiffened Crimbo tiki necklace	0		Damage Reduction: 1, Last Available: "2006-12"
 2208	bobble-hip hula elf doll of incineration of the sweet-tooth	0		Hot Spell Damage: +50, Candy Drop: +100, Last Available: "2006-12"
 2209	lime green electrified Crimbo ukulele	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12"
-2210	Tiki lighter of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Spell Damage: +50, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	prompt educational deck of tropical cards	0		Experience: +1, Adventures: +3, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	spinning family-friendly tropical paperweight of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +1, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	Tiki lighter of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Spell Damage: +50, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	prompt educational deck of tropical cards	0		Experience: +1, Adventures: +3, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	spinning family-friendly tropical paperweight of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +1, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	Tropical Crimbo Hat of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	shaking scandalous Tropical Crimbo Shorts	0		Sleaze Damage: +5, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	Tropical Crimbo Hat of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	shaking scandalous Tropical Crimbo Shorts	0		Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	snack-sized stale squat super ka-bob	2	decent	
-2218	immense enchanted normal beer basted brat	6	good	Effect: "Devil Inside", Effect Duration: 50
+2218	normal immense enchanted beer basted brat	6	good	Effect: "Devil Inside", Effect Duration: 50
 2219	pulsating nippy Tropical Crimbo Sword	0		Cold Damage: +10, Last Available: "2006-12"
 2220	vacuum-sealed alkaline and Crimboween candy	0		Effect: "Barbecue Saucy", Effect Duration: 24, Last Available: "2020-09"
 2221	skewed Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	skewed red censurious savvy liar's pants	0		Mysticality Percent: +20, Sleaze Resistance: +3, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	skewed red censurious savvy liar's pants	0		Mysticality Percent: +20, Sleaze Resistance: +3, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	nasty energetic juggler's balls	0		Maximum MP Percent: +20, Stench Damage: +5, Softcore Only, Last Available: "2007-01"
 2224	blue frightening pink shirt	0		Spooky Damage: +5, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	dog trainer's evil eyeball pendant of the brute	0		Muscle Percent: +30, Experience (familiar): +1, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	frozen non-altered blinking arse-a'fire elixir	0		Effect: "Stenchtastic", Effect Duration: 44, Last Available: "2007-01"
 2228	tarnished altered cosmic lemonade	0		Effect: "Covetous Robbery", Effect Duration: 66, Last Available: "2007-01"
-2229	modified corrupted twirling fuchsia toad horn	0		Effect: "Conspiratory Eyes", Effect Duration: 29, Last Available: "2007-01"
+2229	modified corrupted fuchsia twirling toad horn	0		Effect: "Conspiratory Eyes", Effect Duration: 29, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	mote	0		
 2232	blurry smudged alchemical recipe	0		
@@ -2212,7 +2212,7 @@
 2237	yellow pygmy blowgun	0		
 2238	grievous pygmy nose-bone	0		Weapon Damage Percent: +50, Single Equip
 2239	wool nasty bad voodoo mask	0		Stench Damage: +5, Cold Resistance: +1, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
-2240	upside-down tumbling bottle of alcohol	0		
+2240	tumbling upside-down bottle of alcohol	0		
 2241	narrow arcane researcher's pygmy spear	0		Experience Percent (Mysticality): +10
 2242	dry pressed twirling fuchsia pygmy pygment	0		Effect: "Action", Effect Duration: 36
 2243	Tesla curative headhunter necktie	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Single Equip
@@ -2235,20 +2235,20 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	miniature rotten bouncing stunt nuts	2	crappy	
+2264	rotten miniature bouncing stunt nuts	2	crappy	
 2265	yummy twirling wet stew	3	awesome	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats of wisdom	0		Mysticality: +15
 2269	spoiled gray sausage wonton	3	crappy	
 2270	Usain Bolt's censurious belt	0		Sleaze Resistance: +3, Initiative: +80, Single Equip
-2271	practically non-alcoholic tolerable bottle of Merlot	1	good	
+2271	tolerable practically non-alcoholic bottle of Merlot	1	good	
 2272	lousy bottle of Port	4	decent	
-2273	high-proof drinkable bottle of Pinot Noir	8	good	
+2273	drinkable high-proof bottle of Pinot Noir	8	good	
 2274	perfectly mixed bottle of Zinfandel	3	EPIC	
-2275	tolerable weak wobbly spinning bottle of Marsala	2	good	
+2275	tolerable weak spinning wobbly bottle of Marsala	2	good	
 2276	smooth jittery bottle of Muscat	4	awesome	
-2277	tumbling tumbling olive Fernswarthy's key	0		
+2277	tumbling olive tumbling Fernswarthy's key	0		
 2278	wobbly Fernswarthy's letter	0		
 2279	book	0		
 2280	Manual of Labor	0		
@@ -2274,7 +2274,7 @@
 2300	red fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	blinking worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	polymerized galvanized ionized narrow candy heart	0		Effect: "Like a Fish to Walter", Effect Duration: 27, Last Available: "2007-02"
 2305	enhanced cold-filtered pink candy heart	0		Effect: "So Fresh and So Clean", Effect Duration: 26, Last Available: "2007-02"
 2306	electrified quantum quantum candy heart	0		Effect: "La Bamba", Effect Duration: 45, Last Available: "2007-02"
@@ -2282,7 +2282,7 @@
 2308	nitrogenated adjusted candy heart	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2007-02"
 2309	electrified frozen candy heart	0		Effect: "Stench Jellied", Effect Duration: 19, Last Available: "2007-02"
 2310	pulsating candygram	0		Last Available: "2007-02"
-2311	ghostly lime green pink candygram	0		Last Available: "2007-02"
+2311	lime green ghostly pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
 2313	shaking candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
@@ -2303,19 +2303,19 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	jittery bouquet of circular saw blades	0		
-2332	fancy super-sized adequate huge lime green Better Than Cuddling Cake	5	good	Effect: "Elemental Flavor", Effect Duration: 45
+2332	super-sized adequate fancy lime green huge Better Than Cuddling Cake	5	good	Effect: "Elemental Flavor", Effect Duration: 45
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	cyan rubber WWBBDD? bracelet	0		
 2336	upside-down beefcake's pipe of dire peril	0		Muscle: +25, Weapon Damage: +20
 2337	gravedigger's reinforced beaded headband	0		Spooky Damage: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	decent green pudding	4	good	Wiki Name: "black pudding (food)"
-2339	practically non-alcoholic hand-crafted mirror Blackfly Chardonnay	1	EPIC	
+2339	hand-crafted practically non-alcoholic mirror Blackfly Chardonnay	1	EPIC	
 2340	artisanal & tan	3	EPIC	
 2341	pulsating pepper	0		
 2342	toothsome forest cake	3	awesome	
-2343	special bland forest ham	3	decent	Effect: "Devil Inside", Effect Duration: 5
-2344	non-enhanced flattened irradiated tumbling squat green filthworm hatchling scent gland	0		Effect: "Tenacity of the Snapper", Effect Duration: 24
+2343	bland special forest ham	3	decent	Effect: "Devil Inside", Effect Duration: 5
+2344	non-enhanced flattened irradiated green tumbling squat filthworm hatchling scent gland	0		Effect: "Tenacity of the Snapper", Effect Duration: 24
 2345	cold-filtered mirror filthworm drone scent gland	0		Effect: "Boilermade", Effect Duration: 27
 2346	altered triple-Vulcanized colloidal spinning filthworm royal guard scent gland	0		Effect: "There Is A Spoon", Effect Duration: 47
 2347	heart of the filthworm queen	0		
@@ -2325,7 +2325,7 @@
 2351	superamplified boom box	0		
 2352	wholesome fire poi of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +10
 2353	bejeweled pledge pin of Tarzan	0		Experience (Muscle): +3, Single Equip
-2354	shaking bouncing communications windchimes	0		
+2354	bouncing shaking communications windchimes	0		
 2355	denatured energized tumbling henna face paint	0		Effect: "Nuts about Candy", Effect Duration: 31
 2356	frozen activated tube of dread wax	0		Effect: "Moon-Eyed", Effect Duration: 64
 2357	clever Gaia beads of Leguizamo	0		Maximum MP: +20, Monster Level: +20
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	huge bunch of bananas	0		
-2373	stale jumbo banana	5	decent	
+2373	jumbo stale banana	5	decent	
 2374	banana peel	0		
-2375	massive toothsome banana cream pie	9	awesome	
+2375	toothsome massive banana cream pie	9	awesome	
 2376	aged banana daiquiri	4	awesome	
 2377	bad bungle in the jungle	4	decent	
 2378	blurry banana spritzer	0		
@@ -2396,7 +2396,7 @@
 2422	dry wet twirling irradiated pet snacks	0		Effect: "Unusual Perspective", Effect Duration: 13
 2423	warmed galvanized wobbly Mick's IcyVapoHotness Inhaler	0		Effect: "Cat Class, Cat Style", Effect Duration: 22
 2424	Vulcanized cyclops eyedrops	0		Effect: "Become Superficially interested", Effect Duration: 51
-2425	magnetized diffused red upside-down can of spinach	0		Effect: "It's Soporiffic!", Effect Duration: 20
+2425	magnetized diffused upside-down red can of spinach	0		Effect: "It's Soporiffic!", Effect Duration: 20
 2426	corrupted galvanized narrow fire flower	0		Effect: "Twinklebritches", Effect Duration: 39
 2427	liquefied freezerburned ice cube	0		Effect: "Feelin' Philosophical", Effect Duration: 36
 2428	denatured wet olive skewed fake blood	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 17
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	red Cobb's Knob map	0		
 2443	lime green scandalous stylish pink glowstick	0		Moxie: +25, Sleaze Damage: +5, Last Available: "2007-03"
-2444	tolerable watered-down Supernova Champagne	2	good	
+2444	watered-down tolerable Supernova Champagne	2	good	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2491,8 +2491,8 @@
 2518	spinning sawblade shield of the bloodbag	0		Maximum HP: +100, Damage Reduction: 11
 2519	triple-distilled drinkable McMillicancuddy's Special Lager	7	good	
 2520	lousy melted Jell-o shot	4	decent	
-2521	practically non-alcoholic perfectly mixed cruelty-free wine	1	EPIC	
-2522	special bad twirling thistle wine	3	decent	Effect: "Flexibili Tea", Effect Duration: 5
+2521	perfectly mixed practically non-alcoholic cruelty-free wine	1	EPIC	
+2522	bad special twirling thistle wine	3	decent	Effect: "Flexibili Tea", Effect Duration: 5
 2523	megatofu	0		
 2524	squat displaced fish	0		
 2525	adequate red fish	3	good	
@@ -2518,12 +2518,12 @@
 2545	diffused magnetized tumbling upsy daisy	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 51, Last Available: "2007-05"
 2546	wet half-orchid	0		Effect: "20-20 Second Sight", Effect Duration: 42, Last Available: "2007-05"
 2547	shaking purple beefcake's tin star of courage	0		Muscle: +25, Spooky Resistance: +3, Last Available: "2007-05"
-2548	yellow occult brawny outrageous sombrero	0		Muscle Percent: +20, Spell Damage Percent: +25, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	yellow occult brawny outrageous sombrero	0		Muscle Percent: +20, Spell Damage Percent: +25, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	upside-down Jim Carey's manspreader's &quot;Humorous&quot; T-shirt	0		Monster Level: 35, Last Available: "2007-05"
 2550	twirling pulsating Peppercorns of Power	0		
 2551	blurry vial of mojo	0		
 2552	reeds	0		
-2553	blurry skewed turtle chain	0		
+2553	skewed blurry turtle chain	0		
 2554	distilled seal blood	0		
 2555	huge high-octane olive oil	0		
 2556	squat clever Sinatra's Shagadelic Disco Banjo of the detective	0		Experience (Moxie): +5, Maximum MP: +20, Item Drop: +20, Class: "Disco Bandit"
@@ -2553,7 +2553,7 @@
 2580	greedy scorpion whip of the brute	0		Muscle Percent: +30, Meat Drop: +20
 2581	upside-down handful of sand	0		
 2582	brick of sand	0		
-2583	decent diet centipede eggs	1	good	
+2583	diet decent centipede eggs	1	good	
 2584	gray toasty wonderwall shield	0		Hot Damage: +5, Damage Reduction: 12
 2585	lime green Colonel Mustard's Lonely Spades Club Jacket of the cougar	0		Moxie: +20
 2586	hardened General Sage's Lonely Diamonds Club Jacket	0		Damage Reduction: 3
@@ -2561,7 +2561,7 @@
 2588	MacGyver's Private Pepper's Lonely Hearts Club Jacket	0		Maximum MP: +100
 2589	moldy hot date	4	crappy	
 2590	hand-crafted upside-down distilled fortified wine	3	EPIC	
-2591	half-sized flavorless tasty tart	2	decent	
+2591	flavorless half-sized tasty tart	2	decent	
 2592	Knob Goblin lunchbox	0		
 2593	adequate bouncing Knob pasty	3	good	
 2594	practically non-alcoholic aged thermos full of Knob coffee	1	awesome	
@@ -2589,7 +2589,7 @@
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	Fonzie's Iiti Kitty phone charm	0		Experience (Moxie): +1, Single Equip
-2619	olive skewed jar of swamp gas	0		Last Available: "2007-05"
+2619	skewed olive jar of swamp gas	0		Last Available: "2007-05"
 2620	bland super-sized unidentified jerky	5	decent	
 2621	upside-down aromatic nasty rat mask of the scaredy-cat	0		Monster Level: -15, Stench Resistance: +1, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	weightlifter's ratskin belt of the sewer	0		Muscle: +15, Stench Damage: +25, Single Equip
@@ -2624,27 +2624,27 @@
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	decent S.T.L.T.	4	good	Last Available: "2007-06"
 2653	spoiled honey-dew	3	crappy	Last Available: "2007-06"
-2654	irresponsibly strong perfectly mixed Xanadian	8	EPIC	Last Available: "2007-06"
+2654	perfectly mixed irresponsibly strong Xanadian	8	EPIC	Last Available: "2007-06"
 2655	concentrated quantum pulsating bottle of absinthe	0		Effect: "In the Limelight", Effect Duration: 16, Last Available: "2007-06"
 2656	friendly Drowsy Sword of wisdom	0		Mysticality: +15, Familiar Weight: +3
-2657	stale super-sized escargotsicle	5	decent	Last Available: "2007-06"
-2658	boozy tolerable bottle of realpagne	5	good	Last Available: "2007-06"
+2657	super-sized stale escargotsicle	5	decent	Last Available: "2007-06"
+2658	tolerable boozy bottle of realpagne	5	good	Last Available: "2007-06"
 2659	albatross necklace of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2007-06"
 2660	dehydrated not-a-pipe	1	good	Last Available: "2007-06"
 2661	tolerable fortified flask of Amontillado	5	good	Last Available: "2007-06"
-2662	tumbling lime green Temple Grandin's ball mask	0		Familiar Weight: +7, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	pulsating Oprah's Can-Can skirt	0		Maximum MP Percent: +50, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	tumbling lime green Temple Grandin's ball mask	0		Familiar Weight: +7, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	pulsating Oprah's Can-Can skirt	0		Maximum MP Percent: +50, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	wet altered yellow sensitive poetry journal	0		Effect: "Arse-a'fire", Effect Duration: 13, Last Available: "2007-06"
 2665	non-aerosolized moist huge red bottled inspiration	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 26, Last Available: "2007-06"
-2666	electrified pulsating blue bellhop bell	0		Effect: "Blackberry Politeness", Effect Duration: 16, Last Available: "2007-06"
-2667	wet pulsating blurry spiky collar	0		Effect: "Highland Sheen", Effect Duration: 47, Last Available: "2007-06"
+2666	electrified blue pulsating bellhop bell	0		Effect: "Blackberry Politeness", Effect Duration: 16, Last Available: "2007-06"
+2667	wet blurry pulsating spiky collar	0		Effect: "Highland Sheen", Effect Duration: 47, Last Available: "2007-06"
 2668	twisted can-can-in-a-can	1		Last Available: "2007-06"
 2669	mixed patent antipsychotics	1		Effect: "White-boy Angst", Effect Duration: 15, Last Available: "2007-06"
-2670	diluted spinning olive Mariner's Friend cough drops	1		Effect: "Worth Your Salt", Effect Duration: 30, Last Available: "2007-06"
+2670	diluted olive spinning Mariner's Friend cough drops	1		Effect: "Worth Your Salt", Effect Duration: 30, Last Available: "2007-06"
 2671	lousy shot of nepenthe schnapps	4	decent	Last Available: "2007-06"
 2672	fuchsia library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
-2674	moist colloidal narrow mirror bottle of cat tonic	0		Effect: "The Smeezingtons", Effect Duration: 68, Last Available: "2007-06"
+2674	moist colloidal mirror narrow bottle of cat tonic	0		Effect: "The Smeezingtons", Effect Duration: 68, Last Available: "2007-06"
 2675	twisted huge purple handful of moss	1		
 2676	vaporized maroon bit-o-cactus	1		
 2677	denatured yellow wobbly protein powder	1		Effect: "Nas Tea", Effect Duration: 50
@@ -2665,7 +2665,7 @@
 2692	baleful dangerous driftwood sculpture	0		Weapon Damage: +10, Spell Damage: +25
 2693	sage massive sitar of the businessman	0		Mysticality Percent: +10, Meat Drop: +50
 2694	zippy wizardly stone baseball cap of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100, Initiative: +20, Familiar Effect: "1xVolley, cap 48"
-2695	triple-distilled artisanal cup of beer	10	EPIC	
+2695	artisanal triple-distilled cup of beer	10	EPIC	
 2696	purple ovoid thing	0		
 2697	duct tape	0		
 2698	twirling duct tape wallet	0		
@@ -2681,7 +2681,7 @@
 2708	boiled triple-vacuum-sealed ionized funky dried mushroom	0		Effect: "Crimbo Nostalgia", Effect Duration: 17
 2709	wobbly exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
-2711	chilled improved gray shaking facepaint	0		Effect: "Gummiheart", Effect Duration: 11
+2711	chilled improved shaking gray facepaint	0		Effect: "Gummiheart", Effect Duration: 11
 2712	activated jittery sheepskin diploma	0		Effect: "Woad Warrior", Effect Duration: 55
 2713	moist bouncing Black Body&trade; spray	0		Effect: "Human-Penguin Hybrid", Effect Duration: 53
 2714	teal floorboard cruft	0		
@@ -2694,30 +2694,30 @@
 2721	vibrating medical-grade Fonzie's hand-carved staff	0		Experience (Moxie): +1, Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10
 2722	scorching veiny Staff of the Greasefire of extreme caution of mayonnaise	0		Maximum HP: +10, Monster Level: -25, Hot Damage: +25, Sleaze Spell Damage: +50
 2723	narrow horrifying Staff of the Grand Flamb&eacute; of bravery of the cheetah	0		Spooky Damage: +25, Spooky Resistance: +5, Initiative: +60
-2724	stale upside-down olive bowl of rye sprouts	3	decent	
+2724	stale olive upside-down bowl of rye sprouts	3	decent	
 2725	flavorless snack-sized huge cob of corn	2	decent	
 2726	snack-sized moldy mirror jittery juniper berries	2	crappy	
 2727	moldy plum	3	crappy	
 2728	miniature toothsome pear	2	awesome	
 2729	adequate peach	3	good	
 2730	mediocre shaking plum wine	3	decent	
-2731	weak lousy shot of pear schnapps	2	decent	
-2732	weak bad shot of peach schnapps	2	decent	
+2731	lousy weak shot of pear schnapps	2	decent	
+2732	bad weak shot of peach schnapps	2	decent	
 2733	spoiled bunch of square grapes	4	crappy	
 2734	rotten brown sugar cane	3	crappy	
-2735	fancy immense flavorless sandwich of the gods	9	decent	Effect: "Staying Frosty", Effect Duration: 20
-2736	watered-down bad Pan-Dimensional Gargle Blaster	2	decent	
+2735	flavorless immense fancy sandwich of the gods	9	decent	Effect: "Staying Frosty", Effect Duration: 20
+2736	bad watered-down Pan-Dimensional Gargle Blaster	2	decent	
 2737	powdered wobbly leopard-print barbell	1	EPIC	
 2738	blue pile of smoking rags	0		
-2739	quadruple-flattened shaking olive panty raider camouflage	0		Effect: "The Power of Positive Thinking", Effect Duration: 67
+2739	quadruple-flattened olive shaking panty raider camouflage	0		Effect: "The Power of Positive Thinking", Effect Duration: 67
 2740	double-paned quilted supercool Staff of the Walk-In Freezer	0		Moxie Percent: +20, Damage Absorption: +40, Cold Resistance: +5
 2741	delicious practically non-alcoholic blinking boilermaker	1	awesome	
 2742	stale steel lasagna	4	quest	
-2743	distilled bad steel margarita	5	quest	
+2743	bad distilled steel margarita	5	quest	
 2744	denatured narrow steel-scented air freshener	1		Effect: "Sauce Monocle", Effect Duration: 50
 2745	galvanized blinking spinning fuchsia gremlin mutagen	0		Effect: "On a Roll", Effect Duration: 30
 2746	triple-adjusted extra-potent gremlin mutagen	0		Effect: "Floundering", Effect Duration: 47
-2747	olive tumbling chunk of depleted Grimacite	0		Last Available: "2011-12"
+2747	tumbling olive chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	skewed furniture dolly of the brazier	0		Hot Spell Damage: +25, Single Equip
 2749	aromatic hardened Staff of the Grease Trap of bravery	0		Damage Reduction: 3, Spooky Resistance: +5, Stench Resistance: +1
 2750	tumbling upside-down Jack Frost's wholesome Uranium Omega of Temperance	0		Maximum HP Percent: +10, Cold Spell Damage: +50, Single Equip
@@ -2779,7 +2779,7 @@
 2806	polarized vial of porquoise juice	0		Effect: "Sugary World View", Effect Duration: 66
 2807	chilled flask of hamethyst juice	0		Effect: "Loyal Tea", Effect Duration: 39
 2808	cold-filtered flask of baconstone juice	0		Effect: "Blessing of Charcoatl", Effect Duration: 33
-2809	deionized bouncing mirror flask of porquoise juice	0		Effect: "Tennis Elbow-wow", Effect Duration: 53
+2809	deionized mirror bouncing flask of porquoise juice	0		Effect: "Tennis Elbow-wow", Effect Duration: 53
 2810	pickled cold-filtered jug of hamethyst juice	0		Effect: "Notably Lovely", Effect Duration: 22
 2811	diffused squat jug of baconstone juice	0		Effect: "It's Electric!", Effect Duration: 34
 2812	irradiated extra-wet chilled jug of porquoise juice	0		Effect: "Berry Defensive", Effect Duration: 37
@@ -2789,9 +2789,9 @@
 2816	upside-down sizzling Oprah's Boxers of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Hot Damage: +10, Familiar Effect: "1xVolley, 1xLep"
 2817	narrow tumbling fuchsia mansplainer's veiny rock-hard Brooch	0		Damage Reduction: 5, Maximum HP: +10, Monster Level: +15, Single Equip
 2818	wool Jim Carey's wizardly Bracelet	0		Mysticality: +25, Monster Level: +25, Cold Resistance: +1, Single Equip
-2819	therapeutic Socratic Grimacite gasmask	0		Experience (Mysticality): +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	therapeutic Socratic Grimacite gasmask	0		Experience (Mysticality): +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	studded Grimacite gat of temperance	0		Damage Absorption: +80, Sleaze Resistance: +5, Last Available: "2008-11"
-2821	razor-sharp Grimacite gaiters of Gandalf	0		Weapon Damage Percent: +25, Spell Critical Percent: +20, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	razor-sharp Grimacite gaiters of Gandalf	0		Weapon Damage Percent: +25, Spell Critical Percent: +20, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	therapeutic steel-toed Grimacite gauntlets	0		Damage Reduction: 9, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2008-11"
 2823	Jack Frost's clever Grimacite go-go boots	0		Maximum MP: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2008-11"
 2824	huge shellacked Grimacite girdle of Calamity Jane	0		Damage Reduction: 7, Critical Hit Percent: +15, Single Equip, Last Available: "2008-11"
@@ -2810,7 +2810,7 @@
 2837	purple narrow mint-condition magic wand	0		Last Available: "2011-12"
 2838	Usain Bolt's knitted glowstick	0		Cold Resistance: +3, Initiative: +80, Last Available: "2007-08"
 2839	cyan sizzling Periodical Paintbrush	0		Hot Damage: +10, Softcore Only
-2840	enchanted triple-distilled bad wobbly bottle of cooking sherry	9	decent	Effect: "Liquid Courage", Effect Duration: 30
+2840	bad enchanted triple-distilled wobbly bottle of cooking sherry	9	decent	Effect: "Liquid Courage", Effect Duration: 30
 2841	normal packet of ketchup	3	good	
 2842	fortified hand-crafted green accidental cider	5	EPIC	
 2843	decent blinking dire fudgesicle	3	good	
@@ -2830,7 +2830,7 @@
 2857	super-enhanced cold-filtered ghostly seegar butt	0		Effect: "Super Structure", Effect Duration: 47
 2858	skewed bottled swamp gas	0		
 2859	jittery extremely unsafe witch wart of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5
-2860	normal small swamp muck	2	good	
+2860	small normal swamp muck	2	good	
 2861	lion tamer's shellacked leechknife of the detective	0		Damage Reduction: 7, Experience (familiar): +2, Item Drop: +20
 2862	decomposed boot	0		
 2863	activated colloidal dribbly candle	0		Effect: "Big Meat Big Prizes", Effect Duration: 47
@@ -2910,7 +2910,7 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	enchanted huge normal Surprise Egg	10	good	Effect: "Aries Rising", Effect Duration: 35
+2940	normal enchanted huge Surprise Egg	10	good	Effect: "Aries Rising", Effect Duration: 35
 2941	non-deionized polymerized Steal This Candy	0		Effect: "Deadly Lampblade", Effect Duration: 68
 2942	irradiated liquefied ionized blinking chocolate filthy lucre	0		Effect: "Gunky Dory", Effect Duration: 42
 2943	modified aerosolized Angry Farmer's Wife Candy	0		Effect: "You Can Taste the Darkness", Effect Duration: 42
@@ -2945,11 +2945,11 @@
 2973	flame-wreathed grumpy man charrrm bracelet	0		Hot Spell Damage: +10, Single Equip
 2974	narrow tarrrnish charrrm	0		
 2975	inspector's tarrrnished charrrm bracelet of the scaredy-cat	0		Monster Level: -15, Item Drop: +15, Single Equip
-2976	strong aged shaking tumbling spinning bilge wine	5	awesome	
+2976	aged strong shaking spinning tumbling bilge wine	5	awesome	
 2977	horrifying witty rapier	0		Spooky Damage: +25
 2978	greedy brawny yohohoyo	0		Muscle Percent: +20, Meat Drop: +20
-2979	colloidal aerosolized shaking olive fish-liver oil	0		Effect: "Flaming Weapon", Effect Duration: 37
-2980	blinking huge booty chest charrrm	0		
+2979	colloidal aerosolized olive shaking fish-liver oil	0		Effect: "Flaming Weapon", Effect Duration: 37
+2980	huge blinking booty chest charrrm	0		
 2981	flame-wreathed booty chest charrrm bracelet	0		Hot Spell Damage: +10, Single Equip
 2982	cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
@@ -2963,7 +2963,7 @@
 2991	clingfilm slippers of horror	0		Spooky Spell Damage: +25, Single Equip
 2992	clingfilm tangle	0		
 2993	adequate narrow vinegar-soaked lemon slice	4	good	
-2994	double-magnetized irradiated pulsating skewed pulsating true grit	0		Effect: "Using Protection", Effect Duration: 20
+2994	double-magnetized irradiated skewed pulsating pulsating true grit	0		Effect: "Using Protection", Effect Duration: 20
 2995	fireproof extremely unsafe strapping buoybottoms	0		Muscle: +5, Weapon Damage Percent: +100, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	supercool grungy flannel shirt	0		Moxie Percent: +20
 2997	blinking rosewater-soaked boxer's grungy bandana	0		Muscle Percent: +10, Stench Resistance: +3, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
@@ -2994,29 +2994,29 @@
 3022	squat medium stone triangle	0		
 3023	bouncing small stone triangle	0		
 3024	stone pyramid	0		
-3025	weak perfectly mixed corpse on the beach	2	super ultra mega EPIC	
+3025	perfectly mixed weak corpse on the beach	2	super ultra mega EPIC	
 3026	drinkable corpsetini	3	good	
 3027	artisanal corpsedriver	4	EPIC	
 3028	artisanal weak ghostly Corpse Island iced tea	2	super ultra mega EPIC	
 3029	delicious red-headed corpse	3	awesome	
 3030	artisanal pulsating kamicorpse-ee	4	EPIC	
-3031	weak perfectly mixed corpsel	2	EPIC	
-3032	enchanted boozy smooth corpsebite	5	awesome	Effect: "Frozen Shoulders", Effect Duration: 10
+3031	perfectly mixed weak corpsel	2	EPIC	
+3032	smooth enchanted boozy corpsebite	5	awesome	Effect: "Frozen Shoulders", Effect Duration: 10
 3033	groovy pirate fledges	0		Moxie Percent: +10
 3034	mirror piece of thirteen	0		
 3035	stale pearl onion	4	decent	
-3036	normal huge sea biscuit	6	good	
+3036	huge normal sea biscuit	6	good	
 3037	lousy bottle of rum	3	decent	
 3038	hand-crafted weak bottle of black-label rum	2	EPIC	
 3039	mirror cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
 3042	shaking huge Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
-3043	upside-down jittery metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	massive bland blinking nanite-infested gingerbread bugbear	9	decent	Last Available: "2007-12"
+3043	jittery upside-down metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3045	bland massive blinking nanite-infested gingerbread bugbear	9	decent	Last Available: "2007-12"
 3046	decent enchanted shaking nanite-infested candy cane	3	good	Effect: "Meadulla Oblongota", Effect Duration: 15, Last Available: "2020-09"
-3047	bland skewed green nanite-infested fruitcake	3	decent	Last Available: "2007-12"
+3047	bland green skewed nanite-infested fruitcake	3	decent	Last Available: "2007-12"
 3048	watered-down smooth nanite-infested eggnog	2	awesome	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	twirling nasty eyepatch	0		Stench Damage: +5, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3025,12 +3025,12 @@
 3053	red mood ring	0		Last Available: "2007-02"
 3054	pressed mirror candy heart	0		Effect: "Icy Demeanor", Effect Duration: 29, Last Available: "2007-02"
 3055	boiled pickled cymbal syrup	0		Free Pull, Effect: "In the Limelight", Effect Duration: 54, Last Available: "2007-02"
-3056	metallic foil cat ears of bravery	0		Spooky Resistance: +5, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	metallic foil cat ears of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	narrow theoretical string	0		Last Available: "2007-12"
 3060	synthetic stuffing	0		Last Available: "2007-12"
-3061	red huge toy hoverpad	0		Last Available: "2007-12"
+3061	huge red toy hoverpad	0		Last Available: "2007-12"
 3062	jittery LED block	0		Last Available: "2007-12"
 3063	gyroscope	0		Last Available: "2010-12"
 3064	avaricious cyborg doll	0		Meat Drop: +30, Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	olive Sherlock's roboduck-on-a-string of bravery	0		Spooky Resistance: +5, Item Drop: +25, Last Available: "2007-12"
 3086	twirling ghostly mylar scout drone	0		Last Available: "2007-12"
 3087	olive teddy borg sewing kit	0		Last Available: "2007-12"
-3088	aromatic hardened biomechanical crimborg helmet	0		Damage Reduction: 3, Stench Resistance: +1, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	aromatic hardened biomechanical crimborg helmet	0		Damage Reduction: 3, Stench Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	wholesome forbidden C.B.F.G.	0		Spell Damage Percent: +50, Maximum HP Percent: +10, Last Available: "2007-12"
-3090	avaricious sizzling biomechanical crimborg leg armor	0		Hot Damage: +10, Meat Drop: +30, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	avaricious sizzling biomechanical crimborg leg armor	0		Hot Damage: +10, Meat Drop: +30, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	colloidal polymerized huge vitachoconutriment capsule	0		Effect: "Three Days Slow", Effect Duration: 44, Last Available: "2007-12"
 3092	extremely unsafe handmade hobby horse	0		Weapon Damage Percent: +100, Last Available: "2007-12"
 3093	banded ball-in-a-cup	0		Damage Absorption: +100, Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	cyan old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	lime green divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3135,7 +3135,7 @@
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	broken El Vibrato drone	0		
-3166	spinning skewed blinking repaired El Vibrato drone	0		
+3166	blinking spinning skewed repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	extra-electrified electrified seal eyeball	0		Effect: "Bestial Sympathy", Effect Duration: 29
 3169	decent turtle soup	4	good	Effect: "[598]A Little Bit Evil"
@@ -3145,8 +3145,8 @@
 3173	aerosolized spinning evil vihuela	0		Effect: "Astral Shell", Effect Duration: 52
 3174	spoiled evil boring spaghetti	4	crappy	
 3175	big normal jittery maroon evil noodles	5	good	
-3176	snack-sized normal evil noodles	2	good	
-3177	decent immense spinning evil painful penne pasta	7	good	
+3176	normal snack-sized evil noodles	2	good	
+3177	immense decent spinning evil painful penne pasta	7	good	
 3178	spoiled 3vi1 pr0n m4nic0tti	3	crappy	
 3179	adequate jumbo evil ravioli della hippy	5	good	
 3180	bland yellow evil noodles	4	decent	
@@ -3157,8 +3157,8 @@
 3185	pressed evil ointment of the occult	0		Effect: "Mushroom Samba", Effect Duration: 29
 3186	liquefied extra-liquefied evil serum of sarcasm	0		Effect: "You Read The Manual", Effect Duration: 13
 3187	deionized evil philter of phorce	0		Effect: "Jelly Combed", Effect Duration: 27
-3188	perfectly mixed watered-down blurry an evil sump'm sump'm	2	super EPIC	
-3189	practically non-alcoholic drinkable green evil ducha de oro	1	good	
+3188	watered-down perfectly mixed blurry an evil sump'm sump'm	2	super EPIC	
+3189	drinkable practically non-alcoholic green evil ducha de oro	1	good	
 3190	acceptable twirling evil horizontal tango	3	good	
 3191	hand-crafted evil roll in the hay	4	EPIC	
 3192	squat naughty origami kit	0		Last Available: "2008-02"
@@ -3169,12 +3169,12 @@
 3197	boxer's origami riding crop of the wise owl of doom	0		Mysticality: +20, Muscle Percent: +10, Spooky Spell Damage: +50, Softcore Only, Last Available: "2008-02"
 3198	mirror El Vibrato trapezoid	0		
 3199	lump of coal	0		
-3200	pulsating wobbly lump of diamond	0		
+3200	wobbly pulsating lump of diamond	0		
 3201	spinning thick padded envelope	0		
 3202	rosewater-soaked Jack Frost's frosty KoL Con IV Pole	0		Cold Spell Damage: 60, Stench Resistance: +3, Last Available: "2007-09"
 3203	tumbling upside-down dwarvish magazine	0		
 3204	shaking dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
-3205	pulsating jittery dwarvish war mattock	0		
+3205	jittery pulsating dwarvish war mattock	0		
 3206	olive dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	small laminated card	0		
@@ -3194,9 +3194,9 @@
 3222	gatorskin umbrella of extreme caution	0		Monster Level: -25, Item Drop: +5
 3223	jittery sewer nuggets	0		
 3224	gray sewer wad	0		
-3225	bad triple-distilled bottle of sewage schnapps	7	decent	
+3225	triple-distilled bad bottle of sewage schnapps	7	decent	
 3226	mediocre skewed bottle of Ooze-O	4	decent	
-3227	rotten snack-sized C.H.U.M. chum	2	crappy	
+3227	snack-sized rotten C.H.U.M. chum	2	crappy	
 3228	toothsome unfortunate dumplings	4	awesome	
 3229	skewed decaying goldfish liver	0		
 3230	Vulcanized oil of oiliness	0		Effect: "Voracious Gorging", Effect Duration: 65
@@ -3232,10 +3232,10 @@
 3260	bouncing spinning sharpshooter's experienced Chester's moustache of the businessman	0		Experience: +2, Critical Hit Percent: +10, Meat Drop: +50, Class: "Disco Bandit", Single Equip
 3261	jittery avaricious Chester's bag of candy of the early riser	0		Meat Drop: +30, Adventures: +7, Class: "Disco Bandit"
 3262	Usain Bolt's razor-sharp Chester's cutoffs	0		Weapon Damage Percent: +25, Initiative: +80, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
-3264	gray blurry candygram	0		Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3264	blurry gray candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
-3266	maroon blurry bag of Saccharine Maple saplings	0		
+3266	blurry maroon bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	altered denatured handful of Crotchety Pine needles	0		Effect: "Prince of Seaside Town", Effect Duration: 50
 3269	anodized lump of Saccharine Maple sap	0		Effect: "Venomous Weapon", Effect Duration: 19
@@ -3252,11 +3252,11 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	jittery green smooth stick-on eyebrow piercing	0		Moxie: +15, Last Available: "2008-04"
-3283	massive spoiled twirling salad	7	crappy	
+3283	spoiled massive twirling salad	7	crappy	
 3284	studded dance instructor's C.H.U.M. lantern	0		Experience Percent (Moxie): +10, Damage Absorption: +80
 3285	wobbly savvy C.H.U.M. knife	0		Mysticality Percent: +20
 3286	blinking Da Vinci's Frosty's snowball sack	0		Experience (Mysticality): +5
-3287	bouncing upside-down quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
+3287	upside-down bouncing quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
 3288	shaking shimmering tendrils	0		Class: "Pastamancer"
 3289	scintillating powder	0		Class: "Pastamancer"
 3290	ghostly abandoned candy	0		
@@ -3285,12 +3285,12 @@
 3313	jittery clever marinara jug	0		Maximum MP: +20, Class: "Sauceror"
 3314	maroon makeshift castanets of Tarzan	0		Experience (Muscle): +3, Class: "Disco Bandit"
 3315	huge sharpshooter's left-handed melodica	0		Critical Hit Percent: +10, Class: "Accordion Thief"
-3316	boiled upside-down purple epic wad	1	crappy	
+3316	boiled purple upside-down epic wad	1	crappy	
 3317	lime green stylish bottlecap	0		Moxie: +25, Single Equip
 3318	spinning sharpshooter's corncob pipe	0		Critical Hit Percent: +10, Single Equip
 3319	Mr. Joe's bangles of the empath	0		Familiar Weight: +5, Single Equip
 3320	reassuring frayed rope belt	0		Spooky Resistance: +1, Single Equip
-3321	blinking mirror spinning packet of mayfly bait	0		Last Available: "2008-05"
+3321	mirror blinking spinning packet of mayfly bait	0		Last Available: "2008-05"
 3322	executive mansplainer's mayfly bait necklace	0		Monster Level: +15, Meat Drop: +40, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	tumbling mirror Frosty's frosty mug	0		
@@ -3337,8 +3337,8 @@
 3365	galvanized squat Climate Colada	0		Effect: "Bat Attitude", Effect Duration: 39, Last Available: "2008-06"
 3366	deionized lime green huge digital underground potion	0		Effect: "Feet of Grapefruit", Effect Duration: 54, Last Available: "2008-06"
 3367	mirror interesting-looking twig	0		Last Available: "2008-06"
-3368	modified jittery ghostly shaking teal glimmering roc feather	1	awesome	Last Available: "2008-06"
-3369	mixed mirror blue tumbling jittery glimmering phoenix feather	1		Last Available: "2008-06"
+3368	modified teal ghostly shaking jittery glimmering roc feather	1	awesome	Last Available: "2008-06"
+3369	mixed blue tumbling jittery mirror glimmering phoenix feather	1		Last Available: "2008-06"
 3370	denatured glimmering penguin feather	1		Last Available: "2008-06"
 3371	mixed huge glimmering buzzard feather	1		Effect: "Concentration", Effect Duration: 10, Last Available: "2008-06"
 3372	dehydrated huge glimmering raven feather	1		Last Available: "2008-06"
@@ -3367,7 +3367,7 @@
 3395	mirror spinning flame-retardant Tesla Hodgman's porkpie hat	0		Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	steel-toed Hodgman's lobsterskin pants of doom	0		Damage Reduction: 9, Spooky Spell Damage: +50, Familiar Effect: "atk, 1xPotato"
 3397	groovy Hodgman's bow tie of extreme caution	0		Moxie Percent: +10, Monster Level: -25, Single Equip
-3398	weak perfectly mixed Hodgman's blanket	2	super ultra EPIC	
+3398	perfectly mixed weak Hodgman's blanket	2	super ultra EPIC	
 3399	weak perfectly mixed jar of squeeze	2	super ultra mega turbo EPIC	
 3400	bland bowl of fishysoisse	3	decent	
 3401	quadruple-activated deadly lampshade	0		Effect: "Yuletide Mutations", Effect Duration: 12
@@ -3394,7 +3394,7 @@
 3426	chilled aerosolized strawberry-flavored Hob-O	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 17
 3427	roll of Hob-Os	0		
 3428	enhanced triple-magnetized spinning Everlasting Deckswabber	0		Effect: "Simulation Stimulation", Effect Duration: 67
-3430	lime green blinking huge bindle of joy	0		
+3430	blinking huge lime green bindle of joy	0		
 3431	upside-down cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	tumbling spice melange	0		
@@ -3416,7 +3416,7 @@
 3449	cotton candy cone	0		Last Available: "2008-08"
 3450	fuchsia cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
-3452	tumbling red narrow cotton candy skoshe	0		Last Available: "2008-08"
+3452	tumbling narrow red cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
 3454	cotton candy pillow	0		Last Available: "2008-08"
 3455	mirror cotton candy bale	0		Last Available: "2008-08"
@@ -3453,25 +3453,25 @@
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	squat pristine fish scale	0		
-3489	bland snack-sized beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3489	snack-sized bland beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3490	stale glistening fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
-3491	half-sized flavorless slick fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3491	flavorless half-sized slick fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3492	padded fish scimitar of the brazier	0		Damage Absorption: +20, Hot Spell Damage: +25
 3493	supercool fish stick of Gandalf	0		Moxie Percent: +20, Spell Critical Percent: +20
 3494	perfumed fish bazooka of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +5
 3495	adjusted unsweetened sea salt crystal	0		Effect: "Toast Tea", Effect Duration: 21
 3496	chilled energized red bazookafish bubble gum	0		Effect: "Hyphemariffic", Effect Duration: 46
 3497	smooth bottle of Pete's Sake	3	awesome	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	tiny stale canap&eacute;s	1	decent	
 3502	powdered huge squat thermos of brew	1	decent	Effect: "Singer's Faithful Ocelot", Effect Duration: 35, Last Available: "2011-12"
 3503	hand-crafted glass of brandy	3	EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	LWA ring of the brazier	0		Hot Spell Damage: +25
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	tumbling pulsating Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	tumbling pulsating Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	savvy scratch 'n' sniff sword	0		Mysticality Percent: +20, Last Available: "2008-11"
 3509	gray scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	shaking scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3499,7 +3499,7 @@
 3532	olive ant antidepressant	0		Familiar Weight: +5
 3533	cactus monocle	0		Familiar Weight: +5
 3534	narrow Jawmaster 2000&trade;	0		Familiar Weight: +5
-3535	skewed maroon plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
+3535	maroon skewed plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
@@ -3510,8 +3510,8 @@
 3543	depleted Grimacite gravy boat of Leguizamo of terror	0		Monster Level: +20, Spooky Spell Damage: +10, Last Available: "2011-12"
 3544	crafty depleted Grimacite weightlifting belt of the detective	0		Maximum MP: +10, Item Drop: +20, Single Equip, Last Available: "2011-12"
 3545	nippy hale depleted Grimacite grappling hook	0		Maximum HP: +20, Cold Damage: +10, Single Equip, Last Available: "2011-12"
-3546	upside-down aromatic Da Vinci's depleted Grimacite ninja mask	0		Experience (Mysticality): +5, Stench Resistance: +1, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	spinning lime green MacGyver's razor-sharp depleted Grimacite shinguards	0		Weapon Damage Percent: +25, Maximum MP: +100, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	upside-down aromatic Da Vinci's depleted Grimacite ninja mask	0		Experience (Mysticality): +5, Stench Resistance: +1, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	spinning lime green MacGyver's razor-sharp depleted Grimacite shinguards	0		Weapon Damage Percent: +25, Maximum MP: +100, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	mirror foul-smelling careful depleted Grimacite astrolabe	0		Monster Level: -10, Stench Damage: +10, Single Equip, Last Available: "2011-12"
 3549	gravedigger's groovy KoL Con Cinco Pi&ntilde;ata Bat	0		Moxie Percent: +10, Spooky Damage: +10, Softcore Only, Last Available: "2008-09"
 3550	foul-smelling propeller beanie	0		Stench Damage: +10, Familiar Effect: "atk, cap 7"
@@ -3529,7 +3529,7 @@
 3562	non-ionized frozen pressurized potion of perspicacity	0		Effect: "Night Vision", Effect Duration: 59
 3563	polymerized ionized pressurized potion of pulchritude	0		Effect: "Yes, Can Haz", Effect Duration: 16
 3564	perfectly mixed ghostly berry-infused sake	4	EPIC	
-3565	practically non-alcoholic special bad teal citrus-infused sake	1	decent	Effect: "Hot Jellied", Effect Duration: 20
+3565	special bad practically non-alcoholic teal citrus-infused sake	1	decent	Effect: "Hot Jellied", Effect Duration: 20
 3566	weak delicious melon-infused sake	2	awesome	
 3567	slab of sponge	0		
 3568	wholesome Fonzie's sponge helmet of the cheetah	0		Experience (Moxie): +1, Maximum HP Percent: +10, Initiative: +60, Familiar Effect: "atk, 1xFairy"
@@ -3549,7 +3549,7 @@
 3582	flavorless half-sized rice	2	decent	
 3584	spoiled irradiated candy cane	3	crappy	Last Available: "2008-12"
 3585	immense stale olive gingerbread mutant bugbear	6	decent	Last Available: "2008-12"
-3586	bad high-proof oozenog	6	decent	Last Available: "2008-12"
+3586	high-proof bad oozenog	6	decent	Last Available: "2008-12"
 3587	polarized wet dry blinking wobbly sugar plum	0		Effect: "Man's Worst Enemy", Effect Duration: 35, Last Available: "2008-12"
 3588	enhanced polarized twirling sugar banana	0		Effect: "Intimidating Mien", Effect Duration: 53, Last Available: "2008-12"
 3589	ionized modified green sugar lime	0		Effect: "Crying, Dying", Effect Duration: 69, Last Available: "2008-12"
@@ -3560,7 +3560,7 @@
 3594	Mer-kin killscroll	0		
 3595	oxidized non-pressed Vulcanized Mer-kin fastjuice	0		Effect: "Polka Face", Effect Duration: 29
 3596	imitation crab crate	0		
-3597	jittery yellow imitation crab meat	0		
+3597	yellow jittery imitation crab meat	0		
 3598	imitation crab zoea	0		
 3599	baleful moist sailor's cap of terror of temperance	0		Spell Damage: +25, Spooky Spell Damage: +10, Sleaze Resistance: +5, Familiar Effect: "stench atk"
 3600	scandalous speargun of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5
@@ -3588,8 +3588,8 @@
 3622	spinning gnashing teeth	0		Last Available: "2008-12"
 3623	squat chitinous pod	0		Last Available: "2008-12"
 3624	personal trainer's parasitic claw	0		Experience Percent (Muscle): +10, Last Available: "2008-12"
-3625	parasitic tentacles of the detective	0		Item Drop: +20, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	Usain Bolt's parasitic headgnawer	0		Initiative: +80, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	parasitic tentacles of the detective	0		Item Drop: +20, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	Usain Bolt's parasitic headgnawer	0		Initiative: +80, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	jittery wicked parasitic strangleworm	0		Spell Damage: +5, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	jittery shaking elven socks of dire peril of incineration	0		Weapon Damage: +20, Hot Spell Damage: +50, Last Available: "2008-12"
 3634	aromatic elven gloves of the scaredy-cat	0		Monster Level: -15, Stench Resistance: +1, Last Available: "2008-12"
-3635	squat wicked festive holiday hat of dire peril	0		Weapon Damage: +20, Spell Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	squat wicked festive holiday hat of dire peril	0		Weapon Damage: +20, Spell Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	patent shoes of the sweet-tooth of Flo-Jo	0		Candy Drop: +100, Initiative: +100, Last Available: "2008-12"
 3637	twirling prompt smartaleck's gray bow tie	0		Moxie Percent: +30, Adventures: +3, Last Available: "2008-12"
 3638	blinking upside-down Van der Graaf steel-toed penguin thesaurus	0		Damage Reduction: 9, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-12"
@@ -3611,10 +3611,10 @@
 3645	mediocre watered-down upside-down canteen of wine	2	decent	Last Available: "2008-12"
 3646	normal ghostly elven <i>limbos</i> gingerbread	3	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
-3648	spinning huge magic dragonfish fry	0		
+3648	huge spinning magic dragonfish fry	0		
 3649	ghostly map to Madness Reef	0		
 3650	toothsome toast with jam	3	awesome	Last Available: "2008-12"
-3651	mirror antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	mirror antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	mediocre yellow elven moonshine	4	decent	Last Available: "2008-12"
 3653	bland knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	healthy baleful psycho sweater	0		Spell Damage: +25, Maximum HP Percent: +20, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	shaking savvy plastic strand of DNA	0		Mysticality Percent: +20, Last Available: "2008-12"
 3660	narrow plastic chunk of depleted Grimacite of dire peril	0		Weapon Damage: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	Putty mitre of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	cyan miser's Putty leotard of extreme caution	0		Monster Level: -25, Meat Drop: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	Putty mitre of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	cyan miser's Putty leotard of extreme caution	0		Monster Level: -25, Meat Drop: +10, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	ghostly jittery weightlifter's Putty ball	0		Muscle: +15, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	nasty vibrating brawny Putty snake	0		Muscle Percent: +20, Maximum MP Percent: +10, Stench Damage: +5, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	red electrified glow-in-the-dark burrowgrub	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	flavorless can of franks 'n' beans	4	decent	Last Available: "2010-12"
-3673	weak delicious yellow bottle of peppermint schnapps	2	awesome	Last Available: "2010-12"
+3673	delicious weak yellow bottle of peppermint schnapps	2	awesome	Last Available: "2010-12"
 3674	mirror blurry throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	tumbling Mer-kin foodbucket	0		
@@ -3644,7 +3644,7 @@
 3678	lousy salinated mint julep	4	decent	
 3679	ink bladder	0		
 3680	esca	0		
-3681	blurry yellow bubbling tempura batter	0		
+3681	yellow blurry bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
 3684	spoiled big bouncing tempura carrot	5	crappy	
@@ -3653,7 +3653,7 @@
 3687	decent sea broccoli	3	good	
 3688	rotten huge sea cauliflower	9	crappy	
 3689	rotten tempura broccoli	3	crappy	
-3690	gigantic moldy spinning tempura cauliflower	10	crappy	
+3690	moldy gigantic spinning tempura cauliflower	10	crappy	
 3691	half-sized spoiled wobbly sea blueberry	2	crappy	
 3692	adequate yellow sea persimmon	3	good	
 3693	triple-dry pressurized potion of perception	0		Effect: "Ermine Eyes", Effect Duration: 21
@@ -3701,11 +3701,11 @@
 3735	red fat wallet	0		
 3736	perfumed double-paned handwarmer	0		Cold Resistance: +5, Stench Resistance: +5, Single Equip
 3737	supercharged padded lighter	0		Damage Absorption: +20, Maximum MP Percent: +30
-3738	half-sized stale gray packet of beer nuts	2	decent	
+3738	stale half-sized gray packet of beer nuts	2	decent	
 3739	Boozehounds Anonymous token	0		
 3740	bouncing handful of bees	0		
 3741	spectral jelly	0		
-3742	pressed polarized blurry spinning jellyfish gel	0		Effect: "Saucefingers", Effect Duration: 56
+3742	pressed polarized spinning blurry jellyfish gel	0		Effect: "Saucefingers", Effect Duration: 56
 3743	unstable quark	0		
 3744	software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
@@ -3713,12 +3713,12 @@
 3747	huge blinking mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	nitrogenated concoction of clumsiness	0		Effect: "Slimily Sagacious", Effect Duration: 63
 3750	jittery forbidden vampire pearl earring	0		Spell Damage Percent: +50, Single Equip
-3751	bite-sized stale shaking chocolate chip brownies	1	decent	
-3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3751	stale bite-sized shaking chocolate chip brownies	1	decent	
+3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	super-ionized quadruple-altered red love song of vague ambiguity	0		Effect: "You Drank Fish Wine", Effect Duration: 45, Last Available: "2009-02"
 3755	dry concentrated love song of smoldering passion	0		Effect: "Fitter, Happier", Effect Duration: 37, Last Available: "2009-02"
 3756	extra-polarized improved love song of icy revenge	0		Effect: "Well Owl Be!", Effect Duration: 63, Last Available: "2009-02"
-3757	cold-filtered lime green blurry shaking love song of sugary cuteness	0		Effect: "Scrappy, Shadowy", Effect Duration: 55, Last Available: "2009-02"
+3757	cold-filtered shaking lime green blurry love song of sugary cuteness	0		Effect: "Scrappy, Shadowy", Effect Duration: 55, Last Available: "2009-02"
 3758	vacuum-sealed dry spinning love song of disturbing obsession	0		Effect: "Toothy Grin", Effect Duration: 56, Last Available: "2009-02"
 3759	oxidized irradiated love song of naughty innuendo	0		Effect: "Irresistible Resolve", Effect Duration: 17, Last Available: "2009-02"
 3760	alkaline blurry breath mint	0		Effect: "Ten out of Ten", Effect Duration: 18
@@ -3727,11 +3727,11 @@
 3763	mediocre slug of vodka	4	decent	
 3764	smooth slug of rum	4	awesome	
 3765	mediocre slug of shochu	3	decent	
-3766	drinkable practically non-alcoholic screwdiver	1	good	
+3766	practically non-alcoholic drinkable screwdiver	1	good	
 3767	hand-crafted dew yoana lei	3	EPIC	
 3768	perfectly mixed lychee chuhai	4	EPIC	
 3769	spirit-forward tolerable salacious screwdiver	5	good	
-3770	mediocre extra-dry dew yoana salacious lei	5	decent	
+3770	extra-dry mediocre dew yoana salacious lei	5	decent	
 3771	watered-down perfectly mixed salacious lychee chuhai	2	EPIC	
 3772	artisanal Alewife&trade; Ale	3	EPIC	
 3773	blurry seaode	0		
@@ -3753,8 +3753,8 @@
 3789	blinking twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	foul-smelling Fonzie's beefcake's Mer-kin roundshield	0		Muscle: +25, Experience (Moxie): +1, Stench Damage: +10, Damage Reduction: 14
 3804	Tesla crafty Mer-kin breastplate	0		Maximum MP: +10, MP Regen Min: 7, MP Regen Max: 10
 3805	Mer-kin sneakmask of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,11 +3768,11 @@
 3813	groovy plastic baby	0		Moxie Percent: +10, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	normal half-sized special blinking sea radish	2	good	Effect: "Spooky Weapon", Effect Duration: 40
+3817	special normal half-sized blinking sea radish	2	good	Effect: "Spooky Weapon", Effect Duration: 40
 3818	scandalous gravedigger's medical-grade halibut	0		Spooky Damage: +10, Sleaze Damage: +5, HP Regen Min: 7, HP Regen Max: 10
 3819	eel sauce	0		
 3820	asbestos-lined water-polo mitt	0		Hot Resistance: +5, Single Equip
-3821	improved extra-energized dry purple mirror syringe	0		Effect: "Gamer Rage", Effect Duration: 18
+3821	improved extra-energized dry mirror purple syringe	0		Effect: "Gamer Rage", Effect Duration: 18
 3822	wand	0		Familiar Effect: "fishy spells"
 3823	double-polymerized wad of cotton	0		Effect: "Fungal Fortification", Effect Duration: 25
 3824	blinking Grandma's Note	0		
@@ -3780,11 +3780,11 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	tumbling plastic oyster egg	0		
 3828	maroon Grandma's Map	0		
-3829	normal low-calorie jittery tempura radish	1	good	
+3829	low-calorie normal jittery tempura radish	1	good	
 3830	hale water-polo cap	0		Maximum HP: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	lousy Typical Tavern swill	3	decent	
-3832	practically non-alcoholic artisanal tropical swill	1	super ultra mega turbo EPIC	
-3833	high-proof delicious fruity girl swill	6	awesome	
+3832	artisanal practically non-alcoholic tropical swill	1	super ultra mega turbo EPIC	
+3833	delicious high-proof fruity girl swill	6	awesome	
 3834	lousy maroon blended swill	4	decent	
 3835	costume wardrobe	0		Softcore Only
 3836	steel-toed rock-hard baleful Elvish sunglasses of Flo-Jo	0		Spell Damage: +25, Damage Reduction: 28, Initiative: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
@@ -3850,13 +3850,13 @@
 3896	ionized vial of slime	0		Effect: "Cool, Catlike", Effect Duration: 68
 3897	warmed nitrogenated skewed vial of brown slime	0		Effect: "Ninja, Please", Effect Duration: 47
 3898	bottle of G&uuml;-Gone	0		
-3901	wobbly green seal-blubber candle	0		Class: "Seal Clubber"
+3901	green wobbly seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	tumbling figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
-3907	huge narrow figurine of a shadowy seal	0		Class: "Seal Clubber"
+3907	narrow huge figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	skewed figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
@@ -3876,7 +3876,7 @@
 3924	shaking lion tamer's fortified spiky turtle helmet	0		Damage Absorption: +60, Experience (familiar): +2, Familiar Effect: "atk, 1xFairy, cap 32"
 3925	blue spiky turtle shoulderpads of the wise owl	0		Mysticality: +20, Single Equip
 3926	hardened brainy spiky turtle shield	0		Mysticality: +5, Damage Reduction: 11
-3927	narrow jittery tumbling turtling rod	0		Class: "Turtle Tamer"
+3927	jittery tumbling narrow turtling rod	0		Class: "Turtle Tamer"
 3928	red syncopated turtle	0		
 3929	grinning turtle	0		
 3930	polymerized irradiated bouncing tainted seal's blood	0		Effect: "Superveiny 9000", Effect Duration: 69
@@ -3906,7 +3906,7 @@
 3954	teddy butler	0		
 3955	martini	0		
 3956	crazy bastard sword	0		
-3957	blinking blurry teal tin of caviar	0		
+3957	blurry blinking teal tin of caviar	0		
 3958	Jim Carey's bejeweled cufflinks	0		Monster Level: +25, Single Equip
 3959	mirror garish pinky ring of the cheetah	0		Initiative: +60
 3960	grievous designer sunglasses	0		Weapon Damage Percent: +50, Single Equip
@@ -3918,7 +3918,7 @@
 3966	squat perfumed Annie Oakley's sage hot-ass club	0		Mysticality Percent: +10, Critical Hit Percent: +20, Stench Resistance: +5, Class: "Seal Clubber"
 3967	wool Rosewater's frigid-ass club of chilblains	0		Mysticality Percent: +30, Cold Damage: +25, Cold Resistance: +1, Class: "Seal Clubber"
 3968	mirror Sherlock's quilted creepy-ass club of the pedagogue	0		Experience: +3, Damage Absorption: +40, Item Drop: +25, Class: "Seal Clubber"
-3969	improved skewed ghostly mirror sizzling seal fat	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 47
+3969	improved skewed mirror ghostly sizzling seal fat	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 47
 3970	supercharged savvy Abyssal ember	0		Mysticality Percent: +20, Maximum MP Percent: +30, Class: "Seal Clubber"
 3971	modified frost-rimed seal hide	0		Effect: "The Real Deal", Effect Duration: 59
 3972	flame-retardant seal spine of the boozehound	0		Hot Resistance: +1, Booze Drop: +100, Class: "Seal Clubber"
@@ -3987,23 +3987,23 @@
 4035	shaking memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
 4037	decent slimy sweetbreads	4	good	
-4038	artisanal strong slimy fermented bile bladder	5	EPIC	
+4038	strong artisanal slimy fermented bile bladder	5	EPIC	
 4039	diluted pulsating slimy alveolus	1		
 4040	wobbly memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	stanky brawny pig-iron helm	0		Muscle Percent: +20, Stench Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	inspector's weightlifter's pig-iron shinguards	0		Muscle: +15, Item Drop: +15, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	stanky brawny pig-iron helm	0		Muscle Percent: +20, Stench Spell Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	inspector's weightlifter's pig-iron shinguards	0		Muscle: +15, Item Drop: +15, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	Sinatra's pig-iron bracers of the businessman	0		Experience (Moxie): +5, Meat Drop: +50, Single Equip, Last Available: "2009-06"
 4044	blurry wumpus hair	0		Last Available: "2009-06"
-4045	skewed pulsating wumpus-hair bolo	0		Last Available: "2009-06"
+4045	pulsating skewed wumpus-hair bolo	0		Last Available: "2009-06"
 4046	blue wumpus-hair net	0		Last Available: "2009-06"
 4047	upside-down Temple Grandin's wumpus-hair whip	0		Familiar Weight: +7, Last Available: "2009-06"
-4048	lard-coated wumpus-hair wig of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +25, Item Drop: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	bouncing therapeutic healthy wicked wumpus-hair loincloth	0		Spell Damage: +5, Maximum HP Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	lard-coated wumpus-hair wig of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +25, Item Drop: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	bouncing therapeutic healthy wicked wumpus-hair loincloth	0		Spell Damage: +5, Maximum HP Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	smartaleck's wumpus-hair sweater of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Last Available: "2009-06"
 4051	supercool ring of teleportation	0		Moxie Percent: +20, Single Equip
 4052	enchanted ghostly glass of baboon milk	1	good	Effect: "Full-Body Tan", Effect Duration: 40, Last Available: "2009-06"
 4053	banana milkshake	1	super EPIC	Last Available: "2009-06"
-4054	weak drinkable White Hyborian	2	good	Last Available: "2009-06"
+4054	drinkable weak White Hyborian	2	good	Last Available: "2009-06"
 4055	flame-wreathed goblin hunting spear	0		Hot Spell Damage: +10, Last Available: "2009-06"
 4056	squat green grievous goblin autoblowgun of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Last Available: "2009-06"
 4057	ghostly resourceful tribal beads	0		Maximum MP: +50, Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	manspreader's thinker's grisly shield	0		Mysticality: +10, Monster Level: +10, Slime Hates It: +1, Damage Reduction: 13
 4081	twirling personal trainer's corroded breeches of the blizzard	0		Experience Percent (Muscle): +10, Cold Spell Damage: +25, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	tumbling narrow asbestos-lined pernicious cudgel of terror	0		Spooky Spell Damage: +10, Hot Resistance: +5, Slime Hates It: +1
-4083	flavorless massive cupcake-in-a-cup	9	decent	Last Available: "2009-06"
+4083	massive flavorless cupcake-in-a-cup	9	decent	Last Available: "2009-06"
 4084	narrow pool of liquid	0		Last Available: "2009-06"
 4085	massive moldy protein paste	9	crappy	Last Available: "2009-06"
 4086	zippy cyber-mattock of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +20, Last Available: "2009-06"
@@ -4081,7 +4081,7 @@
 4129	twirling auspicious resourceful hardened slime belt of the storm	0		Maximum MP Percent: +40, Maximum MP: +50, Item Drop: +10, Single Equip
 4130	olive empty agua de vida bottle	0		Last Available: "2009-06"
 4131	pickled gray boot plant	1	decent	Last Available: "2009-06"
-4132	weak bad sham champagne	2	decent	Last Available: "2009-06"
+4132	bad weak sham champagne	2	decent	Last Available: "2009-06"
 4133	polymerized tempura air	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 48
 4134	pressed pressurized potion of pneumaticity	0		Effect: "Vanity Rage", Effect Duration: 24
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4109,8 +4109,8 @@
 4157	red gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	weak delicious fancy pebblebr&auml;u	2	awesome	Effect: "Stimulated Brain", Effect Duration: 25, Last Available: "2009-09"
-4161	immense moldy blinking pulsating rocky road ice cream	6	crappy	Last Available: "2009-09"
+4160	delicious weak fancy pebblebr&auml;u	2	awesome	Effect: "Stimulated Brain", Effect Duration: 25, Last Available: "2009-09"
+4161	moldy immense blinking pulsating rocky road ice cream	6	crappy	Last Available: "2009-09"
 4162	tumbling extra-strength rubber bands	0		Familiar Weight: +5
 4163	non-tarnished dry double-activated children of the candy corn	0		Effect: "Elemental Mastery", Effect Duration: 68
 4164	galvanized twirling Good 'n' Slimy	0		Effect: "The Style... of the Future", Effect Duration: 44
@@ -4130,8 +4130,8 @@
 4178	tumbling thinker's sugar shotgun	0		Mysticality: +10, Last Available: "2009-09"
 4179	shaking sugar shillelagh of the brute	0		Muscle Percent: +30, Last Available: "2009-09"
 4180	medical-grade sugar shank	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-09"
-4181	tumbling lion tamer's therapeutic sugar chapeau of doom	0		Experience (familiar): +2, Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	sugar shorts of Flo-Jo	0		Initiative: +100, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	tumbling lion tamer's therapeutic sugar chapeau of doom	0		Experience (familiar): +2, Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	sugar shorts of Flo-Jo	0		Initiative: +100, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	ghostly slime convention swag bag	0		
 4185	skewed slime convention flyers	0		
@@ -4178,7 +4178,7 @@
 4226	scorching Star of Bravery	0		Hot Damage: +25, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4198,7 +4198,7 @@
 4246	Jim Carey's ivory cue ball	0		Monster Level: +25
 4247	hand-crafted mirror decanter of fine Scotch	3	super EPIC	
 4248	compressed pulsating huge expensive cigar	1		
-4249	wobbly mirror lime green tophat	0		Familiar Weight: +5
+4249	lime green wobbly mirror tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	squat fish-oil smoke bomb	0		
 4252	quantum shaking vial of squid ink	0		Effect: "Spore-Wreathed", Effect Duration: 33
@@ -4207,14 +4207,14 @@
 4255	spinning Wolfman Nardz	0		Last Available: "2009-10"
 4256	energized purple sap	0		Effect: "Ichorous Eyesight", Effect Duration: 64, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	adequate super-sized chocolate-covered scarab beetle	5	good	Last Available: "2009-10"
+4258	super-sized adequate chocolate-covered scarab beetle	5	good	Last Available: "2009-10"
 4259	lousy blurry mulled cider	4	decent	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	skewed pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	olive mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	skewed pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	olive mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	tumbling maroon Ax of L'rose	0		Last Available: "2009-10"
-4264	wobbly purple dog trainer's bark boxers	0		Experience (familiar): +1, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	tumbling lion tamer's bark beret	0		Experience (familiar): +2, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	wobbly purple dog trainer's bark boxers	0		Experience (familiar): +1, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	tumbling lion tamer's bark beret	0		Experience (familiar): +2, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	mirror lightning-fast bark bracelet	0		Initiative: +40, Single Equip
 4267	inspector's Newton's Krakrox's Loincloth	0		Experience (Mysticality): +3, Item Drop: +15, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	purple Sherlock's Newton's Galapagosian Cuisses	0		Experience (Mysticality): +3, Item Drop: +25, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4279,10 +4279,10 @@
 4327	green shaking zippy asbestos-lined ruddy La Hebilla del Cintur&oacute;n de Lopez	0		Maximum HP Percent: +40, Hot Resistance: +5, Initiative: +20, Class: "Accordion Thief", Single Equip
 4328	mirror suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	decent jumbo teal candy kneecapping stick	5	good	Last Available: "2009-12"
-4331	bland fancy licorice garrote	4	decent	Effect: "Blessing of the Creepy Pasta", Effect Duration: 25, Last Available: "2009-12"
+4330	jumbo decent teal candy kneecapping stick	5	good	Last Available: "2009-12"
+4331	fancy bland licorice garrote	4	decent	Effect: "Blessing of the Creepy Pasta", Effect Duration: 25, Last Available: "2009-12"
 4332	ribald candy knuckles	0		Sleaze Damage: +10, Last Available: "2009-12"
-4333	miniature moldy tumbling ghostly jawbruiser	2	crappy	Last Available: "2010-12"
+4333	miniature moldy ghostly tumbling jawbruiser	2	crappy	Last Available: "2010-12"
 4334	extra-corrupted polymerized chocolate car	0		Effect: "Egg-headedness", Effect Duration: 20, Last Available: "2009-12"
 4335	wobbly plastic 11 Dealer of the glutton	0		Food Drop: +100, Last Available: "2009-12"
 4336	plastic Crimbo Casino of James Dean	0		Experience (Moxie): +3, Last Available: "2009-12"
@@ -4298,23 +4298,23 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	spinning gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	Da Vinci's snow hat	0		Experience (Mysticality): +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	inspector's snow pants	0		Item Drop: +15, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	Da Vinci's snow hat	0		Experience (Mysticality): +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	inspector's snow pants	0		Item Drop: +15, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	crafty snow belly	0		Maximum MP: +10, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
-4354	maroon bouncing A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	bouncing maroon A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	wobbly A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	fuchsia tumbling A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	bite-sized moldy expired can of franks 'n' beans	1	crappy	Last Available: "2009-12"
+4360	moldy bite-sized expired can of franks 'n' beans	1	crappy	Last Available: "2009-12"
 4361	tolerable fortified expired bottle of peppermint schnapps	5	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	modified improved elven suicide capsule	0		Effect: "Painted-On Bikini", Effect Duration: 12, Last Available: "2009-12"
-4365	moldy spinning lime green penguin focaccia bread	4	crappy	Last Available: "2009-12"
+4365	moldy lime green spinning penguin focaccia bread	4	crappy	Last Available: "2009-12"
 4366	aged herringcello	3	awesome	Last Available: "2009-12"
 4367	lousy elven cellocello	3	decent	Last Available: "2009-12"
 4368	jittery wobbly wrench handle	0		Last Available: "2009-12"
@@ -4325,7 +4325,7 @@
 4373	bouncing grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
-4376	twirling narrow Crimbomination Contraption	0		Last Available: "2009-12"
+4376	narrow twirling Crimbomination Contraption	0		Last Available: "2009-12"
 4377	pulsating throwing wrench of the dark arts	0		Spell Damage Percent: +100, Last Available: "2009-12"
 4378	blinking healthy pair of bolt cutters	0		Maximum HP Percent: +20, Last Available: "2009-12"
 4379	greedy poison pen	0		Meat Drop: +20, Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	huge brawny pocketwatch on a chain of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Last Available: "2009-12"
 4386	mirror perfumed MacGyver's cement sandals	0		Maximum MP: +100, Stench Resistance: +5, Single Equip, Last Available: "2009-12"
 4387	Samson's brainy night-vision goggles	0		Mysticality: +5, Experience (Muscle): +5, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	purple peanut brittle shield of temperance	0		Sleaze Resistance: +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	shaking greedy healthy Red Rover BB gun	0		Maximum HP Percent: +20, Meat Drop: +20, Last Available: "2009-12"
 4391	upside-down wobbly Jeselnik's red-and-green sweater	0		Sleaze Damage: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4346,10 +4346,10 @@
 4394	improved purple Crimbo fudge	0		Effect: "Human-Insect Hybrid", Effect Duration: 36, Last Available: "2009-12"
 4395	vacuum-sealed quadruple-diffused modified blinking Crimbo pecan	0		Effect: "Macho Profundo", Effect Duration: 43, Last Available: "2009-12"
 4396	Jack-in-the-box	0		Last Available: "2009-12"
-4397	green wobbly crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
+4397	wobbly green crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	blinking cheese ball	0		Last Available: "2010-01"
 4399	squat fireproof cheese sword	0		Hot Resistance: +3, Softcore Only, Last Available: "2010-01"
-4400	blurry cheese diaper of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	blurry cheese diaper of the wise owl	0		Mysticality: +20, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	steel-toed cheese wheel	0		Damage Reduction: 15, Softcore Only, Last Available: "2010-01"
 4402	shaking Jeselnik's cheese eye	0		Sleaze Damage: +25, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	asbestos-lined smartaleck's cool Staff of Queso Escusado	0		Moxie: +5, Moxie Percent: +30, Hot Resistance: +5, Softcore Only, Last Available: "2010-01"
@@ -4360,7 +4360,7 @@
 4409	blinking Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	blurry The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	decent half-sized quantum taco	0		Last Available: "2010-10"
+4412	half-sized decent quantum taco	0		Last Available: "2010-10"
 4413	practically non-alcoholic artisanal Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	lime green colorful plastic ball	0		Last Available: "2010-01"
 4415	lard-coated sealhide hood	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4379,7 +4379,7 @@
 4429	family-friendly candy necklace	0		Sleaze Resistance: +1, Single Equip
 4430	banded teddybear backpack	0		Damage Absorption: +100
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	unsweetened mirror skewed red invisibility potion	0		Effect: "Grrrrrrreat!", Effect Duration: 46, Last Available: "2011-08"
+4432	unsweetened red skewed mirror invisibility potion	0		Effect: "Grrrrrrreat!", Effect Duration: 46, Last Available: "2011-08"
 4433	pressed squat irresistibility potion	0		Effect: "Gummi Badass", Effect Duration: 17, Last Available: "2011-08"
 4434	warmed corrupted upside-down irritability potion	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 50, Last Available: "2011-08"
 4436	skewed cube	0		Last Available: "2011-02"
@@ -4396,7 +4396,7 @@
 4448	distilled cyan Instant Karma	1	good	
 4449	squat painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	careful pointy hat	0		Monster Level: -10, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	careful pointy hat	0		Monster Level: -10, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	green occult machetito	0		Spell Damage Percent: +25, Last Available: "2010-04"
 4453	shellacked lawnmower blade	0		Damage Reduction: 7, Last Available: "2010-04"
 4454	squat grass clippings	0		Last Available: "2023-12"
@@ -4413,11 +4413,11 @@
 4465	warmed green chocolate saucepan	0		Effect: "Heart of White", Effect Duration: 47
 4466	dry super-dry chocolate disco ball	0		Effect: "Creepin' Up on You", Effect Duration: 36
 4467	diffused chocolate stolen accordion	0		Effect: "Eyes All Black", Effect Duration: 43
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	banded BRICKO hat	0		Damage Absorption: +100, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	teal toasty BRICKO pants	0		Hot Damage: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	banded BRICKO hat	0		Damage Absorption: +100, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	teal toasty BRICKO pants	0		Hot Damage: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	frosty BRICKO sword	0		Cold Spell Damage: +10, Last Available: "2010-02"
 4474	huge BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4434,7 +4434,7 @@
 4486	BRICKO pearl	0		Last Available: "2010-02"
 4487	red inspector's BRICKO bulwark	0		Item Drop: +15, Damage Reduction: 3, Last Available: "2010-02"
 4488	BRICKO trunk	0		Last Available: "2010-02"
-4489	shaking twirling gilded BRICKO brick	0		Last Available: "2010-02"
+4489	twirling shaking gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	skewed BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
@@ -4450,26 +4450,26 @@
 4502	polarized modified cyan recording of Donho's Bubbly Ballad	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 16
 4503	dry moist maroon recording of Inigo's Incantation of Inspiration	0		Effect: "Sweet Incentive", Effect Duration: 22, Last Available: "2010-02"
 4504	bouncing narrow grievous heart of the volcano of the pedagogue	0		Experience: +3, Weapon Damage Percent: +50
-4505	extra-concentrated gray pulsating Northern pemmican	0		Effect: "Ancestral Disapproval", Effect Duration: 46
+4505	extra-concentrated pulsating gray Northern pemmican	0		Effect: "Ancestral Disapproval", Effect Duration: 46
 4506	puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	concentrated non-anodized deionized purple skewed &quot;DRINK ME&quot; potion	0		Effect: "Strong Grip", Effect Duration: 25, Last Available: "2010-03"
+4508	concentrated non-anodized deionized skewed purple &quot;DRINK ME&quot; potion	0		Effect: "Strong Grip", Effect Duration: 25, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	stale walrus ice cream	4	decent	Last Available: "2010-03"
-4511	super-sized rotten beautiful soup	5	crappy	Last Available: "2010-03"
+4511	rotten super-sized beautiful soup	5	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	rotten Humpty Dumplings	3	crappy	Last Available: "2010-03"
-4515	spoiled huge Lobster <i>qua</i> Grill	8	crappy	Last Available: "2010-03"
-4516	practically non-alcoholic drinkable wobbly missing wine	1	good	Last Available: "2010-03"
+4515	huge spoiled Lobster <i>qua</i> Grill	8	crappy	Last Available: "2010-03"
+4516	drinkable practically non-alcoholic wobbly missing wine	1	good	Last Available: "2010-03"
 4517	adequate matter custard	4	good	Last Available: "2010-03"
-4518	non-concentrated corrupted skewed blinking comfit?	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2010-03"
+4518	non-concentrated corrupted blinking skewed comfit?	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2010-03"
 4519	jittery ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	upside-down Jim Carey's flamingo mallet of temperance	0		Monster Level: +25, Sleaze Resistance: +5, Last Available: "2010-03"
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	special teal Tiger-lily's milk	1	EPIC	Effect: "Physicali Tea", Effect Duration: 5, Last Available: "2010-03"
 4523	green Usain Bolt's energetic eye of the Tiger-lily	0		Maximum MP Percent: +20, Initiative: +80, Last Available: "2010-03"
-4524	wig of the brazier of the cheetah	0		Hot Spell Damage: +25, Initiative: +60, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	wig of the brazier of the cheetah	0		Hot Spell Damage: +25, Initiative: +60, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	bland donut	4	decent	Last Available: "2010-03"
 4526	spoiled lime green bouncing bucket of honey	3	crappy	Last Available: "2010-03"
 4527	wobbly blinking baleful beefy elephant stinger	0		Muscle: +10, Spell Damage: +25, Last Available: "2010-03"
@@ -4477,15 +4477,15 @@
 4529	toasty nippy snapdragon pistil	0		Cold Damage: +10, Hot Damage: +5, Last Available: "2010-03"
 4530	teal puff of smoke	0		Last Available: "2010-03"
 4531	toothsome rook cookie	4	awesome	Last Available: "2010-03"
-4532	fancy spoiled bishop cookie	3	crappy	Effect: "Coldfinger", Effect Duration: 25, Last Available: "2010-03"
+4532	spoiled fancy bishop cookie	3	crappy	Effect: "Coldfinger", Effect Duration: 25, Last Available: "2010-03"
 4533	decent narrow knight cookie	3	good	Last Available: "2010-03"
 4534	flavorless king cookie	3	decent	Last Available: "2010-03"
-4535	half-sized flavorless queen cookie	2	decent	Effect: "Towering Strength", Last Available: "2010-03"
+4535	flavorless half-sized queen cookie	2	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	yellow coward's insane tophat	0		Monster Level: -20, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	wizardly strapping helm of the knight	0		Muscle: +5, Mysticality: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	yellow coward's insane tophat	0		Monster Level: -20, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	wizardly strapping helm of the knight	0		Muscle: +5, Mysticality: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	flame-wreathed wristwatch of the knight of the blizzard	0		Cold Spell Damage: +25, Hot Spell Damage: +10, Single Equip, Last Available: "2010-03"
-4540	red ruddy trousers of the knight of terror	0		Maximum HP Percent: +40, Spooky Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	red ruddy trousers of the knight of terror	0		Maximum HP Percent: +40, Spooky Spell Damage: +10, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	wobbly wobbly dangerous tophat	0		Weapon Damage: +10, Familiar Effect: "1xBarrr, cap 25"
 4542	greedy tie	0		Meat Drop: +20, Single Equip
 4543	supercool tuxedo pants	0		Moxie Percent: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4510,7 +4510,7 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	lousy fortified shaking world's most unappetizing beverage	5	decent	Last Available: "2010-04"
 4564	gravedigger's slippery when wet shield	0		Spooky Damage: +10, Damage Reduction: 6, Last Available: "2010-04"
-4565	half-sized adequate raisin	2	good	Last Available: "2010-04"
+4565	adequate half-sized raisin	2	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	cyan knitted nasty flyest of shirts	0		Stench Damage: +5, Cold Resistance: +3, Last Available: "2010-04"
 4568	yummy small tumbling a dance upon the palate	2	awesome	Last Available: "2010-04"
@@ -4521,8 +4521,8 @@
 4573	green The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	upside-down narrow teal bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	upside-down narrow teal bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	altered altered blurry Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "[800]Chocolate Reign", Effect Duration: 36, Last Available: "2010-04"
 4580	medical-grade school Mafi<i>a kni</i>cke&frac12;&aelig;	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-04"
@@ -4555,13 +4555,13 @@
 4607	delicious soyburger juice	4	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	gray squat respected companion biscuit	0		Last Available: "2010-08"
 4609	mirror essential tofu	0		Last Available: "2010-08"
-4610	improved nitrogenated skewed narrow essential soy	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 12, Last Available: "2010-08"
+4610	improved nitrogenated narrow skewed essential soy	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 12, Last Available: "2010-08"
 4611	unsweetened denatured squat essential cameraderie	0		Effect: "Itchy Trigger Finger", Effect Duration: 59, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	cyan MacGyver's Crown of Thrones	0		Maximum MP: +100, Softcore Only, Last Available: "2010-05"
-4615	bad practically non-alcoholic pulsating green Cinco Mayo Lager	1	decent	Last Available: "2010-05"
-4616	maroon twirling Underworld sapling	0		Last Available: "2009-10"
+4615	practically non-alcoholic bad green pulsating Cinco Mayo Lager	1	decent	Last Available: "2010-05"
+4616	twirling maroon Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	bouncing frisbee	0		Free Pull, Last Available: "2011-12"
@@ -4577,12 +4577,12 @@
 4629	frosty plastic spider ring	0		Cold Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	plastic kazoo of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-06"
 4631	ghostly Temple Grandin's inflatable baseball bat	0		Familiar Weight: +7, Last Available: "2010-06"
-4632	greedy wicked googly-star hat	0		Spell Damage: +5, Meat Drop: +20, Last Available: "2010-06", Familiar Effect: "atk"
+4632	greedy wicked googly-star hat	0		Spell Damage: +5, Meat Drop: +20, Familiar Effect: "atk", Last Available: "2010-06"
 4633	reassuring Fonzie's googly-ball hat	0		Experience (Moxie): +1, Spooky Resistance: +1, Last Available: "2010-06"
 4634	maroon Fonzie's googly-heart hat of the sewer	0		Experience (Moxie): +1, Stench Damage: +25, Last Available: "2010-06"
 4635	bouncing wool super-sweet boom box of the glutton	0		Cold Resistance: +1, Food Drop: +100, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	beefcake's sinister demon mask of Leguizamo of extreme caution	0		Muscle: +25, Monster Level: -5, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	beefcake's sinister demon mask of Leguizamo of extreme caution	0		Muscle: +25, Monster Level: -5, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	greedy wholesome streetfighting champion's belt of incineration	0		Maximum HP Percent: +10, Hot Spell Damage: +50, Meat Drop: +20, Single Equip, Last Available: "2010-06"
 4639	hardened Space Trip safety headphones of the brute of the overflowing toilet	0		Muscle Percent: +30, Damage Reduction: 3, Stench Spell Damage: +50, Single Equip, Last Available: "2010-06"
 4640	sinister LARP carp	0		Spell Damage: +10
@@ -4594,8 +4594,8 @@
 4646	upside-down lion tamer's Meteoid ice beam of the storm of the brazier	0		Maximum MP Percent: +40, Experience (familiar): +2, Hot Spell Damage: +25, Last Available: "2011-12"
 4647	deadly Newton's Dungeon Fist gauntlet of extreme caution	0		Experience (Mysticality): +3, Weapon Damage: +5, Monster Level: -25, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	tumbling cyan ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	squat wholesome padded ironic knit cap	0		Damage Absorption: +20, Maximum HP Percent: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	blackberry galoshes of dire peril	0		Weapon Damage: +20, Single Equip
 4660	MacGyver's trout fang of temperance	0		Maximum MP: +100, Sleaze Resistance: +5, Last Available: "2010-09"
-4661	spoiled jumbo squat poisonous caviar	5	crappy	Last Available: "2010-09"
+4661	jumbo spoiled squat poisonous caviar	5	crappy	Last Available: "2010-09"
 4662	dry frozen skewed wet venom duct	0		Effect: "The Power of LOV", Effect Duration: 18, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	nippy Ellsbury's skull of horror	0		Cold Damage: +10, Spooky Spell Damage: +25, Last Available: "2010-09"
@@ -4620,20 +4620,20 @@
 4672	mirror comfy pillow	0		
 4673	bland bouncing marshmallow	3	decent	
 4674	bland sponge cake	3	decent	
-4675	perfectly mixed watered-down gin-soaked blotter paper	2	EPIC	
+4675	watered-down perfectly mixed gin-soaked blotter paper	2	EPIC	
 4676	wobbly tree-holed coin	0		
 4677	shaking unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	narrow volcanic ash	0		
 4680	pulsating smoked potsherd	0		
 4681	Tesla pottery shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 3, Last Available: "2010-09"
-4682	family-friendly pottery hat of the brazier	0		Hot Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	mansplainer's chaotic pottery training pants	0		Spell Critical Percent: +10, Monster Level: +15, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	family-friendly pottery hat of the brazier	0		Hot Spell Damage: +25, Sleaze Resistance: +1, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	mansplainer's chaotic pottery training pants	0		Spell Critical Percent: +10, Monster Level: +15, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	Temple Grandin's pottery club	0		Familiar Weight: +7, Last Available: "2010-09"
 4685	electrified pottery yo-yo	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
-4688	blinking huge fossilized serpent skull	0		Last Available: "2010-09"
+4688	huge blinking fossilized serpent skull	0		Last Available: "2010-09"
 4689	blurry fossilized baboon skull	0		Last Available: "2010-09"
 4690	blinking fossilized wyrm skull	0		Last Available: "2010-09"
 4691	fossilized wing	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	twirling toasty padded Greatest American Pants of extreme caution	0		Damage Absorption: +20, Monster Level: -25, Hot Damage: +5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	twirling toasty padded Greatest American Pants of extreme caution	0		Damage Absorption: +20, Monster Level: -25, Hot Damage: +5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	olive squat fossilized necklace of the ox	0		Muscle: +20, Last Available: "2010-09"
 4698	green imp air	0		
 4699	blurry narrow bus pass	0		
@@ -4672,19 +4672,19 @@
 4724	rotten shoo-fish pie	3	crappy	Last Available: "2010-10"
 4725	normal piping organ pie	4	good	Last Available: "2010-10"
 4726	toothsome gray igloo pie	3	awesome	Last Available: "2010-10"
-4727	rotten skewed upside-down stomach turnover	4	crappy	Last Available: "2010-10"
+4727	rotten upside-down skewed stomach turnover	4	crappy	Last Available: "2010-10"
 4728	thick rotten dead lights pie	5	crappy	Last Available: "2010-10"
-4729	normal huge red throbbing organ pie	6	good	Last Available: "2010-10"
+4729	huge normal red throbbing organ pie	6	good	Last Available: "2010-10"
 4730	wobbly tumbling supercool stop shield	0		Moxie Percent: +20, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	gray blinking sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	kitty sheet music	0		Familiar Weight: +5
-4734	skewed squat rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
-4735	pulsating mirror upside-down prop sword	0		Familiar Weight: +5
+4734	squat skewed rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
+4735	upside-down pulsating mirror prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	olive blurry sage beer-soaked mop	0		Mysticality Percent: +10
-4738	lousy irresponsibly strong day-old beer	7	decent	
-4739	practically non-alcoholic acceptable plain beer	1	good	
+4738	irresponsibly strong lousy day-old beer	7	decent	
+4739	acceptable practically non-alcoholic plain beer	1	good	
 4740	smooth fortified overpriced &quot;imported&quot; beer	5	awesome	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
@@ -4692,15 +4692,15 @@
 4744	cold-filtered PlexiPips	0		Effect: "Object Detection", Effect Duration: 38
 4745	quadruple-moist Wax Flask	0		Effect: "Pronounced Potency", Effect Duration: 11
 4746	energized altered wobbly skewed Pain Dip	0		Effect: "Crimbo Nostalgia", Effect Duration: 48
-4747	flavorless half-sized bone meal	2	decent	Last Available: "2010-10"
+4747	half-sized flavorless bone meal	2	decent	Last Available: "2010-10"
 4748	drinkable bouncing bone aperitif	4	good	Last Available: "2010-10"
 4749	teal brainy bonerang	0		Mysticality: +5, Last Available: "2010-10"
 4750	lime green twirling asbestos-lined bone and arrows	0		Hot Resistance: +5, Last Available: "2010-10"
 4751	boning knife of extreme caution	0		Monster Level: -25, Last Available: "2010-10"
 4752	bone crusher of the pedagogue	0		Experience: +3, Last Available: "2010-10"
 4753	huge bone spurs of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2010-10"
-4754	hardened strapping bonedanna	0		Muscle: +5, Damage Reduction: 3, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	foul-smelling boneana hammock of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	hardened strapping bonedanna	0		Muscle: +5, Damage Reduction: 3, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	foul-smelling boneana hammock of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	purple Stabonic scroll	0		Last Available: "2010-10"
 4758	Vulcanized anodized enhanced bouncing candy skeleton	0		Effect: "Gingerbread Robust", Effect Duration: 47, Last Available: "2020-09"
@@ -4708,7 +4708,7 @@
 4760	shaking skewed packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	flavorless big pumpkin pie	5	decent	Last Available: "2010-11"
+4763	big flavorless pumpkin pie	5	decent	Last Available: "2010-11"
 4764	lousy ghostly pumpkin beer	3	decent	Last Available: "2010-11"
 4765	colloidal blurry pumpkin juice	0		Effect: "Tiki Temerity", Effect Duration: 21, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4724,9 +4724,9 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	skewed Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	jittery Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	special huge bland CRIMBCOIDS mints	6	decent	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2011-01"
+4818	huge bland special CRIMBCOIDS mints	6	decent	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	normal miniature ghostly CRIMBCOLOAF	2	good	Last Available: "2011-01"
+4820	miniature normal ghostly CRIMBCOLOAF	2	good	Last Available: "2011-01"
 4821	normal jumbo circular CRIMBCOOKIE	5	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	teal MacGyver's plastic CRIMBCO HQ	0		Maximum MP: +100, Last Available: "2010-12"
 4823	squat bouncing spinning plastic fax machine of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2010-12"
@@ -4751,9 +4751,9 @@
 4842	olive sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	miser's sharpshooter's Uncle Hobo's stocking cap	0		Critical Hit Percent: +10, Meat Drop: +10, Last Available: "2010-12", Familiar Effect: "atk"
+4845	miser's sharpshooter's Uncle Hobo's stocking cap	0		Critical Hit Percent: +10, Meat Drop: +10, Familiar Effect: "atk", Last Available: "2010-12"
 4846	yellow double-paned Uncle Hobo's epic beard of the sweet-tooth	0		Cold Resistance: +5, Candy Drop: +100, Single Equip, Last Available: "2010-12"
-4847	nasty sinister Uncle Hobo's gift baggy pants	0		Spell Damage: +10, Stench Damage: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	nasty sinister Uncle Hobo's gift baggy pants	0		Spell Damage: +10, Stench Damage: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	lime green upside-down Jeselnik's ruddy Uncle Hobo's fingerless tinsel gloves	0		Maximum HP Percent: +40, Sleaze Damage: +25, Single Equip, Last Available: "2010-12"
 4849	lightning-fast Uncle Hobo's highest bough of the wise owl	0		Mysticality: +20, Initiative: +40, Last Available: "2010-12"
 4850	manspreader's Uncle Hobo's belt of the brazier	0		Monster Level: +10, Hot Spell Damage: +25, Single Equip, Last Available: "2010-12"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	cyan scandalous manspreader's smartaleck's paperclip-on tie	0		Moxie Percent: +30, Monster Level: +10, Sleaze Damage: +5, Single Equip, Last Available: "2011-01"
-4869	olive Tesla energetic paperclip pants	0		Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	manspreader's paperclip turban of the ox of dire peril	0		Muscle: +20, Weapon Damage: +20, Monster Level: +10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	olive Tesla energetic paperclip pants	0		Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	manspreader's paperclip turban of the ox of dire peril	0		Muscle: +20, Weapon Damage: +20, Monster Level: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	paperclip cape of dire peril	0		Weapon Damage: +20, Last Available: "2011-01"
 4872	red glob of Blank-Out	0		Last Available: "2011-01"
 4873	ghostly photocopied monster	0		Last Available: "2011-01"
@@ -4787,14 +4787,14 @@
 4878	galvanized blue incense bath ball	0		Effect: "Coming Up Roses", Effect Duration: 16, Last Available: "2011-01"
 4879	activated polarized modified myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Net Tea", Effect Duration: 12, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	artisanal special practically non-alcoholic CRIMBCO wine	1	EPIC	Effect: "In the Saucestream", Effect Duration: 5, Last Available: "2011-01"
+4881	artisanal practically non-alcoholic special CRIMBCO wine	1	EPIC	Effect: "In the Saucestream", Effect Duration: 5, Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	super-sized normal toe jam toast	5	good	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	tasty maroon traffic jam toast	3	awesome	Last Available: "2011-01"
 4887	upside-down space jam	0		Last Available: "2011-01"
-4888	flavorless diet space jam toast	1	decent	Last Available: "2011-01"
+4888	diet flavorless space jam toast	1	decent	Last Available: "2011-01"
 4889	boiled tarnished motivational poster	0		Effect: "Billiards Belligerence", Effect Duration: 47, Last Available: "2011-01"
 4890	maroon sack lunch	0		Last Available: "2011-01"
 4891	skewed bath ball gift set	0		Last Available: "2011-01"
@@ -4841,7 +4841,7 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	tumbling arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	spoiled tiny gray Knob jelly donut	1	crappy	
+4941	tiny spoiled gray Knob jelly donut	1	crappy	
 4942	spinning Knob cake	0		
 4943	purple Knob cake pan	0		
 4944	narrow Knob batter	0		
@@ -4859,7 +4859,7 @@
 4956	super-sized bland philosopher's scone	5	decent	
 4957	chilled half-baked potion	0		Effect: "Pisces Rising", Effect Duration: 18
 4958	blurry rosy-cheeked Knob Goblin deluxe scimitar	0		Maximum HP Percent: +30
-4959	decent tumbling blue Knob nuts	4	good	
+4959	decent blue tumbling Knob nuts	4	good	
 4960	artisanal squat Cobb's Knob Wurstbrau	4	EPIC	
 4961	Subject 37 file	0		
 4962	sharpshooter's personal trainer's mysterious lapel pin	0		Experience Percent (Muscle): +10, Critical Hit Percent: +10, Single Equip
@@ -4870,7 +4870,7 @@
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	skewed Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
-4970	maroon huge spinning Alice's Army Guard	0		Last Available: "2011-03"
+4970	spinning huge maroon Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
 4973	yellow Alice's Army Alchemist	0		Last Available: "2011-03"
@@ -4879,7 +4879,7 @@
 4976	pulsating Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
-4979	narrow red Alice's Army Bowman	0		Last Available: "2011-03"
+4979	red narrow Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	twirling jittery Alice's Army Coward	0		Last Available: "2011-03"
@@ -4897,7 +4897,7 @@
 4994	wobbly Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	tumbling Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	upside-down Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
-4997	ghostly purple Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
+4997	purple ghostly Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	huge Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	green Alice's Army Foil Bowman	0		Last Available: "2011-03"
@@ -4917,7 +4917,7 @@
 5014	bland tobiko pocky	4	decent	Last Available: "2011-03"
 5015	tasty half-sized natto pocky	2	awesome	Last Available: "2011-03"
 5016	drinkable wasabi-infused sake	3	good	Last Available: "2011-03"
-5017	watered-down mediocre lime green bouncing tobiko-infused sake	2	decent	Last Available: "2011-03"
+5017	watered-down mediocre bouncing lime green tobiko-infused sake	2	decent	Last Available: "2011-03"
 5018	hand-crafted natto-infused sake	3	EPIC	Last Available: "2011-03"
 5019	liquefied wasabi marble soda	0		Effect: "Winklered", Effect Duration: 32, Last Available: "2011-03"
 5020	concentrated blurry tobiko marble soda	0		Effect: "Happy Salamander", Effect Duration: 59, Last Available: "2011-03"
@@ -4925,8 +4925,8 @@
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	flattened vacuum-sealed vacuum-sealed elderly jawbreaker	0		Effect: "Outer Wolf&trade;", Effect Duration: 36, Last Available: "2020-09"
 5024	delicious marshmallow flamb&eacute;	3	awesome	Last Available: "2011-03"
-5025	fancy mediocre cranberry schnapps	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 30, Last Available: "2011-03"
-5026	fancy practically non-alcoholic delicious breaded beer	1	awesome	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2011-03"
+5025	mediocre fancy cranberry schnapps	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 30, Last Available: "2011-03"
+5026	delicious fancy practically non-alcoholic breaded beer	1	awesome	Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2011-03"
 5027	lousy twirling soy cordial	3	decent	Last Available: "2011-03"
 5028	skewed prompt quilted astral bludgeon of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40, Adventures: +3
 5029	blinking zippy astral shield of James Dean	0		Experience (Moxie): +3, Initiative: +20, Damage Reduction: 15
@@ -4944,14 +4944,14 @@
 5041	manspreader's smooth astral shirt of the bloodbag	0		Moxie: +15, Maximum HP: +100, Monster Level: +10
 5042	ghostly MacGyver's astral belt of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +100
 5043	decent astral hot dog	4		
-5044	bad irresponsibly strong special pulsating astral pilsner	10		Effect: "Fishy", Effect Duration: 5
+5044	bad special irresponsibly strong pulsating astral pilsner	10		Effect: "Fishy", Effect Duration: 5
 5045	astral hot dog dinner	0		
 5046	pulsating astral six-pack	0		
 5047	tumbling Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	resourceful dangerous beefcake's double-ice cap	0		Muscle: +25, Weapon Damage: +10, Maximum MP: +50, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	resourceful dangerous beefcake's double-ice cap	0		Muscle: +25, Weapon Damage: +10, Maximum MP: +50, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	Jeselnik's Samson's double-ice box of Gandalf	0		Experience (Muscle): +5, Spell Critical Percent: +20, Sleaze Damage: +25, Last Available: "2011-04"
-5051	coward's rosy-cheeked hardened double-ice britches	0		Damage Reduction: 3, Maximum HP Percent: +30, Monster Level: -20, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	coward's rosy-cheeked hardened double-ice britches	0		Damage Reduction: 3, Maximum HP Percent: +30, Monster Level: -20, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	teal handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4965,7 +4965,7 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	decent huge olive spaghetti con calaveras	9	good	Last Available: "2011-04"
+5065	huge decent olive spaghetti con calaveras	9	good	Last Available: "2011-04"
 5066	twirling s'more gun	0		Last Available: "2011-04"
 5067	bland popcorn	3	decent	Last Available: "2011-04"
 5068	spoiled half-sized chaos popcorn	2	crappy	Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	irresponsibly strong artisanal Russian Ice	7	EPIC	Last Available: "2011-04"
 5074	frosty clay ashtray	0		Cold Spell Damage: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	narrow skewed wholesome lanyard	0		Maximum HP Percent: +10, Single Equip, Last Available: "2011-05"
-5076	monster pants of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	monster pants of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	moist colloidal Pok&euml;mann band-aid	0		Effect: "Smoking like a Bandit", Effect Duration: 68, Last Available: "2011-05"
-5079	smooth thinker's Van der Graaf helmet	0		Mysticality: +10, Moxie: +15, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	smooth thinker's Van der Graaf helmet	0		Mysticality: +10, Moxie: +15, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	Rosewater's crutch	0		Mysticality Percent: +30, Last Available: "2011-05"
 5081	shock belt of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5082	non-Vulcanized nitrogenated concentrated lime green Okee-Dokee soda	0		Effect: "Phairly Balanced", Effect Duration: 65, Last Available: "2011-05"
 5083	rubber band gun	0		Item Drop: +5, Last Available: "2011-05"
-5084	blue narrow pin-stripe slacks of the storm	0		Maximum MP Percent: +40, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	blue narrow pin-stripe slacks of the storm	0		Maximum MP Percent: +40, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	hardy gloves	0		Maximum HP: +50, Single Equip, Last Available: "2011-05"
 5086	dry colloidal correction fluid	0		Effect: "So Fresh and So Clean", Effect Duration: 35, Last Available: "2011-05"
 5087	upside-down Pok&euml;mann figurine: Porkachu of the early riser	0		Adventures: +7, Single Equip, Last Available: "2011-05"
@@ -5014,15 +5014,15 @@
 5111	medical-grade Ultracolor&trade; shirt	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05"
 5112	twirling My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
-5114	green ghostly stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
+5114	ghostly green stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	yellow bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	shaking red hardened Fonzie's Admiral's hat of horror	0		Experience (Moxie): +1, Damage Reduction: 3, Spooky Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "atk"
-5122	narrow quilted brawny beefy aviator's cap	0		Muscle: +10, Muscle Percent: +20, Damage Absorption: +40, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	shaking red hardened Fonzie's Admiral's hat of horror	0		Experience (Moxie): +1, Damage Reduction: 3, Spooky Spell Damage: +25, Familiar Effect: "atk", Last Available: "2011-05"
+5122	narrow quilted brawny beefy aviator's cap	0		Muscle: +10, Muscle Percent: +20, Damage Absorption: +40, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	pulsating fuchsia censurious mirrored aviator shades of the businessman	0		Sleaze Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5046,13 +5046,13 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	vacuum-sealed concentrated moist honeypot	0		Effect: "Aided and Abetted", Effect Duration: 52
-5146	diet moldy squat bouncing wild honey pie	1	crappy	
+5146	diet moldy bouncing squat wild honey pie	1	crappy	
 5147	lousy honey mead	3	decent	
 5148	jittery fuchsia reassuring veiny beefy honey dipper	0		Muscle: +10, Maximum HP: +10, Spooky Resistance: +1
 5149	bouncing mansplainer's hale strapping honeybritches	0		Muscle: +5, Maximum HP: +20, Monster Level: +15, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	mansplainer's arcane researcher's honeycap of temperance	0		Experience Percent (Mysticality): +10, Monster Level: +15, Sleaze Resistance: +5, Familiar Effect: "1xPotato, cap 43"
-5151	olive dog trainer's Moonthril Circlet	0		Experience (familiar): +1, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	medical-grade Moonthril Greaves	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	olive dog trainer's Moonthril Circlet	0		Experience (familiar): +1, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	medical-grade Moonthril Greaves	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	dance instructor's Moonthril Flamberge	0		Experience Percent (Moxie): +10, Last Available: "2011-06"
 5154	fuchsia Samson's Moonthril Longbow	0		Experience (Muscle): +5, Last Available: "2011-06"
 5155	supercharged Moonthril Cuirass	0		Maximum MP Percent: +30, Softcore Only, Last Available: "2011-06"
@@ -5076,10 +5076,10 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	practically non-alcoholic tolerable Saison du Lune	1	good	Last Available: "2011-06"
 5175	smooth weak Moonthril Schnapps	2	awesome	Last Available: "2011-06"
-5176	acceptable special practically non-alcoholic Wrecked Generator	1	good	Effect: "Bright!", Effect Duration: 50, Last Available: "2011-06"
+5176	special acceptable practically non-alcoholic Wrecked Generator	1	good	Effect: "Bright!", Effect Duration: 50, Last Available: "2011-06"
 5177	rotten Spaghetti with Moonballs	4	crappy	Last Available: "2011-06"
-5178	stale low-calorie special purple Crepes a la Lune	1	decent	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2011-06"
-5179	spoiled half-sized gray twirling bouncing Moon Pie	2	crappy	Last Available: "2011-06"
+5178	low-calorie stale special purple Crepes a la Lune	1	decent	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2011-06"
+5179	spoiled half-sized bouncing gray twirling Moon Pie	2	crappy	Last Available: "2011-06"
 5180	galvanized Vulcanized twirling Comet Pop	0		Effect: "Human-Horror Hybrid", Effect Duration: 44, Last Available: "2011-06"
 5181	aerosolized double-enhanced triple-nitrogenated Flan in the Moon	0		Effect: "The Strength...  of the Future", Effect Duration: 43, Last Available: "2011-06"
 5182	galvanized 1/6th Pound Cake	0		Effect: "Mathematically Precise", Effect Duration: 68, Last Available: "2011-06"
@@ -5116,18 +5116,18 @@
 5213	dehydrated green Mer-kin paste	1	awesome	Last Available: "2011-08"
 5214	dried wobbly narrow slimy paste	1	good	Last Available: "2011-08"
 5215	altered blue narrow penguin paste	1	crappy	Effect: "Blessing of Squirtlcthulli", Effect Duration: 20, Last Available: "2011-08"
-5216	dehydrated blurry upside-down elemental paste	1	decent	Last Available: "2011-08"
-5217	pickled twirling squat cosmic paste	1	decent	Last Available: "2011-08"
+5216	dehydrated upside-down blurry elemental paste	1	decent	Last Available: "2011-08"
+5217	pickled squat twirling cosmic paste	1	decent	Last Available: "2011-08"
 5218	compressed blinking hobo paste	1	EPIC	Last Available: "2011-08"
 5219	altered green Crimbo paste	1	crappy	Effect: "Bolts about Candy", Effect Duration: 5, Last Available: "2011-08"
 5220	upside-down Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	olive skewed Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	skewed olive Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	immense normal Ur-Donut	6	good	Last Available: "2011-09"
-5225	tumbling ghostly The Bomb	0		Last Available: "2011-09"
+5225	ghostly tumbling The Bomb	0		Last Available: "2011-09"
 5226	blurry box of Familiar Jacks	0		Last Available: "2011-09"
-5227	watered-down drinkable skewed bucket of wine	2	good	Last Available: "2011-09"
+5227	drinkable watered-down skewed bucket of wine	2	good	Last Available: "2011-09"
 5228	rotten ultrafondue	3	crappy	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	upside-down snowflake	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	tumbling smelly furry halo	0		Stench Spell Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	studded frosty halo	0		Damage Absorption: +80, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	tumbling time halo of horror	0		Spooky Spell Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	aged watered-down Lumineux Limnio	2	awesome	Last Available: "2011-09"
+5238	watered-down aged Lumineux Limnio	2	awesome	Last Available: "2011-09"
 5239	drinkable Morto Moreto	3	good	Last Available: "2011-09"
 5240	mediocre watered-down squat huge Temps Tempranillo	2	decent	Last Available: "2011-09"
-5241	bad extra-dry Bordeaux Marteaux	5	decent	Last Available: "2011-09"
+5241	extra-dry bad Bordeaux Marteaux	5	decent	Last Available: "2011-09"
 5242	tolerable huge Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	delicious Beignet Milgranet	4	awesome	Last Available: "2011-09"
 5244	perfectly mixed irresponsibly strong maroon spinning Muschat	10	EPIC	Last Available: "2011-09"
 5245	stale snack-sized cool jelly donut	2	decent	Last Available: "2011-09"
 5246	super-sized normal shrapnel jelly donut	5	good	Last Available: "2011-09"
-5247	toothsome pulsating bouncing occult jelly donut	4	awesome	Last Available: "2011-09"
+5247	toothsome bouncing pulsating occult jelly donut	4	awesome	Last Available: "2011-09"
 5248	adequate thyme jelly donut	4	good	Last Available: "2011-09"
 5249	tasty danish	3	awesome	Last Available: "2011-09"
-5250	tiny delicious smashed danish	1	awesome	Last Available: "2011-09"
-5251	half-sized spoiled gray forbidden danish	2	crappy	Last Available: "2011-09"
-5252	spoiled snack-sized cool cat claw	2	crappy	Last Available: "2011-09"
+5250	delicious tiny smashed danish	1	awesome	Last Available: "2011-09"
+5251	spoiled half-sized gray forbidden danish	2	crappy	Last Available: "2011-09"
+5252	snack-sized spoiled cool cat claw	2	crappy	Last Available: "2011-09"
 5253	stale blunt cat claw	3	decent	Last Available: "2011-09"
-5254	adequate special blinking shadowy cat claw	4	good	Effect: "Burning Ears", Effect Duration: 20, Last Available: "2011-09"
+5254	special adequate blinking shadowy cat claw	4	good	Effect: "Burning Ears", Effect Duration: 20, Last Available: "2011-09"
 5255	bland half-sized cheezburger	2	decent	Last Available: "2011-09"
-5256	toothsome special half-sized olive narrow toasted brie	2	awesome	Effect: "Going Ape", Effect Duration: 25, Last Available: "2011-09"
+5256	special half-sized toothsome narrow olive toasted brie	2	awesome	Effect: "Going Ape", Effect Duration: 25, Last Available: "2011-09"
 5257	enhanced vacuum-sealed denatured potion of the field gar	0		Effect: "Cat-Alyzed", Effect Duration: 56, Last Available: "2011-09"
 5258	non-colloidal frozen bouncing too legit potion	0		Effect: "Sausage Festive", Effect Duration: 60, Last Available: "2011-09"
 5259	polarized dry shaking Bright Water	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 66, Last Available: "2011-09"
@@ -5184,9 +5184,9 @@
 5281	hardened broken clock	0		Damage Reduction: 3, Last Available: "2011-09"
 5282	up-at-dawn dethklok	0		Adventures: +5, Last Available: "2011-09"
 5283	toasty glacial clock	0		Hot Damage: +5, Last Available: "2011-09"
-5284	tumbling Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	tumbling Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	jittery d4	0		Last Available: "2011-09"
-5286	jittery wobbly d6	0		Last Available: "2011-09"
+5286	wobbly jittery d6	0		Last Available: "2011-09"
 5287	narrow d8	0		Last Available: "2011-09"
 5288	tumbling d10	0		Last Available: "2011-09"
 5289	lime green d12	0		Last Available: "2011-09"
@@ -5222,24 +5222,24 @@
 5319	boiled aerosolized blinking Blood 'n' Plenty	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 58, Last Available: "2011-10"
 5320	pressed tumbling Lobos Mints	0		Effect: "Red Misty-Eyed", Effect Duration: 34, Last Available: "2011-10"
 5321	colloidal lime green Sweet Sword	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 12, Last Available: "2011-10"
-5322	watered-down tolerable blinking Ecto-Cooler	2	good	Last Available: "2011-10"
+5322	tolerable watered-down blinking Ecto-Cooler	2	good	Last Available: "2011-10"
 5323	aged practically non-alcoholic Bartles and BRAAAINS wine cooler	1	awesome	Last Available: "2011-10"
 5324	triple-distilled perfectly mixed Blood Light	7	EPIC	Last Available: "2011-10"
-5325	smooth practically non-alcoholic fancy Silver Bullet beer	1	awesome	Effect: "Frozen Hands", Effect Duration: 20, Last Available: "2011-10"
+5325	practically non-alcoholic fancy smooth Silver Bullet beer	1	awesome	Effect: "Frozen Hands", Effect Duration: 20, Last Available: "2011-10"
 5326	high-proof mediocre Bone's Farm &quot;wine&quot;	6	decent	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	flattened sorority brain	0		Effect: "Baconstoned", Effect Duration: 67, Last Available: "2011-10"
 5329	quantum shaking Nightstalker perfume	0		Effect: "Cockroach Scurry", Effect Duration: 47, Last Available: "2011-10"
-5330	chilled flattened narrow blurry drum of pomade	0		Effect: "Slightly Mutated", Effect Duration: 34, Last Available: "2011-10"
+5330	chilled flattened blurry narrow drum of pomade	0		Effect: "Slightly Mutated", Effect Duration: 34, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	dog trainer's extra-see-thru nightie	0		Experience (familiar): +1, Last Available: "2011-10"
-5333	smelly BRAINS shorts of the ox	0		Muscle: +20, Stench Spell Damage: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	smelly BRAINS shorts of the ox	0		Muscle: +20, Stench Spell Damage: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	shaking Mesmereyes&trade; contact lenses of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Last Available: "2011-10"
 5335	scrunchie of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2011-10"
-5336	sharpshooter's baleful extremely skinny jeans	0		Spell Damage: +25, Critical Hit Percent: +10, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	veiny smooth The Necbromancer's Hat	0		Moxie: +15, Maximum HP: +10, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	sharpshooter's baleful extremely skinny jeans	0		Spell Damage: +25, Critical Hit Percent: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	veiny smooth The Necbromancer's Hat	0		Moxie: +15, Maximum HP: +10, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	Lo Pan's Newton's The Necbromancer's Stein of Flo-Jo	0		Experience (Mysticality): +3, Spell Critical Percent: +30, Initiative: +100, Last Available: "2011-10"
-5339	lard-coated manspreader's MacGyver's The Necbromancer's Shorts	0		Maximum MP: +100, Monster Level: +10, Sleaze Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	lard-coated manspreader's MacGyver's The Necbromancer's Shorts	0		Maximum MP: +100, Monster Level: +10, Sleaze Spell Damage: +25, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	arcane researcher's Socratic The Necbromancer's Wizard Staff of the brute	0		Muscle Percent: +30, Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	acceptable The Cooler Out of Space	3	good	Last Available: "2011-10"
@@ -5294,10 +5294,10 @@
 5391	asbestos-lined zombie monkey necklace of the cougar	0		Moxie: +20, Hot Resistance: +5
 5392	skewed Thwaitgold butterfly statuette	0		
 5393	blurry scrap of paper	0		
-5394	squat tumbling sandpaper	0		
+5394	tumbling squat sandpaper	0		
 5395	jittery peppermint sprout	0		Last Available: "2011-11"
 5396	energized peppermint twist	0		Effect: "Dwarven Hardiness", Effect Duration: 19, Last Available: "2011-11"
-5397	tasty small peppermint patty	2	awesome	Last Available: "2011-11"
+5397	small tasty peppermint patty	2	awesome	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	fuchsia peppermint rhino baby	0		Last Available: "2011-11"
 5400	blinking candy cane candygram	0		Last Available: "2011-12"
@@ -5306,20 +5306,20 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	yellow Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	scorching rock-hard cane-mail shirt of the businessman	0		Damage Reduction: 5, Hot Damage: +25, Meat Drop: +50, Last Available: "2011-12"
-5406	twirling foul-smelling hale occult cane-mail pants	0		Spell Damage Percent: +25, Maximum HP: +20, Stench Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	smooth weak enchanted Vodka Matryoshka	2	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25, Last Available: "2011-12"
+5406	twirling foul-smelling hale occult cane-mail pants	0		Spell Damage Percent: +25, Maximum HP: +20, Stench Damage: +10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5407	smooth enchanted weak Vodka Matryoshka	2	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 25, Last Available: "2011-12"
 5408	hand-crafted narrow Gin Mint	3	EPIC	Last Available: "2011-12"
 5409	practically non-alcoholic tolerable Tequiz Navidad	1	good	Last Available: "2011-12"
 5410	watered-down bad Mint Yulep	2	decent	Last Available: "2011-12"
 5411	artisanal skewed shaking Crimbojito	4	EPIC	Last Available: "2011-12"
-5412	watered-down mediocre blinking Sangria de Menthe	2	decent	Last Available: "2011-12"
+5412	mediocre watered-down blinking Sangria de Menthe	2	decent	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	shaking licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
-5415	activated upside-down shaking licorice root	0		Effect: "Chief Executive Optimism", Effect Duration: 49, Last Available: "2011-12"
+5415	activated shaking upside-down licorice root	0		Effect: "Chief Executive Optimism", Effect Duration: 49, Last Available: "2011-12"
 5416	magnetized alkaline banana supersucker	0		Effect: "Berry Berry Cold", Effect Duration: 58, Last Available: "2011-11"
 5417	galvanized fuchsia pear supersucker	0		Effect: "Chief Executive Optimism", Effect Duration: 65, Last Available: "2011-11"
 5418	concentrated lime supersucker	0		Effect: "Florid Cheeks", Effect Duration: 17, Last Available: "2011-11"
-5419	cold-filtered ghostly spinning kumquat supersucker	0		Effect: "Scarysauce", Effect Duration: 27, Last Available: "2011-11"
+5419	cold-filtered spinning ghostly kumquat supersucker	0		Effect: "Scarysauce", Effect Duration: 27, Last Available: "2011-11"
 5420	colloidal liquefied maroon strawberry supersucker	0		Effect: "Bored Stiff", Effect Duration: 62, Last Available: "2011-11"
 5421	mirror bananarama bangle of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2011-11"
 5422	tumbling MacGyver's pair of pearidot earrings	0		Maximum MP: +100, Single Equip, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	reassuring kumquartz ring	0		Spooky Resistance: +1, Single Equip, Last Available: "2011-11"
 5425	stanky strawberyl necklace	0		Stench Spell Damage: +25, Single Equip, Last Available: "2011-11"
 5426	sucker bucket of the brazier	0		Hot Spell Damage: +25, Item Drop: +5, Last Available: "2011-11"
-5427	grievous sucker hakama	0		Weapon Damage Percent: +50, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	frosty sucker kabuto	0		Cold Spell Damage: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	grievous sucker hakama	0		Weapon Damage Percent: +50, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	frosty sucker kabuto	0		Cold Spell Damage: +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	blinking spinning sucker tachi of horror	0		Spooky Spell Damage: +25, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	huge cinnamon troll doll	0		Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	greedy wicked fudgecycle of the empath	0		Spell Damage: +5, Familiar Weight: +5, Meat Drop: +20, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	vacuum-sealed resolution: be wealthier	0		Effect: "Hyphemariffic", Effect Duration: 64, Last Available: "2012-01"
 5465	colloidal moist resolution: be happier	0		Effect: "Smoking like a Bandit", Effect Duration: 60, Last Available: "2012-01"
 5466	colloidal resolution: be stronger	0		Effect: "Riboflavin'", Effect Duration: 53, Last Available: "2012-01"
@@ -5379,8 +5379,8 @@
 5476	corrupted green gummi salamander	0		Effect: "Clean-Shaven", Effect Duration: 24, Last Available: "2011-11"
 5477	corrupted frozen olive gummi snake	0		Effect: "Tenacity of the Snapper", Effect Duration: 62, Last Available: "2011-11"
 5478	super-modified tarnished Vulcanized squat gummi canary	0		Effect: "Muscle Unbound", Effect Duration: 29, Last Available: "2011-11"
-5479	small bland tumbling gummi bear	2	decent	Last Available: "2011-11"
-5480	miniature stale gummi bear	2	decent	Last Available: "2011-11"
+5479	bland small tumbling gummi bear	2	decent	Last Available: "2011-11"
+5480	stale miniature gummi bear	2	decent	Last Available: "2011-11"
 5481	stale super-sized gummi bear	5	decent	Last Available: "2011-11"
 5482	low-calorie decent drunki-bear	1	good	Last Available: "2011-11"
 5483	adequate blue drunki-bear	4	good	Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	pickled wet blue gummi belemnite	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 15, Last Available: "2011-11"
 5497	lime green all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	teal mirror frightening Sinatra's Big Candy's tophat	0		Experience (Moxie): +5, Spooky Damage: +5, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	teal mirror frightening Sinatra's Big Candy's tophat	0		Experience (Moxie): +5, Spooky Damage: +5, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blinking blessed box	0		
 5505	twirling pack of pogs	0		Last Available: "2011-11"
 5506	spoiled diet bouncing jerky coins	1	crappy	Last Available: "2011-11"
-5507	aged watered-down Go-Wassail	2	awesome	Last Available: "2011-11"
+5507	watered-down aged Go-Wassail	2	awesome	Last Available: "2011-11"
 5508	alkaline irradiated red Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Think Win-Lose", Effect Duration: 62, Last Available: "2011-11"
 5509	extra-cold-filtered polymerized super-unsweetened bottle of bubbles	0		Effect: "The Dinsey Spirit", Effect Duration: 14, Last Available: "2011-11"
 5510	energized mirror wind-up meatcar	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 51, Last Available: "2011-11"
@@ -5416,11 +5416,11 @@
 5513	huge Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	skewed Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	pog #01 (spider)	0		Last Available: "2011-11"
-5516	narrow teal pog #02 (Knob goblin)	0		Last Available: "2011-11"
+5516	teal narrow pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	blurry pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
-5520	wobbly yellow pog #06 (filthy hippy)	0		Last Available: "2011-11"
+5520	yellow wobbly pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	twirling pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
@@ -5429,11 +5429,11 @@
 5526	wet corrupted Atomic Pop	0		Effect: "Oiled Skin", Effect Duration: 31, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	decent massive skewed berries of suffering	6	good	Last Available: "2012-12"
+5529	massive decent skewed berries of suffering	6	good	Last Available: "2012-12"
 5530	electrified wobbly shaking baobab sap	0		Effect: "Florid Cheeks", Effect Duration: 69, Last Available: "2012-12"
 5531	blurry cup of hickory chicory	0		Last Available: "2012-12"
 5532	bouncing magnolia blossom	0		Last Available: "2012-12"
-5533	corrupted aerosolized twirling blue Mortimer's nostrum	0		Effect: "Grumpy and Ornery", Effect Duration: 44, Last Available: "2012-12"
+5533	corrupted aerosolized blue twirling Mortimer's nostrum	0		Effect: "Grumpy and Ornery", Effect Duration: 44, Last Available: "2012-12"
 5534	lousy Barulio's bottle	3	decent	Last Available: "2012-12"
 5535	colloidal corrupted corrupted blinking Marvin's marvelous pill	0		Effect: "Sweet Nostalgia", Effect Duration: 63, Last Available: "2012-12"
 5536	blinking Winifred's whistle	0		Last Available: "2012-12"
@@ -5444,8 +5444,8 @@
 5541	bouncing Vivian's Vitamin	0		Last Available: "2012-12"
 5542	narrow pink-belly slapper	0		Last Available: "2012-12"
 5543	steel-toed Leapin' Trousers of chilblains	0		Damage Reduction: 9, Cold Damage: +25
-5544	watered-down artisanal eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
-5545	adequate jumbo hamhock	5	good	Last Available: "2012-12"
+5544	artisanal watered-down eggnog	2	super ultra mega EPIC	Last Available: "2012-12"
+5545	jumbo adequate hamhock	5	good	Last Available: "2012-12"
 5546	jittery The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	olive Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5459,50 +5459,50 @@
 5556	tumbling purple studded Rain-Doh wings	0		Damage Absorption: +80, Item Drop: +5, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	censurious scandalous Rain-Doh laser gun	0		Sleaze Damage: +5, Sleaze Resistance: +3, Softcore Only, Last Available: "2012-02"
-5559	squat Annie Oakley's thinker's Rain-Doh lantern	0		Mysticality: +10, Critical Hit Percent: +20, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	squat Annie Oakley's thinker's Rain-Doh lantern	0		Mysticality: +10, Critical Hit Percent: +20, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	cyan Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	auspicious baleful Rain-Doh violet bo	0		Spell Damage: +25, Item Drop: +10, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	wobbly Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	massive moldy PB&BP	10	crappy	
-5566	spoiled gigantic shaking club sandwich	6	crappy	
+5566	gigantic spoiled shaking club sandwich	6	crappy	
 5567	tiny tasty corned-beef Reuben	1	awesome	
 5568	frayed ninja rope	0		
 5569	cyan dull ninja crampons	0		
 5570	maroon loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	acceptable practically non-alcoholic Drac & Tan	1	good	Last Available: "2012-03"
+5573	practically non-alcoholic acceptable Drac & Tan	1	good	Last Available: "2012-03"
 5574	drinkable Transylvania Sling	4	good	Last Available: "2012-03"
-5575	tolerable practically non-alcoholic maroon Shot of the Living Dead	1	good	Last Available: "2012-03"
-5576	acceptable high-proof upside-down purple Buttery Knob	9	good	Last Available: "2012-03"
+5575	practically non-alcoholic tolerable maroon Shot of the Living Dead	1	good	Last Available: "2012-03"
+5576	high-proof acceptable upside-down purple Buttery Knob	9	good	Last Available: "2012-03"
 5577	smooth Slippery Knob	4	awesome	Last Available: "2012-03"
 5578	mediocre Flaming Knob	3	decent	Last Available: "2012-03"
 5579	weak delicious yellow Grasshopper	2	awesome	Last Available: "2012-03"
 5580	mediocre Locust	3	decent	Last Available: "2012-03"
-5581	watered-down lousy upside-down Plague of Locusts	2	decent	Last Available: "2012-03"
+5581	lousy watered-down upside-down Plague of Locusts	2	decent	Last Available: "2012-03"
 5582	lousy Red Dwarf	3	decent	Last Available: "2012-03"
-5583	artisanal weak enchanted Golden Mean	2	EPIC	Effect: "Took Eleven", Effect Duration: 30, Last Available: "2012-03"
-5584	practically non-alcoholic artisanal Green Giant	1	super ultra EPIC	Last Available: "2012-03"
+5583	enchanted artisanal weak Golden Mean	2	EPIC	Effect: "Took Eleven", Effect Duration: 30, Last Available: "2012-03"
+5584	artisanal practically non-alcoholic Green Giant	1	super ultra EPIC	Last Available: "2012-03"
 5585	drinkable fuchsia Aye Aye	3	good	Last Available: "2012-03"
 5586	acceptable Aye Aye, Captain	4	good	Last Available: "2012-03"
 5587	high-proof mediocre huge huge Aye Aye, Tooth Tooth	7	decent	Last Available: "2012-03"
 5588	delicious Humanitini	3	awesome	Last Available: "2012-03"
-5589	delicious irresponsibly strong More Humanitini than Humanitini	10	awesome	Last Available: "2012-03"
-5590	practically non-alcoholic lousy yellow Oh, the Humanitini	1	decent	Last Available: "2012-03"
-5591	smooth watered-down Great Older Fashioned	2	awesome	Last Available: "2012-03"
+5589	irresponsibly strong delicious More Humanitini than Humanitini	10	awesome	Last Available: "2012-03"
+5590	lousy practically non-alcoholic yellow Oh, the Humanitini	1	decent	Last Available: "2012-03"
+5591	watered-down smooth Great Older Fashioned	2	awesome	Last Available: "2012-03"
 5592	bad upside-down Fuzzy Tentacle	4	decent	Last Available: "2012-03"
-5593	high-proof tolerable Crazymaker	6	good	Last Available: "2012-03"
+5593	tolerable high-proof Crazymaker	6	good	Last Available: "2012-03"
 5594	lousy Zoodriver	3	decent	Last Available: "2012-03"
 5595	mediocre jittery Sloe Comfortable Zoo	4	decent	Last Available: "2012-03"
 5596	delicious watered-down olive Sloe Comfortable Zoo on Fire	2	awesome	Last Available: "2012-03"
-5597	delicious weak Suffering Sinner	2	awesome	Last Available: "2012-03"
+5597	weak delicious Suffering Sinner	2	awesome	Last Available: "2012-03"
 5598	lousy Suppurating Sinner	3	decent	Last Available: "2012-03"
 5599	delicious huge Sizzling Sinner	3	awesome	Last Available: "2012-03"
-5600	lousy fancy high-proof bouncing Firewater	9	decent	Effect: "Neuromancy", Effect Duration: 5, Last Available: "2012-03"
+5600	fancy high-proof lousy bouncing Firewater	9	decent	Effect: "Neuromancy", Effect Duration: 5, Last Available: "2012-03"
 5601	perfectly mixed Earth and Firewater	3	EPIC	Last Available: "2012-03"
-5602	smooth practically non-alcoholic wobbly Earth, Wind and Firewater	1	awesome	Last Available: "2012-03"
+5602	practically non-alcoholic smooth wobbly Earth, Wind and Firewater	1	awesome	Last Available: "2012-03"
 5603	hand-crafted high-proof gray Slimosa	9	EPIC	Last Available: "2012-03"
 5604	aged Extra-slimy Slimosa	3	awesome	Last Available: "2012-03"
 5605	mediocre Slimebite	4	decent	Last Available: "2012-03"
@@ -5512,15 +5512,15 @@
 5609	lousy gray Fauna Libre	4	decent	Last Available: "2012-03"
 5610	fortified delicious Chakra Libre	5	awesome	Last Available: "2012-03"
 5611	perfectly mixed bouncing Aura Libre	3	EPIC	Last Available: "2012-03"
-5612	fortified bad narrow Sazerorc	5	decent	Last Available: "2012-03"
-5613	weak perfectly mixed bouncing Sazuruk-hai	2	EPIC	Last Available: "2012-03"
+5612	bad fortified narrow Sazerorc	5	decent	Last Available: "2012-03"
+5613	perfectly mixed weak bouncing Sazuruk-hai	2	EPIC	Last Available: "2012-03"
 5614	tolerable Flaming Sazerorc	4	good	Last Available: "2012-03"
 5615	artisanal Green Velvet	4	EPIC	Last Available: "2012-03"
-5616	irresponsibly strong perfectly mixed Green Muslin	8	EPIC	Last Available: "2012-03"
+5616	perfectly mixed irresponsibly strong Green Muslin	8	EPIC	Last Available: "2012-03"
 5617	practically non-alcoholic mediocre Green Burlap	1	decent	Last Available: "2012-03"
-5618	hand-crafted weak Mohobo	2	EPIC	Last Available: "2012-03"
-5619	practically non-alcoholic acceptable Moonshine Mohobo	1	good	Last Available: "2012-03"
-5620	mediocre weak bouncing Flaming Mohobo	2	decent	Last Available: "2012-03"
+5618	weak hand-crafted Mohobo	2	EPIC	Last Available: "2012-03"
+5619	acceptable practically non-alcoholic Moonshine Mohobo	1	good	Last Available: "2012-03"
+5620	weak mediocre bouncing Flaming Mohobo	2	decent	Last Available: "2012-03"
 5621	hand-crafted extra-dry Drunken Philosopher	5	EPIC	Last Available: "2012-03"
 5622	artisanal Drunken Neurologist	3	EPIC	Last Available: "2012-03"
 5623	weak mediocre Drunken Astrophysicist	2	decent	Last Available: "2012-03"
@@ -5534,7 +5534,7 @@
 5631	delicious blinking Candy Alexander	4	awesome	Last Available: "2012-03"
 5632	lousy gray Candicaine	3	decent	Last Available: "2012-03"
 5633	tolerable Caipiranha	4	good	Last Available: "2012-03"
-5634	watered-down hand-crafted Flying Caipiranha	2	EPIC	Last Available: "2012-03"
+5634	hand-crafted watered-down Flying Caipiranha	2	EPIC	Last Available: "2012-03"
 5635	practically non-alcoholic bad skewed Flaming Caipiranha	1	decent	Last Available: "2012-03"
 5636	drinkable Punchplanter	3	good	Last Available: "2012-03"
 5637	enchanted acceptable Doublepunchplanter	4	good	Effect: "Hippy Flavor", Effect Duration: 15, Last Available: "2012-03"
@@ -5548,9 +5548,9 @@
 5645	blurry the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	shaking shellacked calendar	0		Damage Reduction: 11
-5648	lightning-fast supercool Boris's Helm	0		Moxie Percent: +20, Initiative: +40, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	lightning-fast supercool Boris's Helm	0		Moxie Percent: +20, Initiative: +40, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	scorching banded staph of homophones	0		Damage Absorption: +100, Hot Damage: +25
-5650	wool Jack Frost's Tesla Boris's Helm (askew)	0		Cold Spell Damage: +50, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	wool Jack Frost's Tesla Boris's Helm (askew)	0		Cold Spell Damage: +50, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	red Monster Manuel	0		Free Pull
 5653	tumbling key-o-tron	0		
@@ -5577,9 +5577,9 @@
 5674	cyan &quot;L&quot;	0		
 5675	pickled watered-down Red Minotaur	1		Effect: "Sleazy Hands", Effect Duration: 15
 5676	pulsating pool torpedo	0		Last Available: "2012-05"
-5677	sage Ze&trade; goggles	0		Mysticality Percent: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	sage Ze&trade; goggles	0		Mysticality Percent: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	green soggy used band-aid	0		Last Available: "2012-05"
-5679	experienced stylish swimsuit of incineration	0		Experience: +2, Hot Spell Damage: +50, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	experienced stylish swimsuit of incineration	0		Experience: +2, Hot Spell Damage: +50, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	twirling lost key	0		Last Available: "2012-05"
 5681	spoiled P.B.L.T.	4	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5587,7 +5587,7 @@
 5684	red handful of juicy garbage	0		
 5685	gray bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	huge cyan bugbear autopsy tweezers	0		
+5687	cyan huge bugbear autopsy tweezers	0		
 5688	UV monocular of the storm	0		Maximum MP Percent: +40, Single Equip
 5689	drone self-destruct chip	0		
 5690	Jeff Goldblum larva	0		
@@ -5599,17 +5599,17 @@
 5696	blurry bugbear purification pill	0		
 5697	narrow 1 Meat	0		
 5698	blurry nasty Newton's The Lost Glasses	0		Experience (Mysticality): +3, Stench Damage: +5, Single Equip
-5699	huge red The Lost Pill Bottle	0		Last Available: "2012-05"
+5699	red huge The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	squat jittery The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	pulsating wax bugbear	0		Last Available: "2012-06"
-5705	tumbling friendly wax hat of doom	0		Familiar Weight: +3, Spooky Spell Damage: +50, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	thinker's wax pants of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	tumbling friendly wax hat of doom	0		Familiar Weight: +3, Spooky Spell Damage: +50, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	thinker's wax pants of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	bouncing FDKOL commendation	0		Last Available: "2012-07"
-5708	quantum wobbly huge bouncing drop of water-37	0		Effect: "Slightly Larger Than Usual", Effect Duration: 19, Last Available: "2012-07"
-5709	squat nasty fireman's helmet of the sweet-tooth	0		Stench Damage: +5, Candy Drop: +100, Last Available: "2012-07", Familiar Effect: "cold atk"
+5708	quantum huge bouncing wobbly drop of water-37	0		Effect: "Slightly Larger Than Usual", Effect Duration: 19, Last Available: "2012-07"
+5709	squat nasty fireman's helmet of the sweet-tooth	0		Stench Damage: +5, Candy Drop: +100, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	fuchsia Jack Frost's fire axe	0		Cold Spell Damage: +50, Last Available: "2012-07"
 5713	bouncing wool stanky experienced fire extinguisher	0		Experience: +2, Stench Spell Damage: +25, Cold Resistance: +1, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,21 +5618,21 @@
 5717	normal FDKOL hotcakes	3	good	Last Available: "2012-07"
 5718	blinking hot egg	0		Last Available: "2012-07"
 5719	upside-down smoking grass	0		Last Available: "2012-07"
-5720	rotten super-sized fiery wing	5	crappy	Last Available: "2012-07"
+5720	super-sized rotten fiery wing	5	crappy	Last Available: "2012-07"
 5721	rosy-cheeked wings of fire of the boozehound	0		Maximum HP Percent: +30, Booze Drop: +100, Last Available: "2012-07"
 5722	huge dance instructor's FDKOL fire hose	0		Experience Percent (Moxie): +10, Last Available: "2012-07"
 5723	super-denatured bottle of fire	0		Effect: "The Halls of Moxiousness", Effect Duration: 69, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	pulsating hot daub	0		Last Available: "2012-07"
-5726	frightening hot daub bun of the wise owl	0		Mysticality: +20, Spooky Damage: +5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	manspreader's sharpshooter's hot daub stand	0		Critical Hit Percent: +10, Monster Level: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	frightening hot daub bun of the wise owl	0		Mysticality: +20, Spooky Damage: +5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	manspreader's sharpshooter's hot daub stand	0		Critical Hit Percent: +10, Monster Level: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	lime green wool foot-long hot daub of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1, Last Available: "2012-07"
 5729	purple mirror ballpark hot daub	0		Last Available: "2012-07"
 5730	stale angst burger	4	decent	
 5731	hand-crafted 5-hour acrimony	3	EPIC	
 5732	wobbly blank note	0		
 5733	eerily silent box	0		
-5734	diet bland forbidden sausage	1	decent	
+5734	bland diet forbidden sausage	1	decent	
 5735	blue Lord Flameface's cloak of the cougar	0		Moxie: +20, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	triple-quantum quadruple-aerosolized modified mirror Drizzlers&trade; Black Licorice	0		Effect: "Human-Human Hybrid", Effect Duration: 17
 5737	energized denatured quadruple-modified daub-breaker	0		Effect: "OMG WTF", Effect Duration: 36, Last Available: "2020-09"
@@ -5644,7 +5644,7 @@
 5743	mediocre high-proof bouncing CSA scoutmaster's &quot;water&quot;	7	decent	Last Available: "2012-07"
 5744	stale enchanted bag of GORF	4	decent	Effect: "Pork Power", Effect Duration: 50, Last Available: "2012-07"
 5745	bouncing CSA discount card	0		Last Available: "2020-09"
-5746	moldy miniature blinking bag of QWOP	2	crappy	Last Available: "2012-07"
+5746	miniature moldy blinking bag of QWOP	2	crappy	Last Available: "2012-07"
 5747	dry concentrated twirling CSA bravery badge	0		Effect: "Far Out", Effect Duration: 30, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	bad CSA cheerfulness ration	4	decent	Last Available: "2012-07"
@@ -5653,7 +5653,7 @@
 5752	bland crappy brain	3	decent	
 5753	toothsome decent brain	3	awesome	
 5754	diet spoiled good brain	1	crappy	
-5755	yummy super-sized blurry boss brain	5	awesome	
+5755	super-sized yummy blurry boss brain	5	awesome	
 5756	stale hunter brain	3	decent	
 5758	foul-smelling groovy Staff of Holiday Sensations of the dark arts	0		Moxie Percent: +10, Spell Damage Percent: +100, Stench Damage: +10, Last Available: "2011-11"
 5759	narrow upside-down foul-smelling supercool staff	0		Moxie Percent: +20, Stench Damage: +10
@@ -5665,23 +5665,23 @@
 5765	horrifying Da Vinci's fuzzy earmuffs	0		Experience (Mysticality): +5, Spooky Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5766	perfumed hale fuzzy montera of the wise owl	0		Mysticality: +20, Maximum HP: +20, Stench Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	narrow gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
-5773	twirling cyan Thwaitgold maggot statuette	0		
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	narrow gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5773	cyan twirling Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	scandalous boxer's Barney's rake	0		Muscle Percent: +10, Sleaze Damage: +5
-5778	rotten jumbo idiot brain	5	crappy	
+5778	jumbo rotten idiot brain	5	crappy	
 5779	keel-haulin' knife of the cheetah	0		Initiative: +60
 5780	frightening ice cream scoop	0		Spooky Damage: +5
 5781	hand-crafted weak squat soft echo eyedrop antidote martini	2	EPIC	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
-5785	upside-down blue thick caulk	0		
+5785	blue upside-down thick caulk	0		
 5786	hard screw	0		
 5787	messy butt joint	0		
 5788	upside-down smut orc keepsake box	0		
@@ -5697,9 +5697,9 @@
 5798	frozen Gnollish Crossdress	0		Effect: "Pop-eyed", Effect Duration: 63
 5799	polarized energized eldritch dough	0		Effect: "Deeply Ironic", Effect Duration: 64
 5800	concentrated quantum quadruple-altered jittery Charity's choker	0		Effect: "Eye of the Seal", Effect Duration: 20
-5801	diffused triple-concentrated tarnished lime green jittery Smart Bone Dust	0		Effect: "Fudge Headache", Effect Duration: 23
+5801	diffused triple-concentrated tarnished jittery lime green Smart Bone Dust	0		Effect: "Fudge Headache", Effect Duration: 23
 5802	concentrated alkaline spinning perpendicular guano	0		Effect: "Nuts about Candy", Effect Duration: 12
-5803	cold-filtered maroon twirling White Chocolate Golem Seeds	0		Effect: "Bats in the Belfry", Effect Duration: 50
+5803	cold-filtered twirling maroon White Chocolate Golem Seeds	0		Effect: "Bats in the Belfry", Effect Duration: 50
 5804	non-polymerized red Shivering Ch&egrave;vre	0		Effect: "Concentration", Effect Duration: 43
 5805	ionized improved mirror breath mint	0		Effect: "Winning Smile", Effect Duration: 35
 5806	denatured denatured muesli	0		Effect: "Bells in the Batfry", Effect Duration: 32
@@ -5727,12 +5727,12 @@
 5828	triple-wet aerosolized lime green skewed gilt perfume bottle	0		Effect: "Punchy, Murdery", Effect Duration: 21
 5829	polarized narrow janglin' bones	0		Effect: "La Bamba", Effect Duration: 62
 5830	energized diffused lime green pygmy papers	0		Effect: "From Nantucket", Effect Duration: 46
-5831	irradiated narrow purple pygmy dart	0		Effect: "Boletus Swoletus", Effect Duration: 21
+5831	irradiated purple narrow pygmy dart	0		Effect: "Boletus Swoletus", Effect Duration: 21
 5832	enhanced secret mummy herbs and spices	0		Effect: "Fizzier Than Light", Effect Duration: 13
 5833	quantum brigand brittle	0		Effect: "Fizzier Than Light", Effect Duration: 34
 5834	polymerized wobbly holistic headache remedy	0		Effect: "Piratastic", Effect Duration: 63
-5835	unsweetened triple-cold-filtered spinning ghostly olive scrunchie tourniquet	0		Effect: "Guts Feeling", Effect Duration: 61
-5836	vacuum-sealed galvanized bouncing skewed embezzler's oil	0		Effect: "Like a Fish to Walter", Effect Duration: 42
+5835	unsweetened triple-cold-filtered spinning olive ghostly scrunchie tourniquet	0		Effect: "Guts Feeling", Effect Duration: 61
+5836	vacuum-sealed galvanized skewed bouncing embezzler's oil	0		Effect: "Like a Fish to Walter", Effect Duration: 42
 5837	irradiated Fu Manchu Wax	0		Effect: "Flaming Weapon", Effect Duration: 62
 5838	chilled Iiti Kitty Gumdrop	0		Effect: "Pretending to Pretend", Effect Duration: 33
 5839	unsweetened pickled spinning yellow ravenous eye	0		Effect: "stats.enq", Effect Duration: 32
@@ -5758,7 +5758,7 @@
 5859	quadruple-polarized polymerized booby trap	0		Effect: "Human-Human Hybrid", Effect Duration: 14
 5860	Vulcanized alkaline blinking Agent Corrigan's cigarette	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 66
 5861	improved boiled good ash	0		Effect: "Stinky Weapon", Effect Duration: 52
-5862	spinning Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	spinning Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	chilled papier-mochi	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 62, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	Tesla medical-grade papier-m&acirc;ch&eacute;te	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-09"
 5869	cyan Tesla papier-m&acirc;chine gun of horror	0		Spooky Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-09"
 5870	executive papier-masque of the early riser	0		Meat Drop: +40, Adventures: +7, Single Equip, Last Available: "2012-09"
-5871	deadly papier-mitre of vim and vigor	0		Weapon Damage: +5, Maximum HP Percent: +50, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	papier-m&acirc;churidars of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	deadly papier-mitre of vim and vigor	0		Weapon Damage: +5, Maximum HP Percent: +50, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	papier-m&acirc;churidars of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5793,7 +5793,7 @@
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
-5897	vaporized skewed lime green Unconscious Collective Dream Jar	1	good	Effect: "Egg on your Face", Effect Duration: 10, Last Available: "2013-12"
+5897	vaporized lime green skewed Unconscious Collective Dream Jar	1	good	Effect: "Egg on your Face", Effect Duration: 10, Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	fuchsia huge jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	twirling jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
@@ -5822,8 +5822,8 @@
 5924	electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
-5927	wobbly spinning BittyCar HotCar	0		Last Available: "2012-12"
-5928	mansplainer's brainwave-controlled unicorn horn	0		Monster Level: +15, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5927	spinning wobbly BittyCar HotCar	0		Last Available: "2012-12"
+5928	mansplainer's brainwave-controlled unicorn horn	0		Monster Level: +15, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	jittery bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blurry blind-packed capsule toy	0		Last Available: "2012-12"
 5931	twirling wobbly zippy flame-wreathed chaotic plastic four-shadowed mime	0		Spell Critical Percent: +10, Hot Spell Damage: +10, Initiative: +20, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	wizardly plastic Father McGruber	0		Mysticality: +25, Last Available: "2012-12"
 5961	hardened plastic Hank North, Photojournalist	0		Damage Reduction: 3, Last Available: "2012-12"
 5962	smartaleck's plastic blazing bat	0		Moxie Percent: +30, Last Available: "2012-12"
-5963	crafty wholesome electronic dulcimer pants	0		Maximum HP Percent: +10, Maximum MP: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	crafty wholesome electronic dulcimer pants	0		Maximum HP Percent: +10, Maximum MP: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	spinning Van der Graaf deadly Frown Exerciser	0		Weapon Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5873,13 +5873,13 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	squat record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	ghostly Usain Bolt's scorching silent beret of temperance	0		Hot Damage: +25, Sleaze Resistance: +5, Initiative: +80, Familiar Effect: "1xVolley, cap 3"
-5978	big adequate slice of pizza	5	good	Last Available: "2013-02"
+5978	adequate big slice of pizza	5	good	Last Available: "2013-02"
 5979	shaking huge coin	0		Last Available: "2013-02"
 5980	wobbly cartoon heart	0		Last Available: "2013-02"
 5981	yellow star	0		Last Available: "2013-02"
 5982	hand-crafted tankard of ale	4	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	knitted lard-coated chilly cloth cap	0		Cold Damage: +5, Sleaze Spell Damage: +25, Cold Resistance: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	knitted lard-coated chilly cloth cap	0		Cold Damage: +5, Sleaze Spell Damage: +25, Cold Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	knitted studded quilted iron dagger	0		Damage Absorption: 120, Cold Resistance: +3, Last Available: "2013-02"
 5986	decent snack-sized purple hamburger	2	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,7 +5887,7 @@
 5989	potion	0		Last Available: "2013-02"
 5990	acceptable bottle of wine	3	good	Last Available: "2013-02"
 5991	wobbly round bomb	0		Last Available: "2013-02"
-5992	fuchsia deadly Socratic iron helmet of the storm	0		Experience (Mysticality): +1, Weapon Damage: +5, Maximum MP Percent: +40, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	fuchsia deadly Socratic iron helmet of the storm	0		Experience (Mysticality): +1, Weapon Damage: +5, Maximum MP Percent: +40, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	yellow fireproof hale steel sword of courage	0		Maximum HP: +20, Hot Resistance: +3, Spooky Resistance: +3, Last Available: "2013-02"
 5994	adequate whole roasted chicken	3	good	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	hand-crafted shining goblet	3	EPIC	Last Available: "2013-02"
 5999	jittery fireball	0		Last Available: "2013-02"
-6000	Annie Oakley's thinker's crown of extreme caution	0		Mysticality: +10, Critical Hit Percent: +20, Monster Level: -25, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	Annie Oakley's thinker's crown of extreme caution	0		Mysticality: +10, Critical Hit Percent: +20, Monster Level: -25, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	maroon wool nasty Sinatra's sword	0		Experience (Moxie): +5, Stench Damage: +5, Cold Resistance: +1, Last Available: "2013-02"
-6002	weightlifter's Helm of the Scream Emperor of the dark arts of Gandalf	0		Muscle: +15, Spell Damage Percent: +100, Spell Critical Percent: +20, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	weightlifter's Helm of the Scream Emperor of the dark arts of Gandalf	0		Muscle: +15, Spell Damage Percent: +100, Spell Critical Percent: +20, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	curative Cloak of Dire Shadows of the cougar of dire peril	0		Moxie: +20, Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-02"
 6004	fireproof coward's boxer's Sword of Dark Omens	0		Muscle Percent: +10, Monster Level: -20, Hot Resistance: +3, Last Available: "2013-02"
 6005	nippy careful therapeutic Shield of Icy Fate	0		Monster Level: -10, Cold Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 7, Last Available: "2013-02"
-6006	clever Samson's Greaves of the Murk Lord of the pedagogue	0		Experience: +3, Experience (Muscle): +5, Maximum MP: +20, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	clever Samson's Greaves of the Murk Lord of the pedagogue	0		Experience: +3, Experience (Muscle): +5, Maximum MP: +20, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	huge bouncing Jeselnik's foul-smelling ruddy Gauntlets of the Blood Moon	0		Maximum HP Percent: +40, Stench Damage: +10, Sleaze Damage: +25, Single Equip, Last Available: "2013-02"
 6008	clever dance instructor's slick Boots of Twilight Whispers	0		Moxie: +10, Experience Percent (Moxie): +10, Maximum MP: +20, Single Equip, Last Available: "2013-02"
 6009	manspreader's wicked groovy Belt of Howling Anger	0		Moxie Percent: +10, Spell Damage: +5, Monster Level: +10, Single Equip, Last Available: "2013-02"
@@ -5923,7 +5923,7 @@
 6025	boiled electrified narrow Polysniff Perfume	0		Effect: "Painted-On Bikini", Effect Duration: 25
 6026	Duskwalker syringe	0		
 6027	yellow Space Tours Tripple	0		
-6028	squat upside-down Battlie Light Saver	0		
+6028	upside-down squat Battlie Light Saver	0		
 6029	huge T.U.R.D.S. Key	0		
 6030	narrow fuchsia brainy dress pants	0		Mysticality: +5, Familiar Effect: "2xFairy, cap 28"
 6031	lime green shellacked badge of authority	0		Damage Reduction: 7, Single Equip
@@ -5931,9 +5931,9 @@
 6033	zippy nippy stolen necklace	0		Cold Damage: +10, Initiative: +20
 6034	auspicious baleful troll britches	0		Spell Damage: +25, Item Drop: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	triple-electrified vial of The Glistening	0		Effect: "Covetous Robbery", Effect Duration: 59
-6036	triple-distilled drinkable blue artisanal limoncello	8	good	
+6036	drinkable triple-distilled blue artisanal limoncello	8	good	
 6037	upside-down spinning ginger ale	0		
-6038	normal snack-sized enchanted incredible pizza	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
+6038	normal enchanted snack-sized incredible pizza	2	good	Effect: "Leisurely Amblin'", Effect Duration: 30
 6039	Newton's oil cap of temperance	0		Experience (Mysticality): +3, Sleaze Resistance: +5, Familiar Effect: "cap 28"
 6040	ribald wicked oil lamp	0		Spell Damage: +5, Sleaze Damage: +10
 6041	greasy oil slacks	0		Sleaze Spell Damage: +10, Familiar Effect: "1xPotato, cap 30"
@@ -5948,7 +5948,7 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	bland Taco Dan's Taco Stand Taco	3	decent	Last Available: "2012-12"
-6053	bad fortified Taco Dan's Taco Stand Chimichangarita	5	decent	Last Available: "2012-12"
+6053	fortified bad Taco Dan's Taco Stand Chimichangarita	5	decent	Last Available: "2012-12"
 6054	dry colloidal diffused spinning Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Briny Blood", Effect Duration: 59, Last Available: "2012-12"
 6055	olive tumbling psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
@@ -5966,13 +5966,13 @@
 6068	fuchsia loose blade	0		
 6069	blinking goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	shaking confusing LED clock	0		Last Available: "2012-12"
 6073	flattened magnetized narrow haggis-infused soap	0		Effect: "Human-Fish Hybrid", Effect Duration: 49, Last Available: "2012-12"
 6074	flattened pickled blurry magicberry tablets	0		Effect: "Orc Chops", Effect Duration: 11, Last Available: "2012-12"
 6075	quantum 37x37x37 puzzle cube	0		Effect: "Superheroic", Effect Duration: 47, Last Available: "2012-12"
-6076	delicious extra-dry special McLeod's Hard Haggis-Ade	5	awesome	Effect: "Hammertime", Effect Duration: 40, Last Available: "2012-12"
-6077	moldy jumbo haggis-wrapped haggis-stuffed haggis	5	crappy	Last Available: "2012-12"
+6076	extra-dry special delicious McLeod's Hard Haggis-Ade	5	awesome	Effect: "Hammertime", Effect Duration: 40, Last Available: "2012-12"
+6077	jumbo moldy haggis-wrapped haggis-stuffed haggis	5	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	blue haggis socks of the detective	0		Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
@@ -5993,7 +5993,7 @@
 6095	occult Microplushie: Fauxnerditide	0		Spell Damage Percent: +25, Last Available: "2012-12"
 6096	upside-down Microplushie: Hipsterine of chilblains	0		Cold Damage: +25, Last Available: "2012-12"
 6097	classy monkey	0		Last Available: "2012-12"
-6098	upside-down shaking gourd potion	0		Last Available: "2013-12"
+6098	shaking upside-down gourd potion	0		Last Available: "2013-12"
 6099	fuchsia Thinknerd T-Shirt of bravery	0		Spooky Resistance: +5, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
 6101	homemade robot	0		Last Available: "2012-12"
@@ -6037,10 +6037,10 @@
 6139	Jeselnik's rubber gloves	0		Sleaze Damage: +25, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	tasty snack-sized roasted duck	2	awesome	Last Available: "2013-12"
+6142	snack-sized tasty roasted duck	2	awesome	Last Available: "2013-12"
 6143	immense bland blue dead meat bun	10	decent	Last Available: "2013-12"
 6144	fuchsia dance instructor's cat collar	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2013-12"
-6145	jittery brainy suspicious-looking fedora of the sweet-tooth	0		Mysticality: +5, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	jittery brainy suspicious-looking fedora of the sweet-tooth	0		Mysticality: +5, Candy Drop: +100, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	bouncing Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	green narrow Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	blinking MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,14 +6058,14 @@
 6161	regret hose of chilblains	0		Cold Damage: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	ruddy commodore's hat of the ox	0		Muscle: +20, Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	naval trousers of the scaredy-cat	0		Monster Level: -15, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	ruddy commodore's hat of the ox	0		Muscle: +20, Maximum HP Percent: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	naval trousers of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	rock-hard wizardly deck cannon	0		Mysticality: +25, Damage Reduction: 5, Last Available: "2013-12"
 6167	ruddy ornamental sextant	0		Maximum HP Percent: +40, Last Available: "2013-12"
 6168	wobbly wicked Bloodbath of the pedagogue	0		Experience: +3, Spell Damage: +5, Last Available: "2013-12"
-6169	perfectly mixed fancy squat Hundred Headed IPA	4	EPIC	Effect: "Memory of Smarts", Effect Duration: 30, Last Available: "2013-12"
-6170	special stale chum	3	decent	Effect: "Black Lung", Effect Duration: 40, Last Available: "2013-12"
-6171	concentrated tumbling teal crude crudit&eacute;s	0		Effect: "Hyphemariffic", Effect Duration: 12
+6169	fancy perfectly mixed squat Hundred Headed IPA	4	EPIC	Effect: "Memory of Smarts", Effect Duration: 30, Last Available: "2013-12"
+6170	stale special chum	3	decent	Effect: "Black Lung", Effect Duration: 40, Last Available: "2013-12"
+6171	concentrated teal tumbling crude crudit&eacute;s	0		Effect: "Hyphemariffic", Effect Duration: 12
 6172	activated colloidal candy crayons	0		Effect: "Arcane in the Brain", Effect Duration: 35, Last Available: "2020-09"
 6173	ruddy Samson's pixel grappling hook	0		Experience (Muscle): +5, Maximum HP Percent: +40
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
@@ -6079,21 +6079,21 @@
 6182	squat cosmic cream	0		
 6183	cosmic fruit	0		
 6184	asbestos-lined Jim Carey's Tesla Jarlsberg's hat	0		Monster Level: +25, Hot Resistance: +5, MP Regen Min: 7, MP Regen Max: 10
-6185	super-sized adequate special consummate hard-boiled egg	5	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 20
-6186	half-sized spoiled consummate fried egg	2	crappy	
+6185	special adequate super-sized consummate hard-boiled egg	5	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 20
+6186	spoiled half-sized consummate fried egg	2	crappy	
 6187	bland blinking consummate egg salad	3	decent	
 6188	flavorless consummate bagel	4	decent	
 6189	flavorless consummate sliced bread	4	decent	
-6190	decent snack-sized gray consummate hot dog bun	2	good	
+6190	snack-sized decent gray consummate hot dog bun	2	good	
 6191	bland snack-sized consummate brownie	2	decent	
-6192	low-calorie toothsome consummate toast	1	awesome	
+6192	toothsome low-calorie consummate toast	1	awesome	
 6193	mediocre fancy passable stout	3	decent	Effect: "Kissed By Fire", Effect Duration: 10
 6194	toothsome consummate soup	4	awesome	
 6195	moldy consummate corn chips	3	crappy	
 6196	low-calorie adequate consummate salad	1	good	
 6197	moldy consummate salsa	4	crappy	
 6198	flavorless consummate sauerkraut	4	decent	
-6199	normal half-sized narrow consummate cheese slice	2	good	
+6199	half-sized normal narrow consummate cheese slice	2	good	
 6200	toothsome consummate melted cheese	4	awesome	
 6201	half-sized normal wobbly consummate bacon	2	good	
 6202	rotten massive consummate meatloaf	10	crappy	
@@ -6104,20 +6104,20 @@
 6207	gigantic rotten consummate baked potato	6	crappy	
 6208	mediocre skewed acceptable vodka	4	decent	
 6209	big decent lime green consummate ice cream	5	good	
-6210	miniature flavorless jittery consummate whipped cream	2	decent	
-6211	rotten diet consummate cream	1	crappy	
+6210	flavorless miniature jittery consummate whipped cream	2	decent	
+6211	diet rotten consummate cream	1	crappy	
 6212	tiny stale consummate strawberries	1	decent	
 6213	spoiled consummate sorbet	4	crappy	
 6214	hand-crafted squat jittery adequate rum	3	EPIC	
 6215	delicious mediocre lager	4	awesome	
 6216	small bland immaculate grilled cheese	2	decent	
 6217	moldy immaculate ice cream sandwich	4	crappy	
-6218	bland half-sized immaculate hot dog	2	decent	
-6219	flavorless immense twirling olive squat immaculate egg salad sandwich	7	decent	
+6218	half-sized bland immaculate hot dog	2	decent	
+6219	immense flavorless squat olive twirling immaculate egg salad sandwich	7	decent	
 6220	toothsome red perfect sandwich	4	awesome	
 6221	decent perfect chef salad	3	good	
 6222	moldy perfect breakfast	4	crappy	
-6223	rotten gigantic cyan sublime deluxe hot dog	9	crappy	
+6223	gigantic rotten cyan sublime deluxe hot dog	9	crappy	
 6224	moldy sublime stew	3	crappy	
 6225	moldy skewed sublime nachos	4	crappy	
 6226	bland Ultimate Breakfast Sandwich	4	decent	
@@ -6128,8 +6128,8 @@
 6231	bad Vodka Dog	4	decent	
 6232	acceptable Disappointed Russian	4	good	
 6233	acceptable Chunky Mary	4	good	
-6234	perfectly mixed practically non-alcoholic Nachojito	1	super ultra EPIC	
-6235	spirit-forward delicious Le Roi	5	awesome	
+6234	practically non-alcoholic perfectly mixed Nachojito	1	super ultra EPIC	
+6235	delicious spirit-forward Le Roi	5	awesome	
 6236	hand-crafted Over Easy Rider	4	EPIC	
 6237	cosmic six-pack	0		
 6239	polarized cube of ectoplasm	0		Effect: "Gamer Rage", Effect Duration: 14
@@ -6174,7 +6174,7 @@
 6278	Ye Olde Medieval Insult	0		
 6279	therapeutic pewter claymore	0		HP Regen Min: 5, HP Regen Max: 7
 6280	veiny artisanal rice peeler	0		Maximum HP: +10
-6281	low-calorie rotten heirloom grape tomato	1	crappy	
+6281	rotten low-calorie heirloom grape tomato	1	crappy	
 6282	chipotle wasabi cilantro aioli	0		
 6283	huge flame-retardant brown felt tophat	0		Hot Resistance: +1, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6231,12 +6231,12 @@
 6335	sea mantle of Gandalf of the early riser	0		Spell Critical Percent: +20, Adventures: +7
 6336	upside-down personal trainer's sea shawl of extreme caution	0		Experience Percent (Muscle): +10, Monster Level: -25, Spell Damage Percent: +150
 6337	lightning-fast coward's sea cape	0		Monster Level: -20, Initiative: 90, Critical Hit Percent: +15
-6338	blurry huge saltwaterbed	0		
+6338	huge blurry saltwaterbed	0		
 6339	nasty electrified muddy pirate hat	0		Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xFairy, cap 31"
 6340	fireproof Jack Frost's floral-print skirt	0		Cold Spell Damage: +50, Hot Resistance: +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	frightening forbidden spectral axe	0		Spell Damage Percent: +50, Spooky Damage: +5
 6342	super-strong air freshener of James Dean of doom	0		Experience (Moxie): +3, Spooky Spell Damage: +50
-6343	magnetized improved huge twirling Mer-kin lipstick	0		Effect: "Innately Wise", Effect Duration: 68
+6343	magnetized improved twirling huge Mer-kin lipstick	0		Effect: "Innately Wise", Effect Duration: 68
 6344	mirror Mer-kin mouthsoap	0		
 6345	liquefied flattened gray Mer-kin strongjuice	0		Effect: "It Didn't Kill You", Effect Duration: 15
 6346	spinning Mer-kin fitbrine	0		
@@ -6246,19 +6246,19 @@
 6350	twirling nippy Mer-kin gutgirdle	0		Cold Damage: +10, Experience (Moxie): +20, Single Equip
 6351	sharpshooter's Mer-kin finpaddle	0		Critical Hit Percent: +10
 6352	upside-down Mer-kin stopwatch of the bloodbag	0		Maximum HP: +100, Initiative: +50
-6353	huge blinking Mer-kin dreadscroll	0		
+6353	blinking huge Mer-kin dreadscroll	0		
 6354	denatured upside-down Mer-kin smartjuice	0		Effect: "Beta Carotene Overdose", Effect Duration: 55
 6355	irradiated wet Mer-kin cooljuice	0		Effect: "Neuroplastici Tea", Effect Duration: 42
 6356	Mer-kin worktea	0		
 6357	blinking Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	Jim Carey's Mer-kin begsign	0		Monster Level: +25, Meat Drop: +40
-6360	fuchsia Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	fuchsia Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	energized warmed pulled taffy	0		Effect: "Your Favorite Flavor", Effect Duration: 14, Last Available: "2013-04"
 6362	altered pulled indigo taffy	0		Effect: "Analog Drunk", Effect Duration: 28, Last Available: "2013-04"
 6363	magnetized quadruple-unsweetened upside-down pulled taffy	0		Effect: "Butt-Rock Hair", Effect Duration: 46, Last Available: "2013-04"
 6364	warmed aerosolized pulled taffy	0		Effect: "Flagrantly Fragrant", Effect Duration: 43, Last Available: "2013-04"
-6365	corrupted Vulcanized deionized tumbling maroon pulled taffy	0		Effect: "Fizzier Than Light", Effect Duration: 65, Last Available: "2013-04"
+6365	corrupted Vulcanized deionized maroon tumbling pulled taffy	0		Effect: "Fizzier Than Light", Effect Duration: 65, Last Available: "2013-04"
 6366	unsweetened improved pulled violet taffy	0		Effect: "Fancy Feasted", Effect Duration: 38, Last Available: "2013-04"
 6367	pressed pulsating pulled taffy	0		Effect: "Turtle Titters", Effect Duration: 60, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
@@ -6278,8 +6278,8 @@
 6383	root beer	1	crappy	
 6384	tumbling jigsaw blade	0		
 6385	wood screw	0		
-6386	olive mirror balsa plank	0		
-6387	pulsating tumbling jittery blob of wood glue	0		
+6386	mirror olive balsa plank	0		
+6387	jittery pulsating tumbling blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	energized Mer-kin rocksalt	0		Effect: "Smugness", Effect Duration: 30
 6390	liquefied jittery Mer-kin saltmint	0		Effect: "Radiated and Grodiated", Effect Duration: 40
@@ -6296,7 +6296,7 @@
 6401	colloidal aerosolized pickled ghostly tear	0		Effect: "Bells in the Batfry", Effect Duration: 20
 6402	magnetized pressed jagged tooth	0		Effect: "Fudge Headache", Effect Duration: 32
 6403	quadruple-ionized grisly shell fragment	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 53
-6404	nitrogenated quantum pulsating squat violent pastilles	0		Effect: "Cinnamouth", Effect Duration: 59
+6404	nitrogenated quantum squat pulsating violent pastilles	0		Effect: "Cinnamouth", Effect Duration: 59
 6405	non-liquefied concentrated maroon worst candy	0		Effect: "Christmessy", Effect Duration: 37
 6406	alkaline diffused huge fudge-shaped hole in space-time	0		Effect: "Piratastic", Effect Duration: 26
 6407	forbidden Samson's Pocket Square of Loathing of the sewer	0		Experience (Muscle): +5, Spell Damage Percent: +50, Stench Damage: +25, Single Equip
@@ -6314,7 +6314,7 @@
 6419	extra-galvanized dry moth dust	0		Effect: "Heal Thy Nanoself", Effect Duration: 51
 6420	galvanized enhanced yellow glob of spoiled mayo	0		Effect: "Waxing", Effect Duration: 54
 6421	upside-down tonic djinn	0		
-6422	adequate half-sized vampire chowder	2	good	
+6422	half-sized adequate vampire chowder	2	good	
 6423	huge Tales of Dread	0		Free Pull
 6424	purple Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6360,7 +6360,7 @@
 6465	miser's extremely unsafe Mayor Ghost's gavel of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +100, Meat Drop: +10, Conditional Skill (Equipped): "Hammer Ghost"
 6466	Usain Bolt's manspreader's Mayor Ghost's sash of terror	0		Monster Level: +10, Spooky Spell Damage: +10, Initiative: +80, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	delicious half-sized ghost pepper	2	awesome	
+6468	half-sized delicious ghost pepper	2	awesome	
 6469	perfumed slick Thunkula's drinking cap of doom	0		Moxie: +10, Spooky Spell Damage: +50, Stench Resistance: +5, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	blurry wool thinker's Drunkula's cape of the empath	0		Mysticality: +10, Familiar Weight: +5, Cold Resistance: +1, Class: "Sauceror"
 6471	gray Annie Oakley's resourceful hardened Drunkula's silky pants	0		Damage Reduction: 3, Maximum MP: +50, Critical Hit Percent: +20, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6408,7 +6408,7 @@
 6513	red wobbly fortified warm fur	0		Damage Absorption: +60
 6514	veiny snowstick	0		Maximum HP: +10
 6515	upside-down Rosewater's eerie fetish	0		Mysticality Percent: +30, Single Equip
-6516	perfectly mixed extra-dry stinkwater	5	EPIC	
+6516	extra-dry perfectly mixed stinkwater	5	EPIC	
 6517	tumbling dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	adequate upside-down accidental mutton	4	good	
 6519	mirror occult strapping drafty drawers	0		Muscle: +5, Spell Damage Percent: +25, Familiar Effect: "1.5xVolley"
@@ -6457,7 +6457,7 @@
 6563	Temple Grandin's hand of Mr. Cards	0		Familiar Weight: +7, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	huge normal Dreadsylvanian hot pocket	8	good	
 6565	decent Dreadsylvanian pocket	3	good	
-6566	special half-sized stale Dreadsylvanian pocket	2	decent	Effect: "Witch's Brood", Effect Duration: 25
+6566	stale half-sized special Dreadsylvanian pocket	2	decent	Effect: "Witch's Brood", Effect Duration: 25
 6567	moldy bite-sized blurry Dreadsylvanian stink pocket	1	crappy	
 6568	rotten Dreadsylvanian sleaze pocket	3	crappy	
 6569	bad weak fancy huge shaking Dreadsylvanian hot toddy	2	decent	Effect: "Hairless and Airless", Effect Duration: 35
@@ -6474,7 +6474,7 @@
 6580	length of fuse	0		
 6581	dreadful box	0		
 6582	jittery Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	blinking pulsating vicious spiked collar	0		Familiar Damage: +20
+6583	pulsating blinking vicious spiked collar	0		Familiar Damage: +20
 6584	olive double-paned hot dog wrapper	0		Cold Resistance: +5
 6585	lion tamer's debonair deboner of vim and vigor	0		Maximum HP Percent: +50, Experience (familiar): +2
 6586	flattened frozen chicle de salchicha	0		Effect: "Certainty", Effect Duration: 65
@@ -6497,7 +6497,7 @@
 6603	clockwork numeral III	0		
 6604	clockwork numeral IV	0		
 6605	clockwork numeral V	0		
-6606	blurry spinning clockwork numeral VI	0		
+6606	spinning blurry clockwork numeral VI	0		
 6607	gray clockwork numeral VII	0		
 6608	cyan clockwork numeral VIII	0		
 6609	squat clockwork numeral IX	0		
@@ -6506,12 +6506,12 @@
 6612	clockwork numeral XII	0		
 6613	maroon clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	triple-distilled hand-crafted Cold One	10	???	
+6615	hand-crafted triple-distilled Cold One	10	???	
 6616	adequate massive spaghetti breakfast	7	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
-6620	twirling lime green folder (green)	0		Moxie: +20, Last Available: "2013-08"
+6620	lime green twirling folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	pulsating folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	wobbly folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
@@ -6530,11 +6530,11 @@
 6636	olive twirling folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
-6639	jittery ghostly folder (owl)	0		Last Available: "2013-08"
+6639	ghostly jittery folder (owl)	0		Last Available: "2013-08"
 6640	folder (Stinky Trash Kid)	0		Last Available: "2013-08"
-6641	pulsating maroon folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
+6641	maroon pulsating folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
 6642	folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
-6643	ghostly shaking folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
+6643	shaking ghostly folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
 6644	folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
 6648	Van der Graaf slide rule of the pedagogue	0		Experience: +3, MP Regen Min: 5, MP Regen Max: 7
@@ -6559,7 +6559,7 @@
 6667	pulsating quasireligious sculpture	0		
 6668	tumbling yellow Faraday cage	0		
 6669	modeling claymore	0		
-6670	wobbly blinking olive clay homunculus	0		
+6670	olive blinking wobbly clay homunculus	0		
 6671	adjusted spinning sodium pentasomething	0		Effect: "Oth-Jeal-O", Effect Duration: 40
 6672	grains of salt	0		
 6673	yellowcake bomb	0		
@@ -6570,7 +6570,7 @@
 6678	blinking dangerous Yearbook Club Camera	0		Weapon Damage: +10, Conditional Skill (Equipped): "Blinding Flash"
 6679	tumbling sizzling machete	0		Hot Damage: +10
 6680	tolerable shaking Cursed Punch	4	good	
-6681	acceptable yellow spinning Bowl of Scorpions	4	good	
+6681	acceptable spinning yellow Bowl of Scorpions	4	good	
 6682	acceptable purple Fog Murderer	4	good	
 6683	book of matches	0		
 6684	surgical mask of Gandalf	0		Spell Critical Percent: +20, Surgeonosity: +1
@@ -6613,7 +6613,7 @@
 6721	jittery Usain Bolt's forbidden Da Vinci's water bottle	0		Experience (Mysticality): +5, Spell Damage Percent: +50, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	galvanized galvanized twirling pygmy phone number	0		Effect: "Block-Rockin' Beet", Effect Duration: 55
 6723	Boozehounds Anonymous token	0		
-6724	spoiled fancy exotic jungle fruit	3	crappy	Effect: "meat.enh", Effect Duration: 50
+6724	fancy spoiled exotic jungle fruit	3	crappy	Effect: "meat.enh", Effect Duration: 50
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	fuchsia huge dude ranch souvenir crate	0		
 6727	spinning tropical island souvenir crate	0		
@@ -6627,7 +6627,7 @@
 6735	junk junk	0		
 6736	Junk-Bond	0		
 6737	tangle of copper wire	0		
-6738	wobbly fuchsia jagged scrap	0		
+6738	fuchsia wobbly jagged scrap	0		
 6739	boiled pressed galvanized bent scrap	0		Effect: "Think Win-Lose", Effect Duration: 63
 6740	squat molten scrap	0		
 6741	narrow eternal car battery	0		
@@ -6652,13 +6652,13 @@
 6760	bad bottle of Old Pugilist	4	decent	Last Available: "2013-09"
 6761	mediocre tumbling bottle of Professor Beer	4	decent	Last Available: "2013-09"
 6762	practically non-alcoholic bad bottle of Rapier Witbier	1	decent	Last Available: "2013-09"
-6763	watered-down bad spinning pulsating mirror bottle of Race Car Red	2	decent	Last Available: "2013-09"
-6764	special acceptable bottle of Greedy Dog	4	good	Effect: "Well-Oiled", Effect Duration: 5, Last Available: "2013-09"
+6763	watered-down bad spinning mirror pulsating bottle of Race Car Red	2	decent	Last Available: "2013-09"
+6764	acceptable special bottle of Greedy Dog	4	good	Effect: "Well-Oiled", Effect Duration: 5, Last Available: "2013-09"
 6765	drinkable bottle of Lambada Lambic	3	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	crappy	Last Available: "2013-09"
-6769	tumbling sharpshooter's therapeutic Newton's tin tam	0		Experience (Mysticality): +3, Critical Hit Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	tumbling sharpshooter's therapeutic Newton's tin tam	0		Experience (Mysticality): +3, Critical Hit Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	moist super-anodized mirror tin cup	0		Effect: "Trufflin'", Effect Duration: 16, Last Available: "2013-09"
 6771	wobbly upside-down double-paned Jack Frost's tin foil of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Cold Resistance: +5, Last Available: "2013-09"
 6772	executive smelly fortified tin drum	0		Damage Absorption: +60, Stench Spell Damage: +10, Meat Drop: +40, Last Available: "2013-09"
@@ -6685,7 +6685,7 @@
 6796	altered electrified diffused bouncing disco horoscope (Pisces)	0		Effect: "Rushin' Hands", Effect Duration: 32
 6797	ionized bouncing disco horoscope (Aries)	0		Effect: "Haunted Stomach", Effect Duration: 41
 6798	anodized disco horoscope (Taurus)	0		Effect: "Bloodstain-Resistant", Effect Duration: 13
-6799	quantum unsweetened blurry bouncing disco horoscope (Gemini)	0		Effect: "Expert Vacationer", Effect Duration: 42
+6799	quantum unsweetened bouncing blurry disco horoscope (Gemini)	0		Effect: "Expert Vacationer", Effect Duration: 42
 6800	corrupted non-denatured disco horoscope (Cancer)	0		Effect: "Wet Rub", Effect Duration: 24
 6801	extra-aerosolized deionized disco horoscope (Leo)	0		Effect: "Eyes All Black", Effect Duration: 62
 6802	dry disco horoscope (Virgo)	0		Effect: "Your Favorite Flavor", Effect Duration: 24
@@ -6721,11 +6721,11 @@
 6832	Way More Tears&trade; pepper spray	0		
 6833	polarized Milk Studs	0		Effect: "Takin' It Greasy", Effect Duration: 22
 6834	pressed wobbly box of Dweebs	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 19
-6835	quadruple-deionized denatured ghostly mirror bag of W&Ws	0		Effect: "Bootyliciousness", Effect Duration: 25
+6835	quadruple-deionized denatured mirror ghostly bag of W&Ws	0		Effect: "Bootyliciousness", Effect Duration: 25
 6836	irradiated wobbly PEEZ dispenser	0		Effect: "Greasy Flavor", Effect Duration: 51
 6837	adjusted double-corrupted tumbling Swizzler	0		Effect: "Smelly Pants", Effect Duration: 14
 6838	deionized quadruple-pickled Bugbearclaw Donut	0		Effect: "Helping Comes Second", Effect Duration: 30
-6839	concentrated frozen blinking olive jam	0		Effect: "Bread-Lined", Effect Duration: 59
+6839	concentrated frozen olive blinking jam	0		Effect: "Bread-Lined", Effect Duration: 59
 6840	enhanced upside-down Whenchamacallit bar	0		Effect: "Unrunnable Face", Effect Duration: 23
 6841	chilled pulsating lime green 8-bit banana	0		Effect: "Devil Inside", Effect Duration: 53
 6842	energized irradiated vial of blood simple syrup	0		Effect: "Scorpio Rising", Effect Duration: 21
@@ -6746,26 +6746,26 @@
 6857	Cajun accordion of the sweet-tooth	0		Candy Drop: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	skewed fortified quirky accordion	0		Damage Absorption: +60, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	chaotic Skipper's accordion of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	spinning dog trainer's chaotic sharpshooter's Pantsgiving of the pedagogue	0		Experience: +3, Critical Hit Percent: +10, Spell Critical Percent: +10, Experience (familiar): +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
-6861	low-calorie moldy maroon blurry can of sardines	1	crappy	Last Available: "2013-11"
+6860	spinning dog trainer's chaotic sharpshooter's Pantsgiving of the pedagogue	0		Experience: +3, Critical Hit Percent: +10, Spell Critical Percent: +10, Experience (familiar): +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6861	moldy low-calorie maroon blurry can of sardines	1	crappy	Last Available: "2013-11"
 6862	delicious miniature tumbling high-calorie sugar substitute	2	awesome	Last Available: "2013-11"
 6863	rotten jittery pat of butter	3	crappy	Last Available: "2013-11"
 6864	rotten dinner roll	4	crappy	Last Available: "2013-11"
 6865	decent fuchsia mashed potatoes	3	good	Last Available: "2013-11"
 6866	small normal whole turkey leg	2	good	Last Available: "2013-11"
-6867	normal snack-sized deviled egg	2	good	Last Available: "2013-11"
+6867	snack-sized normal deviled egg	2	good	Last Available: "2013-11"
 6868	deionized finger exerciser	0		Effect: "Antibiotic Saucesphere", Effect Duration: 34, Last Available: "2013-11"
 6869	modified unsweetened dented spoon	0		Effect: "Wax On Your Shoes", Effect Duration: 19, Last Available: "2013-11"
 6870	deionized love note	0		Effect: "Cold Hard Skin", Effect Duration: 41, Last Available: "2013-11"
-6871	bouncing skewed school beer pull tab	0		Last Available: "2013-11"
+6871	skewed bouncing school beer pull tab	0		Last Available: "2013-11"
 6872	chilled double-modified nail file	0		Effect: "Super-Mega-Charged", Effect Duration: 56, Last Available: "2013-11"
 6873	pressed tarnished candy wrapper	0		Effect: "Tingly Elbows", Effect Duration: 14, Last Available: "2013-11"
-6874	mirror shaking gym membership card	0		Last Available: "2013-11"
+6874	shaking mirror gym membership card	0		Last Available: "2013-11"
 6875	Vulcanized polarized post-holiday sale coupon	0		Effect: "init.enh", Effect Duration: 17, Last Available: "2013-11"
 6876	twirling dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
-6879	olive narrow pocket lint (white)	0		Last Available: "2013-11"
+6879	narrow olive pocket lint (white)	0		Last Available: "2013-11"
 6880	bouncing pocket lint (orange)	0		Last Available: "2013-11"
 6881	mirror horrifying lion tamer's curative Socratic bowl of petunias	0		Experience (Mysticality): +1, Experience (familiar): +2, Spooky Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-11"
 6882	friendly deadly groovy power sock of temperance	0		Moxie Percent: +10, Weapon Damage: +5, Familiar Weight: +3, Sleaze Resistance: +5, Single Equip, Last Available: "2013-11"
@@ -6776,16 +6776,16 @@
 6887	spirit sheet	0		
 6888	spirit mattress	0		
 6889	bouncing spirit blanket	0		
-6890	green bouncing blinking spirit bed	0		
+6890	blinking green bouncing spirit bed	0		
 6891	pulsating rosewater-soaked Herculean stylish spirit bell	0		Moxie: +25, Experience (Muscle): +1, Stench Resistance: +3, Class: "Turtle Tamer"
-6892	activated adjusted activated mirror twirling spoonful of Linguine-Os	0		Effect: "Make Meat FA$T!", Effect Duration: 65, Last Available: "2013-11"
+6892	activated adjusted activated twirling mirror spoonful of Linguine-Os	0		Effect: "Make Meat FA$T!", Effect Duration: 65, Last Available: "2013-11"
 6893	Vulcanized activated freezer-burned frost-bitten tortellini	0		Effect: "Weasels Underfoot", Effect Duration: 66, Last Available: "2013-11"
 6894	quadruple-quantum wet blob of Alphredo&trade;	0		Effect: "Spooky Demeanor", Effect Duration: 17, Last Available: "2013-11"
-6895	electrified bouncing red handful of crafty noodles	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 48, Last Available: "2013-11"
+6895	electrified red bouncing handful of crafty noodles	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 48, Last Available: "2013-11"
 6896	pickled wet teal tangled mass of pasta	0		Effect: "Feeling No Pain", Effect Duration: 30, Last Available: "2013-11"
 6897	non-warmed Can of Spaghetto	0		Effect: "Crocodile Tear", Effect Duration: 67, Last Available: "2013-11"
 6898	squat Chef Boy, R&D's business card	0		Last Available: "2013-11"
-6899	huge spinning Thwaitgold ant statuette	0		
+6899	spinning huge Thwaitgold ant statuette	0		
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	shaking hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	scorching wizardly flask flops	0		Mysticality: +25, Hot Damage: +25, Single Equip
@@ -6793,7 +6793,7 @@
 6904	improved bolts	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 59, Last Available: "2013-12"
 6905	tasty purple gingerbread robot	4	awesome	Last Available: "2013-12"
 6906	delicious petit 4.1	3	awesome	Last Available: "2013-12"
-6907	huge moldy tumbling nut-shaped Crimbo cookie	9	crappy	Last Available: "2023-06"
+6907	moldy huge tumbling nut-shaped Crimbo cookie	9	crappy	Last Available: "2023-06"
 6908	reassuring plastic GORM-8	0		Spooky Resistance: +1, Last Available: "2013-12"
 6909	Van der Graaf plastic warbear	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
 6910	upside-down bouncing cool plastic Toybot	0		Moxie: +5, Last Available: "2013-12"
@@ -6808,31 +6808,31 @@
 6919	double-flattened chilled denatured gray warbear bearserker potion	0		Effect: "Buggy Flavor", Effect Duration: 46, Last Available: "2013-12"
 6920	modified adjusted mirror warbear liquid overcoat	0		Effect: "Tiki Toughness", Effect Duration: 55, Last Available: "2013-12"
 6921	adequate wobbly warbear feasting bread	4	good	Last Available: "2013-12"
-6922	normal big lime green warbear warrior bread	5	good	Last Available: "2013-12"
+6922	big normal lime green warbear warrior bread	5	good	Last Available: "2013-12"
 6923	adequate cyan mirror warbear thermoregulator bread	3	good	Last Available: "2013-12"
 6924	mediocre warbear feasting mead	3	decent	Last Available: "2013-12"
 6925	delicious warbear bearserker mead	3	awesome	Last Available: "2013-12"
 6926	bad blinking warbear blizzard mead	4	decent	Last Available: "2013-12"
 6927	green warbear helm fragment	0		Last Available: "2013-12"
-6928	avaricious grievous warbear plain fedora of temperance	0		Weapon Damage Percent: +50, Sleaze Resistance: +5, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	clever warbear feathered fedora	0		Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	chilly stiffened experienced warbear fedora	0		Experience: +2, Damage Reduction: 1, Cold Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	foul-smelling quilted warbear plain helm of the empath	0		Damage Absorption: +40, Familiar Weight: +5, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	wobbly dog trainer's warbear spiked helm	0		Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	double-paned quilted Fonzie's warbear electro-spiked helm	0		Experience (Moxie): +1, Damage Absorption: +40, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	pulsating ghostly smelly veiny stylish warbear plain ushanka	0		Moxie: +25, Maximum HP: +10, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	sage warbear lined ushanka	0		Mysticality Percent: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	lightning-fast warbear heated ushanka of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Stench Spell Damage: +50, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	avaricious grievous warbear plain fedora of temperance	0		Weapon Damage Percent: +50, Sleaze Resistance: +5, Meat Drop: +30, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	clever warbear feathered fedora	0		Maximum MP: +20, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	chilly stiffened experienced warbear fedora	0		Experience: +2, Damage Reduction: 1, Cold Damage: +5, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	foul-smelling quilted warbear plain helm of the empath	0		Damage Absorption: +40, Familiar Weight: +5, Stench Damage: +10, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	wobbly dog trainer's warbear spiked helm	0		Experience (familiar): +1, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	double-paned quilted Fonzie's warbear electro-spiked helm	0		Experience (Moxie): +1, Damage Absorption: +40, Cold Resistance: +5, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	pulsating ghostly smelly veiny stylish warbear plain ushanka	0		Moxie: +25, Maximum HP: +10, Stench Spell Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	sage warbear lined ushanka	0		Mysticality Percent: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	lightning-fast warbear heated ushanka of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Stench Spell Damage: +50, Initiative: +40, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	frightening flame-wreathed warbear party pants of the sewer	0		Hot Spell Damage: +10, Stench Damage: +25, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	squat warbear ceremonial party pants of the dark arts	0		Spell Damage Percent: +100, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	ruddy razor-sharp savvy warbear high festival pants	0		Mysticality Percent: +20, Weapon Damage Percent: +25, Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	jittery veiny warbear battle greaves of incineration	0		Maximum HP: +10, Hot Spell Damage: +50, Item Drop: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	blurry stylish warbear officer greaves	0		Moxie: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	frightening supercharged Fonzie's warbear bearserker greaves	0		Experience (Moxie): +1, Maximum MP Percent: +30, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	fuchsia skewed banded Samson's warbear johns of the storm	0		Experience (Muscle): +5, Damage Absorption: +100, Maximum MP Percent: +40, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	electrified warbear fleece-lined johns	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	warbear johns of the cougar of chilblains of the sweet-tooth	0		Moxie: +20, Cold Damage: +25, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	frightening flame-wreathed warbear party pants of the sewer	0		Hot Spell Damage: +10, Stench Damage: +25, Spooky Damage: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	squat warbear ceremonial party pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	ruddy razor-sharp savvy warbear high festival pants	0		Mysticality Percent: +20, Weapon Damage Percent: +25, Maximum HP Percent: +40, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	jittery veiny warbear battle greaves of incineration	0		Maximum HP: +10, Hot Spell Damage: +50, Item Drop: +5, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	blurry stylish warbear officer greaves	0		Moxie: +25, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	frightening supercharged Fonzie's warbear bearserker greaves	0		Experience (Moxie): +1, Maximum MP Percent: +30, Spooky Damage: +5, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	fuchsia skewed banded Samson's warbear johns of the storm	0		Experience (Muscle): +5, Damage Absorption: +100, Maximum MP Percent: +40, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	electrified warbear fleece-lined johns	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	warbear johns of the cougar of chilblains of the sweet-tooth	0		Moxie: +20, Cold Damage: +25, Candy Drop: +100, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	sizzling warbear goggles of the bloodbag of doom	0		Maximum HP: +100, Hot Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2013-12"
 6949	forbidden warbear snowblindness goggles	0		Spell Damage Percent: +50, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	purple smelly mansplainer's warbear warscarf of Tarzan	0		Experience (Muscle): +3, Monster Level: +15, Stench Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	red lightning-fast warbear foil hat	0		Initiative: +40, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	red lightning-fast warbear foil hat	0		Initiative: +40, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	Sherlock's flame-retardant warbear oil pan	0		Hot Resistance: +1, Item Drop: +25, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	lime green dance instructor's Herculean die-cast Don Crimbo	0		Experience (Muscle): +1, Experience Percent (Moxie): +10, Last Available: "2013-12"
 7001	jittery mirror censurious die-cast Uncle Hobo of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3, Last Available: "2013-12"
 7002	miser's die-cast Father Crimbo of the cougar	0		Moxie: +20, Meat Drop: +10, Last Available: "2013-12"
-7003	mirror The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	mirror The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	activated Vulcanized Flaskfull of Hollow	0		Effect: "Deep-Seated Rage", Effect Duration: 56, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	dehydrated bouncing handful of Smithereens	1	EPIC	Effect: "Red Misty-Eyed", Effect Duration: 5, Last Available: "2013-12"
-7007	normal immense Every Day is Like This Sundae	8	good	Last Available: "2013-12"
+7007	immense normal Every Day is Like This Sundae	8	good	Last Available: "2013-12"
 7008	decent Miserable Pie	3	good	Last Available: "2013-12"
-7009	half-sized toothsome This Charming Flan	2	awesome	Last Available: "2013-12"
+7009	toothsome half-sized This Charming Flan	2	awesome	Last Available: "2013-12"
 7010	watered-down delicious narrow Irish Coffee, English Heart	2	awesome	Last Available: "2013-12"
-7011	practically non-alcoholic lousy Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
-7012	fancy tolerable Paint A Vulgar Pitcher	3	good	Effect: "Favored by Lyle", Effect Duration: 30, Last Available: "2013-12"
+7011	lousy practically non-alcoholic Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
+7012	tolerable fancy Paint A Vulgar Pitcher	3	good	Effect: "Favored by Lyle", Effect Duration: 30, Last Available: "2013-12"
 7013	huge twirling Golden Light	0		Last Available: "2013-12"
 7014	narrow Louder Than Bomb	0		Last Available: "2013-12"
 7015	jittery Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	asbestos-lined scorching vibrating educational Sheila Take a Crossbow	0		Experience: +1, Maximum MP Percent: +10, Hot Damage: +25, Hot Resistance: +5, Last Available: "2013-12"
 7019	shaking Usain Bolt's shellacked educational Rosewater's A Light that Never Goes Out	0		Mysticality Percent: +30, Experience: +1, Damage Reduction: 7, Initiative: +80, Last Available: "2013-12"
 7020	ghostly stanky smartaleck's Half a Purse of the brazier of the glutton	0		Moxie Percent: +30, Hot Spell Damage: +25, Stench Spell Damage: +25, Food Drop: +100, Last Available: "2013-12"
-7021	lightning-fast padded Da Vinci's Hairpiece On Fire of courage	0		Experience (Mysticality): +5, Damage Absorption: +20, Spooky Resistance: +3, Initiative: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	blue perfumed scandalous Vicar's Tutu of the bloodbag of the blizzard	0		Maximum HP: +100, Cold Spell Damage: +25, Sleaze Damage: +5, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	lightning-fast padded Da Vinci's Hairpiece On Fire of courage	0		Experience (Mysticality): +5, Damage Absorption: +20, Spooky Resistance: +3, Initiative: +40, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	blue perfumed scandalous Vicar's Tutu of the bloodbag of the blizzard	0		Maximum HP: +100, Cold Spell Damage: +25, Sleaze Damage: +5, Stench Resistance: +5, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	occult razor-sharp cool Hand in Glove	0		Moxie: +5, Weapon Damage Percent: +25, Spell Damage Percent: +25, Single Equip, Last Available: "2013-12"
 7024	coward's beefy Meat Tenderizer is Murder of Tarzan	0		Muscle: +10, Experience (Muscle): +3, Monster Level: -20, Class: "Seal Clubber", Last Available: "2013-12"
 7025	ribald Socratic Ouija Board, Ouija Board of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Sleaze Damage: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6923,7 +6923,7 @@
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	tumbling warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
-7037	tumbling upside-down warbear LP-ROM burner	0		Last Available: "2013-12"
+7037	upside-down tumbling warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	tumbling warbear gyrocopter	0		Last Available: "2013-12"
 7039	pickled warbear robo-camouflage unit	0		Effect: "Faboooo", Effect Duration: 45, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
@@ -6963,26 +6963,26 @@
 7074	activated blurry snow cleats	0		Effect: "Fancy Feasted", Effect Duration: 63, Last Available: "2014-01"
 7075	polarized liquid ice pack	0		Effect: "Cold as Ice", Effect Duration: 35, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	delicious gigantic snow crab	10	awesome	Last Available: "2014-01"
+7077	gigantic delicious snow crab	10	awesome	Last Available: "2014-01"
 7078	bad cyan Ice Island Long Tea	3	decent	Last Available: "2014-01"
 7079	mirror unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	snow mobile of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	snow mobile of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	skewed narrow savvy ice bucket	0		Mysticality Percent: +20, Lasts Until Rollover, Last Available: "2014-01"
 7085	red Jack Frost's wholesome snow shovel	0		Maximum HP Percent: +10, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2014-01"
 7086	yellow executive chilly wizardly bod-ice	0		Mysticality: +25, Cold Damage: +5, Meat Drop: +40, Lasts Until Rollover, Last Available: "2014-01"
 7087	perfumed Tesla thinker's snow belt of the glutton	0		Mysticality: +10, Stench Resistance: +5, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	sizzling clever extremely unsafe ice nine of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: +40, Maximum MP: +20, Hot Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7089	shaking snow fort	0		Last Available: "2014-01"
-7090	perfectly mixed weak En Una Fila Tequila	2	EPIC	
+7090	weak perfectly mixed En Una Fila Tequila	2	EPIC	
 7091	Skully's hot chocolate	1	EPIC	
-7092	fuchsia family-friendly studded warbear dress helmet	0		Damage Absorption: +80, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	fuchsia family-friendly studded warbear dress helmet	0		Damage Absorption: +80, Sleaze Resistance: +1, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	Annie Oakley's arcane researcher's warbear dress bracers	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Single Equip, Last Available: "2013-12"
-7094	brawny warbear dress greaves of the glutton	0		Muscle Percent: +20, Food Drop: +100, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	rosewater-soaked ribald sweatband	0		Sleaze Damage: +10, Stench Resistance: +3, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	scandalous Temple Grandin's gym shorts	0		Familiar Weight: +7, Sleaze Damage: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	brawny warbear dress greaves of the glutton	0		Muscle Percent: +20, Food Drop: +100, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	rosewater-soaked ribald sweatband	0		Sleaze Damage: +10, Stench Resistance: +3, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	scandalous Temple Grandin's gym shorts	0		Familiar Weight: +7, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	narrow dangerous Da Vinci's ankleweights	0		Experience (Mysticality): +5, Weapon Damage: +10, Single Equip, Last Available: "2014-12"
 7098	blinking MacGyver's occult educational slick sweat socks	0		Moxie: +10, Experience: +1, Spell Damage Percent: +25, Maximum MP: +100, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6994,7 +6994,7 @@
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	artisanal boozy snakebite	5	EPIC	Last Available: "2014-12"
 7107	jittery Jack Frost's Da Vinci's candy stick	0		Experience (Mysticality): +5, Cold Spell Damage: +50, Last Available: "2014-12"
-7108	stale massive pecan	8	decent	Last Available: "2014-12"
+7108	massive stale pecan	8	decent	Last Available: "2014-12"
 7109	rotten pecan pie	3	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	rotten candy mountain oyster	3	crappy	Last Available: "2014-12"
@@ -7003,13 +7003,13 @@
 7114	delicious candy carrot	4	awesome	Last Available: "2014-12"
 7115	miniature adequate red ghostly candy carrot cake	2	good	Last Available: "2014-12"
 7116	toasty carrot-on-a-stick of the wise owl	0		Mysticality: +20, Hot Damage: +5, Last Available: "2014-12"
-7117	extremely unsafe groovy weasel stomping pants	0		Moxie Percent: +10, Weapon Damage Percent: +100, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	flavorless immense shaking mulberry	6	decent	Last Available: "2014-12"
+7117	extremely unsafe groovy weasel stomping pants	0		Moxie Percent: +10, Weapon Damage Percent: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7118	immense flavorless shaking mulberry	6	decent	Last Available: "2014-12"
 7119	watered-down lousy skewed mulled berry wine	2	decent	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of Gandalf	0		Spell Critical Percent: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	lemon party hat of Gandalf	0		Spell Critical Percent: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	wholesome lemon shirt	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2014-12"
-7123	flame-retardant lemon drop trousers	0		Hot Resistance: +1, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	flame-retardant lemon drop trousers	0		Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	irradiated concentrated pickled green lemonhead caviar	0		Effect: "Blood-Gorged", Effect Duration: 20, Last Available: "2014-12"
 7125	veiny gummi sword of dire peril	0		Weapon Damage: +20, Maximum HP: +10, Last Available: "2014-12"
 7126	concentrated small gummi fin	0		Effect: "Spookyravin'", Effect Duration: 54, Last Available: "2014-12"
@@ -7019,9 +7019,9 @@
 7130	practically non-alcoholic drinkable magnum of champagne	1	good	Last Available: "2014-12"
 7131	squat experienced savvy stylish cow creamer	0		Moxie: +25, Mysticality Percent: +20, Experience: +2, Last Available: "2014-12"
 7132	moist liquefied Outer Wolf&trade; cologne	0		Effect: "Macho, Macho Dog", Effect Duration: 45, Last Available: "2014-12"
-7133	upside-down jittery lupine appetite hormones	0		Last Available: "2014-12"
+7133	jittery upside-down lupine appetite hormones	0		Last Available: "2014-12"
 7134	lard-coated wolf whistle of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	normal immense witch's bread	9	good	Last Available: "2014-12"
+7135	immense normal witch's bread	9	good	Last Available: "2014-12"
 7136	deionized twirling witch's brew	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 57, Last Available: "2014-12"
 7137	lightning-fast energetic witch's bra of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Initiative: +40, Last Available: "2014-12"
 7138	perfectly mixed mid-level medieval mead	3	EPIC	Last Available: "2014-12"
@@ -7031,7 +7031,7 @@
 7142	irradiated twirling hare brush	0		Effect: "Human-Hippy Hybrid", Effect Duration: 21, Last Available: "2014-12"
 7143	hare pin of James Dean of the empath	0		Experience (Moxie): +3, Familiar Weight: +5, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	massive rotten cinnamon cannoli	9	crappy	Last Available: "2014-12"
+7145	rotten massive cinnamon cannoli	9	crappy	Last Available: "2014-12"
 7146	aged mirror expensive champagne	4	awesome	Last Available: "2014-12"
 7147	wet polo trophy	0		Effect: "Mad at Science", Effect Duration: 26, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7042,13 +7042,13 @@
 7153	clay	0		Last Available: "2014-12"
 7154	purple filling	0		Last Available: "2014-12"
 7155	huge parchment	0		Last Available: "2014-12"
-7156	gray spinning glass	0		Last Available: "2014-12"
-7157	wobbly wool rosy-cheeked fire hose of the early riser	0		Maximum HP Percent: +30, Cold Resistance: +1, Adventures: +7, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7156	spinning gray glass	0		Last Available: "2014-12"
+7157	wobbly wool rosy-cheeked fire hose of the early riser	0		Maximum HP Percent: +30, Cold Resistance: +1, Adventures: +7, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	jumbo rotten fireman's lunch	5	crappy	Last Available: "2014-12"
-7159	greasy shellacked sinister plain paper hat	0		Spell Damage: +10, Damage Reduction: 7, Sleaze Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	greasy shellacked sinister plain paper hat	0		Spell Damage: +10, Damage Reduction: 7, Sleaze Spell Damage: +10, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	normal ice cream sandwich	3	good	Last Available: "2014-12"
 7161	Temple Grandin's dance instructor's &quot;honey&quot; dipper of extreme caution	0		Experience Percent (Moxie): +10, Monster Level: -25, Familiar Weight: +7, Last Available: "2014-12"
-7162	flavorless snack-sized plumber's lunch	2	decent	Last Available: "2014-12"
+7162	snack-sized flavorless plumber's lunch	2	decent	Last Available: "2014-12"
 7163	wobbly flame-wreathed wicked skull gearshift knob of the glutton	0		Spell Damage: +5, Hot Spell Damage: +10, Food Drop: +100, Last Available: "2014-12"
 7164	flavorless nachos of the night	3	decent	Last Available: "2014-12"
 7165	yellow censurious supercharged Rosewater's Sketcherz&trade;	0		Mysticality Percent: +30, Maximum MP Percent: +30, Sleaze Resistance: +3, Last Available: "2014-12"
@@ -7060,20 +7060,20 @@
 7171	double-Vulcanized jug of &quot;wine&quot;	0		Effect: "In the Limelight", Effect Duration: 48, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	low-calorie yummy spinning purple humble pie	1	awesome	Last Available: "2014-12"
+7174	low-calorie yummy purple spinning humble pie	1	awesome	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	skewed shaking crappy camera	0		Last Available: "2014-12"
 7177	improved nitrogenated crappy waiter disguise	0		Effect: "Ass Over Teakettle", Effect Duration: 42
-7178	bouncing lime green Copperhead Charm	0		
+7178	lime green bouncing Copperhead Charm	0		
 7179	bouncing huge The First Pizza	0		
 7180	jittery The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	jittery The Stankara Stone	0		
 7183	spinning Murphy's Rancid Black Flag	0		
-7184	pulsating shaking The Shield of Brook	0		
+7184	shaking pulsating The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	irresponsibly strong enchanted mediocre unnamed cocktail	9	decent	Effect: "Army of One", Effect Duration: 25
+7187	enchanted mediocre irresponsibly strong unnamed cocktail	9	decent	Effect: "Army of One", Effect Duration: 25
 7188	handful of tips	0		
 7189	ribald unrequired jacket	0		Sleaze Damage: +10
 7190	sharpshooter's tommy gun	0		Critical Hit Percent: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7095,7 +7095,7 @@
 7206	hand-crafted blinking Green Manalishi	3	EPIC	
 7207	blade of chilblains	0		Cold Damage: +25
 7208	fire of unknown origin	0		
-7209	twirling skewed eagle's milk	1	good	
+7209	skewed twirling eagle's milk	1	good	
 7210	energized eagle feather	0		Effect: "Healthy Blue Glow", Effect Duration: 25
 7211	liquefied corrupted ghostly one pill	0		Effect: "Black Lung", Effect Duration: 44
 7212	gray extremely unsafe Jefferson wings	0		Weapon Damage Percent: +100
@@ -7111,13 +7111,13 @@
 7222	drinkable practically non-alcoholic yellow Flamin' Whatshisname	1	good	
 7223	quadruple-anodized lynyrd musk	0		Effect: "Blessing of Charcoatl", Effect Duration: 49
 7224	olive sizzling vibrating Kashmir sweater	0		Maximum MP Percent: +10, Hot Damage: +10
-7225	tiny bland custard pie	1	decent	
+7225	bland tiny custard pie	1	decent	
 7226	cyan tea for one	1	EPIC	
 7227	watered-down hand-crafted bottle of Evermore	2	EPIC	
 7228	box	0		
 7229	smooth special wine	4	awesome	Effect: "Haunted Stomach", Effect Duration: 30
 7230	acceptable rum	3	good	
-7231	artisanal triple-distilled Murderer's Punch	8	EPIC	
+7231	triple-distilled artisanal Murderer's Punch	8	EPIC	
 7232	stale velvet cake	4	decent	
 7233	triple-alkaline wobbly letter	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 68
 7234	purple zippy Tesla book	0		Initiative: +20, MP Regen Min: 7, MP Regen Max: 10
@@ -7128,7 +7128,7 @@
 7239	curative shirt of courage	0		Spooky Resistance: +3, HP Regen Min: 3, HP Regen Max: 5
 7240	Oprah's coat of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5
 7241	upside-down family-friendly deadly shoe	0		Weapon Damage: +5, Sleaze Resistance: +1, Single Equip
-7242	bouncing cyan button	0		
+7242	cyan bouncing button	0		
 7243	button	0		
 7244	concentrated jittery blood cells	0		Effect: "Inappropriate Spirit", Effect Duration: 69
 7245	Vulcanized green eye	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 55
@@ -7184,7 +7184,7 @@
 7295	spinning elevent	0		Last Available: "2014-03"
 7296	up-at-dawn wholesome elevenderizing hammer	0		Maximum HP Percent: +10, Adventures: +5, Last Available: "2014-03"
 7297	shaking energetic Professor What T-Shirt	0		Maximum MP Percent: +20
-7298	green jittery heavy-duty bendy straw	0		
+7298	jittery green heavy-duty bendy straw	0		
 7299	ghostly pellet of plant food	0		
 7300	sewing kit	0		
 7301	Spookyraven billiards room key	0		
@@ -7210,8 +7210,8 @@
 7321	auspicious personal trainer's Stephen's lab coat	0		Experience Percent (Muscle): +10, Item Drop: +10
 7322	anodized polymerized Stephen's secret formula	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 13
 7323	Jim Carey's boxer's Jacob's rung	0		Muscle Percent: +10, Monster Level: +25
-7324	denatured fuchsia tumbling skewed battery	1		Effect: "Bananas!", Effect Duration: 30
-7325	boozy artisanal snakebite	5	EPIC	
+7324	denatured tumbling fuchsia skewed battery	1		Effect: "Bananas!", Effect Duration: 30
+7325	artisanal boozy snakebite	5	EPIC	
 7326	prompt lard-coated rubber ribcage	0		Sleaze Spell Damage: +25, Adventures: +3, Damage Reduction: 7
 7327	denatured twirling synthetic marrow	1		
 7328	super-nitrogenated irradiated triple-activated funny bone	0		Effect: "Carol of the Bones", Effect Duration: 18
@@ -7229,7 +7229,7 @@
 7340	moose antlers of doom	0		Spooky Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 27"
 7341	cold-filtered yellow moose thought	0		Effect: "Category", Effect Duration: 42
 7342	decent moose chocolate	4	good	
-7343	acceptable triple-distilled blurry painting of a glass of wine	10	good	
+7343	triple-distilled acceptable blurry painting of a glass of wine	10	good	
 7344	oil painting of yourself	0		
 7345	mirror blurry ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7240,7 +7240,7 @@
 7351	tumbling chaotic Tesla Staff of the Electric Range of incineration	0		Spell Critical Percent: +10, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
 7352	rotten deluxe layer cake	3	crappy	
 7353	wobbly chunk of hot iron	0		
-7354	lousy weak red-hot boilermaker	2	decent	
+7354	weak lousy red-hot boilermaker	2	decent	
 7355	mirror boxer's coal shovel	0		Muscle Percent: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	cold-filtered dry mirror hot coal	0		Effect: "Joy", Effect Duration: 50
 7357	pickled coal dust	0		Effect: "Faboooo", Effect Duration: 37
@@ -7256,12 +7256,12 @@
 7367	moist industrial strength starch	0		Effect: "Sweet and Green", Effect Duration: 13, Wiki Name: "industrial strength starch"
 7368	massive tasty extra-flat panini	7	awesome	
 7369	oxidized oxidized squat mangled finger	0		Effect: "So You Can Work More...", Effect Duration: 59
-7370	acceptable triple-distilled Psychotic Train wine	10	good	
+7370	triple-distilled acceptable Psychotic Train wine	10	good	
 7371	crazy hobo notebook	0		
 7372	decent red pie man was not meant to eat	4	good	
 7373	mirror careful sommelier's towel	0		Monster Level: -10
 7374	wizardly tarnished tastevin	0		Mysticality: +25, Single Equip
-7375	stale jumbo actual tapas	5	decent	
+7375	jumbo stale actual tapas	5	decent	
 7376	ghast iron ingot	0		
 7377	pulsating banded strapping ghast iron cleaver	0		Muscle: +5, Damage Absorption: +100
 7378	mansplainer's baleful ghast iron Garibaldi	0		Spell Damage: +25, Monster Level: +15, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7309,7 +7309,7 @@
 7420	red Steam Card: Jackass Plumber (#3)	0		
 7421	pencil thin mushroom	0		Last Available: "2014-05"
 7422	Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
-7423	blinking shaking salty sailor salt	0		Last Available: "2014-05"
+7423	shaking blinking salty sailor salt	0		Last Available: "2014-05"
 7424	spinning bike rental broupon	0		Last Available: "2014-05"
 7425	Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	green sprinkle shaker	0		Last Available: "2014-05"
@@ -7319,7 +7319,7 @@
 7430	cold-filtered cyan Fun-Guy spore	0		Effect: "Turkey-Agitated", Effect Duration: 60, Last Available: "2014-05"
 7431	electrified Vulcanized altered blurry green Boletus Broletus mushroom	0		Effect: "Very Clean Guns", Effect Duration: 39, Last Available: "2014-05"
 7432	triple-wet improved Omphalotus Omphaloskepsis mushroom	0		Effect: "Happy Trails", Effect Duration: 42, Last Available: "2014-05"
-7433	ionized shaking lime green Gyromitra Dynomita mushroom	0		Effect: "Artificially Sweet", Effect Duration: 52, Last Available: "2014-05"
+7433	ionized lime green shaking Gyromitra Dynomita mushroom	0		Effect: "Artificially Sweet", Effect Duration: 52, Last Available: "2014-05"
 7434	triple-pressed Helvella Haemophilia mushroom	0		Effect: "Wasabi With You", Effect Duration: 45, Last Available: "2014-05"
 7435	Vulcanized Stemonitis Staticus mushroom	0		Effect: "Concentration", Effect Duration: 18, Last Available: "2014-05"
 7436	polymerized galvanized yellow Tremella Tarantella mushroom	0		Effect: "Violent Night", Effect Duration: 21, Last Available: "2014-05"
@@ -7328,33 +7328,33 @@
 7439	spoiled fuchsia Brain Food Pastaco	3	crappy	Last Available: "2014-05"
 7440	moldy Cool Brunch Pastaco	4	crappy	Last Available: "2014-05"
 7441	adequate jumbo Medical Pastaco	5	good	Last Available: "2014-05"
-7442	thick bland Energy Buzz Pastaco	5	decent	Last Available: "2014-05"
+7442	bland thick Energy Buzz Pastaco	5	decent	Last Available: "2014-05"
 7443	normal bite-sized red Ludovico Pastaco	1	good	Last Available: "2014-05"
-7444	spirit-forward smooth overpowering mushroom wine	5	awesome	Last Available: "2014-05"
+7444	smooth spirit-forward overpowering mushroom wine	5	awesome	Last Available: "2014-05"
 7445	watered-down mediocre complex mushroom wine	2	decent	Last Available: "2014-05"
 7446	drinkable smooth mushroom wine	3	good	Last Available: "2014-05"
-7447	watered-down perfectly mixed blood-red mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
-7448	extra-dry aged buzzing mushroom wine	5	awesome	Last Available: "2014-05"
-7449	lousy practically non-alcoholic ghostly twirling swirling mushroom wine	1	decent	Last Available: "2014-05"
+7447	perfectly mixed watered-down blood-red mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7448	aged extra-dry buzzing mushroom wine	5	awesome	Last Available: "2014-05"
+7449	practically non-alcoholic lousy twirling ghostly swirling mushroom wine	1	decent	Last Available: "2014-05"
 7450	small adequate Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
 7451	bland small Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	watered-down special smooth wobbly regular-size brogurt	2	awesome	Effect: "Armored Innards", Effect Duration: 35, Last Available: "2014-05"
+7453	watered-down smooth special wobbly regular-size brogurt	2	awesome	Effect: "Armored Innards", Effect Duration: 35, Last Available: "2014-05"
 7454	tolerable practically non-alcoholic super-size brogurt	1	good	Last Available: "2014-05"
-7455	special drinkable broberry brogurt	3	good	Effect: "Night of the Nachos", Effect Duration: 10, Last Available: "2014-05"
+7455	drinkable special broberry brogurt	3	good	Effect: "Night of the Nachos", Effect Duration: 10, Last Available: "2014-05"
 7456	delicious brocolate brogurt	4	awesome	Last Available: "2014-05"
-7457	drinkable lime green huge French bronilla brogurt	3	good	Last Available: "2014-05"
+7457	drinkable huge lime green French bronilla brogurt	3	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	spinning tumbling Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	tumbling industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts of James Dean	0		Experience (Moxie): +3, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	Brogre brorts of James Dean	0		Experience (Moxie): +3, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	beefcake's Brogre brolo shirt	0		Muscle: +25, Last Available: "2014-05"
-7464	jittery olive tumbling wholesome Brogre bucket hat	0		Maximum HP Percent: +10, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	jittery olive tumbling wholesome Brogre bucket hat	0		Maximum HP Percent: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	yellow Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	upside-down one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	studded 8-billed baseball cap of the cougar of the blizzard	0		Moxie: +20, Damage Absorption: +80, Cold Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	studded 8-billed baseball cap of the cougar of the blizzard	0		Moxie: +20, Damage Absorption: +80, Cold Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	narrow skewed thinker's extremely wet T-shirt of extreme caution of incineration	0		Mysticality: +10, Monster Level: -25, Hot Spell Damage: +50, Last Available: "2014-05"
 7470	twirling wholesome shellacked stylish shrimp fork	0		Moxie: +25, Damage Reduction: 7, Maximum HP Percent: +10, Last Available: "2014-05"
 7471	deionized polarized huge BROS Energy Drink	0		Effect: "Meadulla Oblongota", Effect Duration: 36, Last Available: "2014-05"
@@ -7378,7 +7378,7 @@
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
 7491	distilled tolerable bottle of Chateau de Vinegar	5	good	
-7492	shaking blue tumbling mirror blasting soda	0		
+7492	mirror tumbling blue shaking blasting soda	0		
 7493	unstable fulminate	0		
 7494	narrow wine bomb	0		
 7495	huge recipe: mortar-dissolving solution	0		
@@ -7405,7 +7405,7 @@
 7516	red witch's spare house key	0		
 7517	sage spider leg of the cheetah	0		Mysticality Percent: +10, Initiative: +60
 7518	wand of pigification	0		
-7519	aged irresponsibly strong glass of bourbon	10	awesome	
+7519	irresponsibly strong aged glass of bourbon	10	awesome	
 7520	twirling burned government manual fragment	0		Last Available: "2014-05"
 7521	normal government cheese	3	good	Last Available: "2014-05"
 7522	cool pair of government shades	0		Moxie: +5, Single Equip, Last Available: "2014-05"
@@ -7416,17 +7416,17 @@
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	lion tamer's wholesome government-issued night-vision goggles	0		Maximum HP Percent: +10, Experience (familiar): +2, Single Equip, Last Available: "2014-05"
 7529	decent lime green loaf of alien bread	4	good	Last Available: "2014-05"
-7530	jumbo decent grilled cheese sandwich	5	good	Last Available: "2014-05"
-7531	mixed blurry skewed alien protein powder	1	good	Last Available: "2014-05"
+7530	decent jumbo grilled cheese sandwich	5	good	Last Available: "2014-05"
+7531	mixed skewed blurry alien protein powder	1	good	Last Available: "2014-05"
 7532	weak smooth rocket fuel	2	awesome	Last Available: "2014-05"
 7533	spinning alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	pulsating alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	watered-down mediocre stealth bomber	2	decent	Last Available: "2014-05"
+7535	mediocre watered-down stealth bomber	2	decent	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	upside-down ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	huge space beast fur hat of the pedagogue	0		Experience: +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	space beast fur pants of the storm	0		Maximum MP Percent: +40, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	huge space beast fur hat of the pedagogue	0		Experience: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	space beast fur pants of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	purple supercharged space beast fur whip	0		Maximum MP Percent: +30, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	greedy forbidden space heater	0		Spell Damage Percent: +50, Meat Drop: +20, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7458,9 +7458,9 @@
 7569	wool Annie Oakley's Time Bandit Badge of Courage of the cougar	0		Moxie: +20, Critical Hit Percent: +20, Cold Resistance: +1
 7570	corrupted activated spinning Friendliness Beverage	0		Effect: "Ooh, Umami!", Effect Duration: 37
 7571	lime green therapeutic silent pea shooter of Calamity Jane	0		Critical Hit Percent: +15, HP Regen Min: 5, HP Regen Max: 7
-7572	moldy tiny D roll	1	crappy	
+7572	tiny moldy D roll	1	crappy	
 7573	Temple Grandin's weightlifter's kiwi beak	0		Muscle: +15, Familiar Weight: +7
-7574	practically non-alcoholic hand-crafted ghostly New Zealand iced tea	1	super EPIC	
+7574	hand-crafted practically non-alcoholic ghostly New Zealand iced tea	1	super EPIC	
 7575	flame-retardant steel-toed droll monocle	0		Damage Reduction: 9, Hot Resistance: +1, Single Equip
 7576	enhanced non-polymerized future drug: Muscularactum	0		Effect: "Raging Animal", Effect Duration: 69
 7577	double-liquefied triple-electrified future drug: Smartinex	0		Effect: "Lobos Fresh", Effect Duration: 21
@@ -7469,22 +7469,22 @@
 7580	compressed blue liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	stale massive rack of dinosaur ribs	9	decent	
-7583	acceptable triple-distilled scotch on the rocks	8	good	
+7583	triple-distilled acceptable scotch on the rocks	8	good	
 7584	MacGyver's sage yabba dabba doo rag	0		Mysticality Percent: +10, Maximum MP: +100, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	family-friendly Oprah's wooly loincloth	0		Maximum MP Percent: +50, Sleaze Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 27"
-7586	upside-down blinking helix fossil	0		
+7586	blinking upside-down helix fossil	0		
 7587	blurry S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	weak smooth glass of &quot;milk&quot;	2	awesome	Last Available: "2014-07"
+7589	smooth weak glass of &quot;milk&quot;	2	awesome	Last Available: "2014-07"
 7590	hand-crafted weak cup of &quot;tea&quot;	2	EPIC	Last Available: "2014-07"
-7591	watered-down delicious thermos of &quot;whiskey&quot;	2	awesome	Last Available: "2014-07"
+7591	delicious watered-down thermos of &quot;whiskey&quot;	2	awesome	Last Available: "2014-07"
 7592	artisanal watered-down Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	delicious Bee's Knees	3	awesome	Last Available: "2014-07"
 7594	drinkable jittery Sockdollager	4	good	Last Available: "2014-07"
-7595	drinkable irresponsibly strong Ish Kabibble	7	good	Last Available: "2014-07"
+7595	irresponsibly strong drinkable Ish Kabibble	7	good	Last Available: "2014-07"
 7596	hand-crafted olive Hot Socks	3	EPIC	Last Available: "2014-07"
 7597	artisanal Phonus Balonus	4	EPIC	Last Available: "2014-07"
-7598	practically non-alcoholic aged upside-down Flivver	1	awesome	Last Available: "2014-07"
+7598	aged practically non-alcoholic upside-down Flivver	1	awesome	Last Available: "2014-07"
 7599	enchanted hand-crafted Sloppy Jalopy	3	super EPIC	Effect: "On the Trolley", Effect Duration: 45, Last Available: "2014-07"
 7600	non-irradiated olive flame	0		Effect: "Concentrated Concentration", Effect Duration: 23
 7601	denatured warmed temporary yak tattoo	0		Effect: "Dirty Pear", Effect Duration: 17
@@ -7498,7 +7498,7 @@
 7609	chilled Redeye&trade; Eyedrops	0		Effect: "Muscularrr", Effect Duration: 35
 7610	irradiated galvanized Dweebisol&trade; inhaler	0		Effect: "Stimulated Brain", Effect Duration: 50
 7611	tarnished tarnished tumbling Lewd Lemmy Hair Oil	0		Effect: "Tingly Elbows", Effect Duration: 63
-7612	ionized tarnished green spinning tomato soup poster	0		Effect: "Salamander In Your Stomach", Effect Duration: 54
+7612	ionized tarnished spinning green tomato soup poster	0		Effect: "Salamander In Your Stomach", Effect Duration: 54
 7613	nitrogenated liquefied jittery skewed bubblin' chemistry solution	0		Effect: "Good Motivator", Effect Duration: 16
 7614	activated voodoo glowskull	0		Effect: "Egg on your Face", Effect Duration: 31
 7615	modified mirror pygmy adder oil	0		Effect: "It's Soporiffic!", Effect Duration: 53
@@ -7519,9 +7519,9 @@
 7630	denatured magic powder	0		Effect: "Slimily Strong", Effect Duration: 65
 7631	liquefied bouncing friar's tonsure	0		Effect: "Brocolate Brostidigitation", Effect Duration: 64
 7632	anodized double-warmed government-issue identification badge	0		Effect: "Weird Vibrations", Effect Duration: 34
-7633	denatured galvanized red spinning alien hologram projector	0		Effect: "Chain Chain Chains", Effect Duration: 20
+7633	denatured galvanized spinning red alien hologram projector	0		Effect: "Chain Chain Chains", Effect Duration: 20
 7634	concentrated irradiated turtle	0		Effect: "Liquid Courage", Effect Duration: 63
-7635	ionized extra-magnetized blurry lime green cigar box turtle	0		Effect: "Vanity Rage", Effect Duration: 12
+7635	ionized extra-magnetized lime green blurry cigar box turtle	0		Effect: "Vanity Rage", Effect Duration: 12
 7636	huge shaking Jack Frost's energetic shellacked shell	0		Maximum MP Percent: +20, Cold Spell Damage: +50, Class: "Turtle Tamer"
 7637	pillow shell of incineration	0		Hot Spell Damage: +50, Class: "Turtle Tamer"
 7638	clever whatsit-covered turtle shell	0		Maximum MP: +20, Class: "Turtle Tamer"
@@ -7548,7 +7548,7 @@
 7659	toasty neoprene skullcap	0		Hot Damage: +5, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	magnetized goblin water	0		Effect: "Icy Demeanor", Effect Duration: 68
 7661	dumb mud	0		
-7662	half-sized bland Sogg-Os	2	decent	
+7662	bland half-sized Sogg-Os	2	decent	
 7663	narrow reassuring ruddy deadly Lord Soggyraven's Slippers	0		Weapon Damage: +5, Maximum HP Percent: +40, Spooky Resistance: +1, Single Equip
 7664	Vulcanized Ancient Protector Soda	0		Effect: "Elron's Explosive Etude", Effect Duration: 23
 7665	pickled wet spinning liquid ice	0		Effect: "Gummiheart", Effect Duration: 67
@@ -7592,22 +7592,22 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	huge LCD game: Garbage River	0		Last Available: "2014-08"
 7705	pulsating LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	blurry The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	blurry The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	quadruple-Vulcanized shaking rubber nubbin	0		Effect: "Hot Hands", Effect Duration: 13, Last Available: "2014-08"
 7708	censurious dog trainer's rubber cape	0		Experience (familiar): +1, Sleaze Resistance: +3, Last Available: "2014-08"
 7709	green greedy quilted dangerous Fonzie's Thor's Pliers	0		Experience (Moxie): +1, Weapon Damage: +10, Damage Absorption: +40, Meat Drop: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	dry blurry blinking candy UFOs	0		Effect: "Ponderous Potency", Effect Duration: 47
 7711	shaking bouncing padded personal trainer's water wings for babies	0		Experience Percent (Muscle): +10, Damage Absorption: +20
-7712	shaking green beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	snack-sized tasty teal huge Strix stix	2	awesome	
+7712	shaking green beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7713	snack-sized tasty huge teal Strix stix	2	awesome	
 7714	knitted foul-smelling vampire pellet of the early riser	0		Stench Damage: +10, Cold Resistance: +3, Adventures: +7
-7715	practically non-alcoholic artisanal non-aged vinegar	1	EPIC	
+7715	artisanal practically non-alcoholic non-aged vinegar	1	EPIC	
 7716	pulsating nippy unsanitized scalpel	0		Cold Damage: +10
 7717	personal trainer's gladiator tunica	0		Experience Percent (Muscle): +10
 7718	squat electrified Roman sadnals	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 7719	smooth madius	0		Moxie: +15
 7720	veiny radiator heater shield	0		Maximum HP: +10, Damage Reduction: 6
-7721	tarnished fuchsia wobbly salt wages	0		Effect: "Headstrong", Effect Duration: 46
+7721	tarnished wobbly fuchsia salt wages	0		Effect: "Headstrong", Effect Duration: 46
 7722	narrow upside-down scandalous centurion helmet	0		Sleaze Damage: +5, Familiar Effect: "1xFairy, atk, cap 25"
 7723	Chroner cross	0		
 7724	sharpshooter's pteruges	0		Critical Hit Percent: +10, Familiar Effect: "1xFairy, atk, cap 25"
@@ -7630,7 +7630,7 @@
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
 7743	Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
-7744	wobbly lime green Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
+7744	lime green wobbly Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
 7746	blurry maroon Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
 7747	lime green Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
@@ -7639,10 +7639,10 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	blinking Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	medical-grade Xiblaxian xeno-detection goggles	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2014-09"
-7753	purple Xiblaxian stealth cowl of Tarzan of courage	0		Experience (Muscle): +3, Spooky Resistance: +3, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	purple Xiblaxian stealth cowl of Tarzan of courage	0		Experience (Muscle): +3, Spooky Resistance: +3, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	medical-grade Xiblaxian stealth trousers of the dark arts	0		Spell Damage Percent: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-09"
 7755	blue prompt groovy Xiblaxian stealth vest	0		Moxie Percent: +10, Adventures: +3, Last Available: "2014-09"
-7756	spoiled jumbo bouncing Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
+7756	jumbo spoiled bouncing Xiblaxian ultraburrito	5	crappy	Last Available: "2014-09"
 7757	drinkable enchanted twirling Xiblaxian space-whiskey	3	good	Effect: "Eau de Tortue", Effect Duration: 30, Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	oxidized They liver	0		Effect: "Good Karma", Effect Duration: 54, Last Available: "2014-09"
@@ -7669,7 +7669,7 @@
 7780	smelly Herculean educational heavy-duty clipboard	0		Experience: +1, Experience (Muscle): +1, Stench Spell Damage: +10, Damage Reduction: 8, Last Available: "2014-10"
 7781	supercharged experienced boxer's battery-powered drill of the overflowing toilet	0		Muscle Percent: +10, Experience: +2, Maximum MP Percent: +30, Stench Spell Damage: +50, Last Available: "2014-10"
 7782	decent skewed limp broccoli	4	good	Last Available: "2014-10"
-7783	miser's Sherlock's occult hat	0		Spell Damage Percent: +25, Item Drop: +25, Meat Drop: +10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7783	miser's Sherlock's occult hat	0		Spell Damage Percent: +25, Item Drop: +25, Meat Drop: +10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	electrified triple-wet monkey barf	0		Effect: "Pill Power", Effect Duration: 67, Last Available: "2014-10"
 7785	cold-filtered candy	0		Effect: "Bats in the Belfry", Effect Duration: 17, Last Available: "2014-10"
 7786	medical-grade smartaleck's jangly bracelet of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10"
@@ -7681,12 +7681,12 @@
 7792	skewed blurry SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	spinning Armory keycard	0		Last Available: "2014-10"
-7795	thick bland initiative shawarma	5	decent	Last Available: "2014-10"
+7795	bland thick initiative shawarma	5	decent	Last Available: "2014-10"
 7796	bland huge warm war shawarma	4	decent	Last Available: "2014-10"
 7797	moldy yellow karma shawarma	3	crappy	Last Available: "2014-10"
 7798	weak tolerable Jungle Juice	2	good	Last Available: "2014-10"
-7799	artisanal enchanted huge Amnesiac Ale	3	EPIC	Effect: "Human-Plant Hybrid", Effect Duration: 10, Last Available: "2014-10"
-7800	lousy watered-down Highest Bitter	2	decent	Last Available: "2014-10"
+7799	enchanted artisanal huge Amnesiac Ale	3	EPIC	Effect: "Human-Plant Hybrid", Effect Duration: 10, Last Available: "2014-10"
+7800	watered-down lousy Highest Bitter	2	decent	Last Available: "2014-10"
 7801	vibrating beefy mercenary pistol	0		Muscle: +10, Maximum MP Percent: +10, Last Available: "2014-10"
 7802	squat yellow toasty mercenary rifle of the cheetah	0		Hot Damage: +5, Initiative: +60, Last Available: "2014-10"
 7803	purple Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7699,14 +7699,14 @@
 7810	Z-Bone steak	0		
 7811	tumbling viral DNA	0		
 7812	twirling tarnished bottlecap	0		
-7813	small stale seared dino steak	2	decent	
+7813	stale small seared dino steak	2	decent	
 7814	weak perfectly mixed bottle of drinkin' gas	2	EPIC	
-7815	shaking gray handful of napalm	0		
-7816	blurry gray skewed dove DNA	0		
+7815	gray shaking handful of napalm	0		
+7816	skewed blurry gray dove DNA	0		
 7817	gelatinous meat mass	0		
-7818	skewed olive 99.44% pure math	0		
+7818	olive skewed 99.44% pure math	0		
 7819	narrow cyan simple AI	0		
-7820	ghostly olive corrupted bird DNA	0		
+7820	olive ghostly corrupted bird DNA	0		
 7821	tumbling sentient meat mass	0		
 7822	blurry zombie dinosaur egg	0		
 7823	tumbling french-fry grabber	0		Familiar Weight: +5
@@ -7726,7 +7726,7 @@
 7837	Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	special clip: tracers	0		Last Available: "2014-10"
-7840	jittery huge special clip: wailers	0		Last Available: "2014-10"
+7840	huge jittery special clip: wailers	0		Last Available: "2014-10"
 7841	maroon special clip: squelchers	0		Last Available: "2014-10"
 7842	upside-down special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	alkaline perl necklace	0		Effect: "Innately Truthy", Effect Duration: 12, Last Available: "2014-12"
 7846	modified Fudge Fiber Armor Plating	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 60, Last Available: "2014-12"
 7847	oxidized double-chilled ruby on canes	0		Effect: "Violent Night", Effect Duration: 31, Last Available: "2014-12"
-7848	super-sized flavorless petit fortran	5	decent	Last Available: "2014-12"
+7848	flavorless super-sized petit fortran	5	decent	Last Available: "2014-12"
 7849	flavorless half-sized java cookie	2	decent	Last Available: "2014-12"
 7850	stale huge cookie cookie	4	decent	Last Available: "2014-12"
 7851	mirror veiny plastic exo-suited miner	0		Maximum HP: +10, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	blurry purple Herculean plastic Crimbot	0		Experience (Muscle): +1, Last Available: "2014-12"
 7855	pulsating aromatic plastic Crimbomega	0		Stench Resistance: +1, Last Available: "2014-12"
 7856	concentrated super-vacuum-sealed flask of mining oil	0		Effect: "The Strength...  of the Future", Effect Duration: 60, Last Available: "2014-12"
-7857	radiation-resistant helmet of dire peril	0		Weapon Damage: +20, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	wizardly servo-assisted exo-pants	0		Mysticality: +25, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	radiation-resistant helmet of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	wizardly servo-assisted exo-pants	0		Mysticality: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	mirror ghostly zippy healthy high-energy mining laser	0		Maximum HP Percent: +20, Initiative: +20, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	bouncing nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7777,7 +7777,7 @@
 7888	twirling Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
-7891	blinking gray Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
+7891	gray blinking Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	green Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	squat Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
@@ -7811,7 +7811,7 @@
 7922	bad Friendly Turkey	3	decent	Last Available: "2014-11"
 7923	tolerable Agitated Turkey	4	good	Last Available: "2014-11"
 7924	tolerable yellow Ambitious Turkey	4	good	Last Available: "2014-11"
-7925	normal miniature neutron lollipop	2	good	Last Available: "2014-12"
+7925	miniature normal neutron lollipop	2	good	Last Available: "2014-12"
 7926	acceptable spinning gamma nog	3	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7828,7 +7828,7 @@
 7946	dog trainer's Socratic wizardly outlaw bandana	0		Mysticality: +25, Experience (Mysticality): +1, Experience (familiar): +1
 7947	aged jittery whiskey in a broken glass	4	awesome	
 7948	hand-crafted squat shot of mescal	3	EPIC	
-7949	mediocre enchanted glass of herbal tequila	4	decent	Effect: "Red Around the Gills", Effect Duration: 45
+7949	enchanted mediocre glass of herbal tequila	4	decent	Effect: "Red Around the Gills", Effect Duration: 45
 7950	green minin' dynamite	0		
 7951	ghostly yellow blinking plaid cowboy hat of the brute of the storm	0		Muscle Percent: +30, Maximum MP Percent: +40, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7852,7 +7852,7 @@
 7970	squat boning knife	0		
 7971	bouncing Aggressive Carrot	0		Free Pull
 7972	twisted huge mummified fig	1	EPIC	
-7973	altered huge lime green mummified loaf of bread	1	EPIC	
+7973	altered lime green huge mummified loaf of bread	1	EPIC	
 7974	powdered mummified beef haunch	1	good	Effect: "Purpose", Effect Duration: 50
 7975	linen bandages	0		
 7976	cotton bandages	0		
@@ -7881,7 +7881,7 @@
 7999	boiled liquefied choco-Crimbot	0		Effect: "Greedy Resolve", Effect Duration: 59, Last Available: "2014-12"
 8000	chilled oxidized smart watch	0		Effect: "Sensation", Effect Duration: 41, Last Available: "2014-12"
 8001	corrupted frozen upside-down augmented-reality shades	0		Effect: "Sugary World View", Effect Duration: 48, Last Available: "2014-12"
-8002	dog trainer's toy Crimbot mega face	0		Experience (familiar): +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8002	dog trainer's toy Crimbot mega face	0		Experience (familiar): +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
 8003	skewed nasty toy Crimbot power glove	0		Stench Damage: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	flame-wreathed toy Crimbot super fist	0		Hot Spell Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	quilted toy Crimbot rocket legs	0		Damage Absorption: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	aromatic rock-hard Spelunker's fedora of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5, Stench Resistance: +1, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	aromatic rock-hard Spelunker's fedora of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5, Stench Resistance: +1, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	ghostly Sherlock's Tesla vibrating Spelunker's whip	0		Maximum MP Percent: +10, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
-8076	lightning-fast chaotic Spelunker's khakis of the empath	0		Spell Critical Percent: +10, Familiar Weight: +5, Initiative: +40, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	lightning-fast chaotic Spelunker's khakis of the empath	0		Spell Critical Percent: +10, Familiar Weight: +5, Initiative: +40, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	green Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	tumbling LOLmec statuette	0		Last Available: "2015-12"
 8085	lime green shaking Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8023,9 +8023,9 @@
 8149	polarized polymerized irradiated mirror Glo-Pop	0		Effect: "Demonic Taint", Effect Duration: 24
 8150	activated modified sugar sphere	0		Effect: "Egg-stortionary Tactics", Effect Duration: 12
 8151	pressed cold-filtered oxidized blinking Shrubble Bubble	0		Effect: "Human-Insect Hybrid", Effect Duration: 30
-8152	pickled red blurry polyeaster egg	0		Effect: "Disdain of the War Snapper", Effect Duration: 62
+8152	pickled blurry red polyeaster egg	0		Effect: "Disdain of the War Snapper", Effect Duration: 62
 8153	activated vacuum-sealed enhanced lime green candy dish	0		Effect: "Items Are Forever", Effect Duration: 33
-8154	magnetized double-ionized oxidized teal upside-down narrow Spechunky bar	0		Effect: "BOOsted", Effect Duration: 47
+8154	magnetized double-ionized oxidized upside-down narrow teal Spechunky bar	0		Effect: "BOOsted", Effect Duration: 47
 8155	deionized deionized talisman of Horus	0		Effect: "Think Win-Lose", Effect Duration: 47
 8156	check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
@@ -8042,10 +8042,10 @@
 8168	glob of icing	0		
 8169	enhanced ginger snaps	0		Effect: "Mushroom Samba", Effect Duration: 11
 8170	vacuum-sealed boiled mostly-broken sunglasses	0		Effect: "Heavily Breathing", Effect Duration: 50
-8171	smooth practically non-alcoholic green unflavored wine cooler	1	awesome	
+8171	practically non-alcoholic smooth green unflavored wine cooler	1	awesome	
 8172	carton of snake milk	1	crappy	
 8173	sewer snake of the sweet-tooth	0		Candy Drop: +100
-8174	delicious special squat pigeon egg	3	awesome	Effect: "Ginger Snapped", Effect Duration: 25
+8174	special delicious squat pigeon egg	3	awesome	Effect: "Ginger Snapped", Effect Duration: 25
 8175	scorching Samson's jaunty feather	0		Experience (Muscle): +5, Hot Damage: +25
 8176	smooth weak premium malt liquor	2	awesome	
 8177	green brown paper pants of the dark arts of chilblains	0		Spell Damage Percent: +100, Cold Damage: +25
@@ -8056,13 +8056,13 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	dog trainer's bread basket	0		Experience (familiar): +1
 8184	Ed the Undying exhibit crate	0		
-8185	tumbling miser's The Crown of Ed the Undying of wisdom	0		Mysticality: +15, Meat Drop: +10, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	tumbling miser's The Crown of Ed the Undying of wisdom	0		Mysticality: +15, Meat Drop: +10, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	perfectly mixed watered-down special spinning Cherrytastrophe wine cooler	2	EPIC	Effect: "Swimming Head", Effect Duration: 20
+8188	special perfectly mixed watered-down spinning Cherrytastrophe wine cooler	2	EPIC	Effect: "Swimming Head", Effect Duration: 20
 8189	smooth Radberry Rip wine cooler	4	awesome	
 8190	aged Orangemageddon wine cooler	3	awesome	
-8191	perfectly mixed practically non-alcoholic Breakfast Blast wine cooler	1	EPIC	
+8191	practically non-alcoholic perfectly mixed Breakfast Blast wine cooler	1	EPIC	
 8192	perfectly mixed Citrus Crush wine cooler	3	EPIC	
 8193	adequate immense narrow plain bagel	7	good	
 8194	rotten bite-sized glob of cream cheese	1	crappy	
@@ -8071,7 +8071,7 @@
 8197	decent standard-issue cupcake	3	good	
 8198	tiny spoiled twirling ultra-deluxe cupcake	1	crappy	
 8199	hypnotic breadcrumbs	0		
-8200	gigantic decent upside-down popular tart	10	good	
+8200	decent gigantic upside-down popular tart	10	good	
 8201	no-handed pie	0		
 8202	concentrated Doc Galaktik's Vitality Serum	0		Effect: "Puddingskin", Effect Duration: 41
 8203	huge airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8092,7 +8092,7 @@
 8218	toxic globule	0		Last Available: "2015-04"
 8219	rotten toxo	4	crappy	Last Available: "2015-04"
 8220	bad Lemonade-235	3	decent	Last Available: "2015-04"
-8221	fuchsia executive educational isotophat	0		Experience: +1, Meat Drop: +40, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8221	fuchsia executive educational isotophat	0		Experience: +1, Meat Drop: +40, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	Temple Grandin's wicked Three Mile Island shorts	0		Spell Damage: +5, Familiar Weight: +7, Last Available: "2015-04"
 8223	blinking Fonzie's toxic mop	0		Experience (Moxie): +1, Item Drop: +5, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8128,7 +8128,7 @@
 8254	Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	warmed cyan wobbly nasty gum	0		Effect: "Inappropriate Spirit", Effect Duration: 32
+8257	warmed wobbly cyan nasty gum	0		Effect: "Inappropriate Spirit", Effect Duration: 32
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	The Lot's engagement ring of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	Mayo Clinic	0		Last Available: "2015-05"
@@ -8143,8 +8143,8 @@
 8269	pulsating mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	adequate huge squat unappetizing mayolus	8	good	Last Available: "2015-05"
 8271	decent wobbly uninteresting mayolus	3	good	Last Available: "2015-05"
-8272	bland miniature acceptable mayolus	2	decent	Last Available: "2015-05"
-8273	immense stale ghostly enticing mayolus	7	decent	Last Available: "2015-05"
+8272	miniature bland acceptable mayolus	2	decent	Last Available: "2015-05"
+8273	stale immense ghostly enticing mayolus	7	decent	Last Available: "2015-05"
 8274	stale huge mouth-watering mayolus	9	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	gray mayo pump	0		Familiar Weight: +5
@@ -8154,12 +8154,12 @@
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	galvanized Vulcanized Kokomo Resort Brand Suntan Oil	0		Effect: "Ham-Fisted", Effect Duration: 40, Last Available: "2015-04"
 8282	fuchsia Kokomo Resort Order Pad	0		Last Available: "2015-04"
-8283	jittery blinking The Cocktail Shaker	0		Last Available: "2015-04"
+8283	blinking jittery The Cocktail Shaker	0		Last Available: "2015-04"
 8284	extra-electrified Kokomo Resort Pass	0		Effect: "Think Win-Lose", Effect Duration: 45, Last Available: "2023-08"
 8285	Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	super-nitrogenated gray Mayo de Mayo&trade; mayo	0		Effect: "What's That Smell?", Effect Duration: 48
 8287	ghostly puck	0		Free Pull, Last Available: "2015-06"
-8288	upside-down ghostly kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
+8288	ghostly upside-down kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	teal frightening dice ring	0		Spooky Damage: +5, Single Equip
 8291	yellow groovy dice belt buckle	0		Moxie Percent: +10, Single Equip
@@ -8184,8 +8184,8 @@
 8310	tarnished oxidized .epub file	0		Effect: "Alpine Mintiness", Effect Duration: 66
 8311	polymerized mirror BUBBLE GUM	0		Effect: "The Strength...  of the Future", Effect Duration: 17
 8312	chilled improved hustler shades	0		Effect: "Radiant Personality", Effect Duration: 35
-8313	super-enhanced oxidized diffused olive mirror blurry jerky stick	0		Effect: "Ooh, Umami!", Effect Duration: 64
-8314	concentrated twirling red costume rental shop	0		Effect: "Concentrated Concentration", Effect Duration: 45
+8313	super-enhanced oxidized diffused blurry mirror olive jerky stick	0		Effect: "Ooh, Umami!", Effect Duration: 64
+8314	concentrated red twirling costume rental shop	0		Effect: "Concentrated Concentration", Effect Duration: 45
 8315	wet nitrogenated liquefied spinning muscle oil	0		Effect: "Thought", Effect Duration: 68
 8316	modified oxidized spinning bottle of Red-Out	0		Effect: "Adorable Lookout", Effect Duration: 51
 8317	altered polymerized pickpocket protector	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 20
@@ -8225,7 +8225,7 @@
 8351	colloidal olive lump of goofball ore	0		Effect: "Stimulated Brain", Effect Duration: 48
 8352	extra-denatured extra-electrified modified skeleton beans	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 28
 8353	super-electrified diffused yellow narrow grimy lab coat	0		Effect: "Spiro Gyro", Effect Duration: 69
-8354	magnetized colloidal purple squat huge nursery rhyme	0		Effect: "Hot Jellied", Effect Duration: 42
+8354	magnetized colloidal purple huge squat nursery rhyme	0		Effect: "Hot Jellied", Effect Duration: 42
 8355	unsweetened pressed twirling iron torso box	0		Effect: "Hyperoffended", Effect Duration: 39
 8356	adjusted maroon mercenary headband	0		Effect: "Strong Grip", Effect Duration: 15
 8357	liquefied yellow radioactive spider venom	0		Effect: "Stinky Hands", Effect Duration: 15
@@ -8236,7 +8236,7 @@
 8362	electrified shaking tumbling devil-summoning hat	0		Effect: "Full Bottle in front of Me", Effect Duration: 21
 8363	triple-unsweetened super-liquefied shopkeeper beard	0		Effect: "Bear Clawed", Effect Duration: 55
 8364	ionized moist alien autoautopsy kit	0		Effect: "Angry like the Wolf", Effect Duration: 19
-8365	nitrogenated aerosolized extra-activated cyan twirling novelty fruit hat	0		Effect: "Elemental Flavor", Effect Duration: 18
+8365	nitrogenated aerosolized extra-activated twirling cyan novelty fruit hat	0		Effect: "Elemental Flavor", Effect Duration: 18
 8366	unsweetened yellow invisibility cream	0		Effect: "Leash of Linguini", Effect Duration: 31
 8367	liquefied double-quantum handful of stubble	0		Effect: "Winning Smile", Effect Duration: 49
 8368	super-alkaline ionized garbage juice slurpee	0		Effect: "Creepin' Up on You", Effect Duration: 64
@@ -8249,21 +8249,21 @@
 8375	activated activated triple-polarized yellow eyebrow lifter	0		Effect: "Strawberry Alarm", Effect Duration: 32
 8376	jittery submarine	0		Last Available: "2015-06"
 8377	moldy pixel lemon	3	crappy	Last Available: "2015-06"
-8378	practically non-alcoholic mediocre pixel daiquiri	1	decent	Last Available: "2015-06"
+8378	mediocre practically non-alcoholic pixel daiquiri	1	decent	Last Available: "2015-06"
 8379	colloidal blue power pill	0		Effect: "Hombre Muerto Caminando", Effect Duration: 17, Last Available: "2015-06"
 8380	modified dry pixel potion	0		Effect: "One For Tea", Effect Duration: 66, Last Available: "2015-06"
 8381	tumbling Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	teal Deck of Every Card	0		Last Available: "2015-07"
 8383	upside-down popular part	0		
 8384	olive bubblegum heart	0		Last Available: "2015-07"
-8385	tumbling squat cubic zirconia	0		Last Available: "2015-07"
+8385	squat tumbling cubic zirconia	0		Last Available: "2015-07"
 8386	valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
-8388	squat blinking mana	0		Last Available: "2015-07"
+8388	blinking squat mana	0		Last Available: "2015-07"
 8389	mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	huge mana	0		Last Available: "2015-07"
-8392	pulsating blinking gift card	0		Last Available: "2015-07"
+8392	blinking pulsating gift card	0		Last Available: "2015-07"
 8393	twirling hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	Sherlock's The Emperor's new hat	0		Item Drop: +25, Last Available: "2015-07"
@@ -8282,17 +8282,17 @@
 8408	adjusted aerosolized ectoplasmic orbs	0		Effect: "Feet of Grapefruit", Effect Duration: 24
 8409	flavorless crudles	3	decent	
 8410	diet delicious agnolotti arboli	1	awesome	
-8411	miniature fancy decent cyan spaghetti with ghost balls	2	good	Effect: "Good with the Ladies", Effect Duration: 35
+8411	decent miniature fancy cyan spaghetti with ghost balls	2	good	Effect: "Good with the Ladies", Effect Duration: 35
 8412	miniature bland succulent marrow	2	decent	
 8413	jumbo stale salacious crumbs	5	decent	
-8414	small adequate fusilli marrownarrow	2	good	
-8415	enchanted decent suggestive strozzapreti	4	good	Effect: "Hare-o-dynamic", Effect Duration: 15
+8414	adequate small fusilli marrownarrow	2	good	
+8415	decent enchanted suggestive strozzapreti	4	good	Effect: "Hare-o-dynamic", Effect Duration: 15
 8416	Mountain Stream gastrique	0		
 8417	moldy Mt. McLargeHuge oyster	4	crappy	
 8418	mirror wobbly oyster sauce	0		
 8419	flavorless linguini immondizia bianco	4	decent	
 8420	decent shells a la shellfish	4	good	
-8421	jittery blurry Jick's autograph	0		
+8421	blurry jittery Jick's autograph	0		
 8422	shaking upside-down high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	skewed 1,970 carat	0		Last Available: "2015-08"
@@ -8315,7 +8315,7 @@
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
-8444	blue upside-down lava globs	0		Last Available: "2015-08"
+8444	upside-down blue lava globs	0		Last Available: "2015-08"
 8445	fuchsia lava globs	0		Last Available: "2015-08"
 8446	teal SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8329,13 +8329,13 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	cyan crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	hardy high-temperature mining mask of the empath	0		Maximum HP: +50, Familiar Weight: +5, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	hardy high-temperature mining mask of the empath	0		Maximum HP: +50, Familiar Weight: +5, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	flame-retardant stanky fireproof megaphone	0		Stench Spell Damage: +25, Hot Resistance: +1, Last Available: "2015-08"
 8460	super-sized spoiled mineapple	5	crappy	Last Available: "2015-08"
-8461	watered-down mediocre Gold Velvet&trade; whiskey	2	decent	Last Available: "2015-08"
+8461	mediocre watered-down Gold Velvet&trade; whiskey	2	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	awesome	Last Available: "2015-08"
 8463	stale bouncing smelted roe	4	decent	Last Available: "2015-08"
-8464	hand-crafted watered-down lavawater	2	EPIC	Last Available: "2015-08"
+8464	watered-down hand-crafted lavawater	2	EPIC	Last Available: "2015-08"
 8465	triple-ionized huge basaltamander tongue	0		Effect: "Raging Animal", Effect Duration: 43, Last Available: "2015-08"
 8466	double-paned lavalarva of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50, Cold Resistance: +5, Last Available: "2015-08"
 8467	miser's double-paned friendly lava balaclava	0		Familiar Weight: +3, Cold Resistance: +5, Meat Drop: +10, Last Available: "2015-08"
@@ -8350,9 +8350,9 @@
 8476	chilled liquid rhinestones	0		Effect: "Jawin'", Effect Duration: 56, Last Available: "2015-08"
 8477	yummy disco biscuit	3	awesome	Last Available: "2015-08"
 8478	strong drinkable Quaatorade&trade;	5	good	Last Available: "2015-08"
-8479	shaking manspreader's biker's hat of the ox of Leguizamo	0		Muscle: +20, Monster Level: 30, Last Available: "2015-08", Familiar Effect: "atk"
-8480	zippy flame-retardant medical-grade feathered headdress	0		Hot Resistance: +1, Initiative: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	zippy sinister electrician's hardhat of terror	0		Spell Damage: +10, Spooky Spell Damage: +10, Initiative: +20, Last Available: "2015-08", Familiar Effect: "atk"
+8479	shaking manspreader's biker's hat of the ox of Leguizamo	0		Muscle: +20, Monster Level: 30, Familiar Effect: "atk", Last Available: "2015-08"
+8480	zippy flame-retardant medical-grade feathered headdress	0		Hot Resistance: +1, Initiative: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	zippy sinister electrician's hardhat of terror	0		Spell Damage: +10, Spooky Spell Damage: +10, Initiative: +20, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	tumbling airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	shaking New Age hurting crystal	0		Last Available: "2015-08"
-8490	blurry wicked smooth velvet pants	0		Spell Damage: +5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	blurry wicked smooth velvet pants	0		Spell Damage: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	veiny smooth velvet shirt	0		Maximum HP: +10, Last Available: "2015-08"
 8492	smooth velvet hat of the cougar	0		Moxie: +20, Last Available: "2015-08"
 8493	upside-down hardy smooth velvet pocket square	0		Maximum HP: +50, Single Equip, Last Available: "2015-08"
@@ -8376,7 +8376,7 @@
 8502	Pener's crisps	0		Last Available: "2015-08"
 8503	signed deuce	0		Last Available: "2015-08"
 8504	Lavalos core	0		Last Available: "2015-08"
-8505	twirling squat skewed half-melted hula girl	0		Last Available: "2015-08"
+8505	twirling skewed squat half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
 8507	dehydrated gray SMOOCH coffee cup	1	good	Effect: "The Q Is Talking To You", Effect Duration: 40, Last Available: "2015-08"
 8508	flattened gray wobbly labrador cookie	0		Effect: "Stinky Hands", Effect Duration: 69, Last Available: "2015-08"
@@ -8391,28 +8391,28 @@
 8517	narrow wholesome SMOOCH bracers of temperance	0		Maximum HP Percent: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2015-08"
 8518	chaotic SMOOCH kneepads	0		Spell Critical Percent: +10, Single Equip, Last Available: "2015-08"
 8519	wizardly SMOOCH spaulders	0		Mysticality: +25, Single Equip, Last Available: "2015-08"
-8520	executive auspicious SMOOCH codpiece	0		Item Drop: +10, Meat Drop: +40, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	executive auspicious SMOOCH codpiece	0		Item Drop: +10, Meat Drop: +40, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	Tesla SMOOCH breastplate	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	blurry fused fuse	0		Last Available: "2015-08"
 8524	skewed gray superheated	0		Last Available: "2015-08"
 8525	super-sized stale lava cake	5	decent	Last Available: "2015-08"
-8526	moldy big pulsating pink slime	5	crappy	
+8526	big moldy pulsating pink slime	5	crappy	
 8527	bouncing yellow Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	rotten devil hair pasta	3	crappy	
 8530	bland spagecialetti	3	decent	
 8531	blue Salsa Libre	0		
 8532	cyan good gravy	0		
-8533	skewed yellow illicit fish sauce	0		
-8534	small enchanted adequate ghostly libertagliatelle	2	good	Effect: "Punch Another Day", Effect Duration: 5
+8533	yellow skewed illicit fish sauce	0		
+8534	small adequate enchanted ghostly libertagliatelle	2	good	Effect: "Punch Another Day", Effect Duration: 5
 8535	spoiled turkish mostaccioli	3	crappy	
-8536	bite-sized normal linguini of the sea	1	good	
+8536	normal bite-sized linguini of the sea	1	good	
 8537	irradiated boiled Hersey&trade; SMOOCH	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 68
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	half-sized moldy wobbly Fettris	2	crappy	
+8542	moldy half-sized wobbly Fettris	2	crappy	
 8543	decent fusillocybin	4	good	
 8544	stale prescription noodles	3	decent	
 8545	vaporized jittery blood-drive sticker	1	awesome	Effect: "Sticky Hands", Effect Duration: 25
@@ -8424,7 +8424,7 @@
 8551	decent snack-sized sausage without a cause	2	good	
 8552	anodized face paint	0		Effect: "Cautious Prowl", Effect Duration: 28
 8553	tolerable weak green emergency margarita	2	good	
-8554	watered-down tolerable vintage smart drink	2	good	
+8554	tolerable watered-down vintage smart drink	2	good	
 8555	a ten-percent bonus	0		
 8556	skewed Thwaitgold termite statuette	0		
 8557	wobbly The Emperor's new cookie	0		
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	miser's Lo Pan's barrel lid of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Meat Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	scandalous rosy-cheeked thinker's barrel hoop earring	0		Mysticality: +10, Maximum HP Percent: +30, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2015-09"
-8567	greedy shellacked sinister bankruptcy barrel	0		Spell Damage: +10, Damage Reduction: 7, Meat Drop: +20, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	greedy shellacked sinister bankruptcy barrel	0		Spell Damage: +10, Damage Reduction: 7, Meat Drop: +20, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	blinking firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8448,10 +8448,10 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	special tolerable maroon bottle of Amontillado	4	good	Effect: "Disco Concentration", Effect Duration: 5, Last Available: "2015-09"
+8578	tolerable special maroon bottle of Amontillado	4	good	Effect: "Disco Concentration", Effect Duration: 5, Last Available: "2015-09"
 8579	aged weak pulsating barrel-aged martini	2	awesome	Last Available: "2015-09"
 8580	adequate barrel pickle	4	good	Last Available: "2015-09"
-8581	adequate small barrel cracker	2	good	Last Available: "2015-09"
+8581	small adequate barrel cracker	2	good	Last Available: "2015-09"
 8582	vaporized vibrating mushroom	1	good	Effect: "Joy", Effect Duration: 5, Last Available: "2015-09"
 8583	altered mushroom	1	decent	Last Available: "2015-09"
 8584	educational KoL Con 12-gauge	0		Experience: +1, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	tumbling Jack Frost's barrel gun	0		Cold Spell Damage: +50, Last Available: "2015-09"
 8587	shaking barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	normal thick fancy water log	5	good	Effect: "Sealed Brain", Effect Duration: 45, Last Available: "2015-09"
+8589	thick fancy normal water log	5	good	Effect: "Sealed Brain", Effect Duration: 45, Last Available: "2015-09"
 8590	extremely unsafe Herculean barrelhead	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Last Available: "2015-09"
 8591	crafty therapeutic bottoms of the barrel	0		Maximum MP: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-09"
 8592	stanky electrified chest barrel	0		Stench Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
@@ -8478,7 +8478,7 @@
 8605	triple-frozen double-ionized mirror cuppa Improprie tea	0		Effect: "Dragged Through the Coals", Effect Duration: 65, Last Available: "2015-09"
 8606	dry lime green cuppa Frost tea	0		Effect: "Chain Chain Chains", Effect Duration: 27, Last Available: "2015-09"
 8607	warmed electrified quadruple-flattened cuppa Toast tea	0		Effect: "Bloody-minded", Effect Duration: 42, Last Available: "2015-09"
-8608	cold-filtered activated tumbling narrow cuppa Net tea	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 38, Last Available: "2015-09"
+8608	cold-filtered activated narrow tumbling cuppa Net tea	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 38, Last Available: "2015-09"
 8609	double-cold-filtered Vulcanized cuppa Proprie tea	0		Effect: "Macho Profundo", Effect Duration: 16, Last Available: "2015-09"
 8610	moist polymerized cuppa Morbidi tea	0		Effect: "Mana Tea", Effect Duration: 44, Last Available: "2015-09"
 8611	tarnished nitrogenated cuppa Chari tea	0		Effect: "Alpine Mintiness", Effect Duration: 40, Last Available: "2015-09"
@@ -8494,7 +8494,7 @@
 8621	concentrated jittery cuppa Irritabili tea	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 67, Last Available: "2015-09"
 8622	modified cuppa Mediocri tea	0		Effect: "Heart of Pink", Effect Duration: 65, Last Available: "2015-09"
 8623	triple-wet cuppa Loyal tea	0		Effect: "Abyssal Sweat", Effect Duration: 22, Last Available: "2015-09"
-8624	dried shaking fuchsia twirling cuppa Activi tea	1	crappy	Last Available: "2015-09"
+8624	dried shaking twirling fuchsia cuppa Activi tea	1	crappy	Last Available: "2015-09"
 8625	mixed cuppa Cruel tea	1		Last Available: "2015-09"
 8626	cold-filtered denatured cuppa Alacri tea	0		Effect: "Muddled", Effect Duration: 55, Last Available: "2015-09"
 8627	super-denatured moist modified cuppa Vitali tea	0		Effect: "Human-Insect Hybrid", Effect Duration: 32, Last Available: "2015-09"
@@ -8506,14 +8506,14 @@
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
-8636	concentrated super-corrupted twirling bouncing cuppa Craft tea	0		Effect: "Raging Animal", Effect Duration: 34, Last Available: "2015-09"
+8636	concentrated super-corrupted bouncing twirling cuppa Craft tea	0		Effect: "Raging Animal", Effect Duration: 34, Last Available: "2015-09"
 8637	adjusted diffused maroon cuppa Insani tea	0		Effect: "Bonelording", Effect Duration: 27, Last Available: "2015-09"
 8638	jittery electrified weightlifter's Royal scepter of the cheetah	0		Muscle: +15, Initiative: +60, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	toothsome squat bowl of eyeballs	4	awesome	Last Available: "2015-10"
 8642	toothsome bowl of mummy guts	3	awesome	Last Available: "2015-10"
-8643	miniature decent ghostly bowl of maggots	2	good	Last Available: "2015-10"
+8643	decent miniature ghostly bowl of maggots	2	good	Last Available: "2015-10"
 8644	acceptable bouncing blood and blood	4	good	Last Available: "2015-10"
 8645	tolerable Jack-O-Lantern beer	3	good	Last Available: "2015-10"
 8646	drinkable blinking zombie	3	good	Last Available: "2015-10"
@@ -8540,7 +8540,7 @@
 8667	grievous Newton's Yorick of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +3, Weapon Damage Percent: +50
 8668	upside-down blurry rose	0		
 8669	purple tulip	0		
-8670	blinking mirror tulip	0		
+8670	mirror blinking tulip	0		
 8671	tulip	0		
 8672	Walford's bucket	0		Last Available: "2015-11"
 8673	squat Wal-Mart gift certificate	0		Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	yellow The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	blinking bellhop's hat of Tarzan	0		Experience (Muscle): +3, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	fancy bad squat ice porter	3	decent	Effect: "Elbow Sauce", Effect Duration: 20, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	blinking bellhop's hat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	bad fancy squat ice porter	3	decent	Effect: "Elbow Sauce", Effect Duration: 20, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	polymerized irradiated huge exotic travel brochure	0		Effect: "Wet Rub", Effect Duration: 26, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	flattened shampoo-conditioner	0		Effect: "All Fired Up", Effect Duration: 13, Last Available: "2015-11"
@@ -8571,7 +8571,7 @@
 8698	smooth iced plum wine	4	awesome	Last Available: "2016-01"
 8699	zippy electrified experienced training belt	0		Experience: +2, Initiative: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-01"
 8700	pulsating jittery careful dangerous training legwarmers of the empath	0		Weapon Damage: +10, Monster Level: -10, Familiar Weight: +5, Single Equip, Last Available: "2016-01"
-8701	asbestos-lined educational cool training helmet	0		Moxie: +5, Experience: +1, Hot Resistance: +5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	asbestos-lined educational cool training helmet	0		Moxie: +5, Experience: +1, Hot Resistance: +5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	narrow training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	blinking training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	purple training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8583,13 +8583,13 @@
 8710	powdered shaking abstraction: sensation	1		Effect: "Cautious Prowl", Effect Duration: 40, Last Available: "2015-12"
 8711	dehydrated blinking abstraction: purpose	1		Effect: "Sharp Weapon", Effect Duration: 40, Last Available: "2015-12"
 8712	denatured abstraction: category	1		Effect: "Drenched With Filth", Effect Duration: 40, Last Available: "2015-12"
-8713	dried shaking red blinking abstraction: perception	1		Effect: "Hobonic", Effect Duration: 40, Last Available: "2015-12"
+8713	dried red blinking shaking abstraction: perception	1		Effect: "Hobonic", Effect Duration: 40, Last Available: "2015-12"
 8714	boiled blurry abstraction: motion	1		Last Available: "2015-12"
 8715	vaporized abstraction: joy	1		Effect: "Human-Humanoid Hybrid", Effect Duration: 30, Last Available: "2015-12"
 8716	compressed yellow abstraction: certainty	1		Effect: "El Vibrations", Effect Duration: 5, Last Available: "2015-12"
 8717	vaporized abstraction: comprehension	1		Effect: "Alacri Tea", Effect Duration: 30, Last Available: "2015-12"
 8718	purple modern picture frame	0		Last Available: "2015-12"
-8719	small stale VYKEA meatballs	2	decent	Last Available: "2015-11"
+8719	stale small VYKEA meatballs	2	decent	Last Available: "2015-11"
 8720	watered-down perfectly mixed skewed VYKEA mead	2	EPIC	Last Available: "2015-11"
 8721	alkaline enhanced blurry VYKEA woadpaint	0		Effect: "Coldfinger", Effect Duration: 60, Last Available: "2015-11"
 8722	olive VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8601,21 +8601,21 @@
 8728	upside-down VYKEA dowel	0		Last Available: "2015-11"
 8729	hardy Da Vinci's VYKEA hex key of the boozehound	0		Experience (Mysticality): +5, Maximum HP: +50, Booze Drop: +100, Last Available: "2015-11"
 8730	purple VYKEA instructions	0		Last Available: "2015-11"
-8731	toothsome miniature gray tin of submardines	2	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	watered-down lousy bottle of norwhiskey	2	decent	Last Available: "2015-11"
+8731	miniature toothsome gray tin of submardines	2	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	lousy watered-down bottle of norwhiskey	2	decent	Last Available: "2015-11"
 8733	boiled blurry octolus oculus	1	decent	Last Available: "2015-11"
 8734	huge knitted Herculean groovy sardine can key	0		Moxie Percent: +10, Experience (Muscle): +1, Cold Resistance: +3, Last Available: "2015-11"
-8735	pulsating jittery inspector's careful norwhal helmet of the brazier	0		Monster Level: -10, Hot Spell Damage: +25, Item Drop: +15, Last Available: "2015-11", Familiar Effect: "atk"
+8735	pulsating jittery inspector's careful norwhal helmet of the brazier	0		Monster Level: -10, Hot Spell Damage: +25, Item Drop: +15, Familiar Effect: "atk", Last Available: "2015-11"
 8736	zippy electrified octolus-skin cloak of the bloodbag	0		Maximum HP: +100, Initiative: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8737	enchanted acceptable perfect cosmopolitan	3	good	Effect: "Weapon of Mass Destruction", Effect Duration: 45, Last Available: "2015-11"
 8738	drinkable perfect negroni	3	good	Last Available: "2015-11"
-8739	practically non-alcoholic lousy cyan perfect dark and stormy	1	decent	Last Available: "2015-11"
+8739	lousy practically non-alcoholic cyan perfect dark and stormy	1	decent	Last Available: "2015-11"
 8740	hand-crafted perfect mimosa	3	EPIC	Last Available: "2015-11"
-8741	lousy enchanted jittery perfect old-fashioned	4	decent	Effect: "Cold, Dead Hands", Effect Duration: 15, Last Available: "2015-11"
-8742	lousy special watered-down perfect paloma	2	decent	Effect: "Blackberry Politeness", Effect Duration: 50, Last Available: "2015-11"
+8741	enchanted lousy jittery perfect old-fashioned	4	decent	Effect: "Cold, Dead Hands", Effect Duration: 15, Last Available: "2015-11"
+8742	lousy watered-down special perfect paloma	2	decent	Effect: "Blackberry Politeness", Effect Duration: 50, Last Available: "2015-11"
 8743	altered That 70s Cologne	0		Effect: "Liquid Luck", Effect Duration: 23, Last Available: "2015-11"
 8744	altered alkaline red Wal-Mart &quot;diamond&quot; ring	0		Effect: "Punchy, Murdery", Effect Duration: 56, Last Available: "2015-11"
-8745	extra-galvanized huge pulsating Puffstone cigar	0		Effect: "Amorous", Effect Duration: 19, Last Available: "2015-11"
+8745	extra-galvanized pulsating huge Puffstone cigar	0		Effect: "Amorous", Effect Duration: 19, Last Available: "2015-11"
 8746	warmed irradiated narrow upside-down Conspiracy&trade; mascara	0		Effect: "Spiky Frozen Hair", Effect Duration: 36, Last Available: "2015-11"
 8747	ionized triple-ionized altered yellow Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Powdered", Effect Duration: 46, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
@@ -8623,7 +8623,7 @@
 8750	energized dry narrow upside-down hemp candy necklace	0		Effect: "Eyes All Black", Effect Duration: 48, Last Available: "2015-12"
 8751	unsweetened wet non-aerosolized teal communal gobstopper	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 36, Last Available: "2015-12"
 8752	stale upside-down Crimbo salad	4	decent	Last Available: "2015-12"
-8753	low-calorie decent bread line	1	good	Last Available: "2015-12"
+8753	decent low-calorie bread line	1	good	Last Available: "2015-12"
 8754	aged weak bark rootbeer	2	awesome	Last Available: "2015-12"
 8755	acceptable ale	3	good	Last Available: "2015-12"
 8756	blinking smooth plastic Tammy the Tambourine Elf	0		Moxie: +15, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	wobbly BACON	0		Last Available: "2016-05"
 8764	spinning box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	jittery Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	strong perfectly mixed huge Gratitude chocolate (bourbon-filled)	5	EPIC	Last Available: "2016-02"
+8766	perfectly mixed strong huge Gratitude chocolate (bourbon-filled)	5	EPIC	Last Available: "2016-02"
 8767	spinning Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	spinning Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8654,7 +8654,7 @@
 8782	electrified reindeer hammer	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-12"
 8783	prompt elf ploughshare	0		Adventures: +3, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	blinking faded protest sign	0		Last Available: "2015-12"
 8788	ghostly nasty-smelling moss	0		Last Available: "2015-12"
@@ -8664,7 +8664,7 @@
 8792	face paint	0		Free Pull, Last Available: "2015-12"
 8793	face paint	0		Free Pull, Last Available: "2015-12"
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
-8795	squat yellow Batfellow comic	0		Free Pull, Last Available: "2016-12"
+8795	yellow squat Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	squat bat-oomerang	0		Last Available: "2017-01"
 8798	yellow bat-jute	0		Last Available: "2017-01"
@@ -8685,17 +8685,17 @@
 8813	green jittery glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	mirror bat-bearing	0		Last Available: "2017-01"
-8816	miniature normal Kudzu salad	2	good	Last Available: "2016-12"
-8817	mixed lime green spinning Mansquito Serum	1		Last Available: "2016-12"
+8816	normal miniature Kudzu salad	2	good	Last Available: "2016-12"
+8817	mixed spinning lime green Mansquito Serum	1		Last Available: "2016-12"
 8818	aged olive twirling Miss Graves' vermouth	3	awesome	Last Available: "2016-12"
 8819	flavorless The Plumber's mushroom stew	4	decent	Last Available: "2016-12"
 8820	mixed yellow The Author's ink	1		Effect: "Cybernetic Muscles", Effect Duration: 45, Last Available: "2016-02"
 8821	perfectly mixed The Mad Liquor	4	EPIC	Last Available: "2016-12"
 8822	smooth Doc Clock's thyme cocktail	4	awesome	Last Available: "2016-12"
-8823	diet normal Mr. Burnsger	1	good	Last Available: "2016-12"
+8823	normal diet Mr. Burnsger	1	good	Last Available: "2016-12"
 8824	distilled huge The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	MacGyver's wholesome brainy The Jokester's gun	0		Mysticality: +5, Maximum HP Percent: +10, Maximum MP: +100, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	reassuring lard-coated curative The Jokester's wig	0		Sleaze Spell Damage: +25, Spooky Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8826	reassuring lard-coated curative The Jokester's wig	0		Sleaze Spell Damage: +25, Spooky Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
 8827	narrow aromatic forbidden slick The Jokester's pants	0		Moxie: +10, Spell Damage Percent: +50, Stench Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	extra-liquefied blinking blinking Jokester makeup	0		Effect: "Magically Fingered", Effect Duration: 56, Last Available: "2016-12"
 8829	wobbly replica bat-oomerang	0		Last Available: "2016-12"
@@ -8703,8 +8703,8 @@
 8831	fuchsia basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	dry robin's egg	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 62, Last Available: "2016-12"
-8834	normal snack-sized robin flan	2	good	Last Available: "2016-12"
-8835	lousy weak robin nog	2	decent	Last Available: "2016-12"
+8834	snack-sized normal robin flan	2	good	Last Available: "2016-12"
+8835	weak lousy robin nog	2	decent	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	mirror blurry plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8718,7 +8718,7 @@
 8846	double-irradiated Vulcanized tube of pendulum lube	0		Effect: "Gemini Rising", Effect Duration: 46
 8847	boiled bouncing red-hot jawbreaker	0		Effect: "Loyal Tea", Effect Duration: 50
 8848	tarnished question juice	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 41
-8849	modified anodized blurry cyan tube of villain	0		Effect: "Mighty Shout", Effect Duration: 19
+8849	modified anodized cyan blurry tube of villain	0		Effect: "Mighty Shout", Effect Duration: 19
 8850	your cowboy boots of the storm	0		Maximum MP Percent: +40, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
@@ -8745,20 +8745,20 @@
 8873	Pork 'n' Pork 'n' Pork 'n' Beans of the early riser	0		Adventures: +7, Last Available: "2016-02"
 8874	avaricious frightening smelly beefcake's beefy Val-U Brand Every Bean Salad	0		Muscle: 35, Stench Spell Damage: +10, Spooky Damage: +5, Meat Drop: +30, Last Available: "2016-02"
 8875	mirror clever stiffened Shrub's Premium Baked Beans of Leguizamo	0		Damage Reduction: 1, Maximum MP: +20, Monster Level: +20, Last Available: "2016-02"
-8876	super-sized adequate twirling plate of Heimz Fortified Kidney Beans	5	good	Last Available: "2016-02"
-8877	fancy normal plate of Tesla's Electroplated Beans	4	good	Effect: "Slightly Larger Than Usual", Effect Duration: 5, Last Available: "2016-02"
-8878	toothsome snack-sized plate of Mixed Garbanzos and Chickpeas	2	awesome	Last Available: "2016-02"
+8876	adequate super-sized twirling plate of Heimz Fortified Kidney Beans	5	good	Last Available: "2016-02"
+8877	normal fancy plate of Tesla's Electroplated Beans	4	good	Effect: "Slightly Larger Than Usual", Effect Duration: 5, Last Available: "2016-02"
+8878	snack-sized toothsome plate of Mixed Garbanzos and Chickpeas	2	awesome	Last Available: "2016-02"
 8879	low-calorie flavorless plate of Hellfire Spicy Beans	1	decent	Last Available: "2016-02"
-8880	half-sized fancy stale plate of Frigid Northern Beans	2	decent	Effect: "Ack!  Barred!", Effect Duration: 40, Last Available: "2016-02"
+8880	stale fancy half-sized plate of Frigid Northern Beans	2	decent	Effect: "Ack!  Barred!", Effect Duration: 40, Last Available: "2016-02"
 8881	flavorless plate of World's Blackest-Eyed Peas	4	decent	Last Available: "2016-02"
 8882	normal plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
-8883	huge flavorless plate of Pork 'n' Pork 'n' Pork 'n' Beans	6	decent	Last Available: "2016-02"
+8883	flavorless huge plate of Pork 'n' Pork 'n' Pork 'n' Beans	6	decent	Last Available: "2016-02"
 8884	moldy plate of Val-U Brand Every Bean Salad	4	crappy	Last Available: "2016-02"
 8885	big stale plate of Shrub's Premium Baked Beans	5	decent	Last Available: "2016-02"
 8886	Jim Carey's baleful Fancy Jeff's pocket square	0		Spell Damage: +25, Monster Level: +25, Last Available: "2016-02"
-8887	skewed censurious baleful beefy Daisy's unclean bloomers	0		Muscle: +10, Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	skewed censurious baleful beefy Daisy's unclean bloomers	0		Muscle: +10, Spell Damage: +25, Sleaze Resistance: +3, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	olive healthy supercool Amoon-Ra Cowtep's nemes of mayonnaise	0		Moxie Percent: +20, Maximum HP Percent: +20, Sleaze Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	olive healthy supercool Amoon-Ra Cowtep's nemes of mayonnaise	0		Moxie Percent: +20, Maximum HP Percent: +20, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	green Glenn's dice	0		Last Available: "2016-02"
 8891	Usain Bolt's steel-toed shellacked deadly Former Sheriff Dan's tin star of the sweet-tooth	0		Weapon Damage: +5, Damage Reduction: 32, Candy Drop: +100, Initiative: +80, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8850,7 +8850,7 @@
 8978	pressed patent aggression tonic	0		Effect: "Chilblains of the Corn", Effect Duration: 54
 8979	pressed double-dry lime green patent sallowness tonic	0		Effect: "Bread-Lined", Effect Duration: 48
 8980	frozen patent avarice tonic	0		Effect: "Kissed By Fire", Effect Duration: 67
-8981	galvanized blurry twirling lime green patent alacrity tonic	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 43
+8981	galvanized twirling lime green blurry patent alacrity tonic	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 43
 8982	energized corrupted marrow	0		Effect: "The Dinsey Spirit", Effect Duration: 31
 8983	acceptable squat rodeo whiskey	4	good	
 8984	Thwaitgold scorpion statuette	0		
@@ -8867,12 +8867,12 @@
 8995	unsweetened alkaline lime green Greek fire	0		Effect: "Worth Your Salt", Effect Duration: 53, Last Available: "2016-03"
 8996	jittery zippy frosty Tesla resourceful savvy ox-head shield	0		Mysticality Percent: +20, Maximum MP: +50, Cold Spell Damage: +10, Initiative: +20, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	blurry auspicious sizzling wholesome dented scepter of the blizzard of the sweet-tooth	0		Maximum HP Percent: +10, Cold Spell Damage: +25, Hot Damage: +10, Item Drop: +10, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	Usain Bolt's foul-smelling nippy crafty Newton's very pointy crown	0		Experience (Mysticality): +3, Maximum MP: +10, Cold Damage: +10, Stench Damage: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	Usain Bolt's foul-smelling nippy crafty Newton's very pointy crown	0		Experience (Mysticality): +3, Maximum MP: +10, Cold Damage: +10, Stench Damage: +10, Initiative: +80, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	Van der Graaf therapeutic veiny sinister battle broom of incineration	0		Spell Damage: +10, Maximum HP: +10, Hot Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	blinking Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	red rosy-cheeked shellacked carpe of James Dean of the overflowing toilet	0		Experience (Moxie): +3, Damage Reduction: 7, Maximum HP Percent: +30, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04"
 9002	squat lightning-fast fireproof scorching codpiece of the detective	0		Hot Damage: +25, Hot Resistance: +3, Item Drop: +20, Initiative: +40, Lasts Until Rollover, Last Available: "2016-04"
-9003	frosty beefcake's troutsers of Tarzan of Leguizamo	0		Muscle: +25, Experience (Muscle): +3, Monster Level: +20, Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	frosty beefcake's troutsers of Tarzan of Leguizamo	0		Muscle: +25, Experience (Muscle): +3, Monster Level: +20, Cold Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	scorching sharpshooter's resourceful sinister bass clarinet	0		Spell Damage: +10, Maximum MP: +50, Critical Hit Percent: +10, Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9005	zippy flame-retardant mansplainer's fish hatchet of dire peril	0		Weapon Damage: +20, Monster Level: +15, Hot Resistance: +1, Initiative: +20, Lasts Until Rollover, Last Available: "2016-04"
 9006	miser's smelly tunac of the pedagogue of the cheetah	0		Experience: +3, Stench Spell Damage: +10, Meat Drop: +10, Initiative: +60, Lasts Until Rollover, Last Available: "2016-04"
@@ -8904,8 +8904,8 @@
 9032	snack-sized stale bowl of Tastee-Wheet&trade;	2	decent	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	upside-down Source essence	0		Last Available: "2016-06"
-9035	moldy snack-sized browser cookie	2	crappy	Last Available: "2016-06"
-9036	acceptable bouncing wobbly hacked gibson	3	good	Last Available: "2016-06"
+9035	snack-sized moldy browser cookie	2	crappy	Last Available: "2016-06"
+9036	acceptable wobbly bouncing hacked gibson	3	good	Last Available: "2016-06"
 9037	narrow lion tamer's Source shades	0		Experience (familiar): +2, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8936,7 +8936,7 @@
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
-9067	tumbling jittery jittery pill	0		Last Available: "2016-06"
+9067	jittery tumbling jittery pill	0		Last Available: "2016-06"
 9068	prompt stanky hardened strapping plastic detective badge	0		Muscle: +5, Damage Reduction: 3, Stench Spell Damage: +25, Adventures: +3, Last Available: "2016-07"
 9069	gray mirror frightening dangerous beefy bronze detective badge of the brazier	0		Muscle: +10, Weapon Damage: +10, Hot Spell Damage: +25, Spooky Damage: +5, Last Available: "2016-07"
 9070	pulsating occult boxer's beefcake's detective badge of the sewer	0		Muscle: +25, Muscle Percent: +10, Spell Damage Percent: +25, Stench Damage: +25, Last Available: "2016-07"
@@ -8947,8 +8947,8 @@
 9075	galvanized cold-filtered shoe gum	0		Effect: "Blood-Rich", Effect Duration: 22, Last Available: "2016-07"
 9076	ruddy forbidden noir fedora of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Maximum HP Percent: +40, Last Available: "2016-07"
 9077	Jeselnik's hardy quilted trench coat	0		Damage Absorption: +40, Maximum HP: +50, Sleaze Damage: +25, Last Available: "2016-07"
-9078	aged fancy Falcon&trade; Maltese Liquor	3	awesome	Effect: "Experimental Effect G-9", Effect Duration: 5, Last Available: "2016-07"
-9079	miniature moldy special hardboiled egg	2	crappy	Effect: "Improprie Tea", Effect Duration: 50, Last Available: "2016-07"
+9078	fancy aged Falcon&trade; Maltese Liquor	3	awesome	Effect: "Experimental Effect G-9", Effect Duration: 5, Last Available: "2016-07"
+9079	miniature special moldy hardboiled egg	2	crappy	Effect: "Improprie Tea", Effect Duration: 50, Last Available: "2016-07"
 9080	twirling detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	prompt nasty Jack Frost's wicked beefy protonic accelerator pack of the blizzard	0		Muscle: +10, Spell Damage: +5, Cold Spell Damage: 75, Stench Damage: +5, Adventures: +3, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	flame-retardant Mr. Screege's spectacles	0		Hot Resistance: +1, Single Equip, Last Available: "2016-08"
 9092	ribald therapeutic Spookyraven signet of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2016-08"
 9093	rosewater-soaked tie-dyed fannypack of chilblains	0		Cold Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2016-08"
-9094	skewed burnt snowpants of chilblains of the businessman	0		Cold Damage: +25, Meat Drop: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9094	skewed burnt snowpants of chilblains of the businessman	0		Cold Damage: +25, Meat Drop: +50, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
 9095	blinking upside-down deadly standards and practices guide	0		Weapon Damage: +5, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	hale Herculean Carpathian longsword of the cougar	0		Moxie: +20, Experience (Muscle): +1, Maximum HP: +20, Last Available: "2016-08"
 9097	squat stanky coward's hale Liam's mail	0		Maximum HP: +20, Monster Level: -20, Stench Spell Damage: +25, Last Available: "2016-08"
@@ -8995,41 +8995,41 @@
 9123	bouncing School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	yellow droppable microphone	0		
-9126	irresponsibly strong delicious unidentified drink	8	awesome	
+9126	delicious irresponsibly strong unidentified drink	8	awesome	
 9127	KoL Con 13 T-shirt of the storm of the businessman	0		Maximum MP Percent: +40, Meat Drop: +50
 9128	inspector's Temple Grandin's discarded swimming trunks of the brazier	0		Familiar Weight: +7, Hot Spell Damage: +25, Item Drop: +15
 9129	galvanized double-magnetized bouncing spinning diluted makeup	0		Effect: "Beta Carotene Overdose", Effect Duration: 33
 9130	liquefied charisma potion	0		Effect: "Mer-kinny Flavor", Effect Duration: 13
 9131	extremely confusing manual	0		
 9132	hardened pistol of the early riser	0		Damage Reduction: 3, Adventures: +7
-9133	ghostly skewed KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	tasty tiny leftover pasty	1	awesome	
-9135	high-proof hand-crafted very whiskey	9	EPIC	
+9133	skewed ghostly KoL Con 13 snowglobe	0		Last Available: "2016-10"
+9134	tiny tasty leftover pasty	1	awesome	
+9135	hand-crafted high-proof very whiskey	9	EPIC	
 9136	shaking li'l orphan tot	0		Free Pull, Last Available: "2016-10"
-9137	ghostly shaking li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	blinking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	teal li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9146	concentrated blinking bouncing hoarded candy wad	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 45, Last Available: "2016-10"
+9137	shaking ghostly li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	blinking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	teal li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9146	concentrated bouncing blinking hoarded candy wad	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 45, Last Available: "2016-10"
 9147	boiled quadruple-anodized concentrated Prunets	0		Effect: "Devil Inside", Effect Duration: 62
 9148	Twitching Television Tattoo	0		
 9149	teal baby scorpion	0		Familiar Weight: +10
 9150	pressed twirling fuchsia invisible string	0		Lasts Until Rollover, Effect: "Your Eyes are Peeled!", Effect Duration: 62, Last Available: "2016-10"
-9151	flattened pickled spinning fuchsia invisible seam ripper	0		Lasts Until Rollover, Effect: "Blackberry Politeness", Effect Duration: 41, Last Available: "2016-10"
-9152	skewed li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9151	flattened pickled fuchsia spinning invisible seam ripper	0		Lasts Until Rollover, Effect: "Blackberry Politeness", Effect Duration: 41, Last Available: "2016-10"
+9152	skewed li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	delicious raw sweet potato	3	awesome	Last Available: "2016-11"
 9154	spoiled raw beans	4	crappy	Last Available: "2016-11"
 9155	adequate miniature raw stuffing	2	good	Last Available: "2016-11"
 9156	flavorless snack-sized raw cranberry sauce	2	decent	Last Available: "2016-11"
-9157	miniature normal blurry jittery raw turkey	2	good	Last Available: "2016-11"
+9157	normal miniature jittery blurry raw turkey	2	good	Last Available: "2016-11"
 9158	tasty raw mincemeat	3	awesome	Last Available: "2016-11"
 9159	delicious narrow raw potato	3	awesome	Last Available: "2016-11"
-9160	half-sized flavorless raw gravy	2	decent	Last Available: "2016-11"
+9160	flavorless half-sized raw gravy	2	decent	Last Available: "2016-11"
 9161	spoiled raw bread	3	crappy	Last Available: "2016-11"
 9162	scorching extremely unsafe mini-marshmallow dispenser	0		Weapon Damage Percent: +100, Hot Damage: +25, Last Available: "2016-11"
 9163	dog trainer's hale glass casserole dish of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +20, Experience (familiar): +1, Last Available: "2016-11"
@@ -9040,16 +9040,16 @@
 9168	twirling potato masher of the pedagogue of the early riser	0		Experience: +3, Adventures: +7, Last Available: "2016-11"
 9169	narrow gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	stale super-sized sweet potatoes	5	decent	Last Available: "2016-11"
-9172	rotten tiny bean casserole	1	crappy	Last Available: "2016-11"
+9171	super-sized stale sweet potatoes	5	decent	Last Available: "2016-11"
+9172	tiny rotten bean casserole	1	crappy	Last Available: "2016-11"
 9173	tasty baked stuffing	4	awesome	Last Available: "2016-11"
-9174	snack-sized spoiled cranberry cylinder	2	crappy	Last Available: "2016-11"
+9174	spoiled snack-sized cranberry cylinder	2	crappy	Last Available: "2016-11"
 9175	spoiled enchanted thanksgiving turkey	3	crappy	Effect: "Very Clean Guns", Effect Duration: 15, Last Available: "2016-11"
 9176	rotten tumbling mince pie	3	crappy	Last Available: "2016-11"
 9177	moldy mashed potatoes	4	crappy	Last Available: "2016-11"
-9178	delicious snack-sized blue warm gravy	2	awesome	Last Available: "2016-11"
+9178	snack-sized delicious blue warm gravy	2	awesome	Last Available: "2016-11"
 9179	diet moldy bouncing bread roll	1	crappy	Last Available: "2016-11"
-9180	big bland leftovers	5	decent	Last Available: "2016-11"
+9180	bland big leftovers	5	decent	Last Available: "2016-11"
 9181	bland yellow leftovers sandwich	4	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9063,7 +9063,7 @@
 9191	ionized eldritch concentrate	0		Effect: "Coated Arms", Effect Duration: 25, Last Available: "2016-11"
 9192	tolerable pulsating eldritch extract	3	good	Last Available: "2016-11"
 9193	Newton's Official Council Aide Pin of the brazier	0		Experience (Mysticality): +3, Hot Spell Damage: +25, Last Available: "2016-11"
-9194	weak acceptable eldritch distillate	2	good	Last Available: "2016-11"
+9194	acceptable weak eldritch distillate	2	good	Last Available: "2016-11"
 9195	dried teal shaking eldritch essence	1		Last Available: "2016-11"
 9196	squat Newton's Science Notebook	0		Experience (Mysticality): +3
 9197	ghostly gravedigger's groovy weightlifter's eldritch hat	0		Muscle: +15, Moxie Percent: +10, Spooky Damage: +10, Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	narrow sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	bland special half-sized animal part cracker	2	decent	Effect: "All Branned Up", Effect Duration: 15, Last Available: "2016-12"
+9219	half-sized special bland animal part cracker	2	decent	Effect: "All Branned Up", Effect Duration: 15, Last Available: "2016-12"
 9220	mediocre jittery gingerbread wine	3	decent	Last Available: "2016-12"
 9221	flavorless gingerbread mug	4	decent	Last Available: "2016-12"
 9222	gingerbread mask of Flo-Jo	0		Initiative: +100, Last Available: "2016-12"
@@ -9110,7 +9110,7 @@
 9238	huge gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	boozy delicious blurry ginger beer	5	awesome	Last Available: "2016-12"
 9240	ghostly spare chocolate parts	0		Last Available: "2016-12"
-9241	cold-filtered double-pickled blue mirror industrial frosting	0		Effect: "Space Cadet", Effect Duration: 34, Last Available: "2016-12"
+9241	cold-filtered double-pickled mirror blue industrial frosting	0		Effect: "Space Cadet", Effect Duration: 34, Last Available: "2016-12"
 9242	anodized fake cocktail	0		Effect: "Mer-kinny Flavor", Effect Duration: 64, Last Available: "2016-12"
 9243	hand-crafted high-end ginger wine	3	EPIC	Last Available: "2016-12"
 9244	skewed miser's plastic bad vibe	0		Meat Drop: +10, Last Available: "2016-12"
@@ -9123,11 +9123,11 @@
 9251	extra-alkaline Inner Truth	0		Effect: "Broberry Brotality", Effect Duration: 17, Last Available: "2016-12"
 9252	toothsome jittery spiritual candy cane	3	awesome	Last Available: "2016-12"
 9253	irresponsibly strong perfectly mixed spiritual eggnog	7	EPIC	Last Available: "2016-12"
-9254	adequate tiny fuchsia spiritual fruitcake	1	good	Last Available: "2016-12"
+9254	tiny adequate fuchsia spiritual fruitcake	1	good	Last Available: "2016-12"
 9255	small normal spiritual gingerbread	2	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	upside-down chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
-9258	pulsating cyan My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
+9258	cyan pulsating My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	mirror No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
@@ -9161,16 +9161,16 @@
 9289	shellacked banded Uncle Crimbo's hat	0		Damage Absorption: +100, Damage Reduction: 7, Item Drop: +5, Last Available: "2016-12"
 9290	decent Eldritch snap	3	good	Last Available: "2017-01"
 9291	modified blurry hot jelly	1		Effect: "Empathy", Effect Duration: 20, Last Available: "2017-01"
-9292	mixed blue skewed jelly	1		Last Available: "2017-01"
-9293	dehydrated ghostly wobbly jelly	1		Effect: "Sleazy Jellied", Effect Duration: 25, Last Available: "2017-01"
+9292	mixed skewed blue jelly	1		Last Available: "2017-01"
+9293	dehydrated wobbly ghostly jelly	1		Effect: "Sleazy Jellied", Effect Duration: 25, Last Available: "2017-01"
 9294	vaporized tumbling sleaze jelly	1		Last Available: "2017-01"
 9295	distilled squat stench jelly	1		Last Available: "2017-01"
 9296	gray space planula	0		Free Pull, Last Available: "2017-01"
 9297	spoiled toast with hot jelly	3	crappy	Last Available: "2017-01"
 9298	moldy skewed toast with jelly	4	crappy	Last Available: "2017-01"
-9299	moldy diet toast with jelly	1	crappy	Last Available: "2017-01"
-9300	decent snack-sized twirling twirling toast with sleaze jelly	2	good	Last Available: "2017-01"
-9301	super-sized stale toast with stench jelly	5	decent	Last Available: "2017-01"
+9299	diet moldy toast with jelly	1	crappy	Last Available: "2017-01"
+9300	snack-sized decent twirling twirling toast with sleaze jelly	2	good	Last Available: "2017-01"
+9301	stale super-sized toast with stench jelly	5	decent	Last Available: "2017-01"
 9302	ghostly space jellybicycle	0		Familiar Weight: +5
 9303	gray hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	upside-down pewter candlestick	0		Familiar Weight: +10
@@ -9186,13 +9186,13 @@
 9314	lime green crushed steamer trunk	0		Last Available: "2017-01"
 9315	bouncing perfumed recovered cufflinks	0		Stench Resistance: +5, Single Equip, Last Available: "2017-01"
 9316	pulsating heart-shaped crate	0		Free Pull, Last Available: "2017-02"
-9317	anodized alkaline tumbling teal shaking LOV Elixir #3	0		Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2017-02"
+9317	anodized alkaline teal tumbling shaking LOV Elixir #3	0		Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2017-02"
 9318	aerosolized pulsating skewed LOV Elixir #6	0		Effect: "Corona de la Salsa", Effect Duration: 58, Last Available: "2017-02"
-9319	dry non-dry pulsating lime green LOV Elixir #9	0		Effect: "Walberg's Dim Bulb", Effect Duration: 56, Last Available: "2017-02"
+9319	dry non-dry lime green pulsating LOV Elixir #9	0		Effect: "Walberg's Dim Bulb", Effect Duration: 56, Last Available: "2017-02"
 9320	upside-down auspicious stiffened LOV Eardigan of the glutton	0		Damage Reduction: 1, Item Drop: +10, Food Drop: +100, Lasts Until Rollover, Last Available: "2017-02"
 9321	miser's fireproof LOV Epaulettes of Flo-Jo	0		Hot Resistance: +3, Meat Drop: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2017-02"
 9322	frosty LOV Earrings of the empath of the boozehound	0		Familiar Weight: +5, Cold Spell Damage: +10, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
-9323	skewed maroon twirling LOV Enamorang	0		Last Available: "2017-02"
+9323	twirling skewed maroon LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	denatured huge LOV Echinacea Bouquet	1		Last Available: "2017-02"
@@ -9202,7 +9202,7 @@
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	supercharged veiny smooth eldritch hammer	0		Moxie: +15, Maximum HP: +10, Maximum MP Percent: +30, Last Available: "2017-01"
 9332	decent jumbo eldritch mushroom	5	good	Last Available: "2017-03"
-9333	cyan twirling pulsating eldritch ichor	0		
+9333	pulsating cyan twirling eldritch ichor	0		
 9334	spoiled diet eldritch mushroom pizza	1	crappy	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9234,36 +9234,36 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	pulsating slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
-9365	bad watered-down literal grasshopper	2	decent	Last Available: "2017-03"
-9366	bad high-proof double entendre	6	decent	Last Available: "2017-03"
+9365	watered-down bad literal grasshopper	2	decent	Last Available: "2017-03"
+9366	high-proof bad double entendre	6	decent	Last Available: "2017-03"
 9367	practically non-alcoholic perfectly mixed Phlegethon	1	EPIC	Last Available: "2017-03"
 9368	practically non-alcoholic lousy Siberian sunrise	1	decent	Last Available: "2017-03"
 9369	tolerable mentholated wine	4	good	Last Available: "2017-03"
 9370	bad low tide martini	4	decent	Last Available: "2017-03"
 9371	bad shroomtini	4	decent	Last Available: "2017-03"
 9372	enchanted artisanal morning dew	4	EPIC	Effect: "Ruthlessly Efficient", Effect Duration: 50, Last Available: "2017-03"
-9373	weak artisanal whiskey squeeze	2	EPIC	Last Available: "2017-03"
-9374	artisanal fuchsia huge great fashioned	3	EPIC	Last Available: "2017-03"
+9373	artisanal weak whiskey squeeze	2	EPIC	Last Available: "2017-03"
+9374	artisanal huge fuchsia great fashioned	3	EPIC	Last Available: "2017-03"
 9375	drinkable practically non-alcoholic tumbling Gnomish sagngria	1	good	Last Available: "2017-03"
 9376	drinkable vodka stinger	4	good	Last Available: "2017-03"
 9377	weak acceptable extremely slippery nipple	2	good	Last Available: "2017-03"
-9378	artisanal irresponsibly strong upside-down blue piscatini	9	EPIC	Last Available: "2017-03"
+9378	irresponsibly strong artisanal upside-down blue piscatini	9	EPIC	Last Available: "2017-03"
 9379	perfectly mixed boozy bouncing Churchill	5	EPIC	Last Available: "2017-03"
 9380	hand-crafted soilzerac	3	EPIC	Last Available: "2017-03"
 9381	artisanal spinning London frog	3	EPIC	Last Available: "2017-03"
-9382	practically non-alcoholic lousy nothingtini	1	decent	Last Available: "2017-03"
+9382	lousy practically non-alcoholic nothingtini	1	decent	Last Available: "2017-03"
 9383	hand-crafted eighth plague	3	EPIC	Last Available: "2017-03"
-9384	strong hand-crafted single entendre	5	EPIC	Last Available: "2017-03"
+9384	hand-crafted strong single entendre	5	EPIC	Last Available: "2017-03"
 9385	delicious shaking reverse Tantalus	4	awesome	Last Available: "2017-03"
 9386	acceptable elemental caipiroska	3	good	Last Available: "2017-03"
-9387	hand-crafted weak Feliz Navidad	2	EPIC	Last Available: "2017-03"
+9387	weak hand-crafted Feliz Navidad	2	EPIC	Last Available: "2017-03"
 9388	lousy irresponsibly strong blurry Bloody Nora	6	decent	Last Available: "2017-03"
 9389	artisanal irresponsibly strong moreltini	8	EPIC	Last Available: "2017-03"
-9390	lousy irresponsibly strong hell in a bucket	7	decent	Last Available: "2017-03"
-9391	hand-crafted ghostly teal narrow Newark	4	EPIC	Last Available: "2017-03"
+9390	irresponsibly strong lousy hell in a bucket	7	decent	Last Available: "2017-03"
+9391	hand-crafted narrow teal ghostly Newark	4	EPIC	Last Available: "2017-03"
 9392	mediocre tumbling R'lyeh	4	decent	Last Available: "2017-03"
 9393	tolerable special extra-dry blurry Gnollish sangria	5	good	Effect: "Tingling Feeling", Effect Duration: 35, Last Available: "2017-03"
-9394	drinkable watered-down vodka barracuda	2	good	Last Available: "2017-03"
+9394	watered-down drinkable vodka barracuda	2	good	Last Available: "2017-03"
 9395	hand-crafted fuchsia Mysterious Island iced tea	4	EPIC	Last Available: "2017-03"
 9396	lousy watered-down lime green drive-by shooting	2	decent	Last Available: "2017-03"
 9397	acceptable jittery gunner's daughter	4	good	Last Available: "2017-03"
@@ -9284,7 +9284,7 @@
 9412	ghostly alien gemstone	0		Last Available: "2017-04"
 9413	pulsating geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	moldy miniature wobbly edible alien plant bit	2	crappy	Last Available: "2017-04"
+9415	miniature moldy wobbly edible alien plant bit	2	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9301,8 +9301,8 @@
 9429	pulsating alien animal milk	0		Last Available: "2017-04"
 9430	gray spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
-9432	electrified upside-down blue alien medicine	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 34, Last Available: "2017-04"
-9433	stale diet pulsating cyan alien salad	1	decent	Last Available: "2017-04"
+9432	electrified blue upside-down alien medicine	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 34, Last Available: "2017-04"
+9433	diet stale pulsating cyan alien salad	1	decent	Last Available: "2017-04"
 9434	mediocre green alien booze	3	decent	Last Available: "2017-04"
 9435	gray nippy Herculean alien mask of the blizzard	0		Experience (Muscle): +1, Cold Damage: +10, Cold Spell Damage: +25, Last Available: "2017-04"
 9436	lime green toasty Sinatra's alien spear of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Hot Damage: +5, Last Available: "2017-04"
@@ -9343,7 +9343,7 @@
 9471	pulsating knitted personal trainer's Spacegate diplomat's insignia of the detective	0		Experience Percent (Muscle): +10, Cold Resistance: +3, Item Drop: +20, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	decent enchanted cyan alien sandwich	3	good	Effect: "Improprie Tea", Effect Duration: 10, Last Available: "2017-04"
+9474	enchanted decent cyan alien sandwich	3	good	Effect: "Improprie Tea", Effect Duration: 10, Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	irradiated tarnished upside-down Spant eggs	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 35
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9351,11 +9351,11 @@
 9479	concentrated alkaline bouncing Daily Affirmation: Always be Collecting	0		Effect: "Full of Wist", Effect Duration: 28, Last Available: "2017-05"
 9480	corrupted modified blinking Daily Affirmation: Think Win-Lose	0		Effect: "Less Pervious", Effect Duration: 20, Last Available: "2017-05"
 9481	adjusted non-pressed polarized Daily Affirmation: Be Superficially interested	0		Effect: "Salamanderenity", Effect Duration: 58, Last Available: "2017-05"
-9482	pickled dry spinning bouncing Daily Affirmation: Adapt to Change Eventually	0		Effect: "The Halls of Moxiousness", Effect Duration: 16, Last Available: "2017-05"
+9482	pickled dry bouncing spinning Daily Affirmation: Adapt to Change Eventually	0		Effect: "The Halls of Moxiousness", Effect Duration: 16, Last Available: "2017-05"
 9483	corrupted boiled Daily Affirmation: Be a Mind Master	0		Effect: "Mucilaginous Muscle", Effect Duration: 60, Last Available: "2017-05"
 9484	polarized narrow Daily Affirmation: Work For Hours a Week	0		Effect: "The Two-Prong Crown", Effect Duration: 23, Last Available: "2017-05"
 9485	double-wet corrupted blinking Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Sizzling with Fury", Effect Duration: 44, Last Available: "2017-05"
-9486	enchanted decent Affirmation Cookie	4	good	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 5, Last Available: "2017-05"
+9486	decent enchanted Affirmation Cookie	4	good	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 5, Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
@@ -9363,8 +9363,8 @@
 9491	maroon Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	fuchsia aromatic cool Kremlin's Greatest Briefcase of Leguizamo	0		Moxie: +5, Monster Level: +20, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	acceptable spinning spinning bouncing basic martini	4	good	Last Available: "2017-06"
-9495	hand-crafted watered-down improved martini	2	EPIC	Last Available: "2017-06"
+9494	acceptable bouncing spinning spinning basic martini	4	good	Last Available: "2017-06"
+9495	watered-down hand-crafted improved martini	2	EPIC	Last Available: "2017-06"
 9496	tolerable splendid martini	3	good	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	tumbling can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	delicious meteoreo	3	awesome	Last Available: "2017-08"
-9515	lousy weak upside-down meadeorite	2	decent	Last Available: "2017-08"
+9515	weak lousy upside-down meadeorite	2	decent	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	Jeselnik's meteortarboard of temperance of the businessman	0		Sleaze Damage: +25, Sleaze Resistance: +5, Meat Drop: +50, Last Available: "2017-08"
 9518	occult meteorite guard of Calamity Jane of the businessman	0		Spell Damage Percent: +25, Critical Hit Percent: +15, Meat Drop: +50, Damage Reduction: 9, Last Available: "2017-08"
-9519	Oprah's padded meteorb	0		Damage Absorption: +20, Maximum MP Percent: +50, Last Available: "2017-08", Lantern Element: "Hot"
+9519	Oprah's padded meteorb	0		Damage Absorption: +20, Maximum MP Percent: +50, Lantern Element: "Hot", Last Available: "2017-08"
 9520	vibrating grievous asteroid belt	0		Weapon Damage Percent: +50, Maximum MP Percent: +10, Single Equip, Last Available: "2017-08"
 9521	lightning-fast energetic beefy meteorthopedic shoes	0		Muscle: +10, Maximum MP Percent: +20, Initiative: +40, Single Equip, Last Available: "2017-08"
 9522	twirling lightning-fast hardened Socratic shooting morning star	0		Experience (Mysticality): +1, Damage Reduction: 3, Initiative: +40, Single Equip, Last Available: "2017-08"
@@ -9413,12 +9413,12 @@
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	twirling exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
-9544	squat maroon O	0		Last Available: "2017-10"
+9544	maroon squat O	0		Last Available: "2017-10"
 9545	artisanal weak DUFRESNE Suds	2	EPIC	Last Available: "2017-09"
 9546	narrow aromatic fireproof mafia pinky ring	0		Hot Resistance: +3, Stench Resistance: +1, Single Equip
 9547	bad lime green flask of port	3	decent	
 9548	mirror frosty dance instructor's contract enforcement stick	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10
-9549	tasty special Hide-rox&trade; cookie	4	awesome	Effect: "Retrograde Relaxation", Effect Duration: 50, Last Available: "2017-10"
+9549	special tasty Hide-rox&trade; cookie	4	awesome	Effect: "Retrograde Relaxation", Effect Duration: 50, Last Available: "2017-10"
 9550	practically non-alcoholic perfectly mixed teal jug of booze	1	EPIC	Last Available: "2017-10"
 9551	energized blinking pair of candy glasses	0		Effect: "Motion", Effect Duration: 35, Last Available: "2017-10"
 9552	magnetized wet shaking temporary X tattoos	0		Effect: "Slightly Larger Than Usual", Effect Duration: 24, Last Available: "2017-10"
@@ -9428,9 +9428,9 @@
 9556	bouncing bridge truss	0		Last Available: "2017-10"
 9557	spinning foul-smelling pearl necklace of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Stench Damage: +10, Single Equip, Last Available: "2017-10"
 9558	amorphous blob	0		Last Available: "2017-11"
-9559	ghostly yellow X	0		Last Available: "2017-11"
+9559	yellow ghostly X	0		Last Available: "2017-11"
 9560	O	0		Last Available: "2017-11"
-9561	blue mirror squat amorphous blob	0		Last Available: "2017-11"
+9561	mirror blue squat amorphous blob	0		Last Available: "2017-11"
 9562	Usain Bolt's dog trainer's chaotic crafty protection stick	0		Maximum MP: +10, Spell Critical Percent: +10, Experience (familiar): +1, Initiative: +80
 9563	improved corrupted yellow roll of meat	0		Effect: "Chief Executive Optimism", Effect Duration: 36
 9564	bouncing resourceful mafia thumb ring of the early riser	0		Maximum MP: +50, Adventures: +7, Single Equip
@@ -9446,11 +9446,11 @@
 9574	pantogram pants	0		Lasts Until Rollover, Last Available: "2017-11"
 9575	friendly mafia wedding ring of bravery	0		Familiar Weight: +3, Spooky Resistance: +5, Single Equip
 9576	gray foul-smelling mafia organizer badge	0		Stench Damage: +10, Single Equip
-9577	green ghostly mafia filofax	0		
+9577	ghostly green mafia filofax	0		
 9578	transparent nog	1	good	Last Available: "2017-12"
 9579	delicious massive unfinished fruitcake	7	awesome	Last Available: "2017-12"
 9580	improved shaking pulsating and cracker	0		Effect: "Broken Fast", Effect Duration: 23, Last Available: "2017-12"
-9581	tolerable weak neg grog	2	good	Last Available: "2017-12"
+9581	weak tolerable neg grog	2	good	Last Available: "2017-12"
 9582	tiny toothsome half double fruitcake	1	awesome	Last Available: "2017-12"
 9583	bland hushed puppy	3	decent	Last Available: "2017-12"
 9584	thick adequate muffled muffuletta	5	good	Last Available: "2017-12"
@@ -9522,7 +9522,7 @@
 9650	drinkable nega-mushroom wine	4	good	Last Available: "2017-12"
 9651	chilled Cheer-Up soda	0		Effect: "Healthy Blue Glow", Effect Duration: 14, Last Available: "2017-12"
 9652	yummy blue mime army rations	4	awesome	Last Available: "2017-12"
-9653	watered-down drinkable spinning mime army wine	2	good	Last Available: "2017-12"
+9653	drinkable watered-down spinning mime army wine	2	good	Last Available: "2017-12"
 9654	denatured mime army superserum	1		Effect: "Berry Experiential", Effect Duration: 50, Last Available: "2017-12"
 9655	double-modified chilled mime army camouflage kit	0		Effect: "Well-Lubed", Effect Duration: 35, Last Available: "2017-12"
 9656	narrow lightning-fast miming beret of chilblains	0		Cold Damage: +25, Initiative: +40, Last Available: "2017-12"
@@ -9536,14 +9536,14 @@
 9664	ghostly donated candy	0		
 9665	ionized non-chilled corrupted digital honeypot	0		Effect: "Motion", Effect Duration: 37, Last Available: "2025-12"
 9666	jittery green mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	wholesome mime army insignia (infantry)	0		Maximum HP Percent: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	wizardly mime army insignia (intelligence)	0		Mysticality: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	bouncing upside-down shaking censurious mime army insignia (espionage)	0		Sleaze Resistance: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	wholesome mime army insignia (infantry)	0		Maximum HP Percent: +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	wizardly mime army insignia (intelligence)	0		Mysticality: +25, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	bouncing upside-down shaking censurious mime army insignia (espionage)	0		Sleaze Resistance: +3, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	wobbly mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	bouncing mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
-9674	jittery tumbling mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
+9674	tumbling jittery mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	vibrating shellacked mime army infiltration glove	0		Damage Reduction: 7, Maximum MP Percent: +10, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
 9677	lime green mime army challenge coin	0		Last Available: "2017-12"
@@ -9575,10 +9575,10 @@
 9703	altered beefy pill	1		Effect: "Very Clean Guns", Effect Duration: 20
 9704	distilled excitement pill	1		
 9705	twisted tumbling red vitamin G pill	1		
-9706	powdered blinking spinning lucky-ish pill	1		
+9706	powdered spinning blinking lucky-ish pill	1		
 9707	pickled dieting pill	1		Effect: "Preemptive Medicine", Effect Duration: 35
 9712	narrow Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
-9713	pulsating yellow How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
+9713	yellow pulsating How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	huge Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	bouncing Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
@@ -9593,13 +9593,13 @@
 9725	psychic's pslacks of the wise owl of the dark arts	0		Mysticality: +20, Spell Damage Percent: +100, Last Available: "2018-02"
 9726	frightening razor-sharp psychic's amulet	0		Weapon Damage Percent: +25, Spooky Damage: +5, Last Available: "2018-02"
 9727	moldy heart-shaped candy whetstone	4	crappy	Last Available: "2018-02"
-9728	moldy low-calorie upside-down Swedish massage fish	1	crappy	Last Available: "2018-02"
-9729	smooth fortified Third Base	5	awesome	Last Available: "2018-02"
-9730	mediocre extra-dry fancy Bustle Hustler	5	decent	Effect: "Disdain of the War Snapper", Effect Duration: 50, Last Available: "2018-02"
+9728	low-calorie moldy upside-down Swedish massage fish	1	crappy	Last Available: "2018-02"
+9729	fortified smooth Third Base	5	awesome	Last Available: "2018-02"
+9730	fancy extra-dry mediocre Bustle Hustler	5	decent	Effect: "Disdain of the War Snapper", Effect Duration: 50, Last Available: "2018-02"
 9731	vacuum-sealed anodized mirror pulsating Fabiotion	0		Effect: "Permanent Halloween", Effect Duration: 28, Last Available: "2018-02"
 9732	chilled denatured ghostly Bettie page	0		Effect: "Standard Issue Bravery", Effect Duration: 16, Last Available: "2018-02"
 9733	oxidized corrupted tonic o' Banderas	0		Effect: "Dances with Tweedles", Effect Duration: 42, Last Available: "2018-02"
-9734	ionized polarized upside-down mirror heather graham cracker	0		Effect: "Cravin' for a Ravin'", Effect Duration: 32, Last Available: "2018-02"
+9734	ionized polarized mirror upside-down heather graham cracker	0		Effect: "Cravin' for a Ravin'", Effect Duration: 32, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
@@ -9617,7 +9617,7 @@
 9749	riboflavin	0		
 9750	upside-down bronze	0		
 9751	piracetam	0		
-9752	spinning green twirling ultracalcium	0		
+9752	green spinning twirling ultracalcium	0		
 9753	green ginseng	0		
 9754	Team Avarice cap of James Dean	0		Experience (Moxie): +3
 9755	Team Sloth cap of the blizzard	0		Cold Spell Damage: +25, Combat Rate: -15
@@ -9625,7 +9625,7 @@
 9757	spinning up-at-dawn Mu cap	0		Adventures: +5
 9758	Thwaitgold metabug statuette	0		
 9759	bouncing ghostly Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
-9760	skewed narrow packet of tall grass seeds	0		Last Available: "2018-03"
+9760	narrow skewed packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
@@ -9663,13 +9663,13 @@
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
-9798	red pulsating Oppossum	0		Last Available: "2018-03"
+9798	pulsating red Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	wobbly Vulgure	0		Last Available: "2018-03"
 9802	ghostly Squib	0		Last Available: "2018-03"
 9803	green Trafikoan	0		Last Available: "2018-03"
-9804	wobbly shaking Slotter	0		Last Available: "2018-03"
+9804	shaking wobbly Slotter	0		Last Available: "2018-03"
 9805	jittery Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
@@ -9677,7 +9677,7 @@
 9809	Disgeist	0		Last Available: "2018-03"
 9810	jittery Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
-9812	ghostly green Mu	0		Last Available: "2018-03"
+9812	green ghostly Mu	0		Last Available: "2018-03"
 9813	pulsating huge Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
@@ -9685,7 +9685,7 @@
 9817	Jamocha berry	0		Last Available: "2018-03"
 9818	olive Tapioc berry	0		Last Available: "2018-03"
 9819	bouncing Snarf berry	0		Last Available: "2018-03"
-9820	gray huge Keese berry	0		Last Available: "2018-03"
+9820	huge gray Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	spinning shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9697,7 +9697,7 @@
 9829	compressed narrow brilliant oyster egg	1		
 9830	diluted gray glistening oyster egg	1		Effect: "Starry-Eyed", Effect Duration: 30
 9831	denatured scintillating oyster egg	1		
-9832	twisted blinking teal pearlescent oyster egg	1		
+9832	twisted teal blinking pearlescent oyster egg	1		
 9833	denatured red lustrous oyster egg	1		
 9834	dried bouncing gleaming oyster egg	1		Effect: "Bilious Brawn", Effect Duration: 10
 9835	huge FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
@@ -9709,7 +9709,7 @@
 9841	quilted FantasyRealm Rogue's Mask	0		Damage Absorption: +40, Last Available: "2018-04"
 9842	lump of bauxite	0		Last Available: "2018-12"
 9843	horrifying manspreader's arcane researcher's &quot;Remember the Trees&quot; Shirt	0		Experience Percent (Mysticality): +10, Monster Level: +10, Spooky Damage: +25
-9844	twirling huge FantasyRealm key	0		Last Available: "2018-04"
+9844	huge twirling FantasyRealm key	0		Last Available: "2018-04"
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	skewed purple wobbly tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9721,10 +9721,10 @@
 9853	spinning poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	blurry mirror flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9856	mirror blurry flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	energized universal antivenin	0		Lasts Until Rollover, Effect: "La Bamba", Effect Duration: 31, Last Available: "2018-04"
 9858	teal LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9859	purple ghostly wobbly LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
+9859	ghostly wobbly purple LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	stale ghostly FantasyRealm turkey leg	4	decent	Last Available: "2018-04"
@@ -9736,14 +9736,14 @@
 9868	red pulsating grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	spoiled druidic s'more	3	crappy	Last Available: "2018-04"
 9870	powdered twirling sachet of powder	1		Last Available: "2018-04"
-9871	bad practically non-alcoholic mourning wine	1	decent	Last Available: "2018-04"
+9871	practically non-alcoholic bad mourning wine	1	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	mirror map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	twirling map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	snack-sized delicious fancy denastified haunch	2	awesome	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2018-04"
+9878	snack-sized fancy delicious denastified haunch	2	awesome	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2018-04"
 9879	practically non-alcoholic acceptable bad rum and good cola	1	good	Last Available: "2018-04"
 9880	super-modified bouncing gray Potion of Heroism	0		Effect: "Infernal Thirst", Effect Duration: 11, Last Available: "2018-04"
 9881	blinking Usain Bolt's dog trainer's leggings of the Spider Queen of courage	0		Experience (familiar): +1, Spooky Resistance: +3, Initiative: +80, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	triple-distilled tolerable two meat muck	8	good	
-9899	tasty half-sized chocolate Ogre Chieftain	2	awesome	
-9900	massive rotten fuchsia chocolate &quot;Phoenix&quot;	6	crappy	
-9901	jumbo decent chocolate Spider Queen	5	good	
-9902	perfectly mixed practically non-alcoholic fancy squat hipster cocktail	1	super ultra mega turbo EPIC	Effect: "Crying, Dying", Effect Duration: 25
-9903	huge God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	upside-down God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9899	half-sized tasty chocolate Ogre Chieftain	2	awesome	
+9900	rotten massive fuchsia chocolate &quot;Phoenix&quot;	6	crappy	
+9901	decent jumbo chocolate Spider Queen	5	good	
+9902	fancy perfectly mixed practically non-alcoholic squat hipster cocktail	1	super ultra mega turbo EPIC	Effect: "Crying, Dying", Effect Duration: 25
+9903	huge God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	upside-down God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	jittery G	0		
 9910	Garland of Greatness	0		
@@ -9783,7 +9783,7 @@
 9915	normal good guava	3	good	
 9916	practically non-alcoholic lousy gin and ginger	1	decent	
 9917	Thwaitgold chigger statuette	0		
-9918	vaporized bouncing purple gaseous gravy	1		Effect: "Bloodstain-Resistant", Effect Duration: 50
+9918	vaporized purple bouncing gaseous gravy	1		Effect: "Bloodstain-Resistant", Effect Duration: 50
 9919	huge SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	spinning SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	cyan A Guide to Safari	0		Skill: "Experience Safari"
@@ -9843,12 +9843,12 @@
 9976	skewed sizzling beefcake's party pants	0		Muscle: +25, Hot Damage: +10, Last Available: "2018-09"
 9977	shaking toasty medical-grade brainy party whip	0		Mysticality: +5, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	hand-crafted weak red TRIO cup of beer	2	EPIC	Last Available: "2018-09"
+9979	weak hand-crafted red TRIO cup of beer	2	EPIC	Last Available: "2018-09"
 9980	stale party platter for one	4	decent	Last Available: "2018-09"
 9981	modified squat Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	red party pup	0		Last Available: "2018-09"
 9983	skewed Rosewater's party crasher of incineration	0		Mysticality Percent: +30, Hot Spell Damage: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9875,15 +9875,15 @@
 10009	hale wholesome shellacked mutant crown	0		Damage Reduction: 7, Maximum HP Percent: +10, Maximum HP: +20, Last Available: "2018-11"
 10010	small adequate blue ghostly ectoplasm	2	good	Last Available: "2018-11"
 10011	rotten big	5	crappy	Last Available: "2018-11"
-10012	acceptable triple-distilled bottle of vodka	8	good	Last Available: "2018-11"
+10012	triple-distilled acceptable bottle of vodka	8	good	Last Available: "2018-11"
 10013	decent immense pizza	10	good	Last Available: "2018-11"
 10014	lousy fancy martini	3	decent	Effect: "Mutated", Effect Duration: 25, Last Available: "2018-11"
-10015	low-calorie decent cherry pie	1	good	Last Available: "2018-11"
-10016	practically non-alcoholic hand-crafted eggnog	1	super ultra mega EPIC	Last Available: "2018-11"
+10015	decent low-calorie cherry pie	1	good	Last Available: "2018-11"
+10016	hand-crafted practically non-alcoholic eggnog	1	super ultra mega EPIC	Last Available: "2018-11"
 10017	pulsating glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	adequate Hell ramen	4	good	Last Available: "2018-11"
-10019	lousy watered-down gimlet	2	decent	Last Available: "2018-11"
-10020	tolerable weak twice-haunted screwdriver	2	good	Last Available: "2018-11"
+10019	watered-down lousy gimlet	2	decent	Last Available: "2018-11"
+10020	weak tolerable twice-haunted screwdriver	2	good	Last Available: "2018-11"
 10021	tiny adequate candy cane	1	good	Last Available: "2018-12"
 10022	practically non-alcoholic smooth runny fermented egg	1	awesome	Last Available: "2018-12"
 10023	miniature bland oldcake	2	decent	Last Available: "2018-12"
@@ -9902,11 +9902,11 @@
 10036	ghostly cyan bomb	0		Last Available: "2018-12"
 10037	blue plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	tasty low-calorie grilled mooseflank	1	awesome	Last Available: "2018-12"
+10039	low-calorie tasty grilled mooseflank	1	awesome	Last Available: "2018-12"
 10040	normal tumbling moosemeat pie	4	good	Last Available: "2018-12"
 10041	mirror blurry balanced antler	0		Item Drop: +5, Last Available: "2018-12"
 10042	dam of the storm	0		Maximum MP Percent: +40, Damage Reduction: 9, Last Available: "2018-12"
-10043	lousy skewed upside-down beavermouth	3	decent	Last Available: "2018-12"
+10043	lousy upside-down skewed beavermouth	3	decent	Last Available: "2018-12"
 10044	perfectly mixed beaver punch (papaya)	4	EPIC	Last Available: "2018-12"
 10045	bad mirror beaver punch (peach)	4	decent	Last Available: "2018-12"
 10046	artisanal beaver punch (cherry)	4	EPIC	Last Available: "2018-12"
@@ -9914,7 +9914,7 @@
 10048	muskox-skin cap of James Dean	0		Experience (Moxie): +3, Last Available: "2018-12"
 10049	green Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	massive adequate glass of raw eggs	10	good	Last Available: "2018-12"
-10051	weak bad pulsating punch-drunk punch	2	decent	Last Available: "2018-12"
+10051	bad weak pulsating punch-drunk punch	2	decent	Last Available: "2018-12"
 10052	dehydrated narrow body spradium	1		Last Available: "2018-12"
 10053	green razor-sharp bauxite beret	0		Weapon Damage Percent: +25, Last Available: "2018-12"
 10054	bauxite boxers of the glutton	0		Food Drop: +100, Last Available: "2018-12"
@@ -9923,15 +9923,15 @@
 10057	jittery Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	aromatic padded beefcake's Kramco Sausage-o-Matic&trade; of James Dean of the dark arts	0		Muscle: +25, Experience (Moxie): +3, Spell Damage Percent: +100, Damage Absorption: +20, Stench Resistance: +1, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	bland special miniature huge sausage	2	decent	Effect: "Badger Underfoot", Effect Duration: 35, Last Available: "2019-01"
+10060	miniature special bland huge sausage	2	decent	Effect: "Badger Underfoot", Effect Duration: 35, Last Available: "2019-01"
 10061	twirling arcane researcher's brawny red-hot sausage fork	0		Muscle Percent: +20, Experience Percent (Mysticality): +10, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
-10064	twirling ghostly jar of relish	0		Familiar Weight: +5
+10064	ghostly twirling jar of relish	0		Familiar Weight: +5
 10065	teal Toyleporter	0		Last Available: "2018-12"
 10066	tolerable red beer	4	good	Last Available: "2018-12"
 10067	gigantic normal yule gruel	10	good	Last Available: "2018-12"
-10068	bad fancy weak gray narrow hot watered rum	2	decent	Effect: "Izchak's Blessing", Effect Duration: 30, Last Available: "2018-12"
+10068	weak bad fancy gray narrow hot watered rum	2	decent	Effect: "Izchak's Blessing", Effect Duration: 30, Last Available: "2018-12"
 10069	tolerable extra-dry squat bottle of Crimbognac	5	good	Last Available: "2018-12"
 10070	delicious cyan Crimboysters Rockefeller	3	awesome	Last Available: "2018-12"
 10071	compressed wobbly teal Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9959,7 +9959,7 @@
 10093	spinning marble mignonette bowl of the blizzard of the sweet-tooth	0		Cold Spell Damage: +25, Candy Drop: +100, Last Available: "2019-12"
 10094	blurry occult sinister marble medallion	0		Spell Damage: +10, Spell Damage Percent: +25, Single Equip, Last Available: "2019-12"
 10095	Annie Oakley's marble mariachi hat of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +20, Last Available: "2019-12"
-10096	distilled pulsating huge marble molecules	1		Last Available: "2019-12"
+10096	distilled huge pulsating marble molecules	1		Last Available: "2019-12"
 10097	polarized tarnished warmed wobbly Mallomarbles	0		Effect: "Eyes for Miles", Effect Duration: 61
 10098	red toasty brainy punching bag	0		Mysticality: +5, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10099	Usain Bolt's horrifying pith helmet	0		Spooky Damage: +25, Initiative: +80, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
@@ -9983,7 +9983,7 @@
 10117	pulsating fuchsia hardy savvy velour viscometer	0		Mysticality Percent: +20, Maximum HP: +50, Single Equip, Last Available: "2021-12"
 10118	censurious velour valise of the wise owl	0		Mysticality: +20, Sleaze Resistance: +3, Last Available: "2021-12"
 10119	huge smartaleck's velour vaqueros of the sweet-tooth	0		Moxie Percent: +30, Candy Drop: +100, Last Available: "2021-12"
-10120	modified upside-down spinning pulsating velour veneer	1		Effect: "Wistfully Nostalgic", Effect Duration: 40, Last Available: "2021-12"
+10120	modified spinning pulsating upside-down velour veneer	1		Effect: "Wistfully Nostalgic", Effect Duration: 40, Last Available: "2021-12"
 10121	electrified anodized Vulcanized Velougats&trade;	0		Effect: "Frosty the Hitman", Effect Duration: 12
 10122	upside-down cyan ghostly asbestos-lined quilted glass suspenders	0		Damage Absorption: +40, Hot Resistance: +5, Single Equip, Last Available: "2021-12"
 10123	medical-grade glass shield of the cougar	0		Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 7, Last Available: "2021-12"
@@ -10031,14 +10031,14 @@
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	dance instructor's Lil' Doctor&trade; bag of the sewer	0		Experience Percent (Moxie): +10, Stench Damage: +25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
-10169	spoiled snack-sized bloodstick	2	crappy	
-10170	enchanted delicious triple-distilled bottle of Sanguiovese	7	awesome	Effect: "Holiday Bliss", Effect Duration: 35
+10169	snack-sized spoiled bloodstick	2	crappy	
+10170	delicious triple-distilled enchanted bottle of Sanguiovese	7	awesome	Effect: "Holiday Bliss", Effect Duration: 35
 10171	decent big actual blood sausage	5	good	
-10172	artisanal fancy mulled blood	3	EPIC	Effect: "Ichorous Intensity", Effect Duration: 35
+10172	fancy artisanal mulled blood	3	EPIC	Effect: "Ichorous Intensity", Effect Duration: 35
 10173	miniature stale blood snowcone	2	decent	
 10174	drinkable Red Russian	3	good	
 10175	normal blood roll-up	3	good	
-10176	practically non-alcoholic drinkable fancy skewed bottle of blood	1	good	Effect: "Joyful Resolve", Effect Duration: 25
+10176	practically non-alcoholic fancy drinkable skewed bottle of blood	1	good	Effect: "Joyful Resolve", Effect Duration: 25
 10177	moldy twirling blood-soaked sponge cake	3	crappy	
 10178	special hand-crafted spinning vampagne	3	super EPIC	Effect: "A View to Some Meat", Effect Duration: 50
 10179	spoiled plain snowcone	3	crappy	
@@ -10065,15 +10065,15 @@
 10200	jittery melty plastic grenade	0		Last Available: "2019-04"
 10201	bad bottle of dark rhum	3	decent	Last Available: "2019-04"
 10202	weak acceptable bottle of extra-dark rhum	2	good	Last Available: "2019-04"
-10203	artisanal fortified teal bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
-10204	quantum moist gray huge skewed pirate shaving cream	0		Effect: "Crimbo Nostalgia", Effect Duration: 48, Last Available: "2019-04"
+10203	fortified artisanal teal bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
+10204	quantum moist skewed gray huge pirate shaving cream	0		Effect: "Crimbo Nostalgia", Effect Duration: 48, Last Available: "2019-04"
 10205	Newton's conquistador's breastplate of incineration	0		Experience (Mysticality): +3, Hot Spell Damage: +50, Last Available: "2019-04"
 10206	greedy pirate pantaloons of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +20, Last Available: "2019-04"
 10207	[glitch season reward name]	0		
-10208	skewed blurry signal fragment	0		Last Available: "2019-04"
+10208	blurry skewed signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	cool pirate radio ring of doom	0		Moxie: +5, Spooky Spell Damage: +50, Single Equip, Last Available: "2019-04"
-10211	narrow mirror Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
+10211	mirror narrow Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	flavorless fancy pineapple slab	3	decent	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 20, Last Available: "2019-04"
 10213	spoiled hibiscus petal	3	crappy	Last Available: "2019-04"
 10214	warmed activated polymerized ghostly huge mint leaf	0		Effect: "Greased-Up Familiar", Effect Duration: 59, Last Available: "2019-04"
@@ -10094,10 +10094,10 @@
 10229	teal ring	0		Single Equip, Last Available: "2019-04"
 10230	blurry lightning-fast curative piratical blunderbuss	0		Initiative: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-04"
 10231	wobbly quilted padded PirateRealm party hat of the businessman	0		Damage Absorption: 60, Meat Drop: +50, Last Available: "2019-04"
-10232	mediocre high-proof Island Landslide	6	decent	Last Available: "2019-04"
+10232	high-proof mediocre Island Landslide	6	decent	Last Available: "2019-04"
 10233	perfectly mixed upside-down Island Thunderstorm	4	EPIC	Last Available: "2019-04"
 10234	bad jittery Island Hurricane	3	decent	Last Available: "2019-04"
-10235	lousy weak Skull Punch	2	decent	Last Available: "2019-04"
+10235	weak lousy Skull Punch	2	decent	Last Available: "2019-04"
 10236	weak mediocre Electric Punch	2	decent	Last Available: "2019-04"
 10237	aged Smuggler's Punch	3	awesome	Last Available: "2019-04"
 10238	bad Scorpion Bowl	3	decent	Last Available: "2019-04"
@@ -10108,7 +10108,7 @@
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	Vulcanized altered one piece of bubble gum	0		Effect: "Kernel Panic!", Effect Duration: 45
 10245	spinning arcanoferric housing	0		
-10246	olive pulsating intact medium-wave antenna	0		
+10246	pulsating olive intact medium-wave antenna	0		
 10247	squat blurry 18-picohertz resonator crystal	0		
 10248	lime green blown-out speaker cone	0		
 10249	skewed overloaded short-pulse transistor	0		
@@ -10182,7 +10182,7 @@
 10317	fuchsia signal jammer	0		Single Equip
 10318	upside-down low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
-10320	jumbo bland space chowder	5	decent	
+10320	bland jumbo space chowder	5	decent	
 10321	bad space wine	3	decent	
 10322	spinning The Imploded World	0		Skill: "Implode Universe"
 10323	squat packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
@@ -10194,30 +10194,30 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	adequate bu&ntilde;uelos Jaliscos	3	good	Last Available: "2019-12"
-10338	miniature bland flan del mar	2	decent	Last Available: "2019-12"
-10339	adequate miniature Baja sopapilla	2	good	Last Available: "2019-12"
+10338	bland miniature flan del mar	2	decent	Last Available: "2019-12"
+10339	miniature adequate Baja sopapilla	2	good	Last Available: "2019-12"
 10340	supercool plastic Mer-kin baker	0		Moxie Percent: +20, Last Available: "2019-12"
 10341	skewed Rosewater's plastic sea elf	0		Mysticality Percent: +30, Last Available: "2019-12"
 10342	plastic yuleviathan of the wise owl	0		Mysticality: +20, Last Available: "2019-12"
 10343	Fonzie's plastic dolphin &quot;orphan&quot;	0		Experience (Moxie): +1, Single Equip, Last Available: "2019-12"
 10344	blurry dance instructor's plastic Dolph Bossin	0		Experience Percent (Moxie): +10, Last Available: "2019-12"
-10345	tumbling skewed red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	toothsome miniature mana-coated yams	2	awesome	Last Available: "2019-11"
-10347	adequate bite-sized jittery mana-basted tofurkey leg	1	good	Last Available: "2019-11"
-10348	normal enchanted squat mana-fortified cranberry sauce	4	good	Effect: "The Wisdom... of the Future", Effect Duration: 25, Last Available: "2019-11"
+10345	skewed tumbling red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
+10346	miniature toothsome mana-coated yams	2	awesome	Last Available: "2019-11"
+10347	bite-sized adequate jittery mana-basted tofurkey leg	1	good	Last Available: "2019-11"
+10348	enchanted normal squat mana-fortified cranberry sauce	4	good	Effect: "The Wisdom... of the Future", Effect Duration: 25, Last Available: "2019-11"
 10349	stale snack-sized mana-stuffed herbal stuffing	2	decent	Last Available: "2019-11"
-10350	blurry shaking human musk	0		Last Available: "2019-12"
+10350	shaking blurry human musk	0		Last Available: "2019-12"
 10351	aerosolized chilled patch of extra-warm fur	0		Effect: "Booing Radly", Effect Duration: 37, Last Available: "2019-12"
 10352	altered industrial lubricant	1		Last Available: "2019-12"
 10353	dry frozen red unfinished pleasure	0		Effect: "Sweet, Nuts", Effect Duration: 66, Last Available: "2019-12"
-10354	altered bouncing ghostly vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	altered ghostly bouncing vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	boiled cyan wobbly a bug's lymph	1		Last Available: "2019-12"
 10356	quantum anodized organic potpourri	0		Effect: "Beastly Flavor", Effect Duration: 63, Last Available: "2019-12"
 10357	bad boot flask	3	decent	Last Available: "2019-12"
 10358	quadruple-magnetized infernal snowball	0		Effect: "Here to Kick Ass", Effect Duration: 59, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	twisted fish sauce	1		Effect: "Industrial Strength Starch", Effect Duration: 50, Last Available: "2019-12"
-10361	miniature flavorless narrow guffin	2	decent	Last Available: "2019-12"
+10361	flavorless miniature narrow guffin	2	decent	Last Available: "2019-12"
 10362	dehydrated wobbly Shantix&trade;	1		Last Available: "2019-12"
 10363	fuchsia goodberry	0		Last Available: "2019-12"
 10364	twisted blinking non-Euclidean angle	1		Last Available: "2019-12"
@@ -10225,7 +10225,7 @@
 10366	wet ghostly twirling Mer-kin eyedrops	0		Effect: "Nuts about Candy", Effect Duration: 66, Last Available: "2019-12"
 10367	irradiated boiled upside-down extra-strength goo	0		Effect: "Gunky Dory", Effect Duration: 49, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
-10369	altered gray narrow livid energy	1		Effect: "Turtle Titters", Effect Duration: 15, Last Available: "2019-12"
+10369	altered narrow gray livid energy	1		Effect: "Turtle Titters", Effect Duration: 15, Last Available: "2019-12"
 10370	purple micronova	0		Last Available: "2019-12"
 10371	diluted wobbly beggin' cologne	1		Effect: "Can't Be a Chooser", Effect Duration: 20, Last Available: "2019-12"
 10372	squat careful fortified oxygenated eggnog helmet	0		Damage Absorption: +60, Monster Level: -10, Adventure Underwater, Last Available: "2019-12"
@@ -10253,7 +10253,7 @@
 10394	lime green huge mirror gravedigger's Mer-kin rollpin of the businessman	0		Spooky Damage: +10, Meat Drop: +50, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	wobbly wobbly tinsel fin	0		Familiar Weight: +5
-10397	immense rotten bowl of mernudo	10	crappy	Last Available: "2019-12"
+10397	rotten immense bowl of mernudo	10	crappy	Last Available: "2019-12"
 10398	mediocre fishelada	3	decent	Last Available: "2019-12"
 10399	bland upside-down ojo de pez burrito	3	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	hale sinister nutcracker cape	0		Spell Damage: +10, Maximum HP: +20, Last Available: "2019-12"
 10413	weightlifter's nutcracker epaulets of the sewer	0		Muscle: +15, Stench Damage: +25, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	small yummy salt plum	2	awesome	Last Available: "2019-12"
+10415	yummy small salt plum	2	awesome	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	stale half-sized jittery and bean	2	decent	Last Available: "2019-12"
 10418	rosewater-soaked horrifying kelp-holly gun of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +25, Stench Resistance: +3, Last Available: "2019-12"
@@ -10281,8 +10281,8 @@
 10422	personal trainer's Crimbylow-rise jeans of the empath	0		Experience Percent (Muscle): +10, Familiar Weight: +5, Last Available: "2019-12"
 10423	blinking ribald occult kelp-holly drape	0		Spell Damage Percent: +25, Sleaze Damage: +10, Last Available: "2019-12"
 10424	jittery smelly Staff of the Peppermint Twist of vim and vigor of Gandalf of horror	0		Maximum HP Percent: +50, Spell Critical Percent: +20, Stench Spell Damage: +10, Spooky Spell Damage: +25, Last Available: "2019-12"
-10425	massive moldy skewed tempura and bean	10	crappy	Last Available: "2019-12"
-10426	artisanal watered-down salt plum sake	2	super EPIC	Last Available: "2019-12"
+10425	moldy massive skewed tempura and bean	10	crappy	Last Available: "2019-12"
+10426	watered-down artisanal salt plum sake	2	super EPIC	Last Available: "2019-12"
 10427	electrified pulsating pressurized potion of possessiveness	0		Effect: "Squatting and Thrusting", Effect Duration: 32, Last Available: "2019-12"
 10428	magnetized Vulcanized yellow almond	0		Effect: "Sweet Incentive", Effect Duration: 61
 10429	polarized boiled handful of mixed nuts	0		Effect: "Rotten Memories", Effect Duration: 23, Last Available: "2019-12"
@@ -10300,7 +10300,7 @@
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	normal drippy nugget	3	drippy	
-10446	artisanal irresponsibly strong tumbling glass of drippy wine	10	drippy	
+10446	irresponsibly strong artisanal tumbling glass of drippy wine	10	drippy	
 10447	jumbo adequate drippy caviar	5	drippy	
 10448	normal half-sized special drippy plum(?)	2	drippy	Effect: "Sleaze-Resistant Trousers", Effect Duration: 35
 10449	blinking fireproof drippy stake	0		Hot Resistance: +3, Single Equip
@@ -10346,7 +10346,7 @@
 10489	tasty upside-down mushroom filet	3	awesome	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	distilled green twirling mushroom tea	1		Last Available: "2020-03"
-10492	strong tolerable enchanted mushroom whiskey	5	good	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2020-03"
+10492	strong enchanted tolerable mushroom whiskey	5	good	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2020-03"
 10493	squat rosy-cheeked steel-toed quilted mushroom cap	0		Damage Absorption: +40, Damage Reduction: 9, Maximum HP Percent: +30, Last Available: "2020-03"
 10494	red executive rosewater-soaked therapeutic personal trainer's mushroom shield	0		Experience Percent (Muscle): +10, Stench Resistance: +3, Meat Drop: +40, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 6, Last Available: "2020-03"
 10495	wool chaotic stylish mushroom pants of Tarzan	0		Moxie: +25, Experience (Muscle): +3, Spell Critical Percent: +10, Cold Resistance: +1, Last Available: "2020-03"
@@ -10368,7 +10368,7 @@
 10511	supercool pizza box	0		Moxie Percent: +20, Damage Reduction: 6, Last Available: "2020-04"
 10512	deadly chipped coffee mug of the ox	0		Muscle: +20, Weapon Damage: +5, Last Available: "2020-04"
 10513	lard-coated Left-Hand Man action figure	0		Sleaze Spell Damage: +25, Last Available: "2020-04"
-10514	blinking mirror drippy seed	0		
+10514	mirror blinking drippy seed	0		
 10515	drippy grub	0		
 10516	blinking drippy bezoar	0		
 10517	Drip Institute petri dish	0		
@@ -10380,7 +10380,7 @@
 10523	wobbly drippy flux	0		
 10524	drippy stein	0		
 10525	smooth drippy pilsner	4	drippy	
-10526	skewed fuchsia drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
+10526	fuchsia skewed drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	pulsating lustrous drippy orb	0		
 10530	hardy gory drippy orb	0		Maximum HP: +50
@@ -10394,10 +10394,10 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	family-friendly Guzzlr souvenir stein	0		Sleaze Resistance: +1, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	irresponsibly strong bad Ghiaccio Colada	7	decent	Last Available: "2020-05"
+10541	bad irresponsibly strong Ghiaccio Colada	7	decent	Last Available: "2020-05"
 10542	mediocre Sourfinger	3	decent	Last Available: "2020-05"
-10543	delicious weak blinking bouncing Nog-on-the-Cob	2	awesome	Last Available: "2020-05"
-10544	perfectly mixed fortified spinning Steamboat	5	EPIC	Last Available: "2020-05"
+10543	delicious weak bouncing blinking Nog-on-the-Cob	2	awesome	Last Available: "2020-05"
+10544	fortified perfectly mixed spinning Steamboat	5	EPIC	Last Available: "2020-05"
 10545	aged Buttery Boy	4	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	upside-down Usain Bolt's ribald clown car key	0		Sleaze Damage: +10, Initiative: +80, Last Available: "2020-08"
@@ -10425,7 +10425,7 @@
 10569	greasy ribald discarded bike lock key	0		Sleaze Damage: +10, Sleaze Spell Damage: +10, Last Available: "2020-08"
 10570	narrow Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	Vulcanized nitrogenated blinking wobbly marshroom	0		Effect: "The Halls of Mysticality", Effect Duration: 11
+10572	Vulcanized nitrogenated wobbly blinking marshroom	0		Effect: "The Halls of Mysticality", Effect Duration: 11
 10573	fuchsia tumbling bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	twirling drippy candy bar	0		
@@ -10436,7 +10436,7 @@
 10580	skewed dromedary drinking helmet	0		
 10581	blurry packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
-10583	squat red flimsy hardwood scraps	0		Last Available: "2020-08"
+10583	red squat flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	grievous birch battery of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-08"
 10585	chaotic arcane researcher's experienced ebony epee	0		Experience: +2, Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
 10586	teal blinking supercool weeping willow wand of dire peril of the scaredy-cat	0		Moxie Percent: +20, Weapon Damage: +20, Monster Level: -15, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
@@ -10483,7 +10483,7 @@
 10627	huge onyx knight	0		Last Available: "2020-09"
 10628	onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
-10630	twirling teal alabaster queen	0		Last Available: "2020-09"
+10630	teal twirling alabaster queen	0		Last Available: "2020-09"
 10631	alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
 10633	alabaster knight	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	twirling bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	reassuring wool hardy arcane researcher's Cargo Cultist Shorts	0		Experience Percent (Mysticality): +10, Maximum HP: +50, Cold Resistance: +1, Spooky Resistance: +1, Last Available: "2020-09"
 10637	cyan complicated device	0		Last Available: "2020-09"
-10638	practically non-alcoholic drinkable flask of moonshine	1	good	Last Available: "2020-09"
+10638	drinkable practically non-alcoholic flask of moonshine	1	good	Last Available: "2020-09"
 10639	aromatic frightening sizzling sea-worn candlestick	0		Hot Damage: +10, Spooky Damage: +5, Stench Resistance: +1, Last Available: "2020-09"
 10640	mirror Universal Seasoning	0		
 10641	super-adjusted olive null-day exploit	0		Effect: "Nano-juiced", Effect Duration: 33, Last Available: "2025-12"
@@ -10569,12 +10569,12 @@
 10713	shaking The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	blinking The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	miniature rotten and pepper (stale)	2	crappy	Last Available: "2020-12"
-10716	tolerable practically non-alcoholic cranberry margarita (brackish)	1	good	Last Available: "2020-12"
+10716	practically non-alcoholic tolerable cranberry margarita (brackish)	1	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	pulsating nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	fancy drinkable practically non-alcoholic barrel-aged eggnog	1	good	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2020-12"
-10721	big spoiled skewed hand-crafted candy cane	5	crappy	Last Available: "2020-12"
+10720	drinkable fancy practically non-alcoholic barrel-aged eggnog	1	good	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2020-12"
+10721	spoiled big skewed hand-crafted candy cane	5	crappy	Last Available: "2020-12"
 10722	gigantic flavorless drive-thru burger	8	decent	Last Available: "2020-12"
 10723	delicious Boulevardier cocktail	4	awesome	Last Available: "2020-12"
 10724	polarized squat Hotwire&trade; brand candy rope	0		Effect: "Motion", Effect Duration: 48, Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	cyan fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	ghostly spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	ghostly spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	mirror robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10606,7 +10606,7 @@
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	pulsating plate	0		Familiar Weight: +5
 10752	frozen liquefied upside-down short beer	0		Effect: "Electrolit Up", Effect Duration: 67, Last Available: "2021-05"
-10753	diffused polarized boiled blurry wobbly gray short stack of pancakes	0		Effect: "Full of Vinegar", Effect Duration: 38, Last Available: "2021-05"
+10753	diffused polarized boiled blurry gray wobbly short stack of pancakes	0		Effect: "Full of Vinegar", Effect Duration: 38, Last Available: "2021-05"
 10754	extra-modified short stick of butter	0		Effect: "Gonna Get You, Sucker", Effect Duration: 39, Last Available: "2021-05"
 10755	galvanized short glass of water	0		Effect: "Whole Latte Love", Effect Duration: 45, Last Available: "2021-05"
 10756	magnetized short	0		Effect: "Seriously Mutated", Effect Duration: 48, Last Available: "2021-05"
@@ -10631,7 +10631,7 @@
 10775	dry denatured The Beast Within&trade; candle	0		Effect: "Greedy Resolve", Effect Duration: 42, Last Available: "2021-08"
 10776	triple-frozen Salsa Caliente&trade; candle	0		Effect: "Booze Goozles", Effect Duration: 53, Last Available: "2021-08"
 10777	ionized chilled spinning Smoldering Clover&trade; candle	0		Effect: "Neutered Nostrils", Effect Duration: 60, Last Available: "2021-08"
-10778	moist diffused upside-down twirling tumbling Napalm In The Morning&trade; candle	0		Effect: "Cosmic Flavor", Effect Duration: 27, Last Available: "2021-08"
+10778	moist diffused tumbling upside-down twirling Napalm In The Morning&trade; candle	0		Effect: "Cosmic Flavor", Effect Duration: 27, Last Available: "2021-08"
 10779	olive manspreader's extra-large utility candle of the pedagogue	0		Experience: +3, Monster Level: +10, Lasts Until Rollover, Last Available: "2021-08"
 10780	skewed maroon perfumed knitted runed taper candle	0		Cold Resistance: +3, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2021-08"
 10781	lime green savvy novelty sparkling candle of temperance of the sweet-tooth	0		Mysticality Percent: +20, Sleaze Resistance: +5, Candy Drop: +100, Lasts Until Rollover, Last Available: "2021-08"
@@ -10644,7 +10644,7 @@
 10788	cold-filtered votive of confidence	0		Effect: "Lubed", Effect Duration: 66, Last Available: "2021-08"
 10789	water candle of Calamity Jane	0		Critical Hit Percent: +15, Water: 3, Lasts Until Rollover
 10790	purple mirror blurry B. L. A. R. T. of the bloodbag	0		Maximum HP: +100, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
-10791	fuchsia blinking Thwaitgold fire beetle statuette	0		
+10791	blinking fuchsia Thwaitgold fire beetle statuette	0		
 10792	empty nacho cheese can	0		Water: 1
 10793	wobbly literal bucket hat	0		Water: 5
 10794	bouncing rainproof barrel caulk	0		
@@ -10658,10 +10658,10 @@
 10802	French-Transylvanian Dictionary	0		Familiar Weight: +5
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	fireproof hardy Daylight Shavings Helmet of horror	0		Maximum HP: +50, Spooky Spell Damage: +25, Hot Resistance: +3, Last Available: "2021-11"
-10805	spinning lime green eggwater	1	decent	Last Available: "2021-12"
+10805	lime green spinning eggwater	1	decent	Last Available: "2021-12"
 10806	flavorless bread man	4	decent	Last Available: "2021-12"
 10807	toothsome plain candy cane	4	awesome	Last Available: "2021-12"
-10808	miniature adequate enchanted flour cookie	2	good	Effect: "Kissed By Fire", Effect Duration: 25, Last Available: "2021-12"
+10808	enchanted adequate miniature flour cookie	2	good	Effect: "Kissed By Fire", Effect Duration: 25, Last Available: "2021-12"
 10809	plastic food lab of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2021-12"
 10810	spinning Jeselnik's plastic nog lab	0		Sleaze Damage: +25, Single Equip, Last Available: "2021-12"
 10811	gray banded plastic chem lab	0		Damage Absorption: +100, Single Equip, Last Available: "2021-12"
@@ -10676,14 +10676,14 @@
 10820	flavorless bowl of prescription candy	3	decent	Last Available: "2021-12"
 10821	stale fishcake	4	decent	Last Available: "2021-12"
 10822	adequate bone broth	4	good	Last Available: "2021-12"
-10823	adequate diet star pop	1	good	Last Available: "2021-12"
+10823	diet adequate star pop	1	good	Last Available: "2021-12"
 10824	delicious red Doc's Fortifying Wine	4	awesome	Last Available: "2021-12"
 10825	mediocre Doc's Smartifying Wine	3	decent	Last Available: "2021-12"
 10826	hand-crafted Doc's Limbering Wine	4	EPIC	Last Available: "2021-12"
 10827	delicious Doc's Medical-Grade Wine	3	awesome	Last Available: "2021-12"
 10828	mixed Homebodyl&trade;	1		Last Available: "2021-12"
 10829	pickled Extrovermectin&trade;	1		Effect: "The Style... of the Future", Effect Duration: 50, Last Available: "2021-12"
-10830	denatured shaking ghostly Breathitin&trade;	1		Last Available: "2021-12"
+10830	denatured ghostly shaking Breathitin&trade;	1		Last Available: "2021-12"
 10831	boiled narrow tumbling Fleshazole&trade;	1		Last Available: "2021-12"
 10832	unsweetened wet anti-burn cream	0		Effect: "Super Speed", Effect Duration: 52, Last Available: "2021-12"
 10833	extra-wet quadruple-activated liquefied bouncing anti-freeze cream	0		Effect: "Can Has Cyborger", Effect Duration: 29, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	nitrogenated anti-creep cream	0		Effect: "It's Electric!", Effect Duration: 11, Last Available: "2021-12"
 10837	oxidized huge purple anti-pain cream	0		Effect: "Extra Backbone", Effect Duration: 58, Last Available: "2021-12"
 10838	bad Doc's Special Reserve Wine	3	decent	Last Available: "2021-12"
-10839	normal fancy bread pie	3	good	Effect: "Briny Blood", Effect Duration: 5, Last Available: "2021-12"
+10839	fancy normal bread pie	3	good	Effect: "Briny Blood", Effect Duration: 5, Last Available: "2021-12"
 10840	tolerable clear Russian	3	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	upside-down gray Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	bouncing skewed sage cozy scarf	0		Mysticality Percent: +10, Last Available: "2021-12"
-10852	stale jumbo fuchsia huge Crimbo cookie	5	decent	Last Available: "2023-06"
+10852	jumbo stale fuchsia huge Crimbo cookie	5	decent	Last Available: "2023-06"
 10853	concentrated polymerized blinking fleshy putty	0		Effect: "Blessing of Charcoatl", Effect Duration: 45, Last Available: "2021-12"
 10854	rosewater-soaked third ear	0		Stench Resistance: +3, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10715,7 +10715,7 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	mirror double-paned depleted Crimbonium football helmet	0		Cold Resistance: +5, Last Available: "2021-12"
 10861	tumbling synthetic rock	0		Last Available: "2021-12"
-10862	massive yummy &quot;caramel&quot;	7	awesome	Last Available: "2021-12"
+10862	yummy massive &quot;caramel&quot;	7	awesome	Last Available: "2021-12"
 10863	self-repairing earmuffs of the cheetah	0		Initiative: +60, Last Available: "2021-12"
 10864	Jim Carey's carnivorous potted plant	0		Monster Level: +25, Last Available: "2021-12"
 10865	blurry universal biscuit	0		Last Available: "2021-12"
@@ -10729,18 +10729,18 @@
 10873	flame-retardant lard-coated banded can of mixed everything	0		Damage Absorption: +100, Sleaze Spell Damage: +25, Hot Resistance: +1, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	squat the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	low-calorie flavorless wobbly meatball	1	decent	Last Available: "2021-12"
+10876	flavorless low-calorie wobbly meatball	1	decent	Last Available: "2021-12"
 10877	huge cloned monster	0		Last Available: "2021-12"
 10878	huge meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	pickled fried air	1		Last Available: "2021-12"
 10881	bouncing 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	boiled squat huge bouncing astral energy drink	1		
+10883	boiled huge squat bouncing astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	red tumbling experienced smartaleck's magnifying glass of the pedagogue	0		Moxie Percent: +30, Experience: 5, Last Available: "2022-12"
-10886	acceptable olive blurry void lager	3	good	Last Available: "2022-12"
-10887	small delicious void burger	2	awesome	Last Available: "2022-12"
+10886	acceptable blurry olive void lager	3	good	Last Available: "2022-12"
+10887	delicious small void burger	2	awesome	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	narrow flame-wreathed void shard of vim and vigor of Flo-Jo of the early riser	0		Maximum HP Percent: +50, Hot Spell Damage: +10, Initiative: +100, Adventures: +7, Last Available: "2022-12"
 10890	skewed undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
@@ -10767,12 +10767,12 @@
 10911	non-alkaline blurry gaffer's tape	0		Effect: "Hyperoffended", Effect Duration: 65, Last Available: "2022-05"
 10912	decent huge 20-lb can of rice and beans	4	good	Last Available: "2022-05"
 10913	cyan bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	adequate enchanted expired MRE	3	good	Effect: "Heavily Breathing", Effect Duration: 30, Last Available: "2022-05"
+10914	enchanted adequate expired MRE	3	good	Effect: "Heavily Breathing", Effect Duration: 30, Last Available: "2022-05"
 10915	bland spinning cool mint precipice bar	4	decent	Last Available: "2022-05"
-10916	half-sized stale carrot cake precipice bar	2	decent	Last Available: "2022-05"
+10916	stale half-sized carrot cake precipice bar	2	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
-10919	blurry mirror packaged June cleaver	0		Free Pull, Last Available: "2022-06"
+10919	mirror blurry packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	inspector's dance instructor's stylish June cleaver	0		Moxie: +25, Experience Percent (Moxie): +10, Item Drop: +15, Attacks Can't Miss, Last Available: "2022-06"
 10921	delicious high-proof pulsating Dad's brandy	10	awesome	Last Available: "2022-06"
 10922	nasty friendly teacher's pen	0		Familiar Weight: +3, Stench Damage: +5, Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	altered polarized trampled ticket stub	0		Effect: "Sealed Brain", Effect Duration: 29, Last Available: "2022-06"
 10927	liquefied double-wet savings bond	0		Effect: "Cautious Prowl", Effect Duration: 17, Last Available: "2022-06"
 10928	blinking designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	twisted twirling sweat-ade	1		Effect: "Expert Vacationer", Effect Duration: 15, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	wobbly green stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10825,35 +10825,35 @@
 10969	blinking Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	flavorless ratatouille de Jarlsberg	3	decent	Last Available: "2022-11"
 10971	moldy Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
-10972	fancy massive rotten gray roasted vegetable of Jarlsberg	7	crappy	Effect: "Burning Tongue", Effect Duration: 25, Last Available: "2022-11"
-10973	miniature spoiled bouncing St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
+10972	massive rotten fancy gray roasted vegetable of Jarlsberg	7	crappy	Effect: "Burning Tongue", Effect Duration: 25, Last Available: "2022-11"
+10973	spoiled miniature bouncing St. Pete's sneaky smoothie	2	crappy	Last Available: "2022-11"
 10974	decent Pete's wiley whey bar	3	good	Last Available: "2022-11"
 10975	immense stale Pete's rich ricotta	10	decent	Last Available: "2022-11"
-10976	enchanted bad Boris's beer	3	decent	Effect: "The Rich Get Richer", Effect Duration: 20, Last Available: "2022-11"
-10977	yummy huge honey bun of Boris	10	awesome	Last Available: "2022-11"
+10976	bad enchanted Boris's beer	3	decent	Effect: "The Rich Get Richer", Effect Duration: 20, Last Available: "2022-11"
+10977	huge yummy honey bun of Boris	10	awesome	Last Available: "2022-11"
 10978	stale Boris's bread	4	decent	Last Available: "2022-11"
-10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	wobbly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	skewed cyan Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	lime green shaking Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	wobbly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	skewed cyan Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	lime green shaking Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	spoiled baked veggie ricotta casserole	4	crappy	Last Available: "2022-11"
-10989	diet flavorless plain calzone	1	decent	Last Available: "2022-11"
+10989	flavorless diet plain calzone	1	decent	Last Available: "2022-11"
 10990	moldy roasted vegetable focaccia	4	crappy	Last Available: "2022-11"
 10991	adequate massive Pizza of Legend	6	good	Last Available: "2022-11"
-10992	normal small Calzone of Legend	2	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10992	small normal Calzone of Legend	2	good	Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	blinking cookbookbat book	0		Familiar Weight: +5
-10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	special super-sized adequate cyan twirling Deep Dish of Legend	5	good	Effect: "Strawberry Alarm", Effect Duration: 40, Last Available: "2022-11"
+10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	special adequate super-sized cyan twirling Deep Dish of Legend	5	good	Effect: "Strawberry Alarm", Effect Duration: 40, Last Available: "2022-11"
 11001	shaking deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	blurry government per-diem	0		
@@ -10863,9 +10863,9 @@
 11007	booze bindle	0		
 11008	asbestos-lined wholesome rare oboe	0		Maximum HP Percent: +10, Hot Resistance: +5
 11009	knitted deadly bullet necklace	0		Weapon Damage: +5, Cold Resistance: +3, Single Equip
-11010	rotten immense swamp haunch	9	crappy	
+11010	immense rotten swamp haunch	9	crappy	
 11011	ghostly mirror gator shades of vim and vigor of Flo-Jo	0		Maximum HP Percent: +50, Initiative: +100, Single Equip
-11012	squat yellow milk cap	0		
+11012	yellow squat milk cap	0		
 11013	lousy squat Charleston Choo-Choo	4	decent	
 11014	drinkable Velvet Veil	4	good	
 11015	artisanal Marltini	3	EPIC	
@@ -10920,10 +10920,10 @@
 11064	extremely unsafe shoulder-mounted Trainbot of extreme caution of the brazier	0		Weapon Damage Percent: +100, Monster Level: -25, Hot Spell Damage: +25, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	mediocre watered-down dregs of a Crimbo cocktail	2	decent	
+11067	watered-down mediocre dregs of a Crimbo cocktail	2	decent	
 11068	upside-down lost elf luggage	0		
-11069	mirror bouncing Trainbot luggage hook	0		Single Equip
-11070	normal snack-sized special honey-drenched ham slice	2	good	Effect: "Castaway Physique", Effect Duration: 35
+11069	bouncing mirror Trainbot luggage hook	0		Single Equip
+11070	snack-sized special normal honey-drenched ham slice	2	good	Effect: "Castaway Physique", Effect Duration: 35
 11071	lousy irresponsibly strong mostly-empty bottle of cookie wine	8	decent	
 11072	toothsome Crimbo food scraps	3	awesome	
 11073	arm towel	0		Last Available: "2022-12"
@@ -10935,10 +10935,10 @@
 11079	teal really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
-11082	blue narrow crystal Crimbo goblet	0		
+11082	narrow blue crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	practically non-alcoholic lousy huge Crimbosmopolitan	1	decent	Last Available: "2022-12"
-11085	fancy delicious snack-sized spinning Crimbo dinner	2	awesome	Effect: "Hopped Up on Goofballs", Effect Duration: 50, Last Available: "2022-12"
+11085	delicious fancy snack-sized spinning Crimbo dinner	2	awesome	Effect: "Hopped Up on Goofballs", Effect Duration: 50, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	green The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10972,17 +10972,17 @@
 11117	modified oxidized glob of extra-green chlorophyll	0		Effect: "Big", Effect Duration: 48, Last Available: "2023-02"
 11118	irradiated mushroom	0		Effect: "Super Accuracy", Effect Duration: 45, Last Available: "2023-02"
 11119	chilled corrupted five-fingered fern resin	0		Effect: "Slimy Flavor", Effect Duration: 15, Last Available: "2023-02"
-11120	decent fuchsia mirror super good fruit	3	good	Last Available: "2023-02"
+11120	decent mirror fuchsia super good fruit	3	good	Last Available: "2023-02"
 11121	pickled olive energized spores	1		Last Available: "2023-02"
-11122	flame-retardant therapeutic hot pepper	0		Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-02", Lantern Element: "Hot"
+11122	flame-retardant therapeutic hot pepper	0		Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Lantern Element: "Hot", Last Available: "2023-02"
 11123	Vulcanized polymerized huge bouncing out-of-work circus flea	0		Effect: "Flambé-a-thon", Effect Duration: 16, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	galvanized unsweetened fire ant pheromones	0		Effect: "Elemental Flavor", Effect Duration: 32, Last Available: "2023-02"
-11126	ionized dry jittery skewed flapper fly	0		Effect: "Locks Like the Raven", Effect Duration: 32, Last Available: "2023-02"
-11127	watered-down artisanal jittery shot of wasp venom	2	EPIC	Last Available: "2023-02"
+11126	ionized dry skewed jittery flapper fly	0		Effect: "Locks Like the Raven", Effect Duration: 32, Last Available: "2023-02"
+11127	artisanal watered-down jittery shot of wasp venom	2	EPIC	Last Available: "2023-02"
 11128	modified filled mosquito	0		Effect: "Really Deep Breath", Effect Duration: 50, Last Available: "2023-02"
 11129	dry shim of shame shale	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 53, Last Available: "2023-02"
-11130	triple-polymerized twirling blurry pebble of proud pyrite	0		Effect: "Drenched With Filth", Effect Duration: 59, Last Available: "2023-02"
+11130	triple-polymerized blurry twirling pebble of proud pyrite	0		Effect: "Drenched With Filth", Effect Duration: 59, Last Available: "2023-02"
 11131	unsweetened wobbly fuchsia pile of gritty sand	0		Effect: "Partially Ghosted", Effect Duration: 11, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	concentrated angry agate	0		Effect: "Aloofah", Effect Duration: 47, Last Available: "2023-02"
@@ -10990,13 +10990,13 @@
 11135	tasty squat shadow sausage	4	awesome	Last Available: "2023-03"
 11136	dangerous brawny shadow skin	0		Muscle Percent: +20, Weapon Damage: +10, Last Available: "2023-03"
 11137	pressed ionized shadow flame	0		Effect: "Boon of She-Who-Was", Effect Duration: 54, Last Available: "2023-03"
-11138	super-sized enchanted yummy shadow bread	5	awesome	Effect: "Sweet and Red", Effect Duration: 5, Last Available: "2023-03"
+11138	enchanted super-sized yummy shadow bread	5	awesome	Effect: "Sweet and Red", Effect Duration: 5, Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	watered-down lousy special pulsating green shadow fluid	2	decent	Effect: "The Rich Get Richer", Effect Duration: 45, Last Available: "2023-03"
+11140	special lousy watered-down green pulsating shadow fluid	2	decent	Effect: "The Rich Get Richer", Effect Duration: 45, Last Available: "2023-03"
 11141	blinking shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	mediocre high-proof shadow venom	6	decent	Last Available: "2023-03"
+11144	high-proof mediocre shadow venom	6	decent	Last Available: "2023-03"
 11145	compressed shadow nectar	1		Last Available: "2023-03"
 11146	shadow stick of the dark arts of extreme caution of the glutton	0		Spell Damage Percent: +100, Monster Level: -25, Food Drop: +100, Last Available: "2023-03"
 11147	studded bat paw of the sweet-tooth	0		Damage Absorption: +80, Candy Drop: +100
@@ -11043,7 +11043,7 @@
 11188	enhanced maroon shadow candy	0		Effect: "Held Closer", Effect Duration: 33
 11189	blinking replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
-11191	gray jittery replica hand turkey outline	0		
+11191	jittery gray replica hand turkey outline	0		
 11192	shaking shaking replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	jittery dedigitizer schematic: cyburger	0		Last Available: "2025-12"
@@ -11056,7 +11056,7 @@
 11201	family-friendly personal trainer's replica navel ring of navel gazing of Tarzan of mayonnaise	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Sleaze Spell Damage: +50, Sleaze Resistance: +1, Single Equip
 11202	rosewater-soaked razor-sharp replica V for Vivala mask	0		Weapon Damage Percent: +25, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	jittery inspector's padded replica haiku katana of the sweet-tooth	0		Damage Absorption: +20, Item Drop: +15, Candy Drop: +100, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
-11204	bouncing blurry replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
+11204	blurry bouncing replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	pulsating replica cotton candy cocoon	0		
 11206	up-at-dawn avaricious savvy replica Elvish sunglasses of the wise owl	0		Mysticality: +20, Mysticality Percent: +20, Meat Drop: +30, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	purple narrow replica squamous polyp	0		
@@ -11100,7 +11100,7 @@
 11245	up-at-dawn horrifying resourceful deadly replica Cargo Cultist Shorts	0		Weapon Damage: +5, Maximum MP: +50, Spooky Damage: +25, Adventures: +5
 11246	greedy resourceful healthy boxer's replica industrial fire extinguisher of the cougar of the businessman	0		Moxie: +20, Muscle Percent: +10, Maximum HP Percent: +20, Maximum MP: +50, Meat Drop: 70, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 11247	maroon wobbly replica crystal ball	0		Initiative: +50
-11248	tumbling red replica emotion chip	0		Skill: "Replica Emotionally Chipped"
+11248	red tumbling replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	greedy rock-hard replica Jurassic Parka	0		Damage Reduction: 5, Meat Drop: +20
 11250	replica grey gosling	0		
 11251	spinning replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
@@ -11117,7 +11117,7 @@
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	squat Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	blue healthy Flash Liquidizer Ultra Dousing Accessory	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	miser's Amulet of Perpetual Darkness of Leguizamo of the empath	0		Monster Level: +20, Familiar Weight: +5, Item Drop: +5, Meat Drop: +10, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11132,9 +11132,9 @@
 11277	spinning Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	blinking Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	tumbling Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
-11280	upside-down pulsating Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
+11280	pulsating upside-down Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	cyan Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	delicious enchanted fuchsia Sexy Cosmo	4	awesome	Effect: "Meatwise", Effect Duration: 35, Last Available: "2023-06"
+11282	enchanted delicious fuchsia Sexy Cosmo	4	awesome	Effect: "Meatwise", Effect Duration: 35, Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	reassuring hardy cool red-soled high heels	0		Moxie: +5, Maximum HP: +50, Spooky Resistance: +1, Last Available: "2023-06"
 11285	moldy cyburger	3	crappy	Last Available: "2025-12"
@@ -11159,7 +11159,7 @@
 11304	replica sleeping patriotic eagle	0		
 11305	bouncing boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	decent fancy watermelon	4	good	Effect: "Total Protonic Reversal", Effect Duration: 25
+11307	fancy decent watermelon	4	good	Effect: "Total Protonic Reversal", Effect Duration: 25
 11308	upside-down watermelon seed	0		
 11309	shaking water balloon	0		
 11310	lime green thriftshop coupon	0		
@@ -11168,18 +11168,18 @@
 11313	scandalous cat o' nine teeth of the cougar	0		Moxie: +20, Sleaze Damage: +5
 11314	zippy tooth cap of the businessman	0		Meat Drop: +50, Initiative: +20
 11315	nasty Jim Carey's toothy trousers	0		Monster Level: +25, Stench Damage: +5
-11316	miniature rotten banana split	2	crappy	
+11316	rotten miniature banana split	2	crappy	
 11317	spinning handful of toilet paper	0		
 11318	Mrs. Rush	0		
-11319	jittery pulsating medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	practically non-alcoholic smooth ghostly bottle of Cabernet Sauvignon	1	awesome	
+11319	pulsating jittery medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
+11320	smooth practically non-alcoholic ghostly bottle of Cabernet Sauvignon	1	awesome	
 11321	blinking twirling teal family-friendly greasy baywatch of temperance	0		Sleaze Spell Damage: +10, Sleaze Resistance: 6, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	pulsating spinning Thwaitgold fairyfly statue	0		
-11327	blurry narrow residual chitin paste	0		Skill: "Chitinous Soul"
+11327	narrow blurry residual chitin paste	0		Skill: "Chitinous Soul"
 11328	modified concentrated cooking	1		
 11329	denatured blurry meat	1		
 11330	pickled skewed sparkling orb	1		
@@ -11196,7 +11196,7 @@
 11341	maroon inflammable leaf	0		
 11342	rake	0		Item Drop: +1
 11343	narrow rake of extreme caution	0		Monster Level: -25
-11344	maroon wobbly autumnic bomb	0		
+11344	wobbly maroon autumnic bomb	0		
 11345	forest canopy bed	0		
 11346	day shortener	0		
 11347	extra time	0		
@@ -11231,8 +11231,8 @@
 11376	housekeeping automa-core	0		
 11377	bouncing housekeeping robot	0		
 11378	gigantic flavorless purple pickled bread	9	decent	Last Available: "2023-12"
-11379	rotten thick salted mutton	5	crappy	Last Available: "2023-12"
-11380	bland half-sized narrow corned beet	2	decent	Last Available: "2023-12"
+11379	thick rotten salted mutton	5	crappy	Last Available: "2023-12"
+11380	half-sized bland narrow corned beet	2	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11252,7 +11252,7 @@
 11397	maroon squat frightening Crimbuccaneer fledges (mint)	0		Spooky Damage: +5, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
-11400	shaking mirror Elf Guard tinsel grenade	0		Last Available: "2023-12"
+11400	mirror shaking Elf Guard tinsel grenade	0		Last Available: "2023-12"
 11401	perfectly mixed wobbly Crimbuccaneer mologrog cocktail	3	EPIC	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
@@ -11268,7 +11268,7 @@
 11413	pulsating Elf Guard honor present	0		Last Available: "2023-12"
 11414	wicked Elf Guard officer's sidearm of the sweet-tooth	0		Spell Damage: +5, Candy Drop: +100, Last Available: "2023-12"
 11415	inspector's Temple Grandin's Elf Guard insignia (general)	0		Familiar Weight: +7, Item Drop: +15, Single Equip, Last Available: "2023-12"
-11416	watered-down smooth fancy Crimbow Rainbo	2	awesome	Effect: "Heal Thy Nanoself", Effect Duration: 30, Last Available: "2023-12"
+11416	fancy watered-down smooth Crimbow Rainbo	2	awesome	Effect: "Heal Thy Nanoself", Effect Duration: 30, Last Available: "2023-12"
 11417	upside-down Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	wool stylish Elf Guard broom	0		Moxie: +25, Cold Resistance: +1, Last Available: "2023-12"
@@ -11277,12 +11277,12 @@
 11422	practically non-alcoholic smooth old-school pirate grog	1	awesome	Last Available: "2023-12"
 11423	moldy immense grog nuts	10	crappy	Last Available: "2023-12"
 11424	blinking padded educational savvy sawed-off blunderbuss	0		Mysticality Percent: +20, Experience: +1, Damage Absorption: +20, Last Available: "2023-12"
-11425	weak hand-crafted jittery teal officer's nog	2	EPIC	Last Available: "2023-12"
+11425	weak hand-crafted teal jittery officer's nog	2	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	half-sized bland sundae ration	2	decent	Last Available: "2023-12"
-11428	tasty fancy peppermint tack	4	awesome	Effect: "Red-Shirted Escort", Effect Duration: 5, Last Available: "2023-12"
+11427	bland half-sized sundae ration	2	decent	Last Available: "2023-12"
+11428	fancy tasty peppermint tack	4	awesome	Effect: "Red-Shirted Escort", Effect Duration: 5, Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	fancy spoiled narrow whalesteak	3	crappy	Effect: "Holiday Disappointment", Effect Duration: 20, Last Available: "2023-12"
+11430	spoiled fancy narrow whalesteak	3	crappy	Effect: "Holiday Disappointment", Effect Duration: 20, Last Available: "2023-12"
 11431	forbidden Newton's Samson's whalegun	0		Experience (Muscle): +5, Experience (Mysticality): +3, Spell Damage Percent: +50, Last Available: "2023-12"
 11432	Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11313,16 +11313,16 @@
 11458	horrifying rock-hard Crimbuccaneer bombjacket	0		Damage Reduction: 5, Spooky Damage: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	adequate sugarplum ration	3	good	Last Available: "2023-12"
 11460	rotten small gingerbread nylons	2	crappy	Last Available: "2023-12"
-11461	bite-sized moldy rum-soaked fruitcake	1	crappy	Last Available: "2023-12"
-11462	snack-sized normal fancy spinning skewed lime	2	good	Effect: "Feelin' Philosophical", Effect Duration: 45, Last Available: "2023-12"
-11463	tiny decent special gingerbread pirate	1	good	Effect: "Stimulated Body", Effect Duration: 30, Last Available: "2023-12"
-11464	small tasty tumbling fruit-stuffed rumcake	2	awesome	Last Available: "2023-12"
+11461	moldy bite-sized rum-soaked fruitcake	1	crappy	Last Available: "2023-12"
+11462	fancy normal snack-sized skewed spinning lime	2	good	Effect: "Feelin' Philosophical", Effect Duration: 45, Last Available: "2023-12"
+11463	decent tiny special gingerbread pirate	1	good	Effect: "Stimulated Body", Effect Duration: 30, Last Available: "2023-12"
+11464	tasty small tumbling fruit-stuffed rumcake	2	awesome	Last Available: "2023-12"
 11465	delicious jittery mulled wine	4	awesome	Last Available: "2023-12"
-11466	bad distilled narrow Swedish coffee	5	decent	Last Available: "2023-12"
-11467	mediocre high-proof skewed ghostly canteen of eggnog	8	decent	Last Available: "2023-12"
+11466	distilled bad narrow Swedish coffee	5	decent	Last Available: "2023-12"
+11467	high-proof mediocre ghostly skewed canteen of eggnog	8	decent	Last Available: "2023-12"
 11468	triple-distilled acceptable hot wine	9	good	Last Available: "2023-12"
 11469	tolerable Jamaican coffee	4	good	Last Available: "2023-12"
-11470	acceptable triple-distilled flask of egggrog	10	good	Last Available: "2023-12"
+11470	triple-distilled acceptable flask of egggrog	10	good	Last Available: "2023-12"
 11471	tumbling Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	blue pirate encryption key (complete)	0		Last Available: "2023-12"
@@ -11337,7 +11337,7 @@
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	family-friendly sequin-encrusted sweater	0		Sleaze Resistance: +1, Last Available: "2023-12"
 11484	Tesla replica Elf Guard medal of the brazier of the cheetah	0		Hot Spell Damage: +25, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
-11485	gray pulsating Lil' Snowball Factory	0		Last Available: "2023-12"
+11485	pulsating gray Lil' Snowball Factory	0		Last Available: "2023-12"
 11486	gray Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
 11487	prank Crimbo card	0		Last Available: "2023-12"
 11488	greedy Crimbuccaneer squirtblunderbuss of temperance	0		Sleaze Resistance: +5, Meat Drop: +20, Last Available: "2023-12"
@@ -11362,7 +11362,7 @@
 11507	Rosewater's moss mitre of Tarzan	0		Mysticality Percent: +30, Experience (Muscle): +3, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
 11508	narrow coward's moss mantle of the storm	0		Maximum MP Percent: +40, Monster Level: -20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	fuchsia moss marlinspike of the blizzard of the overflowing toilet	0		Cold Spell Damage: +25, Stench Spell Damage: +50, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	mixed teal pulsating squat moss mulch	1		Effect: "Hella Smart", Effect Duration: 25, Last Available: "2024-12"
+11510	mixed pulsating squat teal moss mulch	1		Effect: "Hella Smart", Effect Duration: 25, Last Available: "2024-12"
 11511	electrified energized moss floss	0		Effect: "Gummibrain", Effect Duration: 65
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11382,13 +11382,13 @@
 11527	concentrated blue crepe paper peanut candy	0		Effect: "Action", Effect Duration: 29
 11528	blinking Annie Oakley's Da Vinci's petrified wood war pike	0		Experience (Mysticality): +5, Critical Hit Percent: +20, Last Available: "2025-12"
 11529	avaricious stiffened petrified wood waist protector	0		Damage Reduction: 1, Meat Drop: +30, Single Equip, Last Available: "2025-12"
-11530	blue petrified wood wizard's pouch of the ox of Gandalf	0		Muscle: +20, Spell Critical Percent: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	hardened smartaleck's petrified wood water purifier	0		Moxie Percent: +30, Damage Reduction: 3, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	blue petrified wood wizard's pouch of the ox of Gandalf	0		Muscle: +20, Spell Critical Percent: +20, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	hardened smartaleck's petrified wood water purifier	0		Moxie Percent: +30, Damage Reduction: 3, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	Usain Bolt's zippy petrified wood whoopie panama	0		Initiative: 100, Last Available: "2025-12"
 11533	blinking scorching smooth petrified wood walking pants	0		Moxie: +15, Hot Damage: +25, Last Available: "2025-12"
-11534	powdered blinking maroon pulsating petrified wood waste parts	1		Effect: "Hypercubed", Effect Duration: 35, Last Available: "2025-12"
+11534	powdered pulsating maroon blinking petrified wood waste parts	1		Effect: "Hypercubed", Effect Duration: 35, Last Available: "2025-12"
 11535	extra-galvanized petrified wood wafer praline	0		Effect: "Brain Freeze", Effect Duration: 30
-11536	perfectly mixed spirit-forward cybeer	5	EPIC	Last Available: "2025-12"
+11536	spirit-forward perfectly mixed cybeer	5	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
@@ -11400,7 +11400,7 @@
 11545	pulsating in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	inspector's mansplainer's spring shoes of the sewer	0		Monster Level: +15, Stench Damage: +25, Item Drop: +15, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	flattened ultra-soft ferns	0		Effect: "Fortunate Resolve", Effect Duration: 47, Last Available: "2024-02"
-11548	flattened twirling narrow lime green crunchy brush	0		Effect: "Cranberry Cordiality", Effect Duration: 50, Last Available: "2024-02"
+11548	flattened narrow twirling lime green crunchy brush	0		Effect: "Cranberry Cordiality", Effect Duration: 50, Last Available: "2024-02"
 11549	blue smashed scientific equipment	0		
 11550	ghostly biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
@@ -11414,7 +11414,7 @@
 11559	mirror focused magnetron pistol	0		Single Equip
 11560	packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	fireproof stanky Everfull Dart Holster	0		Stench Spell Damage: +25, Hot Resistance: +3, Single Equip, Last Available: "2024-03"
-11562	blinking mirror research fragment	0		
+11562	mirror blinking research fragment	0		
 11563	ghostly Thwaitgold wolf spider statuette	0		
 11564	boxed Apriling band helmet	0		Free Pull, Last Available: "2024-04"
 11565	bouncing censurious perfumed Lo Pan's Sinatra's Apriling band helmet of chilblains	0		Experience (Moxie): +5, Spell Critical Percent: +30, Cold Damage: +25, Stench Resistance: +5, Sleaze Resistance: +3
@@ -11425,13 +11425,13 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	rotten small enchanted yam	2	crappy	Effect: "Squid Squint", Effect Duration: 40, Last Available: "2024-05"
+11573	enchanted rotten small yam	2	crappy	Effect: "Squid Squint", Effect Duration: 40, Last Available: "2024-05"
 11574	tolerable pulsating yam martini	3	good	Last Available: "2024-05"
 11575	artisanal watered-down sweet potato o' mine	2	EPIC	Last Available: "2024-05"
-11576	acceptable boozy Southern yam	5	good	Last Available: "2024-05"
+11576	boozy acceptable Southern yam	5	good	Last Available: "2024-05"
 11577	lousy blue sweet potato punch	3	decent	Last Available: "2024-05"
 11578	bland gigantic Mayam spinach	7	decent	Last Available: "2024-05"
-11579	fancy normal yam and swiss	4	good	Effect: "Fancy Feasted", Effect Duration: 35, Last Available: "2024-05"
+11579	normal fancy yam and swiss	4	good	Effect: "Fancy Feasted", Effect Duration: 35, Last Available: "2024-05"
 11580	smelly coward's weightlifter's yam cannon	0		Muscle: +15, Monster Level: -20, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
 11581	ghostly yellow yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11449,7 +11449,7 @@
 11594	decent lime green mini kiwi	3	good	Last Available: "2024-06"
 11595	wool veiny occult mini kiwi bikini	0		Spell Damage Percent: +25, Maximum HP: +10, Cold Resistance: +1, Last Available: "2024-06"
 11596	hand-crafted pulsating mini kiwitini	4	EPIC	Last Available: "2024-06"
-11597	olive bouncing mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
+11597	bouncing olive mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	twirling nasty mini kiwi silicon tiepin of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Stench Damage: +5
 11600	mini kiwi tipi	0		
@@ -11471,12 +11471,12 @@
 11616	blinking flagellate flagon	0		
 11617	upside-down proto-proto-protozoa	0		
 11618	decent tiny bacteria bisque	1	good	
-11619	flavorless immense teal blurry ciliophora chowder	8	decent	
+11619	immense flavorless blurry teal ciliophora chowder	8	decent	
 11620	miniature moldy cream of chloroplasts	2	crappy	
 11621	upside-down synaptic soup	0		
 11622	muscular soup	0		
 11623	cyan flagellate soup	0		
-11624	jittery maroon jittery elbow soup	0		
+11624	jittery jittery maroon elbow soup	0		
 11625	lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	extra ooze	0		
@@ -11487,7 +11487,7 @@
 11632	Doll Moll violin case	0		
 11633	cyan Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	drinkable triple-distilled Colera Peste Nebbiolo	6	good	
+11635	triple-distilled drinkable Colera Peste Nebbiolo	6	good	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11502,7 +11502,7 @@
 11647	skewed structural ember	0		Last Available: "2024-09"
 11648	careful Oprah's weightlifter's embers-only jacket	0		Muscle: +15, Maximum MP Percent: +50, Monster Level: -10, Lasts Until Rollover, Last Available: "2024-09"
 11649	yellow bembershoot of the overflowing toilet	0		Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-09"
-11650	decent miniature wheel of camembert	2	good	Last Available: "2024-09"
+11650	miniature decent wheel of camembert	2	good	Last Available: "2024-09"
 11651	medical-grade rosy-cheeked Fonzie's hat of remembering	0		Experience (Moxie): +1, Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11531,8 +11531,8 @@
 11676	peace shooter	0		Last Available: "2024-11"
 11677	compressed drenchrome 2.0	1		Last Available: "2025-12"
 11678	pickled wobbly Synapse Blaster	1		Effect: "Alchemical, Brother", Effect Duration: 30, Last Available: "2025-12"
-11679	purple mirror quantized familiar	0		
-11680	olive twirling spinning quantum watch	0		Adventures: +2
+11679	mirror purple quantized familiar	0		
+11680	spinning olive twirling quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	altered concentrated nitrogenated twirling pea brittle	0		Effect: "Punch Another Day", Effect Duration: 30, Last Available: "2024-11"
 11683	fancy smooth peasco	3	awesome	Effect: "Nature's Bounty", Effect Duration: 5, Last Available: "2024-11"
@@ -11574,9 +11574,9 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	red Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	small flavorless coney haunch	2	decent	Last Available: "2024-12"
+11722	flavorless small coney haunch	2	decent	Last Available: "2024-12"
 11723	enhanced dark chocolate egg	0		Effect: "The Grass...  Is Blue...", Effect Duration: 66, Last Available: "2024-12"
-11724	fancy artisanal triple-distilled moai toai	7	EPIC	Effect: "Healthy Blue Glow", Effect Duration: 35
+11724	triple-distilled fancy artisanal moai toai	7	EPIC	Effect: "Healthy Blue Glow", Effect Duration: 35
 11725	prompt flame-retardant energetic moaiball	0		Maximum MP Percent: +20, Hot Resistance: +1, Adventures: +3, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	alkaline oxidized four-leaf potato sprout	0		Effect: "Seriously Mutated", Effect Duration: 23, Last Available: "2024-12"
@@ -11584,14 +11584,14 @@
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
 11731	pulsating censurious military orb of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +3, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
-11732	polymerized extra-denatured gray pulsating bouncing rum ball	0		Effect: "Disdain of She-Who-Was", Effect Duration: 66
+11732	polymerized extra-denatured gray bouncing pulsating rum ball	0		Effect: "Disdain of She-Who-Was", Effect Duration: 66
 11733	gravy skin	0		Last Available: "2024-12"
 11734	medical-grade gravyskin hat of the cougar	0		Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11735	boxer's beefy gravyskin buckler	0		Muscle: +10, Muscle Percent: +10, Damage Reduction: 7, Last Available: "2024-12"
 11736	red experienced gravyskin skirt of the brazier	0		Experience: +2, Hot Spell Damage: +25, Last Available: "2024-12"
 11737	wool therapeutic gravyskin pants	0		Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11738	adjusted energized extra-improved crystallized pumpkin spice	0		Effect: "Glittering Eyelashes", Effect Duration: 52, Last Available: "2024-12"
-11739	bite-sized decent room scale bean casserole	1	good	Last Available: "2024-12"
+11739	decent bite-sized room scale bean casserole	1	good	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	twirling prompt aromatic perfect Christmas scarf of extreme caution	0		Monster Level: [-25*event(December)], Stench Resistance: [+1*event(December)], Adventures: [+3*event(December)], Single Equip, Last Available: "2024-12"
@@ -11601,35 +11601,35 @@
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	aged practically non-alcoholic Easter grasshopper	1	awesome	Last Available: "2024-12"
 11748	perfectly mixed strong Irish eggnog	5	EPIC	Last Available: "2024-12"
-11749	watered-down bad narrow canteen of jungle juice	2	decent	Last Available: "2024-12"
+11749	bad watered-down narrow canteen of jungle juice	2	decent	Last Available: "2024-12"
 11750	drinkable turchucken	3	good	Last Available: "2024-12"
 11751	perfectly mixed mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
-11752	extra-dry perfectly mixed holiday trip around the world	5	EPIC	Last Available: "2024-12"
+11752	perfectly mixed extra-dry holiday trip around the world	5	EPIC	Last Available: "2024-12"
 11753	flavorless miniature chocolate ostrich egg	2	decent	Last Available: "2024-12"
-11754	flavorless half-sized enchanted beef and cabbage	2	decent	Effect: "Yuletide Industry", Effect Duration: 10, Last Available: "2024-12"
+11754	enchanted half-sized flavorless beef and cabbage	2	decent	Effect: "Yuletide Industry", Effect Duration: 10, Last Available: "2024-12"
 11755	bland candy rations	4	decent	Last Available: "2024-12"
 11756	spoiled bite-sized jittery double-candied yams	1	crappy	Last Available: "2024-12"
 11757	yummy jittery Christmas ham	3	awesome	Last Available: "2024-12"
 11758	delicious wobbly holiday smorgasbord	4	awesome	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bejazzled eyepatch of the dark arts	0		Spell Damage Percent: +100, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	ghostly Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	squat How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	ghostly How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	ghostly Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	squat How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	ghostly How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	twirling censurious horrifying chaotic egg gun of temperance	0		Spell Critical Percent: +10, Spooky Damage: +25, Sleaze Resistance: 8, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	twirling blurry double-paned foul-smelling therapeutic army helmet of incineration	0		Hot Spell Damage: +50, Stench Damage: +10, Cold Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
-11776	bite-sized adequate Thanksgiving ration	1	good	Last Available: "2024-12"
-11777	enchanted lousy Easter eggnog	3	decent	Effect: "Morbidi Tea", Effect Duration: 25, Last Available: "2024-12"
+11776	adequate bite-sized Thanksgiving ration	1	good	Last Available: "2024-12"
+11777	lousy enchanted Easter eggnog	3	decent	Effect: "Morbidi Tea", Effect Duration: 25, Last Available: "2024-12"
 11778	altered clovermint	1		Effect: "Improprie Tea", Effect Duration: 20, Last Available: "2024-12"
 11779	zippy double-paned coward's thinker's nylon Christmas stockings	0		Mysticality: +10, Monster Level: -20, Cold Resistance: +5, Initiative: +20, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11644,7 +11644,7 @@
 11789	twirling 0	0		Last Available: "2025-12"
 11790	distilled spinning eXpand	1		Last Available: "2025-12"
 11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
-11792	fuchsia skewed datastick	0		Last Available: "2025-12"
+11792	skewed fuchsia datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	maroon dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
@@ -11678,9 +11678,9 @@
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	bouncing insignificant bit	0		Last Available: "2025-12"
 11825	cyan parity bit	0		Familiar Weight: +5
-11826	bouncing maroon hashing vise	0		Last Available: "2025-12"
+11826	maroon bouncing hashing vise	0		Last Available: "2025-12"
 11827	tumbling geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
-11828	huge fuchsia geofencing shield	0		Last Available: "2025-12"
+11828	fuchsia huge geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	ninja crampons	0		
@@ -11716,7 +11716,7 @@
 11861	shaking Leprecondo	0		Last Available: "2025-03"
 11862	vaporized scoop of pre-workout powder	1		Effect: "Marco Polarity", Effect Duration: 20, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	irresponsibly strong tolerable pint of Leprechaun Stout	7	good	Last Available: "2025-03"
+11864	tolerable irresponsibly strong pint of Leprechaun Stout	7	good	Last Available: "2025-03"
 11865	vaporized phosphor traces	1		Last Available: "2025-03"
 11866	spinning crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11727,21 +11727,21 @@
 11872	normal Heck ramen	3	good	Last Available: "2025-03"
 11873	decent small burrito	2	good	Last Available: "2025-03"
 11874	delicious small beer brat	4	awesome	Last Available: "2025-03"
-11875	decent enchanted jittery blurry peach pie	3	good	Effect: "Speed of the Internet", Effect Duration: 25, Last Available: "2025-03"
-11876	yummy narrow upside-down incredible mini-pizza	3	awesome	Last Available: "2025-03"
+11875	enchanted decent blurry jittery peach pie	3	good	Effect: "Speed of the Internet", Effect Duration: 25, Last Available: "2025-03"
+11876	yummy upside-down narrow incredible mini-pizza	3	awesome	Last Available: "2025-03"
 11877	artisanal irresponsibly strong Divine sidecar	7	EPIC	Last Available: "2025-03"
-11878	watered-down bad tangarita sidecar	2	decent	Last Available: "2025-03"
+11878	bad watered-down tangarita sidecar	2	decent	Last Available: "2025-03"
 11879	perfectly mixed blurry gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	lousy vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
 11881	aged prussian cathouse sidecar	3	awesome	Last Available: "2025-03"
-11882	practically non-alcoholic bad fancy Mon Tiki sidecar	1	decent	Effect: "In a Lather", Effect Duration: 50, Last Available: "2025-03"
-11883	pulsating ghostly Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
+11882	fancy bad practically non-alcoholic Mon Tiki sidecar	1	decent	Effect: "In a Lather", Effect Duration: 50, Last Available: "2025-03"
+11883	ghostly pulsating Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	flame-retardant healthy April Shower Thoughts shield	0		Maximum HP Percent: +20, Hot Resistance: +1, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	super-improved ionized galvanized cyan wet paper weights	0		Effect: "Cringle's Curative Carol", Effect Duration: 35, Last Available: "2025-04"
 11888	bad Three Sheets to the Wind	4	decent	Last Available: "2025-04"
-11889	rotten diet pile of wet dates	1	crappy	Last Available: "2025-04"
+11889	diet rotten pile of wet dates	1	crappy	Last Available: "2025-04"
 11890	shaking papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	bouncing tumbling family-friendly wet shower cap	0		Sleaze Resistance: +1, Last Available: "2025-04"
@@ -11800,7 +11800,7 @@
 11945	skewed Allied Tattoo Kit	0		
 11946	handheld Allied radio	0		
 11947	Axis codebook	0		
-11948	polymerized denatured bouncing narrow Life Goals Pamphlet	0		Effect: "Memory of Speed", Effect Duration: 39, Last Available: "2025-08"
+11948	polymerized denatured narrow bouncing Life Goals Pamphlet	0		Effect: "Memory of Speed", Effect Duration: 39, Last Available: "2025-08"
 11949	wobbly fortified bully badge	0		Damage Absorption: +60, Lasts Until Rollover, Last Available: "2025-08"
 11950	upside-down olive therapeutic time cop top hat	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2025-08"
 11951	twirling Stock Certificate	0		Last Available: "2025-08"
@@ -11816,7 +11816,7 @@
 11962	Annie Oakley's undersea surveying goggles	0		Critical Hit Percent: +20, Lasts Until Rollover
 11963	mediocre watered-down shaking Ocean-Touched Rum	2	decent	
 11964	altered red water-logged pill	1		Effect: "Well-Swabbed Ear", Effect Duration: 50
-11965	spoiled gray upside-down kelp puck	3	crappy	
+11965	spoiled upside-down gray kelp puck	3	crappy	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	skewed scroll of sea smarm	0		
@@ -11839,14 +11839,14 @@
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	blurry knucklebone	0		
-12052	watered-down tolerable Smoking Pope	2	good	
+12052	tolerable watered-down Smoking Pope	2	good	
 12053	moldy olive prize turkey	3	crappy	
 12054	mixed medicinal gruel	1		
 12055	thick adequate full-sized pumpkin pie	5	good	Last Available: "2025-11"
 12056	delicious watered-down vodka cranberry sauce	2	awesome	Last Available: "2025-11"
 12057	energized ionized yammed candy	0		Effect: "Preemptive Medicine", Effect Duration: 48, Last Available: "2025-11"
 12058	decent purple treasure chestnut	3	good	Last Available: "2025-12"
-12059	drinkable weak mulled butter rum	2	good	Last Available: "2025-12"
+12059	weak drinkable mulled butter rum	2	good	Last Available: "2025-12"
 12060	nitrogenated pulsating cinnamon doubloon	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 16, Last Available: "2025-12"
 12061	huge plastic left skeleton arm of Tarzan	0		Experience (Muscle): +3, Last Available: "2025-12"
 12062	lime green beefy plastic left skeleton leg	0		Muscle: +10, Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	mirror aromatic extra-thick Crimbo sweater	0		Stench Resistance: +1, Last Available: "2025-12"
 12123	cyan The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	bad special weak blinking Steve Abrams' Holiday Sampler Beer	2	decent	Effect: "Broken Bone Nubs", Effect Duration: 5, Last Available: "2025-12"
+12124	bad weak special blinking Steve Abrams' Holiday Sampler Beer	2	decent	Effect: "Broken Bone Nubs", Effect Duration: 5, Last Available: "2025-12"
 12125	blurry crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	drinkable weak bottle of prize-winning rum	2	good	Last Available: "2025-12"
 12127	scandalous careful chaotic Santa-Slayer medal	0		Spell Critical Percent: +10, Monster Level: -10, Sleaze Damage: +5, Single Equip, Last Available: "2025-12"
@@ -11896,7 +11896,7 @@
 12138	squat flame-retardant padded baleful fistbone	0		Spell Damage: +25, Damage Absorption: +20, Hot Resistance: +1, Last Available: "2025-12"
 12139	mirror knitted Fonzie's burnt bone belt of courage	0		Experience (Moxie): +1, Cold Resistance: +3, Spooky Resistance: +3, Single Equip, Last Available: "2025-12"
 12140	scorched skull trophy of the scaredy-cat	0		Monster Level: -15, Last Available: "2025-12"
-12141	flavorless special mirror wing bone	3	decent	Effect: "Hustlin'", Effect Duration: 25, Last Available: "2025-12"
+12141	special flavorless mirror wing bone	3	decent	Effect: "Hustlin'", Effect Duration: 25, Last Available: "2025-12"
 12142	artisanal spinning weak skeleton venom	3	EPIC	Last Available: "2025-12"
 12143	modified squat baked bone meal	1		Effect: "Well-Oiled", Effect Duration: 35, Last Available: "2025-12"
 12144	wholesome plastic skeleton rib cage	0		Maximum HP Percent: +10, Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	spoiled traditional gingerloaf	3	crappy	Last Available: "2025-12"
 12172	lousy Scotch and eggnog	4	decent	Last Available: "2025-12"
 12173	Vulcanized counterskeleton elixir	0		Effect: "Covetous Robbery", Effect Duration: 49, Last Available: "2025-12"
-12174	tolerable practically non-alcoholic &quot;salvaged&quot; wine	1	good	Last Available: "2025-12"
+12174	practically non-alcoholic tolerable &quot;salvaged&quot; wine	1	good	Last Available: "2025-12"
 12175	spinning The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	maroon crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	rotten immense wedge of prize-winning cheese	10	crappy	Last Available: "2025-12"
@@ -11942,7 +11942,7 @@
 12184	huge Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	shaking dinosaur bone fragment	0		Last Available: "2026-03"
-12187	narrow fuchsia Pork Elf pottery shard	0		Last Available: "2026-03"
+12187	fuchsia narrow Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	spinning 2015 landfill detritus	0		Last Available: "2026-03"
 12189	intact dinosaur egg	0		Last Available: "2026-03"
 12190	fossilized cow femur	0		Familiar Weight: +5
@@ -11964,7 +11964,7 @@
 12206	huge Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	gigantic moldy rat pizza	7	crappy	Last Available: "2026-03"
+12209	moldy gigantic rat pizza	7	crappy	Last Available: "2026-03"
 12210	blue Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	hoverboard of the brute of doom of the early riser	0		Muscle Percent: +30, Spooky Spell Damage: +50, Adventures: +7, Single Equip, Last Available: "2026-03"
 12212	olive perfumed hale dangerous left shark fin	0		Weapon Damage: +10, Maximum HP: +20, Stench Resistance: +5, Last Available: "2026-03"
@@ -11977,7 +11977,7 @@
 12222	tumbling pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	twirling legendary noodles	0		Last Available: "2026-05"
-12226	snack-sized decent narrow can of tuna	2	good	
+12226	decent snack-sized narrow can of tuna	2	good	
 12227	rotten alien salad	4	crappy	
 12228	delicious ratbatatouille	4	awesome	
 12229	bland pulsating onigiri	4	decent	
@@ -11985,27 +11985,27 @@
 12231	decent sauced mutton	3	good	
 12232	spoiled snack-sized hot honey ant	2	crappy	
 12233	decent tomb aspic	3	good	
-12234	thick adequate shaking later tots	5	good	
+12234	adequate thick shaking later tots	5	good	
 12235	rotten Frutti di Scatoletta	3	crappy	Last Available: "2026-05"
 12236	snack-sized decent Pesto alla Marziano	2	good	Last Available: "2026-05"
-12237	tiny adequate Arrattabbattabiata	1	good	Last Available: "2026-05"
-12238	decent jumbo Orzo di Riso	5	good	Last Available: "2026-05"
+12237	adequate tiny Arrattabbattabiata	1	good	Last Available: "2026-05"
+12238	jumbo decent Orzo di Riso	5	good	Last Available: "2026-05"
 12239	delicious narrow Pasta Grimavera	3	awesome	Last Available: "2026-05"
-12240	fancy huge stale Linguini Ubriacapa	10	decent	Effect: "Category", Effect Duration: 20, Last Available: "2026-05"
-12241	miniature normal Formica e Pepe	2	good	Last Available: "2026-05"
-12242	enchanted jumbo stale ghostly Tubetto Gelatto	5	decent	Effect: "The Strength...  of the Future", Effect Duration: 20, Last Available: "2026-05"
-12243	delicious half-sized fancy teal Gnocci Domani	2	awesome	Effect: "Antsy in your Pantsy", Effect Duration: 35, Last Available: "2026-05"
+12240	stale fancy huge Linguini Ubriacapa	10	decent	Effect: "Category", Effect Duration: 20, Last Available: "2026-05"
+12241	normal miniature Formica e Pepe	2	good	Last Available: "2026-05"
+12242	jumbo stale enchanted ghostly Tubetto Gelatto	5	decent	Effect: "The Strength...  of the Future", Effect Duration: 20, Last Available: "2026-05"
+12243	fancy half-sized delicious teal Gnocci Domani	2	awesome	Effect: "Antsy in your Pantsy", Effect Duration: 35, Last Available: "2026-05"
 12244	cyan Thwaitgold wallet moth statuette	0		
 12245	blinking scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	blurry mega helmet	0		
 12252	spinning huge huge hale beefy Space Soldier Helmet	0		Muscle: +10, Maximum HP: +20
-12253	low-calorie stale premium turkey leg	1	decent	
+12253	stale low-calorie premium turkey leg	1	decent	
 12254	weak hand-crafted wobbly styrofoam cup of mead	2	EPIC	
 12255	yellow sword of the storm	0		Maximum MP Percent: +40
 12256	tumbling foul-smelling staff	0		Stench Damage: +10
 12257	groovy lute	0		Moxie Percent: +10
-12258	blurry pulsating shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
+12258	pulsating blurry shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	lightning-fast studded The Wizard's Android of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Initiative: +40
 12261	flash paperwad	0		
@@ -12019,15 +12019,15 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	fireproof healthy Portable Laughing Stock of the ox	0		Muscle: +20, Maximum HP Percent: +20, Hot Resistance: +3, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	Sherlock's gravedigger's Staff of Anachronistic Churning of dire peril	0		Weapon Damage: +20, Spooky Damage: +10, Item Drop: +25
-12272	miniature yummy classic banana	2	awesome	Last Available: "2026-07"
-12273	huge bland watermelon	10	decent	Last Available: "2026-07"
+12272	yummy miniature classic banana	2	awesome	Last Available: "2026-07"
+12273	bland huge watermelon	10	decent	Last Available: "2026-07"
 12274	stale pulsating quince	3	decent	Last Available: "2026-07"
-12275	squat pulsating Interesting Coin	0		Last Available: "2026-08"
+12275	pulsating squat Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	toothsome classic banana pie	4	awesome	Last Available: "2026-07"
 12278	unsweetened vacuum-sealed essential banana decoction	0		Effect: "So Fresh and So Clean", Effect Duration: 18, Last Available: "2026-07"
 12279	super-enhanced double-frozen ionized banana quintessence	0		Effect: "The Two-Prong Crown", Effect Duration: 38, Last Available: "2026-07"
-12280	watered-down hand-crafted narrow Aesop Daiquiri	2	EPIC	Last Available: "2026-07"
+12280	hand-crafted watered-down narrow Aesop Daiquiri	2	EPIC	Last Available: "2026-07"
 12281	mediocre jittery Monkey Congress	3	decent	Last Available: "2026-07"
 12282	stale snack-sized watermelon pie	2	decent	Last Available: "2026-07"
 12283	diffused concentrated watermelon juice	0		Effect: "Like a Fish to Walter", Effect Duration: 40, Last Available: "2026-07"
@@ -12037,12 +12037,12 @@
 12287	rotten huge tumbling upside-down quince pie	10	crappy	Last Available: "2026-07"
 12288	galvanized triple-aerosolized blinking quince quaff	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 54, Last Available: "2026-07"
 12289	pressed ionized wobbly Quickquince	0		Effect: "Macho Profundo", Effect Duration: 64, Last Available: "2026-07"
-12290	weak mediocre Quiskey Sour	2	decent	Last Available: "2026-07"
+12290	mediocre weak Quiskey Sour	2	decent	Last Available: "2026-07"
 12291	tolerable spinning Quincea&ntilde;era Cooler	4	good	Last Available: "2026-07"
 12292	drinkable Roth IPA	3	good	Last Available: "2026-08"
 12293	jittery wizardly brainy underdraft protection	0		Mysticality: 30, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	miniature decent soybean futures	2	good	Last Available: "2026-08"
+12295	decent miniature soybean futures	2	good	Last Available: "2026-08"
 12296	polymerized mirror housing bubble	0		Effect: "Fruited", Effect Duration: 68, Last Available: "2026-08"
 12297	denatured moist Pixie-Swordz	0		Effect: "Berry Berry Cold", Effect Duration: 56
 12298	Van der Graaf financial instrument of the dark arts	0		Spell Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Mongoose_cafe_booze.txt
@@ -2,7 +2,7 @@
 -2	weak perfectly mixed Scrawny Stout	2	EPIC	
 -3	bad practically non-alcoholic mirror Infinitesimal IPA	1	decent	
 -4	practically non-alcoholic bad eggnogtini	1	decent	
--5	perfectly mixed practically non-alcoholic candycaine	1	super ultra EPIC	
+-5	practically non-alcoholic perfectly mixed candycaine	1	super ultra EPIC	
 -6	bad mirror braincracker sweet	4	decent	
 -16	aged fermented honey	4	awesome	
 -17	perfectly mixed moons-shine	4	EPIC	
@@ -10,24 +10,24 @@
 -19	aged ecto-nog	4	awesome	
 -20	fancy acceptable yellow hot toady	3	good	
 -21	lousy hot choculate	3	decent	
--49	artisanal weak pulsating Cyder	2	EPIC	
--50	special perfectly mixed Oil Nog	4	EPIC	
--51	lousy watered-down Hi-Octane Peppermint Jet Fuel	2	decent	
--58	watered-down lousy special Grimacider	2	decent	
+-49	weak artisanal pulsating Cyder	2	EPIC	
+-50	perfectly mixed special Oil Nog	4	EPIC	
+-51	watered-down lousy Hi-Octane Peppermint Jet Fuel	2	decent	
+-58	watered-down special lousy Grimacider	2	decent	
 -59	hand-crafted weak Isotope Nog	2	EPIC	
 -60	perfectly mixed irresponsibly strong wobbly Mutagin 'n' Tonic	6	EPIC	
--70	acceptable weak Gin and Herring	2	good	
--71	watered-down hand-crafted Black and Tan and Red All Over	2	EPIC	
+-70	weak acceptable Gin and Herring	2	good	
+-71	hand-crafted watered-down Black and Tan and Red All Over	2	EPIC	
 -72	bad Antarctic Ice Tea	4	decent	
--76	drinkable practically non-alcoholic CRIMBCO Ribbon Candy Schnapps	1	good	
+-76	practically non-alcoholic drinkable CRIMBCO Ribbon Candy Schnapps	1	good	
 -77	hand-crafted upside-down CRIMBCO Egg Substitute Nog Substitute	3	EPIC	
 -78	weak lousy squat CRIMBCO Extreme Braincracker Sour	2	decent	
 -82	perfectly mixed Horseradish-infused Vodka	3	EPIC	
--83	artisanal boozy Jerkitini	5	EPIC	
--84	acceptable high-proof Desert Island Iced Tea	6	good	
--88	acceptable weak Crimbo Saketini	2	good	
+-83	boozy artisanal Jerkitini	5	EPIC	
+-84	high-proof acceptable Desert Island Iced Tea	6	good	
+-88	weak acceptable Crimbo Saketini	2	good	
 -89	acceptable twirling Crimboku Drop	4	good	
 -90	aged Flaming Crimbo Log	3	awesome	
 -107	mediocre jittery Fortified Eggnog Slurry	4	decent	
 -108	artisanal Hot Buttered Rum	3	EPIC	
--109	high-proof enchanted tolerable wobbly Spicy Hot Chocolate	9	good	
+-109	tolerable enchanted high-proof wobbly Spicy Hot Chocolate	9	good	

--- a/data/TCRS/TCRS_Sauceror_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Mongoose_cafe_food.txt
@@ -1,7 +1,7 @@
 -1	bland Peche a la Frog	3	decent	
 -2	small delicious As Jus Gezund Heit	2	awesome	
--3	bite-sized rotten mirror Bouillabaise Coucher Avec Moi	1	crappy	
--7	adequate small gumdrop chow mein	2	good	
+-3	rotten bite-sized mirror Bouillabaise Coucher Avec Moi	1	crappy	
+-7	small adequate gumdrop chow mein	2	good	
 -8	stale candy cane pizza	4	decent	
 -9	delicious gingerbread stir-fry	4	awesome	
 -10	massive bland jittery twigs and gravel	8	decent	
@@ -9,37 +9,37 @@
 -12	yummy bowl of unidentifiable goo	3	awesome	
 -13	delicious pulsating gingerbread massacre	4	awesome	
 -14	decent immense It Came From Beyond Dessert	8	good	
--15	huge flavorless vampire cake	8	decent	
+-15	flavorless huge vampire cake	8	decent	
 -52	bland spinning Soylent Red and Green	3	decent	
 -53	big bland Disc-Shaped Nutrition Unit	5	decent	
 -54	yummy massive Gingerborg Hive	9	awesome	
--61	snack-sized moldy Candy Cane Surprise	2	crappy	
--62	spoiled special Grimdrop Chow Mein	4	crappy	
--63	adequate half-sized Grimgerbread House	2	good	
+-61	moldy snack-sized Candy Cane Surprise	2	crappy	
+-62	special spoiled Grimdrop Chow Mein	4	crappy	
+-63	half-sized adequate Grimgerbread House	2	good	
 -67	spoiled yellow Caviar Carbonara	4	crappy	
 -68	spoiled Halibut Alfredo	3	crappy	
--69	gigantic spoiled Red Herring Velvet Cake	10	crappy	
+-69	spoiled gigantic Red Herring Velvet Cake	10	crappy	
 -73	moldy CRIMBCO Reconstituted Gruel	3	crappy	
--74	snack-sized flavorless New and Improved CRIMBCO Reconstituted Gruel	2	decent	
+-74	flavorless snack-sized New and Improved CRIMBCO Reconstituted Gruel	2	decent	
 -75	adequate snack-sized CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	good	
 -79	normal Brussels Sprout Stir-Fry	4	good	
 -80	low-calorie moldy narrow Carrot, Cabbage, and Kale Pizza	1	crappy	
--81	flavorless super-sized upside-down Turnip and Rutabaga Pie	5	decent	
--85	bland massive Rainbow Spider Fun Roll	7	decent	
+-81	super-sized flavorless upside-down Turnip and Rutabaga Pie	5	decent	
+-85	massive bland Rainbow Spider Fun Roll	7	decent	
 -86	thick moldy Vegas Volcano Lava Roll	5	crappy	
 -87	bland Crazy Dragon Shogun Buddha Roll	4	decent	
 -92	normal miniature basic hot dog	2	good	
 -93	adequate miniature savage macho dog	2	good	
--94	moldy gigantic one with everything	10	crappy	
--95	snack-sized spoiled sly dog	2	crappy	
+-94	gigantic moldy one with everything	10	crappy	
+-95	spoiled snack-sized sly dog	2	crappy	
 -96	normal pulsating devil dog	4	good	
 -97	spoiled miniature chilly dog	2	crappy	
 -98	decent ghost dog	3	good	
 -99	spoiled junkyard dog	4	crappy	
--100	big stale lime green wet dog	5	decent	
+-100	stale big lime green wet dog	5	decent	
 -101	normal sleeping dog	3	good	
 -102	adequate half-sized optimal dog	2	good	
 -103	normal video games hot dog	4	good	
 -104	rotten miniature Peppermint Nutrition Block	2	crappy	
 -105	spoiled Gingerbread Nutrition Block	3	crappy	
--106	decent half-sized Cinnamon Nutrition Block	2	good	
+-106	half-sized decent Cinnamon Nutrition Block	2	good	

--- a/data/TCRS/TCRS_Sauceror_Opossum.txt
+++ b/data/TCRS/TCRS_Sauceror_Opossum.txt
@@ -43,7 +43,7 @@
 44	mirror worthless gewgaw	0		
 45	upside-down worthless knick-knack	0		
 46	figurine	0		
-47	stale wobbly blurry hot buttered roll	3	decent	
+47	stale blurry wobbly hot buttered roll	3	decent	
 48	skewed heart of rock and roll	0		
 49	snack-sized tasty bowl of cottage cheese	2	awesome	
 50	Temple Grandin's Rock and Roll Legend	0		Familiar Weight: +7, Class: "Accordion Thief", Song Duration: 10
@@ -52,12 +52,12 @@
 53	maroon narrow huge medical-grade stone banjo	0		HP Regen Min: 7, HP Regen Max: 10
 54	mirror lard-coated Disco Banjo of extreme caution	0		Monster Level: -25, Sleaze Spell Damage: +25, Class: "Disco Bandit"
 55	jittery jaba&ntilde;ero pepper	0		
-56	pulsating narrow hot sauce	0		
+56	narrow pulsating hot sauce	0		
 57	ribald 5-Alarm Saucepan	0		Sleaze Damage: +10, Class: "Sauceror"
 58	stone turtle	0		
 59	slingshot	0		
 60	Fonzie's Mace of the Tortoise	0		Experience (Moxie): +1, Class: "Turtle Tamer"
-61	tasty skewed wobbly fortune cookie	4	awesome	
+61	tasty wobbly skewed fortune cookie	4	awesome	
 62	manspreader's oriole-feather headdress	0		Monster Level: +10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	staff of mayonnaise of the glutton	0		Sleaze Spell Damage: +50, Food Drop: +100
 104	blurry scarecrow	0		
-105	bland thick skewed bowl of charms	5	decent	
+105	thick bland skewed bowl of charms	5	decent	
 106	ketchup	1	crappy	
 107	narrow catsup	1	crappy	
 108	blinking stick	0		
@@ -115,12 +115,12 @@
 116	personal trainer's stylish Bugfinder Blade	0		Moxie: +25, Experience Percent (Muscle): +10
 117	blinking Gnollish plunger	0		
 118	maroon spring	0		
-119	bouncing lime green sprocket	0		
+119	lime green bouncing sprocket	0		
 120	cog	0		
 121	sprocket assembly	0		
 122	cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
-124	upside-down jittery empty meat tank	0		
+124	jittery upside-down empty meat tank	0		
 125	skewed full meat tank	0		
 126	meat engine	0		
 127	twirling knitted Gnollish autoplunger	0		Cold Resistance: +3
@@ -136,7 +136,7 @@
 137	wobbly dope wheels	0		
 138	mirror ice-cold six-pack	0		
 139	valuable trinket	0		
-140	fuchsia jittery dingy planks	0		
+140	jittery fuchsia dingy planks	0		
 141	tumbling dingy dinghy	0		
 142	anticheese	0		
 143	jittery cottage	0		
@@ -152,7 +152,7 @@
 153	extremely unsafe Ancient Saucehelm of terror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +10, Class: "Sauceror", Familiar Effect: "3xGhuol, cap 25"
 154	weightlifter's Disco 'Fro Pick of the storm	0		Muscle: +15, Maximum MP Percent: +40, Class: "Disco Bandit", Familiar Effect: "3xGhuol, cap 25"
 155	avaricious beefcake's El Sombrero De Lopez	0		Muscle: +25, Meat Drop: +30, Class: "Accordion Thief", Familiar Effect: "3xGhuol, cap 25"
-156	teal bouncing guild application	0		
+156	bouncing teal guild application	0		
 157	Dramatic&trade; range	0		
 158	jittery Gnollish pie tin	0		
 159	wad of dough	0		
@@ -163,7 +163,7 @@
 164	blue smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	normal super-sized ghuol-ear kabob	5	good	
+167	super-sized normal ghuol-ear kabob	5	good	
 168	tumbling maroon crafty bone rattle	0		Maximum MP: +10
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	shaking lihc eye	0		
@@ -175,11 +175,11 @@
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	snack-sized toothsome red chorizo taco	2	awesome	
+179	toothsome snack-sized red chorizo taco	2	awesome	
 180	tolerable fancy ice-cold fotie	4	good	Effect: "Mortarfied", Effect Duration: 5
 181	jittery baseball	0		
 182	batgut	0		
-183	bouncing squat bat wing	0		
+183	squat bouncing bat wing	0		
 184	twirling briefcase	0		
 185	fat stacks of cash	0		
 186	bean	0		
@@ -196,17 +196,17 @@
 198	shaking tumbling rat appendix	0		
 199	bouncing Socratic ring	0		Experience (Mysticality): +1
 200	decent rat appendix kabob	4	good	
-201	tiny special rotten bat wing kabob	1	crappy	Effect: "Deeply Ironic", Effect Duration: 45
+201	tiny rotten special bat wing kabob	1	crappy	Effect: "Deeply Ironic", Effect Duration: 45
 202	yummy upside-down carob chunks	4	awesome	
 203	upside-down herbs	0		
 204	rotten carob chunk cookies	3	crappy	
 205	secret blend of herbs and spices	0		
 206	piercing post	0		
-207	spinning blue hippy herbal tea	1	crappy	
+207	blue spinning hippy herbal tea	1	crappy	
 208	patchouli incense stick	0		
 209	wad of tofu	0		
 210	Feng Shui for Big Dumb Idiots	0		
-211	squat cyan decorative fountain	0		
+211	cyan squat decorative fountain	0		
 212	upside-down windchimes	0		
 213	wool veiny filthy corduroys	0		Maximum HP: +10, Cold Resistance: +1, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	shellacked filthy knitted dread sack	0		Damage Reduction: 7, Familiar Effect: "1xVolley, 1xPotato, cap 15"
@@ -217,7 +217,7 @@
 219	necklace chain	0		
 220	teal gnoll teeth	0		
 221	Herculean gnoll-tooth necklace	0		Experience (Muscle): +1
-222	ghostly wobbly phat turquoise bead	0		
+222	wobbly ghostly phat turquoise bead	0		
 223	narrow phat turquoise bracelet of Calamity Jane	0		Critical Hit Percent: +15
 224	slick eyepatch	0		Moxie: +10, Familiar Effect: "3xBarrr, cap 6"
 225	adequate pulsating tofu casserole	3	good	
@@ -232,8 +232,8 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	gray groovy Bigger Bugfinder Blade of bravery	0		Moxie Percent: +10, Spooky Resistance: +5
 236	Queue Du Coq cocktailcrafting kit	0		
-237	tolerable strong bottle of gin	5	good	
-238	delicious fancy bottle of vodka	3	awesome	Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
+237	strong tolerable bottle of gin	5	good	
+238	fancy delicious bottle of vodka	3	awesome	Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
 239	frightening rock-hard Orcish baseball cap	0		Damage Reduction: 5, Spooky Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	Da Vinci's Orcish cargo shorts of dire peril	0		Experience (Mysticality): +5, Weapon Damage: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	up-at-dawn Orcish frat-paddle	0		Adventures: +5
@@ -244,19 +244,19 @@
 246	spoiled tomato	3	crappy	
 247	fermenting powder	0		
 248	mediocre irresponsibly strong salty dog	10	decent	
-249	practically non-alcoholic tolerable bloody mary	1	good	
-250	watered-down mediocre screwdriver	2	decent	
+249	tolerable practically non-alcoholic bloody mary	1	good	
+250	mediocre watered-down screwdriver	2	decent	
 251	irresponsibly strong perfectly mixed martini	6	EPIC	
 252	delicious mirror bloody beer	4	awesome	
 253	drinkable shot of schnapps	4	good	
 254	artisanal narrow spinning teal shot of grapefruit schnapps	3	EPIC	
 255	tolerable fine wine	3	good	
-256	aged fortified shot of tomato schnapps	5	awesome	
+256	fortified aged shot of tomato schnapps	5	awesome	
 257	drinkable extra-spicy bloody mary	4	good	
 258	dense meat stack	0		
 259	squat maroon upside-down snake skin	0		
 260	rotten White Citadel fries	4	crappy	
-261	moldy small White Citadel burger	2	crappy	
+261	small moldy White Citadel burger	2	crappy	
 262	decent gigantic piece of wedding cake	7	good	
 263	snack-sized adequate chocolate chips	2	good	
 264	yummy chocolate chip cookies	4	awesome	
@@ -266,7 +266,7 @@
 268	scandalous meat cowboy hat	0		Sleaze Damage: +5, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	vibrating sword	0		Maximum MP Percent: +10
 270	picket fence	0		
-271	altered huge red barbell	1		
+271	altered red huge barbell	1		
 272	powdered lime green concentrated magicalness pill	1		Effect: "Woad Warrior", Effect Duration: 10
 273	twisted blinking moxie weed	1		
 274	tumbling Familiar-Gro&trade; Terrarium	0		
@@ -295,10 +295,10 @@
 297	altered tamarind-flavored chewing gum	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 13
 298	dry huge lime-and-chile-flavored chewing gum	0		Effect: "Fangs and Pangs", Effect Duration: 53
 299	super-magnetized diffused pickle-flavored chewing gum	0		Effect: "Psalm of Pointiness", Effect Duration: 39
-300	flattened shaking blurry jaba&ntilde;ero-flavored chewing gum	0		Effect: "Disco Neuropathy", Effect Duration: 12
+300	flattened blurry shaking jaba&ntilde;ero-flavored chewing gum	0		Effect: "Disco Neuropathy", Effect Duration: 12
 301	shaking flat dough	0		
 302	normal half-sized Knob sausage	2	good	
-303	special half-sized moldy Knob mushroom	2	crappy	Effect: "The Chains Down In The Belly-O", Effect Duration: 35
+303	half-sized moldy special Knob mushroom	2	crappy	Effect: "The Chains Down In The Belly-O", Effect Duration: 35
 304	dry noodles	0		
 305	beefy Knob Goblin harem pants	0		Muscle: +10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	rock-hard Knob Goblin harem veil	0		Damage Reduction: 5, Familiar Effect: "5xLep, cap 2"
@@ -310,17 +310,17 @@
 312	frightening Knob Goblin visor	0		Spooky Damage: +5, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	Crown of the Goblin King of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	adequate bean burrito	3	good	
-315	bland low-calorie bean burrito	1	decent	
-316	small tasty wobbly insanely bean burrito	2	awesome	
+315	low-calorie bland bean burrito	1	decent	
+316	tasty small wobbly insanely bean burrito	2	awesome	
 317	rotten pulsating bean burrito	3	crappy	
 318	bland mirror bean burrito	3	decent	
 319	normal insanely bean burrito	4	good	
-320	stale enchanted blurry bat haggis	3	decent	Effect: "Bright!", Effect Duration: 20
+320	enchanted stale blurry bat haggis	3	decent	Effect: "Bright!", Effect Duration: 20
 321	tasty skewed menudo	4	awesome	
-322	half-sized adequate goat cheese	2	good	
-323	flavorless diet squat plain pizza	1	decent	
+322	adequate half-sized goat cheese	2	good	
+323	diet flavorless squat plain pizza	1	decent	
 324	enchanted decent sausage pizza	3	good	Effect: "Employee of the Month", Effect Duration: 20
-325	moldy cyan spinning goat cheese pizza	4	crappy	
+325	moldy spinning cyan goat cheese pizza	4	crappy	
 326	low-calorie flavorless mushroom pizza	1	decent	
 327	goat	0		
 328	delicious fancy skewed bottle of whiskey	3	awesome	Effect: "Feline Ferocity", Effect Duration: 30
@@ -354,7 +354,7 @@
 356	Oprah's snowboarder pants	0		Maximum MP Percent: +50, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	rotten gr8ps	3	crappy	
-359	tasty thick t8r tots	5	awesome	
+359	thick tasty t8r tots	5	awesome	
 360	ghostly steel-toed miner's helmet	0		Damage Reduction: 9, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	lightning-fast miner's pants	0		Initiative: +40, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	teal sizzling 7-Foot Dwarven mattock	0		Hot Damage: +10
@@ -395,7 +395,7 @@
 397	yakskin pants of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "stench atk, 1xPotato, cap 35"
 398	Samson's hippopotamus pants	0		Experience (Muscle): +5, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
 399	twirling knitted eXtreme mittens	0		Cold Resistance: +3
-400	gray ghostly handful of drink tickets	0		
+400	ghostly gray handful of drink tickets	0		
 401	bouncing Knob Kitchen grab-bag	0		
 402	fuchsia smartaleck's swashbuckling pants	0		Moxie Percent: +30, Familiar Effect: "3xPotato, 1.5xFairy, cap 20"
 403	nippy shoulder parrot	0		Cold Damage: +10
@@ -414,13 +414,13 @@
 416	tumbling dog trainer's safarrri hat	0		Experience (familiar): +1, Familiar Effect: "2xVolley, cap 22"
 417	extra-colloidal henna tattoo	0		Effect: "Crocodile Tear", Effect Duration: 24
 418	ionized galvanized pickled skewed Ferrigno's Elixir of Power	0		Effect: "Wolf's Bane", Effect Duration: 36
-419	dry skewed maroon serum of sarcasm	0		Effect: "Wallflowering", Effect Duration: 23
+419	dry maroon skewed serum of sarcasm	0		Effect: "Wallflowering", Effect Duration: 23
 420	alkaline lime green tomato juice of powerful power	0		Effect: "Yes, Can Haz", Effect Duration: 55
 421	pickled galvanized shaking skewed philter of phorce	0		Effect: "Human-Undead Hybrid", Effect Duration: 18
 422	diffused potion of potency	0		Effect: "Weird Flavor", Effect Duration: 16
 423	non-cold-filtered cordial of concentration	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 62
 424	pickled moist ointment of the occult	0		Effect: "Fancy Feasted", Effect Duration: 57
-425	colloidal extra-frozen pulsating maroon oil of expertise	0		Effect: "Inappropriate Spirit", Effect Duration: 53
+425	colloidal extra-frozen maroon pulsating oil of expertise	0		Effect: "Inappropriate Spirit", Effect Duration: 53
 426	adjusted potion of temporary gr8ness	0		Effect: "Tiki Temerity", Effect Duration: 39
 427	teal resourceful box	0		Maximum MP: +50, Wiki Name: "box"
 428	nothing-in-the-box	0		
@@ -451,7 +451,7 @@
 453	cyan sober pill	0		
 454	screwdriver	0		
 455	moldy jumbo olive	4	crappy	
-456	tolerable watered-down dry martini	2	good	
+456	watered-down tolerable dry martini	2	good	
 457	shaking smooth ye olde golde frontes	0		Moxie: +15, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
@@ -462,11 +462,11 @@
 464	jittery pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	enchanted stale pixel pie	3	decent	Effect: "Magically Delicious", Effect Duration: 45
-468	wobbly yellow ruby W	0		
-469	spinning fuchsia wussiness potion	0		
+467	stale enchanted pixel pie	3	decent	Effect: "Magically Delicious", Effect Duration: 45
+468	yellow wobbly ruby W	0		
+469	fuchsia spinning wussiness potion	0		
 470	weak drinkable Imp Ale	2	good	
-471	miniature fancy flavorless purple hot wing	2	decent	Effect: "Sweet and Red", Effect Duration: 5
+471	miniature flavorless fancy purple hot wing	2	decent	Effect: "Sweet and Red", Effect Duration: 5
 472	razor-sharp diamond-studded cane	0		Weapon Damage Percent: +25, Class: "Disco Bandit"
 473	up-at-dawn crutch	0		Adventures: +5
 474	blinking cast	0		
@@ -493,7 +493,7 @@
 495	shaking catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	bland miniature papaya	2	decent	
+498	miniature bland papaya	2	decent	
 499	deadly denim axe of the cheetah	0		Weapon Damage: +5, Initiative: +60
 500	Elf Farm Raffle ticket	0		
 501	immense decent Elfin shortbread	9	good	
@@ -508,7 +508,7 @@
 510	bouncing Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	green Sneaky Pete's key lime	0		
-513	normal half-sized Boris's key lime pie	2	good	
+513	half-sized normal Boris's key lime pie	2	good	
 514	bland Jarlsberg's key lime pie	3	decent	
 515	moldy Sneaky Pete's key lime pie	4	crappy	
 516	blurry Hey Deze map	0		
@@ -519,7 +519,7 @@
 521	lime green kickback cookbook of the ox	0		Muscle: +20
 522	twirling one-winged stab bat	0		
 523	purple tumbling rewinged stab bat	0		
-524	weak bad spinning papaya sling	2	decent	
+524	bad weak spinning papaya sling	2	decent	
 525	blinking grue egg	0		
 526	yellow Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -535,7 +535,7 @@
 537	pr0n legs	0		
 538	tumbling f3d0r4 of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 27"
 539	upside-down lowercase N	0		
-540	improved green twirling Tasty Fun Good rice candy	0		Effect: "Poker Faced", Effect Duration: 36
+540	improved twirling green Tasty Fun Good rice candy	0		Effect: "Poker Faced", Effect Duration: 36
 541	executive draggin' ball hat of horror	0		Spooky Spell Damage: +25, Meat Drop: +40, Familiar Effect: "atk, 1xVolley, cap 25"
 542	shaking wool brawny 1337 7r0uZ0RZ	0		Muscle Percent: +20, Cold Resistance: +1, Familiar Effect: "2xPotato, cap 27"
 543	spoiled Trollhouse cookies	3	crappy	
@@ -543,43 +543,43 @@
 545	moldy Spam Witch sammich	4	crappy	
 546	purple meat vortex	0		
 547	334 scroll	0		
-548	squat squat teal 668 scroll	0		
+548	squat teal squat 668 scroll	0		
 549	30669 scroll	0		
 550	33398 scroll	0		
 551	64067 scroll	0		
 552	narrow 64735 scroll	0		
 553	31337 scroll	0		
-554	enchanted stale pr0n cocktail	4	decent	Effect: "Dirty Pear", Effect Duration: 25
+554	stale enchanted pr0n cocktail	4	decent	Effect: "Dirty Pear", Effect Duration: 25
 555	mirror jittery flame-retardant scorching drywall axe	0		Hot Damage: +25, Hot Resistance: +1
 556	Pine-Fresh air freshener of the cheetah	0		Initiative: +60
-557	high-proof perfectly mixed squat whiskey and cola	7	EPIC	
+557	perfectly mixed high-proof squat whiskey and cola	7	EPIC	
 558	thick decent pulsating maroon papaya taco	5	good	
 559	razor-sharp can lid	0		
 560	rotten narrow stalk of asparagus	3	crappy	
 561	pregnant mushroom	0		
 562	blinking ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	boozy lousy yellow shaking Mad Train wine	5	decent	
+564	boozy lousy shaking yellow Mad Train wine	5	decent	
 565	twirling hobo gloves of the wise owl	0		Mysticality: +20, Single Equip
 566	nasty bum cheek	0		Stench Damage: +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	ghostly hermit script	0		
-568	huge rotten Double Bacon Beelzeburger	6	crappy	
-569	special spoiled pulsating green Lord of the Flies-sized fries	3	crappy	Effect: "Pyramid Power", Effect Duration: 15
+568	rotten huge Double Bacon Beelzeburger	6	crappy	
+569	special spoiled green pulsating Lord of the Flies-sized fries	3	crappy	Effect: "Pyramid Power", Effect Duration: 15
 570	flavorless teal Chicken Sandwich	3	decent	
 571	Jumbo Dr. Lucifer	1	decent	
-572	adequate snack-sized Children's Meal of the Damned	2	good	
+572	snack-sized adequate Children's Meal of the Damned	2	good	
 573	decent noodles	3	good	
 574	toothsome noodles	4	awesome	
 575	decent painful penne pasta	3	good	
-576	bland massive ravioli della hippy	10	decent	
-577	miniature decent pr0n m4nic0tti	2	good	
+576	massive bland ravioli della hippy	10	decent	
+577	decent miniature pr0n m4nic0tti	2	good	
 578	adequate Hell ramen	3	good	
 579	adequate boring spaghetti	3	good	
 580	sauce of the ages	0		
 581	squat schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	half-sized normal fettucini Inconnu	2	good	
-584	big yummy blinking spaghetti with Skullheads	5	awesome	
+584	yummy big blinking spaghetti with Skullheads	5	awesome	
 585	moldy miniature gnocchetti di Nietzsche	2	crappy	
 586	fireproof ridiculously huge sword of the sewer	0		Stench Damage: +25, Hot Resistance: +3
 587	dry maroon super-spiky hair gel	0		Effect: "Grumpy and Ornery", Effect Duration: 26
@@ -620,7 +620,7 @@
 622	blue awful poetry journal	0		
 623	WA	0		
 624	NG	0		
-625	spinning jittery wang	0		
+625	jittery spinning wang	0		
 626	lime green Wand of Nagamar	0		
 627	ND	0		
 628	metallic A	0		
@@ -631,12 +631,12 @@
 633	stanky crafty wolf mask	0		Maximum MP: +10, Stench Spell Damage: +25, Familiar Effect: "1xBarrr, HP regen, cap 37"
 634	cool whip	0		
 635	aromatic paper umbrella	0		Stench Resistance: +1
-636	ghostly narrow meat globe	0		
+636	narrow ghostly meat globe	0		
 637	narrow toaster	0		
 638	bouncing asshat of the sewer of mayonnaise	0		Stench Damage: +25, Sleaze Spell Damage: +50, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	normal enchanted spinning abominable snowcone	3	good	Effect: "Serendipi Tea", Effect Duration: 5
 640	Ent cider	1	awesome	
-641	snack-sized stale toast	2	decent	
+641	stale snack-sized toast	2	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
@@ -669,17 +669,17 @@
 671	bouncing twirling teal horrifying grave robbing shovel of the brute	0		Muscle Percent: +30, Spooky Damage: +25
 672	stale immense cranberries	7	decent	
 673	irresponsibly strong mediocre vodka and cranberry	6	decent	
-674	perfectly mixed spirit-forward whiskey	5	EPIC	
+674	spirit-forward perfectly mixed whiskey	5	EPIC	
 675	up-at-dawn skull of the Bonerdagon	0		Adventures: +5
 676	cyan dragonbone belt buckle	0		
 677	wobbly badass belt of bravery	0		Spooky Resistance: +5
 678	red chest of the Bonerdagon	0		
-679	watered-down hand-crafted roll in the hay	2	EPIC	
+679	hand-crafted watered-down roll in the hay	2	EPIC	
 680	tolerable slap and tickle	4	good	
-681	high-proof drinkable mirror slip 'n' slide	7	good	
+681	drinkable high-proof mirror slip 'n' slide	7	good	
 682	drinkable skewed a sump'm sump'm	3	good	
-683	watered-down tolerable pulsating horizontal tango	2	good	
-684	mediocre irresponsibly strong pink pony	9	decent	
+683	tolerable watered-down pulsating horizontal tango	2	good	
+684	irresponsibly strong mediocre pink pony	9	decent	
 685	greedy smartaleck's Mr. Shirt of horror	0		Moxie Percent: +30, Spooky Spell Damage: +25, Meat Drop: +20
 686	bouncing knuckles of the sweet-tooth	0		Candy Drop: +100
 687	aerosolized dry blinking blood of the Wereseal	0		Effect: "Hobonic", Effect Duration: 55
@@ -716,7 +716,7 @@
 720	wobbly supercharged Sinatra's porquoise necklace	0		Experience (Moxie): +5, Maximum MP Percent: +30, Single Equip
 721	porquoise bracelet of the ox of the cougar	0		Muscle: +20, Moxie: +20
 722	chilly porquoise ring of the ox of the sewer	0		Muscle: +20, Cold Damage: +5, Stench Damage: +25, Single Equip
-723	massive adequate Knoll mushroom	9	good	
+723	adequate massive Knoll mushroom	9	good	
 724	low-calorie decent mushroom	1	good	
 725	one million meat pancakes	0		
 726	dance instructor's huge mirror shard	0		Experience Percent (Moxie): +10
@@ -735,7 +735,7 @@
 739	tambourine bells	0		
 740	gray inspector's tambourine	0		Item Drop: +15
 741	broken skull	0		
-742	stale super-sized pulsating Knoll shroomkabob	5	decent	
+742	super-sized stale pulsating Knoll shroomkabob	5	decent	
 743	rotten jumbo ghostly mushroom	5	crappy	
 744	moist hair spray	0		Effect: "Goldentongue", Effect Duration: 40
 746	stat script	0		
@@ -743,17 +743,17 @@
 748	gourd potion	0		
 749	special moldy warm mushroom	4	crappy	Effect: "Weird Flavor", Effect Duration: 15
 750	small rotten mushroom quesadilla	2	crappy	
-751	diet moldy cool mushroom	1	crappy	
-752	diet moldy shaking cool mushroom casserole	1	crappy	
+751	moldy diet cool mushroom	1	crappy	
+752	moldy diet shaking cool mushroom casserole	1	crappy	
 753	tasty small pointy mushroom	2	awesome	
 754	normal cream of pointy mushroom soup	4	good	
-755	adequate super-sized huge mushroom	5	good	
+755	super-sized adequate huge mushroom	5	good	
 756	normal mushroom	3	good	
 757	spoiled mirror narrow mushroom	3	crappy	
 758	decent shaking ghost cucumber	3	good	
 759	dill	0		
 760	narrow shaking vinegar	0		
-761	pulsating bouncing brine	0		
+761	bouncing pulsating brine	0		
 762	tolerable watered-down red especially salty dog	2	good	
 763	ghostly pickling solution	0		
 764	rotten snack-sized ghostly spectral pickle	2	crappy	
@@ -776,21 +776,21 @@
 781	adjusted wet mafia aria	0		Effect: "Mushroom Samba", Effect Duration: 25
 782	spinning fuchsia Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	lousy practically non-alcoholic Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
+784	practically non-alcoholic lousy Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	yummy strawberry	4	awesome	
 787	aged bottle of rum	3	awesome	
-788	practically non-alcoholic mediocre strawberry daiquiri	1	decent	
-789	spirit-forward special lousy rum and cola	5	decent	Effect: "Hella Smooth", Effect Duration: 30
+788	mediocre practically non-alcoholic strawberry daiquiri	1	decent	
+789	special spirit-forward lousy rum and cola	5	decent	Effect: "Hella Smooth", Effect Duration: 30
 790	distilled bad grog	5	decent	
 791	rosy-cheeked stiffened Mafia bow tie	0		Damage Reduction: 1, Maximum HP Percent: +30, Last Available: "2004-10"
 792	spinning Da Vinci's Golden Mr. Accessory	0		Experience (Mysticality): +5, Softcore Only
-793	ionized unsweetened mirror shaking oil of stability	0		Effect: "Craft Tea", Effect Duration: 30
+793	ionized unsweetened shaking mirror oil of stability	0		Effect: "Craft Tea", Effect Duration: 30
 794	energized oil of slipperiness	0		Effect: "Granolarrrgh", Effect Duration: 12
 795	artisanal tumbling Acque Luride Grezze Cabernet	4	EPIC	Last Available: "2004-10"
 796	blinking horrifying sizzling cement shoes of the cheetah	0		Hot Damage: +10, Spooky Damage: +25, Initiative: +60, Last Available: "2004-10"
 797	practically non-alcoholic artisanal spinning rockin' wagon	1	super ultra mega turbo EPIC	
-798	weak artisanal ocean motion	2	EPIC	
+798	artisanal weak ocean motion	2	EPIC	
 799	tolerable fuzzbump	3	good	
 800	decent ghostly poutine	3	good	
 801	flavorless tiny wobbly Knob stir-fry	1	decent	
@@ -800,19 +800,19 @@
 807	flavorless olive stir-fry	4	decent	
 808	spoiled Knob sausage stir-fry	4	crappy	
 809	adequate bat wing stir-fry	3	good	
-810	flavorless small rat appendix stir-fry	2	decent	
+810	small flavorless rat appendix stir-fry	2	decent	
 811	yummy huge bouncing tofu stir-fry	6	awesome	
 812	bland pr0n stir-fry	3	decent	
-813	decent snack-sized lime green Knob shells	2	good	
+813	snack-sized decent lime green Knob shells	2	good	
 814	spoiled pulsating b&auml;tzle	4	crappy	
-815	rotten gigantic narrow ratini	8	crappy	
-816	rotten enchanted Knob stroganoff	3	crappy	Effect: "Muddled", Effect Duration: 25
-817	jumbo adequate menudo ravioli	5	good	
+815	gigantic rotten narrow ratini	8	crappy	
+816	enchanted rotten Knob stroganoff	3	crappy	Effect: "Muddled", Effect Duration: 25
+817	adequate jumbo menudo ravioli	5	good	
 818	jittery plus sign	0		
 819	milky potion	0		
 820	bouncing swirly potion	0		
 821	bubbly potion	0		
-822	tumbling shaking smoky potion	0		
+822	shaking tumbling smoky potion	0		
 823	wobbly cloudy potion	0		
 824	effervescent potion	0		
 825	fizzy potion	0		
@@ -820,14 +820,14 @@
 827	murky potion	0		
 828	baby killer bee	0		
 829	anti-anti-antidote	0		
-830	adequate super-sized royal jelly	5	good	
+830	super-sized adequate royal jelly	5	good	
 831	small box	0		
 832	box	0		
 833	purple scorching vorpal blade	0		Hot Damage: +25
 834	hale cornuthaum of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +20, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	teal wobbly narrow ring of aggravate monster of the brazier	0		Hot Spell Damage: +25
-836	decent special mind flayer corpse	4	good	Effect: "Amorous Avarice", Effect Duration: 40
-837	practically non-alcoholic delicious tumbling Uovo Marcio Shiraz	1	awesome	Last Available: "2004-10"
+836	special decent mind flayer corpse	4	good	Effect: "Amorous Avarice", Effect Duration: 40
+837	delicious practically non-alcoholic tumbling Uovo Marcio Shiraz	1	awesome	Last Available: "2004-10"
 838	flame-wreathed banded Mafia stogie	0		Damage Absorption: +100, Hot Spell Damage: +10, Last Available: "2004-10"
 839	drinkable squat Maiali Sifilitici Pinot Noir	4	good	Last Available: "2004-10"
 840	double-paned wool Mafia violin case	0		Cold Resistance: 6, Last Available: "2004-10"
@@ -867,7 +867,7 @@
 876	tumbling baleful incredibly dense meat gem of the brute of chilblains	0		Muscle Percent: +30, Spell Damage: +25, Cold Damage: +25
 877	coward's Talisman of Baio	0		Monster Level: -20
 878	rosy-cheeked hypnodisk	0		Maximum HP Percent: +30
-879	wet bouncing ghostly bottle of goofballs	0		Effect: "Hagnk's Gratitude", Effect Duration: 24
+879	wet ghostly bouncing bottle of goofballs	0		Effect: "Hagnk's Gratitude", Effect Duration: 24
 880	Jim Carey's disbelief suspenders	0		Monster Level: +25
 881	red experienced supportive bra	0		Experience: +2
 882	wobbly Blatantly Canadian	0		
@@ -888,7 +888,7 @@
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	fuchsia custom avatar form	0		Free Pull
-900	jittery shaking smile-sharpening stone	0		Familiar Weight: +5
+900	shaking jittery smile-sharpening stone	0		Familiar Weight: +5
 901	bouncing espresso maker	0		Familiar Weight: +5
 902	blurry 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	hand-crafted tumbling pulsating blurry Spasmi Dolorosi Del Rene Champagne	3	super EPIC	Last Available: "2004-10"
@@ -898,7 +898,7 @@
 907	chilled alkaline blinking Mr. Mediocrebar	0		Effect: "Preemptive Medicine", Effect Duration: 28
 908	energized Cold Hots candy	0		Effect: "Improved Candy Vision", Effect Duration: 67
 909	diffused magnetized olive Wint-O-Fresh mint	0		Effect: "Sticky Fingers", Effect Duration: 24
-910	adequate big bouncing dwarf bread	5	good	
+910	big adequate bouncing dwarf bread	5	good	
 911	extra-activated lime green Senior Mints	0		Effect: "You're Not Cooking", Effect Duration: 57
 912	corrupted deionized pixellated candy heart	0		Effect: "Down With Chow", Effect Duration: 19
 913	dry kobold	0		Effect: "Lubed", Effect Duration: 59
@@ -914,14 +914,14 @@
 923	twirling huge broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	spinning dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
-926	super-pressed tarnished tumbling blinking Hawking's Elixir of Brilliance	0		Effect: "Hiding in Plain Sight", Effect Duration: 42
+926	super-pressed tarnished blinking tumbling Hawking's Elixir of Brilliance	0		Effect: "Hiding in Plain Sight", Effect Duration: 42
 927	smooth practically non-alcoholic Ferita Del Petto Zinfandel	1	awesome	Last Available: "2006-12"
 928	huge fuzzy bracelets of doom	0		Spooky Spell Damage: +50
 929	wobbly arse-shooting crossbow of the cougar	0		Moxie: +20
 931	delicious spiced rum	3	awesome	
 932	mediocre distilled eggnog	5	decent	
 933	tasty jittery candy cane	3	awesome	
-934	half-sized stale olive gingerbread bugbear	2	decent	
+934	stale half-sized olive gingerbread bugbear	2	decent	
 935	imitation nice watch of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -941,10 +941,10 @@
 951	blurry extra special Crimbo stocking	0		Last Available: "2004-12"
 952	Temple Grandin's steel-toed hockey mask	0		Damage Reduction: 9, Familiar Weight: +7, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
-954	wobbly cyan orphan baby yeti	0		Free Pull, Last Available: "2011-12"
+954	cyan wobbly orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	brawny fez of etymology	0		Muscle Percent: +20, Familiar Effect: "1xLep, cap 30"
 956	decent cyan carob chunk noodles	3	good	
-957	spoiled bite-sized chorizo brownies	1	crappy	
+957	bite-sized spoiled chorizo brownies	1	crappy	
 958	decent chocolate and tomato pizza	3	good	
 959	flange	0		
 960	clockwork key	0		
@@ -988,31 +988,31 @@
 1000	skewed Meat maid	0		
 1002	narrow shaking sharpshooter's Xlyinia's notebook	0		Critical Hit Percent: +10
 1003	pulsating soda water	0		
-1004	mediocre special bottle of tequila	4	decent	Effect: "Vitamin-Maxed", Effect Duration: 35
+1004	special mediocre bottle of tequila	4	decent	Effect: "Vitamin-Maxed", Effect Duration: 35
 1005	acceptable boxed wine	4	good	
 1006	half-sized normal cherry	2	good	
 1007	shaking brawny coconut shell	0		Muscle Percent: +20, Familiar Effect: "1xFairy, cap 7"
 1008	upside-down Van der Graaf ice cubes	0		MP Regen Min: 5, MP Regen Max: 7
-1009	artisanal high-proof vodka martini	7	EPIC	
+1009	high-proof artisanal vodka martini	7	EPIC	
 1010	weak tolerable whiskey and soda	2	good	
-1011	drinkable practically non-alcoholic shaking monkey wrench	1	good	
+1011	practically non-alcoholic drinkable shaking monkey wrench	1	good	
 1012	tolerable tequila sunrise	4	good	
-1013	weak acceptable margarita	2	good	
-1014	irresponsibly strong hand-crafted cyan strawberry wine	8	EPIC	
+1013	acceptable weak margarita	2	good	
+1014	hand-crafted irresponsibly strong cyan strawberry wine	8	EPIC	
 1015	drinkable watered-down wine spritzer	2	good	
-1016	irresponsibly strong lousy perpendicular hula	7	decent	
+1016	lousy irresponsibly strong perpendicular hula	7	decent	
 1017	mediocre ducha de oro	3	decent	
-1018	weak acceptable narrow calle de miel	2	good	
+1018	acceptable weak narrow calle de miel	2	good	
 1019	mediocre dry vodka martini	3	decent	
 1020	drinkable extra-dry old-fashioned	5	good	
 1021	acceptable watered-down tequila with training wheels	2	good	
 1022	boozy aged sangria	5	awesome	
 1023	tolerable weak vesper	2	good	Last Available: "2004-12"
 1024	aged practically non-alcoholic bodyslam	1	awesome	Last Available: "2004-12"
-1025	hand-crafted irresponsibly strong maroon wobbly sangria del diablo	7	EPIC	Last Available: "2004-12"
+1025	irresponsibly strong hand-crafted wobbly maroon sangria del diablo	7	EPIC	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	jittery whip kit	0		
-1028	ghostly green buckler buckle	0		
+1028	green ghostly buckler buckle	0		
 1029	deadly hippo whip	0		Weapon Damage: +5
 1030	Lo Pan's penguin whip	0		Spell Critical Percent: +30
 1031	nasty yak whip	0		Stench Damage: +5
@@ -1024,7 +1024,7 @@
 1037	resourceful gnauga hide buckler	0		Maximum MP: +50, Damage Reduction: 5
 1038	flattened extra-unsweetened blue twirling Connery's Elixir of Audacity	0		Effect: "Wet Willied", Effect Duration: 59
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	delicious high-proof pulsating beer	10	awesome	
+1041	high-proof delicious pulsating beer	10	awesome	
 1042	Jeselnik's string of beads	0		Sleaze Damage: +25
 1043	shaking vibrating string of beads	0		Maximum MP Percent: +10
 1044	wizardly string of beads	0		Mysticality: +25
@@ -1036,11 +1036,11 @@
 1050	modified yellow oyster egg	1		
 1051	plastic oyster egg	0		
 1052	mixed oyster egg	1		Effect: "Pride of the Vampire", Effect Duration: 25
-1053	compressed ghostly yellow oyster egg	1		Effect: "Morninja", Effect Duration: 10
+1053	compressed yellow ghostly oyster egg	1		Effect: "Morninja", Effect Duration: 10
 1054	boiled squat oyster egg	1		Effect: "Yuletide Mutations", Effect Duration: 30
 1055	narrow plastic oyster egg	0		
 1056	mixed puce oyster egg	1		
-1057	modified narrow green puce oyster egg	1		Effect: "Ruthlessly Efficient", Effect Duration: 35
+1057	modified green narrow puce oyster egg	1		Effect: "Ruthlessly Efficient", Effect Duration: 35
 1058	altered red puce oyster egg	1		
 1059	puce plastic oyster egg	0		
 1060	diluted mauve oyster egg	1		
@@ -1124,14 +1124,14 @@
 1138	mushroom fermenting solution	0		
 1139	hand-crafted squat mushroom wine	3	EPIC	
 1140	aged bouncing icy mushroom wine	4	awesome	
-1141	hand-crafted twirling blue mushroom wine	4	EPIC	
+1141	hand-crafted blue twirling mushroom wine	4	EPIC	
 1142	smooth irresponsibly strong pointy mushroom wine	7	awesome	
-1143	drinkable practically non-alcoholic ghostly flat mushroom wine	1	good	
+1143	practically non-alcoholic drinkable ghostly flat mushroom wine	1	good	
 1144	fancy tolerable practically non-alcoholic spinning cool mushroom wine	1	good	Effect: "Hood Ridin'", Effect Duration: 45
-1145	tolerable maroon shaking knob mushroom wine	3	good	
-1146	aged enchanted knoll mushroom wine	4	awesome	Effect: "Disco State of Mind", Effect Duration: 5
+1145	tolerable shaking maroon knob mushroom wine	3	good	
+1146	enchanted aged knoll mushroom wine	4	awesome	Effect: "Disco State of Mind", Effect Duration: 5
 1147	drinkable purple mushroom wine	3	good	
-1148	triple-distilled artisanal shot of flower schnapps	7	EPIC	
+1148	artisanal triple-distilled shot of flower schnapps	7	EPIC	
 1149	bland flower petal pie	4	decent	
 1150	practically non-alcoholic drinkable bottle of single-barrel whiskey	1	good	
 1151	dog trainer's beefy discarded plastic fork	0		Muscle: +10, Experience (familiar): +1
@@ -1154,17 +1154,17 @@
 1169	exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	narrow coffin	0		
-1172	yellow spinning asbestos box	0		
+1172	spinning yellow asbestos box	0		
 1173	linoleum box	0		
 1174	twirling chrome box	0		
-1175	squat ghostly cryptic puzzle box	0		
+1175	ghostly squat cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	magnetic field	0		
 1178	potted cactus	0		
 1179	huge daisy	0		
 1180	narrow potted fern	0		
 1181	tulip	0		
-1182	wobbly mirror Venus flytrap	0		
+1182	mirror wobbly Venus flytrap	0		
 1183	upside-down all-purpose flower	0		
 1184	exotic orchid	0		
 1185	long-stemmed rose	0		
@@ -1183,15 +1183,15 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	decent mugcake	4	good	
-1201	super-sized enchanted rotten urinal cake	5	crappy	Effect: "For Your Brain Only", Effect Duration: 25
-1202	big special stale Happy Birthday, Claude! cake	5	decent	Effect: "Muscle Unbound", Effect Duration: 50
+1201	rotten enchanted super-sized urinal cake	5	crappy	Effect: "For Your Brain Only", Effect Duration: 25
+1202	special big stale Happy Birthday, Claude! cake	5	decent	Effect: "Muscle Unbound", Effect Duration: 50
 1203	gigantic bland personalized birthday cake	8	decent	
-1204	bland half-sized three-tiered wedding cake	2	decent	
+1204	half-sized bland three-tiered wedding cake	2	decent	
 1205	moldy babycakes	3	crappy	
-1206	bland huge pulsating upside-down velvet cake	6	decent	
+1206	huge bland upside-down pulsating velvet cake	6	decent	
 1207	flavorless squat congratulatory cake	3	decent	
-1208	diet spoiled angel-food cake	1	crappy	
-1209	half-sized spoiled blinking maroon pulsating shaking devil's-food cake	2	crappy	
+1208	spoiled diet angel-food cake	1	crappy	
+1209	half-sized spoiled shaking pulsating maroon blinking devil's-food cake	2	crappy	
 1210	gigantic bland gray birthday party jellybean cheesecake	6	decent	
 1211	huge balloon	0		
 1212	balloon	0		
@@ -1235,9 +1235,9 @@
 1251	stale Knob shroomkabob	4	decent	
 1252	moldy upside-down shroomkabob	3	crappy	
 1253	pile of jumping beans	0		
-1254	enchanted yummy snack-sized jittery jumping bean burrito	2	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 35
+1254	snack-sized yummy enchanted jittery jumping bean burrito	2	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 35
 1255	bland jumping bean burrito	4	decent	
-1256	bland jumbo insanely jumping bean burrito	5	decent	
+1256	jumbo bland insanely jumping bean burrito	5	decent	
 1257	spoiled pulsating maroon rat scrapple	3	crappy	
 1258	pail of pretentious paint	0		
 1259	greedy cool traffic cone	0		Moxie: +5, Meat Drop: +20, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
@@ -1251,7 +1251,7 @@
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	ebony wand	0		
-1270	spinning red hexagonal wand	0		
+1270	red spinning hexagonal wand	0		
 1271	aluminum wand	0		
 1272	ghostly marble wand	0		
 1273	blinking flame-retardant magic lamp	0		Hot Resistance: +1
@@ -1340,16 +1340,16 @@
 1357	delicious watered-down Mt. Noob Pale Ale	2	awesome	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
-1360	twirling huge pirate zombie robot head	0		Last Available: "2005-11"
+1360	huge twirling pirate zombie robot head	0		Last Available: "2005-11"
 1361	smartaleck's disembodied smile	0		Moxie Percent: +30, Single Equip
 1362	sausage	0		
 1363	blinking clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	tasty bite-sized tumbling tofurkey leg	1	awesome	
+1365	bite-sized tasty tumbling tofurkey leg	1	awesome	
 1366	adequate tofurkey gravy	3	good	
 1367	moldy herbal stuffing	3	crappy	
-1368	snack-sized delicious can-shaped gelatinous cranberry sauce	2	awesome	
-1369	massive bland yams	9	decent	
+1368	delicious snack-sized can-shaped gelatinous cranberry sauce	2	awesome	
+1369	bland massive yams	9	decent	
 1370	tumbling rhinestone cowboy shirt of horror	0		Spooky Spell Damage: +25
 1371	up-at-dawn gingham blouse	0		Adventures: +5
 1372	souvenir ski t-shirt of horror	0		Spooky Spell Damage: +25
@@ -1385,14 +1385,14 @@
 1403	chaotic can of fake snow	0		Spell Critical Percent: +10, Last Available: "2005-12"
 1404	blinking crafty colored-light &quot;necklace&quot;	0		Maximum MP: +10, Last Available: "2005-12"
 1405	narrow experienced tree skirt	0		Experience: +2, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	moldy half-sized enchanted wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	enchanted moldy half-sized wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	flavorless bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	adequate tree-shaped Crimbo cookie	4	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	asbestos-lined Unionize The Elves sign	0		Hot Resistance: +5, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	moist snowcone	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 29, Last Available: "2006-01"
-1413	tarnished triple-moist mirror maroon snowcone	0		Effect: "In Vino Vires", Effect Duration: 52, Last Available: "2006-01"
+1413	tarnished triple-moist maroon mirror snowcone	0		Effect: "In Vino Vires", Effect Duration: 52, Last Available: "2006-01"
 1414	galvanized galvanized snowcone	0		Effect: "Arcane in the Brain", Effect Duration: 69, Last Available: "2006-01"
 1415	polarized colloidal dry snowcone	0		Effect: "Ticking Clock", Effect Duration: 43, Last Available: "2006-01"
 1416	modified modified olive snowcone	0		Effect: "Pretending to Pretend", Effect Duration: 58, Last Available: "2006-01"
@@ -1410,7 +1410,7 @@
 1428	stale blinking grue egg omelette	3	decent	
 1429	shaking roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
-1431	fuchsia ghostly pregnant mushroom	0		
+1431	ghostly fuchsia pregnant mushroom	0		
 1432	delicious green mushroom	3	awesome	
 1433	fruit bowl	0		
 1434	fruit basket	0		
@@ -1454,9 +1454,9 @@
 1472	sack of doorknobs	0		
 1473	twirling wobbly ball-and-chain	0		
 1474	automatic catapult	0		
-1475	blurry cyan squat pentacorn hat	0		Familiar Effect: "atk, cap 10"
+1475	squat cyan blurry pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	tumbling goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
-1477	jittery tumbling olive plastic hard hat	0		Familiar Effect: "atk, cap 22"
+1477	tumbling olive jittery plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	purple football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
@@ -1473,7 +1473,7 @@
 1491	olive lion tamer's rice bowl	0		Experience (familiar): +2
 1492	Usain Bolt's ninja mop	0		Initiative: +80
 1493	Jeselnik's Tesla ridiculously overelaborate ninja weapon	0		Sleaze Damage: +25, MP Regen Min: 7, MP Regen Max: 10
-1494	cold-filtered ionized bouncing shaking sugar-coated pine cone	0		Effect: "Smoky Third Eye", Effect Duration: 44, Last Available: "2020-09"
+1494	cold-filtered ionized shaking bouncing sugar-coated pine cone	0		Effect: "Smoky Third Eye", Effect Duration: 44, Last Available: "2020-09"
 1495	upside-down huge Sherlock's traffic cone of the early riser	0		Item Drop: +25, Adventures: +7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	watered-down drinkable gloomy mushroom wine	2	good	
 1497	boozy perfectly mixed mushroom wine	5	EPIC	
@@ -1482,19 +1482,19 @@
 1500	blurry fake fake vomit	0		Last Available: "2006-04"
 1501	altered pickled modified gray explosion-flavored chewing gum	0		Effect: "Wet Jaw", Effect Duration: 30, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
-1503	spinning narrow rubber emo roe	0		Last Available: "2006-04"
+1503	narrow spinning rubber emo roe	0		Last Available: "2006-04"
 1504	warmed anodized bouncing snowcone	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 68, Last Available: "2006-04"
 1505	green ice cube with a fly in it	0		Last Available: "2006-04"
 1506	mediocre spinning calle de miel with a fly in it	3	decent	Last Available: "2006-04"
 1507	artisanal rockin' wagon with a fly in it	3	EPIC	Last Available: "2006-04"
 1508	perfectly mixed distilled shaking perpendicular hula with a fly in it	5	EPIC	Last Available: "2006-04"
-1509	fancy lousy twirling slap and tickle with a fly in it	3	decent	Effect: "Steroid Boost", Effect Duration: 15, Last Available: "2006-04"
+1509	lousy fancy twirling slap and tickle with a fly in it	3	decent	Effect: "Steroid Boost", Effect Duration: 15, Last Available: "2006-04"
 1510	twirling bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of wisdom	0		Mysticality: +15, Last Available: "2006-04"
 1512	twisted Knob Goblin pet-buffing spray	1		Effect: "Notably Lovely", Effect Duration: 50
 1513	altered Knob Goblin learning pill	1		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 40
 1514	boiled pulsating Knob Goblin eyedrops	1		
-1515	boiled spinning shaking red Knob Goblin nasal spray	1		
+1515	boiled shaking red spinning Knob Goblin nasal spray	1		
 1516	KWE-brand transistor radio	0		
 1518	shaking vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1535,7 +1535,7 @@
 1555	special perfectly mixed bottle of Jorge Sinsonte	3	EPIC	Effect: "Hiding in Plain Sight", Effect Duration: 30
 1556	weak lousy boxed champagne	2	decent	
 1557	spoiled miniature jittery kumquat	2	crappy	
-1558	gigantic spoiled tangerine	10	crappy	
+1558	spoiled gigantic tangerine	10	crappy	
 1559	tonic water	0		
 1560	adequate immense cocktail onion	8	good	
 1561	low-calorie flavorless raspberry	1	decent	
@@ -1551,28 +1551,28 @@
 1571	drinkable huge parisian cathouse	3	good	
 1572	lousy rabbit punch	3	decent	
 1573	practically non-alcoholic mediocre caipifruta	1	decent	
-1574	perfectly mixed triple-distilled teqiwila	8	EPIC	
+1574	triple-distilled perfectly mixed teqiwila	8	EPIC	
 1575	lousy Divine	4	decent	
 1576	bad squat Gordon Bennett	3	decent	
-1577	distilled mediocre tangarita	5	decent	
-1578	practically non-alcoholic perfectly mixed huge mandarina colada	1	super ultra mega turbo EPIC	
+1577	mediocre distilled tangarita	5	decent	
+1578	perfectly mixed practically non-alcoholic huge mandarina colada	1	super ultra mega turbo EPIC	
 1579	tolerable strong gimlet	5	good	
 1580	bad maroon brick road	3	decent	
-1581	enchanted smooth vodka stratocaster	4	awesome	Effect: "Ghostly Shell", Effect Duration: 35
+1581	smooth enchanted vodka stratocaster	4	awesome	Effect: "Ghostly Shell", Effect Duration: 35
 1582	enchanted hand-crafted green Neuromancer	4	EPIC	Effect: "Frosty the Hitman", Effect Duration: 30
 1583	drinkable blinking prussian cathouse	4	good	
 1584	tolerable Mae West	4	good	
 1585	tolerable Mon Tiki	4	good	
 1586	drinkable gray teqiwila slammer	3	good	
 1587	miniature stale Knob lo mein	2	decent	
-1588	jumbo flavorless squat asparagus lo mein	5	decent	
+1588	flavorless jumbo squat asparagus lo mein	5	decent	
 1589	bland red Knoll lo mein	4	decent	
 1590	yummy lo mein	4	awesome	
 1591	stale small olive lo mein	2	decent	
 1592	stale hot hi mein	4	decent	
-1593	jumbo toothsome red hi mein	5	awesome	
-1594	low-calorie normal hi mein	1	good	
-1595	normal mirror purple hi mein	3	good	
+1593	toothsome jumbo red hi mein	5	awesome	
+1594	normal low-calorie hi mein	1	good	
+1595	normal purple mirror hi mein	3	good	
 1596	diet yummy cyan sleazy hi mein	1	awesome	
 1597	rock-hard Junior LAAAAME merit badge	0		Damage Reduction: 5, Last Available: "2006-05"
 1598	beefy Senior LAAAAME merit badge	0		Muscle: +10, Last Available: "2006-05"
@@ -1615,20 +1615,20 @@
 1635	scrumdiddlyumptious solution	0		
 1636	blinking mirror Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	nitrogenated yellow lotion of hotness	0		Effect: "Dirge of Dreadfulness", Effect Duration: 11
-1638	frozen electrified olive pulsating lotion of coldness	0		Effect: "Ichorous Intensity", Effect Duration: 26
+1638	frozen electrified pulsating olive lotion of coldness	0		Effect: "Ichorous Intensity", Effect Duration: 26
 1639	polymerized Vulcanized lotion of spookiness	0		Effect: "Cringle's Curative Carol", Effect Duration: 31
 1640	vacuum-sealed liquefied huge lotion of stench	0		Effect: "Hammered", Effect Duration: 38
 1641	concentrated alkaline cyan tumbling lotion of sleaziness	0		Effect: "Spiky Frozen Hair", Effect Duration: 26
-1642	practically non-alcoholic artisanal Grimacite Bock	1	EPIC	Last Available: "2008-11"
+1642	artisanal practically non-alcoholic Grimacite Bock	1	EPIC	Last Available: "2008-11"
 1643	stale bouncing wedge of gray cheese	3	decent	Last Available: "2008-11"
 1644	upside-down hot and sauce	0		
-1645	lime green bouncing and sauce	0		
+1645	bouncing lime green and sauce	0		
 1646	and sauce	0		
 1647	stench and sauce	0		
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	bite-sized bland foie gras	1	decent	
+1651	bland bite-sized foie gras	1	decent	
 1652	quadruple-vacuum-sealed fuchsia candy brain	0		Effect: "Mercenary", Effect Duration: 29, Last Available: "2020-09"
 1653	wobbly wobbly ribald supercharged ruddy jewel-eyed wizard hat	0		Maximum HP Percent: +40, Maximum MP Percent: +30, Sleaze Damage: +10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
 1654	Sherlock's boxer's wad of Crovacite	0		Muscle Percent: +10, Item Drop: +25
@@ -1746,27 +1746,27 @@
 1767	spinning pack of chewing gum	0		
 1768	Gnomish toolbox	0		
 1769	half-sized moldy fricasseed brains	2	crappy	
-1770	huge rotten mirror brains casserole	7	crappy	
+1770	rotten huge mirror brains casserole	7	crappy	
 1771	green butcherknife of the bloodbag	0		Maximum HP: +100
 1772	skewed gravedigger's corn holder	0		Spooky Damage: +10
 1773	Tesla eggbeater	0		MP Regen Min: 7, MP Regen Max: 10
 1774	perfectly mixed squat bottle of popskull	4	EPIC	
 1775	Jeselnik's dishrag	0		Sleaze Damage: +25
-1776	normal diet lime green stale baguette	1	good	
+1776	diet normal lime green stale baguette	1	good	
 1777	leftovers of indeterminate origin	0		
-1778	low-calorie spoiled bouncing dinner	1	crappy	
+1778	spoiled low-calorie bouncing dinner	1	crappy	
 1779	katana	0		Item Drop: +5
 1780	ram stick of mayonnaise	0		Sleaze Spell Damage: +50
 1781	hale enchantlers	0		Maximum HP: +20, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	censurious ram-battering staff of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3
-1783	snack-sized normal crazy Turkish delight	2	good	
+1783	normal snack-sized crazy Turkish delight	2	good	
 1784	pulsating cyan wholesome dangerous Snow Queen Crown	0		Weapon Damage: +10, Maximum HP Percent: +10, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	supercharged forbidden experienced ga-ga radio	0		Experience: +2, Spell Damage Percent: +50, Maximum MP Percent: +30
 1786	six pack of Mountain Stream	0		
 1787	pickled bag of Cheat-Os	0		Effect: "Stogied", Effect Duration: 36
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	watered-down perfectly mixed Ram's Face Lager	2	EPIC	
+1790	perfectly mixed watered-down Ram's Face Lager	2	EPIC	
 1791	ram horns	0		
 1792	bouncing inspector's energetic Travoltan trousers	0		Maximum MP Percent: +20, Item Drop: 20, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	skewed manspreader's razor-sharp pool cue	0		Weapon Damage Percent: +25, Monster Level: +10
@@ -1806,7 +1806,7 @@
 1827	seventh lumbar vertebra	0		
 1828	bouncing sacral vertebrae	0		
 1829	first caudal vertebra	0		
-1830	lime green squat second caudal vertebra	0		
+1830	squat lime green second caudal vertebra	0		
 1831	third caudal vertebra	0		
 1832	blurry fourth caudal vertebra	0		
 1833	fifth caudal vertebra	0		
@@ -1832,7 +1832,7 @@
 1853	purple right third rib	0		
 1854	fuchsia right fourth rib	0		
 1855	cyan right fifth rib	0		
-1856	bouncing shaking right sixth rib	0		
+1856	shaking bouncing right sixth rib	0		
 1857	teal right seventh rib	0		
 1858	right eighth rib	0		
 1859	right ninth rib	0		
@@ -1868,11 +1868,11 @@
 1889	right fourth front claw	0		
 1890	left thumb	0		
 1891	right thumb	0		
-1892	bouncing spinning left first rear claw	0		
+1892	spinning bouncing left first rear claw	0		
 1893	left second rear claw	0		
 1894	left third rear claw	0		
 1895	twirling left fourth rear claw	0		
-1896	maroon blurry right first rear claw	0		
+1896	blurry maroon right first rear claw	0		
 1897	huge right second rear claw	0		
 1898	right third rear claw	0		
 1899	gray blurry right fourth rear claw	0		
@@ -1923,10 +1923,10 @@
 1946	coward's personal trainer's accordion pin	0		Experience Percent (Muscle): +10, Monster Level: -20, Class: "Accordion Thief", Single Equip
 1947	gray worn tophat of the dark arts of horror	0		Spell Damage Percent: +100, Spooky Spell Damage: +25, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	greedy Da Vinci's tap shoes	0		Experience (Mysticality): +5, Meat Drop: +20, Single Equip
-1949	massive normal enchanted Manetwich	7	good	Effect: "Action", Effect Duration: 20
+1949	normal enchanted massive Manetwich	7	good	Effect: "Action", Effect Duration: 20
 1950	bottle of Vangoghbitussin	0		
 1951	artisanal bottle of Pinot Renoir	4	EPIC	
-1952	small enchanted normal desiccated apricot	2	good	Effect: "Capricorn Rising", Effect Duration: 45
+1952	small normal enchanted desiccated apricot	2	good	Effect: "Capricorn Rising", Effect Duration: 45
 1953	perfectly mixed strong purple flute of flat champagne	5	EPIC	
 1954	rotten dehydrated caviar	3	crappy	
 1955	squat upside-down styrofoam peanuts	0		
@@ -1968,14 +1968,14 @@
 1991	rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
 1993	spinning rubber WWSPD? bracelet	0		
-1994	narrow gray rubber WWtNSD? bracelet	0		
+1994	gray narrow rubber WWtNSD? bracelet	0		
 1995	skewed heart necklace	0		Free Pull
 1996	right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	yellow pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
 2000	olive Das &Uuml;berk&uuml;hlraum trading card	0		
-2001	squat fuchsia Vaso De Agua trading card	0		
+2001	fuchsia squat Vaso De Agua trading card	0		
 2002	pulsating mirror The Grand Poo-Bah trading card	0		
 2003	Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
@@ -1994,14 +1994,14 @@
 2017	blurry spade necklace	0		
 2018	club necklace	0		
 2019	bouncing cream pie	0		Free Pull
-2020	huge normal cherry pie	8	good	
+2020	normal huge cherry pie	8	good	
 2021	snack-sized stale strawberry pie	2	decent	
 2022	adequate lemon meringue pie	3	good	
 2023	wobbly yellow Genalen&trade; Bottle	1	EPIC	
 2024	stale skewed narrow mixed wildflower greens	4	decent	
 2025	decent handful of walnuts	3	good	
 2026	flavorless snack-sized nutty organic salad	2	decent	
-2027	snack-sized moldy super salad	2	crappy	
+2027	moldy snack-sized super salad	2	crappy	
 2028	special rotten tofu wonton	3	crappy	Effect: "Blessing of the Pervy Noodles", Effect Duration: 40
 2029	huge hippy protest button	0		Single Equip
 2030	dangerous sage Lockenstock&trade; sandals	0		Mysticality Percent: +10, Weapon Damage: +10, Single Equip
@@ -2012,7 +2012,7 @@
 2035	pulsating tumbling Marquis de Poivre soda	0		
 2036	flattened radium-flavored potato chips	0		Effect: "Icy Composition", Effect Duration: 26
 2037	denatured mirror wintergreen-flavored potato chips	0		Effect: "Dweeby", Effect Duration: 39
-2038	tarnished red narrow ennui-flavored potato chips	0		Effect: "Human-Machine Hybrid", Effect Duration: 67
+2038	tarnished narrow red ennui-flavored potato chips	0		Effect: "Human-Machine Hybrid", Effect Duration: 67
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
 2041	ferret bait	0		
@@ -2020,8 +2020,8 @@
 2043	hemp net	0		
 2044	spinning your father's MacGuffin diary	0		
 2045	tasty brain-meltingly-hot chicken wings	3	awesome	
-2046	huge yummy frat brats	10	awesome	
-2047	super-sized delicious knob ka-bobs	5	awesome	
+2046	yummy huge frat brats	10	awesome	
+2047	delicious super-sized knob ka-bobs	5	awesome	
 2049	weak artisanal can of Swiller	2	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
@@ -2037,7 +2037,7 @@
 2061	shellacked helmet	0		Damage Reduction: 7, Familiar Effect: "1xFairy, cap 40"
 2062	hardy smartaleck's shield	0		Moxie Percent: +30, Maximum HP: +50, Damage Reduction: 10
 2063	stale half-sized huge blackberry	2	decent	
-2064	teal bouncing forged identification documents	0		
+2064	bouncing teal forged identification documents	0		
 2065	PADL Phone	0		
 2066	double-paned knitted kick-ass kicks	0		Cold Resistance: 8, Single Equip
 2067	sake bomb	0		
@@ -2078,7 +2078,7 @@
 2102	greasy dreadlock	0		
 2103	vial of pirate sweat	0		
 2104	ghostly empty aftershave bottle	0		
-2105	jittery blurry coal button	0		
+2105	blurry jittery coal button	0		
 2106	burned-out arcanodiode	0		
 2107	skewed non-Euclidean hoof	0		
 2108	rock	0		
@@ -2122,8 +2122,8 @@
 2147	tumbling evil teddy bear sewing kit	0		
 2148	twirling toothsome rock	0		
 2149	decent frank	4	good	Last Available: "2011-12"
-2150	miniature moldy plate of franks and beans	2	crappy	Last Available: "2011-12"
-2151	lousy practically non-alcoholic wobbly shot of blackberry schnapps	1	decent	
+2150	moldy miniature plate of franks and beans	2	crappy	Last Available: "2011-12"
+2151	practically non-alcoholic lousy wobbly shot of blackberry schnapps	1	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	mirror ion grid	0		Last Available: "2011-12"
@@ -2165,14 +2165,14 @@
 2190	yellow yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	rotten special snack-sized candy stake	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30, Last Available: "2006-12"
+2193	snack-sized special rotten candy stake	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30, Last Available: "2006-12"
 2194	smooth eggnog	3	awesome	Last Available: "2006-12"
-2195	jumbo flavorless unspeakable fruitcake	5	decent	Last Available: "2006-12"
+2195	flavorless jumbo unspeakable fruitcake	5	decent	Last Available: "2006-12"
 2196	normal gingerbread horror	3	good	Last Available: "2006-12"
 2197	cold-filtered quantum but probably evil chocolate	0		Effect: "Transcendental Wind", Effect Duration: 36, Last Available: "2006-12"
 2198	stale bat-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	jumbo enchanted stale narrow shaking skull-shaped Crimboween cookie	5	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	rotten small tombstone-shaped Crimboween cookie	2	crappy	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	small rotten tombstone-shaped Crimboween cookie	2	crappy	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	mirror Jack Frost's plastic gift-wrapping vampire	0		Cold Spell Damage: +50, Last Available: "2006-12"
 2202	blue friendly plastic yuletide troll	0		Familiar Weight: +3, Last Available: "2006-12"
 2203	plastic skeletal reindeer of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2006-12"
@@ -2190,7 +2190,7 @@
 2215	Tropical Crimbo Hat of the detective	0		Item Drop: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	rock-hard Tropical Crimbo Shorts	0		Damage Reduction: 5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	flavorless super ka-bob	3	decent	
-2218	stale fancy blinking mirror beer basted brat	3	decent	Effect: "Full of Vinegar", Effect Duration: 50
+2218	fancy stale blinking mirror beer basted brat	3	decent	Effect: "Full of Vinegar", Effect Duration: 50
 2219	Tropical Crimbo Sword of horror	0		Spooky Spell Damage: +25, Last Available: "2006-12"
 2220	nitrogenated enhanced and Crimboween candy	0		Effect: "Medieval Mage Mayhem", Effect Duration: 50, Last Available: "2020-09"
 2221	upside-down Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2234,7 +2234,7 @@
 2260	hard rock candy	0		
 2261	blurry hard-boiled ostrich egg	0		
 2262	squat bird rib	0		
-2263	spinning blue lion oil	0		
+2263	blue spinning lion oil	0		
 2264	flavorless stunt nuts	3	decent	
 2265	toothsome wet stew	4	awesome	
 2266	ghostly wet stunt nut stew	0		
@@ -2243,10 +2243,10 @@
 2269	toothsome fuchsia sausage wonton	3	awesome	
 2270	chilly Tesla belt	0		Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 2271	perfectly mixed bottle of Merlot	3	EPIC	
-2272	practically non-alcoholic delicious blue bottle of Port	1	awesome	
+2272	delicious practically non-alcoholic blue bottle of Port	1	awesome	
 2273	aged blinking bottle of Pinot Noir	3	awesome	
 2274	tolerable bottle of Zinfandel	4	good	
-2275	fancy smooth watered-down bottle of Marsala	2	awesome	Effect: "Reptilian Fortitude", Effect Duration: 35
+2275	smooth fancy watered-down bottle of Marsala	2	awesome	Effect: "Reptilian Fortitude", Effect Duration: 35
 2276	mediocre bottle of Muscat	3	decent	
 2277	blinking Fernswarthy's key	0		
 2278	huge Fernswarthy's letter	0		
@@ -2280,7 +2280,7 @@
 2306	aerosolized candy heart	0		Effect: "Meatwise", Effect Duration: 38, Last Available: "2007-02"
 2307	triple-deionized super-warmed candy heart	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 12, Last Available: "2007-02"
 2308	Vulcanized frozen candy heart	0		Effect: "Just the Brown Ones", Effect Duration: 55, Last Available: "2007-02"
-2309	pickled teal wobbly candy heart	0		Effect: "Slimily Strong", Effect Duration: 26, Last Available: "2007-02"
+2309	pickled wobbly teal candy heart	0		Effect: "Slimily Strong", Effect Duration: 26, Last Available: "2007-02"
 2310	shaking candygram	0		Last Available: "2007-02"
 2311	squat cyan pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
@@ -2296,9 +2296,9 @@
 2322	blinking worm-riding manual pages 3-15	0		
 2323	blinking headpiece of the Staff of Ed	0		
 2324	Staff of Ed, almost	0		
-2325	narrow mirror Staff of Ed	0		
+2325	mirror narrow Staff of Ed	0		
 2326	stone rose	0		
-2327	anodized tarnished huge skewed can of paint	0		Effect: "Rat-Faced", Effect Duration: 11
+2327	anodized tarnished skewed huge can of paint	0		Effect: "Rat-Faced", Effect Duration: 11
 2328	drum machine	0		
 2329	handful of confetti	0		
 2330	yellow chocolate-covered diamond-studded roses	0		
@@ -2309,11 +2309,11 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	pipe of vim and vigor of the glutton	0		Maximum HP Percent: +50, Food Drop: +100
 2337	foul-smelling reinforced beaded headband	0		Stench Damage: +10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	immense yummy bouncing pudding	7	awesome	Wiki Name: "black pudding (food)"
+2338	yummy immense bouncing pudding	7	awesome	Wiki Name: "black pudding (food)"
 2339	artisanal practically non-alcoholic Blackfly Chardonnay	1	EPIC	
 2340	hand-crafted enchanted ghostly & tan	4	EPIC	Effect: "Joyful Resolve", Effect Duration: 20
 2341	pepper	0		
-2342	bland diet twirling forest cake	1	decent	
+2342	diet bland twirling forest cake	1	decent	
 2343	gigantic normal blinking forest ham	7	good	
 2344	liquefied flattened altered filthworm hatchling scent gland	0		Effect: "Arse-a'fire", Effect Duration: 52
 2345	polymerized filthworm drone scent gland	0		Effect: "Vanity Rage", Effect Duration: 37
@@ -2321,7 +2321,7 @@
 2347	blinking heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	gas balloon	0		
-2350	blue huge squat beer bomb	0		
+2350	huge blue squat beer bomb	0		
 2351	superamplified boom box	0		
 2352	pulsating flame-retardant chilly fire poi	0		Cold Damage: +5, Hot Resistance: +1
 2353	fireproof bejeweled pledge pin	0		Hot Resistance: +3, Single Equip
@@ -2346,13 +2346,13 @@
 2372	bunch of bananas	0		
 2373	adequate banana	3	good	
 2374	gray banana peel	0		
-2375	super-sized decent banana cream pie	5	good	
-2376	drinkable boozy banana daiquiri	5	good	
+2375	decent super-sized banana cream pie	5	good	
+2376	boozy drinkable banana daiquiri	5	good	
 2377	mediocre bungle in the jungle	4	decent	
-2378	mirror wobbly banana spritzer	0		
+2378	wobbly mirror banana spritzer	0		
 2379	frozen extra-vacuum-sealed banana smoothie	0		Effect: "The Halls of Moxiousness", Effect Duration: 14
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
-2381	lime green twirling woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
+2381	twirling lime green woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	blinking class ring	0		
 2383	class ring	0		
 2384	class ring	0		
@@ -2374,7 +2374,7 @@
 2400	molotov cocktail cocktail	0		
 2401	wool stanky beer bong	0		Stench Spell Damage: +25, Cold Resistance: +1
 2402	gauze garter	0		
-2403	shaking purple barrel of gunpowder	0		
+2403	purple shaking barrel of gunpowder	0		
 2404	jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
@@ -2392,7 +2392,7 @@
 2418	spinning purple quilted bounty-hunting pants	0		Damage Absorption: +40, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	warmed alkaline huge bottle of rhinoceros hormones	0		Effect: "Thick-Skinned", Effect Duration: 64
 2420	aerosolized galvanized teeny-tiny magic scroll	0		Effect: "Healthy Red Glow", Effect Duration: 50
-2421	warmed electrified skewed olive bottle of pirate juice	0		Effect: "Red Door Syndrome", Effect Duration: 42
+2421	warmed electrified olive skewed bottle of pirate juice	0		Effect: "Red Door Syndrome", Effect Duration: 42
 2422	flattened concentrated irradiated pet snacks	0		Effect: "Butt-Rock Hair", Effect Duration: 22
 2423	liquefied spinning Mick's IcyVapoHotness Inhaler	0		Effect: "The Q Is Talking To You", Effect Duration: 14
 2424	dry vacuum-sealed gray cyclops eyedrops	0		Effect: "Meatwise", Effect Duration: 24
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	yellow Cobb's Knob map	0		
 2443	blinking sizzling healthy pink glowstick	0		Maximum HP Percent: +20, Hot Damage: +10, Last Available: "2007-03"
-2444	hand-crafted distilled Supernova Champagne	5	EPIC	
+2444	distilled hand-crafted Supernova Champagne	5	EPIC	
 2445	pulsating Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	pulsating hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2491,8 +2491,8 @@
 2518	ghostly fortified sawblade shield	0		Damage Absorption: +60, Damage Reduction: 11
 2519	smooth fortified spinning McMillicancuddy's Special Lager	5	awesome	
 2520	mediocre blinking melted Jell-o shot	4	decent	
-2521	weak mediocre cruelty-free wine	2	decent	
-2522	high-proof tolerable thistle wine	6	good	
+2521	mediocre weak cruelty-free wine	2	decent	
+2522	tolerable high-proof thistle wine	6	good	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	flavorless spinning fish	3	decent	
@@ -2560,7 +2560,7 @@
 2587	supercharged Corporal Fennel's Lonely Clubs Club Jacket	0		Maximum MP Percent: +30
 2588	steel-toed Private Pepper's Lonely Hearts Club Jacket	0		Damage Reduction: 9
 2589	rotten immense hot date	10	crappy	
-2590	high-proof lousy distilled fortified wine	6	decent	
+2590	lousy high-proof distilled fortified wine	6	decent	
 2591	fancy yummy tasty tart	4	awesome	Effect: "Ooh, Salty!", Effect Duration: 25
 2592	Knob Goblin lunchbox	0		
 2593	decent Knob pasty	4	good	
@@ -2601,7 +2601,7 @@
 2628	supercharged boxer's catskin buckler	0		Muscle Percent: +10, Maximum MP Percent: +30, Damage Reduction: 11
 2629	tail o' nine cats of Gandalf of incineration	0		Spell Critical Percent: +20, Hot Spell Damage: +50
 2630	Hugo's Weaving Manual	0		
-2631	galvanized deionized squat upside-down gremlin juice	0		Effect: "Chalked Weapon", Effect Duration: 37
+2631	galvanized deionized upside-down squat gremlin juice	0		Effect: "Chalked Weapon", Effect Duration: 37
 2632	corrupted wet mother's helper	0		Effect: "Bat Attitude", Effect Duration: 69
 2633	blurry Tesla sage pat-a-cake pendant	0		Mysticality Percent: +10, MP Regen Min: 7, MP Regen Max: 10
 2634	gray mummy wrapping	0		
@@ -2628,15 +2628,15 @@
 2655	cold-filtered bottle of absinthe	0		Effect: "Nut-Rition", Effect Duration: 32, Last Available: "2007-06"
 2656	fireproof MacGyver's Drowsy Sword	0		Maximum MP: +100, Hot Resistance: +3
 2657	adequate teal escargotsicle	3	good	Last Available: "2007-06"
-2658	tolerable high-proof wobbly bottle of realpagne	9	good	Last Available: "2007-06"
+2658	high-proof tolerable wobbly bottle of realpagne	9	good	Last Available: "2007-06"
 2659	gravedigger's albatross necklace	0		Spooky Damage: +10, Single Equip, Last Available: "2007-06"
 2660	altered narrow not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	mediocre teal blinking flask of Amontillado	4	decent	Last Available: "2007-06"
+2661	mediocre blinking teal flask of Amontillado	4	decent	Last Available: "2007-06"
 2662	ball mask	0		Item Drop: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	Can-Can skirt of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	irradiated modified sensitive poetry journal	0		Effect: "Bone Homie", Effect Duration: 59, Last Available: "2007-06"
 2665	irradiated double-anodized bottled inspiration	0		Effect: "Spiky Frozen Hair", Effect Duration: 29, Last Available: "2007-06"
-2666	deionized Vulcanized pulsating maroon bellhop bell	0		Effect: "Penguinny Flavor", Effect Duration: 25, Last Available: "2007-06"
+2666	deionized Vulcanized maroon pulsating bellhop bell	0		Effect: "Penguinny Flavor", Effect Duration: 25, Last Available: "2007-06"
 2667	diffused modified blinking teal spiky collar	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 31, Last Available: "2007-06"
 2668	compressed bouncing pulsating can-can-in-a-can	1		Effect: "You Drank Fish Wine", Effect Duration: 10, Last Available: "2007-06"
 2669	powdered patent antipsychotics	1		Last Available: "2007-06"
@@ -2655,7 +2655,7 @@
 2682	detuned radio	0		
 2683	Warehouse 23 crate	0		
 2684	inspector's gravedigger's armgun	0		Spooky Damage: +10, Item Drop: +15
-2685	blurry cyan seashell necklace	0		
+2685	cyan blurry seashell necklace	0		
 2686	commemorative war stein	0		
 2687	stone frisbee	0		
 2688	tumbling personal trainer's dreadlock whip of the scaredy-cat of courage	0		Experience Percent (Muscle): +10, Monster Level: -15, Spooky Resistance: +3
@@ -2679,7 +2679,7 @@
 2706	blue greedy censurious blackberry moccasins of the bloodbag	0		Maximum HP: +100, Sleaze Resistance: +3, Meat Drop: +20, Single Equip
 2707	pulsating crafty weightlifter's blackberry combat boots of mayonnaise	0		Muscle: +15, Maximum MP: +10, Sleaze Spell Damage: +50, Single Equip
 2708	deionized dry blinking funky dried mushroom	0		Effect: "Sticky Hands", Effect Duration: 69
-2709	narrow mirror exotic parrot egg	0		
+2709	mirror narrow exotic parrot egg	0		
 2710	upside-down cracker	0		Familiar Weight: +15
 2711	nitrogenated facepaint	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 56
 2712	dry enhanced sheepskin diploma	0		Effect: "OMG WTF", Effect Duration: 28
@@ -2698,22 +2698,22 @@
 2725	flavorless blinking cob of corn	3	decent	
 2726	stale narrow juniper berries	4	decent	
 2727	decent small plum	2	good	
-2728	fancy moldy tiny bouncing spinning huge pear	1	crappy	Effect: "Whitened Teeth", Effect Duration: 50
+2728	fancy tiny moldy bouncing spinning huge pear	1	crappy	Effect: "Whitened Teeth", Effect Duration: 50
 2729	stale small blue peach	2	decent	
 2730	weak hand-crafted plum wine	2	EPIC	
-2731	delicious practically non-alcoholic fancy mirror shot of pear schnapps	1	awesome	Effect: "Pumped Stomach", Effect Duration: 50
-2732	weak smooth shot of peach schnapps	2	awesome	
+2731	practically non-alcoholic delicious fancy mirror shot of pear schnapps	1	awesome	Effect: "Pumped Stomach", Effect Duration: 50
+2732	smooth weak shot of peach schnapps	2	awesome	
 2733	half-sized decent bunch of square grapes	2	good	
 2734	normal immense mirror brown sugar cane	8	good	
 2735	spoiled sandwich of the gods	3	crappy	
 2736	lousy Pan-Dimensional Gargle Blaster	3	decent	
 2737	powdered blinking leopard-print barbell	1	crappy	
 2738	olive pile of smoking rags	0		
-2739	enhanced dry squat upside-down panty raider camouflage	0		Effect: "Purpose", Effect Duration: 47
+2739	enhanced dry upside-down squat panty raider camouflage	0		Effect: "Purpose", Effect Duration: 47
 2740	wool Jeselnik's smooth Staff of the Walk-In Freezer	0		Moxie: +15, Sleaze Damage: +25, Cold Resistance: +1
 2741	hand-crafted boilermaker	3	EPIC	
 2742	flavorless big steel lasagna	5	quest	
-2743	artisanal triple-distilled steel margarita	7	quest	
+2743	triple-distilled artisanal steel margarita	7	quest	
 2744	dehydrated bouncing steel-scented air freshener	1		
 2745	colloidal gremlin mutagen	0		Effect: "Optimist Primal", Effect Duration: 64
 2746	improved extra-potent gremlin mutagen	0		Effect: "Hangdog", Effect Duration: 58
@@ -2737,9 +2737,9 @@
 2764	Fonzie's Newton's slick Order of the Silver Wossname	0		Moxie: +10, Experience (Mysticality): +3, Experience (Moxie): +1, Single Equip
 2765	Harold's bell	0		
 2766	bowling ball	0		
-2767	moldy huge Crimbo pie	8	crappy	
+2767	huge moldy Crimbo pie	8	crappy	
 2768	stale tumbling pear tart	3	decent	
-2769	adequate miniature peach pie	2	good	
+2769	miniature adequate peach pie	2	good	
 2770	non-improved mirror chunk of rock salt	0		Effect: "Slightly Mutated", Effect Duration: 60
 2771	quadruple-modified huge huge handful of pine needles	0		Effect: "Hella Smooth", Effect Duration: 38
 2772	blinking steamy ruby	0		
@@ -2775,7 +2775,7 @@
 2802	flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	galvanized vial of hamethyst juice	0		Effect: "Wreathed in Merriment", Effect Duration: 36
-2805	alkaline enhanced diffused ghostly gray vial of baconstone juice	0		Effect: "5 Pounds Lighter", Effect Duration: 11
+2805	alkaline enhanced diffused gray ghostly vial of baconstone juice	0		Effect: "5 Pounds Lighter", Effect Duration: 11
 2806	double-ionized improved vial of porquoise juice	0		Effect: "Carrion' On", Effect Duration: 53
 2807	double-diffused flask of hamethyst juice	0		Effect: "Hella Smart", Effect Duration: 37
 2808	anodized colloidal flask of baconstone juice	0		Effect: "New and Improved", Effect Duration: 49
@@ -2810,10 +2810,10 @@
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	reassuring hardy glowstick	0		Maximum HP: +50, Spooky Resistance: +1, Last Available: "2007-08"
 2839	Periodical Paintbrush of Gandalf	0		Spell Critical Percent: +20, Softcore Only
-2840	smooth high-proof bottle of cooking sherry	10	awesome	
-2841	bland huge fancy packet of ketchup	6	decent	Effect: "Heavily Breathing", Effect Duration: 20
+2840	high-proof smooth bottle of cooking sherry	10	awesome	
+2841	fancy bland huge packet of ketchup	6	decent	Effect: "Heavily Breathing", Effect Duration: 20
 2842	tolerable accidental cider	3	good	
-2843	stale bite-sized dire fudgesicle	1	decent	
+2843	bite-sized stale dire fudgesicle	1	decent	
 2844	Van der Graaf dangerous navel ring of navel gazing of temperance of the cheetah	0		Weapon Damage: +10, Sleaze Resistance: +5, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	upside-down plastic bib	0		Last Available: "2011-12"
@@ -2821,7 +2821,7 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	drinkable irresponsibly strong moonberry wine cooler	10	good	
-2851	moldy huge gray fine aged cheddarwurst	9	crappy	
+2851	huge moldy gray fine aged cheddarwurst	9	crappy	
 2852	yellow mirror branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
@@ -2830,7 +2830,7 @@
 2857	oxidized tumbling seegar butt	0		Effect: "Full of Wist", Effect Duration: 42
 2858	bottled swamp gas	0		
 2859	upside-down chaotic witch wart of the businessman	0		Spell Critical Percent: +10, Meat Drop: +50
-2860	snack-sized flavorless wobbly swamp muck	2	decent	
+2860	flavorless snack-sized wobbly swamp muck	2	decent	
 2861	censurious coward's cool leechknife	0		Moxie: +5, Monster Level: -20, Sleaze Resistance: +3
 2862	teal decomposed boot	0		
 2863	quantum purple dribbly candle	0		Effect: "Standard Cheer", Effect Duration: 64
@@ -2910,7 +2910,7 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	ghostly unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	spoiled massive Surprise Egg	6	crappy	
+2940	massive spoiled Surprise Egg	6	crappy	
 2941	colloidal pressed squat Steal This Candy	0		Effect: "Third Based", Effect Duration: 64
 2942	concentrated frozen lime green chocolate filthy lucre	0		Effect: "Kindly Resolve", Effect Duration: 54
 2943	quadruple-ionized non-Vulcanized Angry Farmer's Wife Candy	0		Effect: "Hot Blooded", Effect Duration: 33
@@ -2924,13 +2924,13 @@
 2952	shaking mansplainer's glowstick of bravery	0		Monster Level: +15, Spooky Resistance: +5, Last Available: "2007-11"
 2953	yellow charrrm bracelet	0		
 2954	cool tip jar	0		Moxie: +5
-2955	flavorless small mirror yam candy	2	decent	
+2955	small flavorless mirror yam candy	2	decent	
 2956	cocktail napkin	0		
-2957	jittery teal rum barrel charrrm	0		
-2958	decent thick tube of cranberry Go-Goo	5	good	
+2957	teal jittery rum barrel charrrm	0		
+2958	thick decent tube of cranberry Go-Goo	5	good	
 2959	spinning squat stylish rum barrel charrrm bracelet	0		Moxie: +25
 2960	spoiled single-serving herbal stuffing	3	crappy	
-2961	small spoiled red packet of tofurkey gravy	2	crappy	
+2961	spoiled small red packet of tofurkey gravy	2	crappy	
 2962	normal jittery tofurkey nugget	4	good	
 2963	rigging shampoo	0		
 2964	red ball polish	0		
@@ -2938,7 +2938,7 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	super-chilled unsweetened blurry Swabbie&trade; swab	0		Effect: "Big", Effect Duration: 23
 2968	tarnished Oil of Parrrlay	0		Effect: "Blood-Gorged", Effect Duration: 62
-2969	massive stale creamsicle	8	decent	
+2969	stale massive creamsicle	8	decent	
 2970	delicious cream stout	4	awesome	
 2971	blinking horrifying stiffened curmudgel	0		Damage Reduction: 1, Spooky Damage: +25
 2972	grumpy man charrrm	0		
@@ -2995,26 +2995,26 @@
 3023	small stone triangle	0		
 3024	yellow stone pyramid	0		
 3025	hand-crafted blinking corpse on the beach	4	EPIC	
-3026	perfectly mixed strong corpsetini	5	EPIC	
+3026	strong perfectly mixed corpsetini	5	EPIC	
 3027	bad lime green corpsedriver	3	decent	
 3028	mediocre Corpse Island iced tea	3	decent	
-3029	lousy extra-dry red-headed corpse	5	decent	
+3029	extra-dry lousy red-headed corpse	5	decent	
 3030	special artisanal shaking kamicorpse-ee	4	EPIC	Effect: "Well-Swabbed Ear", Effect Duration: 45
-3031	boozy hand-crafted corpsel	5	EPIC	
-3032	fancy bad corpsebite	3	decent	Effect: "Sleazy Jellied", Effect Duration: 45
+3031	hand-crafted boozy corpsel	5	EPIC	
+3032	bad fancy corpsebite	3	decent	Effect: "Sleazy Jellied", Effect Duration: 45
 3033	energetic pirate fledges	0		Maximum MP Percent: +20
 3034	shaking piece of thirteen	0		
 3035	decent pearl onion	4	good	
 3036	normal massive sea biscuit	8	good	
 3037	weak acceptable bottle of rum	2	good	
-3038	drinkable squat gray bottle of black-label rum	3	good	
+3038	drinkable gray squat bottle of black-label rum	3	good	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	upside-down upside-down joke scroll	0		
 3042	squat Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	blurry metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	diet spoiled nanite-infested gingerbread bugbear	1	crappy	Last Available: "2007-12"
+3045	spoiled diet nanite-infested gingerbread bugbear	1	crappy	Last Available: "2007-12"
 3046	decent nanite-infested candy cane	3	good	Last Available: "2020-09"
 3047	yummy pulsating nanite-infested fruitcake	3	awesome	Last Available: "2007-12"
 3048	extra-dry acceptable nanite-infested eggnog	5	good	Last Available: "2007-12"
@@ -3027,7 +3027,7 @@
 3055	non-boiled colloidal cymbal syrup	0		Free Pull, Effect: "Frostbeard", Effect Duration: 64, Last Available: "2007-02"
 3056	metallic foil cat ears of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	jittery nanofiber cloth	0		Last Available: "2007-12"
-3058	wobbly bouncing iGoogly	0		Last Available: "2007-12"
+3058	bouncing wobbly iGoogly	0		Last Available: "2007-12"
 3059	bouncing theoretical string	0		Last Available: "2007-12"
 3060	spinning synthetic stuffing	0		Last Available: "2007-12"
 3061	mirror toy hoverpad	0		Last Available: "2007-12"
@@ -3039,7 +3039,7 @@
 3067	skewed dollhive	0		Last Available: "2007-12"
 3068	toy deathbot	0		Last Available: "2007-12"
 3069	pulsating laser cannon	0		Last Available: "2007-12"
-3070	upside-down red plexifoam chin strap	0		Last Available: "2007-12"
+3070	red upside-down plexifoam chin strap	0		Last Available: "2007-12"
 3071	silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
@@ -3095,7 +3095,7 @@
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	super-chilled cyan fruitfilm	0		Effect: "Memory of Speed", Effect Duration: 35
 3125	ionized cold-filtered upside-down fuchsia piece of after eight	0		Effect: "Fudge Headache", Effect Duration: 54
-3126	ghostly huge hobo nickel	0		
+3126	huge ghostly hobo nickel	0		
 3127	spinning sandcastle	0		
 3128	marshmallow	0		
 3129	delicious twirling roasted marshmallow	4	awesome	
@@ -3138,25 +3138,25 @@
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	extra-flattened red seal eyeball	0		Effect: "Sleazy Hands", Effect Duration: 47
-3169	massive bland blurry turtle soup	8	decent	Effect: "[598]A Little Bit Evil"
+3169	bland massive blurry turtle soup	8	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	frightening evil paper umbrella	0		Spooky Damage: +5
 3173	oxidized evil vihuela	0		Effect: "Jelly Combed", Effect Duration: 24
 3174	moldy diet evil boring spaghetti	1	crappy	
 3175	stale evil noodles	4	decent	
-3176	stale miniature spinning evil noodles	2	decent	
+3176	miniature stale spinning evil noodles	2	decent	
 3177	big rotten evil painful penne pasta	5	crappy	
 3178	normal pulsating 3vi1 pr0n m4nic0tti	3	good	
 3179	half-sized spoiled evil ravioli della hippy	2	crappy	
 3180	adequate skewed evil noodles	4	good	
 3181	polarized mirror evil potion of potency	0		Effect: "Fury of the Bells", Effect Duration: 42
 3182	alkaline extra-magnetized wobbly evil libation of liveliness	0		Effect: "Chain Chain Chains", Effect Duration: 28
-3183	enhanced polymerized huge shaking evil tomato juice of powerful power	0		Effect: "Savage Beast Inside", Effect Duration: 12
+3183	enhanced polymerized shaking huge evil tomato juice of powerful power	0		Effect: "Savage Beast Inside", Effect Duration: 12
 3184	non-magnetized oxidized evil eyedrops of the ermine	0		Effect: "Bubblin' Rage", Effect Duration: 16
 3185	magnetized evil ointment of the occult	0		Effect: "Trash-Wrapped", Effect Duration: 68
 3186	polarized polymerized ghostly evil serum of sarcasm	0		Effect: "Melancholy Burden", Effect Duration: 20
-3187	aerosolized jittery gray evil philter of phorce	0		Effect: "Ichorous Intensity", Effect Duration: 44
+3187	aerosolized gray jittery evil philter of phorce	0		Effect: "Ichorous Intensity", Effect Duration: 44
 3188	artisanal watered-down wobbly an evil sump'm sump'm	2	super EPIC	
 3189	drinkable evil ducha de oro	4	good	
 3190	mediocre evil horizontal tango	4	decent	
@@ -3167,7 +3167,7 @@
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	olive ghostly slick origami pasties	0		Moxie: +10, Softcore Only, Last Available: "2008-02"
 3197	perfumed padded origami riding crop of Flo-Jo	0		Damage Absorption: +20, Stench Resistance: +5, Initiative: +100, Softcore Only, Last Available: "2008-02"
-3198	blinking yellow El Vibrato trapezoid	0		
+3198	yellow blinking El Vibrato trapezoid	0		
 3199	ghostly lump of coal	0		
 3200	olive lump of diamond	0		
 3201	thick padded envelope	0		
@@ -3180,7 +3180,7 @@
 3208	blinking small laminated card	0		
 3209	fuchsia laminated card	0		
 3210	huge notbig laminated card	0		
-3211	blurry blinking unlarge laminated card	0		
+3211	blinking blurry unlarge laminated card	0		
 3212	dwarvish document	0		
 3213	skewed dwarvish paper	0		
 3214	dwarvish parchment	0		
@@ -3195,7 +3195,7 @@
 3223	sewer nuggets	0		
 3224	sewer wad	0		
 3225	drinkable pulsating bottle of sewage schnapps	3	good	
-3226	practically non-alcoholic perfectly mixed bottle of Ooze-O	1	EPIC	
+3226	perfectly mixed practically non-alcoholic bottle of Ooze-O	1	EPIC	
 3227	toothsome skewed C.H.U.M. chum	3	awesome	
 3228	rotten unfortunate dumplings	4	crappy	
 3229	decaying goldfish liver	0		
@@ -3205,8 +3205,8 @@
 3233	inflatable duck	0		
 3234	olive water wings	0		Wiki Name: "water wings"
 3235	shaking noodle	0		
-3236	wobbly maroon Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
-3237	pulsating skewed Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
+3236	maroon wobbly Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
+3237	skewed pulsating Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
@@ -3236,7 +3236,7 @@
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
-3267	narrow bouncing bag of Laughing Willow saplings	0		
+3267	bouncing narrow bag of Laughing Willow saplings	0		
 3268	double-adjusted handful of Crotchety Pine needles	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 38
 3269	enhanced quantum red lump of Saccharine Maple sap	0		Effect: "Liquid Luck", Effect Duration: 58
 3270	improved fuchsia handful of Laughing Willow bark	0		Effect: "Poker Faced", Effect Duration: 68
@@ -3267,9 +3267,9 @@
 3295	friendly cheez blob	0		
 3296	unusual disco ball	0		
 3297	pulsating stray chihuahua	0		
-3298	huge skewed pretty pink bow	0		
+3298	skewed huge pretty pink bow	0		
 3299	smiley-face sticker	0		
-3300	pulsating purple farfalle bow tie	0		
+3300	purple pulsating farfalle bow tie	0		
 3301	tumbling jalape&ntilde;o slices	0		
 3302	jittery stick-on mini solar panels	0		
 3303	sombrero	0		Sombrero Bonus: +10
@@ -3294,7 +3294,7 @@
 3322	frightening padded mayfly bait necklace	0		Damage Absorption: +20, Spooky Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	maroon Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
-3325	mediocre practically non-alcoholic jar of fermented pickle juice	1	decent	
+3325	practically non-alcoholic mediocre jar of fermented pickle juice	1	decent	
 3326	powdered olive voodoo snuff	1	good	Effect: "Mercenary", Effect Duration: 15
 3327	moldy special extra-greasy slider	3	crappy	Effect: "Sweetened and Fattened", Effect Duration: 25
 3328	yellow sizzling Jack Frost's crumpled felt fedora	0		Cold Spell Damage: +50, Hot Damage: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	twirling greedy dead guy's memento of the cougar	0		Moxie: +20, Meat Drop: +20, Single Equip
-3338	spoiled fancy banquet	4	crappy	Effect: "Aloofah", Effect Duration: 30
+3338	fancy spoiled banquet	4	crappy	Effect: "Aloofah", Effect Duration: 30
 3339	shaking purple sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3323,7 +3323,7 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	quantum jittery llama lama gong	0		Effect: "Infernal Thirst", Effect Duration: 19, Last Available: "2008-06"
-3354	adequate small banana-frosted king cake	2	good	Last Available: "2008-08"
+3354	small adequate banana-frosted king cake	2	good	Last Available: "2008-08"
 3355	narrow censurious brown plastic baby	0		Sleaze Resistance: +3, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3332,8 +3332,8 @@
 3360	mirror stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	snack-sized moldy mole mol&eacute;	2	crappy	Last Available: "2008-06"
-3364	watered-down acceptable blurry Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
+3363	moldy snack-sized mole mol&eacute;	2	crappy	Last Available: "2008-06"
+3364	acceptable watered-down blurry Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
 3365	improved double-diffused gray wobbly Climate Colada	0		Effect: "Night Vision", Effect Duration: 48, Last Available: "2008-06"
 3366	cold-filtered improved spinning blue digital underground potion	0		Effect: "Mutated", Effect Duration: 53, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3342,7 +3342,7 @@
 3370	vaporized lime green glimmering penguin feather	1		Last Available: "2008-06"
 3371	twisted pulsating yellow glimmering buzzard feather	1		Last Available: "2008-06"
 3372	pickled blurry glimmering raven feather	1		Last Available: "2008-06"
-3373	distilled shaking jittery bouncing glimmering great tit feather	1		Effect: "Stimulated Brain", Effect Duration: 15, Last Available: "2008-06"
+3373	distilled jittery shaking bouncing glimmering great tit feather	1		Effect: "Stimulated Brain", Effect Duration: 15, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	twirling red Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3367,12 +3367,12 @@
 3395	Hodgman's porkpie hat of the dark arts	0		Spell Damage Percent: +100, Item Drop: +5, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	wool wholesome Hodgman's lobsterskin pants	0		Maximum HP Percent: +10, Cold Resistance: +1, Familiar Effect: "atk, 1xPotato"
 3397	avaricious perfumed Hodgman's bow tie	0		Stench Resistance: +5, Meat Drop: +30, Single Equip
-3398	drinkable practically non-alcoholic Hodgman's blanket	1	good	
+3398	practically non-alcoholic drinkable Hodgman's blanket	1	good	
 3399	artisanal jar of squeeze	3	super ultra EPIC	
 3400	normal bowl of fishysoisse	3	good	
-3401	nitrogenated dry skewed purple deadly lampshade	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14
-3402	anodized magnetized jittery green concentrated garbage juice	0		Effect: "Squirming Like a Toad", Effect Duration: 23
-3403	tumbling bouncing blinking lewd playing card	0		
+3401	nitrogenated dry purple skewed deadly lampshade	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14
+3402	anodized magnetized green jittery concentrated garbage juice	0		Effect: "Squirming Like a Toad", Effect Duration: 23
+3403	tumbling blinking bouncing lewd playing card	0		
 3404	narrow shaking deck of lewd playing cards of the blizzard of bravery	0		Cold Spell Damage: +25, Spooky Resistance: +5, Item Drop: +5
 3405	skewed upside-down fortified Hodgman's sock	0		Damage Absorption: +60, Single Equip
 3406	smelly Hodgman's varcolac paw	0		Stench Spell Damage: +10
@@ -3423,13 +3423,13 @@
 3456	hale trusty torch	0		Maximum HP: +20, Last Available: "2011-12"
 3457	frightening Junior Adventurer's merit badge	0		Spooky Damage: +5
 3458	alkaline dry double-electrified ghostly STYX deodorant body spray	0		Effect: "Beta Carotene Overdose", Effect Duration: 34
-3459	tolerable boozy white-label gin	5	good	
+3459	boozy tolerable white-label gin	5	good	
 3460	moldy wobbly tin rations	3	crappy	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	practically non-alcoholic fancy tolerable bottle of sake	1	good	Effect: "Shamboozled", Effect Duration: 35
+3463	practically non-alcoholic tolerable fancy bottle of sake	1	good	Effect: "Shamboozled", Effect Duration: 35
 3464	round pebble of the glutton	0		Food Drop: +100
-3465	spoiled enchanted snack-sized Bash-&#332;s cereal	2	crappy	Effect: "Mucilaginous Mentalism", Effect Duration: 35, Wiki Name: "Bash-Os cereal"
+3465	snack-sized enchanted spoiled Bash-&#332;s cereal	2	crappy	Effect: "Mucilaginous Mentalism", Effect Duration: 35, Wiki Name: "Bash-Os cereal"
 3466	ghostly flame-wreathed sizzling beefy haiku katana	0		Muscle: +10, Hot Damage: +10, Hot Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	tumbling bargain flash powder	0		
 3468	huge double-paned plastic baby	0		Cold Resistance: +5, Single Equip, Last Available: "2008-12"
@@ -3454,12 +3454,12 @@
 3487	blue wobbly rough fish scale	0		
 3488	pristine fish scale	0		
 3489	stale beefy fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
-3490	super-sized spoiled maroon glistening fish meat	5	crappy	Effect: "Fishy", Effect Duration: 5
+3490	spoiled super-sized maroon glistening fish meat	5	crappy	Effect: "Fishy", Effect Duration: 5
 3491	decent slick fish meat	3	good	Effect: "Fishy", Effect Duration: 5
 3492	twirling manspreader's stylish fish scimitar	0		Moxie: +25, Monster Level: +10
 3493	flame-wreathed dog trainer's fish stick	0		Experience (familiar): +1, Hot Spell Damage: +10
 3494	huge flame-wreathed fish bazooka of the pedagogue	0		Experience: +3, Hot Spell Damage: +10
-3495	electrified irradiated tumbling blinking sea salt crystal	0		Effect: "Chunky", Effect Duration: 66
+3495	electrified irradiated blinking tumbling sea salt crystal	0		Effect: "Chunky", Effect Duration: 66
 3496	modified tarnished bazookafish bubble gum	0		Effect: "Flexibili Tea", Effect Duration: 47
 3497	tolerable bottle of Pete's Sake	3	good	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
@@ -3467,7 +3467,7 @@
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	half-sized rotten canap&eacute;s	2	crappy	
 3502	powdered thermos of brew	1	good	Effect: "Phairly Balanced", Effect Duration: 25, Last Available: "2011-12"
-3503	lousy high-proof ghostly glass of brandy	8	decent	Last Available: "2011-12"
+3503	high-proof lousy ghostly glass of brandy	8	decent	Last Available: "2011-12"
 3504	French slippers	0		
 3505	LWA ring of Gandalf	0		Spell Critical Percent: +20
 3506	LARP membership card	0		Last Available: "2008-10"
@@ -3489,14 +3489,14 @@
 3522	huge twirling resourceful smooth shark jumper	0		Moxie: +15, Maximum MP: +50
 3523	pressed oxidized narrow shark cartilage	0		Effect: "Thickest, Sickest", Effect Duration: 63
 3524	polymerized oxidized corrupted pulsating eel battery	0		Effect: "Inner Dog", Effect Duration: 25
-3525	improved improved green wobbly temporary teardrop tattoo	0		Effect: "Red Door Syndrome", Effect Duration: 32
+3525	improved improved wobbly green temporary teardrop tattoo	0		Effect: "Red Door Syndrome", Effect Duration: 32
 3526	Samson's scratch 'n' sniff crossbow	0		Experience (Muscle): +5, Last Available: "2008-11"
 3527	twirling mutant rattlesnake egg	0		
 3528	green mutant fire ant egg	0		
 3529	bouncing mutant cactus bud	0		
 3530	wobbly mutant gila monster egg	0		
 3531	upside-down rattlesnake enrager	0		Familiar Weight: +5
-3532	narrow upside-down gray ant antidepressant	0		Familiar Weight: +5
+3532	upside-down gray narrow ant antidepressant	0		Familiar Weight: +5
 3533	cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
@@ -3522,14 +3522,14 @@
 3555	adequate jittery mirror sea carrot	3	good	
 3556	fancy half-sized flavorless fuchsia sea cucumber	2	decent	Effect: "Optimist Primal", Effect Duration: 15
 3557	tasty miniature sea avocado	2	awesome	
-3558	thick normal fuchsia sea lychee	5	good	
-3559	bland immense narrow sea tangelo	7	decent	
+3558	normal thick fuchsia sea lychee	5	good	
+3559	immense bland narrow sea tangelo	7	decent	
 3560	flavorless diet sea honeydew	1	decent	
 3561	pickled anodized unsweetened pressurized potion of puissance	0		Effect: "Sharp Weapon", Effect Duration: 22
 3562	irradiated lime green pressurized potion of perspicacity	0		Effect: "Amplified Fabulousness", Effect Duration: 21
 3563	magnetized colloidal maroon pressurized potion of pulchritude	0		Effect: "Mo' Hobo", Effect Duration: 19
 3564	drinkable berry-infused sake	4	good	
-3565	mediocre strong citrus-infused sake	5	decent	
+3565	strong mediocre citrus-infused sake	5	decent	
 3566	tolerable melon-infused sake	3	good	
 3567	spinning gray blinking slab of sponge	0		
 3568	shellacked wizardly sponge helmet of horror	0		Mysticality: +25, Damage Reduction: 7, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xFairy"
@@ -3549,13 +3549,13 @@
 3582	stale rice	3	decent	
 3584	gigantic rotten irradiated candy cane	10	crappy	Last Available: "2008-12"
 3585	toothsome gingerbread mutant bugbear	3	awesome	Last Available: "2008-12"
-3586	perfectly mixed practically non-alcoholic skewed oozenog	1	super EPIC	Last Available: "2008-12"
+3586	practically non-alcoholic perfectly mixed skewed oozenog	1	super EPIC	Last Available: "2008-12"
 3587	dry bouncing sugar plum	0		Effect: "Destructive Resolve", Effect Duration: 15, Last Available: "2008-12"
 3588	boiled sugar banana	0		Effect: "Sewer-Drenched", Effect Duration: 42, Last Available: "2008-12"
-3589	altered polymerized twirling green sugar lime	0		Effect: "Inscrutable exoskeleton", Effect Duration: 46, Last Available: "2008-12"
+3589	altered polymerized green twirling sugar lime	0		Effect: "Inscrutable exoskeleton", Effect Duration: 46, Last Available: "2008-12"
 3590	nitrogenated corrupted altered sugar cherry	0		Effect: "Prideful Strut", Effect Duration: 53, Last Available: "2008-12"
 3591	squat purple sizzling Newton's Mer-kin hookspear	0		Experience (Mysticality): +3, Hot Damage: +10
-3592	tumbling olive Mer-kin takebag	0		Item Drop: +5
+3592	olive tumbling Mer-kin takebag	0		Item Drop: +5
 3593	blue Mer-kin thingpouch	0		
 3594	yellow Mer-kin killscroll	0		
 3595	vacuum-sealed unsweetened Mer-kin fastjuice	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 29
@@ -3565,7 +3565,7 @@
 3599	zippy veiny moist sailor's cap of temperance	0		Maximum HP: +10, Sleaze Resistance: +5, Initiative: +20, Familiar Effect: "stench atk"
 3600	twirling wizardly speargun of mayonnaise	0		Mysticality: +25, Sleaze Spell Damage: +50
 3601	stiffened compass	0		Damage Reduction: 1
-3602	tumbling squat broken diving helmet	0		
+3602	squat tumbling broken diving helmet	0		
 3603	porthole	0		
 3604	rivet	0		
 3605	bubblin' stone	0		
@@ -3576,7 +3576,7 @@
 3610	bouncing squat squat imitation whetstone	0		
 3611	improved improved fuchsia squat sea grease	0		Effect: "Chain Chain Chains", Effect Duration: 61
 3612	pulsating sturdy Crimbo crate	0		Last Available: "2008-12"
-3613	jittery red battered Crimbo Crate	0		Last Available: "2008-12"
+3613	red jittery battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	blinking rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
@@ -3602,7 +3602,7 @@
 3636	perfumed quilted patent shoes	0		Damage Absorption: +40, Stench Resistance: +5, Last Available: "2008-12"
 3637	nasty gray bow tie of dire peril	0		Weapon Damage: +20, Stench Damage: +5, Last Available: "2008-12"
 3638	rosy-cheeked penguin thesaurus of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Last Available: "2008-12"
-3639	tiny bland blob-shaped Crimbo cookie	1	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	bland tiny blob-shaped Crimbo cookie	1	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	blinking jamfish jam	0		
 3642	dragonfish caviar	0		
@@ -3613,8 +3613,8 @@
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	huge rotten toast with jam	9	crappy	Last Available: "2008-12"
-3651	shaking antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	rotten huge toast with jam	9	crappy	Last Available: "2008-12"
+3651	shaking antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	acceptable fuchsia elven moonshine	3	good	Last Available: "2008-12"
 3653	adequate super-sized knuckle sandwich	5	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	blinking ribald scandalous psycho sweater	0		Sleaze Damage: 15, Last Available: "2008-12"
@@ -3635,13 +3635,13 @@
 3669	wobbly huge friendly glow-in-the-dark dart gun	0		Familiar Weight: +3, Last Available: "2009-01"
 3670	rosy-cheeked glow-in-the-dark burrowgrub	0		Maximum HP Percent: +30, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	bland immense blinking can of franks 'n' beans	7	decent	Last Available: "2010-12"
+3672	immense bland blinking can of franks 'n' beans	7	decent	Last Available: "2010-12"
 3673	weak smooth bottle of peppermint schnapps	2	awesome	Last Available: "2010-12"
 3674	maroon throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	diving muff of James Dean	0		Experience (Moxie): +3, Single Equip
-3678	high-proof hand-crafted salinated mint julep	6	EPIC	
+3678	hand-crafted high-proof salinated mint julep	6	EPIC	
 3679	twirling ink bladder	0		
 3680	huge esca	0		
 3681	bubbling tempura batter	0		
@@ -3651,9 +3651,9 @@
 3685	adequate lime green tempura cucumber	3	good	
 3686	adequate tempura avocado	3	good	
 3687	normal sea broccoli	3	good	
-3688	massive stale sea cauliflower	6	decent	
+3688	stale massive sea cauliflower	6	decent	
 3689	rotten lime green tempura broccoli	3	crappy	
-3690	rotten super-sized bouncing tempura cauliflower	5	crappy	
+3690	super-sized rotten bouncing tempura cauliflower	5	crappy	
 3691	flavorless sea blueberry	3	decent	
 3692	decent squat sea persimmon	4	good	
 3693	super-denatured adjusted twirling pressurized potion of perception	0		Effect: "You Know What's Up", Effect Duration: 46
@@ -3692,7 +3692,7 @@
 3726	gray possessed tomato	0		
 3727	Nardz energy beverage	0		
 3728	pile of coins	0		
-3729	twirling olive hand grenegg	0		
+3729	olive twirling hand grenegg	0		
 3730	caret	0		
 3731	glass gnoll eye of the early riser	0		Adventures: +7
 3732	unsweetened ionized maroon cigar butt	0		Effect: "Blessing of Charcoatl", Effect Duration: 31
@@ -3727,12 +3727,12 @@
 3763	perfectly mixed slug of vodka	3	EPIC	
 3764	perfectly mixed bouncing slug of rum	4	EPIC	
 3765	delicious slug of shochu	3	awesome	
-3766	artisanal practically non-alcoholic screwdiver	1	EPIC	
-3767	fortified delicious dew yoana lei	5	awesome	
-3768	weak bad lychee chuhai	2	decent	
+3766	practically non-alcoholic artisanal screwdiver	1	EPIC	
+3767	delicious fortified dew yoana lei	5	awesome	
+3768	bad weak lychee chuhai	2	decent	
 3769	bad salacious screwdiver	4	decent	
 3770	bad dew yoana salacious lei	4	decent	
-3771	lousy fortified salacious lychee chuhai	5	decent	
+3771	fortified lousy salacious lychee chuhai	5	decent	
 3772	bad watered-down Alewife&trade; Ale	2	decent	
 3773	tumbling seaode	0		
 3774	map to the Dive Bar	0		
@@ -3750,8 +3750,8 @@
 3786	vampire glitter	0		Class: "Pastamancer"
 3787	twirling wine-soaked bone chips	0		Class: "Pastamancer"
 3788	crumbling rat skull	0		Class: "Pastamancer"
-3789	yellow pulsating twitching trigger finger	0		Class: "Pastamancer"
-3799	wobbly narrow Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
+3789	pulsating yellow twitching trigger finger	0		Class: "Pastamancer"
+3799	narrow wobbly Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
 3801	twirling crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
 3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
@@ -3768,7 +3768,7 @@
 3813	flame-retardant plastic baby	0		Hot Resistance: +1, Single Equip, Last Available: "2009-06"
 3815	blue midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	spoiled half-sized sea radish	2	crappy	
+3817	half-sized spoiled sea radish	2	crappy	
 3818	twirling twirling healthy smooth halibut of the pedagogue	0		Moxie: +15, Experience: +3, Maximum HP Percent: +20
 3819	eel sauce	0		
 3820	beefy water-polo mitt	0		Muscle: +10, Single Equip
@@ -3779,13 +3779,13 @@
 3825	Grandma's Fuchsia Yarn	0		
 3826	huge Grandma's Chartreuse Yarn	0		
 3827	olive shaking plastic oyster egg	0		
-3828	red pulsating Grandma's Map	0		
+3828	pulsating red Grandma's Map	0		
 3829	stale mirror tempura radish	3	decent	
 3830	tumbling purple clever water-polo cap	0		Maximum MP: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	acceptable Typical Tavern swill	3	good	
-3832	acceptable spirit-forward tropical swill	5	good	
+3832	spirit-forward acceptable tropical swill	5	good	
 3833	smooth fruity girl swill	3	awesome	
-3834	weak enchanted lousy blended swill	2	decent	Effect: "Carrion' On", Effect Duration: 40
+3834	enchanted lousy weak blended swill	2	decent	Effect: "Carrion' On", Effect Duration: 40
 3835	costume wardrobe	0		Softcore Only
 3836	therapeutic sage beefcake's Elvish sunglasses of the detective	0		Muscle: +25, Mysticality Percent: +10, Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	anniversary safety glass vest	0		Item Drop: +5
@@ -3911,7 +3911,7 @@
 3959	squat garish pinky ring of the sweet-tooth	0		Candy Drop: +100
 3960	squat fireproof designer sunglasses	0		Hot Resistance: +3, Single Equip
 3961	therapeutic extremely unsafe opera glasses	0		Weapon Damage Percent: +100, HP Regen Min: 5, HP Regen Max: 7
-3962	wobbly skewed pulsating blue designer handbag	0		
+3962	pulsating skewed blue wobbly designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	bouncing cell phone	0		Familiar Weight: +10
 3965	energized deionized cube of billiard chalk	0		Effect: "Christmessy", Effect Duration: 37
@@ -3934,7 +3934,7 @@
 3982	blinking grievous torquoise ring of the dark arts	0		Weapon Damage Percent: +50, Spell Damage Percent: +100, Single Equip
 3983	dueling turtle	0		
 3984	squat lime green ghostly double-paned dueling banjo of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +5
-3985	maroon spinning soup turtle	0		
+3985	spinning maroon soup turtle	0		
 3986	samurai turtle	0		
 3987	skewed olive knitted samurai turtle helmet of James Dean	0		Experience (Moxie): +3, Cold Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	jittery turtle shell	0		
@@ -3959,7 +3959,7 @@
 4007	memory of a C	0		Last Available: "2009-06"
 4008	memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
-4010	skewed blue memory of a T	0		Last Available: "2009-06"
+4010	blue skewed memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	huge memory of a CG base pair	0		Last Available: "2009-06"
 4013	fuchsia memory of a CT base pair	0		Last Available: "2009-06"
@@ -3986,7 +3986,7 @@
 4034	jittery memory of an iron key	0		Last Available: "2009-06"
 4035	red twirling memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	bland massive slimy sweetbreads	8	decent	
+4037	massive bland slimy sweetbreads	8	decent	
 4038	special mediocre weak slimy fermented bile bladder	2	decent	Effect: "Extra-Wet", Effect Duration: 50
 4039	altered slimy alveolus	1		
 4040	red memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	wobbly ring of teleportation of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 4052	bouncing glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	mediocre high-proof mirror White Hyborian	9	decent	Last Available: "2009-06"
+4054	high-proof mediocre mirror White Hyborian	9	decent	Last Available: "2009-06"
 4055	goblin hunting spear of the storm	0		Maximum MP Percent: +40, Last Available: "2009-06"
 4056	Jeselnik's medical-grade goblin autoblowgun	0		Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-06"
 4057	tribal beads of courage	0		Spooky Resistance: +3, Last Available: "2009-06"
@@ -4021,7 +4021,7 @@
 4069	essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
 4071	skewed twirling essence of fright	0		Last Available: "2009-06"
-4072	spinning tumbling shaking essence of	0		Last Available: "2009-06"
+4072	tumbling spinning shaking essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
 4074	spinning multi-pass	0		Last Available: "2009-06"
 4075	shaking deadly villainous scythe of bravery	0		Weapon Damage: +5, Spooky Resistance: +5, Slime Hates It: +2
@@ -4037,7 +4037,7 @@
 4085	spoiled protein paste	3	crappy	Last Available: "2009-06"
 4086	twirling frightening therapeutic cyber-mattock	0		Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
-4088	shaking wobbly X-37 gun	0		Last Available: "2009-06"
+4088	wobbly shaking X-37 gun	0		Last Available: "2009-06"
 4089	adjusted anodized neurostim pill	0		Effect: "Hammered", Effect Duration: 23, Last Available: "2009-06"
 4090	alkaline pressed physiostim pill	0		Effect: "Dilated Pupils", Effect Duration: 47, Last Available: "2009-06"
 4091	slimy cyst	0		
@@ -4056,7 +4056,7 @@
 4104	catseye marble of Tarzan	0		Experience (Muscle): +3
 4105	ghostly friendly bumboozer marble	0		Familiar Weight: +3
 4106	upside-down Rosewater's chamoisole	0		Mysticality Percent: +30
-4107	non-concentrated Vulcanized mirror gray bitter pill	0		Effect: "Vanity Rage", Effect Duration: 16
+4107	non-concentrated Vulcanized gray mirror bitter pill	0		Effect: "Vanity Rage", Effect Duration: 16
 4108	fuchsia weightlifter's monstrous monocle	0		Muscle: +15, Item Drop: +5, Last Available: "2009-06"
 4109	beefcake's musty moccasins of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Last Available: "2009-06"
 4110	medical-grade padded molten medallion	0		Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-06"
@@ -4091,7 +4091,7 @@
 4139	jittery a creased paper strip	0		
 4140	olive a folded paper strip	0		
 4141	lime green a crinkled paper strip	0		
-4142	teal bouncing a crumpled paper strip	0		
+4142	bouncing teal a crumpled paper strip	0		
 4143	a ragged paper strip	0		
 4144	blue a ripped paper strip	0		
 4145	veiny funny paper hat	0		Maximum HP: +10, Familiar Effect: "1xVolley, 1xLep, cap 2"
@@ -4110,7 +4110,7 @@
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	perfectly mixed pebblebr&auml;u	3	EPIC	Last Available: "2009-09"
-4161	half-sized bland rocky road ice cream	2	decent	Last Available: "2009-09"
+4161	bland half-sized rocky road ice cream	2	decent	Last Available: "2009-09"
 4162	jittery maroon extra-strength rubber bands	0		Familiar Weight: +5
 4163	liquefied alkaline children of the candy corn	0		Effect: "Bored Stiff", Effect Duration: 23
 4164	magnetized moist Good 'n' Slimy	0		Effect: "Hot Blooded", Effect Duration: 55
@@ -4161,7 +4161,7 @@
 4209	spinning teal skate skin	0		
 4210	narrow bouncing roller skate decoy	0		
 4211	mermaid's purse	0		
-4212	narrow twirling underwater slingshot	0		
+4212	twirling narrow underwater slingshot	0		
 4213	Lo Pan's thinker's skate blade	0		Mysticality: +10, Spell Critical Percent: +30
 4214	spangly unitard	0		
 4215	collapsible baton of the blizzard of the early riser	0		Cold Spell Damage: +25, Adventures: +7
@@ -4208,7 +4208,7 @@
 4256	vacuum-sealed gray sap	0		Effect: "Danish Cunning", Effect Duration: 63, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	immense adequate spinning chocolate-covered scarab beetle	9	good	Last Available: "2009-10"
-4259	watered-down smooth mulled cider	2	awesome	Last Available: "2009-10"
+4259	smooth watered-down mulled cider	2	awesome	Last Available: "2009-10"
 4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
@@ -4229,7 +4229,7 @@
 4277	foul-smelling hale brawny Staff of the Woodfire	0		Muscle Percent: +20, Maximum HP: +20, Stench Damage: +10, Last Available: "2009-10"
 4278	wobbly occult Underworld flail of the blizzard of doom	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2009-10"
 4279	jittery Mer-kin cancerstick	0		
-4280	skewed pulsating Mer-kin sawdust	0		
+4280	pulsating skewed Mer-kin sawdust	0		
 4281	greedy Mer-kin bunwig of Leguizamo	0		Monster Level: +20, Meat Drop: +20, Familiar Effect: "1xVolley"
 4282	lard-coated smelly beefy crappy Mer-kin mask	0		Muscle: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +25, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
 4283	brawny crappy Mer-kin tailpiece of vim and vigor	0		Muscle Percent: +20, Maximum HP Percent: +50, Familiar Effect: "1xBarrr, 1xFairy"
@@ -4290,7 +4290,7 @@
 4338	plastic Don Crimbo of the cheetah	0		Initiative: +60, Last Available: "2009-12"
 4339	rock-hard plastic Crimbomination	0		Damage Reduction: 5, Last Available: "2009-12"
 4340	non-boiled alkaline Piddles	0		Effect: "Dancing Prowess", Effect Duration: 36, Last Available: "2009-12"
-4341	quadruple-activated double-polarized pulsating maroon BitterSweetTarts	0		Effect: "Jammin'", Effect Duration: 44, Last Available: "2009-12"
+4341	quadruple-activated double-polarized maroon pulsating BitterSweetTarts	0		Effect: "Jammin'", Effect Duration: 44, Last Available: "2009-12"
 4342	quantum pulsating Polka Pop	0		Effect: "The Strength...  of the Future", Effect Duration: 29, Last Available: "2009-12"
 4343	tumbling Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
@@ -4310,7 +4310,7 @@
 4358	mirror A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	upside-down A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	yummy narrow jittery expired can of franks 'n' beans	4	awesome	Last Available: "2009-12"
-4361	drinkable watered-down expired bottle of peppermint schnapps	2	good	Last Available: "2009-12"
+4361	watered-down drinkable expired bottle of peppermint schnapps	2	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	teal elf resistance button	0		Last Available: "2009-12"
 4364	denatured mirror elven suicide capsule	0		Effect: "Conspiratory Eyes", Effect Duration: 34, Last Available: "2009-12"
@@ -4325,7 +4325,7 @@
 4373	huge grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	shaking olive spiraling shape	0		Last Available: "2009-12"
-4376	tumbling blurry Crimbomination Contraption	0		Last Available: "2009-12"
+4376	blurry tumbling Crimbomination Contraption	0		Last Available: "2009-12"
 4377	blurry twirling throwing wrench of the ox	0		Muscle: +20, Last Available: "2009-12"
 4378	perfumed pair of bolt cutters	0		Stench Resistance: +5, Last Available: "2009-12"
 4379	poison pen of the empath	0		Familiar Weight: +5, Last Available: "2009-12"
@@ -4372,7 +4372,7 @@
 4421	supercool sealhide gloves	0		Moxie Percent: +20
 4422	Samson's sealhide belt	0		Experience (Muscle): +5
 4423	sealhide snare	0		
-4424	green wobbly huge puzzling trophy	0		
+4424	huge wobbly green puzzling trophy	0		
 4425	improved sealhide seal doll	0		Effect: "Musky", Effect Duration: 61
 4426	blurry hymnal	0		Skill: "Canticle of Carboloading"
 4428	deadly glowstick on a string	0		Weapon Damage: +5
@@ -4422,7 +4422,7 @@
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	blurry BRICKO bat	0		Last Available: "2010-02"
 4476	shaking BRICKO oyster	0		Last Available: "2010-02"
-4477	spinning blurry BRICKO turtle	0		Last Available: "2010-02"
+4477	blurry spinning BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
 4479	bouncing BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	blinking BRICKO python	0		Last Available: "2010-02"
@@ -4444,7 +4444,7 @@
 4496	twirling extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	ionized recording of The Ballad of Richie Thingfinder	0		Effect: "Scavengers Scavenging", Effect Duration: 22
 4498	electrified deionized boiled recording of Benetton's Medley of Diversity	0		Effect: "EVISCERATE!", Effect Duration: 69
-4499	frozen galvanized wet spinning blinking recording of Elron's Explosive Etude	0		Effect: "Alchemical, Brother", Effect Duration: 49
+4499	frozen galvanized wet blinking spinning recording of Elron's Explosive Etude	0		Effect: "Alchemical, Brother", Effect Duration: 49
 4500	ionized liquefied denatured recording of Chorale of Companionship	0		Effect: "You Drank Fish Wine", Effect Duration: 65
 4501	galvanized colloidal bouncing recording of Prelude of Precision	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 51
 4502	vacuum-sealed tumbling recording of Donho's Bubbly Ballad	0		Effect: "Pumped Stomach", Effect Duration: 11
@@ -4455,7 +4455,7 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	corrupted &quot;DRINK ME&quot; potion	0		Effect: "Tomato Power", Effect Duration: 41, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	rotten low-calorie walrus ice cream	1	crappy	Last Available: "2010-03"
+4510	low-calorie rotten walrus ice cream	1	crappy	Last Available: "2010-03"
 4511	miniature flavorless beautiful soup	2	decent	Last Available: "2010-03"
 4512	huge eggman noodles	0		Last Available: "2010-03"
 4513	blurry Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
@@ -4476,9 +4476,9 @@
 4528	delicious upside-down dragon snaps	3	awesome	Last Available: "2010-03"
 4529	snapdragon pistil of chilblains of the boozehound	0		Cold Damage: +25, Booze Drop: +100, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	huge stale shaking wobbly rook cookie	8	decent	Last Available: "2010-03"
-4532	huge spoiled huge bishop cookie	10	crappy	Last Available: "2010-03"
-4533	tasty small skewed knight cookie	2	awesome	Last Available: "2010-03"
+4531	huge stale wobbly shaking rook cookie	8	decent	Last Available: "2010-03"
+4532	spoiled huge huge bishop cookie	10	crappy	Last Available: "2010-03"
+4533	small tasty skewed knight cookie	2	awesome	Last Available: "2010-03"
 4534	adequate jumbo king cookie	5	good	Last Available: "2010-03"
 4535	moldy queen cookie	3	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4508,28 +4508,28 @@
 4560	narrow map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	skewed hair of the calf	0		Last Available: "2010-04"
-4563	practically non-alcoholic acceptable world's most unappetizing beverage	1	good	Last Available: "2010-04"
+4563	acceptable practically non-alcoholic world's most unappetizing beverage	1	good	Last Available: "2010-04"
 4564	maroon aromatic slippery when wet shield	0		Stench Resistance: +1, Damage Reduction: 6, Last Available: "2010-04"
 4565	bite-sized bland raisin	1	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	pulsating sinister wizardly flyest of shirts	0		Mysticality: +25, Spell Damage: +10, Last Available: "2010-04"
-4568	bite-sized bland spinning a dance upon the palate	1	decent	Last Available: "2010-04"
+4568	bland bite-sized spinning a dance upon the palate	1	decent	Last Available: "2010-04"
 4569	fancy yummy prehistoric meteorite jawbreaker	3	awesome	Effect: "Human-Beast Hybrid", Effect Duration: 40, Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	big rotten blue squirmy violent party snack	5	crappy	Last Available: "2010-04"
+4571	rotten big blue squirmy violent party snack	5	crappy	Last Available: "2010-04"
 4572	can-you-dig-it? of the pedagogue	0		Experience: +3, Last Available: "2010-04"
 4573	mirror The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	fuchsia ghostly bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	ghostly fuchsia bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	polarized polymerized upside-down Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Heightened Senses", Effect Duration: 49, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of chilblains	0		Cold Damage: +25, Last Available: "2010-04"
 4581	knitted scorching T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Hot Damage: +25, Cold Resistance: +3, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	special moldy six wedges of goat cheese	4	crappy	Effect: "Ninja, Please", Effect Duration: 15
+4584	moldy special six wedges of goat cheese	4	crappy	Effect: "Ninja, Please", Effect Duration: 15
 4585	pulsating jittery collection of objects	0		
 4586	boulder	0		
 4587	huge goth	0		
@@ -4538,7 +4538,7 @@
 4590	blinking upside-down pixel chain whip of the sweet-tooth	0		Candy Drop: +100, Last Available: "2010-07"
 4591	sinister pixel morning star	0		Spell Damage: +10, Last Available: "2010-07"
 4592	red pixel orb	0		Last Available: "2010-07"
-4593	skewed teal pixellated moneybag	0		Last Available: "2010-07"
+4593	teal skewed pixellated moneybag	0		Last Available: "2010-07"
 4594	mirror pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
@@ -4551,7 +4551,7 @@
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
 4605	padded bottle of Goldschn&ouml;ckered of the ox	0		Muscle: +20, Damage Absorption: +20, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	flavorless enchanted jumbo narrow sun-dried tofu	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4606	enchanted jumbo flavorless narrow sun-dried tofu	5	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	practically non-alcoholic bad soyburger juice	1	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
@@ -4564,9 +4564,9 @@
 4616	jittery Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	huge maroon plastic cup of flat beer	0		
-4619	blue pulsating frisbee	0		Free Pull, Last Available: "2011-12"
+4619	pulsating blue frisbee	0		Free Pull, Last Available: "2011-12"
 4620	purple motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
-4621	wobbly huge Game Grid token	0		Last Available: "2010-06"
+4621	huge wobbly Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	flattened chocolate-covered caviar	0		Effect: "Corona de la Salsa", Effect Duration: 33, Last Available: "2020-09"
 4624	bland small pawn cookie	2	decent	Last Available: "2010-06"
@@ -4619,8 +4619,8 @@
 4671	hand-crafted spinning booze-soaked cherry	3	EPIC	
 4672	comfy pillow	0		
 4673	bland big marshmallow	5	decent	
-4674	big decent sponge cake	5	good	
-4675	tolerable practically non-alcoholic gin-soaked blotter paper	1	good	
+4674	decent big sponge cake	5	good	
+4675	practically non-alcoholic tolerable gin-soaked blotter paper	1	good	
 4676	tree-holed coin	0		
 4677	huge unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	pulsating unearthed potsherd	0		
@@ -4633,14 +4633,14 @@
 4685	pottery yo-yo of the blizzard	0		Cold Spell Damage: +25, Last Available: "2010-09"
 4686	twirling pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
-4688	blurry teal fossilized serpent skull	0		Last Available: "2010-09"
+4688	teal blurry fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
 4690	fossilized wyrm skull	0		Last Available: "2010-09"
 4691	red fossilized wing	0		Last Available: "2010-09"
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
-4695	tumbling blue affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
+4695	blue tumbling affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
 4696	mansplainer's Annie Oakley's rock-hard Greatest American Pants	0		Damage Reduction: 5, Critical Hit Percent: +20, Monster Level: +15, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	fossilized necklace of the storm	0		Maximum MP Percent: +40, Last Available: "2010-09"
 4698	cyan imp air	0		
@@ -4651,7 +4651,7 @@
 4703	red-hot medallion of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2010-09"
 4704	fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
-4706	upside-down mirror sinister tablet	0		
+4706	mirror upside-down sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
 4708	spinning My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
@@ -4662,18 +4662,18 @@
 4714	normal lemon popsicle	4	good	
 4715	stale popsicle	3	decent	
 4716	adequate bite-sized strawberry popsicle	1	good	
-4717	thick decent twirling liver popsicle	5	good	
+4717	decent thick twirling liver popsicle	5	good	
 4718	mariachi hat of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, cap 2"
 4719	pulsating Hollandaise helmet of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	twirling microwave stogie	0		Last Available: "2011-12"
-4722	small fancy yummy wobbly liver and let pie	2	awesome	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2010-10"
+4722	fancy yummy small wobbly liver and let pie	2	awesome	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2010-10"
 4723	bland badass pie	3	decent	Last Available: "2010-10"
 4724	flavorless huge huge shoo-fish pie	8	decent	Last Available: "2010-10"
 4725	stale piping organ pie	4	decent	Last Available: "2010-10"
-4726	small tasty igloo pie	2	awesome	Last Available: "2010-10"
+4726	tasty small igloo pie	2	awesome	Last Available: "2010-10"
 4727	rotten stomach turnover	4	crappy	Last Available: "2010-10"
-4728	stale gigantic wobbly dead lights pie	7	decent	Last Available: "2010-10"
+4728	gigantic stale wobbly dead lights pie	7	decent	Last Available: "2010-10"
 4729	toothsome throbbing organ pie	4	awesome	Last Available: "2010-10"
 4730	bouncing scorching stop shield	0		Hot Damage: +25, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
@@ -4683,16 +4683,16 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	shaking tangle of rat tails	0		
 4737	shaking beer-soaked mop of the storm	0		Maximum MP Percent: +40
-4738	special mediocre day-old beer	3	decent	Effect: "Shoesauce", Effect Duration: 15
+4738	mediocre special day-old beer	3	decent	Effect: "Shoesauce", Effect Duration: 15
 4739	bad skewed plain beer	4	decent	
 4740	perfectly mixed weak overpriced &quot;imported&quot; beer	2	EPIC	
-4741	upside-down twirling smiling rat	0		
+4741	twirling upside-down smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
-4744	tarnished wobbly teal PlexiPips	0		Effect: "Spring Training", Effect Duration: 32
+4744	tarnished teal wobbly PlexiPips	0		Effect: "Spring Training", Effect Duration: 32
 4745	oxidized quadruple-moist moist shaking Wax Flask	0		Effect: "Vital", Effect Duration: 27
 4746	pressed electrified aerosolized pulsating Pain Dip	0		Effect: "Wise Spirit", Effect Duration: 54
-4747	snack-sized delicious special bone meal	2	awesome	Effect: "Muddled", Effect Duration: 10, Last Available: "2010-10"
+4747	special snack-sized delicious bone meal	2	awesome	Effect: "Muddled", Effect Duration: 10, Last Available: "2010-10"
 4748	artisanal practically non-alcoholic skewed bone aperitif	1	super ultra EPIC	Last Available: "2010-10"
 4749	smartaleck's bonerang	0		Moxie Percent: +30, Last Available: "2010-10"
 4750	tumbling squat clever bone and arrows	0		Maximum MP: +20, Last Available: "2010-10"
@@ -4708,7 +4708,7 @@
 4760	narrow packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	upside-down pumpkin	0		Last Available: "2010-11"
 4762	ghostly huge pumpkin	0		Last Available: "2010-11"
-4763	normal snack-sized maroon pumpkin pie	2	good	Last Available: "2010-11"
+4763	snack-sized normal maroon pumpkin pie	2	good	Last Available: "2010-11"
 4764	irresponsibly strong hand-crafted pumpkin beer	9	EPIC	Last Available: "2010-11"
 4765	modified liquefied purple pumpkin juice	0		Effect: "Abyssal Blood", Effect Duration: 69, Last Available: "2010-11"
 4766	tumbling pumpkin bomb	0		Last Available: "2010-11"
@@ -4717,17 +4717,17 @@
 4769	huge pumpkin carriage	0		Last Available: "2010-11"
 4770	jittery Desert Bus pass	0		
 4771	ginormous pumpkin	0		Last Available: "2010-11"
-4804	twirling tumbling Essence of Annoyance	0		Skill: "Summon Annoyance"
+4804	tumbling twirling Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	shaking Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	mirror Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	bland fancy CRIMBCOIDS mints	4	decent	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2011-01"
+4818	fancy bland CRIMBCOIDS mints	4	decent	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2011-01"
 4819	ghostly tumbling can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	rotten snack-sized CRIMBCOLOAF	2	crappy	Last Available: "2011-01"
-4821	spoiled snack-sized circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4820	snack-sized rotten CRIMBCOLOAF	2	crappy	Last Available: "2011-01"
+4821	snack-sized spoiled circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	cool plastic CRIMBCO HQ	0		Moxie: +5, Last Available: "2010-12"
 4823	blurry Oprah's plastic fax machine	0		Maximum MP Percent: +50, Last Available: "2010-12"
 4824	dog trainer's plastic hobo elf	0		Experience (familiar): +1, Last Available: "2010-12"
@@ -4765,7 +4765,7 @@
 4856	paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	blinking resourceful CRIMBCO lanyard	0		Maximum MP: +50, Single Equip, Last Available: "2011-01"
-4859	skewed fuchsia bouncing CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+4859	bouncing skewed fuchsia CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	green CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
@@ -4788,9 +4788,9 @@
 4879	diffused myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Vinegavotte", Effect Duration: 51, Last Available: "2011-01"
 4880	twirling CRIMBCO mug	0		Last Available: "2011-01"
 4881	artisanal watered-down upside-down CRIMBCO wine	2	EPIC	Last Available: "2011-01"
-4882	skewed upside-down Dickory Farms Gift Basket	0		Last Available: "2011-01"
+4882	upside-down skewed Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	ghostly toe jam	0		Last Available: "2011-01"
-4884	half-sized decent huge narrow toe jam toast	2	good	Last Available: "2011-01"
+4884	decent half-sized huge narrow toe jam toast	2	good	Last Available: "2011-01"
 4885	gray traffic jam	0		Last Available: "2011-01"
 4886	moldy huge traffic jam toast	8	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	bouncing blinking slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	stale super-sized teal festive sausage	5	decent	Last Available: "2011-01"
-4895	low-calorie rotten holiday cheese log	1	crappy	Last Available: "2011-01"
+4895	rotten low-calorie holiday cheese log	1	crappy	Last Available: "2011-01"
 4896	lime green holiday log	0		Last Available: "2011-01"
 4897	skewed Usain Bolt's flame-wreathed BGE 'ferocious fruit' shirt	0		Hot Spell Damage: +10, Initiative: +80, Last Available: "2010-12"
 4898	bouncing aromatic padded BGE 'cuddly critter' shirt	0		Damage Absorption: +20, Stench Resistance: +1, Last Available: "2010-12"
@@ -4855,7 +4855,7 @@
 4952	vacuum-sealed dry narrow baggie of sugar	0		Effect: "Slimy Hands", Effect Duration: 57
 4953	veiny shellacked whalebone corset	0		Damage Reduction: 7, Maximum HP: +10, Single Equip
 4954	squat groovy oven mitts	0		Moxie Percent: +10, Single Equip
-4955	half-sized adequate twirling overcookie	2	good	
+4955	adequate half-sized twirling overcookie	2	good	
 4956	bland jumbo philosopher's scone	5	decent	
 4957	boiled ghostly half-baked potion	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 42
 4958	friendly Knob Goblin deluxe scimitar	0		Familiar Weight: +3
@@ -4915,7 +4915,7 @@
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	fancy big moldy wasabi pocky	5	crappy	Effect: "Bananas!", Effect Duration: 20, Last Available: "2011-03"
 5014	normal mirror tobiko pocky	4	good	Last Available: "2011-03"
-5015	moldy miniature natto pocky	2	crappy	Last Available: "2011-03"
+5015	miniature moldy natto pocky	2	crappy	Last Available: "2011-03"
 5016	watered-down bad twirling wasabi-infused sake	2	decent	Last Available: "2011-03"
 5017	special mediocre spirit-forward bouncing tobiko-infused sake	5	decent	Effect: "Bloody-minded", Effect Duration: 5, Last Available: "2011-03"
 5018	triple-distilled hand-crafted natto-infused sake	8	EPIC	Last Available: "2011-03"
@@ -4923,7 +4923,7 @@
 5020	quantum tobiko marble soda	0		Effect: "Meatwise", Effect Duration: 36, Last Available: "2011-03"
 5021	energized natto marble soda	0		Effect: "Cold as Ice", Effect Duration: 40, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
-5023	colloidal enhanced narrow huge elderly jawbreaker	0		Effect: "Happy Trails", Effect Duration: 63, Last Available: "2020-09"
+5023	colloidal enhanced huge narrow elderly jawbreaker	0		Effect: "Happy Trails", Effect Duration: 63, Last Available: "2020-09"
 5024	bad marshmallow flamb&eacute;	4	decent	Last Available: "2011-03"
 5025	hand-crafted upside-down cranberry schnapps	3	EPIC	Last Available: "2011-03"
 5026	hand-crafted breaded beer	4	EPIC	Last Available: "2011-03"
@@ -4944,7 +4944,7 @@
 5041	lard-coated Rosewater's astral shirt of the cheetah	0		Mysticality Percent: +30, Sleaze Spell Damage: +25, Initiative: +60
 5042	extremely unsafe astral belt of the sweet-tooth	0		Weapon Damage Percent: +100, Candy Drop: +100
 5043	stale bouncing astral hot dog	4		
-5044	bad triple-distilled bouncing astral pilsner	6		
+5044	triple-distilled bad bouncing astral pilsner	6		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4968,7 +4968,7 @@
 5065	adequate diet special spaghetti con calaveras	1	good	Effect: "Eyes Wide Propped", Effect Duration: 50, Last Available: "2011-04"
 5066	cyan s'more gun	0		Last Available: "2011-04"
 5067	flavorless tumbling popcorn	3	decent	Last Available: "2011-04"
-5068	jumbo spoiled ghostly chaos popcorn	5	crappy	Last Available: "2011-04"
+5068	spoiled jumbo ghostly chaos popcorn	5	crappy	Last Available: "2011-04"
 5069	MacGyver's hole of the ox of the businessman	0		Muscle: +20, Maximum MP: +100, Meat Drop: +50, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	adequate s'more	0	good	Last Available: "2011-04"
@@ -5004,8 +5004,8 @@
 5101	red Pok&euml;mann figurine: Moog of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2011-05"
 5102	wet willyweed	0		Effect: "Quaaaaaaa", Effect Duration: 44, Last Available: "2011-05"
 5103	liquefied deionized maroon Nuclear Blastball	0		Effect: "Man's Worst Enemy", Effect Duration: 28, Last Available: "2011-05"
-5104	non-concentrated shaking ghostly fish juice box	0		Effect: "Souper Vengeful", Effect Duration: 11, Last Available: "2011-05"
-5105	twirling mirror paint bomb	0		Last Available: "2011-05"
+5104	non-concentrated ghostly shaking fish juice box	0		Effect: "Souper Vengeful", Effect Duration: 11, Last Available: "2011-05"
+5105	mirror twirling paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
 5107	acceptable blurry narrow Jeppson's Malort	3	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
@@ -5033,7 +5033,7 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	double-dry anodized Ultrasoldier Serum	0		Effect: "The Halls of Muscularity", Effect Duration: 40, Last Available: "2011-06"
 5132	bland ghostly elven hardtack	3	decent	Last Available: "2011-06"
-5133	watered-down acceptable elven squeeze	2	good	Last Available: "2011-06"
+5133	acceptable watered-down elven squeeze	2	good	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5074,11 +5074,11 @@
 5171	narrow Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	watered-down acceptable special Saison du Lune	2	good	Effect: "The Solution", Effect Duration: 5, Last Available: "2011-06"
-5175	tolerable blurry squat Moonthril Schnapps	3	good	Last Available: "2011-06"
+5174	special watered-down acceptable Saison du Lune	2	good	Effect: "The Solution", Effect Duration: 5, Last Available: "2011-06"
+5175	tolerable squat blurry Moonthril Schnapps	3	good	Last Available: "2011-06"
 5176	hand-crafted Wrecked Generator	3	super ultra mega EPIC	Last Available: "2011-06"
 5177	tiny rotten yellow Spaghetti with Moonballs	1	crappy	Last Available: "2011-06"
-5178	rotten huge Crepes a la Lune	7	crappy	Last Available: "2011-06"
+5178	huge rotten Crepes a la Lune	7	crappy	Last Available: "2011-06"
 5179	decent bite-sized fuchsia Moon Pie	1	good	Last Available: "2011-06"
 5180	quantum vacuum-sealed flattened bouncing Comet Pop	0		Effect: "A Contender", Effect Duration: 20, Last Available: "2011-06"
 5181	denatured Flan in the Moon	0		Effect: "Really Deep Breath", Effect Duration: 63, Last Available: "2011-06"
@@ -5116,10 +5116,10 @@
 5213	powdered Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	boiled slimy paste	1	EPIC	Effect: "Oxygenated Blood", Effect Duration: 20, Last Available: "2011-08"
 5215	denatured penguin paste	1	good	Effect: "Ack!  Barred!", Effect Duration: 25, Last Available: "2011-08"
-5216	pickled mirror blue elemental paste	1	good	Effect: "Mariachi Mood", Effect Duration: 20, Last Available: "2011-08"
+5216	pickled blue mirror elemental paste	1	good	Effect: "Mariachi Mood", Effect Duration: 20, Last Available: "2011-08"
 5217	boiled cosmic paste	1	good	Effect: "Loco Motives", Effect Duration: 30, Last Available: "2011-08"
 5218	boiled mirror hobo paste	1	good	Last Available: "2011-08"
-5219	powdered upside-down gray narrow Crimbo paste	1	decent	Effect: "Robocamo", Effect Duration: 50, Last Available: "2011-08"
+5219	powdered upside-down narrow gray Crimbo paste	1	decent	Effect: "Robocamo", Effect Duration: 50, Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	huge fat loot token	0		No Pull
 5222	purple Thwaitgold grasshopper statuette	0		
@@ -5127,8 +5127,8 @@
 5224	moldy mirror Ur-Donut	3	crappy	Last Available: "2011-09"
 5225	tumbling shaking The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	hand-crafted watered-down bucket of wine	2	super ultra EPIC	Last Available: "2011-09"
-5228	normal miniature olive ultrafondue	2	good	Last Available: "2011-09"
+5227	watered-down hand-crafted bucket of wine	2	super ultra EPIC	Last Available: "2011-09"
+5228	miniature normal olive ultrafondue	2	good	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5139,23 +5139,23 @@
 5236	wobbly fortified frosty halo	0		Damage Absorption: +60, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	pulsating wobbly miser's time halo	0		Meat Drop: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	weak drinkable Lumineux Limnio	2	good	Last Available: "2011-09"
-5239	hand-crafted practically non-alcoholic huge Morto Moreto	1	EPIC	Last Available: "2011-09"
+5239	practically non-alcoholic hand-crafted huge Morto Moreto	1	EPIC	Last Available: "2011-09"
 5240	hand-crafted Temps Tempranillo	3	EPIC	Last Available: "2011-09"
 5241	perfectly mixed pulsating Bordeaux Marteaux	4	EPIC	Last Available: "2011-09"
 5242	mediocre Fromage Pinotage	3	decent	Last Available: "2011-09"
-5243	practically non-alcoholic acceptable red Beignet Milgranet	1	good	Last Available: "2011-09"
-5244	practically non-alcoholic delicious blurry Muschat	1	awesome	Last Available: "2011-09"
-5245	immense spoiled cool jelly donut	10	crappy	Last Available: "2011-09"
+5243	acceptable practically non-alcoholic red Beignet Milgranet	1	good	Last Available: "2011-09"
+5244	delicious practically non-alcoholic blurry Muschat	1	awesome	Last Available: "2011-09"
+5245	spoiled immense cool jelly donut	10	crappy	Last Available: "2011-09"
 5246	moldy shrapnel jelly donut	3	crappy	Last Available: "2011-09"
 5247	bland thick occult jelly donut	5	decent	Last Available: "2011-09"
 5248	flavorless thyme jelly donut	3	decent	Last Available: "2011-09"
 5249	low-calorie toothsome danish	1	awesome	Last Available: "2011-09"
-5250	stale snack-sized smashed danish	2	decent	Last Available: "2011-09"
+5250	snack-sized stale smashed danish	2	decent	Last Available: "2011-09"
 5251	decent forbidden danish	4	good	Last Available: "2011-09"
 5252	adequate gigantic cool cat claw	10	good	Last Available: "2011-09"
 5253	flavorless blunt cat claw	3	decent	Last Available: "2011-09"
 5254	stale shadowy cat claw	4	decent	Last Available: "2011-09"
-5255	decent tiny upside-down cheezburger	1	good	Last Available: "2011-09"
+5255	tiny decent upside-down cheezburger	1	good	Last Available: "2011-09"
 5256	stale toasted brie	3	decent	Last Available: "2011-09"
 5257	unsweetened quantum tumbling potion of the field gar	0		Effect: "Super Accuracy", Effect Duration: 27, Last Available: "2011-09"
 5258	extra-flattened Vulcanized concentrated spinning tumbling too legit potion	0		Effect: "Ichorous Eyesight", Effect Duration: 53, Last Available: "2011-09"
@@ -5166,7 +5166,7 @@
 5263	irradiated potion of the captain's hammer	0		Effect: "Total Protonic Reversal", Effect Duration: 40, Last Available: "2011-09"
 5264	aerosolized potion of X-ray vision	0		Effect: "Saucefingers", Effect Duration: 14, Last Available: "2011-09"
 5265	super-ionized potion of the litterbox	0		Effect: "Polar Express", Effect Duration: 44, Last Available: "2011-09"
-5266	frozen double-improved green mirror potion of animal rage	0		Effect: "Medieval Mage Mayhem", Effect Duration: 53, Last Available: "2011-09"
+5266	frozen double-improved mirror green potion of animal rage	0		Effect: "Medieval Mage Mayhem", Effect Duration: 53, Last Available: "2011-09"
 5267	ionized denatured potion of punctual companionship	0		Effect: "Mercenary", Effect Duration: 38, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
@@ -5186,7 +5186,7 @@
 5283	Samson's glacial clock	0		Experience (Muscle): +5, Last Available: "2011-09"
 5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
-5286	jittery twirling d6	0		Last Available: "2011-09"
+5286	twirling jittery d6	0		Last Available: "2011-09"
 5287	cyan d8	0		Last Available: "2011-09"
 5288	jittery yellow d10	0		Last Available: "2011-09"
 5289	d12	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	wobbly newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	shaking dungeon dragon chest	0		Last Available: "2011-09"
-5298	tiny flavorless special phish stick	1	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2011-09"
+5298	flavorless tiny special phish stick	1	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2011-09"
 5299	blurry chilly rosy-cheeked padded plastic vampire fangs	0		Damage Absorption: +20, Maximum HP Percent: +30, Cold Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5208,14 +5208,14 @@
 5305	blinking olive pulsating executive Sceptre of the Torremolinos Prince	0		Meat Drop: +40, Last Available: "2011-10"
 5306	upside-down spinning Medallion of the Ventrilo Prince of the businessman	0		Meat Drop: +50, Last Available: "2011-10"
 5307	Haunted Sorority House staff guide	0		Last Available: "2011-10"
-5308	teal tumbling ghost trap	0		Last Available: "2011-10"
+5308	tumbling teal ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
 5310	shotgun shell	0		Last Available: "2011-10"
 5311	spinning funhouse mirror	0		Last Available: "2011-10"
 5312	super-denatured pickled corrupted ghostly body paint	0		Effect: "Bilious Brains", Effect Duration: 34, Last Available: "2011-10"
 5313	anodized wobbly necrotizing body spray	0		Effect: "Jammin'", Effect Duration: 68, Last Available: "2011-10"
 5314	moist vacuum-sealed bite-me-red lipstick	0		Effect: "Red-Shirted Escort", Effect Duration: 43, Last Available: "2011-10"
-5315	corrupted bouncing fuchsia upside-down whisker pencil	0		Effect: "Remaining Alive", Effect Duration: 55, Last Available: "2011-10"
+5315	corrupted fuchsia bouncing upside-down whisker pencil	0		Effect: "Remaining Alive", Effect Duration: 55, Last Available: "2011-10"
 5316	warmed quadruple-tarnished wobbly cyan press-on ribs	0		Effect: "The Real Deal", Effect Duration: 21, Last Available: "2011-10"
 5317	double-oxidized Rattlin' Chains	0		Effect: "Sepia Tan", Effect Duration: 47, Last Available: "2011-10"
 5318	irradiated moist mirror mirror Gummy Brains	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 30, Last Available: "2011-10"
@@ -5224,7 +5224,7 @@
 5321	quantum cyan Sweet Sword	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 42, Last Available: "2011-10"
 5322	perfectly mixed practically non-alcoholic green Ecto-Cooler	1	EPIC	Last Available: "2011-10"
 5323	drinkable Bartles and BRAAAINS wine cooler	3	good	Last Available: "2011-10"
-5324	bad irresponsibly strong Blood Light	8	decent	Last Available: "2011-10"
+5324	irresponsibly strong bad Blood Light	8	decent	Last Available: "2011-10"
 5325	watered-down artisanal Silver Bullet beer	2	EPIC	Last Available: "2011-10"
 5326	mediocre yellow Bone's Farm &quot;wine&quot;	3	decent	Last Available: "2011-10"
 5327	blue ghost protocol	0		Last Available: "2011-10"
@@ -5258,7 +5258,7 @@
 5355	gray Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	bouncing Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
-5358	green narrow shaking Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
+5358	narrow green shaking Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	jittery Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
@@ -5268,7 +5268,7 @@
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 5366	jittery CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
-5368	fuchsia twirling Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
+5368	twirling fuchsia Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	narrow shaking olive KoL Con 8-Bit power bracelet of temperance	0		Sleaze Resistance: +5, Last Available: "2011-09"
 5370	green boiler	0		
 5371	stuffed-shirt scarecrow	0		Free Pull, Last Available: "2011-11"
@@ -5290,7 +5290,7 @@
 5387	scorching ridiculous earring	0		Hot Damage: +25, Last Available: "2011-11"
 5388	chaotic ridiculous sunglasses	0		Spell Critical Percent: +10, Last Available: "2011-11"
 5389	snack-sized stale ridiculous sandwich	2	decent	Last Available: "2011-11"
-5390	drinkable extra-dry squat ridiculous cocktail	5	good	Last Available: "2011-11"
+5390	extra-dry drinkable squat ridiculous cocktail	5	good	Last Available: "2011-11"
 5391	Socratic zombie monkey necklace of the detective	0		Experience (Mysticality): +1, Item Drop: +20
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5307,12 +5307,12 @@
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	Samson's experienced smooth cane-mail shirt	0		Moxie: +15, Experience: +2, Experience (Muscle): +5, Last Available: "2011-12"
 5406	rosewater-soaked banded cool cane-mail pants	0		Moxie: +5, Damage Absorption: +100, Stench Resistance: +3, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	practically non-alcoholic aged Vodka Matryoshka	1	awesome	Last Available: "2011-12"
+5407	aged practically non-alcoholic Vodka Matryoshka	1	awesome	Last Available: "2011-12"
 5408	bad Gin Mint	4	decent	Last Available: "2011-12"
 5409	aged watered-down Tequiz Navidad	2	awesome	Last Available: "2011-12"
 5410	artisanal Mint Yulep	3	EPIC	Last Available: "2011-12"
 5411	drinkable distilled Crimbojito	5	good	Last Available: "2011-12"
-5412	weak mediocre Sangria de Menthe	2	decent	Last Available: "2011-12"
+5412	mediocre weak Sangria de Menthe	2	decent	Last Available: "2011-12"
 5413	teal candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	extra-quantum irradiated licorice root	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 33, Last Available: "2011-12"
@@ -5336,11 +5336,11 @@
 5433	raspberry troll doll	0		Last Available: "2011-11"
 5434	narrow DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
-5436	warmed quadruple-activated non-cold-filtered blue huge fudge lily	0		Effect: "You Can Taste the Darkness", Effect Duration: 52, Last Available: "2011-11"
+5436	warmed quadruple-activated non-cold-filtered huge blue fudge lily	0		Effect: "You Can Taste the Darkness", Effect Duration: 52, Last Available: "2011-11"
 5437	spinning superheated fudge	0		Last Available: "2011-11"
 5438	activated skewed fluid of fudge-finding	0		Effect: "Alacri Tea", Effect Duration: 65, Last Available: "2011-11"
 5439	narrow fudgepuck	0		Last Available: "2011-11"
-5440	low-calorie bland fudgesicle	1	decent	Last Available: "2011-11"
+5440	bland low-calorie fudgesicle	1	decent	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5361,7 +5361,7 @@
 5458	adequate twirling blinking fudge bunny	3	good	Last Available: "2011-11"
 5459	purple fudge spork	0		Last Available: "2011-11"
 5460	dog trainer's fudgecycle of Leguizamo of horror	0		Monster Level: +20, Experience (familiar): +1, Spooky Spell Damage: +25, Single Equip, Last Available: "2011-11"
-5461	gray upside-down mirror fudge cube	0		Last Available: "2011-11"
+5461	upside-down mirror gray fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	upside-down Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	double-enhanced quadruple-aerosolized triple-deionized skewed resolution: be wealthier	0		Effect: "Mo' Hobo", Effect Duration: 24, Last Available: "2012-01"
@@ -5381,16 +5381,16 @@
 5478	denatured flattened tarnished bouncing gummi canary	0		Effect: "Buttermilk Boogie", Effect Duration: 54, Last Available: "2011-11"
 5479	bland gummi bear	3	decent	Last Available: "2011-11"
 5480	bland jumbo gummi bear	5	decent	Last Available: "2011-11"
-5481	small spoiled gummi bear	2	crappy	Last Available: "2011-11"
+5481	spoiled small gummi bear	2	crappy	Last Available: "2011-11"
 5482	spoiled upside-down drunki-bear	3	crappy	Last Available: "2011-11"
 5483	spoiled upside-down drunki-bear	3	crappy	Last Available: "2011-11"
-5484	half-sized decent drunki-bear	2	good	Last Available: "2011-11"
+5484	decent half-sized drunki-bear	2	good	Last Available: "2011-11"
 5485	gummi bowtie of the wise owl	0		Mysticality: +20, Last Available: "2011-11"
 5486	tumbling clever fudge pocket square	0		Maximum MP: +20, Last Available: "2011-11"
 5487	baleful lollipop cufflinks	0		Spell Damage: +25, Last Available: "2011-11"
 5488	trilobite fossil	0		Last Available: "2011-11"
 5489	wobbly ammonite fossil	0		Last Available: "2011-11"
-5490	huge squat belemnite fossil	0		Last Available: "2011-11"
+5490	squat huge belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	mirror blurry ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
@@ -5406,7 +5406,7 @@
 5503	jittery Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blue blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	immense moldy jerky coins	7	crappy	Last Available: "2011-11"
+5506	moldy immense jerky coins	7	crappy	Last Available: "2011-11"
 5507	drinkable Go-Wassail	3	good	Last Available: "2011-11"
 5508	flattened ionized Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Gemini Rising", Effect Duration: 24, Last Available: "2011-11"
 5509	quantum bottle of bubbles	0		Effect: "Improved Candy Vision", Effect Duration: 64, Last Available: "2011-11"
@@ -5459,7 +5459,7 @@
 5556	maroon resourceful Rain-Doh wings of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +50, Softcore Only, Last Available: "2012-02"
 5557	twirling Rain-Doh agent	0		Last Available: "2012-02"
 5558	zippy toasty Rain-Doh laser gun	0		Hot Damage: +5, Initiative: +20, Softcore Only, Last Available: "2012-02"
-5559	Rain-Doh lantern of dire peril of the boozehound	0		Weapon Damage: +20, Booze Drop: +100, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	Rain-Doh lantern of dire peril of the boozehound	0		Weapon Damage: +20, Booze Drop: +100, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	olive Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	tumbling stylish weightlifter's Rain-Doh violet bo	0		Muscle: +15, Moxie: +25, Softcore Only, Last Available: "2012-02"
@@ -5470,15 +5470,15 @@
 5567	rotten corned-beef Reuben	3	crappy	
 5568	upside-down fuchsia frayed ninja rope	0		
 5569	shaking dull ninja crampons	0		
-5570	tumbling narrow yellow loose ninja carabiner	0		
+5570	yellow narrow tumbling loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	acceptable Drac & Tan	4	good	Last Available: "2012-03"
 5574	lousy Transylvania Sling	3	decent	Last Available: "2012-03"
 5575	artisanal Shot of the Living Dead	3	EPIC	Last Available: "2012-03"
-5576	fancy delicious Buttery Knob	4	awesome	Effect: "Berry Thorny", Effect Duration: 15, Last Available: "2012-03"
+5576	delicious fancy Buttery Knob	4	awesome	Effect: "Berry Thorny", Effect Duration: 15, Last Available: "2012-03"
 5577	drinkable spinning Slippery Knob	3	good	Last Available: "2012-03"
-5578	acceptable watered-down Flaming Knob	2	good	Last Available: "2012-03"
+5578	watered-down acceptable Flaming Knob	2	good	Last Available: "2012-03"
 5579	hand-crafted Grasshopper	4	EPIC	Last Available: "2012-03"
 5580	artisanal irresponsibly strong Locust	6	EPIC	Last Available: "2012-03"
 5581	perfectly mixed Plague of Locusts	4	EPIC	Last Available: "2012-03"
@@ -5488,7 +5488,7 @@
 5585	bad watered-down cyan Aye Aye	2	decent	Last Available: "2012-03"
 5586	acceptable Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	hand-crafted irresponsibly strong twirling Aye Aye, Tooth Tooth	6	EPIC	Last Available: "2012-03"
-5588	tolerable extra-dry Humanitini	5	good	Last Available: "2012-03"
+5588	extra-dry tolerable Humanitini	5	good	Last Available: "2012-03"
 5589	distilled bad More Humanitini than Humanitini	5	decent	Last Available: "2012-03"
 5590	drinkable weak Oh, the Humanitini	2	good	Last Available: "2012-03"
 5591	delicious jittery Great Older Fashioned	3	awesome	Last Available: "2012-03"
@@ -5497,51 +5497,51 @@
 5594	acceptable Zoodriver	3	good	Last Available: "2012-03"
 5595	bad tumbling Sloe Comfortable Zoo	4	decent	Last Available: "2012-03"
 5596	tolerable practically non-alcoholic Sloe Comfortable Zoo on Fire	1	good	Last Available: "2012-03"
-5597	special irresponsibly strong acceptable skewed squat Suffering Sinner	6	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45, Last Available: "2012-03"
+5597	irresponsibly strong special acceptable skewed squat Suffering Sinner	6	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45, Last Available: "2012-03"
 5598	aged weak ghostly Suppurating Sinner	2	awesome	Last Available: "2012-03"
 5599	practically non-alcoholic acceptable Sizzling Sinner	1	good	Last Available: "2012-03"
 5600	artisanal Firewater	3	EPIC	Last Available: "2012-03"
-5601	special mediocre watered-down twirling Earth and Firewater	2	decent	Effect: "Turkey-Friendly", Effect Duration: 15, Last Available: "2012-03"
+5601	watered-down special mediocre twirling Earth and Firewater	2	decent	Effect: "Turkey-Friendly", Effect Duration: 15, Last Available: "2012-03"
 5602	watered-down fancy bad Earth, Wind and Firewater	2	decent	Effect: "Uncanny Shot", Effect Duration: 35, Last Available: "2012-03"
 5603	perfectly mixed Slimosa	3	EPIC	Last Available: "2012-03"
-5604	perfectly mixed watered-down Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
+5604	watered-down perfectly mixed Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
 5605	delicious squat Slimebite	4	awesome	Last Available: "2012-03"
 5606	fortified tolerable Cement Mixer	5	good	Last Available: "2012-03"
 5607	drinkable watered-down Jackhammer	2	good	Last Available: "2012-03"
-5608	extra-dry delicious Dump Truck	5	awesome	Last Available: "2012-03"
-5609	acceptable watered-down bouncing Fauna Libre	2	good	Last Available: "2012-03"
-5610	drinkable weak mirror Chakra Libre	2	good	Last Available: "2012-03"
+5608	delicious extra-dry Dump Truck	5	awesome	Last Available: "2012-03"
+5609	watered-down acceptable bouncing Fauna Libre	2	good	Last Available: "2012-03"
+5610	weak drinkable mirror Chakra Libre	2	good	Last Available: "2012-03"
 5611	weak bad Aura Libre	2	decent	Last Available: "2012-03"
 5612	mediocre blinking Sazerorc	3	decent	Last Available: "2012-03"
 5613	perfectly mixed jittery Sazuruk-hai	3	EPIC	Last Available: "2012-03"
 5614	aged jittery Flaming Sazerorc	4	awesome	Last Available: "2012-03"
-5615	weak hand-crafted Green Velvet	2	EPIC	Last Available: "2012-03"
-5616	fortified lousy huge Green Muslin	5	decent	Last Available: "2012-03"
+5615	hand-crafted weak Green Velvet	2	EPIC	Last Available: "2012-03"
+5616	lousy fortified huge Green Muslin	5	decent	Last Available: "2012-03"
 5617	tolerable high-proof Green Burlap	6	good	Last Available: "2012-03"
-5618	watered-down tolerable mirror Mohobo	2	good	Last Available: "2012-03"
+5618	tolerable watered-down mirror Mohobo	2	good	Last Available: "2012-03"
 5619	mediocre Moonshine Mohobo	4	decent	Last Available: "2012-03"
 5620	aged bouncing Flaming Mohobo	4	awesome	Last Available: "2012-03"
-5621	triple-distilled hand-crafted Drunken Philosopher	8	EPIC	Last Available: "2012-03"
-5622	artisanal weak blinking huge Drunken Neurologist	2	EPIC	Last Available: "2012-03"
+5621	hand-crafted triple-distilled Drunken Philosopher	8	EPIC	Last Available: "2012-03"
+5622	artisanal weak huge blinking Drunken Neurologist	2	EPIC	Last Available: "2012-03"
 5623	smooth shaking Drunken Astrophysicist	3	awesome	Last Available: "2012-03"
 5624	watered-down drinkable Dark & Starry	2	good	Last Available: "2012-03"
-5625	special bad spirit-forward Black Hole	5	decent	Effect: "Amorous Avarice", Effect Duration: 40, Last Available: "2012-03"
-5626	artisanal triple-distilled Event Horizon	10	EPIC	Last Available: "2012-03"
+5625	bad spirit-forward special Black Hole	5	decent	Effect: "Amorous Avarice", Effect Duration: 40, Last Available: "2012-03"
+5626	triple-distilled artisanal Event Horizon	10	EPIC	Last Available: "2012-03"
 5627	extra-dry hand-crafted Herring Daiquiri	5	EPIC	Last Available: "2012-03"
 5628	drinkable Herring Wallbanger	3	good	Last Available: "2012-03"
-5629	mediocre enchanted twirling Herringtini	4	decent	Effect: "Sludgesick", Effect Duration: 30, Last Available: "2012-03"
+5629	enchanted mediocre twirling Herringtini	4	decent	Effect: "Sludgesick", Effect Duration: 30, Last Available: "2012-03"
 5630	bad huge Lollipop Drop	3	decent	Last Available: "2012-03"
 5631	watered-down drinkable jittery Candy Alexander	2	good	Last Available: "2012-03"
 5632	practically non-alcoholic artisanal Candicaine	1	super ultra EPIC	Last Available: "2012-03"
-5633	tolerable irresponsibly strong blurry Caipiranha	9	good	Last Available: "2012-03"
-5634	aged special watered-down cyan Flying Caipiranha	2	awesome	Effect: "Butt-Rock Hair", Effect Duration: 15, Last Available: "2012-03"
-5635	smooth weak Flaming Caipiranha	2	awesome	Last Available: "2012-03"
+5633	irresponsibly strong tolerable blurry Caipiranha	9	good	Last Available: "2012-03"
+5634	aged watered-down special cyan Flying Caipiranha	2	awesome	Effect: "Butt-Rock Hair", Effect Duration: 15, Last Available: "2012-03"
+5635	weak smooth Flaming Caipiranha	2	awesome	Last Available: "2012-03"
 5636	lousy Punchplanter	3	decent	Last Available: "2012-03"
 5637	smooth blurry Doublepunchplanter	4	awesome	Last Available: "2012-03"
 5638	fancy tolerable Haymaker	3	good	Effect: "Painted-On Bikini", Effect Duration: 15, Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	toothsome miniature fungus	2	awesome	
+5641	miniature toothsome fungus	2	awesome	
 5642	poisoned dart	0		
 5643	chilled extra-cold-filtered chilled mirror stone wool	0		Effect: "Pwnd", Effect Duration: 31
 5644	stones	0		
@@ -5551,7 +5551,7 @@
 5648	tumbling fuchsia quilted smooth Boris's Helm	0		Moxie: +15, Damage Absorption: +40, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	bouncing greedy fortified staph of homophones	0		Damage Absorption: +60, Meat Drop: +20
 5650	pulsating Annie Oakley's electrified medical-grade Boris's Helm (askew)	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
-5651	spinning upside-down mime soul fragment	0		Last Available: "2012-04"
+5651	upside-down spinning mime soul fragment	0		Last Available: "2012-04"
 5652	shaking Monster Manuel	0		Free Pull
 5653	twirling key-o-tron	0		
 5654	adequate nailswurst	3	good	
@@ -5628,7 +5628,7 @@
 5727	Tesla Herculean hot daub stand	0		Experience (Muscle): +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	ribald foot-long hot daub of terror	0		Spooky Spell Damage: +10, Sleaze Damage: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	decent thick special angst burger	5	good	Effect: "Moose Wisdom", Effect Duration: 15
+5730	thick decent special angst burger	5	good	Effect: "Moose Wisdom", Effect Duration: 15
 5731	hand-crafted 5-hour acrimony	3	EPIC	
 5732	shaking ghostly blank note	0		
 5733	huge eerily silent box	0		
@@ -5642,18 +5642,18 @@
 5741	hand-crafted water purification pills	4	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	delicious boozy CSA scoutmaster's &quot;water&quot;	5	awesome	Last Available: "2012-07"
-5744	rotten snack-sized bag of GORF	2	crappy	Last Available: "2012-07"
+5744	snack-sized rotten bag of GORF	2	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	yummy bag of QWOP	4	awesome	Last Available: "2012-07"
-5747	modified flattened colloidal jittery bouncing CSA bravery badge	0		Effect: "Fit To Be Tide", Effect Duration: 30, Last Available: "2012-07"
+5747	modified flattened colloidal bouncing jittery CSA bravery badge	0		Effect: "Fit To Be Tide", Effect Duration: 30, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	tolerable irresponsibly strong blue CSA cheerfulness ration	10	good	Last Available: "2012-07"
-5750	blurry olive blinking CSA obedience grenade	0		Last Available: "2012-07"
+5749	irresponsibly strong tolerable blue CSA cheerfulness ration	10	good	Last Available: "2012-07"
+5750	blinking blurry olive CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	gigantic decent crappy brain	10	good	
 5753	miniature adequate gray decent brain	2	good	
 5754	delicious low-calorie tumbling good brain	1	awesome	
-5755	toothsome snack-sized boss brain	2	awesome	
+5755	snack-sized toothsome boss brain	2	awesome	
 5756	stale hunter brain	4	decent	
 5758	skewed stanky hale Staff of Holiday Sensations of the businessman	0		Maximum HP: +20, Stench Spell Damage: +25, Meat Drop: +50, Last Available: "2011-11"
 5759	skewed double-paned forbidden staff	0		Spell Damage Percent: +50, Cold Resistance: +5
@@ -5664,7 +5664,7 @@
 5764	jittery cool fuzzy busby of Calamity Jane	0		Moxie: +5, Critical Hit Percent: +15, Familiar Effect: "1.5xVolley, cap 32"
 5765	ghostly inspector's foul-smelling fuzzy earmuffs	0		Stench Damage: +10, Item Drop: +15, Familiar Effect: "1.5xVolley, cap 32"
 5766	flame-retardant studded fuzzy montera of the empath	0		Damage Absorption: +80, Familiar Weight: +5, Hot Resistance: +1, Familiar Effect: "1.5xVolley, cap 32"
-5767	purple mirror Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
+5767	mirror purple Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
 5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
 5769	gnomish coal miner's lung	0		Familiar Effect: "block", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
 5770	gnomish tennis elbow	0		Familiar Effect: "damage", Last Available: "2012-08", Equips On: "Reagnimated Gnome"
@@ -5708,7 +5708,7 @@
 5809	magnetized fuchsia Knob Goblin Mutagen	0		Effect: "El Vibrations", Effect Duration: 15
 5810	aerosolized anodized red Tears of the Quiet Healer	0		Effect: "Berry Critical", Effect Duration: 46
 5811	flattened boiled tube of lipstick	0		Effect: "Painted-On Bikini", Effect Duration: 25
-5812	adjusted pressed shaking blurry skelelton spine	0		Effect: "Sharp Weapon", Effect Duration: 58
+5812	adjusted pressed blurry shaking skelelton spine	0		Effect: "Sharp Weapon", Effect Duration: 58
 5813	super-unsweetened pulsating smut orc sunglasses	0		Effect: "Make Meat FA$T!", Effect Duration: 30
 5814	polarized diffused blob of acid	0		Effect: "Human-Orc Hybrid", Effect Duration: 14
 5815	dry flayed mind	0		Effect: "Orc Chops", Effect Duration: 49
@@ -5729,21 +5729,21 @@
 5830	triple-polymerized pressed pygmy papers	0		Effect: "Square to be Hip", Effect Duration: 60
 5831	diffused pygmy dart	0		Effect: "Concentration", Effect Duration: 47
 5832	extra-irradiated spinning secret mummy herbs and spices	0		Effect: "Eyes for Miles", Effect Duration: 25
-5833	denatured blue bouncing brigand brittle	0		Effect: "Burning Ears", Effect Duration: 49
+5833	denatured bouncing blue brigand brittle	0		Effect: "Burning Ears", Effect Duration: 49
 5834	quantum holistic headache remedy	0		Effect: "Stregngth of the Gnome", Effect Duration: 55
 5835	polymerized shaking scrunchie tourniquet	0		Effect: "Far Out", Effect Duration: 13
 5836	polarized embezzler's oil	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 69
-5837	nitrogenated red jittery Fu Manchu Wax	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 52
+5837	nitrogenated jittery red Fu Manchu Wax	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 52
 5838	Vulcanized Iiti Kitty Gumdrop	0		Effect: "Eyes of the Dragon", Effect Duration: 52
 5839	electrified ravenous eye	0		Effect: "Human-Hippy Hybrid", Effect Duration: 68
-5840	corrupted huge ghostly Rogue Windmill Rouge	0		Effect: "World's Shortest Giant", Effect Duration: 12
+5840	corrupted ghostly huge Rogue Windmill Rouge	0		Effect: "World's Shortest Giant", Effect Duration: 12
 5841	quantum A muse-bouche	0		Effect: "Nas Tea", Effect Duration: 47
 5842	aerosolized non-moist spinning toothbrush	0		Effect: "Alacri Tea", Effect Duration: 35
 5843	frozen pirate cream pie	0		Effect: "Pride of the Vampire", Effect Duration: 29
 5844	oxidized double-dry una poca de gracia	0		Effect: "Happy Trails", Effect Duration: 45
 5845	pickled compressed air canister	0		Effect: "Can't Smell Nothin'", Effect Duration: 44
-5846	warmed quantum shaking spinning salt water taffy	0		Effect: "Destructive Resolve", Effect Duration: 52
-5847	quadruple-electrified blinking maroon bouncing unholy water	0		Effect: "Night Vision", Effect Duration: 53
+5846	warmed quantum spinning shaking salt water taffy	0		Effect: "Destructive Resolve", Effect Duration: 52
+5847	quadruple-electrified maroon blinking bouncing unholy water	0		Effect: "Night Vision", Effect Duration: 53
 5848	adjusted maroon Bangyomaman battle juice	0		Effect: "Engorged Weapon", Effect Duration: 17
 5849	adjusted colloidal purple handyman &quot;hand soap&quot;	0		Effect: "Radium Radicality", Effect Duration: 37
 5850	colloidal huge space marine flash grenade	0		Effect: "Pill Power", Effect Duration: 51
@@ -5799,7 +5799,7 @@
 5900	red jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	skewed cyan jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
-5903	green skewed jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
+5903	skewed green jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	narrow jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	skewed pixel pill	0		
 5907	pixel energy tank	0		
@@ -5863,7 +5863,7 @@
 5965	chilly dangerous Frown Exerciser	0		Weapon Damage: +10, Cold Damage: +5, Single Equip, Last Available: "2012-12"
 5966	red soul monocle	0		Single Equip
 5967	cyan soul doorbell	0		
-5968	mirror wobbly soul coin	0		
+5968	wobbly mirror soul coin	0		
 5969	green soul knife	0		
 5970	soul mask of chilblains	0		Cold Damage: +25, Single Equip
 5971	teal blurry record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5877,7 +5877,7 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	ghostly star	0		Last Available: "2013-02"
-5982	high-proof acceptable tankard of ale	7	good	Last Available: "2013-02"
+5982	acceptable high-proof tankard of ale	7	good	Last Available: "2013-02"
 5983	wobbly vial of holy water	0		Last Available: "2013-02"
 5984	gray mirror reassuring sizzling cloth cap of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +10, Spooky Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	rosy-cheeked weightlifter's iron dagger of horror	0		Muscle: +15, Maximum HP Percent: +30, Spooky Spell Damage: +25, Last Available: "2013-02"
@@ -5933,7 +5933,7 @@
 6035	pickled upside-down tumbling vial of The Glistening	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 48
 6036	perfectly mixed artisanal limoncello	3	EPIC	
 6037	shaking ginger ale	0		
-6038	rotten super-sized bouncing incredible pizza	5	crappy	
+6038	super-sized rotten bouncing incredible pizza	5	crappy	
 6039	narrow ribald oil cap of mayonnaise	0		Sleaze Damage: +10, Sleaze Spell Damage: +50, Familiar Effect: "cap 28"
 6040	shaking lightning-fast hale oil lamp	0		Maximum HP: +20, Initiative: +40
 6041	oil slacks of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1xPotato, cap 30"
@@ -5971,14 +5971,14 @@
 6073	Vulcanized spinning haggis-infused soap	0		Effect: "Wet Willied", Effect Duration: 56, Last Available: "2012-12"
 6074	wet magicberry tablets	0		Effect: "You Know What's Up", Effect Duration: 12, Last Available: "2012-12"
 6075	ionized denatured alkaline 37x37x37 puzzle cube	0		Effect: "Powdered", Effect Duration: 51, Last Available: "2012-12"
-6076	mediocre fancy spinning McLeod's Hard Haggis-Ade	3	decent	Effect: "Oh Snap", Effect Duration: 45, Last Available: "2012-12"
+6076	fancy mediocre spinning McLeod's Hard Haggis-Ade	3	decent	Effect: "Oh Snap", Effect Duration: 45, Last Available: "2012-12"
 6077	flavorless huge enchanted haggis-wrapped haggis-stuffed haggis	9	decent	Effect: "You Know Who to Call", Effect Duration: 45, Last Available: "2012-12"
 6078	huge home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	haggis socks of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
 6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
-6083	jittery twirling actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
+6083	twirling jittery actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	spinning Mr. Haggis	0		Last Available: "2012-12"
 6085	mirror magnetic sculpture kit	0		Last Available: "2012-12"
 6086	supercharged Microplushie: Otakulone	0		Maximum MP Percent: +30, Last Available: "2012-12"
@@ -6001,7 +6001,7 @@
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	maroon Artist's Spatula of Despair	0		Last Available: "2013-12"
-6106	narrow skewed Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
+6106	skewed narrow Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	twirling Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	Sherlock's forbidden Ginsu&trade;	0		Spell Damage Percent: +50, Item Drop: +25, Last Available: "2013-12"
 6109	bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	blinking bonsai tree	0		Last Available: "2013-12"
-6121	artisanal weak Chinese beer	2	EPIC	Last Available: "2013-12"
+6121	weak artisanal Chinese beer	2	EPIC	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6030,7 +6030,7 @@
 6132	battery	0		Last Available: "2013-12"
 6133	fireproof supercharged wizardly White Dragon Fang	0		Mysticality: +25, Maximum MP Percent: +30, Hot Resistance: +3, Last Available: "2013-12"
 6134	shaking butterfly knife of extreme caution	0		Monster Level: -25, Last Available: "2013-12"
-6135	wobbly cyan blurry tube of herbal ointment	0		Last Available: "2013-12"
+6135	cyan wobbly blurry tube of herbal ointment	0		Last Available: "2013-12"
 6136	wobbly pencil kunai	0		Last Available: "2013-12"
 6137	weighted paperclip chain of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2013-12"
 6138	great capacitor	0		Last Available: "2013-12"
@@ -6048,7 +6048,7 @@
 6151	cyan carrot nose	0		Last Available: "2013-01"
 6152	adequate carrot cake	3	good	Last Available: "2013-01"
 6153	tolerable pulsating carrot claret	3	good	Last Available: "2013-01"
-6154	dried purple tumbling carrot juice	1	decent	Last Available: "2013-01"
+6154	dried tumbling purple carrot juice	1	decent	Last Available: "2013-01"
 6155	twirling pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	groovy Byte of the scaredy-cat	0		Moxie Percent: +10, Monster Level: -15, Last Available: "2013-12"
@@ -6064,7 +6064,7 @@
 6167	skewed hardened ornamental sextant	0		Damage Reduction: 3, Last Available: "2013-12"
 6168	Herculean Bloodbath of Gandalf	0		Experience (Muscle): +1, Spell Critical Percent: +20, Last Available: "2013-12"
 6169	practically non-alcoholic hand-crafted Hundred Headed IPA	1	super ultra mega EPIC	Last Available: "2013-12"
-6170	moldy jumbo chum	5	crappy	Last Available: "2013-12"
+6170	jumbo moldy chum	5	crappy	Last Available: "2013-12"
 6171	nitrogenated tarnished crude crudit&eacute;s	0		Effect: "Egg-stortionary Tactics", Effect Duration: 26
 6172	altered concentrated narrow candy crayons	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 15, Last Available: "2020-09"
 6173	ribald forbidden pixel grappling hook	0		Spell Damage Percent: +50, Sleaze Damage: +10
@@ -6079,57 +6079,57 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	wobbly Jack Frost's occult sage Jarlsberg's hat	0		Mysticality Percent: +10, Spell Damage Percent: +25, Cold Spell Damage: +50
-6185	normal diet blurry consummate hard-boiled egg	1	good	
+6185	diet normal blurry consummate hard-boiled egg	1	good	
 6186	spoiled consummate fried egg	4	crappy	
 6187	jumbo toothsome consummate egg salad	5	awesome	
 6188	normal consummate bagel	3	good	
-6189	stale miniature consummate sliced bread	2	decent	
+6189	miniature stale consummate sliced bread	2	decent	
 6190	delicious consummate hot dog bun	3	awesome	
-6191	decent huge shaking consummate brownie	3	good	
+6191	decent shaking huge consummate brownie	3	good	
 6192	adequate big consummate toast	5	good	
-6193	perfectly mixed irresponsibly strong passable stout	6	EPIC	
+6193	irresponsibly strong perfectly mixed passable stout	6	EPIC	
 6194	stale consummate soup	3	decent	
 6195	flavorless mirror huge consummate corn chips	3	decent	
 6196	bland consummate salad	3	decent	
 6197	tasty consummate salsa	4	awesome	
 6198	tiny adequate consummate sauerkraut	1	good	
-6199	adequate immense consummate cheese slice	8	good	
+6199	immense adequate consummate cheese slice	8	good	
 6200	tasty squat consummate melted cheese	4	awesome	
-6201	big bland consummate bacon	5	decent	
+6201	bland big consummate bacon	5	decent	
 6202	tasty consummate meatloaf	3	awesome	
 6203	spoiled jittery consummate steak	3	crappy	
 6204	yummy consummate cuts	4	awesome	
-6205	spoiled miniature consummate frankfurter	2	crappy	
-6206	enchanted toothsome huge jittery consummate french fries	4	awesome	Effect: "Fungal Flambé", Effect Duration: 45
-6207	flavorless small consummate baked potato	2	decent	
+6205	miniature spoiled consummate frankfurter	2	crappy	
+6206	toothsome enchanted huge jittery consummate french fries	4	awesome	Effect: "Fungal Flambé", Effect Duration: 45
+6207	small flavorless consummate baked potato	2	decent	
 6208	bad acceptable vodka	3	decent	
 6209	moldy narrow twirling skewed consummate ice cream	4	crappy	
 6210	delicious consummate whipped cream	4	awesome	
-6211	stale small blurry consummate cream	2	decent	
+6211	small stale blurry consummate cream	2	decent	
 6212	normal consummate strawberries	3	good	
-6213	fancy adequate green consummate sorbet	3	good	Effect: "Swimming with Sharks", Effect Duration: 5
+6213	adequate fancy green consummate sorbet	3	good	Effect: "Swimming with Sharks", Effect Duration: 5
 6214	smooth tumbling mirror adequate rum	3	awesome	
-6215	perfectly mixed weak mirror twirling mediocre lager	2	EPIC	
-6216	stale bite-sized immaculate grilled cheese	1	decent	
-6217	rotten thick enchanted spinning immaculate ice cream sandwich	5	crappy	Effect: "Sugary World View", Effect Duration: 45
-6218	enchanted normal immaculate hot dog	3	good	Effect: "Melancholy Burden", Effect Duration: 45
+6215	perfectly mixed weak twirling mirror mediocre lager	2	EPIC	
+6216	bite-sized stale immaculate grilled cheese	1	decent	
+6217	enchanted thick rotten spinning immaculate ice cream sandwich	5	crappy	Effect: "Sugary World View", Effect Duration: 45
+6218	normal enchanted immaculate hot dog	3	good	Effect: "Melancholy Burden", Effect Duration: 45
 6219	immense stale shaking immaculate egg salad sandwich	8	decent	
 6220	yummy perfect sandwich	3	awesome	
 6221	spoiled perfect chef salad	4	crappy	
-6222	miniature flavorless perfect breakfast	2	decent	
+6222	flavorless miniature perfect breakfast	2	decent	
 6223	rotten sublime deluxe hot dog	3	crappy	
-6224	stale snack-sized upside-down sublime stew	2	decent	
+6224	snack-sized stale upside-down sublime stew	2	decent	
 6225	stale red skewed sublime nachos	3	decent	
 6226	bland yellow Ultimate Breakfast Sandwich	3	decent	
 6227	decent pulsating Loaded Baked Potato	4	good	
 6228	rotten Omega Sundae	3	crappy	
 6229	lousy Das Sauerlager	3	decent	
-6230	mediocre weak Bologna Lambic	2	decent	
-6231	strong bad cyan squat Vodka Dog	5	decent	
+6230	weak mediocre Bologna Lambic	2	decent	
+6231	strong bad squat cyan Vodka Dog	5	decent	
 6232	perfectly mixed strong Disappointed Russian	5	EPIC	
-6233	distilled bad twirling Chunky Mary	5	decent	
+6233	bad distilled twirling Chunky Mary	5	decent	
 6234	perfectly mixed ghostly Nachojito	4	EPIC	
-6235	mediocre irresponsibly strong yellow Le Roi	8	decent	
+6235	irresponsibly strong mediocre yellow Le Roi	8	decent	
 6236	lousy Over Easy Rider	4	decent	
 6237	mirror cosmic six-pack	0		
 6239	adjusted altered cube of ectoplasm	0		Effect: "Celestial Vision", Effect Duration: 57
@@ -6137,7 +6137,7 @@
 6241	pickled censored can label	0		Effect: "Tingly Biceps", Effect Duration: 63
 6242	triple-warmed warmed ectoplasm <i>au jus</i>	0		Effect: "Improprie Tea", Effect Duration: 42
 6243	galvanized the kindest cut	0		Effect: "Filled with Magic", Effect Duration: 46
-6244	concentrated energized blurry wobbly cat's paw	0		Effect: "Boon of the War Snapper", Effect Duration: 56
+6244	concentrated energized wobbly blurry cat's paw	0		Effect: "Boon of the War Snapper", Effect Duration: 56
 6245	ionized denatured jittery ASCII fu manchu	0		Effect: "Boletus Swoletus", Effect Duration: 64
 6246	frozen modified blinking demonic surgical gloves	0		Effect: "Eyes Wide Propped", Effect Duration: 66
 6247	dry wet bouncing wobbly clip-on ninja tie	0		Effect: "Old School Pompadour", Effect Duration: 60
@@ -6160,7 +6160,7 @@
 6264	lime green blurry Da Vinci's Staff of Fruit Salad of chilblains of doom	0		Experience (Mysticality): +5, Cold Damage: +25, Spooky Spell Damage: +50, Jiggle: "Deal Some Prismatic Damage"
 6265	narrow therapeutic stiffened boxer's Staff of the Cream of the Cream	0		Muscle Percent: +10, Damage Reduction: 1, HP Regen Min: 5, HP Regen Max: 7, Jiggle: "Attune to Monster's Essence"
 6266	upside-down jar of protein powder	0		
-6267	moldy fancy grain of protein powder	3	crappy	Effect: "Lemon Enlightenment", Effect Duration: 20
+6267	fancy moldy grain of protein powder	3	crappy	Effect: "Lemon Enlightenment", Effect Duration: 20
 6268	denatured polarized pec oil	0		Effect: "Stinky Hands", Effect Duration: 13
 6269	gym membership card of the sewer	0		Stench Damage: +25
 6270	magnetized yellow Squat-Thrust Magazine	0		Effect: "Shortened", Effect Duration: 31
@@ -6237,7 +6237,7 @@
 6341	reassuring rosy-cheeked spectral axe	0		Maximum HP Percent: +30, Spooky Resistance: +1
 6342	skewed squat Sherlock's reassuring super-strong air freshener	0		Spooky Resistance: +1, Item Drop: +25
 6343	cold-filtered polarized skewed Mer-kin lipstick	0		Effect: "Steroid Boost", Effect Duration: 42
-6344	squat teal Mer-kin mouthsoap	0		
+6344	teal squat Mer-kin mouthsoap	0		
 6345	modified Mer-kin strongjuice	0		Effect: "Well-Lubed", Effect Duration: 65
 6346	Mer-kin fitbrine	0		
 6347	energized nitrogenated Mer-kin ragejuice	0		Effect: "Human-Goblin Hybrid", Effect Duration: 36
@@ -6264,8 +6264,8 @@
 6368	skewed wobbly Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	blinking twisted piece of wire	0		
-6371	practically non-alcoholic hand-crafted can of the cheapest beer	1	EPIC	
-6372	mediocre watered-down cyan bottle of fruity &quot;wine&quot;	2	decent	
+6371	hand-crafted practically non-alcoholic can of the cheapest beer	1	EPIC	
+6372	watered-down mediocre cyan bottle of fruity &quot;wine&quot;	2	decent	
 6373	perfectly mixed single swig of vodka	3	EPIC	
 6374	angry inch	0		
 6375	testy toolbox of the pedagogue	0		Experience: +3
@@ -6276,7 +6276,7 @@
 6381	activated blurry mysterious chemical residue	0		Effect: "Patent Prevention", Effect Duration: 13
 6382	wobbly nugget of sodium	0		
 6383	blinking root beer	1	good	
-6384	bouncing gray jigsaw blade	0		
+6384	gray bouncing jigsaw blade	0		
 6385	maroon wood screw	0		
 6386	wobbly balsa plank	0		
 6387	blob of wood glue	0		
@@ -6305,9 +6305,9 @@
 6410	bow from beyond the stars	0		Familiar Weight: +5
 6411	spinning KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
-6413	cyan narrow Order of the Green Thumb Order Form	0		Free Pull
+6413	narrow cyan Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	super-sized bland flavorless gruel	5	decent	
+6415	bland super-sized flavorless gruel	5	decent	
 6416	spoiled mana curds	3	crappy	
 6417	twist of lime	0		
 6418	pencil stub	0		
@@ -6318,7 +6318,7 @@
 6423	olive Tales of Dread	0		Free Pull
 6424	squat Dreadsylvanian skeleton key	0		
 6425	upside-down Official Seal of Dreadsylvania	0		
-6426	small tasty green huge Dreadsylvanian stew	2	awesome	
+6426	tasty small green huge Dreadsylvanian stew	2	awesome	
 6427	lousy triple-distilled blurry Dreadsylvanian	9	decent	
 6428	galvanized oxidized teal Dreadsylvanian flask	0		Effect: "Bandersnatched", Effect Duration: 34
 6429	vacuum-sealed unsweetened Dreadsylvanian flask	0		Effect: "Cock of the Walk", Effect Duration: 25
@@ -6330,7 +6330,7 @@
 6435	Mark of the Werewolf	0		
 6436	blurry Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
-6438	huge squat Mark of the Vampire	0		
+6438	squat huge Mark of the Vampire	0		
 6439	Mark of the Skeleton	0		
 6440	yellow foul-smelling rosy-cheeked Covers-Your-Head of the cheetah	0		Maximum HP Percent: +30, Stench Damage: +10, Initiative: +60, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
 6441	yellow inspector's occult Drapes-You-Regally of the cougar	0		Moxie: +20, Spell Damage Percent: +25, Item Drop: +15, Class: "Disco Bandit"
@@ -6359,7 +6359,7 @@
 6464	knitted brawny Mayor Ghost's khakis of incineration	0		Muscle Percent: +20, Hot Spell Damage: +50, Cold Resistance: +3, Class: "Pastamancer", Familiar Effect: "1xPotato, HP regen"
 6465	ghostly fireproof Mayor Ghost's gavel of the wise owl of the overflowing toilet	0		Mysticality: +20, Stench Spell Damage: +50, Hot Resistance: +3, Conditional Skill (Equipped): "Hammer Ghost"
 6466	medical-grade Mayor Ghost's sash of the scaredy-cat of horror	0		Monster Level: -15, Spooky Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-6467	squat pulsating Mayor Ghost's scissors	0		
+6467	pulsating squat Mayor Ghost's scissors	0		
 6468	flavorless olive ghost pepper	3	decent	
 6469	auspicious lard-coated Thunkula's drinking cap of bravery	0		Sleaze Spell Damage: +25, Spooky Resistance: +5, Item Drop: +10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	scandalous mansplainer's Drunkula's cape of incineration	0		Monster Level: +15, Hot Spell Damage: +50, Sleaze Damage: +5, Class: "Sauceror"
@@ -6383,7 +6383,7 @@
 6488	normal Dreadsylvanian shepherd's pie	3	good	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
-6491	narrow upside-down tailfeathers	0		Familiar Weight: +5
+6491	upside-down narrow tailfeathers	0		Familiar Weight: +5
 6492	pulsating wax banana	0		
 6493	complicated lock impression	0		
 6494	skewed replica key	0		
@@ -6423,7 +6423,7 @@
 6528	sage hothammer	0		Mysticality Percent: +10
 6529	smooth Thriller Ice	4	awesome	
 6530	fireproof grandfather watch	0		Hot Resistance: +3, Single Equip
-6531	huge maroon muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
+6531	maroon huge muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	Van der Graaf spyglass of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 5, MP Regen Max: 7
 6533	gray vial of hot blood of terror	0		Spooky Spell Damage: +10, Single Equip
 6534	wobbly blurry remorseless knife of the ox	0		Muscle: +20
@@ -6438,7 +6438,7 @@
 6543	executive gravedigger's pogo stick	0		Spooky Damage: +10, Meat Drop: +40, Single Equip
 6545	narrow educational weedy skirt of the ox of the wise owl	0		Muscle: +20, Mysticality: +20, Experience: +1, Familiar Effect: "atk, 1xFairy"
 6546	pants of the ox of vim and vigor	0		Muscle: +20, Maximum HP Percent: +50, Familiar Effect: "atk"
-6547	wobbly ghostly Thwaitgold Goliath beetle statuette	0		
+6547	ghostly wobbly Thwaitgold Goliath beetle statuette	0		
 6548	tumbling cooling iron helmet	0		
 6549	cooling iron breastplate	0		
 6550	huge cooling iron greaves	0		
@@ -6455,15 +6455,15 @@
 6561	narrow adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	extremely unsafe hand of Mr. Cards	0		Weapon Damage Percent: +100, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	flavorless huge Dreadsylvanian hot pocket	6	decent	
-6565	tiny normal bouncing Dreadsylvanian pocket	1	good	
+6564	huge flavorless Dreadsylvanian hot pocket	6	decent	
+6565	normal tiny bouncing Dreadsylvanian pocket	1	good	
 6566	decent Dreadsylvanian pocket	3	good	
 6567	normal twirling Dreadsylvanian stink pocket	3	good	
 6568	spoiled Dreadsylvanian sleaze pocket	3	crappy	
 6569	acceptable Dreadsylvanian hot toddy	3	good	
-6570	watered-down mediocre blinking Dreadsylvanian cold-fashioned	2	decent	
-6571	boozy aged Dreadsylvanian grimlet	5	awesome	
-6572	fancy acceptable weak huge Dreadsylvanian dank and stormy	2	good	Effect: "Warm Belly", Effect Duration: 40
+6570	mediocre watered-down blinking Dreadsylvanian cold-fashioned	2	decent	
+6571	aged boozy Dreadsylvanian grimlet	5	awesome	
+6572	fancy weak acceptable huge Dreadsylvanian dank and stormy	2	good	Effect: "Warm Belly", Effect Duration: 40
 6573	hand-crafted jittery Dreadsylvanian slithery nipple	4	super ultra mega EPIC	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6491,7 +6491,7 @@
 6597	olive clockwork birdhouse	0		
 6598	teal clockwork disc	0		
 6599	blue clockwork hand	0		
-6600	upside-down red clockwork hand	0		
+6600	red upside-down clockwork hand	0		
 6601	squat clockwork numeral I	0		
 6602	clockwork numeral II	0		
 6603	blinking clockwork numeral III	0		
@@ -6505,9 +6505,9 @@
 6611	ghostly clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
-6614	twirling gray cuckoo clock	0		
+6614	gray twirling cuckoo clock	0		
 6615	weak artisanal Cold One	2	???	
-6616	thick spoiled spinning squat spaghetti breakfast	5	???	
+6616	thick spoiled squat spinning spaghetti breakfast	5	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	green folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6541,10 +6541,10 @@
 6649	irradiated Ogres and Oubliettes&trade; module	0		Effect: "Sensation", Effect Duration: 45
 6650	Mountain Stream Code Black Alert	0		
 6651	lime green twisted-up wet towel	0		
-6652	fancy perfectly mixed stepmom's booze	4	EPIC	Effect: "Sealed Brain", Effect Duration: 50
+6652	perfectly mixed fancy stepmom's booze	4	EPIC	Effect: "Sealed Brain", Effect Duration: 50
 6653	surgical tape	0		
 6654	rock-hard band T-shirt	0		Damage Reduction: 5
-6655	fortified drinkable spinning fountain 'soda'	5	good	
+6655	drinkable fortified spinning fountain 'soda'	5	good	
 6656	illegal firecracker	0		
 6657	mansplainer's pickelhaube of the brute	0		Muscle Percent: +30, Monster Level: +15, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	improved improved hair oil	0		Effect: "Sausage Festive", Effect Duration: 42
@@ -6570,8 +6570,8 @@
 6678	toasty Yearbook Club Camera	0		Hot Damage: +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	squat hardened machete	0		Damage Reduction: 3
 6680	tolerable yellow Cursed Punch	4	good	
-6681	high-proof perfectly mixed special Bowl of Scorpions	6	EPIC	Effect: "Fangs and Pangs", Effect Duration: 50
-6682	watered-down hand-crafted Fog Murderer	2	super EPIC	
+6681	high-proof special perfectly mixed Bowl of Scorpions	6	EPIC	Effect: "Fangs and Pangs", Effect Duration: 50
+6682	hand-crafted watered-down Fog Murderer	2	super EPIC	
 6683	ghostly book of matches	0		
 6684	brawny surgical mask	0		Muscle Percent: +20, Surgeonosity: +1
 6685	head mirror of horror	0		Spooky Spell Damage: +25, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	imitation White Russian	1	decent	
 6704	frosty Sinatra's short-handled mop	0		Experience (Moxie): +5, Cold Spell Damage: +10
-6705	spoiled snack-sized jungle floor wax	2	crappy	
+6705	snack-sized spoiled jungle floor wax	2	crappy	
 6706	pulsating smirking shrunken head	0		
 6707	energized galvanized colorful toad	0		Effect: "Granolarrrgh", Effect Duration: 59
 6708	crude voodoo doll	0		
@@ -6618,7 +6618,7 @@
 6726	dude ranch souvenir crate	0		
 6727	tumbling tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
-6729	red mirror UV-resistant compass	0		
+6729	mirror red UV-resistant compass	0		
 6730	funky junk key	0		
 6731	huge Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
@@ -6639,22 +6639,22 @@
 6747	huge chaotic banded swordzall	0		Damage Absorption: +100, Spell Critical Percent: +10
 6748	padded arm buzzer	0		Damage Absorption: +20, Damage Reduction: 6
 6749	knitted rock-hard boilgun	0		Damage Reduction: 5, Cold Resistance: +3
-6750	tumbling red Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
+6750	red tumbling Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	bouncing packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
 6753	cluster of hops	0		
 6754	beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	mediocre high-proof red can of Br&uuml;talbr&auml;u	8	decent	Last Available: "2013-09"
-6758	bad watered-down cyan can of Drooling Monk	2	decent	Last Available: "2013-09"
+6757	high-proof mediocre red can of Br&uuml;talbr&auml;u	8	decent	Last Available: "2013-09"
+6758	watered-down bad cyan can of Drooling Monk	2	decent	Last Available: "2013-09"
 6759	aged can of Impetuous Scofflaw	3	awesome	Last Available: "2013-09"
 6760	acceptable bottle of Old Pugilist	4	good	Last Available: "2013-09"
 6761	weak bad bottle of Professor Beer	2	decent	Last Available: "2013-09"
-6762	perfectly mixed special upside-down olive bottle of Rapier Witbier	3	EPIC	Effect: "Hyperoffended", Effect Duration: 35, Last Available: "2013-09"
+6762	special perfectly mixed olive upside-down bottle of Rapier Witbier	3	EPIC	Effect: "Hyperoffended", Effect Duration: 35, Last Available: "2013-09"
 6763	bad bottle of Race Car Red	4	decent	Last Available: "2013-09"
-6764	smooth watered-down bouncing bottle of Greedy Dog	2	awesome	Last Available: "2013-09"
-6765	mediocre fortified bottle of Lambada Lambic	5	decent	Last Available: "2013-09"
+6764	watered-down smooth bouncing bottle of Greedy Dog	2	awesome	Last Available: "2013-09"
+6765	fortified mediocre bottle of Lambada Lambic	5	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	bouncing artisanal homebrew gift package	0		
 6768	wobbly liquid bread	1	good	Last Available: "2013-09"
@@ -6668,7 +6668,7 @@
 6776	diffused ionized foetid seal tear	0		Effect: "Weepy, Creepy", Effect Duration: 24
 6777	ionized colloidal seal sweat	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 14
 6778	super-deionized diffused tumbling boiling seal blood	0		Effect: "The Magic of LOV", Effect Duration: 24
-6779	tumbling wobbly crystalline seal eye	0		Single Equip
+6779	wobbly tumbling crystalline seal eye	0		Single Equip
 6780	tumbling family-friendly brainy studded sealhide shield	0		Mysticality: +5, Sleaze Resistance: +1, Damage Reduction: 7
 6781	nippy wicked scabrous seal epaulets	0		Spell Damage: +5, Cold Damage: +10, Single Equip
 6782	mirror abyssal battle plans	0		
@@ -6720,7 +6720,7 @@
 6831	moist improved Tallowcreme Halloween Pumpkin	0		Effect: "Ruby-ous", Effect Duration: 39
 6832	Way More Tears&trade; pepper spray	0		
 6833	quadruple-boiled Milk Studs	0		Effect: "Sauce Monocle", Effect Duration: 16
-6834	modified gray jittery box of Dweebs	0		Effect: "Charrrming", Effect Duration: 32
+6834	modified jittery gray box of Dweebs	0		Effect: "Charrrming", Effect Duration: 32
 6835	cold-filtered twirling bag of W&Ws	0		Effect: "Stenchtastic", Effect Duration: 67
 6836	energized pressed olive PEEZ dispenser	0		Effect: "Slimily Sagacious", Effect Duration: 47
 6837	pressed pressed upside-down Swizzler	0		Effect: "Sweet Incentive", Effect Duration: 15
@@ -6738,7 +6738,7 @@
 6849	quadruple-ionized Effermint&trade; tablets	0		Effect: "Ruthlessly Efficient", Effect Duration: 38
 6850	gray flame-wreathed quilted supercool sturdy cane	0		Moxie Percent: +20, Damage Absorption: +40, Hot Spell Damage: +10
 6851	huge bowl of candy	0		
-6852	squat fuchsia Ultra Mega Sour Ball	0		
+6852	fuchsia squat Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	desert sightseeing pamphlet	0		
 6855	squat a suspicious address	0		
@@ -6765,7 +6765,7 @@
 6876	blinking dry cleaning receipt	0		Last Available: "2013-11"
 6877	mirror upside-down pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
-6879	pulsating green mirror pocket lint (white)	0		Last Available: "2013-11"
+6879	green pulsating mirror pocket lint (white)	0		Last Available: "2013-11"
 6880	pocket lint (orange)	0		Last Available: "2013-11"
 6881	nasty dance instructor's Newton's bowl of petunias of the bloodbag	0		Experience (Mysticality): +3, Experience Percent (Moxie): +10, Maximum HP: +100, Stench Damage: +5, Last Available: "2013-11"
 6882	flame-retardant coward's chaotic medical-grade power sock	0		Spell Critical Percent: +10, Monster Level: -20, Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2013-11"
@@ -6793,7 +6793,7 @@
 6904	oxidized bolts	0		Effect: "Truly Gritty", Effect Duration: 64, Last Available: "2013-12"
 6905	rotten gingerbread robot	3	crappy	Last Available: "2013-12"
 6906	fancy adequate squat petit 4.1	3	good	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2013-12"
-6907	bland jumbo green nut-shaped Crimbo cookie	5	decent	Last Available: "2023-06"
+6907	jumbo bland green nut-shaped Crimbo cookie	5	decent	Last Available: "2023-06"
 6908	shaking experienced plastic GORM-8	0		Experience: +2, Last Available: "2013-12"
 6909	double-paned plastic warbear	0		Cold Resistance: +5, Last Available: "2013-12"
 6910	hale plastic Toybot	0		Maximum HP: +20, Last Available: "2013-12"
@@ -6808,12 +6808,12 @@
 6919	triple-dry quadruple-pressed frozen warbear bearserker potion	0		Effect: "Your Interest is Peaked", Effect Duration: 46, Last Available: "2013-12"
 6920	quantum cold-filtered jittery warbear liquid overcoat	0		Effect: "Dreadful Smell", Effect Duration: 59, Last Available: "2013-12"
 6921	moldy warbear feasting bread	3	crappy	Last Available: "2013-12"
-6922	jumbo stale warbear warrior bread	5	decent	Last Available: "2013-12"
+6922	stale jumbo warbear warrior bread	5	decent	Last Available: "2013-12"
 6923	normal warbear thermoregulator bread	3	good	Last Available: "2013-12"
 6924	artisanal blinking warbear feasting mead	4	EPIC	Last Available: "2013-12"
 6925	high-proof artisanal warbear bearserker mead	7	EPIC	Last Available: "2013-12"
 6926	practically non-alcoholic perfectly mixed skewed warbear blizzard mead	1	super ultra mega turbo EPIC	Last Available: "2013-12"
-6927	narrow purple warbear helm fragment	0		Last Available: "2013-12"
+6927	purple narrow warbear helm fragment	0		Last Available: "2013-12"
 6928	cyan sizzling Lo Pan's Rosewater's warbear plain fedora	0		Mysticality Percent: +30, Spell Critical Percent: +30, Hot Damage: +10, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
 6929	sizzling warbear feathered fedora	0		Hot Damage: +10, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
 6930	ghostly family-friendly nippy strapping warbear fedora	0		Muscle: +5, Cold Damage: +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
@@ -6893,11 +6893,11 @@
 7004	alkaline liquefied red Flaskfull of Hollow	0		Effect: "Tingling Feeling", Effect Duration: 24, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	vaporized handful of Smithereens	1	EPIC	Last Available: "2013-12"
-7007	diet adequate Every Day is Like This Sundae	1	good	Last Available: "2013-12"
+7007	adequate diet Every Day is Like This Sundae	1	good	Last Available: "2013-12"
 7008	bland Miserable Pie	4	decent	Last Available: "2013-12"
 7009	small delicious This Charming Flan	2	awesome	Last Available: "2013-12"
-7010	drinkable irresponsibly strong Irish Coffee, English Heart	8	good	Last Available: "2013-12"
-7011	weak acceptable Strikes Again Bigmouth	2	good	Last Available: "2013-12"
+7010	irresponsibly strong drinkable Irish Coffee, English Heart	8	good	Last Available: "2013-12"
+7011	acceptable weak Strikes Again Bigmouth	2	good	Last Available: "2013-12"
 7012	lousy upside-down cyan Paint A Vulgar Pitcher	4	decent	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	smartaleck's brawny Shakespeare's Sister's Accordion of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Moxie Percent: +30, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	beefy third-hand lantern	0		Muscle: +10
 7031	loose purse strings	0		
-7032	thick adequate mirror pickled egg	5	good	
+7032	adequate thick mirror pickled egg	5	good	
 7033	fancy cup of lukewarm tea	1	decent	Effect: "Fever From the Flavor", Effect Duration: 20
 7034	bouncing warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6943,11 +6943,11 @@
 7054	bouncing warbear drone codes	0		Last Available: "2013-12"
 7055	flavorless breakfast mess	3	decent	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	moldy bite-sized breakfast miracle	1	crappy	Last Available: "2013-12"
+7057	bite-sized moldy breakfast miracle	1	crappy	Last Available: "2013-12"
 7058	colloidal Cloaca Cola Polar	0		Effect: "Hare-o-dynamic", Effect Duration: 56, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
-7061	huge skewed grimstone mask	0		Last Available: "2014-12"
+7061	skewed huge grimstone mask	0		Last Available: "2014-12"
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	upside-down hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
@@ -6957,7 +6957,7 @@
 7068	liquefied improved single of Donho's Bubbly Ballad	0		Effect: "Infernal Thirst", Effect Duration: 20
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	spoiled small shaking snow berries	2	crappy	Last Available: "2014-01"
+7071	small spoiled shaking snow berries	2	crappy	Last Available: "2014-01"
 7072	decent squat ice harvest	3	good	Last Available: "2014-01"
 7073	polymerized frost flower	0		Effect: "Busy Bein' Delicious", Effect Duration: 62, Last Available: "2014-01"
 7074	triple-vacuum-sealed alkaline tumbling snow cleats	0		Effect: "PERL of Great Price", Effect Duration: 61, Last Available: "2014-01"
@@ -6967,9 +6967,9 @@
 7078	lousy lime green Ice Island Long Tea	4	decent	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	blurry ice sculpture	0		Last Available: "2014-01"
-7081	bouncing lime green ice house	0		Last Available: "2014-01"
+7081	lime green bouncing ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	vibrating snow mobile	0		Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	vibrating snow mobile	0		Maximum MP Percent: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	spinning foul-smelling ice bucket	0		Stench Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	arcane researcher's wizardly snow shovel	0		Mysticality: +25, Experience Percent (Mysticality): +10, Lasts Until Rollover, Last Available: "2014-01"
 7086	green nippy supercool savvy bod-ice	0		Mysticality Percent: +20, Moxie Percent: +20, Cold Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
@@ -7005,17 +7005,17 @@
 7116	blinking crafty carrot-on-a-stick of the early riser	0		Maximum MP: +10, Adventures: +7, Last Available: "2014-12"
 7117	dance instructor's weasel stomping pants of the empath	0		Experience Percent (Moxie): +10, Familiar Weight: +5, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	flavorless immense mulberry	10	decent	Last Available: "2014-12"
-7119	smooth watered-down shaking maroon blinking mulled berry wine	2	awesome	Last Available: "2014-12"
+7119	smooth watered-down blinking maroon shaking mulled berry wine	2	awesome	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	narrow friendly lemon party hat	0		Familiar Weight: +3, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	Rosewater's lemon shirt	0		Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2014-12"
 7123	green Oprah's lemon drop trousers	0		Maximum MP Percent: +50, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	diffused electrified bouncing lemonhead caviar	0		Effect: "Libra Rising", Effect Duration: 39, Last Available: "2014-12"
 7125	gray supercharged gummi sword of wisdom	0		Mysticality: +15, Maximum MP Percent: +30, Last Available: "2014-12"
-7126	galvanized anodized narrow upside-down small gummi fin	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 60, Last Available: "2014-12"
+7126	galvanized anodized upside-down narrow small gummi fin	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 60, Last Available: "2014-12"
 7127	miser's chocolate cow bone	0		Meat Drop: +10, Last Available: "2014-12"
 7128	pickled blinking gummi fang	0		Effect: "Saucegoggles", Effect Duration: 36, Last Available: "2014-12"
-7129	adequate low-calorie fancy leftover canap&eacute;s	1	good	Effect: "Devil Inside", Effect Duration: 5, Last Available: "2014-12"
+7129	fancy adequate low-calorie leftover canap&eacute;s	1	good	Effect: "Devil Inside", Effect Duration: 5, Last Available: "2014-12"
 7130	lousy fuchsia magnum of champagne	3	decent	Last Available: "2014-12"
 7131	spinning huge smelly fortified wicked cow creamer	0		Spell Damage: +5, Damage Absorption: +60, Stench Spell Damage: +10, Last Available: "2014-12"
 7132	double-flattened flattened spinning Outer Wolf&trade; cologne	0		Effect: "Arabian Knighthood", Effect Duration: 15, Last Available: "2014-12"
@@ -7024,14 +7024,14 @@
 7135	bland squat witch's bread	4	decent	Last Available: "2014-12"
 7136	super-quantum super-corrupted skewed witch's brew	0		Effect: "Egg-headedness", Effect Duration: 47, Last Available: "2014-12"
 7137	zippy reassuring Samson's witch's bra	0		Experience (Muscle): +5, Spooky Resistance: +1, Initiative: +20, Last Available: "2014-12"
-7138	smooth boozy mid-level medieval mead	5	awesome	Last Available: "2014-12"
+7138	boozy smooth mid-level medieval mead	5	awesome	Last Available: "2014-12"
 7139	wet triple-moist vacuum-sealed blinking R&uuml;mpelstiltz	0		Effect: "Salty Mouth", Effect Duration: 12, Last Available: "2014-12"
 7140	narrow spinning wheel	0		Last Available: "2014-12"
 7141	quantum unsweetened hi-octane carrot juice	0		Effect: "Heart of White", Effect Duration: 37, Last Available: "2014-12"
 7142	pickled narrow hare brush	0		Effect: "Sugar Smacks", Effect Duration: 22, Last Available: "2014-12"
 7143	inspector's electrified hare pin	0		Item Drop: +15, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	snack-sized adequate cinnamon cannoli	2	good	Last Available: "2014-12"
+7145	adequate snack-sized cinnamon cannoli	2	good	Last Available: "2014-12"
 7146	acceptable practically non-alcoholic expensive champagne	1	good	Last Available: "2014-12"
 7147	dry double-improved spinning polo trophy	0		Effect: "Ham-Fisted", Effect Duration: 42, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7044,7 +7044,7 @@
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	blue blinking Usain Bolt's resourceful fire hose of terror	0		Maximum MP: +50, Spooky Spell Damage: +10, Initiative: +80, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	jumbo stale fireman's lunch	5	decent	Last Available: "2014-12"
+7158	stale jumbo fireman's lunch	5	decent	Last Available: "2014-12"
 7159	Sherlock's auspicious plain paper hat of the blizzard	0		Cold Spell Damage: +25, Item Drop: 35, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	stale jumbo ice cream sandwich	5	decent	Last Available: "2014-12"
 7161	blinking shellacked &quot;honey&quot; dipper of extreme caution of courage	0		Damage Reduction: 7, Monster Level: -25, Spooky Resistance: +3, Last Available: "2014-12"
@@ -7054,7 +7054,7 @@
 7165	upside-down blue auspicious hardy dance instructor's Sketcherz&trade;	0		Experience Percent (Moxie): +10, Maximum HP: +50, Item Drop: +10, Last Available: "2014-12"
 7166	spoiled can of Adultwitch&trade;	4	crappy	Last Available: "2014-12"
 7167	ionized extra-unsweetened narrow smudge stick	0		Effect: "Super-Electrified", Effect Duration: 59, Last Available: "2014-12"
-7168	vacuum-sealed improved corrupted bouncing pulsating skewed wall	0		Effect: "Using Protection", Effect Duration: 17, Last Available: "2014-12"
+7168	vacuum-sealed improved corrupted bouncing skewed pulsating wall	0		Effect: "Using Protection", Effect Duration: 17, Last Available: "2014-12"
 7169	boozy bad tankard of ale	5	decent	Last Available: "2014-12"
 7170	magnetized energized skewed bouncing scroll case	0		Effect: "Superhuman Sarcasm", Effect Duration: 60, Last Available: "2014-12"
 7171	triple-nitrogenated jug of &quot;wine&quot;	0		Effect: "Wreathed in Merriment", Effect Duration: 24, Last Available: "2014-12"
@@ -7067,13 +7067,13 @@
 7178	blue Copperhead Charm	0		
 7179	The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
-7181	blinking blurry The Eye of the Stars	0		
+7181	blurry blinking The Eye of the Stars	0		
 7182	red The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
-7185	blinking twirling Red Zeppelin ticket	0		
+7185	twirling blinking Red Zeppelin ticket	0		
 7186	jittery teal Copperhead Charm (rampant)	0		
-7187	weak mediocre unnamed cocktail	2	decent	
+7187	mediocre weak unnamed cocktail	2	decent	
 7188	handful of tips	0		
 7189	unrequired jacket of the wise owl	0		Mysticality: +20
 7190	skewed ribald tommy gun	0		Sleaze Damage: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7096,7 +7096,7 @@
 7207	jittery stanky blade	0		Stench Spell Damage: +25
 7208	fire of unknown origin	0		
 7209	wobbly eagle's milk	1	decent	
-7210	diffused green huge eagle feather	0		Effect: "Celestial Body", Effect Duration: 61
+7210	diffused huge green eagle feather	0		Effect: "Celestial Body", Effect Duration: 61
 7211	liquefied enhanced mirror one pill	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 18
 7212	sinister Jefferson wings	0		Spell Damage: +10
 7213	twirling fleetwood macaroni	0		
@@ -7111,14 +7111,14 @@
 7222	smooth Flamin' Whatshisname	4	awesome	
 7223	triple-ionized Vulcanized tumbling lynyrd musk	0		Effect: "Rainbow Bright", Effect Duration: 66
 7224	stanky savvy Kashmir sweater	0		Mysticality Percent: +20, Stench Spell Damage: +25
-7225	bland gigantic fuchsia custard pie	10	decent	
+7225	gigantic bland fuchsia custard pie	10	decent	
 7226	tea for one	1	decent	
-7227	perfectly mixed practically non-alcoholic special bottle of Evermore	1	EPIC	Effect: "Serenity", Effect Duration: 15
+7227	perfectly mixed special practically non-alcoholic bottle of Evermore	1	EPIC	Effect: "Serenity", Effect Duration: 15
 7228	box	0		
 7229	lousy wine	3	decent	
-7230	bad weak rum	2	decent	
+7230	weak bad rum	2	decent	
 7231	weak drinkable Murderer's Punch	2	good	
-7232	stale thick skewed velvet cake	5	decent	
+7232	thick stale skewed velvet cake	5	decent	
 7233	activated blurry letter	0		Effect: "Sugary World View", Effect Duration: 24
 7234	blinking teal executive perfumed book	0		Stench Resistance: +5, Meat Drop: +40
 7235	cool weightlifter's masque	0		Muscle: +15, Moxie: +5, Single Equip
@@ -7141,7 +7141,7 @@
 7252	narrow shot of Sneaky Pete's Mojo	0		Free Pull
 7253	squat Anniversary Miniature Sword & Martini Guy	0		
 7254	blurry really cocktail shaker	0		Familiar Weight: +5
-7255	aged fancy mini-martini	3	awesome	Effect: "Crimbo Nostalgia", Effect Duration: 45
+7255	fancy aged mini-martini	3	awesome	Effect: "Crimbo Nostalgia", Effect Duration: 45
 7256	smoke grenade	0		
 7257	twisted bouncing molotov soda	1	crappy	
 7258	electrified pile of ashes	0		Effect: "Big Punkin'", Effect Duration: 40
@@ -7150,7 +7150,7 @@
 7261	gravedigger's frosty Lo Pan's Sneaky Pete's basket	0		Spell Critical Percent: +30, Cold Spell Damage: +10, Spooky Damage: +10
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
-7264	lime green huge photograph of a nugget	0		
+7264	huge lime green photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
 7266	blinking disposable instant camera	0		
 7267	Temple Grandin's careful manspreader's padded Sneaky Pete's jacket (collar popped)	0		Damage Absorption: +20, Monster Level: 0, Familiar Weight: +7, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7168,7 +7168,7 @@
 7279	adjusted twirling wind-up Whatsian robot	0		Effect: "Ack!  Barred!", Effect Duration: 42
 7280	modified wind-up vampire teeth	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 61
 7281	diffused oxidized wind-up navigation droid	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 36
-7282	alkaline energized bouncing narrow wind-up owl	0		Effect: "Polar Express", Effect Duration: 57
+7282	alkaline energized narrow bouncing wind-up owl	0		Effect: "Polar Express", Effect Duration: 57
 7283	energized galvanized gray wind-up ensign	0		Effect: "Spiky Frozen Hair", Effect Duration: 23
 7284	wobbly crying statue earrings of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Single Equip, Lasts Until Rollover
 7285	therapeutic plastic Duskwalker necklace of Flo-Jo	0		Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover
@@ -7192,7 +7192,7 @@
 7303	Lady Spookyraven's necklace	0		
 7304	red telegram from Lady Spookyraven	0		
 7305	shaking blue Lady Spookyraven's powder puff	0		
-7306	wobbly gray Lady Spookyraven's finest gown	0		
+7306	gray wobbly Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
 7308	cold-filtered boiled eyebrow pencil	0		Effect: "Spooky Weapon", Effect Duration: 38
 7309	double-quantum tarnished spinning rosewater cream	0		Effect: "Alpine Mintiness", Effect Duration: 57
@@ -7213,7 +7213,7 @@
 7324	modified fuchsia battery	1		
 7325	bad weak snakebite	2	decent	
 7326	shaking boxer's smooth rubber ribcage	0		Moxie: +15, Muscle Percent: +10, Damage Reduction: 7
-7327	vaporized huge wobbly gray synthetic marrow	1		
+7327	vaporized wobbly gray huge synthetic marrow	1		
 7328	triple-moist colloidal funny bone	0		Effect: "Disdain of the War Snapper", Effect Duration: 60
 7329	asbestos-lined cool half-melted spoon	0		Moxie: +5, Hot Resistance: +5
 7330	modified huge the funk	1		
@@ -7234,7 +7234,7 @@
 7345	huge ornate picture frame	0		
 7346	skewed doll-eye amulet	0		Single Equip
 7347	skewed lard-coated sinister ghost toga	0		Spell Damage: +10, Sleaze Spell Damage: +25
-7348	bite-sized rotten sheet cake	1	crappy	
+7348	rotten bite-sized sheet cake	1	crappy	
 7349	squat ghost key	0		
 7350	picture of you	0		
 7351	tumbling tumbling twirling teal ribald Staff of the Electric Range of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Sleaze Damage: +10
@@ -7243,7 +7243,7 @@
 7354	watered-down artisanal red-hot boilermaker	2	EPIC	
 7355	slick coal shovel	0		Moxie: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	corrupted vacuum-sealed diffused mirror hot coal	0		Effect: "You Know Where to Go", Effect Duration: 24
-7357	warmed dry cyan mirror coal dust	0		Effect: "OMG WTF", Effect Duration: 51
+7357	warmed dry mirror cyan coal dust	0		Effect: "OMG WTF", Effect Duration: 51
 7358	lion tamer's Bram's choker of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Experience (familiar): +2, Single Equip
 7359	plaid swatch	0		
 7360	shaking plaid bandage	0		
@@ -7254,7 +7254,7 @@
 7365	denatured denatured fabric hardener	0		Effect: "Can Has Cyborger", Effect Duration: 20
 7366	drinkable weak blue bottle of laundry sherry	2	good	
 7367	liquefied non-unsweetened twirling industrial strength starch	0		Effect: "Cranberry Cordiality", Effect Duration: 68, Wiki Name: "industrial strength starch"
-7368	yummy half-sized purple extra-flat panini	2	awesome	
+7368	half-sized yummy purple extra-flat panini	2	awesome	
 7369	oxidized mangled finger	0		Effect: "Think Win-Lose", Effect Duration: 50
 7370	drinkable fancy blurry Psychotic Train wine	3	good	Effect: "Frozen Hands", Effect Duration: 40
 7371	crazy hobo notebook	0		
@@ -7275,7 +7275,7 @@
 7386	warmed ionized blue Gene Tonic: Construct	0		Effect: "New Zeal", Effect Duration: 22, Last Available: "2014-04"
 7387	pressed dry extra-polarized pulsating Gene Tonic: Undead	0		Effect: "Big Punkin'", Effect Duration: 17, Last Available: "2014-04"
 7388	irradiated polarized Gene Tonic: Humanoid	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 48, Last Available: "2014-04"
-7389	liquefied dry shaking yellow Gene Tonic: Insect	0		Effect: "Familial Ties", Effect Duration: 41, Last Available: "2014-04"
+7389	liquefied dry yellow shaking Gene Tonic: Insect	0		Effect: "Familial Ties", Effect Duration: 41, Last Available: "2014-04"
 7390	moist magnetized mirror Gene Tonic: Hippy	0		Effect: "Psalm of Pointiness", Effect Duration: 50, Last Available: "2014-04"
 7391	altered dry Gene Tonic: Orc	0		Effect: "The Halls of Mysticality", Effect Duration: 18, Last Available: "2014-04"
 7392	dry blinking Gene Tonic: Demon	0		Effect: "The Magic of LOV", Effect Duration: 47, Last Available: "2014-04"
@@ -7284,7 +7284,7 @@
 7395	extra-dry energized huge Gene Tonic: Goblin	0		Effect: "Going Ape", Effect Duration: 52, Last Available: "2014-04"
 7396	super-oxidized Gene Tonic: Pirate	0		Effect: "Eagle Eyes", Effect Duration: 23, Last Available: "2014-04"
 7397	oxidized bouncing Gene Tonic: Plant	0		Effect: "Swordholder", Effect Duration: 53, Last Available: "2014-04"
-7398	activated blue narrow Gene Tonic: Weird	0		Effect: "Fishy", Effect Duration: 60, Last Available: "2014-04"
+7398	activated narrow blue Gene Tonic: Weird	0		Effect: "Fishy", Effect Duration: 60, Last Available: "2014-04"
 7399	colloidal Gene Tonic: Elf	0		Effect: "Category", Effect Duration: 12, Last Available: "2014-04"
 7400	unsweetened blue skewed Gene Tonic: Mer-kin	0		Effect: "Shamboozled", Effect Duration: 14, Last Available: "2014-04"
 7401	ionized Gene Tonic: Slime	0		Effect: "Seeing Colors", Effect Duration: 20, Last Available: "2014-04"
@@ -7314,34 +7314,34 @@
 7425	olive shaking blinking Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	sprinkle shaker	0		Last Available: "2014-05"
 7427	super-diffused sleight-of-hand mushroom	0		Effect: "Floundering", Effect Duration: 11, Last Available: "2014-05"
-7428	pulsating narrow Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
+7428	narrow pulsating Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	Beach Buck	0		Last Available: "2014-05"
 7430	improved liquefied mirror Fun-Guy spore	0		Effect: "Ooh, Salty!", Effect Duration: 54, Last Available: "2014-05"
 7431	pickled shaking Boletus Broletus mushroom	0		Effect: "Sweet Tooth", Effect Duration: 29, Last Available: "2014-05"
-7432	triple-ionized denatured magnetized bouncing green Omphalotus Omphaloskepsis mushroom	0		Effect: "License to Punch", Effect Duration: 20, Last Available: "2014-05"
+7432	triple-ionized denatured magnetized green bouncing Omphalotus Omphaloskepsis mushroom	0		Effect: "License to Punch", Effect Duration: 20, Last Available: "2014-05"
 7433	aerosolized aerosolized pressed olive Gyromitra Dynomita mushroom	0		Effect: "Stimulated Body", Effect Duration: 50, Last Available: "2014-05"
 7434	denatured Vulcanized Helvella Haemophilia mushroom	0		Effect: "Abyssal Sweat", Effect Duration: 41, Last Available: "2014-05"
 7435	moist aerosolized pickled Stemonitis Staticus mushroom	0		Effect: "Nothing Is Impossible", Effect Duration: 46, Last Available: "2014-05"
 7436	improved purple narrow Tremella Tarantella mushroom	0		Effect: "Human-Slime Hybrid", Effect Duration: 64, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	spoiled huge upside-down skewed Beefy Crunch Pastaco	10	crappy	Last Available: "2014-05"
-7439	adequate snack-sized Brain Food Pastaco	2	good	Last Available: "2014-05"
+7439	snack-sized adequate Brain Food Pastaco	2	good	Last Available: "2014-05"
 7440	tasty Cool Brunch Pastaco	4	awesome	Last Available: "2014-05"
 7441	tasty maroon Medical Pastaco	4	awesome	Last Available: "2014-05"
-7442	moldy super-sized Energy Buzz Pastaco	5	crappy	Last Available: "2014-05"
+7442	super-sized moldy Energy Buzz Pastaco	5	crappy	Last Available: "2014-05"
 7443	decent Ludovico Pastaco	4	good	Last Available: "2014-05"
-7444	tolerable practically non-alcoholic special overpowering mushroom wine	1	good	Effect: "Feet of Watermelon", Effect Duration: 10, Last Available: "2014-05"
-7445	weak drinkable complex mushroom wine	2	good	Last Available: "2014-05"
+7444	practically non-alcoholic tolerable special overpowering mushroom wine	1	good	Effect: "Feet of Watermelon", Effect Duration: 10, Last Available: "2014-05"
+7445	drinkable weak complex mushroom wine	2	good	Last Available: "2014-05"
 7446	acceptable smooth mushroom wine	3	good	Last Available: "2014-05"
 7447	drinkable extra-dry blood-red mushroom wine	5	good	Last Available: "2014-05"
 7448	lousy watered-down fancy buzzing mushroom wine	2	decent	Effect: "Rotten Memories", Effect Duration: 30, Last Available: "2014-05"
-7449	acceptable watered-down huge swirling mushroom wine	2	good	Last Available: "2014-05"
+7449	watered-down acceptable huge swirling mushroom wine	2	good	Last Available: "2014-05"
 7450	toothsome ghostly Taco Dan's Basic Taco Dan Taco	3	awesome	Last Available: "2014-05"
-7451	moldy fancy diet Taco Dan's Taco Fish Fish Taco	1	crappy	Effect: "Bats in the Belfry", Effect Duration: 25, Last Available: "2014-05"
+7451	diet fancy moldy Taco Dan's Taco Fish Fish Taco	1	crappy	Effect: "Bats in the Belfry", Effect Duration: 25, Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	lousy watered-down twirling regular-size brogurt	2	decent	Last Available: "2014-05"
-7454	distilled drinkable super-size brogurt	5	good	Last Available: "2014-05"
-7455	irresponsibly strong delicious skewed broberry brogurt	10	awesome	Last Available: "2014-05"
+7454	drinkable distilled super-size brogurt	5	good	Last Available: "2014-05"
+7455	delicious irresponsibly strong skewed broberry brogurt	10	awesome	Last Available: "2014-05"
 7456	perfectly mixed mirror brocolate brogurt	3	EPIC	Last Available: "2014-05"
 7457	irresponsibly strong tolerable upside-down French bronilla brogurt	9	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
@@ -7377,8 +7377,8 @@
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	weak mediocre special blurry bottle of Chateau de Vinegar	2	decent	Effect: "Phairly Pheromonal", Effect Duration: 25
-7492	skewed olive blasting soda	0		
+7491	special weak mediocre blurry bottle of Chateau de Vinegar	2	decent	Effect: "Phairly Pheromonal", Effect Duration: 25
+7492	olive skewed blasting soda	0		
 7493	unstable fulminate	0		
 7494	jittery wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
@@ -7395,7 +7395,7 @@
 7506	twirling mirror book of mayonnaise of temperance	0		Sleaze Spell Damage: +50, Sleaze Resistance: +5
 7507	cloak of dire peril	0		Weapon Damage: +20
 7508	label	0		
-7509	diet yummy enchanted mirror Mornington crescent roll	1	awesome	Effect: "Feet of Watermelon", Effect Duration: 40
+7509	diet enchanted yummy mirror Mornington crescent roll	1	awesome	Effect: "Feet of Watermelon", Effect Duration: 40
 7510	alkaline quantum eye shadow	0		Effect: "Eye of the Lihc", Effect Duration: 27
 7511	crumbling wheel	0		
 7512	polymerized poppy	0		Effect: "stats.enq", Effect Duration: 54
@@ -7418,7 +7418,7 @@
 7529	spoiled loaf of alien bread	3	crappy	Last Available: "2014-05"
 7530	enchanted spoiled grilled cheese sandwich	4	crappy	Effect: "So You Can Work More...", Effect Duration: 40, Last Available: "2014-05"
 7531	denatured alien protein powder	1	awesome	Last Available: "2014-05"
-7532	bad weak shaking rocket fuel	2	decent	Last Available: "2014-05"
+7532	weak bad shaking rocket fuel	2	decent	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	acceptable stealth bomber	3	good	Last Available: "2014-05"
@@ -7434,7 +7434,7 @@
 7545	tolerable space port	4	good	Last Available: "2014-05"
 7546	huge baleful smooth space needle	0		Moxie: +15, Spell Damage: +25, Last Available: "2014-05"
 7547	altered tumbling buffed alien drugs	0		Effect: "Superheroic", Effect Duration: 23, Last Available: "2014-05"
-7548	twirling upside-down hot ashes	0		Last Available: "2014-06"
+7548	upside-down twirling hot ashes	0		Last Available: "2014-06"
 7549	quadruple-moist pulsating ash soda	0		Effect: "Sausage Festive", Effect Duration: 35, Last Available: "2014-06"
 7550	quadruple-liquefied pulsating liquid smoke	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 54, Last Available: "2014-06"
 7551	polarized dollop of barbecue sauce	0		Effect: "Hot Hands", Effect Duration: 13, Last Available: "2014-06"
@@ -7444,14 +7444,14 @@
 7555	page	0		
 7556	elephant gift	0		
 7557	wet altered teal blood cells	0		Effect: "This Is Where You're a Viking", Effect Duration: 30
-7558	artisanal watered-down wine	2	EPIC	
+7558	watered-down artisanal wine	2	EPIC	
 7559	non-pressed liquefied diffused maroon gummi turtle	0		Effect: "Sweet Incentive", Effect Duration: 54
 7560	lime green huge turtle-shaped rock	0		
 7561	chilled ionized lime green giraffe-necked turtle	0		Effect: "Sealed Brain", Effect Duration: 30
 7562	flattened deionized musk turtle	0		Effect: "Heart of Green", Effect Duration: 34
 7563	corrupted pulsating programmable turtle	0		Effect: "Tingling Feeling", Effect Duration: 63
 7564	denatured warmed blurry mocking turtle	0		Effect: "Square to be Hip", Effect Duration: 42
-7565	enchanted decent miniature ham steak	2	good	Effect: "Riboflavin'", Effect Duration: 30
+7565	decent miniature enchanted ham steak	2	good	Effect: "Riboflavin'", Effect Duration: 30
 7566	blinking mansplainer's time-twitching toolbelt	0		Monster Level: +15, Single Equip, Free Pull
 7567	fuchsia Chroner	0		
 7568	aromatic lion tamer's Sinatra's Time Lord Badge of Honor	0		Experience (Moxie): +5, Experience (familiar): +2, Stench Resistance: +1
@@ -7468,7 +7468,7 @@
 7579	twitching time capsule	0		
 7580	denatured blinking tumbling liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	flavorless super-sized rack of dinosaur ribs	5	decent	
+7582	super-sized flavorless rack of dinosaur ribs	5	decent	
 7583	watered-down bad scotch on the rocks	2	decent	
 7584	beefcake's yabba dabba doo rag of extreme caution	0		Muscle: +25, Monster Level: -25, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	wooly loincloth of temperance	0		Sleaze Resistance: +5, Item Drop: +5, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7478,8 +7478,8 @@
 7589	lousy glass of &quot;milk&quot;	4	decent	Last Available: "2014-07"
 7590	artisanal cup of &quot;tea&quot;	3	EPIC	Last Available: "2014-07"
 7591	mediocre skewed thermos of &quot;whiskey&quot;	3	decent	Last Available: "2014-07"
-7592	high-proof mediocre Lucky Lindy	8	decent	Last Available: "2014-07"
-7593	tolerable fancy extra-dry Bee's Knees	5	good	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2014-07"
+7592	mediocre high-proof Lucky Lindy	8	decent	Last Available: "2014-07"
+7593	extra-dry fancy tolerable Bee's Knees	5	good	Effect: "Expert Vacationer", Effect Duration: 25, Last Available: "2014-07"
 7594	perfectly mixed Sockdollager	3	EPIC	Last Available: "2014-07"
 7595	mediocre Ish Kabibble	3	decent	Last Available: "2014-07"
 7596	artisanal Hot Socks	3	EPIC	Last Available: "2014-07"
@@ -7536,7 +7536,7 @@
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
 7649	irradiated moist bouncing gourmet gourami oil	0		Effect: "Memory of Strength", Effect Duration: 16
-7650	electrified lime green shaking catfish whiskers	0		Effect: "Waxing", Effect Duration: 50
+7650	electrified shaking lime green catfish whiskers	0		Effect: "Waxing", Effect Duration: 50
 7651	freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
 7653	olive fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7559,7 +7559,7 @@
 7670	huge skewed curative steel-toed padded famous raincoat	0		Damage Absorption: +20, Damage Reduction: 9, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover
 7671	teal scorching lion tamer's lightning rod of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +2, Hot Damage: +25, Lasts Until Rollover
 7672	jittery law-abiding citizen cane of incineration	0		Hot Spell Damage: +50, Single Equip
-7673	fortified hand-crafted ghostly legitimate business on the beach	5	EPIC	
+7673	hand-crafted fortified ghostly legitimate business on the beach	5	EPIC	
 7674	spinning hep waders of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	tasty massive twirling jive turkey leg	6	awesome	
 7676	hale birdbone corset	0		Maximum HP: +20
@@ -7569,7 +7569,7 @@
 7680	super-absorbent tarp of Flo-Jo	0		Initiative: +100
 7681	drinkable unquiet spirits	4	good	
 7682	banjo kazoo mount of courage	0		Spooky Resistance: +3, Single Equip
-7683	aerosolized lime green tumbling grass	0		Effect: "Crying, Dying", Effect Duration: 60
+7683	aerosolized tumbling lime green grass	0		Effect: "Crying, Dying", Effect Duration: 60
 7684	Time Lord Participation Mug of the glutton	0		Food Drop: +100
 7685	teal Temple Grandin's rock-hard Time Bandit Time Towel	0		Damage Reduction: 5, Familiar Weight: +7
 7686	pulsating fuchsia rosy-cheeked Caveman Dan's favorite rock of Gandalf of mayonnaise	0		Maximum HP Percent: +30, Spell Critical Percent: +20, Sleaze Spell Damage: +50, Single Equip
@@ -7615,7 +7615,7 @@
 7726	oxidized Dennis's blessing of Minerva	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 42
 7727	galvanized activated skewed yellow Burt's blessing of Bacchus	0		Effect: "Icy Composition", Effect Duration: 38
 7728	ionized Freddie's blessing of Mercury	0		Effect: "Prince of Seaside Town", Effect Duration: 24
-7729	lime green pulsating Chroner trigger	0		
+7729	pulsating lime green Chroner trigger	0		
 7730	skewed Xi Receiver Unit	0		Last Available: "2014-09"
 7731	huge transmission from planet Xi	0		Last Available: "2014-09"
 7732	Black Bart's Booty	0		Skill: "Pirate Bellow"
@@ -7649,7 +7649,7 @@
 7760	low-calorie flavorless They liver popsicle	1	decent	Last Available: "2014-09"
 7761	skewed holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
-7763	fuchsia upside-down holo-platoon	0		Last Available: "2014-09"
+7763	upside-down fuchsia holo-platoon	0		Last Available: "2014-09"
 7764	boiled mirror residual zeal	1		Last Available: "2014-09"
 7765	mirror Rosewater's Xiblaxian holo-wrist-puter	0		Mysticality Percent: +30, Last Available: "2014-09"
 7766	spinning electrified defective Golden Mr. Accessory of James Dean of the boozehound	0		Experience (Moxie): +3, Booze Drop: +100, MP Regen Min: 3, MP Regen Max: 5
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	tumbling medical-grade rosy-cheeked Fonzie's Personal Ventilation Unit	0		Experience (Moxie): +1, Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2014-10"
 7771	quantum green the most dangerous bait	0		Effect: "Stemonitis Storm", Effect Duration: 25, Last Available: "2014-10"
-7772	tasty miniature &quot;meat&quot; stick	2	awesome	Last Available: "2014-10"
+7772	miniature tasty &quot;meat&quot; stick	2	awesome	Last Available: "2014-10"
 7773	pickled bouncing red transdermal smoke patch	1	crappy	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	greedy Jack Frost's frosty pair of plants	0		Cold Spell Damage: 60, Meat Drop: +20, Last Available: "2014-10"
@@ -7684,19 +7684,19 @@
 7795	half-sized moldy yellow initiative shawarma	2	crappy	Last Available: "2014-10"
 7796	delicious warm war shawarma	3	awesome	Last Available: "2014-10"
 7797	massive yummy karma shawarma	6	awesome	Last Available: "2014-10"
-7798	artisanal irresponsibly strong fancy Jungle Juice	7	EPIC	Effect: "Goldentongue", Effect Duration: 50, Last Available: "2014-10"
+7798	artisanal fancy irresponsibly strong Jungle Juice	7	EPIC	Effect: "Goldentongue", Effect Duration: 50, Last Available: "2014-10"
 7799	artisanal Amnesiac Ale	4	EPIC	Last Available: "2014-10"
-7800	artisanal practically non-alcoholic Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
+7800	practically non-alcoholic artisanal Highest Bitter	1	super ultra mega turbo EPIC	Last Available: "2014-10"
 7801	knitted electrified mercenary pistol	0		Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-10"
 7802	skewed mercenary rifle of doom of bravery	0		Spooky Spell Damage: +50, Spooky Resistance: +5, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
-7804	shaking blurry Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
+7804	blurry shaking Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	cyan Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
 7808	narrow green unused soap	0		
 7809	impure gasoline	0		
-7810	blurry pulsating gray Z-Bone steak	0		
+7810	gray blurry pulsating Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	decent spinning seared dino steak	3	good	
@@ -7714,7 +7714,7 @@
 7825	shaking jittery rock-hard earbuds of vim and vigor of mayonnaise	0		Damage Reduction: 5, Maximum HP Percent: +50, Sleaze Spell Damage: +50, Single Equip
 7826	executive foul-smelling Newton's iFlail	0		Experience (Mysticality): +3, Stench Damage: +10, Meat Drop: +40
 7827	normal small blue unidentifiable dried fruit	2	good	
-7828	tolerable strong flat cider	5	good	
+7828	strong tolerable flat cider	5	good	
 7829	horrifying Sinatra's stylish trench lighter	0		Moxie: +25, Experience (Moxie): +5, Spooky Damage: +25, Last Available: "2014-10"
 7830	tarnished oxidized experimental serum P-00	0		Effect: "Crud&eacute;", Effect Duration: 37, Last Available: "2014-10"
 7831	pulsating military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7735,7 +7735,7 @@
 7846	quadruple-corrupted tarnished concentrated Fudge Fiber Armor Plating	0		Effect: "Super Skill", Effect Duration: 61, Last Available: "2014-12"
 7847	moist blue ruby on canes	0		Effect: "Dreadful Chill", Effect Duration: 25, Last Available: "2014-12"
 7848	bland wobbly petit fortran	3	decent	Last Available: "2014-12"
-7849	tasty shaking teal upside-down java cookie	3	awesome	Last Available: "2014-12"
+7849	tasty upside-down shaking teal java cookie	3	awesome	Last Available: "2014-12"
 7850	decent cookie cookie	3	good	Last Available: "2014-12"
 7851	educational plastic exo-suited miner	0		Experience: +1, Last Available: "2014-12"
 7852	up-at-dawn plastic semi-autonomous drill unit	0		Adventures: +5, Last Available: "2014-12"
@@ -7803,15 +7803,15 @@
 7914	dry twirling Bit O' Quail Spleen	0		Effect: "Ruthlessly Efficient", Effect Duration: 49
 7915	polymerized ionized Take Eleven Bar	0		Effect: "Muddled", Effect Duration: 43
 7916	mimeplasm	0		
-7917	cold-filtered warmed skewed tumbling BOOterfinger	0		Effect: "Sticky Hands", Effect Duration: 11
+7917	cold-filtered warmed tumbling skewed BOOterfinger	0		Effect: "Sticky Hands", Effect Duration: 11
 7918	super-liquefied super-polarized wobbly huge Moonds	0		Effect: "Spooky Flavor", Effect Duration: 54
 7919	dry chilled ionized Big Punk	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 69
 7920	narrow fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	hand-crafted watered-down Friendly Turkey	2	EPIC	Last Available: "2014-11"
-7923	watered-down acceptable Agitated Turkey	2	good	Last Available: "2014-11"
+7922	watered-down hand-crafted Friendly Turkey	2	EPIC	Last Available: "2014-11"
+7923	acceptable watered-down Agitated Turkey	2	good	Last Available: "2014-11"
 7924	mediocre Ambitious Turkey	4	decent	Last Available: "2014-11"
-7925	immense stale twirling neutron lollipop	7	decent	Last Available: "2014-12"
+7925	stale immense twirling neutron lollipop	7	decent	Last Available: "2014-12"
 7926	smooth distilled gamma nog	5	awesome	Last Available: "2014-12"
 7934	squat sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7838,7 +7838,7 @@
 7956	olive Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	even more tinsel	0		Familiar Weight: +5
 7958	blurry box of Crimbo decorations	0		
-7959	blinking cyan letter to Ed the Undying	0		
+7959	cyan blinking letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	zippy rosy-cheeked Staff of Ed of incineration of bravery	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Spooky Resistance: +5, Initiative: +20
 7962	twirling pulsating Eye of Ed	0		
@@ -7900,11 +7900,11 @@
 8018	diffused mirror blinking and rain stick	0		Effect: "Coal-Powered", Effect Duration: 52
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	bland fuchsia Choco-Mint patty	3	decent	Last Available: "2015-01"
-8021	smooth enchanted hot mint schnocolate	3	awesome	Effect: "The Halls of Mysticality", Effect Duration: 10, Last Available: "2015-01"
+8021	enchanted smooth hot mint schnocolate	3	awesome	Effect: "The Halls of Mysticality", Effect Duration: 10, Last Available: "2015-01"
 8022	dried twirling homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
-8025	huge narrow bowl of potpourri	0		Last Available: "2015-01"
+8025	narrow huge bowl of potpourri	0		Last Available: "2015-01"
 8026	fuchsia ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
 8028	artificial skylight	0		Last Available: "2015-01"
@@ -8020,7 +8020,7 @@
 8146	frozen chilled electrified invisible potion	0		Effect: "Fancy Feasted", Effect Duration: 21
 8147	pulsating time shuriken	0		
 8148	perfumed knitted hardened ninjammies	0		Damage Reduction: 3, Cold Resistance: +3, Stench Resistance: +5, Familiar Effect: "atk, 0.5xPotato, cap 25"
-8149	boiled narrow blurry Glo-Pop	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 49
+8149	boiled blurry narrow Glo-Pop	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 49
 8150	cold-filtered spinning sugar sphere	0		Effect: "Chalky Hand", Effect Duration: 37
 8151	magnetized improved warmed Shrubble Bubble	0		Effect: "Conspiratory Eyes", Effect Duration: 64
 8152	deionized galvanized polyeaster egg	0		Effect: "Venomous Weapon", Effect Duration: 16
@@ -8038,16 +8038,16 @@
 8164	jittery Rosewater's remaindered axe of doom	0		Mysticality Percent: +30, Spooky Spell Damage: +50
 8165	low-budget shield	0		Damage Reduction: 3
 8166	ghostly Tesla clever cr&ecirc;epy mask	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "spooky atk, cap 5"
-8167	stale immense baguette	7	decent	
+8167	immense stale baguette	7	decent	
 8168	glob of icing	0		
 8169	modified pickled ghostly ginger snaps	0		Effect: "Human-Pirate Hybrid", Effect Duration: 59
 8170	tarnished triple-activated mostly-broken sunglasses	0		Effect: "Hella Tough", Effect Duration: 46
-8171	practically non-alcoholic aged narrow unflavored wine cooler	1	awesome	
+8171	aged practically non-alcoholic narrow unflavored wine cooler	1	awesome	
 8172	carton of snake milk	1	EPIC	
 8173	extremely unsafe sewer snake	0		Weapon Damage Percent: +100
 8174	fancy normal lime green pigeon egg	3	good	Effect: "Boletus Swoletus", Effect Duration: 30
 8175	up-at-dawn jaunty feather of the glutton	0		Food Drop: +100, Adventures: +5
-8176	strong mediocre blurry premium malt liquor	5	decent	
+8176	mediocre strong blurry premium malt liquor	5	decent	
 8177	sizzling beefy brown paper pants	0		Muscle: +10, Hot Damage: +10
 8178	frightening brown paper bag mask of Calamity Jane	0		Critical Hit Percent: +15, Spooky Damage: +5
 8179	ring of telling skeletons what to do of Flo-Jo	0		Initiative: +100, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8060,15 +8060,15 @@
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	perfectly mixed Cherrytastrophe wine cooler	4	EPIC	
-8189	fortified acceptable Radberry Rip wine cooler	5	good	
-8190	perfectly mixed watered-down Orangemageddon wine cooler	2	EPIC	
-8191	special acceptable triple-distilled Breakfast Blast wine cooler	6	good	Effect: "Mutated", Effect Duration: 20
+8189	acceptable fortified Radberry Rip wine cooler	5	good	
+8190	watered-down perfectly mixed Orangemageddon wine cooler	2	EPIC	
+8191	triple-distilled special acceptable Breakfast Blast wine cooler	6	good	Effect: "Mutated", Effect Duration: 20
 8192	tolerable Citrus Crush wine cooler	3	good	
 8193	yummy plain bagel	3	awesome	
 8194	snack-sized bland glob of cream cheese	2	decent	
 8195	adequate loaf of soda bread	3	good	
 8196	super-sized moldy upside-down acceptable bagel	5	crappy	
-8197	normal miniature standard-issue cupcake	2	good	
+8197	miniature normal standard-issue cupcake	2	good	
 8198	flavorless ultra-deluxe cupcake	3	decent	
 8199	hypnotic breadcrumbs	0		
 8200	decent popular tart	3	good	
@@ -8090,7 +8090,7 @@
 8216	triple-wet activated beard incense	0		Effect: "Mistified", Effect Duration: 56, Last Available: "2015-04"
 8217	gray flame-retardant studded perfume-soaked bandana	0		Damage Absorption: +80, Hot Resistance: +1, Single Equip, Last Available: "2015-04"
 8218	skewed purple toxic globule	0		Last Available: "2015-04"
-8219	bite-sized enchanted normal toxo	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2015-04"
+8219	enchanted bite-sized normal toxo	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2015-04"
 8220	lousy Lemonade-235	4	decent	Last Available: "2015-04"
 8221	shaking rock-hard brawny isotophat	0		Muscle Percent: +20, Damage Reduction: 5, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	smooth Three Mile Island shorts of Flo-Jo	0		Moxie: +15, Initiative: +100, Last Available: "2015-04"
@@ -8144,11 +8144,11 @@
 8270	flavorless half-sized unappetizing mayolus	2	decent	Last Available: "2015-05"
 8271	normal uninteresting mayolus	4	good	Last Available: "2015-05"
 8272	special moldy acceptable mayolus	3	crappy	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2015-05"
-8273	delicious small jittery enticing mayolus	2	awesome	Last Available: "2015-05"
+8273	small delicious jittery enticing mayolus	2	awesome	Last Available: "2015-05"
 8274	bland skewed skewed mouth-watering mayolus	4	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
-8277	huge blurry olive Essence of Bear	0		Skill: "Bear Essence"
+8277	blurry olive huge Essence of Bear	0		Skill: "Bear Essence"
 8278	mediocre blinking Afternoon Delight	3	decent	Last Available: "2015-04"
 8279	gray Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	cyan Golden Kokomo Resort Chip	0		Last Available: "2015-04"
@@ -8209,7 +8209,7 @@
 8335	altered pulsating grease trap	0		Effect: "You Know When to Walk Away", Effect Duration: 20
 8336	anodized shamanic ham	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 21
 8337	frozen porkpocket	0		Effect: "French Bronilla Brogueishness", Effect Duration: 40
-8338	pressed chilled shaking twirling Leonard's glasses	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 56
+8338	pressed chilled twirling shaking Leonard's glasses	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 56
 8339	galvanized altered chilled warehouse walkie-talkie	0		Effect: "Okee-Dokee Go!", Effect Duration: 36
 8340	nitrogenated blue janitor's mop	0		Effect: "Abominably Slippery", Effect Duration: 31
 8341	enhanced warehouse clerk's glasses	0		Effect: "Celestial Vision", Effect Duration: 42
@@ -8220,7 +8220,7 @@
 8346	modified totally sweet mohawk helmet	0		Effect: "Memory of Speed", Effect Duration: 63
 8347	quadruple-chilled pulsating spray chrome	0		Effect: "Stop the Presses!", Effect Duration: 20
 8348	quantum lime green filthy monkey head	0		Effect: "Morninja", Effect Duration: 25
-8349	boiled chilled colloidal huge teal hand of cards	0		Effect: "Gonna Get You, Sucker", Effect Duration: 30
+8349	boiled chilled colloidal teal huge hand of cards	0		Effect: "Gonna Get You, Sucker", Effect Duration: 30
 8350	activated wet narrow damp bar rag	0		Effect: "You're High as a Crow, Marty", Effect Duration: 18
 8351	wet moist lump of goofball ore	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 27
 8352	extra-unsweetened non-altered wobbly skeleton beans	0		Effect: "Afternoon Insight", Effect Duration: 45
@@ -8235,7 +8235,7 @@
 8361	enhanced gray child-sized dracula cloak	0		Effect: "Fangs and Pangs", Effect Duration: 15
 8362	chilled devil-summoning hat	0		Effect: "Quiet 'n' Good", Effect Duration: 64
 8363	denatured shopkeeper beard	0		Effect: "Chlorophyll Flavor", Effect Duration: 40
-8364	pressed corrupted squat green alien autoautopsy kit	0		Effect: "Ooh, Salty!", Effect Duration: 47
+8364	pressed corrupted green squat alien autoautopsy kit	0		Effect: "Ooh, Salty!", Effect Duration: 47
 8365	galvanized pulsating novelty fruit hat	0		Effect: "Almost Cool", Effect Duration: 46
 8366	polymerized Vulcanized invisibility cream	0		Effect: "Elron's Explosive Etude", Effect Duration: 56
 8367	pickled wobbly handful of stubble	0		Effect: "Ocelot Eyes", Effect Duration: 59
@@ -8280,17 +8280,17 @@
 8406	bouncing savory dry noodles	0		
 8407	moldy pestopiary	3	crappy	
 8408	ionized flattened pulsating ectoplasmic orbs	0		Effect: "Cool Spirit", Effect Duration: 67
-8409	stale huge crudles	7	decent	
+8409	huge stale crudles	7	decent	
 8410	tiny flavorless agnolotti arboli	1	decent	
 8411	moldy enchanted big spaghetti with ghost balls	5	crappy	Effect: "Mint-Condition Breath", Effect Duration: 35
 8412	flavorless pulsating succulent marrow	3	decent	
-8413	toothsome enchanted half-sized salacious crumbs	2	awesome	Effect: "Lucky Cat Is Lucky", Effect Duration: 25
+8413	half-sized enchanted toothsome salacious crumbs	2	awesome	Effect: "Lucky Cat Is Lucky", Effect Duration: 25
 8414	bland fusilli marrownarrow	4	decent	
 8415	spoiled snack-sized suggestive strozzapreti	2	crappy	
 8416	upside-down Mountain Stream gastrique	0		
-8417	fancy spoiled upside-down Mt. McLargeHuge oyster	3	crappy	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 35
+8417	spoiled fancy upside-down Mt. McLargeHuge oyster	3	crappy	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 35
 8418	oyster sauce	0		
-8419	immense spoiled linguini immondizia bianco	8	crappy	
+8419	spoiled immense linguini immondizia bianco	8	crappy	
 8420	rotten jittery shells a la shellfish	4	crappy	
 8421	Jick's autograph	0		
 8422	maroon squat high-temperature mining drill	0		Last Available: "2015-08"
@@ -8318,7 +8318,7 @@
 8444	pulsating lava globs	0		Last Available: "2015-08"
 8445	olive lava globs	0		Last Available: "2015-08"
 8446	skewed SMOOCH bottlecap	0		Last Available: "2020-09"
-8447	wobbly spinning uncapped lava bottle	0		Last Available: "2015-08"
+8447	spinning wobbly uncapped lava bottle	0		Last Available: "2015-08"
 8448	shaking blurry fuchsia uncapped lava bottle	0		Last Available: "2015-08"
 8449	cyan uncapped lava bottle	0		Last Available: "2015-08"
 8450	capped lava bottle	0		Last Available: "2015-08"
@@ -8340,14 +8340,14 @@
 8466	narrow therapeutic Herculean educational lavalarva	0		Experience: +1, Experience (Muscle): +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-08"
 8467	ribald dangerous lava balaclava of the blizzard	0		Weapon Damage: +10, Cold Spell Damage: +25, Sleaze Damage: +10, Last Available: "2015-08"
 8468	greedy mansplainer's Oprah's basaltamander buckler	0		Maximum MP Percent: +50, Monster Level: +15, Meat Drop: +20, Damage Reduction: 15, Last Available: "2015-08"
-8469	dry tumbling twirling lava globs	0		Effect: "Bored Stiff", Effect Duration: 43, Last Available: "2015-08"
+8469	dry twirling tumbling lava globs	0		Effect: "Bored Stiff", Effect Duration: 43, Last Available: "2015-08"
 8470	spoiled gooey lava globs	4	crappy	Last Available: "2015-08"
 8471	wool lava-proof pants of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +1, Last Available: "2015-08"
 8472	Tesla clever heat-resistant necktie	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2015-08"
 8473	squat Sherlock's greasy Rosewater's heat-resistant gloves	0		Mysticality Percent: +30, Sleaze Spell Damage: +10, Item Drop: +25, Single Equip, Last Available: "2015-08"
-8474	super-sized bland very hot lunch	5	decent	Last Available: "2015-08"
+8474	bland super-sized very hot lunch	5	decent	Last Available: "2015-08"
 8475	drinkable asbestos thermos	4	good	Last Available: "2015-08"
-8476	concentrated polymerized purple tumbling liquid rhinestones	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 26, Last Available: "2015-08"
+8476	concentrated polymerized tumbling purple liquid rhinestones	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 26, Last Available: "2015-08"
 8477	bland upside-down disco biscuit	3	decent	Last Available: "2015-08"
 8478	drinkable bouncing Quaatorade&trade;	3	good	Last Available: "2015-08"
 8479	squat Socratic cool strapping biker's hat	0		Muscle: +5, Moxie: +5, Experience (Mysticality): +1, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8382,7 +8382,7 @@
 8508	quantum labrador cookie	0		Effect: "Analog Drunk", Effect Duration: 14, Last Available: "2015-08"
 8509	energetic wholesome Mr. Cheeng's spectacles of doom	0		Maximum HP Percent: +10, Maximum MP Percent: +20, Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8510	smartaleck's grease cannon of the wise owl	0		Mysticality: +20, Moxie Percent: +30, Last Available: "2015-08"
-8511	aerosolized warmed super-Vulcanized blinking red demon makeup kit	0		Effect: "Burning Tongue", Effect Duration: 40, Last Available: "2015-08"
+8511	aerosolized warmed super-Vulcanized red blinking demon makeup kit	0		Effect: "Burning Tongue", Effect Duration: 40, Last Available: "2015-08"
 8512	narrow blinking wobbly cyan fortified Sinatra's love of the empath	0		Experience (Moxie): +5, Damage Absorption: +60, Familiar Weight: +5, Last Available: "2015-08"
 8513	censurious flame-wreathed thinker's Pener's drumstick	0		Mysticality: +10, Hot Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2015-08"
 8514	coward's chaotic deuce cape	0		Spell Critical Percent: +10, Monster Level: -20, Last Available: "2015-08"
@@ -8396,8 +8396,8 @@
 8522	squat superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	half-sized rotten special lava cake	2	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2015-08"
-8526	moldy fancy pink slime	3	crappy	Effect: "Salty Mouth", Effect Duration: 15
+8525	special half-sized rotten lava cake	2	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2015-08"
+8526	fancy moldy pink slime	3	crappy	Effect: "Salty Mouth", Effect Duration: 15
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	bland green devil hair pasta	3	decent	
@@ -8413,15 +8413,15 @@
 8540	lime green rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	decent Fettris	4	good	
-8543	rotten half-sized blue fusillocybin	2	crappy	
+8543	half-sized rotten blue fusillocybin	2	crappy	
 8544	stale prescription noodles	3	decent	
 8545	dehydrated blood-drive sticker	1	decent	Effect: "Meadulla Oblongota", Effect Duration: 5
 8546	ionized vacuum-sealed bag of grain	0		Effect: "Celestial Sheen", Effect Duration: 59
 8547	unsweetened magnetized altered skewed pocket maze	0		Effect: "Super Vision", Effect Duration: 67
 8548	quadruple-tarnished magnetized shady shades	0		Effect: "Oiled Skin", Effect Duration: 17
 8549	polarized squeaky toy rose	0		Effect: "Meatwise", Effect Duration: 56
-8550	decent jumbo lime green blinking weird gazelle steak	5	good	
-8551	flavorless small sausage without a cause	2	decent	
+8550	decent jumbo blinking lime green weird gazelle steak	5	good	
+8551	small flavorless sausage without a cause	2	decent	
 8552	deionized chilled blinking face paint	0		Effect: "Artificially Sweet", Effect Duration: 43
 8553	bad strong gray emergency margarita	5	decent	
 8554	lousy vintage smart drink	3	decent	
@@ -8434,7 +8434,7 @@
 8561	nitrogenated anodized Wrotz	0		Effect: "Polka of Plenty", Effect Duration: 60
 8562	vacuum-sealed narrow Gabarbar	0		Effect: "Broken Bone Nubs", Effect Duration: 26
 8563	oxidized warmed olive fiberglass insulation	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 44
-8564	ghostly squat shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
+8564	squat ghostly shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	executive flame-wreathed Newton's barrel lid	0		Experience (Mysticality): +3, Hot Spell Damage: +10, Meat Drop: +40, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	stanky smelly sharpshooter's barrel hoop earring	0		Critical Hit Percent: +10, Stench Spell Damage: 35, Lasts Until Rollover, Last Available: "2015-09"
 8567	Jeselnik's forbidden bankruptcy barrel of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Sleaze Damage: +25, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
@@ -8448,10 +8448,10 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	teal mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	practically non-alcoholic hand-crafted bottle of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2015-09"
-8579	mediocre triple-distilled jittery lime green barrel-aged martini	6	decent	Last Available: "2015-09"
-8580	diet bland maroon wobbly barrel pickle	1	decent	Last Available: "2015-09"
-8581	low-calorie bland huge barrel cracker	1	decent	Last Available: "2015-09"
+8578	hand-crafted practically non-alcoholic bottle of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2015-09"
+8579	triple-distilled mediocre lime green jittery barrel-aged martini	6	decent	Last Available: "2015-09"
+8580	diet bland wobbly maroon barrel pickle	1	decent	Last Available: "2015-09"
+8581	bland low-calorie huge barrel cracker	1	decent	Last Available: "2015-09"
 8582	denatured vibrating mushroom	1	good	Effect: "Your Eyes are Peeled!", Effect Duration: 5, Last Available: "2015-09"
 8583	vaporized jittery mushroom	1	decent	Last Available: "2015-09"
 8584	mirror KoL Con 12-gauge of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	Jack Frost's barrel gun	0		Cold Spell Damage: +50, Last Available: "2015-09"
 8587	yellow barrel	0		Last Available: "2015-09"
 8588	mirror olive barrel beryl	0		Last Available: "2015-09"
-8589	spoiled tiny fancy water log	1	crappy	Effect: "Aries Rising", Effect Duration: 25, Last Available: "2015-09"
+8589	spoiled fancy tiny water log	1	crappy	Effect: "Aries Rising", Effect Duration: 25, Last Available: "2015-09"
 8590	chilly Lo Pan's barrelhead	0		Spell Critical Percent: +30, Cold Damage: +5, Last Available: "2015-09"
 8591	horrifying ruddy bottoms of the barrel	0		Maximum HP Percent: +40, Spooky Damage: +25, Last Available: "2015-09"
 8592	knitted chest barrel of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +3, Last Available: "2015-09"
@@ -8486,7 +8486,7 @@
 8613	triple-liquefied pressed cuppa Feroci tea	0		Effect: "Superioreo", Effect Duration: 27, Last Available: "2015-09"
 8614	triple-quantum nitrogenated diffused cyan cuppa Physicali tea	0		Effect: "Bread-Lined", Effect Duration: 50, Last Available: "2015-09"
 8615	quadruple-liquefied colloidal cuppa Wit tea	0		Effect: "Flexibili Tea", Effect Duration: 13, Last Available: "2015-09"
-8616	ionized galvanized shaking ghostly cuppa Neuroplastici tea	0		Effect: "Stinking Cloud", Effect Duration: 45, Last Available: "2015-09"
+8616	ionized galvanized ghostly shaking cuppa Neuroplastici tea	0		Effect: "Stinking Cloud", Effect Duration: 45, Last Available: "2015-09"
 8617	double-denatured jittery cuppa Dexteri tea	0		Effect: "Buff as a Baobab", Effect Duration: 16, Last Available: "2015-09"
 8618	pressed galvanized cuppa Flexibili tea	0		Effect: "Shawarma Warm War", Effect Duration: 31, Last Available: "2015-09"
 8619	altered cuppa Impregnabili tea	0		Effect: "Armor-Plated", Effect Duration: 69, Last Available: "2015-09"
@@ -8515,7 +8515,7 @@
 8642	low-calorie flavorless wobbly bowl of mummy guts	1	decent	Last Available: "2015-10"
 8643	flavorless bowl of maggots	3	decent	Last Available: "2015-10"
 8644	bad cyan blood and blood	4	decent	Last Available: "2015-10"
-8645	extra-dry smooth upside-down Jack-O-Lantern beer	5	awesome	Last Available: "2015-10"
+8645	smooth extra-dry upside-down Jack-O-Lantern beer	5	awesome	Last Available: "2015-10"
 8646	artisanal zombie	4	EPIC	Last Available: "2015-10"
 8647	olive Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	upside-down wind-up spider	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	gravedigger's Herculean hawk of extreme caution	0		Experience (Muscle): +1, Monster Level: -25, Spooky Damage: +10
-8655	normal super-sized olive squat hamlet sandwich	5	good	
+8655	normal super-sized squat olive hamlet sandwich	5	good	
 8656	forbidden Othello's military jacket	0		Spell Damage Percent: +50
 8657	Othello's dagger of the sweet-tooth	0		Candy Drop: +100, Single Equip
 8658	grievous Othello's handkerchief	0		Weapon Damage Percent: +50, Single Equip
@@ -8540,7 +8540,7 @@
 8667	zippy lion tamer's occult Yorick	0		Spell Damage Percent: +25, Experience (familiar): +2, Initiative: +20
 8668	rose	0		
 8669	huge tulip	0		
-8670	skewed blue tulip	0		
+8670	blue skewed tulip	0		
 8671	tulip	0		
 8672	blurry Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
@@ -8612,11 +8612,11 @@
 8739	acceptable huge upside-down perfect dark and stormy	4	good	Last Available: "2015-11"
 8740	smooth perfect mimosa	3	awesome	Last Available: "2015-11"
 8741	perfectly mixed perfect old-fashioned	3	EPIC	Last Available: "2015-11"
-8742	tolerable practically non-alcoholic twirling perfect paloma	1	good	Last Available: "2015-11"
+8742	practically non-alcoholic tolerable twirling perfect paloma	1	good	Last Available: "2015-11"
 8743	concentrated That 70s Cologne	0		Effect: "Oth-Jeal-O", Effect Duration: 41, Last Available: "2015-11"
 8744	frozen oxidized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Fan-Cooled", Effect Duration: 13, Last Available: "2015-11"
 8745	activated activated blurry Puffstone cigar	0		Effect: "Spooky Blur", Effect Duration: 12, Last Available: "2015-11"
-8746	colloidal concentrated warmed skewed purple Conspiracy&trade; mascara	0		Effect: "Venomous Weapon", Effect Duration: 36, Last Available: "2015-11"
+8746	colloidal concentrated warmed purple skewed Conspiracy&trade; mascara	0		Effect: "Venomous Weapon", Effect Duration: 36, Last Available: "2015-11"
 8747	colloidal ghostly Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Cheered Up", Effect Duration: 50, Last Available: "2015-11"
 8748	narrow airplane tattoo	0		Last Available: "2015-11"
 8749	nitrogenated alkaline twirling Deep Machine Tunnels snowglobe	0		Effect: "Mad at Science", Effect Duration: 15, Last Available: "2015-12"
@@ -8624,7 +8624,7 @@
 8751	liquefied oxidized tumbling communal gobstopper	0		Effect: "Jingle Jangle Jingle", Effect Duration: 63, Last Available: "2015-12"
 8752	bland gray Crimbo salad	3	decent	Last Available: "2015-12"
 8753	normal spinning bread line	3	good	Last Available: "2015-12"
-8754	weak tolerable bouncing olive bark rootbeer	2	good	Last Available: "2015-12"
+8754	weak tolerable olive bouncing bark rootbeer	2	good	Last Available: "2015-12"
 8755	practically non-alcoholic perfectly mixed special ale	1	EPIC	Effect: "Marco Polarity", Effect Duration: 5, Last Available: "2015-12"
 8756	skewed Jeselnik's plastic Tammy the Tambourine Elf	0		Sleaze Damage: +25, Last Available: "2015-12"
 8757	Lo Pan's plastic Rudolph the Red	0		Spell Critical Percent: +30, Last Available: "2015-12"
@@ -8685,12 +8685,12 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	diet rotten olive bouncing Kudzu salad	1	crappy	Last Available: "2016-12"
+8816	rotten diet bouncing olive Kudzu salad	1	crappy	Last Available: "2016-12"
 8817	pickled maroon Mansquito Serum	1		Last Available: "2016-12"
 8818	bad weak squat Miss Graves' vermouth	2	decent	Last Available: "2016-12"
 8819	rotten The Plumber's mushroom stew	3	crappy	Last Available: "2016-12"
 8820	powdered purple The Author's ink	1		Last Available: "2016-02"
-8821	drinkable enchanted The Mad Liquor	4	good	Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2016-12"
+8821	enchanted drinkable The Mad Liquor	4	good	Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2016-12"
 8822	mediocre irresponsibly strong Doc Clock's thyme cocktail	10	decent	Last Available: "2016-12"
 8823	adequate Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	boiled purple The Inquisitor's unidentifiable object	1		Effect: "Man's Worst Enemy", Effect Duration: 25, Last Available: "2016-12"
@@ -8748,13 +8748,13 @@
 8876	yummy plate of Heimz Fortified Kidney Beans	3	awesome	Last Available: "2016-02"
 8877	adequate narrow plate of Tesla's Electroplated Beans	4	good	Last Available: "2016-02"
 8878	moldy plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
-8879	immense flavorless teal plate of Hellfire Spicy Beans	10	decent	Last Available: "2016-02"
-8880	stale snack-sized wobbly huge red plate of Frigid Northern Beans	2	decent	Last Available: "2016-02"
-8881	jumbo moldy plate of World's Blackest-Eyed Peas	5	crappy	Last Available: "2016-02"
+8879	flavorless immense teal plate of Hellfire Spicy Beans	10	decent	Last Available: "2016-02"
+8880	snack-sized stale huge wobbly red plate of Frigid Northern Beans	2	decent	Last Available: "2016-02"
+8881	moldy jumbo plate of World's Blackest-Eyed Peas	5	crappy	Last Available: "2016-02"
 8882	toothsome plate of Trader Olaf's Exotic Stinkbeans	3	awesome	Last Available: "2016-02"
 8883	snack-sized rotten blurry plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
 8884	decent plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
-8885	stale thick plate of Shrub's Premium Baked Beans	5	decent	Last Available: "2016-02"
+8885	thick stale plate of Shrub's Premium Baked Beans	5	decent	Last Available: "2016-02"
 8886	wobbly executive razor-sharp Fancy Jeff's pocket square	0		Weapon Damage Percent: +25, Meat Drop: +40, Last Available: "2016-02"
 8887	wool toasty Temple Grandin's Daisy's unclean bloomers	0		Familiar Weight: +7, Hot Damage: +5, Cold Resistance: +1, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8764,7 +8764,7 @@
 8892	bouncing El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	tumbling cool Granny Hackleton's Gatling gun of the cougar of incineration	0		Moxie: 25, Hot Spell Damage: +50, Last Available: "2016-02"
-8895	skewed gray bouncing buffalo dime	0		Last Available: "2016-02"
+8895	gray bouncing skewed buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
 8897	flattened poker face paint	0		Effect: "Neuromancy", Effect Duration: 51, Last Available: "2016-02"
 8898	huge realistic cap gun	0		Last Available: "2016-02"
@@ -8776,9 +8776,9 @@
 8904	tarnished blurry twirling squat lion musk	0		Effect: "Jammin'", Effect Duration: 69, Last Available: "2016-02"
 8905	rotten gray bear claw	4	crappy	Last Available: "2016-02"
 8906	ionized extra-unsweetened alkaline rattler gland	0		Effect: "The Sweats", Effect Duration: 50, Last Available: "2016-02"
-8907	moist liquefied mirror pulsating yellow half-digested coal	0		Effect: "Chalky White Pallor", Effect Duration: 24, Last Available: "2016-02"
+8907	moist liquefied pulsating mirror yellow half-digested coal	0		Effect: "Chalky White Pallor", Effect Duration: 24, Last Available: "2016-02"
 8908	ionized pickled energized blue tightly-wound spine	0		Effect: "Bloodstain-Resistant", Effect Duration: 18, Last Available: "2016-02"
-8909	bite-sized stale rotting beefsteak	1	decent	Last Available: "2016-02"
+8909	stale bite-sized rotting beefsteak	1	decent	Last Available: "2016-02"
 8910	special hand-crafted firemilk	3	EPIC	Effect: "Improprie Tea", Effect Duration: 35, Last Available: "2016-02"
 8911	chilled spidercow eye-cluster	0		Effect: "Elemental Flavor", Effect Duration: 37, Last Available: "2016-02"
 8912	boiled twirling moomy dust	1		Effect: "Bark of the Dog", Effect Duration: 50, Last Available: "2016-02"
@@ -8796,7 +8796,7 @@
 8924	narrow disc (black)	0		
 8925	disc (red)	0		
 8926	disc (green)	0		
-8927	tumbling maroon disc (blue)	0		
+8927	maroon tumbling disc (blue)	0		
 8928	disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	anodized deionized blinking demonic cow's blood	0		Effect: "Wet and Greedy", Effect Duration: 53, Last Available: "2016-02"
@@ -8805,12 +8805,12 @@
 8933	pulsating squat custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
-8936	squat blue hamethyst-handled sixgun	0		Last Available: "2016-02"
+8936	blue squat hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	coal snakeskin	0		Last Available: "2016-02"
-8941	blue huge frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
+8941	huge blue frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	olive shuddering cow skull	0		Last Available: "2016-02"
 8944	wobbly rhinestone cowhorn	0		Familiar Weight: +5
@@ -8827,7 +8827,7 @@
 8955	blurry Tales of the West: Cow Punching	0		
 8956	wobbly Tales of the West: Beanslinging	0		
 8957	wobbly Tales of the West: Snake Oiling	0		
-8958	tumbling ghostly briefcase full of snakes	0		
+8958	ghostly tumbling briefcase full of snakes	0		
 8959	boxer's one-gallon hat of the businessman	0		Muscle Percent: +10, Meat Drop: +50
 8960	experienced two-gallon hat of wisdom	0		Mysticality: +15, Experience: +2
 8961	asbestos-lined three-gallon hat of Leguizamo	0		Monster Level: +20, Hot Resistance: +5
@@ -8852,7 +8852,7 @@
 8980	dry vacuum-sealed shaking patent avarice tonic	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 39
 8981	deionized concentrated patent alacrity tonic	0		Effect: "Weather, Man", Effect Duration: 17
 8982	super-ionized corrupted marrow	0		Effect: "Boon of She-Who-Was", Effect Duration: 49
-8983	practically non-alcoholic artisanal rodeo whiskey	1	super ultra EPIC	
+8983	artisanal practically non-alcoholic rodeo whiskey	1	super ultra EPIC	
 8984	ghostly tumbling Thwaitgold scorpion statuette	0		
 8985	sage real cowboy hat	0		Mysticality Percent: +10
 8986	bouncing teal Memories of Cow Punching	0		Free Pull
@@ -8890,10 +8890,10 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	upside-down meme generator	0		Last Available: "2016-05"
 9020	red plus one	0		Last Available: "2016-05"
-9021	rotten big gallon of milk	5	crappy	Last Available: "2016-05"
+9021	big rotten gallon of milk	5	crappy	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
-9024	upside-down olive shaking daily dungeon malware	0		Last Available: "2016-05"
+9024	upside-down shaking olive daily dungeon malware	0		Last Available: "2016-05"
 9025	blue infinite BACON machine	0		Last Available: "2016-05"
 9026	First Post shirt package	0		Last Available: "2016-05"
 9027	bouncing Temple Grandin's personal trainer's groovy First Post shirt - Cir Senam	0		Moxie Percent: +10, Experience Percent (Muscle): +10, Familiar Weight: +7, Last Available: "2016-05"
@@ -8928,7 +8928,7 @@
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
-9059	cyan blinking Source terminal file: turbo.edu	0		Last Available: "2016-06"
+9059	blinking cyan Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	skewed Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	blurry Source terminal file: gram.ext	0		Last Available: "2016-06"
@@ -8949,7 +8949,7 @@
 9077	aromatic reassuring dance instructor's trench coat	0		Experience Percent (Moxie): +10, Spooky Resistance: +1, Stench Resistance: +1, Last Available: "2016-07"
 9078	lousy Falcon&trade; Maltese Liquor	4	decent	Last Available: "2016-07"
 9079	stale blurry hardboiled egg	4	decent	Last Available: "2016-07"
-9080	tumbling maroon tumbling detective tattoo	0		Last Available: "2016-07"
+9080	maroon tumbling tumbling detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	teal lightning-fast double-paned frightening electrified padded protonic accelerator pack of dire peril	0		Weapon Damage: +20, Damage Absorption: +20, Spooky Damage: +5, Cold Resistance: +5, Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
@@ -8995,7 +8995,7 @@
 9123	wobbly School of Hard Knocks Diploma	0		
 9124	purple squat baby bark scorpion	0		
 9125	jittery droppable microphone	0		
-9126	practically non-alcoholic mediocre narrow unidentified drink	1	decent	
+9126	mediocre practically non-alcoholic narrow unidentified drink	1	decent	
 9127	tumbling KoL Con 13 T-shirt of the detective of the businessman	0		Item Drop: +20, Meat Drop: +50
 9128	blinking Jim Carey's Lo Pan's discarded swimming trunks of the bloodbag	0		Maximum HP: +100, Spell Critical Percent: +30, Monster Level: +25
 9129	oxidized squat diluted makeup	0		Effect: "Blackberry Politeness", Effect Duration: 11
@@ -9004,7 +9004,7 @@
 9132	scorching Da Vinci's pistol	0		Experience (Mysticality): +5, Hot Damage: +25
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	rotten leftover pasty	4	crappy	
-9135	tolerable practically non-alcoholic very whiskey	1	good	
+9135	practically non-alcoholic tolerable very whiskey	1	good	
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	gray li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	wobbly li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9016,8 +9016,8 @@
 9144	tumbling li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	non-modified ionized hoarded candy wad	0		Effect: "Frigid Weapon", Effect Duration: 22, Last Available: "2016-10"
-9147	adjusted unsweetened narrow spinning Prunets	0		Effect: "Flagrantly Fragrant", Effect Duration: 21
-9148	tumbling purple Twitching Television Tattoo	0		
+9147	adjusted unsweetened spinning narrow Prunets	0		Effect: "Flagrantly Fragrant", Effect Duration: 21
+9148	purple tumbling Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	wet dry invisible string	0		Lasts Until Rollover, Effect: "Sepia Tan", Effect Duration: 53, Last Available: "2016-10"
 9151	energized extra-ionized wet invisible seam ripper	0		Lasts Until Rollover, Effect: "Putting the Pro in Proletariat", Effect Duration: 21, Last Available: "2016-10"
@@ -9025,9 +9025,9 @@
 9153	rotten blinking raw sweet potato	3	crappy	Last Available: "2016-11"
 9154	spoiled gigantic raw beans	8	crappy	Last Available: "2016-11"
 9155	adequate raw stuffing	3	good	Last Available: "2016-11"
-9156	massive tasty red jittery raw cranberry sauce	10	awesome	Last Available: "2016-11"
-9157	miniature spoiled raw turkey	2	crappy	Last Available: "2016-11"
-9158	miniature rotten raw mincemeat	2	crappy	Last Available: "2016-11"
+9156	massive tasty jittery red raw cranberry sauce	10	awesome	Last Available: "2016-11"
+9157	spoiled miniature raw turkey	2	crappy	Last Available: "2016-11"
+9158	rotten miniature raw mincemeat	2	crappy	Last Available: "2016-11"
 9159	rotten raw potato	3	crappy	Last Available: "2016-11"
 9160	rotten wobbly raw gravy	4	crappy	Last Available: "2016-11"
 9161	normal raw bread	4	good	Last Available: "2016-11"
@@ -9035,22 +9035,22 @@
 9163	resourceful glass casserole dish of the bloodbag of Calamity Jane	0		Maximum HP: +100, Maximum MP: +50, Critical Hit Percent: +15, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	skewed Jack Frost's Jim Carey's can opener	0		Monster Level: +25, Cold Spell Damage: +50, Last Available: "2016-11"
-9166	powdered pulsating ghostly turkey blaster	1		Last Available: "2016-11"
+9166	powdered ghostly pulsating turkey blaster	1		Last Available: "2016-11"
 9167	purple steel-toed fortified glass pie plate	0		Damage Absorption: +60, Damage Reduction: 16, Last Available: "2016-11"
 9168	wobbly Newton's supercool potato masher	0		Moxie Percent: +20, Experience (Mysticality): +3, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
-9170	bouncing shaking bread mold	0		Last Available: "2016-11"
-9171	miniature moldy green sweet potatoes	2	crappy	Last Available: "2016-11"
-9172	normal immense bean casserole	9	good	Last Available: "2016-11"
-9173	decent bite-sized baked stuffing	1	good	Last Available: "2016-11"
+9170	shaking bouncing bread mold	0		Last Available: "2016-11"
+9171	moldy miniature green sweet potatoes	2	crappy	Last Available: "2016-11"
+9172	immense normal bean casserole	9	good	Last Available: "2016-11"
+9173	bite-sized decent baked stuffing	1	good	Last Available: "2016-11"
 9174	tiny yummy cranberry cylinder	1	awesome	Last Available: "2016-11"
-9175	adequate small thanksgiving turkey	2	good	Last Available: "2016-11"
-9176	fancy small delicious mince pie	2	awesome	Effect: "Sweet Incentive", Effect Duration: 45, Last Available: "2016-11"
+9175	small adequate thanksgiving turkey	2	good	Last Available: "2016-11"
+9176	fancy delicious small mince pie	2	awesome	Effect: "Sweet Incentive", Effect Duration: 45, Last Available: "2016-11"
 9177	moldy immense mashed potatoes	7	crappy	Last Available: "2016-11"
 9178	moldy warm gravy	4	crappy	Last Available: "2016-11"
 9179	rotten bread roll	4	crappy	Last Available: "2016-11"
-9180	super-sized enchanted normal leftovers	5	good	Effect: "Feroci Tea", Effect Duration: 50, Last Available: "2016-11"
-9181	flavorless thick leftovers sandwich	5	decent	Last Available: "2016-11"
+9180	normal enchanted super-sized leftovers	5	good	Effect: "Feroci Tea", Effect Duration: 50, Last Available: "2016-11"
+9181	thick flavorless leftovers sandwich	5	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	lime green cornucopia	0		Last Available: "2016-11"
 9184	skewed megacopia	0		Last Available: "2016-11"
@@ -9061,14 +9061,14 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	pickled pulsating eldritch concentrate	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 11, Last Available: "2016-11"
-9192	hand-crafted weak maroon eldritch extract	2	EPIC	Last Available: "2016-11"
+9192	weak hand-crafted maroon eldritch extract	2	EPIC	Last Available: "2016-11"
 9193	twirling brainy Official Council Aide Pin of chilblains	0		Mysticality: +5, Cold Damage: +25, Last Available: "2016-11"
 9194	smooth eldritch distillate	3	awesome	Last Available: "2016-11"
 9195	powdered jittery squat eldritch essence	1		Effect: "Egg Burps", Effect Duration: 35, Last Available: "2016-11"
 9196	greasy Science Notebook	0		Sleaze Spell Damage: +10
 9197	nasty Jim Carey's shellacked eldritch hat	0		Damage Reduction: 7, Monster Level: +25, Stench Damage: +5, Last Available: "2016-11"
 9198	ghostly up-at-dawn eldritch pants of the brute of doom	0		Muscle Percent: +30, Spooky Spell Damage: +50, Adventures: +5, Last Available: "2016-11"
-9199	strong delicious eldritch elixir	5	awesome	Last Available: "2016-11"
+9199	delicious strong eldritch elixir	5	awesome	Last Available: "2016-11"
 9200	asbestos-lined energetic Quartet of Flare Masters Jacket	0		Maximum MP Percent: +20, Hot Resistance: +5, Last Available: "2016-11"
 9201	blurry lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9087,7 +9087,7 @@
 9215	broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	interesting clod of dirt	0		
 9217	blurry gingerbread restraining order	0		Last Available: "2016-12"
-9218	teal ghostly sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
+9218	ghostly teal sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	adequate animal part cracker	3	good	Last Available: "2016-12"
 9220	spirit-forward artisanal gingerbread wine	5	EPIC	Last Available: "2016-12"
 9221	big normal gingerbread mug	5	good	Last Available: "2016-12"
@@ -9107,12 +9107,12 @@
 9235	activated green gingerbread spice latte	0		Effect: "Uncucumbered", Effect Duration: 53, Last Available: "2016-12"
 9236	gingerbread gavel of horror of the boozehound	0		Spooky Spell Damage: +25, Booze Drop: +100, Last Available: "2016-12"
 9237	tumbling gingerbread cigarette	0		Last Available: "2016-12"
-9238	skewed ghostly gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
+9238	ghostly skewed gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	artisanal fortified ginger beer	5	EPIC	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	Vulcanized non-colloidal industrial frosting	0		Effect: "Very Clean Guns", Effect Duration: 31, Last Available: "2016-12"
 9242	extra-pickled frozen fake cocktail	0		Effect: "Pyromania", Effect Duration: 59, Last Available: "2016-12"
-9243	enchanted triple-distilled lousy lime green high-end ginger wine	6	decent	Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2016-12"
+9243	triple-distilled enchanted lousy lime green high-end ginger wine	6	decent	Effect: "Full Bottle in front of Me", Effect Duration: 45, Last Available: "2016-12"
 9244	greedy plastic bad vibe	0		Meat Drop: +20, Last Available: "2016-12"
 9245	pulsating plastic angry vikings of the cougar	0		Moxie: +20, Last Available: "2016-12"
 9246	sinister plastic Knows About Chakras	0		Spell Damage: +10, Last Available: "2016-12"
@@ -9121,9 +9121,9 @@
 9249	improved Vulcanized yellow Inner Wisdom	0		Effect: "Fudge Headache", Effect Duration: 62, Last Available: "2016-12"
 9250	polarized boiled diffused Inner Strength	0		Effect: "There Is A Spoon", Effect Duration: 39, Last Available: "2016-12"
 9251	quadruple-denatured triple-polarized Inner Truth	0		Effect: "Natural 20", Effect Duration: 36, Last Available: "2016-12"
-9252	normal half-sized spiritual candy cane	2	good	Last Available: "2016-12"
+9252	half-sized normal spiritual candy cane	2	good	Last Available: "2016-12"
 9253	artisanal squat spiritual eggnog	4	EPIC	Last Available: "2016-12"
-9254	flavorless miniature gray spiritual fruitcake	2	decent	Last Available: "2016-12"
+9254	miniature flavorless gray spiritual fruitcake	2	decent	Last Available: "2016-12"
 9255	spoiled bite-sized upside-down spiritual gingerbread	1	crappy	Last Available: "2016-12"
 9256	pulsating chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9145,10 +9145,10 @@
 9273	dance instructor's Third Eye of the detective	0		Experience Percent (Moxie): +10, Item Drop: +20, Last Available: "2016-12"
 9274	electrified Da Vinci's Krampus Horn	0		Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-12"
 9275	decent hambrosier	4	good	Last Available: "2016-12"
-9276	aged watered-down chakra-mental wine	2	awesome	Last Available: "2016-12"
+9276	watered-down aged chakra-mental wine	2	awesome	Last Available: "2016-12"
 9277	adjusted pickled wobbly chakra malt	0		Effect: "Baconstoned", Effect Duration: 23, Last Available: "2016-12"
-9278	immense stale Black Angus blackburger	8	decent	Last Available: "2016-12"
-9279	bad practically non-alcoholic brandy	1	decent	Last Available: "2016-12"
+9278	stale immense Black Angus blackburger	8	decent	Last Available: "2016-12"
+9279	practically non-alcoholic bad brandy	1	decent	Last Available: "2016-12"
 9280	liquefied diffused tumbling potion of spiritual gunkifying	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 15, Last Available: "2016-12"
 9281	cyan vibrating bad vibroknife of the storm	0		Maximum MP Percent: 50, Last Available: "2016-12"
 9282	mirror squat censurious razor-sharp crystal belt buckle	0		Weapon Damage Percent: +25, Sleaze Resistance: +3, Last Available: "2016-12"
@@ -9163,10 +9163,10 @@
 9291	powdered hot jelly	1		Effect: "Also Schmeckt Zarathustra", Effect Duration: 50, Last Available: "2017-01"
 9292	vaporized jelly	1		Effect: "Hustlin'", Effect Duration: 15, Last Available: "2017-01"
 9293	altered ghostly jelly	1		Last Available: "2017-01"
-9294	boiled upside-down red sleaze jelly	1		Last Available: "2017-01"
+9294	boiled red upside-down sleaze jelly	1		Last Available: "2017-01"
 9295	altered fuchsia stench jelly	1		Last Available: "2017-01"
 9296	huge space planula	0		Free Pull, Last Available: "2017-01"
-9297	low-calorie tasty toast with hot jelly	1	awesome	Last Available: "2017-01"
+9297	tasty low-calorie toast with hot jelly	1	awesome	Last Available: "2017-01"
 9298	moldy toast with jelly	4	crappy	Last Available: "2017-01"
 9299	decent toast with jelly	3	good	Last Available: "2017-01"
 9300	delicious thick twirling toast with sleaze jelly	5	awesome	Last Available: "2017-01"
@@ -9178,7 +9178,7 @@
 9306	frightening forbidden candle	0		Spell Damage Percent: +50, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	yummy twirling wax pancake	3	awesome	Last Available: "2017-01"
 9308	skewed greedy crafty wax face	0		Maximum MP: +10, Meat Drop: +20, Last Available: "2017-01"
-9309	artisanal fortified wax booze	5	EPIC	Last Available: "2017-01"
+9309	fortified artisanal wax booze	5	EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	distilled sea jelly	1		Last Available: "2017-01"
 9312	bland sea truffle	4	decent	Last Available: "2017-01"
@@ -9195,7 +9195,7 @@
 9323	blue pulsating LOV Enamorang	0		Last Available: "2017-02"
 9324	wobbly LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	vaporized jittery blinking mirror LOV Echinacea Bouquet	1		Last Available: "2017-02"
+9326	vaporized mirror jittery blinking LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	twirling mirror medical-grade LOV Elephant	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 6, Last Available: "2017-02"
 9328	family-friendly eldritch scanner	0		Sleaze Resistance: +1, Last Available: "2017-02"
 9329	modified eldritch alignment spray	0		Effect: "Moon'd", Effect Duration: 16, Last Available: "2017-02"
@@ -9234,7 +9234,7 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	maroon imaginary lemon	0		Last Available: "2017-03"
-9365	practically non-alcoholic delicious ghostly pulsating literal grasshopper	1	awesome	Last Available: "2017-03"
+9365	delicious practically non-alcoholic ghostly pulsating literal grasshopper	1	awesome	Last Available: "2017-03"
 9366	hand-crafted practically non-alcoholic double entendre	1	EPIC	Last Available: "2017-03"
 9367	tolerable Phlegethon	4	good	Last Available: "2017-03"
 9368	distilled bad Siberian sunrise	5	decent	Last Available: "2017-03"
@@ -9246,35 +9246,35 @@
 9374	artisanal blue great fashioned	3	EPIC	Last Available: "2017-03"
 9375	tolerable Gnomish sagngria	3	good	Last Available: "2017-03"
 9376	mediocre practically non-alcoholic vodka stinger	1	decent	Last Available: "2017-03"
-9377	mediocre triple-distilled squat extremely slippery nipple	6	decent	Last Available: "2017-03"
+9377	triple-distilled mediocre squat extremely slippery nipple	6	decent	Last Available: "2017-03"
 9378	tolerable piscatini	3	good	Last Available: "2017-03"
 9379	perfectly mixed Churchill	4	EPIC	Last Available: "2017-03"
 9380	perfectly mixed soilzerac	3	EPIC	Last Available: "2017-03"
 9381	strong hand-crafted London frog	5	EPIC	Last Available: "2017-03"
-9382	delicious special practically non-alcoholic nothingtini	1	awesome	Effect: "Ten out of Ten", Effect Duration: 15, Last Available: "2017-03"
+9382	practically non-alcoholic delicious special nothingtini	1	awesome	Effect: "Ten out of Ten", Effect Duration: 15, Last Available: "2017-03"
 9383	perfectly mixed eighth plague	3	EPIC	Last Available: "2017-03"
-9384	acceptable triple-distilled single entendre	9	good	Last Available: "2017-03"
-9385	tolerable triple-distilled reverse Tantalus	9	good	Last Available: "2017-03"
-9386	acceptable practically non-alcoholic elemental caipiroska	1	good	Last Available: "2017-03"
+9384	triple-distilled acceptable single entendre	9	good	Last Available: "2017-03"
+9385	triple-distilled tolerable reverse Tantalus	9	good	Last Available: "2017-03"
+9386	practically non-alcoholic acceptable elemental caipiroska	1	good	Last Available: "2017-03"
 9387	bad Feliz Navidad	3	decent	Last Available: "2017-03"
 9388	perfectly mixed irresponsibly strong Bloody Nora	7	EPIC	Last Available: "2017-03"
 9389	mediocre moreltini	3	decent	Last Available: "2017-03"
 9390	perfectly mixed bouncing hell in a bucket	3	EPIC	Last Available: "2017-03"
-9391	spirit-forward drinkable wobbly Newark	5	good	Last Available: "2017-03"
-9392	perfectly mixed spirit-forward R'lyeh	5	EPIC	Last Available: "2017-03"
+9391	drinkable spirit-forward wobbly Newark	5	good	Last Available: "2017-03"
+9392	spirit-forward perfectly mixed R'lyeh	5	EPIC	Last Available: "2017-03"
 9393	mediocre Gnollish sangria	3	decent	Last Available: "2017-03"
 9394	lousy vodka barracuda	3	decent	Last Available: "2017-03"
 9395	smooth blurry Mysterious Island iced tea	4	awesome	Last Available: "2017-03"
 9396	hand-crafted mirror drive-by shooting	3	EPIC	Last Available: "2017-03"
 9397	lousy triple-distilled blurry gunner's daughter	6	decent	Last Available: "2017-03"
-9398	practically non-alcoholic aged dirt julep	1	awesome	Last Available: "2017-03"
-9399	spirit-forward bad Simepore slime	5	decent	Last Available: "2017-03"
+9398	aged practically non-alcoholic dirt julep	1	awesome	Last Available: "2017-03"
+9399	bad spirit-forward Simepore slime	5	decent	Last Available: "2017-03"
 9400	bad weak blurry Phil Collins	2	decent	Last Available: "2017-03"
 9401	shaking huge unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	maroon toggle switch (Bartend)	0		Familiar Weight: +5
 9403	blurry toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
-9405	tumbling spinning purple filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
+9405	tumbling purple spinning filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	blurry exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	narrow rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	pulsating gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9284,11 +9284,11 @@
 9412	blurry jittery alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	stale jumbo edible alien plant bit	5	decent	Last Available: "2017-04"
+9415	jumbo stale edible alien plant bit	5	decent	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	fuchsia alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
-9419	spinning lime green fascinating alien plant sample	0		Last Available: "2017-04"
+9419	lime green spinning fascinating alien plant sample	0		Last Available: "2017-04"
 9420	powdered cyan alien plant goo	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 10, Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	olive zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9297,13 +9297,13 @@
 9425	pulsating alien zoological sample	0		Last Available: "2017-04"
 9426	wobbly complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	boiled ghostly teal huge alien animal goo	1		Effect: "Hardened Fabric", Effect Duration: 20, Last Available: "2017-04"
+9428	boiled huge teal ghostly alien animal goo	1		Effect: "Hardened Fabric", Effect Duration: 20, Last Available: "2017-04"
 9429	shaking alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	blurry murderbot data core	0		Last Available: "2017-04"
 9432	non-cold-filtered vacuum-sealed alien medicine	0		Effect: "Ooh, Umami!", Effect Duration: 49, Last Available: "2017-04"
 9433	miniature stale alien salad	2	decent	Last Available: "2017-04"
-9434	perfectly mixed triple-distilled alien booze	6	EPIC	Last Available: "2017-04"
+9434	triple-distilled perfectly mixed alien booze	6	EPIC	Last Available: "2017-04"
 9435	sizzling chilly alien mask of doom	0		Cold Damage: +5, Hot Damage: +10, Spooky Spell Damage: +50, Last Available: "2017-04"
 9436	rosewater-soaked Annie Oakley's supercharged alien spear	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Stench Resistance: +3, Last Available: "2017-04"
 9437	Sinatra's alien blowgun of the blizzard of the businessman	0		Experience (Moxie): +5, Cold Spell Damage: +25, Meat Drop: +50, Last Available: "2017-04"
@@ -9331,7 +9331,7 @@
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	huge Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
-9462	green upside-down Procrastinator locker key	0		Last Available: "2017-04"
+9462	upside-down green Procrastinator locker key	0		Last Available: "2017-04"
 9463	mirror Space Baby children's book	0		Last Available: "2017-04"
 9464	wobbly wobbly Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
@@ -9365,7 +9365,7 @@
 9493	huge crafty Fonzie's Kremlin's Greatest Briefcase	0		Experience (Moxie): +1, Maximum MP: +10, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	practically non-alcoholic aged wobbly basic martini	1	awesome	Last Available: "2017-06"
 9495	tolerable practically non-alcoholic improved martini	1	good	Last Available: "2017-06"
-9496	drinkable watered-down splendid martini	2	good	Last Available: "2017-06"
+9496	watered-down drinkable splendid martini	2	good	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	fuchsia can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9381,14 +9381,14 @@
 9509	L.I.M.P. Stock Certificate	0		
 9510	blurry Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
-9512	shaking upside-down Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
+9512	upside-down shaking Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	wobbly Meteorite-Ade	0		Last Available: "2017-08"
 9514	snack-sized decent meteoreo	2	good	Last Available: "2017-08"
 9515	watered-down perfectly mixed meadeorite	2	EPIC	Last Available: "2017-08"
-9516	blurry jittery lime green meteoroid	0		Last Available: "2017-08"
+9516	jittery lime green blurry meteoroid	0		Last Available: "2017-08"
 9517	pulsating Sinatra's brawny meteortarboard of terror	0		Muscle Percent: +20, Experience (Moxie): +5, Spooky Spell Damage: +10, Last Available: "2017-08"
 9518	reassuring smelly flame-wreathed meteorite guard	0		Hot Spell Damage: +10, Stench Spell Damage: +10, Spooky Resistance: +1, Damage Reduction: 9, Last Available: "2017-08"
-9519	meteorb of dire peril of the overflowing toilet	0		Weapon Damage: +20, Stench Spell Damage: +50, Last Available: "2017-08", Lantern Element: "Hot"
+9519	meteorb of dire peril of the overflowing toilet	0		Weapon Damage: +20, Stench Spell Damage: +50, Lantern Element: "Hot", Last Available: "2017-08"
 9520	blinking wicked personal trainer's asteroid belt	0		Experience Percent (Muscle): +10, Spell Damage: +5, Single Equip, Last Available: "2017-08"
 9521	red Usain Bolt's gravedigger's dangerous meteorthopedic shoes	0		Weapon Damage: +10, Spooky Damage: +10, Initiative: +80, Single Equip, Last Available: "2017-08"
 9522	Temple Grandin's thinker's strapping shooting morning star	0		Muscle: +5, Mysticality: +10, Familiar Weight: +7, Single Equip, Last Available: "2017-08"
@@ -9401,9 +9401,9 @@
 9529	genie bottle	0		Last Available: "2017-09"
 9530	teal horrifying banded savvy blessed rustproof +2 gray dragon scale mail	0		Mysticality Percent: +20, Damage Absorption: +100, Spooky Damage: +25, Last Available: "2023-09"
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
-9532	narrow blinking pony: Shutterfly	0		Last Available: "2017-09"
+9532	blinking narrow pony: Shutterfly	0		Last Available: "2017-09"
 9533	tumbling yellow pony: Pearjack	0		Last Available: "2017-09"
-9534	ghostly lime green pony: Uniquity	0		Last Available: "2017-09"
+9534	lime green ghostly pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
 9536	pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
@@ -9418,7 +9418,7 @@
 9546	blinking forbidden razor-sharp mafia pinky ring	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Single Equip
 9547	lousy flask of port	3	decent	
 9548	Van der Graaf stylish contract enforcement stick	0		Moxie: +25, MP Regen Min: 5, MP Regen Max: 7
-9549	normal gigantic Hide-rox&trade; cookie	8	good	Last Available: "2017-10"
+9549	gigantic normal Hide-rox&trade; cookie	8	good	Last Available: "2017-10"
 9550	acceptable jug of booze	4	good	Last Available: "2017-10"
 9551	double-magnetized spinning pair of candy glasses	0		Effect: "Knightlife", Effect Duration: 66, Last Available: "2017-10"
 9552	aerosolized yellow temporary X tattoos	0		Effect: "Headstrong", Effect Duration: 20, Last Available: "2017-10"
@@ -9448,7 +9448,7 @@
 9576	mafia organizer badge of the blizzard	0		Cold Spell Damage: +25, Single Equip
 9577	spinning mafia filofax	0		
 9578	spinning transparent nog	1	EPIC	Last Available: "2017-12"
-9579	flavorless half-sized upside-down unfinished fruitcake	2	decent	Last Available: "2017-12"
+9579	half-sized flavorless upside-down unfinished fruitcake	2	decent	Last Available: "2017-12"
 9580	oxidized and cracker	0		Effect: "Flamingly Floral", Effect Duration: 24, Last Available: "2017-12"
 9581	weak lousy green neg grog	2	decent	Last Available: "2017-12"
 9582	stale half double fruitcake	4	decent	Last Available: "2017-12"
@@ -9463,11 +9463,11 @@
 9591	locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	fancy temperance whiskey	1	awesome	Effect: "Muscle Unbound", Effect Duration: 10, Last Available: "2017-11"
-9594	wet ionized shaking narrow wishbone	0		Effect: "Pill Power", Effect Duration: 63, Last Available: "2017-11"
-9595	triple-distilled hand-crafted Racisto Ruidoso	7	EPIC	Last Available: "2017-11"
+9594	wet ionized narrow shaking wishbone	0		Effect: "Pill Power", Effect Duration: 63, Last Available: "2017-11"
+9595	hand-crafted triple-distilled Racisto Ruidoso	7	EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	stale bran muffin	4	decent	
-9598	bland low-calorie special blueberry muffin	1	decent	Effect: "Biologically Shocked", Effect Duration: 50
+9598	special low-calorie bland blueberry muffin	1	decent	Effect: "Biologically Shocked", Effect Duration: 50
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9494,17 +9494,17 @@
 9622	silent X	0		Last Available: "2017-12"
 9623	skewed silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
-9625	blurry pulsating crystalline cheer	0		Last Available: "2017-12"
+9625	pulsating blurry crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	blinking mime pocket probe	0		Last Available: "2017-12"
-9629	perfectly mixed practically non-alcoholic stale cheer wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
+9629	practically non-alcoholic perfectly mixed stale cheer wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
 9630	miniature adequate blinking stale Cheer-E-Os	2	good	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	twirling resourceful shellacked cheerful antler hat	0		Damage Reduction: 7, Maximum MP: +50, Last Available: "2017-12"
 9633	upside-down horrifying cheerful Crimbo sweater of the bloodbag	0		Maximum HP: +100, Spooky Damage: +25, Last Available: "2017-12"
 9634	frosty MacGyver's cheerful pajama pants	0		Maximum MP: +100, Cold Spell Damage: +10, Last Available: "2017-12"
-9635	blue narrow The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9635	narrow blue The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	teal The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	mirror The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
@@ -9519,7 +9519,7 @@
 9647	mime eraser	0		Last Available: "2017-12"
 9648	artisanal fortified spinning executive mime flask	5	EPIC	Last Available: "2017-12"
 9649	stale pulsating nega-mushroom	4	decent	Last Available: "2017-12"
-9650	enchanted delicious practically non-alcoholic nega-mushroom wine	1	awesome	Effect: "Permanent Halloween", Effect Duration: 50, Last Available: "2017-12"
+9650	practically non-alcoholic delicious enchanted nega-mushroom wine	1	awesome	Effect: "Permanent Halloween", Effect Duration: 50, Last Available: "2017-12"
 9651	polarized triple-deionized Cheer-Up soda	0		Effect: "Inner Warmth", Effect Duration: 31, Last Available: "2017-12"
 9652	stale tiny mime army rations	1	decent	Last Available: "2017-12"
 9653	artisanal mime army wine	3	super ultra mega EPIC	Last Available: "2017-12"
@@ -9545,7 +9545,7 @@
 9673	mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	toasty healthy mime army infiltration glove	0		Maximum HP Percent: +20, Hot Damage: +5, Single Equip, Last Available: "2017-12"
-9676	pulsating cyan mime army shotglass	0		Last Available: "2017-12"
+9676	cyan pulsating mime army shotglass	0		Last Available: "2017-12"
 9677	teal mime army challenge coin	0		Last Available: "2017-12"
 9678	ghostly cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
@@ -9572,9 +9572,9 @@
 9700	horrifying banded novelty monorail ticket	0		Damage Absorption: +100, Spooky Damage: +25
 9701	twisted huge pills	1		
 9702	twisted furry pill	1		Effect: "Just the Brown Ones", Effect Duration: 30
-9703	twisted bouncing ghostly yellow spinning beefy pill	1		Effect: "Chalked Weapon", Effect Duration: 30
+9703	twisted spinning ghostly bouncing yellow beefy pill	1		Effect: "Chalked Weapon", Effect Duration: 30
 9704	mixed twirling twirling excitement pill	1		
-9705	pickled fuchsia twirling vitamin G pill	1		
+9705	pickled twirling fuchsia vitamin G pill	1		
 9706	vaporized jittery lucky-ish pill	1		Effect: "Pisces in the Skyces", Effect Duration: 45
 9707	twisted wobbly dieting pill	1		
 9712	huge Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
@@ -9603,7 +9603,7 @@
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	squat heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
-9738	bouncing cyan personal graffiti kit	0		Last Available: "2018-02"
+9738	cyan bouncing personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	skewed Mysterious Blue Box	0		Last Available: "2018-02"
@@ -9640,14 +9640,14 @@
 9772	Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
 9774	upside-down Peaclock	0		Last Available: "2018-03"
-9775	bouncing jittery Turtive	0		Last Available: "2018-03"
-9776	jittery shaking Lepardner	0		Last Available: "2018-03"
+9775	jittery bouncing Turtive	0		Last Available: "2018-03"
+9776	shaking jittery Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
 9778	pulsating Waifuton	0		Last Available: "2018-03"
 9779	twirling shaking Gorillape	0		Last Available: "2018-03"
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	upside-down Snoutlet	0		Last Available: "2018-03"
-9782	bouncing shaking Ruffalo	0		Last Available: "2018-03"
+9782	shaking bouncing Ruffalo	0		Last Available: "2018-03"
 9783	blue squat Vaporpoise	0		Last Available: "2018-03"
 9784	red ghostly Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
@@ -9685,7 +9685,7 @@
 9817	Jamocha berry	0		Last Available: "2018-03"
 9818	Tapioc berry	0		Last Available: "2018-03"
 9819	Snarf berry	0		Last Available: "2018-03"
-9820	tumbling mirror Keese berry	0		Last Available: "2018-03"
+9820	mirror tumbling Keese berry	0		Last Available: "2018-03"
 9821	bouncing luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9728,15 +9728,15 @@
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	adequate gigantic narrow FantasyRealm turkey leg	6	good	Last Available: "2018-04"
-9863	artisanal practically non-alcoholic enchanted FantasyRealm mead	1	super EPIC	Effect: "Walberg's Dim Bulb", Effect Duration: 10, Last Available: "2018-04"
+9863	enchanted artisanal practically non-alcoholic FantasyRealm mead	1	super EPIC	Effect: "Walberg's Dim Bulb", Effect Duration: 10, Last Available: "2018-04"
 9864	spinning nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	wobbly hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	twirling grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	decent diet druidic s'more	1	good	Last Available: "2018-04"
+9869	diet decent druidic s'more	1	good	Last Available: "2018-04"
 9870	distilled spinning sachet of powder	1		Last Available: "2018-04"
-9871	lousy practically non-alcoholic purple mourning wine	1	decent	Last Available: "2018-04"
+9871	practically non-alcoholic lousy purple mourning wine	1	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9761,16 +9761,16 @@
 9893	wool flame-wreathed supercharged cool deadfall branch	0		Moxie: +5, Maximum MP Percent: +30, Hot Spell Damage: +10, Cold Resistance: +1
 9894	squat cyan Van der Graaf hardy studded experienced wizardly Staff of Kitchen Royalty	0		Mysticality: +25, Experience: +2, Damage Absorption: +80, Maximum HP: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-04"
 9895	huge charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
-9896	ghostly gray dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
+9896	gray ghostly dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	tolerable skewed two meat muck	4	good	
 9899	flavorless chocolate Ogre Chieftain	4	decent	
 9900	special adequate chocolate &quot;Phoenix&quot;	4	good	Effect: "Greasy Visage", Effect Duration: 5
-9901	normal small chocolate Spider Queen	2	good	
+9901	small normal chocolate Spider Queen	2	good	
 9902	tolerable gray hipster cocktail	4	good	
 9903	bouncing God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Last Available: "2018-05", Equips On: "God Lobster"
 9904	cyan God Lobster's Ring	0		Familiar Effect: "sombrero", Last Available: "2018-05", Equips On: "God Lobster"
-9905	huge pulsating God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
+9905	pulsating huge God Lobster's Rod	0		Familiar Effect: "whelp", Last Available: "2018-05", Equips On: "God Lobster"
 9906	God Lobster's Robe	0		Familiar Effect: "block", Last Available: "2018-05", Equips On: "God Lobster"
 9907	God Lobster's Crown	0		Familiar Effect: "fairy", Last Available: "2018-05", Equips On: "God Lobster"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
@@ -9781,9 +9781,9 @@
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	bland good guava	4	decent	
-9916	lousy extra-dry gray gin and ginger	5	decent	
+9916	extra-dry lousy gray gin and ginger	5	decent	
 9917	olive Thwaitgold chigger statuette	0		
-9918	dried jittery skewed gaseous gravy	1		Effect: "Holiday Bliss", Effect Duration: 30
+9918	dried skewed jittery gaseous gravy	1		Effect: "Holiday Bliss", Effect Duration: 30
 9919	twirling SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
@@ -9791,7 +9791,7 @@
 9923	ionized squat Punching Potion	0		Effect: "Amorous", Effect Duration: 24, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
 9925	distilled shaking Nightmare Fuel	1		Last Available: "2018-06"
-9926	pulsating red Gathered Meat-Clip	0		Last Available: "2020-09"
+9926	red pulsating Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	squat Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	rosewater-soaked horrifying nasty studded Brutal brogues	0		Damage Absorption: +80, Stench Damage: +5, Spooky Damage: +25, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2018-07"
@@ -9806,7 +9806,7 @@
 9938	Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	skewed kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	burglar/sleep mask	0		Last Available: "2018-07"
-9941	blurry wobbly Thwaitgold masked hunter statuette	0		
+9941	wobbly blurry Thwaitgold masked hunter statuette	0		
 9942	Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
 9943	narrow Neverending Party guest pass	0		Last Available: "2018-09"
 9944	squat medical-grade dangerous experienced PARTY HARD T-shirt	0		Experience: +2, Weapon Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-09"
@@ -9831,19 +9831,19 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	ruddy grievous noticeable pumps	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	fancy hand-crafted wobbly blinking everfull glass	3		Effect: "Fruited", Effect Duration: 5, Last Available: "2018-09"
+9966	fancy hand-crafted blinking wobbly everfull glass	3		Effect: "Fruited", Effect Duration: 5, Last Available: "2018-09"
 9967	bouncing van key	0		Last Available: "2018-09"
 9968	maroon jam band bootleg	0		Last Available: "2018-09"
 9969	huge tumbling sharpshooter's slick denim jacket	0		Moxie: +10, Critical Hit Percent: +10, Last Available: "2018-09"
 9970	inspector's MacGyver's ratty knitted cap	0		Maximum MP: +100, Item Drop: +15, Last Available: "2018-09"
 9972	nasty intimidating chainsaw of the empath	0		Familiar Weight: +5, Stench Damage: +5, Lasts Until Rollover, Last Available: "2018-09"
 9973	tolerable wobbly yellow party beer bomb	3	good	Last Available: "2018-09"
-9974	stale half-sized purple sweet party mix	2	decent	Last Available: "2018-09"
+9974	half-sized stale purple sweet party mix	2	decent	Last Available: "2018-09"
 9975	dehydrated skewed party balloon	1		Effect: "Low on the Hog", Effect Duration: 50, Last Available: "2018-09"
 9976	knitted party pants of the brazier	0		Hot Spell Damage: +25, Cold Resistance: +3, Last Available: "2018-09"
 9977	aromatic wool party whip of the businessman	0		Cold Resistance: +1, Stench Resistance: +1, Meat Drop: +50, Last Available: "2018-09"
 9978	lime green Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	triple-distilled artisanal special TRIO cup of beer	6	EPIC	Effect: "Liquidy Smoky", Effect Duration: 10, Last Available: "2018-09"
+9979	artisanal triple-distilled special TRIO cup of beer	6	EPIC	Effect: "Liquidy Smoky", Effect Duration: 10, Last Available: "2018-09"
 9980	immense moldy party platter for one	10	crappy	Last Available: "2018-09"
 9981	pickled huge Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	gray party pup	0		Last Available: "2018-09"
@@ -9878,7 +9878,7 @@
 10012	perfectly mixed bottle of vodka	3	EPIC	Last Available: "2018-11"
 10013	flavorless blinking pizza	3	decent	Last Available: "2018-11"
 10014	bad blue martini	3	decent	Last Available: "2018-11"
-10015	half-sized rotten cherry pie	2	crappy	Last Available: "2018-11"
+10015	rotten half-sized cherry pie	2	crappy	Last Available: "2018-11"
 10016	distilled acceptable eggnog	5	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	special adequate Hell ramen	4	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 30, Last Available: "2018-11"
@@ -9903,19 +9903,19 @@
 10037	maroon plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	normal jumbo ghostly grilled mooseflank	5	good	Last Available: "2018-12"
-10040	adequate tiny moosemeat pie	1	good	Last Available: "2018-12"
+10040	tiny adequate moosemeat pie	1	good	Last Available: "2018-12"
 10041	blurry balanced antler of bravery	0		Spooky Resistance: +5, Last Available: "2018-12"
 10042	lime green friendly dam	0		Familiar Weight: +3, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted beavermouth	4	EPIC	Last Available: "2018-12"
 10044	delicious beaver punch (papaya)	3	awesome	Last Available: "2018-12"
 10045	artisanal beaver punch (peach)	3	EPIC	Last Available: "2018-12"
-10046	bad high-proof spinning pulsating beaver punch (cherry)	8	decent	Last Available: "2018-12"
+10046	bad high-proof pulsating spinning beaver punch (cherry)	8	decent	Last Available: "2018-12"
 10047	tumbling fireproof personal trainer's Canadian lantern	0		Experience Percent (Muscle): +10, Hot Resistance: +3, Last Available: "2018-12"
 10048	toasty muskox-skin cap	0		Hot Damage: +5, Last Available: "2018-12"
 10049	wobbly Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	toothsome glass of raw eggs	3	awesome	Last Available: "2018-12"
 10051	acceptable punch-drunk punch	3	good	Last Available: "2018-12"
-10052	boiled squat mirror body spradium	1		Last Available: "2018-12"
+10052	boiled mirror squat body spradium	1		Last Available: "2018-12"
 10053	bauxite beret of chilblains	0		Cold Damage: +25, Last Available: "2018-12"
 10054	stiffened bauxite boxers	0		Damage Reduction: 1, Last Available: "2018-12"
 10055	twirling frightening bauxite bow-tie	0		Spooky Damage: +5, Single Equip, Last Available: "2018-12"
@@ -9923,7 +9923,7 @@
 10057	ghostly Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	bouncing family-friendly wholesome fortified arcane researcher's Kramco Sausage-o-Matic&trade; of Calamity Jane	0		Experience Percent (Mysticality): +10, Damage Absorption: +60, Maximum HP Percent: +10, Critical Hit Percent: +15, Sleaze Resistance: +1, Last Available: "2019-01"
 10059	bouncing sausage casing	0		Last Available: "2019-01"
-10060	decent super-sized sausage	5	good	Last Available: "2019-01"
+10060	super-sized decent sausage	5	good	Last Available: "2019-01"
 10061	jittery prompt Usain Bolt's red-hot sausage fork	0		Initiative: +80, Adventures: +3, Last Available: "2019-01"
 10062	squat bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
@@ -9931,7 +9931,7 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	acceptable beer	3	good	Last Available: "2018-12"
 10067	adequate yule gruel	3	good	Last Available: "2018-12"
-10068	weak special bad hot watered rum	2	decent	Effect: "Rave Nirvana", Effect Duration: 15, Last Available: "2018-12"
+10068	special bad weak hot watered rum	2	decent	Effect: "Rave Nirvana", Effect Duration: 15, Last Available: "2018-12"
 10069	tolerable mirror bottle of Crimbognac	3	good	Last Available: "2018-12"
 10070	bland gigantic bouncing Crimboysters Rockefeller	7	decent	Last Available: "2018-12"
 10071	vaporized Crimbeau de toilette	1		Effect: "Patent Prevention", Effect Duration: 45, Last Available: "2018-12"
@@ -9939,7 +9939,7 @@
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	shaking Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10076	blurry blue Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10076	blue blurry Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	narrow Sinatra's beefy Crimbolex watch of the sewer	0		Muscle: +10, Experience (Moxie): +5, Stench Damage: +25, Single Equip, Last Available: "2018-12"
@@ -9967,7 +9967,7 @@
 10101	pendant of Gandalf of the sweet-tooth	0		Spell Critical Percent: +20, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10102	bouncing pulsating veiny palazzos of the boozehound	0		Maximum HP: +10, Booze Drop: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10103	Usain Bolt's ribald pseudoaccordion	0		Sleaze Damage: +10, Initiative: +80, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10104	altered mirror gray blurry pieces	1		Last Available: "2020-12"
+10104	altered gray blurry mirror pieces	1		Last Available: "2020-12"
 10105	non-alkaline denatured Para-Pop	0		Effect: "Phairly Balanced", Effect Duration: 11
 10106	squat toasty Fonzie's terra cotta truss	0		Experience (Moxie): +1, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10107	reassuring Tesla terra cotta trousers	0		Spooky Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
@@ -10007,21 +10007,21 @@
 10141	flagstone fez of the pedagogue of the cheetah	0		Experience: +3, Initiative: +60, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	family-friendly Jim Carey's flagstone fleece	0		Monster Level: +25, Sleaze Resistance: +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	blurry foul-smelling weightlifter's flagstone fringe	0		Muscle: +15, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	dehydrated blinking squat flagstone flagments	1		Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2022-12"
+10144	dehydrated squat blinking flagstone flagments	1		Effect: "Thick, Sick", Effect Duration: 40, Last Available: "2022-12"
 10145	altered alkaline bouncing Flag by the Foot&trade;	0		Effect: "Tiki Temerity", Effect Duration: 38
 10146	shaking elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
 10148	stylish cobbled-together Meat detector	0		Moxie: +25, Lasts Until Rollover, Last Available: "2019-12"
-10149	corrupted blinking tumbling tin thermos of chai	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 43, Last Available: "2019-12"
+10149	corrupted tumbling blinking tin thermos of chai	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 43, Last Available: "2019-12"
 10150	pickled cyan prototype stimulant	1		Effect: "Punchy, Murdery", Effect Duration: 35, Last Available: "2019-12"
 10151	rock-hard tailored vest	0		Damage Reduction: 5, Lasts Until Rollover, Last Available: "2019-12"
 10152	upside-down sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	occult elf army poncho	0		Spell Damage Percent: +25, Lasts Until Rollover, Last Available: "2019-12"
-10155	normal fancy gigantic elf army field rations	7	good	Effect: "Ripping, Dripping", Effect Duration: 35, Last Available: "2019-12"
+10155	gigantic fancy normal elf army field rations	7	good	Effect: "Ripping, Dripping", Effect Duration: 35, Last Available: "2019-12"
 10156	wobbly gingernade	0		Last Available: "2019-12"
 10157	nippy supercool discarded bowtie	0		Moxie Percent: +20, Cold Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
-10158	artisanal weak red jittery martiny	2	EPIC	Last Available: "2019-12"
+10158	weak artisanal red jittery martiny	2	EPIC	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	extra-energized licorice snake	0		Effect: "Weird Flavor", Effect Duration: 61
 10161	polarized pickled upside-down virgin jello shot	0		Effect: "Neutered Nostrils", Effect Duration: 47
@@ -10035,12 +10035,12 @@
 10170	smooth lime green bottle of Sanguiovese	4	awesome	
 10171	normal actual blood sausage	3	good	
 10172	smooth mulled blood	4	awesome	
-10173	adequate enchanted half-sized blood snowcone	2	good	Effect: "Bells in the Batfry", Effect Duration: 5
+10173	half-sized adequate enchanted blood snowcone	2	good	Effect: "Bells in the Batfry", Effect Duration: 5
 10174	perfectly mixed Red Russian	4	EPIC	
 10175	flavorless blood roll-up	4	decent	
 10176	perfectly mixed bottle of blood	4	EPIC	
-10177	normal big blood-soaked sponge cake	5	good	
-10178	artisanal practically non-alcoholic vampagne	1	super ultra mega turbo EPIC	
+10177	big normal blood-soaked sponge cake	5	good	
+10178	practically non-alcoholic artisanal vampagne	1	super ultra mega turbo EPIC	
 10179	adequate plain snowcone	4	good	
 10180	jittery Booke of Vampyric Knowledge	0		
 10181	money bag	0		
@@ -10050,7 +10050,7 @@
 10185	bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
-10188	huge tumbling PirateRealm guest pass	0		Last Available: "2019-04"
+10188	tumbling huge PirateRealm guest pass	0		Last Available: "2019-04"
 10189	blurry upside-down avaricious Tesla PirateRealm eyepatch of the cheetah	0		Meat Drop: +30, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-04"
 10190	bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	tumbling compass	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10065,7 +10065,7 @@
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	mediocre bottle of dark rhum	4	decent	Last Available: "2019-04"
 10202	delicious bottle of extra-dark rhum	3	awesome	Last Available: "2019-04"
-10203	hand-crafted distilled bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
+10203	distilled hand-crafted bottle of super-extra-dark rhum	5	EPIC	Last Available: "2019-04"
 10204	alkaline pulsating yellow pirate shaving cream	0		Effect: "Weird Flavor", Effect Duration: 20, Last Available: "2019-04"
 10205	mirror lion tamer's conquistador's breastplate of the bloodbag	0		Maximum HP: +100, Experience (familiar): +2, Last Available: "2019-04"
 10206	ghostly foul-smelling rock-hard pirate pantaloons	0		Damage Reduction: 5, Stench Damage: +10, Last Available: "2019-04"
@@ -10078,7 +10078,7 @@
 10213	decent half-sized hibiscus petal	2	good	Last Available: "2019-04"
 10214	improved double-cold-filtered upside-down huge mint leaf	0		Effect: "Fungal Flambé", Effect Duration: 14, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
-10216	denatured huge pulsating ice molecule	1		Last Available: "2019-04"
+10216	denatured pulsating huge ice molecule	1		Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
@@ -10094,14 +10094,14 @@
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	supercool piratical blunderbuss of the boozehound	0		Moxie Percent: +20, Booze Drop: +100, Last Available: "2019-04"
 10231	slick PirateRealm party hat of Tarzan of the bloodbag	0		Moxie: +10, Experience (Muscle): +3, Maximum HP: +100, Last Available: "2019-04"
-10232	artisanal practically non-alcoholic Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
-10233	practically non-alcoholic smooth Island Thunderstorm	1	awesome	Last Available: "2019-04"
+10232	practically non-alcoholic artisanal Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10233	smooth practically non-alcoholic Island Thunderstorm	1	awesome	Last Available: "2019-04"
 10234	acceptable Island Hurricane	4	good	Last Available: "2019-04"
 10235	perfectly mixed Skull Punch	3	EPIC	Last Available: "2019-04"
-10236	watered-down tolerable Electric Punch	2	good	Last Available: "2019-04"
+10236	tolerable watered-down Electric Punch	2	good	Last Available: "2019-04"
 10237	mediocre Smuggler's Punch	4	decent	Last Available: "2019-04"
 10238	tolerable watered-down narrow Scorpion Bowl	2	good	Last Available: "2019-04"
-10239	fancy watered-down tolerable Turtle Bowl	2	good	Effect: "I See Everything Thrice!", Effect Duration: 15, Last Available: "2019-04"
+10239	tolerable fancy watered-down Turtle Bowl	2	good	Effect: "I See Everything Thrice!", Effect Duration: 15, Last Available: "2019-04"
 10240	practically non-alcoholic tolerable spinning Cobra Bowl	1	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	prompt ribald brawny vampyric cloake of courage of the cheetah	0		Muscle Percent: +20, Sleaze Damage: +10, Spooky Resistance: +3, Initiative: +60, Adventures: +3, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
@@ -10118,14 +10118,14 @@
 10253	Thwaitgold nymph statuette	0		
 10254	up-at-dawn avaricious aromatic ribald horrifying lion tamer's energetic hardy healthy hewn moon-rune spoon of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP Percent: +20, Maximum HP: 150, Maximum MP Percent: +20, Experience (familiar): +2, Spooky Damage: +25, Sleaze Damage: +10, Stench Resistance: +1, Meat Drop: +30, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
-10256	wobbly squat fuchsia rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
+10256	wobbly fuchsia squat rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	cyan Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	bouncing bouncing hardened padded dance instructor's Beach Comb	0		Experience Percent (Moxie): +10, Damage Absorption: +20, Damage Reduction: 3, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	bouncing grain of sand	0		Last Available: "2019-07"
 10260	wobbly small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	wobbly skewed pile of sand	0		Last Available: "2019-07"
-10263	jittery narrow empty hourglass	0		Last Available: "2019-07"
+10263	narrow jittery empty hourglass	0		Last Available: "2019-07"
 10264	maroon hourglass	0		Last Available: "2019-07"
 10265	etched hourglass	0		Last Available: "2019-07"
 10266	frozen corrupted vacuum-sealed pulsating magenta seashell	0		Effect: "init.enh", Effect Duration: 44, Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	diffused pickled seashell	0		Effect: "Dwarven Hardiness", Effect Duration: 37, Last Available: "2019-07"
 10270	adjusted vacuum-sealed pulsating green seashell	0		Effect: "Sugary Tongue", Effect Duration: 64, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	acceptable irresponsibly strong bottle of sea wine	7	good	Last Available: "2019-07"
+10272	irresponsibly strong acceptable bottle of sea wine	7	good	Last Available: "2019-07"
 10273	twisted kelp	1		Effect: "Just Aged Enough", Effect Duration: 50, Last Available: "2019-07"
 10274	executive asbestos-lined flame-retardant knitted MacGyver's energetic quilted Herculean savvy driftwood hat	0		Mysticality Percent: +20, Experience (Muscle): +1, Damage Absorption: +40, Maximum MP Percent: +20, Maximum MP: +100, Cold Resistance: +3, Hot Resistance: 6, Meat Drop: +40, Lasts Until Rollover, Last Available: "2019-07"
 10275	zippy nippy sharpshooter's steel-toed boxer's strapping driftwood pants of the cougar of James Dean of the businessman	0		Muscle: +5, Moxie: +20, Muscle Percent: +10, Experience (Moxie): +3, Damage Reduction: 9, Critical Hit Percent: +10, Cold Damage: +10, Meat Drop: +50, Initiative: +20, Lasts Until Rollover, Last Available: "2019-07"
@@ -10151,11 +10151,11 @@
 10286	narrow Jim Carey's thinker's meteorite earring of temperance	0		Mysticality: +10, Monster Level: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2019-07"
 10287	gray medical-grade deadly meteorite necklace of the sewer	0		Weapon Damage: +5, Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2019-07"
 10288	jittery Sherlock's rock-hard meteorite ring of extreme caution	0		Damage Reduction: 5, Monster Level: -25, Item Drop: +25, Single Equip, Last Available: "2019-07"
-10289	super-corrupted blinking purple Finnish Fish	0		Effect: "Rain Dancin'", Effect Duration: 67
+10289	super-corrupted purple blinking Finnish Fish	0		Effect: "Rain Dancin'", Effect Duration: 67
 10290	aerosolized olive chocolate doubloon	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 14
 10291	lion tamer's dangerous brawny driftwood beach comb	0		Muscle Percent: +20, Weapon Damage: +10, Experience (familiar): +2, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	mirror Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
-10293	cyan blurry stick of firewood	0		Last Available: "2019-08"
+10293	blurry cyan stick of firewood	0		Last Available: "2019-08"
 10294	flame-retardant nasty groovy whittled tiara	0		Moxie Percent: +10, Stench Damage: +5, Hot Resistance: +1, Last Available: "2019-08"
 10295	executive medical-grade experienced whittled shorts	0		Experience: +2, Meat Drop: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-08"
 10296	hardy quilted baleful whittled flail	0		Spell Damage: +25, Damage Absorption: +40, Maximum HP: +50, Last Available: "2019-08"
@@ -10166,7 +10166,7 @@
 10301	blurry blinking lard-coated whittled fox figurine of vim and vigor of the brazier	0		Maximum HP Percent: +50, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip, Last Available: "2019-08"
 10302	scorching chilly curative whittled walking stick of the pedagogue	0		Experience: +3, Cold Damage: +5, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-08"
 10303	delicious special campfire hot dog	4	awesome	Effect: "Expert Vacationer", Effect Duration: 40, Last Available: "2019-08"
-10304	delicious thick pulsating campfire baked potato	5	awesome	Last Available: "2019-08"
+10304	thick delicious pulsating campfire baked potato	5	awesome	Last Available: "2019-08"
 10305	big bland campfire s'more	5	decent	Last Available: "2019-08"
 10306	yummy campfire beans	3	awesome	Last Available: "2019-08"
 10307	flavorless wobbly campfire stew	4	decent	Last Available: "2019-08"
@@ -10201,11 +10201,11 @@
 10342	plastic yuleviathan of terror	0		Spooky Spell Damage: +10, Last Available: "2019-12"
 10343	cyan fireproof plastic dolphin &quot;orphan&quot;	0		Hot Resistance: +3, Single Equip, Last Available: "2019-12"
 10344	scandalous plastic Dolph Bossin	0		Sleaze Damage: +5, Last Available: "2019-12"
-10345	narrow fuchsia red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
+10345	fuchsia narrow red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	special moldy mana-coated yams	4	crappy	Effect: "Favored by Lyle", Effect Duration: 35, Last Available: "2019-11"
-10347	special gigantic adequate twirling mana-basted tofurkey leg	7	good	Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2019-11"
-10348	fancy stale bite-sized mana-fortified cranberry sauce	1	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35, Last Available: "2019-11"
-10349	tiny enchanted spoiled maroon mana-stuffed herbal stuffing	1	crappy	Effect: "Burnt 'n' Turnt", Effect Duration: 45, Last Available: "2019-11"
+10347	gigantic special adequate twirling mana-basted tofurkey leg	7	good	Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2019-11"
+10348	bite-sized stale fancy mana-fortified cranberry sauce	1	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35, Last Available: "2019-11"
+10349	enchanted tiny spoiled maroon mana-stuffed herbal stuffing	1	crappy	Effect: "Burnt 'n' Turnt", Effect Duration: 45, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	colloidal triple-dry upside-down patch of extra-warm fur	0		Effect: "Phorcefullness", Effect Duration: 14, Last Available: "2019-12"
 10352	dehydrated industrial lubricant	1		Last Available: "2019-12"
@@ -10214,7 +10214,7 @@
 10355	mixed ghostly a bug's lymph	1		Last Available: "2019-12"
 10356	unsweetened organic potpourri	0		Effect: "Wreathed in Smoke", Effect Duration: 38, Last Available: "2019-12"
 10357	bad boot flask	4	decent	Last Available: "2019-12"
-10358	alkaline teal huge infernal snowball	0		Effect: "Starry-Eyed", Effect Duration: 62, Last Available: "2019-12"
+10358	alkaline huge teal infernal snowball	0		Effect: "Starry-Eyed", Effect Duration: 62, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	denatured mirror fish sauce	1		Last Available: "2019-12"
 10361	spoiled miniature guffin	2	crappy	Last Available: "2019-12"
@@ -10255,7 +10255,7 @@
 10396	tumbling tinsel fin	0		Familiar Weight: +5
 10397	bland bowl of mernudo	3	decent	Last Available: "2019-12"
 10398	practically non-alcoholic artisanal fishelada	1	super ultra EPIC	Last Available: "2019-12"
-10399	diet special normal ojo de pez burrito	1	good	Effect: "Just Aged Enough", Effect Duration: 40, Last Available: "2019-12"
+10399	normal diet special ojo de pez burrito	1	good	Effect: "Just Aged Enough", Effect Duration: 40, Last Available: "2019-12"
 10400	wobbly fuchsia waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	blurry waterlogged stuffing	0		Last Available: "2019-12"
@@ -10284,7 +10284,7 @@
 10425	bland tempura and bean	4	decent	Last Available: "2019-12"
 10426	hand-crafted huge salt plum sake	4	EPIC	Last Available: "2019-12"
 10427	magnetized corrupted triple-flattened shaking pressurized potion of possessiveness	0		Effect: "Jingle Jangle Jingle", Effect Duration: 58, Last Available: "2019-12"
-10428	enhanced purple twirling almond	0		Effect: "Celestial Sheen", Effect Duration: 61
+10428	enhanced twirling purple almond	0		Effect: "Celestial Sheen", Effect Duration: 61
 10429	irradiated moist anodized skewed handful of mixed nuts	0		Effect: "Heal Thy Nanoself", Effect Duration: 59, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
@@ -10294,7 +10294,7 @@
 10437	bouncing mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	prompt electrified therapeutic Powerful Glove of the cougar of the cheetah	0		Moxie: +20, Initiative: +60, Adventures: +3, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	purple enhanced signal receiver	0		
-10440	green bouncing status cymbal	0		Last Available: "2020-02"
+10440	bouncing green status cymbal	0		Last Available: "2020-02"
 10441	Jim Carey's Sinatra's Drip harness of the detective	0		Experience (Moxie): +5, Monster Level: +25, Item Drop: +20
 10442	cyan drippy truncheon of the scaredy-cat	0		Monster Level: -15, Single Equip
 10443	Driplet	0		
@@ -10312,7 +10312,7 @@
 10455	ghostly mushroom	0		
 10456	deluxe mushroom	0		
 10457	super deluxe mushroom	0		
-10458	adjusted huge ghostly blinking fizzy soda	0		Effect: "Rootin' Around", Effect Duration: 43
+10458	adjusted ghostly blinking huge fizzy soda	0		Effect: "Rootin' Around", Effect Duration: 43
 10459	electrified healthy juice	0		Effect: "Turtle Power", Effect Duration: 55
 10460	hammer	0		
 10461	hammer	0		
@@ -10324,7 +10324,7 @@
 10467	red Jeselnik's back shell of temperance	0		Sleaze Damage: +25, Sleaze Resistance: +5
 10468	spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
-10470	blurry yellow twirling Thwaitgold buzzy beetle statuette	0		
+10470	twirling blurry yellow Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
 10472	toasty bony back shell	0		Hot Damage: +5
 10473	frosty button	0		Single Equip
@@ -10337,16 +10337,16 @@
 10480	rubber baby doll	0		
 10481	upside-down Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
-10483	twirling tumbling free-range mushroom	0		Last Available: "2020-03"
+10483	tumbling twirling free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	tumbling free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	jittery pulsating colossal free-range mushroom	0		Last Available: "2020-03"
-10489	massive decent pulsating mushroom filet	6	good	Last Available: "2020-03"
+10489	decent massive pulsating mushroom filet	6	good	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	diluted huge mushroom tea	1		Last Available: "2020-03"
-10492	smooth watered-down mushroom whiskey	2	awesome	Last Available: "2020-03"
+10492	watered-down smooth mushroom whiskey	2	awesome	Last Available: "2020-03"
 10493	censurious chilly slick mushroom cap	0		Moxie: +10, Cold Damage: +5, Sleaze Resistance: +3, Last Available: "2020-03"
 10494	lightning-fast nasty razor-sharp mushroom shield of the cougar	0		Moxie: +20, Weapon Damage Percent: +25, Stench Damage: +5, Initiative: +40, Damage Reduction: 6, Last Available: "2020-03"
 10495	flame-wreathed dog trainer's resourceful mushroom pants of the wise owl	0		Mysticality: +20, Maximum MP: +50, Experience (familiar): +1, Hot Spell Damage: +10, Last Available: "2020-03"
@@ -10380,7 +10380,7 @@
 10523	drippy flux	0		
 10524	lime green drippy stein	0		
 10525	weak lousy drippy pilsner	2	drippy	
-10526	skewed red drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
+10526	red skewed drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	lustrous drippy orb	0		
 10530	Sinatra's gory drippy orb	0		Experience (Moxie): +5
@@ -10394,10 +10394,10 @@
 10538	huge Guzzlr pants	0		Last Available: "2020-05"
 10539	spinning wholesome Guzzlr souvenir stein	0		Maximum HP Percent: +10, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	lousy enchanted Ghiaccio Colada	3	decent	Effect: "Rain Dancin'", Effect Duration: 45, Last Available: "2020-05"
+10541	enchanted lousy Ghiaccio Colada	3	decent	Effect: "Rain Dancin'", Effect Duration: 45, Last Available: "2020-05"
 10542	triple-distilled bad fuchsia Sourfinger	10	decent	Last Available: "2020-05"
 10543	perfectly mixed purple Nog-on-the-Cob	4	EPIC	Last Available: "2020-05"
-10544	drinkable skewed blurry Steamboat	4	good	Last Available: "2020-05"
+10544	drinkable blurry skewed Steamboat	4	good	Last Available: "2020-05"
 10545	artisanal blinking Buttery Boy	4	EPIC	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	Jack Frost's weightlifter's clown car key	0		Muscle: +15, Cold Spell Damage: +50, Last Available: "2020-08"
@@ -10487,11 +10487,11 @@
 10631	shaking alabaster rook	0		Last Available: "2020-09"
 10632	yellow alabaster bishop	0		Last Available: "2020-09"
 10633	alabaster knight	0		Last Available: "2020-09"
-10634	blinking wobbly alabaster pawn	0		Last Available: "2020-09"
+10634	wobbly blinking alabaster pawn	0		Last Available: "2020-09"
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	hardy hardened sinister Cargo Cultist Shorts of the boozehound	0		Spell Damage: +10, Damage Reduction: 3, Maximum HP: +50, Booze Drop: +100, Last Available: "2020-09"
 10637	shaking complicated device	0		Last Available: "2020-09"
-10638	bad watered-down flask of moonshine	2	decent	Last Available: "2020-09"
+10638	watered-down bad flask of moonshine	2	decent	Last Available: "2020-09"
 10639	squat prompt therapeutic fortified sea-worn candlestick	0		Damage Absorption: +60, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	alkaline null-day exploit	0		Effect: "Brocolate Brostidigitation", Effect Duration: 16, Last Available: "2025-12"
@@ -10562,7 +10562,7 @@
 10706	blinking pulsating The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	mirror jittery The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
-10709	blue spinning The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
+10709	spinning blue The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10710	The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
@@ -10579,11 +10579,11 @@
 10723	artisanal spinning Boulevardier cocktail	3	EPIC	Last Available: "2020-12"
 10724	adjusted Hotwire&trade; brand candy rope	0		Effect: "Scrappy, Shadowy", Effect Duration: 52, Last Available: "2020-12"
 10725	flavorless bowl full of jelly	3	decent	Last Available: "2020-12"
-10726	triple-distilled acceptable Eye and a Twist	7	good	Last Available: "2020-12"
+10726	acceptable triple-distilled Eye and a Twist	7	good	Last Available: "2020-12"
 10727	improved maroon Chubby and Plump bar	0		Effect: "Crimbo Epiphany", Effect Duration: 66, Last Available: "2020-12"
-10728	blinking blurry digibritches	0		Last Available: "2025-12"
+10728	blurry blinking digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
-10730	lime green spinning crystal ball	0		Initiative: +50, Last Available: "2021-01"
+10730	spinning lime green crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	blue fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
@@ -10597,10 +10597,10 @@
 10741	pickled battery (D)	0		Effect: "Texas Elegance", Effect Duration: 42, Last Available: "2021-03"
 10742	diffused ghostly gray battery (9-Volt)	0		Effect: "Haunted Liver", Effect Duration: 11, Last Available: "2021-03"
 10743	magnetized colloidal battery (lantern)	0		Effect: "Space Cowboy", Effect Duration: 55, Last Available: "2021-03"
-10744	moist bouncing purple battery (car)	0		Effect: "Lemony Goodness", Effect Duration: 34, Last Available: "2021-03"
+10744	moist purple bouncing battery (car)	0		Effect: "Lemony Goodness", Effect Duration: 34, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	skewed marshmallow	0		
-10747	acceptable fortified spinning bouncing marshmallow bomb	5	good	Last Available: "2021-03"
+10747	fortified acceptable bouncing spinning marshmallow bomb	5	good	Last Available: "2021-03"
 10748	skewed packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10614,7 +10614,7 @@
 10758	twirling quantum of familiar	0		
 10759	perfumed familiar scrapbook of the bloodbag	0		Maximum HP: +100, Stench Resistance: +5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
-10761	jittery narrow clan underground fireworks shop	0		Last Available: "2021-07"
+10761	narrow jittery clan underground fireworks shop	0		Last Available: "2021-07"
 10762	censurious ribald nippy fedora-mounted fountain	0		Cold Damage: +10, Sleaze Damage: +10, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2021-07"
 10763	mirror lard-coated nasty banded sombrero-mounted sparkler	0		Damage Absorption: +100, Stench Damage: +5, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
 10764	hale brawny porkpie-mounted popper of the cheetah	0		Muscle Percent: +20, Maximum HP: +20, Initiative: +60, Lasts Until Rollover, Last Available: "2021-07"
@@ -10672,7 +10672,7 @@
 10816	gray Jack Frost's coward's padded ice crown	0		Damage Absorption: +20, Monster Level: -20, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-12"
 10817	frightening cool jeans of wisdom	0		Mysticality: +15, Moxie: +5, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2021-12"
 10818	huge auspicious hale ice wrap of the cheetah	0		Maximum HP: +20, Item Drop: +10, Initiative: +60, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	normal diet tofu pop	1	good	Last Available: "2021-12"
+10819	diet normal tofu pop	1	good	Last Available: "2021-12"
 10820	spoiled jittery bowl of prescription candy	4	crappy	Last Available: "2021-12"
 10821	decent fishcake	3	good	Last Available: "2021-12"
 10822	stale bone broth	3	decent	Last Available: "2021-12"
@@ -10728,7 +10728,7 @@
 10872	pants of the scaredy-cat	0		Monster Level: -15, Last Available: "2021-12"
 10873	razor-sharp Da Vinci's can of mixed everything of the sweet-tooth	0		Experience (Mysticality): +5, Weapon Damage Percent: +25, Candy Drop: +100, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
-10875	shaking tumbling the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10875	tumbling shaking the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	toothsome meatball	3	awesome	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
@@ -10739,9 +10739,9 @@
 10883	distilled blurry astral energy drink	1		Effect: "Full of Vinegar", Effect Duration: 10
 10884	squat mint condition magnifying glass	0		Last Available: "2022-12"
 10885	blue upside-down avaricious chilly friendly magnifying glass	0		Familiar Weight: +3, Cold Damage: +5, Meat Drop: +30, Last Available: "2022-12"
-10886	practically non-alcoholic aged void lager	1	awesome	Last Available: "2022-12"
-10887	huge decent void burger	10	good	Last Available: "2022-12"
-10888	purple twirling void stone	0		Last Available: "2022-12"
+10886	aged practically non-alcoholic void lager	1	awesome	Last Available: "2022-12"
+10887	decent huge void burger	10	good	Last Available: "2022-12"
+10888	twirling purple void stone	0		Last Available: "2022-12"
 10889	zippy ruddy banded void shard of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Maximum HP Percent: +40, Initiative: +20, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	cosmic bowling ball	0		Last Available: "2022-01"
@@ -10777,7 +10777,7 @@
 10921	artisanal teal Dad's brandy	3	EPIC	Last Available: "2022-06"
 10922	greasy sinister teacher's pen	0		Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2022-06"
 10923	tasty huge fire-roasted lake trout	9	awesome	Last Available: "2022-06"
-10924	adequate immense guilty sprout	7	good	Last Available: "2022-06"
+10924	immense adequate guilty sprout	7	good	Last Available: "2022-06"
 10925	frightening mother's necklace of the cheetah	0		Spooky Damage: +5, Initiative: +60, Last Available: "2022-06"
 10926	oxidized extra-magnetized ionized trampled ticket stub	0		Effect: "Always be Collecting", Effect Duration: 27, Last Available: "2022-06"
 10927	colloidal savings bond	0		Effect: "Christmessy", Effect Duration: 16, Last Available: "2022-06"
@@ -10809,10 +10809,10 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	colloidal ionized bouncing autumn leaf	0		Effect: "Leo Rising", Effect Duration: 67, Last Available: "2022-10"
-10956	practically non-alcoholic mediocre AutumnFest ale	1	decent	Last Available: "2022-10"
+10956	mediocre practically non-alcoholic AutumnFest ale	1	decent	Last Available: "2022-10"
 10957	inspector's Jim Carey's grievous autumn sweater-weather sweater	0		Weapon Damage Percent: +50, Monster Level: +25, Item Drop: +15, Lasts Until Rollover, Last Available: "2022-10"
 10958	spinning frightening Temple Grandin's electrified medical-grade autumn debris shield	0		Familiar Weight: +7, Spooky Damage: +5, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	normal big cyan autumn-spice donut	5	good	Last Available: "2022-10"
+10959	big normal cyan autumn-spice donut	5	good	Last Available: "2022-10"
 10960	boiled blurry autumn dollar	0		Effect: "Dance Interpreter", Effect Duration: 62, Last Available: "2022-10"
 10961	jittery sizzling frosty shellacked autumn leaf pendant	0		Damage Reduction: 7, Cold Spell Damage: +10, Hot Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
 10962	compressed cyan autumn breeze	1		Last Available: "2022-10"
@@ -10823,37 +10823,37 @@
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	blurry St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	diet delicious ratatouille de Jarlsberg	1	awesome	Last Available: "2022-11"
-10971	fancy flavorless Jarlsberg's vegetable soup	3	decent	Effect: "Pumped Stomach", Effect Duration: 10, Last Available: "2022-11"
+10970	delicious diet ratatouille de Jarlsberg	1	awesome	Last Available: "2022-11"
+10971	flavorless fancy Jarlsberg's vegetable soup	3	decent	Effect: "Pumped Stomach", Effect Duration: 10, Last Available: "2022-11"
 10972	toothsome roasted vegetable of Jarlsberg	4	awesome	Last Available: "2022-11"
 10973	flavorless pulsating St. Pete's sneaky smoothie	3	decent	Last Available: "2022-11"
 10974	diet rotten teal Pete's wiley whey bar	1	crappy	Last Available: "2022-11"
-10975	super-sized moldy Pete's rich ricotta	5	crappy	Last Available: "2022-11"
+10975	moldy super-sized Pete's rich ricotta	5	crappy	Last Available: "2022-11"
 10976	artisanal Boris's beer	3	EPIC	Last Available: "2022-11"
 10977	jumbo flavorless shaking honey bun of Boris	5	decent	Last Available: "2022-11"
 10978	snack-sized rotten Boris's bread	2	crappy	Last Available: "2022-11"
-10979	fuchsia Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	twirling Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	green Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	cyan Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	squat Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	fuchsia Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	twirling Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	green Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	cyan Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	squat Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	stale baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
 10989	rotten plain calzone	4	crappy	Last Available: "2022-11"
 10990	spoiled blurry roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	stale Pizza of Legend	4	decent	Last Available: "2022-11"
 10992	decent Calzone of Legend	3	good	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	immense normal Deep Dish of Legend	7	good	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	normal immense Deep Dish of Legend	7	good	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	skewed drink chit	0		
 11003	twirling government per-diem	0		
@@ -10867,11 +10867,11 @@
 11011	tumbling occult gator shades of horror	0		Spell Damage Percent: +25, Spooky Spell Damage: +25, Single Equip
 11012	milk cap	0		
 11013	smooth red Charleston Choo-Choo	3	awesome	
-11014	watered-down artisanal fancy Velvet Veil	2	EPIC	Effect: "Surreally Buff", Effect Duration: 35
-11015	acceptable irresponsibly strong fuchsia Marltini	10	good	
+11014	watered-down fancy artisanal Velvet Veil	2	EPIC	Effect: "Surreally Buff", Effect Duration: 35
+11015	irresponsibly strong acceptable fuchsia Marltini	10	good	
 11016	mediocre tumbling Strong, Silent Type	3	decent	
 11017	mediocre Mysterious Stranger	3	decent	
-11018	practically non-alcoholic mediocre Champagne Shimmy	1	decent	
+11018	mediocre practically non-alcoholic Champagne Shimmy	1	decent	
 11019	the Sot's parcel	0		
 11020	coward's ceramic cestus of wisdom	0		Mysticality: +15, Monster Level: -20, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
 11021	gravedigger's lion tamer's vibrating ceramic centurion shield	0		Maximum MP Percent: +10, Experience (familiar): +2, Spooky Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
@@ -10891,7 +10891,7 @@
 11035	polymerized teal chiffon lemon	0		Effect: "Slimed Stomach", Effect Duration: 55
 11036	immense tasty chocomotive	10	awesome	Last Available: "2022-12"
 11037	spoiled freightcake	3	crappy	Last Available: "2022-12"
-11038	mediocre high-proof yellow blurry cabooze	10	decent	Last Available: "2022-12"
+11038	mediocre high-proof blurry yellow cabooze	10	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	spinning jittery groovy plastic passenger car	0		Moxie Percent: +10, Last Available: "2022-12"
 11041	reassuring plastic dining car	0		Spooky Resistance: +1, Last Available: "2022-12"
@@ -10920,24 +10920,24 @@
 11064	skewed smelly deadly slick shoulder-mounted Trainbot	0		Moxie: +10, Weapon Damage: +5, Stench Spell Damage: +10, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	practically non-alcoholic bad maroon dregs of a Crimbo cocktail	1	decent	
+11067	bad practically non-alcoholic maroon dregs of a Crimbo cocktail	1	decent	
 11068	lost elf luggage	0		
 11069	jittery Trainbot luggage hook	0		Single Equip
-11070	gigantic bland honey-drenched ham slice	10	decent	
-11071	weak bad mostly-empty bottle of cookie wine	2	decent	
+11070	bland gigantic honey-drenched ham slice	10	decent	
+11071	bad weak mostly-empty bottle of cookie wine	2	decent	
 11072	moldy Crimbo food scraps	4	crappy	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	red table-scraper	0		Single Equip
 11076	blue Trainbot slag	0		
-11077	squat narrow pulsating industrially-crushed ice	0		Last Available: "2022-12"
-11078	moldy snack-sized special cyan steamed oyster	2	crappy	Effect: "Biologically Shocked", Effect Duration: 15
+11077	pulsating narrow squat industrially-crushed ice	0		Last Available: "2022-12"
+11078	moldy special snack-sized cyan steamed oyster	2	crappy	Effect: "Biologically Shocked", Effect Duration: 15
 11079	narrow really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	weak enchanted delicious Crimbosmopolitan	2	awesome	Effect: "Frozen Shoulders", Effect Duration: 5, Last Available: "2022-12"
+11084	enchanted delicious weak Crimbosmopolitan	2	awesome	Effect: "Frozen Shoulders", Effect Duration: 5, Last Available: "2022-12"
 11085	half-sized decent Crimbo dinner	2	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	fuchsia train whistle	0		Last Available: "2022-12"
@@ -10972,13 +10972,13 @@
 11117	boiled non-wet glob of extra-green chlorophyll	0		Effect: "Dexteri Tea", Effect Duration: 63, Last Available: "2023-02"
 11118	chilled pressed mushroom	0		Effect: "Reptilian Fortitude", Effect Duration: 17, Last Available: "2023-02"
 11119	frozen enhanced five-fingered fern resin	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 19, Last Available: "2023-02"
-11120	adequate gigantic super good fruit	10	good	Last Available: "2023-02"
+11120	gigantic adequate super good fruit	10	good	Last Available: "2023-02"
 11121	dried energized spores	1		Last Available: "2023-02"
-11122	yellow dog trainer's Van der Graaf hot pepper	0		Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-02", Lantern Element: "Hot"
-11123	Vulcanized modified adjusted wobbly yellow out-of-work circus flea	0		Effect: "Natural 20", Effect Duration: 66, Last Available: "2023-02"
+11122	yellow dog trainer's Van der Graaf hot pepper	0		Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Lantern Element: "Hot", Last Available: "2023-02"
+11123	Vulcanized modified adjusted yellow wobbly out-of-work circus flea	0		Effect: "Natural 20", Effect Duration: 66, Last Available: "2023-02"
 11124	bouncing extra-grubby grub	0		Last Available: "2023-02"
 11125	Vulcanized anodized fire ant pheromones	0		Effect: "Flame-Retardant Trousers", Effect Duration: 38, Last Available: "2023-02"
-11126	deionized denatured blinking blue flapper fly	0		Effect: "Egg on your Face", Effect Duration: 54, Last Available: "2023-02"
+11126	deionized denatured blue blinking flapper fly	0		Effect: "Egg on your Face", Effect Duration: 54, Last Available: "2023-02"
 11127	tolerable shot of wasp venom	4	good	Last Available: "2023-02"
 11128	activated filled mosquito	0		Effect: "Bilious Brains", Effect Duration: 25, Last Available: "2023-02"
 11129	energized tumbling spinning shim of shame shale	0		Effect: "Elemental Mastery", Effect Duration: 16, Last Available: "2023-02"
@@ -10989,8 +10989,8 @@
 11134	chilled lump of loyal latite	0		Effect: "Hippy Flavor", Effect Duration: 40, Last Available: "2023-02"
 11135	rotten blurry green shadow sausage	4	crappy	Last Available: "2023-03"
 11136	skewed foul-smelling hardy shadow skin	0		Maximum HP: +50, Stench Damage: +10, Last Available: "2023-03"
-11137	quadruple-boiled enhanced denatured bouncing jittery shadow flame	0		Effect: "Full Bottle in front of Me", Effect Duration: 56, Last Available: "2023-03"
-11138	small enchanted spoiled shadow bread	2	crappy	Effect: "Steroid Boost", Effect Duration: 35, Last Available: "2023-03"
+11137	quadruple-boiled enhanced denatured jittery bouncing shadow flame	0		Effect: "Full Bottle in front of Me", Effect Duration: 56, Last Available: "2023-03"
+11138	spoiled small enchanted shadow bread	2	crappy	Effect: "Steroid Boost", Effect Duration: 35, Last Available: "2023-03"
 11139	upside-down shadow ice	0		Last Available: "2023-03"
 11140	delicious shadow fluid	3	awesome	Last Available: "2023-03"
 11141	upside-down shadow glass	0		Last Available: "2023-03"
@@ -11037,7 +11037,7 @@
 11182	flavorless spinning shadow hot dog	3	decent	
 11183	tolerable shadow martini	3	good	
 11184	boiled shadow pill	1		Effect: "Bats in the Belfry", Effect Duration: 10
-11185	squat wobbly shadow needle	0		
+11185	wobbly squat shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	triple-tarnished upside-down shadow candy	0		Effect: "Souper Vengeful", Effect Duration: 30
@@ -11070,7 +11070,7 @@
 11215	replica angel	0		
 11216	lion tamer's replica Camp Scout backpack	0		Experience (familiar): +2
 11217	replica deactivated nanobots	0		
-11218	ghostly teal replica Apathargic Bandersnatch	0		
+11218	teal ghostly replica Apathargic Bandersnatch	0		
 11219	replica Smith's Tome	0		
 11220	twirling replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
@@ -11115,9 +11115,9 @@
 11260	upside-down inspector's Jeselnik's pro skateboard	0		Sleaze Damage: +25, Item Drop: +15, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	spinning pulsating Mr. Accessaturday	0		Last Available: "2023-06"
 11262	jittery Meat Butler	0		Last Available: "2023-06"
-11263	maroon blinking Loathing Idol Microphone	0		Last Available: "2023-06"
+11263	blinking maroon Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	tumbling blinking purple Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	blinking purple tumbling Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	jittery flame-wreathed Flash Liquidizer Ultra Dousing Accessory	0		Hot Spell Damage: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	lion tamer's rosy-cheeked sage Amulet of Perpetual Darkness of terror	0		Mysticality Percent: +10, Maximum HP Percent: +30, Experience (familiar): +2, Spooky Spell Damage: +10, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11142,7 +11142,7 @@
 11287	hale rutabuga bag of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20
 11288	upside-down jittery mesquito proboscis of bravery	0		Spooky Resistance: +5
 11289	skewed wholesome senate fly thorax	0		Maximum HP Percent: +10
-11290	enhanced galvanized adjusted spinning blinking bug juice	0		Effect: "Toothy Grin", Effect Duration: 47
+11290	enhanced galvanized adjusted blinking spinning bug juice	0		Effect: "Toothy Grin", Effect Duration: 47
 11291	spider leg of Flo-Jo	0		Initiative: +100
 11292	beetle antenna of temperance	0		Sleaze Resistance: +5
 11293	therapeutic mantis skull	0		HP Regen Min: 5, HP Regen Max: 7
@@ -11168,7 +11168,7 @@
 11313	spinning double-paned flame-wreathed cat o' nine teeth	0		Hot Spell Damage: +10, Cold Resistance: +5
 11314	tumbling curative tooth cap of the glutton	0		Food Drop: +100, HP Regen Min: 3, HP Regen Max: 5
 11315	red crafty brainy toothy trousers	0		Mysticality: +5, Maximum MP: +10
-11316	bland bite-sized banana split	1	decent	
+11316	bite-sized bland banana split	1	decent	
 11317	tumbling handful of toilet paper	0		
 11318	spinning Mrs. Rush	0		
 11319	blinking medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
@@ -11229,7 +11229,7 @@
 11374	Spring Bros. ID badge	0		
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
-11377	wobbly ghostly housekeeping robot	0		
+11377	ghostly wobbly housekeeping robot	0		
 11378	normal pulsating pickled bread	4	good	Last Available: "2023-12"
 11379	spoiled salted mutton	4	crappy	Last Available: "2023-12"
 11380	flavorless corned beet	3	decent	Last Available: "2023-12"
@@ -11253,7 +11253,7 @@
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	skewed upside-down Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	acceptable fancy watered-down Crimbuccaneer mologrog cocktail	2	good	Effect: "Total Protonic Reversal", Effect Duration: 50, Last Available: "2023-12"
+11401	fancy acceptable watered-down Crimbuccaneer mologrog cocktail	2	good	Effect: "Total Protonic Reversal", Effect Duration: 50, Last Available: "2023-12"
 11402	wobbly Elf Army machine parts	0		Last Available: "2023-12"
 11403	blurry Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	huge ribald extremely unsafe Crimbuccaneer lantern of the dark arts	0		Weapon Damage Percent: +100, Spell Damage Percent: +100, Sleaze Damage: +10, Last Available: "2023-12"
@@ -11268,7 +11268,7 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	hardy banded Elf Guard officer's sidearm	0		Damage Absorption: +100, Maximum HP: +50, Last Available: "2023-12"
 11415	mirror gray censurious brawny Elf Guard insignia (general)	0		Muscle Percent: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2023-12"
-11416	high-proof artisanal Crimbow Rainbo	10	EPIC	Last Available: "2023-12"
+11416	artisanal high-proof Crimbow Rainbo	10	EPIC	Last Available: "2023-12"
 11417	tumbling Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	spinning dog trainer's Elf Guard broom of doom	0		Experience (familiar): +1, Spooky Spell Damage: +50, Last Available: "2023-12"
@@ -11279,7 +11279,7 @@
 11424	upside-down prompt curative sawed-off blunderbuss of the scaredy-cat	0		Monster Level: -15, Adventures: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
 11425	aged officer's nog	3	awesome	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	massive decent spinning sundae ration	9	good	Last Available: "2023-12"
+11427	decent massive spinning sundae ration	9	good	Last Available: "2023-12"
 11428	adequate peppermint tack	4	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	tiny spoiled whalesteak	1	crappy	Last Available: "2023-12"
@@ -11318,16 +11318,16 @@
 11463	moldy gingerbread pirate	4	crappy	Last Available: "2023-12"
 11464	moldy fruit-stuffed rumcake	4	crappy	Last Available: "2023-12"
 11465	artisanal fuchsia mulled wine	3	EPIC	Last Available: "2023-12"
-11466	weak tolerable Swedish coffee	2	good	Last Available: "2023-12"
+11466	tolerable weak Swedish coffee	2	good	Last Available: "2023-12"
 11467	practically non-alcoholic artisanal jittery canteen of eggnog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11468	perfectly mixed hot wine	3	EPIC	Last Available: "2023-12"
 11469	artisanal maroon Jamaican coffee	4	EPIC	Last Available: "2023-12"
-11470	lousy enchanted flask of egggrog	3	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 15, Last Available: "2023-12"
+11470	enchanted lousy flask of egggrog	3	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 15, Last Available: "2023-12"
 11471	bouncing narrow Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
-11472	skewed mirror Black and White Apron Meal Kit	0		Last Available: "2024-12"
+11472	mirror skewed Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	lousy yule grog	3	decent	Last Available: "2023-12"
-11475	small spoiled wet tack	2	crappy	Last Available: "2023-12"
+11475	spoiled small wet tack	2	crappy	Last Available: "2023-12"
 11476	adequate red whalecake	3	good	Last Available: "2023-12"
 11477	cyan vibrating fortified sage gunwale whalegun	0		Mysticality Percent: +10, Damage Absorption: +60, Maximum MP Percent: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	aged and claret	4	awesome	Last Available: "2023-12"
@@ -11378,12 +11378,12 @@
 11523	pulsating frightening mansplainer's Fonzie's crepe paper puzzle cube	0		Experience (Moxie): +1, Monster Level: +15, Spooky Damage: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
 11524	squat smelly rosy-cheeked banded crepe paper plunge camisole	0		Damage Absorption: +100, Maximum HP Percent: +30, Stench Spell Damage: +10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
 11525	ghostly gravedigger's energetic crepe paper polka charm of terror	0		Maximum MP Percent: +20, Spooky Damage: +10, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
-11526	altered ghostly mirror crepe paper pared cuttings	1		Last Available: "2025-12"
+11526	altered mirror ghostly crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	vacuum-sealed galvanized unsweetened blurry crepe paper peanut candy	0		Effect: "Hobo Flavor", Effect Duration: 69
 11528	veiny personal trainer's petrified wood war pike	0		Experience Percent (Muscle): +10, Maximum HP: +10, Last Available: "2025-12"
 11529	medical-grade beefy petrified wood waist protector	0		Muscle: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2025-12"
-11530	thinker's petrified wood wizard's pouch of the overflowing toilet	0		Mysticality: +10, Stench Spell Damage: +50, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	rock-hard petrified wood water purifier of the boozehound	0		Damage Reduction: 5, Booze Drop: +100, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	thinker's petrified wood wizard's pouch of the overflowing toilet	0		Mysticality: +10, Stench Spell Damage: +50, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	rock-hard petrified wood water purifier of the boozehound	0		Damage Reduction: 5, Booze Drop: +100, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	banded extremely unsafe petrified wood whoopie panama	0		Weapon Damage Percent: +100, Damage Absorption: +100, Last Available: "2025-12"
 11533	quilted petrified wood walking pants of the storm	0		Damage Absorption: +40, Maximum MP Percent: +40, Last Available: "2025-12"
 11534	dried petrified wood waste parts	1		Effect: "The Two-Prong Crown", Effect Duration: 45, Last Available: "2025-12"
@@ -11411,7 +11411,7 @@
 11556	quick-release fannypack	0		Single Equip
 11557	quick-release utility belt	0		Single Equip
 11558	Jim Carey's motion sensor	0		Monster Level: +25, Single Equip
-11559	narrow mirror focused magnetron pistol	0		Single Equip
+11559	mirror narrow focused magnetron pistol	0		Single Equip
 11560	packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	inspector's padded Everfull Dart Holster	0		Damage Absorption: +20, Item Drop: +15, Single Equip, Last Available: "2024-03"
 11562	research fragment	0		
@@ -11427,35 +11427,35 @@
 11572	green narrow Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	stale yam	4	decent	Last Available: "2024-05"
 11574	delicious yam martini	3	awesome	Last Available: "2024-05"
-11575	special lousy strong green sweet potato o' mine	5	decent	Effect: "Salty Dogs", Effect Duration: 45, Last Available: "2024-05"
+11575	strong lousy special green sweet potato o' mine	5	decent	Effect: "Salty Dogs", Effect Duration: 45, Last Available: "2024-05"
 11576	tolerable Southern yam	3	good	Last Available: "2024-05"
 11577	mediocre practically non-alcoholic sweet potato punch	1	decent	Last Available: "2024-05"
 11578	yummy Mayam spinach	4	awesome	Last Available: "2024-05"
-11579	decent snack-sized spinning yam and swiss	2	good	Last Available: "2024-05"
+11579	snack-sized decent spinning yam and swiss	2	good	Last Available: "2024-05"
 11580	skewed prompt lard-coated hardened yam cannon	0		Damage Reduction: 3, Sleaze Spell Damage: +25, Adventures: +3, Lasts Until Rollover, Last Available: "2024-05"
 11581	olive yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
-11582	upside-down jittery yam battery	0		Last Available: "2024-05"
+11582	jittery upside-down yam battery	0		Last Available: "2024-05"
 11583	fuchsia yam stinkbomb	0		Last Available: "2024-05"
 11584	Annie Oakley's wizardly furry yam buckler of courage	0		Mysticality: +25, Critical Hit Percent: +20, Spooky Resistance: +3, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	purple thanksgiving bomb	0		Last Available: "2024-05"
 11586	lime green frightening chaotic Fonzie's yamtility belt	0		Experience (Moxie): +1, Spell Critical Percent: +10, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2024-05"
 11587	rotten half-sized fancy yam slider	2	crappy	Effect: "Graham Crackling", Effect Duration: 50, Last Available: "2024-05"
 11588	spoiled yam mayo	4	crappy	Last Available: "2024-05"
-11589	enchanted diet spoiled jittery yam burrito	1	crappy	Effect: "Eagle Eyes", Effect Duration: 45, Last Available: "2024-05"
+11589	spoiled enchanted diet jittery yam burrito	1	crappy	Effect: "Eagle Eyes", Effect Duration: 45, Last Available: "2024-05"
 11590	yellow visual packet sniffer	0		Last Available: "2025-12"
 11591	mirror mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	moldy bite-sized fuchsia mini kiwi	1	crappy	Last Available: "2024-06"
 11595	twirling healthy Sinatra's boxer's mini kiwi bikini	0		Muscle Percent: +10, Experience (Moxie): +5, Maximum HP Percent: +20, Last Available: "2024-06"
-11596	lousy strong blue mini kiwitini	5	decent	Last Available: "2024-06"
+11596	strong lousy blue mini kiwitini	5	decent	Last Available: "2024-06"
 11597	shaking mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	rosewater-soaked gravedigger's curative mini kiwi silicon tiepin	0		Spooky Damage: +10, Stench Resistance: +3, HP Regen Min: 3, HP Regen Max: 5
 11600	red mini kiwi tipi	0		
-11601	small bland mini kiwi digitized cookies	2	decent	
-11602	lousy triple-distilled upside-down mini kiwi intoxicating spirits	6	decent	
-11603	pressed alkaline squat gray mini kiwi antimilitaristic hippy petition	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13
+11601	bland small mini kiwi digitized cookies	2	decent	
+11602	triple-distilled lousy upside-down mini kiwi intoxicating spirits	6	decent	
+11603	pressed alkaline gray squat mini kiwi antimilitaristic hippy petition	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13
 11604	polarized skewed mini kiwi illicit antibiotic	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 31
 11605	dog trainer's beefcake's mini kiwi whipping stick	0		Muscle: +25, Experience (familiar): +1
 11606	smelly mini kiwi icepick	0		Stench Spell Damage: +10
@@ -11487,13 +11487,13 @@
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	artisanal practically non-alcoholic Colera Peste Nebbiolo	1	super ultra EPIC	
+11635	practically non-alcoholic artisanal Colera Peste Nebbiolo	1	super ultra EPIC	
 11636	twirling longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	twirling bodyguard badge	0		
 11639	Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
-11641	mirror teal boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
+11641	teal mirror boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	Sept-Ember Censer	0		Last Available: "2024-09"
 11643	teal blinking blade of dismemberment of the detective	0		Item Drop: +20, Lasts Until Rollover, Last Available: "2024-09"
 11644	mirror Embering Hulk	0		Last Available: "2024-09"
@@ -11535,8 +11535,8 @@
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	warmed pea brittle	0		Effect: "Wings of the Grasshopper", Effect Duration: 31, Last Available: "2024-11"
-11683	perfectly mixed weak peasco	2	EPIC	Last Available: "2024-11"
-11684	immense spoiled piece of cake	9	crappy	Last Available: "2024-11"
+11683	weak perfectly mixed peasco	2	EPIC	Last Available: "2024-11"
+11684	spoiled immense piece of cake	9	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	pulsating Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11547,7 +11547,7 @@
 11692	spinning pirrrate's currrse	0		Last Available: "2024-12"
 11693	weak lousy tankard of spiced rum	2	decent	Last Available: "2024-12"
 11694	boozy perfectly mixed green tankard of spiced Goldschlepper	5	EPIC	Last Available: "2024-12"
-11695	jittery purple wobbly packaged luxury garment	0		Last Available: "2024-12"
+11695	wobbly jittery purple packaged luxury garment	0		Last Available: "2024-12"
 11696	governor's daughter's lace collar of courage	0		Spooky Resistance: +3, Last Available: "2024-12"
 11697	governor's daughter's petticoats	0		Item Drop: +5, Last Available: "2024-12"
 11698	clever governor's daughter's pearl hairpin	0		Maximum MP: +20, Last Available: "2024-12"
@@ -11560,7 +11560,7 @@
 11705	pirate dinghy	0		Last Available: "2024-12"
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	Sherlock's smooth silky pirate drawers	0		Moxie: +15, Item Drop: +25, Last Available: "2024-12"
-11708	green tumbling narrow profane eye patch	0		Sleaze Damage: +3
+11708	tumbling green narrow profane eye patch	0		Sleaze Damage: +3
 11709	corrupted pulsating peppermint pegleg	0		Effect: "Sparkly!", Effect Duration: 37, Last Available: "2024-12"
 11710	lousy weak hard cocoa	2	decent	Last Available: "2024-12"
 11711	spoiled salmagumdi	3	crappy	Last Available: "2024-12"
@@ -11600,14 +11600,14 @@
 11745	pulsating dog trainer's smooth Congressional Medal of Insanity of the overflowing toilet	0		Moxie: +15, Experience (familiar): +1, Stench Spell Damage: +50, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	weak hand-crafted Easter grasshopper	2	EPIC	Last Available: "2024-12"
-11748	practically non-alcoholic acceptable Irish eggnog	1	good	Last Available: "2024-12"
+11748	acceptable practically non-alcoholic Irish eggnog	1	good	Last Available: "2024-12"
 11749	artisanal canteen of jungle juice	3	EPIC	Last Available: "2024-12"
 11750	bad green turchucken	3	decent	Last Available: "2024-12"
-11751	enchanted hand-crafted upside-down mechanically-mulled cider	4	EPIC	Effect: "Icy Demeanor", Effect Duration: 35, Last Available: "2024-12"
-11752	drinkable special holiday trip around the world	3	good	Effect: "Stenchtastic", Effect Duration: 15, Last Available: "2024-12"
-11753	immense tasty chocolate ostrich egg	7	awesome	Last Available: "2024-12"
+11751	hand-crafted enchanted upside-down mechanically-mulled cider	4	EPIC	Effect: "Icy Demeanor", Effect Duration: 35, Last Available: "2024-12"
+11752	special drinkable holiday trip around the world	3	good	Effect: "Stenchtastic", Effect Duration: 15, Last Available: "2024-12"
+11753	tasty immense chocolate ostrich egg	7	awesome	Last Available: "2024-12"
 11754	flavorless massive beef and cabbage	6	decent	Last Available: "2024-12"
-11755	stale low-calorie tumbling candy rations	1	decent	Last Available: "2024-12"
+11755	low-calorie stale tumbling candy rations	1	decent	Last Available: "2024-12"
 11756	adequate twirling double-candied yams	3	good	Last Available: "2024-12"
 11757	miniature adequate Christmas ham	2	good	Last Available: "2024-12"
 11758	adequate holiday smorgasbord	3	good	Last Available: "2024-12"
@@ -11616,7 +11616,7 @@
 11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
 11762	teal Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	wobbly cyan How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	cyan wobbly How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	bouncing Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	bouncing Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
@@ -11629,7 +11629,7 @@
 11774	skewed candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
 11776	flavorless Thanksgiving ration	3	decent	Last Available: "2024-12"
-11777	high-proof mediocre Easter eggnog	8	decent	Last Available: "2024-12"
+11777	mediocre high-proof Easter eggnog	8	decent	Last Available: "2024-12"
 11778	diluted cyan clovermint	1		Last Available: "2024-12"
 11779	pulsating executive Jeselnik's flame-wreathed studded nylon Christmas stockings	0		Damage Absorption: +80, Hot Spell Damage: +10, Sleaze Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2024-12"
 11780	ghostly upside-down tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11642,10 +11642,10 @@
 11787	lard-coated McHugeLarge right ski of Tarzan	0		Experience (Muscle): +3, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	twirling 0	0		Last Available: "2025-12"
-11790	altered huge narrow eXpand	1		Last Available: "2025-12"
+11790	altered narrow huge eXpand	1		Last Available: "2025-12"
 11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
-11793	bouncing gray dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
+11793	gray bouncing dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	spinning dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
@@ -11655,7 +11655,7 @@
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	mirror dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
-11803	fuchsia mirror cybervisor	0		Last Available: "2025-12"
+11803	mirror fuchsia cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	ghostly olive pocket GPU	0		Single Equip, Last Available: "2025-12"
 11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
@@ -11675,12 +11675,12 @@
 11820	blinking dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
-11823	shaking skewed STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
+11823	skewed shaking STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	lime green hashing vise	0		Last Available: "2025-12"
 11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
-11828	squat olive geofencing shield	0		Last Available: "2025-12"
+11828	olive squat geofencing shield	0		Last Available: "2025-12"
 11829	blinking virtual cybertattoo	0		Last Available: "2025-12"
 11830	upside-down ninja rope	0		
 11831	ninja crampons	0		
@@ -11727,21 +11727,21 @@
 11872	gigantic spoiled Heck ramen	6	crappy	Last Available: "2025-03"
 11873	decent big burrito	5	good	Last Available: "2025-03"
 11874	adequate small beer brat	4	good	Last Available: "2025-03"
-11875	immense rotten peach pie	10	crappy	Last Available: "2025-03"
+11875	rotten immense peach pie	10	crappy	Last Available: "2025-03"
 11876	moldy bouncing incredible mini-pizza	3	crappy	Last Available: "2025-03"
-11877	high-proof hand-crafted Divine sidecar	8	EPIC	Last Available: "2025-03"
+11877	hand-crafted high-proof Divine sidecar	8	EPIC	Last Available: "2025-03"
 11878	lousy tangarita sidecar	3	decent	Last Available: "2025-03"
 11879	acceptable pulsating gimlet sidecar	4	good	Last Available: "2025-03"
-11880	drinkable fortified vodka stratocaster sidecar	5	good	Last Available: "2025-03"
+11880	fortified drinkable vodka stratocaster sidecar	5	good	Last Available: "2025-03"
 11881	fancy smooth prussian cathouse sidecar	3	awesome	Effect: "Techno Bliss", Effect Duration: 40, Last Available: "2025-03"
 11882	hand-crafted spinning Mon Tiki sidecar	3	EPIC	Last Available: "2025-03"
-11883	olive wobbly Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
+11883	wobbly olive Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	spinning family-friendly April Shower Thoughts shield of the glutton	0		Sleaze Resistance: +1, Food Drop: +100, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	extra-warmed dry wet paper weights	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 13, Last Available: "2025-04"
 11888	watered-down hand-crafted Three Sheets to the Wind	2	EPIC	Last Available: "2025-04"
-11889	spoiled huge blurry pile of wet dates	9	crappy	Last Available: "2025-04"
+11889	huge spoiled blurry pile of wet dates	9	crappy	Last Available: "2025-04"
 11890	skewed papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	blinking wet shower cap of the blizzard	0		Cold Spell Damage: +25, Last Available: "2025-04"
@@ -11789,8 +11789,8 @@
 11934	tumbling orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	immense moldy Skeleton Wars rations	6	crappy	
-11938	weak lousy huge mirror skeleton war fuel can	2	decent	
+11937	moldy immense Skeleton Wars rations	6	crappy	
+11938	weak lousy mirror huge skeleton war fuel can	2	decent	
 11939	red skeleton war grenade	0		
 11940	tumbling chocolate and nylons detector	0		
 11941	gray M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11805,18 +11805,18 @@
 11950	jittery time cop top hat of the pedagogue	0		Experience: +3, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	dehydrated upside-down mixed berry jelly	1		Last Available: "2025-08"
-11953	spoiled bite-sized enchanted jittery toast with mixed berry jelly	1	crappy	Effect: "Concentration", Effect Duration: 15, Last Available: "2025-08"
+11953	enchanted bite-sized spoiled jittery toast with mixed berry jelly	1	crappy	Effect: "Concentration", Effect Duration: 15, Last Available: "2025-08"
 11954	delicious cup of sugar	3	awesome	Last Available: "2025-08"
-11955	super-sized decent mirror Susie's cupcake	5	good	Last Available: "2025-08"
+11955	decent super-sized mirror Susie's cupcake	5	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	padded Sinatra's groovy the gun	0		Moxie Percent: +10, Experience (Moxie): +5, Damage Absorption: +20, Last Available: "2025-08"
 11958	aged wine	3	awesome	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	weightlifter's undersea surveying goggles	0		Muscle: +15, Lasts Until Rollover
-11963	smooth spirit-forward Ocean-Touched Rum	5	awesome	
+11963	spirit-forward smooth Ocean-Touched Rum	5	awesome	
 11964	boiled water-logged pill	1		
-11965	adequate immense mirror kelp puck	8	good	
+11965	immense adequate mirror kelp puck	8	good	
 11966	scroll of sea strength	0		
 11967	jittery scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
@@ -11825,11 +11825,11 @@
 11971	moist fuchsia octopus ink bladder	0		Effect: "Chow Downed", Effect Duration: 45
 11972	durable dolphin whistle	0		
 11973	squat Thwaitgold lobster statuette	0		
-11974	squat green narrow packaged Monodent of the Sea	0		Free Pull
+11974	green squat narrow packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	huge unblemished pearl	0		
 11977	dentadent of mayonnaise	0		Sleaze Spell Damage: +50
-11986	pulsating lime green lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
+11986	lime green pulsating lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	lion tamer's mansplainer's Oprah's steel-toed deadly blood cubic zirconia of the glutton	0		Weapon Damage: +5, Damage Reduction: 9, Maximum MP Percent: +50, Monster Level: +15, Experience (familiar): +2, Food Drop: +100, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	vaporized blood thinner	1		Last Available: "2025-10"
 12045	bad upside-down pheromone cocktail	3	decent	Last Available: "2025-10"
@@ -11845,7 +11845,7 @@
 12055	stale full-sized pumpkin pie	3	decent	Last Available: "2025-11"
 12056	drinkable high-proof olive vodka cranberry sauce	9	good	Last Available: "2025-11"
 12057	enhanced olive yammed candy	0		Effect: "Fitter, Happier", Effect Duration: 32, Last Available: "2025-11"
-12058	normal narrow blurry treasure chestnut	3	good	Last Available: "2025-12"
+12058	normal blurry narrow treasure chestnut	3	good	Last Available: "2025-12"
 12059	bad mulled butter rum	4	decent	Last Available: "2025-12"
 12060	dry tumbling cinnamon doubloon	0		Effect: "Spirit Bubble", Effect Duration: 13, Last Available: "2025-12"
 12061	narrow gray plastic left skeleton arm of the wise owl	0		Mysticality: +20, Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	purple Crymbocurrency	0		Last Available: "2025-12"
 12122	extra-thick Crimbo sweater of the dark arts	0		Spell Damage Percent: +100, Last Available: "2025-12"
 12123	spinning The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	irresponsibly strong mediocre Steve Abrams' Holiday Sampler Beer	7	decent	Last Available: "2025-12"
+12124	mediocre irresponsibly strong Steve Abrams' Holiday Sampler Beer	7	decent	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	watered-down perfectly mixed upside-down bottle of prize-winning rum	2	super EPIC	Last Available: "2025-12"
 12127	twirling jittery rosewater-soaked Fonzie's Santa-Slayer medal of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +1, Stench Resistance: +3, Single Equip, Last Available: "2025-12"
@@ -11891,14 +11891,14 @@
 12133	skewed blue seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	mirror smoldering bone dust	0		Last Available: "2025-12"
-12136	pulsating olive jittery volatile bone bomb	0		Last Available: "2025-12"
+12136	olive pulsating jittery volatile bone bomb	0		Last Available: "2025-12"
 12137	avaricious flame-wreathed weightlifter's hot boning knife	0		Muscle: +15, Hot Spell Damage: +10, Meat Drop: +30, Single Equip, Last Available: "2025-12"
 12138	Herculean boxer's fistbone of vim and vigor	0		Muscle Percent: +10, Experience (Muscle): +1, Maximum HP Percent: +50, Last Available: "2025-12"
 12139	greedy MacGyver's strapping burnt bone belt	0		Muscle: +5, Maximum MP: +100, Meat Drop: +20, Single Equip, Last Available: "2025-12"
 12140	chaotic scorched skull trophy	0		Spell Critical Percent: +10, Last Available: "2025-12"
 12141	spoiled blue wing bone	3	crappy	Last Available: "2025-12"
 12142	tolerable weak skeleton venom	3	good	Last Available: "2025-12"
-12143	vaporized bouncing red baked bone meal	1		Effect: "On a Roll", Effect Duration: 35, Last Available: "2025-12"
+12143	vaporized red bouncing baked bone meal	1		Effect: "On a Roll", Effect Duration: 35, Last Available: "2025-12"
 12144	blurry lion tamer's plastic skeleton rib cage	0		Experience (familiar): +2, Last Available: "2025-12"
 12145	Usain Bolt's plastic skeleton skull	0		Initiative: +80, Last Available: "2025-12"
 12146	plastic skeleton Crimbo hat of Gandalf	0		Spell Critical Percent: +20, Last Available: "2025-12"
@@ -11919,7 +11919,7 @@
 12161	Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
-12164	green ghostly blurry Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
+12164	blurry ghostly green Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12165	Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12166	Crymbocurrency tattoo	0		Last Available: "2025-12"
 12167	mirror boxer's fireproof bonesaw of bravery	0		Muscle Percent: +10, Spooky Resistance: +5, Last Available: "2025-12"
@@ -11932,14 +11932,14 @@
 12174	lousy &quot;salvaged&quot; wine	3	decent	Last Available: "2025-12"
 12175	spinning The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	small special spoiled wedge of prize-winning cheese	2	crappy	Effect: "Frozen Shoulders", Effect Duration: 45, Last Available: "2025-12"
+12177	spoiled special small wedge of prize-winning cheese	2	crappy	Effect: "Frozen Shoulders", Effect Duration: 45, Last Available: "2025-12"
 12178	activated diffused spinning gummi fingerbone	0		Effect: "Triangle, Man", Effect Duration: 27
 12179	glimmering crystal of the bloodbag of Calamity Jane	0		Maximum HP: +100, Critical Hit Percent: +15, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
-12184	skewed olive Archaeologist's Spade	0		Last Available: "2026-03"
+12184	olive skewed Archaeologist's Spade	0		Last Available: "2026-03"
 12185	wobbly boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	dinosaur bone fragment	0		Last Available: "2026-03"
 12187	Pork Elf pottery shard	0		Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	bouncing Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	tasty tiny rat pizza	1	awesome	Last Available: "2026-03"
+12209	tiny tasty rat pizza	1	awesome	Last Available: "2026-03"
 12210	mirror Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	upside-down wholesome sage hoverboard of chilblains	0		Mysticality Percent: +10, Maximum HP Percent: +10, Cold Damage: +25, Single Equip, Last Available: "2026-03"
 12212	jittery fireproof hardened left shark fin of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3, Hot Resistance: +3, Last Available: "2026-03"
@@ -11982,25 +11982,25 @@
 12228	decent miniature ratbatatouille	2	good	
 12229	moldy onigiri	3	crappy	
 12230	adequate crudit&eacute;s	3	good	
-12231	half-sized adequate sauced mutton	2	good	
+12231	adequate half-sized sauced mutton	2	good	
 12232	jumbo normal narrow hot honey ant	5	good	
 12233	huge spoiled tomb aspic	8	crappy	
 12234	yummy jittery later tots	4	awesome	
-12235	decent half-sized huge Frutti di Scatoletta	2	good	Last Available: "2026-05"
-12236	jumbo stale teal jittery Pesto alla Marziano	5	decent	Last Available: "2026-05"
-12237	spoiled small maroon Arrattabbattabiata	2	crappy	Last Available: "2026-05"
+12235	half-sized decent huge Frutti di Scatoletta	2	good	Last Available: "2026-05"
+12236	stale jumbo jittery teal Pesto alla Marziano	5	decent	Last Available: "2026-05"
+12237	small spoiled maroon Arrattabbattabiata	2	crappy	Last Available: "2026-05"
 12238	moldy gray Orzo di Riso	4	crappy	Last Available: "2026-05"
-12239	rotten snack-sized Pasta Grimavera	2	crappy	Last Available: "2026-05"
+12239	snack-sized rotten Pasta Grimavera	2	crappy	Last Available: "2026-05"
 12240	fancy flavorless blurry Linguini Ubriacapa	4	decent	Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2026-05"
 12241	normal Formica e Pepe	4	good	Last Available: "2026-05"
-12242	big decent Tubetto Gelatto	5	good	Last Available: "2026-05"
+12242	decent big Tubetto Gelatto	5	good	Last Available: "2026-05"
 12243	toothsome Gnocci Domani	3	awesome	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	frightening steel-toed Space Soldier Helmet	0		Damage Reduction: 9, Spooky Damage: +5
-12253	bland big spinning premium turkey leg	5	decent	
+12253	big bland spinning premium turkey leg	5	decent	
 12254	drinkable triple-distilled special styrofoam cup of mead	10	good	Effect: "Busy Bein' Delicious", Effect Duration: 20
 12255	blurry clever sword	0		Maximum MP: +20
 12256	beefcake's staff	0		Muscle: +25
@@ -12028,12 +12028,12 @@
 12278	adjusted electrified extra-pickled essential banana decoction	0		Effect: "Ghostly Shell", Effect Duration: 58, Last Available: "2026-07"
 12279	double-liquefied squat banana quintessence	0		Effect: "Simulation Stimulation", Effect Duration: 17, Last Available: "2026-07"
 12280	bad maroon Aesop Daiquiri	4	decent	Last Available: "2026-07"
-12281	tolerable distilled cyan Monkey Congress	5	good	Last Available: "2026-07"
+12281	distilled tolerable cyan Monkey Congress	5	good	Last Available: "2026-07"
 12282	normal yellow watermelon pie	3	good	Last Available: "2026-07"
 12283	alkaline concentrated watermelon juice	0		Effect: "Comic Violence", Effect Duration: 59, Last Available: "2026-07"
 12284	alkaline Aqua Citrulanatae	0		Effect: "Discomfited", Effect Duration: 46, Last Available: "2026-07"
 12285	hand-crafted cyan Melonegroni	4	EPIC	Last Available: "2026-07"
-12286	mediocre enchanted fuchsia Melonade Spritz	3	decent	Effect: "Ruby-ous", Effect Duration: 45, Last Available: "2026-07"
+12286	enchanted mediocre fuchsia Melonade Spritz	3	decent	Effect: "Ruby-ous", Effect Duration: 45, Last Available: "2026-07"
 12287	rotten quince pie	3	crappy	Last Available: "2026-07"
 12288	galvanized galvanized quince quaff	0		Effect: "Rushin' Hands", Effect Duration: 66, Last Available: "2026-07"
 12289	dry cyan Quickquince	0		Effect: "Inner Dog", Effect Duration: 14, Last Available: "2026-07"
@@ -12044,7 +12044,7 @@
 12294	solvent	0		Last Available: "2026-08"
 12295	tasty soybean futures	3	awesome	Last Available: "2026-08"
 12296	altered flattened red housing bubble	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 67, Last Available: "2026-08"
-12297	altered anodized moist blinking cyan mirror Pixie-Swordz	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 34
+12297	altered anodized moist mirror cyan blinking Pixie-Swordz	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 34
 12298	upside-down hale financial instrument of horror	0		Maximum HP: +20, Spooky Spell Damage: +25, Last Available: "2026-08"
 12299	ribald hedge fund clippers of Leguizamo	0		Monster Level: +20, Sleaze Damage: +10, Last Available: "2026-08"
 12300	avaricious selling shorts	0		Meat Drop: +30, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Opossum_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	lousy strong special Petite Porter	5	decent	
+-1	special strong lousy Petite Porter	5	decent	
 -2	perfectly mixed Scrawny Stout	3	EPIC	
 -3	lousy Infinitesimal IPA	3	decent	
 -4	bad eggnogtini	4	decent	
 -5	practically non-alcoholic perfectly mixed purple candycaine	1	super ultra EPIC	
--6	irresponsibly strong mediocre braincracker sweet	10	decent	
+-6	mediocre irresponsibly strong braincracker sweet	10	decent	
 -16	bad fermented honey	3	decent	
 -17	artisanal bouncing moons-shine	3	EPIC	
 -18	bad gin	3	decent	
--19	watered-down perfectly mixed ecto-nog	2	EPIC	
+-19	perfectly mixed watered-down ecto-nog	2	EPIC	
 -20	weak artisanal hot toady	2	EPIC	
 -21	lousy weak enchanted hot choculate	2	decent	
--49	fancy artisanal practically non-alcoholic shaking Cyder	1	EPIC	
+-49	practically non-alcoholic artisanal fancy shaking Cyder	1	EPIC	
 -50	practically non-alcoholic bad Oil Nog	1	decent	
--51	bad weak Hi-Octane Peppermint Jet Fuel	2	decent	
--58	enchanted drinkable weak narrow Grimacider	2	good	
+-51	weak bad Hi-Octane Peppermint Jet Fuel	2	decent	
+-58	weak enchanted drinkable narrow Grimacider	2	good	
 -59	practically non-alcoholic hand-crafted Isotope Nog	1	EPIC	
--60	aged practically non-alcoholic enchanted yellow Mutagin 'n' Tonic	1	awesome	
+-60	practically non-alcoholic aged enchanted yellow Mutagin 'n' Tonic	1	awesome	
 -70	lousy lime green Gin and Herring	4	decent	
--71	drinkable weak purple mirror Black and Tan and Red All Over	2	good	
--72	watered-down enchanted mediocre Antarctic Ice Tea	2	decent	
+-71	weak drinkable purple mirror Black and Tan and Red All Over	2	good	
+-72	enchanted mediocre watered-down Antarctic Ice Tea	2	decent	
 -76	drinkable distilled wobbly CRIMBCO Ribbon Candy Schnapps	5	good	
 -77	tolerable CRIMBCO Egg Substitute Nog Substitute	3	good	
 -78	smooth CRIMBCO Extreme Braincracker Sour	3	awesome	
 -82	mediocre Horseradish-infused Vodka	4	decent	
 -83	tolerable Jerkitini	4	good	
--84	weak smooth yellow Desert Island Iced Tea	2	awesome	
+-84	smooth weak yellow Desert Island Iced Tea	2	awesome	
 -88	drinkable Crimbo Saketini	4	good	
 -89	perfectly mixed watered-down cyan Crimboku Drop	2	EPIC	
 -90	drinkable olive Flaming Crimbo Log	3	good	
 -107	artisanal Fortified Eggnog Slurry	3	EPIC	
 -108	lousy high-proof Hot Buttered Rum	6	decent	
--109	lousy watered-down Spicy Hot Chocolate	2	decent	
+-109	watered-down lousy Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Sauceror_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Opossum_cafe_food.txt
@@ -1,4 +1,4 @@
--1	spoiled special big Peche a la Frog	5	crappy	
+-1	special big spoiled Peche a la Frog	5	crappy	
 -2	decent As Jus Gezund Heit	3	good	
 -3	spoiled Bouillabaise Coucher Avec Moi	3	crappy	
 -7	decent gigantic gumdrop chow mein	8	good	
@@ -6,33 +6,33 @@
 -9	toothsome blinking gingerbread stir-fry	3	awesome	
 -10	normal twigs and gravel	3	good	
 -11	adequate snack-sized skewed shoots and leaves	2	good	
--12	spoiled big bowl of unidentifiable goo	5	crappy	
+-12	big spoiled bowl of unidentifiable goo	5	crappy	
 -13	decent mirror gingerbread massacre	4	good	
 -14	small moldy It Came From Beyond Dessert	2	crappy	
 -15	massive normal vampire cake	8	good	
 -52	gigantic decent huge Soylent Red and Green	7	good	
 -53	rotten Disc-Shaped Nutrition Unit	3	crappy	
 -54	massive flavorless mirror Gingerborg Hive	8	decent	
--61	tiny spoiled Candy Cane Surprise	1	crappy	
+-61	spoiled tiny Candy Cane Surprise	1	crappy	
 -62	flavorless snack-sized upside-down Grimdrop Chow Mein	2	decent	
 -63	rotten upside-down tumbling Grimgerbread House	4	crappy	
--67	rotten thick Caviar Carbonara	5	crappy	
+-67	thick rotten Caviar Carbonara	5	crappy	
 -68	moldy Halibut Alfredo	3	crappy	
 -69	normal Red Herring Velvet Cake	3	good	
--73	adequate cyan shaking CRIMBCO Reconstituted Gruel	3	good	
+-73	adequate shaking cyan CRIMBCO Reconstituted Gruel	3	good	
 -74	normal New and Improved CRIMBCO Reconstituted Gruel	3	good	
--75	rotten shaking purple CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	crappy	
+-75	rotten purple shaking CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	crappy	
 -79	decent bouncing maroon Brussels Sprout Stir-Fry	4	good	
 -80	decent bite-sized Carrot, Cabbage, and Kale Pizza	1	good	
 -81	normal shaking Turnip and Rutabaga Pie	4	good	
 -85	yummy red Rainbow Spider Fun Roll	3	awesome	
--86	normal miniature Vegas Volcano Lava Roll	2	good	
+-86	miniature normal Vegas Volcano Lava Roll	2	good	
 -87	stale skewed Crazy Dragon Shogun Buddha Roll	3	decent	
--92	tiny moldy bouncing basic hot dog	1	crappy	
+-92	moldy tiny bouncing basic hot dog	1	crappy	
 -93	adequate savage macho dog	3	good	
--94	fancy flavorless one with everything	4	decent	
+-94	flavorless fancy one with everything	4	decent	
 -95	adequate yellow sly dog	4	good	
--96	small moldy olive skewed devil dog	2	crappy	
+-96	small moldy skewed olive devil dog	2	crappy	
 -97	huge normal chilly dog	8	good	
 -98	bland narrow ghost dog	4	decent	
 -99	flavorless huge huge junkyard dog	8	decent	
@@ -42,4 +42,4 @@
 -103	stale wobbly video games hot dog	4	decent	
 -104	spoiled gray Peppermint Nutrition Block	4	crappy	
 -105	decent narrow Gingerbread Nutrition Block	4	good	
--106	enchanted moldy blue Cinnamon Nutrition Block	3	crappy	
+-106	moldy enchanted blue Cinnamon Nutrition Block	3	crappy	

--- a/data/TCRS/TCRS_Sauceror_Packrat.txt
+++ b/data/TCRS/TCRS_Sauceror_Packrat.txt
@@ -8,9 +8,9 @@
 8	twirling spices	0		
 9	narrow scandalous disco mask	0		Sleaze Damage: +5, Familiar Effect: "atk, cap 2"
 10	blurry blurry disco ball	0		
-11	skewed narrow stolen accordion	0		Song Duration: 5
+11	narrow skewed stolen accordion	0		Song Duration: 5
 12	ghostly mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	twisted purple mirror moxie weed	1		
+14	twisted mirror purple moxie weed	1		
 15	mixed strongness elixir	1		
 16	mixed spinning magicalness-in-a-can	1		Effect: "Spore-Wreathed", Effect Duration: 5
 17	rotten noodles	3	crappy	
@@ -43,9 +43,9 @@
 44	worthless gewgaw	0		
 45	upside-down worthless knick-knack	0		
 46	figurine	0		
-47	bite-sized rotten cyan hot buttered roll	1	crappy	
+47	rotten bite-sized cyan hot buttered roll	1	crappy	
 48	heart of rock and roll	0		
-49	big decent bowl of cottage cheese	5	good	
+49	decent big bowl of cottage cheese	5	good	
 50	skewed Rock and Roll Legend of bravery	0		Spooky Resistance: +5, Class: "Accordion Thief", Song Duration: 10
 51	mirror Knob Goblin Uberpants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -57,11 +57,11 @@
 58	spinning stone turtle	0		
 59	slingshot	0		
 60	fortified Mace of the Tortoise	0		Damage Absorption: +60, Class: "Turtle Tamer"
-61	bite-sized decent fortune cookie	1	good	
+61	decent bite-sized fortune cookie	1	good	
 62	skewed stiffened oriole-feather headdress	0		Damage Reduction: 1, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
-65	skewed tumbling Mighty Bjorn action figure	0		
+65	tumbling skewed Mighty Bjorn action figure	0		
 66	shaking shaking twig	0		
 67	spaghetti with rock-balls	0		
 68	huge censurious rock-hard Pasta Spoon of Peril	0		Damage Reduction: 5, Sleaze Resistance: +3, Class: "Pastamancer"
@@ -72,7 +72,7 @@
 73	spinning maroon barskin tent	0		
 74	Temple map	0		
 75	sapling	0		
-76	squat pulsating Spooky-Gro fertilizer	0		
+76	pulsating squat Spooky-Gro fertilizer	0		
 77	deadly stick	0		Weapon Damage: +5
 78	double-paned pretty bouquet	0		Cold Resistance: +5
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
@@ -98,11 +98,11 @@
 99	meat face	0		
 100	narrow lifeless meat doll	0		
 101	cyan meat golem	0		
-102	blinking tumbling squat shrunken head	0		
+102	tumbling squat blinking shrunken head	0		
 103	bouncing shellacked staff of the brazier	0		Damage Reduction: 7, Hot Spell Damage: +25
 104	scarecrow	0		
 105	flavorless mirror bowl of charms	3	decent	
-106	ghostly squat ketchup	1	decent	
+106	squat ghostly ketchup	1	decent	
 107	catsup	1	awesome	
 108	skewed stick	0		
 109	pulsating crossbow string	0		
@@ -157,13 +157,13 @@
 158	shaking Gnollish pie tin	0		
 159	wad of dough	0		
 160	pie crust	0		
-161	diet adequate ghuol egg	1	good	
-162	tasty snack-sized fuchsia ghuol egg quiche	2	awesome	
+161	adequate diet ghuol egg	1	good	
+162	snack-sized tasty fuchsia ghuol egg quiche	2	awesome	
 163	weightlifter's skeleton bone	0		Muscle: +15
 164	smart skull	0		
 165	narrow skewer	0		
 166	green ghuol ears	0		
-167	small rotten ghuol-ear kabob	2	crappy	
+167	rotten small ghuol-ear kabob	2	crappy	
 168	slick bone rattle	0		Moxie: +10
 169	green bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	green lihc eye	0		
@@ -231,37 +231,37 @@
 233	lime green Doc Galaktik's Restorative Balm	0		
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	spinning healthy savvy Bigger Bugfinder Blade	0		Mysticality Percent: +20, Maximum HP Percent: +20
-236	wobbly tumbling green Queue Du Coq cocktailcrafting kit	0		
+236	tumbling wobbly green Queue Du Coq cocktailcrafting kit	0		
 237	tolerable enchanted irresponsibly strong bottle of gin	6	good	Effect: "Stenchtastic", Effect Duration: 15
 238	aged bottle of vodka	3	awesome	
 239	prompt sinister Orcish baseball cap	0		Spell Damage: +10, Adventures: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	electrified clever Orcish cargo shorts	0		Maximum MP: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	smartaleck's Orcish frat-paddle	0		Moxie Percent: +30
-242	fancy spoiled	4	crappy	Effect: "Human-Constellation Hybrid", Effect Duration: 50
+242	spoiled fancy	4	crappy	Effect: "Human-Constellation Hybrid", Effect Duration: 50
 243	small rotten grapefruit	2	crappy	
 244	bland small grapes	2	decent	
-245	tiny spoiled blurry olive	1	crappy	
-246	snack-sized special yummy tomato	2	awesome	Effect: "Slightly Larger Than Usual", Effect Duration: 40
+245	spoiled tiny blurry olive	1	crappy	
+246	special yummy snack-sized tomato	2	awesome	Effect: "Slightly Larger Than Usual", Effect Duration: 40
 247	fermenting powder	0		
 248	perfectly mixed salty dog	3	EPIC	
 249	lousy bloody mary	3	decent	
 250	special artisanal practically non-alcoholic tumbling screwdriver	1	EPIC	Effect: "Macho Profundo", Effect Duration: 15
-251	watered-down lousy shaking martini	2	decent	
+251	lousy watered-down shaking martini	2	decent	
 252	lousy bloody beer	3	decent	
 253	perfectly mixed shot of schnapps	3	EPIC	
 254	lousy practically non-alcoholic wobbly shot of grapefruit schnapps	1	decent	
-255	mediocre practically non-alcoholic fine wine	1	decent	
+255	practically non-alcoholic mediocre fine wine	1	decent	
 256	perfectly mixed shot of tomato schnapps	3	EPIC	
-257	bad watered-down extra-spicy bloody mary	2	decent	
+257	watered-down bad extra-spicy bloody mary	2	decent	
 258	dense meat stack	0		
 259	green snake skin	0		
 260	tasty ghostly mirror White Citadel fries	4	awesome	
-261	tiny stale narrow blue White Citadel burger	1	decent	
+261	tiny stale blue narrow White Citadel burger	1	decent	
 262	flavorless mirror piece of wedding cake	4	decent	
 263	normal chocolate chips	3	good	
-264	fancy tasty chocolate chip cookies	4	awesome	Effect: "Quiet 'n' Good", Effect Duration: 50
+264	tasty fancy chocolate chip cookies	4	awesome	Effect: "Quiet 'n' Good", Effect Duration: 50
 265	Van der Graaf satin pants	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 2xPotato, cap 10"
-266	fortified hand-crafted tumbling lightning	5	EPIC	
+266	hand-crafted fortified tumbling lightning	5	EPIC	
 267	dog trainer's mullet wig	0		Experience (familiar): +1, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	meat cowboy hat of the glutton	0		Food Drop: +100, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	avaricious sword	0		Meat Drop: +30
@@ -273,7 +273,7 @@
 275	jittery mosquito larva	0		
 276	leprechaun hatchling	0		
 277	compressed tumbling extra-strength strongness elixir	1		Effect: "New Zeal", Effect Duration: 40
-278	compressed narrow blue jug-o-magicalness	1		
+278	compressed blue narrow jug-o-magicalness	1		
 279	diluted blue suntan lotion of moxiousness	1		
 280	gray Pick-O-Matic lockpicks	0		
 281	gasmask of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xBarrr, cap 12"
@@ -293,12 +293,12 @@
 295	ruddy demonskin trousers	0		Maximum HP Percent: +40, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	extremely unsafe dungeoneer's dungarees	0		Weapon Damage Percent: +100, Familiar Effect: "stench atk, 4xPotato, cap 7"
 297	oxidized jittery tamarind-flavored chewing gum	0		Effect: "Blood-Rich", Effect Duration: 38
-298	pressed green blinking lime-and-chile-flavored chewing gum	0		Effect: "Thunderspell", Effect Duration: 22
+298	pressed blinking green lime-and-chile-flavored chewing gum	0		Effect: "Thunderspell", Effect Duration: 22
 299	concentrated corrupted ghostly pickle-flavored chewing gum	0		Effect: "Powder Power", Effect Duration: 47
 300	polymerized corrupted huge jaba&ntilde;ero-flavored chewing gum	0		Effect: "Pisces in the Skyces", Effect Duration: 64
 301	flat dough	0		
 302	half-sized tasty pulsating Knob sausage	2	awesome	
-303	delicious immense Knob mushroom	7	awesome	
+303	immense delicious Knob mushroom	7	awesome	
 304	dry noodles	0		
 305	coward's Knob Goblin harem pants	0		Monster Level: -20, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	censurious Knob Goblin harem veil	0		Sleaze Resistance: +3, Familiar Effect: "5xLep, cap 2"
@@ -309,26 +309,26 @@
 311	hill of beans	0		
 312	wool Knob Goblin visor	0		Cold Resistance: +1, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	lion tamer's Crown of the Goblin King	0		Experience (familiar): +2, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	fancy tiny bland bean burrito	1	decent	Effect: "All Branned Up", Effect Duration: 45
-315	normal jumbo bean burrito	5	good	
+314	fancy bland tiny bean burrito	1	decent	Effect: "All Branned Up", Effect Duration: 45
+315	jumbo normal bean burrito	5	good	
 316	stale insanely bean burrito	3	decent	
 317	spoiled jumbo bean burrito	5	crappy	
 318	big spoiled bean burrito	5	crappy	
 319	decent insanely bean burrito	3	good	
-320	special rotten bat haggis	3	crappy	Effect: "Shawarma Warm War", Effect Duration: 25
+320	rotten special bat haggis	3	crappy	Effect: "Shawarma Warm War", Effect Duration: 25
 321	normal menudo	3	good	
 322	delicious bite-sized blinking goat cheese	1	awesome	
-323	normal super-sized plain pizza	5	good	
+323	super-sized normal plain pizza	5	good	
 324	normal sausage pizza	3	good	
-325	big spoiled goat cheese pizza	5	crappy	
-326	snack-sized tasty mushroom pizza	2	awesome	
+325	spoiled big goat cheese pizza	5	crappy	
+326	tasty snack-sized mushroom pizza	2	awesome	
 327	upside-down goat	0		
 328	tolerable bottle of whiskey	4	good	
 329	studded goat beard	0		Damage Absorption: +80, Familiar Effect: "atk, 1xPotato, cap 15"
-330	lime green blinking glass of goat's milk	1	awesome	
+330	blinking lime green glass of goat's milk	1	awesome	
 331	lousy Canadian	4	decent	
-332	small stale teal lemon	2	decent	
-333	adequate bite-sized lime	1	good	
+332	stale small teal lemon	2	decent	
+333	bite-sized adequate lime	1	good	
 334	Van der Graaf sabre teeth	0		MP Regen Min: 5, MP Regen Max: 7
 335	sabre-toothed lime cub	0		
 336	fireproof consolation ribbon	0		Hot Resistance: +3
@@ -415,12 +415,12 @@
 417	magnetized energized henna tattoo	0		Effect: "Corona de la Salsa", Effect Duration: 18
 418	pressed Ferrigno's Elixir of Power	0		Effect: "Well Owl Be!", Effect Duration: 20
 419	flattened flattened wet spinning serum of sarcasm	0		Effect: "Oriental Mysticism", Effect Duration: 20
-420	dry fuchsia twirling wobbly tomato juice of powerful power	0		Effect: "Creepypasted", Effect Duration: 65
+420	dry wobbly fuchsia twirling tomato juice of powerful power	0		Effect: "Creepypasted", Effect Duration: 65
 421	boiled oxidized pulsating philter of phorce	0		Effect: "Ten out of Ten", Effect Duration: 42
 422	quadruple-activated potion of potency	0		Effect: "Heightened Senses", Effect Duration: 67
 423	alkaline cordial of concentration	0		Effect: "Deep-Seated Rage", Effect Duration: 49
 424	cold-filtered jittery ointment of the occult	0		Effect: "Lubed", Effect Duration: 11
-425	vacuum-sealed extra-modified lime green jittery oil of expertise	0		Effect: "Scorpio Rising", Effect Duration: 24
+425	vacuum-sealed extra-modified jittery lime green oil of expertise	0		Effect: "Scorpio Rising", Effect Duration: 24
 426	non-anodized fuchsia potion of temporary gr8ness	0		Effect: "Familial Ties", Effect Duration: 46
 427	mirror beefy box	0		Muscle: +10, Wiki Name: "box"
 428	blinking nothing-in-the-box	0		
@@ -456,7 +456,7 @@
 458	continuum transfunctioner	0		
 459	pixel	0		
 460	pixel	0		
-461	blurry teal pixel	0		
+461	teal blurry pixel	0		
 462	pixel	0		
 463	wobbly pixel	0		
 464	pixel potion	0		
@@ -486,20 +486,20 @@
 488	guitar pick	0		
 489	skewed drab sonata	0		
 490	double-paned wicked mesh cap	0		Spell Damage: +5, Cold Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 41"
-491	bouncing gray enormous belt buckle	0		
+491	gray bouncing enormous belt buckle	0		
 492	lime green jittery flame-retardant ribald chaps	0		Sleaze Damage: +10, Hot Resistance: +1, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	mirror ketchup hound	0		
 494	spinning batblade of the scaredy-cat	0		Monster Level: -15
 495	mirror catgut	0		
 496	cat appendix	0		
 497	upside-down gnatwing	0		
-498	special decent big shaking papaya	5	good	Effect: "Purity of Spirit", Effect Duration: 45
+498	big special decent shaking papaya	5	good	Effect: "Purity of Spirit", Effect Duration: 45
 499	prompt fortified denim axe	0		Damage Absorption: +60, Adventures: +3
 500	Elf Farm Raffle ticket	0		
-501	moldy huge Elfin shortbread	6	crappy	
+501	huge moldy Elfin shortbread	6	crappy	
 502	jittery pagoda plans	0		
 503	adequate snack-sized skewered cat appendix	2	good	
-504	shaking narrow twirling evil arches	0		
+504	narrow twirling shaking evil arches	0		
 505	nippy gnatwing earring of the pedagogue	0		Experience: +3, Cold Damage: +10
 506	rotten enchanted Hell broth	4	crappy	Effect: "Took Eleven", Effect Duration: 30
 507	spinning stiffened thunderrr guitarrr	0		Damage Reduction: 1
@@ -509,7 +509,7 @@
 511	blurry Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	yummy Boris's key lime pie	4	awesome	
-514	miniature delicious Jarlsberg's key lime pie	2	awesome	
+514	delicious miniature Jarlsberg's key lime pie	2	awesome	
 515	spoiled enchanted Sneaky Pete's key lime pie	3	crappy	Effect: "Army of One", Effect Duration: 5
 516	ghostly Hey Deze map	0		
 517	frightening bejeweled accordion strap	0		Spooky Damage: +5, Class: "Accordion Thief"
@@ -521,7 +521,7 @@
 523	rewinged stab bat	0		
 524	drinkable twirling papaya sling	4	good	
 525	mirror grue egg	0		
-526	gray pulsating Frobozz Real-Estate Company Instant House (TM)	0		
+526	pulsating gray Frobozz Real-Estate Company Instant House (TM)	0		
 527	narrow volleyball	0		
 528	blood-faced volleyball	0		
 529	fertilized ghuol egg	0		
@@ -563,15 +563,15 @@
 565	careful hobo gloves	0		Monster Level: -10, Single Equip
 566	twirling nippy bum cheek	0		Cold Damage: +10, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	squat hermit script	0		
-568	stale super-sized Double Bacon Beelzeburger	5	decent	
-569	yummy huge Lord of the Flies-sized fries	10	awesome	
-570	special stale Chicken Sandwich	4	decent	Effect: "Shamboozled", Effect Duration: 35
+568	super-sized stale Double Bacon Beelzeburger	5	decent	
+569	huge yummy Lord of the Flies-sized fries	10	awesome	
+570	stale special Chicken Sandwich	4	decent	Effect: "Shamboozled", Effect Duration: 35
 571	Jumbo Dr. Lucifer	1	good	
 572	snack-sized moldy Children's Meal of the Damned	2	crappy	
 573	delicious noodles	3	awesome	
 574	spoiled noodles	3	crappy	
-575	bland small blinking painful penne pasta	2	decent	
-576	snack-sized special normal ravioli della hippy	2	good	Effect: "Abominably Slippery", Effect Duration: 30
+575	small bland blinking painful penne pasta	2	decent	
+576	special snack-sized normal ravioli della hippy	2	good	Effect: "Abominably Slippery", Effect Duration: 30
 577	tasty pr0n m4nic0tti	3	awesome	
 578	normal olive bouncing Hell ramen	4	good	
 579	moldy half-sized boring spaghetti	2	crappy	
@@ -580,7 +580,7 @@
 582	Himalayan Hidalgo sauce	0		
 583	adequate huge blinking fettucini Inconnu	3	good	
 584	moldy skewed shaking spaghetti with Skullheads	4	crappy	
-585	yummy jumbo special upside-down gnocchetti di Nietzsche	5	awesome	Effect: "Fit To Be Tide", Effect Duration: 40
+585	special yummy jumbo upside-down gnocchetti di Nietzsche	5	awesome	Effect: "Fit To Be Tide", Effect Duration: 40
 586	stylish ridiculously huge sword of temperance	0		Moxie: +25, Sleaze Resistance: +5
 587	aerosolized super-spiky hair gel	0		Effect: "critical.enh", Effect Duration: 35
 588	soft echo eyedrop antidote	0		
@@ -602,7 +602,7 @@
 604	Penultimate Fantasy chest	0		
 605	Tissue Paper Immateria	0		
 606	blinking Tin Foil Immateria	0		
-607	jittery teal Gauze Immateria	0		
+607	teal jittery Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
 609	S.O.C.K.	0		
 610	cyan procrastination potion	0		
@@ -611,7 +611,7 @@
 613	plot hole	0		
 614	denatured wet yellow probability potion	0		Effect: "Spooky Blur", Effect Duration: 36
 615	chaos butterfly	0		
-616	narrow upside-down furry fur	0		
+616	upside-down narrow furry fur	0		
 617	chilled dry Angry Farmer candy	0		Effect: "Inebriate Pride", Effect Duration: 53
 618	chilled chilled Mick's IcyVapoHotness Rub	0		Effect: "Sinuses For Miles", Effect Duration: 31
 619	fireproof needle	0		Hot Resistance: +3
@@ -636,12 +636,12 @@
 638	wobbly up-at-dawn Samson's asshat	0		Experience (Muscle): +5, Adventures: +5, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	bland abominable snowcone	3	decent	
 640	Ent cider	1	decent	
-641	tasty half-sized ghostly toast	2	awesome	
+641	half-sized tasty ghostly toast	2	awesome	
 642	skeleton key	0		
 643	huge skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	huge flavorless fruitcake	9	decent	
+646	flavorless huge fruitcake	9	decent	
 647	present	0		Last Available: "2004-11"
 648	Crimbo sword of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2004-10"
 649	rosewater-soaked Crimbo hat	0		Stench Resistance: +3, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
@@ -668,18 +668,18 @@
 670	smartaleck's lihc face	0		Moxie Percent: +30, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	grave robbing shovel of terror of the detective	0		Spooky Spell Damage: +10, Item Drop: +20
 672	rotten cranberries	3	crappy	
-673	high-proof mediocre vodka and cranberry	10	decent	
-674	bad watered-down green whiskey	2	decent	
+673	mediocre high-proof vodka and cranberry	10	decent	
+674	watered-down bad green whiskey	2	decent	
 675	yellow skull of the Bonerdagon of wisdom	0		Mysticality: +15
 676	dragonbone belt buckle	0		
 677	badass belt of the detective	0		Item Drop: +20
 678	squat chest of the Bonerdagon	0		
-679	high-proof aged mirror mirror roll in the hay	9	awesome	
-680	hand-crafted special slap and tickle	3	EPIC	Effect: "Standard Cheer", Effect Duration: 20
+679	aged high-proof mirror mirror roll in the hay	9	awesome	
+680	special hand-crafted slap and tickle	3	EPIC	Effect: "Standard Cheer", Effect Duration: 20
 681	acceptable slip 'n' slide	3	good	
 682	bad squat a sump'm sump'm	3	decent	
 683	tolerable twirling horizontal tango	3	good	
-684	perfectly mixed tumbling skewed pink pony	4	EPIC	
+684	perfectly mixed skewed tumbling pink pony	4	EPIC	
 685	lard-coated supercool brainy Mr. Shirt	0		Mysticality: +5, Moxie Percent: +20, Sleaze Spell Damage: +25
 686	blurry maroon knuckles of the wise owl	0		Mysticality: +20
 687	colloidal bouncing blood of the Wereseal	0		Effect: "EVISCERATE!", Effect Duration: 21
@@ -732,10 +732,10 @@
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
 738	narrow stone tablet (Really Evil Rhythm)	0		
-739	huge ghostly tambourine bells	0		
+739	ghostly huge tambourine bells	0		
 740	tambourine of the empath	0		Familiar Weight: +5
 741	broken skull	0		
-742	stale enchanted miniature Knoll shroomkabob	2	decent	Effect: "Floundering", Effect Duration: 45
+742	miniature enchanted stale Knoll shroomkabob	2	decent	Effect: "Floundering", Effect Duration: 45
 743	huge spoiled mushroom	7	crappy	
 744	corrupted hair spray	0		Effect: "Floundering", Effect Duration: 59
 746	bouncing stat script	0		
@@ -749,8 +749,8 @@
 754	moldy huge jittery cream of pointy mushroom soup	7	crappy	
 755	adequate squat mushroom	3	good	
 756	super-sized rotten mushroom	5	crappy	
-757	massive flavorless gray mushroom	9	decent	
-758	small decent ghost cucumber	2	good	
+757	flavorless massive gray mushroom	9	decent	
+758	decent small ghost cucumber	2	good	
 759	tumbling dill	0		
 760	vinegar	0		
 761	brine	0		
@@ -776,12 +776,12 @@
 781	ionized quadruple-warmed blurry mafia aria	0		Effect: "Mo' Hobo", Effect Duration: 25
 782	bouncing Mr. Exploiter	0		Last Available: "2009-12"
 783	wobbly 'Villa' document	0		
-784	practically non-alcoholic tolerable Acqua Del Piatto Merlot	1	good	Last Available: "2004-10"
-785	wobbly fuchsia raffle ticket	0		
+784	tolerable practically non-alcoholic Acqua Del Piatto Merlot	1	good	Last Available: "2004-10"
+785	fuchsia wobbly raffle ticket	0		
 786	miniature flavorless strawberry	2	decent	
-787	strong hand-crafted upside-down bottle of rum	5	EPIC	
+787	hand-crafted strong upside-down bottle of rum	5	EPIC	
 788	artisanal strawberry daiquiri	4	EPIC	
-789	drinkable practically non-alcoholic rum and cola	1	good	
+789	practically non-alcoholic drinkable rum and cola	1	good	
 790	tolerable grog	4	good	
 791	resourceful razor-sharp Mafia bow tie	0		Weapon Damage Percent: +25, Maximum MP: +50, Last Available: "2004-10"
 792	greasy Golden Mr. Accessory	0		Sleaze Spell Damage: +10, Softcore Only
@@ -789,21 +789,21 @@
 794	nitrogenated vacuum-sealed ionized oil of slipperiness	0		Effect: "Aries Rising", Effect Duration: 14
 795	artisanal Acque Luride Grezze Cabernet	3	super EPIC	Last Available: "2004-10"
 796	stanky medical-grade occult cement shoes	0		Spell Damage Percent: +25, Stench Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10"
-797	smooth practically non-alcoholic wobbly rockin' wagon	1	awesome	
+797	practically non-alcoholic smooth wobbly rockin' wagon	1	awesome	
 798	lousy bouncing ocean motion	4	decent	
 799	weak drinkable fuzzbump	2	good	
 800	stale poutine	3	decent	
 801	flavorless gigantic olive Knob stir-fry	10	decent	
 804	thick adequate Knoll stir-fry	5	good	
-805	adequate big tumbling stir-fry	5	good	
+805	big adequate tumbling stir-fry	5	good	
 806	delicious asparagus stir-fry	4	awesome	
 807	enchanted moldy olive stir-fry	3	crappy	Effect: "Broken Fast", Effect Duration: 40
-808	super-sized adequate Knob sausage stir-fry	5	good	
-809	flavorless immense bat wing stir-fry	7	decent	
+808	adequate super-sized Knob sausage stir-fry	5	good	
+809	immense flavorless bat wing stir-fry	7	decent	
 810	stale blue rat appendix stir-fry	4	decent	
 811	decent skewed tofu stir-fry	3	good	
 812	miniature bland jittery pr0n stir-fry	2	decent	
-813	normal blurry blinking Knob shells	3	good	
+813	normal blinking blurry Knob shells	3	good	
 814	adequate b&auml;tzle	3	good	
 815	yummy ratini	4	awesome	
 816	spoiled half-sized Knob stroganoff	2	crappy	
@@ -827,14 +827,14 @@
 834	tumbling Jack Frost's cornuthaum of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	shaking weightlifter's ring of aggravate monster	0		Muscle: +15
 836	bland mind flayer corpse	4	decent	
-837	watered-down perfectly mixed Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
+837	perfectly mixed watered-down Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
 838	maroon flame-retardant medical-grade Mafia stogie	0		Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10"
-839	watered-down bad Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
+839	bad watered-down Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
 840	supercharged Sinatra's Mafia violin case	0		Experience (Moxie): +5, Maximum MP Percent: +30, Last Available: "2004-10"
 841	lousy triple-distilled tumbling tomato daiquiri	10	decent	
 842	hand-crafted mirror beertini	4	EPIC	
 843	mediocre pulsating salty slug	3	decent	
-844	distilled mediocre olive papaya slung	5	decent	
+844	mediocre distilled olive papaya slung	5	decent	
 845	razor-sharp MAHI fez	0		Weapon Damage Percent: +25, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	narrow heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -878,10 +878,10 @@
 887	leaf	0		
 888	maple leaf	0		
 889	purple clever balaclava	0		Maximum MP: +20, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	stale special balaclava baklava	3	decent	Effect: "Gemini Rising", Effect Duration: 30
+890	special stale balaclava baklava	3	decent	Effect: "Gemini Rising", Effect Duration: 30
 891	tumbling Warehouse 23 bling of bravery	0		Spooky Resistance: +5
 892	blinking groovy sage bugbear-smiting sword of temperance	0		Mysticality Percent: +10, Moxie Percent: +10, Sleaze Resistance: +5
-893	weak lousy lumbering jack	2	decent	
+893	lousy weak lumbering jack	2	decent	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	Ms. Accessory of the bloodbag	0		Maximum HP: +100, Softcore Only
 896	huge lion tamer's coward's Mr. Accessory Jr.	0		Monster Level: -20, Experience (familiar): +2, Softcore Only
@@ -920,8 +920,8 @@
 929	resourceful arse-shooting crossbow	0		Maximum MP: +50
 931	lousy spinning spiced rum	4	decent	
 932	mediocre eggnog	4	decent	
-933	big flavorless maroon candy cane	5	decent	
-934	decent small gingerbread bugbear	2	good	
+933	flavorless big maroon candy cane	5	decent	
+934	small decent gingerbread bugbear	2	good	
 935	careful imitation nice watch	0		Monster Level: -10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -936,14 +936,14 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	wobbly skewered cherry	0		Last Available: "2004-12"
 948	lousy ghostly martini	3	decent	Last Available: "2004-12"
-949	delicious irresponsibly strong grogtini	8	awesome	Last Available: "2004-12"
+949	irresponsibly strong delicious grogtini	8	awesome	Last Available: "2004-12"
 950	perfectly mixed triple-distilled cherry bomb	7	EPIC	Last Available: "2004-12"
 951	purple extra special Crimbo stocking	0		Last Available: "2004-12"
 952	clever quilted hockey mask	0		Damage Absorption: +40, Maximum MP: +20, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	teal smooth fez of etymology	0		Moxie: +15, Familiar Effect: "1xLep, cap 30"
-956	snack-sized delicious carob chunk noodles	2	awesome	
+956	delicious snack-sized carob chunk noodles	2	awesome	
 957	normal massive chorizo brownies	7	good	
 958	fancy flavorless squat chocolate and tomato pizza	3	decent	Effect: "Updated", Effect Duration: 30
 959	twirling flange	0		
@@ -990,26 +990,26 @@
 1003	huge soda water	0		
 1004	distilled perfectly mixed bottle of tequila	5	EPIC	
 1005	drinkable enchanted twirling boxed wine	4	good	Effect: "Remaining Alive", Effect Duration: 15
-1006	bite-sized adequate cherry	1	good	
+1006	adequate bite-sized cherry	1	good	
 1007	coconut shell of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xFairy, cap 7"
 1008	scandalous ice cubes	0		Sleaze Damage: +5
 1009	perfectly mixed bouncing vodka martini	4	EPIC	
 1010	hand-crafted watered-down whiskey and soda	2	EPIC	
-1011	practically non-alcoholic fancy acceptable monkey wrench	1	good	Effect: "Strong Grip", Effect Duration: 10
+1011	fancy acceptable practically non-alcoholic monkey wrench	1	good	Effect: "Strong Grip", Effect Duration: 10
 1012	drinkable tequila sunrise	3	good	
 1013	bad margarita	4	decent	
 1014	watered-down mediocre strawberry wine	2	decent	
 1015	artisanal wine spritzer	4	EPIC	
-1016	triple-distilled tolerable perpendicular hula	7	good	
+1016	tolerable triple-distilled perpendicular hula	7	good	
 1017	mediocre irresponsibly strong narrow ducha de oro	8	decent	
 1018	acceptable calle de miel	3	good	
 1019	artisanal dry vodka martini	3	EPIC	
-1020	delicious special fortified old-fashioned	5	awesome	Effect: "Sugar, Hello", Effect Duration: 25
+1020	fortified special delicious old-fashioned	5	awesome	Effect: "Sugar, Hello", Effect Duration: 25
 1021	mediocre tequila with training wheels	3	decent	
 1022	lousy sangria	4	decent	
 1023	delicious triple-distilled lime green vesper	9	awesome	Last Available: "2004-12"
 1024	tolerable bodyslam	3	good	Last Available: "2004-12"
-1025	practically non-alcoholic lousy sangria del diablo	1	decent	Last Available: "2004-12"
+1025	lousy practically non-alcoholic sangria del diablo	1	decent	Last Available: "2004-12"
 1026	mirror Valentine	0		Free Pull
 1027	whip kit	0		
 1028	blinking buckler buckle	0		
@@ -1031,13 +1031,13 @@
 1045	shaking beefy plastic bottle opener	0		Muscle: +10
 1046	ribald nasty traffic cone	0		Stench Damage: +5, Sleaze Damage: +10, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	watered-down bad N. O. Beer	2	decent	
-1048	dehydrated blinking teal oyster egg	1		Effect: "Yuletide Industry", Effect Duration: 50
+1048	dehydrated teal blinking oyster egg	1		Effect: "Yuletide Industry", Effect Duration: 50
 1049	boiled oyster egg	1		
 1050	twisted oyster egg	1		
 1051	olive plastic oyster egg	0		
 1052	vaporized spinning red oyster egg	1		
-1053	diluted blurry upside-down fuchsia oyster egg	1		
-1054	distilled olive blinking oyster egg	1		
+1053	diluted upside-down blurry fuchsia oyster egg	1		
+1054	distilled blinking olive oyster egg	1		
 1055	plastic oyster egg	0		
 1056	dried yellow puce oyster egg	1		Effect: "Super Speed", Effect Duration: 20
 1057	dried puce oyster egg	1		
@@ -1047,7 +1047,7 @@
 1061	denatured mauve oyster egg	1		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 30
 1062	compressed ghostly mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
-1064	denatured jittery narrow oyster egg	1		
+1064	denatured narrow jittery oyster egg	1		
 1065	pickled blue oyster egg	1		Effect: "Proprie Tea", Effect Duration: 40
 1066	boiled oyster egg	1		
 1067	plastic oyster egg	0		
@@ -1059,7 +1059,7 @@
 1073	modified blinking off-white oyster egg	1		Effect: "Expert Vacationer", Effect Duration: 50
 1074	denatured off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	dried ghostly twirling oyster egg	1		
+1076	dried twirling ghostly oyster egg	1		
 1077	mixed huge oyster egg	1		
 1078	vaporized squat oyster egg	1		Effect: "What's That Smell?", Effect Duration: 5
 1079	plastic oyster egg	0		
@@ -1085,7 +1085,7 @@
 1099	clockwork pants of extreme caution	0		Monster Level: -25, Familiar Effect: "3xPotato, 1.5xGhuol, cap 20"
 1100	chilly gnauga hide chaps	0		Cold Damage: +5, Familiar Effect: "atk, 4xBarrr, cap 20"
 1101	tumbling twirling false eyelashes	0		Familiar Weight: +5
-1102	lime green skewed targeting chip	0		
+1102	skewed lime green targeting chip	0		
 1103	tumbling unwound clockwork grapefruit	0		
 1104	lime green Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
@@ -1124,19 +1124,19 @@
 1138	blurry mushroom fermenting solution	0		
 1139	mediocre mushroom wine	3	decent	
 1140	perfectly mixed squat icy mushroom wine	3	EPIC	
-1141	lousy watered-down mushroom wine	2	decent	
-1142	watered-down mediocre blinking wobbly pointy mushroom wine	2	decent	
+1141	watered-down lousy mushroom wine	2	decent	
+1142	mediocre watered-down wobbly blinking pointy mushroom wine	2	decent	
 1143	acceptable flat mushroom wine	4	good	
 1144	bad cool mushroom wine	3	decent	
-1145	fancy distilled perfectly mixed knob mushroom wine	5	EPIC	Effect: "Litterboxing", Effect Duration: 30
-1146	perfectly mixed boozy knoll mushroom wine	5	EPIC	
-1147	fancy smooth mushroom wine	3	awesome	Effect: "Afternoon Insight", Effect Duration: 40
+1145	perfectly mixed fancy distilled knob mushroom wine	5	EPIC	Effect: "Litterboxing", Effect Duration: 30
+1146	boozy perfectly mixed knoll mushroom wine	5	EPIC	
+1147	smooth fancy mushroom wine	3	awesome	Effect: "Afternoon Insight", Effect Duration: 40
 1148	drinkable shot of flower schnapps	4	good	
-1149	adequate immense flower petal pie	6	good	
+1149	immense adequate flower petal pie	6	good	
 1150	acceptable bottle of single-barrel whiskey	3	good	
 1151	skewed reassuring wicked discarded plastic fork	0		Spell Damage: +5, Spooky Resistance: +1
 1152	narrow gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	yummy tiny cyan Retenez L'Herbe Pat&eacute;	1	awesome	
+1153	tiny yummy cyan Retenez L'Herbe Pat&eacute;	1	awesome	
 1154	altered pulsating Breathetastic&trade; Premium Canned Air	1	good	
 1155	letter from King Ralph XI	0		
 1157	mirror shaking studded wholeberd	0		Damage Absorption: +80
@@ -1182,16 +1182,16 @@
 1197	Mob Penguin	0		
 1198	wobbly blinking sabre-toothed lime	0		
 1199	bugbear	0		
-1200	flavorless wobbly upside-down mugcake	3	decent	
+1200	flavorless upside-down wobbly mugcake	3	decent	
 1201	rotten twirling urinal cake	4	crappy	
 1202	rotten miniature Happy Birthday, Claude! cake	2	crappy	
-1203	moldy huge shaking personalized birthday cake	7	crappy	
-1204	immense moldy three-tiered wedding cake	7	crappy	
+1203	huge moldy shaking personalized birthday cake	7	crappy	
+1204	moldy immense three-tiered wedding cake	7	crappy	
 1205	huge flavorless babycakes	9	decent	
 1206	toothsome velvet cake	4	awesome	
 1207	bland huge congratulatory cake	3	decent	
 1208	decent angel-food cake	3	good	
-1209	adequate miniature devil's-food cake	2	good	
+1209	miniature adequate devil's-food cake	2	good	
 1210	rotten birthday party jellybean cheesecake	3	crappy	
 1211	balloon	0		
 1212	squat balloon	0		
@@ -1219,12 +1219,12 @@
 1235	prompt Usain Bolt's pendant	0		Initiative: +80, Adventures: +3, Four Songs, Single Equip
 1236	teal nippy fortified hockey stick of furious angry rage	0		Damage Absorption: +60, Cold Damage: +10
 1237	olive tapped lotus	0		
-1238	red huge glowsticks	0		Familiar Weight: +5
+1238	huge red glowsticks	0		Familiar Weight: +5
 1239	gray blinking iced-out bling	0		Familiar Weight: +5
 1240	twirling limburger biker boots	0		Familiar Weight: +5
 1241	carton of clove cigarettes	0		Familiar Weight: +5
 1242	deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
-1243	jittery pulsating toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
+1243	pulsating jittery toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
 1244	squat flame-retardant Glass Balls of the Goblin King	0		Hot Resistance: +1
 1245	Codpiece of the Goblin King of the brute	0		Muscle Percent: +30, Single Equip
 1246	narrow auspicious healthy Herculean rib of the Bonerdagon	0		Experience (Muscle): +1, Maximum HP Percent: +20, Item Drop: +10
@@ -1232,10 +1232,10 @@
 1248	blinking stanky hardy wizardly Bonerdagon necklace	0		Mysticality: +25, Maximum HP: +50, Stench Spell Damage: +25
 1249	rosewater-soaked Boss Bat britches	0		Stench Resistance: +3, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	Boss Bat bling of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25
-1251	small normal jittery Knob shroomkabob	2	good	
+1251	normal small jittery Knob shroomkabob	2	good	
 1252	spoiled shroomkabob	3	crappy	
 1253	pile of jumping beans	0		
-1254	low-calorie moldy jumping bean burrito	1	crappy	
+1254	moldy low-calorie jumping bean burrito	1	crappy	
 1255	moldy jumping bean burrito	4	crappy	
 1256	spoiled jittery insanely jumping bean burrito	3	crappy	
 1257	decent rat scrapple	3	good	
@@ -1285,7 +1285,7 @@
 1301	galvanized deodorant	0		Effect: "Turkey-Agitated", Effect Duration: 35
 1302	warmed reodorant	0		Effect: "The Power of LOV", Effect Duration: 46
 1303	Mjolnir Jr.	0		
-1304	shaking wobbly doppelshifter egg	0		Free Pull
+1304	wobbly shaking doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
 1306	Jim Carey's Da Vinci's traffic cone	0		Experience (Mysticality): +5, Monster Level: +25, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	blue calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
@@ -1301,7 +1301,7 @@
 1317	blood flower	0		
 1318	huge lovecat tail	0		
 1319	gray ghostly plastic passion fruit	0		
-1320	half-sized rotten questionable taco	2	crappy	
+1320	rotten half-sized questionable taco	2	crappy	
 1321	olive Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	scandalous time helmet	0		Sleaze Damage: +5, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
@@ -1325,7 +1325,7 @@
 1342	ghostly yellow picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
 1344	energized Gummi-Gnauga	0		Effect: "Dreadful Smell", Effect Duration: 32
-1345	quantum concentrated blinking huge Now and Earlier	0		Effect: "Oiled Skin", Effect Duration: 42, Last Available: "2020-09"
+1345	quantum concentrated huge blinking Now and Earlier	0		Effect: "Oiled Skin", Effect Duration: 42, Last Available: "2020-09"
 1346	quadruple-chilled green Sugar Cog	0		Effect: "Inner Dog", Effect Duration: 34
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	empty blowgun	0		Last Available: "2005-11"
@@ -1349,7 +1349,7 @@
 1366	super-sized decent tofurkey gravy	5	good	
 1367	decent immense herbal stuffing	9	good	
 1368	yummy can-shaped gelatinous cranberry sauce	3	awesome	
-1369	tasty snack-sized yams	2	awesome	
+1369	snack-sized tasty yams	2	awesome	
 1370	maroon rhinestone cowboy shirt of the cougar	0		Moxie: +20
 1371	frosty gingham blouse	0		Cold Spell Damage: +10
 1372	huge electrified souvenir ski t-shirt	0		MP Regen Min: 3, MP Regen Max: 5
@@ -1389,11 +1389,11 @@
 1407	bland bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	tasty tree-shaped Crimbo cookie	3	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	inspector's Unionize The Elves sign	0		Item Drop: +15, Last Available: "2005-12"
-1410	teal huge sleeping snowy owl	0		Last Available: "2005-12"
+1410	huge teal sleeping snowy owl	0		Last Available: "2005-12"
 1411	shaking Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	colloidal snowcone	0		Effect: "Demonic Taint", Effect Duration: 18, Last Available: "2006-01"
 1413	super-aerosolized squat snowcone	0		Effect: "Icy Composition", Effect Duration: 25, Last Available: "2006-01"
-1414	galvanized chilled gray jittery snowcone	0		Effect: "Hyperoxygenated Blood", Effect Duration: 52, Last Available: "2006-01"
+1414	galvanized chilled jittery gray snowcone	0		Effect: "Hyperoxygenated Blood", Effect Duration: 52, Last Available: "2006-01"
 1415	adjusted deionized blurry mirror snowcone	0		Effect: "Human-Penguin Hybrid", Effect Duration: 65, Last Available: "2006-01"
 1416	quadruple-cold-filtered snowcone	0		Effect: "Spiky Frozen Hair", Effect Duration: 68, Last Available: "2006-01"
 1417	deionized ionized narrow snowcone	0		Effect: "Buttermilk Boogie", Effect Duration: 67, Last Available: "2006-01"
@@ -1402,13 +1402,13 @@
 1420	Sherlock's traffic cone of the bloodbag	0		Maximum HP: +100, Item Drop: +25, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	twirling Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
-1423	ghostly bouncing iceberglet	0		Last Available: "2006-02"
+1423	bouncing ghostly iceberglet	0		Last Available: "2006-02"
 1424	Jim Carey's arcane researcher's ice sickle	0		Experience Percent (Mysticality): +10, Monster Level: +25, Softcore Only, Last Available: "2006-02"
 1425	lion tamer's ice baby	0		Experience (familiar): +2, Softcore Only, Last Available: "2006-02"
 1426	jittery ice pick of the overflowing toilet	0		Stench Spell Damage: +50, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	fortified thinker's ice skates	0		Mysticality: +10, Damage Absorption: +60, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	huge stale special grue egg omelette	8	decent	Effect: "Trivia Master", Effect Duration: 25
-1429	upside-down blurry roll of drink tickets	0		
+1428	stale special huge grue egg omelette	8	decent	Effect: "Trivia Master", Effect Duration: 25
+1429	blurry upside-down roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	twirling pregnant mushroom	0		
 1432	delicious huge mushroom	6	awesome	
@@ -1423,7 +1423,7 @@
 1441	unsweetened activated powder	0		Effect: "Prince of Seaside Town", Effect Duration: 59
 1442	cold-filtered stench powder	0		Effect: "Fratty Flavor", Effect Duration: 16
 1443	polarized vacuum-sealed huge sleaze powder	0		Effect: "Inebriate Pride", Effect Duration: 56
-1444	dry tarnished ionized fuchsia jittery twinkly nuggets	0		Effect: "Glittering Eyelashes", Effect Duration: 11
+1444	dry tarnished ionized jittery fuchsia twinkly nuggets	0		Effect: "Glittering Eyelashes", Effect Duration: 11
 1445	liquefied oxidized hot nuggets	0		Effect: "Sated and Furious", Effect Duration: 56
 1446	ionized colloidal jittery twirling yellow nuggets	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 16
 1447	dry shaking nuggets	0		Effect: "Void Between the Stars", Effect Duration: 11
@@ -1437,10 +1437,10 @@
 1455	diluted sleaze wad	1		
 1456	twirling double daisy	0		
 1457	Goth Giant	0		
-1458	fancy adequate tumbling Valentine's Day cake	3	good	Effect: "Bottle in front of Me", Effect Duration: 30
+1458	adequate fancy tumbling Valentine's Day cake	3	good	Effect: "Bottle in front of Me", Effect Duration: 30
 1459	red arrow'd heart balloon	0		
 1460	velvet box	0		
-1461	shaking narrow squashed frog	0		
+1461	narrow shaking squashed frog	0		
 1462	eye of newt	0		
 1463	bouncing salamander spleen	0		
 1464	sleazy fairy gravy	0		
@@ -1455,11 +1455,11 @@
 1473	ball-and-chain	0		
 1474	automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	mirror narrow wobbly goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	narrow wobbly mirror goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	huge salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	olive football helmet	0		Familiar Effect: "atk, cap 37"
-1480	purple tumbling skewed chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
+1480	tumbling purple skewed chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
@@ -1475,7 +1475,7 @@
 1493	nippy ridiculously overelaborate ninja weapon of the sewer	0		Cold Damage: +10, Stench Damage: +25
 1494	improved pickled liquefied sugar-coated pine cone	0		Effect: "Antibiotic Saucesphere", Effect Duration: 27, Last Available: "2020-09"
 1495	shaking blinking blue traffic cone of the storm of horror	0		Maximum MP Percent: +40, Spooky Spell Damage: +25, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	extra-dry enchanted drinkable gloomy mushroom wine	5	good	Effect: "Chilblains of the Corn", Effect Duration: 40
+1496	drinkable extra-dry enchanted gloomy mushroom wine	5	good	Effect: "Chilblains of the Corn", Effect Duration: 40
 1497	weak artisanal mushroom wine	2	super EPIC	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1488,7 +1488,7 @@
 1506	artisanal calle de miel with a fly in it	3	EPIC	Last Available: "2006-04"
 1507	mediocre practically non-alcoholic wobbly rockin' wagon with a fly in it	1	decent	Last Available: "2006-04"
 1508	lousy perpendicular hula with a fly in it	3	decent	Last Available: "2006-04"
-1509	watered-down perfectly mixed slap and tickle with a fly in it	2	EPIC	Last Available: "2006-04"
+1509	perfectly mixed watered-down slap and tickle with a fly in it	2	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	wicked fake hand	0		Spell Damage: +5, Last Available: "2006-04"
 1512	dehydrated upside-down Knob Goblin pet-buffing spray	1		
@@ -1508,7 +1508,7 @@
 1527	narrow diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	wool corkscrew of horror	0		Spooky Spell Damage: +25, Cold Resistance: +1, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
-1530	squat jittery fake plastic grass	0		Last Available: "2011-01"
+1530	jittery squat fake plastic grass	0		Last Available: "2011-01"
 1531	Da Vinci's grass skirt	0		Experience (Mysticality): +5, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
 1532	MacGyver's grass hat	0		Maximum MP: +100, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	fuchsia grass blade of the bloodbag	0		Maximum HP: +100, Last Available: "2011-01"
@@ -1528,51 +1528,51 @@
 1548	tumbling Gazpacho's Glacial Grimoire of Leguizamo of the early riser	0		Monster Level: +20, Adventures: +7
 1549	MSG	0		
 1550	lime green second-hand knockoff engagement ring of James Dean	0		Experience (Moxie): +3, Single Equip
-1551	hand-crafted triple-distilled fancy bottle of Domesticated Turkey	10	EPIC	Effect: "Shredding, Sweating", Effect Duration: 45
+1551	fancy hand-crafted triple-distilled bottle of Domesticated Turkey	10	EPIC	Effect: "Shredding, Sweating", Effect Duration: 45
 1552	practically non-alcoholic smooth bottle of Definit	1	awesome	
 1553	acceptable bottle of Calcutta Emerald	3	good	
-1554	lousy practically non-alcoholic bottle of Lieutenant Freeman	1	decent	
+1554	practically non-alcoholic lousy bottle of Lieutenant Freeman	1	decent	
 1555	hand-crafted triple-distilled bottle of Jorge Sinsonte	6	EPIC	
 1556	triple-distilled artisanal boxed champagne	9	EPIC	
-1557	tasty small kumquat	2	awesome	
+1557	small tasty kumquat	2	awesome	
 1558	moldy tangerine	4	crappy	
 1559	green tonic water	0		
 1560	rotten cocktail onion	4	crappy	
 1561	adequate raspberry	3	good	
 1562	spoiled kiwi	3	crappy	
-1563	perfectly mixed practically non-alcoholic green whiskey bittersweet	1	super EPIC	
+1563	practically non-alcoholic perfectly mixed green whiskey bittersweet	1	super EPIC	
 1564	hand-crafted spirit-forward pulsating mimosette	5	EPIC	
 1565	bad tequila sunset	3	decent	
-1566	lousy high-proof zmobie	9	decent	Wiki Name: "Zmobie (drink)"
+1566	high-proof lousy zmobie	9	decent	Wiki Name: "Zmobie (drink)"
 1567	strong perfectly mixed olive gin and tonic	5	EPIC	
-1568	mediocre irresponsibly strong vodka and tonic	7	decent	
+1568	irresponsibly strong mediocre vodka and tonic	7	decent	
 1569	lousy ghostly vodka gibson	3	decent	
 1570	hand-crafted gibson	3	EPIC	
-1571	watered-down drinkable purple parisian cathouse	2	good	
+1571	drinkable watered-down purple parisian cathouse	2	good	
 1572	practically non-alcoholic artisanal purple rabbit punch	1	super EPIC	
 1573	delicious caipifruta	3	awesome	
 1574	tolerable teqiwila	3	good	
 1575	acceptable Divine	3	good	
-1576	mediocre practically non-alcoholic jittery Gordon Bennett	1	decent	
+1576	practically non-alcoholic mediocre jittery Gordon Bennett	1	decent	
 1577	boozy aged tangarita	5	awesome	
 1578	delicious extra-dry mandarina colada	5	awesome	
 1579	bad gimlet	3	decent	
 1580	smooth brick road	3	awesome	
 1581	tolerable weak vodka stratocaster	2	good	
-1582	mediocre weak red Neuromancer	2	decent	
-1583	tolerable high-proof upside-down prussian cathouse	7	good	
+1582	weak mediocre red Neuromancer	2	decent	
+1583	high-proof tolerable upside-down prussian cathouse	7	good	
 1584	aged Mae West	3	awesome	
 1585	bad Mon Tiki	3	decent	
 1586	triple-distilled acceptable teqiwila slammer	8	good	
 1587	adequate Knob lo mein	4	good	
 1588	decent bouncing asparagus lo mein	3	good	
 1589	adequate Knoll lo mein	3	good	
-1590	low-calorie stale wobbly lo mein	1	decent	
-1591	yummy huge blurry olive lo mein	10	awesome	
+1590	stale low-calorie wobbly lo mein	1	decent	
+1591	huge yummy blurry olive lo mein	10	awesome	
 1592	half-sized tasty hot hi mein	2	awesome	
 1593	stale tumbling hi mein	3	decent	
 1594	flavorless hi mein	3	decent	
-1595	flavorless low-calorie squat hi mein	1	decent	
+1595	low-calorie flavorless squat hi mein	1	decent	
 1596	adequate spinning sleazy hi mein	3	good	
 1597	jittery rosewater-soaked Junior LAAAAME merit badge	0		Stench Resistance: +3, Last Available: "2006-05"
 1598	scandalous Senior LAAAAME merit badge	0		Sleaze Damage: +5, Last Available: "2006-05"
@@ -1580,10 +1580,10 @@
 1600	bad blurry tangarita with a fly in it	3	decent	
 1601	perfectly mixed narrow mandarina colada with a fly in it	3	EPIC	
 1602	weak smooth prussian cathouse with a fly in it	2	awesome	
-1603	special drinkable maroon bouncing Mae West with a fly in it	3	good	Effect: "Bilious Brawn", Effect Duration: 25
+1603	special drinkable bouncing maroon Mae West with a fly in it	3	good	Effect: "Bilious Brawn", Effect Duration: 25
 1604	compressed astronaut ice-cream	1		Last Available: "2006-05"
 1605	bouncing delectable catalyst	0		
-1606	powdered tumbling pulsating ultimate wad	1		
+1606	powdered pulsating tumbling ultimate wad	1		
 1607	double-flattened diffused yellow libation of liveliness	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 46
 1608	flattened liquefied ionized eyedrops of the ermine	0		Effect: "Thunderspell", Effect Duration: 69
 1609	dry ghostly blue perfume of prejudice	0		Effect: "Ponderous Potency", Effect Duration: 58
@@ -1673,12 +1673,12 @@
 1693	concentrated twirling eyedrops of newt	0		Effect: "Slimily Speedy", Effect Duration: 43
 1694	magnetized Frogade	0		Effect: "Cold as Ice", Effect Duration: 43
 1695	super-denatured Vulcanized quantum papotion of papower	0		Effect: "Wet Willied", Effect Duration: 20
-1696	special toothsome tiny upside-down royal jelly taco	1	awesome	Effect: "Black Lung", Effect Duration: 5
+1696	special tiny toothsome upside-down royal jelly taco	1	awesome	Effect: "Black Lung", Effect Duration: 5
 1697	moldy fuchsia tofu taco	4	crappy	
 1698	bland bouncing maroon jumping bean taco	4	decent	
 1699	adequate immense upside-down catgut taco	6	good	
 1700	rotten goat cheese taco	3	crappy	
-1701	jumbo flavorless pr0n taco	5	decent	
+1701	flavorless jumbo pr0n taco	5	decent	
 1702	liquefied polymerized maroon squat alphabet gum	0		Effect: "Armored Innards", Effect Duration: 36
 1703	bouncing Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1740,7 +1740,7 @@
 1761	executive chilly foon of foulness	0		Cold Damage: +5, Meat Drop: +40
 1762	twirling sharpshooter's experienced foon of fearfulness	0		Experience: +2, Critical Hit Percent: +10
 1763	ghostly sage slick foon of fleshiness	0		Moxie: +10, Mysticality Percent: +10
-1764	blinking spinning Spookyraven library key	0		
+1764	spinning blinking Spookyraven library key	0		
 1765	mirror Spookyraven gallery key	0		
 1766	Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
@@ -1754,7 +1754,7 @@
 1775	beefcake's dishrag	0		Muscle: +25
 1776	bland stale baguette	3	decent	
 1777	leftovers of indeterminate origin	0		
-1778	stale snack-sized huge dinner	2	decent	
+1778	snack-sized stale huge dinner	2	decent	
 1779	twirling Sherlock's katana	0		Item Drop: +25
 1780	bouncing baleful ram stick	0		Spell Damage: +25
 1781	enchantlers of Flo-Jo	0		Initiative: +100, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1762,15 +1762,15 @@
 1783	moldy crazy Turkish delight	4	crappy	
 1784	educational Snow Queen Crown of the wise owl	0		Mysticality: +20, Experience: +1, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	dog trainer's medical-grade steel-toed ga-ga radio	0		Damage Reduction: 9, Experience (familiar): +1, HP Regen Min: 7, HP Regen Max: 10
-1786	jittery cyan six pack of Mountain Stream	0		
-1787	flattened double-diffused jittery twirling bag of Cheat-Os	0		Effect: "In Vino Vires", Effect Duration: 27
+1786	cyan jittery six pack of Mountain Stream	0		
+1787	flattened double-diffused twirling jittery bag of Cheat-Os	0		Effect: "In Vino Vires", Effect Duration: 27
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
 1790	artisanal teal Ram's Face Lager	3	EPIC	
 1791	ram horns	0		
 1792	gray squat executive supercharged Travoltan trousers of the pedagogue	0		Experience: +3, Maximum MP Percent: +30, Meat Drop: +40, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	blue friendly resourceful pool cue	0		Maximum MP: +50, Familiar Weight: +3
-1794	flattened ionized squat wobbly handful of hand chalk	0		Effect: "Adrenaline Rush", Effect Duration: 13
+1794	flattened ionized wobbly squat handful of hand chalk	0		Effect: "Adrenaline Rush", Effect Duration: 13
 1795	Counterclockwise Watch of the scaredy-cat	0		Monster Level: -15, Single Equip
 1796	bone collar	0		Familiar Weight: +5
 1797	bouncing misshapen animal skeleton	0		
@@ -1791,7 +1791,7 @@
 1812	fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
-1815	squat jittery seventh thoracic vertebra	0		
+1815	jittery squat seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
@@ -1807,7 +1807,7 @@
 1828	sacral vertebrae	0		
 1829	spinning first caudal vertebra	0		
 1830	second caudal vertebra	0		
-1831	pulsating mirror third caudal vertebra	0		
+1831	mirror pulsating third caudal vertebra	0		
 1832	fourth caudal vertebra	0		
 1833	gray fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
@@ -1823,7 +1823,7 @@
 1844	left sixth rib	0		
 1845	left seventh rib	0		
 1846	shaking left eighth rib	0		
-1847	skewed wobbly left ninth rib	0		
+1847	wobbly skewed left ninth rib	0		
 1848	left tenth rib	0		
 1849	left eleventh rib	0		
 1850	left twelfth rib	0		
@@ -1847,7 +1847,7 @@
 1868	left humerus	0		
 1869	blurry right humerus	0		
 1870	green left radius	0		
-1871	ghostly green right radius	0		
+1871	green ghostly right radius	0		
 1872	left ulna	0		
 1873	wobbly right ulna	0		
 1874	left femur	0		
@@ -1888,7 +1888,7 @@
 1911	studded clockwork staff of the brute of the blizzard	0		Muscle Percent: +30, Damage Absorption: +80, Cold Spell Damage: +25
 1912	blurry Jeselnik's clockwork crossbow of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, Sleaze Damage: +25
 1913	clockwork handle	0		
-1914	shaking wobbly clockwork rod	0		
+1914	wobbly shaking clockwork rod	0		
 1915	twirling clockwork shank	0		
 1916	cyan Lord Spookyraven's spectacles	0		
 1917	squat wallet	0		
@@ -1924,13 +1924,13 @@
 1947	worn tophat of doom of bravery	0		Spooky Spell Damage: +50, Spooky Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	blinking banded grievous tap shoes	0		Weapon Damage Percent: +50, Damage Absorption: +100, Single Equip
 1949	decent squat Manetwich	3	good	
-1950	fuchsia shaking shaking bottle of Vangoghbitussin	0		
+1950	shaking shaking fuchsia bottle of Vangoghbitussin	0		
 1951	acceptable bottle of Pinot Renoir	4	good	
-1952	half-sized special rotten wobbly desiccated apricot	2	crappy	Effect: "Inappropriate Spirit", Effect Duration: 10
-1953	hand-crafted irresponsibly strong flute of flat champagne	8	EPIC	
+1952	half-sized rotten special wobbly desiccated apricot	2	crappy	Effect: "Inappropriate Spirit", Effect Duration: 10
+1953	irresponsibly strong hand-crafted flute of flat champagne	8	EPIC	
 1954	flavorless dehydrated caviar	4	decent	
 1955	narrow styrofoam peanuts	0		
-1956	lousy upside-down huge snifter of thoroughly aged brandy	4	decent	
+1956	lousy huge upside-down snifter of thoroughly aged brandy	4	decent	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	huge spinning tattered scrap of paper	0		
@@ -1960,7 +1960,7 @@
 1983	skewed hand turkey	0		
 1984	narrow snowy owl	0		
 1985	scary death orb	0		
-1986	maroon ghostly mind flayer	0		
+1986	ghostly maroon mind flayer	0		
 1987	undead elbow macaroni	0		
 1988	angry cow	0		
 1989	upside-down Cheshire bitten	0		
@@ -1994,13 +1994,13 @@
 2017	spade necklace	0		
 2018	lime green club necklace	0		
 2019	cream pie	0		Free Pull
-2020	moldy big squat ghostly cherry pie	5	crappy	
+2020	moldy big ghostly squat cherry pie	5	crappy	
 2021	spoiled shaking strawberry pie	4	crappy	
 2022	stale lemon meringue pie	3	decent	
 2023	Genalen&trade; Bottle	1	good	
 2024	flavorless big bouncing mixed wildflower greens	5	decent	
-2025	flavorless big twirling handful of walnuts	5	decent	
-2026	super-sized rotten nutty organic salad	5	crappy	
+2025	big flavorless twirling handful of walnuts	5	decent	
+2026	rotten super-sized nutty organic salad	5	crappy	
 2027	decent super salad	4	good	
 2028	bite-sized bland gray spinning tofu wonton	1	decent	
 2029	skewed hippy protest button	0		Single Equip
@@ -2010,8 +2010,8 @@
 2033	strapping round sunglasses	0		Muscle: +5, Single Equip
 2034	blurry wicked wicker shield	0		Spell Damage: +5, Damage Reduction: 11
 2035	jittery squat Marquis de Poivre soda	0		
-2036	enhanced galvanized blurry maroon radium-flavored potato chips	0		Effect: "Pork Power", Effect Duration: 44
-2037	warmed narrow purple wintergreen-flavored potato chips	0		Effect: "Superheroic", Effect Duration: 41
+2036	enhanced galvanized maroon blurry radium-flavored potato chips	0		Effect: "Pork Power", Effect Duration: 44
+2037	warmed purple narrow wintergreen-flavored potato chips	0		Effect: "Superheroic", Effect Duration: 41
 2038	enhanced twirling ennui-flavored potato chips	0		Effect: "Piratastic", Effect Duration: 63
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
@@ -2142,7 +2142,7 @@
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	blue Annie Oakley's energetic toy ray gun	0		Maximum MP Percent: +20, Critical Hit Percent: +20, Last Available: "2006-12"
 2169	prompt quilted toy space helmet	0		Damage Absorption: +40, Adventures: +3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
-2170	blue upside-down MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
+2170	upside-down blue MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
 2171	shaking shellacked padded astronaut pants	0		Damage Absorption: +20, Damage Reduction: 7, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	pulsating toy jet pack of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12"
 2173	triangular stone	0		
@@ -2159,15 +2159,15 @@
 2184	Harold's hammer	0		
 2185	narrow foul-smelling Kiss the Knob apron	0		Stench Damage: +10
 2186	unlit birthday cake	0		
-2187	spinning teal lit birthday cake	0		
+2187	teal spinning lit birthday cake	0		
 2188	flask of peppermint oil	1	EPIC	Last Available: "2006-12"
-2189	mediocre practically non-alcoholic flask of peppermint schnapps	1	decent	Last Available: "2006-12"
-2190	blue spinning yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
+2189	practically non-alcoholic mediocre flask of peppermint schnapps	1	decent	Last Available: "2006-12"
+2190	spinning blue yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	mirror sheet music	0		Last Available: "2006-12"
-2193	bland snack-sized jittery candy stake	2	decent	Last Available: "2006-12"
-2194	special weak perfectly mixed wobbly upside-down eggnog	2	EPIC	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45, Last Available: "2006-12"
-2195	jumbo stale unspeakable fruitcake	5	decent	Last Available: "2006-12"
+2193	snack-sized bland jittery candy stake	2	decent	Last Available: "2006-12"
+2194	perfectly mixed special weak wobbly upside-down eggnog	2	EPIC	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45, Last Available: "2006-12"
+2195	stale jumbo unspeakable fruitcake	5	decent	Last Available: "2006-12"
 2196	snack-sized spoiled gingerbread horror	2	crappy	Last Available: "2006-12"
 2197	denatured galvanized colloidal upside-down but probably evil chocolate	0		Effect: "Tennis Elbow-wow", Effect Duration: 62, Last Available: "2006-12"
 2198	bland blinking bat-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
@@ -2190,7 +2190,7 @@
 2215	smartaleck's Tropical Crimbo Hat	0		Moxie Percent: +30, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
 2216	flame-wreathed Tropical Crimbo Shorts	0		Hot Spell Damage: +10, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	tasty super ka-bob	3	awesome	
-2218	small rotten fancy beer basted brat	2	crappy	Effect: "Bear Clawed", Effect Duration: 25
+2218	rotten fancy small beer basted brat	2	crappy	Effect: "Bear Clawed", Effect Duration: 25
 2219	squat lime green tumbling healthy Tropical Crimbo Sword	0		Maximum HP Percent: +20, Last Available: "2006-12"
 2220	irradiated blinking and Crimboween candy	0		Effect: "Insulated Trousers", Effect Duration: 53, Last Available: "2020-09"
 2221	mirror Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2209,7 +2209,7 @@
 2234	smelly calavera concertina	0		Stench Spell Damage: +10, Song Duration: 7
 2235	Lo Pan's Herculean ratarang	0		Experience (Muscle): +1, Spell Critical Percent: +30
 2236	magnetized unsweetened turtle pheromones	0		Effect: "BOOsted", Effect Duration: 40
-2237	twirling teal pygmy blowgun	0		
+2237	teal twirling pygmy blowgun	0		
 2238	strapping pygmy nose-bone	0		Muscle: +5, Single Equip
 2239	purple MacGyver's grievous bad voodoo mask	0		Weapon Damage Percent: +50, Maximum MP: +100, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	bottle of alcohol	0		
@@ -2235,18 +2235,18 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	flavorless tiny fancy stunt nuts	1	decent	Effect: "Hip to Be Square Dancin'", Effect Duration: 50
+2264	tiny fancy flavorless stunt nuts	1	decent	Effect: "Hip to Be Square Dancin'", Effect Duration: 50
 2265	moldy wet stew	3	crappy	
 2266	huge wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats of the boozehound	0		Booze Drop: +100
 2269	stale sausage wonton	4	decent	
 2270	knitted sinister belt	0		Spell Damage: +10, Cold Resistance: +3, Single Equip
-2271	tolerable special bottle of Merlot	4	good	Effect: "Headstrong", Effect Duration: 40
-2272	enchanted watered-down hand-crafted blinking bottle of Port	2	EPIC	Effect: "Springy Fusilli", Effect Duration: 35
+2271	special tolerable bottle of Merlot	4	good	Effect: "Headstrong", Effect Duration: 40
+2272	watered-down enchanted hand-crafted blinking bottle of Port	2	EPIC	Effect: "Springy Fusilli", Effect Duration: 35
 2273	hand-crafted bottle of Pinot Noir	3	EPIC	
 2274	perfectly mixed watered-down bottle of Zinfandel	2	EPIC	
-2275	irresponsibly strong perfectly mixed bottle of Marsala	10	EPIC	
+2275	perfectly mixed irresponsibly strong bottle of Marsala	10	EPIC	
 2276	hand-crafted bottle of Muscat	4	EPIC	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2295,7 +2295,7 @@
 2321	worm-riding manual page 2	0		
 2322	worm-riding manual pages 3-15	0		
 2323	headpiece of the Staff of Ed	0		
-2324	fuchsia upside-down Staff of Ed, almost	0		
+2324	upside-down fuchsia Staff of Ed, almost	0		
 2325	Staff of Ed	0		
 2326	blurry stone rose	0		
 2327	energized non-frozen twirling blinking can of paint	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 65
@@ -2303,7 +2303,7 @@
 2329	blinking handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	rotten small red wobbly Better Than Cuddling Cake	2	crappy	
+2332	small rotten red wobbly Better Than Cuddling Cake	2	crappy	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2347,7 +2347,7 @@
 2373	spoiled immense pulsating mirror banana	8	crappy	
 2374	huge banana peel	0		
 2375	normal huge banana cream pie	3	good	
-2376	distilled acceptable banana daiquiri	5	good	
+2376	acceptable distilled banana daiquiri	5	good	
 2377	weak drinkable tumbling bungle in the jungle	2	good	
 2378	bouncing banana spritzer	0		
 2379	denatured corrupted banana smoothie	0		Effect: "Truly Gritty", Effect Duration: 32
@@ -2396,21 +2396,21 @@
 2422	adjusted quantum irradiated pet snacks	0		Effect: "Ruby-ous", Effect Duration: 51
 2423	triple-adjusted activated Mick's IcyVapoHotness Inhaler	0		Effect: "Moon-Eyed", Effect Duration: 61
 2424	concentrated cyclops eyedrops	0		Effect: "Discomfited", Effect Duration: 56
-2425	polarized lime green bouncing can of spinach	0		Effect: "Spooky Demeanor", Effect Duration: 19
+2425	polarized bouncing lime green can of spinach	0		Effect: "Spooky Demeanor", Effect Duration: 19
 2426	magnetized extra-electrified blurry fire flower	0		Effect: "Fire Inside", Effect Duration: 28
 2427	warmed upside-down freezerburned ice cube	0		Effect: "Wistfully Nostalgic", Effect Duration: 17
 2428	irradiated Vulcanized ghostly fake blood	0		Effect: "Penguinny Flavor", Effect Duration: 11
 2429	anodized magnetized huge Eau de Guaneau	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 30
 2430	polymerized bouncing bag of lard	0		Effect: "Shoesauce", Effect Duration: 40
 2431	dry jittery bottle of Mystic Shell	0		Effect: "Coated Arms", Effect Duration: 60
-2432	nitrogenated anodized ghostly maroon SPF 451 lip balm	0		Effect: "Radiated and Grodiated", Effect Duration: 33
+2432	nitrogenated anodized maroon ghostly SPF 451 lip balm	0		Effect: "Radiated and Grodiated", Effect Duration: 33
 2433	adjusted triple-quantum bottle of antifreeze	0		Effect: "Orchid Blood", Effect Duration: 55
 2434	alkaline upside-down eyedrops	0		Effect: "Frog In Your Throat", Effect Duration: 67
 2435	magnetized super-quantum Dogsgotnonoz pills	0		Effect: "Coldfinger", Effect Duration: 35
 2436	magnetized ionized shaking donkey flipbook	0		Effect: "Alacri Tea", Effect Duration: 50
 2437	New Cloaca-Cola	0		
 2438	huge scented massage oil	0		
-2439	ghostly olive poltergeist-in-the-jar-o	0		
+2439	olive ghostly poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
 2441	cyan Knob Goblin Encryption Key	0		
 2442	maroon Cobb's Knob map	0		
@@ -2434,9 +2434,9 @@
 2460	blurry wholesome yak toupee	0		Maximum HP Percent: +10, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	squat Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	flavorless tiny bowl of Bounty-Os	1	decent	
-2465	hand-crafted watered-down Oreille Divis&eacute;e brandy	2	super EPIC	
-2466	blue spinning pompadour'd puppy	0		
+2464	tiny flavorless bowl of Bounty-Os	1	decent	
+2465	watered-down hand-crafted Oreille Divis&eacute;e brandy	2	super EPIC	
+2466	spinning blue pompadour'd puppy	0		
 2467	huge upside-down jittery suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	blinking yellow bundle of receipts	0		
@@ -2489,11 +2489,11 @@
 2516	fortified Rosewater's wrench bracelet	0		Mysticality Percent: +30, Damage Absorption: +60
 2517	bouncing skewed blue jittery lightning-fast padded chain necklace	0		Damage Absorption: +20, Initiative: +40
 2518	sawblade shield of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 11
-2519	perfectly mixed weak McMillicancuddy's Special Lager	2	EPIC	
-2520	delicious practically non-alcoholic melted Jell-o shot	1	awesome	
+2519	weak perfectly mixed McMillicancuddy's Special Lager	2	EPIC	
+2520	practically non-alcoholic delicious melted Jell-o shot	1	awesome	
 2521	drinkable cruelty-free wine	4	good	
-2522	weak perfectly mixed thistle wine	2	EPIC	
-2523	blinking skewed megatofu	0		
+2522	perfectly mixed weak thistle wine	2	EPIC	
+2523	skewed blinking megatofu	0		
 2524	displaced fish	0		
 2525	toothsome fish	3	awesome	
 2526	normal jumbo fish casserole	5	good	
@@ -2503,8 +2503,8 @@
 2530	spoiled small skewed gnatloaf casserole	2	crappy	
 2531	tasty blue gnat lasagna	3	awesome	
 2532	mirror pork	0		
-2533	snack-sized adequate pork chop sandwiches	2	good	
-2534	bland thick wobbly shaking purple pork casserole	5	decent	
+2533	adequate snack-sized pork chop sandwiches	2	good	
+2534	thick bland shaking purple wobbly pork casserole	5	decent	
 2535	moldy pork lasagna	3	crappy	
 2536	canopic jar	0		
 2537	spice	0		
@@ -2564,7 +2564,7 @@
 2591	decent diet tasty tart	1	good	
 2592	Knob Goblin lunchbox	0		
 2593	super-sized stale Knob pasty	5	decent	
-2594	aged triple-distilled fancy thermos full of Knob coffee	10	awesome	Effect: "You Drank Fish Wine", Effect Duration: 10
+2594	fancy triple-distilled aged thermos full of Knob coffee	10	awesome	Effect: "You Drank Fish Wine", Effect Duration: 10
 2595	quadruple-wet Ben-Gal&trade; Balm	0		Effect: "It's Soporiffic!", Effect Duration: 29
 2596	cyan leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	bite-sized stale squat upside-down savoy truffle	1	decent	
+2615	stale bite-sized squat upside-down savoy truffle	1	decent	
 2616	pulsating Magi-Wipes	0		
 2617	boom	0		
 2618	Iiti Kitty phone charm of the brazier	0		Hot Spell Damage: +25, Single Equip
 2619	olive jar of swamp gas	0		Last Available: "2007-05"
-2620	jumbo decent unidentified jerky	5	good	
+2620	decent jumbo unidentified jerky	5	good	
 2621	veiny stiffened nasty rat mask	0		Damage Reduction: 1, Maximum HP: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	foul-smelling thinker's ratskin belt	0		Mysticality: +10, Stench Damage: +10, Single Equip
 2623	shaking Socratic rattail whip of dire peril	0		Experience (Mysticality): +1, Weapon Damage: +20
@@ -2627,7 +2627,7 @@
 2654	perfectly mixed huge Xanadian	4	EPIC	Last Available: "2007-06"
 2655	quadruple-Vulcanized wet bottle of absinthe	0		Effect: "Colorful Gratitude", Effect Duration: 16, Last Available: "2007-06"
 2656	Jeselnik's razor-sharp Drowsy Sword	0		Weapon Damage Percent: +25, Sleaze Damage: +25
-2657	spoiled big escargotsicle	5	crappy	Last Available: "2007-06"
+2657	big spoiled escargotsicle	5	crappy	Last Available: "2007-06"
 2658	tolerable bottle of realpagne	4	good	Last Available: "2007-06"
 2659	albatross necklace of James Dean	0		Experience (Moxie): +3, Single Equip, Last Available: "2007-06"
 2660	dehydrated not-a-pipe	1	decent	Effect: "The Dinsey Way", Effect Duration: 30, Last Available: "2007-06"
@@ -2637,11 +2637,11 @@
 2664	electrified irradiated sensitive poetry journal	0		Effect: "Space Cadet", Effect Duration: 12, Last Available: "2007-06"
 2665	warmed magnetized bottled inspiration	0		Effect: "Angry Bone", Effect Duration: 37, Last Available: "2007-06"
 2666	enhanced super-irradiated bellhop bell	0		Effect: "It Didn't Kill You", Effect Duration: 58, Last Available: "2007-06"
-2667	anodized warmed green squat spiky collar	0		Effect: "Net Tea", Effect Duration: 49, Last Available: "2007-06"
-2668	altered red upside-down blinking can-can-in-a-can	1		Last Available: "2007-06"
+2667	anodized warmed squat green spiky collar	0		Effect: "Net Tea", Effect Duration: 49, Last Available: "2007-06"
+2668	altered upside-down blinking red can-can-in-a-can	1		Last Available: "2007-06"
 2669	pickled patent antipsychotics	1		Effect: "Enraged", Effect Duration: 35, Last Available: "2007-06"
 2670	diluted yellow Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	artisanal irresponsibly strong shot of nepenthe schnapps	6	EPIC	Last Available: "2007-06"
+2671	irresponsibly strong artisanal shot of nepenthe schnapps	6	EPIC	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	blurry Bohemian rhapsody	0		Last Available: "2007-06"
 2674	warmed tumbling gray bottle of cat tonic	0		Effect: "Twinkly Weapon", Effect Duration: 20, Last Available: "2007-06"
@@ -2665,7 +2665,7 @@
 2692	upside-down double-paned manspreader's driftwood sculpture	0		Monster Level: +10, Cold Resistance: +5
 2693	double-paned Jack Frost's massive sitar	0		Cold Spell Damage: +50, Cold Resistance: +5
 2694	Sherlock's steel-toed stone baseball cap of doom	0		Damage Reduction: 9, Spooky Spell Damage: +50, Item Drop: +25, Familiar Effect: "1xVolley, cap 48"
-2695	fancy bad cup of beer	3	decent	Effect: "Clyde's Blessing", Effect Duration: 30
+2695	bad fancy cup of beer	3	decent	Effect: "Clyde's Blessing", Effect Duration: 30
 2696	ovoid thing	0		
 2697	blurry duct tape	0		
 2698	wobbly duct tape wallet	0		
@@ -2697,13 +2697,13 @@
 2724	bland miniature bowl of rye sprouts	2	decent	
 2725	rotten cob of corn	3	crappy	
 2726	flavorless skewed juniper berries	3	decent	
-2727	bite-sized moldy pulsating plum	1	crappy	
-2728	spoiled low-calorie upside-down pear	1	crappy	
+2727	moldy bite-sized pulsating plum	1	crappy	
+2728	low-calorie spoiled upside-down pear	1	crappy	
 2729	adequate thick peach	5	good	
 2730	hand-crafted jittery plum wine	4	EPIC	
 2731	tolerable shot of pear schnapps	3	good	
 2732	delicious shot of peach schnapps	4	awesome	
-2733	normal massive bunch of square grapes	10	good	
+2733	massive normal bunch of square grapes	10	good	
 2734	decent brown sugar cane	4	good	
 2735	huge rotten sandwich of the gods	8	crappy	
 2736	enchanted bad Pan-Dimensional Gargle Blaster	4	decent	Effect: "White-boy Angst", Effect Duration: 5
@@ -2711,7 +2711,7 @@
 2738	jittery pile of smoking rags	0		
 2739	Vulcanized denatured panty raider camouflage	0		Effect: "Heal Thy Nanoself", Effect Duration: 67
 2740	jittery cyan reassuring Staff of the Walk-In Freezer of the sewer	0		Stench Damage: +25, Spooky Resistance: +1, Item Drop: +5
-2741	lousy weak gray boilermaker	2	decent	
+2741	weak lousy gray boilermaker	2	decent	
 2742	adequate diet skewed steel lasagna	1	quest	
 2743	watered-down bad steel margarita	2	quest	
 2744	pickled bouncing steel-scented air freshener	1		Effect: "Like a Fish to Walter", Effect Duration: 30
@@ -2737,9 +2737,9 @@
 2764	blurry supercharged forbidden savvy Order of the Silver Wossname	0		Mysticality Percent: +20, Spell Damage Percent: +50, Maximum MP Percent: +30, Single Equip
 2765	skewed Harold's bell	0		
 2766	bowling ball	0		
-2767	decent tiny Crimbo pie	1	good	
+2767	tiny decent Crimbo pie	1	good	
 2768	toothsome pear tart	3	awesome	
-2769	bland snack-sized peach pie	2	decent	
+2769	snack-sized bland peach pie	2	decent	
 2770	deionized chunk of rock salt	0		Effect: "Muddled", Effect Duration: 16
 2771	warmed upside-down handful of pine needles	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 44
 2772	steamy ruby	0		
@@ -2781,8 +2781,8 @@
 2808	dry flask of baconstone juice	0		Effect: "Sizzling with Fury", Effect Duration: 53
 2809	Vulcanized cyan flask of porquoise juice	0		Effect: "Antarctic Memories", Effect Duration: 35
 2810	oxidized jug of hamethyst juice	0		Effect: "Net Tea", Effect Duration: 59
-2811	polymerized quadruple-cold-filtered liquefied huge bouncing jug of baconstone juice	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 17
-2812	aerosolized squat shaking jug of porquoise juice	0		Effect: "The Halls of Mysticality", Effect Duration: 30
+2811	polymerized quadruple-cold-filtered liquefied bouncing huge jug of baconstone juice	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 17
+2812	aerosolized shaking squat jug of porquoise juice	0		Effect: "The Halls of Mysticality", Effect Duration: 30
 2813	jittery lightning-fast supercharged Beret	0		Maximum MP Percent: +30, Initiative: +40, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	tumbling blue flame-retardant resourceful Bludgeon of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +50, Hot Resistance: +1
 2815	nippy baleful wicked Bunker	0		Spell Damage: 30, Cold Damage: +10, Damage Reduction: 15
@@ -2807,12 +2807,12 @@
 2834	squat rosewater-soaked Van der Graaf beefy bottle-rocket crossbow	0		Muscle: +10, Stench Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	flame-retardant indie comic hipster glasses	0		Hot Resistance: +1, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	spinning wizard action figure	0		Free Pull, Last Available: "2011-12"
-2837	tumbling pulsating mint-condition magic wand	0		Last Available: "2011-12"
+2837	pulsating tumbling mint-condition magic wand	0		Last Available: "2011-12"
 2838	greedy glowstick of the brute	0		Muscle Percent: +30, Meat Drop: +20, Last Available: "2007-08"
 2839	perfumed Periodical Paintbrush	0		Stench Resistance: +5, Softcore Only
 2840	bad bottle of cooking sherry	3	decent	
-2841	special super-sized stale packet of ketchup	5	decent	Effect: "Human-Beast Hybrid", Effect Duration: 40
-2842	irresponsibly strong drinkable accidental cider	6	good	
+2841	special stale super-sized packet of ketchup	5	decent	Effect: "Human-Beast Hybrid", Effect Duration: 40
+2842	drinkable irresponsibly strong accidental cider	6	good	
 2843	normal dire fudgesicle	3	good	
 2844	blurry scandalous hardy occult beefcake's navel ring of navel gazing	0		Muscle: +25, Spell Damage Percent: +25, Maximum HP: +50, Sleaze Damage: +5, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	yellow class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2820,17 +2820,17 @@
 2847	bouncing MacGyver's Dallas Dynasty Falcon Crest shield	0		Maximum MP: +100, Damage Reduction: 15
 2848	blurry upside-down Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	bad weak moonberry wine cooler	2	decent	
+2850	weak bad moonberry wine cooler	2	decent	
 2851	flavorless mirror fine aged cheddarwurst	4	decent	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
-2854	shaking narrow bouquet of swamp roses	0		
+2854	narrow shaking bouquet of swamp roses	0		
 2855	blurry rock-hard smartaleck's huge mosquito proboscis	0		Moxie Percent: +30, Damage Reduction: 5
 2856	chilled polarized swamp lolly	0		Effect: "Fireproof Lips", Effect Duration: 37
 2857	altered anodized seegar butt	0		Effect: "Dexteri Tea", Effect Duration: 13
 2858	narrow bottled swamp gas	0		
 2859	huge witch wart of the ox of the early riser	0		Muscle: +20, Adventures: +7
-2860	thick special flavorless jittery swamp muck	5	decent	Effect: "Uncaged Power", Effect Duration: 20
+2860	special thick flavorless jittery swamp muck	5	decent	Effect: "Uncaged Power", Effect Duration: 20
 2861	leechknife of the pedagogue of Calamity Jane of the overflowing toilet	0		Experience: +3, Critical Hit Percent: +15, Stench Spell Damage: +50
 2862	mirror decomposed boot	0		
 2863	wet shaking dribbly candle	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 46
@@ -2930,7 +2930,7 @@
 2958	thick stale tube of cranberry Go-Goo	5	decent	
 2959	tumbling nasty rum barrel charrrm bracelet	0		Stench Damage: +5
 2960	rotten single-serving herbal stuffing	4	crappy	
-2961	moldy huge packet of tofurkey gravy	9	crappy	
+2961	huge moldy packet of tofurkey gravy	9	crappy	
 2962	miniature rotten shaking tofurkey nugget	2	crappy	
 2963	rigging shampoo	0		
 2964	jittery ball polish	0		
@@ -2938,17 +2938,17 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	flattened Swabbie&trade; swab	0		Effect: "Crotchety, Pining", Effect Duration: 69
 2968	improved warmed Oil of Parrrlay	0		Effect: "Izchak's Blessing", Effect Duration: 32
-2969	huge decent creamsicle	8	good	
-2970	practically non-alcoholic artisanal yellow shaking cream stout	1	EPIC	
+2969	decent huge creamsicle	8	good	
+2970	practically non-alcoholic artisanal shaking yellow cream stout	1	EPIC	
 2971	prompt curmudgel of the sweet-tooth	0		Candy Drop: +100, Adventures: +3
 2972	grumpy man charrrm	0		
 2973	blinking grumpy man charrrm bracelet of the ox	0		Muscle: +20, Single Equip
 2974	tarrrnish charrrm	0		
 2975	toasty sage tarrrnished charrrm bracelet	0		Mysticality Percent: +10, Hot Damage: +5, Single Equip
-2976	fancy distilled perfectly mixed bilge wine	5	EPIC	Effect: "Your Eyes are Peeled!", Effect Duration: 30
+2976	perfectly mixed distilled fancy bilge wine	5	EPIC	Effect: "Your Eyes are Peeled!", Effect Duration: 30
 2977	jittery blurry witty rapier of horror	0		Spooky Spell Damage: +25
 2978	greasy yohohoyo of the cougar	0		Moxie: +20, Sleaze Spell Damage: +10
-2979	dry red jittery fish-liver oil	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 60
+2979	dry jittery red fish-liver oil	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 60
 2980	booty chest charrrm	0		
 2981	booty chest charrrm bracelet of bravery	0		Spooky Resistance: +5, Single Equip
 2982	narrow cannonball charrrm	0		
@@ -2962,7 +2962,7 @@
 2990	scorching sizzling clingfilm cap	0		Hot Damage: 35, Familiar Effect: "1xVolley, cap 37"
 2991	bouncing asbestos-lined clingfilm slippers	0		Hot Resistance: +5, Single Equip
 2992	clingfilm tangle	0		
-2993	tiny flavorless upside-down vinegar-soaked lemon slice	1	decent	
+2993	flavorless tiny upside-down vinegar-soaked lemon slice	1	decent	
 2994	warmed anodized true grit	0		Effect: "Amorphous Cheer", Effect Duration: 29
 2995	bouncing up-at-dawn veiny groovy buoybottoms	0		Moxie Percent: +10, Maximum HP: +10, Adventures: +5, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	electrified grungy flannel shirt	0		MP Regen Min: 3, MP Regen Max: 5
@@ -2999,9 +2999,9 @@
 3027	perfectly mixed tumbling corpsedriver	4	EPIC	
 3028	bad upside-down Corpse Island iced tea	3	decent	
 3029	tolerable ghostly red-headed corpse	4	good	
-3030	mediocre special kamicorpse-ee	3	decent	Effect: "Pride of the Vampire", Effect Duration: 30
-3031	hand-crafted high-proof shaking corpsel	9	EPIC	
-3032	acceptable spirit-forward corpsebite	5	good	
+3030	special mediocre kamicorpse-ee	3	decent	Effect: "Pride of the Vampire", Effect Duration: 30
+3031	high-proof hand-crafted shaking corpsel	9	EPIC	
+3032	spirit-forward acceptable corpsebite	5	good	
 3033	banded pirate fledges	0		Damage Absorption: +100
 3034	piece of thirteen	0		
 3035	tasty pearl onion	4	awesome	
@@ -3017,7 +3017,7 @@
 3045	flavorless nanite-infested gingerbread bugbear	3	decent	Last Available: "2007-12"
 3046	stale nanite-infested candy cane	3	decent	Last Available: "2020-09"
 3047	normal nanite-infested fruitcake	3	good	Last Available: "2007-12"
-3048	acceptable watered-down nanite-infested eggnog	2	good	Last Available: "2007-12"
+3048	watered-down acceptable nanite-infested eggnog	2	good	Last Available: "2007-12"
 3049	jittery El Vibrato power sphere	0		
 3050	scandalous eyepatch	0		Sleaze Damage: +5, Familiar Effect: "spooky atk, 1xBarrr"
 3051	auspicious cutlass	0		Item Drop: +10
@@ -3095,12 +3095,12 @@
 3123	tumbling divine champagne flute	0		Last Available: "2008-01"
 3124	galvanized twirling fruitfilm	0		Effect: "Flashing Eyes", Effect Duration: 67
 3125	dry corrupted tumbling piece of after eight	0		Effect: "Petit Forbearance", Effect Duration: 12
-3126	mirror skewed hobo nickel	0		
+3126	skewed mirror hobo nickel	0		
 3127	huge sandcastle	0		
 3128	jittery marshmallow	0		
-3129	rotten special bite-sized roasted marshmallow	1	crappy	Effect: "Radiated and Grodiated", Effect Duration: 30
+3129	rotten bite-sized special roasted marshmallow	1	crappy	Effect: "Radiated and Grodiated", Effect Duration: 30
 3130	disc	0		Last Available: "2008-01"
-3131	snack-sized delicious tin cup of mulligan stew	2	awesome	
+3131	delicious snack-sized tin cup of mulligan stew	2	awesome	
 3132	auspicious fireproof flamin' bindle	0		Hot Resistance: +3, Item Drop: +10
 3133	narrow freezin' bindle of Leguizamo of Flo-Jo	0		Monster Level: +20, Initiative: +100
 3134	jittery aromatic stinkin' bindle of temperance	0		Stench Resistance: +1, Sleaze Resistance: +5
@@ -3120,7 +3120,7 @@
 3148	El Vibrato punchcard (129 holes)	0		
 3149	El Vibrato punchcard (213 holes)	0		
 3150	El Vibrato punchcard (165 holes)	0		
-3151	bouncing narrow cyan El Vibrato punchcard (142 holes)	0		
+3151	narrow cyan bouncing El Vibrato punchcard (142 holes)	0		
 3152	El Vibrato punchcard (216 holes)	0		
 3153	jittery El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
@@ -3134,34 +3134,34 @@
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	pulsating bouncing El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
-3165	jittery yellow broken El Vibrato drone	0		
+3165	yellow jittery broken El Vibrato drone	0		
 3166	huge repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	activated shaking seal eyeball	0		Effect: "Bone Homie", Effect Duration: 43
-3169	normal massive turtle soup	9	good	Effect: "[598]A Little Bit Evil"
+3169	massive normal turtle soup	9	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	squat prompt evil paper umbrella	0		Adventures: +3
 3173	double-diffused warmed shaking evil vihuela	0		Effect: "Memory of Strength", Effect Duration: 42
 3174	immense decent evil boring spaghetti	7	good	
-3175	massive moldy squat evil noodles	8	crappy	
-3176	adequate huge evil noodles	8	good	
+3175	moldy massive squat evil noodles	8	crappy	
+3176	huge adequate evil noodles	8	good	
 3177	flavorless ghostly evil painful penne pasta	3	decent	
 3178	decent 3vi1 pr0n m4nic0tti	3	good	
 3179	adequate evil ravioli della hippy	3	good	
 3180	decent evil noodles	4	good	
 3181	super-unsweetened aerosolized bouncing evil potion of potency	0		Effect: "High Blood Chocolate Content", Effect Duration: 64
 3182	oxidized warmed evil libation of liveliness	0		Effect: "Arabian Knighthood", Effect Duration: 46
-3183	polarized spinning purple bouncing evil tomato juice of powerful power	0		Effect: "The Power of LOV", Effect Duration: 65
+3183	polarized purple spinning bouncing evil tomato juice of powerful power	0		Effect: "The Power of LOV", Effect Duration: 65
 3184	adjusted energized evil eyedrops of the ermine	0		Effect: "Graham Crackling", Effect Duration: 67
 3185	polarized nitrogenated teal wobbly evil ointment of the occult	0		Effect: "Stimulated Brain", Effect Duration: 24
 3186	warmed oxidized pickled evil serum of sarcasm	0		Effect: "Icy Demeanor", Effect Duration: 57
 3187	ionized Vulcanized narrow evil philter of phorce	0		Effect: "Salt Rockin'", Effect Duration: 59
-3188	perfectly mixed weak an evil sump'm sump'm	2	super EPIC	
+3188	weak perfectly mixed an evil sump'm sump'm	2	super EPIC	
 3189	smooth evil ducha de oro	4	awesome	
 3190	lousy pulsating evil horizontal tango	3	decent	
 3191	artisanal evil roll in the hay	4	EPIC	
-3192	blue narrow naughty origami kit	0		Last Available: "2008-02"
+3192	narrow blue naughty origami kit	0		Last Available: "2008-02"
 3193	huge naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
@@ -3201,7 +3201,7 @@
 3229	shaking maroon decaying goldfish liver	0		
 3230	moist anodized quadruple-denatured oil of oiliness	0		Effect: "Thick, Sick", Effect Duration: 45
 3231	quilted tattered paper crown	0		Damage Absorption: +40, Familiar Effect: "1xSombrero, cap 15"
-3232	special yummy gray vanilla-frosted king cake	4	awesome	Effect: "One Foot Heavier", Effect Duration: 5, Last Available: "2008-03"
+3232	yummy special gray vanilla-frosted king cake	4	awesome	Effect: "One Foot Heavier", Effect Duration: 5, Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3235,7 +3235,7 @@
 3263	skewed Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
-3266	twirling mirror bag of Saccharine Maple saplings	0		
+3266	mirror twirling bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	corrupted jittery handful of Crotchety Pine needles	0		Effect: "Bilious Brawn", Effect Duration: 33
 3269	oxidized lump of Saccharine Maple sap	0		Effect: "Big Flaming Whip", Effect Duration: 20
@@ -3245,14 +3245,14 @@
 3273	beefy willowy bonnet	0		Muscle: +10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	twirling dart	0		Last Available: "2008-04"
-3276	pulsating mirror maroon black-and-blue light	0		Last Available: "2008-04"
+3276	mirror maroon pulsating black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	maroon reassuring studded belt	0		Spooky Resistance: +1, Last Available: "2008-04"
 3279	personal massager	0		Last Available: "2008-04"
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	bouncing miser's stick-on eyebrow piercing	0		Meat Drop: +10, Last Available: "2008-04"
-3283	half-sized decent blurry wobbly salad	2	good	
+3283	decent half-sized blurry wobbly salad	2	good	
 3284	C.H.U.M. lantern of Calamity Jane of bravery	0		Critical Hit Percent: +15, Spooky Resistance: +5
 3285	C.H.U.M. knife of the bloodbag	0		Maximum HP: +100
 3286	foul-smelling Frosty's snowball sack	0		Stench Damage: +10
@@ -3285,7 +3285,7 @@
 3313	squat cyan marinara jug of horror	0		Spooky Spell Damage: +25, Class: "Sauceror"
 3314	jittery dance instructor's makeshift castanets	0		Experience Percent (Moxie): +10, Class: "Disco Bandit"
 3315	left-handed melodica of the sweet-tooth	0		Candy Drop: +100, Class: "Accordion Thief"
-3316	diluted bouncing skewed epic wad	1	decent	Effect: "Sweetened and Fattened", Effect Duration: 30
+3316	diluted skewed bouncing epic wad	1	decent	Effect: "Sweetened and Fattened", Effect Duration: 30
 3317	auspicious bottlecap	0		Item Drop: +10, Single Equip
 3318	corncob pipe of the dark arts	0		Spell Damage Percent: +100, Single Equip
 3319	jittery spinning rosewater-soaked Mr. Joe's bangles	0		Stench Resistance: +3, Single Equip
@@ -3295,7 +3295,7 @@
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	drinkable jar of fermented pickle juice	3	good	
-3326	altered squat blinking voodoo snuff	1	awesome	
+3326	altered blinking squat voodoo snuff	1	awesome	
 3327	small moldy extra-greasy slider	2	crappy	
 3328	ribald occult crumpled felt fedora	0		Spell Damage Percent: +25, Sleaze Damage: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	prompt sinister battered top-hat	0		Spell Damage: +10, Adventures: +3, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3323,25 +3323,25 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	mirror zen motorcycle	0		Last Available: "2008-06"
 3353	super-activated llama lama gong	0		Effect: "The Dinsey Spirit", Effect Duration: 47, Last Available: "2008-06"
-3354	tasty enchanted super-sized banana-frosted king cake	5	awesome	Effect: "Chilblains of the Corn", Effect Duration: 35, Last Available: "2008-08"
+3354	enchanted tasty super-sized banana-frosted king cake	5	awesome	Effect: "Chilblains of the Corn", Effect Duration: 35, Last Available: "2008-08"
 3355	maroon manspreader's brown plastic baby	0		Monster Level: +10, Single Equip, Last Available: "2008-08"
 3356	olive plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	spinning delectable fire ant	0		Last Available: "2008-06"
 3359	blinking scrumptious ice ant	0		Last Available: "2008-06"
-3360	blinking cyan stinkbug	0		Last Available: "2008-06"
-3361	wobbly shaking skewed yummy death watch beetle	0		Last Available: "2008-06"
+3360	cyan blinking stinkbug	0		Last Available: "2008-06"
+3361	shaking skewed wobbly yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	bland huge ghostly mole mol&eacute;	9	decent	Last Available: "2008-06"
-3364	acceptable fancy weak fuchsia Morlock's Mark Bourbon	2	good	Effect: "Gummi Badass", Effect Duration: 15, Last Available: "2008-06"
+3364	weak fancy acceptable fuchsia Morlock's Mark Bourbon	2	good	Effect: "Gummi Badass", Effect Duration: 15, Last Available: "2008-06"
 3365	dry aerosolized Climate Colada	0		Effect: "Celestial Sheen", Effect Duration: 35, Last Available: "2008-06"
 3366	wet pickled upside-down digital underground potion	0		Effect: "Lemony Goodness", Effect Duration: 68, Last Available: "2008-06"
 3367	upside-down interesting-looking twig	0		Last Available: "2008-06"
 3368	pickled tumbling glimmering roc feather	1	good	Last Available: "2008-06"
 3369	twisted glimmering phoenix feather	1		Effect: "Piratey Flavor", Effect Duration: 20, Last Available: "2008-06"
 3370	modified glimmering penguin feather	1		Last Available: "2008-06"
-3371	dried ghostly olive glimmering buzzard feather	1		Last Available: "2008-06"
-3372	mixed spinning tumbling glimmering raven feather	1		Effect: "Well-Lubed", Effect Duration: 45, Last Available: "2008-06"
+3371	dried olive ghostly glimmering buzzard feather	1		Last Available: "2008-06"
+3372	mixed tumbling spinning glimmering raven feather	1		Effect: "Well-Lubed", Effect Duration: 45, Last Available: "2008-06"
 3373	boiled upside-down glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3360,16 +3360,16 @@
 3388	blue Zombo's empty eye	0		
 3389	blinking Oprah's stylish Frosty's arm	0		Moxie: +25, Maximum MP Percent: +50
 3390	grievous beefcake's Staff of the Deepest Freeze of wisdom	0		Muscle: +25, Mysticality: +15, Weapon Damage Percent: +50
-3391	green narrow narrow Frosty's iceball	0		
+3391	narrow green narrow Frosty's iceball	0		
 3392	gray jittery groovy Oscus's garbage can lid	0		Moxie Percent: +10, Damage Reduction: 15
 3393	Oscus's neverending soda	0		
 3394	upside-down Jim Carey's occult Oscus's flypaper pants	0		Spell Damage Percent: +25, Monster Level: +25, Familiar Effect: "stench atk, 1xPotato"
 3395	skewed padded Hodgman's porkpie hat of the detective	0		Damage Absorption: +20, Item Drop: +20, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	Hodgman's lobsterskin pants of Calamity Jane of incineration	0		Critical Hit Percent: +15, Hot Spell Damage: +50, Familiar Effect: "atk, 1xPotato"
 3397	greasy Rosewater's Hodgman's bow tie	0		Mysticality Percent: +30, Sleaze Spell Damage: +10, Single Equip
-3398	watered-down smooth Hodgman's blanket	2	awesome	
-3399	drinkable watered-down jar of squeeze	2	good	
-3400	normal thick bowl of fishysoisse	5	good	
+3398	smooth watered-down Hodgman's blanket	2	awesome	
+3399	watered-down drinkable jar of squeeze	2	good	
+3400	thick normal bowl of fishysoisse	5	good	
 3401	extra-warmed polymerized deadly lampshade	0		Effect: "The Magic of Sharing", Effect Duration: 18
 3402	colloidal concentrated garbage juice	0		Effect: "Piratey Flavor", Effect Duration: 16
 3403	lewd playing card	0		
@@ -3396,9 +3396,9 @@
 3428	tarnished corrupted mirror Everlasting Deckswabber	0		Effect: "Army of One", Effect Duration: 16
 3430	bindle of joy	0		
 3431	maroon cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
-3432	maroon twirling upside-down cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
+3432	upside-down maroon twirling cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
-3434	pulsating squat rattling cigar box	0		Free Pull, Last Available: "2011-12"
+3434	squat pulsating rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	sizzling Temple Grandin's stirring stick	0		Familiar Weight: +7, Hot Damage: +10
 3436	miser's frosty friendly Staff of the Teapot Tempest	0		Familiar Weight: +3, Cold Spell Damage: +10, Meat Drop: +10
 3437	upside-down chaotic Staff of the Black Kettle of Tarzan of temperance	0		Experience (Muscle): +3, Spell Critical Percent: +10, Sleaze Resistance: +5
@@ -3429,7 +3429,7 @@
 3462	gray shaking terrible poem	0		
 3463	smooth bottle of sake	4	awesome	
 3464	teal scorching round pebble	0		Hot Damage: +25
-3465	low-calorie stale Bash-&#332;s cereal	1	decent	Wiki Name: "Bash-Os cereal"
+3465	stale low-calorie Bash-&#332;s cereal	1	decent	Wiki Name: "Bash-Os cereal"
 3466	supercharged smartaleck's haiku katana of Calamity Jane	0		Moxie Percent: +30, Maximum MP Percent: +30, Critical Hit Percent: +15, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	ruddy plastic baby	0		Maximum HP Percent: +40, Single Equip, Last Available: "2008-12"
@@ -3453,7 +3453,7 @@
 3486	purple dull fish scale	0		
 3487	rough fish scale	0		
 3488	olive pristine fish scale	0		
-3489	rotten half-sized beefy fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
+3489	half-sized rotten beefy fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3490	stale fuchsia glistening fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3491	big adequate slick fish meat	5	good	Effect: "Fishy", Effect Duration: 5
 3492	Sherlock's fish scimitar of Gandalf	0		Spell Critical Percent: +20, Item Drop: +25
@@ -3517,20 +3517,20 @@
 3550	Sinatra's propeller beanie	0		Experience (Moxie): +5, Familiar Effect: "atk, cap 7"
 3551	shaking fortified deadly weightlifter's straw hat	0		Muscle: +15, Weapon Damage: +5, Damage Absorption: +60, Familiar Effect: "1xFairy"
 3552	flame-wreathed toasty razor-sharp octopus's spade	0		Weapon Damage Percent: +25, Hot Damage: +5, Hot Spell Damage: +10
-3553	narrow bouncing soggy seed packet	0		
+3553	bouncing narrow soggy seed packet	0		
 3554	glob of slime	0		
-3555	moldy huge shaking lime green sea carrot	7	crappy	
+3555	moldy huge lime green shaking sea carrot	7	crappy	
 3556	moldy sea cucumber	3	crappy	
 3557	moldy sea avocado	3	crappy	
 3558	adequate sea lychee	4	good	
-3559	half-sized spoiled sea tangelo	2	crappy	
+3559	spoiled half-sized sea tangelo	2	crappy	
 3560	bland tiny sea honeydew	1	decent	
-3561	electrified modified wobbly blinking pressurized potion of puissance	0		Effect: "Hoity Toity", Effect Duration: 23
-3562	super-vacuum-sealed fuchsia mirror pressurized potion of perspicacity	0		Effect: "Items Are Forever", Effect Duration: 57
+3561	electrified modified blinking wobbly pressurized potion of puissance	0		Effect: "Hoity Toity", Effect Duration: 23
+3562	super-vacuum-sealed mirror fuchsia pressurized potion of perspicacity	0		Effect: "Items Are Forever", Effect Duration: 57
 3563	wet improved pressurized potion of pulchritude	0		Effect: "Boon of the War Snapper", Effect Duration: 24
-3564	mediocre triple-distilled berry-infused sake	8	decent	
-3565	hand-crafted tumbling green citrus-infused sake	3	EPIC	
-3566	smooth weak melon-infused sake	2	awesome	
+3564	triple-distilled mediocre berry-infused sake	8	decent	
+3565	hand-crafted green tumbling citrus-infused sake	3	EPIC	
+3566	weak smooth melon-infused sake	2	awesome	
 3567	bouncing slab of sponge	0		
 3568	sponge helmet of Calamity Jane of bravery of temperance	0		Critical Hit Percent: +15, Spooky Resistance: +5, Sleaze Resistance: +5, Familiar Effect: "atk, 1xFairy"
 3569	miser's electrified spongy shield of Tarzan	0		Experience (Muscle): +3, Meat Drop: +10, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 14
@@ -3540,18 +3540,18 @@
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	mirror sand dollar	0		
-3576	shaking cyan flytrap bezoar	0		
-3577	fuchsia wobbly bezoar ring	0		
+3576	cyan shaking flytrap bezoar	0		
+3577	wobbly fuchsia bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
-3580	twirling gray wriggling flytrap pellet	0		
+3580	gray twirling wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	flavorless pulsating rice	3	decent	
 3584	normal blurry irradiated candy cane	3	good	Last Available: "2008-12"
 3585	adequate gingerbread mutant bugbear	4	good	Last Available: "2008-12"
-3586	lousy practically non-alcoholic oozenog	1	decent	Last Available: "2008-12"
+3586	practically non-alcoholic lousy oozenog	1	decent	Last Available: "2008-12"
 3587	aerosolized boiled dry sugar plum	0		Effect: "Jerky, Boy", Effect Duration: 42, Last Available: "2008-12"
-3588	concentrated irradiated chilled mirror blurry narrow sugar banana	0		Effect: "Busy Bein' Delicious", Effect Duration: 11, Last Available: "2008-12"
+3588	concentrated irradiated chilled blurry mirror narrow sugar banana	0		Effect: "Busy Bein' Delicious", Effect Duration: 11, Last Available: "2008-12"
 3589	moist flattened sugar lime	0		Effect: "Radiant Personality", Effect Duration: 42, Last Available: "2008-12"
 3590	magnetized quantum pressed sugar cherry	0		Effect: "Eyes for Miles", Effect Duration: 43, Last Available: "2008-12"
 3591	hardy Mer-kin hookspear of wisdom	0		Mysticality: +15, Maximum HP: +50
@@ -3583,7 +3583,7 @@
 3617	extra-pickled deionized narrow bouncing unstable DNA	0		Effect: "Blessing of Charcoatl", Effect Duration: 53, Last Available: "2008-12"
 3618	shaking The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	shaking wriggling tentacle	0		Last Available: "2008-12"
-3620	twirling tumbling mass of wriggling tentacles	0		Last Available: "2008-12"
+3620	tumbling twirling mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	wobbly pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	jittery chitinous pod	0		Last Available: "2008-12"
@@ -3602,19 +3602,19 @@
 3636	shaking nippy dance instructor's patent shoes	0		Experience Percent (Moxie): +10, Cold Damage: +10, Last Available: "2008-12"
 3637	spinning Usain Bolt's Herculean gray bow tie	0		Experience (Muscle): +1, Initiative: +80, Last Available: "2008-12"
 3638	skewed chaotic penguin thesaurus of the wise owl	0		Mysticality: +20, Spell Critical Percent: +10, Last Available: "2008-12"
-3639	stale special blob-shaped Crimbo cookie	3	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	special stale blob-shaped Crimbo cookie	3	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	narrow jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	squat chaotic depleted Grimacite kneecapping stick	0		Spell Critical Percent: +10, Last Available: "2007-06"
-3645	mediocre practically non-alcoholic upside-down canteen of wine	1	decent	Last Available: "2008-12"
-3646	enchanted low-calorie stale elven <i>limbos</i> gingerbread	1	decent	Effect: "Destructive Resolve", Effect Duration: 5, Last Available: "2008-12"
+3645	practically non-alcoholic mediocre upside-down canteen of wine	1	decent	Last Available: "2008-12"
+3646	enchanted stale low-calorie elven <i>limbos</i> gingerbread	1	decent	Effect: "Destructive Resolve", Effect Duration: 5, Last Available: "2008-12"
 3647	bouncing purple elven whittling knife	0		Last Available: "2008-12"
 3648	squat magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	decent thick toast with jam	5	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	thick decent toast with jam	5	good	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	bad mirror elven moonshine	4	decent	Last Available: "2008-12"
 3653	yummy knuckle sandwich	4	awesome	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	rosewater-soaked psycho sweater of dire peril	0		Weapon Damage: +20, Stench Resistance: +3, Last Available: "2008-12"
@@ -3645,15 +3645,15 @@
 3679	bouncing upside-down ink bladder	0		
 3680	esca	0		
 3681	olive bubbling tempura batter	0		
-3682	maroon squat squat globe of Deep Sauce	0		
+3682	squat squat maroon globe of Deep Sauce	0		
 3683	upside-down map to the Marinara Trench	0		
 3684	adequate huge tempura carrot	8	good	
 3685	snack-sized decent tempura cucumber	2	good	
 3686	decent tempura avocado	3	good	
-3687	bland small sea broccoli	2	decent	
+3687	small bland sea broccoli	2	decent	
 3688	adequate sea cauliflower	4	good	
-3689	immense toothsome tempura broccoli	6	awesome	
-3690	massive spoiled tempura cauliflower	6	crappy	
+3689	toothsome immense tempura broccoli	6	awesome	
+3690	spoiled massive tempura cauliflower	6	crappy	
 3691	rotten sea blueberry	4	crappy	
 3692	rotten sea persimmon	3	crappy	
 3693	energized galvanized cyan huge pressurized potion of perception	0		Effect: "Unusual Fashion Sense", Effect Duration: 46
@@ -3664,7 +3664,7 @@
 3698	velcro ore	0		
 3699	teflon ore	0		
 3700	vinyl ore	0		
-3701	tumbling huge map to Anemone Mine	0		
+3701	huge tumbling map to Anemone Mine	0		
 3702	cyan marine aquamarine	0		
 3703	purple valve wheel	0		
 3704	waterlogged bootstraps	0		
@@ -3713,7 +3713,7 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	nitrogenated shaking concoction of clumsiness	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 68
 3750	Sinatra's vampire pearl earring	0		Experience (Moxie): +5, Single Equip
-3751	normal bite-sized chocolate chip brownies	1	good	
+3751	bite-sized normal chocolate chip brownies	1	good	
 3753	yellow Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	activated love song of vague ambiguity	0		Effect: "Angry like the Wolf", Effect Duration: 31, Last Available: "2009-02"
 3755	deionized love song of smoldering passion	0		Effect: "The Style... of the Future", Effect Duration: 17, Last Available: "2009-02"
@@ -3721,21 +3721,21 @@
 3757	colloidal love song of sugary cuteness	0		Effect: "Super Vision", Effect Duration: 32, Last Available: "2009-02"
 3758	magnetized love song of disturbing obsession	0		Effect: "Tomato Power", Effect Duration: 55, Last Available: "2009-02"
 3759	frozen magnetized upside-down love song of naughty innuendo	0		Effect: "Indescribable Flavor", Effect Duration: 56, Last Available: "2009-02"
-3760	super-flattened alkaline skewed red spinning breath mint	0		Effect: "Wreathed in Smoke", Effect Duration: 50
+3760	super-flattened alkaline skewed spinning red breath mint	0		Effect: "Wreathed in Smoke", Effect Duration: 50
 3761	spinning knitted vampire pearl ring	0		Cold Resistance: +3, Single Equip
 3762	vampire pearl necklace of wisdom	0		Mysticality: +15, Single Equip
-3763	acceptable enchanted slug of vodka	3	good	Effect: "Yuletide Sappiness", Effect Duration: 45
+3763	enchanted acceptable slug of vodka	3	good	Effect: "Yuletide Sappiness", Effect Duration: 45
 3764	perfectly mixed slug of rum	3	EPIC	
 3765	lousy high-proof slug of shochu	9	decent	
-3766	delicious watered-down screwdiver	2	awesome	
-3767	watered-down mediocre dew yoana lei	2	decent	
+3766	watered-down delicious screwdiver	2	awesome	
+3767	mediocre watered-down dew yoana lei	2	decent	
 3768	artisanal lychee chuhai	3	EPIC	
-3769	perfectly mixed boozy salacious screwdiver	5	EPIC	
+3769	boozy perfectly mixed salacious screwdiver	5	EPIC	
 3770	mediocre dew yoana salacious lei	3	decent	
-3771	bad enchanted squat huge salacious lychee chuhai	4	decent	Effect: "Heart of Yellow", Effect Duration: 40
-3772	perfectly mixed weak Alewife&trade; Ale	2	EPIC	
+3771	enchanted bad squat huge salacious lychee chuhai	4	decent	Effect: "Heart of Yellow", Effect Duration: 40
+3772	weak perfectly mixed Alewife&trade; Ale	2	EPIC	
 3773	seaode	0		
-3774	narrow skewed map to the Dive Bar	0		
+3774	skewed narrow map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
 3776	Usain Bolt's lion tamer's pink pinkslip slip	0		Experience (familiar): +2, Initiative: +80, Familiar Effect: "1xVolley, 1xBarrr"
 3777	brainy sea salt scrubs of the scaredy-cat	0		Mysticality: +5, Monster Level: -15
@@ -3774,7 +3774,7 @@
 3820	teal bouncing water-polo mitt	0		Item Drop: +5, Single Equip
 3821	polymerized non-adjusted bouncing syringe	0		Effect: "Stregngth of the Gnome", Effect Duration: 39
 3822	skewed wand	0		Familiar Effect: "fishy spells"
-3823	warmed ghostly cyan wad of cotton	0		Effect: "Mucilaginous Muscle", Effect Duration: 26
+3823	warmed cyan ghostly wad of cotton	0		Effect: "Mucilaginous Muscle", Effect Duration: 26
 3824	narrow Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	Grandma's Chartreuse Yarn	0		
@@ -3785,7 +3785,7 @@
 3831	acceptable Typical Tavern swill	3	good	
 3832	drinkable spinning tropical swill	3	good	
 3833	lousy fruity girl swill	4	decent	
-3834	special drinkable blended swill	3	good	Effect: "Slimy Flavor", Effect Duration: 15
+3834	drinkable special blended swill	3	good	Effect: "Slimy Flavor", Effect Duration: 15
 3835	costume wardrobe	0		Softcore Only
 3836	nasty therapeutic shellacked smartaleck's Elvish sunglasses	0		Moxie Percent: +30, Damage Reduction: 7, Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	fuchsia anniversary safety glass vest of the blizzard	0		Cold Spell Damage: +25
@@ -3821,7 +3821,7 @@
 3867	gravedigger's magilaser blastercannon of extreme caution	0		Monster Level: -25, Spooky Damage: +10
 3868	jittery sizzling brawny hanky&#363;	0		Muscle Percent: +20, Hot Damage: +10, Wiki Name: "frigid hankyu"
 3869	Jeselnik's Herculean ultimate ultimate frisbee	0		Experience (Muscle): +1, Sleaze Damage: +25
-3870	lime green shaking stolen office supplies	0		
+3870	shaking lime green stolen office supplies	0		
 3871	tumbling olive greasy curative office-supply crossbow	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 3872	maroon vibrating pocket theremin	0		Maximum MP Percent: +10
 3873	Sinatra's rave whistle of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10
@@ -3844,7 +3844,7 @@
 3890	colloidal wobbly vial of violet slime	0		Effect: "Hagnk's Gratitude", Effect Duration: 36
 3891	polymerized modified ionized vial of vermilion slime	0		Effect: "Can Has Cyborger", Effect Duration: 67
 3892	polymerized wet vial of amber slime	0		Effect: "Thanksgot", Effect Duration: 46
-3893	super-colloidal yellow bouncing vial of chartreuse slime	0		Effect: "Tiki Temerity", Effect Duration: 53
+3893	super-colloidal bouncing yellow vial of chartreuse slime	0		Effect: "Tiki Temerity", Effect Duration: 53
 3894	electrified vial of teal slime	0		Effect: "Stick Emporium Membership", Effect Duration: 56
 3895	modified vial of indigo slime	0		Effect: "Boletus Swoletus", Effect Duration: 30
 3896	flattened double-nitrogenated vial of slime	0		Effect: "Just Aged Enough", Effect Duration: 36
@@ -3852,17 +3852,17 @@
 3898	teal bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	ghostly figurine of a wretched-looking seal	0		Class: "Seal Clubber"
-3903	red blinking figurine of a baby seal	0		Class: "Seal Clubber"
+3903	blinking red figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
-3908	jittery green figurine of a stinking seal	0		Class: "Seal Clubber"
+3908	green jittery figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	upside-down upside-down figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	boozy perfectly mixed blended swill with a fly in it	5	EPIC	
+3913	perfectly mixed boozy blended swill with a fly in it	5	EPIC	
 3914	turtle wax	0		
 3915	rosy-cheeked turtle wax shield	0		Maximum HP Percent: +30, Damage Reduction: 2
 3916	Jeselnik's turtle wax helmet	0		Sleaze Damage: +25, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3934,7 +3934,7 @@
 3982	jittery mirror wizardly torquoise ring of the detective	0		Mysticality: +25, Item Drop: +20, Single Equip
 3983	dueling turtle	0		
 3984	shaking veiny Samson's dueling banjo	0		Experience (Muscle): +5, Maximum HP: +10
-3985	purple shaking soup turtle	0		
+3985	shaking purple soup turtle	0		
 3986	samurai turtle	0		
 3987	jittery double-paned wool samurai turtle helmet	0		Cold Resistance: 6, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	narrow turtle shell	0		
@@ -3942,10 +3942,10 @@
 3990	Sinatra's turtle shell helmet	0		Experience (Moxie): +5, Familiar Effect: "hot atk, cap 8"
 3991	jittery slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
-3993	upside-down mirror slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
+3993	mirror upside-down slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
-3996	green wobbly boxcar turtle	0		
+3996	wobbly green boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	skewed metrognome	0		Familiar Weight: +5
 3999	squat infant sandworm	0		Free Pull, Last Available: "2011-12"
@@ -3987,7 +3987,7 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	green caustic slime nodule	0		
 4037	spoiled slimy sweetbreads	4	crappy	
-4038	watered-down bad slimy fermented bile bladder	2	decent	
+4038	bad watered-down slimy fermented bile bladder	2	decent	
 4039	modified slimy alveolus	1		
 4040	blinking memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	Sherlock's perfumed pig-iron helm	0		Stench Resistance: +5, Item Drop: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
@@ -4003,7 +4003,7 @@
 4051	nasty ring of teleportation	0		Stench Damage: +5, Single Equip
 4052	olive glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	tumbling banana milkshake	1	crappy	Last Available: "2009-06"
-4054	acceptable fancy spirit-forward White Hyborian	5	good	Effect: "Stickler for Promptness", Effect Duration: 45, Last Available: "2009-06"
+4054	fancy acceptable spirit-forward White Hyborian	5	good	Effect: "Stickler for Promptness", Effect Duration: 45, Last Available: "2009-06"
 4055	yellow tumbling goblin hunting spear	0		Item Drop: +5, Last Available: "2009-06"
 4056	family-friendly brainy goblin autoblowgun	0		Mysticality: +5, Sleaze Resistance: +1, Last Available: "2009-06"
 4057	tribal beads of Flo-Jo	0		Initiative: +100, Last Available: "2009-06"
@@ -4081,14 +4081,14 @@
 4129	auspicious nasty dangerous hardened slime belt	0		Weapon Damage: +10, Stench Damage: +5, Item Drop: +10, Single Equip
 4130	green empty agua de vida bottle	0		Last Available: "2009-06"
 4131	twisted jittery mirror boot plant	1	good	Last Available: "2009-06"
-4132	artisanal fortified sham champagne	5	EPIC	Last Available: "2009-06"
+4132	fortified artisanal sham champagne	5	EPIC	Last Available: "2009-06"
 4133	aerosolized modified tempura air	0		Effect: "Slippery Tongue", Effect Duration: 60
 4134	quantum pressurized potion of pneumaticity	0		Effect: "Demonic Taint", Effect Duration: 34
 4135	wobbly moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	yellow blinking greasy clever dance instructor's Rosewater's Bag o' Tricks	0		Mysticality Percent: +30, Experience Percent (Moxie): +10, Maximum MP: +20, Sleaze Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
-4139	jittery twirling a creased paper strip	0		
+4139	twirling jittery a creased paper strip	0		
 4140	olive squat a folded paper strip	0		
 4141	green a crinkled paper strip	0		
 4142	a crumpled paper strip	0		
@@ -4100,7 +4100,7 @@
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	bouncing lint	0		Last Available: "2011-12"
-4151	flattened concentrated twirling blinking dubious peppermint	0		Effect: "Shawarma Warm War", Effect Duration: 63, Last Available: "2020-09"
+4151	flattened concentrated blinking twirling dubious peppermint	0		Effect: "Shawarma Warm War", Effect Duration: 63, Last Available: "2020-09"
 4152	concentrated upside-down Elvish delight	0		Effect: "Meadulla Oblongota", Effect Duration: 36
 4153	rockfish stomach	0		Last Available: "2009-09"
 4154	squat live lobster	0		Last Available: "2011-12"
@@ -4108,7 +4108,7 @@
 4156	pebbles	0		Last Available: "2009-09"
 4157	gravel	0		Last Available: "2009-09"
 4158	gray rock	0		Last Available: "2009-09"
-4159	maroon mirror rock lobster	0		Last Available: "2009-09"
+4159	mirror maroon rock lobster	0		Last Available: "2009-09"
 4160	drinkable pebblebr&auml;u	4	good	Last Available: "2009-09"
 4161	half-sized decent rocky road ice cream	2	good	Last Available: "2009-09"
 4162	ghostly extra-strength rubber bands	0		Familiar Weight: +5
@@ -4165,7 +4165,7 @@
 4213	miser's skate blade of the detective	0		Item Drop: +20, Meat Drop: +10
 4214	spangly unitard	0		
 4215	knitted collapsible baton of extreme caution	0		Monster Level: -25, Cold Resistance: +3
-4216	shaking tumbling groupie lipstick	0		
+4216	tumbling shaking groupie lipstick	0		
 4217	red groupie bra	0		
 4218	anodized groupie spangles	0		Effect: "Smoking like a Bandit", Effect Duration: 38
 4219	energetic skate board of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20
@@ -4192,7 +4192,7 @@
 4240	Vulcanized gun cleaning kit	0		Effect: "Psalm of Pointiness", Effect Duration: 57
 4241	spinning purple stylish sleep mask	0		Moxie: +25, Familiar Effect: "atk, 1xBarrr, cap 37"
 4242	sock garters of the glutton	0		Food Drop: +100, Single Equip
-4243	improved boiled upside-down teal mariachi toothpaste	0		Effect: "The Spy Who Loved XP", Effect Duration: 39
+4243	improved boiled teal upside-down mariachi toothpaste	0		Effect: "The Spy Who Loved XP", Effect Duration: 39
 4244	lard-coated leather-bound tome	0		Sleaze Spell Damage: +25
 4245	bookmark	0		
 4246	mansplainer's ivory cue ball	0		Monster Level: +15
@@ -4204,7 +4204,7 @@
 4252	alkaline double-oxidized vial of squid ink	0		Effect: "Orc Chops", Effect Duration: 18
 4253	nitrogenated potion of speed	0		Effect: "What's That Smell?", Effect Duration: 54
 4254	tumbling blurry bark	0		Last Available: "2009-10"
-4255	pulsating ghostly Wolfman Nardz	0		Last Available: "2009-10"
+4255	ghostly pulsating Wolfman Nardz	0		Last Available: "2009-10"
 4256	enhanced blurry sap	0		Effect: "Vinegavotte", Effect Duration: 25, Last Available: "2009-10"
 4257	maroon petrified wood	0		Last Available: "2009-10"
 4258	moldy chocolate-covered scarab beetle	3	crappy	Last Available: "2009-10"
@@ -4303,18 +4303,18 @@
 4351	narrow supercool snow belly	0		Moxie Percent: +20, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	red Crimbough	0		Last Available: "2009-12"
-4354	cyan skewed A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
-4355	ghostly lime green A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
+4354	skewed cyan A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4355	lime green ghostly A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	narrow A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	wobbly A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	miniature rotten expired can of franks 'n' beans	2	crappy	Last Available: "2009-12"
-4361	watered-down lousy expired bottle of peppermint schnapps	2	decent	Last Available: "2009-12"
-4362	olive blurry snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
+4361	lousy watered-down expired bottle of peppermint schnapps	2	decent	Last Available: "2009-12"
+4362	blurry olive snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	ghostly elf resistance button	0		Last Available: "2009-12"
 4364	energized triple-deionized upside-down elven suicide capsule	0		Effect: "Patched In", Effect Duration: 68, Last Available: "2009-12"
-4365	fancy jumbo moldy blurry penguin focaccia bread	5	crappy	Effect: "Super Speed", Effect Duration: 50, Last Available: "2009-12"
+4365	jumbo moldy fancy blurry penguin focaccia bread	5	crappy	Effect: "Super Speed", Effect Duration: 50, Last Available: "2009-12"
 4366	triple-distilled perfectly mixed herringcello	9	EPIC	Last Available: "2009-12"
 4367	hand-crafted elven cellocello	4	EPIC	Last Available: "2009-12"
 4368	lime green wrench handle	0		Last Available: "2009-12"
@@ -4360,7 +4360,7 @@
 4409	twirling Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	cyan Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	enchanted stale quantum taco	0		Effect: "Saucemastery", Effect Duration: 20, Last Available: "2010-10"
+4412	stale enchanted quantum taco	0		Effect: "Saucemastery", Effect Duration: 20, Last Available: "2010-10"
 4413	mediocre Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	arcane researcher's sealhide hood	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4380,7 +4380,7 @@
 4430	teddybear backpack of the scaredy-cat	0		Monster Level: -15
 4431	NPZR chemistry set	0		Last Available: "2011-08"
 4432	quadruple-vacuum-sealed pickled bouncing invisibility potion	0		Effect: "Incensed", Effect Duration: 58, Last Available: "2011-08"
-4433	alkaline double-pressed tumbling wobbly irresistibility potion	0		Effect: "Pasty", Effect Duration: 41, Last Available: "2011-08"
+4433	alkaline double-pressed wobbly tumbling irresistibility potion	0		Effect: "Pasty", Effect Duration: 41, Last Available: "2011-08"
 4434	flattened unsweetened narrow irritability potion	0		Effect: "Sepia Tan", Effect Duration: 48, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
@@ -4412,7 +4412,7 @@
 4464	polarized chocolate pasta spoon	0		Effect: "Cheered Up", Effect Duration: 17
 4465	alkaline boiled activated chocolate saucepan	0		Effect: "Insatiable Hunger", Effect Duration: 40
 4466	cold-filtered modified concentrated blue chocolate disco ball	0		Effect: "Buff as a Baobab", Effect Duration: 59
-4467	quadruple-magnetized ionized mirror shaking olive chocolate stolen accordion	0		Effect: "Triangle, Man", Effect Duration: 64
+4467	quadruple-magnetized ionized olive shaking mirror chocolate stolen accordion	0		Effect: "Triangle, Man", Effect Duration: 64
 4468	blurry Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
@@ -4428,7 +4428,7 @@
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	squat BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
-4483	bouncing mirror BRICKO cathedral	0		Last Available: "2010-02"
+4483	mirror bouncing BRICKO cathedral	0		Last Available: "2010-02"
 4484	BRICKO gargantuchicken	0		Last Available: "2010-02"
 4485	BRICKO pyramid	0		Last Available: "2010-02"
 4486	BRICKO pearl	0		Last Available: "2010-02"
@@ -4460,7 +4460,7 @@
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	huge Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	rotten blinking Humpty Dumplings	4	crappy	Last Available: "2010-03"
-4515	low-calorie spoiled Lobster <i>qua</i> Grill	1	crappy	Last Available: "2010-03"
+4515	spoiled low-calorie Lobster <i>qua</i> Grill	1	crappy	Last Available: "2010-03"
 4516	hand-crafted missing wine	3	EPIC	Last Available: "2010-03"
 4517	adequate matter custard	3	good	Last Available: "2010-03"
 4518	polymerized cold-filtered comfit?	0		Effect: "The Halls of Mysticality", Effect Duration: 17, Last Available: "2010-03"
@@ -4471,16 +4471,16 @@
 4523	supercool eye of the Tiger-lily of the ox	0		Muscle: +20, Moxie Percent: +20, Last Available: "2010-03"
 4524	wig of the ox of the wise owl	0		Muscle: +20, Mysticality: +20, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	moldy gigantic donut	10	crappy	Last Available: "2010-03"
-4526	massive yummy twirling green bucket of honey	10	awesome	Last Available: "2010-03"
+4526	yummy massive twirling green bucket of honey	10	awesome	Last Available: "2010-03"
 4527	flame-retardant Da Vinci's elephant stinger	0		Experience (Mysticality): +5, Hot Resistance: +1, Last Available: "2010-03"
-4528	miniature moldy dragon snaps	2	crappy	Last Available: "2010-03"
+4528	moldy miniature dragon snaps	2	crappy	Last Available: "2010-03"
 4529	shaking Van der Graaf crafty snapdragon pistil	0		Maximum MP: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-03"
 4530	jittery puff of smoke	0		Last Available: "2010-03"
 4531	miniature adequate spinning rook cookie	2	good	Last Available: "2010-03"
 4532	huge flavorless bishop cookie	9	decent	Last Available: "2010-03"
 4533	big decent knight cookie	5	good	Last Available: "2010-03"
-4534	small spoiled blinking king cookie	2	crappy	Last Available: "2010-03"
-4535	fancy rotten queen cookie	4	crappy	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
+4534	spoiled small blinking king cookie	2	crappy	Last Available: "2010-03"
+4535	rotten fancy queen cookie	4	crappy	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
 4536	twirling fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	squat perfumed insane tophat	0		Stench Resistance: +5, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 4538	bouncing forbidden helm of the knight of the blizzard	0		Spell Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
@@ -4494,7 +4494,7 @@
 4546	bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
-4549	twirling huge carpenter	0		Last Available: "2010-03"
+4549	huge twirling carpenter	0		Last Available: "2010-03"
 4550	dodo	0		Last Available: "2010-03"
 4551	ribald detour shield	0		Sleaze Damage: +10, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
@@ -4504,19 +4504,19 @@
 4556	bouncing right parenthesis	0		
 4557	dollar sign	0		
 4558	skewed equal sign	0		
-4559	bouncing twirling record album	0		Last Available: "2010-04"
+4559	twirling bouncing record album	0		Last Available: "2010-04"
 4560	spinning map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	squat hair of the calf	0		Last Available: "2010-04"
-4563	irresponsibly strong artisanal world's most unappetizing beverage	8	EPIC	Last Available: "2010-04"
+4563	artisanal irresponsibly strong world's most unappetizing beverage	8	EPIC	Last Available: "2010-04"
 4564	Jeselnik's slippery when wet shield	0		Sleaze Damage: +25, Damage Reduction: 6, Last Available: "2010-04"
 4565	bland tumbling raisin	3	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	beefy flyest of shirts of the sewer	0		Muscle: +10, Stench Damage: +25, Last Available: "2010-04"
-4568	decent thick blinking a dance upon the palate	5	good	Last Available: "2010-04"
+4568	thick decent blinking a dance upon the palate	5	good	Last Available: "2010-04"
 4569	thick moldy prehistoric meteorite jawbreaker	5	crappy	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	normal enchanted fuchsia squirmy violent party snack	3	good	Effect: "Cockroach Scurry", Effect Duration: 45, Last Available: "2010-04"
+4571	enchanted normal fuchsia squirmy violent party snack	3	good	Effect: "Cockroach Scurry", Effect Duration: 45, Last Available: "2010-04"
 4572	wobbly zippy can-you-dig-it?	0		Initiative: +20, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	ghostly panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4546,7 +4546,7 @@
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	blinking bottle opener	0		Last Available: "2010-06"
 4600	blinking twirling map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	artisanal high-proof plastic cup of beer	9	EPIC	Last Available: "2010-06"
+4601	high-proof artisanal plastic cup of beer	9	EPIC	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	squat keg	0		Last Available: "2010-06"
@@ -4596,7 +4596,7 @@
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
 4649	pulsating chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
 4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
-4651	green spinning ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
+4651	spinning green ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	occult ironic knit cap of Gandalf	0		Spell Damage Percent: +25, Spell Critical Percent: +20, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	shaking ironic sunglasses	0		Single Equip
 4654	jittery occult ironic battle spoon	0		Spell Damage Percent: +25
@@ -4615,16 +4615,16 @@
 4667	resourceful Victor, the Insult Comic Hellhound Puppet	0		Maximum MP: +50
 4668	observational glasses of courage	0		Spooky Resistance: +3
 4669	bouncing inspector's hilarious comedy prop	0		Item Drop: +15
-4670	narrow ghostly beer-scented teddy bear	0		
-4671	triple-distilled hand-crafted booze-soaked cherry	8	EPIC	
+4670	ghostly narrow beer-scented teddy bear	0		
+4671	hand-crafted triple-distilled booze-soaked cherry	8	EPIC	
 4672	comfy pillow	0		
 4673	adequate marshmallow	4	good	
 4674	spoiled sponge cake	4	crappy	
-4675	special bad practically non-alcoholic olive narrow gin-soaked blotter paper	1	decent	Effect: "Stopping to Smell the Flowers", Effect Duration: 25
+4675	special bad practically non-alcoholic narrow olive gin-soaked blotter paper	1	decent	Effect: "Stopping to Smell the Flowers", Effect Duration: 25
 4676	tree-holed coin	0		
-4677	blinking squat unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
+4677	squat blinking unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	narrow unearthed potsherd	0		
-4679	huge yellow volcanic ash	0		
+4679	yellow huge volcanic ash	0		
 4680	smoked potsherd	0		
 4681	yellow tumbling ruddy pottery shield	0		Maximum HP Percent: +40, Damage Reduction: 3, Last Available: "2010-09"
 4682	careful savvy pottery hat	0		Mysticality Percent: +20, Monster Level: -10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
@@ -4645,7 +4645,7 @@
 4697	veiny fossilized necklace	0		Maximum HP: +10, Last Available: "2010-09"
 4698	skewed imp air	0		
 4699	bus pass	0		
-4700	gray tumbling ghostly fossilized spike	0		Last Available: "2010-09"
+4700	tumbling ghostly gray fossilized spike	0		Last Available: "2010-09"
 4701	twirling huge waterlogged crate	0		Last Available: "2011-12"
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	therapeutic red-hot medallion	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2010-09"
@@ -4660,7 +4660,7 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	blue popsicle stick	0		
 4714	delicious lemon popsicle	3	awesome	
-4715	miniature normal popsicle	2	good	
+4715	normal miniature popsicle	2	good	
 4716	normal jumbo strawberry popsicle	5	good	
 4717	stale liver popsicle	3	decent	
 4718	Rosewater's mariachi hat	0		Mysticality Percent: +30, Familiar Effect: "atk, cap 2"
@@ -4668,13 +4668,13 @@
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	huge microwave stogie	0		Last Available: "2011-12"
 4722	rotten liver and let pie	3	crappy	Last Available: "2010-10"
-4723	big flavorless badass pie	5	decent	Last Available: "2010-10"
+4723	flavorless big badass pie	5	decent	Last Available: "2010-10"
 4724	adequate shoo-fish pie	3	good	Last Available: "2010-10"
-4725	tasty thick piping organ pie	5	awesome	Last Available: "2010-10"
+4725	thick tasty piping organ pie	5	awesome	Last Available: "2010-10"
 4726	normal snack-sized igloo pie	2	good	Last Available: "2010-10"
 4727	diet yummy narrow stomach turnover	1	awesome	Last Available: "2010-10"
-4728	fancy moldy dead lights pie	3	crappy	Effect: "Hairy Palms", Effect Duration: 40, Last Available: "2010-10"
-4729	half-sized flavorless throbbing organ pie	2	decent	Last Available: "2010-10"
+4728	moldy fancy dead lights pie	3	crappy	Effect: "Hairy Palms", Effect Duration: 40, Last Available: "2010-10"
+4729	flavorless half-sized throbbing organ pie	2	decent	Last Available: "2010-10"
 4730	blinking rosy-cheeked stop shield	0		Maximum HP Percent: +30, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	fuchsia sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	lime green huge pumpkin	0		Last Available: "2010-11"
 4763	moldy pumpkin pie	3	crappy	Last Available: "2010-11"
-4764	acceptable weak ghostly pumpkin beer	2	good	Last Available: "2010-11"
+4764	weak acceptable ghostly pumpkin beer	2	good	Last Available: "2010-11"
 4765	galvanized colloidal pumpkin juice	0		Effect: "Demonic Flavor", Effect Duration: 48, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	savvy weightlifter's shin gourds	0		Muscle: +15, Mysticality Percent: +20, Single Equip, Last Available: "2010-11"
@@ -4721,7 +4721,7 @@
 4805	blurry Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
-4810	green blinking Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
+4810	blinking green Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	rotten CRIMBCOIDS mints	3	crappy	Last Available: "2011-01"
@@ -4734,7 +4734,7 @@
 4825	dog trainer's plastic Mr. Mination	0		Experience (familiar): +1, Last Available: "2010-12"
 4826	dance instructor's plastic Best Game Ever	0		Experience Percent (Moxie): +10, Last Available: "2010-12"
 4827	hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
-4828	blue blinking S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
+4828	blinking blue S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
@@ -4745,7 +4745,7 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	thick decent triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	decent thick triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	rotten square CRIMBCOOKIE	3	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	inspector's baleful bindlestocking of the brute	0		Muscle Percent: +30, Spell Damage: +25, Item Drop: +15, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
@@ -4762,7 +4762,7 @@
 4853	pickled activated holly-flavored Hob-O	0		Effect: "Melancholy Burden", Effect Duration: 23, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	huge Toot Oriole care package	0		
-4856	ghostly lime green paperclip	0		Last Available: "2011-01"
+4856	lime green ghostly paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	shellacked CRIMBCO lanyard	0		Damage Reduction: 7, Single Equip, Last Available: "2011-01"
 4859	lime green CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
@@ -4780,7 +4780,7 @@
 4871	wool paperclip cape	0		Cold Resistance: +1, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
-4874	tumbling bouncing gaudy key	0		
+4874	bouncing tumbling gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	modified boiled chocolate bath ball	0		Effect: "Turkey-Ambitious", Effect Duration: 12, Last Available: "2011-01"
 4877	ionized maroon bacon bath ball	0		Effect: "Conspiratory Eyes", Effect Duration: 46, Last Available: "2011-01"
@@ -4792,16 +4792,16 @@
 4883	toe jam	0		Last Available: "2011-01"
 4884	flavorless snack-sized mirror toe jam toast	2	decent	Last Available: "2011-01"
 4885	ghostly traffic jam	0		Last Available: "2011-01"
-4886	bland half-sized traffic jam toast	2	decent	Last Available: "2011-01"
+4886	half-sized bland traffic jam toast	2	decent	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	thick moldy space jam toast	5	crappy	Last Available: "2011-01"
+4888	moldy thick space jam toast	5	crappy	Last Available: "2011-01"
 4889	enhanced pressed Vulcanized huge motivational poster	0		Effect: "Litterboxing", Effect Duration: 25, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
 4894	fancy decent festive sausage	4	good	Effect: "Shawarma Initiative", Effect Duration: 25, Last Available: "2011-01"
-4895	normal miniature holiday cheese log	2	good	Last Available: "2011-01"
+4895	miniature normal holiday cheese log	2	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	skewed lard-coated Annie Oakley's BGE 'ferocious fruit' shirt	0		Critical Hit Percent: +20, Sleaze Spell Damage: +25, Last Available: "2010-12"
 4898	auspicious dog trainer's BGE 'cuddly critter' shirt	0		Experience (familiar): +1, Item Drop: +10, Last Available: "2010-12"
@@ -4811,7 +4811,7 @@
 4902	jittery stapler bear of the dark arts	0		Spell Damage Percent: +100, Last Available: "2010-12"
 4903	skewed up-at-dawn adhesive tape dolly	0		Adventures: +5, Last Available: "2010-12"
 4904	sizzling scissor duck	0		Hot Damage: +10, Last Available: "2010-12"
-4905	ghostly red coal paperweight	0		Last Available: "2010-12"
+4905	red ghostly coal paperweight	0		Last Available: "2010-12"
 4906	jingle bell	0		Last Available: "2010-12"
 4907	rosy-cheeked Seven Loco	0		Maximum HP Percent: +30, Item Drop: +5, Last Available: "2010-09"
 4908	mirror Loathing Legion knife	0		Last Available: "2011-01"
@@ -4840,7 +4840,7 @@
 4937	a angel	0		Free Pull, Last Available: "2011-12"
 4938	bouncing quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
-4940	skewed huge arrowgram	0		Free Pull, Last Available: "2011-12"
+4940	huge skewed arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	spoiled Knob jelly donut	3	crappy	
 4942	Knob cake	0		
 4943	jittery Knob cake pan	0		
@@ -4855,7 +4855,7 @@
 4952	aerosolized ionized wobbly baggie of sugar	0		Effect: "Castaway Physique", Effect Duration: 16
 4953	Samson's whalebone corset of the sewer	0		Experience (Muscle): +5, Stench Damage: +25, Single Equip
 4954	Tesla oven mitts	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
-4955	moldy low-calorie overcookie	1	crappy	
+4955	low-calorie moldy overcookie	1	crappy	
 4956	thick spoiled philosopher's scone	5	crappy	
 4957	enhanced half-baked potion	0		Effect: "Crusty Head", Effect Duration: 36
 4958	executive Knob Goblin deluxe scimitar	0		Meat Drop: +40
@@ -4907,7 +4907,7 @@
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	shaking Alice's Army Foil Dervish	0		Last Available: "2011-03"
-5007	mirror blurry Alice's Army Foil Martyr	0		Last Available: "2011-03"
+5007	blurry mirror Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	squat Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	Usain Bolt's card sleeve	0		Initiative: +80, Last Available: "2011-03"
 5010	evil eye	0		
@@ -4916,7 +4916,7 @@
 5013	spoiled wasabi pocky	3	crappy	Last Available: "2011-03"
 5014	spoiled half-sized bouncing tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	adequate shaking natto pocky	3	good	Last Available: "2011-03"
-5016	drinkable practically non-alcoholic wasabi-infused sake	1	good	Last Available: "2011-03"
+5016	practically non-alcoholic drinkable wasabi-infused sake	1	good	Last Available: "2011-03"
 5017	acceptable green tobiko-infused sake	3	good	Last Available: "2011-03"
 5018	perfectly mixed bouncing natto-infused sake	4	EPIC	Last Available: "2011-03"
 5019	moist concentrated wasabi marble soda	0		Effect: "Bandersnatched", Effect Duration: 66, Last Available: "2011-03"
@@ -4924,10 +4924,10 @@
 5021	unsweetened triple-chilled blue natto marble soda	0		Effect: "Butt-Rock Hair", Effect Duration: 53, Last Available: "2011-03"
 5022	mirror Alice's Army booster box	0		Last Available: "2011-03"
 5023	moist wet spinning elderly jawbreaker	0		Effect: "Cold Hard Skin", Effect Duration: 32, Last Available: "2020-09"
-5024	practically non-alcoholic fancy perfectly mixed marshmallow flamb&eacute;	1	super ultra mega turbo EPIC	Effect: "Haunted Liver", Effect Duration: 25, Last Available: "2011-03"
+5024	perfectly mixed fancy practically non-alcoholic marshmallow flamb&eacute;	1	super ultra mega turbo EPIC	Effect: "Haunted Liver", Effect Duration: 25, Last Available: "2011-03"
 5025	tolerable ghostly cranberry schnapps	3	good	Last Available: "2011-03"
 5026	artisanal wobbly breaded beer	3	super ultra EPIC	Last Available: "2011-03"
-5027	drinkable weak yellow soy cordial	2	good	Last Available: "2011-03"
+5027	weak drinkable yellow soy cordial	2	good	Last Available: "2011-03"
 5028	foul-smelling astral bludgeon of wisdom of horror	0		Mysticality: +15, Stench Damage: +10, Spooky Spell Damage: +25
 5029	frightening nasty astral shield	0		Stench Damage: +5, Spooky Damage: +5, Damage Reduction: 15
 5030	wobbly horrifying clever wholesome astral chapeau	0		Maximum HP Percent: +10, Maximum MP: +20, Spooky Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4944,7 +4944,7 @@
 5041	supercharged therapeutic padded astral shirt	0		Damage Absorption: +20, Maximum MP Percent: +30, HP Regen Min: 5, HP Regen Max: 7
 5042	Sherlock's lard-coated astral belt	0		Sleaze Spell Damage: +25, Item Drop: +25
 5043	spoiled astral hot dog	4		
-5044	practically non-alcoholic smooth spinning astral pilsner	1		
+5044	smooth practically non-alcoholic spinning astral pilsner	1		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	huge Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4955,11 +4955,11 @@
 5052	blurry handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	lime green intriguing puzzle box	0		Last Available: "2011-04"
-5055	pulsating jittery obnoxious riddle	0		Last Available: "2011-04"
+5055	jittery pulsating obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	magnetized skewed mirror Atomic Comic	0		Effect: "Incredibly Hulking", Effect Duration: 31, Last Available: "2011-04"
 5058	super-improved non-galvanized spinning Red Pill	0		Effect: "Spiro Gyro", Effect Duration: 23, Last Available: "2011-04"
-5059	narrow olive Skullhead's Screw	0		Last Available: "2011-04"
+5059	olive narrow Skullhead's Screw	0		Last Available: "2011-04"
 5060	upside-down cyan mysterious present	0		Last Available: "2011-04"
 5061	narrow boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	voodoo doll	0		Last Available: "2011-04"
@@ -4971,7 +4971,7 @@
 5068	spoiled chaos popcorn	4	crappy	Last Available: "2011-04"
 5069	twirling tumbling Jack Frost's wicked Herculean hole	0		Experience (Muscle): +1, Spell Damage: +5, Cold Spell Damage: +50, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	decent small skewed s'more	0	good	Last Available: "2011-04"
+5071	small decent skewed s'more	0	good	Last Available: "2011-04"
 5072	ghostly diamond ring	0		Last Available: "2011-04"
 5073	drinkable Russian Ice	3	good	Last Available: "2011-04"
 5074	educational clay ashtray	0		Experience: +1, Damage Reduction: 3, Last Available: "2011-05"
@@ -5010,7 +5010,7 @@
 5107	hand-crafted Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
 5108	twirling fistful of ashes	0		
 5109	twirling spinning green prompt stress ball	0		Adventures: +3, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
-5110	bouncing fuchsia Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
+5110	fuchsia bouncing Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	huge Da Vinci's Ultracolor&trade; shirt	0		Experience (Mysticality): +5, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
@@ -5046,8 +5046,8 @@
 5143	teal E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	corrupted honeypot	0		Effect: "Wreathed in Smoke", Effect Duration: 44
-5146	diet flavorless special wild honey pie	1	decent	Effect: "Bolts about Candy", Effect Duration: 25
-5147	practically non-alcoholic mediocre honey mead	1	decent	
+5146	diet special flavorless wild honey pie	1	decent	Effect: "Bolts about Candy", Effect Duration: 25
+5147	mediocre practically non-alcoholic honey mead	1	decent	
 5148	blinking tumbling honey dipper of extreme caution of the blizzard of incineration	0		Monster Level: -25, Cold Spell Damage: +25, Hot Spell Damage: +50
 5149	Usain Bolt's Tesla experienced honeybritches	0		Experience: +2, Initiative: +80, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	huge skewed ribald honeycap of the dark arts of Gandalf	0		Spell Damage Percent: +100, Spell Critical Percent: +20, Sleaze Damage: +10, Familiar Effect: "1xPotato, cap 43"
@@ -5074,7 +5074,7 @@
 5171	shaking Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	smooth triple-distilled upside-down Saison du Lune	8	awesome	Last Available: "2011-06"
+5174	triple-distilled smooth upside-down Saison du Lune	8	awesome	Last Available: "2011-06"
 5175	practically non-alcoholic acceptable Moonthril Schnapps	1	good	Last Available: "2011-06"
 5176	bad Wrecked Generator	3	decent	Last Available: "2011-06"
 5177	yummy fuchsia Spaghetti with Moonballs	4	awesome	Last Available: "2011-06"
@@ -5087,7 +5087,7 @@
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
-5187	skewed gray Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
+5187	gray skewed Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	adjusted cold-filtered bouncing honey stick	0		Effect: "Mayeaugh", Effect Duration: 28
 5189	tarnished dry dry green double-ice gum	0		Effect: "Hyperoffended", Effect Duration: 61, Last Available: "2011-04"
 5190	rosewater-soaked wholesome weightlifter's Operation Patriot Shield	0		Muscle: +15, Maximum HP Percent: +10, Stench Resistance: +3, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
@@ -5103,32 +5103,32 @@
 5200	powdered spinning red paste	1	crappy	Last Available: "2011-08"
 5201	denatured ectoplasmic paste	1	decent	Last Available: "2011-08"
 5202	pickled greasy paste	1	decent	Effect: "Man's Worst Enemy", Effect Duration: 45, Last Available: "2011-08"
-5203	dehydrated bouncing twirling upside-down bug paste	1	good	Effect: "Perception", Effect Duration: 30, Last Available: "2011-08"
+5203	dehydrated twirling bouncing upside-down bug paste	1	good	Effect: "Perception", Effect Duration: 30, Last Available: "2011-08"
 5204	boiled mirror hippy paste	1	good	Last Available: "2011-08"
 5205	mixed upside-down orc paste	1	decent	Effect: "Lit Up", Effect Duration: 20, Last Available: "2011-08"
 5206	compressed demonic paste	1	good	Effect: "Ponderous Potency", Effect Duration: 45, Last Available: "2011-08"
-5207	vaporized jittery cyan indescribably horrible paste	1	decent	Last Available: "2011-08"
+5207	vaporized cyan jittery indescribably horrible paste	1	decent	Last Available: "2011-08"
 5208	dried paste	1	crappy	Effect: "Hood Ridin'", Effect Duration: 10, Last Available: "2011-08"
 5209	denatured skewed wobbly goblin paste	1	awesome	Last Available: "2011-08"
 5210	distilled pirate paste	1	awesome	Last Available: "2011-08"
-5211	twisted squat skewed chlorophyll paste	1	good	Last Available: "2011-08"
+5211	twisted skewed squat chlorophyll paste	1	good	Last Available: "2011-08"
 5212	boiled paste	1	good	Effect: "Puzzle Fury", Effect Duration: 40, Last Available: "2011-08"
 5213	diluted Mer-kin paste	1	crappy	Effect: "Bilious Brawn", Effect Duration: 30, Last Available: "2011-08"
 5214	modified squat slimy paste	1	EPIC	Effect: "Egg on your Face", Effect Duration: 50, Last Available: "2011-08"
 5215	pickled upside-down penguin paste	1	decent	Last Available: "2011-08"
 5216	vaporized gray elemental paste	1	decent	Effect: "Ass Over Teakettle", Effect Duration: 50, Last Available: "2011-08"
 5217	powdered cosmic paste	1	good	Last Available: "2011-08"
-5218	compressed skewed red hobo paste	1	crappy	Last Available: "2011-08"
+5218	compressed red skewed hobo paste	1	crappy	Last Available: "2011-08"
 5219	distilled yellow Crimbo paste	1	awesome	Last Available: "2011-08"
 5220	Teachings of the Fist	0		
-5221	green twirling upside-down fat loot token	0		No Pull
+5221	twirling upside-down green fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	yummy half-sized Ur-Donut	2	awesome	Last Available: "2011-09"
 5225	narrow spinning The Bomb	0		Last Available: "2011-09"
 5226	blurry box of Familiar Jacks	0		Last Available: "2011-09"
 5227	lousy triple-distilled bucket of wine	6	decent	Last Available: "2011-09"
-5228	diet fancy flavorless ultrafondue	1	decent	Effect: "Dancing Prowess", Effect Duration: 50, Last Available: "2011-09"
+5228	flavorless diet fancy ultrafondue	1	decent	Effect: "Dancing Prowess", Effect Duration: 50, Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5139,32 +5139,32 @@
 5236	bouncing dog trainer's frosty halo	0		Experience (familiar): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	friendly time halo	0		Familiar Weight: +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	aged irresponsibly strong Lumineux Limnio	10	awesome	Last Available: "2011-09"
-5239	spirit-forward tolerable skewed Morto Moreto	5	good	Last Available: "2011-09"
+5239	tolerable spirit-forward skewed Morto Moreto	5	good	Last Available: "2011-09"
 5240	tolerable Temps Tempranillo	4	good	Last Available: "2011-09"
 5241	lousy weak Bordeaux Marteaux	2	decent	Last Available: "2011-09"
 5242	mediocre boozy Fromage Pinotage	5	decent	Last Available: "2011-09"
 5243	artisanal Beignet Milgranet	3	EPIC	Last Available: "2011-09"
 5244	practically non-alcoholic bad Muschat	1	decent	Last Available: "2011-09"
-5245	small normal shaking cool jelly donut	2	good	Last Available: "2011-09"
+5245	normal small shaking cool jelly donut	2	good	Last Available: "2011-09"
 5246	normal shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	snack-sized stale wobbly occult jelly donut	2	decent	Last Available: "2011-09"
 5248	bland thyme jelly donut	3	decent	Last Available: "2011-09"
 5249	snack-sized stale pulsating blue danish	2	decent	Last Available: "2011-09"
-5250	fancy big rotten squat smashed danish	5	crappy	Effect: "Larger", Effect Duration: 5, Last Available: "2011-09"
+5250	big rotten fancy squat smashed danish	5	crappy	Effect: "Larger", Effect Duration: 5, Last Available: "2011-09"
 5251	thick adequate forbidden danish	5	good	Last Available: "2011-09"
 5252	half-sized stale cool cat claw	2	decent	Last Available: "2011-09"
 5253	rotten blunt cat claw	4	crappy	Last Available: "2011-09"
 5254	toothsome pulsating shadowy cat claw	3	awesome	Last Available: "2011-09"
 5255	spoiled shaking cheezburger	3	crappy	Last Available: "2011-09"
-5256	adequate diet toasted brie	1	good	Last Available: "2011-09"
-5257	corrupted ghostly wobbly potion of the field gar	0		Effect: "Holiday Bliss", Effect Duration: 23, Last Available: "2011-09"
+5256	diet adequate toasted brie	1	good	Last Available: "2011-09"
+5257	corrupted wobbly ghostly potion of the field gar	0		Effect: "Holiday Bliss", Effect Duration: 23, Last Available: "2011-09"
 5258	irradiated cold-filtered too legit potion	0		Effect: "Booze Goozles", Effect Duration: 59, Last Available: "2011-09"
-5259	ionized polymerized huge twirling Bright Water	0		Effect: "Innately Wise", Effect Duration: 18, Last Available: "2011-09"
+5259	ionized polymerized twirling huge Bright Water	0		Effect: "Innately Wise", Effect Duration: 18, Last Available: "2011-09"
 5260	wet boiled blue cold-filtered water	0		Effect: "Hombre Muerto Caminando", Effect Duration: 64, Last Available: "2011-09"
-5261	corrupted shaking blinking graveyard snowglobe	0		Effect: "Human-Beast Hybrid", Effect Duration: 43, Last Available: "2011-09"
+5261	corrupted blinking shaking graveyard snowglobe	0		Effect: "Human-Beast Hybrid", Effect Duration: 43, Last Available: "2011-09"
 5262	tarnished anodized diffused shaking shaking cool cat elixir	0		Effect: "Aided and Abetted", Effect Duration: 34, Last Available: "2011-09"
 5263	cold-filtered upside-down potion of the captain's hammer	0		Effect: "Can't Be a Chooser", Effect Duration: 42, Last Available: "2011-09"
-5264	modified enhanced jittery gray potion of X-ray vision	0		Effect: "Scarysauce", Effect Duration: 64, Last Available: "2011-09"
+5264	modified enhanced gray jittery potion of X-ray vision	0		Effect: "Scarysauce", Effect Duration: 64, Last Available: "2011-09"
 5265	diffused double-colloidal jittery potion of the litterbox	0		Effect: "Chain Chain Chains", Effect Duration: 44, Last Available: "2011-09"
 5266	modified potion of animal rage	0		Effect: "init.enh", Effect Duration: 46, Last Available: "2011-09"
 5267	quadruple-colloidal anodized potion of punctual companionship	0		Effect: "Speed of the Internet", Effect Duration: 67, Last Available: "2011-09"
@@ -5188,12 +5188,12 @@
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
-5288	huge squat d10	0		Last Available: "2011-09"
+5288	squat huge d10	0		Last Available: "2011-09"
 5289	d12	0		Last Available: "2011-09"
 5290	gray spinning d20	0		Last Available: "2011-09"
 5291	tumbling generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
-5293	blurry gray skewed generic restorative potion	0		Last Available: "2011-09"
+5293	skewed gray blurry generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	twirling slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
@@ -5216,16 +5216,16 @@
 5313	deionized polarized necrotizing body spray	0		Effect: "Ice Packed", Effect Duration: 37, Last Available: "2011-10"
 5314	liquefied frozen shaking bite-me-red lipstick	0		Effect: "Antsy in your Pantsy", Effect Duration: 55, Last Available: "2011-10"
 5315	colloidal modified chilled whisker pencil	0		Effect: "Space Cowboy", Effect Duration: 23, Last Available: "2011-10"
-5316	ionized gray narrow press-on ribs	0		Effect: "You Know What's Up", Effect Duration: 39, Last Available: "2011-10"
+5316	ionized narrow gray press-on ribs	0		Effect: "You Know What's Up", Effect Duration: 39, Last Available: "2011-10"
 5317	non-moist diffused triple-anodized ghostly Rattlin' Chains	0		Effect: "Jammin'", Effect Duration: 22, Last Available: "2011-10"
 5318	alkaline Gummy Brains	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 27, Last Available: "2011-10"
 5319	nitrogenated yellow Blood 'n' Plenty	0		Effect: "Vanity Rage", Effect Duration: 62, Last Available: "2011-10"
 5320	pickled ionized enhanced yellow Lobos Mints	0		Effect: "Halloweeny", Effect Duration: 56, Last Available: "2011-10"
-5321	enhanced wet narrow fuchsia Sweet Sword	0		Effect: "Blackberry Politeness", Effect Duration: 40, Last Available: "2011-10"
+5321	enhanced wet fuchsia narrow Sweet Sword	0		Effect: "Blackberry Politeness", Effect Duration: 40, Last Available: "2011-10"
 5322	mediocre Ecto-Cooler	4	decent	Last Available: "2011-10"
 5323	perfectly mixed Bartles and BRAAAINS wine cooler	4	EPIC	Last Available: "2011-10"
-5324	weak tolerable Blood Light	2	good	Last Available: "2011-10"
-5325	hand-crafted watered-down squat Silver Bullet beer	2	EPIC	Last Available: "2011-10"
+5324	tolerable weak Blood Light	2	good	Last Available: "2011-10"
+5325	watered-down hand-crafted squat Silver Bullet beer	2	EPIC	Last Available: "2011-10"
 5326	aged red Bone's Farm &quot;wine&quot;	3	awesome	Last Available: "2011-10"
 5327	tumbling ghost protocol	0		Last Available: "2011-10"
 5328	chilled denatured mirror sorority brain	0		Effect: "Muddled", Effect Duration: 35, Last Available: "2011-10"
@@ -5249,7 +5249,7 @@
 5346	spinning death blossom	0		
 5347	A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
-5349	pulsating blurry A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
+5349	blurry pulsating A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
@@ -5307,7 +5307,7 @@
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	Jim Carey's Fonzie's Rosewater's cane-mail shirt	0		Mysticality Percent: +30, Experience (Moxie): +1, Monster Level: +25, Last Available: "2011-12"
 5406	reassuring dog trainer's deadly cane-mail pants	0		Weapon Damage: +5, Experience (familiar): +1, Spooky Resistance: +1, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	distilled artisanal narrow huge Vodka Matryoshka	5	EPIC	Last Available: "2011-12"
+5407	artisanal distilled huge narrow Vodka Matryoshka	5	EPIC	Last Available: "2011-12"
 5408	bad Gin Mint	4	decent	Last Available: "2011-12"
 5409	acceptable extra-dry Tequiz Navidad	5	good	Last Available: "2011-12"
 5410	perfectly mixed Mint Yulep	3	EPIC	Last Available: "2011-12"
@@ -5337,8 +5337,8 @@
 5434	DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
 5436	boiled fudge lily	0		Effect: "Booze Goozles", Effect Duration: 16, Last Available: "2011-11"
-5437	narrow bouncing ghostly superheated fudge	0		Last Available: "2011-11"
-5438	pressed blinking fuchsia fluid of fudge-finding	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 37, Last Available: "2011-11"
+5437	bouncing narrow ghostly superheated fudge	0		Last Available: "2011-11"
+5438	pressed fuchsia blinking fluid of fudge-finding	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 37, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	bland fudgesicle	3	decent	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	Jeselnik's supercharged healthy fudgecycle	0		Maximum HP Percent: +20, Maximum MP Percent: +30, Sleaze Damage: +25, Single Equip, Last Available: "2011-11"
 5461	mirror fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	mirror maroon Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	maroon mirror Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	super-polarized resolution: be wealthier	0		Effect: "Can Has Cyborger", Effect Duration: 63, Last Available: "2012-01"
 5465	triple-Vulcanized ionized resolution: be happier	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 19, Last Available: "2012-01"
 5466	moist resolution: be stronger	0		Effect: "Blessing of Charcoatl", Effect Duration: 32, Last Available: "2012-01"
@@ -5373,16 +5373,16 @@
 5470	pickled huge skewed resolution: be kinder	0		Effect: "Cookie Backup", Effect Duration: 55, Last Available: "2012-01"
 5471	dry resolution: be more adventurous	0		Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2012-01"
 5472	concentrated resolution: be luckier	0		Effect: "Oxygenated Blood", Effect Duration: 22, Last Available: "2012-01"
-5473	tumbling narrow gummi ingot	0		Last Available: "2011-11"
+5473	narrow tumbling gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
-5476	aerosolized bouncing jittery gummi salamander	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43, Last Available: "2011-11"
+5476	aerosolized jittery bouncing gummi salamander	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43, Last Available: "2011-11"
 5477	non-concentrated altered gummi snake	0		Effect: "Fortunate Resolve", Effect Duration: 28, Last Available: "2011-11"
-5478	aerosolized ionized tumbling blue bouncing gummi canary	0		Effect: "Enraged", Effect Duration: 33, Last Available: "2011-11"
-5479	yummy enchanted shaking green gummi bear	3	awesome	Effect: "Vanity Rage", Effect Duration: 30, Last Available: "2011-11"
+5478	aerosolized ionized bouncing tumbling blue gummi canary	0		Effect: "Enraged", Effect Duration: 33, Last Available: "2011-11"
+5479	enchanted yummy green shaking gummi bear	3	awesome	Effect: "Vanity Rage", Effect Duration: 30, Last Available: "2011-11"
 5480	decent tiny gummi bear	1	good	Last Available: "2011-11"
 5481	rotten gummi bear	3	crappy	Last Available: "2011-11"
-5482	massive spoiled drunki-bear	6	crappy	Last Available: "2011-11"
+5482	spoiled massive drunki-bear	6	crappy	Last Available: "2011-11"
 5483	bland immense drunki-bear	9	decent	Last Available: "2011-11"
 5484	small decent blinking drunki-bear	2	good	Last Available: "2011-11"
 5485	thinker's gummi bowtie	0		Mysticality: +10, Last Available: "2011-11"
@@ -5393,7 +5393,7 @@
 5490	huge belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
-5493	tumbling teal belemnite candy mold	0		Last Available: "2011-11"
+5493	teal tumbling belemnite candy mold	0		Last Available: "2011-11"
 5494	super-alkaline pickled squat gummi trilobite	0		Effect: "Happy Trails", Effect Duration: 25, Last Available: "2011-11"
 5495	galvanized gummi ammonite	0		Effect: "Spooky Hands", Effect Duration: 24, Last Available: "2011-11"
 5496	ionized gummi belemnite	0		Effect: "Saucemastery", Effect Duration: 69, Last Available: "2011-11"
@@ -5402,12 +5402,12 @@
 5499	hardened brainy Big Candy's tophat	0		Mysticality: +5, Damage Reduction: 3, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	tumbling Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	huge Jackass Plumber home game	0		Last Available: "2011-11"
-5502	shaking huge Trivial Avocations board game	0		Last Available: "2011-11"
+5502	huge shaking Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	spoiled fancy jumbo jerky coins	5	crappy	Effect: "Marinated", Effect Duration: 30, Last Available: "2011-11"
-5507	perfectly mixed maroon pulsating Go-Wassail	4	EPIC	Last Available: "2011-11"
+5506	jumbo fancy spoiled jerky coins	5	crappy	Effect: "Marinated", Effect Duration: 30, Last Available: "2011-11"
+5507	perfectly mixed pulsating maroon Go-Wassail	4	EPIC	Last Available: "2011-11"
 5508	frozen Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Conspiratory Eyes", Effect Duration: 12, Last Available: "2011-11"
 5509	quadruple-electrified diffused upside-down bottle of bubbles	0		Effect: "Polar Express", Effect Duration: 36, Last Available: "2011-11"
 5510	triple-pressed cyan wind-up meatcar	0		Effect: "Booooooze", Effect Duration: 43, Last Available: "2011-11"
@@ -5422,19 +5422,19 @@
 5519	cyan pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	twirling twirling pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	blinking pog #07 (orcish frat boy)	0		Last Available: "2011-11"
-5522	green blurry shaking pog #08 (hellion)	0		Last Available: "2011-11"
+5522	shaking green blurry pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	tumbling pog #10 (hobo)	0		Last Available: "2011-11"
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	triple-boiled double-frozen blue Atomic Pop	0		Effect: "Memory of Speed", Effect Duration: 32, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	fancy adequate big berries of suffering	5	good	Effect: "Wings of the Grasshopper", Effect Duration: 50, Last Available: "2012-12"
+5529	big adequate fancy berries of suffering	5	good	Effect: "Wings of the Grasshopper", Effect Duration: 50, Last Available: "2012-12"
 5530	anodized purple baobab sap	0		Effect: "Broken Fast", Effect Duration: 23, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	cyan magnolia blossom	0		Last Available: "2012-12"
 5533	ionized teal Mortimer's nostrum	0		Effect: "Snobby", Effect Duration: 49, Last Available: "2012-12"
-5534	weak lousy jittery blue Barulio's bottle	2	decent	Last Available: "2012-12"
+5534	weak lousy blue jittery Barulio's bottle	2	decent	Last Available: "2012-12"
 5535	galvanized moist altered squat spinning Marvin's marvelous pill	0		Effect: "Clean-Shaven", Effect Duration: 32, Last Available: "2012-12"
 5536	squat Winifred's whistle	0		Last Available: "2012-12"
 5537	wobbly prose pen	0		Last Available: "2012-12"
@@ -5444,12 +5444,12 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	manspreader's curative Leapin' Trousers	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5
-5544	practically non-alcoholic special bad skewed eggnog	1	decent	Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2012-12"
+5544	bad practically non-alcoholic special skewed eggnog	1	decent	Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2012-12"
 5545	delicious bouncing hamhock	3	awesome	Last Available: "2012-12"
 5546	upside-down The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	olive Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
-5549	purple wobbly Clancy's crumhorn	0		Last Available: "2012-12"
+5549	wobbly purple Clancy's crumhorn	0		Last Available: "2012-12"
 5550	twirling The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	cyan Clancy's lute	0		Last Available: "2012-12"
 5552	padded Trusty	0		Damage Absorption: +20
@@ -5465,7 +5465,7 @@
 5562	narrow Sherlock's Socratic Rain-Doh violet bo	0		Experience (Mysticality): +1, Item Drop: +25, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	yummy huge jittery PB&BP	7	awesome	
+5565	huge yummy jittery PB&BP	7	awesome	
 5566	normal club sandwich	3	good	
 5567	normal olive corned-beef Reuben	3	good	
 5568	frayed ninja rope	0		
@@ -5473,63 +5473,63 @@
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	enchanted distilled perfectly mixed gray Drac & Tan	5	EPIC	Effect: "Eye of the Lihc", Effect Duration: 25, Last Available: "2012-03"
+5573	distilled perfectly mixed enchanted gray Drac & Tan	5	EPIC	Effect: "Eye of the Lihc", Effect Duration: 25, Last Available: "2012-03"
 5574	lousy Transylvania Sling	3	decent	Last Available: "2012-03"
 5575	practically non-alcoholic perfectly mixed Shot of the Living Dead	1	super ultra EPIC	Last Available: "2012-03"
-5576	perfectly mixed watered-down Buttery Knob	2	EPIC	Last Available: "2012-03"
+5576	watered-down perfectly mixed Buttery Knob	2	EPIC	Last Available: "2012-03"
 5577	perfectly mixed squat Slippery Knob	3	EPIC	Last Available: "2012-03"
-5578	aged spirit-forward narrow cyan Flaming Knob	5	awesome	Last Available: "2012-03"
+5578	spirit-forward aged cyan narrow Flaming Knob	5	awesome	Last Available: "2012-03"
 5579	artisanal Grasshopper	4	EPIC	Last Available: "2012-03"
 5580	acceptable ghostly Locust	4	good	Last Available: "2012-03"
 5581	smooth Plague of Locusts	4	awesome	Last Available: "2012-03"
 5582	mediocre twirling Red Dwarf	3	decent	Last Available: "2012-03"
 5583	perfectly mixed Golden Mean	3	EPIC	Last Available: "2012-03"
 5584	tolerable practically non-alcoholic jittery Green Giant	1	good	Last Available: "2012-03"
-5585	perfectly mixed extra-dry special Aye Aye	5	EPIC	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2012-03"
-5586	strong tolerable Aye Aye, Captain	5	good	Last Available: "2012-03"
-5587	lousy fortified Aye Aye, Tooth Tooth	5	decent	Last Available: "2012-03"
+5585	extra-dry special perfectly mixed Aye Aye	5	EPIC	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2012-03"
+5586	tolerable strong Aye Aye, Captain	5	good	Last Available: "2012-03"
+5587	fortified lousy Aye Aye, Tooth Tooth	5	decent	Last Available: "2012-03"
 5588	lousy upside-down Humanitini	3	decent	Last Available: "2012-03"
 5589	smooth narrow More Humanitini than Humanitini	4	awesome	Last Available: "2012-03"
-5590	bad special upside-down maroon spinning Oh, the Humanitini	4	decent	Effect: "Radiated and Grodiated", Effect Duration: 15, Last Available: "2012-03"
+5590	bad special spinning upside-down maroon Oh, the Humanitini	4	decent	Effect: "Radiated and Grodiated", Effect Duration: 15, Last Available: "2012-03"
 5591	tolerable Great Older Fashioned	4	good	Last Available: "2012-03"
 5592	drinkable Fuzzy Tentacle	3	good	Last Available: "2012-03"
 5593	weak hand-crafted Crazymaker	2	EPIC	Last Available: "2012-03"
-5594	artisanal extra-dry mirror Zoodriver	5	EPIC	Last Available: "2012-03"
+5594	extra-dry artisanal mirror Zoodriver	5	EPIC	Last Available: "2012-03"
 5595	artisanal Sloe Comfortable Zoo	4	EPIC	Last Available: "2012-03"
 5596	mediocre wobbly Sloe Comfortable Zoo on Fire	3	decent	Last Available: "2012-03"
 5597	triple-distilled drinkable spinning Suffering Sinner	10	good	Last Available: "2012-03"
 5598	drinkable lime green Suppurating Sinner	3	good	Last Available: "2012-03"
 5599	watered-down acceptable Sizzling Sinner	2	good	Last Available: "2012-03"
 5600	acceptable maroon Firewater	4	good	Last Available: "2012-03"
-5601	practically non-alcoholic acceptable Earth and Firewater	1	good	Last Available: "2012-03"
-5602	watered-down bad Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
+5601	acceptable practically non-alcoholic Earth and Firewater	1	good	Last Available: "2012-03"
+5602	bad watered-down Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
 5603	mediocre Slimosa	3	decent	Last Available: "2012-03"
-5604	practically non-alcoholic artisanal olive Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
+5604	artisanal practically non-alcoholic olive Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
 5605	aged Slimebite	3	awesome	Last Available: "2012-03"
 5606	drinkable Cement Mixer	4	good	Last Available: "2012-03"
 5607	acceptable Jackhammer	3	good	Last Available: "2012-03"
 5608	hand-crafted upside-down Dump Truck	4	EPIC	Last Available: "2012-03"
-5609	high-proof acceptable maroon Fauna Libre	7	good	Last Available: "2012-03"
+5609	acceptable high-proof maroon Fauna Libre	7	good	Last Available: "2012-03"
 5610	bad Chakra Libre	4	decent	Last Available: "2012-03"
 5611	perfectly mixed Aura Libre	4	EPIC	Last Available: "2012-03"
 5612	perfectly mixed weak Sazerorc	2	EPIC	Last Available: "2012-03"
 5613	perfectly mixed Sazuruk-hai	3	EPIC	Last Available: "2012-03"
 5614	hand-crafted watered-down Flaming Sazerorc	2	EPIC	Last Available: "2012-03"
 5615	hand-crafted weak Green Velvet	2	EPIC	Last Available: "2012-03"
-5616	watered-down mediocre Green Muslin	2	decent	Last Available: "2012-03"
+5616	mediocre watered-down Green Muslin	2	decent	Last Available: "2012-03"
 5617	perfectly mixed green Green Burlap	3	EPIC	Last Available: "2012-03"
 5618	irresponsibly strong hand-crafted Mohobo	9	EPIC	Last Available: "2012-03"
-5619	hand-crafted irresponsibly strong Moonshine Mohobo	10	EPIC	Last Available: "2012-03"
-5620	weak bad Flaming Mohobo	2	decent	Last Available: "2012-03"
-5621	watered-down acceptable fancy shaking Drunken Philosopher	2	good	Effect: "Morninja", Effect Duration: 5, Last Available: "2012-03"
+5619	irresponsibly strong hand-crafted Moonshine Mohobo	10	EPIC	Last Available: "2012-03"
+5620	bad weak Flaming Mohobo	2	decent	Last Available: "2012-03"
+5621	watered-down fancy acceptable shaking Drunken Philosopher	2	good	Effect: "Morninja", Effect Duration: 5, Last Available: "2012-03"
 5622	mediocre Drunken Neurologist	3	decent	Last Available: "2012-03"
 5623	lousy Drunken Astrophysicist	4	decent	Last Available: "2012-03"
 5624	artisanal Dark & Starry	4	EPIC	Last Available: "2012-03"
-5625	aged practically non-alcoholic gray Black Hole	1	awesome	Last Available: "2012-03"
+5625	practically non-alcoholic aged gray Black Hole	1	awesome	Last Available: "2012-03"
 5626	mediocre Event Horizon	3	decent	Last Available: "2012-03"
 5627	drinkable watered-down Herring Daiquiri	2	good	Last Available: "2012-03"
 5628	tolerable Herring Wallbanger	3	good	Last Available: "2012-03"
-5629	bad enchanted Herringtini	3	decent	Effect: "Spell Transfer Complete", Effect Duration: 50, Last Available: "2012-03"
+5629	enchanted bad Herringtini	3	decent	Effect: "Spell Transfer Complete", Effect Duration: 50, Last Available: "2012-03"
 5630	tolerable watered-down bouncing Lollipop Drop	2	good	Last Available: "2012-03"
 5631	aged watered-down Candy Alexander	2	awesome	Last Available: "2012-03"
 5632	perfectly mixed spinning Candicaine	3	EPIC	Last Available: "2012-03"
@@ -5538,11 +5538,11 @@
 5635	smooth huge Flaming Caipiranha	4	awesome	Last Available: "2012-03"
 5636	smooth Punchplanter	3	awesome	Last Available: "2012-03"
 5637	tolerable spinning Doublepunchplanter	3	good	Last Available: "2012-03"
-5638	tolerable high-proof Haymaker	7	good	Last Available: "2012-03"
+5638	high-proof tolerable Haymaker	7	good	Last Available: "2012-03"
 5639	narrow Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	tumbling crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	low-calorie moldy fungus	1	crappy	
-5642	ghostly blinking poisoned dart	0		
+5642	blinking ghostly poisoned dart	0		
 5643	tarnished improved moist stone wool	0		Effect: "Gleaming White Teeth", Effect Duration: 40
 5644	stones	0		
 5645	wobbly the Nostril of the Serpent	0		
@@ -5555,7 +5555,7 @@
 5652	Monster Manuel	0		Free Pull
 5653	olive key-o-tron	0		
 5654	half-sized moldy nailswurst	2	crappy	
-5655	acceptable watered-down wobbly used beer	2	good	
+5655	watered-down acceptable wobbly used beer	2	good	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5581,7 +5581,7 @@
 5678	soggy used band-aid	0		Last Available: "2012-05"
 5679	narrow supercharged stylish swimsuit of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	wobbly lost key	0		Last Available: "2012-05"
-5681	bland snack-sized spinning P.B.L.T.	2	decent	
+5681	snack-sized bland spinning P.B.L.T.	2	decent	
 5682	blue note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	handful of juicy garbage	0		
@@ -5596,7 +5596,7 @@
 5693	narrow blinking energetic phase-tuned shield generator belt	0		Maximum MP Percent: +20, Single Equip
 5694	Thwaitgold woollybear statuette	0		
 5695	bouncing bugbear detector of bravery	0		Spooky Resistance: +5, Single Equip
-5696	squat ghostly bugbear purification pill	0		
+5696	ghostly squat bugbear purification pill	0		
 5697	1 Meat	0		
 5698	blurry The Lost Glasses of chilblains of temperance	0		Cold Damage: +25, Sleaze Resistance: +5, Single Equip
 5699	mirror The Lost Pill Bottle	0		Last Available: "2012-05"
@@ -5615,10 +5615,10 @@
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	blurry Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	decent diet gray mirror FDKOL hotcakes	1	good	Last Available: "2012-07"
+5717	diet decent gray mirror FDKOL hotcakes	1	good	Last Available: "2012-07"
 5718	ghostly hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	gigantic flavorless fiery wing	8	decent	Last Available: "2012-07"
+5720	flavorless gigantic fiery wing	8	decent	Last Available: "2012-07"
 5721	wings of fire of the sewer of terror	0		Stench Damage: +25, Spooky Spell Damage: +10, Last Available: "2012-07"
 5722	blinking ribald FDKOL fire hose	0		Sleaze Damage: +10, Last Available: "2012-07"
 5723	deionized quadruple-galvanized bottle of fire	0		Effect: "Eyes All Black", Effect Duration: 56, Last Available: "2012-07"
@@ -5632,7 +5632,7 @@
 5731	aged 5-hour acrimony	4	awesome	
 5732	jittery blank note	0		
 5733	eerily silent box	0		
-5734	huge bland forbidden sausage	7	decent	
+5734	bland huge forbidden sausage	7	decent	
 5735	Lord Flameface's cloak of extreme caution	0		Monster Level: -25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	wet wet Drizzlers&trade; Black Licorice	0		Effect: "Ass Over Teakettle", Effect Duration: 38
 5737	irradiated tumbling daub-breaker	0		Effect: "Simulation Stimulation", Effect Duration: 57, Last Available: "2020-09"
@@ -5641,8 +5641,8 @@
 5740	toothsome bag of GORP	4	awesome	Last Available: "2012-07"
 5741	weak lousy water purification pills	2	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	enchanted practically non-alcoholic bad CSA scoutmaster's &quot;water&quot;	1	decent	Effect: "Dancing Prowess", Effect Duration: 45, Last Available: "2012-07"
-5744	half-sized normal olive bag of GORF	2	good	Last Available: "2012-07"
+5743	bad enchanted practically non-alcoholic CSA scoutmaster's &quot;water&quot;	1	decent	Effect: "Dancing Prowess", Effect Duration: 45, Last Available: "2012-07"
+5744	normal half-sized olive bag of GORF	2	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	spoiled bag of QWOP	3	crappy	Last Available: "2012-07"
 5747	tarnished spinning CSA bravery badge	0		Effect: "Lemony Goodness", Effect Duration: 31, Last Available: "2012-07"
@@ -5650,11 +5650,11 @@
 5749	aged jittery CSA cheerfulness ration	4	awesome	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	tasty massive crappy brain	6	awesome	
+5752	massive tasty crappy brain	6	awesome	
 5753	decent jumbo decent brain	5	good	
 5754	adequate jittery good brain	4	good	
-5755	tiny bland boss brain	1	decent	
-5756	yummy tumbling green shaking hunter brain	4	awesome	
+5755	bland tiny boss brain	1	decent	
+5756	yummy green tumbling shaking hunter brain	4	awesome	
 5758	tumbling greedy vibrating beefcake's Staff of Holiday Sensations	0		Muscle: +25, Maximum MP Percent: +10, Meat Drop: +20, Last Available: "2011-11"
 5759	Jack Frost's Socratic staff	0		Experience (Mysticality): +1, Cold Spell Damage: +50
 5760	spinning scandalous friendly brawny staff	0		Muscle Percent: +20, Familiar Weight: +3, Sleaze Damage: +5
@@ -5698,7 +5698,7 @@
 5799	moist electrified red eldritch dough	0		Effect: "Sausage Festive", Effect Duration: 66
 5800	activated quantum diffused Charity's choker	0		Effect: "Seriously Mutated", Effect Duration: 41
 5801	denatured ionized dry Smart Bone Dust	0		Effect: "Very Clean Teeth", Effect Duration: 66
-5802	pickled wobbly shaking huge perpendicular guano	0		Effect: "Feet of Grapefruit", Effect Duration: 61
+5802	pickled shaking wobbly huge perpendicular guano	0		Effect: "Feet of Grapefruit", Effect Duration: 61
 5803	quadruple-deionized electrified White Chocolate Golem Seeds	0		Effect: "Compensatory Cruelness", Effect Duration: 40
 5804	cold-filtered Shivering Ch&egrave;vre	0		Effect: "Quadrilled", Effect Duration: 43
 5805	non-ionized breath mint	0		Effect: "Glittering Eyelashes", Effect Duration: 13
@@ -5729,7 +5729,7 @@
 5830	extra-corrupted ghostly pygmy papers	0		Effect: "Greasy Flavor", Effect Duration: 54
 5831	moist cold-filtered pygmy dart	0		Effect: "Buggy Flavor", Effect Duration: 44
 5832	boiled secret mummy herbs and spices	0		Effect: "Frozen Shoulders", Effect Duration: 56
-5833	nitrogenated lime green upside-down brigand brittle	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
+5833	nitrogenated upside-down lime green brigand brittle	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
 5834	corrupted spinning holistic headache remedy	0		Effect: "Loco Motives", Effect Duration: 42
 5835	quadruple-modified green scrunchie tourniquet	0		Effect: "Hiding in Plain Sight", Effect Duration: 51
 5836	altered boiled embezzler's oil	0		Effect: "Superioreo", Effect Duration: 13
@@ -5739,7 +5739,7 @@
 5840	unsweetened deionized Rogue Windmill Rouge	0		Effect: "Hustlin'", Effect Duration: 65
 5841	double-nitrogenated vacuum-sealed A muse-bouche	0		Effect: "Feline Ferocity", Effect Duration: 27
 5842	enhanced toothbrush	0		Effect: "Employee of the Month", Effect Duration: 11
-5843	enhanced moist pulsating teal pirate cream pie	0		Effect: "Mathematically Precise", Effect Duration: 54
+5843	enhanced moist teal pulsating pirate cream pie	0		Effect: "Mathematically Precise", Effect Duration: 54
 5844	boiled modified una poca de gracia	0		Effect: "Orchid Blood", Effect Duration: 54
 5845	unsweetened nitrogenated double-irradiated cyan compressed air canister	0		Effect: "Savage Beast Inside", Effect Duration: 12
 5846	super-galvanized maroon salt water taffy	0		Effect: "White-boy Angst", Effect Duration: 44
@@ -5864,7 +5864,7 @@
 5966	narrow soul monocle	0		Single Equip
 5967	soul doorbell	0		
 5968	teal soul coin	0		
-5969	bouncing purple soul knife	0		
+5969	purple bouncing soul knife	0		
 5970	squat gravedigger's soul mask	0		Spooky Damage: +10, Single Equip
 5971	record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
 5972	record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5885,7 +5885,7 @@
 5987	ghostly wobbly dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	bad weak bottle of wine	2	decent	Last Available: "2013-02"
+5990	weak bad bottle of wine	2	decent	Last Available: "2013-02"
 5991	blinking round bomb	0		Last Available: "2013-02"
 5992	flame-retardant smelly ruddy iron helmet	0		Maximum HP Percent: +40, Stench Spell Damage: +10, Hot Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	dance instructor's wizardly steel sword of the dark arts	0		Mysticality: +25, Experience Percent (Moxie): +10, Spell Damage Percent: +100, Last Available: "2013-02"
@@ -5893,7 +5893,7 @@
 5995	teal massive gemstone	0		Last Available: "2013-02"
 5996	huge extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	acceptable watered-down maroon shining goblet	2	good	Last Available: "2013-02"
+5998	watered-down acceptable maroon shining goblet	2	good	Last Available: "2013-02"
 5999	blue fireball	0		Last Available: "2013-02"
 6000	double-paned scorching chaotic crown	0		Spell Critical Percent: +10, Hot Damage: +25, Cold Resistance: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	ghostly friendly hale sword of mayonnaise	0		Maximum HP: +20, Familiar Weight: +3, Sleaze Spell Damage: +50, Last Available: "2013-02"
@@ -5941,7 +5941,7 @@
 6043	twirling boid	0		
 6044	woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	bouncing twirling BittyCar SoulCar	0		Last Available: "2012-12"
+6046	twirling bouncing BittyCar SoulCar	0		Last Available: "2012-12"
 6047	banded groovy Misty Cloak	0		Moxie Percent: +10, Damage Absorption: +100
 6048	energetic veiny Misty Robe	0		Maximum HP: +10, Maximum MP Percent: +20
 6049	Socratic brawny Misty Cape of the sewer	0		Muscle Percent: +20, Experience (Mysticality): +1, Stench Damage: +25
@@ -5961,7 +5961,7 @@
 6063	upside-down double-paned Super Crimboman Ultra Mega Hypersword	0		Cold Resistance: +5, Last Available: "2012-12"
 6064	sharp tin strip	0		
 6065	wad of spider silk	0		
-6066	wobbly red goblin collarbone	0		
+6066	red wobbly goblin collarbone	0		
 6067	occult experienced Truthsayer	0		Experience: +2, Spell Damage Percent: +25, Last Available: "2013-12"
 6068	loose blade	0		
 6069	goblin bone hilt	0		
@@ -5971,7 +5971,7 @@
 6073	frozen adjusted haggis-infused soap	0		Effect: "Night Vision", Effect Duration: 39, Last Available: "2012-12"
 6074	tarnished energized blinking magicberry tablets	0		Effect: "Eagle Eyes", Effect Duration: 11, Last Available: "2012-12"
 6075	boiled denatured shaking 37x37x37 puzzle cube	0		Effect: "Dances with Tweedles", Effect Duration: 11, Last Available: "2012-12"
-6076	hand-crafted strong McLeod's Hard Haggis-Ade	5	EPIC	Last Available: "2012-12"
+6076	strong hand-crafted McLeod's Hard Haggis-Ade	5	EPIC	Last Available: "2012-12"
 6077	tasty haggis-wrapped haggis-stuffed haggis	3	awesome	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	drinkable fancy watered-down Chinese beer	2	good	Effect: "Milk Studly", Effect Duration: 5, Last Available: "2013-12"
+6121	fancy watered-down drinkable Chinese beer	2	good	Effect: "Milk Studly", Effect Duration: 5, Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	blue rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6025,7 +6025,7 @@
 6127	cyan pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	furry brown pillow	0		Last Available: "2013-12"
 6129	narrow manspreader's makeshift yakuza mask	0		Monster Level: +10, Last Available: "2013-12"
-6130	twirling gray piece	0		Last Available: "2013-12"
+6130	gray twirling piece	0		Last Available: "2013-12"
 6131	cyan toy taijijian	0		Last Available: "2013-12"
 6132	jittery wobbly battery	0		Last Available: "2013-12"
 6133	Temple Grandin's occult slick White Dragon Fang	0		Moxie: +10, Spell Damage Percent: +25, Familiar Weight: +7, Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	squat rubber gloves of terror	0		Spooky Spell Damage: +10, Last Available: "2013-12"
 6140	ghostly Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	tiny decent roasted duck	1	good	Last Available: "2013-12"
+6142	decent tiny roasted duck	1	good	Last Available: "2013-12"
 6143	miniature rotten dead meat bun	2	crappy	Last Available: "2013-12"
 6144	lime green cat collar of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2013-12"
 6145	nippy studded suspicious-looking fedora	0		Damage Absorption: +80, Cold Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
@@ -6077,29 +6077,29 @@
 6180	cosmic potted meat product	0		
 6181	cosmic potato	0		
 6182	tumbling cosmic cream	0		
-6183	bouncing tumbling cosmic fruit	0		
+6183	tumbling bouncing cosmic fruit	0		
 6184	electrified Jarlsberg's hat of Calamity Jane of the scaredy-cat	0		Critical Hit Percent: +15, Monster Level: -15, MP Regen Min: 3, MP Regen Max: 5
-6185	small adequate consummate hard-boiled egg	2	good	
+6185	adequate small consummate hard-boiled egg	2	good	
 6186	bland consummate fried egg	4	decent	
 6187	toothsome consummate egg salad	3	awesome	
-6188	moldy thick bouncing consummate bagel	5	crappy	
-6189	moldy twirling wobbly olive consummate sliced bread	3	crappy	
+6188	thick moldy bouncing consummate bagel	5	crappy	
+6189	moldy twirling olive wobbly consummate sliced bread	3	crappy	
 6190	flavorless miniature consummate hot dog bun	2	decent	
 6191	delicious blurry consummate brownie	4	awesome	
 6192	rotten consummate toast	3	crappy	
-6193	irresponsibly strong drinkable passable stout	9	good	
+6193	drinkable irresponsibly strong passable stout	9	good	
 6194	rotten snack-sized consummate soup	2	crappy	
 6195	normal consummate corn chips	3	good	
-6196	moldy small consummate salad	2	crappy	
+6196	small moldy consummate salad	2	crappy	
 6197	rotten consummate salsa	3	crappy	
 6198	moldy consummate sauerkraut	4	crappy	
 6199	stale shaking consummate cheese slice	3	decent	
 6200	decent miniature consummate melted cheese	2	good	
-6201	thick stale consummate bacon	5	decent	
-6202	bite-sized yummy consummate meatloaf	1	awesome	
-6203	delicious miniature enchanted consummate steak	2	awesome	Effect: "Petit Forbearance", Effect Duration: 35
+6201	stale thick consummate bacon	5	decent	
+6202	yummy bite-sized consummate meatloaf	1	awesome	
+6203	miniature enchanted delicious consummate steak	2	awesome	Effect: "Petit Forbearance", Effect Duration: 35
 6204	moldy consummate cuts	3	crappy	
-6205	special small spoiled consummate frankfurter	2	crappy	Effect: "Heightened Senses", Effect Duration: 5
+6205	spoiled special small consummate frankfurter	2	crappy	Effect: "Heightened Senses", Effect Duration: 5
 6206	delicious consummate french fries	4	awesome	
 6207	jumbo rotten consummate baked potato	5	crappy	
 6208	high-proof perfectly mixed ghostly acceptable vodka	9	EPIC	
@@ -6116,16 +6116,16 @@
 6219	jumbo decent twirling immaculate egg salad sandwich	5	good	
 6220	spoiled small perfect sandwich	2	crappy	
 6221	immense spoiled perfect chef salad	8	crappy	
-6222	spoiled small perfect breakfast	2	crappy	
-6223	normal super-sized huge sublime deluxe hot dog	5	good	
+6222	small spoiled perfect breakfast	2	crappy	
+6223	super-sized normal huge sublime deluxe hot dog	5	good	
 6224	flavorless twirling sublime stew	3	decent	
-6225	special thick delicious sublime nachos	5	awesome	Effect: "Sludgesick", Effect Duration: 10
-6226	bland jumbo special blinking Ultimate Breakfast Sandwich	5	decent	Effect: "Thick, Sick", Effect Duration: 35
+6225	special delicious thick sublime nachos	5	awesome	Effect: "Sludgesick", Effect Duration: 10
+6226	special bland jumbo blinking Ultimate Breakfast Sandwich	5	decent	Effect: "Thick, Sick", Effect Duration: 35
 6227	rotten miniature bouncing skewed Loaded Baked Potato	2	crappy	
 6228	rotten Omega Sundae	3	crappy	
 6229	special tolerable tumbling Das Sauerlager	3	good	Effect: "Smoking like a Bandit", Effect Duration: 45
 6230	high-proof mediocre squat Bologna Lambic	9	decent	
-6231	strong perfectly mixed Vodka Dog	5	EPIC	
+6231	perfectly mixed strong Vodka Dog	5	EPIC	
 6232	weak drinkable lime green Disappointed Russian	2	good	
 6233	lousy Chunky Mary	3	decent	
 6234	delicious Nachojito	4	awesome	
@@ -6174,7 +6174,7 @@
 6278	blurry Ye Olde Medieval Insult	0		
 6279	pewter claymore of the businessman	0		Meat Drop: +50
 6280	executive artisanal rice peeler	0		Meat Drop: +40
-6281	adequate special blue heirloom grape tomato	3	good	Effect: "Space Tripping", Effect Duration: 25
+6281	special adequate blue heirloom grape tomato	3	good	Effect: "Space Tripping", Effect Duration: 25
 6282	chipotle wasabi cilantro aioli	0		
 6283	flame-retardant brown felt tophat	0		Hot Resistance: +1, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6193,7 +6193,7 @@
 6297	fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	Thwaitgold firefly statuette	0		
 6299	huge model airship	0		
-6300	diffused concentrated narrow tumbling Super Weight-Gain 9000	0		Effect: "Optimist Primal", Effect Duration: 27
+6300	diffused concentrated tumbling narrow Super Weight-Gain 9000	0		Effect: "Optimist Primal", Effect Duration: 27
 6301	frozen boiled jittery possibility potion	0		Effect: "Stickler for Promptness", Effect Duration: 48
 6302	yellow skewed eleven-foot pole	0		
 6303	ring of Detect Boring Doors	0		
@@ -6212,7 +6212,7 @@
 6316	maroon wizardly deep six-shooter of terror	0		Mysticality: +25, Spooky Spell Damage: +10
 6317	upside-down occult experienced sea chaps	0		Experience: +2, Spell Damage Percent: +25, Familiar Effect: "atk, 2xBarrr"
 6318	sharpshooter's sea holster of the cougar of Flo-Jo	0		Moxie: +20, Critical Hit Percent: +10, Initiative: +100, Single Equip
-6319	boiled dry blurry mirror shavin' razor	0		Effect: "Bananas!", Effect Duration: 64
+6319	boiled dry mirror blurry shavin' razor	0		Effect: "Bananas!", Effect Duration: 64
 6320	long-forgotten necklace of mayonnaise	0		Sleaze Spell Damage: +50
 6321	pearl	0		
 6322	spinning sea lace	0		
@@ -6254,10 +6254,10 @@
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	mirror aromatic Mer-kin begsign	0		Stench Resistance: +1, Meat Drop: +40
 6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
-6361	ionized adjusted blue twirling jittery pulled taffy	0		Effect: "Kissed By Fire", Effect Duration: 61, Last Available: "2013-04"
+6361	ionized adjusted jittery twirling blue pulled taffy	0		Effect: "Kissed By Fire", Effect Duration: 61, Last Available: "2013-04"
 6362	Vulcanized pulled indigo taffy	0		Effect: "Boletus Swoletus", Effect Duration: 31, Last Available: "2013-04"
 6363	activated polarized pulled taffy	0		Effect: "Puddingskin", Effect Duration: 42, Last Available: "2013-04"
-6364	super-pickled tumbling blinking pulled taffy	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 37, Last Available: "2013-04"
+6364	super-pickled blinking tumbling pulled taffy	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 37, Last Available: "2013-04"
 6365	tarnished Vulcanized red pulled taffy	0		Effect: "Mystically Oiled", Effect Duration: 18, Last Available: "2013-04"
 6366	denatured twirling pulled violet taffy	0		Effect: "Spooky Blur", Effect Duration: 34, Last Available: "2013-04"
 6367	colloidal ghostly pulled taffy	0		Effect: "Corruption of Wretched Wally", Effect Duration: 25, Last Available: "2013-04"
@@ -6265,7 +6265,7 @@
 6369	wobbly lump of clay	0		
 6370	huge twisted piece of wire	0		
 6371	tolerable skewed can of the cheapest beer	4	good	
-6372	lousy watered-down bottle of fruity &quot;wine&quot;	2	decent	
+6372	watered-down lousy bottle of fruity &quot;wine&quot;	2	decent	
 6373	drinkable single swig of vodka	4	good	
 6374	angry inch	0		
 6375	mirror blurry padded testy toolbox	0		Damage Absorption: +20
@@ -6279,7 +6279,7 @@
 6384	jigsaw blade	0		
 6385	fuchsia wood screw	0		
 6386	ghostly balsa plank	0		
-6387	twirling blurry blob of wood glue	0		
+6387	blurry twirling blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	ionized fuchsia Mer-kin rocksalt	0		Effect: "Phairly Balanced", Effect Duration: 29
 6390	enhanced Mer-kin saltmint	0		Effect: "Booing Radly", Effect Duration: 49
@@ -6295,7 +6295,7 @@
 6400	Mer-kin lunchbox	0		
 6401	liquefied electrified lime green tear	0		Effect: "Bilious Brains", Effect Duration: 15
 6402	dry triple-tarnished jagged tooth	0		Effect: "Rain Dancin'", Effect Duration: 58
-6403	tarnished chilled lime green wobbly spinning grisly shell fragment	0		Effect: "Far Out", Effect Duration: 64
+6403	tarnished chilled wobbly lime green spinning grisly shell fragment	0		Effect: "Far Out", Effect Duration: 64
 6404	anodized polymerized fuchsia violent pastilles	0		Effect: "Holiday Bliss", Effect Duration: 17
 6405	ionized narrow worst candy	0		Effect: "The Strength...  of the Future", Effect Duration: 15
 6406	boiled fudge-shaped hole in space-time	0		Effect: "Banono", Effect Duration: 40
@@ -6308,18 +6308,18 @@
 6413	ghostly Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	tasty flavorless gruel	3	awesome	
-6416	moldy snack-sized mana curds	2	crappy	
+6416	snack-sized moldy mana curds	2	crappy	
 6417	twist of lime	0		
 6418	maroon pencil stub	0		
 6419	dry tarnished blinking moth dust	0		Effect: "Rage of the Reindeer", Effect Duration: 55
 6420	Vulcanized tarnished double-energized glob of spoiled mayo	0		Effect: "Browbeaten", Effect Duration: 54
 6421	tonic djinn	0		
-6422	fancy diet stale vampire chowder	1	decent	Effect: "Well-Oiled", Effect Duration: 45
+6422	stale fancy diet vampire chowder	1	decent	Effect: "Well-Oiled", Effect Duration: 45
 6423	Tales of Dread	0		Free Pull
 6424	twirling Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	adequate Dreadsylvanian stew	3	good	
-6427	irresponsibly strong bad Dreadsylvanian	7	decent	
+6427	bad irresponsibly strong Dreadsylvanian	7	decent	
 6428	denatured shaking Dreadsylvanian flask	0		Effect: "Bat Attitude", Effect Duration: 12
 6429	pickled energized Dreadsylvanian flask	0		Effect: "Brocolate Brostidigitation", Effect Duration: 14
 6430	squat miser's banded dreadful fedora	0		Damage Absorption: +100, Meat Drop: +10, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6338,7 +6338,7 @@
 6443	red wool chilly Helps-You-Sleep	0		Cold Damage: +5, Cold Resistance: +1, Single Equip
 6444	Jeselnik's foul-smelling Quiets-Your-Steps of temperance	0		Stench Damage: +10, Sleaze Damage: +25, Sleaze Resistance: +5, Single Equip
 6445	upside-down flame-wreathed Protects-Your-Junk of horror	0		Hot Spell Damage: +10, Spooky Spell Damage: +25, Single Equip
-6446	lousy watered-down Gets-You-Drunk	2	decent	
+6446	watered-down lousy Gets-You-Drunk	2	decent	
 6447	wobbly asbestos-lined Annie Oakley's Great Wolf's headband of the scaredy-cat	0		Critical Hit Percent: +20, Monster Level: -15, Hot Resistance: +5, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	upside-down extremely unsafe brawny beefcake's Great Wolf's left paw	0		Muscle: +25, Muscle Percent: +20, Weapon Damage Percent: +100, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	family-friendly supercool Great Wolf's right paw of the brazier	0		Moxie Percent: +20, Hot Spell Damage: +25, Sleaze Resistance: +1, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6360,14 +6360,14 @@
 6465	skewed Usain Bolt's Mayor Ghost's gavel of the ox of the early riser	0		Muscle: +20, Initiative: +80, Adventures: +7, Conditional Skill (Equipped): "Hammer Ghost"
 6466	rosy-cheeked personal trainer's Mayor Ghost's sash of the ox	0		Muscle: +20, Experience Percent (Muscle): +10, Maximum HP Percent: +30, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	decent snack-sized ghost pepper	2	good	
+6468	snack-sized decent ghost pepper	2	good	
 6469	ghostly manspreader's therapeutic Thunkula's drinking cap of wisdom	0		Mysticality: +15, Monster Level: +10, HP Regen Min: 5, HP Regen Max: 7, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	lightning-fast scandalous Rosewater's Drunkula's cape	0		Mysticality Percent: +30, Sleaze Damage: +5, Initiative: +40, Class: "Sauceror"
 6471	jittery Jim Carey's Drunkula's silky pants of wisdom of the businessman	0		Mysticality: +15, Monster Level: +25, Meat Drop: +50, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 6472	upside-down Drunkula's bell	0		
 6473	fireproof greasy ribald Drunkula's ring of haze	0		Sleaze Damage: +10, Sleaze Spell Damage: +10, Hot Resistance: +3, Avoid Attack: 1, Single Equip
 6474	Lo Pan's Drunkula's wineglass	0		Spell Critical Percent: +30
-6475	drinkable enchanted high-proof bouncing jittery bottle of Bloodweiser	9	good	Effect: "Florid Cheeks", Effect Duration: 5
+6475	enchanted drinkable high-proof jittery bouncing bottle of Bloodweiser	9	good	Effect: "Florid Cheeks", Effect Duration: 5
 6476	avaricious Unkillable Skeleton's skullcap of courage of the cheetah	0		Spooky Resistance: +3, Meat Drop: +30, Initiative: +60, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	sizzling Samson's Unkillable Skeleton's breastplate of wisdom	0		Mysticality: +15, Experience (Muscle): +5, Hot Damage: +10, Class: "Turtle Tamer"
 6478	squat Usain Bolt's forbidden grievous Unkillable Skeleton's shinguards	0		Weapon Damage Percent: +50, Spell Damage Percent: +50, Initiative: +80, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	pulsating dreadful roast	0		
 6487	stinking agaricus	0		
-6488	normal enchanted Dreadsylvanian shepherd's pie	3	good	Effect: "Discomfited", Effect Duration: 40
+6488	enchanted normal Dreadsylvanian shepherd's pie	3	good	Effect: "Discomfited", Effect Duration: 40
 6489	bouncing music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6421,7 +6421,7 @@
 6526	wool coward's bag of unfinished business	0		Monster Level: -20, Cold Resistance: +1
 6527	healthy studded transparent pants	0		Damage Absorption: +80, Maximum HP Percent: +20, Familiar Effect: "sleaze atk, 1xPotato"
 6528	Jack Frost's hothammer	0		Cold Spell Damage: +50
-6529	distilled smooth yellow blinking Thriller Ice	5	awesome	
+6529	smooth distilled blinking yellow Thriller Ice	5	awesome	
 6530	skewed red energetic grandfather watch	0		Maximum MP Percent: +20, Single Equip
 6531	mirror muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	blue gravedigger's razor-sharp spyglass	0		Weapon Damage Percent: +25, Spooky Damage: +10
@@ -6429,7 +6429,7 @@
 6534	remorseless knife of the storm	0		Maximum MP Percent: +40
 6535	teal intimidating coiffure of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "hot afk, 1xPotato"
 6536	asbestos-lined rock-hard cod cape	0		Damage Reduction: 5, Hot Resistance: +5
-6537	massive moldy blood sausage	8	crappy	
+6537	moldy massive blood sausage	8	crappy	
 6538	blinking clever frying brainpan of extreme caution	0		Maximum MP: +20, Monster Level: -25
 6539	personal trainer's ball and chain of the brute	0		Muscle Percent: +30, Experience Percent (Muscle): +10, Single Equip
 6540	deadly dry bone	0		Weapon Damage: +5
@@ -6455,14 +6455,14 @@
 6561	olive adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	twirling veiny hand of Mr. Cards	0		Maximum HP: +10, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	snack-sized moldy upside-down Dreadsylvanian hot pocket	2	crappy	
+6564	moldy snack-sized upside-down Dreadsylvanian hot pocket	2	crappy	
 6565	spoiled Dreadsylvanian pocket	3	crappy	
-6566	rotten big fuchsia Dreadsylvanian pocket	5	crappy	
+6566	big rotten fuchsia Dreadsylvanian pocket	5	crappy	
 6567	moldy Dreadsylvanian stink pocket	4	crappy	
 6568	flavorless half-sized maroon Dreadsylvanian sleaze pocket	2	decent	
 6569	tolerable watered-down Dreadsylvanian hot toddy	2	good	
-6570	watered-down mediocre skewed tumbling Dreadsylvanian cold-fashioned	2	decent	
-6571	drinkable boozy Dreadsylvanian grimlet	5	good	
+6570	mediocre watered-down skewed tumbling Dreadsylvanian cold-fashioned	2	decent	
+6571	boozy drinkable Dreadsylvanian grimlet	5	good	
 6572	delicious Dreadsylvanian dank and stormy	3	awesome	
 6573	drinkable distilled blinking Dreadsylvanian slithery nipple	5	good	
 6574	hot clusterbomb	0		
@@ -6486,13 +6486,13 @@
 6592	lime green spinning scandalous steel-toed optimal spreadsheet of the blizzard	0		Damage Reduction: 9, Cold Spell Damage: +25, Sleaze Damage: +5
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
-6595	powdered narrow twirling epic cluster	1	decent	
+6595	powdered twirling narrow epic cluster	1	decent	
 6596	clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	narrow shaking clockwork disc	0		
 6599	blinking clockwork hand	0		
 6600	clockwork hand	0		
-6601	bouncing blue clockwork numeral I	0		
+6601	blue bouncing clockwork numeral I	0		
 6602	clockwork numeral II	0		
 6603	clockwork numeral III	0		
 6604	blurry clockwork numeral IV	0		
@@ -6506,7 +6506,7 @@
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	fancy mediocre weak Cold One	2	???	Effect: "Pumped Up", Effect Duration: 35
+6615	weak fancy mediocre Cold One	2	???	Effect: "Pumped Up", Effect Duration: 35
 6616	flavorless spaghetti breakfast	3	???	
 6617	tumbling over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6533,7 +6533,7 @@
 6639	folder (owl)	0		Last Available: "2013-08"
 6640	folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
-6642	spinning ghostly folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
+6642	ghostly spinning folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
 6643	ghostly folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
 6644	folder (Yedi)	0		Spell Damage Percent: +50, Last Available: "2013-08"
 6645	folder (KOLHS)	0		Last Available: "2013-08"
@@ -6561,16 +6561,16 @@
 6669	modeling claymore	0		
 6670	blurry clay homunculus	0		
 6671	tarnished colloidal super-moist blurry sodium pentasomething	0		Effect: "Hot Blooded", Effect Duration: 35
-6672	huge twirling grains of salt	0		
+6672	twirling huge grains of salt	0		
 6673	yellowcake bomb	0		
 6674	stinkbomb	0		
 6675	chilled non-modified tumbling superwater	0		Effect: "Leisurely Amblin'", Effect Duration: 15
-6676	ghostly blurry Thwaitgold bookworm statuette	0		
+6676	blurry ghostly Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	nasty Yearbook Club Camera	0		Stench Damage: +5, Conditional Skill (Equipped): "Blinding Flash"
 6679	squat machete of horror	0		Spooky Spell Damage: +25
 6680	delicious Cursed Punch	3	awesome	
-6681	watered-down perfectly mixed ghostly gray Bowl of Scorpions	2	EPIC	
+6681	perfectly mixed watered-down ghostly gray Bowl of Scorpions	2	EPIC	
 6682	artisanal Fog Murderer	3	EPIC	
 6683	upside-down book of matches	0		
 6684	tumbling surgical mask of doom	0		Spooky Spell Damage: +50, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	tumbling bowler	0		
 6703	imitation White Russian	1	EPIC	
 6704	pulsating Jack Frost's sinister short-handled mop	0		Spell Damage: +10, Cold Spell Damage: +50
-6705	snack-sized bland ghostly jungle floor wax	2	decent	
+6705	bland snack-sized ghostly jungle floor wax	2	decent	
 6706	red blinking smirking shrunken head	0		
 6707	triple-cold-filtered spinning colorful toad	0		Effect: "The Sweats", Effect Duration: 21
 6708	purple crude voodoo doll	0		
@@ -6613,7 +6613,7 @@
 6721	chilly studded Newton's water bottle	0		Experience (Mysticality): +3, Damage Absorption: +80, Cold Damage: +5, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	warmed red pygmy phone number	0		Effect: "Spirit Bubble", Effect Duration: 28
 6723	Boozehounds Anonymous token	0		
-6724	big spoiled exotic jungle fruit	5	crappy	
+6724	spoiled big exotic jungle fruit	5	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	blinking tropical island souvenir crate	0		
@@ -6630,12 +6630,12 @@
 6738	jagged scrap	0		
 6739	quadruple-boiled polarized bent scrap	0		Effect: "Carol of the Bones", Effect Duration: 52
 6740	molten scrap	0		
-6741	lime green wobbly eternal car battery	0		
+6741	wobbly lime green eternal car battery	0		
 6742	jittery junk band of dire peril	0		Weapon Damage: +20
 6743	weightlifter's junk trunks	0		Muscle: +15, Familiar Effect: "cap 15"
 6744	junk-mail shirt of James Dean	0		Experience (Moxie): +3
 6745	miniature normal junk food	2	good	
-6746	lousy weak junk yard	2	decent	
+6746	weak lousy junk yard	2	decent	
 6747	wobbly mansplainer's swordzall of dire peril	0		Weapon Damage: +20, Monster Level: +15
 6748	ghostly arm buzzer of courage	0		Spooky Resistance: +3, Damage Reduction: 6
 6749	Sherlock's cool boilgun	0		Moxie: +5, Item Drop: +25
@@ -6647,13 +6647,13 @@
 6755	bouncing skewed beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	tolerable can of Br&uuml;talbr&auml;u	3	good	Last Available: "2013-09"
-6758	acceptable triple-distilled fancy can of Drooling Monk	10	good	Effect: "Comic Violence", Effect Duration: 45, Last Available: "2013-09"
-6759	bad watered-down olive can of Impetuous Scofflaw	2	decent	Last Available: "2013-09"
-6760	watered-down acceptable bottle of Old Pugilist	2	good	Last Available: "2013-09"
+6758	triple-distilled acceptable fancy can of Drooling Monk	10	good	Effect: "Comic Violence", Effect Duration: 45, Last Available: "2013-09"
+6759	watered-down bad olive can of Impetuous Scofflaw	2	decent	Last Available: "2013-09"
+6760	acceptable watered-down bottle of Old Pugilist	2	good	Last Available: "2013-09"
 6761	acceptable weak bottle of Professor Beer	2	good	Last Available: "2013-09"
 6762	lousy practically non-alcoholic bottle of Rapier Witbier	1	decent	Last Available: "2013-09"
-6763	mediocre enchanted huge bottle of Race Car Red	4	decent	Effect: "Wise Spirit", Effect Duration: 40, Last Available: "2013-09"
-6764	acceptable spirit-forward bottle of Greedy Dog	5	good	Last Available: "2013-09"
+6763	enchanted mediocre huge bottle of Race Car Red	4	decent	Effect: "Wise Spirit", Effect Duration: 40, Last Available: "2013-09"
+6764	spirit-forward acceptable bottle of Greedy Dog	5	good	Last Available: "2013-09"
 6765	weak special artisanal bottle of Lambada Lambic	2	super ultra mega EPIC	Effect: "Vitali Tea", Effect Duration: 25, Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
@@ -6664,7 +6664,7 @@
 6772	mirror family-friendly banded wicked tin drum	0		Spell Damage: +5, Damage Absorption: +100, Sleaze Resistance: +1, Last Available: "2013-09"
 6773	tumbling wobbly tin roof (rusted)	0		Last Available: "2013-09"
 6774	bouncing tin snips	0		Last Available: "2013-09"
-6775	upside-down wobbly tin lizzie	0		Last Available: "2013-09"
+6775	wobbly upside-down tin lizzie	0		Last Available: "2013-09"
 6776	aerosolized Vulcanized polarized olive foetid seal tear	0		Effect: "Vented Spleen", Effect Duration: 37
 6777	activated maroon upside-down seal sweat	0		Effect: "Partially Ghosted", Effect Duration: 54
 6778	polymerized chilled boiling seal blood	0		Effect: "Castaway Physique", Effect Duration: 39
@@ -6684,10 +6684,10 @@
 6795	non-anodized disco horoscope (Aquarius)	0		Effect: "Unrunnable Face", Effect Duration: 67
 6796	super-corrupted Vulcanized huge disco horoscope (Pisces)	0		Effect: "Spirit Bubble", Effect Duration: 39
 6797	super-liquefied adjusted mirror disco horoscope (Aries)	0		Effect: "Ogred and Oublietted", Effect Duration: 56
-6798	double-diffused tarnished twirling red blurry disco horoscope (Taurus)	0		Effect: "Slightly Mutated", Effect Duration: 23
+6798	double-diffused tarnished blurry twirling red disco horoscope (Taurus)	0		Effect: "Slightly Mutated", Effect Duration: 23
 6799	irradiated disco horoscope (Gemini)	0		Effect: "Tiki Temerity", Effect Duration: 19
 6800	dry upside-down disco horoscope (Cancer)	0		Effect: "Angry Bone", Effect Duration: 60
-6801	cold-filtered tarnished tumbling blue disco horoscope (Leo)	0		Effect: "Baconstoned", Effect Duration: 47
+6801	cold-filtered tarnished blue tumbling disco horoscope (Leo)	0		Effect: "Baconstoned", Effect Duration: 47
 6802	denatured tumbling disco horoscope (Virgo)	0		Effect: "Memory of Attractiveness", Effect Duration: 20
 6803	improved disco horoscope (Libra)	0		Effect: "Stuck-Up Hair", Effect Duration: 20
 6804	diffused twirling disco horoscope (Scorpio)	0		Effect: "Human-Machine Hybrid", Effect Duration: 49
@@ -6714,7 +6714,7 @@
 6825	spinning foul-smelling alarm accordion	0		Stench Damage: +10, Item Drop: +5, Class: "Accordion Thief", Song Duration: 20
 6826	executive Sinatra's All-Hallow's Steve's fright wig of the dark arts	0		Experience (Moxie): +5, Spell Damage Percent: +100, Meat Drop: +40, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	Sherlock's frosty KoL Con X Treasure Map	0		Cold Spell Damage: +10, Item Drop: +25
-6828	enchanted hand-crafted triple-distilled discocktail	7	EPIC	Effect: "Hammered", Effect Duration: 30
+6828	enchanted triple-distilled hand-crafted discocktail	7	EPIC	Effect: "Hammered", Effect Duration: 30
 6829	cyan huge KoL Con X Bingo Card of the storm	0		Maximum MP Percent: +40
 6830	cyan mirror Temporal Tempera Tube of the glutton	0		Food Drop: +100
 6831	concentrated modified gray Tallowcreme Halloween Pumpkin	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 55
@@ -6728,7 +6728,7 @@
 6839	double-flattened non-energized vacuum-sealed jam	0		Effect: "Bestial Sympathy", Effect Duration: 34
 6840	quantum non-polymerized Whenchamacallit bar	0		Effect: "Yuletide Sappiness", Effect Duration: 23
 6841	super-corrupted polarized ghostly 8-bit banana	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 29
-6842	anodized skewed twirling lime green vial of blood simple syrup	0		Effect: "Trufflin'", Effect Duration: 52
+6842	anodized skewed lime green twirling vial of blood simple syrup	0		Effect: "Trufflin'", Effect Duration: 52
 6843	polarized moist bone bons	0		Effect: "Crimbo Epiphany", Effect Duration: 64
 6844	wet huge ironic mint	0		Effect: "Hobonic", Effect Duration: 12
 6845	blue ghostly unused walkie-talkie	0		Free Pull
@@ -6753,9 +6753,9 @@
 6864	tasty dinner roll	4	awesome	Last Available: "2013-11"
 6865	normal mashed potatoes	4	good	Last Available: "2013-11"
 6866	thick rotten tumbling whole turkey leg	5	crappy	Last Available: "2013-11"
-6867	big stale special deviled egg	5	decent	Effect: "Craft Tea", Effect Duration: 15, Last Available: "2013-11"
+6867	big special stale deviled egg	5	decent	Effect: "Craft Tea", Effect Duration: 15, Last Available: "2013-11"
 6868	enhanced finger exerciser	0		Effect: "Litterboxing", Effect Duration: 63, Last Available: "2013-11"
-6869	frozen improved pulsating maroon dented spoon	0		Effect: "Hangdog", Effect Duration: 40, Last Available: "2013-11"
+6869	frozen improved maroon pulsating dented spoon	0		Effect: "Hangdog", Effect Duration: 40, Last Available: "2013-11"
 6870	diffused warmed love note	0		Effect: "damage.enh", Effect Duration: 67, Last Available: "2013-11"
 6871	twirling purple school beer pull tab	0		Last Available: "2013-11"
 6872	extra-dry nail file	0		Effect: "Disdain of She-Who-Was", Effect Duration: 34, Last Available: "2013-11"
@@ -6776,7 +6776,7 @@
 6887	spirit sheet	0		
 6888	skewed spirit mattress	0		
 6889	spirit blanket	0		
-6890	blinking skewed spirit bed	0		
+6890	skewed blinking spirit bed	0		
 6891	teal zippy sizzling Da Vinci's spirit bell	0		Experience (Mysticality): +5, Hot Damage: +10, Initiative: +20, Class: "Turtle Tamer"
 6892	extra-energized non-liquefied spoonful of Linguine-Os	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 53, Last Available: "2013-11"
 6893	boiled irradiated double-warmed ghostly freezer-burned frost-bitten tortellini	0		Effect: "Sparkly!", Effect Duration: 44, Last Available: "2013-11"
@@ -6810,7 +6810,7 @@
 6921	low-calorie rotten yellow warbear feasting bread	1	crappy	Last Available: "2013-12"
 6922	normal cyan warbear warrior bread	4	good	Last Available: "2013-12"
 6923	adequate miniature maroon warbear thermoregulator bread	2	good	Last Available: "2013-12"
-6924	practically non-alcoholic hand-crafted warbear feasting mead	1	super ultra mega turbo EPIC	Last Available: "2013-12"
+6924	hand-crafted practically non-alcoholic warbear feasting mead	1	super ultra mega turbo EPIC	Last Available: "2013-12"
 6925	hand-crafted warbear bearserker mead	4	EPIC	Last Available: "2013-12"
 6926	artisanal triple-distilled blue warbear blizzard mead	10	EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
@@ -6850,7 +6850,7 @@
 6961	purple pulsating warbear oil pan of chilblains of the cheetah	0		Cold Damage: +25, Initiative: +60, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	pulsating warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	avaricious warbear exhaust manifold	0		Meat Drop: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
-6964	huge upside-down warbear jackhammer drill press	0		Last Available: "2013-12"
+6964	upside-down huge warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	twirling warbear auto-anvil	0		Last Available: "2013-12"
 6966	purple warbear induction oven	0		Last Available: "2013-12"
 6967	twirling warbear chemistry lab	0		Last Available: "2013-12"
@@ -6893,12 +6893,12 @@
 7004	cold-filtered energized Flaskfull of Hollow	0		Effect: "Educated (Sorta)", Effect Duration: 20, Last Available: "2013-12"
 7005	teal lump of Brituminous coal	0		Last Available: "2013-12"
 7006	boiled blinking handful of Smithereens	1	good	Effect: "Ninja, Please", Effect Duration: 30, Last Available: "2013-12"
-7007	decent diet Every Day is Like This Sundae	1	good	Last Available: "2013-12"
+7007	diet decent Every Day is Like This Sundae	1	good	Last Available: "2013-12"
 7008	stale massive bouncing narrow Miserable Pie	7	decent	Last Available: "2013-12"
 7009	gigantic adequate This Charming Flan	8	good	Last Available: "2013-12"
 7010	perfectly mixed Irish Coffee, English Heart	4	EPIC	Last Available: "2013-12"
 7011	practically non-alcoholic tolerable Strikes Again Bigmouth	1	good	Last Available: "2013-12"
-7012	acceptable fancy tumbling Paint A Vulgar Pitcher	3	good	Effect: "Pemmican't", Effect Duration: 25, Last Available: "2013-12"
+7012	fancy acceptable tumbling Paint A Vulgar Pitcher	3	good	Effect: "Pemmican't", Effect Duration: 25, Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	blurry Handsome Devil	0		Last Available: "2013-12"
@@ -6919,7 +6919,7 @@
 7030	sharpshooter's third-hand lantern	0		Critical Hit Percent: +10
 7031	loose purse strings	0		
 7032	normal pickled egg	3	good	
-7033	yellow mirror cup of lukewarm tea	1	good	
+7033	mirror yellow cup of lukewarm tea	1	good	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	bouncing bouncing warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	cyan warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	extra-modified ionized blurry glass slipper	0		Effect: "Memory of Smarts", Effect Duration: 53, Last Available: "2014-12"
-7045	vaporized maroon bouncing upside-down wobbly antimatter wad	1	awesome	Last Available: "2013-12"
+7045	vaporized bouncing upside-down wobbly maroon antimatter wad	1	awesome	Last Available: "2013-12"
 7046	concentrated polymerized warbear superpotion	0		Effect: "Dragged Through the Coals", Effect Duration: 66, Last Available: "2013-12"
 7047	irradiated alkaline warbear liquid lasers	0		Effect: "Going Ape", Effect Duration: 52, Last Available: "2013-12"
 7048	flattened huge warbear rejuvenation potion	0		Effect: "Tiki Thoughtfulness", Effect Duration: 60, Last Available: "2013-12"
@@ -6957,8 +6957,8 @@
 7068	wet extra-denatured blinking single of Donho's Bubbly Ballad	0		Effect: "Wet Willied", Effect Duration: 36
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	immense fancy adequate olive snow berries	7	good	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2014-01"
-7072	fancy adequate spinning ice harvest	3	good	Effect: "Riboflavin'", Effect Duration: 15, Last Available: "2014-01"
+7071	fancy immense adequate olive snow berries	7	good	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2014-01"
+7072	adequate fancy spinning ice harvest	3	good	Effect: "Riboflavin'", Effect Duration: 15, Last Available: "2014-01"
 7073	polymerized frost flower	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 69, Last Available: "2014-01"
 7074	anodized extra-anodized snow cleats	0		Effect: "Chalky White Pallor", Effect Duration: 13, Last Available: "2014-01"
 7075	dry liquid ice pack	0		Effect: "Bells in the Batfry", Effect Duration: 45, Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	shaking wool Jeselnik's mansplainer's fortified snow belt	0		Damage Absorption: +60, Monster Level: +15, Sleaze Damage: +25, Cold Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	electrified Rosewater's cool brainy ice nine	0		Mysticality: +5, Moxie: +5, Mysticality Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	watered-down lousy En Una Fila Tequila	2	decent	
+7090	lousy watered-down En Una Fila Tequila	2	decent	
 7091	skewed Skully's hot chocolate	1	decent	
 7092	Annie Oakley's Oprah's warbear dress helmet	0		Maximum MP Percent: +50, Critical Hit Percent: +20, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	wholesome warbear dress bracers of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Single Equip, Last Available: "2013-12"
@@ -6985,7 +6985,7 @@
 7096	veiny gym shorts of bravery	0		Maximum HP: +10, Spooky Resistance: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	gravedigger's ankleweights of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +10, Single Equip, Last Available: "2014-12"
 7098	executive occult razor-sharp sweat socks of vim and vigor	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Maximum HP Percent: +50, Meat Drop: +40, Last Available: "2014-12"
-7099	huge olive pint of sweat	0		Last Available: "2014-12"
+7099	olive huge pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	boiled Five Second Energy&trade;	1		Effect: "Sticks and Stones", Effect Duration: 20, Last Available: "2014-12"
 7102	lime green spinning pixie axie	0		Last Available: "2014-12"
@@ -6994,14 +6994,14 @@
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	strong perfectly mixed spinning snakebite	5	EPIC	Last Available: "2014-12"
 7107	mirror lard-coated Sinatra's candy stick	0		Experience (Moxie): +5, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7108	bland half-sized pecan	2	decent	Last Available: "2014-12"
-7109	enchanted moldy pecan pie	4	crappy	Effect: "Holiday Bliss", Effect Duration: 50, Last Available: "2014-12"
+7108	half-sized bland pecan	2	decent	Last Available: "2014-12"
+7109	moldy enchanted pecan pie	4	crappy	Effect: "Holiday Bliss", Effect Duration: 50, Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	miniature spoiled maroon candy mountain oyster	2	crappy	Last Available: "2014-12"
+7111	spoiled miniature maroon candy mountain oyster	2	crappy	Last Available: "2014-12"
 7112	perfectly mixed chocotini	4	EPIC	Last Available: "2014-12"
 7113	Rosewater's chocolate rabbit's foot of the detective of the early riser	0		Mysticality Percent: +30, Item Drop: +20, Adventures: +7, Last Available: "2014-12"
 7114	rotten candy carrot	3	crappy	Last Available: "2014-12"
-7115	immense yummy candy carrot cake	7	awesome	Last Available: "2014-12"
+7115	yummy immense candy carrot cake	7	awesome	Last Available: "2014-12"
 7116	asbestos-lined frosty carrot-on-a-stick	0		Cold Spell Damage: +10, Hot Resistance: +5, Last Available: "2014-12"
 7117	olive experienced weasel stomping pants of the sewer	0		Experience: +2, Stench Damage: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	half-sized moldy mulberry	2	crappy	Last Available: "2014-12"
@@ -7031,7 +7031,7 @@
 7142	nitrogenated squat teal hare brush	0		Effect: "Transcendental Wind", Effect Duration: 37, Last Available: "2014-12"
 7143	forbidden hare pin of the bloodbag	0		Spell Damage Percent: +50, Maximum HP: +100, Single Equip, Last Available: "2014-12"
 7144	wobbly odd coin	0		Last Available: "2014-12"
-7145	spoiled small cinnamon cannoli	2	crappy	Last Available: "2014-12"
+7145	small spoiled cinnamon cannoli	2	crappy	Last Available: "2014-12"
 7146	smooth wobbly expensive champagne	4	awesome	Last Available: "2014-12"
 7147	alkaline huge polo trophy	0		Effect: "Ready to Snap", Effect Duration: 27, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7048,14 +7048,14 @@
 7159	nasty stiffened plain paper hat of the storm	0		Damage Reduction: 1, Maximum MP Percent: +40, Stench Damage: +5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	adequate fancy ice cream sandwich	4	good	Effect: "Sated and Furious", Effect Duration: 45, Last Available: "2014-12"
 7161	dance instructor's &quot;honey&quot; dipper of Tarzan of the brazier	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Hot Spell Damage: +25, Last Available: "2014-12"
-7162	tiny bland plumber's lunch	1	decent	Last Available: "2014-12"
+7162	bland tiny plumber's lunch	1	decent	Last Available: "2014-12"
 7163	blurry narrow hardened Rosewater's cool skull gearshift knob	0		Moxie: +5, Mysticality Percent: +30, Damage Reduction: 3, Last Available: "2014-12"
-7164	rotten tiny nachos of the night	1	crappy	Last Available: "2014-12"
+7164	tiny rotten nachos of the night	1	crappy	Last Available: "2014-12"
 7165	clever hardy arcane researcher's Sketcherz&trade;	0		Experience Percent (Mysticality): +10, Maximum HP: +50, Maximum MP: +20, Last Available: "2014-12"
 7166	bland narrow can of Adultwitch&trade;	4	decent	Last Available: "2014-12"
 7167	modified aerosolized smudge stick	0		Effect: "Fury of the Bells", Effect Duration: 28, Last Available: "2014-12"
 7168	adjusted deionized adjusted wall	0		Effect: "Flambé-a-thon", Effect Duration: 52, Last Available: "2014-12"
-7169	special hand-crafted spinning tankard of ale	4	EPIC	Effect: "Heal Thy Nanoself", Effect Duration: 5, Last Available: "2014-12"
+7169	hand-crafted special spinning tankard of ale	4	EPIC	Effect: "Heal Thy Nanoself", Effect Duration: 5, Last Available: "2014-12"
 7170	galvanized warmed irradiated scroll case	0		Effect: "Motion", Effect Duration: 63, Last Available: "2014-12"
 7171	polymerized jug of &quot;wine&quot;	0		Effect: "Purity of Spirit", Effect Duration: 12, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7092,7 +7092,7 @@
 7203	mirror Annie Oakley's Saturday Night Special	0		Critical Hit Percent: +20
 7204	lynyrd snare	0		
 7205	fleetwood chain of incineration	0		Hot Spell Damage: +50
-7206	fancy perfectly mixed Green Manalishi	3	EPIC	Effect: "Barking Mad", Effect Duration: 35
+7206	perfectly mixed fancy Green Manalishi	3	EPIC	Effect: "Barking Mad", Effect Duration: 35
 7207	squat yellow bouncing blade of courage	0		Spooky Resistance: +3
 7208	blinking mirror mirror fire of unknown origin	0		
 7209	ghostly blinking eagle's milk	1	decent	
@@ -7186,12 +7186,12 @@
 7297	shaking hardy Professor What T-Shirt	0		Maximum HP: +50
 7298	heavy-duty bendy straw	0		
 7299	blinking pellet of plant food	0		
-7300	fuchsia upside-down sewing kit	0		
+7300	upside-down fuchsia sewing kit	0		
 7301	pulsating Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	Lady Spookyraven's necklace	0		
 7304	jittery telegram from Lady Spookyraven	0		
-7305	ghostly skewed Lady Spookyraven's powder puff	0		
+7305	skewed ghostly Lady Spookyraven's powder puff	0		
 7306	huge Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
 7308	activated eyebrow pencil	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 11
@@ -7213,13 +7213,13 @@
 7324	modified huge battery	1		
 7325	drinkable boozy fuchsia snakebite	5	good	
 7326	curative rubber ribcage of the cheetah	0		Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 7
-7327	mixed blurry mirror synthetic marrow	1		
+7327	mixed mirror blurry synthetic marrow	1		
 7328	triple-vacuum-sealed frozen funny bone	0		Effect: "Izchak's Blessing", Effect Duration: 19
 7329	narrow narrow nippy forbidden half-melted spoon	0		Spell Damage Percent: +50, Cold Damage: +10
 7330	altered the funk	1		
 7331	half-sized flavorless squat shaking gunky chicken	2	decent	
 7332	stylish doll head	0		Moxie: +25
-7333	fuchsia twirling droopy doll eye	0		
+7333	twirling fuchsia droopy doll eye	0		
 7334	blinking voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	coward's rock-hard paddle-ball	0		Damage Reduction: 5, Monster Level: -20
 7336	corrupted dry squat sound effects record	0		Effect: "Nature's Bounty", Effect Duration: 55
@@ -7229,21 +7229,21 @@
 7340	moose antlers of the businessman	0		Meat Drop: +50, Familiar Effect: "atk, 1xLep, cap 27"
 7341	colloidal concentrated huge moose thought	0		Effect: "Okee-Dokee Go!", Effect Duration: 12
 7342	rotten miniature moose chocolate	2	crappy	
-7343	watered-down smooth squat painting of a glass of wine	2	awesome	
+7343	smooth watered-down squat painting of a glass of wine	2	awesome	
 7344	purple oil painting of yourself	0		
 7345	huge ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	shellacked ghost toga of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40
-7348	half-sized fancy moldy sheet cake	2	crappy	Effect: "Ancient Protected", Effect Duration: 10
+7348	fancy half-sized moldy sheet cake	2	crappy	Effect: "Ancient Protected", Effect Duration: 10
 7349	ghost key	0		
 7350	picture of you	0		
 7351	Rosewater's Staff of the Electric Range of the cougar of horror	0		Moxie: +20, Mysticality Percent: +30, Spooky Spell Damage: +25
-7352	delicious miniature tumbling deluxe layer cake	2	awesome	
+7352	miniature delicious tumbling deluxe layer cake	2	awesome	
 7353	cyan chunk of hot iron	0		
-7354	acceptable special red-hot boilermaker	3	good	Effect: "Nigh-Invincible", Effect Duration: 15
+7354	special acceptable red-hot boilermaker	3	good	Effect: "Nigh-Invincible", Effect Duration: 15
 7355	sage coal shovel	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	magnetized hot coal	0		Effect: "Permanent Halloween", Effect Duration: 19
-7357	tarnished cold-filtered gray blurry coal dust	0		Effect: "On Pins and Needles", Effect Duration: 58
+7357	tarnished cold-filtered blurry gray coal dust	0		Effect: "On Pins and Needles", Effect Duration: 58
 7358	knitted nasty supercool Bram's choker	0		Moxie Percent: +20, Stench Damage: +5, Cold Resistance: +3, Single Equip
 7359	plaid swatch	0		
 7360	plaid bandage	0		
@@ -7251,10 +7251,10 @@
 7362	yellow twirling shaking gravedigger's plaid skirt of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +10, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	adjusted concentrated bouncing bloodstain stick	0		Effect: "Sticks and Stones", Effect Duration: 30
 7364	squat fabric softener	0		
-7365	electrified anodized twirling lime green fabric hardener	0		Effect: "Bats in the Belfry", Effect Duration: 60
-7366	lousy practically non-alcoholic special yellow bottle of laundry sherry	1	decent	Effect: "New and Improved", Effect Duration: 25
+7365	electrified anodized lime green twirling fabric hardener	0		Effect: "Bats in the Belfry", Effect Duration: 60
+7366	special lousy practically non-alcoholic yellow bottle of laundry sherry	1	decent	Effect: "New and Improved", Effect Duration: 25
 7367	deionized industrial strength starch	0		Effect: "Heart of Orange", Effect Duration: 54, Wiki Name: "industrial strength starch"
-7368	normal blurry lime green extra-flat panini	4	good	
+7368	normal lime green blurry extra-flat panini	4	good	
 7369	triple-chilled blinking mangled finger	0		Effect: "Gummi-Grin", Effect Duration: 24
 7370	bad Psychotic Train wine	3	decent	
 7371	upside-down crazy hobo notebook	0		
@@ -7274,10 +7274,10 @@
 7385	diffused ionized jittery Gene Tonic: Beast	0		Effect: "Smelly Pants", Effect Duration: 29, Last Available: "2014-04"
 7386	concentrated galvanized Gene Tonic: Construct	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 54, Last Available: "2014-04"
 7387	improved Gene Tonic: Undead	0		Effect: "You Liver", Effect Duration: 55, Last Available: "2014-04"
-7388	irradiated diffused bouncing blinking olive Gene Tonic: Humanoid	0		Effect: "Video Game Hot Dog", Effect Duration: 16, Last Available: "2014-04"
+7388	irradiated diffused olive bouncing blinking Gene Tonic: Humanoid	0		Effect: "Video Game Hot Dog", Effect Duration: 16, Last Available: "2014-04"
 7389	extra-ionized modified mirror Gene Tonic: Insect	0		Effect: "Egged On", Effect Duration: 40, Last Available: "2014-04"
 7390	enhanced bouncing Gene Tonic: Hippy	0		Effect: "Grape Expectations", Effect Duration: 57, Last Available: "2014-04"
-7391	quadruple-polarized frozen upside-down squat Gene Tonic: Orc	0		Effect: "Itchy Trigger Finger", Effect Duration: 45, Last Available: "2014-04"
+7391	quadruple-polarized frozen squat upside-down Gene Tonic: Orc	0		Effect: "Itchy Trigger Finger", Effect Duration: 45, Last Available: "2014-04"
 7392	dry bouncing Gene Tonic: Demon	0		Effect: "Weird Flavor", Effect Duration: 18, Last Available: "2014-04"
 7393	galvanized ionized liquefied Gene Tonic: Horror	0		Effect: "Perception", Effect Duration: 69, Last Available: "2014-04"
 7394	liquefied double-Vulcanized Gene Tonic: Fish	0		Effect: "Fangs and Pangs", Effect Duration: 23, Last Available: "2014-04"
@@ -7292,7 +7292,7 @@
 7403	moist Vulcanized ionized Gene Tonic: Elemental	0		Effect: "Wet Jaw", Effect Duration: 69, Last Available: "2014-04"
 7404	polarized spinning Gene Tonic: Constellation	0		Effect: "Extra-Wet", Effect Duration: 42, Last Available: "2014-04"
 7405	activated denatured blinking Gene Tonic: Hobo	0		Effect: "No Worries", Effect Duration: 52, Last Available: "2014-04"
-7406	ghostly pulsating Steam Card: Dungeon Fist (#1)	0		
+7406	pulsating ghostly Steam Card: Dungeon Fist (#1)	0		
 7407	skewed Steam Card: Dungeon Fist (#2)	0		
 7408	blurry Steam Card: Dungeon Fist (#3)	0		
 7409	Steam Card: Space Trip (#1)	0		
@@ -7324,8 +7324,8 @@
 7435	ionized Stemonitis Staticus mushroom	0		Effect: "Puddingskin", Effect Duration: 56, Last Available: "2014-05"
 7436	concentrated Tremella Tarantella mushroom	0		Effect: "Aquarius Rising", Effect Duration: 55, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	moldy thick blinking Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
-7439	adequate miniature Brain Food Pastaco	2	good	Last Available: "2014-05"
+7438	thick moldy blinking Beefy Crunch Pastaco	5	crappy	Last Available: "2014-05"
+7439	miniature adequate Brain Food Pastaco	2	good	Last Available: "2014-05"
 7440	decent Cool Brunch Pastaco	3	good	Last Available: "2014-05"
 7441	bland Medical Pastaco	3	decent	Last Available: "2014-05"
 7442	snack-sized flavorless Energy Buzz Pastaco	2	decent	Last Available: "2014-05"
@@ -7334,9 +7334,9 @@
 7445	fortified lousy complex mushroom wine	5	decent	Last Available: "2014-05"
 7446	mediocre blinking smooth mushroom wine	4	decent	Last Available: "2014-05"
 7447	delicious watered-down blood-red mushroom wine	2	awesome	Last Available: "2014-05"
-7448	tolerable special buzzing mushroom wine	4	good	Effect: "The Grass...  Is Blue...", Effect Duration: 10, Last Available: "2014-05"
+7448	special tolerable buzzing mushroom wine	4	good	Effect: "The Grass...  Is Blue...", Effect Duration: 10, Last Available: "2014-05"
 7449	hand-crafted blurry swirling mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
-7450	small spoiled Taco Dan's Basic Taco Dan Taco	2	crappy	Last Available: "2014-05"
+7450	spoiled small Taco Dan's Basic Taco Dan Taco	2	crappy	Last Available: "2014-05"
 7451	snack-sized stale spinning Taco Dan's Taco Fish Fish Taco	2	decent	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	delicious mirror regular-size brogurt	3	awesome	Last Available: "2014-05"
@@ -7360,7 +7360,7 @@
 7471	chilled BROS Energy Drink	0		Effect: "Insatiable Hunger", Effect Duration: 56, Last Available: "2014-05"
 7472	double-irradiated triple-tarnished spinning go-go potion	0		Effect: "Boletus Swoletus", Effect Duration: 57, Last Available: "2014-05"
 7473	colloidal shrimp cocktail	0		Effect: "You Can Taste the Darkness", Effect Duration: 24, Last Available: "2014-05"
-7474	quantum cold-filtered skewed ghostly Yolo&trade; chocolates	0		Effect: "Wax On Your Shoes", Effect Duration: 19, Last Available: "2020-09"
+7474	quantum cold-filtered ghostly skewed Yolo&trade; chocolates	0		Effect: "Wax On Your Shoes", Effect Duration: 19, Last Available: "2020-09"
 7475	bouncing occult string of moist beads	0		Spell Damage Percent: +25, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	dry Meat-inflating powder	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 13, Last Available: "2014-05"
@@ -7369,7 +7369,7 @@
 7480	dry colloidal sugar bunny	0		Effect: "Virgo Rising", Effect Duration: 48, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	perfectly mixed Rompedores de Fantasmas	4	EPIC	
-7483	enchanted artisanal spirit-forward La Fantasma y La Oscuridad	5	EPIC	Effect: "Macho, Macho Dog", Effect Duration: 20
+7483	enchanted spirit-forward artisanal La Fantasma y La Oscuridad	5	EPIC	Effect: "Macho, Macho Dog", Effect Duration: 20
 7484	bad Fantasma en la M&aacute;quina	3	decent	
 7485	blue loosening powder	0		
 7486	castoreum	0		
@@ -7383,7 +7383,7 @@
 7494	huge wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
 7496	bouncing bottled day	0		
-7497	narrow pulsating ghost formula	0		
+7497	pulsating narrow ghost formula	0		
 7498	red Thwaitgold wheel bug statuette	0		
 7499	adjusted bouncing Hot 'n' Scarys	0		Effect: "A View to Some Meat", Effect Duration: 30
 7500	cyan map	0		
@@ -7395,7 +7395,7 @@
 7506	pulsating narrow Tesla book of the wise owl	0		Mysticality: +20, MP Regen Min: 7, MP Regen Max: 10
 7507	cloak of the overflowing toilet	0		Stench Spell Damage: +50
 7508	twirling label	0		
-7509	half-sized normal huge lime green spinning Mornington crescent roll	2	good	
+7509	normal half-sized lime green huge spinning Mornington crescent roll	2	good	
 7510	energized nitrogenated jittery green eye shadow	0		Effect: "Three Days Slow", Effect Duration: 42
 7511	jittery crumbling wheel	0		
 7512	triple-aerosolized wet poppy	0		Effect: "On the Trolley", Effect Duration: 50
@@ -7411,17 +7411,17 @@
 7522	smooth pair of government shades	0		Moxie: +15, Single Equip, Last Available: "2014-05"
 7523	maroon space junk	0		Last Available: "2014-05"
 7524	cold-filtered government	0		Effect: "items.enh", Effect Duration: 14, Last Available: "2014-05"
-7525	moist blurry blinking alien drugs	0		Effect: "Robocamo", Effect Duration: 31, Last Available: "2023-09"
+7525	moist blinking blurry alien drugs	0		Effect: "Robocamo", Effect Duration: 31, Last Available: "2023-09"
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	energetic stiffened government-issued night-vision goggles	0		Damage Reduction: 1, Maximum MP Percent: +20, Single Equip, Last Available: "2014-05"
 7529	bland half-sized jittery loaf of alien bread	2	decent	Last Available: "2014-05"
 7530	stale grilled cheese sandwich	3	decent	Last Available: "2014-05"
 7531	pickled tumbling alien protein powder	1	decent	Last Available: "2014-05"
-7532	high-proof mediocre rocket fuel	9	decent	Last Available: "2014-05"
+7532	mediocre high-proof rocket fuel	9	decent	Last Available: "2014-05"
 7533	blinking alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	delicious practically non-alcoholic stealth bomber	1	awesome	Last Available: "2014-05"
+7535	practically non-alcoholic delicious stealth bomber	1	awesome	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7440,18 +7440,18 @@
 7551	Vulcanized Vulcanized narrow dollop of barbecue sauce	0		Effect: "You're Rubber", Effect Duration: 45, Last Available: "2014-06"
 7552	liquefied non-electrified bowl of marinade	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 11, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
-7554	improved mirror jittery blue bottle of lighter fluid	0		Effect: "Liquid Courage", Effect Duration: 39, Last Available: "2014-06"
+7554	improved mirror blue jittery bottle of lighter fluid	0		Effect: "Liquid Courage", Effect Duration: 39, Last Available: "2014-06"
 7555	page	0		
 7556	elephant gift	0		
 7557	pressed bouncing blood cells	0		Effect: "In the Slimelight", Effect Duration: 64
-7558	lousy fancy wine	4	decent	Effect: "Greedy Resolve", Effect Duration: 5
+7558	fancy lousy wine	4	decent	Effect: "Greedy Resolve", Effect Duration: 5
 7559	deionized aerosolized unsweetened tumbling gummi turtle	0		Effect: "Tasting the Rainbow", Effect Duration: 27
 7560	maroon turtle-shaped rock	0		
 7561	tarnished energized giraffe-necked turtle	0		Effect: "You Know Who to Call", Effect Duration: 22
 7562	quantum musk turtle	0		Effect: "Nothing Is Impossible", Effect Duration: 52
 7563	super-corrupted pressed programmable turtle	0		Effect: "Coy to the Hurled", Effect Duration: 60
 7564	double-adjusted modified mocking turtle	0		Effect: "Industrial Strength Starch", Effect Duration: 59
-7565	small rotten mirror tumbling ham steak	2	crappy	
+7565	rotten small tumbling mirror ham steak	2	crappy	
 7566	mirror time-twitching toolbelt of the glutton	0		Food Drop: +100, Single Equip, Free Pull
 7567	Chroner	0		
 7568	zippy Newton's Time Lord Badge of Honor of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Initiative: +20
@@ -7467,7 +7467,7 @@
 7578	pickled triple-electrified pulsating future drug: Coolscaline	0		Effect: "Tiki Thoughtfulness", Effect Duration: 64
 7579	twitching time capsule	0		
 7580	dehydrated liquid shifting time weirdness	1		Effect: "EVISCERATE!", Effect Duration: 20
-7581	gray upside-down pulsating shifting time weirdness	0		Adventures: +4, PvP Fights: +4
+7581	upside-down gray pulsating shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	adequate rack of dinosaur ribs	3	good	
 7583	acceptable scotch on the rocks	3	good	
 7584	yabba dabba doo rag of Leguizamo of mayonnaise	0		Monster Level: +20, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7478,13 +7478,13 @@
 7589	tolerable glass of &quot;milk&quot;	4	good	Last Available: "2014-07"
 7590	tolerable cup of &quot;tea&quot;	4	good	Last Available: "2014-07"
 7591	bad thermos of &quot;whiskey&quot;	3	decent	Last Available: "2014-07"
-7592	artisanal special irresponsibly strong Lucky Lindy	9	EPIC	Effect: "Don't Step to Your Stepmother", Effect Duration: 10, Last Available: "2014-07"
+7592	irresponsibly strong artisanal special Lucky Lindy	9	EPIC	Effect: "Don't Step to Your Stepmother", Effect Duration: 10, Last Available: "2014-07"
 7593	hand-crafted Bee's Knees	3	EPIC	Last Available: "2014-07"
-7594	practically non-alcoholic hand-crafted skewed Sockdollager	1	super EPIC	Last Available: "2014-07"
+7594	hand-crafted practically non-alcoholic skewed Sockdollager	1	super EPIC	Last Available: "2014-07"
 7595	acceptable weak Ish Kabibble	2	good	Last Available: "2014-07"
-7596	practically non-alcoholic aged Hot Socks	1	awesome	Last Available: "2014-07"
-7597	watered-down aged Phonus Balonus	2	awesome	Last Available: "2014-07"
-7598	delicious practically non-alcoholic Flivver	1	awesome	Last Available: "2014-07"
+7596	aged practically non-alcoholic Hot Socks	1	awesome	Last Available: "2014-07"
+7597	aged watered-down Phonus Balonus	2	awesome	Last Available: "2014-07"
+7598	practically non-alcoholic delicious Flivver	1	awesome	Last Available: "2014-07"
 7599	artisanal watered-down Sloppy Jalopy	2	super ultra mega EPIC	Last Available: "2014-07"
 7600	ionized anodized flame	0		Effect: "Material Witness", Effect Duration: 35
 7601	extra-wet activated temporary yak tattoo	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 42
@@ -7493,14 +7493,14 @@
 7604	wet artisanal hand-squeezed wheatgrass juice	0		Effect: "Gutterminded", Effect Duration: 15
 7605	quadruple-pressed enhanced twirling punk patch	0		Effect: "License to Punch", Effect Duration: 65
 7606	quadruple-chilled ghostly jittery steampunk potion	0		Effect: "Bustle Hustlin'", Effect Duration: 38
-7607	improved jittery huge olive vial of swamp vapors	0		Effect: "Dilated Pupils", Effect Duration: 19
+7607	improved jittery olive huge vial of swamp vapors	0		Effect: "Dilated Pupils", Effect Duration: 19
 7608	aerosolized upside-down blue turtle mud	0		Effect: "Texas Elegance", Effect Duration: 66
 7609	extra-anodized quadruple-ionized red Redeye&trade; Eyedrops	0		Effect: "Going Ape", Effect Duration: 15
 7610	moist Dweebisol&trade; inhaler	0		Effect: "Eyes All Black", Effect Duration: 57
 7611	activated Lewd Lemmy Hair Oil	0		Effect: "Compensatory Cruelness", Effect Duration: 24
 7612	cold-filtered ionized tomato soup poster	0		Effect: "Flower Power", Effect Duration: 41
 7613	electrified upside-down teal bubblin' chemistry solution	0		Effect: "Afternoon Insight", Effect Duration: 30
-7614	liquefied double-improved olive pulsating voodoo glowskull	0		Effect: "Winning Smile", Effect Duration: 12
+7614	liquefied double-improved pulsating olive voodoo glowskull	0		Effect: "Winning Smile", Effect Duration: 12
 7615	flattened blinking pygmy adder oil	0		Effect: "Heal Thy Nanoself", Effect Duration: 11
 7616	diffused double-pickled green pygmy witchhazel	0		Effect: "Capricorn Rising", Effect Duration: 19
 7617	frozen short deposition	0		Effect: "Angry like the Wolf", Effect Duration: 52
@@ -7531,7 +7531,7 @@
 7642	ingot turtle	0		
 7643	shaking duty umbrella	0		
 7644	pool skimmer	0		
-7645	yellow blurry bouncing life preserver	0		
+7645	yellow bouncing blurry life preserver	0		
 7646	lightning milk	0		
 7647	spinning aquaconda brain	0		
 7648	huge pulsating thunder thigh	0		
@@ -7548,7 +7548,7 @@
 7659	slick neoprene skullcap	0		Moxie: +10, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	concentrated oxidized huge goblin water	0		Effect: "Stuck-Up Hair", Effect Duration: 37
 7661	dumb mud	0		
-7662	flavorless bite-sized Sogg-Os	1	decent	
+7662	bite-sized flavorless Sogg-Os	1	decent	
 7663	Van der Graaf banded studded Lord Soggyraven's Slippers	0		Damage Absorption: 180, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 7664	oxidized lime green Ancient Protector Soda	0		Effect: "Reptilian Fortitude", Effect Duration: 67
 7665	aerosolized chilled liquid ice	0		Effect: "Vitali Tea", Effect Duration: 13
@@ -7565,7 +7565,7 @@
 7676	tumbling shellacked birdbone corset	0		Damage Reduction: 7
 7677	chilled blinking candy cigarette	0		Effect: "Mer-kinny Flavor", Effect Duration: 29
 7678	4-dimensional fez of wisdom	0		Mysticality: +15, Familiar Effect: "atk, 1xLep, cap 12"
-7679	upside-down squat throwing candy	0		
+7679	squat upside-down throwing candy	0		
 7680	Socratic super-absorbent tarp	0		Experience (Mysticality): +1
 7681	watered-down mediocre mirror unquiet spirits	2	decent	
 7682	baleful banjo kazoo mount	0		Spell Damage: +25, Single Equip
@@ -7573,7 +7573,7 @@
 7684	pulsating chilly Time Lord Participation Mug	0		Cold Damage: +5
 7685	foul-smelling Time Bandit Time Towel of the glutton	0		Stench Damage: +10, Food Drop: +100
 7686	lard-coated dog trainer's Caveman Dan's favorite rock of the storm	0		Maximum MP Percent: +40, Experience (familiar): +1, Sleaze Spell Damage: +25, Single Equip
-7687	improved squat wobbly dog ointment	0		Effect: "Triangle, Man", Effect Duration: 69
+7687	improved wobbly squat dog ointment	0		Effect: "Triangle, Man", Effect Duration: 69
 7688	gumshoes of the pedagogue of terror	0		Experience: +3, Spooky Spell Damage: +10, Single Equip
 7689	shaking dance instructor's Socratic flapper floppers	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Single Equip
 7690	squat vibrating sneakeasies of incineration	0		Maximum MP Percent: +10, Hot Spell Damage: +50, Single Equip
@@ -7588,7 +7588,7 @@
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	polarized confiscated comic book	0		Effect: "Bonelording", Effect Duration: 11, Last Available: "2014-08"
 7701	tarnished narrow confiscated cell phone	0		Effect: "Going Ape", Effect Duration: 29, Last Available: "2014-08"
-7702	unsweetened corrupted purple ghostly skewed confiscated love note	0		Effect: "Hammered", Effect Duration: 27, Last Available: "2014-08"
+7702	unsweetened corrupted ghostly skewed purple confiscated love note	0		Effect: "Hammered", Effect Duration: 27, Last Available: "2014-08"
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	tumbling LCD game: Garbage River	0		Last Available: "2014-08"
 7705	cyan LCD game: Burger Belt	0		Last Available: "2014-08"
@@ -7612,7 +7612,7 @@
 7723	cyan Chroner cross	0		
 7724	clever pteruges	0		Maximum MP: +20, Familiar Effect: "1xFairy, atk, cap 25"
 7725	non-frozen twirling squat Bruno's blessing of Mars	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 13
-7726	tarnished quadruple-polymerized lime green squat ghostly skewed Dennis's blessing of Minerva	0		Effect: "Chunky", Effect Duration: 58
+7726	tarnished quadruple-polymerized squat lime green skewed ghostly Dennis's blessing of Minerva	0		Effect: "Chunky", Effect Duration: 58
 7727	concentrated Burt's blessing of Bacchus	0		Effect: "Rave Concentration", Effect Duration: 17
 7728	energized narrow Freddie's blessing of Mercury	0		Effect: "Radium Radicality", Effect Duration: 52
 7729	Chroner trigger	0		
@@ -7624,7 +7624,7 @@
 7735	Xiblaxian alloy	0		Last Available: "2014-09"
 7736	Xiblaxian crystal	0		Last Available: "2014-09"
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
-7738	bouncing tumbling yellow Xiblaxian cache locator simcode	0		Last Available: "2014-09"
+7738	yellow bouncing tumbling Xiblaxian cache locator simcode	0		Last Available: "2014-09"
 7739	Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	wobbly Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
@@ -7643,10 +7643,10 @@
 7754	blurry hardened Samson's Xiblaxian stealth trousers	0		Experience (Muscle): +5, Damage Reduction: 3, Last Available: "2014-09"
 7755	Xiblaxian stealth vest of the cougar of the scaredy-cat	0		Moxie: +20, Monster Level: -15, Last Available: "2014-09"
 7756	normal Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
-7757	distilled acceptable Xiblaxian space-whiskey	5	good	Last Available: "2014-09"
+7757	acceptable distilled Xiblaxian space-whiskey	5	good	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	tarnished They liver	0		Effect: "Frozen Hands", Effect Duration: 57, Last Available: "2014-09"
-7760	decent thick squat They liver popsicle	5	good	Last Available: "2014-09"
+7760	thick decent squat They liver popsicle	5	good	Last Available: "2014-09"
 7761	cyan holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7658,17 +7658,17 @@
 7769	wobbly Coinspiracy	0		Last Available: "2014-10"
 7770	lightning-fast smartaleck's Personal Ventilation Unit of the overflowing toilet	0		Moxie Percent: +30, Stench Spell Damage: +50, Initiative: +40, Single Equip, Last Available: "2014-10"
 7771	activated deionized the most dangerous bait	0		Effect: "Cold, Dead Hands", Effect Duration: 15, Last Available: "2014-10"
-7772	low-calorie normal squat &quot;meat&quot; stick	1	good	Last Available: "2014-10"
+7772	normal low-calorie squat &quot;meat&quot; stick	1	good	Last Available: "2014-10"
 7773	mixed tumbling transdermal smoke patch	1	crappy	Effect: "Oiled Skin", Effect Duration: 15, Last Available: "2014-10"
 7774	narrow specialty ammo bandolier	0		Last Available: "2014-10"
 7775	jittery red perfumed clever hardy pair of plants	0		Maximum HP: +50, Maximum MP: +20, Stench Resistance: +5, Last Available: "2014-10"
 7776	gray coward's padded wicked Sasq&trade; watch	0		Spell Damage: +5, Damage Absorption: +20, Monster Level: -20, Single Equip, Last Available: "2014-10"
 7777	twirling lard-coated Oprah's smoker's cloak of the brazier	0		Maximum MP Percent: +50, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2014-10"
 7778	ghostly lion tamer's extremely unsafe supercool camouflage T-shirt of the boozehound	0		Moxie Percent: +20, Weapon Damage Percent: +100, Experience (familiar): +2, Booze Drop: +100, Last Available: "2014-10"
-7779	flattened polarized blurry skewed experimental serum G-9	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 19, Last Available: "2014-10"
+7779	flattened polarized skewed blurry experimental serum G-9	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 19, Last Available: "2014-10"
 7780	resourceful therapeutic heavy-duty clipboard of extreme caution	0		Maximum MP: +50, Monster Level: -25, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 8, Last Available: "2014-10"
 7781	frosty smooth battery-powered drill of vim and vigor of chilblains	0		Moxie: +15, Maximum HP Percent: +50, Cold Damage: +25, Cold Spell Damage: +10, Last Available: "2014-10"
-7782	bland jumbo limp broccoli	5	decent	Last Available: "2014-10"
+7782	jumbo bland limp broccoli	5	decent	Last Available: "2014-10"
 7783	blurry executive supercharged hat of the cougar	0		Moxie: +20, Maximum MP Percent: +30, Meat Drop: +40, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	extra-irradiated twirling monkey barf	0		Effect: "Gummi Badass", Effect Duration: 19, Last Available: "2014-10"
 7785	tarnished modified candy	0		Effect: "Tea-hee", Effect Duration: 41, Last Available: "2014-10"
@@ -7681,11 +7681,11 @@
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	mirror bottle-opener keycard	0		Last Available: "2014-10"
 7794	lime green mirror Armory keycard	0		Last Available: "2014-10"
-7795	immense stale special upside-down initiative shawarma	9	decent	Effect: "Astral Shell", Effect Duration: 5, Last Available: "2014-10"
-7796	snack-sized flavorless warm war shawarma	2	decent	Last Available: "2014-10"
+7795	immense special stale upside-down initiative shawarma	9	decent	Effect: "Astral Shell", Effect Duration: 5, Last Available: "2014-10"
+7796	flavorless snack-sized warm war shawarma	2	decent	Last Available: "2014-10"
 7797	tasty karma shawarma	3	awesome	Last Available: "2014-10"
 7798	perfectly mixed Jungle Juice	4	EPIC	Last Available: "2014-10"
-7799	hand-crafted enchanted watered-down Amnesiac Ale	2	EPIC	Effect: "Abyssal Tears", Effect Duration: 30, Last Available: "2014-10"
+7799	watered-down enchanted hand-crafted Amnesiac Ale	2	EPIC	Effect: "Abyssal Tears", Effect Duration: 30, Last Available: "2014-10"
 7800	triple-distilled lousy yellow Highest Bitter	10	decent	Last Available: "2014-10"
 7801	Tesla Newton's mercenary pistol	0		Experience (Mysticality): +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
 7802	miser's dangerous mercenary rifle	0		Weapon Damage: +10, Meat Drop: +10, Last Available: "2014-10"
@@ -7714,7 +7714,7 @@
 7825	lion tamer's clever earbuds of terror	0		Maximum MP: +20, Experience (familiar): +2, Spooky Spell Damage: +10, Single Equip
 7826	blinking greedy Samson's weightlifter's iFlail	0		Muscle: +15, Experience (Muscle): +5, Meat Drop: +20
 7827	bland diet ghostly unidentifiable dried fruit	1	decent	
-7828	practically non-alcoholic mediocre flat cider	1	decent	
+7828	mediocre practically non-alcoholic flat cider	1	decent	
 7829	yellow Lo Pan's trench lighter of dire peril of the bloodbag	0		Weapon Damage: +20, Maximum HP: +100, Spell Critical Percent: +30, Last Available: "2014-10"
 7830	polarized experimental serum P-00	0		Effect: "Spiky Frozen Hair", Effect Duration: 41, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7731,7 +7731,7 @@
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	upside-down special clip: graveburpers	0		Last Available: "2014-10"
-7845	aerosolized green spinning perl necklace	0		Effect: "Human-Hobo Hybrid", Effect Duration: 35, Last Available: "2014-12"
+7845	aerosolized spinning green perl necklace	0		Effect: "Human-Hobo Hybrid", Effect Duration: 35, Last Available: "2014-12"
 7846	improved twirling green Fudge Fiber Armor Plating	0		Effect: "Incensed", Effect Duration: 49, Last Available: "2014-12"
 7847	magnetized ruby on canes	0		Effect: "Memory of Speed", Effect Duration: 33, Last Available: "2014-12"
 7848	decent petit fortran	3	good	Last Available: "2014-12"
@@ -7770,7 +7770,7 @@
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
-7884	skewed shaking Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
+7884	shaking skewed Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	squat Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
 7887	pulsating Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
@@ -7809,7 +7809,7 @@
 7920	narrow fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	hand-crafted Friendly Turkey	3	EPIC	Last Available: "2014-11"
-7923	artisanal practically non-alcoholic Agitated Turkey	1	EPIC	Last Available: "2014-11"
+7923	practically non-alcoholic artisanal Agitated Turkey	1	EPIC	Last Available: "2014-11"
 7924	drinkable Ambitious Turkey	3	good	Last Available: "2014-11"
 7925	adequate teal neutron lollipop	3	good	Last Available: "2014-12"
 7926	high-proof artisanal gamma nog	9	EPIC	Last Available: "2014-12"
@@ -7817,7 +7817,7 @@
 7935	blue Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	diluted shaking spinning single atom	1	awesome	Last Available: "2015-02"
+7938	diluted spinning shaking single atom	1	awesome	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
@@ -7826,7 +7826,7 @@
 7944	tooth	0		
 7945	table	0		
 7946	smelly forbidden outlaw bandana of the ox	0		Muscle: +20, Spell Damage Percent: +50, Stench Spell Damage: +10
-7947	mediocre special whiskey in a broken glass	3	decent	Effect: "Bottle in front of Me", Effect Duration: 15
+7947	special mediocre whiskey in a broken glass	3	decent	Effect: "Bottle in front of Me", Effect Duration: 15
 7948	perfectly mixed shot of mescal	3	EPIC	
 7949	lousy strong glass of herbal tequila	5	decent	
 7950	huge minin' dynamite	0		
@@ -7836,12 +7836,12 @@
 7954	rattler rattle	0		
 7955	ghostly bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
-7957	skewed maroon even more tinsel	0		Familiar Weight: +5
+7957	maroon skewed even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
 7959	yellow letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	cyan avaricious Annie Oakley's clever Staff of Ed of the early riser	0		Maximum MP: +20, Critical Hit Percent: +20, Meat Drop: +30, Adventures: +7
-7962	teal mirror Eye of Ed	0		
+7962	mirror teal Eye of Ed	0		
 7963	amulet	0		
 7964	lard-coated Staff of Fats	0		Sleaze Spell Damage: +25
 7965	Holy MacGuffin	0		
@@ -7879,7 +7879,7 @@
 7997	twisted upside-down skewed polyesterene powder	1		Last Available: "2015-12"
 7998	twisted powder	1		Last Available: "2015-12"
 7999	altered choco-Crimbot	0		Effect: "Hella Smooth", Effect Duration: 47, Last Available: "2014-12"
-8000	double-colloidal magnetized energized maroon squat smart watch	0		Effect: "Net Tea", Effect Duration: 20, Last Available: "2014-12"
+8000	double-colloidal magnetized energized squat maroon smart watch	0		Effect: "Net Tea", Effect Duration: 20, Last Available: "2014-12"
 8001	Vulcanized Vulcanized augmented-reality shades	0		Effect: "Twinklebritches", Effect Duration: 25, Last Available: "2014-12"
 8002	groovy toy Crimbot mega face	0		Moxie Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	toy Crimbot power glove of the cheetah	0		Initiative: +60, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
@@ -7905,13 +7905,13 @@
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	shaking foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
-8026	mirror lime green ceiling fan	0		Last Available: "2015-01"
+8026	lime green mirror ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
 8028	artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	shaking stationery set	0		Last Available: "2015-01"
-8032	blinking tumbling calligraphy pen	0		Free Pull, Last Available: "2015-01"
+8032	tumbling blinking calligraphy pen	0		Free Pull, Last Available: "2015-01"
 8033	twirling alpine watercolor set	0		Last Available: "2015-01"
 8034	greasy mansplainer's tope&eacute;	0		Monster Level: +15, Sleaze Spell Damage: +10, Familiar Effect: "3xBarrr, cap 12"
 8035	medical-grade slick topiary tights	0		Moxie: +10, HP Regen Min: 7, HP Regen Max: 10
@@ -7947,9 +7947,9 @@
 8066	denatured ghostly	1	crappy	Effect: "Mad at Science", Effect Duration: 45, Last Available: "2015-12"
 8067	nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
-8069	yellow pulsating Stembridge sidearm	0		Familiar Weight: +5
+8069	pulsating yellow Stembridge sidearm	0		Familiar Weight: +5
 8070	warehouse map page	0		
-8071	jittery blurry warehouse inventory page	0		
+8071	blurry jittery warehouse inventory page	0		
 8072	bouncing janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
 8074	cyan toasty curative fortified Spelunker's fedora	0		Damage Absorption: +60, Hot Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
@@ -7959,7 +7959,7 @@
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	blurry Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
-8087	yellow spinning Thwaitgold scarab beetle statuette	0		
+8087	spinning yellow Thwaitgold scarab beetle statuette	0		
 8088	huge jewel	0		
 8089	headless sparrow	0		
 8090	purple mangled squirrel	0		
@@ -8024,8 +8024,8 @@
 8150	irradiated pulsating sugar sphere	0		Effect: "Burning Ears", Effect Duration: 19
 8151	ionized polymerized Shrubble Bubble	0		Effect: "Disco Inferno", Effect Duration: 64
 8152	quantum non-boiled polyeaster egg	0		Effect: "Cute Vision", Effect Duration: 65
-8153	concentrated upside-down olive candy dish	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 65
-8154	wet pulsating huge Spechunky bar	0		Effect: "Innately Wise", Effect Duration: 38
+8153	concentrated olive upside-down candy dish	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 65
+8154	wet huge pulsating Spechunky bar	0		Effect: "Innately Wise", Effect Duration: 38
 8155	deionized talisman of Horus	0		Effect: "Itchy Trigger Finger", Effect Duration: 44
 8156	check to the Meatsmith	0		
 8157	upside-down Skeleton Store office key	0		
@@ -8042,7 +8042,7 @@
 8168	glob of icing	0		
 8169	aerosolized fuchsia ginger snaps	0		Effect: "Cinnamouth", Effect Duration: 61
 8170	quadruple-diffused chilled mostly-broken sunglasses	0		Effect: "Human-Plant Hybrid", Effect Duration: 66
-8171	lousy distilled unflavored wine cooler	5	decent	
+8171	distilled lousy unflavored wine cooler	5	decent	
 8172	carton of snake milk	1	decent	
 8173	sewer snake of the brazier	0		Hot Spell Damage: +25
 8174	bland pigeon egg	3	decent	
@@ -8055,13 +8055,13 @@
 8181	wobbly loafers of the brute	0		Muscle Percent: +30, Single Equip
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	sinister bread basket	0		Spell Damage: +10
-8184	bouncing bouncing lime green Ed the Undying exhibit crate	0		
+8184	lime green bouncing bouncing Ed the Undying exhibit crate	0		
 8185	pulsating curative arcane researcher's The Crown of Ed the Undying	0		Experience Percent (Mysticality): +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	aged Cherrytastrophe wine cooler	3	awesome	
 8189	mediocre weak Radberry Rip wine cooler	2	decent	
-8190	artisanal spinning upside-down Orangemageddon wine cooler	4	EPIC	
+8190	artisanal upside-down spinning Orangemageddon wine cooler	4	EPIC	
 8191	drinkable Breakfast Blast wine cooler	4	good	
 8192	tolerable Citrus Crush wine cooler	4	good	
 8193	delicious plain bagel	3	awesome	
@@ -8069,7 +8069,7 @@
 8195	tiny flavorless loaf of soda bread	1	decent	
 8196	bite-sized tasty teal acceptable bagel	1	awesome	
 8197	flavorless standard-issue cupcake	3	decent	
-8198	half-sized decent ultra-deluxe cupcake	2	good	
+8198	decent half-sized ultra-deluxe cupcake	2	good	
 8199	hypnotic breadcrumbs	0		
 8200	massive delicious olive popular tart	10	awesome	
 8201	shaking no-handed pie	0		
@@ -8090,7 +8090,7 @@
 8216	electrified concentrated irradiated beard incense	0		Effect: "Artificially Sweet", Effect Duration: 55, Last Available: "2015-04"
 8217	scandalous perfume-soaked bandana of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Single Equip, Last Available: "2015-04"
 8218	blinking toxic globule	0		Last Available: "2015-04"
-8219	half-sized stale toxo	2	decent	Last Available: "2015-04"
+8219	stale half-sized toxo	2	decent	Last Available: "2015-04"
 8220	perfectly mixed practically non-alcoholic Lemonade-235	1	EPIC	Last Available: "2015-04"
 8221	ribald isotophat of the ox	0		Muscle: +20, Sleaze Damage: +10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	shaking wicked Three Mile Island shorts of Tarzan	0		Experience (Muscle): +3, Spell Damage: +5, Last Available: "2015-04"
@@ -8125,9 +8125,9 @@
 8251	twirling frightening nippy sharpshooter's crafty padded garbage sticker of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Maximum MP: +10, Critical Hit Percent: +10, Cold Damage: +10, Spooky Damage: +5, Last Available: "2015-04"
 8252	hardened experienced smooth hazmat helmet of the bloodbag of Calamity Jane	0		Moxie: +15, Experience: +2, Damage Reduction: 3, Maximum HP: +100, Critical Hit Percent: +15, Last Available: "2015-04"
 8253	Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
-8254	squat jittery Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
+8254	jittery squat Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	lime green Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
-8256	huge upside-down gray Dinsey tattoo kit	0		Last Available: "2015-04"
+8256	gray huge upside-down Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	chilled nasty gum	0		Effect: "Fury of the Bells", Effect Duration: 16
 8258	blurry jittery Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	green brainy The Lot's engagement ring	0		Mysticality: +5, Conditional Skill (Equipped): "Propose To Your Opponent"
@@ -8143,13 +8143,13 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	gigantic flavorless unappetizing mayolus	8	decent	Last Available: "2015-05"
 8271	flavorless snack-sized skewed uninteresting mayolus	2	decent	Last Available: "2015-05"
-8272	stale tiny acceptable mayolus	1	decent	Last Available: "2015-05"
-8273	thick bland mirror enticing mayolus	5	decent	Last Available: "2015-05"
-8274	decent immense mouth-watering mayolus	9	good	Last Available: "2015-05"
+8272	tiny stale acceptable mayolus	1	decent	Last Available: "2015-05"
+8273	bland thick mirror enticing mayolus	5	decent	Last Available: "2015-05"
+8274	immense decent mouth-watering mayolus	9	good	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	gray mayo pump	0		Familiar Weight: +5
 8277	purple Essence of Bear	0		Skill: "Bear Essence"
-8278	fancy lousy Afternoon Delight	3	decent	Effect: "Hella Smart", Effect Duration: 35, Last Available: "2015-04"
+8278	lousy fancy Afternoon Delight	3	decent	Effect: "Hella Smart", Effect Duration: 35, Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	blue shaking Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	nitrogenated narrow Kokomo Resort Brand Suntan Oil	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 49, Last Available: "2015-04"
@@ -8172,9 +8172,9 @@
 8298	pixel	0		Last Available: "2015-06"
 8299	pixel coin	0		Last Available: "2015-06"
 8300	quantum gray power pill	0		Effect: "Standard Cheer", Effect Duration: 52, Last Available: "2015-06"
-8301	electrified wobbly twirling teal pixel star	0		Effect: "Quantum of Moxie", Effect Duration: 64, Last Available: "2015-06"
-8302	decent tiny pixel banana	1	good	Last Available: "2015-06"
-8303	lousy irresponsibly strong pixel beer	7	decent	Last Available: "2015-06"
+8301	electrified teal twirling wobbly pixel star	0		Effect: "Quantum of Moxie", Effect Duration: 64, Last Available: "2015-06"
+8302	tiny decent pixel banana	1	good	Last Available: "2015-06"
+8303	irresponsibly strong lousy pixel beer	7	decent	Last Available: "2015-06"
 8304	yellow puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	dry extra-irradiated sludgesicle	0		Effect: "Riboflavin'", Effect Duration: 39
@@ -8214,7 +8214,7 @@
 8340	diffused tumbling janitor's mop	0		Effect: "Kindly Resolve", Effect Duration: 59
 8341	ionized wet skewed warehouse clerk's glasses	0		Effect: "Always In Motion", Effect Duration: 14
 8342	adjusted tumbling baloney rotgut	0		Effect: "Rampage!", Effect Duration: 26
-8343	quadruple-corrupted pulsating twirling carton of gaspers	0		Effect: "Okee-Dokee Go!", Effect Duration: 67
+8343	quadruple-corrupted twirling pulsating carton of gaspers	0		Effect: "Okee-Dokee Go!", Effect Duration: 67
 8344	warmed yellow bronze polish	0		Effect: "Spirit Bubble", Effect Duration: 38
 8345	Vulcanized crident	0		Effect: "Certainty", Effect Duration: 47
 8346	chilled triple-vacuum-sealed alkaline totally sweet mohawk helmet	0		Effect: "Egg-headedness", Effect Duration: 48
@@ -8225,7 +8225,7 @@
 8351	modified magnetized squat lump of goofball ore	0		Effect: "Make Meat FA$T!", Effect Duration: 69
 8352	vacuum-sealed skeleton beans	0		Effect: "Become Intensely interested", Effect Duration: 30
 8353	moist non-galvanized non-altered grimy lab coat	0		Effect: "Square to be Hip", Effect Duration: 41
-8354	deionized warmed wobbly mirror nursery rhyme	0		Effect: "Very Clean Guns", Effect Duration: 42
+8354	deionized warmed mirror wobbly nursery rhyme	0		Effect: "Very Clean Guns", Effect Duration: 42
 8355	unsweetened magnetized corrupted wobbly iron torso box	0		Effect: "Hare-o-dynamic", Effect Duration: 62
 8356	super-tarnished deionized olive mercenary headband	0		Effect: "Horrid, Torrid", Effect Duration: 58
 8357	adjusted ionized radioactive spider venom	0		Effect: "Rave Nirvana", Effect Duration: 17
@@ -8248,10 +8248,10 @@
 8374	non-altered moist drinks tray	0		Effect: "Wistfully Nostalgic", Effect Duration: 13
 8375	ionized bouncing eyebrow lifter	0		Effect: "Winning Smile", Effect Duration: 45
 8376	blinking narrow submarine	0		Last Available: "2015-06"
-8377	stale thick lime green pixel lemon	5	decent	Last Available: "2015-06"
-8378	lousy practically non-alcoholic pixel daiquiri	1	decent	Last Available: "2015-06"
+8377	thick stale lime green pixel lemon	5	decent	Last Available: "2015-06"
+8378	practically non-alcoholic lousy pixel daiquiri	1	decent	Last Available: "2015-06"
 8379	anodized power pill	0		Effect: "Shortened", Effect Duration: 30, Last Available: "2015-06"
-8380	super-polymerized deionized shaking lime green pixel potion	0		Effect: "Lit Up", Effect Duration: 52, Last Available: "2015-06"
+8380	super-polymerized deionized lime green shaking pixel potion	0		Effect: "Lit Up", Effect Duration: 52, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	blinking Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
@@ -8277,20 +8277,20 @@
 8403	mirror Rosewater's revolver of terror	0		Mysticality Percent: +30, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-07"
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	ghostly talking spade	0		Free Pull
-8406	upside-down spinning savory dry noodles	0		
+8406	spinning upside-down savory dry noodles	0		
 8407	miniature adequate skewed pestopiary	2	good	
 8408	aerosolized deionized twirling ectoplasmic orbs	0		Effect: "Ass Over Teakettle", Effect Duration: 53
-8409	small rotten crudles	2	crappy	
+8409	rotten small crudles	2	crappy	
 8410	immense bland fuchsia agnolotti arboli	9	decent	
-8411	snack-sized moldy twirling spaghetti with ghost balls	2	crappy	
-8412	flavorless snack-sized succulent marrow	2	decent	
+8411	moldy snack-sized twirling spaghetti with ghost balls	2	crappy	
+8412	snack-sized flavorless succulent marrow	2	decent	
 8413	moldy salacious crumbs	4	crappy	
 8414	jumbo bland upside-down fusilli marrownarrow	5	decent	
-8415	normal low-calorie suggestive strozzapreti	1	good	
+8415	low-calorie normal suggestive strozzapreti	1	good	
 8416	blurry Mountain Stream gastrique	0		
-8417	super-sized decent Mt. McLargeHuge oyster	5	good	
+8417	decent super-sized Mt. McLargeHuge oyster	5	good	
 8418	skewed oyster sauce	0		
-8419	stale bite-sized fancy linguini immondizia bianco	1	decent	Effect: "Oleaginous Soles", Effect Duration: 20
+8419	stale fancy bite-sized linguini immondizia bianco	1	decent	Effect: "Oleaginous Soles", Effect Duration: 20
 8420	tasty shells a la shellfish	3	awesome	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8315,7 +8315,7 @@
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	tumbling viscous lava globs	0		Last Available: "2015-08"
 8443	lava globs	0		Last Available: "2015-08"
-8444	blue bouncing lava globs	0		Last Available: "2015-08"
+8444	bouncing blue lava globs	0		Last Available: "2015-08"
 8445	lava globs	0		Last Available: "2015-08"
 8446	SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8331,11 +8331,11 @@
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	steel-toed sinister high-temperature mining mask	0		Spell Damage: +10, Damage Reduction: 9, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	jittery greedy smartaleck's fireproof megaphone	0		Moxie Percent: +30, Meat Drop: +20, Last Available: "2015-08"
-8460	super-sized rotten mineapple	5	crappy	Last Available: "2015-08"
+8460	rotten super-sized mineapple	5	crappy	Last Available: "2015-08"
 8461	drinkable Gold Velvet&trade; whiskey	3	good	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	flavorless twirling smelted roe	3	decent	Last Available: "2015-08"
-8464	strong smooth twirling pulsating lavawater	5	awesome	Last Available: "2015-08"
+8464	smooth strong pulsating twirling lavawater	5	awesome	Last Available: "2015-08"
 8465	dry deionized basaltamander tongue	0		Effect: "Engorged Weapon", Effect Duration: 14, Last Available: "2015-08"
 8466	chilly hale sage lavalarva	0		Mysticality Percent: +10, Maximum HP: +20, Cold Damage: +5, Last Available: "2015-08"
 8467	flame-wreathed chilly stiffened lava balaclava	0		Damage Reduction: 1, Cold Damage: +5, Hot Spell Damage: +10, Last Available: "2015-08"
@@ -8345,10 +8345,10 @@
 8471	shellacked Fonzie's lava-proof pants	0		Experience (Moxie): +1, Damage Reduction: 7, Last Available: "2015-08"
 8472	skewed knitted lard-coated heat-resistant necktie	0		Sleaze Spell Damage: +25, Cold Resistance: +3, Single Equip, Last Available: "2015-08"
 8473	resourceful Sinatra's heat-resistant gloves of the sweet-tooth	0		Experience (Moxie): +5, Maximum MP: +50, Candy Drop: +100, Single Equip, Last Available: "2015-08"
-8474	decent big upside-down very hot lunch	5	good	Last Available: "2015-08"
-8475	perfectly mixed practically non-alcoholic asbestos thermos	1	super ultra mega turbo EPIC	Last Available: "2015-08"
-8476	polarized cold-filtered narrow olive liquid rhinestones	0		Effect: "Vitamin-Maxed", Effect Duration: 58, Last Available: "2015-08"
-8477	rotten bite-sized disco biscuit	1	crappy	Last Available: "2015-08"
+8474	big decent upside-down very hot lunch	5	good	Last Available: "2015-08"
+8475	practically non-alcoholic perfectly mixed asbestos thermos	1	super ultra mega turbo EPIC	Last Available: "2015-08"
+8476	polarized cold-filtered olive narrow liquid rhinestones	0		Effect: "Vitamin-Maxed", Effect Duration: 58, Last Available: "2015-08"
+8477	bite-sized rotten disco biscuit	1	crappy	Last Available: "2015-08"
 8478	fortified smooth Quaatorade&trade;	5	awesome	Last Available: "2015-08"
 8479	wobbly green lard-coated sharpshooter's Tesla biker's hat	0		Critical Hit Percent: +10, Sleaze Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk"
 8480	yellow hardened Da Vinci's feathered headdress of the scaredy-cat	0		Experience (Mysticality): +5, Damage Reduction: 3, Monster Level: -15, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
@@ -8377,7 +8377,7 @@
 8503	signed deuce	0		Last Available: "2015-08"
 8504	huge Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
-8506	skewed blurry glass ceiling fragments	0		Last Available: "2015-08"
+8506	blurry skewed glass ceiling fragments	0		Last Available: "2015-08"
 8507	dehydrated SMOOCH coffee cup	1	awesome	Effect: "Corona de la Salsa", Effect Duration: 20, Last Available: "2015-08"
 8508	adjusted jittery labrador cookie	0		Effect: "Bandersnatched", Effect Duration: 62, Last Available: "2015-08"
 8509	shaking coward's Herculean thinker's Mr. Cheeng's spectacles	0		Mysticality: +10, Experience (Muscle): +1, Monster Level: -20, Single Equip, Last Available: "2015-08"
@@ -8400,31 +8400,31 @@
 8526	miniature tasty pink slime	2	awesome	
 8527	Devil's Elbow Hot Sauce	0		
 8528	blurry Special&trade; Sauce	0		
-8529	immense decent devil hair pasta	7	good	
+8529	decent immense devil hair pasta	7	good	
 8530	bland huge spagecialetti	9	decent	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	normal tiny libertagliatelle	1	good	
-8535	diet moldy red skewed turkish mostaccioli	1	crappy	
+8535	diet moldy skewed red turkish mostaccioli	1	crappy	
 8536	super-sized normal ghostly linguini of the sea	5	good	
 8537	improved cold-filtered bouncing Hersey&trade; SMOOCH	0		Effect: "Eyes Wide Propped", Effect Duration: 23
 8539	mirror Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	adequate Fettris	4	good	
-8543	moldy enchanted diet fusillocybin	1	crappy	Effect: "Preternatural Greed", Effect Duration: 45
+8543	diet enchanted moldy fusillocybin	1	crappy	Effect: "Preternatural Greed", Effect Duration: 45
 8544	moldy blinking prescription noodles	3	crappy	
 8545	vaporized mirror squat blood-drive sticker	1	decent	Effect: "Spooky Blur", Effect Duration: 45
 8546	colloidal chilled bag of grain	0		Effect: "Can't Be a Chooser", Effect Duration: 61
 8547	polarized galvanized pocket maze	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 18
 8548	magnetized shady shades	0		Effect: "Aided and Abetted", Effect Duration: 14
-8549	flattened Vulcanized twirling red squeaky toy rose	0		Effect: "Hot Buttoned", Effect Duration: 48
-8550	spoiled diet weird gazelle steak	1	crappy	
+8549	flattened Vulcanized red twirling squeaky toy rose	0		Effect: "Hot Buttoned", Effect Duration: 48
+8550	diet spoiled weird gazelle steak	1	crappy	
 8551	adequate shaking sausage without a cause	4	good	
 8552	quadruple-Vulcanized liquefied diffused narrow narrow face paint	0		Effect: "Fangs and Pangs", Effect Duration: 60
-8553	delicious watered-down emergency margarita	2	awesome	
-8554	irresponsibly strong lousy vintage smart drink	7	decent	
+8553	watered-down delicious emergency margarita	2	awesome	
+8554	lousy irresponsibly strong vintage smart drink	7	decent	
 8555	a ten-percent bonus	0		
 8556	gray pulsating Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8448,7 +8448,7 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	spirit-forward drinkable huge bottle of Amontillado	5	good	Last Available: "2015-09"
+8578	drinkable spirit-forward huge bottle of Amontillado	5	good	Last Available: "2015-09"
 8579	perfectly mixed barrel-aged martini	3	EPIC	Last Available: "2015-09"
 8580	bland half-sized skewed barrel pickle	2	decent	Last Available: "2015-09"
 8581	spoiled barrel cracker	4	crappy	Last Available: "2015-09"
@@ -8477,7 +8477,7 @@
 8604	irradiated wet bouncing cuppa Nas tea	0		Effect: "Egg-stortionary Tactics", Effect Duration: 31, Last Available: "2015-09"
 8605	activated unsweetened quantum cuppa Improprie tea	0		Effect: "Void Between the Stars", Effect Duration: 60, Last Available: "2015-09"
 8606	flattened ionized bouncing cuppa Frost tea	0		Effect: "Hopped Up on Goofballs", Effect Duration: 22, Last Available: "2015-09"
-8607	triple-altered polarized alkaline narrow maroon cuppa Toast tea	0		Effect: "Video Game Hot Dog", Effect Duration: 40, Last Available: "2015-09"
+8607	triple-altered polarized alkaline maroon narrow cuppa Toast tea	0		Effect: "Video Game Hot Dog", Effect Duration: 40, Last Available: "2015-09"
 8608	moist pulsating cuppa Net tea	0		Effect: "Wintry Breath", Effect Duration: 48, Last Available: "2015-09"
 8609	unsweetened polymerized pulsating cuppa Proprie tea	0		Effect: "Hyphemariffic", Effect Duration: 63, Last Available: "2015-09"
 8610	super-galvanized cuppa Morbidi tea	0		Effect: "Smelly Pants", Effect Duration: 43, Last Available: "2015-09"
@@ -8489,11 +8489,11 @@
 8616	diffused dry spinning cuppa Neuroplastici tea	0		Effect: "Hagg-ard", Effect Duration: 14, Last Available: "2015-09"
 8617	colloidal squat cuppa Dexteri tea	0		Effect: "Boilermade", Effect Duration: 33, Last Available: "2015-09"
 8618	triple-wet cuppa Flexibili tea	0		Effect: "Capricorn Rising", Effect Duration: 56, Last Available: "2015-09"
-8619	quantum tarnished bouncing squat blurry cuppa Impregnabili tea	0		Effect: "damage.enh", Effect Duration: 57, Last Available: "2015-09"
+8619	quantum tarnished bouncing blurry squat cuppa Impregnabili tea	0		Effect: "damage.enh", Effect Duration: 57, Last Available: "2015-09"
 8620	corrupted cuppa Obscuri tea	0		Effect: "Bilious Briskness", Effect Duration: 50, Last Available: "2015-09"
 8621	oxidized gray cuppa Irritabili tea	0		Effect: "Tearful, Fearful", Effect Duration: 57, Last Available: "2015-09"
 8622	activated cuppa Mediocri tea	0		Effect: "Eye of the Lihc", Effect Duration: 29, Last Available: "2015-09"
-8623	quadruple-corrupted tumbling upside-down cuppa Loyal tea	0		Effect: "Musky", Effect Duration: 38, Last Available: "2015-09"
+8623	quadruple-corrupted upside-down tumbling cuppa Loyal tea	0		Effect: "Musky", Effect Duration: 38, Last Available: "2015-09"
 8624	denatured cuppa Activi tea	1	good	Last Available: "2015-09"
 8625	modified spinning cuppa Cruel tea	1		Last Available: "2015-09"
 8626	modified tarnished cuppa Alacri tea	0		Effect: "Phairly Balanced", Effect Duration: 29, Last Available: "2015-09"
@@ -8503,7 +8503,7 @@
 8630	colloidal fuchsia cuppa Twen tea	0		Effect: "Action", Effect Duration: 61, Last Available: "2015-09"
 8631	irradiated cuppa Gill tea	0		Effect: "Takin' It Greasy", Effect Duration: 60, Last Available: "2015-09"
 8632	corrupted blue shaking cuppa Uncertain tea	0		Effect: "Full of Wist", Effect Duration: 33, Last Available: "2015-09"
-8633	squat tumbling cuppa Voraci tea	0		Last Available: "2015-09"
+8633	tumbling squat cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
 8636	warmed cuppa Craft tea	0		Effect: "Flagrantly Fragrant", Effect Duration: 36, Last Available: "2015-09"
@@ -8511,7 +8511,7 @@
 8638	aromatic sizzling Royal scepter of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	decent immense bowl of eyeballs	7	good	Last Available: "2015-10"
+8641	immense decent bowl of eyeballs	7	good	Last Available: "2015-10"
 8642	decent bowl of mummy guts	3	good	Last Available: "2015-10"
 8643	adequate bowl of maggots	4	good	Last Available: "2015-10"
 8644	lousy high-proof wobbly blood and blood	10	decent	Last Available: "2015-10"
@@ -8566,13 +8566,13 @@
 8693	narrow hotel minibar key	0		Last Available: "2015-11"
 8694	yellow ice hotel bell	0		Last Available: "2015-11"
 8695	teal Martialest Arts trophy	0		Last Available: "2016-01"
-8696	dried squat tumbling tumbling medicinal herbs	1		Last Available: "2016-01"
+8696	dried tumbling squat tumbling medicinal herbs	1		Last Available: "2016-01"
 8697	decent ice rice	3	good	Last Available: "2016-01"
 8698	acceptable green iced plum wine	3	good	Last Available: "2016-01"
 8699	mirror flame-retardant energetic wicked training belt	0		Spell Damage: +5, Maximum MP Percent: +20, Hot Resistance: +1, Single Equip, Last Available: "2016-01"
 8700	spinning aromatic clever arcane researcher's training legwarmers	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Stench Resistance: +1, Single Equip, Last Available: "2016-01"
 8701	Da Vinci's supercool training helmet of the sweet-tooth	0		Moxie Percent: +20, Experience (Mysticality): +5, Candy Drop: +100, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
-8702	bouncing squat training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
+8702	squat bouncing training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
@@ -8583,10 +8583,10 @@
 8710	twisted upside-down abstraction: sensation	1		Last Available: "2015-12"
 8711	compressed blurry abstraction: purpose	1		Effect: "Abyssal Tears", Effect Duration: 15, Last Available: "2015-12"
 8712	denatured yellow abstraction: category	1		Last Available: "2015-12"
-8713	vaporized bouncing olive skewed abstraction: perception	1		Effect: "Mercenary", Effect Duration: 10, Last Available: "2015-12"
+8713	vaporized bouncing skewed olive abstraction: perception	1		Effect: "Mercenary", Effect Duration: 10, Last Available: "2015-12"
 8714	altered red abstraction: motion	1		Last Available: "2015-12"
 8715	distilled huge abstraction: joy	1		Last Available: "2015-12"
-8716	mixed pulsating blinking abstraction: certainty	1		Effect: "Sleaze-Resistant Trousers", Effect Duration: 10, Last Available: "2015-12"
+8716	mixed blinking pulsating abstraction: certainty	1		Effect: "Sleaze-Resistant Trousers", Effect Duration: 10, Last Available: "2015-12"
 8717	pickled spinning teal abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	yummy miniature VYKEA meatballs	2	awesome	Last Available: "2015-11"
@@ -8601,18 +8601,18 @@
 8728	ghostly VYKEA dowel	0		Last Available: "2015-11"
 8729	perfumed hardy VYKEA hex key of the cheetah	0		Maximum HP: +50, Stench Resistance: +5, Initiative: +60, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	normal big skewed tin of submardines	5	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	practically non-alcoholic aged bottle of norwhiskey	1	awesome	Last Available: "2015-11"
+8731	big normal skewed tin of submardines	5	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	aged practically non-alcoholic bottle of norwhiskey	1	awesome	Last Available: "2015-11"
 8733	vaporized teal tumbling octolus oculus	1	awesome	Effect: "Donho's Bubbly Ballad", Effect Duration: 40, Last Available: "2015-11"
 8734	mirror Sinatra's sage beefcake's sardine can key	0		Muscle: +25, Mysticality Percent: +10, Experience (Moxie): +5, Last Available: "2015-11"
 8735	wool smelly rosy-cheeked norwhal helmet	0		Maximum HP Percent: +30, Stench Spell Damage: +10, Cold Resistance: +1, Last Available: "2015-11", Familiar Effect: "atk"
 8736	chilly Oprah's ruddy octolus-skin cloak	0		Maximum HP Percent: +40, Maximum MP Percent: +50, Cold Damage: +5, Last Available: "2015-11"
 8737	drinkable triple-distilled perfect cosmopolitan	9	good	Last Available: "2015-11"
-8738	practically non-alcoholic hand-crafted perfect negroni	1	super ultra mega turbo EPIC	Last Available: "2015-11"
+8738	hand-crafted practically non-alcoholic perfect negroni	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8739	hand-crafted weak perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
-8740	weak perfectly mixed blurry perfect mimosa	2	super ultra EPIC	Last Available: "2015-11"
+8740	perfectly mixed weak blurry perfect mimosa	2	super ultra EPIC	Last Available: "2015-11"
 8741	acceptable strong perfect old-fashioned	5	good	Last Available: "2015-11"
-8742	watered-down mediocre perfect paloma	2	decent	Last Available: "2015-11"
+8742	mediocre watered-down perfect paloma	2	decent	Last Available: "2015-11"
 8743	Vulcanized irradiated That 70s Cologne	0		Effect: "Mental A-cue-ity", Effect Duration: 25, Last Available: "2015-11"
 8744	ionized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Chlorophyll Flavor", Effect Duration: 58, Last Available: "2015-11"
 8745	aerosolized improved oxidized Puffstone cigar	0		Effect: "Spirit Bubble", Effect Duration: 49, Last Available: "2015-11"
@@ -8646,8 +8646,8 @@
 8773	sharpshooter's savvy reusable shopping bag of the sweet-tooth	0		Mysticality Percent: +20, Critical Hit Percent: +10, Candy Drop: +100, Last Available: "2015-12"
 8775	arcane researcher's coarse hemp socks	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2015-12"
 8776	armband	0		Item Drop: +5, Single Equip, Last Available: "2015-12"
-8777	pulsating red bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
-8778	mirror upside-down nuclear stockpile	0		Last Available: "2015-12"
+8777	red pulsating bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
+8778	upside-down mirror nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
 8781	gravedigger's pine cone necklace	0		Spooky Damage: +10, Last Available: "2015-12"
@@ -8677,7 +8677,7 @@
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	blurry blinking high-grade explosives	0		Last Available: "2017-01"
 8807	blurry experimental gene therapy	0		Last Available: "2017-01"
-8808	spinning tumbling ultracoagulator	0		Last Available: "2017-01"
+8808	tumbling spinning ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	olive confidence-building hug	0		Last Available: "2017-01"
@@ -8686,12 +8686,12 @@
 8814	squat Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bouncing bat-bearing	0		Last Available: "2017-01"
 8816	normal Kudzu salad	3	good	Last Available: "2016-12"
-8817	dehydrated olive blinking wobbly Mansquito Serum	1		Last Available: "2016-12"
-8818	drinkable weak huge Miss Graves' vermouth	2	good	Last Available: "2016-12"
+8817	dehydrated blinking olive wobbly Mansquito Serum	1		Last Available: "2016-12"
+8818	weak drinkable huge Miss Graves' vermouth	2	good	Last Available: "2016-12"
 8819	adequate The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	vaporized The Author's ink	1		Last Available: "2016-02"
 8821	lousy spinning The Mad Liquor	3	decent	Last Available: "2016-12"
-8822	practically non-alcoholic acceptable mirror tumbling Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
+8822	acceptable practically non-alcoholic mirror tumbling Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
 8823	normal Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	modified teal The Inquisitor's unidentifiable object	1		Effect: "Space Cowboy", Effect Duration: 35, Last Available: "2016-12"
 8825	jittery toasty hardened forbidden The Jokester's gun	0		Spell Damage Percent: +50, Damage Reduction: 3, Hot Damage: +5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
@@ -8702,17 +8702,17 @@
 8830	ghostly battoo kit	0		Last Available: "2016-12"
 8831	skewed basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
-8833	vacuum-sealed anodized pulsating maroon robin's egg	0		Effect: "Gleaming White Teeth", Effect Duration: 30, Last Available: "2016-12"
+8833	vacuum-sealed anodized maroon pulsating robin's egg	0		Effect: "Gleaming White Teeth", Effect Duration: 30, Last Available: "2016-12"
 8834	tasty robin flan	3	awesome	Last Available: "2016-12"
-8835	delicious weak tumbling robin nog	2	awesome	Last Available: "2016-12"
+8835	weak delicious tumbling robin nog	2	awesome	Last Available: "2016-12"
 8836	upside-down LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	pulsating exploding gum	0		
-8839	tumbling pulsating root beer barrel	0		
+8839	pulsating tumbling root beer barrel	0		
 8840	altered frozen tumbling Kudzu slaw	0		Effect: "Human-Penguin Hybrid", Effect Duration: 53
 8841	adjusted Mansquito's blood	0		Effect: "Vital", Effect Duration: 31
 8842	unsweetened super-quantum spinning infrablack lipstick	0		Effect: "Florid Cheeks", Effect Duration: 58
-8843	quadruple-dry aerosolized denatured twirling upside-down can of drain cleaner	0		Effect: "Bottle in front of Me", Effect Duration: 26
+8843	quadruple-dry aerosolized denatured upside-down twirling can of drain cleaner	0		Effect: "Bottle in front of Me", Effect Duration: 26
 8844	triple-magnetized electrified The Author's inkwell	0		Effect: "Super-Electrified", Effect Duration: 39
 8845	dry magnetized bag of random words	0		Effect: "Ichorous Intensity", Effect Duration: 36
 8846	energized shaking tube of pendulum lube	0		Effect: "Tomato Power", Effect Duration: 41
@@ -8747,13 +8747,13 @@
 8875	blurry squat frosty wholesome Shrub's Premium Baked Beans of chilblains	0		Maximum HP Percent: +10, Cold Damage: +25, Cold Spell Damage: +10, Last Available: "2016-02"
 8876	yummy upside-down plate of Heimz Fortified Kidney Beans	3	awesome	Last Available: "2016-02"
 8877	adequate wobbly plate of Tesla's Electroplated Beans	3	good	Last Available: "2016-02"
-8878	adequate half-sized special tumbling squat plate of Mixed Garbanzos and Chickpeas	2	good	Effect: "Tea-hee", Effect Duration: 10, Last Available: "2016-02"
+8878	special adequate half-sized tumbling squat plate of Mixed Garbanzos and Chickpeas	2	good	Effect: "Tea-hee", Effect Duration: 10, Last Available: "2016-02"
 8879	low-calorie bland plate of Hellfire Spicy Beans	1	decent	Last Available: "2016-02"
-8880	enchanted small flavorless plate of Frigid Northern Beans	2	decent	Effect: "Spooky Flavor", Effect Duration: 5, Last Available: "2016-02"
+8880	small enchanted flavorless plate of Frigid Northern Beans	2	decent	Effect: "Spooky Flavor", Effect Duration: 5, Last Available: "2016-02"
 8881	normal plate of World's Blackest-Eyed Peas	4	good	Last Available: "2016-02"
-8882	decent small huge plate of Trader Olaf's Exotic Stinkbeans	2	good	Last Available: "2016-02"
+8882	small decent huge plate of Trader Olaf's Exotic Stinkbeans	2	good	Last Available: "2016-02"
 8883	delicious plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	awesome	Last Available: "2016-02"
-8884	super-sized fancy bland plate of Val-U Brand Every Bean Salad	5	decent	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2016-02"
+8884	bland fancy super-sized plate of Val-U Brand Every Bean Salad	5	decent	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2016-02"
 8885	flavorless blinking plate of Shrub's Premium Baked Beans	4	decent	Last Available: "2016-02"
 8886	prompt grievous Fancy Jeff's pocket square	0		Weapon Damage Percent: +50, Adventures: +3, Last Available: "2016-02"
 8887	huge vibrating curative Daisy's unclean bloomers of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
@@ -8766,7 +8766,7 @@
 8894	blinking zippy Jeselnik's gravedigger's Granny Hackleton's Gatling gun	0		Spooky Damage: +10, Sleaze Damage: +25, Initiative: +20, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
-8897	oxidized electrified twirling purple poker face paint	0		Effect: "Crimbo Nostalgia", Effect Duration: 62, Last Available: "2016-02"
+8897	oxidized electrified purple twirling poker face paint	0		Effect: "Crimbo Nostalgia", Effect Duration: 62, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	crappy	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
@@ -8777,7 +8777,7 @@
 8905	yummy gray bear claw	4	awesome	Last Available: "2016-02"
 8906	extra-pressed extra-activated narrow rattler gland	0		Effect: "Mariachi Mood", Effect Duration: 35, Last Available: "2016-02"
 8907	ionized teal half-digested coal	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 54, Last Available: "2016-02"
-8908	moist moist yellow pulsating mirror tightly-wound spine	0		Effect: "Wolf's Bane", Effect Duration: 15, Last Available: "2016-02"
+8908	moist moist mirror yellow pulsating tightly-wound spine	0		Effect: "Wolf's Bane", Effect Duration: 15, Last Available: "2016-02"
 8909	rotten upside-down rotting beefsteak	3	crappy	Last Available: "2016-02"
 8910	drinkable boozy firemilk	5	good	Last Available: "2016-02"
 8911	Vulcanized dry bouncing spidercow eye-cluster	0		Effect: "Vented Spleen", Effect Duration: 61, Last Available: "2016-02"
@@ -8806,14 +8806,14 @@
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	fuchsia porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	twirling purple hamethyst-handled sixgun	0		Last Available: "2016-02"
-8937	upside-down squat mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
+8937	squat upside-down mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	jittery grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	pulsating diamondback skin	0		Last Available: "2016-02"
 8940	coal snakeskin	0		Last Available: "2016-02"
-8941	purple blurry frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
+8941	blurry purple frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	maroon rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
-8944	fuchsia twirling rhinestone cowhorn	0		Familiar Weight: +5
+8944	twirling fuchsia rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
@@ -8826,7 +8826,7 @@
 8954	special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
-8957	gray shaking Tales of the West: Snake Oiling	0		
+8957	shaking gray Tales of the West: Snake Oiling	0		
 8958	briefcase full of snakes	0		
 8959	wobbly supercharged one-gallon hat of the storm	0		Maximum MP Percent: 70
 8960	aromatic two-gallon hat of the ox	0		Muscle: +20, Stench Resistance: +1
@@ -8841,7 +8841,7 @@
 8969	spinning up-at-dawn asbestos-lined eleven-gallon hat	0		Hot Resistance: +5, Adventures: +5
 8970	toy sixgun	0		
 8971	snake oil	0		
-8972	extra-adjusted concentrated ghostly huge skin oil	0		Effect: "Educated (Kinda)", Effect Duration: 61
+8972	extra-adjusted concentrated huge ghostly skin oil	0		Effect: "Educated (Kinda)", Effect Duration: 61
 8973	galvanized triple-alkaline squat unusual oil	0		Effect: "Quadrilled", Effect Duration: 16
 8974	liquefied electrified frozen eldritch oil	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 21
 8975	exclusive club	0		
@@ -8850,8 +8850,8 @@
 8978	activated quadruple-improved maroon patent aggression tonic	0		Effect: "Thunderheart", Effect Duration: 36
 8979	triple-moist narrow patent sallowness tonic	0		Effect: "Buzzard Breath", Effect Duration: 24
 8980	modified upside-down patent avarice tonic	0		Effect: "Shot in the Arse", Effect Duration: 35
-8981	boiled blurry huge patent alacrity tonic	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 54
-8982	polarized chilled narrow blue corrupted marrow	0		Effect: "Tomato Power", Effect Duration: 26
+8981	boiled huge blurry patent alacrity tonic	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 54
+8982	polarized chilled blue narrow corrupted marrow	0		Effect: "Tomato Power", Effect Duration: 26
 8983	tolerable rodeo whiskey	3	good	
 8984	Thwaitgold scorpion statuette	0		
 8985	scandalous real cowboy hat	0		Sleaze Damage: +5
@@ -8888,23 +8888,23 @@
 9016	squat disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
-9019	mirror spinning pulsating purple meme generator	0		Last Available: "2016-05"
+9019	spinning purple pulsating mirror meme generator	0		Last Available: "2016-05"
 9020	blue plus one	0		Last Available: "2016-05"
-9021	enchanted spoiled huge gallon of milk	9	crappy	Effect: "Woad Warrior", Effect Duration: 35, Last Available: "2016-05"
+9021	huge spoiled enchanted gallon of milk	9	crappy	Effect: "Woad Warrior", Effect Duration: 35, Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
-9023	green blinking screencapped monster	0		Last Available: "2016-05"
+9023	blinking green screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
 9025	infinite BACON machine	0		Last Available: "2016-05"
 9026	First Post shirt package	0		Last Available: "2016-05"
 9027	bouncing yellow wholesome First Post shirt - Cir Senam of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Maximum HP Percent: +10, Last Available: "2016-05"
-9028	squat shaking high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
+9028	shaking squat high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
 9030	bland yellow star salad	4	decent	
 9031	shaking Thwaitgold moth statuette	0		
-9032	small stale bowl of Tastee-Wheet&trade;	2	decent	
+9032	stale small bowl of Tastee-Wheet&trade;	2	decent	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	pulsating Source essence	0		Last Available: "2016-06"
-9035	toothsome massive browser cookie	7	awesome	Last Available: "2016-06"
+9035	massive toothsome browser cookie	7	awesome	Last Available: "2016-06"
 9036	delicious bouncing hacked gibson	3	awesome	Last Available: "2016-06"
 9037	hale Source shades	0		Maximum HP: +20, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8932,8 +8932,8 @@
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	ghostly Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	mirror Source terminal file: gram.ext	0		Last Available: "2016-06"
-9063	huge narrow squat Source terminal file: spam.ext	0		Last Available: "2016-06"
-9064	shaking maroon Source terminal file: cram.ext	0		Last Available: "2016-06"
+9063	narrow huge squat Source terminal file: spam.ext	0		Last Available: "2016-06"
+9064	maroon shaking Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	shaking jittery pill	0		Last Available: "2016-06"
@@ -8988,7 +8988,7 @@
 9116	blinking time residue	0		Last Available: "2016-09"
 9117	repaid diaper	0		Item Drop: +5
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	delicious triple-distilled Shot of Kardashian Gin	6	awesome	Last Available: "2016-09"
+9119	triple-distilled delicious Shot of Kardashian Gin	6	awesome	Last Available: "2016-09"
 9120	blinking Unstable Pointy Ears of the detective	0		Item Drop: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	blinking Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	enchanted Tea, Earl Grey, Hot	1	decent	Effect: "Fishily Speeding", Effect Duration: 40, Last Available: "2016-09"
@@ -8998,19 +8998,19 @@
 9126	artisanal unidentified drink	3	EPIC	
 9127	blinking therapeutic KoL Con 13 T-shirt of the boozehound	0		Booze Drop: +100, HP Regen Min: 5, HP Regen Max: 7
 9128	twirling family-friendly manspreader's discarded swimming trunks of wisdom	0		Mysticality: +15, Monster Level: +10, Sleaze Resistance: +1
-9129	non-oxidized jittery purple spinning diluted makeup	0		Effect: "Dweeby", Effect Duration: 28
+9129	non-oxidized purple spinning jittery diluted makeup	0		Effect: "Dweeby", Effect Duration: 28
 9130	warmed super-concentrated charisma potion	0		Effect: "Mercenary", Effect Duration: 39
 9131	squat extremely confusing manual	0		
 9132	pistol of wisdom of incineration	0		Mysticality: +15, Hot Spell Damage: +50
 9133	wobbly KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	super-sized adequate leftover pasty	5	good	
+9134	adequate super-sized leftover pasty	5	good	
 9135	hand-crafted spinning very whiskey	3	EPIC	
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	blinking li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	upside-down shaking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	shaking upside-down li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9142	blinking li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9144	blurry li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
@@ -9028,9 +9028,9 @@
 9156	flavorless raw cranberry sauce	3	decent	Last Available: "2016-11"
 9157	delicious squat raw turkey	3	awesome	Last Available: "2016-11"
 9158	normal green raw mincemeat	4	good	Last Available: "2016-11"
-9159	miniature toothsome raw potato	2	awesome	Last Available: "2016-11"
+9159	toothsome miniature raw potato	2	awesome	Last Available: "2016-11"
 9160	bland raw gravy	3	decent	Last Available: "2016-11"
-9161	spoiled jumbo enchanted raw bread	5	crappy	Effect: "Hagg-ard", Effect Duration: 25, Last Available: "2016-11"
+9161	enchanted spoiled jumbo raw bread	5	crappy	Effect: "Hagg-ard", Effect Duration: 25, Last Available: "2016-11"
 9162	squat coward's mini-marshmallow dispenser of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Last Available: "2016-11"
 9163	red lard-coated baleful weightlifter's glass casserole dish	0		Muscle: +15, Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9044,13 +9044,13 @@
 9172	stale small bouncing bean casserole	2	decent	Last Available: "2016-11"
 9173	bland baked stuffing	3	decent	Last Available: "2016-11"
 9174	big yummy cranberry cylinder	5	awesome	Last Available: "2016-11"
-9175	adequate diet thanksgiving turkey	1	good	Last Available: "2016-11"
-9176	huge moldy bouncing mince pie	8	crappy	Last Available: "2016-11"
+9175	diet adequate thanksgiving turkey	1	good	Last Available: "2016-11"
+9176	moldy huge bouncing mince pie	8	crappy	Last Available: "2016-11"
 9177	tasty ghostly mashed potatoes	4	awesome	Last Available: "2016-11"
 9178	toothsome gigantic warm gravy	8	awesome	Last Available: "2016-11"
-9179	adequate snack-sized mirror narrow bread roll	2	good	Last Available: "2016-11"
+9179	snack-sized adequate mirror narrow bread roll	2	good	Last Available: "2016-11"
 9180	spoiled leftovers	3	crappy	Last Available: "2016-11"
-9181	enchanted delicious blinking leftovers sandwich	3	awesome	Effect: "Tin, Man", Effect Duration: 45, Last Available: "2016-11"
+9181	delicious enchanted blinking leftovers sandwich	3	awesome	Effect: "Tin, Man", Effect Duration: 45, Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	twirling megacopia	0		Last Available: "2016-11"
@@ -9064,7 +9064,7 @@
 9192	artisanal eldritch extract	3	EPIC	Last Available: "2016-11"
 9193	pulsating flame-retardant curative Official Council Aide Pin	0		Hot Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
 9194	boozy perfectly mixed blue eldritch distillate	5	EPIC	Last Available: "2016-11"
-9195	distilled cyan jittery eldritch essence	1		Effect: "Chief Executive Optimism", Effect Duration: 40, Last Available: "2016-11"
+9195	distilled jittery cyan eldritch essence	1		Effect: "Chief Executive Optimism", Effect Duration: 40, Last Available: "2016-11"
 9196	pulsating Science Notebook of the early riser	0		Adventures: +7
 9197	maroon wool dangerous eldritch hat of James Dean	0		Experience (Moxie): +3, Weapon Damage: +10, Cold Resistance: +1, Last Available: "2016-11"
 9198	wobbly asbestos-lined eldritch pants of Leguizamo of the early riser	0		Monster Level: +20, Hot Resistance: +5, Adventures: +7, Last Available: "2016-11"
@@ -9072,7 +9072,7 @@
 9200	sage Quartet of Flare Masters Jacket of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	pulsating squat Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	squat pulsating Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	bouncing counterfeit city	0		Last Available: "2016-12"
 9205	fuchsia sprinkles	0		Last Available: "2016-12"
 9206	huge blinking The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
@@ -9089,7 +9089,7 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	stale animal part cracker	3	decent	Last Available: "2016-12"
-9220	practically non-alcoholic perfectly mixed gingerbread wine	1	super ultra EPIC	Last Available: "2016-12"
+9220	perfectly mixed practically non-alcoholic gingerbread wine	1	super ultra EPIC	Last Available: "2016-12"
 9221	decent gingerbread mug	4	good	Last Available: "2016-12"
 9222	blurry strapping gingerbread mask	0		Muscle: +5, Last Available: "2016-12"
 9223	twirling yellow bouncing Sherlock's beefcake's gingerservo of Tarzan	0		Muscle: +25, Experience (Muscle): +3, Item Drop: +25, Single Equip, Last Available: "2016-12"
@@ -9112,7 +9112,7 @@
 9240	skewed spare chocolate parts	0		Last Available: "2016-12"
 9241	quantum industrial frosting	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 57, Last Available: "2016-12"
 9242	polymerized fake cocktail	0		Effect: "Trash-Wrapped", Effect Duration: 39, Last Available: "2016-12"
-9243	acceptable practically non-alcoholic high-end ginger wine	1	good	Last Available: "2016-12"
+9243	practically non-alcoholic acceptable high-end ginger wine	1	good	Last Available: "2016-12"
 9244	plastic bad vibe of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2016-12"
 9245	blue rosewater-soaked plastic angry vikings	0		Stench Resistance: +3, Last Available: "2016-12"
 9246	sinister plastic Knows About Chakras	0		Spell Damage: +10, Last Available: "2016-12"
@@ -9144,10 +9144,10 @@
 9272	negative lump	0		
 9273	olive stanky steel-toed Third Eye	0		Damage Reduction: 9, Stench Spell Damage: +25, Last Available: "2016-12"
 9274	medical-grade educational Krampus Horn	0		Experience: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2016-12"
-9275	huge decent twirling hambrosier	10	good	Last Available: "2016-12"
+9275	decent huge twirling hambrosier	10	good	Last Available: "2016-12"
 9276	perfectly mixed jittery mirror chakra-mental wine	4	EPIC	Last Available: "2016-12"
 9277	moist chakra malt	0		Effect: "Thick-Skinned", Effect Duration: 60, Last Available: "2016-12"
-9278	super-sized decent Black Angus blackburger	5	good	Last Available: "2016-12"
+9278	decent super-sized Black Angus blackburger	5	good	Last Available: "2016-12"
 9279	bad brandy	3	decent	Last Available: "2016-12"
 9280	diffused potion of spiritual gunkifying	0		Effect: "Vitali Tea", Effect Duration: 67, Last Available: "2016-12"
 9281	groovy bad vibroknife of Flo-Jo	0		Moxie Percent: +10, Initiative: +100, Last Available: "2016-12"
@@ -9166,10 +9166,10 @@
 9294	twisted spinning sleaze jelly	1		Last Available: "2017-01"
 9295	vaporized wobbly stench jelly	1		Last Available: "2017-01"
 9296	huge space planula	0		Free Pull, Last Available: "2017-01"
-9297	adequate bouncing fuchsia toast with hot jelly	3	good	Last Available: "2017-01"
+9297	adequate fuchsia bouncing toast with hot jelly	3	good	Last Available: "2017-01"
 9298	normal toast with jelly	4	good	Last Available: "2017-01"
 9299	spoiled toast with jelly	4	crappy	Last Available: "2017-01"
-9300	spoiled fuchsia jittery toast with sleaze jelly	3	crappy	Last Available: "2017-01"
+9300	spoiled jittery fuchsia toast with sleaze jelly	3	crappy	Last Available: "2017-01"
 9301	big decent toast with stench jelly	5	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9178,7 +9178,7 @@
 9306	flame-retardant mansplainer's candle	0		Monster Level: +15, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2017-01"
 9307	adequate wax pancake	4	good	Last Available: "2017-01"
 9308	squat shellacked quilted wax face	0		Damage Absorption: +40, Damage Reduction: 7, Last Available: "2017-01"
-9309	enchanted smooth blurry wax booze	4	awesome	Effect: "Frozen Shoulders", Effect Duration: 40, Last Available: "2017-01"
+9309	smooth enchanted blurry wax booze	4	awesome	Effect: "Frozen Shoulders", Effect Duration: 40, Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	altered green jittery sea jelly	1		Last Available: "2017-01"
 9312	rotten sea truffle	3	crappy	Last Available: "2017-01"
@@ -9192,9 +9192,9 @@
 9320	personal trainer's LOV Eardigan of the brute of the bloodbag	0		Muscle Percent: +30, Experience Percent (Muscle): +10, Maximum HP: +100, Lasts Until Rollover, Last Available: "2017-02"
 9321	wobbly LOV Epaulettes of the cougar of dire peril of bravery	0		Moxie: +20, Weapon Damage: +20, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2017-02"
 9322	huge upside-down stylish thinker's LOV Earrings of Gandalf	0		Mysticality: +10, Moxie: +25, Spell Critical Percent: +20, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
-9323	huge gray LOV Enamorang	0		Last Available: "2017-02"
+9323	gray huge LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
-9325	upside-down olive LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
+9325	olive upside-down LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	distilled LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	jittery thinker's LOV Elephant	0		Mysticality: +10, Damage Reduction: 6, Last Available: "2017-02"
 9328	jittery eldritch scanner of the pedagogue	0		Experience: +3, Last Available: "2017-02"
@@ -9234,46 +9234,46 @@
 9362	tumbling pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	blinking pulsating imaginary lemon	0		Last Available: "2017-03"
-9365	acceptable weak literal grasshopper	2	good	Last Available: "2017-03"
+9365	weak acceptable literal grasshopper	2	good	Last Available: "2017-03"
 9366	aged triple-distilled double entendre	10	awesome	Last Available: "2017-03"
 9367	watered-down acceptable Phlegethon	2	good	Last Available: "2017-03"
 9368	artisanal Siberian sunrise	3	EPIC	Last Available: "2017-03"
-9369	hand-crafted watered-down mentholated wine	2	EPIC	Last Available: "2017-03"
-9370	mediocre practically non-alcoholic low tide martini	1	decent	Last Available: "2017-03"
+9369	watered-down hand-crafted mentholated wine	2	EPIC	Last Available: "2017-03"
+9370	practically non-alcoholic mediocre low tide martini	1	decent	Last Available: "2017-03"
 9371	weak bad shroomtini	2	decent	Last Available: "2017-03"
-9372	bad weak morning dew	2	decent	Last Available: "2017-03"
+9372	weak bad morning dew	2	decent	Last Available: "2017-03"
 9373	mediocre whiskey squeeze	3	decent	Last Available: "2017-03"
-9374	watered-down tolerable great fashioned	2	good	Last Available: "2017-03"
+9374	tolerable watered-down great fashioned	2	good	Last Available: "2017-03"
 9375	bad triple-distilled Gnomish sagngria	7	decent	Last Available: "2017-03"
 9376	drinkable squat vodka stinger	3	good	Last Available: "2017-03"
 9377	fortified tolerable extremely slippery nipple	5	good	Last Available: "2017-03"
 9378	lousy weak lime green piscatini	2	decent	Last Available: "2017-03"
-9379	artisanal practically non-alcoholic Churchill	1	EPIC	Last Available: "2017-03"
+9379	practically non-alcoholic artisanal Churchill	1	EPIC	Last Available: "2017-03"
 9380	special acceptable soilzerac	3	good	Effect: "Dexteri Tea", Effect Duration: 10, Last Available: "2017-03"
 9381	high-proof tolerable London frog	6	good	Last Available: "2017-03"
 9382	artisanal practically non-alcoholic nothingtini	1	EPIC	Last Available: "2017-03"
 9383	mediocre distilled eighth plague	5	decent	Last Available: "2017-03"
 9384	mediocre practically non-alcoholic single entendre	1	decent	Last Available: "2017-03"
-9385	watered-down mediocre reverse Tantalus	2	decent	Last Available: "2017-03"
-9386	strong smooth elemental caipiroska	5	awesome	Last Available: "2017-03"
+9385	mediocre watered-down reverse Tantalus	2	decent	Last Available: "2017-03"
+9386	smooth strong elemental caipiroska	5	awesome	Last Available: "2017-03"
 9387	lousy Feliz Navidad	4	decent	Last Available: "2017-03"
 9388	lousy Bloody Nora	4	decent	Last Available: "2017-03"
-9389	drinkable watered-down moreltini	2	good	Last Available: "2017-03"
+9389	watered-down drinkable moreltini	2	good	Last Available: "2017-03"
 9390	tolerable hell in a bucket	4	good	Last Available: "2017-03"
 9391	acceptable practically non-alcoholic Newark	1	good	Last Available: "2017-03"
-9392	weak lousy enchanted R'lyeh	2	decent	Effect: "Slimy Hands", Effect Duration: 40, Last Available: "2017-03"
+9392	weak enchanted lousy R'lyeh	2	decent	Effect: "Slimy Hands", Effect Duration: 40, Last Available: "2017-03"
 9393	drinkable Gnollish sangria	3	good	Last Available: "2017-03"
 9394	acceptable vodka barracuda	3	good	Last Available: "2017-03"
 9395	lousy Mysterious Island iced tea	4	decent	Last Available: "2017-03"
 9396	mediocre mirror drive-by shooting	3	decent	Last Available: "2017-03"
 9397	special mediocre practically non-alcoholic narrow gunner's daughter	1	decent	Effect: "Rootin' Around", Effect Duration: 35, Last Available: "2017-03"
-9398	fancy delicious dirt julep	4	awesome	Effect: "Low on the Hog", Effect Duration: 5, Last Available: "2017-03"
-9399	lousy watered-down bouncing upside-down maroon Simepore slime	2	decent	Last Available: "2017-03"
+9398	delicious fancy dirt julep	4	awesome	Effect: "Low on the Hog", Effect Duration: 5, Last Available: "2017-03"
+9399	watered-down lousy bouncing upside-down maroon Simepore slime	2	decent	Last Available: "2017-03"
 9400	hand-crafted Phil Collins	4	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
-9404	blurry upside-down Spacegate access badge	0		Free Pull, Last Available: "2017-04"
+9404	upside-down blurry Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	jittery exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9347,7 +9347,7 @@
 9475	glitched malware	0		Last Available: "2025-12"
 9476	magnetized Spant eggs	0		Effect: "Floundering", Effect Duration: 62
 9477	olive Spacegate (open)	0		Lasts Until Rollover
-9478	squat narrow New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
+9478	narrow squat New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	pressed magnetized upside-down mirror Daily Affirmation: Always be Collecting	0		Effect: "World's Shortest Giant", Effect Duration: 44, Last Available: "2017-05"
 9480	deionized frozen jittery Daily Affirmation: Think Win-Lose	0		Effect: "Vitamin-Maxed", Effect Duration: 49, Last Available: "2017-05"
 9481	aerosolized super-anodized bouncing Daily Affirmation: Be Superficially interested	0		Effect: "Mathematically Precise", Effect Duration: 11, Last Available: "2017-05"
@@ -9383,8 +9383,8 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	blue Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	cyan Meteorite-Ade	0		Last Available: "2017-08"
-9514	low-calorie toothsome squat meteoreo	1	awesome	Last Available: "2017-08"
-9515	acceptable watered-down meadeorite	2	good	Last Available: "2017-08"
+9514	toothsome low-calorie squat meteoreo	1	awesome	Last Available: "2017-08"
+9515	watered-down acceptable meadeorite	2	good	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	squat careful hale Samson's meteortarboard	0		Experience (Muscle): +5, Maximum HP: +20, Monster Level: -10, Last Available: "2017-08"
 9518	gravedigger's slick meteorite guard of the ox	0		Muscle: +20, Moxie: +10, Spooky Damage: +10, Damage Reduction: 9, Last Available: "2017-08"
@@ -9414,9 +9414,9 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	practically non-alcoholic perfectly mixed enchanted DUFRESNE Suds	1	EPIC	Effect: "Dilated Pupils", Effect Duration: 50, Last Available: "2017-09"
+9545	perfectly mixed enchanted practically non-alcoholic DUFRESNE Suds	1	EPIC	Effect: "Dilated Pupils", Effect Duration: 50, Last Available: "2017-09"
 9546	veiny mafia pinky ring of extreme caution	0		Maximum HP: +10, Monster Level: -25, Single Equip
-9547	artisanal extra-dry flask of port	5	EPIC	
+9547	extra-dry artisanal flask of port	5	EPIC	
 9548	censurious sinister contract enforcement stick	0		Spell Damage: +10, Sleaze Resistance: +3
 9549	normal Hide-rox&trade; cookie	3	good	Last Available: "2017-10"
 9550	boozy mediocre mirror jug of booze	5	decent	Last Available: "2017-10"
@@ -9429,7 +9429,7 @@
 9557	narrow knitted sinister pearl necklace of extreme caution	0		Spell Damage: +10, Monster Level: -25, Cold Resistance: +3, Single Equip, Last Available: "2017-10"
 9558	mirror amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
-9560	blue mirror O	0		Last Available: "2017-11"
+9560	mirror blue O	0		Last Available: "2017-11"
 9561	twirling amorphous blob	0		Last Available: "2017-11"
 9562	teal fireproof horrifying groovy protection stick of terror	0		Moxie Percent: +10, Spooky Damage: +25, Spooky Spell Damage: +10, Hot Resistance: +3
 9563	deionized altered green roll of meat	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 60
@@ -9437,7 +9437,7 @@
 9565	non-corrupted wobbly cocoa chondrule	0		Effect: "Haunted Liver", Effect Duration: 30, Last Available: "2020-09"
 9566	tumbling Usain Bolt's dangerous mafia middle finger ring	0		Weapon Damage: +10, Initiative: +80, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	stiffened thinker's steel drivin' hammer of extreme caution of the empath	0		Mysticality: +10, Damage Reduction: 1, Monster Level: -25, Familiar Weight: +5
-9568	squat wobbly piece of steel	0		
+9568	wobbly squat piece of steel	0		
 9569	vibrating dangerous mafia pointer finger ring	0		Weapon Damage: +10, Maximum MP Percent: +10, Single Equip
 9570	dog trainer's worksite credentials	0		Experience (familiar): +1, Single Equip
 9571	up-at-dawn greedy stanky Socratic negotiatin' hammer	0		Experience (Mysticality): +1, Stench Spell Damage: +25, Meat Drop: +20, Adventures: +5
@@ -9449,11 +9449,11 @@
 9577	mafia filofax	0		
 9578	fancy maroon transparent nog	1	crappy	Effect: "Mercenary", Effect Duration: 15, Last Available: "2017-12"
 9579	bland unfinished fruitcake	4	decent	Last Available: "2017-12"
-9580	adjusted triple-polarized frozen lime green skewed and cracker	0		Effect: "Empathy", Effect Duration: 43, Last Available: "2017-12"
+9580	adjusted triple-polarized frozen skewed lime green and cracker	0		Effect: "Empathy", Effect Duration: 43, Last Available: "2017-12"
 9581	mediocre ghostly neg grog	3	decent	Last Available: "2017-12"
-9582	miniature rotten half double fruitcake	2	crappy	Last Available: "2017-12"
+9582	rotten miniature half double fruitcake	2	crappy	Last Available: "2017-12"
 9583	flavorless skewed hushed puppy	3	decent	Last Available: "2017-12"
-9584	massive spoiled muffled muffuletta	8	crappy	Last Available: "2017-12"
+9584	spoiled massive muffled muffuletta	8	crappy	Last Available: "2017-12"
 9585	bland low-calorie shushed potatoes	1	decent	Last Available: "2017-12"
 9586	upside-down plastic mime functionary of the wise owl	0		Mysticality: +20, Last Available: "2017-12"
 9587	gray Oprah's plastic mime scientist	0		Maximum MP Percent: +50, Last Available: "2017-12"
@@ -9462,12 +9462,12 @@
 9590	squat inspector's plastic The Silent Nightmare	0		Item Drop: +15, Last Available: "2017-12"
 9591	narrow locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	mumming trunk	0		Last Available: "2017-12"
-9593	cyan wobbly wobbly temperance whiskey	1	decent	Last Available: "2017-11"
+9593	wobbly wobbly cyan temperance whiskey	1	decent	Last Available: "2017-11"
 9594	modified aerosolized wishbone	0		Effect: "Sweet and Red", Effect Duration: 38, Last Available: "2017-11"
-9595	aged fortified huge Racisto Ruidoso	5	awesome	Last Available: "2017-11"
+9595	fortified aged huge Racisto Ruidoso	5	awesome	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	low-calorie moldy bran muffin	1	crappy	
-9598	snack-sized delicious blueberry muffin	2	awesome	
+9598	delicious snack-sized blueberry muffin	2	awesome	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9493,13 +9493,13 @@
 9621	squat silent W	0		Last Available: "2017-12"
 9622	upside-down silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
-9624	jittery blinking silent Z	0		Last Available: "2017-12"
+9624	blinking jittery silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	bad stale cheer wine	4	decent	Last Available: "2017-12"
-9630	diet rotten stale Cheer-E-Os	1	crappy	Last Available: "2017-12"
+9630	rotten diet stale Cheer-E-Os	1	crappy	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	perfumed arcane researcher's cheerful antler hat	0		Experience Percent (Mysticality): +10, Stench Resistance: +5, Last Available: "2017-12"
 9633	mansplainer's cool cheerful Crimbo sweater	0		Moxie: +5, Monster Level: +15, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	blurry fireproof skip lid	0		Familiar Weight: +5
 9681	normal extra-toasted half sandwich	3	good	Last Available: "2018-12"
-9682	enchanted irresponsibly strong mediocre tumbling mulled hobo wine	8	decent	Effect: "From Nantucket", Effect Duration: 20, Last Available: "2018-12"
+9682	enchanted mediocre irresponsibly strong tumbling mulled hobo wine	8	decent	Effect: "From Nantucket", Effect Duration: 20, Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	twirling ruddy weightlifter's burning paper hat of Flo-Jo	0		Muscle: +15, Maximum HP Percent: +40, Initiative: +100, Lasts Until Rollover, Last Available: "2018-12"
 9685	coward's rosy-cheeked grievous burning cape	0		Weapon Damage Percent: +50, Maximum HP Percent: +30, Monster Level: -20, Lasts Until Rollover, Last Available: "2018-12"
@@ -9574,11 +9574,11 @@
 9702	mixed furry pill	1		
 9703	denatured huge beefy pill	1		Effect: "You Can Really Taste the Dormouse", Effect Duration: 15
 9704	twisted cyan excitement pill	1		
-9705	powdered red upside-down vitamin G pill	1		
+9705	powdered upside-down red vitamin G pill	1		
 9706	pickled purple lucky-ish pill	1		
 9707	boiled blinking dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
-9713	narrow skewed How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
+9713	skewed narrow How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	green Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
@@ -9594,7 +9594,7 @@
 9726	ghostly wool psychic's amulet of the bloodbag	0		Maximum HP: +100, Cold Resistance: +1, Last Available: "2018-02"
 9727	moldy heart-shaped candy whetstone	3	crappy	Last Available: "2018-02"
 9728	adequate Swedish massage fish	3	good	Last Available: "2018-02"
-9729	drinkable weak Third Base	2	good	Last Available: "2018-02"
+9729	weak drinkable Third Base	2	good	Last Available: "2018-02"
 9730	acceptable weak Bustle Hustler	2	good	Last Available: "2018-02"
 9731	irradiated double-warmed adjusted blurry Fabiotion	0		Effect: "Mighty Shout", Effect Duration: 33, Last Available: "2018-02"
 9732	super-ionized electrified maroon pulsating Bettie page	0		Effect: "Crusty Head", Effect Duration: 52, Last Available: "2018-02"
@@ -9635,11 +9635,11 @@
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
-9770	narrow ghostly Carpricorn	0		Last Available: "2018-03"
+9770	ghostly narrow Carpricorn	0		Last Available: "2018-03"
 9771	mirror Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
 9773	blinking Cycloney	0		Last Available: "2018-03"
-9774	blurry huge Peaclock	0		Last Available: "2018-03"
+9774	huge blurry Peaclock	0		Last Available: "2018-03"
 9775	Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	shaking Aiolion	0		Last Available: "2018-03"
@@ -9699,7 +9699,7 @@
 9831	compressed fuchsia scintillating oyster egg	1		Effect: "Sludgesick", Effect Duration: 5
 9832	mixed pearlescent oyster egg	1		
 9833	vaporized lustrous oyster egg	1		
-9834	modified green narrow gleaming oyster egg	1		
+9834	modified narrow green gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	gray nippy clever FantasyRealm G. E. M. of mayonnaise	0		Maximum MP: +20, Cold Damage: +10, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-04"
@@ -9716,7 +9716,7 @@
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	green LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	twirling bouncing dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	bouncing twirling dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	blurry faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	skewed poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9724,11 +9724,11 @@
 9856	flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	pressed universal antivenin	0		Lasts Until Rollover, Effect: "Dreadful Heat", Effect Duration: 57, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9859	huge blurry fuchsia LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
+9859	blurry fuchsia huge LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	twirling LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	tiny decent FantasyRealm turkey leg	1	good	Last Available: "2018-04"
-9863	watered-down mediocre fancy FantasyRealm mead	2	decent	Effect: "Takin' It Greasy", Effect Duration: 5, Last Available: "2018-04"
+9863	mediocre fancy watered-down FantasyRealm mead	2	decent	Effect: "Takin' It Greasy", Effect Duration: 5, Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	twirling Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9736,7 +9736,7 @@
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	adequate spinning cyan druidic s'more	3	good	Last Available: "2018-04"
 9870	dehydrated fuchsia sachet of powder	1		Last Available: "2018-04"
-9871	boozy drinkable spinning blinking mourning wine	5	good	Last Available: "2018-04"
+9871	boozy drinkable blinking spinning mourning wine	5	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9765,8 +9765,8 @@
 9897	bouncing notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	perfectly mixed squat two meat muck	3	EPIC	
 9899	decent chocolate Ogre Chieftain	4	good	
-9900	rotten gigantic chocolate &quot;Phoenix&quot;	6	crappy	
-9901	immense flavorless chocolate Spider Queen	9	decent	
+9900	gigantic rotten chocolate &quot;Phoenix&quot;	6	crappy	
+9901	flavorless immense chocolate Spider Queen	9	decent	
 9902	bad hipster cocktail	4	decent	
 9903	upside-down God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	ghostly God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
@@ -9780,7 +9780,7 @@
 9912	A-Boo glue	0		
 9913	blurry glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	decent bite-sized good guava	1	good	
+9915	bite-sized decent good guava	1	good	
 9916	tolerable gin and ginger	4	good	
 9917	Thwaitgold chigger statuette	0		
 9918	compressed pulsating fuchsia gaseous gravy	1		
@@ -9790,7 +9790,7 @@
 9922	unsweetened Shielding Potion	0		Effect: "Experimental Effect G-9", Effect Duration: 47, Last Available: "2018-06"
 9923	frozen adjusted unsweetened Punching Potion	0		Effect: "Puddingskin", Effect Duration: 28, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	compressed pulsating skewed Nightmare Fuel	1		Last Available: "2018-06"
+9925	compressed skewed pulsating Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	huge Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9845,7 +9845,7 @@
 9978	blinking Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	drinkable practically non-alcoholic TRIO cup of beer	1	good	Last Available: "2018-09"
 9980	tiny moldy party platter for one	1	crappy	Last Available: "2018-09"
-9981	dried twirling tumbling lime green Party-in-a-Can&trade;	1		Effect: "You Can Taste the Darkness", Effect Duration: 15, Last Available: "2018-09"
+9981	dried twirling lime green tumbling Party-in-a-Can&trade;	1		Effect: "You Can Taste the Darkness", Effect Duration: 15, Last Available: "2018-09"
 9982	bouncing party pup	0		Last Available: "2018-09"
 9983	lightning-fast dance instructor's party crasher	0		Experience Percent (Moxie): +10, Initiative: +40, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
@@ -9881,9 +9881,9 @@
 10015	moldy mirror purple cherry pie	4	crappy	Last Available: "2018-11"
 10016	artisanal fancy narrow eggnog	3	EPIC	Effect: "Turtle Power", Effect Duration: 20, Last Available: "2018-11"
 10017	green glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	small bland Hell ramen	2	decent	Last Available: "2018-11"
-10019	artisanal practically non-alcoholic gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
-10020	fancy hand-crafted weak twice-haunted screwdriver	2	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15, Last Available: "2018-11"
+10018	bland small Hell ramen	2	decent	Last Available: "2018-11"
+10019	practically non-alcoholic artisanal gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
+10020	hand-crafted fancy weak twice-haunted screwdriver	2	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15, Last Available: "2018-11"
 10021	fancy decent candy cane	3	good	Effect: "Extra-Thick Blood", Effect Duration: 5, Last Available: "2018-12"
 10022	perfectly mixed runny fermented egg	3	EPIC	Last Available: "2018-12"
 10023	spoiled narrow oldcake	4	crappy	Last Available: "2018-12"
@@ -9895,7 +9895,7 @@
 10029	shaking plastic Abuela Crimbo of the scaredy-cat	0		Monster Level: -15, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
 10031	Braindeer	0		Last Available: "2018-12"
-10032	lime green jittery Crimbo dog sweater	0		Familiar Weight: +5
+10032	jittery lime green Crimbo dog sweater	0		Familiar Weight: +5
 10033	red chilly pristine walrus tusk of the blizzard	0		Cold Damage: +5, Cold Spell Damage: +25, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	executive Staff of Frozen Lard of the wise owl of mayonnaise of bravery	0		Mysticality: +20, Sleaze Spell Damage: +50, Spooky Resistance: +5, Meat Drop: +40, Last Available: "2018-12"
@@ -9907,13 +9907,13 @@
 10041	purple family-friendly balanced antler	0		Sleaze Resistance: +1, Last Available: "2018-12"
 10042	dam of the blizzard	0		Cold Spell Damage: +25, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable weak beavermouth	2	good	Last Available: "2018-12"
-10044	bad spirit-forward beaver punch (papaya)	5	decent	Last Available: "2018-12"
+10044	spirit-forward bad beaver punch (papaya)	5	decent	Last Available: "2018-12"
 10045	tolerable beaver punch (peach)	3	good	Last Available: "2018-12"
-10046	triple-distilled artisanal beaver punch (cherry)	10	EPIC	Last Available: "2018-12"
+10046	artisanal triple-distilled beaver punch (cherry)	10	EPIC	Last Available: "2018-12"
 10047	olive wizardly Canadian lantern	0		Mysticality: +25, Item Drop: +5, Last Available: "2018-12"
 10048	narrow twirling beefcake's muskox-skin cap	0		Muscle: +25, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	jumbo toothsome ghostly glass of raw eggs	5	awesome	Last Available: "2018-12"
+10050	toothsome jumbo ghostly glass of raw eggs	5	awesome	Last Available: "2018-12"
 10051	bad jittery punch-drunk punch	4	decent	Last Available: "2018-12"
 10052	pickled narrow body spradium	1		Last Available: "2018-12"
 10053	shaking pulsating bauxite beret of the ox	0		Muscle: +20, Last Available: "2018-12"
@@ -9929,16 +9929,16 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	narrow jar of relish	0		Familiar Weight: +5
 10065	blue Toyleporter	0		Last Available: "2018-12"
-10066	artisanal high-proof beer	8	EPIC	Last Available: "2018-12"
+10066	high-proof artisanal beer	8	EPIC	Last Available: "2018-12"
 10067	adequate yule gruel	3	good	Last Available: "2018-12"
 10068	aged olive hot watered rum	3	awesome	Last Available: "2018-12"
-10069	hand-crafted watered-down enchanted bottle of Crimbognac	2	super ultra mega EPIC	Effect: "Tiki Temerity", Effect Duration: 5, Last Available: "2018-12"
+10069	enchanted hand-crafted watered-down bottle of Crimbognac	2	super ultra mega EPIC	Effect: "Tiki Temerity", Effect Duration: 5, Last Available: "2018-12"
 10070	rotten Crimboysters Rockefeller	4	crappy	Last Available: "2018-12"
 10071	distilled narrow Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	mirror Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	skewed wobbly Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10075	purple jittery narrow Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10075	jittery purple narrow Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	upside-down blinking Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
@@ -10021,7 +10021,7 @@
 10155	bland elf army field rations	4	decent	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	discarded bowtie of wisdom of extreme caution	0		Mysticality: +15, Monster Level: -25, Lasts Until Rollover, Last Available: "2019-12"
-10158	tolerable watered-down martiny	2	good	Last Available: "2019-12"
+10158	watered-down tolerable martiny	2	good	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	cold-filtered irradiated anodized licorice snake	0		Effect: "Cosmic Flavor", Effect Duration: 31
 10161	non-ionized Vulcanized virgin jello shot	0		Effect: "Inner Dog", Effect Duration: 22
@@ -10032,10 +10032,10 @@
 10166	tumbling stylish Lil' Doctor&trade; bag of the ox	0		Muscle: +20, Moxie: +25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	flavorless miniature bloodstick	2	decent	
-10170	smooth practically non-alcoholic bottle of Sanguiovese	1	awesome	
-10171	big decent blurry actual blood sausage	5	good	
-10172	bad weak mulled blood	2	decent	
-10173	super-sized stale twirling blood snowcone	5	decent	
+10170	practically non-alcoholic smooth bottle of Sanguiovese	1	awesome	
+10171	decent big blurry actual blood sausage	5	good	
+10172	weak bad mulled blood	2	decent	
+10173	stale super-sized twirling blood snowcone	5	decent	
 10174	drinkable Red Russian	3	good	
 10175	moldy blood roll-up	3	crappy	
 10176	weak smooth bottle of blood	2	awesome	
@@ -10058,7 +10058,7 @@
 10193	curious anemometer	0		Lasts Until Rollover, Last Available: "2019-04"
 10194	pulsating Red Roger's flag	0		Lasts Until Rollover, Last Available: "2019-04"
 10195	Glass Jack's spyglass	0		Lasts Until Rollover, Last Available: "2019-04"
-10196	narrow pulsating recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
+10196	pulsating narrow recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	yellow tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	big moldy ghostly crabsicle	5	crappy	Last Available: "2019-04"
@@ -10066,7 +10066,7 @@
 10201	hand-crafted bottle of dark rhum	3	EPIC	Last Available: "2019-04"
 10202	lousy maroon bottle of extra-dark rhum	4	decent	Last Available: "2019-04"
 10203	perfectly mixed weak bottle of super-extra-dark rhum	2	EPIC	Last Available: "2019-04"
-10204	triple-Vulcanized extra-wet upside-down pulsating pirate shaving cream	0		Effect: "Tightly-Wound Spine", Effect Duration: 56, Last Available: "2019-04"
+10204	triple-Vulcanized extra-wet pulsating upside-down pirate shaving cream	0		Effect: "Tightly-Wound Spine", Effect Duration: 56, Last Available: "2019-04"
 10205	squat lard-coated sage conquistador's breastplate	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, Last Available: "2019-04"
 10206	pirate pantaloons of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Last Available: "2019-04"
 10207	[glitch season reward name]	0		
@@ -10096,10 +10096,10 @@
 10231	toasty fortified PirateRealm party hat of the detective	0		Damage Absorption: +60, Hot Damage: +5, Item Drop: +20, Last Available: "2019-04"
 10232	tolerable Island Landslide	3	good	Last Available: "2019-04"
 10233	lousy skewed Island Thunderstorm	3	decent	Last Available: "2019-04"
-10234	tolerable triple-distilled yellow Island Hurricane	6	good	Last Available: "2019-04"
+10234	triple-distilled tolerable yellow Island Hurricane	6	good	Last Available: "2019-04"
 10235	aged Skull Punch	3	awesome	Last Available: "2019-04"
-10236	tolerable strong narrow Electric Punch	5	good	Last Available: "2019-04"
-10237	hand-crafted practically non-alcoholic Smuggler's Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10236	strong tolerable narrow Electric Punch	5	good	Last Available: "2019-04"
+10237	practically non-alcoholic hand-crafted Smuggler's Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10238	practically non-alcoholic delicious Scorpion Bowl	1	awesome	Last Available: "2019-04"
 10239	mediocre Turtle Bowl	3	decent	Last Available: "2019-04"
 10240	bad Cobra Bowl	3	decent	Last Available: "2019-04"
@@ -10135,7 +10135,7 @@
 10270	vacuum-sealed seashell	0		Effect: "Cold, Dead Hands", Effect Duration: 47, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
 10272	delicious bouncing bottle of sea wine	4	awesome	Last Available: "2019-07"
-10273	dehydrated jittery ghostly kelp	1		Last Available: "2019-07"
+10273	dehydrated ghostly jittery kelp	1		Last Available: "2019-07"
 10274	shaking prompt avaricious censurious frosty Temple Grandin's sharpshooter's steel-toed Newton's educational driftwood hat	0		Experience: +1, Experience (Mysticality): +3, Damage Reduction: 9, Critical Hit Percent: +10, Familiar Weight: +7, Cold Spell Damage: +10, Sleaze Resistance: +3, Meat Drop: +30, Adventures: +3, Lasts Until Rollover, Last Available: "2019-07"
 10275	flame-retardant Tesla resourceful Oprah's forbidden Fonzie's driftwood pants of vim and vigor of Gandalf of doom	0		Experience (Moxie): +1, Spell Damage Percent: +50, Maximum HP Percent: +50, Maximum MP Percent: +50, Maximum MP: +50, Spell Critical Percent: +20, Spooky Spell Damage: +50, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10276	miser's dangerous educational groovy driftwood bracelet of Calamity Jane of Gandalf of horror of the businessman of the sweet-tooth	0		Moxie Percent: +10, Experience: +1, Weapon Damage: +10, Critical Hit Percent: +15, Spell Critical Percent: +20, Spooky Spell Damage: +25, Meat Drop: 60, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10166,12 +10166,12 @@
 10301	narrow greasy brainy whittled fox figurine of temperance	0		Mysticality: +5, Sleaze Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2019-08"
 10302	auspicious asbestos-lined chaotic fortified whittled walking stick	0		Damage Absorption: +60, Spell Critical Percent: +10, Hot Resistance: +5, Item Drop: +10, Last Available: "2019-08"
 10303	bland squat campfire hot dog	3	decent	Last Available: "2019-08"
-10304	huge rotten campfire baked potato	9	crappy	Last Available: "2019-08"
+10304	rotten huge campfire baked potato	9	crappy	Last Available: "2019-08"
 10305	thick toothsome huge campfire s'more	5	awesome	Last Available: "2019-08"
-10306	normal immense campfire beans	9	good	Last Available: "2019-08"
+10306	immense normal campfire beans	9	good	Last Available: "2019-08"
 10307	yummy campfire stew	4	awesome	Last Available: "2019-08"
-10308	fancy mirror narrow campfire coffee	1	decent	Effect: "Lobos Fresh", Effect Duration: 40, Last Available: "2019-08"
-10309	irradiated warmed blinking green leftover chocolate bar	0		Effect: "Truly Gritty", Effect Duration: 42
+10308	fancy narrow mirror campfire coffee	1	decent	Effect: "Lobos Fresh", Effect Duration: 40, Last Available: "2019-08"
+10309	irradiated warmed green blinking leftover chocolate bar	0		Effect: "Truly Gritty", Effect Duration: 42
 10310	rare Meat isotope	0		
 10311	pulsating burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
@@ -10195,17 +10195,17 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	bite-sized normal bu&ntilde;uelos Jaliscos	1	good	Last Available: "2019-12"
 10338	huge bland flan del mar	10	decent	Last Available: "2019-12"
-10339	toothsome jumbo Baja sopapilla	5	awesome	Last Available: "2019-12"
+10339	jumbo toothsome Baja sopapilla	5	awesome	Last Available: "2019-12"
 10340	plastic Mer-kin baker of the ox	0		Muscle: +20, Last Available: "2019-12"
 10341	narrow ruddy plastic sea elf	0		Maximum HP Percent: +40, Last Available: "2019-12"
 10342	wholesome plastic yuleviathan	0		Maximum HP Percent: +10, Last Available: "2019-12"
 10343	bouncing rosewater-soaked plastic dolphin &quot;orphan&quot;	0		Stench Resistance: +3, Single Equip, Last Available: "2019-12"
 10344	zippy plastic Dolph Bossin	0		Initiative: +20, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	stale half-sized mana-coated yams	2	decent	Last Available: "2019-11"
+10346	half-sized stale mana-coated yams	2	decent	Last Available: "2019-11"
 10347	moldy mana-basted tofurkey leg	4	crappy	Last Available: "2019-11"
 10348	rotten blinking mana-fortified cranberry sauce	4	crappy	Last Available: "2019-11"
-10349	low-calorie adequate mana-stuffed herbal stuffing	1	good	Last Available: "2019-11"
+10349	adequate low-calorie mana-stuffed herbal stuffing	1	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	flattened dry pulsating patch of extra-warm fur	0		Effect: "Almost Cool", Effect Duration: 20, Last Available: "2019-12"
 10352	modified pulsating industrial lubricant	1		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	Tesla hardened nutcracker cape	0		Damage Reduction: 3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-12"
 10413	jittery asbestos-lined forbidden nutcracker epaulets	0		Spell Damage Percent: +50, Hot Resistance: +5, Single Equip, Last Available: "2019-12"
 10414	red nutcracker figurine	0		Last Available: "2019-12"
-10415	moldy massive salt plum	8	crappy	Last Available: "2019-12"
+10415	massive moldy salt plum	8	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	rotten and bean	3	crappy	Last Available: "2019-12"
 10418	nasty wholesome kelp-holly gun of mayonnaise	0		Maximum HP Percent: +10, Stench Damage: +5, Sleaze Spell Damage: +50, Last Available: "2019-12"
@@ -10285,7 +10285,7 @@
 10426	hand-crafted salt plum sake	3	EPIC	Last Available: "2019-12"
 10427	pressed quadruple-improved purple pressurized potion of possessiveness	0		Effect: "Ghostly Shell", Effect Duration: 35, Last Available: "2019-12"
 10428	wet jittery twirling almond	0		Effect: "Memory of Smarts", Effect Duration: 65
-10429	wet denatured wobbly blurry skewed handful of mixed nuts	0		Effect: "Good with the Ladies", Effect Duration: 24, Last Available: "2019-12"
+10429	wet denatured skewed wobbly blurry handful of mixed nuts	0		Effect: "Good with the Ladies", Effect Duration: 24, Last Available: "2019-12"
 10430	jittery nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	Jack Frost's curative Da Vinci's Retrospecs	0		Experience (Mysticality): +5, Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
@@ -10300,9 +10300,9 @@
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	adequate drippy nugget	4	drippy	
-10446	lousy practically non-alcoholic lime green glass of drippy wine	1	drippy	
+10446	practically non-alcoholic lousy lime green glass of drippy wine	1	drippy	
 10447	adequate drippy caviar	3	drippy	
-10448	rotten super-sized drippy plum(?)	5	drippy	
+10448	super-sized rotten drippy plum(?)	5	drippy	
 10449	hale drippy stake	0		Maximum HP: +20, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10312,7 +10312,7 @@
 10455	ghostly mushroom	0		
 10456	deluxe mushroom	0		
 10457	skewed super deluxe mushroom	0		
-10458	aerosolized pickled lime green spinning fizzy soda	0		Effect: "Rootin' Around", Effect Duration: 22
+10458	aerosolized pickled spinning lime green fizzy soda	0		Effect: "Rootin' Around", Effect Duration: 22
 10459	altered pickled alkaline ghostly green healthy juice	0		Effect: "Empathy", Effect Duration: 45
 10460	hammer	0		
 10461	olive hammer	0		
@@ -10343,10 +10343,10 @@
 10486	skewed wobbly free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	pulsating colossal free-range mushroom	0		Last Available: "2020-03"
-10489	huge moldy mushroom filet	8	crappy	Last Available: "2020-03"
+10489	moldy huge mushroom filet	8	crappy	Last Available: "2020-03"
 10490	bouncing bouncing mushroom slab	0		Last Available: "2020-03"
 10491	vaporized mushroom tea	1		Effect: "All Blued Up", Effect Duration: 20, Last Available: "2020-03"
-10492	bad watered-down ghostly mushroom whiskey	2	decent	Last Available: "2020-03"
+10492	watered-down bad ghostly mushroom whiskey	2	decent	Last Available: "2020-03"
 10493	censurious therapeutic mushroom cap of the boozehound	0		Sleaze Resistance: +3, Booze Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-03"
 10494	huge manspreader's beefy mushroom shield of horror of the cheetah	0		Muscle: +10, Monster Level: +10, Spooky Spell Damage: +25, Initiative: +60, Damage Reduction: 6, Last Available: "2020-03"
 10495	greasy scorching electrified steel-toed mushroom pants	0		Damage Reduction: 9, Hot Damage: +25, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-03"
@@ -10355,7 +10355,7 @@
 10498	pristine piranha seed	0		Last Available: "2020-03"
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	concentrated olive piranha pollen	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 57, Last Available: "2020-03"
-10501	skewed shaking plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
+10501	shaking skewed plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
 10502	sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	blinking Herculean kettle bell	0		Experience (Muscle): +1, Last Available: "2020-04"
 10504	frosty glued-together crystal ball	0		Cold Spell Damage: +10, Last Available: "2020-04"
@@ -10462,7 +10462,7 @@
 10606	moist blurry olive pulsating Yeg's Motel toothbrush	0		Effect: "Celestial Body", Effect Duration: 41, Last Available: "2020-09"
 10607	double-colloidal unsweetened Yeg's Motel hand soap	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 15, Last Available: "2020-09"
 10608	blue Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	decent small cyan Yeg's Motel pillow mint	2	good	Last Available: "2020-09"
+10609	small decent cyan Yeg's Motel pillow mint	2	good	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	alkaline quantum Yeg's Motel mouthwash	0		Effect: "Intimidating Mien", Effect Duration: 19, Last Available: "2020-09"
 10612	green Sinatra's strapping Yeg's Motel shower cap	0		Muscle: +5, Experience (Moxie): +5, Lasts Until Rollover, Last Available: "2020-09"
@@ -10471,10 +10471,10 @@
 10615	squat Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	huge Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
-10618	squat shaking frost-rimed desk bell	0		Last Available: "2020-09"
+10618	shaking squat frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	nasty desk bell	0		Last Available: "2020-09"
-10621	jittery yellow tumbling greasy desk bell	0		Last Available: "2020-09"
+10621	yellow jittery tumbling greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	wobbly onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
@@ -10490,8 +10490,8 @@
 10634	twirling alabaster pawn	0		Last Available: "2020-09"
 10635	teal skewed bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	olive aromatic Fonzie's Cargo Cultist Shorts of the brute of mayonnaise	0		Muscle Percent: +30, Experience (Moxie): +1, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2020-09"
-10637	jittery skewed complicated device	0		Last Available: "2020-09"
-10638	perfectly mixed weak flask of moonshine	2	EPIC	Last Available: "2020-09"
+10637	skewed jittery complicated device	0		Last Available: "2020-09"
+10638	weak perfectly mixed flask of moonshine	2	EPIC	Last Available: "2020-09"
 10639	horrifying flame-wreathed sea-worn candlestick of the wise owl	0		Mysticality: +20, Hot Spell Damage: +10, Spooky Damage: +25, Last Available: "2020-09"
 10640	upside-down Universal Seasoning	0		
 10641	modified unsweetened null-day exploit	0		Effect: "Abominably Slippery", Effect Duration: 58, Last Available: "2025-12"
@@ -10499,7 +10499,7 @@
 10643	rotten skewed chocolate chip muffin	4	crappy	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	blue Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
-10646	pulsating tumbling packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
+10646	tumbling pulsating packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	green box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	gregarious ghostling	0		Free Pull, Last Available: "2020-12"
@@ -10516,7 +10516,7 @@
 10660	pulsating groovy Crimbo smile	0		Moxie Percent: [+10*event(December)], Last Available: "2020-12"
 10661	huge scandalous SalesCo sample kit	0		Sleaze Damage: [+5*event(December)], Last Available: "2020-12"
 10662	adjusted Vulcanized improved jittery bouncing candy harmonica	0		Effect: "Super Vision", Effect Duration: 15, Last Available: "2020-12"
-10663	magnetized blinking blurry yellow sugar	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 16, Last Available: "2020-12"
+10663	magnetized blinking yellow blurry sugar	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 16, Last Available: "2020-12"
 10664	quantum multi-level marzipan	0		Effect: "The Solution", Effect Duration: 11, Last Available: "2020-12"
 10665	plastic Crimbo caroler of the brute	0		Muscle Percent: +30, Last Available: "2020-12"
 10666	pulsating wool plastic multi-level marketer	0		Cold Resistance: +1, Last Available: "2020-12"
@@ -10548,7 +10548,7 @@
 10692	booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	twirling candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	jittery food mailing list	0		Last Available: "2020-12"
-10695	huge ghostly booze mailing list	0		Last Available: "2020-12"
+10695	ghostly huge booze mailing list	0		Last Available: "2020-12"
 10696	olive candy mailing list	0		Last Available: "2020-12"
 10697	Socratic slick fruit bat	0		Moxie: +10, Experience (Mysticality): +1, Class: "Seal Clubber", Single Equip, Last Available: "2020-12"
 10698	smelly Van der Graaf tinsel orb	0		Stench Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Class: "Turtle Tamer", Last Available: "2020-12"
@@ -10561,7 +10561,7 @@
 10705	The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10706	squat The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	cyan The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
-10708	twirling narrow The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
+10708	narrow twirling The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	spinning The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10710	pulsating The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
@@ -10574,33 +10574,33 @@
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	fuchsia goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	drinkable watered-down barrel-aged eggnog	2	good	Last Available: "2020-12"
-10721	rotten fancy bite-sized hand-crafted candy cane	1	crappy	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2020-12"
+10721	bite-sized fancy rotten hand-crafted candy cane	1	crappy	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2020-12"
 10722	normal drive-thru burger	4	good	Last Available: "2020-12"
-10723	practically non-alcoholic smooth green Boulevardier cocktail	1	awesome	Last Available: "2020-12"
+10723	smooth practically non-alcoholic green Boulevardier cocktail	1	awesome	Last Available: "2020-12"
 10724	nitrogenated super-irradiated Hotwire&trade; brand candy rope	0		Effect: "Memories of Puppy Love", Effect Duration: 20, Last Available: "2020-12"
 10725	enchanted decent fuchsia bowl full of jelly	4	good	Effect: "Toothy Grin", Effect Duration: 10, Last Available: "2020-12"
-10726	enchanted weak acceptable Eye and a Twist	2	good	Effect: "Hood Ridin'", Effect Duration: 30, Last Available: "2020-12"
+10726	weak enchanted acceptable Eye and a Twist	2	good	Effect: "Hood Ridin'", Effect Duration: 30, Last Available: "2020-12"
 10727	colloidal tarnished Chubby and Plump bar	0		Effect: "Bloody-minded", Effect Duration: 54, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	blue packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	spinning crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	blinking fresh can of paint	0		Free Pull, Last Available: "2021-12"
-10732	huge blinking skewed fresh coat of paint	0		Last Available: "2021-12"
+10732	skewed blinking huge fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	squat shaking spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	shaking squat spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	pulsating robo-battery	0		
 10736	shaking Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
 10739	ionized battery (AAA)	0		Effect: "License to Punch", Effect Duration: 15, Last Available: "2021-03"
-10740	electrified quantum blue narrow blinking battery (AA)	0		Effect: "Grrrrrrreat!", Effect Duration: 42, Last Available: "2021-03"
+10740	electrified quantum narrow blinking blue battery (AA)	0		Effect: "Grrrrrrreat!", Effect Duration: 42, Last Available: "2021-03"
 10741	cold-filtered upside-down purple battery (D)	0		Effect: "Simulation Stimulation", Effect Duration: 33, Last Available: "2021-03"
 10742	quadruple-activated narrow shaking battery (9-Volt)	0		Effect: "Saucemastery", Effect Duration: 63, Last Available: "2021-03"
 10743	pressed modified ghostly battery (lantern)	0		Effect: "Strawberry Alarm", Effect Duration: 33, Last Available: "2021-03"
 10744	unsweetened corrupted blurry battery (car)	0		Effect: "Stimulated Body", Effect Duration: 31, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	fortified smooth marshmallow bomb	5	awesome	Last Available: "2021-03"
+10747	smooth fortified marshmallow bomb	5	awesome	Last Available: "2021-03"
 10748	yellow packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10621,7 +10621,7 @@
 10765	rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	squat rocket	0		Last Available: "2021-07"
-10768	half-sized moldy spinning fire crackers	2	crappy	Last Available: "2021-07"
+10768	moldy half-sized spinning fire crackers	2	crappy	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	lightning-fast reassuring Catherine Wheel	0		Spooky Resistance: +1, Initiative: +40, Lasts Until Rollover, Last Available: "2021-07"
 10771	blurry narrow flame-wreathed padded rocket boots	0		Damage Absorption: +20, Hot Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10678,22 +10678,22 @@
 10822	flavorless bone broth	4	decent	Last Available: "2021-12"
 10823	moldy star pop	4	crappy	Last Available: "2021-12"
 10824	artisanal Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
-10825	practically non-alcoholic fancy drinkable Doc's Smartifying Wine	1	good	Effect: "Eyes for Miles", Effect Duration: 15, Last Available: "2021-12"
+10825	drinkable fancy practically non-alcoholic Doc's Smartifying Wine	1	good	Effect: "Eyes for Miles", Effect Duration: 15, Last Available: "2021-12"
 10826	practically non-alcoholic smooth Doc's Limbering Wine	1	awesome	Last Available: "2021-12"
 10827	perfectly mixed jittery Doc's Medical-Grade Wine	3	EPIC	Last Available: "2021-12"
 10828	mixed teal Homebodyl&trade;	1		Last Available: "2021-12"
 10829	mixed Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	powdered ghostly Breathitin&trade;	1		Effect: "White Blooded", Effect Duration: 30, Last Available: "2021-12"
-10831	dried twirling yellow Fleshazole&trade;	1		Last Available: "2021-12"
+10831	dried yellow twirling Fleshazole&trade;	1		Last Available: "2021-12"
 10832	extra-flattened anti-burn cream	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 48, Last Available: "2021-12"
 10833	double-chilled jittery anti-freeze cream	0		Effect: "Can't Smell Nothin'", Effect Duration: 64, Last Available: "2021-12"
-10834	adjusted fuchsia bouncing anti-goosebump cream	0		Effect: "Become Intensely interested", Effect Duration: 66, Last Available: "2021-12"
+10834	adjusted bouncing fuchsia anti-goosebump cream	0		Effect: "Become Intensely interested", Effect Duration: 66, Last Available: "2021-12"
 10835	deionized nitrogenated anti-odor cream	0		Effect: "Salty Mouth", Effect Duration: 46, Last Available: "2021-12"
-10836	electrified triple-flattened cyan narrow huge anti-creep cream	0		Effect: "A Few Extra Pounds", Effect Duration: 57, Last Available: "2021-12"
+10836	electrified triple-flattened cyan huge narrow anti-creep cream	0		Effect: "A Few Extra Pounds", Effect Duration: 57, Last Available: "2021-12"
 10837	non-modified pressed boiled anti-pain cream	0		Effect: "Joy", Effect Duration: 20, Last Available: "2021-12"
 10838	drinkable Doc's Special Reserve Wine	4	good	Last Available: "2021-12"
 10839	rotten bread pie	3	crappy	Last Available: "2021-12"
-10840	watered-down drinkable fancy blinking clear Russian	2	good	Effect: "Slimily Sagacious", Effect Duration: 5, Last Available: "2021-12"
+10840	fancy watered-down drinkable blinking clear Russian	2	good	Effect: "Slimily Sagacious", Effect Duration: 5, Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	mirror Crimbo ball	0		Last Available: "2021-12"
 10843	pulsating Crimbo ball	0		Last Available: "2021-12"
@@ -10705,10 +10705,10 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	cozy scarf of the cougar	0		Moxie: +20, Last Available: "2021-12"
-10852	enchanted moldy half-sized huge Crimbo cookie	2	crappy	Effect: "Employee of the Month", Effect Duration: 45, Last Available: "2023-06"
+10852	moldy enchanted half-sized huge Crimbo cookie	2	crappy	Effect: "Employee of the Month", Effect Duration: 45, Last Available: "2023-06"
 10853	super-boiled pulsating fleshy putty	0		Effect: "Frisky Spirit", Effect Duration: 28, Last Available: "2021-12"
 10854	upside-down flame-wreathed third ear	0		Hot Spell Damage: +10, Single Equip, Last Available: "2021-12"
-10855	yellow narrow festive egg sac	0		Last Available: "2021-12"
+10855	narrow yellow festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
 10857	hale peppermint-scented socks	0		Maximum HP: +20, Last Available: "2021-12"
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
@@ -10733,13 +10733,13 @@
 10877	maroon cloned monster	0		Last Available: "2021-12"
 10878	maroon meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
-10880	dehydrated spinning green fried air	1		Last Available: "2021-12"
+10880	dehydrated green spinning fried air	1		Last Available: "2021-12"
 10881	mirror 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	pickled jittery astral energy drink	1		Effect: "Tenacity of the Snapper", Effect Duration: 50
 10884	huge mint condition magnifying glass	0		Last Available: "2022-12"
 10885	Sherlock's weightlifter's magnifying glass of the scaredy-cat	0		Muscle: +15, Monster Level: -15, Item Drop: +25, Last Available: "2022-12"
-10886	tolerable watered-down fancy void lager	2	good	Effect: "Sugary Tongue", Effect Duration: 20, Last Available: "2022-12"
+10886	watered-down fancy tolerable void lager	2	good	Effect: "Sugary Tongue", Effect Duration: 20, Last Available: "2022-12"
 10887	rotten big void burger	5	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	stiffened fortified experienced thinker's void shard	0		Mysticality: +10, Experience: +2, Damage Absorption: +60, Damage Reduction: 1, Last Available: "2022-12"
@@ -10761,22 +10761,22 @@
 10905	mirror wholesome headlamp	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2022-05"
 10906	zippy thermal blanket of the ox of James Dean	0		Muscle: +20, Experience (Moxie): +3, Initiative: +20, Lasts Until Rollover, Last Available: "2022-05"
 10907	upside-down Samson's atlas of local maps	0		Experience (Muscle): +5, Lasts Until Rollover, Last Available: "2022-05"
-10908	corrupted spinning gray spare battery	0		Effect: "Hyperoffended", Effect Duration: 39, Last Available: "2022-05"
+10908	corrupted gray spinning spare battery	0		Effect: "Hyperoffended", Effect Duration: 39, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
 10910	magnetized single-use dust mask	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 21, Last Available: "2022-05"
 10911	concentrated gaffer's tape	0		Effect: "Fustulent", Effect Duration: 52, Last Available: "2022-05"
-10912	decent small 20-lb can of rice and beans	2	good	Last Available: "2022-05"
+10912	small decent 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	mirror bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	yummy blurry expired MRE	4	awesome	Last Available: "2022-05"
-10915	spoiled low-calorie enchanted cool mint precipice bar	1	crappy	Effect: "Corona de la Salsa", Effect Duration: 15, Last Available: "2022-05"
-10916	small flavorless carrot cake precipice bar	2	decent	Last Available: "2022-05"
+10915	spoiled enchanted low-calorie cool mint precipice bar	1	crappy	Effect: "Corona de la Salsa", Effect Duration: 15, Last Available: "2022-05"
+10916	flavorless small carrot cake precipice bar	2	decent	Last Available: "2022-05"
 10917	cyan huge The Big Book of Every Skill	0		
 10918	blue Thwaitgold harvestman statuette	0		
 10919	shaking packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	gray pulsating family-friendly June cleaver of the overflowing toilet of courage	0		Stench Spell Damage: +50, Spooky Resistance: +3, Sleaze Resistance: +1, Attacks Can't Miss, Last Available: "2022-06"
-10921	lousy weak Dad's brandy	2	decent	Last Available: "2022-06"
+10921	weak lousy Dad's brandy	2	decent	Last Available: "2022-06"
 10922	tumbling padded wizardly teacher's pen	0		Mysticality: +25, Damage Absorption: +20, Last Available: "2022-06"
-10923	adequate low-calorie fire-roasted lake trout	1	good	Last Available: "2022-06"
+10923	low-calorie adequate fire-roasted lake trout	1	good	Last Available: "2022-06"
 10924	rotten guilty sprout	3	crappy	Last Available: "2022-06"
 10925	mirror rock-hard stiffened mother's necklace	0		Damage Reduction: 12, Last Available: "2022-06"
 10926	activated wet skewed trampled ticket stub	0		Effect: "Tiki Temerity", Effect Duration: 57, Last Available: "2022-06"
@@ -10795,7 +10795,7 @@
 10939	flatusaur gasmask	0		
 10940	skewed dinosaur dart	0		
 10941	oxidized enhanced ghostly Dino DNAde&trade;	0		Effect: "Stick Emporium Membership", Effect Duration: 39
-10942	olive upside-down dinosaur repellent	0		
+10942	upside-down olive dinosaur repellent	0		
 10943	greasy camouflage vest	0		Sleaze Spell Damage: +10
 10944	spinning Dinodollar	0		
 10945	valuable dinosaur droppings	0		
@@ -10816,7 +10816,7 @@
 10960	boiled autumn dollar	0		Effect: "White-boy Angst", Effect Duration: 41, Last Available: "2022-10"
 10961	mansplainer's autumn leaf pendant of extreme caution of terror	0		Monster Level: -10, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
 10962	powdered autumn breeze	1		Effect: "Aided and Abetted", Effect Duration: 5, Last Available: "2022-10"
-10963	chilled quantum bouncing blue autumn years wisdom	0		Effect: "Healthy Green Glow", Effect Duration: 58, Last Available: "2022-10"
+10963	chilled quantum blue bouncing autumn years wisdom	0		Effect: "Healthy Green Glow", Effect Duration: 58, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	weak artisanal purple Oopsie IPA	2	EPIC	Last Available: "2022-10"
 10966	blinking mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
@@ -10826,28 +10826,28 @@
 10970	normal ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
 10971	adequate big Jarlsberg's vegetable soup	5	good	Last Available: "2022-11"
 10972	rotten roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
-10973	moldy jumbo St. Pete's sneaky smoothie	5	crappy	Last Available: "2022-11"
+10973	jumbo moldy St. Pete's sneaky smoothie	5	crappy	Last Available: "2022-11"
 10974	stale Pete's wiley whey bar	4	decent	Last Available: "2022-11"
-10975	huge enchanted bland blurry maroon Pete's rich ricotta	7	decent	Effect: "Artificially Sweet", Effect Duration: 40, Last Available: "2022-11"
+10975	enchanted bland huge blurry maroon Pete's rich ricotta	7	decent	Effect: "Artificially Sweet", Effect Duration: 40, Last Available: "2022-11"
 10976	mediocre fancy tumbling Boris's beer	4	decent	Effect: "Ready to Snap", Effect Duration: 45, Last Available: "2022-11"
-10977	special decent honey bun of Boris	4	good	Effect: "Memory of Smarts", Effect Duration: 25, Last Available: "2022-11"
+10977	decent special honey bun of Boris	4	good	Effect: "Memory of Smarts", Effect Duration: 25, Last Available: "2022-11"
 10978	decent Boris's bread	3	good	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	shaking skewed Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10983	skewed shaking Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
 10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
-10988	tiny fancy flavorless baked veggie ricotta casserole	1	decent	Effect: "Heart of Green", Effect Duration: 25, Last Available: "2022-11"
+10988	fancy tiny flavorless baked veggie ricotta casserole	1	decent	Effect: "Heart of Green", Effect Duration: 25, Last Available: "2022-11"
 10989	gigantic moldy plain calzone	7	crappy	Last Available: "2022-11"
-10990	rotten half-sized upside-down roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
+10990	half-sized rotten upside-down roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
 10991	super-sized decent Pizza of Legend	5	good	Last Available: "2022-11"
-10992	gigantic spoiled Calzone of Legend	9	crappy	Last Available: "2022-11"
+10992	spoiled gigantic Calzone of Legend	9	crappy	Last Available: "2022-11"
 10993	huge red Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	narrow gray Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10994	gray narrow Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
 10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
@@ -10867,10 +10867,10 @@
 11011	blinking Jeselnik's scorching gator shades	0		Hot Damage: +25, Sleaze Damage: +25, Single Equip
 11012	blurry milk cap	0		
 11013	tolerable Charleston Choo-Choo	3	good	
-11014	perfectly mixed watered-down Velvet Veil	2	EPIC	
+11014	watered-down perfectly mixed Velvet Veil	2	EPIC	
 11015	mediocre high-proof red Marltini	7	decent	
 11016	mediocre Strong, Silent Type	3	decent	
-11017	fortified acceptable special upside-down Mysterious Stranger	5	good	Effect: "Helping Comes Second", Effect Duration: 40
+11017	acceptable special fortified upside-down Mysterious Stranger	5	good	Effect: "Helping Comes Second", Effect Duration: 40
 11018	tolerable Champagne Shimmy	3	good	
 11019	the Sot's parcel	0		
 11020	green bouncing greedy banded ceramic cestus	0		Damage Absorption: +100, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10888,9 +10888,9 @@
 11032	flame-wreathed stiffened arcane researcher's chiffon chakram	0		Experience Percent (Mysticality): +10, Damage Reduction: 1, Hot Spell Damage: +10, Last Available: "2023-12"
 11033	blinking asbestos-lined supercool chiffon chaps of the boozehound	0		Moxie Percent: +20, Hot Resistance: +5, Booze Drop: +100, Last Available: "2023-12"
 11034	diluted chiffon carbage	1		Last Available: "2023-12"
-11035	flattened teal pulsating chiffon lemon	0		Effect: "Just Aged Enough", Effect Duration: 38
+11035	flattened pulsating teal chiffon lemon	0		Effect: "Just Aged Enough", Effect Duration: 38
 11036	delicious chocomotive	3	awesome	Last Available: "2022-12"
-11037	small decent freightcake	2	good	Last Available: "2022-12"
+11037	decent small freightcake	2	good	Last Available: "2022-12"
 11038	hand-crafted narrow cabooze	4	EPIC	Last Available: "2022-12"
 11039	skewed plastic caboose	0		Last Available: "2022-12"
 11040	plastic passenger car of wisdom	0		Mysticality: +15, Last Available: "2022-12"
@@ -10906,7 +10906,7 @@
 11050	oxidized frozen aerosolized bouncing Trainbot circuitry	0		Effect: "Memento Moir&eacute;", Effect Duration: 26
 11051	enhanced Trainbot tubing	0		Effect: "Abominably Slippery", Effect Duration: 43
 11052	galvanized Trainbot plating	0		Effect: "You Know Where to Go", Effect Duration: 53
-11053	altered dry upside-down spinning Trainbot optics	0		Effect: "Hopped Up on Goofballs", Effect Duration: 16
+11053	altered dry spinning upside-down Trainbot optics	0		Effect: "Hopped Up on Goofballs", Effect Duration: 16
 11054	enhanced frozen diffused Trainbot servomotors	0		Effect: "Empty Inside", Effect Duration: 34
 11055	chilled Trainbot linkages	0		Effect: "Healthy Green Glow", Effect Duration: 53
 11056	squat ping-pong paddle	0		Single Equip
@@ -10914,7 +10914,7 @@
 11058	flame-wreathed Trainbot harness	0		Hot Spell Damage: +10
 11059	ping-pong table	0		
 11060	tumbling Crimbo train emergency brake	0		
-11061	blurry red Trainbot autoassembly module	0		
+11061	red blurry Trainbot autoassembly module	0		
 11062	Jack Frost's baleful Newton's head-mounted Trainbot	0		Experience (Mysticality): +3, Spell Damage: +25, Cold Spell Damage: +50, Last Available: "2022-12"
 11063	cyan foul-smelling studded leg-mounted Trainbots of terror	0		Damage Absorption: +80, Stench Damage: +10, Spooky Spell Damage: +10, Last Available: "2022-12"
 11064	pulsating Van der Graaf steel-toed shoulder-mounted Trainbot of the pedagogue	0		Experience: +3, Damage Reduction: 9, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2022-12"
@@ -10925,7 +10925,7 @@
 11069	cyan wobbly Trainbot luggage hook	0		Single Equip
 11070	spoiled thick wobbly honey-drenched ham slice	5	crappy	
 11071	strong mediocre mostly-empty bottle of cookie wine	5	decent	
-11072	gigantic adequate Crimbo food scraps	8	good	
+11072	adequate gigantic Crimbo food scraps	8	good	
 11073	gray arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
@@ -10938,7 +10938,7 @@
 11082	spinning crystal Crimbo goblet	0		
 11083	twirling crystal Crimbo platter	0		
 11084	perfectly mixed huge Crimbosmopolitan	3	super EPIC	Last Available: "2022-12"
-11085	small flavorless twirling Crimbo dinner	2	decent	Last Available: "2022-12"
+11085	flavorless small twirling Crimbo dinner	2	decent	Last Available: "2022-12"
 11086	twirling overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	huge The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10964,15 +10964,15 @@
 11108	teal hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	rotten massive huge pixel bread	6	crappy	
+11112	massive rotten huge pixel bread	6	crappy	
 11113	mediocre pixel whiskey	4	decent	
-11114	ghostly green pixel rock	0		
+11114	green ghostly pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	extra-cold-filtered glob of extra-green chlorophyll	0		Effect: "Uncaged Power", Effect Duration: 56, Last Available: "2023-02"
-11118	cold-filtered ionized pulsating blurry mushroom	0		Effect: "Comprehensively Nourished", Effect Duration: 40, Last Available: "2023-02"
+11118	cold-filtered ionized blurry pulsating mushroom	0		Effect: "Comprehensively Nourished", Effect Duration: 40, Last Available: "2023-02"
 11119	quantum narrow five-fingered fern resin	0		Effect: "Wise Spirit", Effect Duration: 59, Last Available: "2023-02"
-11120	half-sized normal skewed huge super good fruit	2	good	Last Available: "2023-02"
+11120	half-sized normal huge skewed super good fruit	2	good	Last Available: "2023-02"
 11121	diluted teal energized spores	1		Last Available: "2023-02"
 11122	Tesla quilted hot pepper	0		Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-02", Lantern Element: "Hot"
 11123	super-ionized out-of-work circus flea	0		Effect: "Flambé-a-thon", Effect Duration: 44, Last Available: "2023-02"
@@ -10982,21 +10982,21 @@
 11127	lousy blurry shot of wasp venom	4	decent	Last Available: "2023-02"
 11128	double-galvanized narrow filled mosquito	0		Effect: "The Power of LOV", Effect Duration: 44, Last Available: "2023-02"
 11129	triple-chilled modified altered skewed shim of shame shale	0		Effect: "Sizzling with Fury", Effect Duration: 22, Last Available: "2023-02"
-11130	oxidized upside-down ghostly fuchsia pebble of proud pyrite	0		Effect: "Elemental Mastery", Effect Duration: 39, Last Available: "2023-02"
+11130	oxidized upside-down fuchsia ghostly pebble of proud pyrite	0		Effect: "Elemental Mastery", Effect Duration: 39, Last Available: "2023-02"
 11131	Vulcanized double-liquefied blurry pile of gritty sand	0		Effect: "Libra Rising", Effect Duration: 44, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	adjusted improved angry agate	0		Effect: "OMG WTF", Effect Duration: 55, Last Available: "2023-02"
 11134	quadruple-adjusted spinning lump of loyal latite	0		Effect: "Greased-Up Familiar", Effect Duration: 24, Last Available: "2023-02"
-11135	rotten bite-sized fancy gray shadow sausage	1	crappy	Effect: "Serendipi Tea", Effect Duration: 10, Last Available: "2023-03"
+11135	bite-sized rotten fancy gray shadow sausage	1	crappy	Effect: "Serendipi Tea", Effect Duration: 10, Last Available: "2023-03"
 11136	friendly supercharged shadow skin	0		Maximum MP Percent: +30, Familiar Weight: +3, Last Available: "2023-03"
 11137	ionized concentrated shadow flame	0		Effect: "Broberry Brotality", Effect Duration: 65, Last Available: "2023-03"
 11138	normal shadow bread	4	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	watered-down lousy shadow fluid	2	decent	Last Available: "2023-03"
+11140	lousy watered-down shadow fluid	2	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	squat shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	weak perfectly mixed shadow venom	2	EPIC	Last Available: "2023-03"
+11144	perfectly mixed weak shadow venom	2	EPIC	Last Available: "2023-03"
 11145	diluted purple jittery shadow nectar	1		Last Available: "2023-03"
 11146	double-paned resourceful veiny shadow stick	0		Maximum HP: +10, Maximum MP: +50, Cold Resistance: +5, Last Available: "2023-03"
 11147	auspicious Socratic bat paw	0		Experience (Mysticality): +1, Item Drop: +10
@@ -11024,7 +11024,7 @@
 11169	jittery closed-circuit pay phone	0		
 11170	shadow lighter	0		
 11171	spinning shadow heptahedron	0		
-11172	lime green bouncing shadow snowflake	0		
+11172	bouncing lime green shadow snowflake	0		
 11173	shadow heart	0		
 11174	shadow bucket	0		
 11175	olive shadow wave	0		
@@ -11034,7 +11034,7 @@
 11179	squat extremely unsafe groovy shadow hammer	0		Moxie Percent: +10, Weapon Damage Percent: +100
 11180	Annie Oakley's beefy shadow monocle of the bloodbag	0		Muscle: +10, Maximum HP: +100, Critical Hit Percent: +20, Single Equip
 11181	pulsating shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	moldy gigantic shadow hot dog	8	crappy	
+11182	gigantic moldy shadow hot dog	8	crappy	
 11183	fancy tolerable skewed shadow martini	3	good	Effect: "Mushroom Magicalness", Effect Duration: 15
 11184	mixed upside-down shadow pill	1		
 11185	shadow needle	0		
@@ -11116,7 +11116,7 @@
 11261	mirror Mr. Accessaturday	0		Last Available: "2023-06"
 11262	huge Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
-11264	spinning olive pulsating Charter: Nellyville	0		Last Available: "2023-06"
+11264	pulsating olive spinning Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	tumbling Flash Liquidizer Ultra Dousing Accessory of the scaredy-cat	0		Monster Level: -15, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	asbestos-lined MacGyver's curative Amulet of Perpetual Darkness of the cheetah	0		Maximum MP: +100, Hot Resistance: +5, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-06"
@@ -11134,7 +11134,7 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	irresponsibly strong lousy skewed Sexy Cosmo	8	decent	Last Available: "2023-06"
+11282	lousy irresponsibly strong skewed Sexy Cosmo	8	decent	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	up-at-dawn rock-hard red-soled high heels of temperance	0		Damage Reduction: 5, Sleaze Resistance: +5, Adventures: +5, Last Available: "2023-06"
 11285	spoiled snack-sized wobbly cyburger	2	crappy	Last Available: "2025-12"
@@ -11146,11 +11146,11 @@
 11291	mirror spider leg of Calamity Jane	0		Critical Hit Percent: +15
 11292	wobbly skewed gravedigger's beetle antenna	0		Spooky Damage: +10
 11293	red skewed mantis skull of the bloodbag	0		Maximum HP: +100
-11294	liquefied blinking lime green chitin powder	0		Effect: "Elemental Saucesphere", Effect Duration: 45
+11294	liquefied lime green blinking chitin powder	0		Effect: "Elemental Saucesphere", Effect Duration: 45
 11295	Sinatra's brawny daddy shortlegs leg	0		Muscle Percent: +20, Experience (Moxie): +5
 11296	miser's veiny birdybug antenna	0		Maximum HP: +10, Meat Drop: +10
 11297	squat pulsating perfumed Jack Frost's kilopede skull	0		Cold Spell Damage: +50, Stench Resistance: +5
-11298	liquefied frozen shaking narrow olive haemolymphnode	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 69
+11298	liquefied frozen shaking olive narrow haemolymphnode	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 69
 11299	dry boiled ghostly chitin powder paste	0		Effect: "Surreally Buff", Effect Duration: 32
 11300	sleeping patriotic eagle	0		Free Pull
 11301	claw-held flag	0		Familiar Weight: +5
@@ -11159,8 +11159,8 @@
 11304	replica sleeping patriotic eagle	0		
 11305	upside-down boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	half-sized adequate fancy bouncing watermelon	2	good	Effect: "You Read The Manual", Effect Duration: 10
-11308	wobbly jittery watermelon seed	0		
+11307	half-sized fancy adequate bouncing watermelon	2	good	Effect: "You Read The Manual", Effect Duration: 10
+11308	jittery wobbly watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
 11311	rotten squat waffle	4	crappy	
@@ -11168,19 +11168,19 @@
 11313	gravedigger's veiny cat o' nine teeth	0		Maximum HP: +10, Spooky Damage: +10
 11314	dangerous tooth cap of the wise owl	0		Mysticality: +20, Weapon Damage: +10
 11315	medical-grade Newton's toothy trousers	0		Experience (Mysticality): +3, HP Regen Min: 7, HP Regen Max: 10
-11316	decent miniature banana split	2	good	
+11316	miniature decent banana split	2	good	
 11317	blue handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	triple-distilled aged bottle of Cabernet Sauvignon	6	awesome	
+11320	aged triple-distilled bottle of Cabernet Sauvignon	6	awesome	
 11321	Sherlock's horrifying wholesome baywatch	0		Maximum HP Percent: +10, Spooky Damage: +25, Item Drop: +25, Lasts Until Rollover
 11322	tumbling Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	skewed twirling teal Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	twirling teal skewed Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	yellow consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	mirror Thwaitgold fairyfly statue	0		
 11327	jittery residual chitin paste	0		Skill: "Chitinous Soul"
-11328	altered teal upside-down spinning concentrated cooking	1		Effect: "Quiet 'n' Good", Effect Duration: 30
+11328	altered spinning upside-down teal concentrated cooking	1		Effect: "Quiet 'n' Good", Effect Duration: 30
 11329	boiled bouncing tumbling meat	1		
 11330	altered shaking upside-down mirror sparkling orb	1		
 11331	boiled mirror hardening cream	1		
@@ -11201,7 +11201,7 @@
 11346	day shortener	0		
 11347	fuchsia extra time	0		
 11348	nippy Lo Pan's autumnal aegis	0		Spell Critical Percent: +30, Cold Damage: +10, Damage Reduction: 9
-11349	flattened frozen mirror squat distilled resin	0		Effect: "Stinking Cloud", Effect Duration: 46
+11349	flattened frozen squat mirror distilled resin	0		Effect: "Stinking Cloud", Effect Duration: 46
 11350	super-heated leaf	0		
 11351	squat lit leaf lasso	0		
 11352	tied-up leaflet	0		
@@ -11228,21 +11228,21 @@
 11373	Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
 11375	Boltsmann ID badge	0		
-11376	upside-down pulsating housekeeping automa-core	0		
+11376	pulsating upside-down housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	tasty pickled bread	3	awesome	Last Available: "2023-12"
 11379	toothsome spinning salted mutton	3	awesome	Last Available: "2023-12"
-11380	decent half-sized upside-down corned beet	2	good	Last Available: "2023-12"
+11380	half-sized decent upside-down corned beet	2	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
 11384	tiny Crimbuccaneer Foundry	0		Initiative: +3
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
-11387	jittery cyan pirate encryption key bravo	0		Last Available: "2023-12"
-11388	purple squat pirate encryption key charlie	0		Last Available: "2023-12"
+11387	cyan jittery pirate encryption key bravo	0		Last Available: "2023-12"
+11388	squat purple pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
-11390	ghostly skewed skewed wardrobe-o-matic	0		
+11390	skewed skewed ghostly wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
@@ -11275,11 +11275,11 @@
 11420	bouncing auspicious Van der Graaf supercharged Crimbuccaneer tavern swab	0		Maximum MP Percent: +30, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11421	wobbly Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	bad old-school pirate grog	4	decent	Last Available: "2023-12"
-11423	jumbo fancy toothsome grog nuts	5	awesome	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2023-12"
+11423	fancy jumbo toothsome grog nuts	5	awesome	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2023-12"
 11424	wobbly miser's cool sawed-off blunderbuss of the sewer	0		Moxie: +5, Stench Damage: +25, Meat Drop: +10, Last Available: "2023-12"
 11425	hand-crafted huge officer's nog	4	EPIC	Last Available: "2023-12"
 11426	olive peppermint bomb	0		Last Available: "2023-12"
-11427	bland jumbo tumbling sundae ration	5	decent	Last Available: "2023-12"
+11427	jumbo bland tumbling sundae ration	5	decent	Last Available: "2023-12"
 11428	delicious spinning peppermint tack	3	awesome	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	stale whalesteak	3	decent	Last Available: "2023-12"
@@ -11314,7 +11314,7 @@
 11459	tiny stale pulsating sugarplum ration	1	decent	Last Available: "2023-12"
 11460	low-calorie adequate gingerbread nylons	1	good	Last Available: "2023-12"
 11461	spoiled rum-soaked fruitcake	4	crappy	Last Available: "2023-12"
-11462	rotten thick bouncing shaking lime	5	crappy	Last Available: "2023-12"
+11462	rotten thick shaking bouncing lime	5	crappy	Last Available: "2023-12"
 11463	stale gingerbread pirate	3	decent	Last Available: "2023-12"
 11464	diet spoiled fruit-stuffed rumcake	1	crappy	Last Available: "2023-12"
 11465	mediocre maroon mulled wine	3	decent	Last Available: "2023-12"
@@ -11326,11 +11326,11 @@
 11471	ghostly Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	blinking Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	acceptable watered-down maroon ghostly yule grog	2	good	Last Available: "2023-12"
-11475	diet adequate wet tack	1	good	Last Available: "2023-12"
+11474	acceptable watered-down ghostly maroon yule grog	2	good	Last Available: "2023-12"
+11475	adequate diet wet tack	1	good	Last Available: "2023-12"
 11476	moldy enchanted whalecake	3	crappy	Effect: "Jelly Combed", Effect Duration: 30, Last Available: "2023-12"
 11477	teal auspicious therapeutic educational gunwale whalegun	0		Experience: +1, Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
-11478	tolerable maroon twirling and claret	3	good	Last Available: "2023-12"
+11478	tolerable twirling maroon and claret	3	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	nasty sage Elf Guard squirtgun	0		Mysticality Percent: +10, Stench Damage: +5, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
@@ -11346,7 +11346,7 @@
 11491	mirror therapeutic quilted Crimbuccaneer nose ring of the pedagogue	0		Experience: +3, Damage Absorption: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	wobbly Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	pulsating yellow Elf Guard safety bear	0		Last Available: "2023-12"
+11494	yellow pulsating Elf Guard safety bear	0		Last Available: "2023-12"
 11495	mirror kraken	0		Last Available: "2023-12"
 11496	narrow precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11393,7 +11393,7 @@
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	blurry encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	huge baby chest mimic	0		Free Pull
-11541	mirror narrow googly chest eyes	0		Familiar Weight: +5
+11541	narrow mirror googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	skewed friendly groovy Crimbuccaneer war standard	0		Moxie Percent: +10, Familiar Weight: +3, Last Available: "2023-12"
 11544	pulsating sizzling padded Elf Guard war standard	0		Damage Absorption: +20, Hot Damage: +10, Last Available: "2023-12"
@@ -11426,10 +11426,10 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	toothsome yam	3	awesome	Last Available: "2024-05"
-11574	drinkable watered-down yam martini	2	good	Last Available: "2024-05"
-11575	practically non-alcoholic lousy blurry sweet potato o' mine	1	decent	Last Available: "2024-05"
+11574	watered-down drinkable yam martini	2	good	Last Available: "2024-05"
+11575	lousy practically non-alcoholic blurry sweet potato o' mine	1	decent	Last Available: "2024-05"
 11576	fortified mediocre Southern yam	5	decent	Last Available: "2024-05"
-11577	bad weak bouncing sweet potato punch	2	decent	Last Available: "2024-05"
+11577	weak bad bouncing sweet potato punch	2	decent	Last Available: "2024-05"
 11578	thick spoiled twirling Mayam spinach	5	crappy	Last Available: "2024-05"
 11579	spoiled huge yam and swiss	3	crappy	Last Available: "2024-05"
 11580	knitted Van der Graaf yam cannon of wisdom	0		Mysticality: +15, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,8 +11439,8 @@
 11584	teal scandalous sizzling furry yam buckler of the sweet-tooth	0		Hot Damage: +10, Sleaze Damage: +5, Candy Drop: +100, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	spinning thanksgiving bomb	0		Last Available: "2024-05"
 11586	blue resourceful curative Sinatra's yamtility belt	0		Experience (Moxie): +5, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-05"
-11587	tiny rotten yam slider	1	crappy	Last Available: "2024-05"
-11588	adequate snack-sized yam mayo	2	good	Last Available: "2024-05"
+11587	rotten tiny yam slider	1	crappy	Last Available: "2024-05"
+11588	snack-sized adequate yam mayo	2	good	Last Available: "2024-05"
 11589	moldy yam burrito	3	crappy	Last Available: "2024-05"
 11590	upside-down visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11448,18 +11448,18 @@
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	delicious immense maroon mini kiwi	9	awesome	Last Available: "2024-06"
 11595	twirling weightlifter's mini kiwi bikini of Calamity Jane of the detective	0		Muscle: +15, Critical Hit Percent: +15, Item Drop: +20, Last Available: "2024-06"
-11596	perfectly mixed practically non-alcoholic wobbly mini kiwitini	1	EPIC	Last Available: "2024-06"
+11596	practically non-alcoholic perfectly mixed wobbly mini kiwitini	1	EPIC	Last Available: "2024-06"
 11597	tumbling mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	huge friendly Jim Carey's deadly mini kiwi silicon tiepin	0		Weapon Damage: +5, Monster Level: +25, Familiar Weight: +3
 11600	ghostly mini kiwi tipi	0		
-11601	decent super-sized mini kiwi digitized cookies	5	good	
+11601	super-sized decent mini kiwi digitized cookies	5	good	
 11602	tolerable distilled mini kiwi intoxicating spirits	5	good	
 11603	irradiated improved mini kiwi antimilitaristic hippy petition	0		Effect: "Human-Horror Hybrid", Effect Duration: 45
 11604	magnetized frozen wobbly mini kiwi illicit antibiotic	0		Effect: "Flower Power", Effect Duration: 33
 11605	spinning narrow Jeselnik's resourceful mini kiwi whipping stick	0		Maximum MP: +50, Sleaze Damage: +25
 11606	bouncing foul-smelling mini kiwi icepick	0		Stench Damage: +10
-11607	quantum unsweetened wobbly fuchsia mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "You Read The Manual", Effect Duration: 26
+11607	quantum unsweetened fuchsia wobbly mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "You Read The Manual", Effect Duration: 26
 11608	blue packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	huge protogenetic chunklet (synapse)	0		
@@ -11470,9 +11470,9 @@
 11615	gravedigger's sage messenger bag RNA of doom	0		Mysticality Percent: +10, Spooky Damage: +10, Spooky Spell Damage: +50
 11616	huge flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	decent super-sized lime green bacteria bisque	5	good	
+11618	super-sized decent lime green bacteria bisque	5	good	
 11619	thick bland squat ciliophora chowder	5	decent	
-11620	delicious miniature shaking ghostly cream of chloroplasts	2	awesome	
+11620	miniature delicious shaking ghostly cream of chloroplasts	2	awesome	
 11621	blue synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11481,7 +11481,7 @@
 11626	unevolved organism	0		Free Pull
 11627	tumbling extra ooze	0		
 11628	upside-down extra DNA	0		Experience (familiar): +1
-11629	teal squat untorn tearaway pants package	0		Free Pull
+11629	squat teal untorn tearaway pants package	0		Free Pull
 11630	shaking greasy chilly wicked tearaway pants of bravery of Flo-Jo	0		Spell Damage: +5, Cold Damage: +5, Sleaze Spell Damage: +10, Spooky Resistance: +5, Initiative: +100, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	pulsating baby bodyguard	0		
 11632	Doll Moll violin case	0		
@@ -11502,11 +11502,11 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	upside-down scandalous hale beefcake's embers-only jacket	0		Muscle: +25, Maximum HP: +20, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2024-09"
 11649	mirror horrifying bembershoot	0		Spooky Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
-11650	normal bite-sized wheel of camembert	1	good	Last Available: "2024-09"
+11650	bite-sized normal wheel of camembert	1	good	Last Available: "2024-09"
 11651	veiny ruddy padded hat of remembering	0		Damage Absorption: +20, Maximum HP Percent: +40, Maximum HP: +10, Lasts Until Rollover, Last Available: "2024-09"
 11652	mirror throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
-11654	fuchsia blinking embering hunk	0		Last Available: "2024-09"
+11654	blinking fuchsia embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
 11656	twirling wobbly photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	red boxed bat wings	0		Free Pull, Last Available: "2024-10"
@@ -11526,7 +11526,7 @@
 11671	auspicious beefy photo booth supply list	0		Muscle: +10, Item Drop: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	skewed peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
-11674	super-sized flavorless whirled peas	5	decent	Last Available: "2024-11"
+11674	flavorless super-sized whirled peas	5	decent	Last Available: "2024-11"
 11675	decent yellow peaza	3	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	distilled squat drenchrome 2.0	1		Last Available: "2025-12"
@@ -11535,7 +11535,7 @@
 11680	quantum watch	0		Adventures: +2
 11681	blue quantized familiar experience	0		
 11682	boiled warmed flattened pea brittle	0		Effect: "Yuletide Industry", Effect Duration: 46, Last Available: "2024-11"
-11683	delicious special practically non-alcoholic peasco	1	awesome	Effect: "The Strength...  of the Future", Effect Duration: 15, Last Available: "2024-11"
+11683	practically non-alcoholic delicious special peasco	1	awesome	Effect: "The Strength...  of the Future", Effect Duration: 15, Last Available: "2024-11"
 11684	toothsome immense piece of cake	7	awesome	Last Available: "2024-11"
 11685	huge blue handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
@@ -11576,7 +11576,7 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	miniature stale coney haunch	2	decent	Last Available: "2024-12"
 11723	anodized diffused twirling dark chocolate egg	0		Effect: "Hyphemariffic", Effect Duration: 37, Last Available: "2024-12"
-11724	weak mediocre blinking moai toai	2	decent	
+11724	mediocre weak blinking moai toai	2	decent	
 11725	blurry censurious wicked brawny moaiball	0		Muscle Percent: +20, Spell Damage: +5, Sleaze Resistance: +3, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	tarnished four-leaf potato sprout	0		Effect: "Hardened Fabric", Effect Duration: 33, Last Available: "2024-12"
@@ -11603,12 +11603,12 @@
 11748	bad Irish eggnog	3	decent	Last Available: "2024-12"
 11749	perfectly mixed watered-down canteen of jungle juice	2	EPIC	Last Available: "2024-12"
 11750	artisanal turchucken	4	EPIC	Last Available: "2024-12"
-11751	watered-down smooth skewed mechanically-mulled cider	2	awesome	Last Available: "2024-12"
+11751	smooth watered-down skewed mechanically-mulled cider	2	awesome	Last Available: "2024-12"
 11752	smooth bouncing holiday trip around the world	3	awesome	Last Available: "2024-12"
-11753	delicious narrow blurry chocolate ostrich egg	4	awesome	Last Available: "2024-12"
+11753	delicious blurry narrow chocolate ostrich egg	4	awesome	Last Available: "2024-12"
 11754	normal low-calorie beef and cabbage	1	good	Last Available: "2024-12"
 11755	flavorless massive candy rations	6	decent	Last Available: "2024-12"
-11756	tiny normal double-candied yams	1	good	Last Available: "2024-12"
+11756	normal tiny double-candied yams	1	good	Last Available: "2024-12"
 11757	decent Christmas ham	3	good	Last Available: "2024-12"
 11758	decent jumbo holiday smorgasbord	5	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
@@ -11643,7 +11643,7 @@
 11788	1	0		Last Available: "2025-12"
 11789	bouncing 0	0		Last Available: "2025-12"
 11790	compressed yellow eXpand	1		Last Available: "2025-12"
-11791	gray shaking brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	shaking gray brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	mirror datastick	0		Last Available: "2025-12"
 11793	bouncing dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11663,7 +11663,7 @@
 11808	server room key	0		Last Available: "2025-12"
 11809	jittery yellow 3d printed server room key	0		Last Available: "2025-12"
 11810	spinning dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
-11811	shaking mirror logic grenade	0		Last Available: "2025-12"
+11811	mirror shaking logic grenade	0		Last Available: "2025-12"
 11812	diluted psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
@@ -11697,7 +11697,7 @@
 11842	pulsating dark manioc	0		
 11843	skewed narrow Observer source code	0		
 11844	chill gherkin	0		
-11845	pulsating bouncing childrens' stapler	0		
+11845	bouncing pulsating childrens' stapler	0		
 11846	plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
@@ -11714,8 +11714,8 @@
 11859	mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	squat Leprecondo	0		Last Available: "2025-03"
-11862	dried skewed shaking scoop of pre-workout powder	1		Last Available: "2025-03"
-11863	spinning blue table tennis ball	0		Last Available: "2025-03"
+11862	dried shaking skewed scoop of pre-workout powder	1		Last Available: "2025-03"
+11863	blue spinning table tennis ball	0		Last Available: "2025-03"
 11864	high-proof acceptable pint of Leprechaun Stout	9	good	Last Available: "2025-03"
 11865	pickled spinning narrow phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
@@ -11728,18 +11728,18 @@
 11873	flavorless burrito	3	decent	Last Available: "2025-03"
 11874	rotten small beer brat	3	crappy	Last Available: "2025-03"
 11875	huge normal yellow peach pie	9	good	Last Available: "2025-03"
-11876	normal low-calorie incredible mini-pizza	1	good	Last Available: "2025-03"
+11876	low-calorie normal incredible mini-pizza	1	good	Last Available: "2025-03"
 11877	mediocre Divine sidecar	4	decent	Last Available: "2025-03"
-11878	fancy acceptable twirling tangarita sidecar	4	good	Effect: "Hot Buttoned", Effect Duration: 35, Last Available: "2025-03"
+11878	acceptable fancy twirling tangarita sidecar	4	good	Effect: "Hot Buttoned", Effect Duration: 35, Last Available: "2025-03"
 11879	artisanal gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	mediocre vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
-11881	weak acceptable prussian cathouse sidecar	2	good	Last Available: "2025-03"
+11881	acceptable weak prussian cathouse sidecar	2	good	Last Available: "2025-03"
 11882	triple-distilled mediocre twirling Mon Tiki sidecar	9	decent	Last Available: "2025-03"
 11883	blinking Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	yellow mansplainer's April Shower Thoughts shield of dire peril	0		Weapon Damage: +20, Monster Level: +15, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	olive spitball	0		Last Available: "2025-04"
-11887	polarized bouncing upside-down wet paper weights	0		Effect: "Abyssal Sweat", Effect Duration: 69, Last Available: "2025-04"
+11887	polarized upside-down bouncing wet paper weights	0		Effect: "Abyssal Sweat", Effect Duration: 69, Last Available: "2025-04"
 11888	watered-down mediocre Three Sheets to the Wind	2	decent	Last Available: "2025-04"
 11889	flavorless skewed pile of wet dates	3	decent	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
@@ -11769,10 +11769,10 @@
 11914	miser's imposing pilgrim's hat	0		Meat Drop: +10
 11915	blinking crown of thorns	0		
 11916	tumbling censurious stylish bycocket	0		Sleaze Resistance: +3
-11917	cyan ghostly Thwaitgold mad hatterpillar statuette	0		
+11917	ghostly cyan Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
 11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
-11920	skewed upside-down jittery flak shield	0		Damage Reduction: 9
+11920	upside-down jittery skewed flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	maroon yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
 11923	exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
@@ -11780,17 +11780,17 @@
 11925	teal fireproof medical-grade Axis fatigues	0		Hot Resistance: +3, HP Regen Min: 7, HP Regen Max: 10
 11926	stanky beefcake's Axis suspenders	0		Muscle: +25, Stench Spell Damage: +25, Single Equip
 11927	stolen artifact	0		
-11928	huge jittery really expensive stolen artifact	0		
+11928	jittery huge really expensive stolen artifact	0		
 11929	priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	spinning nice nylon stockings	0		
-11932	spinning narrow Allied Radio Backpack Pack	0		Free Pull
+11932	narrow spinning Allied Radio Backpack Pack	0		Free Pull
 11933	miser's cool Allied Radio Backpack of Leguizamo	0		Moxie: +5, Monster Level: +20, Meat Drop: +10, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	bland huge Skeleton Wars rations	9	decent	
-11938	drinkable bouncing jittery skeleton war fuel can	3	good	
+11938	drinkable jittery bouncing skeleton war fuel can	3	good	
 11939	blue skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11805,9 +11805,9 @@
 11950	spinning chaotic time cop top hat	0		Spell Critical Percent: +10, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	diluted mixed berry jelly	1		Last Available: "2025-08"
-11953	jumbo normal toast with mixed berry jelly	5	good	Last Available: "2025-08"
+11953	normal jumbo toast with mixed berry jelly	5	good	Last Available: "2025-08"
 11954	bland wobbly cup of sugar	3	decent	Last Available: "2025-08"
-11955	normal enchanted Susie's cupcake	4	good	Effect: "Human-Slime Hybrid", Effect Duration: 30, Last Available: "2025-08"
+11955	enchanted normal Susie's cupcake	4	good	Effect: "Human-Slime Hybrid", Effect Duration: 30, Last Available: "2025-08"
 11956	maroon clock	0		Last Available: "2025-08"
 11957	smooth thinker's the gun of Gandalf	0		Mysticality: +10, Moxie: +15, Spell Critical Percent: +20, Last Available: "2025-08"
 11958	drinkable mirror wine	4	good	Last Available: "2025-08"
@@ -11816,8 +11816,8 @@
 11962	huge sage undersea surveying goggles	0		Mysticality Percent: +10, Lasts Until Rollover
 11963	drinkable Ocean-Touched Rum	3	good	
 11964	diluted water-logged pill	1		
-11965	snack-sized decent kelp puck	2	good	
-11966	spinning teal scroll of sea strength	0		
+11965	decent snack-sized kelp puck	2	good	
+11966	teal spinning scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	mirror scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
@@ -11844,7 +11844,7 @@
 12054	dehydrated medicinal gruel	1		
 12055	bland small full-sized pumpkin pie	2	decent	Last Available: "2025-11"
 12056	weak hand-crafted vodka cranberry sauce	2	super ultra EPIC	Last Available: "2025-11"
-12057	corrupted wobbly skewed yammed candy	0		Effect: "Tingly Elbows", Effect Duration: 15, Last Available: "2025-11"
+12057	corrupted skewed wobbly yammed candy	0		Effect: "Tingly Elbows", Effect Duration: 15, Last Available: "2025-11"
 12058	bland huge treasure chestnut	3	decent	Last Available: "2025-12"
 12059	acceptable huge mulled butter rum	4	good	Last Available: "2025-12"
 12060	electrified irradiated green cinnamon doubloon	0		Effect: "For Your Brain Only", Effect Duration: 64, Last Available: "2025-12"
@@ -11878,9 +11878,9 @@
 12120	burnt skull	0		Last Available: "2025-12"
 12121	spinning Crymbocurrency	0		Last Available: "2025-12"
 12122	narrow extra-thick Crimbo sweater of the brazier	0		Hot Spell Damage: +25, Last Available: "2025-12"
-12123	blurry purple The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12123	purple blurry The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	drinkable watered-down Steve Abrams' Holiday Sampler Beer	2	good	Last Available: "2025-12"
-12125	huge gray crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
+12125	gray huge crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	bad bottle of prize-winning rum	3	decent	Last Available: "2025-12"
 12127	sizzling Oprah's supercharged Santa-Slayer medal	0		Maximum MP Percent: 80, Hot Damage: +10, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
@@ -11911,7 +11911,7 @@
 12153	skewed scorched skeleton pants of Gandalf of the sewer	0		Spell Critical Percent: +20, Stench Damage: +25, Last Available: "2025-12"
 12154	messenger parrot egg	0		Last Available: "2025-12"
 12155	fuchsia buryable chest	0		Last Available: "2025-12"
-12156	jittery ghostly Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
+12156	ghostly jittery Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
@@ -11928,11 +11928,11 @@
 12170	perfumed careful heat-resistant harpoon pistol	0		Monster Level: -10, Stench Resistance: +5, Last Available: "2025-12"
 12171	bland traditional gingerloaf	3	decent	Last Available: "2025-12"
 12172	drinkable gray Scotch and eggnog	3	good	Last Available: "2025-12"
-12173	nitrogenated upside-down blurry ghostly counterskeleton elixir	0		Effect: "Permafrosty", Effect Duration: 67, Last Available: "2025-12"
-12174	hand-crafted practically non-alcoholic cyan &quot;salvaged&quot; wine	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12173	nitrogenated upside-down ghostly blurry counterskeleton elixir	0		Effect: "Permafrosty", Effect Duration: 67, Last Available: "2025-12"
+12174	practically non-alcoholic hand-crafted cyan &quot;salvaged&quot; wine	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12175	yellow The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	flavorless enchanted wedge of prize-winning cheese	4	decent	Effect: "Nature's Bounty", Effect Duration: 30, Last Available: "2025-12"
+12177	enchanted flavorless wedge of prize-winning cheese	4	decent	Effect: "Nature's Bounty", Effect Duration: 30, Last Available: "2025-12"
 12178	corrupted warmed ghostly gummi fingerbone	0		Effect: "Healthy Bronze Glow", Effect Duration: 54
 12179	Tesla glimmering crystal of bravery	0		Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 12180	narrow wobbly boxed Heartstone	0		Free Pull, Last Available: "2026-02"
@@ -11965,7 +11965,7 @@
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	jittery Pork Elf toilet	0		Last Available: "2026-03"
 12209	spoiled rat pizza	3	crappy	Last Available: "2026-03"
-12210	wobbly spinning Fleek&trade; mascara	0		Last Available: "2026-03"
+12210	spinning wobbly Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	asbestos-lined MacGyver's hoverboard of wisdom	0		Mysticality: +15, Maximum MP: +100, Hot Resistance: +5, Single Equip, Last Available: "2026-03"
 12212	careful wizardly left shark fin of the cougar	0		Mysticality: +25, Moxie: +20, Monster Level: -10, Last Available: "2026-03"
 12213	lion tamer's fitness tracking bracelet	0		Experience (familiar): +2, Single Equip, Last Available: "2026-03"
@@ -11982,15 +11982,15 @@
 12228	moldy snack-sized shaking ratbatatouille	2	crappy	
 12229	spoiled pulsating onigiri	4	crappy	
 12230	spoiled mirror crudit&eacute;s	3	crappy	
-12231	snack-sized normal squat sauced mutton	2	good	
+12231	normal snack-sized squat sauced mutton	2	good	
 12232	miniature adequate blurry hot honey ant	2	good	
-12233	small flavorless tomb aspic	2	decent	
+12233	flavorless small tomb aspic	2	decent	
 12234	big stale jittery later tots	5	decent	
 12235	rotten Frutti di Scatoletta	4	crappy	Last Available: "2026-05"
 12236	bland Pesto alla Marziano	3	decent	Last Available: "2026-05"
-12237	moldy huge Arrattabbattabiata	8	crappy	Last Available: "2026-05"
-12238	small adequate tumbling Orzo di Riso	2	good	Last Available: "2026-05"
-12239	yummy enchanted ghostly Pasta Grimavera	3	awesome	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2026-05"
+12237	huge moldy Arrattabbattabiata	8	crappy	Last Available: "2026-05"
+12238	adequate small tumbling Orzo di Riso	2	good	Last Available: "2026-05"
+12239	enchanted yummy ghostly Pasta Grimavera	3	awesome	Effect: "Protection from Bad Stuff", Effect Duration: 30, Last Available: "2026-05"
 12240	bland Linguini Ubriacapa	3	decent	Last Available: "2026-05"
 12241	toothsome shaking Formica e Pepe	4	awesome	Last Available: "2026-05"
 12242	bland tumbling Tubetto Gelatto	3	decent	Last Available: "2026-05"
@@ -12000,8 +12000,8 @@
 12246	green second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	lime green baleful arcane researcher's Space Soldier Helmet	0		Experience Percent (Mysticality): +10, Spell Damage: +25
-12253	big adequate tumbling premium turkey leg	5	good	
-12254	practically non-alcoholic tolerable tumbling styrofoam cup of mead	1	good	
+12253	adequate big tumbling premium turkey leg	5	good	
+12254	tolerable practically non-alcoholic tumbling styrofoam cup of mead	1	good	
 12255	scorching sword	0		Hot Damage: +25
 12256	spinning purple Fonzie's staff	0		Experience (Moxie): +1
 12257	bouncing stanky lute	0		Stench Spell Damage: +25
@@ -12027,7 +12027,7 @@
 12277	stale classic banana pie	4	decent	Last Available: "2026-07"
 12278	flattened huge huge essential banana decoction	0		Effect: "Booooooze", Effect Duration: 64, Last Available: "2026-07"
 12279	vacuum-sealed enhanced blue banana quintessence	0		Effect: "Strong Grip", Effect Duration: 42, Last Available: "2026-07"
-12280	hand-crafted irresponsibly strong jittery Aesop Daiquiri	6	EPIC	Last Available: "2026-07"
+12280	irresponsibly strong hand-crafted jittery Aesop Daiquiri	6	EPIC	Last Available: "2026-07"
 12281	tolerable tumbling Monkey Congress	3	good	Last Available: "2026-07"
 12282	stale watermelon pie	3	decent	Last Available: "2026-07"
 12283	boiled corrupted green concentrated watermelon juice	0		Effect: "High Blood Chocolate Content", Effect Duration: 62, Last Available: "2026-07"
@@ -12037,12 +12037,12 @@
 12287	bland bouncing quince pie	4	decent	Last Available: "2026-07"
 12288	enhanced corrupted shaking skewed quince quaff	0		Effect: "Polka Face", Effect Duration: 66, Last Available: "2026-07"
 12289	corrupted non-deionized Quickquince	0		Effect: "Good with the Ladies", Effect Duration: 42, Last Available: "2026-07"
-12290	bad enchanted squat tumbling Quiskey Sour	3	decent	Effect: "Dirty Pear", Effect Duration: 40, Last Available: "2026-07"
-12291	bad bouncing narrow Quincea&ntilde;era Cooler	4	decent	Last Available: "2026-07"
+12290	enchanted bad squat tumbling Quiskey Sour	3	decent	Effect: "Dirty Pear", Effect Duration: 40, Last Available: "2026-07"
+12291	bad narrow bouncing Quincea&ntilde;era Cooler	4	decent	Last Available: "2026-07"
 12292	smooth practically non-alcoholic Roth IPA	1	awesome	Last Available: "2026-08"
 12293	shellacked underdraft protection of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40, Last Available: "2026-08"
 12294	gray solvent	0		Last Available: "2026-08"
-12295	decent massive ghostly soybean futures	7	good	Last Available: "2026-08"
+12295	massive decent ghostly soybean futures	7	good	Last Available: "2026-08"
 12296	improved housing bubble	0		Effect: "Super-Electrified", Effect Duration: 14, Last Available: "2026-08"
 12297	polarized Pixie-Swordz	0		Effect: "Chilblains of the Corn", Effect Duration: 13
 12298	twirling scandalous manspreader's financial instrument	0		Monster Level: +10, Sleaze Damage: +5, Last Available: "2026-08"
@@ -12053,7 +12053,7 @@
 12303	narrow wholesome strapping 401k ring	0		Muscle: +5, Maximum HP Percent: +10, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
 12305	cold-filtered tarnished invisible hand	0		Effect: "Dreadful Sheen", Effect Duration: 57, Last Available: "2026-08"
-12306	modified green blurry circle of overdraft protection scroll	0		Effect: "Heart Aflame", Effect Duration: 43, Last Available: "2026-08"
+12306	modified blurry green circle of overdraft protection scroll	0		Effect: "Heart Aflame", Effect Duration: 43, Last Available: "2026-08"
 12307	Vulcanized altered mint	0		Effect: "Hairy Palms", Effect Duration: 13, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Packrat_cafe_booze.txt
@@ -6,28 +6,28 @@
 -6	tolerable braincracker sweet	3	good	
 -16	tolerable fermented honey	4	good	
 -17	watered-down bad jittery moons-shine	2	decent	
--18	practically non-alcoholic perfectly mixed gin	1	EPIC	
+-18	perfectly mixed practically non-alcoholic gin	1	EPIC	
 -19	weak tolerable blurry ecto-nog	2	good	
 -20	drinkable hot toady	3	good	
 -21	mediocre hot choculate	3	decent	
 -49	artisanal Cyder	4	EPIC	
 -50	mediocre Oil Nog	3	decent	
--51	watered-down smooth Hi-Octane Peppermint Jet Fuel	2	awesome	
+-51	smooth watered-down Hi-Octane Peppermint Jet Fuel	2	awesome	
 -58	delicious Grimacider	3	awesome	
 -59	boozy tolerable Isotope Nog	5	good	
 -60	drinkable Mutagin 'n' Tonic	3	good	
--70	weak lousy Gin and Herring	2	decent	
+-70	lousy weak Gin and Herring	2	decent	
 -71	extra-dry drinkable Black and Tan and Red All Over	5	good	
--72	artisanal watered-down Antarctic Ice Tea	2	EPIC	
+-72	watered-down artisanal Antarctic Ice Tea	2	EPIC	
 -76	artisanal high-proof CRIMBCO Ribbon Candy Schnapps	6	EPIC	
--77	mediocre boozy CRIMBCO Egg Substitute Nog Substitute	5	decent	
+-77	boozy mediocre CRIMBCO Egg Substitute Nog Substitute	5	decent	
 -78	artisanal watered-down cyan CRIMBCO Extreme Braincracker Sour	2	EPIC	
--82	tolerable watered-down Horseradish-infused Vodka	2	good	
+-82	watered-down tolerable Horseradish-infused Vodka	2	good	
 -83	hand-crafted cyan Jerkitini	3	EPIC	
 -84	perfectly mixed narrow Desert Island Iced Tea	3	EPIC	
 -88	tolerable Crimbo Saketini	4	good	
 -89	hand-crafted Crimboku Drop	4	EPIC	
 -90	mediocre spirit-forward Flaming Crimbo Log	5	decent	
--107	weak hand-crafted Fortified Eggnog Slurry	2	EPIC	
+-107	hand-crafted weak Fortified Eggnog Slurry	2	EPIC	
 -108	perfectly mixed special Hot Buttered Rum	3	EPIC	
--109	artisanal irresponsibly strong Spicy Hot Chocolate	8	EPIC	
+-109	irresponsibly strong artisanal Spicy Hot Chocolate	8	EPIC	

--- a/data/TCRS/TCRS_Sauceror_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Packrat_cafe_food.txt
@@ -1,44 +1,44 @@
--1	rotten fancy Peche a la Frog	3	crappy	
--2	decent big blue As Jus Gezund Heit	5	good	
+-1	fancy rotten Peche a la Frog	3	crappy	
+-2	big decent blue As Jus Gezund Heit	5	good	
 -3	gigantic rotten twirling Bouillabaise Coucher Avec Moi	8	crappy	
 -7	rotten enchanted twirling gumdrop chow mein	4	crappy	
--8	jumbo bland mirror candy cane pizza	5	decent	
--9	moldy small spinning gingerbread stir-fry	2	crappy	
+-8	bland jumbo mirror candy cane pizza	5	decent	
+-9	small moldy spinning gingerbread stir-fry	2	crappy	
 -10	toothsome gigantic twigs and gravel	7	awesome	
--11	enchanted flavorless low-calorie wobbly shoots and leaves	1	decent	
--12	small rotten lime green bowl of unidentifiable goo	2	crappy	
+-11	flavorless enchanted low-calorie wobbly shoots and leaves	1	decent	
+-12	rotten small lime green bowl of unidentifiable goo	2	crappy	
 -13	rotten gingerbread massacre	3	crappy	
 -14	massive flavorless It Came From Beyond Dessert	8	decent	
--15	super-sized yummy vampire cake	5	awesome	
--52	delicious gigantic Soylent Red and Green	8	awesome	
+-15	yummy super-sized vampire cake	5	awesome	
+-52	gigantic delicious Soylent Red and Green	8	awesome	
 -53	adequate Disc-Shaped Nutrition Unit	4	good	
 -54	tasty Gingerborg Hive	4	awesome	
 -61	rotten big wobbly Candy Cane Surprise	5	crappy	
 -62	stale Grimdrop Chow Mein	3	decent	
 -63	bland massive Grimgerbread House	9	decent	
 -67	adequate Caviar Carbonara	4	good	
--68	miniature delicious narrow Halibut Alfredo	2	awesome	
+-68	delicious miniature narrow Halibut Alfredo	2	awesome	
 -69	decent Red Herring Velvet Cake	3	good	
--73	tiny stale tumbling CRIMBCO Reconstituted Gruel	1	decent	
+-73	stale tiny tumbling CRIMBCO Reconstituted Gruel	1	decent	
 -74	normal New and Improved CRIMBCO Reconstituted Gruel	4	good	
--75	normal immense jittery teal CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	good	
+-75	normal immense teal jittery CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	good	
 -79	bland bite-sized huge Brussels Sprout Stir-Fry	1	decent	
 -80	tasty Carrot, Cabbage, and Kale Pizza	4	awesome	
--81	spoiled twirling wobbly Turnip and Rutabaga Pie	4	crappy	
+-81	spoiled wobbly twirling Turnip and Rutabaga Pie	4	crappy	
 -85	gigantic rotten Rainbow Spider Fun Roll	7	crappy	
 -86	rotten half-sized Vegas Volcano Lava Roll	2	crappy	
 -87	stale tumbling Crazy Dragon Shogun Buddha Roll	3	decent	
--92	normal snack-sized gray basic hot dog	2	good	
--93	adequate gigantic squat savage macho dog	10	good	
+-92	snack-sized normal gray basic hot dog	2	good	
+-93	gigantic adequate squat savage macho dog	10	good	
 -94	bland squat one with everything	3	decent	
--95	special snack-sized tasty sly dog	2	awesome	
+-95	tasty snack-sized special sly dog	2	awesome	
 -96	flavorless miniature mirror devil dog	2	decent	
--97	moldy special red chilly dog	3	crappy	
+-97	special moldy red chilly dog	3	crappy	
 -98	small stale spinning ghost dog	2	decent	
 -99	special rotten pulsating junkyard dog	3	crappy	
--100	decent miniature wet dog	2	good	
--101	massive moldy sleeping dog	10	crappy	
--102	snack-sized moldy optimal dog	2	crappy	
+-100	miniature decent wet dog	2	good	
+-101	moldy massive sleeping dog	10	crappy	
+-102	moldy snack-sized optimal dog	2	crappy	
 -103	moldy green video games hot dog	4	crappy	
 -104	stale blinking Peppermint Nutrition Block	4	decent	
 -105	tasty maroon Gingerbread Nutrition Block	3	awesome	

--- a/data/TCRS/TCRS_Sauceror_Platypus.txt
+++ b/data/TCRS/TCRS_Sauceror_Platypus.txt
@@ -10,10 +10,10 @@
 10	mirror disco ball	0		
 11	blinking stolen accordion	0		Song Duration: 5
 12	twirling mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	dehydrated ghostly blinking moxie weed	1		Effect: "Human-Goblin Hybrid", Effect Duration: 40
-15	modified blue shaking strongness elixir	1		
+14	dehydrated blinking ghostly moxie weed	1		Effect: "Human-Goblin Hybrid", Effect Duration: 40
+15	modified shaking blue strongness elixir	1		
 16	dehydrated magicalness-in-a-can	1		Effect: "The Style... of the Future", Effect Duration: 25
-17	diet rotten squat noodles	1	crappy	
+17	rotten diet squat noodles	1	crappy	
 18	tortoise's blessing	0		
 19	twirling asparagus knife of the businessman	0		Meat Drop: +50
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -57,12 +57,12 @@
 58	stone turtle	0		
 59	olive slingshot	0		
 60	skewed ghostly mansplainer's Mace of the Tortoise	0		Monster Level: +15, Class: "Turtle Tamer"
-61	spoiled fancy blue fortune cookie	4	crappy	Effect: "Sugary Tongue", Effect Duration: 10
+61	fancy spoiled blue fortune cookie	4	crappy	Effect: "Sugary Tongue", Effect Duration: 10
 62	Van der Graaf oriole-feather headdress	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
 65	Mighty Bjorn action figure	0		
-66	yellow blurry twig	0		
+66	blurry yellow twig	0		
 67	spaghetti with rock-balls	0		
 68	shaking knitted Pasta Spoon of Peril of the glutton	0		Cold Resistance: +3, Food Drop: +100, Class: "Pastamancer"
 69	mirror Newbiesport&trade; tent	0		
@@ -77,7 +77,7 @@
 78	pulsating studded pretty bouquet	0		Damage Absorption: +80
 79	blurry bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	mediocre boozy ice-cold Willer	5	decent	
+81	boozy mediocre ice-cold Willer	5	decent	
 82	jittery ring	0		
 83	shaft	0		
 84	squat Orcish meat locker	0		
@@ -86,8 +86,8 @@
 87	skewed meat from yesterday	0		
 88	pulsating meat stack	0		
 89	wobbly sword hilt	0		
-90	teal tumbling helmet recipe	0		
-91	mirror skewed pants kit	0		
+90	tumbling teal helmet recipe	0		
+91	skewed mirror pants kit	0		
 92	meatsmithing guide	0		
 93	twirling prompt basic meat sword	0		Adventures: +3
 94	narrow shellacked basic meat pants	0		Damage Reduction: 7, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -141,7 +141,7 @@
 142	anticheese	0		
 143	cottage	0		
 144	jittery stone of eXtreme power	0		
-145	blue squat barbed-wire fence	0		
+145	squat blue barbed-wire fence	0		
 146	dinghy plans	0		
 147	zippy eXtreme meat sword	0		Initiative: +20
 148	eXtreme meat staff of doom	0		Spooky Spell Damage: +50
@@ -162,12 +162,12 @@
 163	dance instructor's skeleton bone	0		Experience Percent (Moxie): +10
 164	twirling smart skull	0		
 165	skewer	0		
-166	blue blurry ghuol ears	0		
+166	blurry blue ghuol ears	0		
 167	moldy mirror ghuol-ear kabob	3	crappy	
 168	beefcake's bone rattle	0		Muscle: +25
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	adequate miniature blinking lihc eye pie	2	good	
+171	miniature adequate blinking lihc eye pie	2	good	
 172	gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
@@ -176,7 +176,7 @@
 177	squat mirror brainy skull	0		
 178	ghostly detective skull	0		
 179	half-sized bland chorizo taco	2	decent	
-180	watered-down lousy narrow ice-cold fotie	2	decent	
+180	lousy watered-down narrow ice-cold fotie	2	decent	
 181	fuchsia baseball	0		
 182	batgut	0		
 183	tumbling bat wing	0		
@@ -195,12 +195,12 @@
 197	rat whisker	0		
 198	ghostly rat appendix	0		
 199	blinking yellow padded ring	0		Damage Absorption: +20
-200	low-calorie delicious rat appendix kabob	1	awesome	
+200	delicious low-calorie rat appendix kabob	1	awesome	
 201	moldy wobbly wobbly bouncing bat wing kabob	4	crappy	
-202	decent miniature carob chunks	2	good	
+202	miniature decent carob chunks	2	good	
 203	herbs	0		
-204	thick normal bouncing carob chunk cookies	5	good	
-205	mirror upside-down secret blend of herbs and spices	0		
+204	normal thick bouncing carob chunk cookies	5	good	
+205	upside-down mirror secret blend of herbs and spices	0		
 206	lime green piercing post	0		
 207	hippy herbal tea	1	crappy	
 208	gray patchouli incense stick	0		
@@ -211,7 +211,7 @@
 213	blinking steel-toed shellacked filthy corduroys	0		Damage Reduction: 32, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	asbestos-lined filthy knitted dread sack	0		Hot Resistance: +5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	delicious small carob brownies	2	awesome	
+216	small delicious carob brownies	2	awesome	
 217	spoiled herb brownies	4	crappy	
 218	hemp string	0		
 219	necklace chain	0		
@@ -220,7 +220,7 @@
 222	shaking phat turquoise bead	0		
 223	lard-coated phat turquoise bracelet	0		Sleaze Spell Damage: +25
 224	baleful eyepatch	0		Spell Damage: +25, Familiar Effect: "3xBarrr, cap 6"
-225	jumbo spoiled enchanted tofu casserole	5	crappy	Effect: "Deadly Flashing Blade", Effect Duration: 45
+225	spoiled jumbo enchanted tofu casserole	5	crappy	Effect: "Deadly Flashing Blade", Effect Duration: 45
 226	compressed tumbling can of Red Minotaur	1	decent	
 227	rosy-cheeked Kentucky-fried meat sword	0		Maximum HP Percent: +30
 228	brainy Kentucky-fried meat staff	0		Mysticality: +5
@@ -233,29 +233,29 @@
 235	avaricious Bigger Bugfinder Blade of horror	0		Spooky Spell Damage: +25, Meat Drop: +30
 236	huge Queue Du Coq cocktailcrafting kit	0		
 237	acceptable bottle of gin	4	good	
-238	enchanted bad practically non-alcoholic bottle of vodka	1	decent	Effect: "Phairly Pheromonal", Effect Duration: 20
+238	bad enchanted practically non-alcoholic bottle of vodka	1	decent	Effect: "Phairly Pheromonal", Effect Duration: 20
 239	ruddy Orcish baseball cap of the storm	0		Maximum HP Percent: +40, Maximum MP Percent: +40, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	groovy Orcish cargo shorts of the glutton	0		Moxie Percent: +10, Food Drop: +100, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	pulsating sage Orcish frat-paddle	0		Mysticality Percent: +10
 242	rotten	4	crappy	
-243	immense stale teal grapefruit	10	decent	
+243	stale immense teal grapefruit	10	decent	
 244	flavorless gigantic grapes	9	decent	
 245	toothsome tiny blurry olive	1	awesome	
 246	moldy tomato	3	crappy	
 247	blurry fermenting powder	0		
-248	drinkable spirit-forward salty dog	5	good	
+248	spirit-forward drinkable salty dog	5	good	
 249	practically non-alcoholic tolerable bloody mary	1	good	
 250	tolerable mirror screwdriver	3	good	
-251	practically non-alcoholic drinkable martini	1	good	
+251	drinkable practically non-alcoholic martini	1	good	
 252	weak tolerable twirling bloody beer	2	good	
 253	artisanal skewed shot of schnapps	4	EPIC	
 254	drinkable high-proof shot of grapefruit schnapps	6	good	
 255	practically non-alcoholic drinkable maroon narrow fine wine	1	good	
-256	drinkable enchanted weak shot of tomato schnapps	2	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50
-257	fancy high-proof bad wobbly extra-spicy bloody mary	6	decent	Effect: "Smoking like a Bandit", Effect Duration: 20
-258	twirling squat dense meat stack	0		
+256	enchanted weak drinkable shot of tomato schnapps	2	good	Effect: "Bugbear in Tooth and Claw", Effect Duration: 50
+257	bad fancy high-proof wobbly extra-spicy bloody mary	6	decent	Effect: "Smoking like a Bandit", Effect Duration: 20
+258	squat twirling dense meat stack	0		
 259	snake skin	0		
-260	spoiled gray blurry White Citadel fries	4	crappy	
+260	spoiled blurry gray White Citadel fries	4	crappy	
 261	snack-sized adequate White Citadel burger	2	good	
 262	gigantic normal jittery piece of wedding cake	6	good	
 263	rotten squat chocolate chips	4	crappy	
@@ -267,7 +267,7 @@
 269	Da Vinci's sword	0		Experience (Mysticality): +5
 270	skewed picket fence	0		
 271	compressed barbell	1		Effect: "Adrenaline Rush", Effect Duration: 20
-272	boiled jittery green squat concentrated magicalness pill	1		
+272	boiled squat jittery green concentrated magicalness pill	1		
 273	vaporized purple moxie weed	1		Effect: "Dwarven Hardiness", Effect Duration: 15
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
@@ -298,7 +298,7 @@
 300	wet jaba&ntilde;ero-flavored chewing gum	0		Effect: "Leash of Linguini", Effect Duration: 35
 301	cyan flat dough	0		
 302	toothsome Knob sausage	3	awesome	
-303	small adequate upside-down Knob mushroom	2	good	
+303	adequate small upside-down Knob mushroom	2	good	
 304	dry noodles	0		
 305	shaking wobbly Knob Goblin harem pants of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	banded Knob Goblin harem veil	0		Damage Absorption: +100, Familiar Effect: "5xLep, cap 2"
@@ -316,14 +316,14 @@
 318	spoiled blue bean burrito	3	crappy	
 319	yummy wobbly insanely bean burrito	3	awesome	
 320	decent tiny bat haggis	1	good	
-321	tiny normal narrow menudo	1	good	
+321	normal tiny narrow menudo	1	good	
 322	yummy goat cheese	3	awesome	
 323	adequate ghostly plain pizza	3	good	
 324	adequate sausage pizza	4	good	
 325	bland goat cheese pizza	4	decent	
 326	spoiled mushroom pizza	4	crappy	
 327	squat goat	0		
-328	watered-down hand-crafted bottle of whiskey	2	EPIC	
+328	hand-crafted watered-down bottle of whiskey	2	EPIC	
 329	green sharpshooter's goat beard	0		Critical Hit Percent: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	decent	
 331	artisanal Canadian	4	EPIC	
@@ -353,7 +353,7 @@
 355	mansplainer's eXtreme scarf	0		Monster Level: +15, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	hale snowboarder pants	0		Maximum HP: +20, Familiar Effect: "1xPotato, cap 25"
 357	blue Mountain Stream soda	0		
-358	normal small gr8ps	2	good	
+358	small normal gr8ps	2	good	
 359	flavorless ghostly t8r tots	3	decent	
 360	cyan bouncing Jeselnik's miner's helmet	0		Sleaze Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	skewed Jim Carey's miner's pants	0		Monster Level: +25, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -434,7 +434,7 @@
 436	balloon monkey	0		
 437	chef skull	0		
 438	narrow chef-in-the-box	0		
-439	blinking spinning bartender skull	0		
+439	spinning blinking bartender skull	0		
 440	bouncing bartender-in-the-box	0		
 441	ghostly chef-skull-in-the-box	0		
 442	bartender-skull-in-the-box	0		
@@ -462,7 +462,7 @@
 464	huge pixel potion	0		
 465	spinning pixel potion	0		
 466	pixel potion	0		
-467	adequate super-sized pixel pie	5	good	
+467	super-sized adequate pixel pie	5	good	
 468	huge ruby W	0		
 469	wussiness potion	0		
 470	artisanal Imp Ale	3	EPIC	
@@ -496,7 +496,7 @@
 498	spoiled blinking papaya	3	crappy	
 499	rosy-cheeked denim axe of the sewer	0		Maximum HP Percent: +30, Stench Damage: +25
 500	Elf Farm Raffle ticket	0		
-501	bland big pulsating Elfin shortbread	5	decent	
+501	big bland pulsating Elfin shortbread	5	decent	
 502	pagoda plans	0		
 503	adequate skewed skewered cat appendix	3	good	
 504	evil arches	0		
@@ -518,8 +518,8 @@
 520	cyan leaflet	0		
 521	teal ghostly blinking kickback cookbook of mayonnaise	0		Sleaze Spell Damage: +50
 522	one-winged stab bat	0		
-523	gray mirror rewinged stab bat	0		
-524	practically non-alcoholic artisanal papaya sling	1	EPIC	
+523	mirror gray rewinged stab bat	0		
+524	artisanal practically non-alcoholic papaya sling	1	EPIC	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	upside-down teal volleyball	0		
@@ -538,7 +538,7 @@
 540	liquefied blurry Tasty Fun Good rice candy	0		Effect: "The Power of Positive Thinking", Effect Duration: 17
 541	skewed wobbly draggin' ball hat of the sewer of horror	0		Stench Damage: +25, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 25"
 542	jittery green smooth 1337 7r0uZ0RZ of vim and vigor	0		Moxie: +15, Maximum HP Percent: +50, Familiar Effect: "2xPotato, cap 27"
-543	enchanted tasty fuchsia Trollhouse cookies	4	awesome	Effect: "Become Superficially interested", Effect Duration: 30
+543	tasty enchanted fuchsia Trollhouse cookies	4	awesome	Effect: "Become Superficially interested", Effect Duration: 30
 544	auspicious Newton's talons	0		Experience (Mysticality): +3, Item Drop: +10
 545	normal squat Spam Witch sammich	4	good	
 546	meat vortex	0		
@@ -549,13 +549,13 @@
 551	64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	low-calorie fancy bland pr0n cocktail	1	decent	Effect: "Dweeby", Effect Duration: 10
+554	low-calorie bland fancy pr0n cocktail	1	decent	Effect: "Dweeby", Effect Duration: 10
 555	green inspector's Temple Grandin's drywall axe	0		Familiar Weight: +7, Item Drop: +15
 556	manspreader's Pine-Fresh air freshener	0		Monster Level: +10
-557	perfectly mixed blue pulsating whiskey and cola	4	EPIC	
+557	perfectly mixed pulsating blue whiskey and cola	4	EPIC	
 558	snack-sized stale papaya taco	2	decent	
 559	razor-sharp can lid	0		
-560	rotten special stalk of asparagus	4	crappy	Effect: "Some Cheese with Your Wine", Effect Duration: 50
+560	special rotten stalk of asparagus	4	crappy	Effect: "Some Cheese with Your Wine", Effect Duration: 50
 561	olive pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -563,18 +563,18 @@
 565	upside-down greasy hobo gloves	0		Sleaze Spell Damage: +10, Single Equip
 566	teal quilted bum cheek	0		Damage Absorption: +40, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	half-sized flavorless Double Bacon Beelzeburger	2	decent	
+568	flavorless half-sized Double Bacon Beelzeburger	2	decent	
 569	moldy immense Lord of the Flies-sized fries	10	crappy	
 570	rotten miniature narrow Chicken Sandwich	2	crappy	
 571	wobbly Jumbo Dr. Lucifer	1	EPIC	
-572	normal miniature bouncing yellow Children's Meal of the Damned	2	good	
+572	normal miniature yellow bouncing Children's Meal of the Damned	2	good	
 573	adequate noodles	4	good	
-574	moldy huge huge noodles	7	crappy	
-575	spoiled gigantic painful penne pasta	8	crappy	
+574	huge moldy huge noodles	7	crappy	
+575	gigantic spoiled painful penne pasta	8	crappy	
 576	normal shaking ravioli della hippy	3	good	
 577	yummy pr0n m4nic0tti	4	awesome	
 578	snack-sized toothsome ghostly Hell ramen	2	awesome	
-579	tiny adequate boring spaghetti	1	good	
+579	adequate tiny boring spaghetti	1	good	
 580	upside-down sauce of the ages	0		
 581	pulsating schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
@@ -585,7 +585,7 @@
 587	corrupted super-spiky hair gel	0		Effect: "Drenched With Filth", Effect Duration: 18
 588	upside-down soft echo eyedrop antidote	0		
 589	tasty snack-sized cocoa eggshell fragment	2	awesome	
-590	jumbo bland cocoa eggshell fragment	5	decent	
+590	bland jumbo cocoa eggshell fragment	5	decent	
 591	blurry cocoa egg	0		
 592	house	0		
 593	twirling phonics down	0		
@@ -606,7 +606,7 @@
 608	Plastic Wrap Immateria	0		
 609	twirling S.O.C.K.	0		
 610	mirror procrastination potion	0		
-611	cyan twirling D	0		
+611	twirling cyan D	0		
 612	original G	0		
 613	plot hole	0		
 614	altered magnetized probability potion	0		Effect: "Gummi-Grin", Effect Duration: 28
@@ -644,8 +644,8 @@
 646	tasty shaking fruitcake	4	awesome	
 647	present	0		Last Available: "2004-11"
 648	arcane researcher's Crimbo sword	0		Experience Percent (Mysticality): +10, Last Available: "2004-10"
-649	spinning reassuring Crimbo hat	0		Spooky Resistance: +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	shaking wizardly Crimbo pants	0		Mysticality: +25, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	spinning reassuring Crimbo hat	0		Spooky Resistance: +1, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	shaking wizardly Crimbo pants	0		Mysticality: +25, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	curative exclusive ultra-rare item	0		HP Regen Min: 3, HP Regen Max: 5
 652	quantum egg	0		
 653	jittery intragalactic rowboat	0		
@@ -669,16 +669,16 @@
 671	pulsating blurry wholesome smooth grave robbing shovel	0		Moxie: +15, Maximum HP Percent: +10
 672	small yummy yellow cranberries	2	awesome	
 673	weak hand-crafted vodka and cranberry	2	EPIC	
-674	acceptable mirror skewed whiskey	3	good	
+674	acceptable skewed mirror whiskey	3	good	
 675	forbidden skull of the Bonerdagon	0		Spell Damage Percent: +50
 676	maroon dragonbone belt buckle	0		
 677	badass belt of doom	0		Spooky Spell Damage: +50
 678	chest of the Bonerdagon	0		
-679	smooth fancy watered-down shaking roll in the hay	2	awesome	Effect: "Smoking like a Bandit", Effect Duration: 25
-680	artisanal spirit-forward slap and tickle	5	EPIC	
+679	watered-down smooth fancy shaking roll in the hay	2	awesome	Effect: "Smoking like a Bandit", Effect Duration: 25
+680	spirit-forward artisanal slap and tickle	5	EPIC	
 681	bad slip 'n' slide	4	decent	
 682	bad a sump'm sump'm	3	decent	
-683	lousy practically non-alcoholic gray horizontal tango	1	decent	
+683	practically non-alcoholic lousy gray horizontal tango	1	decent	
 684	acceptable pink pony	4	good	
 685	twirling Usain Bolt's boxer's Mr. Shirt of bravery	0		Muscle Percent: +10, Spooky Resistance: +5, Initiative: +80
 686	thinker's knuckles	0		Mysticality: +10
@@ -735,8 +735,8 @@
 739	tambourine bells	0		
 740	sage tambourine	0		Mysticality Percent: +10
 741	jittery broken skull	0		
-742	decent miniature Knoll shroomkabob	2	good	
-743	normal small special mushroom	2	good	Effect: "Cock of the Walk", Effect Duration: 35
+742	miniature decent Knoll shroomkabob	2	good	
+743	special normal small mushroom	2	good	Effect: "Cock of the Walk", Effect Duration: 35
 744	non-dry green hair spray	0		Effect: "Chock Full o' Nanites", Effect Duration: 62
 746	stat script	0		
 747	Knob Goblin firecracker	0		
@@ -744,9 +744,9 @@
 749	bland warm mushroom	4	decent	
 750	spoiled twirling mushroom quesadilla	4	crappy	
 751	adequate half-sized cool mushroom	2	good	
-752	flavorless immense cool mushroom casserole	10	decent	
+752	immense flavorless cool mushroom casserole	10	decent	
 753	yummy snack-sized pointy mushroom	2	awesome	
-754	small yummy jittery cream of pointy mushroom soup	2	awesome	
+754	yummy small jittery cream of pointy mushroom soup	2	awesome	
 755	adequate blurry mushroom	4	good	
 756	tasty mushroom	3	awesome	
 757	moldy fuchsia mushroom	4	crappy	
@@ -756,7 +756,7 @@
 761	brine	0		
 762	lousy shaking pulsating especially salty dog	3	decent	
 763	ghostly pickling solution	0		
-764	snack-sized yummy spectral pickle	2	awesome	
+764	yummy snack-sized spectral pickle	2	awesome	
 765	briny vinegar	0		
 766	spinning ghost pickle on a stick	0		
 767	corrupted spinning cologne of contempt	0		Effect: "Meat the Flintstones", Effect Duration: 32
@@ -778,7 +778,7 @@
 783	'Villa' document	0		
 784	drinkable Acqua Del Piatto Merlot	3	good	Last Available: "2004-10"
 785	cyan raffle ticket	0		
-786	bland thick strawberry	5	decent	
+786	thick bland strawberry	5	decent	
 787	drinkable bottle of rum	3	good	
 788	hand-crafted strawberry daiquiri	4	EPIC	
 789	drinkable rum and cola	3	good	
@@ -787,14 +787,14 @@
 792	huge skewed Golden Mr. Accessory of Tarzan	0		Experience (Muscle): +3, Softcore Only
 793	frozen deionized oil of stability	0		Effect: "Ice Packed", Effect Duration: 42
 794	triple-chilled anodized oil of slipperiness	0		Effect: "Lubed", Effect Duration: 12
-795	aged tumbling olive Acque Luride Grezze Cabernet	3	awesome	Last Available: "2004-10"
+795	aged olive tumbling Acque Luride Grezze Cabernet	3	awesome	Last Available: "2004-10"
 796	Jack Frost's chilly cement shoes of Leguizamo	0		Monster Level: +20, Cold Damage: +5, Cold Spell Damage: +50, Last Available: "2004-10"
-797	spirit-forward hand-crafted rockin' wagon	5	EPIC	
-798	smooth boozy ocean motion	5	awesome	
-799	mediocre distilled fuzzbump	5	decent	
+797	hand-crafted spirit-forward rockin' wagon	5	EPIC	
+798	boozy smooth ocean motion	5	awesome	
+799	distilled mediocre fuzzbump	5	decent	
 800	yummy poutine	3	awesome	
 801	decent twirling blinking Knob stir-fry	4	good	
-804	jumbo adequate special Knoll stir-fry	5	good	Effect: "Lifted Spirits", Effect Duration: 25
+804	adequate special jumbo Knoll stir-fry	5	good	Effect: "Lifted Spirits", Effect Duration: 25
 805	stale wobbly stir-fry	3	decent	
 806	flavorless asparagus stir-fry	4	decent	
 807	delicious ghostly olive stir-fry	4	awesome	
@@ -804,7 +804,7 @@
 811	tiny stale tofu stir-fry	1	decent	
 812	flavorless pulsating pr0n stir-fry	4	decent	
 813	decent bouncing shaking Knob shells	3	good	
-814	jumbo rotten b&auml;tzle	5	crappy	
+814	rotten jumbo b&auml;tzle	5	crappy	
 815	moldy ratini	4	crappy	
 816	spoiled Knob stroganoff	4	crappy	
 817	rotten jittery menudo ravioli	4	crappy	
@@ -820,20 +820,20 @@
 827	murky potion	0		
 828	spinning baby killer bee	0		
 829	anti-anti-antidote	0		
-830	decent thick skewed royal jelly	5	good	
+830	thick decent skewed royal jelly	5	good	
 831	small box	0		
 832	box	0		
 833	quilted vorpal blade	0		Damage Absorption: +40
 834	nippy cornuthaum of wisdom	0		Mysticality: +15, Cold Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	hardy ring of aggravate monster	0		Maximum HP: +50
-836	stale skewed olive mind flayer corpse	3	decent	
+836	stale olive skewed mind flayer corpse	3	decent	
 837	acceptable Uovo Marcio Shiraz	4	good	Last Available: "2004-10"
 838	Mafia stogie of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, Last Available: "2004-10"
-839	aged special distilled Maiali Sifilitici Pinot Noir	5	awesome	Effect: "Bonelording", Effect Duration: 10, Last Available: "2004-10"
+839	special aged distilled Maiali Sifilitici Pinot Noir	5	awesome	Effect: "Bonelording", Effect Duration: 10, Last Available: "2004-10"
 840	brainy Mafia violin case of Leguizamo	0		Mysticality: +5, Monster Level: +20, Last Available: "2004-10"
 841	delicious tomato daiquiri	4	awesome	
 842	artisanal beertini	4	EPIC	
-843	weak perfectly mixed ghostly salty slug	2	EPIC	
+843	perfectly mixed weak ghostly salty slug	2	EPIC	
 844	tolerable twirling papaya slung	3	good	
 845	blurry cyan reassuring MAHI fez	0		Spooky Resistance: +1, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -849,13 +849,13 @@
 857	moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	lime green knife and fork	0		Familiar Weight: +5
-860	ghostly gray eye-pod	0		Familiar Weight: +5
+860	gray ghostly eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
 862	spinning magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
 865	bouncing lead necklace	0		Familiar Weight: +3
-866	pulsating squat shaving cream	0		
+866	squat pulsating shaving cream	0		
 867	unsweetened upside-down blinking pine tar	0		Effect: "Dreadful Heat", Effect Duration: 14
 869	forest tears	0		
 870	stiffened fetus-smashing club	0		Damage Reduction: 1
@@ -881,18 +881,18 @@
 890	low-calorie normal blinking balaclava baklava	1	good	
 891	hardy Warehouse 23 bling	0		Maximum HP: +50
 892	chilly curative bugbear-smiting sword of dire peril	0		Weapon Damage: +20, Cold Damage: +5, HP Regen Min: 3, HP Regen Max: 5
-893	artisanal high-proof lumbering jack	9	EPIC	
+893	high-proof artisanal lumbering jack	9	EPIC	
 894	blinking Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	pulsating spinning healthy Ms. Accessory	0		Maximum HP Percent: +20, Softcore Only
 896	shellacked Mr. Accessory Jr. of the blizzard	0		Damage Reduction: 7, Cold Spell Damage: +25, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
-899	olive tumbling custom avatar form	0		Free Pull
+899	tumbling olive custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	jittery espresso maker	0		Familiar Weight: +5
 902	twirling 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	acceptable Spasmi Dolorosi Del Rene Champagne	3	good	Last Available: "2004-10"
-904	scorching personal trainer's Newton's school Mafia knickerbockers	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Hot Damage: +25, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	scorching personal trainer's Newton's school Mafia knickerbockers	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Hot Damage: +25, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	altered fuchsia Yummy Tummy bean	0		Effect: "Ham-Fisted", Effect Duration: 13
 906	improved jittery Rock Pops	0		Effect: "Muscularrr", Effect Duration: 35
 907	pickled Vulcanized narrow Mr. Mediocrebar	0		Effect: "Extra-Wet", Effect Duration: 52
@@ -906,8 +906,8 @@
 915	twirling yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	ghostly mansplainer's padded intergalactic pom poms	0		Damage Absorption: +20, Monster Level: +15
 917	Mob Penguin protection contract	0		
-918	foul-smelling Radio Free Baseball Cap	0		Stench Damage: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	brawny Radio Free Pants	0		Muscle Percent: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	foul-smelling Radio Free Baseball Cap	0		Stench Damage: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	brawny Radio Free Pants	0		Muscle Percent: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	brawny Radio Free Foil	0		Muscle Percent: +20, Last Available: "2006-07"
 921	tasty small skewed radio button candy	2	awesome	
 922	foul-smelling severed rocking horse head	0		Stench Damage: +10
@@ -920,7 +920,7 @@
 929	stanky arse-shooting crossbow	0		Stench Spell Damage: +25
 931	drinkable spiced rum	4	good	
 932	lousy eggnog	4	decent	
-933	bland jittery narrow candy cane	3	decent	
+933	bland narrow jittery candy cane	3	decent	
 934	spoiled gingerbread bugbear	4	crappy	
 935	imitation nice watch of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2004-12"
 936	blinking Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	mirror small Crimbo Pressie	0		Last Available: "2004-12"
 940	jittery bow	0		Last Available: "2004-12"
 941	purple Crimbo stocking	0		Last Available: "2004-12"
-942	blinking maroon bowler of the pedagogue	0		Experience: +3, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	blinking maroon bowler of the pedagogue	0		Experience: +3, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	healthy Da Vinci's bow staff	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Last Available: "2004-12"
-944	pulsating cool bowlegged pants	0		Moxie: +5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	pulsating cool bowlegged pants	0		Moxie: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	upside-down skewered cherry	0		Last Available: "2004-12"
@@ -945,7 +945,7 @@
 955	dog trainer's fez of etymology	0		Experience (familiar): +1, Familiar Effect: "1xLep, cap 30"
 956	adequate ghostly carob chunk noodles	3	good	
 957	bland chorizo brownies	4	decent	
-958	adequate special chocolate and tomato pizza	3	good	Effect: "Papowerful", Effect Duration: 40
+958	special adequate chocolate and tomato pizza	3	good	Effect: "Papowerful", Effect Duration: 40
 959	flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -993,12 +993,12 @@
 1006	fancy rotten cherry	3	crappy	Effect: "Sticky Hands", Effect Duration: 10
 1007	pulsating reassuring coconut shell	0		Spooky Resistance: +1, Familiar Effect: "1xFairy, cap 7"
 1008	shaking rock-hard ice cubes	0		Damage Reduction: 5
-1009	extra-dry drinkable vodka martini	5	good	
-1010	triple-distilled delicious whiskey and soda	10	awesome	
+1009	drinkable extra-dry vodka martini	5	good	
+1010	delicious triple-distilled whiskey and soda	10	awesome	
 1011	perfectly mixed green monkey wrench	4	EPIC	
 1012	acceptable tequila sunrise	3	good	
-1013	bad weak shaking margarita	2	decent	
-1014	mediocre watered-down red strawberry wine	2	decent	
+1013	weak bad shaking margarita	2	decent	
+1014	watered-down mediocre red strawberry wine	2	decent	
 1015	smooth wine spritzer	3	awesome	
 1016	tolerable weak perpendicular hula	2	good	
 1017	perfectly mixed ducha de oro	3	EPIC	
@@ -1029,17 +1029,17 @@
 1043	wobbly rosy-cheeked string of beads	0		Maximum HP Percent: +30
 1044	pulsating inspector's string of beads	0		Item Drop: +15
 1045	banded plastic bottle opener	0		Damage Absorption: +100
-1046	shaking coward's traffic cone of courage	0		Monster Level: -20, Spooky Resistance: +3, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	shaking coward's traffic cone of courage	0		Monster Level: -20, Spooky Resistance: +3, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	perfectly mixed practically non-alcoholic maroon N. O. Beer	1	EPIC	
-1048	pickled shaking upside-down oyster egg	1		
+1048	pickled upside-down shaking oyster egg	1		
 1049	boiled oyster egg	1		
 1050	twisted blurry oyster egg	1		
 1051	shaking plastic oyster egg	0		
-1052	dried pulsating red upside-down oyster egg	1		
+1052	dried upside-down pulsating red oyster egg	1		
 1053	twisted oyster egg	1		Effect: "Meat the Flintstones", Effect Duration: 50
 1054	modified gray oyster egg	1		
 1055	plastic oyster egg	0		
-1056	boiled upside-down wobbly purple puce oyster egg	1		Effect: "Patent Prevention", Effect Duration: 20
+1056	boiled upside-down purple wobbly puce oyster egg	1		Effect: "Patent Prevention", Effect Duration: 20
 1057	altered teal puce oyster egg	1		Effect: "Hagnk's Gratitude", Effect Duration: 50
 1058	dehydrated spinning puce oyster egg	1		
 1059	shaking puce plastic oyster egg	0		
@@ -1050,12 +1050,12 @@
 1064	diluted twirling narrow oyster egg	1		Effect: "Petit Forbearance", Effect Duration: 50
 1065	pickled oyster egg	1		
 1066	altered blinking oyster egg	1		Effect: "Ancestral Disapproval", Effect Duration: 50
-1067	skewed spinning plastic oyster egg	0		
+1067	spinning skewed plastic oyster egg	0		
 1068	modified pulsating oyster egg	1		
 1069	powdered squat wobbly yellow oyster egg	1		
 1070	pickled upside-down oyster egg	1		
 1071	ghostly plastic oyster egg	0		
-1072	dried narrow mirror off-white oyster egg	1		Effect: "Hot Buttoned", Effect Duration: 15
+1072	dried mirror narrow off-white oyster egg	1		Effect: "Hot Buttoned", Effect Duration: 15
 1073	altered off-white oyster egg	1		
 1074	dried off-white oyster egg	1		
 1075	pulsating yellow off-white plastic oyster egg	0		
@@ -1075,7 +1075,7 @@
 1089	clockwork spine	0		
 1090	clockwork rings	0		
 1091	blinking clockwork claws	0		
-1092	tumbling narrow clockwork sheet	0		
+1092	narrow tumbling clockwork sheet	0		
 1093	clockwork counterclockwise dome	0		
 1094	clockwork sphere	0		
 1095	deactivated MicroMechaMech	0		
@@ -1122,21 +1122,21 @@
 1136	extra-anodized magnetized lipstick	0		Effect: "Squid Squint", Effect Duration: 47
 1137	blinking bicycle chain of the dark arts of the sewer	0		Spell Damage Percent: +100, Stench Damage: +25
 1138	mushroom fermenting solution	0		
-1139	artisanal special high-proof mushroom wine	10	EPIC	Effect: "The Power of Positive Thinking", Effect Duration: 50
+1139	artisanal high-proof special mushroom wine	10	EPIC	Effect: "The Power of Positive Thinking", Effect Duration: 50
 1140	perfectly mixed icy mushroom wine	3	EPIC	
-1141	fancy mediocre strong mushroom wine	5	decent	Effect: "Leo Rising", Effect Duration: 20
-1142	delicious practically non-alcoholic pointy mushroom wine	1	awesome	
-1143	boozy tolerable flat mushroom wine	5	good	
-1144	enchanted practically non-alcoholic hand-crafted teal cool mushroom wine	1	super ultra mega turbo EPIC	Effect: "Human-Penguin Hybrid", Effect Duration: 30
+1141	strong fancy mediocre mushroom wine	5	decent	Effect: "Leo Rising", Effect Duration: 20
+1142	practically non-alcoholic delicious pointy mushroom wine	1	awesome	
+1143	tolerable boozy flat mushroom wine	5	good	
+1144	hand-crafted practically non-alcoholic enchanted teal cool mushroom wine	1	super ultra mega turbo EPIC	Effect: "Human-Penguin Hybrid", Effect Duration: 30
 1145	lousy bouncing knob mushroom wine	4	decent	
 1146	perfectly mixed knoll mushroom wine	3	EPIC	
 1147	drinkable watered-down mushroom wine	2	good	
 1148	artisanal weak wobbly shot of flower schnapps	2	EPIC	
-1149	small yummy flower petal pie	2	awesome	
-1150	bad practically non-alcoholic bottle of single-barrel whiskey	1	decent	
+1149	yummy small flower petal pie	2	awesome	
+1150	practically non-alcoholic bad bottle of single-barrel whiskey	1	decent	
 1151	tumbling wicked Sinatra's discarded plastic fork	0		Experience (Moxie): +5, Spell Damage: +5
 1152	blinking gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	immense flavorless Retenez L'Herbe Pat&eacute;	7	decent	
+1153	flavorless immense Retenez L'Herbe Pat&eacute;	7	decent	
 1154	altered Breathetastic&trade; Premium Canned Air	1	good	
 1155	squat letter from King Ralph XI	0		
 1157	blue Temple Grandin's wholeberd	0		Familiar Weight: +7
@@ -1182,7 +1182,7 @@
 1197	Mob Penguin	0		
 1198	blue sabre-toothed lime	0		
 1199	maroon bugbear	0		
-1200	half-sized moldy twirling squat mugcake	2	crappy	
+1200	moldy half-sized squat twirling mugcake	2	crappy	
 1201	stale urinal cake	4	decent	
 1202	normal Happy Birthday, Claude! cake	3	good	
 1203	moldy personalized birthday cake	4	crappy	
@@ -1191,8 +1191,8 @@
 1206	bland ghostly velvet cake	3	decent	
 1207	delicious congratulatory cake	4	awesome	
 1208	spoiled bouncing angel-food cake	4	crappy	
-1209	rotten miniature devil's-food cake	2	crappy	
-1210	fancy bland huge birthday party jellybean cheesecake	7	decent	Effect: "Stinky Weapon", Effect Duration: 5
+1209	miniature rotten devil's-food cake	2	crappy	
+1210	huge bland fancy birthday party jellybean cheesecake	7	decent	Effect: "Stinky Weapon", Effect Duration: 5
 1211	balloon	0		
 1212	ghostly narrow balloon	0		
 1213	heart-shaped balloon	0		
@@ -1228,36 +1228,36 @@
 1244	skewed Fonzie's Glass Balls of the Goblin King	0		Experience (Moxie): +1
 1245	fuchsia Codpiece of the Goblin King of the sweet-tooth	0		Candy Drop: +100, Single Equip
 1246	frightening therapeutic rib of the Bonerdagon of wisdom	0		Mysticality: +15, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7
-1247	red shaking vertebra of the Bonerdagon	0		
+1247	shaking red vertebra of the Bonerdagon	0		
 1248	family-friendly smooth Bonerdagon necklace of the sewer	0		Moxie: +15, Stench Damage: +25, Sleaze Resistance: +1
 1249	bouncing deadly Boss Bat britches	0		Weapon Damage: +5, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	twirling red sizzling Boss Bat bling of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +10
 1251	normal Knob shroomkabob	4	good	
 1252	delicious half-sized shroomkabob	2	awesome	
 1253	pile of jumping beans	0		
-1254	super-sized fancy toothsome tumbling jittery jumping bean burrito	5	awesome	Effect: "Hella Smooth", Effect Duration: 25
+1254	super-sized fancy toothsome jittery tumbling jumping bean burrito	5	awesome	Effect: "Hella Smooth", Effect Duration: 25
 1255	massive adequate jumping bean burrito	8	good	
-1256	decent super-sized blurry insanely jumping bean burrito	5	good	
+1256	super-sized decent blurry insanely jumping bean burrito	5	good	
 1257	decent olive rat scrapple	4	good	
 1258	pail of pretentious paint	0		
-1259	Temple Grandin's traffic cone of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +7, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	Temple Grandin's traffic cone of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +7, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	purple wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	boiled Hatorade	1		
 1262	extremely unsafe weightlifter's off-hand balloon of the sweet-tooth	0		Muscle: +15, Weapon Damage Percent: +100, Candy Drop: +100
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
-1265	skewed tumbling ghostly box of sunshine	0		Free Pull
-1266	big stale purple gloomy mushroom	5	decent	
+1265	ghostly tumbling skewed box of sunshine	0		Free Pull
+1266	stale big purple gloomy mushroom	5	decent	
 1267	dead mimic	0		
 1268	pine wand	0		
 1269	purple ebony wand	0		
 1270	yellow hexagonal wand	0		
-1271	skewed yellow skewed aluminum wand	0		
+1271	yellow skewed skewed aluminum wand	0		
 1272	marble wand	0		
 1273	upside-down chaotic magic lamp	0		Spell Critical Percent: +10
-1274	boiled blue narrow Medicinal Herb's medicinal herbs	1		
+1274	boiled narrow blue Medicinal Herb's medicinal herbs	1		
 1275	nasty basic meat skirt	0		Stench Damage: +5, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	bad red tumbling Otorian Battle Scar	4	decent	
+1276	bad tumbling red Otorian Battle Scar	4	decent	
 1277	tumbling basic meat kilt of the wise owl	0		Mysticality: +20, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	mirror meat skirt of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	studded meat kilt	0		Damage Absorption: +80, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1283,11 +1283,11 @@
 1299	deadly pirate hook	0		Weapon Damage: +5
 1300	Tesla monster bait	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 1301	quadruple-dry moist deodorant	0		Effect: "Dances with Tweedles", Effect Duration: 13
-1302	alkaline blurry huge wobbly reodorant	0		Effect: "Burning Tongue", Effect Duration: 25
+1302	alkaline wobbly huge blurry reodorant	0		Effect: "Burning Tongue", Effect Duration: 25
 1303	pulsating pulsating fuchsia Mjolnir Jr.	0		
 1304	blurry doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	brawny stylish traffic cone	0		Moxie: +25, Muscle Percent: +20, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	brawny stylish traffic cone	0		Moxie: +25, Muscle Percent: +20, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	twirling calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	rotten questionable taco	3	crappy	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	narrow petrified time	0		Last Available: "2005-10"
-1323	skewed time helmet of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	mirror personal trainer's time trousers	0		Experience Percent (Muscle): +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	skewed time helmet of Gandalf	0		Spell Critical Percent: +20, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	mirror personal trainer's time trousers	0		Experience Percent (Muscle): +10, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	lion tamer's time sword	0		Experience (familiar): +2, Last Available: "2005-10"
 1326	careful Dyspepsi-Cola helmet	0		Monster Level: -10, Familiar Effect: "3xFairy, cap 7"
 1327	Cloaca-Cola shield of the brazier	0		Hot Spell Damage: +25, Damage Reduction: 4
@@ -1335,7 +1335,7 @@
 1352	tolerable redrum	4	good	
 1353	huge ninja pirate zombie robot	0		
 1354	skewed pile of pebbles	0		
-1355	stale huge bowl of oriole's nest soup	8	decent	
+1355	huge stale bowl of oriole's nest soup	8	decent	
 1356	bunny liver	0		
 1357	drinkable Mt. Noob Pale Ale	4	good	
 1358	gray pirate zombie head	0		Last Available: "2005-11"
@@ -1345,10 +1345,10 @@
 1362	sausage	0		
 1363	jittery clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	low-calorie bland tofurkey leg	1	decent	
+1365	bland low-calorie tofurkey leg	1	decent	
 1366	snack-sized normal tofurkey gravy	2	good	
-1367	toothsome bite-sized special herbal stuffing	1	awesome	Effect: "You Drank Fish Wine", Effect Duration: 45
-1368	bland half-sized can-shaped gelatinous cranberry sauce	2	decent	
+1367	special toothsome bite-sized herbal stuffing	1	awesome	Effect: "You Drank Fish Wine", Effect Duration: 45
+1368	half-sized bland can-shaped gelatinous cranberry sauce	2	decent	
 1369	spoiled yams	4	crappy	
 1370	foul-smelling rhinestone cowboy shirt	0		Stench Damage: +10
 1371	gingham blouse of dire peril	0		Weapon Damage: +20
@@ -1370,7 +1370,7 @@
 1388	upside-down toy wheel	0		
 1389	spinning yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
-1391	gray squat ball	0		Last Available: "2010-12"
+1391	squat gray ball	0		Last Available: "2010-12"
 1392	kite	0		Last Available: "2005-12"
 1393	pet rock	0		Last Available: "2005-12"
 1394	mirror doppelshifter	0		Last Available: "2005-12"
@@ -1384,13 +1384,13 @@
 1402	rag doll of the ox	0		Muscle: +20, Last Available: "2005-12"
 1403	therapeutic can of fake snow	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2005-12"
 1404	MacGyver's colored-light &quot;necklace&quot;	0		Maximum MP: +100, Last Available: "2005-12"
-1405	skewed tree skirt of the brute	0		Muscle Percent: +30, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	skewed tree skirt of the brute	0		Muscle Percent: +30, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	rotten wreath-shaped Crimbo cookie	3	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	yummy fuchsia bell-shaped Crimbo cookie	4	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	adequate tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	extremely unsafe Unionize The Elves sign	0		Weapon Damage Percent: +100, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	oxidized enhanced snowcone	0		Effect: "Fiery Spirit", Effect Duration: 26, Last Available: "2006-01"
 1413	double-ionized bouncing snowcone	0		Effect: "The Power of LOV", Effect Duration: 50, Last Available: "2006-01"
 1414	extra-ionized snowcone	0		Effect: "Deadly Flashing Blade", Effect Duration: 68, Last Available: "2006-01"
@@ -1399,15 +1399,15 @@
 1417	alkaline tumbling snowcone	0		Effect: "Ruthlessly Efficient", Effect Duration: 59, Last Available: "2006-01"
 1418	fuchsia Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	Van der Graaf traffic cone of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	Van der Graaf traffic cone of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	mirror ribald careful ice sickle	0		Monster Level: -10, Sleaze Damage: +10, Softcore Only, Last Available: "2006-02"
 1425	healthy ice baby	0		Maximum HP Percent: +20, Softcore Only, Last Available: "2006-02"
-1426	olive ice pick of bravery	0		Spooky Resistance: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	olive ice pick of bravery	0		Spooky Resistance: +5, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	upside-down Tesla ice skates of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	bland huge grue egg omelette	7	decent	
+1428	huge bland grue egg omelette	7	decent	
 1429	squat roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1432,11 +1432,11 @@
 1450	altered twinkly wad	1		
 1451	dehydrated narrow hot wad	1		
 1452	powdered blinking wad	1		
-1453	altered wobbly purple wad	1		Effect: "Stinking Cloud", Effect Duration: 40
+1453	altered purple wobbly wad	1		Effect: "Stinking Cloud", Effect Duration: 40
 1454	altered blurry stench wad	1		
 1455	compressed wobbly sleaze wad	1		Effect: "Itchy Trigger Finger", Effect Duration: 50
 1456	double daisy	0		
-1457	gray bouncing shaking Goth Giant	0		
+1457	shaking bouncing gray Goth Giant	0		
 1458	rotten miniature Valentine's Day cake	2	crappy	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
@@ -1474,10 +1474,10 @@
 1492	spinning narrow censurious ninja mop	0		Sleaze Resistance: +3
 1493	Sherlock's electrified ridiculously overelaborate ninja weapon	0		Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5
 1494	polymerized concentrated narrow sugar-coated pine cone	0		Effect: "Inebriate Pride", Effect Duration: 62, Last Available: "2020-09"
-1495	yellow dangerous brainy traffic cone	0		Mysticality: +5, Weapon Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	yellow dangerous brainy traffic cone	0		Mysticality: +5, Weapon Damage: +10, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	drinkable gloomy mushroom wine	3	good	
 1497	delicious shaking mushroom wine	4	awesome	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	blurry whoopie cushion	0		Last Available: "2006-04"
 1500	green fake fake vomit	0		Last Available: "2006-04"
 1501	dry teal explosion-flavored chewing gum	0		Effect: "Mer-kindliness", Effect Duration: 27, Last Available: "2006-04"
@@ -1488,7 +1488,7 @@
 1506	aged calle de miel with a fly in it	3	awesome	Last Available: "2006-04"
 1507	mediocre blurry rockin' wagon with a fly in it	4	decent	Last Available: "2006-04"
 1508	acceptable red perpendicular hula with a fly in it	4	good	Last Available: "2006-04"
-1509	artisanal irresponsibly strong slap and tickle with a fly in it	6	EPIC	Last Available: "2006-04"
+1509	irresponsibly strong artisanal slap and tickle with a fly in it	6	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	thinker's fake hand	0		Mysticality: +10, Last Available: "2006-04"
 1512	distilled yellow Knob Goblin pet-buffing spray	1		
@@ -1503,23 +1503,23 @@
 1522	wool mansplainer's Radio Free Jersey	0		Monster Level: +15, Cold Resistance: +1
 1523	spinning bottle of used blood	0		
 1524	fuchsia wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	toasty savvy corkscrew	0		Mysticality Percent: +20, Hot Damage: +5, Last Available: "2006-04"
 1529	upside-down upside-down St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	spinning fake plastic grass	0		Last Available: "2011-01"
-1531	miser's grass skirt	0		Meat Drop: +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	blurry strapping grass hat	0		Muscle: +5, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	miser's grass skirt	0		Meat Drop: +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	blurry strapping grass hat	0		Muscle: +5, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	vibrating grass blade	0		Maximum MP Percent: +10, Last Available: "2011-01"
 1534	raffle prize box	0		
-1536	blue pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
+1536	pulsating blue homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	red weegee sqouija	0		Last Available: "2011-12"
 1538	sparkly engagement ring of terror	0		Spooky Spell Damage: +10, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	stanky Grimacite goggles of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	stanky Grimacite goggles of the brazier	0		Hot Spell Damage: +25, Stench Spell Damage: +25, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	dance instructor's Grimacite glaive of chilblains	0		Experience Percent (Moxie): +10, Cold Damage: +25, Last Available: "2008-10"
-1542	greasy padded Grimacite greaves	0		Damage Absorption: +20, Sleaze Spell Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	greasy padded Grimacite greaves	0		Damage Absorption: +20, Sleaze Spell Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	Grimacite garter of the wise owl of the brute	0		Mysticality: +20, Muscle Percent: +30, Last Available: "2008-10"
 1544	Rosewater's Grimacite galoshes of dire peril	0		Mysticality Percent: +30, Weapon Damage: +20, Last Available: "2008-10"
 1545	Van der Graaf vibrating Grimacite gorget	0		Maximum MP Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-10"
@@ -1528,51 +1528,51 @@
 1548	blinking blurry perfumed Gazpacho's Glacial Grimoire of courage	0		Spooky Resistance: +3, Stench Resistance: +5
 1549	MSG	0		
 1550	supercharged second-hand knockoff engagement ring	0		Maximum MP Percent: +30, Single Equip
-1551	fancy perfectly mixed bottle of Domesticated Turkey	3	EPIC	Effect: "Voracious Gorging", Effect Duration: 5
+1551	perfectly mixed fancy bottle of Domesticated Turkey	3	EPIC	Effect: "Voracious Gorging", Effect Duration: 5
 1552	hand-crafted cyan bottle of Definit	4	EPIC	
 1553	lousy bottle of Calcutta Emerald	4	decent	
 1554	hand-crafted bottle of Lieutenant Freeman	3	EPIC	
 1555	practically non-alcoholic perfectly mixed bottle of Jorge Sinsonte	1	EPIC	
 1556	perfectly mixed boxed champagne	3	EPIC	
-1557	gigantic enchanted stale kumquat	9	decent	Effect: "Elemental Mastery", Effect Duration: 35
+1557	gigantic stale enchanted kumquat	9	decent	Effect: "Elemental Mastery", Effect Duration: 35
 1558	decent bite-sized tangerine	1	good	
 1559	tonic water	0		
-1560	delicious low-calorie cocktail onion	1	awesome	
+1560	low-calorie delicious cocktail onion	1	awesome	
 1561	flavorless tumbling blue raspberry	3	decent	
 1562	moldy half-sized kiwi	2	crappy	
 1563	practically non-alcoholic smooth yellow whiskey bittersweet	1	awesome	
 1564	lousy mimosette	3	decent	
-1565	triple-distilled drinkable tequila sunset	10	good	
+1565	drinkable triple-distilled tequila sunset	10	good	
 1566	artisanal narrow zmobie	3	EPIC	Wiki Name: "Zmobie (drink)"
 1567	artisanal gin and tonic	4	EPIC	
 1568	artisanal weak cyan vodka and tonic	2	EPIC	
-1569	smooth fancy wobbly vodka gibson	3	awesome	Effect: "Sizzling with Fury", Effect Duration: 30
+1569	fancy smooth wobbly vodka gibson	3	awesome	Effect: "Sizzling with Fury", Effect Duration: 30
 1570	watered-down mediocre gibson	2	decent	
 1571	lousy parisian cathouse	4	decent	
 1572	bad weak rabbit punch	2	decent	
 1573	aged caipifruta	4	awesome	
 1574	tolerable pulsating teqiwila	4	good	
-1575	acceptable enchanted irresponsibly strong Divine	10	good	Effect: "Flagrantly Fragrant", Effect Duration: 45
+1575	acceptable irresponsibly strong enchanted Divine	10	good	Effect: "Flagrantly Fragrant", Effect Duration: 45
 1576	aged practically non-alcoholic Gordon Bennett	1	awesome	
 1577	drinkable upside-down shaking tangarita	4	good	
 1578	perfectly mixed pulsating mandarina colada	3	EPIC	
 1579	acceptable gimlet	3	good	
-1580	drinkable enchanted mirror brick road	4	good	Effect: "The Dinsey Way", Effect Duration: 25
+1580	enchanted drinkable mirror brick road	4	good	Effect: "The Dinsey Way", Effect Duration: 25
 1581	hand-crafted blinking vodka stratocaster	4	EPIC	
 1582	watered-down bad Neuromancer	2	decent	
 1583	perfectly mixed weak jittery prussian cathouse	2	super ultra EPIC	
 1584	mediocre cyan Mae West	3	decent	
-1585	bad high-proof Mon Tiki	9	decent	
+1585	high-proof bad Mon Tiki	9	decent	
 1586	bad teqiwila slammer	4	decent	
-1587	adequate super-sized fancy Knob lo mein	5	good	Effect: "Mmmmmelon", Effect Duration: 35
+1587	adequate fancy super-sized Knob lo mein	5	good	Effect: "Mmmmmelon", Effect Duration: 35
 1588	spoiled jittery asparagus lo mein	4	crappy	
 1589	adequate Knoll lo mein	4	good	
 1590	normal lo mein	3	good	
-1591	rotten diet blue olive lo mein	1	crappy	
-1592	miniature yummy hot hi mein	2	awesome	
+1591	diet rotten blue olive lo mein	1	crappy	
+1592	yummy miniature hot hi mein	2	awesome	
 1593	fancy bland hi mein	4	decent	Effect: "Dirty Pear", Effect Duration: 15
 1594	bland hi mein	4	decent	
-1595	moldy special hi mein	3	crappy	Effect: "Tingly Wrists", Effect Duration: 40
+1595	special moldy hi mein	3	crappy	Effect: "Tingly Wrists", Effect Duration: 40
 1596	rotten jumbo spinning sleazy hi mein	5	crappy	
 1597	banded Junior LAAAAME merit badge	0		Damage Absorption: +100, Last Available: "2006-05"
 1598	blurry toasty Senior LAAAAME merit badge	0		Hot Damage: +5, Last Available: "2006-05"
@@ -1580,10 +1580,10 @@
 1600	practically non-alcoholic lousy tangarita with a fly in it	1	decent	
 1601	practically non-alcoholic tolerable mandarina colada with a fly in it	1	good	
 1602	lousy prussian cathouse with a fly in it	3	decent	
-1603	perfectly mixed weak Mae West with a fly in it	2	EPIC	
+1603	weak perfectly mixed Mae West with a fly in it	2	EPIC	
 1604	compressed twirling astronaut ice-cream	1		Last Available: "2006-05"
 1605	upside-down delectable catalyst	0		
-1606	boiled jittery mirror ultimate wad	1		
+1606	boiled mirror jittery ultimate wad	1		
 1607	concentrated pulsating twirling libation of liveliness	0		Effect: "EVISCERATE!", Effect Duration: 41
 1608	quantum twirling eyedrops of the ermine	0		Effect: "Turkey-Agitated", Effect Duration: 45
 1609	anodized jittery perfume of prejudice	0		Effect: "Cosmic Flavor", Effect Duration: 49
@@ -1592,8 +1592,8 @@
 1612	double-alkaline concentrated cordial of concentration	0		Effect: "Eye of the Seal", Effect Duration: 27
 1613	Jeselnik's coffin lid	0		Sleaze Damage: +25, Damage Reduction: 3
 1614	lard-coated satin shield	0		Sleaze Spell Damage: +25, Damage Reduction: 5
-1615	tumbling Van der Graaf Cerebral Cloche	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	miser's Cerebral Culottes	0		Meat Drop: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	tumbling Van der Graaf Cerebral Cloche	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	miser's Cerebral Culottes	0		Meat Drop: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	sizzling grievous weightlifter's Cerebral Crossbow	0		Muscle: +15, Weapon Damage Percent: +50, Hot Damage: +10, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1614,10 +1614,10 @@
 1634	mediocre shaking around the world	4	decent	
 1635	scrumdiddlyumptious solution	0		
 1636	upside-down Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
-1637	nitrogenated ghostly yellow lotion of hotness	0		Effect: "Nuts about Candy", Effect Duration: 69
+1637	nitrogenated yellow ghostly lotion of hotness	0		Effect: "Nuts about Candy", Effect Duration: 69
 1638	diffused lotion of coldness	0		Effect: "Serendipi Tea", Effect Duration: 62
 1639	dry triple-altered lotion of spookiness	0		Effect: "The Dinsey Way", Effect Duration: 32
-1640	improved squat gray blinking lotion of stench	0		Effect: "Poker Faced", Effect Duration: 50
+1640	improved blinking squat gray lotion of stench	0		Effect: "Poker Faced", Effect Duration: 50
 1641	super-wet lotion of sleaziness	0		Effect: "Carrion' On", Effect Duration: 28
 1642	tolerable practically non-alcoholic jittery Grimacite Bock	1	good	Last Available: "2008-11"
 1643	rotten wobbly wedge of gray cheese	3	crappy	Last Available: "2008-11"
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	adequate foie gras	3	good	
 1652	magnetized super-warmed candy brain	0		Effect: "Hammered", Effect Duration: 22, Last Available: "2020-09"
-1653	avaricious scorching jewel-eyed wizard hat of chilblains	0		Cold Damage: +25, Hot Damage: +25, Meat Drop: +30, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	avaricious scorching jewel-eyed wizard hat of chilblains	0		Cold Damage: +25, Hot Damage: +25, Meat Drop: +30, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	fortified wad of Crovacite of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10
 1655	squat fuchsia jittery stanky lion tamer's collar	0		Experience (familiar): +2, Stench Spell Damage: +25
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	narrow styrofoam ore	0		
 1677	jittery bubblewrap ore	0		
-1678	tumbling pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	tumbling pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	personal trainer's sword of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20
 1680	Lo Pan's Van der Graaf staff	0		Spell Critical Percent: +30, MP Regen Min: 5, MP Regen Max: 7
 1681	jittery personal trainer's bubblewrap sword of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25
@@ -1703,7 +1703,7 @@
 1723	pulsating prompt frosty repeating crossbow	0		Cold Spell Damage: +10, Adventures: +3
 1725	bigger stick	0		
 1726	jittery tumbling sinewy crossbow string	0		
-1727	huge shaking blue sturdy sword hilt	0		
+1727	shaking huge blue sturdy sword hilt	0		
 1728	dense meat sword of the empath	0		Familiar Weight: +5
 1729	rock-hard dense meat staff	0		Damage Reduction: 5
 1730	twirling flame-wreathed dense meat crossbow	0		Hot Spell Damage: +10
@@ -1740,7 +1740,7 @@
 1761	arcane researcher's foon of foulness of the empath	0		Experience Percent (Mysticality): +10, Familiar Weight: +5
 1762	resourceful foon of fearfulness of the sewer	0		Maximum MP: +50, Stench Damage: +25
 1763	Temple Grandin's padded foon of fleshiness	0		Damage Absorption: +20, Familiar Weight: +7
-1764	green tumbling Spookyraven library key	0		
+1764	tumbling green Spookyraven library key	0		
 1765	Spookyraven gallery key	0		
 1766	Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	tolerable Ram's Face Lager	3	good	
 1791	ram horns	0		
-1792	pulsating Jeselnik's smelly curative Travoltan trousers	0		Stench Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	pulsating Jeselnik's smelly curative Travoltan trousers	0		Stench Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	asbestos-lined rock-hard pool cue	0		Damage Reduction: 5, Hot Resistance: +5
 1794	irradiated corrupted wobbly handful of hand chalk	0		Effect: "Whitened Teeth", Effect Duration: 47
 1795	wobbly Counterclockwise Watch of wisdom	0		Mysticality: +15, Single Equip
@@ -1787,7 +1787,7 @@
 1808	seventh cervical vertebra	0		
 1809	first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
-1811	ghostly red tumbling third thoracic vertebra	0		
+1811	tumbling red ghostly third thoracic vertebra	0		
 1812	squat fourth thoracic vertebra	0		
 1813	blinking fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
@@ -1795,14 +1795,14 @@
 1816	eighth thoracic vertebra	0		
 1817	spinning ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
-1819	blurry upside-down eleventh thoracic vertebra	0		
+1819	upside-down blurry eleventh thoracic vertebra	0		
 1820	twelfth thoracic vertebra	0		
 1821	tumbling first lumbar vertebra	0		
 1822	second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
 1825	fifth lumbar vertebra	0		
-1826	twirling skewed sixth lumbar vertebra	0		
+1826	skewed twirling sixth lumbar vertebra	0		
 1827	blinking seventh lumbar vertebra	0		
 1828	jittery sacral vertebrae	0		
 1829	first caudal vertebra	0		
@@ -1833,7 +1833,7 @@
 1854	right fourth rib	0		
 1855	right fifth rib	0		
 1856	right sixth rib	0		
-1857	upside-down bouncing right seventh rib	0		
+1857	bouncing upside-down right seventh rib	0		
 1858	blue right eighth rib	0		
 1859	right ninth rib	0		
 1860	huge right tenth rib	0		
@@ -1856,7 +1856,7 @@
 1877	right tibia	0		
 1878	blinking left fibula	0		
 1879	right fibula	0		
-1880	blue twirling left kneecap	0		
+1880	twirling blue left kneecap	0		
 1881	right kneecap	0		
 1882	left first front claw	0		
 1883	left second front claw	0		
@@ -1872,7 +1872,7 @@
 1893	left second rear claw	0		
 1894	skewed left third rear claw	0		
 1895	teal left fourth rear claw	0		
-1896	maroon twirling right first rear claw	0		
+1896	twirling maroon right first rear claw	0		
 1897	wobbly right second rear claw	0		
 1898	right third rear claw	0		
 1899	right fourth rear claw	0		
@@ -1887,13 +1887,13 @@
 1910	hardy arcane researcher's stylish clockwork sword	0		Moxie: +25, Experience Percent (Mysticality): +10, Maximum HP: +50
 1911	spinning quilted experienced clockwork staff of the boozehound	0		Experience: +2, Damage Absorption: +40, Booze Drop: +100
 1912	blurry smelly razor-sharp clockwork crossbow of Flo-Jo	0		Weapon Damage Percent: +25, Stench Spell Damage: +10, Initiative: +100
-1913	ghostly teal clockwork handle	0		
+1913	teal ghostly clockwork handle	0		
 1914	clockwork rod	0		
 1915	shaking clockwork shank	0		
 1916	wobbly Lord Spookyraven's spectacles	0		
 1917	shaking wallet	0		
 1918	spinning coin purse	0		
-1919	blue blinking English to A. F. U. E. Dictionary	0		
+1919	blinking blue English to A. F. U. E. Dictionary	0		
 1920	twirling bizarre illegible sheet music	0		
 1921	coward's wakizashi	0		Monster Level: -20
 1922	gob of wet hair	0		
@@ -1926,7 +1926,7 @@
 1949	normal Manetwich	3	good	
 1950	bottle of Vangoghbitussin	0		
 1951	drinkable fancy bottle of Pinot Renoir	3	good	Effect: "Bread Burps", Effect Duration: 45
-1952	moldy snack-sized green desiccated apricot	2	crappy	
+1952	snack-sized moldy green desiccated apricot	2	crappy	
 1953	aged flute of flat champagne	3	awesome	
 1954	special adequate snack-sized dehydrated caviar	2	good	Effect: "Helvella Health", Effect Duration: 25
 1955	styrofoam peanuts	0		
@@ -1999,10 +1999,10 @@
 2022	stale mirror lemon meringue pie	4	decent	
 2023	wobbly Genalen&trade; Bottle	1	EPIC	
 2024	tasty mixed wildflower greens	3	awesome	
-2025	half-sized flavorless bouncing handful of walnuts	2	decent	
+2025	flavorless half-sized bouncing handful of walnuts	2	decent	
 2026	bland miniature nutty organic salad	2	decent	
-2027	normal upside-down blurry super salad	4	good	
-2028	toothsome gigantic tofu wonton	6	awesome	
+2027	normal blurry upside-down super salad	4	good	
+2028	gigantic toothsome tofu wonton	6	awesome	
 2029	hippy protest button	0		Single Equip
 2030	greedy personal trainer's Lockenstock&trade; sandals	0		Experience Percent (Muscle): +10, Meat Drop: +20, Single Equip
 2031	didgeridooka of doom	0		Spooky Spell Damage: +50
@@ -2019,9 +2019,9 @@
 2042	purple exploding hacky-sack	0		
 2043	twirling hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	small adequate brain-meltingly-hot chicken wings	2	good	
-2046	tasty lime green squat frat brats	3	awesome	
-2047	special rotten pulsating knob ka-bobs	4	crappy	Effect: "Pasty", Effect Duration: 10
+2045	adequate small brain-meltingly-hot chicken wings	2	good	
+2046	tasty squat lime green frat brats	3	awesome	
+2047	rotten special pulsating knob ka-bobs	4	crappy	Effect: "Pasty", Effect Duration: 10
 2049	lousy can of Swiller	4	decent	
 2050	broken wings	0		
 2051	sunken eyes	0		
@@ -2036,7 +2036,7 @@
 2060	mirror cyan sword of wisdom of the overflowing toilet	0		Mysticality: +15, Stench Spell Damage: +50
 2061	blurry yellow rosewater-soaked helmet	0		Stench Resistance: +3, Familiar Effect: "1xFairy, cap 40"
 2062	shield of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5, Damage Reduction: 10
-2063	decent upside-down jittery blackberry	3	good	
+2063	decent jittery upside-down blackberry	3	good	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	twirling Jack Frost's kick-ass kicks of wisdom	0		Mysticality: +15, Cold Spell Damage: +50, Single Equip
@@ -2067,7 +2067,7 @@
 2091	mirror bath salts	0		
 2092	hand mirror	0		
 2093	Lo Pan's hors d'oeuvre tray	0		Spell Critical Percent: +30, Damage Reduction: 5
-2094	fancy decent super-sized ballroom blintz	5	good	Effect: "Super-Charged", Effect Duration: 45
+2094	super-sized decent fancy ballroom blintz	5	good	Effect: "Super-Charged", Effect Duration: 45
 2095	towel	0		
 2096	twisted narrow guy made of bee pollen	1		
 2097	ghostly stiffened 17-ball	0		Damage Reduction: 1
@@ -2090,7 +2090,7 @@
 2114	pulsating yo	0		Last Available: "2006-12"
 2115	prehistoric spear of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2006-12"
 2116	blue stick-on-a-string	0		Last Available: "2006-12"
-2117	pulsating MacGyver's fire of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	pulsating MacGyver's fire of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	lime green Grateful Undead T-shirt of courage	0		Spooky Resistance: +3
@@ -2137,13 +2137,13 @@
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
-2165	skewed blue atomic vector plotter	0		Last Available: "2011-12"
+2165	blue skewed atomic vector plotter	0		Last Available: "2011-12"
 2166	spinning ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	stanky grievous toy ray gun	0		Weapon Damage Percent: +50, Stench Spell Damage: +25, Last Available: "2006-12"
-2169	sharpshooter's baleful toy space helmet	0		Spell Damage: +25, Critical Hit Percent: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
-2170	upside-down olive MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	blurry twirling rosewater-soaked greasy astronaut pants	0		Sleaze Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2169	sharpshooter's baleful toy space helmet	0		Spell Damage: +25, Critical Hit Percent: +10, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2170	olive upside-down MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
+2171	blurry twirling rosewater-soaked greasy astronaut pants	0		Sleaze Spell Damage: +10, Stench Resistance: +3, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	blinking Newton's toy jet pack	0		Experience (Mysticality): +3, Last Available: "2006-12"
 2173	spinning triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,13 +2161,13 @@
 2186	unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	crappy	Last Available: "2006-12"
-2189	drinkable practically non-alcoholic flask of peppermint schnapps	1	good	Last Available: "2006-12"
+2189	practically non-alcoholic drinkable flask of peppermint schnapps	1	good	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	skewed book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	bland massive candy stake	7	decent	Last Available: "2006-12"
 2194	bad shaking eggnog	3	decent	Last Available: "2006-12"
-2195	moldy big huge unspeakable fruitcake	5	crappy	Last Available: "2006-12"
+2195	big moldy huge unspeakable fruitcake	5	crappy	Last Available: "2006-12"
 2196	small yummy gingerbread horror	2	awesome	Last Available: "2006-12"
 2197	frozen electrified unsweetened but probably evil chocolate	0		Effect: "Go-Gone", Effect Duration: 64, Last Available: "2006-12"
 2198	delicious bat-shaped Crimboween cookie	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
@@ -2182,19 +2182,19 @@
 2207	Crimbo tiki necklace of the sewer	0		Stench Damage: +25, Last Available: "2006-12"
 2208	vibrating savvy bobble-hip hula elf doll	0		Mysticality Percent: +20, Maximum MP Percent: +10, Last Available: "2006-12"
 2209	spinning mirror thinker's Crimbo ukulele	0		Mysticality: +10, Last Available: "2006-12"
-2210	sinister Tiki lighter of the detective	0		Spell Damage: +10, Item Drop: +20, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	veiny deck of tropical cards of James Dean	0		Experience (Moxie): +3, Maximum HP: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	chaotic tropical paperweight of the overflowing toilet	0		Spell Critical Percent: +10, Stench Spell Damage: +50, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	sinister Tiki lighter of the detective	0		Spell Damage: +10, Item Drop: +20, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	veiny deck of tropical cards of James Dean	0		Experience (Moxie): +3, Maximum HP: +10, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	chaotic tropical paperweight of the overflowing toilet	0		Spell Critical Percent: +10, Stench Spell Damage: +50, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	wholesome Tropical Crimbo Hat	0		Maximum HP Percent: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	Tropical Crimbo Shorts of the glutton	0		Food Drop: +100, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	wholesome Tropical Crimbo Hat	0		Maximum HP Percent: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	Tropical Crimbo Shorts of the glutton	0		Food Drop: +100, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	bland low-calorie super ka-bob	1	decent	
-2218	fancy bland diet squat beer basted brat	1	decent	Effect: "Disco Neuropathy", Effect Duration: 15
+2218	fancy diet bland squat beer basted brat	1	decent	Effect: "Disco Neuropathy", Effect Duration: 15
 2219	Tropical Crimbo Sword of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-12"
 2220	diffused skewed and Crimboween candy	0		Effect: "Healthy Blue Glow", Effect Duration: 48, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	purple upside-down nasty liar's pants of chilblains	0		Cold Damage: +25, Stench Damage: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	purple upside-down nasty liar's pants of chilblains	0		Cold Damage: +25, Stench Damage: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	zippy flame-wreathed juggler's balls	0		Hot Spell Damage: +10, Initiative: +20, Softcore Only, Last Available: "2007-01"
 2224	pink shirt of the scaredy-cat	0		Monster Level: -15, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2236,7 +2236,7 @@
 2262	bird rib	0		
 2263	lion oil	0		
 2264	tasty stunt nuts	4	awesome	
-2265	special rotten huge wet stew	4	crappy	Effect: "Blood-Rich", Effect Duration: 30
+2265	rotten special huge wet stew	4	crappy	Effect: "Blood-Rich", Effect Duration: 30
 2266	gray wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	clever Staff of Fats	0		Maximum MP: +20
@@ -2246,7 +2246,7 @@
 2272	distilled perfectly mixed bottle of Port	5	EPIC	
 2273	acceptable bottle of Pinot Noir	4	good	
 2274	hand-crafted upside-down jittery bottle of Zinfandel	4	EPIC	
-2275	fancy spirit-forward acceptable bottle of Marsala	5	good	Effect: "Flamingly Floral", Effect Duration: 15
+2275	acceptable fancy spirit-forward bottle of Marsala	5	good	Effect: "Flamingly Floral", Effect Duration: 15
 2276	lousy shaking bottle of Muscat	3	decent	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2272,9 +2272,9 @@
 2298	boock of darck magicks	0		
 2299	EZ-Play Harmonica Book	0		
 2300	mirror yellow fingerless hobo gloves	0		
-2301	blurry cyan Chomsky's comic books	0		
+2301	cyan blurry Chomsky's comic books	0		
 2302	pulsating worm-riding hooks	0		
-2303	wobbly Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	wobbly Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	oxidized concentrated candy heart	0		Effect: "Cinnamouth", Effect Duration: 51, Last Available: "2007-02"
 2305	frozen energized red pink candy heart	0		Effect: "Oriental Mysticism", Effect Duration: 56, Last Available: "2007-02"
 2306	frozen unsweetened squat candy heart	0		Effect: "Certainty", Effect Duration: 65, Last Available: "2007-02"
@@ -2303,13 +2303,13 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	shaking bouquet of circular saw blades	0		
-2332	flavorless miniature Better Than Cuddling Cake	2	decent	
+2332	miniature flavorless Better Than Cuddling Cake	2	decent	
 2333	skewed ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	teal rubber WWBBDD? bracelet	0		
 2336	mirror Jeselnik's flame-wreathed pipe	0		Hot Spell Damage: +10, Sleaze Damage: +25
 2337	rock-hard reinforced beaded headband	0		Damage Reduction: 5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	decent gigantic red bouncing pudding	7	good	Wiki Name: "black pudding (food)"
+2338	gigantic decent bouncing red pudding	7	good	Wiki Name: "black pudding (food)"
 2339	artisanal Blackfly Chardonnay	3	EPIC	
 2340	bad high-proof & tan	10	decent	
 2341	tumbling pepper	0		
@@ -2435,7 +2435,7 @@
 2462	tumbling odor extractor	0		Last Available: "2019-12"
 2463	upside-down Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	rotten mirror bowl of Bounty-Os	3	crappy	
-2465	lousy fancy blurry Oreille Divis&eacute;e brandy	3	decent	Effect: "Fury of the Bells", Effect Duration: 20
+2465	fancy lousy blurry Oreille Divis&eacute;e brandy	3	decent	Effect: "Fury of the Bells", Effect Duration: 20
 2466	upside-down pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2462,7 +2462,7 @@
 2489	savvy tuxedo shirt	0		Mysticality Percent: +20
 2490	beefy strapping gnauga hide vest	0		Muscle: 15
 2491	shirt kit	0		
-2492	red twirling tropical orchid	0		
+2492	twirling red tropical orchid	0		
 2493	stick of dynamite	0		
 2494	bouncing rock-hard Necrotelicomnicon of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5
 2495	shaking mansplainer's groovy Cookbook of the Damned	0		Moxie Percent: +10, Monster Level: +15
@@ -2495,36 +2495,36 @@
 2522	mediocre thistle wine	4	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	immense special flavorless blurry fish	10	decent	Effect: "You're Rubber", Effect Duration: 40
-2526	fancy normal small fish casserole	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15
+2525	flavorless special immense blurry fish	10	decent	Effect: "You're Rubber", Effect Duration: 40
+2526	small fancy normal fish casserole	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15
 2527	decent shaking yellow fish lasagna	4	good	
 2528	squat filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	huge spoiled huge gnatloaf	10	crappy	
+2529	spoiled huge huge gnatloaf	10	crappy	
 2530	decent maroon gnatloaf casserole	3	good	
 2531	moldy gnat lasagna	4	crappy	
 2532	pork	0		
-2533	jumbo decent twirling pork chop sandwiches	5	good	
-2534	thick adequate pork casserole	5	good	
+2533	decent jumbo twirling pork chop sandwiches	5	good	
+2534	adequate thick pork casserole	5	good	
 2535	moldy bouncing pork lasagna	3	crappy	
 2536	canopic jar	0		
 2537	pulsating wobbly spice	0		
 2538	organs	0		
 2539	deadly Ankh of Badahnkadh	0		Weapon Damage: +5, Single Equip
-2540	bouncing spinning tomb ratchet	0		
+2540	spinning bouncing tomb ratchet	0		
 2541	cyan Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	electrified narrow lesser grodulated violet	0		Effect: "Ancestral Disapproval", Effect Duration: 27, Last Available: "2007-05"
 2543	nitrogenated polymerized tin magnolia	0		Effect: "Guts Feeling", Effect Duration: 36, Last Available: "2007-05"
 2544	quadruple-boiled flattened begpwnia	0		Effect: "Toast Tea", Effect Duration: 47, Last Available: "2007-05"
-2545	concentrated activated skewed pulsating teal upsy daisy	0		Effect: "Oily Flavor", Effect Duration: 16, Last Available: "2007-05"
+2545	concentrated activated skewed teal pulsating upsy daisy	0		Effect: "Oily Flavor", Effect Duration: 16, Last Available: "2007-05"
 2546	colloidal half-orchid	0		Effect: "Abyssal Sweat", Effect Duration: 31, Last Available: "2007-05"
 2547	greedy Sinatra's tin star	0		Experience (Moxie): +5, Meat Drop: +20, Last Available: "2007-05"
-2548	narrow Sherlock's outrageous sombrero of courage	0		Spooky Resistance: +3, Item Drop: +25, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	narrow Sherlock's outrageous sombrero of courage	0		Spooky Resistance: +3, Item Drop: +25, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	Sherlock's steel-toed &quot;Humorous&quot; T-shirt	0		Damage Reduction: 9, Item Drop: +25, Last Available: "2007-05"
 2550	tumbling Peppercorns of Power	0		
 2551	jittery vial of mojo	0		
-2552	teal squat reeds	0		
+2552	squat teal reeds	0		
 2553	turtle chain	0		
-2554	shaking pulsating distilled seal blood	0		
+2554	pulsating shaking distilled seal blood	0		
 2555	high-octane olive oil	0		
 2556	manspreader's educational Shagadelic Disco Banjo of the early riser	0		Experience: +1, Monster Level: +10, Adventures: +7, Class: "Disco Bandit"
 2557	prompt Van der Graaf Squeezebox of the Ages	0		Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Class: "Accordion Thief", Song Duration: 15
@@ -2534,11 +2534,11 @@
 2561	purple up-at-dawn shellacked Fonzie's Greek Pasta Spoon of Peril	0		Experience (Moxie): +1, Damage Reduction: 7, Adventures: +5, Class: "Pastamancer"
 2562	spinning half-rotten brain	0		
 2563	ghostly upside-down bonesaw	0		
-2564	spinning yellow plus-sized phylactery	0		
+2564	yellow spinning plus-sized phylactery	0		
 2565	can of Ghuol-B-Gone&trade;	0		
 2566	skewed Azazel's unicorn	0		
 2567	huge green Azazel's lollipop	0		
-2568	narrow wobbly olive Azazel's tutu	0		
+2568	olive narrow wobbly Azazel's tutu	0		
 2569	modified ant agonist	0		Effect: "Uncaged Power", Effect Duration: 58
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
@@ -2559,12 +2559,12 @@
 2586	experienced General Sage's Lonely Diamonds Club Jacket	0		Experience: +2
 2587	rock-hard Corporal Fennel's Lonely Clubs Club Jacket	0		Damage Reduction: 5
 2588	auspicious Private Pepper's Lonely Hearts Club Jacket	0		Item Drop: +10
-2589	fancy moldy immense hot date	10	crappy	Effect: "What's That Smell?", Effect Duration: 20
+2589	fancy immense moldy hot date	10	crappy	Effect: "What's That Smell?", Effect Duration: 20
 2590	acceptable fancy bouncing pulsating distilled fortified wine	4	good	Effect: "Sagittarius Rising", Effect Duration: 15
-2591	snack-sized toothsome tasty tart	2	awesome	
+2591	toothsome snack-sized tasty tart	2	awesome	
 2592	Knob Goblin lunchbox	0		
 2593	diet decent Knob pasty	1	good	
-2594	artisanal weak blinking thermos full of Knob coffee	2	EPIC	
+2594	weak artisanal blinking thermos full of Knob coffee	2	EPIC	
 2595	altered triple-moist Ben-Gal&trade; Balm	0		Effect: "Protection from Bad Stuff", Effect Duration: 14
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2584,13 +2584,13 @@
 2611	pulsating palm-frond cloak of the dark arts	0		Spell Damage Percent: +100
 2612	vinyl coin purse	0		
 2613	tumbling rocky raccoon	0		
-2614	wobbly blurry mojo filter	0		
-2615	rotten small savoy truffle	2	crappy	
+2614	blurry wobbly mojo filter	0		
+2615	small rotten savoy truffle	2	crappy	
 2616	huge Magi-Wipes	0		
 2617	boom	0		
 2618	narrow savvy Iiti Kitty phone charm	0		Mysticality Percent: +20, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	stale small blurry unidentified jerky	2	decent	
+2620	small stale blurry unidentified jerky	2	decent	
 2621	narrow flame-wreathed nasty rat mask of the sweet-tooth	0		Hot Spell Damage: +10, Candy Drop: +100, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	blinking ratskin belt of the blizzard of the sewer	0		Cold Spell Damage: +25, Stench Damage: +25, Single Equip
 2623	Temple Grandin's rattail whip of the pedagogue	0		Experience: +3, Familiar Weight: +7
@@ -2616,37 +2616,37 @@
 2643	dog trainer's happiness	0		Experience (familiar): +1
 2644	purple feather	0		
 2645	bouncing feather	0		
-2646	pulsating squat frightful feather	0		
+2646	squat pulsating frightful feather	0		
 2647	fetid feather	0		
 2648	spinning flirtatious feather	0		
 2649	pulsating tumbling sinister Lord Spookyraven's ear trumpet	0		Spell Damage: +10, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	jumbo moldy S.T.L.T.	5	crappy	Last Available: "2007-06"
+2652	moldy jumbo S.T.L.T.	5	crappy	Last Available: "2007-06"
 2653	miniature spoiled honey-dew	2	crappy	Last Available: "2007-06"
 2654	drinkable Xanadian	3	good	Last Available: "2007-06"
 2655	warmed non-adjusted concentrated bottle of absinthe	0		Effect: "Drunk With Power", Effect Duration: 44, Last Available: "2007-06"
 2656	tumbling inspector's friendly Drowsy Sword	0		Familiar Weight: +3, Item Drop: +15
 2657	toothsome escargotsicle	3	awesome	Last Available: "2007-06"
-2658	practically non-alcoholic bad bottle of realpagne	1	decent	Last Available: "2007-06"
+2658	bad practically non-alcoholic bottle of realpagne	1	decent	Last Available: "2007-06"
 2659	fortified albatross necklace	0		Damage Absorption: +60, Single Equip, Last Available: "2007-06"
 2660	vaporized not-a-pipe	1	awesome	Last Available: "2007-06"
-2661	mediocre enchanted watered-down wobbly flask of Amontillado	2	decent	Effect: "Quiet 'n' Good", Effect Duration: 35, Last Available: "2007-06"
-2662	upside-down energetic ball mask	0		Maximum MP Percent: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	Can-Can skirt of dire peril	0		Weapon Damage: +20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
-2664	energized upside-down tumbling sensitive poetry journal	0		Effect: "Tomato Power", Effect Duration: 16, Last Available: "2007-06"
+2661	mediocre watered-down enchanted wobbly flask of Amontillado	2	decent	Effect: "Quiet 'n' Good", Effect Duration: 35, Last Available: "2007-06"
+2662	upside-down energetic ball mask	0		Maximum MP Percent: +20, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	Can-Can skirt of dire peril	0		Weapon Damage: +20, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2664	energized tumbling upside-down sensitive poetry journal	0		Effect: "Tomato Power", Effect Duration: 16, Last Available: "2007-06"
 2665	denatured bottled inspiration	0		Effect: "Make Meat FA$T!", Effect Duration: 56, Last Available: "2007-06"
 2666	energized flattened purple bellhop bell	0		Effect: "Heart Aflame", Effect Duration: 22, Last Available: "2007-06"
 2667	polarized diffused deionized shaking gray spiky collar	0		Effect: "Blessing of Charcoatl", Effect Duration: 26, Last Available: "2007-06"
 2668	powdered can-can-in-a-can	1		Effect: "Chow Downed", Effect Duration: 25, Last Available: "2007-06"
 2669	mixed red bouncing patent antipsychotics	1		Effect: "Discomfited", Effect Duration: 45, Last Available: "2007-06"
 2670	denatured bouncing Mariner's Friend cough drops	1		Effect: "Top Dog", Effect Duration: 35, Last Available: "2007-06"
-2671	lousy boozy shot of nepenthe schnapps	5	decent	Last Available: "2007-06"
+2671	boozy lousy shot of nepenthe schnapps	5	decent	Last Available: "2007-06"
 2672	ghostly library card	0		Last Available: "2007-06"
 2673	purple Bohemian rhapsody	0		Last Available: "2007-06"
 2674	adjusted dry bottle of cat tonic	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 45, Last Available: "2007-06"
 2675	denatured handful of moss	1		
-2676	pickled shaking fuchsia squat skewed bit-o-cactus	1		
+2676	pickled squat shaking fuchsia skewed bit-o-cactus	1		
 2677	twisted upside-down protein powder	1		
 2678	upside-down spectre scepter	0		
 2679	vacuum-sealed alkaline sparkler	0		Effect: "Heal Thy Nanoself", Effect Duration: 48
@@ -2661,11 +2661,11 @@
 2688	chaotic rosy-cheeked dangerous dreadlock whip	0		Weapon Damage: +10, Maximum HP Percent: +30, Spell Critical Percent: +10
 2689	fireproof beer-a-pult of extreme caution	0		Monster Level: -25, Hot Resistance: +3
 2690	mirror skewed coward's wizardly cast-iron legacy paddle	0		Mysticality: +25, Monster Level: -20
-2691	decent mirror wobbly handful of nuts and berries	3	good	
+2691	decent wobbly mirror handful of nuts and berries	3	good	
 2692	supercharged veiny driftwood sculpture	0		Maximum HP: +10, Maximum MP Percent: +30
 2693	chilly massive sitar of terror	0		Cold Damage: +5, Spooky Spell Damage: +10
 2694	greedy rosy-cheeked dangerous stone baseball cap	0		Weapon Damage: +10, Maximum HP Percent: +30, Meat Drop: +20, Familiar Effect: "1xVolley, cap 48"
-2695	lousy practically non-alcoholic pulsating cup of beer	1	decent	
+2695	practically non-alcoholic lousy pulsating cup of beer	1	decent	
 2696	ovoid thing	0		
 2697	duct tape	0		
 2698	tumbling duct tape wallet	0		
@@ -2694,29 +2694,29 @@
 2721	maroon hand-carved staff of vim and vigor of the blizzard	0		Maximum HP Percent: +50, Cold Spell Damage: +25, Item Drop: +5
 2722	purple banded razor-sharp Staff of the Greasefire of bravery of the sweet-tooth	0		Weapon Damage Percent: +25, Damage Absorption: +100, Spooky Resistance: +5, Candy Drop: +100
 2723	frosty baleful stylish Staff of the Grand Flamb&eacute;	0		Moxie: +25, Spell Damage: +25, Cold Spell Damage: +10
-2724	thick spoiled bowl of rye sprouts	5	crappy	
-2725	snack-sized moldy cob of corn	2	crappy	
+2724	spoiled thick bowl of rye sprouts	5	crappy	
+2725	moldy snack-sized cob of corn	2	crappy	
 2726	delicious twirling juniper berries	4	awesome	
-2727	huge adequate plum	6	good	
+2727	adequate huge plum	6	good	
 2728	low-calorie yummy pear	1	awesome	
 2729	flavorless big peach	5	decent	
 2730	practically non-alcoholic lousy plum wine	1	decent	
-2731	watered-down hand-crafted shot of pear schnapps	2	EPIC	
+2731	hand-crafted watered-down shot of pear schnapps	2	EPIC	
 2732	aged gray shot of peach schnapps	4	awesome	
-2733	toothsome big bunch of square grapes	5	awesome	
+2733	big toothsome bunch of square grapes	5	awesome	
 2734	flavorless brown sugar cane	3	decent	
 2735	normal sandwich of the gods	3	good	
 2736	lousy Pan-Dimensional Gargle Blaster	3	decent	
 2737	modified leopard-print barbell	1	awesome	
-2738	tumbling wobbly pile of smoking rags	0		
+2738	wobbly tumbling pile of smoking rags	0		
 2739	improved cyan panty raider camouflage	0		Effect: "Christmessy", Effect Duration: 59
 2740	cyan skewed miser's greasy Jack Frost's Staff of the Walk-In Freezer	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Meat Drop: +10
 2741	bad boilermaker	3	decent	
-2742	snack-sized enchanted flavorless steel lasagna	2	quest	Effect: "Takin' It Greasy", Effect Duration: 10
+2742	flavorless enchanted snack-sized steel lasagna	2	quest	Effect: "Takin' It Greasy", Effect Duration: 10
 2743	acceptable steel margarita	3	quest	
 2744	dehydrated steel-scented air freshener	1		
 2745	energized skewed gremlin mutagen	0		Effect: "Sweet Incentive", Effect Duration: 35
-2746	boiled huge spinning extra-potent gremlin mutagen	0		Effect: "Vanity Rage", Effect Duration: 29
+2746	boiled spinning huge extra-potent gremlin mutagen	0		Effect: "Vanity Rage", Effect Duration: 29
 2747	pulsating chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	wobbly Sinatra's furniture dolly	0		Experience (Moxie): +5, Single Equip
 2749	Jeselnik's therapeutic Staff of the Grease Trap of temperance	0		Sleaze Damage: +25, Sleaze Resistance: +5, HP Regen Min: 5, HP Regen Max: 7
@@ -2737,7 +2737,7 @@
 2764	rosy-cheeked shellacked sinister Order of the Silver Wossname	0		Spell Damage: +10, Damage Reduction: 7, Maximum HP Percent: +30, Single Equip
 2765	maroon Harold's bell	0		
 2766	bowling ball	0		
-2767	normal bouncing skewed Crimbo pie	3	good	
+2767	normal skewed bouncing Crimbo pie	3	good	
 2768	moldy pear tart	4	crappy	
 2769	tasty peach pie	4	awesome	
 2770	aerosolized diffused maroon chunk of rock salt	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 21
@@ -2777,7 +2777,7 @@
 2804	wet adjusted maroon vial of hamethyst juice	0		Effect: "Witch's Brood", Effect Duration: 24
 2805	electrified double-dry mirror vial of baconstone juice	0		Effect: "High Blood Chocolate Content", Effect Duration: 41
 2806	unsweetened super-irradiated fuchsia bouncing vial of porquoise juice	0		Effect: "Slimily Strong", Effect Duration: 11
-2807	adjusted warmed blinking green flask of hamethyst juice	0		Effect: "Improved Candy Vision", Effect Duration: 36
+2807	adjusted warmed green blinking flask of hamethyst juice	0		Effect: "Improved Candy Vision", Effect Duration: 36
 2808	electrified moist flask of baconstone juice	0		Effect: "Aided and Abetted", Effect Duration: 57
 2809	chilled upside-down flask of porquoise juice	0		Effect: "I See Everything Thrice!", Effect Duration: 47
 2810	boiled jug of hamethyst juice	0		Effect: "Lemony Goodness", Effect Duration: 65
@@ -2789,9 +2789,9 @@
 2816	gravedigger's ruddy Boxers of the scaredy-cat	0		Maximum HP Percent: +40, Monster Level: -15, Spooky Damage: +10, Familiar Effect: "1xVolley, 1xLep"
 2817	clever dangerous Samson's Brooch	0		Experience (Muscle): +5, Weapon Damage: +10, Maximum MP: +20, Single Equip
 2818	nippy mansplainer's Annie Oakley's Bracelet	0		Critical Hit Percent: +20, Monster Level: +15, Cold Damage: +10, Single Equip
-2819	twirling razor-sharp Grimacite gasmask of Leguizamo	0		Weapon Damage Percent: +25, Monster Level: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	twirling razor-sharp Grimacite gasmask of Leguizamo	0		Weapon Damage Percent: +25, Monster Level: +20, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	huge energetic Grimacite gat of the cheetah	0		Maximum MP Percent: +20, Initiative: +60, Last Available: "2008-11"
-2821	grievous Newton's Grimacite gaiters	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	grievous Newton's Grimacite gaiters	0		Experience (Mysticality): +3, Weapon Damage Percent: +50, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	blurry Socratic Grimacite gauntlets of extreme caution	0		Experience (Mysticality): +1, Monster Level: -25, Single Equip, Last Available: "2008-11"
 2823	twirling Temple Grandin's Grimacite go-go boots of the early riser	0		Familiar Weight: +7, Adventures: +7, Single Equip, Last Available: "2008-11"
 2824	lime green gravedigger's frightening Grimacite girdle	0		Spooky Damage: 15, Single Equip, Last Available: "2008-11"
@@ -2803,8 +2803,8 @@
 2830	ghostly digital key lime	0		
 2831	maroon star key lime	0		
 2832	adequate immense digital key lime pie	6	good	
-2833	huge enchanted adequate ghostly star key lime pie	9	good	Effect: "Heart of Lavender", Effect Duration: 5
-2834	auspicious Van der Graaf bottle-rocket crossbow of Tarzan	0		Experience (Muscle): +3, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2833	huge adequate enchanted ghostly star key lime pie	9	good	Effect: "Heart of Lavender", Effect Duration: 5
+2834	auspicious Van der Graaf bottle-rocket crossbow of Tarzan	0		Experience (Muscle): +3, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	ghostly indie comic hipster glasses of the bloodbag	0		Maximum HP: +100, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	tumbling wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	tumbling mint-condition magic wand	0		Last Available: "2011-12"
@@ -2910,14 +2910,14 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	huge unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	spoiled diet ghostly Surprise Egg	1	crappy	
+2940	diet spoiled ghostly Surprise Egg	1	crappy	
 2941	aerosolized moist ionized blurry Steal This Candy	0		Effect: "Fungal Flambé", Effect Duration: 53
 2942	Vulcanized moist oxidized chocolate filthy lucre	0		Effect: "Oiled Skin", Effect Duration: 17
 2943	unsweetened quadruple-improved Angry Farmer's Wife Candy	0		Effect: "Human-Pirate Hybrid", Effect Duration: 30
 2945	party hat of the pedagogue of the early riser	0		Experience: +3, Adventures: +7, Familiar Effect: "4xLep, cap 7"
-2946	clever V for Vivala mask of Gandalf	0		Maximum MP: +20, Spell Critical Percent: +20, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	clever V for Vivala mask of Gandalf	0		Maximum MP: +20, Spell Critical Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	weak aged shot of rotgut	2	awesome	
+2948	aged weak shot of rotgut	2	awesome	
 2949	ionized double-Vulcanized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Very Clean Teeth", Effect Duration: 17
 2950	mirror Cap'm Caronch's Map	0		
 2951	cyan shaking skewed Orcish Frat House blueprints	0		
@@ -2929,14 +2929,14 @@
 2957	rum barrel charrrm	0		
 2958	tasty mirror tube of cranberry Go-Goo	4	awesome	
 2959	pulsating olive friendly rum barrel charrrm bracelet	0		Familiar Weight: +3
-2960	rotten huge wobbly single-serving herbal stuffing	4	crappy	
+2960	rotten wobbly huge single-serving herbal stuffing	4	crappy	
 2961	spoiled packet of tofurkey gravy	4	crappy	
 2962	thick rotten tofurkey nugget	5	crappy	
 2963	fuchsia rigging shampoo	0		
 2964	ghostly ball polish	0		
 2965	mizzenmast mop	0		
 2966	Tom's of the Spanish Main Toothpaste	0		
-2967	nitrogenated olive huge bouncing Swabbie&trade; swab	0		Effect: "Slimily Strong", Effect Duration: 22
+2967	nitrogenated olive bouncing huge Swabbie&trade; swab	0		Effect: "Slimily Strong", Effect Duration: 22
 2968	liquefied triple-tarnished Oil of Parrrlay	0		Effect: "Fishily Speeding", Effect Duration: 32
 2969	decent half-sized creamsicle	2	good	
 2970	artisanal watered-down cream stout	2	EPIC	
@@ -2962,8 +2962,8 @@
 2990	curative strapping clingfilm cap	0		Muscle: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, cap 37"
 2991	skewed clingfilm slippers of chilblains	0		Cold Damage: +25, Single Equip
 2992	narrow blinking clingfilm tangle	0		
-2993	immense bland vinegar-soaked lemon slice	8	decent	
-2994	polarized purple bouncing true grit	0		Effect: "Rushin' Hands", Effect Duration: 68
+2993	bland immense vinegar-soaked lemon slice	8	decent	
+2994	polarized bouncing purple true grit	0		Effect: "Rushin' Hands", Effect Duration: 68
 2995	maroon scorching rosy-cheeked beefcake's buoybottoms	0		Muscle: +25, Maximum HP Percent: +30, Hot Damage: +25, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	grungy flannel shirt of the pedagogue	0		Experience: +3
 2997	quilted Rosewater's grungy bandana	0		Mysticality Percent: +30, Damage Absorption: +40, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
@@ -2996,27 +2996,27 @@
 3024	stone pyramid	0		
 3025	weak delicious corpse on the beach	2	awesome	
 3026	perfectly mixed spinning corpsetini	3	super EPIC	
-3027	weak drinkable corpsedriver	2	good	
+3027	drinkable weak corpsedriver	2	good	
 3028	watered-down perfectly mixed Corpse Island iced tea	2	super ultra mega EPIC	
 3029	irresponsibly strong acceptable huge red-headed corpse	8	good	
 3030	drinkable pulsating kamicorpse-ee	3	good	
-3031	high-proof bad corpsel	9	decent	
+3031	bad high-proof corpsel	9	decent	
 3032	lousy corpsebite	3	decent	
 3033	tumbling MacGyver's pirate fledges	0		Maximum MP: +100
 3034	wobbly piece of thirteen	0		
-3035	rotten thick pearl onion	5	crappy	
+3035	thick rotten pearl onion	5	crappy	
 3036	flavorless gray sea biscuit	4	decent	
 3037	smooth bottle of rum	3	awesome	
-3038	acceptable triple-distilled bottle of black-label rum	7	good	
+3038	triple-distilled acceptable bottle of black-label rum	7	good	
 3039	cannonball	0		
 3040	twirling voodoo skull	0		
 3041	wobbly huge joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	spinning metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	spinning metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	small rotten gray nanite-infested gingerbread bugbear	2	crappy	Last Available: "2007-12"
-3046	normal jittery skewed nanite-infested candy cane	3	good	Last Available: "2020-09"
-3047	stale small nanite-infested fruitcake	2	decent	Last Available: "2007-12"
+3046	normal skewed jittery nanite-infested candy cane	3	good	Last Available: "2020-09"
+3047	small stale nanite-infested fruitcake	2	decent	Last Available: "2007-12"
 3048	lousy high-proof nanite-infested eggnog	6	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	manspreader's eyepatch	0		Monster Level: +10, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3025,7 +3025,7 @@
 3053	yellow mood ring	0		Last Available: "2007-02"
 3054	double-modified ionized frozen candy heart	0		Effect: "Egged On", Effect Duration: 40, Last Available: "2007-02"
 3055	nitrogenated cold-filtered tumbling cymbal syrup	0		Free Pull, Effect: "Dancing Prowess", Effect Duration: 19, Last Available: "2007-02"
-3056	tumbling smelly metallic foil cat ears	0		Stench Spell Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	tumbling smelly metallic foil cat ears	0		Stench Spell Damage: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	pulsating nanofiber cloth	0		Last Available: "2007-12"
 3058	green iGoogly	0		Last Available: "2007-12"
 3059	purple theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	jittery kevlateflocite helmet	0		Last Available: "2007-12"
-3079	gray Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	gray Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	blurry teddy borg	0		Last Available: "2007-12"
 3081	marionette collective of the cheetah	0		Initiative: +60, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,14 +3057,14 @@
 3085	cyan inspector's ribald roboduck-on-a-string	0		Sleaze Damage: +10, Item Drop: +15, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	shaking electrified biomechanical crimborg helmet of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	shaking electrified biomechanical crimborg helmet of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	therapeutic C.B.F.G. of Gandalf	0		Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-12"
-3090	biomechanical crimborg leg armor of the sewer of courage	0		Stench Damage: +25, Spooky Resistance: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	biomechanical crimborg leg armor of the sewer of courage	0		Stench Damage: +25, Spooky Resistance: +3, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	aerosolized quadruple-denatured pulsating vitachoconutriment capsule	0		Effect: "Extra Terrestrial", Effect Duration: 65, Last Available: "2007-12"
 3092	rock-hard handmade hobby horse	0		Damage Reduction: 5, Last Available: "2007-12"
 3093	ball-in-a-cup of the pedagogue	0		Experience: +3, Last Available: "2007-12"
 3094	set of jacks of wisdom	0		Mysticality: +15, Last Available: "2007-12"
-3095	normal small olive laser-broiled pear	2	good	Last Available: "2007-12"
+3095	small normal olive laser-broiled pear	2	good	Last Available: "2007-12"
 3096	grievous experienced polyalloy shield	0		Experience: +2, Weapon Damage Percent: +50, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
@@ -3078,7 +3078,7 @@
 3106	veiny savvy brawny cyborg stompin' boot	0		Muscle Percent: +20, Mysticality Percent: +20, Maximum HP: +10, Single Equip, Last Available: "2007-12"
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
-3109	ghostly gray Miniborg stomper	0		Last Available: "2007-12"
+3109	gray ghostly Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
@@ -3086,11 +3086,11 @@
 3114	tumbling Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	spinning Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	spinning Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	tumbling divine can of silly string	0		Last Available: "2008-01"
 3120	narrow divine blowout	0		Last Available: "2008-01"
-3121	spinning skewed divine champagne popper	0		Last Available: "2008-01"
+3121	skewed spinning divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	flattened red fruitfilm	0		Effect: "Astral Shell", Effect Duration: 61
@@ -3098,7 +3098,7 @@
 3126	hobo nickel	0		
 3127	twirling sandcastle	0		
 3128	marshmallow	0		
-3129	bland jumbo enchanted upside-down roasted marshmallow	5	decent	Effect: "Goldentongue", Effect Duration: 35
+3129	jumbo bland enchanted upside-down roasted marshmallow	5	decent	Effect: "Goldentongue", Effect Duration: 35
 3130	red disc	0		Last Available: "2008-01"
 3131	normal diet upside-down tin cup of mulligan stew	1	good	
 3132	wobbly mansplainer's wholesome flamin' bindle	0		Maximum HP Percent: +10, Monster Level: +15
@@ -3127,15 +3127,15 @@
 3155	fuchsia El Vibrato punchcard (176 holes)	0		
 3156	El Vibrato punchcard (104 holes)	0		
 3157	El Vibrato drone	0		
-3158	blinking jittery sparking El Vibrato drone	0		
+3158	jittery blinking sparking El Vibrato drone	0		
 3159	ionized fuchsia warm El Vibrato drone	0		Effect: "Celestial Sheen", Effect Duration: 55
 3160	frozen magnetized colloidal humming El Vibrato drone	0		Effect: "Cold Blooded", Effect Duration: 45
 3161	frozen El Vibrato drone	0		Effect: "Chalked-Up Teeth", Effect Duration: 40
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	shaking El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
-3165	spinning maroon broken El Vibrato drone	0		
-3166	spinning tumbling repaired El Vibrato drone	0		
+3165	maroon spinning broken El Vibrato drone	0		
+3166	tumbling spinning repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	non-energized fuchsia seal eyeball	0		Effect: "Dancing Prowess", Effect Duration: 52
 3169	stale turtle soup	3	decent	Effect: "[598]A Little Bit Evil"
@@ -3143,13 +3143,13 @@
 3171	tumbling nauseating reagent	0		
 3172	occult evil paper umbrella	0		Spell Damage Percent: +25
 3173	nitrogenated wet bouncing evil vihuela	0		Effect: "Think Win-Lose", Effect Duration: 17
-3174	small moldy enchanted evil boring spaghetti	2	crappy	Effect: "Full of Wist", Effect Duration: 10
+3174	moldy enchanted small evil boring spaghetti	2	crappy	Effect: "Full of Wist", Effect Duration: 10
 3175	stale evil noodles	3	decent	
-3176	decent miniature evil noodles	2	good	
+3176	miniature decent evil noodles	2	good	
 3177	stale evil painful penne pasta	4	decent	
 3178	stale twirling 3vi1 pr0n m4nic0tti	3	decent	
 3179	bland jittery evil ravioli della hippy	3	decent	
-3180	toothsome half-sized evil noodles	2	awesome	
+3180	half-sized toothsome evil noodles	2	awesome	
 3181	dry extra-deionized evil potion of potency	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 60
 3182	extra-magnetized olive bouncing evil libation of liveliness	0		Effect: "Bananas!", Effect Duration: 58
 3183	extra-irradiated magnetized corrupted evil tomato juice of powerful power	0		Effect: "Mer-kindliness", Effect Duration: 61
@@ -3157,11 +3157,11 @@
 3185	corrupted evil ointment of the occult	0		Effect: "Happy Trails", Effect Duration: 16
 3186	anodized huge evil serum of sarcasm	0		Effect: "Rad-ish", Effect Duration: 38
 3187	adjusted chilled narrow evil philter of phorce	0		Effect: "The Power of LOV", Effect Duration: 51
-3188	practically non-alcoholic enchanted acceptable skewed an evil sump'm sump'm	1	good	Effect: "Beastly Flavor", Effect Duration: 45
+3188	acceptable enchanted practically non-alcoholic skewed an evil sump'm sump'm	1	good	Effect: "Beastly Flavor", Effect Duration: 45
 3189	acceptable fuchsia evil ducha de oro	3	good	
 3190	bad weak evil horizontal tango	2	decent	
 3191	lousy watered-down evil roll in the hay	2	decent	
-3192	squat maroon naughty origami kit	0		Last Available: "2008-02"
+3192	maroon squat naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	shaking naughty paper shuriken	0		Last Available: "2008-02"
@@ -3172,11 +3172,11 @@
 3200	lump of diamond	0		
 3201	green thick padded envelope	0		
 3202	up-at-dawn reassuring shellacked KoL Con IV Pole	0		Damage Reduction: 7, Spooky Resistance: +1, Adventures: +5, Last Available: "2007-09"
-3203	red shaking dwarvish magazine	0		
+3203	shaking red dwarvish magazine	0		
 3204	pulsating dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	wobbly dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
-3207	wobbly huge dwarvish punchcard	0		
+3207	huge wobbly dwarvish punchcard	0		
 3208	small laminated card	0		
 3209	laminated card	0		
 3210	notbig laminated card	0		
@@ -3196,12 +3196,12 @@
 3224	ghostly sewer wad	0		
 3225	tolerable bottle of sewage schnapps	3	good	
 3226	acceptable bottle of Ooze-O	4	good	
-3227	low-calorie rotten fancy C.H.U.M. chum	1	crappy	Effect: "Muscle Unbound", Effect Duration: 25
+3227	fancy rotten low-calorie C.H.U.M. chum	1	crappy	Effect: "Muscle Unbound", Effect Duration: 25
 3228	flavorless squat unfortunate dumplings	4	decent	
 3229	decaying goldfish liver	0		
 3230	denatured irradiated oil of oiliness	0		Effect: "Quantum of Moxie", Effect Duration: 58
 3231	auspicious tattered paper crown	0		Item Drop: +10, Familiar Effect: "1xSombrero, cap 15"
-3232	enchanted decent vanilla-frosted king cake	3	good	Effect: "Snobby", Effect Duration: 5, Last Available: "2008-03"
+3232	decent enchanted vanilla-frosted king cake	3	good	Effect: "Snobby", Effect Duration: 5, Last Available: "2008-03"
 3233	ghostly inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3232,7 +3232,7 @@
 3260	Rosewater's smooth Chester's moustache of the ox	0		Muscle: +20, Moxie: +15, Mysticality Percent: +30, Class: "Disco Bandit", Single Equip
 3261	cool Chester's bag of candy of the cougar	0		Moxie: 25, Class: "Disco Bandit"
 3262	blurry nippy occult Chester's cutoffs	0		Spell Damage Percent: +25, Cold Damage: +10, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	huge bag of Crotchety Pine saplings	0		
 3266	blurry bag of Saccharine Maple saplings	0		
@@ -3240,9 +3240,9 @@
 3268	chilled wet handful of Crotchety Pine needles	0		Effect: "Hood Ridin'", Effect Duration: 48
 3269	quadruple-vacuum-sealed spinning shaking lump of Saccharine Maple sap	0		Effect: "Tiki Temerity", Effect Duration: 34
 3270	tarnished handful of Laughing Willow bark	0		Effect: "Nas Tea", Effect Duration: 18
-3271	blinking family-friendly crotchety pants	0		Sleaze Resistance: +1, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	blinking family-friendly crotchety pants	0		Sleaze Resistance: +1, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	olive Van der Graaf Saccharine Maple pendant	0		MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Spray Sap"
-3273	nippy willowy bonnet	0		Cold Damage: +10, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	nippy willowy bonnet	0		Cold Damage: +10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	huge black-and-blue light	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	mirror personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	shaking plasma ball	0		Last Available: "2008-04"
 3282	spinning stick-on eyebrow piercing of Flo-Jo	0		Initiative: +100, Last Available: "2008-04"
-3283	bland miniature salad	2	decent	
+3283	miniature bland salad	2	decent	
 3284	smartaleck's C.H.U.M. lantern of wisdom	0		Mysticality: +15, Moxie Percent: +30
 3285	flame-retardant C.H.U.M. knife	0		Hot Resistance: +1
 3286	smelly Frosty's snowball sack	0		Stench Spell Damage: +10
@@ -3291,11 +3291,11 @@
 3319	lime green scandalous Mr. Joe's bangles	0		Sleaze Damage: +5, Single Equip
 3320	upside-down bouncing hardy frayed rope belt	0		Maximum HP: +50, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	greedy lion tamer's mayfly bait necklace	0		Experience (familiar): +2, Meat Drop: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	greedy lion tamer's mayfly bait necklace	0		Experience (familiar): +2, Meat Drop: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	huge Ol' Scratch's salad fork	0		
 3324	shaking cyan Frosty's frosty mug	0		
 3325	acceptable fancy jar of fermented pickle juice	4	good	Effect: "Hagg-ard", Effect Duration: 15
-3326	powdered green squat voodoo snuff	1	crappy	
+3326	powdered squat green voodoo snuff	1	crappy	
 3327	bland squat extra-greasy slider	4	decent	
 3328	blurry resourceful crumpled felt fedora of horror	0		Maximum MP: +50, Spooky Spell Damage: +25, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	red electrified battered top-hat of bravery	0		Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	twirling dead guy's piece of double-sided tape	0		
 3337	gray Newton's sage dead guy's memento	0		Mysticality Percent: +10, Experience (Mysticality): +3, Single Equip
-3338	flavorless spinning jittery banquet	3	decent	
+3338	flavorless jittery spinning banquet	3	decent	
 3339	sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3319,22 +3319,22 @@
 3347	comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
-3350	mediocre practically non-alcoholic lime green jittery Ralph IX cognac	1	decent	
+3350	practically non-alcoholic mediocre lime green jittery Ralph IX cognac	1	decent	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	gray zen motorcycle	0		Last Available: "2008-06"
 3353	tarnished modified llama lama gong	0		Effect: "One For Tea", Effect Duration: 50, Last Available: "2008-06"
-3354	adequate jumbo ghostly banana-frosted king cake	5	good	Last Available: "2008-08"
+3354	jumbo adequate ghostly banana-frosted king cake	5	good	Last Available: "2008-08"
 3355	blue Sherlock's brown plastic baby	0		Item Drop: +25, Single Equip, Last Available: "2008-08"
-3356	ghostly bouncing plump juicy grub	0		Last Available: "2008-06"
+3356	bouncing ghostly plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	skewed scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	ghostly bouncing yummy death watch beetle	0		Last Available: "2008-06"
-3362	blinking purple tasty louse	0		Last Available: "2008-06"
+3362	purple blinking tasty louse	0		Last Available: "2008-06"
 3363	rotten mole mol&eacute;	4	crappy	Last Available: "2008-06"
 3364	lousy Morlock's Mark Bourbon	4	decent	Last Available: "2008-06"
-3365	concentrated upside-down tumbling Climate Colada	0		Effect: "Red Misty-Eyed", Effect Duration: 38, Last Available: "2008-06"
+3365	concentrated tumbling upside-down Climate Colada	0		Effect: "Red Misty-Eyed", Effect Duration: 38, Last Available: "2008-06"
 3366	ionized polarized polarized huge digital underground potion	0		Effect: "Phairly Balanced", Effect Duration: 19, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	mixed glimmering roc feather	1	crappy	Last Available: "2008-06"
@@ -3370,7 +3370,7 @@
 3398	watered-down hand-crafted twirling Hodgman's blanket	2	super ultra EPIC	
 3399	perfectly mixed jar of squeeze	3	super ultra EPIC	
 3400	stale bowl of fishysoisse	4	decent	
-3401	double-flattened modified wobbly ghostly cyan deadly lampshade	0		Effect: "White Knuckles", Effect Duration: 62
+3401	double-flattened modified cyan ghostly wobbly deadly lampshade	0		Effect: "White Knuckles", Effect Duration: 62
 3402	polymerized concentrated garbage juice	0		Effect: "Rain Dancin'", Effect Duration: 30
 3403	lewd playing card	0		
 3404	shaking frosty grievous deck of lewd playing cards of extreme caution	0		Weapon Damage Percent: +50, Monster Level: -25, Cold Spell Damage: +10
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	jittery box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	jittery box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	extra-modified flattened ghostly sterno-flavored Hob-O	0		Effect: "Human-Hippy Hybrid", Effect Duration: 47
 3423	ionized adjusted frostbite-flavored Hob-O	0		Effect: "Robocamo", Effect Duration: 61
 3424	activated fuchsia fry-oil-flavored Hob-O	0		Effect: "Full of Wist", Effect Duration: 28
@@ -3395,7 +3395,7 @@
 3427	fuchsia roll of Hob-Os	0		
 3428	pickled electrified deionized Everlasting Deckswabber	0		Effect: "[1701]Hip to the Jive", Effect Duration: 11
 3430	narrow bindle of joy	0		
-3431	mirror twirling cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
+3431	twirling mirror cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
 3434	squat pulsating rattling cigar box	0		Free Pull, Last Available: "2011-12"
@@ -3407,7 +3407,7 @@
 3440	pickled squat prismatic wad	1	awesome	Last Available: "2008-07"
 3441	club of the five seasons of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2008-07"
 3442	flame-wreathed rainbow crossbow	0		Hot Spell Damage: +10, Last Available: "2008-07"
-3443	shaking narrow kitten	0		
+3443	narrow shaking kitten	0		
 3444	Sherlock's webbed comic mask	0		Item Drop: +25, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 3445	purple Junior Adventurer's kit	0		
 3446	groovy prism necklace	0		Single Equip
@@ -3429,11 +3429,11 @@
 3462	terrible poem	0		
 3463	practically non-alcoholic hand-crafted bottle of sake	1	EPIC	
 3464	twirling savvy round pebble	0		Mysticality Percent: +20
-3465	flavorless immense Bash-&#332;s cereal	10	decent	Wiki Name: "Bash-Os cereal"
-3466	hardy haiku katana of dire peril of chilblains	0		Weapon Damage: +20, Maximum HP: +50, Cold Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3465	immense flavorless Bash-&#332;s cereal	10	decent	Wiki Name: "Bash-Os cereal"
+3466	hardy haiku katana of dire peril of chilblains	0		Weapon Damage: +20, Maximum HP: +50, Cold Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	mirror bargain flash powder	0		
 3468	squat lightning-fast plastic baby	0		Initiative: +40, Single Equip, Last Available: "2008-12"
-3469	special moldy jittery blueberry-frosted king cake	3	crappy	Effect: "Crotchety, Pining", Effect Duration: 35, Last Available: "2008-12"
+3469	moldy special jittery blueberry-frosted king cake	3	crappy	Effect: "Crotchety, Pining", Effect Duration: 35, Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	huge damp boot	0		
 3472	squat aromatic Tesla Seasonal Beret of Calamity Jane	0		Critical Hit Percent: +15, Stench Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3462,16 +3462,16 @@
 3495	altered double-modified sea salt crystal	0		Effect: "Fratty Flavor", Effect Duration: 15
 3496	corrupted vacuum-sealed bouncing bazookafish bubble gum	0		Effect: "Rave Nirvana", Effect Duration: 32
 3497	bad enchanted bottle of Pete's Sake	4	decent	Effect: "The Wisdom... of the Future", Effect Duration: 15
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	normal skewed canap&eacute;s	4	good	
 3502	denatured huge thermos of brew	1	EPIC	Effect: "Spooky Weapon", Effect Duration: 15, Last Available: "2011-12"
 3503	aged glass of brandy	4	awesome	Last Available: "2011-12"
 3504	French slippers	0		
 3505	savvy LWA ring	0		Mysticality Percent: +20
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	twirling Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	twirling Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	hale scratch 'n' sniff sword	0		Maximum HP: +20, Last Available: "2008-11"
 3509	yellow scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	bouncing scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	quilted thinker's depleted Grimacite gravy boat	0		Mysticality: +10, Damage Absorption: +40, Last Available: "2011-12"
 3544	spinning grievous Rosewater's depleted Grimacite weightlifting belt	0		Mysticality Percent: +30, Weapon Damage Percent: +50, Single Equip, Last Available: "2011-12"
 3545	jittery frosty nippy depleted Grimacite grappling hook	0		Cold Damage: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2011-12"
-3546	cyan studded Socratic depleted Grimacite ninja mask	0		Experience (Mysticality): +1, Damage Absorption: +80, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	wool savvy depleted Grimacite shinguards	0		Mysticality Percent: +20, Cold Resistance: +1, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	cyan studded Socratic depleted Grimacite ninja mask	0		Experience (Mysticality): +1, Damage Absorption: +80, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	wool savvy depleted Grimacite shinguards	0		Mysticality Percent: +20, Cold Resistance: +1, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	dog trainer's deadly depleted Grimacite astrolabe	0		Weapon Damage: +5, Experience (familiar): +1, Single Equip, Last Available: "2011-12"
 3549	friendly crafty KoL Con Cinco Pi&ntilde;ata Bat	0		Maximum MP: +10, Familiar Weight: +3, Softcore Only, Last Available: "2008-09"
 3550	spinning vibrating propeller beanie	0		Maximum MP Percent: +10, Familiar Effect: "atk, cap 7"
@@ -3530,7 +3530,7 @@
 3563	polymerized activated twirling pressurized potion of pulchritude	0		Effect: "Sugar High", Effect Duration: 60
 3564	hand-crafted special triple-distilled berry-infused sake	10	EPIC	Effect: "Reedy Pipes", Effect Duration: 5
 3565	bad citrus-infused sake	4	decent	
-3566	practically non-alcoholic bad melon-infused sake	1	decent	
+3566	bad practically non-alcoholic melon-infused sake	1	decent	
 3567	slab of sponge	0		
 3568	tumbling rosewater-soaked asbestos-lined sponge helmet of James Dean	0		Experience (Moxie): +3, Hot Resistance: +5, Stench Resistance: +3, Familiar Effect: "atk, 1xFairy"
 3569	mirror asbestos-lined razor-sharp Rosewater's spongy shield	0		Mysticality Percent: +30, Weapon Damage Percent: +25, Hot Resistance: +5, Damage Reduction: 14
@@ -3546,8 +3546,8 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	squat sushi-rolling mat	0		
-3582	flavorless diet rice	1	decent	
-3584	jumbo spoiled irradiated candy cane	5	crappy	Last Available: "2008-12"
+3582	diet flavorless rice	1	decent	
+3584	spoiled jumbo irradiated candy cane	5	crappy	Last Available: "2008-12"
 3585	adequate gingerbread mutant bugbear	4	good	Last Available: "2008-12"
 3586	perfectly mixed oozenog	4	EPIC	Last Available: "2008-12"
 3587	denatured olive sugar plum	0		Effect: "Brother Smothers's Blessing", Effect Duration: 42, Last Available: "2008-12"
@@ -3575,21 +3575,21 @@
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
 3611	wet flattened sea grease	0		Effect: "Patent Prevention", Effect Duration: 44
-3612	ghostly red sturdy Crimbo crate	0		Last Available: "2008-12"
+3612	red ghostly sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	enhanced activated unstable DNA	0		Effect: "Bestial Sympathy", Effect Duration: 30, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	blinking wriggling tentacle	0		Last Available: "2008-12"
 3620	olive mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	pulsating chitinous pod	0		Last Available: "2008-12"
 3624	blurry squat Newton's parasitic claw	0		Experience (Mysticality): +3, Last Available: "2008-12"
-3625	scorching parasitic tentacles	0		Hot Damage: +25, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	jittery Oprah's parasitic headgnawer	0		Maximum MP Percent: +50, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	scorching parasitic tentacles	0		Hot Damage: +25, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	jittery Oprah's parasitic headgnawer	0		Maximum MP Percent: +50, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	blurry strapping parasitic strangleworm	0		Muscle: +5, Last Available: "2008-12"
 3628	gray pair of ragged claws	0		Last Available: "2008-12"
 3629	wobbly burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	ghostly lard-coated healthy elven socks	0		Maximum HP Percent: +20, Sleaze Spell Damage: +25, Last Available: "2008-12"
 3634	shaking twirling family-friendly elven gloves of extreme caution	0		Monster Level: -25, Sleaze Resistance: +1, Last Available: "2008-12"
-3635	spinning festive holiday hat of chilblains of the cheetah	0		Cold Damage: +25, Initiative: +60, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	spinning festive holiday hat of chilblains of the cheetah	0		Cold Damage: +25, Initiative: +60, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	toasty wicked patent shoes	0		Spell Damage: +5, Hot Damage: +5, Last Available: "2008-12"
 3637	mirror studded gray bow tie of the brute	0		Muscle Percent: +30, Damage Absorption: +80, Last Available: "2008-12"
 3638	olive skewed scandalous mansplainer's penguin thesaurus	0		Monster Level: +15, Sleaze Damage: +5, Last Available: "2008-12"
@@ -3611,12 +3611,12 @@
 3645	aged canteen of wine	3	awesome	Last Available: "2008-12"
 3646	yummy elven <i>limbos</i> gingerbread	3	awesome	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
-3648	mirror skewed magic dragonfish fry	0		
+3648	skewed mirror magic dragonfish fry	0		
 3649	maroon map to Madness Reef	0		
 3650	rotten toast with jam	4	crappy	Last Available: "2008-12"
-3651	red antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	red antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	tolerable elven moonshine	4	good	Last Available: "2008-12"
-3653	stale shaking knuckle sandwich	4	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	stale shaking knuckle sandwich	4	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	sinister psycho sweater of mayonnaise	0		Spell Damage: +10, Sleaze Spell Damage: +50, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	gravedigger's plastic Mob Penguin	0		Spooky Damage: +10, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	plastic strand of DNA of James Dean	0		Experience (Moxie): +3, Last Available: "2008-12"
 3660	bouncing blurry medical-grade plastic chunk of depleted Grimacite	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2008-12"
 3661	ghostly container of Putty	0		Last Available: "2009-01"
-3662	skewed banded Putty mitre	0		Damage Absorption: +100, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	blurry lion tamer's experienced Putty leotard	0		Experience: +2, Experience (familiar): +2, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	skewed banded Putty mitre	0		Damage Absorption: +100, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	blurry lion tamer's experienced Putty leotard	0		Experience: +2, Experience (familiar): +2, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	smooth Putty ball	0		Moxie: +15, Softcore Only, Last Available: "2009-01"
 3665	cyan Putty sheet	0		Last Available: "2009-01"
 3666	pulsating bouncing sage Putty snake of chilblains of the businessman	0		Mysticality Percent: +10, Cold Damage: +25, Meat Drop: +50, Softcore Only, Last Available: "2009-01"
@@ -3636,32 +3636,32 @@
 3670	frightening glow-in-the-dark burrowgrub	0		Spooky Damage: +5, Last Available: "2009-01"
 3671	green Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	decent can of franks 'n' beans	4	good	Last Available: "2010-12"
-3673	bad boozy bottle of peppermint schnapps	5	decent	Last Available: "2010-12"
+3673	boozy bad bottle of peppermint schnapps	5	decent	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	Herculean diving muff	0		Experience (Muscle): +1, Single Equip
-3678	perfectly mixed enchanted blinking salinated mint julep	4	EPIC	Effect: "Dance Interpreter", Effect Duration: 5
+3678	enchanted perfectly mixed blinking salinated mint julep	4	EPIC	Effect: "Dance Interpreter", Effect Duration: 5
 3679	ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	spinning map to the Marinara Trench	0		
-3684	snack-sized bland shaking tempura carrot	2	decent	
-3685	flavorless gigantic spinning tempura cucumber	7	decent	
-3686	flavorless small tempura avocado	2	decent	
+3684	bland snack-sized shaking tempura carrot	2	decent	
+3685	gigantic flavorless spinning tempura cucumber	7	decent	
+3686	small flavorless tempura avocado	2	decent	
 3687	decent sea broccoli	3	good	
 3688	decent sea cauliflower	3	good	
-3689	fancy bland jittery spinning tempura broccoli	4	decent	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 40
-3690	stale snack-sized tempura cauliflower	2	decent	
-3691	tasty fancy sea blueberry	3	awesome	Effect: "Inappropriate Spirit", Effect Duration: 35
+3689	fancy bland spinning jittery tempura broccoli	4	decent	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 40
+3690	snack-sized stale tempura cauliflower	2	decent	
+3691	fancy tasty sea blueberry	3	awesome	Effect: "Inappropriate Spirit", Effect Duration: 35
 3692	moldy sea persimmon	3	crappy	
-3693	concentrated wet lime green huge pressurized potion of perception	0		Effect: "Polar Express", Effect Duration: 31
+3693	concentrated wet huge lime green pressurized potion of perception	0		Effect: "Polar Express", Effect Duration: 31
 3694	pickled cold-filtered non-frozen squat pressurized potion of proficiency	0		Effect: "Spiky Frozen Hair", Effect Duration: 19
 3695	pulsating Socratic Mer-kin digpick	0		Experience (Mysticality): +1
 3696	bouncing anemone nematocyst	0		
 3697	high-pressure seltzer bottle	0		
-3698	mirror pulsating olive velcro ore	0		
+3698	olive mirror pulsating velcro ore	0		
 3699	teflon ore	0		
 3700	vinyl ore	0		
 3701	bouncing map to Anemone Mine	0		
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	shaking sinister sage handwarmer	0		Mysticality Percent: +10, Spell Damage: +10, Single Equip
 3737	up-at-dawn Samson's lighter	0		Experience (Muscle): +5, Adventures: +5
-3738	snack-sized toothsome packet of beer nuts	2	awesome	
+3738	toothsome snack-sized packet of beer nuts	2	awesome	
 3739	blinking Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,27 +3713,27 @@
 3747	blinking mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	frozen concoction of clumsiness	0		Effect: "Cock of the Walk", Effect Duration: 47
 3750	cyan Jeselnik's vampire pearl earring	0		Sleaze Damage: +25, Single Equip
-3751	stale snack-sized special wobbly chocolate chip brownies	2	decent	Effect: "Sleazy Weapon", Effect Duration: 50
-3753	blinking Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3751	special stale snack-sized wobbly chocolate chip brownies	2	decent	Effect: "Sleazy Weapon", Effect Duration: 50
+3753	blinking Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	wet blinking love song of vague ambiguity	0		Effect: "Super Skill", Effect Duration: 66, Last Available: "2009-02"
 3755	activated love song of smoldering passion	0		Effect: "Human-Plant Hybrid", Effect Duration: 51, Last Available: "2009-02"
 3756	unsweetened flattened love song of icy revenge	0		Effect: "Memory of Strength", Effect Duration: 32, Last Available: "2009-02"
 3757	denatured irradiated polarized love song of sugary cuteness	0		Effect: "Grape Expectations", Effect Duration: 23, Last Available: "2009-02"
 3758	pickled flattened red love song of disturbing obsession	0		Effect: "Joyful Resolve", Effect Duration: 67, Last Available: "2009-02"
-3759	energized skewed narrow love song of naughty innuendo	0		Effect: "Covetous Robbery", Effect Duration: 69, Last Available: "2009-02"
+3759	energized narrow skewed love song of naughty innuendo	0		Effect: "Covetous Robbery", Effect Duration: 69, Last Available: "2009-02"
 3760	polarized galvanized mirror breath mint	0		Effect: "Gummi Badass", Effect Duration: 53
 3761	greasy vampire pearl ring	0		Sleaze Spell Damage: +10, Single Equip
 3762	up-at-dawn vampire pearl necklace	0		Adventures: +5, Single Equip
 3763	hand-crafted slug of vodka	4	EPIC	
-3764	aged weak slug of rum	2	awesome	
+3764	weak aged slug of rum	2	awesome	
 3765	mediocre slug of shochu	3	decent	
 3766	drinkable screwdiver	4	good	
 3767	perfectly mixed dew yoana lei	4	EPIC	
-3768	extra-dry tolerable lychee chuhai	5	good	
+3768	tolerable extra-dry lychee chuhai	5	good	
 3769	bad salacious screwdiver	3	decent	
 3770	perfectly mixed dew yoana salacious lei	3	EPIC	
 3771	weak acceptable pulsating salacious lychee chuhai	2	good	
-3772	artisanal strong Alewife&trade; Ale	5	EPIC	
+3772	strong artisanal Alewife&trade; Ale	5	EPIC	
 3773	blurry seaode	0		
 3774	twirling map to the Dive Bar	0		
 3775	squat Mer-kin pinkslip	0		
@@ -3750,11 +3750,11 @@
 3786	upside-down vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
 3788	spinning crumbling rat skull	0		Class: "Pastamancer"
-3789	maroon ghostly twitching trigger finger	0		Class: "Pastamancer"
+3789	ghostly maroon twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	red crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	red crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	prompt inspector's Mer-kin roundshield of the pedagogue	0		Experience: +3, Item Drop: +15, Adventures: +3, Damage Reduction: 14
 3804	knitted Mer-kin breastplate of the pedagogue	0		Experience: +3, Cold Resistance: +3
 3805	blurry pulsating prompt Mer-kin sneakmask of James Dean	0		Experience (Moxie): +3, Adventures: +3, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3780,14 +3780,14 @@
 3826	teal Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	maroon Grandma's Map	0		
-3829	decent small green tempura radish	2	good	
+3829	small decent green tempura radish	2	good	
 3830	pulsating spinning inspector's water-polo cap	0		Item Drop: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	hand-crafted enchanted tumbling squat Typical Tavern swill	3	EPIC	Effect: "Perfect Hair", Effect Duration: 50
 3832	artisanal tropical swill	3	EPIC	
 3833	watered-down bad fruity girl swill	2	decent	
 3834	hand-crafted blended swill	4	EPIC	
 3835	costume wardrobe	0		Softcore Only
-3836	squat foul-smelling electrified beefy Elvish sunglasses of terror	0		Muscle: +10, Stench Damage: +10, Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	squat foul-smelling electrified beefy Elvish sunglasses of terror	0		Muscle: +10, Stench Damage: +10, Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	jittery cool anniversary safety glass vest	0		Moxie: +5
 3838	bouncing anniversary burlap belt of incineration	0		Hot Spell Damage: +50
 3839	anniversary balsa wood socks of the detective	0		Item Drop: +20
@@ -3841,8 +3841,8 @@
 3887	tarnished squat vial of slime	0		Effect: "Hyphemariffic", Effect Duration: 57
 3888	wet triple-wet vial of slime	0		Effect: "Bloody-minded", Effect Duration: 48
 3889	activated ionized vial of slime	0		Effect: "Tiki Temerity", Effect Duration: 30
-3890	activated green upside-down skewed vial of violet slime	0		Effect: "Artificially Sweet", Effect Duration: 58
-3891	dry tumbling upside-down vial of vermilion slime	0		Effect: "Jittery", Effect Duration: 15
+3890	activated upside-down skewed green vial of violet slime	0		Effect: "Artificially Sweet", Effect Duration: 58
+3891	dry upside-down tumbling vial of vermilion slime	0		Effect: "Jittery", Effect Duration: 15
 3892	flattened double-denatured vial of amber slime	0		Effect: "Spooky Blur", Effect Duration: 67
 3893	corrupted wet blurry spinning vial of chartreuse slime	0		Effect: "Extra Backbone", Effect Duration: 46
 3894	cold-filtered olive vial of teal slime	0		Effect: "Frostbeard", Effect Duration: 69
@@ -3850,13 +3850,13 @@
 3896	adjusted dry vial of slime	0		Effect: "Painted-On Bikini", Effect Duration: 35
 3897	quantum pickled nitrogenated vial of brown slime	0		Effect: "Weepy, Creepy", Effect Duration: 13
 3898	spinning bottle of G&uuml;-Gone	0		
-3901	cyan squat seal-blubber candle	0		Class: "Seal Clubber"
-3902	jittery tumbling figurine of a wretched-looking seal	0		Class: "Seal Clubber"
+3901	squat cyan seal-blubber candle	0		Class: "Seal Clubber"
+3902	tumbling jittery figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
-3905	green twirling figurine of an seal	0		Class: "Seal Clubber"
+3905	twirling green figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
-3907	upside-down green squat figurine of a shadowy seal	0		Class: "Seal Clubber"
+3907	green upside-down squat figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	skewed figurine of a charred seal	0		Class: "Seal Clubber"
 3910	pulsating figurine of a seal	0		Class: "Seal Clubber"
@@ -3886,7 +3886,7 @@
 3934	spinning sealbone	0		
 3935	polymerized double-diffused jittery hyperinflated seal lung	0		Effect: "Stemonitis Storm", Effect Duration: 33
 3936	super-moist twirling scrap of shadow	0		Effect: "Turtle Titters", Effect Duration: 61
-3937	pickled fuchsia upside-down fustulent seal grulch	0		Effect: "Berry Berry Cold", Effect Duration: 33
+3937	pickled upside-down fuchsia fustulent seal grulch	0		Effect: "Berry Berry Cold", Effect Duration: 33
 3938	wizardly club of corruption	0		Mysticality: +25, Class: "Seal Clubber"
 3939	razor-sharp corrupt club of corruption	0		Weapon Damage Percent: +25, Class: "Seal Clubber"
 3940	Socratic corrupt club of corrupt corruption	0		Experience (Mysticality): +1, Class: "Seal Clubber"
@@ -3912,8 +3912,8 @@
 3960	aromatic designer sunglasses	0		Stench Resistance: +1, Single Equip
 3961	scorching Oprah's opera glasses	0		Maximum MP Percent: +50, Hot Damage: +25
 3962	designer handbag	0		
-3963	blurry bouncing Clan pool table	0		Free Pull, Last Available: "2009-05"
-3964	teal tumbling cell phone	0		Familiar Weight: +10
+3963	bouncing blurry Clan pool table	0		Free Pull, Last Available: "2009-05"
+3964	tumbling teal cell phone	0		Familiar Weight: +10
 3965	polymerized huge cube of billiard chalk	0		Effect: "Third Based", Effect Duration: 44
 3966	huge supercharged brawny weightlifter's hot-ass club	0		Muscle: +15, Muscle Percent: +20, Maximum MP Percent: +30, Class: "Seal Clubber"
 3967	friendly chaotic frigid-ass club of the glutton	0		Spell Critical Percent: +10, Familiar Weight: +3, Food Drop: +100, Class: "Seal Clubber"
@@ -3926,7 +3926,7 @@
 3974	maroon huge forbidden mannequin leg of doom	0		Spell Damage Percent: +50, Spooky Spell Damage: +50, Class: "Seal Clubber"
 3975	supercharged rosy-cheeked padded tortoise	0		Maximum HP Percent: +30, Maximum MP Percent: +30, Damage Reduction: 6
 3976	frightening wholesome tortoboggan	0		Maximum HP Percent: +10, Spooky Damage: +5, Single Equip
-3977	maroon skewed painted turtle	0		
+3977	skewed maroon painted turtle	0		
 3978	nasty Temple Grandin's painted shield	0		Familiar Weight: +7, Stench Damage: +5, Damage Reduction: 7
 3979	sleeping wereturtle	0		
 3980	shell	0		
@@ -3942,7 +3942,7 @@
 3990	turtle shell helmet of the early riser	0		Adventures: +7, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	slime-soaked brain	0		Skill: "Slimy Synapses"
-3993	squat gray slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
+3993	gray squat slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
 3996	squat boxcar turtle	0		
@@ -3952,7 +3952,7 @@
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	distilled skewed agua de vida	1	good	Last Available: "2009-06"
 4002	twirling tortoboggan shield of the cougar of chilblains	0		Moxie: +20, Cold Damage: +25, Damage Reduction: 6
-4003	skewed mirror bottle of moontan lotion	0		
+4003	mirror skewed bottle of moontan lotion	0		
 4004	lard-coated soup-chucks	0		Sleaze Spell Damage: +25
 4005	colloidal altered ballast turtle	0		Effect: "Electrolit Up", Effect Duration: 66
 4006	spinning memory of some amino acids	0		Last Available: "2009-06"
@@ -3965,7 +3965,7 @@
 4013	memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
-4016	jittery huge memory of a GT base pair	0		Last Available: "2009-06"
+4016	huge jittery memory of a GT base pair	0		Last Available: "2009-06"
 4017	squirming Slime larva	0		
 4018	blinking greaves of extreme caution	0		Monster Level: -25, Familiar Effect: "1xBarrr, cap 37"
 4019	undissolvable contact lenses	0		
@@ -3990,15 +3990,15 @@
 4038	tolerable slimy fermented bile bladder	3	good	
 4039	pickled blurry narrow slimy alveolus	1		Effect: "Hoity Toity", Effect Duration: 40
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	skewed energetic wicked pig-iron helm	0		Spell Damage: +5, Maximum MP Percent: +20, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	shellacked pig-iron shinguards of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	skewed energetic wicked pig-iron helm	0		Spell Damage: +5, Maximum MP Percent: +20, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	shellacked pig-iron shinguards of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	chaotic Annie Oakley's pig-iron bracers	0		Critical Hit Percent: +20, Spell Critical Percent: +10, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	blurry wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	hardy wumpus-hair whip	0		Maximum HP: +50, Last Available: "2009-06"
-4048	perfumed sharpshooter's vibrating wumpus-hair wig	0		Maximum MP Percent: +10, Critical Hit Percent: +10, Stench Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	padded occult weightlifter's wumpus-hair loincloth	0		Muscle: +15, Spell Damage Percent: +25, Damage Absorption: +20, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	perfumed sharpshooter's vibrating wumpus-hair wig	0		Maximum MP Percent: +10, Critical Hit Percent: +10, Stench Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	padded occult weightlifter's wumpus-hair loincloth	0		Muscle: +15, Spell Damage Percent: +25, Damage Absorption: +20, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	cyan curative wicked wumpus-hair sweater	0		Spell Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-06"
 4051	personal trainer's ring of teleportation	0		Experience Percent (Muscle): +10, Single Equip
 4052	glass of baboon milk	1	good	Last Available: "2009-06"
@@ -4017,10 +4017,10 @@
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	jittery Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
-4068	olive upside-down essence of kink	0		Last Available: "2009-06"
+4068	upside-down olive essence of kink	0		Last Available: "2009-06"
 4069	ghostly essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
-4071	red blurry essence of fright	0		Last Available: "2009-06"
+4071	blurry red essence of fright	0		Last Available: "2009-06"
 4072	shaking essence of	0		Last Available: "2009-06"
 4073	upside-down Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
@@ -4034,10 +4034,10 @@
 4082	lightning-fast curative pernicious cudgel	0		Initiative: +40, HP Regen Min: 3, HP Regen Max: 5, Slime Hates It: +1
 4083	decent squat cupcake-in-a-cup	4	good	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	moldy snack-sized blinking blue protein paste	2	crappy	Last Available: "2009-06"
+4085	snack-sized moldy blinking blue protein paste	2	crappy	Last Available: "2009-06"
 4086	Tesla hale cyber-mattock	0		Maximum HP: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
-4088	narrow blurry X-37 gun	0		Last Available: "2009-06"
+4088	blurry narrow X-37 gun	0		Last Available: "2009-06"
 4089	irradiated nitrogenated red neurostim pill	0		Effect: "Floundering", Effect Duration: 65, Last Available: "2009-06"
 4090	adjusted physiostim pill	0		Effect: "Hella Smart", Effect Duration: 34, Last Available: "2009-06"
 4091	blue slimy cyst	0		
@@ -4085,11 +4085,11 @@
 4133	super-vacuum-sealed purple tempura air	0		Effect: "Physicali Tea", Effect Duration: 15
 4134	activated pressurized potion of pneumaticity	0		Effect: "Holiday Bliss", Effect Duration: 28
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	Lo Pan's hardened weightlifter's Bag o' Tricks of terror	0		Muscle: +15, Damage Reduction: 3, Spell Critical Percent: +30, Spooky Spell Damage: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	Lo Pan's hardened weightlifter's Bag o' Tricks of terror	0		Muscle: +15, Damage Reduction: 3, Spell Critical Percent: +30, Spooky Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
-4140	spinning shaking a folded paper strip	0		
+4140	shaking spinning a folded paper strip	0		
 4141	bouncing a crinkled paper strip	0		
 4142	ghostly a crumpled paper strip	0		
 4143	a ragged paper strip	0		
@@ -4119,7 +4119,7 @@
 4167	narrow lion tamer's Voluminous Radio Hat	0		Experience (familiar): +2, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
 4168	flame-wreathed Voluminous Radio Sneakers	0		Hot Spell Damage: +10, Single Equip
 4169	4-d camera	0		
-4170	teal huge shaking 4-d camera	0		
+4170	huge teal shaking 4-d camera	0		
 4171	crystallized memory	0		
 4172	blinking shaking baleful rock helmet	0		Spell Damage: +25, Familiar Effect: "1xGhuol, cap 25"
 4173	olive resourceful rock pants	0		Maximum MP: +50, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
@@ -4130,8 +4130,8 @@
 4178	veiny sugar shotgun	0		Maximum HP: +10, Last Available: "2009-09"
 4179	grievous sugar shillelagh	0		Weapon Damage Percent: +50, Last Available: "2009-09"
 4180	sugar shank of the blizzard	0		Cold Spell Damage: +25, Last Available: "2009-09"
-4181	aromatic boxer's sugar chapeau of terror	0		Muscle Percent: +10, Spooky Spell Damage: +10, Stench Resistance: +1, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	sugar shorts of Flo-Jo	0		Initiative: +100, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	aromatic boxer's sugar chapeau of terror	0		Muscle Percent: +10, Spooky Spell Damage: +10, Stench Resistance: +1, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	sugar shorts of Flo-Jo	0		Initiative: +100, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	olive sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	yellow slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4139,9 +4139,9 @@
 4187	stanky slime convention pin	0		Stench Spell Damage: +25
 4188	slime convention t-shirt	0		
 4189	inverse geode	0		
-4190	spinning cyan control crystal	0		Free Pull, Last Available: "2011-12"
+4190	cyan spinning control crystal	0		Free Pull, Last Available: "2011-12"
 4191	therapeutic sugar shirt	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-09"
-4192	skewed cyan sugar shard	0		Last Available: "2009-09"
+4192	cyan skewed sugar shard	0		Last Available: "2009-09"
 4193	wicked rave visor	0		Spell Damage: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
 4194	beefy baggy rave pants	0		Muscle: +10, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 4195	Herculean pacifier necklace	0		Experience (Muscle): +1, Single Equip
@@ -4158,12 +4158,12 @@
 4206	foul-smelling nasty brand new key	0		Stench Damage: 15
 4207	red mansplainer's dorsal fin	0		Monster Level: +15, Damage Reduction: 13
 4208	skate skates	0		
-4209	shaking teal mirror skate skin	0		
+4209	shaking mirror teal skate skin	0		
 4210	roller skate decoy	0		
 4211	huge mermaid's purse	0		
 4212	underwater slingshot	0		
 4213	shaking purple zippy slick skate blade	0		Moxie: +10, Initiative: +20
-4214	green upside-down spangly unitard	0		
+4214	upside-down green spangly unitard	0		
 4215	medical-grade collapsible baton of the boozehound	0		Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10
 4216	groupie lipstick	0		
 4217	groupie bra	0		
@@ -4171,17 +4171,17 @@
 4219	skewed toasty weightlifter's skate board	0		Muscle: +15, Hot Damage: +5
 4220	teal S.A.V.E. flyer	0		
 4221	bouncing teal crafty yield shield	0		Maximum MP: +10, Damage Reduction: 6, Last Available: "2009-09"
-4222	shaking blue map to the Skate Park	0		
+4222	blue shaking map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	roller skate doll	0		
 4226	nasty Star of Bravery	0		Stench Damage: +5, Single Equip
 4227	wobbly hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	blinking bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
-4232	twirling squat ice skate doll	0		
+4232	squat twirling ice skate doll	0		
 4233	squat hacienda key	0		
 4234	squat squat reassuring pat&eacute; knife	0		Spooky Resistance: +1
 4235	ghostly salt-shaker	0		
@@ -4205,16 +4205,16 @@
 4253	denatured aerosolized potion of speed	0		Effect: "Spooky Demeanor", Effect Duration: 67
 4254	teal bark	0		Last Available: "2009-10"
 4255	red skewed Wolfman Nardz	0		Last Available: "2009-10"
-4256	enhanced tumbling pulsating sap	0		Effect: "Mighty Shout", Effect Duration: 29, Last Available: "2009-10"
+4256	enhanced pulsating tumbling sap	0		Effect: "Mighty Shout", Effect Duration: 29, Last Available: "2009-10"
 4257	narrow petrified wood	0		Last Available: "2009-10"
 4258	bland snack-sized chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
 4259	acceptable mulled cider	4	good	Last Available: "2009-10"
-4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	upside-down olive pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	olive upside-down pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	family-friendly bark boxers	0		Sleaze Resistance: +1, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	grievous bark beret	0		Weapon Damage Percent: +50, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	family-friendly bark boxers	0		Sleaze Resistance: +1, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	grievous bark beret	0		Weapon Damage Percent: +50, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	nippy bark bracelet	0		Cold Damage: +10, Single Equip
 4267	ghostly dog trainer's boxer's Krakrox's Loincloth	0		Muscle Percent: +10, Experience (familiar): +1, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	gravedigger's resourceful Galapagosian Cuisses	0		Maximum MP: +50, Spooky Damage: +10, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	cyan family-friendly medical-grade Ass-Stompers of Violence of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	bouncing forbidden experienced Brand of Violence of James Dean	0		Experience: +2, Experience (Moxie): +3, Spell Damage Percent: +50, Conditional Skill (Equipped): "Brand"
 4299	manspreader's resourceful sinister Novelty Belt Buckle of Violence	0		Spell Damage: +10, Maximum MP: +50, Monster Level: +10, Single Equip
-4300	coward's crafty supercool Lens of Violence	0		Moxie Percent: +20, Maximum MP: +10, Monster Level: -20, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	coward's crafty supercool Lens of Violence	0		Moxie Percent: +20, Maximum MP: +10, Monster Level: -20, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	MacGyver's wholesome Pigsticker of Violence of the storm	0		Maximum HP Percent: +10, Maximum MP Percent: +40, Maximum MP: +100
-4302	teal squat gravedigger's razor-sharp deadly Jodhpurs of Violence	0		Weapon Damage: +5, Weapon Damage Percent: +25, Spooky Damage: +10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	teal squat gravedigger's razor-sharp deadly Jodhpurs of Violence	0		Weapon Damage: +5, Weapon Damage Percent: +25, Spooky Damage: +10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	blinking greedy Cold Stone of Hatred of Tarzan of the boozehound	0		Experience (Muscle): +3, Meat Drop: +20, Booze Drop: +100, Conditional Skill (Equipped): "Chilling Grip"
 4304	gray quilted Sinatra's Girdle of Hatred of terror	0		Experience (Moxie): +5, Damage Absorption: +40, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	knitted stanky manspreader's Staff of Simmering Hatred	0		Monster Level: +10, Stench Spell Damage: +25, Cold Resistance: +3
-4306	twirling aromatic quilted Pantaloons of Hatred of courage	0		Damage Absorption: +40, Spooky Resistance: +3, Stench Resistance: +1, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	twirling aromatic quilted Pantaloons of Hatred of courage	0		Damage Absorption: +40, Spooky Resistance: +3, Stench Resistance: +1, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	horrifying studded arcane researcher's Fuzzy Slippers of Hatred	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Spooky Damage: +25, Single Equip
-4308	cyan careful hardy smooth Lens of Hatred	0		Moxie: +15, Maximum HP: +50, Monster Level: -10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	cyan careful hardy smooth Lens of Hatred	0		Moxie: +15, Maximum HP: +50, Monster Level: -10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	Temple Grandin's MacGyver's smartaleck's Treads of Loathing	0		Moxie Percent: +30, Maximum MP: +100, Familiar Weight: +7, Single Equip
 4310	twirling fireproof lard-coated horrifying Scepter of Loathing	0		Spooky Damage: +25, Sleaze Spell Damage: +25, Hot Resistance: +3
 4311	narrow flame-retardant scorching coward's Belt of Loathing	0		Monster Level: -20, Hot Damage: +25, Hot Resistance: +1, Single Equip
@@ -4280,7 +4280,7 @@
 4328	yellow suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	moldy candy kneecapping stick	3	crappy	Last Available: "2009-12"
-4331	flavorless special big licorice garrote	5	decent	Effect: "Braaaains Over Braaaawwn", Effect Duration: 10, Last Available: "2009-12"
+4331	big special flavorless licorice garrote	5	decent	Effect: "Braaaains Over Braaaawwn", Effect Duration: 10, Last Available: "2009-12"
 4332	huge candy knuckles of the cougar	0		Moxie: +20, Last Available: "2009-12"
 4333	bland gigantic jawbruiser	6	decent	Last Available: "2010-12"
 4334	Vulcanized adjusted deionized chocolate car	0		Effect: "Pwnd", Effect Duration: 44, Last Available: "2009-12"
@@ -4290,7 +4290,7 @@
 4338	clever plastic Don Crimbo	0		Maximum MP: +20, Last Available: "2009-12"
 4339	jittery skewed Samson's plastic Crimbomination	0		Experience (Muscle): +5, Last Available: "2009-12"
 4340	colloidal non-pickled Piddles	0		Effect: "Retrograde Relaxation", Effect Duration: 46, Last Available: "2009-12"
-4341	anodized mirror skewed BitterSweetTarts	0		Effect: "Fan-Cooled", Effect Duration: 45, Last Available: "2009-12"
+4341	anodized skewed mirror BitterSweetTarts	0		Effect: "Fan-Cooled", Effect Duration: 45, Last Available: "2009-12"
 4342	triple-modified aerosolized tumbling shaking Polka Pop	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 51, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	spinning gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	electrified snow hat	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	Sherlock's snow pants	0		Item Drop: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	electrified snow hat	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	Sherlock's snow pants	0		Item Drop: +25, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	pulsating jittery deadly snow belly	0		Weapon Damage: +5, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4322,7 +4322,7 @@
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	squat handful of wires	0		Last Available: "2009-12"
 4372	shaking chunk of cement	0		Last Available: "2009-12"
-4373	lime green mirror grappling hook	0		Last Available: "2009-12"
+4373	mirror lime green grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	blue spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	scorching Da Vinci's pocketwatch on a chain	0		Experience (Mysticality): +5, Hot Damage: +25, Last Available: "2009-12"
 4386	purple greasy cement sandals of Tarzan	0		Experience (Muscle): +3, Sleaze Spell Damage: +10, Single Equip, Last Available: "2009-12"
 4387	mirror lightning-fast foul-smelling night-vision goggles	0		Stench Damage: +10, Initiative: +40, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	skewed executive peanut brittle shield	0		Meat Drop: +40, Damage Reduction: 3, Last Available: "2009-12"
 4390	gray twirling chaotic brawny Red Rover BB gun	0		Muscle Percent: +20, Spell Critical Percent: +10, Last Available: "2009-12"
-4391	censurious red-and-green sweater	0		Sleaze Resistance: +3, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	censurious red-and-green sweater	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	electrified ghostly Crimbo peppermint bark	0		Effect: "The Rich Get Richer", Effect Duration: 14, Last Available: "2009-12"
 4394	energized energized skewed Crimbo fudge	0		Effect: "Demonic Flavor", Effect Duration: 17, Last Available: "2009-12"
@@ -4349,19 +4349,19 @@
 4397	twirling crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	tumbling double-paned cheese sword	0		Cold Resistance: +5, Softcore Only, Last Available: "2010-01"
-4400	cheese diaper of dire peril	0		Weapon Damage: +20, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	cheese diaper of dire peril	0		Weapon Damage: +20, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	narrow mansplainer's cheese wheel	0		Monster Level: +15, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	red banded cheese eye	0		Damage Absorption: +100, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	red banded cheese eye	0		Damage Absorption: +100, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	sharpshooter's hardened sage Staff of Queso Escusado	0		Mysticality Percent: +10, Damage Reduction: 3, Critical Hit Percent: +10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	upside-down The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	huge Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
-4408	spinning red A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
+4408	red spinning A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	blurry Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	snack-sized yummy quantum taco	0		Last Available: "2010-10"
-4413	tolerable weak Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	yummy snack-sized quantum taco	0		Last Available: "2010-10"
+4413	weak tolerable Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	ghostly wicked sealhide hood	0		Spell Damage: +5, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	manspreader's sealhide leggings	0		Monster Level: +10, Familiar Effect: "1xVolley, cap 40"
@@ -4382,7 +4382,7 @@
 4432	aerosolized modified invisibility potion	0		Effect: "Orchid Blood", Effect Duration: 57, Last Available: "2011-08"
 4433	ionized irresistibility potion	0		Effect: "BOOsted", Effect Duration: 54, Last Available: "2011-08"
 4434	concentrated irritability potion	0		Effect: "Patent Alacrity", Effect Duration: 41, Last Available: "2011-08"
-4436	blurry huge cube	0		Last Available: "2011-02"
+4436	huge blurry cube	0		Last Available: "2011-02"
 4438	squat hellseal whisker	0		
 4439	hellseal claw	0		
 4440	guard turtle shell of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 40"
@@ -4396,7 +4396,7 @@
 4448	boiled Instant Karma	1	good	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	narrow pointy hat of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	narrow pointy hat of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	machetito of temperance	0		Sleaze Resistance: +5, Last Available: "2010-04"
 4453	shaking skewed nasty lawnmower blade	0		Stench Damage: +5, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4411,20 +4411,20 @@
 4463	diffused huge red chocolate turtle totem	0		Effect: "Smoky Third Eye", Effect Duration: 53
 4464	non-denatured aerosolized chocolate pasta spoon	0		Effect: "Ooh, Sweet!", Effect Duration: 43
 4465	magnetized spinning chocolate saucepan	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 53
-4466	polymerized squat spinning chocolate disco ball	0		Effect: "Sweet Nostalgia", Effect Duration: 38
+4466	polymerized spinning squat chocolate disco ball	0		Effect: "Sweet Nostalgia", Effect Duration: 38
 4467	denatured quadruple-oxidized chocolate stolen accordion	0		Effect: "On a Roll", Effect Duration: 50
-4468	tumbling Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	tumbling Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	blue BRICKO eye brick	0		Last Available: "2010-02"
-4471	asbestos-lined BRICKO hat	0		Hot Resistance: +5, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	up-at-dawn BRICKO pants	0		Adventures: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	asbestos-lined BRICKO hat	0		Hot Resistance: +5, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	up-at-dawn BRICKO pants	0		Adventures: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	gray hardened BRICKO sword	0		Damage Reduction: 3, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	blurry BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	blinking BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	blinking BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4455,12 +4455,12 @@
 4507	tumbling Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	quantum polarized wobbly &quot;DRINK ME&quot; potion	0		Effect: "Cheered Up", Effect Duration: 64, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	stale diet huge walrus ice cream	1	decent	Last Available: "2010-03"
+4510	diet stale huge walrus ice cream	1	decent	Last Available: "2010-03"
 4511	bland beautiful soup	3	decent	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	mirror Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	rotten Humpty Dumplings	4	crappy	Last Available: "2010-03"
-4515	miniature toothsome Lobster <i>qua</i> Grill	2	awesome	Last Available: "2010-03"
+4515	toothsome miniature Lobster <i>qua</i> Grill	2	awesome	Last Available: "2010-03"
 4516	bad practically non-alcoholic missing wine	1	decent	Last Available: "2010-03"
 4517	stale ghostly matter custard	3	decent	Last Available: "2010-03"
 4518	Vulcanized energized blurry comfit?	0		Effect: "Sticky Hands", Effect Duration: 43, Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	gray croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	twirling eye of the Tiger-lily of vim and vigor of temperance	0		Maximum HP Percent: +50, Sleaze Resistance: +5, Last Available: "2010-03"
-4524	cool wig of wisdom	0		Mysticality: +15, Moxie: +5, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	cool wig of wisdom	0		Mysticality: +15, Moxie: +5, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	tasty thick donut	5	awesome	Last Available: "2010-03"
 4526	rotten jumbo bucket of honey	5	crappy	Last Available: "2010-03"
 4527	aromatic MacGyver's elephant stinger	0		Maximum MP: +100, Stench Resistance: +1, Last Available: "2010-03"
 4528	toothsome dragon snaps	3	awesome	Last Available: "2010-03"
 4529	snapdragon pistil of the brute	0		Muscle Percent: +30, Item Drop: +5, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	small spoiled rook cookie	2	crappy	Last Available: "2010-03"
+4531	spoiled small rook cookie	2	crappy	Last Available: "2010-03"
 4532	stale bishop cookie	3	decent	Last Available: "2010-03"
 4533	flavorless knight cookie	3	decent	Last Available: "2010-03"
-4534	adequate skewed jittery king cookie	4	good	Last Available: "2010-03"
-4535	stale fancy queen cookie	4	decent	Effect: "Towering Strength", Effect Duration: 30, Last Available: "2010-03"
+4534	adequate jittery skewed king cookie	4	good	Last Available: "2010-03"
+4535	fancy stale queen cookie	4	decent	Effect: "Towering Strength", Effect Duration: 30, Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	olive cool insane tophat	0		Moxie: +5, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	helm of the knight of the empath of the blizzard	0		Familiar Weight: +5, Cold Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	olive cool insane tophat	0		Moxie: +5, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	helm of the knight of the empath of the blizzard	0		Familiar Weight: +5, Cold Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	lightning-fast wristwatch of the knight of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +40, Single Equip, Last Available: "2010-03"
-4540	flame-retardant sage trousers of the knight	0		Mysticality Percent: +10, Hot Resistance: +1, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	flame-retardant sage trousers of the knight	0		Mysticality Percent: +10, Hot Resistance: +1, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	studded tophat	0		Damage Absorption: +80, Familiar Effect: "1xBarrr, cap 25"
 4542	blurry auspicious tie	0		Item Drop: +10, Single Equip
 4543	Herculean tuxedo pants	0		Experience (Muscle): +1, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4497,11 +4497,11 @@
 4549	skewed carpenter	0		Last Available: "2010-03"
 4550	dodo	0		Last Available: "2010-03"
 4551	Jack Frost's detour shield	0		Cold Spell Damage: +50, Damage Reduction: 6, Last Available: "2010-03"
-4552	squat mirror left parenthesis	0		
+4552	mirror squat left parenthesis	0		
 4553	lowercase a	0		
 4554	percent sign	0		
 4555	left bracket	0		
-4556	cyan skewed right parenthesis	0		
+4556	skewed cyan right parenthesis	0		
 4557	dollar sign	0		
 4558	equal sign	0		
 4559	wobbly record album	0		Last Available: "2010-04"
@@ -4510,7 +4510,7 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	hand-crafted triple-distilled world's most unappetizing beverage	9	EPIC	Last Available: "2010-04"
 4564	Rosewater's slippery when wet shield	0		Mysticality Percent: +30, Damage Reduction: 6, Last Available: "2010-04"
-4565	thick bland raisin	5	decent	Last Available: "2010-04"
+4565	bland thick raisin	5	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	Van der Graaf smartaleck's flyest of shirts	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-04"
 4568	decent huge a dance upon the palate	4	good	Last Available: "2010-04"
@@ -4521,14 +4521,14 @@
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	anodized double-quantum polarized Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Pronounced Potency", Effect Duration: 34, Last Available: "2010-04"
 4580	arcane researcher's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Experience Percent (Mysticality): +10, Last Available: "2010-04"
-4581	wobbly ghostly experienced T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of horror	0		Experience: +2, Spooky Spell Damage: +25, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	wobbly ghostly experienced T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of horror	0		Experience: +2, Spooky Spell Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	mirror fat bottom quark	0		Last Available: "2010-05"
-4583	mirror tumbling olive glob of skin	0		
+4583	mirror olive tumbling glob of skin	0		
 4584	normal six wedges of goat cheese	3	good	
 4585	squat collection of objects	0		
 4586	boulder	0		
@@ -4542,15 +4542,15 @@
 4594	pulsating pixel cross	0		
 4595	blurry pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
-4597	mirror red 8-Bit Power magazine	0		Last Available: "2010-07"
+4597	red mirror 8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	smooth practically non-alcoholic plastic cup of beer	1	awesome	Last Available: "2010-06"
+4601	practically non-alcoholic smooth plastic cup of beer	1	awesome	Last Available: "2010-06"
 4602	huge orquette's phone number	0		Last Available: "2010-06"
 4603	blue bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	yellow Sherlock's brawny bottle of Goldschn&ouml;ckered	0		Muscle Percent: +20, Item Drop: +25, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	yellow Sherlock's brawny bottle of Goldschn&ouml;ckered	0		Muscle Percent: +20, Item Drop: +25, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	huge bland blinking sun-dried tofu	7	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	aged bouncing soyburger juice	4	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	blue respected companion biscuit	0		Last Available: "2010-08"
@@ -4574,15 +4574,15 @@
 4626	jittery superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	gray parachute guy	0		Last Available: "2010-06"
-4629	Da Vinci's plastic spider ring	0		Experience (Mysticality): +5, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	Da Vinci's plastic spider ring	0		Experience (Mysticality): +5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	supercharged plastic kazoo	0		Maximum MP Percent: +30, Last Available: "2010-06"
 4631	brainy inflatable baseball bat	0		Mysticality: +5, Last Available: "2010-06"
-4632	blinking dance instructor's googly-star hat of the empath	0		Experience Percent (Moxie): +10, Familiar Weight: +5, Familiar Effect: "atk", Last Available: "2010-06"
+4632	blinking dance instructor's googly-star hat of the empath	0		Experience Percent (Moxie): +10, Familiar Weight: +5, Last Available: "2010-06", Familiar Effect: "atk"
 4633	pulsating gravedigger's smelly googly-ball hat	0		Stench Spell Damage: +10, Spooky Damage: +10, Last Available: "2010-06"
 4634	prompt ruddy googly-heart hat	0		Maximum HP Percent: +40, Adventures: +3, Last Available: "2010-06"
 4635	fireproof toasty super-sweet boom box	0		Hot Damage: +5, Hot Resistance: +3, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	Oprah's curative cool sinister demon mask	0		Moxie: +5, Maximum MP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	Oprah's curative cool sinister demon mask	0		Moxie: +5, Maximum MP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	Usain Bolt's flame-wreathed personal trainer's streetfighting champion's belt	0		Experience Percent (Muscle): +10, Hot Spell Damage: +10, Initiative: +80, Single Equip, Last Available: "2010-06"
 4639	pulsating wool chaotic boxer's Space Trip safety headphones	0		Muscle Percent: +10, Spell Critical Percent: +10, Cold Resistance: +1, Single Equip, Last Available: "2010-06"
 4640	cyan hale LARP carp	0		Maximum HP: +20
@@ -4594,8 +4594,8 @@
 4646	smelly Jack Frost's careful Meteoid ice beam	0		Monster Level: -10, Cold Spell Damage: +50, Stench Spell Damage: +10, Last Available: "2011-12"
 4647	manspreader's wicked Dungeon Fist gauntlet of bravery	0		Spell Damage: +5, Monster Level: +10, Spooky Resistance: +5, Last Available: "2011-06"
 4648	squat Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	cyan fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	cyan fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	savvy ironic knit cap of the glutton	0		Mysticality Percent: +20, Food Drop: +100, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	huge ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	lard-coated blackberry galoshes	0		Sleaze Spell Damage: +25, Single Equip
 4660	upside-down blurry stanky electrified trout fang	0		Stench Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-09"
-4661	snack-sized flavorless blinking poisonous caviar	2	decent	Last Available: "2010-09"
+4661	flavorless snack-sized blinking poisonous caviar	2	decent	Last Available: "2010-09"
 4662	ionized warmed upside-down wet venom duct	0		Effect: "You Know What's Up", Effect Duration: 51, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	wholesome arcane researcher's Ellsbury's skull	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +10, Last Available: "2010-09"
@@ -4619,7 +4619,7 @@
 4671	tolerable jittery booze-soaked cherry	3	good	
 4672	comfy pillow	0		
 4673	tasty bouncing marshmallow	3	awesome	
-4674	moldy snack-sized narrow mirror sponge cake	2	crappy	
+4674	snack-sized moldy narrow mirror sponge cake	2	crappy	
 4675	hand-crafted pulsating gin-soaked blotter paper	4	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	blurry friendly pottery shield	0		Familiar Weight: +3, Damage Reduction: 3, Last Available: "2010-09"
-4682	dangerous dance instructor's pottery hat	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	MacGyver's pottery training pants of the blizzard	0		Maximum MP: +100, Cold Spell Damage: +25, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	dangerous dance instructor's pottery hat	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	MacGyver's pottery training pants of the blizzard	0		Maximum MP: +100, Cold Spell Damage: +25, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	experienced pottery club	0		Experience: +2, Last Available: "2010-09"
 4685	manspreader's pottery yo-yo	0		Monster Level: +10, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	purple affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	Jeselnik's gravedigger's Socratic Greatest American Pants	0		Experience (Mysticality): +1, Spooky Damage: +10, Sleaze Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	Jeselnik's gravedigger's Socratic Greatest American Pants	0		Experience (Mysticality): +1, Spooky Damage: +10, Sleaze Damage: +25, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	huge fossilized necklace of the businessman	0		Meat Drop: +50, Last Available: "2010-09"
 4698	pulsating imp air	0		
 4699	bus pass	0		
@@ -4659,19 +4659,19 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	upside-down GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	gray popsicle stick	0		
-4714	toothsome diet lemon popsicle	1	awesome	
+4714	diet toothsome lemon popsicle	1	awesome	
 4715	flavorless blurry popsicle	4	decent	
-4716	bland bite-sized strawberry popsicle	1	decent	
+4716	bite-sized bland strawberry popsicle	1	decent	
 4717	spoiled liver popsicle	4	crappy	
 4718	greedy mariachi hat	0		Meat Drop: +20, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	shaking microwave stogie	0		Last Available: "2011-12"
-4722	moldy miniature liver and let pie	2	crappy	Last Available: "2010-10"
+4722	miniature moldy liver and let pie	2	crappy	Last Available: "2010-10"
 4723	moldy squat shaking badass pie	4	crappy	Last Available: "2010-10"
 4724	adequate shoo-fish pie	3	good	Last Available: "2010-10"
 4725	normal piping organ pie	3	good	Last Available: "2010-10"
-4726	fancy adequate igloo pie	3	good	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2010-10"
+4726	adequate fancy igloo pie	3	good	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2010-10"
 4727	adequate bite-sized stomach turnover	1	good	Last Available: "2010-10"
 4728	moldy snack-sized mirror dead lights pie	2	crappy	Last Available: "2010-10"
 4729	diet bland throbbing organ pie	1	decent	Last Available: "2010-10"
@@ -4679,28 +4679,28 @@
 4731	nest egg	0		
 4732	twirling sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	blurry kitty sheet music	0		Familiar Weight: +5
-4734	twirling pulsating rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
+4734	pulsating twirling rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	bouncing prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	wobbly veiny beer-soaked mop	0		Maximum HP: +10
 4738	tolerable day-old beer	3	good	
-4739	strong acceptable purple plain beer	5	good	
-4740	tolerable special watered-down overpriced &quot;imported&quot; beer	2	good	Effect: "Egg-stra Arm", Effect Duration: 45
+4739	acceptable strong purple plain beer	5	good	
+4740	watered-down special tolerable overpriced &quot;imported&quot; beer	2	good	Effect: "Egg-stra Arm", Effect Duration: 45
 4741	narrow smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	improved PlexiPips	0		Effect: "Salad Days", Effect Duration: 42
 4745	boiled Wax Flask	0		Effect: "Chalky Hand", Effect Duration: 53
 4746	irradiated deionized yellow Pain Dip	0		Effect: "Icy Composition", Effect Duration: 67
-4747	moldy miniature bone meal	2	crappy	Last Available: "2010-10"
-4748	distilled drinkable bone aperitif	5	good	Last Available: "2010-10"
+4747	miniature moldy bone meal	2	crappy	Last Available: "2010-10"
+4748	drinkable distilled bone aperitif	5	good	Last Available: "2010-10"
 4749	cyan double-paned bonerang	0		Cold Resistance: +5, Last Available: "2010-10"
 4750	shellacked bone and arrows	0		Damage Reduction: 7, Last Available: "2010-10"
 4751	boning knife of incineration	0		Hot Spell Damage: +50, Last Available: "2010-10"
 4752	bone crusher of the cheetah	0		Initiative: +60, Last Available: "2010-10"
 4753	twirling bone spurs of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2010-10"
-4754	bonedanna of the sewer of the boozehound	0		Stench Damage: +25, Booze Drop: +100, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	wobbly hardy boneana hammock of the blizzard	0		Maximum HP: +50, Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	bonedanna of the sewer of the boozehound	0		Stench Damage: +25, Booze Drop: +100, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	wobbly hardy boneana hammock of the blizzard	0		Maximum HP: +50, Cold Spell Damage: +25, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	tarnished triple-enhanced candy skeleton	0		Effect: "Super-Charged", Effect Duration: 25, Last Available: "2020-09"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	mirror wobbly huge pumpkin	0		Last Available: "2010-11"
 4763	normal pumpkin pie	3	good	Last Available: "2010-11"
-4764	practically non-alcoholic tolerable blinking pumpkin beer	1	good	Last Available: "2010-11"
+4764	tolerable practically non-alcoholic blinking pumpkin beer	1	good	Last Available: "2010-11"
 4765	pressed pumpkin juice	0		Effect: "Ass Over Teakettle", Effect Duration: 35, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	banded shin gourds of the pedagogue	0		Experience: +3, Damage Absorption: +100, Single Equip, Last Available: "2010-11"
@@ -4725,7 +4725,7 @@
 4811	pulsating Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	narrow Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	normal CRIMBCOIDS mints	4	good	Last Available: "2011-01"
-4819	narrow lime green can of CRIMBCOLA	0		Last Available: "2010-12"
+4819	lime green narrow can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	adequate maroon CRIMBCOLOAF	3	good	Last Available: "2011-01"
 4821	flavorless circular CRIMBCOOKIE	3	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	strapping plastic CRIMBCO HQ	0		Muscle: +5, Last Available: "2010-12"
@@ -4745,15 +4745,15 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	mirror olive robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	massive tasty triangular CRIMBCOOKIE	8	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	tasty massive triangular CRIMBCOOKIE	8	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	bland square CRIMBCOOKIE	4	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	Usain Bolt's inspector's greasy bindlestocking	0		Sleaze Spell Damage: +10, Item Drop: +15, Initiative: +80, Last Available: "2010-12"
 4842	tumbling sleeping stocking	0		Last Available: "2010-12"
 4843	squat Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	shaking cyan The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	Socratic Uncle Hobo's stocking cap of the glutton	0		Experience (Mysticality): +1, Food Drop: +100, Familiar Effect: "atk", Last Available: "2010-12"
+4845	Socratic Uncle Hobo's stocking cap of the glutton	0		Experience (Mysticality): +1, Food Drop: +100, Last Available: "2010-12", Familiar Effect: "atk"
 4846	dangerous Newton's Uncle Hobo's epic beard	0		Experience (Mysticality): +3, Weapon Damage: +10, Single Equip, Last Available: "2010-12"
-4847	deadly personal trainer's Uncle Hobo's gift baggy pants	0		Experience Percent (Muscle): +10, Weapon Damage: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	deadly personal trainer's Uncle Hobo's gift baggy pants	0		Experience Percent (Muscle): +10, Weapon Damage: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	quilted Uncle Hobo's fingerless tinsel gloves of the glutton	0		Damage Absorption: +40, Food Drop: +100, Single Equip, Last Available: "2010-12"
 4849	Uncle Hobo's highest bough of extreme caution of the blizzard	0		Monster Level: -25, Cold Spell Damage: +25, Last Available: "2010-12"
 4850	bouncing Uncle Hobo's belt of the bloodbag of incineration	0		Maximum HP: +100, Hot Spell Damage: +50, Single Equip, Last Available: "2010-12"
@@ -4775,27 +4775,27 @@
 4866	olive Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	manspreader's dance instructor's slick paperclip-on tie	0		Moxie: +10, Experience Percent (Moxie): +10, Monster Level: +10, Single Equip, Last Available: "2011-01"
-4869	huge Tesla beefcake's paperclip pants	0		Muscle: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	greasy flame-wreathed beefy paperclip turban	0		Muscle: +10, Hot Spell Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	huge Tesla beefcake's paperclip pants	0		Muscle: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	greasy flame-wreathed beefy paperclip turban	0		Muscle: +10, Hot Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	ghostly paperclip cape of Leguizamo	0		Monster Level: +20, Last Available: "2011-01"
 4872	twirling glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	blinking gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	non-denatured wobbly chocolate bath ball	0		Effect: "Memory of Smarts", Effect Duration: 45, Last Available: "2011-01"
-4877	corrupted shaking narrow bacon bath ball	0		Effect: "Remaining Alive", Effect Duration: 68, Last Available: "2011-01"
+4877	corrupted narrow shaking bacon bath ball	0		Effect: "Remaining Alive", Effect Duration: 68, Last Available: "2011-01"
 4878	quantum triple-galvanized purple incense bath ball	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 15, Last Available: "2011-01"
 4879	altered myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "On a Roll", Effect Duration: 68, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	extra-dry hand-crafted blue CRIMBCO wine	5	EPIC	Last Available: "2011-01"
+4881	hand-crafted extra-dry blue CRIMBCO wine	5	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	adequate toe jam toast	3	good	Last Available: "2011-01"
-4885	fuchsia spinning traffic jam	0		Last Available: "2011-01"
+4885	spinning fuchsia traffic jam	0		Last Available: "2011-01"
 4886	decent traffic jam toast	4	good	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	flavorless olive ghostly space jam toast	4	decent	Last Available: "2011-01"
-4889	Vulcanized huge wobbly motivational poster	0		Effect: "Hella Tough", Effect Duration: 44, Last Available: "2011-01"
+4888	flavorless ghostly olive space jam toast	4	decent	Last Available: "2011-01"
+4889	Vulcanized wobbly huge motivational poster	0		Effect: "Hella Tough", Effect Duration: 44, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	skewed bath ball gift set	0		Last Available: "2011-01"
 4892	ghostly slow jam collection	0		Last Available: "2011-01"
@@ -4843,7 +4843,7 @@
 4940	wobbly arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	spoiled Knob jelly donut	4	crappy	
 4942	blinking Knob cake	0		
-4943	blinking squat teal Knob cake pan	0		
+4943	squat blinking teal Knob cake pan	0		
 4944	Knob batter	0		
 4945	blurry Knob frosting	0		
 4946	unfrosted Knob cake	0		
@@ -4855,11 +4855,11 @@
 4952	oxidized corrupted chilled baggie of sugar	0		Effect: "Snobby", Effect Duration: 40
 4953	Lo Pan's curative whalebone corset	0		Spell Critical Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Single Equip
 4954	upside-down ruddy oven mitts	0		Maximum HP Percent: +40, Single Equip
-4955	enchanted stale super-sized overcookie	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 35
+4955	super-sized stale enchanted overcookie	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 35
 4956	decent narrow philosopher's scone	4	good	
-4957	magnetized ionized upside-down cyan half-baked potion	0		Effect: "Berry Experiential", Effect Duration: 60
+4957	magnetized ionized cyan upside-down half-baked potion	0		Effect: "Berry Experiential", Effect Duration: 60
 4958	mirror personal trainer's Knob Goblin deluxe scimitar	0		Experience Percent (Muscle): +10
-4959	fancy toothsome small Knob nuts	2	awesome	Effect: "Stimulated Body", Effect Duration: 50
+4959	toothsome fancy small Knob nuts	2	awesome	Effect: "Stimulated Body", Effect Duration: 50
 4960	acceptable Cobb's Knob Wurstbrau	3	good	
 4961	olive Subject 37 file	0		
 4962	ribald wizardly mysterious lapel pin	0		Mysticality: +25, Sleaze Damage: +10, Single Equip
@@ -4891,7 +4891,7 @@
 4988	maroon Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	fuchsia Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
-4991	purple jittery Alice's Army Foil Guard	0		Last Available: "2011-03"
+4991	jittery purple Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	blinking Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
@@ -4904,7 +4904,7 @@
 5001	Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	jittery Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
-5004	bouncing blue Alice's Army Foil Cleric	0		Last Available: "2011-03"
+5004	blue bouncing Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
 5007	Alice's Army Foil Martyr	0		Last Available: "2011-03"
@@ -4914,11 +4914,11 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	bland wasabi pocky	3	decent	Last Available: "2011-03"
-5014	bite-sized decent tobiko pocky	1	good	Last Available: "2011-03"
+5014	decent bite-sized tobiko pocky	1	good	Last Available: "2011-03"
 5015	flavorless massive natto pocky	6	decent	Last Available: "2011-03"
 5016	hand-crafted wasabi-infused sake	3	EPIC	Last Available: "2011-03"
 5017	fortified artisanal tobiko-infused sake	5	EPIC	Last Available: "2011-03"
-5018	aged special twirling tumbling natto-infused sake	3	awesome	Effect: "Weird Flavor", Effect Duration: 15, Last Available: "2011-03"
+5018	special aged tumbling twirling natto-infused sake	3	awesome	Effect: "Weird Flavor", Effect Duration: 15, Last Available: "2011-03"
 5019	triple-Vulcanized lime green wasabi marble soda	0		Effect: "Spooky Demeanor", Effect Duration: 19, Last Available: "2011-03"
 5020	dry narrow tobiko marble soda	0		Effect: "Faboooo", Effect Duration: 57, Last Available: "2011-03"
 5021	pressed green wobbly natto marble soda	0		Effect: "Witch's Brood", Effect Duration: 28, Last Available: "2011-03"
@@ -4926,7 +4926,7 @@
 5023	boiled colloidal elderly jawbreaker	0		Effect: "Hairy Palms", Effect Duration: 55, Last Available: "2020-09"
 5024	delicious bouncing marshmallow flamb&eacute;	3	awesome	Last Available: "2011-03"
 5025	drinkable cranberry schnapps	3	good	Last Available: "2011-03"
-5026	weak delicious spinning breaded beer	2	awesome	Last Available: "2011-03"
+5026	delicious weak spinning breaded beer	2	awesome	Last Available: "2011-03"
 5027	tolerable soy cordial	3	good	Last Available: "2011-03"
 5028	foul-smelling hardy astral bludgeon of extreme caution	0		Maximum HP: +50, Monster Level: -25, Stench Damage: +10
 5029	tumbling astral shield of Leguizamo of the cheetah	0		Monster Level: +20, Initiative: +60, Damage Reduction: 15
@@ -4944,14 +4944,14 @@
 5041	Usain Bolt's Da Vinci's slick astral shirt	0		Moxie: +10, Experience (Mysticality): +5, Initiative: +80
 5042	zippy hale astral belt	0		Maximum HP: +20, Initiative: +20
 5043	snack-sized toothsome blinking astral hot dog	2		
-5044	lousy special distilled astral pilsner	5		Effect: "Your Eyes are Peeled!", Effect Duration: 25
+5044	distilled lousy special astral pilsner	5		Effect: "Your Eyes are Peeled!", Effect Duration: 25
 5045	astral hot dog dinner	0		
 5046	green astral six-pack	0		
 5047	pulsating mirror fuchsia Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	Van der Graaf double-ice cap of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	Van der Graaf double-ice cap of incineration of horror	0		Hot Spell Damage: +50, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	Newton's double-ice box of the bloodbag of the early riser	0		Experience (Mysticality): +3, Maximum HP: +100, Adventures: +7, Last Available: "2011-04"
-5051	Da Vinci's double-ice britches of Tarzan of incineration	0		Experience (Muscle): +3, Experience (Mysticality): +5, Hot Spell Damage: +50, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	Da Vinci's double-ice britches of Tarzan of incineration	0		Experience (Muscle): +3, Experience (Mysticality): +5, Hot Spell Damage: +50, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4968,7 +4968,7 @@
 5065	special moldy spaghetti con calaveras	3	crappy	Effect: "White-boy Angst", Effect Duration: 10, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	decent popcorn	4	good	Last Available: "2011-04"
-5068	super-sized moldy huge chaos popcorn	5	crappy	Last Available: "2011-04"
+5068	moldy super-sized huge chaos popcorn	5	crappy	Last Available: "2011-04"
 5069	green upside-down lightning-fast boxer's hole of the wise owl	0		Mysticality: +20, Muscle Percent: +10, Initiative: +40, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	bland diet s'more	0	decent	Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	practically non-alcoholic tolerable Russian Ice	1	good	Last Available: "2011-04"
 5074	narrow deadly clay ashtray	0		Weapon Damage: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	studded lanyard	0		Damage Absorption: +80, Single Equip, Last Available: "2011-05"
-5076	monster pants of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	monster pants of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	polarized ionized Pok&euml;mann band-aid	0		Effect: "Innately Strong", Effect Duration: 44, Last Available: "2011-05"
-5079	sage Van der Graaf helmet of mayonnaise	0		Mysticality Percent: +10, Sleaze Spell Damage: +50, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	sage Van der Graaf helmet of mayonnaise	0		Mysticality Percent: +10, Sleaze Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	quilted crutch	0		Damage Absorption: +40, Last Available: "2011-05"
 5081	shock belt of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-05"
 5082	flattened irradiated concentrated fuchsia Okee-Dokee soda	0		Effect: "Tingling Feeling", Effect Duration: 24, Last Available: "2011-05"
 5083	electrified rubber band gun	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-05"
-5084	jittery scandalous pin-stripe slacks	0		Sleaze Damage: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	jittery scandalous pin-stripe slacks	0		Sleaze Damage: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	mirror inspector's gloves	0		Item Drop: +15, Single Equip, Last Available: "2011-05"
 5086	oxidized bouncing correction fluid	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 58, Last Available: "2011-05"
 5087	greedy Pok&euml;mann figurine: Porkachu	0		Meat Drop: +20, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	smooth Jeppson's Malort	4	awesome	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	Samson's stress ball	0		Experience (Muscle): +5, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	Samson's stress ball	0		Experience (Muscle): +5, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	skewed Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	green dog trainer's Ultracolor&trade; shirt	0		Experience (familiar): +1, Last Available: "2011-05"
 5112	cyan My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	spinning bird brain	0		
 5119	blinking busted wings	0		
 5120	maroon Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	wholesome educational brawny Admiral's hat	0		Muscle Percent: +20, Experience: +1, Maximum HP Percent: +10, Familiar Effect: "atk", Last Available: "2011-05"
-5122	fireproof frightening forbidden aviator's cap	0		Spell Damage Percent: +50, Spooky Damage: +5, Hot Resistance: +3, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	wholesome educational brawny Admiral's hat	0		Muscle Percent: +20, Experience: +1, Maximum HP Percent: +10, Last Available: "2011-05", Familiar Effect: "atk"
+5122	fireproof frightening forbidden aviator's cap	0		Spell Damage Percent: +50, Spooky Damage: +5, Hot Resistance: +3, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	narrow upside-down chaotic arcane researcher's mirrored aviator shades	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Single Equip, Last Available: "2011-05"
 5124	ghostly Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	blue Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	Jim Carey's resourceful banded honey dipper	0		Damage Absorption: +100, Maximum MP: +50, Monster Level: +25
 5149	double-paned sage honeybritches of the wise owl	0		Mysticality: +20, Mysticality Percent: +10, Cold Resistance: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	ghostly double-paned therapeutic extremely unsafe honeycap	0		Weapon Damage Percent: +100, Cold Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, cap 43"
-5151	teal Moonthril Circlet of bravery	0		Spooky Resistance: +5, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	teal asbestos-lined Moonthril Greaves	0		Hot Resistance: +5, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	teal Moonthril Circlet of bravery	0		Spooky Resistance: +5, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	teal asbestos-lined Moonthril Greaves	0		Hot Resistance: +5, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	ghostly smooth Moonthril Flamberge	0		Moxie: +15, Last Available: "2011-06"
 5154	huge crafty Moonthril Longbow	0		Maximum MP: +10, Last Available: "2011-06"
 5155	razor-sharp Moonthril Cuirass	0		Weapon Damage Percent: +25, Softcore Only, Last Available: "2011-06"
@@ -5075,7 +5075,7 @@
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	watered-down mediocre Saison du Lune	2	decent	Last Available: "2011-06"
-5175	weak lousy shaking Moonthril Schnapps	2	decent	Last Available: "2011-06"
+5175	lousy weak shaking Moonthril Schnapps	2	decent	Last Available: "2011-06"
 5176	weak drinkable green Wrecked Generator	2	good	Last Available: "2011-06"
 5177	spoiled small pulsating Spaghetti with Moonballs	2	crappy	Last Available: "2011-06"
 5178	normal Crepes a la Lune	3	good	Last Available: "2011-06"
@@ -5090,27 +5090,27 @@
 5187	jittery Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	triple-polymerized jittery honey stick	0		Effect: "Boilermade", Effect Duration: 21
 5189	unsweetened spinning double-ice gum	0		Effect: "Bilious Briskness", Effect Duration: 17, Last Available: "2011-04"
-5190	chilly sharpshooter's groovy Operation Patriot Shield	0		Moxie Percent: +10, Critical Hit Percent: +10, Cold Damage: +5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	chilly sharpshooter's groovy Operation Patriot Shield	0		Moxie Percent: +10, Critical Hit Percent: +10, Cold Damage: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	ionized non-concentrated upside-down corrupted data	0		Effect: "Items Are Forever", Effect Duration: 51, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
-5194	lime green ghostly exorcised sandwich	0		
+5194	ghostly lime green exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	jittery nippy Great S-Cape	0		Cold Damage: +10, Softcore Only, Last Available: "2011-07"
 5197	flame-wreathed Marvelous Unitard	0		Hot Spell Damage: +10, Softcore Only, Last Available: "2011-07"
 5198	dehydrated jittery gooey paste	1	awesome	Last Available: "2011-08"
 5199	modified purple beastly paste	1	decent	Last Available: "2011-08"
 5200	twisted shaking paste	1	crappy	Last Available: "2011-08"
-5201	compressed lime green pulsating shaking spinning ectoplasmic paste	1	good	Last Available: "2011-08"
+5201	compressed pulsating spinning lime green shaking ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	denatured pulsating greasy paste	1	decent	Last Available: "2011-08"
 5203	powdered shaking bug paste	1	decent	Effect: "Marinated", Effect Duration: 15, Last Available: "2011-08"
 5204	boiled huge hippy paste	1	good	Effect: "Sugar, Hello", Effect Duration: 45, Last Available: "2011-08"
 5205	dried red jittery orc paste	1	crappy	Last Available: "2011-08"
-5206	distilled cyan squat demonic paste	1	good	Effect: "Libra Rising", Effect Duration: 45, Last Available: "2011-08"
+5206	distilled squat cyan demonic paste	1	good	Effect: "Libra Rising", Effect Duration: 45, Last Available: "2011-08"
 5207	modified tumbling indescribably horrible paste	1	good	Last Available: "2011-08"
 5208	modified paste	1	awesome	Last Available: "2011-08"
 5209	twisted wobbly goblin paste	1	good	Last Available: "2011-08"
-5210	mixed huge spinning pirate paste	1	awesome	Last Available: "2011-08"
+5210	mixed spinning huge pirate paste	1	awesome	Last Available: "2011-08"
 5211	vaporized chlorophyll paste	1	crappy	Last Available: "2011-08"
 5212	compressed paste	1	good	Last Available: "2011-08"
 5213	compressed ghostly Mer-kin paste	1	crappy	Effect: "Billiards Belligerence", Effect Duration: 40, Last Available: "2011-08"
@@ -5123,12 +5123,12 @@
 5220	blinking Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	upside-down upside-down Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	moldy Ur-Donut	4	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	skewed box of Familiar Jacks	0		Last Available: "2011-09"
 5227	high-proof acceptable bucket of wine	9	good	Last Available: "2011-09"
-5228	snack-sized decent ultrafondue	2	good	Last Available: "2011-09"
+5228	decent snack-sized ultrafondue	2	good	Last Available: "2011-09"
 5229	upside-down unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5138,19 +5138,19 @@
 5235	wholesome furry halo	0		Maximum HP Percent: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	Socratic frosty halo	0		Experience (Mysticality): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	tumbling Usain Bolt's time halo	0		Initiative: +80, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	tolerable pulsating blurry Lumineux Limnio	4	good	Last Available: "2011-09"
+5238	tolerable blurry pulsating Lumineux Limnio	4	good	Last Available: "2011-09"
 5239	bad jittery Morto Moreto	3	decent	Last Available: "2011-09"
 5240	drinkable Temps Tempranillo	3	good	Last Available: "2011-09"
-5241	practically non-alcoholic special bad Bordeaux Marteaux	1	decent	Effect: "How to Scam Tourists", Effect Duration: 5, Last Available: "2011-09"
-5242	fortified bad jittery ghostly Fromage Pinotage	5	decent	Last Available: "2011-09"
-5243	mediocre fancy blue Beignet Milgranet	3	decent	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2011-09"
-5244	mediocre distilled Muschat	5	decent	Last Available: "2011-09"
+5241	practically non-alcoholic bad special Bordeaux Marteaux	1	decent	Effect: "How to Scam Tourists", Effect Duration: 5, Last Available: "2011-09"
+5242	bad fortified ghostly jittery Fromage Pinotage	5	decent	Last Available: "2011-09"
+5243	fancy mediocre blue Beignet Milgranet	3	decent	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2011-09"
+5244	distilled mediocre Muschat	5	decent	Last Available: "2011-09"
 5245	delicious blue cool jelly donut	4	awesome	Last Available: "2011-09"
 5246	decent shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	spoiled occult jelly donut	3	crappy	Last Available: "2011-09"
 5248	delicious thyme jelly donut	3	awesome	Last Available: "2011-09"
 5249	bland danish	3	decent	Last Available: "2011-09"
-5250	small bland smashed danish	2	decent	Last Available: "2011-09"
+5250	bland small smashed danish	2	decent	Last Available: "2011-09"
 5251	spoiled super-sized tumbling forbidden danish	5	crappy	Last Available: "2011-09"
 5252	tasty fuchsia cool cat claw	4	awesome	Last Available: "2011-09"
 5253	delicious small enchanted blunt cat claw	2	awesome	Effect: "Baconstoned", Effect Duration: 5, Last Available: "2011-09"
@@ -5158,11 +5158,11 @@
 5255	big bland cheezburger	5	decent	Last Available: "2011-09"
 5256	stale toasted brie	4	decent	Last Available: "2011-09"
 5257	moist skewed potion of the field gar	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 58, Last Available: "2011-09"
-5258	irradiated ionized purple tumbling too legit potion	0		Effect: "Can Has Cyborger", Effect Duration: 69, Last Available: "2011-09"
-5259	energized bouncing cyan Bright Water	0		Effect: "Elbow Sauce", Effect Duration: 49, Last Available: "2011-09"
+5258	irradiated ionized tumbling purple too legit potion	0		Effect: "Can Has Cyborger", Effect Duration: 69, Last Available: "2011-09"
+5259	energized cyan bouncing Bright Water	0		Effect: "Elbow Sauce", Effect Duration: 49, Last Available: "2011-09"
 5260	extra-dry cold-filtered water	0		Effect: "Surreally Buff", Effect Duration: 59, Last Available: "2011-09"
 5261	diffused wobbly wobbly graveyard snowglobe	0		Effect: "Nut-Rition", Effect Duration: 16, Last Available: "2011-09"
-5262	frozen polarized squat skewed cool cat elixir	0		Effect: "What's That Smell?", Effect Duration: 51, Last Available: "2011-09"
+5262	frozen polarized skewed squat cool cat elixir	0		Effect: "What's That Smell?", Effect Duration: 51, Last Available: "2011-09"
 5263	magnetized potion of the captain's hammer	0		Effect: "Swimming Head", Effect Duration: 42, Last Available: "2011-09"
 5264	vacuum-sealed potion of X-ray vision	0		Effect: "Aloofah", Effect Duration: 21, Last Available: "2011-09"
 5265	alkaline super-denatured spinning potion of the litterbox	0		Effect: "Liquidy Smoky", Effect Duration: 43, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of Leguizamo	0		Monster Level: +20, Last Available: "2011-09"
 5282	dethklok of incineration	0		Hot Spell Damage: +50, Last Available: "2011-09"
 5283	weightlifter's glacial clock	0		Muscle: +15, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	huge d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	wobbly d8	0		Last Available: "2011-09"
@@ -5199,8 +5199,8 @@
 5296	tumbling slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	enchanted flavorless phish stick	4	decent	Effect: "Net Tea", Effect Duration: 40, Last Available: "2011-09"
-5299	steel-toed grievous plastic vampire fangs of the empath	0		Weapon Damage Percent: +50, Damage Reduction: 9, Familiar Weight: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
-5300	blurry bouncing Interview With You (a Vampire)	0		Last Available: "2011-10"
+5299	steel-toed grievous plastic vampire fangs of the empath	0		Weapon Damage Percent: +50, Damage Reduction: 9, Familiar Weight: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5300	bouncing blurry Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	bouncing Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	squat your own heart	0		Last Available: "2011-10"
 5303	cool Sword of the Brouhaha Prince	0		Moxie: +5, Last Available: "2011-10"
@@ -5210,7 +5210,7 @@
 5307	mirror Haunted Sorority House staff guide	0		Last Available: "2011-10"
 5308	mirror ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
-5310	blurry blue shotgun shell	0		Last Available: "2011-10"
+5310	blue blurry shotgun shell	0		Last Available: "2011-10"
 5311	funhouse mirror	0		Last Available: "2011-10"
 5312	double-warmed jittery ghostly body paint	0		Effect: "Gummiheart", Effect Duration: 39, Last Available: "2011-10"
 5313	alkaline spinning narrow necrotizing body spray	0		Effect: "Rave Nirvana", Effect Duration: 64, Last Available: "2011-10"
@@ -5224,7 +5224,7 @@
 5321	double-modified dry Sweet Sword	0		Effect: "Make Meat FA$T!", Effect Duration: 35, Last Available: "2011-10"
 5322	artisanal huge Ecto-Cooler	4	EPIC	Last Available: "2011-10"
 5323	acceptable fancy teal tumbling Bartles and BRAAAINS wine cooler	3	good	Effect: "Deadly Lampblade", Effect Duration: 10, Last Available: "2011-10"
-5324	triple-distilled perfectly mixed Blood Light	10	EPIC	Last Available: "2011-10"
+5324	perfectly mixed triple-distilled Blood Light	10	EPIC	Last Available: "2011-10"
 5325	lousy practically non-alcoholic mirror Silver Bullet beer	1	decent	Last Available: "2011-10"
 5326	aged gray Bone's Farm &quot;wine&quot;	3	awesome	Last Available: "2011-10"
 5327	bouncing huge ghost protocol	0		Last Available: "2011-10"
@@ -5233,18 +5233,18 @@
 5330	moist drum of pomade	0		Effect: "Macho Profundo", Effect Duration: 66, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extra-see-thru nightie of horror	0		Spooky Spell Damage: +25, Last Available: "2011-10"
-5333	pulsating ghostly aromatic smooth BRAINS shorts	0		Moxie: +15, Stench Resistance: +1, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	pulsating ghostly aromatic smooth BRAINS shorts	0		Moxie: +15, Stench Resistance: +1, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	narrow wizardly Mesmereyes&trade; contact lenses	0		Mysticality: +25, Single Equip, Last Available: "2011-10"
 5335	strapping scrunchie	0		Muscle: +5, Single Equip, Last Available: "2011-10"
-5336	huge hardened brawny extremely skinny jeans	0		Muscle Percent: +20, Damage Reduction: 3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	avaricious razor-sharp The Necbromancer's Hat	0		Weapon Damage Percent: +25, Meat Drop: +30, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	huge hardened brawny extremely skinny jeans	0		Muscle Percent: +20, Damage Reduction: 3, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	avaricious razor-sharp The Necbromancer's Hat	0		Weapon Damage Percent: +25, Meat Drop: +30, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	Da Vinci's The Necbromancer's Stein of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Experience (Mysticality): +5, Last Available: "2011-10"
-5339	brainy The Necbromancer's Shorts of the bloodbag of chilblains	0		Mysticality: +5, Maximum HP: +100, Cold Damage: +25, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	brainy The Necbromancer's Shorts of the bloodbag of chilblains	0		Mysticality: +5, Maximum HP: +100, Cold Damage: +25, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	narrow pulsating Fonzie's The Necbromancer's Wizard Staff of wisdom of terror	0		Mysticality: +15, Experience (Moxie): +1, Spooky Spell Damage: +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	smooth The Cooler Out of Space	3	awesome	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5344	lime green pulsating sorority girl's box	0		Last Available: "2011-10"
+5344	pulsating lime green sorority girl's box	0		Last Available: "2011-10"
 5345	alkaline tarnished moist Necbro wafers	0		Effect: "Hyphemariffic", Effect Duration: 28, Last Available: "2020-09"
 5346	olive death blossom	0		
 5347	mirror A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
@@ -5289,7 +5289,7 @@
 5386	jittery chilly ridiculous belt	0		Cold Damage: +5, Last Available: "2011-11"
 5387	ridiculous earring of the detective	0		Item Drop: +20, Last Available: "2011-11"
 5388	ridiculous sunglasses of the cougar	0		Moxie: +20, Last Available: "2011-11"
-5389	decent diet ridiculous sandwich	1	good	Last Available: "2011-11"
+5389	diet decent ridiculous sandwich	1	good	Last Available: "2011-11"
 5390	perfectly mixed ridiculous cocktail	4	EPIC	Last Available: "2011-11"
 5391	cool zombie monkey necklace of the wise owl	0		Mysticality: +20, Moxie: +5
 5392	skewed Thwaitgold butterfly statuette	0		
@@ -5297,7 +5297,7 @@
 5394	bouncing sandpaper	0		
 5395	teal peppermint sprout	0		Last Available: "2011-11"
 5396	triple-oxidized pickled skewed peppermint twist	0		Effect: "Mo' Hobo", Effect Duration: 11, Last Available: "2011-11"
-5397	stale gigantic peppermint patty	10	decent	Last Available: "2011-11"
+5397	gigantic stale peppermint patty	10	decent	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5306,13 +5306,13 @@
 5403	wobbly bouncing Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	spinning Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	frightening stanky Samson's cane-mail shirt	0		Experience (Muscle): +5, Stench Spell Damage: +25, Spooky Damage: +5, Last Available: "2011-12"
-5406	gravedigger's cane-mail pants of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Item Drop: +5, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	gravedigger's cane-mail pants of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Item Drop: +5, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	artisanal Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
-5408	watered-down acceptable Gin Mint	2	good	Last Available: "2011-12"
-5409	practically non-alcoholic drinkable Tequiz Navidad	1	good	Last Available: "2011-12"
+5408	acceptable watered-down Gin Mint	2	good	Last Available: "2011-12"
+5409	drinkable practically non-alcoholic Tequiz Navidad	1	good	Last Available: "2011-12"
 5410	acceptable high-proof Mint Yulep	7	good	Last Available: "2011-12"
 5411	aged Crimbojito	4	awesome	Last Available: "2011-12"
-5412	practically non-alcoholic lousy Sangria de Menthe	1	decent	Last Available: "2011-12"
+5412	lousy practically non-alcoholic Sangria de Menthe	1	decent	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	magnetized wet nitrogenated blurry licorice root	0		Effect: "Disco Concentration", Effect Duration: 66, Last Available: "2011-12"
@@ -5327,20 +5327,20 @@
 5424	bouncing bouncing supercharged kumquartz ring	0		Maximum MP Percent: +30, Single Equip, Last Available: "2011-11"
 5425	teal electrified strawberyl necklace	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-11"
 5426	narrow miser's steel-toed sucker bucket	0		Damage Reduction: 9, Meat Drop: +10, Last Available: "2011-11"
-5427	sucker hakama of the cheetah	0		Initiative: +60, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	Sherlock's sucker kabuto	0		Item Drop: +25, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	sucker hakama of the cheetah	0		Initiative: +60, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	Sherlock's sucker kabuto	0		Item Drop: +25, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	lime green mirror Fonzie's sucker tachi	0		Experience (Moxie): +1, Last Available: "2011-11"
 5430	twirling sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
 5432	bouncing grape troll doll	0		Last Available: "2011-11"
-5433	spinning lime green raspberry troll doll	0		Last Available: "2011-11"
+5433	lime green spinning raspberry troll doll	0		Last Available: "2011-11"
 5434	DNOTC Box	0		Last Available: "2017-12"
 5435	spinning fudgecule	0		Last Available: "2011-11"
 5436	frozen nitrogenated shaking fudge lily	0		Effect: "Educated (Sorta)", Effect Duration: 51, Last Available: "2011-11"
 5437	bouncing superheated fudge	0		Last Available: "2011-11"
 5438	corrupted alkaline fluid of fudge-finding	0		Effect: "Liquidy Smoky", Effect Duration: 51, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	adequate half-sized green skewed fudgesicle	2	good	Last Available: "2011-11"
+5440	half-sized adequate green skewed fudgesicle	2	good	Last Available: "2011-11"
 5441	ghostly tumbling wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	twirling miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5358,14 +5358,14 @@
 5455	squat gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	galvanized Vulcanized Fudgie Roll	0		Effect: "Locks Like the Raven", Effect Duration: 50, Last Available: "2011-11"
-5458	adequate massive fancy squat fudge bunny	8	good	Effect: "Baconstoned", Effect Duration: 35, Last Available: "2011-11"
+5458	fancy adequate massive squat fudge bunny	8	good	Effect: "Baconstoned", Effect Duration: 35, Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	Jack Frost's friendly clever fudgecycle	0		Maximum MP: +20, Familiar Weight: +3, Cold Spell Damage: +50, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	polarized warmed green wobbly resolution: be wealthier	0		Effect: "Rushin' Hands", Effect Duration: 20, Last Available: "2012-01"
-5465	anodized wet green spinning resolution: be happier	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 25, Last Available: "2012-01"
+5465	anodized wet spinning green resolution: be happier	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 25, Last Available: "2012-01"
 5466	improved blinking resolution: be stronger	0		Effect: "Influence of Sphere", Effect Duration: 37, Last Available: "2012-01"
 5467	wet double-alkaline spinning resolution: be smarter	0		Effect: "Feet of Grapefruit", Effect Duration: 69, Last Available: "2012-01"
 5468	liquefied resolution: be sexier	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 34, Last Available: "2012-01"
@@ -5379,11 +5379,11 @@
 5476	dry gummi salamander	0		Effect: "Bananas!", Effect Duration: 51, Last Available: "2011-11"
 5477	pressed modified gummi snake	0		Effect: "The Style... of the Future", Effect Duration: 61, Last Available: "2011-11"
 5478	deionized unsweetened upside-down gummi canary	0		Effect: "Polar Express", Effect Duration: 55, Last Available: "2011-11"
-5479	tasty snack-sized olive bouncing gummi bear	2	awesome	Last Available: "2011-11"
+5479	tasty snack-sized bouncing olive gummi bear	2	awesome	Last Available: "2011-11"
 5480	moldy gummi bear	3	crappy	Last Available: "2011-11"
 5481	stale pulsating gummi bear	3	decent	Last Available: "2011-11"
 5482	normal lime green drunki-bear	4	good	Last Available: "2011-11"
-5483	normal small drunki-bear	2	good	Last Available: "2011-11"
+5483	small normal drunki-bear	2	good	Last Available: "2011-11"
 5484	yummy drunki-bear	3	awesome	Last Available: "2011-11"
 5485	gummi bowtie of the sewer	0		Stench Damage: +25, Last Available: "2011-11"
 5486	educational fudge pocket square	0		Experience: +1, Last Available: "2011-11"
@@ -5393,15 +5393,15 @@
 5490	gray belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
 5492	blinking ammonite candy mold	0		Last Available: "2011-11"
-5493	shaking purple belemnite candy mold	0		Last Available: "2011-11"
+5493	purple shaking belemnite candy mold	0		Last Available: "2011-11"
 5494	flattened liquefied mirror gummi trilobite	0		Effect: "Powder Power", Effect Duration: 34, Last Available: "2011-11"
 5495	improved liquefied blue gummi ammonite	0		Effect: "Tingly Biceps", Effect Duration: 59, Last Available: "2011-11"
 5496	quadruple-concentrated irradiated cyan gummi belemnite	0		Effect: "Patent Avarice", Effect Duration: 24, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	spinning studded experienced Big Candy's tophat	0		Experience: +2, Damage Absorption: +80, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	spinning studded experienced Big Candy's tophat	0		Experience: +2, Damage Absorption: +80, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
-5501	lime green twirling Jackass Plumber home game	0		Last Available: "2011-11"
+5501	twirling lime green Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	fuchsia Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	jittery blessed box	0		
@@ -5428,8 +5428,8 @@
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	activated huge Atomic Pop	0		Effect: "Stick Emporium Membership", Effect Duration: 14, Last Available: "2020-09"
 5527	bouncing do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
-5528	jittery cyan whimpering willow bark	0		Last Available: "2012-12"
-5529	adequate tiny berries of suffering	1	good	Last Available: "2012-12"
+5528	cyan jittery whimpering willow bark	0		Last Available: "2012-12"
+5529	tiny adequate berries of suffering	1	good	Last Available: "2012-12"
 5530	super-pressed modified ionized baobab sap	0		Effect: "Salsa Satanica", Effect Duration: 22, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	wobbly magnolia blossom	0		Last Available: "2012-12"
@@ -5459,15 +5459,15 @@
 5556	lightning-fast boxer's Rain-Doh wings	0		Muscle Percent: +10, Initiative: +40, Softcore Only, Last Available: "2012-02"
 5557	blurry Rain-Doh agent	0		Last Available: "2012-02"
 5558	studded sinister Rain-Doh laser gun	0		Spell Damage: +10, Damage Absorption: +80, Softcore Only, Last Available: "2012-02"
-5559	scorching Rain-Doh lantern of the empath	0		Familiar Weight: +5, Hot Damage: +25, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	scorching Rain-Doh lantern of the empath	0		Familiar Weight: +5, Hot Damage: +25, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	nasty Da Vinci's Rain-Doh violet bo	0		Experience (Mysticality): +5, Stench Damage: +5, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	jumbo decent PB&BP	5	good	
-5566	bite-sized bland upside-down club sandwich	1	decent	
-5567	big bland corned-beef Reuben	5	decent	
+5565	decent jumbo PB&BP	5	good	
+5566	bland bite-sized upside-down club sandwich	1	decent	
+5567	bland big corned-beef Reuben	5	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
@@ -5476,16 +5476,16 @@
 5573	drinkable Drac & Tan	4	good	Last Available: "2012-03"
 5574	tolerable practically non-alcoholic Transylvania Sling	1	good	Last Available: "2012-03"
 5575	practically non-alcoholic acceptable skewed Shot of the Living Dead	1	good	Last Available: "2012-03"
-5576	tolerable red mirror Buttery Knob	4	good	Last Available: "2012-03"
-5577	perfectly mixed practically non-alcoholic shaking Slippery Knob	1	EPIC	Last Available: "2012-03"
-5578	lousy practically non-alcoholic Flaming Knob	1	decent	Last Available: "2012-03"
+5576	tolerable mirror red Buttery Knob	4	good	Last Available: "2012-03"
+5577	practically non-alcoholic perfectly mixed shaking Slippery Knob	1	EPIC	Last Available: "2012-03"
+5578	practically non-alcoholic lousy Flaming Knob	1	decent	Last Available: "2012-03"
 5579	weak delicious Grasshopper	2	awesome	Last Available: "2012-03"
 5580	lousy Locust	4	decent	Last Available: "2012-03"
-5581	enchanted lousy Plague of Locusts	3	decent	Effect: "Black Lung", Effect Duration: 20, Last Available: "2012-03"
+5581	lousy enchanted Plague of Locusts	3	decent	Effect: "Black Lung", Effect Duration: 20, Last Available: "2012-03"
 5582	drinkable Red Dwarf	4	good	Last Available: "2012-03"
 5583	watered-down acceptable Golden Mean	2	good	Last Available: "2012-03"
 5584	extra-dry smooth Green Giant	5	awesome	Last Available: "2012-03"
-5585	weak acceptable Aye Aye	2	good	Last Available: "2012-03"
+5585	acceptable weak Aye Aye	2	good	Last Available: "2012-03"
 5586	tolerable Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	mediocre Aye Aye, Tooth Tooth	3	decent	Last Available: "2012-03"
 5588	tolerable twirling Humanitini	4	good	Last Available: "2012-03"
@@ -5493,15 +5493,15 @@
 5590	acceptable Oh, the Humanitini	4	good	Last Available: "2012-03"
 5591	acceptable Great Older Fashioned	4	good	Last Available: "2012-03"
 5592	bad weak pulsating Fuzzy Tentacle	2	decent	Last Available: "2012-03"
-5593	watered-down tolerable Crazymaker	2	good	Last Available: "2012-03"
+5593	tolerable watered-down Crazymaker	2	good	Last Available: "2012-03"
 5594	hand-crafted Zoodriver	3	EPIC	Last Available: "2012-03"
 5595	tolerable huge Sloe Comfortable Zoo	4	good	Last Available: "2012-03"
 5596	smooth Sloe Comfortable Zoo on Fire	3	awesome	Last Available: "2012-03"
 5597	artisanal irresponsibly strong Suffering Sinner	10	EPIC	Last Available: "2012-03"
 5598	lousy huge Suppurating Sinner	4	decent	Last Available: "2012-03"
-5599	special hand-crafted distilled wobbly Sizzling Sinner	5	EPIC	Effect: "Scorpio Rising", Effect Duration: 25, Last Available: "2012-03"
+5599	hand-crafted distilled special wobbly Sizzling Sinner	5	EPIC	Effect: "Scorpio Rising", Effect Duration: 25, Last Available: "2012-03"
 5600	mediocre Firewater	3	decent	Last Available: "2012-03"
-5601	enchanted tolerable practically non-alcoholic Earth and Firewater	1	good	Effect: "Action", Effect Duration: 20, Last Available: "2012-03"
+5601	tolerable enchanted practically non-alcoholic Earth and Firewater	1	good	Effect: "Action", Effect Duration: 20, Last Available: "2012-03"
 5602	perfectly mixed Earth, Wind and Firewater	4	EPIC	Last Available: "2012-03"
 5603	weak drinkable Slimosa	2	good	Last Available: "2012-03"
 5604	hand-crafted watered-down shaking Extra-slimy Slimosa	2	EPIC	Last Available: "2012-03"
@@ -5511,46 +5511,46 @@
 5608	smooth Dump Truck	4	awesome	Last Available: "2012-03"
 5609	hand-crafted Fauna Libre	3	EPIC	Last Available: "2012-03"
 5610	practically non-alcoholic fancy artisanal twirling Chakra Libre	1	EPIC	Effect: "Weasels Underfoot", Effect Duration: 35, Last Available: "2012-03"
-5611	triple-distilled special hand-crafted spinning Aura Libre	10	EPIC	Effect: "Human-Demon Hybrid", Effect Duration: 15, Last Available: "2012-03"
+5611	triple-distilled hand-crafted special spinning Aura Libre	10	EPIC	Effect: "Human-Demon Hybrid", Effect Duration: 15, Last Available: "2012-03"
 5612	drinkable Sazerorc	4	good	Last Available: "2012-03"
-5613	strong tolerable Sazuruk-hai	5	good	Last Available: "2012-03"
+5613	tolerable strong Sazuruk-hai	5	good	Last Available: "2012-03"
 5614	mediocre wobbly Flaming Sazerorc	3	decent	Last Available: "2012-03"
 5615	perfectly mixed Green Velvet	3	EPIC	Last Available: "2012-03"
 5616	delicious wobbly Green Muslin	4	awesome	Last Available: "2012-03"
 5617	mediocre skewed Green Burlap	4	decent	Last Available: "2012-03"
-5618	acceptable irresponsibly strong Mohobo	6	good	Last Available: "2012-03"
-5619	enchanted drinkable Moonshine Mohobo	4	good	Effect: "Hyphemariffic", Effect Duration: 45, Last Available: "2012-03"
-5620	weak lousy Flaming Mohobo	2	decent	Last Available: "2012-03"
-5621	bad practically non-alcoholic fancy Drunken Philosopher	1	decent	Effect: "Partially Ghosted", Effect Duration: 10, Last Available: "2012-03"
+5618	irresponsibly strong acceptable Mohobo	6	good	Last Available: "2012-03"
+5619	drinkable enchanted Moonshine Mohobo	4	good	Effect: "Hyphemariffic", Effect Duration: 45, Last Available: "2012-03"
+5620	lousy weak Flaming Mohobo	2	decent	Last Available: "2012-03"
+5621	practically non-alcoholic bad fancy Drunken Philosopher	1	decent	Effect: "Partially Ghosted", Effect Duration: 10, Last Available: "2012-03"
 5622	aged Drunken Neurologist	4	awesome	Last Available: "2012-03"
 5623	practically non-alcoholic lousy Drunken Astrophysicist	1	decent	Last Available: "2012-03"
 5624	fancy drinkable skewed Dark & Starry	3	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 45, Last Available: "2012-03"
 5625	artisanal skewed Black Hole	3	EPIC	Last Available: "2012-03"
-5626	hand-crafted watered-down Event Horizon	2	EPIC	Last Available: "2012-03"
-5627	acceptable watered-down cyan Herring Daiquiri	2	good	Last Available: "2012-03"
+5626	watered-down hand-crafted Event Horizon	2	EPIC	Last Available: "2012-03"
+5627	watered-down acceptable cyan Herring Daiquiri	2	good	Last Available: "2012-03"
 5628	irresponsibly strong hand-crafted red Herring Wallbanger	8	EPIC	Last Available: "2012-03"
 5629	aged Herringtini	3	awesome	Last Available: "2012-03"
-5630	mediocre lime green blurry Lollipop Drop	3	decent	Last Available: "2012-03"
+5630	mediocre blurry lime green Lollipop Drop	3	decent	Last Available: "2012-03"
 5631	watered-down artisanal squat Candy Alexander	2	EPIC	Last Available: "2012-03"
 5632	weak acceptable blue Candicaine	2	good	Last Available: "2012-03"
-5633	spirit-forward acceptable Caipiranha	5	good	Last Available: "2012-03"
+5633	acceptable spirit-forward Caipiranha	5	good	Last Available: "2012-03"
 5634	hand-crafted weak blinking blurry Flying Caipiranha	2	EPIC	Last Available: "2012-03"
 5635	watered-down lousy Flaming Caipiranha	2	decent	Last Available: "2012-03"
 5636	hand-crafted Punchplanter	4	EPIC	Last Available: "2012-03"
 5637	artisanal Doublepunchplanter	4	EPIC	Last Available: "2012-03"
-5638	practically non-alcoholic artisanal Haymaker	1	super ultra EPIC	Last Available: "2012-03"
+5638	artisanal practically non-alcoholic Haymaker	1	super ultra EPIC	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	purple crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	decent special massive fungus	10	good	Effect: "Ooh, Sour!", Effect Duration: 15
+5641	massive special decent fungus	10	good	Effect: "Ooh, Sour!", Effect Duration: 15
 5642	skewed poisoned dart	0		
 5643	extra-polymerized fuchsia stone wool	0		Effect: "Very Clean Guns", Effect Duration: 47
 5644	shaking stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	narrow calendar of the empath	0		Familiar Weight: +5, Damage Reduction: 4
-5648	chaotic baleful Boris's Helm	0		Spell Damage: +25, Spell Critical Percent: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	chaotic baleful Boris's Helm	0		Spell Damage: +25, Spell Critical Percent: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	nasty occult staph of homophones	0		Spell Damage Percent: +25, Stench Damage: +5
-5650	lion tamer's razor-sharp Boris's Helm (askew) of Gandalf	0		Weapon Damage Percent: +25, Spell Critical Percent: +20, Experience (familiar): +2, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	lion tamer's razor-sharp Boris's Helm (askew) of Gandalf	0		Weapon Damage Percent: +25, Spell Critical Percent: +20, Experience (familiar): +2, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	gray mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	tumbling key-o-tron	0		
@@ -5570,18 +5570,18 @@
 5667	puppet strings	0		Free Pull
 5668	wobbly bagged &quot;L&quot;	0		
 5669	club	0		
-5670	decent snack-sized fettucini &eacute;pines Inconnu	2	good	
+5670	snack-sized decent fettucini &eacute;pines Inconnu	2	good	
 5671	acceptable slap and slap again	4	good	
 5672	yellow gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	vaporized wobbly watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	hale Ze&trade; goggles	0		Maximum HP: +20, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	hale Ze&trade; goggles	0		Maximum HP: +20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	wobbly bouncing stanky stylish swimsuit of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	wobbly bouncing stanky stylish swimsuit of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	yellow lost key	0		Last Available: "2012-05"
-5681	adequate massive P.B.L.T.	8	good	
+5681	massive adequate P.B.L.T.	8	good	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	shaking handful of juicy garbage	0		
@@ -5605,27 +5605,27 @@
 5702	blinking spinning mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	huge wax bugbear	0		Last Available: "2012-06"
-5705	Socratic smooth wax hat	0		Moxie: +15, Experience (Mysticality): +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	wobbly groovy wax pants of the scaredy-cat	0		Moxie Percent: +10, Monster Level: -15, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	Socratic smooth wax hat	0		Moxie: +15, Experience (Mysticality): +1, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	wobbly groovy wax pants of the scaredy-cat	0		Moxie Percent: +10, Monster Level: -15, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
-5708	oxidized tumbling olive drop of water-37	0		Effect: "Well Owl Be!", Effect Duration: 26, Last Available: "2012-07"
-5709	ghostly fireman's helmet of the storm of terror	0		Maximum MP Percent: +40, Spooky Spell Damage: +10, Familiar Effect: "cold atk", Last Available: "2012-07"
+5708	oxidized olive tumbling drop of water-37	0		Effect: "Well Owl Be!", Effect Duration: 26, Last Available: "2012-07"
+5709	ghostly fireman's helmet of the storm of terror	0		Maximum MP Percent: +40, Spooky Spell Damage: +10, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	clever fire axe	0		Maximum MP: +20, Last Available: "2012-07"
 5713	perfumed vibrating fire extinguisher of the businessman	0		Maximum MP Percent: +10, Stench Resistance: +5, Meat Drop: +50, Last Available: "2012-07"
 5714	lime green FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5716	bouncing spinning Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
+5716	spinning bouncing Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	adequate FDKOL hotcakes	3	good	Last Available: "2012-07"
 5718	ghostly hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	jumbo adequate fiery wing	5	good	Last Available: "2012-07"
+5720	adequate jumbo fiery wing	5	good	Last Available: "2012-07"
 5721	careful wings of fire of the detective	0		Monster Level: -10, Item Drop: +20, Last Available: "2012-07"
 5722	twirling olive tumbling personal trainer's FDKOL fire hose	0		Experience Percent (Muscle): +10, Last Available: "2012-07"
 5723	aerosolized bouncing bottle of fire	0		Effect: "Polka of Plenty", Effect Duration: 43, Last Available: "2012-07"
 5724	narrow blurry molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	manspreader's chaotic hot daub bun	0		Spell Critical Percent: +10, Monster Level: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	hale brainy hot daub stand	0		Mysticality: +5, Maximum HP: +20, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	manspreader's chaotic hot daub bun	0		Spell Critical Percent: +10, Monster Level: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	hale brainy hot daub stand	0		Mysticality: +5, Maximum HP: +20, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	veiny padded foot-long hot daub	0		Damage Absorption: +20, Maximum HP: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	rotten tiny angst burger	1	crappy	
@@ -5633,7 +5633,7 @@
 5732	wobbly blank note	0		
 5733	eerily silent box	0		
 5734	flavorless forbidden sausage	3	decent	
-5735	Jeselnik's Lord Flameface's cloak	0		Sleaze Damage: +25, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Jeselnik's Lord Flameface's cloak	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	vacuum-sealed energized Drizzlers&trade; Black Licorice	0		Effect: "Well-Swabbed Ear", Effect Duration: 11
 5737	colloidal galvanized pulsating daub-breaker	0		Effect: "Arresistible", Effect Duration: 31, Last Available: "2020-09"
 5738	chilly Camp Scout backpack	0		Cold Damage: +5, Softcore Only, Last Available: "2012-07"
@@ -5642,7 +5642,7 @@
 5741	lousy practically non-alcoholic water purification pills	1	decent	Last Available: "2012-07"
 5742	bouncing Camp Scout pup tent	0		Last Available: "2012-07"
 5743	mediocre CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
-5744	enchanted moldy jumbo blue bag of GORF	5	crappy	Effect: "Lit Up", Effect Duration: 25, Last Available: "2012-07"
+5744	jumbo moldy enchanted blue bag of GORF	5	crappy	Effect: "Lit Up", Effect Duration: 25, Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	huge bland bag of QWOP	7	decent	Last Available: "2012-07"
 5747	pressed concentrated blinking CSA bravery badge	0		Effect: "Very Clean Guns", Effect Duration: 56, Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	thick rotten decent brain	5	crappy	
 5754	yummy good brain	3	awesome	
 5755	rotten boss brain	4	crappy	
-5756	spoiled enchanted huge hunter brain	8	crappy	Effect: "Standard Cheer", Effect Duration: 20
+5756	enchanted spoiled huge hunter brain	8	crappy	Effect: "Standard Cheer", Effect Duration: 20
 5758	aromatic Herculean Staff of Holiday Sensations of the ox	0		Muscle: +20, Experience (Muscle): +1, Stench Resistance: +1, Last Available: "2011-11"
 5759	staff of the sweet-tooth of the glutton	0		Candy Drop: +100, Food Drop: +100
 5760	wool deadly Da Vinci's staff	0		Experience (Mysticality): +5, Weapon Damage: +5, Cold Resistance: +1
@@ -5665,16 +5665,16 @@
 5765	Jim Carey's Herculean fuzzy earmuffs	0		Experience (Muscle): +1, Monster Level: +25, Familiar Effect: "1.5xVolley, cap 32"
 5766	Sherlock's brawny fuzzy montera of the overflowing toilet	0		Muscle Percent: +20, Stench Spell Damage: +50, Item Drop: +25, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	squat gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	squat gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	pulsating talkative skull	0		
 5775	teal fronts	0		Familiar Weight: +5
 5776	yellow huge perfumed smelly Barney's rake	0		Stench Spell Damage: +10, Stench Resistance: +5
-5778	snack-sized bland idiot brain	2	decent	
+5778	bland snack-sized idiot brain	2	decent	
 5779	lard-coated keel-haulin' knife	0		Sleaze Spell Damage: +25
 5780	personal trainer's ice cream scoop	0		Experience Percent (Muscle): +10
 5781	perfectly mixed blinking soft echo eyedrop antidote martini	4	EPIC	
@@ -5687,8 +5687,8 @@
 5788	bouncing smut orc keepsake box	0		
 5789	narrow bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	skewed ruddy stylish right bear arm	0		Moxie: +25, Maximum HP Percent: +40, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	rosy-cheeked strapping left bear arm of Gandalf	0		Muscle: +5, Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	skewed ruddy stylish right bear arm	0		Moxie: +25, Maximum HP Percent: +40, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	rosy-cheeked strapping left bear arm of Gandalf	0		Muscle: +5, Maximum HP Percent: +30, Spell Critical Percent: +20, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	ghostly ghostly flame-retardant Hat O' Nine Tails	0		Hot Resistance: +1
 5794	polarized ghostly Enchanted Plunger	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 42
 5795	extra-ionized concentrated narrow Enchanted Flyswatter	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 25
@@ -5697,13 +5697,13 @@
 5798	aerosolized Gnollish Crossdress	0		Effect: "The Dinsey Spirit", Effect Duration: 40
 5799	dry boiled eldritch dough	0		Effect: "Tiki Temerity", Effect Duration: 60
 5800	warmed Charity's choker	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 37
-5801	altered galvanized shaking wobbly Smart Bone Dust	0		Effect: "Stinky Weapon", Effect Duration: 48
+5801	altered galvanized wobbly shaking Smart Bone Dust	0		Effect: "Stinky Weapon", Effect Duration: 48
 5802	denatured dry perpendicular guano	0		Effect: "Faboooo", Effect Duration: 42
 5803	dry wobbly White Chocolate Golem Seeds	0		Effect: "Hot Hands", Effect Duration: 29
 5804	irradiated vacuum-sealed Shivering Ch&egrave;vre	0		Effect: "Pockets of Fire", Effect Duration: 26
 5805	quadruple-ionized mirror breath mint	0		Effect: "Old Time Hydration", Effect Duration: 12
 5806	modified electrified purple muesli	0		Effect: "Ghostly Shell", Effect Duration: 63
-5807	oxidized galvanized mirror maroon glass of warm milk	0		Effect: "Space Cadet", Effect Duration: 21
+5807	oxidized galvanized maroon mirror glass of warm milk	0		Effect: "Space Cadet", Effect Duration: 21
 5808	wet adjusted green glass of gnat milk	0		Effect: "Morbidi Tea", Effect Duration: 58
 5809	moist Knob Goblin Mutagen	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14
 5810	warmed blinking Tears of the Quiet Healer	0		Effect: "Dirty Pear", Effect Duration: 55
@@ -5720,10 +5720,10 @@
 5821	polarized quadruple-polarized blue frog lip-print	0		Effect: "Chalked Weapon", Effect Duration: 66
 5822	moist cold-filtered gazely stare	0		Effect: "Savage Beast Inside", Effect Duration: 68
 5823	deionized super-polarized canopic jar	0		Effect: "Arse-a'fire", Effect Duration: 31
-5824	galvanized improved gray squat clove-flavored lip balm	0		Effect: "Arse-a'fire", Effect Duration: 14
+5824	galvanized improved squat gray clove-flavored lip balm	0		Effect: "Arse-a'fire", Effect Duration: 14
 5825	vacuum-sealed Skullery Maid's Knee	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 22
 5826	pickled wobbly zombie hollandaise	0		Effect: "Polka of Plenty", Effect Duration: 27
-5827	frozen super-liquefied liquefied wobbly blue skeletal banana	0		Effect: "Good with the Ladies", Effect Duration: 68
+5827	frozen super-liquefied liquefied blue wobbly skeletal banana	0		Effect: "Good with the Ladies", Effect Duration: 68
 5828	oxidized gilt perfume bottle	0		Effect: "Insatiable Hunger", Effect Duration: 25
 5829	vacuum-sealed energized janglin' bones	0		Effect: "Glo-Face", Effect Duration: 47
 5830	wet wet green pygmy papers	0		Effect: "Broken Fast", Effect Duration: 50
@@ -5750,15 +5750,15 @@
 5851	oxidized aerosolized denatured pulsating temporary tribal tattoo	0		Effect: "Slightly Larger Than Usual", Effect Duration: 14
 5852	cold-filtered moist oil-filled donut	0		Effect: "Disco Nirvana", Effect Duration: 17
 5853	oxidized super-modified stick-on gnome beard	0		Effect: "Corruption of Wretched Wally", Effect Duration: 32
-5854	nitrogenated pickled fuchsia narrow huge BRICKO stud	0		Effect: "Sweetened and Fattened", Effect Duration: 27
+5854	nitrogenated pickled narrow huge fuchsia BRICKO stud	0		Effect: "Sweetened and Fattened", Effect Duration: 27
 5855	enhanced Osk'r Chow	0		Effect: "Wit Tea", Effect Duration: 22
 5856	super-frozen polarized mirror Scuba Snack	0		Effect: "Cancer Rising", Effect Duration: 28
 5857	denatured aerosolized narrow grey cube	0		Effect: "Punchy, Murdery", Effect Duration: 65
 5858	tarnished vacuum-sealed shaking votive candle	0		Effect: "Cold Hard Skin", Effect Duration: 11
-5859	Vulcanized twirling narrow twirling booby trap	0		Effect: "Fiery Spirit", Effect Duration: 20
+5859	Vulcanized twirling twirling narrow booby trap	0		Effect: "Fiery Spirit", Effect Duration: 20
 5860	energized yellow Agent Corrigan's cigarette	0		Effect: "Helvella Health", Effect Duration: 52
-5861	dry chilled wobbly ghostly good ash	0		Effect: "Oxygenated Blood", Effect Duration: 47
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5861	dry chilled ghostly wobbly good ash	0		Effect: "Oxygenated Blood", Effect Duration: 47
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	squat papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	polarized spinning papier-mochi	0		Effect: "Salt Rockin'", Effect Duration: 16, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	Jeselnik's Oprah's papier-m&acirc;ch&eacute;te	0		Maximum MP Percent: +50, Sleaze Damage: +25, Last Available: "2012-09"
 5869	sharpshooter's papier-m&acirc;chine gun of chilblains	0		Critical Hit Percent: +10, Cold Damage: +25, Last Available: "2012-09"
 5870	yellow arcane researcher's Socratic papier-masque	0		Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Single Equip, Last Available: "2012-09"
-5871	skewed frosty papier-mitre of the sewer	0		Cold Spell Damage: +10, Stench Damage: +25, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	papier-m&acirc;churidars of the blizzard of the overflowing toilet	0		Cold Spell Damage: +25, Stench Spell Damage: +50, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	skewed frosty papier-mitre of the sewer	0		Cold Spell Damage: +10, Stench Damage: +25, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	papier-m&acirc;churidars of the blizzard of the overflowing toilet	0		Cold Spell Damage: +25, Stench Spell Damage: +50, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	blurry packet of dragon's teeth	0		Last Available: "2012-10"
 5881	mirror skeleton	0		Last Available: "2012-10"
 5882	mansplainer's Rosewater's skeleton skis of the cheetah	0		Mysticality Percent: +30, Monster Level: +15, Initiative: +60, Single Equip, Last Available: "2012-10"
-5883	half-sized moldy skeleton quiche	2	crappy	Last Available: "2012-10"
+5883	moldy half-sized skeleton quiche	2	crappy	Last Available: "2012-10"
 5884	shaking skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	mirror up-at-dawn auspicious rosy-cheeked Bonestabber of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Item Drop: +10, Adventures: +5, Last Available: "2012-10"
@@ -5795,7 +5795,7 @@
 5896	canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	denatured blinking Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	pulsating jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
-5899	blurry tumbling gray jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
+5899	gray blurry tumbling jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	gray jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
@@ -5818,13 +5818,13 @@
 5920	razor-sharp plastic taco-clad Crimbo elf	0		Weapon Damage Percent: +25, Last Available: "2012-12"
 5921	Sherlock's plastic Uncle Crimboku	0		Item Drop: +25, Last Available: "2012-12"
 5922	executive plastic MechaElf	0		Meat Drop: +40, Last Available: "2012-12"
-5923	blurry shaking plastic ingot	0		Last Available: "2012-12"
+5923	shaking blurry plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
 5925	narrow ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	tumbling blinking BittyCar MeatCar	0		Last Available: "2012-12"
-5927	jittery blinking BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
-5929	tumbling yellow bubble-wrap simulator	0		Last Available: "2012-12"
+5927	blinking jittery BittyCar HotCar	0		Last Available: "2012-12"
+5928	brainwave-controlled unicorn horn of horror	0		Spooky Spell Damage: +25, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5929	yellow tumbling bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	Annie Oakley's Sinatra's plastic four-shadowed mime of the blizzard	0		Experience (Moxie): +5, Critical Hit Percent: +20, Cold Spell Damage: +25, Single Equip, Last Available: "2012-12"
 5932	flame-retardant lion tamer's plastic Bugbear Captain	0		Experience (familiar): +2, Hot Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	bouncing flame-retardant plastic Father McGruber	0		Hot Resistance: +1, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of chilblains	0		Cold Damage: +25, Last Available: "2012-12"
 5962	shaking plastic blazing bat of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2012-12"
-5963	electronic dulcimer pants of the businessman of the early riser	0		Meat Drop: +50, Adventures: +7, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	electronic dulcimer pants of the businessman of the early riser	0		Meat Drop: +50, Adventures: +7, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	tumbling greedy rosewater-soaked Frown Exerciser	0		Stench Resistance: +3, Meat Drop: +20, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5877,9 +5877,9 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	teal cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	artisanal weak tankard of ale	2	EPIC	Last Available: "2013-02"
+5982	weak artisanal tankard of ale	2	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	skewed censurious lard-coated quilted cloth cap	0		Damage Absorption: +40, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	skewed censurious lard-coated quilted cloth cap	0		Damage Absorption: +40, Sleaze Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	toasty Newton's iron dagger of Leguizamo	0		Experience (Mysticality): +3, Monster Level: +20, Hot Damage: +5, Last Available: "2013-02"
 5986	spoiled fancy ghostly hamburger	4	crappy	Effect: "Phairly Balanced", Effect Duration: 20, Last Available: "2013-02"
 5987	wobbly dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	potion	0		Last Available: "2013-02"
 5990	tolerable bottle of wine	3	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	nasty wicked thinker's iron helmet	0		Mysticality: +10, Spell Damage: +5, Stench Damage: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	nasty wicked thinker's iron helmet	0		Mysticality: +10, Spell Damage: +5, Stench Damage: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	tumbling maroon censurious quilted extremely unsafe steel sword	0		Weapon Damage Percent: +100, Damage Absorption: +40, Sleaze Resistance: +3, Last Available: "2013-02"
-5994	moldy small whole roasted chicken	2	crappy	Last Available: "2013-02"
+5994	small moldy whole roasted chicken	2	crappy	Last Available: "2013-02"
 5995	squat massive gemstone	0		Last Available: "2013-02"
 5996	mirror extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	acceptable weak shining goblet	2	good	Last Available: "2013-02"
+5998	weak acceptable shining goblet	2	good	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	green nippy rosy-cheeked slick crown	0		Moxie: +10, Maximum HP Percent: +30, Cold Damage: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	green nippy rosy-cheeked slick crown	0		Moxie: +10, Maximum HP Percent: +30, Cold Damage: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	hardy studded educational sword	0		Experience: +1, Damage Absorption: +80, Maximum HP: +50, Last Available: "2013-02"
-6002	toasty medical-grade deadly Helm of the Scream Emperor	0		Weapon Damage: +5, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	toasty medical-grade deadly Helm of the Scream Emperor	0		Weapon Damage: +5, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	flame-retardant frightening Cloak of Dire Shadows of the storm	0		Maximum MP Percent: +40, Spooky Damage: +5, Hot Resistance: +1, Last Available: "2013-02"
 6004	Jack Frost's extremely unsafe Herculean Sword of Dark Omens	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Cold Spell Damage: +50, Last Available: "2013-02"
 6005	Sherlock's Temple Grandin's wholesome Shield of Icy Fate	0		Maximum HP Percent: +10, Familiar Weight: +7, Item Drop: +25, Damage Reduction: 7, Last Available: "2013-02"
-6006	purple censurious dance instructor's brainy Greaves of the Murk Lord	0		Mysticality: +5, Experience Percent (Moxie): +10, Sleaze Resistance: +3, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	purple censurious dance instructor's brainy Greaves of the Murk Lord	0		Mysticality: +5, Experience Percent (Moxie): +10, Sleaze Resistance: +3, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	miser's Fonzie's Gauntlets of the Blood Moon of doom	0		Experience (Moxie): +1, Spooky Spell Damage: +50, Meat Drop: +10, Single Equip, Last Available: "2013-02"
 6008	MacGyver's strapping Boots of Twilight Whispers of chilblains	0		Muscle: +5, Maximum MP: +100, Cold Damage: +25, Single Equip, Last Available: "2013-02"
 6009	knitted Van der Graaf clever Belt of Howling Anger	0		Maximum MP: +20, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-02"
@@ -5931,7 +5931,7 @@
 6033	skewed experienced stolen necklace of James Dean	0		Experience: +2, Experience (Moxie): +3
 6034	mansplainer's chaotic troll britches	0		Spell Critical Percent: +10, Monster Level: +15, Familiar Effect: "1.5xPotato, cap 28"
 6035	wet nitrogenated dry shaking vial of The Glistening	0		Effect: "Human-Hippy Hybrid", Effect Duration: 24
-6036	hand-crafted practically non-alcoholic enchanted upside-down artisanal limoncello	1	EPIC	Effect: "Stopping to Smell the Flowers", Effect Duration: 35
+6036	practically non-alcoholic enchanted hand-crafted upside-down artisanal limoncello	1	EPIC	Effect: "Stopping to Smell the Flowers", Effect Duration: 35
 6037	tumbling tumbling ginger ale	0		
 6038	adequate incredible pizza	3	good	
 6039	miser's oil cap of the brazier	0		Hot Spell Damage: +25, Meat Drop: +10, Familiar Effect: "cap 28"
@@ -5951,7 +5951,7 @@
 6053	artisanal spinning Taco Dan's Taco Stand Chimichangarita	4	EPIC	Last Available: "2012-12"
 6054	chilled frozen Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Jawin'", Effect Duration: 50, Last Available: "2012-12"
 6055	wobbly psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	olive forbidden Meatcleaver of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Last Available: "2013-12"
 6058	pulsating toasty Crimbo Elf bobble-head	0		Hot Damage: +5, Last Available: "2012-12"
 6059	grievous Crimbo stogie-scented room odorizer	0		Weapon Damage Percent: +50, Last Available: "2012-12"
@@ -5966,17 +5966,17 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	cyan Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
-6072	mirror upside-down confusing LED clock	0		Last Available: "2012-12"
+6071	cyan Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6072	upside-down mirror confusing LED clock	0		Last Available: "2012-12"
 6073	liquefied aerosolized haggis-infused soap	0		Effect: "Hyphemariffic", Effect Duration: 66, Last Available: "2012-12"
 6074	non-galvanized magicberry tablets	0		Effect: "A Contender", Effect Duration: 38, Last Available: "2012-12"
-6075	diffused upside-down bouncing tumbling 37x37x37 puzzle cube	0		Effect: "Top Dog", Effect Duration: 53, Last Available: "2012-12"
+6075	diffused upside-down tumbling bouncing 37x37x37 puzzle cube	0		Effect: "Top Dog", Effect Duration: 53, Last Available: "2012-12"
 6076	bad McLeod's Hard Haggis-Ade	4	decent	Last Available: "2012-12"
-6077	yummy snack-sized haggis-wrapped haggis-stuffed haggis	2	awesome	Last Available: "2012-12"
+6077	snack-sized yummy haggis-wrapped haggis-stuffed haggis	2	awesome	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	shaking baleful haggis socks	0		Spell Damage: +25, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	lime green airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	shaking baleful haggis socks	0		Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	lime green airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	teal Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	narrow actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6008,7 +6008,7 @@
 6110	narrow bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	upside-down zaibatsu lobby card	0		Last Available: "2013-12"
-6113	mirror purple zaibatsu level 1 card	0		Last Available: "2013-12"
+6113	purple mirror zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	bouncing zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	shaking CEO office card	0		Last Available: "2013-12"
@@ -6040,30 +6040,30 @@
 6142	toothsome roasted duck	3	awesome	Last Available: "2013-12"
 6143	rotten ghostly dead meat bun	3	crappy	Last Available: "2013-12"
 6144	cat collar of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2013-12"
-6145	skewed scorching weightlifter's suspicious-looking fedora	0		Muscle: +15, Hot Damage: +25, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	skewed scorching weightlifter's suspicious-looking fedora	0		Muscle: +15, Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	toothsome carrot cake	3	awesome	Last Available: "2013-01"
-6153	fancy lousy squat carrot claret	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 15, Last Available: "2013-01"
+6153	lousy fancy squat carrot claret	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 15, Last Available: "2013-01"
 6154	twisted bouncing carrot juice	1	good	Last Available: "2013-01"
 6155	spinning pixel power cell	0		Last Available: "2013-12"
 6156	ghostly jittery flickering pixel	0		Last Available: "2013-12"
 6157	spinning hardened slick Byte	0		Moxie: +10, Damage Reduction: 3, Last Available: "2013-12"
-6158	ghostly strapping anger blaster	0		Muscle: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	mirror flame-wreathed doubt cannon	0		Hot Spell Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	MacGyver's fear condenser	0		Maximum MP: +100, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	regret hose of the cougar	0		Moxie: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	ghostly strapping anger blaster	0		Muscle: +5, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	mirror flame-wreathed doubt cannon	0		Hot Spell Damage: +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	MacGyver's fear condenser	0		Maximum MP: +100, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	regret hose of the cougar	0		Moxie: +20, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	jittery Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	censurious commodore's hat of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	gray spinning naval trousers of the ox	0		Muscle: +20, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	censurious commodore's hat of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	gray spinning naval trousers of the ox	0		Muscle: +20, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	reassuring deck cannon of wisdom	0		Mysticality: +15, Spooky Resistance: +1, Last Available: "2013-12"
 6167	jittery nasty ornamental sextant	0		Stench Damage: +5, Last Available: "2013-12"
 6168	veiny thinker's Bloodbath	0		Mysticality: +10, Maximum HP: +10, Last Available: "2013-12"
-6169	tolerable fancy Hundred Headed IPA	3	good	Effect: "Shoesauce", Effect Duration: 35, Last Available: "2013-12"
+6169	fancy tolerable Hundred Headed IPA	3	good	Effect: "Shoesauce", Effect Duration: 35, Last Available: "2013-12"
 6170	adequate skewed chum	3	good	Last Available: "2013-12"
 6171	galvanized Vulcanized tumbling crude crudit&eacute;s	0		Effect: "Venomous Weapon", Effect Duration: 61
 6172	denatured candy crayons	0		Effect: "Wreathed in Merriment", Effect Duration: 23, Last Available: "2020-09"
@@ -6080,25 +6080,25 @@
 6183	blinking cosmic fruit	0		
 6184	twirling horrifying Jarlsberg's hat of the bloodbag of horror	0		Maximum HP: +100, Spooky Damage: +25, Spooky Spell Damage: +25
 6185	spoiled consummate hard-boiled egg	4	crappy	
-6186	adequate pulsating upside-down consummate fried egg	3	good	
+6186	adequate upside-down pulsating consummate fried egg	3	good	
 6187	moldy consummate egg salad	4	crappy	
 6188	stale consummate bagel	4	decent	
 6189	bland bite-sized blurry consummate sliced bread	1	decent	
 6190	half-sized moldy consummate hot dog bun	2	crappy	
 6191	small stale blinking consummate brownie	2	decent	
 6192	decent consummate toast	3	good	
-6193	triple-distilled artisanal passable stout	8	EPIC	
-6194	big decent consummate soup	5	good	
+6193	artisanal triple-distilled passable stout	8	EPIC	
+6194	decent big consummate soup	5	good	
 6195	adequate huge consummate corn chips	4	good	
-6196	fancy flavorless big consummate salad	5	decent	Effect: "Rushtacean'", Effect Duration: 25
+6196	fancy big flavorless consummate salad	5	decent	Effect: "Rushtacean'", Effect Duration: 25
 6197	normal consummate salsa	3	good	
 6198	tasty huge pulsating consummate sauerkraut	6	awesome	
-6199	miniature normal consummate cheese slice	2	good	
+6199	normal miniature consummate cheese slice	2	good	
 6200	adequate blinking consummate melted cheese	4	good	
 6201	diet spoiled consummate bacon	1	crappy	
-6202	adequate diet pulsating consummate meatloaf	1	good	
+6202	diet adequate pulsating consummate meatloaf	1	good	
 6203	stale consummate steak	3	decent	
-6204	snack-sized flavorless consummate cuts	2	decent	
+6204	flavorless snack-sized consummate cuts	2	decent	
 6205	tasty gray consummate frankfurter	3	awesome	
 6206	bland consummate french fries	3	decent	
 6207	spoiled upside-down consummate baked potato	4	crappy	
@@ -6106,31 +6106,31 @@
 6209	normal skewed consummate ice cream	4	good	
 6210	fancy decent consummate whipped cream	4	good	Effect: "Bread Burps", Effect Duration: 10
 6211	miniature spoiled shaking consummate cream	2	crappy	
-6212	diet spoiled consummate strawberries	1	crappy	
+6212	spoiled diet consummate strawberries	1	crappy	
 6213	rotten consummate sorbet	4	crappy	
 6214	smooth adequate rum	3	awesome	
 6215	lousy mediocre lager	3	decent	
-6216	flavorless jumbo shaking immaculate grilled cheese	5	decent	
-6217	thick spoiled immaculate ice cream sandwich	5	crappy	
+6216	jumbo flavorless shaking immaculate grilled cheese	5	decent	
+6217	spoiled thick immaculate ice cream sandwich	5	crappy	
 6218	adequate snack-sized gray immaculate hot dog	2	good	
-6219	special decent shaking immaculate egg salad sandwich	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 30
-6220	stale thick skewed green pulsating perfect sandwich	5	decent	
+6219	decent special shaking immaculate egg salad sandwich	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 30
+6220	thick stale skewed green pulsating perfect sandwich	5	decent	
 6221	bland red perfect chef salad	3	decent	
 6222	normal perfect breakfast	3	good	
-6223	small normal special ghostly sublime deluxe hot dog	2	good	Effect: "Bone Homie", Effect Duration: 5
+6223	normal small special ghostly sublime deluxe hot dog	2	good	Effect: "Bone Homie", Effect Duration: 5
 6224	rotten sublime stew	4	crappy	
 6225	normal sublime nachos	3	good	
 6226	normal Ultimate Breakfast Sandwich	4	good	
 6227	rotten small green Loaded Baked Potato	2	crappy	
 6228	decent bouncing Omega Sundae	3	good	
 6229	bad watered-down Das Sauerlager	2	decent	
-6230	tolerable spirit-forward Bologna Lambic	5	good	
+6230	spirit-forward tolerable Bologna Lambic	5	good	
 6231	irresponsibly strong artisanal Vodka Dog	6	EPIC	
 6232	weak bad wobbly Disappointed Russian	2	decent	
-6233	practically non-alcoholic drinkable blinking Chunky Mary	1	good	
-6234	tolerable skewed spinning Nachojito	3	good	
+6233	drinkable practically non-alcoholic blinking Chunky Mary	1	good	
+6234	tolerable spinning skewed Nachojito	3	good	
 6235	acceptable Le Roi	4	good	
-6236	high-proof lousy Over Easy Rider	10	decent	
+6236	lousy high-proof Over Easy Rider	10	decent	
 6237	mirror cosmic six-pack	0		
 6239	extra-dry narrow ghostly cube of ectoplasm	0		Effect: "Expert Vacationer", Effect Duration: 34
 6240	modified ghostly Illuminati earpiece	0		Effect: "Sauce Monocle", Effect Duration: 29
@@ -6169,12 +6169,12 @@
 6273	super-energized activated blurry O'RLY manual	0		Effect: "init.enh", Effect Duration: 48
 6274	tolerable open sauce	3	good	
 6275	olive greedy turkey leg of dire peril	0		Weapon Damage: +20, Meat Drop: +20
-6276	triple-distilled bad Ye Olde Meade	9	decent	
+6276	bad triple-distilled Ye Olde Meade	9	decent	
 6277	flattened polymerized Ye Olde Bawdy Limerick	0		Effect: "Pockets of Fire", Effect Duration: 23
 6278	pulsating Ye Olde Medieval Insult	0		
 6279	resourceful pewter claymore	0		Maximum MP: +50
 6280	scorching artisanal rice peeler	0		Hot Damage: +25
-6281	moldy diet huge heirloom grape tomato	1	crappy	
+6281	diet moldy huge heirloom grape tomato	1	crappy	
 6282	fuchsia chipotle wasabi cilantro aioli	0		
 6283	jittery blurry lightning-fast brown felt tophat	0		Initiative: +40, Familiar Effect: "1xLep, cap 37"
 6284	pulsating gear	0		
@@ -6182,11 +6182,11 @@
 6286	executive Mark II Steam-Hat of incineration of the cheetah	0		Hot Spell Damage: +50, Meat Drop: +40, Initiative: +60, Familiar Effect: "1xLep, cap 37"
 6287	spinning nippy shellacked grievous Mark III Steam-Hat of Gandalf	0		Weapon Damage Percent: +50, Damage Reduction: 7, Spell Critical Percent: +20, Cold Damage: +10, Familiar Effect: "1xLep, cap 37"
 6288	cyan chilly Socratic slick Mark IV Steam-Hat of the wise owl of vim and vigor	0		Mysticality: +20, Moxie: +10, Experience (Mysticality): +1, Maximum HP Percent: +50, Cold Damage: +5, Familiar Effect: "1xLep, cap 37"
-6289	blue careful supercharged sinister Samson's Mark V Steam-Hat of the bloodbag	0		Experience (Muscle): +5, Spell Damage: +10, Maximum HP: +100, Maximum MP Percent: +30, Monster Level: -10, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	blue careful supercharged sinister Samson's Mark V Steam-Hat of the bloodbag	0		Experience (Muscle): +5, Spell Damage: +10, Maximum HP: +100, Maximum MP Percent: +30, Monster Level: -10, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	auspicious reassuring punk rock jacket	0		Spooky Resistance: +1, Item Drop: +10
 6292	blue pulsating shaking veiny personal trainer's safety pin	0		Experience Percent (Muscle): +10, Maximum HP: +10
-6293	adequate snack-sized stolen sushi	2	good	
+6293	snack-sized adequate stolen sushi	2	good	
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6236,7 +6236,7 @@
 6340	reassuring floral-print skirt of Calamity Jane	0		Critical Hit Percent: +15, Spooky Resistance: +1, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	curative hardened spectral axe	0		Damage Reduction: 3, HP Regen Min: 3, HP Regen Max: 5
 6342	smelly super-strong air freshener	0		Stench Spell Damage: +10, Item Drop: +5
-6343	extra-aerosolized super-aerosolized jittery twirling Mer-kin lipstick	0		Effect: "Techno Bliss", Effect Duration: 45
+6343	extra-aerosolized super-aerosolized twirling jittery Mer-kin lipstick	0		Effect: "Techno Bliss", Effect Duration: 45
 6344	upside-down Mer-kin mouthsoap	0		
 6345	deionized energized Mer-kin strongjuice	0		Effect: "The Two-Prong Crown", Effect Duration: 55
 6346	twirling Mer-kin fitbrine	0		
@@ -6253,7 +6253,7 @@
 6357	cyan Mer-kin knucklebone	0		
 6358	shaking gray Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	purple blurry censurious Mer-kin begsign	0		Sleaze Resistance: +3, Meat Drop: +40
-6360	Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	deionized twirling pulled taffy	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 13, Last Available: "2013-04"
 6362	flattened twirling pulled indigo taffy	0		Effect: "Jingle Jangle Jingle", Effect Duration: 48, Last Available: "2013-04"
 6363	pickled moist pulled taffy	0		Effect: "Jingle Jangle Jingle", Effect Duration: 25, Last Available: "2013-04"
@@ -6272,11 +6272,11 @@
 6376	twirling Jick-o-User	0		
 6378	eraser nubbin	0		
 6379	chlorine crystal	0		
-6380	liquefied pulsating olive ph balancer	0		Effect: "Hyperoxygenated Blood", Effect Duration: 39
+6380	liquefied olive pulsating ph balancer	0		Effect: "Hyperoxygenated Blood", Effect Duration: 39
 6381	magnetized mysterious chemical residue	0		Effect: "Saucefingers", Effect Duration: 14
 6382	nugget of sodium	0		
 6383	root beer	1	awesome	
-6384	blue spinning jigsaw blade	0		
+6384	spinning blue jigsaw blade	0		
 6385	narrow wood screw	0		
 6386	balsa plank	0		
 6387	blob of wood glue	0		
@@ -6307,18 +6307,18 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	squat clutch of dodecapede eggs	0		
-6415	gigantic special spoiled flavorless gruel	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35
-6416	bland snack-sized fancy mana curds	2	decent	Effect: "Sauce Monocle", Effect Duration: 30
+6415	spoiled special gigantic flavorless gruel	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35
+6416	fancy snack-sized bland mana curds	2	decent	Effect: "Sauce Monocle", Effect Duration: 30
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	oxidized frozen skewed moth dust	0		Effect: "Sugar, Hello", Effect Duration: 58
 6420	oxidized glob of spoiled mayo	0		Effect: "Gr8ness", Effect Duration: 58
 6421	tonic djinn	0		
-6422	massive rotten vampire chowder	6	crappy	
+6422	rotten massive vampire chowder	6	crappy	
 6423	fuchsia Tales of Dread	0		Free Pull
 6424	upside-down Dreadsylvanian skeleton key	0		
 6425	upside-down Official Seal of Dreadsylvania	0		
-6426	spoiled tiny Dreadsylvanian stew	1	crappy	
+6426	tiny spoiled Dreadsylvanian stew	1	crappy	
 6427	artisanal cyan Dreadsylvanian	3	EPIC	
 6428	super-galvanized Dreadsylvanian flask	0		Effect: "Goldentongue", Effect Duration: 62
 6429	activated spinning Dreadsylvanian flask	0		Effect: "Greasy Flavor", Effect Duration: 53
@@ -6327,7 +6327,7 @@
 6432	dog trainer's dreadful glove	0		Experience (familiar): +1, Kruegerand Drop: 5
 6433	maroon Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
-6435	spinning wobbly Mark of the Werewolf	0		
+6435	wobbly spinning Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
 6437	wobbly Mark of the Ghost	0		
 6438	mirror Mark of the Vampire	0		
@@ -6360,7 +6360,7 @@
 6465	aromatic dog trainer's quilted Mayor Ghost's gavel	0		Damage Absorption: +40, Experience (familiar): +1, Stench Resistance: +1, Conditional Skill (Equipped): "Hammer Ghost"
 6466	ghostly ruddy experienced Mayor Ghost's sash of Flo-Jo	0		Experience: +2, Maximum HP Percent: +40, Initiative: +100, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	tasty immense bouncing fuchsia ghost pepper	8	awesome	
+6468	immense tasty bouncing fuchsia ghost pepper	8	awesome	
 6469	blinking gravedigger's savvy Thunkula's drinking cap of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Spooky Damage: +10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	Sherlock's fortified Drunkula's cape of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10, Item Drop: +25, Class: "Sauceror"
 6471	reassuring vibrating personal trainer's Drunkula's silky pants	0		Experience Percent (Muscle): +10, Maximum MP Percent: +10, Spooky Resistance: +1, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	shaking dreadful roast	0		
 6487	stinking agaricus	0		
-6488	half-sized stale cyan Dreadsylvanian shepherd's pie	2	decent	
+6488	stale half-sized cyan Dreadsylvanian shepherd's pie	2	decent	
 6489	music box parts	0		
 6490	squat unwound mechanical songbird	0		
 6491	skewed tailfeathers	0		Familiar Weight: +5
@@ -6390,7 +6390,7 @@
 6495	chilly Dreadsylvania Auditor's badge	0		Cold Damage: +5, Kruegerand Drop: 5, Single Equip
 6496	squat blood kiwi	0		
 6497	bouncing eau de mort	0		
-6498	mediocre extra-dry bloody kiwitini	5	decent	
+6498	extra-dry mediocre bloody kiwitini	5	decent	
 6499	spinning moon-amber	0		
 6500	polished moon-amber	0		
 6501	tumbling lightning-fast hardy thinker's moon-amber necklace	0		Mysticality: +10, Maximum HP: +50, Initiative: +40, Single Equip
@@ -6410,7 +6410,7 @@
 6515	coward's eerie fetish	0		Monster Level: -20, Single Equip
 6516	watered-down mediocre stinkwater	2	decent	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	special low-calorie flavorless accidental mutton	1	decent	Effect: "Pockets of Fire", Effect Duration: 10
+6518	low-calorie special flavorless accidental mutton	1	decent	Effect: "Pockets of Fire", Effect Duration: 10
 6519	jittery wobbly smelly chilly drafty drawers	0		Cold Damage: +5, Stench Spell Damage: +10, Familiar Effect: "1.5xVolley"
 6520	clever Newton's wolfskull mask	0		Experience (Mysticality): +3, Maximum MP: +20, Familiar Effect: "spooky atk, 1xBarrr"
 6521	wobbly steel-toed guts necklace	0		Damage Reduction: 9, Single Equip
@@ -6456,23 +6456,23 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	boxer's hand of Mr. Cards	0		Muscle Percent: +10, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	diet adequate Dreadsylvanian hot pocket	1	good	
-6565	miniature flavorless bouncing Dreadsylvanian pocket	2	decent	
+6565	flavorless miniature bouncing Dreadsylvanian pocket	2	decent	
 6566	bland Dreadsylvanian pocket	3	decent	
-6567	enchanted rotten bite-sized Dreadsylvanian stink pocket	1	crappy	Effect: "Thaumodynamic", Effect Duration: 50
+6567	rotten bite-sized enchanted Dreadsylvanian stink pocket	1	crappy	Effect: "Thaumodynamic", Effect Duration: 50
 6568	normal narrow Dreadsylvanian sleaze pocket	4	good	
-6569	distilled artisanal Dreadsylvanian hot toddy	5	super EPIC	
+6569	artisanal distilled Dreadsylvanian hot toddy	5	super EPIC	
 6570	perfectly mixed Dreadsylvanian cold-fashioned	3	super ultra mega turbo EPIC	
 6571	acceptable twirling Dreadsylvanian grimlet	4	good	
-6572	fortified artisanal Dreadsylvanian dank and stormy	5	super EPIC	
-6573	watered-down smooth wobbly Dreadsylvanian slithery nipple	2	awesome	
+6572	artisanal fortified Dreadsylvanian dank and stormy	5	super EPIC	
+6573	smooth watered-down wobbly Dreadsylvanian slithery nipple	2	awesome	
 6574	hot clusterbomb	0		
 6575	twirling clusterbomb	0		
 6576	clusterbomb	0		
 6577	stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
-6579	ghostly purple Dreadsylvanian Almanac page	0		
+6579	purple ghostly Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
-6581	jittery upside-down upside-down dreadful box	0		
+6581	upside-down upside-down jittery dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	vicious spiked collar	0		Familiar Damage: +20
 6584	fuchsia jittery arcane researcher's hot dog wrapper	0		Experience Percent (Mysticality): +10
@@ -6494,7 +6494,7 @@
 6600	clockwork hand	0		
 6601	clockwork numeral I	0		
 6602	clockwork numeral II	0		
-6603	twirling mirror clockwork numeral III	0		
+6603	mirror twirling clockwork numeral III	0		
 6604	clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	narrow clockwork numeral VI	0		
@@ -6517,7 +6517,7 @@
 6623	blinking folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	twirling folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
-6626	blurry wobbly upside-down folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
+6626	upside-down wobbly blurry folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
 6628	jittery folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	narrow folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
@@ -6542,13 +6542,13 @@
 6650	blinking Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
 6652	hand-crafted teal stepmom's booze	4	EPIC	
-6653	gray pulsating surgical tape	0		
+6653	pulsating gray surgical tape	0		
 6654	quilted band T-shirt	0		Damage Absorption: +40
 6655	bad watered-down fountain 'soda'	2	decent	
 6656	illegal firecracker	0		
 6657	twirling narrow Temple Grandin's pickelhaube of the bloodbag	0		Maximum HP: +100, Familiar Weight: +7, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	enhanced blinking hair oil	0		Effect: "Stinky Weapon", Effect Duration: 69
-6659	irradiated squat blinking scrap	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 57
+6659	irradiated blinking squat scrap	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 57
 6660	school spirit socket set	0		
 6661	suspension bridge	0		
 6662	scorching curative wicked strapping Staff of the Lunch Lady	0		Muscle: +5, Spell Damage: +5, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5
@@ -6571,7 +6571,7 @@
 6679	ghostly machete of extreme caution	0		Monster Level: -25
 6680	extra-dry aged Cursed Punch	5	awesome	
 6681	acceptable Bowl of Scorpions	4	good	
-6682	lousy weak jittery Fog Murderer	2	decent	
+6682	weak lousy jittery Fog Murderer	2	decent	
 6683	book of matches	0		
 6684	surgical mask of the overflowing toilet	0		Stench Spell Damage: +50, Surgeonosity: +1
 6685	deadly head mirror	0		Weapon Damage: +5, Surgeonosity: +1
@@ -6582,7 +6582,7 @@
 6690	McClusky file (page 2)	0		
 6691	McClusky file (page 3)	0		
 6692	yellow McClusky file (page 4)	0		
-6693	shaking blinking McClusky file (page 5)	0		
+6693	blinking shaking McClusky file (page 5)	0		
 6694	boring binder clip	0		
 6695	McClusky file (complete)	0		
 6696	yellow bowling ball	0		
@@ -6623,7 +6623,7 @@
 6731	Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	clothesline pole	0		
-6734	shaking bouncing cigar sign	0		
+6734	bouncing shaking cigar sign	0		
 6735	junk junk	0		
 6736	pulsating Junk-Bond	0		
 6737	tangle of copper wire	0		
@@ -6634,12 +6634,12 @@
 6742	blurry wizardly junk band	0		Mysticality: +25
 6743	clever junk trunks	0		Maximum MP: +20, Familiar Effect: "cap 15"
 6744	banded junk-mail shirt	0		Damage Absorption: +100
-6745	small delicious junk food	2	awesome	
+6745	delicious small junk food	2	awesome	
 6746	lousy cyan junk yard	4	decent	
 6747	upside-down medical-grade forbidden swordzall	0		Spell Damage Percent: +50, HP Regen Min: 7, HP Regen Max: 10
 6748	upside-down arm buzzer of the brute	0		Muscle Percent: +30, Damage Reduction: 6
 6749	boilgun of the pedagogue of incineration	0		Experience: +3, Hot Spell Damage: +50
-6750	tumbling lime green Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
+6750	lime green tumbling Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	ghostly packet of beer seeds	0		Last Available: "2013-09"
 6752	bouncing cyan handful of barley	0		
 6753	huge cluster of hops	0		
@@ -6647,18 +6647,18 @@
 6755	wobbly beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	artisanal can of Br&uuml;talbr&auml;u	4	EPIC	Last Available: "2013-09"
-6758	weak artisanal can of Drooling Monk	2	EPIC	Last Available: "2013-09"
+6758	artisanal weak can of Drooling Monk	2	EPIC	Last Available: "2013-09"
 6759	drinkable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
 6760	drinkable watered-down mirror bottle of Old Pugilist	2	good	Last Available: "2013-09"
 6761	mediocre bottle of Professor Beer	4	decent	Last Available: "2013-09"
 6762	perfectly mixed bottle of Rapier Witbier	4	EPIC	Last Available: "2013-09"
-6763	practically non-alcoholic smooth bottle of Race Car Red	1	awesome	Last Available: "2013-09"
+6763	smooth practically non-alcoholic bottle of Race Car Red	1	awesome	Last Available: "2013-09"
 6764	perfectly mixed bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
 6765	artisanal squat bottle of Lambada Lambic	3	EPIC	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	wobbly wobbly lime green liquid bread	1	decent	Last Available: "2013-09"
-6769	gray greasy careful tin tam of the sewer	0		Monster Level: -10, Stench Damage: +25, Sleaze Spell Damage: +10, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	gray greasy careful tin tam of the sewer	0		Monster Level: -10, Stench Damage: +25, Sleaze Spell Damage: +10, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	ionized pulsating wobbly tin cup	0		Effect: "Broberry Brotality", Effect Duration: 42, Last Available: "2013-09"
 6771	rock-hard tin foil of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Item Drop: +5, Last Available: "2013-09"
 6772	clever Samson's beefy tin drum	0		Muscle: +10, Experience (Muscle): +5, Maximum MP: +20, Last Available: "2013-09"
@@ -6675,7 +6675,7 @@
 6783	lightning-fast stylish seal medal of dire peril	0		Moxie: +25, Weapon Damage: +20, Initiative: +40
 6784	deanimated reanimator's coffin	0		Free Pull
 6785	olive flask of embalming fluid	0		
-6788	red mirror blank diary	0		
+6788	mirror red blank diary	0		
 6789	blurry ghostly boot knife	0		
 6790	huge broken beer bottle	0		
 6791	sharpened spoon	0		
@@ -6688,7 +6688,7 @@
 6799	Vulcanized disco horoscope (Gemini)	0		Effect: "Pretending to Pretend", Effect Duration: 69
 6800	warmed fuchsia disco horoscope (Cancer)	0		Effect: "Tennis Elbow-wow", Effect Duration: 13
 6801	cold-filtered dry disco horoscope (Leo)	0		Effect: "Muddled", Effect Duration: 62
-6802	wet blue huge disco horoscope (Virgo)	0		Effect: "Ripping, Dripping", Effect Duration: 35
+6802	wet huge blue disco horoscope (Virgo)	0		Effect: "Ripping, Dripping", Effect Duration: 35
 6803	alkaline skewed disco horoscope (Libra)	0		Effect: "Extra-Sharp Weapon", Effect Duration: 17
 6804	boiled pickled disco horoscope (Scorpio)	0		Effect: "Sticky Fingers", Effect Duration: 68
 6805	galvanized blue disco horoscope (Sagittarius)	0		Effect: "Papowerful", Effect Duration: 22
@@ -6714,7 +6714,7 @@
 6825	curative veiny alarm accordion	0		Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5, Class: "Accordion Thief", Song Duration: 20
 6826	shaking dog trainer's Van der Graaf ruddy All-Hallow's Steve's fright wig	0		Maximum HP Percent: +40, Experience (familiar): +1, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	jittery double-paned banded KoL Con X Treasure Map	0		Damage Absorption: +100, Cold Resistance: +5
-6828	artisanal jittery huge discocktail	4	EPIC	
+6828	artisanal huge jittery discocktail	4	EPIC	
 6829	coward's KoL Con X Bingo Card	0		Monster Level: -20
 6830	twirling maroon Temporal Tempera Tube	0		Item Drop: +5
 6831	improved pulsating Tallowcreme Halloween Pumpkin	0		Effect: "Browbeaten", Effect Duration: 53
@@ -6746,14 +6746,14 @@
 6857	occult Cajun accordion	0		Spell Damage Percent: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	avaricious quirky accordion	0		Meat Drop: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	Jack Frost's stiffened Skipper's accordion	0		Damage Reduction: 1, Cold Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	energetic hale Newton's Pantsgiving of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Maximum HP: +20, Maximum MP Percent: +20, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	energetic hale Newton's Pantsgiving of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Maximum HP: +20, Maximum MP Percent: +20, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	normal can of sardines	4	good	Last Available: "2013-11"
 6862	tasty high-calorie sugar substitute	3	awesome	Last Available: "2013-11"
 6863	rotten blinking pat of butter	4	crappy	Last Available: "2013-11"
-6864	stale fancy snack-sized dinner roll	2	decent	Effect: "Hot Hands", Effect Duration: 10, Last Available: "2013-11"
+6864	stale snack-sized fancy dinner roll	2	decent	Effect: "Hot Hands", Effect Duration: 10, Last Available: "2013-11"
 6865	decent mashed potatoes	3	good	Last Available: "2013-11"
 6866	adequate twirling whole turkey leg	4	good	Last Available: "2013-11"
-6867	yummy small blurry deviled egg	2	awesome	Last Available: "2013-11"
+6867	small yummy blurry deviled egg	2	awesome	Last Available: "2013-11"
 6868	modified cold-filtered gray finger exerciser	0		Effect: "Gummibrain", Effect Duration: 31, Last Available: "2013-11"
 6869	denatured pulsating dented spoon	0		Effect: "Got Your Boots On", Effect Duration: 52, Last Available: "2013-11"
 6870	non-altered narrow love note	0		Effect: "Jelly Combed", Effect Duration: 19, Last Available: "2013-11"
@@ -6804,35 +6804,35 @@
 6915	smelly warbear hoverbelt of Leguizamo of the brazier	0		Monster Level: +20, Hot Spell Damage: +25, Stench Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6916	fuchsia warbear battery	0		Last Available: "2013-12"
 6917	upside-down warbear badge	0		Last Available: "2013-12"
-6918	frozen warmed huge jittery warbear wardance potion	0		Effect: "License to Punch", Effect Duration: 42, Last Available: "2013-12"
+6918	frozen warmed jittery huge warbear wardance potion	0		Effect: "License to Punch", Effect Duration: 42, Last Available: "2013-12"
 6919	liquefied altered warbear bearserker potion	0		Effect: "Fishily Speeding", Effect Duration: 51, Last Available: "2013-12"
 6920	denatured warbear liquid overcoat	0		Effect: "Grrrrrrreat!", Effect Duration: 14, Last Available: "2013-12"
 6921	tasty immense warbear feasting bread	9	awesome	Last Available: "2013-12"
-6922	diet stale narrow warbear warrior bread	1	decent	Last Available: "2013-12"
+6922	stale diet narrow warbear warrior bread	1	decent	Last Available: "2013-12"
 6923	bland warbear thermoregulator bread	3	decent	Last Available: "2013-12"
 6924	lousy warbear feasting mead	4	decent	Last Available: "2013-12"
 6925	perfectly mixed weak warbear bearserker mead	2	super EPIC	Last Available: "2013-12"
-6926	lousy high-proof warbear blizzard mead	8	decent	Last Available: "2013-12"
+6926	high-proof lousy warbear blizzard mead	8	decent	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	fortified extremely unsafe razor-sharp warbear plain fedora	0		Weapon Damage Percent: 125, Damage Absorption: +60, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	Jack Frost's warbear feathered fedora	0		Cold Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	careful steel-toed warbear fedora of the early riser	0		Damage Reduction: 9, Monster Level: -10, Adventures: +7, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	blue executive hardy boxer's warbear plain helm	0		Muscle Percent: +10, Maximum HP: +50, Meat Drop: +40, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	curative warbear spiked helm	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	frightening resourceful warbear electro-spiked helm of extreme caution	0		Maximum MP: +50, Monster Level: -25, Spooky Damage: +5, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	blurry double-paned sharpshooter's fortified warbear plain ushanka	0		Damage Absorption: +60, Critical Hit Percent: +10, Cold Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	narrow smelly warbear lined ushanka	0		Stench Spell Damage: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	foul-smelling shellacked warbear heated ushanka of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Stench Damage: +10, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	fortified extremely unsafe razor-sharp warbear plain fedora	0		Weapon Damage Percent: 125, Damage Absorption: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	Jack Frost's warbear feathered fedora	0		Cold Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	careful steel-toed warbear fedora of the early riser	0		Damage Reduction: 9, Monster Level: -10, Adventures: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	blue executive hardy boxer's warbear plain helm	0		Muscle Percent: +10, Maximum HP: +50, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	curative warbear spiked helm	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	frightening resourceful warbear electro-spiked helm of extreme caution	0		Maximum MP: +50, Monster Level: -25, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	blurry double-paned sharpshooter's fortified warbear plain ushanka	0		Damage Absorption: +60, Critical Hit Percent: +10, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	narrow smelly warbear lined ushanka	0		Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	foul-smelling shellacked warbear heated ushanka of the empath	0		Damage Reduction: 7, Familiar Weight: +5, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	upside-down smelly crafty Newton's warbear party pants	0		Experience (Mysticality): +3, Maximum MP: +10, Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	shaking warbear ceremonial party pants of wisdom	0		Mysticality: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	olive flame-retardant ribald mansplainer's warbear high festival pants	0		Monster Level: +15, Sleaze Damage: +10, Hot Resistance: +1, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	mansplainer's rosy-cheeked beefy warbear battle greaves	0		Muscle: +10, Maximum HP Percent: +30, Monster Level: +15, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	spinning thinker's warbear officer greaves	0		Mysticality: +10, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	Sherlock's smartaleck's slick warbear bearserker greaves	0		Moxie: +10, Moxie Percent: +30, Item Drop: +25, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	teal Jack Frost's nippy wholesome warbear johns	0		Maximum HP Percent: +10, Cold Damage: +10, Cold Spell Damage: +50, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	curative warbear fleece-lined johns	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	toasty sage warbear johns of doom	0		Mysticality Percent: +10, Hot Damage: +5, Spooky Spell Damage: +50, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	upside-down smelly crafty Newton's warbear party pants	0		Experience (Mysticality): +3, Maximum MP: +10, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	shaking warbear ceremonial party pants of wisdom	0		Mysticality: +15, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	olive flame-retardant ribald mansplainer's warbear high festival pants	0		Monster Level: +15, Sleaze Damage: +10, Hot Resistance: +1, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	mansplainer's rosy-cheeked beefy warbear battle greaves	0		Muscle: +10, Maximum HP Percent: +30, Monster Level: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	spinning thinker's warbear officer greaves	0		Mysticality: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	Sherlock's smartaleck's slick warbear bearserker greaves	0		Moxie: +10, Moxie Percent: +30, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	teal Jack Frost's nippy wholesome warbear johns	0		Maximum HP Percent: +10, Cold Damage: +10, Cold Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	curative warbear fleece-lined johns	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	toasty sage warbear johns of doom	0		Mysticality Percent: +10, Hot Damage: +5, Spooky Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	gravedigger's friendly warbear goggles of terror	0		Familiar Weight: +3, Spooky Damage: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6949	blurry double-paned warbear snowblindness goggles	0		Cold Resistance: +5, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	lion tamer's sharpshooter's warbear warscarf of doom	0		Critical Hit Percent: +10, Experience (familiar): +2, Spooky Spell Damage: +50, Single Equip, Last Available: "2013-12"
 6957	ghostly warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	warbear foil hat of incineration	0		Hot Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	warbear foil hat of incineration	0		Hot Spell Damage: +50, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	rosewater-soaked dance instructor's warbear oil pan	0		Experience Percent (Moxie): +10, Stench Resistance: +3, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	rosewater-soaked dance instructor's warbear oil pan	0		Experience Percent (Moxie): +10, Stench Resistance: +3, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	blurry zippy warbear exhaust manifold	0		Initiative: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,26 +6889,26 @@
 7000	skewed miser's die-cast Don Crimbo of bravery	0		Spooky Resistance: +5, Meat Drop: +10, Last Available: "2013-12"
 7001	greasy curative die-cast Uncle Hobo	0		Sleaze Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
 7002	stanky Van der Graaf die-cast Father Crimbo	0		Stench Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
-7003	yellow shaking The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	yellow shaking The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	nitrogenated Flaskfull of Hollow	0		Effect: "Spooky Blur", Effect Duration: 43, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered handful of Smithereens	1	good	Last Available: "2013-12"
 7007	adequate Every Day is Like This Sundae	4	good	Last Available: "2013-12"
 7008	fancy decent Miserable Pie	4	good	Effect: "Spring Training", Effect Duration: 50, Last Available: "2013-12"
 7009	stale huge This Charming Flan	3	decent	Last Available: "2013-12"
-7010	weak hand-crafted Irish Coffee, English Heart	2	EPIC	Last Available: "2013-12"
+7010	hand-crafted weak Irish Coffee, English Heart	2	EPIC	Last Available: "2013-12"
 7011	smooth Strikes Again Bigmouth	3	awesome	Last Available: "2013-12"
-7012	smooth watered-down Paint A Vulgar Pitcher	2	awesome	Last Available: "2013-12"
+7012	watered-down smooth Paint A Vulgar Pitcher	2	awesome	Last Available: "2013-12"
 7013	gray Golden Light	0		Last Available: "2013-12"
-7014	blurry skewed Louder Than Bomb	0		Last Available: "2013-12"
+7014	skewed blurry Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
 7016	pulsating aromatic Newton's sage Work is a Four Letter Sword of dire peril	0		Mysticality Percent: +10, Experience (Mysticality): +3, Weapon Damage: +20, Stench Resistance: +1, Last Available: "2013-12"
 7017	double-paned gravedigger's Fonzie's Newton's Staff of the Headmaster's Victuals	0		Experience (Mysticality): +3, Experience (Moxie): +1, Spooky Damage: +10, Cold Resistance: +5, Last Available: "2013-12"
 7018	stanky padded razor-sharp Sheila Take a Crossbow of courage	0		Weapon Damage Percent: +25, Damage Absorption: +20, Stench Spell Damage: +25, Spooky Resistance: +3, Last Available: "2013-12"
 7019	spinning Sherlock's knitted Jim Carey's beefy A Light that Never Goes Out	0		Muscle: +10, Monster Level: +25, Cold Resistance: +3, Item Drop: +25, Last Available: "2013-12"
 7020	Temple Grandin's wholesome Socratic wizardly Half a Purse	0		Mysticality: +25, Experience (Mysticality): +1, Maximum HP Percent: +10, Familiar Weight: +7, Last Available: "2013-12"
-7021	scandalous grievous Hairpiece On Fire of courage of temperance	0		Weapon Damage Percent: +50, Sleaze Damage: +5, Spooky Resistance: +3, Sleaze Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	blurry gravedigger's hardy padded Vicar's Tutu of the cougar	0		Moxie: +20, Damage Absorption: +20, Maximum HP: +50, Spooky Damage: +10, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	scandalous grievous Hairpiece On Fire of courage of temperance	0		Weapon Damage Percent: +50, Sleaze Damage: +5, Spooky Resistance: +3, Sleaze Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	blurry gravedigger's hardy padded Vicar's Tutu of the cougar	0		Moxie: +20, Damage Absorption: +20, Maximum HP: +50, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	ribald hardened Hand in Glove of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Sleaze Damage: +10, Single Equip, Last Available: "2013-12"
 7024	supercharged veiny Meat Tenderizer is Murder of Gandalf	0		Maximum HP: +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Class: "Seal Clubber", Last Available: "2013-12"
 7025	horrifying energetic weightlifter's Ouija Board, Ouija Board	0		Muscle: +15, Maximum MP Percent: +20, Spooky Damage: +25, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6919,12 +6919,12 @@
 7030	bouncing Lo Pan's third-hand lantern	0		Spell Critical Percent: +30
 7031	skewed loose purse strings	0		
 7032	delicious pickled egg	3	awesome	
-7033	spinning lime green mirror cup of lukewarm tea	1	EPIC	
+7033	mirror lime green spinning cup of lukewarm tea	1	EPIC	
 7034	lime green warbear soda machine assembler	0		Last Available: "2013-12"
 7035	jittery warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	shaking warbear LP-ROM burner	0		Last Available: "2013-12"
-7038	blue blurry wobbly warbear gyrocopter	0		Last Available: "2013-12"
+7038	wobbly blue blurry warbear gyrocopter	0		Last Available: "2013-12"
 7039	concentrated ionized warbear robo-camouflage unit	0		Effect: "Reptilian Fortitude", Effect Duration: 53, Last Available: "2013-12"
 7040	mirror warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
@@ -6935,8 +6935,8 @@
 7046	quadruple-polarized pressed dry blurry purple warbear superpotion	0		Effect: "Can Has Cyborger", Effect Duration: 42, Last Available: "2013-12"
 7047	altered warbear liquid lasers	0		Effect: "The Living Hitpoints", Effect Duration: 22, Last Available: "2013-12"
 7048	triple-colloidal frozen galvanized warbear rejuvenation potion	0		Effect: "Engorged Weapon", Effect Duration: 47, Last Available: "2013-12"
-7049	upside-down huge broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	fancy flavorless diet blinking green warbear gyro	1	decent	Effect: "Burning Tongue", Effect Duration: 30, Last Available: "2013-12"
+7049	huge upside-down broken warbear gyrocopter	0		Last Available: "2013-12"
+7050	flavorless diet fancy green blinking warbear gyro	1	decent	Effect: "Burning Tongue", Effect Duration: 30, Last Available: "2013-12"
 7051	energized recording of Rolando's Rondo of Resisto	0		Effect: "On the Shoulders of Giants", Effect Duration: 56, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6969,7 +6969,7 @@
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	shaking snow machine	0		Last Available: "2014-01"
-7083	gray Sherlock's snow mobile	0		Item Drop: +25, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	gray Sherlock's snow mobile	0		Item Drop: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	skewed toasty ice bucket	0		Hot Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
 7085	up-at-dawn snow shovel of the blizzard	0		Cold Spell Damage: +25, Adventures: +5, Lasts Until Rollover, Last Available: "2014-01"
 7086	narrow Temple Grandin's sage bod-ice of courage	0		Mysticality Percent: +10, Familiar Weight: +7, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	watered-down delicious En Una Fila Tequila	2	awesome	
 7091	jittery Skully's hot chocolate	1	EPIC	
-7092	olive double-paned Socratic warbear dress helmet	0		Experience (Mysticality): +1, Cold Resistance: +5, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	olive double-paned Socratic warbear dress helmet	0		Experience (Mysticality): +1, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	careful warbear dress bracers of the sewer	0		Monster Level: -10, Stench Damage: +25, Single Equip, Last Available: "2013-12"
-7094	skewed mirror vibrating Newton's warbear dress greaves	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	hardened sweatband of mayonnaise	0		Damage Reduction: 3, Sleaze Spell Damage: +50, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	yellow friendly supercharged gym shorts	0		Maximum MP Percent: +30, Familiar Weight: +3, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	skewed mirror vibrating Newton's warbear dress greaves	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	hardened sweatband of mayonnaise	0		Damage Reduction: 3, Sleaze Spell Damage: +50, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	yellow friendly supercharged gym shorts	0		Maximum MP Percent: +30, Familiar Weight: +3, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	blinking sizzling ankleweights of terror	0		Hot Damage: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2014-12"
 7098	twirling double-paned electrified smartaleck's beefcake's sweat socks	0		Muscle: +25, Moxie Percent: +30, Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7099	blurry pint of sweat	0		Last Available: "2014-12"
@@ -6994,22 +6994,22 @@
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	bad snakebite	4	decent	Last Available: "2014-12"
 7107	gray wobbly wicked candy stick	0		Spell Damage: +5, Item Drop: +5, Last Available: "2014-12"
-7108	miniature decent pecan	2	good	Last Available: "2014-12"
-7109	small enchanted adequate twirling pecan pie	2	good	Effect: "Crusty Head", Effect Duration: 45, Last Available: "2014-12"
+7108	decent miniature pecan	2	good	Last Available: "2014-12"
+7109	small adequate enchanted twirling pecan pie	2	good	Effect: "Crusty Head", Effect Duration: 45, Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	stale candy mountain oyster	3	decent	Last Available: "2014-12"
-7112	special perfectly mixed watered-down chocotini	2	EPIC	Effect: "Rad-ish", Effect Duration: 10, Last Available: "2014-12"
+7112	special watered-down perfectly mixed chocotini	2	EPIC	Effect: "Rad-ish", Effect Duration: 10, Last Available: "2014-12"
 7113	knitted curative chocolate rabbit's foot of bravery	0		Cold Resistance: +3, Spooky Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12"
 7114	tiny decent cyan candy carrot	1	good	Last Available: "2014-12"
 7115	decent candy carrot cake	3	good	Last Available: "2014-12"
 7116	pulsating wool carrot-on-a-stick of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1, Last Available: "2014-12"
-7117	smelly veiny weasel stomping pants	0		Maximum HP: +10, Stench Spell Damage: +10, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	low-calorie flavorless mulberry	1	decent	Last Available: "2014-12"
+7117	smelly veiny weasel stomping pants	0		Maximum HP: +10, Stench Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7118	flavorless low-calorie mulberry	1	decent	Last Available: "2014-12"
 7119	tolerable mulled berry wine	4	good	Last Available: "2014-12"
 7120	blinking lemony scales	0		Last Available: "2014-12"
-7121	ghostly Van der Graaf lemon party hat	0		MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	ghostly Van der Graaf lemon party hat	0		MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	huge therapeutic lemon shirt	0		HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2014-12"
-7123	strapping lemon drop trousers	0		Muscle: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	strapping lemon drop trousers	0		Muscle: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	aerosolized energized pulsating lemonhead caviar	0		Effect: "Fancy Feasted", Effect Duration: 41, Last Available: "2014-12"
 7125	maroon horrifying smooth gummi sword	0		Moxie: +15, Spooky Damage: +25, Last Available: "2014-12"
 7126	polarized energized teal small gummi fin	0		Effect: "Cold Jellied", Effect Duration: 16, Last Available: "2014-12"
@@ -7018,13 +7018,13 @@
 7129	moldy leftover canap&eacute;s	4	crappy	Last Available: "2014-12"
 7130	mediocre magnum of champagne	3	decent	Last Available: "2014-12"
 7131	reassuring nippy cow creamer of extreme caution	0		Monster Level: -25, Cold Damage: +10, Spooky Resistance: +1, Last Available: "2014-12"
-7132	corrupted vacuum-sealed mirror blurry Outer Wolf&trade; cologne	0		Effect: "Morninja", Effect Duration: 39, Last Available: "2014-12"
+7132	corrupted vacuum-sealed blurry mirror Outer Wolf&trade; cologne	0		Effect: "Morninja", Effect Duration: 39, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	asbestos-lined wolf whistle of the cheetah	0		Hot Resistance: +5, Initiative: +60, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	asbestos-lined wolf whistle of the cheetah	0		Hot Resistance: +5, Initiative: +60, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	decent witch's bread	3	good	Last Available: "2014-12"
 7136	corrupted fuchsia witch's brew	0		Effect: "Insulated Trousers", Effect Duration: 16, Last Available: "2014-12"
 7137	cyan bouncing Oprah's dangerous dance instructor's witch's bra	0		Experience Percent (Moxie): +10, Weapon Damage: +10, Maximum MP Percent: +50, Last Available: "2014-12"
-7138	extra-dry perfectly mixed green mid-level medieval mead	5	EPIC	Last Available: "2014-12"
+7138	perfectly mixed extra-dry green mid-level medieval mead	5	EPIC	Last Available: "2014-12"
 7139	nitrogenated galvanized huge R&uuml;mpelstiltz	0		Effect: "Bear Clawed", Effect Duration: 50, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	polarized hi-octane carrot juice	0		Effect: "Pill Power", Effect Duration: 40, Last Available: "2014-12"
@@ -7043,18 +7043,18 @@
 7154	gray filling	0		Last Available: "2014-12"
 7155	olive parchment	0		Last Available: "2014-12"
 7156	red glass	0		Last Available: "2014-12"
-7157	narrow zippy shellacked dance instructor's fire hose	0		Experience Percent (Moxie): +10, Damage Reduction: 7, Initiative: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	narrow zippy shellacked dance instructor's fire hose	0		Experience Percent (Moxie): +10, Damage Reduction: 7, Initiative: +20, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	half-sized flavorless fireman's lunch	2	decent	Last Available: "2014-12"
-7159	inspector's Jim Carey's dangerous plain paper hat	0		Weapon Damage: +10, Monster Level: +25, Item Drop: +15, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	flavorless tiny ice cream sandwich	1	decent	Last Available: "2014-12"
+7159	inspector's Jim Carey's dangerous plain paper hat	0		Weapon Damage: +10, Monster Level: +25, Item Drop: +15, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7160	tiny flavorless ice cream sandwich	1	decent	Last Available: "2014-12"
 7161	huge energetic Da Vinci's &quot;honey&quot; dipper of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Maximum MP Percent: +20, Last Available: "2014-12"
-7162	snack-sized normal plumber's lunch	2	good	Last Available: "2014-12"
+7162	normal snack-sized plumber's lunch	2	good	Last Available: "2014-12"
 7163	chaotic slick cool skull gearshift knob	0		Moxie: 15, Spell Critical Percent: +10, Last Available: "2014-12"
-7164	spoiled small nachos of the night	2	crappy	Last Available: "2014-12"
+7164	small spoiled nachos of the night	2	crappy	Last Available: "2014-12"
 7165	tumbling perfumed scorching educational Sketcherz&trade;	0		Experience: +1, Hot Damage: +25, Stench Resistance: +5, Last Available: "2014-12"
 7166	moldy special jumbo can of Adultwitch&trade;	5	crappy	Effect: "Heart of Green", Effect Duration: 25, Last Available: "2014-12"
 7167	non-energized corrupted irradiated squat smudge stick	0		Effect: "You Know What's Up", Effect Duration: 29, Last Available: "2014-12"
-7168	super-ionized boiled twirling mirror wall	0		Effect: "Pronounced Potency", Effect Duration: 49, Last Available: "2014-12"
+7168	super-ionized boiled mirror twirling wall	0		Effect: "Pronounced Potency", Effect Duration: 49, Last Available: "2014-12"
 7169	irresponsibly strong mediocre tankard of ale	6	decent	Last Available: "2014-12"
 7170	extra-diffused dry magnetized scroll case	0		Effect: "Tiki Toughness", Effect Duration: 42, Last Available: "2014-12"
 7171	vacuum-sealed jug of &quot;wine&quot;	0		Effect: "Bandersnatched", Effect Duration: 65, Last Available: "2014-12"
@@ -7073,12 +7073,12 @@
 7184	blinking The Shield of Brook	0		
 7185	blurry Red Zeppelin ticket	0		
 7186	blue twirling Copperhead Charm (rampant)	0		
-7187	weak acceptable unnamed cocktail	2	good	
+7187	acceptable weak unnamed cocktail	2	good	
 7188	tumbling handful of tips	0		
 7189	ghostly lightning-fast unrequired jacket	0		Initiative: +40
 7190	jittery ruddy tommy gun	0		Maximum HP Percent: +40, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	narrow drum of tommy ammo	0		
-7192	tumbling pulsating throwing knife	0		
+7192	pulsating tumbling throwing knife	0		
 7193	throwing spoon	0		
 7194	throwing fork	0		
 7195	spinning extremely unsafe razor-sharp breadchucks	0		Weapon Damage Percent: 125
@@ -7092,7 +7092,7 @@
 7203	blue Saturday Night Special of terror	0		Spooky Spell Damage: +10
 7204	tumbling lynyrd snare	0		
 7205	bouncing dance instructor's fleetwood chain	0		Experience Percent (Moxie): +10
-7206	special artisanal Green Manalishi	3	EPIC	Effect: "Become Intensely interested", Effect Duration: 50
+7206	artisanal special Green Manalishi	3	EPIC	Effect: "Become Intensely interested", Effect Duration: 50
 7207	red auspicious blade	0		Item Drop: +10
 7208	fire of unknown origin	0		
 7209	eagle's milk	1	awesome	
@@ -7100,9 +7100,9 @@
 7211	non-enhanced ionized one pill	0		Effect: "Red-Shirted Escort", Effect Duration: 29
 7212	red skewed Jefferson wings of the pedagogue	0		Experience: +3
 7213	ghostly fleetwood macaroni	0		
-7214	ghostly upside-down cheesy eagle sauce	0		
+7214	upside-down ghostly cheesy eagle sauce	0		
 7215	small normal teal fleetwood mac 'n' cheese	2	good	
-7216	jittery skewed lynyrd skin	0		
+7216	skewed jittery lynyrd skin	0		
 7217	prompt lynyrdskin cap	0		Adventures: +3, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	lynyrdskin tunic	0		Item Drop: +5
 7219	tumbling lynyrdskin breeches of the pedagogue	0		Experience: +3, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
@@ -7115,8 +7115,8 @@
 7226	lime green tea for one	1	EPIC	
 7227	hand-crafted bottle of Evermore	3	EPIC	
 7228	box	0		
-7229	artisanal high-proof squat wine	9	EPIC	
-7230	bad practically non-alcoholic rum	1	decent	
+7229	high-proof artisanal squat wine	9	EPIC	
+7230	practically non-alcoholic bad rum	1	decent	
 7231	mediocre fuchsia Murderer's Punch	3	decent	
 7232	delicious bite-sized velvet cake	1	awesome	
 7233	double-alkaline letter	0		Effect: "Corruption of Wretched Wally", Effect Duration: 51
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	lousy watered-down spinning mini-martini	2	decent	
+7255	watered-down lousy spinning mini-martini	2	decent	
 7256	smoke grenade	0		
 7257	denatured pulsating molotov soda	1	crappy	
 7258	chilled aerosolized pile of ashes	0		Effect: "Really Deep Breath", Effect Duration: 59
@@ -7152,7 +7152,7 @@
 7263	photograph of a dog	0		
 7264	upside-down photograph of a nugget	0		
 7265	wobbly photograph of an ostrich egg	0		
-7266	mirror red disposable instant camera	0		
+7266	red mirror disposable instant camera	0		
 7267	purple rosy-cheeked studded wicked supercool Sneaky Pete's jacket (collar popped)	0		Moxie Percent: +20, Spell Damage: +5, Damage Absorption: +80, Maximum HP Percent: +30, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
@@ -7178,7 +7178,7 @@
 7289	arcane researcher's Newton's Rosewater's amok putter	0		Mysticality Percent: +30, Experience (Mysticality): +3, Experience Percent (Mysticality): +10
 7290	normal amok pudding	3	good	
 7291	yellow deactivated putty buddy	0		
-7292	mirror purple putty coat	0		Familiar Weight: +5
+7292	purple mirror putty coat	0		Familiar Weight: +5
 7293	pressed mirror can of V-11	0		Effect: "Night Vision", Effect Duration: 18, Last Available: "2014-03"
 7294	smelly beefcake's elevennis shoes	0		Muscle: +25, Stench Spell Damage: +10, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
@@ -7201,7 +7201,7 @@
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	twirling box of hickory chips	0		Familiar Weight: +5
 7314	mirror poppet	0		
-7315	pulsating narrow rickety rocking horse	0		
+7315	narrow pulsating rickety rocking horse	0		
 7316	jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	greasy crafty hardy ghost of a necklace	0		Maximum HP: +50, Maximum MP: +10, Sleaze Spell Damage: +10
@@ -7211,7 +7211,7 @@
 7322	alkaline non-colloidal Stephen's secret formula	0		Effect: "Ichorous Eyesight", Effect Duration: 58
 7323	groovy Jacob's rung of the bloodbag	0		Moxie Percent: +10, Maximum HP: +100
 7324	boiled battery	1		
-7325	watered-down tolerable bouncing blurry snakebite	2	good	
+7325	tolerable watered-down bouncing blurry snakebite	2	good	
 7326	Da Vinci's rubber ribcage of the boozehound	0		Experience (Mysticality): +5, Booze Drop: +100, Damage Reduction: 7
 7327	pickled synthetic marrow	1		Effect: "Dancing Prowess", Effect Duration: 5
 7328	quadruple-concentrated blurry skewed twirling funny bone	0		Effect: "Amorous Avarice", Effect Duration: 20
@@ -7220,7 +7220,7 @@
 7331	toothsome blinking gunky chicken	4	awesome	
 7332	bouncing doll head of the pedagogue	0		Experience: +3
 7333	narrow droopy doll eye	0		
-7334	lime green upside-down voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
+7334	upside-down lime green voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	shaking inspector's savvy paddle-ball	0		Mysticality Percent: +20, Item Drop: +15
 7336	deionized electrified blurry sound effects record	0		Effect: "Alacri Tea", Effect Duration: 56
 7337	jittery alphabet block	0		
@@ -7234,12 +7234,12 @@
 7345	fuchsia ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	purple manspreader's veiny ghost toga	0		Maximum HP: +10, Monster Level: +10
-7348	moldy huge squat sheet cake	7	crappy	
+7348	huge moldy squat sheet cake	7	crappy	
 7349	squat ghost key	0		
 7350	mirror picture of you	0		
 7351	Usain Bolt's sage Staff of the Electric Range of Tarzan	0		Mysticality Percent: +10, Experience (Muscle): +3, Initiative: +80
 7352	half-sized stale bouncing deluxe layer cake	2	decent	
-7353	green wobbly chunk of hot iron	0		
+7353	wobbly green chunk of hot iron	0		
 7354	mediocre red-hot boilermaker	4	decent	
 7355	Jeselnik's coal shovel	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	double-flattened non-moist anodized hot coal	0		Effect: "Mer-kinny Flavor", Effect Duration: 46
@@ -7258,7 +7258,7 @@
 7369	modified concentrated fuchsia mangled finger	0		Effect: "Voracious Gorging", Effect Duration: 34
 7370	practically non-alcoholic mediocre Psychotic Train wine	1	decent	
 7371	narrow crazy hobo notebook	0		
-7372	special spoiled pie man was not meant to eat	3	crappy	Effect: "Stop the Presses!", Effect Duration: 25
+7372	spoiled special pie man was not meant to eat	3	crappy	Effect: "Stop the Presses!", Effect Duration: 25
 7373	Temple Grandin's sommelier's towel	0		Familiar Weight: +7
 7374	tarnished tastevin of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 7375	normal actual tapas	3	good	
@@ -7273,7 +7273,7 @@
 7384	pickled narrow Gene Tonic: Dude	0		Effect: "Altered Wavelengths", Effect Duration: 53, Last Available: "2014-04"
 7385	double-chilled Gene Tonic: Beast	0		Effect: "Hairy Palms", Effect Duration: 54, Last Available: "2014-04"
 7386	quadruple-quantum altered Gene Tonic: Construct	0		Effect: "Faboooo", Effect Duration: 13, Last Available: "2014-04"
-7387	vacuum-sealed ionized spinning red Gene Tonic: Undead	0		Effect: "Superheroic", Effect Duration: 57, Last Available: "2014-04"
+7387	vacuum-sealed ionized red spinning Gene Tonic: Undead	0		Effect: "Superheroic", Effect Duration: 57, Last Available: "2014-04"
 7388	energized galvanized dry mirror Gene Tonic: Humanoid	0		Effect: "Big Meat Big Prizes", Effect Duration: 29, Last Available: "2014-04"
 7389	cold-filtered Gene Tonic: Insect	0		Effect: "Perception", Effect Duration: 33, Last Available: "2014-04"
 7390	unsweetened Gene Tonic: Hippy	0		Effect: "Stogied", Effect Duration: 20, Last Available: "2014-04"
@@ -7305,7 +7305,7 @@
 7416	maroon Steam Card: DemonStar (#2)	0		
 7417	Steam Card: DemonStar (#3)	0		
 7418	Steam Card: Jackass Plumber (#1)	0		
-7419	ghostly skewed Steam Card: Jackass Plumber (#2)	0		
+7419	skewed ghostly Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	ghostly pencil thin mushroom	0		Last Available: "2014-05"
 7422	yellow Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
@@ -7324,37 +7324,37 @@
 7435	quadruple-quantum Stemonitis Staticus mushroom	0		Effect: "Feline Ferocity", Effect Duration: 21, Last Available: "2014-05"
 7436	triple-electrified irradiated bouncing Tremella Tarantella mushroom	0		Effect: "Disco Inferno", Effect Duration: 68, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	decent shaking narrow Beefy Crunch Pastaco	4	good	Last Available: "2014-05"
+7438	decent narrow shaking Beefy Crunch Pastaco	4	good	Last Available: "2014-05"
 7439	low-calorie normal Brain Food Pastaco	1	good	Last Available: "2014-05"
 7440	decent mirror Cool Brunch Pastaco	4	good	Last Available: "2014-05"
 7441	moldy super-sized gray Medical Pastaco	5	crappy	Last Available: "2014-05"
 7442	normal small Energy Buzz Pastaco	2	good	Last Available: "2014-05"
 7443	fancy adequate Ludovico Pastaco	3	good	Effect: "Sugar Smacks", Effect Duration: 25, Last Available: "2014-05"
-7444	triple-distilled drinkable overpowering mushroom wine	10	good	Last Available: "2014-05"
+7444	drinkable triple-distilled overpowering mushroom wine	10	good	Last Available: "2014-05"
 7445	artisanal complex mushroom wine	3	super EPIC	Last Available: "2014-05"
 7446	weak perfectly mixed smooth mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
-7447	lousy practically non-alcoholic fancy blood-red mushroom wine	1	decent	Effect: "Hot Hands", Effect Duration: 30, Last Available: "2014-05"
+7447	fancy practically non-alcoholic lousy blood-red mushroom wine	1	decent	Effect: "Hot Hands", Effect Duration: 30, Last Available: "2014-05"
 7448	watered-down drinkable buzzing mushroom wine	2	good	Last Available: "2014-05"
 7449	delicious practically non-alcoholic swirling mushroom wine	1	awesome	Last Available: "2014-05"
 7450	normal wobbly Taco Dan's Basic Taco Dan Taco	3	good	Last Available: "2014-05"
 7451	normal Taco Dan's Taco Fish Fish Taco	4	good	Last Available: "2014-05"
 7452	pulsating Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	practically non-alcoholic lousy narrow regular-size brogurt	1	decent	Last Available: "2014-05"
-7454	smooth strong purple super-size brogurt	5	awesome	Last Available: "2014-05"
-7455	high-proof artisanal special broberry brogurt	8	EPIC	Effect: "Elvish", Effect Duration: 35, Last Available: "2014-05"
+7453	lousy practically non-alcoholic narrow regular-size brogurt	1	decent	Last Available: "2014-05"
+7454	strong smooth purple super-size brogurt	5	awesome	Last Available: "2014-05"
+7455	special artisanal high-proof broberry brogurt	8	EPIC	Effect: "Elvish", Effect Duration: 35, Last Available: "2014-05"
 7456	acceptable irresponsibly strong fuchsia brocolate brogurt	7	good	Last Available: "2014-05"
 7457	mediocre blue French bronilla brogurt	3	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	pulsating jittery Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	bouncing industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	strapping Brogre brorts	0		Muscle: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	strapping Brogre brorts	0		Muscle: +5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	Brogre brolo shirt of incineration	0		Hot Spell Damage: +50, Last Available: "2014-05"
-7464	Jeselnik's Brogre bucket hat	0		Sleaze Damage: +25, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	Jeselnik's Brogre bucket hat	0		Sleaze Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	huge Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	Fonzie's 8-billed baseball cap of dire peril of incineration	0		Experience (Moxie): +1, Weapon Damage: +20, Hot Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	Fonzie's 8-billed baseball cap of dire peril of incineration	0		Experience (Moxie): +1, Weapon Damage: +20, Hot Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	wobbly huge zippy rosewater-soaked smelly extremely wet T-shirt	0		Stench Spell Damage: +10, Stench Resistance: +3, Initiative: +20, Last Available: "2014-05"
 7470	gray nasty shrimp fork of the glutton of the early riser	0		Stench Damage: +5, Food Drop: +100, Adventures: +7, Last Available: "2014-05"
 7471	super-irradiated dry tumbling BROS Energy Drink	0		Effect: "Craft Tea", Effect Duration: 69, Last Available: "2014-05"
@@ -7365,10 +7365,10 @@
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	liquefied enhanced Meat-inflating powder	0		Effect: "Your Favorite Flavor", Effect Duration: 17, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
-7479	liquefied bouncing upside-down sugar fairy	0		Effect: "Buzzard Breath", Effect Duration: 39, Last Available: "2014-05"
+7479	liquefied upside-down bouncing sugar fairy	0		Effect: "Buzzard Breath", Effect Duration: 39, Last Available: "2014-05"
 7480	triple-pressed quantum sugar bunny	0		Effect: "Flame-Retardant Trousers", Effect Duration: 37, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	tolerable watered-down fancy bouncing Rompedores de Fantasmas	2	good	Effect: "Puddingface", Effect Duration: 40
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	tolerable fancy watered-down bouncing Rompedores de Fantasmas	2	good	Effect: "Puddingface", Effect Duration: 40
 7483	perfectly mixed La Fantasma y La Oscuridad	3	EPIC	
 7484	high-proof bad Fantasma en la M&aacute;quina	9	decent	
 7485	loosening powder	0		
@@ -7415,7 +7415,7 @@
 7526	bouncing weird space book	0		Last Available: "2014-05"
 7527	upside-down alien force field disruptor bean	0		Last Available: "2014-05"
 7528	huge government-issued night-vision goggles of the empath of the glutton	0		Familiar Weight: +5, Food Drop: +100, Single Equip, Last Available: "2014-05"
-7529	special bite-sized spoiled loaf of alien bread	1	crappy	Effect: "Egg-stra Arm", Effect Duration: 15, Last Available: "2014-05"
+7529	bite-sized spoiled special loaf of alien bread	1	crappy	Effect: "Egg-stra Arm", Effect Duration: 15, Last Available: "2014-05"
 7530	decent small spinning grilled cheese sandwich	2	good	Last Available: "2014-05"
 7531	modified alien protein powder	1	good	Last Available: "2014-05"
 7532	bad rocket fuel	3	decent	Last Available: "2014-05"
@@ -7425,26 +7425,26 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	blinking twitching space egg	0		Last Available: "2014-05"
 7538	jittery ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	skewed avaricious space beast fur hat	0		Meat Drop: +30, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	pulsating horrifying space beast fur pants	0		Spooky Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	skewed avaricious space beast fur hat	0		Meat Drop: +30, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	pulsating horrifying space beast fur pants	0		Spooky Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	medical-grade space beast fur whip	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-05"
 7542	wobbly skewed space invader	0		Last Available: "2014-05"
-7543	smelly space heater of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	smelly space heater of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
 7545	smooth purple space port	3	awesome	Last Available: "2014-05"
 7546	hardy wholesome space needle	0		Maximum HP Percent: +10, Maximum HP: +50, Last Available: "2014-05"
 7547	nitrogenated nitrogenated squat buffed alien drugs	0		Effect: "Bloody-minded", Effect Duration: 68, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
-7549	non-unsweetened pickled narrow green huge ash soda	0		Effect: "Bread-Lined", Effect Duration: 65, Last Available: "2014-06"
+7549	non-unsweetened pickled green narrow huge ash soda	0		Effect: "Bread-Lined", Effect Duration: 65, Last Available: "2014-06"
 7550	liquefied activated lime green liquid smoke	0		Effect: "Some Cheese with Your Wine", Effect Duration: 35, Last Available: "2014-06"
 7551	pressed liquefied dollop of barbecue sauce	0		Effect: "Is This Your Card?", Effect Duration: 40, Last Available: "2014-06"
 7552	flattened wet bowl of marinade	0		Effect: "Pisces Rising", Effect Duration: 56, Last Available: "2014-06"
 7553	upside-down shaker of dry rub	0		Last Available: "2014-06"
-7554	pressed cold-filtered bouncing tumbling mirror bottle of lighter fluid	0		Effect: "Kissed By Fire", Effect Duration: 11, Last Available: "2014-06"
+7554	pressed cold-filtered mirror bouncing tumbling bottle of lighter fluid	0		Effect: "Kissed By Fire", Effect Duration: 11, Last Available: "2014-06"
 7555	lime green page	0		
 7556	blurry elephant gift	0		
 7557	nitrogenated tumbling blood cells	0		Effect: "Marbles in Your Mouth", Effect Duration: 39
-7558	practically non-alcoholic acceptable wine	1	good	
+7558	acceptable practically non-alcoholic wine	1	good	
 7559	vacuum-sealed pressed gummi turtle	0		Effect: "Frozen Hands", Effect Duration: 52
 7560	pulsating turtle-shaped rock	0		
 7561	irradiated wet giraffe-necked turtle	0		Effect: "Lifted Spirits", Effect Duration: 19
@@ -7456,7 +7456,7 @@
 7567	Chroner	0		
 7568	double-paned experienced Time Lord Badge of Honor of the sweet-tooth	0		Experience: +2, Cold Resistance: +5, Candy Drop: +100
 7569	thinker's Time Bandit Badge of Courage of Calamity Jane of the boozehound	0		Mysticality: +10, Critical Hit Percent: +15, Booze Drop: +100
-7570	colloidal polarized olive bouncing Friendliness Beverage	0		Effect: "Snobby", Effect Duration: 50
+7570	colloidal polarized bouncing olive Friendliness Beverage	0		Effect: "Snobby", Effect Duration: 50
 7571	lightning-fast family-friendly silent pea shooter	0		Sleaze Resistance: +1, Initiative: +40
 7572	normal D roll	3	good	
 7573	friendly quilted kiwi beak	0		Damage Absorption: +40, Familiar Weight: +3
@@ -7468,24 +7468,24 @@
 7579	twitching time capsule	0		
 7580	twisted purple huge liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	spoiled tiny rack of dinosaur ribs	1	crappy	
-7583	watered-down artisanal scotch on the rocks	2	super ultra EPIC	
+7582	tiny spoiled rack of dinosaur ribs	1	crappy	
+7583	artisanal watered-down scotch on the rocks	2	super ultra EPIC	
 7584	twirling Jack Frost's Annie Oakley's yabba dabba doo rag	0		Critical Hit Percent: +20, Cold Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	experienced wooly loincloth of the glutton	0		Experience: +2, Food Drop: +100, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	distilled lousy glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
+7589	lousy distilled glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
 7590	bad cup of &quot;tea&quot;	4	decent	Last Available: "2014-07"
 7591	practically non-alcoholic bad thermos of &quot;whiskey&quot;	1	decent	Last Available: "2014-07"
 7592	aged skewed Lucky Lindy	4	awesome	Last Available: "2014-07"
 7593	practically non-alcoholic bad Bee's Knees	1	decent	Last Available: "2014-07"
-7594	drinkable watered-down Sockdollager	2	good	Last Available: "2014-07"
+7594	watered-down drinkable Sockdollager	2	good	Last Available: "2014-07"
 7595	bad Ish Kabibble	4	decent	Last Available: "2014-07"
-7596	tolerable special shaking Hot Socks	3	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2014-07"
+7596	special tolerable shaking Hot Socks	3	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2014-07"
 7597	aged tumbling Phonus Balonus	4	awesome	Last Available: "2014-07"
 7598	hand-crafted green Flivver	4	EPIC	Last Available: "2014-07"
-7599	drinkable practically non-alcoholic Sloppy Jalopy	1	good	Last Available: "2014-07"
+7599	practically non-alcoholic drinkable Sloppy Jalopy	1	good	Last Available: "2014-07"
 7600	altered flame	0		Effect: "Elemental Mastery", Effect Duration: 16
 7601	pickled warmed extra-altered temporary yak tattoo	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 13
 7602	quantum colloidal ghostly Fitspiration&trade; poster	0		Effect: "Angry Bone", Effect Duration: 32
@@ -7495,7 +7495,7 @@
 7606	non-concentrated tarnished steampunk potion	0		Effect: "Red Door Syndrome", Effect Duration: 53
 7607	wet vial of swamp vapors	0		Effect: "Protection from Bad Stuff", Effect Duration: 24
 7608	super-ionized ionized turtle mud	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 63
-7609	quadruple-vacuum-sealed green mirror Redeye&trade; Eyedrops	0		Effect: "All Branned Up", Effect Duration: 59
+7609	quadruple-vacuum-sealed mirror green Redeye&trade; Eyedrops	0		Effect: "All Branned Up", Effect Duration: 59
 7610	triple-Vulcanized extra-diffused tumbling Dweebisol&trade; inhaler	0		Effect: "Industrial Strength Starch", Effect Duration: 54
 7611	pressed huge Lewd Lemmy Hair Oil	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 25
 7612	dry shaking tomato soup poster	0		Effect: "All Branned Up", Effect Duration: 56
@@ -7504,7 +7504,7 @@
 7615	magnetized blinking pygmy adder oil	0		Effect: "Hyperoffended", Effect Duration: 36
 7616	vacuum-sealed jittery pygmy witchhazel	0		Effect: "Ooh, Sour!", Effect Duration: 35
 7617	frozen short deposition	0		Effect: "Here's Mud in Your Eye", Effect Duration: 34
-7618	pickled boiled tumbling blurry skewed straw pole	0		Effect: "Tiki Temerity", Effect Duration: 66
+7618	pickled boiled blurry skewed tumbling straw pole	0		Effect: "Tiki Temerity", Effect Duration: 66
 7619	alkaline dry super-ionized copperhead potion	0		Effect: "Human-Horror Hybrid", Effect Duration: 60
 7620	denatured lime green ninja fear powder	0		Effect: "Spooky Weapon", Effect Duration: 47
 7621	enhanced huge ninja eyeblack	0		Effect: "Can Has Cyborger", Effect Duration: 35
@@ -7528,7 +7528,7 @@
 7639	gray blurry reassuring oil shell	0		Spooky Resistance: +1, Class: "Turtle Tamer"
 7640	gravedigger's flame-wreathed beefy turtle shell	0		Muscle: +10, Hot Spell Damage: +10, Spooky Damage: +10, Class: "Turtle Tamer"
 7641	shocked shell	0		Class: "Turtle Tamer"
-7642	teal spinning ingot turtle	0		
+7642	spinning teal ingot turtle	0		
 7643	duty umbrella	0		
 7644	pool skimmer	0		
 7645	life preserver	0		
@@ -7573,7 +7573,7 @@
 7684	foul-smelling Time Lord Participation Mug	0		Stench Damage: +10
 7685	educational Time Bandit Time Towel of the scaredy-cat	0		Experience: +1, Monster Level: -15
 7686	rosewater-soaked sage Caveman Dan's favorite rock of doom	0		Mysticality Percent: +10, Spooky Spell Damage: +50, Stench Resistance: +3, Single Equip
-7687	modified irradiated jittery lime green dog ointment	0		Effect: "Mystic Circle", Effect Duration: 48
+7687	modified irradiated lime green jittery dog ointment	0		Effect: "Mystic Circle", Effect Duration: 48
 7688	bouncing MacGyver's gumshoes of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Single Equip
 7689	mirror nippy sage flapper floppers	0		Mysticality Percent: +10, Cold Damage: +10, Single Equip
 7690	jittery rosewater-soaked extremely unsafe sneakeasies	0		Weapon Damage Percent: +100, Stench Resistance: +3, Single Equip
@@ -7581,7 +7581,7 @@
 7692	smartaleck's hand whip of the brute	0		Muscle Percent: +30, Moxie Percent: +30, Item Drop: +5, Last Available: "2014-08"
 7693	bouncing teal chilly Jim Carey's steel-toed glow-in-the-dark necklace	0		Damage Reduction: 9, Monster Level: +25, Cold Damage: +5, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	friendly quilted brawny cap gun	0		Muscle Percent: +20, Damage Absorption: +40, Familiar Weight: +3, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	friendly quilted brawny cap gun	0		Muscle Percent: +20, Damage Absorption: +40, Familiar Weight: +3, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	maroon coward's wizardly cassette player	0		Mysticality: +25, Monster Level: -20, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	blinking rubber spider	0		Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	pulsating spinning LCD game: Garbage River	0		Last Available: "2014-08"
 7705	lime green LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
-7707	deionized tarnished modified shaking olive rubber nubbin	0		Effect: "In Tuna", Effect Duration: 32, Last Available: "2014-08"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7707	deionized tarnished modified olive shaking rubber nubbin	0		Effect: "In Tuna", Effect Duration: 32, Last Available: "2014-08"
 7708	yellow sharpshooter's extremely unsafe rubber cape	0		Weapon Damage Percent: +100, Critical Hit Percent: +10, Last Available: "2014-08"
-7709	blinking huge Temple Grandin's steel-toed forbidden razor-sharp Thor's Pliers	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Damage Reduction: 9, Familiar Weight: +7, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	blinking huge Temple Grandin's steel-toed forbidden razor-sharp Thor's Pliers	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Damage Reduction: 9, Familiar Weight: +7, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	irradiated modified candy UFOs	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 69
 7711	lard-coated beefcake's water wings for babies	0		Muscle: +25, Sleaze Spell Damage: +25
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	enchanted decent huge Strix stix	3	good	Effect: "Executive Greed", Effect Duration: 15
 7714	teal veiny padded vampire pellet of mayonnaise	0		Damage Absorption: +20, Maximum HP: +10, Sleaze Spell Damage: +50
 7715	acceptable non-aged vinegar	4	good	
@@ -7612,13 +7612,13 @@
 7723	Chroner cross	0		
 7724	healthy pteruges	0		Maximum HP Percent: +20, Familiar Effect: "1xFairy, atk, cap 25"
 7725	tarnished Bruno's blessing of Mars	0		Effect: "Big Flaming Whip", Effect Duration: 47
-7726	galvanized galvanized spinning maroon bouncing Dennis's blessing of Minerva	0		Effect: "Smoking like a Bandit", Effect Duration: 62
+7726	galvanized galvanized maroon spinning bouncing Dennis's blessing of Minerva	0		Effect: "Smoking like a Bandit", Effect Duration: 62
 7727	electrified double-cold-filtered polarized spinning Burt's blessing of Bacchus	0		Effect: "Fit To Be Tide", Effect Duration: 26
 7728	ionized yellow Freddie's blessing of Mercury	0		Effect: "Amorphous Cheer", Effect Duration: 34
-7729	twirling jittery Chroner trigger	0		
+7729	jittery twirling Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
-7732	squat mirror Black Bart's Booty	0		Skill: "Pirate Bellow"
+7732	mirror squat Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	purple Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	huge teal Xiblaxian polymer	0		Last Available: "2014-09"
 7735	huge Xiblaxian alloy	0		Last Available: "2014-09"
@@ -7633,17 +7633,17 @@
 7744	lime green Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
 7746	wobbly Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
-7747	narrow mirror Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
+7747	mirror narrow Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
 7750	ghostly Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	squat Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	teal Xiblaxian xeno-detection goggles of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-09"
-7753	wobbly chaotic Xiblaxian stealth cowl of the businessman	0		Spell Critical Percent: +10, Meat Drop: +50, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	wobbly chaotic Xiblaxian stealth cowl of the businessman	0		Spell Critical Percent: +10, Meat Drop: +50, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	spinning wobbly chaotic vibrating Xiblaxian stealth trousers	0		Maximum MP Percent: +10, Spell Critical Percent: +10, Last Available: "2014-09"
 7755	sizzling thinker's Xiblaxian stealth vest	0		Mysticality: +10, Hot Damage: +10, Last Available: "2014-09"
 7756	decent half-sized Xiblaxian ultraburrito	2	good	Last Available: "2014-09"
-7757	special aged watered-down twirling Xiblaxian space-whiskey	2	awesome	Effect: "Human-Constellation Hybrid", Effect Duration: 30, Last Available: "2014-09"
+7757	watered-down special aged twirling Xiblaxian space-whiskey	2	awesome	Effect: "Human-Constellation Hybrid", Effect Duration: 30, Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	modified They liver	0		Effect: "Gutterminded", Effect Duration: 26, Last Available: "2014-09"
 7760	delicious They liver popsicle	3	awesome	Last Available: "2014-09"
@@ -7669,12 +7669,12 @@
 7780	supercharged heavy-duty clipboard of temperance of the glutton	0		Maximum MP Percent: +30, Sleaze Resistance: +5, Food Drop: +100, Damage Reduction: 8, Last Available: "2014-10"
 7781	green flame-retardant energetic brawny battery-powered drill of Calamity Jane	0		Muscle Percent: +20, Maximum MP Percent: +20, Critical Hit Percent: +15, Hot Resistance: +1, Last Available: "2014-10"
 7782	bland limp broccoli	3	decent	Last Available: "2014-10"
-7783	yellow hat of dire peril of the bloodbag of the detective	0		Weapon Damage: +20, Maximum HP: +100, Item Drop: +20, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	yellow hat of dire peril of the bloodbag of the detective	0		Weapon Damage: +20, Maximum HP: +100, Item Drop: +20, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	deionized triple-flattened narrow monkey barf	0		Effect: "On the Shoulders of Giants", Effect Duration: 61, Last Available: "2014-10"
 7785	alkaline magnetized candy	0		Effect: "Cautious Prowl", Effect Duration: 31, Last Available: "2014-10"
 7786	teal asbestos-lined vibrating jangly bracelet of the sweet-tooth	0		Maximum MP Percent: +10, Hot Resistance: +5, Candy Drop: +100, Last Available: "2014-10"
-7787	horrifying cuddly teddy bear	0		Spooky Damage: +25, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
-7788	shaking jittery huge ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7787	horrifying cuddly teddy bear	0		Spooky Damage: +25, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7788	huge jittery shaking ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	twirling first-aid pouch of the wise owl of the blizzard	0		Mysticality: +20, Cold Spell Damage: +25, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	triple-oxidized dry airborne mutagen	0		Effect: "Initiative and Let Die", Effect Duration: 19, Last Available: "2014-10"
@@ -7682,7 +7682,7 @@
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	bouncing Armory keycard	0		Last Available: "2014-10"
 7795	spoiled twirling initiative shawarma	3	crappy	Last Available: "2014-10"
-7796	bite-sized spoiled warm war shawarma	1	crappy	Last Available: "2014-10"
+7796	spoiled bite-sized warm war shawarma	1	crappy	Last Available: "2014-10"
 7797	adequate gray karma shawarma	3	good	Last Available: "2014-10"
 7798	bad special Jungle Juice	4	decent	Effect: "Ruby-ous", Effect Duration: 40, Last Available: "2014-10"
 7799	artisanal Amnesiac Ale	4	EPIC	Last Available: "2014-10"
@@ -7696,7 +7696,7 @@
 7807	TI-9000 calculator	0		
 7808	skewed unused soap	0		
 7809	squat impure gasoline	0		
-7810	squat upside-down yellow Z-Bone steak	0		
+7810	squat yellow upside-down Z-Bone steak	0		
 7811	viral DNA	0		
 7812	upside-down tarnished bottlecap	0		
 7813	rotten huge seared dino steak	3	crappy	
@@ -7713,7 +7713,7 @@
 7824	auspicious iShield of the brazier of the boozehound	0		Hot Spell Damage: +25, Item Drop: +10, Booze Drop: +100, Damage Reduction: 6
 7825	supercharged earbuds of vim and vigor of courage	0		Maximum HP Percent: +50, Maximum MP Percent: +30, Spooky Resistance: +3, Single Equip
 7826	iFlail of courage of the glutton of Flo-Jo	0		Spooky Resistance: +3, Food Drop: +100, Initiative: +100
-7827	moldy miniature blurry unidentifiable dried fruit	2	crappy	
+7827	miniature moldy blurry unidentifiable dried fruit	2	crappy	
 7828	smooth flat cider	3	awesome	
 7829	lime green Van der Graaf rock-hard trench lighter of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-10"
 7830	Vulcanized super-energized anodized experimental serum P-00	0		Effect: "Wet Willied", Effect Duration: 21, Last Available: "2014-10"
@@ -7736,15 +7736,15 @@
 7847	modified aerosolized ruby on canes	0		Effect: "You Know Where to Go", Effect Duration: 39, Last Available: "2014-12"
 7848	rotten petit fortran	3	crappy	Last Available: "2014-12"
 7849	rotten java cookie	3	crappy	Last Available: "2014-12"
-7850	decent fancy miniature cookie cookie	2	good	Effect: "Tea-hee", Effect Duration: 20, Last Available: "2014-12"
+7850	miniature fancy decent cookie cookie	2	good	Effect: "Tea-hee", Effect Duration: 20, Last Available: "2014-12"
 7851	purple plastic exo-suited miner of doom	0		Spooky Spell Damage: +50, Last Available: "2014-12"
 7852	coward's plastic semi-autonomous drill unit	0		Monster Level: -20, Last Available: "2014-12"
 7853	pulsating plastic ambulatory robo-minecart of the businessman	0		Meat Drop: +50, Last Available: "2014-12"
 7854	wobbly healthy plastic Crimbot	0		Maximum HP Percent: +20, Last Available: "2014-12"
 7855	Da Vinci's plastic Crimbomega	0		Experience (Mysticality): +5, Last Available: "2014-12"
 7856	liquefied concentrated pulsating flask of mining oil	0		Effect: "Cold Blooded", Effect Duration: 34, Last Available: "2014-12"
-7857	hardy radiation-resistant helmet	0		Maximum HP: +50, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	arcane researcher's servo-assisted exo-pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	hardy radiation-resistant helmet	0		Maximum HP: +50, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	arcane researcher's servo-assisted exo-pants	0		Experience Percent (Mysticality): +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	ghostly rosewater-soaked arcane researcher's high-energy mining laser	0		Experience Percent (Mysticality): +10, Stench Resistance: +3, Last Available: "2014-12"
 7860	bouncing blinking peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7752,12 +7752,12 @@
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	wobbly Petite Paintbrush	0		Adventures: +1
 7865	cyan Crimbot schematic: Gun Face	0		Last Available: "2014-12"
-7866	twirling blue Crimbot schematic: Big Head	0		Last Available: "2014-12"
+7866	blue twirling Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	bouncing Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	blurry Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
-7871	purple pulsating Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
+7871	pulsating purple Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	skewed Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
@@ -7789,7 +7789,7 @@
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	blinking Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
-7903	squat green Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
+7903	green squat Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	olive Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	blinking recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
@@ -7804,15 +7804,15 @@
 7915	chilled quadruple-ionized Take Eleven Bar	0		Effect: "Nightlit", Effect Duration: 49
 7916	mimeplasm	0		
 7917	deionized polarized corrupted BOOterfinger	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 33
-7918	triple-flattened chilled yellow tumbling Moonds	0		Effect: "Big Flaming Whip", Effect Duration: 37
-7919	energized galvanized shaking bouncing fuchsia Big Punk	0		Effect: "Antarctic Memories", Effect Duration: 42
+7918	triple-flattened chilled tumbling yellow Moonds	0		Effect: "Big Flaming Whip", Effect Duration: 37
+7919	energized galvanized fuchsia bouncing shaking Big Punk	0		Effect: "Antarctic Memories", Effect Duration: 42
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	blurry turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	artisanal weak upside-down huge Friendly Turkey	2	EPIC	Last Available: "2014-11"
+7922	weak artisanal huge upside-down Friendly Turkey	2	EPIC	Last Available: "2014-11"
 7923	artisanal blurry ghostly yellow Agitated Turkey	3	EPIC	Last Available: "2014-11"
 7924	bad bouncing Ambitious Turkey	3	decent	Last Available: "2014-11"
 7925	moldy neutron lollipop	4	crappy	Last Available: "2014-12"
-7926	fortified acceptable teal shaking gamma nog	5	good	Last Available: "2014-12"
+7926	fortified acceptable shaking teal gamma nog	5	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
@@ -7841,7 +7841,7 @@
 7959	blinking letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	grievous arcane researcher's Staff of Ed of courage of the cheetah	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Spooky Resistance: +3, Initiative: +60
-7962	skewed squat Eye of Ed	0		
+7962	squat skewed Eye of Ed	0		
 7963	amulet	0		
 7964	lime green greedy Staff of Fats	0		Meat Drop: +20
 7965	jittery Holy MacGuffin	0		
@@ -7880,18 +7880,18 @@
 7998	dried powder	1		Last Available: "2015-12"
 7999	cold-filtered jittery choco-Crimbot	0		Effect: "Fury of the Bells", Effect Duration: 36, Last Available: "2014-12"
 8000	triple-electrified smart watch	0		Effect: "Cat-Alyzed", Effect Duration: 13, Last Available: "2014-12"
-8001	frozen lime green blurry augmented-reality shades	0		Effect: "Scorpio Rising", Effect Duration: 57, Last Available: "2014-12"
-8002	upside-down scorching toy Crimbot mega face	0		Hot Damage: +25, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	thinker's toy Crimbot power glove	0		Mysticality: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	twirling nippy toy Crimbot super fist	0		Cold Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	narrow steel-toed toy Crimbot rocket legs	0		Damage Reduction: 9, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8001	frozen blurry lime green augmented-reality shades	0		Effect: "Scorpio Rising", Effect Duration: 57, Last Available: "2014-12"
+8002	upside-down scorching toy Crimbot mega face	0		Hot Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	thinker's toy Crimbot power glove	0		Mysticality: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	twirling nippy toy Crimbot super fist	0		Cold Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	narrow steel-toed toy Crimbot rocket legs	0		Damage Reduction: 9, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	magnetized blinking Crimbot battery	0		Effect: "All Branned Up", Effect Duration: 62, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	spinning toasty Crimbomega drive chain of doom of the detective	0		Hot Damage: +5, Spooky Spell Damage: +50, Item Drop: +20, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	spinning toasty Crimbomega drive chain of doom of the detective	0		Hot Damage: +5, Spooky Spell Damage: +50, Item Drop: +20, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	bouncing Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,7 +7899,7 @@
 8017	diffused aerosolized flask of tainted mining oil	0		Effect: "Tenacity of the Snapper", Effect Duration: 17, Last Available: "2014-12"
 8018	modified flattened and rain stick	0		Effect: "Sweet Tooth", Effect Duration: 42
 8019	huge Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	bland diet blurry Choco-Mint patty	1	decent	Last Available: "2015-01"
+8020	diet bland blurry Choco-Mint patty	1	decent	Last Available: "2015-01"
 8021	acceptable hot mint schnocolate	3	good	Last Available: "2015-01"
 8022	twisted green huge bouncing homeopathic mint tea	1	awesome	Last Available: "2015-01"
 8023	narrow muscle stimulator	0		Last Available: "2015-01"
@@ -7912,11 +7912,11 @@
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	wobbly stationery set	0		Last Available: "2015-01"
 8032	calligraphy pen	0		Free Pull, Last Available: "2015-01"
-8033	ghostly huge alpine watercolor set	0		Last Available: "2015-01"
+8033	huge ghostly alpine watercolor set	0		Last Available: "2015-01"
 8034	wobbly aromatic tope&eacute; of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Familiar Effect: "3xBarrr, cap 12"
 8035	up-at-dawn miser's topiary tights	0		Meat Drop: +10, Adventures: +5
 8036	crafty topiary necktie	0		Maximum MP: +10
-8037	tiny delicious bowl of topioca	1	awesome	
+8037	delicious tiny bowl of topioca	1	awesome	
 8038	wobbly topiary skunk	0		
 8039	bouncing topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -7952,15 +7952,15 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	Jack Frost's ruddy grievous Spelunker's fedora	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Cold Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	Jack Frost's ruddy grievous Spelunker's fedora	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Cold Spell Damage: +50, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	pulsating miser's censurious resourceful Spelunker's whip	0		Maximum MP: +50, Sleaze Resistance: +3, Meat Drop: +10, Last Available: "2015-12"
-8076	rock-hard boxer's Spelunker's khakis of the blizzard	0		Muscle Percent: +10, Damage Reduction: 5, Cold Spell Damage: +25, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	rock-hard boxer's Spelunker's khakis of the blizzard	0		Muscle Percent: +10, Damage Reduction: 5, Cold Spell Damage: +25, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	tumbling LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
-8088	squat spinning jewel	0		
+8088	spinning squat jewel	0		
 8089	headless sparrow	0		
 8090	mangled squirrel	0		
 8091	rat carcass	0		
@@ -7996,9 +7996,9 @@
 8121	executive flame-retardant garland	0		Hot Resistance: +1, Meat Drop: +40, Single Equip, Last Available: "2018-12"
 8122	cyan dance instructor's smartaleck's gunnysack	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Last Available: "2018-12"
 8123	scandalous careful garibaldi	0		Monster Level: -10, Sleaze Damage: +5, Last Available: "2018-12"
-8124	inspector's personal trainer's girdle	0		Experience Percent (Muscle): +10, Item Drop: +15, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	inspector's personal trainer's girdle	0		Experience Percent (Muscle): +10, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	resourceful occult gloves	0		Spell Damage Percent: +25, Maximum MP: +50, Single Equip, Last Available: "2018-12"
-8126	mixed blurry red smithereens	1		Last Available: "2018-12"
+8126	mixed red blurry smithereens	1		Last Available: "2018-12"
 8127	pulsating wicked dance instructor's fiberglass fetish	0		Experience Percent (Moxie): +10, Spell Damage: +5, Last Available: "2018-12"
 8128	Herculean brainy fiberglass foil	0		Mysticality: +5, Experience (Muscle): +1, Last Available: "2018-12"
 8129	inspector's fiberglass fannypack of extreme caution	0		Monster Level: -25, Item Drop: +15, Single Equip, Last Available: "2018-12"
@@ -8029,7 +8029,7 @@
 8155	alkaline talisman of Horus	0		Effect: "Ironclad", Effect Duration: 32
 8156	check to the Meatsmith	0		
 8157	ghostly Skeleton Store office key	0		
-8158	red squat bone with a price tag on it	0		
+8158	squat red bone with a price tag on it	0		
 8159	bouncing half of a tooth	0		
 8160	frozen oxidized mouse skull	0		Effect: "Demonic Taint", Effect Duration: 20
 8161	moist pressed double-colloidal really thick spine	0		Effect: "Tearful, Fearful", Effect Duration: 60
@@ -8038,9 +8038,9 @@
 8164	curative slick remaindered axe	0		Moxie: +10, HP Regen Min: 3, HP Regen Max: 5
 8165	low-budget shield	0		Damage Reduction: 3
 8166	rosy-cheeked groovy cr&ecirc;epy mask	0		Moxie Percent: +10, Maximum HP Percent: +30, Familiar Effect: "spooky atk, cap 5"
-8167	miniature moldy special baguette	2	crappy	Effect: "Lifted Spirits", Effect Duration: 10
+8167	miniature special moldy baguette	2	crappy	Effect: "Lifted Spirits", Effect Duration: 10
 8168	glob of icing	0		
-8169	enhanced huge wobbly shaking ginger snaps	0		Effect: "Eyes for Miles", Effect Duration: 66
+8169	enhanced wobbly shaking huge ginger snaps	0		Effect: "Eyes for Miles", Effect Duration: 66
 8170	vacuum-sealed Vulcanized colloidal ghostly mostly-broken sunglasses	0		Effect: "Chalky White Pallor", Effect Duration: 69
 8171	smooth unflavored wine cooler	3	awesome	
 8172	carton of snake milk	1	crappy	
@@ -8056,7 +8056,7 @@
 8182	skewed maroon Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	executive bread basket	0		Meat Drop: +40
 8184	shaking Ed the Undying exhibit crate	0		
-8185	MacGyver's savvy The Crown of Ed the Undying	0		Mysticality Percent: +20, Maximum MP: +100, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	MacGyver's savvy The Crown of Ed the Undying	0		Mysticality Percent: +20, Maximum MP: +100, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	lousy fortified narrow Cherrytastrophe wine cooler	5	decent	
@@ -8065,10 +8065,10 @@
 8191	mediocre Breakfast Blast wine cooler	4	decent	
 8192	acceptable Citrus Crush wine cooler	3	good	
 8193	moldy plain bagel	3	crappy	
-8194	massive spoiled glob of cream cheese	8	crappy	
+8194	spoiled massive glob of cream cheese	8	crappy	
 8195	flavorless loaf of soda bread	3	decent	
-8196	stale tiny acceptable bagel	1	decent	
-8197	decent bite-sized standard-issue cupcake	1	good	
+8196	tiny stale acceptable bagel	1	decent	
+8197	bite-sized decent standard-issue cupcake	1	good	
 8198	flavorless ultra-deluxe cupcake	3	decent	
 8199	hypnotic breadcrumbs	0		
 8200	enchanted bland popular tart	4	decent	Effect: "Grape Expectations", Effect Duration: 25
@@ -8086,13 +8086,13 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	smelly Jim Carey's rigging rope	0		Monster Level: +25, Stench Spell Damage: +10, Last Available: "2015-04"
 8214	boiled squat nasty snuff	1	crappy	Last Available: "2015-04"
-8215	gray double-paned sewage-clogged pistol of Flo-Jo	0		Cold Resistance: +5, Initiative: +100, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	gray double-paned sewage-clogged pistol of Flo-Jo	0		Cold Resistance: +5, Initiative: +100, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	chilled irradiated beard incense	0		Effect: "The Power of Negative Thinking", Effect Duration: 57, Last Available: "2015-04"
 8217	smartaleck's perfume-soaked bandana of Calamity Jane	0		Moxie Percent: +30, Critical Hit Percent: +15, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	tasty special big toxo	5	awesome	Effect: "Cookie Backup", Effect Duration: 30, Last Available: "2015-04"
+8219	big special tasty toxo	5	awesome	Effect: "Cookie Backup", Effect Duration: 30, Last Available: "2015-04"
 8220	artisanal Lemonade-235	4	EPIC	Last Available: "2015-04"
-8221	spinning boxer's isotophat of incineration	0		Muscle Percent: +10, Hot Spell Damage: +50, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	spinning boxer's isotophat of incineration	0		Muscle Percent: +10, Hot Spell Damage: +50, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	blurry MacGyver's beefy Three Mile Island shorts	0		Muscle: +10, Maximum MP: +100, Last Available: "2015-04"
 8223	Herculean toxic mop of the sweet-tooth	0		Experience (Muscle): +1, Candy Drop: +100, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	pulsating trash net	0		Last Available: "2015-04"
 8246	stanky supercharged Dinsey mascot mask of the blizzard	0		Maximum MP Percent: +30, Cold Spell Damage: +25, Stench Spell Damage: +25, Last Available: "2015-04"
 8247	moldy huge Dinsey food-cone	3	crappy	Last Available: "2015-04"
-8248	mediocre weak Dinsey Whinskey	2	decent	Last Available: "2015-04"
+8248	weak mediocre Dinsey Whinskey	2	decent	Last Available: "2015-04"
 8249	energized adjusted wobbly fuchsia Dinsey face paint	0		Effect: "Bootyliciousness", Effect Duration: 49, Last Available: "2015-04"
 8250	blurry steel-toed fannypack of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 9, Last Available: "2015-04"
 8251	upside-down censurious chaotic steel-toed garbage sticker of the brute of the blizzard of the cheetah	0		Muscle Percent: +30, Damage Reduction: 9, Spell Critical Percent: +10, Cold Spell Damage: +25, Sleaze Resistance: +3, Initiative: +60, Last Available: "2015-04"
@@ -8141,9 +8141,9 @@
 8267	censurious sphygmayomanometer	0		Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	jittery green mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	miniature normal unappetizing mayolus	2	good	Last Available: "2015-05"
+8270	normal miniature unappetizing mayolus	2	good	Last Available: "2015-05"
 8271	stale uninteresting mayolus	3	decent	Last Available: "2015-05"
-8272	bland fancy tumbling acceptable mayolus	4	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 20, Last Available: "2015-05"
+8272	fancy bland tumbling acceptable mayolus	4	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 20, Last Available: "2015-05"
 8273	normal squat enticing mayolus	3	good	Last Available: "2015-05"
 8274	yummy mouth-watering mayolus	4	awesome	Last Available: "2015-05"
 8275	skewed newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8182,7 +8182,7 @@
 8308	activated oxidized piggy tattoo	0		Effect: "X-Ray Vision", Effect Duration: 48
 8309	liquefied bouncing baggie of regular-sized tardigrades	0		Effect: "Pyromania", Effect Duration: 66
 8310	galvanized galvanized shaking wobbly .epub file	0		Effect: "Salad Days", Effect Duration: 18
-8311	improved mirror twirling lime green BUBBLE GUM	0		Effect: "Warm Shoulders", Effect Duration: 19
+8311	improved mirror lime green twirling BUBBLE GUM	0		Effect: "Warm Shoulders", Effect Duration: 19
 8312	boiled hustler shades	0		Effect: "Crimbo Epiphany", Effect Duration: 67
 8313	polarized wet ghostly jerky stick	0		Effect: "Outer Wolf&trade;", Effect Duration: 25
 8314	energized activated costume rental shop	0		Effect: "Wintergreen Warmongery", Effect Duration: 69
@@ -8194,11 +8194,11 @@
 8320	extra-diffused one glove	0		Effect: "Orc Chops", Effect Duration: 54
 8321	colloidal diffused teal glove	0		Effect: "Sugar High", Effect Duration: 39
 8322	dry handful of fire	0		Effect: "From Nantucket", Effect Duration: 29
-8323	extra-warmed colloidal mirror blurry Cracklin' Oat Bran	0		Effect: "Bureaucratized", Effect Duration: 17
+8323	extra-warmed colloidal blurry mirror Cracklin' Oat Bran	0		Effect: "Bureaucratized", Effect Duration: 17
 8324	chilled disposable lighter	0		Effect: "You Know Where to Go", Effect Duration: 40
 8325	denatured dry wobbly coal contact lenses	0		Effect: "Squid Squint", Effect Duration: 12
 8326	aerosolized tarnished cold-filtered gray conjured ice cream	0		Effect: "Adventurer's Best Friendship", Effect Duration: 47
-8327	pickled purple ghostly Iceberglar scarf	0		Effect: "stats.enq", Effect Duration: 46
+8327	pickled ghostly purple Iceberglar scarf	0		Effect: "stats.enq", Effect Duration: 46
 8328	anodized dry quantum ghostly icy hairspray	0		Effect: "Saucegoggles", Effect Duration: 57
 8329	quadruple-pressed corrupted smellbook	0		Effect: "Patience of the Tortoise", Effect Duration: 44
 8330	pressed moist assassin's cheese knife	0		Effect: "Piratastic", Effect Duration: 12
@@ -8207,13 +8207,13 @@
 8333	adjusted boiled batarang	0		Effect: "You Know When to Walk Away", Effect Duration: 53
 8334	flattened triple-anodized spinning spare neck bolts	0		Effect: "Berry Critical", Effect Duration: 14
 8335	cold-filtered polarized blinking grease trap	0		Effect: "meat.enh", Effect Duration: 46
-8336	corrupted corrupted lime green upside-down shamanic ham	0		Effect: "Nuts about Candy", Effect Duration: 38
+8336	corrupted corrupted upside-down lime green shamanic ham	0		Effect: "Nuts about Candy", Effect Duration: 38
 8337	non-Vulcanized twirling porkpocket	0		Effect: "Patent Prevention", Effect Duration: 68
 8338	adjusted triple-tarnished diffused spinning Leonard's glasses	0		Effect: "Sinuses For Miles", Effect Duration: 60
 8339	ionized corrupted warehouse walkie-talkie	0		Effect: "Well-preserved", Effect Duration: 25
 8340	improved janitor's mop	0		Effect: "You're Not Cooking", Effect Duration: 54
 8341	energized twirling warehouse clerk's glasses	0		Effect: "Mmmmmelon", Effect Duration: 29
-8342	dry vacuum-sealed spinning skewed baloney rotgut	0		Effect: "Truly Gritty", Effect Duration: 32
+8342	dry vacuum-sealed skewed spinning baloney rotgut	0		Effect: "Truly Gritty", Effect Duration: 32
 8343	chilled carton of gaspers	0		Effect: "Hairless and Airless", Effect Duration: 45
 8344	double-polarized bronze polish	0		Effect: "Partially Ghosted", Effect Duration: 27
 8345	moist dry blinking crident	0		Effect: "Abyssal Blood", Effect Duration: 16
@@ -8233,8 +8233,8 @@
 8359	enhanced tarnished tarnished upside-down wrestling mask	0		Effect: "Florid Cheeks", Effect Duration: 14
 8360	magnetized ionized hawkface potion	0		Effect: "Fudgehound", Effect Duration: 69
 8361	denatured child-sized dracula cloak	0		Effect: "Slippery Tongue", Effect Duration: 47
-8362	corrupted tumbling squat devil-summoning hat	0		Effect: "Motion", Effect Duration: 50
-8363	magnetized flattened teal squat shopkeeper beard	0		Effect: "Extra-Thick Blood", Effect Duration: 25
+8362	corrupted squat tumbling devil-summoning hat	0		Effect: "Motion", Effect Duration: 50
+8363	magnetized flattened squat teal shopkeeper beard	0		Effect: "Extra-Thick Blood", Effect Duration: 25
 8364	galvanized skewed alien autoautopsy kit	0		Effect: "Incensed", Effect Duration: 28
 8365	frozen ionized novelty fruit hat	0		Effect: "Memory of Speed", Effect Duration: 27
 8366	liquefied ionized frozen mirror invisibility cream	0		Effect: "Fury of the Bells", Effect Duration: 20
@@ -8276,13 +8276,13 @@
 8402	shaking vibrating knife of James Dean	0		Experience (Moxie): +3, Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2015-07"
 8403	lime green coward's crafty revolver	0		Maximum MP: +10, Monster Level: -20, Lasts Until Rollover, Last Available: "2015-07"
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
-8405	maroon spinning talking spade	0		Free Pull
+8405	spinning maroon talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	small stale pestopiary	2	decent	
+8407	stale small pestopiary	2	decent	
 8408	electrified concentrated pickled ectoplasmic orbs	0		Effect: "Using Protection", Effect Duration: 32
 8409	big delicious mirror crudles	5	awesome	
 8410	normal jumbo agnolotti arboli	5	good	
-8411	bland snack-sized spaghetti with ghost balls	2	decent	
+8411	snack-sized bland spaghetti with ghost balls	2	decent	
 8412	flavorless low-calorie fancy succulent marrow	1	decent	Effect: "Pill Power", Effect Duration: 45
 8413	half-sized decent shaking salacious crumbs	2	good	
 8414	bland teal fusilli marrownarrow	4	decent	
@@ -8303,7 +8303,7 @@
 8429	veiny spore pod	0		
 8430	hard spore pod	0		
 8431	blue spore pod	0		
-8432	red narrow hot spore pod	0		
+8432	narrow red hot spore pod	0		
 8433	cool spore pod	0		
 8434	jingling spore pod	0		
 8435	shellacked LavaCo Lamp&trade; of the brazier	0		Damage Reduction: 7, Hot Spell Damage: +25, Last Available: "2015-08"
@@ -8329,10 +8329,10 @@
 8455	blurry New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	blurry wholesome high-temperature mining mask of the blizzard	0		Maximum HP Percent: +10, Cold Spell Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	blurry wholesome high-temperature mining mask of the blizzard	0		Maximum HP Percent: +10, Cold Spell Damage: +25, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	toasty supercharged fireproof megaphone	0		Maximum MP Percent: +30, Hot Damage: +5, Last Available: "2015-08"
 8460	adequate spinning mineapple	3	good	Last Available: "2015-08"
-8461	weak lousy Gold Velvet&trade; whiskey	2	decent	Last Available: "2015-08"
+8461	lousy weak Gold Velvet&trade; whiskey	2	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	good	Last Available: "2015-08"
 8463	adequate smelted roe	3	good	Last Available: "2015-08"
 8464	perfectly mixed green lavawater	3	EPIC	Last Available: "2015-08"
@@ -8350,18 +8350,18 @@
 8476	boiled electrified narrow liquid rhinestones	0		Effect: "Magically Fingered", Effect Duration: 29, Last Available: "2015-08"
 8477	special moldy disco biscuit	3	crappy	Effect: "Ancestral Disapproval", Effect Duration: 5, Last Available: "2015-08"
 8478	drinkable jittery Quaatorade&trade;	4	good	Last Available: "2015-08"
-8479	grievous wizardly biker's hat of dire peril	0		Mysticality: +25, Weapon Damage: +20, Weapon Damage Percent: +50, Familiar Effect: "atk", Last Available: "2015-08"
-8480	scorching Lo Pan's Tesla feathered headdress	0		Spell Critical Percent: +30, Hot Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	family-friendly ribald friendly electrician's hardhat	0		Familiar Weight: +3, Sleaze Damage: +10, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
+8479	grievous wizardly biker's hat of dire peril	0		Mysticality: +25, Weapon Damage: +20, Weapon Damage Percent: +50, Last Available: "2015-08", Familiar Effect: "atk"
+8480	scorching Lo Pan's Tesla feathered headdress	0		Spell Critical Percent: +30, Hot Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	family-friendly ribald friendly electrician's hardhat	0		Familiar Weight: +3, Sleaze Damage: +10, Sleaze Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	shaking Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
-8488	ghostly blinking Manual of Numberology	0		Skill: "Calculate the Universe"
+8488	blinking ghostly Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	upside-down New Age hurting crystal	0		Last Available: "2015-08"
-8490	tumbling smooth velvet pants of the storm	0		Maximum MP Percent: +40, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	tumbling smooth velvet pants of the storm	0		Maximum MP Percent: +40, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	bouncing padded smooth velvet shirt	0		Damage Absorption: +20, Last Available: "2015-08"
 8492	educational smooth velvet hat	0		Experience: +1, Last Available: "2015-08"
 8493	cool smooth velvet pocket square	0		Moxie: +5, Single Equip, Last Available: "2015-08"
@@ -8391,13 +8391,13 @@
 8517	greasy medical-grade SMOOCH bracers	0		Sleaze Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2015-08"
 8518	pulsating red personal trainer's SMOOCH kneepads	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2015-08"
 8519	fireproof SMOOCH spaulders	0		Hot Resistance: +3, Single Equip, Last Available: "2015-08"
-8520	aromatic medical-grade SMOOCH codpiece	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	aromatic medical-grade SMOOCH codpiece	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	cyan SMOOCH breastplate of wisdom	0		Mysticality: +15, Last Available: "2015-08"
 8522	huge superduperheated	0		Last Available: "2015-08"
 8523	yellow fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	decent lava cake	4	good	Last Available: "2015-08"
-8526	enchanted huge spoiled upside-down pink slime	6	crappy	Effect: "Hagnk's Gratitude", Effect Duration: 45
+8526	spoiled huge enchanted upside-down pink slime	6	crappy	Effect: "Hagnk's Gratitude", Effect Duration: 45
 8527	ghostly Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	tasty shaking devil hair pasta	3	awesome	
@@ -8405,7 +8405,7 @@
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
-8534	half-sized bland libertagliatelle	2	decent	
+8534	bland half-sized libertagliatelle	2	decent	
 8535	decent bite-sized turkish mostaccioli	1	good	
 8536	gigantic adequate linguini of the sea	9	good	
 8537	electrified Hersey&trade; SMOOCH	0		Effect: "Bloody-minded", Effect Duration: 18
@@ -8423,7 +8423,7 @@
 8550	decent weird gazelle steak	3	good	
 8551	normal jumbo sausage without a cause	5	good	
 8552	quantum wobbly face paint	0		Effect: "Flexibili Tea", Effect Duration: 20
-8553	bad watered-down jittery emergency margarita	2	decent	
+8553	watered-down bad jittery emergency margarita	2	decent	
 8554	acceptable vintage smart drink	3	good	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8437,8 +8437,8 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	Temple Grandin's therapeutic sinister barrel lid	0		Spell Damage: +10, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Sherlock's barrel hoop earring of horror of courage	0		Spooky Spell Damage: +25, Spooky Resistance: +3, Item Drop: +25, Lasts Until Rollover, Last Available: "2015-09"
-8567	mansplainer's rock-hard bankruptcy barrel of the sweet-tooth	0		Damage Reduction: 5, Monster Level: +15, Candy Drop: +100, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
-8568	huge twirling firkin	0		Last Available: "2015-09"
+8567	mansplainer's rock-hard bankruptcy barrel of the sweet-tooth	0		Damage Reduction: 5, Monster Level: +15, Candy Drop: +100, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8568	twirling huge firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	twirling tun	0		Last Available: "2015-09"
 8571	wobbly weathered barrel	0		Last Available: "2015-09"
@@ -8450,8 +8450,8 @@
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	artisanal mirror bottle of Amontillado	4	EPIC	Last Available: "2015-09"
 8579	watered-down aged barrel-aged martini	2	awesome	Last Available: "2015-09"
-8580	rotten enchanted massive skewed barrel pickle	6	crappy	Effect: "Je Ne Sais Porquoise", Effect Duration: 25, Last Available: "2015-09"
-8581	miniature tasty barrel cracker	2	awesome	Last Available: "2015-09"
+8580	massive enchanted rotten skewed barrel pickle	6	crappy	Effect: "Je Ne Sais Porquoise", Effect Duration: 25, Last Available: "2015-09"
+8581	tasty miniature barrel cracker	2	awesome	Last Available: "2015-09"
 8582	modified fuchsia vibrating mushroom	1	crappy	Last Available: "2015-09"
 8583	dehydrated tumbling mushroom	1	awesome	Effect: "Highland Sheen", Effect Duration: 50, Last Available: "2015-09"
 8584	mirror olive studded KoL Con 12-gauge	0		Damage Absorption: +80, Last Available: "2015-09"
@@ -8476,13 +8476,13 @@
 8603	altered tarnished wobbly cuppa Boo tea	0		Effect: "Memory of Resilience", Effect Duration: 38, Last Available: "2015-09"
 8604	irradiated oxidized cuppa Nas tea	0		Effect: "Void Between the Stars", Effect Duration: 53, Last Available: "2015-09"
 8605	flattened improved blinking cuppa Improprie tea	0		Effect: "Boletus Swoletus", Effect Duration: 53, Last Available: "2015-09"
-8606	denatured tumbling skewed cuppa Frost tea	0		Effect: "Held Closer", Effect Duration: 29, Last Available: "2015-09"
+8606	denatured skewed tumbling cuppa Frost tea	0		Effect: "Held Closer", Effect Duration: 29, Last Available: "2015-09"
 8607	triple-pressed energized electrified cuppa Toast tea	0		Effect: "Make Meat FA$T!", Effect Duration: 34, Last Available: "2015-09"
 8608	irradiated cuppa Net tea	0		Effect: "Unusual Perspective", Effect Duration: 68, Last Available: "2015-09"
 8609	moist cuppa Proprie tea	0		Effect: "Leo Rising", Effect Duration: 36, Last Available: "2015-09"
 8610	quantum cuppa Morbidi tea	0		Effect: "You're High as a Crow, Marty", Effect Duration: 20, Last Available: "2015-09"
 8611	triple-dry Vulcanized cuppa Chari tea	0		Effect: "Slimy Flavor", Effect Duration: 19, Last Available: "2015-09"
-8612	enhanced jittery lime green cuppa Serendipi tea	0		Effect: "Patent Prevention", Effect Duration: 53, Last Available: "2015-09"
+8612	enhanced lime green jittery cuppa Serendipi tea	0		Effect: "Patent Prevention", Effect Duration: 53, Last Available: "2015-09"
 8613	irradiated cuppa Feroci tea	0		Effect: "Fustulent", Effect Duration: 57, Last Available: "2015-09"
 8614	triple-frozen quantum cuppa Physicali tea	0		Effect: "Scorpio Rising", Effect Duration: 52, Last Available: "2015-09"
 8615	tarnished corrupted cuppa Wit tea	0		Effect: "Turkey-Friendly", Effect Duration: 58, Last Available: "2015-09"
@@ -8492,7 +8492,7 @@
 8619	improved magnetized blurry cuppa Impregnabili tea	0		Effect: "Emotion Sickness", Effect Duration: 22, Last Available: "2015-09"
 8620	chilled cuppa Obscuri tea	0		Effect: "Headstrong", Effect Duration: 33, Last Available: "2015-09"
 8621	warmed cuppa Irritabili tea	0		Effect: "Coal-Powered", Effect Duration: 23, Last Available: "2015-09"
-8622	energized purple blurry cuppa Mediocri tea	0		Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2015-09"
+8622	energized blurry purple cuppa Mediocri tea	0		Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2015-09"
 8623	frozen double-ionized cuppa Loyal tea	0		Effect: "Compensatory Cruelness", Effect Duration: 67, Last Available: "2015-09"
 8624	dried skewed cuppa Activi tea	1	good	Last Available: "2015-09"
 8625	modified wobbly lime green cuppa Cruel tea	1		Effect: "Sweet, Nuts", Effect Duration: 30, Last Available: "2015-09"
@@ -8514,12 +8514,12 @@
 8641	toothsome thick bowl of eyeballs	5	awesome	Last Available: "2015-10"
 8642	half-sized yummy bowl of mummy guts	2	awesome	Last Available: "2015-10"
 8643	decent bowl of maggots	3	good	Last Available: "2015-10"
-8644	acceptable distilled blood and blood	5	good	Last Available: "2015-10"
-8645	drinkable triple-distilled Jack-O-Lantern beer	8	good	Last Available: "2015-10"
-8646	boozy drinkable zombie	5	good	Last Available: "2015-10"
+8644	distilled acceptable blood and blood	5	good	Last Available: "2015-10"
+8645	triple-distilled drinkable Jack-O-Lantern beer	8	good	Last Available: "2015-10"
+8646	drinkable boozy zombie	5	good	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
-8649	tumbling ghostly plastic nightmare troll	0		Last Available: "2015-10"
+8649	ghostly tumbling plastic nightmare troll	0		Last Available: "2015-10"
 8650	tennis ball	0		Last Available: "2015-10"
 8651	upside-down shellacked personal trainer's crown of Leguizamo	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Monster Level: +20, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	aromatic fireproof dance instructor's ghostly dagger	0		Experience Percent (Moxie): +10, Hot Resistance: +3, Stench Resistance: +1
-8663	drinkable watered-down ghost beer	2	good	
+8663	watered-down drinkable ghost beer	2	good	
 8664	double-paned Othello set	0		Cold Resistance: +5
 8665	rotten tomato	0		
 8666	jittery Twelve Night Energy	0		
@@ -8558,8 +8558,8 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	upside-down scandalous bellhop's hat	0		Sleaze Damage: +5, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	drinkable ice porter	3	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	upside-down scandalous bellhop's hat	0		Sleaze Damage: +5, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	drinkable ice porter	3	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	improved ionized exotic travel brochure	0		Effect: "Gummi Badass", Effect Duration: 63, Last Available: "2015-11"
 8691	pulsating bag of foreign bribes	0		Last Available: "2015-11"
 8692	tarnished quadruple-moist warmed shampoo-conditioner	0		Effect: "Nutrient-Rich", Effect Duration: 40, Last Available: "2015-11"
@@ -8568,10 +8568,10 @@
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	mixed mirror medicinal herbs	1		Last Available: "2016-01"
 8697	flavorless ice rice	3	decent	Last Available: "2016-01"
-8698	tolerable watered-down enchanted iced plum wine	2	good	Effect: "Nas Tea", Effect Duration: 15, Last Available: "2016-01"
+8698	tolerable enchanted watered-down iced plum wine	2	good	Effect: "Nas Tea", Effect Duration: 15, Last Available: "2016-01"
 8699	lightning-fast training belt of Leguizamo of the early riser	0		Monster Level: +20, Initiative: +40, Adventures: +7, Single Equip, Last Available: "2016-01"
 8700	skewed family-friendly supercharged beefy training legwarmers	0		Muscle: +10, Maximum MP Percent: +30, Sleaze Resistance: +1, Single Equip, Last Available: "2016-01"
-8701	twirling sharpshooter's curative training helmet of the blizzard	0		Critical Hit Percent: +10, Cold Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	twirling sharpshooter's curative training helmet of the blizzard	0		Critical Hit Percent: +10, Cold Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	wobbly training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8590,7 +8590,7 @@
 8717	compressed shaking blinking abstraction: comprehension	1		Effect: "Frozen Hands", Effect Duration: 25, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	rotten yellow VYKEA meatballs	4	crappy	Last Available: "2015-11"
-8720	bad weak VYKEA mead	2	decent	Last Available: "2015-11"
+8720	weak bad VYKEA mead	2	decent	Last Available: "2015-11"
 8721	unsweetened VYKEA woadpaint	0		Effect: "Chalky White Pallor", Effect Duration: 36, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,18 +8601,18 @@
 8728	blurry VYKEA dowel	0		Last Available: "2015-11"
 8729	gray upside-down lard-coated ruddy VYKEA hex key of the brazier	0		Maximum HP Percent: +40, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	flavorless ghostly tin of submardines	3	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	flavorless ghostly tin of submardines	3	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	irresponsibly strong tolerable bottle of norwhiskey	7	good	Last Available: "2015-11"
-8733	diluted blurry fuchsia ghostly octolus oculus	1	decent	Last Available: "2015-11"
+8733	diluted ghostly blurry fuchsia octolus oculus	1	decent	Last Available: "2015-11"
 8734	shaking friendly sardine can key of the cougar of the pedagogue	0		Moxie: +20, Experience: +3, Familiar Weight: +3, Last Available: "2015-11"
-8735	shaking frightening chaotic groovy norwhal helmet	0		Moxie Percent: +10, Spell Critical Percent: +10, Spooky Damage: +5, Familiar Effect: "atk", Last Available: "2015-11"
+8735	shaking frightening chaotic groovy norwhal helmet	0		Moxie Percent: +10, Spell Critical Percent: +10, Spooky Damage: +5, Last Available: "2015-11", Familiar Effect: "atk"
 8736	experienced boxer's octolus-skin cloak of the glutton	0		Muscle Percent: +10, Experience: +2, Food Drop: +100, Last Available: "2015-11"
-8737	smooth weak perfect cosmopolitan	2	awesome	Last Available: "2015-11"
-8738	fancy mediocre blurry perfect negroni	3	decent	Effect: "Melancholy Burden", Effect Duration: 50, Last Available: "2015-11"
+8737	weak smooth perfect cosmopolitan	2	awesome	Last Available: "2015-11"
+8738	mediocre fancy blurry perfect negroni	3	decent	Effect: "Melancholy Burden", Effect Duration: 50, Last Available: "2015-11"
 8739	mediocre perfect dark and stormy	3	decent	Last Available: "2015-11"
 8740	delicious yellow perfect mimosa	4	awesome	Last Available: "2015-11"
 8741	perfectly mixed irresponsibly strong perfect old-fashioned	9	EPIC	Last Available: "2015-11"
-8742	high-proof perfectly mixed blue perfect paloma	7	EPIC	Last Available: "2015-11"
+8742	perfectly mixed high-proof blue perfect paloma	7	EPIC	Last Available: "2015-11"
 8743	alkaline pickled That 70s Cologne	0		Effect: "Human-Orc Hybrid", Effect Duration: 18, Last Available: "2015-11"
 8744	alkaline ionized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Pill Power", Effect Duration: 48, Last Available: "2015-11"
 8745	tarnished dry Puffstone cigar	0		Effect: "Saucefingers", Effect Duration: 26, Last Available: "2015-11"
@@ -8636,7 +8636,7 @@
 8763	tumbling BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	twirling Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	weak mediocre green Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
+8766	mediocre weak green Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	mirror Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
@@ -8649,12 +8649,12 @@
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
-8780	blurry olive iron chain	0		Last Available: "2015-12"
+8780	olive blurry iron chain	0		Last Available: "2015-12"
 8781	twirling pine cone necklace of the sewer	0		Stench Damage: +25, Last Available: "2015-12"
 8782	shaking Da Vinci's reindeer hammer	0		Experience (Mysticality): +5, Last Available: "2015-12"
 8783	jittery Lo Pan's elf ploughshare	0		Spell Critical Percent: +30, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	jittery nasty-smelling moss	0		Last Available: "2015-12"
@@ -8666,7 +8666,7 @@
 8794	green The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	blinking Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
-8797	upside-down spinning bat-oomerang	0		Last Available: "2017-01"
+8797	spinning upside-down bat-oomerang	0		Last Available: "2017-01"
 8798	huge bat-jute	0		Last Available: "2017-01"
 8799	shaking bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
@@ -8685,18 +8685,18 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	stale miniature special wobbly Kudzu salad	2	decent	Effect: "Sleazy Jellied", Effect Duration: 50, Last Available: "2016-12"
+8816	stale special miniature wobbly Kudzu salad	2	decent	Effect: "Sleazy Jellied", Effect Duration: 50, Last Available: "2016-12"
 8817	modified wobbly Mansquito Serum	1		Effect: "Hennaliciousness", Effect Duration: 15, Last Available: "2016-12"
-8818	special artisanal Miss Graves' vermouth	3	EPIC	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2016-12"
+8818	artisanal special Miss Graves' vermouth	3	EPIC	Effect: "Bugbear in Tooth and Claw", Effect Duration: 20, Last Available: "2016-12"
 8819	moldy jittery The Plumber's mushroom stew	4	crappy	Last Available: "2016-12"
-8820	mixed pulsating blinking The Author's ink	1		Last Available: "2016-02"
+8820	mixed blinking pulsating The Author's ink	1		Last Available: "2016-02"
 8821	acceptable The Mad Liquor	3	good	Last Available: "2016-12"
-8822	tolerable practically non-alcoholic skewed Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
+8822	practically non-alcoholic tolerable skewed Doc Clock's thyme cocktail	1	good	Last Available: "2016-12"
 8823	adequate Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	diluted tumbling The Inquisitor's unidentifiable object	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 25, Last Available: "2016-12"
-8825	rosewater-soaked The Jokester's gun of wisdom of James Dean	0		Mysticality: +15, Experience (Moxie): +3, Stench Resistance: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	wobbly electrified The Jokester's wig of the wise owl of horror	0		Mysticality: +20, Spooky Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	bouncing knitted Van der Graaf personal trainer's The Jokester's pants	0		Experience Percent (Muscle): +10, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	rosewater-soaked The Jokester's gun of wisdom of James Dean	0		Mysticality: +15, Experience (Moxie): +3, Stench Resistance: +3, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	wobbly electrified The Jokester's wig of the wise owl of horror	0		Mysticality: +20, Spooky Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	bouncing knitted Van der Graaf personal trainer's The Jokester's pants	0		Experience Percent (Muscle): +10, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	activated alkaline Jokester makeup	0		Effect: "Heart of Yellow", Effect Duration: 13, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	upside-down battoo kit	0		Last Available: "2016-12"
@@ -8704,10 +8704,10 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	magnetized huge robin's egg	0		Effect: "Shawarma Initiative", Effect Duration: 36, Last Available: "2016-12"
 8834	adequate blue robin flan	3	good	Last Available: "2016-12"
-8835	practically non-alcoholic tolerable robin nog	1	good	Last Available: "2016-12"
+8835	tolerable practically non-alcoholic robin nog	1	good	Last Available: "2016-12"
 8836	cyan LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
-8838	squat bouncing exploding gum	0		
+8838	bouncing squat exploding gum	0		
 8839	root beer barrel	0		
 8840	wet wet Kudzu slaw	0		Effect: "Hairy Palms", Effect Duration: 67
 8841	extra-liquefied frozen quadruple-improved Mansquito's blood	0		Effect: "You're High as a Crow, Marty", Effect Duration: 63
@@ -8719,10 +8719,10 @@
 8847	concentrated cold-filtered magnetized red-hot jawbreaker	0		Effect: "Mighty Shout", Effect Duration: 19
 8848	colloidal spinning question juice	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 53
 8849	colloidal Vulcanized tube of villain	0		Effect: "Mad at Science", Effect Duration: 60
-8850	mirror wool your cowboy boots	0		Cold Resistance: +1, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	mirror wool your cowboy boots	0		Cold Resistance: +1, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	twirling inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
-8853	skewed twirling nugget of thicksilver	0		Last Available: "2016-02"
+8853	twirling skewed nugget of thicksilver	0		Last Available: "2016-02"
 8854	teal nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
@@ -8745,20 +8745,20 @@
 8873	blinking Pork 'n' Pork 'n' Pork 'n' Beans	0		Item Drop: +5, Last Available: "2016-02"
 8874	skewed double-paned hale sinister Sinatra's Val-U Brand Every Bean Salad of vim and vigor	0		Experience (Moxie): +5, Spell Damage: +10, Maximum HP Percent: +50, Maximum HP: +20, Cold Resistance: +5, Last Available: "2016-02"
 8875	twirling Usain Bolt's family-friendly chaotic Shrub's Premium Baked Beans	0		Spell Critical Percent: +10, Sleaze Resistance: +1, Initiative: +80, Last Available: "2016-02"
-8876	spoiled small plate of Heimz Fortified Kidney Beans	2	crappy	Last Available: "2016-02"
-8877	big normal upside-down plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
+8876	small spoiled plate of Heimz Fortified Kidney Beans	2	crappy	Last Available: "2016-02"
+8877	normal big upside-down plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
 8878	normal plate of Mixed Garbanzos and Chickpeas	3	good	Last Available: "2016-02"
 8879	stale plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	bland snack-sized plate of Frigid Northern Beans	2	decent	Last Available: "2016-02"
-8881	small yummy plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
-8882	bite-sized bland plate of Trader Olaf's Exotic Stinkbeans	1	decent	Last Available: "2016-02"
+8881	yummy small plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
+8882	bland bite-sized plate of Trader Olaf's Exotic Stinkbeans	1	decent	Last Available: "2016-02"
 8883	spoiled special plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	crappy	Effect: "Phairly Balanced", Effect Duration: 10, Last Available: "2016-02"
 8884	flavorless plate of Val-U Brand Every Bean Salad	3	decent	Last Available: "2016-02"
 8885	bland ghostly plate of Shrub's Premium Baked Beans	3	decent	Last Available: "2016-02"
 8886	huge clever quilted Fancy Jeff's pocket square	0		Damage Absorption: +40, Maximum MP: +20, Last Available: "2016-02"
-8887	rosewater-soaked vibrating Daisy's unclean bloomers of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50, Stench Resistance: +3, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	rosewater-soaked vibrating Daisy's unclean bloomers of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50, Stench Resistance: +3, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	nippy Amoon-Ra Cowtep's nemes of the scaredy-cat of incineration	0		Monster Level: -15, Cold Damage: +10, Hot Spell Damage: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	nippy Amoon-Ra Cowtep's nemes of the scaredy-cat of incineration	0		Monster Level: -15, Cold Damage: +10, Hot Spell Damage: +50, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	tumbling up-at-dawn prompt supercool Former Sheriff Dan's tin star of the pedagogue of the businessman	0		Moxie Percent: +20, Experience: +3, Meat Drop: +50, Adventures: 8, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8770,15 +8770,15 @@
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	decent	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
-8901	Vulcanized triple-energized narrow spinning triggerfingerbone	0		Effect: "The Style... of the Future", Effect Duration: 57, Last Available: "2016-02"
-8902	activated concentrated improved spinning mirror ghost bit	0		Effect: "Tea-hee", Effect Duration: 22, Last Available: "2016-02"
+8901	Vulcanized triple-energized spinning narrow triggerfingerbone	0		Effect: "The Style... of the Future", Effect Duration: 57, Last Available: "2016-02"
+8902	activated concentrated improved mirror spinning ghost bit	0		Effect: "Tea-hee", Effect Duration: 22, Last Available: "2016-02"
 8903	super-deionized red buzzard feather	0		Effect: "Rootin' Around", Effect Duration: 34, Last Available: "2016-02"
 8904	tarnished double-altered narrow lion musk	0		Effect: "Nature's Bounty", Effect Duration: 38, Last Available: "2016-02"
-8905	tiny decent bear claw	1	good	Last Available: "2016-02"
+8905	decent tiny bear claw	1	good	Last Available: "2016-02"
 8906	polarized oxidized blurry rattler gland	0		Effect: "Hairy Palms", Effect Duration: 42, Last Available: "2016-02"
 8907	oxidized enhanced half-digested coal	0		Effect: "Jerky, Boy", Effect Duration: 53, Last Available: "2016-02"
 8908	alkaline tightly-wound spine	0		Effect: "Sweetened and Fattened", Effect Duration: 68, Last Available: "2016-02"
-8909	diet bland rotting beefsteak	1	decent	Last Available: "2016-02"
+8909	bland diet rotting beefsteak	1	decent	Last Available: "2016-02"
 8910	mediocre firemilk	3	decent	Last Available: "2016-02"
 8911	concentrated energized spinning spidercow eye-cluster	0		Effect: "Radiated and Grodiated", Effect Duration: 41, Last Available: "2016-02"
 8912	distilled narrow moomy dust	1		Last Available: "2016-02"
@@ -8813,7 +8813,7 @@
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
-8944	gray blurry rhinestone cowhorn	0		Familiar Weight: +5
+8944	blurry gray rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	bouncing jangly spurs	0		Last Available: "2016-02"
 8947	spinning quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
@@ -8843,7 +8843,7 @@
 8971	purple snake oil	0		
 8972	irradiated wobbly narrow skin oil	0		Effect: "Inebriate Pride", Effect Duration: 34
 8973	moist oxidized adjusted blinking unusual oil	0		Effect: "Vital", Effect Duration: 20
-8974	polymerized nitrogenated wobbly purple eldritch oil	0		Effect: "Shot in the Arse", Effect Duration: 19
+8974	polymerized nitrogenated purple wobbly eldritch oil	0		Effect: "Shot in the Arse", Effect Duration: 19
 8975	exclusive club	0		
 8976	improved patent preventative tonic	0		Effect: "Human-Orc Hybrid", Effect Duration: 21
 8977	boiled polarized maroon patent invisibility tonic	0		Effect: "Mental A-cue-ity", Effect Duration: 49
@@ -8863,16 +8863,16 @@
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	vaporized narrow armored prawn	1		Last Available: "2016-03"
 8993	bland fancy jumping horseradish	4	decent	Effect: "Hot Blooded", Effect Duration: 40, Last Available: "2016-03"
-8994	drinkable boozy lime green Sacramento wine	5	good	Last Available: "2016-03"
+8994	boozy drinkable lime green Sacramento wine	5	good	Last Available: "2016-03"
 8995	deionized deionized Greek fire	0		Effect: "Kissed By Fire", Effect Duration: 65, Last Available: "2016-03"
 8996	fireproof smelly manspreader's Herculean ox-head shield of chilblains	0		Experience (Muscle): +1, Monster Level: +10, Cold Damage: +25, Stench Spell Damage: +10, Hot Resistance: +3, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	avaricious sizzling electrified brawny dented scepter of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Hot Damage: +10, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	scandalous Temple Grandin's supercharged very pointy crown of the brazier of horror	0		Maximum MP Percent: +30, Familiar Weight: +7, Hot Spell Damage: +25, Spooky Spell Damage: +25, Sleaze Damage: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	scandalous Temple Grandin's supercharged very pointy crown of the brazier of horror	0		Maximum MP Percent: +30, Familiar Weight: +7, Hot Spell Damage: +25, Spooky Spell Damage: +25, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	horrifying smelly mansplainer's thinker's beefy battle broom	0		Muscle: +10, Mysticality: +10, Monster Level: +15, Stench Spell Damage: +10, Spooky Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	rosewater-soaked Da Vinci's brainy carpe of the brazier	0		Mysticality: +5, Experience (Mysticality): +5, Hot Spell Damage: +25, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9002	narrow dog trainer's shellacked dangerous supercool codpiece	0		Moxie Percent: +20, Weapon Damage: +10, Damage Reduction: 7, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2016-04"
-9003	double-paned chilly grievous Herculean troutsers	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Cold Damage: +5, Cold Resistance: +5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	double-paned chilly grievous Herculean troutsers	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Cold Damage: +5, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	Jeselnik's sizzling coward's bass clarinet of the sweet-tooth	0		Monster Level: -20, Hot Damage: +10, Sleaze Damage: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9005	red hale educational fish hatchet of the scaredy-cat of the glutton	0		Experience: +1, Maximum HP: +20, Monster Level: -15, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9006	narrow electrified clever tunac of Leguizamo of the scaredy-cat	0		Maximum MP: +20, Monster Level: 5, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
@@ -8889,7 +8889,7 @@
 9017	viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	upside-down meme generator	0		Last Available: "2016-05"
-9020	shaking mirror plus one	0		Last Available: "2016-05"
+9020	mirror shaking plus one	0		Last Available: "2016-05"
 9021	normal big blurry gallon of milk	5	good	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	mirror screencapped monster	0		Last Available: "2016-05"
@@ -8899,7 +8899,7 @@
 9027	up-at-dawn executive baleful First Post shirt - Cir Senam	0		Spell Damage: +25, Meat Drop: +40, Adventures: +5, Last Available: "2016-05"
 9028	wobbly high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	blurry no spoon	0		
-9030	bite-sized flavorless wobbly star salad	1	decent	
+9030	flavorless bite-sized wobbly star salad	1	decent	
 9031	Thwaitgold moth statuette	0		
 9032	snack-sized spoiled bowl of Tastee-Wheet&trade;	2	crappy	
 9033	shaking twirling Source terminal	0		Free Pull, Last Available: "2016-06"
@@ -8948,10 +8948,10 @@
 9076	mirror spinning mirror chilly MacGyver's noir fedora of the bloodbag	0		Maximum HP: +100, Maximum MP: +100, Cold Damage: +5, Last Available: "2016-07"
 9077	blinking resourceful therapeutic trench coat of Tarzan	0		Experience (Muscle): +3, Maximum MP: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-07"
 9078	smooth Falcon&trade; Maltese Liquor	4	awesome	Last Available: "2016-07"
-9079	adequate gigantic lime green hardboiled egg	7	good	Last Available: "2016-07"
+9079	gigantic adequate lime green hardboiled egg	7	good	Last Available: "2016-07"
 9080	ghostly detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	mirror family-friendly wool lard-coated hale protonic accelerator pack of vim and vigor of the brazier	0		Maximum HP Percent: +50, Maximum HP: +20, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	mirror family-friendly wool lard-coated hale protonic accelerator pack of vim and vigor of the brazier	0		Maximum HP Percent: +50, Maximum HP: +20, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Cold Resistance: +1, Sleaze Resistance: +1, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	bouncing almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	studded Adventurer bobblehead	0		Damage Absorption: +80, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	foul-smelling Mr. Screege's spectacles	0		Stench Damage: +10, Single Equip, Last Available: "2016-08"
 9092	greedy miser's groovy Spookyraven signet	0		Moxie Percent: +10, Meat Drop: 30, Single Equip, Last Available: "2016-08"
 9093	fortified forbidden tie-dyed fannypack	0		Spell Damage Percent: +50, Damage Absorption: +60, Single Equip, Last Available: "2016-08"
-9094	horrifying chilly burnt snowpants	0		Cold Damage: +5, Spooky Damage: +25, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	quilted standards and practices guide	0		Damage Absorption: +40, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	horrifying chilly burnt snowpants	0		Cold Damage: +5, Spooky Damage: +25, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	quilted standards and practices guide	0		Damage Absorption: +40, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	narrow Temple Grandin's occult sage Carpathian longsword	0		Mysticality Percent: +10, Spell Damage Percent: +25, Familiar Weight: +7, Last Available: "2016-08"
 9097	lightning-fast supercharged shellacked Liam's mail	0		Damage Reduction: 7, Maximum MP Percent: +30, Initiative: +40, Last Available: "2016-08"
 9098	squat scorching wicked brainy Unfortunato's foolscap	0		Mysticality: +5, Spell Damage: +5, Hot Damage: +25, Last Available: "2016-08"
@@ -8972,7 +8972,7 @@
 9100	rad	0		
 9101	purification tablet	0		
 9102	narrow Samson's Wrist-Boy	0		Experience (Muscle): +5
-9103	lime green upside-down Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
+9103	upside-down lime green Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	jittery Time-Spinner	0		Last Available: "2016-09"
 9105	compounded experience	0		Last Available: "2016-09"
 9106	bouncing Rad-B-Gone (1 lb.)	0		
@@ -8988,47 +8988,47 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	pulsating blurry careful repaid diaper	0		Monster Level: -10
 9118	upside-down Riker's Search History	0		Last Available: "2016-09"
-9119	irresponsibly strong acceptable Shot of Kardashian Gin	6	good	Last Available: "2016-09"
+9119	acceptable irresponsibly strong Shot of Kardashian Gin	6	good	Last Available: "2016-09"
 9120	skewed asbestos-lined Unstable Pointy Ears	0		Hot Resistance: +5, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	yellow droppable microphone	0		
-9126	watered-down bad unidentified drink	2	decent	
+9126	bad watered-down unidentified drink	2	decent	
 9127	deadly supercool KoL Con 13 T-shirt	0		Moxie Percent: +20, Weapon Damage: +5
 9128	knitted Jeselnik's slick discarded swimming trunks	0		Moxie: +10, Sleaze Damage: +25, Cold Resistance: +3
-9129	cold-filtered huge shaking diluted makeup	0		Effect: "Libra Rising", Effect Duration: 47
+9129	cold-filtered shaking huge diluted makeup	0		Effect: "Libra Rising", Effect Duration: 47
 9130	aerosolized lime green charisma potion	0		Effect: "Disco Neuropathy", Effect Duration: 66
 9131	lime green extremely confusing manual	0		
 9132	blinking greasy pistol of the early riser	0		Sleaze Spell Damage: +10, Adventures: +7
-9133	purple tumbling KoL Con 13 snowglobe	0		Last Available: "2016-10"
+9133	tumbling purple KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	delicious immense leftover pasty	8	awesome	
 9135	acceptable boozy blinking very whiskey	5	good	
 9136	twirling li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	huge li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	blurry li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	wobbly li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	blurry li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	wobbly li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	polymerized hoarded candy wad	0		Effect: "Like a Fish to Walter", Effect Duration: 23, Last Available: "2016-10"
 9147	warmed non-enhanced skewed maroon Prunets	0		Effect: "Blubbered Up", Effect Duration: 24
 9148	Twitching Television Tattoo	0		
 9149	tumbling baby scorpion	0		Familiar Weight: +10
 9150	polarized nitrogenated fuchsia invisible string	0		Lasts Until Rollover, Effect: "Squatting and Thrusting", Effect Duration: 35, Last Available: "2016-10"
 9151	quantum irradiated pulsating invisible seam ripper	0		Lasts Until Rollover, Effect: "Bloodstain-Resistant", Effect Duration: 18, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	flavorless raw sweet potato	3	decent	Last Available: "2016-11"
 9154	decent huge teal raw beans	10	good	Last Available: "2016-11"
-9155	decent fancy raw stuffing	4	good	Effect: "Helvella Health", Effect Duration: 30, Last Available: "2016-11"
+9155	fancy decent raw stuffing	4	good	Effect: "Helvella Health", Effect Duration: 30, Last Available: "2016-11"
 9156	bland raw cranberry sauce	4	decent	Last Available: "2016-11"
 9157	decent raw turkey	4	good	Last Available: "2016-11"
-9158	flavorless tiny lime green spinning raw mincemeat	1	decent	Last Available: "2016-11"
-9159	low-calorie bland raw potato	1	decent	Last Available: "2016-11"
+9158	tiny flavorless spinning lime green raw mincemeat	1	decent	Last Available: "2016-11"
+9159	bland low-calorie raw potato	1	decent	Last Available: "2016-11"
 9160	moldy blurry raw gravy	3	crappy	Last Available: "2016-11"
 9161	miniature yummy raw bread	2	awesome	Last Available: "2016-11"
 9162	mini-marshmallow dispenser of the sweet-tooth	0		Item Drop: +5, Candy Drop: +100, Last Available: "2016-11"
@@ -9042,7 +9042,7 @@
 9170	upside-down bread mold	0		Last Available: "2016-11"
 9171	adequate ghostly sweet potatoes	3	good	Last Available: "2016-11"
 9172	yummy bean casserole	4	awesome	Last Available: "2016-11"
-9173	fancy bland snack-sized baked stuffing	2	decent	Effect: "Thanksgot", Effect Duration: 50, Last Available: "2016-11"
+9173	bland fancy snack-sized baked stuffing	2	decent	Effect: "Thanksgot", Effect Duration: 50, Last Available: "2016-11"
 9174	rotten tumbling cranberry cylinder	3	crappy	Last Available: "2016-11"
 9175	rotten fancy thanksgiving turkey	3	crappy	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 15, Last Available: "2016-11"
 9176	flavorless mince pie	3	decent	Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	pressed improved mirror eldritch concentrate	0		Effect: "Swimming Head", Effect Duration: 62, Last Available: "2016-11"
-9192	acceptable triple-distilled eldritch extract	8	good	Last Available: "2016-11"
+9192	triple-distilled acceptable eldritch extract	8	good	Last Available: "2016-11"
 9193	greedy frosty Official Council Aide Pin	0		Cold Spell Damage: +10, Meat Drop: +20, Last Available: "2016-11"
-9194	acceptable watered-down huge squat eldritch distillate	2	good	Last Available: "2016-11"
+9194	acceptable watered-down squat huge eldritch distillate	2	good	Last Available: "2016-11"
 9195	mixed eldritch essence	1		Last Available: "2016-11"
 9196	supercharged Science Notebook	0		Maximum MP Percent: +30
 9197	wool Rosewater's eldritch hat of doom	0		Mysticality Percent: +30, Spooky Spell Damage: +50, Cold Resistance: +1, Last Available: "2016-11"
@@ -9108,11 +9108,11 @@
 9236	tumbling electrified rock-hard gingerbread gavel	0		Damage Reduction: 5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	watered-down hand-crafted ginger beer	2	EPIC	Last Available: "2016-12"
+9239	hand-crafted watered-down ginger beer	2	EPIC	Last Available: "2016-12"
 9240	fuchsia spare chocolate parts	0		Last Available: "2016-12"
 9241	boiled double-colloidal anodized industrial frosting	0		Effect: "Fit To Be Tide", Effect Duration: 56, Last Available: "2016-12"
 9242	quantum anodized blurry fake cocktail	0		Effect: "Improprie Tea", Effect Duration: 29, Last Available: "2016-12"
-9243	aged practically non-alcoholic high-end ginger wine	1	awesome	Last Available: "2016-12"
+9243	practically non-alcoholic aged high-end ginger wine	1	awesome	Last Available: "2016-12"
 9244	brawny plastic bad vibe	0		Muscle Percent: +20, Last Available: "2016-12"
 9245	plastic angry vikings of the boozehound	0		Booze Drop: +100, Last Available: "2016-12"
 9246	blinking quilted plastic Knows About Chakras	0		Damage Absorption: +40, Last Available: "2016-12"
@@ -9121,9 +9121,9 @@
 9249	electrified Inner Wisdom	0		Effect: "Innately Strong", Effect Duration: 29, Last Available: "2016-12"
 9250	diffused super-electrified pulsating Inner Strength	0		Effect: "Conspiratory Eyes", Effect Duration: 36, Last Available: "2016-12"
 9251	non-nitrogenated enhanced Inner Truth	0		Effect: "Wings of the Grasshopper", Effect Duration: 28, Last Available: "2016-12"
-9252	decent miniature spiritual candy cane	2	good	Last Available: "2016-12"
+9252	miniature decent spiritual candy cane	2	good	Last Available: "2016-12"
 9253	artisanal spiritual eggnog	3	EPIC	Last Available: "2016-12"
-9254	normal snack-sized skewed spiritual fruitcake	2	good	Last Available: "2016-12"
+9254	snack-sized normal skewed spiritual fruitcake	2	good	Last Available: "2016-12"
 9255	toothsome special spiritual gingerbread	3	awesome	Effect: "Cock of the Walk", Effect Duration: 10, Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	bouncing negative lump	0		
 9273	blue greasy Third Eye of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Last Available: "2016-12"
 9274	chilly groovy Krampus Horn	0		Moxie Percent: +10, Cold Damage: +5, Single Equip, Last Available: "2016-12"
-9275	spoiled bite-sized hambrosier	1	crappy	Last Available: "2016-12"
-9276	bad irresponsibly strong upside-down chakra-mental wine	6	decent	Last Available: "2016-12"
+9275	bite-sized spoiled hambrosier	1	crappy	Last Available: "2016-12"
+9276	irresponsibly strong bad upside-down chakra-mental wine	6	decent	Last Available: "2016-12"
 9277	dry alkaline liquefied shaking chakra malt	0		Effect: "Crimbo Epiphany", Effect Duration: 58, Last Available: "2016-12"
-9278	special spoiled big wobbly narrow Black Angus blackburger	5	crappy	Effect: "Egg-headedness", Effect Duration: 30, Last Available: "2016-12"
-9279	irresponsibly strong fancy hand-crafted brandy	7	EPIC	Effect: "Towering Strength", Effect Duration: 5, Last Available: "2016-12"
+9278	special big spoiled wobbly narrow Black Angus blackburger	5	crappy	Effect: "Egg-headedness", Effect Duration: 30, Last Available: "2016-12"
+9279	hand-crafted irresponsibly strong fancy brandy	7	EPIC	Effect: "Towering Strength", Effect Duration: 5, Last Available: "2016-12"
 9280	ionized polymerized potion of spiritual gunkifying	0		Effect: "Insatiable Hunger", Effect Duration: 12, Last Available: "2016-12"
 9281	purple steel-toed bad vibroknife of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 9, Last Available: "2016-12"
 9282	Van der Graaf Fonzie's crystal belt buckle	0		Experience (Moxie): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12"
@@ -9168,9 +9168,9 @@
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	flavorless twirling toast with hot jelly	4	decent	Last Available: "2017-01"
 9298	super-sized flavorless toast with jelly	5	decent	Last Available: "2017-01"
-9299	decent half-sized toast with jelly	2	good	Last Available: "2017-01"
-9300	moldy snack-sized special toast with sleaze jelly	2	crappy	Effect: "Yuletide Mutations", Effect Duration: 10, Last Available: "2017-01"
-9301	gigantic rotten toast with stench jelly	9	crappy	Last Available: "2017-01"
+9299	half-sized decent toast with jelly	2	good	Last Available: "2017-01"
+9300	snack-sized moldy special toast with sleaze jelly	2	crappy	Effect: "Yuletide Mutations", Effect Duration: 10, Last Available: "2017-01"
+9301	rotten gigantic toast with stench jelly	9	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9178,7 +9178,7 @@
 9306	twirling Samson's weightlifter's candle	0		Muscle: +15, Experience (Muscle): +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	normal miniature wax pancake	2	good	Last Available: "2017-01"
 9308	Usain Bolt's Jeselnik's wax face	0		Sleaze Damage: +25, Initiative: +80, Last Available: "2017-01"
-9309	special distilled lousy wax booze	5	decent	Effect: "Texas Elegance", Effect Duration: 10, Last Available: "2017-01"
+9309	lousy special distilled wax booze	5	decent	Effect: "Texas Elegance", Effect Duration: 10, Last Available: "2017-01"
 9310	narrow glob of melted wax	0		Last Available: "2017-01"
 9311	dried skewed sea jelly	1		Last Available: "2017-01"
 9312	flavorless sea truffle	4	decent	Last Available: "2017-01"
@@ -9187,7 +9187,7 @@
 9315	twirling horrifying recovered cufflinks	0		Spooky Damage: +25, Single Equip, Last Available: "2017-01"
 9316	narrow heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	pressed aerosolized maroon ghostly LOV Elixir #3	0		Effect: "Celestial Sheen", Effect Duration: 32, Last Available: "2017-02"
-9318	alkaline lime green skewed LOV Elixir #6	0		Effect: "Sepia Tan", Effect Duration: 67, Last Available: "2017-02"
+9318	alkaline skewed lime green LOV Elixir #6	0		Effect: "Sepia Tan", Effect Duration: 67, Last Available: "2017-02"
 9319	double-modified non-ionized blinking LOV Elixir #9	0		Effect: "Memory of Strength", Effect Duration: 18, Last Available: "2017-02"
 9320	inspector's knitted experienced LOV Eardigan	0		Experience: +2, Cold Resistance: +3, Item Drop: +15, Lasts Until Rollover, Last Available: "2017-02"
 9321	teal personal trainer's LOV Epaulettes of the pedagogue of the boozehound	0		Experience: +3, Experience Percent (Muscle): +10, Booze Drop: +100, Lasts Until Rollover, Last Available: "2017-02"
@@ -9236,33 +9236,33 @@
 9364	bouncing imaginary lemon	0		Last Available: "2017-03"
 9365	lousy huge literal grasshopper	3	decent	Last Available: "2017-03"
 9366	aged watered-down double entendre	2	awesome	Last Available: "2017-03"
-9367	weak acceptable Phlegethon	2	good	Last Available: "2017-03"
+9367	acceptable weak Phlegethon	2	good	Last Available: "2017-03"
 9368	hand-crafted high-proof Siberian sunrise	7	EPIC	Last Available: "2017-03"
-9369	tolerable weak mentholated wine	2	good	Last Available: "2017-03"
+9369	weak tolerable mentholated wine	2	good	Last Available: "2017-03"
 9370	bad enchanted low tide martini	3	decent	Effect: "Can't Smell Nothin'", Effect Duration: 10, Last Available: "2017-03"
-9371	weak bad blinking shroomtini	2	decent	Last Available: "2017-03"
+9371	bad weak blinking shroomtini	2	decent	Last Available: "2017-03"
 9372	aged morning dew	3	awesome	Last Available: "2017-03"
 9373	tolerable huge whiskey squeeze	4	good	Last Available: "2017-03"
 9374	boozy perfectly mixed great fashioned	5	EPIC	Last Available: "2017-03"
 9375	smooth green Gnomish sagngria	4	awesome	Last Available: "2017-03"
-9376	fancy fortified hand-crafted ghostly vodka stinger	5	EPIC	Effect: "Gleaming White Teeth", Effect Duration: 40, Last Available: "2017-03"
-9377	artisanal practically non-alcoholic extremely slippery nipple	1	EPIC	Last Available: "2017-03"
-9378	perfectly mixed irresponsibly strong piscatini	8	EPIC	Last Available: "2017-03"
+9376	fortified hand-crafted fancy ghostly vodka stinger	5	EPIC	Effect: "Gleaming White Teeth", Effect Duration: 40, Last Available: "2017-03"
+9377	practically non-alcoholic artisanal extremely slippery nipple	1	EPIC	Last Available: "2017-03"
+9378	irresponsibly strong perfectly mixed piscatini	8	EPIC	Last Available: "2017-03"
 9379	mediocre olive Churchill	3	decent	Last Available: "2017-03"
 9380	hand-crafted soilzerac	4	EPIC	Last Available: "2017-03"
 9381	artisanal weak London frog	2	EPIC	Last Available: "2017-03"
 9382	hand-crafted watered-down pulsating nothingtini	2	EPIC	Last Available: "2017-03"
 9383	bad eighth plague	4	decent	Last Available: "2017-03"
-9384	hand-crafted watered-down single entendre	2	EPIC	Last Available: "2017-03"
+9384	watered-down hand-crafted single entendre	2	EPIC	Last Available: "2017-03"
 9385	distilled mediocre blinking reverse Tantalus	5	decent	Last Available: "2017-03"
-9386	fancy lousy elemental caipiroska	3	decent	Effect: "Crusty Head", Effect Duration: 40, Last Available: "2017-03"
+9386	lousy fancy elemental caipiroska	3	decent	Effect: "Crusty Head", Effect Duration: 40, Last Available: "2017-03"
 9387	smooth blinking Feliz Navidad	3	awesome	Last Available: "2017-03"
 9388	artisanal mirror Bloody Nora	4	EPIC	Last Available: "2017-03"
 9389	triple-distilled drinkable moreltini	9	good	Last Available: "2017-03"
 9390	drinkable hell in a bucket	3	good	Last Available: "2017-03"
-9391	enchanted perfectly mixed high-proof Newark	7	EPIC	Effect: "Pasta Oneness", Effect Duration: 20, Last Available: "2017-03"
+9391	enchanted high-proof perfectly mixed Newark	7	EPIC	Effect: "Pasta Oneness", Effect Duration: 20, Last Available: "2017-03"
 9392	aged R'lyeh	4	awesome	Last Available: "2017-03"
-9393	practically non-alcoholic acceptable Gnollish sangria	1	good	Last Available: "2017-03"
+9393	acceptable practically non-alcoholic Gnollish sangria	1	good	Last Available: "2017-03"
 9394	tolerable twirling vodka barracuda	4	good	Last Available: "2017-03"
 9395	lousy Mysterious Island iced tea	3	decent	Last Available: "2017-03"
 9396	triple-distilled delicious drive-by shooting	10	awesome	Last Available: "2017-03"
@@ -9284,25 +9284,25 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	tumbling green geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	decent bouncing ghostly edible alien plant bit	3	good	Last Available: "2017-04"
+9415	decent ghostly bouncing edible alien plant bit	3	good	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	narrow alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
-9419	wobbly yellow fascinating alien plant sample	0		Last Available: "2017-04"
+9419	yellow wobbly fascinating alien plant sample	0		Last Available: "2017-04"
 9420	compressed upside-down alien plant goo	1		Last Available: "2017-04"
 9421	skewed alien plant pod	0		Last Available: "2017-04"
 9422	skewed zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	delicious alien meat	3	awesome	Last Available: "2017-04"
 9424	huge alien toenails	0		Last Available: "2017-04"
 9425	skewed alien zoological sample	0		Last Available: "2017-04"
-9426	purple jittery complex alien zoological sample	0		Last Available: "2017-04"
+9426	jittery purple complex alien zoological sample	0		Last Available: "2017-04"
 9427	lime green fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	vaporized narrow alien animal goo	1		Last Available: "2017-04"
 9429	blinking alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	blinking murderbot data core	0		Last Available: "2017-04"
 9432	non-enhanced wet pressed pulsating alien medicine	0		Effect: "Pie in the Sky", Effect Duration: 14, Last Available: "2017-04"
-9433	low-calorie adequate alien salad	1	good	Last Available: "2017-04"
+9433	adequate low-calorie alien salad	1	good	Last Available: "2017-04"
 9434	aged watered-down alien booze	2	awesome	Last Available: "2017-04"
 9435	wobbly up-at-dawn therapeutic alien mask of the sewer	0		Stench Damage: +25, Adventures: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-04"
 9436	rosewater-soaked clever alien spear of wisdom	0		Mysticality: +15, Maximum MP: +20, Stench Resistance: +3, Last Available: "2017-04"
@@ -9318,14 +9318,14 @@
 9446	toasty razor-sharp spant backplate	0		Weapon Damage Percent: +25, Hot Damage: +5, Last Available: "2017-04"
 9447	foul-smelling spant spear of the glutton	0		Stench Damage: +10, Food Drop: +100, Last Available: "2017-04"
 9448	murderbot power cell	0		Last Available: "2017-04"
-9449	lime green shaking murderbot component casing	0		Last Available: "2017-04"
+9449	shaking lime green murderbot component casing	0		Last Available: "2017-04"
 9450	murderbot monofilament	0		Last Available: "2017-04"
 9451	vacuum-sealed aerosolized altered murderbot shield unit	0		Effect: "Proprie Tea", Effect Duration: 38, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	sharpshooter's ruddy forbidden murderbot mask	0		Spell Damage Percent: +50, Maximum HP Percent: +40, Critical Hit Percent: +10, Avatar: "Murderbot", Last Available: "2017-04"
 9454	oxidized tarnished lime green skewed murderbot spring injector	0		Effect: "Fastbreaker", Effect Duration: 53, Last Available: "2017-04"
 9455	double-paned murderbot whip of temperance	0		Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2017-04"
-9456	murderbot plasma rifle of the ox of courage	0		Muscle: +20, Spooky Resistance: +3, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	murderbot plasma rifle of the ox of courage	0		Muscle: +20, Spooky Resistance: +3, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	squat murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	yellow Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9335,7 +9335,7 @@
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	bouncing Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
-9466	decent special half-sized maroon Aldebaran sardines	2	good	Effect: "Halloweeny", Effect Duration: 25, Last Available: "2017-04"
+9466	half-sized decent special maroon Aldebaran sardines	2	good	Effect: "Halloweeny", Effect Duration: 25, Last Available: "2017-04"
 9467	perfectly mixed Centauri fish wine	3	EPIC	Last Available: "2017-04"
 9468	twisted oxygen	1		Last Available: "2017-04"
 9469	perfumed Newton's Spacegate scientist's insignia	0		Experience (Mysticality): +3, Stench Resistance: +5, Single Equip, Last Available: "2017-04"
@@ -9343,29 +9343,29 @@
 9471	rosewater-soaked crafty Spacegate diplomat's insignia of the empath	0		Maximum MP: +10, Familiar Weight: +5, Stench Resistance: +3, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	upside-down Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	decent bite-sized alien sandwich	1	good	Last Available: "2017-04"
+9474	bite-sized decent alien sandwich	1	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
-9476	unsweetened polarized skewed maroon Spant eggs	0		Effect: "Tingling Feeling", Effect Duration: 68
+9476	unsweetened polarized maroon skewed Spant eggs	0		Effect: "Tingling Feeling", Effect Duration: 68
 9477	ghostly Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	super-Vulcanized concentrated Daily Affirmation: Always be Collecting	0		Effect: "Sleazy Hands", Effect Duration: 61, Last Available: "2017-05"
-9480	non-galvanized pulsating maroon Daily Affirmation: Think Win-Lose	0		Effect: "Leo Rising", Effect Duration: 23, Last Available: "2017-05"
+9480	non-galvanized maroon pulsating Daily Affirmation: Think Win-Lose	0		Effect: "Leo Rising", Effect Duration: 23, Last Available: "2017-05"
 9481	wet pulsating Daily Affirmation: Be Superficially interested	0		Effect: "Cinnamouth", Effect Duration: 28, Last Available: "2017-05"
 9482	tarnished warmed skewed ghostly Daily Affirmation: Adapt to Change Eventually	0		Effect: "Space Cowboy", Effect Duration: 40, Last Available: "2017-05"
 9483	electrified ghostly huge Daily Affirmation: Be a Mind Master	0		Effect: "Strange Mental Acuity", Effect Duration: 66, Last Available: "2017-05"
-9484	ionized pulsating skewed Daily Affirmation: Work For Hours a Week	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 30, Last Available: "2017-05"
+9484	ionized skewed pulsating Daily Affirmation: Work For Hours a Week	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 30, Last Available: "2017-05"
 9485	quadruple-cold-filtered Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Spookyravin'", Effect Duration: 59, Last Available: "2017-05"
-9486	spoiled enchanted olive tumbling Affirmation Cookie	3	crappy	Effect: "Grape Expectations", Effect Duration: 40, Last Available: "2017-05"
+9486	enchanted spoiled tumbling olive Affirmation Cookie	3	crappy	Effect: "Grape Expectations", Effect Duration: 40, Last Available: "2017-05"
 9487	License To Kill	0		
 9488	huge Thwaitgold bug statuette	0		
 9489	wobbly Victor's Spoils	0		
 9490	quadruple-polymerized adjusted jittery Threatening Missive	0		Effect: "Seriously Mutated", Effect Duration: 15
-9491	twirling blue twirling Targeted Plague Vector	0		
+9491	twirling twirling blue Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	Kremlin's Greatest Briefcase of James Dean of the bloodbag of the cheetah	0		Experience (Moxie): +3, Maximum HP: +100, Initiative: +60, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	high-proof enchanted mediocre ghostly basic martini	7	decent	Effect: "Engorged Weapon", Effect Duration: 15, Last Available: "2017-06"
+9493	Kremlin's Greatest Briefcase of James Dean of the bloodbag of the cheetah	0		Experience (Moxie): +3, Maximum HP: +100, Initiative: +60, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	high-proof mediocre enchanted ghostly basic martini	7	decent	Effect: "Engorged Weapon", Effect Duration: 15, Last Available: "2017-06"
 9495	acceptable improved martini	3	good	Last Available: "2017-06"
-9496	watered-down hand-crafted splendid martini	2	EPIC	Last Available: "2017-06"
+9496	hand-crafted watered-down splendid martini	2	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	green pulsating tattoo gun	0		Last Available: "2017-06"
@@ -9373,8 +9373,8 @@
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	cyan narrow aromatic nippy plastic gundam of the glutton	0		Cold Damage: +10, Stench Resistance: +1, Food Drop: +100, Last Available: "2017-06"
 9503	purple License to Chill	0		Last Available: "2017-07"
-9504	jittery fuchsia Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
-9505	twirling huge Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
+9504	fuchsia jittery Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
+9505	huge twirling Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
 9507	jittery fuchsia LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	spinning Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
@@ -9388,11 +9388,11 @@
 9516	meteoroid	0		Last Available: "2017-08"
 9517	spinning prompt supercharged curative meteortarboard	0		Maximum MP Percent: +30, Adventures: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-08"
 9518	frightening thinker's meteorite guard of the brute	0		Mysticality: +10, Muscle Percent: +30, Spooky Damage: +5, Damage Reduction: 9, Last Available: "2017-08"
-9519	curative meteorb of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5, Lantern Element: "Hot", Last Available: "2017-08"
+9519	curative meteorb of dire peril	0		Weapon Damage: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-08", Lantern Element: "Hot"
 9520	mirror ghostly scorching lion tamer's asteroid belt	0		Experience (familiar): +2, Hot Damage: +25, Single Equip, Last Available: "2017-08"
 9521	lion tamer's slick meteorthopedic shoes of the wise owl	0		Mysticality: +20, Moxie: +10, Experience (familiar): +2, Single Equip, Last Available: "2017-08"
 9522	red veiny studded shooting morning star of the scaredy-cat	0		Damage Absorption: +80, Maximum HP: +10, Monster Level: -15, Single Equip, Last Available: "2017-08"
-9523	spinning huge fuchsia meteoroid	0		Last Available: "2017-08"
+9523	fuchsia huge spinning meteoroid	0		Last Available: "2017-08"
 9524	meteor shower cap	0		Familiar Weight: +5
 9525	bouncing Thwaitgold time fly statuette	0		
 9526	pulsating perfectly fair coin	0		Last Available: "2017-11"
@@ -9425,7 +9425,7 @@
 9553	distilled glyph of athleticism	1		Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	colloidal triple-aerosolized shaking new habit	0		Effect: "Eye of the Seal", Effect Duration: 44, Last Available: "2017-10"
-9556	skewed squat bridge truss	0		Last Available: "2017-10"
+9556	squat skewed bridge truss	0		Last Available: "2017-10"
 9557	razor-sharp Socratic pearl necklace of courage	0		Experience (Mysticality): +1, Weapon Damage Percent: +25, Spooky Resistance: +3, Single Equip, Last Available: "2017-10"
 9558	blinking amorphous blob	0		Last Available: "2017-11"
 9559	X	0		Last Available: "2017-11"
@@ -9434,7 +9434,7 @@
 9562	sizzling hardened banded protection stick of the overflowing toilet	0		Damage Absorption: +100, Damage Reduction: 3, Hot Damage: +10, Stench Spell Damage: +50
 9563	oxidized blinking roll of meat	0		Effect: "Yet tea", Effect Duration: 26
 9564	blurry razor-sharp mafia thumb ring of the brazier	0		Weapon Damage Percent: +25, Hot Spell Damage: +25, Single Equip
-9565	unsweetened extra-liquefied jittery teal cocoa chondrule	0		Effect: "Abyssal Blood", Effect Duration: 61, Last Available: "2020-09"
+9565	unsweetened extra-liquefied teal jittery cocoa chondrule	0		Effect: "Abyssal Blood", Effect Duration: 61, Last Available: "2020-09"
 9566	tumbling censurious Newton's mafia middle finger ring	0		Experience (Mysticality): +3, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	blue bouncing prompt boxer's thinker's steel drivin' hammer of the bloodbag	0		Mysticality: +10, Muscle Percent: +10, Maximum HP: +100, Adventures: +3
 9568	piece of steel	0		
@@ -9453,7 +9453,7 @@
 9581	hand-crafted neg grog	4	EPIC	Last Available: "2017-12"
 9582	stale snack-sized half double fruitcake	2	decent	Last Available: "2017-12"
 9583	adequate blurry hushed puppy	3	good	Last Available: "2017-12"
-9584	flavorless green upside-down muffled muffuletta	3	decent	Last Available: "2017-12"
+9584	flavorless upside-down green muffled muffuletta	3	decent	Last Available: "2017-12"
 9585	miniature bland shushed potatoes	2	decent	Last Available: "2017-12"
 9586	plastic mime functionary of the sewer	0		Stench Damage: +25, Last Available: "2017-12"
 9587	Annie Oakley's plastic mime scientist	0		Critical Hit Percent: +20, Last Available: "2017-12"
@@ -9492,7 +9492,7 @@
 9620	silent V	0		Last Available: "2017-12"
 9621	wobbly silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
-9623	narrow cyan silent Y	0		Last Available: "2017-12"
+9623	cyan narrow silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
 9625	mirror crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
@@ -9511,18 +9511,18 @@
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	tumbling The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
-9642	lime green pulsating The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
+9642	pulsating lime green The Journal of Mime Science Vol. 4 (used)	0		Skill: "Silent Treatment", Last Available: "2017-12"
 9643	huge The Journal of Mime Science Vol. 5	0		Skill: "Silent Knife", Last Available: "2017-12"
 9644	wobbly The Journal of Mime Science Vol. 5 (used)	0		Skill: "Silent Knife", Last Available: "2017-12"
-9645	wobbly tumbling The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
+9645	tumbling wobbly The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	smooth watered-down executive mime flask	2	awesome	Last Available: "2017-12"
-9649	half-sized rotten nega-mushroom	2	crappy	Last Available: "2017-12"
+9648	watered-down smooth executive mime flask	2	awesome	Last Available: "2017-12"
+9649	rotten half-sized nega-mushroom	2	crappy	Last Available: "2017-12"
 9650	lousy blurry nega-mushroom wine	3	decent	Last Available: "2017-12"
 9651	quantum improved Cheer-Up soda	0		Effect: "Grumpy and Ornery", Effect Duration: 67, Last Available: "2017-12"
-9652	normal gigantic mime army rations	8	good	Last Available: "2017-12"
-9653	delicious watered-down bouncing mime army wine	2	awesome	Last Available: "2017-12"
+9652	gigantic normal mime army rations	8	good	Last Available: "2017-12"
+9653	watered-down delicious bouncing mime army wine	2	awesome	Last Available: "2017-12"
 9654	powdered mime army superserum	1		Last Available: "2017-12"
 9655	oxidized improved mime army camouflage kit	0		Effect: "Extra Terrestrial", Effect Duration: 45, Last Available: "2017-12"
 9656	red miming beret of the bloodbag of bravery	0		Maximum HP: +100, Spooky Resistance: +5, Last Available: "2017-12"
@@ -9533,15 +9533,15 @@
 9661	God Lobster Egg	0		Free Pull, Last Available: "2018-05"
 9662	donated booze	0		
 9663	donated food	0		
-9664	upside-down green spinning donated candy	0		
+9664	upside-down spinning green donated candy	0		
 9665	frozen unsweetened modified digital honeypot	0		Effect: "Sweetened and Fattened", Effect Duration: 15, Last Available: "2025-12"
 9666	cyan mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of courage	0		Spooky Resistance: +3, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	banded mime army insignia (intelligence)	0		Damage Absorption: +100, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	cyan mime army insignia (espionage) of the dark arts	0		Spell Damage Percent: +100, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	mime army insignia (infantry) of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	banded mime army insignia (intelligence)	0		Damage Absorption: +100, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	cyan mime army insignia (espionage) of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
-9672	blurry jittery mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
+9672	jittery blurry mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	narrow mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	auspicious mime army infiltration glove of extreme caution	0		Monster Level: -25, Item Drop: +10, Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	narrow kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	jumbo flavorless extra-toasted half sandwich	5	decent	Last Available: "2018-12"
-9682	lousy weak mulled hobo wine	2	decent	Last Available: "2018-12"
+9682	weak lousy mulled hobo wine	2	decent	Last Available: "2018-12"
 9683	jittery burning newspaper	0		Last Available: "2018-12"
 9684	quilted burning paper hat of the blizzard of courage	0		Damage Absorption: +40, Cold Spell Damage: +25, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2018-12"
 9685	censurious aromatic knitted burning cape	0		Cold Resistance: +3, Stench Resistance: +1, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2018-12"
@@ -9595,7 +9595,7 @@
 9727	delicious heart-shaped candy whetstone	3	awesome	Last Available: "2018-02"
 9728	bland Swedish massage fish	4	decent	Last Available: "2018-02"
 9729	drinkable extra-dry Third Base	5	good	Last Available: "2018-02"
-9730	artisanal practically non-alcoholic Bustle Hustler	1	EPIC	Last Available: "2018-02"
+9730	practically non-alcoholic artisanal Bustle Hustler	1	EPIC	Last Available: "2018-02"
 9731	tarnished Fabiotion	0		Effect: "Ninja, Please", Effect Duration: 55, Last Available: "2018-02"
 9732	tarnished super-electrified Bettie page	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 31, Last Available: "2018-02"
 9733	oxidized pickled activated green tonic o' Banderas	0		Effect: "Sizzling with Fury", Effect Duration: 32, Last Available: "2018-02"
@@ -9651,7 +9651,7 @@
 9783	Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
-9786	ghostly red bouncing Flan	0		Last Available: "2018-03"
+9786	bouncing ghostly red Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	Ched	0		Last Available: "2018-03"
 9789	maroon Gazelleton	0		Last Available: "2018-03"
@@ -9687,7 +9687,7 @@
 9819	squat Snarf berry	0		Last Available: "2018-03"
 9820	blue Keese berry	0		Last Available: "2018-03"
 9821	squat luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
-9822	spinning olive upside-down shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9822	spinning upside-down olive shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	purple spinning muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	spinning olive amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9698,10 +9698,10 @@
 9830	powdered glistening oyster egg	1		
 9831	compressed scintillating oyster egg	1		
 9832	modified pearlescent oyster egg	1		Effect: "critical.enh", Effect Duration: 20
-9833	dehydrated wobbly purple lustrous oyster egg	1		
+9833	dehydrated purple wobbly lustrous oyster egg	1		
 9834	mixed yellow gleaming oyster egg	1		Effect: "Starry-Eyed", Effect Duration: 10
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
-9836	fuchsia jittery FantasyRealm guest pass	0		Last Available: "2018-04"
+9836	jittery fuchsia FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	tumbling prompt ruddy FantasyRealm G. E. M. of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Adventures: +3, Lasts Until Rollover, Last Available: "2018-04"
 9838	blurry Rubee&trade;	0		Last Available: "2018-04"
 9839	experienced FantasyRealm Warrior's Helm	0		Experience: +2, Last Available: "2018-04"
@@ -9718,7 +9718,7 @@
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
 9851	fuchsia dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
-9853	yellow mirror poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
+9853	mirror yellow poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	skewed druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9727,8 +9727,8 @@
 9859	mirror LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	spoiled tiny upside-down FantasyRealm turkey leg	1	crappy	Last Available: "2018-04"
-9863	artisanal distilled FantasyRealm mead	5	EPIC	Last Available: "2018-04"
+9862	tiny spoiled upside-down FantasyRealm turkey leg	1	crappy	Last Available: "2018-04"
+9863	distilled artisanal FantasyRealm mead	5	EPIC	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9742,7 +9742,7 @@
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
-9877	blurry tumbling map to the Sprawling Cemetery	0		Last Available: "2018-04"
+9877	tumbling blurry map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	adequate lime green denastified haunch	3	good	Last Available: "2018-04"
 9879	tolerable watered-down bad rum and good cola	2	good	Last Available: "2018-04"
 9880	liquefied upside-down Potion of Heroism	0		Effect: "Big Flaming Whip", Effect Duration: 45, Last Available: "2018-04"
@@ -9761,18 +9761,18 @@
 9893	executive occult wicked deadfall branch of Tarzan	0		Experience (Muscle): +3, Spell Damage: +5, Spell Damage Percent: +25, Meat Drop: +40
 9894	blurry Lo Pan's clever rock-hard stylish Staff of Kitchen Royalty of courage	0		Moxie: +25, Damage Reduction: 5, Maximum MP: +20, Spell Critical Percent: +30, Spooky Resistance: +3, Last Available: "2018-04"
 9895	fuchsia charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
-9896	skewed ghostly dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
+9896	ghostly skewed dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	aged two meat muck	3	awesome	
 9899	gigantic moldy chocolate Ogre Chieftain	6	crappy	
 9900	massive yummy chocolate &quot;Phoenix&quot;	6	awesome	
 9901	yummy chocolate Spider Queen	4	awesome	
 9902	mediocre hipster cocktail	4	decent	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	spinning God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	blurry God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	spinning God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	blurry God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	shaking G	0		
 9910	Garland of Greatness	0		
@@ -9797,11 +9797,11 @@
 9929	wobbly Tesla shellacked beefy Brutal brogues of bravery	0		Muscle: +10, Damage Reduction: 7, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-07"
 9930	fireproof clever smartaleck's beefcake's Draftsman's driving gloves	0		Muscle: +25, Moxie Percent: +30, Maximum MP: +20, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2018-07"
 9931	flame-retardant chilly brawny Nouveau nosering of mayonnaise	0		Muscle Percent: +20, Cold Damage: +5, Sleaze Spell Damage: +50, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2018-07"
-9932	aerosolized magnetized upside-down twirling blue sharkfin gumbo	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 56, Last Available: "2018-07"
+9932	aerosolized magnetized twirling blue upside-down sharkfin gumbo	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 56, Last Available: "2018-07"
 9933	polymerized polymerized blurry boiling broth	0		Effect: "Lobos Fresh", Effect Duration: 63, Last Available: "2018-07"
 9934	triple-Vulcanized squat interrogative elixir	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 22, Last Available: "2018-07"
 9935	yellow Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
-9936	green skewed Bastille Battalion tattoo kit	0		Last Available: "2018-07"
+9936	skewed green Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	cyan Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	kitten burglar	0		Free Pull, Last Available: "2018-07"
@@ -9821,7 +9821,7 @@
 9953	moldy thick blinking PB&J with the crusts cut off	5	crappy	Last Available: "2018-09"
 9954	tumbling steel-toed dorky glasses of the brazier	0		Damage Reduction: 9, Hot Spell Damage: +25, Single Equip, Last Available: "2018-09"
 9955	knitted ponytail clip of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +3, Last Available: "2018-09"
-9956	brainy paint palette	0		Mysticality: +5, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	brainy paint palette	0		Mysticality: +5, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	altered mirror Purple Beast energy drink	1		Last Available: "2018-09"
 9959	mansplainer's cosmetic football	0		Monster Level: +15, Last Available: "2018-09"
@@ -9843,15 +9843,15 @@
 9976	Jim Carey's rosy-cheeked party pants	0		Maximum HP Percent: +30, Monster Level: +25, Last Available: "2018-09"
 9977	frosty rosy-cheeked dangerous party whip	0		Weapon Damage: +10, Maximum HP Percent: +30, Cold Spell Damage: +10, Last Available: "2018-09"
 9978	shaking spinning Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	special watered-down mediocre TRIO cup of beer	2	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 10, Last Available: "2018-09"
+9979	watered-down mediocre special TRIO cup of beer	2	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 10, Last Available: "2018-09"
 9980	adequate party platter for one	3	good	Last Available: "2018-09"
 9981	dehydrated Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	spinning lion tamer's arcane researcher's party crasher	0		Experience Percent (Mysticality): +10, Experience (familiar): +2, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	tumbling huge Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	spinning lion tamer's arcane researcher's party crasher	0		Experience Percent (Mysticality): +10, Experience (familiar): +2, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	tumbling huge Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	pulsating party mouse hat	0		Familiar Weight: +5
-9987	wobbly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	wobbly latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	purple voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of incineration	0		Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-11"
@@ -9874,20 +9874,20 @@
 10008	ghostly teal Usain Bolt's thinker's mutant legs of Leguizamo	0		Mysticality: +10, Monster Level: +20, Initiative: +80, Last Available: "2018-11"
 10009	spinning forbidden Sinatra's mutant crown of Gandalf	0		Experience (Moxie): +5, Spell Damage Percent: +50, Spell Critical Percent: +20, Last Available: "2018-11"
 10010	bland half-sized cyan ghostly ectoplasm	2	decent	Last Available: "2018-11"
-10011	decent jumbo	5	good	Last Available: "2018-11"
+10011	jumbo decent	5	good	Last Available: "2018-11"
 10012	spirit-forward mediocre bottle of vodka	5	decent	Last Available: "2018-11"
 10013	moldy skewed pizza	4	crappy	Last Available: "2018-11"
-10014	mediocre fancy martini	3	decent	Effect: "Good with the Ladies", Effect Duration: 40, Last Available: "2018-11"
+10014	fancy mediocre martini	3	decent	Effect: "Good with the Ladies", Effect Duration: 40, Last Available: "2018-11"
 10015	bite-sized normal narrow blurry cherry pie	1	good	Last Available: "2018-11"
 10016	practically non-alcoholic perfectly mixed eggnog	1	super ultra mega EPIC	Last Available: "2018-11"
 10017	green glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	tasty Hell ramen	4	awesome	Last Available: "2018-11"
-10019	delicious fancy watered-down narrow gimlet	2	awesome	Effect: "Eau de Tortue", Effect Duration: 25, Last Available: "2018-11"
+10019	delicious watered-down fancy narrow gimlet	2	awesome	Effect: "Eau de Tortue", Effect Duration: 25, Last Available: "2018-11"
 10020	mediocre watered-down twice-haunted screwdriver	2	decent	Last Available: "2018-11"
-10021	jumbo adequate tumbling candy cane	5	good	Last Available: "2018-12"
+10021	adequate jumbo tumbling candy cane	5	good	Last Available: "2018-12"
 10022	mediocre runny fermented egg	4	decent	Last Available: "2018-12"
 10023	delicious oldcake	4	awesome	Last Available: "2018-12"
-10024	thick bland special traditional Crimbo cookie	5	decent	Effect: "Cosmic Flavor", Effect Duration: 40, Last Available: "2023-06"
+10024	bland special thick traditional Crimbo cookie	5	decent	Effect: "Cosmic Flavor", Effect Duration: 40, Last Available: "2023-06"
 10025	mirror educational plastic wild beaver	0		Experience: +1, Last Available: "2018-12"
 10026	blue executive plastic reindeer	0		Meat Drop: +40, Last Available: "2018-12"
 10027	mansplainer's plastic Caf&eacute; Elf	0		Monster Level: +15, Last Available: "2018-12"
@@ -9906,7 +9906,7 @@
 10040	big delicious wobbly moosemeat pie	5	awesome	Last Available: "2018-12"
 10041	Jack Frost's balanced antler	0		Cold Spell Damage: +50, Last Available: "2018-12"
 10042	family-friendly dam	0		Sleaze Resistance: +1, Damage Reduction: 9, Last Available: "2018-12"
-10043	watered-down lousy beavermouth	2	decent	Last Available: "2018-12"
+10043	lousy watered-down beavermouth	2	decent	Last Available: "2018-12"
 10044	high-proof mediocre beaver punch (papaya)	10	decent	Last Available: "2018-12"
 10045	lousy beaver punch (peach)	3	decent	Last Available: "2018-12"
 10046	bad spinning beaver punch (cherry)	4	decent	Last Available: "2018-12"
@@ -9915,7 +9915,7 @@
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	stale bouncing glass of raw eggs	3	decent	Last Available: "2018-12"
 10051	hand-crafted punch-drunk punch	3	EPIC	Last Available: "2018-12"
-10052	dried blurry narrow red body spradium	1		Last Available: "2018-12"
+10052	dried red blurry narrow body spradium	1		Last Available: "2018-12"
 10053	gray gravedigger's bauxite beret	0		Spooky Damage: +10, Last Available: "2018-12"
 10054	perfumed bauxite boxers	0		Stench Resistance: +5, Last Available: "2018-12"
 10055	vibrating bauxite bow-tie	0		Maximum MP Percent: +10, Single Equip, Last Available: "2018-12"
@@ -9933,7 +9933,7 @@
 10067	bland mirror yule gruel	3	decent	Last Available: "2018-12"
 10068	artisanal hot watered rum	3	EPIC	Last Available: "2018-12"
 10069	acceptable upside-down bottle of Crimbognac	3	good	Last Available: "2018-12"
-10070	bland miniature Crimboysters Rockefeller	2	decent	Last Available: "2018-12"
+10070	miniature bland Crimboysters Rockefeller	2	decent	Last Available: "2018-12"
 10071	powdered Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	marble mariachi hat of Calamity Jane of extreme caution	0		Critical Hit Percent: +15, Monster Level: -25, Last Available: "2019-12"
 10096	dried tumbling marble molecules	1		Last Available: "2019-12"
 10097	anodized diffused spinning Mallomarbles	0		Effect: "Cotton Mouthed", Effect Duration: 14
-10098	maroon nasty punching bag of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	Van der Graaf arcane researcher's pith helmet	0		Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	miser's Jim Carey's poncho	0		Monster Level: +25, Meat Drop: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	Van der Graaf sage pendant	0		Mysticality Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	shellacked Da Vinci's palazzos	0		Experience (Mysticality): +5, Damage Reduction: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	brawny pseudoaccordion of the sweet-tooth	0		Muscle Percent: +20, Candy Drop: +100, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	maroon nasty punching bag of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	Van der Graaf arcane researcher's pith helmet	0		Experience Percent (Mysticality): +10, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	miser's Jim Carey's poncho	0		Monster Level: +25, Meat Drop: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	Van der Graaf sage pendant	0		Mysticality Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	shellacked Da Vinci's palazzos	0		Experience (Mysticality): +5, Damage Reduction: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	brawny pseudoaccordion of the sweet-tooth	0		Muscle Percent: +20, Candy Drop: +100, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	compressed green spinning pieces	1		Effect: "Mer-kinny Flavor", Effect Duration: 40, Last Available: "2020-12"
 10105	warmed Para-Pop	0		Effect: "The Two-Prong Crown", Effect Duration: 53
-10106	wobbly narrow fireproof strapping terra cotta truss	0		Muscle: +5, Hot Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	veiny hardened terra cotta trousers	0		Damage Reduction: 3, Maximum HP: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	prompt careful terra cotta tongs	0		Monster Level: -10, Adventures: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	supercool brawny terra cotta train	0		Muscle Percent: +20, Moxie Percent: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	auspicious double-paned terra cotta tie tack	0		Cold Resistance: +5, Item Drop: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	Usain Bolt's smartaleck's terra cotta tambourine	0		Moxie Percent: +30, Initiative: +80, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	wobbly narrow fireproof strapping terra cotta truss	0		Muscle: +5, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	veiny hardened terra cotta trousers	0		Damage Reduction: 3, Maximum HP: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	prompt careful terra cotta tongs	0		Monster Level: -10, Adventures: +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	supercool brawny terra cotta train	0		Muscle Percent: +20, Moxie Percent: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	auspicious double-paned terra cotta tie tack	0		Cold Resistance: +5, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	Usain Bolt's smartaleck's terra cotta tambourine	0		Moxie Percent: +30, Initiative: +80, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	compressed red terra cotta tidbits	1		Last Available: "2020-12"
 10113	moist pulsating huge terra panna cotta	0		Effect: "Goldentongue", Effect Duration: 60
 10114	mansplainer's velour voulge of the scaredy-cat	0		Monster Level: 0, Last Available: "2021-12"
@@ -9993,21 +9993,21 @@
 10127	Lo Pan's glass serape of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Last Available: "2021-12"
 10128	boiled pulsating shaking glass shards	1		Last Available: "2021-12"
 10129	warmed hard candy	0		Effect: "Mushroom Melody", Effect Duration: 51
-10130	sizzling stiffened loofah lumberjack's hat	0		Damage Reduction: 1, Hot Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	chilly loofah lei of dire peril	0		Weapon Damage: +20, Cold Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	up-at-dawn personal trainer's loofah lederhosen	0		Experience Percent (Muscle): +10, Adventures: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	lion tamer's loofah ladle of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	teal blinking curative loofah legwarmers of chilblains	0		Cold Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	greedy perfumed loofah lavalier	0		Stench Resistance: +5, Meat Drop: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	sizzling stiffened loofah lumberjack's hat	0		Damage Reduction: 1, Hot Damage: +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	chilly loofah lei of dire peril	0		Weapon Damage: +20, Cold Damage: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	up-at-dawn personal trainer's loofah lederhosen	0		Experience Percent (Muscle): +10, Adventures: +5, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	lion tamer's loofah ladle of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	teal blinking curative loofah legwarmers of chilblains	0		Cold Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	greedy perfumed loofah lavalier	0		Stench Resistance: +5, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	boiled loofah lumps	1		Last Available: "2022-12"
 10137	polarized ghostly chocolate-covered loofah	0		Effect: "Granolarrrgh", Effect Duration: 55
-10138	maroon blurry flagstone flag of the bloodbag of the empath	0		Maximum HP: +100, Familiar Weight: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	pulsating rock-hard flagstone flail of incineration	0		Damage Reduction: 5, Hot Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	Jim Carey's banded flagstone flip-flops	0		Damage Absorption: +100, Monster Level: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	Annie Oakley's dangerous flagstone fez	0		Weapon Damage: +10, Critical Hit Percent: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	dog trainer's dance instructor's flagstone fleece	0		Experience Percent (Moxie): +10, Experience (familiar): +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	twirling teal Van der Graaf flagstone fringe of the glutton	0		Food Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	denatured ghostly twirling purple flagstone flagments	1		Last Available: "2022-12"
+10138	maroon blurry flagstone flag of the bloodbag of the empath	0		Maximum HP: +100, Familiar Weight: +5, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	pulsating rock-hard flagstone flail of incineration	0		Damage Reduction: 5, Hot Spell Damage: +50, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	Jim Carey's banded flagstone flip-flops	0		Damage Absorption: +100, Monster Level: +25, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	Annie Oakley's dangerous flagstone fez	0		Weapon Damage: +10, Critical Hit Percent: +20, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	dog trainer's dance instructor's flagstone fleece	0		Experience Percent (Moxie): +10, Experience (familiar): +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	twirling teal Van der Graaf flagstone fringe of the glutton	0		Food Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10144	denatured ghostly purple twirling flagstone flagments	1		Last Available: "2022-12"
 10145	super-enhanced Flag by the Foot&trade;	0		Effect: "Sweet and Yellow", Effect Duration: 30
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
@@ -10029,19 +10029,19 @@
 10163	tarnished improved spinning government-issued candy	0		Effect: "Strong Spirit", Effect Duration: 68
 10164	modified activated shaking lime green Pneumo bar	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 12
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	upside-down resourceful Fonzie's Lil' Doctor&trade; bag	0		Experience (Moxie): +1, Maximum MP: +50, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	upside-down resourceful Fonzie's Lil' Doctor&trade; bag	0		Experience (Moxie): +1, Maximum MP: +50, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	rotten wobbly bloodstick	4	crappy	
-10170	tolerable watered-down yellow narrow bottle of Sanguiovese	2	good	
+10170	watered-down tolerable narrow yellow bottle of Sanguiovese	2	good	
 10171	rotten snack-sized actual blood sausage	2	crappy	
 10172	smooth mulled blood	4	awesome	
-10173	adequate special diet blood snowcone	1	good	Effect: "Hip to Be Square Dancin'", Effect Duration: 25
-10174	weak lousy Red Russian	2	decent	
-10175	half-sized bland blood roll-up	2	decent	
-10176	fortified hand-crafted ghostly bottle of blood	5	EPIC	
+10173	special diet adequate blood snowcone	1	good	Effect: "Hip to Be Square Dancin'", Effect Duration: 25
+10174	lousy weak Red Russian	2	decent	
+10175	bland half-sized blood roll-up	2	decent	
+10176	hand-crafted fortified ghostly bottle of blood	5	EPIC	
 10177	normal blood-soaked sponge cake	4	good	
 10178	practically non-alcoholic perfectly mixed bouncing vampagne	1	super ultra mega turbo EPIC	
-10179	spoiled low-calorie plain snowcone	1	crappy	
+10179	low-calorie spoiled plain snowcone	1	crappy	
 10180	blurry Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
@@ -10063,18 +10063,18 @@
 10198	huge Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	miniature spoiled bouncing crabsicle	2	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	watered-down hand-crafted mirror bottle of dark rhum	2	EPIC	Last Available: "2019-04"
+10201	hand-crafted watered-down mirror bottle of dark rhum	2	EPIC	Last Available: "2019-04"
 10202	bad boozy bottle of extra-dark rhum	5	decent	Last Available: "2019-04"
-10203	watered-down aged bottle of super-extra-dark rhum	2	awesome	Last Available: "2019-04"
+10203	aged watered-down bottle of super-extra-dark rhum	2	awesome	Last Available: "2019-04"
 10204	dry concentrated pirate shaving cream	0		Effect: "Memory of Smarts", Effect Duration: 12, Last Available: "2019-04"
 10205	olive fortified sinister conquistador's breastplate	0		Spell Damage: +10, Damage Absorption: +60, Last Available: "2019-04"
 10206	skewed educational pirate pantaloons of the bloodbag	0		Experience: +1, Maximum HP: +100, Last Available: "2019-04"
 10207	blurry wobbly [glitch season reward name]	0		
-10208	teal narrow signal fragment	0		Last Available: "2019-04"
+10208	narrow teal signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	mirror dangerous Fonzie's pirate radio ring	0		Experience (Moxie): +1, Weapon Damage: +10, Single Equip, Last Available: "2019-04"
 10211	pulsating Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	moldy bite-sized spinning pineapple slab	1	crappy	Last Available: "2019-04"
+10212	bite-sized moldy spinning pineapple slab	1	crappy	Last Available: "2019-04"
 10213	normal spinning hibiscus petal	4	good	Last Available: "2019-04"
 10214	concentrated huge mint leaf	0		Effect: "Innately Wise", Effect Duration: 34, Last Available: "2019-04"
 10215	shaking cocoa of youth	0		Last Available: "2019-04"
@@ -10082,7 +10082,7 @@
 10217	spinning Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
-10220	lime green narrow Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10220	narrow lime green Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	spinning Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	denatured spinning pewter shavings	1		Last Available: "2019-04"
@@ -10098,13 +10098,13 @@
 10233	bad Island Thunderstorm	4	decent	Last Available: "2019-04"
 10234	hand-crafted Island Hurricane	3	EPIC	Last Available: "2019-04"
 10235	hand-crafted cyan Skull Punch	4	EPIC	Last Available: "2019-04"
-10236	tolerable weak Electric Punch	2	good	Last Available: "2019-04"
+10236	weak tolerable Electric Punch	2	good	Last Available: "2019-04"
 10237	weak mediocre Smuggler's Punch	2	decent	Last Available: "2019-04"
 10238	delicious fuchsia Scorpion Bowl	4	awesome	Last Available: "2019-04"
 10239	bad irresponsibly strong Turtle Bowl	8	decent	Last Available: "2019-04"
-10240	bad weak special Cobra Bowl	2	decent	Effect: "Feline Ferocity", Effect Duration: 50, Last Available: "2019-04"
+10240	weak bad special Cobra Bowl	2	decent	Effect: "Feline Ferocity", Effect Duration: 50, Last Available: "2019-04"
 10241	yellow vampyric cloake pattern	0		Free Pull
-10242	auspicious double-paned Van der Graaf vampyric cloake of the empath of doom	0		Familiar Weight: +5, Spooky Spell Damage: +50, Cold Resistance: +5, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	auspicious double-paned Van der Graaf vampyric cloake of the empath of doom	0		Familiar Weight: +5, Spooky Spell Damage: +50, Cold Resistance: +5, Item Drop: +10, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	pulsating plastic pirate hat	0		Familiar Weight: +5
 10244	dry one piece of bubble gum	0		Effect: "One For Tea", Effect Duration: 59
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	tumbling overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	bouncing nasty fortified Fourth of May Cosplay Saber of bravery	0		Damage Absorption: +60, Stench Damage: +5, Spooky Resistance: +5, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	bouncing nasty fortified Fourth of May Cosplay Saber of bravery	0		Damage Absorption: +60, Stench Damage: +5, Spooky Resistance: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	scandalous mansplainer's electrified banded padded boxer's weightlifter's strapping hewn moon-rune spoon of vim and vigor of the storm of bravery	0		Muscle: 20, Muscle Percent: +10, Damage Absorption: 120, Maximum HP Percent: +50, Maximum MP Percent: +40, Monster Level: +15, Sleaze Damage: +5, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	scandalous mansplainer's electrified banded padded boxer's weightlifter's strapping hewn moon-rune spoon of vim and vigor of the storm of bravery	0		Muscle: 20, Muscle Percent: +10, Damage Absorption: 120, Maximum HP Percent: +50, Maximum MP Percent: +40, Monster Level: +15, Sleaze Damage: +5, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	mirror cartoon harpoon	0		Last Available: "2019-06"
 10256	skewed rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	upside-down sharpshooter's Beach Comb of wisdom of the cheetah	0		Mysticality: +15, Critical Hit Percent: +10, Initiative: +60, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	upside-down sharpshooter's Beach Comb of wisdom of the cheetah	0		Mysticality: +15, Critical Hit Percent: +10, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10168,8 +10168,8 @@
 10303	miniature moldy green campfire hot dog	2	crappy	Last Available: "2019-08"
 10304	spoiled immense huge campfire baked potato	9	crappy	Last Available: "2019-08"
 10305	normal campfire s'more	3	good	Last Available: "2019-08"
-10306	decent small jittery campfire beans	2	good	Last Available: "2019-08"
-10307	diet decent campfire stew	1	good	Last Available: "2019-08"
+10306	small decent jittery campfire beans	2	good	Last Available: "2019-08"
+10307	decent diet campfire stew	1	good	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
 10309	adjusted leftover chocolate bar	0		Effect: "You Can Taste the Darkness", Effect Duration: 62
 10310	yellow rare Meat isotope	0		
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	bland space chowder	3	decent	
-10321	enchanted lousy extra-dry space wine	5	decent	Effect: "Chunky", Effect Duration: 5
+10321	lousy enchanted extra-dry space wine	5	decent	Effect: "Chunky", Effect Duration: 5
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	blinking Pocket Professor memory chip	0		
@@ -10202,22 +10202,22 @@
 10343	huge bouncing plastic dolphin &quot;orphan&quot; of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2019-12"
 10344	grievous plastic Dolph Bossin	0		Weapon Damage Percent: +50, Last Available: "2019-12"
 10345	maroon red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	rotten diet skewed mana-coated yams	1	crappy	Last Available: "2019-11"
-10347	stale thick blurry mana-basted tofurkey leg	5	decent	Last Available: "2019-11"
+10346	diet rotten skewed mana-coated yams	1	crappy	Last Available: "2019-11"
+10347	thick stale blurry mana-basted tofurkey leg	5	decent	Last Available: "2019-11"
 10348	thick rotten blinking mana-fortified cranberry sauce	5	crappy	Last Available: "2019-11"
 10349	flavorless huge mana-stuffed herbal stuffing	8	decent	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	concentrated narrow patch of extra-warm fur	0		Effect: "Staying Frosty", Effect Duration: 68, Last Available: "2019-12"
 10352	boiled industrial lubricant	1		Effect: "Video Game Hot Dog", Effect Duration: 10, Last Available: "2019-12"
-10353	double-Vulcanized mirror spinning unfinished pleasure	0		Effect: "Boon of the War Snapper", Effect Duration: 20, Last Available: "2019-12"
+10353	double-Vulcanized spinning mirror unfinished pleasure	0		Effect: "Boon of the War Snapper", Effect Duration: 20, Last Available: "2019-12"
 10354	dehydrated narrow maroon vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dehydrated a bug's lymph	1		Effect: "The Chains Down In The Belly-O", Effect Duration: 20, Last Available: "2019-12"
-10356	flattened super-adjusted tumbling shaking organic potpourri	0		Effect: "Nature's Bounty", Effect Duration: 14, Last Available: "2019-12"
+10356	flattened super-adjusted shaking tumbling organic potpourri	0		Effect: "Nature's Bounty", Effect Duration: 14, Last Available: "2019-12"
 10357	drinkable irresponsibly strong boot flask	7	good	Last Available: "2019-12"
 10358	galvanized polarized upside-down infernal snowball	0		Effect: "Heart of Pink", Effect Duration: 66, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	compressed fish sauce	1		Effect: "Flamibili Tea", Effect Duration: 35, Last Available: "2019-12"
-10361	bite-sized moldy ghostly cyan guffin	1	crappy	Last Available: "2019-12"
+10361	bite-sized moldy cyan ghostly guffin	1	crappy	Last Available: "2019-12"
 10362	compressed Shantix&trade;	1		Effect: "Red-Shirted Escort", Effect Duration: 45, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	mixed narrow non-Euclidean angle	1		Effect: "Granolarrrgh", Effect Duration: 25, Last Available: "2019-12"
@@ -10233,7 +10233,7 @@
 10374	tumbling peppermint harpoon gun	0		Last Available: "2019-12"
 10375	magnetized modified chilled huge concentrated fish broth	0		Effect: "Rad-ish", Effect Duration: 22, Last Available: "2019-12"
 10376	dry electrified liquid SONAR	0		Effect: "Psalm of Pointiness", Effect Duration: 55, Last Available: "2019-12"
-10377	spinning squat narrow map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
+10377	narrow squat spinning map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
 10378	pulsating Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	coward's sharpshooter's Dolph Bossin's Crimbo hat of the sewer	0		Critical Hit Percent: +10, Monster Level: -20, Stench Damage: +25, Last Available: "2019-12"
 10380	The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
@@ -10253,13 +10253,13 @@
 10394	tumbling knitted sizzling Mer-kin rollpin	0		Hot Damage: +10, Cold Resistance: +3, Last Available: "2019-12"
 10395	wobbly personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	purple tinsel fin	0		Familiar Weight: +5
-10397	delicious miniature bowl of mernudo	2	awesome	Last Available: "2019-12"
+10397	miniature delicious bowl of mernudo	2	awesome	Last Available: "2019-12"
 10398	artisanal strong skewed fishelada	5	EPIC	Last Available: "2019-12"
 10399	rotten ojo de pez burrito	4	crappy	Last Available: "2019-12"
 10400	skewed waterlogged wood	0		Last Available: "2019-12"
 10401	blurry waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
-10403	jittery squat waterlogged	0		Last Available: "2019-12"
+10403	squat jittery waterlogged	0		Last Available: "2019-12"
 10404	mirror waterlogged	0		Last Available: "2019-12"
 10405	Herculean nutcracker hat of chilblains	0		Experience (Muscle): +1, Cold Damage: +25, Last Available: "2019-12"
 10406	jittery upside-down Oprah's nutcracker waistcoat of the early riser	0		Maximum MP Percent: +50, Adventures: +7, Last Available: "2019-12"
@@ -10271,9 +10271,9 @@
 10412	huge skewed Van der Graaf Herculean nutcracker cape	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
 10413	rosewater-soaked personal trainer's nutcracker epaulets	0		Experience Percent (Muscle): +10, Stench Resistance: +3, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	miniature stale teal salt plum	2	decent	Last Available: "2019-12"
+10415	stale miniature teal salt plum	2	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	big adequate and bean	5	good	Last Available: "2019-12"
+10417	adequate big and bean	5	good	Last Available: "2019-12"
 10418	tumbling skewed friendly Fonzie's kelp-holly gun of the wise owl	0		Mysticality: +20, Experience (Moxie): +1, Familiar Weight: +3, Last Available: "2019-12"
 10419	bouncing horrifying beefcake's Yuleviathan necklace	0		Muscle: +25, Spooky Damage: +25, Single Equip, Last Available: "2019-12"
 10420	brainy peppermint spine	0		Mysticality: +5, Item Drop: +5, Last Available: "2019-12"
@@ -10281,25 +10281,25 @@
 10422	maroon frosty razor-sharp Crimbylow-rise jeans	0		Weapon Damage Percent: +25, Cold Spell Damage: +10, Last Available: "2019-12"
 10423	Jeselnik's stiffened kelp-holly drape	0		Damage Reduction: 1, Sleaze Damage: +25, Last Available: "2019-12"
 10424	pulsating coward's mansplainer's Tesla stylish Staff of the Peppermint Twist	0		Moxie: +25, Monster Level: -5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-12"
-10425	normal bouncing blinking tempura and bean	3	good	Last Available: "2019-12"
+10425	normal blinking bouncing tempura and bean	3	good	Last Available: "2019-12"
 10426	lousy upside-down salt plum sake	3	decent	Last Available: "2019-12"
 10427	diffused magnetized denatured pressurized potion of possessiveness	0		Effect: "Big Meat Big Prizes", Effect Duration: 45, Last Available: "2019-12"
 10428	moist tarnished triple-denatured almond	0		Effect: "Red-Shirted Escort", Effect Duration: 43
 10429	warmed super-nitrogenated handful of mixed nuts	0		Effect: "Human-Elf Hybrid", Effect Duration: 64, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	purple Oprah's brainy Retrospecs of the early riser	0		Mysticality: +5, Maximum MP Percent: +50, Adventures: +7, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	purple Oprah's brainy Retrospecs of the early riser	0		Mysticality: +5, Maximum MP Percent: +50, Adventures: +7, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	olive mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	electrified arcane researcher's Socratic savvy Powerful Glove of the detective	0		Mysticality Percent: +20, Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Item Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	electrified arcane researcher's Socratic savvy Powerful Glove of the detective	0		Mysticality Percent: +20, Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Item Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	foul-smelling Lo Pan's Drip harness of the detective	0		Spell Critical Percent: +30, Stench Damage: +10, Item Drop: +20
 10442	drippy truncheon of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip
 10443	blinking Driplet	0		
 10444	olive drippy snail shell	0		
-10445	jumbo delicious drippy nugget	5	drippy	
+10445	delicious jumbo drippy nugget	5	drippy	
 10446	lousy glass of drippy wine	4	drippy	
 10447	small bland drippy caviar	2	drippy	
 10448	tasty drippy plum(?)	4	drippy	
@@ -10336,7 +10336,7 @@
 10479	plastic doll legs	0		
 10480	red rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
-10482	narrow fuchsia blurry packet of mushroom spores	0		Last Available: "2020-03"
+10482	blurry narrow fuchsia packet of mushroom spores	0		Last Available: "2020-03"
 10483	pulsating free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
@@ -10369,7 +10369,7 @@
 10512	flame-retardant Oprah's chipped coffee mug	0		Maximum MP Percent: +50, Hot Resistance: +1, Last Available: "2020-04"
 10513	Left-Hand Man action figure of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2020-04"
 10514	pulsating drippy seed	0		
-10515	cyan wobbly drippy grub	0		
+10515	wobbly cyan drippy grub	0		
 10516	drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	drippy ichor	0		
@@ -10397,7 +10397,7 @@
 10541	acceptable Ghiaccio Colada	3	good	Last Available: "2020-05"
 10542	bad Sourfinger	4	decent	Last Available: "2020-05"
 10543	drinkable watered-down Nog-on-the-Cob	2	good	Last Available: "2020-05"
-10544	watered-down aged Steamboat	2	awesome	Last Available: "2020-05"
+10544	aged watered-down Steamboat	2	awesome	Last Available: "2020-05"
 10545	hand-crafted Buttery Boy	3	EPIC	Last Available: "2020-05"
 10546	spinning Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	lime green stylish clown car key of the businessman	0		Moxie: +25, Meat Drop: +50, Last Available: "2020-08"
@@ -10438,16 +10438,16 @@
 10582	skewed SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	wobbly medical-grade birch battery of the overflowing toilet	0		Stench Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08"
-10585	foul-smelling razor-sharp ebony epee of the detective	0		Weapon Damage Percent: +25, Stench Damage: +10, Item Drop: +20, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	reassuring lion tamer's weeping willow wand of James Dean	0		Experience (Moxie): +3, Experience (familiar): +2, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	Sherlock's chaotic smooth beechwood blowgun	0		Moxie: +15, Spell Critical Percent: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	foul-smelling razor-sharp ebony epee of the detective	0		Weapon Damage Percent: +25, Stench Damage: +10, Item Drop: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	reassuring lion tamer's weeping willow wand of James Dean	0		Experience (Moxie): +3, Experience (familiar): +2, Spooky Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	Sherlock's chaotic smooth beechwood blowgun	0		Moxie: +15, Spell Critical Percent: +10, Item Drop: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	wool Temple Grandin's experienced maple magnet	0		Experience: +2, Familiar Weight: +7, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2020-08"
 10589	spinning Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	avaricious gravedigger's slick hemlock helm	0		Moxie: +10, Spooky Damage: +10, Meat Drop: +30, Last Available: "2020-08"
 10591	shaking sweaty balsam	0		Last Available: "2020-08"
 10592	smelly razor-sharp dangerous balsam barrel	0		Weapon Damage: +10, Weapon Damage Percent: +25, Stench Spell Damage: +10, Last Available: "2020-08"
 10593	redwood	0		Last Available: "2020-08"
-10594	oxidized mirror jittery redwood rain stick	0		Effect: "Feet of Grapefruit", Effect Duration: 28, Last Available: "2020-08"
+10594	oxidized jittery mirror redwood rain stick	0		Effect: "Feet of Grapefruit", Effect Duration: 28, Last Available: "2020-08"
 10595	bouncing purpleheart logs	0		Last Available: "2020-08"
 10596	smelly therapeutic purpleheart &quot;pants&quot; of vim and vigor	0		Maximum HP Percent: +50, Stench Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-08"
 10597	wormwood stick	0		Last Available: "2020-08"
@@ -10462,7 +10462,7 @@
 10606	electrified flattened huge Yeg's Motel toothbrush	0		Effect: "Virgo Rising", Effect Duration: 26, Last Available: "2020-09"
 10607	energized cyan Yeg's Motel hand soap	0		Effect: "Barbecue Saucy", Effect Duration: 64, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	bland fancy ghostly Yeg's Motel pillow mint	4	decent	Effect: "Sticky Fingers", Effect Duration: 40, Last Available: "2020-09"
+10609	fancy bland ghostly Yeg's Motel pillow mint	4	decent	Effect: "Sticky Fingers", Effect Duration: 40, Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	wet narrow Yeg's Motel mouthwash	0		Effect: "Aloofah", Effect Duration: 25, Last Available: "2020-09"
 10612	veiny banded Yeg's Motel shower cap	0		Damage Absorption: +100, Maximum HP: +10, Lasts Until Rollover, Last Available: "2020-09"
@@ -10537,7 +10537,7 @@
 10681	candy bucket of Flo-Jo	0		Initiative: +100, Lasts Until Rollover, Last Available: "2020-12"
 10682	denatured energized diffused prescription teeth whitener	0		Effect: "Ass Over Teakettle", Effect Duration: 68, Last Available: "2020-12"
 10683	deionized huge imported lemon lozenge	0		Effect: "So You Can Work More...", Effect Duration: 34, Last Available: "2020-12"
-10684	triple-anodized pulsating huge hermedisiac cologne	0		Effect: "The Halls of Moxiousness", Effect Duration: 24, Last Available: "2020-12"
+10684	triple-anodized huge pulsating hermedisiac cologne	0		Effect: "The Halls of Moxiousness", Effect Duration: 24, Last Available: "2020-12"
 10685	spinning government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	huge government candy shipment	0		Last Available: "2020-12"
@@ -10548,7 +10548,7 @@
 10692	booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	wobbly candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
-10695	narrow skewed booze mailing list	0		Last Available: "2020-12"
+10695	skewed narrow booze mailing list	0		Last Available: "2020-12"
 10696	candy mailing list	0		Last Available: "2020-12"
 10697	squat Temple Grandin's beefcake's fruit bat	0		Muscle: +25, Familiar Weight: +7, Class: "Seal Clubber", Single Equip, Last Available: "2020-12"
 10698	nippy tinsel orb of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +10, Class: "Turtle Tamer", Last Available: "2020-12"
@@ -10569,12 +10569,12 @@
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	twirling The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	decent and pepper (stale)	3	good	Last Available: "2020-12"
-10716	smooth extra-dry huge cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
+10716	extra-dry smooth huge cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	maroon goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	watered-down special acceptable barrel-aged eggnog	2	good	Effect: "Ninja, Please", Effect Duration: 15, Last Available: "2020-12"
-10721	jumbo spoiled hand-crafted candy cane	5	crappy	Last Available: "2020-12"
+10720	special watered-down acceptable barrel-aged eggnog	2	good	Effect: "Ninja, Please", Effect Duration: 15, Last Available: "2020-12"
+10721	spoiled jumbo hand-crafted candy cane	5	crappy	Last Available: "2020-12"
 10722	spoiled drive-thru burger	4	crappy	Last Available: "2020-12"
 10723	perfectly mixed Boulevardier cocktail	3	EPIC	Last Available: "2020-12"
 10724	dry corrupted corrupted cyan pulsating Hotwire&trade; brand candy rope	0		Effect: "Motion", Effect Duration: 18, Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	jittery fresh coat of paint	0		Last Available: "2021-12"
-10733	wobbly emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	blurry spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	wobbly emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	blurry spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10602,17 +10602,17 @@
 10746	marshmallow	0		
 10747	artisanal fancy marshmallow bomb	4	EPIC	Effect: "Hyphemariffic", Effect Duration: 45, Last Available: "2021-03"
 10748	mirror packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shaking shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	unsweetened wet shaking short beer	0		Effect: "Stogied", Effect Duration: 37, Last Available: "2021-05"
 10753	chilled magnetized colloidal short stack of pancakes	0		Effect: "Gleaming White Teeth", Effect Duration: 12, Last Available: "2021-05"
 10754	galvanized short stick of butter	0		Effect: "Standard Issue Bravery", Effect Duration: 16, Last Available: "2021-05"
 10755	magnetized tumbling short glass of water	0		Effect: "Meadulla Oblongota", Effect Duration: 46, Last Available: "2021-05"
-10756	flattened polymerized tumbling twirling fuchsia short	0		Effect: "Some Cheese with Your Wine", Effect Duration: 67, Last Available: "2021-05"
+10756	flattened polymerized tumbling fuchsia twirling short	0		Effect: "Some Cheese with Your Wine", Effect Duration: 67, Last Available: "2021-05"
 10757	huge Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	chaotic familiar scrapbook of Flo-Jo	0		Spell Critical Percent: +10, Initiative: +100, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	chaotic familiar scrapbook of Flo-Jo	0		Spell Critical Percent: +10, Initiative: +100, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	olive clan underground fireworks shop	0		Last Available: "2021-07"
 10762	blinking thinker's fedora-mounted fountain of James Dean of chilblains	0		Mysticality: +10, Experience (Moxie): +3, Cold Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
@@ -10645,12 +10645,12 @@
 10789	healthy water candle	0		Maximum HP Percent: +20, Water: 3, Lasts Until Rollover
 10790	avaricious B. L. A. R. T.	0		Meat Drop: +30, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	Thwaitgold fire beetle statuette	0		
-10792	purple mirror empty nacho cheese can	0		Water: 1
+10792	mirror purple empty nacho cheese can	0		Water: 1
 10793	literal bucket hat	0		Water: 5
 10794	spinning rainproof barrel caulk	0		
 10795	bouncing pump grease	0		
 10796	shaking packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	blurry Usain Bolt's friendly brawny beefy industrial fire extinguisher of James Dean of the sewer	0		Muscle: +10, Muscle Percent: +20, Experience (Moxie): +3, Familiar Weight: +3, Stench Damage: +25, Initiative: +80, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	blurry Usain Bolt's friendly brawny beefy industrial fire extinguisher of James Dean of the sewer	0		Muscle: +10, Muscle Percent: +20, Experience (Moxie): +3, Familiar Weight: +3, Stench Damage: +25, Initiative: +80, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10673,18 +10673,18 @@
 10817	frosty smartaleck's Rosewater's jeans	0		Mysticality Percent: +30, Moxie Percent: +30, Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-12"
 10818	pulsating greasy Annie Oakley's Tesla ice wrap	0		Critical Hit Percent: +20, Sleaze Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	flavorless tofu pop	4	decent	Last Available: "2021-12"
-10820	small flavorless bowl of prescription candy	2	decent	Last Available: "2021-12"
+10820	flavorless small bowl of prescription candy	2	decent	Last Available: "2021-12"
 10821	spoiled spinning fishcake	3	crappy	Last Available: "2021-12"
-10822	bland small bone broth	2	decent	Last Available: "2021-12"
+10822	small bland bone broth	2	decent	Last Available: "2021-12"
 10823	adequate star pop	4	good	Last Available: "2021-12"
 10824	enchanted smooth Doc's Fortifying Wine	3	awesome	Effect: "Spooky Flavor", Effect Duration: 50, Last Available: "2021-12"
 10825	lousy practically non-alcoholic Doc's Smartifying Wine	1	decent	Last Available: "2021-12"
-10826	acceptable triple-distilled Doc's Limbering Wine	6	good	Last Available: "2021-12"
+10826	triple-distilled acceptable Doc's Limbering Wine	6	good	Last Available: "2021-12"
 10827	tolerable red Doc's Medical-Grade Wine	3	good	Last Available: "2021-12"
 10828	boiled pulsating cyan Homebodyl&trade;	1		Effect: "Phairly Balanced", Effect Duration: 25, Last Available: "2021-12"
 10829	denatured narrow blinking Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	mixed Breathitin&trade;	1		Effect: "Brother Smothers's Blessing", Effect Duration: 10, Last Available: "2021-12"
-10831	dried purple shaking Fleshazole&trade;	1		Last Available: "2021-12"
+10831	dried shaking purple Fleshazole&trade;	1		Last Available: "2021-12"
 10832	tarnished shaking anti-burn cream	0		Effect: "Hobonic", Effect Duration: 21, Last Available: "2021-12"
 10833	double-polarized anti-freeze cream	0		Effect: "Pharmaceutically Cool", Effect Duration: 49, Last Available: "2021-12"
 10834	dry anti-goosebump cream	0		Effect: "Bats in the Belfry", Effect Duration: 14, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	tarnished improved anti-creep cream	0		Effect: "Influence of Sphere", Effect Duration: 39, Last Available: "2021-12"
 10837	pressed pressed jittery anti-pain cream	0		Effect: "Space Cowboy", Effect Duration: 41, Last Available: "2021-12"
 10838	mediocre narrow Doc's Special Reserve Wine	4	decent	Last Available: "2021-12"
-10839	toothsome shaking cyan bread pie	3	awesome	Last Available: "2021-12"
+10839	toothsome cyan shaking bread pie	3	awesome	Last Available: "2021-12"
 10840	delicious special clear Russian	4	awesome	Effect: "Pie in the Sky", Effect Duration: 25, Last Available: "2021-12"
 10841	skewed zero-trust tanktop	0		Last Available: "2025-12"
 10842	maroon Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	yellow goo magnet	0		Last Available: "2021-12"
 10851	double-paned cozy scarf	0		Cold Resistance: +5, Last Available: "2021-12"
-10852	immense bland huge Crimbo cookie	8	decent	Last Available: "2023-06"
+10852	bland immense huge Crimbo cookie	8	decent	Last Available: "2023-06"
 10853	triple-anodized pressed fleshy putty	0		Effect: "Executive Greed", Effect Duration: 48, Last Available: "2021-12"
 10854	third ear of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2021-12"
 10855	teal festive egg sac	0		Last Available: "2021-12"
@@ -10729,21 +10729,21 @@
 10873	blurry nasty hale can of mixed everything of wisdom	0		Mysticality: +15, Maximum HP: +20, Stench Damage: +5, Last Available: "2021-12"
 10874	lime green Site Alpha ID badge	0		Familiar Weight: +5
 10875	maroon the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	small spoiled meatball	2	crappy	Last Available: "2021-12"
+10876	spoiled small meatball	2	crappy	Last Available: "2021-12"
 10877	fuchsia cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	dehydrated fried air	1		Last Available: "2021-12"
-10881	skewed blurry 11-leaf clover	0		
+10881	blurry skewed 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	diluted maroon astral energy drink	1		Effect: "Also Schmeckt Zarathustra", Effect Duration: 20
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	censurious Jack Frost's vibrating magnifying glass	0		Maximum MP Percent: +10, Cold Spell Damage: +50, Sleaze Resistance: +3, Last Available: "2022-12"
 10886	lousy high-proof green void lager	7	decent	Last Available: "2022-12"
-10887	enchanted rotten void burger	4	crappy	Effect: "Gobliny Flavor", Effect Duration: 20, Last Available: "2022-12"
+10887	rotten enchanted void burger	4	crappy	Effect: "Gobliny Flavor", Effect Duration: 20, Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	zippy gravedigger's careful void shard of wisdom	0		Mysticality: +15, Monster Level: -10, Spooky Damage: +10, Initiative: +20, Last Available: "2022-12"
-10890	skewed blinking undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
+10890	blinking skewed undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	cosmic bowling ball	0		Last Available: "2022-01"
 10892	combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	miser's combat lover's locket	0		Meat Drop: +10, Single Equip, Last Available: "2022-02"
@@ -10765,9 +10765,9 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	vacuum-sealed spinning jittery single-use dust mask	0		Effect: "Okee-Dokee Computer", Effect Duration: 20, Last Available: "2022-05"
 10911	oxidized jittery gaffer's tape	0		Effect: "Amorous", Effect Duration: 56, Last Available: "2022-05"
-10912	tasty small gray tumbling 20-lb can of rice and beans	2	awesome	Last Available: "2022-05"
-10913	gray huge bar of freeze-dried water	1	awesome	Last Available: "2022-05"
-10914	super-sized moldy expired MRE	5	crappy	Last Available: "2022-05"
+10912	small tasty tumbling gray 20-lb can of rice and beans	2	awesome	Last Available: "2022-05"
+10913	huge gray bar of freeze-dried water	1	awesome	Last Available: "2022-05"
+10914	moldy super-sized expired MRE	5	crappy	Last Available: "2022-05"
 10915	decent jumbo cool mint precipice bar	5	good	Last Available: "2022-05"
 10916	super-sized moldy carrot cake precipice bar	5	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
@@ -10777,25 +10777,25 @@
 10921	drinkable boozy Dad's brandy	5	good	Last Available: "2022-06"
 10922	electrified teacher's pen of the sewer	0		Stench Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-06"
 10923	delicious fire-roasted lake trout	4	awesome	Last Available: "2022-06"
-10924	flavorless immense guilty sprout	7	decent	Last Available: "2022-06"
+10924	immense flavorless guilty sprout	7	decent	Last Available: "2022-06"
 10925	resourceful mother's necklace of the blizzard	0		Maximum MP: +50, Cold Spell Damage: +25, Last Available: "2022-06"
 10926	alkaline dry trampled ticket stub	0		Effect: "Uncaged Power", Effect Duration: 57, Last Available: "2022-06"
 10927	concentrated concentrated skewed savings bond	0		Effect: "Mitre Cut", Effect Duration: 51, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	blurry designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	blurry designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	dried sweat-ade	1		Last Available: "2022-07"
 10931	yellow unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
-10933	lime green mirror thick dinosaur	0		
+10933	mirror lime green thick dinosaur	0		
 10934	green dinosaur scale	0		
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	blinking occult pterodactyl rifle	0		Spell Damage Percent: +25, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
-10939	shaking wobbly flatusaur gasmask	0		
+10939	wobbly shaking flatusaur gasmask	0		
 10940	blurry dinosaur dart	0		
 10941	non-energized tarnished Dino DNAde&trade;	0		Effect: "Trivia Master", Effect Duration: 69
-10942	narrow red dinosaur repellent	0		
+10942	red narrow dinosaur repellent	0		
 10943	twirling camouflage vest of the boozehound	0		Booze Drop: +100
 10944	Dinodollar	0		
 10945	valuable dinosaur droppings	0		
@@ -10805,11 +10805,11 @@
 10949	Temple Grandin's dinosaur	0		Familiar Weight: +7
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	narrow packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	smelly Jurassic Parka of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	smelly Jurassic Parka of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	narrow autumn-aton	0		Last Available: "2022-10"
 10955	nitrogenated quantum twirling autumn leaf	0		Effect: "Hardened Fabric", Effect Duration: 26, Last Available: "2022-10"
-10956	smooth irresponsibly strong squat AutumnFest ale	8	awesome	Last Available: "2022-10"
+10956	irresponsibly strong smooth squat AutumnFest ale	8	awesome	Last Available: "2022-10"
 10957	gray jittery up-at-dawn double-paned arcane researcher's autumn sweater-weather sweater	0		Experience Percent (Mysticality): +10, Cold Resistance: +5, Adventures: +5, Lasts Until Rollover, Last Available: "2022-10"
 10958	greasy dangerous thinker's autumn debris shield of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Weapon Damage: +10, Sleaze Spell Damage: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	adequate immense autumn-spice donut	7	good	Last Available: "2022-10"
@@ -10823,36 +10823,36 @@
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	red St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	teal Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	moldy huge ratatouille de Jarlsberg	10	crappy	Last Available: "2022-11"
-10971	rotten massive Jarlsberg's vegetable soup	10	crappy	Last Available: "2022-11"
+10970	huge moldy ratatouille de Jarlsberg	10	crappy	Last Available: "2022-11"
+10971	massive rotten Jarlsberg's vegetable soup	10	crappy	Last Available: "2022-11"
 10972	adequate purple roasted vegetable of Jarlsberg	4	good	Last Available: "2022-11"
 10973	bland shaking St. Pete's sneaky smoothie	3	decent	Last Available: "2022-11"
 10974	thick spoiled Pete's wiley whey bar	5	crappy	Last Available: "2022-11"
 10975	stale big fuchsia Pete's rich ricotta	5	decent	Last Available: "2022-11"
-10976	smooth fuchsia narrow Boris's beer	4	awesome	Last Available: "2022-11"
-10977	small adequate honey bun of Boris	2	good	Last Available: "2022-11"
+10976	smooth narrow fuchsia Boris's beer	4	awesome	Last Available: "2022-11"
+10977	adequate small honey bun of Boris	2	good	Last Available: "2022-11"
 10978	spoiled Boris's bread	4	crappy	Last Available: "2022-11"
-10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	mirror skewed Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	tumbling bouncing Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	blue Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	blurry Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	jittery Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	mirror skewed Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	tumbling bouncing Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	blue Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	blurry Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	jittery Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	yummy baked veggie ricotta casserole	4	awesome	Last Available: "2022-11"
 10989	flavorless lime green plain calzone	4	decent	Last Available: "2022-11"
-10990	adequate miniature red roasted vegetable focaccia	2	good	Last Available: "2022-11"
+10990	miniature adequate red roasted vegetable focaccia	2	good	Last Available: "2022-11"
 10991	flavorless Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	flavorless Calzone of Legend	3	decent	Last Available: "2022-11"
-10993	twirling Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	blinking Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	wobbly Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	twirling Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	blinking Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	wobbly Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	spoiled Deep Dish of Legend	4	crappy	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
@@ -10860,27 +10860,27 @@
 11004	hardened prohie's hat	0		Damage Reduction: 3
 11005	double-electrified huge imported taffy	0		Effect: "Bureaucratized", Effect Duration: 63
 11006	purple savvy Charleston shoes of bravery	0		Mysticality Percent: +20, Spooky Resistance: +5, Single Equip
-11007	squat red booze bindle	0		
+11007	red squat booze bindle	0		
 11008	purple miser's frosty rare oboe	0		Cold Spell Damage: +10, Meat Drop: +10
 11009	educational cool bullet necklace	0		Moxie: +5, Experience: +1, Single Equip
 11010	stale massive swamp haunch	6	decent	
 11011	reassuring double-paned gator shades	0		Cold Resistance: +5, Spooky Resistance: +1, Single Equip
 11012	teal milk cap	0		
-11013	drinkable fancy Charleston Choo-Choo	4	good	Effect: "High Blood Chocolate Content", Effect Duration: 25
+11013	fancy drinkable Charleston Choo-Choo	4	good	Effect: "High Blood Chocolate Content", Effect Duration: 25
 11014	perfectly mixed triple-distilled Velvet Veil	10	EPIC	
 11015	hand-crafted weak blurry Marltini	2	EPIC	
 11016	mediocre Strong, Silent Type	3	decent	
 11017	smooth wobbly Mysterious Stranger	3	awesome	
-11018	watered-down drinkable Champagne Shimmy	2	good	
+11018	drinkable watered-down Champagne Shimmy	2	good	
 11019	cyan the Sot's parcel	0		
-11020	upside-down Temple Grandin's ceramic cestus of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	spinning maroon scandalous Socratic experienced ceramic centurion shield	0		Experience: +2, Experience (Mysticality): +1, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	Jim Carey's ceramic celery grater of horror	0		Monster Level: +25, Spooky Spell Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	squat Lo Pan's sinister ceramic celsiturometer of mayonnaise	0		Spell Damage: +10, Spell Critical Percent: +30, Sleaze Spell Damage: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	nasty sizzling dance instructor's ceramic cerecloth belt	0		Experience Percent (Moxie): +10, Hot Damage: +10, Stench Damage: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	aromatic horrifying slick ceramic cenobite's robe	0		Moxie: +10, Spooky Damage: +25, Stench Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	upside-down Temple Grandin's ceramic cestus of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	spinning maroon scandalous Socratic experienced ceramic centurion shield	0		Experience: +2, Experience (Mysticality): +1, Sleaze Damage: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	Jim Carey's ceramic celery grater of horror	0		Monster Level: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	squat Lo Pan's sinister ceramic celsiturometer of mayonnaise	0		Spell Damage: +10, Spell Critical Percent: +30, Sleaze Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	nasty sizzling dance instructor's ceramic cerecloth belt	0		Experience Percent (Moxie): +10, Hot Damage: +10, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	aromatic horrifying slick ceramic cenobite's robe	0		Moxie: +10, Spooky Damage: +25, Stench Resistance: +1, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	dehydrated green ceramic scree	1		Effect: "Dirge of Dreadfulness", Effect Duration: 30, Last Available: "2023-12"
-11027	Vulcanized non-aerosolized squat huge extra-hard jawbreaker	0		Effect: "Ogred and Oublietted", Effect Duration: 59
+11027	Vulcanized non-aerosolized huge squat extra-hard jawbreaker	0		Effect: "Ogred and Oublietted", Effect Duration: 59
 11028	huge boxer's chiffon chevrons of the ox of doom	0		Muscle: +20, Muscle Percent: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2023-12"
 11029	jittery boxer's wizardly chiffon chapeau of the ox	0		Muscle: +20, Mysticality: +25, Muscle Percent: +10, Last Available: "2023-12"
 11030	hale Rosewater's chiffon chamberpot of the cougar	0		Moxie: +20, Mysticality Percent: +30, Maximum HP: +20, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	Van der Graaf Samson's chiffon chaps of courage	0		Experience (Muscle): +5, Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11034	dehydrated chiffon carbage	1		Last Available: "2023-12"
 11035	unsweetened chilled chiffon lemon	0		Effect: "Corona de la Salsa", Effect Duration: 49
-11036	small moldy chocomotive	2	crappy	Last Available: "2022-12"
+11036	moldy small chocomotive	2	crappy	Last Available: "2022-12"
 11037	normal half-sized freightcake	2	good	Last Available: "2022-12"
 11038	mediocre cabooze	3	decent	Last Available: "2022-12"
 11039	ghostly plastic caboose	0		Last Available: "2022-12"
@@ -10913,7 +10913,7 @@
 11057	ping-pong ball	0		
 11058	Rosewater's Trainbot harness	0		Mysticality Percent: +30
 11059	ping-pong table	0		
-11060	shaking ghostly mirror Crimbo train emergency brake	0		
+11060	ghostly mirror shaking Crimbo train emergency brake	0		
 11061	Trainbot autoassembly module	0		
 11062	flame-retardant Tesla rosy-cheeked head-mounted Trainbot	0		Maximum HP Percent: +30, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-12"
 11063	bouncing gravedigger's Sinatra's leg-mounted Trainbots of Calamity Jane	0		Experience (Moxie): +5, Critical Hit Percent: +15, Spooky Damage: +10, Last Available: "2022-12"
@@ -10937,20 +10937,20 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	acceptable watered-down Crimbosmopolitan	2	good	Last Available: "2022-12"
+11084	watered-down acceptable Crimbosmopolitan	2	good	Last Available: "2022-12"
 11085	stale Crimbo dinner	4	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	wobbly train whistle	0		Last Available: "2022-12"
-11088	skewed tumbling olive narrow The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
+11088	skewed olive tumbling narrow The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
-11090	narrow huge half-height cigar	0		Familiar Weight: +5
+11090	huge narrow half-height cigar	0		Familiar Weight: +5
 11091	gray grubby wool	0		
 11092	blurry fortified grievous Herculean grubby wool hat	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Damage Absorption: +60
 11093	shaking slick grubby wool scarf of the wise owl	0		Mysticality: +20, Moxie: +10, Single Equip
 11094	family-friendly reassuring nasty grubby wool trousers	0		Stench Damage: +5, Spooky Resistance: +1, Sleaze Resistance: +1
 11095	rosewater-soaked resourceful therapeutic grubby wool gloves of Calamity Jane	0		Maximum MP: +50, Critical Hit Percent: +15, Stench Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip
-11096	huge blinking grubby wool beerwarmer	0		
-11097	practically non-alcoholic delicious nice warm beer	1	awesome	
+11096	blinking huge grubby wool beerwarmer	0		
+11097	delicious practically non-alcoholic nice warm beer	1	awesome	
 11098	grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10964,7 +10964,7 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	gigantic toothsome pixel bread	10	awesome	
+11112	toothsome gigantic pixel bread	10	awesome	
 11113	drinkable irresponsibly strong pixel whiskey	10	good	
 11114	twirling pixel rock	0		
 11115	ghostly cyan S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10974,7 +10974,7 @@
 11119	galvanized five-fingered fern resin	0		Effect: "Petit Forbearance", Effect Duration: 63, Last Available: "2023-02"
 11120	diet rotten super good fruit	1	crappy	Last Available: "2023-02"
 11121	distilled energized spores	1		Last Available: "2023-02"
-11122	careful stiffened hot pepper	0		Damage Reduction: 1, Monster Level: -10, Lantern Element: "Hot", Last Available: "2023-02"
+11122	careful stiffened hot pepper	0		Damage Reduction: 1, Monster Level: -10, Last Available: "2023-02", Lantern Element: "Hot"
 11123	corrupted frozen huge cyan out-of-work circus flea	0		Effect: "The Best a Pirate Can Get", Effect Duration: 38, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	triple-activated twirling fire ant pheromones	0		Effect: "Tiki Toughness", Effect Duration: 54, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	maroon hollow rock	0		Last Available: "2023-02"
 11133	irradiated angry agate	0		Effect: "Boilermade", Effect Duration: 22, Last Available: "2023-02"
 11134	frozen lump of loyal latite	0		Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2023-02"
-11135	bland huge skewed shadow sausage	4	decent	Last Available: "2023-03"
+11135	bland skewed huge shadow sausage	4	decent	Last Available: "2023-03"
 11136	huge wicked wizardly shadow skin	0		Mysticality: +25, Spell Damage: +5, Last Available: "2023-03"
 11137	ionized lime green shadow flame	0		Effect: "How to Scam Tourists", Effect Duration: 35, Last Available: "2023-03"
 11138	adequate shadow bread	4	good	Last Available: "2023-03"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	blurry shadow brick	0		Last Available: "2023-03"
 11143	narrow shadow sinew	0		Last Available: "2023-03"
-11144	artisanal weak shadow venom	2	EPIC	Last Available: "2023-03"
+11144	weak artisanal shadow venom	2	EPIC	Last Available: "2023-03"
 11145	compressed shadow nectar	1		Last Available: "2023-03"
 11146	flame-retardant knitted Tesla shadow stick	0		Cold Resistance: +3, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-03"
 11147	lightning-fast bat paw of the blizzard	0		Cold Spell Damage: +25, Initiative: +40
@@ -11037,8 +11037,8 @@
 11182	huge moldy ghostly shadow hot dog	8	crappy	
 11183	lousy spinning shadow martini	3	decent	
 11184	dehydrated shadow pill	1		
-11185	red pulsating huge shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11185	red huge pulsating shadow needle	0		
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	shaking olive monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	cold-filtered diffused shadow candy	0		Effect: "Salt Rockin'", Effect Duration: 48
 11189	replica Mr. Accessory	0		
@@ -11067,7 +11067,7 @@
 11212	squat chaotic wholesome replica Operation Patriot Shield of horror	0		Maximum HP Percent: +10, Spell Critical Percent: +10, Spooky Spell Damage: +25, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	replica Libram of Resolutions	0		
 11214	rock-hard replica plastic vampire fangs of the ox of horror	0		Muscle: +20, Damage Reduction: 5, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Feed"
-11215	olive tumbling replica angel	0		
+11215	tumbling olive replica angel	0		
 11216	green hale replica Camp Scout backpack	0		Maximum HP: +20
 11217	squat replica deactivated nanobots	0		
 11218	lime green squat replica Apathargic Bandersnatch	0		
@@ -11075,7 +11075,7 @@
 11220	shaking replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	purple shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	upside-down lime green flame-retardant stanky strapping Cincho de Mayo of vim and vigor	0		Muscle: +5, Maximum HP Percent: +50, Stench Spell Damage: +25, Hot Resistance: +1, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	upside-down lime green flame-retardant stanky strapping Cincho de Mayo of vim and vigor	0		Muscle: +5, Maximum HP Percent: +50, Stench Spell Damage: +25, Hot Resistance: +1, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	spinning dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11086,7 +11086,7 @@
 11231	replica Source terminal	0		
 11232	replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
-11234	tumbling squat replica genie bottle	0		
+11234	squat tumbling replica genie bottle	0		
 11235	replica space planula	0		
 11236	spinning replica unpowered Robortender	0		
 11237	blue replica Neverending Party invitation envelope	0		
@@ -11100,10 +11100,10 @@
 11245	frightening sizzling frosty resourceful replica Cargo Cultist Shorts	0		Maximum MP: +50, Cold Spell Damage: +10, Hot Damage: +10, Spooky Damage: +5
 11246	red scandalous gravedigger's careful Lo Pan's MacGyver's Da Vinci's replica industrial fire extinguisher	0		Experience (Mysticality): +5, Maximum MP: +100, Spell Critical Percent: +30, Monster Level: -10, Spooky Damage: +10, Sleaze Damage: +5, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 11247	replica crystal ball	0		Initiative: +50
-11248	mirror twirling olive replica emotion chip	0		Skill: "Replica Emotionally Chipped"
+11248	mirror olive twirling replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	Lo Pan's replica Jurassic Parka of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +30
 11250	replica grey gosling	0		
-11251	narrow replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	narrow replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	lion tamer's strapping replica Cincho de Mayo of the pedagogue of the blizzard	0		Muscle: +5, Experience: +3, Experience (familiar): +2, Cold Spell Damage: +25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	narrow red 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	mirror lard-coated nippy curative brawny wizardly &quot;I survived Y2K&quot; T-Shirt of the detective	0		Mysticality: +25, Muscle Percent: +20, Cold Damage: +10, Sleaze Spell Damage: +25, Item Drop: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-06"
 11259	yellow Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	huge Annie Oakley's pro skateboard of the cougar	0		Moxie: +20, Critical Hit Percent: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	huge Annie Oakley's pro skateboard of the cougar	0		Moxie: +20, Critical Hit Percent: +20, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	bouncing Charter: Nellyville	0		Last Available: "2023-06"
-11265	green pulsating Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	Socratic Flash Liquidizer Ultra Dousing Accessory	0		Experience (Mysticality): +1, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	green pulsating Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	Socratic Flash Liquidizer Ultra Dousing Accessory	0		Experience (Mysticality): +1, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	wobbly family-friendly friendly steel-toed forbidden Amulet of Perpetual Darkness	0		Spell Damage Percent: +50, Damage Reduction: 9, Familiar Weight: +3, Sleaze Resistance: +1, Last Available: "2023-06"
 11268	mirror Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11126,7 +11126,7 @@
 11271	enhanced galvanized ghostly scroll of minor invulnerability	0		Effect: "protect.enq", Effect Duration: 14, Last Available: "2023-06"
 11272	bouncing Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
-11274	huge narrow Azurite	0		Last Available: "2023-06"
+11274	narrow huge Azurite	0		Last Available: "2023-06"
 11275	bouncing Arrow (+1)	0		Last Available: "2023-06"
 11276	quadruple-galvanized scroll of protection from lycanthropes	0		Effect: "Litterboxing", Effect Duration: 38, Last Available: "2023-06"
 11277	Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
@@ -11174,14 +11174,14 @@
 11319	lime green huge medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	watered-down mediocre bottle of Cabernet Sauvignon	2	decent	
 11321	avaricious curative experienced baywatch	0		Experience: +2, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	bouncing Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	bouncing Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	teal consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	boiled bouncing concentrated cooking	1		Effect: "Chalky Hand", Effect Duration: 20
-11329	powdered twirling blinking narrow meat	1		
+11329	powdered twirling narrow blinking meat	1		
 11330	diluted sparkling orb	1		Effect: "Slippery Tongue", Effect Duration: 50
 11331	pickled squat hardening cream	1		
 11332	altered yellow pool shark hair oil	1		
@@ -11231,7 +11231,7 @@
 11376	squat housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	yummy pickled bread	3	awesome	Last Available: "2023-12"
-11379	bland half-sized salted mutton	2	decent	Last Available: "2023-12"
+11379	half-sized bland salted mutton	2	decent	Last Available: "2023-12"
 11380	bland bite-sized squat corned beet	1	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11274,7 +11274,7 @@
 11419	skewed ghostly Tesla Elf Guard broom of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
 11420	Usain Bolt's MacGyver's Crimbuccaneer tavern swab of horror	0		Maximum MP: +100, Spooky Spell Damage: +25, Initiative: +80, Last Available: "2023-12"
 11421	purple Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	bad practically non-alcoholic old-school pirate grog	1	decent	Last Available: "2023-12"
+11422	practically non-alcoholic bad old-school pirate grog	1	decent	Last Available: "2023-12"
 11423	tiny adequate grog nuts	1	good	Last Available: "2023-12"
 11424	double-paned Herculean cool sawed-off blunderbuss	0		Moxie: +5, Experience (Muscle): +1, Cold Resistance: +5, Last Available: "2023-12"
 11425	tolerable weak officer's nog	2	good	Last Available: "2023-12"
@@ -11282,7 +11282,7 @@
 11427	moldy tumbling tumbling sundae ration	4	crappy	Last Available: "2023-12"
 11428	stale skewed red peppermint tack	3	decent	Last Available: "2023-12"
 11429	bouncing Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	fancy bland whalesteak	4	decent	Effect: "Less Pervious", Effect Duration: 35, Last Available: "2023-12"
+11430	bland fancy whalesteak	4	decent	Effect: "Less Pervious", Effect Duration: 35, Last Available: "2023-12"
 11431	beefy whalegun of the bloodbag of Calamity Jane	0		Muscle: +10, Maximum HP: +100, Critical Hit Percent: +15, Last Available: "2023-12"
 11432	huge Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11307,21 +11307,21 @@
 11452	greedy rosewater-soaked greasy hale supercool Elf dessert spoon of the sweet-tooth	0		Moxie Percent: +20, Maximum HP: +20, Sleaze Spell Damage: +10, Stench Resistance: +3, Meat Drop: +20, Candy Drop: +100, Last Available: "2023-12"
 11453	Jim Carey's groovy Elf Guard SCUBA tank	0		Moxie Percent: +10, Monster Level: +25, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	narrow Socratic experienced free boots	0		Experience: +2, Experience (Mysticality): +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	narrow Socratic experienced free boots	0		Experience: +2, Experience (Mysticality): +1, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	tumbling healthy Da Vinci's beefy Elvish underarmor	0		Muscle: +10, Experience (Mysticality): +5, Maximum HP Percent: +20, Single Equip, Last Available: "2023-12"
 11458	twirling Crimbuccaneer bombjacket of James Dean of the boozehound	0		Experience (Moxie): +3, Booze Drop: +100, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	tasty miniature sugarplum ration	2	awesome	Last Available: "2023-12"
-11460	miniature spoiled skewed gingerbread nylons	2	crappy	Last Available: "2023-12"
-11461	fancy tasty small rum-soaked fruitcake	2	awesome	Effect: "Pemmican't", Effect Duration: 45, Last Available: "2023-12"
-11462	snack-sized rotten pulsating lime	2	crappy	Last Available: "2023-12"
+11459	miniature tasty sugarplum ration	2	awesome	Last Available: "2023-12"
+11460	spoiled miniature skewed gingerbread nylons	2	crappy	Last Available: "2023-12"
+11461	small fancy tasty rum-soaked fruitcake	2	awesome	Effect: "Pemmican't", Effect Duration: 45, Last Available: "2023-12"
+11462	rotten snack-sized pulsating lime	2	crappy	Last Available: "2023-12"
 11463	normal gingerbread pirate	3	good	Last Available: "2023-12"
-11464	diet stale fruit-stuffed rumcake	1	decent	Last Available: "2023-12"
+11464	stale diet fruit-stuffed rumcake	1	decent	Last Available: "2023-12"
 11465	perfectly mixed cyan mulled wine	3	EPIC	Last Available: "2023-12"
-11466	practically non-alcoholic tolerable gray blinking Swedish coffee	1	good	Last Available: "2023-12"
-11467	lousy weak canteen of eggnog	2	decent	Last Available: "2023-12"
-11468	weak bad hot wine	2	decent	Last Available: "2023-12"
-11469	artisanal enchanted Jamaican coffee	3	EPIC	Effect: "Ancient Protected", Effect Duration: 20, Last Available: "2023-12"
+11466	tolerable practically non-alcoholic blinking gray Swedish coffee	1	good	Last Available: "2023-12"
+11467	weak lousy canteen of eggnog	2	decent	Last Available: "2023-12"
+11468	bad weak hot wine	2	decent	Last Available: "2023-12"
+11469	enchanted artisanal Jamaican coffee	3	EPIC	Effect: "Ancient Protected", Effect Duration: 20, Last Available: "2023-12"
 11470	tolerable weak flask of egggrog	2	good	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
@@ -11329,11 +11329,11 @@
 11474	aged yule grog	4	awesome	Last Available: "2023-12"
 11475	decent massive olive wet tack	8	good	Last Available: "2023-12"
 11476	flavorless mirror whalecake	3	decent	Last Available: "2023-12"
-11477	ghostly avaricious stanky thinker's gunwale whalegun	0		Mysticality: +10, Stench Spell Damage: +25, Meat Drop: +30, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	ghostly avaricious stanky thinker's gunwale whalegun	0		Mysticality: +10, Stench Spell Damage: +25, Meat Drop: +30, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	acceptable and claret	3	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	lime green trick coin	0		Last Available: "2023-12"
-11481	horrifying cool Elf Guard squirtgun	0		Moxie: +5, Spooky Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	horrifying cool Elf Guard squirtgun	0		Moxie: +5, Spooky Damage: +25, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	purple chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	upside-down strapping sequin-encrusted sweater	0		Muscle: +5, Last Available: "2023-12"
 11484	gravedigger's replica Elf Guard medal of wisdom of James Dean	0		Mysticality: +15, Experience (Moxie): +3, Spooky Damage: +10, Last Available: "2023-12"
@@ -11356,14 +11356,14 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	galvanized green military candy cane	0		Effect: "familiar.enq", Effect Duration: 53
 11503	liquefied twirling groggipop	0		Effect: "In the Saucestream", Effect Duration: 63
-11504	narrow supercool wizardly moss mace	0		Mysticality: +25, Moxie Percent: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	jittery manspreader's moss megaphone of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	therapeutic moss medal of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	wool strapping moss mitre	0		Muscle: +5, Cold Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	cyan friendly stylish moss mantle	0		Moxie: +25, Familiar Weight: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	narrow supercool wizardly moss mace	0		Mysticality: +25, Moxie Percent: +20, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	jittery manspreader's moss megaphone of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	therapeutic moss medal of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	wool strapping moss mitre	0		Muscle: +5, Cold Resistance: +1, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	cyan friendly stylish moss mantle	0		Moxie: +25, Familiar Weight: +3, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	chaotic beefy moss marlinspike	0		Muscle: +10, Spell Critical Percent: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	denatured upside-down twirling moss mulch	1		Effect: "Christmessy", Effect Duration: 35, Last Available: "2024-12"
-11511	modified polarized blinking ghostly moss floss	0		Effect: "Twen Tea", Effect Duration: 14
+11510	denatured twirling upside-down moss mulch	1		Effect: "Christmessy", Effect Duration: 35, Last Available: "2024-12"
+11511	modified polarized ghostly blinking moss floss	0		Effect: "Twen Tea", Effect Duration: 14
 11512	blurry adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
@@ -11372,34 +11372,34 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	mixed adobe assortment	1		Effect: "All Branned Up", Effect Duration: 40, Last Available: "2024-12"
 11519	denatured adobe brittle	0		Effect: "Booooooze", Effect Duration: 41
-11520	blinking ribald resourceful medical-grade crepe paper phrygian cap	0		Maximum MP: +50, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	blinking ribald resourceful medical-grade crepe paper phrygian cap	0		Maximum MP: +50, Sleaze Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	Jeselnik's smooth crepe paper parachute cape of Calamity Jane	0		Moxie: +15, Critical Hit Percent: +15, Sleaze Damage: +25, Last Available: "2025-12"
-11522	purple tumbling coward's crepe paper pie clip of the pedagogue of the glutton	0		Experience: +3, Monster Level: -20, Food Drop: +100, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	perfumed experienced crepe paper puzzle cube of the pedagogue	0		Experience: 5, Stench Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	vibrating banded baleful crepe paper plunge camisole	0		Spell Damage: +25, Damage Absorption: +100, Maximum MP Percent: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	auspicious coward's crepe paper polka charm of the overflowing toilet	0		Monster Level: -20, Stench Spell Damage: +50, Item Drop: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	purple tumbling coward's crepe paper pie clip of the pedagogue of the glutton	0		Experience: +3, Monster Level: -20, Food Drop: +100, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	perfumed experienced crepe paper puzzle cube of the pedagogue	0		Experience: 5, Stench Resistance: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	vibrating banded baleful crepe paper plunge camisole	0		Spell Damage: +25, Damage Absorption: +100, Maximum MP Percent: +10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	auspicious coward's crepe paper polka charm of the overflowing toilet	0		Monster Level: -20, Stench Spell Damage: +50, Item Drop: +10, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	powdered narrow crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	frozen non-altered anodized crepe paper peanut candy	0		Effect: "Human-Pirate Hybrid", Effect Duration: 35
 11528	brawny petrified wood war pike of Leguizamo	0		Muscle Percent: +20, Monster Level: +20, Last Available: "2025-12"
 11529	narrow dance instructor's petrified wood waist protector of the dark arts	0		Experience Percent (Moxie): +10, Spell Damage Percent: +100, Single Equip, Last Available: "2025-12"
-11530	razor-sharp petrified wood wizard's pouch of the detective	0		Weapon Damage Percent: +25, Item Drop: +20, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	foul-smelling petrified wood water purifier	0		Stench Damage: +10, Item Drop: +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	razor-sharp petrified wood wizard's pouch of the detective	0		Weapon Damage Percent: +25, Item Drop: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	foul-smelling petrified wood water purifier	0		Stench Damage: +10, Item Drop: +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	horrifying wholesome petrified wood whoopie panama	0		Maximum HP Percent: +10, Spooky Damage: +25, Last Available: "2025-12"
 11533	fuchsia jittery flame-retardant Da Vinci's petrified wood walking pants	0		Experience (Mysticality): +5, Hot Resistance: +1, Last Available: "2025-12"
 11534	powdered squat petrified wood waste parts	1		Last Available: "2025-12"
 11535	activated wobbly petrified wood wafer praline	0		Effect: "Ten out of Ten", Effect Duration: 68
-11536	drinkable shaking narrow cybeer	4	good	Last Available: "2025-12"
+11536	drinkable narrow shaking cybeer	4	good	Last Available: "2025-12"
 11537	mirror ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	gravedigger's baleful Crimbuccaneer war standard	0		Spell Damage: +25, Spooky Damage: +10, Last Available: "2023-12"
 11544	lime green pulsating hardy strapping Elf Guard war standard	0		Muscle: +5, Maximum HP: +50, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	grievous Da Vinci's spring shoes of the sweet-tooth	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Candy Drop: +100, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
-11547	oxidized jittery bouncing ultra-soft ferns	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24, Last Available: "2024-02"
+11546	grievous Da Vinci's spring shoes of the sweet-tooth	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Candy Drop: +100, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11547	oxidized bouncing jittery ultra-soft ferns	0		Effect: "Hyperoxygenated Blood", Effect Duration: 24, Last Available: "2024-02"
 11548	dry nitrogenated crunchy brush	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 37, Last Available: "2024-02"
 11549	ghostly smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
@@ -11408,7 +11408,7 @@
 11553	ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	blurry quick-release belt pouch	0		Single Equip
-11556	ghostly maroon quick-release fannypack	0		Single Equip
+11556	maroon ghostly quick-release fannypack	0		Single Equip
 11557	quick-release utility belt	0		Single Equip
 11558	spinning motion sensor of the pedagogue	0		Experience: +3, Single Equip
 11559	focused magnetron pistol	0		Single Equip
@@ -11426,12 +11426,12 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	adequate yam	4	good	Last Available: "2024-05"
-11574	practically non-alcoholic bad tumbling fuchsia yam martini	1	decent	Last Available: "2024-05"
+11574	bad practically non-alcoholic fuchsia tumbling yam martini	1	decent	Last Available: "2024-05"
 11575	artisanal sweet potato o' mine	3	EPIC	Last Available: "2024-05"
 11576	drinkable green Southern yam	3	good	Last Available: "2024-05"
 11577	lousy fuchsia sweet potato punch	3	decent	Last Available: "2024-05"
 11578	flavorless Mayam spinach	3	decent	Last Available: "2024-05"
-11579	spoiled massive yam and swiss	9	crappy	Last Available: "2024-05"
+11579	massive spoiled yam and swiss	9	crappy	Last Available: "2024-05"
 11580	clever hale yam cannon of the cougar	0		Moxie: +20, Maximum HP: +20, Maximum MP: +20, Lasts Until Rollover, Last Available: "2024-05"
 11581	huge yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	skewed yam battery	0		Last Available: "2024-05"
@@ -11439,14 +11439,14 @@
 11584	wobbly gravedigger's Annie Oakley's brainy furry yam buckler	0		Mysticality: +5, Critical Hit Percent: +20, Spooky Damage: +10, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	Usain Bolt's steel-toed studded yamtility belt	0		Damage Absorption: +80, Damage Reduction: 9, Initiative: +80, Lasts Until Rollover, Last Available: "2024-05"
-11587	immense adequate yam slider	10	good	Last Available: "2024-05"
+11587	adequate immense yam slider	10	good	Last Available: "2024-05"
 11588	flavorless yam mayo	3	decent	Last Available: "2024-05"
 11589	enchanted super-sized flavorless yam burrito	5	decent	Effect: "Sappy Blood", Effect Duration: 45, Last Available: "2024-05"
 11590	narrow visual packet sniffer	0		Last Available: "2025-12"
 11591	pulsating mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	ghostly Thwaitgold Illinigina illinoiensis model	0		
-11594	big fancy flavorless mini kiwi	5	decent	Effect: "Rushin' Hands", Effect Duration: 10, Last Available: "2024-06"
+11594	fancy big flavorless mini kiwi	5	decent	Effect: "Rushin' Hands", Effect Duration: 10, Last Available: "2024-06"
 11595	studded Sinatra's mini kiwi bikini of Flo-Jo	0		Experience (Moxie): +5, Damage Absorption: +80, Initiative: +100, Last Available: "2024-06"
 11596	artisanal strong mini kiwitini	5	EPIC	Last Available: "2024-06"
 11597	pulsating mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11461,7 +11461,7 @@
 11606	tumbling mini kiwi icepick of doom	0		Spooky Spell Damage: +50
 11607	diffused shaking mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Sweet Incentive", Effect Duration: 39
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	olive protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11470,9 +11470,9 @@
 11615	zippy flame-retardant hale messenger bag RNA	0		Maximum HP: +20, Hot Resistance: +1, Initiative: +20
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	spoiled jumbo bacteria bisque	5	crappy	
+11618	jumbo spoiled bacteria bisque	5	crappy	
 11619	spoiled wobbly ciliophora chowder	4	crappy	
-11620	moldy miniature cream of chloroplasts	2	crappy	
+11620	miniature moldy cream of chloroplasts	2	crappy	
 11621	narrow synaptic soup	0		
 11622	muscular soup	0		
 11623	tumbling flagellate soup	0		
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	skewed photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	narrow hardened wizardly bat wings of the empath	0		Mysticality: +25, Damage Reduction: 3, Familiar Weight: +5, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	narrow hardened wizardly bat wings of the empath	0		Mysticality: +25, Damage Reduction: 3, Familiar Weight: +5, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	lion tamer's monocle on a stick of the early riser	0		Experience (familiar): +2, Adventures: +7, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,10 +11523,10 @@
 11668	spinning medical-grade Sheriff badge of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	therapeutic sinister Sheriff pistol	0		Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-10"
 11670	jittery Usain Bolt's rosy-cheeked Sheriff moustache	0		Maximum HP Percent: +30, Initiative: +80, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	perfumed mansplainer's photo booth supply list	0		Monster Level: +15, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	perfumed mansplainer's photo booth supply list	0		Monster Level: +15, Stench Resistance: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	mirror tie-dye headband	0		
-11674	stale huge special whirled peas	8	decent	Effect: "Resilient Spirit", Effect Duration: 15, Last Available: "2024-11"
+11674	stale special huge whirled peas	8	decent	Effect: "Resilient Spirit", Effect Duration: 15, Last Available: "2024-11"
 11675	normal mirror peaza	4	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	diluted skewed drenchrome 2.0	1		Last Available: "2025-12"
@@ -11536,17 +11536,17 @@
 11681	tumbling quantized familiar experience	0		
 11682	magnetized dry pea brittle	0		Effect: "Turkey-Ambitious", Effect Duration: 68, Last Available: "2024-11"
 11683	mediocre ghostly peasco	4	decent	Last Available: "2024-11"
-11684	decent gigantic jittery piece of cake	7	good	Last Available: "2024-11"
+11684	gigantic decent jittery piece of cake	7	good	Last Available: "2024-11"
 11685	bouncing handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	maroon cool deft pirate hook of the businessman	0		Moxie: +5, Meat Drop: +50, Lasts Until Rollover, Last Available: "2024-12"
-11689	jittery stiffened iron tricorn hat of wisdom	0		Mysticality: +15, Damage Reduction: 1, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	jittery stiffened iron tricorn hat of wisdom	0		Mysticality: +15, Damage Reduction: 1, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	brawny jolly roger flag	0		Muscle Percent: +20, Lasts Until Rollover, Last Available: "2024-12"
 11691	skewed sleeping profane parrot	0		Last Available: "2024-12"
 11692	wobbly pirrrate's currrse	0		Last Available: "2024-12"
 11693	artisanal olive tankard of spiced rum	4	EPIC	Last Available: "2024-12"
-11694	fancy smooth distilled tankard of spiced Goldschlepper	5	awesome	Effect: "Cockroach Scurry", Effect Duration: 25, Last Available: "2024-12"
+11694	distilled smooth fancy tankard of spiced Goldschlepper	5	awesome	Effect: "Cockroach Scurry", Effect Duration: 25, Last Available: "2024-12"
 11695	skewed blurry packaged luxury garment	0		Last Available: "2024-12"
 11696	lard-coated governor's daughter's lace collar	0		Sleaze Spell Damage: +25, Last Available: "2024-12"
 11697	purple bouncing governor's daughter's petticoats of the wise owl	0		Mysticality: +20, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	lime green profane eye patch	0		Sleaze Damage: +3
 11709	unsweetened liquefied anodized narrow peppermint pegleg	0		Effect: "Mayeaugh", Effect Duration: 40, Last Available: "2024-12"
 11710	extra-dry delicious hard cocoa	5	awesome	Last Available: "2024-12"
-11711	gigantic moldy salmagumdi	9	crappy	Last Available: "2024-12"
+11711	moldy gigantic salmagumdi	9	crappy	Last Available: "2024-12"
 11712	shaking inspector's plastic Easter Island Bunny	0		Item Drop: +15, Last Available: "2024-12"
 11713	fortified plastic St. Patrick	0		Damage Absorption: +60, Last Available: "2024-12"
 11714	dog trainer's sinister plastic Colonel Brando	0		Spell Damage: +10, Experience (familiar): +1, Last Available: "2024-12"
@@ -11573,17 +11573,17 @@
 11718	bouncing Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	wobbly Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	squat Spirit of Thanksgiving	0		Last Available: "2024-12"
-11721	jittery wobbly purple Spirit of Christmas	0		Last Available: "2024-12"
-11722	yummy half-sized coney haunch	2	awesome	Last Available: "2024-12"
+11721	purple jittery wobbly Spirit of Christmas	0		Last Available: "2024-12"
+11722	half-sized yummy coney haunch	2	awesome	Last Available: "2024-12"
 11723	dry spinning dark chocolate egg	0		Effect: "Boo Tea", Effect Duration: 17, Last Available: "2024-12"
-11724	special artisanal moai toai	3	EPIC	Effect: "Thick-Skinned", Effect Duration: 35
+11724	artisanal special moai toai	3	EPIC	Effect: "Thick-Skinned", Effect Duration: 35
 11725	nippy moaiball of extreme caution of the empath	0		Monster Level: -25, Familiar Weight: +5, Cold Damage: +10, Last Available: "2024-12"
 11726	narrow half-digested rat	0		Last Available: "2024-12"
 11727	nitrogenated denatured four-leaf potato sprout	0		Effect: "Paging Betty", Effect Duration: 16, Last Available: "2024-12"
 11728	wobbly aromatic reassuring medical-grade potato jacket	0		Spooky Resistance: +1, Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	nasty arcane researcher's military orb	0		Experience Percent (Mysticality): +10, Stench Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	nasty arcane researcher's military orb	0		Experience Percent (Mysticality): +10, Stench Damage: +5, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	chilled tarnished blurry rum ball	0		Effect: "Cool, Catlike", Effect Duration: 57
 11733	gravy skin	0		Last Available: "2024-12"
 11734	blurry savvy gravyskin hat of temperance	0		Mysticality Percent: +20, Sleaze Resistance: +5, Last Available: "2024-12"
@@ -11595,40 +11595,40 @@
 11740	jittery fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	horrifying smelly perfect Christmas scarf of horror	0		Stench Spell Damage: [+10*event(December)], Spooky Damage: [+25*event(December)], Spooky Spell Damage: [+25*event(December)], Single Equip, Last Available: "2024-12"
-11743	zippy brawny snowman-enchanting tophat	0		Muscle Percent: +20, Initiative: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	zippy brawny snowman-enchanting tophat	0		Muscle Percent: +20, Initiative: +20, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	ionized LIDAR candle	0		Effect: "Brocolate Brostidigitation", Effect Duration: 29, Last Available: "2024-12"
 11745	rosewater-soaked arcane researcher's Congressional Medal of Insanity of horror	0		Experience Percent (Mysticality): +10, Spooky Spell Damage: +25, Stench Resistance: +3, Last Available: "2024-12"
 11746	blinking pumpkin spice whorl	0		Last Available: "2024-12"
 11747	artisanal Easter grasshopper	3	EPIC	Last Available: "2024-12"
 11748	perfectly mixed purple Irish eggnog	4	EPIC	Last Available: "2024-12"
-11749	irresponsibly strong acceptable jittery canteen of jungle juice	7	good	Last Available: "2024-12"
-11750	tolerable practically non-alcoholic turchucken	1	good	Last Available: "2024-12"
+11749	acceptable irresponsibly strong jittery canteen of jungle juice	7	good	Last Available: "2024-12"
+11750	practically non-alcoholic tolerable turchucken	1	good	Last Available: "2024-12"
 11751	hand-crafted mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
 11752	hand-crafted upside-down holiday trip around the world	4	super EPIC	Last Available: "2024-12"
-11753	snack-sized stale spinning chocolate ostrich egg	2	decent	Last Available: "2024-12"
-11754	massive stale beef and cabbage	6	decent	Last Available: "2024-12"
+11753	stale snack-sized spinning chocolate ostrich egg	2	decent	Last Available: "2024-12"
+11754	stale massive beef and cabbage	6	decent	Last Available: "2024-12"
 11755	rotten candy rations	3	crappy	Last Available: "2024-12"
 11756	toothsome shaking double-candied yams	3	awesome	Last Available: "2024-12"
 11757	moldy Christmas ham	3	crappy	Last Available: "2024-12"
 11758	decent snack-sized holiday smorgasbord	2	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	steel-toed bejazzled eyepatch	0		Damage Reduction: 9, Last Available: "2024-12"
-11761	green blinking Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	skewed Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11771	huge tumbling moai statuette	0		Last Available: "2024-12"
-11772	pulsating narrow scorching electrified egg gun of vim and vigor of extreme caution	0		Maximum HP Percent: +50, Monster Level: -25, Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11761	green blinking Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	skewed Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11771	tumbling huge moai statuette	0		Last Available: "2024-12"
+11772	pulsating narrow scorching electrified egg gun of vim and vigor of extreme caution	0		Maximum HP Percent: +50, Monster Level: -25, Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	grievous Rosewater's boxer's stylish army helmet	0		Moxie: +25, Muscle Percent: +10, Mysticality Percent: +30, Weapon Damage Percent: +50, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	teal napkin	0		Last Available: "2024-12"
-11776	snack-sized flavorless Thanksgiving ration	2	decent	Last Available: "2024-12"
+11776	flavorless snack-sized Thanksgiving ration	2	decent	Last Available: "2024-12"
 11777	delicious weak Easter eggnog	2	awesome	Last Available: "2024-12"
 11778	compressed yellow clovermint	1		Effect: "Moon-Eyed", Effect Duration: 50, Last Available: "2024-12"
 11779	twirling miser's occult baleful nylon Christmas stockings of the bloodbag	0		Spell Damage: +25, Spell Damage Percent: +25, Maximum HP: +100, Meat Drop: +10, Single Equip, Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	diffused Vulcanized deviled candy egg	0		Effect: "Horrid, Torrid", Effect Duration: 51, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	ribald Annie Oakley's McHugeLarge duffel bag	0		Critical Hit Percent: +20, Sleaze Damage: +10, Last Available: "2025-01"
-11784	squat Annie Oakley's steel-toed McHugeLarge left pole of chilblains	0		Damage Reduction: 9, Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	tumbling lard-coated scandalous supercharged McHugeLarge right pole	0		Maximum MP Percent: +30, Sleaze Damage: +5, Sleaze Spell Damage: +25, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	nippy brawny McHugeLarge left ski	0		Muscle Percent: +20, Cold Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	McHugeLarge right ski of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	squat Annie Oakley's steel-toed McHugeLarge left pole of chilblains	0		Damage Reduction: 9, Critical Hit Percent: +20, Cold Damage: +25, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	tumbling lard-coated scandalous supercharged McHugeLarge right pole	0		Maximum MP Percent: +30, Sleaze Damage: +5, Sleaze Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	nippy brawny McHugeLarge left ski	0		Muscle Percent: +20, Cold Damage: +10, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	McHugeLarge right ski of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
-11790	dehydrated cyan blurry eXpand	1		Effect: "Inner Dog", Effect Duration: 20, Last Available: "2025-12"
-11791	shaking brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11790	dehydrated blurry cyan eXpand	1		Effect: "Inner Dog", Effect Duration: 20, Last Available: "2025-12"
+11791	shaking brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	ghostly dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	blurry dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	pulsating cybervisor	0		Last Available: "2025-12"
 11804	wobbly retro floppy disk	0		Last Available: "2025-12"
 11805	spinning pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	ghostly malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	ghostly malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	jittery CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	blurry pulsating server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	lime green parity bit	0		Familiar Weight: +5
 11826	shaking hashing vise	0		Last Available: "2025-12"
-11827	jittery geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	jittery geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	gray virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11693,7 +11693,7 @@
 11838	heat arc	0		
 11839	spinning scrape	0		
 11840	phantom digit	0		
-11841	twirling pulsating foul line	0		
+11841	pulsating twirling foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
 11844	chill gherkin	0		
@@ -11701,11 +11701,11 @@
 11846	plover's egg	0		
 11847	twirling shaking flyswatter	0		
 11848	twirling Thwaitgold cordyceps ant statuette	0		
-11849	upside-down jittery heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
+11849	jittery upside-down heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	red skewed phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
-11853	mirror maroon foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
+11853	maroon mirror foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
 11855	upside-down rift oculus	0		Combat Rate: +5
 11856	fuchsia sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
@@ -11713,7 +11713,7 @@
 11858	maroon glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
-11861	narrow blurry Leprecondo	0		Last Available: "2025-03"
+11861	blurry narrow Leprecondo	0		Last Available: "2025-03"
 11862	denatured scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	special watered-down smooth pint of Leprechaun Stout	2	awesome	Effect: "The Halls of Moxiousness", Effect Duration: 50, Last Available: "2025-03"
@@ -11729,18 +11729,18 @@
 11874	moldy snack-sized upside-down small beer brat	2	crappy	Last Available: "2025-03"
 11875	decent tiny blinking cyan peach pie	1	good	Last Available: "2025-03"
 11876	bland incredible mini-pizza	3	decent	Last Available: "2025-03"
-11877	enchanted bad practically non-alcoholic Divine sidecar	1	decent	Effect: "You Know When to Walk Away", Effect Duration: 40, Last Available: "2025-03"
-11878	perfectly mixed weak tangarita sidecar	2	EPIC	Last Available: "2025-03"
+11877	bad enchanted practically non-alcoholic Divine sidecar	1	decent	Effect: "You Know When to Walk Away", Effect Duration: 40, Last Available: "2025-03"
+11878	weak perfectly mixed tangarita sidecar	2	EPIC	Last Available: "2025-03"
 11879	acceptable twirling gimlet sidecar	3	good	Last Available: "2025-03"
 11880	tolerable vodka stratocaster sidecar	4	good	Last Available: "2025-03"
 11881	bad tumbling prussian cathouse sidecar	3	decent	Last Available: "2025-03"
-11882	weak hand-crafted Mon Tiki sidecar	2	EPIC	Last Available: "2025-03"
+11882	hand-crafted weak Mon Tiki sidecar	2	EPIC	Last Available: "2025-03"
 11883	green Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	jittery reassuring April Shower Thoughts shield of the bloodbag	0		Maximum HP: +100, Spooky Resistance: +1, Damage Reduction: 6, Last Available: "2025-04"
 11885	green glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	liquefied quantum wet paper weights	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 67, Last Available: "2025-04"
-11888	enchanted hand-crafted Three Sheets to the Wind	3	EPIC	Effect: "Berry Elemental", Effect Duration: 40, Last Available: "2025-04"
+11888	hand-crafted enchanted Three Sheets to the Wind	3	EPIC	Effect: "Berry Elemental", Effect Duration: 40, Last Available: "2025-04"
 11889	stale pile of wet dates	4	decent	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	ghostly grievous stylish bycocket	0		Weapon Damage Percent: +50
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	mirror packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	fuchsia yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	spinning ordnance magnet	0		Single Equip
 11936	mirror green confetti grenade	0		
-11937	normal miniature mirror Skeleton Wars rations	2	good	
+11937	miniature normal mirror Skeleton Wars rations	2	good	
 11938	perfectly mixed skeleton war fuel can	3	EPIC	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11806,7 +11806,7 @@
 11951	purple Stock Certificate	0		Last Available: "2025-08"
 11952	modified tumbling mixed berry jelly	1		Effect: "Empathy", Effect Duration: 30, Last Available: "2025-08"
 11953	rotten snack-sized toast with mixed berry jelly	2	crappy	Last Available: "2025-08"
-11954	moldy small cup of sugar	2	crappy	Last Available: "2025-08"
+11954	small moldy cup of sugar	2	crappy	Last Available: "2025-08"
 11955	miniature adequate spinning Susie's cupcake	2	good	Last Available: "2025-08"
 11956	wobbly clock	0		Last Available: "2025-08"
 11957	forbidden savvy the gun of the blizzard	0		Mysticality Percent: +20, Spell Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2025-08"
@@ -11826,26 +11826,26 @@
 11972	skewed durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	wobbly packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	aromatic dentadent	0		Stench Resistance: +1
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	tumbling quilted Sinatra's thinker's blood cubic zirconia of the brute of the bloodbag of horror	0		Mysticality: +10, Muscle Percent: +30, Experience (Moxie): +5, Damage Absorption: +40, Maximum HP: +100, Spooky Spell Damage: +25, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	tumbling quilted Sinatra's thinker's blood cubic zirconia of the brute of the bloodbag of horror	0		Mysticality: +10, Muscle Percent: +30, Experience (Moxie): +5, Damage Absorption: +40, Maximum HP: +100, Spooky Spell Damage: +25, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	pickled twirling blood thinner	1		Last Available: "2025-10"
 12045	perfectly mixed pheromone cocktail	3	EPIC	Last Available: "2025-10"
 12046	toothsome spinal tapas	3	awesome	Last Available: "2025-10"
 12047	shaking lime green shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	jittery hale hardened Newton's shrunken head	0		Experience (Mysticality): +3, Damage Reduction: 3, Maximum HP: +20, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	jittery hale hardened Newton's shrunken head	0		Experience (Mysticality): +3, Damage Reduction: 3, Maximum HP: +20, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	narrow small peppermint-flavored sugar walking crook	0		
 12051	blinking knucklebone	0		
-12052	practically non-alcoholic artisanal upside-down Smoking Pope	1	super ultra mega turbo EPIC	
+12052	artisanal practically non-alcoholic upside-down Smoking Pope	1	super ultra mega turbo EPIC	
 12053	adequate yellow prize turkey	4	good	
 12054	distilled medicinal gruel	1		
-12055	normal miniature huge bouncing full-sized pumpkin pie	2	good	Last Available: "2025-11"
-12056	triple-distilled mediocre vodka cranberry sauce	7	decent	Last Available: "2025-11"
+12055	miniature normal bouncing huge full-sized pumpkin pie	2	good	Last Available: "2025-11"
+12056	mediocre triple-distilled vodka cranberry sauce	7	decent	Last Available: "2025-11"
 12057	modified yammed candy	0		Effect: "Cold Hands", Effect Duration: 30, Last Available: "2025-11"
-12058	tiny adequate treasure chestnut	1	good	Last Available: "2025-12"
+12058	adequate tiny treasure chestnut	1	good	Last Available: "2025-12"
 12059	hand-crafted mulled butter rum	4	EPIC	Last Available: "2025-12"
 12060	magnetized adjusted cinnamon doubloon	0		Effect: "Blubbered Up", Effect Duration: 38, Last Available: "2025-12"
 12061	family-friendly plastic left skeleton arm	0		Sleaze Resistance: +1, Last Available: "2025-12"
@@ -11861,7 +11861,7 @@
 12071	wholesome angelbone mantle of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +10, Last Available: "2026-12"
 12072	angelbone dice of the ox	0		Muscle: +20, Single Equip, Last Available: "2026-12"
 12073	gray electrified energetic angelbone halo	0		Maximum MP Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2026-12"
-12074	denatured squat jittery wobbly angelbone fragments	1		Effect: "Squid Squint", Effect Duration: 50, Last Available: "2026-12"
+12074	denatured jittery wobbly squat angelbone fragments	1		Effect: "Squid Squint", Effect Duration: 50, Last Available: "2026-12"
 12075	deionized biblically accurate gumdrops	0		Effect: "Marco Polarity", Effect Duration: 49
 12076	Usain Bolt's chaotic devilbone helmet	0		Spell Critical Percent: +10, Initiative: +80, Last Available: "2026-12"
 12077	blurry Sinatra's devilbone greaves	0		Experience (Moxie): +5, Last Available: "2026-12"
@@ -11871,7 +11871,7 @@
 12081	weightlifter's devilbone rosary	0		Muscle: +15, Single Equip, Last Available: "2026-12"
 12082	dehydrated devilbone chunks	1		Effect: "Ode to Booze", Effect Duration: 5, Last Available: "2026-12"
 12083	chilled huge Gehenna tattoo	0		Effect: "Human-Fish Hybrid", Effect Duration: 40
-12116	purple twirling burnt incisor	0		Last Available: "2025-12"
+12116	twirling purple burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
 12118	burnt radius	0		Last Available: "2025-12"
 12119	bouncing burnt rib	0		Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	non-deionized boiling synovial fluid	0		Effect: "Pyramid Power", Effect Duration: 19, Last Available: "2025-12"
 12132	horrifying dance instructor's smoldering vertebra of extreme caution	0		Experience Percent (Moxie): +10, Monster Level: -25, Spooky Damage: +25, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	green blinking volatile bone bomb	0		Last Available: "2025-12"
 12137	dog trainer's Sinatra's groovy hot boning knife	0		Moxie Percent: +10, Experience (Moxie): +5, Experience (familiar): +1, Single Equip, Last Available: "2025-12"
@@ -11904,7 +11904,7 @@
 12146	plastic skeleton Crimbo hat of temperance	0		Sleaze Resistance: +5, Last Available: "2025-12"
 12147	assembled plastic Santa skeleton	0		Last Available: "2025-12"
 12148	sleigh	0		Familiar Weight: +10
-12149	squat skewed undertakers' forceps	0		Last Available: "2025-12"
+12149	skewed squat undertakers' forceps	0		Last Available: "2025-12"
 12150	blurry bone-polishing rag	0		Last Available: "2025-12"
 12151	narrow greedy smartaleck's scorched skeleton mask	0		Moxie Percent: +30, Meat Drop: +20, Last Available: "2025-12"
 12152	banded baleful scorched skeleton shirt	0		Spell Damage: +25, Damage Absorption: +100, Last Available: "2025-12"
@@ -11935,8 +11935,8 @@
 12177	normal wedge of prize-winning cheese	3	good	Last Available: "2025-12"
 12178	super-aerosolized magnetized gummi fingerbone	0		Effect: "Helvella Health", Effect Duration: 38
 12179	Usain Bolt's banded glimmering crystal	0		Damage Absorption: +100, Initiative: +80, Last Available: "2025-12"
-12180	tumbling yellow boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12180	yellow tumbling boxed Heartstone	0		Free Pull, Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	twirling Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11962,7 +11962,7 @@
 12204	watered-down bad gray Pork Elf cough syrup	2	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
-12207	spinning jittery blurry Pork Elf sink	0		Last Available: "2026-03"
+12207	jittery spinning blurry Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
 12209	spoiled rat pizza	4	crappy	Last Available: "2026-03"
 12210	mirror Fleek&trade; mascara	0		Last Available: "2026-03"
@@ -11970,7 +11970,7 @@
 12212	inspector's Da Vinci's smooth left shark fin	0		Moxie: +15, Experience (Mysticality): +5, Item Drop: +15, Last Available: "2026-03"
 12213	blurry fitness tracking bracelet of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2026-03"
 12214	boiled twirling candy bone	1		
-12215	mirror squat wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
+12215	squat mirror wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	bland discarded hot dog	3	decent	Last Available: "2026-04"
 12218	perfectly mixed spirit-forward most of a beer	5	EPIC	Last Available: "2026-04"
@@ -11978,17 +11978,17 @@
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	moldy can of tuna	3	crappy	
-12227	small flavorless narrow alien salad	2	decent	
+12227	flavorless small narrow alien salad	2	decent	
 12228	bland tumbling ratbatatouille	3	decent	
-12229	jumbo delicious olive onigiri	5	awesome	
-12230	stale miniature crudit&eacute;s	2	decent	
-12231	moldy snack-sized pulsating sauced mutton	2	crappy	
+12229	delicious jumbo olive onigiri	5	awesome	
+12230	miniature stale crudit&eacute;s	2	decent	
+12231	snack-sized moldy pulsating sauced mutton	2	crappy	
 12232	decent hot honey ant	3	good	
 12233	decent miniature tomb aspic	2	good	
 12234	stale shaking later tots	4	decent	
 12235	adequate snack-sized spinning Frutti di Scatoletta	2	good	Last Available: "2026-05"
-12236	spoiled olive shaking Pesto alla Marziano	3	crappy	Last Available: "2026-05"
-12237	moldy half-sized Arrattabbattabiata	2	crappy	Last Available: "2026-05"
+12236	spoiled shaking olive Pesto alla Marziano	3	crappy	Last Available: "2026-05"
+12237	half-sized moldy Arrattabbattabiata	2	crappy	Last Available: "2026-05"
 12238	normal ghostly Orzo di Riso	4	good	Last Available: "2026-05"
 12239	rotten super-sized Pasta Grimavera	5	crappy	Last Available: "2026-05"
 12240	rotten Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
@@ -12000,8 +12000,8 @@
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	flame-wreathed razor-sharp Space Soldier Helmet	0		Weapon Damage Percent: +25, Hot Spell Damage: +10
-12253	decent jumbo premium turkey leg	5	good	
-12254	boozy tolerable styrofoam cup of mead	5	good	
+12253	jumbo decent premium turkey leg	5	good	
+12254	tolerable boozy styrofoam cup of mead	5	good	
 12255	greedy sword	0		Meat Drop: +20
 12256	blinking upside-down staff of the storm	0		Maximum MP Percent: +40
 12257	steel-toed lute	0		Damage Reduction: 9
@@ -12017,11 +12017,11 @@
 12267	razor-sharp flimsy plastic breastplate	0		Weapon Damage Percent: +25
 12268	flimsy plastic shield of the blizzard	0		Cold Spell Damage: +25, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	fireproof banded Rosewater's Portable Laughing Stock	0		Mysticality Percent: +30, Damage Absorption: +100, Hot Resistance: +3, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	fireproof banded Rosewater's Portable Laughing Stock	0		Mysticality Percent: +30, Damage Absorption: +100, Hot Resistance: +3, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	double-paned knitted frightening Staff of Anachronistic Churning	0		Spooky Damage: +5, Cold Resistance: 8
 12272	tiny tasty classic banana	1	awesome	Last Available: "2026-07"
-12273	immense bland watermelon	9	decent	Last Available: "2026-07"
-12274	moldy spinning yellow quince	3	crappy	Last Available: "2026-07"
+12273	bland immense watermelon	9	decent	Last Available: "2026-07"
+12274	moldy yellow spinning quince	3	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	spoiled classic banana pie	3	crappy	Last Available: "2026-07"
@@ -12033,23 +12033,23 @@
 12283	aerosolized ghostly concentrated watermelon juice	0		Effect: "Whippin' It Good", Effect Duration: 14, Last Available: "2026-07"
 12284	quadruple-enhanced chilled Aqua Citrulanatae	0		Effect: "Spookypants", Effect Duration: 26, Last Available: "2026-07"
 12285	mediocre Melonegroni	3	decent	Last Available: "2026-07"
-12286	practically non-alcoholic fancy perfectly mixed Melonade Spritz	1	super ultra mega turbo EPIC	Effect: "Piratey Flavor", Effect Duration: 30, Last Available: "2026-07"
-12287	bland gigantic quince pie	7	decent	Last Available: "2026-07"
+12286	fancy practically non-alcoholic perfectly mixed Melonade Spritz	1	super ultra mega turbo EPIC	Effect: "Piratey Flavor", Effect Duration: 30, Last Available: "2026-07"
+12287	gigantic bland quince pie	7	decent	Last Available: "2026-07"
 12288	concentrated adjusted quince quaff	0		Effect: "New Zeal", Effect Duration: 13, Last Available: "2026-07"
 12289	enhanced activated purple Quickquince	0		Effect: "Melancholy Burden", Effect Duration: 67, Last Available: "2026-07"
 12290	artisanal high-proof Quiskey Sour	9	EPIC	Last Available: "2026-07"
-12291	perfectly mixed watered-down Quincea&ntilde;era Cooler	2	super EPIC	Last Available: "2026-07"
+12291	watered-down perfectly mixed Quincea&ntilde;era Cooler	2	super EPIC	Last Available: "2026-07"
 12292	aged Roth IPA	4	awesome	Last Available: "2026-08"
 12293	shaking dog trainer's beefcake's underdraft protection	0		Muscle: +25, Experience (familiar): +1, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	jumbo flavorless ghostly soybean futures	5	decent	Last Available: "2026-08"
+12295	flavorless jumbo ghostly soybean futures	5	decent	Last Available: "2026-08"
 12296	magnetized double-electrified housing bubble	0		Effect: "Saucefingers", Effect Duration: 58, Last Available: "2026-08"
 12297	alkaline Vulcanized Pixie-Swordz	0		Effect: "Ticking Clock", Effect Duration: 18
 12298	inspector's manspreader's financial instrument	0		Monster Level: +10, Item Drop: +15, Last Available: "2026-08"
 12299	executive scorching hedge fund clippers	0		Hot Damage: +25, Meat Drop: +40, Last Available: "2026-08"
 12300	tumbling selling shorts of wisdom	0		Mysticality: +15, Last Available: "2026-08"
 12301	yellow bear tattoo	0		Last Available: "2026-08"
-12302	lime green bouncing narrow bull tattoo	0		Last Available: "2026-08"
+12302	lime green narrow bouncing bull tattoo	0		Last Available: "2026-08"
 12303	zippy smooth 401k ring	0		Moxie: +15, Initiative: +20, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
 12305	liquefied vacuum-sealed flattened invisible hand	0		Effect: "Leo Rising", Effect Duration: 40, Last Available: "2026-08"
@@ -12059,6 +12059,6 @@
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	twisted toxic asset	1		Last Available: "2026-08"
 12311	distilled cyan huge intangible asset	1		Effect: "Jammin'", Effect Duration: 10, Last Available: "2026-08"
-12312	altered red twirling wobbly liquid asset	1		Last Available: "2026-08"
+12312	altered red wobbly twirling liquid asset	1		Last Available: "2026-08"
 12313	mirror gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Sauceror_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Platypus_cafe_booze.txt
@@ -1,32 +1,32 @@
 -1	lousy pulsating shaking Petite Porter	3	decent	
--2	perfectly mixed watered-down Scrawny Stout	2	EPIC	
+-2	watered-down perfectly mixed Scrawny Stout	2	EPIC	
 -3	strong lousy Infinitesimal IPA	5	decent	
--4	lousy high-proof shaking eggnogtini	9	decent	
--5	practically non-alcoholic acceptable spinning candycaine	1	good	
+-4	high-proof lousy shaking eggnogtini	9	decent	
+-5	acceptable practically non-alcoholic spinning candycaine	1	good	
 -6	acceptable braincracker sweet	3	good	
 -16	delicious fermented honey	3	awesome	
--17	artisanal watered-down spinning moons-shine	2	EPIC	
+-17	watered-down artisanal spinning moons-shine	2	EPIC	
 -18	acceptable blurry gin	3	good	
--19	drinkable boozy ecto-nog	5	good	
--20	high-proof mediocre hot toady	6	decent	
--21	watered-down drinkable mirror hot choculate	2	good	
--49	artisanal watered-down enchanted Cyder	2	EPIC	
+-19	boozy drinkable ecto-nog	5	good	
+-20	mediocre high-proof hot toady	6	decent	
+-21	drinkable watered-down mirror hot choculate	2	good	
+-49	artisanal enchanted watered-down Cyder	2	EPIC	
 -50	lousy Oil Nog	4	decent	
 -51	fancy high-proof perfectly mixed bouncing Hi-Octane Peppermint Jet Fuel	6	EPIC	
--58	acceptable boozy Grimacider	5	good	
+-58	boozy acceptable Grimacider	5	good	
 -59	artisanal Isotope Nog	4	EPIC	
 -60	irresponsibly strong hand-crafted twirling Mutagin 'n' Tonic	9	EPIC	
 -70	watered-down hand-crafted Gin and Herring	2	EPIC	
--71	smooth practically non-alcoholic skewed ghostly Black and Tan and Red All Over	1	awesome	
--72	drinkable weak Antarctic Ice Tea	2	good	
+-71	practically non-alcoholic smooth skewed ghostly Black and Tan and Red All Over	1	awesome	
+-72	weak drinkable Antarctic Ice Tea	2	good	
 -76	perfectly mixed CRIMBCO Ribbon Candy Schnapps	4	EPIC	
--77	watered-down hand-crafted tumbling CRIMBCO Egg Substitute Nog Substitute	2	EPIC	
+-77	hand-crafted watered-down tumbling CRIMBCO Egg Substitute Nog Substitute	2	EPIC	
 -78	lousy CRIMBCO Extreme Braincracker Sour	4	decent	
--82	smooth weak shaking Horseradish-infused Vodka	2	awesome	
--83	irresponsibly strong lousy Jerkitini	10	decent	
+-82	weak smooth shaking Horseradish-infused Vodka	2	awesome	
+-83	lousy irresponsibly strong Jerkitini	10	decent	
 -84	perfectly mixed Desert Island Iced Tea	3	EPIC	
 -88	bad Crimbo Saketini	3	decent	
--89	smooth practically non-alcoholic lime green Crimboku Drop	1	awesome	
+-89	practically non-alcoholic smooth lime green Crimboku Drop	1	awesome	
 -90	fancy bad twirling Flaming Crimbo Log	4	decent	
 -107	hand-crafted Fortified Eggnog Slurry	4	EPIC	
 -108	irresponsibly strong tolerable Hot Buttered Rum	8	good	

--- a/data/TCRS/TCRS_Sauceror_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Platypus_cafe_food.txt
@@ -1,45 +1,45 @@
--1	spoiled shaking pulsating Peche a la Frog	3	crappy	
+-1	spoiled pulsating shaking Peche a la Frog	3	crappy	
 -2	half-sized decent As Jus Gezund Heit	2	good	
 -3	big spoiled Bouillabaise Coucher Avec Moi	5	crappy	
 -7	bland spinning gumdrop chow mein	4	decent	
 -8	yummy candy cane pizza	4	awesome	
 -9	spoiled gingerbread stir-fry	3	crappy	
--10	huge spoiled twigs and gravel	6	crappy	
--11	normal snack-sized enchanted shoots and leaves	2	good	
--12	snack-sized normal bowl of unidentifiable goo	2	good	
--13	bite-sized yummy yellow gingerbread massacre	1	awesome	
+-10	spoiled huge twigs and gravel	6	crappy	
+-11	snack-sized normal enchanted shoots and leaves	2	good	
+-12	normal snack-sized bowl of unidentifiable goo	2	good	
+-13	yummy bite-sized yellow gingerbread massacre	1	awesome	
 -14	delicious small It Came From Beyond Dessert	2	awesome	
 -15	stale vampire cake	3	decent	
 -52	rotten Soylent Red and Green	3	crappy	
 -53	spoiled wobbly Disc-Shaped Nutrition Unit	3	crappy	
 -54	big rotten narrow Gingerborg Hive	5	crappy	
 -61	flavorless huge Candy Cane Surprise	3	decent	
--62	normal thick Grimdrop Chow Mein	5	good	
--63	moldy half-sized Grimgerbread House	2	crappy	
+-62	thick normal Grimdrop Chow Mein	5	good	
+-63	half-sized moldy Grimgerbread House	2	crappy	
 -67	stale Caviar Carbonara	4	decent	
 -68	yummy Halibut Alfredo	3	awesome	
--69	super-sized rotten jittery Red Herring Velvet Cake	5	crappy	
+-69	rotten super-sized jittery Red Herring Velvet Cake	5	crappy	
 -73	spoiled CRIMBCO Reconstituted Gruel	3	crappy	
--74	gigantic rotten special spinning New and Improved CRIMBCO Reconstituted Gruel	7	crappy	
--75	bland miniature CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	decent	
+-74	rotten gigantic special spinning New and Improved CRIMBCO Reconstituted Gruel	7	crappy	
+-75	miniature bland CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	decent	
 -79	yummy tumbling Brussels Sprout Stir-Fry	4	awesome	
 -80	rotten special wobbly Carrot, Cabbage, and Kale Pizza	4	crappy	
--81	rotten miniature Turnip and Rutabaga Pie	2	crappy	
+-81	miniature rotten Turnip and Rutabaga Pie	2	crappy	
 -85	bland small ghostly Rainbow Spider Fun Roll	2	decent	
--86	flavorless thick blinking Vegas Volcano Lava Roll	5	decent	
+-86	thick flavorless blinking Vegas Volcano Lava Roll	5	decent	
 -87	moldy Crazy Dragon Shogun Buddha Roll	3	crappy	
 -92	jumbo stale basic hot dog	5	decent	
--93	small adequate savage macho dog	2	good	
+-93	adequate small savage macho dog	2	good	
 -94	toothsome huge one with everything	7	awesome	
 -95	stale sly dog	3	decent	
--96	immense rotten devil dog	10	crappy	
+-96	rotten immense devil dog	10	crappy	
 -97	spoiled pulsating chilly dog	3	crappy	
--98	rotten miniature ghost dog	2	crappy	
--99	bland bouncing squat junkyard dog	3	decent	
--100	rotten tiny fuchsia wet dog	1	crappy	
--101	half-sized tasty red sleeping dog	2	awesome	
+-98	miniature rotten ghost dog	2	crappy	
+-99	bland squat bouncing junkyard dog	3	decent	
+-100	tiny rotten fuchsia wet dog	1	crappy	
+-101	tasty half-sized red sleeping dog	2	awesome	
 -102	bite-sized tasty fuchsia optimal dog	1	awesome	
 -103	normal jumbo video games hot dog	5	good	
 -104	low-calorie spoiled maroon Peppermint Nutrition Block	1	crappy	
 -105	normal Gingerbread Nutrition Block	3	good	
--106	rotten huge upside-down Cinnamon Nutrition Block	4	crappy	
+-106	rotten upside-down huge Cinnamon Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Sauceror_Vole.txt
+++ b/data/TCRS/TCRS_Sauceror_Vole.txt
@@ -9,7 +9,7 @@
 9	ruddy disco mask	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 2"
 10	disco ball	0		
 11	stolen accordion	0		Song Duration: 5
-12	blue skewed mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
+12	skewed blue mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	powdered shaking squat moxie weed	1		
 15	powdered twirling strongness elixir	1		
 16	boiled magicalness-in-a-can	1		Effect: "Pumped Up", Effect Duration: 45
@@ -42,7 +42,7 @@
 43	worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
-46	blinking shaking twirling figurine	0		
+46	shaking blinking twirling figurine	0		
 47	stale enchanted skewed hot buttered roll	3	decent	Effect: "Abyssal Tears", Effect Duration: 15
 48	heart of rock and roll	0		
 49	normal small bowl of cottage cheese	2	good	
@@ -71,7 +71,7 @@
 72	teal barskin hat of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "atk, 1xVolley, cap 13"
 73	spinning barskin tent	0		
 74	Temple map	0		
-75	skewed fuchsia sapling	0		
+75	fuchsia skewed sapling	0		
 76	yellow Spooky-Gro fertilizer	0		
 77	dance instructor's stick	0		Experience Percent (Moxie): +10
 78	steel-toed pretty bouquet	0		Damage Reduction: 9
@@ -153,11 +153,11 @@
 154	frightening Disco 'Fro Pick of the cheetah	0		Spooky Damage: +5, Initiative: +60, Class: "Disco Bandit", Familiar Effect: "3xGhuol, cap 25"
 155	sharpshooter's El Sombrero De Lopez of Flo-Jo	0		Critical Hit Percent: +10, Initiative: +100, Class: "Accordion Thief", Familiar Effect: "3xGhuol, cap 25"
 156	guild application	0		
-157	red huge Dramatic&trade; range	0		
+157	huge red Dramatic&trade; range	0		
 158	Gnollish pie tin	0		
 159	olive wad of dough	0		
 160	wobbly pie crust	0		
-161	snack-sized yummy ghuol egg	2	awesome	
+161	yummy snack-sized ghuol egg	2	awesome	
 162	bland tiny skewed ghuol egg quiche	1	decent	
 163	skeleton bone of bravery	0		Spooky Resistance: +5
 164	smart skull	0		
@@ -179,7 +179,7 @@
 180	acceptable blurry ice-cold fotie	3	good	
 181	mirror baseball	0		
 182	narrow batgut	0		
-183	twirling spinning lime green bat wing	0		
+183	lime green spinning twirling bat wing	0		
 184	blinking briefcase	0		
 185	fat stacks of cash	0		
 186	bean	0		
@@ -187,19 +187,19 @@
 188	shaking bat guano	0		
 189	guano coffee cup	0		
 191	yellow rosy-cheeked batskin belt	0		Maximum HP Percent: +30
-192	tumbling blurry blinking batskin belt	0		
+192	blinking tumbling blurry batskin belt	0		
 193	narrow birthday candle	0		
 194	blurry smartaleck's Mr. Accessory	0		Moxie Percent: +30, Softcore Only
 195	ghostly red eXtreme nose ring of chilblains	0		Cold Damage: +25
 196	disassembled clover	0		
-197	huge yellow ghostly rat whisker	0		
+197	huge ghostly yellow rat whisker	0		
 198	rat appendix	0		
 199	huge ring of the cheetah	0		Initiative: +60
 200	delicious snack-sized skewed rat appendix kabob	2	awesome	
 201	yummy bat wing kabob	4	awesome	
 202	rotten carob chunks	3	crappy	
 203	herbs	0		
-204	decent gigantic carob chunk cookies	7	good	
+204	gigantic decent carob chunk cookies	7	good	
 205	twirling secret blend of herbs and spices	0		
 206	mirror piercing post	0		
 207	hippy herbal tea	1	EPIC	
@@ -212,7 +212,7 @@
 214	clever filthy knitted dread sack	0		Maximum MP: +20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
 216	moldy maroon wobbly carob brownies	3	crappy	
-217	low-calorie special adequate herb brownies	1	good	Effect: "Think Win-Lose", Effect Duration: 30
+217	adequate low-calorie special herb brownies	1	good	Effect: "Think Win-Lose", Effect Duration: 30
 218	hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -221,12 +221,12 @@
 223	blue phat turquoise bracelet of the cougar	0		Moxie: +20
 224	tumbling forbidden eyepatch	0		Spell Damage Percent: +50, Familiar Effect: "3xBarrr, cap 6"
 225	special moldy twirling tofu casserole	4	crappy	Effect: "Sweet and Green", Effect Duration: 20
-226	distilled wobbly spinning wobbly red can of Red Minotaur	1	decent	
+226	distilled red wobbly spinning wobbly can of Red Minotaur	1	decent	
 227	dangerous Kentucky-fried meat sword	0		Weapon Damage: +10
 228	electrified Kentucky-fried meat staff	0		MP Regen Min: 3, MP Regen Max: 5
 229	flame-wreathed Kentucky-fried meat crossbow	0		Hot Spell Damage: +10
 230	weightlifter's dead guy's watch	0		Muscle: +15, Single Equip
-231	upside-down blinking Doc Galaktik's Pungent Unguent	0		
+231	blinking upside-down Doc Galaktik's Pungent Unguent	0		
 232	Doc Galaktik's Ailment Ointment	0		
 233	Doc Galaktik's Restorative Balm	0		
 234	blinking ghostly Doc Galaktik's Homeopathic Elixir	0		
@@ -238,15 +238,15 @@
 240	careful arcane researcher's Orcish cargo shorts	0		Experience Percent (Mysticality): +10, Monster Level: -10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	lard-coated Orcish frat-paddle	0		Sleaze Spell Damage: +25
 242	moldy half-sized	2	crappy	
-243	tasty diet ghostly grapefruit	1	awesome	
+243	diet tasty ghostly grapefruit	1	awesome	
 244	moldy grapes	3	crappy	
 245	yummy olive	3	awesome	
-246	rotten miniature narrow tomato	2	crappy	
+246	miniature rotten narrow tomato	2	crappy	
 247	fermenting powder	0		
 248	artisanal irresponsibly strong skewed salty dog	9	EPIC	
 249	practically non-alcoholic perfectly mixed tumbling bloody mary	1	EPIC	
 250	tolerable bouncing screwdriver	3	good	
-251	practically non-alcoholic delicious martini	1	awesome	
+251	delicious practically non-alcoholic martini	1	awesome	
 252	acceptable enchanted skewed bloody beer	3	good	Effect: "Human-Humanoid Hybrid", Effect Duration: 40
 253	weak hand-crafted shot of schnapps	2	EPIC	
 254	lousy weak skewed shot of grapefruit schnapps	2	decent	
@@ -255,20 +255,20 @@
 257	tolerable special extra-spicy bloody mary	3	good	Effect: "protect.enq", Effect Duration: 15
 258	dense meat stack	0		
 259	snake skin	0		
-260	miniature normal White Citadel fries	2	good	
+260	normal miniature White Citadel fries	2	good	
 261	adequate spinning White Citadel burger	3	good	
 262	decent maroon piece of wedding cake	3	good	
-263	decent immense chocolate chips	8	good	
-264	decent big chocolate chip cookies	5	good	
+263	immense decent chocolate chips	8	good	
+264	big decent chocolate chip cookies	5	good	
 265	Samson's satin pants	0		Experience (Muscle): +5, Familiar Effect: "atk, 2xPotato, cap 10"
 266	perfectly mixed lightning	3	EPIC	
 267	shaking supercharged mullet wig	0		Maximum MP Percent: +30, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	wobbly yellow rock-hard meat cowboy hat	0		Damage Reduction: 5, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	scorching sword	0		Hot Damage: +25
-270	upside-down teal picket fence	0		
+270	teal upside-down picket fence	0		
 271	powdered twirling shaking barbell	1		Effect: "Sucrose-Colored Glasses", Effect Duration: 20
 272	mixed twirling concentrated magicalness pill	1		
-273	compressed tumbling narrow moxie weed	1		
+273	compressed narrow tumbling moxie weed	1		
 274	bouncing Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
@@ -298,7 +298,7 @@
 300	magnetized pressed mirror yellow jaba&ntilde;ero-flavored chewing gum	0		Effect: "Tingly Wrists", Effect Duration: 28
 301	flat dough	0		
 302	normal jittery skewed Knob sausage	3	good	
-303	flavorless small blurry Knob mushroom	2	decent	
+303	small flavorless blurry Knob mushroom	2	decent	
 304	lime green dry noodles	0		
 305	asbestos-lined Knob Goblin harem pants	0		Hot Resistance: +5, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	twirling tumbling cool Knob Goblin harem veil	0		Moxie: +5, Familiar Effect: "5xLep, cap 2"
@@ -309,14 +309,14 @@
 311	gray blinking hill of beans	0		
 312	clever Knob Goblin visor	0		Maximum MP: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	purple Crown of the Goblin King of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	miniature moldy red bean burrito	2	crappy	
-315	jumbo moldy bean burrito	5	crappy	
-316	bland massive pulsating ghostly insanely bean burrito	6	decent	
+314	moldy miniature red bean burrito	2	crappy	
+315	moldy jumbo bean burrito	5	crappy	
+316	massive bland ghostly pulsating insanely bean burrito	6	decent	
 317	tasty lime green bean burrito	3	awesome	
 318	bland bean burrito	3	decent	
 319	bland insanely bean burrito	3	decent	
 320	spoiled blurry bat haggis	3	crappy	
-321	bland snack-sized menudo	2	decent	
+321	snack-sized bland menudo	2	decent	
 322	normal goat cheese	4	good	
 323	spoiled plain pizza	3	crappy	
 324	adequate snack-sized sausage pizza	2	good	
@@ -354,7 +354,7 @@
 356	jittery resourceful snowboarder pants	0		Maximum MP: +50, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	spoiled jittery purple gr8ps	3	crappy	
-359	huge delicious t8r tots	6	awesome	
+359	delicious huge t8r tots	6	awesome	
 360	quilted miner's helmet	0		Damage Absorption: +40, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	lime green resourceful miner's pants	0		Maximum MP: +50, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	huge electrified 7-Foot Dwarven mattock	0		MP Regen Min: 3, MP Regen Max: 5
@@ -372,7 +372,7 @@
 374	chrome crossbow string	0		
 375	purple linoleum meat stack	0		
 376	squat asbestos meat stack	0		
-377	mirror cyan chrome meat stack	0		
+377	cyan mirror chrome meat stack	0		
 378	skewed banded linoleum sword of the brazier	0		Damage Absorption: +100, Hot Spell Damage: +25
 379	linoleum staff of the empath of the cheetah	0		Familiar Weight: +5, Initiative: +60
 380	Da Vinci's linoleum crossbow of doom	0		Experience (Mysticality): +5, Spooky Spell Damage: +50
@@ -406,14 +406,14 @@
 408	pirate skeleton	0		
 409	vial of patchouli oil	0		
 410	rosewater-soaked sk8board	0		Stench Resistance: +3
-411	narrow twirling Jolly Roger charrrm	0		
+411	twirling narrow Jolly Roger charrrm	0		
 412	barrrnacle	0		
 413	jittery smooth Jolly Roger charrrm bracelet	0		Moxie: +15
 414	up-at-dawn crowbarrr	0		Adventures: +5
 415	manspreader's leotarrrd	0		Monster Level: +10, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	Sherlock's safarrri hat	0		Item Drop: +25, Familiar Effect: "2xVolley, cap 22"
 417	tarnished henna tattoo	0		Effect: "Cookie Backup", Effect Duration: 42
-418	polarized spinning yellow spinning Ferrigno's Elixir of Power	0		Effect: "Crotchety, Pining", Effect Duration: 55
+418	polarized yellow spinning spinning Ferrigno's Elixir of Power	0		Effect: "Crotchety, Pining", Effect Duration: 55
 419	boiled yellow serum of sarcasm	0		Effect: "Slimily Speedy", Effect Duration: 14
 420	alkaline chilled spinning tomato juice of powerful power	0		Effect: "Polka Face", Effect Duration: 42
 421	dry energized philter of phorce	0		Effect: "A Contender", Effect Duration: 21
@@ -462,7 +462,7 @@
 464	pixel potion	0		
 465	squat pixel potion	0		
 466	pixel potion	0		
-467	massive normal pixel pie	6	good	
+467	normal massive pixel pie	6	good	
 468	upside-down ruby W	0		
 469	mirror wussiness potion	0		
 470	lousy narrow Imp Ale	3	decent	
@@ -501,10 +501,10 @@
 503	flavorless skewered cat appendix	4	decent	
 504	evil arches	0		
 505	pulsating Van der Graaf gnatwing earring of the storm	0		Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7
-506	special flavorless Hell broth	4	decent	Effect: "Smugness", Effect Duration: 25
+506	flavorless special Hell broth	4	decent	Effect: "Smugness", Effect Duration: 25
 507	smooth thunderrr guitarrr	0		Moxie: +15
 508	ghostly sonata	0		
-509	narrow skewed Hey Deze nuts	0		
+509	skewed narrow Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	blinking Sneaky Pete's key lime	0		
@@ -555,7 +555,7 @@
 557	hand-crafted whiskey and cola	3	EPIC	
 558	spoiled papaya taco	4	crappy	
 559	razor-sharp can lid	0		
-560	fancy rotten half-sized narrow stalk of asparagus	2	crappy	Effect: "Hustlin'", Effect Duration: 10
+560	half-sized rotten fancy narrow stalk of asparagus	2	crappy	Effect: "Hustlin'", Effect Duration: 10
 561	wobbly pregnant mushroom	0		
 562	ghostly ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -564,23 +564,23 @@
 566	smelly bum cheek	0		Stench Spell Damage: +10, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
 568	normal gigantic Double Bacon Beelzeburger	9	good	
-569	miniature toothsome Lord of the Flies-sized fries	2	awesome	
+569	toothsome miniature Lord of the Flies-sized fries	2	awesome	
 570	spoiled Chicken Sandwich	3	crappy	
 571	Jumbo Dr. Lucifer	1	EPIC	
-572	jumbo flavorless Children's Meal of the Damned	5	decent	
-573	spoiled big noodles	5	crappy	
-574	rotten massive enchanted noodles	10	crappy	Effect: "Joy", Effect Duration: 45
-575	bland miniature upside-down painful penne pasta	2	decent	
+572	flavorless jumbo Children's Meal of the Damned	5	decent	
+573	big spoiled noodles	5	crappy	
+574	enchanted rotten massive noodles	10	crappy	Effect: "Joy", Effect Duration: 45
+575	miniature bland upside-down painful penne pasta	2	decent	
 576	flavorless spinning ravioli della hippy	4	decent	
 577	stale pr0n m4nic0tti	4	decent	
 578	spoiled Hell ramen	4	crappy	
 579	flavorless boring spaghetti	3	decent	
-580	red huge sauce of the ages	0		
+580	huge red sauce of the ages	0		
 581	cyan schmancy cheese sauce	0		
-582	shaking huge Himalayan Hidalgo sauce	0		
-583	stale diet upside-down pulsating fettucini Inconnu	1	decent	
+582	huge shaking Himalayan Hidalgo sauce	0		
+583	stale diet pulsating upside-down fettucini Inconnu	1	decent	
 584	tasty spaghetti with Skullheads	4	awesome	
-585	moldy low-calorie gnocchetti di Nietzsche	1	crappy	
+585	low-calorie moldy gnocchetti di Nietzsche	1	crappy	
 586	ridiculously huge sword of extreme caution of the glutton	0		Monster Level: -25, Food Drop: +100
 587	magnetized super-spiky hair gel	0		Effect: "Electrolit Up", Effect Duration: 33
 588	soft echo eyedrop antidote	0		
@@ -612,7 +612,7 @@
 614	energized magnetized probability potion	0		Effect: "Hella Tough", Effect Duration: 11
 615	chaos butterfly	0		
 616	furry fur	0		
-617	non-diffused skewed shaking teal Angry Farmer candy	0		Effect: "Cold Throat", Effect Duration: 34
+617	non-diffused skewed teal shaking Angry Farmer candy	0		Effect: "Cold Throat", Effect Duration: 34
 618	liquefied altered Mick's IcyVapoHotness Rub	0		Effect: "Slimily Sagacious", Effect Duration: 65
 619	crafty needle	0		Maximum MP: +10
 620	alkaline improved thin candle	0		Effect: "Patent Prevention", Effect Duration: 68
@@ -644,8 +644,8 @@
 646	special stale yellow fruitcake	4	decent	Effect: "Good with the Ladies", Effect Duration: 5
 647	present	0		Last Available: "2004-11"
 648	rosewater-soaked Crimbo sword	0		Stench Resistance: +3, Last Available: "2004-10"
-649	Crimbo hat of the businessman	0		Meat Drop: +50, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	experienced Crimbo pants	0		Experience: +2, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	Crimbo hat of the businessman	0		Meat Drop: +50, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	experienced Crimbo pants	0		Experience: +2, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	exclusive ultra-rare item of the early riser	0		Adventures: +7
 652	quantum egg	0		
 653	purple intragalactic rowboat	0		
@@ -673,11 +673,11 @@
 675	zippy skull of the Bonerdagon	0		Initiative: +20
 676	dragonbone belt buckle	0		
 677	badass belt of terror	0		Spooky Spell Damage: +10
-678	shaking red chest of the Bonerdagon	0		
-679	bad watered-down roll in the hay	2	decent	
-680	watered-down perfectly mixed slap and tickle	2	EPIC	
+678	red shaking chest of the Bonerdagon	0		
+679	watered-down bad roll in the hay	2	decent	
+680	perfectly mixed watered-down slap and tickle	2	EPIC	
 681	delicious slip 'n' slide	4	awesome	
-682	weak artisanal shaking a sump'm sump'm	2	EPIC	
+682	artisanal weak shaking a sump'm sump'm	2	EPIC	
 683	lousy practically non-alcoholic horizontal tango	1	decent	
 684	acceptable weak pink pony	2	good	
 685	arcane researcher's beefy Mr. Shirt of vim and vigor	0		Muscle: +10, Experience Percent (Mysticality): +10, Maximum HP Percent: +50
@@ -716,7 +716,7 @@
 720	Annie Oakley's rosy-cheeked porquoise necklace	0		Maximum HP Percent: +30, Critical Hit Percent: +20, Single Equip
 721	huge wicked boxer's porquoise bracelet	0		Muscle Percent: +10, Spell Damage: +5
 722	squat prompt frightening porquoise ring of the dark arts	0		Spell Damage Percent: +100, Spooky Damage: +5, Adventures: +3, Single Equip
-723	gigantic adequate Knoll mushroom	7	good	
+723	adequate gigantic Knoll mushroom	7	good	
 724	half-sized toothsome mushroom	2	awesome	
 725	lime green one million meat pancakes	0		
 726	mansplainer's huge mirror shard	0		Monster Level: +15
@@ -737,24 +737,24 @@
 741	broken skull	0		
 742	rotten Knoll shroomkabob	3	crappy	
 743	super-sized delicious olive mushroom	5	awesome	
-744	concentrated modified pulsating tumbling hair spray	0		Effect: "Haunted Stomach", Effect Duration: 48
+744	concentrated modified tumbling pulsating hair spray	0		Effect: "Haunted Stomach", Effect Duration: 48
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	moldy diet warm mushroom	1	crappy	
+749	diet moldy warm mushroom	1	crappy	
 750	half-sized moldy mushroom quesadilla	2	crappy	
 751	adequate cool mushroom	3	good	
 752	spoiled cool mushroom casserole	3	crappy	
 753	moldy immense blue blinking pointy mushroom	9	crappy	
-754	flavorless small cream of pointy mushroom soup	2	decent	
+754	small flavorless cream of pointy mushroom soup	2	decent	
 755	spoiled mushroom	3	crappy	
 756	moldy mushroom	3	crappy	
 757	bland mushroom	3	decent	
-758	yummy immense tumbling olive huge ghost cucumber	9	awesome	
+758	yummy immense olive huge tumbling ghost cucumber	9	awesome	
 759	dill	0		
 760	red vinegar	0		
 761	brine	0		
-762	practically non-alcoholic artisanal jittery upside-down especially salty dog	1	super ultra mega turbo EPIC	
+762	artisanal practically non-alcoholic upside-down jittery especially salty dog	1	super ultra mega turbo EPIC	
 763	narrow shaking ghostly pickling solution	0		
 764	normal spectral pickle	3	good	
 765	briny vinegar	0		
@@ -776,23 +776,23 @@
 781	ionized concentrated spinning mafia aria	0		Effect: "Crotchety, Pining", Effect Duration: 19
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	drinkable boozy Acqua Del Piatto Merlot	5	good	Last Available: "2004-10"
+784	boozy drinkable Acqua Del Piatto Merlot	5	good	Last Available: "2004-10"
 785	raffle ticket	0		
 786	jumbo rotten strawberry	5	crappy	
 787	hand-crafted green bottle of rum	4	EPIC	
 788	delicious spinning skewed strawberry daiquiri	3	awesome	
-789	hand-crafted spirit-forward rum and cola	5	EPIC	
+789	spirit-forward hand-crafted rum and cola	5	EPIC	
 790	acceptable grog	3	good	
 791	skewed hardy groovy Mafia bow tie	0		Moxie Percent: +10, Maximum HP: +50, Last Available: "2004-10"
 792	Temple Grandin's Golden Mr. Accessory	0		Familiar Weight: +7, Softcore Only
 793	diffused flattened oil of stability	0		Effect: "Hobo Flavor", Effect Duration: 47
 794	triple-ionized oil of slipperiness	0		Effect: "Locks Like the Raven", Effect Duration: 69
-795	delicious practically non-alcoholic Acque Luride Grezze Cabernet	1	awesome	Last Available: "2004-10"
+795	practically non-alcoholic delicious Acque Luride Grezze Cabernet	1	awesome	Last Available: "2004-10"
 796	olive veiny Socratic cement shoes of Calamity Jane	0		Experience (Mysticality): +1, Maximum HP: +10, Critical Hit Percent: +15, Last Available: "2004-10"
-797	irresponsibly strong hand-crafted rockin' wagon	9	EPIC	
+797	hand-crafted irresponsibly strong rockin' wagon	9	EPIC	
 798	extra-dry bad ocean motion	5	decent	
 799	irresponsibly strong smooth teal fuzzbump	6	awesome	
-800	fancy decent thick poutine	5	good	Effect: "Square to be Hip", Effect Duration: 40
+800	decent fancy thick poutine	5	good	Effect: "Square to be Hip", Effect Duration: 40
 801	stale Knob stir-fry	3	decent	
 804	spoiled pulsating Knoll stir-fry	3	crappy	
 805	rotten stir-fry	4	crappy	
@@ -801,11 +801,11 @@
 808	toothsome shaking Knob sausage stir-fry	4	awesome	
 809	stale ghostly bat wing stir-fry	4	decent	
 810	decent half-sized rat appendix stir-fry	2	good	
-811	special rotten jittery tofu stir-fry	3	crappy	Effect: "Jerky, Boy", Effect Duration: 30
-812	normal huge pr0n stir-fry	9	good	
+811	rotten special jittery tofu stir-fry	3	crappy	Effect: "Jerky, Boy", Effect Duration: 30
+812	huge normal pr0n stir-fry	9	good	
 813	normal Knob shells	4	good	
 814	gigantic rotten narrow b&auml;tzle	10	crappy	
-815	stale gigantic twirling blurry ratini	10	decent	
+815	stale gigantic blurry twirling ratini	10	decent	
 816	normal purple Knob stroganoff	3	good	
 817	rotten menudo ravioli	3	crappy	
 818	plus sign	0		
@@ -831,8 +831,8 @@
 838	arcane researcher's Samson's Mafia stogie	0		Experience (Muscle): +5, Experience Percent (Mysticality): +10, Last Available: "2004-10"
 839	acceptable Maiali Sifilitici Pinot Noir	3	good	Last Available: "2004-10"
 840	avaricious rosewater-soaked Mafia violin case	0		Stench Resistance: +3, Meat Drop: +30, Last Available: "2004-10"
-841	drinkable triple-distilled jittery tomato daiquiri	8	good	
-842	watered-down acceptable blinking maroon beertini	2	good	
+841	triple-distilled drinkable jittery tomato daiquiri	8	good	
+842	acceptable watered-down blinking maroon beertini	2	good	
 843	drinkable blue salty slug	3	good	
 844	smooth papaya slung	4	awesome	
 845	Tesla MAHI fez	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -857,7 +857,7 @@
 865	lead necklace	0		Familiar Weight: +3
 866	green shaving cream	0		
 867	improved chilled squat pine tar	0		Effect: "Ancient Protected", Effect Duration: 24
-869	pulsating twirling forest tears	0		
+869	twirling pulsating forest tears	0		
 870	fetus-smashing club of the ox	0		Muscle: +20
 871	bouncing pulsating meatcar model	0		Familiar Weight: +5
 872	cyan Time Juice	0		Last Available: "2004-01"
@@ -874,7 +874,7 @@
 883	maple syrup	1	good	
 884	narrow nasty los chinos	0		Stench Damage: +5, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	wobbly gravedigger's axe	0		Spooky Damage: +10
-886	twirling tumbling leaflet	0		
+886	tumbling twirling leaflet	0		
 887	leaf	0		
 888	tumbling maple leaf	0		
 889	balaclava of the bloodbag	0		Maximum HP: +100, Familiar Effect: "cold atk, 1.5xLep, cap 12"
@@ -892,8 +892,8 @@
 901	olive espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	tolerable high-proof squat upside-down Spasmi Dolorosi Del Rene Champagne	10	good	Last Available: "2004-10"
-904	wobbly wicked Da Vinci's school Mafia knickerbockers of temperance	0		Experience (Mysticality): +5, Spell Damage: +5, Sleaze Resistance: +5, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
-905	pickled ionized cyan upside-down skewed Yummy Tummy bean	0		Effect: "High Blood Chocolate Content", Effect Duration: 47
+904	wobbly wicked Da Vinci's school Mafia knickerbockers of temperance	0		Experience (Mysticality): +5, Spell Damage: +5, Sleaze Resistance: +5, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+905	pickled ionized skewed cyan upside-down Yummy Tummy bean	0		Effect: "High Blood Chocolate Content", Effect Duration: 47
 906	altered Rock Pops	0		Effect: "Pisces in the Skyces", Effect Duration: 54
 907	energized green Mr. Mediocrebar	0		Effect: "Elvish", Effect Duration: 26
 908	dry Cold Hots candy	0		Effect: "Sticks and Stones", Effect Duration: 13
@@ -906,12 +906,12 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	crafty extremely unsafe intergalactic pom poms	0		Weapon Damage Percent: +100, Maximum MP: +10
 917	Mob Penguin protection contract	0		
-918	blinking personal trainer's Radio Free Baseball Cap	0		Experience Percent (Muscle): +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	extremely unsafe Radio Free Pants	0		Weapon Damage Percent: +100, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	blinking personal trainer's Radio Free Baseball Cap	0		Experience Percent (Muscle): +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	extremely unsafe Radio Free Pants	0		Weapon Damage Percent: +100, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	supercool Radio Free Foil	0		Moxie Percent: +20, Last Available: "2006-07"
 921	super-sized stale mirror radio button candy	5	decent	
 922	severed rocking horse head of the dark arts	0		Spell Damage Percent: +100
-923	huge squat broken cellular phone	0		Last Available: "2004-01"
+923	squat huge broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	magnetized enhanced blurry Hawking's Elixir of Brilliance	0		Effect: "Stregngth of the Gnome", Effect Duration: 15
@@ -919,21 +919,21 @@
 928	stiffened fuzzy bracelets	0		Damage Reduction: 1
 929	squat miser's arse-shooting crossbow	0		Meat Drop: +10
 931	special artisanal spiced rum	3	EPIC	Effect: "Broken Fast", Effect Duration: 45
-932	watered-down lousy spinning eggnog	2	decent	
+932	lousy watered-down spinning eggnog	2	decent	
 933	rotten candy cane	3	crappy	
 934	moldy gingerbread bugbear	4	crappy	
 935	blinking banded imitation nice watch	0		Damage Absorption: +100, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
 938	jittery experienced plastic sword	0		Experience: +2, Last Available: "2004-12"
-939	red twirling small Crimbo Pressie	0		Last Available: "2004-12"
+939	twirling red small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	Jim Carey's bowler	0		Monster Level: +25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	Jim Carey's bowler	0		Monster Level: +25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	Temple Grandin's bow staff of the pedagogue	0		Experience: +3, Familiar Weight: +7, Last Available: "2004-12"
-944	wicked bowlegged pants	0		Spell Damage: +5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	wicked bowlegged pants	0		Spell Damage: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
-946	squat bouncing skewered lime	0		Last Available: "2004-12"
+946	bouncing squat skewered lime	0		Last Available: "2004-12"
 947	upside-down skewered cherry	0		Last Available: "2004-12"
 948	watered-down perfectly mixed martini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 949	hand-crafted boozy grogtini	5	EPIC	Last Available: "2004-12"
@@ -943,7 +943,7 @@
 953	bouncing penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	rosewater-soaked fez of etymology	0		Stench Resistance: +3, Familiar Effect: "1xLep, cap 30"
-956	yummy tiny carob chunk noodles	1	awesome	
+956	tiny yummy carob chunk noodles	1	awesome	
 957	diet flavorless chorizo brownies	1	decent	
 958	bland chocolate and tomato pizza	3	decent	
 959	spinning flange	0		
@@ -989,27 +989,27 @@
 1002	Xlyinia's notebook of doom	0		Spooky Spell Damage: +50
 1003	shaking soda water	0		
 1004	lousy bottle of tequila	4	decent	
-1005	perfectly mixed weak narrow boxed wine	2	EPIC	
+1005	weak perfectly mixed narrow boxed wine	2	EPIC	
 1006	decent immense cherry	7	good	
 1007	pulsating Herculean coconut shell	0		Experience (Muscle): +1, Familiar Effect: "1xFairy, cap 7"
 1008	supercharged ice cubes	0		Maximum MP Percent: +30
 1009	aged vodka martini	3	awesome	
 1010	boozy mediocre whiskey and soda	5	decent	
-1011	artisanal watered-down monkey wrench	2	EPIC	
+1011	watered-down artisanal monkey wrench	2	EPIC	
 1012	delicious watered-down special skewed tequila sunrise	2	awesome	Effect: "Fit To Be Tide", Effect Duration: 15
-1013	distilled hand-crafted narrow margarita	5	EPIC	
-1014	bad fancy strawberry wine	3	decent	Effect: "Shredding, Sweating", Effect Duration: 10
+1013	hand-crafted distilled narrow margarita	5	EPIC	
+1014	fancy bad strawberry wine	3	decent	Effect: "Shredding, Sweating", Effect Duration: 10
 1015	acceptable fuchsia wine spritzer	3	good	
 1016	tolerable blurry bouncing perpendicular hula	4	good	
-1017	tolerable practically non-alcoholic ducha de oro	1	good	
+1017	practically non-alcoholic tolerable ducha de oro	1	good	
 1018	acceptable calle de miel	3	good	
-1019	perfectly mixed enchanted weak teal wobbly dry vodka martini	2	EPIC	Effect: "Coated Arms", Effect Duration: 45
+1019	enchanted weak perfectly mixed wobbly teal dry vodka martini	2	EPIC	Effect: "Coated Arms", Effect Duration: 45
 1020	bad old-fashioned	4	decent	
-1021	distilled perfectly mixed tequila with training wheels	5	EPIC	
+1021	perfectly mixed distilled tequila with training wheels	5	EPIC	
 1022	mediocre pulsating sangria	3	decent	
 1023	drinkable bouncing vesper	4	good	Last Available: "2004-12"
-1024	mediocre weak bodyslam	2	decent	Last Available: "2004-12"
-1025	lousy practically non-alcoholic sangria del diablo	1	decent	Last Available: "2004-12"
+1024	weak mediocre bodyslam	2	decent	Last Available: "2004-12"
+1025	practically non-alcoholic lousy sangria del diablo	1	decent	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1029,8 +1029,8 @@
 1043	twirling flame-retardant string of beads	0		Hot Resistance: +1
 1044	purple Rosewater's string of beads	0		Mysticality Percent: +30
 1045	fireproof plastic bottle opener	0		Hot Resistance: +3
-1046	upside-down perfumed smartaleck's traffic cone	0		Moxie Percent: +30, Stench Resistance: +5, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	hand-crafted boozy N. O. Beer	5	EPIC	
+1046	upside-down perfumed smartaleck's traffic cone	0		Moxie Percent: +30, Stench Resistance: +5, Last Available: "2005-03", Familiar Effect: "cap 15"
+1047	boozy hand-crafted N. O. Beer	5	EPIC	
 1048	boiled wobbly cyan oyster egg	1		
 1049	boiled oyster egg	1		
 1050	twisted oyster egg	1		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 15
@@ -1040,16 +1040,16 @@
 1054	powdered ghostly bouncing oyster egg	1		Effect: "Squatting and Thrusting", Effect Duration: 25
 1055	huge plastic oyster egg	0		
 1056	pickled puce oyster egg	1		
-1057	boiled narrow spinning ghostly puce oyster egg	1		
-1058	powdered spinning huge puce oyster egg	1		
+1057	boiled narrow ghostly spinning puce oyster egg	1		
+1058	powdered huge spinning puce oyster egg	1		
 1059	yellow puce plastic oyster egg	0		
 1060	dried squat mauve oyster egg	1		Effect: "Mortarfied", Effect Duration: 25
 1061	vaporized mauve oyster egg	1		
 1062	mixed shaking mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
-1064	denatured jittery narrow cyan oyster egg	1		Effect: "Faboooo", Effect Duration: 10
+1064	denatured cyan jittery narrow oyster egg	1		Effect: "Faboooo", Effect Duration: 10
 1065	modified upside-down oyster egg	1		Effect: "Blessing of the Pervy Noodles", Effect Duration: 5
-1066	diluted tumbling blurry jittery oyster egg	1		
+1066	diluted jittery blurry tumbling oyster egg	1		
 1067	plastic oyster egg	0		
 1068	diluted oyster egg	1		Effect: "Human-Machine Hybrid", Effect Duration: 15
 1069	altered blurry oyster egg	1		
@@ -1063,7 +1063,7 @@
 1077	powdered oyster egg	1		
 1078	altered ghostly narrow oyster egg	1		Effect: "Super Accuracy", Effect Duration: 25
 1079	jittery plastic oyster egg	0		
-1080	green blurry oyster basket	0		
+1080	blurry green oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
@@ -1104,7 +1104,7 @@
 1118	shaking huge pregnant mushroom	0		
 1119	twirling pregnant mushroom	0		
 1120	pregnant mushroom	0		
-1121	maroon spinning inexplicably rock	0		
+1121	spinning maroon inexplicably rock	0		
 1122	fairy gravy	0		
 1123	blue lightning-fast halfberd	0		Initiative: +40
 1124	narrow yellow small glove	0		
@@ -1123,15 +1123,15 @@
 1137	dog trainer's bicycle chain of Flo-Jo	0		Experience (familiar): +1, Initiative: +100
 1138	mushroom fermenting solution	0		
 1139	delicious mushroom wine	3	awesome	
-1140	weak hand-crafted icy mushroom wine	2	EPIC	
+1140	hand-crafted weak icy mushroom wine	2	EPIC	
 1141	acceptable mushroom wine	3	good	
 1142	tolerable pointy mushroom wine	4	good	
 1143	acceptable twirling flat mushroom wine	3	good	
-1144	weak hand-crafted cool mushroom wine	2	EPIC	
-1145	drinkable spirit-forward knob mushroom wine	5	good	
+1144	hand-crafted weak cool mushroom wine	2	EPIC	
+1145	spirit-forward drinkable knob mushroom wine	5	good	
 1146	smooth knoll mushroom wine	3	awesome	
-1147	lousy watered-down mushroom wine	2	decent	
-1148	distilled lousy shot of flower schnapps	5	decent	
+1147	watered-down lousy mushroom wine	2	decent	
+1148	lousy distilled shot of flower schnapps	5	decent	
 1149	moldy flower petal pie	3	crappy	
 1150	hand-crafted bottle of single-barrel whiskey	4	EPIC	
 1151	Van der Graaf wizardly discarded plastic fork	0		Mysticality: +25, MP Regen Min: 5, MP Regen Max: 7
@@ -1173,7 +1173,7 @@
 1188	skewed maroon lotus	0		
 1189	can of asparagus	0		
 1190	dodecapede	0		
-1191	upside-down cyan ghuol whelp	0		
+1191	cyan upside-down ghuol whelp	0		
 1192	pulsating zmobie	0		
 1193	teal Raggedy Hippy doll	0		
 1194	stab bat	0		
@@ -1184,13 +1184,13 @@
 1199	bugbear	0		
 1200	rotten mugcake	3	crappy	
 1201	decent tumbling urinal cake	4	good	
-1202	stale jumbo fuchsia Happy Birthday, Claude! cake	5	decent	
+1202	jumbo stale fuchsia Happy Birthday, Claude! cake	5	decent	
 1203	snack-sized normal personalized birthday cake	2	good	
-1204	half-sized decent three-tiered wedding cake	2	good	
+1204	decent half-sized three-tiered wedding cake	2	good	
 1205	spoiled blinking babycakes	4	crappy	
 1206	rotten shaking velvet cake	3	crappy	
-1207	spoiled snack-sized congratulatory cake	2	crappy	
-1208	moldy small bouncing angel-food cake	2	crappy	
+1207	snack-sized spoiled congratulatory cake	2	crappy	
+1208	small moldy bouncing angel-food cake	2	crappy	
 1209	flavorless devil's-food cake	4	decent	
 1210	normal birthday party jellybean cheesecake	3	good	
 1211	balloon	0		
@@ -1232,22 +1232,22 @@
 1248	foul-smelling wholesome Bonerdagon necklace of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Stench Damage: +10
 1249	twirling wool Boss Bat britches	0		Cold Resistance: +1, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	slick Boss Bat bling of Leguizamo	0		Moxie: +10, Monster Level: +20
-1251	jumbo normal Knob shroomkabob	5	good	
+1251	normal jumbo Knob shroomkabob	5	good	
 1252	yummy shroomkabob	4	awesome	
 1253	blurry pile of jumping beans	0		
-1254	thick decent jumping bean burrito	5	good	
+1254	decent thick jumping bean burrito	5	good	
 1255	big moldy enchanted tumbling jumping bean burrito	5	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25
 1256	decent red insanely jumping bean burrito	3	good	
 1257	bland rat scrapple	4	decent	
 1258	lime green pail of pretentious paint	0		
-1259	traffic cone of the detective of the glutton	0		Item Drop: +20, Food Drop: +100, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	traffic cone of the detective of the glutton	0		Item Drop: +20, Food Drop: +100, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	purple wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	vaporized Hatorade	1		
 1262	knitted crafty wicked off-hand balloon	0		Spell Damage: +5, Maximum MP: +10, Cold Resistance: +3
 1263	wobbly pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	pulsating yellow nose-bone fetish	0		Last Available: "2011-12"
 1265	pulsating box of sunshine	0		Free Pull
-1266	tiny decent shaking gloomy mushroom	1	good	
+1266	decent tiny shaking gloomy mushroom	1	good	
 1267	dead mimic	0		
 1268	blinking pine wand	0		
 1269	ebony wand	0		
@@ -1255,7 +1255,7 @@
 1271	blurry aluminum wand	0		
 1272	mirror marble wand	0		
 1273	wholesome magic lamp	0		Maximum HP Percent: +10
-1274	diluted cyan squat Medicinal Herb's medicinal herbs	1		
+1274	diluted squat cyan Medicinal Herb's medicinal herbs	1		
 1275	wobbly aromatic basic meat skirt	0		Stench Resistance: +1, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	lousy Otorian Battle Scar	3	decent	
 1277	Oprah's basic meat kilt	0		Maximum MP Percent: +50, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1283,11 +1283,11 @@
 1299	scandalous pirate hook	0		Sleaze Damage: +5
 1300	Usain Bolt's monster bait	0		Initiative: +80, Single Equip
 1301	tarnished mirror deodorant	0		Effect: "Heightened Senses", Effect Duration: 66
-1302	ionized ghostly twirling reodorant	0		Effect: "Frozen Shoulders", Effect Duration: 26
+1302	ionized twirling ghostly reodorant	0		Effect: "Frozen Shoulders", Effect Duration: 26
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	blinking wool traffic cone of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +1, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	blinking wool traffic cone of Tarzan	0		Experience (Muscle): +3, Cold Resistance: +1, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	spoiled questionable taco	3	crappy	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	green petrified time	0		Last Available: "2005-10"
-1323	therapeutic time helmet	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	grievous time trousers	0		Weapon Damage Percent: +50, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	therapeutic time helmet	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	grievous time trousers	0		Weapon Damage Percent: +50, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	time sword of horror	0		Spooky Spell Damage: +25, Last Available: "2005-10"
 1326	vibrating Dyspepsi-Cola helmet	0		Maximum MP Percent: +10, Familiar Effect: "3xFairy, cap 7"
 1327	wholesome Cloaca-Cola shield	0		Maximum HP Percent: +10, Damage Reduction: 4
@@ -1314,8 +1314,8 @@
 1330	banded Dyspepsi-Cola fatigues	0		Damage Absorption: +100, Familiar Effect: "3.5xPotato, 3xVolley, cap 7"
 1331	red double-paned Cloaca-Cola helmet	0		Cold Resistance: +5, Familiar Effect: "3xFairy, cap 7"
 1332	Cloaca-Cola knapsack	0		
-1333	tumbling olive narrow Dyspepsi-Cola knapsack	0		
-1334	wobbly narrow jittery Cloaca-Cola	0		
+1333	narrow olive tumbling Dyspepsi-Cola knapsack	0		
+1334	narrow jittery wobbly Cloaca-Cola	0		
 1335	fuchsia Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
 1338	narrow Dyspepsi-Cola d-rations	0		
@@ -1324,7 +1324,7 @@
 1341	hardened Dyspepsi-Cola-issue canteen	0		Damage Reduction: 3, Single Equip
 1342	picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
-1344	energized wobbly tumbling Gummi-Gnauga	0		Effect: "Proprie Tea", Effect Duration: 34
+1344	energized tumbling wobbly Gummi-Gnauga	0		Effect: "Proprie Tea", Effect Duration: 34
 1345	aerosolized spinning blurry Now and Earlier	0		Effect: "Bricked-In", Effect Duration: 33, Last Available: "2020-09"
 1346	boiled improved fuchsia Sugar Cog	0		Effect: "Drenched With Filth", Effect Duration: 58
 1347	shaking loaded serum blowgun	0		Last Available: "2005-11"
@@ -1332,7 +1332,7 @@
 1349	ghostly miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	mirror 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	squat flame-wreathed pinky ring	0		Hot Spell Damage: +10, Single Equip
-1352	fortified lousy redrum	5	decent	
+1352	lousy fortified redrum	5	decent	
 1353	lime green blinking ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	adequate diet bowl of oriole's nest soup	1	good	
@@ -1384,7 +1384,7 @@
 1402	teal aromatic rag doll	0		Stench Resistance: +1, Last Available: "2005-12"
 1403	steel-toed can of fake snow	0		Damage Reduction: 9, Last Available: "2005-12"
 1404	smooth colored-light &quot;necklace&quot;	0		Moxie: +15, Last Available: "2005-12"
-1405	teal savvy tree skirt	0		Mysticality Percent: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	teal savvy tree skirt	0		Mysticality Percent: +20, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	jumbo stale wreath-shaped Crimbo cookie	5	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	adequate thick olive bell-shaped Crimbo cookie	5	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	bland gigantic tree-shaped Crimbo cookie	6	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
@@ -1399,13 +1399,13 @@
 1417	deionized snowcone	0		Effect: "High Blood Chocolate Content", Effect Duration: 37, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	mirror teal smelly traffic cone of doom	0		Stench Spell Damage: +10, Spooky Spell Damage: +50, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	mirror teal smelly traffic cone of doom	0		Stench Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	gray iceberglet	0		Last Available: "2006-02"
 1424	wholesome ice sickle of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Softcore Only, Last Available: "2006-02"
 1425	olive avaricious ice baby	0		Meat Drop: +30, Softcore Only, Last Available: "2006-02"
-1426	Van der Graaf ice pick	0		MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	Van der Graaf ice pick	0		MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	ice skates of the pedagogue of Calamity Jane	0		Experience: +3, Critical Hit Percent: +15, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	half-sized adequate grue egg omelette	2	good	
 1429	roll of drink tickets	0		
@@ -1429,7 +1429,7 @@
 1447	enhanced extra-activated upside-down nuggets	0		Effect: "Radiated and Grodiated", Effect Duration: 47
 1448	flattened stench nuggets	0		Effect: "Feline Ferocity", Effect Duration: 20
 1449	ionized yellow sleaze nuggets	0		Effect: "Fit To Be Tide", Effect Duration: 25
-1450	compressed twirling lime green shaking narrow twinkly wad	1		
+1450	compressed shaking narrow twirling lime green twinkly wad	1		
 1451	boiled yellow hot wad	1		
 1452	vaporized upside-down wad	1		Effect: "Eagle Eyes", Effect Duration: 50
 1453	powdered wad	1		
@@ -1439,7 +1439,7 @@
 1457	Goth Giant	0		
 1458	decent tumbling Valentine's Day cake	3	good	
 1459	arrow'd heart balloon	0		
-1460	blinking mirror velvet box	0		
+1460	mirror blinking velvet box	0		
 1461	squashed frog	0		
 1462	eye of newt	0		
 1463	salamander spleen	0		
@@ -1465,7 +1465,7 @@
 1483	upside-down troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	tumbling horrifying Lo Pan's rabbit's foot	0		Spell Critical Percent: +30, Spooky Damage: +25
-1486	blinking tumbling massive bag of catnip	0		
+1486	tumbling blinking massive bag of catnip	0		
 1487	narrow hang glider	0		
 1488	shaking March hat	0		Free Pull
 1489	yellow dormouse	0		
@@ -1474,7 +1474,7 @@
 1492	ninja mop of extreme caution	0		Monster Level: -25
 1493	nasty healthy ridiculously overelaborate ninja weapon	0		Maximum HP Percent: +20, Stench Damage: +5
 1494	anodized sugar-coated pine cone	0		Effect: "Witch Breaded", Effect Duration: 14, Last Available: "2020-09"
-1495	therapeutic sage traffic cone	0		Mysticality Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	therapeutic sage traffic cone	0		Mysticality Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	mediocre twirling gloomy mushroom wine	4	decent	
 1497	hand-crafted mushroom wine	3	EPIC	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
@@ -1503,23 +1503,23 @@
 1522	crafty Radio Free Jersey of the bloodbag	0		Maximum HP: +100, Maximum MP: +10
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	resourceful quilted corkscrew	0		Damage Absorption: +40, Maximum MP: +50, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	cyan fake plastic grass	0		Last Available: "2011-01"
-1531	energetic grass skirt	0		Maximum MP Percent: +20, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	huge Jack Frost's grass hat	0		Cold Spell Damage: +50, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	energetic grass skirt	0		Maximum MP Percent: +20, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	huge Jack Frost's grass hat	0		Cold Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	sage grass blade	0		Mysticality Percent: +10, Last Available: "2011-01"
 1534	upside-down raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	cyan squat Annie Oakley's sparkly engagement ring	0		Critical Hit Percent: +20, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	censurious Grimacite goggles of the detective	0		Sleaze Resistance: +3, Item Drop: +20, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	censurious Grimacite goggles of the detective	0		Sleaze Resistance: +3, Item Drop: +20, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	fireproof wholesome Grimacite glaive	0		Maximum HP Percent: +10, Hot Resistance: +3, Last Available: "2008-10"
-1542	fortified Grimacite greaves of the overflowing toilet	0		Damage Absorption: +60, Stench Spell Damage: +50, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	fortified Grimacite greaves of the overflowing toilet	0		Damage Absorption: +60, Stench Spell Damage: +50, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	tumbling clever therapeutic Grimacite garter	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2008-10"
 1544	red upside-down narrow flame-wreathed Grimacite galoshes of the overflowing toilet	0		Hot Spell Damage: +10, Stench Spell Damage: +50, Last Available: "2008-10"
 1545	up-at-dawn smartaleck's Grimacite gorget	0		Moxie Percent: +30, Adventures: +5, Last Available: "2008-10"
@@ -1528,9 +1528,9 @@
 1548	mirror flame-wreathed Gazpacho's Glacial Grimoire of the ox	0		Muscle: +20, Hot Spell Damage: +10
 1549	MSG	0		
 1550	shaking Jack Frost's second-hand knockoff engagement ring	0		Cold Spell Damage: +50, Single Equip
-1551	practically non-alcoholic tolerable bouncing bottle of Domesticated Turkey	1	good	
-1552	distilled smooth bottle of Definit	5	awesome	
-1553	delicious watered-down spinning bottle of Calcutta Emerald	2	awesome	
+1551	tolerable practically non-alcoholic bouncing bottle of Domesticated Turkey	1	good	
+1552	smooth distilled bottle of Definit	5	awesome	
+1553	watered-down delicious spinning bottle of Calcutta Emerald	2	awesome	
 1554	lousy blurry bottle of Lieutenant Freeman	3	decent	
 1555	drinkable bottle of Jorge Sinsonte	4	good	
 1556	practically non-alcoholic artisanal boxed champagne	1	EPIC	
@@ -1539,7 +1539,7 @@
 1559	tonic water	0		
 1560	adequate small wobbly cocktail onion	2	good	
 1561	stale gigantic raspberry	7	decent	
-1562	small flavorless kiwi	2	decent	
+1562	flavorless small kiwi	2	decent	
 1563	tolerable whiskey bittersweet	4	good	
 1564	mediocre mimosette	4	decent	
 1565	aged green tequila sunset	4	awesome	
@@ -1551,13 +1551,13 @@
 1571	watered-down drinkable mirror yellow parisian cathouse	2	good	
 1572	weak lousy rabbit punch	2	decent	
 1573	bad caipifruta	4	decent	
-1574	hand-crafted distilled upside-down teqiwila	5	EPIC	
+1574	distilled hand-crafted upside-down teqiwila	5	EPIC	
 1575	delicious Divine	4	awesome	
 1576	hand-crafted Gordon Bennett	4	EPIC	
 1577	tolerable fancy tangarita	4	good	Effect: "Savage Beast Inside", Effect Duration: 20
-1578	artisanal spirit-forward tumbling mandarina colada	5	EPIC	
+1578	spirit-forward artisanal tumbling mandarina colada	5	EPIC	
 1579	perfectly mixed gimlet	3	EPIC	
-1580	special watered-down delicious jittery brick road	2	awesome	Effect: "Cool Spirit", Effect Duration: 45
+1580	delicious watered-down special jittery brick road	2	awesome	Effect: "Cool Spirit", Effect Duration: 45
 1581	smooth vodka stratocaster	4	awesome	
 1582	aged Neuromancer	3	awesome	
 1583	smooth pulsating lime green prussian cathouse	3	awesome	
@@ -1565,35 +1565,35 @@
 1585	hand-crafted Mon Tiki	4	EPIC	
 1586	acceptable narrow teqiwila slammer	4	good	
 1587	decent Knob lo mein	3	good	
-1588	rotten thick asparagus lo mein	5	crappy	
+1588	thick rotten asparagus lo mein	5	crappy	
 1589	moldy Knoll lo mein	3	crappy	
 1590	spoiled lo mein	3	crappy	
 1591	normal olive lo mein	3	good	
 1592	flavorless hot hi mein	3	decent	
-1593	normal thick hi mein	5	good	
+1593	thick normal hi mein	5	good	
 1594	normal hi mein	3	good	
-1595	immense normal hi mein	6	good	
+1595	normal immense hi mein	6	good	
 1596	rotten small shaking sleazy hi mein	2	crappy	
 1597	flame-wreathed Junior LAAAAME merit badge	0		Hot Spell Damage: +10, Last Available: "2006-05"
 1598	pulsating Senior LAAAAME merit badge of chilblains	0		Cold Damage: +25, Last Available: "2006-05"
 1599	squat jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	lousy practically non-alcoholic tangarita with a fly in it	1	decent	
+1600	practically non-alcoholic lousy tangarita with a fly in it	1	decent	
 1601	weak artisanal mandarina colada with a fly in it	2	EPIC	
 1602	practically non-alcoholic bad prussian cathouse with a fly in it	1	decent	
-1603	boozy hand-crafted Mae West with a fly in it	5	EPIC	
-1604	boiled ghostly blurry astronaut ice-cream	1		Last Available: "2006-05"
+1603	hand-crafted boozy Mae West with a fly in it	5	EPIC	
+1604	boiled blurry ghostly astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	distilled ultimate wad	1		Effect: "Chalked Weapon", Effect Duration: 10
 1607	wet boiled corrupted libation of liveliness	0		Effect: "Spooky Weapon", Effect Duration: 48
 1608	frozen eyedrops of the ermine	0		Effect: "Litterboxing", Effect Duration: 24
-1609	quantum huge skewed perfume of prejudice	0		Effect: "Fastbreaker", Effect Duration: 12
+1609	quantum skewed huge perfume of prejudice	0		Effect: "Fastbreaker", Effect Duration: 12
 1610	aerosolized cold-filtered jittery eyedrops of the ocelot	0		Effect: "Creepin' Up on You", Effect Duration: 32
 1611	polymerized potent potion of potency	0		Effect: "Boletus Swoletus", Effect Duration: 63
 1612	dry concentrated cordial of concentration	0		Effect: "Pretending to Pretend", Effect Duration: 67
 1613	coffin lid of the businessman	0		Meat Drop: +50, Damage Reduction: 3
 1614	teal satin shield of the storm	0		Maximum MP Percent: +40, Damage Reduction: 5
-1615	Cerebral Cloche of bravery	0		Spooky Resistance: +5, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	narrow censurious Cerebral Culottes	0		Sleaze Resistance: +3, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	Cerebral Cloche of bravery	0		Spooky Resistance: +5, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	narrow censurious Cerebral Culottes	0		Sleaze Resistance: +3, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	sharpshooter's arcane researcher's Cerebral Crossbow of mayonnaise	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +10, Sleaze Spell Damage: +50, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1620,7 +1620,7 @@
 1640	ionized ghostly lotion of stench	0		Effect: "Haunted Liver", Effect Duration: 29
 1641	ionized triple-Vulcanized narrow lotion of sleaziness	0		Effect: "Electrolit Up", Effect Duration: 57
 1642	lousy Grimacite Bock	3	decent	Last Available: "2008-11"
-1643	yummy miniature upside-down blinking wedge of gray cheese	2	awesome	Last Available: "2008-11"
+1643	miniature yummy upside-down blinking wedge of gray cheese	2	awesome	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
@@ -1630,10 +1630,10 @@
 1650	squat milk of magnesium	0		
 1651	rotten snack-sized foie gras	2	crappy	
 1652	liquefied wobbly candy brain	0		Effect: "Frog In Your Throat", Effect Duration: 59, Last Available: "2020-09"
-1653	sizzling dog trainer's wicked jewel-eyed wizard hat	0		Spell Damage: +5, Experience (familiar): +1, Hot Damage: +10, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	sizzling dog trainer's wicked jewel-eyed wizard hat	0		Spell Damage: +5, Experience (familiar): +1, Hot Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	healthy wad of Crovacite of temperance	0		Maximum HP Percent: +20, Sleaze Resistance: +5
 1655	collar of dire peril of the boozehound	0		Weapon Damage: +20, Booze Drop: +100
-1656	squat blurry White Citadel Satisfaction Satchel	0		
+1656	blurry squat White Citadel Satisfaction Satchel	0		
 1657	onion shurikens	0		
 1658	Cherry Cloaca Cola	0		
 1659	upside-down Diet Cloaca Cola	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	mirror nasty Da Vinci's sword	0		Experience (Mysticality): +5, Stench Damage: +5
 1680	twirling clever hale staff	0		Maximum HP: +20, Maximum MP: +20
 1681	Tesla crafty bubblewrap sword	0		Maximum MP: +10, MP Regen Min: 7, MP Regen Max: 10
@@ -1672,8 +1672,8 @@
 1692	flattened vacuum-sealed adjusted salamander slurry	0		Effect: "Saucemastery", Effect Duration: 26
 1693	anodized yellow eyedrops of newt	0		Effect: "Flashing Eyes", Effect Duration: 39
 1694	corrupted corrupted Frogade	0		Effect: "Provocative Perkiness", Effect Duration: 39
-1695	adjusted shaking huge papotion of papower	0		Effect: "Black Lung", Effect Duration: 54
-1696	flavorless super-sized royal jelly taco	5	decent	
+1695	adjusted huge shaking papotion of papower	0		Effect: "Black Lung", Effect Duration: 54
+1696	super-sized flavorless royal jelly taco	5	decent	
 1697	flavorless tofu taco	3	decent	
 1698	normal small jumping bean taco	2	good	
 1699	snack-sized rotten catgut taco	2	crappy	
@@ -1759,18 +1759,18 @@
 1780	ram stick of chilblains	0		Cold Damage: +25
 1781	vibrating enchantlers	0		Maximum MP Percent: +10, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	frightening studded ram-battering staff	0		Damage Absorption: +80, Spooky Damage: +5
-1783	special yummy crazy Turkish delight	3	awesome	Effect: "Bright!", Effect Duration: 40
+1783	yummy special crazy Turkish delight	3	awesome	Effect: "Bright!", Effect Duration: 40
 1784	blue bouncing banded dangerous Snow Queen Crown	0		Weapon Damage: +10, Damage Absorption: +100, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	up-at-dawn smelly ga-ga radio of incineration	0		Hot Spell Damage: +50, Stench Spell Damage: +10, Adventures: +5
 1786	spinning six pack of Mountain Stream	0		
 1787	tarnished shaking gray bag of Cheat-Os	0		Effect: "A Contender", Effect Duration: 43
-1788	skewed huge unrefined Mountain Stream syrup	0		
+1788	huge skewed unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
 1790	perfectly mixed distilled Ram's Face Lager	5	EPIC	
 1791	mirror ram horns	0		
-1792	foul-smelling Oprah's Travoltan trousers of the glutton	0		Maximum MP Percent: +50, Stench Damage: +10, Food Drop: +100, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	foul-smelling Oprah's Travoltan trousers of the glutton	0		Maximum MP Percent: +50, Stench Damage: +10, Food Drop: +100, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	pool cue of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15
-1794	vacuum-sealed diffused bouncing tumbling handful of hand chalk	0		Effect: "Resilient Spirit", Effect Duration: 20
+1794	vacuum-sealed diffused tumbling bouncing handful of hand chalk	0		Effect: "Resilient Spirit", Effect Duration: 20
 1795	twirling lion tamer's Counterclockwise Watch	0		Experience (familiar): +2, Single Equip
 1796	tumbling bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
@@ -1780,8 +1780,8 @@
 1801	spinning animal jawbone	0		
 1802	shaking first cervical vertebra	0		
 1803	tumbling second cervical vertebra	0		
-1804	pulsating shaking third cervical vertebra	0		
-1805	pulsating jittery fourth cervical vertebra	0		
+1804	shaking pulsating third cervical vertebra	0		
+1805	jittery pulsating fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
 1807	maroon sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
@@ -1793,7 +1793,7 @@
 1814	twirling sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
-1817	teal narrow ninth thoracic vertebra	0		
+1817	narrow teal ninth thoracic vertebra	0		
 1818	spinning tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
 1820	twelfth thoracic vertebra	0		
@@ -1814,7 +1814,7 @@
 1835	gray seventh caudal vertebra	0		
 1836	olive eighth caudal vertebra	0		
 1837	huge ninth caudal vertebra	0		
-1838	pulsating shaking tenth caudal vertebra	0		
+1838	shaking pulsating tenth caudal vertebra	0		
 1839	skewed left first rib	0		
 1840	left second rib	0		
 1841	left third rib	0		
@@ -1822,11 +1822,11 @@
 1843	left fifth rib	0		
 1844	left sixth rib	0		
 1845	twirling left seventh rib	0		
-1846	green bouncing jittery left eighth rib	0		
+1846	bouncing jittery green left eighth rib	0		
 1847	left ninth rib	0		
 1848	left tenth rib	0		
 1849	ghostly left eleventh rib	0		
-1850	narrow blurry left twelfth rib	0		
+1850	blurry narrow left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
 1853	right third rib	0		
@@ -1875,7 +1875,7 @@
 1896	blinking right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
-1899	pulsating narrow right fourth rear claw	0		
+1899	narrow pulsating right fourth rear claw	0		
 1900	veiny 1-ball	0		Maximum HP: +10
 1901	dog trainer's Jim Carey's 2-ball	0		Monster Level: +25, Experience (familiar): +1
 1902	shaking flame-retardant sinister 3-ball	0		Spell Damage: +10, Hot Resistance: +1
@@ -1890,7 +1890,7 @@
 1913	maroon clockwork handle	0		
 1914	clockwork rod	0		
 1915	clockwork shank	0		
-1916	wobbly pulsating cyan Lord Spookyraven's spectacles	0		
+1916	cyan wobbly pulsating Lord Spookyraven's spectacles	0		
 1917	green wallet	0		
 1918	twirling coin purse	0		
 1919	English to A. F. U. E. Dictionary	0		
@@ -1927,8 +1927,8 @@
 1950	bottle of Vangoghbitussin	0		
 1951	delicious watered-down bottle of Pinot Renoir	2	awesome	
 1952	rotten desiccated apricot	3	crappy	
-1953	distilled artisanal flute of flat champagne	5	EPIC	
-1954	low-calorie bland dehydrated caviar	1	decent	
+1953	artisanal distilled flute of flat champagne	5	EPIC	
+1954	bland low-calorie dehydrated caviar	1	decent	
 1955	styrofoam peanuts	0		
 1956	tolerable snifter of thoroughly aged brandy	4	good	
 1957	quill pen	0		
@@ -1943,7 +1943,7 @@
 1966	banded Amulet of Yendor of the pedagogue	0		Experience: +3, Damage Absorption: +100, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	cyan bottle of perfume	0		Familiar Weight: +5
-1969	pulsating wobbly spoon!	0		Familiar Weight: +5
+1969	wobbly pulsating spoon!	0		Familiar Weight: +5
 1970	pulsating nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	yellow plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	aromatic brawny shrimp fork	0		Muscle Percent: +20, Stench Resistance: +1
@@ -1956,7 +1956,7 @@
 1979	gravy fairy	0		
 1980	spinning sleazy gravy fairy	0		
 1981	twirling astral badger	0		
-1982	blurry green MagiMechTech MicroMechaMech	0		
+1982	green blurry MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	snowy owl	0		
 1985	wobbly scary death orb	0		
@@ -1969,7 +1969,7 @@
 1992	rubber WWBD? bracelet	0		
 1993	jittery rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
-1995	gray bouncing heart necklace	0		Free Pull
+1995	bouncing gray heart necklace	0		Free Pull
 1996	blurry right half of a heart necklace	0		
 1997	left half of a heart necklace	0		
 1998	huge pack of KWE trading card	0		
@@ -1996,9 +1996,9 @@
 2019	maroon cream pie	0		Free Pull
 2020	enchanted stale cherry pie	3	decent	Effect: "Celestial Body", Effect Duration: 50
 2021	rotten blurry strawberry pie	3	crappy	
-2022	low-calorie stale lemon meringue pie	1	decent	
-2023	narrow tumbling Genalen&trade; Bottle	1	awesome	
-2024	flavorless diet mixed wildflower greens	1	decent	
+2022	stale low-calorie lemon meringue pie	1	decent	
+2023	tumbling narrow Genalen&trade; Bottle	1	awesome	
+2024	diet flavorless mixed wildflower greens	1	decent	
 2025	adequate handful of walnuts	4	good	
 2026	small decent nutty organic salad	2	good	
 2027	bland blue super salad	3	decent	
@@ -2010,7 +2010,7 @@
 2033	yellow beefcake's round sunglasses	0		Muscle: +25, Single Equip
 2034	padded wicker shield	0		Damage Absorption: +20, Damage Reduction: 11
 2035	Marquis de Poivre soda	0		
-2036	corrupted bouncing pulsating radium-flavored potato chips	0		Effect: "Leash of Linguini", Effect Duration: 25
+2036	corrupted pulsating bouncing radium-flavored potato chips	0		Effect: "Leash of Linguini", Effect Duration: 25
 2037	enhanced deionized wintergreen-flavored potato chips	0		Effect: "Bark of the Dog", Effect Duration: 34
 2038	triple-moist polarized upside-down ennui-flavored potato chips	0		Effect: "Buggy Flavor", Effect Duration: 65
 2039	x-ray specs	0		Last Available: "2011-12"
@@ -2022,8 +2022,8 @@
 2045	tasty pulsating brain-meltingly-hot chicken wings	4	awesome	
 2046	stale frat brats	3	decent	
 2047	rotten wobbly knob ka-bobs	3	crappy	
-2049	watered-down mediocre can of Swiller	2	decent	
-2050	twirling jittery broken wings	0		
+2049	mediocre watered-down can of Swiller	2	decent	
+2050	jittery twirling broken wings	0		
 2051	mirror sunken eyes	0		
 2052	bouncing reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
@@ -2036,7 +2036,7 @@
 2060	hale thinker's sword	0		Mysticality: +10, Maximum HP: +20
 2061	helmet of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xFairy, cap 40"
 2062	MacGyver's steel-toed shield	0		Damage Reduction: 19, Maximum MP: +100
-2063	stale tiny blackberry	1	decent	
+2063	tiny stale blackberry	1	decent	
 2064	shaking forged identification documents	0		
 2065	PADL Phone	0		
 2066	miser's kick-ass kicks of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +10, Single Equip
@@ -2056,7 +2056,7 @@
 2080	ghostly ribald makeshift cape	0		Sleaze Damage: +10
 2081	Jim Carey's makeshift skirt	0		Monster Level: +25, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
 2082	toothbrush	0		
-2083	skewed green makeshift crane	0		
+2083	green skewed makeshift crane	0		
 2084	can of starch	0		
 2085	modified huge bottle of ultravitamins	1		
 2086	distilled fuchsia bottle of cough syrup	1		
@@ -2067,7 +2067,7 @@
 2091	bath salts	0		
 2092	red hand mirror	0		
 2093	huge hors d'oeuvre tray of the ox	0		Muscle: +20, Damage Reduction: 5
-2094	small yummy ballroom blintz	2	awesome	
+2094	yummy small ballroom blintz	2	awesome	
 2095	narrow towel	0		
 2096	diluted blinking guy made of bee pollen	1		Effect: "Earthen Fist", Effect Duration: 20
 2097	yellow MacGyver's 17-ball	0		Maximum MP: +100
@@ -2090,9 +2090,9 @@
 2114	yo	0		Last Available: "2006-12"
 2115	prehistoric spear of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	ghostly Tesla fire of the dark arts	0		Spell Damage Percent: +100, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	ghostly Tesla fire of the dark arts	0		Spell Damage Percent: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
-2119	wobbly blinking lit cigar	0		Last Available: "2011-12"
+2119	blinking wobbly lit cigar	0		Last Available: "2011-12"
 2120	boxer's Grateful Undead T-shirt	0		Muscle Percent: +10
 2121	wobbly spinning occult ASCII shirt	0		Spell Damage Percent: +25
 2122	blue safety vest of wisdom of the early riser	0		Mysticality: +15, Adventures: +7
@@ -2118,12 +2118,12 @@
 2143	felt	0		Last Available: "2011-12"
 2144	evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
-2146	bouncing green evil teddy bear	0		Last Available: "2006-12"
+2146	green bouncing evil teddy bear	0		Last Available: "2006-12"
 2147	wobbly evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	moldy fancy frank	3	crappy	Effect: "Be a Mind Master", Effect Duration: 15, Last Available: "2011-12"
+2149	fancy moldy frank	3	crappy	Effect: "Be a Mind Master", Effect Duration: 15, Last Available: "2011-12"
 2150	adequate blinking plate of franks and beans	3	good	Last Available: "2011-12"
-2151	special strong perfectly mixed shot of blackberry schnapps	5	EPIC	Effect: "Ancient Protected", Effect Duration: 15
+2151	strong perfectly mixed special shot of blackberry schnapps	5	EPIC	Effect: "Ancient Protected", Effect Duration: 15
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	spinning carbon nanotube frame	0		Last Available: "2011-12"
 2154	pulsating ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	huge hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	blue hardened sage toy ray gun	0		Mysticality Percent: +10, Damage Reduction: 3, Last Available: "2006-12"
-2169	chilly crafty toy space helmet	0		Maximum MP: +10, Cold Damage: +5, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	chilly crafty toy space helmet	0		Maximum MP: +10, Cold Damage: +5, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	pulsating banded cool astronaut pants	0		Moxie: +5, Damage Absorption: +100, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	pulsating banded cool astronaut pants	0		Moxie: +5, Damage Absorption: +100, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	toy jet pack of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-12"
 2173	jittery triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,17 +2161,17 @@
 2186	unlit birthday cake	0		
 2187	spinning lit birthday cake	0		
 2188	flask of peppermint oil	1	awesome	Last Available: "2006-12"
-2189	perfectly mixed weak flask of peppermint schnapps	2	EPIC	Last Available: "2006-12"
+2189	weak perfectly mixed flask of peppermint schnapps	2	EPIC	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	bouncing book of carols	0		Last Available: "2006-12"
-2192	yellow pulsating sheet music	0		Last Available: "2006-12"
+2192	pulsating yellow sheet music	0		Last Available: "2006-12"
 2193	moldy candy stake	4	crappy	Last Available: "2006-12"
 2194	drinkable eggnog	4	good	Last Available: "2006-12"
 2195	bland olive unspeakable fruitcake	3	decent	Last Available: "2006-12"
-2196	miniature adequate gingerbread horror	2	good	Last Available: "2006-12"
+2196	adequate miniature gingerbread horror	2	good	Last Available: "2006-12"
 2197	triple-wet but probably evil chocolate	0		Effect: "Penguinny Flavor", Effect Duration: 46, Last Available: "2006-12"
 2198	tasty bite-sized bat-shaped Crimboween cookie	1	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	massive normal skull-shaped Crimboween cookie	8	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2199	normal massive skull-shaped Crimboween cookie	8	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	miniature decent tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	green double-paned plastic gift-wrapping vampire	0		Cold Resistance: +5, Last Available: "2006-12"
 2202	beefcake's plastic yuletide troll	0		Muscle: +25, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	blue blurry prompt Crimbo tiki necklace	0		Adventures: +3, Last Available: "2006-12"
 2208	bouncing smartaleck's supercool bobble-hip hula elf doll	0		Moxie Percent: 50, Last Available: "2006-12"
 2209	squat Newton's Crimbo ukulele	0		Experience (Mysticality): +3, Last Available: "2006-12"
-2210	veiny wizardly Tiki lighter	0		Mysticality: +25, Maximum HP: +10, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	ribald boxer's deck of tropical cards	0		Muscle Percent: +10, Sleaze Damage: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	flame-retardant chaotic tropical paperweight	0		Spell Critical Percent: +10, Hot Resistance: +1, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	veiny wizardly Tiki lighter	0		Mysticality: +25, Maximum HP: +10, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	ribald boxer's deck of tropical cards	0		Muscle Percent: +10, Sleaze Damage: +10, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	flame-retardant chaotic tropical paperweight	0		Spell Critical Percent: +10, Hot Resistance: +1, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	blurry tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	nippy Tropical Crimbo Hat	0		Cold Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	mirror Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	nippy Tropical Crimbo Hat	0		Cold Damage: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	mirror Oprah's Tropical Crimbo Shorts	0		Maximum MP Percent: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	delicious miniature skewed tumbling super ka-bob	2	awesome	
 2218	normal immense huge beer basted brat	9	good	
 2219	Tropical Crimbo Sword of Flo-Jo	0		Initiative: +100, Last Available: "2006-12"
 2220	super-dry cold-filtered and Crimboween candy	0		Effect: "Thickest, Sickest", Effect Duration: 19, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	huge steel-toed experienced liar's pants	0		Experience: +2, Damage Reduction: 9, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	huge steel-toed experienced liar's pants	0		Experience: +2, Damage Reduction: 9, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	personal trainer's juggler's balls of James Dean	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Softcore Only, Last Available: "2007-01"
 2224	mirror scandalous pink shirt	0		Sleaze Damage: +5, Softcore Only, Last Available: "2007-01"
 2225	blurry familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2209,7 +2209,7 @@
 2234	calavera concertina of bravery	0		Spooky Resistance: +5, Song Duration: 7
 2235	Jim Carey's shellacked ratarang	0		Damage Reduction: 7, Monster Level: +25
 2236	irradiated turtle pheromones	0		Effect: "Buff as a Baobab", Effect Duration: 27
-2237	blue mirror pygmy blowgun	0		
+2237	mirror blue pygmy blowgun	0		
 2238	electrified pygmy nose-bone	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 2239	forbidden smooth bad voodoo mask	0		Moxie: +15, Spell Damage Percent: +50, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	gray bottle of alcohol	0		
@@ -2236,11 +2236,11 @@
 2262	bird rib	0		
 2263	jittery lion oil	0		
 2264	normal special squat stunt nuts	3	good	Effect: "Fudge Headache", Effect Duration: 15
-2265	snack-sized bland mirror wobbly wet stew	2	decent	
+2265	snack-sized bland wobbly mirror wet stew	2	decent	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats of the cougar	0		Moxie: +20
-2269	spoiled gigantic huge sausage wonton	6	crappy	
+2269	gigantic spoiled huge sausage wonton	6	crappy	
 2270	ribald resourceful belt	0		Maximum MP: +50, Sleaze Damage: +10, Single Equip
 2271	acceptable enchanted blinking bottle of Merlot	3	good	Effect: "Flashing Eyes", Effect Duration: 15
 2272	tolerable bottle of Port	3	good	
@@ -2252,18 +2252,18 @@
 2278	Fernswarthy's letter	0		
 2279	book	0		
 2280	bouncing wobbly Manual of Labor	0		
-2281	spinning yellow Manual of Transmission	0		
+2281	yellow spinning Manual of Transmission	0		
 2282	wobbly Manual of Dexterity	0		
 2283	seal-skull helmet of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
 2285	yellow chisel	0		
 2286	Eye of Ed	0		
 2287	savvy wizardly glowstick	0		Mysticality: +25, Mysticality Percent: +20, Last Available: "2007-01"
-2288	wobbly yellow encoder ring	0		Single Equip
+2288	yellow wobbly encoder ring	0		Single Equip
 2289	teal paperclip	0		
 2290	tumbling gray really house	0		
 2291	Non-Essential Amulet	0		
-2292	teal bouncing wine vinaigrette	0		
+2292	bouncing teal wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
 2294	Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	marinated stakes	0		
@@ -2299,11 +2299,11 @@
 2325	Staff of Ed	0		
 2326	stone rose	0		
 2327	aerosolized denatured pulsating can of paint	0		Effect: "Thick, Sick", Effect Duration: 33
-2328	ghostly twirling drum machine	0		
+2328	twirling ghostly drum machine	0		
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	normal miniature Better Than Cuddling Cake	2	good	
+2332	miniature normal Better Than Cuddling Cake	2	good	
 2333	blinking ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2311,7 +2311,7 @@
 2337	ghostly wizardly reinforced beaded headband	0		Mysticality: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	adequate enchanted pudding	4	good	Effect: "Quiet 'n' Good", Effect Duration: 50, Wiki Name: "black pudding (food)"
 2339	weak perfectly mixed Blackfly Chardonnay	2	EPIC	
-2340	perfectly mixed practically non-alcoholic & tan	1	EPIC	
+2340	practically non-alcoholic perfectly mixed & tan	1	EPIC	
 2341	huge pepper	0		
 2342	bland fancy huge forest cake	3	decent	Effect: "Dreadful Chill", Effect Duration: 50
 2343	immense moldy twirling forest ham	9	crappy	
@@ -2344,15 +2344,15 @@
 2370	spinning natural fennel soda	0		
 2371	smoke bomb	0		
 2372	fuchsia bunch of bananas	0		
-2373	diet toothsome banana	1	awesome	
+2373	toothsome diet banana	1	awesome	
 2374	banana peel	0		
-2375	jumbo flavorless banana cream pie	5	decent	
+2375	flavorless jumbo banana cream pie	5	decent	
 2376	drinkable banana daiquiri	3	good	
 2377	artisanal tumbling bungle in the jungle	4	EPIC	
 2378	bouncing banana spritzer	0		
 2379	enhanced wobbly banana smoothie	0		Effect: "Melancholy Burden", Effect Duration: 49
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
-2381	twirling blinking woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
+2381	blinking twirling woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	class ring	0		
 2384	class ring	0		
@@ -2380,7 +2380,7 @@
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	pink bat eye	0		
 2408	shaking worthless piece of glass	0		
-2409	spinning skewed billy idol	0		
+2409	skewed spinning billy idol	0		
 2410	teal rag	0		
 2411	broken petri dish	0		
 2412	upside-down sammich crust	0		
@@ -2415,7 +2415,7 @@
 2441	ghostly Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	mirror baleful dangerous pink glowstick	0		Weapon Damage: +10, Spell Damage: +25, Last Available: "2007-03"
-2444	spirit-forward mediocre twirling Supernova Champagne	5	decent	
+2444	mediocre spirit-forward twirling Supernova Champagne	5	decent	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2467,7 +2467,7 @@
 2494	beefcake's Necrotelicomnicon of chilblains	0		Muscle: +25, Cold Damage: +25
 2495	educational Cookbook of the Damned of the scaredy-cat	0		Experience: +1, Monster Level: -15
 2496	narrow miser's Sinful Desires of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +10
-2497	yellow tumbling spinning molybdenum magnet	0		
+2497	yellow spinning tumbling molybdenum magnet	0		
 2498	molybdenum hammer	0		
 2499	mirror molybdenum screwdriver	0		
 2500	molybdenum pliers	0		
@@ -2490,20 +2490,20 @@
 2517	frosty coward's chain necklace	0		Monster Level: -20, Cold Spell Damage: +10
 2518	slick sawblade shield	0		Moxie: +10, Damage Reduction: 11
 2519	tolerable blue McMillicancuddy's Special Lager	3	good	
-2520	watered-down mediocre fuchsia pulsating tumbling melted Jell-o shot	2	decent	
-2521	drinkable watered-down cruelty-free wine	2	good	
+2520	watered-down mediocre tumbling pulsating fuchsia melted Jell-o shot	2	decent	
+2521	watered-down drinkable cruelty-free wine	2	good	
 2522	smooth purple thistle wine	3	awesome	
 2523	pulsating spinning megatofu	0		
 2524	displaced fish	0		
 2525	adequate fish	3	good	
 2526	bland fish casserole	3	decent	
-2527	diet delicious bouncing fish lasagna	1	awesome	
+2527	delicious diet bouncing fish lasagna	1	awesome	
 2528	bouncing filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	spoiled gnatloaf	3	crappy	
-2530	snack-sized stale gnatloaf casserole	2	decent	
+2530	stale snack-sized gnatloaf casserole	2	decent	
 2531	tasty gnat lasagna	3	awesome	
 2532	pork	0		
-2533	gigantic normal pork chop sandwiches	8	good	
+2533	normal gigantic pork chop sandwiches	8	good	
 2534	low-calorie rotten pork casserole	1	crappy	
 2535	adequate snack-sized pork lasagna	2	good	
 2536	canopic jar	0		
@@ -2518,7 +2518,7 @@
 2545	deionized upsy daisy	0		Effect: "Springy Fusilli", Effect Duration: 13, Last Available: "2007-05"
 2546	enhanced green half-orchid	0		Effect: "Influence of Sphere", Effect Duration: 50, Last Available: "2007-05"
 2547	gravedigger's dangerous tin star	0		Weapon Damage: +10, Spooky Damage: +10, Last Available: "2007-05"
-2548	cool wizardly outrageous sombrero	0		Mysticality: +25, Moxie: +5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	cool wizardly outrageous sombrero	0		Mysticality: +25, Moxie: +5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	&quot;Humorous&quot; T-shirt of James Dean of terror	0		Experience (Moxie): +3, Spooky Spell Damage: +10, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2535,13 +2535,13 @@
 2562	half-rotten brain	0		
 2563	bonesaw	0		
 2564	plus-sized phylactery	0		
-2565	teal mirror can of Ghuol-B-Gone&trade;	0		
-2566	blurry shaking Azazel's unicorn	0		
+2565	mirror teal can of Ghuol-B-Gone&trade;	0		
+2566	shaking blurry Azazel's unicorn	0		
 2567	Azazel's lollipop	0		
 2568	Azazel's tutu	0		
 2569	warmed colloidal narrow ant agonist	0		Effect: "Oth-Jeal-O", Effect Duration: 15
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
-2571	ghostly purple ant rake	0		Familiar Effect: "hot damage, meat"
+2571	purple ghostly ant rake	0		Familiar Effect: "hot damage, meat"
 2572	upside-down ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	green ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	upside-down ant pick	0		Familiar Effect: "cold damage, meat"
@@ -2553,7 +2553,7 @@
 2580	energetic medical-grade scorpion whip	0		Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10
 2581	handful of sand	0		
 2582	bouncing brick of sand	0		
-2583	miniature adequate centipede eggs	2	good	
+2583	adequate miniature centipede eggs	2	good	
 2584	wonderwall shield of dire peril	0		Weapon Damage: +20, Damage Reduction: 12
 2585	Colonel Mustard's Lonely Spades Club Jacket of the sewer	0		Stench Damage: +25
 2586	razor-sharp General Sage's Lonely Diamonds Club Jacket	0		Weapon Damage Percent: +25
@@ -2561,7 +2561,7 @@
 2588	green stiffened Private Pepper's Lonely Hearts Club Jacket	0		Damage Reduction: 1
 2589	small normal hot date	2	good	
 2590	drinkable distilled fortified wine	4	good	
-2591	tasty huge olive tasty tart	9	awesome	
+2591	huge tasty olive tasty tart	9	awesome	
 2592	Knob Goblin lunchbox	0		
 2593	rotten spinning Knob pasty	4	crappy	
 2594	perfectly mixed thermos full of Knob coffee	4	EPIC	
@@ -2578,18 +2578,18 @@
 2605	palm frond	0		
 2606	palm-frond fan	0		
 2607	fortified palm-frond whip	0		Damage Absorption: +60
-2608	shaking upside-down palm-frond net	0		
+2608	upside-down shaking palm-frond net	0		
 2609	reassuring palm-frond capris of the pedagogue	0		Experience: +3, Spooky Resistance: +1, Familiar Effect: "1.5xGhuol, cap 35"
 2610	Jack Frost's extra-large palm-frond toupee	0		Cold Spell Damage: +50, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 2611	hardened palm-frond cloak	0		Damage Reduction: 3
 2612	vinyl coin purse	0		
 2613	upside-down rocky raccoon	0		
 2614	mojo filter	0		
-2615	snack-sized tasty savoy truffle	2	awesome	
+2615	tasty snack-sized savoy truffle	2	awesome	
 2616	Magi-Wipes	0		
 2617	boom	0		
 2618	gravedigger's Iiti Kitty phone charm	0		Spooky Damage: +10, Single Equip
-2619	narrow olive jar of swamp gas	0		Last Available: "2007-05"
+2619	olive narrow jar of swamp gas	0		Last Available: "2007-05"
 2620	adequate unidentified jerky	4	good	
 2621	flame-wreathed supercool nasty rat mask	0		Moxie Percent: +20, Hot Spell Damage: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	experienced ratskin belt of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Single Equip
@@ -2621,26 +2621,26 @@
 2648	flirtatious feather	0		
 2649	green supercharged Lord Spookyraven's ear trumpet	0		Maximum MP Percent: +30, Single Equip
 2650	bottled pixie	0		Free Pull
-2651	twirling wobbly pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
+2651	wobbly twirling pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	massive yummy S.T.L.T.	9	awesome	Last Available: "2007-06"
 2653	stale honey-dew	4	decent	Last Available: "2007-06"
 2654	mediocre yellow bouncing Xanadian	3	decent	Last Available: "2007-06"
 2655	magnetized bottle of absinthe	0		Effect: "Sizzling with Fury", Effect Duration: 22, Last Available: "2007-06"
 2656	chilly razor-sharp Drowsy Sword	0		Weapon Damage Percent: +25, Cold Damage: +5
-2657	snack-sized spoiled escargotsicle	2	crappy	Last Available: "2007-06"
-2658	extra-dry mediocre purple bottle of realpagne	5	decent	Last Available: "2007-06"
+2657	spoiled snack-sized escargotsicle	2	crappy	Last Available: "2007-06"
+2658	mediocre extra-dry purple bottle of realpagne	5	decent	Last Available: "2007-06"
 2659	beefcake's albatross necklace	0		Muscle: +25, Single Equip, Last Available: "2007-06"
-2660	modified huge blue not-a-pipe	1	good	Effect: "Human-Orc Hybrid", Effect Duration: 40, Last Available: "2007-06"
+2660	modified blue huge not-a-pipe	1	good	Effect: "Human-Orc Hybrid", Effect Duration: 40, Last Available: "2007-06"
 2661	artisanal squat flask of Amontillado	3	EPIC	Last Available: "2007-06"
-2662	jittery quilted ball mask	0		Damage Absorption: +40, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	wicked Can-Can skirt	0		Spell Damage: +5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	jittery quilted ball mask	0		Damage Absorption: +40, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	wicked Can-Can skirt	0		Spell Damage: +5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	chilled corrupted mirror sensitive poetry journal	0		Effect: "Impregnabili Tea", Effect Duration: 69, Last Available: "2007-06"
 2665	deionized double-boiled liquefied bottled inspiration	0		Effect: "Burning Tongue", Effect Duration: 23, Last Available: "2007-06"
 2666	non-irradiated pressed bellhop bell	0		Effect: "Low on the Hog", Effect Duration: 20, Last Available: "2007-06"
 2667	oxidized gray spiky collar	0		Effect: "Sepia Tan", Effect Duration: 21, Last Available: "2007-06"
 2668	powdered ghostly can-can-in-a-can	1		Effect: "Rushin' Hands", Effect Duration: 10, Last Available: "2007-06"
 2669	vaporized upside-down patent antipsychotics	1		Effect: "Papowerful", Effect Duration: 20, Last Available: "2007-06"
-2670	vaporized shaking yellow Mariner's Friend cough drops	1		Effect: "Stop the Presses!", Effect Duration: 25, Last Available: "2007-06"
+2670	vaporized yellow shaking Mariner's Friend cough drops	1		Effect: "Stop the Presses!", Effect Duration: 25, Last Available: "2007-06"
 2671	drinkable extra-dry shot of nepenthe schnapps	5	good	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
@@ -2650,7 +2650,7 @@
 2677	pickled protein powder	1		
 2678	spectre scepter	0		
 2679	colloidal tarnished vacuum-sealed sparkler	0		Effect: "Wet and Greedy", Effect Duration: 61
-2680	wet blinking ghostly snake	0		Effect: "Perception", Effect Duration: 53, Wiki Name: "snake"
+2680	wet ghostly blinking snake	0		Effect: "Perception", Effect Duration: 53, Wiki Name: "snake"
 2681	pickled M-242	0		Effect: "5 Pounds Lighter", Effect Duration: 54
 2682	detuned radio	0		
 2683	shaking Warehouse 23 crate	0		
@@ -2661,14 +2661,14 @@
 2688	greasy baleful dreadlock whip of courage	0		Spell Damage: +25, Sleaze Spell Damage: +10, Spooky Resistance: +3
 2689	beer-a-pult of the blizzard of doom	0		Cold Spell Damage: +25, Spooky Spell Damage: +50
 2690	ghostly greedy frightening cast-iron legacy paddle	0		Spooky Damage: +5, Meat Drop: +20
-2691	gigantic decent handful of nuts and berries	8	good	
+2691	decent gigantic handful of nuts and berries	8	good	
 2692	shaking driftwood sculpture of the empath of the overflowing toilet	0		Familiar Weight: +5, Stench Spell Damage: +50
 2693	clever massive sitar of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100
 2694	blinking red frosty careful stone baseball cap of the detective	0		Monster Level: -10, Cold Spell Damage: +10, Item Drop: +20, Familiar Effect: "1xVolley, cap 48"
 2695	lousy weak special upside-down cup of beer	2	decent	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 40
 2696	ovoid thing	0		
 2697	duct tape	0		
-2698	jittery blurry duct tape wallet	0		
+2698	blurry jittery duct tape wallet	0		
 2699	flame-retardant horrifying duct tape shirt	0		Spooky Damage: +25, Hot Resistance: +1
 2700	lard-coated hale duct tape fedora	0		Maximum HP: +20, Sleaze Spell Damage: +25, Familiar Effect: "1xBarrr, 1xLep, cap 48"
 2701	avaricious auspicious duct tape sword	0		Item Drop: +10, Meat Drop: +30
@@ -2695,24 +2695,24 @@
 2722	knitted therapeutic wholesome studded Staff of the Greasefire	0		Damage Absorption: +80, Maximum HP Percent: +10, Cold Resistance: +3, HP Regen Min: 5, HP Regen Max: 7
 2723	energetic Newton's savvy Staff of the Grand Flamb&eacute;	0		Mysticality Percent: +20, Experience (Mysticality): +3, Maximum MP Percent: +20
 2724	flavorless small bowl of rye sprouts	2	decent	
-2725	half-sized rotten mirror cob of corn	2	crappy	
+2725	rotten half-sized mirror cob of corn	2	crappy	
 2726	normal miniature juniper berries	2	good	
-2727	miniature decent plum	2	good	
+2727	decent miniature plum	2	good	
 2728	adequate tumbling pear	3	good	
 2729	spoiled peach	3	crappy	
 2730	bad blue jittery plum wine	4	decent	
 2731	acceptable shot of pear schnapps	3	good	
 2732	tolerable shot of peach schnapps	3	good	
-2733	toothsome diet maroon bunch of square grapes	1	awesome	
+2733	diet toothsome maroon bunch of square grapes	1	awesome	
 2734	moldy pulsating brown sugar cane	3	crappy	
-2735	half-sized bland sandwich of the gods	2	decent	
+2735	bland half-sized sandwich of the gods	2	decent	
 2736	smooth Pan-Dimensional Gargle Blaster	3	awesome	
 2737	twisted tumbling leopard-print barbell	1	good	
 2738	lime green pile of smoking rags	0		
 2739	enhanced ionized tumbling panty raider camouflage	0		Effect: "Enraged", Effect Duration: 46
 2740	blurry pulsating healthy brawny weightlifter's Staff of the Walk-In Freezer	0		Muscle: +15, Muscle Percent: +20, Maximum HP Percent: +20
 2741	acceptable huge boilermaker	4	good	
-2742	low-calorie toothsome blue steel lasagna	1	quest	
+2742	toothsome low-calorie blue steel lasagna	1	quest	
 2743	drinkable huge huge steel margarita	3	quest	
 2744	powdered steel-scented air freshener	1		Effect: "Extra Terrestrial", Effect Duration: 20
 2745	super-Vulcanized dry triple-oxidized blinking gremlin mutagen	0		Effect: "Comprehensively Nourished", Effect Duration: 31
@@ -2737,13 +2737,13 @@
 2764	Order of the Silver Wossname of the bloodbag of the brazier	0		Maximum HP: +100, Hot Spell Damage: +25, Item Drop: +5, Single Equip
 2765	Harold's bell	0		
 2766	wobbly bowling ball	0		
-2767	half-sized normal Crimbo pie	2	good	
-2768	thick fancy flavorless tumbling pear tart	5	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 25
-2769	jumbo stale gray peach pie	5	decent	
+2767	normal half-sized Crimbo pie	2	good	
+2768	fancy flavorless thick tumbling pear tart	5	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 25
+2769	stale jumbo gray peach pie	5	decent	
 2770	colloidal pressed blurry chunk of rock salt	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 13
 2771	activated huge handful of pine needles	0		Effect: "Nutrient-Rich", Effect Duration: 53
 2772	steamy ruby	0		
-2773	twirling narrow blurry glacial sapphire	0		
+2773	twirling blurry narrow glacial sapphire	0		
 2774	unearthly onyx	0		
 2775	effluvious emerald	0		
 2776	upside-down tawdry amethyst	0		
@@ -2789,9 +2789,9 @@
 2816	shellacked studded educational Boxers	0		Experience: +1, Damage Absorption: +80, Damage Reduction: 7, Familiar Effect: "1xVolley, 1xLep"
 2817	jittery executive ribald Brooch of chilblains	0		Cold Damage: +25, Sleaze Damage: +10, Meat Drop: +40, Single Equip
 2818	bouncing careful arcane researcher's Bracelet of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Monster Level: -10, Single Equip
-2819	squat vibrating padded Grimacite gasmask	0		Damage Absorption: +20, Maximum MP Percent: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	squat vibrating padded Grimacite gasmask	0		Damage Absorption: +20, Maximum MP Percent: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	Newton's Grimacite gat of the overflowing toilet	0		Experience (Mysticality): +3, Stench Spell Damage: +50, Last Available: "2008-11"
-2821	tumbling ghostly censurious strapping Grimacite gaiters	0		Muscle: +5, Sleaze Resistance: +3, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	tumbling ghostly censurious strapping Grimacite gaiters	0		Muscle: +5, Sleaze Resistance: +3, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	fireproof dog trainer's Grimacite gauntlets	0		Experience (familiar): +1, Hot Resistance: +3, Single Equip, Last Available: "2008-11"
 2823	Da Vinci's Grimacite go-go boots of temperance	0		Experience (Mysticality): +5, Sleaze Resistance: +5, Single Equip, Last Available: "2008-11"
 2824	blurry twirling mansplainer's thinker's Grimacite girdle	0		Mysticality: +10, Monster Level: +15, Single Equip, Last Available: "2008-11"
@@ -2804,23 +2804,23 @@
 2831	star key lime	0		
 2832	stale digital key lime pie	3	decent	
 2833	normal star key lime pie	4	good	
-2834	greasy Van der Graaf thinker's bottle-rocket crossbow	0		Mysticality: +10, Sleaze Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	greasy Van der Graaf thinker's bottle-rocket crossbow	0		Mysticality: +10, Sleaze Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	blinking shaking healthy indie comic hipster glasses	0		Maximum HP Percent: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	twirling mint-condition magic wand	0		Last Available: "2011-12"
 2838	wobbly censurious sharpshooter's glowstick	0		Critical Hit Percent: +10, Sleaze Resistance: +3, Last Available: "2007-08"
 2839	family-friendly Periodical Paintbrush	0		Sleaze Resistance: +1, Softcore Only
 2840	mediocre lime green bottle of cooking sherry	3	decent	
-2841	snack-sized bland packet of ketchup	2	decent	
-2842	high-proof tolerable spinning accidental cider	8	good	
+2841	bland snack-sized packet of ketchup	2	decent	
+2842	tolerable high-proof spinning accidental cider	8	good	
 2843	rotten mirror dire fudgesicle	3	crappy	
 2844	teal Jeselnik's frightening curative beefcake's navel ring of navel gazing	0		Muscle: +25, Spooky Damage: +5, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
-2846	blurry yellow plastic bib	0		Last Available: "2011-12"
+2846	yellow blurry plastic bib	0		Last Available: "2011-12"
 2847	wobbly Dallas Dynasty Falcon Crest shield of doom	0		Spooky Spell Damage: +50, Damage Reduction: 15
 2848	wobbly Gnomitronic Hyperspatial Demodulizer	0		
 2849	pulsating shrunken navigator head	0		
-2850	artisanal upside-down teal moonberry wine cooler	3	EPIC	
+2850	artisanal teal upside-down moonberry wine cooler	3	EPIC	
 2851	spoiled fine aged cheddarwurst	3	crappy	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2832,9 +2832,9 @@
 2859	scorching witch wart of the brazier	0		Hot Damage: +25, Hot Spell Damage: +25
 2860	jumbo decent swamp muck	5	good	
 2861	fireproof chaotic baleful leechknife	0		Spell Damage: +25, Spell Critical Percent: +10, Hot Resistance: +3
-2862	shaking teal decomposed boot	0		
+2862	teal shaking decomposed boot	0		
 2863	ionized cyan dribbly candle	0		Effect: "Spooky Demeanor", Effect Duration: 24
-2864	ghostly upside-down yellow stolen meatpouch	0		
+2864	upside-down yellow ghostly stolen meatpouch	0		
 2865	red Sherlock's greasy beaver spear	0		Sleaze Spell Damage: +10, Item Drop: +25
 2866	auspicious shamanic beads of James Dean	0		Experience (Moxie): +3, Item Drop: +10
 2867	dilapidated wizard hat of the sweet-tooth of the early riser	0		Candy Drop: +100, Adventures: +7, Familiar Effect: "cap 31"
@@ -2915,21 +2915,21 @@
 2942	tarnished chocolate filthy lucre	0		Effect: "Turkey-Agitated", Effect Duration: 46
 2943	pickled pickled Angry Farmer's Wife Candy	0		Effect: "Well-preserved", Effect Duration: 60
 2945	wobbly fuchsia Tesla party hat of courage	0		Spooky Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "4xLep, cap 7"
-2946	family-friendly V for Vivala mask of wisdom	0		Mysticality: +15, Sleaze Resistance: +1, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	family-friendly V for Vivala mask of wisdom	0		Mysticality: +15, Sleaze Resistance: +1, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	weak artisanal shot of rotgut	2	EPIC	
+2948	artisanal weak shot of rotgut	2	EPIC	
 2949	diffused flattened blinking jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Full Bottle in front of Me", Effect Duration: 23
 2950	huge Cap'm Caronch's Map	0		
 2951	twirling Orcish Frat House blueprints	0		
 2952	huge banded deadly glowstick	0		Weapon Damage: +5, Damage Absorption: +100, Last Available: "2007-11"
 2953	red charrrm bracelet	0		
 2954	hardy tip jar	0		Maximum HP: +50
-2955	snack-sized delicious lime green blurry yam candy	2	awesome	
+2955	snack-sized delicious blurry lime green yam candy	2	awesome	
 2956	spinning cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	spoiled tube of cranberry Go-Goo	3	crappy	
 2959	Jim Carey's rum barrel charrrm bracelet	0		Monster Level: +25
-2960	decent immense single-serving herbal stuffing	8	good	
+2960	immense decent single-serving herbal stuffing	8	good	
 2961	diet rotten mirror packet of tofurkey gravy	1	crappy	
 2962	spoiled fancy tofurkey nugget	3	crappy	Effect: "Haunted Stomach", Effect Duration: 40
 2963	rigging shampoo	0		
@@ -2994,18 +2994,18 @@
 3022	medium stone triangle	0		
 3023	blinking small stone triangle	0		
 3024	yellow stone pyramid	0		
-3025	watered-down perfectly mixed corpse on the beach	2	super ultra mega EPIC	
+3025	perfectly mixed watered-down corpse on the beach	2	super ultra mega EPIC	
 3026	perfectly mixed practically non-alcoholic twirling corpsetini	1	super ultra mega turbo EPIC	
-3027	watered-down lousy corpsedriver	2	decent	
+3027	lousy watered-down corpsedriver	2	decent	
 3028	aged Corpse Island iced tea	4	awesome	
 3029	tolerable weak red-headed corpse	2	good	
-3030	hand-crafted practically non-alcoholic fancy kamicorpse-ee	1	super EPIC	Effect: "Rosewater Mark", Effect Duration: 5
-3031	mediocre gray spinning corpsel	4	decent	
+3030	fancy hand-crafted practically non-alcoholic kamicorpse-ee	1	super EPIC	Effect: "Rosewater Mark", Effect Duration: 5
+3031	mediocre spinning gray corpsel	4	decent	
 3032	artisanal corpsebite	3	EPIC	
 3033	greedy pirate fledges	0		Meat Drop: +20
 3034	piece of thirteen	0		
-3035	enchanted normal pearl onion	3	good	Effect: "Human-Goblin Hybrid", Effect Duration: 25
-3036	delicious tiny sea biscuit	1	awesome	
+3035	normal enchanted pearl onion	3	good	Effect: "Human-Goblin Hybrid", Effect Duration: 25
+3036	tiny delicious sea biscuit	1	awesome	
 3037	artisanal bouncing bottle of rum	4	EPIC	
 3038	tolerable purple bottle of black-label rum	3	good	
 3039	upside-down cannonball	0		
@@ -3013,11 +3013,11 @@
 3041	bouncing joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	upside-down yellow metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	upside-down yellow metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	snack-sized stale nanite-infested gingerbread bugbear	2	decent	Last Available: "2007-12"
 3046	normal thick nanite-infested candy cane	5	good	Last Available: "2020-09"
 3047	moldy fancy nanite-infested fruitcake	4	crappy	Effect: "Boon of the Storm Tortoise", Effect Duration: 50, Last Available: "2007-12"
-3048	acceptable triple-distilled nanite-infested eggnog	10	good	Last Available: "2007-12"
+3048	triple-distilled acceptable nanite-infested eggnog	10	good	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	narrow wicked eyepatch	0		Spell Damage: +5, Familiar Effect: "spooky atk, 1xBarrr"
 3051	tumbling supercharged cutlass	0		Maximum MP Percent: +30
@@ -3025,7 +3025,7 @@
 3053	teal mood ring	0		Last Available: "2007-02"
 3054	triple-wet double-tarnished colloidal candy heart	0		Effect: "Gleaming White Teeth", Effect Duration: 12, Last Available: "2007-02"
 3055	alkaline triple-enhanced lime green cymbal syrup	0		Free Pull, Effect: "You Know Where to Go", Effect Duration: 64, Last Available: "2007-02"
-3056	Jack Frost's metallic foil cat ears	0		Cold Spell Damage: +50, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	Jack Frost's metallic foil cat ears	0		Cold Spell Damage: +50, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	pulsating spinning Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	spinning pulsating Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	upside-down teddy borg	0		Last Available: "2007-12"
 3081	wobbly chaotic marionette collective	0		Spell Critical Percent: +10, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	flame-retardant wholesome roboduck-on-a-string	0		Maximum HP Percent: +10, Hot Resistance: +1, Last Available: "2007-12"
 3086	upside-down mylar scout drone	0		Last Available: "2007-12"
 3087	cyan teddy borg sewing kit	0		Last Available: "2007-12"
-3088	zippy forbidden biomechanical crimborg helmet	0		Spell Damage Percent: +50, Initiative: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	zippy forbidden biomechanical crimborg helmet	0		Spell Damage Percent: +50, Initiative: +20, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	studded C.B.F.G. of the pedagogue	0		Experience: +3, Damage Absorption: +80, Last Available: "2007-12"
-3090	bouncing skewed steel-toed dangerous biomechanical crimborg leg armor	0		Weapon Damage: +10, Damage Reduction: 9, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	bouncing skewed steel-toed dangerous biomechanical crimborg leg armor	0		Weapon Damage: +10, Damage Reduction: 9, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	Vulcanized Vulcanized vitachoconutriment capsule	0		Effect: "Saucemastery", Effect Duration: 56, Last Available: "2007-12"
 3092	gray handmade hobby horse of terror	0		Spooky Spell Damage: +10, Last Available: "2007-12"
 3093	huge teal ball-in-a-cup of the boozehound	0		Booze Drop: +100, Last Available: "2007-12"
@@ -3076,10 +3076,10 @@
 3104	chilly beefy vibrating cyborg knife	0		Muscle: +10, Cold Damage: +5, Last Available: "2007-12"
 3105	Tesla immense cyborg hand of dire peril	0		Weapon Damage: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2007-12"
 3106	family-friendly chilly fortified cyborg stompin' boot	0		Damage Absorption: +60, Cold Damage: +5, Sleaze Resistance: +1, Single Equip, Last Available: "2007-12"
-3107	upside-down blurry deactivated RoboGoose	0		Last Available: "2007-12"
+3107	blurry upside-down deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	Miniborg stomper	0		Last Available: "2007-12"
-3110	huge twirling Miniborg strangler	0		Last Available: "2007-12"
+3110	twirling huge Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	spoiled roasted marshmallow	3	crappy	
 3130	disc	0		Last Available: "2008-01"
-3131	decent half-sized tin cup of mulligan stew	2	good	
+3131	half-sized decent tin cup of mulligan stew	2	good	
 3132	shaking occult savvy flamin' bindle	0		Mysticality Percent: +20, Spell Damage Percent: +25
 3133	wobbly maroon double-paned brawny freezin' bindle	0		Muscle Percent: +20, Cold Resistance: +5
 3134	spinning steel-toed stinkin' bindle of the blizzard	0		Damage Reduction: 9, Cold Spell Damage: +25
@@ -3129,27 +3129,27 @@
 3157	shaking twirling El Vibrato drone	0		
 3158	sparking El Vibrato drone	0		
 3159	altered non-dry adjusted warm El Vibrato drone	0		Effect: "Frigid Weapon", Effect Duration: 41
-3160	dry blurry maroon humming El Vibrato drone	0		Effect: "Shamboozled", Effect Duration: 58
+3160	dry maroon blurry humming El Vibrato drone	0		Effect: "Shamboozled", Effect Duration: 58
 3161	unsweetened quadruple-galvanized skewed El Vibrato drone	0		Effect: "Old Time Hydration", Effect Duration: 64
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	gray El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	upside-down broken El Vibrato drone	0		
 3166	ghostly repaired El Vibrato drone	0		
-3167	blue squat augmented El Vibrato drone	0		
+3167	squat blue augmented El Vibrato drone	0		
 3168	modified altered seal eyeball	0		Effect: "Flame-Retardant Trousers", Effect Duration: 44
 3169	adequate turtle soup	3	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
-3171	teal ghostly nauseating reagent	0		
+3171	ghostly teal nauseating reagent	0		
 3172	gray squat jittery coward's evil paper umbrella	0		Monster Level: -20
 3173	electrified improved jittery evil vihuela	0		Effect: "Holiday Disappointment", Effect Duration: 65
 3174	normal bouncing evil boring spaghetti	4	good	
 3175	spoiled evil noodles	3	crappy	
 3176	decent evil noodles	3	good	
-3177	huge flavorless evil painful penne pasta	8	decent	
+3177	flavorless huge evil painful penne pasta	8	decent	
 3178	huge normal yellow 3vi1 pr0n m4nic0tti	7	good	
 3179	rotten pulsating evil ravioli della hippy	4	crappy	
-3180	rotten special tiny evil noodles	1	crappy	Effect: "Quaaaaaaa", Effect Duration: 5
+3180	special tiny rotten evil noodles	1	crappy	Effect: "Quaaaaaaa", Effect Duration: 5
 3181	wet adjusted colloidal skewed evil potion of potency	0		Effect: "Sticks and Stones", Effect Duration: 52
 3182	oxidized super-pickled skewed squat evil libation of liveliness	0		Effect: "Berry Berry Cold", Effect Duration: 28
 3183	colloidal wobbly evil tomato juice of powerful power	0		Effect: "Joy", Effect Duration: 15
@@ -3160,7 +3160,7 @@
 3188	tolerable weak an evil sump'm sump'm	2	good	
 3189	hand-crafted evil ducha de oro	3	EPIC	
 3190	mediocre tumbling evil horizontal tango	3	decent	
-3191	bad triple-distilled evil roll in the hay	6	decent	
+3191	triple-distilled bad evil roll in the hay	6	decent	
 3192	mirror naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3181,7 +3181,7 @@
 3209	laminated card	0		
 3210	bouncing notbig laminated card	0		
 3211	mirror unlarge laminated card	0		
-3212	upside-down jittery dwarvish document	0		
+3212	jittery upside-down dwarvish document	0		
 3213	mirror dwarvish paper	0		
 3214	dwarvish parchment	0		
 3215	twirling overcharged El Vibrato power sphere	0		
@@ -3196,7 +3196,7 @@
 3224	mirror sewer wad	0		
 3225	smooth bottle of sewage schnapps	4	awesome	
 3226	bad bottle of Ooze-O	4	decent	
-3227	yummy immense C.H.U.M. chum	9	awesome	
+3227	immense yummy C.H.U.M. chum	9	awesome	
 3228	flavorless unfortunate dumplings	3	decent	
 3229	teal decaying goldfish liver	0		
 3230	anodized purple oil of oiliness	0		Effect: "Grumpy and Ornery", Effect Duration: 65
@@ -3238,11 +3238,11 @@
 3266	bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	electrified polymerized handful of Crotchety Pine needles	0		Effect: "Hypercubed", Effect Duration: 47
-3269	anodized denatured wobbly ghostly lump of Saccharine Maple sap	0		Effect: "It Didn't Kill You", Effect Duration: 46
+3269	anodized denatured ghostly wobbly lump of Saccharine Maple sap	0		Effect: "It Didn't Kill You", Effect Duration: 46
 3270	polymerized flattened handful of Laughing Willow bark	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 19
-3271	spinning razor-sharp crotchety pants	0		Weapon Damage Percent: +25, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	spinning razor-sharp crotchety pants	0		Weapon Damage Percent: +25, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	veiny Saccharine Maple pendant	0		Maximum HP: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	willowy bonnet of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	willowy bonnet of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	pulsating flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3257,8 +3257,8 @@
 3285	brawny C.H.U.M. knife	0		Muscle Percent: +20
 3286	lard-coated Frosty's snowball sack	0		Sleaze Spell Damage: +25
 3287	quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
-3288	cyan squat shimmering tendrils	0		Class: "Pastamancer"
-3289	bouncing maroon jittery scintillating powder	0		Class: "Pastamancer"
+3288	squat cyan shimmering tendrils	0		Class: "Pastamancer"
+3289	maroon bouncing jittery scintillating powder	0		Class: "Pastamancer"
 3290	abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
@@ -3275,7 +3275,7 @@
 3303	sombrero	0		Sombrero Bonus: +10
 3304	Argarggagarg's fang	0		
 3305	Safari Jack's moustache	0		
-3306	twirling bouncing Yakisoba's hat	0		
+3306	bouncing twirling Yakisoba's hat	0		
 3307	bouncing Heimandatz's heart	0		
 3308	Jocko Homo's head	0		
 3309	shaking The Mariachi's guitar case	0		
@@ -3291,12 +3291,12 @@
 3319	green Jim Carey's Mr. Joe's bangles	0		Monster Level: +25, Single Equip
 3320	tumbling frayed rope belt	0		Item Drop: +5, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	blurry miser's horrifying mayfly bait necklace	0		Spooky Damage: +25, Meat Drop: +10, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	blurry miser's horrifying mayfly bait necklace	0		Spooky Damage: +25, Meat Drop: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	aged spinning jar of fermented pickle juice	3	awesome	
-3326	dehydrated jittery twirling voodoo snuff	1	good	
-3327	flavorless low-calorie upside-down extra-greasy slider	1	decent	
+3326	dehydrated twirling jittery voodoo snuff	1	good	
+3327	low-calorie flavorless upside-down extra-greasy slider	1	decent	
 3328	squat crafty boxer's crumpled felt fedora	0		Muscle Percent: +10, Maximum MP: +10, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	twirling reassuring Van der Graaf battered top-hat	0		Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	sizzling shapeless wide-brimmed hat	0		Hot Damage: +10, Item Drop: +5, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3312,12 +3312,12 @@
 3340	narrow very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	hobo monkey	0		
-3343	blinking ghostly bindle	0		Familiar Weight: +5
+3343	ghostly blinking bindle	0		Familiar Weight: +5
 3344	tumbling bed of coals	0		
 3345	air mattress	0		
 3346	shaking filth-encrusted futon	0		
 3347	comfy coffin	0		
-3348	jittery yellow mattress	0		
+3348	yellow jittery mattress	0		
 3349	dinged-up triangle	0		
 3350	perfectly mixed ghostly Ralph IX cognac	3	super ultra mega turbo EPIC	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
@@ -3333,7 +3333,7 @@
 3361	squat yummy death watch beetle	0		Last Available: "2008-06"
 3362	pulsating tasty louse	0		Last Available: "2008-06"
 3363	flavorless mole mol&eacute;	3	decent	Last Available: "2008-06"
-3364	aged watered-down Morlock's Mark Bourbon	2	awesome	Last Available: "2008-06"
+3364	watered-down aged Morlock's Mark Bourbon	2	awesome	Last Available: "2008-06"
 3365	alkaline shaking Climate Colada	0		Effect: "Big Punkin'", Effect Duration: 60, Last Available: "2008-06"
 3366	super-pressed digital underground potion	0		Effect: "Gonna Get You, Sucker", Effect Duration: 65, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3344,7 +3344,7 @@
 3372	pickled ghostly squat glimmering raven feather	1		Last Available: "2008-06"
 3373	altered fuchsia glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
-3375	upside-down mirror The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
+3375	mirror upside-down The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	blinking Chorale of Companionship	0		Skill: "Chorale of Companionship"
@@ -3368,7 +3368,7 @@
 3396	cyan dangerous Hodgman's lobsterskin pants of the ox	0		Muscle: +20, Weapon Damage: +10, Familiar Effect: "atk, 1xPotato"
 3397	shaking padded deadly Hodgman's bow tie	0		Weapon Damage: +5, Damage Absorption: +20, Single Equip
 3398	tolerable watered-down lime green Hodgman's blanket	2	good	
-3399	mediocre weak jar of squeeze	2	decent	
+3399	weak mediocre jar of squeeze	2	decent	
 3400	moldy bowl of fishysoisse	3	crappy	
 3401	tarnished denatured activated deadly lampshade	0		Effect: "Winning Smile", Effect Duration: 39
 3402	modified activated teal concentrated garbage juice	0		Effect: "Filled with Magic", Effect Duration: 27
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	olive hobo fortress blueprints	0		
-3421	fuchsia box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	fuchsia box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	super-polarized pulsating twirling sterno-flavored Hob-O	0		Effect: "Happy Trails", Effect Duration: 34
 3423	irradiated moist skewed frostbite-flavored Hob-O	0		Effect: "Briny Blood", Effect Duration: 12
 3424	deionized cold-filtered modified fry-oil-flavored Hob-O	0		Effect: "So Fresh and So Clean", Effect Duration: 26
@@ -3396,7 +3396,7 @@
 3428	pressed dry jittery Everlasting Deckswabber	0		Effect: "5 Pounds Lighter", Effect Duration: 25
 3430	bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
-3432	fuchsia squat narrow cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
+3432	squat narrow fuchsia cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
 3434	rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	foul-smelling slick stirring stick	0		Moxie: +10, Stench Damage: +10
@@ -3412,7 +3412,7 @@
 3445	Junior Adventurer's kit	0		
 3446	groovy prism necklace	0		Single Equip
 3447	perfumed six-rainbow shield of the empath	0		Familiar Weight: +5, Stench Resistance: +5, Damage Reduction: 12, Last Available: "2008-07"
-3448	blurry yellow rainbow bomb	0		Last Available: "2008-07"
+3448	yellow blurry rainbow bomb	0		Last Available: "2008-07"
 3449	blurry cotton candy cone	0		Last Available: "2008-08"
 3450	mirror cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
@@ -3423,18 +3423,18 @@
 3456	fuchsia strapping trusty torch	0		Muscle: +5, Last Available: "2011-12"
 3457	spinning wobbly energetic Junior Adventurer's merit badge	0		Maximum MP Percent: +20
 3458	irradiated concentrated STYX deodorant body spray	0		Effect: "Conspiratory Eyes", Effect Duration: 40
-3459	practically non-alcoholic lousy fancy white-label gin	1	decent	Effect: "You Can Taste the Darkness", Effect Duration: 15
+3459	practically non-alcoholic fancy lousy white-label gin	1	decent	Effect: "You Can Taste the Darkness", Effect Duration: 15
 3460	adequate tiny tin rations	1	good	
 3461	pulsating haiku challenge map	0		
 3462	terrible poem	0		
-3463	mediocre watered-down bottle of sake	2	decent	
+3463	watered-down mediocre bottle of sake	2	decent	
 3464	tumbling round pebble of the overflowing toilet	0		Stench Spell Damage: +50
 3465	rotten ghostly Bash-&#332;s cereal	4	crappy	Wiki Name: "Bash-Os cereal"
-3466	horrifying Socratic haiku katana of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Spooky Damage: +25, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	horrifying Socratic haiku katana of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Spooky Damage: +25, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	red plastic baby of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2008-12"
 3469	normal blueberry-frosted king cake	4	good	Last Available: "2008-12"
-3470	ghostly wobbly bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
+3470	wobbly ghostly bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	Usain Bolt's deadly savvy Seasonal Beret	0		Mysticality Percent: +20, Weapon Damage: +5, Initiative: +80, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
@@ -3454,7 +3454,7 @@
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
 3489	stale beefy fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
-3490	toothsome half-sized bouncing glistening fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
+3490	half-sized toothsome bouncing glistening fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
 3491	flavorless bouncing slick fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3492	maroon shaking hale fish scimitar of Calamity Jane	0		Maximum HP: +20, Critical Hit Percent: +15
 3493	censurious Annie Oakley's fish stick	0		Critical Hit Percent: +20, Sleaze Resistance: +3
@@ -3462,9 +3462,9 @@
 3495	liquefied sea salt crystal	0		Effect: "Dreadful Heat", Effect Duration: 23
 3496	vacuum-sealed electrified mirror bazookafish bubble gum	0		Effect: "Artificially Sweet", Effect Duration: 61
 3497	aged bottle of Pete's Sake	4	awesome	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	miniature yummy shaking maroon canap&eacute;s	2	awesome	
 3502	dried blinking blinking thermos of brew	1	awesome	Effect: "Destructive Resolve", Effect Duration: 45, Last Available: "2011-12"
 3503	smooth watered-down glass of brandy	2	awesome	Last Available: "2011-12"
@@ -3493,7 +3493,7 @@
 3526	mirror spinning green smelly scratch 'n' sniff crossbow	0		Stench Spell Damage: +10, Last Available: "2008-11"
 3527	upside-down mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
-3529	skewed gray mutant cactus bud	0		
+3529	gray skewed mutant cactus bud	0		
 3530	mutant gila monster egg	0		
 3531	bouncing rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
@@ -3510,8 +3510,8 @@
 3543	blurry executive strapping depleted Grimacite gravy boat	0		Muscle: +5, Meat Drop: +40, Last Available: "2011-12"
 3544	squat stiffened dangerous depleted Grimacite weightlifting belt	0		Weapon Damage: +10, Damage Reduction: 1, Single Equip, Last Available: "2011-12"
 3545	slick depleted Grimacite grappling hook of terror	0		Moxie: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2011-12"
-3546	mirror lightning-fast depleted Grimacite ninja mask of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	squat healthy cool depleted Grimacite shinguards	0		Moxie: +5, Maximum HP Percent: +20, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	mirror lightning-fast depleted Grimacite ninja mask of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	squat healthy cool depleted Grimacite shinguards	0		Moxie: +5, Maximum HP Percent: +20, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	ghostly fireproof manspreader's depleted Grimacite astrolabe	0		Monster Level: +10, Hot Resistance: +3, Single Equip, Last Available: "2011-12"
 3549	huge dog trainer's Oprah's KoL Con Cinco Pi&ntilde;ata Bat	0		Maximum MP Percent: +50, Experience (familiar): +1, Softcore Only, Last Available: "2008-09"
 3550	curative propeller beanie	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, cap 7"
@@ -3520,10 +3520,10 @@
 3553	soggy seed packet	0		
 3554	squat glob of slime	0		
 3555	bland sea carrot	4	decent	
-3556	flavorless jumbo upside-down sea cucumber	5	decent	
+3556	jumbo flavorless upside-down sea cucumber	5	decent	
 3557	yummy sea avocado	3	awesome	
 3558	yummy sea lychee	3	awesome	
-3559	small yummy sea tangelo	2	awesome	
+3559	yummy small sea tangelo	2	awesome	
 3560	stale sea honeydew	4	decent	
 3561	aerosolized adjusted spinning pressurized potion of puissance	0		Effect: "Gummi-Grin", Effect Duration: 56
 3562	chilled pressurized potion of perspicacity	0		Effect: "Mighty Shout", Effect Duration: 51
@@ -3551,7 +3551,7 @@
 3585	bland gray gingerbread mutant bugbear	4	decent	Last Available: "2008-12"
 3586	weak hand-crafted wobbly oozenog	2	EPIC	Last Available: "2008-12"
 3587	diffused mirror sugar plum	0		Effect: "Abyssal Tears", Effect Duration: 44, Last Available: "2008-12"
-3588	magnetized Vulcanized wobbly mirror sugar banana	0		Effect: "Muscle Unbound", Effect Duration: 16, Last Available: "2008-12"
+3588	magnetized Vulcanized mirror wobbly sugar banana	0		Effect: "Muscle Unbound", Effect Duration: 16, Last Available: "2008-12"
 3589	quadruple-corrupted cyan sugar lime	0		Effect: "Ripping, Dripping", Effect Duration: 31, Last Available: "2008-12"
 3590	improved concentrated blurry sugar cherry	0		Effect: "Human-Plant Hybrid", Effect Duration: 64, Last Available: "2008-12"
 3591	lightning-fast studded Mer-kin hookspear	0		Damage Absorption: +80, Initiative: +40
@@ -3559,7 +3559,7 @@
 3593	Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	wet Mer-kin fastjuice	0		Effect: "Full of Vinegar", Effect Duration: 59
-3596	teal squat imitation crab crate	0		
+3596	squat teal imitation crab crate	0		
 3597	imitation crab meat	0		
 3598	imitation crab zoea	0		
 3599	blinking lion tamer's supercharged moist sailor's cap of the blizzard	0		Maximum MP Percent: +30, Experience (familiar): +2, Cold Spell Damage: +25, Familiar Effect: "stench atk"
@@ -3577,19 +3577,19 @@
 3611	modified sea grease	0		Effect: "Speed of the Internet", Effect Duration: 61
 3612	blinking sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	spinning battered Crimbo Crate	0		Last Available: "2008-12"
-3614	tumbling bouncing olive twitching claw	0		Last Available: "2008-12"
+3614	bouncing olive tumbling twitching claw	0		Last Available: "2008-12"
 3615	maroon rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	polarized warmed pulsating unstable DNA	0		Effect: "Florid Cheeks", Effect Duration: 23, Last Available: "2008-12"
-3618	purple The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	purple The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	tumbling chitinous pod	0		Last Available: "2008-12"
 3624	blinking jittery dangerous parasitic claw	0		Weapon Damage: +10, Last Available: "2008-12"
-3625	blinking parasitic tentacles of the empath	0		Familiar Weight: +5, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	parasitic headgnawer of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	blinking parasitic tentacles of the empath	0		Familiar Weight: +5, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	parasitic headgnawer of horror	0		Spooky Spell Damage: +25, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	parasitic strangleworm of the early riser	0		Adventures: +7, Last Available: "2008-12"
 3628	wobbly pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,11 +3598,11 @@
 3632	upside-down radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	miser's rosewater-soaked elven socks	0		Stench Resistance: +3, Meat Drop: +10, Last Available: "2008-12"
 3634	slick elven gloves of courage	0		Moxie: +10, Spooky Resistance: +3, Last Available: "2008-12"
-3635	lightning-fast Annie Oakley's festive holiday hat	0		Critical Hit Percent: +20, Initiative: +40, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	lightning-fast Annie Oakley's festive holiday hat	0		Critical Hit Percent: +20, Initiative: +40, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	upside-down purple fireproof patent shoes of the overflowing toilet	0		Stench Spell Damage: +50, Hot Resistance: +3, Last Available: "2008-12"
 3637	double-paned friendly gray bow tie	0		Familiar Weight: +3, Cold Resistance: +5, Last Available: "2008-12"
 3638	huge penguin thesaurus of the brazier of terror	0		Hot Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2008-12"
-3639	moldy snack-sized blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	snack-sized moldy blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	olive jamfish jam	0		
 3642	dragonfish caviar	0		
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	decent toast with jam	4	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	triple-distilled bad elven moonshine	8	decent	Last Available: "2008-12"
-3653	yummy huge knuckle sandwich	10	awesome	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	huge yummy knuckle sandwich	10	awesome	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	maroon electrified strapping psycho sweater	0		Muscle: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	tumbling Usain Bolt's plastic Mob Penguin	0		Initiative: +80, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	cyan plastic strand of DNA of Tarzan	0		Experience (Muscle): +3, Last Available: "2008-12"
 3660	up-at-dawn plastic chunk of depleted Grimacite	0		Adventures: +5, Last Available: "2008-12"
 3661	narrow container of Putty	0		Last Available: "2009-01"
-3662	double-paned Putty mitre	0		Cold Resistance: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	pulsating Putty leotard of the bloodbag of mayonnaise	0		Maximum HP: +100, Sleaze Spell Damage: +50, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	double-paned Putty mitre	0		Cold Resistance: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	pulsating Putty leotard of the bloodbag of mayonnaise	0		Maximum HP: +100, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Tesla Putty ball	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	frightening Putty snake of Gandalf of the blizzard	0		Spell Critical Percent: +20, Cold Spell Damage: +25, Spooky Damage: +5, Softcore Only, Last Available: "2009-01"
@@ -3639,27 +3639,27 @@
 3673	tolerable bottle of peppermint schnapps	4	good	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	blinking Mer-kin pressureglobe	0		
-3676	yellow ghostly Mer-kin foodbucket	0		
+3676	ghostly yellow Mer-kin foodbucket	0		
 3677	rosy-cheeked diving muff	0		Maximum HP Percent: +30, Single Equip
-3678	lousy weak salinated mint julep	2	decent	
+3678	weak lousy salinated mint julep	2	decent	
 3679	ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	big flavorless bouncing tempura carrot	5	decent	
+3684	flavorless big bouncing tempura carrot	5	decent	
 3685	flavorless snack-sized yellow tempura cucumber	2	decent	
 3686	delicious jumbo tempura avocado	5	awesome	
 3687	stale sea broccoli	3	decent	
-3688	massive stale sea cauliflower	8	decent	
+3688	stale massive sea cauliflower	8	decent	
 3689	rotten small tempura broccoli	2	crappy	
 3690	yummy cyan tempura cauliflower	4	awesome	
-3691	special bland half-sized gray skewed sea blueberry	2	decent	Effect: "Thunderheart", Effect Duration: 10
-3692	super-sized flavorless sea persimmon	5	decent	
-3693	deionized huge ghostly pressurized potion of perception	0		Effect: "Disdain of She-Who-Was", Effect Duration: 28
+3691	bland special half-sized gray skewed sea blueberry	2	decent	Effect: "Thunderheart", Effect Duration: 10
+3692	flavorless super-sized sea persimmon	5	decent	
+3693	deionized ghostly huge pressurized potion of perception	0		Effect: "Disdain of She-Who-Was", Effect Duration: 28
 3694	improved super-wet ionized pressurized potion of proficiency	0		Effect: "Always In Motion", Effect Duration: 33
 3695	olive squat friendly Mer-kin digpick	0		Familiar Weight: +3
-3696	yellow jittery anemone nematocyst	0		
+3696	jittery yellow anemone nematocyst	0		
 3697	gray high-pressure seltzer bottle	0		
 3698	velcro ore	0		
 3699	lime green teflon ore	0		
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	jittery perfumed lard-coated handwarmer	0		Sleaze Spell Damage: +25, Stench Resistance: +5, Single Equip
 3737	groovy weightlifter's lighter	0		Muscle: +15, Moxie Percent: +10
-3738	flavorless fancy blurry packet of beer nuts	3	decent	Effect: "Abyssal Tears", Effect Duration: 10
+3738	fancy flavorless blurry packet of beer nuts	3	decent	Effect: "Abyssal Tears", Effect Duration: 10
 3739	Boozehounds Anonymous token	0		
 3740	twirling squat handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,10 +3713,10 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	deionized oxidized twirling blinking concoction of clumsiness	0		Effect: "Phoenix, Right?", Effect Duration: 65
 3750	vampire pearl earring of Flo-Jo	0		Initiative: +100, Single Equip
-3751	stale gigantic chocolate chip brownies	7	decent	
+3751	gigantic stale chocolate chip brownies	7	decent	
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	electrified dry tumbling love song of vague ambiguity	0		Effect: "Salty Mouth", Effect Duration: 64, Last Available: "2009-02"
-3755	adjusted tumbling cyan love song of smoldering passion	0		Effect: "Peppermint Bite", Effect Duration: 11, Last Available: "2009-02"
+3755	adjusted cyan tumbling love song of smoldering passion	0		Effect: "Peppermint Bite", Effect Duration: 11, Last Available: "2009-02"
 3756	denatured love song of icy revenge	0		Effect: "Swimming Head", Effect Duration: 30, Last Available: "2009-02"
 3757	colloidal adjusted improved love song of sugary cuteness	0		Effect: "You Know Where to Go", Effect Duration: 50, Last Available: "2009-02"
 3758	corrupted flattened love song of disturbing obsession	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 31, Last Available: "2009-02"
@@ -3726,7 +3726,7 @@
 3762	smooth vampire pearl necklace	0		Moxie: +15, Single Equip
 3763	smooth high-proof slug of vodka	9	awesome	
 3764	artisanal slug of rum	3	EPIC	
-3765	hand-crafted watered-down slug of shochu	2	EPIC	
+3765	watered-down hand-crafted slug of shochu	2	EPIC	
 3766	hand-crafted boozy screwdiver	5	EPIC	
 3767	mediocre lime green dew yoana lei	3	decent	
 3768	hand-crafted lychee chuhai	3	EPIC	
@@ -3751,10 +3751,10 @@
 3787	twirling wine-soaked bone chips	0		Class: "Pastamancer"
 3788	ghostly crumbling rat skull	0		Class: "Pastamancer"
 3789	squat twitching trigger finger	0		Class: "Pastamancer"
-3799	jittery narrow Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
+3799	narrow jittery Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	squat aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	narrow blue twirling toasty Annie Oakley's rock-hard Mer-kin roundshield	0		Damage Reduction: 19, Critical Hit Percent: +20, Hot Damage: +5
 3804	nasty Mer-kin breastplate of incineration	0		Hot Spell Damage: +50, Stench Damage: +5
 3805	twirling twirling flame-retardant Mer-kin sneakmask of Leguizamo	0		Monster Level: +20, Hot Resistance: +1, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3780,14 +3780,14 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	half-sized normal tumbling tempura radish	2	good	
+3829	normal half-sized tumbling tempura radish	2	good	
 3830	teal forbidden water-polo cap	0		Spell Damage Percent: +50, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable Typical Tavern swill	4	good	
-3832	perfectly mixed distilled tumbling tropical swill	5	EPIC	
+3832	distilled perfectly mixed tumbling tropical swill	5	EPIC	
 3833	tolerable fruity girl swill	3	good	
-3834	bad watered-down spinning blinking blended swill	2	decent	
+3834	bad watered-down blinking spinning blended swill	2	decent	
 3835	wobbly costume wardrobe	0		Softcore Only
-3836	reassuring horrifying flame-wreathed Elvish sunglasses of Flo-Jo	0		Hot Spell Damage: +10, Spooky Damage: +25, Spooky Resistance: +1, Initiative: +100, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	reassuring horrifying flame-wreathed Elvish sunglasses of Flo-Jo	0		Hot Spell Damage: +10, Spooky Damage: +25, Spooky Resistance: +1, Initiative: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	bouncing dance instructor's anniversary safety glass vest	0		Experience Percent (Moxie): +10
 3838	lion tamer's anniversary burlap belt	0		Experience (familiar): +2
 3839	anniversary balsa wood socks of the dark arts	0		Spell Damage Percent: +100
@@ -3848,7 +3848,7 @@
 3894	chilled vial of teal slime	0		Effect: "Morninja", Effect Duration: 46
 3895	cold-filtered vial of indigo slime	0		Effect: "Texas Elegance", Effect Duration: 59
 3896	magnetized unsweetened vial of slime	0		Effect: "Phairly Pheromonal", Effect Duration: 43
-3897	unsweetened nitrogenated yellow narrow vial of brown slime	0		Effect: "Ponderous Potency", Effect Duration: 52
+3897	unsweetened nitrogenated narrow yellow vial of brown slime	0		Effect: "Ponderous Potency", Effect Duration: 52
 3898	bottle of G&uuml;-Gone	0		
 3901	bouncing seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
@@ -3912,7 +3912,7 @@
 3960	yellow hardy designer sunglasses	0		Maximum HP: +50, Single Equip
 3961	squat prompt opera glasses of the empath	0		Familiar Weight: +5, Adventures: +3
 3962	designer handbag	0		
-3963	wobbly tumbling Clan pool table	0		Free Pull, Last Available: "2009-05"
+3963	tumbling wobbly Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
 3965	double-magnetized cube of billiard chalk	0		Effect: "Sleazy Jellied", Effect Duration: 24
 3966	maroon horrifying savvy hot-ass club of chilblains	0		Mysticality Percent: +20, Cold Damage: +25, Spooky Damage: +25, Class: "Seal Clubber"
@@ -3952,7 +3952,7 @@
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	denatured agua de vida	1	crappy	Effect: "Third Based", Effect Duration: 40, Last Available: "2009-06"
 4002	Lo Pan's tortoboggan shield of doom	0		Spell Critical Percent: +30, Spooky Spell Damage: +50, Damage Reduction: 6
-4003	tumbling spinning bottle of moontan lotion	0		
+4003	spinning tumbling bottle of moontan lotion	0		
 4004	soup-chucks of the storm	0		Maximum MP Percent: +40
 4005	warmed adjusted ballast turtle	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 46
 4006	memory of some amino acids	0		Last Available: "2009-06"
@@ -3985,20 +3985,20 @@
 4033	skewed memory of a stone half-circle	0		Last Available: "2009-06"
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	narrow memory of a crystal	0		Last Available: "2009-06"
-4036	lime green shaking caustic slime nodule	0		
-4037	small adequate bouncing slimy sweetbreads	2	good	
+4036	shaking lime green caustic slime nodule	0		
+4037	adequate small bouncing slimy sweetbreads	2	good	
 4038	acceptable wobbly slimy fermented bile bladder	4	good	
 4039	altered jittery slimy alveolus	1		
 4040	cyan memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	blurry executive sage pig-iron helm	0		Mysticality Percent: +10, Meat Drop: +40, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	prompt double-paned pig-iron shinguards	0		Cold Resistance: +5, Adventures: +3, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	blurry executive sage pig-iron helm	0		Mysticality Percent: +10, Meat Drop: +40, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	prompt double-paned pig-iron shinguards	0		Cold Resistance: +5, Adventures: +3, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	yellow greasy sharpshooter's pig-iron bracers	0		Critical Hit Percent: +10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2009-06"
 4044	fuchsia wumpus hair	0		Last Available: "2009-06"
 4045	pulsating wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	narrow narrow healthy wumpus-hair whip	0		Maximum HP Percent: +20, Last Available: "2009-06"
-4048	olive asbestos-lined quilted wumpus-hair wig of the sweet-tooth	0		Damage Absorption: +40, Hot Resistance: +5, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	zippy wicked wumpus-hair loincloth of the early riser	0		Spell Damage: +5, Initiative: +20, Adventures: +7, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	olive asbestos-lined quilted wumpus-hair wig of the sweet-tooth	0		Damage Absorption: +40, Hot Resistance: +5, Candy Drop: +100, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	zippy wicked wumpus-hair loincloth of the early riser	0		Spell Damage: +5, Initiative: +20, Adventures: +7, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	ruddy smartaleck's wumpus-hair sweater	0		Moxie Percent: +30, Maximum HP Percent: +40, Last Available: "2009-06"
 4051	tumbling ribald ring of teleportation	0		Sleaze Damage: +10, Single Equip
 4052	glass of baboon milk	1	good	Last Available: "2009-06"
@@ -4018,7 +4018,7 @@
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
-4069	gray squat essence of	0		Last Available: "2009-06"
+4069	squat gray essence of	0		Last Available: "2009-06"
 4070	narrow essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	ghostly essence of	0		Last Available: "2009-06"
@@ -4040,7 +4040,7 @@
 4088	X-37 gun	0		Last Available: "2009-06"
 4089	activated neurostim pill	0		Effect: "Ticking Clock", Effect Duration: 25, Last Available: "2009-06"
 4090	diffused physiostim pill	0		Effect: "Grrrrrrreat!", Effect Duration: 68, Last Available: "2009-06"
-4091	blinking spinning slimy cyst	0		
+4091	spinning blinking slimy cyst	0		
 4092	wobbly small slimy cyst	0		
 4093	spinning medium slimy cyst	0		
 4094	fuchsia slimy cyst	0		
@@ -4085,7 +4085,7 @@
 4133	activated extra-oxidized lime green tempura air	0		Effect: "Human-Insect Hybrid", Effect Duration: 39
 4134	nitrogenated nitrogenated pressurized potion of pneumaticity	0		Effect: "Boletus Swoletus", Effect Duration: 44
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	wool lard-coated vibrating curative Bag o' Tricks	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, Cold Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	wool lard-coated vibrating curative Bag o' Tricks	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, Cold Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4130,14 +4130,14 @@
 4178	cyan rock-hard sugar shotgun	0		Damage Reduction: 5, Last Available: "2009-09"
 4179	scandalous sugar shillelagh	0		Sleaze Damage: +5, Last Available: "2009-09"
 4180	squat nasty sugar shank	0		Stench Damage: +5, Last Available: "2009-09"
-4181	frosty sugar chapeau of extreme caution of courage	0		Monster Level: -25, Cold Spell Damage: +10, Spooky Resistance: +3, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	Van der Graaf sugar shorts	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
-4183	twirling narrow yellow sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4181	frosty sugar chapeau of extreme caution of courage	0		Monster Level: -25, Cold Spell Damage: +10, Spooky Resistance: +3, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	Van der Graaf sugar shorts	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4183	yellow narrow twirling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	pulsating slime convention flyers	0		
 4186	slime convention coupons	0		
 4187	coward's slime convention pin	0		Monster Level: -20
-4188	narrow blinking slime convention t-shirt	0		
+4188	blinking narrow slime convention t-shirt	0		
 4189	wobbly squat inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	auspicious sugar shirt	0		Item Drop: +10, Last Available: "2009-09"
@@ -4150,7 +4150,7 @@
 4198	sea lasso	0		
 4199	deadly Fonzie's Herculean sea cowboy hat	0		Experience (Muscle): +1, Experience (Moxie): +1, Weapon Damage: +5, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
-4201	narrow teal upside-down gill rings	0		Familiar Weight: +5
+4201	teal upside-down narrow gill rings	0		Familiar Weight: +5
 4202	urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
 4204	tumbling lime green Mer-kin cheatsheet	0		
@@ -4178,7 +4178,7 @@
 4226	Star of Bravery of doom	0		Spooky Spell Damage: +50, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	bouncing amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	bouncing amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	green bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4202,19 +4202,19 @@
 4250	fisherman's sack	0		
 4251	olive fish-oil smoke bomb	0		
 4252	wet deionized vial of squid ink	0		Effect: "Bright!", Effect Duration: 16
-4253	oxidized tumbling pulsating potion of speed	0		Effect: "Nigh-Invincible", Effect Duration: 12
+4253	oxidized pulsating tumbling potion of speed	0		Effect: "Nigh-Invincible", Effect Duration: 12
 4254	bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	energized Vulcanized purple sap	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 22, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	tasty shaking chocolate-covered scarab beetle	3	awesome	Last Available: "2009-10"
 4259	hand-crafted mulled cider	3	EPIC	Last Available: "2009-10"
-4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	blinking pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	upside-down mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	blinking pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	upside-down mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	pulsating Ax of L'rose	0		Last Available: "2009-10"
-4264	scorching bark boxers	0		Hot Damage: +25, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	shellacked bark beret	0		Damage Reduction: 7, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	scorching bark boxers	0		Hot Damage: +25, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	shellacked bark beret	0		Damage Reduction: 7, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	yellow ruddy bark bracelet	0		Maximum HP Percent: +40, Single Equip
 4267	wholesome Krakrox's Loincloth of the pedagogue	0		Experience: +3, Maximum HP Percent: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	skewed gray Rosewater's wizardly Galapagosian Cuisses	0		Mysticality: +25, Mysticality Percent: +30, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	green steel-toed supercool Ass-Stompers of Violence of the wise owl	0		Mysticality: +20, Moxie Percent: +20, Damage Reduction: 9, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	inspector's educational Brand of Violence of the boozehound	0		Experience: +1, Item Drop: +15, Booze Drop: +100, Conditional Skill (Equipped): "Brand"
 4299	ghostly horrifying nippy supercharged Novelty Belt Buckle of Violence	0		Maximum MP Percent: +30, Cold Damage: +10, Spooky Damage: +25, Single Equip
-4300	bouncing twirling coward's Da Vinci's Lens of Violence of the businessman	0		Experience (Mysticality): +5, Monster Level: -20, Meat Drop: +50, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	bouncing twirling coward's Da Vinci's Lens of Violence of the businessman	0		Experience (Mysticality): +5, Monster Level: -20, Meat Drop: +50, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	beefcake's Pigsticker of Violence of James Dean of bravery	0		Muscle: +25, Experience (Moxie): +3, Spooky Resistance: +5
-4302	lion tamer's boxer's strapping Jodhpurs of Violence	0		Muscle: +5, Muscle Percent: +10, Experience (familiar): +2, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	lion tamer's boxer's strapping Jodhpurs of Violence	0		Muscle: +5, Muscle Percent: +10, Experience (familiar): +2, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	Sinatra's boxer's thinker's Cold Stone of Hatred	0		Mysticality: +10, Muscle Percent: +10, Experience (Moxie): +5, Conditional Skill (Equipped): "Chilling Grip"
 4304	Sinatra's supercool Girdle of Hatred of the businessman	0		Moxie Percent: +20, Experience (Moxie): +5, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	twirling blinking inspector's wool resourceful Staff of Simmering Hatred	0		Maximum MP: +50, Cold Resistance: +1, Item Drop: +15
-4306	healthy hardened Pantaloons of Hatred of terror	0		Damage Reduction: 3, Maximum HP Percent: +20, Spooky Spell Damage: +10, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	healthy hardened Pantaloons of Hatred of terror	0		Damage Reduction: 3, Maximum HP Percent: +20, Spooky Spell Damage: +10, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	energetic beefy Fuzzy Slippers of Hatred of terror	0		Muscle: +10, Maximum MP Percent: +20, Spooky Spell Damage: +10, Single Equip
-4308	wool rosy-cheeked Lens of Hatred of bravery	0		Maximum HP Percent: +30, Cold Resistance: +1, Spooky Resistance: +5, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	wool rosy-cheeked Lens of Hatred of bravery	0		Maximum HP Percent: +30, Cold Resistance: +1, Spooky Resistance: +5, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	perfumed lard-coated banded Treads of Loathing	0		Damage Absorption: +100, Sleaze Spell Damage: +25, Stench Resistance: +5, Single Equip
 4310	slick brainy Scepter of Loathing of James Dean	0		Mysticality: +5, Moxie: +10, Experience (Moxie): +3
 4311	weightlifter's Belt of Loathing of the brute of the storm	0		Muscle: +15, Muscle Percent: +30, Maximum MP Percent: +40, Single Equip
@@ -4277,7 +4277,7 @@
 4325	twirling inspector's aromatic Gravyskin Belt of the Sauceblob of the brute	0		Muscle Percent: +30, Stench Resistance: +1, Item Drop: +15, Class: "Sauceror", Single Equip
 4326	narrow Tesla wholesome Bling of the New Wave of the businessman	0		Maximum HP Percent: +10, Meat Drop: +50, MP Regen Min: 7, MP Regen Max: 10, Class: "Disco Bandit", Single Equip
 4327	Usain Bolt's sizzling La Hebilla del Cintur&oacute;n de Lopez of the empath	0		Familiar Weight: +5, Hot Damage: +10, Initiative: +80, Class: "Accordion Thief", Single Equip
-4328	tumbling upside-down suspicious stocking	0		Free Pull, Last Available: "2009-12"
+4328	upside-down tumbling suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	stale super-sized candy kneecapping stick	5	decent	Last Available: "2009-12"
 4331	spoiled snack-sized licorice garrote	2	crappy	Last Available: "2009-12"
@@ -4294,12 +4294,12 @@
 4342	chilled liquefied Polka Pop	0		Effect: "In the Limelight", Effect Duration: 39, Last Available: "2009-12"
 4343	blurry Crimbuck	0		Last Available: "2009-12"
 4344	mirror Crimbo wreath	0		Last Available: "2009-12"
-4345	shaking jittery narrow string of Crimbo lights	0		Last Available: "2009-12"
+4345	narrow jittery shaking string of Crimbo lights	0		Last Available: "2009-12"
 4346	maroon blurry plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	purple gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	spinning snow hat of the sewer	0		Stench Damage: +25, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	rosy-cheeked snow pants	0		Maximum HP Percent: +30, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	spinning snow hat of the sewer	0		Stench Damage: +25, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	rosy-cheeked snow pants	0		Maximum HP Percent: +30, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	mansplainer's snow belly	0		Monster Level: +15, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	shaking Crimbough	0		Last Available: "2009-12"
@@ -4310,11 +4310,11 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	jittery A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	tiny stale bouncing expired can of franks 'n' beans	1	decent	Last Available: "2009-12"
-4361	artisanal boozy purple expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
+4361	boozy artisanal purple expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	huge elf resistance button	0		Last Available: "2009-12"
 4364	dry alkaline elven suicide capsule	0		Effect: "Sealed Brain", Effect Duration: 51, Last Available: "2009-12"
-4365	thick normal penguin focaccia bread	5	good	Last Available: "2009-12"
+4365	normal thick penguin focaccia bread	5	good	Last Available: "2009-12"
 4366	high-proof hand-crafted herringcello	8	EPIC	Last Available: "2009-12"
 4367	acceptable weak elven cellocello	2	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	shellacked beefy pocketwatch on a chain	0		Muscle: +10, Damage Reduction: 7, Last Available: "2009-12"
 4386	perfumed occult cement sandals	0		Spell Damage Percent: +25, Stench Resistance: +5, Single Equip, Last Available: "2009-12"
 4387	teal blinking Herculean night-vision goggles of chilblains	0		Experience (Muscle): +1, Cold Damage: +25, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	blinking Lo Pan's peanut brittle shield	0		Spell Critical Percent: +30, Damage Reduction: 3, Last Available: "2009-12"
 4390	stanky Red Rover BB gun of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +25, Last Available: "2009-12"
-4391	Jeselnik's red-and-green sweater	0		Sleaze Damage: +25, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	Jeselnik's red-and-green sweater	0		Sleaze Damage: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	pulsating Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	oxidized energized upside-down Crimbo peppermint bark	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 53, Last Available: "2009-12"
 4394	energized red bouncing Crimbo fudge	0		Effect: "You Know Where to Go", Effect Duration: 16, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	blurry cheese ball	0		Last Available: "2010-01"
 4399	mirror cheese sword of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2010-01"
-4400	cheese diaper of terror	0		Spooky Spell Damage: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	cheese diaper of terror	0		Spooky Spell Damage: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	family-friendly cheese wheel	0		Sleaze Resistance: +1, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	purple cheese eye of the cheetah	0		Initiative: +60, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	purple cheese eye of the cheetah	0		Initiative: +60, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	lion tamer's smooth Staff of Queso Escusado	0		Moxie: +15, Experience (familiar): +2, Item Drop: +5, Softcore Only, Last Available: "2010-01"
 4405	shaking foreign box	0		
 4406	yellow The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4360,7 +4360,7 @@
 4409	yellow Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	miniature decent quantum taco	0		Last Available: "2010-10"
+4412	decent miniature quantum taco	0		Last Available: "2010-10"
 4413	bad enchanted Schr&ouml;dinger's thermos	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 40, Last Available: "2010-04"
 4414	blue colorful plastic ball	0		Last Available: "2010-01"
 4415	spinning beefcake's sealhide hood	0		Muscle: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4396,7 +4396,7 @@
 4448	mixed Instant Karma	1	decent	Effect: "Morbidi Tea", Effect Duration: 5
 4449	tumbling painting of a landscape	0		Last Available: "2010-04"
 4450	bouncing map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	green executive pointy hat	0		Meat Drop: +40, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	green executive pointy hat	0		Meat Drop: +40, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	greedy machetito	0		Meat Drop: +20, Last Available: "2010-04"
 4453	Fonzie's lawnmower blade	0		Experience (Moxie): +1, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4407,7 +4407,7 @@
 4459	blue aromatic snailmail breeches of the sewer	0		Stench Damage: +25, Stench Resistance: +1, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
 4460	upside-down lime green lightning-fast brawny snailmail hauberk	0		Muscle Percent: +20, Initiative: +40
 4461	dry seal-brain elixir	0		Effect: "Celestial Sheen", Effect Duration: 39
-4462	enhanced lime green twirling chocolate seal-clubbing club	0		Effect: "Become Superficially interested", Effect Duration: 31
+4462	enhanced twirling lime green chocolate seal-clubbing club	0		Effect: "Become Superficially interested", Effect Duration: 31
 4463	non-magnetized alkaline electrified bouncing chocolate turtle totem	0		Effect: "Oriental Mysticism", Effect Duration: 61
 4464	corrupted boiled chocolate pasta spoon	0		Effect: "Ancient Protected", Effect Duration: 54
 4465	wet modified fuchsia chocolate saucepan	0		Effect: "Strength of Ten Ettins", Effect Duration: 20
@@ -4416,15 +4416,15 @@
 4468	jittery Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	fuchsia BRICKO eye brick	0		Last Available: "2010-02"
-4471	aromatic BRICKO hat	0		Stench Resistance: +1, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	smooth BRICKO pants	0		Moxie: +15, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	aromatic BRICKO hat	0		Stench Resistance: +1, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	smooth BRICKO pants	0		Moxie: +15, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	bouncing electrified BRICKO sword	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-02"
 4474	tumbling BRICKO ooze	0		Last Available: "2010-02"
 4475	jittery BRICKO bat	0		Last Available: "2010-02"
 4476	tumbling BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4436,11 +4436,11 @@
 4488	BRICKO trunk	0		Last Available: "2010-02"
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
-4491	tumbling shaking olive BRICKO brick	0		Last Available: "2010-02"
+4491	olive tumbling shaking BRICKO brick	0		Last Available: "2010-02"
 4492	blinking BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
-4494	twirling fuchsia BRICKO reactor	0		Last Available: "2010-02"
-4495	narrow cyan BRICKO egg	0		Last Available: "2010-02"
+4494	fuchsia twirling BRICKO reactor	0		Last Available: "2010-02"
+4495	cyan narrow BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	super-moist alkaline recording of The Ballad of Richie Thingfinder	0		Effect: "Stick Emporium Membership", Effect Duration: 63
 4498	colloidal moist recording of Benetton's Medley of Diversity	0		Effect: "Chorale of Companionship", Effect Duration: 40
@@ -4455,21 +4455,21 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	electrified dry &quot;DRINK ME&quot; potion	0		Effect: "Mad at Science", Effect Duration: 46, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	miniature moldy walrus ice cream	2	crappy	Last Available: "2010-03"
+4510	moldy miniature walrus ice cream	2	crappy	Last Available: "2010-03"
 4511	moldy blinking beautiful soup	3	crappy	Last Available: "2010-03"
 4512	skewed eggman noodles	0		Last Available: "2010-03"
 4513	bouncing Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	special spoiled twirling Humpty Dumplings	4	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2010-03"
 4515	delicious small Lobster <i>qua</i> Grill	2	awesome	Last Available: "2010-03"
-4516	extra-dry hand-crafted olive jittery missing wine	5	EPIC	Last Available: "2010-03"
-4517	yummy big matter custard	5	awesome	Last Available: "2010-03"
+4516	hand-crafted extra-dry jittery olive missing wine	5	EPIC	Last Available: "2010-03"
+4517	big yummy matter custard	5	awesome	Last Available: "2010-03"
 4518	chilled colloidal altered huge comfit?	0		Effect: "Demonic Taint", Effect Duration: 65, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	censurious electrified flamingo mallet	0		Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-03"
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	narrow Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	skewed Usain Bolt's eye of the Tiger-lily of Gandalf	0		Spell Critical Percent: +20, Initiative: +80, Last Available: "2010-03"
-4524	supercharged wig of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	supercharged wig of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	stale donut	3	decent	Last Available: "2010-03"
 4526	moldy bucket of honey	4	crappy	Last Available: "2010-03"
 4527	ruddy elephant stinger of the empath	0		Maximum HP Percent: +40, Familiar Weight: +5, Last Available: "2010-03"
@@ -4477,15 +4477,15 @@
 4529	savvy wizardly snapdragon pistil	0		Mysticality: +25, Mysticality Percent: +20, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	decent rook cookie	4	good	Last Available: "2010-03"
-4532	enchanted yummy bishop cookie	4	awesome	Effect: "Oiled Skin", Effect Duration: 45, Last Available: "2010-03"
-4533	decent diet knight cookie	1	good	Last Available: "2010-03"
+4532	yummy enchanted bishop cookie	4	awesome	Effect: "Oiled Skin", Effect Duration: 45, Last Available: "2010-03"
+4533	diet decent knight cookie	1	good	Last Available: "2010-03"
 4534	stale super-sized upside-down king cookie	5	decent	Last Available: "2010-03"
-4535	decent miniature skewed gray queen cookie	2	good	Effect: "Towering Strength", Last Available: "2010-03"
+4535	miniature decent skewed gray queen cookie	2	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	spinning beefy insane tophat	0		Muscle: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	blurry lime green healthy educational helm of the knight	0		Experience: +1, Maximum HP Percent: +20, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	spinning beefy insane tophat	0		Muscle: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	blurry lime green healthy educational helm of the knight	0		Experience: +1, Maximum HP Percent: +20, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	narrow wristwatch of the knight of the wise owl of Tarzan	0		Mysticality: +20, Experience (Muscle): +3, Single Equip, Last Available: "2010-03"
-4540	wobbly supercool trousers of the knight of extreme caution	0		Moxie Percent: +20, Monster Level: -25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	wobbly supercool trousers of the knight of extreme caution	0		Moxie Percent: +20, Monster Level: -25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	shaking mirror scorching tophat	0		Hot Damage: +25, Familiar Effect: "1xBarrr, cap 25"
 4542	cool tie	0		Moxie: +5, Single Equip
 4543	tuxedo pants of the detective	0		Item Drop: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4516,17 +4516,17 @@
 4568	moldy a dance upon the palate	4	crappy	Last Available: "2010-04"
 4569	fancy massive delicious prehistoric meteorite jawbreaker	10	awesome	Effect: "Feet of Grapefruit", Effect Duration: 5, Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	stale low-calorie squirmy violent party snack	1	decent	Last Available: "2010-04"
+4571	low-calorie stale squirmy violent party snack	1	decent	Last Available: "2010-04"
 4572	censurious can-you-dig-it?	0		Sleaze Resistance: +3, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	yellow blurry panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	Vulcanized colloidal Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Muscle Unbound", Effect Duration: 40, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of dire peril	0		Weapon Damage: +20, Last Available: "2010-04"
-4581	ghostly shellacked personal trainer's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	ghostly shellacked personal trainer's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	cyan fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	special bland six wedges of goat cheese	4	decent	Effect: "Salty Dogs", Effect Duration: 25
@@ -4550,8 +4550,8 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	upside-down bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	cyan MacGyver's Fonzie's bottle of Goldschn&ouml;ckered	0		Experience (Moxie): +1, Maximum MP: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
-4606	small flavorless sun-dried tofu	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	cyan MacGyver's Fonzie's bottle of Goldschn&ouml;ckered	0		Experience (Moxie): +1, Maximum MP: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4606	flavorless small sun-dried tofu	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	bad soyburger juice	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	ghostly essential tofu	0		Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	yellow souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	Crown of Thrones of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2010-05"
-4615	lousy weak Cinco Mayo Lager	2	decent	Last Available: "2010-05"
+4615	weak lousy Cinco Mayo Lager	2	decent	Last Available: "2010-05"
 4616	olive Underworld sapling	0		Last Available: "2009-10"
 4617	upside-down pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4568,21 +4568,21 @@
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	spinning Game Grid token	0		Last Available: "2010-06"
 4622	blue Game Grid ticket	0		Last Available: "2010-06"
-4623	alkaline ghostly lime green chocolate-covered caviar	0		Effect: "Kernel Panic!", Effect Duration: 33, Last Available: "2020-09"
+4623	alkaline lime green ghostly chocolate-covered caviar	0		Effect: "Kernel Panic!", Effect Duration: 33, Last Available: "2020-09"
 4624	gigantic stale pawn cookie	10	decent	Last Available: "2010-06"
 4625	diluted squat coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	cyan superduperball	0		Last Available: "2010-06"
 4627	gray finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	plastic spider ring of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	plastic spider ring of the wise owl	0		Mysticality: +20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	jittery therapeutic plastic kazoo	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-06"
 4631	jittery tumbling inflatable baseball bat of the glutton	0		Food Drop: +100, Last Available: "2010-06"
-4632	sinister googly-star hat of the sewer	0		Spell Damage: +10, Stench Damage: +25, Familiar Effect: "atk", Last Available: "2010-06"
+4632	sinister googly-star hat of the sewer	0		Spell Damage: +10, Stench Damage: +25, Last Available: "2010-06", Familiar Effect: "atk"
 4633	jittery Jeselnik's Da Vinci's googly-ball hat	0		Experience (Mysticality): +5, Sleaze Damage: +25, Last Available: "2010-06"
 4634	dance instructor's googly-heart hat of the sewer	0		Experience Percent (Moxie): +10, Stench Damage: +25, Last Available: "2010-06"
 4635	horrifying super-sweet boom box of Leguizamo	0		Monster Level: +20, Spooky Damage: +25, Four Songs, Last Available: "2010-06"
 4636	pulsating pulsating Game Grid valued membership card	0		Last Available: "2010-06"
-4637	narrow red frightening lion tamer's energetic sinister demon mask	0		Maximum MP Percent: +20, Experience (familiar): +2, Spooky Damage: +5, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	narrow red frightening lion tamer's energetic sinister demon mask	0		Maximum MP Percent: +20, Experience (familiar): +2, Spooky Damage: +5, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	brawny streetfighting champion's belt of the businessman of the glutton	0		Muscle Percent: +20, Meat Drop: +50, Food Drop: +100, Single Equip, Last Available: "2010-06"
 4639	jittery lion tamer's Tesla Space Trip safety headphones of the cougar	0		Moxie: +20, Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2010-06"
 4640	arcane researcher's LARP carp	0		Experience Percent (Mysticality): +10
@@ -4594,8 +4594,8 @@
 4646	studded stylish thinker's Meteoid ice beam	0		Mysticality: +10, Moxie: +25, Damage Absorption: +80, Last Available: "2011-12"
 4647	red MacGyver's wicked Dungeon Fist gauntlet of the glutton	0		Spell Damage: +5, Maximum MP: +100, Food Drop: +100, Last Available: "2011-06"
 4648	skewed Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	frosty ironic knit cap of the dark arts	0		Spell Damage Percent: +100, Cold Spell Damage: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	pulsating ironic sunglasses	0		Single Equip
@@ -4617,18 +4617,18 @@
 4669	boxer's hilarious comedy prop	0		Muscle Percent: +10
 4670	beer-scented teddy bear	0		
 4671	smooth booze-soaked cherry	3	awesome	
-4672	gray jittery comfy pillow	0		
+4672	jittery gray comfy pillow	0		
 4673	normal lime green marshmallow	4	good	
-4674	stale small sponge cake	2	decent	
-4675	acceptable boozy gin-soaked blotter paper	5	good	
+4674	small stale sponge cake	2	decent	
+4675	boozy acceptable gin-soaked blotter paper	5	good	
 4676	twirling tree-holed coin	0		
 4677	blurry unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	blurry smoked potsherd	0		
 4681	squat Fonzie's pottery shield	0		Experience (Moxie): +1, Damage Reduction: 3, Last Available: "2010-09"
-4682	lightning-fast veiny pottery hat	0		Maximum HP: +10, Initiative: +40, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	skewed ghostly Usain Bolt's reassuring pottery training pants	0		Spooky Resistance: +1, Initiative: +80, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	lightning-fast veiny pottery hat	0		Maximum HP: +10, Initiative: +40, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	skewed ghostly Usain Bolt's reassuring pottery training pants	0		Spooky Resistance: +1, Initiative: +80, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	brainy pottery club	0		Mysticality: +5, Last Available: "2010-09"
 4685	tumbling pottery yo-yo of wisdom	0		Mysticality: +15, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	pulsating fossilized torso	0		Last Available: "2010-09"
 4694	narrow fossilized spine	0		Last Available: "2010-09"
 4695	fuchsia affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	horrifying frightening foul-smelling Greatest American Pants	0		Stench Damage: +10, Spooky Damage: 30, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	horrifying frightening foul-smelling Greatest American Pants	0		Stench Damage: +10, Spooky Damage: 30, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	blurry smooth fossilized necklace	0		Moxie: +15, Last Available: "2010-09"
 4698	imp air	0		
 4699	jittery bus pass	0		
@@ -4660,18 +4660,18 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	adequate massive lemon popsicle	10	good	
-4715	stale low-calorie popsicle	1	decent	
-4716	low-calorie decent strawberry popsicle	1	good	
-4717	small adequate liver popsicle	2	good	
+4715	low-calorie stale popsicle	1	decent	
+4716	decent low-calorie strawberry popsicle	1	good	
+4717	adequate small liver popsicle	2	good	
 4718	bouncing crafty mariachi hat	0		Maximum MP: +10, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of the pedagogue	0		Experience: +3, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	flavorless liver and let pie	4	decent	Last Available: "2010-10"
-4723	enchanted tasty badass pie	3	awesome	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2010-10"
+4723	tasty enchanted badass pie	3	awesome	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2010-10"
 4724	flavorless shoo-fish pie	4	decent	Last Available: "2010-10"
-4725	moldy small bouncing piping organ pie	2	crappy	Last Available: "2010-10"
-4726	stale special igloo pie	4	decent	Effect: "Bright!", Effect Duration: 35, Last Available: "2010-10"
+4725	small moldy bouncing piping organ pie	2	crappy	Last Available: "2010-10"
+4726	special stale igloo pie	4	decent	Effect: "Bright!", Effect Duration: 35, Last Available: "2010-10"
 4727	toothsome spinning squat teal stomach turnover	4	awesome	Last Available: "2010-10"
 4728	delicious big blue dead lights pie	5	awesome	Last Available: "2010-10"
 4729	adequate throbbing organ pie	4	good	Last Available: "2010-10"
@@ -4699,8 +4699,8 @@
 4751	rosy-cheeked boning knife	0		Maximum HP Percent: +30, Last Available: "2010-10"
 4752	Usain Bolt's bone crusher	0		Initiative: +80, Last Available: "2010-10"
 4753	MacGyver's bone spurs	0		Maximum MP: +100, Single Equip, Last Available: "2010-10"
-4754	tumbling double-paned cool bonedanna	0		Moxie: +5, Cold Resistance: +5, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	Da Vinci's boneana hammock of the blizzard	0		Experience (Mysticality): +5, Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	tumbling double-paned cool bonedanna	0		Moxie: +5, Cold Resistance: +5, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	Da Vinci's boneana hammock of the blizzard	0		Experience (Mysticality): +5, Cold Spell Damage: +25, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	bouncing Stabonic scroll	0		Last Available: "2010-10"
 4758	super-diffused pickled candy skeleton	0		Effect: "Feline Ferocity", Effect Duration: 31, Last Available: "2020-09"
@@ -4708,8 +4708,8 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	mirror pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	stale huge bouncing pumpkin pie	10	decent	Last Available: "2010-11"
-4764	watered-down perfectly mixed pumpkin beer	2	EPIC	Last Available: "2010-11"
+4763	huge stale bouncing pumpkin pie	10	decent	Last Available: "2010-11"
+4764	perfectly mixed watered-down pumpkin beer	2	EPIC	Last Available: "2010-11"
 4765	dry quadruple-oxidized pumpkin juice	0		Effect: "Good Karma", Effect Duration: 21, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	family-friendly banded shin gourds	0		Damage Absorption: +100, Sleaze Resistance: +1, Single Equip, Last Available: "2010-11"
@@ -4738,22 +4738,22 @@
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
-4832	twirling ghostly robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
+4832	ghostly twirling robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	yellow robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	blurry mirror robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	green robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	normal diet ghostly triangular CRIMBCOOKIE	1	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	diet normal ghostly triangular CRIMBCOOKIE	1	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	small bland square CRIMBCOOKIE	2	decent	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	Temple Grandin's razor-sharp bindlestocking of dire peril	0		Weapon Damage: +20, Weapon Damage Percent: +25, Familiar Weight: +7, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	dance instructor's groovy Uncle Hobo's stocking cap	0		Moxie Percent: +10, Experience Percent (Moxie): +10, Familiar Effect: "atk", Last Available: "2010-12"
+4845	dance instructor's groovy Uncle Hobo's stocking cap	0		Moxie Percent: +10, Experience Percent (Moxie): +10, Last Available: "2010-12", Familiar Effect: "atk"
 4846	prompt boxer's Uncle Hobo's epic beard	0		Muscle Percent: +10, Adventures: +3, Single Equip, Last Available: "2010-12"
-4847	wobbly upside-down smelly sharpshooter's Uncle Hobo's gift baggy pants	0		Critical Hit Percent: +10, Stench Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	wobbly upside-down smelly sharpshooter's Uncle Hobo's gift baggy pants	0		Critical Hit Percent: +10, Stench Spell Damage: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	knitted sage Uncle Hobo's fingerless tinsel gloves	0		Mysticality Percent: +10, Cold Resistance: +3, Single Equip, Last Available: "2010-12"
 4849	Herculean Uncle Hobo's highest bough	0		Experience (Muscle): +1, Item Drop: +5, Last Available: "2010-12"
 4850	upside-down upside-down Uncle Hobo's belt of courage of the businessman	0		Spooky Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2010-12"
@@ -4769,14 +4769,14 @@
 4860	CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	upside-down CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	narrow CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
-4863	bouncing blurry CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
+4863	blurry bouncing CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	photocopier	0		Last Available: "2011-01"
 4865	mirror deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
-4867	blinking green paperclip sproinger	0		Last Available: "2011-01"
+4867	green blinking paperclip sproinger	0		Last Available: "2011-01"
 4868	horrifying smartaleck's paperclip-on tie of chilblains	0		Moxie Percent: +30, Cold Damage: +25, Spooky Damage: +25, Single Equip, Last Available: "2011-01"
-4869	jittery careful Socratic paperclip pants	0		Experience (Mysticality): +1, Monster Level: -10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	olive scandalous paperclip turban of the dark arts of Gandalf	0		Spell Damage Percent: +100, Spell Critical Percent: +20, Sleaze Damage: +5, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	jittery careful Socratic paperclip pants	0		Experience (Mysticality): +1, Monster Level: -10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	olive scandalous paperclip turban of the dark arts of Gandalf	0		Spell Damage Percent: +100, Spell Critical Percent: +20, Sleaze Damage: +5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	cyan ghostly paperclip cape of doom	0		Spooky Spell Damage: +50, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4794,13 +4794,13 @@
 4885	traffic jam	0		Last Available: "2011-01"
 4886	decent traffic jam toast	3	good	Last Available: "2011-01"
 4887	pulsating space jam	0		Last Available: "2011-01"
-4888	massive flavorless space jam toast	7	decent	Last Available: "2011-01"
-4889	diffused denatured yellow skewed motivational poster	0		Effect: "The Wisdom... of the Future", Effect Duration: 15, Last Available: "2011-01"
+4888	flavorless massive space jam toast	7	decent	Last Available: "2011-01"
+4889	diffused denatured skewed yellow motivational poster	0		Effect: "The Wisdom... of the Future", Effect Duration: 15, Last Available: "2011-01"
 4890	green sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	adequate special immense festive sausage	7	good	Effect: "Strong Grip", Effect Duration: 15, Last Available: "2011-01"
+4894	adequate immense special festive sausage	7	good	Effect: "Strong Grip", Effect Duration: 15, Last Available: "2011-01"
 4895	toothsome diet holiday cheese log	1	awesome	Last Available: "2011-01"
 4896	tumbling holiday log	0		Last Available: "2011-01"
 4897	wool rosy-cheeked BGE 'ferocious fruit' shirt	0		Maximum HP Percent: +30, Cold Resistance: +1, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	immense stale Knob jelly donut	8	decent	
+4941	stale immense Knob jelly donut	8	decent	
 4942	Knob cake	0		
 4943	squat Knob cake pan	0		
 4944	Knob batter	0		
@@ -4859,8 +4859,8 @@
 4956	moldy philosopher's scone	3	crappy	
 4957	dry alkaline half-baked potion	0		Effect: "Bottle in front of Me", Effect Duration: 56
 4958	Jack Frost's Knob Goblin deluxe scimitar	0		Cold Spell Damage: +50
-4959	stale snack-sized blinking Knob nuts	2	decent	
-4960	tolerable watered-down Cobb's Knob Wurstbrau	2	good	
+4959	snack-sized stale blinking Knob nuts	2	decent	
+4960	watered-down tolerable Cobb's Knob Wurstbrau	2	good	
 4961	Subject 37 file	0		
 4962	scandalous mysterious lapel pin of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, Single Equip
 4963	spinning state loom	0		Familiar Weight: +10
@@ -4902,7 +4902,7 @@
 4999	Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	spinning Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	cyan Alice's Army Foil Lanceman	0		Last Available: "2011-03"
-5002	red tumbling Alice's Army Foil Horseman	0		Last Available: "2011-03"
+5002	tumbling red Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	tumbling Alice's Army Foil Sniper	0		Last Available: "2011-03"
@@ -4914,8 +4914,8 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	tasty wasabi pocky	3	awesome	Last Available: "2011-03"
-5014	bland snack-sized tobiko pocky	2	decent	Last Available: "2011-03"
-5015	delicious small natto pocky	2	awesome	Last Available: "2011-03"
+5014	snack-sized bland tobiko pocky	2	decent	Last Available: "2011-03"
+5015	small delicious natto pocky	2	awesome	Last Available: "2011-03"
 5016	bad olive wasabi-infused sake	3	decent	Last Available: "2011-03"
 5017	bad tobiko-infused sake	4	decent	Last Available: "2011-03"
 5018	hand-crafted natto-infused sake	3	EPIC	Last Available: "2011-03"
@@ -4949,15 +4949,15 @@
 5046	astral six-pack	0		
 5047	wobbly maroon Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	perfumed strapping double-ice cap of the empath	0		Muscle: +5, Familiar Weight: +5, Stench Resistance: +5, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	perfumed strapping double-ice cap of the empath	0		Muscle: +5, Familiar Weight: +5, Stench Resistance: +5, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	family-friendly asbestos-lined flame-wreathed double-ice box	0		Hot Spell Damage: +10, Hot Resistance: +5, Sleaze Resistance: +1, Last Available: "2011-04"
-5051	maroon wizardly double-ice britches of terror of horror	0		Mysticality: +25, Spooky Spell Damage: 35, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	maroon wizardly double-ice britches of terror of horror	0		Mysticality: +25, Spooky Spell Damage: 35, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	tumbling handful of numbers	0		Last Available: "2020-09"
 5053	pulsating Lars the Cyberian	0		Last Available: "2011-04"
 5054	narrow intriguing puzzle box	0		Last Available: "2011-04"
 5055	blurry obnoxious riddle	0		Last Available: "2011-04"
 5056	mirror best joke ever	0		Last Available: "2011-04"
-5057	warmed modified spinning jittery Atomic Comic	0		Effect: "20/20 Vision", Effect Duration: 45, Last Available: "2011-04"
+5057	warmed modified jittery spinning Atomic Comic	0		Effect: "20/20 Vision", Effect Duration: 45, Last Available: "2011-04"
 5058	cold-filtered spinning Red Pill	0		Effect: "Turkey-Ambitious", Effect Duration: 59, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	mysterious present	0		Last Available: "2011-04"
@@ -4971,20 +4971,20 @@
 5068	rotten chaos popcorn	3	crappy	Last Available: "2011-04"
 5069	squat aromatic gravedigger's smelly hole	0		Stench Spell Damage: +10, Spooky Damage: +10, Stench Resistance: +1, Last Available: "2011-04"
 5070	tumbling innuendo	0		Last Available: "2011-04"
-5071	enchanted stale wobbly blinking s'more	0	decent	Effect: "Mucilaginous Muscle", Effect Duration: 25, Last Available: "2011-04"
-5072	cyan pulsating diamond ring	0		Last Available: "2011-04"
-5073	watered-down aged Russian Ice	2	awesome	Last Available: "2011-04"
+5071	enchanted stale blinking wobbly s'more	0	decent	Effect: "Mucilaginous Muscle", Effect Duration: 25, Last Available: "2011-04"
+5072	pulsating cyan diamond ring	0		Last Available: "2011-04"
+5073	aged watered-down Russian Ice	2	awesome	Last Available: "2011-04"
 5074	narrow ghostly miser's clay ashtray	0		Meat Drop: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	lanyard of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2011-05"
-5076	skewed strapping monster pants	0		Muscle: +5, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
-5077	wobbly twirling box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
+5076	skewed strapping monster pants	0		Muscle: +5, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5077	twirling wobbly box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	modified polarized unsweetened Pok&euml;mann band-aid	0		Effect: "So You Can Work More...", Effect Duration: 17, Last Available: "2011-05"
-5079	tumbling zippy Van der Graaf helmet of chilblains	0		Cold Damage: +25, Initiative: +20, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	tumbling zippy Van der Graaf helmet of chilblains	0		Cold Damage: +25, Initiative: +20, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	jittery ghostly crutch of the scaredy-cat	0		Monster Level: -15, Last Available: "2011-05"
 5081	boxer's shock belt	0		Muscle Percent: +10, Single Equip, Last Available: "2011-05"
 5082	dry huge Okee-Dokee soda	0		Effect: "Like a Fish to Walter", Effect Duration: 53, Last Available: "2011-05"
 5083	gray wool rubber band gun	0		Cold Resistance: +1, Last Available: "2011-05"
-5084	pin-stripe slacks of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	pin-stripe slacks of the sweet-tooth	0		Candy Drop: +100, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	blurry gloves of the cougar	0		Moxie: +20, Single Equip, Last Available: "2011-05"
 5086	non-denatured non-electrified squat correction fluid	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 41, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of the glutton	0		Food Drop: +100, Single Equip, Last Available: "2011-05"
@@ -5009,20 +5009,20 @@
 5106	fuchsia hideous egg	0		Last Available: "2011-05"
 5107	drinkable pulsating bouncing Jeppson's Malort	4	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	ghostly purple weightlifter's stress ball	0		Muscle: +15, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	ghostly purple weightlifter's stress ball	0		Muscle: +15, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	pulsating Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Jeselnik's Ultracolor&trade; shirt	0		Sleaze Damage: +25, Last Available: "2011-05"
 5112	fuchsia My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
 5114	wobbly blinking pulsating stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
-5115	red wobbly hedge trimmers	0		
+5115	wobbly red hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	pulsating reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	perfumed Oprah's rock-hard Admiral's hat	0		Damage Reduction: 5, Maximum MP Percent: +50, Stench Resistance: +5, Familiar Effect: "atk", Last Available: "2011-05"
-5122	crafty padded aviator's cap of mayonnaise	0		Damage Absorption: +20, Maximum MP: +10, Sleaze Spell Damage: +50, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	perfumed Oprah's rock-hard Admiral's hat	0		Damage Reduction: 5, Maximum MP Percent: +50, Stench Resistance: +5, Last Available: "2011-05", Familiar Effect: "atk"
+5122	crafty padded aviator's cap of mayonnaise	0		Damage Absorption: +20, Maximum MP: +10, Sleaze Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	beefy strapping mirrored aviator shades	0		Muscle: 15, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	twirling Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	bouncing fortified honey dipper of the brazier of the early riser	0		Damage Absorption: +60, Hot Spell Damage: +25, Adventures: +7
 5149	Jeselnik's padded honeybritches	0		Damage Absorption: +20, Sleaze Damage: +25, Item Drop: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	dog trainer's Oprah's honeycap of the cougar	0		Moxie: +20, Maximum MP Percent: +50, Experience (familiar): +1, Familiar Effect: "1xPotato, cap 43"
-5151	pulsating prompt Moonthril Circlet	0		Adventures: +3, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	smartaleck's Moonthril Greaves	0		Moxie Percent: +30, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	pulsating prompt Moonthril Circlet	0		Adventures: +3, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	smartaleck's Moonthril Greaves	0		Moxie Percent: +30, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	upside-down up-at-dawn Moonthril Flamberge	0		Adventures: +5, Last Available: "2011-06"
 5154	fuchsia steel-toed Moonthril Longbow	0		Damage Reduction: 9, Last Available: "2011-06"
 5155	green chaotic Moonthril Cuirass	0		Spell Critical Percent: +10, Softcore Only, Last Available: "2011-06"
@@ -5072,14 +5072,14 @@
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	wet blurry transporter transponder	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 33, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
-5172	huge fuchsia Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
+5172	fuchsia huge Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	acceptable enchanted narrow Saison du Lune	4	good	Effect: "Sharpened Sweet Tooth", Effect Duration: 45, Last Available: "2011-06"
 5175	mediocre squat mirror Moonthril Schnapps	4	decent	Last Available: "2011-06"
-5176	watered-down tolerable tumbling blurry Wrecked Generator	2	good	Last Available: "2011-06"
+5176	tolerable watered-down tumbling blurry Wrecked Generator	2	good	Last Available: "2011-06"
 5177	spoiled bouncing Spaghetti with Moonballs	4	crappy	Last Available: "2011-06"
-5178	big moldy Crepes a la Lune	5	crappy	Last Available: "2011-06"
-5179	half-sized normal twirling Moon Pie	2	good	Last Available: "2011-06"
+5178	moldy big Crepes a la Lune	5	crappy	Last Available: "2011-06"
+5179	normal half-sized twirling Moon Pie	2	good	Last Available: "2011-06"
 5180	energized wet lime green Comet Pop	0		Effect: "Standard Cheer", Effect Duration: 21, Last Available: "2011-06"
 5181	diffused activated pulsating Flan in the Moon	0		Effect: "Arresistible", Effect Duration: 48, Last Available: "2011-06"
 5182	quadruple-irradiated upside-down upside-down gray 1/6th Pound Cake	0		Effect: "Booing Radly", Effect Duration: 31, Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	squat blue Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	Vulcanized electrified quadruple-denatured honey stick	0		Effect: "Eldritch Concentration", Effect Duration: 56
 5189	non-ionized non-altered quantum double-ice gum	0		Effect: "The Halls of Muscularity", Effect Duration: 61, Last Available: "2011-04"
-5190	jittery zippy manspreader's electrified Operation Patriot Shield	0		Monster Level: +10, Initiative: +20, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	jittery zippy manspreader's electrified Operation Patriot Shield	0		Monster Level: +10, Initiative: +20, MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	moist green spinning corrupted data	0		Effect: "Elron's Explosive Etude", Effect Duration: 63, Last Available: "2011-06"
 5193	fuchsia 11-inch knob sausage	0		
@@ -5107,24 +5107,24 @@
 5204	vaporized huge hippy paste	1	EPIC	Last Available: "2011-08"
 5205	denatured purple orc paste	1	EPIC	Last Available: "2011-08"
 5206	twisted green spinning demonic paste	1	awesome	Effect: "Permafrosty", Effect Duration: 45, Last Available: "2011-08"
-5207	twisted mirror cyan indescribably horrible paste	1	EPIC	Last Available: "2011-08"
+5207	twisted cyan mirror indescribably horrible paste	1	EPIC	Last Available: "2011-08"
 5208	boiled olive paste	1	EPIC	Effect: "Eyes All Black", Effect Duration: 25, Last Available: "2011-08"
 5209	denatured huge goblin paste	1	crappy	Last Available: "2011-08"
 5210	twisted pirate paste	1	decent	Last Available: "2011-08"
 5211	pickled chlorophyll paste	1	decent	Last Available: "2011-08"
-5212	compressed wobbly narrow paste	1	good	Last Available: "2011-08"
-5213	compressed blurry red jittery Mer-kin paste	1	EPIC	Last Available: "2011-08"
-5214	distilled blue jittery huge slimy paste	1	decent	Last Available: "2011-08"
+5212	compressed narrow wobbly paste	1	good	Last Available: "2011-08"
+5213	compressed red blurry jittery Mer-kin paste	1	EPIC	Last Available: "2011-08"
+5214	distilled blue huge jittery slimy paste	1	decent	Last Available: "2011-08"
 5215	diluted penguin paste	1	crappy	Last Available: "2011-08"
-5216	dried bouncing maroon upside-down elemental paste	1	EPIC	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 40, Last Available: "2011-08"
+5216	dried bouncing upside-down maroon elemental paste	1	EPIC	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 40, Last Available: "2011-08"
 5217	pickled squat yellow tumbling cosmic paste	1	good	Last Available: "2011-08"
-5218	powdered green skewed hobo paste	1	good	Last Available: "2011-08"
+5218	powdered skewed green hobo paste	1	good	Last Available: "2011-08"
 5219	pickled maroon Crimbo paste	1	crappy	Last Available: "2011-08"
 5220	wobbly Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	spoiled small Ur-Donut	2	crappy	Last Available: "2011-09"
+5224	small spoiled Ur-Donut	2	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	mediocre bucket of wine	3	decent	Last Available: "2011-09"
@@ -5140,7 +5140,7 @@
 5237	avaricious time halo	0		Meat Drop: +30, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	weak perfectly mixed Lumineux Limnio	2	EPIC	Last Available: "2011-09"
 5239	aged Morto Moreto	3	awesome	Last Available: "2011-09"
-5240	watered-down fancy bad Temps Tempranillo	2	decent	Last Available: "2011-09"
+5240	bad fancy watered-down Temps Tempranillo	2	decent	Last Available: "2011-09"
 5241	watered-down drinkable Bordeaux Marteaux	2	good	Last Available: "2011-09"
 5242	artisanal high-proof jittery Fromage Pinotage	6	EPIC	Last Available: "2011-09"
 5243	hand-crafted shaking Beignet Milgranet	4	EPIC	Last Available: "2011-09"
@@ -5152,10 +5152,10 @@
 5249	flavorless danish	3	decent	Last Available: "2011-09"
 5250	immense normal shaking smashed danish	8	good	Last Available: "2011-09"
 5251	bland forbidden danish	3	decent	Last Available: "2011-09"
-5252	decent gray squat cool cat claw	4	good	Last Available: "2011-09"
+5252	decent squat gray cool cat claw	4	good	Last Available: "2011-09"
 5253	rotten blinking blunt cat claw	3	crappy	Last Available: "2011-09"
 5254	moldy small shadowy cat claw	2	crappy	Last Available: "2011-09"
-5255	tasty super-sized olive bouncing cheezburger	5	awesome	Last Available: "2011-09"
+5255	super-sized tasty bouncing olive cheezburger	5	awesome	Last Available: "2011-09"
 5256	stale bite-sized toasted brie	1	decent	Last Available: "2011-09"
 5257	ionized unsweetened teal potion of the field gar	0		Effect: "Pill Power", Effect Duration: 32, Last Available: "2011-09"
 5258	adjusted too legit potion	0		Effect: "Corruption of Wretched Wally", Effect Duration: 58, Last Available: "2011-09"
@@ -5171,7 +5171,7 @@
 5268	lime green holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
 5270	lime green chocolate frosted sugar bomb	0		Last Available: "2011-09"
-5271	bouncing bouncing jittery broken glass grenade	0		Last Available: "2011-09"
+5271	jittery bouncing bouncing broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	huge skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	shaking slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	normal phish stick	4	good	Last Available: "2011-09"
-5299	ruddy educational smooth plastic vampire fangs	0		Moxie: +15, Experience: +1, Maximum HP Percent: +40, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	ruddy educational smooth plastic vampire fangs	0		Moxie: +15, Experience: +1, Maximum HP Percent: +40, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	lime green Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	huge Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5208,12 +5208,12 @@
 5305	red banded Sceptre of the Torremolinos Prince	0		Damage Absorption: +100, Last Available: "2011-10"
 5306	banded Medallion of the Ventrilo Prince	0		Damage Absorption: +100, Last Available: "2011-10"
 5307	squat Haunted Sorority House staff guide	0		Last Available: "2011-10"
-5308	squat jittery bouncing ghost trap	0		Last Available: "2011-10"
+5308	squat bouncing jittery ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
 5310	shotgun shell	0		Last Available: "2011-10"
 5311	funhouse mirror	0		Last Available: "2011-10"
 5312	frozen corrupted skewed ghostly body paint	0		Effect: "Starry-Eyed", Effect Duration: 37, Last Available: "2011-10"
-5313	quantum moist dry wobbly twirling necrotizing body spray	0		Effect: "Mushroom Melody", Effect Duration: 50, Last Available: "2011-10"
+5313	quantum moist dry twirling wobbly necrotizing body spray	0		Effect: "Mushroom Melody", Effect Duration: 50, Last Available: "2011-10"
 5314	adjusted electrified olive upside-down bite-me-red lipstick	0		Effect: "You Read The Manual", Effect Duration: 55, Last Available: "2011-10"
 5315	magnetized colloidal huge whisker pencil	0		Effect: "Hammertime", Effect Duration: 33, Last Available: "2011-10"
 5316	cold-filtered cyan press-on ribs	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 21, Last Available: "2011-10"
@@ -5223,7 +5223,7 @@
 5320	triple-frozen pickled Lobos Mints	0		Effect: "Egg-stra Arm", Effect Duration: 57, Last Available: "2011-10"
 5321	magnetized modified blurry Sweet Sword	0		Effect: "A Few Extra Pounds", Effect Duration: 69, Last Available: "2011-10"
 5322	tolerable Ecto-Cooler	3	good	Last Available: "2011-10"
-5323	weak mediocre Bartles and BRAAAINS wine cooler	2	decent	Last Available: "2011-10"
+5323	mediocre weak Bartles and BRAAAINS wine cooler	2	decent	Last Available: "2011-10"
 5324	artisanal weak Blood Light	2	EPIC	Last Available: "2011-10"
 5325	aged Silver Bullet beer	3	awesome	Last Available: "2011-10"
 5326	fancy lousy Bone's Farm &quot;wine&quot;	3	decent	Effect: "Creepin' Up on You", Effect Duration: 40, Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	concentrated extra-colloidal drum of pomade	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 16, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	crafty extra-see-thru nightie	0		Maximum MP: +10, Last Available: "2011-10"
-5333	smartaleck's boxer's BRAINS shorts	0		Muscle Percent: +10, Moxie Percent: +30, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	smartaleck's boxer's BRAINS shorts	0		Muscle Percent: +10, Moxie Percent: +30, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	jittery beefy Mesmereyes&trade; contact lenses	0		Muscle: +10, Single Equip, Last Available: "2011-10"
 5335	supercharged scrunchie	0		Maximum MP Percent: +30, Single Equip, Last Available: "2011-10"
-5336	jittery arcane researcher's extremely skinny jeans of courage	0		Experience Percent (Mysticality): +10, Spooky Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	wholesome The Necbromancer's Hat of the sewer	0		Maximum HP Percent: +10, Stench Damage: +25, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	jittery arcane researcher's extremely skinny jeans of courage	0		Experience Percent (Mysticality): +10, Spooky Resistance: +3, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	wholesome The Necbromancer's Hat of the sewer	0		Maximum HP Percent: +10, Stench Damage: +25, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	narrow chaotic The Necbromancer's Stein of the ox of terror	0		Muscle: +20, Spell Critical Percent: +10, Spooky Spell Damage: +10, Last Available: "2011-10"
-5339	bouncing red twirling medical-grade fortified padded The Necbromancer's Shorts	0		Damage Absorption: 80, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	bouncing red twirling medical-grade fortified padded The Necbromancer's Shorts	0		Damage Absorption: 80, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	blue chilly Jim Carey's The Necbromancer's Wizard Staff of the ox	0		Muscle: +20, Monster Level: +25, Cold Damage: +5, Last Available: "2011-10"
 5341	maroon The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	spirit-forward bad The Cooler Out of Space	5	decent	Last Available: "2011-10"
@@ -5290,7 +5290,7 @@
 5387	forbidden ridiculous earring	0		Spell Damage Percent: +50, Last Available: "2011-11"
 5388	purple vibrating ridiculous sunglasses	0		Maximum MP Percent: +10, Last Available: "2011-11"
 5389	stale blue ridiculous sandwich	3	decent	Last Available: "2011-11"
-5390	drinkable weak spinning ridiculous cocktail	2	good	Last Available: "2011-11"
+5390	weak drinkable spinning ridiculous cocktail	2	good	Last Available: "2011-11"
 5391	Jack Frost's zombie monkey necklace of the sewer	0		Cold Spell Damage: +50, Stench Damage: +25
 5392	Thwaitgold butterfly statuette	0		
 5393	upside-down scrap of paper	0		
@@ -5306,13 +5306,13 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	fortified extremely unsafe cane-mail shirt of the storm	0		Weapon Damage Percent: +100, Damage Absorption: +60, Maximum MP Percent: +40, Last Available: "2011-12"
-5406	greasy arcane researcher's Herculean cane-mail pants	0		Experience (Muscle): +1, Experience Percent (Mysticality): +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	greasy arcane researcher's Herculean cane-mail pants	0		Experience (Muscle): +1, Experience Percent (Mysticality): +10, Sleaze Spell Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	high-proof bad Vodka Matryoshka	8	decent	Last Available: "2011-12"
-5408	watered-down tolerable Gin Mint	2	good	Last Available: "2011-12"
+5408	tolerable watered-down Gin Mint	2	good	Last Available: "2011-12"
 5409	practically non-alcoholic delicious ghostly Tequiz Navidad	1	awesome	Last Available: "2011-12"
 5410	acceptable Mint Yulep	3	good	Last Available: "2011-12"
 5411	smooth Crimbojito	3	awesome	Last Available: "2011-12"
-5412	distilled mediocre Sangria de Menthe	5	decent	Last Available: "2011-12"
+5412	mediocre distilled Sangria de Menthe	5	decent	Last Available: "2011-12"
 5413	jittery candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	colloidal warmed narrow licorice root	0		Effect: "Tiki Thoughtfulness", Effect Duration: 33, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	kumquartz ring of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2011-11"
 5425	strawberyl necklace of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2011-11"
 5426	careful experienced sucker bucket	0		Experience: +2, Monster Level: -10, Last Available: "2011-11"
-5427	chilly sucker hakama	0		Cold Damage: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	sucker kabuto of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	chilly sucker hakama	0		Cold Damage: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	sucker kabuto of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	educational sucker tachi	0		Experience: +1, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	yellow cinnamon troll doll	0		Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	narrow superheated fudge	0		Last Available: "2011-11"
 5438	aerosolized twirling fluid of fudge-finding	0		Effect: "Twinkly Weapon", Effect Duration: 50, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	big decent fudgesicle	5	good	Last Available: "2011-11"
+5440	decent big fudgesicle	5	good	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	purple miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5358,20 +5358,20 @@
 5455	pulsating gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	dry bouncing mirror Fudgie Roll	0		Effect: "Wings of the Grasshopper", Effect Duration: 32, Last Available: "2011-11"
-5458	adequate small upside-down fudge bunny	2	good	Last Available: "2011-11"
+5458	small adequate upside-down fudge bunny	2	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	horrifying stiffened personal trainer's fudgecycle	0		Experience Percent (Muscle): +10, Damage Reduction: 1, Spooky Damage: +25, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	spinning Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	dry activated resolution: be wealthier	0		Effect: "Perfect Hair", Effect Duration: 30, Last Available: "2012-01"
-5465	ionized energized jittery teal resolution: be happier	0		Effect: "Far Out", Effect Duration: 65, Last Available: "2012-01"
+5465	ionized energized teal jittery resolution: be happier	0		Effect: "Far Out", Effect Duration: 65, Last Available: "2012-01"
 5466	quadruple-Vulcanized resolution: be stronger	0		Effect: "Outer Wolf&trade;", Effect Duration: 25, Last Available: "2012-01"
 5467	Vulcanized spinning resolution: be smarter	0		Effect: "Burning Tongue", Effect Duration: 65, Last Available: "2012-01"
 5468	frozen alkaline ionized jittery resolution: be sexier	0		Effect: "Fratty Flavor", Effect Duration: 58, Last Available: "2012-01"
 5469	galvanized improved energized lime green resolution: be feistier	0		Effect: "Sugary World View", Effect Duration: 45, Last Available: "2012-01"
 5470	activated galvanized resolution: be kinder	0		Effect: "Fit To Be Tide", Effect Duration: 29, Last Available: "2012-01"
-5471	quadruple-boiled pressed fuchsia narrow resolution: be more adventurous	0		Effect: "Rat-Faced", Effect Duration: 23, Last Available: "2012-01"
+5471	quadruple-boiled pressed narrow fuchsia resolution: be more adventurous	0		Effect: "Rat-Faced", Effect Duration: 23, Last Available: "2012-01"
 5472	double-aerosolized twirling resolution: be luckier	0		Effect: "Clyde's Blessing", Effect Duration: 53, Last Available: "2012-01"
 5473	jittery gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
@@ -5382,8 +5382,8 @@
 5479	toothsome gummi bear	3	awesome	Last Available: "2011-11"
 5480	spoiled gummi bear	4	crappy	Last Available: "2011-11"
 5481	moldy gummi bear	4	crappy	Last Available: "2011-11"
-5482	flavorless super-sized drunki-bear	5	decent	Last Available: "2011-11"
-5483	half-sized moldy blinking drunki-bear	2	crappy	Last Available: "2011-11"
+5482	super-sized flavorless drunki-bear	5	decent	Last Available: "2011-11"
+5483	moldy half-sized blinking drunki-bear	2	crappy	Last Available: "2011-11"
 5484	snack-sized flavorless drunki-bear	2	decent	Last Available: "2011-11"
 5485	huge vibrating gummi bowtie	0		Maximum MP Percent: +10, Last Available: "2011-11"
 5486	chilly fudge pocket square	0		Cold Damage: +5, Last Available: "2011-11"
@@ -5391,21 +5391,21 @@
 5488	twirling trilobite fossil	0		Last Available: "2011-11"
 5489	ammonite fossil	0		Last Available: "2011-11"
 5490	belemnite fossil	0		Last Available: "2011-11"
-5491	twirling bouncing trilobite candy mold	0		Last Available: "2011-11"
+5491	bouncing twirling trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	squat belemnite candy mold	0		Last Available: "2011-11"
 5494	diffused denatured tumbling gummi trilobite	0		Effect: "Engorged Weapon", Effect Duration: 44, Last Available: "2011-11"
 5495	frozen spinning gummi ammonite	0		Effect: "One Very Clear Eye", Effect Duration: 33, Last Available: "2011-11"
 5496	vacuum-sealed gummi belemnite	0		Effect: "Super-Charged", Effect Duration: 11, Last Available: "2011-11"
 5497	jittery all-year sucker	0		Last Available: "2011-11"
-5498	blurry blinking heart of dark chocolate	0		Last Available: "2011-11"
-5499	fireproof Big Candy's tophat of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5498	blinking blurry heart of dark chocolate	0		Last Available: "2011-11"
+5499	fireproof Big Candy's tophat of James Dean	0		Experience (Moxie): +3, Hot Resistance: +3, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	tumbling Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	skewed blessed box	0		
-5505	fuchsia pulsating pack of pogs	0		Last Available: "2011-11"
+5505	pulsating fuchsia pack of pogs	0		Last Available: "2011-11"
 5506	rotten thick jerky coins	5	crappy	Last Available: "2011-11"
 5507	tolerable Go-Wassail	3	good	Last Available: "2011-11"
 5508	denatured skewed Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Walberg's Dim Bulb", Effect Duration: 42, Last Available: "2011-11"
@@ -5435,7 +5435,7 @@
 5532	pulsating magnolia blossom	0		Last Available: "2012-12"
 5533	unsweetened polarized shaking green Mortimer's nostrum	0		Effect: "Poker Faced", Effect Duration: 69, Last Available: "2012-12"
 5534	lousy Barulio's bottle	3	decent	Last Available: "2012-12"
-5535	quadruple-adjusted flattened extra-irradiated tumbling bouncing red Marvin's marvelous pill	0		Effect: "Tea-hee", Effect Duration: 20, Last Available: "2012-12"
+5535	quadruple-adjusted flattened extra-irradiated red tumbling bouncing Marvin's marvelous pill	0		Effect: "Tea-hee", Effect Duration: 20, Last Available: "2012-12"
 5536	mirror Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	half-empty carton of milk	0		Last Available: "2012-12"
@@ -5445,11 +5445,11 @@
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	Jeselnik's Leapin' Trousers of the glutton	0		Sleaze Damage: +25, Food Drop: +100
 5544	practically non-alcoholic mediocre eggnog	1	decent	Last Available: "2012-12"
-5545	flavorless special hamhock	4	decent	Effect: "Limber as Mortimer", Effect Duration: 35, Last Available: "2012-12"
+5545	special flavorless hamhock	4	decent	Effect: "Limber as Mortimer", Effect Duration: 35, Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
-5549	fuchsia jittery Clancy's crumhorn	0		Last Available: "2012-12"
+5549	jittery fuchsia Clancy's crumhorn	0		Last Available: "2012-12"
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	Trusty of terror	0		Spooky Spell Damage: +10
@@ -5459,7 +5459,7 @@
 5556	upside-down lard-coated Rain-Doh wings of Flo-Jo	0		Sleaze Spell Damage: +25, Initiative: +100, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	huge grievous wizardly Rain-Doh laser gun	0		Mysticality: +25, Weapon Damage Percent: +50, Softcore Only, Last Available: "2012-02"
-5559	groovy Rain-Doh lantern of horror	0		Moxie Percent: +10, Spooky Spell Damage: +25, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	groovy Rain-Doh lantern of horror	0		Moxie Percent: +10, Spooky Spell Damage: +25, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	maroon quilted Rain-Doh violet bo of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40, Softcore Only, Last Available: "2012-02"
@@ -5474,36 +5474,36 @@
 5571	Groar's fur	0		
 5572	twirling Thwaitgold stag beetle statuette	0		
 5573	mediocre teal Drac & Tan	4	decent	Last Available: "2012-03"
-5574	triple-distilled bad Transylvania Sling	10	decent	Last Available: "2012-03"
-5575	practically non-alcoholic tolerable Shot of the Living Dead	1	good	Last Available: "2012-03"
+5574	bad triple-distilled Transylvania Sling	10	decent	Last Available: "2012-03"
+5575	tolerable practically non-alcoholic Shot of the Living Dead	1	good	Last Available: "2012-03"
 5576	acceptable Buttery Knob	3	good	Last Available: "2012-03"
 5577	tolerable high-proof Slippery Knob	6	good	Last Available: "2012-03"
 5578	bad Flaming Knob	4	decent	Last Available: "2012-03"
-5579	hand-crafted spirit-forward Grasshopper	5	EPIC	Last Available: "2012-03"
-5580	acceptable practically non-alcoholic Locust	1	good	Last Available: "2012-03"
+5579	spirit-forward hand-crafted Grasshopper	5	EPIC	Last Available: "2012-03"
+5580	practically non-alcoholic acceptable Locust	1	good	Last Available: "2012-03"
 5581	tolerable cyan Plague of Locusts	4	good	Last Available: "2012-03"
-5582	perfectly mixed fancy skewed Red Dwarf	3	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25, Last Available: "2012-03"
-5583	enchanted perfectly mixed practically non-alcoholic Golden Mean	1	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15, Last Available: "2012-03"
+5582	fancy perfectly mixed skewed Red Dwarf	3	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25, Last Available: "2012-03"
+5583	perfectly mixed practically non-alcoholic enchanted Golden Mean	1	EPIC	Effect: "Make Meat FA$T!", Effect Duration: 15, Last Available: "2012-03"
 5584	drinkable Green Giant	3	good	Last Available: "2012-03"
 5585	tolerable fortified spinning Aye Aye	5	good	Last Available: "2012-03"
-5586	perfectly mixed watered-down blinking Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
+5586	watered-down perfectly mixed blinking Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
 5587	bad narrow Aye Aye, Tooth Tooth	3	decent	Last Available: "2012-03"
 5588	artisanal Humanitini	4	EPIC	Last Available: "2012-03"
-5589	lousy practically non-alcoholic More Humanitini than Humanitini	1	decent	Last Available: "2012-03"
+5589	practically non-alcoholic lousy More Humanitini than Humanitini	1	decent	Last Available: "2012-03"
 5590	artisanal fancy twirling Oh, the Humanitini	4	EPIC	Effect: "Wallflowering", Effect Duration: 10, Last Available: "2012-03"
-5591	hand-crafted watered-down Great Older Fashioned	2	EPIC	Last Available: "2012-03"
+5591	watered-down hand-crafted Great Older Fashioned	2	EPIC	Last Available: "2012-03"
 5592	lousy Fuzzy Tentacle	4	decent	Last Available: "2012-03"
-5593	drinkable watered-down Crazymaker	2	good	Last Available: "2012-03"
+5593	watered-down drinkable Crazymaker	2	good	Last Available: "2012-03"
 5594	acceptable narrow Zoodriver	4	good	Last Available: "2012-03"
-5595	irresponsibly strong special lousy Sloe Comfortable Zoo	8	decent	Effect: "Go-Gone", Effect Duration: 50, Last Available: "2012-03"
-5596	weak artisanal Sloe Comfortable Zoo on Fire	2	EPIC	Last Available: "2012-03"
+5595	irresponsibly strong lousy special Sloe Comfortable Zoo	8	decent	Effect: "Go-Gone", Effect Duration: 50, Last Available: "2012-03"
+5596	artisanal weak Sloe Comfortable Zoo on Fire	2	EPIC	Last Available: "2012-03"
 5597	smooth skewed Suffering Sinner	3	awesome	Last Available: "2012-03"
 5598	perfectly mixed blue Suppurating Sinner	3	EPIC	Last Available: "2012-03"
 5599	perfectly mixed Sizzling Sinner	4	EPIC	Last Available: "2012-03"
 5600	drinkable Firewater	4	good	Last Available: "2012-03"
 5601	hand-crafted Earth and Firewater	4	EPIC	Last Available: "2012-03"
 5602	lousy Earth, Wind and Firewater	3	decent	Last Available: "2012-03"
-5603	watered-down tolerable Slimosa	2	good	Last Available: "2012-03"
+5603	tolerable watered-down Slimosa	2	good	Last Available: "2012-03"
 5604	tolerable Extra-slimy Slimosa	3	good	Last Available: "2012-03"
 5605	drinkable Slimebite	4	good	Last Available: "2012-03"
 5606	bad cyan Cement Mixer	3	decent	Last Available: "2012-03"
@@ -5514,19 +5514,19 @@
 5611	tolerable Aura Libre	4	good	Last Available: "2012-03"
 5612	practically non-alcoholic acceptable Sazerorc	1	good	Last Available: "2012-03"
 5613	bad narrow Sazuruk-hai	4	decent	Last Available: "2012-03"
-5614	weak lousy fancy upside-down Flaming Sazerorc	2	decent	Effect: "Flaming Weapon", Effect Duration: 15, Last Available: "2012-03"
+5614	lousy fancy weak upside-down Flaming Sazerorc	2	decent	Effect: "Flaming Weapon", Effect Duration: 15, Last Available: "2012-03"
 5615	perfectly mixed Green Velvet	3	EPIC	Last Available: "2012-03"
 5616	artisanal Green Muslin	4	EPIC	Last Available: "2012-03"
 5617	perfectly mixed practically non-alcoholic spinning Green Burlap	1	super ultra EPIC	Last Available: "2012-03"
-5618	enchanted tolerable Mohobo	4	good	Effect: "Spooky Jellied", Effect Duration: 30, Last Available: "2012-03"
-5619	watered-down tolerable lime green Moonshine Mohobo	2	good	Last Available: "2012-03"
+5618	tolerable enchanted Mohobo	4	good	Effect: "Spooky Jellied", Effect Duration: 30, Last Available: "2012-03"
+5619	tolerable watered-down lime green Moonshine Mohobo	2	good	Last Available: "2012-03"
 5620	artisanal Flaming Mohobo	4	EPIC	Last Available: "2012-03"
-5621	watered-down acceptable Drunken Philosopher	2	good	Last Available: "2012-03"
-5622	drinkable irresponsibly strong Drunken Neurologist	10	good	Last Available: "2012-03"
+5621	acceptable watered-down Drunken Philosopher	2	good	Last Available: "2012-03"
+5622	irresponsibly strong drinkable Drunken Neurologist	10	good	Last Available: "2012-03"
 5623	perfectly mixed squat Drunken Astrophysicist	4	EPIC	Last Available: "2012-03"
 5624	drinkable Dark & Starry	3	good	Last Available: "2012-03"
 5625	weak hand-crafted Black Hole	2	EPIC	Last Available: "2012-03"
-5626	tolerable practically non-alcoholic ghostly Event Horizon	1	good	Last Available: "2012-03"
+5626	practically non-alcoholic tolerable ghostly Event Horizon	1	good	Last Available: "2012-03"
 5627	watered-down tolerable twirling Herring Daiquiri	2	good	Last Available: "2012-03"
 5628	lousy high-proof Herring Wallbanger	7	decent	Last Available: "2012-03"
 5629	bad Herringtini	3	decent	Last Available: "2012-03"
@@ -5538,7 +5538,7 @@
 5635	acceptable Flaming Caipiranha	4	good	Last Available: "2012-03"
 5636	bad Punchplanter	3	decent	Last Available: "2012-03"
 5637	drinkable Doublepunchplanter	3	good	Last Available: "2012-03"
-5638	lousy triple-distilled Haymaker	10	decent	Last Available: "2012-03"
+5638	triple-distilled lousy Haymaker	10	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	shaking crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	adequate massive fungus	9	good	
@@ -5548,16 +5548,16 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	wicked calendar	0		Spell Damage: +5, Damage Reduction: 4
-5648	ribald Boris's Helm of Leguizamo	0		Monster Level: +20, Sleaze Damage: +10, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	ribald Boris's Helm of Leguizamo	0		Monster Level: +20, Sleaze Damage: +10, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	huge Socratic sage staph of homophones	0		Mysticality Percent: +10, Experience (Mysticality): +1
-5650	nippy curative Rosewater's Boris's Helm (askew)	0		Mysticality Percent: +30, Cold Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	nippy curative Rosewater's Boris's Helm (askew)	0		Mysticality Percent: +30, Cold Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	spoiled tiny upside-down nailswurst	1	crappy	
+5654	tiny spoiled upside-down nailswurst	1	crappy	
 5655	lousy fancy used beer	4	decent	Effect: "Jacked In", Effect Duration: 15
 5656	spinning spinning Huggler Radio	0		Free Pull
-5657	purple squat fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
+5657	squat purple fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
 5659	shellacked insulting hat	0		Damage Reduction: 7, Familiar Effect: "cap 2"
 5660	shaking offensive moustache of vim and vigor	0		Maximum HP Percent: +50, Single Equip
@@ -5567,23 +5567,23 @@
 5664	pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	jittery How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
-5667	purple squat puppet strings	0		Free Pull
+5667	squat purple puppet strings	0		Free Pull
 5668	spinning bagged &quot;L&quot;	0		
 5669	tumbling club	0		
 5670	spoiled fettucini &eacute;pines Inconnu	3	crappy	
-5671	drinkable triple-distilled slap and slap again	6	good	
+5671	triple-distilled drinkable slap and slap again	6	good	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	squat &quot;L&quot;	0		
 5675	dried watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	savvy Ze&trade; goggles	0		Mysticality Percent: +20, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	savvy Ze&trade; goggles	0		Mysticality Percent: +20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	gray rosewater-soaked beefy stylish swimsuit	0		Muscle: +10, Stench Resistance: +3, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	gray rosewater-soaked beefy stylish swimsuit	0		Muscle: +10, Stench Resistance: +3, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
 5681	stale teal P.B.L.T.	4	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
-5683	tumbling narrow BURT	0		
+5683	narrow tumbling BURT	0		
 5684	handful of juicy garbage	0		
 5685	upside-down bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
@@ -5605,56 +5605,56 @@
 5702	blinking mannequin	0		Familiar Weight: +5
 5703	yellow crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	ruddy beefy wax hat	0		Muscle: +10, Maximum HP Percent: +40, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	Oprah's stylish wax pants	0		Moxie: +25, Maximum MP Percent: +50, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
-5707	upside-down fuchsia huge FDKOL commendation	0		Last Available: "2012-07"
+5705	ruddy beefy wax hat	0		Muscle: +10, Maximum HP Percent: +40, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	Oprah's stylish wax pants	0		Moxie: +25, Maximum MP Percent: +50, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5707	huge fuchsia upside-down FDKOL commendation	0		Last Available: "2012-07"
 5708	dry blurry drop of water-37	0		Effect: "Standard Cheer", Effect Duration: 18, Last Available: "2012-07"
-5709	jittery family-friendly fireman's helmet of the ox	0		Muscle: +20, Sleaze Resistance: +1, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	jittery family-friendly fireman's helmet of the ox	0		Muscle: +20, Sleaze Resistance: +1, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	spinning MacGyver's fire axe	0		Maximum MP: +100, Last Available: "2012-07"
 5713	zippy greedy sage fire extinguisher	0		Mysticality Percent: +10, Meat Drop: +20, Initiative: +20, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	tumbling Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	huge Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	spoiled fancy FDKOL hotcakes	3	crappy	Effect: "Eau de Tortue", Effect Duration: 35, Last Available: "2012-07"
+5717	fancy spoiled FDKOL hotcakes	3	crappy	Effect: "Eau de Tortue", Effect Duration: 35, Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	gigantic normal fiery wing	10	good	Last Available: "2012-07"
 5721	family-friendly healthy wings of fire	0		Maximum HP Percent: +20, Sleaze Resistance: +1, Last Available: "2012-07"
 5722	mirror coward's FDKOL fire hose	0		Monster Level: -20, Last Available: "2012-07"
-5723	pickled adjusted lime green twirling bottle of fire	0		Effect: "You Drank Fish Wine", Effect Duration: 62, Last Available: "2012-07"
+5723	pickled adjusted twirling lime green bottle of fire	0		Effect: "You Drank Fish Wine", Effect Duration: 62, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	deadly hot daub bun of Leguizamo	0		Weapon Damage: +5, Monster Level: +20, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	ghostly medical-grade hot daub stand of bravery	0		Spooky Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	deadly hot daub bun of Leguizamo	0		Weapon Damage: +5, Monster Level: +20, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	ghostly medical-grade hot daub stand of bravery	0		Spooky Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	blurry foot-long hot daub of the cougar of James Dean	0		Moxie: +20, Experience (Moxie): +3, Last Available: "2012-07"
 5729	blurry tumbling ballpark hot daub	0		Last Available: "2012-07"
-5730	normal super-sized angst burger	5	good	
-5731	tolerable wobbly narrow 5-hour acrimony	3	good	
+5730	super-sized normal angst burger	5	good	
+5731	tolerable narrow wobbly 5-hour acrimony	3	good	
 5732	blank note	0		
 5733	blurry eerily silent box	0		
 5734	flavorless forbidden sausage	3	decent	
-5735	Lord Flameface's cloak of the cougar	0		Moxie: +20, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Lord Flameface's cloak of the cougar	0		Moxie: +20, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	wet fuchsia Drizzlers&trade; Black Licorice	0		Effect: "All Blued Up", Effect Duration: 43
 5737	anodized energized daub-breaker	0		Effect: "Uncaged Power", Effect Duration: 37, Last Available: "2020-09"
 5738	miser's Camp Scout backpack	0		Meat Drop: +10, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	fancy delicious snack-sized bag of GORP	2	awesome	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2012-07"
+5740	delicious snack-sized fancy bag of GORP	2	awesome	Effect: "Drunk With Power", Effect Duration: 20, Last Available: "2012-07"
 5741	drinkable water purification pills	4	good	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	watered-down lousy CSA scoutmaster's &quot;water&quot;	2	decent	Last Available: "2012-07"
-5744	gigantic flavorless bag of GORF	10	decent	Last Available: "2012-07"
+5743	lousy watered-down CSA scoutmaster's &quot;water&quot;	2	decent	Last Available: "2012-07"
+5744	flavorless gigantic bag of GORF	10	decent	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	rotten big bag of QWOP	5	crappy	Last Available: "2012-07"
 5747	flattened CSA bravery badge	0		Effect: "Yuletide Industry", Effect Duration: 39, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	perfectly mixed weak special CSA cheerfulness ration	2	EPIC	Effect: "You Liver", Effect Duration: 30, Last Available: "2012-07"
+5749	special perfectly mixed weak CSA cheerfulness ration	2	EPIC	Effect: "You Liver", Effect Duration: 30, Last Available: "2012-07"
 5750	narrow CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	immense yummy crappy brain	6	awesome	
 5753	adequate decent brain	4	good	
 5754	small normal good brain	2	good	
-5755	small normal upside-down maroon boss brain	2	good	
-5756	big flavorless hunter brain	5	decent	
+5755	normal small upside-down maroon boss brain	2	good	
+5756	flavorless big hunter brain	5	decent	
 5758	twirling electrified supercool Staff of Holiday Sensations of the wise owl	0		Mysticality: +20, Moxie Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
 5759	healthy staff of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +20
 5760	energetic Fonzie's staff of Flo-Jo	0		Experience (Moxie): +1, Maximum MP Percent: +20, Initiative: +100
@@ -5665,11 +5665,11 @@
 5765	twirling fuchsia avaricious razor-sharp fuzzy earmuffs	0		Weapon Damage Percent: +25, Meat Drop: +30, Familiar Effect: "1.5xVolley, cap 32"
 5766	jittery wobbly energetic fuzzy montera of the storm of incineration	0		Maximum MP Percent: 60, Hot Spell Damage: +50, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	squat gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	blinking gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	squat gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	blinking gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5687,14 +5687,14 @@
 5788	wobbly fuchsia smut orc keepsake box	0		
 5789	jittery bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	Tesla right bear arm of the sewer	0		Stench Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	asbestos-lined greasy dance instructor's left bear arm	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	Tesla right bear arm of the sewer	0		Stench Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	asbestos-lined greasy dance instructor's left bear arm	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +10, Hot Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	slick Hat O' Nine Tails	0		Moxie: +10
 5794	ionized mirror cyan Enchanted Plunger	0		Effect: "Hippy Flavor", Effect Duration: 36
 5795	polarized Enchanted Flyswatter	0		Effect: "Bustle Hustlin'", Effect Duration: 53
 5796	extra-pressed galvanized jittery Gearhead Goo	0		Effect: "Here to Kick Ass", Effect Duration: 21
 5797	unsweetened ionized spinning Missing Eye Simulation Device	0		Effect: "Pemmican't", Effect Duration: 56
-5798	deionized unsweetened blurry twirling Gnollish Crossdress	0		Effect: "Mad at Science", Effect Duration: 68
+5798	deionized unsweetened twirling blurry Gnollish Crossdress	0		Effect: "Mad at Science", Effect Duration: 68
 5799	dry polarized jittery eldritch dough	0		Effect: "Lemon Enlightenment", Effect Duration: 59
 5800	oxidized diffused deionized Charity's choker	0		Effect: "Provocative Perkiness", Effect Duration: 43
 5801	quadruple-denatured concentrated Smart Bone Dust	0		Effect: "Partially Ghosted", Effect Duration: 46
@@ -5711,14 +5711,14 @@
 5812	magnetized wet skelelton spine	0		Effect: "French Bronilla Brogueishness", Effect Duration: 43
 5813	ionized cold-filtered green upside-down smut orc sunglasses	0		Effect: "Preternatural Greed", Effect Duration: 48
 5814	super-chilled non-alkaline bouncing blob of acid	0		Effect: "Fangs and Pangs", Effect Duration: 24
-5815	diffused ionized jittery tumbling flayed mind	0		Effect: "Sewer-Drenched", Effect Duration: 30
+5815	diffused ionized tumbling jittery flayed mind	0		Effect: "Sewer-Drenched", Effect Duration: 30
 5816	oxidized diffused kobold kibble	0		Effect: "Shawarma Warm War", Effect Duration: 45
 5817	altered extra-moist forest spirit rattle	0		Effect: "Soles of Glass", Effect Duration: 42
 5818	unsweetened frozen jittery Stone Golem pebbles	0		Effect: "Patched In", Effect Duration: 26
 5819	adjusted gravy fairy warlock hat	0		Effect: "Aided and Abetted", Effect Duration: 16
 5820	modified non-oxidized blurry bull blubber	0		Effect: "Pockets of Fire", Effect Duration: 24
 5821	anodized electrified frog lip-print	0		Effect: "Petit Forbearance", Effect Duration: 47
-5822	boiled twirling fuchsia gazely stare	0		Effect: "Cybernetic Muscles", Effect Duration: 64
+5822	boiled fuchsia twirling gazely stare	0		Effect: "Cybernetic Muscles", Effect Duration: 64
 5823	colloidal colloidal canopic jar	0		Effect: "Oriental Mysticism", Effect Duration: 32
 5824	aerosolized clove-flavored lip balm	0		Effect: "Memory of Attractiveness", Effect Duration: 37
 5825	ionized double-tarnished blinking Skullery Maid's Knee	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 25
@@ -5745,7 +5745,7 @@
 5846	corrupted salt water taffy	0		Effect: "Hairless and Airless", Effect Duration: 67
 5847	boiled unholy water	0		Effect: "Gummi Badass", Effect Duration: 66
 5848	moist Bangyomaman battle juice	0		Effect: "Stemonitis Storm", Effect Duration: 19
-5849	boiled upside-down twirling handyman &quot;hand soap&quot;	0		Effect: "Puzzle Fury", Effect Duration: 25
+5849	boiled twirling upside-down handyman &quot;hand soap&quot;	0		Effect: "Puzzle Fury", Effect Duration: 25
 5850	adjusted denatured corrupted space marine flash grenade	0		Effect: "Whitened Teeth", Effect Duration: 60
 5851	frozen frozen red temporary tribal tattoo	0		Effect: "Big", Effect Duration: 23
 5852	ionized oil-filled donut	0		Effect: "Hot Jellied", Effect Duration: 47
@@ -5767,11 +5767,11 @@
 5868	supercharged papier-m&acirc;ch&eacute;te of the glutton	0		Maximum MP Percent: +30, Food Drop: +100, Last Available: "2012-09"
 5869	blurry nippy papier-m&acirc;chine gun of James Dean	0		Experience (Moxie): +3, Cold Damage: +10, Last Available: "2012-09"
 5870	papier-masque of extreme caution of the overflowing toilet	0		Monster Level: -25, Stench Spell Damage: +50, Single Equip, Last Available: "2012-09"
-5871	spinning vibrating papier-mitre	0		Maximum MP Percent: +10, Item Drop: +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	green vibrating hardened papier-m&acirc;churidars	0		Damage Reduction: 3, Maximum MP Percent: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	spinning vibrating papier-mitre	0		Maximum MP Percent: +10, Item Drop: +5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	green vibrating hardened papier-m&acirc;churidars	0		Damage Reduction: 3, Maximum MP Percent: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	upside-down papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
-5875	bouncing green jittery papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
+5875	jittery bouncing green papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
 5876	papier-m&acirc;ch&eacute; bowl	0		Last Available: "2012-09"
 5877	papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	gravedigger's Rainbow Jello Mould	0		Spooky Damage: +10
@@ -5781,7 +5781,7 @@
 5882	grievous slick skeleton skis of the cheetah	0		Moxie: +10, Weapon Damage Percent: +50, Initiative: +60, Single Equip, Last Available: "2012-10"
 5883	bland tumbling skeleton quiche	3	decent	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
-5885	shaking mirror skeletal skiff	0		Last Available: "2012-10"
+5885	mirror shaking skeletal skiff	0		Last Available: "2012-10"
 5886	avaricious toasty vibrating Newton's Bonestabber	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Hot Damage: +5, Meat Drop: +30, Last Available: "2012-10"
 5887	acceptable crystal skeleton vodka	3	good	Last Available: "2012-10"
 5888	skewed Lazybones&trade; recliner	0		Last Available: "2012-10"
@@ -5802,7 +5802,7 @@
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	twirling pixel pill	0		
-5907	blue upside-down pixel energy tank	0		
+5907	upside-down blue pixel energy tank	0		
 5908	gray ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	pulsating chaotic experienced wedding ring	0		Experience: +2, Spell Critical Percent: +10, Single Equip
 5910	deactivated nanobots	0		Free Pull, Last Available: "2012-11"
@@ -5811,7 +5811,7 @@
 5913	pickled candy sushi set	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 50, Last Available: "2012-12"
 5914	chilled nitrogenated frozen spinning green sweet mochi ball	0		Effect: "Optimist Primal", Effect Duration: 54, Last Available: "2012-12"
 5915	enhanced liquefied maroon tumbling beet-flavored Mr. Mediocrebar	0		Effect: "Slime Time", Effect Duration: 28, Last Available: "2012-12"
-5916	nitrogenated wobbly purple wobbly sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Pasty", Effect Duration: 63, Last Available: "2012-12"
+5916	nitrogenated wobbly wobbly purple sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Pasty", Effect Duration: 63, Last Available: "2012-12"
 5917	Vulcanized frozen cabbage-flavored Mr. Mediocrebar	0		Effect: "Orchid Blood", Effect Duration: 55, Last Available: "2012-12"
 5918	rosy-cheeked plastic animelf	0		Maximum HP Percent: +30, Last Available: "2012-12"
 5919	plastic ChibiBuddy&trade; of terror	0		Spooky Spell Damage: +10, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	wobbly blinking ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	forbidden brainwave-controlled unicorn horn	0		Spell Damage Percent: +50, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	forbidden brainwave-controlled unicorn horn	0		Spell Damage Percent: +50, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	jittery blind-packed capsule toy	0		Last Available: "2012-12"
 5931	huge purple perfumed friendly plastic four-shadowed mime of the pedagogue	0		Experience: +3, Familiar Weight: +3, Stench Resistance: +5, Single Equip, Last Available: "2012-12"
@@ -5858,12 +5858,12 @@
 5960	frosty plastic Father McGruber	0		Cold Spell Damage: +10, Last Available: "2012-12"
 5961	hardy plastic Hank North, Photojournalist	0		Maximum HP: +50, Last Available: "2012-12"
 5962	tumbling blue plastic blazing bat of the ox	0		Muscle: +20, Last Available: "2012-12"
-5963	boxer's electronic dulcimer pants of the overflowing toilet	0		Muscle Percent: +10, Stench Spell Damage: +50, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	boxer's electronic dulcimer pants of the overflowing toilet	0		Muscle Percent: +10, Stench Spell Damage: +50, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	bouncing A-Boo clue	0		
 5965	twirling friendly Da Vinci's Frown Exerciser	0		Experience (Mysticality): +5, Familiar Weight: +3, Single Equip, Last Available: "2012-12"
 5966	lime green soul monocle	0		Single Equip
 5967	soul doorbell	0		
-5968	huge fuchsia soul coin	0		
+5968	fuchsia huge soul coin	0		
 5969	blue soul knife	0		
 5970	olive smartaleck's soul mask	0		Moxie Percent: +30, Single Equip
 5971	wobbly record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5879,7 +5879,7 @@
 5981	narrow star	0		Last Available: "2013-02"
 5982	hand-crafted tankard of ale	3	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	pulsating grievous Herculean cloth cap of the dark arts	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Spell Damage Percent: +100, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	pulsating grievous Herculean cloth cap of the dark arts	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Spell Damage Percent: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	cyan lightning-fast stanky savvy iron dagger	0		Mysticality Percent: +20, Stench Spell Damage: +25, Initiative: +40, Last Available: "2013-02"
 5986	adequate hamburger	3	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,7 +5887,7 @@
 5989	green potion	0		Last Available: "2013-02"
 5990	artisanal bottle of wine	3	EPIC	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	wobbly mansplainer's vibrating wicked iron helmet	0		Spell Damage: +5, Maximum MP Percent: +10, Monster Level: +15, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	wobbly mansplainer's vibrating wicked iron helmet	0		Spell Damage: +5, Maximum MP Percent: +10, Monster Level: +15, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	blurry aromatic experienced steel sword of Tarzan	0		Experience: +2, Experience (Muscle): +3, Stench Resistance: +1, Last Available: "2013-02"
 5994	jumbo rotten whole roasted chicken	5	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	hand-crafted shining goblet	3	EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	Usain Bolt's perfumed stanky crown	0		Stench Spell Damage: +25, Stench Resistance: +5, Initiative: +80, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	Usain Bolt's perfumed stanky crown	0		Stench Spell Damage: +25, Stench Resistance: +5, Initiative: +80, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	blinking supercool savvy sword of doom	0		Mysticality Percent: +20, Moxie Percent: +20, Spooky Spell Damage: +50, Last Available: "2013-02"
-6002	upside-down lightning-fast dangerous Helm of the Scream Emperor of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Initiative: +40, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	upside-down lightning-fast dangerous Helm of the Scream Emperor of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Initiative: +40, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	careful Fonzie's wizardly Cloak of Dire Shadows	0		Mysticality: +25, Experience (Moxie): +1, Monster Level: -10, Last Available: "2013-02"
 6004	knitted arcane researcher's Sword of Dark Omens of temperance	0		Experience Percent (Mysticality): +10, Cold Resistance: +3, Sleaze Resistance: +5, Last Available: "2013-02"
 6005	aromatic smooth Shield of Icy Fate of dire peril	0		Moxie: +15, Weapon Damage: +20, Stench Resistance: +1, Damage Reduction: 7, Last Available: "2013-02"
-6006	fireproof lard-coated Greaves of the Murk Lord of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +25, Hot Resistance: +3, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	fireproof lard-coated Greaves of the Murk Lord of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +25, Hot Resistance: +3, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	foul-smelling sharpshooter's Gauntlets of the Blood Moon of the blizzard	0		Critical Hit Percent: +10, Cold Spell Damage: +25, Stench Damage: +10, Single Equip, Last Available: "2013-02"
 6008	Tesla brainy Boots of Twilight Whispers of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-02"
 6009	padded occult Rosewater's Belt of Howling Anger	0		Mysticality Percent: +30, Spell Damage Percent: +25, Damage Absorption: +20, Single Equip, Last Available: "2013-02"
@@ -5931,7 +5931,7 @@
 6033	banded fortified stolen necklace	0		Damage Absorption: 160
 6034	rock-hard slick troll britches	0		Moxie: +10, Damage Reduction: 5, Familiar Effect: "1.5xPotato, cap 28"
 6035	oxidized ghostly vial of The Glistening	0		Effect: "Deeply Ironic", Effect Duration: 14
-6036	bad special artisanal limoncello	4	decent	Effect: "Fortunate Resolve", Effect Duration: 5
+6036	special bad artisanal limoncello	4	decent	Effect: "Fortunate Resolve", Effect Duration: 5
 6037	twirling ginger ale	0		
 6038	bland green incredible pizza	3	decent	
 6039	up-at-dawn oil cap of the storm	0		Maximum MP Percent: +40, Adventures: +5, Familiar Effect: "cap 28"
@@ -5951,7 +5951,7 @@
 6053	perfectly mixed Taco Dan's Taco Stand Chimichangarita	4	EPIC	Last Available: "2012-12"
 6054	cold-filtered aerosolized huge Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Greedy Resolve", Effect Duration: 42, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	pulsating The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	pulsating The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	reassuring stiffened Meatcleaver	0		Damage Reduction: 1, Spooky Resistance: +1, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of Tarzan	0		Experience (Muscle): +3, Last Available: "2012-12"
 6059	twirling arcane researcher's Crimbo stogie-scented room odorizer	0		Experience Percent (Mysticality): +10, Last Available: "2012-12"
@@ -5965,7 +5965,7 @@
 6067	spinning greedy Truthsayer of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +20, Last Available: "2013-12"
 6068	loose blade	0		
 6069	purple wobbly goblin bone hilt	0		
-6070	bouncing pulsating sword blade	0		
+6070	pulsating bouncing sword blade	0		
 6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	tumbling confusing LED clock	0		Last Available: "2012-12"
 6073	triple-wet haggis-infused soap	0		Effect: "Christmessy", Effect Duration: 19, Last Available: "2012-12"
@@ -5975,12 +5975,12 @@
 6077	toothsome haggis-wrapped haggis-stuffed haggis	3	awesome	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	skewed upside-down school calculator watch	0		Last Available: "2012-12"
-6080	blue dog trainer's haggis socks	0		Experience (familiar): +1, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	huge airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	blue dog trainer's haggis socks	0		Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	huge airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	pulsating Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
-6085	huge green magnetic sculpture kit	0		Last Available: "2012-12"
+6085	green huge magnetic sculpture kit	0		Last Available: "2012-12"
 6086	friendly Microplushie: Otakulone	0		Familiar Weight: +3, Last Available: "2012-12"
 6087	Oprah's Microplushie: Hippylase	0		Maximum MP Percent: +50, Last Available: "2012-12"
 6088	knitted Microplushie: Bropane	0		Cold Resistance: +3, Last Available: "2012-12"
@@ -6030,17 +6030,17 @@
 6132	battery	0		Last Available: "2013-12"
 6133	lime green lard-coated greasy White Dragon Fang of doom	0		Spooky Spell Damage: +50, Sleaze Spell Damage: 35, Last Available: "2013-12"
 6134	censurious butterfly knife	0		Sleaze Resistance: +3, Last Available: "2013-12"
-6135	ghostly tumbling tube of herbal ointment	0		Last Available: "2013-12"
+6135	tumbling ghostly tube of herbal ointment	0		Last Available: "2013-12"
 6136	tumbling pencil kunai	0		Last Available: "2013-12"
 6137	smooth weighted paperclip chain	0		Moxie: +15, Last Available: "2013-12"
 6138	great capacitor	0		Last Available: "2013-12"
 6139	upside-down experienced rubber gloves	0		Experience: +2, Last Available: "2013-12"
 6140	shaking teal Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	gigantic bland enchanted roasted duck	6	decent	Effect: "meat.enh", Effect Duration: 5, Last Available: "2013-12"
-6143	big moldy blinking dead meat bun	5	crappy	Last Available: "2013-12"
+6142	enchanted gigantic bland roasted duck	6	decent	Effect: "meat.enh", Effect Duration: 5, Last Available: "2013-12"
+6143	moldy big blinking dead meat bun	5	crappy	Last Available: "2013-12"
 6144	gray supercharged cat collar	0		Maximum MP Percent: +30, Single Equip, Last Available: "2013-12"
-6145	Samson's suspicious-looking fedora of terror	0		Experience (Muscle): +5, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	Samson's suspicious-looking fedora of terror	0		Experience (Muscle): +5, Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	bouncing Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	skewed Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	mirror MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6048,23 +6048,23 @@
 6151	carrot nose	0		Last Available: "2013-01"
 6152	stale carrot cake	4	decent	Last Available: "2013-01"
 6153	mediocre carrot claret	4	decent	Last Available: "2013-01"
-6154	mixed yellow ghostly pulsating carrot juice	1	awesome	Last Available: "2013-01"
+6154	mixed pulsating yellow ghostly carrot juice	1	awesome	Last Available: "2013-01"
 6155	blue pixel power cell	0		Last Available: "2013-12"
 6156	pulsating flickering pixel	0		Last Available: "2013-12"
 6157	blue toasty wizardly Byte	0		Mysticality: +25, Hot Damage: +5, Last Available: "2013-12"
-6158	blinking purple anger blaster of the dark arts	0		Spell Damage Percent: +100, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	squat lion tamer's doubt cannon	0		Experience (familiar): +2, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	nasty fear condenser	0		Stench Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	miser's regret hose	0		Meat Drop: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	blinking purple anger blaster of the dark arts	0		Spell Damage Percent: +100, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	squat lion tamer's doubt cannon	0		Experience (familiar): +2, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	nasty fear condenser	0		Stench Damage: +5, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	miser's regret hose	0		Meat Drop: +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	jittery huge Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	narrow Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	chaotic supercool commodore's hat	0		Moxie Percent: +20, Spell Critical Percent: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	twirling rosewater-soaked naval trousers	0		Stench Resistance: +3, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	chaotic supercool commodore's hat	0		Moxie Percent: +20, Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	twirling rosewater-soaked naval trousers	0		Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	Fonzie's strapping deck cannon	0		Muscle: +5, Experience (Moxie): +1, Last Available: "2013-12"
 6167	ornamental sextant	0		Item Drop: +5, Last Available: "2013-12"
 6168	narrow Bloodbath of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Last Available: "2013-12"
 6169	aged watered-down Hundred Headed IPA	2	awesome	Last Available: "2013-12"
-6170	bland super-sized squat chum	5	decent	Last Available: "2013-12"
+6170	super-sized bland squat chum	5	decent	Last Available: "2013-12"
 6171	double-diffused altered crude crudit&eacute;s	0		Effect: "Certainty", Effect Duration: 23
 6172	wet narrow candy crayons	0		Effect: "Gummi Badass", Effect Duration: 32, Last Available: "2020-09"
 6173	coward's clever pixel grappling hook	0		Maximum MP: +20, Monster Level: -20
@@ -6079,16 +6079,16 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	narrow toasty dance instructor's Jarlsberg's hat of Gandalf	0		Experience Percent (Moxie): +10, Spell Critical Percent: +20, Hot Damage: +5
-6185	miniature yummy consummate hard-boiled egg	2	awesome	
+6185	yummy miniature consummate hard-boiled egg	2	awesome	
 6186	rotten half-sized narrow consummate fried egg	2	crappy	
-6187	bland half-sized shaking consummate egg salad	2	decent	
+6187	half-sized bland shaking consummate egg salad	2	decent	
 6188	rotten consummate bagel	4	crappy	
 6189	tasty consummate sliced bread	4	awesome	
 6190	tasty spinning consummate hot dog bun	4	awesome	
-6191	tiny decent consummate brownie	1	good	
+6191	decent tiny consummate brownie	1	good	
 6192	immense decent consummate toast	8	good	
 6193	tolerable fortified passable stout	5	good	
-6194	diet bland consummate soup	1	decent	
+6194	bland diet consummate soup	1	decent	
 6195	rotten consummate corn chips	3	crappy	
 6196	moldy enchanted consummate salad	3	crappy	Effect: "Eldritch Concentration", Effect Duration: 30
 6197	yummy consummate salsa	3	awesome	
@@ -6097,37 +6097,37 @@
 6200	rotten consummate melted cheese	3	crappy	
 6201	stale consummate bacon	3	decent	
 6202	enchanted bland consummate meatloaf	3	decent	Effect: "Ogred and Oublietted", Effect Duration: 35
-6203	fancy super-sized adequate consummate steak	5	good	Effect: "Certainty", Effect Duration: 30
-6204	miniature adequate consummate cuts	2	good	
+6203	adequate fancy super-sized consummate steak	5	good	Effect: "Certainty", Effect Duration: 30
+6204	adequate miniature consummate cuts	2	good	
 6205	delicious consummate frankfurter	3	awesome	
-6206	jumbo fancy bland blue consummate french fries	5	decent	Effect: "Musky", Effect Duration: 45
-6207	yummy massive wobbly jittery consummate baked potato	8	awesome	
+6206	jumbo bland fancy blue consummate french fries	5	decent	Effect: "Musky", Effect Duration: 45
+6207	massive yummy jittery wobbly consummate baked potato	8	awesome	
 6208	delicious acceptable vodka	3	awesome	
-6209	snack-sized bland consummate ice cream	2	decent	
+6209	bland snack-sized consummate ice cream	2	decent	
 6210	spoiled miniature consummate whipped cream	2	crappy	
 6211	bland purple consummate cream	3	decent	
 6212	bland twirling consummate strawberries	4	decent	
 6213	half-sized tasty consummate sorbet	2	awesome	
-6214	triple-distilled tolerable lime green adequate rum	7	good	
+6214	tolerable triple-distilled lime green adequate rum	7	good	
 6215	drinkable mediocre lager	4	good	
-6216	stale super-sized pulsating immaculate grilled cheese	5	decent	
+6216	super-sized stale pulsating immaculate grilled cheese	5	decent	
 6217	miniature stale immaculate ice cream sandwich	2	decent	
-6218	delicious gigantic cyan upside-down immaculate hot dog	8	awesome	
+6218	gigantic delicious upside-down cyan immaculate hot dog	8	awesome	
 6219	stale jittery immaculate egg salad sandwich	4	decent	
-6220	snack-sized toothsome perfect sandwich	2	awesome	
+6220	toothsome snack-sized perfect sandwich	2	awesome	
 6221	super-sized adequate perfect chef salad	5	good	
-6222	super-sized delicious perfect breakfast	5	awesome	
+6222	delicious super-sized perfect breakfast	5	awesome	
 6223	yummy sublime deluxe hot dog	4	awesome	
-6224	big stale sublime stew	5	decent	
+6224	stale big sublime stew	5	decent	
 6225	delicious immense twirling sublime nachos	10	awesome	
-6226	low-calorie spoiled blue Ultimate Breakfast Sandwich	1	crappy	
-6227	fancy snack-sized spoiled Loaded Baked Potato	2	crappy	Effect: "Violent Night", Effect Duration: 10
+6226	spoiled low-calorie blue Ultimate Breakfast Sandwich	1	crappy	
+6227	spoiled fancy snack-sized Loaded Baked Potato	2	crappy	Effect: "Violent Night", Effect Duration: 10
 6228	spoiled small narrow Omega Sundae	2	crappy	
-6229	strong lousy Das Sauerlager	5	decent	
+6229	lousy strong Das Sauerlager	5	decent	
 6230	delicious tumbling Bologna Lambic	4	awesome	
-6231	artisanal distilled Vodka Dog	5	EPIC	
-6232	watered-down lousy Disappointed Russian	2	decent	
-6233	watered-down lousy huge Chunky Mary	2	decent	
+6231	distilled artisanal Vodka Dog	5	EPIC	
+6232	lousy watered-down Disappointed Russian	2	decent	
+6233	lousy watered-down huge Chunky Mary	2	decent	
 6234	special lousy mirror Nachojito	3	decent	Effect: "Grrrrrrreat!", Effect Duration: 45
 6235	mediocre Le Roi	4	decent	
 6236	mediocre Over Easy Rider	4	decent	
@@ -6145,7 +6145,7 @@
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	shaking chaotic rosy-cheeked groovy boxer's numberwang of Tarzan of Flo-Jo	0		Muscle Percent: +10, Moxie Percent: +10, Experience (Muscle): +3, Maximum HP Percent: +30, Spell Critical Percent: +10, Initiative: +100, Single Equip
 6251	unsweetened polarized olive scroll of Protection from Bad Stuff	0		Effect: "Musky", Effect Duration: 35, Last Available: "2013-02"
-6252	ionized spinning bouncing jittery scroll of Puddingskin	0		Effect: "stats.enq", Effect Duration: 40, Last Available: "2013-02"
+6252	ionized jittery bouncing spinning scroll of Puddingskin	0		Effect: "stats.enq", Effect Duration: 40, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	blurry Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
@@ -6161,7 +6161,7 @@
 6265	fireproof Jack Frost's Lo Pan's Staff of the Cream of the Cream	0		Spell Critical Percent: +30, Cold Spell Damage: +50, Hot Resistance: +3, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
 6267	rotten bite-sized fuchsia grain of protein powder	1	crappy	
-6268	chilled quadruple-Vulcanized jittery red twirling pec oil	0		Effect: "Mushroom Moxiousness", Effect Duration: 53
+6268	chilled quadruple-Vulcanized red twirling jittery pec oil	0		Effect: "Mushroom Moxiousness", Effect Duration: 53
 6269	sharpshooter's gym membership card	0		Critical Hit Percent: +10
 6270	triple-aerosolized yellow Squat-Thrust Magazine	0		Effect: "Fancy Feasted", Effect Duration: 45
 6271	massive dumbbell	0		
@@ -6170,7 +6170,7 @@
 6274	tolerable fortified wobbly open sauce	5	good	
 6275	wobbly wool foul-smelling turkey leg	0		Stench Damage: +10, Cold Resistance: +1
 6276	perfectly mixed Ye Olde Meade	3	EPIC	
-6277	dry bouncing twirling huge Ye Olde Bawdy Limerick	0		Effect: "Mushroom Samba", Effect Duration: 16
+6277	dry huge bouncing twirling Ye Olde Bawdy Limerick	0		Effect: "Mushroom Samba", Effect Duration: 16
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of the brute	0		Muscle Percent: +30
 6280	shaking dance instructor's artisanal rice peeler	0		Experience Percent (Moxie): +10
@@ -6182,7 +6182,7 @@
 6286	veiny stiffened wicked Mark II Steam-Hat	0		Spell Damage: +5, Damage Reduction: 1, Maximum HP: +10, Familiar Effect: "1xLep, cap 37"
 6287	stanky veiny hardened Mark III Steam-Hat of terror	0		Damage Reduction: 3, Maximum HP: +10, Stench Spell Damage: +25, Spooky Spell Damage: +10, Familiar Effect: "1xLep, cap 37"
 6288	Jack Frost's Annie Oakley's Oprah's extremely unsafe Mark IV Steam-Hat of the detective	0		Weapon Damage Percent: +100, Maximum MP Percent: +50, Critical Hit Percent: +20, Cold Spell Damage: +50, Item Drop: +20, Familiar Effect: "1xLep, cap 37"
-6289	blurry twirling resourceful therapeutic razor-sharp Samson's supercool Mark V Steam-Hat	0		Moxie Percent: +20, Experience (Muscle): +5, Weapon Damage Percent: +25, Maximum MP: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	blurry twirling resourceful therapeutic razor-sharp Samson's supercool Mark V Steam-Hat	0		Moxie Percent: +20, Experience (Muscle): +5, Weapon Damage Percent: +25, Maximum MP: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	greasy rosy-cheeked punk rock jacket	0		Maximum HP Percent: +30, Sleaze Spell Damage: +10
 6292	banded safety pin of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100
@@ -6191,7 +6191,7 @@
 6295	squat drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	blue fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
-6298	twirling green Thwaitgold firefly statuette	0		
+6298	green twirling Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	triple-chilled alkaline concentrated Super Weight-Gain 9000	0		Effect: "Witch Breaded", Effect Duration: 22
 6301	adjusted mirror possibility potion	0		Effect: "Wreathed in Smoke", Effect Duration: 20
@@ -6246,7 +6246,7 @@
 6350	ghostly sizzling Mer-kin gutgirdle	0		Hot Damage: +10, Experience (Moxie): +20, Single Equip
 6351	blinking pulsating beefy Mer-kin finpaddle	0		Muscle: +10
 6352	Mer-kin stopwatch of temperance	0		Sleaze Resistance: +5, Initiative: +50
-6353	blurry narrow Mer-kin dreadscroll	0		
+6353	narrow blurry Mer-kin dreadscroll	0		
 6354	warmed unsweetened Mer-kin smartjuice	0		Effect: "Rave Concentration", Effect Duration: 45
 6355	non-alkaline colloidal liquefied twirling Mer-kin cooljuice	0		Effect: "Dweeby", Effect Duration: 42
 6356	twirling Mer-kin worktea	0		
@@ -6265,7 +6265,7 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	drinkable practically non-alcoholic can of the cheapest beer	1	good	
-6372	mediocre blinking bouncing bottle of fruity &quot;wine&quot;	4	decent	
+6372	mediocre bouncing blinking bottle of fruity &quot;wine&quot;	4	decent	
 6373	tolerable single swig of vodka	4	good	
 6374	angry inch	0		
 6375	huge manspreader's testy toolbox	0		Monster Level: +10
@@ -6278,14 +6278,14 @@
 6383	root beer	1	awesome	
 6384	jigsaw blade	0		
 6385	cyan wood screw	0		
-6386	skewed tumbling balsa plank	0		
+6386	tumbling skewed balsa plank	0		
 6387	blob of wood glue	0		
 6388	pulsating envyfish egg	0		Last Available: "2013-04"
 6389	polarized vacuum-sealed mirror Mer-kin rocksalt	0		Effect: "Wreathed in Smoke", Effect Duration: 14
 6390	super-energized irradiated super-anodized gray Mer-kin saltmint	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 57
 6391	tarnished tarnished Mer-kin saltsquid	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 13
 6392	rock-hard smartaleck's scale-mail underwear	0		Moxie Percent: +30, Damage Reduction: 5, Familiar Effect: "2xVolley"
-6393	enhanced double-enhanced green upside-down comb jelly	0		Effect: "Cold Hands", Effect Duration: 14
+6393	enhanced double-enhanced upside-down green comb jelly	0		Effect: "Cold Hands", Effect Duration: 14
 6394	anemone sauce	0		
 6395	inky squid sauce	0		
 6396	blue Mer-kin weaksauce	0		
@@ -6308,17 +6308,17 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	half-sized decent flavorless gruel	2	good	
-6416	jumbo decent mana curds	5	good	
+6416	decent jumbo mana curds	5	good	
 6417	teal twist of lime	0		
 6418	pencil stub	0		
 6419	boiled olive moth dust	0		Effect: "Vented Spleen", Effect Duration: 24
 6420	chilled glob of spoiled mayo	0		Effect: "There Is A Spoon", Effect Duration: 35
 6421	tonic djinn	0		
-6422	bland half-sized vampire chowder	2	decent	
+6422	half-sized bland vampire chowder	2	decent	
 6423	narrow Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
-6425	teal blurry Official Seal of Dreadsylvania	0		
-6426	stale gigantic Dreadsylvanian stew	10	decent	
+6425	blurry teal Official Seal of Dreadsylvania	0		
+6426	gigantic stale Dreadsylvanian stew	10	decent	
 6427	lousy Dreadsylvanian	3	decent	
 6428	boiled magnetized Dreadsylvanian flask	0		Effect: "Arse-a'fire", Effect Duration: 28
 6429	double-pickled Dreadsylvanian flask	0		Effect: "Spooky Hands", Effect Duration: 28
@@ -6338,7 +6338,7 @@
 6443	manspreader's Helps-You-Sleep of mayonnaise	0		Monster Level: +10, Sleaze Spell Damage: +50, Single Equip
 6444	manspreader's occult Quiets-Your-Steps of the boozehound	0		Spell Damage Percent: +25, Monster Level: +10, Booze Drop: +100, Single Equip
 6445	fuchsia Protects-Your-Junk of extreme caution of the overflowing toilet	0		Monster Level: -25, Stench Spell Damage: +50, Single Equip
-6446	distilled artisanal jittery mirror Gets-You-Drunk	5	EPIC	
+6446	distilled artisanal mirror jittery Gets-You-Drunk	5	EPIC	
 6447	pulsating toasty steel-toed dangerous Great Wolf's headband	0		Weapon Damage: +10, Damage Reduction: 9, Hot Damage: +5, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	bouncing Jack Frost's supercharged dance instructor's Great Wolf's left paw	0		Experience Percent (Moxie): +10, Maximum MP Percent: +30, Cold Spell Damage: +50, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	shellacked arcane researcher's Great Wolf's right paw of the ox	0		Muscle: +20, Experience Percent (Mysticality): +10, Damage Reduction: 7, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6390,7 +6390,7 @@
 6495	blue Dreadsylvania Auditor's badge of the boozehound	0		Booze Drop: +100, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
-6498	bad practically non-alcoholic bloody kiwitini	1	decent	
+6498	practically non-alcoholic bad bloody kiwitini	1	decent	
 6499	moon-amber	0		
 6500	ghostly polished moon-amber	0		
 6501	shaking inspector's extremely unsafe moon-amber necklace of temperance	0		Weapon Damage Percent: +100, Sleaze Resistance: +5, Item Drop: +15, Single Equip
@@ -6438,7 +6438,7 @@
 6543	razor-sharp pogo stick of the sewer	0		Weapon Damage Percent: +25, Stench Damage: +25, Single Equip
 6545	chaotic energetic weedy skirt	0		Maximum MP Percent: +20, Spell Critical Percent: +10, Item Drop: +5, Familiar Effect: "atk, 1xFairy"
 6546	vibrating medical-grade pants	0		Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk"
-6547	huge shaking Thwaitgold Goliath beetle statuette	0		
+6547	shaking huge Thwaitgold Goliath beetle statuette	0		
 6548	bouncing cooling iron helmet	0		
 6549	cooling iron breastplate	0		
 6550	tumbling cooling iron greaves	0		
@@ -6455,22 +6455,22 @@
 6561	squat adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	ghostly mini-Mr. Accessory	0		Familiar Weight: +5
 6563	grievous hand of Mr. Cards	0		Weapon Damage Percent: +50, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	enchanted stale thick wobbly Dreadsylvanian hot pocket	5	decent	Effect: "Blubbered Up", Effect Duration: 30
+6564	thick enchanted stale wobbly Dreadsylvanian hot pocket	5	decent	Effect: "Blubbered Up", Effect Duration: 30
 6565	big tasty maroon Dreadsylvanian pocket	5	awesome	
-6566	delicious huge Dreadsylvanian pocket	10	awesome	
-6567	low-calorie rotten Dreadsylvanian stink pocket	1	crappy	
+6566	huge delicious Dreadsylvanian pocket	10	awesome	
+6567	rotten low-calorie Dreadsylvanian stink pocket	1	crappy	
 6568	decent Dreadsylvanian sleaze pocket	3	good	
 6569	hand-crafted blinking Dreadsylvanian hot toddy	3	super ultra mega turbo EPIC	
 6570	acceptable weak twirling Dreadsylvanian cold-fashioned	2	good	
 6571	hand-crafted Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	
 6572	watered-down drinkable Dreadsylvanian dank and stormy	2	good	
-6573	practically non-alcoholic acceptable squat Dreadsylvanian slithery nipple	1	good	
+6573	acceptable practically non-alcoholic squat Dreadsylvanian slithery nipple	1	good	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	narrow clusterbomb	0		
 6577	stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
-6579	pulsating green Dreadsylvanian Almanac page	0		
+6579	green pulsating Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	dreadful box	0		
 6582	lime green Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
@@ -6482,7 +6482,7 @@
 6588	mirror smelly arcane researcher's gnawed-up dog bone	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +10
 6589	tumbling supercharged Grey Guanon	0		Maximum MP Percent: +30
 6590	shaking flame-retardant Fonzie's Engorged Sausages and You of Gandalf	0		Experience (Moxie): +1, Spell Critical Percent: +20, Hot Resistance: +1
-6591	perfectly mixed fortified upside-down dream of a dog	5	EPIC	
+6591	fortified perfectly mixed upside-down dream of a dog	5	EPIC	
 6592	yellow reassuring flame-retardant stiffened optimal spreadsheet	0		Damage Reduction: 1, Hot Resistance: +1, Spooky Resistance: +1
 6593	defective Game Grid token	0		
 6594	shaking green hot Dreadsylvanian cocoa	0		
@@ -6507,7 +6507,7 @@
 6613	shaking clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	aged distilled Cold One	5	???	
-6616	stale spinning blinking spaghetti breakfast	3	???	
+6616	stale blinking spinning spaghetti breakfast	3	???	
 6617	bouncing over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6529,7 +6529,7 @@
 6635	skewed folder (Seawolf)	0		Last Available: "2013-08"
 6636	spinning folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
-6638	jittery spinning folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
+6638	spinning jittery folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	folder (owl)	0		Last Available: "2013-08"
 6640	folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	wobbly folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
@@ -6548,8 +6548,8 @@
 6656	illegal firecracker	0		
 6657	aromatic friendly pickelhaube	0		Familiar Weight: +3, Stench Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	boiled huge hair oil	0		Effect: "Moon-Eyed", Effect Duration: 52
-6659	super-tarnished Vulcanized diffused green tumbling scrap	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 21
-6660	tumbling purple school spirit socket set	0		
+6659	super-tarnished Vulcanized diffused tumbling green scrap	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 21
+6660	purple tumbling school spirit socket set	0		
 6661	suspension bridge	0		
 6662	personal trainer's educational Staff of the Lunch Lady of Leguizamo of terror	0		Experience: +1, Experience Percent (Muscle): +10, Monster Level: +20, Spooky Spell Damage: +10
 6663	bouncing universal key	0		
@@ -6571,7 +6571,7 @@
 6679	gray narrow dangerous machete	0		Weapon Damage: +10
 6680	strong tolerable Cursed Punch	5	good	
 6681	bad Bowl of Scorpions	3	decent	
-6682	high-proof lousy Fog Murderer	6	decent	
+6682	lousy high-proof Fog Murderer	6	decent	
 6683	pulsating book of matches	0		
 6684	brawny surgical mask	0		Muscle Percent: +20, Surgeonosity: +1
 6685	huge studded head mirror	0		Damage Absorption: +80, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	bowler	0		
 6703	imitation White Russian	1	good	
 6704	miser's therapeutic short-handled mop	0		Meat Drop: +10, HP Regen Min: 5, HP Regen Max: 7
-6705	decent spinning huge jungle floor wax	4	good	
+6705	decent huge spinning jungle floor wax	4	good	
 6706	smirking shrunken head	0		
 6707	denatured colorful toad	0		Effect: "Ghostly Shell", Effect Duration: 51
 6708	crude voodoo doll	0		
@@ -6613,7 +6613,7 @@
 6721	extremely unsafe sage water bottle of the detective	0		Mysticality Percent: +10, Weapon Damage Percent: +100, Item Drop: +20, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	magnetized quadruple-nitrogenated pygmy phone number	0		Effect: "Devil Inside", Effect Duration: 69
 6723	lime green Boozehounds Anonymous token	0		
-6724	immense enchanted rotten exotic jungle fruit	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5
+6724	enchanted rotten immense exotic jungle fruit	6	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 5
 6725	cyan Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6635,7 +6635,7 @@
 6743	junk trunks of the businessman	0		Meat Drop: +50, Familiar Effect: "cap 15"
 6744	tumbling junk-mail shirt of the sewer	0		Stench Damage: +25
 6745	spoiled junk food	3	crappy	
-6746	weak perfectly mixed twirling junk yard	2	EPIC	
+6746	perfectly mixed weak twirling junk yard	2	EPIC	
 6747	energetic extremely unsafe swordzall	0		Weapon Damage Percent: +100, Maximum MP Percent: +20
 6748	arm buzzer of the brute	0		Muscle Percent: +30, Damage Reduction: 6
 6749	careful boilgun of the cheetah	0		Monster Level: -10, Initiative: +60
@@ -6646,7 +6646,7 @@
 6754	beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	aged weak can of Br&uuml;talbr&auml;u	2	awesome	Last Available: "2013-09"
+6757	weak aged can of Br&uuml;talbr&auml;u	2	awesome	Last Available: "2013-09"
 6758	tolerable can of Drooling Monk	3	good	Last Available: "2013-09"
 6759	hand-crafted can of Impetuous Scofflaw	4	EPIC	Last Available: "2013-09"
 6760	mediocre bottle of Old Pugilist	4	decent	Last Available: "2013-09"
@@ -6657,8 +6657,8 @@
 6765	artisanal bottle of Lambada Lambic	3	EPIC	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
-6768	enchanted squat gray skewed liquid bread	1	crappy	Effect: "Aspect of the Twinklefairy", Effect Duration: 30, Last Available: "2013-09"
-6769	huge executive vibrating tin tam of the businessman	0		Maximum MP Percent: +10, Meat Drop: 90, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6768	enchanted gray squat skewed liquid bread	1	crappy	Effect: "Aspect of the Twinklefairy", Effect Duration: 30, Last Available: "2013-09"
+6769	huge executive vibrating tin tam of the businessman	0		Maximum MP Percent: +10, Meat Drop: 90, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	quadruple-wet tin cup	0		Effect: "Buggy Flavor", Effect Duration: 27, Last Available: "2013-09"
 6771	inspector's rock-hard tin foil of courage	0		Damage Reduction: 5, Spooky Resistance: +3, Item Drop: +15, Last Available: "2013-09"
 6772	double-paned frosty smooth tin drum	0		Moxie: +15, Cold Spell Damage: +10, Cold Resistance: +5, Last Available: "2013-09"
@@ -6666,7 +6666,7 @@
 6774	spinning tin snips	0		Last Available: "2013-09"
 6775	narrow upside-down tin lizzie	0		Last Available: "2013-09"
 6776	triple-galvanized frozen blinking foetid seal tear	0		Effect: "Metal Speed", Effect Duration: 46
-6777	ionized blurry wobbly seal sweat	0		Effect: "Thunderspell", Effect Duration: 30
+6777	ionized wobbly blurry seal sweat	0		Effect: "Thunderspell", Effect Duration: 30
 6778	corrupted enhanced boiling seal blood	0		Effect: "Human-Orc Hybrid", Effect Duration: 16
 6779	crystalline seal eye	0		Single Equip
 6780	family-friendly ribald studded sealhide shield	0		Sleaze Damage: +10, Sleaze Resistance: +1, Damage Reduction: 7
@@ -6681,7 +6681,7 @@
 6791	fuchsia sharpened spoon	0		
 6792	candy knife	0		
 6793	mirror soap knife	0		
-6795	polarized lime green blinking disco horoscope (Aquarius)	0		Effect: "Dreadful Heat", Effect Duration: 33
+6795	polarized blinking lime green disco horoscope (Aquarius)	0		Effect: "Dreadful Heat", Effect Duration: 33
 6796	altered upside-down disco horoscope (Pisces)	0		Effect: "Nano-juiced", Effect Duration: 43
 6797	improved corrupted disco horoscope (Aries)	0		Effect: "Hennaliciousness", Effect Duration: 60
 6798	oxidized anodized disco horoscope (Taurus)	0		Effect: "Bread-Lined", Effect Duration: 68
@@ -6714,7 +6714,7 @@
 6825	squat ruddy rosy-cheeked alarm accordion	0		Maximum HP Percent: 70, Class: "Accordion Thief", Song Duration: 20
 6826	spinning twirling ribald Samson's All-Hallow's Steve's fright wig of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Sleaze Damage: +10, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	mirror chaotic stylish KoL Con X Treasure Map	0		Moxie: +25, Spell Critical Percent: +10
-6828	fancy artisanal practically non-alcoholic mirror discocktail	1	super ultra EPIC	Effect: "Tingly Biceps", Effect Duration: 20
+6828	practically non-alcoholic artisanal fancy mirror discocktail	1	super ultra EPIC	Effect: "Tingly Biceps", Effect Duration: 20
 6829	wobbly executive KoL Con X Bingo Card	0		Meat Drop: +40
 6830	upside-down razor-sharp Temporal Tempera Tube	0		Weapon Damage Percent: +25
 6831	altered modified fuchsia Tallowcreme Halloween Pumpkin	0		Effect: "Antsy in your Pantsy", Effect Duration: 13
@@ -6727,7 +6727,7 @@
 6838	cold-filtered oxidized Bugbearclaw Donut	0		Effect: "Object Detection", Effect Duration: 22
 6839	wet modified jam	0		Effect: "Eye of the Seal", Effect Duration: 35
 6840	chilled concentrated blue Whenchamacallit bar	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 21
-6841	magnetized adjusted purple jittery 8-bit banana	0		Effect: "Perception", Effect Duration: 11
+6841	magnetized adjusted jittery purple 8-bit banana	0		Effect: "Perception", Effect Duration: 11
 6842	energized shaking vial of blood simple syrup	0		Effect: "Pharmaceutically Cool", Effect Duration: 64
 6843	colloidal bone bons	0		Effect: "Well-Swabbed Ear", Effect Duration: 38
 6844	super-boiled tarnished pulsating ironic mint	0		Effect: "Hyphemariffic", Effect Duration: 13
@@ -6741,12 +6741,12 @@
 6852	Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	blurry desert sightseeing pamphlet	0		
-6855	blurry fuchsia a suspicious address	0		
+6855	fuchsia blurry a suspicious address	0		
 6856	twirling Bal-musette accordion of vim and vigor	0		Maximum HP Percent: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	studded Cajun accordion	0		Damage Absorption: +80, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	mirror careful quirky accordion	0		Monster Level: -10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	studded grievous Skipper's accordion	0		Weapon Damage Percent: +50, Damage Absorption: +80, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	bouncing coward's experienced Pantsgiving of Gandalf of incineration	0		Experience: +2, Spell Critical Percent: +20, Monster Level: -20, Hot Spell Damage: +50, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	bouncing coward's experienced Pantsgiving of Gandalf of incineration	0		Experience: +2, Spell Critical Percent: +20, Monster Level: -20, Hot Spell Damage: +50, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	yummy can of sardines	3	awesome	Last Available: "2013-11"
 6862	moldy high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
 6863	rotten pat of butter	4	crappy	Last Available: "2013-11"
@@ -6755,7 +6755,7 @@
 6866	flavorless whole turkey leg	3	decent	Last Available: "2013-11"
 6867	yummy deviled egg	4	awesome	Last Available: "2013-11"
 6868	activated wobbly finger exerciser	0		Effect: "OMG WTF", Effect Duration: 49, Last Available: "2013-11"
-6869	dry purple huge dented spoon	0		Effect: "Stinkybeard", Effect Duration: 69, Last Available: "2013-11"
+6869	dry huge purple dented spoon	0		Effect: "Stinkybeard", Effect Duration: 69, Last Available: "2013-11"
 6870	magnetized flattened galvanized blinking love note	0		Effect: "Compensatory Cruelness", Effect Duration: 16, Last Available: "2013-11"
 6871	skewed spinning school beer pull tab	0		Last Available: "2013-11"
 6872	flattened cold-filtered nail file	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 35, Last Available: "2013-11"
@@ -6790,10 +6790,10 @@
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	spinning careful healthy flask flops	0		Maximum HP Percent: +20, Monster Level: -10, Single Equip
 6903	pressed unsweetened nuts	0		Effect: "Rain Dancin'", Effect Duration: 23, Last Available: "2013-12"
-6904	dry squat gray bolts	0		Effect: "Nasty, Nasty Breath", Effect Duration: 46, Last Available: "2013-12"
+6904	dry gray squat bolts	0		Effect: "Nasty, Nasty Breath", Effect Duration: 46, Last Available: "2013-12"
 6905	stale gingerbread robot	4	decent	Last Available: "2013-12"
-6906	low-calorie enchanted stale petit 4.1	1	decent	Effect: "Very Clean Teeth", Effect Duration: 50, Last Available: "2013-12"
-6907	moldy half-sized nut-shaped Crimbo cookie	2	crappy	Last Available: "2023-06"
+6906	enchanted stale low-calorie petit 4.1	1	decent	Effect: "Very Clean Teeth", Effect Duration: 50, Last Available: "2013-12"
+6907	half-sized moldy nut-shaped Crimbo cookie	2	crappy	Last Available: "2023-06"
 6908	jittery wholesome plastic GORM-8	0		Maximum HP Percent: +10, Last Available: "2013-12"
 6909	rosy-cheeked plastic warbear	0		Maximum HP Percent: +30, Last Available: "2013-12"
 6910	chaotic plastic Toybot	0		Spell Critical Percent: +10, Last Available: "2013-12"
@@ -6809,30 +6809,30 @@
 6920	non-flattened corrupted warbear liquid overcoat	0		Effect: "Barbecue Saucy", Effect Duration: 63, Last Available: "2013-12"
 6921	super-sized bland warbear feasting bread	5	decent	Last Available: "2013-12"
 6922	decent warbear warrior bread	4	good	Last Available: "2013-12"
-6923	small rotten warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
+6923	rotten small warbear thermoregulator bread	2	crappy	Last Available: "2013-12"
 6924	smooth fancy warbear feasting mead	4	awesome	Effect: "One For Tea", Effect Duration: 20, Last Available: "2013-12"
-6925	lousy high-proof warbear bearserker mead	6	decent	Last Available: "2013-12"
+6925	high-proof lousy warbear bearserker mead	6	decent	Last Available: "2013-12"
 6926	tolerable warbear blizzard mead	3	good	Last Available: "2013-12"
 6927	narrow warbear helm fragment	0		Last Available: "2013-12"
-6928	pulsating pulsating wool veiny dance instructor's warbear plain fedora	0		Experience Percent (Moxie): +10, Maximum HP: +10, Cold Resistance: +1, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	warbear feathered fedora of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	slick warbear fedora of terror of doom	0		Moxie: +10, Spooky Spell Damage: 60, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	lime green bouncing coward's sharpshooter's Da Vinci's warbear plain helm	0		Experience (Mysticality): +5, Critical Hit Percent: +10, Monster Level: -20, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	savvy warbear spiked helm	0		Mysticality Percent: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	clever supercharged Fonzie's warbear electro-spiked helm	0		Experience (Moxie): +1, Maximum MP Percent: +30, Maximum MP: +20, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	ruddy Samson's beefy warbear plain ushanka	0		Muscle: +10, Experience (Muscle): +5, Maximum HP Percent: +40, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	twirling beefy warbear lined ushanka	0		Muscle: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	aromatic dog trainer's warbear heated ushanka of the early riser	0		Experience (familiar): +1, Stench Resistance: +1, Adventures: +7, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	pulsating pulsating wool veiny dance instructor's warbear plain fedora	0		Experience Percent (Moxie): +10, Maximum HP: +10, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	warbear feathered fedora of Flo-Jo	0		Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	slick warbear fedora of terror of doom	0		Moxie: +10, Spooky Spell Damage: 60, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	lime green bouncing coward's sharpshooter's Da Vinci's warbear plain helm	0		Experience (Mysticality): +5, Critical Hit Percent: +10, Monster Level: -20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	savvy warbear spiked helm	0		Mysticality Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	clever supercharged Fonzie's warbear electro-spiked helm	0		Experience (Moxie): +1, Maximum MP Percent: +30, Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	ruddy Samson's beefy warbear plain ushanka	0		Muscle: +10, Experience (Muscle): +5, Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	twirling beefy warbear lined ushanka	0		Muscle: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	aromatic dog trainer's warbear heated ushanka of the early riser	0		Experience (familiar): +1, Stench Resistance: +1, Adventures: +7, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	stylish thinker's warbear party pants of the empath	0		Mysticality: +10, Moxie: +25, Familiar Weight: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	educational warbear ceremonial party pants	0		Experience: +1, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	Sherlock's wizardly warbear high festival pants of the empath	0		Mysticality: +25, Familiar Weight: +5, Item Drop: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	bouncing fireproof baleful warbear battle greaves of Tarzan	0		Experience (Muscle): +3, Spell Damage: +25, Hot Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	yellow strapping warbear officer greaves	0		Muscle: +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	spinning inspector's quilted warbear bearserker greaves of the scaredy-cat	0		Damage Absorption: +40, Monster Level: -15, Item Drop: +15, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	wool experienced warbear johns of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Cold Resistance: +1, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	strapping warbear fleece-lined johns	0		Muscle: +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	warbear johns of the wise owl of the cougar of the businessman	0		Mysticality: +20, Moxie: +20, Meat Drop: +50, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	stylish thinker's warbear party pants of the empath	0		Mysticality: +10, Moxie: +25, Familiar Weight: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	educational warbear ceremonial party pants	0		Experience: +1, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	Sherlock's wizardly warbear high festival pants of the empath	0		Mysticality: +25, Familiar Weight: +5, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	bouncing fireproof baleful warbear battle greaves of Tarzan	0		Experience (Muscle): +3, Spell Damage: +25, Hot Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	yellow strapping warbear officer greaves	0		Muscle: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	spinning inspector's quilted warbear bearserker greaves of the scaredy-cat	0		Damage Absorption: +40, Monster Level: -15, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	wool experienced warbear johns of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	strapping warbear fleece-lined johns	0		Muscle: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	warbear johns of the wise owl of the cougar of the businessman	0		Mysticality: +20, Moxie: +20, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	healthy thinker's warbear goggles of Flo-Jo	0		Mysticality: +10, Maximum HP Percent: +20, Initiative: +100, Single Equip, Last Available: "2013-12"
 6949	wobbly warbear snowblindness goggles of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2013-12"
@@ -6845,12 +6845,12 @@
 6956	wobbly rosy-cheeked strapping warbear warscarf of the sweet-tooth	0		Muscle: +5, Maximum HP Percent: +30, Candy Drop: +100, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	tumbling frosty warbear foil hat	0		Cold Spell Damage: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	tumbling frosty warbear foil hat	0		Cold Spell Damage: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	ghostly warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	up-at-dawn veiny warbear oil pan	0		Maximum HP: +10, Adventures: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	up-at-dawn veiny warbear oil pan	0		Maximum HP: +10, Adventures: +5, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	warbear exhaust manifold of the wise owl	0		Mysticality: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
-6964	bouncing tumbling warbear jackhammer drill press	0		Last Available: "2013-12"
+6964	tumbling bouncing warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	warbear auto-anvil	0		Last Available: "2013-12"
 6966	blurry warbear induction oven	0		Last Available: "2013-12"
 6967	jittery warbear chemistry lab	0		Last Available: "2013-12"
@@ -6890,15 +6890,15 @@
 7001	clever Oprah's die-cast Uncle Hobo	0		Maximum MP Percent: +50, Maximum MP: +20, Last Available: "2013-12"
 7002	censurious ruddy die-cast Father Crimbo	0		Maximum HP Percent: +40, Sleaze Resistance: +3, Last Available: "2013-12"
 7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
-7004	dry upside-down cyan skewed Flaskfull of Hollow	0		Effect: "White Blooded", Effect Duration: 45, Last Available: "2013-12"
+7004	dry cyan skewed upside-down Flaskfull of Hollow	0		Effect: "White Blooded", Effect Duration: 45, Last Available: "2013-12"
 7005	wobbly lump of Brituminous coal	0		Last Available: "2013-12"
 7006	distilled jittery handful of Smithereens	1	awesome	Last Available: "2013-12"
-7007	rotten small Every Day is Like This Sundae	2	crappy	Last Available: "2013-12"
+7007	small rotten Every Day is Like This Sundae	2	crappy	Last Available: "2013-12"
 7008	rotten Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	normal This Charming Flan	4	good	Last Available: "2013-12"
 7010	bad red Irish Coffee, English Heart	4	decent	Last Available: "2013-12"
 7011	mediocre Strikes Again Bigmouth	4	decent	Last Available: "2013-12"
-7012	bad weak mirror Paint A Vulgar Pitcher	2	decent	Last Available: "2013-12"
+7012	weak bad mirror Paint A Vulgar Pitcher	2	decent	Last Available: "2013-12"
 7013	blurry Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	tumbling Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	twirling up-at-dawn rosy-cheeked fortified stylish Sheila Take a Crossbow	0		Moxie: +25, Damage Absorption: +60, Maximum HP Percent: +30, Adventures: +5, Last Available: "2013-12"
 7019	miser's manspreader's razor-sharp A Light that Never Goes Out of the blizzard	0		Weapon Damage Percent: +25, Monster Level: +10, Cold Spell Damage: +25, Meat Drop: +10, Last Available: "2013-12"
 7020	fuchsia chilly Tesla stiffened educational Half a Purse	0		Experience: +1, Damage Reduction: 1, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
-7021	scandalous friendly dance instructor's savvy Hairpiece On Fire	0		Mysticality Percent: +20, Experience Percent (Moxie): +10, Familiar Weight: +3, Sleaze Damage: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	blue Usain Bolt's frightening curative Vicar's Tutu of the empath	0		Familiar Weight: +5, Spooky Damage: +5, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	scandalous friendly dance instructor's savvy Hairpiece On Fire	0		Mysticality Percent: +20, Experience Percent (Moxie): +10, Familiar Weight: +3, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	blue Usain Bolt's frightening curative Vicar's Tutu of the empath	0		Familiar Weight: +5, Spooky Damage: +5, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	narrow zippy Fonzie's Hand in Glove of the empath	0		Experience (Moxie): +1, Familiar Weight: +5, Initiative: +20, Single Equip, Last Available: "2013-12"
 7024	shaking spinning studded boxer's Meat Tenderizer is Murder of chilblains	0		Muscle Percent: +10, Damage Absorption: +80, Cold Damage: +25, Class: "Seal Clubber", Last Available: "2013-12"
 7025	blurry Oprah's healthy extremely unsafe Ouija Board, Ouija Board	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Maximum MP Percent: +50, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6927,11 +6927,11 @@
 7038	warbear gyrocopter	0		Last Available: "2013-12"
 7039	polymerized warbear robo-camouflage unit	0		Effect: "Gamer Rage", Effect Duration: 29, Last Available: "2013-12"
 7040	purple warbear beeping telegram	0		Last Available: "2013-12"
-7041	lime green pulsating warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
+7041	pulsating lime green warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	shaking warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	diffused pulsating glass slipper	0		Effect: "Ode to Booze", Effect Duration: 45, Last Available: "2014-12"
-7045	pickled narrow jittery gray antimatter wad	1	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2013-12"
+7045	pickled narrow gray jittery antimatter wad	1	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2013-12"
 7046	irradiated frozen improved shaking warbear superpotion	0		Effect: "Heart Aflame", Effect Duration: 45, Last Available: "2013-12"
 7047	unsweetened tarnished chilled warbear liquid lasers	0		Effect: "Mucilaginous Mentalism", Effect Duration: 36, Last Available: "2013-12"
 7048	extra-vacuum-sealed irradiated pulsating warbear rejuvenation potion	0		Effect: "[1609]Dancin' Fool", Effect Duration: 25, Last Available: "2013-12"
@@ -6951,17 +6951,17 @@
 7062	skewed praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	powdered ghostly yellow grim fairy tale	1	good	Effect: "Stimulated Body", Effect Duration: 35, Last Available: "2014-12"
+7065	powdered yellow ghostly grim fairy tale	1	good	Effect: "Stimulated Body", Effect Duration: 35, Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
-7067	polarized modified alkaline purple mirror single of Inigo's Incantation of Inspiration	0		Effect: "Discomfited", Effect Duration: 66, Last Available: "2010-02"
+7067	polarized modified alkaline mirror purple single of Inigo's Incantation of Inspiration	0		Effect: "Discomfited", Effect Duration: 66, Last Available: "2010-02"
 7068	moist blinking single of Donho's Bubbly Ballad	0		Effect: "Penguinny Flavor", Effect Duration: 50
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	tumbling packet of winter seeds	0		Last Available: "2014-01"
-7071	moldy bite-sized red snow berries	1	crappy	Last Available: "2014-01"
+7071	bite-sized moldy red snow berries	1	crappy	Last Available: "2014-01"
 7072	stale half-sized ice harvest	2	decent	Last Available: "2014-01"
 7073	flattened tumbling frost flower	0		Effect: "Ghost Finger", Effect Duration: 38, Last Available: "2014-01"
 7074	enhanced purple snow cleats	0		Effect: "Insulated Trousers", Effect Duration: 27, Last Available: "2014-01"
-7075	enhanced dry shaking wobbly liquid ice pack	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 38, Last Available: "2014-01"
+7075	enhanced dry wobbly shaking liquid ice pack	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 38, Last Available: "2014-01"
 7076	huge pulsating snow boards	0		Last Available: "2014-01"
 7077	flavorless tiny snow crab	1	decent	Last Available: "2014-01"
 7078	irresponsibly strong artisanal Ice Island Long Tea	10	EPIC	Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	blinking ice sculpture	0		Last Available: "2014-01"
 7081	mirror ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	blue skewed banded snow mobile	0		Damage Absorption: +100, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	blue skewed banded snow mobile	0		Damage Absorption: +100, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	beefy ice bucket	0		Muscle: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	thinker's snow shovel of the sewer	0		Mysticality: +10, Stench Damage: +25, Lasts Until Rollover, Last Available: "2014-01"
 7086	scandalous stanky Sinatra's bod-ice	0		Experience (Moxie): +5, Stench Spell Damage: +25, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,18 +6978,18 @@
 7089	gray twirling snow fort	0		Last Available: "2014-01"
 7090	lousy gray En Una Fila Tequila	3	decent	
 7091	fancy Skully's hot chocolate	1	EPIC	Effect: "Sticky Fingers", Effect Duration: 45
-7092	medical-grade warbear dress helmet of the cougar	0		Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	medical-grade warbear dress helmet of the cougar	0		Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	sharpshooter's Newton's warbear dress bracers	0		Experience (Mysticality): +3, Critical Hit Percent: +10, Single Equip, Last Available: "2013-12"
-7094	auspicious supercool warbear dress greaves	0		Moxie Percent: +20, Item Drop: +10, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	jittery lion tamer's resourceful sweatband	0		Maximum MP: +50, Experience (familiar): +2, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	Van der Graaf gym shorts of the ox	0		Muscle: +20, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	auspicious supercool warbear dress greaves	0		Moxie Percent: +20, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	jittery lion tamer's resourceful sweatband	0		Maximum MP: +50, Experience (familiar): +2, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	Van der Graaf gym shorts of the ox	0		Muscle: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	fortified grievous ankleweights	0		Weapon Damage Percent: +50, Damage Absorption: +60, Single Equip, Last Available: "2014-12"
 7098	rosewater-soaked flame-retardant Jack Frost's sweat socks of the ox	0		Muscle: +20, Cold Spell Damage: +50, Hot Resistance: +1, Stench Resistance: +3, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	dried spinning bouncing cyan Five Second Energy&trade;	1		Effect: "Fit To Be Tide", Effect Duration: 10, Last Available: "2014-12"
+7101	dried bouncing spinning cyan Five Second Energy&trade;	1		Effect: "Fit To Be Tide", Effect Duration: 10, Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
-7103	ionized modified liquefied huge red powder	0		Effect: "Leash of Linguini", Effect Duration: 15, Last Available: "2014-12"
+7103	ionized modified liquefied red huge powder	0		Effect: "Leash of Linguini", Effect Duration: 15, Last Available: "2014-12"
 7104	jittery wool licorice whip	0		Cold Resistance: +1, Last Available: "2014-12"
 7105	pulsating anise-flavored venom	0		Last Available: "2014-12"
 7106	perfectly mixed snakebite	4	EPIC	Last Available: "2014-12"
@@ -7003,25 +7003,25 @@
 7114	moldy candy carrot	4	crappy	Last Available: "2014-12"
 7115	super-sized spoiled fuchsia candy carrot cake	5	crappy	Last Available: "2014-12"
 7116	cyan beefy carrot-on-a-stick of the cheetah	0		Muscle: +10, Initiative: +60, Last Available: "2014-12"
-7117	banded weightlifter's weasel stomping pants	0		Muscle: +15, Damage Absorption: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	normal snack-sized mulberry	2	good	Last Available: "2014-12"
+7117	banded weightlifter's weasel stomping pants	0		Muscle: +15, Damage Absorption: +100, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7118	snack-sized normal mulberry	2	good	Last Available: "2014-12"
 7119	watered-down perfectly mixed upside-down mulled berry wine	2	super ultra mega EPIC	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	banded lemon party hat	0		Damage Absorption: +100, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	banded lemon party hat	0		Damage Absorption: +100, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	lemon shirt of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2014-12"
-7123	prompt lemon drop trousers	0		Adventures: +3, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	prompt lemon drop trousers	0		Adventures: +3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	pressed mirror mirror lemonhead caviar	0		Effect: "Baconstoned", Effect Duration: 46, Last Available: "2014-12"
 7125	smelly gummi sword of the bloodbag	0		Maximum HP: +100, Stench Spell Damage: +10, Last Available: "2014-12"
 7126	polymerized small gummi fin	0		Effect: "Big", Effect Duration: 45, Last Available: "2014-12"
 7127	chocolate cow bone of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2014-12"
 7128	liquefied oxidized mirror gummi fang	0		Effect: "Sensation", Effect Duration: 57, Last Available: "2014-12"
-7129	miniature decent lime green leftover canap&eacute;s	2	good	Last Available: "2014-12"
-7130	watered-down artisanal magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
+7129	decent miniature lime green leftover canap&eacute;s	2	good	Last Available: "2014-12"
+7130	artisanal watered-down magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
 7131	pulsating lard-coated electrified cow creamer of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7132	diffused Outer Wolf&trade; cologne	0		Effect: "Bloodstain-Resistant", Effect Duration: 18, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	inspector's thinker's wolf whistle	0		Mysticality: +10, Item Drop: +15, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	stale super-sized witch's bread	5	decent	Last Available: "2014-12"
+7134	inspector's thinker's wolf whistle	0		Mysticality: +10, Item Drop: +15, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	super-sized stale witch's bread	5	decent	Last Available: "2014-12"
 7136	alkaline witch's brew	0		Effect: "Work For Hours a Week", Effect Duration: 14, Last Available: "2014-12"
 7137	scorching clever witch's bra of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +20, Hot Damage: +25, Last Available: "2014-12"
 7138	artisanal ghostly mid-level medieval mead	4	EPIC	Last Available: "2014-12"
@@ -7043,16 +7043,16 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	curative wholesome fire hose of the boozehound	0		Maximum HP Percent: +10, Booze Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	curative wholesome fire hose of the boozehound	0		Maximum HP Percent: +10, Booze Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	decent fireman's lunch	3	good	Last Available: "2014-12"
-7159	greedy double-paned plain paper hat of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +5, Meat Drop: +20, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	greedy double-paned plain paper hat of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +5, Meat Drop: +20, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	bland ice cream sandwich	4	decent	Last Available: "2014-12"
 7161	purple frightening therapeutic occult &quot;honey&quot; dipper	0		Spell Damage Percent: +25, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
-7162	half-sized enchanted bland plumber's lunch	2	decent	Effect: "Mad at Science", Effect Duration: 10, Last Available: "2014-12"
+7162	enchanted bland half-sized plumber's lunch	2	decent	Effect: "Mad at Science", Effect Duration: 10, Last Available: "2014-12"
 7163	red auspicious friendly deadly skull gearshift knob	0		Weapon Damage: +5, Familiar Weight: +3, Item Drop: +10, Last Available: "2014-12"
-7164	bland snack-sized olive nachos of the night	2	decent	Last Available: "2014-12"
+7164	snack-sized bland olive nachos of the night	2	decent	Last Available: "2014-12"
 7165	Jack Frost's Sketcherz&trade; of the cougar of the bloodbag	0		Moxie: +20, Maximum HP: +100, Cold Spell Damage: +50, Last Available: "2014-12"
-7166	jumbo adequate can of Adultwitch&trade;	5	good	Last Available: "2014-12"
+7166	adequate jumbo can of Adultwitch&trade;	5	good	Last Available: "2014-12"
 7167	vacuum-sealed smudge stick	0		Effect: "French Bronilla Brogueishness", Effect Duration: 25, Last Available: "2014-12"
 7168	magnetized vacuum-sealed wall	0		Effect: "Greasy Flavor", Effect Duration: 57, Last Available: "2014-12"
 7169	delicious tankard of ale	4	awesome	Last Available: "2014-12"
@@ -7088,11 +7088,11 @@
 7199	purple blowdart	0		
 7200	Jim Carey's Buddy Bjorn	0		Monster Level: +25, Softcore Only, Last Available: "2014-02"
 7201	ribald ruddy The Nuge's favorite crossbow of the overflowing toilet	0		Maximum HP Percent: +40, Stench Spell Damage: +50, Sleaze Damage: +10
-7202	normal fancy narrow sweet roll Alabama	3	good	Effect: "Sweet Tooth", Effect Duration: 20
+7202	fancy normal narrow sweet roll Alabama	3	good	Effect: "Sweet Tooth", Effect Duration: 20
 7203	upside-down arcane researcher's Saturday Night Special	0		Experience Percent (Mysticality): +10
 7204	jittery lynyrd snare	0		
 7205	groovy fleetwood chain	0		Moxie Percent: +10
-7206	perfectly mixed distilled blurry shaking Green Manalishi	5	EPIC	
+7206	distilled perfectly mixed blurry shaking Green Manalishi	5	EPIC	
 7207	upside-down blade of horror	0		Spooky Spell Damage: +25
 7208	pulsating fire of unknown origin	0		
 7209	eagle's milk	1	good	
@@ -7101,7 +7101,7 @@
 7212	ghostly shellacked Jefferson wings	0		Damage Reduction: 7
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	tiny moldy fancy fleetwood mac 'n' cheese	1	crappy	Effect: "Shot in the Arse", Effect Duration: 45
+7215	fancy moldy tiny fleetwood mac 'n' cheese	1	crappy	Effect: "Shot in the Arse", Effect Duration: 45
 7216	mirror lynyrd skin	0		
 7217	ribald lynyrdskin cap	0		Sleaze Damage: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	red cool lynyrdskin tunic	0		Moxie: +5
@@ -7115,10 +7115,10 @@
 7226	tea for one	1	good	
 7227	mediocre watered-down pulsating bottle of Evermore	2	decent	
 7228	skewed box	0		
-7229	practically non-alcoholic drinkable wine	1	good	
+7229	drinkable practically non-alcoholic wine	1	good	
 7230	high-proof mediocre squat rum	10	decent	
 7231	tolerable practically non-alcoholic Murderer's Punch	1	good	
-7232	moldy snack-sized purple velvet cake	2	crappy	
+7232	snack-sized moldy purple velvet cake	2	crappy	
 7233	double-alkaline super-ionized letter	0		Effect: "Meadulla Oblongota", Effect Duration: 63
 7234	wobbly avaricious therapeutic book	0		Meat Drop: +30, HP Regen Min: 5, HP Regen Max: 7
 7235	sinister masque of the blizzard	0		Spell Damage: +10, Cold Spell Damage: +25, Single Equip
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	extra-dry bad green mini-martini	5	decent	
+7255	bad extra-dry green mini-martini	5	decent	
 7256	smoke grenade	0		
 7257	powdered mirror molotov soda	1	EPIC	
 7258	triple-unsweetened pile of ashes	0		Effect: "Feroci Tea", Effect Duration: 25
@@ -7164,7 +7164,7 @@
 7275	extremely unsafe plastic Gary Claybender	0		Weapon Damage Percent: +100
 7276	plastic Captain Kerkard of doom	0		Spooky Spell Damage: +50
 7277	activated electrified robot grease	0		Effect: "Sensation", Effect Duration: 35
-7278	blurry yellow returned Thinknerd package	0		
+7278	yellow blurry returned Thinknerd package	0		
 7279	colloidal electrified non-liquefied wind-up Whatsian robot	0		Effect: "Macho, Macho Dog", Effect Duration: 52
 7280	alkaline nitrogenated wind-up vampire teeth	0		Effect: "Cheered Up", Effect Duration: 38
 7281	quadruple-pressed adjusted wind-up navigation droid	0		Effect: "Polka of Plenty", Effect Duration: 54
@@ -7190,7 +7190,7 @@
 7301	Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	lime green Lady Spookyraven's necklace	0		
-7304	olive twirling telegram from Lady Spookyraven	0		
+7304	twirling olive telegram from Lady Spookyraven	0		
 7305	ghostly Lady Spookyraven's powder puff	0		
 7306	Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
@@ -7217,18 +7217,18 @@
 7328	wet bouncing funny bone	0		Effect: "Old Time Hydration", Effect Duration: 14
 7329	fireproof half-melted spoon of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +3
 7330	altered the funk	1		Effect: "Prideful Strut", Effect Duration: 30
-7331	adequate small gunky chicken	2	good	
+7331	small adequate gunky chicken	2	good	
 7332	flame-retardant doll head	0		Hot Resistance: +1
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	clever steel-toed paddle-ball	0		Damage Reduction: 9, Maximum MP: +20
 7336	adjusted wet sound effects record	0		Effect: "In the Saucestream", Effect Duration: 35
-7337	twirling upside-down alphabet block	0		
+7337	upside-down twirling alphabet block	0		
 7338	magnetized polymerized ghostly dancer	0		Effect: "Hangdog", Effect Duration: 69
 7339	music box mechanism	0		
 7340	studded moose antlers	0		Damage Absorption: +80, Familiar Effect: "atk, 1xLep, cap 27"
 7341	triple-oxidized adjusted moose thought	0		Effect: "Jungle Juiced", Effect Duration: 39
-7342	fancy stale huge moose chocolate	9	decent	Effect: "Okee-Dokee Go!", Effect Duration: 10
+7342	huge stale fancy moose chocolate	9	decent	Effect: "Okee-Dokee Go!", Effect Duration: 10
 7343	hand-crafted tumbling painting of a glass of wine	4	EPIC	
 7344	pulsating oil painting of yourself	0		
 7345	gray ornate picture frame	0		
@@ -7254,14 +7254,14 @@
 7365	non-galvanized deionized tarnished fabric hardener	0		Effect: "Penguinny Flavor", Effect Duration: 66
 7366	aged bottle of laundry sherry	4	awesome	
 7367	magnetized maroon industrial strength starch	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 67, Wiki Name: "industrial strength starch"
-7368	adequate super-sized extra-flat panini	5	good	
+7368	super-sized adequate extra-flat panini	5	good	
 7369	moist tarnished mangled finger	0		Effect: "Spell Transfer Complete", Effect Duration: 25
 7370	artisanal watered-down blue Psychotic Train wine	2	super ultra mega EPIC	
 7371	crazy hobo notebook	0		
 7372	delicious pie man was not meant to eat	4	awesome	
 7373	Tesla sommelier's towel	0		MP Regen Min: 7, MP Regen Max: 10
 7374	tarnished tastevin of bravery	0		Spooky Resistance: +5, Single Equip
-7375	special bland actual tapas	4	decent	Effect: "Indescribable Flavor", Effect Duration: 15
+7375	bland special actual tapas	4	decent	Effect: "Indescribable Flavor", Effect Duration: 15
 7376	ghast iron ingot	0		
 7377	upside-down ghast iron cleaver of the pedagogue of the glutton	0		Experience: +3, Food Drop: +100
 7378	brainy ghast iron Garibaldi of the boozehound	0		Mysticality: +5, Booze Drop: +100, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7308,12 +7308,12 @@
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	pencil thin mushroom	0		Last Available: "2014-05"
-7422	mirror blue Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
+7422	blue mirror Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
 7425	upside-down Taco Dan's Taco Stand Cocktail Sauce Bottle	0		Last Available: "2014-05"
 7426	sprinkle shaker	0		Last Available: "2014-05"
-7427	denatured electrified purple blurry sleight-of-hand mushroom	0		Effect: "Nasty, Nasty Breath", Effect Duration: 49, Last Available: "2014-05"
+7427	denatured electrified blurry purple sleight-of-hand mushroom	0		Effect: "Nasty, Nasty Breath", Effect Duration: 49, Last Available: "2014-05"
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	Beach Buck	0		Last Available: "2014-05"
 7430	frozen modified liquefied bouncing bouncing Fun-Guy spore	0		Effect: "Bandersnatched", Effect Duration: 28, Last Available: "2014-05"
@@ -7326,35 +7326,35 @@
 7437	huge twirling Pastaco shell	0		Last Available: "2014-05"
 7438	adequate Beefy Crunch Pastaco	4	good	Last Available: "2014-05"
 7439	normal skewed Brain Food Pastaco	3	good	Last Available: "2014-05"
-7440	special normal half-sized shaking tumbling Cool Brunch Pastaco	2	good	Effect: "Frost Tea", Effect Duration: 50, Last Available: "2014-05"
+7440	half-sized normal special shaking tumbling Cool Brunch Pastaco	2	good	Effect: "Frost Tea", Effect Duration: 50, Last Available: "2014-05"
 7441	adequate wobbly Medical Pastaco	3	good	Last Available: "2014-05"
-7442	toothsome half-sized mirror Energy Buzz Pastaco	2	awesome	Last Available: "2014-05"
+7442	half-sized toothsome mirror Energy Buzz Pastaco	2	awesome	Last Available: "2014-05"
 7443	flavorless tiny Ludovico Pastaco	1	decent	Last Available: "2014-05"
 7444	aged overpowering mushroom wine	3	awesome	Last Available: "2014-05"
 7445	artisanal complex mushroom wine	3	super EPIC	Last Available: "2014-05"
 7446	fortified perfectly mixed smooth mushroom wine	5	EPIC	Last Available: "2014-05"
 7447	tolerable blood-red mushroom wine	3	good	Last Available: "2014-05"
-7448	practically non-alcoholic lousy buzzing mushroom wine	1	decent	Last Available: "2014-05"
+7448	lousy practically non-alcoholic buzzing mushroom wine	1	decent	Last Available: "2014-05"
 7449	smooth weak swirling mushroom wine	2	awesome	Last Available: "2014-05"
 7450	adequate snack-sized pulsating Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
 7451	adequate pulsating Taco Dan's Taco Fish Fish Taco	3	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	triple-distilled artisanal ghostly regular-size brogurt	6	EPIC	Last Available: "2014-05"
 7454	bad super-size brogurt	4	decent	Last Available: "2014-05"
-7455	practically non-alcoholic bad broberry brogurt	1	decent	Last Available: "2014-05"
-7456	weak delicious pulsating brocolate brogurt	2	awesome	Last Available: "2014-05"
-7457	weak perfectly mixed French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7455	bad practically non-alcoholic broberry brogurt	1	decent	Last Available: "2014-05"
+7456	delicious weak pulsating brocolate brogurt	2	awesome	Last Available: "2014-05"
+7457	perfectly mixed weak French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
 7458	bouncing History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	huge Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	huge Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Brogre brorts of Tarzan	0		Experience (Muscle): +3, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	frosty Brogre brolo shirt	0		Cold Spell Damage: +10, Last Available: "2014-05"
-7464	dog trainer's Brogre bucket hat	0		Experience (familiar): +1, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	dog trainer's Brogre bucket hat	0		Experience (familiar): +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	skewed Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	blurry airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	ghostly one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	Sherlock's smartaleck's 8-billed baseball cap of the dark arts	0		Moxie Percent: +30, Spell Damage Percent: +100, Item Drop: +25, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	Sherlock's smartaleck's 8-billed baseball cap of the dark arts	0		Moxie Percent: +30, Spell Damage Percent: +100, Item Drop: +25, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	frosty cool extremely wet T-shirt of courage	0		Moxie: +5, Cold Spell Damage: +10, Spooky Resistance: +3, Last Available: "2014-05"
 7470	up-at-dawn studded shrimp fork of the sewer	0		Damage Absorption: +80, Stench Damage: +25, Adventures: +5, Last Available: "2014-05"
 7471	quadruple-denatured denatured BROS Energy Drink	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 59, Last Available: "2014-05"
@@ -7367,7 +7367,7 @@
 7478	huge possessed sugar cube	0		Last Available: "2014-05"
 7479	quantum narrow squat gray sugar fairy	0		Effect: "Sticky Fingers", Effect Duration: 55, Last Available: "2014-05"
 7480	pressed sugar bunny	0		Effect: "Go-Gone", Effect Duration: 47, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	artisanal skewed Rompedores de Fantasmas	3	EPIC	
 7483	enchanted weak hand-crafted La Fantasma y La Oscuridad	2	EPIC	Effect: "A Taste of Rainbow", Effect Duration: 50
 7484	practically non-alcoholic drinkable Fantasma en la M&aacute;quina	1	good	
@@ -7395,8 +7395,8 @@
 7506	wicked thinker's book	0		Mysticality: +10, Spell Damage: +5
 7507	spinning Temple Grandin's cloak	0		Familiar Weight: +7
 7508	label	0		
-7509	rotten miniature Mornington crescent roll	2	crappy	
-7510	electrified activated moist shaking lime green eye shadow	0		Effect: "Aided and Abetted", Effect Duration: 62
+7509	miniature rotten Mornington crescent roll	2	crappy	
+7510	electrified activated moist lime green shaking eye shadow	0		Effect: "Aided and Abetted", Effect Duration: 62
 7511	crumbling wheel	0		
 7512	colloidal galvanized poppy	0		Effect: "Disdain of She-Who-Was", Effect Duration: 55
 7513	narrow opium grenade	0		
@@ -7405,7 +7405,7 @@
 7516	witch's spare house key	0		
 7517	slick spider leg of courage	0		Moxie: +10, Spooky Resistance: +3
 7518	wand of pigification	0		
-7519	weak lousy glass of bourbon	2	decent	
+7519	lousy weak glass of bourbon	2	decent	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	thick special stale government cheese	5	decent	Effect: "Thick-Skinned", Effect Duration: 20, Last Available: "2014-05"
 7522	arcane researcher's pair of government shades	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2014-05"
@@ -7425,13 +7425,13 @@
 7536	blurry space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	space beast fur hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	space beast fur pants of the glutton	0		Food Drop: +100, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	space beast fur hat of James Dean	0		Experience (Moxie): +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	space beast fur pants of the glutton	0		Food Drop: +100, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	upside-down shaking Rosewater's space beast fur whip	0		Mysticality Percent: +30, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	huge educational slick space heater	0		Moxie: +10, Experience: +1, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	huge educational slick space heater	0		Moxie: +10, Experience: +1, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
-7545	perfectly mixed watered-down ghostly space port	2	EPIC	Last Available: "2014-05"
+7545	watered-down perfectly mixed ghostly space port	2	EPIC	Last Available: "2014-05"
 7546	zippy space needle of dire peril	0		Weapon Damage: +20, Initiative: +20, Last Available: "2014-05"
 7547	pickled irradiated upside-down buffed alien drugs	0		Effect: "Hella Smooth", Effect Duration: 24, Last Available: "2014-05"
 7548	lime green hot ashes	0		Last Available: "2014-06"
@@ -7468,8 +7468,8 @@
 7579	shaking twitching time capsule	0		
 7580	vaporized liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	normal enchanted rack of dinosaur ribs	4	good	Effect: "Healthy Blue Glow", Effect Duration: 15
-7583	hand-crafted high-proof scotch on the rocks	9	EPIC	
+7582	enchanted normal rack of dinosaur ribs	4	good	Effect: "Healthy Blue Glow", Effect Duration: 15
+7583	high-proof hand-crafted scotch on the rocks	9	EPIC	
 7584	Samson's savvy yabba dabba doo rag	0		Mysticality Percent: +20, Experience (Muscle): +5, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	wobbly slick wooly loincloth of the early riser	0		Moxie: +10, Adventures: +7, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	teal helix fossil	0		
@@ -7479,13 +7479,13 @@
 7590	practically non-alcoholic mediocre tumbling cup of &quot;tea&quot;	1	decent	Last Available: "2014-07"
 7591	artisanal thermos of &quot;whiskey&quot;	4	EPIC	Last Available: "2014-07"
 7592	delicious Lucky Lindy	3	awesome	Last Available: "2014-07"
-7593	mediocre fancy squat shaking Bee's Knees	4	decent	Effect: "Blood-Rich", Effect Duration: 50, Last Available: "2014-07"
+7593	fancy mediocre squat shaking Bee's Knees	4	decent	Effect: "Blood-Rich", Effect Duration: 50, Last Available: "2014-07"
 7594	artisanal Sockdollager	4	EPIC	Last Available: "2014-07"
 7595	drinkable watered-down lime green Ish Kabibble	2	good	Last Available: "2014-07"
 7596	acceptable boozy Hot Socks	5	good	Last Available: "2014-07"
-7597	perfectly mixed enchanted Phonus Balonus	4	EPIC	Effect: "Dreams and Lights", Effect Duration: 5, Last Available: "2014-07"
+7597	enchanted perfectly mixed Phonus Balonus	4	EPIC	Effect: "Dreams and Lights", Effect Duration: 5, Last Available: "2014-07"
 7598	irresponsibly strong perfectly mixed Flivver	8	EPIC	Last Available: "2014-07"
-7599	artisanal enchanted watered-down Sloppy Jalopy	2	super ultra mega EPIC	Effect: "Fit To Be Tide", Effect Duration: 20, Last Available: "2014-07"
+7599	watered-down artisanal enchanted Sloppy Jalopy	2	super ultra mega EPIC	Effect: "Fit To Be Tide", Effect Duration: 20, Last Available: "2014-07"
 7600	improved skewed flame	0		Effect: "Ooh, Bitter!", Effect Duration: 41
 7601	triple-quantum cold-filtered anodized temporary yak tattoo	0		Effect: "Stregngth of the Gnome", Effect Duration: 17
 7602	electrified nitrogenated Fitspiration&trade; poster	0		Effect: "Human-Demon Hybrid", Effect Duration: 33
@@ -7500,7 +7500,7 @@
 7611	diffused Lewd Lemmy Hair Oil	0		Effect: "Stinky Hands", Effect Duration: 36
 7612	energized oxidized irradiated tomato soup poster	0		Effect: "Space Cadet", Effect Duration: 18
 7613	wet quadruple-magnetized activated mirror squat bubblin' chemistry solution	0		Effect: "Cotton Mouthed", Effect Duration: 51
-7614	alkaline wobbly blurry voodoo glowskull	0		Effect: "Mushroom Moxiousness", Effect Duration: 48
+7614	alkaline blurry wobbly voodoo glowskull	0		Effect: "Mushroom Moxiousness", Effect Duration: 48
 7615	irradiated aerosolized narrow pygmy adder oil	0		Effect: "Jerky, Boy", Effect Duration: 24
 7616	deionized blue pygmy witchhazel	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 11
 7617	improved chilled polarized short deposition	0		Effect: "Chunky", Effect Duration: 53
@@ -7536,7 +7536,7 @@
 7647	aquaconda brain	0		
 7648	upside-down thunder thigh	0		
 7649	adjusted ghostly gourmet gourami oil	0		Effect: "Sparkling Consciousness", Effect Duration: 65
-7650	dry fuchsia bouncing shaking catfish whiskers	0		Effect: "You Know Who to Call", Effect Duration: 36
+7650	dry bouncing shaking fuchsia catfish whiskers	0		Effect: "You Know Who to Call", Effect Duration: 36
 7651	freshwater fishbone	0		
 7652	green fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7552,7 +7552,7 @@
 7663	lard-coated horrifying thinker's Lord Soggyraven's Slippers	0		Mysticality: +10, Spooky Damage: +25, Sleaze Spell Damage: +25, Single Equip
 7664	extra-nitrogenated Vulcanized fuchsia Ancient Protector Soda	0		Effect: "Prideful Strut", Effect Duration: 60
 7665	chilled vacuum-sealed narrow spinning liquid ice	0		Effect: "Heightened Senses", Effect Duration: 48
-7666	special mediocre extra-dry Wet Russian	5	decent	Effect: "Putting the Pro in Proletariat", Effect Duration: 20
+7666	mediocre extra-dry special Wet Russian	5	decent	Effect: "Putting the Pro in Proletariat", Effect Duration: 20
 7667	low-calorie flavorless filet of The Fish	1	decent	
 7668	Thwaitgold spider statuette	0		
 7669	Annie Oakley's savvy brainy thunder down underwear	0		Mysticality: +5, Mysticality Percent: +20, Critical Hit Percent: +20, Lasts Until Rollover
@@ -7561,7 +7561,7 @@
 7672	frosty law-abiding citizen cane	0		Cold Spell Damage: +10, Single Equip
 7673	mediocre blinking blurry legitimate business on the beach	3	decent	
 7674	tumbling Van der Graaf hep waders	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	jumbo rotten special narrow jive turkey leg	5	crappy	Effect: "Smoky Third Eye", Effect Duration: 5
+7675	jumbo special rotten narrow jive turkey leg	5	crappy	Effect: "Smoky Third Eye", Effect Duration: 5
 7676	crafty birdbone corset	0		Maximum MP: +10
 7677	quadruple-corrupted nitrogenated bouncing candy cigarette	0		Effect: "Turtle Titters", Effect Duration: 60
 7678	huge personal trainer's 4-dimensional fez	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7581,7 +7581,7 @@
 7692	blurry gravedigger's hand whip of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Spooky Damage: +10, Last Available: "2014-08"
 7693	jittery crafty studded glow-in-the-dark necklace of temperance	0		Damage Absorption: +80, Maximum MP: +10, Sleaze Resistance: +5, Last Available: "2014-08"
 7694	red Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	narrow flame-retardant slick cool cap gun	0		Moxie: 15, Hot Resistance: +1, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	narrow flame-retardant slick cool cap gun	0		Moxie: 15, Hot Resistance: +1, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	teal ghostly ribald friendly cassette player	0		Familiar Weight: +3, Sleaze Damage: +10, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7595,7 +7595,7 @@
 7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	quadruple-galvanized pressed squat squat rubber nubbin	0		Effect: "Puzzle Fury", Effect Duration: 43, Last Available: "2014-08"
 7708	foul-smelling deadly rubber cape	0		Weapon Damage: +5, Stench Damage: +10, Last Available: "2014-08"
-7709	skewed family-friendly steel-toed Da Vinci's smartaleck's Thor's Pliers	0		Moxie Percent: +30, Experience (Mysticality): +5, Damage Reduction: 9, Sleaze Resistance: +1, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	skewed family-friendly steel-toed Da Vinci's smartaleck's Thor's Pliers	0		Moxie Percent: +30, Experience (Mysticality): +5, Damage Reduction: 9, Sleaze Resistance: +1, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	aerosolized pressed candy UFOs	0		Effect: "Super Structure", Effect Duration: 21
 7711	healthy experienced water wings for babies	0		Experience: +2, Maximum HP Percent: +20
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
@@ -7613,7 +7613,7 @@
 7724	pteruges of Leguizamo	0		Monster Level: +20, Familiar Effect: "1xFairy, atk, cap 25"
 7725	super-chilled vacuum-sealed chilled lime green Bruno's blessing of Mars	0		Effect: "Haunted Liver", Effect Duration: 24
 7726	double-liquefied squat huge Dennis's blessing of Minerva	0		Effect: "Tiki Temerity", Effect Duration: 34
-7727	ionized bouncing huge Burt's blessing of Bacchus	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 23
+7727	ionized huge bouncing Burt's blessing of Bacchus	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 23
 7728	concentrated Freddie's blessing of Mercury	0		Effect: "Okee-Dokee Go!", Effect Duration: 24
 7729	Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	stylish Xiblaxian xeno-detection goggles	0		Moxie: +25, Single Equip, Last Available: "2014-09"
-7753	olive careful Xiblaxian stealth cowl of the pedagogue	0		Experience: +3, Monster Level: -10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	olive careful Xiblaxian stealth cowl of the pedagogue	0		Experience: +3, Monster Level: -10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	frosty personal trainer's Xiblaxian stealth trousers	0		Experience Percent (Muscle): +10, Cold Spell Damage: +10, Last Available: "2014-09"
 7755	supercharged studded Xiblaxian stealth vest	0		Damage Absorption: +80, Maximum MP Percent: +30, Last Available: "2014-09"
 7756	low-calorie spoiled ghostly Xiblaxian ultraburrito	1	crappy	Last Available: "2014-09"
 7757	watered-down lousy cyan Xiblaxian space-whiskey	2	decent	Last Available: "2014-09"
-7758	huge jittery Xiblaxian residence-cube	0		Last Available: "2014-09"
+7758	jittery huge Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	activated shaking They liver	0		Effect: "Remaining Alive", Effect Duration: 63, Last Available: "2014-09"
-7760	delicious snack-sized blue They liver popsicle	2	awesome	Last Available: "2014-09"
+7760	snack-sized delicious blue They liver popsicle	2	awesome	Last Available: "2014-09"
 7761	ghostly holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	lime green holo-platoon	0		Last Available: "2014-09"
@@ -7654,7 +7654,7 @@
 7765	tumbling dance instructor's Xiblaxian holo-wrist-puter	0		Experience Percent (Moxie): +10, Last Available: "2014-09"
 7766	greedy energetic arcane researcher's defective Golden Mr. Accessory	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Meat Drop: +20
 7767	olive airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
-7768	huge red one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
+7768	red huge one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	shaking inspector's greasy savvy Personal Ventilation Unit	0		Mysticality Percent: +20, Sleaze Spell Damage: +10, Item Drop: +15, Single Equip, Last Available: "2014-10"
 7771	extra-corrupted non-polarized the most dangerous bait	0		Effect: "Uncanny Shot", Effect Duration: 53, Last Available: "2014-10"
@@ -7668,12 +7668,12 @@
 7779	wet purple experimental serum G-9	0		Effect: "Tremella Tremens", Effect Duration: 29, Last Available: "2014-10"
 7780	upside-down prompt Jack Frost's sinister heavy-duty clipboard	0		Spell Damage: +10, Cold Spell Damage: +50, Adventures: +3, Damage Reduction: 8, Last Available: "2014-10"
 7781	knitted battery-powered drill of dire peril of horror of bravery	0		Weapon Damage: +20, Spooky Spell Damage: +25, Cold Resistance: +3, Spooky Resistance: +5, Last Available: "2014-10"
-7782	enchanted adequate upside-down limp broccoli	3	good	Effect: "Pasty", Effect Duration: 5, Last Available: "2014-10"
-7783	scorching supercharged hat of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Hot Damage: +25, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7782	adequate enchanted upside-down limp broccoli	3	good	Effect: "Pasty", Effect Duration: 5, Last Available: "2014-10"
+7783	scorching supercharged hat of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Hot Damage: +25, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	super-modified twirling lime green monkey barf	0		Effect: "Wings of the Grasshopper", Effect Duration: 48, Last Available: "2014-10"
 7785	modified diffused upside-down candy	0		Effect: "Superveiny 9000", Effect Duration: 68, Last Available: "2014-10"
 7786	medical-grade rosy-cheeked savvy jangly bracelet	0		Mysticality Percent: +20, Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10"
-7787	shaking nasty cuddly teddy bear	0		Stench Damage: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	shaking nasty cuddly teddy bear	0		Stench Damage: +5, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	squat ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	inspector's beefy first-aid pouch	0		Muscle: +10, Item Drop: +15, Last Available: "2014-10"
 7790	blue khaki duffel bag	0		Last Available: "2014-10"
@@ -7682,11 +7682,11 @@
 7793	maroon bottle-opener keycard	0		Last Available: "2014-10"
 7794	green Armory keycard	0		Last Available: "2014-10"
 7795	normal lime green blinking initiative shawarma	3	good	Last Available: "2014-10"
-7796	stale miniature warm war shawarma	2	decent	Last Available: "2014-10"
-7797	spoiled special karma shawarma	4	crappy	Effect: "Thunderspell", Effect Duration: 10, Last Available: "2014-10"
-7798	delicious enchanted boozy twirling Jungle Juice	5	awesome	Effect: "Boo Tea", Effect Duration: 40, Last Available: "2014-10"
-7799	strong acceptable Amnesiac Ale	5	good	Last Available: "2014-10"
-7800	triple-distilled hand-crafted Highest Bitter	8	EPIC	Last Available: "2014-10"
+7796	miniature stale warm war shawarma	2	decent	Last Available: "2014-10"
+7797	special spoiled karma shawarma	4	crappy	Effect: "Thunderspell", Effect Duration: 10, Last Available: "2014-10"
+7798	enchanted delicious boozy twirling Jungle Juice	5	awesome	Effect: "Boo Tea", Effect Duration: 40, Last Available: "2014-10"
+7799	acceptable strong Amnesiac Ale	5	good	Last Available: "2014-10"
+7800	hand-crafted triple-distilled Highest Bitter	8	EPIC	Last Available: "2014-10"
 7801	mercenary pistol of dire peril of Flo-Jo	0		Weapon Damage: +20, Initiative: +100, Last Available: "2014-10"
 7802	fortified supercool mercenary rifle	0		Moxie Percent: +20, Damage Absorption: +60, Last Available: "2014-10"
 7803	blurry Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7701,10 +7701,10 @@
 7812	narrow fuchsia tarnished bottlecap	0		
 7813	bite-sized flavorless bouncing seared dino steak	1	decent	
 7814	practically non-alcoholic mediocre bottle of drinkin' gas	1	decent	
-7815	shaking blue squat handful of napalm	0		
+7815	shaking squat blue handful of napalm	0		
 7816	dove DNA	0		
 7817	skewed gelatinous meat mass	0		
-7818	spinning spinning squat 99.44% pure math	0		
+7818	spinning squat spinning 99.44% pure math	0		
 7819	simple AI	0		
 7820	corrupted bird DNA	0		
 7821	huge sentient meat mass	0		
@@ -7734,7 +7734,7 @@
 7845	non-aerosolized moist upside-down perl necklace	0		Effect: "Jelly Combed", Effect Duration: 56, Last Available: "2014-12"
 7846	boiled double-dry energized Fudge Fiber Armor Plating	0		Effect: "Beastly Flavor", Effect Duration: 22, Last Available: "2014-12"
 7847	dry quantum tumbling ruby on canes	0		Effect: "Clean-Shaven", Effect Duration: 14, Last Available: "2014-12"
-7848	special delicious petit fortran	4	awesome	Effect: "Mercenary", Effect Duration: 30, Last Available: "2014-12"
+7848	delicious special petit fortran	4	awesome	Effect: "Mercenary", Effect Duration: 30, Last Available: "2014-12"
 7849	spoiled tiny purple java cookie	1	crappy	Last Available: "2014-12"
 7850	huge decent cookie cookie	6	good	Last Available: "2014-12"
 7851	plastic exo-suited miner of the wise owl	0		Mysticality: +20, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	ruddy plastic Crimbot	0		Maximum HP Percent: +40, Last Available: "2014-12"
 7855	plastic Crimbomega of Gandalf	0		Spell Critical Percent: +20, Last Available: "2014-12"
 7856	galvanized magnetized flask of mining oil	0		Effect: "Hagg-ard", Effect Duration: 38, Last Available: "2014-12"
-7857	narrow supercool radiation-resistant helmet	0		Moxie Percent: +20, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	censurious servo-assisted exo-pants	0		Sleaze Resistance: +3, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	narrow supercool radiation-resistant helmet	0		Moxie Percent: +20, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	censurious servo-assisted exo-pants	0		Sleaze Resistance: +3, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	wholesome fortified high-energy mining laser	0		Damage Absorption: +60, Maximum HP Percent: +10, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7753,7 +7753,7 @@
 7864	blurry Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	Crimbot schematic: Big Head	0		Last Available: "2014-12"
-7867	shaking blinking Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
+7867	blinking shaking Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	bouncing lime green Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
@@ -7769,7 +7769,7 @@
 7880	bouncing Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
-7883	squat cyan Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
+7883	cyan squat Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
@@ -7783,7 +7783,7 @@
 7894	red Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	spinning Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	shaking Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
-7897	twirling tumbling Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
+7897	tumbling twirling Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	tumbling maroon Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
@@ -7812,7 +7812,7 @@
 7923	mediocre fancy Agitated Turkey	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 15, Last Available: "2014-11"
 7924	hand-crafted Ambitious Turkey	4	EPIC	Last Available: "2014-11"
 7925	flavorless half-sized narrow neutron lollipop	2	decent	Last Available: "2014-12"
-7926	boozy bad enchanted maroon gamma nog	5	decent	Effect: "Flagrantly Fragrant", Effect Duration: 30, Last Available: "2014-12"
+7926	bad boozy enchanted maroon gamma nog	5	decent	Effect: "Flagrantly Fragrant", Effect Duration: 30, Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
@@ -7838,7 +7838,7 @@
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	shaking even more tinsel	0		Familiar Weight: +5
 7958	huge box of Crimbo decorations	0		
-7959	maroon tumbling blurry letter to Ed the Undying	0		
+7959	tumbling blurry maroon letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	smelly crafty arcane researcher's Staff of Ed of incineration	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Hot Spell Damage: +50, Stench Spell Damage: +10
 7962	skewed Eye of Ed	0		
@@ -7853,7 +7853,7 @@
 7971	Aggressive Carrot	0		Free Pull
 7972	powdered tumbling mummified fig	1	decent	
 7973	distilled mummified loaf of bread	1	decent	Effect: "Perfect Hair", Effect Duration: 40
-7974	compressed huge twirling mummified beef haunch	1	EPIC	
+7974	compressed twirling huge mummified beef haunch	1	EPIC	
 7975	linen bandages	0		
 7976	skewed jittery cotton bandages	0		
 7977	silk bandages	0		
@@ -7881,17 +7881,17 @@
 7999	deionized blurry shaking choco-Crimbot	0		Effect: "Red-Shirted Escort", Effect Duration: 60, Last Available: "2014-12"
 8000	dry triple-colloidal lime green smart watch	0		Effect: "Pasta Oneness", Effect Duration: 33, Last Available: "2014-12"
 8001	quantum pickled wobbly augmented-reality shades	0		Effect: "Well-Swabbed Ear", Effect Duration: 32, Last Available: "2014-12"
-8002	hardened toy Crimbot mega face	0		Damage Reduction: 3, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	grievous toy Crimbot power glove	0		Weapon Damage Percent: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	Jim Carey's toy Crimbot super fist	0		Monster Level: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of the glutton	0		Food Drop: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	hardened toy Crimbot mega face	0		Damage Reduction: 3, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	grievous toy Crimbot power glove	0		Weapon Damage Percent: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	Jim Carey's toy Crimbot super fist	0		Monster Level: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of the glutton	0		Food Drop: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	electrified skewed Crimbot battery	0		Effect: "Sugar, Hello", Effect Duration: 65, Last Available: "2014-12"
 8007	shaking Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	mirror Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	tumbling Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	bouncing heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	purple sizzling banded Crimbomega drive chain of courage	0		Damage Absorption: +100, Hot Damage: +10, Spooky Resistance: +3, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	purple sizzling banded Crimbomega drive chain of courage	0		Damage Absorption: +100, Hot Damage: +10, Spooky Resistance: +3, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	red Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	blinking bouncing Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,7 +7899,7 @@
 8017	extra-anodized flask of tainted mining oil	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 38, Last Available: "2014-12"
 8018	diffused activated ionized pulsating and rain stick	0		Effect: "Amorous", Effect Duration: 46
 8019	spinning Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	yummy super-sized Choco-Mint patty	5	awesome	Last Available: "2015-01"
+8020	super-sized yummy Choco-Mint patty	5	awesome	Last Available: "2015-01"
 8021	smooth hot mint schnocolate	4	awesome	Last Available: "2015-01"
 8022	vaporized lime green homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	lightning-fast cool tope&eacute;	0		Moxie: +5, Initiative: +40, Familiar Effect: "3xBarrr, cap 12"
 8035	skewed sharpshooter's Tesla topiary tights	0		Critical Hit Percent: +10, MP Regen Min: 7, MP Regen Max: 10
 8036	Jack Frost's topiary necktie	0		Cold Spell Damage: +50
-8037	bland massive bowl of topioca	8	decent	
+8037	massive bland bowl of topioca	8	decent	
 8038	jittery topiary skunk	0		
 8039	jittery topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	spinning squat Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	huge clever curative Spelunker's fedora of the pedagogue	0		Experience: +3, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	huge clever curative Spelunker's fedora of the pedagogue	0		Experience: +3, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	ghostly reassuring Annie Oakley's hardy Spelunker's whip	0		Maximum HP: +50, Critical Hit Percent: +20, Spooky Resistance: +1, Last Available: "2015-12"
-8076	tumbling dance instructor's Spelunker's khakis of incineration of temperance	0		Experience Percent (Moxie): +10, Hot Spell Damage: +50, Sleaze Resistance: +5, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	tumbling dance instructor's Spelunker's khakis of incineration of temperance	0		Experience Percent (Moxie): +10, Hot Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7962,7 +7962,7 @@
 8087	Thwaitgold scarab beetle statuette	0		
 8088	jewel	0		
 8089	headless sparrow	0		
-8090	huge ghostly skewed mangled squirrel	0		
+8090	ghostly huge skewed mangled squirrel	0		
 8091	rat carcass	0		
 8092	sizzling manspreader's wicker kickers	0		Monster Level: +10, Hot Damage: +10, Single Equip, Last Available: "2016-12"
 8093	tumbling skewed greasy MacGyver's wicker slicker	0		Maximum MP: +100, Sleaze Spell Damage: +10, Last Available: "2016-12"
@@ -7991,12 +7991,12 @@
 8116	mirror Lo Pan's forbidden whisk	0		Spell Damage Percent: +50, Spell Critical Percent: +30, Last Available: "2017-12"
 8117	upside-down ribald wicked walker	0		Spell Damage: +5, Sleaze Damage: +10, Single Equip, Last Available: "2017-12"
 8118	squat nasty vibrating waders	0		Maximum MP Percent: +10, Stench Damage: +5, Last Available: "2017-12"
-8119	pickled upside-down blurry flakes	1		Last Available: "2017-12"
+8119	pickled blurry upside-down flakes	1		Last Available: "2017-12"
 8120	gaiters of extreme caution of mayonnaise	0		Monster Level: -25, Sleaze Spell Damage: +50, Last Available: "2018-12"
 8121	fortified beefcake's garland	0		Muscle: +25, Damage Absorption: +60, Single Equip, Last Available: "2018-12"
 8122	chaotic smartaleck's gunnysack	0		Moxie Percent: +30, Spell Critical Percent: +10, Last Available: "2018-12"
 8123	wholesome dangerous garibaldi	0		Weapon Damage: +10, Maximum HP Percent: +10, Last Available: "2018-12"
-8124	greasy Newton's girdle	0		Experience (Mysticality): +3, Sleaze Spell Damage: +10, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	greasy Newton's girdle	0		Experience (Mysticality): +3, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	lime green Annie Oakley's sage gloves	0		Mysticality Percent: +10, Critical Hit Percent: +20, Single Equip, Last Available: "2018-12"
 8126	distilled maroon smithereens	1		Last Available: "2018-12"
 8127	flame-retardant rosy-cheeked fiberglass fetish	0		Maximum HP Percent: +30, Hot Resistance: +1, Last Available: "2018-12"
@@ -8056,22 +8056,22 @@
 8182	shaking Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	blurry baleful bread basket	0		Spell Damage: +25
 8184	Ed the Undying exhibit crate	0		
-8185	cool The Crown of Ed the Undying of Flo-Jo	0		Moxie: +5, Initiative: +100, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	cool The Crown of Ed the Undying of Flo-Jo	0		Moxie: +5, Initiative: +100, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	bouncing Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	drinkable practically non-alcoholic Cherrytastrophe wine cooler	1	good	
 8189	boozy tolerable shaking Radberry Rip wine cooler	5	good	
 8190	weak smooth wobbly Orangemageddon wine cooler	2	awesome	
 8191	spirit-forward lousy tumbling Breakfast Blast wine cooler	5	decent	
-8192	extra-dry smooth Citrus Crush wine cooler	5	awesome	
+8192	smooth extra-dry Citrus Crush wine cooler	5	awesome	
 8193	flavorless small plain bagel	2	decent	
 8194	rotten pulsating glob of cream cheese	3	crappy	
-8195	adequate bite-sized maroon loaf of soda bread	1	good	
-8196	small bland acceptable bagel	2	decent	
+8195	bite-sized adequate maroon loaf of soda bread	1	good	
+8196	bland small acceptable bagel	2	decent	
 8197	half-sized spoiled lime green standard-issue cupcake	2	crappy	
-8198	stale half-sized pulsating teal ultra-deluxe cupcake	2	decent	
+8198	half-sized stale teal pulsating ultra-deluxe cupcake	2	decent	
 8199	hypnotic breadcrumbs	0		
-8200	flavorless half-sized popular tart	2	decent	
+8200	half-sized flavorless popular tart	2	decent	
 8201	spinning no-handed pie	0		
 8202	enhanced non-frozen green Doc Galaktik's Vitality Serum	0		Effect: "Human-Pirate Hybrid", Effect Duration: 19
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8081,18 +8081,18 @@
 8207	twirling sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	boiled How to Avoid Scams	0		Effect: "The Two-Prong Crown", Effect Duration: 34, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
-8210	twirling fuchsia bag of gross foreign snacks	0		Last Available: "2015-04"
+8210	fuchsia twirling bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	shaking shaking rigging rope of the sewer of the overflowing toilet	0		Stench Damage: +25, Stench Spell Damage: +50, Last Available: "2015-04"
 8214	boiled nasty snuff	1	crappy	Last Available: "2015-04"
-8215	fireproof gravedigger's sewage-clogged pistol	0		Spooky Damage: +10, Hot Resistance: +3, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
-8216	liquefied pulsating red beard incense	0		Effect: "Ichorous Intensity", Effect Duration: 25, Last Available: "2015-04"
+8215	fireproof gravedigger's sewage-clogged pistol	0		Spooky Damage: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8216	liquefied red pulsating beard incense	0		Effect: "Ichorous Intensity", Effect Duration: 25, Last Available: "2015-04"
 8217	razor-sharp perfume-soaked bandana of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	tiny normal toxo	1	good	Last Available: "2015-04"
 8220	special aged Lemonade-235	3	awesome	Effect: "Beastly Flavor", Effect Duration: 25, Last Available: "2015-04"
-8221	therapeutic isotophat of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	therapeutic isotophat of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Lo Pan's dance instructor's Three Mile Island shorts	0		Experience Percent (Moxie): +10, Spell Critical Percent: +30, Last Available: "2015-04"
 8223	lightning-fast toxic mop of the cheetah	0		Initiative: 100, Last Available: "2015-04"
 8224	huge inert sludgepuppy	0		Last Available: "2015-04"
@@ -8145,11 +8145,11 @@
 8271	big flavorless spinning uninteresting mayolus	5	decent	Last Available: "2015-05"
 8272	moldy pulsating acceptable mayolus	4	crappy	Last Available: "2015-05"
 8273	bland fancy enticing mayolus	3	decent	Effect: "Dirty Pear", Effect Duration: 45, Last Available: "2015-05"
-8274	small rotten mouth-watering mayolus	2	crappy	Last Available: "2015-05"
+8274	rotten small mouth-watering mayolus	2	crappy	Last Available: "2015-05"
 8275	olive newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	spinning mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	lousy watered-down Afternoon Delight	2	decent	Last Available: "2015-04"
+8278	watered-down lousy Afternoon Delight	2	decent	Last Available: "2015-04"
 8279	tumbling Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	skewed Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	non-polymerized cold-filtered pulsating Kokomo Resort Brand Suntan Oil	0		Effect: "Space Tripping", Effect Duration: 55, Last Available: "2015-04"
@@ -8174,14 +8174,14 @@
 8300	ionized electrified power pill	0		Effect: "Tingly Biceps", Effect Duration: 37, Last Available: "2015-06"
 8301	triple-electrified anodized gray pixel star	0		Effect: "Charrrming", Effect Duration: 38, Last Available: "2015-06"
 8302	huge spoiled pixel banana	10	crappy	Last Available: "2015-06"
-8303	weak perfectly mixed pixel beer	2	EPIC	Last Available: "2015-06"
+8303	perfectly mixed weak pixel beer	2	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	squat pumps	0		Last Available: "2015-06"
 8306	super-activated upside-down sludgesicle	0		Effect: "Memory of Strength", Effect Duration: 32
 8307	boiled vacuum-sealed &Uuml;berraschthexengebr&auml;u	0		Effect: "Crying, Dying", Effect Duration: 55
 8308	vacuum-sealed piggy tattoo	0		Effect: "Gobliny Flavor", Effect Duration: 24
 8309	polymerized baggie of regular-sized tardigrades	0		Effect: "Trufflin'", Effect Duration: 31
-8310	double-magnetized twirling ghostly .epub file	0		Effect: "Boon of the War Snapper", Effect Duration: 62
+8310	double-magnetized ghostly twirling .epub file	0		Effect: "Boon of the War Snapper", Effect Duration: 62
 8311	liquefied nitrogenated BUBBLE GUM	0		Effect: "La Bamba", Effect Duration: 66
 8312	dry frozen hustler shades	0		Effect: "The Rich Get Richer", Effect Duration: 23
 8313	cold-filtered triple-warmed jerky stick	0		Effect: "Thick, Sick", Effect Duration: 25
@@ -8226,20 +8226,20 @@
 8352	cold-filtered jittery skeleton beans	0		Effect: "Orchid Blood", Effect Duration: 22
 8353	ionized grimy lab coat	0		Effect: "Snobby", Effect Duration: 68
 8354	double-energized nursery rhyme	0		Effect: "Old Time Hydration", Effect Duration: 24
-8355	irradiated fuchsia twirling iron torso box	0		Effect: "Human-Elf Hybrid", Effect Duration: 54
+8355	irradiated twirling fuchsia iron torso box	0		Effect: "Human-Elf Hybrid", Effect Duration: 54
 8356	dry magnetized twirling mercenary headband	0		Effect: "Your Interest is Peaked", Effect Duration: 69
-8357	electrified anodized blurry teal shaking radioactive spider venom	0		Effect: "Crimbo Nostalgia", Effect Duration: 11
+8357	electrified anodized blurry shaking teal radioactive spider venom	0		Effect: "Crimbo Nostalgia", Effect Duration: 11
 8358	ionized concentrated cyan x-ray mirror	0		Effect: "Standard Cheer", Effect Duration: 14
-8359	energized mirror huge wrestling mask	0		Effect: "Spore-Wreathed", Effect Duration: 31
+8359	energized huge mirror wrestling mask	0		Effect: "Spore-Wreathed", Effect Duration: 31
 8360	oxidized alkaline blurry hawkface potion	0		Effect: "Eyes All Black", Effect Duration: 67
 8361	triple-tarnished tumbling tumbling child-sized dracula cloak	0		Effect: "Techno Bliss", Effect Duration: 13
 8362	activated activated bouncing devil-summoning hat	0		Effect: "Slimily Strong", Effect Duration: 47
 8363	unsweetened shopkeeper beard	0		Effect: "Crusty Head", Effect Duration: 56
-8364	warmed electrified ghostly spinning alien autoautopsy kit	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33
+8364	warmed electrified spinning ghostly alien autoautopsy kit	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33
 8365	dry extra-tarnished novelty fruit hat	0		Effect: "El Vibrations", Effect Duration: 17
 8366	chilled blurry invisibility cream	0		Effect: "Super Structure", Effect Duration: 50
 8367	quantum polarized blinking handful of stubble	0		Effect: "Vented Spleen", Effect Duration: 66
-8368	galvanized bouncing ghostly garbage juice slurpee	0		Effect: "Mighty Shout", Effect Duration: 30
+8368	galvanized ghostly bouncing garbage juice slurpee	0		Effect: "Mighty Shout", Effect Duration: 30
 8369	improved plunge-leg	0		Effect: "Frozen Shoulders", Effect Duration: 51
 8370	concentrated squat funky eyepatch	0		Effect: "Gemini Rising", Effect Duration: 11
 8371	nitrogenated warmed huge bucket of fish juice	0		Effect: "Rushin' Hands", Effect Duration: 29
@@ -8248,7 +8248,7 @@
 8374	ionized polymerized triple-warmed spinning shaking drinks tray	0		Effect: "Mutated", Effect Duration: 12
 8375	dry eyebrow lifter	0		Effect: "Seeing Colors", Effect Duration: 37
 8376	submarine	0		Last Available: "2015-06"
-8377	tiny rotten pixel lemon	1	crappy	Last Available: "2015-06"
+8377	rotten tiny pixel lemon	1	crappy	Last Available: "2015-06"
 8378	perfectly mixed twirling pixel daiquiri	4	EPIC	Last Available: "2015-06"
 8379	irradiated blurry power pill	0		Effect: "Cheered Up", Effect Duration: 50, Last Available: "2015-06"
 8380	super-improved colloidal pixel potion	0		Effect: "Slimy Flavor", Effect Duration: 21, Last Available: "2015-06"
@@ -8282,7 +8282,7 @@
 8408	concentrated irradiated moist ectoplasmic orbs	0		Effect: "Woad Warrior", Effect Duration: 23
 8409	bland wobbly crudles	3	decent	
 8410	big rotten agnolotti arboli	5	crappy	
-8411	bland snack-sized spaghetti with ghost balls	2	decent	
+8411	snack-sized bland spaghetti with ghost balls	2	decent	
 8412	snack-sized adequate succulent marrow	2	good	
 8413	toothsome blurry salacious crumbs	3	awesome	
 8414	decent fusilli marrownarrow	3	good	
@@ -8329,30 +8329,30 @@
 8455	upside-down New Age crystal	0		Last Available: "2015-08"
 8456	maroon crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	squat friendly high-temperature mining mask of James Dean	0		Experience (Moxie): +3, Familiar Weight: +3, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	squat friendly high-temperature mining mask of James Dean	0		Experience (Moxie): +3, Familiar Weight: +3, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	spinning pulsating groovy brawny fireproof megaphone	0		Muscle Percent: +20, Moxie Percent: +10, Last Available: "2015-08"
-8460	decent small mineapple	2	good	Last Available: "2015-08"
+8460	small decent mineapple	2	good	Last Available: "2015-08"
 8461	artisanal skewed Gold Velvet&trade; whiskey	4	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	awesome	Last Available: "2015-08"
 8463	immense spoiled smelted roe	10	crappy	Last Available: "2015-08"
-8464	practically non-alcoholic enchanted drinkable lavawater	1	good	Effect: "Pie in the Sky", Effect Duration: 10, Last Available: "2015-08"
+8464	enchanted drinkable practically non-alcoholic lavawater	1	good	Effect: "Pie in the Sky", Effect Duration: 10, Last Available: "2015-08"
 8465	irradiated basaltamander tongue	0		Effect: "Outer Wolf&trade;", Effect Duration: 55, Last Available: "2015-08"
 8466	skewed nasty sizzling savvy lavalarva	0		Mysticality Percent: +20, Hot Damage: +10, Stench Damage: +5, Last Available: "2015-08"
 8467	narrow Annie Oakley's electrified lava balaclava of Tarzan	0		Experience (Muscle): +3, Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08"
 8468	manspreader's grievous strapping basaltamander buckler	0		Muscle: +5, Weapon Damage Percent: +50, Monster Level: +10, Damage Reduction: 15, Last Available: "2015-08"
 8469	boiled upside-down lava globs	0		Effect: "Irresistible Resolve", Effect Duration: 17, Last Available: "2015-08"
-8470	rotten big gooey lava globs	5	crappy	Last Available: "2015-08"
+8470	big rotten gooey lava globs	5	crappy	Last Available: "2015-08"
 8471	zippy lava-proof pants of wisdom	0		Mysticality: +15, Initiative: +20, Last Available: "2015-08"
 8472	blue Sinatra's heat-resistant necktie of the sewer	0		Experience (Moxie): +5, Stench Damage: +25, Single Equip, Last Available: "2015-08"
 8473	Usain Bolt's fireproof heat-resistant gloves of the cougar	0		Moxie: +20, Hot Resistance: +3, Initiative: +80, Single Equip, Last Available: "2015-08"
 8474	adequate very hot lunch	3	good	Last Available: "2015-08"
-8475	drinkable watered-down asbestos thermos	2	good	Last Available: "2015-08"
+8475	watered-down drinkable asbestos thermos	2	good	Last Available: "2015-08"
 8476	alkaline alkaline blue liquid rhinestones	0		Effect: "Sugary World View", Effect Duration: 47, Last Available: "2015-08"
-8477	adequate gigantic disco biscuit	10	good	Last Available: "2015-08"
+8477	gigantic adequate disco biscuit	10	good	Last Available: "2015-08"
 8478	lousy Quaatorade&trade;	3	decent	Last Available: "2015-08"
-8479	purple pulsating Annie Oakley's steel-toed biker's hat of wisdom	0		Mysticality: +15, Damage Reduction: 9, Critical Hit Percent: +20, Familiar Effect: "atk", Last Available: "2015-08"
-8480	greasy feathered headdress of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: 60, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	healthy Samson's electrician's hardhat of wisdom	0		Mysticality: +15, Experience (Muscle): +5, Maximum HP Percent: +20, Familiar Effect: "atk", Last Available: "2015-08"
+8479	purple pulsating Annie Oakley's steel-toed biker's hat of wisdom	0		Mysticality: +15, Damage Reduction: 9, Critical Hit Percent: +20, Last Available: "2015-08", Familiar Effect: "atk"
+8480	greasy feathered headdress of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: 60, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	healthy Samson's electrician's hardhat of wisdom	0		Mysticality: +15, Experience (Muscle): +5, Maximum HP Percent: +20, Last Available: "2015-08", Familiar Effect: "atk"
 8482	pulsating Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	huge airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	smooth velvet pants of courage	0		Spooky Resistance: +3, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	smooth velvet pants of courage	0		Spooky Resistance: +3, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	smooth velvet shirt of the empath	0		Familiar Weight: +5, Last Available: "2015-08"
 8492	asbestos-lined smooth velvet hat	0		Hot Resistance: +5, Last Available: "2015-08"
 8493	twirling sharpshooter's smooth velvet pocket square	0		Critical Hit Percent: +10, Single Equip, Last Available: "2015-08"
@@ -8371,7 +8371,7 @@
 8497	Mr. Choch's bone	0		Last Available: "2015-08"
 8498	Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	skewed Saturday Night thermometer	0		Last Available: "2015-08"
-8500	maroon mirror the tongue of Smimmons	0		Last Available: "2015-08"
+8500	mirror maroon the tongue of Smimmons	0		Last Available: "2015-08"
 8501	mirror Raul's guitar pick	0		Last Available: "2015-08"
 8502	maroon Pener's crisps	0		Last Available: "2015-08"
 8503	signed deuce	0		Last Available: "2015-08"
@@ -8382,7 +8382,7 @@
 8508	concentrated purple labrador cookie	0		Effect: "Triangle, Man", Effect Duration: 43, Last Available: "2015-08"
 8509	extremely unsafe Mr. Cheeng's spectacles of terror of temperance	0		Weapon Damage Percent: +100, Spooky Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2015-08"
 8510	wool grease cannon of the blizzard	0		Cold Spell Damage: +25, Cold Resistance: +1, Last Available: "2015-08"
-8511	magnetized polarized olive jittery demon makeup kit	0		Effect: "Ooh, Umami!", Effect Duration: 18, Last Available: "2015-08"
+8511	magnetized polarized jittery olive demon makeup kit	0		Effect: "Ooh, Umami!", Effect Duration: 18, Last Available: "2015-08"
 8512	shaking resourceful Sinatra's love of the scaredy-cat	0		Experience (Moxie): +5, Maximum MP: +50, Monster Level: -15, Last Available: "2015-08"
 8513	blurry lightning-fast arcane researcher's boxer's Pener's drumstick	0		Muscle Percent: +10, Experience Percent (Mysticality): +10, Initiative: +40, Last Available: "2015-08"
 8514	deuce cape of Leguizamo of the early riser	0		Monster Level: +20, Adventures: +7, Last Available: "2015-08"
@@ -8391,12 +8391,12 @@
 8517	rosy-cheeked Samson's SMOOCH bracers	0		Experience (Muscle): +5, Maximum HP Percent: +30, Single Equip, Last Available: "2015-08"
 8518	weightlifter's SMOOCH kneepads	0		Muscle: +15, Single Equip, Last Available: "2015-08"
 8519	greedy SMOOCH spaulders	0		Meat Drop: +20, Single Equip, Last Available: "2015-08"
-8520	shaking electrified banded SMOOCH codpiece	0		Damage Absorption: +100, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	shaking electrified banded SMOOCH codpiece	0		Damage Absorption: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	padded SMOOCH breastplate	0		Damage Absorption: +20, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	special tasty diet lava cake	1	awesome	Effect: "Always In Motion", Effect Duration: 50, Last Available: "2015-08"
+8525	special diet tasty lava cake	1	awesome	Effect: "Always In Motion", Effect Duration: 50, Last Available: "2015-08"
 8526	tiny rotten pink slime	1	crappy	
 8527	blinking Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
@@ -8405,25 +8405,25 @@
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	ghostly illicit fish sauce	0		
-8534	super-sized fancy bland libertagliatelle	5	decent	Effect: "Frozen Shoulders", Effect Duration: 25
+8534	bland fancy super-sized libertagliatelle	5	decent	Effect: "Frozen Shoulders", Effect Duration: 25
 8535	rotten thick turkish mostaccioli	5	crappy	
 8536	bland gray linguini of the sea	4	decent	
 8537	tarnished ionized Hersey&trade; SMOOCH	0		Effect: "From Nantucket", Effect Duration: 58
 8539	blinking Alexy sauce	0		
 8540	pulsating rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	decent upside-down blue Fettris	3	good	
+8542	decent blue upside-down Fettris	3	good	
 8543	bland fusillocybin	3	decent	
 8544	flavorless prescription noodles	4	decent	
-8545	boiled ghostly yellow blood-drive sticker	1	decent	
+8545	boiled yellow ghostly blood-drive sticker	1	decent	
 8546	deionized colloidal bag of grain	0		Effect: "Litterboxing", Effect Duration: 54
-8547	adjusted quadruple-diffused ghostly blinking pocket maze	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 34
+8547	adjusted quadruple-diffused blinking ghostly pocket maze	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 34
 8548	quantum tumbling shady shades	0		Effect: "Virgo Rising", Effect Duration: 16
 8549	alkaline quantum cold-filtered wobbly squeaky toy rose	0		Effect: "Greased-Up Familiar", Effect Duration: 36
 8550	flavorless tiny weird gazelle steak	1	decent	
-8551	stale enchanted massive sausage without a cause	6	decent	Effect: "Chalked Weapon", Effect Duration: 10
+8551	massive stale enchanted sausage without a cause	6	decent	Effect: "Chalked Weapon", Effect Duration: 10
 8552	aerosolized face paint	0		Effect: "Alpine Mintiness", Effect Duration: 69
-8553	artisanal triple-distilled narrow emergency margarita	9	EPIC	
+8553	triple-distilled artisanal narrow emergency margarita	9	EPIC	
 8554	bad vintage smart drink	4	decent	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
@@ -8437,11 +8437,11 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	mirror careful chaotic groovy barrel lid	0		Moxie Percent: +10, Spell Critical Percent: +10, Monster Level: -10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	ghostly maroon Annie Oakley's padded barrel hoop earring of terror	0		Damage Absorption: +20, Critical Hit Percent: +20, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	skewed flame-retardant friendly forbidden bankruptcy barrel	0		Spell Damage Percent: +50, Familiar Weight: +3, Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	skewed flame-retardant friendly forbidden bankruptcy barrel	0		Spell Damage Percent: +50, Familiar Weight: +3, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	mirror firkin	0		Last Available: "2015-09"
 8569	pulsating normal barrel	0		Last Available: "2015-09"
 8570	huge tun	0		Last Available: "2015-09"
-8571	mirror blinking weathered barrel	0		Last Available: "2015-09"
+8571	blinking mirror weathered barrel	0		Last Available: "2015-09"
 8572	upside-down barrel	0		Last Available: "2015-09"
 8573	barrel	0		Last Available: "2015-09"
 8574	moist barrel	0		Last Available: "2015-09"
@@ -8449,11 +8449,11 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	watered-down hand-crafted bottle of Amontillado	2	EPIC	Last Available: "2015-09"
-8579	acceptable practically non-alcoholic narrow barrel-aged martini	1	good	Last Available: "2015-09"
+8579	practically non-alcoholic acceptable narrow barrel-aged martini	1	good	Last Available: "2015-09"
 8580	bland half-sized barrel pickle	2	decent	Last Available: "2015-09"
-8581	spoiled diet barrel cracker	1	crappy	Last Available: "2015-09"
+8581	diet spoiled barrel cracker	1	crappy	Last Available: "2015-09"
 8582	twisted upside-down pulsating vibrating mushroom	1	good	Last Available: "2015-09"
-8583	denatured huge twirling maroon mushroom	1	decent	Effect: "Oth-Jeal-O", Effect Duration: 40, Last Available: "2015-09"
+8583	denatured twirling maroon huge mushroom	1	decent	Effect: "Oth-Jeal-O", Effect Duration: 40, Last Available: "2015-09"
 8584	KoL Con 12-gauge of horror	0		Spooky Spell Damage: +25, Last Available: "2015-09"
 8585	wobbly pulsating Golden Mr. Eh?	0		Item Drop: +5, Last Available: "2015-09"
 8586	occult barrel gun	0		Spell Damage Percent: +25, Last Available: "2015-09"
@@ -8500,9 +8500,9 @@
 8627	tarnished cold-filtered magnetized cuppa Vitali tea	0		Effect: "Superveiny 9000", Effect Duration: 46, Last Available: "2015-09"
 8628	ionized enhanced cuppa Mana tea	0		Effect: "Proprie Tea", Effect Duration: 26, Last Available: "2015-09"
 8629	aerosolized triple-Vulcanized wet cuppa Monstrosi tea	0		Effect: "Tiki Toughness", Effect Duration: 12, Last Available: "2015-09"
-8630	adjusted wobbly blurry cuppa Twen tea	0		Effect: "Human-Constellation Hybrid", Effect Duration: 45, Last Available: "2015-09"
+8630	adjusted blurry wobbly cuppa Twen tea	0		Effect: "Human-Constellation Hybrid", Effect Duration: 45, Last Available: "2015-09"
 8631	concentrated twirling cuppa Gill tea	0		Effect: "Feet of Watermelon", Effect Duration: 37, Last Available: "2015-09"
-8632	frozen cold-filtered lime green blinking cuppa Uncertain tea	0		Effect: "Mortarfied", Effect Duration: 59, Last Available: "2015-09"
+8632	frozen cold-filtered blinking lime green cuppa Uncertain tea	0		Effect: "Mortarfied", Effect Duration: 59, Last Available: "2015-09"
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
@@ -8511,12 +8511,12 @@
 8638	skewed auspicious frosty Temple Grandin's Royal scepter	0		Familiar Weight: +7, Cold Spell Damage: +10, Item Drop: +10, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	skewed Ghost Dog Chow	0		Last Available: "2015-10"
-8641	spoiled fuchsia narrow bowl of eyeballs	4	crappy	Last Available: "2015-10"
-8642	adequate enchanted big bowl of mummy guts	5	good	Effect: "Cringle's Curative Carol", Effect Duration: 45, Last Available: "2015-10"
-8643	immense spoiled bowl of maggots	7	crappy	Last Available: "2015-10"
+8641	spoiled narrow fuchsia bowl of eyeballs	4	crappy	Last Available: "2015-10"
+8642	enchanted adequate big bowl of mummy guts	5	good	Effect: "Cringle's Curative Carol", Effect Duration: 45, Last Available: "2015-10"
+8643	spoiled immense bowl of maggots	7	crappy	Last Available: "2015-10"
 8644	weak bad tumbling blood and blood	2	decent	Last Available: "2015-10"
-8645	distilled tolerable Jack-O-Lantern beer	5	good	Last Available: "2015-10"
-8646	watered-down acceptable twirling zombie	2	good	Last Available: "2015-10"
+8645	tolerable distilled Jack-O-Lantern beer	5	good	Last Available: "2015-10"
+8646	acceptable watered-down twirling zombie	2	good	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	upside-down plastic nightmare troll	0		Last Available: "2015-10"
@@ -8533,13 +8533,13 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	spinning thinker's ghostly dagger of chilblains of the blizzard	0		Mysticality: +10, Cold Damage: +25, Cold Spell Damage: +25
-8663	drinkable high-proof ghost beer	9	good	
+8663	high-proof drinkable ghost beer	9	good	
 8664	blurry Jim Carey's Othello set	0		Monster Level: +25
 8665	cyan rotten tomato	0		
 8666	mirror Twelve Night Energy	0		
 8667	avaricious fortified Yorick of the ox	0		Muscle: +20, Damage Absorption: +60, Meat Drop: +30
 8668	rose	0		
-8669	tumbling olive squat tulip	0		
+8669	squat olive tumbling tulip	0		
 8670	wobbly tulip	0		
 8671	tulip	0		
 8672	Walford's bucket	0		Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	bouncing Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	wobbly The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	Oprah's bellhop's hat	0		Maximum MP Percent: +50, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	hand-crafted enchanted ice porter	3	EPIC	Effect: "Speed of the Internet", Effect Duration: 40, Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	Oprah's bellhop's hat	0		Maximum MP Percent: +50, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	enchanted hand-crafted ice porter	3	EPIC	Effect: "Speed of the Internet", Effect Duration: 40, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	super-concentrated exotic travel brochure	0		Effect: "Tomato Power", Effect Duration: 65, Last Available: "2015-11"
 8691	huge bag of foreign bribes	0		Last Available: "2015-11"
 8692	boiled shaking maroon shampoo-conditioner	0		Effect: "Tapped In", Effect Duration: 50, Last Available: "2015-11"
@@ -8567,17 +8567,17 @@
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	boiled olive medicinal herbs	1		Effect: "Unrunnable Face", Effect Duration: 35, Last Available: "2016-01"
-8697	snack-sized enchanted rotten ice rice	2	crappy	Effect: "New and Improved", Effect Duration: 10, Last Available: "2016-01"
+8697	enchanted rotten snack-sized ice rice	2	crappy	Effect: "New and Improved", Effect Duration: 10, Last Available: "2016-01"
 8698	fancy drinkable iced plum wine	4	good	Effect: "Riboflavin'", Effect Duration: 10, Last Available: "2016-01"
 8699	miser's auspicious aromatic training belt	0		Stench Resistance: +1, Item Drop: +10, Meat Drop: +10, Single Equip, Last Available: "2016-01"
 8700	up-at-dawn wholesome training legwarmers	0		Maximum HP Percent: +10, Item Drop: +5, Adventures: +5, Single Equip, Last Available: "2016-01"
-8701	greasy training helmet of incineration of the businessman	0		Hot Spell Damage: +50, Sleaze Spell Damage: +10, Meat Drop: +50, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	greasy training helmet of incineration of the businessman	0		Hot Spell Damage: +50, Sleaze Spell Damage: +10, Meat Drop: +50, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	upside-down training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
-8707	blurry jittery self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
+8707	jittery blurry self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	powdered abstraction: action	1		Last Available: "2015-12"
 8709	dehydrated abstraction: thought	1		Last Available: "2015-12"
 8710	vaporized spinning abstraction: sensation	1		Last Available: "2015-12"
@@ -8587,7 +8587,7 @@
 8714	boiled upside-down huge pulsating abstraction: motion	1		Last Available: "2015-12"
 8715	vaporized green blinking abstraction: joy	1		Effect: "Libra Rising", Effect Duration: 25, Last Available: "2015-12"
 8716	boiled abstraction: certainty	1		Last Available: "2015-12"
-8717	mixed ghostly shaking cyan abstraction: comprehension	1		Last Available: "2015-12"
+8717	mixed ghostly cyan shaking abstraction: comprehension	1		Last Available: "2015-12"
 8718	mirror modern picture frame	0		Last Available: "2015-12"
 8719	normal VYKEA meatballs	3	good	Last Available: "2015-11"
 8720	mediocre wobbly VYKEA mead	4	decent	Last Available: "2015-11"
@@ -8600,31 +8600,31 @@
 8727	VYKEA bracket	0		Last Available: "2015-11"
 8728	bouncing VYKEA dowel	0		Last Available: "2015-11"
 8729	knitted Lo Pan's rosy-cheeked VYKEA hex key	0		Maximum HP Percent: +30, Spell Critical Percent: +30, Cold Resistance: +3, Last Available: "2015-11"
-8730	bouncing huge blue VYKEA instructions	0		Last Available: "2015-11"
-8731	stale tin of submardines	4	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	tolerable weak spinning narrow bottle of norwhiskey	2	good	Last Available: "2015-11"
+8730	blue bouncing huge VYKEA instructions	0		Last Available: "2015-11"
+8731	stale tin of submardines	4	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	tolerable weak narrow spinning bottle of norwhiskey	2	good	Last Available: "2015-11"
 8733	compressed octolus oculus	1	good	Effect: "Filled with Magic", Effect Duration: 40, Last Available: "2015-11"
 8734	mirror friendly sinister sardine can key of the sweet-tooth	0		Spell Damage: +10, Familiar Weight: +3, Candy Drop: +100, Last Available: "2015-11"
-8735	dangerous norwhal helmet of the dark arts of temperance	0		Weapon Damage: +10, Spell Damage Percent: +100, Sleaze Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
+8735	dangerous norwhal helmet of the dark arts of temperance	0		Weapon Damage: +10, Spell Damage Percent: +100, Sleaze Resistance: +5, Last Available: "2015-11", Familiar Effect: "atk"
 8736	frightening Fonzie's octolus-skin cloak of temperance	0		Experience (Moxie): +1, Spooky Damage: +5, Sleaze Resistance: +5, Last Available: "2015-11"
-8737	perfectly mixed practically non-alcoholic enchanted yellow perfect cosmopolitan	1	super ultra mega turbo EPIC	Effect: "Perception", Effect Duration: 5, Last Available: "2015-11"
+8737	practically non-alcoholic perfectly mixed enchanted yellow perfect cosmopolitan	1	super ultra mega turbo EPIC	Effect: "Perception", Effect Duration: 5, Last Available: "2015-11"
 8738	drinkable watered-down perfect negroni	2	good	Last Available: "2015-11"
-8739	aged blurry upside-down perfect dark and stormy	3	awesome	Last Available: "2015-11"
-8740	strong bad blue perfect mimosa	5	decent	Last Available: "2015-11"
+8739	aged upside-down blurry perfect dark and stormy	3	awesome	Last Available: "2015-11"
+8740	bad strong blue perfect mimosa	5	decent	Last Available: "2015-11"
 8741	perfectly mixed cyan perfect old-fashioned	3	EPIC	Last Available: "2015-11"
 8742	smooth perfect paloma	4	awesome	Last Available: "2015-11"
 8743	energized pressed That 70s Cologne	0		Effect: "Old School Pompadour", Effect Duration: 48, Last Available: "2015-11"
 8744	ionized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Rage of the Reindeer", Effect Duration: 17, Last Available: "2015-11"
-8745	improved blurry spinning lime green Puffstone cigar	0		Effect: "Ham-Fisted", Effect Duration: 47, Last Available: "2015-11"
+8745	improved blurry lime green spinning Puffstone cigar	0		Effect: "Ham-Fisted", Effect Duration: 47, Last Available: "2015-11"
 8746	super-liquefied warmed non-moist gray Conspiracy&trade; mascara	0		Effect: "Fishy", Effect Duration: 63, Last Available: "2015-11"
 8747	chilled deionized diffused Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Deep-Seated Rage", Effect Duration: 26, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
-8749	flattened quantum alkaline teal ghostly Deep Machine Tunnels snowglobe	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 19, Last Available: "2015-12"
+8749	flattened quantum alkaline ghostly teal Deep Machine Tunnels snowglobe	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 19, Last Available: "2015-12"
 8750	Vulcanized spinning hemp candy necklace	0		Effect: "Souper Vengeful", Effect Duration: 49, Last Available: "2015-12"
 8751	energized magnetized communal gobstopper	0		Effect: "Seriously Mutated", Effect Duration: 32, Last Available: "2015-12"
-8752	huge yummy blinking Crimbo salad	9	awesome	Last Available: "2015-12"
+8752	yummy huge blinking Crimbo salad	9	awesome	Last Available: "2015-12"
 8753	enchanted tasty bread line	4	awesome	Effect: "Ten out of Ten", Effect Duration: 35, Last Available: "2015-12"
-8754	mediocre practically non-alcoholic bark rootbeer	1	decent	Last Available: "2015-12"
+8754	practically non-alcoholic mediocre bark rootbeer	1	decent	Last Available: "2015-12"
 8755	irresponsibly strong bad ale	9	decent	Last Available: "2015-12"
 8756	baleful plastic Tammy the Tambourine Elf	0		Spell Damage: +25, Last Available: "2015-12"
 8757	occult plastic Rudolph the Red	0		Spell Damage Percent: +25, Last Available: "2015-12"
@@ -8649,7 +8649,7 @@
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
-8780	jittery red iron chain	0		Last Available: "2015-12"
+8780	red jittery iron chain	0		Last Available: "2015-12"
 8781	mirror pine cone necklace	0		Item Drop: +5, Last Available: "2015-12"
 8782	Oprah's reindeer hammer	0		Maximum MP Percent: +50, Last Available: "2015-12"
 8783	knitted elf ploughshare	0		Cold Resistance: +3, Last Available: "2015-12"
@@ -8673,7 +8673,7 @@
 8801	incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
 8803	kidnapped orphan	0		Last Available: "2017-01"
-8804	twirling teal high-grade	0		Last Available: "2017-01"
+8804	teal twirling high-grade	0		Last Available: "2017-01"
 8805	high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
 8807	experimental gene therapy	0		Last Available: "2017-01"
@@ -8686,17 +8686,17 @@
 8814	blurry Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	narrow ghostly bat-bearing	0		Last Available: "2017-01"
 8816	huge bland Kudzu salad	7	decent	Last Available: "2016-12"
-8817	dehydrated tumbling blinking Mansquito Serum	1		Last Available: "2016-12"
-8818	practically non-alcoholic hand-crafted narrow Miss Graves' vermouth	1	super ultra mega turbo EPIC	Last Available: "2016-12"
+8817	dehydrated blinking tumbling Mansquito Serum	1		Last Available: "2016-12"
+8818	hand-crafted practically non-alcoholic narrow Miss Graves' vermouth	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 8819	spoiled The Plumber's mushroom stew	4	crappy	Last Available: "2016-12"
 8820	vaporized The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed The Mad Liquor	3	super EPIC	Last Available: "2016-12"
 8822	drinkable squat Doc Clock's thyme cocktail	3	good	Last Available: "2016-12"
 8823	toothsome super-sized Mr. Burnsger	5	awesome	Last Available: "2016-12"
 8824	distilled shaking skewed The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	careful supercharged Newton's The Jokester's gun	0		Experience (Mysticality): +3, Maximum MP Percent: +30, Monster Level: -10, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	skewed horrifying frosty strapping The Jokester's wig	0		Muscle: +5, Cold Spell Damage: +10, Spooky Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	gray squat reassuring wholesome The Jokester's pants	0		Maximum HP Percent: +10, Spooky Resistance: +1, Item Drop: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	careful supercharged Newton's The Jokester's gun	0		Experience (Mysticality): +3, Maximum MP Percent: +30, Monster Level: -10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	skewed horrifying frosty strapping The Jokester's wig	0		Muscle: +5, Cold Spell Damage: +10, Spooky Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	gray squat reassuring wholesome The Jokester's pants	0		Maximum HP Percent: +10, Spooky Resistance: +1, Item Drop: +5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	frozen polymerized deionized Jokester makeup	0		Effect: "Tremella Tremens", Effect Duration: 63, Last Available: "2016-12"
 8829	bouncing replica bat-oomerang	0		Last Available: "2016-12"
 8830	shaking battoo kit	0		Last Available: "2016-12"
@@ -8719,13 +8719,13 @@
 8847	extra-polymerized twirling red-hot jawbreaker	0		Effect: "Coal-Powered", Effect Duration: 15
 8848	vacuum-sealed question juice	0		Effect: "Crimbo Flavor", Effect Duration: 55
 8849	flattened deionized aerosolized tube of villain	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 36
-8850	Da Vinci's your cowboy boots	0		Experience (Mysticality): +5, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	Da Vinci's your cowboy boots	0		Experience (Mysticality): +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	huge nugget of thicksilver	0		Last Available: "2016-02"
 8854	nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
-8856	bouncing upside-down blue nugget of sicksilver	0		Last Available: "2016-02"
+8856	bouncing blue upside-down nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
 8858	bouncing nugget of ticksilver	0		Last Available: "2016-02"
 8859	sage quicksilver ring	0		Mysticality Percent: +10, Single Equip, Last Available: "2016-02"
@@ -8745,20 +8745,20 @@
 8873	electrified Pork 'n' Pork 'n' Pork 'n' Beans	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-02"
 8874	baleful Newton's Val-U Brand Every Bean Salad of dire peril of Calamity Jane of terror	0		Experience (Mysticality): +3, Weapon Damage: +20, Spell Damage: +25, Critical Hit Percent: +15, Spooky Spell Damage: +10, Last Available: "2016-02"
 8875	bouncing veiny rock-hard Shrub's Premium Baked Beans of Leguizamo	0		Damage Reduction: 5, Maximum HP: +10, Monster Level: +20, Last Available: "2016-02"
-8876	half-sized bland plate of Heimz Fortified Kidney Beans	2	decent	Last Available: "2016-02"
+8876	bland half-sized plate of Heimz Fortified Kidney Beans	2	decent	Last Available: "2016-02"
 8877	decent plate of Tesla's Electroplated Beans	3	good	Last Available: "2016-02"
-8878	stale half-sized plate of Mixed Garbanzos and Chickpeas	2	decent	Last Available: "2016-02"
-8879	miniature adequate plate of Hellfire Spicy Beans	2	good	Last Available: "2016-02"
+8878	half-sized stale plate of Mixed Garbanzos and Chickpeas	2	decent	Last Available: "2016-02"
+8879	adequate miniature plate of Hellfire Spicy Beans	2	good	Last Available: "2016-02"
 8880	stale plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
 8881	flavorless plate of World's Blackest-Eyed Peas	3	decent	Last Available: "2016-02"
-8882	decent special shaking plate of Trader Olaf's Exotic Stinkbeans	4	good	Effect: "Block-Rockin' Beet", Effect Duration: 25, Last Available: "2016-02"
+8882	special decent shaking plate of Trader Olaf's Exotic Stinkbeans	4	good	Effect: "Block-Rockin' Beet", Effect Duration: 25, Last Available: "2016-02"
 8883	enchanted spoiled plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	crappy	Effect: "Flame-Retardant Trousers", Effect Duration: 5, Last Available: "2016-02"
 8884	half-sized flavorless plate of Val-U Brand Every Bean Salad	2	decent	Last Available: "2016-02"
-8885	bland fancy half-sized plate of Shrub's Premium Baked Beans	2	decent	Effect: "Hammered", Effect Duration: 45, Last Available: "2016-02"
+8885	half-sized fancy bland plate of Shrub's Premium Baked Beans	2	decent	Effect: "Hammered", Effect Duration: 45, Last Available: "2016-02"
 8886	shaking frightening Socratic Fancy Jeff's pocket square	0		Experience (Mysticality): +1, Spooky Damage: +5, Last Available: "2016-02"
-8887	blinking zippy curative Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Initiative: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	blinking zippy curative Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Initiative: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	blurry Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	flame-wreathed Van der Graaf Amoon-Ra Cowtep's nemes of wisdom	0		Mysticality: +15, Hot Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	flame-wreathed Van der Graaf Amoon-Ra Cowtep's nemes of wisdom	0		Mysticality: +15, Hot Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	bouncing Glenn's dice	0		Last Available: "2016-02"
 8891	tumbling blue scorching Former Sheriff Dan's tin star of wisdom of the wise owl of the dark arts of doom	0		Mysticality: 35, Spell Damage Percent: +100, Hot Damage: +25, Spooky Spell Damage: +50, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8774,11 +8774,11 @@
 8902	ionized ghost bit	0		Effect: "Nas Tea", Effect Duration: 16, Last Available: "2016-02"
 8903	double-improved pickled buzzard feather	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 19, Last Available: "2016-02"
 8904	modified lion musk	0		Effect: "Gemini Rising", Effect Duration: 12, Last Available: "2016-02"
-8905	decent super-sized bear claw	5	good	Last Available: "2016-02"
+8905	super-sized decent bear claw	5	good	Last Available: "2016-02"
 8906	energized vacuum-sealed blurry rattler gland	0		Effect: "Extra Terrestrial", Effect Duration: 67, Last Available: "2016-02"
 8907	moist half-digested coal	0		Effect: "Human-Elf Hybrid", Effect Duration: 15, Last Available: "2016-02"
 8908	liquefied tightly-wound spine	0		Effect: "The Sweats", Effect Duration: 25, Last Available: "2016-02"
-8909	huge stale rotting beefsteak	8	decent	Last Available: "2016-02"
+8909	stale huge rotting beefsteak	8	decent	Last Available: "2016-02"
 8910	lousy firemilk	3	decent	Last Available: "2016-02"
 8911	pickled electrified spidercow eye-cluster	0		Effect: "Fungal Flambé", Effect Duration: 66, Last Available: "2016-02"
 8912	diluted upside-down moomy dust	1		Effect: "Arcane in the Brain", Effect Duration: 40, Last Available: "2016-02"
@@ -8801,11 +8801,11 @@
 8929	blurry red-hot knucklebone	0		Last Available: "2016-02"
 8930	triple-colloidal demonic cow's blood	0		Effect: "Cat-Alyzed", Effect Duration: 29, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
-8932	red twirling makeshift sixgun	0		Last Available: "2016-02"
+8932	twirling red makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
-8936	blurry gray hamethyst-handled sixgun	0		Last Available: "2016-02"
+8936	gray blurry hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	maroon mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	narrow diamondback skin	0		Last Available: "2016-02"
@@ -8843,7 +8843,7 @@
 8971	snake oil	0		
 8972	non-frozen denatured narrow skin oil	0		Effect: "meat.enh", Effect Duration: 38
 8973	diffused diffused unusual oil	0		Effect: "Discomfited", Effect Duration: 15
-8974	corrupted activated skewed red eldritch oil	0		Effect: "Unusual Fashion Sense", Effect Duration: 69
+8974	corrupted activated red skewed eldritch oil	0		Effect: "Unusual Fashion Sense", Effect Duration: 69
 8975	cyan exclusive club	0		
 8976	ionized wet alkaline patent preventative tonic	0		Effect: "Polar Express", Effect Duration: 19
 8977	aerosolized upside-down patent invisibility tonic	0		Effect: "On the Trolley", Effect Duration: 28
@@ -8861,24 +8861,24 @@
 8989	lime green narrow Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	twisted cyan skewed armored prawn	1		Last Available: "2016-03"
-8993	fancy gigantic adequate jumping horseradish	7	good	Effect: "Baconstoned", Effect Duration: 5, Last Available: "2016-03"
+8992	twisted skewed cyan armored prawn	1		Last Available: "2016-03"
+8993	fancy adequate gigantic jumping horseradish	7	good	Effect: "Baconstoned", Effect Duration: 5, Last Available: "2016-03"
 8994	drinkable tumbling pulsating Sacramento wine	3	good	Last Available: "2016-03"
 8995	liquefied concentrated blinking Greek fire	0		Effect: "Marbles in Your Mouth", Effect Duration: 61, Last Available: "2016-03"
 8996	energetic wizardly ox-head shield of Tarzan of James Dean of horror	0		Mysticality: +25, Experience (Muscle): +3, Experience (Moxie): +3, Maximum MP Percent: +20, Spooky Spell Damage: +25, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	foul-smelling grievous dented scepter of vim and vigor of the brazier of terror	0		Weapon Damage Percent: +50, Maximum HP Percent: +50, Hot Spell Damage: +25, Stench Damage: +10, Spooky Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	Sherlock's stanky hardy fortified razor-sharp very pointy crown	0		Weapon Damage Percent: +25, Damage Absorption: +60, Maximum HP: +50, Stench Spell Damage: +25, Item Drop: +25, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	Sherlock's stanky hardy fortified razor-sharp very pointy crown	0		Weapon Damage Percent: +25, Damage Absorption: +60, Maximum HP: +50, Stench Spell Damage: +25, Item Drop: +25, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	spinning executive scorching boxer's battle broom of the sewer of courage	0		Muscle Percent: +10, Hot Damage: +25, Stench Damage: +25, Spooky Resistance: +3, Meat Drop: +40, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	narrow Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	huge careful electrified Oprah's deadly carpe	0		Weapon Damage: +5, Maximum MP Percent: +50, Monster Level: -10, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
 9002	Lo Pan's wicked stylish codpiece of horror	0		Moxie: +25, Spell Damage: +5, Spell Critical Percent: +30, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
-9003	knitted stanky Van der Graaf brainy troutsers	0		Mysticality: +5, Stench Spell Damage: +25, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	knitted stanky Van der Graaf brainy troutsers	0		Mysticality: +5, Stench Spell Damage: +25, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	miser's chilly quilted Sinatra's bass clarinet	0		Experience (Moxie): +5, Damage Absorption: +40, Cold Damage: +5, Meat Drop: +10, Lasts Until Rollover, Last Available: "2016-04"
 9005	squat auspicious Sinatra's strapping fish hatchet of bravery	0		Muscle: +5, Experience (Moxie): +5, Spooky Resistance: +5, Item Drop: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	resourceful brawny tunac of the overflowing toilet of the cheetah	0		Muscle Percent: +20, Maximum MP: +50, Stench Spell Damage: +50, Initiative: +60, Lasts Until Rollover, Last Available: "2016-04"
 9007	pulsating fishin' pole	0		Last Available: "2016-04"
 9008	polarized nitrogenated mirror wriggling worm	0		Effect: "5 Pounds Lighter", Effect Duration: 26, Last Available: "2016-04"
-9009	fancy drinkable lime green bottle of Fishhead 900-Day IPA	3	good	Effect: "Alacri Tea", Effect Duration: 45, Last Available: "2016-04"
+9009	drinkable fancy lime green bottle of Fishhead 900-Day IPA	3	good	Effect: "Alacri Tea", Effect Duration: 45, Last Available: "2016-04"
 9010	Vulcanized galvanized blurry high-test fishing line	0		Effect: "Tomato Power", Effect Duration: 69, Last Available: "2016-04"
 9011	wobbly flame-wreathed fishin' hat	0		Hot Spell Damage: +10, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8904,7 +8904,7 @@
 9032	decent twirling bowl of Tastee-Wheet&trade;	3	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	bland enchanted yellow tumbling mirror browser cookie	4	decent	Effect: "Livin' Large", Effect Duration: 45, Last Available: "2016-06"
+9035	enchanted bland mirror tumbling yellow browser cookie	4	decent	Effect: "Livin' Large", Effect Duration: 45, Last Available: "2016-06"
 9036	distilled artisanal hacked gibson	5	EPIC	Last Available: "2016-06"
 9037	cyan Source shades of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2016-06"
 9038	shaking software bug	0		Last Available: "2016-06"
@@ -8944,14 +8944,14 @@
 9072	cop dollar	0		Last Available: "2016-07"
 9073	detective school application	0		Free Pull, Last Available: "2016-07"
 9074	asbestos-lined greasy MacGyver's detective roscoe	0		Maximum MP: +100, Sleaze Spell Damage: +10, Hot Resistance: +5, Last Available: "2016-07"
-9075	non-magnetized upside-down tumbling shoe gum	0		Effect: "Abyssal Tears", Effect Duration: 60, Last Available: "2016-07"
+9075	non-magnetized tumbling upside-down shoe gum	0		Effect: "Abyssal Tears", Effect Duration: 60, Last Available: "2016-07"
 9076	Sherlock's brainy noir fedora of the early riser	0		Mysticality: +5, Item Drop: +25, Adventures: +7, Last Available: "2016-07"
 9077	double-paned Jeselnik's weightlifter's trench coat	0		Muscle: +15, Sleaze Damage: +25, Cold Resistance: +5, Last Available: "2016-07"
 9078	artisanal spirit-forward Falcon&trade; Maltese Liquor	5	EPIC	Last Available: "2016-07"
 9079	stale hardboiled egg	4	decent	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	rosewater-soaked Jim Carey's hale stylish protonic accelerator pack of dire peril	0		Moxie: +25, Weapon Damage: +20, Maximum HP: +20, Monster Level: +25, Stench Resistance: +3, Item Drop: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	rosewater-soaked Jim Carey's hale stylish protonic accelerator pack of dire peril	0		Moxie: +25, Weapon Damage: +20, Maximum HP: +20, Monster Level: +25, Stench Resistance: +3, Item Drop: +5, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	blinking scorching Adventurer bobblehead	0		Hot Damage: +25, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	crafty Mr. Screege's spectacles	0		Maximum MP: +10, Single Equip, Last Available: "2016-08"
 9092	double-paned Spookyraven signet of wisdom of the sweet-tooth	0		Mysticality: +15, Cold Resistance: +5, Candy Drop: +100, Single Equip, Last Available: "2016-08"
 9093	thinker's tie-dyed fannypack of the sweet-tooth	0		Mysticality: +10, Candy Drop: +100, Single Equip, Last Available: "2016-08"
-9094	beefcake's burnt snowpants of the pedagogue	0		Muscle: +25, Experience: +3, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	arcane researcher's standards and practices guide	0		Experience Percent (Mysticality): +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	beefcake's burnt snowpants of the pedagogue	0		Muscle: +25, Experience: +3, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	arcane researcher's standards and practices guide	0		Experience Percent (Mysticality): +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	twirling olive blinking asbestos-lined frightening Carpathian longsword of wisdom	0		Mysticality: +15, Spooky Damage: +5, Hot Resistance: +5, Last Available: "2016-08"
 9097	Usain Bolt's miser's shellacked Liam's mail	0		Damage Reduction: 7, Meat Drop: +10, Initiative: +80, Last Available: "2016-08"
 9098	nasty Van der Graaf supercharged Unfortunato's foolscap	0		Maximum MP Percent: +30, Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-08"
@@ -8979,7 +8979,7 @@
 9107	improved skewed Rad-Pro (1 oz.)	0		Effect: "Mucilaginous Mentalism", Effect Duration: 39
 9108	twirling maroon lead umbrella	0		
 9109	warmed dry maroon Shrieking Weasel holo-record	0		Effect: "Strong Grip", Effect Duration: 45
-9110	dry non-concentrated shaking blinking Power-Guy 2000 holo-record	0		Effect: "Flagrantly Fragrant", Effect Duration: 24
+9110	dry non-concentrated blinking shaking Power-Guy 2000 holo-record	0		Effect: "Flagrantly Fragrant", Effect Duration: 24
 9111	galvanized oxidized purple Lucky Strikes holo-record	0		Effect: "Fruited", Effect Duration: 59
 9112	modified blurry EMD holo-record	0		Effect: "Saucefingers", Effect Duration: 36
 9113	boiled unsweetened Superdrifter holo-record	0		Effect: "Salty Mouth", Effect Duration: 63
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	repaid diaper of James Dean	0		Experience (Moxie): +3
 9118	wobbly Riker's Search History	0		Last Available: "2016-09"
-9119	high-proof bad olive Shot of Kardashian Gin	8	decent	Last Available: "2016-09"
+9119	bad high-proof olive Shot of Kardashian Gin	8	decent	Last Available: "2016-09"
 9120	green Newton's Unstable Pointy Ears	0		Experience (Mysticality): +3, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	crappy	Last Available: "2016-09"
@@ -9004,32 +9004,32 @@
 9132	nasty pistol	0		Stench Damage: +5, Item Drop: +5
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	diet spoiled twirling leftover pasty	1	crappy	
-9135	mediocre watered-down pulsating very whiskey	2	decent	
+9135	watered-down mediocre pulsating very whiskey	2	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	jittery li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	fuchsia li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	bouncing lime green li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	jittery li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	fuchsia li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	bouncing lime green li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	irradiated lime green hoarded candy wad	0		Effect: "Turkey-Friendly", Effect Duration: 25, Last Available: "2016-10"
 9147	extra-alkaline purple huge Prunets	0		Effect: "Super Skill", Effect Duration: 30
 9148	Twitching Television Tattoo	0		
 9149	upside-down squat baby scorpion	0		Familiar Weight: +10
 9150	oxidized invisible string	0		Lasts Until Rollover, Effect: "Eagle Eyes", Effect Duration: 47, Last Available: "2016-10"
 9151	double-Vulcanized invisible seam ripper	0		Lasts Until Rollover, Effect: "Executive Greed", Effect Duration: 69, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	rotten jumbo raw sweet potato	5	crappy	Last Available: "2016-11"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9153	jumbo rotten raw sweet potato	5	crappy	Last Available: "2016-11"
 9154	rotten raw beans	3	crappy	Last Available: "2016-11"
-9155	bland gigantic mirror raw stuffing	7	decent	Last Available: "2016-11"
-9156	delicious shaking blinking raw cranberry sauce	3	awesome	Last Available: "2016-11"
+9155	gigantic bland mirror raw stuffing	7	decent	Last Available: "2016-11"
+9156	delicious blinking shaking raw cranberry sauce	3	awesome	Last Available: "2016-11"
 9157	stale huge raw turkey	9	decent	Last Available: "2016-11"
 9158	normal fancy raw mincemeat	4	good	Effect: "Spirit of Alph", Effect Duration: 50, Last Available: "2016-11"
 9159	tasty raw potato	3	awesome	Last Available: "2016-11"
-9160	adequate green jittery raw gravy	3	good	Last Available: "2016-11"
+9160	adequate jittery green raw gravy	3	good	Last Available: "2016-11"
 9161	stale half-sized squat raw bread	2	decent	Last Available: "2016-11"
 9162	blinking wool stylish mini-marshmallow dispenser	0		Moxie: +25, Cold Resistance: +1, Last Available: "2016-11"
 9163	hale Da Vinci's glass casserole dish of Leguizamo	0		Experience (Mysticality): +5, Maximum HP: +20, Monster Level: +20, Last Available: "2016-11"
@@ -9040,16 +9040,16 @@
 9168	MacGyver's potato masher of the sweet-tooth	0		Maximum MP: +100, Candy Drop: +100, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	massive rotten sweet potatoes	8	crappy	Last Available: "2016-11"
+9171	rotten massive sweet potatoes	8	crappy	Last Available: "2016-11"
 9172	normal bean casserole	3	good	Last Available: "2016-11"
-9173	yummy fancy baked stuffing	3	awesome	Effect: "Warm Shoulders", Effect Duration: 20, Last Available: "2016-11"
+9173	fancy yummy baked stuffing	3	awesome	Effect: "Warm Shoulders", Effect Duration: 20, Last Available: "2016-11"
 9174	spoiled cranberry cylinder	4	crappy	Last Available: "2016-11"
 9175	toothsome thanksgiving turkey	3	awesome	Last Available: "2016-11"
 9176	decent diet jittery mince pie	1	good	Last Available: "2016-11"
 9177	rotten wobbly mashed potatoes	3	crappy	Last Available: "2016-11"
 9178	decent green warm gravy	3	good	Last Available: "2016-11"
 9179	rotten bread roll	3	crappy	Last Available: "2016-11"
-9180	bland squat fuchsia leftovers	3	decent	Last Available: "2016-11"
+9180	bland fuchsia squat leftovers	3	decent	Last Available: "2016-11"
 9181	stale immense leftovers sandwich	7	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9109,10 +9109,10 @@
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	lousy blue ginger beer	3	decent	Last Available: "2016-12"
-9240	mirror purple spare chocolate parts	0		Last Available: "2016-12"
+9240	purple mirror spare chocolate parts	0		Last Available: "2016-12"
 9241	irradiated industrial frosting	0		Effect: "Turtle Titters", Effect Duration: 15, Last Available: "2016-12"
 9242	corrupted chilled gray fake cocktail	0		Effect: "Rotten Memories", Effect Duration: 43, Last Available: "2016-12"
-9243	practically non-alcoholic bad high-end ginger wine	1	decent	Last Available: "2016-12"
+9243	bad practically non-alcoholic high-end ginger wine	1	decent	Last Available: "2016-12"
 9244	plastic bad vibe of the dark arts	0		Spell Damage Percent: +100, Last Available: "2016-12"
 9245	Jim Carey's plastic angry vikings	0		Monster Level: +25, Last Available: "2016-12"
 9246	wholesome plastic Knows About Chakras	0		Maximum HP Percent: +10, Last Available: "2016-12"
@@ -9121,11 +9121,11 @@
 9249	magnetized wobbly Inner Wisdom	0		Effect: "Wet Rub", Effect Duration: 46, Last Available: "2016-12"
 9250	concentrated activated shaking Inner Strength	0		Effect: "Appeteyes", Effect Duration: 38, Last Available: "2016-12"
 9251	polymerized flattened triple-corrupted Inner Truth	0		Effect: "Spiky Hair", Effect Duration: 55, Last Available: "2016-12"
-9252	adequate miniature upside-down spiritual candy cane	2	good	Last Available: "2016-12"
+9252	miniature adequate upside-down spiritual candy cane	2	good	Last Available: "2016-12"
 9253	bad squat spiritual eggnog	4	decent	Last Available: "2016-12"
 9254	flavorless spiritual fruitcake	3	decent	Last Available: "2016-12"
 9255	normal spiritual gingerbread	4	good	Last Available: "2016-12"
-9256	shaking olive chocolate puppy	0		Last Available: "2016-12"
+9256	olive shaking chocolate puppy	0		Last Available: "2016-12"
 9257	skewed chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	wobbly My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	ghostly Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
@@ -9147,7 +9147,7 @@
 9275	moldy fancy blinking hambrosier	3	crappy	Effect: "Quiet 'n' Good", Effect Duration: 15, Last Available: "2016-12"
 9276	smooth chakra-mental wine	3	awesome	Last Available: "2016-12"
 9277	liquefied flattened yellow chakra malt	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 19, Last Available: "2016-12"
-9278	miniature bland Black Angus blackburger	2	decent	Last Available: "2016-12"
+9278	bland miniature Black Angus blackburger	2	decent	Last Available: "2016-12"
 9279	lousy brandy	3	decent	Last Available: "2016-12"
 9280	anodized potion of spiritual gunkifying	0		Effect: "Egg on your Face", Effect Duration: 18, Last Available: "2016-12"
 9281	double-paned veiny bad vibroknife	0		Maximum HP: +10, Cold Resistance: +5, Last Available: "2016-12"
@@ -9167,7 +9167,7 @@
 9295	boiled twirling stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal toast with hot jelly	4	good	Last Available: "2017-01"
-9298	moldy small toast with jelly	2	crappy	Last Available: "2017-01"
+9298	small moldy toast with jelly	2	crappy	Last Available: "2017-01"
 9299	tasty toast with jelly	3	awesome	Last Available: "2017-01"
 9300	yummy toast with sleaze jelly	4	awesome	Last Available: "2017-01"
 9301	normal toast with stench jelly	4	good	Last Available: "2017-01"
@@ -9188,20 +9188,20 @@
 9316	heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	super-oxidized electrified gray LOV Elixir #3	0		Effect: "Carol of the Bones", Effect Duration: 51, Last Available: "2017-02"
 9318	activated LOV Elixir #6	0		Effect: "Deeply Ironic", Effect Duration: 28, Last Available: "2017-02"
-9319	vacuum-sealed colloidal tarnished squat gray narrow pulsating LOV Elixir #9	0		Effect: "Hennaliciousness", Effect Duration: 48, Last Available: "2017-02"
+9319	vacuum-sealed colloidal tarnished narrow pulsating gray squat LOV Elixir #9	0		Effect: "Hennaliciousness", Effect Duration: 48, Last Available: "2017-02"
 9320	mirror perfumed manspreader's electrified LOV Eardigan	0		Monster Level: +10, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2017-02"
 9321	miser's ribald grievous LOV Epaulettes	0		Weapon Damage Percent: +50, Sleaze Damage: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2017-02"
 9322	asbestos-lined wool LOV Earrings of the empath	0		Familiar Weight: +5, Cold Resistance: +1, Hot Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	LOV Enamorang	0		Last Available: "2017-02"
-9324	gray spinning LOV Emotionizer	0		Last Available: "2017-02"
+9324	spinning gray LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	altered upside-down LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	narrow LOV Elephant of horror	0		Spooky Spell Damage: +25, Damage Reduction: 6, Last Available: "2017-02"
 9328	sharpshooter's eldritch scanner	0		Critical Hit Percent: +10, Last Available: "2017-02"
-9329	liquefied anodized mirror wobbly eldritch alignment spray	0		Effect: "Blackberry Politeness", Effect Duration: 30, Last Available: "2017-02"
+9329	liquefied anodized wobbly mirror eldritch alignment spray	0		Effect: "Blackberry Politeness", Effect Duration: 30, Last Available: "2017-02"
 9330	shaking LOV Entrance Pass	0		Last Available: "2017-02"
 9331	narrow auspicious smelly healthy eldritch hammer	0		Maximum HP Percent: +20, Stench Spell Damage: +10, Item Drop: +10, Last Available: "2017-01"
-9332	spoiled snack-sized green eldritch mushroom	2	crappy	Last Available: "2017-03"
+9332	snack-sized spoiled green eldritch mushroom	2	crappy	Last Available: "2017-03"
 9333	blinking eldritch ichor	0		
 9334	immense adequate eldritch mushroom pizza	7	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9221,15 +9221,15 @@
 9349	blinking bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	shaking elemental sugarcube	0		Last Available: "2017-03"
 9351	mirror peppermint sprig	0		Last Available: "2017-03"
-9352	blinking skewed bottle of clam juice	0		Last Available: "2017-03"
-9353	blinking purple cocktail mushroom	0		Last Available: "2017-03"
+9352	skewed blinking bottle of clam juice	0		Last Available: "2017-03"
+9353	purple blinking cocktail mushroom	0		Last Available: "2017-03"
 9354	yellow shot of granola liqueur	0		Last Available: "2017-03"
 9355	upside-down can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	olive lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	baby oil shooter	0		Last Available: "2017-03"
-9360	blurry twirling fish head	0		Last Available: "2017-03"
+9360	twirling blurry fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	wobbly bouncing slime shooter	0		Last Available: "2017-03"
@@ -9239,20 +9239,20 @@
 9367	aged Phlegethon	3	awesome	Last Available: "2017-03"
 9368	hand-crafted Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	drinkable blurry mentholated wine	3	good	Last Available: "2017-03"
-9370	weak special acceptable low tide martini	2	good	Effect: "A Taste of Rainbow", Effect Duration: 45, Last Available: "2017-03"
+9370	acceptable weak special low tide martini	2	good	Effect: "A Taste of Rainbow", Effect Duration: 45, Last Available: "2017-03"
 9371	aged watered-down shroomtini	2	awesome	Last Available: "2017-03"
-9372	aged weak morning dew	2	awesome	Last Available: "2017-03"
+9372	weak aged morning dew	2	awesome	Last Available: "2017-03"
 9373	artisanal whiskey squeeze	4	EPIC	Last Available: "2017-03"
 9374	drinkable great fashioned	4	good	Last Available: "2017-03"
 9375	watered-down hand-crafted tumbling Gnomish sagngria	2	EPIC	Last Available: "2017-03"
 9376	drinkable vodka stinger	3	good	Last Available: "2017-03"
-9377	special aged wobbly extremely slippery nipple	4	awesome	Effect: "Donho's Bubbly Ballad", Effect Duration: 40, Last Available: "2017-03"
-9378	special irresponsibly strong lousy piscatini	8	decent	Effect: "Discomfited", Effect Duration: 15, Last Available: "2017-03"
+9377	aged special wobbly extremely slippery nipple	4	awesome	Effect: "Donho's Bubbly Ballad", Effect Duration: 40, Last Available: "2017-03"
+9378	irresponsibly strong lousy special piscatini	8	decent	Effect: "Discomfited", Effect Duration: 15, Last Available: "2017-03"
 9379	bad Churchill	4	decent	Last Available: "2017-03"
-9380	fancy hand-crafted soilzerac	4	EPIC	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2017-03"
-9381	enchanted bad practically non-alcoholic London frog	1	decent	Effect: "Armored Innards", Effect Duration: 25, Last Available: "2017-03"
+9380	hand-crafted fancy soilzerac	4	EPIC	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2017-03"
+9381	bad practically non-alcoholic enchanted London frog	1	decent	Effect: "Armored Innards", Effect Duration: 25, Last Available: "2017-03"
 9382	watered-down smooth nothingtini	2	awesome	Last Available: "2017-03"
-9383	weak tolerable eighth plague	2	good	Last Available: "2017-03"
+9383	tolerable weak eighth plague	2	good	Last Available: "2017-03"
 9384	practically non-alcoholic perfectly mixed single entendre	1	EPIC	Last Available: "2017-03"
 9385	lousy blue reverse Tantalus	3	decent	Last Available: "2017-03"
 9386	mediocre elemental caipiroska	3	decent	Last Available: "2017-03"
@@ -9260,16 +9260,16 @@
 9388	hand-crafted yellow Bloody Nora	3	EPIC	Last Available: "2017-03"
 9389	practically non-alcoholic lousy moreltini	1	decent	Last Available: "2017-03"
 9390	practically non-alcoholic artisanal hell in a bucket	1	EPIC	Last Available: "2017-03"
-9391	mediocre tumbling yellow Newark	3	decent	Last Available: "2017-03"
+9391	mediocre yellow tumbling Newark	3	decent	Last Available: "2017-03"
 9392	lousy twirling R'lyeh	4	decent	Last Available: "2017-03"
-9393	tolerable distilled enchanted lime green jittery Gnollish sangria	5	good	Effect: "Natural 20", Effect Duration: 20, Last Available: "2017-03"
+9393	distilled tolerable enchanted jittery lime green Gnollish sangria	5	good	Effect: "Natural 20", Effect Duration: 20, Last Available: "2017-03"
 9394	fancy artisanal upside-down vodka barracuda	3	EPIC	Effect: "Polka Face", Effect Duration: 35, Last Available: "2017-03"
-9395	watered-down enchanted delicious wobbly Mysterious Island iced tea	2	awesome	Effect: "Dance of the Sugar Fairy", Effect Duration: 50, Last Available: "2017-03"
-9396	weak lousy drive-by shooting	2	decent	Last Available: "2017-03"
-9397	perfectly mixed high-proof special maroon gunner's daughter	7	EPIC	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2017-03"
+9395	enchanted delicious watered-down wobbly Mysterious Island iced tea	2	awesome	Effect: "Dance of the Sugar Fairy", Effect Duration: 50, Last Available: "2017-03"
+9396	lousy weak drive-by shooting	2	decent	Last Available: "2017-03"
+9397	high-proof special perfectly mixed maroon gunner's daughter	7	EPIC	Effect: "Whitened Teeth", Effect Duration: 50, Last Available: "2017-03"
 9398	hand-crafted maroon dirt julep	3	EPIC	Last Available: "2017-03"
 9399	drinkable Simepore slime	3	good	Last Available: "2017-03"
-9400	perfectly mixed weak Phil Collins	2	EPIC	Last Available: "2017-03"
+9400	weak perfectly mixed Phil Collins	2	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	blinking gray toggle switch (Bartend)	0		Familiar Weight: +5
 9403	spinning toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	skewed geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	huge delicious olive edible alien plant bit	6	awesome	Last Available: "2017-04"
+9415	delicious huge olive edible alien plant bit	6	awesome	Last Available: "2017-04"
 9416	twirling alien plant fibers	0		Last Available: "2017-04"
 9417	upside-down alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	skewed murderbot data core	0		Last Available: "2017-04"
 9432	chilled extra-corrupted alien medicine	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 34, Last Available: "2017-04"
-9433	miniature delicious alien salad	2	awesome	Last Available: "2017-04"
+9433	delicious miniature alien salad	2	awesome	Last Available: "2017-04"
 9434	drinkable blurry alien booze	4	good	Last Available: "2017-04"
 9435	upside-down wobbly alien mask of the wise owl of James Dean of dire peril	0		Mysticality: +20, Experience (Moxie): +3, Weapon Damage: +20, Last Available: "2017-04"
 9436	double-paned flame-wreathed extremely unsafe alien spear	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Cold Resistance: +5, Last Available: "2017-04"
@@ -9311,7 +9311,7 @@
 9439	Temple Grandin's beefcake's alien totem of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Familiar Weight: +7, Last Available: "2017-04"
 9440	blurry Fonzie's alien necklace of incineration of horror	0		Experience (Moxie): +1, Hot Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2017-04"
 9441	spant chitin	0		Last Available: "2017-04"
-9442	mirror olive shaking spant tendon	0		Last Available: "2017-04"
+9442	olive mirror shaking spant tendon	0		Last Available: "2017-04"
 9443	bouncing hale wizardly spants	0		Mysticality: +25, Maximum HP: +20, Last Available: "2017-04"
 9444	jittery extremely unsafe personal trainer's spant shield	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +100, Damage Reduction: 6, Last Available: "2017-04"
 9445	scandalous forbidden spant shoulderpads	0		Spell Damage Percent: +50, Sleaze Damage: +5, Single Equip, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	skewed murderbot mask of the sewer of terror of the glutton	0		Stench Damage: +25, Spooky Spell Damage: +10, Food Drop: +100, Avatar: "Murderbot", Last Available: "2017-04"
 9454	denatured non-denatured murderbot spring injector	0		Effect: "Hammertime", Effect Duration: 28, Last Available: "2017-04"
 9455	Samson's murderbot whip of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Last Available: "2017-04"
-9456	yellow shaking upside-down lion tamer's careful murderbot plasma rifle	0		Monster Level: -10, Experience (familiar): +2, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	yellow shaking upside-down lion tamer's careful murderbot plasma rifle	0		Monster Level: -10, Experience (familiar): +2, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	blurry murderbot memory chip	0		Last Available: "2017-04"
 9458	bouncing space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9337,7 +9337,7 @@
 9465	Spacegate	0		Last Available: "2017-04"
 9466	toothsome narrow Aldebaran sardines	3	awesome	Last Available: "2017-04"
 9467	drinkable skewed Centauri fish wine	3	good	Last Available: "2017-04"
-9468	diluted gray blinking mirror oxygen	1		Last Available: "2017-04"
+9468	diluted blinking mirror gray oxygen	1		Last Available: "2017-04"
 9469	Oprah's quilted Spacegate scientist's insignia	0		Damage Absorption: +40, Maximum MP Percent: +50, Single Equip, Last Available: "2017-04"
 9470	bouncing smelly ruddy Spacegate military insignia	0		Maximum HP Percent: +40, Stench Spell Damage: +10, Single Equip, Last Available: "2017-04"
 9471	squat yellow zippy deadly supercool Spacegate diplomat's insignia	0		Moxie Percent: +20, Weapon Damage: +5, Initiative: +20, Single Equip, Last Available: "2017-04"
@@ -9351,7 +9351,7 @@
 9479	galvanized modified fuchsia Daily Affirmation: Always be Collecting	0		Effect: "Your Eyes are Peeled!", Effect Duration: 20, Last Available: "2017-05"
 9480	ionized concentrated Daily Affirmation: Think Win-Lose	0		Effect: "Going Ape", Effect Duration: 36, Last Available: "2017-05"
 9481	corrupted tumbling Daily Affirmation: Be Superficially interested	0		Effect: "Pumped Stomach", Effect Duration: 41, Last Available: "2017-05"
-9482	non-corrupted upside-down cyan bouncing Daily Affirmation: Adapt to Change Eventually	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 34, Last Available: "2017-05"
+9482	non-corrupted cyan bouncing upside-down Daily Affirmation: Adapt to Change Eventually	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 34, Last Available: "2017-05"
 9483	dry wet mirror Daily Affirmation: Be a Mind Master	0		Effect: "What's That Smell?", Effect Duration: 20, Last Available: "2017-05"
 9484	boiled green Daily Affirmation: Work For Hours a Week	0		Effect: "Faboooo", Effect Duration: 50, Last Available: "2017-05"
 9485	ionized Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Cold, Dead Hands", Effect Duration: 11, Last Available: "2017-05"
@@ -9362,7 +9362,7 @@
 9490	enhanced wobbly Threatening Missive	0		Effect: "Muscularrr", Effect Duration: 65
 9491	purple bouncing Targeted Plague Vector	0		
 9492	spinning suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	spinning double-paned Socratic Kremlin's Greatest Briefcase of courage	0		Experience (Mysticality): +1, Cold Resistance: +5, Spooky Resistance: +3, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	spinning double-paned Socratic Kremlin's Greatest Briefcase of courage	0		Experience (Mysticality): +1, Cold Resistance: +5, Spooky Resistance: +3, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	bad skewed basic martini	4	decent	Last Available: "2017-06"
 9495	drinkable skewed improved martini	4	good	Last Available: "2017-06"
 9496	weak acceptable splendid martini	2	good	Last Available: "2017-06"
@@ -9388,7 +9388,7 @@
 9516	upside-down maroon meteoroid	0		Last Available: "2017-08"
 9517	maroon auspicious meteortarboard of the cougar of dire peril	0		Moxie: +20, Weapon Damage: +20, Item Drop: +10, Last Available: "2017-08"
 9518	horrifying flame-wreathed coward's meteorite guard	0		Monster Level: -20, Hot Spell Damage: +10, Spooky Damage: +25, Damage Reduction: 9, Last Available: "2017-08"
-9519	tumbling prompt zippy meteorb	0		Initiative: +20, Adventures: +3, Lantern Element: "Hot", Last Available: "2017-08"
+9519	tumbling prompt zippy meteorb	0		Initiative: +20, Adventures: +3, Last Available: "2017-08", Lantern Element: "Hot"
 9520	horrifying stiffened asteroid belt	0		Damage Reduction: 1, Spooky Damage: +25, Single Equip, Last Available: "2017-08"
 9521	stanky Tesla meteorthopedic shoes of bravery	0		Stench Spell Damage: +25, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2017-08"
 9522	lightning-fast Fonzie's beefy shooting morning star	0		Muscle: +10, Experience (Moxie): +1, Initiative: +40, Single Equip, Last Available: "2017-08"
@@ -9414,15 +9414,15 @@
 9542	pulsating exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	skewed X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	bad watered-down yellow skewed DUFRESNE Suds	2	decent	Last Available: "2017-09"
+9545	bad watered-down skewed yellow DUFRESNE Suds	2	decent	Last Available: "2017-09"
 9546	mafia pinky ring of the scaredy-cat of horror	0		Monster Level: -15, Spooky Spell Damage: +25, Single Equip
-9547	bad practically non-alcoholic flask of port	1	decent	
+9547	practically non-alcoholic bad flask of port	1	decent	
 9548	zippy hardened contract enforcement stick	0		Damage Reduction: 3, Initiative: +20
-9549	spoiled snack-sized purple Hide-rox&trade; cookie	2	crappy	Last Available: "2017-10"
+9549	snack-sized spoiled purple Hide-rox&trade; cookie	2	crappy	Last Available: "2017-10"
 9550	perfectly mixed strong jug of booze	5	EPIC	Last Available: "2017-10"
 9551	Vulcanized jittery pair of candy glasses	0		Effect: "Gummi Badass", Effect Duration: 15, Last Available: "2017-10"
 9552	modified non-frozen red temporary X tattoos	0		Effect: "Blood-Rich", Effect Duration: 14, Last Available: "2017-10"
-9553	dried tumbling yellow glyph of athleticism	1		Last Available: "2017-10"
+9553	dried yellow tumbling glyph of athleticism	1		Last Available: "2017-10"
 9554	squat pair of scissors	0		Last Available: "2017-10"
 9555	aerosolized new habit	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 41, Last Available: "2017-10"
 9556	gray bridge truss	0		Last Available: "2017-10"
@@ -9448,13 +9448,13 @@
 9576	twirling cool mafia organizer badge	0		Moxie: +5, Single Equip
 9577	mirror mafia filofax	0		
 9578	transparent nog	1	decent	Last Available: "2017-12"
-9579	stale tiny unfinished fruitcake	1	decent	Last Available: "2017-12"
+9579	tiny stale unfinished fruitcake	1	decent	Last Available: "2017-12"
 9580	Vulcanized polymerized narrow bouncing and cracker	0		Effect: "Mucilaginous Mentalism", Effect Duration: 51, Last Available: "2017-12"
 9581	hand-crafted neg grog	3	EPIC	Last Available: "2017-12"
-9582	snack-sized fancy stale huge half double fruitcake	2	decent	Effect: "Ogred and Oublietted", Effect Duration: 40, Last Available: "2017-12"
-9583	special rotten hushed puppy	3	crappy	Effect: "Good Karma", Effect Duration: 50, Last Available: "2017-12"
+9582	snack-sized stale fancy huge half double fruitcake	2	decent	Effect: "Ogred and Oublietted", Effect Duration: 40, Last Available: "2017-12"
+9583	rotten special hushed puppy	3	crappy	Effect: "Good Karma", Effect Duration: 50, Last Available: "2017-12"
 9584	bland muffled muffuletta	3	decent	Last Available: "2017-12"
-9585	toothsome small pulsating shushed potatoes	2	awesome	Last Available: "2017-12"
+9585	small toothsome pulsating shushed potatoes	2	awesome	Last Available: "2017-12"
 9586	ghostly plastic mime functionary	0		Item Drop: +5, Last Available: "2017-12"
 9587	aromatic plastic mime scientist	0		Stench Resistance: +1, Last Available: "2017-12"
 9588	ghostly chaotic plastic mime soldier	0		Spell Critical Percent: +10, Last Available: "2017-12"
@@ -9464,9 +9464,9 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	special mirror temperance whiskey	1	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2017-11"
 9594	enhanced pickled blinking wishbone	0		Effect: "Rage of the Reindeer", Effect Duration: 49, Last Available: "2017-11"
-9595	special spirit-forward delicious Racisto Ruidoso	5	awesome	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2017-11"
+9595	spirit-forward special delicious Racisto Ruidoso	5	awesome	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2017-11"
 9596	teal earthenware muffin tin	0		
-9597	spoiled pulsating narrow bran muffin	3	crappy	
+9597	spoiled narrow pulsating bran muffin	3	crappy	
 9598	jumbo spoiled narrow blueberry muffin	5	crappy	
 9599	tumbling silent A	0		Last Available: "2017-12"
 9600	pulsating silent B	0		Last Available: "2017-12"
@@ -9488,7 +9488,7 @@
 9616	silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
-9619	fuchsia mirror blinking silent U	0		Last Available: "2017-12"
+9619	mirror blinking fuchsia silent U	0		Last Available: "2017-12"
 9620	twirling yellow silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	delicious stale cheer wine	3	awesome	Last Available: "2017-12"
-9630	super-sized adequate stale Cheer-E-Os	5	good	Last Available: "2017-12"
+9630	adequate super-sized stale Cheer-E-Os	5	good	Last Available: "2017-12"
 9631	mirror cheer-o-gram	0		Last Available: "2017-12"
 9632	inspector's Jack Frost's cheerful antler hat	0		Cold Spell Damage: +50, Item Drop: +15, Last Available: "2017-12"
 9633	narrow censurious cheerful Crimbo sweater of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +3, Last Available: "2017-12"
@@ -9518,10 +9518,10 @@
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	cyan mime eraser	0		Last Available: "2017-12"
 9648	drinkable enchanted executive mime flask	4	good	Effect: "Items Are Forever", Effect Duration: 40, Last Available: "2017-12"
-9649	rotten snack-sized green nega-mushroom	2	crappy	Last Available: "2017-12"
-9650	artisanal high-proof nega-mushroom wine	7	EPIC	Last Available: "2017-12"
+9649	snack-sized rotten green nega-mushroom	2	crappy	Last Available: "2017-12"
+9650	high-proof artisanal nega-mushroom wine	7	EPIC	Last Available: "2017-12"
 9651	chilled mirror Cheer-Up soda	0		Effect: "Radium Radicality", Effect Duration: 58, Last Available: "2017-12"
-9652	low-calorie bland mime army rations	1	decent	Last Available: "2017-12"
+9652	bland low-calorie mime army rations	1	decent	Last Available: "2017-12"
 9653	drinkable mime army wine	3	good	Last Available: "2017-12"
 9654	distilled jittery mime army superserum	1		Last Available: "2017-12"
 9655	triple-dry frozen mime army camouflage kit	0		Effect: "Ocelot Eyes", Effect Duration: 52, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	enhanced spinning digital honeypot	0		Effect: "Pyramid Power", Effect Duration: 58, Last Available: "2025-12"
 9666	spinning mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	wool mime army insignia (intelligence)	0		Cold Resistance: +1, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	asbestos-lined mime army insignia (espionage)	0		Hot Resistance: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	mime army insignia (infantry) of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	wool mime army insignia (intelligence)	0		Cold Resistance: +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	asbestos-lined mime army insignia (espionage)	0		Hot Resistance: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	shaking mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	skewed kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	tasty special extra-toasted half sandwich	3	awesome	Effect: "Pumped Stomach", Effect Duration: 40, Last Available: "2018-12"
+9681	special tasty extra-toasted half sandwich	3	awesome	Effect: "Pumped Stomach", Effect Duration: 40, Last Available: "2018-12"
 9682	drinkable triple-distilled mulled hobo wine	10	good	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	rosewater-soaked Herculean burning paper hat of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2018-12"
@@ -9592,11 +9592,11 @@
 9724	psychic's crystal ball of courage of the cheetah	0		Spooky Resistance: +3, Initiative: +60, Last Available: "2018-02"
 9725	fuchsia narrow savvy psychic's pslacks of Gandalf	0		Mysticality Percent: +20, Spell Critical Percent: +20, Last Available: "2018-02"
 9726	healthy psychic's amulet of the brazier	0		Maximum HP Percent: +20, Hot Spell Damage: +25, Last Available: "2018-02"
-9727	miniature flavorless heart-shaped candy whetstone	2	decent	Last Available: "2018-02"
-9728	enchanted flavorless tiny tumbling Swedish massage fish	1	decent	Effect: "Big Flaming Whip", Effect Duration: 35, Last Available: "2018-02"
+9727	flavorless miniature heart-shaped candy whetstone	2	decent	Last Available: "2018-02"
+9728	flavorless tiny enchanted tumbling Swedish massage fish	1	decent	Effect: "Big Flaming Whip", Effect Duration: 35, Last Available: "2018-02"
 9729	perfectly mixed Third Base	4	EPIC	Last Available: "2018-02"
 9730	bad watered-down Bustle Hustler	2	decent	Last Available: "2018-02"
-9731	anodized activated modified blinking squat Fabiotion	0		Effect: "Drunk With Power", Effect Duration: 15, Last Available: "2018-02"
+9731	anodized activated modified squat blinking Fabiotion	0		Effect: "Drunk With Power", Effect Duration: 15, Last Available: "2018-02"
 9732	liquefied ghostly Bettie page	0		Effect: "Vitamin-Maxed", Effect Duration: 32, Last Available: "2018-02"
 9733	diffused wobbly tonic o' Banderas	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 42, Last Available: "2018-02"
 9734	non-tarnished deionized jittery heather graham cracker	0		Effect: "Slimy Flavor", Effect Duration: 55, Last Available: "2018-02"
@@ -9628,13 +9628,13 @@
 9760	packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	skewed Globmule	0		Last Available: "2018-03"
-9763	jittery blinking Bluzzard	0		Last Available: "2018-03"
+9763	blinking jittery Bluzzard	0		Last Available: "2018-03"
 9764	gray Faux	0		Last Available: "2018-03"
 9765	fuchsia Sledgehamster	0		Last Available: "2018-03"
 9766	bouncing mirror Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	huge Dressage	0		Last Available: "2018-03"
-9769	twirling mirror Sequestrian	0		Last Available: "2018-03"
+9769	mirror twirling Sequestrian	0		Last Available: "2018-03"
 9770	Carpricorn	0		Last Available: "2018-03"
 9771	Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
@@ -9683,7 +9683,7 @@
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
-9818	huge maroon Tapioc berry	0		Last Available: "2018-03"
+9818	maroon huge Tapioc berry	0		Last Available: "2018-03"
 9819	Snarf berry	0		Last Available: "2018-03"
 9820	olive Keese berry	0		Last Available: "2018-03"
 9821	twirling luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	distilled blurry magnificent oyster egg	1		Effect: "Sweet and Green", Effect Duration: 50
 9829	twisted squat brilliant oyster egg	1		
 9830	dehydrated glistening oyster egg	1		
-9831	modified pulsating purple scintillating oyster egg	1		
+9831	modified purple pulsating scintillating oyster egg	1		
 9832	boiled tumbling pearlescent oyster egg	1		Effect: "Beta Carotene Overdose", Effect Duration: 10
 9833	distilled lustrous oyster egg	1		Effect: "Spookypants", Effect Duration: 20
 9834	mixed gleaming oyster egg	1		Effect: "Heart of Orange", Effect Duration: 35
@@ -9721,7 +9721,7 @@
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	blinking druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
-9856	jittery spinning flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
+9856	spinning jittery flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	non-pickled universal antivenin	0		Lasts Until Rollover, Effect: "Concentration", Effect Duration: 13, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
@@ -9734,7 +9734,7 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	decent diet druidic s'more	1	good	Last Available: "2018-04"
+9869	diet decent druidic s'more	1	good	Last Available: "2018-04"
 9870	distilled ghostly sachet of powder	1		Effect: "Whitened Teeth", Effect Duration: 15, Last Available: "2018-04"
 9871	bad high-proof mourning wine	6	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless denastified haunch	3	decent	Last Available: "2018-04"
-9879	delicious fortified bad rum and good cola	5	awesome	Last Available: "2018-04"
+9879	fortified delicious bad rum and good cola	5	awesome	Last Available: "2018-04"
 9880	wet irradiated cyan Potion of Heroism	0		Effect: "Alacri Tea", Effect Duration: 58, Last Available: "2018-04"
 9881	perfumed Van der Graaf arcane researcher's leggings of the Spider Queen	0		Experience Percent (Mysticality): +10, Stench Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-04"
 9882	blinking medical-grade padded Master Thief's utility belt of the cougar	0		Moxie: +20, Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	acceptable squat two meat muck	3	good	
-9899	fancy stale chocolate Ogre Chieftain	3	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30
+9899	stale fancy chocolate Ogre Chieftain	3	decent	Effect: "Human-Weird Thing Hybrid", Effect Duration: 30
 9900	decent huge chocolate &quot;Phoenix&quot;	4	good	
-9901	flavorless small chocolate Spider Queen	2	decent	
+9901	small flavorless chocolate Spider Queen	2	decent	
 9902	mediocre hipster cocktail	3	decent	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	pulsating God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	maroon God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	pulsating God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	maroon God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	jittery Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	blinking G	0		
 9910	Garland of Greatness	0		
@@ -9790,7 +9790,7 @@
 9922	diffused boiled Shielding Potion	0		Effect: "Ooh, Bitter!", Effect Duration: 35, Last Available: "2018-06"
 9923	deionized nitrogenated Punching Potion	0		Effect: "Greased-Up Familiar", Effect Duration: 53, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	pickled red bouncing Nightmare Fuel	1		Last Available: "2018-06"
+9925	pickled bouncing red Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9821,9 +9821,9 @@
 9953	bland PB&J with the crusts cut off	4	decent	Last Available: "2018-09"
 9954	purple huge steel-toed dorky glasses of terror	0		Damage Reduction: 9, Spooky Spell Damage: +10, Single Equip, Last Available: "2018-09"
 9955	bouncing purple Van der Graaf ponytail clip of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-09"
-9956	paint palette of dire peril	0		Weapon Damage: +20, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	paint palette of dire peril	0		Weapon Damage: +20, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	maroon unremarkable duffel bag	0		Last Available: "2018-09"
-9958	distilled ghostly red pulsating Purple Beast energy drink	1		Effect: "Good Motivator", Effect Duration: 5, Last Available: "2018-09"
+9958	distilled red ghostly pulsating Purple Beast energy drink	1		Effect: "Good Motivator", Effect Duration: 5, Last Available: "2018-09"
 9959	scandalous cosmetic football	0		Sleaze Damage: +5, Last Available: "2018-09"
 9960	Jim Carey's occult shoe ad T-shirt	0		Spell Damage Percent: +25, Monster Level: +25, Last Available: "2018-09"
 9961	huge pump-up high-tops of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2018-09"
@@ -9837,21 +9837,21 @@
 9969	greedy supercharged denim jacket	0		Maximum MP Percent: +30, Meat Drop: +20, Last Available: "2018-09"
 9970	blinking ratty knitted cap of doom of Flo-Jo	0		Spooky Spell Damage: +50, Initiative: +100, Last Available: "2018-09"
 9972	studded weightlifter's intimidating chainsaw	0		Muscle: +15, Damage Absorption: +80, Lasts Until Rollover, Last Available: "2018-09"
-9973	practically non-alcoholic special hand-crafted wobbly party beer bomb	1	EPIC	Effect: "Hood Ridin'", Effect Duration: 30, Last Available: "2018-09"
-9974	fancy delicious jittery upside-down sweet party mix	3	awesome	Effect: "Chalk Outline", Effect Duration: 5, Last Available: "2018-09"
+9973	hand-crafted practically non-alcoholic special wobbly party beer bomb	1	EPIC	Effect: "Hood Ridin'", Effect Duration: 30, Last Available: "2018-09"
+9974	delicious fancy upside-down jittery sweet party mix	3	awesome	Effect: "Chalk Outline", Effect Duration: 5, Last Available: "2018-09"
 9975	twisted party balloon	1		Last Available: "2018-09"
 9976	cool party pants of incineration	0		Moxie: +5, Hot Spell Damage: +50, Last Available: "2018-09"
 9977	wholesome steel-toed party whip of vim and vigor	0		Damage Reduction: 9, Maximum HP Percent: 60, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	drinkable wobbly TRIO cup of beer	3	good	Last Available: "2018-09"
 9980	adequate skewed party platter for one	3	good	Last Available: "2018-09"
-9981	powdered pulsating yellow narrow Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9981	powdered narrow yellow pulsating Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	skewed wholesome party crasher of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	skewed wholesome party crasher of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	olive Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	upside-down latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	upside-down latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	pulsating &quot;I Voted!&quot; sticker of incineration	0		Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-11"
@@ -9874,18 +9874,18 @@
 10008	family-friendly personal trainer's Sinatra's mutant legs	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Sleaze Resistance: +1, Last Available: "2018-11"
 10009	purple mirror tumbling Oprah's wholesome personal trainer's mutant crown	0		Experience Percent (Muscle): +10, Maximum HP Percent: +10, Maximum MP Percent: +50, Last Available: "2018-11"
 10010	adequate ghostly ectoplasm	4	good	Last Available: "2018-11"
-10011	bite-sized stale teal	1	decent	Last Available: "2018-11"
+10011	stale bite-sized teal	1	decent	Last Available: "2018-11"
 10012	bad bottle of vodka	4	decent	Last Available: "2018-11"
 10013	thick toothsome pizza	5	awesome	Last Available: "2018-11"
 10014	bad martini	3	decent	Last Available: "2018-11"
 10015	stale cherry pie	4	decent	Last Available: "2018-11"
 10016	watered-down acceptable teal eggnog	2	good	Last Available: "2018-11"
 10017	narrow glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	thick flavorless jittery Hell ramen	5	decent	Last Available: "2018-11"
+10018	flavorless thick jittery Hell ramen	5	decent	Last Available: "2018-11"
 10019	weak hand-crafted gimlet	2	super ultra EPIC	Last Available: "2018-11"
-10020	artisanal watered-down twice-haunted screwdriver	2	EPIC	Last Available: "2018-11"
+10020	watered-down artisanal twice-haunted screwdriver	2	EPIC	Last Available: "2018-11"
 10021	half-sized yummy candy cane	2	awesome	Last Available: "2018-12"
-10022	drinkable irresponsibly strong shaking runny fermented egg	6	good	Last Available: "2018-12"
+10022	irresponsibly strong drinkable shaking runny fermented egg	6	good	Last Available: "2018-12"
 10023	decent snack-sized oldcake	2	good	Last Available: "2018-12"
 10024	bland traditional Crimbo cookie	4	decent	Last Available: "2023-06"
 10025	lightning-fast plastic wild beaver	0		Initiative: +40, Last Available: "2018-12"
@@ -9913,7 +9913,7 @@
 10047	Sherlock's vibrating Canadian lantern	0		Maximum MP Percent: +10, Item Drop: +25, Last Available: "2018-12"
 10048	savvy muskox-skin cap	0		Mysticality Percent: +20, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	flavorless jumbo glass of raw eggs	5	decent	Last Available: "2018-12"
+10050	jumbo flavorless glass of raw eggs	5	decent	Last Available: "2018-12"
 10051	artisanal narrow punch-drunk punch	3	EPIC	Last Available: "2018-12"
 10052	mixed huge gray body spradium	1		Last Available: "2018-12"
 10053	up-at-dawn bauxite beret	0		Adventures: +5, Last Available: "2018-12"
@@ -9929,9 +9929,9 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	blinking jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	weak perfectly mixed beer	2	super ultra EPIC	Last Available: "2018-12"
+10066	perfectly mixed weak beer	2	super ultra EPIC	Last Available: "2018-12"
 10067	adequate huge yule gruel	4	good	Last Available: "2018-12"
-10068	fancy perfectly mixed weak hot watered rum	2	EPIC	Effect: "Broken Fast", Effect Duration: 35, Last Available: "2018-12"
+10068	fancy weak perfectly mixed hot watered rum	2	EPIC	Effect: "Broken Fast", Effect Duration: 35, Last Available: "2018-12"
 10069	artisanal strong blurry bottle of Crimbognac	5	EPIC	Last Available: "2018-12"
 10070	moldy Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
 10071	dried squat Crimbeau de toilette	1		Effect: "Third Based", Effect Duration: 50, Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	shaking knitted marble mariachi hat of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +3, Last Available: "2019-12"
 10096	vaporized blue marble molecules	1		Last Available: "2019-12"
 10097	moist Mallomarbles	0		Effect: "Adapt to Change Eventually", Effect Duration: 32
-10098	nasty shellacked punching bag	0		Damage Reduction: 7, Stench Damage: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	careful groovy pith helmet	0		Moxie Percent: +10, Monster Level: -10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	stanky Socratic poncho	0		Experience (Mysticality): +1, Stench Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	blue Usain Bolt's pendant of chilblains	0		Cold Damage: +25, Initiative: +80, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	mirror ribald thinker's palazzos	0		Mysticality: +10, Sleaze Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	red mansplainer's healthy pseudoaccordion	0		Maximum HP Percent: +20, Monster Level: +15, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	nasty shellacked punching bag	0		Damage Reduction: 7, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	careful groovy pith helmet	0		Moxie Percent: +10, Monster Level: -10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	stanky Socratic poncho	0		Experience (Mysticality): +1, Stench Spell Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	blue Usain Bolt's pendant of chilblains	0		Cold Damage: +25, Initiative: +80, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	mirror ribald thinker's palazzos	0		Mysticality: +10, Sleaze Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	red mansplainer's healthy pseudoaccordion	0		Maximum HP Percent: +20, Monster Level: +15, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	diluted upside-down pieces	1		Effect: "The Wisdom... of the Future", Effect Duration: 20, Last Available: "2020-12"
 10105	energized yellow Para-Pop	0		Effect: "Berry Critical", Effect Duration: 69
-10106	scandalous deadly terra cotta truss	0		Weapon Damage: +5, Sleaze Damage: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	wobbly nippy quilted terra cotta trousers	0		Damage Absorption: +40, Cold Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	weightlifter's terra cotta tongs of incineration	0		Muscle: +15, Hot Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	flame-wreathed Sinatra's terra cotta train	0		Experience (Moxie): +5, Hot Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	ribald nippy terra cotta tie tack	0		Cold Damage: +10, Sleaze Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	smelly Herculean terra cotta tambourine	0		Experience (Muscle): +1, Stench Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	scandalous deadly terra cotta truss	0		Weapon Damage: +5, Sleaze Damage: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	wobbly nippy quilted terra cotta trousers	0		Damage Absorption: +40, Cold Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	weightlifter's terra cotta tongs of incineration	0		Muscle: +15, Hot Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	flame-wreathed Sinatra's terra cotta train	0		Experience (Moxie): +5, Hot Spell Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	ribald nippy terra cotta tie tack	0		Cold Damage: +10, Sleaze Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	smelly Herculean terra cotta tambourine	0		Experience (Muscle): +1, Stench Spell Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	boiled pulsating terra cotta tidbits	1		Effect: "Busy Bein' Delicious", Effect Duration: 40, Last Available: "2020-12"
 10113	adjusted terra panna cotta	0		Effect: "Smelly Pants", Effect Duration: 53
 10114	velour voulge of the brazier of the early riser	0		Hot Spell Damage: +25, Adventures: +7, Last Available: "2021-12"
@@ -9983,7 +9983,7 @@
 10117	arcane researcher's velour viscometer of wisdom	0		Mysticality: +15, Experience Percent (Mysticality): +10, Single Equip, Last Available: "2021-12"
 10118	wobbly Samson's velour valise of mayonnaise	0		Experience (Muscle): +5, Sleaze Spell Damage: +50, Last Available: "2021-12"
 10119	fortified wizardly velour vaqueros	0		Mysticality: +25, Damage Absorption: +60, Last Available: "2021-12"
-10120	boiled spinning blue narrow velour veneer	1		Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2021-12"
+10120	boiled narrow blue spinning velour veneer	1		Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2021-12"
 10121	dry chilled purple upside-down Velougats&trade;	0		Effect: "Dreadful Heat", Effect Duration: 14
 10122	red fireproof manspreader's glass suspenders	0		Monster Level: +10, Hot Resistance: +3, Single Equip, Last Available: "2021-12"
 10123	careful Van der Graaf glass shield	0		Monster Level: -10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 7, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	Usain Bolt's cool glass serape	0		Moxie: +5, Initiative: +80, Last Available: "2021-12"
 10128	boiled huge glass shards	1		Last Available: "2021-12"
 10129	colloidal anodized hard candy	0		Effect: "Browbeaten", Effect Duration: 69
-10130	upside-down beefy loofah lumberjack's hat of the wise owl	0		Muscle: +10, Mysticality: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	experienced loofah lei of James Dean	0		Experience: +2, Experience (Moxie): +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	purple manspreader's Van der Graaf loofah lederhosen	0		Monster Level: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	electrified deadly loofah ladle	0		Weapon Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	wool Rosewater's loofah legwarmers	0		Mysticality Percent: +30, Cold Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	green blurry crafty Fonzie's loofah lavalier	0		Experience (Moxie): +1, Maximum MP: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	upside-down beefy loofah lumberjack's hat of the wise owl	0		Muscle: +10, Mysticality: +20, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	experienced loofah lei of James Dean	0		Experience: +2, Experience (Moxie): +3, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	purple manspreader's Van der Graaf loofah lederhosen	0		Monster Level: +10, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	electrified deadly loofah ladle	0		Weapon Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	wool Rosewater's loofah legwarmers	0		Mysticality Percent: +30, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	green blurry crafty Fonzie's loofah lavalier	0		Experience (Moxie): +1, Maximum MP: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	twisted loofah lumps	1		Last Available: "2022-12"
 10137	concentrated oxidized purple chocolate-covered loofah	0		Effect: "Human-Demon Hybrid", Effect Duration: 39
-10138	wholesome occult flagstone flag	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	red upside-down Da Vinci's Herculean flagstone flail	0		Experience (Muscle): +1, Experience (Mysticality): +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	foul-smelling flagstone flip-flops of the glutton	0		Stench Damage: +10, Food Drop: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	twirling yellow thinker's flagstone fez of the cheetah	0		Mysticality: +10, Initiative: +60, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	mirror executive weightlifter's flagstone fleece	0		Muscle: +15, Meat Drop: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	double-paned smooth flagstone fringe	0		Moxie: +15, Cold Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	wholesome occult flagstone flag	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	red upside-down Da Vinci's Herculean flagstone flail	0		Experience (Muscle): +1, Experience (Mysticality): +5, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	foul-smelling flagstone flip-flops of the glutton	0		Stench Damage: +10, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	twirling yellow thinker's flagstone fez of the cheetah	0		Mysticality: +10, Initiative: +60, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	mirror executive weightlifter's flagstone fleece	0		Muscle: +15, Meat Drop: +40, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	double-paned smooth flagstone fringe	0		Moxie: +15, Cold Resistance: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	altered flagstone flagments	1		Last Available: "2022-12"
 10145	tarnished Flag by the Foot&trade;	0		Effect: "Ice Packed", Effect Duration: 45
 10146	spinning elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10026,21 +10026,21 @@
 10160	altered alkaline licorice snake	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 69
 10161	quadruple-warmed deionized virgin jello shot	0		Effect: "Carrrsmic", Effect Duration: 16
 10162	modified pressed mutated candy lump	0		Effect: "Turtle Titters", Effect Duration: 16
-10163	modified wet narrow blinking government-issued candy	0		Effect: "Cool, Catlike", Effect Duration: 43
+10163	modified wet blinking narrow government-issued candy	0		Effect: "Cool, Catlike", Effect Duration: 43
 10164	non-aerosolized double-unsweetened Pneumo bar	0		Effect: "[800]Chocolate Reign", Effect Duration: 38
 10165	tumbling mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	smooth Lil' Doctor&trade; bag of bravery	0		Moxie: +15, Spooky Resistance: +5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	smooth Lil' Doctor&trade; bag of bravery	0		Moxie: +15, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	spoiled bloodstick	4	crappy	
 10170	artisanal bottle of Sanguiovese	4	EPIC	
-10171	diet rotten ghostly actual blood sausage	1	crappy	
+10171	rotten diet ghostly actual blood sausage	1	crappy	
 10172	artisanal spinning mulled blood	3	EPIC	
 10173	normal maroon blood snowcone	4	good	
 10174	artisanal Red Russian	3	EPIC	
-10175	normal huge skewed blood roll-up	4	good	
-10176	practically non-alcoholic mediocre shaking bottle of blood	1	decent	
+10175	normal skewed huge blood roll-up	4	good	
+10176	mediocre practically non-alcoholic shaking bottle of blood	1	decent	
 10177	toothsome blood-soaked sponge cake	4	awesome	
-10178	watered-down tolerable vampagne	2	good	
+10178	tolerable watered-down vampagne	2	good	
 10179	rotten miniature narrow plain snowcone	2	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	wobbly money bag	0		
@@ -10074,7 +10074,7 @@
 10209	windicle	0		Last Available: "2019-04"
 10210	reassuring weightlifter's pirate radio ring	0		Muscle: +15, Spooky Resistance: +1, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	special jumbo adequate purple pineapple slab	5	good	Effect: "Oiled Skin", Effect Duration: 20, Last Available: "2019-04"
+10212	jumbo special adequate purple pineapple slab	5	good	Effect: "Oiled Skin", Effect Duration: 20, Last Available: "2019-04"
 10213	bland maroon huge hibiscus petal	3	decent	Last Available: "2019-04"
 10214	dry anodized pulsating huge mint leaf	0		Effect: "Blackberry Politeness", Effect Duration: 61, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
@@ -10097,14 +10097,14 @@
 10232	spirit-forward bad Island Landslide	5	decent	Last Available: "2019-04"
 10233	drinkable Island Thunderstorm	3	good	Last Available: "2019-04"
 10234	smooth Island Hurricane	3	awesome	Last Available: "2019-04"
-10235	drinkable fortified Skull Punch	5	good	Last Available: "2019-04"
+10235	fortified drinkable Skull Punch	5	good	Last Available: "2019-04"
 10236	mediocre bouncing Electric Punch	3	decent	Last Available: "2019-04"
 10237	mediocre Smuggler's Punch	3	decent	Last Available: "2019-04"
 10238	bad Scorpion Bowl	4	decent	Last Available: "2019-04"
-10239	practically non-alcoholic smooth fancy Turtle Bowl	1	awesome	Effect: "'Roids of the Rhinoceros", Effect Duration: 15, Last Available: "2019-04"
+10239	smooth fancy practically non-alcoholic Turtle Bowl	1	awesome	Effect: "'Roids of the Rhinoceros", Effect Duration: 15, Last Available: "2019-04"
 10240	lousy skewed Cobra Bowl	3	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	miser's lion tamer's vampyric cloake of the brazier of temperance of the cheetah	0		Experience (familiar): +2, Hot Spell Damage: +25, Sleaze Resistance: +5, Meat Drop: +10, Initiative: +60, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	miser's lion tamer's vampyric cloake of the brazier of temperance of the cheetah	0		Experience (familiar): +2, Hot Spell Damage: +25, Sleaze Resistance: +5, Meat Drop: +10, Initiative: +60, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	flattened one piece of bubble gum	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 67
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	twirling upside-down Da Vinci's savvy Fourth of May Cosplay Saber of extreme caution	0		Mysticality Percent: +20, Experience (Mysticality): +5, Monster Level: -25, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	twirling upside-down Da Vinci's savvy Fourth of May Cosplay Saber of extreme caution	0		Mysticality Percent: +20, Experience (Mysticality): +5, Monster Level: -25, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	cyan Jeselnik's MacGyver's supercharged medical-grade veiny quilted personal trainer's sage wizardly hewn moon-rune spoon of James Dean of terror	0		Mysticality: +25, Mysticality Percent: +10, Experience (Moxie): +3, Experience Percent (Muscle): +10, Damage Absorption: +40, Maximum HP: +10, Maximum MP Percent: +30, Maximum MP: +100, Spooky Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	cyan Jeselnik's MacGyver's supercharged medical-grade veiny quilted personal trainer's sage wizardly hewn moon-rune spoon of James Dean of terror	0		Mysticality: +25, Mysticality Percent: +10, Experience (Moxie): +3, Experience Percent (Muscle): +10, Damage Absorption: +40, Maximum HP: +10, Maximum MP Percent: +30, Maximum MP: +100, Spooky Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	wobbly Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	manspreader's Beach Comb of the cougar of Leguizamo	0		Moxie: +20, Monster Level: 30, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	manspreader's Beach Comb of the cougar of Leguizamo	0		Moxie: +20, Monster Level: 30, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	wobbly grain of sand	0		Last Available: "2019-07"
 10260	blurry small pile of sand	0		Last Available: "2019-07"
 10261	huge pile of sand	0		Last Available: "2019-07"
@@ -10167,8 +10167,8 @@
 10302	green Usain Bolt's avaricious frosty chaotic whittled walking stick	0		Spell Critical Percent: +10, Cold Spell Damage: +10, Meat Drop: +30, Initiative: +80, Last Available: "2019-08"
 10303	normal spinning campfire hot dog	3	good	Last Available: "2019-08"
 10304	spoiled tiny campfire baked potato	1	crappy	Last Available: "2019-08"
-10305	low-calorie normal green shaking campfire s'more	1	good	Last Available: "2019-08"
-10306	stale huge campfire beans	6	decent	Last Available: "2019-08"
+10305	normal low-calorie shaking green campfire s'more	1	good	Last Available: "2019-08"
+10306	huge stale campfire beans	6	decent	Last Available: "2019-08"
 10307	moldy campfire stew	3	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	crappy	Last Available: "2019-08"
 10309	quadruple-corrupted diffused olive leftover chocolate bar	0		Effect: "Rotten Memories", Effect Duration: 27
@@ -10180,7 +10180,7 @@
 10315	signal receiver	0		
 10316	space shield	0		Damage Reduction: 9
 10317	signal jammer	0		Single Equip
-10318	blurry shaking low-pressure oxygen tank	0		Single Equip
+10318	shaking blurry low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	immense moldy space chowder	8	crappy	
 10321	extra-dry aged space wine	5	awesome	
@@ -10194,7 +10194,7 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	rotten special bu&ntilde;uelos Jaliscos	4	crappy	Effect: "Ghost Finger", Effect Duration: 15, Last Available: "2019-12"
-10338	moldy big spinning upside-down flan del mar	5	crappy	Last Available: "2019-12"
+10338	moldy big upside-down spinning flan del mar	5	crappy	Last Available: "2019-12"
 10339	moldy big Baja sopapilla	5	crappy	Last Available: "2019-12"
 10340	mirror jittery razor-sharp plastic Mer-kin baker	0		Weapon Damage Percent: +25, Last Available: "2019-12"
 10341	smooth plastic sea elf	0		Moxie: +15, Last Available: "2019-12"
@@ -10203,9 +10203,9 @@
 10344	horrifying plastic Dolph Bossin	0		Spooky Damage: +25, Last Available: "2019-12"
 10345	spinning red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	adequate blinking mana-coated yams	3	good	Last Available: "2019-11"
-10347	decent blurry olive mana-basted tofurkey leg	3	good	Last Available: "2019-11"
-10348	special bland mana-fortified cranberry sauce	3	decent	Effect: "Cancer Rising", Effect Duration: 35, Last Available: "2019-11"
-10349	thick spoiled huge mana-stuffed herbal stuffing	5	crappy	Last Available: "2019-11"
+10347	decent olive blurry mana-basted tofurkey leg	3	good	Last Available: "2019-11"
+10348	bland special mana-fortified cranberry sauce	3	decent	Effect: "Cancer Rising", Effect Duration: 35, Last Available: "2019-11"
+10349	spoiled thick huge mana-stuffed herbal stuffing	5	crappy	Last Available: "2019-11"
 10350	blue human musk	0		Last Available: "2019-12"
 10351	super-warmed triple-Vulcanized patch of extra-warm fur	0		Effect: "Medieval Mage Mayhem", Effect Duration: 38, Last Available: "2019-12"
 10352	altered blurry industrial lubricant	1		Last Available: "2019-12"
@@ -10213,7 +10213,7 @@
 10354	boiled vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	vaporized blinking a bug's lymph	1		Last Available: "2019-12"
 10356	extra-frozen energized tumbling organic potpourri	0		Effect: "World's Shortest Giant", Effect Duration: 23, Last Available: "2019-12"
-10357	drinkable irresponsibly strong boot flask	10	good	Last Available: "2019-12"
+10357	irresponsibly strong drinkable boot flask	10	good	Last Available: "2019-12"
 10358	enhanced improved blinking infernal snowball	0		Effect: "Took Eleven", Effect Duration: 38, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	boiled ghostly fish sauce	1		Last Available: "2019-12"
@@ -10256,7 +10256,7 @@
 10397	normal skewed bowl of mernudo	3	good	Last Available: "2019-12"
 10398	high-proof acceptable twirling fishelada	6	good	Last Available: "2019-12"
 10399	yummy lime green ojo de pez burrito	4	awesome	Last Available: "2019-12"
-10400	skewed narrow waterlogged wood	0		Last Available: "2019-12"
+10400	narrow skewed waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
@@ -10288,11 +10288,11 @@
 10429	magnetized flattened handful of mixed nuts	0		Effect: "Stinky Hands", Effect Duration: 50, Last Available: "2019-12"
 10430	twirling nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	narrow greedy Retrospecs of the wise owl of the cougar	0		Mysticality: +20, Moxie: +20, Meat Drop: +20, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
-10433	purple pulsating unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
+10432	narrow greedy Retrospecs of the wise owl of the cougar	0		Mysticality: +20, Moxie: +20, Meat Drop: +20, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10433	pulsating purple unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	spinning Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	blurry mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	mirror lightning-fast scandalous frightening deadly Powerful Glove of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40, Spooky Damage: +5, Sleaze Damage: +5, Initiative: +40, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	mirror lightning-fast scandalous frightening deadly Powerful Glove of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40, Spooky Damage: +5, Sleaze Damage: +5, Initiative: +40, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	double-paned shellacked hardened Drip harness	0		Damage Reduction: 20, Cold Resistance: +5
@@ -10309,7 +10309,7 @@
 10452	wobbly drippy shield	0		
 10453	The Fingernail of the Thing in the Basement	0		
 10454	twirling coin	0		
-10455	bouncing mirror mushroom	0		
+10455	mirror bouncing mushroom	0		
 10456	green deluxe mushroom	0		
 10457	super deluxe mushroom	0		
 10458	double-cold-filtered green narrow fizzy soda	0		Effect: "No Worries", Effect Duration: 58
@@ -10325,7 +10325,7 @@
 10468	spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
 10470	olive Thwaitgold buzzy beetle statuette	0		
-10471	spinning purple Plumber's Union Handbook	0		
+10471	purple spinning Plumber's Union Handbook	0		
 10472	skewed bony back shell of the brute	0		Muscle Percent: +30
 10473	shaking frosty button	0		Single Equip
 10474	frozen magnetized warmed blooper ink	0		Effect: "Analog Drunk", Effect Duration: 14
@@ -10334,7 +10334,7 @@
 10477	rubber doll body	0		
 10478	huge plastic doll arms	0		
 10479	plastic doll legs	0		
-10480	blue pulsating rubber baby doll	0		
+10480	pulsating blue rubber baby doll	0		
 10481	upside-down Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
 10483	red free-range mushroom	0		Last Available: "2020-03"
@@ -10343,7 +10343,7 @@
 10486	green free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	jittery colossal free-range mushroom	0		Last Available: "2020-03"
-10489	normal massive mushroom filet	7	good	Last Available: "2020-03"
+10489	massive normal mushroom filet	7	good	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	distilled mushroom tea	1		Effect: "Lemony Goodness", Effect Duration: 10, Last Available: "2020-03"
 10492	smooth watered-down mushroom whiskey	2	awesome	Last Available: "2020-03"
@@ -10394,11 +10394,11 @@
 10538	mirror bouncing Guzzlr pants	0		Last Available: "2020-05"
 10539	shellacked Guzzlr souvenir stein	0		Damage Reduction: 7, Last Available: "2020-05"
 10540	ghostly Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	enchanted hand-crafted weak pulsating Ghiaccio Colada	2	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 50, Last Available: "2020-05"
+10541	hand-crafted enchanted weak pulsating Ghiaccio Colada	2	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 50, Last Available: "2020-05"
 10542	watered-down drinkable Sourfinger	2	good	Last Available: "2020-05"
 10543	tolerable Nog-on-the-Cob	3	good	Last Available: "2020-05"
 10544	perfectly mixed mirror Steamboat	3	EPIC	Last Available: "2020-05"
-10545	mediocre spirit-forward maroon Buttery Boy	5	decent	Last Available: "2020-05"
+10545	spirit-forward mediocre maroon Buttery Boy	5	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	clown car key of the businessman of Flo-Jo	0		Meat Drop: +50, Initiative: +100, Last Available: "2020-08"
 10548	Sherlock's batting cage key of incineration	0		Hot Spell Damage: +50, Item Drop: 30, Last Available: "2020-08"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	birch battery of doom of the sweet-tooth	0		Spooky Spell Damage: +50, Candy Drop: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	Usain Bolt's padded strapping ebony epee	0		Muscle: +5, Damage Absorption: +20, Initiative: +80, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	Tesla educational weeping willow wand	0		Experience: +1, Item Drop: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	Usain Bolt's sizzling educational beechwood blowgun	0		Experience: +1, Hot Damage: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	Usain Bolt's padded strapping ebony epee	0		Muscle: +5, Damage Absorption: +20, Initiative: +80, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	Tesla educational weeping willow wand	0		Experience: +1, Item Drop: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	Usain Bolt's sizzling educational beechwood blowgun	0		Experience: +1, Hot Damage: +10, Initiative: +80, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	upside-down lion tamer's educational maple magnet of Flo-Jo	0		Experience: +1, Experience (familiar): +2, Initiative: +100, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	blurry clever grievous hemlock helm of the sewer	0		Weapon Damage Percent: +50, Maximum MP: +20, Stench Damage: +25, Last Available: "2020-08"
@@ -10468,7 +10468,7 @@
 10612	Yeg's Motel shower cap of courage of the boozehound	0		Spooky Resistance: +3, Booze Drop: +100, Lasts Until Rollover, Last Available: "2020-09"
 10613	wool Yeg's Motel bathrobe of Flo-Jo	0		Cold Resistance: +1, Initiative: +100, Lasts Until Rollover, Last Available: "2020-09"
 10614	ghostly ghostly frosty smooth Yeg's Motel slippers	0		Moxie: +15, Cold Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
-10615	jittery bouncing Yeg's Motel stationery	0		Last Available: "2020-09"
+10615	bouncing jittery Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	wobbly frost-rimed desk bell	0		Last Available: "2020-09"
@@ -10477,7 +10477,7 @@
 10621	mirror greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
-10624	pulsating red onyx queen	0		Last Available: "2020-09"
+10624	red pulsating onyx queen	0		Last Available: "2020-09"
 10625	pulsating onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
@@ -10491,11 +10491,11 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	upside-down electrified Newton's smartaleck's Cargo Cultist Shorts of the sweet-tooth	0		Moxie Percent: +30, Experience (Mysticality): +3, Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-09"
 10637	wobbly complicated device	0		Last Available: "2020-09"
-10638	watered-down lousy flask of moonshine	2	decent	Last Available: "2020-09"
+10638	lousy watered-down flask of moonshine	2	decent	Last Available: "2020-09"
 10639	mansplainer's dance instructor's sea-worn candlestick of Calamity Jane	0		Experience Percent (Moxie): +10, Critical Hit Percent: +15, Monster Level: +15, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	polarized quadruple-irradiated null-day exploit	0		Effect: "Human-Constellation Hybrid", Effect Duration: 11, Last Available: "2025-12"
-10642	gray jittery flame orb	0		Last Available: "2020-09"
+10642	jittery gray flame orb	0		Last Available: "2020-09"
 10643	spoiled massive chocolate chip muffin	7	crappy	
 10644	bouncing Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
@@ -10506,8 +10506,8 @@
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	ghostly greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
-10653	anodized twirling ghostly bouncing fortifying hot cocoa	0		Effect: "Wet Willied", Effect Duration: 19, Last Available: "2020-12"
-10654	electrified fuchsia ghostly boiling hot cocoa	0		Effect: "Abyssal Blood", Effect Duration: 14, Last Available: "2020-12"
+10653	anodized bouncing ghostly twirling fortifying hot cocoa	0		Effect: "Wet Willied", Effect Duration: 19, Last Available: "2020-12"
+10654	electrified ghostly fuchsia boiling hot cocoa	0		Effect: "Abyssal Blood", Effect Duration: 14, Last Available: "2020-12"
 10655	vacuum-sealed vacuum-sealed skewed cool hot cocoa	0		Effect: "What's That Smell?", Effect Duration: 55, Last Available: "2020-12"
 10656	extra-polymerized overly-fancy hot cocoa	0		Effect: "Fratty Flavor", Effect Duration: 57, Last Available: "2020-12"
 10657	dry vacuum-sealed hot cocoa au beurre	0		Effect: "Bubblin' Rage", Effect Duration: 25, Last Available: "2020-12"
@@ -10573,13 +10573,13 @@
 10717	pulsating fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	huge nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	upside-down goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	delicious red wobbly barrel-aged eggnog	4	awesome	Last Available: "2020-12"
+10720	delicious wobbly red barrel-aged eggnog	4	awesome	Last Available: "2020-12"
 10721	bland hand-crafted candy cane	4	decent	Last Available: "2020-12"
 10722	normal drive-thru burger	3	good	Last Available: "2020-12"
-10723	fancy mediocre Boulevardier cocktail	3	decent	Effect: "Marco Polarity", Effect Duration: 15, Last Available: "2020-12"
+10723	mediocre fancy Boulevardier cocktail	3	decent	Effect: "Marco Polarity", Effect Duration: 15, Last Available: "2020-12"
 10724	boiled corrupted Hotwire&trade; brand candy rope	0		Effect: "Sharp Weapon", Effect Duration: 59, Last Available: "2020-12"
 10725	flavorless bowl full of jelly	3	decent	Last Available: "2020-12"
-10726	watered-down tolerable tumbling Eye and a Twist	2	good	Last Available: "2020-12"
+10726	tolerable watered-down tumbling Eye and a Twist	2	good	Last Available: "2020-12"
 10727	pressed diffused narrow Chubby and Plump bar	0		Effect: "Hippy Flavor", Effect Duration: 29, Last Available: "2020-12"
 10728	green twirling digibritches	0		Last Available: "2025-12"
 10729	ghostly packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10588,7 +10588,7 @@
 10732	fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
 10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
-10735	spinning wobbly robo-battery	0		
+10735	wobbly spinning robo-battery	0		
 10736	squat Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	marshmallow	0		
 10747	perfectly mixed marshmallow bomb	3	EPIC	Last Available: "2021-03"
 10748	bouncing packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	denatured magnetized short beer	0		Effect: "All Glory To the Toad", Effect Duration: 53, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	colloidal short	0		Effect: "Woad Warrior", Effect Duration: 67, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	blue quantum of familiar	0		
-10759	scorching rosy-cheeked familiar scrapbook	0		Maximum HP Percent: +30, Hot Damage: +25, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	scorching rosy-cheeked familiar scrapbook	0		Maximum HP Percent: +30, Hot Damage: +25, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	green packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	arcane researcher's Sinatra's supercool fedora-mounted fountain	0		Moxie Percent: +20, Experience (Moxie): +5, Experience Percent (Mysticality): +10, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	wobbly pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	zippy gravedigger's sinister groovy slick industrial fire extinguisher of the ox	0		Muscle: +20, Moxie: +10, Moxie Percent: +10, Spell Damage: +10, Spooky Damage: +10, Initiative: +20, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	zippy gravedigger's sinister groovy slick industrial fire extinguisher of the ox	0		Muscle: +20, Moxie: +10, Moxie Percent: +10, Spell Damage: +10, Spooky Damage: +10, Initiative: +20, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	blurry The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	upside-down The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10658,10 +10658,10 @@
 10802	purple French-Transylvanian Dictionary	0		Familiar Weight: +5
 10803	tumbling packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	zippy sharpshooter's Daylight Shavings Helmet of the detective	0		Critical Hit Percent: +10, Item Drop: +20, Initiative: +20, Last Available: "2021-11"
-10805	twirling olive eggwater	1	good	Last Available: "2021-12"
+10805	olive twirling eggwater	1	good	Last Available: "2021-12"
 10806	huge yummy bread man	7	awesome	Last Available: "2021-12"
 10807	bland plain candy cane	3	decent	Last Available: "2021-12"
-10808	super-sized yummy flour cookie	5	awesome	Last Available: "2021-12"
+10808	yummy super-sized flour cookie	5	awesome	Last Available: "2021-12"
 10809	electrified plastic food lab	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2021-12"
 10810	Sherlock's plastic nog lab	0		Item Drop: +25, Single Equip, Last Available: "2021-12"
 10811	red auspicious plastic chem lab	0		Item Drop: +10, Single Equip, Last Available: "2021-12"
@@ -10672,7 +10672,7 @@
 10816	stanky shellacked ice crown of terror	0		Damage Reduction: 7, Stench Spell Damage: +25, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-12"
 10817	spinning knitted Samson's thinker's jeans	0		Mysticality: +10, Experience (Muscle): +5, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2021-12"
 10818	extremely unsafe weightlifter's ice wrap of the glutton	0		Muscle: +15, Weapon Damage Percent: +100, Food Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	super-sized delicious tofu pop	5	awesome	Last Available: "2021-12"
+10819	delicious super-sized tofu pop	5	awesome	Last Available: "2021-12"
 10820	rotten huge bowl of prescription candy	3	crappy	Last Available: "2021-12"
 10821	special toothsome fishcake	4	awesome	Effect: "Feet of Grapefruit", Effect Duration: 50, Last Available: "2021-12"
 10822	yummy low-calorie ghostly bone broth	1	awesome	Last Available: "2021-12"
@@ -10684,14 +10684,14 @@
 10828	vaporized teal Homebodyl&trade;	1		Last Available: "2021-12"
 10829	distilled twirling wobbly Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	boiled Breathitin&trade;	1		Last Available: "2021-12"
-10831	diluted gray huge Fleshazole&trade;	1		Last Available: "2021-12"
+10831	diluted huge gray Fleshazole&trade;	1		Last Available: "2021-12"
 10832	pressed flattened anti-burn cream	0		Effect: "Spooky Hands", Effect Duration: 29, Last Available: "2021-12"
 10833	ionized flattened olive anti-freeze cream	0		Effect: "Radiant Personality", Effect Duration: 51, Last Available: "2021-12"
 10834	anodized super-pressed anti-goosebump cream	0		Effect: "Earthen Fist", Effect Duration: 16, Last Available: "2021-12"
 10835	double-flattened anti-odor cream	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 55, Last Available: "2021-12"
 10836	double-adjusted anti-creep cream	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 42, Last Available: "2021-12"
 10837	altered diffused moist mirror anti-pain cream	0		Effect: "Heart of Pink", Effect Duration: 57, Last Available: "2021-12"
-10838	distilled bad Doc's Special Reserve Wine	5	decent	Last Available: "2021-12"
+10838	bad distilled Doc's Special Reserve Wine	5	decent	Last Available: "2021-12"
 10839	bland bread pie	3	decent	Last Available: "2021-12"
 10840	mediocre pulsating clear Russian	3	decent	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
@@ -10727,9 +10727,9 @@
 10871	cloning kit	0		Last Available: "2021-12"
 10872	huge pants of the cheetah	0		Initiative: +60, Last Available: "2021-12"
 10873	scorching Annie Oakley's fortified can of mixed everything	0		Damage Absorption: +60, Critical Hit Percent: +20, Hot Damage: +25, Last Available: "2021-12"
-10874	narrow spinning Site Alpha ID badge	0		Familiar Weight: +5
+10874	spinning narrow Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	snack-sized enchanted yummy bouncing meatball	2	awesome	Effect: "Super Speed", Effect Duration: 30, Last Available: "2021-12"
+10876	enchanted yummy snack-sized bouncing meatball	2	awesome	Effect: "Super Speed", Effect Duration: 30, Last Available: "2021-12"
 10877	narrow cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10762,7 +10762,7 @@
 10906	shaking supercharged wicked thermal blanket	0		Spell Damage: +5, Maximum MP Percent: +30, Item Drop: +5, Lasts Until Rollover, Last Available: "2022-05"
 10907	jittery nasty atlas of local maps	0		Stench Damage: +5, Lasts Until Rollover, Last Available: "2022-05"
 10908	extra-nitrogenated blinking spare battery	0		Effect: "Bonelording", Effect Duration: 16, Last Available: "2022-05"
-10909	huge yellow space blanket	0		Last Available: "2022-05"
+10909	yellow huge space blanket	0		Last Available: "2022-05"
 10910	quantum chilled red tumbling single-use dust mask	0		Effect: "Alchemical, Brother", Effect Duration: 69, Last Available: "2022-05"
 10911	unsweetened gaffer's tape	0		Effect: "Dexteri Tea", Effect Duration: 48, Last Available: "2022-05"
 10912	rotten pulsating 20-lb can of rice and beans	4	crappy	Last Available: "2022-05"
@@ -10782,12 +10782,12 @@
 10926	double-ionized extra-Vulcanized narrow trampled ticket stub	0		Effect: "Fastbreaker", Effect Duration: 47, Last Available: "2022-06"
 10927	vacuum-sealed red savings bond	0		Effect: "There Wolf", Effect Duration: 50, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	green designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	green designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	boiled sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
-10934	yellow upside-down dinosaur scale	0		
+10934	upside-down yellow dinosaur scale	0		
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	chilly pterodactyl rifle	0		Cold Damage: +5, Conditional Skill (Equipped): "Snipe Pterodactyl"
@@ -10804,12 +10804,12 @@
 10948	supercharged reflective vest	0		Maximum MP Percent: +30
 10949	therapeutic dinosaur	0		HP Regen Min: 5, HP Regen Max: 7
 10950	cyan Thwaitgold mosquito-in-amber statuette	0		
-10951	pulsating shaking packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	horrifying arcane researcher's Jurassic Parka	0		Experience Percent (Mysticality): +10, Spooky Damage: +25, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10951	shaking pulsating packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
+10952	horrifying arcane researcher's Jurassic Parka	0		Experience Percent (Mysticality): +10, Spooky Damage: +25, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	blurry autumn-aton	0		Last Available: "2022-10"
 10955	nitrogenated maroon autumn leaf	0		Effect: "Moon-Eyed", Effect Duration: 38, Last Available: "2022-10"
-10956	high-proof perfectly mixed AutumnFest ale	6	EPIC	Last Available: "2022-10"
+10956	perfectly mixed high-proof AutumnFest ale	6	EPIC	Last Available: "2022-10"
 10957	flame-retardant nasty grievous autumn sweater-weather sweater	0		Weapon Damage Percent: +50, Stench Damage: +5, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2022-10"
 10958	olive blinking friendly energetic studded autumn debris shield of the brazier	0		Damage Absorption: +80, Maximum MP Percent: +20, Familiar Weight: +3, Hot Spell Damage: +25, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	bland autumn-spice donut	4	decent	Last Available: "2022-10"
@@ -10818,41 +10818,41 @@
 10962	powdered squat autumn breeze	1		Effect: "Oiled Skin", Effect Duration: 5, Last Available: "2022-10"
 10963	energized autumn years wisdom	0		Effect: "Mercenary", Effect Duration: 33, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	drinkable watered-down Oopsie IPA	2	good	Last Available: "2022-10"
+10965	watered-down drinkable Oopsie IPA	2	good	Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	bland ratatouille de Jarlsberg	3	decent	Last Available: "2022-11"
 10971	moldy bouncing gray Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
-10972	rotten enchanted diet roasted vegetable of Jarlsberg	1	crappy	Effect: "You Ate Some Hemp Candy", Effect Duration: 25, Last Available: "2022-11"
+10972	diet rotten enchanted roasted vegetable of Jarlsberg	1	crappy	Effect: "You Ate Some Hemp Candy", Effect Duration: 25, Last Available: "2022-11"
 10973	bland shaking St. Pete's sneaky smoothie	4	decent	Last Available: "2022-11"
 10974	immense stale Pete's wiley whey bar	8	decent	Last Available: "2022-11"
 10975	tasty pulsating Pete's rich ricotta	3	awesome	Last Available: "2022-11"
 10976	mediocre Boris's beer	3	decent	Last Available: "2022-11"
 10977	adequate honey bun of Boris	3	good	Last Available: "2022-11"
-10978	bland low-calorie Boris's bread	1	decent	Last Available: "2022-11"
-10979	spinning Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	green pulsating Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	huge Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	narrow gray Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10978	low-calorie bland Boris's bread	1	decent	Last Available: "2022-11"
+10979	spinning Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	green pulsating Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	huge Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	narrow gray Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	spoiled massive baked veggie ricotta casserole	10	crappy	Last Available: "2022-11"
 10989	spoiled plain calzone	4	crappy	Last Available: "2022-11"
 10990	spoiled roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	moldy tumbling Pizza of Legend	3	crappy	Last Available: "2022-11"
 10992	spoiled Calzone of Legend	4	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	bouncing Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	skewed Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	teal tumbling Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	bouncing Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	skewed Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	tumbling teal Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	blinking cookbookbat book	0		Familiar Weight: +5
-10999	jittery Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	jittery Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	massive stale enchanted Deep Dish of Legend	10	decent	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
@@ -10873,12 +10873,12 @@
 11017	acceptable Mysterious Stranger	3	good	
 11018	tolerable practically non-alcoholic Champagne Shimmy	1	good	
 11019	the Sot's parcel	0		
-11020	olive ghostly vibrating razor-sharp ceramic cestus	0		Weapon Damage Percent: +25, Maximum MP Percent: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	greasy ceramic centurion shield of James Dean of mayonnaise	0		Experience (Moxie): +3, Sleaze Spell Damage: 60, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	maroon rosy-cheeked ceramic celery grater of the glutton	0		Maximum HP Percent: +30, Food Drop: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	blinking Usain Bolt's auspicious Oprah's ceramic celsiturometer	0		Maximum MP Percent: +50, Item Drop: +10, Initiative: +80, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	family-friendly smooth ceramic cerecloth belt of the pedagogue	0		Moxie: +15, Experience: +3, Sleaze Resistance: +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	narrow purple forbidden Newton's groovy ceramic cenobite's robe	0		Moxie Percent: +10, Experience (Mysticality): +3, Spell Damage Percent: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	olive ghostly vibrating razor-sharp ceramic cestus	0		Weapon Damage Percent: +25, Maximum MP Percent: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	greasy ceramic centurion shield of James Dean of mayonnaise	0		Experience (Moxie): +3, Sleaze Spell Damage: 60, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	maroon rosy-cheeked ceramic celery grater of the glutton	0		Maximum HP Percent: +30, Food Drop: +100, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	blinking Usain Bolt's auspicious Oprah's ceramic celsiturometer	0		Maximum MP Percent: +50, Item Drop: +10, Initiative: +80, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	family-friendly smooth ceramic cerecloth belt of the pedagogue	0		Moxie: +15, Experience: +3, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	narrow purple forbidden Newton's groovy ceramic cenobite's robe	0		Moxie Percent: +10, Experience (Mysticality): +3, Spell Damage Percent: +50, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	diluted ceramic scree	1		Last Available: "2023-12"
 11027	triple-flattened tumbling extra-hard jawbreaker	0		Effect: "Icy Composition", Effect Duration: 41
 11028	teal Tesla Herculean chiffon chevrons of terror	0		Experience (Muscle): +1, Spooky Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	Jeselnik's mansplainer's brawny chiffon chaps	0		Muscle Percent: +20, Monster Level: +15, Sleaze Damage: +25, Last Available: "2023-12"
 11034	dehydrated chiffon carbage	1		Last Available: "2023-12"
 11035	pickled skewed chiffon lemon	0		Effect: "Influence of Sphere", Effect Duration: 17
-11036	delicious massive chocomotive	6	awesome	Last Available: "2022-12"
+11036	massive delicious chocomotive	6	awesome	Last Available: "2022-12"
 11037	normal skewed freightcake	3	good	Last Available: "2022-12"
 11038	mediocre fortified cyan cabooze	5	decent	Last Available: "2022-12"
 11039	pulsating plastic caboose	0		Last Available: "2022-12"
@@ -10897,7 +10897,7 @@
 11041	double-paned plastic dining car	0		Cold Resistance: +5, Last Available: "2022-12"
 11042	hale sinister plastic coal car	0		Spell Damage: +10, Maximum HP: +20, Last Available: "2022-12"
 11043	executive plastic locomotive	0		Meat Drop: +40, Last Available: "2022-12"
-11044	wobbly shaking packaged model train set	0		Free Pull, Last Available: "2022-12"
+11044	shaking wobbly packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	model train set	0		Last Available: "2022-12"
 11046	blinking Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
@@ -10909,7 +10909,7 @@
 11053	electrified upside-down Trainbot optics	0		Effect: "Mucilaginous Muscle", Effect Duration: 52
 11054	aerosolized Trainbot servomotors	0		Effect: "Net Tea", Effect Duration: 26
 11055	unsweetened pressed Trainbot linkages	0		Effect: "Items Are Forever", Effect Duration: 32
-11056	shaking mirror ping-pong paddle	0		Single Equip
+11056	mirror shaking ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	studded Trainbot harness	0		Damage Absorption: +80
 11059	green ping-pong table	0		
@@ -10920,7 +10920,7 @@
 11064	curative Newton's shoulder-mounted Trainbot of the sweet-tooth	0		Experience (Mysticality): +3, Candy Drop: +100, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	hand-crafted weak jittery dregs of a Crimbo cocktail	2	EPIC	
+11067	weak hand-crafted jittery dregs of a Crimbo cocktail	2	EPIC	
 11068	lost elf luggage	0		
 11069	olive upside-down Trainbot luggage hook	0		Single Equip
 11070	decent blurry honey-drenched ham slice	4	good	
@@ -10931,7 +10931,7 @@
 11075	table-scraper	0		Single Equip
 11076	bouncing Trainbot slag	0		
 11077	skewed industrially-crushed ice	0		Last Available: "2022-12"
-11078	delicious thick steamed oyster	5	awesome	
+11078	thick delicious steamed oyster	5	awesome	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
@@ -10955,7 +10955,7 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	dried shaking jittery fruity pebble	1		Effect: "meat.enh", Effect Duration: 20, Last Available: "2023-01"
+11102	dried jittery shaking fruity pebble	1		Effect: "meat.enh", Effect Duration: 20, Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	teal milestone	0		Last Available: "2023-01"
 11105	wobbly bolder boulder	0		Last Available: "2023-01"
@@ -10965,7 +10965,7 @@
 11109	stalagmite	0		Last Available: "2023-01"
 11110	jittery chocolate covered ping-pong ball	0		
 11112	adequate blurry pixel bread	3	good	
-11113	special weak lousy pixel whiskey	2	decent	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10
+11113	lousy weak special pixel whiskey	2	decent	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10974,12 +10974,12 @@
 11119	electrified alkaline denatured five-fingered fern resin	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 33, Last Available: "2023-02"
 11120	moldy small super good fruit	2	crappy	Last Available: "2023-02"
 11121	dehydrated squat energized spores	1		Effect: "Locks Like the Raven", Effect Duration: 35, Last Available: "2023-02"
-11122	mansplainer's strapping hot pepper	0		Muscle: +5, Monster Level: +15, Lantern Element: "Hot", Last Available: "2023-02"
+11122	mansplainer's strapping hot pepper	0		Muscle: +5, Monster Level: +15, Last Available: "2023-02", Lantern Element: "Hot"
 11123	denatured warmed blurry out-of-work circus flea	0		Effect: "Ooh, Sweet!", Effect Duration: 20, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	pickled tarnished dry fire ant pheromones	0		Effect: "Grape Expectations", Effect Duration: 14, Last Available: "2023-02"
 11126	liquefied shaking flapper fly	0		Effect: "Gummi-Grin", Effect Duration: 47, Last Available: "2023-02"
-11127	drinkable jittery lime green shot of wasp venom	3	good	Last Available: "2023-02"
+11127	drinkable lime green jittery shot of wasp venom	3	good	Last Available: "2023-02"
 11128	Vulcanized blurry filled mosquito	0		Effect: "Bootyliciousness", Effect Duration: 54, Last Available: "2023-02"
 11129	super-irradiated quantum shim of shame shale	0		Effect: "Preemptive Medicine", Effect Duration: 61, Last Available: "2023-02"
 11130	diffused polarized pebble of proud pyrite	0		Effect: "Dreadful Fear", Effect Duration: 64, Last Available: "2023-02"
@@ -10987,12 +10987,12 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	quantum irradiated angry agate	0		Effect: "Hoity Toity", Effect Duration: 25, Last Available: "2023-02"
 11134	alkaline irradiated maroon lump of loyal latite	0		Effect: "The Strength...  of the Future", Effect Duration: 67, Last Available: "2023-02"
-11135	small rotten yellow shadow sausage	2	crappy	Last Available: "2023-03"
+11135	rotten small yellow shadow sausage	2	crappy	Last Available: "2023-03"
 11136	Rosewater's shadow skin of wisdom	0		Mysticality: +15, Mysticality Percent: +30, Last Available: "2023-03"
 11137	frozen alkaline shadow flame	0		Effect: "Supafly", Effect Duration: 39, Last Available: "2023-03"
 11138	super-sized decent shadow bread	5	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	mediocre practically non-alcoholic blue shadow fluid	1	decent	Last Available: "2023-03"
+11140	practically non-alcoholic mediocre blue shadow fluid	1	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	upside-down shadow sinew	0		Last Available: "2023-03"
@@ -11011,7 +11011,7 @@
 11156	fuchsia spinning deadly uncursed arcane orb	0		Weapon Damage: +5
 11157	narrow occult machete	0		Spell Damage Percent: +25
 11158	wholesome uncursed machete	0		Maximum HP Percent: +10
-11159	blue wobbly blanket	0		
+11159	wobbly blue blanket	0		
 11160	narrow uncursed blanket	0		
 11161	Newton's supercool medallion of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Experience (Mysticality): +3
 11162	uncursed medallion of the boozehound	0		Booze Drop: +100
@@ -11035,16 +11035,16 @@
 11180	fireproof nasty shadow monocle of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +5, Hot Resistance: +3, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	flavorless shadow hot dog	4	decent	
-11183	practically non-alcoholic special tolerable shadow martini	1	good	Effect: "Barbecue Saucy", Effect Duration: 5
+11183	tolerable special practically non-alcoholic shadow martini	1	good	Effect: "Barbecue Saucy", Effect Duration: 5
 11184	twisted squat shadow pill	1		
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	blinking monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	corrupted diffused shadow candy	0		Effect: "Indescribable Flavor", Effect Duration: 38
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	fuchsia replica hand turkey outline	0		
-11192	upside-down shaking replica crimbo elfling	0		
+11192	shaking upside-down replica crimbo elfling	0		
 11193	lime green replica pygmy bugbear shaman	0		
 11194	tumbling dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	mirror replica gravy-covered maypole	0		Item Drop: +25
@@ -11057,12 +11057,12 @@
 11202	auspicious therapeutic replica V for Vivala mask	0		Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	bouncing auspicious Rosewater's replica haiku katana of the brute	0		Muscle Percent: +30, Mysticality Percent: +30, Item Drop: +10, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 11204	twirling pulsating replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
-11205	wobbly purple wobbly replica cotton candy cocoon	0		
+11205	purple wobbly wobbly replica cotton candy cocoon	0		
 11206	lightning-fast smelly resourceful boxer's replica Elvish sunglasses	0		Muscle Percent: +10, Maximum MP: +50, Stench Spell Damage: +10, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
 11208	replica stone sphere	0		
 11209	narrow inspector's thinker's replica Greatest American Pants of Tarzan	0		Mysticality: +10, Experience (Muscle): +3, Item Drop: +15
-11210	spinning upside-down replica organ grinder	0		
+11210	upside-down spinning replica organ grinder	0		
 11211	lion tamer's slick replica Juju Mojo Mask of the businessman	0		Moxie: +10, Experience (familiar): +2, Meat Drop: +50, Single Equip
 11212	squat censurious crafty arcane researcher's replica Operation Patriot Shield	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Sleaze Resistance: +3, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	replica Libram of Resolutions	0		
@@ -11071,11 +11071,11 @@
 11216	green up-at-dawn replica Camp Scout backpack	0		Adventures: +5
 11217	replica deactivated nanobots	0		
 11218	replica Apathargic Bandersnatch	0		
-11219	mirror narrow ghostly replica Smith's Tome	0		
+11219	mirror ghostly narrow replica Smith's Tome	0		
 11220	shaking replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
-11222	cyan jittery shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	perfumed wicked Cincho de Mayo of the detective of the cheetah	0		Spell Damage: +5, Stench Resistance: +5, Item Drop: +20, Initiative: +60, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11222	jittery cyan shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
+11223	perfumed wicked Cincho de Mayo of the detective of the cheetah	0		Spell Damage: +5, Stench Resistance: +5, Item Drop: +20, Initiative: +60, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	spinning vibrating wholesome replica Jurassic Parka	0		Maximum HP Percent: +10, Maximum MP Percent: +10
 11250	replica grey gosling	0		
-11251	jittery replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	jittery replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	scandalous rosy-cheeked brawny replica Cincho de Mayo of the storm	0		Muscle Percent: +20, Maximum HP Percent: +30, Maximum MP Percent: +40, Sleaze Damage: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,18 +11112,18 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	upside-down up-at-dawn family-friendly Annie Oakley's cool &quot;I survived Y2K&quot; T-Shirt of the wise owl of the scaredy-cat	0		Mysticality: +20, Moxie: +5, Critical Hit Percent: +20, Monster Level: -15, Sleaze Resistance: +1, Adventures: +5, Single Equip, Last Available: "2023-06"
 11259	jittery Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	sinister Herculean pro skateboard	0		Experience (Muscle): +1, Spell Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	sinister Herculean pro skateboard	0		Experience (Muscle): +1, Spell Damage: +10, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	spinning Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	gravedigger's Flash Liquidizer Ultra Dousing Accessory	0		Spooky Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	gravedigger's Flash Liquidizer Ultra Dousing Accessory	0		Spooky Damage: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	skewed skewed avaricious perfumed toasty smooth Amulet of Perpetual Darkness	0		Moxie: +15, Hot Damage: +5, Stench Resistance: +5, Meat Drop: +30, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
-11271	altered flattened tumbling huge scroll of minor invulnerability	0		Effect: "Leisurely Amblin'", Effect Duration: 15, Last Available: "2023-06"
+11271	altered flattened huge tumbling scroll of minor invulnerability	0		Effect: "Leisurely Amblin'", Effect Duration: 15, Last Available: "2023-06"
 11272	lime green Lapis Lazuli	0		Last Available: "2023-06"
 11273	fuchsia Eye Agate	0		Last Available: "2023-06"
 11274	wobbly Azurite	0		Last Available: "2023-06"
@@ -11137,7 +11137,7 @@
 11282	artisanal lime green Sexy Cosmo	3	EPIC	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	coward's healthy deadly red-soled high heels	0		Weapon Damage: +5, Maximum HP Percent: +20, Monster Level: -20, Last Available: "2023-06"
-11285	fancy bite-sized moldy cyburger	1	crappy	Effect: "Blessing of Pikachutlotal", Effect Duration: 45, Last Available: "2025-12"
+11285	bite-sized moldy fancy cyburger	1	crappy	Effect: "Blessing of Pikachutlotal", Effect Duration: 45, Last Available: "2025-12"
 11286	upside-down quilted ncle leg	0		Damage Absorption: +40
 11287	perfumed toasty rutabuga bag	0		Hot Damage: +5, Stench Resistance: +5
 11288	ribald mesquito proboscis	0		Sleaze Damage: +10
@@ -11159,7 +11159,7 @@
 11304	replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	huge stale jittery watermelon	7	decent	
+11307	stale huge jittery watermelon	7	decent	
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
@@ -11182,7 +11182,7 @@
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	compressed blurry concentrated cooking	1		
 11329	dehydrated olive meat	1		
-11330	modified pulsating red jittery sparkling orb	1		Effect: "Arcane in the Brain", Effect Duration: 5
+11330	modified red pulsating jittery sparkling orb	1		Effect: "Arcane in the Brain", Effect Duration: 5
 11331	diluted ghostly purple hardening cream	1		
 11332	mixed pool shark hair oil	1		Effect: "Feet of Watermelon", Effect Duration: 15
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11213,7 +11213,7 @@
 11358	ghostly smoldering leafcutter ant egg	0		
 11359	spinning narrow ribald hale Socratic smartaleck's groovy leaf crown of Flo-Jo	0		Moxie Percent: 40, Experience (Mysticality): +1, Maximum HP: +20, Sleaze Damage: +10, Initiative: +100
 11360	moldy leafy browns	4	crappy	
-11361	anodized improved spinning blue twirling autumnic balm	0		Effect: "Afternoon Insight", Effect Duration: 60
+11361	anodized improved twirling spinning blue autumnic balm	0		Effect: "Afternoon Insight", Effect Duration: 60
 11362	quantum triple-irradiated narrow narrow coping juice	0		Effect: "Phoenix, Right?", Effect Duration: 46
 11363	flame-wreathed lion tamer's Oprah's slick candy cane sword cane of wisdom	0		Mysticality: +15, Moxie: +10, Maximum MP Percent: +50, Experience (familiar): +2, Hot Spell Damage: +10, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	bouncing wrapped candy cane sword cane	0		Free Pull
@@ -11222,7 +11222,7 @@
 11367	spinning Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	narrow Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	ghostly automa-bot parts	0		
-11370	ghostly fuchsia security automa-core	0		
+11370	fuchsia ghostly security automa-core	0		
 11371	clerical automa-core	0		
 11372	skewed handful of Boltsmann bearings	0		
 11373	skewed Spring Bros. solenoid	0		
@@ -11231,7 +11231,7 @@
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	yummy pickled bread	4	awesome	Last Available: "2023-12"
-11379	bland low-calorie salted mutton	1	decent	Last Available: "2023-12"
+11379	low-calorie bland salted mutton	1	decent	Last Available: "2023-12"
 11380	stale corned beet	4	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11307,33 +11307,33 @@
 11452	dangerous personal trainer's slick beefcake's Elf dessert spoon of the pedagogue of Calamity Jane	0		Muscle: +25, Moxie: +10, Experience: +3, Experience Percent (Muscle): +10, Weapon Damage: +10, Critical Hit Percent: +15, Last Available: "2023-12"
 11453	gray sizzling arcane researcher's Elf Guard SCUBA tank	0		Experience Percent (Mysticality): +10, Hot Damage: +10, Last Available: "2023-12"
 11454	upside-down Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	yellow veiny wicked free boots	0		Spell Damage: +5, Maximum HP: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	yellow veiny wicked free boots	0		Spell Damage: +5, Maximum HP: +10, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	wobbly Sherlock's Samson's beefcake's Elvish underarmor	0		Muscle: +25, Experience (Muscle): +5, Item Drop: +25, Single Equip, Last Available: "2023-12"
 11458	double-paned dangerous Crimbuccaneer bombjacket	0		Weapon Damage: +10, Cold Resistance: +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	normal sugarplum ration	3	good	Last Available: "2023-12"
-11460	jumbo moldy tumbling huge gingerbread nylons	5	crappy	Last Available: "2023-12"
-11461	stale tiny rum-soaked fruitcake	1	decent	Last Available: "2023-12"
+11460	moldy jumbo huge tumbling gingerbread nylons	5	crappy	Last Available: "2023-12"
+11461	tiny stale rum-soaked fruitcake	1	decent	Last Available: "2023-12"
 11462	flavorless tiny lime	1	decent	Last Available: "2023-12"
-11463	bite-sized spoiled gingerbread pirate	1	crappy	Last Available: "2023-12"
+11463	spoiled bite-sized gingerbread pirate	1	crappy	Last Available: "2023-12"
 11464	bland cyan fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
 11465	hand-crafted watered-down purple mulled wine	2	EPIC	Last Available: "2023-12"
 11466	practically non-alcoholic bad Swedish coffee	1	decent	Last Available: "2023-12"
-11467	watered-down acceptable canteen of eggnog	2	good	Last Available: "2023-12"
-11468	artisanal weak hot wine	2	super EPIC	Last Available: "2023-12"
-11469	triple-distilled acceptable Jamaican coffee	9	good	Last Available: "2023-12"
+11467	acceptable watered-down canteen of eggnog	2	good	Last Available: "2023-12"
+11468	weak artisanal hot wine	2	super EPIC	Last Available: "2023-12"
+11469	acceptable triple-distilled Jamaican coffee	9	good	Last Available: "2023-12"
 11470	delicious flask of egggrog	3	awesome	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	enchanted acceptable irresponsibly strong yule grog	7	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2023-12"
+11474	enchanted irresponsibly strong acceptable yule grog	7	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2023-12"
 11475	rotten twirling wet tack	3	crappy	Last Available: "2023-12"
-11476	tiny flavorless shaking whalecake	1	decent	Last Available: "2023-12"
-11477	Tesla dangerous brainy gunwale whalegun	0		Mysticality: +5, Weapon Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11476	flavorless tiny shaking whalecake	1	decent	Last Available: "2023-12"
+11477	Tesla dangerous brainy gunwale whalegun	0		Mysticality: +5, Weapon Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	bad and claret	3	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	shaking smelly sizzling Elf Guard squirtgun	0		Hot Damage: +10, Stench Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	shaking smelly sizzling Elf Guard squirtgun	0		Hot Damage: +10, Stench Spell Damage: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	sequin-encrusted sweater of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2023-12"
 11484	Jack Frost's Da Vinci's cool replica Elf Guard medal	0		Moxie: +5, Experience (Mysticality): +5, Cold Spell Damage: +50, Last Available: "2023-12"
@@ -11356,15 +11356,15 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	Vulcanized teal military candy cane	0		Effect: "Sepia Tan", Effect Duration: 39
 11503	Vulcanized groggipop	0		Effect: "Coldfinger", Effect Duration: 39
-11504	gray aromatic medical-grade moss mace	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	horrifying careful moss megaphone	0		Monster Level: -10, Spooky Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	upside-down Fonzie's brawny moss medal	0		Muscle Percent: +20, Experience (Moxie): +1, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	sizzling moss mitre of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	ghostly educational supercool moss mantle	0		Moxie Percent: +20, Experience: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	gray aromatic medical-grade moss mace	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	horrifying careful moss megaphone	0		Monster Level: -10, Spooky Damage: +25, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	upside-down Fonzie's brawny moss medal	0		Muscle Percent: +20, Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	sizzling moss mitre of the overflowing toilet	0		Hot Damage: +10, Stench Spell Damage: +50, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	ghostly educational supercool moss mantle	0		Moxie Percent: +20, Experience: +1, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	knitted moss marlinspike of the empath	0		Familiar Weight: +5, Cold Resistance: +3, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	denatured jittery moss mulch	1		Last Available: "2024-12"
 11511	vacuum-sealed upside-down moss floss	0		Effect: "Wreathed in Merriment", Effect Duration: 69
-11512	narrow twirling adobe arsecover	0		Last Available: "2024-12"
+11512	twirling narrow adobe arsecover	0		Last Available: "2024-12"
 11513	twirling adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
 11515	adobe ayam	0		Last Available: "2024-12"
@@ -11372,33 +11372,33 @@
 11517	spinning adobe abaya	0		Last Available: "2024-12"
 11518	altered twirling adobe assortment	1		Last Available: "2024-12"
 11519	deionized activated cyan adobe brittle	0		Effect: "Sewer-Drenched", Effect Duration: 31
-11520	padded occult crepe paper phrygian cap of the wise owl	0		Mysticality: +20, Spell Damage Percent: +25, Damage Absorption: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	padded occult crepe paper phrygian cap of the wise owl	0		Mysticality: +20, Spell Damage Percent: +25, Damage Absorption: +20, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	frightening dance instructor's crepe paper parachute cape of the cougar	0		Moxie: +20, Experience Percent (Moxie): +10, Spooky Damage: +5, Last Available: "2025-12"
-11522	toasty Jim Carey's crepe paper pie clip of the sweet-tooth	0		Monster Level: +25, Hot Damage: +5, Candy Drop: +100, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	squat foul-smelling forbidden strapping crepe paper puzzle cube	0		Muscle: +5, Spell Damage Percent: +50, Stench Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	Jack Frost's grievous beefcake's crepe paper plunge camisole	0		Muscle: +25, Weapon Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	curative smooth crepe paper polka charm of the sewer	0		Moxie: +15, Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	toasty Jim Carey's crepe paper pie clip of the sweet-tooth	0		Monster Level: +25, Hot Damage: +5, Candy Drop: +100, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	squat foul-smelling forbidden strapping crepe paper puzzle cube	0		Muscle: +5, Spell Damage Percent: +50, Stench Damage: +10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	Jack Frost's grievous beefcake's crepe paper plunge camisole	0		Muscle: +25, Weapon Damage Percent: +50, Cold Spell Damage: +50, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	curative smooth crepe paper polka charm of the sewer	0		Moxie: +15, Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	dehydrated blinking bouncing crepe paper pared cuttings	1		Effect: "You Can Taste the Darkness", Effect Duration: 35, Last Available: "2025-12"
 11527	enhanced pulsating crepe paper peanut candy	0		Effect: "Wings of the Grasshopper", Effect Duration: 43
 11528	bouncing resourceful beefy petrified wood war pike	0		Muscle: +10, Maximum MP: +50, Last Available: "2025-12"
 11529	manspreader's grievous petrified wood waist protector	0		Weapon Damage Percent: +50, Monster Level: +10, Single Equip, Last Available: "2025-12"
-11530	mansplainer's studded petrified wood wizard's pouch	0		Damage Absorption: +80, Monster Level: +15, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	jittery crafty petrified wood water purifier of the sewer	0		Maximum MP: +10, Stench Damage: +25, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	mansplainer's studded petrified wood wizard's pouch	0		Damage Absorption: +80, Monster Level: +15, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	jittery crafty petrified wood water purifier of the sewer	0		Maximum MP: +10, Stench Damage: +25, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	pulsating sinister petrified wood whoopie panama of James Dean	0		Experience (Moxie): +3, Spell Damage: +10, Last Available: "2025-12"
 11533	upside-down greedy petrified wood walking pants of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +20, Last Available: "2025-12"
 11534	altered purple petrified wood waste parts	1		Effect: "Danish Cunning", Effect Duration: 15, Last Available: "2025-12"
 11535	dry double-unsweetened petrified wood wafer praline	0		Effect: "Drenched With Filth", Effect Duration: 25
 11536	tolerable cybeer	4	good	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	pulsating squat upside-down chilly Crimbuccaneer war standard of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +5, Last Available: "2023-12"
 11544	tumbling scandalous Elf Guard war standard of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	horrifying frightening shellacked spring shoes	0		Damage Reduction: 7, Spooky Damage: 30, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	horrifying frightening shellacked spring shoes	0		Damage Reduction: 7, Spooky Damage: 30, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	boiled twirling ultra-soft ferns	0		Effect: "Prelude of Precision", Effect Duration: 43, Last Available: "2024-02"
 11548	Vulcanized double-tarnished bouncing crunchy brush	0		Effect: "Sugary World View", Effect Duration: 16, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11428,8 +11428,8 @@
 11573	delicious blurry yam	3	awesome	Last Available: "2024-05"
 11574	perfectly mixed yam martini	3	EPIC	Last Available: "2024-05"
 11575	lousy fancy blinking sweet potato o' mine	4	decent	Effect: "Ghost Finger", Effect Duration: 5, Last Available: "2024-05"
-11576	tolerable watered-down Southern yam	2	good	Last Available: "2024-05"
-11577	watered-down acceptable sweet potato punch	2	good	Last Available: "2024-05"
+11576	watered-down tolerable Southern yam	2	good	Last Available: "2024-05"
+11577	acceptable watered-down sweet potato punch	2	good	Last Available: "2024-05"
 11578	flavorless big Mayam spinach	5	decent	Last Available: "2024-05"
 11579	rotten yam and swiss	4	crappy	Last Available: "2024-05"
 11580	wobbly friendly beefy yam cannon of the wise owl	0		Muscle: +10, Mysticality: +20, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2024-05"
@@ -11446,14 +11446,14 @@
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	ghostly Thwaitgold Illinigina illinoiensis model	0		
-11594	moldy bite-sized mini kiwi	1	crappy	Last Available: "2024-06"
+11594	bite-sized moldy mini kiwi	1	crappy	Last Available: "2024-06"
 11595	perfumed banded studded mini kiwi bikini	0		Damage Absorption: 180, Stench Resistance: +5, Last Available: "2024-06"
 11596	practically non-alcoholic acceptable mini kiwitini	1	good	Last Available: "2024-06"
 11597	twirling mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	avaricious fortified mini kiwi silicon tiepin of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Meat Drop: +30
 11600	mini kiwi tipi	0		
-11601	adequate small mini kiwi digitized cookies	2	good	
+11601	small adequate mini kiwi digitized cookies	2	good	
 11602	smooth mini kiwi intoxicating spirits	3	awesome	
 11603	super-pickled colloidal squat mini kiwi antimilitaristic hippy petition	0		Effect: "Sludgesick", Effect Duration: 33
 11604	non-alkaline Vulcanized improved squat mini kiwi illicit antibiotic	0		Effect: "Mo' Hobo", Effect Duration: 47
@@ -11461,7 +11461,7 @@
 11606	miser's mini kiwi icepick	0		Meat Drop: +10
 11607	tarnished mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Comprehensively Nourished", Effect Duration: 46
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	narrow protogenetic chunklet (synapse)	0		
 11611	blurry protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11472,7 +11472,7 @@
 11617	gray proto-proto-protozoa	0		
 11618	rotten bacteria bisque	3	crappy	
 11619	rotten ciliophora chowder	3	crappy	
-11620	enchanted flavorless huge cream of chloroplasts	6	decent	Effect: "Swimming with Sharks", Effect Duration: 25
+11620	flavorless enchanted huge cream of chloroplasts	6	decent	Effect: "Swimming with Sharks", Effect Duration: 25
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11483,7 +11483,7 @@
 11628	gray extra DNA	0		Experience (familiar): +1
 11629	twirling green untorn tearaway pants package	0		Free Pull
 11630	lard-coated wholesome wicked tearaway pants of the ox of chilblains	0		Muscle: +20, Spell Damage: +5, Maximum HP Percent: +10, Cold Damage: +25, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Tear Away your Pants!"
-11631	narrow shaking bouncing baby bodyguard	0		
+11631	narrow bouncing shaking baby bodyguard	0		
 11632	Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	upside-down tattoo gun	0		
@@ -11492,7 +11492,7 @@
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	spinning Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
-11640	wobbly olive Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
+11640	olive wobbly Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	ghostly boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
 11642	pulsating Sept-Ember Censer	0		Last Available: "2024-09"
 11643	chaotic blade of dismemberment	0		Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	reassuring Rosewater's bat wings of the empath	0		Mysticality Percent: +30, Familiar Weight: +5, Spooky Resistance: +1, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	reassuring Rosewater's bat wings of the empath	0		Mysticality Percent: +30, Familiar Weight: +5, Spooky Resistance: +1, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	red ember egg	0		Last Available: "2024-09"
 11660	skewed ember	0		Cold Resistance: +1
 11661	careful monocle on a stick of the storm	0		Maximum MP Percent: +40, Monster Level: -10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,11 +11523,11 @@
 11668	reassuring flame-retardant Sheriff badge	0		Hot Resistance: +1, Spooky Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	wicked Sheriff pistol of the storm	0		Spell Damage: +5, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2024-10"
 11670	nasty grievous Sheriff moustache	0		Weapon Damage Percent: +50, Stench Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	avaricious veiny photo booth supply list	0		Maximum HP: +10, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	avaricious veiny photo booth supply list	0		Maximum HP: +10, Meat Drop: +30, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	flavorless whirled peas	3	decent	Last Available: "2024-11"
-11675	normal immense peaza	9	good	Last Available: "2024-11"
+11675	immense normal peaza	9	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	pickled purple narrow drenchrome 2.0	1		Last Available: "2025-12"
 11678	modified Synapse Blaster	1		Last Available: "2025-12"
@@ -11541,7 +11541,7 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	red TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	flame-retardant stylish deft pirate hook	0		Moxie: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2024-12"
-11689	flame-retardant iron tricorn hat of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	flame-retardant iron tricorn hat of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	Herculean jolly roger flag	0		Experience (Muscle): +1, Lasts Until Rollover, Last Available: "2024-12"
 11691	narrow sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
@@ -11554,7 +11554,7 @@
 11699	harpoon	0		Last Available: "2024-12"
 11700	grievous chili powder cutlass	0		Weapon Damage Percent: +50, Last Available: "2024-12"
 11701	normal Aztec tamale	3	good	Last Available: "2024-12"
-11702	mirror green jolly roger tattoo kit	0		Last Available: "2024-12"
+11702	green mirror jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	green hardy groggles	0		Maximum HP: +50, Last Available: "2024-12"
 11705	pirate dinghy	0		Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	blue dance instructor's silky pirate drawers of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	chilled triple-tarnished double-dry peppermint pegleg	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 53, Last Available: "2024-12"
-11710	bad distilled hard cocoa	5	decent	Last Available: "2024-12"
+11710	distilled bad hard cocoa	5	decent	Last Available: "2024-12"
 11711	normal salmagumdi	3	good	Last Available: "2024-12"
 11712	clever plastic Easter Island Bunny	0		Maximum MP: +20, Last Available: "2024-12"
 11713	fuchsia sinister plastic St. Patrick	0		Spell Damage: +10, Last Available: "2024-12"
@@ -11570,7 +11570,7 @@
 11715	maroon therapeutic plastic Jedediah and Boiling Cloud	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11716	tumbling plastic &quot;Santa Claus&quot; of the wise owl	0		Mysticality: +20, Last Available: "2024-12"
 11717	blurry Spirit of Easter	0		Last Available: "2024-12"
-11718	squat pulsating Spirit of St. Patrick's Day	0		Last Available: "2024-12"
+11718	pulsating squat Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	skewed Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
@@ -11581,9 +11581,9 @@
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	polarized four-leaf potato sprout	0		Effect: "Dance Interpreter", Effect Duration: 37, Last Available: "2024-12"
 11728	huge lard-coated thinker's potato jacket of incineration	0		Mysticality: +10, Hot Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2024-12"
-11729	pulsating maroon traumatic holiday memory	0		Last Available: "2024-12"
+11729	maroon pulsating traumatic holiday memory	0		Last Available: "2024-12"
 11730	mirror Brandonian footlocker key	0		Last Available: "2024-12"
-11731	prompt mansplainer's military orb	0		Monster Level: +15, Adventures: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	prompt mansplainer's military orb	0		Monster Level: +15, Adventures: +3, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	diffused concentrated rum ball	0		Effect: "Eagle Eyes", Effect Duration: 22
 11733	gravy skin	0		Last Available: "2024-12"
 11734	rosewater-soaked personal trainer's gravyskin hat	0		Experience Percent (Muscle): +10, Stench Resistance: +3, Last Available: "2024-12"
@@ -11592,24 +11592,24 @@
 11737	miser's Samson's gravyskin pants	0		Experience (Muscle): +5, Meat Drop: +10, Last Available: "2024-12"
 11738	warmed magnetized upside-down crystallized pumpkin spice	0		Effect: "Purpose", Effect Duration: 62, Last Available: "2024-12"
 11739	jumbo rotten room scale bean casserole	5	crappy	Last Available: "2024-12"
-11740	upside-down ghostly fragile Christmas ornament	0		Last Available: "2024-12"
+11740	ghostly upside-down fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	horrifying Tesla shellacked perfect Christmas scarf	0		Damage Reduction: [7*event(December)], Spooky Damage: [+25*event(December)], MP Regen Min: [7*event(December)], MP Regen Max: [10*event(December)], Single Equip, Last Available: "2024-12"
-11743	blue clever snowman-enchanting tophat of the brazier	0		Maximum MP: +20, Hot Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	blue clever snowman-enchanting tophat of the brazier	0		Maximum MP: +20, Hot Spell Damage: +25, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	frozen electrified frozen twirling LIDAR candle	0		Effect: "Joyful Resolve", Effect Duration: 32, Last Available: "2024-12"
 11745	twirling Annie Oakley's studded Congressional Medal of Insanity of terror	0		Damage Absorption: +80, Critical Hit Percent: +20, Spooky Spell Damage: +10, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	high-proof perfectly mixed Easter grasshopper	7	EPIC	Last Available: "2024-12"
 11748	drinkable Irish eggnog	3	good	Last Available: "2024-12"
-11749	acceptable irresponsibly strong enchanted canteen of jungle juice	7	good	Effect: "Frost Tea", Effect Duration: 5, Last Available: "2024-12"
+11749	irresponsibly strong enchanted acceptable canteen of jungle juice	7	good	Effect: "Frost Tea", Effect Duration: 5, Last Available: "2024-12"
 11750	delicious tumbling narrow turchucken	4	awesome	Last Available: "2024-12"
 11751	perfectly mixed mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
 11752	acceptable holiday trip around the world	4	good	Last Available: "2024-12"
 11753	bland chocolate ostrich egg	3	decent	Last Available: "2024-12"
 11754	flavorless upside-down beef and cabbage	4	decent	Last Available: "2024-12"
-11755	small rotten blinking squat candy rations	2	crappy	Last Available: "2024-12"
+11755	rotten small blinking squat candy rations	2	crappy	Last Available: "2024-12"
 11756	normal blurry double-candied yams	3	good	Last Available: "2024-12"
-11757	massive adequate twirling Christmas ham	8	good	Last Available: "2024-12"
+11757	adequate massive twirling Christmas ham	8	good	Last Available: "2024-12"
 11758	decent holiday smorgasbord	3	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	asbestos-lined bejazzled eyepatch	0		Hot Resistance: +5, Last Available: "2024-12"
@@ -11618,13 +11618,13 @@
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	pulsating Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	jittery bouncing Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	bouncing jittery Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	shaking Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	pulsating moai statuette	0		Last Available: "2024-12"
-11772	auspicious therapeutic hardened smartaleck's egg gun	0		Moxie Percent: +30, Damage Reduction: 3, Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	auspicious therapeutic hardened smartaleck's egg gun	0		Moxie Percent: +30, Damage Reduction: 3, Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	zippy sharpshooter's Samson's Herculean army helmet	0		Experience (Muscle): 6, Critical Hit Percent: +10, Initiative: +20, Last Available: "2024-12"
 11774	squat candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	triple-oxidized jittery deviled candy egg	0		Effect: "Hot Blooded", Effect Duration: 36, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	chaotic experienced McHugeLarge duffel bag	0		Experience: +2, Spell Critical Percent: +10, Last Available: "2025-01"
-11784	Newton's McHugeLarge left pole of terror of the boozehound	0		Experience (Mysticality): +3, Spooky Spell Damage: +10, Booze Drop: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	lard-coated Socratic McHugeLarge right pole of the glutton	0		Experience (Mysticality): +1, Sleaze Spell Damage: +25, Food Drop: +100, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	pulsating knitted ruddy McHugeLarge left ski	0		Maximum HP Percent: +40, Cold Resistance: +3, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	Annie Oakley's Herculean McHugeLarge right ski	0		Experience (Muscle): +1, Critical Hit Percent: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	Newton's McHugeLarge left pole of terror of the boozehound	0		Experience (Mysticality): +3, Spooky Spell Damage: +10, Booze Drop: +100, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	lard-coated Socratic McHugeLarge right pole of the glutton	0		Experience (Mysticality): +1, Sleaze Spell Damage: +25, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	pulsating knitted ruddy McHugeLarge left ski	0		Maximum HP Percent: +40, Cold Resistance: +3, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	Annie Oakley's Herculean McHugeLarge right ski	0		Experience (Muscle): +1, Critical Hit Percent: +20, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	twisted lime green eXpand	1		Effect: "Don't Step to Your Stepmother", Effect Duration: 25, Last Available: "2025-12"
-11791	huge brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	huge brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	skewed datastick	0		Last Available: "2025-12"
 11793	blue dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,14 +11658,14 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	fuchsia retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	boiled upside-down cyan psilocyber mushroom	1		Last Available: "2025-12"
-11813	fuchsia wobbly dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
+11813	wobbly fuchsia dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	mirror dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
@@ -11677,13 +11677,13 @@
 11822	ghostly OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	tumbling insignificant bit	0		Last Available: "2025-12"
-11825	pulsating twirling parity bit	0		Familiar Weight: +5
+11825	twirling pulsating parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	olive geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	olive geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
-11831	blinking upside-down ninja crampons	0		
+11831	upside-down blinking ninja crampons	0		
 11832	ninja carabiner	0		
 11833	irradiated purple synthetic coffee	0		Effect: "Egg-stortionary Tactics", Effect Duration: 39
 11834	activated moist huge iDrops	0		Effect: "Eyes All Black", Effect Duration: 16
@@ -11727,21 +11727,21 @@
 11872	adequate Heck ramen	3	good	Last Available: "2025-03"
 11873	flavorless burrito	3	decent	Last Available: "2025-03"
 11874	fancy rotten gigantic small beer brat	9	crappy	Effect: "Salt Rockin'", Effect Duration: 35, Last Available: "2025-03"
-11875	spoiled special small blue peach pie	2	crappy	Effect: "Educated (Sorta)", Effect Duration: 5, Last Available: "2025-03"
-11876	tiny delicious twirling incredible mini-pizza	1	awesome	Last Available: "2025-03"
+11875	spoiled small special blue peach pie	2	crappy	Effect: "Educated (Sorta)", Effect Duration: 5, Last Available: "2025-03"
+11876	delicious tiny twirling incredible mini-pizza	1	awesome	Last Available: "2025-03"
 11877	aged Divine sidecar	4	awesome	Last Available: "2025-03"
 11878	lousy tangarita sidecar	4	decent	Last Available: "2025-03"
-11879	acceptable special weak gimlet sidecar	2	good	Effect: "Permanent Halloween", Effect Duration: 30, Last Available: "2025-03"
+11879	acceptable weak special gimlet sidecar	2	good	Effect: "Permanent Halloween", Effect Duration: 30, Last Available: "2025-03"
 11880	acceptable vodka stratocaster sidecar	3	good	Last Available: "2025-03"
 11881	drinkable blurry prussian cathouse sidecar	3	good	Last Available: "2025-03"
-11882	weak drinkable Mon Tiki sidecar	2	good	Last Available: "2025-03"
+11882	drinkable weak Mon Tiki sidecar	2	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	Usain Bolt's manspreader's April Shower Thoughts shield	0		Monster Level: +10, Initiative: +80, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	green spitball	0		Last Available: "2025-04"
 11887	adjusted flattened bouncing wet paper weights	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 38, Last Available: "2025-04"
-11888	watered-down delicious Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
-11889	immense spoiled pile of wet dates	8	crappy	Last Available: "2025-04"
+11888	delicious watered-down Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
+11889	spoiled immense pile of wet dates	8	crappy	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	wool wet shower cap	0		Cold Resistance: +1, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	pulsating sage stylish bycocket	0		Mysticality Percent: +10
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	fuchsia flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	mirror yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11790,7 +11790,7 @@
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	stale Skeleton Wars rations	3	decent	
-11938	watered-down enchanted hand-crafted skeleton war fuel can	2	EPIC	Effect: "Sleazy Weapon", Effect Duration: 50
+11938	enchanted hand-crafted watered-down skeleton war fuel can	2	EPIC	Effect: "Sleazy Weapon", Effect Duration: 50
 11939	tumbling skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,48 +11804,48 @@
 11949	tumbling yellow bully badge of terror	0		Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2025-08"
 11950	lion tamer's time cop top hat	0		Experience (familiar): +2, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	modified jittery bouncing bouncing mixed berry jelly	1		Effect: "Down With Chow", Effect Duration: 40, Last Available: "2025-08"
+11952	modified bouncing jittery bouncing mixed berry jelly	1		Effect: "Down With Chow", Effect Duration: 40, Last Available: "2025-08"
 11953	decent mirror twirling toast with mixed berry jelly	3	good	Last Available: "2025-08"
-11954	adequate special super-sized cup of sugar	5	good	Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2025-08"
+11954	adequate super-sized special cup of sugar	5	good	Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2025-08"
 11955	stale squat Susie's cupcake	3	decent	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	manspreader's Fonzie's the gun of the brazier	0		Experience (Moxie): +1, Monster Level: +10, Hot Spell Damage: +25, Last Available: "2025-08"
-11958	weak tolerable wine	2	good	Last Available: "2025-08"
+11958	tolerable weak wine	2	good	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	jittery purple sand penny	0		
 11962	blurry green blurry undersea surveying goggles of the blizzard	0		Cold Spell Damage: +25, Lasts Until Rollover
-11963	weak bad Ocean-Touched Rum	2	decent	
-11964	dehydrated mirror squat water-logged pill	1		
+11963	bad weak Ocean-Touched Rum	2	decent	
+11964	dehydrated squat mirror water-logged pill	1		
 11965	decent kelp puck	4	good	
 11966	spinning scroll of sea strength	0		
 11967	tumbling scroll of sea smarts	0		
 11968	pulsating twirling scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	mirror sea gel	0		
-11971	non-improved pickled purple shaking octopus ink bladder	0		Effect: "Gutterminded", Effect Duration: 16
+11971	non-improved pickled shaking purple octopus ink bladder	0		Effect: "Gutterminded", Effect Duration: 16
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	olive packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	frosty dentadent	0		Cold Spell Damage: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	flame-wreathed shellacked educational blood cubic zirconia of Tarzan of incineration of the detective	0		Experience: +1, Experience (Muscle): +3, Damage Reduction: 7, Hot Spell Damage: 60, Item Drop: +20, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	flame-wreathed shellacked educational blood cubic zirconia of Tarzan of incineration of the detective	0		Experience: +1, Experience (Muscle): +3, Damage Reduction: 7, Hot Spell Damage: 60, Item Drop: +20, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	altered skewed blood thinner	1		Last Available: "2025-10"
 12045	perfectly mixed pheromone cocktail	3	EPIC	Last Available: "2025-10"
-12046	special tasty spinal tapas	4	awesome	Effect: "Spooky Demeanor", Effect Duration: 50, Last Available: "2025-10"
+12046	tasty special spinal tapas	4	awesome	Effect: "Spooky Demeanor", Effect Duration: 50, Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	miser's grievous Samson's shrunken head	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Meat Drop: +10, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	miser's grievous Samson's shrunken head	0		Experience (Muscle): +5, Weapon Damage Percent: +50, Meat Drop: +10, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	special hand-crafted wobbly Smoking Pope	4	EPIC	Effect: "Hopped Up on Goofballs", Effect Duration: 50
 12053	yummy tumbling prize turkey	3	awesome	
-12054	compressed fuchsia twirling medicinal gruel	1		
+12054	compressed twirling fuchsia medicinal gruel	1		
 12055	immense bland full-sized pumpkin pie	7	decent	Last Available: "2025-11"
 12056	delicious vodka cranberry sauce	3	awesome	Last Available: "2025-11"
 12057	adjusted activated yammed candy	0		Effect: "Walberg's Dim Bulb", Effect Duration: 28, Last Available: "2025-11"
-12058	moldy massive treasure chestnut	7	crappy	Last Available: "2025-12"
+12058	massive moldy treasure chestnut	7	crappy	Last Available: "2025-12"
 12059	hand-crafted blurry mulled butter rum	4	EPIC	Last Available: "2025-12"
 12060	polarized cinnamon doubloon	0		Effect: "Demonic Taint", Effect Duration: 13, Last Available: "2025-12"
 12061	squat knitted plastic left skeleton arm	0		Cold Resistance: +3, Last Available: "2025-12"
@@ -11869,7 +11869,7 @@
 12079	Usain Bolt's devilbone corset	0		Initiative: +80, Last Available: "2026-12"
 12080	banded occult devilbone flute	0		Spell Damage Percent: +25, Damage Absorption: +100, Last Available: "2026-12"
 12081	devilbone rosary of the early riser	0		Adventures: +7, Single Equip, Last Available: "2026-12"
-12082	altered mirror olive devilbone chunks	1		Last Available: "2026-12"
+12082	altered olive mirror devilbone chunks	1		Last Available: "2026-12"
 12083	frozen green Gehenna tattoo	0		Effect: "Pumped Up", Effect Duration: 53
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11889,16 +11889,16 @@
 12131	energized bouncing boiling synovial fluid	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 16, Last Available: "2025-12"
 12132	pulsating steel-toed rock-hard fortified smoldering vertebra	0		Damage Absorption: +60, Damage Reduction: 28, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	narrow smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	lion tamer's Oprah's savvy hot boning knife	0		Mysticality Percent: +20, Maximum MP Percent: +50, Experience (familiar): +2, Single Equip, Last Available: "2025-12"
 12138	Tesla Rosewater's fistbone of Tarzan	0		Mysticality Percent: +30, Experience (Muscle): +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 12139	squat sizzling Temple Grandin's fortified burnt bone belt	0		Damage Absorption: +60, Familiar Weight: +7, Hot Damage: +10, Single Equip, Last Available: "2025-12"
 12140	pulsating censurious scorched skull trophy	0		Sleaze Resistance: +3, Last Available: "2025-12"
-12141	gigantic adequate red wing bone	6	good	Last Available: "2025-12"
+12141	adequate gigantic red wing bone	6	good	Last Available: "2025-12"
 12142	aged weak skeleton venom	3	awesome	Last Available: "2025-12"
-12143	dehydrated wobbly bouncing baked bone meal	1		Last Available: "2025-12"
+12143	dehydrated bouncing wobbly baked bone meal	1		Last Available: "2025-12"
 12144	squat blinking plastic skeleton rib cage of chilblains	0		Cold Damage: +25, Last Available: "2025-12"
 12145	blinking bouncing dance instructor's plastic skeleton skull	0		Experience Percent (Moxie): +10, Last Available: "2025-12"
 12146	Socratic plastic skeleton Crimbo hat	0		Experience (Mysticality): +1, Last Available: "2025-12"
@@ -11909,7 +11909,7 @@
 12151	spinning upside-down lightning-fast brawny scorched skeleton mask	0		Muscle Percent: +20, Initiative: +40, Last Available: "2025-12"
 12152	zippy scorched skeleton shirt of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +20, Last Available: "2025-12"
 12153	Sherlock's savvy scorched skeleton pants	0		Mysticality Percent: +20, Item Drop: +25, Last Available: "2025-12"
-12154	squat olive messenger parrot egg	0		Last Available: "2025-12"
+12154	olive squat messenger parrot egg	0		Last Available: "2025-12"
 12155	buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	skewed Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
@@ -11926,17 +11926,17 @@
 12168	bouncing studded smartaleck's vermiculite shield	0		Moxie Percent: +30, Damage Absorption: +80, Damage Reduction: 9, Last Available: "2025-12"
 12169	ship's lantern of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2025-12"
 12170	fuchsia wobbly mansplainer's weightlifter's heat-resistant harpoon pistol	0		Muscle: +15, Monster Level: +15, Last Available: "2025-12"
-12171	immense adequate traditional gingerloaf	10	good	Last Available: "2025-12"
-12172	drinkable weak Scotch and eggnog	2	good	Last Available: "2025-12"
+12171	adequate immense traditional gingerloaf	10	good	Last Available: "2025-12"
+12172	weak drinkable Scotch and eggnog	2	good	Last Available: "2025-12"
 12173	dry warmed counterskeleton elixir	0		Effect: "Tingly Biceps", Effect Duration: 22, Last Available: "2025-12"
-12174	boozy acceptable &quot;salvaged&quot; wine	5	good	Last Available: "2025-12"
+12174	acceptable boozy &quot;salvaged&quot; wine	5	good	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	shaking crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	decent thick wedge of prize-winning cheese	5	good	Last Available: "2025-12"
 12178	activated gummi fingerbone	0		Effect: "Tenacity of the Snapper", Effect Duration: 64
 12179	maroon glimmering crystal of the dark arts of the bloodbag	0		Spell Damage Percent: +100, Maximum HP: +100, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11959,12 +11959,12 @@
 12201	green resourceful dinosaur bone club	0		Maximum MP: +50, Last Available: "2026-03"
 12202	bouncing strapping dinosaur skull helmet of vim and vigor	0		Muscle: +5, Maximum HP Percent: +50, Last Available: "2026-03"
 12203	frosty extremely unsafe deadly dinosaur bone corset	0		Weapon Damage: +5, Weapon Damage Percent: +100, Cold Spell Damage: +10, Last Available: "2026-03"
-12204	mediocre extra-dry maroon Pork Elf cough syrup	5	decent	Last Available: "2026-03"
+12204	extra-dry mediocre maroon Pork Elf cough syrup	5	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	huge Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	moldy super-sized enchanted rat pizza	5	crappy	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2026-03"
+12209	moldy enchanted super-sized rat pizza	5	crappy	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	huge lime green lightning-fast perfumed hoverboard of the cheetah	0		Stench Resistance: +5, Initiative: 100, Single Equip, Last Available: "2026-03"
 12212	ghostly Jack Frost's sage left shark fin of horror	0		Mysticality Percent: +10, Cold Spell Damage: +50, Spooky Spell Damage: +25, Last Available: "2026-03"
@@ -11973,35 +11973,35 @@
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	super-sized normal discarded hot dog	5	good	Last Available: "2026-04"
-12218	weak mediocre most of a beer	2	decent	Last Available: "2026-04"
+12218	mediocre weak most of a beer	2	decent	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	shaking legendary noodles	0		Last Available: "2026-05"
 12226	bland super-sized can of tuna	5	decent	
 12227	rotten massive alien salad	10	crappy	
-12228	diet tasty ratbatatouille	1	awesome	
+12228	tasty diet ratbatatouille	1	awesome	
 12229	moldy onigiri	3	crappy	
 12230	stale crudit&eacute;s	3	decent	
-12231	miniature yummy wobbly sauced mutton	2	awesome	
+12231	yummy miniature wobbly sauced mutton	2	awesome	
 12232	tasty small hot honey ant	2	awesome	
-12233	enchanted low-calorie adequate fuchsia tomb aspic	1	good	Effect: "Fishy Fortification", Effect Duration: 15
+12233	adequate low-calorie enchanted fuchsia tomb aspic	1	good	Effect: "Fishy Fortification", Effect Duration: 15
 12234	normal bouncing later tots	4	good	
 12235	rotten blurry Frutti di Scatoletta	4	crappy	Last Available: "2026-05"
 12236	bland spinning Pesto alla Marziano	3	decent	Last Available: "2026-05"
 12237	stale immense Arrattabbattabiata	9	decent	Last Available: "2026-05"
 12238	decent upside-down Orzo di Riso	4	good	Last Available: "2026-05"
 12239	toothsome Pasta Grimavera	4	awesome	Last Available: "2026-05"
-12240	huge toothsome Linguini Ubriacapa	10	awesome	Last Available: "2026-05"
-12241	moldy half-sized Formica e Pepe	2	crappy	Last Available: "2026-05"
-12242	rotten fancy half-sized Tubetto Gelatto	2	crappy	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2026-05"
+12240	toothsome huge Linguini Ubriacapa	10	awesome	Last Available: "2026-05"
+12241	half-sized moldy Formica e Pepe	2	crappy	Last Available: "2026-05"
+12242	half-sized fancy rotten Tubetto Gelatto	2	crappy	Effect: "Weird Flavor", Effect Duration: 10, Last Available: "2026-05"
 12243	enchanted stale Gnocci Domani	3	decent	Effect: "You Know When to Walk Away", Effect Duration: 25, Last Available: "2026-05"
-12244	shaking skewed Thwaitgold wallet moth statuette	0		
+12244	skewed shaking Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	jittery second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	upside-down mega helmet	0		
 12252	green perfumed Oprah's Space Soldier Helmet	0		Maximum MP Percent: +50, Stench Resistance: +5
 12253	rotten half-sized spinning premium turkey leg	2	crappy	
-12254	high-proof tolerable shaking styrofoam cup of mead	9	good	
+12254	tolerable high-proof shaking styrofoam cup of mead	9	good	
 12255	gray twirling ghostly sword of the brute	0		Muscle Percent: +30
 12256	gravedigger's staff	0		Spooky Damage: +10
 12257	careful lute	0		Monster Level: -10
@@ -12017,26 +12017,26 @@
 12267	narrow MacGyver's flimsy plastic breastplate	0		Maximum MP: +100
 12268	flimsy plastic shield of the blizzard	0		Cold Spell Damage: +25, Damage Reduction: 3
 12269	bouncing packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	fuchsia skewed supercharged Portable Laughing Stock of the bloodbag of bravery	0		Maximum HP: +100, Maximum MP Percent: +30, Spooky Resistance: +5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	fuchsia skewed supercharged Portable Laughing Stock of the bloodbag of bravery	0		Maximum HP: +100, Maximum MP Percent: +30, Spooky Resistance: +5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	red occult Newton's Staff of Anachronistic Churning of James Dean	0		Experience (Mysticality): +3, Experience (Moxie): +3, Spell Damage Percent: +25
-12272	small bland classic banana	2	decent	Last Available: "2026-07"
-12273	half-sized toothsome fancy blinking watermelon	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2026-07"
+12272	bland small classic banana	2	decent	Last Available: "2026-07"
+12273	half-sized fancy toothsome blinking watermelon	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2026-07"
 12274	miniature moldy upside-down quince	2	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	decent enchanted blue classic banana pie	4	good	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2026-07"
+12277	enchanted decent blue classic banana pie	4	good	Effect: "Improprie Tea", Effect Duration: 25, Last Available: "2026-07"
 12278	galvanized pressed denatured essential banana decoction	0		Effect: "Punch Another Day", Effect Duration: 22, Last Available: "2026-07"
 12279	liquefied triple-polarized blue banana quintessence	0		Effect: "Techno Bliss", Effect Duration: 43, Last Available: "2026-07"
-12280	enchanted mediocre Aesop Daiquiri	3	decent	Effect: "Human-Beast Hybrid", Effect Duration: 30, Last Available: "2026-07"
+12280	mediocre enchanted Aesop Daiquiri	3	decent	Effect: "Human-Beast Hybrid", Effect Duration: 30, Last Available: "2026-07"
 12281	acceptable lime green Monkey Congress	3	good	Last Available: "2026-07"
 12282	bite-sized decent watermelon pie	1	good	Last Available: "2026-07"
 12283	enhanced aerosolized concentrated watermelon juice	0		Effect: "Astral Shell", Effect Duration: 15, Last Available: "2026-07"
 12284	energized green Aqua Citrulanatae	0		Effect: "Paging Betty", Effect Duration: 67, Last Available: "2026-07"
-12285	delicious high-proof ghostly Melonegroni	10	awesome	Last Available: "2026-07"
+12285	high-proof delicious ghostly Melonegroni	10	awesome	Last Available: "2026-07"
 12286	mediocre blue Melonade Spritz	4	decent	Last Available: "2026-07"
 12287	adequate tiny wobbly quince pie	1	good	Last Available: "2026-07"
 12288	extra-aerosolized alkaline twirling quince quaff	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 50, Last Available: "2026-07"
-12289	denatured wet jittery tumbling Quickquince	0		Effect: "Burning Hands", Effect Duration: 27, Last Available: "2026-07"
+12289	denatured wet tumbling jittery Quickquince	0		Effect: "Burning Hands", Effect Duration: 27, Last Available: "2026-07"
 12290	delicious practically non-alcoholic pulsating Quiskey Sour	1	awesome	Last Available: "2026-07"
 12291	bad spirit-forward Quincea&ntilde;era Cooler	5	decent	Last Available: "2026-07"
 12292	weak bad bouncing Roth IPA	2	decent	Last Available: "2026-08"
@@ -12052,7 +12052,7 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	perfumed Van der Graaf 401k ring	0		Stench Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-08"
 12304	skewed balance sheet	0		Last Available: "2026-08"
-12305	non-ionized Vulcanized activated cyan wobbly bouncing invisible hand	0		Effect: "On the Shoulders of Giants", Effect Duration: 67, Last Available: "2026-08"
+12305	non-ionized Vulcanized activated wobbly cyan bouncing invisible hand	0		Effect: "On the Shoulders of Giants", Effect Duration: 67, Last Available: "2026-08"
 12306	electrified huge circle of overdraft protection scroll	0		Effect: "Elemental Mastery", Effect Duration: 49, Last Available: "2026-08"
 12307	extra-boiled adjusted ionized lime green mint	0		Effect: "Sugar, Hello", Effect Duration: 23, Last Available: "2026-08"
 12308	tumbling savings bondo	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Sauceror_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Vole_cafe_booze.txt
@@ -1,21 +1,21 @@
 -1	perfectly mixed Petite Porter	3	EPIC	
--2	hand-crafted watered-down Scrawny Stout	2	EPIC	
--3	mediocre weak Infinitesimal IPA	2	decent	
+-2	watered-down hand-crafted Scrawny Stout	2	EPIC	
+-3	weak mediocre Infinitesimal IPA	2	decent	
 -4	acceptable practically non-alcoholic bouncing eggnogtini	1	good	
--5	acceptable watered-down ghostly candycaine	2	good	
--6	acceptable watered-down jittery braincracker sweet	2	good	
+-5	watered-down acceptable ghostly candycaine	2	good	
+-6	watered-down acceptable jittery braincracker sweet	2	good	
 -16	tolerable huge fermented honey	4	good	
 -17	perfectly mixed tumbling moons-shine	3	EPIC	
 -18	mediocre gin	3	decent	
 -19	smooth fortified green ecto-nog	5	awesome	
 -20	acceptable bouncing hot toady	3	good	
 -21	aged gray hot choculate	3	awesome	
--49	weak tolerable Cyder	2	good	
+-49	tolerable weak Cyder	2	good	
 -50	acceptable ghostly Oil Nog	3	good	
 -51	weak lousy Hi-Octane Peppermint Jet Fuel	2	decent	
--58	drinkable fortified narrow maroon Grimacider	5	good	
+-58	fortified drinkable narrow maroon Grimacider	5	good	
 -59	bad weak Isotope Nog	2	decent	
--60	watered-down aged Mutagin 'n' Tonic	2	awesome	
+-60	aged watered-down Mutagin 'n' Tonic	2	awesome	
 -70	hand-crafted Gin and Herring	4	EPIC	
 -71	drinkable Black and Tan and Red All Over	4	good	
 -72	artisanal practically non-alcoholic Antarctic Ice Tea	1	EPIC	
@@ -23,11 +23,11 @@
 -77	acceptable green CRIMBCO Egg Substitute Nog Substitute	4	good	
 -78	aged CRIMBCO Extreme Braincracker Sour	4	awesome	
 -82	lousy squat Horseradish-infused Vodka	4	decent	
--83	mediocre watered-down Jerkitini	2	decent	
+-83	watered-down mediocre Jerkitini	2	decent	
 -84	hand-crafted Desert Island Iced Tea	3	EPIC	
 -88	lousy strong mirror Crimbo Saketini	5	decent	
 -89	drinkable Crimboku Drop	3	good	
--90	weak mediocre twirling Flaming Crimbo Log	2	decent	
+-90	mediocre weak twirling Flaming Crimbo Log	2	decent	
 -107	artisanal fancy weak jittery Fortified Eggnog Slurry	2	EPIC	
 -108	lousy irresponsibly strong Hot Buttered Rum	9	decent	
 -109	artisanal spinning Spicy Hot Chocolate	3	EPIC	

--- a/data/TCRS/TCRS_Sauceror_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Vole_cafe_food.txt
@@ -1,11 +1,11 @@
 -1	decent Peche a la Frog	3	good	
--2	normal half-sized As Jus Gezund Heit	2	good	
--3	moldy snack-sized Bouillabaise Coucher Avec Moi	2	crappy	
--7	big rotten gumdrop chow mein	5	crappy	
+-2	half-sized normal As Jus Gezund Heit	2	good	
+-3	snack-sized moldy Bouillabaise Coucher Avec Moi	2	crappy	
+-7	rotten big gumdrop chow mein	5	crappy	
 -8	adequate candy cane pizza	4	good	
 -9	special low-calorie flavorless blinking gingerbread stir-fry	1	decent	
 -10	immense enchanted toothsome twigs and gravel	8	awesome	
--11	snack-sized moldy enchanted shoots and leaves	2	crappy	
+-11	enchanted moldy snack-sized shoots and leaves	2	crappy	
 -12	adequate olive bowl of unidentifiable goo	3	good	
 -13	flavorless gingerbread massacre	3	decent	
 -14	rotten It Came From Beyond Dessert	3	crappy	
@@ -14,32 +14,32 @@
 -53	snack-sized normal Disc-Shaped Nutrition Unit	2	good	
 -54	delicious Gingerborg Hive	4	awesome	
 -61	bland Candy Cane Surprise	4	decent	
--62	diet decent Grimdrop Chow Mein	1	good	
+-62	decent diet Grimdrop Chow Mein	1	good	
 -63	fancy tasty Grimgerbread House	3	awesome	
--67	rotten miniature Caviar Carbonara	2	crappy	
+-67	miniature rotten Caviar Carbonara	2	crappy	
 -68	stale shaking Halibut Alfredo	3	decent	
 -69	moldy snack-sized Red Herring Velvet Cake	2	crappy	
 -73	flavorless CRIMBCO Reconstituted Gruel	4	decent	
 -74	normal New and Improved CRIMBCO Reconstituted Gruel	3	good	
 -75	delicious CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	awesome	
--79	flavorless miniature Brussels Sprout Stir-Fry	2	decent	
+-79	miniature flavorless Brussels Sprout Stir-Fry	2	decent	
 -80	normal Carrot, Cabbage, and Kale Pizza	3	good	
 -81	normal huge Turnip and Rutabaga Pie	4	good	
--85	small decent Rainbow Spider Fun Roll	2	good	
+-85	decent small Rainbow Spider Fun Roll	2	good	
 -86	rotten Vegas Volcano Lava Roll	3	crappy	
 -87	rotten Crazy Dragon Shogun Buddha Roll	3	crappy	
 -92	adequate jittery basic hot dog	4	good	
 -93	moldy savage macho dog	4	crappy	
 -94	moldy one with everything	3	crappy	
 -95	spoiled sly dog	4	crappy	
--96	low-calorie enchanted bland devil dog	1	decent	
+-96	low-calorie bland enchanted devil dog	1	decent	
 -97	toothsome blue chilly dog	4	awesome	
--98	adequate big ghost dog	5	good	
+-98	big adequate ghost dog	5	good	
 -99	rotten junkyard dog	3	crappy	
 -100	moldy wet dog	3	crappy	
--101	huge stale sleeping dog	9	decent	
+-101	stale huge sleeping dog	9	decent	
 -102	spoiled optimal dog	3	crappy	
 -103	decent fancy video games hot dog	4	good	
 -104	moldy miniature blinking Peppermint Nutrition Block	2	crappy	
 -105	decent upside-down Gingerbread Nutrition Block	3	good	
--106	adequate massive Cinnamon Nutrition Block	10	good	
+-106	massive adequate Cinnamon Nutrition Block	10	good	

--- a/data/TCRS/TCRS_Sauceror_Wallaby.txt
+++ b/data/TCRS/TCRS_Sauceror_Wallaby.txt
@@ -13,7 +13,7 @@
 14	boiled jittery moxie weed	1		Effect: "Mad at Science", Effect Duration: 10
 15	boiled spinning strongness elixir	1		
 16	boiled skewed magicalness-in-a-can	1		
-17	bland bite-sized noodles	1	decent	
+17	bite-sized bland noodles	1	decent	
 18	wobbly tortoise's blessing	0		
 19	Usain Bolt's asparagus knife	0		Initiative: +80
 20	Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -120,7 +120,7 @@
 121	sprocket assembly	0		
 122	wobbly cog and sprocket assembly	0		
 123	ghostly Gnollish flyswatter	0		
-124	red tumbling empty meat tank	0		
+124	tumbling red empty meat tank	0		
 125	full meat tank	0		
 126	meat engine	0		
 127	banded Gnollish autoplunger	0		Damage Absorption: +100
@@ -142,7 +142,7 @@
 143	spinning cottage	0		
 144	stone of eXtreme power	0		
 145	green barbed-wire fence	0		
-146	cyan blurry dinghy plans	0		
+146	blurry cyan dinghy plans	0		
 147	boxer's eXtreme meat sword	0		Muscle Percent: +10
 148	squat steel-toed eXtreme meat staff	0		Damage Reduction: 9
 149	squat beefcake's eXtreme meat crossbow	0		Muscle: +25
@@ -157,8 +157,8 @@
 158	Gnollish pie tin	0		
 159	gray ghostly wad of dough	0		
 160	pie crust	0		
-161	jumbo flavorless shaking ghuol egg	5	decent	
-162	miniature rotten lime green ghuol egg quiche	2	crappy	
+161	flavorless jumbo shaking ghuol egg	5	decent	
+162	rotten miniature lime green ghuol egg quiche	2	crappy	
 163	green shaking nippy skeleton bone	0		Cold Damage: +10
 164	blinking smart skull	0		
 165	skewer	0		
@@ -196,7 +196,7 @@
 198	rat appendix	0		
 199	nippy ring	0		Cold Damage: +10
 200	bland rat appendix kabob	4	decent	
-201	jumbo flavorless bat wing kabob	5	decent	
+201	flavorless jumbo bat wing kabob	5	decent	
 202	spoiled special carob chunks	3	crappy	Effect: "Punchy, Murdery", Effect Duration: 25
 203	herbs	0		
 204	adequate carob chunk cookies	3	good	
@@ -211,7 +211,7 @@
 213	greedy ribald filthy corduroys	0		Sleaze Damage: +10, Meat Drop: +20, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	squat Sinatra's filthy knitted dread sack	0		Experience (Moxie): +5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	fancy toothsome carob brownies	4	awesome	Effect: "Hustlin'", Effect Duration: 25
+216	toothsome fancy carob brownies	4	awesome	Effect: "Hustlin'", Effect Duration: 25
 217	rotten tumbling jittery herb brownies	3	crappy	
 218	hemp string	0		
 219	necklace chain	0		
@@ -233,7 +233,7 @@
 235	medical-grade Bigger Bugfinder Blade of Flo-Jo	0		Initiative: +100, HP Regen Min: 7, HP Regen Max: 10
 236	wobbly Queue Du Coq cocktailcrafting kit	0		
 237	artisanal bottle of gin	4	EPIC	
-238	artisanal practically non-alcoholic fuchsia blurry bottle of vodka	1	EPIC	
+238	artisanal practically non-alcoholic blurry fuchsia bottle of vodka	1	EPIC	
 239	energetic dance instructor's Orcish baseball cap	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	greasy smelly Orcish cargo shorts	0		Stench Spell Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Orcish frat-paddle of the pedagogue	0		Experience: +3
@@ -241,45 +241,45 @@
 243	decent massive grapefruit	7	good	
 244	yummy grapes	3	awesome	
 245	adequate bouncing bouncing olive	4	good	
-246	rotten super-sized tomato	5	crappy	
+246	super-sized rotten tomato	5	crappy	
 247	spinning fermenting powder	0		
-248	perfectly mixed spirit-forward salty dog	5	EPIC	
+248	spirit-forward perfectly mixed salty dog	5	EPIC	
 249	bad bloody mary	3	decent	
-250	fancy artisanal skewed screwdriver	3	EPIC	Effect: "Spooky Jellied", Effect Duration: 10
+250	artisanal fancy skewed screwdriver	3	EPIC	Effect: "Spooky Jellied", Effect Duration: 10
 251	artisanal martini	4	EPIC	
 252	perfectly mixed extra-dry bloody beer	5	EPIC	
 253	acceptable practically non-alcoholic mirror shot of schnapps	1	good	
 254	delicious shot of grapefruit schnapps	4	awesome	
-255	tolerable practically non-alcoholic fine wine	1	good	
+255	practically non-alcoholic tolerable fine wine	1	good	
 256	aged watered-down shot of tomato schnapps	2	awesome	
-257	artisanal fortified extra-spicy bloody mary	5	EPIC	
+257	fortified artisanal extra-spicy bloody mary	5	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
-260	decent snack-sized skewed White Citadel fries	2	good	
+260	snack-sized decent skewed White Citadel fries	2	good	
 261	bite-sized special spoiled White Citadel burger	1	crappy	Effect: "Hobo Flavor", Effect Duration: 25
 262	normal piece of wedding cake	3	good	
-263	big delicious blue chocolate chips	5	awesome	
-264	special half-sized yummy jittery chocolate chip cookies	2	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 20
+263	delicious big blue chocolate chips	5	awesome	
+264	yummy half-sized special jittery chocolate chip cookies	2	awesome	Effect: "Hagnk's Gratitude", Effect Duration: 20
 265	Jeselnik's satin pants	0		Sleaze Damage: +25, Familiar Effect: "atk, 2xPotato, cap 10"
 266	weak tolerable spinning lightning	2	good	
 267	arcane researcher's mullet wig	0		Experience Percent (Mysticality): +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	avaricious meat cowboy hat	0		Meat Drop: +30, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	mirror scorching sword	0		Hot Damage: +25
 270	picket fence	0		
-271	modified blurry blurry red barbell	1		
+271	modified red blurry blurry barbell	1		
 272	boiled wobbly upside-down concentrated magicalness pill	1		
 273	vaporized blue moxie weed	1		Effect: "You Liver", Effect Duration: 50
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	modified wobbly purple twirling extra-strength strongness elixir	1		Effect: "Shot in the Arse", Effect Duration: 15
+277	modified purple wobbly twirling extra-strength strongness elixir	1		Effect: "Shot in the Arse", Effect Duration: 15
 278	diluted blurry tumbling mirror jug-o-magicalness	1		
-279	modified ghostly pulsating suntan lotion of moxiousness	1		
+279	modified pulsating ghostly suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	green gasmask of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xBarrr, cap 12"
 282	jittery Boris's key	0		
 283	Jarlsberg's key	0		
-284	jittery blue tumbling Sneaky Pete's key	0		
+284	jittery tumbling blue Sneaky Pete's key	0		
 285	miser's walrus-tusk earring	0		Meat Drop: +10
 286	gray ring of half-assed regeneration of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
 287	frightening Boris's ring	0		Spooky Damage: +5
@@ -293,12 +293,12 @@
 295	huge fuchsia dangerous demonskin trousers	0		Weapon Damage: +10, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	fireproof dungeoneer's dungarees	0		Hot Resistance: +3, Familiar Effect: "stench atk, 4xPotato, cap 7"
 297	quantum upside-down tamarind-flavored chewing gum	0		Effect: "Salt Rockin'", Effect Duration: 45
-298	dry twirling bouncing lime-and-chile-flavored chewing gum	0		Effect: "Halloweeny", Effect Duration: 32
+298	dry bouncing twirling lime-and-chile-flavored chewing gum	0		Effect: "Halloweeny", Effect Duration: 32
 299	dry yellow pickle-flavored chewing gum	0		Effect: "The Solution", Effect Duration: 37
 300	super-galvanized oxidized fuchsia jaba&ntilde;ero-flavored chewing gum	0		Effect: "Feroci Tea", Effect Duration: 12
 301	flat dough	0		
 302	rotten Knob sausage	3	crappy	
-303	normal small huge Knob mushroom	2	good	
+303	small normal huge Knob mushroom	2	good	
 304	jittery dry noodles	0		
 305	bouncing Knob Goblin harem pants of doom	0		Spooky Spell Damage: +50, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	blue upside-down cool Knob Goblin harem veil	0		Moxie: +5, Familiar Effect: "5xLep, cap 2"
@@ -312,7 +312,7 @@
 314	decent diet purple bean burrito	1	good	
 315	bland bean burrito	4	decent	
 316	big normal insanely bean burrito	5	good	
-317	normal massive bean burrito	8	good	
+317	massive normal bean burrito	8	good	
 318	tiny toothsome bean burrito	1	awesome	
 319	delicious red insanely bean burrito	3	awesome	
 320	adequate bat haggis	3	good	
@@ -323,12 +323,12 @@
 325	stale enchanted goat cheese pizza	3	decent	Effect: "Big Meat Big Prizes", Effect Duration: 45
 326	bland green mushroom pizza	4	decent	
 327	blinking goat	0		
-328	drinkable practically non-alcoholic mirror spinning bottle of whiskey	1	good	
+328	practically non-alcoholic drinkable mirror spinning bottle of whiskey	1	good	
 329	stylish goat beard	0		Moxie: +25, Familiar Effect: "atk, 1xPotato, cap 15"
 330	fancy shaking twirling cyan glass of goat's milk	1	decent	Effect: "Sweet and Green", Effect Duration: 10
 331	lousy weak Canadian	2	decent	
 332	flavorless lemon	3	decent	
-333	normal fancy skewed lime	3	good	Effect: "Buggy Flavor", Effect Duration: 30
+333	fancy normal skewed lime	3	good	Effect: "Buggy Flavor", Effect Duration: 30
 334	fuchsia dangerous sabre teeth	0		Weapon Damage: +10
 335	sabre-toothed lime cub	0		
 336	twirling pulsating consolation ribbon of Calamity Jane	0		Critical Hit Percent: +15
@@ -340,7 +340,7 @@
 342	squat Knob Goblin stink bomb	0		
 343	non-Vulcanized moist polymerized Knob Goblin sharpening spray	0		Effect: "Hiding in Plain Sight", Effect Duration: 42
 344	Knob Goblin seltzer	0		
-345	mirror shaking Knob Goblin superseltzer	0		
+345	shaking mirror Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
 348	ninja mask of the businessman	0		Meat Drop: +50, Familiar Effect: "cold atk, 1xBarrr, cap 20"
@@ -353,7 +353,7 @@
 355	auspicious eXtreme scarf	0		Item Drop: +10, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	rosy-cheeked snowboarder pants	0		Maximum HP Percent: +30, Familiar Effect: "1xPotato, cap 25"
 357	blinking Mountain Stream soda	0		
-358	moldy snack-sized gr8ps	2	crappy	
+358	snack-sized moldy gr8ps	2	crappy	
 359	bland t8r tots	4	decent	
 360	twirling blurry strapping miner's helmet	0		Muscle: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	shaking miner's pants of extreme caution	0		Monster Level: -25, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -371,7 +371,7 @@
 373	chrome stick	0		
 374	huge chrome crossbow string	0		
 375	wobbly linoleum meat stack	0		
-376	pulsating blinking asbestos meat stack	0		
+376	blinking pulsating asbestos meat stack	0		
 377	chrome meat stack	0		
 378	blinking nippy linoleum sword of the brute	0		Muscle Percent: +30, Cold Damage: +10
 379	Jeselnik's ruddy linoleum staff	0		Maximum HP Percent: +40, Sleaze Damage: +25
@@ -462,11 +462,11 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	low-calorie delicious pixel pie	1	awesome	
+467	delicious low-calorie pixel pie	1	awesome	
 468	ruby W	0		
 469	skewed wussiness potion	0		
 470	lousy weak gray Imp Ale	2	decent	
-471	yummy big hot wing	5	awesome	
+471	big yummy hot wing	5	awesome	
 472	scorching diamond-studded cane	0		Hot Damage: +25, Class: "Disco Bandit"
 473	blurry executive crutch	0		Meat Drop: +40
 474	cast	0		
@@ -509,7 +509,7 @@
 511	Jarlsberg's key lime	0		
 512	blinking Sneaky Pete's key lime	0		
 513	moldy Boris's key lime pie	3	crappy	
-514	adequate small enchanted blinking Jarlsberg's key lime pie	2	good	Effect: "Mushroom Magicalness", Effect Duration: 15
+514	small enchanted adequate blinking Jarlsberg's key lime pie	2	good	Effect: "Mushroom Magicalness", Effect Duration: 15
 515	stale blinking Sneaky Pete's key lime pie	3	decent	
 516	cyan narrow Hey Deze map	0		
 517	bejeweled accordion strap of the cheetah	0		Initiative: +60, Class: "Accordion Thief"
@@ -519,8 +519,8 @@
 521	bouncing squat deadly kickback cookbook	0		Weapon Damage: +5
 522	yellow squat one-winged stab bat	0		
 523	squat rewinged stab bat	0		
-524	hand-crafted weak papaya sling	2	EPIC	
-525	red huge grue egg	0		
+524	weak hand-crafted papaya sling	2	EPIC	
+525	huge red grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
@@ -532,7 +532,7 @@
 534	abridged dictionary	0		
 535	blinking tumbling bridge	0		
 536	dictionary	0		
-537	narrow blinking pr0n legs	0		
+537	blinking narrow pr0n legs	0		
 538	resourceful f3d0r4	0		Maximum MP: +50, Familiar Effect: "atk, 1xLep, cap 27"
 539	lowercase N	0		
 540	enhanced Tasty Fun Good rice candy	0		Effect: "Frisky Spirit", Effect Duration: 43
@@ -540,7 +540,7 @@
 542	perfumed hardened 1337 7r0uZ0RZ	0		Damage Reduction: 3, Stench Resistance: +5, Familiar Effect: "2xPotato, cap 27"
 543	miniature adequate Trollhouse cookies	2	good	
 544	blurry Lo Pan's talons of the sweet-tooth	0		Spell Critical Percent: +30, Candy Drop: +100
-545	immense fancy tasty Spam Witch sammich	9	awesome	Effect: "Stimulated Body", Effect Duration: 40
+545	tasty immense fancy Spam Witch sammich	9	awesome	Effect: "Stimulated Body", Effect Duration: 40
 546	meat vortex	0		
 547	squat 334 scroll	0		
 548	668 scroll	0		
@@ -568,18 +568,18 @@
 570	rotten low-calorie Chicken Sandwich	1	crappy	
 571	Jumbo Dr. Lucifer	1	crappy	
 572	stale Children's Meal of the Damned	3	decent	
-573	bland super-sized tumbling fuchsia noodles	5	decent	
+573	super-sized bland tumbling fuchsia noodles	5	decent	
 574	stale noodles	4	decent	
-575	delicious miniature pulsating painful penne pasta	2	awesome	
+575	miniature delicious pulsating painful penne pasta	2	awesome	
 576	jumbo adequate ravioli della hippy	5	good	
-577	toothsome low-calorie pr0n m4nic0tti	1	awesome	
+577	low-calorie toothsome pr0n m4nic0tti	1	awesome	
 578	decent Hell ramen	3	good	
-579	big moldy boring spaghetti	5	crappy	
+579	moldy big boring spaghetti	5	crappy	
 580	upside-down sauce of the ages	0		
 581	green schmancy cheese sauce	0		
 582	skewed Himalayan Hidalgo sauce	0		
 583	normal lime green skewed fettucini Inconnu	3	good	
-584	snack-sized adequate spaghetti with Skullheads	2	good	
+584	adequate snack-sized spaghetti with Skullheads	2	good	
 585	rotten gnocchetti di Nietzsche	4	crappy	
 586	wobbly steel-toed padded ridiculously huge sword	0		Damage Absorption: +20, Damage Reduction: 9
 587	quadruple-galvanized narrow super-spiky hair gel	0		Effect: "Prelude of Precision", Effect Duration: 33
@@ -608,7 +608,7 @@
 610	squat procrastination potion	0		
 611	D	0		
 612	skewed original G	0		
-613	lime green narrow blinking plot hole	0		
+613	narrow lime green blinking plot hole	0		
 614	triple-activated teal probability potion	0		Effect: "Sated and Furious", Effect Duration: 22
 615	chaos butterfly	0		
 616	furry fur	0		
@@ -636,21 +636,21 @@
 638	lard-coated brainy asshat	0		Mysticality: +5, Sleaze Spell Damage: +25, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	thick rotten abominable snowcone	5	crappy	
 640	Ent cider	1	good	
-641	bland immense bouncing ghostly toast	8	decent	
+641	immense bland bouncing ghostly toast	8	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	normal snack-sized fruitcake	2	good	
+646	snack-sized normal fruitcake	2	good	
 647	fuchsia present	0		Last Available: "2004-11"
 648	up-at-dawn Crimbo sword	0		Adventures: +5, Last Available: "2004-10"
-649	hardened Crimbo hat	0		Damage Reduction: 3, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	upside-down weightlifter's Crimbo pants	0		Muscle: +15, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	hardened Crimbo hat	0		Damage Reduction: 3, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	upside-down weightlifter's Crimbo pants	0		Muscle: +15, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	pulsating ruddy exclusive ultra-rare item	0		Maximum HP Percent: +40
 652	quantum egg	0		
 653	intragalactic rowboat	0		
 654	blinking star	0		
-655	purple blurry line	0		
+655	blurry purple line	0		
 656	star chart	0		
 657	reassuring star sword	0		Spooky Resistance: +1
 658	olive shaking asbestos-lined star crossbow	0		Hot Resistance: +5
@@ -671,14 +671,14 @@
 673	tolerable vodka and cranberry	4	good	
 674	hand-crafted special practically non-alcoholic whiskey	1	EPIC	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 10
 675	lion tamer's skull of the Bonerdagon	0		Experience (familiar): +2
-676	green tumbling dragonbone belt buckle	0		
+676	tumbling green dragonbone belt buckle	0		
 677	badass belt of the ox	0		Muscle: +20
 678	chest of the Bonerdagon	0		
 679	drinkable roll in the hay	3	good	
 680	spirit-forward lousy slap and tickle	5	decent	
-681	practically non-alcoholic perfectly mixed slip 'n' slide	1	super ultra mega turbo EPIC	
+681	perfectly mixed practically non-alcoholic slip 'n' slide	1	super ultra mega turbo EPIC	
 682	weak lousy a sump'm sump'm	2	decent	
-683	irresponsibly strong lousy horizontal tango	6	decent	
+683	lousy irresponsibly strong horizontal tango	6	decent	
 684	perfectly mixed pink pony	3	EPIC	
 685	inspector's Mr. Shirt of the empath of incineration	0		Familiar Weight: +5, Hot Spell Damage: +50, Item Drop: +15
 686	knuckles of horror	0		Spooky Spell Damage: +25
@@ -717,7 +717,7 @@
 721	prompt clever porquoise bracelet	0		Maximum MP: +20, Adventures: +3
 722	red fireproof frosty Temple Grandin's porquoise ring	0		Familiar Weight: +7, Cold Spell Damage: +10, Hot Resistance: +3, Single Equip
 723	snack-sized delicious tumbling Knoll mushroom	2	awesome	
-724	yummy gigantic mushroom	6	awesome	
+724	gigantic yummy mushroom	6	awesome	
 725	huge one million meat pancakes	0		
 726	prompt huge mirror shard	0		Adventures: +3
 727	blinking hedge maze puzzle	0		
@@ -742,21 +742,21 @@
 747	narrow Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	stale warm mushroom	4	decent	
-750	small moldy maroon mushroom quesadilla	2	crappy	
+750	moldy small maroon mushroom quesadilla	2	crappy	
 751	enchanted stale cool mushroom	3	decent	Effect: "Mental A-cue-ity", Effect Duration: 50
 752	decent wobbly cool mushroom casserole	3	good	
-753	moldy immense pointy mushroom	6	crappy	
+753	immense moldy pointy mushroom	6	crappy	
 754	stale wobbly cream of pointy mushroom soup	4	decent	
-755	jumbo normal mushroom	5	good	
+755	normal jumbo mushroom	5	good	
 756	spoiled fancy mushroom	4	crappy	Effect: "Sinuses For Miles", Effect Duration: 20
-757	miniature moldy mushroom	2	crappy	
-758	jumbo delicious ghost cucumber	5	awesome	
+757	moldy miniature mushroom	2	crappy	
+758	delicious jumbo ghost cucumber	5	awesome	
 759	dill	0		
 760	jittery vinegar	0		
 761	brine	0		
 762	artisanal especially salty dog	3	EPIC	
 763	blurry ghostly pickling solution	0		
-764	miniature rotten spinning spectral pickle	2	crappy	
+764	rotten miniature spinning spectral pickle	2	crappy	
 765	briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	aerosolized frozen red cologne of contempt	0		Effect: "Magically Fingered", Effect Duration: 16
@@ -779,7 +779,7 @@
 784	delicious squat Acqua Del Piatto Merlot	4	awesome	Last Available: "2004-10"
 785	raffle ticket	0		
 786	delicious wobbly strawberry	3	awesome	
-787	tolerable irresponsibly strong bottle of rum	7	good	
+787	irresponsibly strong tolerable bottle of rum	7	good	
 788	mediocre squat strawberry daiquiri	4	decent	
 789	mediocre rum and cola	3	decent	
 790	tolerable yellow grog	3	good	
@@ -787,13 +787,13 @@
 792	shaking prompt Golden Mr. Accessory	0		Adventures: +3, Softcore Only
 793	double-dry quadruple-chilled extra-diffused bouncing oil of stability	0		Effect: "Discomfited", Effect Duration: 11
 794	altered oil of slipperiness	0		Effect: "Simulation Stimulation", Effect Duration: 39
-795	triple-distilled smooth teal shaking Acque Luride Grezze Cabernet	9	awesome	Last Available: "2004-10"
+795	triple-distilled smooth shaking teal Acque Luride Grezze Cabernet	9	awesome	Last Available: "2004-10"
 796	purple upside-down censurious rosewater-soaked cement shoes of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +3, Sleaze Resistance: +3, Last Available: "2004-10"
 797	aged rockin' wagon	3	awesome	
-798	watered-down lousy bouncing cyan blurry ocean motion	2	decent	
+798	lousy watered-down blurry bouncing cyan ocean motion	2	decent	
 799	delicious fuzzbump	4	awesome	
-800	big bland poutine	5	decent	
-801	flavorless half-sized Knob stir-fry	2	decent	
+800	bland big poutine	5	decent	
+801	half-sized flavorless Knob stir-fry	2	decent	
 804	bland narrow Knoll stir-fry	3	decent	
 805	decent stir-fry	3	good	
 806	spoiled asparagus stir-fry	4	crappy	
@@ -806,7 +806,7 @@
 813	normal Knob shells	3	good	
 814	stale b&auml;tzle	3	decent	
 815	flavorless diet twirling ratini	1	decent	
-816	immense adequate Knob stroganoff	7	good	
+816	adequate immense Knob stroganoff	7	good	
 817	rotten menudo ravioli	3	crappy	
 818	plus sign	0		
 819	milky potion	0		
@@ -826,7 +826,7 @@
 833	wobbly healthy vorpal blade	0		Maximum HP Percent: +20
 834	Oprah's cornuthaum of the boozehound	0		Maximum MP Percent: +50, Booze Drop: +100, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	ring of aggravate monster of Leguizamo	0		Monster Level: +20
-836	spoiled tiny blurry mind flayer corpse	1	crappy	
+836	tiny spoiled blurry mind flayer corpse	1	crappy	
 837	drinkable Uovo Marcio Shiraz	3	good	Last Available: "2004-10"
 838	reassuring Mafia stogie of courage	0		Spooky Resistance: 4, Last Available: "2004-10"
 839	fortified acceptable Maiali Sifilitici Pinot Noir	5	good	Last Available: "2004-10"
@@ -838,7 +838,7 @@
 845	tumbling MAHI fez of the early riser	0		Adventures: +7, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
-849	wobbly spinning Meat detector	0		Familiar Weight: +5
+849	spinning wobbly Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
 851	prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
@@ -891,8 +891,8 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	delicious fancy weak Spasmi Dolorosi Del Rene Champagne	2	awesome	Effect: "meat.enh", Effect Duration: 40, Last Available: "2004-10"
-904	lard-coated chilly careful school Mafia knickerbockers	0		Monster Level: -10, Cold Damage: +5, Sleaze Spell Damage: +25, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+903	weak fancy delicious Spasmi Dolorosi Del Rene Champagne	2	awesome	Effect: "meat.enh", Effect Duration: 40, Last Available: "2004-10"
+904	lard-coated chilly careful school Mafia knickerbockers	0		Monster Level: -10, Cold Damage: +5, Sleaze Spell Damage: +25, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	frozen Yummy Tummy bean	0		Effect: "OMG WTF", Effect Duration: 41
 906	flattened bouncing Rock Pops	0		Effect: "Nigh-Invincible", Effect Duration: 34
 907	aerosolized Mr. Mediocrebar	0		Effect: "This Is Where You're a Viking", Effect Duration: 29
@@ -901,15 +901,15 @@
 910	snack-sized moldy dwarf bread	2	crappy	
 911	ionized Senior Mints	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 29
 912	altered dry mirror pixellated candy heart	0		Effect: "Bloodstain-Resistant", Effect Duration: 34
-913	non-pressed red blinking kobold	0		Effect: "Ancestral Disapproval", Effect Duration: 13
+913	non-pressed blinking red kobold	0		Effect: "Ancestral Disapproval", Effect Duration: 13
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
-915	maroon huge wobbly yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
+915	maroon wobbly huge yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	greedy scandalous intergalactic pom poms	0		Sleaze Damage: +5, Meat Drop: +20
 917	Mob Penguin protection contract	0		
-918	reassuring Radio Free Baseball Cap	0		Spooky Resistance: +1, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	upside-down chilly Radio Free Pants	0		Cold Damage: +5, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	reassuring Radio Free Baseball Cap	0		Spooky Resistance: +1, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	upside-down chilly Radio Free Pants	0		Cold Damage: +5, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	olive smooth Radio Free Foil	0		Moxie: +15, Last Available: "2006-07"
-921	rotten fancy small radio button candy	2	crappy	Effect: "Super-Electrified", Effect Duration: 10
+921	small rotten fancy radio button candy	2	crappy	Effect: "Super-Electrified", Effect Duration: 10
 922	ruddy severed rocking horse head	0		Maximum HP Percent: +40
 923	wobbly broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -919,9 +919,9 @@
 928	wobbly fuzzy bracelets of wisdom	0		Mysticality: +15
 929	up-at-dawn arse-shooting crossbow	0		Adventures: +5
 931	drinkable spiced rum	3	good	
-932	artisanal spirit-forward maroon eggnog	5	EPIC	
+932	spirit-forward artisanal maroon eggnog	5	EPIC	
 933	normal cyan candy cane	4	good	
-934	decent small gingerbread bugbear	2	good	
+934	small decent gingerbread bugbear	2	good	
 935	huge huge frightening imitation nice watch	0		Spooky Damage: +5, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	razor-sharp bowler	0		Weapon Damage Percent: +25, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	razor-sharp bowler	0		Weapon Damage Percent: +25, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	padded bow staff of the ox	0		Muscle: +20, Damage Absorption: +20, Last Available: "2004-12"
-944	horrifying bowlegged pants	0		Spooky Damage: +25, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	horrifying bowlegged pants	0		Spooky Damage: +25, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	olive blurry wobbly skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -943,13 +943,13 @@
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	narrow clever fez of etymology	0		Maximum MP: +20, Familiar Effect: "1xLep, cap 30"
-956	thick moldy twirling green carob chunk noodles	5	crappy	
+956	moldy thick twirling green carob chunk noodles	5	crappy	
 957	adequate skewed chorizo brownies	4	good	
 958	moldy chocolate and tomato pizza	3	crappy	
-959	wobbly jittery flange	0		
+959	jittery wobbly flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
-962	huge gray velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
+962	gray huge velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	prompt careful plastic seal clubber	0		Monster Level: -10, Adventures: +3
 964	rock-hard plastic turtle tamer of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5
 965	gray double-paned plastic pastamancer of the cougar	0		Moxie: +20, Cold Resistance: +5
@@ -982,34 +982,34 @@
 992	inspector's wool hale plastic Jarlsberg	0		Maximum HP: +20, Cold Resistance: +1, Item Drop: +15
 993	huge occult sage plastic Sneaky Pete of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3, Spell Damage Percent: +25
 994	blinking boxer's plastic Susie	0		Muscle Percent: +10
-995	delicious low-calorie Lucky Surprise Egg	1	awesome	
+995	low-calorie delicious Lucky Surprise Egg	1	awesome	
 998	blurry maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	maid head	0		
 1000	Meat maid	0		
 1002	arcane researcher's Xlyinia's notebook	0		Experience Percent (Mysticality): +10
 1003	soda water	0		
-1004	artisanal triple-distilled blinking bottle of tequila	9	EPIC	
-1005	enchanted artisanal boxed wine	4	EPIC	Effect: "Painted-On Bikini", Effect Duration: 5
+1004	triple-distilled artisanal blinking bottle of tequila	9	EPIC	
+1005	artisanal enchanted boxed wine	4	EPIC	Effect: "Painted-On Bikini", Effect Duration: 5
 1006	normal half-sized cherry	2	good	
 1007	shellacked coconut shell	0		Damage Reduction: 7, Familiar Effect: "1xFairy, cap 7"
 1008	shaking wobbly electrified ice cubes	0		MP Regen Min: 3, MP Regen Max: 5
-1009	perfectly mixed practically non-alcoholic olive vodka martini	1	EPIC	
+1009	practically non-alcoholic perfectly mixed olive vodka martini	1	EPIC	
 1010	hand-crafted shaking whiskey and soda	3	EPIC	
 1011	bad monkey wrench	4	decent	
 1012	spirit-forward acceptable tequila sunrise	5	good	
 1013	artisanal watered-down margarita	2	EPIC	
-1014	bad practically non-alcoholic strawberry wine	1	decent	
-1015	hand-crafted practically non-alcoholic wine spritzer	1	EPIC	
+1014	practically non-alcoholic bad strawberry wine	1	decent	
+1015	practically non-alcoholic hand-crafted wine spritzer	1	EPIC	
 1016	watered-down acceptable perpendicular hula	2	good	
-1017	hand-crafted strong ducha de oro	5	EPIC	
+1017	strong hand-crafted ducha de oro	5	EPIC	
 1018	hand-crafted calle de miel	3	EPIC	
-1019	watered-down perfectly mixed dry vodka martini	2	EPIC	
+1019	perfectly mixed watered-down dry vodka martini	2	EPIC	
 1020	mediocre practically non-alcoholic old-fashioned	1	decent	
-1021	drinkable irresponsibly strong spinning tequila with training wheels	9	good	
+1021	irresponsibly strong drinkable spinning tequila with training wheels	9	good	
 1022	tolerable sangria	3	good	
 1023	bad vesper	3	decent	Last Available: "2004-12"
-1024	drinkable special weak bodyslam	2	good	Effect: "Wit Tea", Effect Duration: 35, Last Available: "2004-12"
-1025	fancy artisanal sangria del diablo	4	EPIC	Effect: "Dilated Pupils", Effect Duration: 30, Last Available: "2004-12"
+1024	weak drinkable special bodyslam	2	good	Effect: "Wit Tea", Effect Duration: 35, Last Available: "2004-12"
+1025	artisanal fancy sangria del diablo	4	EPIC	Effect: "Dilated Pupils", Effect Duration: 30, Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1024,12 +1024,12 @@
 1037	blurry electrified gnauga hide buckler	0		MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 5
 1038	frozen teal Connery's Elixir of Audacity	0		Effect: "Cool, Catlike", Effect Duration: 47
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	boozy tolerable beer	5	good	
+1041	tolerable boozy beer	5	good	
 1042	mansplainer's string of beads	0		Monster Level: +15
 1043	string of beads of the storm	0		Maximum MP Percent: +40
 1044	jittery gray hardened string of beads	0		Damage Reduction: 3
 1045	wizardly plastic bottle opener	0		Mysticality: +25
-1046	curative supercool traffic cone	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	curative supercool traffic cone	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	mediocre N. O. Beer	3	decent	
 1048	modified spinning oyster egg	1		Effect: "Ancient Protected", Effect Duration: 20
 1049	modified narrow oyster egg	1		Effect: "Resilient Spirit", Effect Duration: 25
@@ -1039,7 +1039,7 @@
 1053	distilled oyster egg	1		Effect: "Shredding, Sweating", Effect Duration: 10
 1054	mixed oyster egg	1		Effect: "Holiday Disappointment", Effect Duration: 5
 1055	squat plastic oyster egg	0		
-1056	altered mirror skewed huge puce oyster egg	1		Effect: "The Solution", Effect Duration: 20
+1056	altered skewed huge mirror puce oyster egg	1		Effect: "The Solution", Effect Duration: 20
 1057	powdered blurry puce oyster egg	1		Effect: "Feet of Watermelon", Effect Duration: 15
 1058	denatured blinking puce oyster egg	1		
 1059	puce plastic oyster egg	0		
@@ -1056,11 +1056,11 @@
 1070	boiled wobbly oyster egg	1		Effect: "Spell Transfer Complete", Effect Duration: 20
 1071	plastic oyster egg	0		
 1072	twisted shaking off-white oyster egg	1		Effect: "Tomato Power", Effect Duration: 15
-1073	compressed skewed red blurry off-white oyster egg	1		
+1073	compressed red skewed blurry off-white oyster egg	1		
 1074	dried off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	dehydrated oyster egg	1		
-1077	denatured narrow red wobbly oyster egg	1		
+1077	denatured narrow wobbly red oyster egg	1		
 1078	dried twirling oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
@@ -1075,7 +1075,7 @@
 1089	clockwork spine	0		
 1090	clockwork rings	0		
 1091	clockwork claws	0		
-1092	huge twirling clockwork sheet	0		
+1092	twirling huge clockwork sheet	0		
 1093	red clockwork counterclockwise dome	0		
 1094	tumbling clockwork sphere	0		
 1095	deactivated MicroMechaMech	0		
@@ -1124,19 +1124,19 @@
 1138	mushroom fermenting solution	0		
 1139	acceptable olive mushroom wine	4	good	
 1140	practically non-alcoholic artisanal icy mushroom wine	1	super ultra mega turbo EPIC	
-1141	lousy fortified mushroom wine	5	decent	
-1142	lousy weak wobbly pointy mushroom wine	2	decent	
-1143	watered-down lousy flat mushroom wine	2	decent	
+1141	fortified lousy mushroom wine	5	decent	
+1142	weak lousy wobbly pointy mushroom wine	2	decent	
+1143	lousy watered-down flat mushroom wine	2	decent	
 1144	bad gray cool mushroom wine	4	decent	
 1145	triple-distilled hand-crafted knob mushroom wine	8	EPIC	
 1146	smooth narrow knoll mushroom wine	4	awesome	
 1147	delicious high-proof mushroom wine	10	awesome	
 1148	watered-down aged shot of flower schnapps	2	awesome	
-1149	immense decent wobbly flower petal pie	10	good	
-1150	artisanal high-proof bottle of single-barrel whiskey	8	EPIC	
+1149	decent immense wobbly flower petal pie	10	good	
+1150	high-proof artisanal bottle of single-barrel whiskey	8	EPIC	
 1151	steel-toed deadly discarded plastic fork	0		Weapon Damage: +5, Damage Reduction: 9
 1152	shaking gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	enchanted tasty Retenez L'Herbe Pat&eacute;	3	awesome	Effect: "Gemini Rising", Effect Duration: 45
+1153	tasty enchanted Retenez L'Herbe Pat&eacute;	3	awesome	Effect: "Gemini Rising", Effect Duration: 45
 1154	mixed Breathetastic&trade; Premium Canned Air	1	good	Effect: "Chalked-Up Teeth", Effect Duration: 35
 1155	letter from King Ralph XI	0		
 1157	blurry censurious wholeberd	0		Sleaze Resistance: +3
@@ -1148,12 +1148,12 @@
 1163	super-polarized flattened marzipan skull	0		Effect: "Gunky Dory", Effect Duration: 39
 1164	poultrygeist	0		
 1165	hovering sombrero	0		
-1166	narrow spinning maracas	0		Familiar Weight: +5
+1166	spinning narrow maracas	0		Familiar Weight: +5
 1167	huge plain brown wrapper	0		
 1168	ghostly less-than-three-shaped box	0		
 1169	jittery exactly-three-shaped box	0		
 1170	teal chocolate box	0		
-1171	tumbling narrow coffin	0		
+1171	narrow tumbling coffin	0		
 1172	asbestos box	0		
 1173	linoleum box	0		
 1174	chrome box	0		
@@ -1187,12 +1187,12 @@
 1202	special small bland Happy Birthday, Claude! cake	2	decent	Effect: "Unusual Perspective", Effect Duration: 50
 1203	miniature rotten ghostly personalized birthday cake	2	crappy	
 1204	rotten huge three-tiered wedding cake	6	crappy	
-1205	massive delicious babycakes	6	awesome	
+1205	delicious massive babycakes	6	awesome	
 1206	stale blinking velvet cake	3	decent	
-1207	spoiled miniature congratulatory cake	2	crappy	
+1207	miniature spoiled congratulatory cake	2	crappy	
 1208	immense yummy maroon angel-food cake	10	awesome	
 1209	yummy devil's-food cake	3	awesome	
-1210	diet moldy teal birthday party jellybean cheesecake	1	crappy	
+1210	moldy diet teal birthday party jellybean cheesecake	1	crappy	
 1211	wobbly balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
@@ -1233,22 +1233,22 @@
 1249	twirling Fonzie's Boss Bat britches	0		Experience (Moxie): +1, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	squat Boss Bat bling of terror of bravery	0		Spooky Spell Damage: +10, Spooky Resistance: +5
 1251	flavorless Knob shroomkabob	3	decent	
-1252	decent half-sized shroomkabob	2	good	
+1252	half-sized decent shroomkabob	2	good	
 1253	wobbly pile of jumping beans	0		
 1254	rotten special jumping bean burrito	3	crappy	Effect: "Beastly Flavor", Effect Duration: 15
 1255	yummy jumping bean burrito	3	awesome	
 1256	delicious insanely jumping bean burrito	3	awesome	
 1257	super-sized tasty rat scrapple	5	awesome	
 1258	tumbling pail of pretentious paint	0		
-1259	traffic cone of chilblains of bravery	0		Cold Damage: +25, Spooky Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
-1260	ghostly teal wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
+1259	traffic cone of chilblains of bravery	0		Cold Damage: +25, Spooky Resistance: +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1260	teal ghostly wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	vaporized lime green Hatorade	1		Effect: "Smoky Third Eye", Effect Duration: 50
 1262	foul-smelling Samson's off-hand balloon of Leguizamo	0		Experience (Muscle): +5, Monster Level: +20, Stench Damage: +10
 1263	squat pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
-1266	bland enchanted gloomy mushroom	4	decent	Effect: "Nano-juiced", Effect Duration: 15
-1267	blurry upside-down dead mimic	0		
+1266	enchanted bland gloomy mushroom	4	decent	Effect: "Nano-juiced", Effect Duration: 15
+1267	upside-down blurry dead mimic	0		
 1268	pine wand	0		
 1269	twirling ebony wand	0		
 1270	fuchsia squat hexagonal wand	0		
@@ -1287,10 +1287,10 @@
 1303	Mjolnir Jr.	0		
 1304	huge doppelshifter egg	0		Free Pull
 1305	blinking makeup kit	0		Familiar Weight: +15
-1306	avaricious traffic cone of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	avaricious traffic cone of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
-1309	fuchsia jittery attention spanner	0		Familiar Weight: +5
+1309	jittery fuchsia attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
 1311	shaking comfy blanket	0		Last Available: "2005-10"
 1312	Da Vinci's Baron von Ratsworth's monocle	0		Experience (Mysticality): +5, Single Equip
@@ -1301,11 +1301,11 @@
 1317	spinning blood flower	0		
 1318	lovecat tail	0		
 1319	maroon plastic passion fruit	0		
-1320	special adequate questionable taco	4	good	Effect: "Slimily Sagacious", Effect Duration: 35
+1320	adequate special questionable taco	4	good	Effect: "Slimily Sagacious", Effect Duration: 35
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	blue petrified time	0		Last Available: "2005-10"
-1323	gray stanky time helmet	0		Stench Spell Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	bouncing electrified time trousers	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	gray stanky time helmet	0		Stench Spell Damage: +25, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	bouncing electrified time trousers	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	cool time sword	0		Moxie: +5, Last Available: "2005-10"
 1326	arcane researcher's Dyspepsi-Cola helmet	0		Experience Percent (Mysticality): +10, Familiar Effect: "3xFairy, cap 7"
 1327	blurry toasty Cloaca-Cola shield	0		Hot Damage: +5, Damage Reduction: 4
@@ -1318,7 +1318,7 @@
 1334	Cloaca-Cola	0		
 1335	Dyspepsi grenade	0		
 1336	shaking Cloaca grenade	0		
-1338	blurry gray Dyspepsi-Cola d-rations	0		
+1338	gray blurry Dyspepsi-Cola d-rations	0		
 1339	tumbling Cloaca-Cola c-rations	0		
 1340	bouncing Cloaca-Cola-issue combat knife	0		
 1341	shaking greedy Dyspepsi-Cola-issue canteen	0		Meat Drop: +20, Single Equip
@@ -1347,8 +1347,8 @@
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	adequate super-sized tofurkey leg	5	good	
 1366	gigantic rotten huge tofurkey gravy	10	crappy	
-1367	half-sized adequate enchanted herbal stuffing	2	good	Effect: "Total Protonic Reversal", Effect Duration: 5
-1368	moldy super-sized can-shaped gelatinous cranberry sauce	5	crappy	
+1367	adequate enchanted half-sized herbal stuffing	2	good	Effect: "Total Protonic Reversal", Effect Duration: 5
+1368	super-sized moldy can-shaped gelatinous cranberry sauce	5	crappy	
 1369	adequate yams	4	good	
 1370	reassuring rhinestone cowboy shirt	0		Spooky Resistance: +1
 1371	beefy gingham blouse	0		Muscle: +10
@@ -1384,39 +1384,39 @@
 1402	padded rag doll	0		Damage Absorption: +20, Last Available: "2005-12"
 1403	cyan can of fake snow of the wise owl	0		Mysticality: +20, Last Available: "2005-12"
 1404	colored-light &quot;necklace&quot; of the glutton	0		Food Drop: +100, Last Available: "2005-12"
-1405	bouncing tree skirt of the businessman	0		Meat Drop: +50, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	flavorless miniature enchanted tumbling wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	half-sized adequate bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1405	bouncing tree skirt of the businessman	0		Meat Drop: +50, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1406	enchanted flavorless miniature tumbling wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1407	adequate half-sized bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	stale pulsating tree-shaped Crimbo cookie	4	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	chilly Unionize The Elves sign	0		Cold Damage: +5, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	narrow Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	narrow Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	electrified snowcone	0		Effect: "In the Slimelight", Effect Duration: 52, Last Available: "2006-01"
-1413	liquefied electrified blinking blue snowcone	0		Effect: "Adorable Lookout", Effect Duration: 63, Last Available: "2006-01"
+1413	liquefied electrified blue blinking snowcone	0		Effect: "Adorable Lookout", Effect Duration: 63, Last Available: "2006-01"
 1414	alkaline alkaline gray snowcone	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 16, Last Available: "2006-01"
 1415	vacuum-sealed purple snowcone	0		Effect: "Lobos Fresh", Effect Duration: 63, Last Available: "2006-01"
 1416	non-unsweetened snowcone	0		Effect: "Smokin'", Effect Duration: 51, Last Available: "2006-01"
 1417	energized polarized snowcone	0		Effect: "So You Can Work More...", Effect Duration: 16, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
-1419	green mirror tumbling teddy bear sewing kit	0		Last Available: "2006-01"
-1420	padded traffic cone of the boozehound	0		Damage Absorption: +20, Booze Drop: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1419	mirror tumbling green teddy bear sewing kit	0		Last Available: "2006-01"
+1420	padded traffic cone of the boozehound	0		Damage Absorption: +20, Booze Drop: +100, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	mirror Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	hardened fortified ice sickle	0		Damage Absorption: +60, Damage Reduction: 3, Softcore Only, Last Available: "2006-02"
 1425	ice baby of the pedagogue	0		Experience: +3, Softcore Only, Last Available: "2006-02"
-1426	ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	huge scandalous healthy ice skates	0		Maximum HP Percent: +20, Sleaze Damage: +5, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	miniature stale bouncing grue egg omelette	2	decent	
+1428	stale miniature bouncing grue egg omelette	2	decent	
 1429	roll of drink tickets	0		
 1430	mirror upside-down pregnant gloomy mushroom	0		
-1431	upside-down spinning pregnant mushroom	0		
-1432	miniature adequate teal mushroom	2	good	
+1431	spinning upside-down pregnant mushroom	0		
+1432	adequate miniature teal mushroom	2	good	
 1433	fruit bowl	0		
 1434	mirror fruit basket	0		
 1435	twirling hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
-1437	spinning blinking useless powder	0		
+1437	blinking spinning useless powder	0		
 1438	tarnished maroon twinkly powder	0		Effect: "Bestial Sympathy", Effect Duration: 16
 1439	pressed liquefied wobbly ghostly hot powder	0		Effect: "Florid Cheeks", Effect Duration: 29
 1440	wet powder	0		Effect: "Heart of Orange", Effect Duration: 41
@@ -1436,7 +1436,7 @@
 1454	dried green stench wad	1		Effect: "Think Win-Lose", Effect Duration: 50
 1455	vaporized sleaze wad	1		
 1456	double daisy	0		
-1457	fuchsia ghostly Goth Giant	0		
+1457	ghostly fuchsia Goth Giant	0		
 1458	rotten Valentine's Day cake	3	crappy	
 1459	narrow arrow'd heart balloon	0		
 1460	velvet box	0		
@@ -1466,7 +1466,7 @@
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	blue deadly smartaleck's rabbit's foot	0		Moxie Percent: +30, Weapon Damage: +5
 1486	upside-down massive bag of catnip	0		
-1487	red shaking hang glider	0		
+1487	shaking red hang glider	0		
 1488	March hat	0		Free Pull
 1489	dormouse	0		
 1490	wobbly coward's chopsticks of bravery	0		Monster Level: -20, Spooky Resistance: +5
@@ -1474,10 +1474,10 @@
 1492	lightning-fast ninja mop	0		Initiative: +40
 1493	lion tamer's ridiculously overelaborate ninja weapon of Tarzan	0		Experience (Muscle): +3, Experience (familiar): +2
 1494	enhanced tumbling sugar-coated pine cone	0		Effect: "Mushroom Magicalness", Effect Duration: 15, Last Available: "2020-09"
-1495	traffic cone of mayonnaise of the sweet-tooth	0		Sleaze Spell Damage: +50, Candy Drop: +100, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	extra-dry mediocre spinning gloomy mushroom wine	5	decent	
+1495	traffic cone of mayonnaise of the sweet-tooth	0		Sleaze Spell Damage: +50, Candy Drop: +100, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1496	mediocre extra-dry spinning gloomy mushroom wine	5	decent	
 1497	lousy mushroom wine	3	decent	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	activated tarnished blurry explosion-flavored chewing gum	0		Effect: "Fire Inside", Effect Duration: 36, Last Available: "2006-04"
@@ -1486,9 +1486,9 @@
 1504	pressed triple-cold-filtered snowcone	0		Effect: "Sweet and Yellow", Effect Duration: 14, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	tolerable calle de miel with a fly in it	3	good	Last Available: "2006-04"
-1507	enchanted lousy huge jittery rockin' wagon with a fly in it	3	decent	Effect: "Tiki Toughness", Effect Duration: 10, Last Available: "2006-04"
+1507	lousy enchanted jittery huge rockin' wagon with a fly in it	3	decent	Effect: "Tiki Toughness", Effect Duration: 10, Last Available: "2006-04"
 1508	drinkable perpendicular hula with a fly in it	3	good	Last Available: "2006-04"
-1509	perfectly mixed practically non-alcoholic slap and tickle with a fly in it	1	EPIC	Last Available: "2006-04"
+1509	practically non-alcoholic perfectly mixed slap and tickle with a fly in it	1	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	lion tamer's fake hand	0		Experience (familiar): +2, Last Available: "2006-04"
 1512	diluted Knob Goblin pet-buffing spray	1		
@@ -1501,25 +1501,25 @@
 1520	twirling energetic slick Radio KoL Coffee Mug	0		Moxie: +10, Maximum MP Percent: +20
 1521	Frank Gorshin trophy	0		
 1522	auspicious Radio Free Jersey of the early riser	0		Item Drop: +10, Adventures: +7
-1523	huge spinning bottle of used blood	0		
+1523	spinning huge bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	squat joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
-1527	mirror skewed diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
+1525	squat joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1527	skewed mirror diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	skewed stanky smartaleck's corkscrew	0		Moxie Percent: +30, Stench Spell Damage: +25, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	skewed grass skirt of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	bouncing grass hat of temperance	0		Sleaze Resistance: +5, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	skewed grass skirt of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	bouncing grass hat of temperance	0		Sleaze Resistance: +5, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	huge twirling grass blade of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-01"
 1534	blue raffle prize box	0		
 1536	olive pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	skewed sage sparkly engagement ring	0		Mysticality Percent: +10, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	careful groovy Grimacite goggles	0		Moxie Percent: +10, Monster Level: -10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	careful groovy Grimacite goggles	0		Moxie Percent: +10, Monster Level: -10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	frightening Da Vinci's Grimacite glaive	0		Experience (Mysticality): +5, Spooky Damage: +5, Last Available: "2008-10"
-1542	clever fortified Grimacite greaves	0		Damage Absorption: +60, Maximum MP: +20, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	clever fortified Grimacite greaves	0		Damage Absorption: +60, Maximum MP: +20, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	clever Grimacite garter of the cheetah	0		Maximum MP: +20, Initiative: +60, Last Available: "2008-10"
 1544	Jack Frost's electrified Grimacite galoshes	0		Cold Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-10"
 1545	rosewater-soaked forbidden Grimacite gorget	0		Spell Damage Percent: +50, Stench Resistance: +3, Last Available: "2008-10"
@@ -1528,42 +1528,42 @@
 1548	teal frosty weightlifter's Gazpacho's Glacial Grimoire	0		Muscle: +15, Cold Spell Damage: +10
 1549	MSG	0		
 1550	narrow second-hand knockoff engagement ring of courage	0		Spooky Resistance: +3, Single Equip
-1551	tolerable practically non-alcoholic bottle of Domesticated Turkey	1	good	
-1552	acceptable watered-down bottle of Definit	2	good	
+1551	practically non-alcoholic tolerable bottle of Domesticated Turkey	1	good	
+1552	watered-down acceptable bottle of Definit	2	good	
 1553	mediocre jittery bottle of Calcutta Emerald	4	decent	
 1554	artisanal red bottle of Lieutenant Freeman	4	EPIC	
-1555	watered-down hand-crafted narrow bottle of Jorge Sinsonte	2	EPIC	
-1556	tolerable spirit-forward fancy ghostly boxed champagne	5	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5
+1555	hand-crafted watered-down narrow bottle of Jorge Sinsonte	2	EPIC	
+1556	fancy tolerable spirit-forward ghostly boxed champagne	5	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5
 1557	normal gigantic narrow kumquat	8	good	
-1558	small enchanted spoiled tangerine	2	crappy	Effect: "Nut-Rition", Effect Duration: 40
+1558	spoiled small enchanted tangerine	2	crappy	Effect: "Nut-Rition", Effect Duration: 40
 1559	tonic water	0		
 1560	stale cocktail onion	3	decent	
 1561	normal half-sized bouncing raspberry	2	good	
 1562	massive moldy kiwi	6	crappy	
 1563	bad whiskey bittersweet	4	decent	
-1564	weak tolerable mimosette	2	good	
+1564	tolerable weak mimosette	2	good	
 1565	tolerable tequila sunset	3	good	
 1566	drinkable pulsating zmobie	4	good	Wiki Name: "Zmobie (drink)"
 1567	smooth shaking gin and tonic	3	awesome	
 1568	artisanal narrow vodka and tonic	4	EPIC	
-1569	enchanted acceptable weak maroon vodka gibson	2	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45
-1570	irresponsibly strong smooth mirror skewed gibson	9	awesome	
+1569	weak acceptable enchanted maroon vodka gibson	2	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45
+1570	irresponsibly strong smooth skewed mirror gibson	9	awesome	
 1571	mediocre parisian cathouse	3	decent	
-1572	lousy enchanted maroon rabbit punch	4	decent	Effect: "Macho Profundo", Effect Duration: 10
+1572	enchanted lousy maroon rabbit punch	4	decent	Effect: "Macho Profundo", Effect Duration: 10
 1573	tolerable caipifruta	3	good	
-1574	watered-down artisanal teqiwila	2	EPIC	
+1574	artisanal watered-down teqiwila	2	EPIC	
 1575	tolerable weak ghostly Divine	2	good	
-1576	bad fancy tumbling Gordon Bennett	4	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 35
+1576	fancy bad tumbling Gordon Bennett	4	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 35
 1577	mediocre tangarita	4	decent	
 1578	tolerable narrow mandarina colada	4	good	
-1579	perfectly mixed watered-down gimlet	2	super ultra EPIC	
-1580	irresponsibly strong mediocre brick road	7	decent	
+1579	watered-down perfectly mixed gimlet	2	super ultra EPIC	
+1580	mediocre irresponsibly strong brick road	7	decent	
 1581	bad vodka stratocaster	4	decent	
 1582	mediocre Neuromancer	4	decent	
 1583	perfectly mixed prussian cathouse	3	EPIC	
 1584	tolerable squat Mae West	4	good	
 1585	tolerable Mon Tiki	4	good	
-1586	fancy drinkable blurry green teqiwila slammer	3	good	Effect: "Dreadful Chill", Effect Duration: 45
+1586	fancy drinkable green blurry teqiwila slammer	3	good	Effect: "Dreadful Chill", Effect Duration: 45
 1587	spoiled squat Knob lo mein	3	crappy	
 1588	stale asparagus lo mein	4	decent	
 1589	immense rotten gray Knoll lo mein	10	crappy	
@@ -1573,27 +1573,27 @@
 1593	decent hi mein	3	good	
 1594	moldy shaking hi mein	3	crappy	
 1595	diet stale red hi mein	1	decent	
-1596	diet moldy shaking sleazy hi mein	1	crappy	
+1596	moldy diet shaking sleazy hi mein	1	crappy	
 1597	huge Newton's Junior LAAAAME merit badge	0		Experience (Mysticality): +3, Last Available: "2006-05"
 1598	Senior LAAAAME merit badge of bravery	0		Spooky Resistance: +5, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	enchanted distilled smooth tangarita with a fly in it	5	awesome	Effect: "Vinegavotte", Effect Duration: 20
+1600	smooth enchanted distilled tangarita with a fly in it	5	awesome	Effect: "Vinegavotte", Effect Duration: 20
 1601	bad practically non-alcoholic mandarina colada with a fly in it	1	decent	
 1602	acceptable prussian cathouse with a fly in it	3	good	
-1603	bad practically non-alcoholic Mae West with a fly in it	1	decent	
+1603	practically non-alcoholic bad Mae West with a fly in it	1	decent	
 1604	denatured squat astronaut ice-cream	1		Effect: "Antsy in your Pantsy", Effect Duration: 15, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	powdered narrow ultimate wad	1		
 1607	moist ghostly twirling libation of liveliness	0		Effect: "Super-Mega-Charged", Effect Duration: 33
 1608	super-vacuum-sealed eyedrops of the ermine	0		Effect: "Mushroom Samba", Effect Duration: 30
 1609	super-ionized super-deionized twirling perfume of prejudice	0		Effect: "All Is Forgiven", Effect Duration: 51
-1610	boiled electrified jittery purple eyedrops of the ocelot	0		Effect: "Remaining Alive", Effect Duration: 26
-1611	polarized diffused purple ghostly potent potion of potency	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
+1610	boiled electrified purple jittery eyedrops of the ocelot	0		Effect: "Remaining Alive", Effect Duration: 26
+1611	polarized diffused ghostly purple potent potion of potency	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
 1612	moist concentrated cordial of concentration	0		Effect: "Shot in the Arse", Effect Duration: 62
 1613	clever coffin lid	0		Maximum MP: +20, Damage Reduction: 3
 1614	horrifying satin shield	0		Spooky Damage: +25, Damage Reduction: 5
-1615	pulsating smelly Cerebral Cloche	0		Stench Spell Damage: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	blinking Cerebral Culottes of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	pulsating smelly Cerebral Cloche	0		Stench Spell Damage: +10, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	blinking Cerebral Culottes of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	vibrating baleful Cerebral Crossbow of the glutton	0		Spell Damage: +25, Maximum MP Percent: +10, Food Drop: +100, Last Available: "2006-06"
 1618	shaking ice stein	0		Last Available: "2006-06"
 1619	tumbling munchies pill	0		Last Available: "2006-06"
@@ -1616,7 +1616,7 @@
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	dry blinking lotion of hotness	0		Effect: "Uncucumbered", Effect Duration: 47
 1638	vacuum-sealed upside-down lotion of coldness	0		Effect: "Strawberry Alarm", Effect Duration: 49
-1639	boiled bouncing lime green lotion of spookiness	0		Effect: "Nightlit", Effect Duration: 25
+1639	boiled lime green bouncing lotion of spookiness	0		Effect: "Nightlit", Effect Duration: 25
 1640	diffused triple-modified lotion of stench	0		Effect: "Human-Pirate Hybrid", Effect Duration: 44
 1641	energized lotion of sleaziness	0		Effect: "Took Eleven", Effect Duration: 49
 1642	aged Grimacite Bock	4	awesome	Last Available: "2008-11"
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	immense adequate twirling foie gras	8	good	
 1652	altered wobbly blue candy brain	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 50, Last Available: "2020-09"
-1653	crafty Socratic jewel-eyed wizard hat of the businessman	0		Experience (Mysticality): +1, Maximum MP: +10, Meat Drop: +50, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	crafty Socratic jewel-eyed wizard hat of the businessman	0		Experience (Mysticality): +1, Maximum MP: +10, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	aromatic dog trainer's wad of Crovacite	0		Experience (familiar): +1, Stench Resistance: +1
 1655	rosy-cheeked collar of doom	0		Maximum HP Percent: +30, Spooky Spell Damage: +50
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	jittery pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	jittery pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	squat cyan rosy-cheeked sword of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25
 1680	twirling maroon staff of the brute of the glutton	0		Muscle Percent: +30, Food Drop: +100
 1681	experienced bubblewrap sword of the blizzard	0		Experience: +2, Cold Spell Damage: +25
@@ -1670,10 +1670,10 @@
 1690	scorching chilly discarded bottlecap	0		Cold Damage: +5, Hot Damage: +25, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	greasy discarded torn-up glove of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	nitrogenated boiled wobbly shaking lime green salamander slurry	0		Effect: "Human-Slime Hybrid", Effect Duration: 54
-1693	wet blurry blurry jittery eyedrops of newt	0		Effect: "Marbles in Your Mouth", Effect Duration: 65
+1693	wet blurry jittery blurry eyedrops of newt	0		Effect: "Marbles in Your Mouth", Effect Duration: 65
 1694	double-anodized Frogade	0		Effect: "Arresistible", Effect Duration: 55
 1695	corrupted ionized energized papotion of papower	0		Effect: "Yuletide Sappiness", Effect Duration: 29
-1696	flavorless low-calorie royal jelly taco	1	decent	
+1696	low-calorie flavorless royal jelly taco	1	decent	
 1697	stale tofu taco	4	decent	
 1698	spoiled bouncing jumping bean taco	3	crappy	
 1699	spoiled bite-sized wobbly catgut taco	1	crappy	
@@ -1702,7 +1702,7 @@
 1722	censurious glistening staff of the detective	0		Sleaze Resistance: +3, Item Drop: +20
 1723	tumbling Sinatra's repeating crossbow of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10
 1725	bigger stick	0		
-1726	red squat jittery sinewy crossbow string	0		
+1726	squat red jittery sinewy crossbow string	0		
 1727	sturdy sword hilt	0		
 1728	foul-smelling dense meat sword	0		Stench Damage: +10
 1729	dog trainer's dense meat staff	0		Experience (familiar): +1
@@ -1766,9 +1766,9 @@
 1787	non-frozen irradiated blurry bag of Cheat-Os	0		Effect: "Industrial Strength Starch", Effect Duration: 60
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	special tolerable high-proof Ram's Face Lager	7	good	Effect: "Techno Bliss", Effect Duration: 45
+1790	high-proof special tolerable Ram's Face Lager	7	good	Effect: "Techno Bliss", Effect Duration: 45
 1791	upside-down ram horns	0		
-1792	green bouncing auspicious sizzling beefcake's Travoltan trousers	0		Muscle: +25, Hot Damage: +10, Item Drop: +10, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	green bouncing auspicious sizzling beefcake's Travoltan trousers	0		Muscle: +25, Hot Damage: +10, Item Drop: +10, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	scorching careful pool cue	0		Monster Level: -10, Hot Damage: +25
 1794	Vulcanized irradiated narrow handful of hand chalk	0		Effect: "Voracious Gorging", Effect Duration: 16
 1795	baleful Counterclockwise Watch	0		Spell Damage: +25, Single Equip
@@ -1810,7 +1810,7 @@
 1831	third caudal vertebra	0		
 1832	squat fourth caudal vertebra	0		
 1833	upside-down fifth caudal vertebra	0		
-1834	twirling blurry sixth caudal vertebra	0		
+1834	blurry twirling sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
 1836	eighth caudal vertebra	0		
 1837	twirling ninth caudal vertebra	0		
@@ -1858,7 +1858,7 @@
 1879	right fibula	0		
 1880	left kneecap	0		
 1881	right kneecap	0		
-1882	ghostly squat left first front claw	0		
+1882	squat ghostly left first front claw	0		
 1883	tumbling left second front claw	0		
 1884	narrow left third front claw	0		
 1885	left fourth front claw	0		
@@ -1890,7 +1890,7 @@
 1913	clockwork handle	0		
 1914	ghostly clockwork rod	0		
 1915	huge narrow clockwork shank	0		
-1916	ghostly fuchsia skewed Lord Spookyraven's spectacles	0		
+1916	skewed ghostly fuchsia Lord Spookyraven's spectacles	0		
 1917	wallet	0		
 1918	coin purse	0		
 1919	blurry English to A. F. U. E. Dictionary	0		
@@ -1923,14 +1923,14 @@
 1946	Herculean beefy accordion pin	0		Muscle: +10, Experience (Muscle): +1, Class: "Accordion Thief", Single Equip
 1947	skewed foul-smelling worn tophat of the businessman	0		Stench Damage: +10, Meat Drop: +50, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	jittery narrow zippy sinister tap shoes	0		Spell Damage: +10, Initiative: +20, Single Equip
-1949	bland diet Manetwich	1	decent	
+1949	diet bland Manetwich	1	decent	
 1950	narrow bottle of Vangoghbitussin	0		
-1951	mediocre practically non-alcoholic upside-down bottle of Pinot Renoir	1	decent	
+1951	practically non-alcoholic mediocre upside-down bottle of Pinot Renoir	1	decent	
 1952	small rotten desiccated apricot	2	crappy	
 1953	delicious fuchsia flute of flat champagne	4	awesome	
 1954	stale low-calorie dehydrated caviar	1	decent	
 1955	styrofoam peanuts	0		
-1956	aged irresponsibly strong snifter of thoroughly aged brandy	9	awesome	
+1956	irresponsibly strong aged snifter of thoroughly aged brandy	9	awesome	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	squat tattered scrap of paper	0		
@@ -1948,7 +1948,7 @@
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	upside-down Jeselnik's wicked shrimp fork	0		Spell Damage: +5, Sleaze Damage: +25
 1973	shaking half of a memo	0		
-1974	fuchsia bouncing cocoabo	0		
+1974	bouncing fuchsia cocoabo	0		
 1975	jittery baby gravy fairy	0		
 1976	gray gravy fairy	0		
 1977	purple gravy fairy	0		
@@ -1959,7 +1959,7 @@
 1982	blinking MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	yellow snowy owl	0		
-1985	wobbly jittery scary death orb	0		
+1985	jittery wobbly scary death orb	0		
 1986	mind flayer	0		
 1987	undead elbow macaroni	0		
 1988	angry cow	0		
@@ -1995,14 +1995,14 @@
 2018	pulsating club necklace	0		
 2019	cream pie	0		Free Pull
 2020	rotten cherry pie	4	crappy	
-2021	normal bite-sized twirling strawberry pie	1	good	
-2022	bland bite-sized lemon meringue pie	1	decent	
+2021	bite-sized normal twirling strawberry pie	1	good	
+2022	bite-sized bland lemon meringue pie	1	decent	
 2023	lime green Genalen&trade; Bottle	1	good	
-2024	stale gigantic mixed wildflower greens	7	decent	
+2024	gigantic stale mixed wildflower greens	7	decent	
 2025	moldy handful of walnuts	3	crappy	
 2026	miniature decent lime green nutty organic salad	2	good	
 2027	decent super salad	3	good	
-2028	moldy shaking pulsating tofu wonton	3	crappy	
+2028	moldy pulsating shaking tofu wonton	3	crappy	
 2029	hippy protest button	0		Single Equip
 2030	chaotic rock-hard Lockenstock&trade; sandals	0		Damage Reduction: 5, Spell Critical Percent: +10, Single Equip
 2031	miser's didgeridooka	0		Meat Drop: +10
@@ -2020,8 +2020,8 @@
 2043	blue upside-down hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	big bland brain-meltingly-hot chicken wings	5	decent	
-2046	bland special wobbly frat brats	3	decent	Effect: "Boon of She-Who-Was", Effect Duration: 50
-2047	flavorless snack-sized mirror knob ka-bobs	2	decent	
+2046	special bland wobbly frat brats	3	decent	Effect: "Boon of She-Who-Was", Effect Duration: 50
+2047	snack-sized flavorless mirror knob ka-bobs	2	decent	
 2049	fancy drinkable purple can of Swiller	3	good	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 40
 2050	broken wings	0		
 2051	spinning cyan sunken eyes	0		
@@ -2032,7 +2032,7 @@
 2056	flattened adder bladder	0		Effect: "So Fresh and So Clean", Effect Duration: 46
 2057	pension check	0		
 2058	huge picnic basket	0		
-2059	extra-chilled skewed shaking Black No. 2	0		Effect: "Banono", Effect Duration: 23
+2059	extra-chilled shaking skewed Black No. 2	0		Effect: "Banono", Effect Duration: 23
 2060	steel-toed personal trainer's sword	0		Experience Percent (Muscle): +10, Damage Reduction: 9
 2061	Jim Carey's helmet	0		Monster Level: +25, Familiar Effect: "1xFairy, cap 40"
 2062	Temple Grandin's sage shield	0		Mysticality Percent: +10, Familiar Weight: +7, Damage Reduction: 10
@@ -2067,7 +2067,7 @@
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	bouncing squat horrifying hors d'oeuvre tray	0		Spooky Damage: +25, Damage Reduction: 5
-2094	normal gigantic special ballroom blintz	6	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 50
+2094	gigantic normal special ballroom blintz	6	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 50
 2095	towel	0		
 2096	powdered guy made of bee pollen	1		
 2097	upside-down cyan 17-ball of the sewer	0		Stench Damage: +25
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	skewed gray groovy prehistoric spear	0		Moxie Percent: +10, Last Available: "2006-12"
 2116	huge stick-on-a-string	0		Last Available: "2006-12"
-2117	blinking censurious fire of temperance	0		Sleaze Resistance: 8, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	blinking censurious fire of temperance	0		Sleaze Resistance: 8, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	huge leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	squat Grateful Undead T-shirt of the detective	0		Item Drop: +20
@@ -2112,7 +2112,7 @@
 2137	toy crazy train of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2006-12"
 2138	huge razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	toy mercenary	0		Last Available: "2006-12"
-2140	blurry huge narrow length of string	0		Last Available: "2011-12"
+2140	huge blurry narrow length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
 2142	teal block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
@@ -2121,7 +2121,7 @@
 2146	twirling evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	stale fancy super-sized frank	5	decent	Effect: "Good Motivator", Effect Duration: 35, Last Available: "2011-12"
+2149	stale super-sized fancy frank	5	decent	Effect: "Good Motivator", Effect Duration: 35, Last Available: "2011-12"
 2150	stale small plate of franks and beans	2	decent	Last Available: "2011-12"
 2151	perfectly mixed shot of blackberry schnapps	3	EPIC	
 2152	spinning gray capacitor relay	0		Last Available: "2011-12"
@@ -2141,11 +2141,11 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	inspector's manspreader's toy ray gun	0		Monster Level: +10, Item Drop: +15, Last Available: "2006-12"
-2169	blinking toy space helmet of Gandalf of the scaredy-cat	0		Spell Critical Percent: +20, Monster Level: -15, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	blinking toy space helmet of Gandalf of the scaredy-cat	0		Spell Critical Percent: +20, Monster Level: -15, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	fuchsia rosewater-soaked brawny astronaut pants	0		Muscle Percent: +20, Stench Resistance: +3, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	fuchsia rosewater-soaked brawny astronaut pants	0		Muscle Percent: +20, Stench Resistance: +3, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	dog trainer's toy jet pack	0		Experience (familiar): +1, Last Available: "2006-12"
-2173	maroon narrow triangular stone	0		
+2173	narrow maroon triangular stone	0		
 2174	skewed mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	cracked stone sphere	0		
@@ -2161,18 +2161,18 @@
 2186	cyan unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	awesome	Last Available: "2006-12"
-2189	weak bad special flask of peppermint schnapps	2	decent	Effect: "Livin' Large", Effect Duration: 30, Last Available: "2006-12"
+2189	special bad weak flask of peppermint schnapps	2	decent	Effect: "Livin' Large", Effect Duration: 30, Last Available: "2006-12"
 2190	upside-down yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	rotten small candy stake	2	crappy	Last Available: "2006-12"
 2194	high-proof acceptable huge eggnog	10	good	Last Available: "2006-12"
-2195	fancy flavorless unspeakable fruitcake	3	decent	Effect: "Patent Prevention", Effect Duration: 5, Last Available: "2006-12"
-2196	snack-sized enchanted flavorless gingerbread horror	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50, Last Available: "2006-12"
+2195	flavorless fancy unspeakable fruitcake	3	decent	Effect: "Patent Prevention", Effect Duration: 5, Last Available: "2006-12"
+2196	flavorless enchanted snack-sized gingerbread horror	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50, Last Available: "2006-12"
 2197	activated Vulcanized but probably evil chocolate	0		Effect: "Celestial Vision", Effect Duration: 28, Last Available: "2006-12"
 2198	moldy bat-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	stale skull-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	adequate bite-sized tombstone-shaped Crimboween cookie	1	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	bite-sized adequate tombstone-shaped Crimboween cookie	1	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	cyan Sherlock's plastic gift-wrapping vampire	0		Item Drop: +25, Last Available: "2006-12"
 2202	sizzling plastic yuletide troll	0		Hot Damage: +10, Last Available: "2006-12"
 2203	blurry family-friendly plastic skeletal reindeer	0		Sleaze Resistance: +1, Single Equip, Last Available: "2006-12"
@@ -2182,29 +2182,29 @@
 2207	twirling Crimbo tiki necklace of the dark arts	0		Spell Damage Percent: +100, Last Available: "2006-12"
 2208	red Annie Oakley's bobble-hip hula elf doll of chilblains	0		Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2006-12"
 2209	skewed horrifying Crimbo ukulele	0		Spooky Damage: +25, Last Available: "2006-12"
-2210	Sherlock's Tiki lighter of temperance	0		Sleaze Resistance: +5, Item Drop: +25, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	forbidden dangerous deck of tropical cards	0		Weapon Damage: +10, Spell Damage Percent: +50, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	miser's wool tropical paperweight	0		Cold Resistance: +1, Meat Drop: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	Sherlock's Tiki lighter of temperance	0		Sleaze Resistance: +5, Item Drop: +25, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	forbidden dangerous deck of tropical cards	0		Weapon Damage: +10, Spell Damage Percent: +50, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	miser's wool tropical paperweight	0		Cold Resistance: +1, Meat Drop: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	weightlifter's Tropical Crimbo Hat	0		Muscle: +15, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	upside-down Jack Frost's Tropical Crimbo Shorts	0		Cold Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	delicious miniature blinking super ka-bob	2	awesome	
+2215	weightlifter's Tropical Crimbo Hat	0		Muscle: +15, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	upside-down Jack Frost's Tropical Crimbo Shorts	0		Cold Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2217	miniature delicious blinking super ka-bob	2	awesome	
 2218	decent beer basted brat	4	good	
 2219	censurious Tropical Crimbo Sword	0		Sleaze Resistance: +3, Last Available: "2006-12"
 2220	non-alkaline pickled and Crimboween candy	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 58, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	Jeselnik's careful liar's pants	0		Monster Level: -10, Sleaze Damage: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	Jeselnik's careful liar's pants	0		Monster Level: -10, Sleaze Damage: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	flame-retardant extremely unsafe juggler's balls	0		Weapon Damage Percent: +100, Hot Resistance: +1, Softcore Only, Last Available: "2007-01"
 2224	pulsating energetic pink shirt	0		Maximum MP Percent: +20, Softcore Only, Last Available: "2007-01"
 2225	blue familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	stylish strapping evil eyeball pendant	0		Muscle: +5, Moxie: +25, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	oxidized adjusted ghostly arse-a'fire elixir	0		Effect: "Tiki Temerity", Effect Duration: 21, Last Available: "2007-01"
-2228	concentrated cyan shaking cosmic lemonade	0		Effect: "Helping Comes Second", Effect Duration: 12, Last Available: "2007-01"
+2228	concentrated shaking cyan cosmic lemonade	0		Effect: "Helping Comes Second", Effect Duration: 12, Last Available: "2007-01"
 2229	magnetized toad horn	0		Effect: "Here to Kick Ass", Effect Duration: 50, Last Available: "2007-01"
 2230	spinning icicle katana	0		Familiar Weight: +5
 2231	mote	0		
-2232	spinning narrow smudged alchemical recipe	0		
+2232	narrow spinning smudged alchemical recipe	0		
 2233	stiffened bow tie	0		Damage Reduction: 1, Clowniness: 75
 2234	energetic calavera concertina	0		Maximum MP Percent: +20, Song Duration: 7
 2235	ratarang of James Dean of the sweet-tooth	0		Experience (Moxie): +3, Candy Drop: +100
@@ -2235,16 +2235,16 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	squat lion oil	0		
-2264	thick decent stunt nuts	5	good	
+2264	decent thick stunt nuts	5	good	
 2265	adequate wet stew	3	good	
 2266	wet stunt nut stew	0		
 2267	green Mega Gem	0		
 2268	careful Staff of Fats	0		Monster Level: -10
-2269	moldy snack-sized sausage wonton	2	crappy	
+2269	snack-sized moldy sausage wonton	2	crappy	
 2270	wholesome sinister belt	0		Spell Damage: +10, Maximum HP Percent: +10, Single Equip
-2271	mediocre narrow skewed bottle of Merlot	3	decent	
+2271	mediocre skewed narrow bottle of Merlot	3	decent	
 2272	distilled smooth maroon bottle of Port	5	awesome	
-2273	practically non-alcoholic fancy bad shaking spinning purple bottle of Pinot Noir	1	decent	Effect: "Cancer Rising", Effect Duration: 10
+2273	bad practically non-alcoholic fancy purple shaking spinning bottle of Pinot Noir	1	decent	Effect: "Cancer Rising", Effect Duration: 10
 2274	distilled acceptable upside-down bottle of Zinfandel	5	good	
 2275	drinkable blurry bottle of Marsala	4	good	
 2276	acceptable irresponsibly strong bottle of Muscat	10	good	
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	twirling Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	electrified denatured candy heart	0		Effect: "Hella Smooth", Effect Duration: 35, Last Available: "2007-02"
 2305	wet pink candy heart	0		Effect: "Slimily Strong", Effect Duration: 41, Last Available: "2007-02"
 2306	energized dry candy heart	0		Effect: "Go-Gone", Effect Duration: 23, Last Available: "2007-02"
@@ -2299,7 +2299,7 @@
 2325	Staff of Ed	0		
 2326	stone rose	0		
 2327	pressed can of paint	0		Effect: "Bureaucratized", Effect Duration: 45
-2328	squat yellow drum machine	0		
+2328	yellow squat drum machine	0		
 2329	gray handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	twirling bouquet of circular saw blades	0		
@@ -2315,13 +2315,13 @@
 2341	pepper	0		
 2342	jumbo normal forest cake	5	good	
 2343	adequate forest ham	3	good	
-2344	non-aerosolized vacuum-sealed jittery squat purple filthworm hatchling scent gland	0		Effect: "Educated (Sorta)", Effect Duration: 32
+2344	non-aerosolized vacuum-sealed squat jittery purple filthworm hatchling scent gland	0		Effect: "Educated (Sorta)", Effect Duration: 32
 2345	ionized magnetized blinking filthworm drone scent gland	0		Effect: "Hagnk's Gratitude", Effect Duration: 29
-2346	ionized green spinning filthworm royal guard scent gland	0		Effect: "Sated and Furious", Effect Duration: 16
+2346	ionized spinning green filthworm royal guard scent gland	0		Effect: "Sated and Furious", Effect Duration: 16
 2347	heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	upside-down gas balloon	0		
-2350	twirling huge beer bomb	0		
+2350	huge twirling beer bomb	0		
 2351	jittery superamplified boom box	0		
 2352	hardy Da Vinci's fire poi	0		Experience (Mysticality): +5, Maximum HP: +50
 2353	narrow avaricious bejeweled pledge pin	0		Meat Drop: +30, Single Equip
@@ -2344,11 +2344,11 @@
 2370	squat natural fennel soda	0		
 2371	smoke bomb	0		
 2372	bunch of bananas	0		
-2373	adequate snack-sized banana	2	good	
+2373	snack-sized adequate banana	2	good	
 2374	skewed banana peel	0		
-2375	flavorless snack-sized banana cream pie	2	decent	
-2376	artisanal fancy yellow banana daiquiri	3	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 10
-2377	hand-crafted watered-down twirling ghostly bungle in the jungle	2	super EPIC	
+2375	snack-sized flavorless banana cream pie	2	decent	
+2376	fancy artisanal yellow banana daiquiri	3	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 10
+2377	watered-down hand-crafted ghostly twirling bungle in the jungle	2	super EPIC	
 2378	twirling blue banana spritzer	0		
 2379	colloidal banana smoothie	0		Effect: "Super-Electrified", Effect Duration: 20
 2380	cyan dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2382,7 +2382,7 @@
 2408	worthless piece of glass	0		
 2409	billy idol	0		
 2410	rag	0		
-2411	teal squat squat wobbly broken petri dish	0		
+2411	wobbly squat teal squat broken petri dish	0		
 2412	sammich crust	0		
 2413	triffid bark	0		
 2414	lint	0		
@@ -2403,7 +2403,7 @@
 2429	enhanced huge gray Eau de Guaneau	0		Effect: "Impregnably Delicious", Effect Duration: 45
 2430	activated bouncing bag of lard	0		Effect: "Mucilaginous Mentalism", Effect Duration: 39
 2431	oxidized blurry ghostly bottle of Mystic Shell	0		Effect: "Soles of Glass", Effect Duration: 30
-2432	ionized maroon narrow SPF 451 lip balm	0		Effect: "Cotton Mouthed", Effect Duration: 40
+2432	ionized narrow maroon SPF 451 lip balm	0		Effect: "Cotton Mouthed", Effect Duration: 40
 2433	colloidal denatured narrow bottle of antifreeze	0		Effect: "Red Around the Gills", Effect Duration: 11
 2434	super-aerosolized pickled eyedrops	0		Effect: "Powdered", Effect Duration: 35
 2435	enhanced magnetized wobbly Dogsgotnonoz pills	0		Effect: "Polka Face", Effect Duration: 12
@@ -2473,7 +2473,7 @@
 2500	molybdenum pliers	0		
 2501	skewed molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
-2503	tumbling skewed extra-fancy ring setting	0		
+2503	skewed tumbling extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	wobbly bouncing necklace chain	0		
 2506	beach glass bead	0		
@@ -2489,8 +2489,8 @@
 2516	wrench bracelet of the ox of the glutton	0		Muscle: +20, Food Drop: +100
 2517	ribald Da Vinci's chain necklace	0		Experience (Mysticality): +5, Sleaze Damage: +10
 2518	mirror horrifying sawblade shield	0		Spooky Damage: +25, Damage Reduction: 11
-2519	smooth weak McMillicancuddy's Special Lager	2	awesome	
-2520	weak drinkable ghostly melted Jell-o shot	2	good	
+2519	weak smooth McMillicancuddy's Special Lager	2	awesome	
+2520	drinkable weak ghostly melted Jell-o shot	2	good	
 2521	weak delicious shaking cruelty-free wine	2	awesome	
 2522	drinkable thistle wine	4	good	
 2523	mirror megatofu	0		
@@ -2501,7 +2501,7 @@
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	toothsome upside-down gnatloaf	3	awesome	
 2530	moldy fancy gnatloaf casserole	4	crappy	Effect: "Greasy Peasy", Effect Duration: 20
-2531	flavorless enchanted gnat lasagna	4	decent	Effect: "Unusual Fashion Sense", Effect Duration: 35
+2531	enchanted flavorless gnat lasagna	4	decent	Effect: "Unusual Fashion Sense", Effect Duration: 35
 2532	spinning pork	0		
 2533	moldy squat spinning pork chop sandwiches	3	crappy	
 2534	adequate pork casserole	4	good	
@@ -2518,7 +2518,7 @@
 2545	modified purple upsy daisy	0		Effect: "Boo Tea", Effect Duration: 30, Last Available: "2007-05"
 2546	warmed ionized half-orchid	0		Effect: "stats.enq", Effect Duration: 30, Last Available: "2007-05"
 2547	lard-coated tin star of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +25, Last Available: "2007-05"
-2548	knitted outrageous sombrero of Leguizamo	0		Monster Level: +20, Cold Resistance: +3, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	knitted outrageous sombrero of Leguizamo	0		Monster Level: +20, Cold Resistance: +3, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	stiffened fortified &quot;Humorous&quot; T-shirt	0		Damage Absorption: +60, Damage Reduction: 1, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2543,7 +2543,7 @@
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
-2573	tumbling jittery ant sickle	0		Familiar Effect: "spooky damage, meat"
+2573	jittery tumbling ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	huge ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
 2576	blurry honey-dipped locust	0		
@@ -2561,9 +2561,9 @@
 2588	spinning weightlifter's Private Pepper's Lonely Hearts Club Jacket	0		Muscle: +15
 2589	immense delicious red hot date	7	awesome	
 2590	bad ghostly distilled fortified wine	4	decent	
-2591	immense enchanted bland narrow tasty tart	10	decent	Effect: "Gummi Badass", Effect Duration: 20
+2591	bland enchanted immense narrow tasty tart	10	decent	Effect: "Gummi Badass", Effect Duration: 20
 2592	bouncing Knob Goblin lunchbox	0		
-2593	big bland cyan Knob pasty	5	decent	
+2593	bland big cyan Knob pasty	5	decent	
 2594	tolerable practically non-alcoholic thermos full of Knob coffee	1	good	
 2595	chilled Ben-Gal&trade; Balm	0		Effect: "Funky Coal Patina", Effect Duration: 43
 2596	leathery cat skin	0		
@@ -2622,9 +2622,9 @@
 2649	tumbling Jack Frost's Lord Spookyraven's ear trumpet	0		Cold Spell Damage: +50, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	gigantic normal twirling S.T.L.T.	10	good	Last Available: "2007-06"
+2652	normal gigantic twirling S.T.L.T.	10	good	Last Available: "2007-06"
 2653	adequate honey-dew	4	good	Last Available: "2007-06"
-2654	special hand-crafted Xanadian	4	EPIC	Effect: "Human-Human Hybrid", Effect Duration: 40, Last Available: "2007-06"
+2654	hand-crafted special Xanadian	4	EPIC	Effect: "Human-Human Hybrid", Effect Duration: 40, Last Available: "2007-06"
 2655	Vulcanized bottle of absinthe	0		Effect: "Abyssal Tears", Effect Duration: 44, Last Available: "2007-06"
 2656	wobbly zippy sinister Drowsy Sword	0		Spell Damage: +10, Initiative: +20
 2657	adequate escargotsicle	3	good	Last Available: "2007-06"
@@ -2632,8 +2632,8 @@
 2659	shaking albatross necklace of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2007-06"
 2660	vaporized green not-a-pipe	1	crappy	Last Available: "2007-06"
 2661	drinkable blurry teal flask of Amontillado	3	good	Last Available: "2007-06"
-2662	thinker's ball mask	0		Mysticality: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	vibrating Can-Can skirt	0		Maximum MP Percent: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	thinker's ball mask	0		Mysticality: +10, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	vibrating Can-Can skirt	0		Maximum MP Percent: +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	ionized sensitive poetry journal	0		Effect: "Spring Training", Effect Duration: 19, Last Available: "2007-06"
 2665	polymerized lime green bottled inspiration	0		Effect: "Patched In", Effect Duration: 11, Last Available: "2007-06"
 2666	altered double-Vulcanized bellhop bell	0		Effect: "Marinated", Effect Duration: 52, Last Available: "2007-06"
@@ -2711,9 +2711,9 @@
 2738	pile of smoking rags	0		
 2739	non-activated panty raider camouflage	0		Effect: "Spring Training", Effect Duration: 32
 2740	sharpshooter's veiny cool Staff of the Walk-In Freezer	0		Moxie: +5, Maximum HP: +10, Critical Hit Percent: +10
-2741	special weak mediocre boilermaker	2	decent	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 10
+2741	special mediocre weak boilermaker	2	decent	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 10
 2742	decent steel lasagna	3	quest	
-2743	watered-down hand-crafted narrow steel margarita	2	quest	
+2743	hand-crafted watered-down narrow steel margarita	2	quest	
 2744	diluted steel-scented air freshener	1		Effect: "Adventurer's Best Friendship", Effect Duration: 15
 2745	irradiated gremlin mutagen	0		Effect: "Jerky, Boy", Effect Duration: 13
 2746	Vulcanized extra-potent gremlin mutagen	0		Effect: "Well-Swabbed Ear", Effect Duration: 65
@@ -2779,7 +2779,7 @@
 2806	Vulcanized pressed vial of porquoise juice	0		Effect: "On Pins and Needles", Effect Duration: 62
 2807	cold-filtered alkaline bouncing shaking flask of hamethyst juice	0		Effect: "Healthy Red Glow", Effect Duration: 28
 2808	anodized flask of baconstone juice	0		Effect: "Scarysauce", Effect Duration: 20
-2809	vacuum-sealed cyan shaking flask of porquoise juice	0		Effect: "Uncaged Power", Effect Duration: 18
+2809	vacuum-sealed shaking cyan flask of porquoise juice	0		Effect: "Uncaged Power", Effect Duration: 18
 2810	cold-filtered alkaline vacuum-sealed blinking jug of hamethyst juice	0		Effect: "You Know When to Walk Away", Effect Duration: 27
 2811	electrified huge bouncing jug of baconstone juice	0		Effect: "Your Favorite Flavor", Effect Duration: 63
 2812	diffused jug of porquoise juice	0		Effect: "Wings of the Grasshopper", Effect Duration: 41
@@ -2789,9 +2789,9 @@
 2816	ghostly medical-grade baleful extremely unsafe Boxers	0		Weapon Damage Percent: +100, Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley, 1xLep"
 2817	twirling auspicious toasty Annie Oakley's Brooch	0		Critical Hit Percent: +20, Hot Damage: +5, Item Drop: +10, Single Equip
 2818	bouncing lightning-fast asbestos-lined arcane researcher's Bracelet	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Initiative: +40, Single Equip
-2819	shaking jittery lightning-fast boxer's Grimacite gasmask	0		Muscle Percent: +10, Initiative: +40, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	shaking jittery lightning-fast boxer's Grimacite gasmask	0		Muscle Percent: +10, Initiative: +40, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	jittery sizzling Grimacite gat of the sewer	0		Hot Damage: +10, Stench Damage: +25, Last Available: "2008-11"
-2821	squat shellacked Grimacite gaiters of the scaredy-cat	0		Damage Reduction: 7, Monster Level: -15, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	squat shellacked Grimacite gaiters of the scaredy-cat	0		Damage Reduction: 7, Monster Level: -15, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	dance instructor's Grimacite gauntlets	0		Experience Percent (Moxie): +10, Item Drop: +5, Single Equip, Last Available: "2008-11"
 2823	cyan pulsating asbestos-lined dog trainer's Grimacite go-go boots	0		Experience (familiar): +1, Hot Resistance: +5, Single Equip, Last Available: "2008-11"
 2824	mirror Temple Grandin's Van der Graaf Grimacite girdle	0		Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2008-11"
@@ -2804,14 +2804,14 @@
 2831	mirror star key lime	0		
 2832	decent super-sized narrow digital key lime pie	5	good	
 2833	normal star key lime pie	3	good	
-2834	knitted smelly bottle-rocket crossbow of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, Cold Resistance: +3, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	knitted smelly bottle-rocket crossbow of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, Cold Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	pulsating veiny indie comic hipster glasses	0		Maximum HP: +10, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	wobbly mint-condition magic wand	0		Last Available: "2011-12"
 2838	lime green pulsating Lo Pan's sinister glowstick	0		Spell Damage: +10, Spell Critical Percent: +30, Last Available: "2007-08"
 2839	Periodical Paintbrush of Gandalf	0		Spell Critical Percent: +20, Softcore Only
 2840	fancy lousy teal bottle of cooking sherry	4	decent	Effect: "Omphalotus Omnipresence", Effect Duration: 15
-2841	massive stale purple packet of ketchup	10	decent	
+2841	stale massive purple packet of ketchup	10	decent	
 2842	lousy accidental cider	3	decent	
 2843	decent dire fudgesicle	3	good	
 2844	zippy dog trainer's navel ring of navel gazing of Gandalf of temperance	0		Spell Critical Percent: +20, Experience (familiar): +1, Sleaze Resistance: +5, Initiative: +20, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2820,7 +2820,7 @@
 2847	wholesome Dallas Dynasty Falcon Crest shield	0		Maximum HP Percent: +10, Damage Reduction: 15
 2848	twirling Gnomitronic Hyperspatial Demodulizer	0		
 2849	spinning shrunken navigator head	0		
-2850	tolerable weak moonberry wine cooler	2	good	
+2850	weak tolerable moonberry wine cooler	2	good	
 2851	delicious tumbling fine aged cheddarwurst	3	awesome	
 2852	twirling branch from the Great Tree	0		
 2853	upside-down Phil Bunion's axe	0		
@@ -2830,7 +2830,7 @@
 2857	enhanced seegar butt	0		Effect: "Polar Express", Effect Duration: 14
 2858	bottled swamp gas	0		
 2859	brawny witch wart	0		Muscle Percent: +20, Item Drop: +5
-2860	flavorless fancy half-sized swamp muck	2	decent	Effect: "Just the Brown Ones", Effect Duration: 35
+2860	half-sized flavorless fancy swamp muck	2	decent	Effect: "Just the Brown Ones", Effect Duration: 35
 2861	avaricious greedy supercool leechknife	0		Moxie Percent: +20, Meat Drop: 50
 2862	blurry upside-down decomposed boot	0		
 2863	enhanced denatured dribbly candle	0		Effect: "You Read The Manual", Effect Duration: 55
@@ -2839,7 +2839,7 @@
 2866	foul-smelling vibrating shamanic beads	0		Maximum MP Percent: +10, Stench Damage: +10
 2867	Newton's Socratic dilapidated wizard hat	0		Experience (Mysticality): 4, Familiar Effect: "cap 31"
 2868	dry pirate pamphlet	0		Effect: "Human-Insect Hybrid", Effect Duration: 11
-2869	non-irradiated boiled bouncing blinking pirate brochure	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 26
+2869	non-irradiated boiled blinking bouncing pirate brochure	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 26
 2870	polarized magnetized pirate tract	0		Effect: "Mad at Science", Effect Duration: 52
 2871	red burnt flower	0		
 2872	tumbling deadly plastic Naughty Sorceress of Flo-Jo	0		Weapon Damage: +5, Initiative: +100
@@ -2915,7 +2915,7 @@
 2942	dry blurry chocolate filthy lucre	0		Effect: "stats.enq", Effect Duration: 65
 2943	anodized Angry Farmer's Wife Candy	0		Effect: "Thunderheart", Effect Duration: 59
 2945	baleful brawny party hat	0		Muscle Percent: +20, Spell Damage: +25, Familiar Effect: "4xLep, cap 7"
-2946	nippy V for Vivala mask of the early riser	0		Cold Damage: +10, Adventures: +7, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	nippy V for Vivala mask of the early riser	0		Cold Damage: +10, Adventures: +7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	smooth special shot of rotgut	3	awesome	Effect: "French Bronilla Brogueishness", Effect Duration: 15
 2949	electrified energized extra-colloidal jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Void Between the Stars", Effect Duration: 25
@@ -2931,21 +2931,21 @@
 2959	rum barrel charrrm bracelet of courage	0		Spooky Resistance: +3
 2960	stale fancy single-serving herbal stuffing	3	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 40
 2961	decent packet of tofurkey gravy	4	good	
-2962	fancy flavorless tofurkey nugget	4	decent	Effect: "Holiday Disappointment", Effect Duration: 15
+2962	flavorless fancy tofurkey nugget	4	decent	Effect: "Holiday Disappointment", Effect Duration: 15
 2963	rigging shampoo	0		
 2964	ball polish	0		
 2965	skewed mizzenmast mop	0		
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	irradiated altered Swabbie&trade; swab	0		Effect: "Slimy Flavor", Effect Duration: 60
 2968	warmed electrified ghostly Oil of Parrrlay	0		Effect: "Lubed", Effect Duration: 57
-2969	rotten half-sized creamsicle	2	crappy	
+2969	half-sized rotten creamsicle	2	crappy	
 2970	lousy cream stout	3	decent	
 2971	crafty beefcake's curmudgel	0		Muscle: +25, Maximum MP: +10
 2972	bouncing grumpy man charrrm	0		
 2973	banded grumpy man charrrm bracelet	0		Damage Absorption: +100, Single Equip
 2974	shaking tarrrnish charrrm	0		
 2975	shaking scorching personal trainer's tarrrnished charrrm bracelet	0		Experience Percent (Muscle): +10, Hot Damage: +25, Single Equip
-2976	practically non-alcoholic acceptable bilge wine	1	good	
+2976	acceptable practically non-alcoholic bilge wine	1	good	
 2977	chilly witty rapier	0		Cold Damage: +5
 2978	Lo Pan's yohohoyo of the ox	0		Muscle: +20, Spell Critical Percent: +30
 2979	enhanced tarnished twirling fish-liver oil	0		Effect: "Extra-Wet", Effect Duration: 49
@@ -2974,7 +2974,7 @@
 3002	lam&eacute; pants of bravery	0		Spooky Resistance: +5, Familiar Effect: "2xPotato, 1xLep, cap 25"
 3003	Sinatra's enormous hoop earring	0		Experience (Moxie): +5
 3004	greedy Newton's costume sword	0		Experience (Mysticality): +3, Meat Drop: +20
-3005	narrow squat gray rainbow pearl	0		Last Available: "2007-12"
+3005	gray narrow squat rainbow pearl	0		Last Available: "2007-12"
 3006	scandalous resourceful rainbow pearl earring	0		Maximum MP: +50, Sleaze Damage: +5, Single Equip, Last Available: "2007-12"
 3007	twirling hale rainbow pearl necklace of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20, Single Equip, Last Available: "2007-12"
 3008	blurry yellow Sinatra's slick rainbow pearl ring	0		Moxie: +10, Experience (Moxie): +5, Single Equip, Last Available: "2007-12"
@@ -2985,7 +2985,7 @@
 3013	blinking simple key	0		
 3014	ornate key	0		
 3015	gilded key	0		
-3016	tumbling cyan foot locker	0		
+3016	cyan tumbling foot locker	0		
 3017	ornate chest	0		
 3018	squat gilded chest	0		
 3019	all-purpose cleaner	0		
@@ -2994,30 +2994,30 @@
 3022	medium stone triangle	0		
 3023	lime green small stone triangle	0		
 3024	stone pyramid	0		
-3025	watered-down artisanal fancy corpse on the beach	2	super ultra mega EPIC	Effect: "Educated (Sorta)", Effect Duration: 15
-3026	artisanal practically non-alcoholic corpsetini	1	super ultra mega turbo EPIC	
+3025	watered-down fancy artisanal corpse on the beach	2	super ultra mega EPIC	Effect: "Educated (Sorta)", Effect Duration: 15
+3026	practically non-alcoholic artisanal corpsetini	1	super ultra mega turbo EPIC	
 3027	watered-down mediocre corpsedriver	2	decent	
 3028	aged Corpse Island iced tea	4	awesome	
 3029	bad watered-down red-headed corpse	2	decent	
 3030	tolerable kamicorpse-ee	3	good	
-3031	delicious watered-down corpsel	2	awesome	
+3031	watered-down delicious corpsel	2	awesome	
 3032	mediocre narrow corpsebite	3	decent	
 3033	aromatic pirate fledges	0		Stench Resistance: +1
 3034	piece of thirteen	0		
-3035	super-sized stale ghostly pearl onion	5	decent	
+3035	stale super-sized ghostly pearl onion	5	decent	
 3036	flavorless sea biscuit	4	decent	
-3037	artisanal weak green bottle of rum	2	EPIC	
+3037	weak artisanal green bottle of rum	2	EPIC	
 3038	lousy bottle of black-label rum	3	decent	
 3039	cannonball	0		
 3040	tumbling voodoo skull	0		
 3041	joke scroll	0		
 3042	mirror Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	adequate small nanite-infested gingerbread bugbear	2	good	Last Available: "2007-12"
-3046	snack-sized moldy nanite-infested candy cane	2	crappy	Last Available: "2020-09"
+3046	moldy snack-sized nanite-infested candy cane	2	crappy	Last Available: "2020-09"
 3047	spoiled bite-sized nanite-infested fruitcake	1	crappy	Last Available: "2007-12"
-3048	practically non-alcoholic drinkable teal nanite-infested eggnog	1	good	Last Available: "2007-12"
+3048	drinkable practically non-alcoholic teal nanite-infested eggnog	1	good	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	eyepatch of the cheetah	0		Initiative: +60, Familiar Effect: "spooky atk, 1xBarrr"
 3051	savvy cutlass	0		Mysticality Percent: +20
@@ -3025,7 +3025,7 @@
 3053	yellow squat mood ring	0		Last Available: "2007-02"
 3054	super-electrified purple candy heart	0		Effect: "Drunk With Power", Effect Duration: 49, Last Available: "2007-02"
 3055	oxidized denatured blinking cymbal syrup	0		Free Pull, Effect: "Amorphous Cheer", Effect Duration: 62, Last Available: "2007-02"
-3056	padded metallic foil cat ears	0		Damage Absorption: +20, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	padded metallic foil cat ears	0		Damage Absorption: +20, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	mirror iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	fuchsia laser targeting chip	0		Last Available: "2007-12"
 3077	purple hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	narrow kevlateflocite helmet	0		Last Available: "2007-12"
-3079	spinning Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	spinning Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	spinning teddy borg	0		Last Available: "2007-12"
 3081	Samson's marionette collective	0		Experience (Muscle): +5, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	pulsating friendly chaotic roboduck-on-a-string	0		Spell Critical Percent: +10, Familiar Weight: +3, Last Available: "2007-12"
 3086	blinking mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	twirling hardy razor-sharp biomechanical crimborg helmet	0		Weapon Damage Percent: +25, Maximum HP: +50, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	twirling hardy razor-sharp biomechanical crimborg helmet	0		Weapon Damage Percent: +25, Maximum HP: +50, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	purple fortified C.B.F.G. of doom	0		Damage Absorption: +60, Spooky Spell Damage: +50, Last Available: "2007-12"
-3090	inspector's grievous biomechanical crimborg leg armor	0		Weapon Damage Percent: +50, Item Drop: +15, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	inspector's grievous biomechanical crimborg leg armor	0		Weapon Damage Percent: +50, Item Drop: +15, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	boiled vitachoconutriment capsule	0		Effect: "Trivia Master", Effect Duration: 50, Last Available: "2007-12"
 3092	extremely unsafe handmade hobby horse	0		Weapon Damage Percent: +100, Last Available: "2007-12"
 3093	ball-in-a-cup of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2007-12"
@@ -3086,21 +3086,21 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	mirror divine noisemaker	0		Last Available: "2008-01"
 3119	upside-down divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
-3124	double-activated narrow blinking fruitfilm	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 53
-3125	polarized denatured bouncing blurry piece of after eight	0		Effect: "Spiritually Awake", Effect Duration: 27
-3126	jittery bouncing hobo nickel	0		
+3124	double-activated blinking narrow fruitfilm	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 53
+3125	polarized denatured blurry bouncing piece of after eight	0		Effect: "Spiritually Awake", Effect Duration: 27
+3126	bouncing jittery hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	normal half-sized enchanted huge roasted marshmallow	2	good	Effect: "Memento Moir&eacute;", Effect Duration: 15
+3129	enchanted normal half-sized huge roasted marshmallow	2	good	Effect: "Memento Moir&eacute;", Effect Duration: 15
 3130	upside-down disc	0		Last Available: "2008-01"
-3131	tasty miniature bouncing tin cup of mulligan stew	2	awesome	
+3131	miniature tasty bouncing tin cup of mulligan stew	2	awesome	
 3132	narrow inspector's flamin' bindle of the empath	0		Familiar Weight: +5, Item Drop: +15
 3133	foul-smelling freezin' bindle of James Dean	0		Experience (Moxie): +3, Stench Damage: +10
 3134	shaking groovy stinkin' bindle of bravery	0		Moxie Percent: +10, Spooky Resistance: +5
@@ -3114,7 +3114,7 @@
 3142	lard-coated cup of infinite pencils	0		Sleaze Spell Damage: +25
 3143	sizzling veiny Hodgman's disgusting technicolor overcoat	0		Maximum HP: +10, Hot Damage: +10
 3144	upside-down green a torn paper strip	0		
-3145	squat teal tumbling El Vibrato translator	0		
+3145	tumbling teal squat El Vibrato translator	0		
 3146	huge El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
@@ -3145,23 +3145,23 @@
 3173	tarnished narrow evil vihuela	0		Effect: "Voracious Gorging", Effect Duration: 42
 3174	rotten evil boring spaghetti	4	crappy	
 3175	yummy tumbling evil noodles	4	awesome	
-3176	tiny stale upside-down evil noodles	1	decent	
-3177	huge special normal evil painful penne pasta	7	good	Effect: "Unrunnable Face", Effect Duration: 5
-3178	flavorless small 3vi1 pr0n m4nic0tti	2	decent	
+3176	stale tiny upside-down evil noodles	1	decent	
+3177	normal special huge evil painful penne pasta	7	good	Effect: "Unrunnable Face", Effect Duration: 5
+3178	small flavorless 3vi1 pr0n m4nic0tti	2	decent	
 3179	moldy evil ravioli della hippy	4	crappy	
-3180	half-sized adequate evil noodles	2	good	
+3180	adequate half-sized evil noodles	2	good	
 3181	polarized teal evil potion of potency	0		Effect: "Whitened Teeth", Effect Duration: 27
 3182	oxidized energized olive evil libation of liveliness	0		Effect: "In Tuna", Effect Duration: 32
 3183	vacuum-sealed evil tomato juice of powerful power	0		Effect: "Space Tripping", Effect Duration: 45
 3184	corrupted improved evil eyedrops of the ermine	0		Effect: "Ermine Eyes", Effect Duration: 60
 3185	nitrogenated evil ointment of the occult	0		Effect: "Saucemastery", Effect Duration: 23
 3186	anodized evil serum of sarcasm	0		Effect: "Winklered", Effect Duration: 60
-3187	alkaline alkaline pulsating mirror evil philter of phorce	0		Effect: "Hiding in Plain Sight", Effect Duration: 12
-3188	hand-crafted strong an evil sump'm sump'm	5	EPIC	
-3189	bad triple-distilled evil ducha de oro	9	decent	
+3187	alkaline alkaline mirror pulsating evil philter of phorce	0		Effect: "Hiding in Plain Sight", Effect Duration: 12
+3188	strong hand-crafted an evil sump'm sump'm	5	EPIC	
+3189	triple-distilled bad evil ducha de oro	9	decent	
 3190	drinkable irresponsibly strong jittery evil horizontal tango	7	good	
-3191	watered-down perfectly mixed evil roll in the hay	2	super EPIC	
-3192	blinking jittery naughty origami kit	0		Last Available: "2008-02"
+3191	perfectly mixed watered-down evil roll in the hay	2	super EPIC	
+3192	jittery blinking naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	pulsating origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
@@ -3195,9 +3195,9 @@
 3223	sewer nuggets	0		
 3224	sewer wad	0		
 3225	lousy bottle of sewage schnapps	3	decent	
-3226	irresponsibly strong perfectly mixed blue squat bottle of Ooze-O	9	EPIC	
-3227	snack-sized spoiled C.H.U.M. chum	2	crappy	
-3228	adequate blurry purple unfortunate dumplings	3	good	
+3226	perfectly mixed irresponsibly strong blue squat bottle of Ooze-O	9	EPIC	
+3227	spoiled snack-sized C.H.U.M. chum	2	crappy	
+3228	adequate purple blurry unfortunate dumplings	3	good	
 3229	huge decaying goldfish liver	0		
 3230	anodized wet mirror oil of oiliness	0		Effect: "The Moxie of LOV", Effect Duration: 49
 3231	avaricious tattered paper crown	0		Meat Drop: +30, Familiar Effect: "1xSombrero, cap 15"
@@ -3208,7 +3208,7 @@
 3236	ghostly Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	lime green Blizzards I Have Died In	0		Skill: "Snowclone"
-3239	green skewed shaking Maxing, Relaxing	0		Skill: "Maximum Chill"
+3239	skewed shaking green Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	tumbling Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	bouncing Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
@@ -3232,7 +3232,7 @@
 3260	personal trainer's Chester's moustache of the overflowing toilet	0		Experience Percent (Muscle): +10, Stench Spell Damage: +50, Item Drop: +5, Class: "Disco Bandit", Single Equip
 3261	maroon skewed pulsating Socratic thinker's Chester's bag of candy	0		Mysticality: +10, Experience (Mysticality): +1, Class: "Disco Bandit"
 3262	sage Chester's cutoffs of horror	0		Mysticality Percent: +10, Spooky Spell Damage: +25, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	blinking candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3240,9 +3240,9 @@
 3268	improved handful of Crotchety Pine needles	0		Effect: "Okee-Dokee Computer", Effect Duration: 50
 3269	liquefied lump of Saccharine Maple sap	0		Effect: "You Drank Fish Wine", Effect Duration: 49
 3270	boiled handful of Laughing Willow bark	0		Effect: "Gemini Rising", Effect Duration: 20
-3271	bouncing zippy crotchety pants	0		Initiative: +20, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	bouncing zippy crotchety pants	0		Initiative: +20, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	toasty Saccharine Maple pendant	0		Hot Damage: +5, Conditional Skill (Equipped): "Spray Sap"
-3273	Jim Carey's willowy bonnet	0		Monster Level: +25, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	Jim Carey's willowy bonnet	0		Monster Level: +25, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	twirling black-and-blue light	0		Last Available: "2008-04"
@@ -3252,11 +3252,11 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	shaking foul-smelling stick-on eyebrow piercing	0		Stench Damage: +10, Last Available: "2008-04"
-3283	big adequate salad	5	good	
+3283	adequate big salad	5	good	
 3284	ghostly dog trainer's Jim Carey's C.H.U.M. lantern	0		Monster Level: +25, Experience (familiar): +1
 3285	flame-retardant C.H.U.M. knife	0		Hot Resistance: +1
 3286	teal mansplainer's Frosty's snowball sack	0		Monster Level: +15
-3287	maroon skewed quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
+3287	skewed maroon quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
 3288	shimmering tendrils	0		Class: "Pastamancer"
 3289	yellow scintillating powder	0		Class: "Pastamancer"
 3290	narrow abandoned candy	0		
@@ -3276,7 +3276,7 @@
 3304	Argarggagarg's fang	0		
 3305	Safari Jack's moustache	0		
 3306	Yakisoba's hat	0		
-3307	skewed bouncing Heimandatz's heart	0		
+3307	bouncing skewed Heimandatz's heart	0		
 3308	Jocko Homo's head	0		
 3309	mirror The Mariachi's guitar case	0		
 3310	Da Vinci's sealskin drum	0		Experience (Mysticality): +5, Class: "Seal Clubber"
@@ -3291,7 +3291,7 @@
 3319	narrow miser's Mr. Joe's bangles	0		Meat Drop: +10, Single Equip
 3320	frayed rope belt of extreme caution	0		Monster Level: -25, Single Equip
 3321	upside-down packet of mayfly bait	0		Last Available: "2008-05"
-3322	horrifying nippy mayfly bait necklace	0		Cold Damage: +10, Spooky Damage: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	horrifying nippy mayfly bait necklace	0		Cold Damage: +10, Spooky Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	huge Ol' Scratch's salad fork	0		
 3324	skewed Frosty's frosty mug	0		
 3325	bad practically non-alcoholic wobbly jar of fermented pickle juice	1	decent	
@@ -3303,20 +3303,20 @@
 3331	dangerous mostly rat-hide leggings of the dark arts	0		Weapon Damage: +10, Spell Damage Percent: +100, Familiar Effect: "stench atk, 1xPotato"
 3332	blurry up-at-dawn hobo dungarees of Calamity Jane	0		Critical Hit Percent: +15, Adventures: +5, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	arcane researcher's patched suit-pants of courage	0		Experience Percent (Mysticality): +10, Spooky Resistance: +3, Familiar Effect: "1xPotato, 0.5xFairy"
-3334	purple pulsating jittery hobo stogie	0		Single Equip
+3334	pulsating purple jittery hobo stogie	0		Single Equip
 3335	pulsating green rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	narrow occult extremely unsafe dead guy's memento	0		Weapon Damage Percent: +100, Spell Damage Percent: +25, Single Equip
-3338	bite-sized decent banquet	1	good	
+3338	decent bite-sized banquet	1	good	
 3339	sharpened hubcap	0		
 3340	very caltrop	0		
-3341	spinning twirling squat The Six-Pack of Pain	0		
+3341	twirling spinning squat The Six-Pack of Pain	0		
 3342	pulsating hobo monkey	0		
 3343	bindle	0		Familiar Weight: +5
 3344	bed of coals	0		
 3345	air mattress	0		
 3346	filth-encrusted futon	0		
-3347	skewed fuchsia twirling comfy coffin	0		
+3347	twirling fuchsia skewed comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
 3350	perfectly mixed Ralph IX cognac	4	super ultra mega turbo EPIC	
@@ -3332,7 +3332,7 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	blinking yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	half-sized rotten shaking mole mol&eacute;	2	crappy	Last Available: "2008-06"
+3363	rotten half-sized shaking mole mol&eacute;	2	crappy	Last Available: "2008-06"
 3364	delicious practically non-alcoholic purple Morlock's Mark Bourbon	1	awesome	Last Available: "2008-06"
 3365	electrified quadruple-warmed Climate Colada	0		Effect: "Altered Wavelengths", Effect Duration: 28, Last Available: "2008-06"
 3366	polarized wet digital underground potion	0		Effect: "Buttermilk Boogie", Effect Duration: 49, Last Available: "2008-06"
@@ -3369,7 +3369,7 @@
 3397	sinister smooth Hodgman's bow tie	0		Moxie: +15, Spell Damage: +10, Single Equip
 3398	drinkable Hodgman's blanket	4	good	
 3399	smooth watered-down jar of squeeze	2	awesome	
-3400	gigantic adequate bowl of fishysoisse	6	good	
+3400	adequate gigantic bowl of fishysoisse	6	good	
 3401	double-ionized red deadly lampshade	0		Effect: "Improved Candy Vision", Effect Duration: 34
 3402	extra-ionized twirling concentrated garbage juice	0		Effect: "Down With Chow", Effect Duration: 51
 3403	lewd playing card	0		
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	blue upside-down Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	blurry bouncing box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	blurry bouncing box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	moist red bouncing sterno-flavored Hob-O	0		Effect: "Familial Ties", Effect Duration: 13
 3423	vacuum-sealed tarnished narrow frostbite-flavored Hob-O	0		Effect: "Voracious Gorging", Effect Duration: 67
 3424	anodized fry-oil-flavored Hob-O	0		Effect: "Strength of Ten Ettins", Effect Duration: 67
@@ -3404,7 +3404,7 @@
 3437	up-at-dawn flame-retardant supercool Staff of the Black Kettle	0		Moxie Percent: +20, Hot Resistance: +1, Adventures: +5
 3438	ghostly frightening groovy cool Staff of the Well-Tempered Cauldron	0		Moxie: +5, Moxie Percent: +10, Spooky Damage: +5
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	dried mirror yellow prismatic wad	1	good	Last Available: "2008-07"
+3440	dried yellow mirror prismatic wad	1	good	Last Available: "2008-07"
 3441	gray miser's club of the five seasons	0		Meat Drop: +10, Last Available: "2008-07"
 3442	brawny rainbow crossbow	0		Muscle Percent: +20, Last Available: "2008-07"
 3443	blue narrow kitten	0		
@@ -3430,7 +3430,7 @@
 3463	enchanted mediocre bottle of sake	3	decent	Effect: "Memory of Strength", Effect Duration: 50
 3464	round pebble of the dark arts	0		Spell Damage Percent: +100
 3465	small rotten lime green pulsating Bash-&#332;s cereal	2	crappy	Wiki Name: "Bash-Os cereal"
-3466	spinning Sherlock's electrified savvy haiku katana	0		Mysticality Percent: +20, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	spinning Sherlock's electrified savvy haiku katana	0		Mysticality Percent: +20, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	fireproof plastic baby	0		Hot Resistance: +3, Single Equip, Last Available: "2008-12"
 3469	tasty bouncing blueberry-frosted king cake	3	awesome	Last Available: "2008-12"
@@ -3439,12 +3439,12 @@
 3472	narrow asbestos-lined knitted Seasonal Beret of the cheetah	0		Cold Resistance: +3, Hot Resistance: +5, Initiative: +60, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	shaking Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	non-boiled ionized ghostly cranberry cordial	0		Effect: "Weather, Man", Effect Duration: 38
-3475	galvanized ionized magnetized cyan blurry spinning blackberry polite	0		Effect: "Joyful Resolve", Effect Duration: 22
+3475	galvanized ionized magnetized spinning cyan blurry blackberry polite	0		Effect: "Joyful Resolve", Effect Duration: 22
 3476	boiled blinking plum lozenge	0		Effect: "Carrion' On", Effect Duration: 50
 3477	tarnished activated double-polymerized jittery pear lozenge	0		Effect: "Grumpy and Ornery", Effect Duration: 41
 3478	ionized blue peach lozenge	0		Effect: "Your Interest is Peaked", Effect Duration: 18
 3479	balloon shield	0		Damage Reduction: 3
-3480	huge squat jittery spot	0		
+3480	jittery huge squat spot	0		
 3481	upside-down uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	spinning psychedelic bubble wand	0		Familiar Weight: +5
@@ -3454,24 +3454,24 @@
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
 3489	decent bouncing beefy fish meat	3	good	Effect: "Fishy", Effect Duration: 5
-3490	spoiled bite-sized enchanted blurry glistening fish meat	1	crappy	Effect: "Fishy", Effect Duration: 5
+3490	spoiled enchanted bite-sized blurry glistening fish meat	1	crappy	Effect: "Fishy", Effect Duration: 5
 3491	massive moldy narrow slick fish meat	7	crappy	Effect: "Fishy", Effect Duration: 5
 3492	stiffened Herculean fish scimitar	0		Experience (Muscle): +1, Damage Reduction: 1
 3493	wholesome dance instructor's fish stick	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10
 3494	energetic fish bazooka of the detective	0		Maximum MP Percent: +20, Item Drop: +20
 3495	polarized yellow sea salt crystal	0		Effect: "Impregnabili Tea", Effect Duration: 43
 3496	polarized bazookafish bubble gum	0		Effect: "Make Meat FA$T!", Effect Duration: 42
-3497	delicious weak yellow mirror bottle of Pete's Sake	2	awesome	
-3498	upside-down invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	enchanted moldy immense narrow canap&eacute;s	10	crappy	Effect: "Meadulla Oblongota", Effect Duration: 20
+3497	weak delicious mirror yellow bottle of Pete's Sake	2	awesome	
+3498	upside-down invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3501	immense enchanted moldy narrow canap&eacute;s	10	crappy	Effect: "Meadulla Oblongota", Effect Duration: 20
 3502	dehydrated thermos of brew	1	good	Last Available: "2011-12"
-3503	fancy drinkable glass of brandy	4	good	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 25, Last Available: "2011-12"
+3503	drinkable fancy glass of brandy	4	good	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 25, Last Available: "2011-12"
 3504	blinking French slippers	0		
 3505	executive LWA ring	0		Meat Drop: +40
 3506	shaking LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	blinking narrow frightening scratch 'n' sniff sword	0		Spooky Damage: +5, Last Available: "2008-11"
 3509	fuchsia scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,27 +3510,27 @@
 3543	upside-down jittery frosty depleted Grimacite gravy boat of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2011-12"
 3544	dog trainer's groovy depleted Grimacite weightlifting belt	0		Moxie Percent: +10, Experience (familiar): +1, Single Equip, Last Available: "2011-12"
 3545	wobbly nasty energetic depleted Grimacite grappling hook	0		Maximum MP Percent: +20, Stench Damage: +5, Single Equip, Last Available: "2011-12"
-3546	hale arcane researcher's depleted Grimacite ninja mask	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	lime green flame-wreathed depleted Grimacite shinguards of Calamity Jane	0		Critical Hit Percent: +15, Hot Spell Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	hale arcane researcher's depleted Grimacite ninja mask	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	lime green flame-wreathed depleted Grimacite shinguards of Calamity Jane	0		Critical Hit Percent: +15, Hot Spell Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	spinning blue lion tamer's occult depleted Grimacite astrolabe	0		Spell Damage Percent: +25, Experience (familiar): +2, Single Equip, Last Available: "2011-12"
 3549	sharpshooter's smooth KoL Con Cinco Pi&ntilde;ata Bat	0		Moxie: +15, Critical Hit Percent: +10, Softcore Only, Last Available: "2008-09"
 3550	bouncing gravedigger's propeller beanie	0		Spooky Damage: +10, Familiar Effect: "atk, cap 7"
 3551	vibrating cool straw hat of incineration	0		Moxie: +5, Maximum MP Percent: +10, Hot Spell Damage: +50, Familiar Effect: "1xFairy"
 3552	skewed friendly healthy dangerous octopus's spade	0		Weapon Damage: +10, Maximum HP Percent: +20, Familiar Weight: +3
-3553	purple jittery soggy seed packet	0		
+3553	jittery purple soggy seed packet	0		
 3554	glob of slime	0		
 3555	spoiled blinking sea carrot	3	crappy	
-3556	bland super-sized squat sea cucumber	5	decent	
+3556	super-sized bland squat sea cucumber	5	decent	
 3557	normal snack-sized sea avocado	2	good	
 3558	bite-sized decent special spinning sea lychee	1	good	Effect: "Patience of the Tortoise", Effect Duration: 30
-3559	half-sized adequate wobbly sea tangelo	2	good	
-3560	spoiled fuchsia squat sea honeydew	4	crappy	
+3559	adequate half-sized wobbly sea tangelo	2	good	
+3560	spoiled squat fuchsia sea honeydew	4	crappy	
 3561	improved chilled pressurized potion of puissance	0		Effect: "Patent Prevention", Effect Duration: 19
 3562	wet maroon spinning pressurized potion of perspicacity	0		Effect: "Ginger Snapped", Effect Duration: 63
-3563	liquefied modified huge spinning pressurized potion of pulchritude	0		Effect: "Engorged Weapon", Effect Duration: 54
+3563	liquefied modified spinning huge pressurized potion of pulchritude	0		Effect: "Engorged Weapon", Effect Duration: 54
 3564	hand-crafted berry-infused sake	3	EPIC	
 3565	perfectly mixed citrus-infused sake	4	EPIC	
-3566	watered-down delicious melon-infused sake	2	awesome	
+3566	delicious watered-down melon-infused sake	2	awesome	
 3567	slab of sponge	0		
 3568	chilly lion tamer's smartaleck's sponge helmet	0		Moxie Percent: +30, Experience (familiar): +2, Cold Damage: +5, Familiar Effect: "atk, 1xFairy"
 3569	ribald Oprah's spongy shield of extreme caution	0		Maximum MP Percent: +50, Monster Level: -25, Sleaze Damage: +10, Damage Reduction: 14
@@ -3547,10 +3547,10 @@
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	adequate rice	4	good	
-3584	snack-sized special bland irradiated candy cane	2	decent	Effect: "Goldentongue", Effect Duration: 30, Last Available: "2008-12"
+3584	bland special snack-sized irradiated candy cane	2	decent	Effect: "Goldentongue", Effect Duration: 30, Last Available: "2008-12"
 3585	normal miniature gingerbread mutant bugbear	2	good	Last Available: "2008-12"
 3586	drinkable oozenog	3	good	Last Available: "2008-12"
-3587	polymerized frozen green huge sugar plum	0		Effect: "Hobo Flavor", Effect Duration: 24, Last Available: "2008-12"
+3587	polymerized frozen huge green sugar plum	0		Effect: "Hobo Flavor", Effect Duration: 24, Last Available: "2008-12"
 3588	anodized diffused olive sugar banana	0		Effect: "Rat-Faced", Effect Duration: 21, Last Available: "2008-12"
 3589	dry skewed sugar lime	0		Effect: "Weird Flavor", Effect Duration: 46, Last Available: "2008-12"
 3590	galvanized lime green sugar cherry	0		Effect: "Loyal Tea", Effect Duration: 53, Last Available: "2008-12"
@@ -3575,21 +3575,21 @@
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	mirror imitation whetstone	0		
 3611	cold-filtered skewed sea grease	0		Effect: "Savage Beast Inside", Effect Duration: 37
-3612	bouncing blinking sturdy Crimbo crate	0		Last Available: "2008-12"
+3612	blinking bouncing sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	huge jittery rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	Vulcanized ghostly unstable DNA	0		Effect: "Big Punkin'", Effect Duration: 44, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	wobbly pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	supercool parasitic claw	0		Moxie Percent: +20, Last Available: "2008-12"
-3625	parasitic tentacles of the brute	0		Muscle Percent: +30, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	narrow twirling parasitic headgnawer of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	parasitic tentacles of the brute	0		Muscle Percent: +30, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	narrow twirling parasitic headgnawer of Tarzan	0		Experience (Muscle): +3, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	spinning squat fortified parasitic strangleworm	0		Damage Absorption: +60, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,25 +3598,25 @@
 3632	spinning radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	brawny brainy elven socks	0		Mysticality: +5, Muscle Percent: +20, Last Available: "2008-12"
 3634	cyan medical-grade arcane researcher's elven gloves	0		Experience Percent (Mysticality): +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2008-12"
-3635	purple blurry Tesla electrified festive holiday hat	0		MP Regen Min: 10, MP Regen Max: 15, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	purple blurry Tesla electrified festive holiday hat	0		MP Regen Min: 10, MP Regen Max: 15, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	Newton's educational patent shoes	0		Experience: +1, Experience (Mysticality): +3, Last Available: "2008-12"
 3637	gray bow tie of the cougar of the empath	0		Moxie: +20, Familiar Weight: +5, Last Available: "2008-12"
 3638	padded penguin thesaurus of the sweet-tooth	0		Damage Absorption: +20, Candy Drop: +100, Last Available: "2008-12"
-3639	tasty big blob-shaped Crimbo cookie	5	awesome	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	big tasty blob-shaped Crimbo cookie	5	awesome	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	wobbly jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	tumbling red pufferfish spine	0		
 3644	avaricious depleted Grimacite kneecapping stick	0		Meat Drop: +30, Last Available: "2007-06"
-3645	watered-down drinkable canteen of wine	2	good	Last Available: "2008-12"
+3645	drinkable watered-down canteen of wine	2	good	Last Available: "2008-12"
 3646	spoiled elven <i>limbos</i> gingerbread	3	crappy	Last Available: "2008-12"
 3647	skewed elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	pulsating map to Madness Reef	0		
 3650	yummy toast with jam	4	awesome	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	tolerable elven moonshine	3	good	Last Available: "2008-12"
-3653	special spoiled narrow jittery knuckle sandwich	3	crappy	Effect: "Sausage Festive", Effect Duration: 45, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	spoiled special narrow jittery knuckle sandwich	3	crappy	Effect: "Sausage Festive", Effect Duration: 45, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	reassuring hardy psycho sweater	0		Maximum HP: +50, Spooky Resistance: +1, Last Available: "2008-12"
 3655	cyan fin-bit wax	0		Familiar Weight: +5
 3656	Usain Bolt's plastic Mob Penguin	0		Initiative: +80, Last Available: "2008-12"
@@ -3624,9 +3624,9 @@
 3658	blurry curative plastic fat stack of cash	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-12"
 3659	tumbling manspreader's plastic strand of DNA	0		Monster Level: +10, Last Available: "2008-12"
 3660	bouncing wobbly Temple Grandin's plastic chunk of depleted Grimacite	0		Familiar Weight: +7, Last Available: "2008-12"
-3661	twirling red container of Putty	0		Last Available: "2009-01"
-3662	rosy-cheeked Putty mitre	0		Maximum HP Percent: +30, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	tumbling occult slick Putty leotard	0		Moxie: +10, Spell Damage Percent: +25, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3661	red twirling container of Putty	0		Last Available: "2009-01"
+3662	rosy-cheeked Putty mitre	0		Maximum HP Percent: +30, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	tumbling occult slick Putty leotard	0		Moxie: +10, Spell Damage Percent: +25, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	bouncing hardy Putty ball	0		Maximum HP: +50, Softcore Only, Last Available: "2009-01"
 3665	spinning Putty sheet	0		Last Available: "2009-01"
 3666	MacGyver's steel-toed wizardly Putty snake	0		Mysticality: +25, Damage Reduction: 9, Maximum MP: +100, Softcore Only, Last Available: "2009-01"
@@ -3636,7 +3636,7 @@
 3670	weightlifter's glow-in-the-dark burrowgrub	0		Muscle: +15, Last Available: "2009-01"
 3671	jittery jittery Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	adequate can of franks 'n' beans	3	good	Last Available: "2010-12"
-3673	bad practically non-alcoholic blurry bottle of peppermint schnapps	1	decent	Last Available: "2010-12"
+3673	practically non-alcoholic bad blurry bottle of peppermint schnapps	1	decent	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
@@ -3652,10 +3652,10 @@
 3686	bland tempura avocado	3	decent	
 3687	bland snack-sized sea broccoli	2	decent	
 3688	flavorless sea cauliflower	4	decent	
-3689	spoiled snack-sized tempura broccoli	2	crappy	
+3689	snack-sized spoiled tempura broccoli	2	crappy	
 3690	normal massive tempura cauliflower	7	good	
-3691	fancy spoiled sea blueberry	4	crappy	Effect: "Mint-Condition Breath", Effect Duration: 30
-3692	jumbo bland sea persimmon	5	decent	
+3691	spoiled fancy sea blueberry	4	crappy	Effect: "Mint-Condition Breath", Effect Duration: 30
+3692	bland jumbo sea persimmon	5	decent	
 3693	triple-energized quantum ghostly ghostly pressurized potion of perception	0		Effect: "Your Eyes are Peeled!", Effect Duration: 29
 3694	nitrogenated purple pressurized potion of proficiency	0		Effect: "Vinegavotte", Effect Duration: 62
 3695	blinking wool Mer-kin digpick	0		Cold Resistance: +1
@@ -3714,8 +3714,8 @@
 3749	chilled concoction of clumsiness	0		Effect: "Pemmican't", Effect Duration: 37
 3750	huge ruddy vampire pearl earring	0		Maximum HP Percent: +40, Single Equip
 3751	bland chocolate chip brownies	3	decent	
-3753	jittery Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
-3754	frozen triple-nitrogenated tumbling blinking love song of vague ambiguity	0		Effect: "Radiated and Grodiated", Effect Duration: 14, Last Available: "2009-02"
+3753	jittery Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3754	frozen triple-nitrogenated blinking tumbling love song of vague ambiguity	0		Effect: "Radiated and Grodiated", Effect Duration: 14, Last Available: "2009-02"
 3755	vacuum-sealed ionized blurry love song of smoldering passion	0		Effect: "Hagg-ard", Effect Duration: 51, Last Available: "2009-02"
 3756	frozen corrupted love song of icy revenge	0		Effect: "Wet and Greedy", Effect Duration: 50, Last Available: "2009-02"
 3757	triple-electrified love song of sugary cuteness	0		Effect: "Phairly Pheromonal", Effect Duration: 64, Last Available: "2009-02"
@@ -3727,16 +3727,16 @@
 3763	tolerable slug of vodka	4	good	
 3764	practically non-alcoholic lousy shaking pulsating slug of rum	1	decent	
 3765	acceptable slug of shochu	4	good	
-3766	weak bad screwdiver	2	decent	
+3766	bad weak screwdiver	2	decent	
 3767	perfectly mixed pulsating dew yoana lei	4	EPIC	
 3768	drinkable lychee chuhai	4	good	
 3769	acceptable salacious screwdiver	3	good	
-3770	lousy irresponsibly strong dew yoana salacious lei	7	decent	
+3770	irresponsibly strong lousy dew yoana salacious lei	7	decent	
 3771	lousy practically non-alcoholic salacious lychee chuhai	1	decent	
 3772	lousy Alewife&trade; Ale	3	decent	
 3773	seaode	0		
 3774	spinning map to the Dive Bar	0		
-3775	tumbling fuchsia Mer-kin pinkslip	0		
+3775	fuchsia tumbling Mer-kin pinkslip	0		
 3776	aromatic ruddy pink pinkslip slip	0		Maximum HP Percent: +40, Stench Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr"
 3777	up-at-dawn manspreader's sea salt scrubs	0		Monster Level: +10, Adventures: +5
 3778	Jim Carey's arcane researcher's amber aviator shades of Tarzan	0		Experience (Muscle): +3, Experience Percent (Mysticality): +10, Monster Level: +25, Single Equip
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	aromatic sizzling grievous Mer-kin roundshield	0		Weapon Damage Percent: +50, Hot Damage: +10, Stench Resistance: +1, Damage Reduction: 14
 3804	shaking Jeselnik's ruddy Mer-kin breastplate	0		Maximum HP Percent: +40, Sleaze Damage: +25
 3805	vibrating Mer-kin sneakmask of mayonnaise	0		Maximum MP Percent: +10, Sleaze Spell Damage: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,7 +3768,7 @@
 3813	wizardly plastic baby	0		Mysticality: +25, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	diet moldy yellow sea radish	1	crappy	
+3817	moldy diet yellow sea radish	1	crappy	
 3818	gravedigger's Annie Oakley's occult halibut	0		Spell Damage Percent: +25, Critical Hit Percent: +20, Spooky Damage: +10
 3819	red eel sauce	0		
 3820	teal ghostly greedy water-polo mitt	0		Meat Drop: +20, Single Equip
@@ -3784,10 +3784,10 @@
 3830	water-polo cap of the wise owl	0		Mysticality: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	tolerable Typical Tavern swill	4	good	
 3832	artisanal tropical swill	4	EPIC	
-3833	watered-down hand-crafted fruity girl swill	2	EPIC	
-3834	drinkable watered-down pulsating blended swill	2	good	
+3833	hand-crafted watered-down fruity girl swill	2	EPIC	
+3834	watered-down drinkable pulsating blended swill	2	good	
 3835	costume wardrobe	0		Softcore Only
-3836	Van der Graaf Da Vinci's slick Elvish sunglasses of the storm	0		Moxie: +10, Experience (Mysticality): +5, Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	Van der Graaf Da Vinci's slick Elvish sunglasses of the storm	0		Moxie: +10, Experience (Mysticality): +5, Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	upside-down wizardly anniversary safety glass vest	0		Mysticality: +25
 3838	shaking frosty anniversary burlap belt	0		Cold Spell Damage: +10
 3839	frightening anniversary balsa wood socks	0		Spooky Damage: +5
@@ -3812,7 +3812,7 @@
 3858	electrified bone flute	0		MP Regen Min: 3, MP Regen Max: 5
 3859	nippy infernal fife	0		Cold Damage: +10
 3860	bouncing stiffened charming flute	0		Damage Reduction: 1
-3861	blurry jittery leaf of grass	0		
+3861	jittery blurry leaf of grass	0		
 3862	lime green prompt Sinatra's grass whistle	0		Experience (Moxie): +5, Adventures: +3
 3863	huge rosewater-soaked scorching plastic guitar	0		Hot Damage: +25, Stench Resistance: +3
 3864	rosy-cheeked finger cymbals	0		Maximum HP Percent: +30
@@ -3860,7 +3860,7 @@
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
 3910	blurry figurine of a seal	0		Class: "Seal Clubber"
-3911	red shaking figurine of a slippery seal	0		Class: "Seal Clubber"
+3911	shaking red figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	jittery imbued seal-blubber candle	0		Class: "Seal Clubber"
 3913	artisanal spinning blended swill with a fly in it	3	EPIC	
 3914	turtle wax	0		
@@ -3912,7 +3912,7 @@
 3960	supercool designer sunglasses	0		Moxie Percent: +20, Single Equip
 3961	veiny opera glasses of Calamity Jane	0		Maximum HP: +10, Critical Hit Percent: +15
 3962	designer handbag	0		
-3963	green bouncing Clan pool table	0		Free Pull, Last Available: "2009-05"
+3963	bouncing green Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cyan cell phone	0		Familiar Weight: +10
 3965	denatured dry twirling cube of billiard chalk	0		Effect: "Shredding, Sweating", Effect Duration: 16
 3966	lightning-fast medical-grade hot-ass club of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, HP Regen Min: 7, HP Regen Max: 10, Class: "Seal Clubber"
@@ -3920,7 +3920,7 @@
 3968	dog trainer's Annie Oakley's arcane researcher's creepy-ass club	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Experience (familiar): +1, Class: "Seal Clubber"
 3969	extra-dry dry yellow blinking sizzling seal fat	0		Effect: "Void Between the Stars", Effect Duration: 39
 3970	narrow maroon greasy crafty Abyssal ember	0		Maximum MP: +10, Sleaze Spell Damage: +10, Class: "Seal Clubber"
-3971	colloidal moist jittery olive shaking frost-rimed seal hide	0		Effect: "Spell Transfer Complete", Effect Duration: 32
+3971	colloidal moist olive shaking jittery frost-rimed seal hide	0		Effect: "Spell Transfer Complete", Effect Duration: 32
 3972	wholesome seal spine of the overflowing toilet	0		Maximum HP Percent: +10, Stench Spell Damage: +50, Class: "Seal Clubber"
 3973	triple-nitrogenated triple-nitrogenated seal lube	0		Effect: "Helping Comes Second", Effect Duration: 66
 3974	smooth mannequin leg of Calamity Jane	0		Moxie: +15, Critical Hit Percent: +15, Class: "Seal Clubber"
@@ -3929,7 +3929,7 @@
 3977	painted turtle	0		
 3978	inspector's extremely unsafe painted shield	0		Weapon Damage Percent: +100, Item Drop: +15, Damage Reduction: 7
 3979	sleeping wereturtle	0		
-3980	shaking bouncing shell	0		
+3980	bouncing shaking shell	0		
 3981	torquoise	0		
 3982	stiffened torquoise ring of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 1, Single Equip
 3983	dueling turtle	0		
@@ -3941,7 +3941,7 @@
 3989	wobbly turtle shell powder	0		
 3990	jittery turtle shell helmet of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
-3992	bouncing red slime-soaked brain	0		Skill: "Slimy Synapses"
+3992	red bouncing slime-soaked brain	0		Skill: "Slimy Synapses"
 3993	slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	maroon security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
@@ -3978,7 +3978,7 @@
 4026	studded Newton's lantern of the cheetah	0		Experience (Mysticality): +3, Damage Absorption: +80, Initiative: +60
 4027	toasty supercool greaves of terror	0		Moxie Percent: +20, Hot Damage: +5, Spooky Spell Damage: +10, Familiar Effect: "sleaze atk, 0.5xBarrr"
 4028	pulsating Annie Oakley's sinister club of Leguizamo	0		Spell Damage: +10, Critical Hit Percent: +20, Monster Level: +20
-4029	skewed pulsating memory of a grappling hook	0		Last Available: "2009-06"
+4029	pulsating skewed memory of a grappling hook	0		Last Available: "2009-06"
 4030	memory of a small stone block	0		Last Available: "2009-06"
 4031	memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
@@ -3987,23 +3987,23 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
 4037	thick flavorless slimy sweetbreads	5	decent	
-4038	strong hand-crafted slimy fermented bile bladder	5	EPIC	
+4038	hand-crafted strong slimy fermented bile bladder	5	EPIC	
 4039	distilled jittery slimy alveolus	1		
 4040	jittery memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	bouncing sizzling chilly pig-iron helm	0		Cold Damage: +5, Hot Damage: +10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	spinning lion tamer's pig-iron shinguards of the brazier	0		Experience (familiar): +2, Hot Spell Damage: +25, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	bouncing sizzling chilly pig-iron helm	0		Cold Damage: +5, Hot Damage: +10, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	spinning lion tamer's pig-iron shinguards of the brazier	0		Experience (familiar): +2, Hot Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	gray pig-iron bracers of dire peril of Flo-Jo	0		Weapon Damage: +20, Initiative: +100, Single Equip, Last Available: "2009-06"
 4044	huge wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	ghostly wumpus-hair net	0		Last Available: "2009-06"
 4047	wumpus-hair whip of wisdom	0		Mysticality: +15, Last Available: "2009-06"
-4048	Sherlock's coward's wumpus-hair wig of temperance	0		Monster Level: -20, Sleaze Resistance: +5, Item Drop: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	lightning-fast wizardly wumpus-hair loincloth of the overflowing toilet	0		Mysticality: +25, Stench Spell Damage: +50, Initiative: +40, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	Sherlock's coward's wumpus-hair wig of temperance	0		Monster Level: -20, Sleaze Resistance: +5, Item Drop: +25, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	lightning-fast wizardly wumpus-hair loincloth of the overflowing toilet	0		Mysticality: +25, Stench Spell Damage: +50, Initiative: +40, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	deadly boxer's wumpus-hair sweater	0		Muscle Percent: +10, Weapon Damage: +5, Last Available: "2009-06"
 4051	ring of teleportation of chilblains	0		Cold Damage: +25, Single Equip
 4052	glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	bouncing banana milkshake	1	awesome	Last Available: "2009-06"
-4054	spirit-forward perfectly mixed White Hyborian	5	EPIC	Last Available: "2009-06"
+4054	perfectly mixed spirit-forward White Hyborian	5	EPIC	Last Available: "2009-06"
 4055	studded goblin hunting spear	0		Damage Absorption: +80, Last Available: "2009-06"
 4056	shellacked goblin autoblowgun of the brazier	0		Damage Reduction: 7, Hot Spell Damage: +25, Last Available: "2009-06"
 4057	dog trainer's tribal beads	0		Experience (familiar): +1, Last Available: "2009-06"
@@ -4034,7 +4034,7 @@
 4082	Annie Oakley's Rosewater's pernicious cudgel	0		Mysticality Percent: +30, Critical Hit Percent: +20, Slime Hates It: +1
 4083	normal cupcake-in-a-cup	3	good	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	moldy jumbo fancy purple protein paste	5	crappy	Effect: "Sated and Furious", Effect Duration: 5, Last Available: "2009-06"
+4085	fancy moldy jumbo purple protein paste	5	crappy	Effect: "Sated and Furious", Effect Duration: 5, Last Available: "2009-06"
 4086	medical-grade supercool cyber-mattock	0		Moxie Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	ionized deionized diffused tempura air	0		Effect: "Cold Throat", Effect Duration: 24
 4134	frozen moist pressurized potion of pneumaticity	0		Effect: "Weasels Underfoot", Effect Duration: 69
 4135	bouncing moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	smelly Jack Frost's boxer's stylish Bag o' Tricks	0		Moxie: +25, Muscle Percent: +10, Cold Spell Damage: +50, Stench Spell Damage: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	smelly Jack Frost's boxer's stylish Bag o' Tricks	0		Moxie: +25, Muscle Percent: +10, Cold Spell Damage: +50, Stench Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	olive slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4102,7 +4102,7 @@
 4150	lint	0		Last Available: "2011-12"
 4151	chilled dubious peppermint	0		Effect: "Amorous", Effect Duration: 12, Last Available: "2020-09"
 4152	irradiated spinning wobbly yellow Elvish delight	0		Effect: "A Taste of Rainbow", Effect Duration: 11
-4153	spinning shaking rockfish stomach	0		Last Available: "2009-09"
+4153	shaking spinning rockfish stomach	0		Last Available: "2009-09"
 4154	squat live lobster	0		Last Available: "2011-12"
 4155	gray wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
@@ -4118,7 +4118,7 @@
 4166	MacGyver's Voluminous Radio Pants	0		Maximum MP: +100, Familiar Effect: "2xGhoul, cap 37"
 4167	Voluminous Radio Hat of the cheetah	0		Initiative: +60, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
 4168	cool Voluminous Radio Sneakers	0		Moxie: +5, Single Equip
-4169	red jittery 4-d camera	0		
+4169	jittery red 4-d camera	0		
 4170	shaking 4-d camera	0		
 4171	crystallized memory	0		
 4172	mirror stanky rock helmet	0		Stench Spell Damage: +25, Familiar Effect: "1xGhuol, cap 25"
@@ -4130,14 +4130,14 @@
 4178	slick sugar shotgun	0		Moxie: +10, Last Available: "2009-09"
 4179	squat sugar shillelagh of chilblains	0		Cold Damage: +25, Last Available: "2009-09"
 4180	razor-sharp sugar shank	0		Weapon Damage Percent: +25, Last Available: "2009-09"
-4181	shaking knitted sugar chapeau of the ox of the overflowing toilet	0		Muscle: +20, Stench Spell Damage: +50, Cold Resistance: +3, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	baleful sugar shorts	0		Spell Damage: +25, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	shaking knitted sugar chapeau of the ox of the overflowing toilet	0		Muscle: +20, Stench Spell Damage: +50, Cold Resistance: +3, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	baleful sugar shorts	0		Spell Damage: +25, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
-4185	pulsating gray slime convention flyers	0		
+4185	gray pulsating slime convention flyers	0		
 4186	slime convention coupons	0		
 4187	blurry blurry greasy slime convention pin	0		Sleaze Spell Damage: +10
-4188	wobbly upside-down slime convention t-shirt	0		
+4188	upside-down wobbly slime convention t-shirt	0		
 4189	inverse geode	0		
 4190	ghostly control crystal	0		Free Pull, Last Available: "2011-12"
 4191	family-friendly sugar shirt	0		Sleaze Resistance: +1, Last Available: "2009-09"
@@ -4150,7 +4150,7 @@
 4198	sea lasso	0		
 4199	purple blinking mansplainer's forbidden sea cowboy hat of the bloodbag	0		Spell Damage Percent: +50, Maximum HP: +100, Monster Level: +15, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
-4201	upside-down wobbly gill rings	0		Familiar Weight: +5
+4201	wobbly upside-down gill rings	0		Familiar Weight: +5
 4202	huge urchin roe	0		
 4203	pulsating pet anemone	0		Familiar Weight: +5
 4204	green Mer-kin cheatsheet	0		
@@ -4160,16 +4160,16 @@
 4208	blurry skate skates	0		
 4209	skate skin	0		
 4210	roller skate decoy	0		
-4211	twirling skewed mermaid's purse	0		
+4211	skewed twirling mermaid's purse	0		
 4212	upside-down underwater slingshot	0		
 4213	tumbling rock-hard Fonzie's skate blade	0		Experience (Moxie): +1, Damage Reduction: 5
 4214	spangly unitard	0		
 4215	olive wobbly wool Samson's collapsible baton	0		Experience (Muscle): +5, Cold Resistance: +1
 4216	groupie lipstick	0		
-4217	blurry upside-down groupie bra	0		
-4218	deionized bouncing spinning groupie spangles	0		Effect: "Mana Tea", Effect Duration: 58
+4217	upside-down blurry groupie bra	0		
+4218	deionized spinning bouncing groupie spangles	0		Effect: "Mana Tea", Effect Duration: 58
 4219	auspicious nasty skate board	0		Stench Damage: +5, Item Drop: +10
-4220	red shaking S.A.V.E. flyer	0		
+4220	shaking red S.A.V.E. flyer	0		
 4221	yield shield of the businessman	0		Meat Drop: +50, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
 4223	spinning squamous polyp	0		Free Pull, Last Available: "2011-12"
@@ -4178,7 +4178,7 @@
 4226	gravedigger's Star of Bravery	0		Spooky Damage: +10, Single Equip
 4227	huge hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	teal perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	blue amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	blue amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	huge can of sterno	0		
 4237	cheese-slicer of temperance	0		Sleaze Resistance: +5
-4238	decent low-calorie beef jerky	1	good	
+4238	low-calorie decent beef jerky	1	good	
 4239	fuchsia banded pipe wrench	0		Damage Absorption: +100
 4240	quantum Vulcanized spinning gun cleaning kit	0		Effect: "World's Shortest Giant", Effect Duration: 18
 4241	teal sleep mask of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4196,7 +4196,7 @@
 4244	foul-smelling leather-bound tome	0		Stench Damage: +10
 4245	ghostly bookmark	0		
 4246	sinister ivory cue ball	0		Spell Damage: +10
-4247	fancy artisanal decanter of fine Scotch	3	super EPIC	Effect: "Punchy, Murdery", Effect Duration: 35
+4247	artisanal fancy decanter of fine Scotch	3	super EPIC	Effect: "Punchy, Murdery", Effect Duration: 35
 4248	dried purple expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	adequate chocolate-covered scarab beetle	4	good	Last Available: "2009-10"
 4259	hand-crafted mulled cider	4	EPIC	Last Available: "2009-10"
-4260	twirling jittery wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	jittery twirling wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	bark boxers of the empath	0		Familiar Weight: +5, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	narrow bark beret of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	bark boxers of the empath	0		Familiar Weight: +5, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	narrow bark beret of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	deadly bark bracelet	0		Weapon Damage: +5, Single Equip
 4267	olive Fonzie's sage Krakrox's Loincloth	0		Mysticality Percent: +10, Experience (Moxie): +1, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	yellow stanky crafty Galapagosian Cuisses	0		Maximum MP: +10, Stench Spell Damage: +25, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	blurry therapeutic Ass-Stompers of Violence of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	baleful Newton's Brand of Violence of the blizzard	0		Experience (Mysticality): +3, Spell Damage: +25, Cold Spell Damage: +25, Conditional Skill (Equipped): "Brand"
 4299	lightning-fast zippy censurious Novelty Belt Buckle of Violence	0		Sleaze Resistance: +3, Initiative: 60, Single Equip
-4300	careful Tesla steel-toed Lens of Violence	0		Damage Reduction: 9, Monster Level: -10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	careful Tesla steel-toed Lens of Violence	0		Damage Reduction: 9, Monster Level: -10, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	reassuring steel-toed supercool Pigsticker of Violence	0		Moxie Percent: +20, Damage Reduction: 9, Spooky Resistance: +1
-4302	perfumed electrified rock-hard Jodhpurs of Violence	0		Damage Reduction: 5, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	perfumed electrified rock-hard Jodhpurs of Violence	0		Damage Reduction: 5, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	bouncing gravedigger's Tesla crafty Cold Stone of Hatred	0		Maximum MP: +10, Spooky Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Chilling Grip"
 4304	horrifying electrified shellacked Girdle of Hatred	0		Damage Reduction: 7, Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	cyan blinking cool Staff of Simmering Hatred of Calamity Jane of the sewer	0		Moxie: +5, Critical Hit Percent: +15, Stench Damage: +25
-4306	blue sizzling vibrating Pantaloons of Hatred of the storm	0		Maximum MP Percent: 50, Hot Damage: +10, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	blue sizzling vibrating Pantaloons of Hatred of the storm	0		Maximum MP Percent: 50, Hot Damage: +10, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	zippy Jim Carey's Fuzzy Slippers of Hatred of the pedagogue	0		Experience: +3, Monster Level: +25, Initiative: +20, Single Equip
-4308	greasy Newton's supercool Lens of Hatred	0		Moxie Percent: +20, Experience (Mysticality): +3, Sleaze Spell Damage: +10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	greasy Newton's supercool Lens of Hatred	0		Moxie Percent: +20, Experience (Mysticality): +3, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	flame-retardant greasy medical-grade Treads of Loathing	0		Sleaze Spell Damage: +10, Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4310	pulsating knitted chilly Scepter of Loathing of the sweet-tooth	0		Cold Damage: +5, Cold Resistance: +3, Candy Drop: +100
 4311	aromatic electrified medical-grade Belt of Loathing	0		Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip
@@ -4290,7 +4290,7 @@
 4338	plastic Don Crimbo of the storm	0		Maximum MP Percent: +40, Last Available: "2009-12"
 4339	yellow censurious plastic Crimbomination	0		Sleaze Resistance: +3, Last Available: "2009-12"
 4340	pressed dry Piddles	0		Effect: "Coy to the Hurled", Effect Duration: 28, Last Available: "2009-12"
-4341	nitrogenated energized ghostly pulsating BitterSweetTarts	0		Effect: "Resilient Spirit", Effect Duration: 30, Last Available: "2009-12"
+4341	nitrogenated energized pulsating ghostly BitterSweetTarts	0		Effect: "Resilient Spirit", Effect Duration: 30, Last Available: "2009-12"
 4342	denatured pressed Polka Pop	0		Effect: "Top Dog", Effect Duration: 20, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	purple plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	blue tumbling gingerbread house	0		Last Available: "2009-12"
 4348	gray leftover Crimbo rations	0		Last Available: "2009-12"
-4349	Temple Grandin's snow hat	0		Familiar Weight: +7, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	green fireproof snow pants	0		Hot Resistance: +3, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	Temple Grandin's snow hat	0		Familiar Weight: +7, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	green fireproof snow pants	0		Hot Resistance: +3, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	olive flame-retardant snow belly	0		Hot Resistance: +1, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4310,20 +4310,20 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	spoiled expired can of franks 'n' beans	3	crappy	Last Available: "2009-12"
-4361	drinkable enchanted twirling expired bottle of peppermint schnapps	4	good	Effect: "Antarctic Memories", Effect Duration: 35, Last Available: "2009-12"
+4361	enchanted drinkable twirling expired bottle of peppermint schnapps	4	good	Effect: "Antarctic Memories", Effect Duration: 35, Last Available: "2009-12"
 4362	squat snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
-4363	fuchsia bouncing elf resistance button	0		Last Available: "2009-12"
-4364	electrified shaking upside-down elven suicide capsule	0		Effect: "Morbidi Tea", Effect Duration: 28, Last Available: "2009-12"
+4363	bouncing fuchsia elf resistance button	0		Last Available: "2009-12"
+4364	electrified upside-down shaking elven suicide capsule	0		Effect: "Morbidi Tea", Effect Duration: 28, Last Available: "2009-12"
 4365	diet bland pulsating penguin focaccia bread	1	decent	Last Available: "2009-12"
-4366	special hand-crafted weak herringcello	2	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2009-12"
-4367	bad weak elven cellocello	2	decent	Last Available: "2009-12"
+4366	weak special hand-crafted herringcello	2	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50, Last Available: "2009-12"
+4367	weak bad elven cellocello	2	decent	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
 4372	tumbling chunk of cement	0		Last Available: "2009-12"
 4373	shaking purple grappling hook	0		Last Available: "2009-12"
-4374	twirling squat elf ear	0		Last Available: "2009-12"
+4374	squat twirling elf ear	0		Last Available: "2009-12"
 4375	tumbling spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
 4377	spinning throwing wrench of incineration	0		Hot Spell Damage: +50, Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	narrow Sherlock's pocketwatch on a chain of incineration	0		Hot Spell Damage: +50, Item Drop: +25, Last Available: "2009-12"
 4386	coward's rock-hard cement sandals	0		Damage Reduction: 5, Monster Level: -20, Single Equip, Last Available: "2009-12"
 4387	sizzling wizardly night-vision goggles	0		Mysticality: +25, Hot Damage: +10, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	hardened peanut brittle shield	0		Damage Reduction: 6, Last Available: "2009-12"
 4390	razor-sharp arcane researcher's Red Rover BB gun	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +25, Last Available: "2009-12"
-4391	strapping red-and-green sweater	0		Muscle: +5, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	strapping red-and-green sweater	0		Muscle: +5, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	pulsating Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	Vulcanized liquefied electrified Crimbo peppermint bark	0		Effect: "Biologically Shocked", Effect Duration: 44, Last Available: "2009-12"
 4394	extra-ionized Crimbo fudge	0		Effect: "The Best a Pirate Can Get", Effect Duration: 14, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	smooth cheese sword	0		Moxie: +15, Softcore Only, Last Available: "2010-01"
-4400	wholesome cheese diaper	0		Maximum HP Percent: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	wholesome cheese diaper	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	twirling gravedigger's cheese wheel	0		Spooky Damage: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	skewed cheese eye of James Dean	0		Experience (Moxie): +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	skewed cheese eye of James Dean	0		Experience (Moxie): +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	prompt Lo Pan's smartaleck's Staff of Queso Escusado	0		Moxie Percent: +30, Spell Critical Percent: +30, Adventures: +3, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4393,10 +4393,10 @@
 4445	huge spangly mariachi pants of horror	0		Spooky Spell Damage: +25, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	spangly mariachi vest of Gandalf of the brazier	0		Spell Critical Percent: +20, Hot Spell Damage: +25
 4447	inspector's spangly sombrero	0		Item Drop: +15, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	pickled twirling ghostly cyan Instant Karma	1	decent	Effect: "Comprehensively Nourished", Effect Duration: 20
+4448	pickled ghostly twirling cyan Instant Karma	1	decent	Effect: "Comprehensively Nourished", Effect Duration: 20
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	mirror experienced pointy hat	0		Experience: +2, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	mirror experienced pointy hat	0		Experience: +2, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	machetito of Tarzan	0		Experience (Muscle): +3, Last Available: "2010-04"
 4453	jittery tumbling huge aromatic lawnmower blade	0		Stench Resistance: +1, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	double-flattened vacuum-sealed tumbling chocolate saucepan	0		Effect: "Limber as Mortimer", Effect Duration: 43
 4466	alkaline dry chocolate disco ball	0		Effect: "Human-Pirate Hybrid", Effect Duration: 39
 4467	quadruple-energized energized corrupted huge chocolate stolen accordion	0		Effect: "Jittery", Effect Duration: 50
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	blue BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	bouncing gravedigger's BRICKO hat	0		Spooky Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	double-paned BRICKO pants	0		Cold Resistance: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	bouncing gravedigger's BRICKO hat	0		Spooky Damage: +10, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	double-paned BRICKO pants	0		Cold Resistance: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	BRICKO sword of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	skewed BRICKO bat	0		Last Available: "2010-02"
 4476	blue BRICKO oyster	0		Last Available: "2010-02"
 4477	narrow BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	wobbly BRICKO airship	0		Last Available: "2010-02"
@@ -4455,22 +4455,22 @@
 4507	tumbling blurry Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	oxidized &quot;DRINK ME&quot; potion	0		Effect: "Ermine Eyes", Effect Duration: 18, Last Available: "2010-03"
 4509	mirror spinning reflection of a map	0		Last Available: "2010-03"
-4510	fancy yummy walrus ice cream	3	awesome	Effect: "Wet Willied", Effect Duration: 10, Last Available: "2010-03"
-4511	small stale beautiful soup	2	decent	Last Available: "2010-03"
+4510	yummy fancy walrus ice cream	3	awesome	Effect: "Wet Willied", Effect Duration: 10, Last Available: "2010-03"
+4511	stale small beautiful soup	2	decent	Last Available: "2010-03"
 4512	shaking eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	adequate half-sized Humpty Dumplings	2	good	Last Available: "2010-03"
+4514	half-sized adequate Humpty Dumplings	2	good	Last Available: "2010-03"
 4515	normal upside-down Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
 4516	lousy special blinking missing wine	4	decent	Effect: "Rat-Faced", Effect Duration: 25, Last Available: "2010-03"
 4517	toothsome matter custard	3	awesome	Last Available: "2010-03"
-4518	denatured aerosolized jittery ghostly comfit?	0		Effect: "Surreally Buff", Effect Duration: 46, Last Available: "2010-03"
+4518	denatured aerosolized ghostly jittery comfit?	0		Effect: "Surreally Buff", Effect Duration: 46, Last Available: "2010-03"
 4519	cyan ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	sizzling flamingo mallet of the brazier	0		Hot Damage: +10, Hot Spell Damage: +25, Last Available: "2010-03"
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	spinning Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	nasty MacGyver's eye of the Tiger-lily	0		Maximum MP: +100, Stench Damage: +5, Last Available: "2010-03"
-4524	double-paned wig of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	thick decent skewed donut	5	good	Last Available: "2010-03"
+4524	double-paned wig of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +5, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	decent thick skewed donut	5	good	Last Available: "2010-03"
 4526	tasty bucket of honey	3	awesome	Last Available: "2010-03"
 4527	Oprah's elephant stinger of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Last Available: "2010-03"
 4528	stale dragon snaps	3	decent	Last Available: "2010-03"
@@ -4480,12 +4480,12 @@
 4532	flavorless bishop cookie	4	decent	Last Available: "2010-03"
 4533	stale bouncing knight cookie	3	decent	Last Available: "2010-03"
 4534	flavorless snack-sized maroon king cookie	2	decent	Last Available: "2010-03"
-4535	special decent cyan queen cookie	4	good	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
+4535	decent special cyan queen cookie	4	good	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	olive insane tophat of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	bouncing ghostly fuchsia banded helm of the knight of chilblains	0		Damage Absorption: +100, Cold Damage: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	olive insane tophat of Flo-Jo	0		Initiative: +100, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	bouncing ghostly fuchsia banded helm of the knight of chilblains	0		Damage Absorption: +100, Cold Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	tumbling avaricious wristwatch of the knight of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +30, Single Equip, Last Available: "2010-03"
-4540	trousers of the knight of the storm of extreme caution	0		Maximum MP Percent: +40, Monster Level: -25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	trousers of the knight of the storm of extreme caution	0		Maximum MP Percent: +40, Monster Level: -25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	crafty tophat	0		Maximum MP: +10, Familiar Effect: "1xBarrr, cap 25"
 4542	olive hale tie	0		Maximum HP: +20, Single Equip
 4543	hardened tuxedo pants	0		Damage Reduction: 3, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4521,15 +4521,15 @@
 4573	blurry The Legendary Beat	0		Last Available: "2010-04"
 4574	maroon panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	maroon skewed skewed bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	skewed maroon skewed bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	boiled improved maroon Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Rave Concentration", Effect Duration: 20, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-04"
-4581	fuchsia Temple Grandin's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the sewer	0		Familiar Weight: +7, Stench Damage: +25, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	fuchsia Temple Grandin's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the sewer	0		Familiar Weight: +7, Stench Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	red jittery fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	decent bouncing yellow squat six wedges of goat cheese	3	good	
+4584	decent bouncing squat yellow six wedges of goat cheese	3	good	
 4585	collection of objects	0		
 4586	twirling boulder	0		
 4587	goth	0		
@@ -4550,10 +4550,10 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	maroon jittery bronze handcuffs	0		Last Available: "2010-06"
 4604	red keg	0		Last Available: "2010-06"
-4605	mirror asbestos-lined bottle of Goldschn&ouml;ckered of the sweet-tooth	0		Hot Resistance: +5, Candy Drop: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	mirror asbestos-lined bottle of Goldschn&ouml;ckered of the sweet-tooth	0		Hot Resistance: +5, Candy Drop: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	bland sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	strong artisanal soyburger juice	5	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4608	narrow huge respected companion biscuit	0		Last Available: "2010-08"
+4608	huge narrow respected companion biscuit	0		Last Available: "2010-08"
 4609	red wobbly essential tofu	0		Last Available: "2010-08"
 4610	warmed extra-colloidal huge essential soy	0		Effect: "One For Tea", Effect Duration: 18, Last Available: "2010-08"
 4611	chilled nitrogenated essential cameraderie	0		Effect: "Coming Up Roses", Effect Duration: 39, Last Available: "2010-08"
@@ -4570,19 +4570,19 @@
 4622	red pulsating Game Grid ticket	0		Last Available: "2010-06"
 4623	altered bouncing shaking chocolate-covered caviar	0		Effect: "Sinuses For Miles", Effect Duration: 11, Last Available: "2020-09"
 4624	tasty pawn cookie	3	awesome	Last Available: "2010-06"
-4625	twisted bouncing huge coffee pixie stick	1	EPIC	Effect: "X-Ray Vision", Effect Duration: 35, Last Available: "2010-06"
+4625	twisted huge bouncing coffee pixie stick	1	EPIC	Effect: "X-Ray Vision", Effect Duration: 35, Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	red finger cuffs	0		Last Available: "2010-06"
 4628	red parachute guy	0		Last Available: "2010-06"
-4629	coward's plastic spider ring	0		Monster Level: -20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	coward's plastic spider ring	0		Monster Level: -20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	Lo Pan's plastic kazoo	0		Spell Critical Percent: +30, Last Available: "2010-06"
 4631	groovy inflatable baseball bat	0		Moxie Percent: +10, Last Available: "2010-06"
-4632	ruddy googly-star hat of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Familiar Effect: "atk", Last Available: "2010-06"
+4632	ruddy googly-star hat of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Last Available: "2010-06", Familiar Effect: "atk"
 4633	tumbling mansplainer's strapping googly-ball hat	0		Muscle: +5, Monster Level: +15, Last Available: "2010-06"
 4634	tumbling googly-heart hat of the overflowing toilet of the glutton	0		Stench Spell Damage: +50, Food Drop: +100, Last Available: "2010-06"
 4635	wool super-sweet boom box of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +1, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	wobbly ribald stiffened educational sinister demon mask	0		Experience: +1, Damage Reduction: 1, Sleaze Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	wobbly ribald stiffened educational sinister demon mask	0		Experience: +1, Damage Reduction: 1, Sleaze Damage: +10, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	Usain Bolt's executive Annie Oakley's streetfighting champion's belt	0		Critical Hit Percent: +20, Meat Drop: +40, Initiative: +80, Single Equip, Last Available: "2010-06"
 4639	beefcake's strapping Space Trip safety headphones of Tarzan	0		Muscle: 30, Experience (Muscle): +3, Single Equip, Last Available: "2010-06"
 4640	purple occult LARP carp	0		Spell Damage Percent: +25
@@ -4594,8 +4594,8 @@
 4646	avaricious greedy Meteoid ice beam of Flo-Jo	0		Meat Drop: 50, Initiative: +100, Last Available: "2011-12"
 4647	Oprah's healthy dangerous Dungeon Fist gauntlet	0		Weapon Damage: +10, Maximum HP Percent: +20, Maximum MP Percent: +50, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	shaking chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	wobbly fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	shaking chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	wobbly fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ghostly ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	careful thinker's ironic knit cap	0		Mysticality: +10, Monster Level: -10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	lime green map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	hardy blackberry galoshes	0		Maximum HP: +50, Single Equip
 4660	shaking avaricious occult trout fang	0		Spell Damage Percent: +25, Meat Drop: +30, Last Available: "2010-09"
-4661	huge bland poisonous caviar	8	decent	Last Available: "2010-09"
+4661	bland huge poisonous caviar	8	decent	Last Available: "2010-09"
 4662	polymerized wet venom duct	0		Effect: "Hagg-ard", Effect Duration: 56, Last Available: "2010-09"
 4663	blinking Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	twirling flame-retardant Ellsbury's skull of temperance	0		Hot Resistance: +1, Sleaze Resistance: +5, Last Available: "2010-09"
@@ -4616,7 +4616,7 @@
 4668	banded observational glasses	0		Damage Absorption: +100
 4669	narrow horrifying hilarious comedy prop	0		Spooky Damage: +25
 4670	beer-scented teddy bear	0		
-4671	practically non-alcoholic drinkable booze-soaked cherry	1	good	
+4671	drinkable practically non-alcoholic booze-soaked cherry	1	good	
 4672	comfy pillow	0		
 4673	yummy marshmallow	3	awesome	
 4674	moldy special sponge cake	3	crappy	Effect: "Venomous Weapon", Effect Duration: 25
@@ -4627,8 +4627,8 @@
 4679	blue volcanic ash	0		
 4680	smoked potsherd	0		
 4681	sinister pottery shield	0		Spell Damage: +10, Damage Reduction: 3, Last Available: "2010-09"
-4682	twirling Sherlock's pottery hat of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	mirror censurious pottery training pants of the pedagogue	0		Experience: +3, Sleaze Resistance: +3, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	twirling Sherlock's pottery hat of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +25, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	mirror censurious pottery training pants of the pedagogue	0		Experience: +3, Sleaze Resistance: +3, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	sizzling pottery club	0		Hot Damage: +10, Last Available: "2010-09"
 4685	pottery yo-yo of wisdom	0		Mysticality: +15, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,13 +4641,13 @@
 4693	red fossilized torso	0		Last Available: "2010-09"
 4694	shaking fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	purple executive Oprah's Greatest American Pants of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Meat Drop: +40, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	purple executive Oprah's Greatest American Pants of the empath	0		Maximum MP Percent: +50, Familiar Weight: +5, Meat Drop: +40, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	Usain Bolt's fossilized necklace	0		Initiative: +80, Last Available: "2010-09"
 4698	jittery imp air	0		
 4699	bus pass	0		
 4700	upside-down fossilized spike	0		Last Available: "2010-09"
-4701	upside-down shaking blinking waterlogged crate	0		Last Available: "2011-12"
-4702	squat wobbly archaeologing shovel	0		Last Available: "2011-12"
+4701	shaking blinking upside-down waterlogged crate	0		Last Available: "2011-12"
+4702	wobbly squat archaeologing shovel	0		Last Available: "2011-12"
 4703	wobbly red-hot medallion of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2010-09"
 4704	fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
@@ -4660,7 +4660,7 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	flavorless lemon popsicle	3	decent	
-4715	miniature spoiled blinking popsicle	2	crappy	
+4715	spoiled miniature blinking popsicle	2	crappy	
 4716	decent strawberry popsicle	3	good	
 4717	delicious liver popsicle	4	awesome	
 4718	tumbling squat narrow Annie Oakley's mariachi hat	0		Critical Hit Percent: +20, Familiar Effect: "atk, cap 2"
@@ -4669,38 +4669,38 @@
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	massive normal liver and let pie	9	good	Last Available: "2010-10"
 4723	normal teal badass pie	3	good	Last Available: "2010-10"
-4724	massive delicious shoo-fish pie	7	awesome	Last Available: "2010-10"
+4724	delicious massive shoo-fish pie	7	awesome	Last Available: "2010-10"
 4725	stale tiny piping organ pie	1	decent	Last Available: "2010-10"
 4726	stale igloo pie	3	decent	Last Available: "2010-10"
 4727	spoiled stomach turnover	3	crappy	Last Available: "2010-10"
-4728	miniature stale shaking dead lights pie	2	decent	Last Available: "2010-10"
+4728	stale miniature shaking dead lights pie	2	decent	Last Available: "2010-10"
 4729	spoiled throbbing organ pie	3	crappy	Last Available: "2010-10"
 4730	jittery veiny stop shield	0		Maximum HP: +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	teal sleeping piano cat	0		Free Pull, Last Available: "2011-12"
-4733	skewed narrow kitty sheet music	0		Familiar Weight: +5
+4733	narrow skewed kitty sheet music	0		Familiar Weight: +5
 4734	shaking rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	beer-soaked mop of the storm	0		Maximum MP Percent: +40
-4738	special acceptable practically non-alcoholic day-old beer	1	good	Effect: "Bloodstain-Resistant", Effect Duration: 30
-4739	watered-down hand-crafted plain beer	2	EPIC	
-4740	drinkable weak enchanted overpriced &quot;imported&quot; beer	2	good	Effect: "Old School Pompadour", Effect Duration: 5
+4738	special practically non-alcoholic acceptable day-old beer	1	good	Effect: "Bloodstain-Resistant", Effect Duration: 30
+4739	hand-crafted watered-down plain beer	2	EPIC	
+4740	weak enchanted drinkable overpriced &quot;imported&quot; beer	2	good	Effect: "Old School Pompadour", Effect Duration: 5
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	dry boiled wobbly PlexiPips	0		Effect: "Surreally Buff", Effect Duration: 22
 4745	diffused Wax Flask	0		Effect: "Chorale of Companionship", Effect Duration: 26
 4746	quantum cyan Pain Dip	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 29
-4747	delicious miniature enchanted bone meal	2	awesome	Effect: "Okee-Dokee, Smokee", Effect Duration: 30, Last Available: "2010-10"
+4747	miniature delicious enchanted bone meal	2	awesome	Effect: "Okee-Dokee, Smokee", Effect Duration: 30, Last Available: "2010-10"
 4748	lousy enchanted mirror bone aperitif	3	decent	Effect: "Brother Corsican's Blessing", Effect Duration: 20, Last Available: "2010-10"
 4749	Samson's bonerang	0		Experience (Muscle): +5, Last Available: "2010-10"
 4750	wicked bone and arrows	0		Spell Damage: +5, Last Available: "2010-10"
 4751	double-paned boning knife	0		Cold Resistance: +5, Last Available: "2010-10"
 4752	lime green groovy bone crusher	0		Moxie Percent: +10, Last Available: "2010-10"
 4753	bone spurs of horror	0		Spooky Spell Damage: +25, Single Equip, Last Available: "2010-10"
-4754	greasy dangerous bonedanna	0		Weapon Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	auspicious boneana hammock of the wise owl	0		Mysticality: +20, Item Drop: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	greasy dangerous bonedanna	0		Weapon Damage: +10, Sleaze Spell Damage: +10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	auspicious boneana hammock of the wise owl	0		Mysticality: +20, Item Drop: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	spinning bag of bones	0		Last Available: "2010-10"
 4757	mirror pulsating Stabonic scroll	0		Last Available: "2010-10"
 4758	deionized candy skeleton	0		Effect: "Irresistible Resolve", Effect Duration: 16, Last Available: "2020-09"
@@ -4724,9 +4724,9 @@
 4810	wobbly Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	narrow Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	yellow Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	delicious low-calorie squat CRIMBCOIDS mints	1	awesome	Last Available: "2011-01"
+4818	low-calorie delicious squat CRIMBCOIDS mints	1	awesome	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	snack-sized tasty blurry CRIMBCOLOAF	2	awesome	Last Available: "2011-01"
+4820	tasty snack-sized blurry CRIMBCOLOAF	2	awesome	Last Available: "2011-01"
 4821	rotten narrow circular CRIMBCOOKIE	3	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	chilly plastic CRIMBCO HQ	0		Cold Damage: +5, Last Available: "2010-12"
 4823	pulsating sinister plastic fax machine	0		Spell Damage: +10, Last Available: "2010-12"
@@ -4735,25 +4735,25 @@
 4826	maroon Jeselnik's plastic Best Game Ever	0		Sleaze Damage: +25, Last Available: "2010-12"
 4827	squat hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	green S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
-4829	jittery blinking robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
+4829	blinking jittery robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	blinking robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	purple robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	bouncing robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
-4836	wobbly mirror robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
+4836	mirror wobbly robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	purple robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	snack-sized rotten triangular CRIMBCOOKIE	2	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	rotten snack-sized triangular CRIMBCOOKIE	2	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	yummy square CRIMBCOOKIE	4	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	steel-toed sinister bindlestocking of the pedagogue	0		Experience: +3, Spell Damage: +10, Damage Reduction: 9, Last Available: "2010-12"
 4842	wobbly sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	blurry blurry The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	avaricious Uncle Hobo's stocking cap of the cheetah	0		Meat Drop: +30, Initiative: +60, Familiar Effect: "atk", Last Available: "2010-12"
+4845	avaricious Uncle Hobo's stocking cap of the cheetah	0		Meat Drop: +30, Initiative: +60, Last Available: "2010-12", Familiar Effect: "atk"
 4846	upside-down red flame-wreathed Uncle Hobo's epic beard of the scaredy-cat	0		Monster Level: -15, Hot Spell Damage: +10, Single Equip, Last Available: "2010-12"
-4847	Uncle Hobo's gift baggy pants of wisdom of temperance	0		Mysticality: +15, Sleaze Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	Uncle Hobo's gift baggy pants of wisdom of temperance	0		Mysticality: +15, Sleaze Resistance: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	sharpshooter's Uncle Hobo's fingerless tinsel gloves of Leguizamo	0		Critical Hit Percent: +10, Monster Level: +20, Single Equip, Last Available: "2010-12"
 4849	strapping Uncle Hobo's highest bough of the sewer	0		Muscle: +5, Stench Damage: +25, Last Available: "2010-12"
 4850	groovy Uncle Hobo's belt of James Dean	0		Moxie Percent: +10, Experience (Moxie): +3, Single Equip, Last Available: "2010-12"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	tumbling cyan paperclip sproinger	0		Last Available: "2011-01"
 4868	greedy smartaleck's paperclip-on tie of James Dean	0		Moxie Percent: +30, Experience (Moxie): +3, Meat Drop: +20, Single Equip, Last Available: "2011-01"
-4869	inspector's aromatic paperclip pants	0		Stench Resistance: +1, Item Drop: +15, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	skewed Samson's supercool smooth paperclip turban	0		Moxie: +15, Moxie Percent: +20, Experience (Muscle): +5, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	inspector's aromatic paperclip pants	0		Stench Resistance: +1, Item Drop: +15, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	skewed Samson's supercool smooth paperclip turban	0		Moxie: +15, Moxie Percent: +20, Experience (Muscle): +5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	spinning veiny paperclip cape	0		Maximum HP: +10, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	shaking photocopied monster	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	magnetized upside-down incense bath ball	0		Effect: "Well-Swabbed Ear", Effect Duration: 49, Last Available: "2011-01"
 4879	activated boiled ghostly myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Meatwise", Effect Duration: 22, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	lousy fancy blinking CRIMBCO wine	3	decent	Effect: "Pygmy Drinking Buddy", Effect Duration: 10, Last Available: "2011-01"
+4881	fancy lousy blinking CRIMBCO wine	3	decent	Effect: "Pygmy Drinking Buddy", Effect Duration: 10, Last Available: "2011-01"
 4882	tumbling Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	huge toe jam	0		Last Available: "2011-01"
 4884	moldy toe jam toast	4	crappy	Last Available: "2011-01"
@@ -4795,7 +4795,7 @@
 4886	bland enchanted traffic jam toast	3	decent	Effect: "Cheered Up", Effect Duration: 20, Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
 4888	normal immense space jam toast	7	good	Last Available: "2011-01"
-4889	altered magnetized cyan bouncing motivational poster	0		Effect: "Material Witness", Effect Duration: 35, Last Available: "2011-01"
+4889	altered magnetized bouncing cyan motivational poster	0		Effect: "Material Witness", Effect Duration: 35, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	tumbling slow jam collection	0		Last Available: "2011-01"
@@ -4832,7 +4832,7 @@
 4923	shaking groovy Loathing Legion abacus	0		Moxie Percent: +10, Softcore Only, Last Available: "2011-01"
 4924	upside-down Loathing Legion helicopter	0		Familiar Weight: +5, Softcore Only, Last Available: "2011-01"
 4925	Loathing Legion pizza stone of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 6, Softcore Only, Last Available: "2011-01"
-4926	jittery tumbling Loathing Legion universal screwdriver	0		Last Available: "2011-01"
+4926	tumbling jittery Loathing Legion universal screwdriver	0		Last Available: "2011-01"
 4927	huge blinking Loathing Legion jackhammer	0		Softcore Only, Last Available: "2011-01"
 4928	nasty Loathing Legion hammer	0		Stench Damage: +5, Softcore Only, Last Available: "2011-01"
 4929	Uncle Crimbo's Sack	0		Last Available: "2011-01"
@@ -4860,7 +4860,7 @@
 4957	vacuum-sealed improved skewed half-baked potion	0		Effect: "In the Limelight", Effect Duration: 50
 4958	bouncing Knob Goblin deluxe scimitar of the businessman	0		Meat Drop: +50
 4959	delicious Knob nuts	3	awesome	
-4960	weak lousy purple Cobb's Knob Wurstbrau	2	decent	
+4960	lousy weak purple Cobb's Knob Wurstbrau	2	decent	
 4961	Subject 37 file	0		
 4962	Socratic mysterious lapel pin of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4879,7 +4879,7 @@
 4976	blinking Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	huge Alice's Army Nurse	0		Last Available: "2011-03"
 4978	teal Alice's Army Hammerman	0		Last Available: "2011-03"
-4979	narrow upside-down purple Alice's Army Bowman	0		Last Available: "2011-03"
+4979	narrow purple upside-down Alice's Army Bowman	0		Last Available: "2011-03"
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	tumbling Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
@@ -4913,20 +4913,20 @@
 5010	narrow evil eye	0		
 5011	spinning Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	skewed Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	spoiled massive enchanted wasabi pocky	9	crappy	Effect: "On a Roll", Effect Duration: 10, Last Available: "2011-03"
-5014	special snack-sized decent tobiko pocky	2	good	Effect: "Spooky Flavor", Effect Duration: 40, Last Available: "2011-03"
+5013	massive spoiled enchanted wasabi pocky	9	crappy	Effect: "On a Roll", Effect Duration: 10, Last Available: "2011-03"
+5014	snack-sized decent special tobiko pocky	2	good	Effect: "Spooky Flavor", Effect Duration: 40, Last Available: "2011-03"
 5015	delicious big olive natto pocky	5	awesome	Last Available: "2011-03"
 5016	tolerable blue wasabi-infused sake	3	good	Last Available: "2011-03"
 5017	acceptable tobiko-infused sake	3	good	Last Available: "2011-03"
 5018	acceptable distilled natto-infused sake	5	good	Last Available: "2011-03"
-5019	dry blurry jittery fuchsia wasabi marble soda	0		Effect: "Executive Greed", Effect Duration: 41, Last Available: "2011-03"
+5019	dry fuchsia blurry jittery wasabi marble soda	0		Effect: "Executive Greed", Effect Duration: 41, Last Available: "2011-03"
 5020	altered upside-down tobiko marble soda	0		Effect: "Mushroom Melody", Effect Duration: 27, Last Available: "2011-03"
 5021	denatured ionized unsweetened natto marble soda	0		Effect: "The Strength...  of the Future", Effect Duration: 38, Last Available: "2011-03"
 5022	blinking Alice's Army booster box	0		Last Available: "2011-03"
 5023	corrupted polymerized elderly jawbreaker	0		Effect: "Bottle in front of Me", Effect Duration: 38, Last Available: "2020-09"
 5024	watered-down delicious marshmallow flamb&eacute;	2	awesome	Last Available: "2011-03"
 5025	artisanal cranberry schnapps	3	EPIC	Last Available: "2011-03"
-5026	bad boozy breaded beer	5	decent	Last Available: "2011-03"
+5026	boozy bad breaded beer	5	decent	Last Available: "2011-03"
 5027	tolerable soy cordial	3	good	Last Available: "2011-03"
 5028	chilly mansplainer's strapping astral bludgeon	0		Muscle: +5, Monster Level: +15, Cold Damage: +5
 5029	occult astral shield of mayonnaise	0		Spell Damage Percent: +25, Sleaze Spell Damage: +50, Damage Reduction: 15
@@ -4943,15 +4943,15 @@
 5040	wobbly astral pet sweater	0		Familiar Weight: +10
 5041	family-friendly astral shirt of the bloodbag of the blizzard	0		Maximum HP: +100, Cold Spell Damage: +25, Sleaze Resistance: +1
 5042	nasty astral belt of the businessman	0		Stench Damage: +5, Meat Drop: +50
-5043	miniature rotten mirror astral hot dog	2		
-5044	weak perfectly mixed astral pilsner	2		
+5043	rotten miniature mirror astral hot dog	2		
+5044	perfectly mixed weak astral pilsner	2		
 5045	astral hot dog dinner	0		
 5046	spinning astral six-pack	0		
 5047	spinning Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	spinning shard of double-ice	0		Last Available: "2011-04"
-5049	friendly careful double-ice cap of chilblains	0		Monster Level: -10, Familiar Weight: +3, Cold Damage: +25, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	friendly careful double-ice cap of chilblains	0		Monster Level: -10, Familiar Weight: +3, Cold Damage: +25, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	wobbly chilly resourceful razor-sharp double-ice box	0		Weapon Damage Percent: +25, Maximum MP: +50, Cold Damage: +5, Last Available: "2011-04"
-5051	crafty experienced double-ice britches	0		Experience: +2, Maximum MP: +10, Item Drop: +5, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	crafty experienced double-ice britches	0		Experience: +2, Maximum MP: +10, Item Drop: +5, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4965,26 +4965,26 @@
 5062	yellow voodoo doll	0		Last Available: "2011-04"
 5063	lime green the finger	0		Last Available: "2011-04"
 5064	jittery Salsa de las Epocas	0		Last Available: "2011-04"
-5065	fancy bland diet spaghetti con calaveras	1	decent	Effect: "Sated and Furious", Effect Duration: 45, Last Available: "2011-04"
+5065	fancy diet bland spaghetti con calaveras	1	decent	Effect: "Sated and Furious", Effect Duration: 45, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	bland spinning popcorn	3	decent	Last Available: "2011-04"
 5068	normal small chaos popcorn	2	good	Last Available: "2011-04"
 5069	lime green vibrating sinister hole of the sweet-tooth	0		Spell Damage: +10, Maximum MP Percent: +10, Candy Drop: +100, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	huge rotten blurry s'more	0	crappy	Last Available: "2011-04"
+5071	rotten huge blurry s'more	0	crappy	Last Available: "2011-04"
 5072	yellow diamond ring	0		Last Available: "2011-04"
 5073	acceptable pulsating Russian Ice	4	good	Last Available: "2011-04"
 5074	blinking Usain Bolt's clay ashtray	0		Initiative: +80, Damage Reduction: 3, Last Available: "2011-05"
 5075	padded lanyard	0		Damage Absorption: +20, Single Equip, Last Available: "2011-05"
-5076	slick monster pants	0		Moxie: +10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	slick monster pants	0		Moxie: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	spinning box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	wet quadruple-diffused Pok&euml;mann band-aid	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 54, Last Available: "2011-05"
-5079	upside-down electrified Van der Graaf helmet of the bloodbag	0		Maximum HP: +100, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	upside-down electrified Van der Graaf helmet of the bloodbag	0		Maximum HP: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	spinning crutch of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-05"
 5081	spinning pulsating quilted shock belt	0		Damage Absorption: +40, Single Equip, Last Available: "2011-05"
 5082	pickled red Okee-Dokee soda	0		Effect: "Experimental Effect G-9", Effect Duration: 30, Last Available: "2011-05"
 5083	rubber band gun of the pedagogue	0		Experience: +3, Last Available: "2011-05"
-5084	weightlifter's pin-stripe slacks	0		Muscle: +15, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	weightlifter's pin-stripe slacks	0		Muscle: +15, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	gloves of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2011-05"
 5086	ionized modified correction fluid	0		Effect: "Tennis Elbow-wow", Effect Duration: 33, Last Available: "2011-05"
 5087	hardy Pok&euml;mann figurine: Porkachu	0		Maximum HP: +50, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	drinkable Jeppson's Malort	3	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	quilted stress ball	0		Damage Absorption: +40, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	quilted stress ball	0		Damage Absorption: +40, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	manspreader's Ultracolor&trade; shirt	0		Monster Level: +10, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5018,11 +5018,11 @@
 5115	hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
-5118	yellow jittery bird brain	0		
+5118	jittery yellow bird brain	0		
 5119	busted wings	0		
 5120	mirror Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	shaking ghostly sizzling Jim Carey's shellacked Admiral's hat	0		Damage Reduction: 7, Monster Level: +25, Hot Damage: +10, Familiar Effect: "atk", Last Available: "2011-05"
-5122	yellow hale banded thinker's aviator's cap	0		Mysticality: +10, Damage Absorption: +100, Maximum HP: +20, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	shaking ghostly sizzling Jim Carey's shellacked Admiral's hat	0		Damage Reduction: 7, Monster Level: +25, Hot Damage: +10, Last Available: "2011-05", Familiar Effect: "atk"
+5122	yellow hale banded thinker's aviator's cap	0		Mysticality: +10, Damage Absorption: +100, Maximum HP: +20, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	sinister beefcake's mirrored aviator shades	0		Muscle: +25, Spell Damage: +10, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	olive Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5033,7 +5033,7 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	non-quantum cold-filtered Ultrasoldier Serum	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 35, Last Available: "2011-06"
 5132	flavorless elven hardtack	3	decent	Last Available: "2011-06"
-5133	practically non-alcoholic acceptable elven squeeze	1	good	Last Available: "2011-06"
+5133	acceptable practically non-alcoholic elven squeeze	1	good	Last Available: "2011-06"
 5134	pulsating lunar isotope	0		Last Available: "2011-06"
 5135	mirror E.M.U. joystick	0		Last Available: "2011-06"
 5136	lime green E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	green narrow scandalous toasty Lo Pan's honey dipper	0		Spell Critical Percent: +30, Hot Damage: +5, Sleaze Damage: +5
 5149	honeybritches of the blizzard of courage of the boozehound	0		Cold Spell Damage: +25, Spooky Resistance: +3, Booze Drop: +100, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	knitted savvy honeycap of doom	0		Mysticality Percent: +20, Spooky Spell Damage: +50, Cold Resistance: +3, Familiar Effect: "1xPotato, cap 43"
-5151	mirror teal perfumed Moonthril Circlet	0		Stench Resistance: +5, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	bouncing occult Moonthril Greaves	0		Spell Damage Percent: +25, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	mirror teal perfumed Moonthril Circlet	0		Stench Resistance: +5, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	bouncing occult Moonthril Greaves	0		Spell Damage Percent: +25, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	Moonthril Flamberge of extreme caution	0		Monster Level: -25, Last Available: "2011-06"
 5154	frightening Moonthril Longbow	0		Spooky Damage: +5, Last Available: "2011-06"
 5155	olive lightning-fast Moonthril Cuirass	0		Initiative: +40, Softcore Only, Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	Vulcanized honey stick	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 54
 5189	diffused double-ice gum	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 21, Last Available: "2011-04"
-5190	cyan zippy quilted Operation Patriot Shield of the brute	0		Muscle Percent: +30, Damage Absorption: +40, Initiative: +20, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	cyan zippy quilted Operation Patriot Shield of the brute	0		Muscle Percent: +30, Damage Absorption: +40, Initiative: +20, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	electrified altered corrupted data	0		Effect: "Pie in the Sky", Effect Duration: 16, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5099,7 +5099,7 @@
 5196	pulsating knitted Great S-Cape	0		Cold Resistance: +3, Softcore Only, Last Available: "2011-07"
 5197	executive Marvelous Unitard	0		Meat Drop: +40, Softcore Only, Last Available: "2011-07"
 5198	powdered upside-down gooey paste	1	EPIC	Effect: "Full of Wist", Effect Duration: 50, Last Available: "2011-08"
-5199	pickled squat skewed beastly paste	1	EPIC	Last Available: "2011-08"
+5199	pickled skewed squat beastly paste	1	EPIC	Last Available: "2011-08"
 5200	dehydrated maroon paste	1	decent	Effect: "A Few Extra Pounds", Effect Duration: 50, Last Available: "2011-08"
 5201	compressed pulsating ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	mixed cyan greasy paste	1	good	Effect: "Ripping, Dripping", Effect Duration: 30, Last Available: "2011-08"
@@ -5115,7 +5115,7 @@
 5212	twisted upside-down paste	1	EPIC	Last Available: "2011-08"
 5213	powdered Mer-kin paste	1	good	Effect: "Pasta Oneness", Effect Duration: 30, Last Available: "2011-08"
 5214	twisted slimy paste	1	awesome	Last Available: "2011-08"
-5215	dehydrated upside-down tumbling penguin paste	1	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 25, Last Available: "2011-08"
+5215	dehydrated tumbling upside-down penguin paste	1	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 25, Last Available: "2011-08"
 5216	dehydrated elemental paste	1	good	Effect: "Bear Clawed", Effect Duration: 25, Last Available: "2011-08"
 5217	altered bouncing cosmic paste	1	EPIC	Effect: "Spookypants", Effect Duration: 45, Last Available: "2011-08"
 5218	denatured blinking shaking hobo paste	1	decent	Last Available: "2011-08"
@@ -5123,11 +5123,11 @@
 5220	Teachings of the Fist	0		
 5221	bouncing fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	normal half-sized twirling Ur-Donut	2	good	Last Available: "2011-09"
-5225	upside-down red The Bomb	0		Last Available: "2011-09"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5224	half-sized normal twirling Ur-Donut	2	good	Last Available: "2011-09"
+5225	red upside-down The Bomb	0		Last Available: "2011-09"
 5226	blinking box of Familiar Jacks	0		Last Available: "2011-09"
-5227	delicious shaking squat bucket of wine	3	awesome	Last Available: "2011-09"
+5227	delicious squat shaking bucket of wine	3	awesome	Last Available: "2011-09"
 5228	stale ultrafondue	3	decent	Last Available: "2011-09"
 5229	teal unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5138,25 +5138,25 @@
 5235	tumbling studded furry halo	0		Damage Absorption: +80, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	chaotic frosty halo	0		Spell Critical Percent: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	aromatic time halo	0		Stench Resistance: +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	artisanal watered-down jittery Lumineux Limnio	2	EPIC	Last Available: "2011-09"
-5239	watered-down drinkable narrow Morto Moreto	2	good	Last Available: "2011-09"
-5240	watered-down hand-crafted Temps Tempranillo	2	EPIC	Last Available: "2011-09"
+5238	watered-down artisanal jittery Lumineux Limnio	2	EPIC	Last Available: "2011-09"
+5239	drinkable watered-down narrow Morto Moreto	2	good	Last Available: "2011-09"
+5240	hand-crafted watered-down Temps Tempranillo	2	EPIC	Last Available: "2011-09"
 5241	hand-crafted Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
-5242	boozy lousy Fromage Pinotage	5	decent	Last Available: "2011-09"
+5242	lousy boozy Fromage Pinotage	5	decent	Last Available: "2011-09"
 5243	acceptable triple-distilled Beignet Milgranet	8	good	Last Available: "2011-09"
 5244	tolerable Muschat	3	good	Last Available: "2011-09"
 5245	snack-sized moldy cool jelly donut	2	crappy	Last Available: "2011-09"
-5246	yummy small shrapnel jelly donut	2	awesome	Last Available: "2011-09"
-5247	adequate enchanted occult jelly donut	4	good	Effect: "Impregnabili Tea", Effect Duration: 10, Last Available: "2011-09"
+5246	small yummy shrapnel jelly donut	2	awesome	Last Available: "2011-09"
+5247	enchanted adequate occult jelly donut	4	good	Effect: "Impregnabili Tea", Effect Duration: 10, Last Available: "2011-09"
 5248	normal huge thyme jelly donut	3	good	Last Available: "2011-09"
-5249	snack-sized enchanted rotten danish	2	crappy	Effect: "Concentrated Concentration", Effect Duration: 15, Last Available: "2011-09"
+5249	rotten enchanted snack-sized danish	2	crappy	Effect: "Concentrated Concentration", Effect Duration: 15, Last Available: "2011-09"
 5250	miniature adequate smashed danish	2	good	Last Available: "2011-09"
-5251	stale miniature forbidden danish	2	decent	Last Available: "2011-09"
+5251	miniature stale forbidden danish	2	decent	Last Available: "2011-09"
 5252	decent cool cat claw	3	good	Last Available: "2011-09"
 5253	flavorless pulsating blunt cat claw	4	decent	Last Available: "2011-09"
 5254	fancy spoiled red shadowy cat claw	3	crappy	Effect: "Human-Horror Hybrid", Effect Duration: 10, Last Available: "2011-09"
 5255	adequate cheezburger	4	good	Last Available: "2011-09"
-5256	bite-sized enchanted decent toasted brie	1	good	Effect: "Liquid Courage", Effect Duration: 25, Last Available: "2011-09"
+5256	enchanted decent bite-sized toasted brie	1	good	Effect: "Liquid Courage", Effect Duration: 25, Last Available: "2011-09"
 5257	vacuum-sealed colloidal potion of the field gar	0		Effect: "Pie in the Sky", Effect Duration: 21, Last Available: "2011-09"
 5258	galvanized galvanized altered too legit potion	0		Effect: "Super-Charged", Effect Duration: 63, Last Available: "2011-09"
 5259	Vulcanized upside-down Bright Water	0		Effect: "Mushroom Might", Effect Duration: 17, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	fuchsia narrow flame-wreathed broken clock	0		Hot Spell Damage: +10, Last Available: "2011-09"
 5282	greasy dethklok	0		Sleaze Spell Damage: +10, Last Available: "2011-09"
 5283	weightlifter's glacial clock	0		Muscle: +15, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	skewed d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy phish stick	3	crappy	Last Available: "2011-09"
-5299	huge ghostly double-paned occult plastic vampire fangs of horror	0		Spell Damage Percent: +25, Spooky Spell Damage: +25, Cold Resistance: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	huge ghostly double-paned occult plastic vampire fangs of horror	0		Spell Damage Percent: +25, Spooky Spell Damage: +25, Cold Resistance: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5222,10 +5222,10 @@
 5319	alkaline irradiated dry Blood 'n' Plenty	0		Effect: "Sausage Festive", Effect Duration: 58, Last Available: "2011-10"
 5320	alkaline nitrogenated jittery Lobos Mints	0		Effect: "Dweeby", Effect Duration: 65, Last Available: "2011-10"
 5321	double-tarnished irradiated polarized jittery Sweet Sword	0		Effect: "Egged On", Effect Duration: 51, Last Available: "2011-10"
-5322	high-proof tolerable mirror Ecto-Cooler	7	good	Last Available: "2011-10"
+5322	tolerable high-proof mirror Ecto-Cooler	7	good	Last Available: "2011-10"
 5323	mediocre Bartles and BRAAAINS wine cooler	4	decent	Last Available: "2011-10"
 5324	lousy Blood Light	3	decent	Last Available: "2011-10"
-5325	drinkable fortified Silver Bullet beer	5	good	Last Available: "2011-10"
+5325	fortified drinkable Silver Bullet beer	5	good	Last Available: "2011-10"
 5326	drinkable Bone's Farm &quot;wine&quot;	3	good	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	altered quantum sorority brain	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 37, Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	aerosolized modified moist drum of pomade	0		Effect: "It's Soporiffic!", Effect Duration: 36, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	wobbly Sherlock's extra-see-thru nightie	0		Item Drop: +25, Last Available: "2011-10"
-5333	BRAINS shorts of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	BRAINS shorts of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	squat weightlifter's Mesmereyes&trade; contact lenses	0		Muscle: +15, Single Equip, Last Available: "2011-10"
 5335	ghostly educational scrunchie	0		Experience: +1, Single Equip, Last Available: "2011-10"
-5336	ghostly steel-toed groovy extremely skinny jeans	0		Moxie Percent: +10, Damage Reduction: 9, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	padded The Necbromancer's Hat of the detective	0		Damage Absorption: +20, Item Drop: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	ghostly steel-toed groovy extremely skinny jeans	0		Moxie Percent: +10, Damage Reduction: 9, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	padded The Necbromancer's Hat of the detective	0		Damage Absorption: +20, Item Drop: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	jittery personal trainer's Sinatra's The Necbromancer's Stein of the dark arts	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Spell Damage Percent: +100, Last Available: "2011-10"
-5339	personal trainer's The Necbromancer's Shorts of the wise owl of the brazier	0		Mysticality: +20, Experience Percent (Muscle): +10, Hot Spell Damage: +25, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	personal trainer's The Necbromancer's Shorts of the wise owl of the brazier	0		Mysticality: +20, Experience Percent (Muscle): +10, Hot Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	boxer's The Necbromancer's Wizard Staff of Gandalf of the overflowing toilet	0		Muscle Percent: +10, Spell Critical Percent: +20, Stench Spell Damage: +50, Last Available: "2011-10"
 5341	skewed The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	drinkable The Cooler Out of Space	3	good	Last Available: "2011-10"
@@ -5249,7 +5249,7 @@
 5346	death blossom	0		
 5347	A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
-5349	olive spinning A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
+5349	spinning olive A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	blurry A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	pulsating A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
@@ -5264,7 +5264,7 @@
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	red CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
-5364	blue pulsating CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
+5364	pulsating blue CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 5366	CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
@@ -5289,8 +5289,8 @@
 5386	deadly ridiculous belt	0		Weapon Damage: +5, Last Available: "2011-11"
 5387	ghostly smelly ridiculous earring	0		Stench Spell Damage: +10, Last Available: "2011-11"
 5388	ruddy ridiculous sunglasses	0		Maximum HP Percent: +40, Last Available: "2011-11"
-5389	normal half-sized ridiculous sandwich	2	good	Last Available: "2011-11"
-5390	drinkable irresponsibly strong ridiculous cocktail	10	good	Last Available: "2011-11"
+5389	half-sized normal ridiculous sandwich	2	good	Last Available: "2011-11"
+5390	irresponsibly strong drinkable ridiculous cocktail	10	good	Last Available: "2011-11"
 5391	electrified deadly zombie monkey necklace	0		Weapon Damage: +5, MP Regen Min: 3, MP Regen Max: 5
 5392	spinning Thwaitgold butterfly statuette	0		
 5393	skewed wobbly scrap of paper	0		
@@ -5306,14 +5306,14 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	up-at-dawn perfumed Da Vinci's cane-mail shirt	0		Experience (Mysticality): +5, Stench Resistance: +5, Adventures: +5, Last Available: "2011-12"
-5406	blinking inspector's chaotic beefcake's cane-mail pants	0		Muscle: +25, Spell Critical Percent: +10, Item Drop: +15, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	watered-down artisanal Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
+5406	blinking inspector's chaotic beefcake's cane-mail pants	0		Muscle: +25, Spell Critical Percent: +10, Item Drop: +15, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5407	artisanal watered-down Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
 5408	artisanal Gin Mint	3	EPIC	Last Available: "2011-12"
 5409	boozy artisanal Tequiz Navidad	5	EPIC	Last Available: "2011-12"
-5410	fortified perfectly mixed Mint Yulep	5	EPIC	Last Available: "2011-12"
-5411	perfectly mixed spirit-forward blurry wobbly Crimbojito	5	EPIC	Last Available: "2011-12"
+5410	perfectly mixed fortified Mint Yulep	5	EPIC	Last Available: "2011-12"
+5411	perfectly mixed spirit-forward wobbly blurry Crimbojito	5	EPIC	Last Available: "2011-12"
 5412	hand-crafted squat Sangria de Menthe	3	EPIC	Last Available: "2011-12"
-5413	squat twirling candycaine powder	0		Last Available: "2011-12"
+5413	twirling squat candycaine powder	0		Last Available: "2011-12"
 5414	blinking squat licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	irradiated jittery licorice root	0		Effect: "Blubbered Up", Effect Duration: 56, Last Available: "2011-12"
 5416	deionized dry banana supersucker	0		Effect: "Sewer-Drenched", Effect Duration: 38, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	executive kumquartz ring	0		Meat Drop: +40, Single Equip, Last Available: "2011-11"
 5425	weightlifter's strawberyl necklace	0		Muscle: +15, Single Equip, Last Available: "2011-11"
 5426	narrow Sherlock's sucker bucket of the early riser	0		Item Drop: +25, Adventures: +7, Last Available: "2011-11"
-5427	supercool sucker hakama	0		Moxie Percent: +20, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	weightlifter's sucker kabuto	0		Muscle: +15, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	supercool sucker hakama	0		Moxie Percent: +20, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	weightlifter's sucker kabuto	0		Muscle: +15, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	spinning spinning Jack Frost's sucker tachi	0		Cold Spell Damage: +50, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	energetic vibrating fudgecycle of the bloodbag	0		Maximum HP: +100, Maximum MP Percent: 30, Single Equip, Last Available: "2011-11"
 5461	cyan fudge cube	0		Last Available: "2011-11"
 5462	wobbly blank fudge mold	0		Last Available: "2011-11"
-5463	twirling Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	twirling Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	adjusted jittery cyan resolution: be wealthier	0		Effect: "Mad at Science", Effect Duration: 69, Last Available: "2012-01"
 5465	activated energized resolution: be happier	0		Effect: "French Bronilla Brogueishness", Effect Duration: 33, Last Available: "2012-01"
 5466	ionized resolution: be stronger	0		Effect: "Tenacity of the Snapper", Effect Duration: 51, Last Available: "2012-01"
@@ -5379,12 +5379,12 @@
 5476	diffused cyan gummi salamander	0		Effect: "Highland Sheen", Effect Duration: 18, Last Available: "2011-11"
 5477	super-alkaline gummi snake	0		Effect: "Greasy Peasy", Effect Duration: 23, Last Available: "2011-11"
 5478	cold-filtered chilled blinking gummi canary	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 25, Last Available: "2011-11"
-5479	normal immense gummi bear	9	good	Last Available: "2011-11"
+5479	immense normal gummi bear	9	good	Last Available: "2011-11"
 5480	spoiled fuchsia gummi bear	3	crappy	Last Available: "2011-11"
 5481	low-calorie rotten lime green gummi bear	1	crappy	Last Available: "2011-11"
 5482	adequate tumbling drunki-bear	3	good	Last Available: "2011-11"
 5483	jumbo normal yellow drunki-bear	5	good	Last Available: "2011-11"
-5484	gigantic tasty green drunki-bear	9	awesome	Last Available: "2011-11"
+5484	tasty gigantic green drunki-bear	9	awesome	Last Available: "2011-11"
 5485	healthy gummi bowtie	0		Maximum HP Percent: +20, Last Available: "2011-11"
 5486	blinking horrifying fudge pocket square	0		Spooky Damage: +25, Last Available: "2011-11"
 5487	sinister lollipop cufflinks	0		Spell Damage: +10, Last Available: "2011-11"
@@ -5399,18 +5399,18 @@
 5496	improved ionized jittery gummi belemnite	0		Effect: "From Nantucket", Effect Duration: 61, Last Available: "2011-11"
 5497	bouncing all-year sucker	0		Last Available: "2011-11"
 5498	squat heart of dark chocolate	0		Last Available: "2011-11"
-5499	wool Big Candy's tophat of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +1, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	wool Big Candy's tophat of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +1, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	ghostly Jackass Plumber home game	0		Last Available: "2011-11"
 5502	blinking Trivial Avocations board game	0		Last Available: "2011-11"
 5503	fuchsia Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	massive spoiled jerky coins	6	crappy	Last Available: "2011-11"
+5506	spoiled massive jerky coins	6	crappy	Last Available: "2011-11"
 5507	lousy Go-Wassail	3	decent	Last Available: "2011-11"
 5508	polarized energized wet lime green Uncle Greenspan's Bathroom Finance Guide	0		Effect: "One Foot Heavier", Effect Duration: 34, Last Available: "2011-11"
 5509	colloidal concentrated bottle of bubbles	0		Effect: "Stench Jellied", Effect Duration: 61, Last Available: "2011-11"
-5510	irradiated fuchsia wobbly squat wind-up meatcar	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 47, Last Available: "2011-11"
+5510	irradiated wobbly squat fuchsia wind-up meatcar	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 47, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5423,11 +5423,11 @@
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	pog #08 (hellion)	0		Last Available: "2011-11"
-5523	tumbling spinning pog #09 (pirate)	0		Last Available: "2011-11"
+5523	spinning tumbling pog #09 (pirate)	0		Last Available: "2011-11"
 5524	skewed pog #10 (hobo)	0		Last Available: "2011-11"
 5525	jittery pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	non-moist skewed Atomic Pop	0		Effect: "Stinky Hands", Effect Duration: 63, Last Available: "2020-09"
-5527	skewed pulsating do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
+5527	pulsating skewed do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
 5529	adequate twirling berries of suffering	4	good	Last Available: "2012-12"
 5530	corrupted baobab sap	0		Effect: "Jacked In", Effect Duration: 42, Last Available: "2012-12"
@@ -5459,69 +5459,69 @@
 5556	miser's toasty Rain-Doh wings	0		Hot Damage: +5, Meat Drop: +10, Softcore Only, Last Available: "2012-02"
 5557	bouncing Rain-Doh agent	0		Last Available: "2012-02"
 5558	frosty Rain-Doh laser gun of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Softcore Only, Last Available: "2012-02"
-5559	twirling chilly sharpshooter's Rain-Doh lantern	0		Critical Hit Percent: +10, Cold Damage: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	twirling chilly sharpshooter's Rain-Doh lantern	0		Critical Hit Percent: +10, Cold Damage: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	pulsating Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	nippy Rain-Doh violet bo of mayonnaise	0		Cold Damage: +10, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	diet spoiled enchanted PB&BP	1	crappy	Effect: "Human-Goblin Hybrid", Effect Duration: 50
+5565	spoiled enchanted diet PB&BP	1	crappy	Effect: "Human-Goblin Hybrid", Effect Duration: 50
 5566	moldy club sandwich	3	crappy	
-5567	gigantic adequate blinking corned-beef Reuben	8	good	
+5567	adequate gigantic blinking corned-beef Reuben	8	good	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	mirror Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	artisanal jittery lime green wobbly Drac & Tan	3	EPIC	Last Available: "2012-03"
+5573	artisanal lime green wobbly jittery Drac & Tan	3	EPIC	Last Available: "2012-03"
 5574	bad Transylvania Sling	3	decent	Last Available: "2012-03"
-5575	fortified acceptable spinning tumbling Shot of the Living Dead	5	good	Last Available: "2012-03"
+5575	fortified acceptable tumbling spinning Shot of the Living Dead	5	good	Last Available: "2012-03"
 5576	watered-down acceptable Buttery Knob	2	good	Last Available: "2012-03"
 5577	bad Slippery Knob	4	decent	Last Available: "2012-03"
-5578	triple-distilled special artisanal Flaming Knob	6	EPIC	Effect: "Mana Tea", Effect Duration: 30, Last Available: "2012-03"
+5578	special triple-distilled artisanal Flaming Knob	6	EPIC	Effect: "Mana Tea", Effect Duration: 30, Last Available: "2012-03"
 5579	practically non-alcoholic hand-crafted squat Grasshopper	1	EPIC	Last Available: "2012-03"
-5580	perfectly mixed fortified enchanted Locust	5	EPIC	Effect: "Heart of White", Effect Duration: 20, Last Available: "2012-03"
+5580	fortified enchanted perfectly mixed Locust	5	EPIC	Effect: "Heart of White", Effect Duration: 20, Last Available: "2012-03"
 5581	hand-crafted Plague of Locusts	3	EPIC	Last Available: "2012-03"
 5582	drinkable Red Dwarf	3	good	Last Available: "2012-03"
 5583	aged watered-down Golden Mean	2	awesome	Last Available: "2012-03"
-5584	artisanal strong Green Giant	5	EPIC	Last Available: "2012-03"
-5585	drinkable watered-down upside-down Aye Aye	2	good	Last Available: "2012-03"
-5586	perfectly mixed high-proof Aye Aye, Captain	7	EPIC	Last Available: "2012-03"
+5584	strong artisanal Green Giant	5	EPIC	Last Available: "2012-03"
+5585	watered-down drinkable upside-down Aye Aye	2	good	Last Available: "2012-03"
+5586	high-proof perfectly mixed Aye Aye, Captain	7	EPIC	Last Available: "2012-03"
 5587	lousy distilled Aye Aye, Tooth Tooth	5	decent	Last Available: "2012-03"
 5588	tolerable special Humanitini	4	good	Effect: "Discomfited", Effect Duration: 30, Last Available: "2012-03"
 5589	mediocre More Humanitini than Humanitini	3	decent	Last Available: "2012-03"
 5590	artisanal Oh, the Humanitini	4	EPIC	Last Available: "2012-03"
 5591	tolerable Great Older Fashioned	4	good	Last Available: "2012-03"
-5592	practically non-alcoholic lousy squat Fuzzy Tentacle	1	decent	Last Available: "2012-03"
+5592	lousy practically non-alcoholic squat Fuzzy Tentacle	1	decent	Last Available: "2012-03"
 5593	mediocre Crazymaker	3	decent	Last Available: "2012-03"
 5594	perfectly mixed distilled Zoodriver	5	EPIC	Last Available: "2012-03"
 5595	delicious Sloe Comfortable Zoo	3	awesome	Last Available: "2012-03"
-5596	weak special aged blurry pulsating Sloe Comfortable Zoo on Fire	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2012-03"
+5596	weak aged special blurry pulsating Sloe Comfortable Zoo on Fire	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2012-03"
 5597	perfectly mixed irresponsibly strong blue Suffering Sinner	10	EPIC	Last Available: "2012-03"
 5598	mediocre teal Suppurating Sinner	3	decent	Last Available: "2012-03"
-5599	watered-down perfectly mixed huge Sizzling Sinner	2	EPIC	Last Available: "2012-03"
+5599	perfectly mixed watered-down huge Sizzling Sinner	2	EPIC	Last Available: "2012-03"
 5600	drinkable tumbling Firewater	3	good	Last Available: "2012-03"
-5601	high-proof acceptable Earth and Firewater	6	good	Last Available: "2012-03"
+5601	acceptable high-proof Earth and Firewater	6	good	Last Available: "2012-03"
 5602	perfectly mixed Earth, Wind and Firewater	4	EPIC	Last Available: "2012-03"
 5603	practically non-alcoholic artisanal Slimosa	1	EPIC	Last Available: "2012-03"
 5604	bad Extra-slimy Slimosa	3	decent	Last Available: "2012-03"
-5605	watered-down perfectly mixed Slimebite	2	EPIC	Last Available: "2012-03"
+5605	perfectly mixed watered-down Slimebite	2	EPIC	Last Available: "2012-03"
 5606	practically non-alcoholic acceptable Cement Mixer	1	good	Last Available: "2012-03"
 5607	artisanal Jackhammer	3	EPIC	Last Available: "2012-03"
 5608	drinkable Dump Truck	3	good	Last Available: "2012-03"
 5609	acceptable Fauna Libre	4	good	Last Available: "2012-03"
-5610	triple-distilled special hand-crafted Chakra Libre	6	EPIC	Effect: "Superioreo", Effect Duration: 35, Last Available: "2012-03"
-5611	smooth fancy bouncing Aura Libre	4	awesome	Effect: "Purpose", Effect Duration: 35, Last Available: "2012-03"
-5612	artisanal watered-down Sazerorc	2	EPIC	Last Available: "2012-03"
-5613	tolerable boozy Sazuruk-hai	5	good	Last Available: "2012-03"
-5614	artisanal extra-dry Flaming Sazerorc	5	EPIC	Last Available: "2012-03"
+5610	triple-distilled hand-crafted special Chakra Libre	6	EPIC	Effect: "Superioreo", Effect Duration: 35, Last Available: "2012-03"
+5611	fancy smooth bouncing Aura Libre	4	awesome	Effect: "Purpose", Effect Duration: 35, Last Available: "2012-03"
+5612	watered-down artisanal Sazerorc	2	EPIC	Last Available: "2012-03"
+5613	boozy tolerable Sazuruk-hai	5	good	Last Available: "2012-03"
+5614	extra-dry artisanal Flaming Sazerorc	5	EPIC	Last Available: "2012-03"
 5615	lousy weak Green Velvet	2	decent	Last Available: "2012-03"
-5616	extra-dry perfectly mixed Green Muslin	5	EPIC	Last Available: "2012-03"
+5616	perfectly mixed extra-dry Green Muslin	5	EPIC	Last Available: "2012-03"
 5617	hand-crafted gray Green Burlap	3	EPIC	Last Available: "2012-03"
 5618	artisanal wobbly Mohobo	4	EPIC	Last Available: "2012-03"
-5619	perfectly mixed enchanted Moonshine Mohobo	4	EPIC	Effect: "Fancy Feasted", Effect Duration: 10, Last Available: "2012-03"
+5619	enchanted perfectly mixed Moonshine Mohobo	4	EPIC	Effect: "Fancy Feasted", Effect Duration: 10, Last Available: "2012-03"
 5620	tolerable Flaming Mohobo	4	good	Last Available: "2012-03"
-5621	bad weak Drunken Philosopher	2	decent	Last Available: "2012-03"
+5621	weak bad Drunken Philosopher	2	decent	Last Available: "2012-03"
 5622	weak drinkable Drunken Neurologist	2	good	Last Available: "2012-03"
 5623	hand-crafted Drunken Astrophysicist	3	EPIC	Last Available: "2012-03"
 5624	tolerable Dark & Starry	3	good	Last Available: "2012-03"
@@ -5540,7 +5540,7 @@
 5637	lousy teal Doublepunchplanter	3	decent	Last Available: "2012-03"
 5638	acceptable Haymaker	4	good	Last Available: "2012-03"
 5639	mirror Small Medium	0		Free Pull, Last Available: "2012-03"
-5640	skewed twirling crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
+5640	twirling skewed crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	rotten fungus	4	crappy	
 5642	poisoned dart	0		
 5643	activated galvanized stone wool	0		Effect: "Fungal Flambé", Effect Duration: 50
@@ -5548,14 +5548,14 @@
 5645	jittery the Nostril of the Serpent	0		
 5646	blinking calendar fragment	0		
 5647	lime green inspector's calendar	0		Item Drop: +15, Damage Reduction: 4
-5648	shaking wobbly Fonzie's Boris's Helm of the pedagogue	0		Experience: +3, Experience (Moxie): +1, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	shaking wobbly Fonzie's Boris's Helm of the pedagogue	0		Experience: +3, Experience (Moxie): +1, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	twirling slick staph of homophones of incineration	0		Moxie: +10, Hot Spell Damage: +50
-5650	narrow wobbly perfumed Sinatra's Boris's Helm (askew) of horror	0		Experience (Moxie): +5, Spooky Spell Damage: +25, Stench Resistance: +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	narrow wobbly perfumed Sinatra's Boris's Helm (askew) of horror	0		Experience (Moxie): +5, Spooky Spell Damage: +25, Stench Resistance: +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	bouncing mime soul fragment	0		Last Available: "2012-04"
 5652	jittery Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	enchanted toothsome nailswurst	4	awesome	Effect: "Outer Wolf&trade;", Effect Duration: 40
-5655	practically non-alcoholic drinkable wobbly used beer	1	good	
+5655	drinkable practically non-alcoholic wobbly used beer	1	good	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5575,13 +5575,13 @@
 5672	gunpowder burrito	2	good	
 5673	spinning beery blood	2	good	
 5674	tumbling &quot;L&quot;	0		
-5675	distilled tumbling spinning yellow watered-down Red Minotaur	1		
+5675	distilled tumbling yellow spinning watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	greasy Ze&trade; goggles	0		Sleaze Spell Damage: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	greasy Ze&trade; goggles	0		Sleaze Spell Damage: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	twirling soggy used band-aid	0		Last Available: "2012-05"
-5679	spinning miser's beefcake's stylish swimsuit	0		Muscle: +25, Meat Drop: +10, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	spinning miser's beefcake's stylish swimsuit	0		Muscle: +25, Meat Drop: +10, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	huge lost key	0		Last Available: "2012-05"
-5681	moldy diet P.B.L.T.	1	crappy	
+5681	diet moldy P.B.L.T.	1	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	handful of juicy garbage	0		
@@ -5603,19 +5603,19 @@
 5700	The Lost Comb	0		
 5701	red Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	mannequin	0		Familiar Weight: +5
-5703	mirror blue crayon shavings	0		Last Available: "2012-06"
+5703	blue mirror crayon shavings	0		Last Available: "2012-06"
 5704	tumbling wax bugbear	0		Last Available: "2012-06"
-5705	fuchsia crafty wax hat of incineration	0		Maximum MP: +10, Hot Spell Damage: +50, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	teal flame-retardant weightlifter's wax pants	0		Muscle: +15, Hot Resistance: +1, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	fuchsia crafty wax hat of incineration	0		Maximum MP: +10, Hot Spell Damage: +50, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	teal flame-retardant weightlifter's wax pants	0		Muscle: +15, Hot Resistance: +1, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	wet pressed drop of water-37	0		Effect: "Cheered Up", Effect Duration: 41, Last Available: "2012-07"
-5709	tumbling ghostly olive censurious wholesome fireman's helmet	0		Maximum HP Percent: +10, Sleaze Resistance: +3, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	tumbling ghostly olive censurious wholesome fireman's helmet	0		Maximum HP Percent: +10, Sleaze Resistance: +3, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	frosty fire axe	0		Cold Spell Damage: +10, Last Available: "2012-07"
 5713	shaking spinning banded Samson's strapping fire extinguisher	0		Muscle: +5, Experience (Muscle): +5, Damage Absorption: +100, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	ghostly Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5716	spinning yellow Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	flavorless jumbo FDKOL hotcakes	5	decent	Last Available: "2012-07"
+5716	yellow spinning Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
+5717	jumbo flavorless FDKOL hotcakes	5	decent	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	rotten fancy fiery wing	3	crappy	Effect: "Ticking Clock", Effect Duration: 40, Last Available: "2012-07"
@@ -5624,8 +5624,8 @@
 5723	frozen bottle of fire	0		Effect: "Macho, Macho Dog", Effect Duration: 20, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	frightening Samson's hot daub bun	0		Experience (Muscle): +5, Spooky Damage: +5, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	lion tamer's Rosewater's hot daub stand	0		Mysticality Percent: +30, Experience (familiar): +2, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	frightening Samson's hot daub bun	0		Experience (Muscle): +5, Spooky Damage: +5, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	lion tamer's Rosewater's hot daub stand	0		Mysticality Percent: +30, Experience (familiar): +2, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	smooth foot-long hot daub of vim and vigor	0		Moxie: +15, Maximum HP Percent: +50, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	stale angst burger	4	decent	
@@ -5633,7 +5633,7 @@
 5732	blank note	0		
 5733	eerily silent box	0		
 5734	stale maroon forbidden sausage	3	decent	
-5735	Lord Flameface's cloak of the cheetah	0		Initiative: +60, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Lord Flameface's cloak of the cheetah	0		Initiative: +60, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	chilled diffused shaking Drizzlers&trade; Black Licorice	0		Effect: "Heart of Yellow", Effect Duration: 39
 5737	activated fuchsia bouncing daub-breaker	0		Effect: "Ooh, Salty!", Effect Duration: 29, Last Available: "2020-09"
 5738	ribald Camp Scout backpack	0		Sleaze Damage: +10, Softcore Only, Last Available: "2012-07"
@@ -5642,7 +5642,7 @@
 5741	delicious water purification pills	4	awesome	Last Available: "2012-07"
 5742	narrow Camp Scout pup tent	0		Last Available: "2012-07"
 5743	tolerable CSA scoutmaster's &quot;water&quot;	4	good	Last Available: "2012-07"
-5744	rotten small bag of GORF	2	crappy	Last Available: "2012-07"
+5744	small rotten bag of GORF	2	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	adequate bag of QWOP	4	good	Last Available: "2012-07"
 5747	altered CSA bravery badge	0		Effect: "Cautious Prowl", Effect Duration: 26, Last Available: "2012-07"
@@ -5650,11 +5650,11 @@
 5749	lousy olive CSA cheerfulness ration	4	decent	Last Available: "2012-07"
 5750	ghostly CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	snack-sized flavorless crappy brain	2	decent	
+5752	flavorless snack-sized crappy brain	2	decent	
 5753	flavorless red decent brain	3	decent	
 5754	toothsome good brain	3	awesome	
-5755	normal snack-sized boss brain	2	good	
-5756	rotten jumbo hunter brain	5	crappy	
+5755	snack-sized normal boss brain	2	good	
+5756	jumbo rotten hunter brain	5	crappy	
 5758	squat up-at-dawn horrifying arcane researcher's Staff of Holiday Sensations	0		Experience Percent (Mysticality): +10, Spooky Damage: +25, Adventures: +5, Last Available: "2011-11"
 5759	stanky educational staff	0		Experience: +1, Stench Spell Damage: +25
 5760	foul-smelling nasty rock-hard staff	0		Damage Reduction: 5, Stench Damage: 15
@@ -5665,14 +5665,14 @@
 5765	shaking executive gravedigger's fuzzy earmuffs	0		Spooky Damage: +10, Meat Drop: +40, Familiar Effect: "1.5xVolley, cap 32"
 5766	tumbling shellacked fuzzy montera of Calamity Jane of the boozehound	0		Damage Reduction: 7, Critical Hit Percent: +15, Booze Drop: +100, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	narrow gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	spinning gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	narrow gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	spinning gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	huge Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
-5775	wobbly spinning fronts	0		Familiar Weight: +5
+5775	spinning wobbly fronts	0		Familiar Weight: +5
 5776	studded beefy Barney's rake	0		Muscle: +10, Damage Absorption: +80
 5778	stale wobbly idiot brain	3	decent	
 5779	keel-haulin' knife of the dark arts	0		Spell Damage Percent: +100
@@ -5681,21 +5681,21 @@
 5782	morningwood plank	0		
 5783	bouncing raging hardwood plank	0		
 5784	yellow weirdwood plank	0		
-5785	olive squat thick caulk	0		
+5785	squat olive thick caulk	0		
 5786	ghostly hard screw	0		
 5787	messy butt joint	0		
 5788	cyan smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	therapeutic right bear arm of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	jittery double-paned friendly hale left bear arm	0		Maximum HP: +20, Familiar Weight: +3, Cold Resistance: +5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	therapeutic right bear arm of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	jittery double-paned friendly hale left bear arm	0		Maximum HP: +20, Familiar Weight: +3, Cold Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	supercool Hat O' Nine Tails	0		Moxie Percent: +20
 5794	colloidal anodized ghostly Enchanted Plunger	0		Effect: "Mental A-cue-ity", Effect Duration: 67
 5795	extra-denatured Enchanted Flyswatter	0		Effect: "Feet of Grapefruit", Effect Duration: 20
 5796	super-electrified spinning Gearhead Goo	0		Effect: "Patience of the Tortoise", Effect Duration: 14
-5797	colloidal cold-filtered bouncing gray Missing Eye Simulation Device	0		Effect: "Earthen Fist", Effect Duration: 23
+5797	colloidal cold-filtered gray bouncing Missing Eye Simulation Device	0		Effect: "Earthen Fist", Effect Duration: 23
 5798	quadruple-dry quantum Gnollish Crossdress	0		Effect: "On a Roll", Effect Duration: 50
-5799	quantum jittery upside-down eldritch dough	0		Effect: "Gamer Rage", Effect Duration: 28
+5799	quantum upside-down jittery eldritch dough	0		Effect: "Gamer Rage", Effect Duration: 28
 5800	flattened Charity's choker	0		Effect: "Top Dog", Effect Duration: 12
 5801	vacuum-sealed quantum blinking blinking Smart Bone Dust	0		Effect: "Booooooze", Effect Duration: 39
 5802	altered double-nitrogenated perpendicular guano	0		Effect: "Superveiny 9000", Effect Duration: 60
@@ -5705,7 +5705,7 @@
 5806	frozen deionized unsweetened muesli	0		Effect: "Crocodile Tear", Effect Duration: 21
 5807	adjusted flattened green glass of warm milk	0		Effect: "Macho Profundo", Effect Duration: 32
 5808	activated glass of gnat milk	0		Effect: "Goldentongue", Effect Duration: 68
-5809	polymerized mirror red upside-down Knob Goblin Mutagen	0		Effect: "What's That Smell?", Effect Duration: 64
+5809	polymerized upside-down red mirror Knob Goblin Mutagen	0		Effect: "What's That Smell?", Effect Duration: 64
 5810	concentrated pressed Tears of the Quiet Healer	0		Effect: "Heart of Orange", Effect Duration: 48
 5811	flattened tube of lipstick	0		Effect: "Neutered Nostrils", Effect Duration: 35
 5812	colloidal cold-filtered skelelton spine	0		Effect: "Eyes All Black", Effect Duration: 34
@@ -5725,8 +5725,8 @@
 5826	vacuum-sealed polymerized zombie hollandaise	0		Effect: "Sugary Tongue", Effect Duration: 42
 5827	adjusted skeletal banana	0		Effect: "Impregnabili Tea", Effect Duration: 68
 5828	pressed gray gilt perfume bottle	0		Effect: "Tremella Tremens", Effect Duration: 27
-5829	diffused olive narrow janglin' bones	0		Effect: "Sludgesick", Effect Duration: 60
-5830	aerosolized dry upside-down mirror pygmy papers	0		Effect: "The Grass...  Is Blue...", Effect Duration: 29
+5829	diffused narrow olive janglin' bones	0		Effect: "Sludgesick", Effect Duration: 60
+5830	aerosolized dry mirror upside-down pygmy papers	0		Effect: "The Grass...  Is Blue...", Effect Duration: 29
 5831	electrified vacuum-sealed pygmy dart	0		Effect: "Squatting and Thrusting", Effect Duration: 18
 5832	diffused secret mummy herbs and spices	0		Effect: "Pork Power", Effect Duration: 19
 5833	pressed ionized brigand brittle	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 35
@@ -5735,12 +5735,12 @@
 5836	magnetized embezzler's oil	0		Effect: "Armored Innards", Effect Duration: 33
 5837	boiled ghostly Fu Manchu Wax	0		Effect: "Well Owl Be!", Effect Duration: 60
 5838	super-energized wet ghostly Iiti Kitty Gumdrop	0		Effect: "Icy Composition", Effect Duration: 66
-5839	deionized upside-down wobbly ravenous eye	0		Effect: "Billiards Belligerence", Effect Duration: 15
+5839	deionized wobbly upside-down ravenous eye	0		Effect: "Billiards Belligerence", Effect Duration: 15
 5840	enhanced alkaline polymerized Rogue Windmill Rouge	0		Effect: "The Moxious Madrigal", Effect Duration: 27
 5841	boiled alkaline corrupted A muse-bouche	0		Effect: "Hyphemariffic", Effect Duration: 28
 5842	colloidal huge toothbrush	0		Effect: "Tightly-Wound Spine", Effect Duration: 66
 5843	deionized pirate cream pie	0		Effect: "Oily Flavor", Effect Duration: 48
-5844	nitrogenated modified mirror tumbling una poca de gracia	0		Effect: "Mushroom Magicalness", Effect Duration: 52
+5844	nitrogenated modified tumbling mirror una poca de gracia	0		Effect: "Mushroom Magicalness", Effect Duration: 52
 5845	electrified aerosolized twirling compressed air canister	0		Effect: "Adventurer's Best Friendship", Effect Duration: 18
 5846	pickled skewed salt water taffy	0		Effect: "How to Scam Tourists", Effect Duration: 65
 5847	activated jittery unholy water	0		Effect: "Oily Flavor", Effect Duration: 15
@@ -5750,7 +5750,7 @@
 5851	aerosolized pressed blurry temporary tribal tattoo	0		Effect: "Stenchtastic", Effect Duration: 33
 5852	vacuum-sealed irradiated oil-filled donut	0		Effect: "Black Eyes", Effect Duration: 58
 5853	quadruple-aerosolized upside-down stick-on gnome beard	0		Effect: "Neuromancy", Effect Duration: 69
-5854	non-deionized corrupted blinking fuchsia BRICKO stud	0		Effect: "Superheroic", Effect Duration: 11
+5854	non-deionized corrupted fuchsia blinking BRICKO stud	0		Effect: "Superheroic", Effect Duration: 11
 5855	flattened unsweetened extra-Vulcanized jittery Osk'r Chow	0		Effect: "You Liver", Effect Duration: 64
 5856	improved Scuba Snack	0		Effect: "Rave Concentration", Effect Duration: 62
 5857	galvanized corrupted teal grey cube	0		Effect: "Booze Goozles", Effect Duration: 66
@@ -5758,17 +5758,17 @@
 5859	anodized deionized fuchsia booby trap	0		Effect: "Hardened Fabric", Effect Duration: 22
 5860	diffused electrified huge Agent Corrigan's cigarette	0		Effect: "Fastbreaker", Effect Duration: 16
 5861	ionized good ash	0		Effect: "Ruthlessly Efficient", Effect Duration: 52
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
-5864	olive jittery twirling papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
+5864	jittery twirling olive papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	ionized skewed papier-mochi	0		Effect: "License to Punch", Effect Duration: 26, Last Available: "2012-09"
 5866	vacuum-sealed boiled papier-m&acirc;chaeranthera	0		Effect: "Vitali Tea", Effect Duration: 22, Last Available: "2012-09"
 5867	ionized modified wet papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Can Has Cyborger", Effect Duration: 13, Last Available: "2012-09"
 5868	resourceful papier-m&acirc;ch&eacute;te of Gandalf	0		Maximum MP: +50, Spell Critical Percent: +20, Last Available: "2012-09"
 5869	pulsating frightening Jack Frost's papier-m&acirc;chine gun	0		Cold Spell Damage: +50, Spooky Damage: +5, Last Available: "2012-09"
 5870	blinking blurry papier-masque of courage of bravery	0		Spooky Resistance: 8, Single Equip, Last Available: "2012-09"
-5871	olive lightning-fast double-paned papier-mitre	0		Cold Resistance: +5, Initiative: +40, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	squat ribald papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Sleaze Damage: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	olive lightning-fast double-paned papier-mitre	0		Cold Resistance: +5, Initiative: +40, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	squat ribald papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Sleaze Damage: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	lime green papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5784,7 +5784,7 @@
 5885	narrow skeletal skiff	0		Last Available: "2012-10"
 5886	nasty veiny thinker's Bonestabber of wisdom	0		Mysticality: 25, Maximum HP: +10, Stench Damage: +5, Last Available: "2012-10"
 5887	drinkable watered-down crystal skeleton vodka	2	good	Last Available: "2012-10"
-5888	ghostly shaking Lazybones&trade; recliner	0		Last Available: "2012-10"
+5888	shaking ghostly Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	twirling twirling auxiliary backbone of dire peril	0		Weapon Damage: +20, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
@@ -5822,8 +5822,8 @@
 5924	electrical thingamabob	0		Last Available: "2012-12"
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	green BittyCar MeatCar	0		Last Available: "2012-12"
-5927	spinning bouncing BittyCar HotCar	0		Last Available: "2012-12"
-5928	fuchsia brainwave-controlled unicorn horn of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5927	bouncing spinning BittyCar HotCar	0		Last Available: "2012-12"
+5928	fuchsia brainwave-controlled unicorn horn of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	ribald Socratic plastic four-shadowed mime of the early riser	0		Experience (Mysticality): +1, Sleaze Damage: +10, Adventures: +7, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	tumbling medical-grade plastic Father McGruber	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist	0		Item Drop: +5, Last Available: "2012-12"
 5962	energetic plastic blazing bat	0		Maximum MP Percent: +20, Last Available: "2012-12"
-5963	blinking manspreader's Socratic electronic dulcimer pants	0		Experience (Mysticality): +1, Monster Level: +10, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	blinking manspreader's Socratic electronic dulcimer pants	0		Experience (Mysticality): +1, Monster Level: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	chilly coward's Frown Exerciser	0		Monster Level: -20, Cold Damage: +5, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5873,35 +5873,35 @@
 5975	purple record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	shaking record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	jittery Temple Grandin's sharpshooter's therapeutic silent beret	0		Critical Hit Percent: +10, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, cap 3"
-5978	snack-sized spoiled slice of pizza	2	crappy	Last Available: "2013-02"
+5978	spoiled snack-sized slice of pizza	2	crappy	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	artisanal tankard of ale	4	EPIC	Last Available: "2013-02"
 5983	spinning vial of holy water	0		Last Available: "2013-02"
-5984	perfumed vibrating cloth cap of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Stench Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	perfumed vibrating cloth cap of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Stench Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	double-paned smelly iron dagger of the glutton	0		Stench Spell Damage: +10, Cold Resistance: +5, Food Drop: +100, Last Available: "2013-02"
 5986	rotten massive wobbly hamburger	8	crappy	Last Available: "2013-02"
 5987	ghostly dollar-sign bag	0		Last Available: "2013-02"
 5988	blinking potion	0		Last Available: "2013-02"
 5989	twirling potion	0		Last Available: "2013-02"
-5990	perfectly mixed practically non-alcoholic bottle of wine	1	super ultra EPIC	Last Available: "2013-02"
+5990	practically non-alcoholic perfectly mixed bottle of wine	1	super ultra EPIC	Last Available: "2013-02"
 5991	blurry round bomb	0		Last Available: "2013-02"
-5992	dog trainer's quilted iron helmet of incineration	0		Damage Absorption: +40, Experience (familiar): +1, Hot Spell Damage: +50, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	dog trainer's quilted iron helmet of incineration	0		Damage Absorption: +40, Experience (familiar): +1, Hot Spell Damage: +50, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	supercharged energetic steel sword of terror	0		Maximum MP Percent: 50, Spooky Spell Damage: +10, Last Available: "2013-02"
 5994	small yummy whole roasted chicken	2	awesome	Last Available: "2013-02"
 5995	blue massive gemstone	0		Last Available: "2013-02"
-5996	lime green tumbling pulsating extra-strength potion	0		Last Available: "2013-02"
+5996	tumbling lime green pulsating extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	strong lousy olive shining goblet	5	decent	Last Available: "2013-02"
+5998	lousy strong olive shining goblet	5	decent	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	slick wizardly crown of the blizzard	0		Mysticality: +25, Moxie: +10, Cold Spell Damage: +25, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	slick wizardly crown of the blizzard	0		Mysticality: +25, Moxie: +10, Cold Spell Damage: +25, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	censurious scandalous Annie Oakley's sword	0		Critical Hit Percent: +20, Sleaze Damage: +5, Sleaze Resistance: +3, Last Available: "2013-02"
-6002	huge miser's Newton's Helm of the Scream Emperor of mayonnaise	0		Experience (Mysticality): +3, Sleaze Spell Damage: +50, Meat Drop: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	huge miser's Newton's Helm of the Scream Emperor of mayonnaise	0		Experience (Mysticality): +3, Sleaze Spell Damage: +50, Meat Drop: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	wobbly chilly medical-grade strapping Cloak of Dire Shadows	0		Muscle: +5, Cold Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02"
 6004	careful sinister Sword of Dark Omens of terror	0		Spell Damage: +10, Monster Level: -10, Spooky Spell Damage: +10, Last Available: "2013-02"
 6005	supercool Shield of Icy Fate of dire peril of Flo-Jo	0		Moxie Percent: +20, Weapon Damage: +20, Initiative: +100, Damage Reduction: 7, Last Available: "2013-02"
-6006	green toasty Greaves of the Murk Lord of the dark arts of terror	0		Spell Damage Percent: +100, Hot Damage: +5, Spooky Spell Damage: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	green toasty Greaves of the Murk Lord of the dark arts of terror	0		Spell Damage Percent: +100, Hot Damage: +5, Spooky Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	squat stanky Temple Grandin's Gauntlets of the Blood Moon of the overflowing toilet	0		Familiar Weight: +7, Stench Spell Damage: 75, Single Equip, Last Available: "2013-02"
 6008	clever Boots of Twilight Whispers of the scaredy-cat of the early riser	0		Maximum MP: +20, Monster Level: -15, Adventures: +7, Single Equip, Last Available: "2013-02"
 6009	rosewater-soaked Jack Frost's stylish Belt of Howling Anger	0		Moxie: +25, Cold Spell Damage: +50, Stench Resistance: +3, Single Equip, Last Available: "2013-02"
@@ -5920,7 +5920,7 @@
 6022	green Space Tourist Phaser	0		
 6023	ghostly cyan sinister Whoompa Fur Pants of the pedagogue	0		Experience: +3, Spell Damage: +10, Familiar Effect: "atk, cap 27"
 6024	green Whatsian Ionic Pliers of the sweet-tooth	0		Candy Drop: +100
-6025	chilled nitrogenated twirling wobbly Polysniff Perfume	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 33
+6025	chilled nitrogenated wobbly twirling Polysniff Perfume	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 33
 6026	squat Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
@@ -5940,18 +5940,18 @@
 6042	oil pan of the cougar	0		Moxie: +20
 6043	boid	0		
 6044	woim	0		
-6045	bouncing tumbling Thwaitgold praying mantis statuette	0		
+6045	tumbling bouncing Thwaitgold praying mantis statuette	0		
 6046	huge BittyCar SoulCar	0		Last Available: "2012-12"
 6047	twirling clever smooth Misty Cloak	0		Moxie: +15, Maximum MP: +20
 6048	Da Vinci's Misty Robe of chilblains	0		Experience (Mysticality): +5, Cold Damage: +25
 6049	gray prompt studded deadly Misty Cape	0		Weapon Damage: +5, Damage Absorption: +80, Adventures: +3
 6050	woimbook	0		Familiar Weight: +5
 6051	mirror Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	snack-sized rotten red Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
-6053	practically non-alcoholic bad Taco Dan's Taco Stand Chimichangarita	1	decent	Last Available: "2012-12"
+6052	rotten snack-sized red Taco Dan's Taco Stand Taco	2	crappy	Last Available: "2012-12"
+6053	bad practically non-alcoholic Taco Dan's Taco Stand Chimichangarita	1	decent	Last Available: "2012-12"
 6054	tarnished blue Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Texas Elegance", Effect Duration: 21, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	maroon The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	maroon The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	supercool Meatcleaver of James Dean	0		Moxie Percent: +20, Experience (Moxie): +3, Last Available: "2013-12"
 6058	green Crimbo Elf bobble-head of Flo-Jo	0		Initiative: +100, Last Available: "2012-12"
 6059	stiffened Crimbo stogie-scented room odorizer	0		Damage Reduction: 1, Last Available: "2012-12"
@@ -5966,17 +5966,17 @@
 6068	loose blade	0		
 6069	pulsating goblin bone hilt	0		
 6070	sword blade	0		
-6071	twirling Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	twirling Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	blurry confusing LED clock	0		Last Available: "2012-12"
 6073	nitrogenated haggis-infused soap	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 26, Last Available: "2012-12"
 6074	vacuum-sealed activated tumbling magicberry tablets	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 64, Last Available: "2012-12"
 6075	nitrogenated shaking 37x37x37 puzzle cube	0		Effect: "Stone-Faced", Effect Duration: 60, Last Available: "2012-12"
-6076	high-proof tolerable McLeod's Hard Haggis-Ade	7	good	Last Available: "2012-12"
+6076	tolerable high-proof McLeod's Hard Haggis-Ade	7	good	Last Available: "2012-12"
 6077	spoiled pulsating haggis-wrapped haggis-stuffed haggis	4	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	squat narrow haggis socks of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	squat narrow haggis socks of the wise owl	0		Mysticality: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	squat actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	huge Mr. Haggis	0		Last Available: "2012-12"
@@ -6008,7 +6008,7 @@
 6110	cyan bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	zaibatsu lobby card	0		Last Available: "2013-12"
-6113	fuchsia blurry zaibatsu level 1 card	0		Last Available: "2013-12"
+6113	blurry fuchsia zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	CEO office card	0		Last Available: "2013-12"
@@ -6040,33 +6040,33 @@
 6142	spoiled roasted duck	3	crappy	Last Available: "2013-12"
 6143	adequate red dead meat bun	3	good	Last Available: "2013-12"
 6144	boxer's cat collar	0		Muscle Percent: +10, Single Equip, Last Available: "2013-12"
-6145	asbestos-lined chilly suspicious-looking fedora	0		Cold Damage: +5, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	asbestos-lined chilly suspicious-looking fedora	0		Cold Damage: +5, Hot Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	bouncing Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	upside-down shaking MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	mirror Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	huge adequate carrot cake	8	good	Last Available: "2013-01"
-6153	artisanal fancy carrot claret	3	EPIC	Effect: "Flaming Weapon", Effect Duration: 45, Last Available: "2013-01"
+6153	fancy artisanal carrot claret	3	EPIC	Effect: "Flaming Weapon", Effect Duration: 45, Last Available: "2013-01"
 6154	distilled ghostly carrot juice	1	awesome	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	Tesla Rosewater's Byte	0		Mysticality Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
-6158	mirror anger blaster of the cougar	0		Moxie: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	Jim Carey's doubt cannon	0		Monster Level: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	energetic fear condenser	0		Maximum MP Percent: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	pulsating regret hose	0		Item Drop: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	mirror anger blaster of the cougar	0		Moxie: +20, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	Jim Carey's doubt cannon	0		Monster Level: +25, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	energetic fear condenser	0		Maximum MP Percent: +20, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	pulsating regret hose	0		Item Drop: +5, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	studded commodore's hat of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	double-paned naval trousers	0		Cold Resistance: +5, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	studded commodore's hat of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	double-paned naval trousers	0		Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	jittery arcane researcher's deck cannon of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Last Available: "2013-12"
 6167	bouncing personal trainer's ornamental sextant	0		Experience Percent (Muscle): +10, Last Available: "2013-12"
 6168	veiny beefcake's Bloodbath	0		Muscle: +25, Maximum HP: +10, Last Available: "2013-12"
-6169	acceptable practically non-alcoholic Hundred Headed IPA	1	good	Last Available: "2013-12"
+6169	practically non-alcoholic acceptable Hundred Headed IPA	1	good	Last Available: "2013-12"
 6170	spoiled chum	3	crappy	Last Available: "2013-12"
 6171	chilled pickled crude crudit&eacute;s	0		Effect: "Mutated", Effect Duration: 61
-6172	oxidized moist blurry wobbly candy crayons	0		Effect: "Conspiratory Eyes", Effect Duration: 55, Last Available: "2020-09"
+6172	oxidized moist wobbly blurry candy crayons	0		Effect: "Conspiratory Eyes", Effect Duration: 55, Last Available: "2020-09"
 6173	ruddy pixel grappling hook of the bloodbag	0		Maximum HP Percent: +40, Maximum HP: +100
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6081,54 +6081,54 @@
 6184	spinning Sherlock's inspector's Jarlsberg's hat of the overflowing toilet	0		Stench Spell Damage: +50, Item Drop: 40
 6185	super-sized rotten consummate hard-boiled egg	5	crappy	
 6186	miniature decent consummate fried egg	2	good	
-6187	diet spoiled jittery consummate egg salad	1	crappy	
+6187	spoiled diet jittery consummate egg salad	1	crappy	
 6188	normal consummate bagel	3	good	
 6189	bland consummate sliced bread	3	decent	
-6190	rotten huge shaking consummate hot dog bun	9	crappy	
-6191	massive rotten consummate brownie	9	crappy	
+6190	huge rotten shaking consummate hot dog bun	9	crappy	
+6191	rotten massive consummate brownie	9	crappy	
 6192	bland consummate toast	4	decent	
 6193	artisanal passable stout	3	EPIC	
 6194	moldy skewed consummate soup	4	crappy	
 6195	stale consummate corn chips	3	decent	
 6196	flavorless consummate salad	3	decent	
 6197	bland consummate salsa	4	decent	
-6198	bite-sized decent consummate sauerkraut	1	good	
+6198	decent bite-sized consummate sauerkraut	1	good	
 6199	delicious twirling consummate cheese slice	4	awesome	
-6200	bland huge consummate melted cheese	9	decent	
-6201	low-calorie flavorless consummate bacon	1	decent	
+6200	huge bland consummate melted cheese	9	decent	
+6201	flavorless low-calorie consummate bacon	1	decent	
 6202	tiny rotten consummate meatloaf	1	crappy	
 6203	stale consummate steak	4	decent	
-6204	enchanted bland red consummate cuts	4	decent	Effect: "Disco Inferno", Effect Duration: 5
+6204	bland enchanted red consummate cuts	4	decent	Effect: "Disco Inferno", Effect Duration: 5
 6205	delicious big blinking consummate frankfurter	5	awesome	
-6206	rotten super-sized spinning consummate french fries	5	crappy	
+6206	super-sized rotten spinning consummate french fries	5	crappy	
 6207	stale miniature consummate baked potato	2	decent	
 6208	bad acceptable vodka	4	decent	
 6209	immense adequate consummate ice cream	10	good	
 6210	spoiled consummate whipped cream	4	crappy	
 6211	stale consummate cream	3	decent	
 6212	bland pulsating consummate strawberries	3	decent	
-6213	huge normal consummate sorbet	6	good	
+6213	normal huge consummate sorbet	6	good	
 6214	artisanal blinking adequate rum	3	EPIC	
 6215	artisanal mediocre lager	4	EPIC	
 6216	stale mirror immaculate grilled cheese	3	decent	
 6217	bland immaculate ice cream sandwich	3	decent	
-6218	rotten big immaculate hot dog	5	crappy	
+6218	big rotten immaculate hot dog	5	crappy	
 6219	bite-sized spoiled immaculate egg salad sandwich	1	crappy	
 6220	snack-sized bland upside-down perfect sandwich	2	decent	
-6221	snack-sized moldy ghostly lime green perfect chef salad	2	crappy	
+6221	snack-sized moldy lime green ghostly perfect chef salad	2	crappy	
 6222	flavorless perfect breakfast	4	decent	
 6223	delicious sublime deluxe hot dog	4	awesome	
-6224	rotten spinning yellow narrow sublime stew	3	crappy	
-6225	big rotten bouncing sublime nachos	5	crappy	
-6226	fancy small decent Ultimate Breakfast Sandwich	2	good	Effect: "Eye of the Seal", Effect Duration: 35
+6224	rotten yellow narrow spinning sublime stew	3	crappy	
+6225	rotten big bouncing sublime nachos	5	crappy	
+6226	decent small fancy Ultimate Breakfast Sandwich	2	good	Effect: "Eye of the Seal", Effect Duration: 35
 6227	moldy Loaded Baked Potato	3	crappy	
 6228	decent miniature Omega Sundae	2	good	
-6229	mediocre extra-dry Das Sauerlager	5	decent	
+6229	extra-dry mediocre Das Sauerlager	5	decent	
 6230	lousy Bologna Lambic	3	decent	
 6231	bad ghostly Vodka Dog	3	decent	
-6232	practically non-alcoholic fancy tolerable Disappointed Russian	1	good	Effect: "Jacked In", Effect Duration: 25
-6233	weak artisanal Chunky Mary	2	EPIC	
-6234	enchanted hand-crafted Nachojito	3	EPIC	Effect: "Super-Electrified", Effect Duration: 10
+6232	fancy tolerable practically non-alcoholic Disappointed Russian	1	good	Effect: "Jacked In", Effect Duration: 25
+6233	artisanal weak Chunky Mary	2	EPIC	
+6234	hand-crafted enchanted Nachojito	3	EPIC	Effect: "Super-Electrified", Effect Duration: 10
 6235	irresponsibly strong artisanal Le Roi	6	EPIC	
 6236	lousy Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
@@ -6160,7 +6160,7 @@
 6264	toasty stiffened grievous Staff of Fruit Salad	0		Weapon Damage Percent: +50, Damage Reduction: 1, Hot Damage: +5, Jiggle: "Deal Some Prismatic Damage"
 6265	chaotic Staff of the Cream of the Cream of Calamity Jane of horror	0		Critical Hit Percent: +15, Spell Critical Percent: +10, Spooky Spell Damage: +25, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	miniature rotten grain of protein powder	2	crappy	
+6267	rotten miniature grain of protein powder	2	crappy	
 6268	galvanized warmed pec oil	0		Effect: "Fustulent", Effect Duration: 24
 6269	Da Vinci's gym membership card	0		Experience (Mysticality): +5
 6270	electrified bouncing Squat-Thrust Magazine	0		Effect: "Concentration", Effect Duration: 37
@@ -6182,7 +6182,7 @@
 6286	skewed toasty sage stylish Mark II Steam-Hat	0		Moxie: +25, Mysticality Percent: +10, Hot Damage: +5, Familiar Effect: "1xLep, cap 37"
 6287	scorching occult personal trainer's brawny Mark III Steam-Hat	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Spell Damage Percent: +25, Hot Damage: +25, Familiar Effect: "1xLep, cap 37"
 6288	squat thinker's Mark IV Steam-Hat of wisdom of Gandalf of the empath of temperance	0		Mysticality: 25, Spell Critical Percent: +20, Familiar Weight: +5, Sleaze Resistance: +5, Familiar Effect: "1xLep, cap 37"
-6289	therapeutic Herculean brainy Mark V Steam-Hat of the scaredy-cat of the blizzard	0		Mysticality: +5, Experience (Muscle): +1, Monster Level: -15, Cold Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	therapeutic Herculean brainy Mark V Steam-Hat of the scaredy-cat of the blizzard	0		Mysticality: +5, Experience (Muscle): +1, Monster Level: -15, Cold Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	jittery steam-powered model rocketship	0		
 6291	chilly punk rock jacket of extreme caution	0		Monster Level: -25, Cold Damage: +5
 6292	stiffened dance instructor's safety pin	0		Experience Percent (Moxie): +10, Damage Reduction: 1
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	deadly Mer-kin begsign	0		Weapon Damage: +5, Meat Drop: +40
-6360	twirling jittery Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	twirling jittery Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	diffused electrified blinking pulled taffy	0		Effect: "Flower Power", Effect Duration: 28, Last Available: "2013-04"
 6362	non-tarnished quadruple-aerosolized pulled indigo taffy	0		Effect: "Extra Backbone", Effect Duration: 28, Last Available: "2013-04"
 6363	colloidal non-polymerized pulled taffy	0		Effect: "Twen Tea", Effect Duration: 11, Last Available: "2013-04"
@@ -6286,7 +6286,7 @@
 6391	concentrated Mer-kin saltsquid	0		Effect: "Haunted Liver", Effect Duration: 42
 6392	spinning aromatic quilted scale-mail underwear	0		Damage Absorption: +40, Stench Resistance: +1, Familiar Effect: "2xVolley"
 6393	denatured comb jelly	0		Effect: "Certainty", Effect Duration: 21
-6394	tumbling ghostly anemone sauce	0		
+6394	ghostly tumbling anemone sauce	0		
 6395	inky squid sauce	0		
 6396	Mer-kin weaksauce	0		
 6397	peanut sauce	0		
@@ -6302,13 +6302,13 @@
 6407	spinning steel-toed Samson's Pocket Square of Loathing of the wise owl	0		Mysticality: +20, Experience (Muscle): +5, Damage Reduction: 9, Single Equip
 6408	skewed corrupted stardust	0		
 6409	Star Spawn	0		
-6410	lime green bouncing bow from beyond the stars	0		Familiar Weight: +5
+6410	bouncing lime green bow from beyond the stars	0		Familiar Weight: +5
 6411	KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	stale thick flavorless gruel	5	decent	
-6416	stale immense wobbly mana curds	7	decent	
+6415	thick stale flavorless gruel	5	decent	
+6416	immense stale wobbly mana curds	7	decent	
 6417	twist of lime	0		
 6418	narrow pencil stub	0		
 6419	pickled extra-vacuum-sealed bouncing moth dust	0		Effect: "Altered Wavelengths", Effect Duration: 26
@@ -6317,7 +6317,7 @@
 6422	moldy vampire chowder	4	crappy	
 6423	skewed Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
-6425	narrow blurry Official Seal of Dreadsylvania	0		
+6425	blurry narrow Official Seal of Dreadsylvania	0		
 6426	adequate Dreadsylvanian stew	4	good	
 6427	perfectly mixed irresponsibly strong Dreadsylvanian	10	EPIC	
 6428	improved nitrogenated jittery upside-down Dreadsylvanian flask	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 39
@@ -6367,7 +6367,7 @@
 6472	twirling spinning Drunkula's bell	0		
 6473	teal jittery flame-retardant savvy Drunkula's ring of haze of Gandalf	0		Mysticality Percent: +20, Spell Critical Percent: +20, Hot Resistance: +1, Avoid Attack: 1, Single Equip
 6474	Drunkula's wineglass of the brute	0		Muscle Percent: +30
-6475	perfectly mixed irresponsibly strong bottle of Bloodweiser	8	EPIC	
+6475	irresponsibly strong perfectly mixed bottle of Bloodweiser	8	EPIC	
 6476	avaricious curative Unkillable Skeleton's skullcap of the sewer	0		Stench Damage: +25, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	reassuring Herculean slick Unkillable Skeleton's breastplate	0		Moxie: +10, Experience (Muscle): +1, Spooky Resistance: +1, Class: "Turtle Tamer"
 6478	greedy medical-grade baleful Unkillable Skeleton's shinguards	0		Spell Damage: +25, Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,13 +6380,13 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	super-sized decent Dreadsylvanian shepherd's pie	5	good	
+6488	decent super-sized Dreadsylvanian shepherd's pie	5	good	
 6489	green music box parts	0		
 6490	bouncing unwound mechanical songbird	0		
 6491	bouncing tailfeathers	0		Familiar Weight: +5
 6492	twirling wax banana	0		
 6493	blinking complicated lock impression	0		
-6494	gray upside-down replica key	0		
+6494	upside-down gray replica key	0		
 6495	executive Dreadsylvania Auditor's badge	0		Meat Drop: +40, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
@@ -6410,7 +6410,7 @@
 6515	upside-down jittery perfumed eerie fetish	0		Stench Resistance: +5, Single Equip
 6516	special tolerable stinkwater	3	good	Effect: "Bark of the Dog", Effect Duration: 35
 6517	jittery dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	delicious fancy jumbo accidental mutton	5	awesome	Effect: "Elron's Explosive Etude", Effect Duration: 35
+6518	jumbo delicious fancy accidental mutton	5	awesome	Effect: "Elron's Explosive Etude", Effect Duration: 35
 6519	gravedigger's supercharged drafty drawers	0		Maximum MP Percent: +30, Spooky Damage: +10, Familiar Effect: "1.5xVolley"
 6520	MacGyver's groovy wolfskull mask	0		Moxie Percent: +10, Maximum MP: +100, Familiar Effect: "spooky atk, 1xBarrr"
 6521	jittery guts necklace of the wise owl	0		Mysticality: +20, Single Equip
@@ -6453,18 +6453,18 @@
 6559	polymerized pulsating phial of stench	0		Effect: "Cancer Rising", Effect Duration: 49
 6560	magnetized wet huge phial of sleaziness	0		Effect: "Sparkling Consciousness", Effect Duration: 40
 6561	upside-down adventurer clone egg	0		Free Pull, Last Available: "2013-06"
-6562	upside-down blinking mini-Mr. Accessory	0		Familiar Weight: +5
+6562	blinking upside-down mini-Mr. Accessory	0		Familiar Weight: +5
 6563	Jim Carey's hand of Mr. Cards	0		Monster Level: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	flavorless massive Dreadsylvanian hot pocket	9	decent	
 6565	enchanted toothsome gray Dreadsylvanian pocket	3	awesome	Effect: "Sleaze-Resistant Trousers", Effect Duration: 20
 6566	decent squat Dreadsylvanian pocket	3	good	
 6567	flavorless ghostly Dreadsylvanian stink pocket	3	decent	
 6568	stale Dreadsylvanian sleaze pocket	4	decent	
-6569	watered-down smooth maroon upside-down Dreadsylvanian hot toddy	2	awesome	
+6569	smooth watered-down maroon upside-down Dreadsylvanian hot toddy	2	awesome	
 6570	perfectly mixed Dreadsylvanian cold-fashioned	4	super ultra mega EPIC	
-6571	tolerable boozy Dreadsylvanian grimlet	5	good	
+6571	boozy tolerable Dreadsylvanian grimlet	5	good	
 6572	tolerable Dreadsylvanian dank and stormy	3	good	
-6573	hand-crafted practically non-alcoholic Dreadsylvanian slithery nipple	1	super ultra mega turbo EPIC	
+6573	practically non-alcoholic hand-crafted Dreadsylvanian slithery nipple	1	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
@@ -6498,7 +6498,7 @@
 6604	shaking clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	clockwork numeral VI	0		
-6607	blurry narrow olive clockwork numeral VII	0		
+6607	blurry olive narrow clockwork numeral VII	0		
 6608	squat clockwork numeral VIII	0		
 6609	upside-down clockwork numeral IX	0		
 6610	clockwork numeral X	0		
@@ -6512,25 +6512,25 @@
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
-6621	teal pulsating folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
+6621	pulsating teal folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	spinning folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	cyan folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	jittery folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
-6628	tumbling bouncing folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
+6628	bouncing tumbling folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	pulsating lime green folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	maroon folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
-6633	tumbling bouncing folder (barbarian)	0		Last Available: "2013-08"
+6633	bouncing tumbling folder (barbarian)	0		Last Available: "2013-08"
 6634	maroon folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	spinning folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	fuchsia folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
-6639	upside-down twirling folder (owl)	0		Last Available: "2013-08"
+6639	twirling upside-down folder (owl)	0		Last Available: "2013-08"
 6640	folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	spinning folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
 6642	folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
@@ -6547,8 +6547,8 @@
 6655	drinkable fuchsia fountain 'soda'	3	good	
 6656	illegal firecracker	0		
 6657	stanky beefcake's pickelhaube	0		Muscle: +25, Stench Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 18"
-6658	ionized diffused pickled shaking lime green hair oil	0		Effect: "Intimidating Mien", Effect Duration: 60
-6659	enhanced tumbling lime green scrap	0		Effect: "Stogied", Effect Duration: 32
+6658	ionized diffused pickled lime green shaking hair oil	0		Effect: "Intimidating Mien", Effect Duration: 60
+6659	enhanced lime green tumbling scrap	0		Effect: "Stogied", Effect Duration: 32
 6660	school spirit socket set	0		
 6661	suspension bridge	0		
 6662	ribald sharpshooter's smooth beefcake's Staff of the Lunch Lady	0		Muscle: +25, Moxie: +15, Critical Hit Percent: +10, Sleaze Damage: +10
@@ -6570,9 +6570,9 @@
 6678	Yearbook Club Camera of the pedagogue	0		Experience: +3, Conditional Skill (Equipped): "Blinding Flash"
 6679	blurry baleful machete	0		Spell Damage: +25
 6680	watered-down bad Cursed Punch	2	decent	
-6681	weak hand-crafted Bowl of Scorpions	2	EPIC	
+6681	hand-crafted weak Bowl of Scorpions	2	EPIC	
 6682	aged watered-down fancy Fog Murderer	2	awesome	Effect: "Chunky", Effect Duration: 15
-6683	ghostly tumbling book of matches	0		
+6683	tumbling ghostly book of matches	0		
 6684	ghostly fireproof surgical mask	0		Hot Resistance: +3, Surgeonosity: +1
 6685	huge dance instructor's head mirror	0		Experience Percent (Moxie): +10, Surgeonosity: +1
 6686	red half-size scalpel of the sewer	0		Stench Damage: +25, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	blurry bowler	0		
 6703	teal imitation White Russian	1	EPIC	
 6704	shellacked experienced short-handled mop	0		Experience: +2, Damage Reduction: 7
-6705	stale tiny jungle floor wax	1	decent	
+6705	tiny stale jungle floor wax	1	decent	
 6706	spinning smirking shrunken head	0		
 6707	deionized skewed colorful toad	0		Effect: "Stickler for Promptness", Effect Duration: 47
 6708	spinning crude voodoo doll	0		
@@ -6634,8 +6634,8 @@
 6742	wobbly stiffened junk band	0		Damage Reduction: 1
 6743	smelly junk trunks	0		Stench Spell Damage: +10, Familiar Effect: "cap 15"
 6744	junk-mail shirt of dire peril	0		Weapon Damage: +20
-6745	rotten miniature junk food	2	crappy	
-6746	tolerable practically non-alcoholic junk yard	1	good	
+6745	miniature rotten junk food	2	crappy	
+6746	practically non-alcoholic tolerable junk yard	1	good	
 6747	twirling upside-down chilly swordzall of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +5
 6748	yellow coward's arm buzzer	0		Monster Level: -20, Damage Reduction: 6
 6749	boilgun of the wise owl of Gandalf	0		Mysticality: +20, Spell Critical Percent: +20
@@ -6643,23 +6643,23 @@
 6751	purple packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
 6753	cluster of hops	0		
-6754	ghostly gray beer bottle	0		
+6754	gray ghostly beer bottle	0		
 6755	beer label	0		
 6756	twirling artisanal homebrew sampler	0		
-6757	bad narrow skewed tumbling can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
-6758	practically non-alcoholic drinkable skewed green can of Drooling Monk	1	good	Last Available: "2013-09"
+6757	bad skewed tumbling narrow can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
+6758	drinkable practically non-alcoholic skewed green can of Drooling Monk	1	good	Last Available: "2013-09"
 6759	delicious can of Impetuous Scofflaw	3	awesome	Last Available: "2013-09"
-6760	fancy perfectly mixed fortified bottle of Old Pugilist	5	EPIC	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20, Last Available: "2013-09"
+6760	fortified fancy perfectly mixed bottle of Old Pugilist	5	EPIC	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20, Last Available: "2013-09"
 6761	watered-down acceptable bottle of Professor Beer	2	good	Last Available: "2013-09"
-6762	lousy irresponsibly strong bottle of Rapier Witbier	8	decent	Last Available: "2013-09"
-6763	weak fancy mediocre mirror bottle of Race Car Red	2	decent	Effect: "Soles of Glass", Effect Duration: 50, Last Available: "2013-09"
+6762	irresponsibly strong lousy bottle of Rapier Witbier	8	decent	Last Available: "2013-09"
+6763	fancy weak mediocre mirror bottle of Race Car Red	2	decent	Effect: "Soles of Glass", Effect Duration: 50, Last Available: "2013-09"
 6764	drinkable green bottle of Greedy Dog	3	good	Last Available: "2013-09"
 6765	perfectly mixed twirling bottle of Lambada Lambic	4	EPIC	Last Available: "2013-09"
 6766	upside-down tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	shaking liquid bread	1	good	Last Available: "2013-09"
-6769	friendly tin tam of the ox of the wise owl	0		Muscle: +20, Mysticality: +20, Familiar Weight: +3, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
-6770	concentrated double-improved squat huge tin cup	0		Effect: "Empathy", Effect Duration: 25, Last Available: "2013-09"
+6769	friendly tin tam of the ox of the wise owl	0		Muscle: +20, Mysticality: +20, Familiar Weight: +3, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6770	concentrated double-improved huge squat tin cup	0		Effect: "Empathy", Effect Duration: 25, Last Available: "2013-09"
 6771	hardened tin foil of the ox of temperance	0		Muscle: +20, Damage Reduction: 3, Sleaze Resistance: +5, Last Available: "2013-09"
 6772	wobbly flame-retardant clever tin drum of the pedagogue	0		Experience: +3, Maximum MP: +20, Hot Resistance: +1, Last Available: "2013-09"
 6773	tin roof (rusted)	0		Last Available: "2013-09"
@@ -6723,8 +6723,8 @@
 6834	modified enhanced huge box of Dweebs	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 45
 6835	Vulcanized bag of W&Ws	0		Effect: "Human-Elf Hybrid", Effect Duration: 25
 6836	triple-activated aerosolized blinking PEEZ dispenser	0		Effect: "Human-Machine Hybrid", Effect Duration: 27
-6837	liquefied ghostly green Swizzler	0		Effect: "Smoking like a Bandit", Effect Duration: 11
-6838	colloidal pulsating jittery Bugbearclaw Donut	0		Effect: "Salty Dogs", Effect Duration: 40
+6837	liquefied green ghostly Swizzler	0		Effect: "Smoking like a Bandit", Effect Duration: 11
+6838	colloidal jittery pulsating Bugbearclaw Donut	0		Effect: "Salty Dogs", Effect Duration: 40
 6839	tarnished jam	0		Effect: "Ogred and Oublietted", Effect Duration: 38
 6840	diffused super-nitrogenated triple-deionized Whenchamacallit bar	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 37
 6841	super-ionized chilled 8-bit banana	0		Effect: "Trash-Wrapped", Effect Duration: 35
@@ -6740,19 +6740,19 @@
 6851	huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
 6853	jittery ghostly carton of rotten eggs	0		
-6854	pulsating blurry desert sightseeing pamphlet	0		
+6854	blurry pulsating desert sightseeing pamphlet	0		
 6855	a suspicious address	0		
 6856	blurry Bal-musette accordion of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	Cajun accordion of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	gravedigger's quirky accordion	0		Spooky Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery hardy Skipper's accordion of the cougar	0		Moxie: +20, Maximum HP: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	bouncing lard-coated wizardly Pantsgiving of the brute of the scaredy-cat	0		Mysticality: +25, Muscle Percent: +30, Monster Level: -15, Sleaze Spell Damage: +25, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	adequate small can of sardines	2	good	Last Available: "2013-11"
+6860	bouncing lard-coated wizardly Pantsgiving of the brute of the scaredy-cat	0		Mysticality: +25, Muscle Percent: +30, Monster Level: -15, Sleaze Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	small adequate can of sardines	2	good	Last Available: "2013-11"
 6862	small moldy shaking high-calorie sugar substitute	2	crappy	Last Available: "2013-11"
-6863	stale low-calorie pat of butter	1	decent	Last Available: "2013-11"
-6864	snack-sized spoiled jittery dinner roll	2	crappy	Last Available: "2013-11"
+6863	low-calorie stale pat of butter	1	decent	Last Available: "2013-11"
+6864	spoiled snack-sized jittery dinner roll	2	crappy	Last Available: "2013-11"
 6865	normal ghostly mashed potatoes	3	good	Last Available: "2013-11"
-6866	jumbo yummy whole turkey leg	5	awesome	Last Available: "2013-11"
+6866	yummy jumbo whole turkey leg	5	awesome	Last Available: "2013-11"
 6867	small spoiled deviled egg	2	crappy	Last Available: "2013-11"
 6868	quantum electrified finger exerciser	0		Effect: "Dirge of Dreadfulness", Effect Duration: 48, Last Available: "2013-11"
 6869	electrified non-colloidal squat dented spoon	0		Effect: "The Halls of Mysticality", Effect Duration: 64, Last Available: "2013-11"
@@ -6774,11 +6774,11 @@
 6885	denatured yellow spirit gum	0		Effect: "Mercenary", Effect Duration: 33
 6886	olive spirit pillow	0		
 6887	spirit sheet	0		
-6888	lime green narrow tumbling spirit mattress	0		
+6888	narrow lime green tumbling spirit mattress	0		
 6889	mirror huge spirit blanket	0		
 6890	spirit bed	0		
 6891	skewed greasy spirit bell of vim and vigor of the sweet-tooth	0		Maximum HP Percent: +50, Sleaze Spell Damage: +10, Candy Drop: +100, Class: "Turtle Tamer"
-6892	boiled frozen green spinning squat spoonful of Linguine-Os	0		Effect: "Amorphous Cheer", Effect Duration: 12, Last Available: "2013-11"
+6892	boiled frozen spinning squat green spoonful of Linguine-Os	0		Effect: "Amorphous Cheer", Effect Duration: 12, Last Available: "2013-11"
 6893	activated huge freezer-burned frost-bitten tortellini	0		Effect: "Gr8ness", Effect Duration: 55, Last Available: "2013-11"
 6894	activated polymerized pulsating blob of Alphredo&trade;	0		Effect: "Coated Arms", Effect Duration: 31, Last Available: "2013-11"
 6895	anodized denatured handful of crafty noodles	0		Effect: "Macho, Macho Dog", Effect Duration: 63, Last Available: "2013-11"
@@ -6807,32 +6807,32 @@
 6918	polymerized diffused colloidal twirling warbear wardance potion	0		Effect: "Techno Bliss", Effect Duration: 16, Last Available: "2013-12"
 6919	boiled ghostly warbear bearserker potion	0		Effect: "Work For Hours a Week", Effect Duration: 11, Last Available: "2013-12"
 6920	deionized warbear liquid overcoat	0		Effect: "Colorful Gratitude", Effect Duration: 68, Last Available: "2013-12"
-6921	jumbo flavorless warbear feasting bread	5	decent	Last Available: "2013-12"
-6922	fancy adequate spinning warbear warrior bread	4	good	Effect: "Sticks and Stones", Effect Duration: 15, Last Available: "2013-12"
+6921	flavorless jumbo warbear feasting bread	5	decent	Last Available: "2013-12"
+6922	adequate fancy spinning warbear warrior bread	4	good	Effect: "Sticks and Stones", Effect Duration: 15, Last Available: "2013-12"
 6923	tiny normal warbear thermoregulator bread	1	good	Last Available: "2013-12"
-6924	weak bad warbear feasting mead	2	decent	Last Available: "2013-12"
+6924	bad weak warbear feasting mead	2	decent	Last Available: "2013-12"
 6925	delicious warbear bearserker mead	4	awesome	Last Available: "2013-12"
 6926	watered-down drinkable warbear blizzard mead	2	good	Last Available: "2013-12"
 6927	cyan warbear helm fragment	0		Last Available: "2013-12"
-6928	chaotic Tesla supercharged warbear plain fedora	0		Maximum MP Percent: +30, Spell Critical Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	ghostly Rosewater's warbear feathered fedora	0		Mysticality Percent: +30, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	skewed greasy mansplainer's beefcake's warbear fedora	0		Muscle: +25, Monster Level: +15, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	chaotic crafty warbear plain helm of the detective	0		Maximum MP: +10, Spell Critical Percent: +10, Item Drop: +20, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	skewed warbear spiked helm of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	crafty wicked warbear electro-spiked helm of chilblains	0		Spell Damage: +5, Maximum MP: +10, Cold Damage: +25, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	cyan quilted smartaleck's warbear plain ushanka of the pedagogue	0		Moxie Percent: +30, Experience: +3, Damage Absorption: +40, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	Herculean warbear lined ushanka	0		Experience (Muscle): +1, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	tumbling huge chaotic resourceful razor-sharp warbear heated ushanka	0		Weapon Damage Percent: +25, Maximum MP: +50, Spell Critical Percent: +10, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	chaotic Tesla supercharged warbear plain fedora	0		Maximum MP Percent: +30, Spell Critical Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	ghostly Rosewater's warbear feathered fedora	0		Mysticality Percent: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	skewed greasy mansplainer's beefcake's warbear fedora	0		Muscle: +25, Monster Level: +15, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	chaotic crafty warbear plain helm of the detective	0		Maximum MP: +10, Spell Critical Percent: +10, Item Drop: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	skewed warbear spiked helm of bravery	0		Spooky Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	crafty wicked warbear electro-spiked helm of chilblains	0		Spell Damage: +5, Maximum MP: +10, Cold Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	cyan quilted smartaleck's warbear plain ushanka of the pedagogue	0		Moxie Percent: +30, Experience: +3, Damage Absorption: +40, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	Herculean warbear lined ushanka	0		Experience (Muscle): +1, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	tumbling huge chaotic resourceful razor-sharp warbear heated ushanka	0		Weapon Damage Percent: +25, Maximum MP: +50, Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	frosty slick warbear party pants of Leguizamo	0		Moxie: +10, Monster Level: +20, Cold Spell Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	blurry knitted warbear ceremonial party pants	0		Cold Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	Jeselnik's careful beefy warbear high festival pants	0		Muscle: +10, Monster Level: -10, Sleaze Damage: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	gravedigger's clever wicked warbear battle greaves	0		Spell Damage: +5, Maximum MP: +20, Spooky Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	mirror friendly warbear officer greaves	0		Familiar Weight: +3, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	extremely unsafe deadly warbear bearserker greaves of dire peril	0		Weapon Damage: 25, Weapon Damage Percent: +100, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	banded thinker's warbear johns of the blizzard	0		Mysticality: +10, Damage Absorption: +100, Cold Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	blurry Socratic warbear fleece-lined johns	0		Experience (Mysticality): +1, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	chilly warbear johns of the brazier of the cheetah	0		Cold Damage: +5, Hot Spell Damage: +25, Initiative: +60, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	frosty slick warbear party pants of Leguizamo	0		Moxie: +10, Monster Level: +20, Cold Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	blurry knitted warbear ceremonial party pants	0		Cold Resistance: +3, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	Jeselnik's careful beefy warbear high festival pants	0		Muscle: +10, Monster Level: -10, Sleaze Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	gravedigger's clever wicked warbear battle greaves	0		Spell Damage: +5, Maximum MP: +20, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	mirror friendly warbear officer greaves	0		Familiar Weight: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	extremely unsafe deadly warbear bearserker greaves of dire peril	0		Weapon Damage: 25, Weapon Damage Percent: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	banded thinker's warbear johns of the blizzard	0		Mysticality: +10, Damage Absorption: +100, Cold Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	blurry Socratic warbear fleece-lined johns	0		Experience (Mysticality): +1, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	chilly warbear johns of the brazier of the cheetah	0		Cold Damage: +5, Hot Spell Damage: +25, Initiative: +60, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	chilly careful wicked warbear goggles	0		Spell Damage: +5, Monster Level: -10, Cold Damage: +5, Single Equip, Last Available: "2013-12"
 6949	frosty warbear snowblindness goggles	0		Cold Spell Damage: +10, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	studded brainy warbear warscarf of bravery	0		Mysticality: +5, Damage Absorption: +80, Spooky Resistance: +5, Single Equip, Last Available: "2013-12"
 6957	pulsating warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	Sherlock's warbear foil hat	0		Item Drop: +25, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	Sherlock's warbear foil hat	0		Item Drop: +25, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	mirror tumbling horrifying rock-hard warbear oil pan	0		Damage Reduction: 5, Spooky Damage: +25, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	mirror tumbling horrifying rock-hard warbear oil pan	0		Damage Reduction: 5, Spooky Damage: +25, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	ghostly foul-smelling warbear exhaust manifold	0		Stench Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,7 +6889,7 @@
 7000	skewed MacGyver's educational die-cast Don Crimbo	0		Experience: +1, Maximum MP: +100, Last Available: "2013-12"
 7001	vibrating cool die-cast Uncle Hobo	0		Moxie: +5, Maximum MP Percent: +10, Last Available: "2013-12"
 7002	boxer's die-cast Father Crimbo of the brute	0		Muscle Percent: 40, Last Available: "2013-12"
-7003	tumbling The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	tumbling The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	ionized chilled Flaskfull of Hollow	0		Effect: "Biologically Shocked", Effect Duration: 60, Last Available: "2013-12"
 7005	tumbling lump of Brituminous coal	0		Last Available: "2013-12"
 7006	compressed purple handful of Smithereens	1	decent	Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	greedy toasty Lo Pan's Sheila Take a Crossbow of chilblains	0		Spell Critical Percent: +30, Cold Damage: +25, Hot Damage: +5, Meat Drop: +20, Last Available: "2013-12"
 7019	gray inspector's nippy lion tamer's A Light that Never Goes Out of terror	0		Experience (familiar): +2, Cold Damage: +10, Spooky Spell Damage: +10, Item Drop: +15, Last Available: "2013-12"
 7020	executive miser's healthy sage Half a Purse	0		Mysticality Percent: +10, Maximum HP Percent: +20, Meat Drop: 50, Last Available: "2013-12"
-7021	knitted Hairpiece On Fire of vim and vigor of the blizzard of temperance	0		Maximum HP Percent: +50, Cold Spell Damage: +25, Cold Resistance: +3, Sleaze Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	horrifying lion tamer's Vicar's Tutu of the businessman of the cheetah	0		Experience (familiar): +2, Spooky Damage: +25, Meat Drop: +50, Initiative: +60, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	knitted Hairpiece On Fire of vim and vigor of the blizzard of temperance	0		Maximum HP Percent: +50, Cold Spell Damage: +25, Cold Resistance: +3, Sleaze Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	horrifying lion tamer's Vicar's Tutu of the businessman of the cheetah	0		Experience (familiar): +2, Spooky Damage: +25, Meat Drop: +50, Initiative: +60, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	jittery flame-retardant therapeutic Newton's Hand in Glove	0		Experience (Mysticality): +3, Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
 7024	frightening hale Da Vinci's Meat Tenderizer is Murder	0		Experience (Mysticality): +5, Maximum HP: +20, Spooky Damage: +5, Class: "Seal Clubber", Last Available: "2013-12"
 7025	pulsating knitted manspreader's MacGyver's Ouija Board, Ouija Board	0		Maximum MP: +100, Monster Level: +10, Cold Resistance: +3, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,9 +6918,9 @@
 7029	nippy electrified groovy Shakespeare's Sister's Accordion	0		Moxie Percent: +10, Cold Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	supercharged third-hand lantern	0		Maximum MP Percent: +30
 7031	loose purse strings	0		
-7032	adequate special tumbling pickled egg	3	good	Effect: "Leisurely Amblin'", Effect Duration: 10
+7032	special adequate tumbling pickled egg	3	good	Effect: "Leisurely Amblin'", Effect Duration: 10
 7033	cup of lukewarm tea	1	crappy	
-7034	maroon shaking narrow warbear soda machine assembler	0		Last Available: "2013-12"
+7034	narrow maroon shaking warbear soda machine assembler	0		Last Available: "2013-12"
 7035	mirror warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
@@ -6930,8 +6930,8 @@
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	green warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	gray warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	Vulcanized colloidal jittery blinking teal glass slipper	0		Effect: "Rushtacean'", Effect Duration: 15, Last Available: "2014-12"
-7045	pickled bouncing jittery antimatter wad	1	decent	Last Available: "2013-12"
+7044	Vulcanized colloidal teal blinking jittery glass slipper	0		Effect: "Rushtacean'", Effect Duration: 15, Last Available: "2014-12"
+7045	pickled jittery bouncing antimatter wad	1	decent	Last Available: "2013-12"
 7046	altered improved mirror warbear superpotion	0		Effect: "Industrial Strength Starch", Effect Duration: 44, Last Available: "2013-12"
 7047	ionized alkaline warbear liquid lasers	0		Effect: "Sleazy Jellied", Effect Duration: 59, Last Available: "2013-12"
 7048	vacuum-sealed non-polarized chilled warbear rejuvenation potion	0		Effect: "In Vino Vires", Effect Duration: 45, Last Available: "2013-12"
@@ -6941,9 +6941,9 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	red warbear drone codes	0		Last Available: "2013-12"
-7055	delicious enchanted blurry breakfast mess	4	awesome	Effect: "Gummibrain", Effect Duration: 30, Last Available: "2013-12"
+7055	enchanted delicious blurry breakfast mess	4	awesome	Effect: "Gummibrain", Effect Duration: 30, Last Available: "2013-12"
 7056	squat warbear breakfast machine	0		Last Available: "2013-12"
-7057	fancy decent teal breakfast miracle	3	good	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2013-12"
+7057	decent fancy teal breakfast miracle	3	good	Effect: "Dancing Prowess", Effect Duration: 25, Last Available: "2013-12"
 7058	unsweetened spinning Cloaca Cola Polar	0		Effect: "Saucemastery", Effect Duration: 41, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6951,7 +6951,7 @@
 7062	skewed praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	huge Grim Brothers' story book	0		Familiar Weight: +5
 7064	mirror hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	denatured wobbly tumbling grim fairy tale	1	decent	Last Available: "2014-12"
+7065	denatured tumbling wobbly grim fairy tale	1	decent	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	frozen single of Inigo's Incantation of Inspiration	0		Effect: "Brain Freeze", Effect Duration: 50, Last Available: "2010-02"
 7068	double-polarized alkaline single of Donho's Bubbly Ballad	0		Effect: "Spiky Frozen Hair", Effect Duration: 36
@@ -6967,49 +6967,49 @@
 7078	delicious Ice Island Long Tea	4	awesome	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
-7081	wobbly ghostly lime green ice house	0		Last Available: "2014-01"
+7081	lime green ghostly wobbly ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	snow mobile of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	snow mobile of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	spinning ribald ice bucket	0		Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	dog trainer's deadly snow shovel	0		Weapon Damage: +5, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2014-01"
 7086	ghostly twirling prompt auspicious bod-ice of the brute	0		Muscle Percent: +30, Item Drop: +10, Adventures: +3, Lasts Until Rollover, Last Available: "2014-01"
 7087	boxer's stylish snow belt of the overflowing toilet of horror	0		Moxie: +25, Muscle Percent: +10, Stench Spell Damage: +50, Spooky Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	pulsating flame-wreathed stiffened forbidden Rosewater's ice nine	0		Mysticality Percent: +30, Spell Damage Percent: +50, Damage Reduction: 1, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	smooth weak En Una Fila Tequila	2	awesome	
+7090	weak smooth En Una Fila Tequila	2	awesome	
 7091	fancy Skully's hot chocolate	1	good	Effect: "Glittering Eyelashes", Effect Duration: 30
-7092	skewed tumbling electrified weightlifter's warbear dress helmet	0		Muscle: +15, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	skewed tumbling electrified weightlifter's warbear dress helmet	0		Muscle: +15, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	curative warbear dress bracers of the pedagogue	0		Experience: +3, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-12"
-7094	Jim Carey's warbear dress greaves of the dark arts	0		Spell Damage Percent: +100, Monster Level: +25, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	tumbling nippy sweatband of the glutton	0		Cold Damage: +10, Food Drop: +100, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	blinking mirror razor-sharp beefy gym shorts	0		Muscle: +10, Weapon Damage Percent: +25, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	Jim Carey's warbear dress greaves of the dark arts	0		Spell Damage Percent: +100, Monster Level: +25, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	tumbling nippy sweatband of the glutton	0		Cold Damage: +10, Food Drop: +100, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	blinking mirror razor-sharp beefy gym shorts	0		Muscle: +10, Weapon Damage Percent: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	healthy rock-hard ankleweights	0		Damage Reduction: 5, Maximum HP Percent: +20, Single Equip, Last Available: "2014-12"
 7098	up-at-dawn flame-retardant supercool sweat socks of chilblains	0		Moxie Percent: +20, Cold Damage: +25, Hot Resistance: +1, Adventures: +5, Last Available: "2014-12"
 7099	maroon pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	denatured spinning Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
-7103	triple-ionized shaking wobbly powder	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 12, Last Available: "2014-12"
+7103	triple-ionized wobbly shaking powder	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 12, Last Available: "2014-12"
 7104	ghostly prompt licorice whip	0		Adventures: +3, Last Available: "2014-12"
 7105	twirling anise-flavored venom	0		Last Available: "2014-12"
 7106	weak lousy snakebite	2	decent	Last Available: "2014-12"
 7107	horrifying scorching candy stick	0		Hot Damage: +25, Spooky Damage: +25, Last Available: "2014-12"
-7108	rotten huge pecan	6	crappy	Last Available: "2014-12"
+7108	huge rotten pecan	6	crappy	Last Available: "2014-12"
 7109	jumbo adequate pecan pie	5	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	jumbo flavorless candy mountain oyster	5	decent	Last Available: "2014-12"
+7111	flavorless jumbo candy mountain oyster	5	decent	Last Available: "2014-12"
 7112	hand-crafted boozy chocotini	5	EPIC	Last Available: "2014-12"
 7113	executive Sherlock's razor-sharp chocolate rabbit's foot	0		Weapon Damage Percent: +25, Item Drop: +25, Meat Drop: +40, Last Available: "2014-12"
 7114	spoiled olive candy carrot	4	crappy	Last Available: "2014-12"
 7115	yummy candy carrot cake	3	awesome	Last Available: "2014-12"
 7116	fortified Sinatra's carrot-on-a-stick	0		Experience (Moxie): +5, Damage Absorption: +60, Last Available: "2014-12"
-7117	electrified wholesome weasel stomping pants	0		Maximum HP Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	flavorless half-sized mulberry	2	decent	Last Available: "2014-12"
-7119	fortified perfectly mixed mulled berry wine	5	EPIC	Last Available: "2014-12"
+7117	electrified wholesome weasel stomping pants	0		Maximum HP Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7118	half-sized flavorless mulberry	2	decent	Last Available: "2014-12"
+7119	perfectly mixed fortified mulled berry wine	5	EPIC	Last Available: "2014-12"
 7120	gray jittery lemony scales	0		Last Available: "2014-12"
-7121	green lemon party hat of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	green lemon party hat of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	personal trainer's lemon shirt	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2014-12"
-7123	mirror blinking pulsating savvy lemon drop trousers	0		Mysticality Percent: +20, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	mirror blinking pulsating savvy lemon drop trousers	0		Mysticality Percent: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	warmed jittery lemonhead caviar	0		Effect: "Nano-juiced", Effect Duration: 66, Last Available: "2014-12"
 7125	shaking knitted gummi sword of the empath	0		Familiar Weight: +5, Cold Resistance: +3, Last Available: "2014-12"
 7126	polarized Vulcanized small gummi fin	0		Effect: "Unrunnable Face", Effect Duration: 66, Last Available: "2014-12"
@@ -7020,8 +7020,8 @@
 7131	cow creamer of James Dean of the dark arts of Gandalf	0		Experience (Moxie): +3, Spell Damage Percent: +100, Spell Critical Percent: +20, Last Available: "2014-12"
 7132	unsweetened dry Outer Wolf&trade; cologne	0		Effect: "This Is Where You're a Viking", Effect Duration: 18, Last Available: "2014-12"
 7133	mirror lupine appetite hormones	0		Last Available: "2014-12"
-7134	twirling Temple Grandin's Rosewater's wolf whistle	0		Mysticality Percent: +30, Familiar Weight: +7, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	tiny yummy mirror witch's bread	1	awesome	Last Available: "2014-12"
+7134	twirling Temple Grandin's Rosewater's wolf whistle	0		Mysticality Percent: +30, Familiar Weight: +7, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	yummy tiny mirror witch's bread	1	awesome	Last Available: "2014-12"
 7136	dry pressed witch's brew	0		Effect: "Tearful, Fearful", Effect Duration: 52, Last Available: "2014-12"
 7137	Socratic slick witch's bra of the overflowing toilet	0		Moxie: +10, Experience (Mysticality): +1, Stench Spell Damage: +50, Last Available: "2014-12"
 7138	artisanal twirling mid-level medieval mead	3	EPIC	Last Available: "2014-12"
@@ -7031,8 +7031,8 @@
 7142	dry alkaline mirror squat hare brush	0		Effect: "Wet and Greedy", Effect Duration: 40, Last Available: "2014-12"
 7143	squat shaking cyan supercool hare pin of mayonnaise	0		Moxie Percent: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	half-sized moldy shaking jittery cinnamon cannoli	2	crappy	Last Available: "2014-12"
-7146	fortified drinkable ghostly expensive champagne	5	good	Last Available: "2014-12"
+7145	moldy half-sized jittery shaking cinnamon cannoli	2	crappy	Last Available: "2014-12"
+7146	drinkable fortified ghostly expensive champagne	5	good	Last Available: "2014-12"
 7147	adjusted oxidized polo trophy	0		Effect: "Papowerful", Effect Duration: 16, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7043,14 +7043,14 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	Van der Graaf Oprah's medical-grade fire hose	0		Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	miniature flavorless special fireman's lunch	2	decent	Effect: "Slightly Mutated", Effect Duration: 15, Last Available: "2014-12"
-7159	teal padded Rosewater's plain paper hat of the detective	0		Mysticality Percent: +30, Damage Absorption: +20, Item Drop: +20, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	super-sized normal ice cream sandwich	5	good	Last Available: "2014-12"
+7157	Van der Graaf Oprah's medical-grade fire hose	0		Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7158	flavorless special miniature fireman's lunch	2	decent	Effect: "Slightly Mutated", Effect Duration: 15, Last Available: "2014-12"
+7159	teal padded Rosewater's plain paper hat of the detective	0		Mysticality Percent: +30, Damage Absorption: +20, Item Drop: +20, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7160	normal super-sized ice cream sandwich	5	good	Last Available: "2014-12"
 7161	Oprah's forbidden baleful &quot;honey&quot; dipper	0		Spell Damage: +25, Spell Damage Percent: +50, Maximum MP Percent: +50, Last Available: "2014-12"
 7162	bite-sized spoiled plumber's lunch	1	crappy	Last Available: "2014-12"
 7163	smelly clever smooth skull gearshift knob	0		Moxie: +15, Maximum MP: +20, Stench Spell Damage: +10, Last Available: "2014-12"
-7164	decent diet nachos of the night	1	good	Last Available: "2014-12"
+7164	diet decent nachos of the night	1	good	Last Available: "2014-12"
 7165	crafty Samson's Sketcherz&trade; of terror	0		Experience (Muscle): +5, Maximum MP: +10, Spooky Spell Damage: +10, Last Available: "2014-12"
 7166	diet moldy can of Adultwitch&trade;	1	crappy	Last Available: "2014-12"
 7167	boiled improved mirror smudge stick	0		Effect: "Radium Radicality", Effect Duration: 42, Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	polymerized boiled jug of &quot;wine&quot;	0		Effect: "Tearful, Fearful", Effect Duration: 31, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	twirling crappy camera	0		Last Available: "2014-12"
-7174	stale jumbo humble pie	5	decent	Last Available: "2014-12"
+7174	jumbo stale humble pie	5	decent	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	jittery shaking crappy camera	0		Last Available: "2014-12"
 7177	wet cold-filtered crappy waiter disguise	0		Effect: "Adventurer's Best Friendship", Effect Duration: 32
@@ -7088,11 +7088,11 @@
 7199	cyan blowdart	0		
 7200	Usain Bolt's Buddy Bjorn	0		Initiative: +80, Softcore Only, Last Available: "2014-02"
 7201	rosewater-soaked quilted Socratic The Nuge's favorite crossbow	0		Experience (Mysticality): +1, Damage Absorption: +40, Stench Resistance: +3
-7202	moldy low-calorie spinning sweet roll Alabama	1	crappy	
+7202	low-calorie moldy spinning sweet roll Alabama	1	crappy	
 7203	twirling perfumed Saturday Night Special	0		Stench Resistance: +5
 7204	lynyrd snare	0		
 7205	spinning fleetwood chain of Calamity Jane	0		Critical Hit Percent: +15
-7206	extra-dry lousy Green Manalishi	5	decent	
+7206	lousy extra-dry Green Manalishi	5	decent	
 7207	ghostly reassuring blade	0		Spooky Resistance: +1
 7208	teal fire of unknown origin	0		
 7209	special shaking eagle's milk	1	crappy	Effect: "[800]Chocolate Reign", Effect Duration: 15
@@ -7111,7 +7111,7 @@
 7222	weak artisanal Flamin' Whatshisname	2	EPIC	
 7223	quantum yellow lynyrd musk	0		Effect: "There Is A Spoon", Effect Duration: 59
 7224	green ghostly Usain Bolt's supercharged Kashmir sweater	0		Maximum MP Percent: +30, Initiative: +80
-7225	toothsome miniature lime green custard pie	2	awesome	
+7225	miniature toothsome lime green custard pie	2	awesome	
 7226	tea for one	1	good	
 7227	artisanal bottle of Evermore	3	EPIC	
 7228	blurry box	0		
@@ -7165,10 +7165,10 @@
 7276	strapping plastic Captain Kerkard	0		Muscle: +5
 7277	irradiated corrupted robot grease	0		Effect: "OMG WTF", Effect Duration: 16
 7278	returned Thinknerd package	0		
-7279	diffused shaking twirling wind-up Whatsian robot	0		Effect: "Spooky Flavor", Effect Duration: 58
+7279	diffused twirling shaking wind-up Whatsian robot	0		Effect: "Spooky Flavor", Effect Duration: 58
 7280	ionized colloidal gray shaking wind-up vampire teeth	0		Effect: "Patent Alacrity", Effect Duration: 57
 7281	chilled upside-down wind-up navigation droid	0		Effect: "Patent Prevention", Effect Duration: 69
-7282	oxidized activated blue blurry wind-up owl	0		Effect: "Penguinny Flavor", Effect Duration: 68
+7282	oxidized activated blurry blue wind-up owl	0		Effect: "Penguinny Flavor", Effect Duration: 68
 7283	oxidized wind-up ensign	0		Effect: "Tiki Toughness", Effect Duration: 49
 7284	Jeselnik's crying statue earrings of the dark arts	0		Spell Damage Percent: +100, Sleaze Damage: +25, Single Equip, Lasts Until Rollover
 7285	ghostly chilly sage plastic Duskwalker necklace	0		Mysticality Percent: +10, Cold Damage: +5, Single Equip, Lasts Until Rollover
@@ -7176,7 +7176,7 @@
 7287	skewed groovy thinker's Gary Claybender's Time Screwer	0		Mysticality: +10, Moxie Percent: +10, Single Equip, Lasts Until Rollover
 7288	sage boxer's Space Tourist palmdoctor	0		Muscle Percent: +10, Mysticality Percent: +10, Lasts Until Rollover
 7289	gravedigger's mansplainer's hale amok putter	0		Maximum HP: +20, Monster Level: +15, Spooky Damage: +10
-7290	big spoiled amok pudding	5	crappy	
+7290	spoiled big amok pudding	5	crappy	
 7291	deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	warmed can of V-11	0		Effect: "Good with the Ladies", Effect Duration: 68, Last Available: "2014-03"
@@ -7186,7 +7186,7 @@
 7297	manspreader's Professor What T-Shirt	0		Monster Level: +10
 7298	heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
-7300	cyan twirling mirror sewing kit	0		
+7300	mirror cyan twirling sewing kit	0		
 7301	Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	jittery Lady Spookyraven's necklace	0		
@@ -7213,34 +7213,34 @@
 7324	vaporized jittery battery	1		
 7325	smooth snakebite	3	awesome	
 7326	squat lightning-fast thinker's rubber ribcage	0		Mysticality: +10, Initiative: +40, Damage Reduction: 7
-7327	twisted wobbly jittery synthetic marrow	1		
+7327	twisted jittery wobbly synthetic marrow	1		
 7328	denatured warmed modified funny bone	0		Effect: "One Very Clear Eye", Effect Duration: 52
 7329	Sherlock's grievous half-melted spoon	0		Weapon Damage Percent: +50, Item Drop: +25
-7330	modified yellow tumbling upside-down the funk	1		
+7330	modified upside-down yellow tumbling the funk	1		
 7331	bland gunky chicken	4	decent	
 7332	doll head of Calamity Jane	0		Critical Hit Percent: +15
 7333	shaking droopy doll eye	0		
-7334	blue squat blurry voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
+7334	blurry blue squat voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	censurious paddle-ball of terror	0		Spooky Spell Damage: +10, Sleaze Resistance: +3
 7336	deionized altered sound effects record	0		Effect: "Astral Shell", Effect Duration: 68
 7337	alphabet block	0		
 7338	magnetized bouncing dancer	0		Effect: "New Zeal", Effect Duration: 35
 7339	music box mechanism	0		
 7340	arcane researcher's moose antlers	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xLep, cap 27"
-7341	cold-filtered quadruple-enhanced wobbly blinking moose thought	0		Effect: "Your Eyes are Peeled!", Effect Duration: 34
-7342	adequate miniature moose chocolate	2	good	
+7341	cold-filtered quadruple-enhanced blinking wobbly moose thought	0		Effect: "Your Eyes are Peeled!", Effect Duration: 34
+7342	miniature adequate moose chocolate	2	good	
 7343	bad squat painting of a glass of wine	3	decent	
-7344	upside-down blinking oil painting of yourself	0		
+7344	blinking upside-down oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	purple doll-eye amulet	0		Single Equip
 7347	up-at-dawn Sinatra's ghost toga	0		Experience (Moxie): +5, Adventures: +5
-7348	super-sized rotten sheet cake	5	crappy	
+7348	rotten super-sized sheet cake	5	crappy	
 7349	ghost key	0		
 7350	ghostly picture of you	0		
 7351	Staff of the Electric Range of the empath of the businessman of the glutton	0		Familiar Weight: +5, Meat Drop: +50, Food Drop: +100
 7352	tasty deluxe layer cake	4	awesome	
 7353	chunk of hot iron	0		
-7354	drinkable triple-distilled red-hot boilermaker	10	good	
+7354	triple-distilled drinkable red-hot boilermaker	10	good	
 7355	arcane researcher's coal shovel	0		Experience Percent (Mysticality): +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	double-polarized ionized hot coal	0		Effect: "Leo Rising", Effect Duration: 47
 7357	oxidized altered coal dust	0		Effect: "Staying Frosty", Effect Duration: 62
@@ -7275,10 +7275,10 @@
 7386	liquefied Gene Tonic: Construct	0		Effect: "Fire Inside", Effect Duration: 46, Last Available: "2014-04"
 7387	polarized galvanized spinning Gene Tonic: Undead	0		Effect: "Greedy Resolve", Effect Duration: 60, Last Available: "2014-04"
 7388	magnetized aerosolized gray Gene Tonic: Humanoid	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 66, Last Available: "2014-04"
-7389	corrupted boiled blurry skewed Gene Tonic: Insect	0		Effect: "Material Witness", Effect Duration: 25, Last Available: "2014-04"
+7389	corrupted boiled skewed blurry Gene Tonic: Insect	0		Effect: "Material Witness", Effect Duration: 25, Last Available: "2014-04"
 7390	quantum mirror Gene Tonic: Hippy	0		Effect: "Updated", Effect Duration: 15, Last Available: "2014-04"
 7391	deionized vacuum-sealed colloidal yellow Gene Tonic: Orc	0		Effect: "Alchemical, Brother", Effect Duration: 27, Last Available: "2014-04"
-7392	ionized extra-ionized mirror shaking Gene Tonic: Demon	0		Effect: "Weepy, Creepy", Effect Duration: 39, Last Available: "2014-04"
+7392	ionized extra-ionized shaking mirror Gene Tonic: Demon	0		Effect: "Weepy, Creepy", Effect Duration: 39, Last Available: "2014-04"
 7393	irradiated gray Gene Tonic: Horror	0		Effect: "The Magic of LOV", Effect Duration: 20, Last Available: "2014-04"
 7394	ionized deionized Gene Tonic: Fish	0		Effect: "Red-Shirted Escort", Effect Duration: 69, Last Available: "2014-04"
 7395	cold-filtered modified narrow maroon Gene Tonic: Goblin	0		Effect: "This Is Where You're a Viking", Effect Duration: 27, Last Available: "2014-04"
@@ -7294,7 +7294,7 @@
 7405	galvanized dry Gene Tonic: Hobo	0		Effect: "Adrenaline Rush", Effect Duration: 43, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
-7408	mirror shaking Steam Card: Dungeon Fist (#3)	0		
+7408	shaking mirror Steam Card: Dungeon Fist (#3)	0		
 7409	Steam Card: Space Trip (#1)	0		
 7410	blue Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
@@ -7325,36 +7325,36 @@
 7436	corrupted teal shaking Tremella Tarantella mushroom	0		Effect: "Boilermade", Effect Duration: 16, Last Available: "2014-05"
 7437	mirror Pastaco shell	0		Last Available: "2014-05"
 7438	decent massive yellow Beefy Crunch Pastaco	8	good	Last Available: "2014-05"
-7439	delicious low-calorie Brain Food Pastaco	1	awesome	Last Available: "2014-05"
+7439	low-calorie delicious Brain Food Pastaco	1	awesome	Last Available: "2014-05"
 7440	moldy thick Cool Brunch Pastaco	5	crappy	Last Available: "2014-05"
-7441	miniature flavorless mirror Medical Pastaco	2	decent	Last Available: "2014-05"
+7441	flavorless miniature mirror Medical Pastaco	2	decent	Last Available: "2014-05"
 7442	spoiled Energy Buzz Pastaco	4	crappy	Last Available: "2014-05"
 7443	moldy Ludovico Pastaco	3	crappy	Last Available: "2014-05"
 7444	lousy overpowering mushroom wine	4	decent	Last Available: "2014-05"
-7445	practically non-alcoholic mediocre complex mushroom wine	1	decent	Last Available: "2014-05"
-7446	drinkable watered-down blinking smooth mushroom wine	2	good	Last Available: "2014-05"
+7445	mediocre practically non-alcoholic complex mushroom wine	1	decent	Last Available: "2014-05"
+7446	watered-down drinkable blinking smooth mushroom wine	2	good	Last Available: "2014-05"
 7447	mediocre blood-red mushroom wine	4	decent	Last Available: "2014-05"
 7448	tolerable buzzing mushroom wine	3	good	Last Available: "2014-05"
 7449	delicious swirling mushroom wine	3	awesome	Last Available: "2014-05"
 7450	miniature bland Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
 7451	normal Taco Dan's Taco Fish Fish Taco	4	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	acceptable practically non-alcoholic regular-size brogurt	1	good	Last Available: "2014-05"
-7454	tolerable irresponsibly strong narrow super-size brogurt	9	good	Last Available: "2014-05"
-7455	spirit-forward hand-crafted blinking cyan broberry brogurt	5	EPIC	Last Available: "2014-05"
-7456	lousy high-proof fancy brocolate brogurt	9	decent	Effect: "Empathy", Effect Duration: 35, Last Available: "2014-05"
-7457	watered-down artisanal French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7453	practically non-alcoholic acceptable regular-size brogurt	1	good	Last Available: "2014-05"
+7454	irresponsibly strong tolerable narrow super-size brogurt	9	good	Last Available: "2014-05"
+7455	hand-crafted spirit-forward blinking cyan broberry brogurt	5	EPIC	Last Available: "2014-05"
+7456	fancy lousy high-proof brocolate brogurt	9	decent	Effect: "Empathy", Effect Duration: 35, Last Available: "2014-05"
+7457	artisanal watered-down French bronilla brogurt	2	super ultra EPIC	Last Available: "2014-05"
 7458	wobbly History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	upside-down industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Brogre brorts of the brazier	0		Hot Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	cyan twirling stylish Brogre brolo shirt	0		Moxie: +25, Last Available: "2014-05"
-7464	blinking brainy Brogre bucket hat	0		Mysticality: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	blinking brainy Brogre bucket hat	0		Mysticality: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	skewed spinning airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	squat one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	olive reassuring nasty ruddy 8-billed baseball cap	0		Maximum HP Percent: +40, Stench Damage: +5, Spooky Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	olive reassuring nasty ruddy 8-billed baseball cap	0		Maximum HP Percent: +40, Stench Damage: +5, Spooky Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	lightning-fast veiny arcane researcher's extremely wet T-shirt	0		Experience Percent (Mysticality): +10, Maximum HP: +10, Initiative: +40, Last Available: "2014-05"
 7470	Jeselnik's veiny shrimp fork of the businessman	0		Maximum HP: +10, Sleaze Damage: +25, Meat Drop: +50, Last Available: "2014-05"
 7471	altered BROS Energy Drink	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 56, Last Available: "2014-05"
@@ -7367,18 +7367,18 @@
 7478	fuchsia possessed sugar cube	0		Last Available: "2014-05"
 7479	non-ionized pulsating sugar fairy	0		Effect: "Chalked Weapon", Effect Duration: 41, Last Available: "2014-05"
 7480	frozen energized frozen tumbling sugar bunny	0		Effect: "Rave Nirvana", Effect Duration: 30, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	smooth Rompedores de Fantasmas	3	awesome	
-7483	practically non-alcoholic acceptable mirror La Fantasma y La Oscuridad	1	good	
-7484	distilled tolerable mirror lime green Fantasma en la M&aacute;quina	5	good	
+7483	acceptable practically non-alcoholic mirror La Fantasma y La Oscuridad	1	good	
+7484	tolerable distilled lime green mirror Fantasma en la M&aacute;quina	5	good	
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	drain dissolver	0		
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	perfectly mixed weak bottle of Chateau de Vinegar	2	EPIC	
-7492	mirror fuchsia blasting soda	0		
+7491	weak perfectly mixed bottle of Chateau de Vinegar	2	EPIC	
+7492	fuchsia mirror blasting soda	0		
 7493	unstable fulminate	0		
 7494	mirror wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
@@ -7416,22 +7416,22 @@
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	dangerous smartaleck's government-issued night-vision goggles	0		Moxie Percent: +30, Weapon Damage: +10, Single Equip, Last Available: "2014-05"
 7529	massive yummy loaf of alien bread	10	awesome	Last Available: "2014-05"
-7530	bland miniature grilled cheese sandwich	2	decent	Last Available: "2014-05"
-7531	pickled cyan shaking alien protein powder	1	decent	Last Available: "2014-05"
-7532	artisanal watered-down mirror rocket fuel	2	EPIC	Last Available: "2014-05"
+7530	miniature bland grilled cheese sandwich	2	decent	Last Available: "2014-05"
+7531	pickled shaking cyan alien protein powder	1	decent	Last Available: "2014-05"
+7532	watered-down artisanal mirror rocket fuel	2	EPIC	Last Available: "2014-05"
 7533	mirror alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7534	cyan mirror alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7534	mirror cyan alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	hand-crafted stealth bomber	3	EPIC	Last Available: "2014-05"
 7536	tumbling space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	greedy space beast fur hat	0		Meat Drop: +20, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	family-friendly space beast fur pants	0		Sleaze Resistance: +1, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	greedy space beast fur hat	0		Meat Drop: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	family-friendly space beast fur pants	0		Sleaze Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	censurious space beast fur whip	0		Sleaze Resistance: +3, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	foul-smelling space heater of the detective	0		Stench Damage: +10, Item Drop: +20, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	foul-smelling space heater of the detective	0		Stench Damage: +10, Item Drop: +20, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	twirling space bar	0		Last Available: "2014-05"
-7545	smooth weak space port	2	awesome	Last Available: "2014-05"
+7545	weak smooth space port	2	awesome	Last Available: "2014-05"
 7546	blurry lard-coated space needle of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +25, Last Available: "2014-05"
 7547	extra-adjusted liquefied ionized buffed alien drugs	0		Effect: "Ichorous Intensity", Effect Duration: 52, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7460,14 +7460,14 @@
 7571	thinker's silent pea shooter of courage	0		Mysticality: +10, Spooky Resistance: +3
 7572	adequate D roll	3	good	
 7573	squat extremely unsafe kiwi beak of the businessman	0		Weapon Damage Percent: +100, Meat Drop: +50
-7574	watered-down artisanal green skewed New Zealand iced tea	2	EPIC	
+7574	watered-down artisanal skewed green New Zealand iced tea	2	EPIC	
 7575	gray inspector's sharpshooter's droll monocle	0		Critical Hit Percent: +10, Item Drop: +15, Single Equip
 7576	oxidized bouncing future drug: Muscularactum	0		Effect: "Briny Blood", Effect Duration: 60
 7577	galvanized future drug: Smartinex	0		Effect: "Serenity", Effect Duration: 30
 7578	concentrated jittery future drug: Coolscaline	0		Effect: "Stogied", Effect Duration: 22
 7579	jittery twitching time capsule	0		
 7580	pickled skewed liquid shifting time weirdness	1		
-7581	shaking squat cyan shifting time weirdness	0		Adventures: +4, PvP Fights: +4
+7581	squat cyan shaking shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	tiny normal rack of dinosaur ribs	1	good	
 7583	tolerable practically non-alcoholic skewed scotch on the rocks	1	good	
 7584	mirror blinking occult Samson's yabba dabba doo rag	0		Experience (Muscle): +5, Spell Damage Percent: +25, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7475,24 +7475,24 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	ghostly Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	mediocre spirit-forward blurry glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
+7589	spirit-forward mediocre blurry glass of &quot;milk&quot;	5	decent	Last Available: "2014-07"
 7590	hand-crafted squat cup of &quot;tea&quot;	4	EPIC	Last Available: "2014-07"
 7591	bad weak thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
 7592	delicious high-proof Lucky Lindy	8	awesome	Last Available: "2014-07"
 7593	delicious special green Bee's Knees	3	awesome	Effect: "You're Rubber", Effect Duration: 35, Last Available: "2014-07"
-7594	acceptable practically non-alcoholic wobbly Sockdollager	1	good	Last Available: "2014-07"
-7595	lousy practically non-alcoholic squat Ish Kabibble	1	decent	Last Available: "2014-07"
-7596	mediocre spirit-forward Hot Socks	5	decent	Last Available: "2014-07"
-7597	lousy extra-dry Phonus Balonus	5	decent	Last Available: "2014-07"
+7594	practically non-alcoholic acceptable wobbly Sockdollager	1	good	Last Available: "2014-07"
+7595	practically non-alcoholic lousy squat Ish Kabibble	1	decent	Last Available: "2014-07"
+7596	spirit-forward mediocre Hot Socks	5	decent	Last Available: "2014-07"
+7597	extra-dry lousy Phonus Balonus	5	decent	Last Available: "2014-07"
 7598	artisanal Flivver	3	EPIC	Last Available: "2014-07"
-7599	hand-crafted practically non-alcoholic Sloppy Jalopy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
+7599	practically non-alcoholic hand-crafted Sloppy Jalopy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7600	non-colloidal Vulcanized blue flame	0		Effect: "Brother Smothers's Blessing", Effect Duration: 41
 7601	moist pressed temporary yak tattoo	0		Effect: "Tiki Temerity", Effect Duration: 62
 7602	ionized cold-filtered Fitspiration&trade; poster	0		Effect: "Coal-Powered", Effect Duration: 28
 7603	chilled extra-oxidized neckbeard	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 11
-7604	modified polarized upside-down huge squat artisanal hand-squeezed wheatgrass juice	0		Effect: "Comprehensively Nourished", Effect Duration: 54
+7604	modified polarized upside-down squat huge artisanal hand-squeezed wheatgrass juice	0		Effect: "Comprehensively Nourished", Effect Duration: 54
 7605	corrupted bouncing punk patch	0		Effect: "Fruited", Effect Duration: 58
-7606	super-nitrogenated fuchsia huge steampunk potion	0		Effect: "Haunted Liver", Effect Duration: 59
+7606	super-nitrogenated huge fuchsia steampunk potion	0		Effect: "Haunted Liver", Effect Duration: 59
 7607	enhanced upside-down upside-down vial of swamp vapors	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 19
 7608	unsweetened quadruple-warmed turtle mud	0		Effect: "Electrolit Up", Effect Duration: 33
 7609	pickled Redeye&trade; Eyedrops	0		Effect: "Incredibly Hulking", Effect Duration: 42
@@ -7503,8 +7503,8 @@
 7614	vacuum-sealed colloidal voodoo glowskull	0		Effect: "Sugar High", Effect Duration: 16
 7615	irradiated twirling pygmy adder oil	0		Effect: "Go-Gone", Effect Duration: 54
 7616	deionized pygmy witchhazel	0		Effect: "Twen Tea", Effect Duration: 42
-7617	pickled anodized blue squat skewed short deposition	0		Effect: "Whitened Teeth", Effect Duration: 15
-7618	flattened twirling lime green straw pole	0		Effect: "Weird Flavor", Effect Duration: 60
+7617	pickled anodized blue skewed squat short deposition	0		Effect: "Whitened Teeth", Effect Duration: 15
+7618	flattened lime green twirling straw pole	0		Effect: "Weird Flavor", Effect Duration: 60
 7619	deionized enhanced teal copperhead potion	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 48
 7620	altered ninja fear powder	0		Effect: "Drenched With Filth", Effect Duration: 19
 7621	quadruple-dry boiled polymerized ninja eyeblack	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 37
@@ -7548,18 +7548,18 @@
 7659	yellow neoprene skullcap of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	unsweetened teal goblin water	0		Effect: "Gummiskin", Effect Duration: 22
 7661	dumb mud	0		
-7662	gigantic special normal ghostly upside-down Sogg-Os	6	good	Effect: "Psalm of Pointiness", Effect Duration: 10
+7662	normal special gigantic upside-down ghostly Sogg-Os	6	good	Effect: "Psalm of Pointiness", Effect Duration: 10
 7663	mansplainer's savvy Lord Soggyraven's Slippers of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Monster Level: +15, Single Equip
-7664	ionized alkaline energized jittery yellow Ancient Protector Soda	0		Effect: "Ogred and Oublietted", Effect Duration: 68
-7665	cold-filtered ionized gray blinking liquid ice	0		Effect: "Aided and Abetted", Effect Duration: 56
-7666	acceptable special high-proof Wet Russian	10	good	Effect: "Broken Bone Nubs", Effect Duration: 45
+7664	ionized alkaline energized yellow jittery Ancient Protector Soda	0		Effect: "Ogred and Oublietted", Effect Duration: 68
+7665	cold-filtered ionized blinking gray liquid ice	0		Effect: "Aided and Abetted", Effect Duration: 56
+7666	special high-proof acceptable Wet Russian	10	good	Effect: "Broken Bone Nubs", Effect Duration: 45
 7667	bland big twirling filet of The Fish	5	decent	
 7668	Thwaitgold spider statuette	0		
 7669	blurry aromatic Van der Graaf baleful thunder down underwear	0		Spell Damage: +25, Stench Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover
 7670	nippy Da Vinci's famous raincoat of the empath	0		Experience (Mysticality): +5, Familiar Weight: +5, Cold Damage: +10, Lasts Until Rollover
 7671	zippy aromatic medical-grade lightning rod	0		Stench Resistance: +1, Initiative: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 7672	red law-abiding citizen cane of chilblains	0		Cold Damage: +25, Single Equip
-7673	distilled delicious spinning legitimate business on the beach	5	awesome	
+7673	delicious distilled spinning legitimate business on the beach	5	awesome	
 7674	dangerous hep waders	0		Weapon Damage: +10, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	low-calorie stale gray jive turkey leg	1	decent	
 7676	pulsating upside-down scandalous birdbone corset	0		Sleaze Damage: +5
@@ -7573,7 +7573,7 @@
 7684	wobbly occult Time Lord Participation Mug	0		Spell Damage Percent: +25
 7685	Rosewater's Time Bandit Time Towel of the pedagogue	0		Mysticality Percent: +30, Experience: +3
 7686	knitted Fonzie's Caveman Dan's favorite rock of the cheetah	0		Experience (Moxie): +1, Cold Resistance: +3, Initiative: +60, Single Equip
-7687	anodized dry teal upside-down huge dog ointment	0		Effect: "Frog In Your Throat", Effect Duration: 23
+7687	anodized dry upside-down huge teal dog ointment	0		Effect: "Frog In Your Throat", Effect Duration: 23
 7688	avaricious experienced gumshoes	0		Experience: +2, Meat Drop: +30, Single Equip
 7689	sizzling flapper floppers of the empath	0		Familiar Weight: +5, Hot Damage: +10, Single Equip
 7690	narrow sage sneakeasies of the bloodbag	0		Mysticality Percent: +10, Maximum HP: +100, Single Equip
@@ -7581,7 +7581,7 @@
 7692	family-friendly rosy-cheeked beefcake's hand whip	0		Muscle: +25, Maximum HP Percent: +30, Sleaze Resistance: +1, Last Available: "2014-08"
 7693	Jeselnik's energetic ruddy glow-in-the-dark necklace	0		Maximum HP Percent: +40, Maximum MP Percent: +20, Sleaze Damage: +25, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	stanky smelly deadly cap gun	0		Weapon Damage: +5, Stench Spell Damage: 35, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	stanky smelly deadly cap gun	0		Weapon Damage: +5, Stench Spell Damage: 35, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	chilly curative cassette player	0		Cold Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	spinning LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	tarnished altered non-denatured blue rubber nubbin	0		Effect: "Always be Collecting", Effect Duration: 58, Last Available: "2014-08"
 7708	up-at-dawn supercharged rubber cape	0		Maximum MP Percent: +30, Adventures: +5, Last Available: "2014-08"
-7709	stanky supercharged energetic Thor's Pliers of mayonnaise	0		Maximum MP Percent: 50, Stench Spell Damage: +25, Sleaze Spell Damage: +50, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	stanky supercharged energetic Thor's Pliers of mayonnaise	0		Maximum MP Percent: 50, Stench Spell Damage: +25, Sleaze Spell Damage: +50, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	chilled blinking candy UFOs	0		Effect: "Fury of the Bells", Effect Duration: 18
 7711	pulsating avaricious water wings for babies of extreme caution	0		Monster Level: -25, Meat Drop: +30
-7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	normal half-sized Strix stix	2	good	
 7714	tumbling family-friendly Jack Frost's therapeutic vampire pellet	0		Cold Spell Damage: +50, Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 7715	artisanal non-aged vinegar	4	EPIC	
@@ -7607,13 +7607,13 @@
 7718	curative Roman sadnals	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
 7719	medical-grade madius	0		HP Regen Min: 7, HP Regen Max: 10
 7720	wobbly flame-retardant radiator heater shield	0		Hot Resistance: +1, Damage Reduction: 6
-7721	diffused twirling pulsating fuchsia salt wages	0		Effect: "Coy to the Hurled", Effect Duration: 45
+7721	diffused pulsating twirling fuchsia salt wages	0		Effect: "Coy to the Hurled", Effect Duration: 45
 7722	centurion helmet of extreme caution	0		Monster Level: -25, Familiar Effect: "1xFairy, atk, cap 25"
 7723	olive Chroner cross	0		
 7724	brainy pteruges	0		Mysticality: +5, Familiar Effect: "1xFairy, atk, cap 25"
 7725	vacuum-sealed squat Bruno's blessing of Mars	0		Effect: "Spring Training", Effect Duration: 49
 7726	nitrogenated chilled Dennis's blessing of Minerva	0		Effect: "Incensed", Effect Duration: 24
-7727	pickled quantum narrow upside-down Burt's blessing of Bacchus	0		Effect: "Buff as a Baobab", Effect Duration: 27
+7727	pickled quantum upside-down narrow Burt's blessing of Bacchus	0		Effect: "Buff as a Baobab", Effect Duration: 27
 7728	dry polymerized Freddie's blessing of Mercury	0		Effect: "Savage Beast Inside", Effect Duration: 54
 7729	upside-down teal Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
@@ -7639,11 +7639,11 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	yellow Xiblaxian xeno-detection goggles of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2014-09"
-7753	sinister Xiblaxian stealth cowl of the businessman	0		Spell Damage: +10, Meat Drop: +50, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	sinister Xiblaxian stealth cowl of the businessman	0		Spell Damage: +10, Meat Drop: +50, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	shaking Tesla forbidden Xiblaxian stealth trousers	0		Spell Damage Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-09"
 7755	fuchsia tumbling experienced cool Xiblaxian stealth vest	0		Moxie: +5, Experience: +2, Last Available: "2014-09"
 7756	stale enchanted olive Xiblaxian ultraburrito	3	decent	Effect: "Amorous", Effect Duration: 45, Last Available: "2014-09"
-7757	enchanted practically non-alcoholic mediocre Xiblaxian space-whiskey	1	decent	Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2014-09"
+7757	enchanted mediocre practically non-alcoholic Xiblaxian space-whiskey	1	decent	Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2014-09"
 7758	bouncing Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	flattened warmed blinking They liver	0		Effect: "Chalk Outline", Effect Duration: 41, Last Available: "2014-09"
 7760	delicious They liver popsicle	4	awesome	Last Available: "2014-09"
@@ -7669,11 +7669,11 @@
 7780	lightning-fast heavy-duty clipboard of the brute of Gandalf	0		Muscle Percent: +30, Spell Critical Percent: +20, Initiative: +40, Damage Reduction: 8, Last Available: "2014-10"
 7781	cyan twirling nippy MacGyver's sinister battery-powered drill of Flo-Jo	0		Spell Damage: +10, Maximum MP: +100, Cold Damage: +10, Initiative: +100, Last Available: "2014-10"
 7782	flavorless bouncing limp broccoli	4	decent	Last Available: "2014-10"
-7783	maroon Usain Bolt's supercharged hat of Calamity Jane	0		Maximum MP Percent: +30, Critical Hit Percent: +15, Initiative: +80, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	maroon Usain Bolt's supercharged hat of Calamity Jane	0		Maximum MP Percent: +30, Critical Hit Percent: +15, Initiative: +80, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	non-pressed improved squat monkey barf	0		Effect: "Vanity Rage", Effect Duration: 16, Last Available: "2014-10"
 7785	double-moist energized ionized wobbly candy	0		Effect: "Barking Mad", Effect Duration: 50, Last Available: "2014-10"
 7786	Herculean jangly bracelet of incineration of doom	0		Experience (Muscle): +1, Hot Spell Damage: +50, Spooky Spell Damage: +50, Last Available: "2014-10"
-7787	greedy cuddly teddy bear	0		Meat Drop: +20, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	greedy cuddly teddy bear	0		Meat Drop: +20, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	red ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	sizzling Jack Frost's first-aid pouch	0		Cold Spell Damage: +50, Hot Damage: +10, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7683,9 +7683,9 @@
 7794	red Armory keycard	0		Last Available: "2014-10"
 7795	decent initiative shawarma	3	good	Last Available: "2014-10"
 7796	delicious warm war shawarma	4	awesome	Last Available: "2014-10"
-7797	flavorless super-sized huge karma shawarma	5	decent	Last Available: "2014-10"
+7797	super-sized flavorless huge karma shawarma	5	decent	Last Available: "2014-10"
 7798	high-proof mediocre huge Jungle Juice	10	decent	Last Available: "2014-10"
-7799	practically non-alcoholic drinkable Amnesiac Ale	1	good	Last Available: "2014-10"
+7799	drinkable practically non-alcoholic Amnesiac Ale	1	good	Last Available: "2014-10"
 7800	high-proof acceptable shaking Highest Bitter	8	good	Last Available: "2014-10"
 7801	shaking gravedigger's nippy mercenary pistol	0		Cold Damage: +10, Spooky Damage: +10, Last Available: "2014-10"
 7802	ruddy mercenary rifle of the glutton	0		Maximum HP Percent: +40, Food Drop: +100, Last Available: "2014-10"
@@ -7699,8 +7699,8 @@
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	small decent seared dino steak	2	good	
-7814	watered-down drinkable ghostly bottle of drinkin' gas	2	good	
+7813	decent small seared dino steak	2	good	
+7814	drinkable watered-down ghostly bottle of drinkin' gas	2	good	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7718,7 +7718,7 @@
 7829	hardy Socratic brainy trench lighter	0		Mysticality: +5, Experience (Mysticality): +1, Maximum HP: +50, Last Available: "2014-10"
 7830	concentrated experimental serum P-00	0		Effect: "The Q Is Talking To You", Effect Duration: 21, Last Available: "2014-10"
 7831	blue military-grade fingernail clippers	0		Last Available: "2014-10"
-7832	shaking maroon encrypted micro-cassette recorder	0		Last Available: "2014-10"
+7832	maroon shaking encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	green gore bucket	0		Last Available: "2014-10"
 7834	pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
@@ -7727,14 +7727,14 @@
 7838	fuchsia Agent Mauve	0		Last Available: "2014-10"
 7839	special clip: tracers	0		Last Available: "2014-10"
 7840	twirling special clip: wailers	0		Last Available: "2014-10"
-7841	wobbly bouncing jittery special clip: squelchers	0		Last Available: "2014-10"
+7841	bouncing wobbly jittery special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	skewed special clip: graveburpers	0		Last Available: "2014-10"
 7845	vacuum-sealed perl necklace	0		Effect: "Stemonitis Storm", Effect Duration: 48, Last Available: "2014-12"
 7846	deionized extra-polymerized polarized blurry Fudge Fiber Armor Plating	0		Effect: "Punchy, Murdery", Effect Duration: 41, Last Available: "2014-12"
 7847	oxidized ruby on canes	0		Effect: "Educated (Kinda)", Effect Duration: 49, Last Available: "2014-12"
-7848	stale half-sized petit fortran	2	decent	Last Available: "2014-12"
+7848	half-sized stale petit fortran	2	decent	Last Available: "2014-12"
 7849	flavorless java cookie	4	decent	Last Available: "2014-12"
 7850	spoiled jumbo cookie cookie	5	crappy	Last Available: "2014-12"
 7851	strapping plastic exo-suited miner	0		Muscle: +5, Last Available: "2014-12"
@@ -7742,9 +7742,9 @@
 7853	narrow gray flame-wreathed plastic ambulatory robo-minecart	0		Hot Spell Damage: +10, Last Available: "2014-12"
 7854	plastic Crimbot of the sewer	0		Stench Damage: +25, Last Available: "2014-12"
 7855	ghostly spinning plastic Crimbomega of doom	0		Spooky Spell Damage: +50, Last Available: "2014-12"
-7856	ionized cyan skewed flask of mining oil	0		Effect: "Thicker, Sicker", Effect Duration: 47, Last Available: "2014-12"
-7857	avaricious radiation-resistant helmet	0		Meat Drop: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	sizzling servo-assisted exo-pants	0		Hot Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7856	ionized skewed cyan flask of mining oil	0		Effect: "Thicker, Sicker", Effect Duration: 47, Last Available: "2014-12"
+7857	avaricious radiation-resistant helmet	0		Meat Drop: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	sizzling servo-assisted exo-pants	0		Hot Damage: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	foul-smelling dangerous high-energy mining laser	0		Weapon Damage: +10, Stench Damage: +10, Last Available: "2014-12"
 7860	jittery peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7828,7 +7828,7 @@
 7946	jittery blinking studded boxer's outlaw bandana of courage	0		Muscle Percent: +10, Damage Absorption: +80, Spooky Resistance: +3
 7947	perfectly mixed jittery whiskey in a broken glass	3	EPIC	
 7948	bad irresponsibly strong shot of mescal	6	decent	
-7949	practically non-alcoholic mediocre glass of herbal tequila	1	decent	
+7949	mediocre practically non-alcoholic glass of herbal tequila	1	decent	
 7950	minin' dynamite	0		
 7951	lard-coated supercharged plaid cowboy hat	0		Maximum MP Percent: +30, Sleaze Spell Damage: +25, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lime green lasso	0		
@@ -7841,7 +7841,7 @@
 7959	letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	supercharged wholesome Staff of Ed of the bloodbag of Gandalf	0		Maximum HP Percent: +10, Maximum HP: +100, Maximum MP Percent: +30, Spell Critical Percent: +20
-7962	huge blurry Eye of Ed	0		
+7962	blurry huge Eye of Ed	0		
 7963	amulet	0		
 7964	gray Newton's Staff of Fats	0		Experience (Mysticality): +3
 7965	Holy MacGuffin	0		
@@ -7856,7 +7856,7 @@
 7974	dehydrated upside-down cyan mummified beef haunch	1	good	Effect: "In the Slimelight", Effect Duration: 10
 7975	twirling linen bandages	0		
 7976	cotton bandages	0		
-7977	wobbly lime green silk bandages	0		
+7977	lime green wobbly silk bandages	0		
 7978	holy spring water	0		
 7979	fuchsia spirit beer	0		
 7980	sacramental wine	0		
@@ -7881,37 +7881,37 @@
 7999	dry spinning choco-Crimbot	0		Effect: "The Smeezingtons", Effect Duration: 12, Last Available: "2014-12"
 8000	electrified smart watch	0		Effect: "Intimidating Mien", Effect Duration: 26, Last Available: "2014-12"
 8001	extra-liquefied augmented-reality shades	0		Effect: "Alpine Mintiness", Effect Duration: 44, Last Available: "2014-12"
-8002	toy Crimbot mega face of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	jittery crafty toy Crimbot power glove	0		Maximum MP: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	toy Crimbot super fist of Calamity Jane	0		Critical Hit Percent: +15, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of extreme caution	0		Monster Level: -25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	toy Crimbot mega face of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	jittery crafty toy Crimbot power glove	0		Maximum MP: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	toy Crimbot super fist of Calamity Jane	0		Critical Hit Percent: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of extreme caution	0		Monster Level: -25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	quantum super-flattened dry purple Crimbot battery	0		Effect: "Gingerbread Robust", Effect Duration: 53, Last Available: "2014-12"
 8007	skewed Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	lime green Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	green Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	zippy scandalous shellacked Crimbomega drive chain	0		Damage Reduction: 7, Sleaze Damage: +5, Initiative: +20, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	zippy scandalous shellacked Crimbomega drive chain	0		Damage Reduction: 7, Sleaze Damage: +5, Initiative: +20, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	tumbling Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
-8014	jittery yellow jittery Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
+8014	jittery jittery yellow Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	blinking Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	electrified irradiated fitness wristband	0		Effect: "Spookyravin'", Effect Duration: 64, Last Available: "2014-12"
 8017	chilled oxidized flask of tainted mining oil	0		Effect: "Inner Warmth", Effect Duration: 49, Last Available: "2014-12"
 8018	enhanced dry polarized and rain stick	0		Effect: "Oriental Mysticism", Effect Duration: 41
 8019	lime green Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	adequate Choco-Mint patty	3	good	Last Available: "2015-01"
-8021	triple-distilled acceptable special upside-down hot mint schnocolate	8	good	Effect: "Libra Rising", Effect Duration: 25, Last Available: "2015-01"
-8022	distilled cyan squat homeopathic mint tea	1	decent	Last Available: "2015-01"
+8021	acceptable special triple-distilled upside-down hot mint schnocolate	8	good	Effect: "Libra Rising", Effect Duration: 25, Last Available: "2015-01"
+8022	distilled squat cyan homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
-8026	upside-down jittery ceiling fan	0		Last Available: "2015-01"
+8026	jittery upside-down ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
 8028	blue artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	blurry stationery set	0		Last Available: "2015-01"
-8032	yellow blinking calligraphy pen	0		Free Pull, Last Available: "2015-01"
+8032	blinking yellow calligraphy pen	0		Free Pull, Last Available: "2015-01"
 8033	blurry alpine watercolor set	0		Last Available: "2015-01"
 8034	squat tope&eacute; of the businessman	0		Item Drop: +5, Meat Drop: +50, Familiar Effect: "3xBarrr, cap 12"
 8035	mirror reassuring topiary tights of the bloodbag	0		Maximum HP: +100, Spooky Resistance: +1
@@ -7948,13 +7948,13 @@
 8067	nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
-8070	ghostly gray shaking blinking warehouse map page	0		
+8070	shaking ghostly gray blinking warehouse map page	0		
 8071	lime green warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	Annie Oakley's Fonzie's Spelunker's fedora of the blizzard	0		Experience (Moxie): +1, Critical Hit Percent: +20, Cold Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	Annie Oakley's Fonzie's Spelunker's fedora of the blizzard	0		Experience (Moxie): +1, Critical Hit Percent: +20, Cold Spell Damage: +25, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	sharpshooter's Spelunker's whip of Gandalf of incineration	0		Critical Hit Percent: +10, Spell Critical Percent: +20, Hot Spell Damage: +50, Last Available: "2015-12"
-8076	upside-down Lo Pan's dance instructor's Spelunker's khakis of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Spell Critical Percent: +30, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	upside-down Lo Pan's dance instructor's Spelunker's khakis of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Spell Critical Percent: +30, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7977,7 +7977,7 @@
 8102	bouncing jittery hardy brooch of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100, Single Equip, Last Available: "2016-12"
 8103	mirror perfumed curative breeches	0		Stench Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-12"
 8104	wobbly savvy backpack of extreme caution	0		Mysticality Percent: +20, Monster Level: -25, Last Available: "2016-12"
-8105	twisted blue spinning bits	1		Effect: "Amorous", Effect Duration: 40, Last Available: "2016-12"
+8105	twisted spinning blue bits	1		Effect: "Amorous", Effect Duration: 40, Last Available: "2016-12"
 8106	skewed clever therapeutic anvil	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2017-12"
 8107	stanky Oprah's akubra	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Last Available: "2017-12"
 8108	family-friendly apron	0		Sleaze Resistance: +1, Item Drop: +5, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	quilted garland of wisdom	0		Mysticality: +15, Damage Absorption: +40, Single Equip, Last Available: "2018-12"
 8122	executive smartaleck's gunnysack	0		Moxie Percent: +30, Meat Drop: +40, Last Available: "2018-12"
 8123	zippy garibaldi of wisdom	0		Mysticality: +15, Initiative: +20, Last Available: "2018-12"
-8124	chaotic girdle of doom	0		Spell Critical Percent: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	chaotic girdle of doom	0		Spell Critical Percent: +10, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	gloves of Tarzan of Calamity Jane	0		Experience (Muscle): +3, Critical Hit Percent: +15, Single Equip, Last Available: "2018-12"
 8126	vaporized jittery smithereens	1		Last Available: "2018-12"
 8127	green occult fiberglass fetish of wisdom	0		Mysticality: +15, Spell Damage Percent: +25, Last Available: "2018-12"
@@ -8008,7 +8008,7 @@
 8133	compressed fiberglass fibers	1		Last Available: "2018-12"
 8134	blinking bottle of lovebug pheromones	0		Free Pull
 8135	purple winged yeti fur	0		
-8136	blue shaking talisman of Renenutet	0		
+8136	shaking blue talisman of Renenutet	0		
 8138	rubber spatula of wisdom	0		Mysticality: +15
 8139	family-friendly spoon	0		Sleaze Resistance: +1
 8140	lard-coated crystalline reamer	0		Sleaze Spell Damage: +25
@@ -8045,7 +8045,7 @@
 8171	mediocre unflavored wine cooler	3	decent	
 8172	carton of snake milk	1	decent	
 8173	sizzling sewer snake	0		Hot Damage: +10
-8174	huge spoiled fancy mirror pigeon egg	9	crappy	Effect: "Hypercubed", Effect Duration: 30
+8174	huge fancy spoiled mirror pigeon egg	9	crappy	Effect: "Hypercubed", Effect Duration: 30
 8175	wobbly lard-coated jaunty feather of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +25
 8176	drinkable premium malt liquor	3	good	
 8177	padded baleful brown paper pants	0		Spell Damage: +25, Damage Absorption: +20
@@ -8056,17 +8056,17 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	mirror hale bread basket	0		Maximum HP: +20
 8184	Ed the Undying exhibit crate	0		
-8185	twirling foul-smelling slick The Crown of Ed the Undying	0		Moxie: +10, Stench Damage: +10, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	twirling foul-smelling slick The Crown of Ed the Undying	0		Moxie: +10, Stench Damage: +10, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	delicious irresponsibly strong Cherrytastrophe wine cooler	10	awesome	
-8189	special perfectly mixed practically non-alcoholic skewed Radberry Rip wine cooler	1	EPIC	Effect: "Uncanny Shot", Effect Duration: 20
-8190	artisanal fortified Orangemageddon wine cooler	5	EPIC	
+8189	practically non-alcoholic special perfectly mixed skewed Radberry Rip wine cooler	1	EPIC	Effect: "Uncanny Shot", Effect Duration: 20
+8190	fortified artisanal Orangemageddon wine cooler	5	EPIC	
 8191	artisanal Breakfast Blast wine cooler	4	EPIC	
-8192	practically non-alcoholic lousy yellow Citrus Crush wine cooler	1	decent	
+8192	lousy practically non-alcoholic yellow Citrus Crush wine cooler	1	decent	
 8193	decent plain bagel	4	good	
-8194	rotten special huge glob of cream cheese	4	crappy	Effect: "Little Mouse Skull Buddy", Effect Duration: 45
-8195	fancy rotten bouncing wobbly loaf of soda bread	3	crappy	Effect: "Angry like the Wolf", Effect Duration: 30
+8194	special rotten huge glob of cream cheese	4	crappy	Effect: "Little Mouse Skull Buddy", Effect Duration: 45
+8195	fancy rotten wobbly bouncing loaf of soda bread	3	crappy	Effect: "Angry like the Wolf", Effect Duration: 30
 8196	moldy acceptable bagel	4	crappy	
 8197	adequate standard-issue cupcake	4	good	
 8198	gigantic bland upside-down ultra-deluxe cupcake	7	decent	
@@ -8086,13 +8086,13 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	smelly rigging rope of the detective	0		Stench Spell Damage: +10, Item Drop: +20, Last Available: "2015-04"
 8214	boiled twirling nasty snuff	1	EPIC	Last Available: "2015-04"
-8215	narrow Lo Pan's shellacked sewage-clogged pistol	0		Damage Reduction: 7, Spell Critical Percent: +30, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
-8216	ionized pressed cold-filtered pulsating tumbling beard incense	0		Effect: "Haunted Stomach", Effect Duration: 28, Last Available: "2015-04"
+8215	narrow Lo Pan's shellacked sewage-clogged pistol	0		Damage Reduction: 7, Spell Critical Percent: +30, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8216	ionized pressed cold-filtered tumbling pulsating beard incense	0		Effect: "Haunted Stomach", Effect Duration: 28, Last Available: "2015-04"
 8217	red ghostly Tesla curative perfume-soaked bandana	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	adequate toxo	3	good	Last Available: "2015-04"
-8220	perfectly mixed skewed upside-down Lemonade-235	3	EPIC	Last Available: "2015-04"
-8221	scorching beefy isotophat	0		Muscle: +10, Hot Damage: +25, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	perfectly mixed upside-down skewed Lemonade-235	3	EPIC	Last Available: "2015-04"
+8221	scorching beefy isotophat	0		Muscle: +10, Hot Damage: +25, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	skewed wicked dangerous Three Mile Island shorts	0		Weapon Damage: +10, Spell Damage: +5, Last Available: "2015-04"
 8223	lime green supercharged toxic mop of James Dean	0		Experience (Moxie): +3, Maximum MP Percent: +30, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8112,14 +8112,14 @@
 8238	wobbly brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
 8240	keycard &beta;	0		Last Available: "2015-04"
-8241	yellow ghostly keycard &gamma;	0		Last Available: "2015-04"
+8241	ghostly yellow keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
 8243	narrow complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	narrow gravedigger's lube-shoes	0		Spooky Damage: +10, Last Available: "2015-04"
 8245	teal trash net	0		Last Available: "2015-04"
 8246	Annie Oakley's supercharged wicked Dinsey mascot mask	0		Spell Damage: +5, Maximum MP Percent: +30, Critical Hit Percent: +20, Last Available: "2015-04"
 8247	spoiled Dinsey food-cone	4	crappy	Last Available: "2015-04"
-8248	perfectly mixed weak Dinsey Whinskey	2	EPIC	Last Available: "2015-04"
+8248	weak perfectly mixed Dinsey Whinskey	2	EPIC	Last Available: "2015-04"
 8249	quantum deionized gray Dinsey face paint	0		Effect: "Inner Warmth", Effect Duration: 34, Last Available: "2015-04"
 8250	hale fannypack of James Dean	0		Experience (Moxie): +3, Maximum HP: +20, Last Available: "2015-04"
 8251	blinking lion tamer's veiny stiffened extremely unsafe garbage sticker of the ox of dire peril	0		Muscle: +20, Weapon Damage: +20, Weapon Damage Percent: +100, Damage Reduction: 1, Maximum HP: +10, Experience (familiar): +2, Last Available: "2015-04"
@@ -8142,7 +8142,7 @@
 8268	skewed tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	moldy unappetizing mayolus	3	crappy	Last Available: "2015-05"
-8271	delicious miniature uninteresting mayolus	2	awesome	Last Available: "2015-05"
+8271	miniature delicious uninteresting mayolus	2	awesome	Last Available: "2015-05"
 8272	thick spoiled acceptable mayolus	5	crappy	Last Available: "2015-05"
 8273	toothsome enticing mayolus	3	awesome	Last Available: "2015-05"
 8274	decent wobbly mouth-watering mayolus	3	good	Last Available: "2015-05"
@@ -8169,19 +8169,19 @@
 8295	energetic dice sunglasses	0		Maximum MP Percent: +20, Single Equip
 8296	Thwaitgold caterpillar statuette	0		
 8297	enhanced dice	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 32
-8298	skewed blue jittery pixel	0		Last Available: "2015-06"
+8298	blue jittery skewed pixel	0		Last Available: "2015-06"
 8299	spinning pixel coin	0		Last Available: "2015-06"
-8300	triple-energized upside-down huge ghostly power pill	0		Effect: "Work For Hours a Week", Effect Duration: 13, Last Available: "2015-06"
+8300	triple-energized huge upside-down ghostly power pill	0		Effect: "Work For Hours a Week", Effect Duration: 13, Last Available: "2015-06"
 8301	dry bouncing pixel star	0		Effect: "Crimbo Flavor", Effect Duration: 66, Last Available: "2015-06"
 8302	adequate pixel banana	3	good	Last Available: "2015-06"
 8303	mediocre blurry pixel beer	4	decent	Last Available: "2015-06"
-8304	mirror fuchsia puck with a bow on it	0		Free Pull, Last Available: "2015-06"
+8304	fuchsia mirror puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	mirror narrow pumps	0		Last Available: "2015-06"
 8306	alkaline sludgesicle	0		Effect: "For Your Brain Only", Effect Duration: 52
 8307	extra-frozen shaking &Uuml;berraschthexengebr&auml;u	0		Effect: "Flambé-a-thon", Effect Duration: 68
 8308	oxidized ghostly piggy tattoo	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 63
 8309	nitrogenated denatured teal baggie of regular-sized tardigrades	0		Effect: "Berry Critical", Effect Duration: 27
-8310	double-activated blurry blue skewed .epub file	0		Effect: "Beastly Flavor", Effect Duration: 33
+8310	double-activated blue blurry skewed .epub file	0		Effect: "Beastly Flavor", Effect Duration: 33
 8311	flattened BUBBLE GUM	0		Effect: "Broberry Brotality", Effect Duration: 45
 8312	super-diffused spinning hustler shades	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 59
 8313	nitrogenated electrified jerky stick	0		Effect: "Drunk With Power", Effect Duration: 52
@@ -8221,7 +8221,7 @@
 8347	irradiated galvanized moist huge spray chrome	0		Effect: "Locks Like the Raven", Effect Duration: 50
 8348	irradiated squat filthy monkey head	0		Effect: "Badger Underfoot", Effect Duration: 56
 8349	wet dry magnetized pulsating hand of cards	0		Effect: "Crotchety, Pining", Effect Duration: 61
-8350	diffused triple-boiled lime green bouncing damp bar rag	0		Effect: "Altered Wavelengths", Effect Duration: 49
+8350	diffused triple-boiled bouncing lime green damp bar rag	0		Effect: "Altered Wavelengths", Effect Duration: 49
 8351	altered wobbly lump of goofball ore	0		Effect: "Spring Training", Effect Duration: 44
 8352	activated diffused diffused skewed skeleton beans	0		Effect: "Unusual Fashion Sense", Effect Duration: 68
 8353	polarized spinning grimy lab coat	0		Effect: "Triangle, Man", Effect Duration: 45
@@ -8248,7 +8248,7 @@
 8374	frozen bouncing drinks tray	0		Effect: "Greasy Peasy", Effect Duration: 36
 8375	unsweetened dry pulsating eyebrow lifter	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 46
 8376	submarine	0		Last Available: "2015-06"
-8377	moldy small pixel lemon	2	crappy	Last Available: "2015-06"
+8377	small moldy pixel lemon	2	crappy	Last Available: "2015-06"
 8378	artisanal weak pixel daiquiri	2	EPIC	Last Available: "2015-06"
 8379	vacuum-sealed extra-vacuum-sealed twirling power pill	0		Effect: "Ghostly Shell", Effect Duration: 25, Last Available: "2015-06"
 8380	ionized energized purple pixel potion	0		Effect: "Arse-a'fire", Effect Duration: 61, Last Available: "2015-06"
@@ -8265,7 +8265,7 @@
 8391	mana	0		Last Available: "2015-07"
 8392	twirling gift card	0		Last Available: "2015-07"
 8393	squat hermit factoid	0		Last Available: "2015-07"
-8394	spinning jittery The Emperor's dry cleaning	0		Last Available: "2015-07"
+8394	jittery spinning The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	cool The Emperor's new hat	0		Moxie: +5, Last Available: "2015-07"
 8396	jittery flame-retardant The Emperor's new shirt	0		Hot Resistance: +1, Last Available: "2015-07"
 8397	The Emperor's new pants of the early riser	0		Adventures: +7, Last Available: "2015-07"
@@ -8281,7 +8281,7 @@
 8407	stale squat pestopiary	4	decent	
 8408	deionized quadruple-nitrogenated ectoplasmic orbs	0		Effect: "You're Not Cooking", Effect Duration: 23
 8409	rotten thick crudles	5	crappy	
-8410	rotten snack-sized fancy agnolotti arboli	2	crappy	Effect: "Salamander In Your Stomach", Effect Duration: 25
+8410	fancy rotten snack-sized agnolotti arboli	2	crappy	Effect: "Salamander In Your Stomach", Effect Duration: 25
 8411	decent spaghetti with ghost balls	3	good	
 8412	jumbo adequate succulent marrow	5	good	
 8413	small spoiled salacious crumbs	2	crappy	
@@ -8301,9 +8301,9 @@
 8427	fizzing spore pod	0		
 8428	spore pod	0		
 8429	lime green blurry veiny spore pod	0		
-8430	tumbling upside-down hard spore pod	0		
+8430	upside-down tumbling hard spore pod	0		
 8431	spore pod	0		
-8432	squat teal hot spore pod	0		
+8432	teal squat hot spore pod	0		
 8433	lime green cool spore pod	0		
 8434	jingling spore pod	0		
 8435	huge pulsating brainy LavaCo Lamp&trade; of the pedagogue	0		Mysticality: +5, Experience: +3, Last Available: "2015-08"
@@ -8329,14 +8329,14 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	high-temperature mining mask of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	high-temperature mining mask of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	beefcake's fireproof megaphone of terror	0		Muscle: +25, Spooky Spell Damage: +10, Last Available: "2015-08"
 8460	decent huge mineapple	6	good	Last Available: "2015-08"
 8461	artisanal Gold Velvet&trade; whiskey	4	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	crappy	Last Available: "2015-08"
 8463	stale smelted roe	3	decent	Last Available: "2015-08"
 8464	delicious triple-distilled wobbly lavawater	7	awesome	Last Available: "2015-08"
-8465	non-aerosolized activated blurry mirror narrow basaltamander tongue	0		Effect: "Rage of the Reindeer", Effect Duration: 24, Last Available: "2015-08"
+8465	non-aerosolized activated narrow blurry mirror basaltamander tongue	0		Effect: "Rage of the Reindeer", Effect Duration: 24, Last Available: "2015-08"
 8466	wobbly Usain Bolt's lard-coated MacGyver's lavalarva	0		Maximum MP: +100, Sleaze Spell Damage: +25, Initiative: +80, Last Available: "2015-08"
 8467	double-paned fortified stylish lava balaclava	0		Moxie: +25, Damage Absorption: +60, Cold Resistance: +5, Last Available: "2015-08"
 8468	curative Da Vinci's Samson's basaltamander buckler	0		Experience (Muscle): +5, Experience (Mysticality): +5, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 15, Last Available: "2015-08"
@@ -8345,14 +8345,14 @@
 8471	fireproof groovy lava-proof pants	0		Moxie Percent: +10, Hot Resistance: +3, Last Available: "2015-08"
 8472	spinning blinking Temple Grandin's heat-resistant necktie of the wise owl	0		Mysticality: +20, Familiar Weight: +7, Single Equip, Last Available: "2015-08"
 8473	red Temple Grandin's manspreader's dance instructor's heat-resistant gloves	0		Experience Percent (Moxie): +10, Monster Level: +10, Familiar Weight: +7, Single Equip, Last Available: "2015-08"
-8474	toothsome massive very hot lunch	7	awesome	Last Available: "2015-08"
-8475	distilled tolerable asbestos thermos	5	good	Last Available: "2015-08"
+8474	massive toothsome very hot lunch	7	awesome	Last Available: "2015-08"
+8475	tolerable distilled asbestos thermos	5	good	Last Available: "2015-08"
 8476	activated activated electrified liquid rhinestones	0		Effect: "Witch Breaded", Effect Duration: 43, Last Available: "2015-08"
 8477	tasty disco biscuit	3	awesome	Last Available: "2015-08"
 8478	lousy Quaatorade&trade;	3	decent	Last Available: "2015-08"
-8479	jittery reassuring chilly medical-grade biker's hat	0		Cold Damage: +5, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk", Last Available: "2015-08"
-8480	fireproof Jack Frost's feathered headdress of Flo-Jo	0		Cold Spell Damage: +50, Hot Resistance: +3, Initiative: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	mirror rosewater-soaked wool dangerous electrician's hardhat	0		Weapon Damage: +10, Cold Resistance: +1, Stench Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8479	jittery reassuring chilly medical-grade biker's hat	0		Cold Damage: +5, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk"
+8480	fireproof Jack Frost's feathered headdress of Flo-Jo	0		Cold Spell Damage: +50, Hot Resistance: +3, Initiative: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	mirror rosewater-soaked wool dangerous electrician's hardhat	0		Weapon Damage: +10, Cold Resistance: +1, Stench Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
 8482	bouncing Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	fuchsia Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	narrow The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,21 +8361,21 @@
 8487	narrow airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	spinning red Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	spinning New Age hurting crystal	0		Last Available: "2015-08"
-8490	smooth velvet pants of dire peril	0		Weapon Damage: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	smooth velvet pants of dire peril	0		Weapon Damage: +20, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	smooth velvet shirt of the empath	0		Familiar Weight: +5, Last Available: "2015-08"
 8492	experienced smooth velvet hat	0		Experience: +2, Last Available: "2015-08"
 8493	grievous smooth velvet pocket square	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2015-08"
 8494	ghostly educational smooth velvet socks	0		Experience: +1, Single Equip, Last Available: "2015-08"
 8495	educational smooth velvet hanky	0		Experience: +1, Single Equip, Last Available: "2015-08"
 8496	upside-down coward's The One Mood Ring of James Dean	0		Experience (Moxie): +3, Monster Level: -20, Single Equip, Last Available: "2015-08"
-8497	jittery gray Mr. Choch's bone	0		Last Available: "2015-08"
+8497	gray jittery Mr. Choch's bone	0		Last Available: "2015-08"
 8498	upside-down Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	Saturday Night thermometer	0		Last Available: "2015-08"
 8500	the tongue of Smimmons	0		Last Available: "2015-08"
 8501	Raul's guitar pick	0		Last Available: "2015-08"
 8502	jittery Pener's crisps	0		Last Available: "2015-08"
 8503	mirror signed deuce	0		Last Available: "2015-08"
-8504	ghostly shaking ghostly Lavalos core	0		Last Available: "2015-08"
+8504	shaking ghostly ghostly Lavalos core	0		Last Available: "2015-08"
 8505	mirror half-melted hula girl	0		Last Available: "2015-08"
 8506	maroon glass ceiling fragments	0		Last Available: "2015-08"
 8507	modified SMOOCH coffee cup	1	awesome	Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	bouncing auspicious manspreader's SMOOCH bracers	0		Monster Level: +10, Item Drop: +10, Single Equip, Last Available: "2015-08"
 8518	cyan SMOOCH kneepads of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8519	ruddy SMOOCH spaulders	0		Maximum HP Percent: +40, Single Equip, Last Available: "2015-08"
-8520	shellacked SMOOCH codpiece of temperance	0		Damage Reduction: 7, Sleaze Resistance: +5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	shellacked SMOOCH codpiece of temperance	0		Damage Reduction: 7, Sleaze Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	experienced SMOOCH breastplate	0		Experience: +2, Last Available: "2015-08"
 8522	bouncing superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8413,7 +8413,7 @@
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	toothsome spinning Fettris	3	awesome	
-8543	rotten tiny fusillocybin	1	crappy	
+8543	tiny rotten fusillocybin	1	crappy	
 8544	gigantic adequate pulsating prescription noodles	9	good	
 8545	twisted blood-drive sticker	1	decent	Effect: "Deeply Ironic", Effect Duration: 50
 8546	tarnished lime green bag of grain	0		Effect: "The Power of Positive Thinking", Effect Duration: 13
@@ -8428,7 +8428,7 @@
 8555	blurry a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	concentrated electrified narrow mirror Wickers bar	0		Effect: "Fungal Flambé", Effect Duration: 19
+8558	concentrated electrified mirror narrow Wickers bar	0		Effect: "Fungal Flambé", Effect Duration: 19
 8559	electrified concentrated bakelite-covered bacon	0		Effect: "Raging Animal", Effect Duration: 65
 8560	irradiated chilled Aerheads	0		Effect: "Hobonic", Effect Duration: 29
 8561	dry Wrotz	0		Effect: "Butt-Rock Hair", Effect Duration: 69
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	barrel lid of the brute of terror of the boozehound	0		Muscle Percent: +30, Spooky Spell Damage: +10, Booze Drop: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	wobbly ruddy studded barrel hoop earring of James Dean	0		Experience (Moxie): +3, Damage Absorption: +80, Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2015-09"
-8567	fuchsia smelly friendly bankruptcy barrel of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +3, Stench Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	fuchsia smelly friendly bankruptcy barrel of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +3, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	pulsating tun	0		Last Available: "2015-09"
@@ -8448,7 +8448,7 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	artisanal jittery fuchsia bottle of Amontillado	3	EPIC	Last Available: "2015-09"
+8578	artisanal fuchsia jittery bottle of Amontillado	3	EPIC	Last Available: "2015-09"
 8579	tolerable barrel-aged martini	3	good	Last Available: "2015-09"
 8580	yummy barrel pickle	3	awesome	Last Available: "2015-09"
 8581	gigantic stale barrel cracker	6	decent	Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	blue stanky barrel gun	0		Stench Spell Damage: +25, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	huge rotten cyan blurry water log	8	crappy	Last Available: "2015-09"
+8589	rotten huge cyan blurry water log	8	crappy	Last Available: "2015-09"
 8590	aromatic barrelhead of the businessman	0		Stench Resistance: +1, Meat Drop: +50, Last Available: "2015-09"
 8591	manspreader's dance instructor's bottoms of the barrel	0		Experience Percent (Moxie): +10, Monster Level: +10, Last Available: "2015-09"
 8592	spinning hardy ruddy chest barrel	0		Maximum HP Percent: +40, Maximum HP: +50, Last Available: "2015-09"
@@ -8479,10 +8479,10 @@
 8606	oxidized dry pulsating spinning cuppa Frost tea	0		Effect: "Surreally Buff", Effect Duration: 30, Last Available: "2015-09"
 8607	energized altered cuppa Toast tea	0		Effect: "Some Cheese with Your Wine", Effect Duration: 67, Last Available: "2015-09"
 8608	magnetized cuppa Net tea	0		Effect: "Quiet 'n' Good", Effect Duration: 13, Last Available: "2015-09"
-8609	quadruple-quantum improved jittery spinning cuppa Proprie tea	0		Effect: "Stinking Cloud", Effect Duration: 52, Last Available: "2015-09"
+8609	quadruple-quantum improved spinning jittery cuppa Proprie tea	0		Effect: "Stinking Cloud", Effect Duration: 52, Last Available: "2015-09"
 8610	oxidized cuppa Morbidi tea	0		Effect: "The Power of Positive Thinking", Effect Duration: 22, Last Available: "2015-09"
-8611	modified colloidal warmed spinning blurry cuppa Chari tea	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2015-09"
-8612	quantum skewed huge cuppa Serendipi tea	0		Effect: "Human-Machine Hybrid", Effect Duration: 50, Last Available: "2015-09"
+8611	modified colloidal warmed blurry spinning cuppa Chari tea	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 68, Last Available: "2015-09"
+8612	quantum huge skewed cuppa Serendipi tea	0		Effect: "Human-Machine Hybrid", Effect Duration: 50, Last Available: "2015-09"
 8613	dry ionized modified yellow cuppa Feroci tea	0		Effect: "Human-Penguin Hybrid", Effect Duration: 16, Last Available: "2015-09"
 8614	polymerized quadruple-ionized tumbling cuppa Physicali tea	0		Effect: "Abyssal Blood", Effect Duration: 36, Last Available: "2015-09"
 8615	dry quantum upside-down cuppa Wit tea	0		Effect: "Far Out", Effect Duration: 12, Last Available: "2015-09"
@@ -8491,14 +8491,14 @@
 8618	ionized tumbling cuppa Flexibili tea	0		Effect: "Cold Blooded", Effect Duration: 60, Last Available: "2015-09"
 8619	triple-flattened cuppa Impregnabili tea	0		Effect: "Earthen Fist", Effect Duration: 65, Last Available: "2015-09"
 8620	Vulcanized nitrogenated cuppa Obscuri tea	0		Effect: "critical.enh", Effect Duration: 16, Last Available: "2015-09"
-8621	chilled energized altered olive ghostly pulsating cuppa Irritabili tea	0		Effect: "All Blued Up", Effect Duration: 45, Last Available: "2015-09"
+8621	chilled energized altered pulsating olive ghostly cuppa Irritabili tea	0		Effect: "All Blued Up", Effect Duration: 45, Last Available: "2015-09"
 8622	tarnished cuppa Mediocri tea	0		Effect: "Cold Blooded", Effect Duration: 53, Last Available: "2015-09"
 8623	activated quadruple-dry skewed cuppa Loyal tea	0		Effect: "Unusual Perspective", Effect Duration: 64, Last Available: "2015-09"
 8624	boiled green narrow cuppa Activi tea	1	good	Last Available: "2015-09"
 8625	pickled cuppa Cruel tea	1		Effect: "Sweet Tooth", Effect Duration: 20, Last Available: "2015-09"
-8626	quadruple-deionized mirror squat cuppa Alacri tea	0		Effect: "Wistfully Nostalgic", Effect Duration: 57, Last Available: "2015-09"
+8626	quadruple-deionized squat mirror cuppa Alacri tea	0		Effect: "Wistfully Nostalgic", Effect Duration: 57, Last Available: "2015-09"
 8627	polarized teal cuppa Vitali tea	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 26, Last Available: "2015-09"
-8628	quadruple-denatured super-polarized quadruple-irradiated blue jittery cuppa Mana tea	0		Effect: "This Is Where You're a Viking", Effect Duration: 29, Last Available: "2015-09"
+8628	quadruple-denatured super-polarized quadruple-irradiated jittery blue cuppa Mana tea	0		Effect: "This Is Where You're a Viking", Effect Duration: 29, Last Available: "2015-09"
 8629	moist extra-vacuum-sealed cuppa Monstrosi tea	0		Effect: "No Worries", Effect Duration: 24, Last Available: "2015-09"
 8630	diffused cuppa Twen tea	0		Effect: "Frozen Hands", Effect Duration: 61, Last Available: "2015-09"
 8631	oxidized cuppa Gill tea	0		Effect: "Full-Body Tan", Effect Duration: 50, Last Available: "2015-09"
@@ -8506,17 +8506,17 @@
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
-8636	improved gray mirror cuppa Craft tea	0		Effect: "New Zeal", Effect Duration: 27, Last Available: "2015-09"
+8636	improved mirror gray cuppa Craft tea	0		Effect: "New Zeal", Effect Duration: 27, Last Available: "2015-09"
 8637	activated liquefied blinking cuppa Insani tea	0		Effect: "Orc Chops", Effect Duration: 42, Last Available: "2015-09"
 8638	maroon censurious scandalous razor-sharp Royal scepter	0		Weapon Damage Percent: +25, Sleaze Damage: +5, Sleaze Resistance: +3, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	squat Ghost Dog Chow	0		Last Available: "2015-10"
-8641	enchanted super-sized spoiled bowl of eyeballs	5	crappy	Effect: "Space Cadet", Effect Duration: 10, Last Available: "2015-10"
+8641	super-sized spoiled enchanted bowl of eyeballs	5	crappy	Effect: "Space Cadet", Effect Duration: 10, Last Available: "2015-10"
 8642	spoiled upside-down bowl of mummy guts	4	crappy	Last Available: "2015-10"
 8643	bland pulsating bowl of maggots	3	decent	Last Available: "2015-10"
 8644	artisanal teal blood and blood	4	EPIC	Last Available: "2015-10"
 8645	mediocre Jack-O-Lantern beer	3	decent	Last Available: "2015-10"
-8646	acceptable fortified cyan zombie	5	good	Last Available: "2015-10"
+8646	fortified acceptable cyan zombie	5	good	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	spinning plastic nightmare troll	0		Last Available: "2015-10"
@@ -8547,7 +8547,7 @@
 8674	wobbly airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	wet shoulder-warming lotion	0		Effect: "Smokin'", Effect Duration: 60, Last Available: "2015-11"
-8677	special delicious iceberg lettuce	3	awesome	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2015-11"
+8677	delicious special iceberg lettuce	3	awesome	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2015-11"
 8678	mediocre ice wine	4	decent	Last Available: "2015-11"
 8679	blinking horrifying forbidden cool Wal-Mart snowglobe	0		Moxie: +5, Spell Damage Percent: +50, Spooky Damage: +25, Last Available: "2015-11"
 8680	steel-toed Wal-Mart nametag of the dark arts of the blizzard	0		Spell Damage Percent: +100, Damage Reduction: 9, Cold Spell Damage: +25, Last Available: "2015-11"
@@ -8558,20 +8558,20 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	skewed perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	Temple Grandin's bellhop's hat	0		Familiar Weight: +7, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	delicious weak ice porter	2	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	Temple Grandin's bellhop's hat	0		Familiar Weight: +7, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	delicious weak ice porter	2	awesome	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	electrified anodized tumbling exotic travel brochure	0		Effect: "Halloweeny", Effect Duration: 65, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	tarnished shampoo-conditioner	0		Effect: "Dreams and Lights", Effect Duration: 36, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
-8695	skewed tumbling Martialest Arts trophy	0		Last Available: "2016-01"
+8695	tumbling skewed Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered medicinal herbs	1		Last Available: "2016-01"
-8697	special adequate ice rice	4	good	Effect: "Arse-a'fire", Effect Duration: 20, Last Available: "2016-01"
+8697	adequate special ice rice	4	good	Effect: "Arse-a'fire", Effect Duration: 20, Last Available: "2016-01"
 8698	mediocre squat iced plum wine	4	decent	Last Available: "2016-01"
 8699	family-friendly groovy training belt of bravery	0		Moxie Percent: +10, Spooky Resistance: +5, Sleaze Resistance: +1, Single Equip, Last Available: "2016-01"
 8700	pulsating frosty medical-grade strapping training legwarmers	0		Muscle: +5, Cold Spell Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2016-01"
-8701	spinning gravedigger's brawny training helmet of the pedagogue	0		Muscle Percent: +20, Experience: +3, Spooky Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	spinning gravedigger's brawny training helmet of the pedagogue	0		Muscle Percent: +20, Experience: +3, Spooky Damage: +10, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	ghostly training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8585,34 +8585,34 @@
 8712	dried abstraction: category	1		Last Available: "2015-12"
 8713	diluted abstraction: perception	1		Last Available: "2015-12"
 8714	diluted abstraction: motion	1		Last Available: "2015-12"
-8715	pickled spinning fuchsia blurry abstraction: joy	1		Effect: "Squatting and Thrusting", Effect Duration: 45, Last Available: "2015-12"
+8715	pickled fuchsia spinning blurry abstraction: joy	1		Effect: "Squatting and Thrusting", Effect Duration: 45, Last Available: "2015-12"
 8716	compressed mirror abstraction: certainty	1		Effect: "Purity of Spirit", Effect Duration: 15, Last Available: "2015-12"
 8717	altered mirror abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	small adequate VYKEA meatballs	2	good	Last Available: "2015-11"
+8719	adequate small VYKEA meatballs	2	good	Last Available: "2015-11"
 8720	tolerable VYKEA mead	3	good	Last Available: "2015-11"
 8721	oxidized VYKEA woadpaint	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 31, Last Available: "2015-11"
-8722	blue upside-down VYKEA frenzy rune	0		Last Available: "2015-11"
+8722	upside-down blue VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	purple VYKEA blood rune	0		Last Available: "2015-11"
 8724	huge VYKEA lightning rune	0		Last Available: "2015-11"
 8725	fuchsia twirling VYKEA plank	0		Last Available: "2015-11"
 8726	blue VYKEA rail	0		Last Available: "2015-11"
-8727	jittery shaking red VYKEA bracket	0		Last Available: "2015-11"
+8727	red jittery shaking VYKEA bracket	0		Last Available: "2015-11"
 8728	wobbly VYKEA dowel	0		Last Available: "2015-11"
 8729	aromatic supercool VYKEA hex key of vim and vigor	0		Moxie Percent: +20, Maximum HP Percent: +50, Stench Resistance: +1, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	decent tin of submardines	3	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	decent tin of submardines	3	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	hand-crafted bottle of norwhiskey	4	EPIC	Last Available: "2015-11"
 8733	modified octolus oculus	1	awesome	Last Available: "2015-11"
 8734	mirror prompt lightning-fast scandalous sardine can key	0		Sleaze Damage: +5, Initiative: +40, Adventures: +3, Last Available: "2015-11"
-8735	tumbling green healthy norwhal helmet of the scaredy-cat of the boozehound	0		Maximum HP Percent: +20, Monster Level: -15, Booze Drop: +100, Familiar Effect: "atk", Last Available: "2015-11"
+8735	tumbling green healthy norwhal helmet of the scaredy-cat of the boozehound	0		Maximum HP Percent: +20, Monster Level: -15, Booze Drop: +100, Last Available: "2015-11", Familiar Effect: "atk"
 8736	jittery frosty clever healthy octolus-skin cloak	0		Maximum HP Percent: +20, Maximum MP: +20, Cold Spell Damage: +10, Last Available: "2015-11"
 8737	bad lime green bouncing perfect cosmopolitan	3	decent	Last Available: "2015-11"
-8738	tolerable weak blurry perfect negroni	2	good	Last Available: "2015-11"
+8738	weak tolerable blurry perfect negroni	2	good	Last Available: "2015-11"
 8739	bad perfect dark and stormy	3	decent	Last Available: "2015-11"
 8740	lousy triple-distilled perfect mimosa	6	decent	Last Available: "2015-11"
 8741	smooth irresponsibly strong perfect old-fashioned	7	awesome	Last Available: "2015-11"
-8742	acceptable special pulsating perfect paloma	3	good	Effect: "Craft Tea", Effect Duration: 15, Last Available: "2015-11"
+8742	special acceptable pulsating perfect paloma	3	good	Effect: "Craft Tea", Effect Duration: 15, Last Available: "2015-11"
 8743	enhanced deionized That 70s Cologne	0		Effect: "Super Vision", Effect Duration: 22, Last Available: "2015-11"
 8744	alkaline vacuum-sealed squat Wal-Mart &quot;diamond&quot; ring	0		Effect: "Yet tea", Effect Duration: 65, Last Available: "2015-11"
 8745	pressed upside-down Puffstone cigar	0		Effect: "Sludgesick", Effect Duration: 34, Last Available: "2015-11"
@@ -8623,8 +8623,8 @@
 8750	extra-boiled activated tumbling hemp candy necklace	0		Effect: "The Magic of Sharing", Effect Duration: 34, Last Available: "2015-12"
 8751	magnetized super-deionized communal gobstopper	0		Effect: "Texas Elegance", Effect Duration: 51, Last Available: "2015-12"
 8752	jumbo stale Crimbo salad	5	decent	Last Available: "2015-12"
-8753	adequate immense bread line	6	good	Last Available: "2015-12"
-8754	aged high-proof bark rootbeer	7	awesome	Last Available: "2015-12"
+8753	immense adequate bread line	6	good	Last Available: "2015-12"
+8754	high-proof aged bark rootbeer	7	awesome	Last Available: "2015-12"
 8755	weak tolerable skewed mirror ale	2	good	Last Available: "2015-12"
 8756	stiffened plastic Tammy the Tambourine Elf	0		Damage Reduction: 1, Last Available: "2015-12"
 8757	fireproof plastic Rudolph the Red	0		Hot Resistance: +3, Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	reindeer hammer of the brazier	0		Hot Spell Damage: +25, Last Available: "2015-12"
 8783	blinking upside-down stanky elf ploughshare	0		Stench Spell Damage: +25, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	mirror faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8689,14 +8689,14 @@
 8817	dehydrated olive Mansquito Serum	1		Last Available: "2016-12"
 8818	perfectly mixed mirror Miss Graves' vermouth	3	EPIC	Last Available: "2016-12"
 8819	toothsome The Plumber's mushroom stew	3	awesome	Last Available: "2016-12"
-8820	compressed jittery tumbling The Author's ink	1		Last Available: "2016-02"
+8820	compressed tumbling jittery The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed enchanted shaking The Mad Liquor	3	super EPIC	Effect: "Pasty", Effect Duration: 20, Last Available: "2016-12"
 8822	artisanal practically non-alcoholic Doc Clock's thyme cocktail	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 8823	rotten fancy Mr. Burnsger	3	crappy	Effect: "Sleazy Jellied", Effect Duration: 25, Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	veiny ruddy Rosewater's The Jokester's gun	0		Mysticality Percent: +30, Maximum HP Percent: +40, Maximum HP: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	resourceful curative sage The Jokester's wig	0		Mysticality Percent: +10, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	censurious Van der Graaf The Jokester's pants of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	veiny ruddy Rosewater's The Jokester's gun	0		Mysticality Percent: +30, Maximum HP Percent: +40, Maximum HP: +10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	resourceful curative sage The Jokester's wig	0		Mysticality Percent: +10, Maximum MP: +50, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	censurious Van der Graaf The Jokester's pants of the empath	0		Familiar Weight: +5, Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	alkaline pickled chilled Jokester makeup	0		Effect: "Flexibili Tea", Effect Duration: 67, Last Available: "2016-12"
 8829	tumbling green replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8704,13 +8704,13 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	tarnished boiled bouncing robin's egg	0		Effect: "Spookypants", Effect Duration: 56, Last Available: "2016-12"
 8834	adequate robin flan	3	good	Last Available: "2016-12"
-8835	watered-down acceptable robin nog	2	good	Last Available: "2016-12"
+8835	acceptable watered-down robin nog	2	good	Last Available: "2016-12"
 8836	fuchsia LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	jittery exploding gum	0		
 8839	bouncing root beer barrel	0		
 8840	polymerized Kudzu slaw	0		Effect: "Elemental Mastery", Effect Duration: 59
-8841	pickled triple-Vulcanized cyan spinning Mansquito's blood	0		Effect: "Wallflowering", Effect Duration: 20
+8841	pickled triple-Vulcanized spinning cyan Mansquito's blood	0		Effect: "Wallflowering", Effect Duration: 20
 8842	deionized electrified infrablack lipstick	0		Effect: "I See Everything Thrice!", Effect Duration: 38
 8843	polarized improved squat can of drain cleaner	0		Effect: "Work For Hours a Week", Effect Duration: 36
 8844	deionized purple The Author's inkwell	0		Effect: "This Is Where You're a Viking", Effect Duration: 59
@@ -8719,7 +8719,7 @@
 8847	chilled triple-ionized red-hot jawbreaker	0		Effect: "Patience of the Tortoise", Effect Duration: 19
 8848	flattened polymerized tarnished blurry question juice	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 19
 8849	non-ionized tube of villain	0		Effect: "Riboflavin'", Effect Duration: 34
-8850	teal narrow asbestos-lined your cowboy boots	0		Hot Resistance: +5, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	teal narrow asbestos-lined your cowboy boots	0		Hot Resistance: +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	bouncing nugget of quicksilver	0		Last Available: "2016-02"
 8853	maroon narrow nugget of thicksilver	0		Last Available: "2016-02"
@@ -8747,8 +8747,8 @@
 8875	red hardy Rosewater's Shrub's Premium Baked Beans of James Dean	0		Mysticality Percent: +30, Experience (Moxie): +3, Maximum HP: +50, Last Available: "2016-02"
 8876	stale plate of Heimz Fortified Kidney Beans	4	decent	Last Available: "2016-02"
 8877	normal plate of Tesla's Electroplated Beans	4	good	Last Available: "2016-02"
-8878	fancy massive moldy plate of Mixed Garbanzos and Chickpeas	10	crappy	Effect: "Chalk Outline", Effect Duration: 45, Last Available: "2016-02"
-8879	snack-sized spoiled plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
+8878	moldy massive fancy plate of Mixed Garbanzos and Chickpeas	10	crappy	Effect: "Chalk Outline", Effect Duration: 45, Last Available: "2016-02"
+8879	spoiled snack-sized plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
 8880	bland plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
 8881	small bland plate of World's Blackest-Eyed Peas	2	decent	Last Available: "2016-02"
 8882	rotten plate of Trader Olaf's Exotic Stinkbeans	3	crappy	Last Available: "2016-02"
@@ -8756,9 +8756,9 @@
 8884	decent plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
 8885	moldy plate of Shrub's Premium Baked Beans	4	crappy	Last Available: "2016-02"
 8886	squat auspicious careful Fancy Jeff's pocket square	0		Monster Level: -10, Item Drop: +10, Last Available: "2016-02"
-8887	scorching Samson's sage Daisy's unclean bloomers	0		Mysticality Percent: +10, Experience (Muscle): +5, Hot Damage: +25, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	scorching Samson's sage Daisy's unclean bloomers	0		Mysticality Percent: +10, Experience (Muscle): +5, Hot Damage: +25, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	coward's mansplainer's experienced Amoon-Ra Cowtep's nemes	0		Experience: +2, Monster Level: -5, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	coward's mansplainer's experienced Amoon-Ra Cowtep's nemes	0		Experience: +2, Monster Level: -5, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	olive rock-hard studded personal trainer's beefcake's Former Sheriff Dan's tin star of Flo-Jo	0		Muscle: +25, Experience Percent (Muscle): +10, Damage Absorption: +80, Damage Reduction: 5, Initiative: +100, Last Available: "2016-02"
 8892	upside-down El Vibrato restraints	0		Last Available: "2016-02"
@@ -8772,14 +8772,14 @@
 8900	gun parts	0		Last Available: "2016-02"
 8901	flattened twirling skewed triggerfingerbone	0		Effect: "Comic Violence", Effect Duration: 67, Last Available: "2016-02"
 8902	triple-oxidized tumbling ghost bit	0		Effect: "Sweet Tooth", Effect Duration: 54, Last Available: "2016-02"
-8903	pressed spinning huge buzzard feather	0		Effect: "New Zeal", Effect Duration: 37, Last Available: "2016-02"
+8903	pressed huge spinning buzzard feather	0		Effect: "New Zeal", Effect Duration: 37, Last Available: "2016-02"
 8904	cold-filtered lion musk	0		Effect: "Okee-Dokee Computer", Effect Duration: 33, Last Available: "2016-02"
 8905	moldy snack-sized bear claw	2	crappy	Last Available: "2016-02"
 8906	denatured oxidized jittery rattler gland	0		Effect: "Stands Alone", Effect Duration: 67, Last Available: "2016-02"
-8907	vacuum-sealed mirror maroon half-digested coal	0		Effect: "Initiative and Let Die", Effect Duration: 24, Last Available: "2016-02"
+8907	vacuum-sealed maroon mirror half-digested coal	0		Effect: "Initiative and Let Die", Effect Duration: 24, Last Available: "2016-02"
 8908	oxidized modified non-colloidal tightly-wound spine	0		Effect: "Pecan Pied Piper", Effect Duration: 35, Last Available: "2016-02"
-8909	decent miniature fuchsia rotting beefsteak	2	good	Last Available: "2016-02"
-8910	perfectly mixed fancy high-proof skewed firemilk	7	EPIC	Effect: "The Solution", Effect Duration: 40, Last Available: "2016-02"
+8909	miniature decent fuchsia rotting beefsteak	2	good	Last Available: "2016-02"
+8910	fancy perfectly mixed high-proof skewed firemilk	7	EPIC	Effect: "The Solution", Effect Duration: 40, Last Available: "2016-02"
 8911	wet modified spidercow eye-cluster	0		Effect: "Broken Bone Nubs", Effect Duration: 26, Last Available: "2016-02"
 8912	powdered blinking moomy dust	1		Last Available: "2016-02"
 8913	medical-grade Fonzie's western-style skinning knife	0		Experience (Moxie): +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-02"
@@ -8797,7 +8797,7 @@
 8925	disc (red)	0		
 8926	shaking disc (green)	0		
 8927	ghostly disc (blue)	0		
-8928	tumbling squat disc (yellow)	0		
+8928	squat tumbling disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	galvanized ionized demonic cow's blood	0		Effect: "Floundering", Effect Duration: 40, Last Available: "2016-02"
 8931	upside-down rinky-dink sixgun	0		Last Available: "2016-02"
@@ -8815,7 +8815,7 @@
 8943	shuddering cow skull	0		Last Available: "2016-02"
 8944	rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
-8946	squat wobbly jangly spurs	0		Last Available: "2016-02"
+8946	wobbly squat jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
@@ -8849,30 +8849,30 @@
 8977	adjusted dry patent invisibility tonic	0		Effect: "No Worries", Effect Duration: 60
 8978	galvanized denatured denatured patent aggression tonic	0		Effect: "Ocelot Eyes", Effect Duration: 69
 8979	moist liquefied patent sallowness tonic	0		Effect: "Booooooze", Effect Duration: 17
-8980	oxidized activated tumbling red ghostly upside-down patent avarice tonic	0		Effect: "Patent Prevention", Effect Duration: 62
+8980	oxidized activated upside-down tumbling red ghostly patent avarice tonic	0		Effect: "Patent Prevention", Effect Duration: 62
 8981	chilled aerosolized tumbling patent alacrity tonic	0		Effect: "Become Superficially interested", Effect Duration: 62
 8982	super-irradiated corrupted marrow	0		Effect: "Chorale of Companionship", Effect Duration: 15
 8983	mediocre ghostly rodeo whiskey	3	decent	
 8984	Thwaitgold scorpion statuette	0		
 8985	real cowboy hat of extreme caution	0		Monster Level: -25
 8986	Memories of Cow Punching	0		Free Pull
-8987	jittery green Memories of Beanslinging	0		Free Pull
+8987	green jittery Memories of Beanslinging	0		Free Pull
 8988	cyan Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	compressed twirling armored prawn	1		Last Available: "2016-03"
-8993	adequate half-sized jumping horseradish	2	good	Last Available: "2016-03"
-8994	hand-crafted practically non-alcoholic enchanted Sacramento wine	1	EPIC	Effect: "Broken Fast", Effect Duration: 40, Last Available: "2016-03"
+8993	half-sized adequate jumping horseradish	2	good	Last Available: "2016-03"
+8994	hand-crafted enchanted practically non-alcoholic Sacramento wine	1	EPIC	Effect: "Broken Fast", Effect Duration: 40, Last Available: "2016-03"
 8995	warmed gray Greek fire	0		Effect: "Become Intensely interested", Effect Duration: 44, Last Available: "2016-03"
 8996	twirling flame-wreathed sizzling personal trainer's ox-head shield of the storm of Calamity Jane	0		Experience Percent (Muscle): +10, Maximum MP Percent: +40, Critical Hit Percent: +15, Hot Damage: +10, Hot Spell Damage: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	maroon jittery prompt crafty medical-grade stylish dented scepter of doom	0		Moxie: +25, Maximum MP: +10, Spooky Spell Damage: +50, Adventures: +3, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	flame-retardant dance instructor's personal trainer's very pointy crown of the cougar of temperance	0		Moxie: +20, Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Hot Resistance: +1, Sleaze Resistance: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	flame-retardant dance instructor's personal trainer's very pointy crown of the cougar of temperance	0		Moxie: +20, Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Hot Resistance: +1, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	nasty flame-wreathed quilted Newton's battle broom of doom	0		Experience (Mysticality): +3, Damage Absorption: +40, Hot Spell Damage: +10, Stench Damage: +5, Spooky Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	frightening toasty curative educational carpe	0		Experience: +1, Hot Damage: +5, Spooky Damage: +5, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04"
 9002	grievous educational brawny codpiece of temperance	0		Muscle Percent: +20, Experience: +1, Weapon Damage Percent: +50, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	wholesome supercool groovy stylish troutsers	0		Moxie: +25, Moxie Percent: 30, Maximum HP Percent: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	wholesome supercool groovy stylish troutsers	0		Moxie: +25, Moxie Percent: 30, Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	lightning-fast Sinatra's educational bass clarinet of the sweet-tooth	0		Experience: +1, Experience (Moxie): +5, Candy Drop: +100, Initiative: +40, Lasts Until Rollover, Last Available: "2016-04"
 9005	double-paned Oprah's experienced fish hatchet of bravery	0		Experience: +2, Maximum MP Percent: +50, Cold Resistance: +5, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
 9006	flame-retardant ribald therapeutic tunac of bravery	0		Sleaze Damage: +10, Hot Resistance: +1, Spooky Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-04"
@@ -8899,12 +8899,12 @@
 9027	bouncing frosty sage First Post shirt - Cir Senam of the dark arts	0		Mysticality Percent: +10, Spell Damage Percent: +100, Cold Spell Damage: +10, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	mirror skewed no spoon	0		
-9030	toothsome fancy star salad	3	awesome	Effect: "Hobonic", Effect Duration: 35
+9030	fancy toothsome star salad	3	awesome	Effect: "Hobonic", Effect Duration: 35
 9031	Thwaitgold moth statuette	0		
-9032	gigantic adequate bowl of Tastee-Wheet&trade;	7	good	
+9032	adequate gigantic bowl of Tastee-Wheet&trade;	7	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	wobbly Source essence	0		Last Available: "2016-06"
-9035	adequate diet jittery browser cookie	1	good	Last Available: "2016-06"
+9035	diet adequate jittery browser cookie	1	good	Last Available: "2016-06"
 9036	mediocre hacked gibson	4	decent	Last Available: "2016-06"
 9037	savvy Source shades	0		Mysticality Percent: +20, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8947,14 +8947,14 @@
 9075	vacuum-sealed mirror shaking shoe gum	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 26, Last Available: "2016-07"
 9076	bouncing chaotic supercool noir fedora of the pedagogue	0		Moxie Percent: +20, Experience: +3, Spell Critical Percent: +10, Last Available: "2016-07"
 9077	executive toasty trench coat of the pedagogue	0		Experience: +3, Hot Damage: +5, Meat Drop: +40, Last Available: "2016-07"
-9078	irresponsibly strong bad Falcon&trade; Maltese Liquor	6	decent	Last Available: "2016-07"
+9078	bad irresponsibly strong Falcon&trade; Maltese Liquor	6	decent	Last Available: "2016-07"
 9079	rotten tiny hardboiled egg	1	crappy	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	reassuring Lo Pan's studded fortified brawny protonic accelerator pack of the ox	0		Muscle: +20, Muscle Percent: +20, Damage Absorption: 140, Spell Critical Percent: +30, Spooky Resistance: +1, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	reassuring Lo Pan's studded fortified brawny protonic accelerator pack of the ox	0		Muscle: +20, Muscle Percent: +20, Damage Absorption: 140, Spell Critical Percent: +30, Spooky Resistance: +1, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	upside-down Newton's Adventurer bobblehead	0		Experience (Mysticality): +3, Last Available: "2016-11"
-9085	squat narrow psychokinetic energy blob	0		Last Available: "2016-08"
+9085	narrow squat psychokinetic energy blob	0		Last Available: "2016-08"
 9086	veiny weightlifter's bindle	0		Muscle: +15, Maximum HP: +10, Last Available: "2016-08"
 9087	pulsating bouncing Annie Oakley's fortified fleshy lump	0		Damage Absorption: +60, Critical Hit Percent: +20, Damage Reduction: 3, Last Available: "2016-08"
 9088	auspicious mansplainer's smoldering bagel punch	0		Monster Level: +15, Item Drop: +10, Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	teal asbestos-lined Mr. Screege's spectacles	0		Hot Resistance: +5, Single Equip, Last Available: "2016-08"
 9092	electrified Oprah's Spookyraven signet of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-08"
 9093	greasy sinister tie-dyed fannypack	0		Spell Damage: +10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2016-08"
-9094	Usain Bolt's lightning-fast burnt snowpants	0		Initiative: 120, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	greedy standards and practices guide	0		Meat Drop: +20, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	Usain Bolt's lightning-fast burnt snowpants	0		Initiative: 120, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	greedy standards and practices guide	0		Meat Drop: +20, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	blinking chilly Temple Grandin's Carpathian longsword of Gandalf	0		Spell Critical Percent: +20, Familiar Weight: +7, Cold Damage: +5, Last Available: "2016-08"
 9097	inspector's sage Liam's mail of the empath	0		Mysticality Percent: +10, Familiar Weight: +5, Item Drop: +15, Last Available: "2016-08"
 9098	MacGyver's vibrating Unfortunato's foolscap of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +10, Maximum MP: +100, Last Available: "2016-08"
@@ -8973,7 +8973,7 @@
 9101	twirling purification tablet	0		
 9102	blurry Wrist-Boy of the glutton	0		Food Drop: +100
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
-9104	upside-down purple wobbly Time-Spinner	0		Last Available: "2016-09"
+9104	purple wobbly upside-down Time-Spinner	0		Last Available: "2016-09"
 9105	bouncing compounded experience	0		Last Available: "2016-09"
 9106	Rad-B-Gone (1 lb.)	0		
 9107	alkaline tumbling Rad-Pro (1 oz.)	0		Effect: "Rainbow Bright", Effect Duration: 51
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	fuchsia experienced repaid diaper	0		Experience: +2
 9118	pulsating skewed Riker's Search History	0		Last Available: "2016-09"
-9119	hand-crafted weak Shot of Kardashian Gin	2	EPIC	Last Available: "2016-09"
+9119	weak hand-crafted Shot of Kardashian Gin	2	EPIC	Last Available: "2016-09"
 9120	quilted Unstable Pointy Ears	0		Damage Absorption: +40, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	upside-down Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
@@ -9004,33 +9004,33 @@
 9132	friendly wizardly pistol	0		Mysticality: +25, Familiar Weight: +3
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	immense spoiled leftover pasty	9	crappy	
-9135	watered-down drinkable very whiskey	2	good	
+9135	drinkable watered-down very whiskey	2	good	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	huge li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	twirling li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	skewed li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	spinning li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	huge li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	huge li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	twirling li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	skewed li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	spinning li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	huge li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	quadruple-tarnished chilled hoarded candy wad	0		Effect: "Pork Power", Effect Duration: 54, Last Available: "2016-10"
 9147	moist Prunets	0		Effect: "Disco Concentration", Effect Duration: 40
 9148	ghostly Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	galvanized invisible string	0		Lasts Until Rollover, Effect: "Concentrated Concentration", Effect Duration: 14, Last Available: "2016-10"
 9151	aerosolized anodized upside-down invisible seam ripper	0		Lasts Until Rollover, Effect: "Cruisin' for a Bruisin'", Effect Duration: 45, Last Available: "2016-10"
-9152	blurry li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	blurry li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	adequate blinking raw sweet potato	3	good	Last Available: "2016-11"
 9154	flavorless snack-sized raw beans	2	decent	Last Available: "2016-11"
-9155	spoiled big raw stuffing	5	crappy	Last Available: "2016-11"
+9155	big spoiled raw stuffing	5	crappy	Last Available: "2016-11"
 9156	bland bite-sized raw cranberry sauce	1	decent	Last Available: "2016-11"
 9157	delicious raw turkey	3	awesome	Last Available: "2016-11"
-9158	bland half-sized raw mincemeat	2	decent	Last Available: "2016-11"
+9158	half-sized bland raw mincemeat	2	decent	Last Available: "2016-11"
 9159	half-sized flavorless huge raw potato	2	decent	Last Available: "2016-11"
-9160	enchanted moldy raw gravy	4	crappy	Effect: "Executive Greed", Effect Duration: 30, Last Available: "2016-11"
-9161	snack-sized spoiled skewed raw bread	2	crappy	Last Available: "2016-11"
+9160	moldy enchanted raw gravy	4	crappy	Effect: "Executive Greed", Effect Duration: 30, Last Available: "2016-11"
+9161	spoiled snack-sized skewed raw bread	2	crappy	Last Available: "2016-11"
 9162	fuchsia spinning arcane researcher's mini-marshmallow dispenser of wisdom	0		Mysticality: +15, Experience Percent (Mysticality): +10, Last Available: "2016-11"
 9163	therapeutic ruddy educational glass casserole dish	0		Experience: +1, Maximum HP Percent: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9044,11 +9044,11 @@
 9172	half-sized spoiled spinning bean casserole	2	crappy	Last Available: "2016-11"
 9173	fancy adequate yellow squat baked stuffing	4	good	Effect: "Fever From the Flavor", Effect Duration: 5, Last Available: "2016-11"
 9174	bland spinning cranberry cylinder	3	decent	Last Available: "2016-11"
-9175	bland super-sized thanksgiving turkey	5	decent	Last Available: "2016-11"
-9176	half-sized flavorless mince pie	2	decent	Last Available: "2016-11"
+9175	super-sized bland thanksgiving turkey	5	decent	Last Available: "2016-11"
+9176	flavorless half-sized mince pie	2	decent	Last Available: "2016-11"
 9177	decent pulsating mashed potatoes	4	good	Last Available: "2016-11"
 9178	jumbo rotten warm gravy	5	crappy	Last Available: "2016-11"
-9179	miniature toothsome red bread roll	2	awesome	Last Available: "2016-11"
+9179	toothsome miniature red bread roll	2	awesome	Last Available: "2016-11"
 9180	bland leftovers	3	decent	Last Available: "2016-11"
 9181	bland leftovers sandwich	4	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9108,7 +9108,7 @@
 9236	blurry dog trainer's thinker's gingerbread gavel	0		Mysticality: +10, Experience (familiar): +1, Last Available: "2016-12"
 9237	spinning ghostly green gingerbread cigarette	0		Last Available: "2016-12"
 9238	tumbling gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	perfectly mixed strong special ginger beer	5	EPIC	Effect: "Blessing of the Hot Linguine", Effect Duration: 25, Last Available: "2016-12"
+9239	special perfectly mixed strong ginger beer	5	EPIC	Effect: "Blessing of the Hot Linguine", Effect Duration: 25, Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	adjusted unsweetened industrial frosting	0		Effect: "Capricorn Rising", Effect Duration: 23, Last Available: "2016-12"
 9242	frozen denatured blue fake cocktail	0		Effect: "The Strength...  of the Future", Effect Duration: 44, Last Available: "2016-12"
@@ -9122,7 +9122,7 @@
 9250	double-galvanized spinning mirror Inner Strength	0		Effect: "Petit Forbearance", Effect Duration: 50, Last Available: "2016-12"
 9251	pressed alkaline boiled Inner Truth	0		Effect: "Serendipi Tea", Effect Duration: 26, Last Available: "2016-12"
 9252	rotten spiritual candy cane	4	crappy	Last Available: "2016-12"
-9253	perfectly mixed fancy spiritual eggnog	3	EPIC	Effect: "Always In Motion", Effect Duration: 20, Last Available: "2016-12"
+9253	fancy perfectly mixed spiritual eggnog	3	EPIC	Effect: "Always In Motion", Effect Duration: 20, Last Available: "2016-12"
 9254	decent spiritual fruitcake	3	good	Last Available: "2016-12"
 9255	tasty skewed spiritual gingerbread	4	awesome	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
@@ -9145,7 +9145,7 @@
 9273	narrow manspreader's experienced Third Eye	0		Experience: +2, Monster Level: +10, Last Available: "2016-12"
 9274	narrow narrow inspector's stylish Krampus Horn	0		Moxie: +25, Item Drop: +15, Single Equip, Last Available: "2016-12"
 9275	rotten hambrosier	4	crappy	Last Available: "2016-12"
-9276	strong aged chakra-mental wine	5	awesome	Last Available: "2016-12"
+9276	aged strong chakra-mental wine	5	awesome	Last Available: "2016-12"
 9277	triple-dry chakra malt	0		Effect: "Stimulated Brain", Effect Duration: 31, Last Available: "2016-12"
 9278	moldy Black Angus blackburger	3	crappy	Last Available: "2016-12"
 9279	perfectly mixed watered-down brandy	2	EPIC	Last Available: "2016-12"
@@ -9159,16 +9159,16 @@
 9287	pulsating pet bad vibe	0		Last Available: "2016-12"
 9288	upside-down gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	MacGyver's vibrating experienced Uncle Crimbo's hat	0		Experience: +2, Maximum MP Percent: +10, Maximum MP: +100, Last Available: "2016-12"
-9290	small rotten spinning Eldritch snap	2	crappy	Last Available: "2017-01"
+9290	rotten small spinning Eldritch snap	2	crappy	Last Available: "2017-01"
 9291	altered lime green hot jelly	1		Last Available: "2017-01"
 9292	dried jelly	1		Last Available: "2017-01"
 9293	twisted jittery jelly	1		Last Available: "2017-01"
-9294	diluted narrow mirror bouncing sleaze jelly	1		Last Available: "2017-01"
+9294	diluted narrow bouncing mirror sleaze jelly	1		Last Available: "2017-01"
 9295	pickled stench jelly	1		Last Available: "2017-01"
 9296	spinning upside-down space planula	0		Free Pull, Last Available: "2017-01"
-9297	rotten miniature tumbling toast with hot jelly	2	crappy	Last Available: "2017-01"
-9298	thick tasty toast with jelly	5	awesome	Last Available: "2017-01"
-9299	flavorless tiny narrow toast with jelly	1	decent	Last Available: "2017-01"
+9297	miniature rotten tumbling toast with hot jelly	2	crappy	Last Available: "2017-01"
+9298	tasty thick toast with jelly	5	awesome	Last Available: "2017-01"
+9299	tiny flavorless narrow toast with jelly	1	decent	Last Available: "2017-01"
 9300	rotten green toast with sleaze jelly	3	crappy	Last Available: "2017-01"
 9301	stale toast with stench jelly	3	decent	Last Available: "2017-01"
 9302	mirror maroon mirror space jellybicycle	0		Familiar Weight: +5
@@ -9176,12 +9176,12 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	pulsating nasty crafty wax hand	0		Maximum MP: +10, Stench Damage: +5, Last Available: "2017-01"
 9306	zippy Samson's candle	0		Experience (Muscle): +5, Initiative: +20, Lasts Until Rollover, Last Available: "2017-01"
-9307	gigantic decent wax pancake	6	good	Last Available: "2017-01"
+9307	decent gigantic wax pancake	6	good	Last Available: "2017-01"
 9308	Jim Carey's brainy wax face	0		Mysticality: +5, Monster Level: +25, Last Available: "2017-01"
 9309	mediocre narrow wax booze	3	decent	Last Available: "2017-01"
 9310	green glob of melted wax	0		Last Available: "2017-01"
 9311	dried spinning gray sea jelly	1		Last Available: "2017-01"
-9312	spoiled miniature sea truffle	2	crappy	Last Available: "2017-01"
+9312	miniature spoiled sea truffle	2	crappy	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	squat narrow groovy recovered cufflinks	0		Moxie Percent: +10, Single Equip, Last Available: "2017-01"
@@ -9212,12 +9212,12 @@
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	green Diamond HP-35 Calculator	0		
-9343	huge red bottlecap	0		
-9344	blinking upside-down discarded button	0		
+9343	red huge bottlecap	0		
+9344	upside-down blinking discarded button	0		
 9345	Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
 9347	skewed pickled grasshopper	0		Last Available: "2017-03"
-9348	twirling spinning bottle of an&iacute;s	0		Last Available: "2017-03"
+9348	spinning twirling bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
@@ -9237,27 +9237,27 @@
 9365	drinkable watered-down literal grasshopper	2	good	Last Available: "2017-03"
 9366	aged double entendre	3	awesome	Last Available: "2017-03"
 9367	aged Phlegethon	4	awesome	Last Available: "2017-03"
-9368	hand-crafted watered-down Siberian sunrise	2	EPIC	Last Available: "2017-03"
+9368	watered-down hand-crafted Siberian sunrise	2	EPIC	Last Available: "2017-03"
 9369	artisanal squat mentholated wine	3	EPIC	Last Available: "2017-03"
 9370	drinkable low tide martini	3	good	Last Available: "2017-03"
 9371	perfectly mixed shroomtini	3	EPIC	Last Available: "2017-03"
 9372	smooth morning dew	3	awesome	Last Available: "2017-03"
-9373	irresponsibly strong bad squat whiskey squeeze	6	decent	Last Available: "2017-03"
+9373	bad irresponsibly strong squat whiskey squeeze	6	decent	Last Available: "2017-03"
 9374	tolerable great fashioned	3	good	Last Available: "2017-03"
-9375	hand-crafted high-proof Gnomish sagngria	9	EPIC	Last Available: "2017-03"
+9375	high-proof hand-crafted Gnomish sagngria	9	EPIC	Last Available: "2017-03"
 9376	lousy vodka stinger	4	decent	Last Available: "2017-03"
 9377	weak artisanal twirling extremely slippery nipple	2	EPIC	Last Available: "2017-03"
 9378	mediocre piscatini	3	decent	Last Available: "2017-03"
 9379	drinkable Churchill	3	good	Last Available: "2017-03"
 9380	bad ghostly soilzerac	3	decent	Last Available: "2017-03"
-9381	perfectly mixed practically non-alcoholic London frog	1	EPIC	Last Available: "2017-03"
+9381	practically non-alcoholic perfectly mixed London frog	1	EPIC	Last Available: "2017-03"
 9382	perfectly mixed nothingtini	4	EPIC	Last Available: "2017-03"
-9383	special high-proof lousy eighth plague	7	decent	Effect: "Spell Transfer Complete", Effect Duration: 30, Last Available: "2017-03"
-9384	perfectly mixed boozy single entendre	5	EPIC	Last Available: "2017-03"
+9383	high-proof special lousy eighth plague	7	decent	Effect: "Spell Transfer Complete", Effect Duration: 30, Last Available: "2017-03"
+9384	boozy perfectly mixed single entendre	5	EPIC	Last Available: "2017-03"
 9385	weak artisanal reverse Tantalus	2	EPIC	Last Available: "2017-03"
 9386	lousy skewed elemental caipiroska	3	decent	Last Available: "2017-03"
 9387	watered-down perfectly mixed Feliz Navidad	2	EPIC	Last Available: "2017-03"
-9388	lousy enchanted Bloody Nora	3	decent	Effect: "Puzzle Fury", Effect Duration: 15, Last Available: "2017-03"
+9388	enchanted lousy Bloody Nora	3	decent	Effect: "Puzzle Fury", Effect Duration: 15, Last Available: "2017-03"
 9389	aged moreltini	4	awesome	Last Available: "2017-03"
 9390	smooth blue hell in a bucket	3	awesome	Last Available: "2017-03"
 9391	irresponsibly strong artisanal Newark	6	EPIC	Last Available: "2017-03"
@@ -9269,12 +9269,12 @@
 9397	drinkable gunner's daughter	3	good	Last Available: "2017-03"
 9398	lousy practically non-alcoholic dirt julep	1	decent	Last Available: "2017-03"
 9399	drinkable irresponsibly strong blurry Simepore slime	8	good	Last Available: "2017-03"
-9400	perfectly mixed lime green skewed Phil Collins	3	EPIC	Last Available: "2017-03"
+9400	perfectly mixed skewed lime green Phil Collins	3	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	pulsating toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
-9405	olive tumbling filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
+9405	tumbling olive filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	wobbly rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	shaking blinking gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
@@ -9282,7 +9282,7 @@
 9410	Spacegate Research	0		Last Available: "2017-04"
 9411	alien rock sample	0		Last Available: "2017-04"
 9412	gray alien gemstone	0		Last Available: "2017-04"
-9413	wobbly skewed wobbly geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9413	wobbly wobbly skewed geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	pulsating squat botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9415	decent jumbo edible alien plant bit	5	good	Last Available: "2017-04"
 9416	blurry alien plant fibers	0		Last Available: "2017-04"
@@ -9325,12 +9325,12 @@
 9453	sinister strapping murderbot mask of horror	0		Muscle: +5, Spell Damage: +10, Spooky Spell Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
 9454	tarnished mirror murderbot spring injector	0		Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2017-04"
 9455	rock-hard Herculean murderbot whip	0		Experience (Muscle): +1, Damage Reduction: 5, Last Available: "2017-04"
-9456	huge jittery MacGyver's murderbot plasma rifle of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	huge jittery MacGyver's murderbot plasma rifle of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	yellow murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
-9461	tumbling yellow Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
+9461	yellow tumbling Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	spinning Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
@@ -9341,54 +9341,54 @@
 9469	fuchsia Herculean Spacegate scientist's insignia of the wise owl	0		Mysticality: +20, Experience (Muscle): +1, Single Equip, Last Available: "2017-04"
 9470	censurious Spacegate military insignia of the detective	0		Sleaze Resistance: +3, Item Drop: +20, Single Equip, Last Available: "2017-04"
 9471	lard-coated scorching Spacegate diplomat's insignia of the brute	0		Muscle Percent: +30, Hot Damage: +25, Sleaze Spell Damage: +25, Single Equip, Last Available: "2017-04"
-9472	huge shaking Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
+9472	shaking huge Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	rotten alien sandwich	3	crappy	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	Vulcanized Spant eggs	0		Effect: "Stop and Smell the Fudge", Effect Duration: 51
 9477	blue Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	liquefied purple wobbly Daily Affirmation: Always be Collecting	0		Effect: "Amorous", Effect Duration: 53, Last Available: "2017-05"
+9479	liquefied wobbly purple Daily Affirmation: Always be Collecting	0		Effect: "Amorous", Effect Duration: 53, Last Available: "2017-05"
 9480	corrupted enhanced galvanized Daily Affirmation: Think Win-Lose	0		Effect: "Smoky Third Eye", Effect Duration: 25, Last Available: "2017-05"
 9481	aerosolized blinking Daily Affirmation: Be Superficially interested	0		Effect: "Ghostly Shell", Effect Duration: 43, Last Available: "2017-05"
 9482	Vulcanized ionized twirling Daily Affirmation: Adapt to Change Eventually	0		Effect: "Eye of the Lihc", Effect Duration: 26, Last Available: "2017-05"
 9483	vacuum-sealed Daily Affirmation: Be a Mind Master	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 12, Last Available: "2017-05"
 9484	dry magnetized wobbly Daily Affirmation: Work For Hours a Week	0		Effect: "Memory of Attractiveness", Effect Duration: 46, Last Available: "2017-05"
 9485	galvanized Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Kernel Panic!", Effect Duration: 49, Last Available: "2017-05"
-9486	fancy adequate Affirmation Cookie	4	good	Effect: "Stenchtastic", Effect Duration: 25, Last Available: "2017-05"
+9486	adequate fancy Affirmation Cookie	4	good	Effect: "Stenchtastic", Effect Duration: 25, Last Available: "2017-05"
 9487	spinning License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	spinning cyan Victor's Spoils	0		
 9490	altered Threatening Missive	0		Effect: "On a Roll", Effect Duration: 45
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	friendly MacGyver's Kremlin's Greatest Briefcase	0		Maximum MP: +100, Familiar Weight: +3, Item Drop: +5, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	friendly MacGyver's Kremlin's Greatest Briefcase	0		Maximum MP: +100, Familiar Weight: +3, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	drinkable pulsating basic martini	3	good	Last Available: "2017-06"
 9495	artisanal improved martini	3	EPIC	Last Available: "2017-06"
 9496	weak bad ghostly splendid martini	2	decent	Last Available: "2017-06"
-9497	jittery twirling exploding cigar	0		Last Available: "2017-06"
-9498	huge tumbling can of Minions-Be-Gone	0		Last Available: "2017-06"
+9497	twirling jittery exploding cigar	0		Last Available: "2017-06"
+9498	tumbling huge can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	spinning tattoo gun	0		Last Available: "2017-06"
 9500	mirror gun	0		Free Pull, Last Available: "2017-06"
-9501	squat spinning gum	0		Free Pull, Last Available: "2017-06"
+9501	spinning squat gum	0		Free Pull, Last Available: "2017-06"
 9502	squat twirling baleful beefy plastic gundam of the businessman	0		Muscle: +10, Spell Damage: +25, Meat Drop: +50, Last Available: "2017-06"
 9503	purple License to Chill	0		Last Available: "2017-07"
 9504	narrow Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
-9508	jittery olive Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
+9508	olive jittery Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
 9510	Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	lime green Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	upside-down Meteorite-Ade	0		Last Available: "2017-08"
-9514	delicious tiny meteoreo	1	awesome	Last Available: "2017-08"
+9514	tiny delicious meteoreo	1	awesome	Last Available: "2017-08"
 9515	hand-crafted pulsating meadeorite	3	EPIC	Last Available: "2017-08"
 9516	jittery meteoroid	0		Last Available: "2017-08"
 9517	maroon foul-smelling Tesla smooth meteortarboard	0		Moxie: +15, Stench Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2017-08"
 9518	toasty fortified Rosewater's meteorite guard	0		Mysticality Percent: +30, Damage Absorption: +60, Hot Damage: +5, Damage Reduction: 9, Last Available: "2017-08"
-9519	censurious groovy meteorb	0		Moxie Percent: +10, Sleaze Resistance: +3, Lantern Element: "Hot", Last Available: "2017-08"
+9519	censurious groovy meteorb	0		Moxie Percent: +10, Sleaze Resistance: +3, Last Available: "2017-08", Lantern Element: "Hot"
 9520	scandalous stiffened asteroid belt	0		Damage Reduction: 1, Sleaze Damage: +5, Single Equip, Last Available: "2017-08"
 9521	gray narrow sizzling shellacked grievous meteorthopedic shoes	0		Weapon Damage Percent: +50, Damage Reduction: 7, Hot Damage: +10, Single Equip, Last Available: "2017-08"
 9522	skewed miser's chilly shooting morning star of the glutton	0		Cold Damage: +5, Meat Drop: +10, Food Drop: +100, Single Equip, Last Available: "2017-08"
@@ -9402,8 +9402,8 @@
 9530	energetic Socratic blessed rustproof +2 gray dragon scale mail of the sewer	0		Experience (Mysticality): +1, Maximum MP Percent: +20, Stench Damage: +25, Last Available: "2023-09"
 9531	spinning pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	mirror pony: Shutterfly	0		Last Available: "2017-09"
-9533	yellow jittery pony: Pearjack	0		Last Available: "2017-09"
-9534	pulsating teal pony: Uniquity	0		Last Available: "2017-09"
+9533	jittery yellow pony: Pearjack	0		Last Available: "2017-09"
+9534	teal pulsating pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
 9536	jittery pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
@@ -9432,7 +9432,7 @@
 9560	blinking pulsating O	0		Last Available: "2017-11"
 9561	lime green amorphous blob	0		Last Available: "2017-11"
 9562	pulsating squat ribald sinister razor-sharp protection stick of mayonnaise	0		Weapon Damage Percent: +25, Spell Damage: +10, Sleaze Damage: +10, Sleaze Spell Damage: +50
-9563	boiled green twirling roll of meat	0		Effect: "Rushin' Hands", Effect Duration: 68
+9563	boiled twirling green roll of meat	0		Effect: "Rushin' Hands", Effect Duration: 68
 9564	coward's mafia thumb ring of wisdom	0		Mysticality: +15, Monster Level: -20, Single Equip
 9565	extra-alkaline huge bouncing cocoa chondrule	0		Effect: "Jittery", Effect Duration: 55, Last Available: "2020-09"
 9566	huge energetic beefcake's mafia middle finger ring	0		Muscle: +25, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Show them your ring"
@@ -9451,7 +9451,7 @@
 9579	rotten unfinished fruitcake	3	crappy	Last Available: "2017-12"
 9580	oxidized unsweetened magnetized skewed and cracker	0		Effect: "Frozen Hands", Effect Duration: 60, Last Available: "2017-12"
 9581	mediocre neg grog	3	decent	Last Available: "2017-12"
-9582	snack-sized decent half double fruitcake	2	good	Last Available: "2017-12"
+9582	decent snack-sized half double fruitcake	2	good	Last Available: "2017-12"
 9583	rotten hushed puppy	3	crappy	Last Available: "2017-12"
 9584	bite-sized rotten muffled muffuletta	1	crappy	Last Available: "2017-12"
 9585	yummy shushed potatoes	3	awesome	Last Available: "2017-12"
@@ -9464,12 +9464,12 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	good	Last Available: "2017-11"
 9594	aerosolized wishbone	0		Effect: "Very Clean Guns", Effect Duration: 48, Last Available: "2017-11"
-9595	weak lousy fancy Racisto Ruidoso	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2017-11"
+9595	lousy weak fancy Racisto Ruidoso	2	decent	Effect: "Sleazy Hands", Effect Duration: 30, Last Available: "2017-11"
 9596	blinking earthenware muffin tin	0		
-9597	super-sized bland bran muffin	5	decent	
+9597	bland super-sized bran muffin	5	decent	
 9598	decent blueberry muffin	4	good	
 9599	fuchsia silent A	0		Last Available: "2017-12"
-9600	shaking narrow silent B	0		Last Available: "2017-12"
+9600	narrow shaking silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
 9602	silent D	0		Last Available: "2017-12"
 9603	silent E	0		Last Available: "2017-12"
@@ -9507,7 +9507,7 @@
 9635	narrow The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	lime green The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
-9638	jittery blurry The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
+9638	blurry jittery The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
@@ -9518,13 +9518,13 @@
 9646	teal The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	red mime eraser	0		Last Available: "2017-12"
 9648	drinkable weak jittery executive mime flask	2	good	Last Available: "2017-12"
-9649	normal diet huge nega-mushroom	1	good	Last Available: "2017-12"
+9649	diet normal huge nega-mushroom	1	good	Last Available: "2017-12"
 9650	acceptable extra-dry nega-mushroom wine	5	good	Last Available: "2017-12"
 9651	deionized Cheer-Up soda	0		Effect: "It Didn't Kill You", Effect Duration: 28, Last Available: "2017-12"
 9652	spoiled mime army rations	3	crappy	Last Available: "2017-12"
 9653	aged mime army wine	3	awesome	Last Available: "2017-12"
 9654	pickled blinking mime army superserum	1		Last Available: "2017-12"
-9655	galvanized jittery fuchsia mime army camouflage kit	0		Effect: "Buff as a Baobab", Effect Duration: 39, Last Available: "2017-12"
+9655	galvanized fuchsia jittery mime army camouflage kit	0		Effect: "Buff as a Baobab", Effect Duration: 39, Last Available: "2017-12"
 9656	olive asbestos-lined Jim Carey's miming beret	0		Monster Level: +25, Hot Resistance: +5, Last Available: "2017-12"
 9657	gravedigger's experienced miming shirt	0		Experience: +2, Spooky Damage: +10, Last Available: "2017-12"
 9658	Jeselnik's occult miming corduroys	0		Spell Damage Percent: +25, Sleaze Damage: +25, Last Available: "2017-12"
@@ -9536,22 +9536,22 @@
 9664	donated candy	0		
 9665	polymerized modified digital honeypot	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 43, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	tumbling lime green Jack Frost's mime army insignia (infantry)	0		Cold Spell Damage: +50, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	fireproof mime army insignia (intelligence)	0		Hot Resistance: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	upside-down jittery mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	tumbling lime green Jack Frost's mime army insignia (infantry)	0		Cold Spell Damage: +50, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	fireproof mime army insignia (intelligence)	0		Hot Resistance: +3, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	upside-down jittery mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	fuchsia mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	purple twirling mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	maroon miser's hardened mime army infiltration glove	0		Damage Reduction: 3, Meat Drop: +10, Single Equip, Last Available: "2017-12"
-9676	gray spinning mime army shotglass	0		Last Available: "2017-12"
+9676	spinning gray mime army shotglass	0		Last Available: "2017-12"
 9677	twirling mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	wobbly fireproof skip lid	0		Familiar Weight: +5
 9681	adequate tumbling extra-toasted half sandwich	3	good	Last Available: "2018-12"
-9682	spirit-forward mediocre mulled hobo wine	5	decent	Last Available: "2018-12"
+9682	mediocre spirit-forward mulled hobo wine	5	decent	Last Available: "2018-12"
 9683	mirror burning newspaper	0		Last Available: "2018-12"
 9684	lightning-fast beefy burning paper hat of Gandalf	0		Muscle: +10, Spell Critical Percent: +20, Initiative: +40, Lasts Until Rollover, Last Available: "2018-12"
 9685	perfumed burning cape of extreme caution of the detective	0		Monster Level: -25, Stench Resistance: +5, Item Drop: +20, Lasts Until Rollover, Last Available: "2018-12"
@@ -9594,13 +9594,13 @@
 9726	stiffened psychic's amulet of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Last Available: "2018-02"
 9727	delicious heart-shaped candy whetstone	3	awesome	Last Available: "2018-02"
 9728	gigantic adequate teal Swedish massage fish	8	good	Last Available: "2018-02"
-9729	artisanal irresponsibly strong Third Base	7	EPIC	Last Available: "2018-02"
+9729	irresponsibly strong artisanal Third Base	7	EPIC	Last Available: "2018-02"
 9730	watered-down artisanal Bustle Hustler	2	EPIC	Last Available: "2018-02"
 9731	nitrogenated ionized wobbly Fabiotion	0		Effect: "Human-Hippy Hybrid", Effect Duration: 39, Last Available: "2018-02"
 9732	oxidized Bettie page	0		Effect: "Coldfinger", Effect Duration: 35, Last Available: "2018-02"
 9733	cold-filtered chilled flattened tonic o' Banderas	0		Effect: "Eyes All Black", Effect Duration: 31, Last Available: "2018-02"
 9734	extra-enhanced heather graham cracker	0		Effect: "Mint-Condition Breath", Effect Duration: 61, Last Available: "2018-02"
-9735	narrow red Lolsipop	0		Last Available: "2018-02"
+9735	red narrow Lolsipop	0		Last Available: "2018-02"
 9736	heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
 9738	red personal graffiti kit	0		Last Available: "2018-02"
@@ -9608,7 +9608,7 @@
 9740	blurry Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	tumbling Mysterious Black Box	0		Last Available: "2018-02"
-9743	boiled irradiated lime green squat rainbow jellybean	0		Effect: "Eyes All Black", Effect Duration: 26
+9743	boiled irradiated squat lime green rainbow jellybean	0		Effect: "Eyes All Black", Effect Duration: 26
 9744	chilled mystery lollipop	0		Effect: "Fancy Feasted", Effect Duration: 49
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	tarnished tarnished rhinestone	0		Effect: "Stuck-Up Hair", Effect Duration: 25
@@ -9629,7 +9629,7 @@
 9761	pulsating Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
-9764	yellow shaking Faux	0		Last Available: "2018-03"
+9764	shaking yellow Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
@@ -9679,7 +9679,7 @@
 9811	pulsating ghostly Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	cyan Glum berry	0		Last Available: "2018-03"
-9814	narrow green ghostly Egnaro berry	0		Last Available: "2018-03"
+9814	ghostly narrow green Egnaro berry	0		Last Available: "2018-03"
 9815	spinning Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	cyan Jamocha berry	0		Last Available: "2018-03"
@@ -9695,10 +9695,10 @@
 9827	rocket	0		
 9828	dehydrated magnificent oyster egg	1		
 9829	pickled pulsating ghostly brilliant oyster egg	1		Effect: "Bananas!", Effect Duration: 50
-9830	denatured ghostly purple glistening oyster egg	1		
+9830	denatured purple ghostly glistening oyster egg	1		
 9831	compressed tumbling scintillating oyster egg	1		
 9832	mixed pearlescent oyster egg	1		
-9833	modified ghostly skewed lime green lustrous oyster egg	1		
+9833	modified lime green ghostly skewed lustrous oyster egg	1		
 9834	compressed gleaming oyster egg	1		Effect: "Stinky Weapon", Effect Duration: 25
 9835	yellow FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	ghostly FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9716,7 +9716,7 @@
 9848	LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
 9850	My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
-9851	mirror bouncing dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
+9851	bouncing mirror dragon aluminum ore	0		Lasts Until Rollover, Last Available: "2018-04"
 9852	blue twirling faerie dust	0		Lasts Until Rollover, Last Available: "2018-04"
 9853	poisoned druidic s'more	0		Lasts Until Rollover, Last Available: "2018-04"
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9727,14 +9727,14 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	delicious massive ghostly FantasyRealm turkey leg	9	awesome	Last Available: "2018-04"
+9862	massive delicious ghostly FantasyRealm turkey leg	9	awesome	Last Available: "2018-04"
 9863	hand-crafted teal FantasyRealm mead	3	EPIC	Last Available: "2018-04"
 9864	spinning nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	immense bland spinning druidic s'more	7	decent	Last Available: "2018-04"
+9869	bland immense spinning druidic s'more	7	decent	Last Available: "2018-04"
 9870	vaporized ghostly sachet of powder	1		Last Available: "2018-04"
 9871	tolerable pulsating mourning wine	4	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	tumbling map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	flavorless low-calorie upside-down skewed denastified haunch	1	decent	Last Available: "2018-04"
+9878	low-calorie flavorless upside-down skewed denastified haunch	1	decent	Last Available: "2018-04"
 9879	aged bad rum and good cola	3	awesome	Last Available: "2018-04"
 9880	moist oxidized Potion of Heroism	0		Effect: "Heightened Senses", Effect Duration: 32, Last Available: "2018-04"
 9881	avaricious energetic supercool leggings of the Spider Queen	0		Moxie Percent: +20, Maximum MP Percent: +20, Meat Drop: +30, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	gray charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	blurry dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	practically non-alcoholic lousy cyan two meat muck	1	decent	
+9898	lousy practically non-alcoholic cyan two meat muck	1	decent	
 9899	tasty chocolate Ogre Chieftain	3	awesome	
-9900	stale tumbling blinking maroon chocolate &quot;Phoenix&quot;	4	decent	
-9901	spoiled snack-sized pulsating chocolate Spider Queen	2	crappy	
+9900	stale maroon tumbling blinking chocolate &quot;Phoenix&quot;	4	decent	
+9901	snack-sized spoiled pulsating chocolate Spider Queen	2	crappy	
 9902	bad green hipster cocktail	3	decent	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	mirror God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	mirror God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	teal G	0		
 9910	Garland of Greatness	0		
@@ -9786,7 +9786,7 @@
 9918	dried gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
-9921	spinning huge A Guide to Safari	0		Skill: "Experience Safari"
+9921	huge spinning A Guide to Safari	0		Skill: "Experience Safari"
 9922	tarnished Shielding Potion	0		Effect: "Pretending to Pretend", Effect Duration: 62, Last Available: "2018-06"
 9923	energized alkaline Punching Potion	0		Effect: "Strong Grip", Effect Duration: 28, Last Available: "2018-06"
 9924	teal Special Seasoning	0		Last Available: "2018-06"
@@ -9818,10 +9818,10 @@
 9950	up-at-dawn double-paned pentagram bandana	0		Cold Resistance: +5, Adventures: +5, Last Available: "2018-09"
 9951	blurry brawny skull ring	0		Muscle Percent: +20, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	fancy adequate miniature jittery PB&J with the crusts cut off	2	good	Effect: "Extra-Thick Blood", Effect Duration: 35, Last Available: "2018-09"
+9953	adequate fancy miniature jittery PB&J with the crusts cut off	2	good	Effect: "Extra-Thick Blood", Effect Duration: 35, Last Available: "2018-09"
 9954	huge executive veiny dorky glasses	0		Maximum HP: +10, Meat Drop: +40, Single Equip, Last Available: "2018-09"
 9955	deadly ponytail clip of the bloodbag	0		Weapon Damage: +5, Maximum HP: +100, Last Available: "2018-09"
-9956	paint palette of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	paint palette of the overflowing toilet	0		Stench Spell Damage: +50, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	compressed red jittery Purple Beast energy drink	1		Last Available: "2018-09"
 9959	ghostly ruddy cosmetic football	0		Maximum HP Percent: +40, Last Available: "2018-09"
@@ -9839,7 +9839,7 @@
 9972	crafty intimidating chainsaw of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +10, Lasts Until Rollover, Last Available: "2018-09"
 9973	mediocre watered-down party beer bomb	2	decent	Last Available: "2018-09"
 9974	decent mirror sweet party mix	3	good	Last Available: "2018-09"
-9975	compressed narrow huge blinking party balloon	1		Last Available: "2018-09"
+9975	compressed narrow blinking huge party balloon	1		Last Available: "2018-09"
 9976	party pants of the storm of Calamity Jane	0		Maximum MP Percent: +40, Critical Hit Percent: +15, Last Available: "2018-09"
 9977	scorching Lo Pan's healthy party whip	0		Maximum HP Percent: +20, Spell Critical Percent: +30, Hot Damage: +25, Last Available: "2018-09"
 9978	huge Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	flavorless skewed party platter for one	3	decent	Last Available: "2018-09"
 9981	distilled Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	horrifying beefcake's party crasher	0		Muscle: +25, Spooky Damage: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	horrifying beefcake's party crasher	0		Muscle: +25, Spooky Damage: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	shaking latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	jittery smartaleck's &quot;I Voted!&quot; sticker	0		Moxie Percent: +30, Lasts Until Rollover, Last Available: "2018-11"
@@ -9879,12 +9879,12 @@
 10013	toothsome pizza	3	awesome	Last Available: "2018-11"
 10014	perfectly mixed jittery martini	3	EPIC	Last Available: "2018-11"
 10015	normal squat cherry pie	4	good	Last Available: "2018-11"
-10016	drinkable fancy eggnog	3	good	Effect: "The Magic of Sharing", Effect Duration: 5, Last Available: "2018-11"
+10016	fancy drinkable eggnog	3	good	Effect: "The Magic of Sharing", Effect Duration: 5, Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	diet moldy Hell ramen	1	crappy	Last Available: "2018-11"
 10019	aged gimlet	3	awesome	Last Available: "2018-11"
-10020	practically non-alcoholic drinkable special twice-haunted screwdriver	1	good	Effect: "Black Lung", Effect Duration: 45, Last Available: "2018-11"
-10021	decent huge twirling candy cane	4	good	Last Available: "2018-12"
+10020	drinkable practically non-alcoholic special twice-haunted screwdriver	1	good	Effect: "Black Lung", Effect Duration: 45, Last Available: "2018-11"
+10021	decent twirling huge candy cane	4	good	Last Available: "2018-12"
 10022	mediocre narrow runny fermented egg	3	decent	Last Available: "2018-12"
 10023	normal small oldcake	2	good	Last Available: "2018-12"
 10024	toothsome big traditional Crimbo cookie	5	awesome	Last Available: "2023-06"
@@ -9899,21 +9899,21 @@
 10033	censurious pristine walrus tusk of the wise owl	0		Mysticality: +20, Sleaze Resistance: +3, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	ribald friendly sage Staff of Frozen Lard of horror	0		Mysticality Percent: +10, Familiar Weight: +3, Spooky Spell Damage: +25, Sleaze Damage: +10, Last Available: "2018-12"
-10036	huge maroon bomb	0		Last Available: "2018-12"
+10036	maroon huge bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	teal mooseflank	0		Last Available: "2018-12"
 10039	stale grilled mooseflank	3	decent	Last Available: "2018-12"
 10040	normal jumbo moosemeat pie	5	good	Last Available: "2018-12"
 10041	extremely unsafe balanced antler	0		Weapon Damage Percent: +100, Last Available: "2018-12"
 10042	dam of the boozehound	0		Booze Drop: +100, Damage Reduction: 9, Last Available: "2018-12"
-10043	acceptable weak pulsating beavermouth	2	good	Last Available: "2018-12"
+10043	weak acceptable pulsating beavermouth	2	good	Last Available: "2018-12"
 10044	mediocre practically non-alcoholic beaver punch (papaya)	1	decent	Last Available: "2018-12"
 10045	mediocre beaver punch (peach)	4	decent	Last Available: "2018-12"
 10046	hand-crafted squat beaver punch (cherry)	4	EPIC	Last Available: "2018-12"
 10047	teal gravedigger's Canadian lantern of the storm	0		Maximum MP Percent: +40, Spooky Damage: +10, Last Available: "2018-12"
 10048	cyan muskox-skin cap of the dark arts	0		Spell Damage Percent: +100, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	thick toothsome twirling glass of raw eggs	5	awesome	Last Available: "2018-12"
+10050	toothsome thick twirling glass of raw eggs	5	awesome	Last Available: "2018-12"
 10051	hand-crafted punch-drunk punch	4	EPIC	Last Available: "2018-12"
 10052	mixed body spradium	1		Effect: "Here's Mud in Your Eye", Effect Duration: 25, Last Available: "2018-12"
 10053	bauxite beret of the ox	0		Muscle: +20, Last Available: "2018-12"
@@ -9923,21 +9923,21 @@
 10057	upside-down Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	pulsating coward's mansplainer's Lo Pan's beefy Kramco Sausage-o-Matic&trade; of Gandalf	0		Muscle: +10, Spell Critical Percent: 50, Monster Level: -5, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	low-calorie rotten sausage	1	crappy	Last Available: "2019-01"
+10060	rotten low-calorie sausage	1	crappy	Last Available: "2019-01"
 10061	jittery asbestos-lined stanky red-hot sausage fork	0		Stench Spell Damage: +25, Hot Resistance: +5, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	irresponsibly strong smooth beer	7	awesome	Last Available: "2018-12"
+10066	smooth irresponsibly strong beer	7	awesome	Last Available: "2018-12"
 10067	flavorless bouncing yule gruel	3	decent	Last Available: "2018-12"
-10068	mediocre distilled red hot watered rum	5	decent	Last Available: "2018-12"
-10069	boozy smooth huge bottle of Crimbognac	5	awesome	Last Available: "2018-12"
+10068	distilled mediocre red hot watered rum	5	decent	Last Available: "2018-12"
+10069	smooth boozy huge bottle of Crimbognac	5	awesome	Last Available: "2018-12"
 10070	yummy Crimboysters Rockefeller	3	awesome	Last Available: "2018-12"
 10071	twisted cyan Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10074	shaking purple Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
+10074	purple shaking Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	upside-down Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	lime green Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	supercharged strapping marble mariachi hat	0		Muscle: +5, Maximum MP Percent: +30, Last Available: "2019-12"
 10096	distilled tumbling jittery marble molecules	1		Effect: "Okee-Dokee, Smokee", Effect Duration: 15, Last Available: "2019-12"
 10097	deionized Mallomarbles	0		Effect: "Strange Mental Acuity", Effect Duration: 52
-10098	purple asbestos-lined extremely unsafe punching bag	0		Weapon Damage Percent: +100, Hot Resistance: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	ghostly Van der Graaf pith helmet of bravery	0		Spooky Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	huge green therapeutic hale poncho	0		Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	lion tamer's pendant of Flo-Jo	0		Experience (familiar): +2, Initiative: +100, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	lime green miser's smartaleck's palazzos	0		Moxie Percent: +30, Meat Drop: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	friendly hale pseudoaccordion	0		Maximum HP: +20, Familiar Weight: +3, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	purple asbestos-lined extremely unsafe punching bag	0		Weapon Damage Percent: +100, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	ghostly Van der Graaf pith helmet of bravery	0		Spooky Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	huge green therapeutic hale poncho	0		Maximum HP: +20, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	lion tamer's pendant of Flo-Jo	0		Experience (familiar): +2, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	lime green miser's smartaleck's palazzos	0		Moxie Percent: +30, Meat Drop: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	friendly hale pseudoaccordion	0		Maximum HP: +20, Familiar Weight: +3, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	vaporized wobbly pieces	1		Last Available: "2020-12"
 10105	dry aerosolized skewed jittery Para-Pop	0		Effect: "Petit Force", Effect Duration: 66
-10106	censurious terra cotta truss of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	jittery savvy terra cotta trousers	0		Mysticality Percent: +20, Item Drop: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	flame-wreathed terra cotta tongs of the sweet-tooth	0		Hot Spell Damage: +10, Candy Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	teal occult terra cotta train of the sweet-tooth	0		Spell Damage Percent: +25, Candy Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	blinking therapeutic supercool terra cotta tie tack	0		Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	fireproof terra cotta tambourine of Gandalf	0		Spell Critical Percent: +20, Hot Resistance: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	censurious terra cotta truss of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	jittery savvy terra cotta trousers	0		Mysticality Percent: +20, Item Drop: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	flame-wreathed terra cotta tongs of the sweet-tooth	0		Hot Spell Damage: +10, Candy Drop: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	teal occult terra cotta train of the sweet-tooth	0		Spell Damage Percent: +25, Candy Drop: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	blinking therapeutic supercool terra cotta tie tack	0		Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	fireproof terra cotta tambourine of Gandalf	0		Spell Critical Percent: +20, Hot Resistance: +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	dehydrated blinking terra cotta tidbits	1		Effect: "The Style... of the Future", Effect Duration: 10, Last Available: "2020-12"
 10113	super-warmed dry twirling terra panna cotta	0		Effect: "Bubblin' Rage", Effect Duration: 20
 10114	velour voulge of the blizzard of Flo-Jo	0		Cold Spell Damage: +25, Initiative: +100, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	purple reassuring gravedigger's glass serape	0		Spooky Damage: +10, Spooky Resistance: +1, Last Available: "2021-12"
 10128	boiled maroon glass shards	1		Last Available: "2021-12"
 10129	ionized activated hard candy	0		Effect: "In the Saucestream", Effect Duration: 55
-10130	manspreader's veiny loofah lumberjack's hat	0		Maximum HP: +10, Monster Level: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	green shellacked arcane researcher's loofah lei	0		Experience Percent (Mysticality): +10, Damage Reduction: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	mirror Van der Graaf strapping loofah lederhosen	0		Muscle: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	fireproof manspreader's loofah ladle	0		Monster Level: +10, Hot Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	asbestos-lined groovy loofah legwarmers	0		Moxie Percent: +10, Hot Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	red toasty therapeutic loofah lavalier	0		Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	manspreader's veiny loofah lumberjack's hat	0		Maximum HP: +10, Monster Level: +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	green shellacked arcane researcher's loofah lei	0		Experience Percent (Mysticality): +10, Damage Reduction: 7, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	mirror Van der Graaf strapping loofah lederhosen	0		Muscle: +5, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	fireproof manspreader's loofah ladle	0		Monster Level: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	asbestos-lined groovy loofah legwarmers	0		Moxie Percent: +10, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	red toasty therapeutic loofah lavalier	0		Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	pickled loofah lumps	1		Last Available: "2022-12"
 10137	denatured chocolate-covered loofah	0		Effect: "For Your Brain Only", Effect Duration: 59
-10138	lightning-fast electrified flagstone flag	0		Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	deadly dance instructor's flagstone flail	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	wobbly fireproof Fonzie's flagstone flip-flops	0		Experience (Moxie): +1, Hot Resistance: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	electrified Samson's flagstone fez	0		Experience (Muscle): +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	bouncing clever flagstone fleece of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	energetic Da Vinci's flagstone fringe	0		Experience (Mysticality): +5, Maximum MP Percent: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	lightning-fast electrified flagstone flag	0		Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	deadly dance instructor's flagstone flail	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	wobbly fireproof Fonzie's flagstone flip-flops	0		Experience (Moxie): +1, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	electrified Samson's flagstone fez	0		Experience (Muscle): +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	bouncing clever flagstone fleece of temperance	0		Maximum MP: +20, Sleaze Resistance: +5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	energetic Da Vinci's flagstone fringe	0		Experience (Mysticality): +5, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	powdered twirling flagstone flagments	1		Effect: "Greasy Flavor", Effect Duration: 35, Last Available: "2022-12"
 10145	flattened concentrated purple Flag by the Foot&trade;	0		Effect: "Pronounced Potency", Effect Duration: 34
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10021,7 +10021,7 @@
 10155	moldy immense blurry elf army field rations	6	crappy	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	upside-down skewed green discarded bowtie of Tarzan of incineration	0		Experience (Muscle): +3, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2019-12"
-10158	bad enchanted martiny	3	decent	Effect: "Mistified", Effect Duration: 15, Last Available: "2019-12"
+10158	enchanted bad martiny	3	decent	Effect: "Mistified", Effect Duration: 15, Last Available: "2019-12"
 10159	huge tryptophan dart	0		Last Available: "2019-12"
 10160	liquefied lime green licorice snake	0		Effect: "Space Cowboy", Effect Duration: 32
 10161	ionized polarized blurry virgin jello shot	0		Effect: "Twen Tea", Effect Duration: 36
@@ -10029,17 +10029,17 @@
 10163	polymerized altered government-issued candy	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 33
 10164	boiled Pneumo bar	0		Effect: "Goldentongue", Effect Duration: 33
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	clever medical-grade Lil' Doctor&trade; bag	0		Maximum MP: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	clever medical-grade Lil' Doctor&trade; bag	0		Maximum MP: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	low-calorie delicious bloodstick	1	awesome	
-10170	weak mediocre bottle of Sanguiovese	2	decent	
+10170	mediocre weak bottle of Sanguiovese	2	decent	
 10171	stale actual blood sausage	3	decent	
-10172	mediocre practically non-alcoholic mulled blood	1	decent	
-10173	moldy gigantic red blood snowcone	7	crappy	
+10172	practically non-alcoholic mediocre mulled blood	1	decent	
+10173	gigantic moldy red blood snowcone	7	crappy	
 10174	perfectly mixed weak gray tumbling Red Russian	2	super ultra EPIC	
 10175	spoiled blood roll-up	3	crappy	
-10176	perfectly mixed weak shaking blinking olive bottle of blood	2	super ultra mega EPIC	
-10177	miniature special tasty blood-soaked sponge cake	2	awesome	Effect: "Melancholy Burden", Effect Duration: 50
+10176	weak perfectly mixed blinking shaking olive bottle of blood	2	super ultra mega EPIC	
+10177	miniature tasty special blood-soaked sponge cake	2	awesome	Effect: "Melancholy Burden", Effect Duration: 50
 10178	hand-crafted vampagne	3	super EPIC	
 10179	adequate mirror plain snowcone	4	good	
 10180	Booke of Vampyric Knowledge	0		
@@ -10078,7 +10078,7 @@
 10213	moldy wobbly hibiscus petal	3	crappy	Last Available: "2019-04"
 10214	corrupted wet quadruple-polarized blinking huge mint leaf	0		Effect: "Mistified", Effect Duration: 22, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
-10216	boiled squat shaking ice molecule	1		Last Available: "2019-04"
+10216	boiled shaking squat ice molecule	1		Last Available: "2019-04"
 10217	shaking Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
@@ -10087,7 +10087,7 @@
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	distilled skewed pewter shavings	1		Effect: "Carrrsmic", Effect Duration: 15, Last Available: "2019-04"
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
-10225	skewed blurry PirateRealm fun-a-log	0		Last Available: "2019-04"
+10225	blurry skewed PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	nippy plush sea serpent	0		Cold Damage: +10, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	flavorless pirate fork	3		Last Available: "2019-04"
 10228	upside-down green Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
@@ -10095,16 +10095,16 @@
 10230	banded piratical blunderbuss of chilblains	0		Damage Absorption: +100, Cold Damage: +25, Last Available: "2019-04"
 10231	twirling olive up-at-dawn Annie Oakley's studded PirateRealm party hat	0		Damage Absorption: +80, Critical Hit Percent: +20, Adventures: +5, Last Available: "2019-04"
 10232	tolerable weak upside-down Island Landslide	2	good	Last Available: "2019-04"
-10233	fortified drinkable Island Thunderstorm	5	good	Last Available: "2019-04"
+10233	drinkable fortified Island Thunderstorm	5	good	Last Available: "2019-04"
 10234	strong acceptable Island Hurricane	5	good	Last Available: "2019-04"
 10235	mediocre Skull Punch	3	decent	Last Available: "2019-04"
-10236	practically non-alcoholic smooth Electric Punch	1	awesome	Last Available: "2019-04"
+10236	smooth practically non-alcoholic Electric Punch	1	awesome	Last Available: "2019-04"
 10237	bad Smuggler's Punch	3	decent	Last Available: "2019-04"
-10238	boozy hand-crafted Scorpion Bowl	5	EPIC	Last Available: "2019-04"
-10239	enchanted irresponsibly strong mediocre bouncing spinning Turtle Bowl	9	decent	Effect: "Heart of Orange", Effect Duration: 20, Last Available: "2019-04"
+10238	hand-crafted boozy Scorpion Bowl	5	EPIC	Last Available: "2019-04"
+10239	enchanted mediocre irresponsibly strong spinning bouncing Turtle Bowl	9	decent	Effect: "Heart of Orange", Effect Duration: 20, Last Available: "2019-04"
 10240	artisanal mirror Cobra Bowl	4	EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	smelly Lo Pan's brainy vampyric cloake of the brute of the early riser	0		Mysticality: +5, Muscle Percent: +30, Spell Critical Percent: +30, Stench Spell Damage: +10, Adventures: +7, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	smelly Lo Pan's brainy vampyric cloake of the brute of the early riser	0		Mysticality: +5, Muscle Percent: +30, Spell Critical Percent: +30, Stench Spell Damage: +10, Adventures: +7, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	magnetized polymerized shaking one piece of bubble gum	0		Effect: "Enraged", Effect Duration: 65
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	ghostly blown-out speaker cone	0		
 10249	purple shaking overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	lightning-fast Oprah's Fourth of May Cosplay Saber of Leguizamo	0		Maximum MP Percent: +50, Monster Level: +20, Initiative: +40, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	lightning-fast Oprah's Fourth of May Cosplay Saber of Leguizamo	0		Maximum MP Percent: +50, Monster Level: +20, Initiative: +40, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	ghostly toasty friendly chaotic Tesla rosy-cheeked rock-hard grievous Socratic stylish hewn moon-rune spoon of Leguizamo of incineration	0		Moxie: +25, Experience (Mysticality): +1, Weapon Damage Percent: +50, Damage Reduction: 5, Maximum HP Percent: +30, Spell Critical Percent: +10, Monster Level: +20, Familiar Weight: +3, Hot Damage: +5, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	ghostly toasty friendly chaotic Tesla rosy-cheeked rock-hard grievous Socratic stylish hewn moon-rune spoon of Leguizamo of incineration	0		Moxie: +25, Experience (Mysticality): +1, Weapon Damage Percent: +50, Damage Reduction: 5, Maximum HP Percent: +30, Spell Critical Percent: +10, Monster Level: +20, Familiar Weight: +3, Hot Damage: +5, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	mirror coward's resourceful stiffened Beach Comb	0		Damage Reduction: 1, Maximum MP: +50, Monster Level: -20, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	mirror coward's resourceful stiffened Beach Comb	0		Damage Reduction: 1, Maximum MP: +50, Monster Level: -20, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	wobbly small pile of sand	0		Last Available: "2019-07"
 10261	ghostly pile of sand	0		Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	altered huge seashell	0		Effect: "Disco Concentration", Effect Duration: 37, Last Available: "2019-07"
 10270	alkaline adjusted seashell	0		Effect: "A View to Some Meat", Effect Duration: 28, Last Available: "2019-07"
 10271	green bunch of sea grapes	0		Last Available: "2019-07"
-10272	bad irresponsibly strong bottle of sea wine	6	decent	Last Available: "2019-07"
+10272	irresponsibly strong bad bottle of sea wine	6	decent	Last Available: "2019-07"
 10273	mixed kelp	1		Last Available: "2019-07"
 10274	fuchsia spinning rosewater-soaked Jack Frost's manspreader's occult smartaleck's Rosewater's brawny driftwood hat of Calamity Jane	0		Muscle Percent: +20, Mysticality Percent: +30, Moxie Percent: +30, Spell Damage Percent: +25, Critical Hit Percent: +15, Monster Level: +10, Cold Spell Damage: +50, Stench Resistance: +3, Item Drop: +5, Lasts Until Rollover, Last Available: "2019-07"
 10275	up-at-dawn Usain Bolt's auspicious Temple Grandin's vibrating studded experienced thinker's driftwood pants of Gandalf	0		Mysticality: +10, Experience: +2, Damage Absorption: +80, Maximum MP Percent: +10, Spell Critical Percent: +20, Familiar Weight: +7, Item Drop: +10, Initiative: +80, Adventures: +5, Lasts Until Rollover, Last Available: "2019-07"
@@ -10143,7 +10143,7 @@
 10278	shaking inspector's scorching manspreader's spearfish fishing spear	0		Monster Level: +10, Hot Damage: +25, Item Drop: +15, Last Available: "2019-07"
 10279	teal foul-smelling rabbitfish fin of Calamity Jane of the scaredy-cat	0		Critical Hit Percent: +15, Monster Level: -15, Stench Damage: +10, Single Equip, Last Available: "2019-07"
 10280	ghostly piece of coral	0		Last Available: "2019-07"
-10281	blurry upside-down gray piece of driftwood	0		Last Available: "2019-07"
+10281	upside-down gray blurry piece of driftwood	0		Last Available: "2019-07"
 10282	yellow toasty pirate cutlass of vim and vigor of terror	0		Maximum HP Percent: +50, Hot Damage: +5, Spooky Spell Damage: +10, Single Equip, Last Available: "2019-07"
 10283	spinning blue stanky wholesome tricorn hat of the ox	0		Muscle: +20, Maximum HP Percent: +10, Stench Spell Damage: +25, Last Available: "2019-07"
 10284	nippy stiffened Newton's swash buckle	0		Experience (Mysticality): +3, Damage Reduction: 1, Cold Damage: +10, Single Equip, Last Available: "2019-07"
@@ -10165,10 +10165,10 @@
 10300	lime green manspreader's sage whittled owl figurine of the blizzard	0		Mysticality Percent: +10, Monster Level: +10, Cold Spell Damage: +25, Single Equip, Last Available: "2019-08"
 10301	narrow perfumed clever therapeutic whittled fox figurine	0		Maximum MP: +20, Stench Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-08"
 10302	blinking lion tamer's sharpshooter's weightlifter's whittled walking stick of mayonnaise	0		Muscle: +15, Critical Hit Percent: +10, Experience (familiar): +2, Sleaze Spell Damage: +50, Last Available: "2019-08"
-10303	normal tiny campfire hot dog	1	good	Last Available: "2019-08"
+10303	tiny normal campfire hot dog	1	good	Last Available: "2019-08"
 10304	flavorless massive campfire baked potato	6	decent	Last Available: "2019-08"
 10305	spoiled campfire s'more	3	crappy	Last Available: "2019-08"
-10306	stale special wobbly campfire beans	3	decent	Effect: "Kissed By Fire", Effect Duration: 20, Last Available: "2019-08"
+10306	special stale wobbly campfire beans	3	decent	Effect: "Kissed By Fire", Effect Duration: 20, Last Available: "2019-08"
 10307	moldy miniature campfire stew	2	crappy	Last Available: "2019-08"
 10308	twirling twirling campfire coffee	1	EPIC	Last Available: "2019-08"
 10309	frozen polymerized leftover chocolate bar	0		Effect: "Stenchtastic", Effect Duration: 24
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	blinking Thwaitgold bombardier beetle statuette	0		
 10320	decent space chowder	3	good	
-10321	acceptable distilled enchanted space wine	5	good	Effect: "Blood-Rich", Effect Duration: 20
+10321	distilled acceptable enchanted space wine	5	good	Effect: "Blood-Rich", Effect Duration: 20
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	normal miniature bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
 10338	immense normal ghostly flan del mar	7	good	Last Available: "2019-12"
-10339	thick moldy Baja sopapilla	5	crappy	Last Available: "2019-12"
+10339	moldy thick Baja sopapilla	5	crappy	Last Available: "2019-12"
 10340	upside-down plastic Mer-kin baker of doom	0		Spooky Spell Damage: +50, Last Available: "2019-12"
 10341	cyan personal trainer's plastic sea elf	0		Experience Percent (Muscle): +10, Last Available: "2019-12"
 10342	sharpshooter's plastic yuleviathan	0		Critical Hit Percent: +10, Last Available: "2019-12"
@@ -10214,13 +10214,13 @@
 10355	pickled a bug's lymph	1		Effect: "Cold Blooded", Effect Duration: 10, Last Available: "2019-12"
 10356	double-quantum deionized organic potpourri	0		Effect: "Thickest, Sickest", Effect Duration: 68, Last Available: "2019-12"
 10357	drinkable boot flask	3	good	Last Available: "2019-12"
-10358	altered liquefied shaking pulsating infernal snowball	0		Effect: "Lemony Goodness", Effect Duration: 11, Last Available: "2019-12"
+10358	altered liquefied pulsating shaking infernal snowball	0		Effect: "Lemony Goodness", Effect Duration: 11, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	compressed fish sauce	1		Last Available: "2019-12"
 10361	flavorless diet guffin	1	decent	Last Available: "2019-12"
 10362	pickled mirror Shantix&trade;	1		Last Available: "2019-12"
 10363	cyan goodberry	0		Last Available: "2019-12"
-10364	boiled spinning squat non-Euclidean angle	1		Last Available: "2019-12"
+10364	boiled squat spinning non-Euclidean angle	1		Last Available: "2019-12"
 10365	frozen ionized peppermint syrup	0		Effect: "Alchemical, Brother", Effect Duration: 19, Last Available: "2019-12"
 10366	moist Mer-kin eyedrops	0		Effect: "Heart of White", Effect Duration: 23, Last Available: "2019-12"
 10367	activated corrupted extra-strength goo	0		Effect: "You're Rubber", Effect Duration: 22, Last Available: "2019-12"
@@ -10255,7 +10255,7 @@
 10396	tinsel fin	0		Familiar Weight: +5
 10397	bland half-sized green bowl of mernudo	2	decent	Last Available: "2019-12"
 10398	enchanted smooth practically non-alcoholic fishelada	1	awesome	Effect: "Mistified", Effect Duration: 40, Last Available: "2019-12"
-10399	moldy massive ojo de pez burrito	8	crappy	Last Available: "2019-12"
+10399	massive moldy ojo de pez burrito	8	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	narrow teal waterlogged stuffing	0		Last Available: "2019-12"
@@ -10288,11 +10288,11 @@
 10429	super-activated handful of mixed nuts	0		Effect: "Norwhalloped", Effect Duration: 28, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	ghostly knitted smelly Tesla Retrospecs	0		Stench Spell Damage: +10, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	ghostly knitted smelly Tesla Retrospecs	0		Stench Spell Damage: +10, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	spinning maroon unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	cyan Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	spinning mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	avaricious auspicious boxer's weightlifter's Powerful Glove of mayonnaise	0		Muscle: +15, Muscle Percent: +10, Sleaze Spell Damage: +50, Item Drop: +10, Meat Drop: +30, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	avaricious auspicious boxer's weightlifter's Powerful Glove of mayonnaise	0		Muscle: +15, Muscle Percent: +10, Sleaze Spell Damage: +50, Item Drop: +10, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	bouncing status cymbal	0		Last Available: "2020-02"
 10441	mansplainer's fortified experienced Drip harness	0		Experience: +2, Damage Absorption: +60, Monster Level: +15
@@ -10331,22 +10331,22 @@
 10474	enhanced blooper ink	0		Effect: "Man's Worst Enemy", Effect Duration: 42
 10475	coin	0		
 10476	rubber doll head	0		
-10477	spinning maroon rubber doll body	0		
+10477	maroon spinning rubber doll body	0		
 10478	squat plastic doll arms	0		
-10479	pulsating olive plastic doll legs	0		
+10479	olive pulsating plastic doll legs	0		
 10480	rubber baby doll	0		
 10481	Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	blinking packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	pulsating bulky free-range mushroom	0		Last Available: "2020-03"
-10486	blinking shaking free-range mushroom	0		Last Available: "2020-03"
+10486	shaking blinking free-range mushroom	0		Last Available: "2020-03"
 10487	upside-down immense free-range mushroom	0		Last Available: "2020-03"
-10488	ghostly narrow colossal free-range mushroom	0		Last Available: "2020-03"
-10489	adequate low-calorie mushroom filet	1	good	Last Available: "2020-03"
+10488	narrow ghostly colossal free-range mushroom	0		Last Available: "2020-03"
+10489	low-calorie adequate mushroom filet	1	good	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
-10491	compressed blinking bouncing fuchsia mushroom tea	1		Last Available: "2020-03"
-10492	artisanal weak upside-down mushroom whiskey	2	EPIC	Last Available: "2020-03"
+10491	compressed bouncing fuchsia blinking mushroom tea	1		Last Available: "2020-03"
+10492	weak artisanal upside-down mushroom whiskey	2	EPIC	Last Available: "2020-03"
 10493	arcane researcher's mushroom cap of the storm of extreme caution	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +40, Monster Level: -25, Last Available: "2020-03"
 10494	horrifying Lo Pan's stylish mushroom shield of vim and vigor	0		Moxie: +25, Maximum HP Percent: +50, Spell Critical Percent: +30, Spooky Damage: +25, Damage Reduction: 6, Last Available: "2020-03"
 10495	reassuring knitted dog trainer's sage mushroom pants	0		Mysticality Percent: +10, Experience (familiar): +1, Cold Resistance: +3, Spooky Resistance: +1, Last Available: "2020-03"
@@ -10395,7 +10395,7 @@
 10539	fireproof Guzzlr souvenir stein	0		Hot Resistance: +3, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	perfectly mixed enchanted Ghiaccio Colada	3	EPIC	Effect: "On the Trolley", Effect Duration: 20, Last Available: "2020-05"
-10542	weak drinkable Sourfinger	2	good	Last Available: "2020-05"
+10542	drinkable weak Sourfinger	2	good	Last Available: "2020-05"
 10543	high-proof mediocre tumbling Nog-on-the-Cob	6	decent	Last Available: "2020-05"
 10544	enchanted tolerable Steamboat	4	good	Effect: "Nut-Rition", Effect Duration: 20, Last Available: "2020-05"
 10545	lousy Buttery Boy	3	decent	Last Available: "2020-05"
@@ -10438,11 +10438,11 @@
 10582	mirror SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	skewed flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	scandalous smartaleck's birch battery	0		Moxie Percent: +30, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2020-08"
-10585	pulsating horrifying careful slick ebony epee	0		Moxie: +10, Monster Level: -10, Spooky Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	family-friendly Lo Pan's rock-hard weeping willow wand	0		Damage Reduction: 5, Spell Critical Percent: +30, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	veiny beechwood blowgun of Calamity Jane of terror	0		Maximum HP: +10, Critical Hit Percent: +15, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	pulsating horrifying careful slick ebony epee	0		Moxie: +10, Monster Level: -10, Spooky Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	family-friendly Lo Pan's rock-hard weeping willow wand	0		Damage Reduction: 5, Spell Critical Percent: +30, Sleaze Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	veiny beechwood blowgun of Calamity Jane of terror	0		Maximum HP: +10, Critical Hit Percent: +15, Spooky Spell Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	shaking aromatic sizzling thinker's maple magnet	0		Mysticality: +10, Hot Damage: +10, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2020-08"
-10589	squat olive Dreadsylvanian hemlock	0		Last Available: "2020-08"
+10589	olive squat Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	jittery jittery veiny hemlock helm of dire peril of temperance	0		Weapon Damage: +20, Maximum HP: +10, Sleaze Resistance: +5, Last Available: "2020-08"
 10591	blurry sweaty balsam	0		Last Available: "2020-08"
 10592	Jack Frost's balsam barrel of the cougar of temperance	0		Moxie: +20, Cold Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2020-08"
@@ -10456,7 +10456,7 @@
 10600	drippy diadem	0		Last Available: "2020-08"
 10601	skewed Thwaitgold slug statuette	0		
 10602	ert grey goo ring of the brazier	0		Hot Spell Damage: +25
-10603	narrow bouncing fistful of wood shavings	0		
+10603	bouncing narrow fistful of wood shavings	0		
 10604	blinking Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	moist improved ghostly Yeg's Motel toothbrush	0		Effect: "Human-Hippy Hybrid", Effect Duration: 34, Last Available: "2020-09"
@@ -10485,7 +10485,7 @@
 10629	alabaster king	0		Last Available: "2020-09"
 10630	spinning alabaster queen	0		Last Available: "2020-09"
 10631	alabaster rook	0		Last Available: "2020-09"
-10632	ghostly maroon alabaster bishop	0		Last Available: "2020-09"
+10632	maroon ghostly alabaster bishop	0		Last Available: "2020-09"
 10633	squat alabaster knight	0		Last Available: "2020-09"
 10634	skewed alabaster pawn	0		Last Available: "2020-09"
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
@@ -10495,8 +10495,8 @@
 10639	auspicious knitted boxer's sea-worn candlestick	0		Muscle Percent: +10, Cold Resistance: +3, Item Drop: +10, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	ionized narrow null-day exploit	0		Effect: "Medieval Mage Mayhem", Effect Duration: 69, Last Available: "2025-12"
-10642	purple ghostly flame orb	0		Last Available: "2020-09"
-10643	big decent skewed narrow chocolate chip muffin	5	good	
+10642	ghostly purple flame orb	0		Last Available: "2020-09"
+10643	decent big narrow skewed chocolate chip muffin	5	good	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	blinking packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10524,7 +10524,7 @@
 10668	plastic Mirth of the brazier	0		Hot Spell Damage: +25, Last Available: "2020-12"
 10669	Lo Pan's plastic Penny	0		Spell Critical Percent: +30, Last Available: "2020-12"
 10670	overflowing gift basket	0		Last Available: "2020-12"
-10671	mirror shaking personalized wassail stein	0		Last Available: "2020-12"
+10671	shaking mirror personalized wassail stein	0		Last Available: "2020-12"
 10672	olive tabletop candy dispenser	0		Last Available: "2020-12"
 10673	shellacked neck wreath	0		Damage Reduction: [7*event(December)], Single Equip, Last Available: "2020-12"
 10674	upside-down shining star cap of the brute	0		Muscle Percent: [+30*event(December)], Last Available: "2020-12"
@@ -10536,9 +10536,9 @@
 10680	perfumed wine carrier	0		Stench Resistance: +5, Lasts Until Rollover, Last Available: "2020-12"
 10681	ghostly lion tamer's candy bucket	0		Experience (familiar): +2, Lasts Until Rollover, Last Available: "2020-12"
 10682	extra-colloidal diffused prescription teeth whitener	0		Effect: "Radiant Personality", Effect Duration: 65, Last Available: "2020-12"
-10683	double-pickled altered maroon pulsating imported lemon lozenge	0		Effect: "Hippy Flavor", Effect Duration: 21, Last Available: "2020-12"
+10683	double-pickled altered pulsating maroon imported lemon lozenge	0		Effect: "Hippy Flavor", Effect Duration: 21, Last Available: "2020-12"
 10684	dry hermedisiac cologne	0		Effect: "Medieval Mage Mayhem", Effect Duration: 19, Last Available: "2020-12"
-10685	twirling purple government food shipment	0		Last Available: "2020-12"
+10685	purple twirling government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	huge government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
@@ -10559,50 +10559,50 @@
 10703	The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	skewed The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10705	The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
-10706	bouncing pulsating The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+10706	pulsating bouncing The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	wobbly The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
-10708	upside-down upside-down fuchsia The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
+10708	upside-down fuchsia upside-down The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10709	The Night Before Crimbo, Ch. 4	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10710	blurry The Night Before Crimbo, Ch. 4 (used)	0		Skill: "Eye and a Twist", Last Available: "2020-12"
 10711	tumbling The Night Before Crimbo, Ch. 5	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	spoiled fancy big squat and pepper (stale)	5	crappy	Effect: "Corruption of Wretched Wally", Effect Duration: 50, Last Available: "2020-12"
+10715	big spoiled fancy squat and pepper (stale)	5	crappy	Effect: "Corruption of Wretched Wally", Effect Duration: 50, Last Available: "2020-12"
 10716	bad watered-down cyan cranberry margarita (brackish)	2	decent	Last Available: "2020-12"
 10717	blurry fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
-10718	blue tumbling nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
+10718	tumbling blue nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	narrow goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	acceptable barrel-aged eggnog	4	good	Last Available: "2020-12"
 10721	rotten narrow hand-crafted candy cane	3	crappy	Last Available: "2020-12"
-10722	rotten thick drive-thru burger	5	crappy	Last Available: "2020-12"
-10723	practically non-alcoholic acceptable gray Boulevardier cocktail	1	good	Last Available: "2020-12"
+10722	thick rotten drive-thru burger	5	crappy	Last Available: "2020-12"
+10723	acceptable practically non-alcoholic gray Boulevardier cocktail	1	good	Last Available: "2020-12"
 10724	moist altered Hotwire&trade; brand candy rope	0		Effect: "Insatiable Hunger", Effect Duration: 18, Last Available: "2020-12"
 10725	snack-sized normal narrow bowl full of jelly	2	good	Last Available: "2020-12"
-10726	tolerable special Eye and a Twist	3	good	Effect: "Glo-Face", Effect Duration: 5, Last Available: "2020-12"
+10726	special tolerable Eye and a Twist	3	good	Effect: "Glo-Face", Effect Duration: 5, Last Available: "2020-12"
 10727	pressed Chubby and Plump bar	0		Effect: "Frozen Shoulders", Effect Duration: 35, Last Available: "2020-12"
 10728	wobbly digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	cyan upside-down emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	upside-down cyan emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	red robo-battery	0		
 10736	teal Thwaitgold listening bug statuette	0		
 10737	wobbly power seed	0		Free Pull, Last Available: "2021-03"
 10738	blue potted power plant	0		Last Available: "2021-03"
 10739	quantum double-polymerized cyan battery (AAA)	0		Effect: "Bat Attitude", Effect Duration: 47, Last Available: "2021-03"
-10740	moist teal bouncing battery (AA)	0		Effect: "Greasy Visage", Effect Duration: 65, Last Available: "2021-03"
+10740	moist bouncing teal battery (AA)	0		Effect: "Greasy Visage", Effect Duration: 65, Last Available: "2021-03"
 10741	colloidal shaking battery (D)	0		Effect: "Grrrrrrreat!", Effect Duration: 61, Last Available: "2021-03"
 10742	polarized green battery (9-Volt)	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 68, Last Available: "2021-03"
 10743	dry spinning battery (lantern)	0		Effect: "Souper Vengeful", Effect Duration: 57, Last Available: "2021-03"
 10744	cold-filtered deionized battery (car)	0		Effect: "Elemental Saucesphere", Effect Duration: 32, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	smooth enchanted marshmallow bomb	4	awesome	Effect: "Nano-juiced", Effect Duration: 35, Last Available: "2021-03"
+10747	enchanted smooth marshmallow bomb	4	awesome	Effect: "Nano-juiced", Effect Duration: 35, Last Available: "2021-03"
 10748	mirror packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	skewed wobbly shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	pressed frozen short beer	0		Effect: "Tingly Biceps", Effect Duration: 31, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	moist irradiated skewed short	0		Effect: "Frostbeard", Effect Duration: 50, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	twirling quantum of familiar	0		
-10759	blinking weightlifter's familiar scrapbook of the brute	0		Muscle: +15, Muscle Percent: +30, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	blinking weightlifter's familiar scrapbook of the brute	0		Muscle: +15, Muscle Percent: +30, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	horrifying chaotic Fonzie's fedora-mounted fountain	0		Experience (Moxie): +1, Spell Critical Percent: +10, Spooky Damage: +25, Lasts Until Rollover, Last Available: "2021-07"
@@ -10637,7 +10637,7 @@
 10781	nasty novelty sparkling candle of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Item Drop: +5, Lasts Until Rollover, Last Available: "2021-08"
 10782	flame-retardant quilted Abracandalabra	0		Damage Absorption: +40, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
 10783	mansplainer's grievous extra-wide head candle	0		Weapon Damage Percent: +50, Monster Level: +15, Lasts Until Rollover, Last Available: "2021-08"
-10784	alkaline blinking cyan natural magick candle	0		Effect: "Minerva's Zen", Effect Duration: 28, Last Available: "2021-08"
+10784	alkaline cyan blinking natural magick candle	0		Effect: "Minerva's Zen", Effect Duration: 28, Last Available: "2021-08"
 10785	deionized adjusted blurry rainbow glitter candle	0		Effect: "Fancy Feasted", Effect Duration: 15, Last Available: "2021-08"
 10786	modified quadruple-quantum banana candle	0		Effect: "Turkey-Agitated", Effect Duration: 12, Last Available: "2021-08"
 10787	double-warmed ear candle	0		Effect: "Pie in the Sky", Effect Duration: 34, Last Available: "2021-08"
@@ -10650,8 +10650,8 @@
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	bouncing gravedigger's nasty friendly stiffened dance instructor's industrial fire extinguisher of the blizzard	0		Experience Percent (Moxie): +10, Damage Reduction: 1, Familiar Weight: +3, Cold Spell Damage: +25, Stench Damage: +5, Spooky Damage: +10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
-10798	squat fuchsia The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
+10797	bouncing gravedigger's nasty friendly stiffened dance instructor's industrial fire extinguisher of the blizzard	0		Experience Percent (Moxie): +10, Damage Reduction: 1, Familiar Weight: +3, Cold Spell Damage: +25, Stench Damage: +5, Spooky Damage: +10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10798	fuchsia squat The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	tumbling The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
@@ -10661,7 +10661,7 @@
 10805	eggwater	1	decent	Last Available: "2021-12"
 10806	rotten bread man	3	crappy	Last Available: "2021-12"
 10807	yummy plain candy cane	3	awesome	Last Available: "2021-12"
-10808	miniature bland flour cookie	2	decent	Last Available: "2021-12"
+10808	bland miniature flour cookie	2	decent	Last Available: "2021-12"
 10809	plastic food lab of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2021-12"
 10810	extremely unsafe plastic nog lab	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2021-12"
 10811	thinker's plastic chem lab	0		Mysticality: +10, Single Equip, Last Available: "2021-12"
@@ -10673,14 +10673,14 @@
 10817	jittery friendly Samson's strapping jeans	0		Muscle: +5, Experience (Muscle): +5, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2021-12"
 10818	electrified ice wrap of terror of horror	0		Spooky Spell Damage: 35, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	flavorless fuchsia tofu pop	3	decent	Last Available: "2021-12"
-10820	toothsome jumbo fuchsia bowl of prescription candy	5	awesome	Last Available: "2021-12"
+10820	jumbo toothsome fuchsia bowl of prescription candy	5	awesome	Last Available: "2021-12"
 10821	adequate blurry fishcake	4	good	Last Available: "2021-12"
 10822	flavorless small bone broth	2	decent	Last Available: "2021-12"
-10823	big spoiled enchanted star pop	5	crappy	Effect: "Flower Power", Effect Duration: 20, Last Available: "2021-12"
+10823	enchanted big spoiled star pop	5	crappy	Effect: "Flower Power", Effect Duration: 20, Last Available: "2021-12"
 10824	hand-crafted extra-dry upside-down Doc's Fortifying Wine	5	EPIC	Last Available: "2021-12"
-10825	watered-down lousy Doc's Smartifying Wine	2	decent	Last Available: "2021-12"
-10826	acceptable weak Doc's Limbering Wine	2	good	Last Available: "2021-12"
-10827	tolerable triple-distilled Doc's Medical-Grade Wine	7	good	Last Available: "2021-12"
+10825	lousy watered-down Doc's Smartifying Wine	2	decent	Last Available: "2021-12"
+10826	weak acceptable Doc's Limbering Wine	2	good	Last Available: "2021-12"
+10827	triple-distilled tolerable Doc's Medical-Grade Wine	7	good	Last Available: "2021-12"
 10828	mixed Homebodyl&trade;	1		Last Available: "2021-12"
 10829	dried gray Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	diluted Breathitin&trade;	1		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	blurry cozy scarf of doom	0		Spooky Spell Damage: +50, Last Available: "2021-12"
-10852	tasty immense huge Crimbo cookie	6	awesome	Last Available: "2023-06"
+10852	immense tasty huge Crimbo cookie	6	awesome	Last Available: "2023-06"
 10853	galvanized pulsating fleshy putty	0		Effect: "Wet and Greedy", Effect Duration: 48, Last Available: "2021-12"
 10854	reassuring third ear	0		Spooky Resistance: +1, Single Equip, Last Available: "2021-12"
 10855	jittery festive egg sac	0		Last Available: "2021-12"
@@ -10715,10 +10715,10 @@
 10859	olive projectile chemistry set	0		Last Available: "2021-12"
 10860	upside-down blue extremely unsafe depleted Crimbonium football helmet	0		Weapon Damage Percent: +100, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	special normal low-calorie &quot;caramel&quot;	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 15, Last Available: "2021-12"
+10862	special low-calorie normal &quot;caramel&quot;	1	good	Effect: "The Power of Positive Thinking", Effect Duration: 15, Last Available: "2021-12"
 10863	Temple Grandin's self-repairing earmuffs	0		Familiar Weight: +7, Last Available: "2021-12"
 10864	mirror carnivorous potted plant of bravery	0		Spooky Resistance: +5, Last Available: "2021-12"
-10865	jittery fuchsia shaking universal biscuit	0		Last Available: "2021-12"
+10865	jittery shaking fuchsia universal biscuit	0		Last Available: "2021-12"
 10866	electrified yule hatchet	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2021-12"
 10867	blinking potato alarm clock	0		Last Available: "2021-12"
 10868	normal bouncing lab-grown meat	4	good	Last Available: "2021-12"
@@ -10736,12 +10736,12 @@
 10880	boiled pulsating fried air	1		Effect: "A Taste of Rainbow", Effect Duration: 25, Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	wobbly carton of astral energy drinks	0		
-10883	diluted shaking huge astral energy drink	1		
+10883	diluted huge shaking astral energy drink	1		
 10884	spinning mint condition magnifying glass	0		Last Available: "2022-12"
 10885	MacGyver's dance instructor's Socratic magnifying glass	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Maximum MP: +100, Last Available: "2022-12"
 10886	hand-crafted distilled shaking void lager	5	EPIC	Last Available: "2022-12"
 10887	low-calorie rotten squat void burger	1	crappy	Last Available: "2022-12"
-10888	red blurry void stone	0		Last Available: "2022-12"
+10888	blurry red void stone	0		Last Available: "2022-12"
 10889	hale wicked beefcake's void shard of the empath	0		Muscle: +25, Spell Damage: +5, Maximum HP: +20, Familiar Weight: +5, Last Available: "2022-12"
 10890	wobbly undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	bouncing cosmic bowling ball	0		Last Available: "2022-01"
@@ -10754,8 +10754,8 @@
 10898	undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	fireproof personal trainer's unbreakable umbrella (broken) of the pedagogue of the sewer	0		Experience: +3, Experience Percent (Muscle): +10, Stench Damage: +25, Hot Resistance: +3
 10900	spinning MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
-10901	spinning narrow MayDay&trade; supply package	0		Last Available: "2022-05"
-10902	alkaline jittery fuchsia emergency glowstick	0		Effect: "Biologically Shocked", Effect Duration: 51, Last Available: "2022-05"
+10901	narrow spinning MayDay&trade; supply package	0		Last Available: "2022-05"
+10902	alkaline fuchsia jittery emergency glowstick	0		Effect: "Biologically Shocked", Effect Duration: 51, Last Available: "2022-05"
 10903	mirror bouncing survival knife of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Last Available: "2022-05"
 10904	mirror crank-powered radio on a lanyard of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-05"
 10905	headlamp of Leguizamo	0		Monster Level: +20, Lasts Until Rollover, Last Available: "2022-05"
@@ -10767,7 +10767,7 @@
 10911	enhanced skewed gaffer's tape	0		Effect: "Browbeaten", Effect Duration: 30, Last Available: "2022-05"
 10912	spoiled 20-lb can of rice and beans	3	crappy	Last Available: "2022-05"
 10913	special bar of freeze-dried water	1	crappy	Effect: "Deadly Lampblade", Effect Duration: 5, Last Available: "2022-05"
-10914	special normal expired MRE	4	good	Effect: "Coming Up Roses", Effect Duration: 50, Last Available: "2022-05"
+10914	normal special expired MRE	4	good	Effect: "Coming Up Roses", Effect Duration: 50, Last Available: "2022-05"
 10915	low-calorie spoiled blinking cool mint precipice bar	1	crappy	Last Available: "2022-05"
 10916	moldy carrot cake precipice bar	4	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
@@ -10782,7 +10782,7 @@
 10926	wet nitrogenated trampled ticket stub	0		Effect: "Virgo Rising", Effect Duration: 32, Last Available: "2022-06"
 10927	extra-polymerized nitrogenated twirling savings bond	0		Effect: "Orchid Blood", Effect Duration: 31, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
 10930	diluted maroon sweat-ade	1		Last Available: "2022-07"
 10931	blue unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10805,7 +10805,7 @@
 10949	Annie Oakley's dinosaur	0		Critical Hit Percent: +20
 10950	blurry Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	steel-toed beefy Jurassic Parka	0		Muscle: +10, Damage Reduction: 9, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	steel-toed beefy Jurassic Parka	0		Muscle: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	irradiated autumn leaf	0		Effect: "Gunky Dory", Effect Duration: 42, Last Available: "2022-10"
@@ -10816,7 +10816,7 @@
 10960	polarized autumn dollar	0		Effect: "Jawin'", Effect Duration: 68, Last Available: "2022-10"
 10961	arcane researcher's autumn leaf pendant of chilblains of bravery	0		Experience Percent (Mysticality): +10, Cold Damage: +25, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2022-10"
 10962	powdered mirror autumn breeze	1		Last Available: "2022-10"
-10963	energized shaking jittery autumn years wisdom	0		Effect: "Thought", Effect Duration: 56, Last Available: "2022-10"
+10963	energized jittery shaking autumn years wisdom	0		Effect: "Thought", Effect Duration: 56, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	practically non-alcoholic tolerable Oopsie IPA	1	good	Last Available: "2022-10"
 10966	blue mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
@@ -10826,34 +10826,34 @@
 10970	diet normal ratatouille de Jarlsberg	1	good	Last Available: "2022-11"
 10971	normal Jarlsberg's vegetable soup	4	good	Last Available: "2022-11"
 10972	spoiled tumbling roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
-10973	immense normal jittery St. Pete's sneaky smoothie	9	good	Last Available: "2022-11"
+10973	normal immense jittery St. Pete's sneaky smoothie	9	good	Last Available: "2022-11"
 10974	super-sized fancy adequate Pete's wiley whey bar	5	good	Effect: "Strong Spirit", Effect Duration: 45, Last Available: "2022-11"
 10975	tiny adequate bouncing Pete's rich ricotta	1	good	Last Available: "2022-11"
 10976	hand-crafted high-proof Boris's beer	9	EPIC	Last Available: "2022-11"
-10977	special decent honey bun of Boris	4	good	Effect: "Elron's Explosive Etude", Effect Duration: 50, Last Available: "2022-11"
+10977	decent special honey bun of Boris	4	good	Effect: "Elron's Explosive Etude", Effect Duration: 50, Last Available: "2022-11"
 10978	stale Boris's bread	4	decent	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	blurry Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	pulsating Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	narrow Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	gray Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	blurry Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	pulsating Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	narrow Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	gray Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	flavorless baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
 10989	delicious plain calzone	4	awesome	Last Available: "2022-11"
-10990	super-sized normal wobbly roasted vegetable focaccia	5	good	Last Available: "2022-11"
+10990	normal super-sized wobbly roasted vegetable focaccia	5	good	Last Available: "2022-11"
 10991	toothsome Pizza of Legend	4	awesome	Last Available: "2022-11"
 10992	bland Calzone of Legend	3	decent	Last Available: "2022-11"
-10993	upside-down Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	skewed Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	upside-down Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	skewed Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	huge cookbookbat book	0		Familiar Weight: +5
-10999	blue Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	adequate big Deep Dish of Legend	5	good	Last Available: "2022-11"
+10999	blue Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	big adequate Deep Dish of Legend	5	good	Last Available: "2022-11"
 11001	squat deed to Oliver's Place	0		Free Pull
 11002	pulsating drink chit	0		
 11003	squat government per-diem	0		
@@ -10867,18 +10867,18 @@
 11011	wobbly clever gator shades of the storm	0		Maximum MP Percent: +40, Maximum MP: +20, Single Equip
 11012	milk cap	0		
 11013	tolerable Charleston Choo-Choo	4	good	
-11014	weak hand-crafted narrow Velvet Veil	2	EPIC	
+11014	hand-crafted weak narrow Velvet Veil	2	EPIC	
 11015	bad Marltini	3	decent	
 11016	artisanal Strong, Silent Type	3	EPIC	
 11017	bad Mysterious Stranger	3	decent	
-11018	hand-crafted watered-down squat Champagne Shimmy	2	EPIC	
+11018	watered-down hand-crafted squat Champagne Shimmy	2	EPIC	
 11019	twirling twirling the Sot's parcel	0		
-11020	Samson's ceramic cestus of doom	0		Experience (Muscle): +5, Spooky Spell Damage: +50, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	bouncing avaricious greedy ceramic centurion shield of the wise owl	0		Mysticality: +20, Meat Drop: 50, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	ceramic celery grater of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	energetic smartaleck's brawny ceramic celsiturometer	0		Muscle Percent: +20, Moxie Percent: +30, Maximum MP Percent: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	yellow sizzling chaotic ceramic cerecloth belt of the ox	0		Muscle: +20, Spell Critical Percent: +10, Hot Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	miser's veiny slick ceramic cenobite's robe	0		Moxie: +10, Maximum HP: +10, Meat Drop: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	Samson's ceramic cestus of doom	0		Experience (Muscle): +5, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	bouncing avaricious greedy ceramic centurion shield of the wise owl	0		Mysticality: +20, Meat Drop: 50, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	ceramic celery grater of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	energetic smartaleck's brawny ceramic celsiturometer	0		Muscle Percent: +20, Moxie Percent: +30, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	yellow sizzling chaotic ceramic cerecloth belt of the ox	0		Muscle: +20, Spell Critical Percent: +10, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	miser's veiny slick ceramic cenobite's robe	0		Moxie: +10, Maximum HP: +10, Meat Drop: +10, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	dehydrated twirling ceramic scree	1		Effect: "All Is Forgiven", Effect Duration: 35, Last Available: "2023-12"
 11027	super-tarnished energized extra-hard jawbreaker	0		Effect: "On the Trolley", Effect Duration: 56
 11028	foul-smelling beefcake's chiffon chevrons of the empath	0		Muscle: +25, Familiar Weight: +5, Stench Damage: +10, Single Equip, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	Van der Graaf supercharged supercool chiffon chaps	0		Moxie Percent: +20, Maximum MP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11034	diluted huge chiffon carbage	1		Effect: "Full of Wist", Effect Duration: 20, Last Available: "2023-12"
 11035	vacuum-sealed blinking chiffon lemon	0		Effect: "So You Can Work More...", Effect Duration: 21
-11036	miniature bland chocomotive	2	decent	Last Available: "2022-12"
+11036	bland miniature chocomotive	2	decent	Last Available: "2022-12"
 11037	rotten shaking freightcake	3	crappy	Last Available: "2022-12"
 11038	perfectly mixed cabooze	4	EPIC	Last Available: "2022-12"
 11039	olive plastic caboose	0		Last Available: "2022-12"
@@ -10935,9 +10935,9 @@
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	purple steam unit	0		Last Available: "2022-12"
-11082	bouncing wobbly crystal Crimbo goblet	0		
+11082	wobbly bouncing crystal Crimbo goblet	0		
 11083	squat crystal Crimbo platter	0		
-11084	hand-crafted strong Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
+11084	strong hand-crafted Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
 11085	flavorless Crimbo dinner	4	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	blinking train whistle	0		Last Available: "2022-12"
@@ -10956,7 +10956,7 @@
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
 11102	powdered fruity pebble	1		Last Available: "2023-01"
-11103	tumbling teal shaking lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
+11103	shaking teal tumbling lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	huge molehill mountain	0		Last Available: "2023-01"
@@ -10974,14 +10974,14 @@
 11119	double-galvanized improved activated huge five-fingered fern resin	0		Effect: "Cold Hard Skin", Effect Duration: 43, Last Available: "2023-02"
 11120	toothsome super good fruit	3	awesome	Last Available: "2023-02"
 11121	vaporized squat energized spores	1		Last Available: "2023-02"
-11122	dangerous hot pepper of the sewer	0		Weapon Damage: +10, Stench Damage: +25, Lantern Element: "Hot", Last Available: "2023-02"
-11123	liquefied denatured ghostly blue narrow out-of-work circus flea	0		Effect: "Greasy Flavor", Effect Duration: 60, Last Available: "2023-02"
+11122	dangerous hot pepper of the sewer	0		Weapon Damage: +10, Stench Damage: +25, Last Available: "2023-02", Lantern Element: "Hot"
+11123	liquefied denatured blue ghostly narrow out-of-work circus flea	0		Effect: "Greasy Flavor", Effect Duration: 60, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	altered non-diffused fire ant pheromones	0		Effect: "Wistfully Nostalgic", Effect Duration: 28, Last Available: "2023-02"
 11126	activated flapper fly	0		Effect: "Seriously Mutated", Effect Duration: 49, Last Available: "2023-02"
 11127	acceptable jittery shot of wasp venom	3	good	Last Available: "2023-02"
 11128	Vulcanized filled mosquito	0		Effect: "Heart of Orange", Effect Duration: 19, Last Available: "2023-02"
-11129	double-ionized ghostly narrow shim of shame shale	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 37, Last Available: "2023-02"
+11129	double-ionized narrow ghostly shim of shame shale	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 37, Last Available: "2023-02"
 11130	ionized deionized pebble of proud pyrite	0		Effect: "Stinky Weapon", Effect Duration: 53, Last Available: "2023-02"
 11131	non-dry pile of gritty sand	0		Effect: "Hiding in Plain Sight", Effect Duration: 17, Last Available: "2023-02"
 11132	shaking hollow rock	0		Last Available: "2023-02"
@@ -10997,7 +10997,7 @@
 11142	shadow brick	0		Last Available: "2023-03"
 11143	fuchsia shadow sinew	0		Last Available: "2023-03"
 11144	mediocre shadow venom	3	decent	Last Available: "2023-03"
-11145	distilled gray blurry shadow nectar	1		Effect: "Wreathed in Smoke", Effect Duration: 50, Last Available: "2023-03"
+11145	distilled blurry gray shadow nectar	1		Effect: "Wreathed in Smoke", Effect Duration: 50, Last Available: "2023-03"
 11146	maroon Socratic shadow stick of the detective of the boozehound	0		Experience (Mysticality): +1, Item Drop: +20, Booze Drop: +100, Last Available: "2023-03"
 11147	frightening energetic bat paw	0		Maximum MP Percent: +20, Spooky Damage: +5
 11148	scorching uncursed bat paw	0		Hot Damage: +25
@@ -11035,10 +11035,10 @@
 11180	lightning-fast perfumed shadow monocle of the cheetah	0		Stench Resistance: +5, Initiative: 100, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	bland shadow hot dog	3	decent	
-11183	watered-down lousy purple tumbling shadow martini	2	decent	
+11183	lousy watered-down tumbling purple shadow martini	2	decent	
 11184	modified shadow pill	1		
 11185	twirling shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	liquefied skewed shadow candy	0		Effect: "Libra Rising", Effect Duration: 23
 11189	huge replica Mr. Accessory	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	twirling shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	stanky resourceful Socratic Cincho de Mayo of horror	0		Experience (Mysticality): +1, Maximum MP: +50, Stench Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	stanky resourceful Socratic Cincho de Mayo of horror	0		Experience (Mysticality): +1, Maximum MP: +50, Stench Spell Damage: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11085,7 +11085,7 @@
 11230	skewed replica Deck of Every Card	0		
 11231	bouncing replica Source terminal	0		
 11232	replica disconnected intergnat	0		
-11233	olive ghostly replica Witchess Set	0		
+11233	ghostly olive replica Witchess Set	0		
 11234	replica genie bottle	0		
 11235	replica space planula	0		
 11236	tumbling replica unpowered Robortender	0		
@@ -11103,7 +11103,7 @@
 11248	bouncing replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	veiny fortified replica Jurassic Parka	0		Damage Absorption: +60, Maximum HP: +10
 11250	replica grey gosling	0		
-11251	bouncing tumbling replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	tumbling bouncing replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	wobbly replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	wobbly replica Ten Dollars	0		
 11254	foul-smelling Lo Pan's quilted Sinatra's replica Cincho de Mayo	0		Experience (Moxie): +5, Damage Absorption: +40, Spell Critical Percent: +30, Stench Damage: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	huge spinning reassuring stanky Van der Graaf rock-hard &quot;I survived Y2K&quot; T-Shirt of chilblains of doom	0		Damage Reduction: 5, Cold Damage: +25, Stench Spell Damage: +25, Spooky Spell Damage: +50, Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	steel-toed pro skateboard of mayonnaise	0		Damage Reduction: 9, Sleaze Spell Damage: +50, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	steel-toed pro skateboard of mayonnaise	0		Damage Reduction: 9, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	twirling Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	mirror teal spinning Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	huge Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	huge Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +5, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	rosewater-soaked quilted Amulet of Perpetual Darkness of Gandalf of the sweet-tooth	0		Damage Absorption: +40, Spell Critical Percent: +20, Stench Resistance: +3, Candy Drop: +100, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11134,10 +11134,10 @@
 11279	upside-down Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	lousy practically non-alcoholic Sexy Cosmo	1	decent	Last Available: "2023-06"
+11282	practically non-alcoholic lousy Sexy Cosmo	1	decent	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	Usain Bolt's reassuring Rosewater's red-soled high heels	0		Mysticality Percent: +30, Spooky Resistance: +1, Initiative: +80, Last Available: "2023-06"
-11285	snack-sized bland cyburger	2	decent	Last Available: "2025-12"
+11285	bland snack-sized cyburger	2	decent	Last Available: "2025-12"
 11286	strapping ncle leg	0		Muscle: +5
 11287	mirror Jack Frost's rutabuga bag	0		Cold Spell Damage: +50, Item Drop: +5
 11288	ghostly wicked mesquito proboscis	0		Spell Damage: +5
@@ -11174,15 +11174,15 @@
 11319	narrow medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	tolerable fortified bottle of Cabernet Sauvignon	5	good	
 11321	purple brainy baywatch of the storm of Calamity Jane	0		Mysticality: +5, Maximum MP Percent: +40, Critical Hit Percent: +15, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	mirror Thwaitgold fairyfly statue	0		
 11327	twirling residual chitin paste	0		Skill: "Chitinous Soul"
 11328	powdered concentrated cooking	1		
 11329	modified meat	1		Effect: "Weapon of Mass Destruction", Effect Duration: 15
-11330	modified blinking maroon sparkling orb	1		
+11330	modified maroon blinking sparkling orb	1		
 11331	pickled shaking hardening cream	1		Effect: "Hagnk's Gratitude", Effect Duration: 25
 11332	denatured gray pool shark hair oil	1		
 11333	skewed book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11230,9 +11230,9 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	red housekeeping robot	0		
-11378	adequate fancy pickled bread	3	good	Effect: "Less Pervious", Effect Duration: 40, Last Available: "2023-12"
+11378	fancy adequate pickled bread	3	good	Effect: "Less Pervious", Effect Duration: 40, Last Available: "2023-12"
 11379	decent salted mutton	3	good	Last Available: "2023-12"
-11380	moldy bite-sized jittery corned beet	1	crappy	Last Available: "2023-12"
+11380	bite-sized moldy jittery corned beet	1	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11247,13 +11247,13 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	miniature adequate peppermint donut	2	good	
+11395	adequate miniature peppermint donut	2	good	
 11396	Elf Guard insignia (private) of the cougar	0		Moxie: +20, Last Available: "2023-12"
 11397	Sherlock's Crimbuccaneer fledges (mint)	0		Item Drop: +25, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	maroon Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	squat Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	practically non-alcoholic acceptable twirling Crimbuccaneer mologrog cocktail	1	good	Last Available: "2023-12"
+11401	acceptable practically non-alcoholic twirling Crimbuccaneer mologrog cocktail	1	good	Last Available: "2023-12"
 11402	ghostly Elf Army machine parts	0		Last Available: "2023-12"
 11403	squat Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	healthy beefy Crimbuccaneer lantern of Calamity Jane	0		Muscle: +10, Maximum HP Percent: +20, Critical Hit Percent: +15, Last Available: "2023-12"
@@ -11275,20 +11275,20 @@
 11420	teal shaking mirror frosty razor-sharp Crimbuccaneer tavern swab of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +25, Cold Spell Damage: +10, Last Available: "2023-12"
 11421	pulsating Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	triple-distilled acceptable old-school pirate grog	9	good	Last Available: "2023-12"
-11423	tasty jumbo fancy bouncing grog nuts	5	awesome	Effect: "Gamer Rage", Effect Duration: 10, Last Available: "2023-12"
+11423	jumbo tasty fancy bouncing grog nuts	5	awesome	Effect: "Gamer Rage", Effect Duration: 10, Last Available: "2023-12"
 11424	zippy asbestos-lined sawed-off blunderbuss of the cheetah	0		Hot Resistance: +5, Initiative: 80, Last Available: "2023-12"
 11425	delicious officer's nog	3	awesome	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	flavorless sundae ration	4	decent	Last Available: "2023-12"
-11428	huge normal peppermint tack	8	good	Last Available: "2023-12"
+11428	normal huge peppermint tack	8	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten whalesteak	4	crappy	Last Available: "2023-12"
 11431	aromatic Temple Grandin's cool whalegun	0		Moxie: +5, Familiar Weight: +7, Stench Resistance: +1, Last Available: "2023-12"
-11432	narrow blurry maroon Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
+11432	blurry narrow maroon Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	huge lion tamer's arcane researcher's Elf Guard clipboard of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Experience (familiar): +2, Last Available: "2023-12"
 11435	dance instructor's pegfinger	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2023-12"
-11436	weak mediocre tumbling and claret	2	decent	Last Available: "2023-12"
+11436	mediocre weak tumbling and claret	2	decent	Last Available: "2023-12"
 11437	personal trainer's Elf Guard and beret	0		Experience Percent (Muscle): [+10*event(December)], Last Available: "2023-12"
 11438	cyan wobbly smooth shipwright's hammer of the empath of the boozehound	0		Moxie: +15, Familiar Weight: +5, Booze Drop: +100, Last Available: "2023-12"
 11439	ruddy occult Fonzie's gunwale	0		Experience (Moxie): +1, Spell Damage Percent: +25, Maximum HP Percent: +40, Damage Reduction: 9, Last Available: "2023-12"
@@ -11307,18 +11307,18 @@
 11452	tumbling blurry nasty lion tamer's MacGyver's Socratic Elf dessert spoon of the storm of Flo-Jo	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Maximum MP: +100, Experience (familiar): +2, Stench Damage: +5, Initiative: +100, Last Available: "2023-12"
 11453	blurry huge Elf Guard SCUBA tank of Calamity Jane of the scaredy-cat	0		Critical Hit Percent: +15, Monster Level: -15, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	blinking executive Temple Grandin's free boots	0		Familiar Weight: +7, Meat Drop: +40, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	blinking executive Temple Grandin's free boots	0		Familiar Weight: +7, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	olive huge baby rigging snake	0		Last Available: "2023-12"
 11457	sizzling vibrating Elvish underarmor of the brazier	0		Maximum MP Percent: +10, Hot Damage: +10, Hot Spell Damage: +25, Single Equip, Last Available: "2023-12"
 11458	twirling narrow Crimbuccaneer bombjacket of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	adequate sugarplum ration	3	good	Last Available: "2023-12"
-11460	massive stale gingerbread nylons	10	decent	Last Available: "2023-12"
+11460	stale massive gingerbread nylons	10	decent	Last Available: "2023-12"
 11461	decent rum-soaked fruitcake	4	good	Last Available: "2023-12"
-11462	bite-sized moldy lime	1	crappy	Last Available: "2023-12"
+11462	moldy bite-sized lime	1	crappy	Last Available: "2023-12"
 11463	snack-sized adequate wobbly gingerbread pirate	2	good	Last Available: "2023-12"
 11464	decent fruit-stuffed rumcake	3	good	Last Available: "2023-12"
-11465	practically non-alcoholic tolerable mirror mulled wine	1	good	Last Available: "2023-12"
-11466	triple-distilled lousy Swedish coffee	6	decent	Last Available: "2023-12"
+11465	tolerable practically non-alcoholic mirror mulled wine	1	good	Last Available: "2023-12"
+11466	lousy triple-distilled Swedish coffee	6	decent	Last Available: "2023-12"
 11467	hand-crafted canteen of eggnog	3	super EPIC	Last Available: "2023-12"
 11468	weak smooth hot wine	2	awesome	Last Available: "2023-12"
 11469	acceptable triple-distilled blurry Jamaican coffee	10	good	Last Available: "2023-12"
@@ -11326,14 +11326,14 @@
 11471	mirror Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	skewed pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	triple-distilled acceptable fancy yule grog	10	good	Effect: "Super-Mega-Charged", Effect Duration: 15, Last Available: "2023-12"
+11474	triple-distilled fancy acceptable yule grog	10	good	Effect: "Super-Mega-Charged", Effect Duration: 15, Last Available: "2023-12"
 11475	fancy decent wet tack	3	good	Effect: "Perception", Effect Duration: 30, Last Available: "2023-12"
 11476	massive decent shaking whalecake	9	good	Last Available: "2023-12"
-11477	reassuring toasty frosty gunwale whalegun	0		Cold Spell Damage: +10, Hot Damage: +5, Spooky Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	tolerable triple-distilled and claret	8	good	Last Available: "2023-12"
+11477	reassuring toasty frosty gunwale whalegun	0		Cold Spell Damage: +10, Hot Damage: +5, Spooky Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	triple-distilled tolerable and claret	8	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
-11480	mirror ghostly trick coin	0		Last Available: "2023-12"
-11481	knitted nasty Elf Guard squirtgun	0		Stench Damage: +5, Cold Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11480	ghostly mirror trick coin	0		Last Available: "2023-12"
+11481	knitted nasty Elf Guard squirtgun	0		Stench Damage: +5, Cold Resistance: +3, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	blinking smartaleck's sequin-encrusted sweater	0		Moxie Percent: +30, Last Available: "2023-12"
 11484	spinning lard-coated scorching replica Elf Guard medal of temperance	0		Hot Damage: +25, Sleaze Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2023-12"
@@ -11344,23 +11344,23 @@
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	friendly barnacle-encrusted sweater of the bloodbag of extreme caution	0		Maximum HP: +100, Monster Level: -25, Familiar Weight: +3, Last Available: "2023-12"
 11491	gray Newton's smooth brainy Crimbuccaneer nose ring	0		Mysticality: +5, Moxie: +15, Experience (Mysticality): +3, Last Available: "2023-12"
-11492	blue blinking pet anchor	0		Last Available: "2023-12"
+11492	blinking blue pet anchor	0		Last Available: "2023-12"
 11493	tumbling Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	jittery narrow Elf Guard safety bear	0		Last Available: "2023-12"
+11494	narrow jittery Elf Guard safety bear	0		Last Available: "2023-12"
 11495	yellow kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11498	narrow ghostly Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
+11498	ghostly narrow Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	ghostly Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	mirror mirror The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	adjusted military candy cane	0		Effect: "Buff as a Baobab", Effect Duration: 47
-11503	irradiated spinning squat groggipop	0		Effect: "Very Clean Teeth", Effect Duration: 67
-11504	auspicious moss mace of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	squat moss megaphone of vim and vigor of Gandalf	0		Maximum HP Percent: +50, Spell Critical Percent: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	squat rosewater-soaked energetic moss medal	0		Maximum MP Percent: +20, Stench Resistance: +3, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	jittery Tesla beefcake's moss mitre	0		Muscle: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	green jittery resourceful beefy moss mantle	0		Muscle: +10, Maximum MP: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11503	irradiated squat spinning groggipop	0		Effect: "Very Clean Teeth", Effect Duration: 67
+11504	auspicious moss mace of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	squat moss megaphone of vim and vigor of Gandalf	0		Maximum HP Percent: +50, Spell Critical Percent: +20, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	squat rosewater-soaked energetic moss medal	0		Maximum MP Percent: +20, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	jittery Tesla beefcake's moss mitre	0		Muscle: +25, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	green jittery resourceful beefy moss mantle	0		Muscle: +10, Maximum MP: +50, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	spinning pulsating vibrating experienced moss marlinspike	0		Experience: +2, Maximum MP Percent: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	vaporized upside-down moss mulch	1		Last Available: "2024-12"
 11511	anodized altered moss floss	0		Effect: "Phorcefullness", Effect Duration: 63
@@ -11372,39 +11372,39 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	vaporized jittery adobe assortment	1		Last Available: "2024-12"
 11519	altered adobe brittle	0		Effect: "Polka Face", Effect Duration: 22
-11520	Van der Graaf extremely unsafe Fonzie's crepe paper phrygian cap	0		Experience (Moxie): +1, Weapon Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	Van der Graaf extremely unsafe Fonzie's crepe paper phrygian cap	0		Experience (Moxie): +1, Weapon Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	inspector's lard-coated energetic crepe paper parachute cape	0		Maximum MP Percent: +20, Sleaze Spell Damage: +25, Item Drop: +15, Last Available: "2025-12"
-11522	lime green narrow Rosewater's crepe paper pie clip of the dark arts of courage	0		Mysticality Percent: +30, Spell Damage Percent: +100, Spooky Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	friendly slick crepe paper puzzle cube of the brute	0		Moxie: +10, Muscle Percent: +30, Familiar Weight: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	rosewater-soaked razor-sharp crepe paper plunge camisole of the scaredy-cat	0		Weapon Damage Percent: +25, Monster Level: -15, Stench Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	forbidden crepe paper polka charm of the empath of the blizzard	0		Spell Damage Percent: +50, Familiar Weight: +5, Cold Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
-11526	mixed twirling spinning crepe paper pared cuttings	1		Last Available: "2025-12"
+11522	lime green narrow Rosewater's crepe paper pie clip of the dark arts of courage	0		Mysticality Percent: +30, Spell Damage Percent: +100, Spooky Resistance: +3, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	friendly slick crepe paper puzzle cube of the brute	0		Moxie: +10, Muscle Percent: +30, Familiar Weight: +3, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	rosewater-soaked razor-sharp crepe paper plunge camisole of the scaredy-cat	0		Weapon Damage Percent: +25, Monster Level: -15, Stench Resistance: +3, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	forbidden crepe paper polka charm of the empath of the blizzard	0		Spell Damage Percent: +50, Familiar Weight: +5, Cold Spell Damage: +25, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11526	mixed spinning twirling crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	extra-deionized boiled crepe paper peanut candy	0		Effect: "Permafrosty", Effect Duration: 42
 11528	shellacked petrified wood war pike of dire peril	0		Weapon Damage: +20, Damage Reduction: 7, Last Available: "2025-12"
 11529	Fonzie's smooth petrified wood waist protector	0		Moxie: +15, Experience (Moxie): +1, Single Equip, Last Available: "2025-12"
-11530	yellow blurry petrified wood wizard's pouch of the brute of the boozehound	0		Muscle Percent: +30, Booze Drop: +100, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	smartaleck's petrified wood water purifier of the cheetah	0		Moxie Percent: +30, Initiative: +60, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	yellow blurry petrified wood wizard's pouch of the brute of the boozehound	0		Muscle Percent: +30, Booze Drop: +100, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	smartaleck's petrified wood water purifier of the cheetah	0		Moxie Percent: +30, Initiative: +60, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	blue medical-grade petrified wood whoopie panama of vim and vigor	0		Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12"
 11533	lard-coated petrified wood walking pants of courage	0		Sleaze Spell Damage: +25, Spooky Resistance: +3, Last Available: "2025-12"
 11534	modified petrified wood waste parts	1		Last Available: "2025-12"
 11535	warmed cold-filtered cyan petrified wood wafer praline	0		Effect: "Memory of Strength", Effect Duration: 32
 11536	perfectly mixed cybeer	3	EPIC	Last Available: "2025-12"
 11537	jittery ICEbox	0		Last Available: "2025-12"
-11538	lime green wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	blurry squat encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	lime green wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	blurry squat encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	tumbling baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	family-friendly rock-hard Crimbuccaneer war standard	0		Damage Reduction: 5, Sleaze Resistance: +1, Last Available: "2023-12"
 11544	lion tamer's Lo Pan's Elf Guard war standard	0		Spell Critical Percent: +30, Experience (familiar): +2, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	auspicious rock-hard groovy spring shoes	0		Moxie Percent: +10, Damage Reduction: 5, Item Drop: +10, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	auspicious rock-hard groovy spring shoes	0		Moxie Percent: +10, Damage Reduction: 5, Item Drop: +10, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	colloidal red ultra-soft ferns	0		Effect: "I See Everything Thrice!", Effect Duration: 19, Last Available: "2024-02"
 11548	vacuum-sealed electrified non-polymerized bouncing crunchy brush	0		Effect: "Tiki Thoughtfulness", Effect Duration: 12, Last Available: "2024-02"
 11549	skewed smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	jittery triphasic molecular oculus	0		
-11552	bouncing mirror spinning cyan high-tension exoskeleton	0		
+11552	mirror bouncing cyan spinning high-tension exoskeleton	0		
 11553	narrow ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
@@ -11416,7 +11416,7 @@
 11561	avaricious crafty Everfull Dart Holster	0		Maximum MP: +10, Meat Drop: +30, Single Equip, Last Available: "2024-03"
 11562	twirling research fragment	0		
 11563	yellow Thwaitgold wolf spider statuette	0		
-11564	tumbling yellow boxed Apriling band helmet	0		Free Pull, Last Available: "2024-04"
+11564	yellow tumbling boxed Apriling band helmet	0		Free Pull, Last Available: "2024-04"
 11565	stanky chaotic slick Apriling band helmet of Calamity Jane of courage	0		Moxie: +10, Critical Hit Percent: +15, Spell Critical Percent: +10, Stench Spell Damage: +25, Spooky Resistance: +3
 11566	foul-smelling razor-sharp dance instructor's Apriling band saxophone of courage	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Stench Damage: +10, Spooky Resistance: +3, Lasts Until Rollover
 11567	flame-retardant toasty resourceful smooth Apriling band quad tom	0		Moxie: +15, Maximum MP: +50, Hot Damage: +5, Hot Resistance: +1, Lasts Until Rollover
@@ -11426,9 +11426,9 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	bland bite-sized blurry yam	1	decent	Last Available: "2024-05"
-11574	bad weak yam martini	2	decent	Last Available: "2024-05"
+11574	weak bad yam martini	2	decent	Last Available: "2024-05"
 11575	acceptable tumbling sweet potato o' mine	3	good	Last Available: "2024-05"
-11576	perfectly mixed fancy Southern yam	4	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 50, Last Available: "2024-05"
+11576	fancy perfectly mixed Southern yam	4	EPIC	Effect: "Shrimpin' Ain't Easy", Effect Duration: 50, Last Available: "2024-05"
 11577	acceptable sweet potato punch	3	good	Last Available: "2024-05"
 11578	spoiled tumbling Mayam spinach	3	crappy	Last Available: "2024-05"
 11579	tiny bland ghostly yam and swiss	1	decent	Last Available: "2024-05"
@@ -11454,14 +11454,14 @@
 11599	hale beefy mini kiwi silicon tiepin of vim and vigor	0		Muscle: +10, Maximum HP Percent: +50, Maximum HP: +20
 11600	upside-down mini kiwi tipi	0		
 11601	miniature adequate mini kiwi digitized cookies	2	good	
-11602	special smooth weak mini kiwi intoxicating spirits	2	awesome	Effect: "Itchy Trigger Finger", Effect Duration: 30
+11602	weak smooth special mini kiwi intoxicating spirits	2	awesome	Effect: "Itchy Trigger Finger", Effect Duration: 30
 11603	Vulcanized mini kiwi antimilitaristic hippy petition	0		Effect: "Almost Cool", Effect Duration: 66
 11604	flattened mini kiwi illicit antibiotic	0		Effect: "Jerky, Boy", Effect Duration: 30
 11605	upside-down mansplainer's wizardly mini kiwi whipping stick	0		Mysticality: +25, Monster Level: +15
 11606	upside-down mini kiwi icepick of the bloodbag	0		Maximum HP: +100
 11607	dry irradiated vacuum-sealed teal mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Healthy Green Glow", Effect Duration: 53
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	purple protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11470,9 +11470,9 @@
 11615	twirling flame-wreathed Sinatra's messenger bag RNA of the businessman	0		Experience (Moxie): +5, Hot Spell Damage: +10, Meat Drop: +50
 11616	spinning flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	snack-sized normal bacteria bisque	2	good	
-11619	enchanted miniature adequate ciliophora chowder	2	good	Effect: "Old School Pompadour", Effect Duration: 10
-11620	stale miniature cream of chloroplasts	2	decent	
+11618	normal snack-sized bacteria bisque	2	good	
+11619	adequate enchanted miniature ciliophora chowder	2	good	Effect: "Old School Pompadour", Effect Duration: 10
+11620	miniature stale cream of chloroplasts	2	decent	
 11621	synaptic soup	0		
 11622	tumbling ghostly muscular soup	0		
 11623	flagellate soup	0		
@@ -11502,15 +11502,15 @@
 11647	wobbly structural ember	0		Last Available: "2024-09"
 11648	spinning blurry lightning-fast flame-retardant ruddy embers-only jacket	0		Maximum HP Percent: +40, Hot Resistance: +1, Initiative: +40, Lasts Until Rollover, Last Available: "2024-09"
 11649	thinker's bembershoot	0		Mysticality: +10, Lasts Until Rollover, Last Available: "2024-09"
-11650	fancy rotten wheel of camembert	4	crappy	Effect: "Dreadful Fear", Effect Duration: 15, Last Available: "2024-09"
+11650	rotten fancy wheel of camembert	4	crappy	Effect: "Dreadful Fear", Effect Duration: 15, Last Available: "2024-09"
 11651	aromatic Temple Grandin's deadly hat of remembering	0		Weapon Damage: +5, Familiar Weight: +7, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-09"
 11652	upside-down throwin' ember	0		Last Available: "2024-09"
-11653	fuchsia ghostly head of emberg lettuce	0		Last Available: "2024-09"
+11653	ghostly fuchsia head of emberg lettuce	0		Last Available: "2024-09"
 11654	embering hunk	0		Last Available: "2024-09"
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	green boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	gray Temple Grandin's grievous bat wings of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Familiar Weight: +7, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	gray Temple Grandin's grievous bat wings of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Familiar Weight: +7, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	chaotic shellacked monocle on a stick	0		Damage Reduction: 7, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,10 +11523,10 @@
 11668	Sheriff badge of the boozehound of the sweet-tooth	0		Booze Drop: +100, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	skewed smelly dance instructor's Sheriff pistol	0		Experience Percent (Moxie): +10, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
 11670	frightening Sheriff moustache of Gandalf	0		Spell Critical Percent: +20, Spooky Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	frightening Tesla photo booth supply list	0		Spooky Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	frightening Tesla photo booth supply list	0		Spooky Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	huge tie-dye headband	0		
-11674	fancy rotten whirled peas	3	crappy	Effect: "Adrenaline Rush", Effect Duration: 30, Last Available: "2024-11"
+11674	rotten fancy whirled peas	3	crappy	Effect: "Adrenaline Rush", Effect Duration: 30, Last Available: "2024-11"
 11675	diet normal peaza	1	good	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	modified tumbling drenchrome 2.0	1		Effect: "Cold Throat", Effect Duration: 40, Last Available: "2025-12"
@@ -11535,13 +11535,13 @@
 11680	upside-down quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	frozen skewed shaking pea brittle	0		Effect: "Loco Motives", Effect Duration: 11, Last Available: "2024-11"
-11683	tolerable weak peasco	2	good	Last Available: "2024-11"
+11683	weak tolerable peasco	2	good	Last Available: "2024-11"
 11684	spoiled miniature piece of cake	2	crappy	Last Available: "2024-11"
 11685	spinning handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	tumbling coward's Van der Graaf deft pirate hook	0		Monster Level: -20, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2024-12"
-11689	Rosewater's iron tricorn hat of bravery	0		Mysticality Percent: +30, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	Rosewater's iron tricorn hat of bravery	0		Mysticality Percent: +30, Spooky Resistance: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	jolly roger flag of the sewer	0		Stench Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	pulsating tumbling sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	blinking dog trainer's governor's daughter's pearl hairpin	0		Experience (familiar): +1, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	grievous chili powder cutlass	0		Weapon Damage Percent: +50, Last Available: "2024-12"
-11701	decent bite-sized blinking Aztec tamale	1	good	Last Available: "2024-12"
+11701	bite-sized decent blinking Aztec tamale	1	good	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	bouncing pet rock	0		Last Available: "2024-12"
 11704	pulsating MacGyver's groggles	0		Maximum MP: +100, Last Available: "2024-12"
@@ -11574,16 +11574,16 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	squat Spirit of Christmas	0		Last Available: "2024-12"
-11722	rotten massive coney haunch	7	crappy	Last Available: "2024-12"
+11722	massive rotten coney haunch	7	crappy	Last Available: "2024-12"
 11723	activated jittery twirling dark chocolate egg	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 65, Last Available: "2024-12"
 11724	enchanted hand-crafted moai toai	3	EPIC	Effect: "Nasty, Nasty Breath", Effect Duration: 50
 11725	manspreader's steel-toed moaiball of the overflowing toilet	0		Damage Reduction: 9, Monster Level: +10, Stench Spell Damage: +50, Last Available: "2024-12"
 11726	huge half-digested rat	0		Last Available: "2024-12"
 11727	enhanced polymerized teal blurry four-leaf potato sprout	0		Effect: "Cat-Alyzed", Effect Duration: 66, Last Available: "2024-12"
 11728	inspector's beefcake's potato jacket of the brute	0		Muscle: +25, Muscle Percent: +30, Item Drop: +15, Last Available: "2024-12"
-11729	spinning twirling traumatic holiday memory	0		Last Available: "2024-12"
+11729	twirling spinning traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	ghostly medical-grade military orb of the cheetah	0		Initiative: +60, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	ghostly medical-grade military orb of the cheetah	0		Initiative: +60, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	denatured twirling blinking rum ball	0		Effect: "Sepia Tan", Effect Duration: 32
 11733	pulsating gravy skin	0		Last Available: "2024-12"
 11734	skewed stiffened thinker's gravyskin hat	0		Mysticality: +10, Damage Reduction: 1, Last Available: "2024-12"
@@ -11595,36 +11595,36 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ghostly ragged wool yarn	0		Last Available: "2024-12"
 11742	gray censurious experienced brawny perfect Christmas scarf	0		Muscle Percent: [+20*event(December)], Experience: [+2*event(December)], Sleaze Resistance: [+3*event(December)], Single Equip, Last Available: "2024-12"
-11743	tumbling shellacked banded snowman-enchanting tophat	0		Damage Absorption: +100, Damage Reduction: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	tumbling shellacked banded snowman-enchanting tophat	0		Damage Absorption: +100, Damage Reduction: 7, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	magnetized ionized LIDAR candle	0		Effect: "Some Cheese with Your Wine", Effect Duration: 38, Last Available: "2024-12"
 11745	MacGyver's arcane researcher's Congressional Medal of Insanity of temperance	0		Experience Percent (Mysticality): +10, Maximum MP: +100, Sleaze Resistance: +5, Last Available: "2024-12"
 11746	yellow pumpkin spice whorl	0		Last Available: "2024-12"
-11747	smooth watered-down Easter grasshopper	2	awesome	Last Available: "2024-12"
-11748	perfectly mixed pulsating tumbling Irish eggnog	3	EPIC	Last Available: "2024-12"
-11749	perfectly mixed practically non-alcoholic canteen of jungle juice	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11747	watered-down smooth Easter grasshopper	2	awesome	Last Available: "2024-12"
+11748	perfectly mixed tumbling pulsating Irish eggnog	3	EPIC	Last Available: "2024-12"
+11749	practically non-alcoholic perfectly mixed canteen of jungle juice	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11750	perfectly mixed mirror turchucken	3	EPIC	Last Available: "2024-12"
-11751	weak acceptable mechanically-mulled cider	2	good	Last Available: "2024-12"
-11752	delicious strong holiday trip around the world	5	awesome	Last Available: "2024-12"
+11751	acceptable weak mechanically-mulled cider	2	good	Last Available: "2024-12"
+11752	strong delicious holiday trip around the world	5	awesome	Last Available: "2024-12"
 11753	tasty chocolate ostrich egg	4	awesome	Last Available: "2024-12"
 11754	stale beef and cabbage	4	decent	Last Available: "2024-12"
 11755	normal upside-down candy rations	3	good	Last Available: "2024-12"
-11756	miniature moldy double-candied yams	2	crappy	Last Available: "2024-12"
+11756	moldy miniature double-candied yams	2	crappy	Last Available: "2024-12"
 11757	delicious Christmas ham	3	awesome	Last Available: "2024-12"
 11758	stale holiday smorgasbord	3	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	shaking censurious bejazzled eyepatch	0		Sleaze Resistance: +3, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	wobbly Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	squat How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	twirling Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	mirror teal Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	wobbly Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	squat How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	twirling Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	teal mirror Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	bouncing moai statuette	0		Last Available: "2024-12"
-11772	tumbling lion tamer's manspreader's smartaleck's egg gun of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Monster Level: +10, Experience (familiar): +2, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	tumbling lion tamer's manspreader's smartaleck's egg gun of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Monster Level: +10, Experience (familiar): +2, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	Usain Bolt's nippy stiffened thinker's army helmet	0		Mysticality: +10, Damage Reduction: 1, Cold Damage: +10, Initiative: +80, Last Available: "2024-12"
 11774	blinking candy egg deviler	0		Last Available: "2024-12"
 11775	blinking napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	improved oxidized frozen red deviled candy egg	0		Effect: "Blood-Gorged", Effect Duration: 42, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	mirror forbidden Newton's McHugeLarge duffel bag	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Last Available: "2025-01"
-11784	spinning blinking asbestos-lined lion tamer's McHugeLarge left pole of the sweet-tooth	0		Experience (familiar): +2, Hot Resistance: +5, Candy Drop: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	friendly Lo Pan's resourceful McHugeLarge right pole	0		Maximum MP: +50, Spell Critical Percent: +30, Familiar Weight: +3, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	blurry Sinatra's strapping McHugeLarge left ski	0		Muscle: +5, Experience (Moxie): +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	McHugeLarge right ski of the boozehound of Flo-Jo	0		Booze Drop: +100, Initiative: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	spinning blinking asbestos-lined lion tamer's McHugeLarge left pole of the sweet-tooth	0		Experience (familiar): +2, Hot Resistance: +5, Candy Drop: +100, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	friendly Lo Pan's resourceful McHugeLarge right pole	0		Maximum MP: +50, Spell Critical Percent: +30, Familiar Weight: +3, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	blurry Sinatra's strapping McHugeLarge left ski	0		Muscle: +5, Experience (Moxie): +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	McHugeLarge right ski of the boozehound of Flo-Jo	0		Booze Drop: +100, Initiative: +100, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	dehydrated upside-down upside-down eXpand	1		Effect: "Army of One", Effect Duration: 30, Last Available: "2025-12"
-11791	teal brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	teal brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	narrow datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,18 +11658,18 @@
 11803	squat cybervisor	0		Last Available: "2025-12"
 11804	upside-down retro floppy disk	0		Last Available: "2025-12"
 11805	purple pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	lime green ghostly dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
-11811	blinking squat logic grenade	0		Last Available: "2025-12"
-11812	dried pulsating jittery psilocyber mushroom	1		Last Available: "2025-12"
+11811	squat blinking logic grenade	0		Last Available: "2025-12"
+11812	dried jittery pulsating psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
-11817	spinning narrow dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
+11817	narrow spinning dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
@@ -11679,9 +11679,9 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	pulsating hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
-11829	pulsating squat virtual cybertattoo	0		Last Available: "2025-12"
+11829	squat pulsating virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	ninja crampons	0		
 11832	tumbling ninja carabiner	0		
@@ -11702,7 +11702,7 @@
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	huge heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
-11850	olive wobbly sore	0		Cold Damage: +10, Cold Spell Damage: +10
+11850	wobbly olive sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	skewed stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	huge cyan foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
@@ -11724,14 +11724,14 @@
 11869	unironic knife	0		
 11870	spinning bar dart	0		Last Available: "2025-03"
 11871	denatured leprechaun antidepressant pill	1		Effect: "Stimulated Brain", Effect Duration: 50, Last Available: "2025-03"
-11872	moldy bite-sized Heck ramen	1	crappy	Last Available: "2025-03"
+11872	bite-sized moldy Heck ramen	1	crappy	Last Available: "2025-03"
 11873	immense adequate burrito	6	good	Last Available: "2025-03"
 11874	bland small beer brat	3	decent	Last Available: "2025-03"
 11875	flavorless miniature spinning peach pie	2	decent	Last Available: "2025-03"
 11876	tasty incredible mini-pizza	3	awesome	Last Available: "2025-03"
-11877	drinkable irresponsibly strong spinning Divine sidecar	6	good	Last Available: "2025-03"
+11877	irresponsibly strong drinkable spinning Divine sidecar	6	good	Last Available: "2025-03"
 11878	hand-crafted tangarita sidecar	4	EPIC	Last Available: "2025-03"
-11879	irresponsibly strong tolerable gimlet sidecar	6	good	Last Available: "2025-03"
+11879	tolerable irresponsibly strong gimlet sidecar	6	good	Last Available: "2025-03"
 11880	aged bouncing vodka stratocaster sidecar	4	awesome	Last Available: "2025-03"
 11881	hand-crafted watered-down prussian cathouse sidecar	2	EPIC	Last Available: "2025-03"
 11882	fancy lousy Mon Tiki sidecar	4	decent	Effect: "Industrial Strength Starch", Effect Duration: 15, Last Available: "2025-03"
@@ -11771,7 +11771,7 @@
 11916	Jeselnik's stylish bycocket	0		Sleaze Damage: +25
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11781,7 +11781,7 @@
 11926	groovy brawny Axis suspenders	0		Muscle Percent: +20, Moxie Percent: +10, Single Equip
 11927	tumbling gray stolen artifact	0		
 11928	teal really expensive stolen artifact	0		
-11929	bouncing blinking squat priceless stolen artifact	0		
+11929	bouncing squat blinking priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	ghostly nice nylon stockings	0		
 11932	lime green Allied Radio Backpack Pack	0		Free Pull
@@ -11789,8 +11789,8 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	delicious snack-sized enchanted Skeleton Wars rations	2	awesome	Effect: "La Bamba", Effect Duration: 50
-11938	delicious weak special skeleton war fuel can	2	awesome	Effect: "So You Can Work More...", Effect Duration: 10
+11937	snack-sized enchanted delicious Skeleton Wars rations	2	awesome	Effect: "La Bamba", Effect Duration: 50
+11938	weak special delicious skeleton war fuel can	2	awesome	Effect: "So You Can Work More...", Effect Duration: 10
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11804,10 +11804,10 @@
 11949	bully badge	0		Item Drop: +5, Lasts Until Rollover, Last Available: "2025-08"
 11950	green tumbling hardened time cop top hat	0		Damage Reduction: 3, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	denatured fuchsia mirror mixed berry jelly	1		Effect: "Standard Issue Bravery", Effect Duration: 40, Last Available: "2025-08"
-11953	decent diet toast with mixed berry jelly	1	good	Last Available: "2025-08"
+11952	denatured mirror fuchsia mixed berry jelly	1		Effect: "Standard Issue Bravery", Effect Duration: 40, Last Available: "2025-08"
+11953	diet decent toast with mixed berry jelly	1	good	Last Available: "2025-08"
 11954	moldy green cup of sugar	4	crappy	Last Available: "2025-08"
-11955	tiny bland huge Susie's cupcake	1	decent	Last Available: "2025-08"
+11955	bland tiny huge Susie's cupcake	1	decent	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	cyan Temple Grandin's boxer's the gun of Calamity Jane	0		Muscle Percent: +10, Critical Hit Percent: +15, Familiar Weight: +7, Last Available: "2025-08"
 11958	practically non-alcoholic hand-crafted blurry wine	1	super ultra mega turbo EPIC	Last Available: "2025-08"
@@ -11819,33 +11819,33 @@
 11965	spoiled small kelp puck	2	crappy	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
-11968	tumbling blurry scroll of sea smarm	0		
+11968	blurry tumbling scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	sea gel	0		
 11971	dry non-frozen chilled skewed squat octopus ink bladder	0		Effect: "On Pins and Needles", Effect Duration: 26
 11972	twirling durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	maroon packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	blue steel-toed dentadent	0		Damage Reduction: 9
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	auspicious foul-smelling veiny studded Newton's smartaleck's blood cubic zirconia	0		Moxie Percent: +30, Experience (Mysticality): +3, Damage Absorption: +80, Maximum HP: +10, Stench Damage: +10, Item Drop: +10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	auspicious foul-smelling veiny studded Newton's smartaleck's blood cubic zirconia	0		Moxie Percent: +30, Experience (Mysticality): +3, Damage Absorption: +80, Maximum HP: +10, Stench Damage: +10, Item Drop: +10, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	denatured green ghostly blood thinner	1		Effect: "A View to Some Meat", Effect Duration: 50, Last Available: "2025-10"
 12045	artisanal pheromone cocktail	4	EPIC	Last Available: "2025-10"
-12046	small rotten shaking spinal tapas	2	crappy	Last Available: "2025-10"
+12046	rotten small shaking spinal tapas	2	crappy	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	toasty careful shrunken head of the businessman	0		Monster Level: -10, Hot Damage: +5, Meat Drop: +50, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	toasty careful shrunken head of the businessman	0		Monster Level: -10, Hot Damage: +5, Meat Drop: +50, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	smooth bouncing Smoking Pope	3	awesome	
 12053	normal prize turkey	3	good	
-12054	mixed skewed fuchsia medicinal gruel	1		Effect: "Haunted Liver", Effect Duration: 10
-12055	miniature rotten full-sized pumpkin pie	2	crappy	Last Available: "2025-11"
+12054	mixed fuchsia skewed medicinal gruel	1		Effect: "Haunted Liver", Effect Duration: 10
+12055	rotten miniature full-sized pumpkin pie	2	crappy	Last Available: "2025-11"
 12056	tolerable vodka cranberry sauce	3	good	Last Available: "2025-11"
 12057	quantum pickled oxidized yammed candy	0		Effect: "You Know What's Up", Effect Duration: 44, Last Available: "2025-11"
-12058	decent miniature treasure chestnut	2	good	Last Available: "2025-12"
+12058	miniature decent treasure chestnut	2	good	Last Available: "2025-12"
 12059	mediocre enchanted weak skewed maroon mulled butter rum	2	decent	Effect: "Boon of She-Who-Was", Effect Duration: 35, Last Available: "2025-12"
 12060	vacuum-sealed shaking cinnamon doubloon	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 49, Last Available: "2025-12"
 12061	smartaleck's plastic left skeleton arm	0		Moxie Percent: +30, Last Available: "2025-12"
@@ -11888,8 +11888,8 @@
 12130	extra-altered pressed mirror boiling cerebrospinal fluid	0		Effect: "Spirit of Alph", Effect Duration: 64, Last Available: "2025-12"
 12131	denatured energized blinking boiling synovial fluid	0		Effect: "Amplified Fabulousness", Effect Duration: 47, Last Available: "2025-12"
 12132	jittery double-paned Temple Grandin's smoldering vertebra of the pedagogue	0		Experience: +3, Familiar Weight: +7, Cold Resistance: +5, Single Equip, Last Available: "2025-12"
-12133	teal spinning seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12133	spinning teal seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	tumbling careful clever hot boning knife of the sewer	0		Maximum MP: +20, Monster Level: -10, Stench Damage: +25, Single Equip, Last Available: "2025-12"
@@ -11897,7 +11897,7 @@
 12139	stanky sizzling veiny burnt bone belt	0		Maximum HP: +10, Hot Damage: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2025-12"
 12140	greasy scorched skull trophy	0		Sleaze Spell Damage: +10, Last Available: "2025-12"
 12141	adequate wing bone	4	good	Last Available: "2025-12"
-12142	mediocre weak weak skeleton venom	2	decent	Last Available: "2025-12"
+12142	weak mediocre weak skeleton venom	2	decent	Last Available: "2025-12"
 12143	mixed upside-down squat baked bone meal	1		Last Available: "2025-12"
 12144	plastic skeleton rib cage of the brazier	0		Hot Spell Damage: +25, Last Available: "2025-12"
 12145	up-at-dawn plastic skeleton skull	0		Adventures: +5, Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	irradiated gummi fingerbone	0		Effect: "Lobos Fresh", Effect Duration: 42
 12179	weightlifter's glimmering crystal of the sweet-tooth	0		Muscle: +15, Candy Drop: +100, Last Available: "2025-12"
 12180	wobbly boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	gray Thwaitgold meat bee statuette	0		
 12183	jittery tumbling loose Meats	0		
 12184	blue Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11964,7 +11964,7 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	ghostly Pork Elf sink	0		Last Available: "2026-03"
 12208	teal Pork Elf toilet	0		Last Available: "2026-03"
-12209	tiny normal special maroon blurry rat pizza	1	good	Effect: "Smoking like a Bandit", Effect Duration: 35, Last Available: "2026-03"
+12209	special normal tiny blurry maroon rat pizza	1	good	Effect: "Smoking like a Bandit", Effect Duration: 35, Last Available: "2026-03"
 12210	bouncing Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	horrifying Jack Frost's smartaleck's hoverboard	0		Moxie Percent: +30, Cold Spell Damage: +50, Spooky Damage: +25, Single Equip, Last Available: "2026-03"
 12212	greedy miser's Jack Frost's left shark fin	0		Cold Spell Damage: +50, Meat Drop: 30, Last Available: "2026-03"
@@ -11979,28 +11979,28 @@
 12225	upside-down legendary noodles	0		Last Available: "2026-05"
 12226	toothsome cyan can of tuna	4	awesome	
 12227	stale green alien salad	4	decent	
-12228	moldy big ratbatatouille	5	crappy	
-12229	bland miniature fancy onigiri	2	decent	Effect: "Al Dente Inferno", Effect Duration: 25
-12230	snack-sized stale wobbly crudit&eacute;s	2	decent	
-12231	bland half-sized tumbling sauced mutton	2	decent	
+12228	big moldy ratbatatouille	5	crappy	
+12229	miniature bland fancy onigiri	2	decent	Effect: "Al Dente Inferno", Effect Duration: 25
+12230	stale snack-sized wobbly crudit&eacute;s	2	decent	
+12231	half-sized bland tumbling sauced mutton	2	decent	
 12232	normal immense hot honey ant	9	good	
-12233	spoiled miniature tomb aspic	2	crappy	
+12233	miniature spoiled tomb aspic	2	crappy	
 12234	delicious upside-down later tots	3	awesome	
 12235	moldy Frutti di Scatoletta	3	crappy	Last Available: "2026-05"
-12236	immense normal Pesto alla Marziano	6	good	Last Available: "2026-05"
+12236	normal immense Pesto alla Marziano	6	good	Last Available: "2026-05"
 12237	small bland Arrattabbattabiata	2	decent	Last Available: "2026-05"
 12238	spoiled huge Orzo di Riso	8	crappy	Last Available: "2026-05"
 12239	stale low-calorie Pasta Grimavera	1	decent	Last Available: "2026-05"
 12240	bland Linguini Ubriacapa	4	decent	Last Available: "2026-05"
 12241	gigantic stale Formica e Pepe	8	decent	Last Available: "2026-05"
-12242	stale immense Tubetto Gelatto	9	decent	Last Available: "2026-05"
+12242	immense stale Tubetto Gelatto	9	decent	Last Available: "2026-05"
 12243	decent Gnocci Domani	4	good	Last Available: "2026-05"
 12244	olive Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	steel-toed Space Soldier Helmet of the empath	0		Damage Reduction: 9, Familiar Weight: +5
-12253	delicious jittery huge red premium turkey leg	4	awesome	
+12253	delicious red huge jittery premium turkey leg	4	awesome	
 12254	bad fancy styrofoam cup of mead	4	decent	Effect: "Tiki Temerity", Effect Duration: 40
 12255	pulsating Van der Graaf sword	0		MP Regen Min: 5, MP Regen Max: 7
 12256	zippy staff	0		Initiative: +20
@@ -12017,32 +12017,32 @@
 12267	narrow Fonzie's flimsy plastic breastplate	0		Experience (Moxie): +1
 12268	veiny flimsy plastic shield	0		Maximum HP: +10, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	purple blinking zippy foul-smelling Portable Laughing Stock of Flo-Jo	0		Stench Damage: +10, Initiative: 120, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	purple blinking zippy foul-smelling Portable Laughing Stock of Flo-Jo	0		Stench Damage: +10, Initiative: 120, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	twirling twirling smartaleck's Staff of Anachronistic Churning of chilblains of bravery	0		Moxie Percent: +30, Cold Damage: +25, Spooky Resistance: +5
 12272	spoiled classic banana	4	crappy	Last Available: "2026-07"
-12273	tiny rotten watermelon	1	crappy	Last Available: "2026-07"
+12273	rotten tiny watermelon	1	crappy	Last Available: "2026-07"
 12274	flavorless twirling quince	4	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	delicious tumbling blinking classic banana pie	4	awesome	Last Available: "2026-07"
 12278	double-improved squat essential banana decoction	0		Effect: "Hair on Your Chest", Effect Duration: 28, Last Available: "2026-07"
 12279	nitrogenated moist frozen cyan banana quintessence	0		Effect: "Ripping, Dripping", Effect Duration: 18, Last Available: "2026-07"
-12280	aged watered-down Aesop Daiquiri	2	awesome	Last Available: "2026-07"
+12280	watered-down aged Aesop Daiquiri	2	awesome	Last Available: "2026-07"
 12281	weak artisanal gray Monkey Congress	2	super EPIC	Last Available: "2026-07"
-12282	fancy decent half-sized watermelon pie	2	good	Effect: "Just the Brown Ones", Effect Duration: 35, Last Available: "2026-07"
+12282	half-sized decent fancy watermelon pie	2	good	Effect: "Just the Brown Ones", Effect Duration: 35, Last Available: "2026-07"
 12283	dry concentrated watermelon juice	0		Effect: "There Is A Spoon", Effect Duration: 40, Last Available: "2026-07"
 12284	non-cold-filtered spinning Aqua Citrulanatae	0		Effect: "Floundering", Effect Duration: 37, Last Available: "2026-07"
-12285	practically non-alcoholic acceptable Melonegroni	1	good	Last Available: "2026-07"
-12286	practically non-alcoholic perfectly mixed Melonade Spritz	1	super ultra mega turbo EPIC	Last Available: "2026-07"
+12285	acceptable practically non-alcoholic Melonegroni	1	good	Last Available: "2026-07"
+12286	perfectly mixed practically non-alcoholic Melonade Spritz	1	super ultra mega turbo EPIC	Last Available: "2026-07"
 12287	fancy decent quince pie	4	good	Effect: "Top Dog", Effect Duration: 45, Last Available: "2026-07"
 12288	wet Vulcanized wobbly quince quaff	0		Effect: "stats.enq", Effect Duration: 25, Last Available: "2026-07"
 12289	flattened triple-galvanized Quickquince	0		Effect: "Craft Tea", Effect Duration: 48, Last Available: "2026-07"
-12290	watered-down hand-crafted shaking narrow Quiskey Sour	2	EPIC	Last Available: "2026-07"
-12291	smooth watered-down Quincea&ntilde;era Cooler	2	awesome	Last Available: "2026-07"
+12290	hand-crafted watered-down shaking narrow Quiskey Sour	2	EPIC	Last Available: "2026-07"
+12291	watered-down smooth Quincea&ntilde;era Cooler	2	awesome	Last Available: "2026-07"
 12292	high-proof acceptable Roth IPA	8	good	Last Available: "2026-08"
 12293	lightning-fast underdraft protection of temperance	0		Sleaze Resistance: +5, Initiative: +40, Last Available: "2026-08"
 12294	huge solvent	0		Last Available: "2026-08"
-12295	rotten low-calorie soybean futures	1	crappy	Last Available: "2026-08"
+12295	low-calorie rotten soybean futures	1	crappy	Last Available: "2026-08"
 12296	altered warmed housing bubble	0		Effect: "Egg on your Face", Effect Duration: 54, Last Available: "2026-08"
 12297	deionized Pixie-Swordz	0		Effect: "Big Meat Big Prizes", Effect Duration: 55
 12298	Van der Graaf financial instrument of the empath	0		Familiar Weight: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	boiled bouncing toxic asset	1		Last Available: "2026-08"
-12311	powdered narrow yellow jittery intangible asset	1		Last Available: "2026-08"
+12311	powdered jittery yellow narrow intangible asset	1		Last Available: "2026-08"
 12312	boiled liquid asset	1		Effect: "Spookypants", Effect Duration: 35, Last Available: "2026-08"
-12313	teal narrow gross prophet chrysalis	0		Last Available: "2026-08"
+12313	narrow teal gross prophet chrysalis	0		Last Available: "2026-08"
 12314	jittery cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Sauceror_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Wallaby_cafe_booze.txt
@@ -3,19 +3,19 @@
 -3	artisanal wobbly Infinitesimal IPA	3	EPIC	
 -4	acceptable enchanted eggnogtini	3	good	
 -5	acceptable irresponsibly strong candycaine	9	good	
--6	bad spirit-forward braincracker sweet	5	decent	
+-6	spirit-forward bad braincracker sweet	5	decent	
 -16	smooth teal fermented honey	3	awesome	
--17	acceptable watered-down fancy moons-shine	2	good	
--18	watered-down delicious gin	2	awesome	
+-17	acceptable fancy watered-down moons-shine	2	good	
+-18	delicious watered-down gin	2	awesome	
 -19	perfectly mixed ecto-nog	3	EPIC	
 -20	acceptable hot toady	4	good	
 -21	perfectly mixed skewed hot choculate	3	EPIC	
 -49	acceptable squat Cyder	3	good	
 -50	hand-crafted spinning Oil Nog	4	EPIC	
--51	irresponsibly strong mediocre Hi-Octane Peppermint Jet Fuel	7	decent	
--58	artisanal watered-down Grimacider	2	EPIC	
+-51	mediocre irresponsibly strong Hi-Octane Peppermint Jet Fuel	7	decent	
+-58	watered-down artisanal Grimacider	2	EPIC	
 -59	tolerable Isotope Nog	3	good	
--60	weak artisanal Mutagin 'n' Tonic	2	EPIC	
+-60	artisanal weak Mutagin 'n' Tonic	2	EPIC	
 -70	hand-crafted practically non-alcoholic Gin and Herring	1	EPIC	
 -71	perfectly mixed Black and Tan and Red All Over	3	EPIC	
 -72	tolerable watered-down Antarctic Ice Tea	2	good	
@@ -24,7 +24,7 @@
 -78	mediocre blue twirling CRIMBCO Extreme Braincracker Sour	3	decent	
 -82	hand-crafted Horseradish-infused Vodka	4	EPIC	
 -83	drinkable shaking Jerkitini	3	good	
--84	special spirit-forward acceptable Desert Island Iced Tea	5	good	
+-84	spirit-forward acceptable special Desert Island Iced Tea	5	good	
 -88	mediocre Crimbo Saketini	3	decent	
 -89	drinkable Crimboku Drop	3	good	
 -90	tolerable Flaming Crimbo Log	3	good	

--- a/data/TCRS/TCRS_Sauceror_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Wallaby_cafe_food.txt
@@ -4,17 +4,17 @@
 -7	rotten skewed gumdrop chow mein	4	crappy	
 -8	spoiled miniature candy cane pizza	2	crappy	
 -9	spoiled skewed gingerbread stir-fry	3	crappy	
--10	big delicious green twigs and gravel	5	awesome	
+-10	delicious big green twigs and gravel	5	awesome	
 -11	flavorless shoots and leaves	3	decent	
 -12	big spoiled blurry bowl of unidentifiable goo	5	crappy	
 -13	spoiled jittery bouncing gingerbread massacre	4	crappy	
 -14	stale gigantic It Came From Beyond Dessert	7	decent	
 -15	rotten red vampire cake	4	crappy	
 -52	spoiled gigantic Soylent Red and Green	9	crappy	
--53	tiny stale wobbly Disc-Shaped Nutrition Unit	1	decent	
+-53	stale tiny wobbly Disc-Shaped Nutrition Unit	1	decent	
 -54	half-sized bland special Gingerborg Hive	2	decent	
--61	moldy big Candy Cane Surprise	5	crappy	
--62	half-sized tasty Grimdrop Chow Mein	2	awesome	
+-61	big moldy Candy Cane Surprise	5	crappy	
+-62	tasty half-sized Grimdrop Chow Mein	2	awesome	
 -63	bland Grimgerbread House	4	decent	
 -67	tasty miniature Caviar Carbonara	2	awesome	
 -68	normal twirling Halibut Alfredo	3	good	
@@ -23,22 +23,22 @@
 -74	small rotten New and Improved CRIMBCO Reconstituted Gruel	2	crappy	
 -75	toothsome CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	awesome	
 -79	bland Brussels Sprout Stir-Fry	3	decent	
--80	decent snack-sized Carrot, Cabbage, and Kale Pizza	2	good	
+-80	snack-sized decent Carrot, Cabbage, and Kale Pizza	2	good	
 -81	snack-sized stale Turnip and Rutabaga Pie	2	decent	
 -85	spoiled Rainbow Spider Fun Roll	4	crappy	
--86	half-sized spoiled Vegas Volcano Lava Roll	2	crappy	
+-86	spoiled half-sized Vegas Volcano Lava Roll	2	crappy	
 -87	bland shaking Crazy Dragon Shogun Buddha Roll	3	decent	
--92	normal small enchanted skewed gray basic hot dog	2	good	
+-92	enchanted normal small skewed gray basic hot dog	2	good	
 -93	spoiled half-sized savage macho dog	2	crappy	
 -94	bland one with everything	4	decent	
 -95	adequate fuchsia sly dog	4	good	
 -96	stale devil dog	4	decent	
--97	normal red huge chilly dog	3	good	
+-97	normal huge red chilly dog	3	good	
 -98	decent ghost dog	4	good	
 -99	stale skewed junkyard dog	4	decent	
--100	moldy huge blurry wet dog	10	crappy	
--101	delicious red shaking narrow sleeping dog	3	awesome	
--102	jumbo tasty optimal dog	5	awesome	
+-100	huge moldy blurry wet dog	10	crappy	
+-101	delicious narrow red shaking sleeping dog	3	awesome	
+-102	tasty jumbo optimal dog	5	awesome	
 -103	moldy video games hot dog	4	crappy	
 -104	moldy ghostly ghostly Peppermint Nutrition Block	4	crappy	
 -105	huge stale cyan Gingerbread Nutrition Block	9	decent	

--- a/data/TCRS/TCRS_Sauceror_Wombat.txt
+++ b/data/TCRS/TCRS_Sauceror_Wombat.txt
@@ -72,12 +72,12 @@
 73	barskin tent	0		
 74	Temple map	0		
 75	sapling	0		
-76	jittery lime green Spooky-Gro fertilizer	0		
+76	lime green jittery Spooky-Gro fertilizer	0		
 77	stick of vim and vigor	0		Maximum HP Percent: +50
 78	pretty bouquet of the early riser	0		Adventures: +7
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	acceptable irresponsibly strong ice-cold Willer	9	good	
+81	irresponsibly strong acceptable ice-cold Willer	9	good	
 82	ring	0		
 83	shaft	0		
 84	wobbly twirling Orcish meat locker	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	lion tamer's manspreader's staff	0		Monster Level: +10, Experience (familiar): +2
 104	scarecrow	0		
-105	toothsome big bowl of charms	5	awesome	
+105	big toothsome bowl of charms	5	awesome	
 106	squat ketchup	1	decent	
 107	catsup	1	awesome	
 108	stick	0		
@@ -117,8 +117,8 @@
 118	upside-down purple spring	0		
 119	sprocket	0		
 120	cog	0		
-121	huge blurry sprocket assembly	0		
-122	teal blinking cog and sprocket assembly	0		
+121	blurry huge sprocket assembly	0		
+122	blinking teal cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
 124	gray pulsating empty meat tank	0		
 125	jittery full meat tank	0		
@@ -158,16 +158,16 @@
 159	wad of dough	0		
 160	pie crust	0		
 161	decent ghuol egg	3	good	
-162	bland half-sized upside-down blinking ghuol egg quiche	2	decent	
+162	half-sized bland upside-down blinking ghuol egg quiche	2	decent	
 163	skeleton bone of the bloodbag	0		Maximum HP: +100
 164	mirror red smart skull	0		
 165	skewed skewer	0		
 166	pulsating ghuol ears	0		
-167	normal miniature shaking ghuol-ear kabob	2	good	
+167	miniature normal shaking ghuol-ear kabob	2	good	
 168	narrow educational bone rattle	0		Experience: +1
 169	mirror blue bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	snack-sized spoiled lihc eye pie	2	crappy	
+171	spoiled snack-sized lihc eye pie	2	crappy	
 172	jittery gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
@@ -175,8 +175,8 @@
 176	tumbling disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	small spoiled chorizo taco	2	crappy	
-180	acceptable extra-dry ice-cold fotie	5	good	
+179	spoiled small chorizo taco	2	crappy	
+180	extra-dry acceptable ice-cold fotie	5	good	
 181	wobbly baseball	0		
 182	batgut	0		
 183	twirling bat wing	0		
@@ -196,7 +196,7 @@
 198	rat appendix	0		
 199	brainy ring	0		Mysticality: +5
 200	stale squat rat appendix kabob	4	decent	
-201	adequate fancy spinning narrow bat wing kabob	4	good	Effect: "Grape Expectations", Effect Duration: 15
+201	fancy adequate narrow spinning bat wing kabob	4	good	Effect: "Grape Expectations", Effect Duration: 15
 202	flavorless carob chunks	4	decent	
 203	herbs	0		
 204	yummy miniature mirror carob chunk cookies	2	awesome	
@@ -207,7 +207,7 @@
 209	wad of tofu	0		
 210	skewed Feng Shui for Big Dumb Idiots	0		
 211	squat decorative fountain	0		
-212	purple wobbly pulsating windchimes	0		
+212	purple pulsating wobbly windchimes	0		
 213	pulsating frightening occult filthy corduroys	0		Spell Damage Percent: +25, Spooky Damage: +5, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	spinning jittery slick filthy knitted dread sack	0		Moxie: +10, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
@@ -233,32 +233,32 @@
 235	blue dangerous Bigger Bugfinder Blade of courage	0		Weapon Damage: +10, Spooky Resistance: +3
 236	Queue Du Coq cocktailcrafting kit	0		
 237	acceptable skewed bottle of gin	4	good	
-238	hand-crafted strong bottle of vodka	5	EPIC	
+238	strong hand-crafted bottle of vodka	5	EPIC	
 239	Van der Graaf fortified Orcish baseball cap	0		Damage Absorption: +60, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	brainy Orcish cargo shorts of wisdom	0		Mysticality: 20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	frightening Orcish frat-paddle	0		Spooky Damage: +5
 242	adequate	4	good	
 243	spoiled yellow wobbly grapefruit	4	crappy	
 244	bite-sized rotten grapes	1	crappy	
-245	delicious immense lime green olive	8	awesome	
+245	immense delicious lime green olive	8	awesome	
 246	flavorless ghostly tomato	3	decent	
 247	mirror fermenting powder	0		
-248	bad high-proof fancy salty dog	10	decent	Effect: "Witch's Brood", Effect Duration: 45
-249	mediocre extra-dry upside-down twirling bloody mary	5	decent	
-250	weak aged screwdriver	2	awesome	
+248	bad fancy high-proof salty dog	10	decent	Effect: "Witch's Brood", Effect Duration: 45
+249	mediocre extra-dry twirling upside-down bloody mary	5	decent	
+250	aged weak screwdriver	2	awesome	
 251	watered-down mediocre martini	2	decent	
-252	enchanted weak mediocre bloody beer	2	decent	Effect: "Sealed Brain", Effect Duration: 40
+252	weak mediocre enchanted bloody beer	2	decent	Effect: "Sealed Brain", Effect Duration: 40
 253	artisanal twirling shot of schnapps	3	EPIC	
 254	triple-distilled bad skewed shot of grapefruit schnapps	7	decent	
-255	distilled bad upside-down fine wine	5	decent	
+255	bad distilled upside-down fine wine	5	decent	
 256	bad shot of tomato schnapps	3	decent	
 257	acceptable extra-spicy bloody mary	4	good	
 258	pulsating dense meat stack	0		
 259	snake skin	0		
 260	delicious mirror White Citadel fries	3	awesome	
 261	small decent White Citadel burger	2	good	
-262	enchanted bland diet piece of wedding cake	1	decent	Effect: "Mortarfied", Effect Duration: 10
-263	huge normal chocolate chips	10	good	
+262	bland enchanted diet piece of wedding cake	1	decent	Effect: "Mortarfied", Effect Duration: 10
+263	normal huge chocolate chips	10	good	
 264	flavorless tumbling chocolate chip cookies	3	decent	
 265	personal trainer's satin pants	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	drinkable lightning	4	good	
@@ -273,11 +273,11 @@
 275	jittery mosquito larva	0		
 276	leprechaun hatchling	0		
 277	altered twirling extra-strength strongness elixir	1		Effect: "Bread Burps", Effect Duration: 45
-278	modified narrow bouncing jug-o-magicalness	1		Effect: "Puddingface", Effect Duration: 35
+278	modified bouncing narrow jug-o-magicalness	1		Effect: "Puddingface", Effect Duration: 35
 279	boiled suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
 281	educational gasmask	0		Experience: +1, Familiar Effect: "1xBarrr, cap 12"
-282	blurry teal Boris's key	0		
+282	teal blurry Boris's key	0		
 283	Jarlsberg's key	0		
 284	pulsating Sneaky Pete's key	0		
 285	yellow walrus-tusk earring of the boozehound	0		Booze Drop: +100
@@ -298,7 +298,7 @@
 300	Vulcanized jaba&ntilde;ero-flavored chewing gum	0		Effect: "Super-Charged", Effect Duration: 31
 301	skewed flat dough	0		
 302	moldy Knob sausage	3	crappy	
-303	adequate huge skewed Knob mushroom	9	good	
+303	huge adequate skewed Knob mushroom	9	good	
 304	dry noodles	0		
 305	yellow Knob Goblin harem pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	stanky Knob Goblin harem veil	0		Stench Spell Damage: +25, Familiar Effect: "5xLep, cap 2"
@@ -310,30 +310,30 @@
 312	steel-toed Knob Goblin visor	0		Damage Reduction: 9, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	huge groovy Crown of the Goblin King	0		Moxie Percent: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	yummy bean burrito	3	awesome	
-315	diet adequate bean burrito	1	good	
+315	adequate diet bean burrito	1	good	
 316	snack-sized normal olive insanely bean burrito	2	good	
 317	flavorless bean burrito	3	decent	
 318	flavorless fuchsia bean burrito	3	decent	
-319	toothsome snack-sized insanely bean burrito	2	awesome	
+319	snack-sized toothsome insanely bean burrito	2	awesome	
 320	normal bat haggis	3	good	
 321	toothsome thick shaking menudo	5	awesome	
 322	stale jumbo yellow goat cheese	5	decent	
-323	toothsome diet plain pizza	1	awesome	
-324	bland immense sausage pizza	10	decent	
+323	diet toothsome plain pizza	1	awesome	
+324	immense bland sausage pizza	10	decent	
 325	thick bland goat cheese pizza	5	decent	
 326	flavorless twirling mushroom pizza	3	decent	
 327	blurry goat	0		
 328	artisanal boozy skewed bottle of whiskey	5	EPIC	
 329	gravedigger's goat beard	0		Spooky Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	enchanted glass of goat's milk	1	decent	Effect: "Yeah, It's Just Gasoline", Effect Duration: 40
-331	tolerable irresponsibly strong purple Canadian	6	good	
+331	irresponsibly strong tolerable purple Canadian	6	good	
 332	flavorless lemon	3	decent	
-333	snack-sized rotten lime	2	crappy	
+333	rotten snack-sized lime	2	crappy	
 334	spinning double-paned sabre teeth	0		Cold Resistance: +5
 335	sabre-toothed lime cub	0		
 336	blurry zippy consolation ribbon	0		Initiative: +20
 337	blue ghostly ol' trophy	0		
-338	bouncing yellow tenderizing hammer	0		
+338	yellow bouncing tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
 340	irradiated Knob Goblin steroids	0		Effect: "The Spy Who Loved XP", Effect Duration: 56
 341	boiled Knob Goblin love potion	0		Effect: "Ninja, Please", Effect Duration: 58
@@ -342,10 +342,10 @@
 344	Knob Goblin seltzer	0		
 345	huge Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
-347	blurry pulsating Dyspepsi-Cola	0		
+347	pulsating blurry Dyspepsi-Cola	0		
 348	mansplainer's ninja mask	0		Monster Level: +15, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	blurry red tumbling icy katana hilt	0		
-350	cyan skewed hot katana blade	0		
+350	skewed cyan hot katana blade	0		
 351	ruddy fortified icy-hot katana	0		Damage Absorption: +60, Maximum HP Percent: +40
 352	shellacked ninja hot pants	0		Damage Reduction: 7, Familiar Effect: "hot atk, 3xPotato, cap 17"
 353	ninja stars	0		
@@ -353,7 +353,7 @@
 355	eXtreme scarf of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	mirror snowboarder pants of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xPotato, cap 25"
 357	twirling Mountain Stream soda	0		
-358	snack-sized adequate gr8ps	2	good	
+358	adequate snack-sized gr8ps	2	good	
 359	adequate mirror t8r tots	4	good	
 360	censurious miner's helmet	0		Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	greasy miner's pants	0		Sleaze Spell Damage: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -460,13 +460,13 @@
 462	pixel	0		
 463	pixel	0		
 464	jittery pixel potion	0		
-465	blinking ghostly pixel potion	0		
+465	ghostly blinking pixel potion	0		
 466	teal pixel potion	0		
-467	small flavorless pixel pie	2	decent	
+467	flavorless small pixel pie	2	decent	
 468	ruby W	0		
 469	cyan wussiness potion	0		
 470	tolerable red Imp Ale	3	good	
-471	enchanted bland hot wing	4	decent	Effect: "Stop the Presses!", Effect Duration: 45
+471	bland enchanted hot wing	4	decent	Effect: "Stop the Presses!", Effect Duration: 45
 472	bouncing thinker's diamond-studded cane	0		Mysticality: +10, Class: "Disco Bandit"
 473	olive boxer's crutch	0		Muscle Percent: +10
 474	cast	0		
@@ -484,7 +484,7 @@
 486	strapping Talisman o' Namsilat	0		Muscle: +5, Single Equip
 487	gray Jim Carey's arrrgyle socks	0		Monster Level: +25
 488	blurry guitar pick	0		
-489	cyan jittery blinking drab sonata	0		
+489	cyan blinking jittery drab sonata	0		
 490	Newton's mesh cap of horror	0		Experience (Mysticality): +3, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 41"
 491	enormous belt buckle	0		
 492	chaps of the boozehound of the sweet-tooth	0		Booze Drop: +100, Candy Drop: +100, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
@@ -496,18 +496,18 @@
 498	moldy papaya	3	crappy	
 499	red upside-down Samson's denim axe of Gandalf	0		Experience (Muscle): +5, Spell Critical Percent: +20
 500	Elf Farm Raffle ticket	0		
-501	rotten low-calorie ghostly Elfin shortbread	1	crappy	
+501	low-calorie rotten ghostly Elfin shortbread	1	crappy	
 502	pagoda plans	0		
 503	special stale narrow skewered cat appendix	4	decent	Effect: "Liquidy Smoky", Effect Duration: 5
 504	evil arches	0		
 505	auspicious quilted gnatwing earring	0		Damage Absorption: +40, Item Drop: +10
-506	special flavorless Hell broth	3	decent	Effect: "Empathy", Effect Duration: 25
+506	flavorless special Hell broth	3	decent	Effect: "Empathy", Effect Duration: 25
 507	ghostly fortified thunderrr guitarrr	0		Damage Absorption: +60
 508	sonata	0		
 509	Hey Deze nuts	0		
 510	teal Boris's key lime	0		
 511	Jarlsberg's key lime	0		
-512	cyan mirror Sneaky Pete's key lime	0		
+512	mirror cyan Sneaky Pete's key lime	0		
 513	yummy squat Boris's key lime pie	4	awesome	
 514	adequate tiny skewed skewed Jarlsberg's key lime pie	1	good	
 515	diet normal shaking Sneaky Pete's key lime pie	1	good	
@@ -549,13 +549,13 @@
 551	jittery teal 64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	small moldy pr0n cocktail	2	crappy	
+554	moldy small pr0n cocktail	2	crappy	
 555	supercharged drywall axe of the early riser	0		Maximum MP Percent: +30, Adventures: +7
 556	spinning upside-down Pine-Fresh air freshener of James Dean	0		Experience (Moxie): +3
-557	lousy irresponsibly strong whiskey and cola	6	decent	
+557	irresponsibly strong lousy whiskey and cola	6	decent	
 558	delicious blinking papaya taco	4	awesome	
 559	green razor-sharp can lid	0		
-560	yummy half-sized stalk of asparagus	2	awesome	
+560	half-sized yummy stalk of asparagus	2	awesome	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	wobbly sonar-in-a-biscuit	0		
@@ -567,13 +567,13 @@
 569	spoiled Lord of the Flies-sized fries	4	crappy	
 570	bland shaking Chicken Sandwich	3	decent	
 571	squat Jumbo Dr. Lucifer	1	crappy	
-572	miniature spoiled upside-down Children's Meal of the Damned	2	crappy	
+572	spoiled miniature upside-down Children's Meal of the Damned	2	crappy	
 573	moldy noodles	4	crappy	
 574	moldy bite-sized noodles	1	crappy	
-575	decent snack-sized painful penne pasta	2	good	
-576	snack-sized decent blue ravioli della hippy	2	good	
-577	immense normal fancy jittery pr0n m4nic0tti	6	good	Effect: "Wintry Breath", Effect Duration: 25
-578	flavorless bite-sized Hell ramen	1	decent	
+575	snack-sized decent painful penne pasta	2	good	
+576	decent snack-sized blue ravioli della hippy	2	good	
+577	normal immense fancy jittery pr0n m4nic0tti	6	good	Effect: "Wintry Breath", Effect Duration: 25
+578	bite-sized flavorless Hell ramen	1	decent	
 579	rotten gray boring spaghetti	3	crappy	
 580	narrow sauce of the ages	0		
 581	schmancy cheese sauce	0		
@@ -634,7 +634,7 @@
 636	jittery meat globe	0		
 637	spinning toaster	0		
 638	bouncing resourceful Da Vinci's asshat	0		Experience (Mysticality): +5, Maximum MP: +50, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	gigantic adequate bouncing abominable snowcone	9	good	
+639	adequate gigantic bouncing abominable snowcone	9	good	
 640	pulsating Ent cider	1	EPIC	
 641	yummy upside-down toast	3	awesome	
 642	skeleton key	0		
@@ -644,8 +644,8 @@
 646	stale fruitcake	3	decent	
 647	upside-down present	0		Last Available: "2004-11"
 648	Crimbo sword of the sweet-tooth	0		Candy Drop: +100, Last Available: "2004-10"
-649	forbidden Crimbo hat	0		Spell Damage Percent: +50, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	huge family-friendly Crimbo pants	0		Sleaze Resistance: +1, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	forbidden Crimbo hat	0		Spell Damage Percent: +50, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	huge family-friendly Crimbo pants	0		Sleaze Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	blue wizardly exclusive ultra-rare item	0		Mysticality: +25
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -674,15 +674,15 @@
 676	blurry dragonbone belt buckle	0		
 677	Oprah's badass belt	0		Maximum MP Percent: +50
 678	chest of the Bonerdagon	0		
-679	aged extra-dry roll in the hay	5	awesome	
+679	extra-dry aged roll in the hay	5	awesome	
 680	mediocre slap and tickle	3	decent	
-681	irresponsibly strong perfectly mixed slip 'n' slide	6	EPIC	
-682	weak special bad a sump'm sump'm	2	decent	Effect: "Very Clean Teeth", Effect Duration: 45
-683	practically non-alcoholic hand-crafted special horizontal tango	1	super ultra mega turbo EPIC	Effect: "Lubed", Effect Duration: 15
+681	perfectly mixed irresponsibly strong slip 'n' slide	6	EPIC	
+682	bad special weak a sump'm sump'm	2	decent	Effect: "Very Clean Teeth", Effect Duration: 45
+683	special hand-crafted practically non-alcoholic horizontal tango	1	super ultra mega turbo EPIC	Effect: "Lubed", Effect Duration: 15
 684	boozy tolerable pink pony	5	good	
 685	lard-coated Mr. Shirt of the blizzard of the glutton	0		Cold Spell Damage: +25, Sleaze Spell Damage: +25, Food Drop: +100
 686	hardened knuckles	0		Damage Reduction: 3
-687	polymerized shaking upside-down blood of the Wereseal	0		Effect: "The Solution", Effect Duration: 27
+687	polymerized upside-down shaking blood of the Wereseal	0		Effect: "The Solution", Effect Duration: 27
 688	gray Temple Grandin's pixel hat	0		Familiar Weight: +7, Familiar Effect: "atk, 2xVolley, cap 12"
 689	miser's pixel pants	0		Meat Drop: +10, Familiar Effect: "atk, 4xPotato, cap 12"
 690	Annie Oakley's pixel sword	0		Critical Hit Percent: +20
@@ -722,7 +722,7 @@
 726	huge mirror shard of the pedagogue	0		Experience: +3
 727	hedge maze puzzle	0		
 728	bouncing hedge maze key	0		
-729	narrow red fishbowl	0		
+729	red narrow fishbowl	0		
 730	fishtank	0		
 731	fish hose	0		
 732	hosed tank	0		
@@ -735,22 +735,22 @@
 739	upside-down tambourine bells	0		
 740	fortified tambourine	0		Damage Absorption: +60
 741	broken skull	0		
-742	small bland yellow Knoll shroomkabob	2	decent	
+742	bland small yellow Knoll shroomkabob	2	decent	
 743	rotten mushroom	3	crappy	
 744	energized quadruple-polarized ghostly hair spray	0		Effect: "Thunderspell", Effect Duration: 18
 746	stat script	0		
 747	narrow Knob Goblin firecracker	0		
 748	narrow gourd potion	0		
-749	spoiled massive warm mushroom	8	crappy	
+749	massive spoiled warm mushroom	8	crappy	
 750	moldy snack-sized mushroom quesadilla	2	crappy	
 751	adequate super-sized cool mushroom	5	good	
 752	rotten jumbo cool mushroom casserole	5	crappy	
-753	flavorless huge ghostly bouncing pointy mushroom	6	decent	
+753	huge flavorless ghostly bouncing pointy mushroom	6	decent	
 754	rotten cream of pointy mushroom soup	3	crappy	
 755	rotten thick wobbly mushroom	5	crappy	
-756	bite-sized bland enchanted mushroom	1	decent	Effect: "Ticking Clock", Effect Duration: 25
-757	adequate upside-down blue mushroom	4	good	
-758	low-calorie decent ghost cucumber	1	good	
+756	bite-sized enchanted bland mushroom	1	decent	Effect: "Ticking Clock", Effect Duration: 25
+757	adequate blue upside-down mushroom	4	good	
+758	decent low-calorie ghost cucumber	1	good	
 759	dill	0		
 760	vinegar	0		
 761	brine	0		
@@ -789,7 +789,7 @@
 794	altered extra-energized pressed spinning oil of slipperiness	0		Effect: "Devil Inside", Effect Duration: 20
 795	hand-crafted triple-distilled Acque Luride Grezze Cabernet	10	EPIC	Last Available: "2004-10"
 796	knitted scorching smooth cement shoes	0		Moxie: +15, Hot Damage: +25, Cold Resistance: +3, Last Available: "2004-10"
-797	perfectly mixed watered-down rockin' wagon	2	EPIC	
+797	watered-down perfectly mixed rockin' wagon	2	EPIC	
 798	drinkable ocean motion	4	good	
 799	artisanal mirror fuzzbump	3	EPIC	
 800	decent fancy bouncing poutine	3	good	Effect: "Blood-Gorged", Effect Duration: 5
@@ -797,26 +797,26 @@
 804	yummy enchanted Knoll stir-fry	3	awesome	Effect: "Purpose", Effect Duration: 20
 805	decent wobbly stir-fry	3	good	
 806	low-calorie rotten ghostly asparagus stir-fry	1	crappy	
-807	enchanted rotten olive stir-fry	3	crappy	Effect: "Cool Spirit", Effect Duration: 50
+807	rotten enchanted olive stir-fry	3	crappy	Effect: "Cool Spirit", Effect Duration: 50
 808	bland olive Knob sausage stir-fry	4	decent	
 809	small normal bat wing stir-fry	2	good	
 810	flavorless massive tumbling rat appendix stir-fry	9	decent	
 811	delicious tofu stir-fry	4	awesome	
 812	yummy tumbling pr0n stir-fry	4	awesome	
-813	tasty snack-sized Knob shells	2	awesome	
+813	snack-sized tasty Knob shells	2	awesome	
 814	normal b&auml;tzle	4	good	
 815	stale shaking ratini	3	decent	
-816	decent massive Knob stroganoff	9	good	
+816	massive decent Knob stroganoff	9	good	
 817	thick decent menudo ravioli	5	good	
 818	tumbling plus sign	0		
-819	upside-down pulsating milky potion	0		
+819	pulsating upside-down milky potion	0		
 820	swirly potion	0		
 821	skewed bubbly potion	0		
 822	pulsating smoky potion	0		
 823	wobbly cloudy potion	0		
 824	effervescent potion	0		
 825	cyan fizzy potion	0		
-826	ghostly gray dark potion	0		
+826	gray ghostly dark potion	0		
 827	murky potion	0		
 828	tumbling mirror baby killer bee	0		
 829	narrow anti-anti-antidote	0		
@@ -826,7 +826,7 @@
 833	vorpal blade of Calamity Jane	0		Critical Hit Percent: +15
 834	cornuthaum of the brazier of mayonnaise	0		Hot Spell Damage: +25, Sleaze Spell Damage: +50, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	squat Da Vinci's ring of aggravate monster	0		Experience (Mysticality): +5
-836	thick rotten tumbling mind flayer corpse	5	crappy	
+836	rotten thick tumbling mind flayer corpse	5	crappy	
 837	drinkable Uovo Marcio Shiraz	3	good	Last Available: "2004-10"
 838	horrifying clever Mafia stogie	0		Maximum MP: +20, Spooky Damage: +25, Last Available: "2004-10"
 839	tolerable Maiali Sifilitici Pinot Noir	3	good	Last Available: "2004-10"
@@ -860,7 +860,7 @@
 869	forest tears	0		
 870	twirling upside-down supercharged fetus-smashing club	0		Maximum MP Percent: +30
 871	jittery meatcar model	0		Familiar Weight: +5
-872	yellow wobbly Time Juice	0		Last Available: "2004-01"
+872	wobbly yellow Time Juice	0		Last Available: "2004-01"
 873	rolling pin	0		
 874	blurry unrolling pin	0		
 875	spinning greasy healthy baleful crazy bastard sword	0		Spell Damage: +25, Maximum HP Percent: +20, Sleaze Spell Damage: +10
@@ -878,38 +878,38 @@
 887	leaf	0		
 888	huge maple leaf	0		
 889	Jeselnik's balaclava	0		Sleaze Damage: +25, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	special stale snack-sized balaclava baklava	2	decent	Effect: "Bread Burps", Effect Duration: 15
+890	snack-sized special stale balaclava baklava	2	decent	Effect: "Bread Burps", Effect Duration: 15
 891	blurry Warehouse 23 bling of the detective	0		Item Drop: +20
 892	greedy quilted bugbear-smiting sword of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40, Meat Drop: +20
 893	hand-crafted practically non-alcoholic lumbering jack	1	EPIC	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	pulsating bouncing sage Ms. Accessory	0		Mysticality Percent: +10, Softcore Only
 896	ghostly frosty sage Mr. Accessory Jr.	0		Mysticality Percent: +10, Cold Spell Damage: +10, Softcore Only
-897	maroon squat coffee sprite	0		Free Pull, Last Available: "2005-10"
+897	squat maroon coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
 900	tumbling smile-sharpening stone	0		Familiar Weight: +5
 901	red espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	smooth Spasmi Dolorosi Del Rene Champagne	4	awesome	Last Available: "2004-10"
-904	electrified supercharged extremely unsafe school Mafia knickerbockers	0		Weapon Damage Percent: +100, Maximum MP Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	electrified supercharged extremely unsafe school Mafia knickerbockers	0		Weapon Damage Percent: +100, Maximum MP Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	vacuum-sealed concentrated Yummy Tummy bean	0		Effect: "Weird Flavor", Effect Duration: 20
 906	extra-ionized blurry bouncing Rock Pops	0		Effect: "World's Shortest Giant", Effect Duration: 54
 907	liquefied activated Mr. Mediocrebar	0		Effect: "Pharmaceutically Cool", Effect Duration: 28
 908	colloidal Cold Hots candy	0		Effect: "A Few Extra Pounds", Effect Duration: 45
 909	cold-filtered Wint-O-Fresh mint	0		Effect: "Adrenaline Rush", Effect Duration: 24
-910	decent miniature dwarf bread	2	good	
+910	miniature decent dwarf bread	2	good	
 911	polymerized skewed Senior Mints	0		Effect: "Stuck-Up Hair", Effect Duration: 26
 912	anodized pixellated candy heart	0		Effect: "Meadulla Oblongota", Effect Duration: 25
 913	deionized activated kobold	0		Effect: "Pyromania", Effect Duration: 12
-914	bouncing red hand turkey outline	0		Free Pull, Last Available: "2004-11"
+914	red bouncing hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	veiny wholesome intergalactic pom poms	0		Maximum HP Percent: +10, Maximum HP: +10
 917	Mob Penguin protection contract	0		
-918	mirror blinking frightening Radio Free Baseball Cap	0		Spooky Damage: +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	wobbly thinker's Radio Free Pants	0		Mysticality: +10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	mirror blinking frightening Radio Free Baseball Cap	0		Spooky Damage: +5, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	wobbly thinker's Radio Free Pants	0		Mysticality: +10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	sharpshooter's Radio Free Foil	0		Critical Hit Percent: +10, Last Available: "2006-07"
-921	decent blinking gray radio button candy	4	good	
+921	decent gray blinking radio button candy	4	good	
 922	thinker's severed rocking horse head	0		Mysticality: +10
 923	mirror broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -918,7 +918,7 @@
 927	watered-down tolerable ghostly Ferita Del Petto Zinfandel	2	good	Last Available: "2006-12"
 928	Herculean fuzzy bracelets	0		Experience (Muscle): +1
 929	squat zippy arse-shooting crossbow	0		Initiative: +20
-931	fancy practically non-alcoholic perfectly mixed cyan spiced rum	1	EPIC	Effect: "Norwhalloped", Effect Duration: 35
+931	practically non-alcoholic fancy perfectly mixed cyan spiced rum	1	EPIC	Effect: "Norwhalloped", Effect Duration: 35
 932	artisanal eggnog	3	EPIC	
 933	bland snack-sized skewed candy cane	2	decent	
 934	spoiled blurry gingerbread bugbear	3	crappy	
@@ -929,15 +929,15 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	blinking bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	jittery shaking padded bowler	0		Damage Absorption: +20, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	jittery shaking padded bowler	0		Damage Absorption: +20, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	inspector's smartaleck's bow staff	0		Moxie Percent: +30, Item Drop: +15, Last Available: "2004-12"
-944	wobbly double-paned bowlegged pants	0		Cold Resistance: +5, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	wobbly double-paned bowlegged pants	0		Cold Resistance: +5, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	bouncing skewered cherry	0		Last Available: "2004-12"
 948	artisanal special wobbly martini	3	super ultra EPIC	Effect: "Jerky, Boy", Effect Duration: 30, Last Available: "2004-12"
-949	irresponsibly strong mediocre grogtini	9	decent	Last Available: "2004-12"
-950	hand-crafted extra-dry cherry bomb	5	EPIC	Last Available: "2004-12"
+949	mediocre irresponsibly strong grogtini	9	decent	Last Available: "2004-12"
+950	extra-dry hand-crafted cherry bomb	5	EPIC	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	wobbly fuchsia forbidden dance instructor's hockey mask	0		Experience Percent (Moxie): +10, Spell Damage Percent: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
@@ -947,7 +947,7 @@
 957	super-sized adequate spinning chorizo brownies	5	good	
 958	tasty thick chocolate and tomato pizza	5	awesome	
 959	lime green flange	0		
-960	bouncing fuchsia clockwork key	0		
+960	fuchsia bouncing clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
 962	narrow velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	resourceful sage plastic seal clubber	0		Mysticality Percent: +10, Maximum MP: +50
@@ -993,7 +993,7 @@
 1006	normal special blurry cherry	4	good	Effect: "The Style... of the Future", Effect Duration: 45
 1007	boxer's coconut shell	0		Muscle Percent: +10, Familiar Effect: "1xFairy, cap 7"
 1008	zippy ice cubes	0		Initiative: +20
-1009	bad irresponsibly strong vodka martini	7	decent	
+1009	irresponsibly strong bad vodka martini	7	decent	
 1010	artisanal whiskey and soda	3	EPIC	
 1011	lousy blurry monkey wrench	3	decent	
 1012	practically non-alcoholic perfectly mixed tequila sunrise	1	EPIC	
@@ -1001,15 +1001,15 @@
 1014	artisanal strawberry wine	3	EPIC	
 1015	artisanal maroon wine spritzer	3	EPIC	
 1016	hand-crafted bouncing perpendicular hula	4	EPIC	
-1017	lousy weak ducha de oro	2	decent	
-1018	perfectly mixed watered-down calle de miel	2	EPIC	
+1017	weak lousy ducha de oro	2	decent	
+1018	watered-down perfectly mixed calle de miel	2	EPIC	
 1019	bad dry vodka martini	3	decent	
-1020	mediocre irresponsibly strong huge old-fashioned	7	decent	
-1021	tolerable strong tequila with training wheels	5	good	
+1020	irresponsibly strong mediocre huge old-fashioned	7	decent	
+1021	strong tolerable tequila with training wheels	5	good	
 1022	enchanted mediocre sangria	4	decent	Effect: "Ponderous Potency", Effect Duration: 10
-1023	watered-down delicious ghostly vesper	2	awesome	Last Available: "2004-12"
+1023	delicious watered-down ghostly vesper	2	awesome	Last Available: "2004-12"
 1024	drinkable watered-down bodyslam	2	good	Last Available: "2004-12"
-1025	tolerable teal tumbling sangria del diablo	3	good	Last Available: "2004-12"
+1025	tolerable tumbling teal sangria del diablo	3	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
 1028	huge huge buckler buckle	0		
@@ -1029,9 +1029,9 @@
 1043	skewed string of beads of the sweet-tooth	0		Candy Drop: +100
 1044	deadly string of beads	0		Weapon Damage: +5
 1045	mirror wobbly Lo Pan's plastic bottle opener	0		Spell Critical Percent: +30
-1046	medical-grade forbidden traffic cone	0		Spell Damage Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	medical-grade forbidden traffic cone	0		Spell Damage Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	hand-crafted fancy N. O. Beer	3	EPIC	Effect: "Moon'd", Effect Duration: 15
-1048	diluted green ghostly wobbly huge oyster egg	1		Effect: "Red-Shirted Escort", Effect Duration: 45
+1048	diluted wobbly ghostly huge green oyster egg	1		Effect: "Red-Shirted Escort", Effect Duration: 45
 1049	vaporized oyster egg	1		
 1050	mixed blurry oyster egg	1		Effect: "Wet and Greedy", Effect Duration: 20
 1051	plastic oyster egg	0		
@@ -1039,7 +1039,7 @@
 1053	compressed oyster egg	1		Effect: "Heightened Senses", Effect Duration: 20
 1054	distilled blinking jittery oyster egg	1		
 1055	wobbly plastic oyster egg	0		
-1056	dried upside-down red jittery puce oyster egg	1		
+1056	dried red upside-down jittery puce oyster egg	1		
 1057	dried shaking puce oyster egg	1		Effect: "Gummi Badass", Effect Duration: 5
 1058	altered spinning puce oyster egg	1		
 1059	shaking puce plastic oyster egg	0		
@@ -1053,13 +1053,13 @@
 1067	cyan plastic oyster egg	0		
 1068	modified oyster egg	1		Effect: "Flexibili Tea", Effect Duration: 40
 1069	modified oyster egg	1		
-1070	distilled blinking upside-down oyster egg	1		Effect: "Fishy Fortification", Effect Duration: 45
+1070	distilled upside-down blinking oyster egg	1		Effect: "Fishy Fortification", Effect Duration: 45
 1071	bouncing plastic oyster egg	0		
 1072	modified huge off-white oyster egg	1		
 1073	diluted off-white oyster egg	1		
 1074	dried squat wobbly off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	vaporized mirror shaking oyster egg	1		
+1076	vaporized shaking mirror oyster egg	1		
 1077	distilled fuchsia oyster egg	1		Effect: "Healthy Green Glow", Effect Duration: 50
 1078	dehydrated bouncing oyster egg	1		
 1079	green plastic oyster egg	0		
@@ -1069,7 +1069,7 @@
 1083	skewed personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	clockwork widget	0		
-1086	cyan blurry spinning clockwork thingamajig	0		
+1086	blurry spinning cyan clockwork thingamajig	0		
 1087	clockwork doohickey	0		
 1088	clockwork clockwise dome	0		
 1089	clockwork spine	0		
@@ -1114,10 +1114,10 @@
 1128	jittery teeny-tiny ninja stars	0		
 1129	auspicious sequined fez	0		Item Drop: +10, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
-1131	cyan huge beet	0		Last Available: "2005-12"
+1131	huge cyan beet	0		Last Available: "2005-12"
 1132	upside-down Totally Gay Claymore	0		
 1133	blurry blinking Tesla star shirt	0		MP Regen Min: 7, MP Regen Max: 10
-1134	wobbly cyan mirror cosmetics bag	0		
+1134	mirror wobbly cyan cosmetics bag	0		
 1135	pickled pulsating eyeliner	0		Effect: "Comic Violence", Effect Duration: 16
 1136	liquefied vacuum-sealed modified huge lipstick	0		Effect: "Hella Tough", Effect Duration: 38
 1137	huge wobbly rosy-cheeked bicycle chain of the wise owl	0		Mysticality: +20, Maximum HP Percent: +30
@@ -1125,14 +1125,14 @@
 1139	irresponsibly strong lousy mushroom wine	8	decent	
 1140	hand-crafted icy mushroom wine	3	EPIC	
 1141	weak delicious mushroom wine	2	awesome	
-1142	delicious weak pointy mushroom wine	2	awesome	
+1142	weak delicious pointy mushroom wine	2	awesome	
 1143	bad blurry flat mushroom wine	3	decent	
 1144	acceptable cool mushroom wine	3	good	
-1145	high-proof mediocre huge bouncing knob mushroom wine	9	decent	
-1146	practically non-alcoholic smooth knoll mushroom wine	1	awesome	
+1145	mediocre high-proof huge bouncing knob mushroom wine	9	decent	
+1146	smooth practically non-alcoholic knoll mushroom wine	1	awesome	
 1147	hand-crafted mushroom wine	3	EPIC	
-1148	mediocre triple-distilled skewed shot of flower schnapps	8	decent	
-1149	stale half-sized skewed bouncing bouncing flower petal pie	2	decent	
+1148	triple-distilled mediocre skewed shot of flower schnapps	8	decent	
+1149	stale half-sized bouncing skewed bouncing flower petal pie	2	decent	
 1150	strong mediocre bottle of single-barrel whiskey	5	decent	
 1151	asbestos-lined resourceful discarded plastic fork	0		Maximum MP: +50, Hot Resistance: +5
 1152	wobbly gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1156,7 +1156,7 @@
 1171	blinking coffin	0		
 1172	asbestos box	0		
 1173	fuchsia linoleum box	0		
-1174	ghostly bouncing chrome box	0		
+1174	bouncing ghostly chrome box	0		
 1175	cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	gray magnetic field	0		
@@ -1191,14 +1191,14 @@
 1206	half-sized moldy olive velvet cake	2	crappy	
 1207	rotten tiny congratulatory cake	1	crappy	
 1208	tasty skewed angel-food cake	3	awesome	
-1209	diet stale devil's-food cake	1	decent	
+1209	stale diet devil's-food cake	1	decent	
 1210	flavorless birthday party jellybean cheesecake	3	decent	
 1211	jittery blue balloon	0		
 1212	tumbling balloon	0		
 1213	skewed heart-shaped balloon	0		
 1214	anniversary balloon	0		
 1215	pulsating Mylar balloon	0		
-1216	upside-down skewed Kevlar balloon	0		
+1216	skewed upside-down Kevlar balloon	0		
 1217	narrow thought balloon	0		
 1218	twirling rat head balloon	0		Familiar Weight: -3
 1219	mini-zeppelin	0		
@@ -1233,23 +1233,23 @@
 1249	skewed jittery Boss Bat britches of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	flame-wreathed Boss Bat bling of courage	0		Hot Spell Damage: +10, Spooky Resistance: +3
 1251	normal snack-sized shaking Knob shroomkabob	2	good	
-1252	delicious diet shroomkabob	1	awesome	
+1252	diet delicious shroomkabob	1	awesome	
 1253	pile of jumping beans	0		
-1254	spoiled jumbo bouncing jumping bean burrito	5	crappy	
+1254	jumbo spoiled bouncing jumping bean burrito	5	crappy	
 1255	spoiled pulsating jumping bean burrito	4	crappy	
 1256	snack-sized decent insanely jumping bean burrito	2	good	
 1257	miniature adequate rat scrapple	2	good	
 1258	pail of pretentious paint	0		
-1259	twirling smooth traffic cone of the businessman	0		Moxie: +15, Meat Drop: +50, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	twirling smooth traffic cone of the businessman	0		Moxie: +15, Meat Drop: +50, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
-1261	pickled gray tumbling blurry Hatorade	1		Effect: "Jacked In", Effect Duration: 5
+1261	pickled tumbling gray blurry Hatorade	1		Effect: "Jacked In", Effect Duration: 5
 1262	ghostly greedy manspreader's supercool off-hand balloon	0		Moxie Percent: +20, Monster Level: +10, Meat Drop: +20
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
 1266	small rotten gloomy mushroom	2	crappy	
 1267	dead mimic	0		
-1268	twirling narrow pine wand	0		
+1268	narrow twirling pine wand	0		
 1269	maroon ebony wand	0		
 1270	hexagonal wand	0		
 1271	aluminum wand	0		
@@ -1287,7 +1287,7 @@
 1303	jittery Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	teal Jack Frost's MacGyver's traffic cone	0		Maximum MP: +100, Cold Spell Damage: +50, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	teal Jack Frost's MacGyver's traffic cone	0		Maximum MP: +100, Cold Spell Damage: +50, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	yellow calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	fuchsia unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	gigantic adequate questionable taco	10	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	time helmet of incineration	0		Hot Spell Damage: +50, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	nasty time trousers	0		Stench Damage: +5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	time helmet of incineration	0		Hot Spell Damage: +50, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	nasty time trousers	0		Stench Damage: +5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	blurry olive occult time sword	0		Spell Damage Percent: +25, Last Available: "2005-10"
 1326	ghostly Dyspepsi-Cola helmet of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "3xFairy, cap 7"
 1327	tumbling blurry lard-coated Cloaca-Cola shield	0		Sleaze Spell Damage: +25, Damage Reduction: 4
@@ -1347,9 +1347,9 @@
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	immense adequate tofurkey leg	9	good	
 1366	rotten tofurkey gravy	3	crappy	
-1367	decent snack-sized twirling herbal stuffing	2	good	
-1368	huge decent enchanted can-shaped gelatinous cranberry sauce	8	good	Effect: "Snobby", Effect Duration: 30
-1369	tiny special toothsome bouncing yams	1	awesome	Effect: "Gr8ness", Effect Duration: 5
+1367	snack-sized decent twirling herbal stuffing	2	good	
+1368	decent huge enchanted can-shaped gelatinous cranberry sauce	8	good	Effect: "Snobby", Effect Duration: 30
+1369	special toothsome tiny bouncing yams	1	awesome	Effect: "Gr8ness", Effect Duration: 5
 1370	fortified rhinestone cowboy shirt	0		Damage Absorption: +60
 1371	bouncing narrow lightning-fast gingham blouse	0		Initiative: +40
 1372	hale souvenir ski t-shirt	0		Maximum HP: +20
@@ -1384,10 +1384,10 @@
 1402	beefcake's rag doll	0		Muscle: +25, Last Available: "2005-12"
 1403	can of fake snow of Flo-Jo	0		Initiative: +100, Last Available: "2005-12"
 1404	personal trainer's colored-light &quot;necklace&quot;	0		Experience Percent (Muscle): +10, Last Available: "2005-12"
-1405	tree skirt of wisdom	0		Mysticality: +15, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	tree skirt of wisdom	0		Mysticality: +15, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	tasty wreath-shaped Crimbo cookie	3	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	tasty bell-shaped Crimbo cookie	3	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	decent enchanted tree-shaped Crimbo cookie	4	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	enchanted decent tree-shaped Crimbo cookie	4	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	gray baleful Unionize The Elves sign	0		Spell Damage: +25, Last Available: "2005-12"
 1410	blinking sleeping snowy owl	0		Last Available: "2005-12"
 1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
@@ -1399,15 +1399,15 @@
 1417	super-polymerized snowcone	0		Effect: "[1609]Dancin' Fool", Effect Duration: 54, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	green teddy bear sewing kit	0		Last Available: "2006-01"
-1420	green Jeselnik's weightlifter's traffic cone	0		Muscle: +15, Sleaze Damage: +25, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	green Jeselnik's weightlifter's traffic cone	0		Muscle: +15, Sleaze Damage: +25, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	huge Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	blurry mansplainer's therapeutic ice sickle	0		Monster Level: +15, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2006-02"
 1425	rosewater-soaked ice baby	0		Stench Resistance: +3, Softcore Only, Last Available: "2006-02"
-1426	huge occult ice pick	0		Spell Damage Percent: +25, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	huge occult ice pick	0		Spell Damage Percent: +25, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	Fonzie's ice skates of doom	0		Experience (Moxie): +1, Spooky Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	tasty jumbo grue egg omelette	5	awesome	
+1428	jumbo tasty grue egg omelette	5	awesome	
 1429	pulsating roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1433,13 +1433,13 @@
 1451	dehydrated blue huge hot wad	1		Effect: "Worth Your Salt", Effect Duration: 30
 1452	diluted teal blurry wad	1		
 1453	denatured shaking wad	1		
-1454	diluted wobbly tumbling spinning stench wad	1		Effect: "Cold Throat", Effect Duration: 40
-1455	modified bouncing teal sleaze wad	1		Effect: "Empty Inside", Effect Duration: 40
+1454	diluted spinning wobbly tumbling stench wad	1		Effect: "Cold Throat", Effect Duration: 40
+1455	modified teal bouncing sleaze wad	1		Effect: "Empty Inside", Effect Duration: 40
 1456	blinking double daisy	0		
 1457	Goth Giant	0		
-1458	spoiled small Valentine's Day cake	2	crappy	
+1458	small spoiled Valentine's Day cake	2	crappy	
 1459	arrow'd heart balloon	0		
-1460	tumbling pulsating bouncing velvet box	0		
+1460	bouncing tumbling pulsating velvet box	0		
 1461	squashed frog	0		
 1462	shaking eye of newt	0		
 1463	salamander spleen	0		
@@ -1455,11 +1455,11 @@
 1473	ball-and-chain	0		
 1474	automatic catapult	0		
 1475	narrow pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	tumbling blue goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	blue tumbling goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	teal plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	huge football helmet	0		Familiar Effect: "atk, cap 37"
-1480	gray blinking shaking chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
+1480	shaking blinking gray chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	upside-down paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	shaking troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
@@ -1474,7 +1474,7 @@
 1492	tumbling grievous ninja mop	0		Weapon Damage Percent: +50
 1493	Usain Bolt's arcane researcher's ridiculously overelaborate ninja weapon	0		Experience Percent (Mysticality): +10, Initiative: +80
 1494	diffused super-unsweetened quadruple-aerosolized upside-down sugar-coated pine cone	0		Effect: "Disco Inferno", Effect Duration: 38, Last Available: "2020-09"
-1495	shaking nasty traffic cone of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +5, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	shaking nasty traffic cone of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	mediocre triple-distilled gloomy mushroom wine	6	decent	
 1497	drinkable mushroom wine	4	good	
 1498	twirling McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
@@ -1492,9 +1492,9 @@
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-04"
 1512	dried wobbly Knob Goblin pet-buffing spray	1		Effect: "Think Win-Lose", Effect Duration: 30
-1513	twisted narrow olive Knob Goblin learning pill	1		Effect: "Shawarma Warm War", Effect Duration: 35
+1513	twisted olive narrow Knob Goblin learning pill	1		Effect: "Shawarma Warm War", Effect Duration: 35
 1514	dried Knob Goblin eyedrops	1		Effect: "Egg on your Face", Effect Duration: 15
-1515	modified bouncing skewed Knob Goblin nasal spray	1		Effect: "Eyes of the Dragon", Effect Duration: 20
+1515	modified skewed bouncing Knob Goblin nasal spray	1		Effect: "Eyes of the Dragon", Effect Duration: 20
 1516	huge KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1504,22 +1504,22 @@
 1523	bottle of used blood	0		
 1524	narrow wind-up chattering teeth	0		Last Available: "2006-04"
 1525	upside-down joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	spinning diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	forbidden personal trainer's corkscrew	0		Experience Percent (Muscle): +10, Spell Damage Percent: +50, Last Available: "2006-04"
 1529	olive St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	twirling gray personal trainer's grass skirt	0		Experience Percent (Muscle): +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	grass hat of Tarzan	0		Experience (Muscle): +3, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	twirling gray personal trainer's grass skirt	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	grass hat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	twirling flame-retardant grass blade	0		Hot Resistance: +1, Last Available: "2011-01"
 1534	wobbly raffle prize box	0		
 1536	squat homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	wobbly Sinatra's sparkly engagement ring	0		Experience (Moxie): +5, Single Equip
 1539	red Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	scorching smooth Grimacite goggles	0		Moxie: +15, Hot Damage: +25, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	scorching smooth Grimacite goggles	0		Moxie: +15, Hot Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	upside-down frightening Van der Graaf Grimacite glaive	0		Spooky Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-10"
-1542	electrified Grimacite greaves of James Dean	0		Experience (Moxie): +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	electrified Grimacite greaves of James Dean	0		Experience (Moxie): +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	stylish Grimacite garter of the scaredy-cat	0		Moxie: +25, Monster Level: -15, Last Available: "2008-10"
 1544	executive Grimacite galoshes of courage	0		Spooky Resistance: +3, Meat Drop: +40, Last Available: "2008-10"
 1545	Grimacite gorget of the pedagogue of the detective	0		Experience: +3, Item Drop: +20, Last Available: "2008-10"
@@ -1530,56 +1530,56 @@
 1550	tumbling aromatic second-hand knockoff engagement ring	0		Stench Resistance: +1, Single Equip
 1551	aged distilled bottle of Domesticated Turkey	5	awesome	
 1552	acceptable irresponsibly strong shaking bottle of Definit	8	good	
-1553	lousy enchanted bottle of Calcutta Emerald	3	decent	Effect: "Wet Willied", Effect Duration: 10
+1553	enchanted lousy bottle of Calcutta Emerald	3	decent	Effect: "Wet Willied", Effect Duration: 10
 1554	perfectly mixed blinking bottle of Lieutenant Freeman	4	EPIC	
 1555	practically non-alcoholic delicious bottle of Jorge Sinsonte	1	awesome	
-1556	bad triple-distilled special boxed champagne	7	decent	Effect: "Coated Arms", Effect Duration: 30
+1556	triple-distilled special bad boxed champagne	7	decent	Effect: "Coated Arms", Effect Duration: 30
 1557	adequate kumquat	3	good	
 1558	moldy tangerine	3	crappy	
 1559	tonic water	0		
 1560	stale cocktail onion	3	decent	
 1561	adequate raspberry	3	good	
 1562	normal super-sized kiwi	5	good	
-1563	mediocre triple-distilled whiskey bittersweet	10	decent	
+1563	triple-distilled mediocre whiskey bittersweet	10	decent	
 1564	watered-down artisanal bouncing squat mimosette	2	EPIC	
 1565	tolerable tequila sunset	3	good	
 1566	artisanal shaking zmobie	3	EPIC	Wiki Name: "Zmobie (drink)"
 1567	acceptable watered-down gin and tonic	2	good	
 1568	high-proof bad vodka and tonic	10	decent	
 1569	mediocre vodka gibson	3	decent	
-1570	bad weak gibson	2	decent	
+1570	weak bad gibson	2	decent	
 1571	acceptable parisian cathouse	4	good	
-1572	weak perfectly mixed purple bouncing rabbit punch	2	EPIC	
+1572	perfectly mixed weak purple bouncing rabbit punch	2	EPIC	
 1573	delicious weak pulsating caipifruta	2	awesome	
 1574	perfectly mixed upside-down teqiwila	3	EPIC	
-1575	acceptable distilled Divine	5	good	
-1576	tolerable distilled tumbling Gordon Bennett	5	good	
+1575	distilled acceptable Divine	5	good	
+1576	distilled tolerable tumbling Gordon Bennett	5	good	
 1577	mediocre tangarita	4	decent	
-1578	artisanal practically non-alcoholic mandarina colada	1	super ultra mega turbo EPIC	
+1578	practically non-alcoholic artisanal mandarina colada	1	super ultra mega turbo EPIC	
 1579	irresponsibly strong perfectly mixed gimlet	9	EPIC	
 1580	smooth ghostly brick road	3	awesome	
 1581	mediocre upside-down vodka stratocaster	3	decent	
 1582	delicious Neuromancer	4	awesome	
 1583	perfectly mixed watered-down fuchsia prussian cathouse	2	super ultra EPIC	
 1584	tolerable blurry Mae West	4	good	
-1585	tolerable practically non-alcoholic Mon Tiki	1	good	
-1586	artisanal boozy teqiwila slammer	5	EPIC	
+1585	practically non-alcoholic tolerable Mon Tiki	1	good	
+1586	boozy artisanal teqiwila slammer	5	EPIC	
 1587	decent Knob lo mein	3	good	
 1588	miniature normal asparagus lo mein	2	good	
 1589	diet decent tumbling Knoll lo mein	1	good	
 1590	flavorless lo mein	3	decent	
 1591	rotten olive lo mein	4	crappy	
 1592	toothsome hot hi mein	3	awesome	
-1593	small moldy enchanted blinking hi mein	2	crappy	Effect: "Spooky Hands", Effect Duration: 50
+1593	enchanted moldy small blinking hi mein	2	crappy	Effect: "Spooky Hands", Effect Duration: 50
 1594	spoiled hi mein	3	crappy	
-1595	delicious small hi mein	2	awesome	
+1595	small delicious hi mein	2	awesome	
 1596	spoiled sleazy hi mein	4	crappy	
 1597	Junior LAAAAME merit badge of the dark arts	0		Spell Damage Percent: +100, Last Available: "2006-05"
 1598	studded Senior LAAAAME merit badge	0		Damage Absorption: +80, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	hand-crafted tangarita with a fly in it	3	EPIC	
 1601	perfectly mixed practically non-alcoholic shaking ghostly mandarina colada with a fly in it	1	EPIC	
-1602	practically non-alcoholic aged lime green blinking prussian cathouse with a fly in it	1	awesome	
+1602	practically non-alcoholic aged blinking lime green prussian cathouse with a fly in it	1	awesome	
 1603	artisanal skewed Mae West with a fly in it	3	EPIC	
 1604	denatured skewed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1592,8 +1592,8 @@
 1612	polarized wobbly concentrated cordial of concentration	0		Effect: "Slimy Flavor", Effect Duration: 39
 1613	coffin lid of the scaredy-cat	0		Monster Level: -15, Damage Reduction: 3
 1614	bouncing lard-coated satin shield	0		Sleaze Spell Damage: +25, Damage Reduction: 5
-1615	shaking scorching Cerebral Cloche	0		Hot Damage: +25, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	coward's Cerebral Culottes	0		Monster Level: -20, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	shaking scorching Cerebral Cloche	0		Hot Damage: +25, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	coward's Cerebral Culottes	0		Monster Level: -20, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	scorching Da Vinci's stylish Cerebral Crossbow	0		Moxie: +25, Experience (Mysticality): +5, Hot Damage: +25, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1605,14 +1605,14 @@
 1625	nitrogenated pickled mirror green-frosted astral cupcake	0		Effect: "Dirge of Dreadfulness", Effect Duration: 60, Last Available: "2006-06"
 1626	unsweetened vacuum-sealed orange-frosted astral cupcake	0		Effect: "Night of the Nachos", Effect Duration: 32, Last Available: "2006-06"
 1627	polymerized flattened gray purple-frosted astral cupcake	0		Effect: "Cookie Backup", Effect Duration: 27, Last Available: "2006-06"
-1628	corrupted maroon shaking tumbling pink-frosted astral cupcake	0		Effect: "Taurus Rising", Effect Duration: 64, Last Available: "2006-06"
+1628	corrupted shaking tumbling maroon pink-frosted astral cupcake	0		Effect: "Taurus Rising", Effect Duration: 64, Last Available: "2006-06"
 1629	thinker's raspberry beret	0		Mysticality: +10, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	cyan wobbly beefcake's pixel shield	0		Muscle: +25, Damage Reduction: 3
 1631	jittery beer cartilage	0		
 1632	upside-down Spanish fly trap	0		
 1633	Spanish fly	0		
 1634	hand-crafted practically non-alcoholic around the world	1	super ultra mega turbo EPIC	
-1635	tumbling jittery scrumdiddlyumptious solution	0		
+1635	jittery tumbling scrumdiddlyumptious solution	0		
 1636	blue Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	dry mirror lotion of hotness	0		Effect: "Jerky, Boy", Effect Duration: 69
 1638	pressed galvanized lotion of coldness	0		Effect: "Down With Chow", Effect Duration: 51
@@ -1620,17 +1620,17 @@
 1640	extra-Vulcanized wet lotion of stench	0		Effect: "Afternoon Insight", Effect Duration: 48
 1641	polarized lotion of sleaziness	0		Effect: "Neuromancy", Effect Duration: 19
 1642	artisanal Grimacite Bock	3	EPIC	Last Available: "2008-11"
-1643	decent bite-sized wedge of gray cheese	1	good	Last Available: "2008-11"
+1643	bite-sized decent wedge of gray cheese	1	good	Last Available: "2008-11"
 1644	spinning hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
 1647	stench and sauce	0		
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
-1650	wobbly narrow milk of magnesium	0		
-1651	small adequate pulsating foie gras	2	good	
+1650	narrow wobbly milk of magnesium	0		
+1651	adequate small pulsating foie gras	2	good	
 1652	unsweetened vacuum-sealed candy brain	0		Effect: "Bilious Brains", Effect Duration: 41, Last Available: "2020-09"
-1653	olive nippy Samson's slick jewel-eyed wizard hat	0		Moxie: +10, Experience (Muscle): +5, Cold Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	olive nippy Samson's slick jewel-eyed wizard hat	0		Moxie: +10, Experience (Muscle): +5, Cold Damage: +10, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	blurry Herculean stylish wad of Crovacite	0		Moxie: +25, Experience (Muscle): +1
 1655	horrifying crafty collar	0		Maximum MP: +10, Spooky Damage: +25
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	huge pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	huge pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	blinking Van der Graaf sword of extreme caution	0		Monster Level: -25, MP Regen Min: 5, MP Regen Max: 7
 1680	flame-wreathed MacGyver's staff	0		Maximum MP: +100, Hot Spell Damage: +10
 1681	padded experienced bubblewrap sword	0		Experience: +2, Damage Absorption: +20
@@ -1664,7 +1664,7 @@
 1684	sharpshooter's wicked styrofoam sword	0		Spell Damage: +5, Critical Hit Percent: +10
 1685	inspector's Tesla styrofoam staff	0		Item Drop: +15, MP Regen Min: 7, MP Regen Max: 10
 1686	censurious scorching styrofoam crossbow	0		Hot Damage: +25, Sleaze Resistance: +3
-1687	skewed fuchsia Platinum Yendorian Express Card	0		
+1687	fuchsia skewed Platinum Yendorian Express Card	0		
 1688	blinking lime green wool Temple Grandin's crossbow	0		Familiar Weight: +7, Cold Resistance: +1
 1689	greasy ribbon	0		Sleaze Spell Damage: +10, Last Available: "2006-07"
 1690	Jack Frost's discarded bottlecap of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 38"
@@ -1676,8 +1676,8 @@
 1696	miniature flavorless royal jelly taco	2	decent	
 1697	flavorless tofu taco	4	decent	
 1698	spoiled wobbly jumping bean taco	3	crappy	
-1699	jumbo rotten blue twirling shaking catgut taco	5	crappy	
-1700	toothsome big goat cheese taco	5	awesome	
+1699	rotten jumbo shaking blue twirling catgut taco	5	crappy	
+1700	big toothsome goat cheese taco	5	awesome	
 1701	small rotten pr0n taco	2	crappy	
 1702	Vulcanized quadruple-moist alphabet gum	0		Effect: "Just the Brown Ones", Effect Duration: 25
 1703	pulsating Comma Chameleon egg	0		Free Pull
@@ -1752,14 +1752,14 @@
 1773	squat rosy-cheeked eggbeater	0		Maximum HP Percent: +30
 1774	artisanal bottle of popskull	3	EPIC	
 1775	dishrag of the ox	0		Muscle: +20
-1776	tiny decent teal stale baguette	1	good	
+1776	decent tiny teal stale baguette	1	good	
 1777	tumbling leftovers of indeterminate origin	0		
 1778	decent bouncing dinner	4	good	
 1779	cyan katana of Flo-Jo	0		Initiative: +100
 1780	Samson's ram stick	0		Experience (Muscle): +5
 1781	occult enchantlers	0		Spell Damage Percent: +25, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	yellow resourceful experienced ram-battering staff	0		Experience: +2, Maximum MP: +50
-1783	toothsome miniature crazy Turkish delight	2	awesome	
+1783	miniature toothsome crazy Turkish delight	2	awesome	
 1784	nasty sharpshooter's Snow Queen Crown	0		Critical Hit Percent: +10, Stench Damage: +5, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	blinking resourceful arcane researcher's ga-ga radio of mayonnaise	0		Experience Percent (Mysticality): +10, Maximum MP: +50, Sleaze Spell Damage: +50
 1786	six pack of Mountain Stream	0		
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	lousy practically non-alcoholic Ram's Face Lager	1	decent	
 1791	ram horns	0		
-1792	family-friendly ruddy Travoltan trousers of the overflowing toilet	0		Maximum HP Percent: +40, Stench Spell Damage: +50, Sleaze Resistance: +1, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	family-friendly ruddy Travoltan trousers of the overflowing toilet	0		Maximum HP Percent: +40, Stench Spell Damage: +50, Sleaze Resistance: +1, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	wobbly deadly pool cue of doom	0		Weapon Damage: +5, Spooky Spell Damage: +50
 1794	wet upside-down handful of hand chalk	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 49
 1795	blue bouncing Jeselnik's Counterclockwise Watch	0		Sleaze Damage: +25, Single Equip
@@ -1843,12 +1843,12 @@
 1864	blue left scapula	0		
 1865	right scapula	0		
 1866	twirling left clavicle	0		
-1867	mirror tumbling right clavicle	0		
+1867	tumbling mirror right clavicle	0		
 1868	squat left humerus	0		
 1869	twirling right humerus	0		
 1870	left radius	0		
 1871	right radius	0		
-1872	gray pulsating left ulna	0		
+1872	pulsating gray left ulna	0		
 1873	green right ulna	0		
 1874	skewed left femur	0		
 1875	pulsating red right femur	0		
@@ -1927,7 +1927,7 @@
 1950	yellow bottle of Vangoghbitussin	0		
 1951	weak smooth bottle of Pinot Renoir	2	awesome	
 1952	super-sized spoiled desiccated apricot	5	crappy	
-1953	drinkable practically non-alcoholic pulsating flute of flat champagne	1	good	
+1953	practically non-alcoholic drinkable pulsating flute of flat champagne	1	good	
 1954	miniature stale wobbly dehydrated caviar	2	decent	
 1955	styrofoam peanuts	0		
 1956	watered-down lousy snifter of thoroughly aged brandy	2	decent	
@@ -1963,7 +1963,7 @@
 1986	mind flayer	0		
 1987	blinking undead elbow macaroni	0		
 1988	narrow angry cow	0		
-1989	teal shaking Cheshire bitten	0		
+1989	shaking teal Cheshire bitten	0		
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
 1992	squat tumbling rubber WWBD? bracelet	0		
@@ -1978,7 +1978,7 @@
 2001	squat Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	Thorny Toad trading card	0		
-2004	skewed purple Chori Zo trading card	0		
+2004	purple skewed Chori Zo trading card	0		
 2005	mirror Morbidda trading card	0		
 2006	Poison Oak trading card	0		
 2007	Princess Rutabaga trading card	0		
@@ -1988,7 +1988,7 @@
 2011	Nayztameetjoo trading card	0		
 2012	Arrrmetia trading card	0		
 2013	blinking Serenity trading card	0		
-2014	spinning twirling Inndya trading card	0		
+2014	twirling spinning Inndya trading card	0		
 2015	Kitty the Zmobie Basher trading card	0		
 2016	diamond necklace	0		
 2017	spade necklace	0		
@@ -2000,7 +2000,7 @@
 2023	cyan Genalen&trade; Bottle	1	EPIC	
 2024	moldy tumbling mixed wildflower greens	4	crappy	
 2025	decent handful of walnuts	3	good	
-2026	yummy bite-sized nutty organic salad	1	awesome	
+2026	bite-sized yummy nutty organic salad	1	awesome	
 2027	normal ghostly super salad	3	good	
 2028	miniature bland wobbly tofu wonton	2	decent	
 2029	gray hippy protest button	0		Single Equip
@@ -2058,8 +2058,8 @@
 2082	toothbrush	0		
 2083	wobbly makeshift crane	0		
 2084	can of starch	0		
-2085	pickled squat jittery bottle of ultravitamins	1		Effect: "Pie in the Sky", Effect Duration: 30
-2086	mixed jittery huge bottle of cough syrup	1		Effect: "Lobos Fresh", Effect Duration: 25
+2085	pickled jittery squat bottle of ultravitamins	1		Effect: "Pie in the Sky", Effect Duration: 30
+2086	mixed huge jittery bottle of cough syrup	1		Effect: "Lobos Fresh", Effect Duration: 25
 2087	compressed maroon tube of hair oil	1		
 2088	diffused skewed Daffy Taffy	0		Effect: "Black Eyes", Effect Duration: 34
 2089	Crimboween memo	0		Last Available: "2006-10"
@@ -2067,9 +2067,9 @@
 2091	bath salts	0		
 2092	narrow hand mirror	0		
 2093	dog trainer's hors d'oeuvre tray	0		Experience (familiar): +1, Damage Reduction: 5
-2094	diet decent ballroom blintz	1	good	
-2095	pulsating yellow towel	0		
-2096	boiled tumbling red narrow guy made of bee pollen	1		Effect: "Jingle Jangle Jingle", Effect Duration: 15
+2094	decent diet ballroom blintz	1	good	
+2095	yellow pulsating towel	0		
+2096	boiled narrow red tumbling guy made of bee pollen	1		Effect: "Jingle Jangle Jingle", Effect Duration: 15
 2097	pulsating wobbly Usain Bolt's 17-ball	0		Initiative: +80
 2098	filthy lucre	0		
 2099	huge hobo gristle	0		
@@ -2089,8 +2089,8 @@
 2113	shaking wheel of chilblains	0		Cold Damage: +25, Last Available: "2006-12"
 2114	ghostly yo	0		Last Available: "2006-12"
 2115	wobbly beefy prehistoric spear	0		Muscle: +10, Last Available: "2006-12"
-2116	spinning skewed stick-on-a-string	0		Last Available: "2006-12"
-2117	wobbly wizardly fire of the sewer	0		Mysticality: +25, Stench Damage: +25, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2116	skewed spinning stick-on-a-string	0		Last Available: "2006-12"
+2117	wobbly wizardly fire of the sewer	0		Mysticality: +25, Stench Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	mirror lit cigar	0		Last Available: "2011-12"
 2120	twirling Grateful Undead T-shirt of the early riser	0		Adventures: +7
@@ -2107,14 +2107,14 @@
 2132	family-friendly incredibly marionette	0		Sleaze Resistance: +1, Last Available: "2006-12"
 2133	blue dress ball	0		Last Available: "2010-12"
 2134	Tesla mad scientist's sock monkey	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2006-12"
-2135	twirling olive alien blob	0		Last Available: "2006-12"
+2135	olive twirling alien blob	0		Last Available: "2006-12"
 2136	green lion tamer's vampire duck-on-a-string of doom	0		Experience (familiar): +2, Spooky Spell Damage: +50, Last Available: "2006-12"
 2137	toy crazy train of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2006-12"
 2138	ghostly razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	bouncing toy mercenary	0		Last Available: "2006-12"
 2140	shaking length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
-2142	jittery bouncing teal block	0		Last Available: "2011-12"
+2142	bouncing teal jittery block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
 2144	pulsating evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
@@ -2136,14 +2136,14 @@
 2161	computronic processing unit	0		Last Available: "2011-12"
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
-2164	pulsating yellow recursive spline reticulator	0		Last Available: "2011-12"
+2164	yellow pulsating recursive spline reticulator	0		Last Available: "2011-12"
 2165	mirror atomic vector plotter	0		Last Available: "2011-12"
-2166	blurry bouncing ion-pulse modulation stabilizer	0		Last Available: "2011-12"
+2166	bouncing blurry ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	horrifying MacGyver's toy ray gun	0		Maximum MP: +100, Spooky Damage: +25, Last Available: "2006-12"
-2169	huge groovy toy space helmet of horror	0		Moxie Percent: +10, Spooky Spell Damage: +25, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	huge groovy toy space helmet of horror	0		Moxie Percent: +10, Spooky Spell Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	horrifying banded astronaut pants	0		Damage Absorption: +100, Spooky Damage: +25, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	horrifying banded astronaut pants	0		Damage Absorption: +100, Spooky Damage: +25, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	strapping toy jet pack	0		Muscle: +5, Last Available: "2006-12"
 2173	ghostly triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2165,8 +2165,8 @@
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	adequate enchanted massive candy stake	8	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2006-12"
-2194	practically non-alcoholic delicious purple skewed eggnog	1	awesome	Last Available: "2006-12"
+2193	massive adequate enchanted candy stake	8	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2006-12"
+2194	delicious practically non-alcoholic skewed purple eggnog	1	awesome	Last Available: "2006-12"
 2195	rotten unspeakable fruitcake	4	crappy	Last Available: "2006-12"
 2196	normal gingerbread horror	4	good	Last Available: "2006-12"
 2197	moist warmed bouncing but probably evil chocolate	0		Effect: "Updated", Effect Duration: 59, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	Fonzie's Crimbo tiki necklace	0		Experience (Moxie): +1, Last Available: "2006-12"
 2208	bouncing Samson's bobble-hip hula elf doll of courage	0		Experience (Muscle): +5, Spooky Resistance: +3, Last Available: "2006-12"
 2209	toasty Crimbo ukulele	0		Hot Damage: +5, Last Available: "2006-12"
-2210	asbestos-lined nippy Tiki lighter	0		Cold Damage: +10, Hot Resistance: +5, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	tumbling double-paned hardy deck of tropical cards	0		Maximum HP: +50, Cold Resistance: +5, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	tropical paperweight of horror of the early riser	0		Spooky Spell Damage: +25, Adventures: +7, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	asbestos-lined nippy Tiki lighter	0		Cold Damage: +10, Hot Resistance: +5, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	tumbling double-paned hardy deck of tropical cards	0		Maximum HP: +50, Cold Resistance: +5, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	tropical paperweight of horror of the early riser	0		Spooky Spell Damage: +25, Adventures: +7, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	skewed tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	ghostly skewed hardened Tropical Crimbo Hat	0		Damage Reduction: 3, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	supercool Tropical Crimbo Shorts	0		Moxie Percent: +20, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	ghostly skewed hardened Tropical Crimbo Hat	0		Damage Reduction: 3, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	supercool Tropical Crimbo Shorts	0		Moxie Percent: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	decent super ka-bob	3	good	
 2218	normal gigantic jittery beer basted brat	7	good	
 2219	fuchsia zippy Tropical Crimbo Sword	0		Initiative: +20, Last Available: "2006-12"
 2220	energized quantum skewed and Crimboween candy	0		Effect: "On the Shoulders of Giants", Effect Duration: 21, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	liar's pants of the bloodbag of the early riser	0		Maximum HP: +100, Adventures: +7, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	liar's pants of the bloodbag of the early riser	0		Maximum HP: +100, Adventures: +7, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	stanky Temple Grandin's juggler's balls	0		Familiar Weight: +7, Stench Spell Damage: +25, Softcore Only, Last Available: "2007-01"
 2224	supercool pink shirt	0		Moxie Percent: +20, Softcore Only, Last Available: "2007-01"
 2225	twirling familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2208,7 +2208,7 @@
 2233	forbidden bow tie	0		Spell Damage Percent: +50, Clowniness: 75
 2234	jittery calavera concertina of the boozehound	0		Booze Drop: +100, Song Duration: 7
 2235	greedy ratarang of chilblains	0		Cold Damage: +25, Meat Drop: +20
-2236	magnetized mirror teal turtle pheromones	0		Effect: "The Style... of the Future", Effect Duration: 14
+2236	magnetized teal mirror turtle pheromones	0		Effect: "The Style... of the Future", Effect Duration: 14
 2237	shaking maroon pygmy blowgun	0		
 2238	squat pygmy nose-bone of the brute	0		Muscle Percent: +30, Single Equip
 2239	huge jittery gravedigger's bad voodoo mask of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
@@ -2235,23 +2235,23 @@
 2261	spinning hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	bland miniature stunt nuts	2	decent	
+2264	miniature bland stunt nuts	2	decent	
 2265	moldy wet stew	4	crappy	
 2266	wet stunt nut stew	0		
 2267	squat Mega Gem	0		
 2268	Staff of Fats of the empath	0		Familiar Weight: +5
-2269	bland ghostly shaking green sausage wonton	3	decent	
+2269	bland shaking ghostly green sausage wonton	3	decent	
 2270	auspicious knitted belt	0		Cold Resistance: +3, Item Drop: +10, Single Equip
 2271	bad bottle of Merlot	3	decent	
 2272	drinkable bottle of Port	4	good	
 2273	hand-crafted upside-down bottle of Pinot Noir	3	EPIC	
-2274	high-proof mediocre bottle of Zinfandel	7	decent	
+2274	mediocre high-proof bottle of Zinfandel	7	decent	
 2275	perfectly mixed bottle of Marsala	3	EPIC	
 2276	delicious tumbling bottle of Muscat	3	awesome	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
 2279	book	0		
-2280	mirror tumbling Manual of Labor	0		
+2280	tumbling mirror Manual of Labor	0		
 2281	Manual of Transmission	0		
 2282	fuchsia Manual of Dexterity	0		
 2283	blurry shaking lightning-fast seal-skull helmet	0		Initiative: +40, Familiar Effect: "atk, cap 2"
@@ -2264,7 +2264,7 @@
 2290	really house	0		
 2291	jittery Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
-2293	blurry tumbling cup of strong herbal tea	0		
+2293	tumbling blurry cup of strong herbal tea	0		
 2294	huge Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	spinning marinated stakes	0		
 2296	knob butter	0		
@@ -2303,21 +2303,21 @@
 2329	twirling handful of confetti	0		
 2330	twirling chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	thick spoiled mirror Better Than Cuddling Cake	5	crappy	
+2332	spoiled thick mirror Better Than Cuddling Cake	5	crappy	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	mirror rubber WWBBDD? bracelet	0		
 2336	asbestos-lined Jeselnik's pipe	0		Sleaze Damage: +25, Hot Resistance: +5
 2337	jittery frightening reinforced beaded headband	0		Spooky Damage: +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	normal small huge pudding	2	good	Wiki Name: "black pudding (food)"
-2339	hand-crafted irresponsibly strong twirling Blackfly Chardonnay	7	EPIC	
+2339	irresponsibly strong hand-crafted twirling Blackfly Chardonnay	7	EPIC	
 2340	hand-crafted & tan	4	EPIC	
 2341	pepper	0		
-2342	miniature decent gray forest cake	2	good	
-2343	stale low-calorie narrow tumbling forest ham	1	decent	
+2342	decent miniature gray forest cake	2	good	
+2343	low-calorie stale narrow tumbling forest ham	1	decent	
 2344	warmed energized filthworm hatchling scent gland	0		Effect: "Virgo Rising", Effect Duration: 11
 2345	liquefied dry filthworm drone scent gland	0		Effect: "Hair on Your Chest", Effect Duration: 15
-2346	corrupted magnetized squat red filthworm royal guard scent gland	0		Effect: "One For Tea", Effect Duration: 59
+2346	corrupted magnetized red squat filthworm royal guard scent gland	0		Effect: "One For Tea", Effect Duration: 59
 2347	heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	gas balloon	0		
@@ -2326,8 +2326,8 @@
 2352	gray fire poi of James Dean of the glutton	0		Experience (Moxie): +3, Food Drop: +100
 2353	blinking bejeweled pledge pin of vim and vigor	0		Maximum HP Percent: +50, Single Equip
 2354	communications windchimes	0		
-2355	energized unsweetened mirror mirror lime green henna face paint	0		Effect: "Gyromitra Gymnastics", Effect Duration: 41
-2356	non-ionized altered ghostly mirror teal tube of dread wax	0		Effect: "Slippery Tongue", Effect Duration: 21
+2355	energized unsweetened mirror lime green mirror henna face paint	0		Effect: "Gyromitra Gymnastics", Effect Duration: 41
+2356	non-ionized altered mirror ghostly teal tube of dread wax	0		Effect: "Slippery Tongue", Effect Duration: 21
 2357	skewed up-at-dawn boxer's Gaia beads	0		Muscle Percent: +10, Adventures: +5
 2358	narrow pink clay bead	0		
 2359	tumbling clay bead	0		
@@ -2397,7 +2397,7 @@
 2423	triple-corrupted extra-improved Mick's IcyVapoHotness Inhaler	0		Effect: "Uncanny Shot", Effect Duration: 24
 2424	diffused twirling cyclops eyedrops	0		Effect: "Fancy Feasted", Effect Duration: 25
 2425	super-tarnished can of spinach	0		Effect: "Flamingly Floral", Effect Duration: 54
-2426	altered twirling lime green fire flower	0		Effect: "Gunky Dory", Effect Duration: 40
+2426	altered lime green twirling fire flower	0		Effect: "Gunky Dory", Effect Duration: 40
 2427	activated spinning freezerburned ice cube	0		Effect: "Space Cadet", Effect Duration: 13
 2428	corrupted spinning fake blood	0		Effect: "Heart Aflame", Effect Duration: 29
 2429	colloidal cold-filtered huge Eau de Guaneau	0		Effect: "Saucemastery", Effect Duration: 49
@@ -2406,9 +2406,9 @@
 2432	ionized SPF 451 lip balm	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 66
 2433	wet mirror bottle of antifreeze	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 17
 2434	colloidal pressed eyedrops	0		Effect: "Spiky Frozen Hair", Effect Duration: 25
-2435	diffused concentrated jittery maroon Dogsgotnonoz pills	0		Effect: "Memory of Attractiveness", Effect Duration: 54
-2436	ionized wobbly ghostly donkey flipbook	0		Effect: "Scrappy, Shadowy", Effect Duration: 49
-2437	squat purple bouncing New Cloaca-Cola	0		
+2435	diffused concentrated maroon jittery Dogsgotnonoz pills	0		Effect: "Memory of Attractiveness", Effect Duration: 54
+2436	ionized ghostly wobbly donkey flipbook	0		Effect: "Scrappy, Shadowy", Effect Duration: 49
+2437	bouncing purple squat New Cloaca-Cola	0		
 2438	scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
 2440	huge unnatural gas	0		
@@ -2434,7 +2434,7 @@
 2460	medical-grade yak toupee	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	shaking odor extractor	0		Last Available: "2019-12"
 2463	spinning upside-down Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	gigantic spoiled mirror bowl of Bounty-Os	9	crappy	
+2464	spoiled gigantic mirror bowl of Bounty-Os	9	crappy	
 2465	hand-crafted Oreille Divis&eacute;e brandy	3	EPIC	
 2466	pulsating pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
@@ -2491,17 +2491,17 @@
 2518	smelly sawblade shield	0		Stench Spell Damage: +10, Damage Reduction: 11
 2519	perfectly mixed teal McMillicancuddy's Special Lager	4	EPIC	
 2520	drinkable melted Jell-o shot	4	good	
-2521	aged weak cruelty-free wine	2	awesome	
+2521	weak aged cruelty-free wine	2	awesome	
 2522	delicious pulsating thistle wine	3	awesome	
 2523	spinning megatofu	0		
 2524	displaced fish	0		
-2525	spoiled tumbling gray fish	4	crappy	
+2525	spoiled gray tumbling fish	4	crappy	
 2526	flavorless fish casserole	4	decent	
 2527	spoiled cyan fish lasagna	3	crappy	
 2528	ghostly filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	adequate gnatloaf	4	good	
 2530	yummy gnatloaf casserole	4	awesome	
-2531	massive tasty gnat lasagna	6	awesome	
+2531	tasty massive gnat lasagna	6	awesome	
 2532	pork	0		
 2533	bland upside-down pork chop sandwiches	3	decent	
 2534	decent pork casserole	4	good	
@@ -2516,11 +2516,11 @@
 2543	extra-liquefied blurry tin magnolia	0		Effect: "Heart of Yellow", Effect Duration: 23, Last Available: "2007-05"
 2544	boiled bouncing begpwnia	0		Effect: "Chalk Outline", Effect Duration: 55, Last Available: "2007-05"
 2545	liquefied upsy daisy	0		Effect: "Stands Alone", Effect Duration: 47, Last Available: "2007-05"
-2546	vacuum-sealed olive pulsating half-orchid	0		Effect: "Petit Forbearance", Effect Duration: 45, Last Available: "2007-05"
+2546	vacuum-sealed pulsating olive half-orchid	0		Effect: "Petit Forbearance", Effect Duration: 45, Last Available: "2007-05"
 2547	Sherlock's tin star	0		Item Drop: 30, Last Available: "2007-05"
-2548	rock-hard dangerous outrageous sombrero	0		Weapon Damage: +10, Damage Reduction: 5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	rock-hard dangerous outrageous sombrero	0		Weapon Damage: +10, Damage Reduction: 5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	wobbly MacGyver's Rosewater's &quot;Humorous&quot; T-shirt	0		Mysticality Percent: +30, Maximum MP: +100, Last Available: "2007-05"
-2550	tumbling maroon Peppercorns of Power	0		
+2550	maroon tumbling Peppercorns of Power	0		
 2551	upside-down vial of mojo	0		
 2552	reeds	0		
 2553	turtle chain	0		
@@ -2532,7 +2532,7 @@
 2559	bouncing twirling foul-smelling Hammer of Smiting of the glutton	0		Stench Damage: +10, Food Drop: +100, Class: "Seal Clubber"
 2560	dog trainer's Da Vinci's 17-alarm Saucepan	0		Experience (Mysticality): +5, Experience (familiar): +1, Class: "Sauceror"
 2561	rosy-cheeked Greek Pasta Spoon of Peril of the empath of Flo-Jo	0		Maximum HP Percent: +30, Familiar Weight: +5, Initiative: +100, Class: "Pastamancer"
-2562	shaking jittery half-rotten brain	0		
+2562	jittery shaking half-rotten brain	0		
 2563	bonesaw	0		
 2564	plus-sized phylactery	0		
 2565	shaking can of Ghuol-B-Gone&trade;	0		
@@ -2544,7 +2544,7 @@
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	squat ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ghostly ant sickle	0		Familiar Effect: "spooky damage, meat"
-2574	cyan squat ant pick	0		Familiar Effect: "cold damage, meat"
+2574	squat cyan ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
 2576	honey-dipped locust	0		
 2577	twirling wicked Sinatra's cactus quill	0		Experience (Moxie): +5, Spell Damage: +5
@@ -2553,13 +2553,13 @@
 2580	frosty Jim Carey's scorpion whip	0		Monster Level: +25, Cold Spell Damage: +10
 2581	handful of sand	0		
 2582	blinking jittery brick of sand	0		
-2583	miniature decent enchanted centipede eggs	2	good	Effect: "Extra-Thick Blood", Effect Duration: 30
+2583	decent miniature enchanted centipede eggs	2	good	Effect: "Extra-Thick Blood", Effect Duration: 30
 2584	sharpshooter's wonderwall shield	0		Critical Hit Percent: +10, Damage Reduction: 12
 2585	teal Colonel Mustard's Lonely Spades Club Jacket of extreme caution	0		Monster Level: -25
 2586	green aromatic General Sage's Lonely Diamonds Club Jacket	0		Stench Resistance: +1
 2587	twirling executive Corporal Fennel's Lonely Clubs Club Jacket	0		Meat Drop: +40
 2588	scorching Private Pepper's Lonely Hearts Club Jacket	0		Hot Damage: +25
-2589	rotten half-sized hot date	2	crappy	
+2589	half-sized rotten hot date	2	crappy	
 2590	practically non-alcoholic bad distilled fortified wine	1	decent	
 2591	stale blurry tasty tart	4	decent	
 2592	Knob Goblin lunchbox	0		
@@ -2590,7 +2590,7 @@
 2617	boom	0		
 2618	miser's Iiti Kitty phone charm	0		Meat Drop: +10, Single Equip
 2619	shaking jar of swamp gas	0		Last Available: "2007-05"
-2620	stale bite-sized unidentified jerky	1	decent	
+2620	bite-sized stale unidentified jerky	1	decent	
 2621	weightlifter's nasty rat mask of bravery	0		Muscle: +15, Spooky Resistance: +5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	blinking grievous smartaleck's ratskin belt	0		Moxie Percent: +30, Weapon Damage Percent: +50, Single Equip
 2623	squat friendly supercharged rattail whip	0		Maximum MP Percent: +30, Familiar Weight: +3
@@ -2622,7 +2622,7 @@
 2649	supercharged Lord Spookyraven's ear trumpet	0		Maximum MP Percent: +30, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	narrow pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	small yummy S.T.L.T.	2	awesome	Last Available: "2007-06"
+2652	yummy small S.T.L.T.	2	awesome	Last Available: "2007-06"
 2653	adequate honey-dew	4	good	Last Available: "2007-06"
 2654	fancy hand-crafted narrow Xanadian	3	EPIC	Effect: "Chock Full o' Nanites", Effect Duration: 50, Last Available: "2007-06"
 2655	flattened triple-dry purple bottle of absinthe	0		Effect: "Healthy Blue Glow", Effect Duration: 39, Last Available: "2007-06"
@@ -2632,8 +2632,8 @@
 2659	wobbly aromatic albatross necklace	0		Stench Resistance: +1, Single Equip, Last Available: "2007-06"
 2660	powdered green not-a-pipe	1	decent	Last Available: "2007-06"
 2661	perfectly mixed flask of Amontillado	4	EPIC	Last Available: "2007-06"
-2662	energetic ball mask	0		Maximum MP Percent: +20, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	coward's Can-Can skirt	0		Monster Level: -20, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	energetic ball mask	0		Maximum MP Percent: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	coward's Can-Can skirt	0		Monster Level: -20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	non-cold-filtered sensitive poetry journal	0		Effect: "Lit Up", Effect Duration: 68, Last Available: "2007-06"
 2665	oxidized boiled upside-down bottled inspiration	0		Effect: "Red Around the Gills", Effect Duration: 21, Last Available: "2007-06"
 2666	anodized wobbly bellhop bell	0		Effect: "Macho, Macho Dog", Effect Duration: 48, Last Available: "2007-06"
@@ -2646,11 +2646,11 @@
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	dry mirror bottle of cat tonic	0		Effect: "Slightly Larger Than Usual", Effect Duration: 42, Last Available: "2007-06"
 2675	compressed handful of moss	1		
-2676	boiled shaking blinking yellow bit-o-cactus	1		
+2676	boiled blinking yellow shaking bit-o-cactus	1		
 2677	powdered tumbling protein powder	1		
 2678	spectre scepter	0		
 2679	aerosolized cold-filtered sparkler	0		Effect: "Healthy Red Glow", Effect Duration: 35
-2680	activated tumbling ghostly snake	0		Effect: "Moon'd", Effect Duration: 68, Wiki Name: "snake"
+2680	activated ghostly tumbling snake	0		Effect: "Moon'd", Effect Duration: 68, Wiki Name: "snake"
 2681	alkaline warmed tumbling M-242	0		Effect: "One For Tea", Effect Duration: 28
 2682	detuned radio	0		
 2683	Warehouse 23 crate	0		
@@ -2665,7 +2665,7 @@
 2692	mirror razor-sharp Socratic driftwood sculpture	0		Experience (Mysticality): +1, Weapon Damage Percent: +25
 2693	gray inspector's personal trainer's massive sitar	0		Experience Percent (Muscle): +10, Item Drop: +15
 2694	red huge prompt flame-retardant scorching stone baseball cap	0		Hot Damage: +25, Hot Resistance: +1, Adventures: +3, Familiar Effect: "1xVolley, cap 48"
-2695	hand-crafted special cup of beer	4	EPIC	Effect: "So You Can Work More...", Effect Duration: 15
+2695	special hand-crafted cup of beer	4	EPIC	Effect: "So You Can Work More...", Effect Duration: 15
 2696	ovoid thing	0		
 2697	duct tape	0		
 2698	duct tape wallet	0		
@@ -2682,7 +2682,7 @@
 2709	exotic parrot egg	0		
 2710	cracker	0		Familiar Weight: +15
 2711	denatured narrow facepaint	0		Effect: "Aquarius Rising", Effect Duration: 47
-2712	liquefied blinking mirror upside-down sheepskin diploma	0		Effect: "Human-Fish Hybrid", Effect Duration: 51
+2712	liquefied mirror blinking upside-down sheepskin diploma	0		Effect: "Human-Fish Hybrid", Effect Duration: 51
 2713	enhanced dry Black Body&trade; spray	0		Effect: "Carrion' On", Effect Duration: 45
 2714	floorboard cruft	0		
 2715	tumbling sausage bomb	0		
@@ -2695,15 +2695,15 @@
 2722	arcane researcher's slick thinker's Staff of the Greasefire of the pedagogue	0		Mysticality: +10, Moxie: +10, Experience: +3, Experience Percent (Mysticality): +10
 2723	razor-sharp weightlifter's Staff of the Grand Flamb&eacute; of the pedagogue	0		Muscle: +15, Experience: +3, Weapon Damage Percent: +25
 2724	flavorless bowl of rye sprouts	3	decent	
-2725	miniature normal cob of corn	2	good	
+2725	normal miniature cob of corn	2	good	
 2726	enchanted normal juniper berries	3	good	Effect: "Frostbeard", Effect Duration: 25
 2727	moldy plum	3	crappy	
 2728	stale pear	3	decent	
 2729	flavorless peach	3	decent	
 2730	perfectly mixed plum wine	3	EPIC	
-2731	spirit-forward tolerable cyan shaking shot of pear schnapps	5	good	
+2731	spirit-forward tolerable shaking cyan shot of pear schnapps	5	good	
 2732	acceptable fuchsia shot of peach schnapps	4	good	
-2733	big decent bunch of square grapes	5	good	
+2733	decent big bunch of square grapes	5	good	
 2734	half-sized delicious mirror brown sugar cane	2	awesome	
 2735	flavorless sandwich of the gods	3	decent	
 2736	practically non-alcoholic lousy ghostly Pan-Dimensional Gargle Blaster	1	decent	
@@ -2712,11 +2712,11 @@
 2739	magnetized magnetized spinning panty raider camouflage	0		Effect: "No Worries", Effect Duration: 44
 2740	lion tamer's Staff of the Walk-In Freezer of doom of the glutton	0		Experience (familiar): +2, Spooky Spell Damage: +50, Food Drop: +100
 2741	weak hand-crafted boilermaker	2	EPIC	
-2742	miniature moldy steel lasagna	2	quest	
+2742	moldy miniature steel lasagna	2	quest	
 2743	tolerable steel margarita	3	quest	
 2744	denatured steel-scented air freshener	1		Effect: "Greasy Flavor", Effect Duration: 35
 2745	alkaline denatured narrow gremlin mutagen	0		Effect: "Hella Smooth", Effect Duration: 50
-2746	activated double-quantum spinning skewed extra-potent gremlin mutagen	0		Effect: "Brother Corsican's Blessing", Effect Duration: 34
+2746	activated double-quantum skewed spinning extra-potent gremlin mutagen	0		Effect: "Brother Corsican's Blessing", Effect Duration: 34
 2747	blue chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	mirror Jim Carey's furniture dolly	0		Monster Level: +25, Single Equip
 2749	resourceful wholesome Staff of the Grease Trap of the brute	0		Muscle Percent: +30, Maximum HP Percent: +10, Maximum MP: +50
@@ -2789,9 +2789,9 @@
 2816	fireproof vibrating Fonzie's Boxers	0		Experience (Moxie): +1, Maximum MP Percent: +10, Hot Resistance: +3, Familiar Effect: "1xVolley, 1xLep"
 2817	gray rosy-cheeked rock-hard Socratic Brooch	0		Experience (Mysticality): +1, Damage Reduction: 5, Maximum HP Percent: +30, Single Equip
 2818	Sherlock's lion tamer's therapeutic Bracelet	0		Experience (familiar): +2, Item Drop: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip
-2819	sharpshooter's Grimacite gasmask of the brute	0		Muscle Percent: +30, Critical Hit Percent: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	sharpshooter's Grimacite gasmask of the brute	0		Muscle Percent: +30, Critical Hit Percent: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	electrified beefy Grimacite gat	0		Muscle: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-11"
-2821	electrified forbidden Grimacite gaiters	0		Spell Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	electrified forbidden Grimacite gaiters	0		Spell Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	grievous educational Grimacite gauntlets	0		Experience: +1, Weapon Damage Percent: +50, Single Equip, Last Available: "2008-11"
 2823	sharpshooter's smooth Grimacite go-go boots	0		Moxie: +15, Critical Hit Percent: +10, Single Equip, Last Available: "2008-11"
 2824	shaking flame-wreathed arcane researcher's Grimacite girdle	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +10, Single Equip, Last Available: "2008-11"
@@ -2801,7 +2801,7 @@
 2828	loaded dice	0		
 2829	narrow really dense meat stack	0		
 2830	digital key lime	0		
-2831	huge upside-down star key lime	0		
+2831	upside-down huge star key lime	0		
 2832	yummy pulsating digital key lime pie	4	awesome	
 2833	flavorless star key lime pie	3	decent	
 2834	censurious double-paned studded bottle-rocket crossbow	0		Damage Absorption: +80, Cold Resistance: +5, Sleaze Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
@@ -2813,15 +2813,15 @@
 2840	acceptable bottle of cooking sherry	3	good	
 2841	moldy upside-down packet of ketchup	3	crappy	
 2842	bad accidental cider	3	decent	
-2843	immense spoiled dire fudgesicle	9	crappy	
+2843	spoiled immense dire fudgesicle	9	crappy	
 2844	Usain Bolt's asbestos-lined baleful navel ring of navel gazing of the storm	0		Spell Damage: +25, Maximum MP Percent: +40, Hot Resistance: +5, Initiative: +80, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	narrow plastic bib	0		Last Available: "2011-12"
 2847	ghostly Dallas Dynasty Falcon Crest shield of horror	0		Spooky Spell Damage: +25, Damage Reduction: 15
 2848	pulsating Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	weak bad moonberry wine cooler	2	decent	
-2851	moldy snack-sized pulsating lime green fine aged cheddarwurst	2	crappy	
+2850	bad weak moonberry wine cooler	2	decent	
+2851	snack-sized moldy pulsating lime green fine aged cheddarwurst	2	crappy	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	red bouquet of swamp roses	0		
@@ -2924,19 +2924,19 @@
 2952	aromatic Newton's glowstick	0		Experience (Mysticality): +3, Stench Resistance: +1, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	frosty tip jar	0		Cold Spell Damage: +10
-2955	normal tiny tumbling yam candy	1	good	
+2955	tiny normal tumbling yam candy	1	good	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	flavorless snack-sized tube of cranberry Go-Goo	2	decent	
+2958	snack-sized flavorless tube of cranberry Go-Goo	2	decent	
 2959	auspicious rum barrel charrrm bracelet	0		Item Drop: +10
 2960	huge moldy single-serving herbal stuffing	7	crappy	
 2961	stale half-sized tumbling packet of tofurkey gravy	2	decent	
-2962	spoiled super-sized bouncing tofurkey nugget	5	crappy	
+2962	super-sized spoiled bouncing tofurkey nugget	5	crappy	
 2963	bouncing rigging shampoo	0		
 2964	tumbling ball polish	0		
 2965	mizzenmast mop	0		
 2966	Tom's of the Spanish Main Toothpaste	0		
-2967	dry quantum huge wobbly blinking Swabbie&trade; swab	0		Effect: "Fudgehound", Effect Duration: 16
+2967	dry quantum blinking huge wobbly Swabbie&trade; swab	0		Effect: "Fudgehound", Effect Duration: 16
 2968	adjusted triple-denatured Oil of Parrrlay	0		Effect: "Funky Coal Patina", Effect Duration: 61
 2969	stale fancy skewed maroon creamsicle	4	decent	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40
 2970	bad bouncing cream stout	4	decent	
@@ -3001,19 +3001,19 @@
 3029	aged red-headed corpse	3	awesome	
 3030	bad mirror kamicorpse-ee	4	decent	
 3031	bad purple corpsel	3	decent	
-3032	hand-crafted boozy corpsebite	5	EPIC	
+3032	boozy hand-crafted corpsebite	5	EPIC	
 3033	pirate fledges of Flo-Jo	0		Initiative: +100
 3034	piece of thirteen	0		
 3035	big bland squat pearl onion	5	decent	
 3036	bland sea biscuit	3	decent	
-3037	acceptable watered-down bottle of rum	2	good	
+3037	watered-down acceptable bottle of rum	2	good	
 3038	artisanal bottle of black-label rum	3	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	twirling metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	twirling metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	half-sized spoiled bouncing nanite-infested gingerbread bugbear	2	crappy	Last Available: "2007-12"
 3046	spoiled lime green nanite-infested candy cane	3	crappy	Last Available: "2020-09"
 3047	rotten nanite-infested fruitcake	4	crappy	Last Available: "2007-12"
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	improved aerosolized candy heart	0		Effect: "Rootin' Around", Effect Duration: 49, Last Available: "2007-02"
 3055	aerosolized altered bouncing cyan cymbal syrup	0		Free Pull, Effect: "Staying Frosty", Effect Duration: 22, Last Available: "2007-02"
-3056	spinning extremely unsafe metallic foil cat ears	0		Weapon Damage Percent: +100, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	spinning extremely unsafe metallic foil cat ears	0		Weapon Damage Percent: +100, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	maroon nanofiber cloth	0		Last Available: "2007-12"
 3058	ghostly iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3036,7 +3036,7 @@
 3064	wobbly cyan brainy cyborg doll	0		Mysticality: +5, Last Available: "2007-12"
 3065	skewed buckyball	0		Last Available: "2010-12"
 3066	auspicious toy maglev monorail	0		Item Drop: +10, Single Equip, Last Available: "2007-12"
-3067	mirror ghostly dollhive	0		Last Available: "2007-12"
+3067	ghostly mirror dollhive	0		Last Available: "2007-12"
 3068	toy deathbot	0		Last Available: "2007-12"
 3069	squat laser cannon	0		Last Available: "2007-12"
 3070	plexifoam chin strap	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	wobbly laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	tumbling baleful marionette collective	0		Spell Damage: +25, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	squat double-paned Jeselnik's roboduck-on-a-string	0		Sleaze Damage: +25, Cold Resistance: +5, Last Available: "2007-12"
 3086	fuchsia mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	upside-down zippy inspector's biomechanical crimborg helmet	0		Item Drop: +15, Initiative: +20, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	upside-down zippy inspector's biomechanical crimborg helmet	0		Item Drop: +15, Initiative: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	foul-smelling healthy C.B.F.G.	0		Maximum HP Percent: +20, Stench Damage: +10, Last Available: "2007-12"
-3090	bouncing auspicious biomechanical crimborg leg armor of temperance	0		Sleaze Resistance: +5, Item Drop: +10, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	bouncing auspicious biomechanical crimborg leg armor of temperance	0		Sleaze Resistance: +5, Item Drop: +10, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	galvanized tumbling vitachoconutriment capsule	0		Effect: "Covetous Robbery", Effect Duration: 34, Last Available: "2007-12"
 3092	jittery gravedigger's handmade hobby horse	0		Spooky Damage: +10, Last Available: "2007-12"
 3093	frightening ball-in-a-cup	0		Spooky Damage: +5, Last Available: "2007-12"
@@ -3089,12 +3089,12 @@
 3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
-3120	narrow red divine blowout	0		Last Available: "2008-01"
+3120	red narrow divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
-3122	fuchsia shaking shaking divine cracker	0		Last Available: "2008-01"
+3122	shaking fuchsia shaking divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
 3124	ionized denatured fruitfilm	0		Effect: "Tomato Power", Effect Duration: 33
-3125	extra-electrified aerosolized chilled pulsating olive piece of after eight	0		Effect: "Preemptive Medicine", Effect Duration: 39
+3125	extra-electrified aerosolized chilled olive pulsating piece of after eight	0		Effect: "Preemptive Medicine", Effect Duration: 39
 3126	hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
@@ -3119,7 +3119,7 @@
 3147	El Vibrato punchcard (97 holes)	0		
 3148	tumbling El Vibrato punchcard (129 holes)	0		
 3149	El Vibrato punchcard (213 holes)	0		
-3150	tumbling blinking El Vibrato punchcard (165 holes)	0		
+3150	blinking tumbling El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
 3152	fuchsia El Vibrato punchcard (216 holes)	0		
 3153	El Vibrato punchcard (88 holes)	0		
@@ -3145,9 +3145,9 @@
 3173	double-oxidized tarnished evil vihuela	0		Effect: "Thickest, Sickest", Effect Duration: 19
 3174	moldy evil boring spaghetti	3	crappy	
 3175	small flavorless skewed evil noodles	2	decent	
-3176	decent half-sized huge evil noodles	2	good	
+3176	half-sized decent huge evil noodles	2	good	
 3177	flavorless squat evil painful penne pasta	4	decent	
-3178	bland snack-sized 3vi1 pr0n m4nic0tti	2	decent	
+3178	snack-sized bland 3vi1 pr0n m4nic0tti	2	decent	
 3179	flavorless maroon evil ravioli della hippy	4	decent	
 3180	spoiled half-sized evil noodles	2	crappy	
 3181	anodized evil potion of potency	0		Effect: "Improprie Tea", Effect Duration: 15
@@ -3160,9 +3160,9 @@
 3188	acceptable an evil sump'm sump'm	3	good	
 3189	fancy acceptable evil ducha de oro	3	good	Effect: "Coming Up Roses", Effect Duration: 30
 3190	irresponsibly strong special hand-crafted evil horizontal tango	9	EPIC	Effect: "Wet Rub", Effect Duration: 50
-3191	bad boozy ghostly evil roll in the hay	5	decent	
+3191	boozy bad ghostly evil roll in the hay	5	decent	
 3192	blinking naughty origami kit	0		Last Available: "2008-02"
-3193	tumbling shaking naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
+3193	shaking tumbling naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	blue naughty paper shuriken	0		Last Available: "2008-02"
 3196	smelly origami pasties	0		Stench Spell Damage: +10, Softcore Only, Last Available: "2008-02"
@@ -3185,7 +3185,7 @@
 3213	fuchsia dwarvish paper	0		
 3214	yellow dwarvish parchment	0		
 3215	overcharged El Vibrato power sphere	0		
-3216	huge wobbly Fly-By-Knight Heraldry form	0		Free Pull
+3216	wobbly huge Fly-By-Knight Heraldry form	0		Free Pull
 3217	fuchsia El Vibrato Megadrone	0		
 3218	blurry auspicious glowstick of the detective	0		Item Drop: 30, Last Available: "2008-02"
 3219	sane hatrack	0		Free Pull, Last Available: "2011-12"
@@ -3194,8 +3194,8 @@
 3222	coward's electrified gatorskin umbrella	0		Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	aged spirit-forward blurry bottle of sewage schnapps	5	awesome	
-3226	lousy fortified bottle of Ooze-O	5	decent	
+3225	spirit-forward aged blurry bottle of sewage schnapps	5	awesome	
+3226	fortified lousy bottle of Ooze-O	5	decent	
 3227	flavorless C.H.U.M. chum	3	decent	
 3228	tasty mirror unfortunate dumplings	3	awesome	
 3229	decaying goldfish liver	0		
@@ -3250,9 +3250,9 @@
 3278	executive studded belt	0		Meat Drop: +40, Last Available: "2008-04"
 3279	upside-down lime green personal massager	0		Last Available: "2008-04"
 3280	skewed personalized coffee mug	0		Free Pull, Last Available: "2008-04"
-3281	cyan pulsating plasma ball	0		Last Available: "2008-04"
+3281	pulsating cyan plasma ball	0		Last Available: "2008-04"
 3282	narrow avaricious stick-on eyebrow piercing	0		Meat Drop: +30, Last Available: "2008-04"
-3283	spoiled huge green salad	8	crappy	
+3283	huge spoiled green salad	8	crappy	
 3284	blurry flame-retardant medical-grade C.H.U.M. lantern	0		Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10
 3285	beefy C.H.U.M. knife	0		Muscle: +10
 3286	narrow quilted Frosty's snowball sack	0		Damage Absorption: +40
@@ -3293,9 +3293,9 @@
 3321	ghostly packet of mayfly bait	0		Last Available: "2008-05"
 3322	mayfly bait necklace of the brute of the early riser	0		Muscle Percent: +30, Adventures: +7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	squat Ol' Scratch's salad fork	0		
-3324	upside-down red Frosty's frosty mug	0		
+3324	red upside-down Frosty's frosty mug	0		
 3325	smooth fortified jar of fermented pickle juice	5	awesome	
-3326	powdered tumbling mirror voodoo snuff	1	good	
+3326	powdered mirror tumbling voodoo snuff	1	good	
 3327	spoiled pulsating extra-greasy slider	3	crappy	
 3328	fuchsia skewed stiffened crumpled felt fedora of incineration	0		Damage Reduction: 1, Hot Spell Damage: +50, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	tumbling forbidden battered top-hat of the cheetah	0		Spell Damage Percent: +50, Initiative: +60, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3340,8 +3340,8 @@
 3368	modified glimmering roc feather	1	decent	Last Available: "2008-06"
 3369	twisted huge glimmering phoenix feather	1		Effect: "Booing Radly", Effect Duration: 30, Last Available: "2008-06"
 3370	boiled ghostly fuchsia glimmering penguin feather	1		Effect: "Mer-kindliness", Effect Duration: 50, Last Available: "2008-06"
-3371	distilled twirling jittery glimmering buzzard feather	1		Last Available: "2008-06"
-3372	twisted shaking twirling glimmering raven feather	1		Last Available: "2008-06"
+3371	distilled jittery twirling glimmering buzzard feather	1		Last Available: "2008-06"
+3372	twisted twirling shaking glimmering raven feather	1		Last Available: "2008-06"
 3373	mixed wobbly glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3368,7 +3368,7 @@
 3396	narrow zippy rosewater-soaked Hodgman's lobsterskin pants	0		Stench Resistance: +3, Initiative: +20, Familiar Effect: "atk, 1xPotato"
 3397	Jeselnik's Hodgman's bow tie of the cheetah	0		Sleaze Damage: +25, Initiative: +60, Single Equip
 3398	tolerable Hodgman's blanket	4	good	
-3399	bad watered-down jar of squeeze	2	decent	
+3399	watered-down bad jar of squeeze	2	decent	
 3400	bland bowl of fishysoisse	4	decent	
 3401	unsweetened anodized pickled cyan deadly lampshade	0		Effect: "Hyperoffended", Effect Duration: 18
 3402	adjusted ionized concentrated garbage juice	0		Effect: "Fudgehound", Effect Duration: 16
@@ -3396,7 +3396,7 @@
 3428	Vulcanized Everlasting Deckswabber	0		Effect: "Cautious Prowl", Effect Duration: 40
 3430	bindle of joy	0		
 3431	red cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
-3432	yellow huge cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
+3432	huge yellow cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
 3433	spice melange	0		
 3434	rattling cigar box	0		Free Pull, Last Available: "2011-12"
 3435	friendly stirring stick of horror	0		Familiar Weight: +3, Spooky Spell Damage: +25
@@ -3404,7 +3404,7 @@
 3437	yellow blurry padded wizardly Staff of the Black Kettle of the glutton	0		Mysticality: +25, Damage Absorption: +20, Food Drop: +100
 3438	Lo Pan's Staff of the Well-Tempered Cauldron of terror of Flo-Jo	0		Spell Critical Percent: +30, Spooky Spell Damage: +10, Initiative: +100
 3439	upside-down Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	powdered upside-down narrow prismatic wad	1	good	Last Available: "2008-07"
+3440	powdered narrow upside-down prismatic wad	1	good	Last Available: "2008-07"
 3441	toasty club of the five seasons	0		Hot Damage: +5, Last Available: "2008-07"
 3442	flame-wreathed rainbow crossbow	0		Hot Spell Damage: +10, Last Available: "2008-07"
 3443	kitten	0		
@@ -3423,7 +3423,7 @@
 3456	inspector's trusty torch	0		Item Drop: +15, Last Available: "2011-12"
 3457	skewed skewed gravedigger's Junior Adventurer's merit badge	0		Spooky Damage: +10
 3458	non-altered diffused skewed STYX deodorant body spray	0		Effect: "Happy Trails", Effect Duration: 19
-3459	weak fancy aged white-label gin	2	awesome	Effect: "Ticking Clock", Effect Duration: 25
+3459	aged weak fancy white-label gin	2	awesome	Effect: "Ticking Clock", Effect Duration: 25
 3460	stale tin rations	4	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
@@ -3446,28 +3446,28 @@
 3479	shaking squat balloon shield	0		Damage Reduction: 3
 3480	spot	0		
 3481	mirror uniclops egg	0		Free Pull, Last Available: "2009-10"
-3482	skewed spinning passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
-3483	upside-down maroon psychedelic bubble wand	0		Familiar Weight: +5
+3482	spinning skewed passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
+3483	maroon upside-down psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	improved frozen glittery mascara	0		Effect: "Heart of White", Effect Duration: 11
 3486	yellow dull fish scale	0		
 3487	rough fish scale	0		
 3488	bouncing pristine fish scale	0		
-3489	snack-sized bland beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
-3490	bite-sized bland glistening fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
+3489	bland snack-sized beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3490	bland bite-sized glistening fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
 3491	stale slick fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3492	crafty fish scimitar of the brute	0		Muscle Percent: +30, Maximum MP: +10
 3493	wicked fish stick of temperance	0		Spell Damage: +5, Sleaze Resistance: +5
 3494	mirror hardy fish bazooka of doom	0		Maximum HP: +50, Spooky Spell Damage: +50
-3495	moist spinning mirror sea salt crystal	0		Effect: "Peppermint Bite", Effect Duration: 58
+3495	moist mirror spinning sea salt crystal	0		Effect: "Peppermint Bite", Effect Duration: 58
 3496	modified super-ionized shaking pulsating bazookafish bubble gum	0		Effect: "Berry Experiential", Effect Duration: 37
-3497	weak hand-crafted lime green bottle of Pete's Sake	2	EPIC	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3497	hand-crafted weak lime green bottle of Pete's Sake	2	EPIC	
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	adequate canap&eacute;s	3	good	
 3502	modified olive thermos of brew	1	awesome	Effect: "Guts Feeling", Effect Duration: 20, Last Available: "2011-12"
-3503	artisanal special huge glass of brandy	4	EPIC	Effect: "Cool Spirit", Effect Duration: 10, Last Available: "2011-12"
+3503	special artisanal huge glass of brandy	4	EPIC	Effect: "Cool Spirit", Effect Duration: 10, Last Available: "2011-12"
 3504	French slippers	0		
 3505	blurry LWA ring of the boozehound	0		Booze Drop: +100
 3506	LARP membership card	0		Last Available: "2008-10"
@@ -3476,7 +3476,7 @@
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
-3512	spinning ghostly scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
+3512	ghostly spinning scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	skewed scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	maroon ganger bandana of the wise owl of the dark arts	0		Mysticality: +20, Spell Damage Percent: +100, Familiar Effect: "atk"
@@ -3487,7 +3487,7 @@
 3520	shark tooth	0		
 3521	shark tooth necklace of bravery of the boozehound	0		Spooky Resistance: +5, Booze Drop: +100, Single Equip
 3522	narrow supercharged forbidden shark jumper	0		Spell Damage Percent: +50, Maximum MP Percent: +30
-3523	chilled skewed upside-down shark cartilage	0		Effect: "Jerky, Boy", Effect Duration: 30
+3523	chilled upside-down skewed shark cartilage	0		Effect: "Jerky, Boy", Effect Duration: 30
 3524	dry eel battery	0		Effect: "Jingle Jangle Jingle", Effect Duration: 28
 3525	electrified temporary teardrop tattoo	0		Effect: "Gummibrain", Effect Duration: 14
 3526	hale scratch 'n' sniff crossbow	0		Maximum HP: +20, Last Available: "2008-11"
@@ -3497,7 +3497,7 @@
 3530	mutant gila monster egg	0		
 3531	squat rattlesnake enrager	0		Familiar Weight: +5
 3532	wobbly ant antidepressant	0		Familiar Weight: +5
-3533	squat twirling cactus monocle	0		Familiar Weight: +5
+3533	twirling squat cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
@@ -3510,8 +3510,8 @@
 3543	squat MacGyver's smartaleck's depleted Grimacite gravy boat	0		Moxie Percent: +30, Maximum MP: +100, Last Available: "2011-12"
 3544	bouncing horrifying hale depleted Grimacite weightlifting belt	0		Maximum HP: +20, Spooky Damage: +25, Single Equip, Last Available: "2011-12"
 3545	blurry zippy Newton's depleted Grimacite grappling hook	0		Experience (Mysticality): +3, Initiative: +20, Single Equip, Last Available: "2011-12"
-3546	zippy depleted Grimacite ninja mask of extreme caution	0		Monster Level: -25, Initiative: +20, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	Fonzie's Samson's depleted Grimacite shinguards	0		Experience (Muscle): +5, Experience (Moxie): +1, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	zippy depleted Grimacite ninja mask of extreme caution	0		Monster Level: -25, Initiative: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	Fonzie's Samson's depleted Grimacite shinguards	0		Experience (Muscle): +5, Experience (Moxie): +1, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	olive sinister depleted Grimacite astrolabe	0		Spell Damage: +10, Item Drop: +5, Single Equip, Last Available: "2011-12"
 3549	lightning-fast savvy KoL Con Cinco Pi&ntilde;ata Bat	0		Mysticality Percent: +20, Initiative: +40, Softcore Only, Last Available: "2008-09"
 3550	red lard-coated propeller beanie	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, cap 7"
@@ -3521,9 +3521,9 @@
 3554	glob of slime	0		
 3555	bland tumbling sea carrot	3	decent	
 3556	bland bite-sized sea cucumber	1	decent	
-3557	thick delicious sea avocado	5	awesome	
+3557	delicious thick sea avocado	5	awesome	
 3558	moldy sea lychee	4	crappy	
-3559	special bland sea tangelo	4	decent	Effect: "Sausage Festive", Effect Duration: 45
+3559	bland special sea tangelo	4	decent	Effect: "Sausage Festive", Effect Duration: 45
 3560	normal cyan sea honeydew	3	good	
 3561	polymerized gray jittery pressurized potion of puissance	0		Effect: "Insatiable Hunger", Effect Duration: 18
 3562	double-activated ghostly olive pressurized potion of perspicacity	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 55
@@ -3548,7 +3548,7 @@
 3581	sushi-rolling mat	0		
 3582	normal skewed rice	4	good	
 3584	rotten wobbly irradiated candy cane	3	crappy	Last Available: "2008-12"
-3585	spoiled tiny skewed shaking gingerbread mutant bugbear	1	crappy	Last Available: "2008-12"
+3585	spoiled tiny shaking skewed gingerbread mutant bugbear	1	crappy	Last Available: "2008-12"
 3586	lousy oozenog	4	decent	Last Available: "2008-12"
 3587	enhanced pickled sugar plum	0		Effect: "Thought", Effect Duration: 52, Last Available: "2008-12"
 3588	activated ionized wobbly sugar banana	0		Effect: "Go-Gone", Effect Duration: 44, Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	wobbly chitinous pod	0		Last Available: "2008-12"
 3624	smooth parasitic claw	0		Moxie: +15, Last Available: "2008-12"
-3625	fortified parasitic tentacles	0		Damage Absorption: +60, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	studded parasitic headgnawer	0		Damage Absorption: +80, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	fortified parasitic tentacles	0		Damage Absorption: +60, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	studded parasitic headgnawer	0		Damage Absorption: +80, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	tumbling blurry parasitic strangleworm of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,11 +3598,11 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	elven socks of Tarzan of the early riser	0		Experience (Muscle): +3, Adventures: +7, Last Available: "2008-12"
 3634	shellacked savvy elven gloves	0		Mysticality Percent: +20, Damage Reduction: 7, Last Available: "2008-12"
-3635	gray scandalous supercharged festive holiday hat	0		Maximum MP Percent: +30, Sleaze Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	gray scandalous supercharged festive holiday hat	0		Maximum MP Percent: +30, Sleaze Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	ghostly tumbling twirling beefy patent shoes of the cheetah	0		Muscle: +10, Initiative: +60, Last Available: "2008-12"
 3637	supercharged rosy-cheeked gray bow tie	0		Maximum HP Percent: +30, Maximum MP Percent: +30, Last Available: "2008-12"
 3638	supercharged smartaleck's penguin thesaurus	0		Moxie Percent: +30, Maximum MP Percent: +30, Last Available: "2008-12"
-3639	flavorless small blob-shaped Crimbo cookie	2	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	small flavorless blob-shaped Crimbo cookie	2	decent	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	spinning seaweed	0		
 3641	spinning jamfish jam	0		
 3642	dragonfish caviar	0		
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	mirror map to Madness Reef	0		
 3650	tasty fancy tumbling toast with jam	3	awesome	Effect: "Loyal Tea", Effect Duration: 35, Last Available: "2008-12"
-3651	twirling antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	twirling antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	mediocre practically non-alcoholic elven moonshine	1	decent	Last Available: "2008-12"
-3653	adequate gigantic ghostly knuckle sandwich	6	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	adequate gigantic ghostly knuckle sandwich	6	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	lightning-fast aromatic psycho sweater	0		Stench Resistance: +1, Initiative: +40, Last Available: "2008-12"
 3655	twirling fin-bit wax	0		Familiar Weight: +5
 3656	nasty plastic Mob Penguin	0		Stench Damage: +5, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	supercharged plastic strand of DNA	0		Maximum MP Percent: +30, Last Available: "2008-12"
 3660	studded plastic chunk of depleted Grimacite	0		Damage Absorption: +80, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	crafty Putty mitre	0		Maximum MP: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	skewed scorching sharpshooter's Putty leotard	0		Critical Hit Percent: +10, Hot Damage: +25, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	crafty Putty mitre	0		Maximum MP: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	skewed scorching sharpshooter's Putty leotard	0		Critical Hit Percent: +10, Hot Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	clever Putty ball	0		Maximum MP: +20, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	sinister smooth Putty snake of the wise owl	0		Mysticality: +20, Moxie: +15, Spell Damage: +10, Softcore Only, Last Available: "2009-01"
@@ -3641,22 +3641,22 @@
 3675	blinking Mer-kin pressureglobe	0		
 3676	wobbly Mer-kin foodbucket	0		
 3677	foul-smelling diving muff	0		Stench Damage: +10, Single Equip
-3678	weak tolerable red salinated mint julep	2	good	
+3678	tolerable weak red salinated mint julep	2	good	
 3679	ink bladder	0		
 3680	wobbly esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	squat map to the Marinara Trench	0		
-3684	decent big tempura carrot	5	good	
-3685	rotten fancy big tempura cucumber	5	crappy	Effect: "Saucemastery", Effect Duration: 35
+3684	big decent tempura carrot	5	good	
+3685	big rotten fancy tempura cucumber	5	crappy	Effect: "Saucemastery", Effect Duration: 35
 3686	delicious blurry tempura avocado	4	awesome	
 3687	decent red sea broccoli	4	good	
 3688	immense adequate sea cauliflower	7	good	
 3689	big spoiled tempura broccoli	5	crappy	
-3690	rotten bite-sized bouncing huge tempura cauliflower	1	crappy	
+3690	bite-sized rotten bouncing huge tempura cauliflower	1	crappy	
 3691	spoiled immense jittery sea blueberry	7	crappy	
 3692	bland jittery sea persimmon	4	decent	
-3693	anodized double-galvanized cyan blurry pulsating pressurized potion of perception	0		Effect: "Egg-stra Arm", Effect Duration: 33
+3693	anodized double-galvanized pulsating blurry cyan pressurized potion of perception	0		Effect: "Egg-stra Arm", Effect Duration: 33
 3694	unsweetened pressurized potion of proficiency	0		Effect: "Bone Homie", Effect Duration: 61
 3695	hardened Mer-kin digpick	0		Damage Reduction: 3
 3696	bouncing anemone nematocyst	0		
@@ -3683,7 +3683,7 @@
 3717	narrow decaying oar	0		
 3718	fishhook	0		
 3719	lantern	0		
-3720	twirling blue decaying pole	0		
+3720	blue twirling decaying pole	0		
 3721	decaying paddle	0		
 3722	tarnished ring	0		
 3723	tarnished rod	0		
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	ghostly double-paned hardened handwarmer	0		Damage Reduction: 3, Cold Resistance: +5, Single Equip
 3737	lard-coated lighter of doom	0		Spooky Spell Damage: +50, Sleaze Spell Damage: +25
-3738	normal immense red packet of beer nuts	10	good	
+3738	immense normal red packet of beer nuts	10	good	
 3739	narrow Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,7 +3713,7 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	modified super-nitrogenated lime green concoction of clumsiness	0		Effect: "Wreathed in Smoke", Effect Duration: 29
 3750	clever vampire pearl earring	0		Maximum MP: +20, Single Equip
-3751	spoiled half-sized narrow red chocolate chip brownies	2	crappy	
+3751	spoiled half-sized red narrow chocolate chip brownies	2	crappy	
 3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	concentrated denatured modified ghostly love song of vague ambiguity	0		Effect: "Spooky Demeanor", Effect Duration: 19, Last Available: "2009-02"
 3755	aerosolized blurry love song of smoldering passion	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 23, Last Available: "2009-02"
@@ -3732,7 +3732,7 @@
 3768	high-proof drinkable lychee chuhai	6	good	
 3769	delicious salacious screwdiver	4	awesome	
 3770	aged dew yoana salacious lei	4	awesome	
-3771	mediocre yellow shaking salacious lychee chuhai	3	decent	
+3771	mediocre shaking yellow salacious lychee chuhai	3	decent	
 3772	acceptable Alewife&trade; Ale	4	good	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
@@ -3747,14 +3747,14 @@
 3783	dehydrated narrow bottle of extra-strength melodramamine	1		
 3784	wobbly paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
-3786	blinking pulsating vampire glitter	0		Class: "Pastamancer"
+3786	pulsating blinking vampire glitter	0		Class: "Pastamancer"
 3787	wine-soaked bone chips	0		Class: "Pastamancer"
 3788	crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	maroon mirror charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	maroon mirror charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	olive chilly Sinatra's Mer-kin roundshield of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +5, Cold Damage: +5, Damage Reduction: 14
 3804	aromatic stylish Mer-kin breastplate	0		Moxie: +25, Stench Resistance: +1
 3805	shaking Annie Oakley's brainy Mer-kin sneakmask	0		Mysticality: +5, Critical Hit Percent: +20, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3777,13 +3777,13 @@
 3823	vacuum-sealed unsweetened wad of cotton	0		Effect: "Crimbo Epiphany", Effect Duration: 13
 3824	Grandma's Note	0		
 3825	mirror Grandma's Fuchsia Yarn	0		
-3826	huge spinning Grandma's Chartreuse Yarn	0		
+3826	spinning huge Grandma's Chartreuse Yarn	0		
 3827	green plastic oyster egg	0		
 3828	lime green Grandma's Map	0		
-3829	flavorless half-sized tempura radish	2	decent	
+3829	half-sized flavorless tempura radish	2	decent	
 3830	padded water-polo cap	0		Damage Absorption: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	weak acceptable jittery twirling Typical Tavern swill	2	good	
-3832	weak mediocre spinning tropical swill	2	decent	
+3832	mediocre weak spinning tropical swill	2	decent	
 3833	drinkable boozy fruity girl swill	5	good	
 3834	acceptable weak skewed blended swill	2	good	
 3835	costume wardrobe	0		Softcore Only
@@ -3861,8 +3861,8 @@
 3909	huge figurine of a charred seal	0		Class: "Seal Clubber"
 3910	spinning figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
-3912	purple tumbling imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	fortified lousy blended swill with a fly in it	5	decent	
+3912	tumbling purple imbued seal-blubber candle	0		Class: "Seal Clubber"
+3913	lousy fortified blended swill with a fly in it	5	decent	
 3914	blurry turtle wax	0		
 3915	executive turtle wax shield	0		Meat Drop: +40, Damage Reduction: 2
 3916	yellow turtle wax helmet of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3904,7 +3904,7 @@
 3952	twirling bouncing monocle	0		
 3953	mink	0		
 3954	teddy butler	0		
-3955	ghostly bouncing martini	0		
+3955	bouncing ghostly martini	0		
 3956	crazy bastard sword	0		
 3957	huge tin of caviar	0		
 3958	squat savvy bejeweled cufflinks	0		Mysticality Percent: +20, Single Equip
@@ -3942,7 +3942,7 @@
 3990	turtle shell helmet of horror	0		Spooky Spell Damage: +25, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
 3992	wobbly slime-soaked brain	0		Skill: "Slimy Synapses"
-3993	maroon jittery slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
+3993	jittery maroon slime-soaked sweat gland	0		Skill: "Slimy Shoulders"
 3994	fuchsia security blankie	0		Familiar Weight: +5
 3995	bundle of chamoix	0		
 3996	boxcar turtle	0		
@@ -3987,23 +3987,23 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	purple caustic slime nodule	0		
 4037	super-sized normal upside-down slimy sweetbreads	5	good	
-4038	tolerable triple-distilled slimy fermented bile bladder	8	good	
+4038	triple-distilled tolerable slimy fermented bile bladder	8	good	
 4039	twisted slimy alveolus	1		Effect: "It Tickles!  It Tickles!", Effect Duration: 5
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	weightlifter's pig-iron helm of the scaredy-cat	0		Muscle: +15, Monster Level: -15, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	smartaleck's cool pig-iron shinguards	0		Moxie: +5, Moxie Percent: +30, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	weightlifter's pig-iron helm of the scaredy-cat	0		Muscle: +15, Monster Level: -15, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	smartaleck's cool pig-iron shinguards	0		Moxie: +5, Moxie Percent: +30, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	Van der Graaf pig-iron bracers of James Dean	0		Experience (Moxie): +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	blinking wumpus-hair bolo	0		Last Available: "2009-06"
-4046	shaking mirror wumpus-hair net	0		Last Available: "2009-06"
+4046	mirror shaking wumpus-hair net	0		Last Available: "2009-06"
 4047	jittery skewed razor-sharp wumpus-hair whip	0		Weapon Damage Percent: +25, Last Available: "2009-06"
-4048	jittery careful brainy wumpus-hair wig of bravery	0		Mysticality: +5, Monster Level: -10, Spooky Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	twirling lard-coated Annie Oakley's curative wumpus-hair loincloth	0		Critical Hit Percent: +20, Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	jittery careful brainy wumpus-hair wig of bravery	0		Mysticality: +5, Monster Level: -10, Spooky Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	twirling lard-coated Annie Oakley's curative wumpus-hair loincloth	0		Critical Hit Percent: +20, Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	huge family-friendly wumpus-hair sweater of bravery	0		Spooky Resistance: +5, Sleaze Resistance: +1, Last Available: "2009-06"
 4051	hale ring of teleportation	0		Maximum HP: +20, Single Equip
 4052	tumbling glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	banana milkshake	1	crappy	Last Available: "2009-06"
-4054	tolerable weak shaking White Hyborian	2	good	Last Available: "2009-06"
+4054	weak tolerable shaking White Hyborian	2	good	Last Available: "2009-06"
 4055	goblin hunting spear of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-06"
 4056	dog trainer's Rosewater's goblin autoblowgun	0		Mysticality Percent: +30, Experience (familiar): +1, Last Available: "2009-06"
 4057	stylish tribal beads	0		Moxie: +25, Last Available: "2009-06"
@@ -4012,7 +4012,7 @@
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
-4063	squat tumbling Mecha Mayhem Club Card	0		Last Available: "2009-06"
+4063	tumbling squat Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	olive Ruby Rod	0		Last Available: "2009-06"
@@ -4034,12 +4034,12 @@
 4082	purple wobbly hale pernicious cudgel of mayonnaise	0		Maximum HP: +20, Sleaze Spell Damage: +50, Slime Hates It: +1
 4083	snack-sized tasty cupcake-in-a-cup	2	awesome	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	thick rotten protein paste	5	crappy	Last Available: "2009-06"
+4085	rotten thick protein paste	5	crappy	Last Available: "2009-06"
 4086	friendly cyber-mattock of the brute	0		Muscle Percent: +30, Familiar Weight: +3, Last Available: "2009-06"
 4087	purple facehugging alien	0		Last Available: "2009-06"
 4088	mirror X-37 gun	0		Last Available: "2009-06"
 4089	modified triple-polarized blue neurostim pill	0		Effect: "Here's Mud in Your Eye", Effect Duration: 56, Last Available: "2009-06"
-4090	flattened twirling yellow huge physiostim pill	0		Effect: "Cravin' for a Ravin'", Effect Duration: 60, Last Available: "2009-06"
+4090	flattened twirling huge yellow physiostim pill	0		Effect: "Cravin' for a Ravin'", Effect Duration: 60, Last Available: "2009-06"
 4091	twirling slimy cyst	0		
 4092	small slimy cyst	0		
 4093	medium slimy cyst	0		
@@ -4081,7 +4081,7 @@
 4129	dog trainer's friendly groovy hardened slime belt	0		Moxie Percent: +10, Familiar Weight: +3, Experience (familiar): +1, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	altered mirror green boot plant	1	EPIC	Last Available: "2009-06"
-4132	practically non-alcoholic hand-crafted sham champagne	1	EPIC	Last Available: "2009-06"
+4132	hand-crafted practically non-alcoholic sham champagne	1	EPIC	Last Available: "2009-06"
 4133	nitrogenated energized squat tempura air	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 29
 4134	flattened ghostly pressurized potion of pneumaticity	0		Effect: "Weapon of Mass Destruction", Effect Duration: 29
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4130,8 +4130,8 @@
 4178	curative sugar shotgun	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-09"
 4179	pulsating sugar shillelagh of the blizzard	0		Cold Spell Damage: +25, Last Available: "2009-09"
 4180	sugar shank of the brazier	0		Hot Spell Damage: +25, Last Available: "2009-09"
-4181	auspicious banded sugar chapeau of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Item Drop: +10, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	sharpshooter's sugar shorts	0		Critical Hit Percent: +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	auspicious banded sugar chapeau of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Item Drop: +10, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	sharpshooter's sugar shorts	0		Critical Hit Percent: +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	bouncing narrow sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	tumbling slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4178,7 +4178,7 @@
 4226	Star of Bravery of James Dean	0		Experience (Moxie): +3, Single Equip
 4227	narrow hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	twirling bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ghostly ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4199,7 +4199,7 @@
 4247	watered-down lousy maroon decanter of fine Scotch	2	decent	
 4248	vaporized tumbling expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
-4250	squat jittery maroon fisherman's sack	0		
+4250	squat maroon jittery fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	chilled jittery vial of squid ink	0		Effect: "Scavengers Scavenging", Effect Duration: 17
 4253	triple-quantum dry oxidized potion of speed	0		Effect: "Dances with Tweedles", Effect Duration: 19
@@ -4209,12 +4209,12 @@
 4257	twirling maroon petrified wood	0		Last Available: "2009-10"
 4258	rotten big chocolate-covered scarab beetle	5	crappy	Last Available: "2009-10"
 4259	artisanal jittery mulled cider	4	EPIC	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	tumbling pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	tumbling pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	healthy bark boxers	0		Maximum HP Percent: +20, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	brawny bark beret	0		Muscle Percent: +20, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	healthy bark boxers	0		Maximum HP Percent: +20, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	brawny bark beret	0		Muscle Percent: +20, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	bark bracelet of the businessman	0		Meat Drop: +50, Single Equip
 4267	smelly experienced Krakrox's Loincloth	0		Experience: +2, Stench Spell Damage: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	huge Jack Frost's lion tamer's Galapagosian Cuisses	0		Experience (familiar): +2, Cold Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4279,7 +4279,7 @@
 4327	jittery quilted wizardly La Hebilla del Cintur&oacute;n de Lopez of the businessman	0		Mysticality: +25, Damage Absorption: +40, Meat Drop: +50, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	enchanted rotten candy kneecapping stick	3	crappy	Effect: "Antarctic Memories", Effect Duration: 20, Last Available: "2009-12"
+4330	rotten enchanted candy kneecapping stick	3	crappy	Effect: "Antarctic Memories", Effect Duration: 20, Last Available: "2009-12"
 4331	bland tumbling licorice garrote	3	decent	Last Available: "2009-12"
 4332	candy knuckles of the detective	0		Item Drop: +20, Last Available: "2009-12"
 4333	stale tumbling jawbruiser	3	decent	Last Available: "2010-12"
@@ -4290,7 +4290,7 @@
 4338	ghostly Samson's plastic Don Crimbo	0		Experience (Muscle): +5, Last Available: "2009-12"
 4339	plastic Crimbomination of the sweet-tooth	0		Candy Drop: +100, Last Available: "2009-12"
 4340	ionized triple-oxidized shaking Piddles	0		Effect: "Scorpio Rising", Effect Duration: 19, Last Available: "2009-12"
-4341	corrupted ghostly maroon bouncing BitterSweetTarts	0		Effect: "Crimbo Flavor", Effect Duration: 31, Last Available: "2009-12"
+4341	corrupted maroon bouncing ghostly BitterSweetTarts	0		Effect: "Crimbo Flavor", Effect Duration: 31, Last Available: "2009-12"
 4342	ionized tarnished twirling Polka Pop	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 38, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	lime green Crimbo wreath	0		Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	bouncing gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	nasty snow hat	0		Stench Damage: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	spinning snow pants of the empath	0		Familiar Weight: +5, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	nasty snow hat	0		Stench Damage: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	spinning snow pants of the empath	0		Familiar Weight: +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	wobbly snow belly of terror	0		Spooky Spell Damage: +10, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	purple Crimbough	0		Last Available: "2009-12"
@@ -4316,7 +4316,7 @@
 4364	double-cold-filtered ghostly jittery elven suicide capsule	0		Effect: "Chlorophyll Flavor", Effect Duration: 62, Last Available: "2009-12"
 4365	moldy upside-down penguin focaccia bread	3	crappy	Last Available: "2009-12"
 4366	hand-crafted triple-distilled huge herringcello	10	EPIC	Last Available: "2009-12"
-4367	artisanal triple-distilled elven cellocello	6	EPIC	Last Available: "2009-12"
+4367	triple-distilled artisanal elven cellocello	6	EPIC	Last Available: "2009-12"
 4368	mirror wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	blinking Socratic pocketwatch on a chain of incineration	0		Experience (Mysticality): +1, Hot Spell Damage: +50, Last Available: "2009-12"
 4386	twirling strapping cement sandals of the pedagogue	0		Muscle: +5, Experience: +3, Single Equip, Last Available: "2009-12"
 4387	night-vision goggles of the dark arts of the detective	0		Spell Damage Percent: +100, Item Drop: +20, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	red pulsating Sherlock's peanut brittle shield	0		Item Drop: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	avaricious Jeselnik's Red Rover BB gun	0		Sleaze Damage: +25, Meat Drop: +30, Last Available: "2009-12"
 4391	tumbling red-and-green sweater of the brute	0		Muscle Percent: +30, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	yellow cheese ball	0		Last Available: "2010-01"
 4399	shaking fortified cheese sword	0		Damage Absorption: +60, Softcore Only, Last Available: "2010-01"
-4400	red cheese diaper of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	red cheese diaper of the wise owl	0		Mysticality: +20, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	spinning aromatic cheese wheel	0		Stench Resistance: +1, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	cheese eye of the cougar	0		Moxie: +20, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	Van der Graaf Staff of Queso Escusado of the empath of the detective	0		Familiar Weight: +5, Item Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-01"
@@ -4360,8 +4360,8 @@
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	half-sized bland quantum taco	0		Last Available: "2010-10"
-4413	irresponsibly strong lousy gray Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	bland half-sized quantum taco	0		Last Available: "2010-10"
+4413	lousy irresponsibly strong gray Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	purple twirling colorful plastic ball	0		Last Available: "2010-01"
 4415	dog trainer's sealhide hood	0		Experience (familiar): +1, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	razor-sharp sealhide leggings	0		Weapon Damage Percent: +25, Familiar Effect: "1xVolley, cap 40"
@@ -4373,7 +4373,7 @@
 4422	sealhide belt of the early riser	0		Adventures: +7
 4423	skewed sealhide snare	0		
 4424	puzzling trophy	0		
-4425	alkaline colloidal upside-down ghostly sealhide seal doll	0		Effect: "Stemonitis Storm", Effect Duration: 22
+4425	alkaline colloidal ghostly upside-down sealhide seal doll	0		Effect: "Stemonitis Storm", Effect Duration: 22
 4426	fuchsia hymnal	0		Skill: "Canticle of Carboloading"
 4428	purple glowstick on a string of mayonnaise	0		Sleaze Spell Damage: +50
 4429	flame-wreathed candy necklace	0		Hot Spell Damage: +10, Single Equip
@@ -4396,7 +4396,7 @@
 4448	compressed Instant Karma	1	decent	Effect: "Top Dog", Effect Duration: 25
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	tumbling map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	upside-down pointy hat of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	upside-down pointy hat of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	energetic machetito	0		Maximum MP Percent: +20, Last Available: "2010-04"
 4453	Newton's lawnmower blade	0		Experience (Mysticality): +3, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4416,15 +4416,15 @@
 4468	ghostly lime green Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	occult BRICKO hat	0		Spell Damage Percent: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	zippy BRICKO pants	0		Initiative: +20, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	occult BRICKO hat	0		Spell Damage Percent: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	zippy BRICKO pants	0		Initiative: +20, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	skewed steel-toed BRICKO sword	0		Damage Reduction: 9, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
-4477	jittery yellow BRICKO turtle	0		Last Available: "2010-02"
+4477	yellow jittery BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4435,11 +4435,11 @@
 4487	coward's BRICKO bulwark	0		Monster Level: -20, Damage Reduction: 3, Last Available: "2010-02"
 4488	BRICKO trunk	0		Last Available: "2010-02"
 4489	bouncing gilded BRICKO brick	0		Last Available: "2010-02"
-4490	huge teal gilded BRICKO chalice	0		Last Available: "2010-02"
+4490	teal huge gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	blurry BRICKO brick	0		Last Available: "2010-02"
 4492	mirror BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
-4494	blurry tumbling BRICKO reactor	0		Last Available: "2010-02"
+4494	tumbling blurry BRICKO reactor	0		Last Available: "2010-02"
 4495	BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	nitrogenated maroon recording of The Ballad of Richie Thingfinder	0		Effect: "Analog Drunk", Effect Duration: 23
@@ -4453,7 +4453,7 @@
 4505	energized polarized Northern pemmican	0		Effect: "Slightly Mutated", Effect Duration: 37
 4506	skewed puzzling ribbon	0		
 4507	ghostly Clan looking glass	0		Free Pull, Last Available: "2010-03"
-4508	energized magnetized mirror maroon &quot;DRINK ME&quot; potion	0		Effect: "Weapon of Mass Destruction", Effect Duration: 39, Last Available: "2010-03"
+4508	energized magnetized maroon mirror &quot;DRINK ME&quot; potion	0		Effect: "Weapon of Mass Destruction", Effect Duration: 39, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	moldy walrus ice cream	3	crappy	Last Available: "2010-03"
 4511	bland beautiful soup	3	decent	Last Available: "2010-03"
@@ -4461,7 +4461,7 @@
 4513	pulsating Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	stale upside-down pulsating Humpty Dumplings	4	decent	Last Available: "2010-03"
 4515	adequate Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
-4516	practically non-alcoholic acceptable ghostly missing wine	1	good	Last Available: "2010-03"
+4516	acceptable practically non-alcoholic ghostly missing wine	1	good	Last Available: "2010-03"
 4517	yummy matter custard	4	awesome	Last Available: "2010-03"
 4518	vacuum-sealed extra-galvanized bouncing comfit?	0		Effect: "Berry Thorny", Effect Duration: 57, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	MacGyver's eye of the Tiger-lily of doom	0		Maximum MP: +100, Spooky Spell Damage: +50, Last Available: "2010-03"
-4524	brawny wig of the businessman	0		Muscle Percent: +20, Meat Drop: +50, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4524	brawny wig of the businessman	0		Muscle Percent: +20, Meat Drop: +50, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	special flavorless donut	4	decent	Effect: "Feline Ferocity", Effect Duration: 35, Last Available: "2010-03"
 4526	flavorless bucket of honey	3	decent	Last Available: "2010-03"
 4527	olive greedy elephant stinger of James Dean	0		Experience (Moxie): +3, Meat Drop: +20, Last Available: "2010-03"
-4528	snack-sized moldy dragon snaps	2	crappy	Last Available: "2010-03"
+4528	moldy snack-sized dragon snaps	2	crappy	Last Available: "2010-03"
 4529	blinking mirror shaking inspector's rosewater-soaked snapdragon pistil	0		Stench Resistance: +3, Item Drop: +15, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	bland huge rook cookie	7	decent	Last Available: "2010-03"
-4532	thick adequate fancy bishop cookie	5	good	Effect: "Bilious Brawn", Effect Duration: 25, Last Available: "2010-03"
+4531	huge bland rook cookie	7	decent	Last Available: "2010-03"
+4532	thick fancy adequate bishop cookie	5	good	Effect: "Bilious Brawn", Effect Duration: 25, Last Available: "2010-03"
 4533	bland knight cookie	3	decent	Last Available: "2010-03"
-4534	miniature rotten tumbling lime green king cookie	2	crappy	Last Available: "2010-03"
-4535	snack-sized toothsome ghostly queen cookie	2	awesome	Effect: "Towering Strength", Last Available: "2010-03"
+4534	miniature rotten lime green tumbling king cookie	2	crappy	Last Available: "2010-03"
+4535	toothsome snack-sized ghostly queen cookie	2	awesome	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	greasy insane tophat	0		Sleaze Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	ghostly supercharged helm of the knight of the detective	0		Maximum MP Percent: +30, Item Drop: +20, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	greasy insane tophat	0		Sleaze Spell Damage: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	ghostly supercharged helm of the knight of the detective	0		Maximum MP Percent: +30, Item Drop: +20, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	double-paned occult wristwatch of the knight	0		Spell Damage Percent: +25, Cold Resistance: +5, Single Equip, Last Available: "2010-03"
-4540	spinning studded trousers of the knight of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	spinning studded trousers of the knight of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	bouncing wicked tophat	0		Spell Damage: +5, Familiar Effect: "1xBarrr, cap 25"
 4542	wool tie	0		Cold Resistance: +1, Single Equip
 4543	stylish tuxedo pants	0		Moxie: +25, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4510,26 +4510,26 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	mediocre world's most unappetizing beverage	3	decent	Last Available: "2010-04"
 4564	prompt slippery when wet shield	0		Adventures: +3, Damage Reduction: 6, Last Available: "2010-04"
-4565	gigantic decent raisin	6	good	Last Available: "2010-04"
-4566	blue jittery fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
+4565	decent gigantic raisin	6	good	Last Available: "2010-04"
+4566	jittery blue fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	pulsating Jack Frost's forbidden flyest of shirts	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2010-04"
 4568	bland snack-sized a dance upon the palate	2	decent	Last Available: "2010-04"
-4569	thick normal squat prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
+4569	normal thick squat prehistoric meteorite jawbreaker	5	good	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	moldy special wobbly squirmy violent party snack	3	crappy	Effect: "Crocodile Tear", Effect Duration: 25, Last Available: "2010-04"
 4572	mirror boxer's can-you-dig-it?	0		Muscle Percent: +10, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	ghostly bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	ghostly bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	narrow meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	altered lime green Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Mistified", Effect Duration: 65, Last Available: "2010-04"
 4580	double-paned school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Cold Resistance: +5, Last Available: "2010-04"
-4581	blinking vibrating hardy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Maximum HP: +50, Maximum MP Percent: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	blinking vibrating hardy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Maximum HP: +50, Maximum MP Percent: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	pulsating pulsating fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	snack-sized normal six wedges of goat cheese	2	good	
+4584	normal snack-sized six wedges of goat cheese	2	good	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	upside-down goth	0		
@@ -4577,12 +4577,12 @@
 4629	curative plastic spider ring	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	Rosewater's plastic kazoo	0		Mysticality Percent: +30, Last Available: "2010-06"
 4631	executive inflatable baseball bat	0		Meat Drop: +40, Last Available: "2010-06"
-4632	flame-retardant Herculean googly-star hat	0		Experience (Muscle): +1, Hot Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk"
+4632	flame-retardant Herculean googly-star hat	0		Experience (Muscle): +1, Hot Resistance: +1, Familiar Effect: "atk", Last Available: "2010-06"
 4633	narrow nippy googly-ball hat of James Dean	0		Experience (Moxie): +3, Cold Damage: +10, Last Available: "2010-06"
 4634	prompt clever googly-heart hat	0		Maximum MP: +20, Adventures: +3, Last Available: "2010-06"
 4635	narrow skewed experienced supercool super-sweet boom box	0		Moxie Percent: +20, Experience: +2, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	Lo Pan's quilted Sinatra's sinister demon mask	0		Experience (Moxie): +5, Damage Absorption: +40, Spell Critical Percent: +30, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	Lo Pan's quilted Sinatra's sinister demon mask	0		Experience (Moxie): +5, Damage Absorption: +40, Spell Critical Percent: +30, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	perfumed deadly smooth streetfighting champion's belt	0		Moxie: +15, Weapon Damage: +5, Stench Resistance: +5, Single Equip, Last Available: "2010-06"
 4639	double-paned Jim Carey's hale Space Trip safety headphones	0		Maximum HP: +20, Monster Level: +25, Cold Resistance: +5, Single Equip, Last Available: "2010-06"
 4640	LARP carp of the sewer	0		Stench Damage: +25
@@ -4594,8 +4594,8 @@
 4646	narrow family-friendly Socratic Herculean Meteoid ice beam	0		Experience (Muscle): +1, Experience (Mysticality): +1, Sleaze Resistance: +1, Last Available: "2011-12"
 4647	Da Vinci's Dungeon Fist gauntlet of Gandalf of Flo-Jo	0		Experience (Mysticality): +5, Spell Critical Percent: +20, Initiative: +100, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	red squat chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	cyan shaking fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	squat red chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	shaking cyan fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	tumbling ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	frosty lion tamer's ironic knit cap	0		Experience (familiar): +2, Cold Spell Damage: +10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	narrow ironic sunglasses	0		Single Equip
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	toasty pottery shield	0		Hot Damage: +5, Damage Reduction: 3, Last Available: "2010-09"
-4682	narrow deadly pottery hat of the overflowing toilet	0		Weapon Damage: +5, Stench Spell Damage: +50, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	weightlifter's pottery training pants of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	narrow deadly pottery hat of the overflowing toilet	0		Weapon Damage: +5, Stench Spell Damage: +50, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	weightlifter's pottery training pants of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	upside-down blurry Lo Pan's pottery club	0		Spell Critical Percent: +30, Last Available: "2010-09"
 4685	pottery yo-yo of the ox	0		Muscle: +20, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	huge fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	olive affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	studded beefy Greatest American Pants of the storm	0		Muscle: +10, Damage Absorption: +80, Maximum MP Percent: +40, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	studded beefy Greatest American Pants of the storm	0		Muscle: +10, Damage Absorption: +80, Maximum MP Percent: +40, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	Herculean fossilized necklace	0		Experience (Muscle): +1, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4650,7 +4650,7 @@
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	skewed blinking sharpshooter's red-hot medallion	0		Critical Hit Percent: +10, Single Equip, Last Available: "2010-09"
 4704	fossilized demon skull	0		Last Available: "2010-09"
-4705	jittery lime green ghostly fossilized spider skull	0		Last Available: "2010-09"
+4705	lime green ghostly jittery fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
 4708	yellow My First Shaker&trade;	0		
@@ -4668,22 +4668,22 @@
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	moldy liver and let pie	4	crappy	Last Available: "2010-10"
-4723	moldy big badass pie	5	crappy	Last Available: "2010-10"
-4724	stale bouncing spinning shoo-fish pie	3	decent	Last Available: "2010-10"
+4723	big moldy badass pie	5	crappy	Last Available: "2010-10"
+4724	stale spinning bouncing shoo-fish pie	3	decent	Last Available: "2010-10"
 4725	stale piping organ pie	4	decent	Last Available: "2010-10"
-4726	rotten tiny igloo pie	1	crappy	Last Available: "2010-10"
-4727	big normal fancy stomach turnover	5	good	Effect: "Influence of Sphere", Effect Duration: 30, Last Available: "2010-10"
+4726	tiny rotten igloo pie	1	crappy	Last Available: "2010-10"
+4727	fancy big normal stomach turnover	5	good	Effect: "Influence of Sphere", Effect Duration: 30, Last Available: "2010-10"
 4728	flavorless wobbly dead lights pie	3	decent	Last Available: "2010-10"
 4729	bland shaking throbbing organ pie	3	decent	Last Available: "2010-10"
 4730	dangerous stop shield	0		Weapon Damage: +10, Damage Reduction: 6, Last Available: "2009-12"
-4731	squat huge nest egg	0		
+4731	huge squat nest egg	0		
 4732	bouncing sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	kitty sheet music	0		Familiar Weight: +5
 4734	upside-down rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
-4735	bouncing jittery olive prop sword	0		Familiar Weight: +5
+4735	bouncing olive jittery prop sword	0		Familiar Weight: +5
 4736	wobbly tangle of rat tails	0		
 4737	steel-toed beer-soaked mop	0		Damage Reduction: 9
-4738	bad practically non-alcoholic day-old beer	1	decent	
+4738	practically non-alcoholic bad day-old beer	1	decent	
 4739	artisanal plain beer	3	EPIC	
 4740	bad overpriced &quot;imported&quot; beer	3	decent	
 4741	smiling rat	0		
@@ -4692,15 +4692,15 @@
 4744	deionized denatured dry PlexiPips	0		Effect: "Toast Tea", Effect Duration: 65
 4745	colloidal denatured unsweetened Wax Flask	0		Effect: "Enraged", Effect Duration: 29
 4746	concentrated Pain Dip	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 47
-4747	gigantic spoiled shaking shaking bone meal	7	crappy	Last Available: "2010-10"
-4748	perfectly mixed practically non-alcoholic bone aperitif	1	super ultra EPIC	Last Available: "2010-10"
+4747	spoiled gigantic shaking shaking bone meal	7	crappy	Last Available: "2010-10"
+4748	practically non-alcoholic perfectly mixed bone aperitif	1	super ultra EPIC	Last Available: "2010-10"
 4749	bouncing wizardly bonerang	0		Mysticality: +25, Last Available: "2010-10"
 4750	aromatic bone and arrows	0		Stench Resistance: +1, Last Available: "2010-10"
 4751	wobbly careful boning knife	0		Monster Level: -10, Last Available: "2010-10"
 4752	stiffened bone crusher	0		Damage Reduction: 1, Last Available: "2010-10"
 4753	bone spurs of the detective	0		Item Drop: +20, Single Equip, Last Available: "2010-10"
-4754	censurious bonedanna of dire peril	0		Weapon Damage: +20, Sleaze Resistance: +3, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	auspicious boneana hammock of Flo-Jo	0		Item Drop: +10, Initiative: +100, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	censurious bonedanna of dire peril	0		Weapon Damage: +20, Sleaze Resistance: +3, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	auspicious boneana hammock of Flo-Jo	0		Item Drop: +10, Initiative: +100, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	quantum candy skeleton	0		Effect: "Booooooze", Effect Duration: 22, Last Available: "2020-09"
@@ -4708,7 +4708,7 @@
 4760	squat packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	tiny moldy lime green mirror wobbly pumpkin pie	1	crappy	Last Available: "2010-11"
+4763	tiny moldy mirror wobbly lime green pumpkin pie	1	crappy	Last Available: "2010-11"
 4764	tolerable pumpkin beer	4	good	Last Available: "2010-11"
 4765	modified olive pumpkin juice	0		Effect: "Heart of Orange", Effect Duration: 25, Last Available: "2010-11"
 4766	shaking pumpkin bomb	0		Last Available: "2010-11"
@@ -4716,18 +4716,18 @@
 4768	squat zippy Jack Frost's lion tamer's Staff of the November Jack-O-Lantern	0		Experience (familiar): +2, Cold Spell Damage: +50, Initiative: +20, Last Available: "2010-11"
 4769	spinning pumpkin carriage	0		Last Available: "2010-11"
 4770	lime green Desert Bus pass	0		
-4771	twirling shaking ginormous pumpkin	0		Last Available: "2010-11"
-4804	blue upside-down Essence of Annoyance	0		Skill: "Summon Annoyance"
+4771	shaking twirling ginormous pumpkin	0		Last Available: "2010-11"
+4804	upside-down blue Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
 4806	spinning Unmotivator: Success Warrior	0		Free Pull
 4807	tumbling Unmotivator: Crashed Meat Car	0		Free Pull
-4810	upside-down twirling Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
+4810	twirling upside-down Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	jittery Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	big moldy CRIMBCOIDS mints	5	crappy	Last Available: "2011-01"
+4818	moldy big CRIMBCOIDS mints	5	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	adequate CRIMBCOLOAF	3	good	Last Available: "2011-01"
-4821	miniature moldy wobbly circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	moldy miniature wobbly circular CRIMBCOOKIE	2	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	savvy plastic CRIMBCO HQ	0		Mysticality Percent: +20, Last Available: "2010-12"
 4823	blurry greasy plastic fax machine	0		Sleaze Spell Damage: +10, Last Available: "2010-12"
 4824	twirling frosty plastic hobo elf	0		Cold Spell Damage: +10, Last Available: "2010-12"
@@ -4745,22 +4745,22 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	huge normal triangular CRIMBCOOKIE	7	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	special rotten big twirling square CRIMBCOOKIE	5	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4839	normal huge triangular CRIMBCOOKIE	7	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4840	rotten big special twirling square CRIMBCOOKIE	5	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	sizzling careful groovy bindlestocking	0		Moxie Percent: +10, Monster Level: -10, Hot Damage: +10, Last Available: "2010-12"
 4842	narrow red sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	quilted Uncle Hobo's stocking cap of incineration	0		Damage Absorption: +40, Hot Spell Damage: +50, Last Available: "2010-12", Familiar Effect: "atk"
+4845	quilted Uncle Hobo's stocking cap of incineration	0		Damage Absorption: +40, Hot Spell Damage: +50, Familiar Effect: "atk", Last Available: "2010-12"
 4846	Fonzie's sage Uncle Hobo's epic beard	0		Mysticality Percent: +10, Experience (Moxie): +1, Single Equip, Last Available: "2010-12"
-4847	prompt lion tamer's Uncle Hobo's gift baggy pants	0		Experience (familiar): +2, Adventures: +3, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	prompt lion tamer's Uncle Hobo's gift baggy pants	0		Experience (familiar): +2, Adventures: +3, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	ghostly spinning occult Uncle Hobo's fingerless tinsel gloves of the blizzard	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Single Equip, Last Available: "2010-12"
 4849	frightening vibrating Uncle Hobo's highest bough	0		Maximum MP Percent: +10, Spooky Damage: +5, Last Available: "2010-12"
 4850	Jack Frost's banded Uncle Hobo's belt	0		Damage Absorption: +100, Cold Spell Damage: +50, Single Equip, Last Available: "2010-12"
 4851	super-activated mirror chocolate cigar	0		Effect: "Slimily Strong", Effect Duration: 69, Last Available: "2010-12"
 4852	olive shellacked gift-a-pult	0		Damage Reduction: 7, Last Available: "2010-12"
 4853	tarnished polymerized tumbling holly-flavored Hob-O	0		Effect: "Reptilian Fortitude", Effect Duration: 39, Last Available: "2020-09"
-4854	upside-down squat CRIMBCO scrip	0		Last Available: "2011-01"
+4854	squat upside-down CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	wobbly Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	stanky hale grievous paperclip-on tie	0		Weapon Damage Percent: +50, Maximum HP: +20, Stench Spell Damage: +25, Single Equip, Last Available: "2011-01"
-4869	Newton's paperclip pants of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	spinning cyan sinister paperclip turban of vim and vigor of horror	0		Spell Damage: +10, Maximum HP Percent: +50, Spooky Spell Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	Newton's paperclip pants of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	spinning cyan sinister paperclip turban of vim and vigor of horror	0		Spell Damage: +10, Maximum HP Percent: +50, Spooky Spell Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	wobbly ghostly rosy-cheeked paperclip cape	0		Maximum HP Percent: +30, Last Available: "2011-01"
 4872	skewed glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	flattened incense bath ball	0		Effect: "Super-Charged", Effect Duration: 54, Last Available: "2011-01"
 4879	cold-filtered corrupted altered myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Nut-Rition", Effect Duration: 29, Last Available: "2011-01"
 4880	tumbling CRIMBCO mug	0		Last Available: "2011-01"
-4881	strong perfectly mixed twirling purple CRIMBCO wine	5	EPIC	Last Available: "2011-01"
+4881	perfectly mixed strong twirling purple CRIMBCO wine	5	EPIC	Last Available: "2011-01"
 4882	upside-down Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	jittery toe jam	0		Last Available: "2011-01"
 4884	adequate toe jam toast	3	good	Last Available: "2011-01"
@@ -4860,7 +4860,7 @@
 4957	galvanized half-baked potion	0		Effect: "Liquid Courage", Effect Duration: 41
 4958	strapping Knob Goblin deluxe scimitar	0		Muscle: +5
 4959	flavorless fancy Knob nuts	4	decent	Effect: "Supafly", Effect Duration: 10
-4960	drinkable weak squat gray Cobb's Knob Wurstbrau	2	good	
+4960	drinkable weak gray squat Cobb's Knob Wurstbrau	2	good	
 4961	purple Subject 37 file	0		
 4962	sizzling arcane researcher's mysterious lapel pin	0		Experience Percent (Mysticality): +10, Hot Damage: +10, Single Equip
 4963	blinking state loom	0		Familiar Weight: +10
@@ -4876,7 +4876,7 @@
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	blurry Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
-4976	fuchsia wobbly Alice's Army Mad Bomber	0		Last Available: "2011-03"
+4976	wobbly fuchsia Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	mirror Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	wobbly shaking Alice's Army Bowman	0		Last Available: "2011-03"
@@ -4921,12 +4921,12 @@
 5018	artisanal lime green mirror natto-infused sake	3	EPIC	Last Available: "2011-03"
 5019	colloidal dry olive wasabi marble soda	0		Effect: "Virgo Rising", Effect Duration: 56, Last Available: "2011-03"
 5020	magnetized altered tobiko marble soda	0		Effect: "Well-Swabbed Ear", Effect Duration: 28, Last Available: "2011-03"
-5021	deionized shaking pulsating natto marble soda	0		Effect: "Educated (Sorta)", Effect Duration: 31, Last Available: "2011-03"
+5021	deionized pulsating shaking natto marble soda	0		Effect: "Educated (Sorta)", Effect Duration: 31, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	quadruple-concentrated elderly jawbreaker	0		Effect: "Insatiable Hunger", Effect Duration: 41, Last Available: "2020-09"
 5024	spirit-forward hand-crafted marshmallow flamb&eacute;	5	EPIC	Last Available: "2011-03"
 5025	spirit-forward tolerable cranberry schnapps	5	good	Last Available: "2011-03"
-5026	weak acceptable breaded beer	2	good	Last Available: "2011-03"
+5026	acceptable weak breaded beer	2	good	Last Available: "2011-03"
 5027	acceptable pulsating soy cordial	3	good	Last Available: "2011-03"
 5028	rosewater-soaked astral bludgeon of terror of mayonnaise	0		Spooky Spell Damage: +10, Sleaze Spell Damage: +50, Stench Resistance: +3
 5029	Herculean astral shield of the pedagogue	0		Experience: +3, Experience (Muscle): +1, Damage Reduction: 15
@@ -4943,19 +4943,19 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	jittery grievous smartaleck's astral shirt of the bloodbag	0		Moxie Percent: +30, Weapon Damage Percent: +50, Maximum HP: +100
 5042	upside-down Sherlock's savvy astral belt	0		Mysticality Percent: +20, Item Drop: +25
-5043	diet moldy astral hot dog	1		
+5043	moldy diet astral hot dog	1		
 5044	hand-crafted astral pilsner	4		
 5045	astral hot dog dinner	0		
 5046	mirror astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	spinning shard of double-ice	0		Last Available: "2011-04"
-5049	shaking MacGyver's extremely unsafe double-ice cap of the early riser	0		Weapon Damage Percent: +100, Maximum MP: +100, Adventures: +7, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	shaking MacGyver's extremely unsafe double-ice cap of the early riser	0		Weapon Damage Percent: +100, Maximum MP: +100, Adventures: +7, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	aromatic wizardly double-ice box of the early riser	0		Mysticality: +25, Stench Resistance: +1, Adventures: +7, Last Available: "2011-04"
-5051	family-friendly sizzling double-ice britches of dire peril	0		Weapon Damage: +20, Hot Damage: +10, Sleaze Resistance: +1, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	family-friendly sizzling double-ice britches of dire peril	0		Weapon Damage: +20, Hot Damage: +10, Sleaze Resistance: +1, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	bouncing intriguing puzzle box	0		Last Available: "2011-04"
-5055	shaking blurry obnoxious riddle	0		Last Available: "2011-04"
+5055	blurry shaking obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	nitrogenated Atomic Comic	0		Effect: "Altered Wavelengths", Effect Duration: 37, Last Available: "2011-04"
 5058	colloidal quantum Red Pill	0		Effect: "X-Ray Vision", Effect Duration: 61, Last Available: "2011-04"
@@ -4965,26 +4965,26 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	lime green twirling Salsa de las Epocas	0		Last Available: "2011-04"
-5065	spoiled tiny fuchsia tumbling spaghetti con calaveras	1	crappy	Last Available: "2011-04"
+5065	spoiled tiny tumbling fuchsia spaghetti con calaveras	1	crappy	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	rotten popcorn	4	crappy	Last Available: "2011-04"
 5068	rotten chaos popcorn	3	crappy	Last Available: "2011-04"
 5069	dangerous groovy hole of the sweet-tooth	0		Moxie Percent: +10, Weapon Damage: +10, Candy Drop: +100, Last Available: "2011-04"
 5070	blurry innuendo	0		Last Available: "2011-04"
 5071	small stale tumbling s'more	0	decent	Last Available: "2011-04"
-5072	huge ghostly diamond ring	0		Last Available: "2011-04"
-5073	hand-crafted weak blue Russian Ice	2	EPIC	Last Available: "2011-04"
+5072	ghostly huge diamond ring	0		Last Available: "2011-04"
+5073	weak hand-crafted blue Russian Ice	2	EPIC	Last Available: "2011-04"
 5074	squat blurry brainy clay ashtray	0		Mysticality: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	dog trainer's lanyard	0		Experience (familiar): +1, Single Equip, Last Available: "2011-05"
-5076	spinning monster pants of wisdom	0		Mysticality: +15, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	spinning monster pants of wisdom	0		Mysticality: +15, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	blinking box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	chilled liquefied cyan Pok&euml;mann band-aid	0		Effect: "Alchemical, Brother", Effect Duration: 47, Last Available: "2011-05"
-5079	smelly sizzling Van der Graaf helmet	0		Hot Damage: +10, Stench Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	smelly sizzling Van der Graaf helmet	0		Hot Damage: +10, Stench Spell Damage: +10, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	frosty crutch	0		Cold Spell Damage: +10, Last Available: "2011-05"
 5081	hale shock belt	0		Maximum HP: +20, Single Equip, Last Available: "2011-05"
-5082	liquefied upside-down tumbling Okee-Dokee soda	0		Effect: "Nature's Bounty", Effect Duration: 59, Last Available: "2011-05"
+5082	liquefied tumbling upside-down Okee-Dokee soda	0		Effect: "Nature's Bounty", Effect Duration: 59, Last Available: "2011-05"
 5083	hale rubber band gun	0		Maximum HP: +20, Last Available: "2011-05"
-5084	miser's pin-stripe slacks	0		Meat Drop: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	miser's pin-stripe slacks	0		Meat Drop: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	blurry sizzling gloves	0		Hot Damage: +10, Single Equip, Last Available: "2011-05"
 5086	alkaline yellow correction fluid	0		Effect: "Feet of Watermelon", Effect Duration: 54, Last Available: "2011-05"
 5087	vibrating Pok&euml;mann figurine: Porkachu	0		Maximum MP Percent: +10, Single Equip, Last Available: "2011-05"
@@ -5012,7 +5012,7 @@
 5109	twirling teal Herculean stress ball	0		Experience (Muscle): +1, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Sherlock's Ultracolor&trade; shirt	0		Item Drop: +25, Last Available: "2011-05"
-5112	huge twirling My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
+5112	twirling huge My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	lime green hedge trimmers	0		
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	upside-down Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	blinking knitted Van der Graaf personal trainer's Admiral's hat	0		Experience Percent (Muscle): +10, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-05", Familiar Effect: "atk"
-5122	twirling mirror greedy asbestos-lined aviator's cap of Flo-Jo	0		Hot Resistance: +5, Meat Drop: +20, Initiative: +100, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	blinking knitted Van der Graaf personal trainer's Admiral's hat	0		Experience Percent (Muscle): +10, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk", Last Available: "2011-05"
+5122	twirling mirror greedy asbestos-lined aviator's cap of Flo-Jo	0		Hot Resistance: +5, Meat Drop: +20, Initiative: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	hardy mirrored aviator shades of the bloodbag	0		Maximum HP: 150, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	jittery Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5032,15 +5032,15 @@
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	activated Ultrasoldier Serum	0		Effect: "Cat-Alyzed", Effect Duration: 43, Last Available: "2011-06"
-5132	stale gigantic tumbling elven hardtack	6	decent	Last Available: "2011-06"
-5133	artisanal extra-dry elven squeeze	5	EPIC	Last Available: "2011-06"
+5132	gigantic stale tumbling elven hardtack	6	decent	Last Available: "2011-06"
+5133	extra-dry artisanal elven squeeze	5	EPIC	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	pulsating E.M.U. joystick	0		Last Available: "2011-06"
 5136	squat E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
-5138	skewed bouncing E.M.U. harness	0		Last Available: "2011-06"
+5138	bouncing skewed E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
-5140	dried narrow squat astral energy drink	1		
+5140	dried squat narrow astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	blurry wicked Da Vinci's honey dipper of horror	0		Experience (Mysticality): +5, Spell Damage: +5, Spooky Spell Damage: +25
 5149	manspreader's Socratic honeybritches of Calamity Jane	0		Experience (Mysticality): +1, Critical Hit Percent: +15, Monster Level: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	avaricious lard-coated Jim Carey's honeycap	0		Monster Level: +25, Sleaze Spell Damage: +25, Meat Drop: +30, Familiar Effect: "1xPotato, cap 43"
-5151	skewed forbidden Moonthril Circlet	0		Spell Damage Percent: +50, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	teal Moonthril Greaves of horror	0		Spooky Spell Damage: +25, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	skewed forbidden Moonthril Circlet	0		Spell Damage Percent: +50, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	teal Moonthril Greaves of horror	0		Spooky Spell Damage: +25, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	lime green Moonthril Flamberge of doom	0		Spooky Spell Damage: +50, Last Available: "2011-06"
 5154	Moonthril Longbow of the brute	0		Muscle Percent: +30, Last Available: "2011-06"
 5155	upside-down Temple Grandin's Moonthril Cuirass	0		Familiar Weight: +7, Softcore Only, Last Available: "2011-06"
@@ -5076,10 +5076,10 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	drinkable Saison du Lune	4	good	Last Available: "2011-06"
 5175	delicious blurry skewed Moonthril Schnapps	4	awesome	Last Available: "2011-06"
-5176	hand-crafted strong Wrecked Generator	5	EPIC	Last Available: "2011-06"
+5176	strong hand-crafted Wrecked Generator	5	EPIC	Last Available: "2011-06"
 5177	rotten Spaghetti with Moonballs	3	crappy	Last Available: "2011-06"
 5178	flavorless Crepes a la Lune	3	decent	Last Available: "2011-06"
-5179	snack-sized moldy Moon Pie	2	crappy	Last Available: "2011-06"
+5179	moldy snack-sized Moon Pie	2	crappy	Last Available: "2011-06"
 5180	polarized adjusted Vulcanized jittery Comet Pop	0		Effect: "Cake Caked", Effect Duration: 16, Last Available: "2011-06"
 5181	colloidal quadruple-enhanced spinning Flan in the Moon	0		Effect: "Alchemical, Brother", Effect Duration: 25, Last Available: "2011-06"
 5182	irradiated improved 1/6th Pound Cake	0		Effect: "Trash-Wrapped", Effect Duration: 38, Last Available: "2011-06"
@@ -5089,7 +5089,7 @@
 5186	Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	activated honey stick	0		Effect: "Stogied", Effect Duration: 32
-5189	vacuum-sealed teal blurry double-ice gum	0		Effect: "Hobo Flavor", Effect Duration: 69, Last Available: "2011-04"
+5189	vacuum-sealed blurry teal double-ice gum	0		Effect: "Hobo Flavor", Effect Duration: 69, Last Available: "2011-04"
 5190	teal Operation Patriot Shield of the brute of the pedagogue of the empath	0		Muscle Percent: +30, Experience: +3, Familiar Weight: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	ionized chilled squat corrupted data	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 66, Last Available: "2011-06"
@@ -5105,14 +5105,14 @@
 5202	pickled greasy paste	1	crappy	Last Available: "2011-08"
 5203	altered bug paste	1	EPIC	Last Available: "2011-08"
 5204	diluted mirror hippy paste	1	EPIC	Effect: "Lifted Spirits", Effect Duration: 25, Last Available: "2011-08"
-5205	dehydrated skewed purple jittery orc paste	1	good	Last Available: "2011-08"
+5205	dehydrated purple skewed jittery orc paste	1	good	Last Available: "2011-08"
 5206	boiled olive blurry demonic paste	1	crappy	Last Available: "2011-08"
-5207	diluted ghostly cyan indescribably horrible paste	1	crappy	Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2011-08"
+5207	diluted cyan ghostly indescribably horrible paste	1	crappy	Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2011-08"
 5208	diluted ghostly paste	1	crappy	Last Available: "2011-08"
 5209	modified goblin paste	1	crappy	Last Available: "2011-08"
 5210	diluted bouncing purple pirate paste	1	EPIC	Last Available: "2011-08"
 5211	diluted red tumbling chlorophyll paste	1	good	Last Available: "2011-08"
-5212	distilled maroon wobbly paste	1	EPIC	Last Available: "2011-08"
+5212	distilled wobbly maroon paste	1	EPIC	Last Available: "2011-08"
 5213	dried blinking Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	dehydrated skewed wobbly slimy paste	1	decent	Last Available: "2011-08"
 5215	compressed huge maroon penguin paste	1	good	Effect: "Superioreo", Effect Duration: 35, Last Available: "2011-08"
@@ -5125,9 +5125,9 @@
 5222	shaking Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	rotten shaking Ur-Donut	4	crappy	Last Available: "2011-09"
-5225	skewed blurry huge The Bomb	0		Last Available: "2011-09"
+5225	blurry skewed huge The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
-5227	delicious boozy jittery bucket of wine	5	awesome	Last Available: "2011-09"
+5227	boozy delicious jittery bucket of wine	5	awesome	Last Available: "2011-09"
 5228	spoiled ultrafondue	3	crappy	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
@@ -5139,25 +5139,25 @@
 5236	grievous frosty halo	0		Weapon Damage Percent: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of terror	0		Spooky Spell Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	tolerable Lumineux Limnio	3	good	Last Available: "2011-09"
-5239	acceptable enchanted Morto Moreto	3	good	Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2011-09"
+5239	enchanted acceptable Morto Moreto	3	good	Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2011-09"
 5240	spirit-forward perfectly mixed gray Temps Tempranillo	5	EPIC	Last Available: "2011-09"
-5241	drinkable distilled shaking shaking Bordeaux Marteaux	5	good	Last Available: "2011-09"
-5242	bad practically non-alcoholic tumbling Fromage Pinotage	1	decent	Last Available: "2011-09"
+5241	distilled drinkable shaking shaking Bordeaux Marteaux	5	good	Last Available: "2011-09"
+5242	practically non-alcoholic bad tumbling Fromage Pinotage	1	decent	Last Available: "2011-09"
 5243	delicious gray Beignet Milgranet	4	awesome	Last Available: "2011-09"
 5244	tolerable blurry Muschat	3	good	Last Available: "2011-09"
 5245	toothsome cool jelly donut	4	awesome	Last Available: "2011-09"
-5246	tasty enchanted snack-sized tumbling upside-down shrapnel jelly donut	2	awesome	Effect: "Okee-Dokee Go!", Effect Duration: 15, Last Available: "2011-09"
+5246	tasty enchanted snack-sized upside-down tumbling shrapnel jelly donut	2	awesome	Effect: "Okee-Dokee Go!", Effect Duration: 15, Last Available: "2011-09"
 5247	flavorless occult jelly donut	3	decent	Last Available: "2011-09"
 5248	small spoiled gray thyme jelly donut	2	crappy	Last Available: "2011-09"
-5249	toothsome super-sized danish	5	awesome	Last Available: "2011-09"
+5249	super-sized toothsome danish	5	awesome	Last Available: "2011-09"
 5250	low-calorie decent smashed danish	1	good	Last Available: "2011-09"
 5251	decent forbidden danish	3	good	Last Available: "2011-09"
 5252	decent cool cat claw	3	good	Last Available: "2011-09"
 5253	rotten blunt cat claw	4	crappy	Last Available: "2011-09"
-5254	normal huge olive shadowy cat claw	3	good	Last Available: "2011-09"
+5254	normal olive huge shadowy cat claw	3	good	Last Available: "2011-09"
 5255	flavorless diet cheezburger	1	decent	Last Available: "2011-09"
 5256	stale skewed toasted brie	4	decent	Last Available: "2011-09"
-5257	aerosolized dry quadruple-flattened skewed blurry potion of the field gar	0		Effect: "Corona de la Salsa", Effect Duration: 61, Last Available: "2011-09"
+5257	aerosolized dry quadruple-flattened blurry skewed potion of the field gar	0		Effect: "Corona de la Salsa", Effect Duration: 61, Last Available: "2011-09"
 5258	triple-vacuum-sealed too legit potion	0		Effect: "The Halls of Muscularity", Effect Duration: 27, Last Available: "2011-09"
 5259	moist Bright Water	0		Effect: "The Halls of Mysticality", Effect Duration: 31, Last Available: "2011-09"
 5260	quantum yellow cold-filtered water	0		Effect: "Sparkly!", Effect Duration: 14, Last Available: "2011-09"
@@ -5173,7 +5173,7 @@
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
-5273	narrow red skull with a fuse in it	0		Last Available: "2011-09"
+5273	red narrow skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	quilted hammerus	0		Damage Absorption: +40, Last Available: "2011-09"
 5276	wobbly Jack Frost's blunt icepick	0		Cold Spell Damage: +50, Last Available: "2011-09"
@@ -5193,12 +5193,12 @@
 5290	twirling d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
-5293	blinking maroon generic restorative potion	0		Last Available: "2011-09"
+5293	maroon blinking generic restorative potion	0		Last Available: "2011-09"
 5294	spinning spinning kobold treasure hoard	0		Last Available: "2011-09"
-5295	ghostly upside-down newborn kobold	0		Last Available: "2011-09"
+5295	upside-down ghostly newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	huge moldy phish stick	7	crappy	Last Available: "2011-09"
+5298	moldy huge phish stick	7	crappy	Last Available: "2011-09"
 5299	flame-retardant vibrating steel-toed plastic vampire fangs	0		Damage Reduction: 9, Maximum MP Percent: +10, Hot Resistance: +1, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5224,8 +5224,8 @@
 5321	enhanced shaking Sweet Sword	0		Effect: "Mutated", Effect Duration: 36, Last Available: "2011-10"
 5322	artisanal cyan Ecto-Cooler	4	EPIC	Last Available: "2011-10"
 5323	acceptable Bartles and BRAAAINS wine cooler	4	good	Last Available: "2011-10"
-5324	smooth ghostly gray Blood Light	3	awesome	Last Available: "2011-10"
-5325	fancy acceptable Silver Bullet beer	3	good	Effect: "Sparkly!", Effect Duration: 10, Last Available: "2011-10"
+5324	smooth gray ghostly Blood Light	3	awesome	Last Available: "2011-10"
+5325	acceptable fancy Silver Bullet beer	3	good	Effect: "Sparkly!", Effect Duration: 10, Last Available: "2011-10"
 5326	hand-crafted strong Bone's Farm &quot;wine&quot;	5	EPIC	Last Available: "2011-10"
 5327	purple ghost protocol	0		Last Available: "2011-10"
 5328	liquefied electrified mirror sorority brain	0		Effect: "Resilient Spirit", Effect Duration: 35, Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	flattened skewed lime green drum of pomade	0		Effect: "Standard Cheer", Effect Duration: 68, Last Available: "2011-10"
 5331	gray throwing bone	0		Last Available: "2011-10"
 5332	bouncing baleful extra-see-thru nightie	0		Spell Damage: +25, Last Available: "2011-10"
-5333	Herculean BRAINS shorts of temperance	0		Experience (Muscle): +1, Sleaze Resistance: +5, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	Herculean BRAINS shorts of temperance	0		Experience (Muscle): +1, Sleaze Resistance: +5, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	huge Tesla Mesmereyes&trade; contact lenses	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-10"
 5335	banded scrunchie	0		Damage Absorption: +100, Single Equip, Last Available: "2011-10"
-5336	Usain Bolt's veiny extremely skinny jeans	0		Maximum HP: +10, Initiative: +80, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	rosewater-soaked banded The Necbromancer's Hat	0		Damage Absorption: +100, Stench Resistance: +3, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	Usain Bolt's veiny extremely skinny jeans	0		Maximum HP: +10, Initiative: +80, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	rosewater-soaked banded The Necbromancer's Hat	0		Damage Absorption: +100, Stench Resistance: +3, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	avaricious scandalous The Necbromancer's Stein of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, Meat Drop: +30, Last Available: "2011-10"
-5339	therapeutic occult wicked The Necbromancer's Shorts	0		Spell Damage: +5, Spell Damage Percent: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	therapeutic occult wicked The Necbromancer's Shorts	0		Spell Damage: +5, Spell Damage Percent: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	zippy nippy The Necbromancer's Wizard Staff of courage	0		Cold Damage: +10, Spooky Resistance: +3, Initiative: +20, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	bad cyan The Cooler Out of Space	3	decent	Last Available: "2011-10"
@@ -5290,7 +5290,7 @@
 5387	scandalous ridiculous earring	0		Sleaze Damage: +5, Last Available: "2011-11"
 5388	miser's ridiculous sunglasses	0		Meat Drop: +10, Last Available: "2011-11"
 5389	moldy ridiculous sandwich	4	crappy	Last Available: "2011-11"
-5390	delicious watered-down ridiculous cocktail	2	awesome	Last Available: "2011-11"
+5390	watered-down delicious ridiculous cocktail	2	awesome	Last Available: "2011-11"
 5391	rock-hard Herculean zombie monkey necklace	0		Experience (Muscle): +1, Damage Reduction: 5
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5306,13 +5306,13 @@
 5403	mirror Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	wobbly Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	double-paned MacGyver's occult cane-mail shirt	0		Spell Damage Percent: +25, Maximum MP: +100, Cold Resistance: +5, Last Available: "2011-12"
-5406	purple medical-grade brainy cane-mail pants of the boozehound	0		Mysticality: +5, Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5406	purple medical-grade brainy cane-mail pants of the boozehound	0		Mysticality: +5, Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	delicious Vodka Matryoshka	3	awesome	Last Available: "2011-12"
-5408	weak perfectly mixed teal Gin Mint	2	EPIC	Last Available: "2011-12"
-5409	drinkable weak Tequiz Navidad	2	good	Last Available: "2011-12"
+5408	perfectly mixed weak teal Gin Mint	2	EPIC	Last Available: "2011-12"
+5409	weak drinkable Tequiz Navidad	2	good	Last Available: "2011-12"
 5410	acceptable Mint Yulep	4	good	Last Available: "2011-12"
 5411	perfectly mixed Crimbojito	3	EPIC	Last Available: "2011-12"
-5412	irresponsibly strong perfectly mixed Sangria de Menthe	9	EPIC	Last Available: "2011-12"
+5412	perfectly mixed irresponsibly strong Sangria de Menthe	9	EPIC	Last Available: "2011-12"
 5413	blue candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	modified huge licorice root	0		Effect: "Raging Animal", Effect Duration: 18, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	manspreader's kumquartz ring	0		Monster Level: +10, Single Equip, Last Available: "2011-11"
 5425	blurry lime green strawberyl necklace of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2011-11"
 5426	bouncing zippy asbestos-lined sucker bucket	0		Hot Resistance: +5, Initiative: +20, Last Available: "2011-11"
-5427	banded sucker hakama	0		Damage Absorption: +100, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	green jittery greasy sucker kabuto	0		Sleaze Spell Damage: +10, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	banded sucker hakama	0		Damage Absorption: +100, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	green jittery greasy sucker kabuto	0		Sleaze Spell Damage: +10, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	greedy sucker tachi	0		Meat Drop: +20, Last Available: "2011-11"
 5430	blurry sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5337,10 +5337,10 @@
 5434	DNOTC Box	0		Last Available: "2017-12"
 5435	fudgecule	0		Last Available: "2011-11"
 5436	cold-filtered spinning jittery fudge lily	0		Effect: "A Few Extra Pounds", Effect Duration: 48, Last Available: "2011-11"
-5437	blurry wobbly superheated fudge	0		Last Available: "2011-11"
+5437	wobbly blurry superheated fudge	0		Last Available: "2011-11"
 5438	quantum fluid of fudge-finding	0		Effect: "The Dinsey Way", Effect Duration: 15, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	half-sized rotten fudgesicle	2	crappy	Last Available: "2011-11"
+5440	rotten half-sized fudgesicle	2	crappy	Last Available: "2011-11"
 5441	narrow wand of fudge control	0		Last Available: "2011-11"
 5442	skewed The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	red mirror miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5382,7 +5382,7 @@
 5479	tasty bouncing gummi bear	4	awesome	Last Available: "2011-11"
 5480	adequate gummi bear	3	good	Last Available: "2011-11"
 5481	stale gummi bear	3	decent	Last Available: "2011-11"
-5482	snack-sized flavorless drunki-bear	2	decent	Last Available: "2011-11"
+5482	flavorless snack-sized drunki-bear	2	decent	Last Available: "2011-11"
 5483	spoiled huge wobbly drunki-bear	8	crappy	Last Available: "2011-11"
 5484	rotten super-sized upside-down drunki-bear	5	crappy	Last Available: "2011-11"
 5485	tumbling baleful gummi bowtie	0		Spell Damage: +25, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	electrified gummi belemnite	0		Effect: "Greasy Peasy", Effect Duration: 32, Last Available: "2011-11"
 5497	olive all-year sucker	0		Last Available: "2011-11"
 5498	olive heart of dark chocolate	0		Last Available: "2011-11"
-5499	bouncing beefy Big Candy's tophat of the businessman	0		Muscle: +10, Meat Drop: +50, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	bouncing beefy Big Candy's tophat of the businessman	0		Muscle: +10, Meat Drop: +50, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	spinning Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	gray cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	dry pulsating Mortimer's nostrum	0		Effect: "Pwnd", Effect Duration: 15, Last Available: "2012-12"
-5534	drinkable watered-down bouncing twirling Barulio's bottle	2	good	Last Available: "2012-12"
+5534	watered-down drinkable bouncing twirling Barulio's bottle	2	good	Last Available: "2012-12"
 5535	altered diffused teal Marvin's marvelous pill	0		Effect: "Action", Effect Duration: 54, Last Available: "2012-12"
 5536	shaking Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5459,14 +5459,14 @@
 5556	lightning-fast flame-wreathed Rain-Doh wings	0		Hot Spell Damage: +10, Initiative: +40, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	scorching Rain-Doh laser gun of chilblains	0		Cold Damage: +25, Hot Damage: +25, Softcore Only, Last Available: "2012-02"
-5559	narrow Rain-Doh lantern of the brazier of bravery	0		Hot Spell Damage: +25, Spooky Resistance: +5, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	narrow Rain-Doh lantern of the brazier of bravery	0		Hot Spell Damage: +25, Spooky Resistance: +5, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	squat Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	hardy slick Rain-Doh violet bo	0		Moxie: +10, Maximum HP: +50, Softcore Only, Last Available: "2012-02"
 5563	ghostly Rain-Doh box	0		Last Available: "2012-02"
 5564	narrow Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	normal PB&BP	3	good	
-5566	adequate pulsating blinking club sandwich	4	good	
+5566	adequate blinking pulsating club sandwich	4	good	
 5567	normal jumbo corned-beef Reuben	5	good	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
@@ -5474,83 +5474,83 @@
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	hand-crafted Drac & Tan	4	EPIC	Last Available: "2012-03"
-5574	lousy irresponsibly strong fuchsia Transylvania Sling	10	decent	Last Available: "2012-03"
+5574	irresponsibly strong lousy fuchsia Transylvania Sling	10	decent	Last Available: "2012-03"
 5575	artisanal blinking Shot of the Living Dead	3	EPIC	Last Available: "2012-03"
 5576	delicious Buttery Knob	3	awesome	Last Available: "2012-03"
-5577	practically non-alcoholic mediocre tumbling Slippery Knob	1	decent	Last Available: "2012-03"
+5577	mediocre practically non-alcoholic tumbling Slippery Knob	1	decent	Last Available: "2012-03"
 5578	artisanal Flaming Knob	4	EPIC	Last Available: "2012-03"
 5579	drinkable Grasshopper	4	good	Last Available: "2012-03"
 5580	bad spinning Locust	3	decent	Last Available: "2012-03"
 5581	watered-down drinkable blue Plague of Locusts	2	good	Last Available: "2012-03"
 5582	hand-crafted Red Dwarf	4	EPIC	Last Available: "2012-03"
 5583	drinkable upside-down Golden Mean	3	good	Last Available: "2012-03"
-5584	high-proof artisanal Green Giant	7	EPIC	Last Available: "2012-03"
-5585	lousy distilled skewed Aye Aye	5	decent	Last Available: "2012-03"
+5584	artisanal high-proof Green Giant	7	EPIC	Last Available: "2012-03"
+5585	distilled lousy skewed Aye Aye	5	decent	Last Available: "2012-03"
 5586	perfectly mixed huge Aye Aye, Captain	3	EPIC	Last Available: "2012-03"
 5587	bad Aye Aye, Tooth Tooth	4	decent	Last Available: "2012-03"
 5588	practically non-alcoholic mediocre Humanitini	1	decent	Last Available: "2012-03"
-5589	acceptable triple-distilled More Humanitini than Humanitini	9	good	Last Available: "2012-03"
-5590	acceptable olive shaking Oh, the Humanitini	4	good	Last Available: "2012-03"
+5589	triple-distilled acceptable More Humanitini than Humanitini	9	good	Last Available: "2012-03"
+5590	acceptable shaking olive Oh, the Humanitini	4	good	Last Available: "2012-03"
 5591	watered-down acceptable Great Older Fashioned	2	good	Last Available: "2012-03"
 5592	weak perfectly mixed Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	smooth Crazymaker	4	awesome	Last Available: "2012-03"
-5594	hand-crafted practically non-alcoholic Zoodriver	1	EPIC	Last Available: "2012-03"
+5594	practically non-alcoholic hand-crafted Zoodriver	1	EPIC	Last Available: "2012-03"
 5595	aged skewed Sloe Comfortable Zoo	3	awesome	Last Available: "2012-03"
 5596	bad Sloe Comfortable Zoo on Fire	4	decent	Last Available: "2012-03"
 5597	smooth Suffering Sinner	4	awesome	Last Available: "2012-03"
 5598	weak tolerable Suppurating Sinner	2	good	Last Available: "2012-03"
-5599	special weak acceptable wobbly Sizzling Sinner	2	good	Effect: "Berry Critical", Effect Duration: 40, Last Available: "2012-03"
+5599	acceptable weak special wobbly Sizzling Sinner	2	good	Effect: "Berry Critical", Effect Duration: 40, Last Available: "2012-03"
 5600	mediocre Firewater	4	decent	Last Available: "2012-03"
 5601	extra-dry artisanal Earth and Firewater	5	EPIC	Last Available: "2012-03"
 5602	drinkable Earth, Wind and Firewater	3	good	Last Available: "2012-03"
 5603	hand-crafted Slimosa	4	EPIC	Last Available: "2012-03"
-5604	practically non-alcoholic perfectly mixed Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
+5604	perfectly mixed practically non-alcoholic Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
 5605	hand-crafted Slimebite	3	EPIC	Last Available: "2012-03"
 5606	practically non-alcoholic aged fuchsia Cement Mixer	1	awesome	Last Available: "2012-03"
-5607	hand-crafted watered-down jittery Jackhammer	2	EPIC	Last Available: "2012-03"
+5607	watered-down hand-crafted jittery Jackhammer	2	EPIC	Last Available: "2012-03"
 5608	acceptable blurry Dump Truck	3	good	Last Available: "2012-03"
-5609	smooth practically non-alcoholic Fauna Libre	1	awesome	Last Available: "2012-03"
-5610	artisanal watered-down Chakra Libre	2	EPIC	Last Available: "2012-03"
-5611	spirit-forward perfectly mixed olive Aura Libre	5	EPIC	Last Available: "2012-03"
+5609	practically non-alcoholic smooth Fauna Libre	1	awesome	Last Available: "2012-03"
+5610	watered-down artisanal Chakra Libre	2	EPIC	Last Available: "2012-03"
+5611	perfectly mixed spirit-forward olive Aura Libre	5	EPIC	Last Available: "2012-03"
 5612	triple-distilled hand-crafted Sazerorc	7	EPIC	Last Available: "2012-03"
 5613	weak hand-crafted Sazuruk-hai	2	EPIC	Last Available: "2012-03"
 5614	drinkable distilled Flaming Sazerorc	5	good	Last Available: "2012-03"
 5615	watered-down mediocre Green Velvet	2	decent	Last Available: "2012-03"
-5616	weak drinkable mirror Green Muslin	2	good	Last Available: "2012-03"
+5616	drinkable weak mirror Green Muslin	2	good	Last Available: "2012-03"
 5617	watered-down hand-crafted Green Burlap	2	EPIC	Last Available: "2012-03"
-5618	mediocre practically non-alcoholic huge pulsating Mohobo	1	decent	Last Available: "2012-03"
+5618	mediocre practically non-alcoholic pulsating huge Mohobo	1	decent	Last Available: "2012-03"
 5619	tolerable Moonshine Mohobo	3	good	Last Available: "2012-03"
 5620	irresponsibly strong mediocre blurry Flaming Mohobo	8	decent	Last Available: "2012-03"
-5621	tolerable enchanted watered-down Drunken Philosopher	2	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 50, Last Available: "2012-03"
-5622	enchanted artisanal Drunken Neurologist	4	EPIC	Effect: "Human-Horror Hybrid", Effect Duration: 25, Last Available: "2012-03"
+5621	tolerable watered-down enchanted Drunken Philosopher	2	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 50, Last Available: "2012-03"
+5622	artisanal enchanted Drunken Neurologist	4	EPIC	Effect: "Human-Horror Hybrid", Effect Duration: 25, Last Available: "2012-03"
 5623	weak acceptable Drunken Astrophysicist	2	good	Last Available: "2012-03"
-5624	high-proof bad Dark & Starry	9	decent	Last Available: "2012-03"
-5625	perfectly mixed distilled Black Hole	5	EPIC	Last Available: "2012-03"
+5624	bad high-proof Dark & Starry	9	decent	Last Available: "2012-03"
+5625	distilled perfectly mixed Black Hole	5	EPIC	Last Available: "2012-03"
 5626	hand-crafted skewed Event Horizon	3	EPIC	Last Available: "2012-03"
 5627	artisanal Herring Daiquiri	3	EPIC	Last Available: "2012-03"
-5628	acceptable irresponsibly strong Herring Wallbanger	8	good	Last Available: "2012-03"
-5629	mediocre distilled Herringtini	5	decent	Last Available: "2012-03"
+5628	irresponsibly strong acceptable Herring Wallbanger	8	good	Last Available: "2012-03"
+5629	distilled mediocre Herringtini	5	decent	Last Available: "2012-03"
 5630	bad ghostly Lollipop Drop	3	decent	Last Available: "2012-03"
 5631	bad Candy Alexander	4	decent	Last Available: "2012-03"
-5632	distilled drinkable twirling Candicaine	5	good	Last Available: "2012-03"
-5633	watered-down tolerable squat Caipiranha	2	good	Last Available: "2012-03"
+5632	drinkable distilled twirling Candicaine	5	good	Last Available: "2012-03"
+5633	tolerable watered-down squat Caipiranha	2	good	Last Available: "2012-03"
 5634	tolerable Flying Caipiranha	3	good	Last Available: "2012-03"
 5635	smooth Flaming Caipiranha	3	awesome	Last Available: "2012-03"
-5636	watered-down special hand-crafted Punchplanter	2	EPIC	Effect: "Eyes of the Dragon", Effect Duration: 30, Last Available: "2012-03"
+5636	hand-crafted special watered-down Punchplanter	2	EPIC	Effect: "Eyes of the Dragon", Effect Duration: 30, Last Available: "2012-03"
 5637	artisanal triple-distilled wobbly Doublepunchplanter	9	EPIC	Last Available: "2012-03"
 5638	lousy Haymaker	3	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	massive normal fungus	9	good	
+5641	normal massive fungus	9	good	
 5642	shaking poisoned dart	0		
 5643	boiled stone wool	0		Effect: "It's Electric!", Effect Duration: 47
 5644	narrow stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	jittery manspreader's calendar	0		Monster Level: +10, Damage Reduction: 4
-5648	censurious gravedigger's Boris's Helm	0		Spooky Damage: +10, Sleaze Resistance: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	censurious gravedigger's Boris's Helm	0		Spooky Damage: +10, Sleaze Resistance: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	pulsating Usain Bolt's wizardly staph of homophones	0		Mysticality: +25, Initiative: +80
-5650	reassuring vibrating Boris's Helm (askew) of mayonnaise	0		Maximum MP Percent: +10, Sleaze Spell Damage: +50, Spooky Resistance: +1, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	reassuring vibrating Boris's Helm (askew) of mayonnaise	0		Maximum MP Percent: +10, Sleaze Spell Damage: +50, Spooky Resistance: +1, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	shaking mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	wobbly key-o-tron	0		
@@ -5577,9 +5577,9 @@
 5674	skewed &quot;L&quot;	0		
 5675	distilled pulsating watered-down Red Minotaur	1		Effect: "Frozen Hands", Effect Duration: 30
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	mirror gray Van der Graaf Ze&trade; goggles	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	mirror gray Van der Graaf Ze&trade; goggles	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	tumbling soggy used band-aid	0		Last Available: "2012-05"
-5679	Jack Frost's wizardly stylish swimsuit	0		Mysticality: +25, Cold Spell Damage: +50, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	Jack Frost's wizardly stylish swimsuit	0		Mysticality: +25, Cold Spell Damage: +50, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	moldy red P.B.L.T.	4	crappy	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5605,43 +5605,43 @@
 5702	upside-down mannequin	0		Familiar Weight: +5
 5703	huge crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	executive extremely unsafe wax hat	0		Weapon Damage Percent: +100, Meat Drop: +40, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	savvy wax pants of the cougar	0		Moxie: +20, Mysticality Percent: +20, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	executive extremely unsafe wax hat	0		Weapon Damage Percent: +100, Meat Drop: +40, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	savvy wax pants of the cougar	0		Moxie: +20, Mysticality Percent: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
-5708	quantum yellow bouncing drop of water-37	0		Effect: "Hammered", Effect Duration: 32, Last Available: "2012-07"
-5709	Herculean fireman's helmet of Flo-Jo	0		Experience (Muscle): +1, Initiative: +100, Last Available: "2012-07", Familiar Effect: "cold atk"
+5708	quantum bouncing yellow drop of water-37	0		Effect: "Hammered", Effect Duration: 32, Last Available: "2012-07"
+5709	Herculean fireman's helmet of Flo-Jo	0		Experience (Muscle): +1, Initiative: +100, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	forbidden fire axe	0		Spell Damage Percent: +50, Last Available: "2012-07"
 5713	Usain Bolt's fire extinguisher of vim and vigor of the bloodbag	0		Maximum HP Percent: +50, Maximum HP: +100, Initiative: +80, Last Available: "2012-07"
 5714	upside-down FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	shaking skewed Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	toothsome snack-sized FDKOL hotcakes	2	awesome	Last Available: "2012-07"
+5717	snack-sized toothsome FDKOL hotcakes	2	awesome	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	flavorless big fuchsia fiery wing	5	decent	Last Available: "2012-07"
+5720	big flavorless fuchsia fiery wing	5	decent	Last Available: "2012-07"
 5721	brainy wings of fire of the brute	0		Mysticality: +5, Muscle Percent: +30, Last Available: "2012-07"
 5722	pulsating hardened FDKOL fire hose	0		Damage Reduction: 3, Last Available: "2012-07"
 5723	non-improved deionized bottle of fire	0		Effect: "Optimist Primal", Effect Duration: 15, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	shaking hot daub	0		Last Available: "2012-07"
-5726	knitted healthy hot daub bun	0		Maximum HP Percent: +20, Cold Resistance: +3, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	red manspreader's grievous hot daub stand	0		Weapon Damage Percent: +50, Monster Level: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	knitted healthy hot daub bun	0		Maximum HP Percent: +20, Cold Resistance: +3, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	red manspreader's grievous hot daub stand	0		Weapon Damage Percent: +50, Monster Level: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	tumbling purple blinking veiny foot-long hot daub of the brute	0		Muscle Percent: +30, Maximum HP: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	small tasty mirror angst burger	2	awesome	
 5731	fortified perfectly mixed 5-hour acrimony	5	EPIC	
 5732	blank note	0		
 5733	eerily silent box	0		
-5734	decent small tumbling forbidden sausage	2	good	
+5734	small decent tumbling forbidden sausage	2	good	
 5735	personal trainer's Lord Flameface's cloak	0		Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	improved wet wet Drizzlers&trade; Black Licorice	0		Effect: "Turkey-Ambitious", Effect Duration: 21
 5737	pickled daub-breaker	0		Effect: "Mmmmmelon", Effect Duration: 25, Last Available: "2020-09"
 5738	Camp Scout backpack of mayonnaise	0		Sleaze Spell Damage: +50, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	adequate bouncing bag of GORP	3	good	Last Available: "2012-07"
-5741	mediocre strong water purification pills	5	decent	Last Available: "2012-07"
+5741	strong mediocre water purification pills	5	decent	Last Available: "2012-07"
 5742	jittery Camp Scout pup tent	0		Last Available: "2012-07"
-5743	watered-down artisanal CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
+5743	artisanal watered-down CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
 5744	decent bag of GORF	4	good	Last Available: "2012-07"
 5745	huge ghostly CSA discount card	0		Last Available: "2020-09"
 5746	fancy tasty bag of QWOP	4	awesome	Effect: "Dirty Pear", Effect Duration: 35, Last Available: "2012-07"
@@ -5650,10 +5650,10 @@
 5749	tolerable CSA cheerfulness ration	4	good	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	tasty bite-sized crappy brain	1	awesome	
+5752	bite-sized tasty crappy brain	1	awesome	
 5753	bland massive cyan decent brain	6	decent	
 5754	bland skewed good brain	3	decent	
-5755	small decent boss brain	2	good	
+5755	decent small boss brain	2	good	
 5756	stale immense hunter brain	8	decent	
 5758	narrow Temple Grandin's personal trainer's Staff of Holiday Sensations of Leguizamo	0		Experience Percent (Muscle): +10, Monster Level: +20, Familiar Weight: +7, Last Available: "2011-11"
 5759	flame-wreathed hardy staff	0		Maximum HP: +50, Hot Spell Damage: +10
@@ -5665,11 +5665,11 @@
 5765	twirling fuzzy earmuffs of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Familiar Effect: "1.5xVolley, cap 32"
 5766	blinking skewed greedy MacGyver's boxer's fuzzy montera	0		Muscle Percent: +10, Maximum MP: +100, Meat Drop: +20, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	twirling gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	squat gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	blurry gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	twirling gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	squat gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	blurry gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	narrow talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5718,8 +5718,8 @@
 5819	flattened unsweetened gravy fairy warlock hat	0		Effect: "The Living Hitpoints", Effect Duration: 68
 5820	quadruple-energized dry bull blubber	0		Effect: "Preemptive Medicine", Effect Duration: 46
 5821	aerosolized galvanized frog lip-print	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 53
-5822	aerosolized polymerized irradiated jittery bouncing huge gazely stare	0		Effect: "Emotion Sickness", Effect Duration: 24
-5823	anodized anodized squat fuchsia spinning canopic jar	0		Effect: "The Magic of LOV", Effect Duration: 27
+5822	aerosolized polymerized irradiated jittery huge bouncing gazely stare	0		Effect: "Emotion Sickness", Effect Duration: 24
+5823	anodized anodized fuchsia squat spinning canopic jar	0		Effect: "The Magic of LOV", Effect Duration: 27
 5824	ionized adjusted clove-flavored lip balm	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 40
 5825	non-tarnished pickled Skullery Maid's Knee	0		Effect: "Biologically Shocked", Effect Duration: 49
 5826	alkaline anodized red mirror zombie hollandaise	0		Effect: "20/20 Vision", Effect Duration: 46
@@ -5728,7 +5728,7 @@
 5829	vacuum-sealed dry moist mirror janglin' bones	0		Effect: "Prelude of Precision", Effect Duration: 65
 5830	flattened pygmy papers	0		Effect: "Barking Mad", Effect Duration: 25
 5831	modified pygmy dart	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 56
-5832	extra-boiled quadruple-flattened teal ghostly secret mummy herbs and spices	0		Effect: "Izchak's Blessing", Effect Duration: 20
+5832	extra-boiled quadruple-flattened ghostly teal secret mummy herbs and spices	0		Effect: "Izchak's Blessing", Effect Duration: 20
 5833	non-nitrogenated jittery brigand brittle	0		Effect: "Tingly Wrists", Effect Duration: 19
 5834	polarized holistic headache remedy	0		Effect: "Drunk With Power", Effect Duration: 11
 5835	chilled lime green scrunchie tourniquet	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 33
@@ -5741,8 +5741,8 @@
 5842	diffused dry toothbrush	0		Effect: "Mortarfied", Effect Duration: 50
 5843	corrupted pirate cream pie	0		Effect: "It's Electric!", Effect Duration: 32
 5844	boiled una poca de gracia	0		Effect: "All Branned Up", Effect Duration: 31
-5845	dry non-denatured skewed twirling teal blurry compressed air canister	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 56
-5846	anodized twirling teal salt water taffy	0		Effect: "White-boy Angst", Effect Duration: 15
+5845	dry non-denatured skewed twirling blurry teal compressed air canister	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 56
+5846	anodized teal twirling salt water taffy	0		Effect: "White-boy Angst", Effect Duration: 15
 5847	altered dry enhanced purple unholy water	0		Effect: "Void Between the Stars", Effect Duration: 15
 5848	polarized cyan Bangyomaman battle juice	0		Effect: "Outer Wolf&trade;", Effect Duration: 67
 5849	oxidized squat handyman &quot;hand soap&quot;	0		Effect: "Ancestral Disapproval", Effect Duration: 58
@@ -5756,7 +5756,7 @@
 5857	extra-energized grey cube	0		Effect: "Cotton Mouthed", Effect Duration: 56
 5858	irradiated frozen votive candle	0		Effect: "Blood-Gorged", Effect Duration: 49
 5859	extra-improved skewed maroon ghostly booby trap	0		Effect: "Sticks and Stones", Effect Duration: 54
-5860	polarized ionized blurry mirror Agent Corrigan's cigarette	0		Effect: "Sugar High", Effect Duration: 22
+5860	polarized ionized mirror blurry Agent Corrigan's cigarette	0		Effect: "Sugar High", Effect Duration: 22
 5861	moist good ash	0		Effect: "Staying Frosty", Effect Duration: 28
 5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	beefcake's papier-m&acirc;ch&eacute;te of temperance	0		Muscle: +25, Sleaze Resistance: +5, Last Available: "2012-09"
 5869	experienced papier-m&acirc;chine gun of temperance	0		Experience: +2, Sleaze Resistance: +5, Last Available: "2012-09"
 5870	squat Annie Oakley's baleful papier-masque	0		Spell Damage: +25, Critical Hit Percent: +20, Single Equip, Last Available: "2012-09"
-5871	spinning shellacked Newton's papier-mitre	0		Experience (Mysticality): +3, Damage Reduction: 7, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	papier-m&acirc;churidars of the dark arts of doom	0		Spell Damage Percent: +100, Spooky Spell Damage: +50, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	spinning shellacked Newton's papier-mitre	0		Experience (Mysticality): +3, Damage Reduction: 7, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	papier-m&acirc;churidars of the dark arts of doom	0		Spell Damage Percent: +100, Spooky Spell Damage: +50, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5783,13 +5783,13 @@
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	jittery skeletal skiff	0		Last Available: "2012-10"
 5886	stanky experienced thinker's beefy Bonestabber	0		Muscle: +10, Mysticality: +10, Experience: +2, Stench Spell Damage: +25, Last Available: "2012-10"
-5887	drinkable weak crystal skeleton vodka	2	good	Last Available: "2012-10"
+5887	weak drinkable crystal skeleton vodka	2	good	Last Available: "2012-10"
 5888	spinning Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	shaking horrifying auxiliary backbone	0		Spooky Damage: +25, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	galvanized extra-liquefied blinking that gum you like	0		Effect: "Slimed Stomach", Effect Duration: 52
-5893	teal mirror dreaming Jung man	0		Free Pull, Last Available: "2013-12"
+5893	mirror teal dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	shaking Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	wobbly shaking avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	green canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
@@ -5802,7 +5802,7 @@
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	wobbly jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	pulsating pixel pill	0		
-5907	tumbling red pixel energy tank	0		
+5907	red tumbling pixel energy tank	0		
 5908	skewed ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	wobbly lard-coated Temple Grandin's wedding ring	0		Familiar Weight: +7, Sleaze Spell Damage: +25, Single Equip
 5910	deactivated nanobots	0		Free Pull, Last Available: "2012-11"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	huge BittyCar HotCar	0		Last Available: "2012-12"
-5928	huge greasy brainwave-controlled unicorn horn	0		Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	huge greasy brainwave-controlled unicorn horn	0		Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	bouncing bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	Temple Grandin's plastic four-shadowed mime of the storm of doom	0		Maximum MP Percent: +40, Familiar Weight: +7, Spooky Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	twirling scorching plastic Father McGruber	0		Hot Damage: +25, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of the brute	0		Muscle Percent: +30, Last Available: "2012-12"
 5962	hardy plastic blazing bat	0		Maximum HP: +50, Last Available: "2012-12"
-5963	arcane researcher's electronic dulcimer pants of temperance	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +5, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	arcane researcher's electronic dulcimer pants of temperance	0		Experience Percent (Mysticality): +10, Sleaze Resistance: +5, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	A-Boo clue	0		
 5965	frightening vibrating Frown Exerciser	0		Maximum MP Percent: +10, Spooky Damage: +5, Single Equip, Last Available: "2012-12"
 5966	squat bouncing soul monocle	0		Single Equip
@@ -5871,7 +5871,7 @@
 5973	record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	ghostly record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	shaking record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
-5976	narrow lime green blurry skewed record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
+5976	lime green narrow blurry skewed record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	dance instructor's beefy silent beret of Gandalf	0		Muscle: +10, Experience Percent (Moxie): +10, Spell Critical Percent: +20, Familiar Effect: "1xVolley, cap 3"
 5978	flavorless slice of pizza	3	decent	Last Available: "2013-02"
 5979	teal huge coin	0		Last Available: "2013-02"
@@ -5879,15 +5879,15 @@
 5981	squat star	0		Last Available: "2013-02"
 5982	lousy tankard of ale	3	decent	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	ghostly electrified therapeutic cloth cap of chilblains	0		Cold Damage: +25, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	ghostly electrified therapeutic cloth cap of chilblains	0		Cold Damage: +25, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	skewed ghostly scandalous horrifying iron dagger of the bloodbag	0		Maximum HP: +100, Spooky Damage: +25, Sleaze Damage: +5, Last Available: "2013-02"
 5986	rotten narrow hamburger	3	crappy	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	maroon potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	watered-down delicious bouncing bottle of wine	2	awesome	Last Available: "2013-02"
+5990	delicious watered-down bouncing bottle of wine	2	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	Sinatra's iron helmet of the pedagogue of Flo-Jo	0		Experience: +3, Experience (Moxie): +5, Initiative: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	Sinatra's iron helmet of the pedagogue of Flo-Jo	0		Experience: +3, Experience (Moxie): +5, Initiative: +100, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	blurry energetic healthy Socratic steel sword	0		Experience (Mysticality): +1, Maximum HP Percent: +20, Maximum MP Percent: +20, Last Available: "2013-02"
 5994	small bland whole roasted chicken	2	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	bad shining goblet	3	decent	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	ghostly friendly ruddy crown of chilblains	0		Maximum HP Percent: +40, Familiar Weight: +3, Cold Damage: +25, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	ghostly friendly ruddy crown of chilblains	0		Maximum HP Percent: +40, Familiar Weight: +3, Cold Damage: +25, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	tumbling pulsating resourceful Fonzie's weightlifter's sword	0		Muscle: +15, Experience (Moxie): +1, Maximum MP: +50, Last Available: "2013-02"
-6002	experienced Helm of the Scream Emperor of dire peril of the sewer	0		Experience: +2, Weapon Damage: +20, Stench Damage: +25, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	experienced Helm of the Scream Emperor of dire peril of the sewer	0		Experience: +2, Weapon Damage: +20, Stench Damage: +25, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	wobbly dog trainer's Oprah's strapping Cloak of Dire Shadows	0		Muscle: +5, Maximum MP Percent: +50, Experience (familiar): +1, Last Available: "2013-02"
 6004	censurious friendly deadly Sword of Dark Omens	0		Weapon Damage: +5, Familiar Weight: +3, Sleaze Resistance: +3, Last Available: "2013-02"
 6005	razor-sharp Shield of Icy Fate of the empath of the blizzard	0		Weapon Damage Percent: +25, Familiar Weight: +5, Cold Spell Damage: +25, Damage Reduction: 7, Last Available: "2013-02"
-6006	maroon curative sinister Greaves of the Murk Lord of courage	0		Spell Damage: +10, Spooky Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	maroon curative sinister Greaves of the Murk Lord of courage	0		Spell Damage: +10, Spooky Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	blurry Usain Bolt's beefcake's Gauntlets of the Blood Moon of James Dean	0		Muscle: +25, Experience (Moxie): +3, Initiative: +80, Single Equip, Last Available: "2013-02"
 6008	inspector's Temple Grandin's hardened Boots of Twilight Whispers	0		Damage Reduction: 3, Familiar Weight: +7, Item Drop: +15, Single Equip, Last Available: "2013-02"
 6009	mansplainer's crafty Samson's Belt of Howling Anger	0		Experience (Muscle): +5, Maximum MP: +10, Monster Level: +15, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	anodized orcish hand lotion	0		Effect: "Icy Demeanor", Effect Duration: 18
 6016	anodized orcish rubber	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 11
 6017	warmed aerosolized orcish nailing lube	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 16
-6018	watered-down mediocre gray backwoods screwdriver	2	decent	
+6018	mediocre watered-down gray backwoods screwdriver	2	decent	
 6019	fuchsia loadstone of the pedagogue	0		Experience: +3
 6020	spinning hardy Claybender glasses of the early riser	0		Maximum HP: +50, Adventures: +7, Single Equip
 6021	mansplainer's cool Duskwalker fangs	0		Moxie: +5, Monster Level: +15
@@ -5931,7 +5931,7 @@
 6033	foul-smelling rosy-cheeked stolen necklace	0		Maximum HP Percent: +30, Stench Damage: +10
 6034	ghostly twirling rosy-cheeked stylish troll britches	0		Moxie: +25, Maximum HP Percent: +30, Familiar Effect: "1.5xPotato, cap 28"
 6035	adjusted chilled denatured vial of The Glistening	0		Effect: "Puzzle Fury", Effect Duration: 21
-6036	practically non-alcoholic hand-crafted spinning artisanal limoncello	1	EPIC	
+6036	hand-crafted practically non-alcoholic spinning artisanal limoncello	1	EPIC	
 6037	ginger ale	0		
 6038	decent incredible pizza	3	good	
 6039	avaricious oil cap of the sewer	0		Stench Damage: +25, Meat Drop: +30, Familiar Effect: "cap 28"
@@ -5948,10 +5948,10 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	stale Taco Dan's Taco Stand Taco	4	decent	Last Available: "2012-12"
-6053	spirit-forward acceptable olive wobbly Taco Dan's Taco Stand Chimichangarita	5	good	Last Available: "2012-12"
+6053	acceptable spirit-forward wobbly olive Taco Dan's Taco Stand Chimichangarita	5	good	Last Available: "2012-12"
 6054	aerosolized tarnished bouncing Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Stickler for Promptness", Effect Duration: 23, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	hale Meatcleaver of Gandalf	0		Maximum HP: +20, Spell Critical Percent: +20, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of the pedagogue	0		Experience: +3, Last Available: "2012-12"
 6059	narrow squat therapeutic Crimbo stogie-scented room odorizer	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-12"
@@ -6001,7 +6001,7 @@
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	mirror Artist's Spatula of Despair	0		Last Available: "2013-12"
-6106	narrow skewed Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
+6106	skewed narrow Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	avaricious careful Ginsu&trade;	0		Monster Level: -10, Meat Drop: +30, Last Available: "2013-12"
 6109	huge bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
@@ -6036,11 +6036,11 @@
 6138	blue great capacitor	0		Last Available: "2013-12"
 6139	rubber gloves of the businessman	0		Meat Drop: +50, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
-6141	olive squat triad summoning scroll	0		Last Available: "2013-12"
+6141	squat olive triad summoning scroll	0		Last Available: "2013-12"
 6142	miniature yummy roasted duck	2	awesome	Last Available: "2013-12"
 6143	tasty dead meat bun	3	awesome	Last Available: "2013-12"
 6144	sharpshooter's cat collar	0		Critical Hit Percent: +10, Single Equip, Last Available: "2013-12"
-6145	baleful strapping suspicious-looking fedora	0		Muscle: +5, Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	baleful strapping suspicious-looking fedora	0		Muscle: +5, Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	upside-down Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	jittery MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,18 +6058,18 @@
 6161	pulsating fuchsia therapeutic regret hose	0		HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	skewed tumbling Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	green Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	blue perfumed smooth commodore's hat	0		Moxie: +15, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	huge sharpshooter's naval trousers	0		Critical Hit Percent: +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	blue perfumed smooth commodore's hat	0		Moxie: +15, Stench Resistance: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	huge sharpshooter's naval trousers	0		Critical Hit Percent: +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	resourceful deck cannon of the sweet-tooth	0		Maximum MP: +50, Candy Drop: +100, Last Available: "2013-12"
 6167	shellacked ornamental sextant	0		Damage Reduction: 7, Last Available: "2013-12"
 6168	yellow wicked boxer's Bloodbath	0		Muscle Percent: +10, Spell Damage: +5, Last Available: "2013-12"
-6169	fancy aged practically non-alcoholic squat fuchsia Hundred Headed IPA	1	awesome	Effect: "Strange Mental Acuity", Effect Duration: 35, Last Available: "2013-12"
+6169	fancy practically non-alcoholic aged fuchsia squat Hundred Headed IPA	1	awesome	Effect: "Strange Mental Acuity", Effect Duration: 35, Last Available: "2013-12"
 6170	yummy squat chum	3	awesome	Last Available: "2013-12"
 6171	deionized crude crudit&eacute;s	0		Effect: "Concentration", Effect Duration: 59
 6172	ionized skewed candy crayons	0		Effect: "Yet tea", Effect Duration: 44, Last Available: "2020-09"
 6173	lion tamer's Rosewater's pixel grappling hook	0		Mysticality Percent: +30, Experience (familiar): +2
 6174	blurry GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
-6175	wobbly skewed gray GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
+6175	skewed gray wobbly GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	green tumbling cosmic dough	0		
 6178	purple cosmic vegetable	0		
@@ -6079,58 +6079,58 @@
 6182	cyan cosmic cream	0		
 6183	cosmic fruit	0		
 6184	wool lion tamer's resourceful Jarlsberg's hat	0		Maximum MP: +50, Experience (familiar): +2, Cold Resistance: +1
-6185	half-sized enchanted bland yellow consummate hard-boiled egg	2	decent	Effect: "Prideful Strut", Effect Duration: 35
+6185	enchanted bland half-sized yellow consummate hard-boiled egg	2	decent	Effect: "Prideful Strut", Effect Duration: 35
 6186	stale consummate fried egg	3	decent	
 6187	rotten blinking consummate egg salad	4	crappy	
 6188	moldy twirling consummate bagel	3	crappy	
 6189	rotten diet jittery consummate sliced bread	1	crappy	
-6190	adequate gigantic squat consummate hot dog bun	7	good	
-6191	flavorless diet tumbling consummate brownie	1	decent	
-6192	flavorless immense twirling consummate toast	10	decent	
-6193	distilled acceptable passable stout	5	good	
+6190	gigantic adequate squat consummate hot dog bun	7	good	
+6191	diet flavorless tumbling consummate brownie	1	decent	
+6192	immense flavorless twirling consummate toast	10	decent	
+6193	acceptable distilled passable stout	5	good	
 6194	normal huge consummate soup	10	good	
-6195	delicious immense fancy consummate corn chips	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35
+6195	delicious fancy immense consummate corn chips	10	awesome	Effect: "Al Dente Inferno", Effect Duration: 35
 6196	flavorless consummate salad	3	decent	
-6197	miniature yummy squat consummate salsa	2	awesome	
+6197	yummy miniature squat consummate salsa	2	awesome	
 6198	huge decent consummate sauerkraut	7	good	
-6199	flavorless fancy consummate cheese slice	4	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 30
+6199	fancy flavorless consummate cheese slice	4	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 30
 6200	stale huge consummate melted cheese	3	decent	
 6201	spoiled small fuchsia consummate bacon	2	crappy	
 6202	adequate consummate meatloaf	3	good	
-6203	decent immense yellow consummate steak	9	good	
+6203	immense decent yellow consummate steak	9	good	
 6204	adequate snack-sized consummate cuts	2	good	
 6205	bite-sized bland consummate frankfurter	1	decent	
 6206	decent immense enchanted squat consummate french fries	9	good	Effect: "Frost Tea", Effect Duration: 5
-6207	moldy super-sized consummate baked potato	5	crappy	
-6208	tolerable boozy special blurry acceptable vodka	5	good	Effect: "Gonna Get You, Sucker", Effect Duration: 50
+6207	super-sized moldy consummate baked potato	5	crappy	
+6208	special boozy tolerable blurry acceptable vodka	5	good	Effect: "Gonna Get You, Sucker", Effect Duration: 50
 6209	rotten ghostly consummate ice cream	3	crappy	
 6210	decent consummate whipped cream	4	good	
-6211	bland diet consummate cream	1	decent	
-6212	half-sized spoiled cyan blinking consummate strawberries	2	crappy	
-6213	flavorless snack-sized huge consummate sorbet	2	decent	
-6214	practically non-alcoholic acceptable adequate rum	1	good	
+6211	diet bland consummate cream	1	decent	
+6212	spoiled half-sized cyan blinking consummate strawberries	2	crappy	
+6213	snack-sized flavorless huge consummate sorbet	2	decent	
+6214	acceptable practically non-alcoholic adequate rum	1	good	
 6215	lousy mediocre lager	4	decent	
-6216	rotten snack-sized immaculate grilled cheese	2	crappy	
+6216	snack-sized rotten immaculate grilled cheese	2	crappy	
 6217	diet bland immaculate ice cream sandwich	1	decent	
-6218	yummy immense immaculate hot dog	6	awesome	
+6218	immense yummy immaculate hot dog	6	awesome	
 6219	flavorless cyan immaculate egg salad sandwich	4	decent	
 6220	stale perfect sandwich	3	decent	
-6221	bland miniature twirling perfect chef salad	2	decent	
-6222	delicious diet tumbling perfect breakfast	1	awesome	
-6223	stale super-sized special sublime deluxe hot dog	5	decent	Effect: "Rain Dancin'", Effect Duration: 10
+6221	miniature bland twirling perfect chef salad	2	decent	
+6222	diet delicious tumbling perfect breakfast	1	awesome	
+6223	stale special super-sized sublime deluxe hot dog	5	decent	Effect: "Rain Dancin'", Effect Duration: 10
 6224	bland sublime stew	3	decent	
 6225	gigantic stale twirling sublime nachos	8	decent	
 6226	tasty Ultimate Breakfast Sandwich	4	awesome	
 6227	bland bite-sized tumbling Loaded Baked Potato	1	decent	
-6228	small flavorless Omega Sundae	2	decent	
+6228	flavorless small Omega Sundae	2	decent	
 6229	hand-crafted Das Sauerlager	4	EPIC	
 6230	mediocre Bologna Lambic	3	decent	
-6231	artisanal special triple-distilled Vodka Dog	7	EPIC	Effect: "Concentrated Concentration", Effect Duration: 45
+6231	special triple-distilled artisanal Vodka Dog	7	EPIC	Effect: "Concentrated Concentration", Effect Duration: 45
 6232	aged blinking Disappointed Russian	4	awesome	
 6233	hand-crafted Chunky Mary	3	EPIC	
-6234	bad watered-down Nachojito	2	decent	
+6234	watered-down bad Nachojito	2	decent	
 6235	hand-crafted ghostly Le Roi	3	EPIC	
-6236	special lousy Over Easy Rider	3	decent	Effect: "Witch Breaded", Effect Duration: 35
+6236	lousy special Over Easy Rider	3	decent	Effect: "Witch Breaded", Effect Duration: 35
 6237	cosmic six-pack	0		
 6239	enhanced wobbly cube of ectoplasm	0		Effect: "Ripping, Dripping", Effect Duration: 47
 6240	flattened extra-Vulcanized alkaline Illuminati earpiece	0		Effect: "Vented Spleen", Effect Duration: 14
@@ -6144,7 +6144,7 @@
 6248	cold-filtered gamer slurry	0		Effect: "Spirit Bubble", Effect Duration: 15
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	greedy ribald grievous sage stylish numberwang of the overflowing toilet	0		Moxie: +25, Mysticality Percent: +10, Weapon Damage Percent: +50, Stench Spell Damage: +50, Sleaze Damage: +10, Meat Drop: +20, Single Equip
-6251	super-oxidized tumbling narrow scroll of Protection from Bad Stuff	0		Effect: "Wreathed in Merriment", Effect Duration: 56, Last Available: "2013-02"
+6251	super-oxidized narrow tumbling scroll of Protection from Bad Stuff	0		Effect: "Wreathed in Merriment", Effect Duration: 56, Last Available: "2013-02"
 6252	quantum flattened scroll of Puddingskin	0		Effect: "Grrrrrrreat!", Effect Duration: 54, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	fuchsia Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
@@ -6166,15 +6166,15 @@
 6270	deionized vacuum-sealed blurry Squat-Thrust Magazine	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
 6271	skewed massive dumbbell	0		
 6272	dog trainer's Fonzie's penguin keychain	0		Experience (Moxie): +1, Experience (familiar): +1, Damage Reduction: 10
-6273	ionized super-corrupted wobbly huge O'RLY manual	0		Effect: "Stogied", Effect Duration: 28
+6273	ionized super-corrupted huge wobbly O'RLY manual	0		Effect: "Stogied", Effect Duration: 28
 6274	fancy tolerable open sauce	3	good	Effect: "Badger Underfoot", Effect Duration: 30
 6275	blinking family-friendly turkey leg of the detective	0		Sleaze Resistance: +1, Item Drop: +20
-6276	tolerable high-proof Ye Olde Meade	7	good	
+6276	high-proof tolerable Ye Olde Meade	7	good	
 6277	vacuum-sealed pulsating Ye Olde Bawdy Limerick	0		Effect: "Partially Ghosted", Effect Duration: 42
 6278	Ye Olde Medieval Insult	0		
 6279	skewed occult pewter claymore	0		Spell Damage Percent: +25
 6280	bouncing Lo Pan's artisanal rice peeler	0		Spell Critical Percent: +30
-6281	snack-sized moldy heirloom grape tomato	2	crappy	
+6281	moldy snack-sized heirloom grape tomato	2	crappy	
 6282	chipotle wasabi cilantro aioli	0		
 6283	frightening brown felt tophat	0		Spooky Damage: +5, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6275,7 +6275,7 @@
 6380	polymerized irradiated pulsating ph balancer	0		Effect: "Go-Gone", Effect Duration: 30
 6381	polarized modified double-polarized mysterious chemical residue	0		Effect: "Your Eyes are Peeled!", Effect Duration: 30
 6382	fuchsia nugget of sodium	0		
-6383	cyan tumbling root beer	1	EPIC	
+6383	tumbling cyan root beer	1	EPIC	
 6384	jigsaw blade	0		
 6385	spinning wood screw	0		
 6386	balsa plank	0		
@@ -6290,12 +6290,12 @@
 6395	inky squid sauce	0		
 6396	Mer-kin weaksauce	0		
 6397	wobbly peanut sauce	0		
-6398	blurry fuchsia glass	0		
+6398	fuchsia blurry glass	0		
 6399	warmed corrupted irradiated green squat Boss Drops	0		Effect: "Empty Inside", Effect Duration: 62
 6400	olive Mer-kin lunchbox	0		
 6401	diffused aerosolized tear	0		Effect: "Hippy Flavor", Effect Duration: 14
 6402	cold-filtered non-boiled ionized skewed jagged tooth	0		Effect: "Human-Machine Hybrid", Effect Duration: 11
-6403	liquefied upside-down green grisly shell fragment	0		Effect: "Squatting and Thrusting", Effect Duration: 35
+6403	liquefied green upside-down grisly shell fragment	0		Effect: "Squatting and Thrusting", Effect Duration: 35
 6404	adjusted mirror violent pastilles	0		Effect: "Demonic Taint", Effect Duration: 35
 6405	aerosolized wobbly worst candy	0		Effect: "Good Karma", Effect Duration: 47
 6406	concentrated dry fudge-shaped hole in space-time	0		Effect: "Chalky Hand", Effect Duration: 62
@@ -6306,20 +6306,20 @@
 6411	blinking KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
-6414	pulsating skewed clutch of dodecapede eggs	0		
-6415	decent miniature flavorless gruel	2	good	
-6416	bland tiny jittery mana curds	1	decent	
+6414	skewed pulsating clutch of dodecapede eggs	0		
+6415	miniature decent flavorless gruel	2	good	
+6416	tiny bland jittery mana curds	1	decent	
 6417	twist of lime	0		
-6418	blurry yellow pencil stub	0		
+6418	yellow blurry pencil stub	0		
 6419	oxidized flattened moth dust	0		Effect: "Ack!  Barred!", Effect Duration: 41
 6420	irradiated quadruple-alkaline unsweetened upside-down glob of spoiled mayo	0		Effect: "Ooh, Salty!", Effect Duration: 35
 6421	tonic djinn	0		
-6422	small decent vampire chowder	2	good	
+6422	decent small vampire chowder	2	good	
 6423	narrow Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	narrow Official Seal of Dreadsylvania	0		
 6426	adequate Dreadsylvanian stew	3	good	
-6427	strong mediocre Dreadsylvanian	5	decent	
+6427	mediocre strong Dreadsylvanian	5	decent	
 6428	boiled irradiated narrow Dreadsylvanian flask	0		Effect: "Larger", Effect Duration: 48
 6429	pressed Dreadsylvanian flask	0		Effect: "Frozen Shoulders", Effect Duration: 29
 6430	dreadful fedora of temperance of the detective	0		Sleaze Resistance: +5, Item Drop: +20, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6338,13 +6338,13 @@
 6443	lime green up-at-dawn smelly Helps-You-Sleep	0		Stench Spell Damage: +10, Adventures: +5, Single Equip
 6444	gray narrow hardy fortified Sinatra's Quiets-Your-Steps	0		Experience (Moxie): +5, Damage Absorption: +60, Maximum HP: +50, Single Equip
 6445	squat manspreader's Tesla Protects-Your-Junk	0		Monster Level: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-6446	practically non-alcoholic lousy Gets-You-Drunk	1	decent	
+6446	lousy practically non-alcoholic Gets-You-Drunk	1	decent	
 6447	lard-coated Great Wolf's headband of the cougar of Tarzan	0		Moxie: +20, Experience (Muscle): +3, Sleaze Spell Damage: +25, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	executive Great Wolf's left paw of the dark arts of the blizzard	0		Spell Damage Percent: +100, Cold Spell Damage: +25, Meat Drop: +40, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	prompt miser's Great Wolf's right paw of the empath	0		Familiar Weight: +5, Meat Drop: +10, Adventures: +3, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	ghostly lightning-fast Great Wolf's rocket launcher of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	baleful dangerous groovy Great Wolf's beastly trousers	0		Moxie Percent: +10, Weapon Damage: +10, Spell Damage: +25, Familiar Effect: "1xPotato, 1.5xWhelp"
-6452	spinning pulsating Great Wolf's lice	0		
+6452	pulsating spinning Great Wolf's lice	0		
 6453	liquefied Hunger&trade; Sauce	0		Effect: "Hyperoffended", Effect Duration: 35
 6454	lion tamer's hale sage zombie mariachi hat	0		Mysticality Percent: +10, Maximum HP: +20, Experience (familiar): +2, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	blurry steel-toed cool zombie accordion of the blizzard	0		Moxie: +5, Damage Reduction: 9, Cold Spell Damage: +25, Class: "Accordion Thief", Single Equip, Song Duration: 20
@@ -6360,7 +6360,7 @@
 6465	Temple Grandin's Lo Pan's Mayor Ghost's gavel of horror	0		Spell Critical Percent: +30, Familiar Weight: +7, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Hammer Ghost"
 6466	twirling fireproof flame-wreathed educational Mayor Ghost's sash	0		Experience: +1, Hot Spell Damage: +10, Hot Resistance: +3, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	normal big ghost pepper	5	good	
+6468	big normal ghost pepper	5	good	
 6469	shaking perfumed wool Thunkula's drinking cap of the businessman	0		Cold Resistance: +1, Stench Resistance: +5, Meat Drop: +50, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	reassuring ribald experienced Drunkula's cape	0		Experience: +2, Sleaze Damage: +10, Spooky Resistance: +1, Class: "Sauceror"
 6471	up-at-dawn baleful savvy Drunkula's silky pants	0		Mysticality Percent: +20, Spell Damage: +25, Adventures: +5, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6379,10 +6379,10 @@
 6484	dread tarragon	0		
 6485	skewed bone flour	0		
 6486	dreadful roast	0		
-6487	mirror tumbling stinking agaricus	0		
+6487	tumbling mirror stinking agaricus	0		
 6488	decent thick mirror Dreadsylvanian shepherd's pie	5	good	
 6489	jittery music box parts	0		
-6490	twirling skewed unwound mechanical songbird	0		
+6490	skewed twirling unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
 6492	wobbly wax banana	0		
 6493	complicated lock impression	0		
@@ -6445,9 +6445,9 @@
 6551	upside-down hot cluster	0		
 6552	cluster	0		
 6553	cluster	0		
-6554	maroon shaking stench cluster	0		
+6554	shaking maroon stench cluster	0		
 6555	narrow sleaze cluster	0		
-6556	quadruple-galvanized improved skewed fuchsia phial of hotness	0		Effect: "Favored by Lyle", Effect Duration: 51
+6556	quadruple-galvanized improved fuchsia skewed phial of hotness	0		Effect: "Favored by Lyle", Effect Duration: 51
 6557	tarnished phial of coldness	0		Effect: "Devil Inside", Effect Duration: 45
 6558	liquefied phial of spookiness	0		Effect: "Human-Hobo Hybrid", Effect Duration: 69
 6559	pressed galvanized non-diffused phial of stench	0		Effect: "Motion", Effect Duration: 35
@@ -6456,14 +6456,14 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	stiffened hand of Mr. Cards	0		Damage Reduction: 1, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	special spoiled Dreadsylvanian hot pocket	4	crappy	Effect: "Bread-Lined", Effect Duration: 25
-6565	enchanted stale Dreadsylvanian pocket	4	decent	Effect: "Ooh, Sour!", Effect Duration: 10
+6565	stale enchanted Dreadsylvanian pocket	4	decent	Effect: "Ooh, Sour!", Effect Duration: 10
 6566	spoiled Dreadsylvanian pocket	3	crappy	
 6567	low-calorie stale special Dreadsylvanian stink pocket	1	decent	Effect: "Starry-Eyed", Effect Duration: 35
 6568	tasty gigantic Dreadsylvanian sleaze pocket	6	awesome	
 6569	mediocre blinking Dreadsylvanian hot toddy	4	decent	
 6570	drinkable ghostly Dreadsylvanian cold-fashioned	3	good	
 6571	hand-crafted spinning Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	
-6572	enchanted aged watered-down Dreadsylvanian dank and stormy	2	awesome	Effect: "Dance of the Sugar Fairy", Effect Duration: 45
+6572	enchanted watered-down aged Dreadsylvanian dank and stormy	2	awesome	Effect: "Dance of the Sugar Fairy", Effect Duration: 45
 6573	bad Dreadsylvanian slithery nipple	4	decent	
 6574	bouncing hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6506,7 +6506,7 @@
 6612	squat clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	weak hand-crafted special Cold One	2	???	Effect: "Oriental Mysticism", Effect Duration: 25
+6615	hand-crafted special weak Cold One	2	???	Effect: "Oriental Mysticism", Effect Duration: 25
 6616	half-sized stale spinning spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	fuchsia folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6516,7 +6516,7 @@
 6622	spinning folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	jittery folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	maroon upside-down folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
-6625	yellow narrow squat jittery folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
+6625	yellow squat jittery narrow folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	mirror folder (D-Team)	0		Last Available: "2013-08"
 6628	narrow folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
@@ -6571,7 +6571,7 @@
 6679	flame-retardant machete	0		Hot Resistance: +1
 6680	smooth Cursed Punch	4	awesome	
 6681	acceptable Bowl of Scorpions	3	good	
-6682	weak acceptable lime green Fog Murderer	2	good	
+6682	acceptable weak lime green Fog Murderer	2	good	
 6683	book of matches	0		
 6684	skewed boxer's surgical mask	0		Muscle Percent: +10, Surgeonosity: +1
 6685	head mirror of the boozehound	0		Booze Drop: +100, Surgeonosity: +1
@@ -6601,7 +6601,7 @@
 6709	shaking attorney's badge	0		Single Equip
 6710	skewed smelly dangerous pygmy briefs	0		Weapon Damage: +10, Stench Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	huge short writ of habeas corpus	0		
-6712	squat upside-down bone abacus	0		
+6712	upside-down squat bone abacus	0		
 6713	adder	0		
 6714	short calculator	0		
 6715	Temple Grandin's sphygmomanometer of Tarzan	0		Experience (Muscle): +3, Familiar Weight: +7
@@ -6634,7 +6634,7 @@
 6742	wicked junk band	0		Spell Damage: +5
 6743	junk trunks of Leguizamo	0		Monster Level: +20, Familiar Effect: "cap 15"
 6744	spinning teal toasty junk-mail shirt	0		Hot Damage: +5
-6745	decent miniature junk food	2	good	
+6745	miniature decent junk food	2	good	
 6746	delicious junk yard	3	awesome	
 6747	wobbly greasy Jack Frost's swordzall	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10
 6748	ruddy arm buzzer	0		Maximum HP Percent: +40, Damage Reduction: 6
@@ -6646,19 +6646,19 @@
 6754	beer bottle	0		
 6755	beer label	0		
 6756	blurry artisanal homebrew sampler	0		
-6757	perfectly mixed special can of Br&uuml;talbr&auml;u	4	EPIC	Effect: "Angry like the Wolf", Effect Duration: 40, Last Available: "2013-09"
-6758	aged enchanted ghostly squat can of Drooling Monk	3	awesome	Effect: "Standard Cheer", Effect Duration: 15, Last Available: "2013-09"
-6759	bad practically non-alcoholic fuchsia can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
+6757	special perfectly mixed can of Br&uuml;talbr&auml;u	4	EPIC	Effect: "Angry like the Wolf", Effect Duration: 40, Last Available: "2013-09"
+6758	aged enchanted squat ghostly can of Drooling Monk	3	awesome	Effect: "Standard Cheer", Effect Duration: 15, Last Available: "2013-09"
+6759	practically non-alcoholic bad fuchsia can of Impetuous Scofflaw	1	decent	Last Available: "2013-09"
 6760	acceptable bottle of Old Pugilist	3	good	Last Available: "2013-09"
 6761	drinkable bottle of Professor Beer	3	good	Last Available: "2013-09"
-6762	hand-crafted practically non-alcoholic jittery bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
-6763	tolerable triple-distilled bottle of Race Car Red	6	good	Last Available: "2013-09"
+6762	practically non-alcoholic hand-crafted jittery bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6763	triple-distilled tolerable bottle of Race Car Red	6	good	Last Available: "2013-09"
 6764	boozy drinkable ghostly huge bottle of Greedy Dog	5	good	Last Available: "2013-09"
-6765	boozy mediocre special bottle of Lambada Lambic	5	decent	Effect: "Gobliny Flavor", Effect Duration: 30, Last Available: "2013-09"
+6765	special mediocre boozy bottle of Lambada Lambic	5	decent	Effect: "Gobliny Flavor", Effect Duration: 30, Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	fancy liquid bread	1	decent	Effect: "It Didn't Kill You", Effect Duration: 10, Last Available: "2013-09"
-6769	chaotic Oprah's boxer's tin tam	0		Muscle Percent: +10, Maximum MP Percent: +50, Spell Critical Percent: +10, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	chaotic Oprah's boxer's tin tam	0		Muscle Percent: +10, Maximum MP Percent: +50, Spell Critical Percent: +10, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	polymerized tumbling tin cup	0		Effect: "Barbecue Saucy", Effect Duration: 41, Last Available: "2013-09"
 6771	teal wobbly zippy hardy rosy-cheeked tin foil	0		Maximum HP Percent: +30, Maximum HP: +50, Initiative: +20, Last Available: "2013-09"
 6772	lard-coated scandalous careful tin drum	0		Monster Level: -10, Sleaze Damage: +5, Sleaze Spell Damage: +25, Last Available: "2013-09"
@@ -6676,25 +6676,25 @@
 6784	bouncing deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
 6788	blank diary	0		
-6789	bouncing pulsating boot knife	0		
+6789	pulsating bouncing boot knife	0		
 6790	mirror broken beer bottle	0		
 6791	sharpened spoon	0		
 6792	candy knife	0		
 6793	soap knife	0		
 6795	quantum dry disco horoscope (Aquarius)	0		Effect: "Toast Tea", Effect Duration: 66
 6796	vacuum-sealed irradiated blinking disco horoscope (Pisces)	0		Effect: "Comprehensively Nourished", Effect Duration: 59
-6797	adjusted tarnished spinning yellow disco horoscope (Aries)	0		Effect: "Booooooze", Effect Duration: 56
-6798	moist spinning purple disco horoscope (Taurus)	0		Effect: "Barking Mad", Effect Duration: 62
+6797	adjusted tarnished yellow spinning disco horoscope (Aries)	0		Effect: "Booooooze", Effect Duration: 56
+6798	moist purple spinning disco horoscope (Taurus)	0		Effect: "Barking Mad", Effect Duration: 62
 6799	ionized disco horoscope (Gemini)	0		Effect: "Strong Grip", Effect Duration: 17
 6800	double-vacuum-sealed altered disco horoscope (Cancer)	0		Effect: "Mer-kinny Flavor", Effect Duration: 28
 6801	triple-denatured twirling disco horoscope (Leo)	0		Effect: "Innately Strong", Effect Duration: 21
 6802	colloidal deionized disco horoscope (Virgo)	0		Effect: "Bloody-minded", Effect Duration: 28
 6803	nitrogenated tumbling disco horoscope (Libra)	0		Effect: "Smokin'", Effect Duration: 33
 6804	wet disco horoscope (Scorpio)	0		Effect: "Feeling No Pain", Effect Duration: 15
-6805	adjusted diffused twirling yellow disco horoscope (Sagittarius)	0		Effect: "Well-preserved", Effect Duration: 66
+6805	adjusted diffused yellow twirling disco horoscope (Sagittarius)	0		Effect: "Well-preserved", Effect Duration: 66
 6806	pressed frozen disco horoscope (Capricorn)	0		Effect: "Tremella Tremens", Effect Duration: 54
 6807	MacGyver's The Sagittarian's leisure pants of dire peril	0		Weapon Damage: +20, Maximum MP: +100, Familiar Effect: "atk, cap 18"
-6808	lime green narrow toy accordion	0		Song Duration: 5
+6808	narrow lime green toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
 6810	upside-down beer-battered accordion of wisdom	0		Mysticality: +15, Class: "Accordion Thief", Song Duration: 6
 6811	slick baritone accordion	0		Moxie: +10, Class: "Accordion Thief", Song Duration: 7
@@ -6718,13 +6718,13 @@
 6829	spinning KoL Con X Bingo Card of the blizzard	0		Cold Spell Damage: +25
 6830	dance instructor's Temporal Tempera Tube	0		Experience Percent (Moxie): +10
 6831	triple-ionized dry Tallowcreme Halloween Pumpkin	0		Effect: "Fiery Spirit", Effect Duration: 43
-6832	bouncing tumbling Way More Tears&trade; pepper spray	0		
+6832	tumbling bouncing Way More Tears&trade; pepper spray	0		
 6833	polarized Milk Studs	0		Effect: "Big Flaming Whip", Effect Duration: 20
 6834	dry shaking box of Dweebs	0		Effect: "Inner Dog", Effect Duration: 32
 6835	enhanced anodized bag of W&Ws	0		Effect: "Turkey-Friendly", Effect Duration: 36
 6836	enhanced super-warmed Vulcanized mirror upside-down PEEZ dispenser	0		Effect: "Mortarfied", Effect Duration: 14
 6837	colloidal quadruple-wet Swizzler	0		Effect: "Yes, Can Haz", Effect Duration: 49
-6838	triple-galvanized wobbly ghostly Bugbearclaw Donut	0		Effect: "Hot Hands", Effect Duration: 15
+6838	triple-galvanized ghostly wobbly Bugbearclaw Donut	0		Effect: "Hot Hands", Effect Duration: 15
 6839	deionized pulsating jam	0		Effect: "Red-Shirted Escort", Effect Duration: 57
 6840	enhanced Whenchamacallit bar	0		Effect: "Flagrantly Fragrant", Effect Duration: 15
 6841	irradiated cyan 8-bit banana	0		Effect: "Less Pervious", Effect Duration: 68
@@ -6746,12 +6746,12 @@
 6857	wobbly skewed Rosewater's Cajun accordion	0		Mysticality Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	bouncing smartaleck's quirky accordion	0		Moxie Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery supercharged sage Skipper's accordion	0		Mysticality Percent: +10, Maximum MP Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	Jeselnik's ruddy grievous Pantsgiving of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +50, Maximum HP Percent: +40, Sleaze Damage: +25, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
-6861	moldy snack-sized can of sardines	2	crappy	Last Available: "2013-11"
+6860	Jeselnik's ruddy grievous Pantsgiving of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +50, Maximum HP Percent: +40, Sleaze Damage: +25, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6861	snack-sized moldy can of sardines	2	crappy	Last Available: "2013-11"
 6862	normal high-calorie sugar substitute	4	good	Last Available: "2013-11"
 6863	normal huge pat of butter	6	good	Last Available: "2013-11"
-6864	miniature delicious dinner roll	2	awesome	Last Available: "2013-11"
-6865	small spoiled mashed potatoes	2	crappy	Last Available: "2013-11"
+6864	delicious miniature dinner roll	2	awesome	Last Available: "2013-11"
+6865	spoiled small mashed potatoes	2	crappy	Last Available: "2013-11"
 6866	normal half-sized whole turkey leg	2	good	Last Available: "2013-11"
 6867	flavorless squat deviled egg	3	decent	Last Available: "2013-11"
 6868	alkaline finger exerciser	0		Effect: "Standard Issue Bravery", Effect Duration: 43, Last Available: "2013-11"
@@ -6760,13 +6760,13 @@
 6871	upside-down school beer pull tab	0		Last Available: "2013-11"
 6872	moist pressed skewed nail file	0		Effect: "Gummi Badass", Effect Duration: 53, Last Available: "2013-11"
 6873	non-unsweetened quadruple-dry corrupted candy wrapper	0		Effect: "Flaming Weapon", Effect Duration: 40, Last Available: "2013-11"
-6874	maroon bouncing squat gym membership card	0		Last Available: "2013-11"
+6874	squat bouncing maroon gym membership card	0		Last Available: "2013-11"
 6875	activated wet post-holiday sale coupon	0		Effect: "Haunted Stomach", Effect Duration: 16, Last Available: "2013-11"
-6876	spinning twirling dry cleaning receipt	0		Last Available: "2013-11"
+6876	twirling spinning dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	upside-down pocket lint (green)	0		Last Available: "2013-11"
 6879	pocket lint (white)	0		Last Available: "2013-11"
-6880	wobbly squat pocket lint (orange)	0		Last Available: "2013-11"
+6880	squat wobbly pocket lint (orange)	0		Last Available: "2013-11"
 6881	Oprah's rosy-cheeked banded bowl of petunias of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Maximum HP Percent: +30, Maximum MP Percent: +50, Last Available: "2013-11"
 6882	medical-grade hale stiffened power sock of the empath	0		Damage Reduction: 1, Maximum HP: +20, Familiar Weight: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2013-11"
 6883	family-friendly clever brawny boxer's wool sock	0		Muscle Percent: 30, Maximum MP: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2013-11"
@@ -6776,7 +6776,7 @@
 6887	olive spinning spirit sheet	0		
 6888	spirit mattress	0		
 6889	spirit blanket	0		
-6890	fuchsia ghostly spirit bed	0		
+6890	ghostly fuchsia spirit bed	0		
 6891	jittery nasty Van der Graaf spirit bell of terror	0		Stench Damage: +5, Spooky Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Class: "Turtle Tamer"
 6892	quantum anodized spoonful of Linguine-Os	0		Effect: "Chlorophyll Flavor", Effect Duration: 65, Last Available: "2013-11"
 6893	alkaline upside-down freezer-burned frost-bitten tortellini	0		Effect: "Steroid Boost", Effect Duration: 48, Last Available: "2013-11"
@@ -6807,32 +6807,32 @@
 6918	activated warbear wardance potion	0		Effect: "Dirty Pear", Effect Duration: 65, Last Available: "2013-12"
 6919	altered irradiated warbear bearserker potion	0		Effect: "Patent Alacrity", Effect Duration: 39, Last Available: "2013-12"
 6920	alkaline flattened warbear liquid overcoat	0		Effect: "The Best a Pirate Can Get", Effect Duration: 21, Last Available: "2013-12"
-6921	bite-sized moldy warbear feasting bread	1	crappy	Last Available: "2013-12"
-6922	stale thick warbear warrior bread	5	decent	Last Available: "2013-12"
-6923	bland bite-sized warbear thermoregulator bread	1	decent	Last Available: "2013-12"
-6924	spirit-forward lousy warbear feasting mead	5	decent	Last Available: "2013-12"
+6921	moldy bite-sized warbear feasting bread	1	crappy	Last Available: "2013-12"
+6922	thick stale warbear warrior bread	5	decent	Last Available: "2013-12"
+6923	bite-sized bland warbear thermoregulator bread	1	decent	Last Available: "2013-12"
+6924	lousy spirit-forward warbear feasting mead	5	decent	Last Available: "2013-12"
 6925	extra-dry tolerable upside-down warbear bearserker mead	5	good	Last Available: "2013-12"
-6926	acceptable spirit-forward red warbear blizzard mead	5	good	Last Available: "2013-12"
+6926	spirit-forward acceptable red warbear blizzard mead	5	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	narrow ruddy arcane researcher's warbear plain fedora of Flo-Jo	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	wobbly upside-down extremely unsafe warbear feathered fedora	0		Weapon Damage Percent: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	lion tamer's Fonzie's warbear fedora of Calamity Jane	0		Experience (Moxie): +1, Critical Hit Percent: +15, Experience (familiar): +2, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	lard-coated medical-grade smooth warbear plain helm	0		Moxie: +15, Sleaze Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	experienced warbear spiked helm	0		Experience: +2, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	spinning frightening Newton's warbear electro-spiked helm of the overflowing toilet	0		Experience (Mysticality): +3, Stench Spell Damage: +50, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	bouncing sharpshooter's Oprah's warbear plain ushanka of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, Critical Hit Percent: +10, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	Usain Bolt's warbear lined ushanka	0		Initiative: +80, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	zippy executive energetic warbear heated ushanka	0		Maximum MP Percent: +20, Meat Drop: +40, Initiative: +20, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	narrow ruddy arcane researcher's warbear plain fedora of Flo-Jo	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, Initiative: +100, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	wobbly upside-down extremely unsafe warbear feathered fedora	0		Weapon Damage Percent: +100, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	lion tamer's Fonzie's warbear fedora of Calamity Jane	0		Experience (Moxie): +1, Critical Hit Percent: +15, Experience (familiar): +2, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	lard-coated medical-grade smooth warbear plain helm	0		Moxie: +15, Sleaze Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	experienced warbear spiked helm	0		Experience: +2, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	spinning frightening Newton's warbear electro-spiked helm of the overflowing toilet	0		Experience (Mysticality): +3, Stench Spell Damage: +50, Spooky Damage: +5, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	bouncing sharpshooter's Oprah's warbear plain ushanka of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, Critical Hit Percent: +10, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	Usain Bolt's warbear lined ushanka	0		Initiative: +80, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	zippy executive energetic warbear heated ushanka	0		Maximum MP Percent: +20, Meat Drop: +40, Initiative: +20, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	wool greasy quilted warbear party pants	0		Damage Absorption: +40, Sleaze Spell Damage: +10, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	Rosewater's warbear ceremonial party pants	0		Mysticality Percent: +30, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	lightning-fast clever warbear high festival pants of the glutton	0		Maximum MP: +20, Food Drop: +100, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	strapping warbear battle greaves of Calamity Jane of the overflowing toilet	0		Muscle: +5, Critical Hit Percent: +15, Stench Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	purple blurry strapping warbear officer greaves	0		Muscle: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	wobbly inspector's aromatic resourceful warbear bearserker greaves	0		Maximum MP: +50, Stench Resistance: +1, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	pulsating clever deadly warbear johns	0		Weapon Damage: +5, Maximum MP: +20, Item Drop: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	shaking stanky warbear fleece-lined johns	0		Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	blue arcane researcher's supercool smooth warbear johns	0		Moxie: +15, Moxie Percent: +20, Experience Percent (Mysticality): +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	wool greasy quilted warbear party pants	0		Damage Absorption: +40, Sleaze Spell Damage: +10, Cold Resistance: +1, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	Rosewater's warbear ceremonial party pants	0		Mysticality Percent: +30, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	lightning-fast clever warbear high festival pants of the glutton	0		Maximum MP: +20, Food Drop: +100, Initiative: +40, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	strapping warbear battle greaves of Calamity Jane of the overflowing toilet	0		Muscle: +5, Critical Hit Percent: +15, Stench Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	purple blurry strapping warbear officer greaves	0		Muscle: +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	wobbly inspector's aromatic resourceful warbear bearserker greaves	0		Maximum MP: +50, Stench Resistance: +1, Item Drop: +15, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	pulsating clever deadly warbear johns	0		Weapon Damage: +5, Maximum MP: +20, Item Drop: +5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	shaking stanky warbear fleece-lined johns	0		Stench Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	blue arcane researcher's supercool smooth warbear johns	0		Moxie: +15, Moxie Percent: +20, Experience Percent (Mysticality): +10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	ghostly warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	perfumed stanky wholesome warbear goggles	0		Maximum HP Percent: +10, Stench Spell Damage: +25, Stench Resistance: +5, Single Equip, Last Available: "2013-12"
 6949	miser's warbear snowblindness goggles	0		Meat Drop: +10, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	red vibrating healthy personal trainer's warbear warscarf	0		Experience Percent (Muscle): +10, Maximum HP Percent: +20, Maximum MP Percent: +10, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	Lo Pan's warbear foil hat	0		Spell Critical Percent: +30, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	Lo Pan's warbear foil hat	0		Spell Critical Percent: +30, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	bouncing forbidden smartaleck's warbear oil pan	0		Moxie Percent: +30, Spell Damage Percent: +50, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	shaking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6893,13 +6893,13 @@
 7004	moist Flaskfull of Hollow	0		Effect: "Fit To Be Tide", Effect Duration: 52, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered squat handful of Smithereens	1	crappy	Effect: "You Know Who to Call", Effect Duration: 25, Last Available: "2013-12"
-7007	huge flavorless Every Day is Like This Sundae	6	decent	Last Available: "2013-12"
+7007	flavorless huge Every Day is Like This Sundae	6	decent	Last Available: "2013-12"
 7008	half-sized adequate mirror Miserable Pie	2	good	Last Available: "2013-12"
 7009	flavorless tumbling This Charming Flan	3	decent	Last Available: "2013-12"
 7010	high-proof hand-crafted bouncing Irish Coffee, English Heart	9	EPIC	Last Available: "2013-12"
 7011	artisanal Strikes Again Bigmouth	4	EPIC	Last Available: "2013-12"
-7012	drinkable triple-distilled Paint A Vulgar Pitcher	9	good	Last Available: "2013-12"
-7013	shaking blue Golden Light	0		Last Available: "2013-12"
+7012	triple-distilled drinkable Paint A Vulgar Pitcher	9	good	Last Available: "2013-12"
+7013	blue shaking Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
 7016	razor-sharp Work is a Four Letter Sword of incineration of temperance of the businessman	0		Weapon Damage Percent: +25, Hot Spell Damage: +50, Sleaze Resistance: +5, Meat Drop: +50, Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	avaricious Annie Oakley's occult brawny Sheila Take a Crossbow	0		Muscle Percent: +20, Spell Damage Percent: +25, Critical Hit Percent: +20, Meat Drop: +30, Last Available: "2013-12"
 7019	greedy Jim Carey's curative supercool A Light that Never Goes Out	0		Moxie Percent: +20, Monster Level: +25, Meat Drop: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12"
 7020	pulsating wicked dance instructor's stylish Half a Purse of the sewer	0		Moxie: +25, Experience Percent (Moxie): +10, Spell Damage: +5, Stench Damage: +25, Last Available: "2013-12"
-7021	frosty dog trainer's Oprah's Hairpiece On Fire of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, Experience (familiar): +1, Cold Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	smooth thinker's Vicar's Tutu of the scaredy-cat of mayonnaise	0		Mysticality: +10, Moxie: +15, Monster Level: -15, Sleaze Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	frosty dog trainer's Oprah's Hairpiece On Fire of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, Experience (familiar): +1, Cold Spell Damage: +10, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	smooth thinker's Vicar's Tutu of the scaredy-cat of mayonnaise	0		Mysticality: +10, Moxie: +15, Monster Level: -15, Sleaze Spell Damage: +50, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	gravedigger's foul-smelling Temple Grandin's Hand in Glove	0		Familiar Weight: +7, Stench Damage: +10, Spooky Damage: +10, Single Equip, Last Available: "2013-12"
 7024	wholesome personal trainer's slick Meat Tenderizer is Murder	0		Moxie: +10, Experience Percent (Muscle): +10, Maximum HP Percent: +10, Class: "Seal Clubber", Last Available: "2013-12"
 7025	ribald chilly Ouija Board, Ouija Board of courage	0		Cold Damage: +5, Sleaze Damage: +10, Spooky Resistance: +3, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6921,7 +6921,7 @@
 7032	normal pickled egg	4	good	
 7033	mirror cup of lukewarm tea	1	good	
 7034	shaking warbear soda machine assembler	0		Last Available: "2013-12"
-7035	tumbling blurry warbear box	0		Last Available: "2013-12"
+7035	blurry tumbling warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	warbear gyrocopter	0		Last Available: "2013-12"
@@ -6936,7 +6936,7 @@
 7047	electrified warbear liquid lasers	0		Effect: "Weird Flavor", Effect Duration: 22, Last Available: "2013-12"
 7048	ionized dry huge warbear rejuvenation potion	0		Effect: "Comprehensively Nourished", Effect Duration: 36, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	rotten snack-sized pulsating warbear gyro	2	crappy	Last Available: "2013-12"
+7050	snack-sized rotten pulsating warbear gyro	2	crappy	Last Available: "2013-12"
 7051	polymerized blinking recording of Rolando's Rondo of Resisto	0		Effect: "White-boy Angst", Effect Duration: 64, Last Available: "2013-12"
 7052	ghostly warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	narrow warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6944,7 +6944,7 @@
 7055	rotten breakfast mess	3	crappy	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	bland breakfast miracle	4	decent	Last Available: "2013-12"
-7058	irradiated ghostly skewed olive Cloaca Cola Polar	0		Effect: "Angry like the Wolf", Effect Duration: 21, Last Available: "2013-12"
+7058	irradiated ghostly olive skewed Cloaca Cola Polar	0		Effect: "Angry like the Wolf", Effect Duration: 21, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	fuchsia grimstone mask	0		Last Available: "2014-12"
@@ -6964,12 +6964,12 @@
 7075	magnetized unsweetened blue liquid ice pack	0		Effect: "Demonic Flavor", Effect Duration: 62, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	rotten ghostly snow crab	4	crappy	Last Available: "2014-01"
-7078	watered-down perfectly mixed blurry Ice Island Long Tea	2	super ultra mega EPIC	Last Available: "2014-01"
+7078	perfectly mixed watered-down blurry Ice Island Long Tea	2	super ultra mega EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	bouncing snow machine	0		Last Available: "2014-01"
-7083	bouncing careful snow mobile	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	bouncing careful snow mobile	0		Monster Level: -10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	rosewater-soaked ice bucket	0		Stench Resistance: +3, Lasts Until Rollover, Last Available: "2014-01"
 7085	miser's nippy snow shovel	0		Cold Damage: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2014-01"
 7086	ghostly teal bod-ice of Gandalf of the brazier of the glutton	0		Spell Critical Percent: +20, Hot Spell Damage: +25, Food Drop: +100, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	smooth tumbling En Una Fila Tequila	4	awesome	
 7091	Skully's hot chocolate	1	crappy	
-7092	maroon Van der Graaf slick warbear dress helmet	0		Moxie: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	maroon Van der Graaf slick warbear dress helmet	0		Moxie: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	miser's warbear dress bracers of temperance	0		Sleaze Resistance: +5, Meat Drop: +10, Single Equip, Last Available: "2013-12"
-7094	pulsating dog trainer's steel-toed warbear dress greaves	0		Damage Reduction: 9, Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	wool supercharged sweatband	0		Maximum MP Percent: +30, Cold Resistance: +1, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	narrow blurry resourceful gym shorts of the cheetah	0		Maximum MP: +50, Initiative: +60, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	pulsating dog trainer's steel-toed warbear dress greaves	0		Damage Reduction: 9, Experience (familiar): +1, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	wool supercharged sweatband	0		Maximum MP Percent: +30, Cold Resistance: +1, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	narrow blurry resourceful gym shorts of the cheetah	0		Maximum MP: +50, Initiative: +60, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	cyan mansplainer's Herculean ankleweights	0		Experience (Muscle): +1, Monster Level: +15, Single Equip, Last Available: "2014-12"
 7098	purple grievous brawny smooth sweat socks of the cougar	0		Moxie: 35, Muscle Percent: +20, Weapon Damage Percent: +50, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6995,33 +6995,33 @@
 7106	drinkable blinking snakebite	4	good	Last Available: "2014-12"
 7107	blurry Temple Grandin's smartaleck's candy stick	0		Moxie Percent: +30, Familiar Weight: +7, Last Available: "2014-12"
 7108	rotten mirror blurry pecan	3	crappy	Last Available: "2014-12"
-7109	rotten jumbo pecan pie	5	crappy	Last Available: "2014-12"
+7109	jumbo rotten pecan pie	5	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	toothsome fuchsia candy mountain oyster	4	awesome	Last Available: "2014-12"
-7112	lousy enchanted huge chocotini	3	decent	Effect: "Chilblains of the Corn", Effect Duration: 15, Last Available: "2014-12"
+7112	enchanted lousy huge chocotini	3	decent	Effect: "Chilblains of the Corn", Effect Duration: 15, Last Available: "2014-12"
 7113	gray upside-down greasy slick chocolate rabbit's foot of chilblains	0		Moxie: +10, Cold Damage: +25, Sleaze Spell Damage: +10, Last Available: "2014-12"
 7114	flavorless candy carrot	3	decent	Last Available: "2014-12"
 7115	stale red candy carrot cake	3	decent	Last Available: "2014-12"
 7116	lightning-fast electrified carrot-on-a-stick	0		Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
-7117	Sinatra's weasel stomping pants of the sweet-tooth	0		Experience (Moxie): +5, Candy Drop: +100, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	decent bite-sized jittery mulberry	1	good	Last Available: "2014-12"
-7119	bad fortified jittery mulled berry wine	5	decent	Last Available: "2014-12"
+7117	Sinatra's weasel stomping pants of the sweet-tooth	0		Experience (Moxie): +5, Candy Drop: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7118	bite-sized decent jittery mulberry	1	good	Last Available: "2014-12"
+7119	fortified bad jittery mulled berry wine	5	decent	Last Available: "2014-12"
 7120	narrow lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of Calamity Jane	0		Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	lemon party hat of Calamity Jane	0		Critical Hit Percent: +15, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	resourceful lemon shirt	0		Maximum MP: +50, Lasts Until Rollover, Last Available: "2014-12"
-7123	purple upside-down personal trainer's lemon drop trousers	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	purple upside-down personal trainer's lemon drop trousers	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	improved squat lemonhead caviar	0		Effect: "Patience of the Tortoise", Effect Duration: 69, Last Available: "2014-12"
 7125	crafty grievous gummi sword	0		Weapon Damage Percent: +50, Maximum MP: +10, Last Available: "2014-12"
 7126	pickled huge small gummi fin	0		Effect: "Rushtacean'", Effect Duration: 25, Last Available: "2014-12"
 7127	blue rock-hard chocolate cow bone	0		Damage Reduction: 5, Last Available: "2014-12"
 7128	quantum gummi fang	0		Effect: "Pharmaceutically Cool", Effect Duration: 49, Last Available: "2014-12"
-7129	flavorless super-sized enchanted leftover canap&eacute;s	5	decent	Effect: "You Know What's Up", Effect Duration: 35, Last Available: "2014-12"
+7129	enchanted super-sized flavorless leftover canap&eacute;s	5	decent	Effect: "You Know What's Up", Effect Duration: 35, Last Available: "2014-12"
 7130	acceptable blinking magnum of champagne	3	good	Last Available: "2014-12"
 7131	Temple Grandin's sharpshooter's razor-sharp cow creamer	0		Weapon Damage Percent: +25, Critical Hit Percent: +10, Familiar Weight: +7, Last Available: "2014-12"
 7132	tarnished Outer Wolf&trade; cologne	0		Effect: "Loco Motives", Effect Duration: 16, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
 7134	Lo Pan's veiny wolf whistle	0		Maximum HP: +10, Spell Critical Percent: +30, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	jumbo rotten jittery witch's bread	5	crappy	Last Available: "2014-12"
+7135	rotten jumbo jittery witch's bread	5	crappy	Last Available: "2014-12"
 7136	Vulcanized diffused ghostly witch's brew	0		Effect: "Coming Up Roses", Effect Duration: 62, Last Available: "2014-12"
 7137	Jack Frost's Fonzie's supercool witch's bra	0		Moxie Percent: +20, Experience (Moxie): +1, Cold Spell Damage: +50, Last Available: "2014-12"
 7138	perfectly mixed mid-level medieval mead	3	EPIC	Last Available: "2014-12"
@@ -7043,9 +7043,9 @@
 7154	narrow filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	twirling glass	0		Last Available: "2014-12"
-7157	spinning ribald nasty dog trainer's fire hose	0		Experience (familiar): +1, Stench Damage: +5, Sleaze Damage: +10, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	spinning ribald nasty dog trainer's fire hose	0		Experience (familiar): +1, Stench Damage: +5, Sleaze Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	bland fireman's lunch	3	decent	Last Available: "2014-12"
-7159	tumbling frightening flame-wreathed plain paper hat of Flo-Jo	0		Hot Spell Damage: +10, Spooky Damage: +5, Initiative: +100, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7159	tumbling frightening flame-wreathed plain paper hat of Flo-Jo	0		Hot Spell Damage: +10, Spooky Damage: +5, Initiative: +100, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	small decent maroon ice cream sandwich	2	good	Last Available: "2014-12"
 7161	mirror narrow medical-grade dangerous &quot;honey&quot; dipper of bravery	0		Weapon Damage: +10, Spooky Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12"
 7162	rotten pulsating plumber's lunch	3	crappy	Last Available: "2014-12"
@@ -7073,14 +7073,14 @@
 7184	The Shield of Brook	0		
 7185	wobbly Red Zeppelin ticket	0		
 7186	tumbling Copperhead Charm (rampant)	0		
-7187	weak artisanal unnamed cocktail	2	EPIC	
+7187	artisanal weak unnamed cocktail	2	EPIC	
 7188	handful of tips	0		
 7189	thinker's unrequired jacket	0		Mysticality: +10
 7190	tommy gun of bravery	0		Spooky Resistance: +5, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	shaking drum of tommy ammo	0		
 7192	throwing knife	0		
-7193	skewed blue throwing spoon	0		
-7194	yellow tumbling throwing fork	0		
+7193	blue skewed throwing spoon	0		
+7194	tumbling yellow throwing fork	0		
 7195	groovy breadchucks of dire peril	0		Moxie Percent: +10, Weapon Damage: +20
 7196	wobbly shuriken salad	0		
 7197	combat fan of Flo-Jo	0		Initiative: +100
@@ -7102,7 +7102,7 @@
 7213	fleetwood macaroni	0		
 7214	huge cheesy eagle sauce	0		
 7215	moldy fleetwood mac 'n' cheese	4	crappy	
-7216	shaking tumbling lynyrd skin	0		
+7216	tumbling shaking lynyrd skin	0		
 7217	lard-coated lynyrdskin cap	0		Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	pulsating steel-toed lynyrdskin tunic	0		Damage Reduction: 9
 7219	boxer's lynyrdskin breeches	0		Muscle Percent: +10, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
@@ -7134,14 +7134,14 @@
 7245	irradiated magnetized narrow eye	0		Effect: "Ogred and Oublietted", Effect Duration: 15
 7246	glark cable	0		
 7247	yellow sizzling extremely unsafe Red Fox glove	0		Weapon Damage Percent: +100, Hot Damage: +10, Attacks Can't Miss, Single Equip
-7248	tarnished denatured skewed yellow wobbly foxglove	0		Effect: "Berry Experiential", Effect Duration: 28
+7248	tarnished denatured yellow skewed wobbly foxglove	0		Effect: "Berry Experiential", Effect Duration: 28
 7249	Thwaitgold dragonfly statuette	0		
 7250	asbestos-lined flame-wreathed Sneaky Pete's jacket of the sewer of the glutton	0		Hot Spell Damage: +10, Stench Damage: +25, Hot Resistance: +5, Food Drop: +100, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	jug of Sneaky Pete's Mojo	0		Free Pull
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
-7253	cyan narrow Anniversary Miniature Sword & Martini Guy	0		
+7253	narrow cyan Anniversary Miniature Sword & Martini Guy	0		
 7254	jittery really cocktail shaker	0		Familiar Weight: +5
-7255	smooth triple-distilled mini-martini	8	awesome	
+7255	triple-distilled smooth mini-martini	8	awesome	
 7256	smoke grenade	0		
 7257	twisted molotov soda	1	awesome	Effect: "Glittering Eyelashes", Effect Duration: 30
 7258	extra-denatured teal squat pile of ashes	0		Effect: "Blood-Rich", Effect Duration: 21
@@ -7150,7 +7150,7 @@
 7261	twirling olive Jack Frost's chilly sage Sneaky Pete's basket	0		Mysticality Percent: +10, Cold Damage: +5, Cold Spell Damage: +50
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
-7264	yellow blinking photograph of a nugget	0		
+7264	blinking yellow photograph of a nugget	0		
 7265	fuchsia photograph of an ostrich egg	0		
 7266	wobbly disposable instant camera	0		
 7267	censurious flame-wreathed manspreader's thinker's Sneaky Pete's jacket (collar popped)	0		Mysticality: +10, Monster Level: +10, Hot Spell Damage: +10, Sleaze Resistance: +3, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7187,7 +7187,7 @@
 7298	olive heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
 7300	sewing kit	0		
-7301	red upside-down Spookyraven billiards room key	0		
+7301	upside-down red Spookyraven billiards room key	0		
 7302	skewed Spookyraven library key	0		
 7303	Lady Spookyraven's necklace	0		
 7304	squat telegram from Lady Spookyraven	0		
@@ -7201,7 +7201,7 @@
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
-7315	bouncing squat rickety rocking horse	0		
+7315	squat bouncing rickety rocking horse	0		
 7316	jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	prompt scandalous wholesome ghost of a necklace	0		Maximum HP Percent: +10, Sleaze Damage: +5, Adventures: +3
@@ -7214,13 +7214,13 @@
 7325	weak hand-crafted snakebite	2	EPIC	
 7326	mansplainer's rubber ribcage of the businessman	0		Monster Level: +15, Meat Drop: +50, Damage Reduction: 7
 7327	powdered synthetic marrow	1		
-7328	modified triple-magnetized shaking teal funny bone	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 17
+7328	modified triple-magnetized teal shaking funny bone	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 17
 7329	energetic half-melted spoon of the blizzard	0		Maximum MP Percent: +20, Cold Spell Damage: +25
 7330	diluted tumbling the funk	1		Effect: "Sugary Tongue", Effect Duration: 5
-7331	stale big gunky chicken	5	decent	
+7331	big stale gunky chicken	5	decent	
 7332	frosty doll head	0		Cold Spell Damage: +10
 7333	droopy doll eye	0		
-7334	narrow squat voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
+7334	squat narrow voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	zippy paddle-ball of horror	0		Spooky Spell Damage: +25, Initiative: +20
 7336	tarnished blurry sound effects record	0		Effect: "Hombre Muerto Caminando", Effect Duration: 60
 7337	alphabet block	0		
@@ -7228,13 +7228,13 @@
 7339	music box mechanism	0		
 7340	moose antlers of the glutton	0		Food Drop: +100, Familiar Effect: "atk, 1xLep, cap 27"
 7341	flattened wet blinking moose thought	0		Effect: "Full-Body Tan", Effect Duration: 60
-7342	spoiled small ghostly moose chocolate	2	crappy	
-7343	lousy enchanted wobbly painting of a glass of wine	4	decent	Effect: "Knightlife", Effect Duration: 15
+7342	small spoiled ghostly moose chocolate	2	crappy	
+7343	enchanted lousy wobbly painting of a glass of wine	4	decent	Effect: "Knightlife", Effect Duration: 15
 7344	oil painting of yourself	0		
 7345	upside-down ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	MacGyver's educational ghost toga	0		Experience: +1, Maximum MP: +100
-7348	miniature tasty sheet cake	2	awesome	
+7348	tasty miniature sheet cake	2	awesome	
 7349	tumbling ghost key	0		
 7350	picture of you	0		
 7351	purple banded Staff of the Electric Range of the overflowing toilet of temperance	0		Damage Absorption: +100, Stench Spell Damage: +50, Sleaze Resistance: +5
@@ -7254,11 +7254,11 @@
 7365	non-wet ionized fabric hardener	0		Effect: "Booooooze", Effect Duration: 52
 7366	bad narrow bottle of laundry sherry	4	decent	
 7367	extra-adjusted wet energized industrial strength starch	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 29, Wiki Name: "industrial strength starch"
-7368	spoiled massive extra-flat panini	7	crappy	
-7369	boiled moist narrow blinking mangled finger	0		Effect: "Perception", Effect Duration: 20
+7368	massive spoiled extra-flat panini	7	crappy	
+7369	boiled moist blinking narrow mangled finger	0		Effect: "Perception", Effect Duration: 20
 7370	watered-down drinkable Psychotic Train wine	2	good	
 7371	crazy hobo notebook	0		
-7372	yummy small pie man was not meant to eat	2	awesome	
+7372	small yummy pie man was not meant to eat	2	awesome	
 7373	groovy sommelier's towel	0		Moxie Percent: +10
 7374	teal deadly tarnished tastevin	0		Weapon Damage: +5, Single Equip
 7375	decent actual tapas	4	good	
@@ -7273,7 +7273,7 @@
 7384	triple-pressed Gene Tonic: Dude	0		Effect: "I See Everything Thrice!", Effect Duration: 46, Last Available: "2014-04"
 7385	quadruple-ionized flattened blurry maroon Gene Tonic: Beast	0		Effect: "Stinky Hands", Effect Duration: 28, Last Available: "2014-04"
 7386	moist adjusted bouncing Gene Tonic: Construct	0		Effect: "Nut-Rition", Effect Duration: 50, Last Available: "2014-04"
-7387	ionized wobbly pulsating Gene Tonic: Undead	0		Effect: "Unrunnable Face", Effect Duration: 44, Last Available: "2014-04"
+7387	ionized pulsating wobbly Gene Tonic: Undead	0		Effect: "Unrunnable Face", Effect Duration: 44, Last Available: "2014-04"
 7388	cold-filtered moist Gene Tonic: Humanoid	0		Effect: "The Spy Who Loved XP", Effect Duration: 48, Last Available: "2014-04"
 7389	altered Gene Tonic: Insect	0		Effect: "Bright!", Effect Duration: 33, Last Available: "2014-04"
 7390	quantum Gene Tonic: Hippy	0		Effect: "Chlorophyll Flavor", Effect Duration: 48, Last Available: "2014-04"
@@ -7324,37 +7324,37 @@
 7435	modified alkaline purple Stemonitis Staticus mushroom	0		Effect: "A Contender", Effect Duration: 63, Last Available: "2014-05"
 7436	vacuum-sealed dry upside-down Tremella Tarantella mushroom	0		Effect: "It's Electric!", Effect Duration: 20, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	gigantic flavorless ghostly Beefy Crunch Pastaco	6	decent	Last Available: "2014-05"
+7438	flavorless gigantic ghostly Beefy Crunch Pastaco	6	decent	Last Available: "2014-05"
 7439	bland twirling Brain Food Pastaco	4	decent	Last Available: "2014-05"
-7440	decent diet ghostly Cool Brunch Pastaco	1	good	Last Available: "2014-05"
+7440	diet decent ghostly Cool Brunch Pastaco	1	good	Last Available: "2014-05"
 7441	moldy blinking Medical Pastaco	3	crappy	Last Available: "2014-05"
-7442	spoiled huge fancy Energy Buzz Pastaco	10	crappy	Effect: "Initiative and Let Die", Effect Duration: 15, Last Available: "2014-05"
-7443	bland special pulsating Ludovico Pastaco	3	decent	Effect: "Spiky Frozen Hair", Effect Duration: 5, Last Available: "2014-05"
-7444	bad spirit-forward overpowering mushroom wine	5	decent	Last Available: "2014-05"
+7442	fancy spoiled huge Energy Buzz Pastaco	10	crappy	Effect: "Initiative and Let Die", Effect Duration: 15, Last Available: "2014-05"
+7443	special bland pulsating Ludovico Pastaco	3	decent	Effect: "Spiky Frozen Hair", Effect Duration: 5, Last Available: "2014-05"
+7444	spirit-forward bad overpowering mushroom wine	5	decent	Last Available: "2014-05"
 7445	triple-distilled bad complex mushroom wine	9	decent	Last Available: "2014-05"
-7446	mediocre distilled huge smooth mushroom wine	5	decent	Last Available: "2014-05"
+7446	distilled mediocre huge smooth mushroom wine	5	decent	Last Available: "2014-05"
 7447	delicious wobbly blood-red mushroom wine	3	awesome	Last Available: "2014-05"
 7448	weak lousy buzzing mushroom wine	2	decent	Last Available: "2014-05"
 7449	acceptable narrow swirling mushroom wine	4	good	Last Available: "2014-05"
 7450	tiny adequate Taco Dan's Basic Taco Dan Taco	1	good	Last Available: "2014-05"
-7451	bite-sized rotten Taco Dan's Taco Fish Fish Taco	1	crappy	Last Available: "2014-05"
+7451	rotten bite-sized Taco Dan's Taco Fish Fish Taco	1	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	perfectly mixed spirit-forward narrow regular-size brogurt	5	EPIC	Last Available: "2014-05"
-7454	lousy irresponsibly strong super-size brogurt	10	decent	Last Available: "2014-05"
-7455	artisanal watered-down broberry brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7456	watered-down hand-crafted fancy brocolate brogurt	2	super ultra EPIC	Effect: "Mer-kindliness", Effect Duration: 30, Last Available: "2014-05"
+7454	irresponsibly strong lousy super-size brogurt	10	decent	Last Available: "2014-05"
+7455	watered-down artisanal broberry brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7456	fancy watered-down hand-crafted brocolate brogurt	2	super ultra EPIC	Effect: "Mer-kindliness", Effect Duration: 30, Last Available: "2014-05"
 7457	strong drinkable French bronilla brogurt	5	good	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	upside-down bouncing Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	squat squat industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	ghostly boxer's Brogre brorts	0		Muscle Percent: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	ghostly boxer's Brogre brorts	0		Muscle Percent: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	upside-down blurry forbidden Brogre brolo shirt	0		Spell Damage Percent: +50, Last Available: "2014-05"
-7464	veiny Brogre bucket hat	0		Maximum HP: +10, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	veiny Brogre bucket hat	0		Maximum HP: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	mirror Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	jittery avaricious nasty educational 8-billed baseball cap	0		Experience: +1, Stench Damage: +5, Meat Drop: +30, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	jittery avaricious nasty educational 8-billed baseball cap	0		Experience: +1, Stench Damage: +5, Meat Drop: +30, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	upside-down auspicious extremely wet T-shirt of the storm of mayonnaise	0		Maximum MP Percent: +40, Sleaze Spell Damage: +50, Item Drop: +10, Last Available: "2014-05"
 7470	savvy smooth shrimp fork of the detective	0		Moxie: +15, Mysticality Percent: +20, Item Drop: +20, Last Available: "2014-05"
 7471	pickled chilled BROS Energy Drink	0		Effect: "Big Flaming Whip", Effect Duration: 65, Last Available: "2014-05"
@@ -7367,9 +7367,9 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	dry moist sugar fairy	0		Effect: "Moon-Eyed", Effect Duration: 29, Last Available: "2014-05"
 7480	super-flattened cold-filtered sugar bunny	0		Effect: "The Solution", Effect Duration: 36, Last Available: "2014-05"
-7481	mirror sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	mirror sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	bad Rompedores de Fantasmas	4	decent	
-7483	perfectly mixed fortified La Fantasma y La Oscuridad	5	EPIC	
+7483	fortified perfectly mixed La Fantasma y La Oscuridad	5	EPIC	
 7484	drinkable Fantasma en la M&aacute;quina	3	good	
 7485	skewed loosening powder	0		
 7486	castoreum	0		
@@ -7377,7 +7377,7 @@
 7488	huge skewed triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	acceptable watered-down bottle of Chateau de Vinegar	2	good	
+7491	watered-down acceptable bottle of Chateau de Vinegar	2	good	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	jittery wine bomb	0		
@@ -7415,7 +7415,7 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	shellacked brawny government-issued night-vision goggles	0		Muscle Percent: +20, Damage Reduction: 7, Single Equip, Last Available: "2014-05"
-7529	massive stale ghostly loaf of alien bread	6	decent	Last Available: "2014-05"
+7529	stale massive ghostly loaf of alien bread	6	decent	Last Available: "2014-05"
 7530	moldy grilled cheese sandwich	4	crappy	Last Available: "2014-05"
 7531	diluted olive jittery alien protein powder	1	awesome	Effect: "Quaaaaaaa", Effect Duration: 25, Last Available: "2014-05"
 7532	tolerable rocket fuel	3	good	Last Available: "2014-05"
@@ -7425,8 +7425,8 @@
 7536	shaking space beast fur	0		Last Available: "2014-05"
 7537	huge twitching space egg	0		Last Available: "2014-05"
 7538	blurry ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	spinning nippy space beast fur hat	0		Cold Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	razor-sharp space beast fur pants	0		Weapon Damage Percent: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	spinning nippy space beast fur hat	0		Cold Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	razor-sharp space beast fur pants	0		Weapon Damage Percent: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	space beast fur whip of the sweet-tooth	0		Candy Drop: +100, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	fuchsia forbidden space heater of the sewer	0		Spell Damage Percent: +50, Stench Damage: +25, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7462,7 +7462,7 @@
 7573	fuchsia Herculean kiwi beak of the dark arts	0		Experience (Muscle): +1, Spell Damage Percent: +100
 7574	mediocre lime green New Zealand iced tea	4	decent	
 7575	lightning-fast dance instructor's droll monocle	0		Experience Percent (Moxie): +10, Initiative: +40, Single Equip
-7576	vacuum-sealed electrified green narrow huge future drug: Muscularactum	0		Effect: "Hot Blooded", Effect Duration: 42
+7576	vacuum-sealed electrified narrow green huge future drug: Muscularactum	0		Effect: "Hot Blooded", Effect Duration: 42
 7577	liquefied diffused improved future drug: Smartinex	0		Effect: "Neutered Nostrils", Effect Duration: 42
 7578	warmed wet future drug: Coolscaline	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 11
 7579	blurry twitching time capsule	0		
@@ -7478,13 +7478,13 @@
 7589	tolerable glass of &quot;milk&quot;	3	good	Last Available: "2014-07"
 7590	mediocre blinking cup of &quot;tea&quot;	3	decent	Last Available: "2014-07"
 7591	lousy extra-dry thermos of &quot;whiskey&quot;	5	decent	Last Available: "2014-07"
-7592	watered-down artisanal Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
-7593	aged fancy maroon Bee's Knees	4	awesome	Effect: "Uncanny Shot", Effect Duration: 15, Last Available: "2014-07"
-7594	practically non-alcoholic mediocre Sockdollager	1	decent	Last Available: "2014-07"
-7595	practically non-alcoholic tolerable blue Ish Kabibble	1	good	Last Available: "2014-07"
+7592	artisanal watered-down Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
+7593	fancy aged maroon Bee's Knees	4	awesome	Effect: "Uncanny Shot", Effect Duration: 15, Last Available: "2014-07"
+7594	mediocre practically non-alcoholic Sockdollager	1	decent	Last Available: "2014-07"
+7595	tolerable practically non-alcoholic blue Ish Kabibble	1	good	Last Available: "2014-07"
 7596	hand-crafted high-proof Hot Socks	7	EPIC	Last Available: "2014-07"
 7597	tolerable fuchsia Phonus Balonus	4	good	Last Available: "2014-07"
-7598	special boozy drinkable Flivver	5	good	Effect: "Tingly Biceps", Effect Duration: 5, Last Available: "2014-07"
+7598	boozy special drinkable Flivver	5	good	Effect: "Tingly Biceps", Effect Duration: 5, Last Available: "2014-07"
 7599	smooth high-proof Sloppy Jalopy	10	awesome	Last Available: "2014-07"
 7600	pressed enhanced yellow squat flame	0		Effect: "Ancestral Disapproval", Effect Duration: 52
 7601	magnetized temporary yak tattoo	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 65
@@ -7519,7 +7519,7 @@
 7630	non-galvanized magic powder	0		Effect: "Elemental Saucesphere", Effect Duration: 67
 7631	quantum modified bouncing friar's tonsure	0		Effect: "Infernal Thirst", Effect Duration: 51
 7632	alkaline moist government-issue identification badge	0		Effect: "Stone-Faced", Effect Duration: 20
-7633	modified quadruple-magnetized olive mirror alien hologram projector	0		Effect: "Jungle Juiced", Effect Duration: 31
+7633	modified quadruple-magnetized mirror olive alien hologram projector	0		Effect: "Jungle Juiced", Effect Duration: 31
 7634	liquefied electrified narrow irradiated turtle	0		Effect: "Mathematically Precise", Effect Duration: 57
 7635	extra-polymerized dry wobbly cigar box turtle	0		Effect: "Cat Class, Cat Style", Effect Duration: 50
 7636	healthy shellacked shell of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +20, Class: "Turtle Tamer"
@@ -7541,17 +7541,17 @@
 7652	fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
-7655	spinning lime green fishbone fins	0		Single Equip
+7655	lime green spinning fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	neoprene skullcap of the wise owl	0		Mysticality: +20, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	magnetized goblin water	0		Effect: "Eyes of the Dragon", Effect Duration: 29
 7661	maroon dumb mud	0		
-7662	big yummy Sogg-Os	5	awesome	
+7662	yummy big Sogg-Os	5	awesome	
 7663	perfumed dance instructor's Lord Soggyraven's Slippers of the scaredy-cat	0		Experience Percent (Moxie): +10, Monster Level: -15, Stench Resistance: +5, Single Equip
 7664	quadruple-altered Ancient Protector Soda	0		Effect: "The Rich Get Richer", Effect Duration: 56
-7665	diffused energized red wobbly liquid ice	0		Effect: "Patched In", Effect Duration: 35
+7665	diffused energized wobbly red liquid ice	0		Effect: "Patched In", Effect Duration: 35
 7666	fancy artisanal lime green huge Wet Russian	4	EPIC	Effect: "Joyful Resolve", Effect Duration: 20
 7667	big decent shaking filet of The Fish	5	good	
 7668	upside-down Thwaitgold spider statuette	0		
@@ -7559,7 +7559,7 @@
 7670	jittery double-paned beefcake's famous raincoat of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Cold Resistance: +5, Lasts Until Rollover
 7671	grievous lightning rod of the empath of the cheetah	0		Weapon Damage Percent: +50, Familiar Weight: +5, Initiative: +60, Lasts Until Rollover
 7672	scandalous law-abiding citizen cane	0		Sleaze Damage: +5, Single Equip
-7673	enchanted perfectly mixed weak legitimate business on the beach	2	EPIC	Effect: "Flagrantly Fragrant", Effect Duration: 10
+7673	perfectly mixed enchanted weak legitimate business on the beach	2	EPIC	Effect: "Flagrantly Fragrant", Effect Duration: 10
 7674	jittery wicked hep waders	0		Spell Damage: +5, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	fancy bland spinning jive turkey leg	4	decent	Effect: "Pharmaceutically Cool", Effect Duration: 15
 7676	lightning-fast birdbone corset	0		Initiative: +40
@@ -7580,7 +7580,7 @@
 7691	ghostly blinking gravedigger's crafty plastic nunchaku	0		Maximum MP: +10, Spooky Damage: +10, Last Available: "2014-08"
 7692	stanky grievous hand whip of horror	0		Weapon Damage Percent: +50, Stench Spell Damage: +25, Spooky Spell Damage: +25, Last Available: "2014-08"
 7693	twirling rosewater-soaked savvy glow-in-the-dark necklace of the cougar	0		Moxie: +20, Mysticality Percent: +20, Stench Resistance: +3, Last Available: "2014-08"
-7694	bouncing tumbling Groll doll	0		Single Equip, Last Available: "2014-08"
+7694	tumbling bouncing Groll doll	0		Single Equip, Last Available: "2014-08"
 7695	steel-toed stiffened cap gun of the detective	0		Damage Reduction: 20, Item Drop: +20, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	green Herculean cassette player of chilblains	0		Experience (Muscle): +1, Cold Damage: +25, Single Equip, Last Available: "2014-08"
 7697	shaking chewable paper	0		Free Pull, Last Available: "2014-08"
@@ -7593,15 +7593,15 @@
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	spinning LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
-7707	cold-filtered blinking jittery rubber nubbin	0		Effect: "Locks Like the Raven", Effect Duration: 53, Last Available: "2014-08"
+7707	cold-filtered jittery blinking rubber nubbin	0		Effect: "Locks Like the Raven", Effect Duration: 53, Last Available: "2014-08"
 7708	spinning yellow spinning wool rubber cape of the brazier	0		Hot Spell Damage: +25, Cold Resistance: +1, Last Available: "2014-08"
 7709	Sinatra's educational savvy Thor's Pliers of the pedagogue	0		Mysticality Percent: +20, Experience: 4, Experience (Moxie): +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	wet candy UFOs	0		Effect: "Third Based", Effect Duration: 26
 7711	hardened water wings for babies of the empath	0		Damage Reduction: 3, Familiar Weight: +5
 7712	squat beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	adequate super-sized Strix stix	5	good	
+7713	super-sized adequate Strix stix	5	good	
 7714	Sherlock's mansplainer's boxer's vampire pellet	0		Muscle Percent: +10, Monster Level: +15, Item Drop: +25
-7715	artisanal irresponsibly strong non-aged vinegar	6	EPIC	
+7715	irresponsibly strong artisanal non-aged vinegar	6	EPIC	
 7716	Van der Graaf unsanitized scalpel	0		MP Regen Min: 5, MP Regen Max: 7
 7717	blurry foul-smelling gladiator tunica	0		Stench Damage: +10
 7718	MacGyver's Roman sadnals	0		Maximum MP: +100, Single Equip
@@ -7624,7 +7624,7 @@
 7735	Xiblaxian alloy	0		Last Available: "2014-09"
 7736	Xiblaxian crystal	0		Last Available: "2014-09"
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
-7738	twirling mirror Xiblaxian cache locator simcode	0		Last Available: "2014-09"
+7738	mirror twirling Xiblaxian cache locator simcode	0		Last Available: "2014-09"
 7739	Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	gray Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	ghostly thinker's Xiblaxian xeno-detection goggles	0		Mysticality: +10, Single Equip, Last Available: "2014-09"
-7753	pulsating sharpshooter's banded Xiblaxian stealth cowl	0		Damage Absorption: +100, Critical Hit Percent: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	pulsating sharpshooter's banded Xiblaxian stealth cowl	0		Damage Absorption: +100, Critical Hit Percent: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	squat flame-retardant Xiblaxian stealth trousers of the ox	0		Muscle: +20, Hot Resistance: +1, Last Available: "2014-09"
 7755	spinning fireproof experienced Xiblaxian stealth vest	0		Experience: +2, Hot Resistance: +3, Last Available: "2014-09"
 7756	flavorless narrow Xiblaxian ultraburrito	4	decent	Last Available: "2014-09"
 7757	tolerable Xiblaxian space-whiskey	4	good	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	dry enhanced diffused They liver	0		Effect: "Amorous", Effect Duration: 66, Last Available: "2014-09"
-7760	immense toothsome lime green They liver popsicle	6	awesome	Last Available: "2014-09"
+7760	toothsome immense lime green They liver popsicle	6	awesome	Last Available: "2014-09"
 7761	blinking holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	bouncing holo-platoon	0		Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	asbestos-lined friendly Sinatra's Personal Ventilation Unit	0		Experience (Moxie): +5, Familiar Weight: +3, Hot Resistance: +5, Single Equip, Last Available: "2014-10"
 7771	alkaline twirling jittery the most dangerous bait	0		Effect: "The Moxie of LOV", Effect Duration: 24, Last Available: "2014-10"
-7772	huge toothsome shaking ghostly &quot;meat&quot; stick	10	awesome	Last Available: "2014-10"
+7772	toothsome huge shaking ghostly &quot;meat&quot; stick	10	awesome	Last Available: "2014-10"
 7773	twisted transdermal smoke patch	1	good	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	lime green pulsating fireproof friendly pair of plants of the storm	0		Maximum MP Percent: +40, Familiar Weight: +3, Hot Resistance: +3, Last Available: "2014-10"
@@ -7669,7 +7669,7 @@
 7780	narrow aromatic hale heavy-duty clipboard of Tarzan	0		Experience (Muscle): +3, Maximum HP: +20, Stench Resistance: +1, Damage Reduction: 8, Last Available: "2014-10"
 7781	ghostly frightening sharpshooter's arcane researcher's battery-powered drill of Flo-Jo	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +10, Spooky Damage: +5, Initiative: +100, Last Available: "2014-10"
 7782	tiny rotten upside-down limp broccoli	1	crappy	Last Available: "2014-10"
-7783	padded hat of mayonnaise of Flo-Jo	0		Damage Absorption: +20, Sleaze Spell Damage: +50, Initiative: +100, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7783	padded hat of mayonnaise of Flo-Jo	0		Damage Absorption: +20, Sleaze Spell Damage: +50, Initiative: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	ionized improved monkey barf	0		Effect: "Thunderheart", Effect Duration: 34, Last Available: "2014-10"
 7785	warmed candy	0		Effect: "Loyal Tea", Effect Duration: 18, Last Available: "2014-10"
 7786	wobbly hardy baleful arcane researcher's jangly bracelet	0		Experience Percent (Mysticality): +10, Spell Damage: +25, Maximum HP: +50, Last Available: "2014-10"
@@ -7685,8 +7685,8 @@
 7796	tasty warm war shawarma	3	awesome	Last Available: "2014-10"
 7797	stale bite-sized karma shawarma	1	decent	Last Available: "2014-10"
 7798	smooth Jungle Juice	4	awesome	Last Available: "2014-10"
-7799	aged distilled jittery Amnesiac Ale	5	awesome	Last Available: "2014-10"
-7800	perfectly mixed high-proof Highest Bitter	10	EPIC	Last Available: "2014-10"
+7799	distilled aged jittery Amnesiac Ale	5	awesome	Last Available: "2014-10"
+7800	high-proof perfectly mixed Highest Bitter	10	EPIC	Last Available: "2014-10"
 7801	mansplainer's banded mercenary pistol	0		Damage Absorption: +100, Monster Level: +15, Last Available: "2014-10"
 7802	hardy rosy-cheeked mercenary rifle	0		Maximum HP Percent: +30, Maximum HP: +50, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7699,8 +7699,8 @@
 7810	Z-Bone steak	0		
 7811	teal viral DNA	0		
 7812	spinning tarnished bottlecap	0		
-7813	enchanted normal seared dino steak	4	good	Effect: "Swimming Head", Effect Duration: 20
-7814	perfectly mixed practically non-alcoholic bottle of drinkin' gas	1	EPIC	
+7813	normal enchanted seared dino steak	4	good	Effect: "Swimming Head", Effect Duration: 20
+7814	practically non-alcoholic perfectly mixed bottle of drinkin' gas	1	EPIC	
 7815	narrow handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7743,8 +7743,8 @@
 7854	groovy plastic Crimbot	0		Moxie Percent: +10, Last Available: "2014-12"
 7855	brawny plastic Crimbomega	0		Muscle Percent: +20, Last Available: "2014-12"
 7856	dry lime green flask of mining oil	0		Effect: "Far Out", Effect Duration: 65, Last Available: "2014-12"
-7857	sizzling radiation-resistant helmet	0		Hot Damage: +10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	rock-hard servo-assisted exo-pants	0		Damage Reduction: 5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	sizzling radiation-resistant helmet	0		Hot Damage: +10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	rock-hard servo-assisted exo-pants	0		Damage Reduction: 5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	horrifying frosty high-energy mining laser	0		Cold Spell Damage: +10, Spooky Damage: +25, Last Available: "2014-12"
 7860	maroon peppermint tailings	0		Last Available: "2014-12"
 7861	upside-down maroon pulsating nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7790,7 +7790,7 @@
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	blurry Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
-7904	bouncing mirror Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
+7904	mirror bouncing Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
 7907	recovered elf sleeping pills	0		Last Available: "2014-12"
@@ -7833,7 +7833,7 @@
 7951	up-at-dawn plaid cowboy hat of chilblains	0		Cold Damage: +25, Adventures: +5, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
 7953	ghostly spinning horrifying dangerous rusted-out shootin' iron of doom	0		Weapon Damage: +10, Spooky Damage: +25, Spooky Spell Damage: +50
-7954	shaking blue rattler rattle	0		
+7954	blue shaking rattler rattle	0		
 7955	bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	shaking even more tinsel	0		Familiar Weight: +5
@@ -7877,11 +7877,11 @@
 7995	coward's energetic pelerine	0		Maximum MP Percent: +20, Monster Level: -20, Last Available: "2015-12"
 7996	fireproof electrified phantom mask	0		Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2015-12"
 7997	dried ghostly polyesterene powder	1		Effect: "Inner Dog", Effect Duration: 5, Last Available: "2015-12"
-7998	dried blurry spinning powder	1		Effect: "Devil Inside", Effect Duration: 10, Last Available: "2015-12"
-7999	quadruple-moist blue twirling choco-Crimbot	0		Effect: "Dweeby", Effect Duration: 41, Last Available: "2014-12"
+7998	dried spinning blurry powder	1		Effect: "Devil Inside", Effect Duration: 10, Last Available: "2015-12"
+7999	quadruple-moist twirling blue choco-Crimbot	0		Effect: "Dweeby", Effect Duration: 41, Last Available: "2014-12"
 8000	pressed extra-moist cyan smart watch	0		Effect: "Jerky, Boy", Effect Duration: 61, Last Available: "2014-12"
 8001	concentrated mirror augmented-reality shades	0		Effect: "Extra-Wet", Effect Duration: 43, Last Available: "2014-12"
-8002	narrow ruddy toy Crimbot mega face	0		Maximum HP Percent: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8002	narrow ruddy toy Crimbot mega face	0		Maximum HP Percent: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
 8003	shaking supercharged toy Crimbot power glove	0		Maximum MP Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	asbestos-lined toy Crimbot super fist	0		Hot Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	flame-wreathed toy Crimbot rocket legs	0		Hot Spell Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
@@ -7902,7 +7902,7 @@
 8020	normal Choco-Mint patty	4	good	Last Available: "2015-01"
 8021	fancy bad hot mint schnocolate	3	decent	Effect: "Nano-juiced", Effect Duration: 5, Last Available: "2015-01"
 8022	dehydrated wobbly homeopathic mint tea	1	awesome	Effect: "You Know Who to Call", Effect Duration: 35, Last Available: "2015-01"
-8023	tumbling jittery muscle stimulator	0		Last Available: "2015-01"
+8023	jittery tumbling muscle stimulator	0		Last Available: "2015-01"
 8024	green foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
 8026	shaking ceiling fan	0		Last Available: "2015-01"
@@ -7932,7 +7932,7 @@
 8051	therapeutic cape	0		HP Regen Min: 5, HP Regen Max: 7
 8052	flame-wreathed jetpack	0		Hot Spell Damage: +10
 8053	spring boots	0		
-8054	tumbling jittery spiked boots	0		
+8054	jittery tumbling spiked boots	0		
 8055	jittery fortified pickaxe	0		Damage Absorption: +60
 8056	skewed twirling torch	0		
 8057	greedy veiny [spelunking test kit]	0		Maximum HP: +10, Meat Drop: +20
@@ -7944,7 +7944,7 @@
 8063	squat Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	spinning banana	0		Familiar Weight: +5
-8066	mixed twirling shaking	1	awesome	Effect: "Big Punkin'", Effect Duration: 35, Last Available: "2015-12"
+8066	mixed shaking twirling	1	awesome	Effect: "Big Punkin'", Effect Duration: 35, Last Available: "2015-12"
 8067	wobbly twirling mirror nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	jittery Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	red ghostly supercool beefy Spelunker's fedora of courage	0		Muscle: +10, Moxie Percent: +20, Spooky Resistance: +3, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	red ghostly supercool beefy Spelunker's fedora of courage	0		Muscle: +10, Moxie Percent: +20, Spooky Resistance: +3, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	mansplainer's Fonzie's groovy Spelunker's whip	0		Moxie Percent: +10, Experience (Moxie): +1, Monster Level: +15, Last Available: "2015-12"
-8076	Annie Oakley's Spelunker's khakis of Calamity Jane of chilblains	0		Critical Hit Percent: 35, Cold Damage: +25, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	Annie Oakley's Spelunker's khakis of Calamity Jane of chilblains	0		Critical Hit Percent: 35, Cold Damage: +25, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	teal LOLmec statuette	0		Last Available: "2015-12"
 8085	squat Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8007,7 +8007,7 @@
 8132	upside-down Van der Graaf sage fiberglass fedora	0		Mysticality Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
 8133	vaporized fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
-8135	narrow skewed winged yeti fur	0		
+8135	skewed narrow winged yeti fur	0		
 8136	gray talisman of Renenutet	0		
 8138	blue fortified rubber spatula	0		Damage Absorption: +60
 8139	narrow sage spoon	0		Mysticality Percent: +10
@@ -8038,11 +8038,11 @@
 8164	sinister remaindered axe of dire peril	0		Weapon Damage: +20, Spell Damage: +10
 8165	narrow low-budget shield	0		Damage Reduction: 3
 8166	chaotic Oprah's cr&ecirc;epy mask	0		Maximum MP Percent: +50, Spell Critical Percent: +10, Familiar Effect: "spooky atk, cap 5"
-8167	enchanted adequate teal bouncing baguette	4	good	Effect: "Pasty", Effect Duration: 45
+8167	enchanted adequate bouncing teal baguette	4	good	Effect: "Pasty", Effect Duration: 45
 8168	glob of icing	0		
 8169	moist cold-filtered ginger snaps	0		Effect: "Macho Profundo", Effect Duration: 20
 8170	chilled mostly-broken sunglasses	0		Effect: "Thick-Skinned", Effect Duration: 42
-8171	drinkable high-proof special unflavored wine cooler	9	good	Effect: "Faboooo", Effect Duration: 25
+8171	special high-proof drinkable unflavored wine cooler	9	good	Effect: "Faboooo", Effect Duration: 25
 8172	fancy teal carton of snake milk	1	EPIC	Effect: "Drunk With Power", Effect Duration: 10
 8173	flame-wreathed sewer snake	0		Hot Spell Damage: +10
 8174	stale twirling pigeon egg	3	decent	
@@ -8053,18 +8053,18 @@
 8179	educational ring of telling skeletons what to do	0		Experience: +1, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
 8180	Sinatra's breadwand	0		Experience (Moxie): +5
 8181	cyan skewed chaotic loafers	0		Spell Critical Percent: +10, Single Equip
-8182	twirling pulsating Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
+8182	pulsating twirling Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	Jack Frost's bread basket	0		Cold Spell Damage: +50
 8184	fuchsia Ed the Undying exhibit crate	0		
-8185	skewed censurious hardened The Crown of Ed the Undying	0		Damage Reduction: 3, Sleaze Resistance: +3, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	skewed censurious hardened The Crown of Ed the Undying	0		Damage Reduction: 3, Sleaze Resistance: +3, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	tolerable fortified mirror Cherrytastrophe wine cooler	5	good	
-8189	perfectly mixed practically non-alcoholic Radberry Rip wine cooler	1	EPIC	
+8189	practically non-alcoholic perfectly mixed Radberry Rip wine cooler	1	EPIC	
 8190	artisanal pulsating Orangemageddon wine cooler	3	EPIC	
-8191	weak lousy spinning blurry Breakfast Blast wine cooler	2	decent	
-8192	perfectly mixed triple-distilled Citrus Crush wine cooler	8	EPIC	
-8193	spoiled small plain bagel	2	crappy	
+8191	weak lousy blurry spinning Breakfast Blast wine cooler	2	decent	
+8192	triple-distilled perfectly mixed Citrus Crush wine cooler	8	EPIC	
+8193	small spoiled plain bagel	2	crappy	
 8194	tiny toothsome glob of cream cheese	1	awesome	
 8195	decent purple loaf of soda bread	3	good	
 8196	normal wobbly acceptable bagel	3	good	
@@ -8082,7 +8082,7 @@
 8208	dry jittery How to Avoid Scams	0		Effect: "Capricorn Rising", Effect Duration: 13, Last Available: "2015-04"
 8209	filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	huge bag of gross foreign snacks	0		Last Available: "2015-04"
-8211	twirling ghostly bag of park garbage	0		Last Available: "2015-04"
+8211	ghostly twirling bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	bouncing reassuring rigging rope of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Resistance: +1, Last Available: "2015-04"
 8214	vaporized nasty snuff	1	awesome	Effect: "Seeing Colors", Effect Duration: 35, Last Available: "2015-04"
@@ -8090,9 +8090,9 @@
 8216	liquefied beard incense	0		Effect: "Gummibrain", Effect Duration: 60, Last Available: "2015-04"
 8217	blurry purple twirling perfume-soaked bandana of the ox of the glutton	0		Muscle: +20, Food Drop: +100, Single Equip, Last Available: "2015-04"
 8218	mirror toxic globule	0		Last Available: "2015-04"
-8219	normal thick toxo	5	good	Last Available: "2015-04"
+8219	thick normal toxo	5	good	Last Available: "2015-04"
 8220	watered-down hand-crafted twirling Lemonade-235	2	EPIC	Last Available: "2015-04"
-8221	lime green Sinatra's Da Vinci's isotophat	0		Experience (Mysticality): +5, Experience (Moxie): +5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8221	lime green Sinatra's Da Vinci's isotophat	0		Experience (Mysticality): +5, Experience (Moxie): +5, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	zippy frightening Three Mile Island shorts	0		Spooky Damage: +5, Initiative: +20, Last Available: "2015-04"
 8223	cyan tumbling wobbly horrifying shellacked toxic mop	0		Damage Reduction: 7, Spooky Damage: +25, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	narrow trash net	0		Last Available: "2015-04"
 8246	blurry sinister cool Dinsey mascot mask of the pedagogue	0		Moxie: +5, Experience: +3, Spell Damage: +10, Last Available: "2015-04"
 8247	toothsome purple Dinsey food-cone	3	awesome	Last Available: "2015-04"
-8248	mediocre watered-down Dinsey Whinskey	2	decent	Last Available: "2015-04"
+8248	watered-down mediocre Dinsey Whinskey	2	decent	Last Available: "2015-04"
 8249	aerosolized twirling Dinsey face paint	0		Effect: "Tiki Thoughtfulness", Effect Duration: 36, Last Available: "2015-04"
 8250	manspreader's sinister fannypack	0		Spell Damage: +10, Monster Level: +10, Last Available: "2015-04"
 8251	greedy auspicious scandalous electrified savvy garbage sticker of courage	0		Mysticality Percent: +20, Sleaze Damage: +5, Spooky Resistance: +3, Item Drop: +10, Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-04"
@@ -8142,8 +8142,8 @@
 8268	shaking tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	spoiled unappetizing mayolus	3	crappy	Last Available: "2015-05"
-8271	bland small uninteresting mayolus	2	decent	Last Available: "2015-05"
-8272	rotten miniature teal acceptable mayolus	2	crappy	Last Available: "2015-05"
+8271	small bland uninteresting mayolus	2	decent	Last Available: "2015-05"
+8272	miniature rotten teal acceptable mayolus	2	crappy	Last Available: "2015-05"
 8273	adequate enticing mayolus	4	good	Last Available: "2015-05"
 8274	rotten skewed mouth-watering mayolus	3	crappy	Last Available: "2015-05"
 8275	jittery newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8173,7 +8173,7 @@
 8299	blinking pixel coin	0		Last Available: "2015-06"
 8300	altered power pill	0		Effect: "Patent Prevention", Effect Duration: 49, Last Available: "2015-06"
 8301	deionized vacuum-sealed teal blinking pixel star	0		Effect: "Bats in the Belfry", Effect Duration: 46, Last Available: "2015-06"
-8302	spoiled wobbly spinning pixel banana	3	crappy	Last Available: "2015-06"
+8302	spoiled spinning wobbly pixel banana	3	crappy	Last Available: "2015-06"
 8303	hand-crafted pixel beer	3	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	bouncing pumps	0		Last Available: "2015-06"
@@ -8183,7 +8183,7 @@
 8309	dry baggie of regular-sized tardigrades	0		Effect: "Fan-Cooled", Effect Duration: 34
 8310	diffused .epub file	0		Effect: "In Vino Vires", Effect Duration: 56
 8311	aerosolized BUBBLE GUM	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
-8312	dry super-aerosolized ghostly blurry blue hustler shades	0		Effect: "Coy to the Hurled", Effect Duration: 29
+8312	dry super-aerosolized ghostly blue blurry hustler shades	0		Effect: "Coy to the Hurled", Effect Duration: 29
 8313	magnetized activated electrified jerky stick	0		Effect: "Walberg's Dim Bulb", Effect Duration: 29
 8314	galvanized nitrogenated costume rental shop	0		Effect: "Pasty", Effect Duration: 65
 8315	unsweetened dry teal muscle oil	0		Effect: "Twinklebritches", Effect Duration: 32
@@ -8248,9 +8248,9 @@
 8374	modified altered mirror drinks tray	0		Effect: "Cravin' for a Ravin'", Effect Duration: 69
 8375	moist eyebrow lifter	0		Effect: "Weasels Underfoot", Effect Duration: 67
 8376	blurry submarine	0		Last Available: "2015-06"
-8377	thick delicious pixel lemon	5	awesome	Last Available: "2015-06"
+8377	delicious thick pixel lemon	5	awesome	Last Available: "2015-06"
 8378	acceptable bouncing pixel daiquiri	4	good	Last Available: "2015-06"
-8379	denatured liquefied upside-down yellow power pill	0		Effect: "Human-Machine Hybrid", Effect Duration: 48, Last Available: "2015-06"
+8379	denatured liquefied yellow upside-down power pill	0		Effect: "Human-Machine Hybrid", Effect Duration: 48, Last Available: "2015-06"
 8380	colloidal pixel potion	0		Effect: "Artificially Sweet", Effect Duration: 48, Last Available: "2015-06"
 8381	purple twirling Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
@@ -8277,21 +8277,21 @@
 8403	blinking tumbling chaotic revolver of the ox	0		Muscle: +20, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2015-07"
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
-8406	huge narrow savory dry noodles	0		
+8406	narrow huge savory dry noodles	0		
 8407	normal pestopiary	3	good	
 8408	double-pressed enhanced ectoplasmic orbs	0		Effect: "Shawarma Warm War", Effect Duration: 53
 8409	stale green crudles	3	decent	
 8410	bland half-sized agnolotti arboli	2	decent	
 8411	rotten spaghetti with ghost balls	3	crappy	
-8412	massive tasty succulent marrow	9	awesome	
+8412	tasty massive succulent marrow	9	awesome	
 8413	big stale salacious crumbs	5	decent	
-8414	enchanted bite-sized normal fusilli marrownarrow	1	good	Effect: "Twen Tea", Effect Duration: 40
+8414	normal bite-sized enchanted fusilli marrownarrow	1	good	Effect: "Twen Tea", Effect Duration: 40
 8415	stale suggestive strozzapreti	3	decent	
 8416	Mountain Stream gastrique	0		
-8417	toothsome miniature Mt. McLargeHuge oyster	2	awesome	
+8417	miniature toothsome Mt. McLargeHuge oyster	2	awesome	
 8418	oyster sauce	0		
-8419	huge decent linguini immondizia bianco	8	good	
-8420	bland bite-sized shells a la shellfish	1	decent	
+8419	decent huge linguini immondizia bianco	8	good	
+8420	bite-sized bland shells a la shellfish	1	decent	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	skewed unsmoothed velvet	0		Last Available: "2015-08"
@@ -8329,10 +8329,10 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	reassuring Samson's high-temperature mining mask	0		Experience (Muscle): +5, Spooky Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	reassuring Samson's high-temperature mining mask	0		Experience (Muscle): +5, Spooky Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	nippy rock-hard fireproof megaphone	0		Damage Reduction: 5, Cold Damage: +10, Last Available: "2015-08"
-8460	miniature spoiled spinning mineapple	2	crappy	Last Available: "2015-08"
-8461	boozy artisanal Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
+8460	spoiled miniature spinning mineapple	2	crappy	Last Available: "2015-08"
+8461	artisanal boozy Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
 8462	lime green SMOOCH soda	1	good	Last Available: "2015-08"
 8463	delicious smelted roe	4	awesome	Last Available: "2015-08"
 8464	lousy lavawater	3	decent	Last Available: "2015-08"
@@ -8350,9 +8350,9 @@
 8476	polymerized ionized liquid rhinestones	0		Effect: "Mortarfied", Effect Duration: 33, Last Available: "2015-08"
 8477	spoiled disco biscuit	4	crappy	Last Available: "2015-08"
 8478	lousy Quaatorade&trade;	4	decent	Last Available: "2015-08"
-8479	Jack Frost's biker's hat of the bloodbag of terror	0		Maximum HP: +100, Cold Spell Damage: +50, Spooky Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
-8480	smelly brawny stylish feathered headdress	0		Moxie: +25, Muscle Percent: +20, Stench Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	executive friendly electrician's hardhat of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Meat Drop: +40, Last Available: "2015-08", Familiar Effect: "atk"
+8479	Jack Frost's biker's hat of the bloodbag of terror	0		Maximum HP: +100, Cold Spell Damage: +50, Spooky Spell Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
+8480	smelly brawny stylish feathered headdress	0		Moxie: +25, Muscle Percent: +20, Stench Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	executive friendly electrician's hardhat of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Meat Drop: +40, Familiar Effect: "atk", Last Available: "2015-08"
 8482	blurry Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	squat Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	pulsating New Age hurting crystal	0		Last Available: "2015-08"
-8490	fuchsia wicked smooth velvet pants	0		Spell Damage: +5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	fuchsia wicked smooth velvet pants	0		Spell Damage: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	smooth velvet shirt of Gandalf	0		Spell Critical Percent: +20, Last Available: "2015-08"
 8492	savvy smooth velvet hat	0		Mysticality Percent: +20, Last Available: "2015-08"
 8493	perfumed smooth velvet pocket square	0		Stench Resistance: +5, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	blue brawny SMOOCH bracers of doom	0		Muscle Percent: +20, Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8518	huge squat mansplainer's SMOOCH kneepads	0		Monster Level: +15, Single Equip, Last Available: "2015-08"
 8519	fireproof SMOOCH spaulders	0		Hot Resistance: +3, Single Equip, Last Available: "2015-08"
-8520	Lo Pan's vibrating SMOOCH codpiece	0		Maximum MP Percent: +10, Spell Critical Percent: +30, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	Lo Pan's vibrating SMOOCH codpiece	0		Maximum MP Percent: +10, Spell Critical Percent: +30, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	pulsating studded SMOOCH breastplate	0		Damage Absorption: +80, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8413,45 +8413,45 @@
 8540	ghostly rainbow sauce	0		
 8541	upside-down drug cocktail sauce	0		
 8542	half-sized spoiled Fettris	2	crappy	
-8543	adequate snack-sized fusillocybin	2	good	
+8543	snack-sized adequate fusillocybin	2	good	
 8544	spoiled prescription noodles	3	crappy	
-8545	vaporized blurry cyan blinking blood-drive sticker	1	decent	
+8545	vaporized blinking blurry cyan blood-drive sticker	1	decent	
 8546	oxidized vacuum-sealed bag of grain	0		Effect: "Lobos Fresh", Effect Duration: 69
 8547	quadruple-concentrated colloidal pocket maze	0		Effect: "Initiative and Let Die", Effect Duration: 46
 8548	colloidal triple-pressed unsweetened tumbling blurry shady shades	0		Effect: "Net Tea", Effect Duration: 30
 8549	corrupted liquefied jittery squeaky toy rose	0		Effect: "Overstimulated", Effect Duration: 14
 8550	normal weird gazelle steak	4	good	
 8551	yummy spinning sausage without a cause	3	awesome	
-8552	deionized blurry bouncing face paint	0		Effect: "Saucegoggles", Effect Duration: 29
+8552	deionized bouncing blurry face paint	0		Effect: "Saucegoggles", Effect Duration: 29
 8553	mediocre upside-down emergency margarita	3	decent	
-8554	mediocre practically non-alcoholic purple vintage smart drink	1	decent	
+8554	practically non-alcoholic mediocre purple vintage smart drink	1	decent	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	enhanced deionized activated mirror ghostly Wickers bar	0		Effect: "Updated", Effect Duration: 41
+8558	enhanced deionized activated ghostly mirror Wickers bar	0		Effect: "Updated", Effect Duration: 41
 8559	oxidized flattened blue skewed bakelite-covered bacon	0		Effect: "Antarctic Memories", Effect Duration: 52
 8560	colloidal boiled quadruple-vacuum-sealed Aerheads	0		Effect: "Overstimulated", Effect Duration: 22
 8561	polymerized energized Wrotz	0		Effect: "Unrunnable Face", Effect Duration: 12
 8562	electrified oxidized flattened mirror Gabarbar	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 33
-8563	galvanized tarnished huge green fiberglass insulation	0		Effect: "Ruthlessly Efficient", Effect Duration: 67
+8563	galvanized tarnished green huge fiberglass insulation	0		Effect: "Ruthlessly Efficient", Effect Duration: 67
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	fortified barrel lid of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10, Item Drop: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	aromatic knitted barrel hoop earring of courage	0		Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2015-09"
-8567	rosewater-soaked flame-wreathed lion tamer's bankruptcy barrel	0		Experience (familiar): +2, Hot Spell Damage: +10, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	rosewater-soaked flame-wreathed lion tamer's bankruptcy barrel	0		Experience (familiar): +2, Hot Spell Damage: +10, Stench Resistance: +3, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	wobbly firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
-8570	tumbling mirror tun	0		Last Available: "2015-09"
+8570	mirror tumbling tun	0		Last Available: "2015-09"
 8571	shaking weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
 8573	yellow barrel	0		Last Available: "2015-09"
-8574	teal pulsating ghostly moist barrel	0		Last Available: "2015-09"
+8574	teal ghostly pulsating moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	tolerable weak bottle of Amontillado	2	good	Last Available: "2015-09"
 8579	hand-crafted watered-down barrel-aged martini	2	EPIC	Last Available: "2015-09"
-8580	massive rotten barrel pickle	8	crappy	Last Available: "2015-09"
-8581	rotten snack-sized olive barrel cracker	2	crappy	Last Available: "2015-09"
+8580	rotten massive barrel pickle	8	crappy	Last Available: "2015-09"
+8581	snack-sized rotten olive barrel cracker	2	crappy	Last Available: "2015-09"
 8582	vaporized blurry vibrating mushroom	1	awesome	Effect: "Nothing Is Impossible", Effect Duration: 30, Last Available: "2015-09"
 8583	pickled mushroom	1	decent	Last Available: "2015-09"
 8584	rosy-cheeked KoL Con 12-gauge	0		Maximum HP Percent: +30, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	lime green upside-down weightlifter's barrel gun	0		Muscle: +15, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	spoiled small purple water log	2	crappy	Last Available: "2015-09"
+8589	small spoiled purple water log	2	crappy	Last Available: "2015-09"
 8590	aromatic greasy barrelhead	0		Sleaze Spell Damage: +10, Stench Resistance: +1, Last Available: "2015-09"
 8591	occult educational bottoms of the barrel	0		Experience: +1, Spell Damage Percent: +25, Last Available: "2015-09"
 8592	up-at-dawn shellacked chest barrel	0		Damage Reduction: 7, Adventures: +5, Last Available: "2015-09"
@@ -8475,7 +8475,7 @@
 8602	dry nitrogenated red cuppa Yet tea	0		Effect: "Fangs and Pangs", Effect Duration: 29, Last Available: "2015-09"
 8603	pressed blinking cuppa Boo tea	0		Effect: "Carrion' On", Effect Duration: 45, Last Available: "2015-09"
 8604	quantum enhanced squat spinning cuppa Nas tea	0		Effect: "You Drank Fish Wine", Effect Duration: 44, Last Available: "2015-09"
-8605	energized ghostly shaking cuppa Improprie tea	0		Effect: "Slimed Stomach", Effect Duration: 16, Last Available: "2015-09"
+8605	energized shaking ghostly cuppa Improprie tea	0		Effect: "Slimed Stomach", Effect Duration: 16, Last Available: "2015-09"
 8606	chilled oxidized cold-filtered cuppa Frost tea	0		Effect: "Prideful Strut", Effect Duration: 57, Last Available: "2015-09"
 8607	chilled warmed cuppa Toast tea	0		Effect: "Thick-Skinned", Effect Duration: 63, Last Available: "2015-09"
 8608	boiled anodized cyan cuppa Net tea	0		Effect: "Bats in the Belfry", Effect Duration: 64, Last Available: "2015-09"
@@ -8495,7 +8495,7 @@
 8622	super-deionized polarized cuppa Mediocri tea	0		Effect: "Spookypants", Effect Duration: 63, Last Available: "2015-09"
 8623	improved magnetized shaking cuppa Loyal tea	0		Effect: "Meatwise", Effect Duration: 55, Last Available: "2015-09"
 8624	distilled cyan blinking cuppa Activi tea	1	decent	Effect: "Patent Prevention", Effect Duration: 30, Last Available: "2015-09"
-8625	compressed olive squat cuppa Cruel tea	1		Last Available: "2015-09"
+8625	compressed squat olive cuppa Cruel tea	1		Last Available: "2015-09"
 8626	magnetized moist jittery cuppa Alacri tea	0		Effect: "Ghost Finger", Effect Duration: 32, Last Available: "2015-09"
 8627	pickled pickled blurry maroon cuppa Vitali tea	0		Effect: "Cookie Backup", Effect Duration: 69, Last Available: "2015-09"
 8628	improved cuppa Mana tea	0		Effect: "[1609]Dancin' Fool", Effect Duration: 60, Last Available: "2015-09"
@@ -8512,9 +8512,9 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	wobbly Ghost Dog Chow	0		Last Available: "2015-10"
 8641	delicious bowl of eyeballs	3	awesome	Last Available: "2015-10"
-8642	tiny bland shaking bowl of mummy guts	1	decent	Last Available: "2015-10"
+8642	bland tiny shaking bowl of mummy guts	1	decent	Last Available: "2015-10"
 8643	massive adequate bowl of maggots	10	good	Last Available: "2015-10"
-8644	drinkable practically non-alcoholic ghostly blood and blood	1	good	Last Available: "2015-10"
+8644	practically non-alcoholic drinkable ghostly blood and blood	1	good	Last Available: "2015-10"
 8645	artisanal special Jack-O-Lantern beer	3	EPIC	Effect: "Sagittarius Rising", Effect Duration: 35, Last Available: "2015-10"
 8646	hand-crafted mirror zombie	4	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
@@ -8525,15 +8525,15 @@
 8652	bouncing ear poison	0		
 8653	blurry stink-penny	0		
 8654	shaking Sherlock's family-friendly sinister hawk	0		Spell Damage: +10, Sleaze Resistance: +1, Item Drop: +25
-8655	massive delicious ghostly hamlet sandwich	7	awesome	
+8655	delicious massive ghostly hamlet sandwich	7	awesome	
 8656	chaotic Othello's military jacket	0		Spell Critical Percent: +10
 8657	banded Othello's dagger	0		Damage Absorption: +100, Single Equip
 8658	bouncing Tesla Othello's handkerchief	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 8659	Vulcanized maroon bowl of Jeal-O	0		Effect: "Towering Strength", Effect Duration: 41
 8660	grip key	0		
-8661	blinking red How to Play Othello	0		
+8661	red blinking How to Play Othello	0		
 8662	aromatic veiny smooth ghostly dagger	0		Moxie: +15, Maximum HP: +10, Stench Resistance: +1
-8663	high-proof hand-crafted ghost beer	6	EPIC	
+8663	hand-crafted high-proof ghost beer	6	EPIC	
 8664	smartaleck's Othello set	0		Moxie Percent: +30
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8548,7 +8548,7 @@
 8675	yellow one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	double-diffused altered unsweetened ghostly shoulder-warming lotion	0		Effect: "Spring Training", Effect Duration: 12, Last Available: "2015-11"
 8677	huge bland iceberg lettuce	7	decent	Last Available: "2015-11"
-8678	artisanal weak special ice wine	2	EPIC	Effect: "Pumped Stomach", Effect Duration: 5, Last Available: "2015-11"
+8678	special artisanal weak ice wine	2	EPIC	Effect: "Pumped Stomach", Effect Duration: 5, Last Available: "2015-11"
 8679	dangerous Socratic Wal-Mart snowglobe of the ox	0		Muscle: +20, Experience (Mysticality): +1, Weapon Damage: +10, Last Available: "2015-11"
 8680	skewed occult brainy Wal-Mart nametag of Gandalf	0		Mysticality: +5, Spell Damage Percent: +25, Spell Critical Percent: +20, Last Available: "2015-11"
 8681	scorching stiffened Wal-Mart overalls of the cougar	0		Moxie: +20, Damage Reduction: 1, Hot Damage: +25, Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	mirror Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	upside-down perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	sinister bellhop's hat	0		Spell Damage: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	aged spirit-forward ice porter	5	awesome	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	sinister bellhop's hat	0		Spell Damage: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	spirit-forward aged ice porter	5	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	super-boiled quadruple-cold-filtered lime green exotic travel brochure	0		Effect: "Super-Mega-Charged", Effect Duration: 19, Last Available: "2015-11"
 8691	pulsating bag of foreign bribes	0		Last Available: "2015-11"
 8692	improved polymerized mirror shampoo-conditioner	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 39, Last Available: "2015-11"
@@ -8567,11 +8567,11 @@
 8694	bouncing ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	pickled pulsating medicinal herbs	1		Last Available: "2016-01"
-8697	small normal ice rice	2	good	Last Available: "2016-01"
+8697	normal small ice rice	2	good	Last Available: "2016-01"
 8698	mediocre blinking iced plum wine	4	decent	Last Available: "2016-01"
 8699	Temple Grandin's friendly wicked training belt	0		Spell Damage: +5, Familiar Weight: 10, Single Equip, Last Available: "2016-01"
 8700	huge up-at-dawn strapping training legwarmers of the bloodbag	0		Muscle: +5, Maximum HP: +100, Adventures: +5, Single Equip, Last Available: "2016-01"
-8701	pulsating flame-wreathed Annie Oakley's training helmet of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: 35, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	pulsating flame-wreathed Annie Oakley's training helmet of the brazier	0		Critical Hit Percent: +20, Hot Spell Damage: 35, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	blinking training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8581,19 +8581,19 @@
 8708	pickled abstraction: action	1		Effect: "Deadly Lampblade", Effect Duration: 35, Last Available: "2015-12"
 8709	dehydrated abstraction: thought	1		Last Available: "2015-12"
 8710	compressed ghostly abstraction: sensation	1		Effect: "On the Trolley", Effect Duration: 25, Last Available: "2015-12"
-8711	pickled fuchsia ghostly abstraction: purpose	1		Last Available: "2015-12"
+8711	pickled ghostly fuchsia abstraction: purpose	1		Last Available: "2015-12"
 8712	diluted ghostly abstraction: category	1		Last Available: "2015-12"
-8713	vaporized pulsating blue abstraction: perception	1		Last Available: "2015-12"
+8713	vaporized blue pulsating abstraction: perception	1		Last Available: "2015-12"
 8714	pickled huge abstraction: motion	1		Last Available: "2015-12"
 8715	boiled pulsating abstraction: joy	1		Last Available: "2015-12"
 8716	powdered abstraction: certainty	1		Last Available: "2015-12"
 8717	dried blurry abstraction: comprehension	1		Last Available: "2015-12"
 8718	ghostly modern picture frame	0		Last Available: "2015-12"
-8719	enchanted normal snack-sized VYKEA meatballs	2	good	Effect: "Slimily Sagacious", Effect Duration: 20, Last Available: "2015-11"
+8719	normal enchanted snack-sized VYKEA meatballs	2	good	Effect: "Slimily Sagacious", Effect Duration: 20, Last Available: "2015-11"
 8720	lousy maroon VYKEA mead	3	decent	Last Available: "2015-11"
 8721	alkaline super-denatured boiled VYKEA woadpaint	0		Effect: "Weird Vibrations", Effect Duration: 60, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
-8723	gray pulsating VYKEA blood rune	0		Last Available: "2015-11"
+8723	pulsating gray VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	pulsating VYKEA plank	0		Last Available: "2015-11"
 8726	tumbling VYKEA rail	0		Last Available: "2015-11"
@@ -8601,15 +8601,15 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	purple shellacked savvy sage VYKEA hex key	0		Mysticality Percent: 30, Damage Reduction: 7, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	stale tin of submardines	4	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	stale tin of submardines	4	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	tolerable bottle of norwhiskey	3	good	Last Available: "2015-11"
 8733	distilled huge octolus oculus	1	good	Last Available: "2015-11"
 8734	Fonzie's smartaleck's sardine can key of Leguizamo	0		Moxie Percent: +30, Experience (Moxie): +1, Monster Level: +20, Last Available: "2015-11"
-8735	bouncing stanky crafty norwhal helmet of the glutton	0		Maximum MP: +10, Stench Spell Damage: +25, Food Drop: +100, Last Available: "2015-11", Familiar Effect: "atk"
+8735	bouncing stanky crafty norwhal helmet of the glutton	0		Maximum MP: +10, Stench Spell Damage: +25, Food Drop: +100, Familiar Effect: "atk", Last Available: "2015-11"
 8736	frightening electrified groovy octolus-skin cloak	0		Moxie Percent: +10, Spooky Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8737	smooth perfect cosmopolitan	4	awesome	Last Available: "2015-11"
 8738	hand-crafted perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	delicious triple-distilled wobbly perfect dark and stormy	7	awesome	Last Available: "2015-11"
+8739	triple-distilled delicious wobbly perfect dark and stormy	7	awesome	Last Available: "2015-11"
 8740	hand-crafted perfect mimosa	3	EPIC	Last Available: "2015-11"
 8741	perfectly mixed wobbly perfect old-fashioned	4	EPIC	Last Available: "2015-11"
 8742	practically non-alcoholic aged blurry perfect paloma	1	awesome	Last Available: "2015-11"
@@ -8622,7 +8622,7 @@
 8749	triple-alkaline unsweetened jittery Deep Machine Tunnels snowglobe	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 52, Last Available: "2015-12"
 8750	deionized pulsating hemp candy necklace	0		Effect: "Worth Your Salt", Effect Duration: 38, Last Available: "2015-12"
 8751	polarized ionized ghostly communal gobstopper	0		Effect: "Venomous Weapon", Effect Duration: 38, Last Available: "2015-12"
-8752	special adequate snack-sized wobbly Crimbo salad	2	good	Effect: "Intimidating Mien", Effect Duration: 10, Last Available: "2015-12"
+8752	snack-sized special adequate wobbly Crimbo salad	2	good	Effect: "Intimidating Mien", Effect Duration: 10, Last Available: "2015-12"
 8753	jumbo normal maroon bread line	5	good	Last Available: "2015-12"
 8754	lousy bark rootbeer	4	decent	Last Available: "2015-12"
 8755	artisanal strong ale	5	EPIC	Last Available: "2015-12"
@@ -8633,7 +8633,7 @@
 8760	thinker's plastic Crimbodhisattva	0		Mysticality: +10, Last Available: "2015-12"
 8761	wobbly bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
-8763	lime green skewed BACON	0		Last Available: "2016-05"
+8763	skewed lime green BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	mirror huge Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
 8766	boozy bad Gratitude chocolate (bourbon-filled)	5	decent	Last Available: "2016-02"
@@ -8665,7 +8665,7 @@
 8793	face paint	0		Free Pull, Last Available: "2015-12"
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
-8796	yellow blurry plastic spoiler	0		
+8796	blurry yellow plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
 8799	fuchsia bat-o-mite	0		Last Available: "2017-01"
@@ -8687,7 +8687,7 @@
 8815	skewed bat-bearing	0		Last Available: "2017-01"
 8816	bland Kudzu salad	3	decent	Last Available: "2016-12"
 8817	dried purple Mansquito Serum	1		Last Available: "2016-12"
-8818	perfectly mixed irresponsibly strong blurry spinning Miss Graves' vermouth	8	EPIC	Last Available: "2016-12"
+8818	irresponsibly strong perfectly mixed blurry spinning Miss Graves' vermouth	8	EPIC	Last Available: "2016-12"
 8819	normal The Plumber's mushroom stew	4	good	Last Available: "2016-12"
 8820	altered The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed The Mad Liquor	4	EPIC	Last Available: "2016-12"
@@ -8695,7 +8695,7 @@
 8823	super-sized normal huge Mr. Burnsger	5	good	Last Available: "2016-12"
 8824	dried The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	blurry miser's greasy friendly The Jokester's gun	0		Familiar Weight: +3, Sleaze Spell Damage: +10, Meat Drop: +10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	huge flame-retardant healthy The Jokester's wig of the detective	0		Maximum HP Percent: +20, Hot Resistance: +1, Item Drop: +20, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8826	huge flame-retardant healthy The Jokester's wig of the detective	0		Maximum HP Percent: +20, Hot Resistance: +1, Item Drop: +20, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
 8827	executive supercool The Jokester's pants of the cougar	0		Moxie: +20, Moxie Percent: +20, Meat Drop: +40, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	liquefied quadruple-energized Jokester makeup	0		Effect: "Ichorous Intensity", Effect Duration: 31, Last Available: "2016-12"
 8829	yellow replica bat-oomerang	0		Last Available: "2016-12"
@@ -8746,19 +8746,19 @@
 8874	executive lard-coated nippy coward's deadly Val-U Brand Every Bean Salad	0		Weapon Damage: +5, Monster Level: -20, Cold Damage: +10, Sleaze Spell Damage: +25, Meat Drop: +40, Last Available: "2016-02"
 8875	careful hale Shrub's Premium Baked Beans of extreme caution	0		Maximum HP: +20, Monster Level: -35, Last Available: "2016-02"
 8876	decent plate of Heimz Fortified Kidney Beans	4	good	Last Available: "2016-02"
-8877	small bland plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
+8877	bland small plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
 8878	flavorless plate of Mixed Garbanzos and Chickpeas	3	decent	Last Available: "2016-02"
 8879	flavorless blurry plate of Hellfire Spicy Beans	4	decent	Last Available: "2016-02"
-8880	special stale plate of Frigid Northern Beans	3	decent	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2016-02"
+8880	stale special plate of Frigid Northern Beans	3	decent	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2016-02"
 8881	toothsome jittery plate of World's Blackest-Eyed Peas	3	awesome	Last Available: "2016-02"
 8882	adequate plate of Trader Olaf's Exotic Stinkbeans	4	good	Last Available: "2016-02"
-8883	bite-sized rotten plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	crappy	Last Available: "2016-02"
+8883	rotten bite-sized plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	crappy	Last Available: "2016-02"
 8884	super-sized stale plate of Val-U Brand Every Bean Salad	5	decent	Last Available: "2016-02"
 8885	moldy miniature fuchsia plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	cyan avaricious brainy Fancy Jeff's pocket square	0		Mysticality: +5, Meat Drop: +30, Last Available: "2016-02"
-8887	spinning zippy sharpshooter's Daisy's unclean bloomers of the detective	0		Critical Hit Percent: +10, Item Drop: +20, Initiative: +20, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	spinning zippy sharpshooter's Daisy's unclean bloomers of the detective	0		Critical Hit Percent: +10, Item Drop: +20, Initiative: +20, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	frightening forbidden boxer's Amoon-Ra Cowtep's nemes	0		Muscle Percent: +10, Spell Damage Percent: +50, Spooky Damage: +5, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	frightening forbidden boxer's Amoon-Ra Cowtep's nemes	0		Muscle Percent: +10, Spell Damage Percent: +50, Spooky Damage: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	olive up-at-dawn MacGyver's Rosewater's Former Sheriff Dan's tin star of the empath of the brazier	0		Mysticality Percent: +30, Maximum MP: +100, Familiar Weight: +5, Hot Spell Damage: +25, Adventures: +5, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8778,9 +8778,9 @@
 8906	modified rattler gland	0		Effect: "Nas Tea", Effect Duration: 14, Last Available: "2016-02"
 8907	pressed teal half-digested coal	0		Effect: "Papowerful", Effect Duration: 59, Last Available: "2016-02"
 8908	altered adjusted tightly-wound spine	0		Effect: "Hagg-ard", Effect Duration: 24, Last Available: "2016-02"
-8909	huge rotten squat rotting beefsteak	7	crappy	Last Available: "2016-02"
-8910	extra-dry tolerable firemilk	5	good	Last Available: "2016-02"
-8911	moist huge olive spidercow eye-cluster	0		Effect: "Well-Lubed", Effect Duration: 43, Last Available: "2016-02"
+8909	rotten huge squat rotting beefsteak	7	crappy	Last Available: "2016-02"
+8910	tolerable extra-dry firemilk	5	good	Last Available: "2016-02"
+8911	moist olive huge spidercow eye-cluster	0		Effect: "Well-Lubed", Effect Duration: 43, Last Available: "2016-02"
 8912	vaporized bouncing moomy dust	1		Effect: "This Is Where You're a Viking", Effect Duration: 20, Last Available: "2016-02"
 8913	skewed wool flame-wreathed western-style skinning knife	0		Hot Spell Damage: +10, Cold Resistance: +1, Last Available: "2016-02"
 8914	bouncing reliable sixgun	0		Last Available: "2016-02"
@@ -8792,8 +8792,8 @@
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	shaking Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	wobbly Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
-8923	narrow bouncing disc (white)	0		
-8924	green pulsating disc (black)	0		
+8923	bouncing narrow disc (white)	0		
+8924	pulsating green disc (black)	0		
 8925	disc (red)	0		
 8926	skewed disc (green)	0		
 8927	disc (blue)	0		
@@ -8867,12 +8867,12 @@
 8995	unsweetened tumbling upside-down Greek fire	0		Effect: "5 Pounds Lighter", Effect Duration: 37, Last Available: "2016-03"
 8996	jittery double-paned frightening razor-sharp Newton's strapping ox-head shield	0		Muscle: +5, Experience (Mysticality): +3, Weapon Damage Percent: +25, Spooky Damage: +5, Cold Resistance: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	vibrating hale wholesome steel-toed supercool dented scepter	0		Moxie Percent: +20, Damage Reduction: 9, Maximum HP Percent: +10, Maximum HP: +20, Maximum MP Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	red dog trainer's Oprah's hardened beefcake's very pointy crown of terror	0		Muscle: +25, Damage Reduction: 3, Maximum MP Percent: +50, Experience (familiar): +1, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	red dog trainer's Oprah's hardened beefcake's very pointy crown of terror	0		Muscle: +25, Damage Reduction: 3, Maximum MP Percent: +50, Experience (familiar): +1, Spooky Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	purple frosty battle broom of Calamity Jane of chilblains of bravery of the boozehound	0		Critical Hit Percent: +15, Cold Damage: +25, Cold Spell Damage: +10, Spooky Resistance: +5, Booze Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	pulsating crafty steel-toed thinker's carpe of the sewer	0		Mysticality: +10, Damage Reduction: 9, Maximum MP: +10, Stench Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9002	Annie Oakley's shellacked codpiece of the blizzard of bravery	0		Damage Reduction: 7, Critical Hit Percent: +20, Cold Spell Damage: +25, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	supercharged hardy sage troutsers of the detective	0		Mysticality Percent: +10, Maximum HP: +50, Maximum MP Percent: +30, Item Drop: +20, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	supercharged hardy sage troutsers of the detective	0		Mysticality Percent: +10, Maximum HP: +50, Maximum MP Percent: +30, Item Drop: +20, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	blinking yellow friendly grievous bass clarinet of terror of the businessman	0		Weapon Damage Percent: +50, Familiar Weight: +3, Spooky Spell Damage: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2016-04"
 9005	green narrow jittery aromatic double-paned Sinatra's Herculean fish hatchet	0		Experience (Muscle): +1, Experience (Moxie): +5, Cold Resistance: +5, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9006	scorching Jack Frost's rosy-cheeked tunac of vim and vigor	0		Maximum HP Percent: 80, Cold Spell Damage: +50, Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	bouncing internet point	0		Last Available: "2016-05"
 9019	shaking meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	snack-sized adequate enchanted wobbly gallon of milk	2	good	Effect: "Ironclad", Effect Duration: 25, Last Available: "2016-05"
+9021	enchanted snack-sized adequate wobbly gallon of milk	2	good	Effect: "Ironclad", Effect Duration: 25, Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8904,7 +8904,7 @@
 9032	adequate bowl of Tastee-Wheet&trade;	3	good	
 9033	pulsating Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	enchanted moldy browser cookie	4	crappy	Effect: "Just the Brown Ones", Effect Duration: 50, Last Available: "2016-06"
+9035	moldy enchanted browser cookie	4	crappy	Effect: "Just the Brown Ones", Effect Duration: 50, Last Available: "2016-06"
 9036	smooth weak hacked gibson	2	awesome	Last Available: "2016-06"
 9037	pulsating Source shades of Tarzan	0		Experience (Muscle): +3, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8927,7 +8927,7 @@
 9055	mirror Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	maroon Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
-9058	blue wobbly Source terminal file: portscan.edu	0		Last Available: "2016-06"
+9058	wobbly blue Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	tumbling Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	bouncing Source terminal file: pram.ext	0		Last Available: "2016-06"
@@ -8949,7 +8949,7 @@
 9077	Sherlock's Herculean trench coat of the cheetah	0		Experience (Muscle): +1, Item Drop: +25, Initiative: +60, Last Available: "2016-07"
 9078	aged weak Falcon&trade; Maltese Liquor	2	awesome	Last Available: "2016-07"
 9079	bland low-calorie twirling hardboiled egg	1	decent	Last Available: "2016-07"
-9080	maroon upside-down detective tattoo	0		Last Available: "2016-07"
+9080	upside-down maroon detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	knitted wool Tesla medical-grade quilted beefy protonic accelerator pack	0		Muscle: +10, Damage Absorption: +40, Cold Resistance: 4, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	mirror almost-dead walkie-talkie	0		Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	maroon narrow greasy Mr. Screege's spectacles	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2016-08"
 9092	skewed teal Temple Grandin's studded brainy Spookyraven signet	0		Mysticality: +5, Damage Absorption: +80, Familiar Weight: +7, Single Equip, Last Available: "2016-08"
 9093	Tesla groovy tie-dyed fannypack	0		Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2016-08"
-9094	cool weightlifter's burnt snowpants	0		Muscle: +15, Moxie: +5, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9094	cool weightlifter's burnt snowpants	0		Muscle: +15, Moxie: +5, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
 9095	cyan brawny standards and practices guide	0		Muscle Percent: +20, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	hale Carpathian longsword of Calamity Jane of horror	0		Maximum HP: +20, Critical Hit Percent: +15, Spooky Spell Damage: +25, Last Available: "2016-08"
 9097	skewed maroon scorching mansplainer's Liam's mail of the boozehound	0		Monster Level: +15, Hot Damage: +25, Booze Drop: +100, Last Available: "2016-08"
@@ -8974,7 +8974,7 @@
 9102	friendly Wrist-Boy	0		Familiar Weight: +3
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
-9105	skewed blurry compounded experience	0		Last Available: "2016-09"
+9105	blurry skewed compounded experience	0		Last Available: "2016-09"
 9106	blurry Rad-B-Gone (1 lb.)	0		
 9107	electrified tarnished Rad-Pro (1 oz.)	0		Effect: "[1701]Hip to the Jive", Effect Duration: 50
 9108	lead umbrella	0		
@@ -8995,7 +8995,7 @@
 9123	School of Hard Knocks Diploma	0		
 9124	blurry baby bark scorpion	0		
 9125	wobbly droppable microphone	0		
-9126	watered-down special bad spinning unidentified drink	2	decent	Effect: "Chief Executive Optimism", Effect Duration: 5
+9126	special bad watered-down spinning unidentified drink	2	decent	Effect: "Chief Executive Optimism", Effect Duration: 5
 9127	sharpshooter's beefcake's KoL Con 13 T-shirt	0		Muscle: +25, Critical Hit Percent: +10
 9128	nippy grievous discarded swimming trunks of the brazier	0		Weapon Damage Percent: +50, Cold Damage: +10, Hot Spell Damage: +25
 9129	ionized wobbly diluted makeup	0		Effect: "Sourpuss", Effect Duration: 11
@@ -9003,34 +9003,34 @@
 9131	extremely confusing manual	0		
 9132	friendly beefcake's pistol	0		Muscle: +25, Familiar Weight: +3
 9133	shaking KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	toothsome miniature fuchsia leftover pasty	2	awesome	
+9134	miniature toothsome fuchsia leftover pasty	2	awesome	
 9135	bad very whiskey	3	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	pulsating li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	bouncing li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	huge li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	bouncing li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	huge li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	oxidized non-anodized hoarded candy wad	0		Effect: "Bonelording", Effect Duration: 60, Last Available: "2016-10"
-9147	warmed oxidized twirling upside-down Prunets	0		Effect: "The Power of Positive Thinking", Effect Duration: 35
+9147	warmed oxidized upside-down twirling Prunets	0		Effect: "The Power of Positive Thinking", Effect Duration: 35
 9148	red Twitching Television Tattoo	0		
 9149	huge baby scorpion	0		Familiar Weight: +10
 9150	diffused ionized wobbly invisible string	0		Lasts Until Rollover, Effect: "Nas Tea", Effect Duration: 58, Last Available: "2016-10"
 9151	irradiated invisible seam ripper	0		Lasts Until Rollover, Effect: "Big", Effect Duration: 59, Last Available: "2016-10"
-9152	green twirling li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	twirling green li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	massive toothsome raw sweet potato	6	awesome	Last Available: "2016-11"
 9154	miniature toothsome raw beans	2	awesome	Last Available: "2016-11"
 9155	rotten raw stuffing	3	crappy	Last Available: "2016-11"
 9156	diet normal raw cranberry sauce	1	good	Last Available: "2016-11"
-9157	rotten bite-sized enchanted blinking raw turkey	1	crappy	Effect: "Human-Undead Hybrid", Effect Duration: 45, Last Available: "2016-11"
-9158	normal snack-sized raw mincemeat	2	good	Last Available: "2016-11"
+9157	rotten enchanted bite-sized blinking raw turkey	1	crappy	Effect: "Human-Undead Hybrid", Effect Duration: 45, Last Available: "2016-11"
+9158	snack-sized normal raw mincemeat	2	good	Last Available: "2016-11"
 9159	snack-sized stale raw potato	2	decent	Last Available: "2016-11"
 9160	spoiled raw gravy	3	crappy	Last Available: "2016-11"
-9161	flavorless massive raw bread	6	decent	Last Available: "2016-11"
+9161	massive flavorless raw bread	6	decent	Last Available: "2016-11"
 9162	brawny mini-marshmallow dispenser of horror	0		Muscle Percent: +20, Spooky Spell Damage: +25, Last Available: "2016-11"
 9163	lime green asbestos-lined arcane researcher's glass casserole dish of the glutton	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Food Drop: +100, Last Available: "2016-11"
 9164	tumbling stuffing fluffer	0		Last Available: "2016-11"
@@ -9051,7 +9051,7 @@
 9179	stale bread roll	4	decent	Last Available: "2016-11"
 9180	stale miniature purple squat leftovers	2	decent	Last Available: "2016-11"
 9181	stale half-sized twirling skewed leftovers sandwich	2	decent	Last Available: "2016-11"
-9182	gray skewed Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
+9182	skewed gray Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	squat interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	tumbling sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	toothsome maroon ghostly animal part cracker	3	awesome	Last Available: "2016-12"
+9219	toothsome ghostly maroon animal part cracker	3	awesome	Last Available: "2016-12"
 9220	bad watered-down gingerbread wine	2	decent	Last Available: "2016-12"
 9221	half-sized spoiled gingerbread mug	2	crappy	Last Available: "2016-12"
 9222	squat Samson's gingerbread mask	0		Experience (Muscle): +5, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	smelly gingerbread gavel of the boozehound	0		Stench Spell Damage: +10, Booze Drop: +100, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	fancy artisanal ginger beer	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 15, Last Available: "2016-12"
+9239	artisanal fancy ginger beer	3	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 15, Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	diffused industrial frosting	0		Effect: "Whitened Teeth", Effect Duration: 66, Last Available: "2016-12"
 9242	extra-enhanced fake cocktail	0		Effect: "In the Slimelight", Effect Duration: 20, Last Available: "2016-12"
@@ -9120,18 +9120,18 @@
 9248	squat dog trainer's plastic Krampus	0		Experience (familiar): +1, Last Available: "2016-12"
 9249	ionized corrupted Inner Wisdom	0		Effect: "So You Can Work More...", Effect Duration: 29, Last Available: "2016-12"
 9250	anodized denatured adjusted gray Inner Strength	0		Effect: "Memory of Attractiveness", Effect Duration: 45, Last Available: "2016-12"
-9251	ionized bouncing huge narrow Inner Truth	0		Effect: "Human-Pirate Hybrid", Effect Duration: 52, Last Available: "2016-12"
-9252	normal gigantic mirror spiritual candy cane	8	good	Last Available: "2016-12"
-9253	delicious watered-down spiritual eggnog	2	awesome	Last Available: "2016-12"
-9254	moldy bite-sized spiritual fruitcake	1	crappy	Last Available: "2016-12"
-9255	toothsome small wobbly spiritual gingerbread	2	awesome	Last Available: "2016-12"
+9251	ionized narrow huge bouncing Inner Truth	0		Effect: "Human-Pirate Hybrid", Effect Duration: 52, Last Available: "2016-12"
+9252	gigantic normal mirror spiritual candy cane	8	good	Last Available: "2016-12"
+9253	watered-down delicious spiritual eggnog	2	awesome	Last Available: "2016-12"
+9254	bite-sized moldy spiritual fruitcake	1	crappy	Last Available: "2016-12"
+9255	small toothsome wobbly spiritual gingerbread	2	awesome	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	teal chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	jittery My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	upside-down No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	olive Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
-9262	pulsating fuchsia fruit-leather negatives	0		Last Available: "2016-12"
+9262	fuchsia pulsating fruit-leather negatives	0		Last Available: "2016-12"
 9263	jittery gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	squat briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
@@ -9145,10 +9145,10 @@
 9273	family-friendly crafty Third Eye	0		Maximum MP: +10, Sleaze Resistance: +1, Last Available: "2016-12"
 9274	stanky strapping Krampus Horn	0		Muscle: +5, Stench Spell Damage: +25, Single Equip, Last Available: "2016-12"
 9275	stale hambrosier	4	decent	Last Available: "2016-12"
-9276	drinkable fuchsia spinning chakra-mental wine	3	good	Last Available: "2016-12"
+9276	drinkable spinning fuchsia chakra-mental wine	3	good	Last Available: "2016-12"
 9277	ionized polarized extra-enhanced chakra malt	0		Effect: "The Halls of Mysticality", Effect Duration: 53, Last Available: "2016-12"
 9278	flavorless blinking Black Angus blackburger	3	decent	Last Available: "2016-12"
-9279	drinkable enchanted brandy	4	good	Effect: "Burning Ears", Effect Duration: 10, Last Available: "2016-12"
+9279	enchanted drinkable brandy	4	good	Effect: "Burning Ears", Effect Duration: 10, Last Available: "2016-12"
 9280	moist blinking potion of spiritual gunkifying	0		Effect: "Optimist Primal", Effect Duration: 52, Last Available: "2016-12"
 9281	steel-toed stylish bad vibroknife	0		Moxie: +25, Damage Reduction: 9, Last Available: "2016-12"
 9282	skewed zippy vibrating crystal belt buckle	0		Maximum MP Percent: +10, Initiative: +20, Last Available: "2016-12"
@@ -9169,14 +9169,14 @@
 9297	decent low-calorie toast with hot jelly	1	good	Last Available: "2017-01"
 9298	spoiled enchanted toast with jelly	3	crappy	Effect: "Helvella Health", Effect Duration: 5, Last Available: "2017-01"
 9299	adequate toast with jelly	3	good	Last Available: "2017-01"
-9300	flavorless snack-sized toast with sleaze jelly	2	decent	Last Available: "2017-01"
+9300	snack-sized flavorless toast with sleaze jelly	2	decent	Last Available: "2017-01"
 9301	decent small shaking upside-down toast with stench jelly	2	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	olive hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	family-friendly wax hand of the boozehound	0		Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2017-01"
 9306	olive nasty experienced candle	0		Experience: +2, Stench Damage: +5, Lasts Until Rollover, Last Available: "2017-01"
-9307	diet flavorless wax pancake	1	decent	Last Available: "2017-01"
+9307	flavorless diet wax pancake	1	decent	Last Available: "2017-01"
 9308	avaricious wax face of dire peril	0		Weapon Damage: +20, Meat Drop: +30, Last Available: "2017-01"
 9309	mediocre weak wax booze	2	decent	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
@@ -9193,7 +9193,7 @@
 9321	ribald groovy LOV Epaulettes of the cougar	0		Moxie: +20, Moxie Percent: +10, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2017-02"
 9322	aromatic baleful LOV Earrings of Gandalf	0		Spell Damage: +25, Spell Critical Percent: +20, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	LOV Enamorang	0		Last Available: "2017-02"
-9324	tumbling teal jittery LOV Emotionizer	0		Last Available: "2017-02"
+9324	jittery teal tumbling LOV Emotionizer	0		Last Available: "2017-02"
 9325	huge LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	mixed upside-down LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	pulsating blue MacGyver's LOV Elephant	0		Maximum MP: +100, Damage Reduction: 6, Last Available: "2017-02"
@@ -9203,20 +9203,20 @@
 9331	up-at-dawn frosty eldritch hammer of the businessman	0		Cold Spell Damage: +10, Meat Drop: +50, Adventures: +5, Last Available: "2017-01"
 9332	stale enchanted skewed eldritch mushroom	4	decent	Effect: "Fratty Flavor", Effect Duration: 20, Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	spoiled wobbly pulsating eldritch mushroom pizza	3	crappy	Last Available: "2017-03"
+9334	spoiled pulsating wobbly eldritch mushroom pizza	3	crappy	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	non-cold-filtered pickled warmed eldritch rub	0		Effect: "Inner Dog", Effect Duration: 32, Last Available: "2017-02"
-9338	tumbling spinning red HP-35 Calculator	0		
+9338	red spinning tumbling HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
-9340	tumbling wobbly Golden HP-35 Calculator	0		
+9340	wobbly tumbling Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
 9343	bottlecap	0		
 9344	discarded button	0		
 9345	narrow Gummi-Memory	0		
 9346	squat Thwaitgold amoeba statuette	0		
-9347	pulsating huge tumbling pickled grasshopper	0		Last Available: "2017-03"
+9347	tumbling pulsating huge pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	bouncing bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	twirling elemental sugarcube	0		Last Available: "2017-03"
@@ -9226,7 +9226,7 @@
 9354	shot of granola liqueur	0		Last Available: "2017-03"
 9355	twirling can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	narrow lump of ichor	0		Last Available: "2017-03"
-9357	narrow olive bottle of gregnadigne	0		Last Available: "2017-03"
+9357	olive narrow bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
@@ -9234,43 +9234,43 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	twirling imaginary lemon	0		Last Available: "2017-03"
-9365	perfectly mixed irresponsibly strong literal grasshopper	8	EPIC	Last Available: "2017-03"
-9366	fancy lousy watered-down blue ghostly double entendre	2	decent	Effect: "Initiative and Let Die", Effect Duration: 45, Last Available: "2017-03"
+9365	irresponsibly strong perfectly mixed literal grasshopper	8	EPIC	Last Available: "2017-03"
+9366	lousy watered-down fancy ghostly blue double entendre	2	decent	Effect: "Initiative and Let Die", Effect Duration: 45, Last Available: "2017-03"
 9367	tolerable Phlegethon	4	good	Last Available: "2017-03"
 9368	tolerable Siberian sunrise	4	good	Last Available: "2017-03"
 9369	tolerable mirror mentholated wine	4	good	Last Available: "2017-03"
 9370	delicious low tide martini	3	awesome	Last Available: "2017-03"
-9371	drinkable triple-distilled shroomtini	7	good	Last Available: "2017-03"
-9372	mediocre weak morning dew	2	decent	Last Available: "2017-03"
+9371	triple-distilled drinkable shroomtini	7	good	Last Available: "2017-03"
+9372	weak mediocre morning dew	2	decent	Last Available: "2017-03"
 9373	tolerable upside-down whiskey squeeze	4	good	Last Available: "2017-03"
-9374	watered-down tolerable great fashioned	2	good	Last Available: "2017-03"
-9375	drinkable watered-down teal Gnomish sagngria	2	good	Last Available: "2017-03"
+9374	tolerable watered-down great fashioned	2	good	Last Available: "2017-03"
+9375	watered-down drinkable teal Gnomish sagngria	2	good	Last Available: "2017-03"
 9376	acceptable vodka stinger	3	good	Last Available: "2017-03"
-9377	smooth watered-down extremely slippery nipple	2	awesome	Last Available: "2017-03"
+9377	watered-down smooth extremely slippery nipple	2	awesome	Last Available: "2017-03"
 9378	weak smooth piscatini	2	awesome	Last Available: "2017-03"
-9379	weak drinkable Churchill	2	good	Last Available: "2017-03"
+9379	drinkable weak Churchill	2	good	Last Available: "2017-03"
 9380	perfectly mixed soilzerac	3	EPIC	Last Available: "2017-03"
 9381	irresponsibly strong drinkable fuchsia London frog	10	good	Last Available: "2017-03"
-9382	spirit-forward drinkable nothingtini	5	good	Last Available: "2017-03"
+9382	drinkable spirit-forward nothingtini	5	good	Last Available: "2017-03"
 9383	lousy eighth plague	4	decent	Last Available: "2017-03"
 9384	irresponsibly strong hand-crafted single entendre	9	EPIC	Last Available: "2017-03"
 9385	perfectly mixed reverse Tantalus	4	EPIC	Last Available: "2017-03"
 9386	bad elemental caipiroska	4	decent	Last Available: "2017-03"
 9387	aged Feliz Navidad	4	awesome	Last Available: "2017-03"
 9388	perfectly mixed tumbling Bloody Nora	3	EPIC	Last Available: "2017-03"
-9389	irresponsibly strong aged moreltini	7	awesome	Last Available: "2017-03"
+9389	aged irresponsibly strong moreltini	7	awesome	Last Available: "2017-03"
 9390	bad hell in a bucket	3	decent	Last Available: "2017-03"
 9391	lousy Newark	4	decent	Last Available: "2017-03"
 9392	tolerable R'lyeh	3	good	Last Available: "2017-03"
-9393	special irresponsibly strong tolerable Gnollish sangria	10	good	Effect: "So Fresh and So Clean", Effect Duration: 25, Last Available: "2017-03"
+9393	special tolerable irresponsibly strong Gnollish sangria	10	good	Effect: "So Fresh and So Clean", Effect Duration: 25, Last Available: "2017-03"
 9394	mediocre weak purple vodka barracuda	2	decent	Last Available: "2017-03"
-9395	tolerable weak bouncing Mysterious Island iced tea	2	good	Last Available: "2017-03"
-9396	perfectly mixed high-proof drive-by shooting	6	EPIC	Last Available: "2017-03"
-9397	weak tolerable gunner's daughter	2	good	Last Available: "2017-03"
+9395	weak tolerable bouncing Mysterious Island iced tea	2	good	Last Available: "2017-03"
+9396	high-proof perfectly mixed drive-by shooting	6	EPIC	Last Available: "2017-03"
+9397	tolerable weak gunner's daughter	2	good	Last Available: "2017-03"
 9398	mediocre dirt julep	3	decent	Last Available: "2017-03"
-9399	fancy hand-crafted weak Simepore slime	2	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 50, Last Available: "2017-03"
-9400	weak mediocre Phil Collins	2	decent	Last Available: "2017-03"
-9401	maroon mirror ghostly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
+9399	weak hand-crafted fancy Simepore slime	2	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 50, Last Available: "2017-03"
+9400	mediocre weak Phil Collins	2	decent	Last Available: "2017-03"
+9401	mirror maroon ghostly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
@@ -9280,11 +9280,11 @@
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	tumbling high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
-9411	pulsating purple alien rock sample	0		Last Available: "2017-04"
+9411	purple pulsating alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	narrow geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	red botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	small spoiled edible alien plant bit	2	crappy	Last Available: "2017-04"
+9415	spoiled small edible alien plant bit	2	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9319,7 +9319,7 @@
 9447	Jim Carey's Fonzie's spant spear	0		Experience (Moxie): +1, Monster Level: +25, Last Available: "2017-04"
 9448	murderbot power cell	0		Last Available: "2017-04"
 9449	blinking murderbot component casing	0		Last Available: "2017-04"
-9450	squat red murderbot monofilament	0		Last Available: "2017-04"
+9450	red squat murderbot monofilament	0		Last Available: "2017-04"
 9451	quantum colloidal squat murderbot shield unit	0		Effect: "Salt Rockin'", Effect Duration: 17, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	strapping murderbot mask of wisdom of Tarzan	0		Muscle: +5, Mysticality: +15, Experience (Muscle): +3, Avatar: "Murderbot", Last Available: "2017-04"
@@ -9341,9 +9341,9 @@
 9469	stanky educational Spacegate scientist's insignia	0		Experience: +1, Stench Spell Damage: +25, Single Equip, Last Available: "2017-04"
 9470	frosty sharpshooter's Spacegate military insignia	0		Critical Hit Percent: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2017-04"
 9471	therapeutic padded slick Spacegate diplomat's insignia	0		Moxie: +10, Damage Absorption: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2017-04"
-9472	mirror green Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
+9472	green mirror Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	spinning Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	decent bite-sized alien sandwich	1	good	Last Available: "2017-04"
+9474	bite-sized decent alien sandwich	1	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	nitrogenated Spant eggs	0		Effect: "Ooh, Bitter!", Effect Duration: 60
 9477	Spacegate (open)	0		Lasts Until Rollover
@@ -9363,9 +9363,9 @@
 9491	Targeted Plague Vector	0		
 9492	tumbling suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	red blurry blurry fortified Kremlin's Greatest Briefcase of the dark arts of horror	0		Spell Damage Percent: +100, Damage Absorption: +60, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	triple-distilled special drinkable basic martini	7	good	Effect: "Squid Squint", Effect Duration: 45, Last Available: "2017-06"
+9494	triple-distilled drinkable special basic martini	7	good	Effect: "Squid Squint", Effect Duration: 45, Last Available: "2017-06"
 9495	weak artisanal improved martini	2	EPIC	Last Available: "2017-06"
-9496	lousy spirit-forward splendid martini	5	decent	Last Available: "2017-06"
+9496	spirit-forward lousy splendid martini	5	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9379,16 +9379,16 @@
 9507	narrow LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
-9510	skewed skewed lime green Dust bunny	0		
+9510	lime green skewed skewed Dust bunny	0		
 9511	purple Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
-9513	twirling olive Meteorite-Ade	0		Last Available: "2017-08"
+9513	olive twirling Meteorite-Ade	0		Last Available: "2017-08"
 9514	bland meteoreo	3	decent	Last Available: "2017-08"
 9515	practically non-alcoholic lousy meadeorite	1	decent	Last Available: "2017-08"
 9516	narrow meteoroid	0		Last Available: "2017-08"
 9517	shaking scandalous weightlifter's meteortarboard of the boozehound	0		Muscle: +15, Sleaze Damage: +5, Booze Drop: +100, Last Available: "2017-08"
 9518	huge pulsating family-friendly veiny meteorite guard of the blizzard	0		Maximum HP: +10, Cold Spell Damage: +25, Sleaze Resistance: +1, Damage Reduction: 9, Last Available: "2017-08"
-9519	twirling greedy boxer's meteorb	0		Muscle Percent: +10, Meat Drop: +20, Last Available: "2017-08", Lantern Element: "Hot"
+9519	twirling greedy boxer's meteorb	0		Muscle Percent: +10, Meat Drop: +20, Lantern Element: "Hot", Last Available: "2017-08"
 9520	narrow greasy Socratic asteroid belt	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10, Single Equip, Last Available: "2017-08"
 9521	friendly supercool meteorthopedic shoes of the blizzard	0		Moxie Percent: +20, Familiar Weight: +3, Cold Spell Damage: +25, Single Equip, Last Available: "2017-08"
 9522	mirror MacGyver's baleful Samson's shooting morning star	0		Experience (Muscle): +5, Spell Damage: +25, Maximum MP: +100, Single Equip, Last Available: "2017-08"
@@ -9416,10 +9416,10 @@
 9544	tumbling O	0		Last Available: "2017-10"
 9545	drinkable DUFRESNE Suds	3	good	Last Available: "2017-09"
 9546	mansplainer's mafia pinky ring of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +15, Single Equip
-9547	mediocre watered-down blurry flask of port	2	decent	
+9547	watered-down mediocre blurry flask of port	2	decent	
 9548	scandalous boxer's contract enforcement stick	0		Muscle Percent: +10, Sleaze Damage: +5
 9549	spoiled narrow Hide-rox&trade; cookie	4	crappy	Last Available: "2017-10"
-9550	tolerable distilled jug of booze	5	good	Last Available: "2017-10"
+9550	distilled tolerable jug of booze	5	good	Last Available: "2017-10"
 9551	oxidized quantum modified pair of candy glasses	0		Effect: "Jittery", Effect Duration: 16, Last Available: "2017-10"
 9552	pressed blurry temporary X tattoos	0		Effect: "Tea-hee", Effect Duration: 69, Last Available: "2017-10"
 9553	altered glyph of athleticism	1		Last Available: "2017-10"
@@ -9453,7 +9453,7 @@
 9581	smooth strong neg grog	5	awesome	Last Available: "2017-12"
 9582	flavorless half double fruitcake	4	decent	Last Available: "2017-12"
 9583	bland gigantic hushed puppy	6	decent	Last Available: "2017-12"
-9584	bland jumbo muffled muffuletta	5	decent	Last Available: "2017-12"
+9584	jumbo bland muffled muffuletta	5	decent	Last Available: "2017-12"
 9585	decent huge teal shushed potatoes	9	good	Last Available: "2017-12"
 9586	shellacked plastic mime functionary	0		Damage Reduction: 7, Last Available: "2017-12"
 9587	mirror flame-retardant plastic mime scientist	0		Hot Resistance: +1, Last Available: "2017-12"
@@ -9461,10 +9461,10 @@
 9589	spinning bouncing savvy plastic mime executive	0		Mysticality Percent: +20, Last Available: "2017-12"
 9590	blurry chilly plastic The Silent Nightmare	0		Cold Damage: +5, Last Available: "2017-12"
 9591	locked mumming trunk	0		Free Pull, Last Available: "2017-12"
-9592	blurry huge mumming trunk	0		Last Available: "2017-12"
+9592	huge blurry mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	super ultra EPIC	Last Available: "2017-11"
 9594	extra-oxidized concentrated wishbone	0		Effect: "Clean-Shaven", Effect Duration: 61, Last Available: "2017-11"
-9595	triple-distilled acceptable skewed Racisto Ruidoso	10	good	Last Available: "2017-11"
+9595	acceptable triple-distilled skewed Racisto Ruidoso	10	good	Last Available: "2017-11"
 9596	bouncing earthenware muffin tin	0		
 9597	toothsome bran muffin	4	awesome	
 9598	flavorless blinking blueberry muffin	4	decent	
@@ -9490,7 +9490,7 @@
 9618	silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
 9620	blurry silent V	0		Last Available: "2017-12"
-9621	narrow shaking yellow silent W	0		Last Available: "2017-12"
+9621	yellow narrow shaking silent W	0		Last Available: "2017-12"
 9622	blurry silent X	0		Last Available: "2017-12"
 9623	squat silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
@@ -9517,13 +9517,13 @@
 9645	narrow The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	weak tolerable ghostly executive mime flask	2	good	Last Available: "2017-12"
-9649	decent jumbo tumbling skewed nega-mushroom	5	good	Last Available: "2017-12"
+9648	tolerable weak ghostly executive mime flask	2	good	Last Available: "2017-12"
+9649	decent jumbo skewed tumbling nega-mushroom	5	good	Last Available: "2017-12"
 9650	tolerable yellow nega-mushroom wine	4	good	Last Available: "2017-12"
 9651	altered pickled oxidized shaking Cheer-Up soda	0		Effect: "Hare-o-dynamic", Effect Duration: 46, Last Available: "2017-12"
 9652	spoiled mime army rations	3	crappy	Last Available: "2017-12"
 9653	irresponsibly strong bad tumbling mime army wine	9	decent	Last Available: "2017-12"
-9654	boiled blinking wobbly mime army superserum	1		Last Available: "2017-12"
+9654	boiled wobbly blinking mime army superserum	1		Last Available: "2017-12"
 9655	alkaline mime army camouflage kit	0		Effect: "Conspiratory Eyes", Effect Duration: 63, Last Available: "2017-12"
 9656	family-friendly reassuring miming beret	0		Spooky Resistance: +1, Sleaze Resistance: +1, Last Available: "2017-12"
 9657	wobbly rosy-cheeked miming shirt of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	lime green donated candy	0		
 9665	electrified ionized digital honeypot	0		Effect: "The Grass...  Is Blue...", Effect Duration: 40, Last Available: "2025-12"
 9666	teal mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	ribald mime army insignia (infantry)	0		Sleaze Damage: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	wool mime army insignia (intelligence)	0		Cold Resistance: +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	chaotic mime army insignia (espionage)	0		Spell Critical Percent: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	ribald mime army insignia (infantry)	0		Sleaze Damage: +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	wool mime army insignia (intelligence)	0		Cold Resistance: +1, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	chaotic mime army insignia (espionage)	0		Spell Critical Percent: +10, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	skewed mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	narrow mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9570,7 +9570,7 @@
 9698	flattened alkaline hot button candy	0		Effect: "Bubblin' Rage", Effect Duration: 61
 9699	greasy ruddy makeshift garbage shirt of the detective	0		Maximum HP Percent: +40, Sleaze Spell Damage: +10, Item Drop: +20, Last Available: "2018-01"
 9700	squat miser's novelty monorail ticket of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +10
-9701	dried mirror wobbly olive pills	1		Effect: "Sweet Incentive", Effect Duration: 15
+9701	dried wobbly mirror olive pills	1		Effect: "Sweet Incentive", Effect Duration: 15
 9702	modified furry pill	1		
 9703	vaporized shaking beefy pill	1		Effect: "Human-Hobo Hybrid", Effect Duration: 25
 9704	dried excitement pill	1		Effect: "Hobonic", Effect Duration: 20
@@ -9592,12 +9592,12 @@
 9724	deadly psychic's crystal ball of the brazier	0		Weapon Damage: +5, Hot Spell Damage: +25, Last Available: "2018-02"
 9725	smooth psychic's pslacks of Tarzan	0		Moxie: +15, Experience (Muscle): +3, Last Available: "2018-02"
 9726	upside-down greedy medical-grade psychic's amulet	0		Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-02"
-9727	adequate small heart-shaped candy whetstone	2	good	Last Available: "2018-02"
-9728	small adequate Swedish massage fish	2	good	Last Available: "2018-02"
+9727	small adequate heart-shaped candy whetstone	2	good	Last Available: "2018-02"
+9728	adequate small Swedish massage fish	2	good	Last Available: "2018-02"
 9729	weak hand-crafted Third Base	2	EPIC	Last Available: "2018-02"
 9730	aged Bustle Hustler	3	awesome	Last Available: "2018-02"
 9731	tarnished dry Fabiotion	0		Effect: "Chock Full o' Nanites", Effect Duration: 30, Last Available: "2018-02"
-9732	polymerized non-denatured pulsating fuchsia Bettie page	0		Effect: "Cold Hands", Effect Duration: 65, Last Available: "2018-02"
+9732	polymerized non-denatured fuchsia pulsating Bettie page	0		Effect: "Cold Hands", Effect Duration: 65, Last Available: "2018-02"
 9733	diffused quadruple-colloidal tonic o' Banderas	0		Effect: "Soles of Glass", Effect Duration: 15, Last Available: "2018-02"
 9734	energized ionized cold-filtered squat heather graham cracker	0		Effect: "Ooh, Umami!", Effect Duration: 26, Last Available: "2018-02"
 9735	pulsating Lolsipop	0		Last Available: "2018-02"
@@ -9669,7 +9669,7 @@
 9801	Vulgure	0		Last Available: "2018-03"
 9802	Squib	0		Last Available: "2018-03"
 9803	pulsating Trafikoan	0		Last Available: "2018-03"
-9804	blue blinking wobbly Slotter	0		Last Available: "2018-03"
+9804	wobbly blue blinking Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
 9806	wobbly Glamare	0		Last Available: "2018-03"
 9807	wobbly Unspeakachu	0		Last Available: "2018-03"
@@ -9684,7 +9684,7 @@
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
 9818	Tapioc berry	0		Last Available: "2018-03"
-9819	maroon narrow Snarf berry	0		Last Available: "2018-03"
+9819	narrow maroon Snarf berry	0		Last Available: "2018-03"
 9820	mirror Keese berry	0		Last Available: "2018-03"
 9821	red luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9693,8 +9693,8 @@
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
-9828	boiled upside-down shaking magnificent oyster egg	1		
-9829	altered purple twirling brilliant oyster egg	1		
+9828	boiled shaking upside-down magnificent oyster egg	1		
+9829	altered twirling purple brilliant oyster egg	1		
 9830	compressed glistening oyster egg	1		
 9831	compressed olive scintillating oyster egg	1		
 9832	diluted pearlescent oyster egg	1		Effect: "Pygmy Drinking Buddy", Effect Duration: 5
@@ -9723,7 +9723,7 @@
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
 9857	moist pickled universal antivenin	0		Lasts Until Rollover, Effect: "Purpose", Effect Duration: 57, Last Available: "2018-04"
-9858	tumbling jittery LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
+9858	jittery tumbling LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	jittery LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	huge FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
@@ -9766,31 +9766,31 @@
 9898	lousy two meat muck	3	decent	
 9899	moldy chocolate Ogre Chieftain	4	crappy	
 9900	rotten wobbly chocolate &quot;Phoenix&quot;	3	crappy	
-9901	fancy spoiled half-sized narrow olive chocolate Spider Queen	2	crappy	Effect: "Bats in the Belfry", Effect Duration: 25
+9901	fancy spoiled half-sized olive narrow chocolate Spider Queen	2	crappy	Effect: "Bats in the Belfry", Effect Duration: 25
 9902	lousy bouncing bouncing hipster cocktail	3	decent	
-9903	wobbly God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	squat God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	jittery God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	mirror God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	blurry God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	wobbly God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	squat God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	jittery God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	mirror God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	blurry God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	purple Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	blinking G	0		
 9910	Garland of Greatness	0		
 9911	gattoo	0		
 9912	A-Boo glue	0		
-9913	tumbling blurry glued A-Boo clue	0		
-9914	spinning narrow crude oil congealer	0		
+9913	blurry tumbling glued A-Boo clue	0		
+9914	narrow spinning crude oil congealer	0		
 9915	spoiled good guava	4	crappy	
 9916	triple-distilled perfectly mixed gin and ginger	8	EPIC	
 9917	blurry Thwaitgold chigger statuette	0		
-9918	diluted skewed purple gaseous gravy	1		
+9918	diluted purple skewed gaseous gravy	1		
 9919	red ghostly SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	tumbling A Guide to Safari	0		Skill: "Experience Safari"
 9922	vacuum-sealed Shielding Potion	0		Effect: "Elvish", Effect Duration: 64, Last Available: "2018-06"
 9923	quadruple-magnetized Punching Potion	0		Effect: "Void Between the Stars", Effect Duration: 41, Last Available: "2018-06"
 9924	huge Special Seasoning	0		Last Available: "2018-06"
-9925	dried bouncing purple Nightmare Fuel	1		Last Available: "2018-06"
+9925	dried purple bouncing Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	fuchsia Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	huge Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9818,7 +9818,7 @@
 9950	lard-coated beefy pentagram bandana	0		Muscle: +10, Sleaze Spell Damage: +25, Last Available: "2018-09"
 9951	ghostly Jeselnik's skull ring	0		Sleaze Damage: +25, Single Equip, Last Available: "2018-09"
 9952	blue electronics kit	0		Last Available: "2018-09"
-9953	small special bland shaking PB&J with the crusts cut off	2	decent	Effect: "Hypercubed", Effect Duration: 15, Last Available: "2018-09"
+9953	bland special small shaking PB&J with the crusts cut off	2	decent	Effect: "Hypercubed", Effect Duration: 15, Last Available: "2018-09"
 9954	rock-hard grievous dorky glasses	0		Weapon Damage Percent: +50, Damage Reduction: 5, Single Equip, Last Available: "2018-09"
 9955	frightening sharpshooter's ponytail clip	0		Critical Hit Percent: +10, Spooky Damage: +5, Last Available: "2018-09"
 9956	nippy paint palette	0		Cold Damage: +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
@@ -9831,20 +9831,20 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	mirror upside-down Annie Oakley's noticeable pumps	0		Critical Hit Percent: +20, Item Drop: +5, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	tolerable high-proof everfull glass	7		Last Available: "2018-09"
+9966	high-proof tolerable everfull glass	7		Last Available: "2018-09"
 9967	squat van key	0		Last Available: "2018-09"
 9968	blurry jam band bootleg	0		Last Available: "2018-09"
 9969	narrow Newton's denim jacket of chilblains	0		Experience (Mysticality): +3, Cold Damage: +25, Last Available: "2018-09"
 9970	ratty knitted cap of James Dean of the overflowing toilet	0		Experience (Moxie): +3, Stench Spell Damage: +50, Last Available: "2018-09"
 9972	Usain Bolt's intimidating chainsaw of the cougar	0		Moxie: +20, Initiative: +80, Lasts Until Rollover, Last Available: "2018-09"
 9973	artisanal party beer bomb	4	EPIC	Last Available: "2018-09"
-9974	yummy blue ghostly sweet party mix	3	awesome	Last Available: "2018-09"
+9974	yummy ghostly blue sweet party mix	3	awesome	Last Available: "2018-09"
 9975	dried teal party balloon	1		Last Available: "2018-09"
 9976	sinister party pants of the storm	0		Spell Damage: +10, Maximum MP Percent: +40, Last Available: "2018-09"
 9977	wobbly dog trainer's manspreader's hardened party whip	0		Damage Reduction: 3, Monster Level: +10, Experience (familiar): +1, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	perfectly mixed special watered-down TRIO cup of beer	2	EPIC	Effect: "Physicali Tea", Effect Duration: 30, Last Available: "2018-09"
-9980	adequate low-calorie party platter for one	1	good	Last Available: "2018-09"
+9979	watered-down perfectly mixed special TRIO cup of beer	2	EPIC	Effect: "Physicali Tea", Effect Duration: 30, Last Available: "2018-09"
+9980	low-calorie adequate party platter for one	1	good	Last Available: "2018-09"
 9981	modified maroon Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	frightening party crasher of incineration	0		Hot Spell Damage: +50, Spooky Damage: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
@@ -9874,16 +9874,16 @@
 10008	tumbling tumbling lard-coated steel-toed smartaleck's mutant legs	0		Moxie Percent: +30, Damage Reduction: 9, Sleaze Spell Damage: +25, Last Available: "2018-11"
 10009	spinning mutant crown of the brute of Gandalf of doom	0		Muscle Percent: +30, Spell Critical Percent: +20, Spooky Spell Damage: +50, Last Available: "2018-11"
 10010	miniature rotten squat ghostly ectoplasm	2	crappy	Last Available: "2018-11"
-10011	moldy snack-sized	2	crappy	Last Available: "2018-11"
+10011	snack-sized moldy	2	crappy	Last Available: "2018-11"
 10012	hand-crafted bottle of vodka	4	EPIC	Last Available: "2018-11"
 10013	flavorless pizza	4	decent	Last Available: "2018-11"
 10014	acceptable martini	4	good	Last Available: "2018-11"
 10015	bland cherry pie	3	decent	Last Available: "2018-11"
-10016	practically non-alcoholic drinkable eggnog	1	good	Last Available: "2018-11"
+10016	drinkable practically non-alcoholic eggnog	1	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	spoiled gigantic Hell ramen	9	crappy	Last Available: "2018-11"
+10018	gigantic spoiled Hell ramen	9	crappy	Last Available: "2018-11"
 10019	aged maroon gimlet	4	awesome	Last Available: "2018-11"
-10020	tolerable high-proof twice-haunted screwdriver	8	good	Last Available: "2018-11"
+10020	high-proof tolerable twice-haunted screwdriver	8	good	Last Available: "2018-11"
 10021	spoiled candy cane	3	crappy	Last Available: "2018-12"
 10022	irresponsibly strong acceptable runny fermented egg	9	good	Last Available: "2018-12"
 10023	moldy oldcake	3	crappy	Last Available: "2018-12"
@@ -9902,12 +9902,12 @@
 10036	bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	wobbly red mooseflank	0		Last Available: "2018-12"
-10039	snack-sized decent grilled mooseflank	2	good	Last Available: "2018-12"
+10039	decent snack-sized grilled mooseflank	2	good	Last Available: "2018-12"
 10040	miniature delicious moosemeat pie	2	awesome	Last Available: "2018-12"
 10041	skewed stylish balanced antler	0		Moxie: +25, Last Available: "2018-12"
 10042	manspreader's dam	0		Monster Level: +10, Damage Reduction: 9, Last Available: "2018-12"
 10043	mediocre weak beavermouth	2	decent	Last Available: "2018-12"
-10044	practically non-alcoholic delicious blinking beaver punch (papaya)	1	awesome	Last Available: "2018-12"
+10044	delicious practically non-alcoholic blinking beaver punch (papaya)	1	awesome	Last Available: "2018-12"
 10045	hand-crafted beaver punch (peach)	4	EPIC	Last Available: "2018-12"
 10046	mediocre beaver punch (cherry)	4	decent	Last Available: "2018-12"
 10047	frightening manspreader's Canadian lantern	0		Monster Level: +10, Spooky Damage: +5, Last Available: "2018-12"
@@ -9922,7 +9922,7 @@
 10056	skewed Boxing Day Pass	0		Last Available: "2018-12"
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	auspicious friendly arcane researcher's Kramco Sausage-o-Matic&trade; of the brute of courage	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Familiar Weight: +3, Spooky Resistance: +3, Item Drop: +10, Last Available: "2019-01"
-10059	red blinking sausage casing	0		Last Available: "2019-01"
+10059	blinking red sausage casing	0		Last Available: "2019-01"
 10060	tasty sausage	3	awesome	Last Available: "2019-01"
 10061	spinning MacGyver's red-hot sausage fork of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Last Available: "2019-01"
 10062	skewed bag of sausage links	0		Last Available: "2019-01"
@@ -9938,12 +9938,12 @@
 10072	Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	squat twirling Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10075	narrow bouncing Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10075	bouncing narrow Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10077	Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	greedy auspicious Jim Carey's Crimbolex watch	0		Monster Level: +25, Item Drop: +10, Meat Drop: +20, Single Equip, Last Available: "2018-12"
-10080	blue twirling Crimbo tattoo kit	0		Last Available: "2018-12"
+10080	twirling blue Crimbo tattoo kit	0		Last Available: "2018-12"
 10081	steel-toed Rosewater's hand-knitted Crimbo socks of incineration	0		Mysticality Percent: +30, Damage Reduction: 9, Hot Spell Damage: +50
 10082	jittery scandalous manspreader's chalk chlamys	0		Monster Level: +10, Sleaze Damage: +5, Last Available: "2019-12"
 10083	stanky dangerous chalk chain	0		Weapon Damage: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	tumbling sew-on bandage	0		Last Available: "2019-12"
 10153	spinning blinking really nice net	0		Last Available: "2019-12"
 10154	elf army poncho of incineration	0		Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2019-12"
-10155	bland purple narrow elf army field rations	4	decent	Last Available: "2019-12"
+10155	bland narrow purple elf army field rations	4	decent	Last Available: "2019-12"
 10156	blinking gingernade	0		Last Available: "2019-12"
 10157	bouncing spinning scandalous discarded bowtie of the businessman	0		Sleaze Damage: +5, Meat Drop: +50, Lasts Until Rollover, Last Available: "2019-12"
 10158	lousy jittery martiny	3	decent	Last Available: "2019-12"
@@ -10032,14 +10032,14 @@
 10166	baleful Da Vinci's Lil' Doctor&trade; bag	0		Experience (Mysticality): +5, Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	adequate bloodstick	4	good	
-10170	mediocre watered-down bottle of Sanguiovese	2	decent	
-10171	enchanted miniature bland actual blood sausage	2	decent	Effect: "Shawarma Initiative", Effect Duration: 25
-10172	watered-down perfectly mixed blurry mulled blood	2	super EPIC	
+10170	watered-down mediocre bottle of Sanguiovese	2	decent	
+10171	enchanted bland miniature actual blood sausage	2	decent	Effect: "Shawarma Initiative", Effect Duration: 25
+10172	perfectly mixed watered-down blurry mulled blood	2	super EPIC	
 10173	adequate bite-sized blood snowcone	1	good	
-10174	bad irresponsibly strong blinking narrow Red Russian	6	decent	
-10175	decent immense blood roll-up	10	good	
+10174	bad irresponsibly strong narrow blinking Red Russian	6	decent	
+10175	immense decent blood roll-up	10	good	
 10176	bad bottle of blood	4	decent	
-10177	huge spoiled blood-soaked sponge cake	6	crappy	
+10177	spoiled huge blood-soaked sponge cake	6	crappy	
 10178	hand-crafted watered-down vampagne	2	super ultra mega turbo EPIC	
 10179	delicious mirror plain snowcone	3	awesome	
 10180	jittery Booke of Vampyric Knowledge	0		
@@ -10059,11 +10059,11 @@
 10194	Red Roger's flag	0		Lasts Until Rollover, Last Available: "2019-04"
 10195	mirror Glass Jack's spyglass	0		Lasts Until Rollover, Last Available: "2019-04"
 10196	yellow recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
-10197	yellow upside-down tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
+10197	upside-down yellow tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	blurry huge Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	low-calorie rotten squat crabsicle	1	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	perfectly mixed extra-dry bottle of dark rhum	5	EPIC	Last Available: "2019-04"
+10201	extra-dry perfectly mixed bottle of dark rhum	5	EPIC	Last Available: "2019-04"
 10202	lousy bottle of extra-dark rhum	4	decent	Last Available: "2019-04"
 10203	bad bottle of super-extra-dark rhum	3	decent	Last Available: "2019-04"
 10204	cold-filtered pirate shaving cream	0		Effect: "Norwhalloped", Effect Duration: 51, Last Available: "2019-04"
@@ -10071,7 +10071,7 @@
 10206	Rosewater's pirate pantaloons of the scaredy-cat	0		Mysticality Percent: +30, Monster Level: -15, Last Available: "2019-04"
 10207	[glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
-10209	wobbly tumbling windicle	0		Last Available: "2019-04"
+10209	tumbling wobbly windicle	0		Last Available: "2019-04"
 10210	foul-smelling pirate radio ring of the sewer	0		Stench Damage: 35, Single Equip, Last Available: "2019-04"
 10211	tumbling Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	massive bland spinning pineapple slab	6	decent	Last Available: "2019-04"
@@ -10082,7 +10082,7 @@
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	ghostly teal Red Roger's left hand	0		Last Available: "2019-04"
-10220	green huge Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10220	huge green Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	cyan Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	tumbling Red Roger's skull	0		Last Available: "2019-04"
 10223	denatured jittery twirling pewter shavings	1		Effect: "Yuletide Mutations", Effect Duration: 45, Last Available: "2019-04"
@@ -10096,12 +10096,12 @@
 10231	reassuring occult dance instructor's PirateRealm party hat	0		Experience Percent (Moxie): +10, Spell Damage Percent: +25, Spooky Resistance: +1, Last Available: "2019-04"
 10232	lousy wobbly Island Landslide	4	decent	Last Available: "2019-04"
 10233	artisanal watered-down cyan Island Thunderstorm	2	super EPIC	Last Available: "2019-04"
-10234	watered-down artisanal Island Hurricane	2	super EPIC	Last Available: "2019-04"
-10235	hand-crafted boozy Skull Punch	5	EPIC	Last Available: "2019-04"
-10236	high-proof artisanal Electric Punch	7	EPIC	Last Available: "2019-04"
+10234	artisanal watered-down Island Hurricane	2	super EPIC	Last Available: "2019-04"
+10235	boozy hand-crafted Skull Punch	5	EPIC	Last Available: "2019-04"
+10236	artisanal high-proof Electric Punch	7	EPIC	Last Available: "2019-04"
 10237	tolerable Smuggler's Punch	3	good	Last Available: "2019-04"
 10238	lousy narrow Scorpion Bowl	3	decent	Last Available: "2019-04"
-10239	bad high-proof Turtle Bowl	6	decent	Last Available: "2019-04"
+10239	high-proof bad Turtle Bowl	6	decent	Last Available: "2019-04"
 10240	weak tolerable Cobra Bowl	2	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	fuchsia skewed stanky rosy-cheeked Newton's stylish vampyric cloake of vim and vigor	0		Moxie: +25, Experience (Mysticality): +3, Maximum HP Percent: 80, Stench Spell Damage: +25, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
@@ -10122,7 +10122,7 @@
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	Usain Bolt's double-paned Beach Comb of Flo-Jo	0		Cold Resistance: +5, Initiative: 180, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
-10260	upside-down blue small pile of sand	0		Last Available: "2019-07"
+10260	blue upside-down small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
@@ -10131,10 +10131,10 @@
 10266	dry activated magenta seashell	0		Effect: "Flambé-a-thon", Effect Duration: 64, Last Available: "2019-07"
 10267	altered wobbly cyan seashell	0		Effect: "Twinklebritches", Effect Duration: 48, Last Available: "2019-07"
 10268	activated gray seashell	0		Effect: "Engorged Weapon", Effect Duration: 48, Last Available: "2019-07"
-10269	energized mirror squat seashell	0		Effect: "Hoity Toity", Effect Duration: 48, Last Available: "2019-07"
+10269	energized squat mirror seashell	0		Effect: "Hoity Toity", Effect Duration: 48, Last Available: "2019-07"
 10270	pressed mirror seashell	0		Effect: "Punch Another Day", Effect Duration: 26, Last Available: "2019-07"
 10271	jittery bunch of sea grapes	0		Last Available: "2019-07"
-10272	mediocre weak blinking bottle of sea wine	2	decent	Last Available: "2019-07"
+10272	weak mediocre blinking bottle of sea wine	2	decent	Last Available: "2019-07"
 10273	mixed bouncing kelp	1		Last Available: "2019-07"
 10274	pulsating flame-retardant smelly clever medical-grade ruddy razor-sharp experienced supercool brawny driftwood hat	0		Muscle Percent: +20, Moxie Percent: +20, Experience: +2, Weapon Damage Percent: +25, Maximum HP Percent: +40, Maximum MP: +20, Stench Spell Damage: +10, Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10275	tumbling tumbling green lightning-fast lard-coated foul-smelling Van der Graaf crafty energetic stiffened wicked driftwood pants of the pedagogue	0		Experience: +3, Spell Damage: +5, Damage Reduction: 1, Maximum MP Percent: +20, Maximum MP: +10, Stench Damage: +10, Sleaze Spell Damage: +25, Initiative: +40, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2019-07"
@@ -10166,16 +10166,16 @@
 10301	narrow spinning careful resourceful supercharged whittled fox figurine	0		Maximum MP Percent: +30, Maximum MP: +50, Monster Level: -10, Single Equip, Last Available: "2019-08"
 10302	ribald toasty sharpshooter's resourceful whittled walking stick	0		Maximum MP: +50, Critical Hit Percent: +10, Hot Damage: +5, Sleaze Damage: +10, Last Available: "2019-08"
 10303	normal campfire hot dog	3	good	Last Available: "2019-08"
-10304	miniature adequate upside-down narrow campfire baked potato	2	good	Last Available: "2019-08"
-10305	thick moldy campfire s'more	5	crappy	Last Available: "2019-08"
+10304	miniature adequate narrow upside-down campfire baked potato	2	good	Last Available: "2019-08"
+10305	moldy thick campfire s'more	5	crappy	Last Available: "2019-08"
 10306	decent small jittery campfire beans	2	good	Last Available: "2019-08"
-10307	decent immense skewed campfire stew	9	good	Last Available: "2019-08"
+10307	immense decent skewed campfire stew	9	good	Last Available: "2019-08"
 10308	cyan campfire coffee	1	awesome	Last Available: "2019-08"
 10309	colloidal blurry leftover chocolate bar	0		Effect: "Weird Vibrations", Effect Duration: 40
 10310	cyan rare Meat isotope	0		
 10311	skewed blue burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
-10313	wobbly green campfire smoke	0		
+10313	green wobbly campfire smoke	0		
 10314	Murgatroyd diode	0		
 10315	signal receiver	0		
 10316	space shield	0		Damage Reduction: 9
@@ -10183,7 +10183,7 @@
 10318	ghostly low-pressure oxygen tank	0		Single Equip
 10319	lime green Thwaitgold bombardier beetle statuette	0		
 10320	tasty space chowder	4	awesome	
-10321	special bad space wine	4	decent	Effect: "Smelly Pants", Effect Duration: 10
+10321	bad special space wine	4	decent	Effect: "Smelly Pants", Effect Duration: 10
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	purple packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10195,17 +10195,17 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	small adequate green bu&ntilde;uelos Jaliscos	2	good	Last Available: "2019-12"
 10338	flavorless flan del mar	3	decent	Last Available: "2019-12"
-10339	special bite-sized tasty Baja sopapilla	1	awesome	Effect: "Jerky, Boy", Effect Duration: 10, Last Available: "2019-12"
+10339	tasty special bite-sized Baja sopapilla	1	awesome	Effect: "Jerky, Boy", Effect Duration: 10, Last Available: "2019-12"
 10340	hardened plastic Mer-kin baker	0		Damage Reduction: 3, Last Available: "2019-12"
 10341	fireproof plastic sea elf	0		Hot Resistance: +3, Last Available: "2019-12"
 10342	horrifying plastic yuleviathan	0		Spooky Damage: +25, Last Available: "2019-12"
 10343	flame-retardant plastic dolphin &quot;orphan&quot;	0		Hot Resistance: +1, Single Equip, Last Available: "2019-12"
 10344	deadly plastic Dolph Bossin	0		Weapon Damage: +5, Last Available: "2019-12"
 10345	squat red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	rotten thick skewed mana-coated yams	5	crappy	Last Available: "2019-11"
+10346	thick rotten skewed mana-coated yams	5	crappy	Last Available: "2019-11"
 10347	snack-sized adequate mana-basted tofurkey leg	2	good	Last Available: "2019-11"
 10348	spoiled special mana-fortified cranberry sauce	3	crappy	Effect: "Stinky Weapon", Effect Duration: 45, Last Available: "2019-11"
-10349	flavorless fancy gray mana-stuffed herbal stuffing	4	decent	Effect: "Super Vision", Effect Duration: 15, Last Available: "2019-11"
+10349	fancy flavorless gray mana-stuffed herbal stuffing	4	decent	Effect: "Super Vision", Effect Duration: 15, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	cold-filtered altered blurry patch of extra-warm fur	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 51, Last Available: "2019-12"
 10352	powdered upside-down industrial lubricant	1		Last Available: "2019-12"
@@ -10225,7 +10225,7 @@
 10366	tarnished triple-quantum wet Mer-kin eyedrops	0		Effect: "Okee-Dokee Computer", Effect Duration: 25, Last Available: "2019-12"
 10367	oxidized activated energized extra-strength goo	0		Effect: "Human-Elf Hybrid", Effect Duration: 13, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
-10369	modified ghostly skewed livid energy	1		Effect: "Livin' Large", Effect Duration: 45, Last Available: "2019-12"
+10369	modified skewed ghostly livid energy	1		Effect: "Livin' Large", Effect Duration: 45, Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
 10371	twisted fuchsia beggin' cologne	1		Last Available: "2019-12"
 10372	thinker's oxygenated eggnog helmet of the storm	0		Mysticality: +10, Maximum MP Percent: +40, Adventure Underwater, Last Available: "2019-12"
@@ -10253,9 +10253,9 @@
 10394	wizardly Mer-kin rollpin of Flo-Jo	0		Mysticality: +25, Initiative: +100, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	mirror tinsel fin	0		Familiar Weight: +5
-10397	half-sized spoiled mirror bowl of mernudo	2	crappy	Last Available: "2019-12"
+10397	spoiled half-sized mirror bowl of mernudo	2	crappy	Last Available: "2019-12"
 10398	lousy fishelada	4	decent	Last Available: "2019-12"
-10399	tiny adequate pulsating ojo de pez burrito	1	good	Last Available: "2019-12"
+10399	adequate tiny pulsating ojo de pez burrito	1	good	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	scorching nutcracker cape of the cheetah	0		Hot Damage: +25, Initiative: +60, Last Available: "2019-12"
 10413	yellow greasy razor-sharp nutcracker epaulets	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10, Single Equip, Last Available: "2019-12"
 10414	lime green nutcracker figurine	0		Last Available: "2019-12"
-10415	jumbo flavorless salt plum	5	decent	Last Available: "2019-12"
+10415	flavorless jumbo salt plum	5	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	spoiled gigantic and bean	9	crappy	Last Available: "2019-12"
 10418	mirror Temple Grandin's kelp-holly gun of Gandalf of the boozehound	0		Spell Critical Percent: +20, Familiar Weight: +7, Booze Drop: +100, Last Available: "2019-12"
@@ -10283,7 +10283,7 @@
 10424	clever crafty savvy Staff of the Peppermint Twist of the detective	0		Mysticality Percent: +20, Maximum MP: 30, Item Drop: +20, Last Available: "2019-12"
 10425	flavorless tempura and bean	3	decent	Last Available: "2019-12"
 10426	triple-distilled artisanal salt plum sake	6	EPIC	Last Available: "2019-12"
-10427	quadruple-alkaline pulsating teal pressurized potion of possessiveness	0		Effect: "meat.enh", Effect Duration: 69, Last Available: "2019-12"
+10427	quadruple-alkaline teal pulsating pressurized potion of possessiveness	0		Effect: "meat.enh", Effect Duration: 69, Last Available: "2019-12"
 10428	extra-quantum oxidized shaking almond	0		Effect: "[1701]Hip to the Jive", Effect Duration: 49
 10429	quadruple-cold-filtered vacuum-sealed handful of mixed nuts	0		Effect: "Bats in the Belfry", Effect Duration: 25, Last Available: "2019-12"
 10430	nutcracking pliers	0		
@@ -10318,7 +10318,7 @@
 10461	hammer	0		
 10462	tumbling ghostly fire flower	0		
 10463	shaking bonfire flower	0		
-10464	maroon blinking work boots	0		Single Equip
+10464	blinking maroon work boots	0		Single Equip
 10465	boots	0		Single Equip
 10466	prompt cape	0		Adventures: +3
 10467	red censurious wicked back shell	0		Spell Damage: +5, Sleaze Resistance: +3
@@ -10373,7 +10373,7 @@
 10516	drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	ghostly drippy ichor	0		
-10519	narrow olive drippy enzyme	0		
+10519	olive narrow drippy enzyme	0		
 10520	drippy salt	0		
 10521	drippy pigment	0		
 10522	drippy bromide	0		
@@ -10394,11 +10394,11 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	wool Guzzlr souvenir stein	0		Cold Resistance: +1, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	enchanted watered-down drinkable skewed Ghiaccio Colada	2	good	Effect: "Shamboozled", Effect Duration: 40, Last Available: "2020-05"
-10542	weak acceptable huge green Sourfinger	2	good	Last Available: "2020-05"
-10543	irresponsibly strong special artisanal shaking Nog-on-the-Cob	10	EPIC	Effect: "Egged On", Effect Duration: 20, Last Available: "2020-05"
+10541	enchanted drinkable watered-down skewed Ghiaccio Colada	2	good	Effect: "Shamboozled", Effect Duration: 40, Last Available: "2020-05"
+10542	acceptable weak huge green Sourfinger	2	good	Last Available: "2020-05"
+10543	artisanal irresponsibly strong special shaking Nog-on-the-Cob	10	EPIC	Effect: "Egged On", Effect Duration: 20, Last Available: "2020-05"
 10544	hand-crafted weak Steamboat	2	EPIC	Last Available: "2020-05"
-10545	irresponsibly strong lousy cyan Buttery Boy	10	decent	Last Available: "2020-05"
+10545	lousy irresponsibly strong cyan Buttery Boy	10	decent	Last Available: "2020-05"
 10546	blinking Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	fuchsia clown car key of the brute of Calamity Jane	0		Muscle Percent: +30, Critical Hit Percent: +15, Last Available: "2020-08"
 10548	auspicious personal trainer's batting cage key of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Item Drop: +10, Last Available: "2020-08"
@@ -10457,12 +10457,12 @@
 10601	Thwaitgold slug statuette	0		
 10602	mirror coward's ert grey goo ring	0		Monster Level: -20
 10603	fistful of wood shavings	0		
-10604	shaking blinking Yeg's Motel ashtray	0		Last Available: "2020-09"
+10604	blinking shaking Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	double-magnetized improved triple-nitrogenated Yeg's Motel toothbrush	0		Effect: "Spooky Jellied", Effect Duration: 32, Last Available: "2020-09"
 10607	quadruple-dry boiled alkaline Yeg's Motel hand soap	0		Effect: "Bestial Sympathy", Effect Duration: 12, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	massive flavorless huge pulsating Yeg's Motel pillow mint	9	decent	Last Available: "2020-09"
+10609	flavorless massive huge pulsating Yeg's Motel pillow mint	9	decent	Last Available: "2020-09"
 10610	jittery Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	unsweetened galvanized flattened Yeg's Motel mouthwash	0		Effect: "Your Favorite Flavor", Effect Duration: 47, Last Available: "2020-09"
 10612	blurry toasty Yeg's Motel shower cap of the cougar	0		Moxie: +20, Hot Damage: +5, Lasts Until Rollover, Last Available: "2020-09"
@@ -10475,7 +10475,7 @@
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	bouncing jittery nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
-10622	skewed shaking maroon chess set	0		Last Available: "2020-09"
+10622	maroon skewed shaking chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
@@ -10491,11 +10491,11 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	forbidden occult boxer's Cargo Cultist Shorts of the overflowing toilet	0		Muscle Percent: +10, Spell Damage Percent: 75, Stench Spell Damage: +50, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	perfectly mixed weak flask of moonshine	2	EPIC	Last Available: "2020-09"
+10638	weak perfectly mixed flask of moonshine	2	EPIC	Last Available: "2020-09"
 10639	double-paned electrified sinister sea-worn candlestick	0		Spell Damage: +10, Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-09"
 10640	blinking Universal Seasoning	0		
 10641	liquefied null-day exploit	0		Effect: "Action", Effect Duration: 52, Last Available: "2025-12"
-10642	lime green skewed flame orb	0		Last Available: "2020-09"
+10642	skewed lime green flame orb	0		Last Available: "2020-09"
 10643	jumbo flavorless spinning chocolate chip muffin	5	decent	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
@@ -10503,7 +10503,7 @@
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	pulsating gregarious ghostling	0		Free Pull, Last Available: "2020-12"
-10650	teal wobbly grinning ghostling	0		Free Pull, Last Available: "2020-12"
+10650	wobbly teal grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	blinking greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	shaking subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	quadruple-dry anodized fortifying hot cocoa	0		Effect: "Ooh, Sour!", Effect Duration: 37, Last Available: "2020-12"
@@ -10516,7 +10516,7 @@
 10660	cyan supercool Crimbo smile	0		Moxie Percent: [+20*event(December)], Last Available: "2020-12"
 10661	mirror prompt SalesCo sample kit	0		Adventures: [+3*event(December)], Last Available: "2020-12"
 10662	concentrated pulsating candy harmonica	0		Effect: "Melancholy Burden", Effect Duration: 40, Last Available: "2020-12"
-10663	double-nitrogenated squat purple shaking sugar	0		Effect: "Spiritually Awake", Effect Duration: 33, Last Available: "2020-12"
+10663	double-nitrogenated shaking squat purple sugar	0		Effect: "Spiritually Awake", Effect Duration: 33, Last Available: "2020-12"
 10664	non-activated alkaline multi-level marzipan	0		Effect: "You Know When to Walk Away", Effect Duration: 18, Last Available: "2020-12"
 10665	occult plastic Crimbo caroler	0		Spell Damage Percent: +25, Last Available: "2020-12"
 10666	plastic multi-level marketer of the detective	0		Item Drop: +20, Last Available: "2020-12"
@@ -10556,7 +10556,7 @@
 10700	curative hardy Satan hat	0		Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5, Class: "Sauceror", Last Available: "2020-12"
 10701	purple supercool Crimbo stockings of James Dean	0		Moxie Percent: +20, Experience (Moxie): +3, Class: "Disco Bandit", Last Available: "2020-12"
 10702	Jack Frost's poncho de azucar of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Class: "Accordion Thief", Last Available: "2020-12"
-10703	gray ghostly The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
+10703	ghostly gray The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10705	The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10706	lime green The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
@@ -10573,13 +10573,13 @@
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	jittery goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	perfectly mixed fancy tumbling barrel-aged eggnog	3	EPIC	Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2020-12"
-10721	jumbo rotten spinning mirror hand-crafted candy cane	5	crappy	Last Available: "2020-12"
-10722	rotten low-calorie special drive-thru burger	1	crappy	Effect: "Briny Blood", Effect Duration: 30, Last Available: "2020-12"
+10720	fancy perfectly mixed tumbling barrel-aged eggnog	3	EPIC	Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2020-12"
+10721	rotten jumbo mirror spinning hand-crafted candy cane	5	crappy	Last Available: "2020-12"
+10722	low-calorie rotten special drive-thru burger	1	crappy	Effect: "Briny Blood", Effect Duration: 30, Last Available: "2020-12"
 10723	bad Boulevardier cocktail	3	decent	Last Available: "2020-12"
 10724	boiled tumbling Hotwire&trade; brand candy rope	0		Effect: "Incredibly Hulking", Effect Duration: 27, Last Available: "2020-12"
 10725	stale purple bowl full of jelly	3	decent	Last Available: "2020-12"
-10726	practically non-alcoholic acceptable jittery Eye and a Twist	1	good	Last Available: "2020-12"
+10726	acceptable practically non-alcoholic jittery Eye and a Twist	1	good	Last Available: "2020-12"
 10727	unsweetened red Chubby and Plump bar	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 64, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10595,12 +10595,12 @@
 10739	pressed battery (AAA)	0		Effect: "Surreally Buff", Effect Duration: 49, Last Available: "2021-03"
 10740	modified oxidized squat battery (AA)	0		Effect: "Pronounced Potency", Effect Duration: 17, Last Available: "2021-03"
 10741	enhanced non-ionized blurry battery (D)	0		Effect: "Big Punkin'", Effect Duration: 30, Last Available: "2021-03"
-10742	polymerized skewed fuchsia bouncing battery (9-Volt)	0		Effect: "Adorable Lookout", Effect Duration: 15, Last Available: "2021-03"
+10742	polymerized bouncing skewed fuchsia battery (9-Volt)	0		Effect: "Adorable Lookout", Effect Duration: 15, Last Available: "2021-03"
 10743	moist tumbling battery (lantern)	0		Effect: "Updated", Effect Duration: 40, Last Available: "2021-03"
 10744	triple-alkaline lime green battery (car)	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 28, Last Available: "2021-03"
-10745	skewed blinking cryptocloak	0		Last Available: "2025-12"
+10745	blinking skewed cryptocloak	0		Last Available: "2025-12"
 10746	olive marshmallow	0		
-10747	high-proof perfectly mixed marshmallow bomb	9	EPIC	Last Available: "2021-03"
+10747	perfectly mixed high-proof marshmallow bomb	9	EPIC	Last Available: "2021-03"
 10748	ghostly packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
@@ -10631,13 +10631,13 @@
 10775	altered modified modified gray The Beast Within&trade; candle	0		Effect: "Melancholy Burden", Effect Duration: 69, Last Available: "2021-08"
 10776	super-colloidal liquefied narrow Salsa Caliente&trade; candle	0		Effect: "Disdain of She-Who-Was", Effect Duration: 45, Last Available: "2021-08"
 10777	moist Smoldering Clover&trade; candle	0		Effect: "Unusual Perspective", Effect Duration: 49, Last Available: "2021-08"
-10778	wet activated skewed maroon Napalm In The Morning&trade; candle	0		Effect: "Creepin' Up on You", Effect Duration: 57, Last Available: "2021-08"
+10778	wet activated maroon skewed Napalm In The Morning&trade; candle	0		Effect: "Creepin' Up on You", Effect Duration: 57, Last Available: "2021-08"
 10779	aromatic deadly extra-large utility candle	0		Weapon Damage: +5, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
 10780	reassuring boxer's runed taper candle	0		Muscle Percent: +10, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
 10781	nasty sinister novelty sparkling candle of Leguizamo	0		Spell Damage: +10, Monster Level: +20, Stench Damage: +5, Lasts Until Rollover, Last Available: "2021-08"
 10782	huge chilly Oprah's Abracandalabra	0		Maximum MP Percent: +50, Cold Damage: +5, Lasts Until Rollover, Last Available: "2021-08"
 10783	aromatic chilly extra-wide head candle	0		Cold Damage: +5, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
-10784	warmed pulsating tumbling natural magick candle	0		Effect: "Feroci Tea", Effect Duration: 35, Last Available: "2021-08"
+10784	warmed tumbling pulsating natural magick candle	0		Effect: "Feroci Tea", Effect Duration: 35, Last Available: "2021-08"
 10785	quantum denatured rainbow glitter candle	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 28, Last Available: "2021-08"
 10786	alkaline ionized banana candle	0		Effect: "Pyramid Power", Effect Duration: 48, Last Available: "2021-08"
 10787	polarized super-aerosolized lime green ear candle	0		Effect: "Empathy", Effect Duration: 63, Last Available: "2021-08"
@@ -10659,7 +10659,7 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	spinning blinking greedy energetic hardened Daylight Shavings Helmet	0		Damage Reduction: 3, Maximum MP Percent: +20, Meat Drop: +20, Last Available: "2021-11"
 10805	eggwater	1	good	Last Available: "2021-12"
-10806	half-sized stale twirling bread man	2	decent	Last Available: "2021-12"
+10806	stale half-sized twirling bread man	2	decent	Last Available: "2021-12"
 10807	stale plain candy cane	3	decent	Last Available: "2021-12"
 10808	immense moldy flour cookie	8	crappy	Last Available: "2021-12"
 10809	sage plastic food lab	0		Mysticality Percent: +10, Single Equip, Last Available: "2021-12"
@@ -10668,15 +10668,15 @@
 10812	plastic primary lab of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2021-12"
 10813	shaking dangerous plastic Cheer Core	0		Weapon Damage: +10, Single Equip, Last Available: "2021-12"
 10814	jittery packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
-10815	huge squat medicine cabinet	0		Last Available: "2021-12"
+10815	squat huge medicine cabinet	0		Last Available: "2021-12"
 10816	Newton's groovy ice crown of courage	0		Moxie Percent: +10, Experience (Mysticality): +3, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2021-12"
 10817	aromatic occult savvy jeans	0		Mysticality Percent: +20, Spell Damage Percent: +25, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2021-12"
 10818	wobbly Herculean ice wrap of the wise owl of the businessman	0		Mysticality: +20, Experience (Muscle): +1, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	tasty red tofu pop	4	awesome	Last Available: "2021-12"
 10820	half-sized spoiled twirling bowl of prescription candy	2	crappy	Last Available: "2021-12"
-10821	spoiled thick fishcake	5	crappy	Last Available: "2021-12"
-10822	small enchanted rotten teal bone broth	2	crappy	Effect: "Slime Time", Effect Duration: 30, Last Available: "2021-12"
-10823	diet spoiled star pop	1	crappy	Last Available: "2021-12"
+10821	thick spoiled fishcake	5	crappy	Last Available: "2021-12"
+10822	rotten small enchanted teal bone broth	2	crappy	Effect: "Slime Time", Effect Duration: 30, Last Available: "2021-12"
+10823	spoiled diet star pop	1	crappy	Last Available: "2021-12"
 10824	hand-crafted weak Doc's Fortifying Wine	2	EPIC	Last Available: "2021-12"
 10825	mediocre Doc's Smartifying Wine	3	decent	Last Available: "2021-12"
 10826	drinkable wobbly Doc's Limbering Wine	4	good	Last Available: "2021-12"
@@ -10685,15 +10685,15 @@
 10829	pickled twirling Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	modified cyan Breathitin&trade;	1		Last Available: "2021-12"
 10831	altered pulsating Fleshazole&trade;	1		Effect: "Sticky Fingers", Effect Duration: 15, Last Available: "2021-12"
-10832	warmed double-colloidal triple-ionized olive shaking anti-burn cream	0		Effect: "Vitali Tea", Effect Duration: 22, Last Available: "2021-12"
+10832	warmed double-colloidal triple-ionized shaking olive anti-burn cream	0		Effect: "Vitali Tea", Effect Duration: 22, Last Available: "2021-12"
 10833	enhanced pressed anti-freeze cream	0		Effect: "Squirming Like a Toad", Effect Duration: 42, Last Available: "2021-12"
-10834	enhanced red squat jittery anti-goosebump cream	0		Effect: "Boilermade", Effect Duration: 43, Last Available: "2021-12"
+10834	enhanced jittery squat red anti-goosebump cream	0		Effect: "Boilermade", Effect Duration: 43, Last Available: "2021-12"
 10835	activated anti-odor cream	0		Effect: "Intimidating Mien", Effect Duration: 59, Last Available: "2021-12"
 10836	concentrated unsweetened anti-creep cream	0		Effect: "Egg-stra Arm", Effect Duration: 33, Last Available: "2021-12"
 10837	dry tumbling anti-pain cream	0		Effect: "Human-Slime Hybrid", Effect Duration: 37, Last Available: "2021-12"
 10838	tolerable blinking Doc's Special Reserve Wine	4	good	Last Available: "2021-12"
 10839	immense stale enchanted bread pie	6	decent	Effect: "The Power of LOV", Effect Duration: 10, Last Available: "2021-12"
-10840	weak delicious clear Russian	2	awesome	Last Available: "2021-12"
+10840	delicious weak clear Russian	2	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	occult educational can of mixed everything of mayonnaise	0		Experience: +1, Spell Damage Percent: +25, Sleaze Spell Damage: +50, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	special snack-sized yummy meatball	2	awesome	Effect: "Employee of the Month", Effect Duration: 5, Last Available: "2021-12"
+10876	yummy snack-sized special meatball	2	awesome	Effect: "Employee of the Month", Effect Duration: 5, Last Available: "2021-12"
 10877	cyan cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10764,12 +10764,12 @@
 10908	corrupted super-ionized maroon spare battery	0		Effect: "Punchy, Murdery", Effect Duration: 29, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
 10910	enhanced single-use dust mask	0		Effect: "Pumped Stomach", Effect Duration: 39, Last Available: "2022-05"
-10911	electrified red squat gaffer's tape	0		Effect: "Tingly Biceps", Effect Duration: 28, Last Available: "2022-05"
-10912	toothsome jumbo 20-lb can of rice and beans	5	awesome	Last Available: "2022-05"
+10911	electrified squat red gaffer's tape	0		Effect: "Tingly Biceps", Effect Duration: 28, Last Available: "2022-05"
+10912	jumbo toothsome 20-lb can of rice and beans	5	awesome	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	crappy	Last Available: "2022-05"
-10914	snack-sized bland expired MRE	2	decent	Last Available: "2022-05"
+10914	bland snack-sized expired MRE	2	decent	Last Available: "2022-05"
 10915	normal cool mint precipice bar	3	good	Last Available: "2022-05"
-10916	spoiled huge red carrot cake precipice bar	4	crappy	Last Available: "2022-05"
+10916	spoiled red huge carrot cake precipice bar	4	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	huge Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10777,12 +10777,12 @@
 10921	aged Dad's brandy	4	awesome	Last Available: "2022-06"
 10922	blue miser's teacher's pen of the brute	0		Muscle Percent: +30, Meat Drop: +10, Last Available: "2022-06"
 10923	decent fuchsia fire-roasted lake trout	4	good	Last Available: "2022-06"
-10924	big bland jittery yellow guilty sprout	5	decent	Last Available: "2022-06"
+10924	bland big yellow jittery guilty sprout	5	decent	Last Available: "2022-06"
 10925	teal mirror padded brawny mother's necklace	0		Muscle Percent: +20, Damage Absorption: +20, Last Available: "2022-06"
 10926	vacuum-sealed pulsating mirror trampled ticket stub	0		Effect: "Yuletide Industry", Effect Duration: 65, Last Available: "2022-06"
 10927	denatured blinking savings bond	0		Effect: "Cold Blooded", Effect Duration: 26, Last Available: "2022-06"
 10928	blinking designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	teal designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	teal designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	mixed mirror sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	wobbly stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10798,7 +10798,7 @@
 10942	blurry dinosaur repellent	0		
 10943	deadly camouflage vest	0		Weapon Damage: +5
 10944	Dinodollar	0		
-10945	narrow narrow pulsating valuable dinosaur droppings	0		
+10945	narrow pulsating narrow valuable dinosaur droppings	0		
 10946	dinosaur pheromone kit	0		
 10947	Jim Carey's MacGyver's Socratic awkward dinosaur research harness	0		Experience (Mysticality): +1, Maximum MP: +100, Monster Level: +25
 10948	perfumed reflective vest	0		Stench Resistance: +5
@@ -10818,42 +10818,42 @@
 10962	twisted shaking autumn breeze	1		Last Available: "2022-10"
 10963	dry Vulcanized magnetized mirror squat autumn years wisdom	0		Effect: "Dweeby", Effect Duration: 48, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	high-proof mediocre pulsating Oopsie IPA	7	decent	Last Available: "2022-10"
+10965	mediocre high-proof pulsating Oopsie IPA	7	decent	Last Available: "2022-10"
 10966	huge mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	mirror St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	normal ratatouille de Jarlsberg	4	good	Last Available: "2022-11"
 10971	spoiled Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
-10972	low-calorie rotten olive roasted vegetable of Jarlsberg	1	crappy	Last Available: "2022-11"
+10972	rotten low-calorie olive roasted vegetable of Jarlsberg	1	crappy	Last Available: "2022-11"
 10973	normal small St. Pete's sneaky smoothie	2	good	Last Available: "2022-11"
 10974	adequate Pete's wiley whey bar	3	good	Last Available: "2022-11"
-10975	snack-sized flavorless Pete's rich ricotta	2	decent	Last Available: "2022-11"
+10975	flavorless snack-sized Pete's rich ricotta	2	decent	Last Available: "2022-11"
 10976	weak lousy Boris's beer	2	decent	Last Available: "2022-11"
 10977	decent honey bun of Boris	4	good	Last Available: "2022-11"
 10978	decent Boris's bread	4	good	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	skewed Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	yellow squat Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	ghostly Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	wobbly Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	skewed Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	yellow squat Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	ghostly Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	wobbly Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	normal baked veggie ricotta casserole	4	good	Last Available: "2022-11"
-10989	snack-sized stale narrow plain calzone	2	decent	Last Available: "2022-11"
+10989	stale snack-sized narrow plain calzone	2	decent	Last Available: "2022-11"
 10990	spoiled blurry roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
-10991	small flavorless Pizza of Legend	2	decent	Last Available: "2022-11"
-10992	jumbo tasty Calzone of Legend	5	awesome	Last Available: "2022-11"
-10993	upside-down blinking Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	maroon Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	cyan Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	squat Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10991	flavorless small Pizza of Legend	2	decent	Last Available: "2022-11"
+10992	tasty jumbo Calzone of Legend	5	awesome	Last Available: "2022-11"
+10993	upside-down blinking Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	maroon Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	cyan Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	squat Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	decent small lime green bouncing Deep Dish of Legend	2	good	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	small decent bouncing lime green Deep Dish of Legend	2	good	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10866,8 +10866,8 @@
 11010	tasty swamp haunch	3	awesome	
 11011	Temple Grandin's rosy-cheeked gator shades	0		Maximum HP Percent: +30, Familiar Weight: +7, Single Equip
 11012	milk cap	0		
-11013	practically non-alcoholic tolerable Charleston Choo-Choo	1	good	
-11014	special drinkable weak pulsating Velvet Veil	2	good	Effect: "Top Dog", Effect Duration: 5
+11013	tolerable practically non-alcoholic Charleston Choo-Choo	1	good	
+11014	special weak drinkable pulsating Velvet Veil	2	good	Effect: "Top Dog", Effect Duration: 5
 11015	lousy Marltini	3	decent	
 11016	acceptable Strong, Silent Type	3	good	
 11017	watered-down perfectly mixed blurry Mysterious Stranger	2	EPIC	
@@ -10910,7 +10910,7 @@
 11054	vacuum-sealed upside-down Trainbot servomotors	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 58
 11055	improved moist teal Trainbot linkages	0		Effect: "Purpose", Effect Duration: 50
 11056	upside-down ping-pong paddle	0		Single Equip
-11057	fuchsia upside-down ping-pong ball	0		
+11057	upside-down fuchsia ping-pong ball	0		
 11058	Trainbot harness of vim and vigor	0		Maximum HP Percent: +50
 11059	ping-pong table	0		
 11060	skewed Crimbo train emergency brake	0		
@@ -10923,9 +10923,9 @@
 11067	acceptable dregs of a Crimbo cocktail	3	good	
 11068	yellow lost elf luggage	0		
 11069	jittery Trainbot luggage hook	0		Single Equip
-11070	delicious thick maroon honey-drenched ham slice	5	awesome	
+11070	thick delicious maroon honey-drenched ham slice	5	awesome	
 11071	weak acceptable mostly-empty bottle of cookie wine	2	good	
-11072	bite-sized rotten jittery Crimbo food scraps	1	crappy	
+11072	rotten bite-sized jittery Crimbo food scraps	1	crappy	
 11073	pulsating arm towel	0		Last Available: "2022-12"
 11074	spinning tumbling automatic wine thief	0		Single Equip
 11075	bouncing table-scraper	0		Single Equip
@@ -10937,12 +10937,12 @@
 11081	squat steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	jittery crystal Crimbo platter	0		
-11084	distilled bad fuchsia huge Crimbosmopolitan	5	decent	Last Available: "2022-12"
+11084	bad distilled huge fuchsia Crimbosmopolitan	5	decent	Last Available: "2022-12"
 11085	decent Crimbo dinner	3	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	tumbling train whistle	0		Last Available: "2022-12"
 11088	gray The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
-11089	spinning maroon unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
+11089	maroon spinning unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	skewed half-height cigar	0		Familiar Weight: +5
 11091	skewed grubby wool	0		
 11092	twirling fireproof smelly stylish grubby wool hat	0		Moxie: +25, Stench Spell Damage: +10, Hot Resistance: +3
@@ -10950,7 +10950,7 @@
 11094	olive Usain Bolt's banded razor-sharp grubby wool trousers	0		Weapon Damage Percent: +25, Damage Absorption: +100, Initiative: +80
 11095	rosewater-soaked extremely unsafe Samson's grubby wool gloves	0		Experience (Muscle): +5, Weapon Damage Percent: +100, Stench Resistance: +3, Item Drop: +5, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	drinkable practically non-alcoholic jittery jittery nice warm beer	1	good	
+11097	practically non-alcoholic drinkable jittery jittery nice warm beer	1	good	
 11098	ghostly grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10964,19 +10964,19 @@
 11108	lime green hard rock	0		Last Available: "2023-01"
 11109	cyan blinking stalagmite	0		Last Available: "2023-01"
 11110	squat chocolate covered ping-pong ball	0		
-11112	small spoiled pixel bread	2	crappy	
+11112	spoiled small pixel bread	2	crappy	
 11113	artisanal pixel whiskey	4	EPIC	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
-11117	polarized cyan shaking blinking glob of extra-green chlorophyll	0		Effect: "You Know When to Walk Away", Effect Duration: 18, Last Available: "2023-02"
+11117	polarized blinking shaking cyan glob of extra-green chlorophyll	0		Effect: "You Know When to Walk Away", Effect Duration: 18, Last Available: "2023-02"
 11118	concentrated enhanced mushroom	0		Effect: "Bolts about Candy", Effect Duration: 15, Last Available: "2023-02"
 11119	oxidized unsweetened liquefied skewed five-fingered fern resin	0		Effect: "Salamander In Your Stomach", Effect Duration: 20, Last Available: "2023-02"
-11120	bite-sized delicious super good fruit	1	awesome	Last Available: "2023-02"
+11120	delicious bite-sized super good fruit	1	awesome	Last Available: "2023-02"
 11121	twisted purple energized spores	1		Last Available: "2023-02"
-11122	hardened hot pepper of bravery	0		Damage Reduction: 3, Spooky Resistance: +5, Last Available: "2023-02", Lantern Element: "Hot"
+11122	hardened hot pepper of bravery	0		Damage Reduction: 3, Spooky Resistance: +5, Lantern Element: "Hot", Last Available: "2023-02"
 11123	activated moist spinning out-of-work circus flea	0		Effect: "Chalk Outline", Effect Duration: 31, Last Available: "2023-02"
-11124	jittery maroon extra-grubby grub	0		Last Available: "2023-02"
+11124	maroon jittery extra-grubby grub	0		Last Available: "2023-02"
 11125	triple-denatured fire ant pheromones	0		Effect: "Crocodile Tear", Effect Duration: 59, Last Available: "2023-02"
 11126	pressed flapper fly	0		Effect: "Rad-ish", Effect Duration: 37, Last Available: "2023-02"
 11127	practically non-alcoholic bad narrow maroon shot of wasp venom	1	decent	Last Available: "2023-02"
@@ -10987,14 +10987,14 @@
 11132	bouncing hollow rock	0		Last Available: "2023-02"
 11133	chilled enhanced angry agate	0		Effect: "Gyromitra Gymnastics", Effect Duration: 52, Last Available: "2023-02"
 11134	magnetized twirling red lump of loyal latite	0		Effect: "It Didn't Kill You", Effect Duration: 15, Last Available: "2023-02"
-11135	normal special shadow sausage	4	good	Effect: "Hobonic", Effect Duration: 5, Last Available: "2023-03"
+11135	special normal shadow sausage	4	good	Effect: "Hobonic", Effect Duration: 5, Last Available: "2023-03"
 11136	greasy Socratic shadow skin	0		Experience (Mysticality): +1, Sleaze Spell Damage: +10, Last Available: "2023-03"
 11137	polarized shadow flame	0		Effect: "The Rich Get Richer", Effect Duration: 53, Last Available: "2023-03"
 11138	toothsome shadow bread	3	awesome	Last Available: "2023-03"
-11139	bouncing blinking pulsating shadow ice	0		Last Available: "2023-03"
+11139	bouncing pulsating blinking shadow ice	0		Last Available: "2023-03"
 11140	bad shadow fluid	4	decent	Last Available: "2023-03"
 11141	fuchsia shadow glass	0		Last Available: "2023-03"
-11142	upside-down squat shadow brick	0		Last Available: "2023-03"
+11142	squat upside-down shadow brick	0		Last Available: "2023-03"
 11143	pulsating shadow sinew	0		Last Available: "2023-03"
 11144	delicious shadow venom	3	awesome	Last Available: "2023-03"
 11145	twisted wobbly shadow nectar	1		Last Available: "2023-03"
@@ -11011,7 +11011,7 @@
 11156	Oprah's uncursed arcane orb	0		Maximum MP Percent: +50
 11157	knitted machete	0		Cold Resistance: +3
 11158	blinking purple uncursed machete of Tarzan	0		Experience (Muscle): +3
-11159	blue blinking blanket	0		
+11159	blinking blue blanket	0		
 11160	uncursed blanket	0		
 11161	upside-down miser's stanky Oprah's medallion	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Meat Drop: +10
 11162	Tesla uncursed medallion	0		MP Regen Min: 7, MP Regen Max: 10
@@ -11059,7 +11059,7 @@
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	replica cotton candy cocoon	0		
 11206	foul-smelling sizzling curative replica Elvish sunglasses of mayonnaise	0		Hot Damage: +10, Stench Damage: +10, Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
-11207	tumbling lime green replica squamous polyp	0		
+11207	lime green tumbling replica squamous polyp	0		
 11208	jittery replica stone sphere	0		
 11209	boxer's replica Greatest American Pants of Leguizamo of the businessman	0		Muscle Percent: +10, Monster Level: +20, Meat Drop: +50
 11210	replica organ grinder	0		
@@ -11137,7 +11137,7 @@
 11282	artisanal irresponsibly strong blue mirror Sexy Cosmo	9	EPIC	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	wobbly bouncing double-paned red-soled high heels of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Cold Resistance: +5, Initiative: +100, Last Available: "2023-06"
-11285	miniature rotten pulsating cyburger	2	crappy	Last Available: "2025-12"
+11285	rotten miniature pulsating cyburger	2	crappy	Last Available: "2025-12"
 11286	rock-hard ncle leg	0		Damage Reduction: 5
 11287	personal trainer's rutabuga bag of the detective	0		Experience Percent (Muscle): +10, Item Drop: +20
 11288	Jack Frost's mesquito proboscis	0		Cold Spell Damage: +50
@@ -11146,7 +11146,7 @@
 11291	skewed spider leg of the detective	0		Item Drop: +20
 11292	green ghostly beetle antenna of the overflowing toilet	0		Stench Spell Damage: +50
 11293	spinning occult mantis skull	0		Spell Damage Percent: +25
-11294	quadruple-frozen aerosolized chilled pulsating gray chitin powder	0		Effect: "Egg-stra Arm", Effect Duration: 63
+11294	quadruple-frozen aerosolized chilled gray pulsating chitin powder	0		Effect: "Egg-stra Arm", Effect Duration: 63
 11295	wobbly crafty groovy daddy shortlegs leg	0		Moxie Percent: +10, Maximum MP: +10
 11296	huge upside-down beefy birdybug antenna of wisdom	0		Muscle: +10, Mysticality: +15
 11297	foul-smelling kilopede skull of the boozehound	0		Stench Damage: +10, Booze Drop: +100
@@ -11163,13 +11163,13 @@
 11308	huge watermelon seed	0		
 11309	water balloon	0		
 11310	blinking thriftshop coupon	0		
-11311	normal massive mirror waffle	10	good	
+11311	massive normal mirror waffle	10	good	
 11312	fixodent	0		
 11313	healthy cat o' nine teeth of incineration	0		Maximum HP Percent: +20, Hot Spell Damage: +50
 11314	educational tooth cap of the brazier	0		Experience: +1, Hot Spell Damage: +25
 11315	purple supercool toothy trousers of Tarzan	0		Moxie Percent: +20, Experience (Muscle): +3
-11316	rotten fancy tumbling banana split	3	crappy	Effect: "Kernel Panic!", Effect Duration: 10
-11317	squat skewed handful of toilet paper	0		
+11316	fancy rotten tumbling banana split	3	crappy	Effect: "Kernel Panic!", Effect Duration: 10
+11317	skewed squat handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	fortified hand-crafted twirling bottle of Cabernet Sauvignon	5	EPIC	
@@ -11214,7 +11214,7 @@
 11359	aromatic sizzling therapeutic savvy leaf crown of Calamity Jane of the blizzard	0		Mysticality Percent: +20, Critical Hit Percent: +15, Cold Spell Damage: +25, Hot Damage: +10, Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 11360	massive bland leafy browns	10	decent	
 11361	flattened aerosolized non-wet autumnic balm	0		Effect: "Creepypasted", Effect Duration: 11
-11362	enhanced warmed twirling red coping juice	0		Effect: "Enraged", Effect Duration: 53
+11362	enhanced warmed red twirling coping juice	0		Effect: "Enraged", Effect Duration: 53
 11363	chilly friendly energetic wholesome Da Vinci's candy cane sword cane	0		Experience (Mysticality): +5, Maximum HP Percent: +10, Maximum MP Percent: +20, Familiar Weight: +3, Cold Damage: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	pulsating wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
@@ -11224,7 +11224,7 @@
 11369	automa-bot parts	0		
 11370	jittery security automa-core	0		
 11371	cyan clerical automa-core	0		
-11372	pulsating blinking handful of Boltsmann bearings	0		
+11372	blinking pulsating handful of Boltsmann bearings	0		
 11373	Spring Bros. solenoid	0		
 11374	bouncing Spring Bros. ID badge	0		
 11375	Boltsmann ID badge	0		
@@ -11232,7 +11232,7 @@
 11377	housekeeping robot	0		
 11378	flavorless pickled bread	4	decent	Last Available: "2023-12"
 11379	fancy spoiled salted mutton	4	crappy	Effect: "Petit Force", Effect Duration: 25, Last Available: "2023-12"
-11380	snack-sized moldy corned beet	2	crappy	Last Available: "2023-12"
+11380	moldy snack-sized corned beet	2	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11253,7 +11253,7 @@
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	mirror Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	practically non-alcoholic artisanal squat Crimbuccaneer mologrog cocktail	1	super ultra mega EPIC	Last Available: "2023-12"
+11401	artisanal practically non-alcoholic squat Crimbuccaneer mologrog cocktail	1	super ultra mega EPIC	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	prompt steel-toed brawny Crimbuccaneer lantern	0		Muscle Percent: +20, Damage Reduction: 9, Adventures: +3, Last Available: "2023-12"
@@ -11268,7 +11268,7 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	Elf Guard officer's sidearm of courage of the boozehound	0		Spooky Resistance: +3, Booze Drop: +100, Last Available: "2023-12"
 11415	greedy sage Elf Guard insignia (general)	0		Mysticality Percent: +10, Meat Drop: +20, Single Equip, Last Available: "2023-12"
-11416	aged irresponsibly strong Crimbow Rainbo	6	awesome	Last Available: "2023-12"
+11416	irresponsibly strong aged Crimbow Rainbo	6	awesome	Last Available: "2023-12"
 11417	jittery Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	blinking miser's fireproof Elf Guard broom	0		Hot Resistance: +3, Meat Drop: +10, Last Available: "2023-12"
@@ -11282,13 +11282,13 @@
 11427	low-calorie delicious sundae ration	1	awesome	Last Available: "2023-12"
 11428	toothsome cyan peppermint tack	4	awesome	Last Available: "2023-12"
 11429	blinking Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	delicious miniature whalesteak	2	awesome	Last Available: "2023-12"
+11430	miniature delicious whalesteak	2	awesome	Last Available: "2023-12"
 11431	upside-down reassuring fireproof rosy-cheeked whalegun	0		Maximum HP Percent: +30, Hot Resistance: +3, Spooky Resistance: +1, Last Available: "2023-12"
 11432	Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	frightening sharpshooter's clever Elf Guard clipboard	0		Maximum MP: +20, Critical Hit Percent: +10, Spooky Damage: +5, Last Available: "2023-12"
 11435	pegfinger of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2023-12"
-11436	practically non-alcoholic perfectly mixed and claret	1	EPIC	Last Available: "2023-12"
+11436	perfectly mixed practically non-alcoholic and claret	1	EPIC	Last Available: "2023-12"
 11437	veiny Elf Guard and beret	0		Maximum HP: [+10*event(December)], Last Available: "2023-12"
 11438	sizzling crafty wholesome shipwright's hammer	0		Maximum HP Percent: +10, Maximum MP: +10, Hot Damage: +10, Last Available: "2023-12"
 11439	jittery ruddy deadly boxer's gunwale	0		Muscle Percent: +10, Weapon Damage: +5, Maximum HP Percent: +40, Damage Reduction: 9, Last Available: "2023-12"
@@ -11313,10 +11313,10 @@
 11458	olive Fonzie's Crimbuccaneer bombjacket of the boozehound	0		Experience (Moxie): +1, Booze Drop: +100, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	half-sized normal sugarplum ration	2	good	Last Available: "2023-12"
 11460	toothsome gingerbread nylons	4	awesome	Last Available: "2023-12"
-11461	gigantic moldy rum-soaked fruitcake	8	crappy	Last Available: "2023-12"
+11461	moldy gigantic rum-soaked fruitcake	8	crappy	Last Available: "2023-12"
 11462	bland super-sized lime	5	decent	Last Available: "2023-12"
 11463	miniature rotten gingerbread pirate	2	crappy	Last Available: "2023-12"
-11464	miniature yummy fuchsia fruit-stuffed rumcake	2	awesome	Last Available: "2023-12"
+11464	yummy miniature fuchsia fruit-stuffed rumcake	2	awesome	Last Available: "2023-12"
 11465	drinkable mulled wine	3	good	Last Available: "2023-12"
 11466	hand-crafted boozy maroon Swedish coffee	5	EPIC	Last Available: "2023-12"
 11467	drinkable canteen of eggnog	4	good	Last Available: "2023-12"
@@ -11326,9 +11326,9 @@
 11471	blurry Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	special mediocre gray yule grog	4	decent	Effect: "On a Roll", Effect Duration: 30, Last Available: "2023-12"
+11474	mediocre special gray yule grog	4	decent	Effect: "On a Roll", Effect Duration: 30, Last Available: "2023-12"
 11475	flavorless wet tack	3	decent	Last Available: "2023-12"
-11476	flavorless snack-sized whalecake	2	decent	Last Available: "2023-12"
+11476	snack-sized flavorless whalecake	2	decent	Last Available: "2023-12"
 11477	inspector's groovy weightlifter's gunwale whalegun	0		Muscle: +15, Moxie Percent: +10, Item Drop: +15, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	boozy delicious and claret	5	awesome	Last Available: "2023-12"
 11479	tumbling rigging knot	0		Familiar Weight: +5
@@ -11344,7 +11344,7 @@
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	blinking prompt auspicious beefcake's barnacle-encrusted sweater	0		Muscle: +25, Item Drop: +10, Adventures: +3, Last Available: "2023-12"
 11491	jittery sharpshooter's Crimbuccaneer nose ring of the sweet-tooth of the early riser	0		Critical Hit Percent: +10, Candy Drop: +100, Adventures: +7, Last Available: "2023-12"
-11492	twirling tumbling pet anchor	0		Last Available: "2023-12"
+11492	tumbling twirling pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
@@ -11382,13 +11382,13 @@
 11527	pressed magnetized upside-down crepe paper peanut candy	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 21
 11528	chilly petrified wood war pike of James Dean	0		Experience (Moxie): +3, Cold Damage: +5, Last Available: "2025-12"
 11529	MacGyver's petrified wood waist protector of extreme caution	0		Maximum MP: +100, Monster Level: -25, Single Equip, Last Available: "2025-12"
-11530	blue zippy greedy petrified wood wizard's pouch	0		Meat Drop: +20, Initiative: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	blurry avaricious smelly petrified wood water purifier	0		Stench Spell Damage: +10, Meat Drop: +30, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	blue zippy greedy petrified wood wizard's pouch	0		Meat Drop: +20, Initiative: +20, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	blurry avaricious smelly petrified wood water purifier	0		Stench Spell Damage: +10, Meat Drop: +30, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	jittery supercharged smooth petrified wood whoopie panama	0		Moxie: +15, Maximum MP Percent: +30, Last Available: "2025-12"
 11533	stanky Annie Oakley's petrified wood walking pants	0		Critical Hit Percent: +20, Stench Spell Damage: +25, Last Available: "2025-12"
-11534	modified jittery gray petrified wood waste parts	1		Effect: "Shamboozled", Effect Duration: 5, Last Available: "2025-12"
+11534	modified gray jittery petrified wood waste parts	1		Effect: "Shamboozled", Effect Duration: 5, Last Available: "2025-12"
 11535	pressed alkaline tumbling petrified wood wafer praline	0		Effect: "Egg on your Face", Effect Duration: 16
-11536	extra-dry artisanal cybeer	5	EPIC	Last Available: "2025-12"
+11536	artisanal extra-dry cybeer	5	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
@@ -11441,19 +11441,19 @@
 11586	wobbly healthy Socratic yamtility belt of the sweet-tooth	0		Experience (Mysticality): +1, Maximum HP Percent: +20, Candy Drop: +100, Lasts Until Rollover, Last Available: "2024-05"
 11587	adequate yam slider	3	good	Last Available: "2024-05"
 11588	yummy yam mayo	3	awesome	Last Available: "2024-05"
-11589	huge yummy cyan yam burrito	7	awesome	Last Available: "2024-05"
+11589	yummy huge cyan yam burrito	7	awesome	Last Available: "2024-05"
 11590	green visual packet sniffer	0		Last Available: "2025-12"
 11591	ghostly mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	blurry aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	adequate thick mini kiwi	5	good	Last Available: "2024-06"
 11595	twirling ribald healthy padded mini kiwi bikini	0		Damage Absorption: +20, Maximum HP Percent: +20, Sleaze Damage: +10, Last Available: "2024-06"
-11596	acceptable irresponsibly strong mini kiwitini	7	good	Last Available: "2024-06"
+11596	irresponsibly strong acceptable mini kiwitini	7	good	Last Available: "2024-06"
 11597	cyan mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	Jeselnik's lion tamer's dog trainer's mini kiwi silicon tiepin	0		Experience (familiar): 3, Sleaze Damage: +25
 11600	tumbling mini kiwi tipi	0		
-11601	big adequate tumbling mini kiwi digitized cookies	5	good	
+11601	adequate big tumbling mini kiwi digitized cookies	5	good	
 11602	hand-crafted tumbling mini kiwi intoxicating spirits	3	EPIC	
 11603	denatured polarized flattened huge mini kiwi antimilitaristic hippy petition	0		Effect: "Hot Buttoned", Effect Duration: 20
 11604	corrupted pickled lime green skewed huge mini kiwi illicit antibiotic	0		Effect: "Sealed Brain", Effect Duration: 55
@@ -11470,9 +11470,9 @@
 11615	olive tumbling huge aromatic lion tamer's fortified messenger bag RNA	0		Damage Absorption: +60, Experience (familiar): +2, Stench Resistance: +1
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	small bland maroon bacteria bisque	2	decent	
+11618	bland small maroon bacteria bisque	2	decent	
 11619	small adequate ciliophora chowder	2	good	
-11620	fancy stale cream of chloroplasts	4	decent	Effect: "Oxygenated Blood", Effect Duration: 10
+11620	stale fancy cream of chloroplasts	4	decent	Effect: "Oxygenated Blood", Effect Duration: 10
 11621	skewed synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11484,7 +11484,7 @@
 11629	untorn tearaway pants package	0		Free Pull
 11630	jittery chilly banded savvy slick tearaway pants of the brazier	0		Moxie: +10, Mysticality Percent: +20, Damage Absorption: +100, Cold Damage: +5, Hot Spell Damage: +25, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	baby bodyguard	0		
-11632	wobbly maroon Doll Moll violin case	0		
+11632	maroon wobbly Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
 11635	drinkable Colera Peste Nebbiolo	3	good	
@@ -11497,12 +11497,12 @@
 11642	upside-down Sept-Ember Censer	0		Last Available: "2024-09"
 11643	jittery horrifying blade of dismemberment	0		Spooky Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
-11645	blurry lime green skewed Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
+11645	lime green skewed blurry Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
 11646	Septapus summoning charm	0		Last Available: "2024-09"
 11647	structural ember	0		Last Available: "2024-09"
 11648	skewed horrifying sinister dance instructor's embers-only jacket	0		Experience Percent (Moxie): +10, Spell Damage: +10, Spooky Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
 11649	spinning upside-down strapping bembershoot	0		Muscle: +5, Lasts Until Rollover, Last Available: "2024-09"
-11650	half-sized spoiled twirling wheel of camembert	2	crappy	Last Available: "2024-09"
+11650	spoiled half-sized twirling wheel of camembert	2	crappy	Last Available: "2024-09"
 11651	wobbly hat of remembering of the brute of the overflowing toilet of the glutton	0		Muscle Percent: +30, Stench Spell Damage: +50, Food Drop: +100, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11545,7 +11545,7 @@
 11690	weightlifter's jolly roger flag	0		Muscle: +15, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	blinking pirrrate's currrse	0		Last Available: "2024-12"
-11693	lousy boozy tankard of spiced rum	5	decent	Last Available: "2024-12"
+11693	boozy lousy tankard of spiced rum	5	decent	Last Available: "2024-12"
 11694	hand-crafted watered-down tankard of spiced Goldschlepper	2	EPIC	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	nippy governor's daughter's lace collar	0		Cold Damage: +10, Last Available: "2024-12"
@@ -11600,16 +11600,16 @@
 11745	toasty stylish slick Congressional Medal of Insanity	0		Moxie: 35, Hot Damage: +5, Last Available: "2024-12"
 11746	tumbling pumpkin spice whorl	0		Last Available: "2024-12"
 11747	lousy Easter grasshopper	4	decent	Last Available: "2024-12"
-11748	weak hand-crafted Irish eggnog	2	EPIC	Last Available: "2024-12"
-11749	weak bad red canteen of jungle juice	2	decent	Last Available: "2024-12"
+11748	hand-crafted weak Irish eggnog	2	EPIC	Last Available: "2024-12"
+11749	bad weak red canteen of jungle juice	2	decent	Last Available: "2024-12"
 11750	bad turchucken	3	decent	Last Available: "2024-12"
-11751	tolerable irresponsibly strong fancy mechanically-mulled cider	7	good	Effect: "Lemony Goodness", Effect Duration: 15, Last Available: "2024-12"
+11751	fancy irresponsibly strong tolerable mechanically-mulled cider	7	good	Effect: "Lemony Goodness", Effect Duration: 15, Last Available: "2024-12"
 11752	perfectly mixed purple holiday trip around the world	4	super EPIC	Last Available: "2024-12"
 11753	delicious ghostly chocolate ostrich egg	3	awesome	Last Available: "2024-12"
-11754	normal enchanted blurry beef and cabbage	4	good	Effect: "Loco Motives", Effect Duration: 15, Last Available: "2024-12"
-11755	rotten miniature twirling candy rations	2	crappy	Last Available: "2024-12"
+11754	enchanted normal blurry beef and cabbage	4	good	Effect: "Loco Motives", Effect Duration: 15, Last Available: "2024-12"
+11755	miniature rotten twirling candy rations	2	crappy	Last Available: "2024-12"
 11756	thick moldy double-candied yams	5	crappy	Last Available: "2024-12"
-11757	small rotten Christmas ham	2	crappy	Last Available: "2024-12"
+11757	rotten small Christmas ham	2	crappy	Last Available: "2024-12"
 11758	stale immense shaking holiday smorgasbord	9	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	blurry chilly bejazzled eyepatch	0		Cold Damage: +5, Last Available: "2024-12"
@@ -11618,7 +11618,7 @@
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	ghostly lime green Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	lime green ghostly Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
@@ -11671,7 +11671,7 @@
 11816	twirling dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	upside-down dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	fuchsia dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
-11819	pulsating bouncing dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
+11819	bouncing pulsating dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	ghostly SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
@@ -11712,8 +11712,8 @@
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	gray glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
-11860	huge ghostly assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
-11861	teal huge Leprecondo	0		Last Available: "2025-03"
+11860	ghostly huge assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
+11861	huge teal Leprecondo	0		Last Available: "2025-03"
 11862	boiled shaking scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	weak artisanal special skewed pint of Leprechaun Stout	2	EPIC	Effect: "Once Bitten Twice Fried", Effect Duration: 35, Last Available: "2025-03"
@@ -11724,23 +11724,23 @@
 11869	pulsating unironic knife	0		
 11870	blue bar dart	0		Last Available: "2025-03"
 11871	distilled bouncing leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	gigantic bland blinking Heck ramen	8	decent	Last Available: "2025-03"
+11872	bland gigantic blinking Heck ramen	8	decent	Last Available: "2025-03"
 11873	spoiled half-sized burrito	2	crappy	Last Available: "2025-03"
-11874	stale special small beer brat	3	decent	Effect: "Nature's Bounty", Effect Duration: 25, Last Available: "2025-03"
-11875	jumbo adequate shaking gray peach pie	5	good	Last Available: "2025-03"
+11874	special stale small beer brat	3	decent	Effect: "Nature's Bounty", Effect Duration: 25, Last Available: "2025-03"
+11875	adequate jumbo gray shaking peach pie	5	good	Last Available: "2025-03"
 11876	miniature toothsome incredible mini-pizza	2	awesome	Last Available: "2025-03"
-11877	fortified perfectly mixed blue Divine sidecar	5	EPIC	Last Available: "2025-03"
-11878	weak bad tangarita sidecar	2	decent	Last Available: "2025-03"
+11877	perfectly mixed fortified blue Divine sidecar	5	EPIC	Last Available: "2025-03"
+11878	bad weak tangarita sidecar	2	decent	Last Available: "2025-03"
 11879	practically non-alcoholic artisanal gimlet sidecar	1	EPIC	Last Available: "2025-03"
 11880	lousy watered-down cyan vodka stratocaster sidecar	2	decent	Last Available: "2025-03"
-11881	tolerable weak blurry prussian cathouse sidecar	2	good	Last Available: "2025-03"
-11882	mediocre watered-down shaking Mon Tiki sidecar	2	decent	Last Available: "2025-03"
+11881	weak tolerable blurry prussian cathouse sidecar	2	good	Last Available: "2025-03"
+11882	watered-down mediocre shaking Mon Tiki sidecar	2	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	purple censurious cool April Shower Thoughts shield	0		Moxie: +5, Sleaze Resistance: +3, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	huge spitball	0		Last Available: "2025-04"
 11887	cold-filtered enhanced olive wet paper weights	0		Effect: "Fratty Flavor", Effect Duration: 51, Last Available: "2025-04"
-11888	hand-crafted irresponsibly strong Three Sheets to the Wind	7	EPIC	Last Available: "2025-04"
+11888	irresponsibly strong hand-crafted Three Sheets to the Wind	7	EPIC	Last Available: "2025-04"
 11889	adequate pile of wet dates	4	good	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11774,7 +11774,7 @@
 11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
-11922	spinning fuchsia yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
+11922	fuchsia spinning yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
 11923	fuchsia exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
 11924	ghostly greasy razor-sharp Axis helmet	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10
 11925	scandalous dog trainer's Axis fatigues	0		Experience (familiar): +1, Sleaze Damage: +5
@@ -11786,8 +11786,8 @@
 11931	nice nylon stockings	0		
 11932	mirror Allied Radio Backpack Pack	0		Free Pull
 11933	lightning-fast chaotic Allied Radio Backpack of incineration	0		Spell Critical Percent: +10, Hot Spell Damage: +50, Initiative: +40, Conditional Skill (Equipped): "Call in an Airstrike"
-11934	tumbling upside-down blurry orphaned baby skeleton	0		
-11935	bouncing narrow mirror ordnance magnet	0		Single Equip
+11934	blurry tumbling upside-down orphaned baby skeleton	0		
+11935	mirror narrow bouncing ordnance magnet	0		Single Equip
 11936	tumbling confetti grenade	0		
 11937	toothsome Skeleton Wars rations	4	awesome	
 11938	drinkable jittery skeleton war fuel can	3	good	
@@ -11814,7 +11814,7 @@
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	huge blue dance instructor's undersea surveying goggles	0		Experience Percent (Moxie): +10, Lasts Until Rollover
-11963	delicious weak yellow Ocean-Touched Rum	2	awesome	
+11963	weak delicious yellow Ocean-Touched Rum	2	awesome	
 11964	diluted water-logged pill	1		
 11965	bland kelp puck	4	decent	
 11966	scroll of sea strength	0		
@@ -11832,7 +11832,7 @@
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	censurious fireproof gravedigger's mansplainer's Oprah's rosy-cheeked blood cubic zirconia	0		Maximum HP Percent: +30, Maximum MP Percent: +50, Monster Level: +15, Spooky Damage: +10, Hot Resistance: +3, Sleaze Resistance: +3, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	dehydrated blood thinner	1		Last Available: "2025-10"
-12045	tolerable watered-down wobbly pheromone cocktail	2	good	Last Available: "2025-10"
+12045	watered-down tolerable wobbly pheromone cocktail	2	good	Last Available: "2025-10"
 12046	stale spinal tapas	3	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	shrunken head of the wise owl of Tarzan of the cheetah	0		Mysticality: +20, Experience (Muscle): +3, Initiative: +60, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
@@ -11840,13 +11840,13 @@
 12050	skewed small peppermint-flavored sugar walking crook	0		
 12051	jittery knucklebone	0		
 12052	drinkable practically non-alcoholic bouncing Smoking Pope	1	good	
-12053	flavorless small prize turkey	2	decent	
+12053	small flavorless prize turkey	2	decent	
 12054	compressed medicinal gruel	1		
 12055	normal snack-sized full-sized pumpkin pie	2	good	Last Available: "2025-11"
 12056	tolerable vodka cranberry sauce	4	good	Last Available: "2025-11"
 12057	cold-filtered yammed candy	0		Effect: "Voracious Gorging", Effect Duration: 48, Last Available: "2025-11"
 12058	bland treasure chestnut	3	decent	Last Available: "2025-12"
-12059	tolerable triple-distilled special upside-down olive mulled butter rum	8	good	Effect: "Comic Violence", Effect Duration: 40, Last Available: "2025-12"
+12059	triple-distilled tolerable special upside-down olive mulled butter rum	8	good	Effect: "Comic Violence", Effect Duration: 40, Last Available: "2025-12"
 12060	denatured cinnamon doubloon	0		Effect: "Sugary Tongue", Effect Duration: 54, Last Available: "2025-12"
 12061	pulsating beefy plastic left skeleton arm	0		Muscle: +10, Last Available: "2025-12"
 12062	resourceful plastic left skeleton leg	0		Maximum MP: +50, Last Available: "2025-12"
@@ -11874,14 +11874,14 @@
 12116	lime green narrow burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
 12118	burnt radius	0		Last Available: "2025-12"
-12119	blurry teal burnt rib	0		Last Available: "2025-12"
+12119	teal blurry burnt rib	0		Last Available: "2025-12"
 12120	blinking burnt skull	0		Last Available: "2025-12"
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	ghostly Samson's extra-thick Crimbo sweater	0		Experience (Muscle): +5, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	hand-crafted Steve Abrams' Holiday Sampler Beer	4	EPIC	Last Available: "2025-12"
 12125	teal crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	fortified hand-crafted bottle of prize-winning rum	5	EPIC	Last Available: "2025-12"
+12126	hand-crafted fortified bottle of prize-winning rum	5	EPIC	Last Available: "2025-12"
 12127	rosy-cheeked Santa-Slayer medal of Tarzan of Flo-Jo	0		Experience (Muscle): +3, Maximum HP Percent: +30, Initiative: +100, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	quadruple-improved tarnished shaking boiling bone marrow	0		Effect: "Scarysauce", Effect Duration: 62, Last Available: "2025-12"
@@ -11917,7 +11917,7 @@
 12159	red Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12162	olive shaking Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
+12162	shaking olive Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	blurry Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	yellow Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12165	Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
@@ -11927,9 +11927,9 @@
 12169	Tesla ship's lantern	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 12170	prompt nippy heat-resistant harpoon pistol	0		Cold Damage: +10, Adventures: +3, Last Available: "2025-12"
 12171	adequate skewed traditional gingerloaf	3	good	Last Available: "2025-12"
-12172	delicious weak Scotch and eggnog	2	awesome	Last Available: "2025-12"
+12172	weak delicious Scotch and eggnog	2	awesome	Last Available: "2025-12"
 12173	quantum deionized counterskeleton elixir	0		Effect: "Bestial Sympathy", Effect Duration: 42, Last Available: "2025-12"
-12174	weak tolerable tumbling &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
+12174	tolerable weak tumbling &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
 12175	fuchsia The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	huge crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	bland wedge of prize-winning cheese	3	decent	Last Available: "2025-12"
@@ -11964,7 +11964,7 @@
 12206	jittery Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	twirling Pork Elf toilet	0		Last Available: "2026-03"
-12209	adequate enchanted rat pizza	3	good	Effect: "It's Electric!", Effect Duration: 30, Last Available: "2026-03"
+12209	enchanted adequate rat pizza	3	good	Effect: "It's Electric!", Effect Duration: 30, Last Available: "2026-03"
 12210	skewed Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	auspicious smelly hoverboard of the pedagogue	0		Experience: +3, Stench Spell Damage: +10, Item Drop: +10, Single Equip, Last Available: "2026-03"
 12212	upside-down Temple Grandin's smartaleck's boxer's left shark fin	0		Muscle Percent: +10, Moxie Percent: +30, Familiar Weight: +7, Last Available: "2026-03"
@@ -11972,25 +11972,25 @@
 12214	pickled green candy bone	1		Effect: "Baconstoned", Effect Duration: 20
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	small adequate blinking discarded hot dog	2	good	Last Available: "2026-04"
-12218	weak perfectly mixed most of a beer	2	EPIC	Last Available: "2026-04"
+12217	adequate small blinking discarded hot dog	2	good	Last Available: "2026-04"
+12218	perfectly mixed weak most of a beer	2	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	fuchsia legendary noodles	0		Last Available: "2026-05"
 12226	tiny adequate can of tuna	1	good	
 12227	delicious small alien salad	2	awesome	
-12228	decent maroon spinning ratbatatouille	4	good	
+12228	decent spinning maroon ratbatatouille	4	good	
 12229	bite-sized moldy onigiri	1	crappy	
 12230	bland diet crudit&eacute;s	1	decent	
 12231	moldy miniature ghostly sauced mutton	2	crappy	
 12232	normal low-calorie hot honey ant	1	good	
 12233	bland tomb aspic	3	decent	
-12234	spoiled yellow upside-down later tots	4	crappy	
+12234	spoiled upside-down yellow later tots	4	crappy	
 12235	toothsome Frutti di Scatoletta	4	awesome	Last Available: "2026-05"
 12236	immense rotten Pesto alla Marziano	10	crappy	Last Available: "2026-05"
-12237	miniature normal Arrattabbattabiata	2	good	Last Available: "2026-05"
-12238	rotten miniature Orzo di Riso	2	crappy	Last Available: "2026-05"
-12239	bite-sized tasty Pasta Grimavera	1	awesome	Last Available: "2026-05"
+12237	normal miniature Arrattabbattabiata	2	good	Last Available: "2026-05"
+12238	miniature rotten Orzo di Riso	2	crappy	Last Available: "2026-05"
+12239	tasty bite-sized Pasta Grimavera	1	awesome	Last Available: "2026-05"
 12240	bland blurry Linguini Ubriacapa	3	decent	Last Available: "2026-05"
 12241	massive delicious upside-down Formica e Pepe	9	awesome	Last Available: "2026-05"
 12242	normal Tubetto Gelatto	4	good	Last Available: "2026-05"
@@ -12016,7 +12016,7 @@
 12266	blinking double-paned flimsy plastic greaves	0		Cold Resistance: +5
 12267	Newton's flimsy plastic breastplate	0		Experience (Mysticality): +3
 12268	spinning brainy flimsy plastic shield	0		Mysticality: +5, Damage Reduction: 3
-12269	cyan huge packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
+12269	huge cyan packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	knitted Van der Graaf Portable Laughing Stock of the empath	0		Familiar Weight: +5, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	purple perfumed Jeselnik's Staff of Anachronistic Churning of the businessman	0		Sleaze Damage: +25, Stench Resistance: +5, Meat Drop: +50
 12272	tasty jittery classic banana	3	awesome	Last Available: "2026-07"
@@ -12027,7 +12027,7 @@
 12277	spoiled classic banana pie	3	crappy	Last Available: "2026-07"
 12278	frozen blue essential banana decoction	0		Effect: "Cancer Rising", Effect Duration: 25, Last Available: "2026-07"
 12279	energized activated ghostly shaking banana quintessence	0		Effect: "Flaming Weapon", Effect Duration: 23, Last Available: "2026-07"
-12280	practically non-alcoholic delicious Aesop Daiquiri	1	awesome	Last Available: "2026-07"
+12280	delicious practically non-alcoholic Aesop Daiquiri	1	awesome	Last Available: "2026-07"
 12281	bad wobbly Monkey Congress	3	decent	Last Available: "2026-07"
 12282	huge stale watermelon pie	9	decent	Last Available: "2026-07"
 12283	double-concentrated alkaline shaking concentrated watermelon juice	0		Effect: "Hagnk's Gratitude", Effect Duration: 11, Last Available: "2026-07"
@@ -12037,12 +12037,12 @@
 12287	spoiled narrow quince pie	3	crappy	Last Available: "2026-07"
 12288	liquefied energized quince quaff	0		Effect: "Yuletide Industry", Effect Duration: 46, Last Available: "2026-07"
 12289	dry Quickquince	0		Effect: "It's Soporiffic!", Effect Duration: 46, Last Available: "2026-07"
-12290	watered-down lousy pulsating Quiskey Sour	2	decent	Last Available: "2026-07"
+12290	lousy watered-down pulsating Quiskey Sour	2	decent	Last Available: "2026-07"
 12291	triple-distilled lousy Quincea&ntilde;era Cooler	9	decent	Last Available: "2026-07"
-12292	weak aged twirling Roth IPA	2	awesome	Last Available: "2026-08"
+12292	aged weak twirling Roth IPA	2	awesome	Last Available: "2026-08"
 12293	skewed skewed miser's flame-retardant underdraft protection	0		Hot Resistance: +1, Meat Drop: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	miniature normal soybean futures	2	good	Last Available: "2026-08"
+12295	normal miniature soybean futures	2	good	Last Available: "2026-08"
 12296	altered vacuum-sealed chilled skewed housing bubble	0		Effect: "Electrolit Up", Effect Duration: 37, Last Available: "2026-08"
 12297	improved double-deionized Pixie-Swordz	0		Effect: "Arabian Knighthood", Effect Duration: 39
 12298	pulsating smartaleck's financial instrument of vim and vigor	0		Moxie Percent: +30, Maximum HP Percent: +50, Last Available: "2026-08"
@@ -12057,8 +12057,8 @@
 12307	aerosolized oxidized gray mint	0		Effect: "Knightlife", Effect Duration: 16, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
-12310	vaporized narrow squat toxic asset	1		Last Available: "2026-08"
-12311	twisted blue squat intangible asset	1		Effect: "Lubed", Effect Duration: 35, Last Available: "2026-08"
+12310	vaporized squat narrow toxic asset	1		Last Available: "2026-08"
+12311	twisted squat blue intangible asset	1		Effect: "Lubed", Effect Duration: 35, Last Available: "2026-08"
 12312	compressed squat tumbling liquid asset	1		Effect: "Mighty Shout", Effect Duration: 50, Last Available: "2026-08"
 12313	blue gross prophet chrysalis	0		Last Available: "2026-08"
 12314	tumbling cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Sauceror_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Sauceror_Wombat_cafe_booze.txt
@@ -1,8 +1,8 @@
 -1	mediocre Petite Porter	4	decent	
 -2	tolerable Scrawny Stout	4	good	
 -3	enchanted aged Infinitesimal IPA	4	awesome	
--4	lousy weak eggnogtini	2	decent	
--5	weak perfectly mixed candycaine	2	EPIC	
+-4	weak lousy eggnogtini	2	decent	
+-5	perfectly mixed weak candycaine	2	EPIC	
 -6	perfectly mixed watered-down braincracker sweet	2	EPIC	
 -16	drinkable fermented honey	4	good	
 -17	lousy mirror moons-shine	4	decent	
@@ -15,19 +15,19 @@
 -51	weak perfectly mixed Hi-Octane Peppermint Jet Fuel	2	EPIC	
 -58	lousy Grimacider	4	decent	
 -59	drinkable Isotope Nog	3	good	
--60	watered-down bad Mutagin 'n' Tonic	2	decent	
+-60	bad watered-down Mutagin 'n' Tonic	2	decent	
 -70	artisanal Gin and Herring	4	EPIC	
--71	watered-down lousy Black and Tan and Red All Over	2	decent	
--72	weak smooth squat Antarctic Ice Tea	2	awesome	
+-71	lousy watered-down Black and Tan and Red All Over	2	decent	
+-72	smooth weak squat Antarctic Ice Tea	2	awesome	
 -76	bad CRIMBCO Ribbon Candy Schnapps	3	decent	
--77	smooth weak CRIMBCO Egg Substitute Nog Substitute	2	awesome	
--78	special hand-crafted ghostly CRIMBCO Extreme Braincracker Sour	4	EPIC	
+-77	weak smooth CRIMBCO Egg Substitute Nog Substitute	2	awesome	
+-78	hand-crafted special ghostly CRIMBCO Extreme Braincracker Sour	4	EPIC	
 -82	hand-crafted Horseradish-infused Vodka	3	EPIC	
 -83	extra-dry artisanal Jerkitini	5	EPIC	
 -84	mediocre weak Desert Island Iced Tea	2	decent	
 -88	triple-distilled mediocre green Crimbo Saketini	10	decent	
 -89	artisanal shaking Crimboku Drop	4	EPIC	
 -90	aged Flaming Crimbo Log	3	awesome	
--107	mediocre fortified purple Fortified Eggnog Slurry	5	decent	
+-107	fortified mediocre purple Fortified Eggnog Slurry	5	decent	
 -108	fortified perfectly mixed Hot Buttered Rum	5	EPIC	
 -109	aged Spicy Hot Chocolate	3	awesome	

--- a/data/TCRS/TCRS_Sauceror_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Sauceror_Wombat_cafe_food.txt
@@ -5,41 +5,41 @@
 -8	adequate candy cane pizza	3	good	
 -9	rotten gingerbread stir-fry	4	crappy	
 -10	yummy cyan twigs and gravel	4	awesome	
--11	bland miniature jittery shoots and leaves	2	decent	
--12	adequate special gray bowl of unidentifiable goo	3	good	
--13	super-sized bland special gingerbread massacre	5	decent	
+-11	miniature bland jittery shoots and leaves	2	decent	
+-12	special adequate gray bowl of unidentifiable goo	3	good	
+-13	super-sized special bland gingerbread massacre	5	decent	
 -14	rotten narrow It Came From Beyond Dessert	3	crappy	
--15	rotten low-calorie squat vampire cake	1	crappy	
--52	flavorless enchanted blurry Soylent Red and Green	4	decent	
--53	decent miniature green Disc-Shaped Nutrition Unit	2	good	
+-15	low-calorie rotten squat vampire cake	1	crappy	
+-52	enchanted flavorless blurry Soylent Red and Green	4	decent	
+-53	miniature decent green Disc-Shaped Nutrition Unit	2	good	
 -54	massive toothsome Gingerborg Hive	9	awesome	
 -61	bland wobbly Candy Cane Surprise	3	decent	
 -62	jumbo flavorless Grimdrop Chow Mein	5	decent	
--63	half-sized special tasty purple Grimgerbread House	2	awesome	
--67	adequate maroon blinking Caviar Carbonara	4	good	
+-63	tasty special half-sized purple Grimgerbread House	2	awesome	
+-67	adequate blinking maroon Caviar Carbonara	4	good	
 -68	decent Halibut Alfredo	3	good	
 -69	miniature spoiled Red Herring Velvet Cake	2	crappy	
 -73	bland CRIMBCO Reconstituted Gruel	3	decent	
 -74	adequate New and Improved CRIMBCO Reconstituted Gruel	4	good	
--75	small stale shaking CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	decent	
+-75	stale small shaking CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	decent	
 -79	toothsome Brussels Sprout Stir-Fry	3	awesome	
 -80	stale narrow Carrot, Cabbage, and Kale Pizza	3	decent	
 -81	delicious ghostly Turnip and Rutabaga Pie	3	awesome	
 -85	tasty Rainbow Spider Fun Roll	3	awesome	
--86	moldy huge Vegas Volcano Lava Roll	9	crappy	
+-86	huge moldy Vegas Volcano Lava Roll	9	crappy	
 -87	bland Crazy Dragon Shogun Buddha Roll	3	decent	
 -92	miniature stale basic hot dog	2	decent	
 -93	rotten big blue savage macho dog	5	crappy	
--94	stale snack-sized one with everything	2	decent	
+-94	snack-sized stale one with everything	2	decent	
 -95	special rotten sly dog	3	crappy	
--96	normal skewed blinking devil dog	3	good	
--97	fancy stale chilly dog	4	decent	
--98	bland half-sized ghost dog	2	decent	
+-96	normal blinking skewed devil dog	3	good	
+-97	stale fancy chilly dog	4	decent	
+-98	half-sized bland ghost dog	2	decent	
 -99	tasty junkyard dog	4	awesome	
 -100	spoiled wet dog	3	crappy	
 -101	normal sleeping dog	4	good	
 -102	spoiled tumbling optimal dog	3	crappy	
 -103	small moldy video games hot dog	2	crappy	
 -104	yummy teal Peppermint Nutrition Block	4	awesome	
--105	moldy bite-sized enchanted Gingerbread Nutrition Block	1	crappy	
+-105	enchanted moldy bite-sized Gingerbread Nutrition Block	1	crappy	
 -106	flavorless Cinnamon Nutrition Block	3	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Blender.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Blender.txt
@@ -5,7 +5,7 @@
 5	pasta spoon	0		
 6	jittery pulsating crafty ravioli hat	0		Maximum MP: +10, Familiar Effect: "atk, cap 2"
 7	saucepan	0		
-8	lime green jittery spices	0		
+8	jittery lime green spices	0		
 9	disco mask of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, cap 2"
 10	squat disco ball	0		
 11	gray stolen accordion	0		Song Duration: 5
@@ -13,7 +13,7 @@
 14	mixed ghostly moxie weed	1		
 15	dehydrated strongness elixir	1		
 16	boiled narrow magicalness-in-a-can	1		
-17	adequate miniature noodles	2	good	
+17	miniature adequate noodles	2	good	
 18	narrow tortoise's blessing	0		
 19	purple twirling asparagus knife of the boozehound	0		Booze Drop: +100
 20	purple jittery Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -45,14 +45,14 @@
 46	figurine	0		
 47	decent hot buttered roll	3	good	
 48	heart of rock and roll	0		
-49	adequate immense bowl of cottage cheese	6	good	
+49	immense adequate bowl of cottage cheese	6	good	
 50	wobbly smelly Rock and Roll Legend	0		Stench Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10
 51	Knob Goblin Uberpants of incineration	0		Hot Spell Damage: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
 53	spinning huge greasy stone banjo	0		Sleaze Spell Damage: +10
 54	rosewater-soaked brawny Disco Banjo	0		Muscle Percent: +20, Stench Resistance: +3, Class: "Disco Bandit"
 55	jaba&ntilde;ero pepper	0		
-56	green squat hot sauce	0		
+56	squat green hot sauce	0		
 57	5-Alarm Saucepan of the storm	0		Maximum MP Percent: +40, Class: "Sauceror"
 58	stone turtle	0		
 59	huge slingshot	0		
@@ -66,7 +66,7 @@
 67	spaghetti with rock-balls	0		
 68	zippy scorching Pasta Spoon of Peril	0		Hot Damage: +25, Initiative: +20, Class: "Pastamancer"
 69	Newbiesport&trade; tent	0		
-70	jittery teal bar skin	0		
+70	teal jittery bar skin	0		
 71	stakes of the scaredy-cat	0		Monster Level: -15
 72	skewed barskin hat	0		Item Drop: +5, Familiar Effect: "atk, 1xVolley, cap 13"
 73	barskin tent	0		
@@ -87,7 +87,7 @@
 88	meat stack	0		
 89	pulsating sword hilt	0		
 90	helmet recipe	0		
-91	skewed pulsating pants kit	0		
+91	pulsating skewed pants kit	0		
 92	pulsating meatsmithing guide	0		
 93	mirror flame-wreathed basic meat sword	0		Hot Spell Damage: +10
 94	hardy basic meat pants	0		Maximum HP: +50, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -129,7 +129,7 @@
 130	blinking green medical-grade eyepatch	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "4xBarrr, cap 8"
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	mirror wobbly Meat maid body	0		
-133	twirling narrow Certificate of Participation	0		
+133	narrow twirling Certificate of Participation	0		
 134	bitchin' meatcar	0		
 135	sweet rims	0		
 136	tires	0		
@@ -157,18 +157,18 @@
 158	huge Gnollish pie tin	0		
 159	wad of dough	0		
 160	shaking huge pie crust	0		
-161	bland thick ghuol egg	5	decent	
+161	thick bland ghuol egg	5	decent	
 162	stale ghuol egg quiche	4	decent	
 163	horrifying skeleton bone	0		Spooky Damage: +25
 164	smart skull	0		
 165	blurry skewer	0		
 166	ghuol ears	0		
-167	spoiled diet narrow ghuol-ear kabob	1	crappy	
+167	diet spoiled narrow ghuol-ear kabob	1	crappy	
 168	spinning friendly bone rattle	0		Familiar Weight: +3
 169	huge bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	small normal lihc eye pie	2	good	
-172	narrow huge gnoll lips	0		
+171	normal small lihc eye pie	2	good	
+172	huge narrow gnoll lips	0		
 173	taco shell	0		
 174	narrow Gnollish casserole dish	0		
 175	miniature yummy uncooked chorizo	2	awesome	
@@ -215,7 +215,7 @@
 217	bland herb brownies	3	decent	
 218	hemp string	0		
 219	necklace chain	0		
-220	lime green bouncing gnoll teeth	0		
+220	bouncing lime green gnoll teeth	0		
 221	vibrating gnoll-tooth necklace	0		Maximum MP Percent: +10
 222	spinning phat turquoise bead	0		
 223	nippy phat turquoise bracelet	0		Cold Damage: +10
@@ -240,28 +240,28 @@
 242	normal immense jittery	6	good	
 243	bland grapefruit	3	decent	
 244	bland half-sized grapes	2	decent	
-245	adequate immense olive	7	good	
+245	immense adequate olive	7	good	
 246	yummy wobbly tomato	3	awesome	
 247	lime green narrow fermenting powder	0		
 248	hand-crafted squat salty dog	3	EPIC	
 249	delicious bloody mary	4	awesome	
 250	mediocre screwdriver	3	decent	
 251	mediocre martini	3	decent	
-252	perfectly mixed spirit-forward tumbling bloody beer	5	EPIC	
+252	spirit-forward perfectly mixed tumbling bloody beer	5	EPIC	
 253	drinkable shot of schnapps	4	good	
 254	lousy shot of grapefruit schnapps	3	decent	
 255	aged fine wine	4	awesome	
-256	practically non-alcoholic bad shot of tomato schnapps	1	decent	
+256	bad practically non-alcoholic shot of tomato schnapps	1	decent	
 257	acceptable watered-down extra-spicy bloody mary	2	good	
 258	spinning dense meat stack	0		
 259	snake skin	0		
-260	stale big White Citadel fries	5	decent	
+260	big stale White Citadel fries	5	decent	
 261	decent White Citadel burger	3	good	
 262	rotten small olive piece of wedding cake	2	crappy	
 263	decent gigantic chocolate chips	9	good	
-264	decent enchanted skewed jittery chocolate chip cookies	3	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 5
+264	enchanted decent skewed jittery chocolate chip cookies	3	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 5
 265	Newton's satin pants	0		Experience (Mysticality): +3, Familiar Effect: "atk, 2xPotato, cap 10"
-266	acceptable watered-down skewed lightning	2	good	
+266	watered-down acceptable skewed lightning	2	good	
 267	sage mullet wig	0		Mysticality Percent: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	tumbling meat cowboy hat of chilblains	0		Cold Damage: +25, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	blinking deadly sword	0		Weapon Damage: +5
@@ -298,7 +298,7 @@
 300	anodized adjusted squat jaba&ntilde;ero-flavored chewing gum	0		Effect: "Winning Smile", Effect Duration: 47
 301	flat dough	0		
 302	flavorless low-calorie upside-down Knob sausage	1	decent	
-303	spoiled fancy Knob mushroom	4	crappy	Effect: "Stinking Cloud", Effect Duration: 10
+303	fancy spoiled Knob mushroom	4	crappy	Effect: "Stinking Cloud", Effect Duration: 10
 304	dry noodles	0		
 305	narrow wobbly green prompt Knob Goblin harem pants	0		Adventures: +3, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	Rosewater's Knob Goblin harem veil	0		Mysticality Percent: +30, Familiar Effect: "5xLep, cap 2"
@@ -311,17 +311,17 @@
 313	energetic Crown of the Goblin King	0		Maximum MP Percent: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	rotten massive blurry bean burrito	10	crappy	
 315	spoiled spinning bean burrito	3	crappy	
-316	snack-sized normal insanely bean burrito	2	good	
+316	normal snack-sized insanely bean burrito	2	good	
 317	diet delicious bean burrito	1	awesome	
-318	decent enchanted bean burrito	4	good	Effect: "Feet of Watermelon", Effect Duration: 35
-319	moldy immense twirling insanely bean burrito	10	crappy	
-320	snack-sized bland twirling mirror bat haggis	2	decent	
+318	enchanted decent bean burrito	4	good	Effect: "Feet of Watermelon", Effect Duration: 35
+319	immense moldy twirling insanely bean burrito	10	crappy	
+320	bland snack-sized mirror twirling bat haggis	2	decent	
 321	bland maroon menudo	3	decent	
-322	yummy thick goat cheese	5	awesome	
-323	thick rotten shaking plain pizza	5	crappy	
-324	stale snack-sized purple sausage pizza	2	decent	
+322	thick yummy goat cheese	5	awesome	
+323	rotten thick shaking plain pizza	5	crappy	
+324	snack-sized stale purple sausage pizza	2	decent	
 325	spoiled thick goat cheese pizza	5	crappy	
-326	immense adequate mushroom pizza	9	good	
+326	adequate immense mushroom pizza	9	good	
 327	blurry blinking goat	0		
 328	bad bottle of whiskey	4	decent	
 329	skewed crafty goat beard	0		Maximum MP: +10, Familiar Effect: "atk, 1xPotato, cap 15"
@@ -345,7 +345,7 @@
 347	Dyspepsi-Cola	0		
 348	blurry blinking Samson's ninja mask	0		Experience (Muscle): +5, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	ghostly icy katana hilt	0		
-350	jittery blurry hot katana blade	0		
+350	blurry jittery hot katana blade	0		
 351	veiny icy-hot katana of extreme caution	0		Maximum HP: +10, Monster Level: -25
 352	ninja hot pants of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "hot atk, 3xPotato, cap 17"
 353	spinning ninja stars	0		
@@ -353,8 +353,8 @@
 355	skewed eXtreme scarf of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	snowboarder pants of the glutton	0		Food Drop: +100, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	half-sized enchanted yummy narrow gr8ps	2	awesome	Effect: "There Wolf", Effect Duration: 15
-359	gigantic delicious spinning t8r tots	10	awesome	
+358	yummy enchanted half-sized narrow gr8ps	2	awesome	Effect: "There Wolf", Effect Duration: 15
+359	delicious gigantic spinning t8r tots	10	awesome	
 360	wobbly horrifying miner's helmet	0		Spooky Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	rosy-cheeked miner's pants	0		Maximum HP Percent: +30, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	yellow squat 7-Foot Dwarven mattock of vim and vigor	0		Maximum HP Percent: +50
@@ -383,7 +383,7 @@
 385	healthy savvy chrome staff	0		Mysticality Percent: +20, Maximum HP Percent: +20
 386	shaking ghostly mansplainer's hardened chrome crossbow	0		Damage Reduction: 3, Monster Level: +15
 387	fuzzy dice	0		
-388	huge maroon spinning yeti fur	0		
+388	spinning maroon huge yeti fur	0		
 389	green forbidden meaty helmet turtle	0		Spell Damage Percent: +50, Familiar Effect: "sleaze atk, 1xFairy, cap 17"
 390	yellow asbestos helmet turtle of the brute	0		Muscle Percent: +30, Familiar Effect: "hot atk, 1xFairy, cap 20"
 391	wholesome linoleum helmet turtle	0		Maximum HP Percent: +10, Familiar Effect: "stench atk, 1xFairy, cap 25"
@@ -395,7 +395,7 @@
 397	squat executive yakskin pants	0		Meat Drop: +40, Familiar Effect: "stench atk, 1xPotato, cap 35"
 398	wobbly Van der Graaf hippopotamus pants	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
 399	fuchsia Rosewater's eXtreme mittens	0		Mysticality Percent: +30
-400	tumbling pulsating handful of drink tickets	0		
+400	pulsating tumbling handful of drink tickets	0		
 401	Knob Kitchen grab-bag	0		
 402	sage swashbuckling pants	0		Mysticality Percent: +10, Familiar Effect: "3xPotato, 1.5xFairy, cap 20"
 403	stiffened shoulder parrot	0		Damage Reduction: 1
@@ -450,7 +450,7 @@
 452	disease	0		
 453	blurry sober pill	0		
 454	screwdriver	0		
-455	decent huge jumbo olive	10	good	
+455	huge decent jumbo olive	10	good	
 456	bad extra-dry dry martini	5	decent	
 457	avaricious ye olde golde frontes	0		Meat Drop: +30, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
@@ -474,7 +474,7 @@
 476	spinning hellion cube	0		
 477	infernal insoles of James Dean of the brazier	0		Experience (Moxie): +3, Hot Spell Damage: +25
 478	evil arch	0		
-479	jittery tumbling dodecagram	0		
+479	tumbling jittery dodecagram	0		
 480	huge box of birthday candles	0		
 481	eldritch butterknife	0		
 482	Mr. Container of the storm	0		Maximum MP Percent: +40, Last Available: "2004-12"
@@ -488,12 +488,12 @@
 490	fuchsia horrifying chilly mesh cap	0		Cold Damage: +5, Spooky Damage: +25, Familiar Effect: "atk, 1xVolley, cap 41"
 491	enormous belt buckle	0		
 492	healthy chaps of the detective	0		Maximum HP Percent: +20, Item Drop: +20, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
-493	mirror narrow ketchup hound	0		
+493	narrow mirror ketchup hound	0		
 494	forbidden batblade	0		Spell Damage Percent: +50
 495	blurry catgut	0		
 496	cat appendix	0		
 497	blurry gnatwing	0		
-498	half-sized adequate papaya	2	good	
+498	adequate half-sized papaya	2	good	
 499	purple hardy denim axe of the cougar	0		Moxie: +20, Maximum HP: +50
 500	Elf Farm Raffle ticket	0		
 501	bland Elfin shortbread	3	decent	
@@ -508,7 +508,7 @@
 510	blurry Boris's key lime	0		
 511	green Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	gigantic adequate blinking Boris's key lime pie	10	good	
+513	adequate gigantic blinking Boris's key lime pie	10	good	
 514	stale Jarlsberg's key lime pie	4	decent	
 515	normal fancy Sneaky Pete's key lime pie	3	good	Effect: "Texas Elegance", Effect Duration: 45
 516	squat Hey Deze map	0		
@@ -525,7 +525,7 @@
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	skewed fertilized ghuol egg	0		
-530	denatured improved magnetized teal bouncing spray paint	0		Effect: "Ticking Clock", Effect Duration: 60
+530	denatured improved magnetized bouncing teal spray paint	0		Effect: "Ticking Clock", Effect Duration: 60
 531	fireproof special sauce glove	0		Hot Resistance: +3, Class: "Sauceror", Single Equip
 532	careful ladle of mystery	0		Monster Level: -10, Class: "Sauceror"
 533	green Gnollish toolbox	0		
@@ -559,7 +559,7 @@
 561	pregnant mushroom	0		
 562	red ratgut	0		
 563	pulsating sonar-in-a-biscuit	0		
-564	artisanal strong skewed Mad Train wine	5	EPIC	
+564	strong artisanal skewed Mad Train wine	5	EPIC	
 565	baleful hobo gloves	0		Spell Damage: +25, Single Equip
 566	healthy bum cheek	0		Maximum HP Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	bouncing hermit script	0		
@@ -570,11 +570,11 @@
 572	flavorless mirror Children's Meal of the Damned	3	decent	
 573	decent small noodles	2	good	
 574	adequate noodles	3	good	
-575	delicious diet blurry painful penne pasta	1	awesome	
-576	decent shaking huge ravioli della hippy	3	good	
-577	spoiled enchanted tiny pulsating pr0n m4nic0tti	1	crappy	Effect: "Cat-Alyzed", Effect Duration: 50
+575	diet delicious blurry painful penne pasta	1	awesome	
+576	decent huge shaking ravioli della hippy	3	good	
+577	enchanted tiny spoiled pulsating pr0n m4nic0tti	1	crappy	Effect: "Cat-Alyzed", Effect Duration: 50
 578	flavorless Hell ramen	3	decent	
-579	special spoiled boring spaghetti	4	crappy	Effect: "Chalked-Up Teeth", Effect Duration: 10
+579	spoiled special boring spaghetti	4	crappy	Effect: "Chalked-Up Teeth", Effect Duration: 10
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	squat Himalayan Hidalgo sauce	0		
@@ -641,11 +641,11 @@
 643	skeleton key ring	0		
 644	teal Crimbo pressie	0		Last Available: "2003-12"
 645	mirror wrapping paper	0		Last Available: "2003-12"
-646	massive adequate fruitcake	6	good	
+646	adequate massive fruitcake	6	good	
 647	wobbly present	0		Last Available: "2004-11"
 648	electrified Crimbo sword	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-10"
-649	occult Crimbo hat	0		Spell Damage Percent: +25, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	mirror Crimbo pants of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	occult Crimbo hat	0		Spell Damage Percent: +25, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	mirror Crimbo pants of Flo-Jo	0		Initiative: +100, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	exclusive ultra-rare item of temperance	0		Sleaze Resistance: +5
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -668,18 +668,18 @@
 670	lihc face of the storm	0		Maximum MP Percent: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	occult educational grave robbing shovel	0		Experience: +1, Spell Damage Percent: +25
 672	normal cranberries	3	good	
-673	boozy drinkable vodka and cranberry	5	good	
+673	drinkable boozy vodka and cranberry	5	good	
 674	perfectly mixed jittery whiskey	4	EPIC	
 675	sizzling skull of the Bonerdagon	0		Hot Damage: +10
 676	wobbly dragonbone belt buckle	0		
 677	beefcake's badass belt	0		Muscle: +25
 678	chest of the Bonerdagon	0		
 679	perfectly mixed mirror roll in the hay	4	EPIC	
-680	triple-distilled drinkable slap and tickle	8	good	
-681	practically non-alcoholic perfectly mixed slip 'n' slide	1	super ultra mega turbo EPIC	
-682	watered-down drinkable a sump'm sump'm	2	good	
+680	drinkable triple-distilled slap and tickle	8	good	
+681	perfectly mixed practically non-alcoholic slip 'n' slide	1	super ultra mega turbo EPIC	
+682	drinkable watered-down a sump'm sump'm	2	good	
 683	acceptable horizontal tango	3	good	
-684	bad purple tumbling pink pony	3	decent	
+684	bad tumbling purple pink pony	3	decent	
 685	chilly chaotic wicked Mr. Shirt	0		Spell Damage: +5, Spell Critical Percent: +10, Cold Damage: +5
 686	upside-down olive Sherlock's knuckles	0		Item Drop: +25
 687	aerosolized purple blood of the Wereseal	0		Effect: "Unusual Perspective", Effect Duration: 11
@@ -716,7 +716,7 @@
 720	porquoise necklace of mayonnaise of the boozehound	0		Sleaze Spell Damage: +50, Booze Drop: +100, Single Equip
 721	MacGyver's porquoise bracelet of the overflowing toilet	0		Maximum MP: +100, Stench Spell Damage: +50
 722	yellow Jim Carey's porquoise ring of Calamity Jane of mayonnaise	0		Critical Hit Percent: +15, Monster Level: +25, Sleaze Spell Damage: +50, Single Equip
-723	enchanted normal immense Knoll mushroom	8	good	Effect: "Salsa Satanica", Effect Duration: 30
+723	enchanted immense normal Knoll mushroom	8	good	Effect: "Salsa Satanica", Effect Duration: 30
 724	spoiled mushroom	3	crappy	
 725	spinning one million meat pancakes	0		
 726	reassuring huge mirror shard	0		Spooky Resistance: +1
@@ -742,10 +742,10 @@
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	moldy warm mushroom	3	crappy	
-750	huge rotten mushroom quesadilla	7	crappy	
+750	rotten huge mushroom quesadilla	7	crappy	
 751	bland miniature cool mushroom	2	decent	
-752	snack-sized tasty cool mushroom casserole	2	awesome	
-753	jumbo rotten pointy mushroom	5	crappy	
+752	tasty snack-sized cool mushroom casserole	2	awesome	
+753	rotten jumbo pointy mushroom	5	crappy	
 754	rotten half-sized gray cream of pointy mushroom soup	2	crappy	
 755	adequate immense mushroom	6	good	
 756	flavorless enchanted blurry mushroom	3	decent	Effect: "Eldritch Concentration", Effect Duration: 50
@@ -780,19 +780,19 @@
 785	raffle ticket	0		
 786	normal strawberry	3	good	
 787	perfectly mixed high-proof bottle of rum	9	EPIC	
-788	high-proof smooth bouncing strawberry daiquiri	10	awesome	
-789	special perfectly mixed triple-distilled blinking rum and cola	10	EPIC	Effect: "How to Scam Tourists", Effect Duration: 20
-790	lousy weak grog	2	decent	
+788	smooth high-proof bouncing strawberry daiquiri	10	awesome	
+789	triple-distilled perfectly mixed special blinking rum and cola	10	EPIC	Effect: "How to Scam Tourists", Effect Duration: 20
+790	weak lousy grog	2	decent	
 791	pulsating blue brawny Mafia bow tie of the early riser	0		Muscle Percent: +20, Adventures: +7, Last Available: "2004-10"
 792	huge Jim Carey's Golden Mr. Accessory	0		Monster Level: +25, Softcore Only
 793	enhanced liquefied lime green oil of stability	0		Effect: "Scorpio Rising", Effect Duration: 45
 794	modified ionized oil of slipperiness	0		Effect: "Mucilaginous Muscle", Effect Duration: 46
-795	bad special Acque Luride Grezze Cabernet	3	decent	Effect: "The Style... of the Future", Effect Duration: 15, Last Available: "2004-10"
+795	special bad Acque Luride Grezze Cabernet	3	decent	Effect: "The Style... of the Future", Effect Duration: 15, Last Available: "2004-10"
 796	jittery vibrating occult stylish cement shoes	0		Moxie: +25, Spell Damage Percent: +25, Maximum MP Percent: +10, Last Available: "2004-10"
-797	practically non-alcoholic drinkable rockin' wagon	1	good	
+797	drinkable practically non-alcoholic rockin' wagon	1	good	
 798	acceptable narrow ocean motion	3	good	
-799	tolerable special watered-down fuzzbump	2	good	Effect: "Human-Human Hybrid", Effect Duration: 45
-800	stale diet green blurry poutine	1	decent	
+799	watered-down special tolerable fuzzbump	2	good	Effect: "Human-Human Hybrid", Effect Duration: 45
+800	stale diet blurry green poutine	1	decent	
 801	huge spoiled squat Knob stir-fry	7	crappy	
 804	normal Knoll stir-fry	3	good	
 805	flavorless tiny twirling stir-fry	1	decent	
@@ -803,11 +803,11 @@
 810	normal rat appendix stir-fry	3	good	
 811	toothsome lime green tofu stir-fry	3	awesome	
 812	tasty pr0n stir-fry	3	awesome	
-813	tiny stale Knob shells	1	decent	
+813	stale tiny Knob shells	1	decent	
 814	huge moldy mirror b&auml;tzle	7	crappy	
 815	toothsome ratini	4	awesome	
 816	decent Knob stroganoff	3	good	
-817	adequate gigantic menudo ravioli	7	good	
+817	gigantic adequate menudo ravioli	7	good	
 818	plus sign	0		
 819	shaking milky potion	0		
 820	pulsating swirly potion	0		
@@ -829,12 +829,12 @@
 836	spoiled fancy mind flayer corpse	3	crappy	Effect: "Glittering Eyelashes", Effect Duration: 40
 837	artisanal Uovo Marcio Shiraz	3	super EPIC	Last Available: "2004-10"
 838	frightening Mafia stogie of doom	0		Spooky Damage: +5, Spooky Spell Damage: +50, Last Available: "2004-10"
-839	fancy artisanal pulsating Maiali Sifilitici Pinot Noir	3	super EPIC	Effect: "Witch Breaded", Effect Duration: 40, Last Available: "2004-10"
+839	artisanal fancy pulsating Maiali Sifilitici Pinot Noir	3	super EPIC	Effect: "Witch Breaded", Effect Duration: 40, Last Available: "2004-10"
 840	rosy-cheeked Rosewater's Mafia violin case	0		Mysticality Percent: +30, Maximum HP Percent: +30, Last Available: "2004-10"
 841	tolerable irresponsibly strong blurry tomato daiquiri	8	good	
 842	mediocre beertini	3	decent	
-843	practically non-alcoholic hand-crafted spinning salty slug	1	EPIC	
-844	bad enchanted papaya slung	3	decent	Effect: "One Foot Heavier", Effect Duration: 25
+843	hand-crafted practically non-alcoholic spinning salty slug	1	EPIC	
+844	enchanted bad papaya slung	3	decent	Effect: "One Foot Heavier", Effect Duration: 25
 845	executive MAHI fez	0		Meat Drop: +40, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	blue hypodermic needle	0		Familiar Weight: +5
@@ -853,7 +853,7 @@
 861	huge chocolate spurs	0		Familiar Weight: +5
 862	magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
-864	bouncing mirror stinger	0		Familiar Weight: +5
+864	mirror bouncing stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	liquefied vacuum-sealed blurry pine tar	0		Effect: "You're High as a Crow, Marty", Effect Duration: 42
@@ -892,13 +892,13 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	drinkable Spasmi Dolorosi Del Rene Champagne	3	good	Last Available: "2004-10"
-904	Tesla curative school Mafia knickerbockers of the boozehound	0		Booze Drop: +100, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	Tesla curative school Mafia knickerbockers of the boozehound	0		Booze Drop: +100, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	wet wet ionized Yummy Tummy bean	0		Effect: "Human-Horror Hybrid", Effect Duration: 42
 906	vacuum-sealed Rock Pops	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 14
 907	wet deionized Mr. Mediocrebar	0		Effect: "Disco State of Mind", Effect Duration: 26
 908	aerosolized dry Cold Hots candy	0		Effect: "Rotten Memories", Effect Duration: 16
 909	tarnished Wint-O-Fresh mint	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 64
-910	normal gigantic dwarf bread	6	good	
+910	gigantic normal dwarf bread	6	good	
 911	deionized bouncing Senior Mints	0		Effect: "The Power of LOV", Effect Duration: 54
 912	wet pixellated candy heart	0		Effect: "In a Lather", Effect Duration: 41
 913	magnetized kobold	0		Effect: "Spell Transfer Complete", Effect Duration: 35
@@ -906,19 +906,19 @@
 915	upside-down yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	Usain Bolt's flame-wreathed intergalactic pom poms	0		Hot Spell Damage: +10, Initiative: +80
 917	upside-down Mob Penguin protection contract	0		
-918	Radio Free Baseball Cap of the businessman	0		Meat Drop: +50, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	Radio Free Pants of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	Radio Free Baseball Cap of the businessman	0		Meat Drop: +50, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	Radio Free Pants of the storm	0		Maximum MP Percent: +40, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	Sinatra's Radio Free Foil	0		Experience (Moxie): +5, Last Available: "2006-07"
-921	diet bland fancy radio button candy	1	decent	Effect: "Bone Homie", Effect Duration: 25
+921	bland fancy diet radio button candy	1	decent	Effect: "Bone Homie", Effect Duration: 25
 922	up-at-dawn severed rocking horse head	0		Adventures: +5
 923	spinning broken cellular phone	0		Last Available: "2004-01"
-924	twirling squat upside-down crimbo elfling	0		Free Pull, Last Available: "2011-12"
+924	squat upside-down twirling crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	spinning skewed dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	polymerized warmed mirror Hawking's Elixir of Brilliance	0		Effect: "Chari Tea", Effect Duration: 48
 927	smooth Ferita Del Petto Zinfandel	3	awesome	Last Available: "2006-12"
 928	huge deadly fuzzy bracelets	0		Weapon Damage: +5
 929	tumbling green chaotic arse-shooting crossbow	0		Spell Critical Percent: +10
-931	special mediocre triple-distilled spiced rum	10	decent	Effect: "Ogred and Oublietted", Effect Duration: 30
+931	mediocre triple-distilled special spiced rum	10	decent	Effect: "Ogred and Oublietted", Effect Duration: 30
 932	high-proof acceptable blurry eggnog	8	good	
 933	bland candy cane	3	decent	
 934	diet stale gingerbread bugbear	1	decent	
@@ -929,15 +929,15 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	fuchsia bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	smooth bowler	0		Moxie: +15, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	smooth bowler	0		Moxie: +15, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	sharpshooter's savvy bow staff	0		Mysticality Percent: +20, Critical Hit Percent: +10, Last Available: "2004-12"
-944	rosewater-soaked bowlegged pants	0		Stench Resistance: +3, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	rosewater-soaked bowlegged pants	0		Stench Resistance: +3, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	artisanal gray martini	3	super ultra EPIC	Last Available: "2004-12"
 949	acceptable grogtini	3	good	Last Available: "2004-12"
-950	high-proof artisanal cherry bomb	10	EPIC	Last Available: "2004-12"
+950	artisanal high-proof cherry bomb	10	EPIC	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	lard-coated horrifying hockey mask	0		Spooky Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
@@ -945,7 +945,7 @@
 955	cyan blinking auspicious fez of etymology	0		Item Drop: +10, Familiar Effect: "1xLep, cap 30"
 956	rotten snack-sized carob chunk noodles	2	crappy	
 957	normal chorizo brownies	4	good	
-958	diet normal chocolate and tomato pizza	1	good	
+958	normal diet chocolate and tomato pizza	1	good	
 959	wobbly flange	0		
 960	clockwork key	0		
 961	twirling silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -995,12 +995,12 @@
 1008	purple ice cubes of the cheetah	0		Initiative: +60
 1009	bad mirror vodka martini	3	decent	
 1010	weak perfectly mixed whiskey and soda	2	EPIC	
-1011	watered-down artisanal spinning maroon monkey wrench	2	EPIC	
+1011	artisanal watered-down maroon spinning monkey wrench	2	EPIC	
 1012	artisanal tequila sunrise	3	EPIC	
 1013	bad margarita	4	decent	
-1014	weak hand-crafted squat twirling strawberry wine	2	EPIC	
-1015	acceptable extra-dry green spinning wine spritzer	5	good	
-1016	perfectly mixed practically non-alcoholic skewed spinning perpendicular hula	1	super ultra mega turbo EPIC	
+1014	hand-crafted weak twirling squat strawberry wine	2	EPIC	
+1015	extra-dry acceptable spinning green wine spritzer	5	good	
+1016	practically non-alcoholic perfectly mixed skewed spinning perpendicular hula	1	super ultra mega turbo EPIC	
 1017	mediocre ducha de oro	3	decent	
 1018	practically non-alcoholic acceptable calle de miel	1	good	
 1019	artisanal dry vodka martini	3	EPIC	
@@ -1012,7 +1012,7 @@
 1025	smooth narrow sangria del diablo	4	awesome	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
-1028	shaking teal buckler buckle	0		
+1028	teal shaking buckler buckle	0		
 1029	horrifying hippo whip	0		Spooky Damage: +25
 1030	ghostly beefcake's penguin whip	0		Muscle: +25
 1031	teal nippy yak whip	0		Cold Damage: +10
@@ -1024,13 +1024,13 @@
 1037	shaking healthy gnauga hide buckler	0		Maximum HP Percent: +20, Damage Reduction: 5
 1038	activated chilled Vulcanized Connery's Elixir of Audacity	0		Effect: "The Spy Who Loved XP", Effect Duration: 62
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	acceptable practically non-alcoholic beer	1	good	
+1041	practically non-alcoholic acceptable beer	1	good	
 1042	spinning lion tamer's string of beads	0		Experience (familiar): +2
 1043	aromatic string of beads	0		Stench Resistance: +1
 1044	sharpshooter's string of beads	0		Critical Hit Percent: +10
 1045	nasty plastic bottle opener	0		Stench Damage: +5
-1046	boxer's traffic cone of the cheetah	0		Muscle Percent: +10, Initiative: +60, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	aged distilled N. O. Beer	5	awesome	
+1046	boxer's traffic cone of the cheetah	0		Muscle Percent: +10, Initiative: +60, Last Available: "2005-03", Familiar Effect: "cap 15"
+1047	distilled aged N. O. Beer	5	awesome	
 1048	dehydrated jittery mirror oyster egg	1		
 1049	modified oyster egg	1		
 1050	diluted oyster egg	1		
@@ -1040,7 +1040,7 @@
 1054	vaporized wobbly narrow oyster egg	1		
 1055	plastic oyster egg	0		
 1056	distilled bouncing puce oyster egg	1		
-1057	compressed pulsating blinking puce oyster egg	1		Effect: "Pwnd", Effect Duration: 25
+1057	compressed blinking pulsating puce oyster egg	1		Effect: "Pwnd", Effect Duration: 25
 1058	twisted puce oyster egg	1		Effect: "Virgo Rising", Effect Duration: 35
 1059	puce plastic oyster egg	0		
 1060	mixed pulsating lime green mauve oyster egg	1		
@@ -1055,11 +1055,11 @@
 1069	dried yellow oyster egg	1		Effect: "Hyperoxygenated Blood", Effect Duration: 35
 1070	dried red squat oyster egg	1		
 1071	plastic oyster egg	0		
-1072	modified narrow narrow skewed off-white oyster egg	1		
+1072	modified skewed narrow narrow off-white oyster egg	1		
 1073	powdered spinning off-white oyster egg	1		Effect: "Hyperoffended", Effect Duration: 45
 1074	distilled off-white oyster egg	1		
 1075	bouncing off-white plastic oyster egg	0		
-1076	diluted squat purple oyster egg	1		
+1076	diluted purple squat oyster egg	1		
 1077	compressed squat oyster egg	1		
 1078	modified blinking oyster egg	1		Effect: "Good Karma", Effect Duration: 40
 1079	bouncing plastic oyster egg	0		
@@ -1078,7 +1078,7 @@
 1092	clockwork sheet	0		
 1093	skewed clockwork counterclockwise dome	0		
 1094	upside-down clockwork sphere	0		
-1095	blurry jittery deactivated MicroMechaMech	0		
+1095	jittery blurry deactivated MicroMechaMech	0		
 1096	clockwork endoskeleton	0		
 1097	stiffened clockwork hat	0		Damage Reduction: 1, Familiar Effect: "atk, 1xVolley, cap 20"
 1098	deadly clockwork trench coat	0		Weapon Damage: +5
@@ -1086,7 +1086,7 @@
 1100	medical-grade gnauga hide chaps	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 4xBarrr, cap 20"
 1101	gray false eyelashes	0		Familiar Weight: +5
 1102	blue targeting chip	0		
-1103	blue skewed unwound clockwork grapefruit	0		
+1103	skewed blue unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
 1106	clockwork chef head	0		
@@ -1099,7 +1099,7 @@
 1113	clockwork maid	0		
 1114	jittery tisket	0		
 1115	tasket	0		
-1116	lime green skewed annoying pitchfork	0		Monster Level: +5
+1116	skewed lime green annoying pitchfork	0		Monster Level: +5
 1117	miser's Stupid University Diploma of doom of courage	0		Spooky Spell Damage: +50, Spooky Resistance: +3, Meat Drop: +10
 1118	pregnant mushroom	0		
 1119	shaking pregnant mushroom	0		
@@ -1123,7 +1123,7 @@
 1137	strapping bicycle chain of Tarzan	0		Muscle: +5, Experience (Muscle): +3
 1138	mushroom fermenting solution	0		
 1139	acceptable mushroom wine	4	good	
-1140	acceptable weak icy mushroom wine	2	good	
+1140	weak acceptable icy mushroom wine	2	good	
 1141	perfectly mixed tumbling mushroom wine	3	EPIC	
 1142	spirit-forward mediocre pointy mushroom wine	5	decent	
 1143	extra-dry smooth flat mushroom wine	5	awesome	
@@ -1145,7 +1145,7 @@
 1160	squat huge green up-at-dawn irate sombrero	0		Adventures: +5, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
 1162	tarnished handsomeness potion	0		Effect: "Mistified", Effect Duration: 24
-1163	wet wet blue blurry marzipan skull	0		Effect: "French Bronilla Brogueishness", Effect Duration: 51
+1163	wet wet blurry blue marzipan skull	0		Effect: "French Bronilla Brogueishness", Effect Duration: 51
 1164	bouncing poultrygeist	0		
 1165	hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
@@ -1164,7 +1164,7 @@
 1179	huge daisy	0		
 1180	squat huge potted fern	0		
 1181	tumbling tulip	0		
-1182	purple ghostly Venus flytrap	0		
+1182	ghostly purple Venus flytrap	0		
 1183	all-purpose flower	0		
 1184	exotic orchid	0		
 1185	long-stemmed rose	0		
@@ -1187,12 +1187,12 @@
 1202	adequate Happy Birthday, Claude! cake	4	good	
 1203	big adequate personalized birthday cake	5	good	
 1204	stale three-tiered wedding cake	4	decent	
-1205	rotten small babycakes	2	crappy	
+1205	small rotten babycakes	2	crappy	
 1206	moldy velvet cake	3	crappy	
 1207	yummy jumbo spinning congratulatory cake	5	awesome	
 1208	adequate super-sized jittery angel-food cake	5	good	
 1209	normal mirror devil's-food cake	4	good	
-1210	super-sized moldy bouncing birthday party jellybean cheesecake	5	crappy	
+1210	moldy super-sized bouncing birthday party jellybean cheesecake	5	crappy	
 1211	gray balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
@@ -1240,7 +1240,7 @@
 1256	moldy insanely jumping bean burrito	4	crappy	
 1257	enchanted flavorless rat scrapple	3	decent	Effect: "Uncucumbered", Effect Duration: 25
 1258	green pail of pretentious paint	0		
-1259	lion tamer's wicked traffic cone	0		Spell Damage: +5, Experience (familiar): +2, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	lion tamer's wicked traffic cone	0		Spell Damage: +5, Experience (familiar): +2, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	huge wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	twisted Hatorade	1		
 1262	squat lard-coated thinker's off-hand balloon of Gandalf	0		Mysticality: +10, Spell Critical Percent: +20, Sleaze Spell Damage: +25
@@ -1287,7 +1287,7 @@
 1303	huge Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	rosewater-soaked Sinatra's traffic cone	0		Experience (Moxie): +5, Stench Resistance: +3, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	rosewater-soaked Sinatra's traffic cone	0		Experience (Moxie): +5, Stench Resistance: +3, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1297,15 +1297,15 @@
 1313	tumbling censurious Baron von Ratsworth's money clip	0		Sleaze Resistance: +3, Single Equip
 1314	yellow tumbling Tesla Baron von Ratsworth's tophat	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
 1315	clever rose-colored glasses	0		Maximum MP: +20
-1316	tumbling twirling facsimile dictionary	0		
+1316	twirling tumbling facsimile dictionary	0		
 1317	wobbly blood flower	0		
 1318	green lovecat tail	0		
 1319	plastic passion fruit	0		
 1320	flavorless questionable taco	3	decent	
 1321	wobbly Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	upside-down petrified time	0		Last Available: "2005-10"
-1323	occult time helmet	0		Spell Damage Percent: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	rosewater-soaked time trousers	0		Stench Resistance: +3, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	occult time helmet	0		Spell Damage Percent: +25, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	rosewater-soaked time trousers	0		Stench Resistance: +3, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	teal aromatic time sword	0		Stench Resistance: +1, Last Available: "2005-10"
 1326	Dyspepsi-Cola helmet of the detective	0		Item Drop: +20, Familiar Effect: "3xFairy, cap 7"
 1327	dance instructor's Cloaca-Cola shield	0		Experience Percent (Moxie): +10, Damage Reduction: 4
@@ -1325,22 +1325,22 @@
 1342	blurry picture of a dead guy's girlfriend	0		
 1343	purple zombie pineal gland	0		Last Available: "2005-11"
 1344	vacuum-sealed adjusted Gummi-Gnauga	0		Effect: "New and Improved", Effect Duration: 63
-1345	super-deionized gray narrow Now and Earlier	0		Effect: "Limber as Mortimer", Effect Duration: 28, Last Available: "2020-09"
+1345	super-deionized narrow gray Now and Earlier	0		Effect: "Limber as Mortimer", Effect Duration: 28, Last Available: "2020-09"
 1346	denatured huge jittery cyan Sugar Cog	0		Effect: "Employee of the Month", Effect Duration: 11
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	empty blowgun	0		Last Available: "2005-11"
 1349	maroon miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	upside-down huge 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	huge pinky ring of the ox	0		Muscle: +20, Single Equip
-1352	hand-crafted weak blinking redrum	2	EPIC	
+1352	weak hand-crafted blinking redrum	2	EPIC	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	miniature delicious bowl of oriole's nest soup	2	awesome	
 1356	spinning bouncing bunny liver	0		
-1357	drinkable watered-down yellow Mt. Noob Pale Ale	2	good	
+1357	watered-down drinkable yellow Mt. Noob Pale Ale	2	good	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
-1360	huge ghostly pirate zombie robot head	0		Last Available: "2005-11"
+1360	ghostly huge pirate zombie robot head	0		Last Available: "2005-11"
 1361	huge cool disembodied smile	0		Moxie: +5, Single Equip
 1362	sausage	0		
 1363	clockwork pirate skull	0		
@@ -1384,13 +1384,13 @@
 1402	rag doll of chilblains	0		Cold Damage: +25, Last Available: "2005-12"
 1403	shaking lion tamer's can of fake snow	0		Experience (familiar): +2, Last Available: "2005-12"
 1404	maroon frosty colored-light &quot;necklace&quot;	0		Cold Spell Damage: +10, Last Available: "2005-12"
-1405	fireproof tree skirt	0		Hot Resistance: +3, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	fireproof tree skirt	0		Hot Resistance: +3, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	normal wreath-shaped Crimbo cookie	4	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	special miniature decent bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	decent miniature special bell-shaped Crimbo cookie	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	flavorless tree-shaped Crimbo cookie	4	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	mirror blinking curative Unionize The Elves sign	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	magnetized galvanized snowcone	0		Effect: "Jingle Jangle Jingle", Effect Duration: 29, Last Available: "2006-01"
 1413	aerosolized snowcone	0		Effect: "Marinated", Effect Duration: 18, Last Available: "2006-01"
 1414	polymerized shaking snowcone	0		Effect: "Purity of Spirit", Effect Duration: 21, Last Available: "2006-01"
@@ -1398,24 +1398,24 @@
 1416	quadruple-magnetized oxidized ghostly blue snowcone	0		Effect: "Trash-Wrapped", Effect Duration: 39, Last Available: "2006-01"
 1417	alkaline adjusted blinking snowcone	0		Effect: "Rootin' Around", Effect Duration: 17, Last Available: "2006-01"
 1418	huge Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
-1419	purple blurry teddy bear sewing kit	0		Last Available: "2006-01"
-1420	extremely unsafe traffic cone of the scaredy-cat	0		Weapon Damage Percent: +100, Monster Level: -15, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1419	blurry purple teddy bear sewing kit	0		Last Available: "2006-01"
+1420	extremely unsafe traffic cone of the scaredy-cat	0		Weapon Damage Percent: +100, Monster Level: -15, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	double-paned brainy ice sickle	0		Mysticality: +5, Cold Resistance: +5, Softcore Only, Last Available: "2006-02"
 1425	wobbly yellow brawny ice baby	0		Muscle Percent: +20, Softcore Only, Last Available: "2006-02"
-1426	green Lo Pan's ice pick	0		Spell Critical Percent: +30, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	green Lo Pan's ice pick	0		Spell Critical Percent: +30, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	strapping ice skates of James Dean	0		Muscle: +5, Experience (Moxie): +3, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	decent miniature wobbly grue egg omelette	2	good	
+1428	miniature decent wobbly grue egg omelette	2	good	
 1429	roll of drink tickets	0		
 1430	mirror pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	rotten half-sized mushroom	2	crappy	
+1432	half-sized rotten mushroom	2	crappy	
 1433	fruit bowl	0		
 1434	pulsating fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
-1436	gray wobbly hot stuffing	0		
+1436	wobbly gray hot stuffing	0		
 1437	useless powder	0		
 1438	non-dry twinkly powder	0		Effect: "Stick Emporium Membership", Effect Duration: 47
 1439	ionized flattened hot powder	0		Effect: "It's Electric!", Effect Duration: 15
@@ -1447,7 +1447,7 @@
 1465	twirling purple suede shortsword	0		
 1466	yellow bamboo bokuto	0		
 1467	25-meat staff	0		
-1468	ghostly twirling two-handed depthsword	0		
+1468	twirling ghostly two-handed depthsword	0		
 1469	bill bec-de-bardiche glaive-guisarme	0		
 1470	lime green lead yo-yo	0		
 1471	shaking slightly peevedbow	0		
@@ -1456,7 +1456,7 @@
 1474	automatic catapult	0		
 1475	shaking pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
-1477	squat upside-down plastic hard hat	0		Familiar Effect: "atk, cap 22"
+1477	upside-down squat plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	football helmet	0		Familiar Effect: "atk, cap 37"
 1480	pulsating chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
@@ -1474,10 +1474,10 @@
 1492	narrow pulsating forbidden ninja mop	0		Spell Damage Percent: +50
 1493	ridiculously overelaborate ninja weapon of the cheetah of Flo-Jo	0		Initiative: 160
 1494	alkaline moist twirling sugar-coated pine cone	0		Effect: "Cat-Alyzed", Effect Duration: 59, Last Available: "2020-09"
-1495	manspreader's traffic cone of extreme caution	0		Monster Level: -15, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	fancy watered-down aged gloomy mushroom wine	2	awesome	Effect: "Clyde's Blessing", Effect Duration: 15
+1495	manspreader's traffic cone of extreme caution	0		Monster Level: -15, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1496	fancy aged watered-down gloomy mushroom wine	2	awesome	Effect: "Clyde's Blessing", Effect Duration: 15
 1497	hand-crafted mushroom wine	3	EPIC	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	ghostly whoopie cushion	0		Last Available: "2006-04"
 1500	huge fake fake vomit	0		Last Available: "2006-04"
 1501	wet improved adjusted bouncing blurry explosion-flavored chewing gum	0		Effect: "Oxygenated Blood", Effect Duration: 24, Last Available: "2006-04"
@@ -1494,32 +1494,32 @@
 1512	modified pulsating Knob Goblin pet-buffing spray	1		
 1513	diluted green squat Knob Goblin learning pill	1		
 1514	vaporized Knob Goblin eyedrops	1		
-1515	vaporized jittery olive narrow Knob Goblin nasal spray	1		
+1515	vaporized olive jittery narrow Knob Goblin nasal spray	1		
 1516	upside-down KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
 1520	Radio KoL Coffee Mug of incineration of the early riser	0		Hot Spell Damage: +50, Adventures: +7
-1521	blurry olive huge Frank Gorshin trophy	0		
+1521	olive huge blurry Frank Gorshin trophy	0		
 1522	brawny Radio Free Jersey of courage	0		Muscle Percent: +20, Spooky Resistance: +3
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	lime green pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	lime green pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	perfumed shellacked corkscrew	0		Damage Reduction: 7, Stench Resistance: +5, Last Available: "2006-04"
 1529	blurry St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	personal trainer's grass skirt	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	fortified grass hat	0		Damage Absorption: +60, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	personal trainer's grass skirt	0		Experience Percent (Muscle): +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	fortified grass hat	0		Damage Absorption: +60, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	bouncing scorching grass blade	0		Hot Damage: +25, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
-1537	narrow huge bouncing weegee sqouija	0		Last Available: "2011-12"
+1537	narrow bouncing huge weegee sqouija	0		Last Available: "2011-12"
 1538	sparkly engagement ring of the cheetah	0		Initiative: +60, Single Equip
 1539	bouncing Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	nasty Grimacite goggles of mayonnaise	0		Stench Damage: +5, Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	nasty Grimacite goggles of mayonnaise	0		Stench Damage: +5, Sleaze Spell Damage: +50, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	tumbling smelly banded Grimacite glaive	0		Damage Absorption: +100, Stench Spell Damage: +10, Last Available: "2008-10"
-1542	pulsating beefcake's Grimacite greaves of James Dean	0		Muscle: +25, Experience (Moxie): +3, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	pulsating beefcake's Grimacite greaves of James Dean	0		Muscle: +25, Experience (Moxie): +3, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	auspicious Grimacite garter of the cougar	0		Moxie: +20, Item Drop: +10, Last Available: "2008-10"
 1544	Temple Grandin's Grimacite galoshes of the brute	0		Muscle Percent: +30, Familiar Weight: +7, Last Available: "2008-10"
 1545	coward's Grimacite gorget of chilblains	0		Monster Level: -20, Cold Damage: +25, Last Available: "2008-10"
@@ -1529,7 +1529,7 @@
 1549	MSG	0		
 1550	shaking razor-sharp second-hand knockoff engagement ring	0		Weapon Damage Percent: +25, Single Equip
 1551	aged bottle of Domesticated Turkey	4	awesome	
-1552	fortified tolerable teal bottle of Definit	5	good	
+1552	tolerable fortified teal bottle of Definit	5	good	
 1553	drinkable ghostly bottle of Calcutta Emerald	4	good	
 1554	bad teal bottle of Lieutenant Freeman	4	decent	
 1555	artisanal fuchsia bottle of Jorge Sinsonte	4	EPIC	
@@ -1543,42 +1543,42 @@
 1563	hand-crafted fancy whiskey bittersweet	4	EPIC	Effect: "Pisces in the Skyces", Effect Duration: 40
 1564	irresponsibly strong drinkable upside-down mimosette	8	good	
 1565	lousy watered-down tequila sunset	2	decent	
-1566	lousy special practically non-alcoholic shaking zmobie	1	decent	Effect: "Protection from Bad Stuff", Effect Duration: 45, Wiki Name: "Zmobie (drink)"
-1567	enchanted hand-crafted triple-distilled gin and tonic	8	EPIC	Effect: "Muscle Unbound", Effect Duration: 20
-1568	drinkable weak vodka and tonic	2	good	
+1566	practically non-alcoholic lousy special shaking zmobie	1	decent	Effect: "Protection from Bad Stuff", Effect Duration: 45, Wiki Name: "Zmobie (drink)"
+1567	triple-distilled enchanted hand-crafted gin and tonic	8	EPIC	Effect: "Muscle Unbound", Effect Duration: 20
+1568	weak drinkable vodka and tonic	2	good	
 1569	aged vodka gibson	3	awesome	
 1570	hand-crafted enchanted gibson	3	EPIC	Effect: "Top Dog", Effect Duration: 15
-1571	drinkable practically non-alcoholic parisian cathouse	1	good	
+1571	practically non-alcoholic drinkable parisian cathouse	1	good	
 1572	smooth green rabbit punch	4	awesome	
 1573	practically non-alcoholic bad caipifruta	1	decent	
 1574	weak perfectly mixed teqiwila	2	EPIC	
-1575	extra-dry tolerable blue Divine	5	good	
+1575	tolerable extra-dry blue Divine	5	good	
 1576	perfectly mixed Gordon Bennett	4	EPIC	
 1577	perfectly mixed tangarita	3	EPIC	
 1578	lousy watered-down mandarina colada	2	decent	
 1579	artisanal weak gimlet	2	super ultra EPIC	
-1580	hand-crafted practically non-alcoholic brick road	1	super ultra mega turbo EPIC	
-1581	bad enchanted mirror vodka stratocaster	4	decent	Effect: "Memory of Resilience", Effect Duration: 15
+1580	practically non-alcoholic hand-crafted brick road	1	super ultra mega turbo EPIC	
+1581	enchanted bad mirror vodka stratocaster	4	decent	Effect: "Memory of Resilience", Effect Duration: 15
 1582	hand-crafted Neuromancer	3	EPIC	
 1583	hand-crafted fancy skewed prussian cathouse	3	EPIC	Effect: "In Vino Vires", Effect Duration: 20
 1584	tolerable Mae West	3	good	
 1585	acceptable Mon Tiki	4	good	
 1586	smooth teqiwila slammer	3	awesome	
 1587	spoiled Knob lo mein	3	crappy	
-1588	flavorless gigantic asparagus lo mein	10	decent	
+1588	gigantic flavorless asparagus lo mein	10	decent	
 1589	adequate green Knoll lo mein	3	good	
-1590	enchanted rotten lo mein	3	crappy	Effect: "Chalked Weapon", Effect Duration: 10
+1590	rotten enchanted lo mein	3	crappy	Effect: "Chalked Weapon", Effect Duration: 10
 1591	stale teal olive lo mein	3	decent	
 1592	rotten mirror hot hi mein	3	crappy	
-1593	bland enchanted hi mein	4	decent	Effect: "Bloodstain-Resistant", Effect Duration: 45
+1593	enchanted bland hi mein	4	decent	Effect: "Bloodstain-Resistant", Effect Duration: 45
 1594	bland hi mein	3	decent	
-1595	toothsome thick hi mein	5	awesome	
-1596	small normal sleazy hi mein	2	good	
+1595	thick toothsome hi mein	5	awesome	
+1596	normal small sleazy hi mein	2	good	
 1597	Samson's Junior LAAAAME merit badge	0		Experience (Muscle): +5, Last Available: "2006-05"
 1598	Senior LAAAAME merit badge of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	high-proof hand-crafted special tangarita with a fly in it	9	EPIC	Effect: "Chari Tea", Effect Duration: 20
-1601	smooth triple-distilled upside-down mandarina colada with a fly in it	7	awesome	
+1600	hand-crafted special high-proof tangarita with a fly in it	9	EPIC	Effect: "Chari Tea", Effect Duration: 20
+1601	triple-distilled smooth upside-down mandarina colada with a fly in it	7	awesome	
 1602	aged teal prussian cathouse with a fly in it	4	awesome	
 1603	high-proof tolerable spinning Mae West with a fly in it	7	good	
 1604	modified maroon astronaut ice-cream	1		Effect: "The Living Hitpoints", Effect Duration: 10, Last Available: "2006-05"
@@ -1592,8 +1592,8 @@
 1612	anodized cold-filtered concentrated cordial of concentration	0		Effect: "Squid Squint", Effect Duration: 15
 1613	auspicious coffin lid	0		Item Drop: +10, Damage Reduction: 3
 1614	twirling satin shield of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 5
-1615	Sinatra's Cerebral Cloche	0		Experience (Moxie): +5, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	twirling squat smelly Cerebral Culottes	0		Stench Spell Damage: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	Sinatra's Cerebral Cloche	0		Experience (Moxie): +5, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	twirling squat smelly Cerebral Culottes	0		Stench Spell Damage: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	prompt zippy Cerebral Crossbow of the businessman	0		Meat Drop: +50, Initiative: +20, Adventures: +3, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1619,7 +1619,7 @@
 1639	oxidized cyan lotion of spookiness	0		Effect: "Cockroach Scurry", Effect Duration: 37
 1640	unsweetened ionized blinking lotion of stench	0		Effect: "Cute Vision", Effect Duration: 58
 1641	extra-diffused lotion of sleaziness	0		Effect: "Always be Collecting", Effect Duration: 34
-1642	acceptable watered-down pulsating Grimacite Bock	2	good	Last Available: "2008-11"
+1642	watered-down acceptable pulsating Grimacite Bock	2	good	Last Available: "2008-11"
 1643	yummy wedge of gray cheese	3	awesome	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
@@ -1628,9 +1628,9 @@
 1648	sleazy and sauce	0		
 1649	blurry brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	half-sized bland foie gras	2	decent	
+1651	bland half-sized foie gras	2	decent	
 1652	frozen candy brain	0		Effect: "Hagnk's Gratitude", Effect Duration: 61, Last Available: "2020-09"
-1653	hardened Herculean jewel-eyed wizard hat of the brazier	0		Experience (Muscle): +1, Damage Reduction: 3, Hot Spell Damage: +25, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	hardened Herculean jewel-eyed wizard hat of the brazier	0		Experience (Muscle): +1, Damage Reduction: 3, Hot Spell Damage: +25, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	green auspicious Rosewater's wad of Crovacite	0		Mysticality Percent: +30, Item Drop: +10
 1655	fortified wizardly collar	0		Mysticality: +25, Damage Absorption: +60
 1656	White Citadel Satisfaction Satchel	0		
@@ -1647,7 +1647,7 @@
 1667	sinister Cat-Herding Prod	0		Spell Damage: +10
 1668	horrifying star boomerang	0		Spooky Damage: +25
 1669	Oprah's star stiletto	0		Maximum MP Percent: +50
-1670	huge bouncing fraudwort	0		
+1670	bouncing huge fraudwort	0		
 1671	narrow shysterweed	0		
 1672	swindleblossom	0		
 1673	avaricious educational grave robbing shovel	0		Experience: +1, Meat Drop: +30
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	purple bubblewrap ore	0		
-1678	upside-down blue pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	blue upside-down pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	up-at-dawn double-paned sword	0		Cold Resistance: +5, Adventures: +5
 1680	purple upside-down ruddy stiffened staff	0		Damage Reduction: 1, Maximum HP Percent: +40
 1681	squat lion tamer's beefcake's bubblewrap sword	0		Muscle: +25, Experience (familiar): +2
@@ -1746,7 +1746,7 @@
 1767	jittery pack of chewing gum	0		
 1768	upside-down Gnomish toolbox	0		
 1769	miniature moldy blurry fricasseed brains	2	crappy	
-1770	stale snack-sized brains casserole	2	decent	
+1770	snack-sized stale brains casserole	2	decent	
 1771	teal Oprah's butcherknife	0		Maximum MP Percent: +50
 1772	Tesla corn holder	0		MP Regen Min: 7, MP Regen Max: 10
 1773	eggbeater of dire peril	0		Weapon Damage: +20
@@ -1754,7 +1754,7 @@
 1775	padded dishrag	0		Damage Absorption: +20
 1776	adequate stale baguette	4	good	
 1777	olive leftovers of indeterminate origin	0		
-1778	normal gigantic dinner	8	good	
+1778	gigantic normal dinner	8	good	
 1779	scandalous katana	0		Sleaze Damage: +5
 1780	perfumed ram stick	0		Stench Resistance: +5
 1781	ruddy enchantlers	0		Maximum HP Percent: +40, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1768,11 +1768,11 @@
 1789	Mob Penguin	0		
 1790	practically non-alcoholic hand-crafted Ram's Face Lager	1	EPIC	
 1791	wobbly ram horns	0		
-1792	twirling greasy electrified quilted Travoltan trousers	0		Damage Absorption: +40, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	twirling greasy electrified quilted Travoltan trousers	0		Damage Absorption: +40, Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	mirror wicked pool cue of the boozehound	0		Spell Damage: +5, Booze Drop: +100
 1794	super-irradiated unsweetened non-altered huge skewed handful of hand chalk	0		Effect: "Sugary Tongue", Effect Duration: 62
 1795	nippy Counterclockwise Watch	0		Cold Damage: +10, Single Equip
-1796	teal blinking bone collar	0		Familiar Weight: +5
+1796	blinking teal bone collar	0		Familiar Weight: +5
 1797	ghostly misshapen animal skeleton	0		
 1798	pile of animal bones	0		
 1799	animal skull	0		
@@ -1789,13 +1789,13 @@
 1810	second thoracic vertebra	0		
 1811	red third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
-1813	shaking skewed fifth thoracic vertebra	0		
+1813	skewed shaking fifth thoracic vertebra	0		
 1814	lime green sixth thoracic vertebra	0		
 1815	bouncing seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	red ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
-1819	tumbling olive eleventh thoracic vertebra	0		
+1819	olive tumbling eleventh thoracic vertebra	0		
 1820	blurry twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
 1822	narrow second lumbar vertebra	0		
@@ -1836,13 +1836,13 @@
 1857	pulsating right seventh rib	0		
 1858	right eighth rib	0		
 1859	right ninth rib	0		
-1860	pulsating spinning right tenth rib	0		
+1860	spinning pulsating right tenth rib	0		
 1861	upside-down right eleventh rib	0		
 1862	pulsating right twelfth rib	0		
 1863	animal pelvis	0		
 1864	wobbly left scapula	0		
 1865	right scapula	0		
-1866	bouncing pulsating left clavicle	0		
+1866	pulsating bouncing left clavicle	0		
 1867	right clavicle	0		
 1868	left humerus	0		
 1869	right humerus	0		
@@ -1875,7 +1875,7 @@
 1896	right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
-1899	huge twirling right fourth rear claw	0		
+1899	twirling huge right fourth rear claw	0		
 1900	friendly 1-ball	0		Familiar Weight: +3
 1901	rosewater-soaked sage 2-ball	0		Mysticality Percent: +10, Stench Resistance: +3
 1902	lion tamer's sharpshooter's 3-ball	0		Critical Hit Percent: +10, Experience (familiar): +2
@@ -1928,8 +1928,8 @@
 1951	fortified acceptable tumbling blinking bottle of Pinot Renoir	5	good	
 1952	flavorless super-sized desiccated apricot	5	decent	
 1953	spirit-forward drinkable flute of flat champagne	5	good	
-1954	snack-sized moldy dehydrated caviar	2	crappy	
-1955	jittery tumbling yellow styrofoam peanuts	0		
+1954	moldy snack-sized dehydrated caviar	2	crappy	
+1955	tumbling yellow jittery styrofoam peanuts	0		
 1956	drinkable snifter of thoroughly aged brandy	4	good	
 1957	quill pen	0		
 1958	inkwell	0		
@@ -1941,7 +1941,7 @@
 1964	olive fireproof opera mask	0		Hot Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
 1966	blurry shaking Amulet of Yendor of the storm of the sweet-tooth	0		Maximum MP Percent: +40, Candy Drop: +100, Single Equip, Last Available: "2011-12"
-1967	narrow ghostly green ghostly jitterbug larva	0		Free Pull, Last Available: "2007-10"
+1967	narrow ghostly ghostly green jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	bottle of perfume	0		Familiar Weight: +5
 1969	blurry spoon!	0		Familiar Weight: +5
 1970	nervous tick egg	0		Free Pull, Last Available: "2007-10"
@@ -1955,7 +1955,7 @@
 1978	huge gravy fairy	0		
 1979	gravy fairy	0		
 1980	squat sleazy gravy fairy	0		
-1981	bouncing pulsating astral badger	0		
+1981	pulsating bouncing astral badger	0		
 1982	MagiMechTech MicroMechaMech	0		
 1983	pulsating hand turkey	0		
 1984	snowy owl	0		
@@ -1994,15 +1994,15 @@
 2017	spade necklace	0		
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
-2020	normal thick cherry pie	5	good	
+2020	thick normal cherry pie	5	good	
 2021	flavorless strawberry pie	3	decent	
 2022	stale lemon meringue pie	4	decent	
 2023	pulsating Genalen&trade; Bottle	1	good	
 2024	immense stale mixed wildflower greens	9	decent	
 2025	rotten handful of walnuts	3	crappy	
-2026	stale twirling purple nutty organic salad	3	decent	
-2027	miniature flavorless fancy super salad	2	decent	Effect: "Cute Vision", Effect Duration: 20
-2028	immense normal enchanted tofu wonton	9	good	Effect: "Creepin' Up on You", Effect Duration: 35
+2026	stale purple twirling nutty organic salad	3	decent	
+2027	fancy miniature flavorless super salad	2	decent	Effect: "Cute Vision", Effect Duration: 20
+2028	enchanted immense normal tofu wonton	9	good	Effect: "Creepin' Up on You", Effect Duration: 35
 2029	hippy protest button	0		Single Equip
 2030	greasy nippy Lockenstock&trade; sandals	0		Cold Damage: +10, Sleaze Spell Damage: +10, Single Equip
 2031	twirling Usain Bolt's didgeridooka	0		Initiative: +80
@@ -2020,12 +2020,12 @@
 2043	hemp net	0		
 2044	pulsating your father's MacGuffin diary	0		
 2045	immense adequate brain-meltingly-hot chicken wings	6	good	
-2046	rotten half-sized blue frat brats	2	crappy	
-2047	enchanted tiny rotten wobbly knob ka-bobs	1	crappy	Effect: "From Nantucket", Effect Duration: 10
+2046	half-sized rotten blue frat brats	2	crappy	
+2047	tiny rotten enchanted wobbly knob ka-bobs	1	crappy	Effect: "From Nantucket", Effect Duration: 10
 2049	perfectly mixed squat can of Swiller	3	EPIC	
 2050	broken wings	0		
 2051	sunken eyes	0		
-2052	blurry purple reassembled blackbird	0		
+2052	purple blurry reassembled blackbird	0		
 2053	bouncing bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
 2055	skewed snake skin	0		
@@ -2090,7 +2090,7 @@
 2114	pulsating yo	0		Last Available: "2006-12"
 2115	prehistoric spear of the businessman	0		Meat Drop: +50, Last Available: "2006-12"
 2116	green stick-on-a-string	0		Last Available: "2006-12"
-2117	purple Annie Oakley's curative fire	0		Critical Hit Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	purple Annie Oakley's curative fire	0		Critical Hit Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	chilly Grateful Undead T-shirt	0		Cold Damage: +5
@@ -2101,7 +2101,7 @@
 2126	ribald padded bronze breastplate	0		Damage Absorption: +20, Sleaze Damage: +10
 2127	personal trainer's hat hacker T-shirt of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10
 2128	yellow vampire collar	0		Single Equip
-2129	tumbling skewed maroon possessed top	0		Last Available: "2010-12"
+2129	maroon skewed tumbling possessed top	0		Last Available: "2010-12"
 2130	avaricious killer rag doll	0		Meat Drop: +30, Last Available: "2006-12"
 2131	tree-eating kite	0		Last Available: "2006-12"
 2132	foul-smelling incredibly marionette	0		Stench Damage: +10, Last Available: "2006-12"
@@ -2122,13 +2122,13 @@
 2147	yellow evil teddy bear sewing kit	0		
 2148	red toothsome rock	0		
 2149	bland jittery frank	4	decent	Last Available: "2011-12"
-2150	adequate special plate of franks and beans	3	good	Effect: "One Very Clear Eye", Effect Duration: 45, Last Available: "2011-12"
+2150	special adequate plate of franks and beans	3	good	Effect: "One Very Clear Eye", Effect Duration: 45, Last Available: "2011-12"
 2151	perfectly mixed shot of blackberry schnapps	3	EPIC	
 2152	wobbly purple capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	purple ion grid	0		Last Available: "2011-12"
 2155	skewed Feynman gate	0		Last Available: "2011-12"
-2156	ghostly yellow logic synthesizer	0		Last Available: "2011-12"
+2156	yellow ghostly logic synthesizer	0		Last Available: "2011-12"
 2157	gray high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	mirror quantum polarity inducer	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	blinking ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	huge hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	dance instructor's smooth toy ray gun	0		Moxie: +15, Experience Percent (Moxie): +10, Last Available: "2006-12"
-2169	teal spinning deadly toy space helmet of Leguizamo	0		Weapon Damage: +5, Monster Level: +20, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	teal spinning deadly toy space helmet of Leguizamo	0		Weapon Damage: +5, Monster Level: +20, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	red blinking MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	Sherlock's flame-retardant astronaut pants	0		Hot Resistance: +1, Item Drop: +25, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	Sherlock's flame-retardant astronaut pants	0		Hot Resistance: +1, Item Drop: +25, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	arcane researcher's toy jet pack	0		Experience Percent (Mysticality): +10, Last Available: "2006-12"
 2173	ghostly triangular stone	0		
 2174	blinking mossy stone sphere	0		
@@ -2167,8 +2167,8 @@
 2192	skewed sheet music	0		Last Available: "2006-12"
 2193	spoiled candy stake	4	crappy	Last Available: "2006-12"
 2194	hand-crafted eggnog	3	EPIC	Last Available: "2006-12"
-2195	thick moldy unspeakable fruitcake	5	crappy	Last Available: "2006-12"
-2196	flavorless diet squat pulsating gingerbread horror	1	decent	Last Available: "2006-12"
+2195	moldy thick unspeakable fruitcake	5	crappy	Last Available: "2006-12"
+2196	diet flavorless squat pulsating gingerbread horror	1	decent	Last Available: "2006-12"
 2197	anodized non-aerosolized but probably evil chocolate	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 57, Last Available: "2006-12"
 2198	miniature spoiled bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	moldy skull-shaped Crimboween cookie	4	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2182,22 +2182,22 @@
 2207	olive Crimbo tiki necklace of chilblains	0		Cold Damage: +25, Last Available: "2006-12"
 2208	rosy-cheeked bobble-hip hula elf doll of the sweet-tooth	0		Maximum HP Percent: +30, Candy Drop: +100, Last Available: "2006-12"
 2209	narrow Crimbo ukulele of temperance	0		Sleaze Resistance: +5, Last Available: "2006-12"
-2210	tumbling Temple Grandin's razor-sharp Tiki lighter	0		Weapon Damage Percent: +25, Familiar Weight: +7, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	mirror bouncing executive Sinatra's deck of tropical cards	0		Experience (Moxie): +5, Meat Drop: +40, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	pulsating ghostly flame-wreathed healthy tropical paperweight	0		Maximum HP Percent: +20, Hot Spell Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	tumbling Temple Grandin's razor-sharp Tiki lighter	0		Weapon Damage Percent: +25, Familiar Weight: +7, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	mirror bouncing executive Sinatra's deck of tropical cards	0		Experience (Moxie): +5, Meat Drop: +40, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	pulsating ghostly flame-wreathed healthy tropical paperweight	0		Maximum HP Percent: +20, Hot Spell Damage: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	gray tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	savvy Tropical Crimbo Hat	0		Mysticality Percent: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	Tropical Crimbo Shorts of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	savvy Tropical Crimbo Hat	0		Mysticality Percent: +20, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	Tropical Crimbo Shorts of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	tasty big green super ka-bob	5	awesome	
 2218	spoiled thick spinning beer basted brat	5	crappy	
 2219	inspector's Tropical Crimbo Sword	0		Item Drop: +15, Last Available: "2006-12"
 2220	altered oxidized and Crimboween candy	0		Effect: "Certainty", Effect Duration: 53, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	blinking yellow double-paned liar's pants of the empath	0		Familiar Weight: +5, Cold Resistance: +5, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	blinking yellow double-paned liar's pants of the empath	0		Familiar Weight: +5, Cold Resistance: +5, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	inspector's juggler's balls of the early riser	0		Item Drop: +15, Adventures: +7, Softcore Only, Last Available: "2007-01"
 2224	nippy pink shirt	0		Cold Damage: +10, Softcore Only, Last Available: "2007-01"
-2225	pulsating purple blurry familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
+2225	pulsating blurry purple familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	Fonzie's evil eyeball pendant of the detective	0		Experience (Moxie): +1, Item Drop: +20, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	Vulcanized wobbly arse-a'fire elixir	0		Effect: "Antsy in your Pantsy", Effect Duration: 46, Last Available: "2007-01"
 2228	energized cosmic lemonade	0		Effect: "Pronounced Potency", Effect Duration: 43, Last Available: "2007-01"
@@ -2242,11 +2242,11 @@
 2268	vibrating Staff of Fats	0		Maximum MP Percent: +10
 2269	flavorless tumbling upside-down sausage wonton	3	decent	
 2270	supercharged belt of the blizzard	0		Maximum MP Percent: +30, Cold Spell Damage: +25, Single Equip
-2271	drinkable special irresponsibly strong bottle of Merlot	9	good	Effect: "Going Ape", Effect Duration: 40
+2271	irresponsibly strong drinkable special bottle of Merlot	9	good	Effect: "Going Ape", Effect Duration: 40
 2272	acceptable bottle of Port	3	good	
-2273	acceptable watered-down bottle of Pinot Noir	2	good	
-2274	tolerable irresponsibly strong bottle of Zinfandel	6	good	
-2275	artisanal weak skewed bottle of Marsala	2	EPIC	
+2273	watered-down acceptable bottle of Pinot Noir	2	good	
+2274	irresponsibly strong tolerable bottle of Zinfandel	6	good	
+2275	weak artisanal skewed bottle of Marsala	2	EPIC	
 2276	special aged bouncing bottle of Muscat	3	awesome	Effect: "Helvella Health", Effect Duration: 30
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2261,7 +2261,7 @@
 2287	Temple Grandin's glowstick of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
 2289	paperclip	0		
-2290	twirling shaking red really house	0		
+2290	shaking red twirling really house	0		
 2291	narrow Non-Essential Amulet	0		
 2292	blurry wine vinaigrette	0		
 2293	blurry cup of strong herbal tea	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	mirror Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	ionized tarnished skewed wobbly candy heart	0		Effect: "The Wisdom... of the Future", Effect Duration: 63, Last Available: "2007-02"
 2305	aerosolized pink candy heart	0		Effect: "Patience of the Tortoise", Effect Duration: 53, Last Available: "2007-02"
 2306	extra-quantum quadruple-oxidized tumbling candy heart	0		Effect: "Sharp Weapon", Effect Duration: 49, Last Available: "2007-02"
@@ -2309,11 +2309,11 @@
 2335	huge rubber WWBBDD? bracelet	0		
 2336	smelly sharpshooter's pipe	0		Critical Hit Percent: +10, Stench Spell Damage: +10
 2337	reinforced beaded headband of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	massive bland shaking pudding	7	decent	Wiki Name: "black pudding (food)"
+2338	bland massive shaking pudding	7	decent	Wiki Name: "black pudding (food)"
 2339	hand-crafted triple-distilled Blackfly Chardonnay	10	EPIC	
 2340	smooth & tan	3	awesome	
 2341	wobbly pepper	0		
-2342	miniature bland red twirling forest cake	2	decent	
+2342	miniature bland twirling red forest cake	2	decent	
 2343	decent bouncing forest ham	3	good	
 2344	flattened triple-dry fuchsia filthworm hatchling scent gland	0		Effect: "Stop and Smell the Fudge", Effect Duration: 60
 2345	denatured jittery filthworm drone scent gland	0		Effect: "You Drank Fish Wine", Effect Duration: 60
@@ -2346,14 +2346,14 @@
 2372	shaking bunch of bananas	0		
 2373	stale banana	3	decent	
 2374	banana peel	0		
-2375	normal gigantic tumbling skewed banana cream pie	6	good	
+2375	gigantic normal skewed tumbling banana cream pie	6	good	
 2376	triple-distilled artisanal banana daiquiri	10	EPIC	
-2377	bad weak bouncing bungle in the jungle	2	decent	
+2377	weak bad bouncing bungle in the jungle	2	decent	
 2378	banana spritzer	0		
 2379	corrupted banana smoothie	0		Effect: "Space Cadet", Effect Duration: 24
 2380	fuchsia dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
-2382	squat red class ring	0		
+2382	red squat class ring	0		
 2383	mirror class ring	0		
 2384	tumbling class ring	0		
 2385	bottle opener belt buckle	0		Single Equip
@@ -2406,7 +2406,7 @@
 2432	magnetized triple-enhanced boiled SPF 451 lip balm	0		Effect: "Ponderous Potency", Effect Duration: 31
 2433	wet bottle of antifreeze	0		Effect: "Down With Chow", Effect Duration: 52
 2434	dry eyedrops	0		Effect: "Indescribable Flavor", Effect Duration: 17
-2435	oxidized jittery wobbly Dogsgotnonoz pills	0		Effect: "Ponderous Potency", Effect Duration: 49
+2435	oxidized wobbly jittery Dogsgotnonoz pills	0		Effect: "Ponderous Potency", Effect Duration: 49
 2436	unsweetened bouncing donkey flipbook	0		Effect: "You're High as a Crow, Marty", Effect Duration: 32
 2437	lime green New Cloaca-Cola	0		
 2438	scented massage oil	0		
@@ -2471,7 +2471,7 @@
 2498	skewed molybdenum hammer	0		
 2499	molybdenum screwdriver	0		
 2500	molybdenum pliers	0		
-2501	fuchsia blinking pulsating molybdenum crescent wrench	0		
+2501	pulsating blinking fuchsia molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	teal extra-fancy ring setting	0		
 2504	narrow precious piercing post	0		
@@ -2489,22 +2489,22 @@
 2516	Jack Frost's personal trainer's wrench bracelet	0		Experience Percent (Muscle): +10, Cold Spell Damage: +50
 2517	squat executive chain necklace of Leguizamo	0		Monster Level: +20, Meat Drop: +40
 2518	tumbling sawblade shield of extreme caution	0		Monster Level: -25, Damage Reduction: 11
-2519	tolerable weak McMillicancuddy's Special Lager	2	good	
+2519	weak tolerable McMillicancuddy's Special Lager	2	good	
 2520	bad jittery melted Jell-o shot	4	decent	
 2521	bad cruelty-free wine	3	decent	
-2522	watered-down tolerable special thistle wine	2	good	Effect: "The Power of Positive Thinking", Effect Duration: 20
+2522	special watered-down tolerable thistle wine	2	good	Effect: "The Power of Positive Thinking", Effect Duration: 20
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	small stale fish	2	decent	
 2526	rotten snack-sized fish casserole	2	crappy	
 2527	decent fish lasagna	3	good	
 2528	wobbly filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	miniature spoiled gnatloaf	2	crappy	
+2529	spoiled miniature gnatloaf	2	crappy	
 2530	rotten gnatloaf casserole	3	crappy	
-2531	fancy normal squat gnat lasagna	3	good	Effect: "Punchy, Murdery", Effect Duration: 45
+2531	normal fancy squat gnat lasagna	3	good	Effect: "Punchy, Murdery", Effect Duration: 45
 2532	fuchsia pork	0		
-2533	special tasty half-sized pork chop sandwiches	2	awesome	Effect: "Pemmican't", Effect Duration: 20
-2534	big moldy pork casserole	5	crappy	
+2533	half-sized tasty special pork chop sandwiches	2	awesome	Effect: "Pemmican't", Effect Duration: 20
+2534	moldy big pork casserole	5	crappy	
 2535	rotten pork lasagna	4	crappy	
 2536	canopic jar	0		
 2537	ghostly spice	0		
@@ -2518,11 +2518,11 @@
 2545	quantum altered altered upsy daisy	0		Effect: "Shoesauce", Effect Duration: 56, Last Available: "2007-05"
 2546	ionized half-orchid	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 57, Last Available: "2007-05"
 2547	family-friendly tin star of the sweet-tooth	0		Sleaze Resistance: +1, Candy Drop: +100, Last Available: "2007-05"
-2548	blinking wicked outrageous sombrero of the cougar	0		Moxie: +20, Spell Damage: +5, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	blinking wicked outrageous sombrero of the cougar	0		Moxie: +20, Spell Damage: +5, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	mirror careful deadly &quot;Humorous&quot; T-shirt	0		Weapon Damage: +5, Monster Level: -10, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	blurry vial of mojo	0		
-2552	red blurry reeds	0		
+2552	blurry red reeds	0		
 2553	turtle chain	0		
 2554	twirling distilled seal blood	0		
 2555	high-octane olive oil	0		
@@ -2564,7 +2564,7 @@
 2591	decent tasty tart	3	good	
 2592	Knob Goblin lunchbox	0		
 2593	spoiled Knob pasty	4	crappy	
-2594	artisanal strong thermos full of Knob coffee	5	EPIC	
+2594	strong artisanal thermos full of Knob coffee	5	EPIC	
 2595	non-galvanized Ben-Gal&trade; Balm	0		Effect: "In the Slimelight", Effect Duration: 51
 2596	pulsating leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2601,14 +2601,14 @@
 2628	twirling blurry wicked Da Vinci's catskin buckler	0		Experience (Mysticality): +5, Spell Damage: +5, Damage Reduction: 11
 2629	foul-smelling cool tail o' nine cats	0		Moxie: +5, Stench Damage: +10
 2630	yellow Hugo's Weaving Manual	0		
-2631	wet quadruple-irradiated corrupted upside-down green gremlin juice	0		Effect: "Stogied", Effect Duration: 31
+2631	wet quadruple-irradiated corrupted green upside-down gremlin juice	0		Effect: "Stogied", Effect Duration: 31
 2632	cold-filtered double-altered mother's helper	0		Effect: "Sepia Tan", Effect Duration: 66
 2633	squat red occult sinister pat-a-cake pendant	0		Spell Damage: +10, Spell Damage Percent: +25
 2634	mummy wrapping	0		
 2635	twirling really thick bandage	0		
 2636	deadly mummy mask	0		Weapon Damage: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	wholesome gauze shorts of Gandalf	0		Maximum HP Percent: +10, Spell Critical Percent: +20, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
-2638	teal squat gauze hammock	0		
+2638	squat teal gauze hammock	0		
 2639	spinning cherry soda	0		
 2640	greaves of the empath of temperance	0		Familiar Weight: +5, Sleaze Resistance: +5, Familiar Effect: "atk, 1xBarrr, cap 40"
 2641	bouncing rosy-cheeked cowboy hat of horror	0		Maximum HP Percent: +30, Spooky Spell Damage: +25, Familiar Effect: "1xBarrr, 1xLep, cap 41"
@@ -2622,7 +2622,7 @@
 2649	blinking hardy Lord Spookyraven's ear trumpet	0		Maximum HP: +50, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	jittery pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	yummy small green S.T.L.T.	2	awesome	Last Available: "2007-06"
+2652	small yummy green S.T.L.T.	2	awesome	Last Available: "2007-06"
 2653	huge rotten ghostly honey-dew	9	crappy	Last Available: "2007-06"
 2654	spirit-forward perfectly mixed Xanadian	5	EPIC	Last Available: "2007-06"
 2655	flattened upside-down bottle of absinthe	0		Effect: "Spooky Jellied", Effect Duration: 66, Last Available: "2007-06"
@@ -2632,15 +2632,15 @@
 2659	blue nippy albatross necklace	0		Cold Damage: +10, Single Equip, Last Available: "2007-06"
 2660	pickled not-a-pipe	1	good	Last Available: "2007-06"
 2661	tolerable flask of Amontillado	4	good	Last Available: "2007-06"
-2662	scandalous ball mask	0		Sleaze Damage: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	baleful Can-Can skirt	0		Spell Damage: +25, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
-2664	triple-Vulcanized maroon shaking sensitive poetry journal	0		Effect: "Become Intensely interested", Effect Duration: 68, Last Available: "2007-06"
+2662	scandalous ball mask	0		Sleaze Damage: +5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	baleful Can-Can skirt	0		Spell Damage: +25, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2664	triple-Vulcanized shaking maroon sensitive poetry journal	0		Effect: "Become Intensely interested", Effect Duration: 68, Last Available: "2007-06"
 2665	polarized frozen vacuum-sealed mirror bottled inspiration	0		Effect: "Adrenaline Rush", Effect Duration: 14, Last Available: "2007-06"
 2666	polymerized wobbly twirling bellhop bell	0		Effect: "Mushroom Might", Effect Duration: 45, Last Available: "2007-06"
 2667	frozen wet blue spiky collar	0		Effect: "Conspiratory Eyes", Effect Duration: 69, Last Available: "2007-06"
 2668	altered narrow can-can-in-a-can	1		Last Available: "2007-06"
 2669	denatured patent antipsychotics	1		Effect: "Bear Clawed", Effect Duration: 30, Last Available: "2007-06"
-2670	dried huge mirror Mariner's Friend cough drops	1		Effect: "Concentrated Concentration", Effect Duration: 40, Last Available: "2007-06"
+2670	dried mirror huge Mariner's Friend cough drops	1		Effect: "Concentrated Concentration", Effect Duration: 40, Last Available: "2007-06"
 2671	high-proof acceptable twirling shot of nepenthe schnapps	10	good	Last Available: "2007-06"
 2672	yellow library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
@@ -2683,7 +2683,7 @@
 2710	gray cracker	0		Familiar Weight: +15
 2711	pickled blurry maroon facepaint	0		Effect: "Joy", Effect Duration: 47
 2712	galvanized unsweetened sheepskin diploma	0		Effect: "Abominably Slippery", Effect Duration: 61
-2713	polarized fuchsia twirling squat upside-down Black Body&trade; spray	0		Effect: "Hippy Flavor", Effect Duration: 15
+2713	polarized twirling upside-down squat fuchsia Black Body&trade; spray	0		Effect: "Hippy Flavor", Effect Duration: 15
 2714	huge floorboard cruft	0		
 2715	sausage bomb	0		
 2716	asbestos-lined manspreader's battered hubcap of extreme caution	0		Monster Level: -15, Hot Resistance: +5, Damage Reduction: 14
@@ -2694,25 +2694,25 @@
 2721	yellow mansplainer's crafty groovy hand-carved staff	0		Moxie Percent: +10, Maximum MP: +10, Monster Level: +15
 2722	bouncing scandalous clever Fonzie's brainy Staff of the Greasefire	0		Mysticality: +5, Experience (Moxie): +1, Maximum MP: +20, Sleaze Damage: +5
 2723	spinning ghostly ribald flame-wreathed strapping Staff of the Grand Flamb&eacute;	0		Muscle: +5, Hot Spell Damage: +10, Sleaze Damage: +10
-2724	big spoiled bouncing blinking bowl of rye sprouts	5	crappy	
-2725	decent massive special blurry cob of corn	6	good	Effect: "Fishily Speeding", Effect Duration: 40
+2724	spoiled big bouncing blinking bowl of rye sprouts	5	crappy	
+2725	special massive decent blurry cob of corn	6	good	Effect: "Fishily Speeding", Effect Duration: 40
 2726	toothsome twirling juniper berries	3	awesome	
 2727	huge decent special plum	7	good	Effect: "Here's Mud in Your Eye", Effect Duration: 40
 2728	rotten pear	4	crappy	
 2729	stale half-sized huge peach	2	decent	
 2730	mediocre fancy shaking plum wine	4	decent	Effect: "Heart of White", Effect Duration: 30
-2731	triple-distilled lousy shot of pear schnapps	8	decent	
+2731	lousy triple-distilled shot of pear schnapps	8	decent	
 2732	tolerable shot of peach schnapps	4	good	
 2733	bland bunch of square grapes	3	decent	
 2734	spoiled small blurry brown sugar cane	2	crappy	
-2735	snack-sized rotten blurry blue sandwich of the gods	2	crappy	
+2735	snack-sized rotten blue blurry sandwich of the gods	2	crappy	
 2736	mediocre extra-dry blue Pan-Dimensional Gargle Blaster	5	decent	
 2737	altered leopard-print barbell	1	crappy	Effect: "Quiet 'n' Good", Effect Duration: 35
 2738	pile of smoking rags	0		
 2739	liquefied pickled red panty raider camouflage	0		Effect: "Items Are Forever", Effect Duration: 49
 2740	Jim Carey's medical-grade Staff of the Walk-In Freezer of James Dean	0		Experience (Moxie): +3, Monster Level: +25, HP Regen Min: 7, HP Regen Max: 10
-2741	practically non-alcoholic acceptable ghostly boilermaker	1	good	
-2742	normal jumbo twirling steel lasagna	5	quest	
+2741	acceptable practically non-alcoholic ghostly boilermaker	1	good	
+2742	jumbo normal twirling steel lasagna	5	quest	
 2743	lousy weak steel margarita	2	quest	
 2744	dried steel-scented air freshener	1		Effect: "Items Are Forever", Effect Duration: 40
 2745	pressed gremlin mutagen	0		Effect: "Twinklebritches", Effect Duration: 47
@@ -2778,8 +2778,8 @@
 2805	deionized ionized maroon vial of baconstone juice	0		Effect: "Memento Moir&eacute;", Effect Duration: 15
 2806	nitrogenated vial of porquoise juice	0		Effect: "Supafly", Effect Duration: 65
 2807	concentrated gray flask of hamethyst juice	0		Effect: "Chorale of Companionship", Effect Duration: 42
-2808	non-adjusted unsweetened energized narrow upside-down flask of baconstone juice	0		Effect: "Spooky Flavor", Effect Duration: 23
-2809	dry ghostly mirror flask of porquoise juice	0		Effect: "Scorpio Rising", Effect Duration: 19
+2808	non-adjusted unsweetened energized upside-down narrow flask of baconstone juice	0		Effect: "Spooky Flavor", Effect Duration: 23
+2809	dry mirror ghostly flask of porquoise juice	0		Effect: "Scorpio Rising", Effect Duration: 19
 2810	concentrated pressed skewed jug of hamethyst juice	0		Effect: "Greasy Visage", Effect Duration: 34
 2811	moist enhanced double-dry spinning olive jug of baconstone juice	0		Effect: "Elemental Saucesphere", Effect Duration: 66
 2812	galvanized jug of porquoise juice	0		Effect: "Abyssal Blood", Effect Duration: 33
@@ -2789,9 +2789,9 @@
 2816	skewed upside-down fireproof Boxers of the sewer of the early riser	0		Stench Damage: +25, Hot Resistance: +3, Adventures: +7, Familiar Effect: "1xVolley, 1xLep"
 2817	crafty cool Brooch of the overflowing toilet	0		Moxie: +5, Maximum MP: +10, Stench Spell Damage: +50, Single Equip
 2818	lightning-fast greasy ruddy Bracelet	0		Maximum HP Percent: +40, Sleaze Spell Damage: +10, Initiative: +40, Single Equip
-2819	squat resourceful Rosewater's Grimacite gasmask	0		Mysticality Percent: +30, Maximum MP: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	squat resourceful Rosewater's Grimacite gasmask	0		Mysticality Percent: +30, Maximum MP: +50, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	mirror nasty groovy Grimacite gat	0		Moxie Percent: +10, Stench Damage: +5, Last Available: "2008-11"
-2821	skewed hardened smooth Grimacite gaiters	0		Moxie: +15, Damage Reduction: 3, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	skewed hardened smooth Grimacite gaiters	0		Moxie: +15, Damage Reduction: 3, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	skewed bouncing baleful Grimacite gauntlets of terror	0		Spell Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2008-11"
 2823	avaricious family-friendly Grimacite go-go boots	0		Sleaze Resistance: +1, Meat Drop: +30, Single Equip, Last Available: "2008-11"
 2824	hardened fortified Grimacite girdle	0		Damage Absorption: +60, Damage Reduction: 3, Single Equip, Last Available: "2008-11"
@@ -2802,8 +2802,8 @@
 2829	narrow really dense meat stack	0		
 2830	digital key lime	0		
 2831	mirror star key lime	0		
-2832	flavorless jumbo digital key lime pie	5	decent	
-2833	immense flavorless star key lime pie	6	decent	
+2832	jumbo flavorless digital key lime pie	5	decent	
+2833	flavorless immense star key lime pie	6	decent	
 2834	shaking ghostly scandalous sharpshooter's educational bottle-rocket crossbow	0		Experience: +1, Critical Hit Percent: +10, Sleaze Damage: +5, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	jittery healthy indie comic hipster glasses	0		Maximum HP Percent: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2812,7 +2812,7 @@
 2839	fireproof Periodical Paintbrush	0		Hot Resistance: +3, Softcore Only
 2840	drinkable bottle of cooking sherry	3	good	
 2841	flavorless shaking packet of ketchup	3	decent	
-2842	watered-down tolerable accidental cider	2	good	
+2842	tolerable watered-down accidental cider	2	good	
 2843	delicious dire fudgesicle	3	awesome	
 2844	frosty vibrating smooth navel ring of navel gazing of horror	0		Moxie: +15, Maximum MP Percent: +10, Cold Spell Damage: +10, Spooky Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2927,9 +2927,9 @@
 2955	spoiled big yam candy	5	crappy	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	special bite-sized flavorless spinning tube of cranberry Go-Goo	1	decent	Effect: "The Halls of Muscularity", Effect Duration: 45
+2958	flavorless bite-sized special spinning tube of cranberry Go-Goo	1	decent	Effect: "The Halls of Muscularity", Effect Duration: 45
 2959	narrow blue rum barrel charrrm bracelet of the wise owl	0		Mysticality: +20
-2960	half-sized stale ghostly single-serving herbal stuffing	2	decent	
+2960	stale half-sized ghostly single-serving herbal stuffing	2	decent	
 2961	decent packet of tofurkey gravy	3	good	
 2962	toothsome tofurkey nugget	3	awesome	
 2963	rigging shampoo	0		
@@ -2945,7 +2945,7 @@
 2973	lime green shellacked grumpy man charrrm bracelet	0		Damage Reduction: 7, Single Equip
 2974	tarrrnish charrrm	0		
 2975	smelly Fonzie's tarrrnished charrrm bracelet	0		Experience (Moxie): +1, Stench Spell Damage: +10, Single Equip
-2976	smooth fancy weak bilge wine	2	awesome	Effect: "Elemental Mastery", Effect Duration: 40
+2976	fancy smooth weak bilge wine	2	awesome	Effect: "Elemental Mastery", Effect Duration: 40
 2977	huge mirror prompt witty rapier	0		Adventures: +3
 2978	squat MacGyver's yohohoyo of the detective	0		Maximum MP: +100, Item Drop: +20
 2979	polarized upside-down fish-liver oil	0		Effect: "Badger Underfoot", Effect Duration: 13
@@ -2962,7 +2962,7 @@
 2990	olive shaking Temple Grandin's clingfilm cap of incineration	0		Familiar Weight: +7, Hot Spell Damage: +50, Familiar Effect: "1xVolley, cap 37"
 2991	clingfilm slippers of bravery	0		Spooky Resistance: +5, Single Equip
 2992	clingfilm tangle	0		
-2993	spoiled enchanted vinegar-soaked lemon slice	4	crappy	Effect: "The Best a Pirate Can Get", Effect Duration: 5
+2993	enchanted spoiled vinegar-soaked lemon slice	4	crappy	Effect: "The Best a Pirate Can Get", Effect Duration: 5
 2994	frozen true grit	0		Effect: "Dragged Through the Coals", Effect Duration: 32
 2995	clever razor-sharp buoybottoms of the businessman	0		Weapon Damage Percent: +25, Maximum MP: +20, Meat Drop: +50, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	wobbly skewed grungy flannel shirt of the scaredy-cat	0		Monster Level: -15
@@ -2998,34 +2998,34 @@
 3026	acceptable boozy corpsetini	5	good	
 3027	smooth ghostly cyan corpsedriver	4	awesome	
 3028	lousy Corpse Island iced tea	3	decent	
-3029	enchanted aged weak red-headed corpse	2	awesome	Effect: "Purity of Spirit", Effect Duration: 5
-3030	enchanted hand-crafted weak kamicorpse-ee	2	EPIC	Effect: "Artificially Sweet", Effect Duration: 20
+3029	aged enchanted weak red-headed corpse	2	awesome	Effect: "Purity of Spirit", Effect Duration: 5
+3030	hand-crafted weak enchanted kamicorpse-ee	2	EPIC	Effect: "Artificially Sweet", Effect Duration: 20
 3031	delicious narrow corpsel	3	awesome	
 3032	weak acceptable corpsebite	2	good	
 3033	dangerous pirate fledges	0		Weapon Damage: +10
 3034	piece of thirteen	0		
 3035	stale pearl onion	3	decent	
-3036	decent miniature sea biscuit	2	good	
+3036	miniature decent sea biscuit	2	good	
 3037	acceptable bottle of rum	4	good	
-3038	acceptable special bottle of black-label rum	3	good	Effect: "Bottle in front of Me", Effect Duration: 30
+3038	special acceptable bottle of black-label rum	3	good	Effect: "Bottle in front of Me", Effect Duration: 30
 3039	skewed cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
 3042	huge Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	maroon metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	normal huge nanite-infested gingerbread bugbear	10	good	Last Available: "2007-12"
 3046	bland ghostly nanite-infested candy cane	3	decent	Last Available: "2020-09"
 3047	flavorless nanite-infested fruitcake	3	decent	Last Available: "2007-12"
-3048	fancy drinkable blurry nanite-infested eggnog	3	good	Effect: "Fishy", Effect Duration: 5, Last Available: "2007-12"
+3048	drinkable fancy blurry nanite-infested eggnog	3	good	Effect: "Fishy", Effect Duration: 5, Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	skewed aromatic eyepatch	0		Stench Resistance: +1, Familiar Effect: "spooky atk, 1xBarrr"
 3051	cutlass of the wise owl	0		Mysticality: +20
 3052	breeches of the brute	0		Muscle Percent: +30, Familiar Effect: "stench atk, 1xPotato"
-3053	ghostly tumbling mood ring	0		Last Available: "2007-02"
+3053	tumbling ghostly mood ring	0		Last Available: "2007-02"
 3054	ionized candy heart	0		Effect: "The Magic of LOV", Effect Duration: 47, Last Available: "2007-02"
 3055	galvanized huge cymbal syrup	0		Free Pull, Effect: "Eggs-tra Sensory Perception", Effect Duration: 67, Last Available: "2007-02"
-3056	blinking flame-retardant metallic foil cat ears	0		Hot Resistance: +1, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	blinking flame-retardant metallic foil cat ears	0		Hot Resistance: +1, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	twirling nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	cyan hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	marionette collective of the brazier	0		Hot Spell Damage: +25, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,14 +3057,14 @@
 3085	Herculean roboduck-on-a-string of the detective	0		Experience (Muscle): +1, Item Drop: +20, Last Available: "2007-12"
 3086	gray mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	zippy quilted biomechanical crimborg helmet	0		Damage Absorption: +40, Initiative: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	zippy quilted biomechanical crimborg helmet	0		Damage Absorption: +40, Initiative: +20, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	mirror fireproof steel-toed C.B.F.G.	0		Damage Reduction: 9, Hot Resistance: +3, Last Available: "2007-12"
-3090	ghostly tumbling executive steel-toed biomechanical crimborg leg armor	0		Damage Reduction: 9, Meat Drop: +40, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	ghostly tumbling executive steel-toed biomechanical crimborg leg armor	0		Damage Reduction: 9, Meat Drop: +40, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	electrified vitachoconutriment capsule	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 51, Last Available: "2007-12"
 3092	handmade hobby horse of the pedagogue	0		Experience: +3, Last Available: "2007-12"
 3093	narrow ball-in-a-cup of chilblains	0		Cold Damage: +25, Last Available: "2007-12"
 3094	ghostly lightning-fast set of jacks	0		Initiative: +40, Last Available: "2007-12"
-3095	thick stale laser-broiled pear	5	decent	Last Available: "2007-12"
+3095	stale thick laser-broiled pear	5	decent	Last Available: "2007-12"
 3096	wobbly energetic polyalloy shield of Flo-Jo	0		Maximum MP Percent: +20, Initiative: +100, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	pulsating killing feather	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	mirror Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	blue old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	shaking Hodgman	0		
-3117	upside-down ghostly Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	ghostly upside-down Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3121,7 +3121,7 @@
 3149	cyan El Vibrato punchcard (213 holes)	0		
 3150	El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
-3152	olive wobbly El Vibrato punchcard (216 holes)	0		
+3152	wobbly olive El Vibrato punchcard (216 holes)	0		
 3153	El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
 3155	El Vibrato punchcard (176 holes)	0		
@@ -3138,27 +3138,27 @@
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	ionized pickled spinning seal eyeball	0		Effect: "Fungal Flambé", Effect Duration: 53
-3169	normal small turtle soup	2	good	Effect: "[598]A Little Bit Evil"
+3169	small normal turtle soup	2	good	Effect: "[598]A Little Bit Evil"
 3170	blurry evil noodles	0		
-3171	ghostly blinking ghostly fuchsia nauseating reagent	0		
+3171	ghostly ghostly fuchsia blinking nauseating reagent	0		
 3172	Usain Bolt's evil paper umbrella	0		Initiative: +80
 3173	triple-cold-filtered evil vihuela	0		Effect: "BOOsted", Effect Duration: 40
-3174	half-sized normal evil boring spaghetti	2	good	
+3174	normal half-sized evil boring spaghetti	2	good	
 3175	decent teal spinning evil noodles	3	good	
 3176	rotten evil noodles	3	crappy	
 3177	normal evil painful penne pasta	3	good	
-3178	bland massive 3vi1 pr0n m4nic0tti	10	decent	
+3178	massive bland 3vi1 pr0n m4nic0tti	10	decent	
 3179	enchanted thick flavorless blurry evil ravioli della hippy	5	decent	Effect: "Bootyliciousness", Effect Duration: 25
 3180	toothsome evil noodles	3	awesome	
 3181	magnetized triple-denatured evil potion of potency	0		Effect: "Wintry Breath", Effect Duration: 67
-3182	modified teal mirror evil libation of liveliness	0		Effect: "You're Rubber", Effect Duration: 52
+3182	modified mirror teal evil libation of liveliness	0		Effect: "You're Rubber", Effect Duration: 52
 3183	chilled flattened mirror evil tomato juice of powerful power	0		Effect: "Nano-juiced", Effect Duration: 27
 3184	liquefied yellow evil eyedrops of the ermine	0		Effect: "Well-preserved", Effect Duration: 34
 3185	double-chilled tarnished purple evil ointment of the occult	0		Effect: "Icy Demeanor", Effect Duration: 27
 3186	warmed dry extra-cold-filtered fuchsia evil serum of sarcasm	0		Effect: "Elemental Mastery", Effect Duration: 31
 3187	adjusted evil philter of phorce	0		Effect: "Educated (Sorta)", Effect Duration: 20
-3188	delicious weak an evil sump'm sump'm	2	awesome	
-3189	mediocre practically non-alcoholic skewed evil ducha de oro	1	decent	
+3188	weak delicious an evil sump'm sump'm	2	awesome	
+3189	practically non-alcoholic mediocre skewed evil ducha de oro	1	decent	
 3190	weak bad evil horizontal tango	2	decent	
 3191	acceptable evil roll in the hay	3	good	
 3192	huge naughty origami kit	0		Last Available: "2008-02"
@@ -3196,18 +3196,18 @@
 3224	sewer wad	0		
 3225	artisanal maroon bottle of sewage schnapps	4	EPIC	
 3226	tolerable bottle of Ooze-O	4	good	
-3227	immense bland pulsating C.H.U.M. chum	9	decent	
-3228	flavorless half-sized blurry unfortunate dumplings	2	decent	
+3227	bland immense pulsating C.H.U.M. chum	9	decent	
+3228	half-sized flavorless blurry unfortunate dumplings	2	decent	
 3229	decaying goldfish liver	0		
-3230	dry moist spinning lime green oil of oiliness	0		Effect: "Egg-stra Arm", Effect Duration: 30
+3230	dry moist lime green spinning oil of oiliness	0		Effect: "Egg-stra Arm", Effect Duration: 30
 3231	ghostly spinning medical-grade tattered paper crown	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xSombrero, cap 15"
-3232	rotten low-calorie vanilla-frosted king cake	1	crappy	Last Available: "2008-03"
+3232	low-calorie rotten vanilla-frosted king cake	1	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	purple water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
 3236	Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
-3238	twirling olive Blizzards I Have Died In	0		Skill: "Snowclone"
+3238	olive twirling Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	twirling Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	ghostly Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	upside-down Travels with Jerry	0		Skill: "Mudbath"
@@ -3232,7 +3232,7 @@
 3260	mansplainer's thinker's strapping Chester's moustache	0		Muscle: +5, Mysticality: +10, Monster Level: +15, Class: "Disco Bandit", Single Equip
 3261	hardened dangerous Chester's bag of candy	0		Weapon Damage: +10, Damage Reduction: 3, Class: "Disco Bandit"
 3262	Chester's cutoffs of the ox of mayonnaise	0		Muscle: +20, Sleaze Spell Damage: +50, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	blue bag of Crotchety Pine saplings	0		
 3266	ghostly bag of Saccharine Maple saplings	0		
@@ -3341,7 +3341,7 @@
 3369	powdered glimmering phoenix feather	1		Last Available: "2008-06"
 3370	compressed huge glimmering penguin feather	1		Last Available: "2008-06"
 3371	powdered bouncing glimmering buzzard feather	1		Last Available: "2008-06"
-3372	modified wobbly bouncing glimmering raven feather	1		Last Available: "2008-06"
+3372	modified bouncing wobbly glimmering raven feather	1		Last Available: "2008-06"
 3373	compressed glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3371,7 +3371,7 @@
 3399	artisanal distilled jar of squeeze	5	EPIC	
 3400	fancy delicious bowl of fishysoisse	3	awesome	Effect: "Mystic Circle", Effect Duration: 30
 3401	improved cold-filtered skewed deadly lampshade	0		Effect: "Ooh, Sour!", Effect Duration: 53
-3402	concentrated squat gray huge concentrated garbage juice	0		Effect: "Memories of Puppy Love", Effect Duration: 41
+3402	concentrated huge gray squat concentrated garbage juice	0		Effect: "Memories of Puppy Love", Effect Duration: 41
 3403	lewd playing card	0		
 3404	lard-coated deck of lewd playing cards of dire peril of the brazier	0		Weapon Damage: +20, Hot Spell Damage: +25, Sleaze Spell Damage: +25
 3405	Hodgman's sock of the brazier	0		Hot Spell Damage: +25, Single Equip
@@ -3385,8 +3385,8 @@
 3413	cyan Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	maroon Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
-3416	ghostly blue hobo fortress blueprints	0		
-3421	twirling skewed box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3416	blue ghostly hobo fortress blueprints	0		
+3421	skewed twirling box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	boiled warmed narrow sterno-flavored Hob-O	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 68
 3423	galvanized oxidized frozen frostbite-flavored Hob-O	0		Effect: "Industrial Strength Starch", Effect Duration: 13
 3424	quadruple-frozen moist galvanized blinking fry-oil-flavored Hob-O	0		Effect: "Chalked Weapon", Effect Duration: 61
@@ -3404,7 +3404,7 @@
 3437	nippy medical-grade Staff of the Black Kettle of Flo-Jo	0		Cold Damage: +10, Initiative: +100, HP Regen Min: 7, HP Regen Max: 10
 3438	mirror greedy ribald Staff of the Well-Tempered Cauldron of temperance	0		Sleaze Damage: +10, Sleaze Resistance: +5, Meat Drop: +20
 3439	gray Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	vaporized mirror upside-down prismatic wad	1	good	Effect: "Okee-Dokee Go!", Effect Duration: 30, Last Available: "2008-07"
+3440	vaporized upside-down mirror prismatic wad	1	good	Effect: "Okee-Dokee Go!", Effect Duration: 30, Last Available: "2008-07"
 3441	clever club of the five seasons	0		Maximum MP: +20, Last Available: "2008-07"
 3442	jittery blurry wool rainbow crossbow	0		Cold Resistance: +1, Last Available: "2008-07"
 3443	kitten	0		
@@ -3419,19 +3419,19 @@
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	wobbly cotton candy plug	0		Last Available: "2008-08"
 3454	cotton candy pillow	0		Last Available: "2008-08"
-3455	wobbly twirling cotton candy bale	0		Last Available: "2008-08"
+3455	twirling wobbly cotton candy bale	0		Last Available: "2008-08"
 3456	Socratic trusty torch	0		Experience (Mysticality): +1, Last Available: "2011-12"
 3457	coward's Junior Adventurer's merit badge	0		Monster Level: -20
 3458	magnetized STYX deodorant body spray	0		Effect: "Mortarfied", Effect Duration: 58
 3459	lousy teal ghostly white-label gin	3	decent	
-3460	small yummy tin rations	2	awesome	
+3460	yummy small tin rations	2	awesome	
 3461	wobbly haiku challenge map	0		
 3462	terrible poem	0		
 3463	artisanal bottle of sake	4	EPIC	
 3464	wobbly round pebble of Leguizamo	0		Monster Level: +20
 3465	decent Bash-&#332;s cereal	4	good	Wiki Name: "Bash-Os cereal"
 3466	gravedigger's quilted Sinatra's haiku katana	0		Experience (Moxie): +5, Damage Absorption: +40, Spooky Damage: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
-3467	skewed blurry blinking bargain flash powder	0		
+3467	blinking blurry skewed bargain flash powder	0		
 3468	lion tamer's plastic baby	0		Experience (familiar): +2, Single Equip, Last Available: "2008-12"
 3469	adequate lime green blueberry-frosted king cake	4	good	Last Available: "2008-12"
 3470	mirror bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
@@ -3449,7 +3449,7 @@
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	twirling psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
-3485	extra-pressed mirror twirling glittery mascara	0		Effect: "Lemony Goodness", Effect Duration: 52
+3485	extra-pressed twirling mirror glittery mascara	0		Effect: "Lemony Goodness", Effect Duration: 52
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
@@ -3462,16 +3462,16 @@
 3495	ionized colloidal frozen sea salt crystal	0		Effect: "Human-Horror Hybrid", Effect Duration: 30
 3496	non-corrupted electrified mirror green bazookafish bubble gum	0		Effect: "Tremella Tremens", Effect Duration: 61
 3497	smooth bottle of Pete's Sake	3	awesome	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	bouncing beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	bouncing beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	miniature stale canap&eacute;s	2	decent	
 3502	dehydrated yellow thermos of brew	1	EPIC	Last Available: "2011-12"
 3503	tolerable blinking glass of brandy	4	good	Last Available: "2011-12"
 3504	French slippers	0		
 3505	electrified LWA ring	0		MP Regen Min: 3, MP Regen Max: 5
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	blurry Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	blurry Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	lime green Annie Oakley's scratch 'n' sniff sword	0		Critical Hit Percent: +20, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3480,7 +3480,7 @@
 3513	scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	cyan scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	up-at-dawn cool ganger bandana	0		Moxie: +5, Adventures: +5, Familiar Effect: "atk"
-3516	skewed fuchsia eel skin	0		
+3516	fuchsia skewed eel skin	0		
 3517	narrow scandalous eelskin hat	0		Sleaze Damage: +5, Familiar Effect: "atk"
 3518	lion tamer's eelskin pants	0		Experience (familiar): +2, Familiar Effect: "1xPotato, MP regen"
 3519	forbidden eelskin shield	0		Spell Damage Percent: +50, Damage Reduction: 13
@@ -3510,8 +3510,8 @@
 3543	rosewater-soaked sizzling depleted Grimacite gravy boat	0		Hot Damage: +10, Stench Resistance: +3, Last Available: "2011-12"
 3544	teal ribald gravedigger's depleted Grimacite weightlifting belt	0		Spooky Damage: +10, Sleaze Damage: +10, Single Equip, Last Available: "2011-12"
 3545	fortified depleted Grimacite grappling hook of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100, Single Equip, Last Available: "2011-12"
-3546	rosy-cheeked depleted Grimacite ninja mask of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	electrified depleted Grimacite shinguards of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	rosy-cheeked depleted Grimacite ninja mask of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	electrified depleted Grimacite shinguards of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	mirror studded depleted Grimacite astrolabe of temperance	0		Damage Absorption: +80, Sleaze Resistance: +5, Single Equip, Last Available: "2011-12"
 3549	Lo Pan's padded KoL Con Cinco Pi&ntilde;ata Bat	0		Damage Absorption: +20, Spell Critical Percent: +30, Softcore Only, Last Available: "2008-09"
 3550	twirling family-friendly propeller beanie	0		Sleaze Resistance: +1, Familiar Effect: "atk, cap 7"
@@ -3520,11 +3520,11 @@
 3553	soggy seed packet	0		
 3554	pulsating glob of slime	0		
 3555	adequate low-calorie twirling sea carrot	1	good	
-3556	flavorless low-calorie twirling sea cucumber	1	decent	
-3557	immense tasty sea avocado	9	awesome	
-3558	normal snack-sized sea lychee	2	good	
+3556	low-calorie flavorless twirling sea cucumber	1	decent	
+3557	tasty immense sea avocado	9	awesome	
+3558	snack-sized normal sea lychee	2	good	
 3559	big delicious wobbly sea tangelo	5	awesome	
-3560	super-sized decent sea honeydew	5	good	
+3560	decent super-sized sea honeydew	5	good	
 3561	pickled tumbling pressurized potion of puissance	0		Effect: "Scrappy, Shadowy", Effect Duration: 63
 3562	colloidal tarnished jittery pressurized potion of perspicacity	0		Effect: "Ironclad", Effect Duration: 17
 3563	frozen aerosolized pressurized potion of pulchritude	0		Effect: "Crimbo Epiphany", Effect Duration: 54
@@ -3542,12 +3542,12 @@
 3575	fuchsia mirror sand dollar	0		
 3576	flytrap bezoar	0		
 3577	olive bezoar ring	0		
-3578	ghostly upside-down wobbly candy cornucopia	0		Free Pull, Last Available: "2011-12"
+3578	upside-down wobbly ghostly candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	squat wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	flavorless snack-sized fancy rice	2	decent	Effect: "Resilient Spirit", Effect Duration: 45
-3584	bland fancy huge irradiated candy cane	4	decent	Effect: "Beastly Flavor", Effect Duration: 45, Last Available: "2008-12"
+3582	fancy snack-sized flavorless rice	2	decent	Effect: "Resilient Spirit", Effect Duration: 45
+3584	fancy bland huge irradiated candy cane	4	decent	Effect: "Beastly Flavor", Effect Duration: 45, Last Available: "2008-12"
 3585	big toothsome gingerbread mutant bugbear	5	awesome	Last Available: "2008-12"
 3586	weak perfectly mixed oozenog	2	EPIC	Last Available: "2008-12"
 3587	anodized improved ghostly fuchsia sugar plum	0		Effect: "You Know When to Walk Away", Effect Duration: 37, Last Available: "2008-12"
@@ -3565,14 +3565,14 @@
 3599	gray beefy moist sailor's cap of courage of the detective	0		Muscle: +10, Spooky Resistance: +3, Item Drop: +20, Familiar Effect: "stench atk"
 3600	blinking extremely unsafe Newton's speargun	0		Experience (Mysticality): +3, Weapon Damage Percent: +100
 3601	compass of the cougar	0		Moxie: +20
-3602	wobbly blue shaking broken diving helmet	0		
+3602	shaking wobbly blue broken diving helmet	0		
 3603	porthole	0		
 3604	upside-down rivet	0		
 3605	bubblin' stone	0		
 3606	upside-down flame-wreathed Tesla deadly diving helmet	0		Weapon Damage: +5, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "0.5xPotato"
 3607	Usain Bolt's frightening lion tamer's aerated diving helmet	0		Experience (familiar): +2, Spooky Damage: +5, Initiative: +80, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	live nautical mine	0		
-3609	tumbling ghostly das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
+3609	ghostly tumbling das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
 3611	modified ionized sea grease	0		Effect: "Deeply Ironic", Effect Duration: 18
 3612	pulsating sturdy Crimbo crate	0		Last Available: "2008-12"
@@ -3588,17 +3588,17 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	pulsating chitinous pod	0		Last Available: "2008-12"
 3624	yellow squat ruddy parasitic claw	0		Maximum HP Percent: +40, Last Available: "2008-12"
-3625	jittery narrow parasitic tentacles of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	brawny parasitic headgnawer	0		Muscle Percent: +20, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	jittery narrow parasitic tentacles of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	brawny parasitic headgnawer	0		Muscle Percent: +20, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	fortified parasitic strangleworm	0		Damage Absorption: +60, Last Available: "2008-12"
-3628	upside-down blurry pair of ragged claws	0		Last Available: "2008-12"
+3628	blurry upside-down pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
 3630	Crimbo crate	0		Last Available: "2008-12"
 3631	aerosolized Gummi-DNA	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 53, Last Available: "2020-09"
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	gray squat nippy elven socks of Flo-Jo	0		Cold Damage: +10, Initiative: +100, Last Available: "2008-12"
 3634	narrow elven gloves of Gandalf of the sewer	0		Spell Critical Percent: +20, Stench Damage: +25, Last Available: "2008-12"
-3635	teal deadly educational festive holiday hat	0		Experience: +1, Weapon Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	teal deadly educational festive holiday hat	0		Experience: +1, Weapon Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	fireproof wizardly patent shoes	0		Mysticality: +25, Hot Resistance: +3, Last Available: "2008-12"
 3637	Temple Grandin's gray bow tie of the empath	0		Familiar Weight: 12, Last Available: "2008-12"
 3638	healthy penguin thesaurus of the glutton	0		Maximum HP Percent: +20, Food Drop: +100, Last Available: "2008-12"
@@ -3608,15 +3608,15 @@
 3642	dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	occult depleted Grimacite kneecapping stick	0		Spell Damage Percent: +25, Last Available: "2007-06"
-3645	drinkable strong canteen of wine	5	good	Last Available: "2008-12"
+3645	strong drinkable canteen of wine	5	good	Last Available: "2008-12"
 3646	moldy elven <i>limbos</i> gingerbread	4	crappy	Last Available: "2008-12"
 3647	upside-down elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	enchanted bland tumbling toast with jam	3	decent	Effect: "Blackberry Politeness", Effect Duration: 50, Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	mediocre elven moonshine	3	decent	Last Available: "2008-12"
-3653	normal big knuckle sandwich	5	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	normal big knuckle sandwich	5	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	spinning manspreader's Rosewater's psycho sweater	0		Mysticality Percent: +30, Monster Level: +10, Last Available: "2008-12"
 3655	spinning fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of the empath	0		Familiar Weight: +5, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	manspreader's plastic strand of DNA	0		Monster Level: +10, Last Available: "2008-12"
 3660	olive spinning frightening plastic chunk of depleted Grimacite	0		Spooky Damage: +5, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	maroon steel-toed Putty mitre	0		Damage Reduction: 9, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	censurious supercool Putty leotard	0		Moxie Percent: +20, Sleaze Resistance: +3, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	maroon steel-toed Putty mitre	0		Damage Reduction: 9, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	censurious supercool Putty leotard	0		Moxie Percent: +20, Sleaze Resistance: +3, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Putty ball of Tarzan	0		Experience (Muscle): +3, Softcore Only, Last Available: "2009-01"
 3665	blurry tumbling Putty sheet	0		Last Available: "2009-01"
 3666	shellacked wizardly Putty snake of vim and vigor	0		Mysticality: +25, Damage Reduction: 7, Maximum HP Percent: +50, Softcore Only, Last Available: "2009-01"
@@ -3635,7 +3635,7 @@
 3669	boxer's glow-in-the-dark dart gun	0		Muscle Percent: +10, Last Available: "2009-01"
 3670	green beefcake's glow-in-the-dark burrowgrub	0		Muscle: +25, Last Available: "2009-01"
 3671	red Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	special stale immense blurry can of franks 'n' beans	9	decent	Effect: "Broken Fast", Effect Duration: 50, Last Available: "2010-12"
+3672	immense stale special blurry can of franks 'n' beans	9	decent	Effect: "Broken Fast", Effect Duration: 50, Last Available: "2010-12"
 3673	weak aged bottle of peppermint schnapps	2	awesome	Last Available: "2010-12"
 3674	ghostly throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
@@ -3649,13 +3649,13 @@
 3683	twirling map to the Marinara Trench	0		
 3684	spoiled tempura carrot	4	crappy	
 3685	adequate bouncing tempura cucumber	3	good	
-3686	rotten massive tempura avocado	9	crappy	
+3686	massive rotten tempura avocado	9	crappy	
 3687	spoiled huge sea broccoli	4	crappy	
 3688	small rotten sea cauliflower	2	crappy	
 3689	big yummy upside-down tempura broccoli	5	awesome	
 3690	adequate tempura cauliflower	4	good	
 3691	spoiled sea blueberry	3	crappy	
-3692	miniature normal fuchsia huge sea persimmon	2	good	
+3692	normal miniature fuchsia huge sea persimmon	2	good	
 3693	anodized ionized pressurized potion of perception	0		Effect: "substats.enh", Effect Duration: 40
 3694	deionized super-polarized pressurized potion of proficiency	0		Effect: "Liquidy Smoky", Effect Duration: 42
 3695	cool Mer-kin digpick	0		Moxie: +5
@@ -3665,7 +3665,7 @@
 3699	teflon ore	0		
 3700	gray vinyl ore	0		
 3701	twirling map to Anemone Mine	0		
-3702	squat twirling twirling marine aquamarine	0		
+3702	twirling twirling squat marine aquamarine	0		
 3703	valve wheel	0		
 3704	waterlogged bootstraps	0		
 3705	bouncing manspreader's rock-hard velcro broadsword of the sewer	0		Damage Reduction: 5, Monster Level: +10, Stench Damage: +25
@@ -3706,7 +3706,7 @@
 3740	handful of bees	0		
 3741	mirror spectral jelly	0		
 3742	double-unsweetened jellyfish gel	0		Effect: "Powder Power", Effect Duration: 11
-3743	shaking upside-down huge unstable quark	0		
+3743	upside-down huge shaking unstable quark	0		
 3744	tumbling software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	red vampire pearl	0		
@@ -3714,7 +3714,7 @@
 3749	altered corrupted modified blinking concoction of clumsiness	0		Effect: "Berry Experiential", Effect Duration: 16
 3750	tumbling electrified vampire pearl earring	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 3751	adequate snack-sized chocolate chip brownies	2	good	
-3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	dry love song of vague ambiguity	0		Effect: "Memory of Speed", Effect Duration: 58, Last Available: "2009-02"
 3755	pickled chilled magnetized skewed love song of smoldering passion	0		Effect: "Jittery", Effect Duration: 30, Last Available: "2009-02"
 3756	anodized alkaline fuchsia love song of icy revenge	0		Effect: "Hypercubed", Effect Duration: 61, Last Available: "2009-02"
@@ -3727,13 +3727,13 @@
 3763	weak acceptable slug of vodka	2	good	
 3764	acceptable purple slug of rum	3	good	
 3765	artisanal slug of shochu	3	EPIC	
-3766	perfectly mixed practically non-alcoholic huge screwdiver	1	EPIC	
+3766	practically non-alcoholic perfectly mixed huge screwdiver	1	EPIC	
 3767	special lousy high-proof ghostly dew yoana lei	6	decent	Effect: "Hammertime", Effect Duration: 20
-3768	hand-crafted pulsating upside-down lychee chuhai	3	EPIC	
+3768	hand-crafted upside-down pulsating lychee chuhai	3	EPIC	
 3769	aged weak salacious screwdiver	2	awesome	
-3770	irresponsibly strong lousy dew yoana salacious lei	9	decent	
+3770	lousy irresponsibly strong dew yoana salacious lei	9	decent	
 3771	tolerable salacious lychee chuhai	3	good	
-3772	high-proof mediocre wobbly Alewife&trade; Ale	10	decent	
+3772	mediocre high-proof wobbly Alewife&trade; Ale	10	decent	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3753,8 +3753,8 @@
 3789	ghostly twitching trigger finger	0		Class: "Pastamancer"
 3799	blurry Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	upside-down charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	upside-down charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	narrow squat red Oprah's baleful Mer-kin roundshield of the scaredy-cat	0		Spell Damage: +25, Maximum MP Percent: +50, Monster Level: -15, Damage Reduction: 14
 3804	shaking double-paned Newton's Mer-kin breastplate	0		Experience (Mysticality): +3, Cold Resistance: +5
 3805	chaotic Mer-kin sneakmask of James Dean	0		Experience (Moxie): +3, Spell Critical Percent: +10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3773,7 +3773,7 @@
 3819	eel sauce	0		
 3820	blinking foul-smelling water-polo mitt	0		Stench Damage: +10, Single Equip
 3821	electrified pressed huge syringe	0		Effect: "Sweet Tooth", Effect Duration: 61
-3822	narrow blue wand	0		Familiar Effect: "fishy spells"
+3822	blue narrow wand	0		Familiar Effect: "fishy spells"
 3823	double-denatured triple-flattened corrupted blurry wad of cotton	0		Effect: "Big", Effect Duration: 45
 3824	Grandma's Note	0		
 3825	twirling Grandma's Fuchsia Yarn	0		
@@ -3782,10 +3782,10 @@
 3828	Grandma's Map	0		
 3829	flavorless bite-sized tempura radish	1	decent	
 3830	sharpshooter's water-polo cap	0		Critical Hit Percent: +10, Familiar Effect: "1xVolley, 1xBarrr"
-3831	delicious weak Typical Tavern swill	2	awesome	
+3831	weak delicious Typical Tavern swill	2	awesome	
 3832	lousy tropical swill	3	decent	
 3833	tolerable fruity girl swill	4	good	
-3834	weak enchanted tolerable blended swill	2	good	Effect: "Greased-Up Familiar", Effect Duration: 35
+3834	enchanted tolerable weak blended swill	2	good	Effect: "Greased-Up Familiar", Effect Duration: 35
 3835	costume wardrobe	0		Softcore Only
 3836	Usain Bolt's reassuring frightening Elvish sunglasses of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Spooky Resistance: +1, Initiative: +80, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	anniversary safety glass vest of dire peril	0		Weapon Damage: +20
@@ -3830,20 +3830,20 @@
 3876	hellseal brain	0		
 3877	maroon burst hellseal brain	0		
 3878	jittery hellseal sinew	0		
-3879	ghostly squat torn hellseal sinew	0		
+3879	squat ghostly torn hellseal sinew	0		
 3880	shaking hellseal disguise	0		
 3881	yellow fireproof fouet de tortue-dressage	0		Hot Resistance: +3, Item Drop: +5, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	ghostly encoded cult documents	0		
 3883	squat cult memo	0		
 3884	mirror decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
-3885	pickled triple-activated yellow twirling vial of slime	0		Effect: "Ham-Fisted", Effect Duration: 18
+3885	pickled triple-activated twirling yellow vial of slime	0		Effect: "Ham-Fisted", Effect Duration: 18
 3886	boiled vial of slime	0		Effect: "Tearful, Fearful", Effect Duration: 60
 3887	non-deionized double-polarized spinning vial of slime	0		Effect: "Rain Dancin'", Effect Duration: 34
 3888	electrified vial of slime	0		Effect: "The Living Hitpoints", Effect Duration: 54
 3889	dry frozen vial of slime	0		Effect: "Graham Crackling", Effect Duration: 32
 3890	tarnished liquefied skewed vial of violet slime	0		Effect: "Greasy Visage", Effect Duration: 26
 3891	pressed squat vial of vermilion slime	0		Effect: "Castaway Physique", Effect Duration: 36
-3892	quadruple-altered skewed green vial of amber slime	0		Effect: "Phoenix, Right?", Effect Duration: 14
+3892	quadruple-altered green skewed vial of amber slime	0		Effect: "Phoenix, Right?", Effect Duration: 14
 3893	super-vacuum-sealed concentrated huge vial of chartreuse slime	0		Effect: "Comic Violence", Effect Duration: 44
 3894	extra-magnetized purple vial of teal slime	0		Effect: "Ichorous Eyesight", Effect Duration: 47
 3895	non-deionized ionized tumbling vial of indigo slime	0		Effect: "Greedy Resolve", Effect Duration: 25
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	weak aged blended swill with a fly in it	2	awesome	
+3913	aged weak blended swill with a fly in it	2	awesome	
 3914	squat turtle wax	0		
 3915	double-paned turtle wax shield	0		Cold Resistance: +5, Damage Reduction: 2
 3916	Da Vinci's turtle wax helmet	0		Experience (Mysticality): +5, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3947,7 +3947,7 @@
 3995	ghostly bundle of chamoix	0		
 3996	red boxcar turtle	0		
 3997	purple dolphin whistle	0		
-3998	squat ghostly metrognome	0		Familiar Weight: +5
+3998	ghostly squat metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	pickled spinning agua de vida	1	good	Last Available: "2009-06"
@@ -3963,7 +3963,7 @@
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	squat memory of a CG base pair	0		Last Available: "2009-06"
 4013	narrow memory of a CT base pair	0		Last Available: "2009-06"
-4014	wobbly narrow memory of an AG base pair	0		Last Available: "2009-06"
+4014	narrow wobbly memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
 4016	bouncing memory of a GT base pair	0		Last Available: "2009-06"
 4017	squirming Slime larva	0		
@@ -3982,7 +3982,7 @@
 4030	memory of a small stone block	0		Last Available: "2009-06"
 4031	narrow memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
-4033	blurry upside-down memory of a stone half-circle	0		Last Available: "2009-06"
+4033	upside-down blurry memory of a stone half-circle	0		Last Available: "2009-06"
 4034	wobbly memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	lime green caustic slime nodule	0		
@@ -3990,30 +3990,30 @@
 4038	acceptable slimy fermented bile bladder	4	good	
 4039	diluted pulsating slimy alveolus	1		
 4040	spinning shaking memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	squat Temple Grandin's pig-iron helm of the boozehound	0		Familiar Weight: +7, Booze Drop: +100, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	pulsating scorching padded pig-iron shinguards	0		Damage Absorption: +20, Hot Damage: +25, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	squat Temple Grandin's pig-iron helm of the boozehound	0		Familiar Weight: +7, Booze Drop: +100, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	pulsating scorching padded pig-iron shinguards	0		Damage Absorption: +20, Hot Damage: +25, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	nippy groovy pig-iron bracers	0		Moxie Percent: +10, Cold Damage: +10, Single Equip, Last Available: "2009-06"
 4044	mirror wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	huge wumpus-hair whip of the empath	0		Familiar Weight: +5, Last Available: "2009-06"
-4048	blurry asbestos-lined horrifying sizzling wumpus-hair wig	0		Hot Damage: +10, Spooky Damage: +25, Hot Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	jittery horrifying hardened stylish wumpus-hair loincloth	0		Moxie: +25, Damage Reduction: 3, Spooky Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	blurry asbestos-lined horrifying sizzling wumpus-hair wig	0		Hot Damage: +10, Spooky Damage: +25, Hot Resistance: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	jittery horrifying hardened stylish wumpus-hair loincloth	0		Moxie: +25, Damage Reduction: 3, Spooky Damage: +25, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	purple auspicious strapping wumpus-hair sweater	0		Muscle: +5, Item Drop: +10, Last Available: "2009-06"
 4051	ring of teleportation of bravery	0		Spooky Resistance: +5, Single Equip
 4052	glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	triple-distilled fancy acceptable White Hyborian	7	good	Effect: "Salamanderenity", Effect Duration: 35, Last Available: "2009-06"
+4054	triple-distilled acceptable fancy White Hyborian	7	good	Effect: "Salamanderenity", Effect Duration: 35, Last Available: "2009-06"
 4055	wholesome goblin hunting spear	0		Maximum HP Percent: +10, Last Available: "2009-06"
 4056	frightening friendly goblin autoblowgun	0		Familiar Weight: +3, Spooky Damage: +5, Last Available: "2009-06"
 4057	tribal beads of extreme caution	0		Monster Level: -25, Last Available: "2009-06"
 4058	nasty stone fist of the cougar	0		Moxie: +20, Stench Damage: +5, Last Available: "2009-06"
 4059	foul-smelling stone head	0		Stench Damage: +10, Damage Reduction: 5, Last Available: "2009-06"
 4060	wobbly upside-down Indigo Party Invitation	0		Last Available: "2009-06"
-4061	blurry ghostly Violet Hunt Invitation	0		Last Available: "2009-06"
+4061	ghostly blurry Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
-4064	fuchsia shaking 'Smuggler Shot First' Button	0		Last Available: "2009-06"
+4064	shaking fuchsia 'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	squat Ruby Rod	0		Last Available: "2009-06"
 4067	huge essence of heat	0		Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	blurry grisly shield of doom	0		Spooky Spell Damage: +50, Item Drop: +5, Slime Hates It: +1, Damage Reduction: 13
 4081	executive corroded breeches of courage	0		Spooky Resistance: +3, Meat Drop: +40, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	knitted pernicious cudgel of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +3, Slime Hates It: +1
-4083	small stale shaking cupcake-in-a-cup	2	decent	Last Available: "2009-06"
+4083	stale small shaking cupcake-in-a-cup	2	decent	Last Available: "2009-06"
 4084	upside-down pool of liquid	0		Last Available: "2009-06"
 4085	snack-sized normal protein paste	2	good	Last Available: "2009-06"
 4086	zippy Newton's cyber-mattock	0		Experience (Mysticality): +3, Initiative: +20, Last Available: "2009-06"
@@ -4095,12 +4095,12 @@
 4143	a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	asbestos-lined funny paper hat	0		Hot Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	double-liquefied spinning gray sand	0		Effect: "Old School Pompadour", Effect Duration: 54
+4146	double-liquefied gray spinning sand	0		Effect: "Old School Pompadour", Effect Duration: 54
 4147	up-at-dawn charged magnet of the bloodbag	0		Maximum HP: +100, Adventures: +5, Last Available: "2009-09"
 4148	upside-down stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	huge quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
-4150	mirror skewed spinning lint	0		Last Available: "2011-12"
-4151	wet huge yellow dubious peppermint	0		Effect: "Human-Goblin Hybrid", Effect Duration: 21, Last Available: "2020-09"
+4150	mirror spinning skewed lint	0		Last Available: "2011-12"
+4151	wet yellow huge dubious peppermint	0		Effect: "Human-Goblin Hybrid", Effect Duration: 21, Last Available: "2020-09"
 4152	deionized tumbling Elvish delight	0		Effect: "Angry like the Wolf", Effect Duration: 66
 4153	rockfish stomach	0		Last Available: "2009-09"
 4154	live lobster	0		Last Available: "2011-12"
@@ -4118,7 +4118,7 @@
 4166	huge red Voluminous Radio Pants of the brute	0		Muscle Percent: +30, Familiar Effect: "2xGhoul, cap 37"
 4167	twirling dangerous Voluminous Radio Hat	0		Weapon Damage: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
 4168	red MacGyver's Voluminous Radio Sneakers	0		Maximum MP: +100, Single Equip
-4169	jittery narrow blurry 4-d camera	0		
+4169	narrow blurry jittery 4-d camera	0		
 4170	huge shaking 4-d camera	0		
 4171	crystallized memory	0		
 4172	lime green quilted rock helmet	0		Damage Absorption: +40, Familiar Effect: "1xGhuol, cap 25"
@@ -4130,9 +4130,9 @@
 4178	sugar shotgun of the empath	0		Familiar Weight: +5, Last Available: "2009-09"
 4179	sage sugar shillelagh	0		Mysticality Percent: +10, Last Available: "2009-09"
 4180	sugar shank of Flo-Jo	0		Initiative: +100, Last Available: "2009-09"
-4181	wool Da Vinci's thinker's sugar chapeau	0		Mysticality: +10, Experience (Mysticality): +5, Cold Resistance: +1, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	smartaleck's sugar shorts	0		Moxie Percent: +30, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
-4183	twirling pulsating blinking sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4181	wool Da Vinci's thinker's sugar chapeau	0		Mysticality: +10, Experience (Mysticality): +5, Cold Resistance: +1, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	smartaleck's sugar shorts	0		Moxie Percent: +30, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4183	pulsating blinking twirling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	upside-down slime convention swag bag	0		
 4185	slime convention flyers	0		
 4186	twirling slime convention coupons	0		
@@ -4178,7 +4178,7 @@
 4226	olive Star of Bravery of the empath	0		Familiar Weight: +5, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	upside-down ice skate doll	0		
@@ -4196,11 +4196,11 @@
 4244	huge squat slick leather-bound tome	0		Moxie: +10
 4245	wobbly bookmark	0		
 4246	pulsating ivory cue ball of the empath	0		Familiar Weight: +5
-4247	practically non-alcoholic artisanal skewed maroon decanter of fine Scotch	1	super ultra mega turbo EPIC	
-4248	pickled mirror ghostly expensive cigar	1		
+4247	artisanal practically non-alcoholic skewed maroon decanter of fine Scotch	1	super ultra mega turbo EPIC	
+4248	pickled ghostly mirror expensive cigar	1		
 4249	teal ghostly tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
-4251	squat twirling fish-oil smoke bomb	0		
+4251	twirling squat fish-oil smoke bomb	0		
 4252	quantum vial of squid ink	0		Effect: "Black Eyes", Effect Duration: 19
 4253	triple-unsweetened diffused tarnished potion of speed	0		Effect: "Corruption of Wretched Wally", Effect Duration: 47
 4254	bark	0		Last Available: "2009-10"
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	adequate chocolate-covered scarab beetle	4	good	Last Available: "2009-10"
 4259	bad mulled cider	4	decent	Last Available: "2009-10"
-4260	bouncing wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	bouncing wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	bark boxers of horror	0		Spooky Spell Damage: +25, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	slick bark beret	0		Moxie: +10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	bark boxers of horror	0		Spooky Spell Damage: +25, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	slick bark beret	0		Moxie: +10, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	savvy bark bracelet	0		Mysticality Percent: +20, Single Equip
 4267	gravedigger's Krakrox's Loincloth of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	ruddy sinister Galapagosian Cuisses	0		Spell Damage: +10, Maximum HP Percent: +40, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4279,7 +4279,7 @@
 4327	ribald sinister La Hebilla del Cintur&oacute;n de Lopez of the scaredy-cat	0		Spell Damage: +10, Monster Level: -15, Sleaze Damage: +10, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	ghostly bag of many confections	0		Last Available: "2009-12"
-4330	bite-sized normal candy kneecapping stick	1	good	Last Available: "2009-12"
+4330	normal bite-sized candy kneecapping stick	1	good	Last Available: "2009-12"
 4331	flavorless licorice garrote	3	decent	Last Available: "2009-12"
 4332	zippy candy knuckles	0		Initiative: +20, Last Available: "2009-12"
 4333	decent jittery jawbruiser	3	good	Last Available: "2010-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	huge leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	wobbly flame-wreathed snow pants	0		Hot Spell Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	snow hat of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	wobbly flame-wreathed snow pants	0		Hot Spell Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	experienced snow belly	0		Experience: +2, Single Equip, Last Available: "2009-12"
 4352	lime green pile of loose snow	0		Last Available: "2009-12"
 4353	cyan Crimbough	0		Last Available: "2009-12"
@@ -4316,7 +4316,7 @@
 4364	triple-altered magnetized elven suicide capsule	0		Effect: "Dwarven Hardiness", Effect Duration: 47, Last Available: "2009-12"
 4365	adequate penguin focaccia bread	3	good	Last Available: "2009-12"
 4366	boozy acceptable herringcello	5	good	Last Available: "2009-12"
-4367	lousy spirit-forward blinking elven cellocello	5	decent	Last Available: "2009-12"
+4367	spirit-forward lousy blinking elven cellocello	5	decent	Last Available: "2009-12"
 4368	twirling wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	narrow baleful pocketwatch on a chain of Tarzan	0		Experience (Muscle): +3, Spell Damage: +25, Last Available: "2009-12"
 4386	ghostly coward's sinister cement sandals	0		Spell Damage: +10, Monster Level: -20, Single Equip, Last Available: "2009-12"
 4387	mansplainer's night-vision goggles of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +15, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	wobbly careful peanut brittle shield	0		Monster Level: -10, Damage Reduction: 3, Last Available: "2009-12"
 4390	blurry mansplainer's MacGyver's Red Rover BB gun	0		Maximum MP: +100, Monster Level: +15, Last Available: "2009-12"
 4391	upside-down wobbly flame-retardant red-and-green sweater	0		Hot Resistance: +1, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	mirror shaking cheese ball	0		Last Available: "2010-01"
 4399	smartaleck's cheese sword	0		Moxie Percent: +30, Softcore Only, Last Available: "2010-01"
-4400	cheese diaper of the businessman	0		Meat Drop: +50, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	cheese diaper of the businessman	0		Meat Drop: +50, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	manspreader's cheese wheel	0		Monster Level: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	bouncing upside-down manspreader's cheese eye	0		Monster Level: +10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	Jeselnik's flame-wreathed shellacked Staff of Queso Escusado	0		Damage Reduction: 7, Hot Spell Damage: +10, Sleaze Damage: +25, Softcore Only, Last Available: "2010-01"
@@ -4361,7 +4361,7 @@
 4410	bouncing The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	yummy quantum taco	0		Last Available: "2010-10"
-4413	strong aged jittery Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	aged strong jittery Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	mirror colorful plastic ball	0		Last Available: "2010-01"
 4415	sealhide hood of the empath	0		Familiar Weight: +5, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	wobbly savvy sealhide leggings	0		Mysticality Percent: +20, Familiar Effect: "1xVolley, cap 40"
@@ -4371,7 +4371,7 @@
 4420	sealhide moccasins of wisdom	0		Mysticality: +15, Single Equip
 4421	twirling sealhide gloves of doom	0		Spooky Spell Damage: +50
 4422	blue sage sealhide belt	0		Mysticality Percent: +10
-4423	green huge tumbling sealhide snare	0		
+4423	huge green tumbling sealhide snare	0		
 4424	puzzling trophy	0		
 4425	aerosolized sealhide seal doll	0		Effect: "Burnt 'n' Turnt", Effect Duration: 25
 4426	tumbling hymnal	0		Skill: "Canticle of Carboloading"
@@ -4379,7 +4379,7 @@
 4429	up-at-dawn candy necklace	0		Adventures: +5, Single Equip
 4430	teddybear backpack of the early riser	0		Adventures: +7
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	pickled denatured teal mirror invisibility potion	0		Effect: "Worth Your Salt", Effect Duration: 31, Last Available: "2011-08"
+4432	pickled denatured mirror teal invisibility potion	0		Effect: "Worth Your Salt", Effect Duration: 31, Last Available: "2011-08"
 4433	alkaline tarnished irresistibility potion	0		Effect: "Eye of the Seal", Effect Duration: 21, Last Available: "2011-08"
 4434	ionized modified irritability potion	0		Effect: "Feeling No Pain", Effect Duration: 56, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
@@ -4396,7 +4396,7 @@
 4448	modified Instant Karma	1	EPIC	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 35
 4449	tumbling painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	fireproof pointy hat	0		Hot Resistance: +3, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	fireproof pointy hat	0		Hot Resistance: +3, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	huge sizzling machetito	0		Hot Damage: +10, Last Available: "2010-04"
 4453	blurry Fonzie's lawnmower blade	0		Experience (Moxie): +1, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	frozen triple-corrupted maroon skewed chocolate saucepan	0		Effect: "Comprehensively Nourished", Effect Duration: 20
 4466	anodized aerosolized maroon skewed chocolate disco ball	0		Effect: "Butt-Rock Hair", Effect Duration: 52
 4467	flattened activated cyan chocolate stolen accordion	0		Effect: "Gleaming White Teeth", Effect Duration: 60
-4468	lime green Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	lime green Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	blue BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	huge supercharged BRICKO hat	0		Maximum MP Percent: +30, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	Usain Bolt's BRICKO pants	0		Initiative: +80, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	huge supercharged BRICKO hat	0		Maximum MP Percent: +30, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	Usain Bolt's BRICKO pants	0		Initiative: +80, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	olive BRICKO sword of courage	0		Spooky Resistance: +3, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	cyan BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4454,7 +4454,7 @@
 4506	puzzling ribbon	0		
 4507	cyan Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	unsweetened denatured adjusted &quot;DRINK ME&quot; potion	0		Effect: "Thicker, Sicker", Effect Duration: 14, Last Available: "2010-03"
-4509	ghostly pulsating reflection of a map	0		Last Available: "2010-03"
+4509	pulsating ghostly reflection of a map	0		Last Available: "2010-03"
 4510	rotten huge walrus ice cream	7	crappy	Last Available: "2010-03"
 4511	moldy beautiful soup	3	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	gray narrow manspreader's personal trainer's eye of the Tiger-lily	0		Experience Percent (Muscle): +10, Monster Level: +10, Last Available: "2010-03"
-4524	family-friendly Da Vinci's wig	0		Experience (Mysticality): +5, Sleaze Resistance: +1, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	family-friendly Da Vinci's wig	0		Experience (Mysticality): +5, Sleaze Resistance: +1, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	normal donut	4	good	Last Available: "2010-03"
-4526	moldy small cyan spinning bucket of honey	2	crappy	Last Available: "2010-03"
+4526	moldy small spinning cyan bucket of honey	2	crappy	Last Available: "2010-03"
 4527	gray spinning elephant stinger of the sewer of mayonnaise	0		Stench Damage: +25, Sleaze Spell Damage: +50, Last Available: "2010-03"
 4528	miniature normal dragon snaps	2	good	Last Available: "2010-03"
 4529	reassuring resourceful snapdragon pistil	0		Maximum MP: +50, Spooky Resistance: +1, Last Available: "2010-03"
 4530	upside-down puff of smoke	0		Last Available: "2010-03"
 4531	normal rook cookie	4	good	Last Available: "2010-03"
-4532	flavorless half-sized bishop cookie	2	decent	Last Available: "2010-03"
+4532	half-sized flavorless bishop cookie	2	decent	Last Available: "2010-03"
 4533	bland knight cookie	4	decent	Last Available: "2010-03"
 4534	snack-sized spoiled king cookie	2	crappy	Last Available: "2010-03"
 4535	rotten queen cookie	4	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	flame-retardant insane tophat	0		Hot Resistance: +1, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	wool helm of the knight of wisdom	0		Mysticality: +15, Cold Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	flame-retardant insane tophat	0		Hot Resistance: +1, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	wool helm of the knight of wisdom	0		Mysticality: +15, Cold Resistance: +1, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	huge toasty baleful wristwatch of the knight	0		Spell Damage: +25, Hot Damage: +5, Single Equip, Last Available: "2010-03"
-4540	double-paned smelly trousers of the knight	0		Stench Spell Damage: +10, Cold Resistance: +5, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	double-paned smelly trousers of the knight	0		Stench Spell Damage: +10, Cold Resistance: +5, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	tophat of the cougar	0		Moxie: +20, Familiar Effect: "1xBarrr, cap 25"
 4542	wobbly Rosewater's tie	0		Mysticality Percent: +30, Single Equip
 4543	squat greedy tuxedo pants	0		Meat Drop: +20, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4510,23 +4510,23 @@
 4562	shaking hair of the calf	0		Last Available: "2010-04"
 4563	drinkable world's most unappetizing beverage	4	good	Last Available: "2010-04"
 4564	scorching slippery when wet shield	0		Hot Damage: +25, Damage Reduction: 6, Last Available: "2010-04"
-4565	delicious half-sized raisin	2	awesome	Last Available: "2010-04"
+4565	half-sized delicious raisin	2	awesome	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	fireproof banded flyest of shirts	0		Damage Absorption: +100, Hot Resistance: +3, Last Available: "2010-04"
-4568	decent immense bouncing a dance upon the palate	7	good	Last Available: "2010-04"
-4569	adequate enchanted blurry prehistoric meteorite jawbreaker	4	good	Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2010-04"
+4568	immense decent bouncing a dance upon the palate	7	good	Last Available: "2010-04"
+4569	enchanted adequate blurry prehistoric meteorite jawbreaker	4	good	Effect: "Rushin' Hands", Effect Duration: 40, Last Available: "2010-04"
 4570	twirling Crazyleg's razor	0		Last Available: "2010-04"
 4571	special adequate spinning squirmy violent party snack	3	good	Effect: "Sagittarius Rising", Effect Duration: 15, Last Available: "2010-04"
 4572	steel-toed can-you-dig-it?	0		Damage Reduction: 9, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	denatured triple-modified Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Magically Fingered", Effect Duration: 54, Last Available: "2010-04"
 4580	careful school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Monster Level: -10, Last Available: "2010-04"
-4581	up-at-dawn ruddy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Maximum HP Percent: +40, Adventures: +5, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	up-at-dawn ruddy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Maximum HP Percent: +40, Adventures: +5, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	spoiled six wedges of goat cheese	3	crappy	
@@ -4552,7 +4552,7 @@
 4604	keg	0		Last Available: "2010-06"
 4605	bottle of Goldschn&ouml;ckered of the wise owl of the overflowing toilet	0		Mysticality: +20, Stench Spell Damage: +50, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	moldy snack-sized sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	delicious strong pulsating soyburger juice	5	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	strong delicious pulsating soyburger juice	5	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	tumbling twirling respected companion biscuit	0		Last Available: "2010-08"
 4609	ghostly essential tofu	0		Last Available: "2010-08"
 4610	non-oxidized essential soy	0		Effect: "Weird Flavor", Effect Duration: 63, Last Available: "2010-08"
@@ -4569,7 +4569,7 @@
 4621	cyan Game Grid token	0		Last Available: "2010-06"
 4622	purple ghostly Game Grid ticket	0		Last Available: "2010-06"
 4623	corrupted dry teal chocolate-covered caviar	0		Effect: "Turkey-Ambitious", Effect Duration: 51, Last Available: "2020-09"
-4624	bland tiny pawn cookie	1	decent	Last Available: "2010-06"
+4624	tiny bland pawn cookie	1	decent	Last Available: "2010-06"
 4625	modified olive coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	cyan superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
@@ -4577,12 +4577,12 @@
 4629	plastic spider ring of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	Annie Oakley's plastic kazoo	0		Critical Hit Percent: +20, Last Available: "2010-06"
 4631	fuchsia flame-retardant inflatable baseball bat	0		Hot Resistance: +1, Last Available: "2010-06"
-4632	wobbly scandalous smelly googly-star hat	0		Stench Spell Damage: +10, Sleaze Damage: +5, Familiar Effect: "atk", Last Available: "2010-06"
+4632	wobbly scandalous smelly googly-star hat	0		Stench Spell Damage: +10, Sleaze Damage: +5, Last Available: "2010-06", Familiar Effect: "atk"
 4633	up-at-dawn perfumed googly-ball hat	0		Stench Resistance: +5, Adventures: +5, Last Available: "2010-06"
 4634	red tumbling stylish googly-heart hat of the empath	0		Moxie: +25, Familiar Weight: +5, Last Available: "2010-06"
 4635	purple lard-coated experienced super-sweet boom box	0		Experience: +2, Sleaze Spell Damage: +25, Four Songs, Last Available: "2010-06"
 4636	mirror Game Grid valued membership card	0		Last Available: "2010-06"
-4637	lard-coated horrifying resourceful sinister demon mask	0		Maximum MP: +50, Spooky Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	lard-coated horrifying resourceful sinister demon mask	0		Maximum MP: +50, Spooky Damage: +25, Sleaze Spell Damage: +25, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	purple smelly frosty streetfighting champion's belt of the brazier	0		Cold Spell Damage: +10, Hot Spell Damage: +25, Stench Spell Damage: +10, Single Equip, Last Available: "2010-06"
 4639	miser's Jeselnik's Space Trip safety headphones of terror	0		Spooky Spell Damage: +10, Sleaze Damage: +25, Meat Drop: +10, Single Equip, Last Available: "2010-06"
 4640	ghostly razor-sharp LARP carp	0		Weapon Damage Percent: +25
@@ -4594,8 +4594,8 @@
 4646	Jack Frost's savvy cool Meteoid ice beam	0		Moxie: +5, Mysticality Percent: +20, Cold Spell Damage: +50, Last Available: "2011-12"
 4647	Jim Carey's MacGyver's baleful Dungeon Fist gauntlet	0		Spell Damage: +25, Maximum MP: +100, Monster Level: +25, Last Available: "2011-06"
 4648	olive Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	wobbly chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	red fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	wobbly chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	red fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	aromatic supercool ironic knit cap	0		Moxie Percent: +20, Stench Resistance: +1, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	purple ironic sunglasses	0		Single Equip
@@ -4615,11 +4615,11 @@
 4667	twirling aromatic Victor, the Insult Comic Hellhound Puppet	0		Stench Resistance: +1
 4668	spinning fuchsia occult observational glasses	0		Spell Damage Percent: +25
 4669	padded hilarious comedy prop	0		Damage Absorption: +20
-4670	olive blinking upside-down beer-scented teddy bear	0		
+4670	olive upside-down blinking beer-scented teddy bear	0		
 4671	delicious booze-soaked cherry	4	awesome	
-4672	skewed cyan comfy pillow	0		
-4673	bland snack-sized marshmallow	2	decent	
-4674	rotten snack-sized sponge cake	2	crappy	
+4672	cyan skewed comfy pillow	0		
+4673	snack-sized bland marshmallow	2	decent	
+4674	snack-sized rotten sponge cake	2	crappy	
 4675	drinkable gin-soaked blotter paper	3	good	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	inspector's pottery shield	0		Item Drop: +15, Damage Reduction: 3, Last Available: "2010-09"
-4682	asbestos-lined Herculean pottery hat	0		Experience (Muscle): +1, Hot Resistance: +5, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	upside-down chilly quilted pottery training pants	0		Damage Absorption: +40, Cold Damage: +5, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	asbestos-lined Herculean pottery hat	0		Experience (Muscle): +1, Hot Resistance: +5, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	upside-down chilly quilted pottery training pants	0		Damage Absorption: +40, Cold Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	rock-hard pottery club	0		Damage Reduction: 5, Last Available: "2010-09"
 4685	sage pottery yo-yo	0		Mysticality Percent: +10, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	up-at-dawn personal trainer's Greatest American Pants of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Adventures: +5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	up-at-dawn personal trainer's Greatest American Pants of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Adventures: +5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	mansplainer's fossilized necklace	0		Monster Level: +15, Last Available: "2010-09"
 4698	shaking spinning imp air	0		
 4699	pulsating bus pass	0		
@@ -4649,7 +4649,7 @@
 4701	waterlogged crate	0		Last Available: "2011-12"
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	blurry ghostly dance instructor's red-hot medallion	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2010-09"
-4704	blurry teal fossilized demon skull	0		Last Available: "2010-09"
+4704	teal blurry fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	gray E-Z Cook&trade; oven	0		
@@ -4658,19 +4658,19 @@
 4710	red immense ballet shoes	0		Familiar Weight: +5
 4711	narrow sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
-4713	tumbling squat popsicle stick	0		
+4713	squat tumbling popsicle stick	0		
 4714	spoiled spinning lemon popsicle	3	crappy	
 4715	delicious popsicle	3	awesome	
-4716	immense bland wobbly strawberry popsicle	8	decent	
-4717	immense yummy twirling liver popsicle	9	awesome	
+4716	bland immense wobbly strawberry popsicle	8	decent	
+4717	yummy immense twirling liver popsicle	9	awesome	
 4718	blinking spinning crafty mariachi hat	0		Maximum MP: +10, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	twirling organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	jumbo stale liver and let pie	5	decent	Last Available: "2010-10"
+4722	stale jumbo liver and let pie	5	decent	Last Available: "2010-10"
 4723	normal badass pie	3	good	Last Available: "2010-10"
 4724	adequate miniature shoo-fish pie	2	good	Last Available: "2010-10"
-4725	miniature stale tumbling piping organ pie	2	decent	Last Available: "2010-10"
+4725	stale miniature tumbling piping organ pie	2	decent	Last Available: "2010-10"
 4726	tasty blue igloo pie	4	awesome	Last Available: "2010-10"
 4727	spoiled thick stomach turnover	5	crappy	Last Available: "2010-10"
 4728	flavorless thick dead lights pie	5	decent	Last Available: "2010-10"
@@ -4685,25 +4685,25 @@
 4737	censurious beer-soaked mop	0		Sleaze Resistance: +3
 4738	tolerable day-old beer	4	good	
 4739	triple-distilled lousy plain beer	8	decent	
-4740	acceptable blinking maroon overpriced &quot;imported&quot; beer	3	good	
+4740	acceptable maroon blinking overpriced &quot;imported&quot; beer	3	good	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	pickled activated yellow PlexiPips	0		Effect: "Fishy Fortification", Effect Duration: 64
 4745	dry huge Wax Flask	0		Effect: "Barbecue Saucy", Effect Duration: 32
 4746	double-chilled concentrated blurry Pain Dip	0		Effect: "Mystically Oiled", Effect Duration: 11
-4747	miniature adequate bone meal	2	good	Last Available: "2010-10"
+4747	adequate miniature bone meal	2	good	Last Available: "2010-10"
 4748	mediocre watered-down bone aperitif	2	decent	Last Available: "2010-10"
 4749	narrow clever bonerang	0		Maximum MP: +20, Last Available: "2010-10"
 4750	smelly bone and arrows	0		Stench Spell Damage: +10, Last Available: "2010-10"
 4751	therapeutic boning knife	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-10"
 4752	wobbly twirling fireproof bone crusher	0		Hot Resistance: +3, Last Available: "2010-10"
 4753	jittery bone spurs of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2010-10"
-4754	sizzling dangerous bonedanna	0		Weapon Damage: +10, Hot Damage: +10, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	green knitted foul-smelling boneana hammock	0		Stench Damage: +10, Cold Resistance: +3, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	sizzling dangerous bonedanna	0		Weapon Damage: +10, Hot Damage: +10, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	green knitted foul-smelling boneana hammock	0		Stench Damage: +10, Cold Resistance: +3, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	green bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
-4758	double-energized jittery red candy skeleton	0		Effect: "Demonic Flavor", Effect Duration: 58, Last Available: "2020-09"
+4758	double-energized red jittery candy skeleton	0		Effect: "Demonic Flavor", Effect Duration: 58, Last Available: "2020-09"
 4759	narrow Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	squat packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
@@ -4746,14 +4746,14 @@
 4837	tumbling robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	spinning robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	spoiled triangular CRIMBCOOKIE	4	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	small normal square CRIMBCOOKIE	2	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	normal small square CRIMBCOOKIE	2	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	censurious personal trainer's Sinatra's bindlestocking	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Sleaze Resistance: +3, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	Uncle Hobo's stocking cap of the glutton	0		Item Drop: +5, Food Drop: +100, Familiar Effect: "atk", Last Available: "2010-12"
+4845	Uncle Hobo's stocking cap of the glutton	0		Item Drop: +5, Food Drop: +100, Last Available: "2010-12", Familiar Effect: "atk"
 4846	blinking razor-sharp sage Uncle Hobo's epic beard	0		Mysticality Percent: +10, Weapon Damage Percent: +25, Single Equip, Last Available: "2010-12"
-4847	groovy Uncle Hobo's gift baggy pants of the wise owl	0		Mysticality: +20, Moxie Percent: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	groovy Uncle Hobo's gift baggy pants of the wise owl	0		Mysticality: +20, Moxie Percent: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	pulsating careful Uncle Hobo's fingerless tinsel gloves of mayonnaise	0		Monster Level: -10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2010-12"
 4849	ghostly grievous wizardly Uncle Hobo's highest bough	0		Mysticality: +25, Weapon Damage Percent: +50, Last Available: "2010-12"
 4850	squat inspector's wool Uncle Hobo's belt	0		Cold Resistance: +1, Item Drop: +15, Single Equip, Last Available: "2010-12"
@@ -4770,16 +4770,16 @@
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	shaking CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
-4864	narrow tumbling photocopier	0		Last Available: "2011-01"
+4864	tumbling narrow photocopier	0		Last Available: "2011-01"
 4865	blue deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	up-at-dawn occult paperclip-on tie of vim and vigor	0		Spell Damage Percent: +25, Maximum HP Percent: +50, Adventures: +5, Single Equip, Last Available: "2011-01"
-4869	greedy savvy paperclip pants	0		Mysticality Percent: +20, Meat Drop: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	scandalous groovy paperclip turban of the detective	0		Moxie Percent: +10, Sleaze Damage: +5, Item Drop: +20, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	greedy savvy paperclip pants	0		Mysticality Percent: +20, Meat Drop: +20, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	scandalous groovy paperclip turban of the detective	0		Moxie Percent: +10, Sleaze Damage: +5, Item Drop: +20, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	skewed Annie Oakley's paperclip cape	0		Critical Hit Percent: +20, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
-4873	spinning jittery photocopied monster	0		Last Available: "2011-01"
+4873	jittery spinning photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	dry chocolate bath ball	0		Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2011-01"
@@ -4788,9 +4788,9 @@
 4879	super-modified improved denatured olive myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Gingerbread Robust", Effect Duration: 21, Last Available: "2011-01"
 4880	ghostly CRIMBCO mug	0		Last Available: "2011-01"
 4881	acceptable CRIMBCO wine	4	good	Last Available: "2011-01"
-4882	tumbling gray Dickory Farms Gift Basket	0		Last Available: "2011-01"
-4883	huge ghostly toe jam	0		Last Available: "2011-01"
-4884	spoiled gigantic toe jam toast	7	crappy	Last Available: "2011-01"
+4882	gray tumbling Dickory Farms Gift Basket	0		Last Available: "2011-01"
+4883	ghostly huge toe jam	0		Last Available: "2011-01"
+4884	gigantic spoiled toe jam toast	7	crappy	Last Available: "2011-01"
 4885	purple traffic jam	0		Last Available: "2011-01"
 4886	stale traffic jam toast	3	decent	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	mirror BGE shotglass	0		Last Available: "2010-12"
 4894	yummy festive sausage	3	awesome	Last Available: "2011-01"
-4895	adequate snack-sized holiday cheese log	2	good	Last Available: "2011-01"
+4895	snack-sized adequate holiday cheese log	2	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	jittery aromatic therapeutic BGE 'ferocious fruit' shirt	0		Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-12"
 4898	asbestos-lined BGE 'cuddly critter' shirt of the brute	0		Muscle Percent: +30, Hot Resistance: +5, Last Available: "2010-12"
@@ -4852,14 +4852,14 @@
 4949	diffused unsweetened moist weremoose spit	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 32
 4950	galvanized abominable blubber	0		Effect: "Salty Mouth", Effect Duration: 56
 4951	flimsy clipboard of the storm	0		Maximum MP Percent: +40, Damage Reduction: 3
-4952	denatured pickled wobbly fuchsia baggie of sugar	0		Effect: "Improved Candy Vision", Effect Duration: 54
+4952	denatured pickled fuchsia wobbly baggie of sugar	0		Effect: "Improved Candy Vision", Effect Duration: 54
 4953	upside-down shellacked Newton's whalebone corset	0		Experience (Mysticality): +3, Damage Reduction: 7, Single Equip
 4954	maroon spinning executive oven mitts	0		Meat Drop: +40, Single Equip
 4955	thick flavorless overcookie	5	decent	
 4956	stale squat philosopher's scone	3	decent	
 4957	colloidal skewed squat half-baked potion	0		Effect: "Wistfully Nostalgic", Effect Duration: 61
 4958	shaking arcane researcher's Knob Goblin deluxe scimitar	0		Experience Percent (Mysticality): +10
-4959	bite-sized normal bouncing Knob nuts	1	good	
+4959	normal bite-sized bouncing Knob nuts	1	good	
 4960	aged jittery Cobb's Knob Wurstbrau	4	awesome	
 4961	mirror Subject 37 file	0		
 4962	spinning steel-toed Sinatra's mysterious lapel pin	0		Experience (Moxie): +5, Damage Reduction: 9, Single Equip
@@ -4893,11 +4893,11 @@
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	jittery tumbling Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	blurry Alice's Army Foil Wallman	0		Last Available: "2011-03"
-4993	wobbly bouncing Alice's Army Foil Ninja	0		Last Available: "2011-03"
+4993	bouncing wobbly Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
 4995	blinking Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
-4997	gray ghostly Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
+4997	ghostly gray Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	spinning Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	Alice's Army Foil Bowman	0		Last Available: "2011-03"
@@ -4914,7 +4914,7 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	small bland wasabi pocky	2	decent	Last Available: "2011-03"
-5014	adequate massive tobiko pocky	9	good	Last Available: "2011-03"
+5014	massive adequate tobiko pocky	9	good	Last Available: "2011-03"
 5015	adequate fancy upside-down natto pocky	4	good	Effect: "Swimming Head", Effect Duration: 35, Last Available: "2011-03"
 5016	acceptable wasabi-infused sake	4	good	Last Available: "2011-03"
 5017	spirit-forward delicious tobiko-infused sake	5	awesome	Last Available: "2011-03"
@@ -4924,7 +4924,7 @@
 5021	irradiated twirling natto marble soda	0		Effect: "Covetous Robbery", Effect Duration: 56, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	anodized anodized super-oxidized elderly jawbreaker	0		Effect: "Space Cowboy", Effect Duration: 37, Last Available: "2020-09"
-5024	mediocre high-proof twirling marshmallow flamb&eacute;	8	decent	Last Available: "2011-03"
+5024	high-proof mediocre twirling marshmallow flamb&eacute;	8	decent	Last Available: "2011-03"
 5025	special mediocre cranberry schnapps	3	decent	Effect: "Inebriate Pride", Effect Duration: 10, Last Available: "2011-03"
 5026	drinkable breaded beer	3	good	Last Available: "2011-03"
 5027	tolerable soy cordial	3	good	Last Available: "2011-03"
@@ -4949,9 +4949,9 @@
 5046	astral six-pack	0		
 5047	gray Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	perfumed forbidden occult double-ice cap	0		Spell Damage Percent: 75, Stench Resistance: +5, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	perfumed forbidden occult double-ice cap	0		Spell Damage Percent: 75, Stench Resistance: +5, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	mirror wobbly dance instructor's personal trainer's double-ice box of the cheetah	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Initiative: +60, Last Available: "2011-04"
-5051	squat scandalous manspreader's personal trainer's double-ice britches	0		Experience Percent (Muscle): +10, Monster Level: +10, Sleaze Damage: +5, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	squat scandalous manspreader's personal trainer's double-ice britches	0		Experience Percent (Muscle): +10, Monster Level: +10, Sleaze Damage: +5, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	upside-down handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4963,28 +4963,28 @@
 5060	bouncing skewed mysterious present	0		Last Available: "2011-04"
 5061	boxing-glove-in-a-box	0		Last Available: "2011-04"
 5062	narrow green voodoo doll	0		Last Available: "2011-04"
-5063	lime green shaking spinning tumbling the finger	0		Last Available: "2011-04"
+5063	tumbling spinning lime green shaking the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
 5065	tiny normal spaghetti con calaveras	1	good	Last Available: "2011-04"
 5066	ghostly s'more gun	0		Last Available: "2011-04"
-5067	massive adequate popcorn	8	good	Last Available: "2011-04"
-5068	half-sized special rotten chaos popcorn	2	crappy	Last Available: "2011-04"
+5067	adequate massive popcorn	8	good	Last Available: "2011-04"
+5068	rotten half-sized special chaos popcorn	2	crappy	Last Available: "2011-04"
 5069	chilly razor-sharp experienced hole	0		Experience: +2, Weapon Damage Percent: +25, Cold Damage: +5, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	flavorless spinning s'more	0	decent	Last Available: "2011-04"
-5072	skewed blurry diamond ring	0		Last Available: "2011-04"
+5072	blurry skewed diamond ring	0		Last Available: "2011-04"
 5073	practically non-alcoholic mediocre Russian Ice	1	decent	Last Available: "2011-04"
 5074	clay ashtray of the empath	0		Familiar Weight: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	skewed fortified lanyard	0		Damage Absorption: +60, Single Equip, Last Available: "2011-05"
-5076	Jeselnik's monster pants	0		Sleaze Damage: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	Jeselnik's monster pants	0		Sleaze Damage: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	jittery box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	quantum polarized pulsating Pok&euml;mann band-aid	0		Effect: "Stinky Weapon", Effect Duration: 30, Last Available: "2011-05"
-5079	executive quilted Van der Graaf helmet	0		Damage Absorption: +40, Meat Drop: +40, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	executive quilted Van der Graaf helmet	0		Damage Absorption: +40, Meat Drop: +40, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	narrow narrow hale crutch	0		Maximum HP: +20, Last Available: "2011-05"
 5081	Samson's shock belt	0		Experience (Muscle): +5, Single Equip, Last Available: "2011-05"
 5082	alkaline tarnished pressed Okee-Dokee soda	0		Effect: "Ghost Finger", Effect Duration: 63, Last Available: "2011-05"
 5083	narrow baleful rubber band gun	0		Spell Damage: +25, Last Available: "2011-05"
-5084	sharpshooter's pin-stripe slacks	0		Critical Hit Percent: +10, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	sharpshooter's pin-stripe slacks	0		Critical Hit Percent: +10, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	squat rock-hard gloves	0		Damage Reduction: 5, Single Equip, Last Available: "2011-05"
 5086	irradiated flattened correction fluid	0		Effect: "damage.enh", Effect Duration: 11, Last Available: "2011-05"
 5087	rosewater-soaked Pok&euml;mann figurine: Porkachu	0		Stench Resistance: +3, Single Equip, Last Available: "2011-05"
@@ -5007,7 +5007,7 @@
 5104	vacuum-sealed irradiated extra-polarized maroon fish juice box	0		Effect: "Gummiskin", Effect Duration: 67, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	shaking hideous egg	0		Last Available: "2011-05"
-5107	artisanal practically non-alcoholic Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
+5107	practically non-alcoholic artisanal Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	Tesla stress ball	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5015,14 +5015,14 @@
 5112	mirror blurry My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
-5115	skewed narrow hedge trimmers	0		
+5115	narrow skewed hedge trimmers	0		
 5116	narrow lime green A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	ghostly reconstituted crow	0		Last Available: "2011-05"
 5118	red bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	Jeselnik's thinker's Admiral's hat of extreme caution	0		Mysticality: +10, Monster Level: -25, Sleaze Damage: +25, Familiar Effect: "atk", Last Available: "2011-05"
-5122	flame-wreathed mansplainer's brawny aviator's cap	0		Muscle Percent: +20, Monster Level: +15, Hot Spell Damage: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	Jeselnik's thinker's Admiral's hat of extreme caution	0		Mysticality: +10, Monster Level: -25, Sleaze Damage: +25, Last Available: "2011-05", Familiar Effect: "atk"
+5122	flame-wreathed mansplainer's brawny aviator's cap	0		Muscle Percent: +20, Monster Level: +15, Hot Spell Damage: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	skewed sharpshooter's resourceful mirrored aviator shades	0		Maximum MP: +50, Critical Hit Percent: +10, Single Equip, Last Available: "2011-05"
 5124	jittery Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	teal ribald honey dipper of the pedagogue of the storm	0		Experience: +3, Maximum MP Percent: +40, Sleaze Damage: +10
 5149	scandalous sizzling Socratic honeybritches	0		Experience (Mysticality): +1, Hot Damage: +10, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	gravedigger's Temple Grandin's honeycap of the early riser	0		Familiar Weight: +7, Spooky Damage: +10, Adventures: +7, Familiar Effect: "1xPotato, cap 43"
-5151	Jim Carey's Moonthril Circlet	0		Monster Level: +25, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	censurious Moonthril Greaves	0		Sleaze Resistance: +3, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	Jim Carey's Moonthril Circlet	0		Monster Level: +25, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	censurious Moonthril Greaves	0		Sleaze Resistance: +3, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	rosy-cheeked Moonthril Flamberge	0		Maximum HP Percent: +30, Last Available: "2011-06"
 5154	Moonthril Longbow of Tarzan	0		Experience (Muscle): +3, Last Available: "2011-06"
 5155	quilted Moonthril Cuirass	0		Damage Absorption: +40, Softcore Only, Last Available: "2011-06"
@@ -5074,11 +5074,11 @@
 5171	wobbly Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	jittery Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	jittery yellow elven magi-pack	0		Last Available: "2011-06"
-5174	acceptable practically non-alcoholic spinning spinning Saison du Lune	1	good	Last Available: "2011-06"
+5174	practically non-alcoholic acceptable spinning spinning Saison du Lune	1	good	Last Available: "2011-06"
 5175	watered-down tolerable Moonthril Schnapps	2	good	Last Available: "2011-06"
 5176	aged weak mirror Wrecked Generator	2	awesome	Last Available: "2011-06"
-5177	normal enchanted Spaghetti with Moonballs	3	good	Effect: "Ooh, Bitter!", Effect Duration: 25, Last Available: "2011-06"
-5178	small bland Crepes a la Lune	2	decent	Last Available: "2011-06"
+5177	enchanted normal Spaghetti with Moonballs	3	good	Effect: "Ooh, Bitter!", Effect Duration: 25, Last Available: "2011-06"
+5178	bland small Crepes a la Lune	2	decent	Last Available: "2011-06"
 5179	snack-sized stale ghostly Moon Pie	2	decent	Last Available: "2011-06"
 5180	frozen bouncing Comet Pop	0		Effect: "Mushroom Moxiousness", Effect Duration: 33, Last Available: "2011-06"
 5181	ionized non-adjusted Flan in the Moon	0		Effect: "Feroci Tea", Effect Duration: 43, Last Available: "2011-06"
@@ -5108,12 +5108,12 @@
 5205	modified orc paste	1	EPIC	Effect: "Fancy Feasted", Effect Duration: 30, Last Available: "2011-08"
 5206	powdered demonic paste	1	decent	Last Available: "2011-08"
 5207	dehydrated red indescribably horrible paste	1	decent	Effect: "Surreally Buff", Effect Duration: 30, Last Available: "2011-08"
-5208	distilled blinking bouncing paste	1	decent	Last Available: "2011-08"
-5209	dried pulsating ghostly goblin paste	1	decent	Last Available: "2011-08"
+5208	distilled bouncing blinking paste	1	decent	Last Available: "2011-08"
+5209	dried ghostly pulsating goblin paste	1	decent	Last Available: "2011-08"
 5210	modified pirate paste	1	awesome	Last Available: "2011-08"
 5211	powdered chlorophyll paste	1	decent	Effect: "In the Saucestream", Effect Duration: 50, Last Available: "2011-08"
 5212	twisted twirling paste	1	crappy	Last Available: "2011-08"
-5213	dried teal shaking mirror Mer-kin paste	1	decent	Last Available: "2011-08"
+5213	dried shaking mirror teal Mer-kin paste	1	decent	Last Available: "2011-08"
 5214	compressed blinking blue slimy paste	1	good	Last Available: "2011-08"
 5215	dried penguin paste	1	EPIC	Effect: "Grape Expectations", Effect Duration: 20, Last Available: "2011-08"
 5216	powdered mirror elemental paste	1	EPIC	Effect: "Sauce Monocle", Effect Duration: 5, Last Available: "2011-08"
@@ -5123,12 +5123,12 @@
 5220	Teachings of the Fist	0		
 5221	wobbly fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	fancy spoiled spinning Ur-Donut	4	crappy	Effect: "Gamer Rage", Effect Duration: 20, Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	perfectly mixed bucket of wine	4	EPIC	Last Available: "2011-09"
-5228	decent super-sized bouncing ultrafondue	5	good	Last Available: "2011-09"
+5228	super-sized decent bouncing ultrafondue	5	good	Last Available: "2011-09"
 5229	mirror unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5139,19 +5139,19 @@
 5236	frosty halo of the wise owl	0		Mysticality: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of the blizzard	0		Cold Spell Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	acceptable practically non-alcoholic Lumineux Limnio	1	good	Last Available: "2011-09"
-5239	aged fancy spinning Morto Moreto	4	awesome	Effect: "Dreadful Chill", Effect Duration: 10, Last Available: "2011-09"
-5240	triple-distilled tolerable Temps Tempranillo	8	good	Last Available: "2011-09"
+5239	fancy aged spinning Morto Moreto	4	awesome	Effect: "Dreadful Chill", Effect Duration: 10, Last Available: "2011-09"
+5240	tolerable triple-distilled Temps Tempranillo	8	good	Last Available: "2011-09"
 5241	watered-down aged bouncing Bordeaux Marteaux	2	awesome	Last Available: "2011-09"
 5242	artisanal Fromage Pinotage	4	EPIC	Last Available: "2011-09"
 5243	mediocre weak twirling Beignet Milgranet	2	decent	Last Available: "2011-09"
 5244	irresponsibly strong tolerable squat ghostly Muschat	10	good	Last Available: "2011-09"
 5245	toothsome cool jelly donut	3	awesome	Last Available: "2011-09"
 5246	stale shrapnel jelly donut	3	decent	Last Available: "2011-09"
-5247	low-calorie spoiled occult jelly donut	1	crappy	Last Available: "2011-09"
+5247	spoiled low-calorie occult jelly donut	1	crappy	Last Available: "2011-09"
 5248	spoiled thyme jelly donut	3	crappy	Last Available: "2011-09"
 5249	adequate thick danish	5	good	Last Available: "2011-09"
 5250	delicious smashed danish	4	awesome	Last Available: "2011-09"
-5251	bland fuchsia squat forbidden danish	3	decent	Last Available: "2011-09"
+5251	bland squat fuchsia forbidden danish	3	decent	Last Available: "2011-09"
 5252	diet spoiled cool cat claw	1	crappy	Last Available: "2011-09"
 5253	miniature tasty blunt cat claw	2	awesome	Last Available: "2011-09"
 5254	spoiled blinking shadowy cat claw	4	crappy	Last Available: "2011-09"
@@ -5159,18 +5159,18 @@
 5256	adequate toasted brie	3	good	Last Available: "2011-09"
 5257	altered potion of the field gar	0		Effect: "Al Dente Inferno", Effect Duration: 11, Last Available: "2011-09"
 5258	polymerized too legit potion	0		Effect: "Healthy Bronze Glow", Effect Duration: 65, Last Available: "2011-09"
-5259	polymerized tumbling blinking blue Bright Water	0		Effect: "Itchy Trigger Finger", Effect Duration: 47, Last Available: "2011-09"
+5259	polymerized blinking blue tumbling Bright Water	0		Effect: "Itchy Trigger Finger", Effect Duration: 47, Last Available: "2011-09"
 5260	magnetized cold-filtered water	0		Effect: "Liquid Luck", Effect Duration: 48, Last Available: "2011-09"
 5261	Vulcanized pressed graveyard snowglobe	0		Effect: "Powder Power", Effect Duration: 31, Last Available: "2011-09"
 5262	frozen warmed blue cool cat elixir	0		Effect: "Memento Moir&eacute;", Effect Duration: 49, Last Available: "2011-09"
 5263	chilled potion of the captain's hammer	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 17, Last Available: "2011-09"
 5264	cold-filtered aerosolized potion of X-ray vision	0		Effect: "Frog In Your Throat", Effect Duration: 19, Last Available: "2011-09"
-5265	diffused non-wet blinking bouncing potion of the litterbox	0		Effect: "Feeling No Pain", Effect Duration: 11, Last Available: "2011-09"
+5265	diffused non-wet bouncing blinking potion of the litterbox	0		Effect: "Feeling No Pain", Effect Duration: 11, Last Available: "2011-09"
 5266	deionized moist potion of animal rage	0		Effect: "Tea-hee", Effect Duration: 28, Last Available: "2011-09"
 5267	non-dry potion of punctual companionship	0		Effect: "Spooky Blur", Effect Duration: 52, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	twirling bobcat grenade	0		Last Available: "2011-09"
-5270	pulsating cyan huge chocolate frosted sugar bomb	0		Last Available: "2011-09"
+5270	cyan pulsating huge chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
@@ -5184,10 +5184,10 @@
 5281	broken clock of terror	0		Spooky Spell Damage: +10, Last Available: "2011-09"
 5282	Annie Oakley's dethklok	0		Critical Hit Percent: +20, Last Available: "2011-09"
 5283	shaking glacial clock of the wise owl	0		Mysticality: +20, Last Available: "2011-09"
-5284	mirror Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	mirror Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	spinning d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
-5287	upside-down maroon d8	0		Last Available: "2011-09"
+5287	maroon upside-down d8	0		Last Available: "2011-09"
 5288	d10	0		Last Available: "2011-09"
 5289	d12	0		Last Available: "2011-09"
 5290	blurry d20	0		Last Available: "2011-09"
@@ -5210,7 +5210,7 @@
 5307	Haunted Sorority House staff guide	0		Last Available: "2011-10"
 5308	ghost trap	0		Last Available: "2011-10"
 5309	squat chainsaw chain	0		Last Available: "2011-10"
-5310	spinning maroon shotgun shell	0		Last Available: "2011-10"
+5310	maroon spinning shotgun shell	0		Last Available: "2011-10"
 5311	mirror funhouse mirror	0		Last Available: "2011-10"
 5312	adjusted extra-ionized teal ghostly body paint	0		Effect: "Took Eleven", Effect Duration: 47, Last Available: "2011-10"
 5313	deionized skewed necrotizing body spray	0		Effect: "Mayeaugh", Effect Duration: 64, Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	corrupted drum of pomade	0		Effect: "Hangdog", Effect Duration: 55, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	padded extra-see-thru nightie	0		Damage Absorption: +20, Last Available: "2011-10"
-5333	foul-smelling fortified BRAINS shorts	0		Damage Absorption: +60, Stench Damage: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	foul-smelling fortified BRAINS shorts	0		Damage Absorption: +60, Stench Damage: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	mirror steel-toed Mesmereyes&trade; contact lenses	0		Damage Reduction: 9, Single Equip, Last Available: "2011-10"
 5335	ghostly scrunchie of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2011-10"
-5336	censurious sinister extremely skinny jeans	0		Spell Damage: +10, Sleaze Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	tumbling toasty Jim Carey's The Necbromancer's Hat	0		Monster Level: +25, Hot Damage: +5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	censurious sinister extremely skinny jeans	0		Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	tumbling toasty Jim Carey's The Necbromancer's Hat	0		Monster Level: +25, Hot Damage: +5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	jittery stanky Fonzie's The Necbromancer's Stein of the sweet-tooth	0		Experience (Moxie): +1, Stench Spell Damage: +25, Candy Drop: +100, Last Available: "2011-10"
-5339	lightning-fast nippy The Necbromancer's Shorts of the boozehound	0		Cold Damage: +10, Booze Drop: +100, Initiative: +40, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	lightning-fast nippy The Necbromancer's Shorts of the boozehound	0		Cold Damage: +10, Booze Drop: +100, Initiative: +40, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	jittery knitted hardened The Necbromancer's Wizard Staff of vim and vigor	0		Damage Reduction: 3, Maximum HP Percent: +50, Cold Resistance: +3, Last Available: "2011-10"
 5341	twirling twirling The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	artisanal enchanted The Cooler Out of Space	3	EPIC	Effect: "Appeteyes", Effect Duration: 5, Last Available: "2011-10"
@@ -5257,7 +5257,7 @@
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	narrow Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
-5357	blue narrow blinking Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
+5357	narrow blinking blue Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	jittery Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
@@ -5306,7 +5306,7 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	cyan Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	squat rosewater-soaked greasy cane-mail shirt of the cougar	0		Moxie: +20, Sleaze Spell Damage: +10, Stench Resistance: +3, Last Available: "2011-12"
-5406	greedy scorching cane-mail pants of horror	0		Hot Damage: +25, Spooky Spell Damage: +25, Meat Drop: +20, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	greedy scorching cane-mail pants of horror	0		Hot Damage: +25, Spooky Spell Damage: +25, Meat Drop: +20, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	delicious Vodka Matryoshka	3	awesome	Last Available: "2011-12"
 5408	perfectly mixed Gin Mint	3	EPIC	Last Available: "2011-12"
 5409	acceptable Tequiz Navidad	3	good	Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	kumquartz ring of the ox	0		Muscle: +20, Single Equip, Last Available: "2011-11"
 5425	fireproof strawberyl necklace	0		Hot Resistance: +3, Single Equip, Last Available: "2011-11"
 5426	mirror flame-wreathed sucker bucket of the early riser	0		Hot Spell Damage: +10, Adventures: +7, Last Available: "2011-11"
-5427	blinking skewed personal trainer's sucker hakama	0		Experience Percent (Muscle): +10, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	weightlifter's sucker kabuto	0		Muscle: +15, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	blinking skewed personal trainer's sucker hakama	0		Experience Percent (Muscle): +10, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	weightlifter's sucker kabuto	0		Muscle: +15, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	quilted sucker tachi	0		Damage Absorption: +40, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	shaking cinnamon troll doll	0		Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	shaking superheated fudge	0		Last Available: "2011-11"
 5438	extra-galvanized alkaline electrified olive fluid of fudge-finding	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 27, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	flavorless half-sized enchanted fuchsia fudgesicle	2	decent	Effect: "Destructive Resolve", Effect Duration: 15, Last Available: "2011-11"
+5440	enchanted flavorless half-sized fuchsia fudgesicle	2	decent	Effect: "Destructive Resolve", Effect Duration: 15, Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5363,7 +5363,7 @@
 5460	jittery lime green chilly slick fudgecycle of the sewer	0		Moxie: +10, Cold Damage: +5, Stench Damage: +25, Single Equip, Last Available: "2011-11"
 5461	tumbling fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	ghostly Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	ghostly Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	pickled cold-filtered frozen resolution: be wealthier	0		Effect: "Wintergreen Warmongery", Effect Duration: 45, Last Available: "2012-01"
 5465	oxidized anodized resolution: be happier	0		Effect: "Full of Vinegar", Effect Duration: 16, Last Available: "2012-01"
 5466	denatured wobbly upside-down resolution: be stronger	0		Effect: "Strange Mental Acuity", Effect Duration: 27, Last Available: "2012-01"
@@ -5377,14 +5377,14 @@
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	chilled blurry bouncing gummi salamander	0		Effect: "Ginger Snapped", Effect Duration: 53, Last Available: "2011-11"
-5477	super-improved wet denatured bouncing ghostly gummi snake	0		Effect: "Hypercubed", Effect Duration: 51, Last Available: "2011-11"
+5477	super-improved wet denatured ghostly bouncing gummi snake	0		Effect: "Hypercubed", Effect Duration: 51, Last Available: "2011-11"
 5478	Vulcanized anodized squat gummi canary	0		Effect: "Abyssal Sweat", Effect Duration: 34, Last Available: "2011-11"
 5479	flavorless gummi bear	3	decent	Last Available: "2011-11"
 5480	adequate upside-down gummi bear	3	good	Last Available: "2011-11"
 5481	bland cyan gummi bear	4	decent	Last Available: "2011-11"
 5482	delicious bouncing drunki-bear	3	awesome	Last Available: "2011-11"
 5483	huge spoiled drunki-bear	10	crappy	Last Available: "2011-11"
-5484	super-sized moldy drunki-bear	5	crappy	Last Available: "2011-11"
+5484	moldy super-sized drunki-bear	5	crappy	Last Available: "2011-11"
 5485	frightening gummi bowtie	0		Spooky Damage: +5, Last Available: "2011-11"
 5486	pulsating fudge pocket square of the bloodbag	0		Maximum HP: +100, Last Available: "2011-11"
 5487	huge lollipop cufflinks of the scaredy-cat	0		Monster Level: -15, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	aerosolized unsweetened gray gummi belemnite	0		Effect: "Spooky Flavor", Effect Duration: 67, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	mirror perfumed Big Candy's tophat of dire peril	0		Weapon Damage: +20, Stench Resistance: +5, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	mirror perfumed Big Candy's tophat of dire peril	0		Weapon Damage: +20, Stench Resistance: +5, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	green Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	skewed blessed box	0		
 5505	tumbling pack of pogs	0		Last Available: "2011-11"
 5506	stale teal jerky coins	4	decent	Last Available: "2011-11"
-5507	bad enchanted distilled Go-Wassail	5	decent	Effect: "Pill Power", Effect Duration: 45, Last Available: "2011-11"
+5507	bad distilled enchanted Go-Wassail	5	decent	Effect: "Pill Power", Effect Duration: 45, Last Available: "2011-11"
 5508	cold-filtered double-liquefied Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Inebriate Pride", Effect Duration: 49, Last Available: "2011-11"
 5509	unsweetened quadruple-frozen polarized bottle of bubbles	0		Effect: "Patent Avarice", Effect Duration: 20, Last Available: "2011-11"
 5510	dry flattened wind-up meatcar	0		Effect: "Gingerbread Robust", Effect Duration: 46, Last Available: "2011-11"
@@ -5421,7 +5421,7 @@
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
-5521	blue pulsating pog #07 (orcish frat boy)	0		Last Available: "2011-11"
+5521	pulsating blue pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	pog #08 (hellion)	0		Last Available: "2011-11"
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
@@ -5445,13 +5445,13 @@
 5542	jittery pink-belly slapper	0		Last Available: "2012-12"
 5543	censurious personal trainer's Leapin' Trousers	0		Experience Percent (Muscle): +10, Sleaze Resistance: +3
 5544	drinkable bouncing eggnog	3	good	Last Available: "2012-12"
-5545	adequate thick wobbly huge hamhock	5	good	Last Available: "2012-12"
+5545	thick adequate huge wobbly hamhock	5	good	Last Available: "2012-12"
 5546	wobbly The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	narrow Clancy's sackbut	0		Last Available: "2012-12"
 5548	blue Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
 5549	bouncing Clancy's crumhorn	0		Last Available: "2012-12"
-5550	narrow green blinking The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
-5551	squat tumbling green Clancy's lute	0		Last Available: "2012-12"
+5550	blinking narrow green The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
+5551	green squat tumbling Clancy's lute	0		Last Available: "2012-12"
 5552	wholesome Trusty	0		Maximum HP Percent: +10
 5553	can of Rain-Doh	0		Last Available: "2012-02"
 5554	empty Rain-Doh can	0		Last Available: "2012-02"
@@ -5459,7 +5459,7 @@
 5556	Newton's Rain-Doh wings of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +3, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	blurry Lo Pan's brawny Rain-Doh laser gun	0		Muscle Percent: +20, Spell Critical Percent: +30, Softcore Only, Last Available: "2012-02"
-5559	educational brainy Rain-Doh lantern	0		Mysticality: +5, Experience: +1, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	educational brainy Rain-Doh lantern	0		Mysticality: +5, Experience: +1, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	mirror auspicious Rain-Doh violet bo of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Softcore Only, Last Available: "2012-02"
@@ -5473,18 +5473,18 @@
 5570	jittery loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	blurry Thwaitgold stag beetle statuette	0		
-5573	aged fancy spirit-forward Drac & Tan	5	awesome	Effect: "Pop-eyed", Effect Duration: 5, Last Available: "2012-03"
+5573	spirit-forward aged fancy Drac & Tan	5	awesome	Effect: "Pop-eyed", Effect Duration: 5, Last Available: "2012-03"
 5574	lousy strong tumbling Transylvania Sling	5	decent	Last Available: "2012-03"
 5575	lousy practically non-alcoholic Shot of the Living Dead	1	decent	Last Available: "2012-03"
 5576	tolerable Buttery Knob	3	good	Last Available: "2012-03"
-5577	weak bad Slippery Knob	2	decent	Last Available: "2012-03"
+5577	bad weak Slippery Knob	2	decent	Last Available: "2012-03"
 5578	weak hand-crafted Flaming Knob	2	EPIC	Last Available: "2012-03"
-5579	extra-dry bad green Grasshopper	5	decent	Last Available: "2012-03"
-5580	irresponsibly strong aged Locust	6	awesome	Last Available: "2012-03"
+5579	bad extra-dry green Grasshopper	5	decent	Last Available: "2012-03"
+5580	aged irresponsibly strong Locust	6	awesome	Last Available: "2012-03"
 5581	acceptable Plague of Locusts	3	good	Last Available: "2012-03"
 5582	boozy aged pulsating Red Dwarf	5	awesome	Last Available: "2012-03"
 5583	enchanted mediocre Golden Mean	4	decent	Effect: "Hot Blooded", Effect Duration: 30, Last Available: "2012-03"
-5584	fortified perfectly mixed Green Giant	5	EPIC	Last Available: "2012-03"
+5584	perfectly mixed fortified Green Giant	5	EPIC	Last Available: "2012-03"
 5585	artisanal Aye Aye	3	EPIC	Last Available: "2012-03"
 5586	drinkable shaking Aye Aye, Captain	3	good	Last Available: "2012-03"
 5587	high-proof perfectly mixed Aye Aye, Tooth Tooth	6	EPIC	Last Available: "2012-03"
@@ -5492,24 +5492,24 @@
 5589	drinkable weak More Humanitini than Humanitini	2	good	Last Available: "2012-03"
 5590	drinkable Oh, the Humanitini	3	good	Last Available: "2012-03"
 5591	hand-crafted Great Older Fashioned	3	EPIC	Last Available: "2012-03"
-5592	hand-crafted spirit-forward Fuzzy Tentacle	5	EPIC	Last Available: "2012-03"
-5593	smooth spinning lime green Crazymaker	4	awesome	Last Available: "2012-03"
+5592	spirit-forward hand-crafted Fuzzy Tentacle	5	EPIC	Last Available: "2012-03"
+5593	smooth lime green spinning Crazymaker	4	awesome	Last Available: "2012-03"
 5594	perfectly mixed Zoodriver	4	EPIC	Last Available: "2012-03"
 5595	artisanal watered-down blinking Sloe Comfortable Zoo	2	EPIC	Last Available: "2012-03"
 5596	weak tolerable jittery Sloe Comfortable Zoo on Fire	2	good	Last Available: "2012-03"
-5597	boozy perfectly mixed Suffering Sinner	5	EPIC	Last Available: "2012-03"
+5597	perfectly mixed boozy Suffering Sinner	5	EPIC	Last Available: "2012-03"
 5598	drinkable upside-down Suppurating Sinner	3	good	Last Available: "2012-03"
 5599	tolerable Sizzling Sinner	3	good	Last Available: "2012-03"
 5600	perfectly mixed bouncing Firewater	3	EPIC	Last Available: "2012-03"
 5601	hand-crafted practically non-alcoholic Earth and Firewater	1	EPIC	Last Available: "2012-03"
-5602	boozy artisanal Earth, Wind and Firewater	5	EPIC	Last Available: "2012-03"
-5603	mediocre spirit-forward Slimosa	5	decent	Last Available: "2012-03"
+5602	artisanal boozy Earth, Wind and Firewater	5	EPIC	Last Available: "2012-03"
+5603	spirit-forward mediocre Slimosa	5	decent	Last Available: "2012-03"
 5604	delicious Extra-slimy Slimosa	3	awesome	Last Available: "2012-03"
 5605	acceptable practically non-alcoholic skewed Slimebite	1	good	Last Available: "2012-03"
-5606	fancy triple-distilled acceptable Cement Mixer	9	good	Effect: "Gummi Badass", Effect Duration: 30, Last Available: "2012-03"
+5606	fancy acceptable triple-distilled Cement Mixer	9	good	Effect: "Gummi Badass", Effect Duration: 30, Last Available: "2012-03"
 5607	tolerable lime green Jackhammer	3	good	Last Available: "2012-03"
 5608	bad Dump Truck	3	decent	Last Available: "2012-03"
-5609	spirit-forward aged Fauna Libre	5	awesome	Last Available: "2012-03"
+5609	aged spirit-forward Fauna Libre	5	awesome	Last Available: "2012-03"
 5610	smooth Chakra Libre	3	awesome	Last Available: "2012-03"
 5611	hand-crafted boozy huge Aura Libre	5	EPIC	Last Available: "2012-03"
 5612	bad Sazerorc	3	decent	Last Available: "2012-03"
@@ -5517,16 +5517,16 @@
 5614	acceptable Flaming Sazerorc	4	good	Last Available: "2012-03"
 5615	aged Green Velvet	4	awesome	Last Available: "2012-03"
 5616	bad blue Green Muslin	3	decent	Last Available: "2012-03"
-5617	strong mediocre Green Burlap	5	decent	Last Available: "2012-03"
+5617	mediocre strong Green Burlap	5	decent	Last Available: "2012-03"
 5618	artisanal squat Mohobo	3	EPIC	Last Available: "2012-03"
 5619	delicious Moonshine Mohobo	4	awesome	Last Available: "2012-03"
-5620	perfectly mixed weak Flaming Mohobo	2	EPIC	Last Available: "2012-03"
+5620	weak perfectly mixed Flaming Mohobo	2	EPIC	Last Available: "2012-03"
 5621	lousy Drunken Philosopher	4	decent	Last Available: "2012-03"
-5622	watered-down mediocre skewed jittery Drunken Neurologist	2	decent	Last Available: "2012-03"
+5622	mediocre watered-down jittery skewed Drunken Neurologist	2	decent	Last Available: "2012-03"
 5623	tolerable fuchsia Drunken Astrophysicist	4	good	Last Available: "2012-03"
-5624	bad triple-distilled Dark & Starry	8	decent	Last Available: "2012-03"
+5624	triple-distilled bad Dark & Starry	8	decent	Last Available: "2012-03"
 5625	watered-down drinkable Black Hole	2	good	Last Available: "2012-03"
-5626	drinkable spirit-forward Event Horizon	5	good	Last Available: "2012-03"
+5626	spirit-forward drinkable Event Horizon	5	good	Last Available: "2012-03"
 5627	artisanal Herring Daiquiri	3	EPIC	Last Available: "2012-03"
 5628	watered-down lousy Herring Wallbanger	2	decent	Last Available: "2012-03"
 5629	bad Herringtini	3	decent	Last Available: "2012-03"
@@ -5534,11 +5534,11 @@
 5631	acceptable Candy Alexander	4	good	Last Available: "2012-03"
 5632	hand-crafted Candicaine	3	EPIC	Last Available: "2012-03"
 5633	perfectly mixed fortified spinning lime green Caipiranha	5	EPIC	Last Available: "2012-03"
-5634	acceptable strong Flying Caipiranha	5	good	Last Available: "2012-03"
+5634	strong acceptable Flying Caipiranha	5	good	Last Available: "2012-03"
 5635	acceptable Flaming Caipiranha	4	good	Last Available: "2012-03"
 5636	smooth weak blinking Punchplanter	2	awesome	Last Available: "2012-03"
 5637	lousy high-proof Doublepunchplanter	6	decent	Last Available: "2012-03"
-5638	practically non-alcoholic drinkable Haymaker	1	good	Last Available: "2012-03"
+5638	drinkable practically non-alcoholic Haymaker	1	good	Last Available: "2012-03"
 5639	squat Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	immense flavorless fungus	7	decent	
@@ -5548,14 +5548,14 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	weightlifter's calendar	0		Muscle: +15, Damage Reduction: 4
-5648	Boris's Helm of the brute of the storm	0		Muscle Percent: +30, Maximum MP Percent: +40, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	Boris's Helm of the brute of the storm	0		Muscle Percent: +30, Maximum MP Percent: +40, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	sizzling staph of homophones of the bloodbag	0		Maximum HP: +100, Hot Damage: +10
-5650	Lo Pan's savvy thinker's Boris's Helm (askew)	0		Mysticality: +10, Mysticality Percent: +20, Spell Critical Percent: +30, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	Lo Pan's savvy thinker's Boris's Helm (askew)	0		Mysticality: +10, Mysticality Percent: +20, Spell Critical Percent: +30, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	flavorless nailswurst	4	decent	
-5655	weak smooth used beer	2	awesome	
+5655	smooth weak used beer	2	awesome	
 5656	Huggler Radio	0		Free Pull
 5657	tumbling blinking fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	purple slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5565,7 +5565,7 @@
 5662	tumbling maroon Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	microwave	0		Free Pull
 5664	bouncing pony keg	0		Free Pull
-5665	mirror blinking shaking How to Tolerate Jerks	0		Skill: "Thick-Skinned"
+5665	blinking mirror shaking How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
@@ -5577,9 +5577,9 @@
 5674	&quot;L&quot;	0		
 5675	pickled watered-down Red Minotaur	1		Effect: "Medieval Mage Mayhem", Effect Duration: 45
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	fuchsia wobbly friendly Ze&trade; goggles	0		Familiar Weight: +3, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
-5678	skewed jittery soggy used band-aid	0		Last Available: "2012-05"
-5679	Jeselnik's Rosewater's stylish swimsuit	0		Mysticality Percent: +30, Sleaze Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5677	fuchsia wobbly friendly Ze&trade; goggles	0		Familiar Weight: +3, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5678	jittery skewed soggy used band-aid	0		Last Available: "2012-05"
+5679	Jeselnik's Rosewater's stylish swimsuit	0		Mysticality Percent: +30, Sleaze Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	twirling lost key	0		Last Available: "2012-05"
 5681	bland P.B.L.T.	4	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5601,15 +5601,15 @@
 5698	family-friendly nasty The Lost Glasses	0		Stench Damage: +5, Sleaze Resistance: +1, Single Equip
 5699	jittery The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
-5701	skewed twirling green Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
+5701	twirling skewed green Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	wobbly mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	purple wax bugbear	0		Last Available: "2012-06"
-5705	resourceful occult wax hat	0		Spell Damage Percent: +25, Maximum MP: +50, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	double-paned scorching wax pants	0		Hot Damage: +25, Cold Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	resourceful occult wax hat	0		Spell Damage Percent: +25, Maximum MP: +50, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	double-paned scorching wax pants	0		Hot Damage: +25, Cold Resistance: +5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	bouncing FDKOL commendation	0		Last Available: "2012-07"
 5708	magnetized drop of water-37	0		Effect: "Top Dog", Effect Duration: 48, Last Available: "2012-07"
-5709	bouncing Annie Oakley's beefy fireman's helmet	0		Muscle: +10, Critical Hit Percent: +20, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	bouncing Annie Oakley's beefy fireman's helmet	0		Muscle: +10, Critical Hit Percent: +20, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	wobbly gravedigger's fire axe	0		Spooky Damage: +10, Last Available: "2012-07"
 5713	Jeselnik's curative fire extinguisher of the wise owl	0		Mysticality: +20, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5618,18 +5618,18 @@
 5717	decent FDKOL hotcakes	4	good	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	squat smoking grass	0		Last Available: "2012-07"
-5720	small spoiled fiery wing	2	crappy	Last Available: "2012-07"
+5720	spoiled small fiery wing	2	crappy	Last Available: "2012-07"
 5721	bouncing avaricious inspector's wings of fire	0		Item Drop: +15, Meat Drop: +30, Last Available: "2012-07"
 5722	purple pulsating FDKOL fire hose of the wise owl	0		Mysticality: +20, Last Available: "2012-07"
 5723	vacuum-sealed ionized cyan bottle of fire	0		Effect: "Halloweeny", Effect Duration: 43, Last Available: "2012-07"
 5724	wobbly molten brick	0		Last Available: "2012-07"
-5725	skewed jittery hot daub	0		Last Available: "2012-07"
-5726	blue spinning toasty hot daub bun of the boozehound	0		Hot Damage: +5, Booze Drop: +100, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	ghostly chilly therapeutic hot daub stand	0		Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5725	jittery skewed hot daub	0		Last Available: "2012-07"
+5726	blue spinning toasty hot daub bun of the boozehound	0		Hot Damage: +5, Booze Drop: +100, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	ghostly chilly therapeutic hot daub stand	0		Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	tumbling hardy foot-long hot daub of terror	0		Maximum HP: +50, Spooky Spell Damage: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	bland angst burger	3	decent	
-5731	tolerable fortified enchanted bouncing 5-hour acrimony	5	good	Effect: "PERL of Great Price", Effect Duration: 10
+5731	fortified enchanted tolerable bouncing 5-hour acrimony	5	good	Effect: "PERL of Great Price", Effect Duration: 10
 5732	upside-down blank note	0		
 5733	pulsating eerily silent box	0		
 5734	miniature rotten forbidden sausage	2	crappy	
@@ -5641,7 +5641,7 @@
 5740	adequate bag of GORP	4	good	Last Available: "2012-07"
 5741	drinkable water purification pills	3	good	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	perfectly mixed weak CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
+5743	weak perfectly mixed CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
 5744	spoiled huge bag of GORF	8	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	flavorless bag of QWOP	4	decent	Last Available: "2012-07"
@@ -5651,10 +5651,10 @@
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	massive spoiled crappy brain	7	crappy	
-5753	miniature tasty pulsating decent brain	2	awesome	
-5754	small toothsome good brain	2	awesome	
+5753	tasty miniature pulsating decent brain	2	awesome	
+5754	toothsome small good brain	2	awesome	
 5755	rotten boss brain	4	crappy	
-5756	normal fancy half-sized hunter brain	2	good	Effect: "Permanent Halloween", Effect Duration: 10
+5756	half-sized fancy normal hunter brain	2	good	Effect: "Permanent Halloween", Effect Duration: 10
 5758	squat green gravedigger's thinker's Staff of Holiday Sensations of the early riser	0		Mysticality: +10, Spooky Damage: +10, Adventures: +7, Last Available: "2011-11"
 5759	perfumed staff of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +5
 5760	bouncing blurry educational staff of wisdom of Flo-Jo	0		Mysticality: +15, Experience: +1, Initiative: +100
@@ -5665,11 +5665,11 @@
 5765	medical-grade fuzzy earmuffs of the sweet-tooth	0		Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5766	wobbly teal Tesla Herculean supercool fuzzy montera	0		Moxie Percent: +20, Experience (Muscle): +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5767	upside-down Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	twirling gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	twirling gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5697,11 +5697,11 @@
 5798	warmed narrow Gnollish Crossdress	0		Effect: "Flaming Weapon", Effect Duration: 11
 5799	pickled narrow eldritch dough	0		Effect: "Extra-Sharp Weapon", Effect Duration: 67
 5800	chilled wet Charity's choker	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 56
-5801	quadruple-frozen pulsating lime green shaking Smart Bone Dust	0		Effect: "Irresistible Resolve", Effect Duration: 40
+5801	quadruple-frozen shaking pulsating lime green Smart Bone Dust	0		Effect: "Irresistible Resolve", Effect Duration: 40
 5802	concentrated moist perpendicular guano	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 69
 5803	electrified concentrated squat White Chocolate Golem Seeds	0		Effect: "Thick, Sick", Effect Duration: 50
 5804	electrified Shivering Ch&egrave;vre	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 54
-5805	Vulcanized squat blinking bouncing breath mint	0		Effect: "Slimy Hands", Effect Duration: 38
+5805	Vulcanized blinking squat bouncing breath mint	0		Effect: "Slimy Hands", Effect Duration: 38
 5806	alkaline muesli	0		Effect: "Trivia Master", Effect Duration: 51
 5807	dry glass of warm milk	0		Effect: "Locks Like the Raven", Effect Duration: 16
 5808	unsweetened double-alkaline pulsating glass of gnat milk	0		Effect: "Human-Horror Hybrid", Effect Duration: 43
@@ -5715,7 +5715,7 @@
 5816	oxidized double-corrupted boiled kobold kibble	0		Effect: "Creepypasted", Effect Duration: 14
 5817	ionized corrupted unsweetened forest spirit rattle	0		Effect: "Space Tripping", Effect Duration: 68
 5818	triple-irradiated ionized huge Stone Golem pebbles	0		Effect: "Ermine Eyes", Effect Duration: 39
-5819	pickled pressed gray blinking gravy fairy warlock hat	0		Effect: "The Power of LOV", Effect Duration: 49
+5819	pickled pressed blinking gray gravy fairy warlock hat	0		Effect: "The Power of LOV", Effect Duration: 49
 5820	corrupted deionized bull blubber	0		Effect: "Fiery Spirit", Effect Duration: 64
 5821	boiled pressed extra-Vulcanized frog lip-print	0		Effect: "Ghost Finger", Effect Duration: 60
 5822	polymerized gazely stare	0		Effect: "Purity of Spirit", Effect Duration: 38
@@ -5730,7 +5730,7 @@
 5831	anodized extra-improved unsweetened skewed skewed pygmy dart	0		Effect: "Brocolate Brostidigitation", Effect Duration: 50
 5832	anodized modified secret mummy herbs and spices	0		Effect: "Altered Wavelengths", Effect Duration: 69
 5833	non-polymerized cyan brigand brittle	0		Effect: "Berry Experiential", Effect Duration: 51
-5834	moist quadruple-improved spinning teal twirling holistic headache remedy	0		Effect: "Mortarfied", Effect Duration: 27
+5834	moist quadruple-improved twirling teal spinning holistic headache remedy	0		Effect: "Mortarfied", Effect Duration: 27
 5835	cold-filtered super-vacuum-sealed ghostly scrunchie tourniquet	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 61
 5836	non-oxidized double-dry embezzler's oil	0		Effect: "Thought", Effect Duration: 46
 5837	anodized Fu Manchu Wax	0		Effect: "Sweet Taste", Effect Duration: 25
@@ -5758,7 +5758,7 @@
 5859	moist nitrogenated double-tarnished booby trap	0		Effect: "A Taste of Rainbow", Effect Duration: 19
 5860	unsweetened Agent Corrigan's cigarette	0		Effect: "Spooky Weapon", Effect Duration: 55
 5861	moist non-magnetized good ash	0		Effect: "Frost Tea", Effect Duration: 29
-5862	wobbly Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	wobbly Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	mirror papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	pickled upside-down papier-mochi	0		Effect: "Sourpuss", Effect Duration: 54, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	hale savvy papier-m&acirc;ch&eacute;te	0		Mysticality Percent: +20, Maximum HP: +20, Last Available: "2012-09"
 5869	auspicious papier-m&acirc;chine gun of the detective	0		Item Drop: 30, Last Available: "2012-09"
 5870	shaking stanky smelly papier-masque	0		Stench Spell Damage: 35, Single Equip, Last Available: "2012-09"
-5871	cool papier-mitre of the cougar	0		Moxie: 25, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	teal groovy papier-m&acirc;churidars of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	cool papier-mitre of the cougar	0		Moxie: 25, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	teal groovy papier-m&acirc;churidars of the overflowing toilet	0		Moxie Percent: +10, Stench Spell Damage: +50, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	squat papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	mirror papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5783,12 +5783,12 @@
 5884	ghostly skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	upside-down manspreader's Tesla Sinatra's experienced Bonestabber	0		Experience: +2, Experience (Moxie): +5, Monster Level: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-10"
-5887	fancy mediocre extra-dry crystal skeleton vodka	5	decent	Effect: "Toast Tea", Effect Duration: 15, Last Available: "2012-10"
+5887	extra-dry fancy mediocre crystal skeleton vodka	5	decent	Effect: "Toast Tea", Effect Duration: 15, Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	double-paned auxiliary backbone	0		Cold Resistance: +5, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
-5892	boiled adjusted fuchsia narrow that gum you like	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 15
+5892	boiled adjusted narrow fuchsia that gum you like	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 15
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
@@ -5796,7 +5796,7 @@
 5897	compressed Unconscious Collective Dream Jar	1	good	Effect: "Mathematically Precise", Effect Duration: 30, Last Available: "2013-12"
 5898	upside-down upside-down jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
-5900	tumbling wobbly lime green jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
+5900	lime green wobbly tumbling jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	narrow jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	purple jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	gray jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	ghostly BittyCar MeatCar	0		Last Available: "2012-12"
 5927	upside-down BittyCar HotCar	0		Last Available: "2012-12"
-5928	ghostly sinister brainwave-controlled unicorn horn	0		Spell Damage: +10, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	ghostly sinister brainwave-controlled unicorn horn	0		Spell Damage: +10, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	purple avaricious fireproof plastic four-shadowed mime of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +3, Meat Drop: +30, Single Equip, Last Available: "2012-12"
@@ -5858,8 +5858,8 @@
 5960	padded plastic Father McGruber	0		Damage Absorption: +20, Last Available: "2012-12"
 5961	yellow frightening plastic Hank North, Photojournalist	0		Spooky Damage: +5, Last Available: "2012-12"
 5962	bouncing plastic blazing bat of the cheetah	0		Initiative: +60, Last Available: "2012-12"
-5963	mirror flame-retardant arcane researcher's electronic dulcimer pants	0		Experience Percent (Mysticality): +10, Hot Resistance: +1, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
-5964	skewed olive A-Boo clue	0		
+5963	mirror flame-retardant arcane researcher's electronic dulcimer pants	0		Experience Percent (Mysticality): +10, Hot Resistance: +1, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5964	olive skewed A-Boo clue	0		
 5965	tumbling therapeutic Frown Exerciser of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2012-12"
 5966	wobbly soul monocle	0		Single Equip
 5967	soul doorbell	0		
@@ -5873,21 +5873,21 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	narrow miser's padded silent beret of wisdom	0		Mysticality: +15, Damage Absorption: +20, Meat Drop: +10, Familiar Effect: "1xVolley, cap 3"
-5978	normal jumbo slice of pizza	5	good	Last Available: "2013-02"
+5978	jumbo normal slice of pizza	5	good	Last Available: "2013-02"
 5979	purple huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	fuchsia star	0		Last Available: "2013-02"
 5982	hand-crafted spirit-forward tankard of ale	5	EPIC	Last Available: "2013-02"
 5983	ghostly vial of holy water	0		Last Available: "2013-02"
-5984	mirror tumbling asbestos-lined slick cloth cap of the glutton	0		Moxie: +10, Hot Resistance: +5, Food Drop: +100, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	mirror tumbling asbestos-lined slick cloth cap of the glutton	0		Moxie: +10, Hot Resistance: +5, Food Drop: +100, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	Jeselnik's frosty wizardly iron dagger	0		Mysticality: +25, Cold Spell Damage: +10, Sleaze Damage: +25, Last Available: "2013-02"
 5986	toothsome hamburger	3	awesome	Last Available: "2013-02"
 5987	shaking dollar-sign bag	0		Last Available: "2013-02"
-5988	squat blurry potion	0		Last Available: "2013-02"
+5988	blurry squat potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	delicious watered-down bottle of wine	2	awesome	Last Available: "2013-02"
+5990	watered-down delicious bottle of wine	2	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	squat smelly toasty dog trainer's iron helmet	0		Experience (familiar): +1, Hot Damage: +5, Stench Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	squat smelly toasty dog trainer's iron helmet	0		Experience (familiar): +1, Hot Damage: +5, Stench Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	shaking cyan chaotic thinker's steel sword of the detective	0		Mysticality: +10, Spell Critical Percent: +10, Item Drop: +20, Last Available: "2013-02"
 5994	adequate super-sized fuchsia whole roasted chicken	5	good	Last Available: "2013-02"
 5995	lime green upside-down massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	perfectly mixed shining goblet	4	EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	nasty friendly dangerous crown	0		Weapon Damage: +10, Familiar Weight: +3, Stench Damage: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	nasty friendly dangerous crown	0		Weapon Damage: +10, Familiar Weight: +3, Stench Damage: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	pulsating fuchsia personal trainer's sword of mayonnaise of the sweet-tooth	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +50, Candy Drop: +100, Last Available: "2013-02"
-6002	Oprah's supercharged stylish Helm of the Scream Emperor	0		Moxie: +25, Maximum MP Percent: 80, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	Oprah's supercharged stylish Helm of the Scream Emperor	0		Moxie: +25, Maximum MP Percent: 80, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	aromatic steel-toed studded Cloak of Dire Shadows	0		Damage Absorption: +80, Damage Reduction: 9, Stench Resistance: +1, Last Available: "2013-02"
 6004	cyan steel-toed Newton's Sword of Dark Omens of temperance	0		Experience (Mysticality): +3, Damage Reduction: 9, Sleaze Resistance: +5, Last Available: "2013-02"
 6005	narrow Van der Graaf wicked slick Shield of Icy Fate	0		Moxie: +10, Spell Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 7, Last Available: "2013-02"
-6006	pulsating auspicious steel-toed Socratic Greaves of the Murk Lord	0		Experience (Mysticality): +1, Damage Reduction: 9, Item Drop: +10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	pulsating auspicious steel-toed Socratic Greaves of the Murk Lord	0		Experience (Mysticality): +1, Damage Reduction: 9, Item Drop: +10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	double-paned chilly electrified Gauntlets of the Blood Moon	0		Cold Damage: +5, Cold Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2013-02"
 6008	cyan sizzling sinister brainy Boots of Twilight Whispers	0		Mysticality: +5, Spell Damage: +10, Hot Damage: +10, Single Equip, Last Available: "2013-02"
 6009	tumbling greasy Belt of Howling Anger of the brute of the boozehound	0		Muscle Percent: +30, Sleaze Spell Damage: +10, Booze Drop: +100, Single Equip, Last Available: "2013-02"
@@ -5912,7 +5912,7 @@
 6014	up-at-dawn screwing pooch	0		Adventures: +5
 6015	anodized orcish hand lotion	0		Effect: "Minerva's Zen", Effect Duration: 57
 6016	polarized quantum orcish rubber	0		Effect: "Industrial Strength Starch", Effect Duration: 66
-6017	concentrated boiled aerosolized upside-down blurry orcish nailing lube	0		Effect: "Papowerful", Effect Duration: 50
+6017	concentrated boiled aerosolized blurry upside-down orcish nailing lube	0		Effect: "Papowerful", Effect Duration: 50
 6018	drinkable backwoods screwdriver	3	good	
 6019	upside-down upside-down blue loadstone of chilblains	0		Cold Damage: +25
 6020	Jeselnik's veiny Claybender glasses	0		Maximum HP: +10, Sleaze Damage: +25, Single Equip
@@ -5921,7 +5921,7 @@
 6023	huge vibrating Whoompa Fur Pants of Calamity Jane	0		Maximum MP Percent: +10, Critical Hit Percent: +15, Familiar Effect: "atk, cap 27"
 6024	ghostly avaricious Whatsian Ionic Pliers	0		Meat Drop: +30
 6025	boiled blue Polysniff Perfume	0		Effect: "Super Vision", Effect Duration: 21
-6026	ghostly skewed Duskwalker syringe	0		
+6026	skewed ghostly Duskwalker syringe	0		
 6027	bouncing Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	bouncing T.U.R.D.S. Key	0		
@@ -5931,7 +5931,7 @@
 6033	chilly stolen necklace of the businessman	0		Cold Damage: +5, Meat Drop: +50
 6034	frosty ruddy troll britches	0		Maximum HP Percent: +40, Cold Spell Damage: +10, Familiar Effect: "1.5xPotato, cap 28"
 6035	non-diffused lime green vial of The Glistening	0		Effect: "Sparkling Consciousness", Effect Duration: 25
-6036	mediocre triple-distilled artisanal limoncello	6	decent	
+6036	triple-distilled mediocre artisanal limoncello	6	decent	
 6037	bouncing ginger ale	0		
 6038	toothsome incredible pizza	3	awesome	
 6039	up-at-dawn oil cap of temperance	0		Sleaze Resistance: +5, Adventures: +5, Familiar Effect: "cap 28"
@@ -5948,10 +5948,10 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	decent cyan Taco Dan's Taco Stand Taco	3	good	Last Available: "2012-12"
-6053	triple-distilled lousy Taco Dan's Taco Stand Chimichangarita	7	decent	Last Available: "2012-12"
-6054	liquefied aerosolized shaking teal Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Sweet, Nuts", Effect Duration: 66, Last Available: "2012-12"
+6053	lousy triple-distilled Taco Dan's Taco Stand Chimichangarita	7	decent	Last Available: "2012-12"
+6054	liquefied aerosolized teal shaking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Sweet, Nuts", Effect Duration: 66, Last Available: "2012-12"
 6055	fuchsia psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	Jim Carey's Sinatra's Meatcleaver	0		Experience (Moxie): +5, Monster Level: +25, Last Available: "2013-12"
 6058	wobbly wobbly flame-retardant Crimbo Elf bobble-head	0		Hot Resistance: +1, Last Available: "2012-12"
 6059	purple extremely unsafe Crimbo stogie-scented room odorizer	0		Weapon Damage Percent: +100, Last Available: "2012-12"
@@ -5966,13 +5966,13 @@
 6068	loose blade	0		
 6069	green goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	unsweetened flattened boiled haggis-infused soap	0		Effect: "Morninja", Effect Duration: 59, Last Available: "2012-12"
 6074	triple-polymerized shaking yellow shaking magicberry tablets	0		Effect: "Memories of Puppy Love", Effect Duration: 21, Last Available: "2012-12"
 6075	pickled electrified super-adjusted 37x37x37 puzzle cube	0		Effect: "Slightly Larger Than Usual", Effect Duration: 44, Last Available: "2012-12"
-6076	delicious fancy McLeod's Hard Haggis-Ade	3	awesome	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2012-12"
-6077	toothsome small haggis-wrapped haggis-stuffed haggis	2	awesome	Last Available: "2012-12"
+6076	fancy delicious McLeod's Hard Haggis-Ade	3	awesome	Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2012-12"
+6077	small toothsome haggis-wrapped haggis-stuffed haggis	2	awesome	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	mansplainer's haggis socks	0		Monster Level: +15, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
@@ -6037,16 +6037,16 @@
 6139	sizzling rubber gloves	0		Hot Damage: +10, Last Available: "2013-12"
 6140	blinking Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	rotten purple huge roasted duck	3	crappy	Last Available: "2013-12"
+6142	rotten huge purple roasted duck	3	crappy	Last Available: "2013-12"
 6143	bland dead meat bun	3	decent	Last Available: "2013-12"
 6144	teal healthy cat collar	0		Maximum HP Percent: +20, Single Equip, Last Available: "2013-12"
-6145	stiffened suspicious-looking fedora of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	stiffened suspicious-looking fedora of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	tumbling Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	fuchsia Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	ghostly carrot nose	0		Last Available: "2013-01"
-6152	half-sized decent green skewed carrot cake	2	good	Last Available: "2013-01"
+6152	decent half-sized skewed green carrot cake	2	good	Last Available: "2013-01"
 6153	tolerable carrot claret	3	good	Last Available: "2013-01"
 6154	compressed carrot juice	1	awesome	Last Available: "2013-01"
 6155	skewed pixel power cell	0		Last Available: "2013-12"
@@ -6058,13 +6058,13 @@
 6161	regret hose of terror	0		Spooky Spell Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	upside-down Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	shaking chaotic crafty commodore's hat	0		Maximum MP: +10, Spell Critical Percent: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	aromatic naval trousers	0		Stench Resistance: +1, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	shaking chaotic crafty commodore's hat	0		Maximum MP: +10, Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	aromatic naval trousers	0		Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	double-paned deck cannon of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +5, Last Available: "2013-12"
 6167	energetic ornamental sextant	0		Maximum MP Percent: +20, Last Available: "2013-12"
 6168	zippy auspicious Bloodbath	0		Item Drop: +10, Initiative: +20, Last Available: "2013-12"
 6169	drinkable fancy Hundred Headed IPA	4	good	Effect: "Happy Salamander", Effect Duration: 30, Last Available: "2013-12"
-6170	thick normal shaking chum	5	good	Last Available: "2013-12"
+6170	normal thick shaking chum	5	good	Last Available: "2013-12"
 6171	irradiated squat crude crudit&eacute;s	0		Effect: "Bilious Briskness", Effect Duration: 21
 6172	pressed shaking candy crayons	0		Effect: "Meatwise", Effect Duration: 30, Last Available: "2020-09"
 6173	wobbly asbestos-lined baleful pixel grappling hook	0		Spell Damage: +25, Hot Resistance: +5
@@ -6080,28 +6080,28 @@
 6183	cosmic fruit	0		
 6184	nasty flame-wreathed wizardly Jarlsberg's hat	0		Mysticality: +25, Hot Spell Damage: +10, Stench Damage: +5
 6185	bland consummate hard-boiled egg	3	decent	
-6186	decent small special lime green consummate fried egg	2	good	Effect: "Weird Vibrations", Effect Duration: 30
+6186	decent special small lime green consummate fried egg	2	good	Effect: "Weird Vibrations", Effect Duration: 30
 6187	bland small lime green consummate egg salad	2	decent	
 6188	spoiled ghostly consummate bagel	3	crappy	
-6189	adequate big consummate sliced bread	5	good	
+6189	big adequate consummate sliced bread	5	good	
 6190	decent cyan consummate hot dog bun	4	good	
 6191	tasty consummate brownie	4	awesome	
 6192	decent consummate toast	3	good	
 6193	watered-down drinkable shaking passable stout	2	good	
 6194	bland yellow consummate soup	3	decent	
-6195	half-sized rotten bouncing narrow maroon consummate corn chips	2	crappy	
+6195	rotten half-sized maroon narrow bouncing consummate corn chips	2	crappy	
 6196	moldy consummate salad	4	crappy	
 6197	decent snack-sized consummate salsa	2	good	
 6198	spoiled bouncing consummate sauerkraut	4	crappy	
-6199	bland thick blurry yellow consummate cheese slice	5	decent	
+6199	thick bland yellow blurry consummate cheese slice	5	decent	
 6200	normal big cyan consummate melted cheese	5	good	
-6201	normal low-calorie consummate bacon	1	good	
-6202	flavorless snack-sized consummate meatloaf	2	decent	
+6201	low-calorie normal consummate bacon	1	good	
+6202	snack-sized flavorless consummate meatloaf	2	decent	
 6203	decent consummate steak	4	good	
 6204	massive normal consummate cuts	6	good	
-6205	special spoiled consummate frankfurter	4	crappy	Effect: "Radium Radicality", Effect Duration: 20
+6205	spoiled special consummate frankfurter	4	crappy	Effect: "Radium Radicality", Effect Duration: 20
 6206	yummy consummate french fries	3	awesome	
-6207	decent miniature consummate baked potato	2	good	
+6207	miniature decent consummate baked potato	2	good	
 6208	bad acceptable vodka	3	decent	
 6209	bland tiny consummate ice cream	1	decent	
 6210	decent consummate whipped cream	3	good	
@@ -6112,17 +6112,17 @@
 6215	tolerable practically non-alcoholic ghostly mediocre lager	1	good	
 6216	stale immaculate grilled cheese	3	decent	
 6217	stale immaculate ice cream sandwich	3	decent	
-6218	spoiled small immaculate hot dog	2	crappy	
+6218	small spoiled immaculate hot dog	2	crappy	
 6219	normal immaculate egg salad sandwich	3	good	
 6220	normal small olive perfect sandwich	2	good	
-6221	snack-sized moldy perfect chef salad	2	crappy	
+6221	moldy snack-sized perfect chef salad	2	crappy	
 6222	stale perfect breakfast	3	decent	
 6223	yummy sublime deluxe hot dog	3	awesome	
 6224	adequate small ghostly sublime stew	2	good	
 6225	normal sublime nachos	4	good	
 6226	normal pulsating Ultimate Breakfast Sandwich	3	good	
 6227	stale Loaded Baked Potato	3	decent	
-6228	flavorless fuchsia twirling Omega Sundae	4	decent	
+6228	flavorless twirling fuchsia Omega Sundae	4	decent	
 6229	hand-crafted practically non-alcoholic Das Sauerlager	1	EPIC	
 6230	tolerable Bologna Lambic	3	good	
 6231	fancy mediocre Vodka Dog	4	decent	Effect: "Truly Gritty", Effect Duration: 30
@@ -6160,7 +6160,7 @@
 6264	purple dog trainer's veiny healthy Staff of Fruit Salad	0		Maximum HP Percent: +20, Maximum HP: +10, Experience (familiar): +1, Jiggle: "Deal Some Prismatic Damage"
 6265	zippy scandalous beefy Staff of the Cream of the Cream	0		Muscle: +10, Sleaze Damage: +5, Initiative: +20, Jiggle: "Attune to Monster's Essence"
 6266	red jar of protein powder	0		
-6267	toothsome fancy blue grain of protein powder	4	awesome	Effect: "You Know Who to Call", Effect Duration: 5
+6267	fancy toothsome blue grain of protein powder	4	awesome	Effect: "You Know Who to Call", Effect Duration: 5
 6268	double-tarnished pec oil	0		Effect: "Spooky Jellied", Effect Duration: 33
 6269	energetic gym membership card	0		Maximum MP Percent: +20
 6270	colloidal boiled huge Squat-Thrust Magazine	0		Effect: "Speed of the Internet", Effect Duration: 17
@@ -6169,9 +6169,9 @@
 6273	liquefied spinning O'RLY manual	0		Effect: "Spookypants", Effect Duration: 56
 6274	lousy practically non-alcoholic shaking open sauce	1	decent	
 6275	extremely unsafe turkey leg of dire peril	0		Weapon Damage: +20, Weapon Damage Percent: +100
-6276	fortified fancy mediocre Ye Olde Meade	5	decent	Effect: "Frog In Your Throat", Effect Duration: 50
+6276	fortified mediocre fancy Ye Olde Meade	5	decent	Effect: "Frog In Your Throat", Effect Duration: 50
 6277	ionized ionized bouncing Ye Olde Bawdy Limerick	0		Effect: "Conspiratory Eyes", Effect Duration: 57
-6278	huge upside-down Ye Olde Medieval Insult	0		
+6278	upside-down huge Ye Olde Medieval Insult	0		
 6279	slick pewter claymore	0		Moxie: +10
 6280	bouncing careful artisanal rice peeler	0		Monster Level: -10
 6281	stale heirloom grape tomato	4	decent	
@@ -6253,17 +6253,17 @@
 6357	Mer-kin knucklebone	0		
 6358	squat Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	Mer-kin begsign of the sewer	0		Stench Damage: +25, Meat Drop: +40
-6360	upside-down Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	upside-down Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	cold-filtered blurry pulled taffy	0		Effect: "Tomato Power", Effect Duration: 49, Last Available: "2013-04"
 6362	Vulcanized pulled indigo taffy	0		Effect: "Deadly Flashing Blade", Effect Duration: 33, Last Available: "2013-04"
 6363	non-energized altered pulled taffy	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 20, Last Available: "2013-04"
 6364	colloidal denatured narrow blurry pulled taffy	0		Effect: "Space Cadet", Effect Duration: 37, Last Available: "2013-04"
 6365	nitrogenated nitrogenated colloidal pulled taffy	0		Effect: "Neutered Nostrils", Effect Duration: 68, Last Available: "2013-04"
-6366	triple-dry blue spinning pulled violet taffy	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 64, Last Available: "2013-04"
-6367	super-boiled corrupted pulsating jittery pulled taffy	0		Effect: "Bilious Briskness", Effect Duration: 12, Last Available: "2013-04"
+6366	triple-dry spinning blue pulled violet taffy	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 64, Last Available: "2013-04"
+6367	super-boiled corrupted jittery pulsating pulled taffy	0		Effect: "Bilious Briskness", Effect Duration: 12, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
 6369	gray lump of clay	0		
-6370	fuchsia bouncing twisted piece of wire	0		
+6370	bouncing fuchsia twisted piece of wire	0		
 6371	smooth can of the cheapest beer	3	awesome	
 6372	hand-crafted bottle of fruity &quot;wine&quot;	4	EPIC	
 6373	practically non-alcoholic mediocre single swig of vodka	1	decent	
@@ -6295,7 +6295,7 @@
 6400	huge Mer-kin lunchbox	0		
 6401	concentrated double-Vulcanized bouncing tear	0		Effect: "Strong Grip", Effect Duration: 47
 6402	adjusted ionized jagged tooth	0		Effect: "Sweet Nostalgia", Effect Duration: 17
-6403	chilled blinking shaking lime green grisly shell fragment	0		Effect: "Human-Penguin Hybrid", Effect Duration: 33
+6403	chilled lime green blinking shaking grisly shell fragment	0		Effect: "Human-Penguin Hybrid", Effect Duration: 33
 6404	extra-moist modified cyan violent pastilles	0		Effect: "Super Accuracy", Effect Duration: 65
 6405	moist colloidal worst candy	0		Effect: "Mushroom Samba", Effect Duration: 15
 6406	triple-deionized fuchsia fudge-shaped hole in space-time	0		Effect: "Dances with Tweedles", Effect Duration: 67
@@ -6304,19 +6304,19 @@
 6409	Star Spawn	0		
 6410	bow from beyond the stars	0		Familiar Weight: +5
 6411	KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
-6412	narrow blinking shaking skull	0		No Pull
+6412	blinking narrow shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	bland miniature upside-down jittery flavorless gruel	2	decent	
-6416	moldy snack-sized mana curds	2	crappy	
+6415	bland miniature jittery upside-down flavorless gruel	2	decent	
+6416	snack-sized moldy mana curds	2	crappy	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	activated pickled moth dust	0		Effect: "Gingerbread Robust", Effect Duration: 12
-6420	flattened blinking jittery glob of spoiled mayo	0		Effect: "Cute Vision", Effect Duration: 63
+6420	flattened jittery blinking glob of spoiled mayo	0		Effect: "Cute Vision", Effect Duration: 63
 6421	tonic djinn	0		
-6422	normal special vampire chowder	4	good	Effect: "Retrograde Relaxation", Effect Duration: 30
+6422	special normal vampire chowder	4	good	Effect: "Retrograde Relaxation", Effect Duration: 30
 6423	Tales of Dread	0		Free Pull
-6424	green squat Dreadsylvanian skeleton key	0		
+6424	squat green Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	huge moldy Dreadsylvanian stew	10	crappy	
 6427	hand-crafted Dreadsylvanian	3	EPIC	
@@ -6326,7 +6326,7 @@
 6431	mirror shaking dreadful sweater of bravery	0		Spooky Resistance: +5, Kruegerand Drop: 5
 6432	pulsating dreadful glove of the glutton	0		Food Drop: +100, Kruegerand Drop: 5
 6433	lime green Freddy Kruegerand	0		
-6434	shaking huge Mark of the Bugbear	0		
+6434	huge shaking Mark of the Bugbear	0		
 6435	Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
@@ -6353,7 +6353,7 @@
 6458	prompt smooth HOA zombie eyes of the sewer	0		Moxie: +15, Stench Damage: +25, Adventures: +3, Single Equip
 6459	HOA citation pad	0		
 6460	wobbly wriggling severed nose	0		
-6461	jittery shaking nosy nose ringy ring	0		Familiar Weight: +15
+6461	shaking jittery nosy nose ringy ring	0		Familiar Weight: +15
 6462	teal inspector's scandalous sizzling Mayor Ghost's toupee	0		Hot Damage: +10, Sleaze Damage: +5, Item Drop: +15, Class: "Pastamancer", Familiar Effect: "spooky atk, 1xBarrr"
 6463	green auspicious grievous sage Mayor Ghost's cloak	0		Mysticality Percent: +10, Weapon Damage Percent: +50, Item Drop: +10, Class: "Pastamancer"
 6464	Socratic groovy stylish Mayor Ghost's khakis	0		Moxie: +25, Moxie Percent: +10, Experience (Mysticality): +1, Class: "Pastamancer", Familiar Effect: "1xPotato, HP regen"
@@ -6390,7 +6390,7 @@
 6495	purple nippy Dreadsylvania Auditor's badge	0		Cold Damage: +10, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	skewed purple eau de mort	0		
-6498	mediocre strong bloody kiwitini	5	decent	
+6498	strong mediocre bloody kiwitini	5	decent	
 6499	moon-amber	0		
 6500	blinking polished moon-amber	0		
 6501	friendly Tesla veiny moon-amber necklace	0		Maximum HP: +10, Familiar Weight: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -6421,7 +6421,7 @@
 6526	olive mirror blinking censurious Jack Frost's bag of unfinished business	0		Cold Spell Damage: +50, Sleaze Resistance: +3
 6527	avaricious sage transparent pants	0		Mysticality Percent: +10, Meat Drop: +30, Familiar Effect: "sleaze atk, 1xPotato"
 6528	supercharged hothammer	0		Maximum MP Percent: +30
-6529	strong delicious Thriller Ice	5	awesome	
+6529	delicious strong Thriller Ice	5	awesome	
 6530	grandfather watch of the detective	0		Item Drop: +20, Single Equip
 6531	olive muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	steel-toed extremely unsafe spyglass	0		Weapon Damage Percent: +100, Damage Reduction: 9
@@ -6429,7 +6429,7 @@
 6534	mirror mirror scorching remorseless knife	0		Hot Damage: +25
 6535	blurry intimidating coiffure of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "hot afk, 1xPotato"
 6536	Van der Graaf healthy cod cape	0		Maximum HP Percent: +20, MP Regen Min: 5, MP Regen Max: 7
-6537	bland snack-sized blood sausage	2	decent	
+6537	snack-sized bland blood sausage	2	decent	
 6538	huge avaricious arcane researcher's frying brainpan	0		Experience Percent (Mysticality): +10, Meat Drop: +30
 6539	Newton's ball and chain of the empath	0		Experience (Mysticality): +3, Familiar Weight: +5, Single Equip
 6540	Socratic dry bone	0		Experience (Mysticality): +1
@@ -6438,14 +6438,14 @@
 6543	wool pogo stick of Flo-Jo	0		Cold Resistance: +1, Initiative: +100, Single Equip
 6545	quilted Da Vinci's weedy skirt of terror	0		Experience (Mysticality): +5, Damage Absorption: +40, Spooky Spell Damage: +10, Familiar Effect: "atk, 1xFairy"
 6546	purple stanky pants of the scaredy-cat	0		Monster Level: -15, Stench Spell Damage: +25, Familiar Effect: "atk"
-6547	cyan jittery Thwaitgold Goliath beetle statuette	0		
+6547	jittery cyan Thwaitgold Goliath beetle statuette	0		
 6548	cooling iron helmet	0		
 6549	teal blurry cooling iron breastplate	0		
 6550	wobbly cooling iron greaves	0		
 6551	hot cluster	0		
 6552	cluster	0		
 6553	cluster	0		
-6554	wobbly yellow stench cluster	0		
+6554	yellow wobbly stench cluster	0		
 6555	spinning sleaze cluster	0		
 6556	pressed Vulcanized phial of hotness	0		Effect: "Weepy, Creepy", Effect Duration: 46
 6557	boiled phial of coldness	0		Effect: "El Vibrations", Effect Duration: 15
@@ -6455,14 +6455,14 @@
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	foul-smelling hand of Mr. Cards	0		Stench Damage: +10, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	small moldy Dreadsylvanian hot pocket	2	crappy	
-6565	snack-sized rotten narrow teal bouncing Dreadsylvanian pocket	2	crappy	
+6564	moldy small Dreadsylvanian hot pocket	2	crappy	
+6565	rotten snack-sized teal narrow bouncing Dreadsylvanian pocket	2	crappy	
 6566	spoiled pulsating Dreadsylvanian pocket	3	crappy	
 6567	flavorless Dreadsylvanian stink pocket	3	decent	
 6568	bland Dreadsylvanian sleaze pocket	3	decent	
 6569	bad Dreadsylvanian hot toddy	3	decent	
 6570	delicious blinking Dreadsylvanian cold-fashioned	3	awesome	
-6571	weak enchanted aged fuchsia Dreadsylvanian grimlet	2	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 40
+6571	enchanted weak aged fuchsia Dreadsylvanian grimlet	2	awesome	Effect: "Big Ol' Glass of Rum", Effect Duration: 40
 6572	bad Dreadsylvanian dank and stormy	4	decent	
 6573	perfectly mixed fancy Dreadsylvanian slithery nipple	4	super ultra mega EPIC	Effect: "Broken Bone Nubs", Effect Duration: 5
 6574	hot clusterbomb	0		
@@ -6488,13 +6488,13 @@
 6594	hot Dreadsylvanian cocoa	0		
 6595	compressed epic cluster	1	good	
 6596	clockwork egg	0		
-6597	upside-down purple clockwork birdhouse	0		
+6597	purple upside-down clockwork birdhouse	0		
 6598	clockwork disc	0		
 6599	teal clockwork hand	0		
 6600	clockwork hand	0		
 6601	blurry clockwork numeral I	0		
 6602	clockwork numeral II	0		
-6603	huge pulsating clockwork numeral III	0		
+6603	pulsating huge clockwork numeral III	0		
 6604	bouncing clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	huge clockwork numeral VI	0		
@@ -6506,18 +6506,18 @@
 6612	ghostly clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	ghostly cuckoo clock	0		
-6615	weak hand-crafted skewed Cold One	2	???	
-6616	special adequate small spaghetti breakfast	2	???	Effect: "Bilious Brains", Effect Duration: 40
+6615	hand-crafted weak skewed Cold One	2	???	
+6616	small special adequate spaghetti breakfast	2	???	Effect: "Bilious Brains", Effect Duration: 40
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	purple folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
-6623	shaking ghostly folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
+6623	ghostly shaking folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
-6626	huge narrow folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
+6626	narrow huge folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	weak drinkable stepmom's booze	2	good	
 6653	mirror surgical tape	0		
 6654	savvy band T-shirt	0		Mysticality Percent: +20
-6655	hand-crafted triple-distilled enchanted fountain 'soda'	10	EPIC	Effect: "Broken Bone Nubs", Effect Duration: 5
+6655	hand-crafted enchanted triple-distilled fountain 'soda'	10	EPIC	Effect: "Broken Bone Nubs", Effect Duration: 5
 6656	illegal firecracker	0		
 6657	Sherlock's chilly pickelhaube	0		Cold Damage: +5, Item Drop: +25, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	adjusted vacuum-sealed dry jittery hair oil	0		Effect: "Orc Chops", Effect Duration: 49
@@ -6559,7 +6559,7 @@
 6667	quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	modeling claymore	0		
-6670	cyan squat clay homunculus	0		
+6670	squat cyan clay homunculus	0		
 6671	aerosolized sodium pentasomething	0		Effect: "Scrappy, Shadowy", Effect Duration: 61
 6672	olive grains of salt	0		
 6673	yellowcake bomb	0		
@@ -6586,7 +6586,7 @@
 6694	boring binder clip	0		
 6695	McClusky file (complete)	0		
 6696	bowling ball	0		
-6697	teal squat moss-covered stone sphere	0		
+6697	squat teal moss-covered stone sphere	0		
 6698	dripping stone sphere	0		
 6699	crackling stone sphere	0		
 6700	scorched stone sphere	0		
@@ -6611,9 +6611,9 @@
 6719	executive scorching midriff scrubs	0		Hot Damage: +25, Meat Drop: +40
 6720	quantum tumbling pill cup	0		Effect: "Wet Rub", Effect Duration: 15
 6721	lightning-fast Sherlock's educational water bottle	0		Experience: +1, Item Drop: +25, Initiative: +40, Familiar Effect: "atk, 1xFairy, cap 40"
-6722	deionized oxidized double-galvanized shaking jittery pygmy phone number	0		Effect: "Oh Snap", Effect Duration: 28
+6722	deionized oxidized double-galvanized jittery shaking pygmy phone number	0		Effect: "Oh Snap", Effect Duration: 28
 6723	Boozehounds Anonymous token	0		
-6724	moldy super-sized exotic jungle fruit	5	crappy	
+6724	super-sized moldy exotic jungle fruit	5	crappy	
 6725	blurry Shore Inc. Ship Trip Scrip	0		
 6726	blinking dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6634,7 +6634,7 @@
 6742	bouncing frightening junk band	0		Spooky Damage: +5
 6743	dance instructor's junk trunks	0		Experience Percent (Moxie): +10, Familiar Effect: "cap 15"
 6744	yellow shaking junk-mail shirt of the empath	0		Familiar Weight: +5
-6745	big bland junk food	5	decent	
+6745	bland big junk food	5	decent	
 6746	lousy junk yard	3	decent	
 6747	hale swordzall of the storm	0		Maximum HP: +20, Maximum MP Percent: +40
 6748	rosewater-soaked arm buzzer	0		Stench Resistance: +3, Damage Reduction: 6
@@ -6646,19 +6646,19 @@
 6754	blurry beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	weak special mediocre can of Br&uuml;talbr&auml;u	2	decent	Effect: "Grape Expectations", Effect Duration: 30, Last Available: "2013-09"
+6757	weak mediocre special can of Br&uuml;talbr&auml;u	2	decent	Effect: "Grape Expectations", Effect Duration: 30, Last Available: "2013-09"
 6758	lousy spinning can of Drooling Monk	4	decent	Last Available: "2013-09"
 6759	bad can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
 6760	practically non-alcoholic tolerable ghostly bottle of Old Pugilist	1	good	Last Available: "2013-09"
-6761	drinkable fancy bottle of Professor Beer	3	good	Effect: "Dirge of Dreadfulness", Effect Duration: 20, Last Available: "2013-09"
+6761	fancy drinkable bottle of Professor Beer	3	good	Effect: "Dirge of Dreadfulness", Effect Duration: 20, Last Available: "2013-09"
 6762	lousy bottle of Rapier Witbier	3	decent	Last Available: "2013-09"
 6763	hand-crafted bottle of Race Car Red	3	EPIC	Last Available: "2013-09"
-6764	perfectly mixed fancy bottle of Greedy Dog	3	EPIC	Effect: "Remaining Alive", Effect Duration: 40, Last Available: "2013-09"
+6764	fancy perfectly mixed bottle of Greedy Dog	3	EPIC	Effect: "Remaining Alive", Effect Duration: 40, Last Available: "2013-09"
 6765	bad bottle of Lambada Lambic	4	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	decent	Last Available: "2013-09"
-6769	Samson's tin tam of the cougar of Gandalf	0		Moxie: +20, Experience (Muscle): +5, Spell Critical Percent: +20, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	Samson's tin tam of the cougar of Gandalf	0		Moxie: +20, Experience (Muscle): +5, Spell Critical Percent: +20, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	improved double-wet tin cup	0		Effect: "Dance Interpreter", Effect Duration: 21, Last Available: "2013-09"
 6771	mirror Herculean tin foil of extreme caution of the brazier	0		Experience (Muscle): +1, Monster Level: -25, Hot Spell Damage: +25, Last Available: "2013-09"
 6772	gray shaking nippy Van der Graaf stylish tin drum	0		Moxie: +25, Cold Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-09"
@@ -6714,18 +6714,18 @@
 6825	flame-retardant clever alarm accordion	0		Maximum MP: +20, Hot Resistance: +1, Class: "Accordion Thief", Song Duration: 20
 6826	friendly medical-grade hale All-Hallow's Steve's fright wig	0		Maximum HP: +20, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	chaotic KoL Con X Treasure Map of the sewer	0		Spell Critical Percent: +10, Stench Damage: +25
-6828	tolerable high-proof fancy discocktail	6	good	Effect: "Fiery Spirit", Effect Duration: 5
+6828	tolerable fancy high-proof discocktail	6	good	Effect: "Fiery Spirit", Effect Duration: 5
 6829	careful KoL Con X Bingo Card	0		Monster Level: -10
 6830	wobbly stanky Temporal Tempera Tube	0		Stench Spell Damage: +25
 6831	denatured purple Tallowcreme Halloween Pumpkin	0		Effect: "Feroci Tea", Effect Duration: 23
-6832	huge squat Way More Tears&trade; pepper spray	0		
+6832	squat huge Way More Tears&trade; pepper spray	0		
 6833	activated Milk Studs	0		Effect: "Squid Squint", Effect Duration: 56
 6834	cold-filtered frozen boiled box of Dweebs	0		Effect: "Gutterminded", Effect Duration: 22
 6835	energized bag of W&Ws	0		Effect: "Halloweeny", Effect Duration: 43
 6836	triple-aerosolized PEEZ dispenser	0		Effect: "Mutated", Effect Duration: 40
 6837	non-boiled oxidized Swizzler	0		Effect: "Dreadful Smell", Effect Duration: 18
 6838	double-pickled triple-frozen Bugbearclaw Donut	0		Effect: "Sated and Furious", Effect Duration: 35
-6839	polymerized altered bouncing fuchsia jam	0		Effect: "Armored Innards", Effect Duration: 66
+6839	polymerized altered fuchsia bouncing jam	0		Effect: "Armored Innards", Effect Duration: 66
 6840	improved bouncing Whenchamacallit bar	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 54
 6841	nitrogenated 8-bit banana	0		Effect: "Astral Shell", Effect Duration: 41
 6842	quadruple-aerosolized vial of blood simple syrup	0		Effect: "Weird Flavor", Effect Duration: 28
@@ -6733,7 +6733,7 @@
 6844	frozen adjusted ironic mint	0		Effect: "It Didn't Kill You", Effect Duration: 24
 6845	twirling unused walkie-talkie	0		Free Pull
 6846	walkie-talkie	0		Free Pull
-6847	blinking cyan killing jar	0		
+6847	cyan blinking killing jar	0		
 6848	frightening security flashlight	0		Spooky Damage: +5
 6849	quadruple-oxidized Effermint&trade; tablets	0		Effect: "Stench Jellied", Effect Duration: 28
 6850	Socratic sturdy cane of the scaredy-cat of the brazier	0		Experience (Mysticality): +1, Monster Level: -15, Hot Spell Damage: +25
@@ -6741,19 +6741,19 @@
 6852	pulsating Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	blinking desert sightseeing pamphlet	0		
-6855	bouncing spinning a suspicious address	0		
+6855	spinning bouncing a suspicious address	0		
 6856	Sinatra's Bal-musette accordion	0		Experience (Moxie): +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6857	tumbling avaricious Cajun accordion	0		Meat Drop: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	Temple Grandin's quirky accordion	0		Familiar Weight: +7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	supercool Skipper's accordion of the sweet-tooth	0		Moxie Percent: +20, Candy Drop: +100, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	occult wizardly beefy Pantsgiving of courage	0		Muscle: +10, Mysticality: +25, Spell Damage Percent: +25, Spooky Resistance: +3, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	occult wizardly beefy Pantsgiving of courage	0		Muscle: +10, Mysticality: +25, Spell Damage Percent: +25, Spooky Resistance: +3, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	adequate can of sardines	4	good	Last Available: "2013-11"
 6862	normal huge high-calorie sugar substitute	4	good	Last Available: "2013-11"
 6863	flavorless lime green pat of butter	3	decent	Last Available: "2013-11"
-6864	flavorless super-sized dinner roll	5	decent	Last Available: "2013-11"
+6864	super-sized flavorless dinner roll	5	decent	Last Available: "2013-11"
 6865	delicious mashed potatoes	4	awesome	Last Available: "2013-11"
 6866	moldy whole turkey leg	3	crappy	Last Available: "2013-11"
-6867	huge moldy deviled egg	7	crappy	Last Available: "2013-11"
+6867	moldy huge deviled egg	7	crappy	Last Available: "2013-11"
 6868	ionized blurry finger exerciser	0		Effect: "Ham-Fisted", Effect Duration: 51, Last Available: "2013-11"
 6869	frozen dry dented spoon	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 59, Last Available: "2013-11"
 6870	colloidal cold-filtered Vulcanized spinning love note	0		Effect: "Bananas!", Effect Duration: 17, Last Available: "2013-11"
@@ -6790,10 +6790,10 @@
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	lard-coated rock-hard flask flops	0		Damage Reduction: 5, Sleaze Spell Damage: +25, Single Equip
 6903	galvanized magnetized huge nuts	0		Effect: "Human-Hobo Hybrid", Effect Duration: 41, Last Available: "2013-12"
-6904	colloidal pulsating cyan bolts	0		Effect: "Mutated", Effect Duration: 37, Last Available: "2013-12"
+6904	colloidal cyan pulsating bolts	0		Effect: "Mutated", Effect Duration: 37, Last Available: "2013-12"
 6905	spoiled gingerbread robot	4	crappy	Last Available: "2013-12"
 6906	half-sized moldy petit 4.1	2	crappy	Last Available: "2013-12"
-6907	miniature adequate nut-shaped Crimbo cookie	2	good	Last Available: "2023-06"
+6907	adequate miniature nut-shaped Crimbo cookie	2	good	Last Available: "2023-06"
 6908	squat beefy plastic GORM-8	0		Muscle: +10, Last Available: "2013-12"
 6909	blurry olive groovy plastic warbear	0		Moxie Percent: +10, Last Available: "2013-12"
 6910	twirling shaking plastic Toybot of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2013-12"
@@ -6806,7 +6806,7 @@
 6917	yellow warbear badge	0		Last Available: "2013-12"
 6918	alkaline triple-galvanized electrified warbear wardance potion	0		Effect: "Supafly", Effect Duration: 56, Last Available: "2013-12"
 6919	polymerized flattened mirror warbear bearserker potion	0		Effect: "Smokin'", Effect Duration: 55, Last Available: "2013-12"
-6920	Vulcanized galvanized blinking skewed warbear liquid overcoat	0		Effect: "Bilious Brains", Effect Duration: 58, Last Available: "2013-12"
+6920	Vulcanized galvanized skewed blinking warbear liquid overcoat	0		Effect: "Bilious Brains", Effect Duration: 58, Last Available: "2013-12"
 6921	moldy warbear feasting bread	4	crappy	Last Available: "2013-12"
 6922	decent enchanted skewed warbear warrior bread	4	good	Effect: "Reptilian Fortitude", Effect Duration: 30, Last Available: "2013-12"
 6923	snack-sized fancy yummy warbear thermoregulator bread	2	awesome	Effect: "Omphalotus Omnipresence", Effect Duration: 20, Last Available: "2013-12"
@@ -6814,25 +6814,25 @@
 6925	irresponsibly strong acceptable tumbling warbear bearserker mead	9	good	Last Available: "2013-12"
 6926	lousy warbear blizzard mead	3	decent	Last Available: "2013-12"
 6927	pulsating teal warbear helm fragment	0		Last Available: "2013-12"
-6928	avaricious studded warbear plain fedora of extreme caution	0		Damage Absorption: +80, Monster Level: -25, Meat Drop: +30, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	brainy warbear feathered fedora	0		Mysticality: +5, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	gravedigger's hardy wholesome warbear fedora	0		Maximum HP Percent: +10, Maximum HP: +50, Spooky Damage: +10, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	blue double-paned smelly studded warbear plain helm	0		Damage Absorption: +80, Stench Spell Damage: +10, Cold Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	blinking fireproof warbear spiked helm	0		Hot Resistance: +3, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	spinning scorching steel-toed warbear electro-spiked helm of Calamity Jane	0		Damage Reduction: 9, Critical Hit Percent: +15, Hot Damage: +25, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	huge narrow horrifying lion tamer's warbear plain ushanka of temperance	0		Experience (familiar): +2, Spooky Damage: +25, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	cyan Lo Pan's warbear lined ushanka	0		Spell Critical Percent: +30, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	frightening electrified occult warbear heated ushanka	0		Spell Damage Percent: +25, Spooky Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	avaricious studded warbear plain fedora of extreme caution	0		Damage Absorption: +80, Monster Level: -25, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	brainy warbear feathered fedora	0		Mysticality: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	gravedigger's hardy wholesome warbear fedora	0		Maximum HP Percent: +10, Maximum HP: +50, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	blue double-paned smelly studded warbear plain helm	0		Damage Absorption: +80, Stench Spell Damage: +10, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	blinking fireproof warbear spiked helm	0		Hot Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	spinning scorching steel-toed warbear electro-spiked helm of Calamity Jane	0		Damage Reduction: 9, Critical Hit Percent: +15, Hot Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	huge narrow horrifying lion tamer's warbear plain ushanka of temperance	0		Experience (familiar): +2, Spooky Damage: +25, Sleaze Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	cyan Lo Pan's warbear lined ushanka	0		Spell Critical Percent: +30, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	frightening electrified occult warbear heated ushanka	0		Spell Damage Percent: +25, Spooky Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	maroon warbear trouser fragment	0		Last Available: "2013-12"
-6938	nasty stiffened beefy warbear party pants	0		Muscle: +10, Damage Reduction: 1, Stench Damage: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	mansplainer's warbear ceremonial party pants	0		Monster Level: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	shaking lion tamer's warbear high festival pants of vim and vigor of the storm	0		Maximum HP Percent: +50, Maximum MP Percent: +40, Experience (familiar): +2, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	rock-hard warbear battle greaves of vim and vigor of Leguizamo	0		Damage Reduction: 5, Maximum HP Percent: +50, Monster Level: +20, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	warbear officer greaves of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	censurious frightening warbear bearserker greaves of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Sleaze Resistance: +3, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	twirling vibrating Fonzie's warbear johns of the storm	0		Experience (Moxie): +1, Maximum MP Percent: 50, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	occult warbear fleece-lined johns	0		Spell Damage Percent: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	frightening coward's occult warbear johns	0		Spell Damage Percent: +25, Monster Level: -20, Spooky Damage: +5, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	nasty stiffened beefy warbear party pants	0		Muscle: +10, Damage Reduction: 1, Stench Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	mansplainer's warbear ceremonial party pants	0		Monster Level: +15, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	shaking lion tamer's warbear high festival pants of vim and vigor of the storm	0		Maximum HP Percent: +50, Maximum MP Percent: +40, Experience (familiar): +2, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	rock-hard warbear battle greaves of vim and vigor of Leguizamo	0		Damage Reduction: 5, Maximum HP Percent: +50, Monster Level: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	warbear officer greaves of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	censurious frightening warbear bearserker greaves of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Sleaze Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	twirling vibrating Fonzie's warbear johns of the storm	0		Experience (Moxie): +1, Maximum MP Percent: 50, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	occult warbear fleece-lined johns	0		Spell Damage Percent: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	frightening coward's occult warbear johns	0		Spell Damage Percent: +25, Monster Level: -20, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	sharpshooter's Newton's warbear goggles of the dark arts	0		Experience (Mysticality): +3, Spell Damage Percent: +100, Critical Hit Percent: +10, Single Equip, Last Available: "2013-12"
 6949	twirling warbear snowblindness goggles of the cougar	0		Moxie: +20, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	Temple Grandin's supercool warbear warscarf of mayonnaise	0		Moxie Percent: +20, Familiar Weight: +7, Sleaze Spell Damage: +50, Single Equip, Last Available: "2013-12"
 6957	pulsating warbear requisition box	0		Last Available: "2013-12"
 6958	twirling warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	sizzling warbear foil hat	0		Hot Damage: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	sizzling warbear foil hat	0		Hot Damage: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	ghostly warbear oil pan of the ox of Tarzan	0		Muscle: +20, Experience (Muscle): +3, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	ghostly warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	mirror energetic die-cast Don Crimbo of the scaredy-cat	0		Maximum MP Percent: +20, Monster Level: -15, Last Available: "2013-12"
 7001	Herculean die-cast Uncle Hobo of James Dean	0		Experience (Muscle): +1, Experience (Moxie): +3, Last Available: "2013-12"
 7002	narrow fuchsia friendly brainy die-cast Father Crimbo	0		Mysticality: +5, Familiar Weight: +3, Last Available: "2013-12"
-7003	jittery cyan The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	jittery cyan The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	polarized unsweetened blue Flaskfull of Hollow	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 50, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
-7006	vaporized pulsating red handful of Smithereens	1	decent	Effect: "Cybernetic Muscles", Effect Duration: 50, Last Available: "2013-12"
+7006	vaporized red pulsating handful of Smithereens	1	decent	Effect: "Cybernetic Muscles", Effect Duration: 50, Last Available: "2013-12"
 7007	bland Every Day is Like This Sundae	3	decent	Last Available: "2013-12"
-7008	rotten super-sized Miserable Pie	5	crappy	Last Available: "2013-12"
-7009	toothsome massive This Charming Flan	9	awesome	Last Available: "2013-12"
+7008	super-sized rotten Miserable Pie	5	crappy	Last Available: "2013-12"
+7009	massive toothsome This Charming Flan	9	awesome	Last Available: "2013-12"
 7010	lousy Irish Coffee, English Heart	3	decent	Last Available: "2013-12"
 7011	acceptable Strikes Again Bigmouth	4	good	Last Available: "2013-12"
-7012	drinkable distilled Paint A Vulgar Pitcher	5	good	Last Available: "2013-12"
+7012	distilled drinkable Paint A Vulgar Pitcher	5	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	upside-down Louder Than Bomb	0		Last Available: "2013-12"
 7015	shaking Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	skewed Jim Carey's Sheila Take a Crossbow of vim and vigor of the storm of courage	0		Maximum HP Percent: +50, Maximum MP Percent: +40, Monster Level: +25, Spooky Resistance: +3, Last Available: "2013-12"
 7019	prompt Jeselnik's clever A Light that Never Goes Out of Flo-Jo	0		Maximum MP: +20, Sleaze Damage: +25, Initiative: +100, Adventures: +3, Last Available: "2013-12"
 7020	Usain Bolt's hale dance instructor's Half a Purse of mayonnaise	0		Experience Percent (Moxie): +10, Maximum HP: +20, Sleaze Spell Damage: +50, Initiative: +80, Last Available: "2013-12"
-7021	twirling energetic wholesome experienced Hairpiece On Fire of the early riser	0		Experience: +2, Maximum HP Percent: +10, Maximum MP Percent: +20, Adventures: +7, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	aromatic rock-hard Vicar's Tutu of the empath of the boozehound	0		Damage Reduction: 5, Familiar Weight: +5, Stench Resistance: +1, Booze Drop: +100, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	twirling energetic wholesome experienced Hairpiece On Fire of the early riser	0		Experience: +2, Maximum HP Percent: +10, Maximum MP Percent: +20, Adventures: +7, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	aromatic rock-hard Vicar's Tutu of the empath of the boozehound	0		Damage Reduction: 5, Familiar Weight: +5, Stench Resistance: +1, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	foul-smelling Socratic Hand in Glove of the pedagogue	0		Experience: +3, Experience (Mysticality): +1, Stench Damage: +10, Single Equip, Last Available: "2013-12"
 7024	gravedigger's therapeutic razor-sharp Meat Tenderizer is Murder	0		Weapon Damage Percent: +25, Spooky Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Class: "Seal Clubber", Last Available: "2013-12"
 7025	Annie Oakley's medical-grade beefcake's Ouija Board, Ouija Board	0		Muscle: +25, Critical Hit Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6925,14 +6925,14 @@
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	warbear gyrocopter	0		Last Available: "2013-12"
-7039	warmed jittery tumbling warbear robo-camouflage unit	0		Effect: "Slimily Strong", Effect Duration: 66, Last Available: "2013-12"
+7039	warmed tumbling jittery warbear robo-camouflage unit	0		Effect: "Slimily Strong", Effect Duration: 66, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	teal warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	squat warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
-7043	spinning lime green warbear sequential gaiety distribution system	0		Last Available: "2013-12"
+7043	lime green spinning warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	energized skewed narrow glass slipper	0		Effect: "Berry Experiential", Effect Duration: 52, Last Available: "2014-12"
 7045	compressed antimatter wad	1	crappy	Last Available: "2013-12"
-7046	quantum blurry gray warbear superpotion	0		Effect: "Deadly Lampblade", Effect Duration: 15, Last Available: "2013-12"
+7046	quantum gray blurry warbear superpotion	0		Effect: "Deadly Lampblade", Effect Duration: 15, Last Available: "2013-12"
 7047	modified warbear liquid lasers	0		Effect: "Demonic Flavor", Effect Duration: 37, Last Available: "2013-12"
 7048	dry warbear rejuvenation potion	0		Effect: "Material Witness", Effect Duration: 25, Last Available: "2013-12"
 7049	green broken warbear gyrocopter	0		Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	decent super-sized breakfast mess	5	good	Last Available: "2013-12"
+7055	super-sized decent breakfast mess	5	good	Last Available: "2013-12"
 7056	ghostly warbear breakfast machine	0		Last Available: "2013-12"
 7057	flavorless green breakfast miracle	4	decent	Last Available: "2013-12"
 7058	pickled Cloaca Cola Polar	0		Effect: "Hood Ridin'", Effect Duration: 21, Last Available: "2013-12"
@@ -6963,13 +6963,13 @@
 7074	quadruple-concentrated nitrogenated irradiated huge huge snow cleats	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 35, Last Available: "2014-01"
 7075	tarnished dry lime green liquid ice pack	0		Effect: "Adventurer's Best Friendship", Effect Duration: 12, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	toothsome small narrow snow crab	2	awesome	Last Available: "2014-01"
+7077	small toothsome narrow snow crab	2	awesome	Last Available: "2014-01"
 7078	practically non-alcoholic artisanal Ice Island Long Tea	1	super ultra mega turbo EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	twirling snow machine	0		Last Available: "2014-01"
-7083	fuchsia clever snow mobile	0		Maximum MP: +20, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	fuchsia clever snow mobile	0		Maximum MP: +20, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	teal ruddy ice bucket	0		Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2014-01"
 7085	Jack Frost's stiffened snow shovel	0		Damage Reduction: 1, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2014-01"
 7086	spinning friendly therapeutic Rosewater's bod-ice	0		Mysticality Percent: +30, Familiar Weight: +3, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	mediocre En Una Fila Tequila	3	decent	
 7091	Skully's hot chocolate	1	good	
-7092	boxer's stylish warbear dress helmet	0		Moxie: +25, Muscle Percent: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	boxer's stylish warbear dress helmet	0		Moxie: +25, Muscle Percent: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	tumbling resourceful warbear dress bracers of the sweet-tooth	0		Maximum MP: +50, Candy Drop: +100, Single Equip, Last Available: "2013-12"
-7094	mirror beefy warbear dress greaves of the early riser	0		Muscle: +10, Adventures: +7, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	ghostly executive savvy sweatband	0		Mysticality Percent: +20, Meat Drop: +40, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	fuchsia family-friendly frightening gym shorts	0		Spooky Damage: +5, Sleaze Resistance: +1, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	mirror beefy warbear dress greaves of the early riser	0		Muscle: +10, Adventures: +7, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	ghostly executive savvy sweatband	0		Mysticality Percent: +20, Meat Drop: +40, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	fuchsia family-friendly frightening gym shorts	0		Spooky Damage: +5, Sleaze Resistance: +1, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	cool ankleweights of temperance	0		Moxie: +5, Sleaze Resistance: +5, Single Equip, Last Available: "2014-12"
 7098	Annie Oakley's healthy dance instructor's sweat socks of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: 70, Critical Hit Percent: +20, Last Available: "2014-12"
 7099	ghostly pint of sweat	0		Last Available: "2014-12"
@@ -7000,31 +7000,31 @@
 7111	decent candy mountain oyster	3	good	Last Available: "2014-12"
 7112	artisanal chocotini	3	EPIC	Last Available: "2014-12"
 7113	prompt smelly chocolate rabbit's foot of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10, Adventures: +3, Last Available: "2014-12"
-7114	bland immense tumbling candy carrot	10	decent	Last Available: "2014-12"
+7114	immense bland tumbling candy carrot	10	decent	Last Available: "2014-12"
 7115	adequate candy carrot cake	3	good	Last Available: "2014-12"
 7116	maroon avaricious Samson's carrot-on-a-stick	0		Experience (Muscle): +5, Meat Drop: +30, Last Available: "2014-12"
-7117	toasty deadly weasel stomping pants	0		Weapon Damage: +5, Hot Damage: +5, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	toasty deadly weasel stomping pants	0		Weapon Damage: +5, Hot Damage: +5, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	spoiled mulberry	3	crappy	Last Available: "2014-12"
 7119	smooth mulled berry wine	3	awesome	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
-7121	wizardly lemon party hat	0		Mysticality: +25, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	wizardly lemon party hat	0		Mysticality: +25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	knitted lemon shirt	0		Cold Resistance: +3, Lasts Until Rollover, Last Available: "2014-12"
-7123	narrow auspicious lemon drop trousers	0		Item Drop: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	narrow auspicious lemon drop trousers	0		Item Drop: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	quantum maroon lemonhead caviar	0		Effect: "Riboflavin'", Effect Duration: 51, Last Available: "2014-12"
 7125	Lo Pan's groovy gummi sword	0		Moxie Percent: +10, Spell Critical Percent: +30, Last Available: "2014-12"
 7126	liquefied upside-down small gummi fin	0		Effect: "Armored Innards", Effect Duration: 67, Last Available: "2014-12"
 7127	chocolate cow bone of the ox	0		Muscle: +20, Last Available: "2014-12"
 7128	liquefied squat olive gummi fang	0		Effect: "Fit To Be Tide", Effect Duration: 66, Last Available: "2014-12"
-7129	miniature normal squat leftover canap&eacute;s	2	good	Last Available: "2014-12"
+7129	normal miniature squat leftover canap&eacute;s	2	good	Last Available: "2014-12"
 7130	aged magnum of champagne	4	awesome	Last Available: "2014-12"
 7131	careful Lo Pan's cow creamer of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Monster Level: -10, Last Available: "2014-12"
 7132	quantum super-tarnished Outer Wolf&trade; cologne	0		Effect: "Bottle in front of Me", Effect Duration: 43, Last Available: "2014-12"
-7133	spinning jittery lupine appetite hormones	0		Last Available: "2014-12"
+7133	jittery spinning lupine appetite hormones	0		Last Available: "2014-12"
 7134	healthy wolf whistle of the cougar	0		Moxie: +20, Maximum HP Percent: +20, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	decent witch's bread	3	good	Last Available: "2014-12"
 7136	moist witch's brew	0		Effect: "Your Eyes are Peeled!", Effect Duration: 47, Last Available: "2014-12"
 7137	Temple Grandin's hardened witch's bra of Leguizamo	0		Damage Reduction: 3, Monster Level: +20, Familiar Weight: +7, Last Available: "2014-12"
-7138	weak acceptable mid-level medieval mead	2	good	Last Available: "2014-12"
+7138	acceptable weak mid-level medieval mead	2	good	Last Available: "2014-12"
 7139	moist R&uuml;mpelstiltz	0		Effect: "PERL of Great Price", Effect Duration: 27, Last Available: "2014-12"
 7140	wobbly spinning wheel	0		Last Available: "2014-12"
 7141	diffused hi-octane carrot juice	0		Effect: "Gemini Rising", Effect Duration: 21, Last Available: "2014-12"
@@ -7043,10 +7043,10 @@
 7154	wobbly filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	green glass	0		Last Available: "2014-12"
-7157	lightning-fast supercharged Rosewater's fire hose	0		Mysticality Percent: +30, Maximum MP Percent: +30, Initiative: +40, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	snack-sized yummy yellow fireman's lunch	2	awesome	Last Available: "2014-12"
-7159	huge twirling miser's banded fortified plain paper hat	0		Damage Absorption: 160, Meat Drop: +10, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	fancy immense adequate ice cream sandwich	8	good	Effect: "Red-Shirted Escort", Effect Duration: 10, Last Available: "2014-12"
+7157	lightning-fast supercharged Rosewater's fire hose	0		Mysticality Percent: +30, Maximum MP Percent: +30, Initiative: +40, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7158	yummy snack-sized yellow fireman's lunch	2	awesome	Last Available: "2014-12"
+7159	huge twirling miser's banded fortified plain paper hat	0		Damage Absorption: 160, Meat Drop: +10, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7160	fancy adequate immense ice cream sandwich	8	good	Effect: "Red-Shirted Escort", Effect Duration: 10, Last Available: "2014-12"
 7161	blurry hardened banded &quot;honey&quot; dipper of the detective	0		Damage Absorption: +100, Damage Reduction: 3, Item Drop: +20, Last Available: "2014-12"
 7162	rotten plumber's lunch	4	crappy	Last Available: "2014-12"
 7163	Sherlock's horrifying deadly skull gearshift knob	0		Weapon Damage: +5, Spooky Damage: +25, Item Drop: +25, Last Available: "2014-12"
@@ -7073,7 +7073,7 @@
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	bad watered-down upside-down unnamed cocktail	2	decent	
+7187	watered-down bad upside-down unnamed cocktail	2	decent	
 7188	handful of tips	0		
 7189	Jim Carey's unrequired jacket	0		Monster Level: +25
 7190	smooth tommy gun	0		Moxie: +15, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7090,7 +7090,7 @@
 7201	up-at-dawn Newton's The Nuge's favorite crossbow of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Adventures: +5
 7202	bland sweet roll Alabama	3	decent	
 7203	arcane researcher's Saturday Night Special	0		Experience Percent (Mysticality): +10
-7204	jittery squat lynyrd snare	0		
+7204	squat jittery lynyrd snare	0		
 7205	boxer's fleetwood chain	0		Muscle Percent: +10
 7206	watered-down drinkable Green Manalishi	2	good	
 7207	Fonzie's blade	0		Experience (Moxie): +1
@@ -7111,12 +7111,12 @@
 7222	perfectly mixed cyan Flamin' Whatshisname	3	EPIC	
 7223	deionized double-deionized tumbling lynyrd musk	0		Effect: "There Is A Spoon", Effect Duration: 59
 7224	nasty Van der Graaf Kashmir sweater	0		Stench Damage: +5, MP Regen Min: 5, MP Regen Max: 7
-7225	immense spoiled pulsating custard pie	8	crappy	
+7225	spoiled immense pulsating custard pie	8	crappy	
 7226	tea for one	1	crappy	
 7227	watered-down mediocre bottle of Evermore	2	decent	
 7228	huge box	0		
-7229	smooth high-proof wine	10	awesome	
-7230	distilled artisanal narrow rum	5	EPIC	
+7229	high-proof smooth wine	10	awesome	
+7230	artisanal distilled narrow rum	5	EPIC	
 7231	delicious watered-down Murderer's Punch	2	awesome	
 7232	spoiled snack-sized velvet cake	2	crappy	
 7233	deionized yellow letter	0		Effect: "Mystically Oiled", Effect Duration: 44
@@ -7154,7 +7154,7 @@
 7265	photograph of an ostrich egg	0		
 7266	green disposable instant camera	0		
 7267	blurry double-paned frightening sinister sage Sneaky Pete's jacket (collar popped)	0		Mysticality Percent: +10, Spell Damage: +10, Spooky Damage: +5, Cold Resistance: +5, Softcore Only, Free Pull, Last Available: "2014-03"
-7268	skewed maroon Letter for Melvign the Gnome	0		
+7268	maroon skewed Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
 7270	&quot;2 Love Me, Vol. 2&quot;	0		
 7271	Thinknerd Blind-Packed Toy	0		
@@ -7208,7 +7208,7 @@
 7319	Temple Grandin's Elizabeth's Dollie of the early riser	0		Familiar Weight: +7, Adventures: +7
 7320	extra-energized pickled huge Elizabeth's paintbrush	0		Effect: "Blood-Gorged", Effect Duration: 27
 7321	educational strapping Stephen's lab coat	0		Muscle: +5, Experience: +1
-7322	liquefied gray pulsating Stephen's secret formula	0		Effect: "Cold, Dead Hands", Effect Duration: 57
+7322	liquefied pulsating gray Stephen's secret formula	0		Effect: "Cold, Dead Hands", Effect Duration: 57
 7323	Usain Bolt's frightening Jacob's rung	0		Spooky Damage: +5, Initiative: +80
 7324	powdered tumbling huge battery	1		Effect: "Truly Gritty", Effect Duration: 20
 7325	smooth snakebite	4	awesome	
@@ -7216,7 +7216,7 @@
 7327	twisted synthetic marrow	1		
 7328	pressed boiled yellow funny bone	0		Effect: "5 Pounds Lighter", Effect Duration: 18
 7329	crafty half-melted spoon of the ox	0		Muscle: +20, Maximum MP: +10
-7330	diluted red jittery the funk	1		
+7330	diluted jittery red the funk	1		
 7331	rotten gunky chicken	4	crappy	
 7332	boxer's doll head	0		Muscle Percent: +10
 7333	droopy doll eye	0		
@@ -7224,11 +7224,11 @@
 7335	thinker's paddle-ball of dire peril	0		Mysticality: +10, Weapon Damage: +20
 7336	ionized olive sound effects record	0		Effect: "Chock Full o' Nanites", Effect Duration: 16
 7337	olive alphabet block	0		
-7338	triple-alkaline jittery yellow dancer	0		Effect: "Pork Power", Effect Duration: 65
+7338	triple-alkaline yellow jittery dancer	0		Effect: "Pork Power", Effect Duration: 65
 7339	music box mechanism	0		
 7340	Tesla moose antlers	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xLep, cap 27"
-7341	irradiated quantum bouncing yellow moose thought	0		Effect: "Fury of the Bells", Effect Duration: 44
-7342	stale snack-sized tumbling moose chocolate	2	decent	
+7341	irradiated quantum yellow bouncing moose thought	0		Effect: "Fury of the Bells", Effect Duration: 44
+7342	snack-sized stale tumbling moose chocolate	2	decent	
 7343	mediocre painting of a glass of wine	4	decent	
 7344	oil painting of yourself	0		
 7345	spinning ornate picture frame	0		
@@ -7240,9 +7240,9 @@
 7351	supercharged occult stylish Staff of the Electric Range	0		Moxie: +25, Spell Damage Percent: +25, Maximum MP Percent: +30
 7352	bland deluxe layer cake	3	decent	
 7353	chunk of hot iron	0		
-7354	acceptable weak red-hot boilermaker	2	good	
+7354	weak acceptable red-hot boilermaker	2	good	
 7355	pulsating cyan weightlifter's coal shovel	0		Muscle: +15, Conditional Skill (Equipped): "Shovel Hot Coal"
-7356	improved upside-down skewed hot coal	0		Effect: "Hella Smooth", Effect Duration: 40
+7356	improved skewed upside-down hot coal	0		Effect: "Hella Smooth", Effect Duration: 40
 7357	magnetized corrupted coal dust	0		Effect: "Educated (Sorta)", Effect Duration: 18
 7358	twirling greasy hale strapping Bram's choker	0		Muscle: +5, Maximum HP: +20, Sleaze Spell Damage: +10, Single Equip
 7359	narrow plaid swatch	0		
@@ -7252,17 +7252,17 @@
 7363	enhanced blinking bloodstain stick	0		Effect: "Hare-o-dynamic", Effect Duration: 48
 7364	spinning fabric softener	0		
 7365	aerosolized improved fabric hardener	0		Effect: "Stregngth of the Gnome", Effect Duration: 69
-7366	aged weak bottle of laundry sherry	2	awesome	
+7366	weak aged bottle of laundry sherry	2	awesome	
 7367	oxidized Vulcanized industrial strength starch	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 15, Wiki Name: "industrial strength starch"
-7368	jumbo bland squat extra-flat panini	5	decent	
+7368	bland jumbo squat extra-flat panini	5	decent	
 7369	altered mangled finger	0		Effect: "Trivia Master", Effect Duration: 29
-7370	weak delicious spinning Psychotic Train wine	2	awesome	
+7370	delicious weak spinning Psychotic Train wine	2	awesome	
 7371	crazy hobo notebook	0		
 7372	moldy pie man was not meant to eat	3	crappy	
 7373	Jack Frost's sommelier's towel	0		Cold Spell Damage: +50
 7374	maroon Usain Bolt's tarnished tastevin	0		Initiative: +80, Single Equip
 7375	gigantic bland actual tapas	7	decent	
-7376	ghostly jittery ghast iron ingot	0		
+7376	jittery ghostly ghast iron ingot	0		
 7377	upside-down Fonzie's boxer's ghast iron cleaver	0		Muscle Percent: +10, Experience (Moxie): +1
 7378	forbidden Samson's ghast iron Garibaldi	0		Experience (Muscle): +5, Spell Damage Percent: +50, Familiar Effect: "atk, 1xFairy, cap 14"
 7379	dangerous ghast iron heater shield of the storm	0		Weapon Damage: +10, Maximum MP Percent: +40, Damage Reduction: 11
@@ -7270,7 +7270,7 @@
 7381	twirling Pendant of Gargalesis of the empath	0		Familiar Weight: +5
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	twirling DNA extraction syringe	0		Last Available: "2014-04"
-7384	polarized enhanced magnetized yellow skewed Gene Tonic: Dude	0		Effect: "Educated (Sorta)", Effect Duration: 11, Last Available: "2014-04"
+7384	polarized enhanced magnetized skewed yellow Gene Tonic: Dude	0		Effect: "Educated (Sorta)", Effect Duration: 11, Last Available: "2014-04"
 7385	corrupted Gene Tonic: Beast	0		Effect: "Oleaginous Soles", Effect Duration: 58, Last Available: "2014-04"
 7386	corrupted Gene Tonic: Construct	0		Effect: "Gummi Badass", Effect Duration: 20, Last Available: "2014-04"
 7387	diffused twirling Gene Tonic: Undead	0		Effect: "Bonelording", Effect Duration: 15, Last Available: "2014-04"
@@ -7280,10 +7280,10 @@
 7391	polarized blinking Gene Tonic: Orc	0		Effect: "Morninja", Effect Duration: 55, Last Available: "2014-04"
 7392	cold-filtered aerosolized wobbly Gene Tonic: Demon	0		Effect: "Brain Freeze", Effect Duration: 15, Last Available: "2014-04"
 7393	chilled mirror Gene Tonic: Horror	0		Effect: "Smugness", Effect Duration: 67, Last Available: "2014-04"
-7394	galvanized pulsating huge Gene Tonic: Fish	0		Effect: "Goldentongue", Effect Duration: 15, Last Available: "2014-04"
-7395	altered ghostly skewed Gene Tonic: Goblin	0		Effect: "Turkey-Ambitious", Effect Duration: 36, Last Available: "2014-04"
+7394	galvanized huge pulsating Gene Tonic: Fish	0		Effect: "Goldentongue", Effect Duration: 15, Last Available: "2014-04"
+7395	altered skewed ghostly Gene Tonic: Goblin	0		Effect: "Turkey-Ambitious", Effect Duration: 36, Last Available: "2014-04"
 7396	magnetized tumbling twirling Gene Tonic: Pirate	0		Effect: "Sauce Monocle", Effect Duration: 62, Last Available: "2014-04"
-7397	deionized corrupted jittery lime green Gene Tonic: Plant	0		Effect: "Winklered", Effect Duration: 44, Last Available: "2014-04"
+7397	deionized corrupted lime green jittery Gene Tonic: Plant	0		Effect: "Winklered", Effect Duration: 44, Last Available: "2014-04"
 7398	corrupted flattened liquefied Gene Tonic: Weird	0		Effect: "[1701]Hip to the Jive", Effect Duration: 42, Last Available: "2014-04"
 7399	dry Gene Tonic: Elf	0		Effect: "Vitali Tea", Effect Duration: 42, Last Available: "2014-04"
 7400	irradiated diffused shaking Gene Tonic: Mer-kin	0		Effect: "Category", Effect Duration: 54, Last Available: "2014-04"
@@ -7297,7 +7297,7 @@
 7408	spinning Steam Card: Dungeon Fist (#3)	0		
 7409	pulsating teal Steam Card: Space Trip (#1)	0		
 7410	spinning Steam Card: Space Trip (#2)	0		
-7411	pulsating skewed Steam Card: Space Trip (#3)	0		
+7411	skewed pulsating Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
 7413	wobbly Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
@@ -7324,37 +7324,37 @@
 7435	extra-Vulcanized mirror Stemonitis Staticus mushroom	0		Effect: "Ooh, Umami!", Effect Duration: 64, Last Available: "2014-05"
 7436	activated magnetized Tremella Tarantella mushroom	0		Effect: "Heart of Lavender", Effect Duration: 45, Last Available: "2014-05"
 7437	squat Pastaco shell	0		Last Available: "2014-05"
-7438	normal huge Beefy Crunch Pastaco	6	good	Last Available: "2014-05"
+7438	huge normal Beefy Crunch Pastaco	6	good	Last Available: "2014-05"
 7439	moldy snack-sized Brain Food Pastaco	2	crappy	Last Available: "2014-05"
-7440	normal tiny huge Cool Brunch Pastaco	1	good	Last Available: "2014-05"
-7441	half-sized bland twirling Medical Pastaco	2	decent	Last Available: "2014-05"
+7440	tiny normal huge Cool Brunch Pastaco	1	good	Last Available: "2014-05"
+7441	bland half-sized twirling Medical Pastaco	2	decent	Last Available: "2014-05"
 7442	small spoiled ghostly red Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
 7443	bland upside-down Ludovico Pastaco	3	decent	Last Available: "2014-05"
 7444	aged overpowering mushroom wine	3	awesome	Last Available: "2014-05"
 7445	tolerable complex mushroom wine	4	good	Last Available: "2014-05"
 7446	artisanal skewed smooth mushroom wine	3	super EPIC	Last Available: "2014-05"
 7447	bad blurry blood-red mushroom wine	3	decent	Last Available: "2014-05"
-7448	boozy tolerable huge buzzing mushroom wine	5	good	Last Available: "2014-05"
+7448	tolerable boozy huge buzzing mushroom wine	5	good	Last Available: "2014-05"
 7449	mediocre twirling swirling mushroom wine	4	decent	Last Available: "2014-05"
-7450	half-sized delicious Taco Dan's Basic Taco Dan Taco	2	awesome	Last Available: "2014-05"
+7450	delicious half-sized Taco Dan's Basic Taco Dan Taco	2	awesome	Last Available: "2014-05"
 7451	yummy skewed Taco Dan's Taco Fish Fish Taco	3	awesome	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	hand-crafted fortified twirling regular-size brogurt	5	EPIC	Last Available: "2014-05"
+7453	fortified hand-crafted twirling regular-size brogurt	5	EPIC	Last Available: "2014-05"
 7454	drinkable fortified lime green super-size brogurt	5	good	Last Available: "2014-05"
 7455	drinkable huge broberry brogurt	3	good	Last Available: "2014-05"
-7456	drinkable weak brocolate brogurt	2	good	Last Available: "2014-05"
+7456	weak drinkable brocolate brogurt	2	good	Last Available: "2014-05"
 7457	lousy boozy French bronilla brogurt	5	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	blurry Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	blinking Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	beefy Brogre brorts	0		Muscle: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	beefy Brogre brorts	0		Muscle: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	lime green beefy Brogre brolo shirt	0		Muscle: +10, Last Available: "2014-05"
-7464	healthy Brogre bucket hat	0		Maximum HP Percent: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	healthy Brogre bucket hat	0		Maximum HP Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	wobbly airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	ghostly asbestos-lined energetic 8-billed baseball cap of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +20, Hot Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	ghostly asbestos-lined energetic 8-billed baseball cap of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +20, Hot Resistance: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	narrow lime green scorching quilted strapping extremely wet T-shirt	0		Muscle: +5, Damage Absorption: +40, Hot Damage: +25, Last Available: "2014-05"
 7470	lightning-fast shrimp fork of the blizzard of mayonnaise	0		Cold Spell Damage: +25, Sleaze Spell Damage: +50, Initiative: +40, Last Available: "2014-05"
 7471	activated Vulcanized teal BROS Energy Drink	0		Effect: "All Branned Up", Effect Duration: 30, Last Available: "2014-05"
@@ -7367,7 +7367,7 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	double-dry pulsating sugar fairy	0		Effect: "French Bronilla Brogueishness", Effect Duration: 14, Last Available: "2014-05"
 7480	extra-electrified Vulcanized sugar bunny	0		Effect: "The Two-Prong Crown", Effect Duration: 65, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	tolerable upside-down Rompedores de Fantasmas	3	good	
 7483	hand-crafted La Fantasma y La Oscuridad	3	EPIC	
 7484	watered-down drinkable blurry Fantasma en la M&aacute;quina	2	good	
@@ -7409,28 +7409,28 @@
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	toothsome government cheese	4	awesome	Last Available: "2014-05"
 7522	mirror Rosewater's pair of government shades	0		Mysticality Percent: +30, Single Equip, Last Available: "2014-05"
-7523	narrow jittery space junk	0		Last Available: "2014-05"
+7523	jittery narrow space junk	0		Last Available: "2014-05"
 7524	enhanced dry government	0		Effect: "Ack!  Barred!", Effect Duration: 54, Last Available: "2014-05"
 7525	activated upside-down alien drugs	0		Effect: "Big Meat Big Prizes", Effect Duration: 26, Last Available: "2023-09"
 7526	ghostly weird space book	0		Last Available: "2014-05"
 7527	ghostly spinning alien force field disruptor bean	0		Last Available: "2014-05"
 7528	ghostly MacGyver's government-issued night-vision goggles	0		Maximum MP: +100, Item Drop: +5, Single Equip, Last Available: "2014-05"
 7529	snack-sized adequate loaf of alien bread	2	good	Last Available: "2014-05"
-7530	decent enchanted grilled cheese sandwich	4	good	Effect: "It Tickles!  It Tickles!", Effect Duration: 45, Last Available: "2014-05"
+7530	enchanted decent grilled cheese sandwich	4	good	Effect: "It Tickles!  It Tickles!", Effect Duration: 45, Last Available: "2014-05"
 7531	altered alien protein powder	1	EPIC	Last Available: "2014-05"
 7532	hand-crafted rocket fuel	4	EPIC	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7534	huge upside-down alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	mediocre practically non-alcoholic stealth bomber	1	decent	Last Available: "2014-05"
+7534	upside-down huge alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7535	practically non-alcoholic mediocre stealth bomber	1	decent	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	upside-down twitching space egg	0		Last Available: "2014-05"
 7538	huge ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	narrow Newton's space beast fur hat	0		Experience (Mysticality): +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	supercool space beast fur pants	0		Moxie Percent: +20, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	narrow Newton's space beast fur hat	0		Experience (Mysticality): +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	supercool space beast fur pants	0		Moxie Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	padded space beast fur whip	0		Damage Absorption: +20, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	blinking extremely unsafe space heater	0		Weapon Damage Percent: +100, Item Drop: +5, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
-7544	jittery gray space bar	0		Last Available: "2014-05"
+7544	gray jittery space bar	0		Last Available: "2014-05"
 7545	drinkable high-proof space port	10	good	Last Available: "2014-05"
 7546	Sherlock's beefy space needle	0		Muscle: +10, Item Drop: +25, Last Available: "2014-05"
 7547	alkaline buffed alien drugs	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 55, Last Available: "2014-05"
@@ -7438,7 +7438,7 @@
 7549	tarnished moist ash soda	0		Effect: "Natural 20", Effect Duration: 40, Last Available: "2014-06"
 7550	flattened wobbly cyan liquid smoke	0		Effect: "Deeply Ironic", Effect Duration: 16, Last Available: "2014-06"
 7551	unsweetened deionized dollop of barbecue sauce	0		Effect: "Big Punkin'", Effect Duration: 65, Last Available: "2014-06"
-7552	alkaline oxidized diffused cyan jittery wobbly bowl of marinade	0		Effect: "Simulation Stimulation", Effect Duration: 68, Last Available: "2014-06"
+7552	alkaline oxidized diffused jittery wobbly cyan bowl of marinade	0		Effect: "Simulation Stimulation", Effect Duration: 68, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
 7554	pickled double-boiled bottle of lighter fluid	0		Effect: "Arabian Knighthood", Effect Duration: 60, Last Available: "2014-06"
 7555	page	0		
@@ -7468,7 +7468,7 @@
 7579	twitching time capsule	0		
 7580	modified liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	moldy huge rack of dinosaur ribs	6	crappy	
+7582	huge moldy rack of dinosaur ribs	6	crappy	
 7583	lousy scotch on the rocks	4	decent	
 7584	fuchsia huge stiffened yabba dabba doo rag of incineration	0		Damage Reduction: 1, Hot Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	frosty beefy wooly loincloth	0		Muscle: +10, Cold Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7477,28 +7477,28 @@
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	artisanal fortified lime green glass of &quot;milk&quot;	5	EPIC	Last Available: "2014-07"
 7590	enchanted drinkable cup of &quot;tea&quot;	4	good	Effect: "Ripping, Dripping", Effect Duration: 25, Last Available: "2014-07"
-7591	strong bad thermos of &quot;whiskey&quot;	5	decent	Last Available: "2014-07"
+7591	bad strong thermos of &quot;whiskey&quot;	5	decent	Last Available: "2014-07"
 7592	bad Lucky Lindy	4	decent	Last Available: "2014-07"
 7593	drinkable Bee's Knees	3	good	Last Available: "2014-07"
 7594	triple-distilled bad maroon Sockdollager	10	decent	Last Available: "2014-07"
 7595	perfectly mixed fortified Ish Kabibble	5	EPIC	Last Available: "2014-07"
 7596	delicious weak yellow Hot Socks	2	awesome	Last Available: "2014-07"
-7597	irresponsibly strong artisanal narrow Phonus Balonus	8	EPIC	Last Available: "2014-07"
-7598	distilled artisanal gray huge Flivver	5	EPIC	Last Available: "2014-07"
+7597	artisanal irresponsibly strong narrow Phonus Balonus	8	EPIC	Last Available: "2014-07"
+7598	artisanal distilled gray huge Flivver	5	EPIC	Last Available: "2014-07"
 7599	triple-distilled lousy Sloppy Jalopy	6	decent	Last Available: "2014-07"
 7600	quadruple-diffused flame	0		Effect: "Sticks and Stones", Effect Duration: 41
 7601	vacuum-sealed triple-vacuum-sealed bouncing temporary yak tattoo	0		Effect: "Mer-kinny Flavor", Effect Duration: 15
 7602	altered non-nitrogenated anodized green Fitspiration&trade; poster	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 50
 7603	energized neckbeard	0		Effect: "Jingle Jangle Jingle", Effect Duration: 63
 7604	wet tarnished artisanal hand-squeezed wheatgrass juice	0		Effect: "It Didn't Kill You", Effect Duration: 21
-7605	aerosolized squat blinking punk patch	0		Effect: "Wet Rub", Effect Duration: 53
+7605	aerosolized blinking squat punk patch	0		Effect: "Wet Rub", Effect Duration: 53
 7606	oxidized steampunk potion	0		Effect: "Oth-Jeal-O", Effect Duration: 28
-7607	triple-improved double-vacuum-sealed denatured twirling lime green narrow vial of swamp vapors	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 43
+7607	triple-improved double-vacuum-sealed denatured lime green twirling narrow vial of swamp vapors	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 43
 7608	boiled altered turtle mud	0		Effect: "Greasy Peasy", Effect Duration: 45
-7609	activated squat gray Redeye&trade; Eyedrops	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 43
+7609	activated gray squat Redeye&trade; Eyedrops	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 43
 7610	activated quadruple-quantum Dweebisol&trade; inhaler	0		Effect: "Hyphemariffic", Effect Duration: 65
 7611	flattened ionized moist Lewd Lemmy Hair Oil	0		Effect: "White-boy Angst", Effect Duration: 66
-7612	chilled blurry purple tomato soup poster	0		Effect: "Brain Freeze", Effect Duration: 57
+7612	chilled purple blurry tomato soup poster	0		Effect: "Brain Freeze", Effect Duration: 57
 7613	corrupted chilled bubblin' chemistry solution	0		Effect: "Can't Be a Chooser", Effect Duration: 18
 7614	quantum voodoo glowskull	0		Effect: "Mariachi Mood", Effect Duration: 13
 7615	deionized pygmy adder oil	0		Effect: "Red Door Syndrome", Effect Duration: 46
@@ -7552,18 +7552,18 @@
 7663	Sherlock's therapeutic Lord Soggyraven's Slippers of doom	0		Spooky Spell Damage: +50, Item Drop: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 7664	galvanized Ancient Protector Soda	0		Effect: "The Style... of the Future", Effect Duration: 66
 7665	corrupted liquid ice	0		Effect: "Phorcefullness", Effect Duration: 66
-7666	hand-crafted practically non-alcoholic Wet Russian	1	super ultra mega turbo EPIC	
+7666	practically non-alcoholic hand-crafted Wet Russian	1	super ultra mega turbo EPIC	
 7667	flavorless fancy filet of The Fish	3	decent	Effect: "Mystically Oiled", Effect Duration: 35
 7668	Thwaitgold spider statuette	0		
 7669	blinking mirror avaricious Da Vinci's brainy thunder down underwear	0		Mysticality: +5, Experience (Mysticality): +5, Meat Drop: +30, Lasts Until Rollover
 7670	spinning Oprah's steel-toed occult famous raincoat	0		Spell Damage Percent: +25, Damage Reduction: 9, Maximum MP Percent: +50, Lasts Until Rollover
 7671	yellow fireproof lightning rod of Tarzan of the cheetah	0		Experience (Muscle): +3, Hot Resistance: +3, Initiative: +60, Lasts Until Rollover
 7672	bouncing padded law-abiding citizen cane	0		Damage Absorption: +20, Single Equip
-7673	extra-dry drinkable legitimate business on the beach	5	good	
+7673	drinkable extra-dry legitimate business on the beach	5	good	
 7674	baleful hep waders	0		Spell Damage: +25, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	flavorless jive turkey leg	3	decent	
 7676	dangerous birdbone corset	0		Weapon Damage: +10
-7677	diffused cold-filtered huge fuchsia candy cigarette	0		Effect: "Crimbo Nostalgia", Effect Duration: 31
+7677	diffused cold-filtered fuchsia huge candy cigarette	0		Effect: "Crimbo Nostalgia", Effect Duration: 31
 7678	tumbling Jim Carey's 4-dimensional fez	0		Monster Level: +25, Familiar Effect: "atk, 1xLep, cap 12"
 7679	wobbly throwing candy	0		
 7680	reassuring super-absorbent tarp	0		Spooky Resistance: +1
@@ -7573,7 +7573,7 @@
 7684	family-friendly Time Lord Participation Mug	0		Sleaze Resistance: +1
 7685	perfumed fireproof Time Bandit Time Towel	0		Hot Resistance: +3, Stench Resistance: +5
 7686	inspector's Van der Graaf Caveman Dan's favorite rock of mayonnaise	0		Sleaze Spell Damage: +50, Item Drop: +15, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-7687	pickled purple shaking dog ointment	0		Effect: "Cool Spirit", Effect Duration: 31
+7687	pickled shaking purple dog ointment	0		Effect: "Cool Spirit", Effect Duration: 31
 7688	censurious gumshoes of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100, Single Equip
 7689	censurious Samson's flapper floppers	0		Experience (Muscle): +5, Sleaze Resistance: +3, Single Equip
 7690	Jim Carey's sneakeasies of the early riser	0		Monster Level: +25, Adventures: +7, Single Equip
@@ -7592,14 +7592,14 @@
 7703	tumbling LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	huge LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	ghostly The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	ghostly The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	improved blurry rubber nubbin	0		Effect: "Disco Nirvana", Effect Duration: 39, Last Available: "2014-08"
 7708	slick rubber cape of vim and vigor	0		Moxie: +10, Maximum HP Percent: +50, Last Available: "2014-08"
 7709	inspector's double-paned Jeselnik's Jim Carey's Thor's Pliers	0		Monster Level: +25, Sleaze Damage: +25, Cold Resistance: +5, Item Drop: +15, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	alkaline upside-down candy UFOs	0		Effect: "Human-Penguin Hybrid", Effect Duration: 25
 7711	stiffened arcane researcher's water wings for babies	0		Experience Percent (Mysticality): +10, Damage Reduction: 1
-7712	squat beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	immense rotten upside-down Strix stix	6	crappy	
+7712	squat beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7713	rotten immense upside-down Strix stix	6	crappy	
 7714	zippy frightening curative vampire pellet	0		Spooky Damage: +5, Initiative: +20, HP Regen Min: 3, HP Regen Max: 5
 7715	acceptable huge non-aged vinegar	3	good	
 7716	mirror cool unsanitized scalpel	0		Moxie: +5
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	occult Xiblaxian xeno-detection goggles	0		Spell Damage Percent: +25, Single Equip, Last Available: "2014-09"
-7753	spinning red energetic arcane researcher's Xiblaxian stealth cowl	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	spinning red energetic arcane researcher's Xiblaxian stealth cowl	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	Annie Oakley's brainy Xiblaxian stealth trousers	0		Mysticality: +5, Critical Hit Percent: +20, Last Available: "2014-09"
 7755	squat zippy Socratic Xiblaxian stealth vest	0		Experience (Mysticality): +1, Initiative: +20, Last Available: "2014-09"
-7756	decent small maroon twirling Xiblaxian ultraburrito	2	good	Last Available: "2014-09"
+7756	small decent twirling maroon Xiblaxian ultraburrito	2	good	Last Available: "2014-09"
 7757	aged Xiblaxian space-whiskey	3	awesome	Last Available: "2014-09"
 7758	blinking Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	enhanced ionized They liver	0		Effect: "20-20 Second Sight", Effect Duration: 25, Last Available: "2014-09"
-7760	immense adequate They liver popsicle	7	good	Last Available: "2014-09"
+7760	adequate immense They liver popsicle	7	good	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	jittery holo-bomber	0		Last Available: "2014-09"
 7763	upside-down holo-platoon	0		Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	inspector's groovy stylish Personal Ventilation Unit	0		Moxie: +25, Moxie Percent: +10, Item Drop: +15, Single Equip, Last Available: "2014-10"
 7771	energized warmed the most dangerous bait	0		Effect: "Wet Rub", Effect Duration: 37, Last Available: "2014-10"
-7772	miniature bland &quot;meat&quot; stick	2	decent	Last Available: "2014-10"
+7772	bland miniature &quot;meat&quot; stick	2	decent	Last Available: "2014-10"
 7773	vaporized blinking transdermal smoke patch	1	decent	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	padded deadly pair of plants of the storm	0		Weapon Damage: +5, Damage Absorption: +20, Maximum MP Percent: +40, Last Available: "2014-10"
@@ -7669,15 +7669,15 @@
 7780	frosty wicked heavy-duty clipboard of horror	0		Spell Damage: +5, Cold Spell Damage: +10, Spooky Spell Damage: +25, Damage Reduction: 8, Last Available: "2014-10"
 7781	ghostly inspector's perfumed sharpshooter's battery-powered drill of doom	0		Critical Hit Percent: +10, Spooky Spell Damage: +50, Stench Resistance: +5, Item Drop: +15, Last Available: "2014-10"
 7782	spoiled twirling limp broccoli	3	crappy	Last Available: "2014-10"
-7783	energetic Fonzie's hat of the glutton	0		Experience (Moxie): +1, Maximum MP Percent: +20, Food Drop: +100, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	energetic Fonzie's hat of the glutton	0		Experience (Moxie): +1, Maximum MP Percent: +20, Food Drop: +100, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	warmed maroon monkey barf	0		Effect: "Big Punkin'", Effect Duration: 18, Last Available: "2014-10"
 7785	liquefied electrified oxidized candy	0		Effect: "Ooh, Sweet!", Effect Duration: 29, Last Available: "2014-10"
 7786	nippy electrified savvy jangly bracelet	0		Mysticality Percent: +20, Cold Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-10"
 7787	smelly cuddly teddy bear	0		Stench Spell Damage: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
-7788	skewed ghostly ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7788	ghostly skewed ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	skewed ghostly experienced first-aid pouch of bravery	0		Experience: +2, Spooky Resistance: +5, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
-7791	polymerized Vulcanized fuchsia squat airborne mutagen	0		Effect: "Permafrosty", Effect Duration: 43, Last Available: "2014-10"
+7791	polymerized Vulcanized squat fuchsia airborne mutagen	0		Effect: "Permafrosty", Effect Duration: 43, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	wobbly shaking Armory keycard	0		Last Available: "2014-10"
@@ -7685,7 +7685,7 @@
 7796	gigantic flavorless warm war shawarma	7	decent	Last Available: "2014-10"
 7797	flavorless karma shawarma	3	decent	Last Available: "2014-10"
 7798	artisanal tumbling Jungle Juice	4	EPIC	Last Available: "2014-10"
-7799	delicious boozy mirror Amnesiac Ale	5	awesome	Last Available: "2014-10"
+7799	boozy delicious mirror Amnesiac Ale	5	awesome	Last Available: "2014-10"
 7800	perfectly mixed Highest Bitter	4	EPIC	Last Available: "2014-10"
 7801	Jack Frost's frosty mercenary pistol	0		Cold Spell Damage: 60, Last Available: "2014-10"
 7802	chilly mercenary rifle of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5, Last Available: "2014-10"
@@ -7705,7 +7705,7 @@
 7816	cyan dove DNA	0		
 7817	gelatinous meat mass	0		
 7818	fuchsia 99.44% pure math	0		
-7819	spinning skewed simple AI	0		
+7819	skewed spinning simple AI	0		
 7820	corrupted bird DNA	0		
 7821	gray sentient meat mass	0		
 7822	zombie dinosaur egg	0		
@@ -7713,14 +7713,14 @@
 7824	executive scandalous Newton's iShield	0		Experience (Mysticality): +3, Sleaze Damage: +5, Meat Drop: +40, Damage Reduction: 6
 7825	mirror miser's manspreader's earbuds of dire peril	0		Weapon Damage: +20, Monster Level: +10, Meat Drop: +10, Single Equip
 7826	prompt scorching resourceful iFlail	0		Maximum MP: +50, Hot Damage: +25, Adventures: +3
-7827	snack-sized toothsome maroon unidentifiable dried fruit	2	awesome	
+7827	toothsome snack-sized maroon unidentifiable dried fruit	2	awesome	
 7828	drinkable flat cider	3	good	
 7829	mirror reassuring Rosewater's trench lighter of the wise owl	0		Mysticality: +20, Mysticality Percent: +30, Spooky Resistance: +1, Last Available: "2014-10"
 7830	flattened experimental serum P-00	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 43, Last Available: "2014-10"
 7831	maroon wobbly military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	blinking gore bucket	0		Last Available: "2014-10"
-7834	twirling maroon pack of smokes	0		Last Available: "2014-10"
+7834	maroon twirling pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	blue Project T. L. B.	0		Last Available: "2014-10"
@@ -7729,7 +7729,7 @@
 7840	narrow special clip: wailers	0		Last Available: "2014-10"
 7841	tumbling special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
-7843	squat ghostly special clip: boneburners	0		Last Available: "2014-10"
+7843	ghostly squat special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	ionized twirling narrow perl necklace	0		Effect: "Dweeby", Effect Duration: 48, Last Available: "2014-12"
 7846	corrupted concentrated Fudge Fiber Armor Plating	0		Effect: "Hella Smooth", Effect Duration: 62, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	upside-down wholesome plastic Crimbot	0		Maximum HP Percent: +10, Last Available: "2014-12"
 7855	knitted plastic Crimbomega	0		Cold Resistance: +3, Last Available: "2014-12"
 7856	triple-tarnished oxidized lime green huge blurry flask of mining oil	0		Effect: "Strong Grip", Effect Duration: 44, Last Available: "2014-12"
-7857	extremely unsafe radiation-resistant helmet	0		Weapon Damage Percent: +100, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	purple jittery Da Vinci's servo-assisted exo-pants	0		Experience (Mysticality): +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	extremely unsafe radiation-resistant helmet	0		Weapon Damage Percent: +100, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	purple jittery Da Vinci's servo-assisted exo-pants	0		Experience (Mysticality): +5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	teal shellacked wizardly high-energy mining laser	0		Mysticality: +25, Damage Reduction: 7, Last Available: "2014-12"
 7860	jittery peppermint tailings	0		Last Available: "2014-12"
 7861	squat nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7811,12 +7811,12 @@
 7922	aged Friendly Turkey	3	awesome	Last Available: "2014-11"
 7923	hand-crafted jittery Agitated Turkey	3	EPIC	Last Available: "2014-11"
 7924	perfectly mixed Ambitious Turkey	4	EPIC	Last Available: "2014-11"
-7925	moldy bite-sized spinning twirling neutron lollipop	1	crappy	Last Available: "2014-12"
+7925	bite-sized moldy twirling spinning neutron lollipop	1	crappy	Last Available: "2014-12"
 7926	artisanal gamma nog	3	EPIC	Last Available: "2014-12"
 7934	shaking sneaky wrapping paper	0		Last Available: "2014-12"
 7935	twirling Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
-7937	skewed upside-down Crimbo Credit	0		
+7937	upside-down skewed Crimbo Credit	0		
 7938	boiled gray single atom	1	crappy	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
@@ -7826,7 +7826,7 @@
 7944	tooth	0		
 7945	table	0		
 7946	rock-hard Rosewater's smooth outlaw bandana	0		Moxie: +15, Mysticality Percent: +30, Damage Reduction: 5
-7947	watered-down lousy fancy whiskey in a broken glass	2	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 45
+7947	fancy watered-down lousy whiskey in a broken glass	2	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 45
 7948	delicious shot of mescal	4	awesome	
 7949	mediocre glass of herbal tequila	4	decent	
 7950	maroon minin' dynamite	0		
@@ -7877,11 +7877,11 @@
 7995	vibrating pelerine of the storm	0		Maximum MP Percent: 50, Last Available: "2015-12"
 7996	resourceful phantom mask of the sewer	0		Maximum MP: +50, Stench Damage: +25, Single Equip, Last Available: "2015-12"
 7997	pickled polyesterene powder	1		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 50, Last Available: "2015-12"
-7998	boiled shaking bouncing powder	1		Effect: "Grape Expectations", Effect Duration: 50, Last Available: "2015-12"
+7998	boiled bouncing shaking powder	1		Effect: "Grape Expectations", Effect Duration: 50, Last Available: "2015-12"
 7999	boiled dry wobbly red choco-Crimbot	0		Effect: "critical.enh", Effect Duration: 68, Last Available: "2014-12"
-8000	denatured bouncing spinning upside-down smart watch	0		Effect: "Speed of the Internet", Effect Duration: 51, Last Available: "2014-12"
-8001	concentrated purple pulsating blinking augmented-reality shades	0		Effect: "Inappropriate Spirit", Effect Duration: 28, Last Available: "2014-12"
-8002	toy Crimbot mega face of the cougar	0		Moxie: +20, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8000	denatured bouncing upside-down spinning smart watch	0		Effect: "Speed of the Internet", Effect Duration: 51, Last Available: "2014-12"
+8001	concentrated blinking pulsating purple augmented-reality shades	0		Effect: "Inappropriate Spirit", Effect Duration: 28, Last Available: "2014-12"
+8002	toy Crimbot mega face of the cougar	0		Moxie: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
 8003	aromatic toy Crimbot power glove	0		Stench Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	narrow wobbly toy Crimbot super fist of James Dean	0		Experience (Moxie): +3, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	dangerous toy Crimbot rocket legs	0		Weapon Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
@@ -7900,19 +7900,19 @@
 8018	altered maroon and rain stick	0		Effect: "Really Deep Breath", Effect Duration: 33
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	super-sized normal Choco-Mint patty	5	good	Last Available: "2015-01"
-8021	lousy spirit-forward hot mint schnocolate	5	decent	Last Available: "2015-01"
+8021	spirit-forward lousy hot mint schnocolate	5	decent	Last Available: "2015-01"
 8022	denatured narrow twirling homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	tumbling muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	green bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
-8028	blinking bouncing green artificial skylight	0		Last Available: "2015-01"
+8028	green blinking bouncing artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	stationery set	0		Last Available: "2015-01"
 8032	blinking calligraphy pen	0		Free Pull, Last Available: "2015-01"
-8033	upside-down teal alpine watercolor set	0		Last Available: "2015-01"
+8033	teal upside-down alpine watercolor set	0		Last Available: "2015-01"
 8034	flame-wreathed tope&eacute;	0		Hot Spell Damage: +10, Item Drop: +5, Familiar Effect: "3xBarrr, cap 12"
 8035	skewed horrifying wicked topiary tights	0		Spell Damage: +5, Spooky Damage: +25
 8036	Da Vinci's topiary necktie	0		Experience (Mysticality): +5
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	rock-hard fortified strapping Spelunker's fedora	0		Muscle: +5, Damage Absorption: +60, Damage Reduction: 5, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	rock-hard fortified strapping Spelunker's fedora	0		Muscle: +5, Damage Absorption: +60, Damage Reduction: 5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	ghostly twirling wool Tesla Spelunker's whip of the brute	0		Muscle Percent: +30, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
-8076	miser's foul-smelling beefy Spelunker's khakis	0		Muscle: +10, Stench Damage: +10, Meat Drop: +10, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	miser's foul-smelling beefy Spelunker's khakis	0		Muscle: +10, Stench Damage: +10, Meat Drop: +10, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	fuchsia Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	twirling Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -8025,7 +8025,7 @@
 8151	triple-polymerized twirling Shrubble Bubble	0		Effect: "Mana Tea", Effect Duration: 62
 8152	triple-pressed polymerized spinning polyeaster egg	0		Effect: "Abyssal Blood", Effect Duration: 21
 8153	galvanized narrow mirror candy dish	0		Effect: "Remaining Alive", Effect Duration: 64
-8154	oxidized electrified galvanized red skewed Spechunky bar	0		Effect: "Thaumodynamic", Effect Duration: 23
+8154	oxidized electrified galvanized skewed red Spechunky bar	0		Effect: "Thaumodynamic", Effect Duration: 23
 8155	moist narrow talisman of Horus	0		Effect: "Stuck-Up Hair", Effect Duration: 13
 8156	mirror check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
@@ -8038,14 +8038,14 @@
 8164	quilted remaindered axe of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25
 8165	low-budget shield	0		Damage Reduction: 3
 8166	frosty Annie Oakley's cr&ecirc;epy mask	0		Critical Hit Percent: +20, Cold Spell Damage: +10, Familiar Effect: "spooky atk, cap 5"
-8167	gigantic adequate tumbling baguette	9	good	
+8167	adequate gigantic tumbling baguette	9	good	
 8168	glob of icing	0		
 8169	dry boiled lime green blurry ginger snaps	0		Effect: "Stogied", Effect Duration: 61
 8170	magnetized chilled mostly-broken sunglasses	0		Effect: "Staying Frosty", Effect Duration: 21
 8171	tolerable unflavored wine cooler	4	good	
 8172	carton of snake milk	1	awesome	
 8173	upside-down upside-down sewer snake of courage	0		Spooky Resistance: +3
-8174	low-calorie adequate twirling pigeon egg	1	good	
+8174	adequate low-calorie twirling pigeon egg	1	good	
 8175	gray stiffened brawny jaunty feather	0		Muscle Percent: +20, Damage Reduction: 1
 8176	practically non-alcoholic drinkable premium malt liquor	1	good	
 8177	fuchsia clever brown paper pants of bravery	0		Maximum MP: +20, Spooky Resistance: +5
@@ -8056,18 +8056,18 @@
 8182	green Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	bread basket of the cougar	0		Moxie: +20
 8184	wobbly Ed the Undying exhibit crate	0		
-8185	stiffened strapping The Crown of Ed the Undying	0		Muscle: +5, Damage Reduction: 1, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	stiffened strapping The Crown of Ed the Undying	0		Muscle: +5, Damage Reduction: 1, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
-8187	red tumbling map to a hidden booze cache	0		
+8187	tumbling red map to a hidden booze cache	0		
 8188	fancy smooth pulsating Cherrytastrophe wine cooler	3	awesome	Effect: "Greased-Up Familiar", Effect Duration: 15
 8189	drinkable weak Radberry Rip wine cooler	2	good	
 8190	aged Orangemageddon wine cooler	3	awesome	
 8191	drinkable watered-down squat Breakfast Blast wine cooler	2	good	
 8192	aged practically non-alcoholic Citrus Crush wine cooler	1	awesome	
-8193	enchanted adequate narrow ghostly plain bagel	3	good	Effect: "The Q Is Talking To You", Effect Duration: 30
+8193	adequate enchanted narrow ghostly plain bagel	3	good	Effect: "The Q Is Talking To You", Effect Duration: 30
 8194	normal wobbly glob of cream cheese	4	good	
-8195	flavorless low-calorie jittery loaf of soda bread	1	decent	
-8196	super-sized normal bouncing acceptable bagel	5	good	
+8195	low-calorie flavorless jittery loaf of soda bread	1	decent	
+8196	normal super-sized bouncing acceptable bagel	5	good	
 8197	delicious maroon tumbling standard-issue cupcake	4	awesome	
 8198	special rotten jittery ultra-deluxe cupcake	4	crappy	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 45
 8199	hypnotic breadcrumbs	0		
@@ -8092,7 +8092,7 @@
 8218	toxic globule	0		Last Available: "2015-04"
 8219	adequate small purple toxo	2	good	Last Available: "2015-04"
 8220	bad practically non-alcoholic Lemonade-235	1	decent	Last Available: "2015-04"
-8221	smelly isotophat of courage	0		Stench Spell Damage: +10, Spooky Resistance: +3, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	smelly isotophat of courage	0		Stench Spell Damage: +10, Spooky Resistance: +3, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	teal up-at-dawn Three Mile Island shorts of wisdom	0		Mysticality: +15, Adventures: +5, Last Available: "2015-04"
 8223	weightlifter's toxic mop of the businessman	0		Muscle: +15, Meat Drop: +50, Last Available: "2015-04"
 8224	jittery inert sludgepuppy	0		Last Available: "2015-04"
@@ -8141,14 +8141,14 @@
 8267	narrow dog trainer's sphygmayomanometer	0		Experience (familiar): +1, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	yummy thick unappetizing mayolus	5	awesome	Last Available: "2015-05"
+8270	thick yummy unappetizing mayolus	5	awesome	Last Available: "2015-05"
 8271	flavorless uninteresting mayolus	4	decent	Last Available: "2015-05"
-8272	stale purple skewed acceptable mayolus	3	decent	Last Available: "2015-05"
+8272	stale skewed purple acceptable mayolus	3	decent	Last Available: "2015-05"
 8273	moldy enticing mayolus	3	crappy	Last Available: "2015-05"
-8274	moldy immense mouth-watering mayolus	6	crappy	Last Available: "2015-05"
+8274	immense moldy mouth-watering mayolus	6	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
-8277	blinking twirling Essence of Bear	0		Skill: "Bear Essence"
+8277	twirling blinking Essence of Bear	0		Skill: "Bear Essence"
 8278	drinkable Afternoon Delight	3	good	Last Available: "2015-04"
 8279	lime green Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	wobbly Golden Kokomo Resort Chip	0		Last Available: "2015-04"
@@ -8157,7 +8157,7 @@
 8283	huge The Cocktail Shaker	0		Last Available: "2015-04"
 8284	ionized flattened Kokomo Resort Pass	0		Effect: "Human-Undead Hybrid", Effect Duration: 21, Last Available: "2023-08"
 8285	huge Mayo Minder&trade;	0		Last Available: "2015-05"
-8286	alkaline olive bouncing Mayo de Mayo&trade; mayo	0		Effect: "Hobonic", Effect Duration: 13
+8286	alkaline bouncing olive Mayo de Mayo&trade; mayo	0		Effect: "Hobonic", Effect Duration: 13
 8287	bouncing puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
@@ -8174,8 +8174,8 @@
 8300	denatured spinning power pill	0		Effect: "Very Clean Teeth", Effect Duration: 34, Last Available: "2015-06"
 8301	triple-deionized extra-cold-filtered squat pixel star	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 50, Last Available: "2015-06"
 8302	fancy moldy pixel banana	3	crappy	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 15, Last Available: "2015-06"
-8303	weak bad skewed pixel beer	2	decent	Last Available: "2015-06"
-8304	huge yellow puck with a bow on it	0		Free Pull, Last Available: "2015-06"
+8303	bad weak skewed pixel beer	2	decent	Last Available: "2015-06"
+8304	yellow huge puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	chilled enhanced sludgesicle	0		Effect: "Net Tea", Effect Duration: 60
 8307	concentrated super-chilled &Uuml;berraschthexengebr&auml;u	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 43
@@ -8199,7 +8199,7 @@
 8325	galvanized adjusted triple-energized blue coal contact lenses	0		Effect: "White Blooded", Effect Duration: 60
 8326	triple-polarized conjured ice cream	0		Effect: "Altered Wavelengths", Effect Duration: 22
 8327	deionized Iceberglar scarf	0		Effect: "You Know What's Up", Effect Duration: 37
-8328	moist blurry olive icy hairspray	0		Effect: "Good Karma", Effect Duration: 58
+8328	moist olive blurry icy hairspray	0		Effect: "Good Karma", Effect Duration: 58
 8329	dry altered tarnished smellbook	0		Effect: "What's That Smell?", Effect Duration: 40
 8330	adjusted nitrogenated dry spinning assassin's cheese knife	0		Effect: "Ripping, Dripping", Effect Duration: 60
 8331	triple-frozen filthy armor	0		Effect: "Spiro Gyro", Effect Duration: 67
@@ -8212,7 +8212,7 @@
 8338	irradiated wobbly Leonard's glasses	0		Effect: "Fishy Fortification", Effect Duration: 32
 8339	double-Vulcanized double-deionized tumbling warehouse walkie-talkie	0		Effect: "Creepin' Up on You", Effect Duration: 63
 8340	dry modified denatured wobbly janitor's mop	0		Effect: "Dexteri Tea", Effect Duration: 32
-8341	cold-filtered triple-flattened bouncing huge warehouse clerk's glasses	0		Effect: "Jammin'", Effect Duration: 26
+8341	cold-filtered triple-flattened huge bouncing warehouse clerk's glasses	0		Effect: "Jammin'", Effect Duration: 26
 8342	pressed denatured baloney rotgut	0		Effect: "Chalked-Up Teeth", Effect Duration: 39
 8343	altered ionized carton of gaspers	0		Effect: "Texas Elegance", Effect Duration: 26
 8344	nitrogenated bronze polish	0		Effect: "Ripping, Dripping", Effect Duration: 57
@@ -8231,21 +8231,21 @@
 8357	irradiated blinking radioactive spider venom	0		Effect: "Red Around the Gills", Effect Duration: 16
 8358	unsweetened x-ray mirror	0		Effect: "Thought", Effect Duration: 69
 8359	deionized nitrogenated warmed cyan huge wrestling mask	0		Effect: "Hare-o-dynamic", Effect Duration: 64
-8360	frozen purple blurry hawkface potion	0		Effect: "White-boy Angst", Effect Duration: 24
+8360	frozen blurry purple hawkface potion	0		Effect: "White-boy Angst", Effect Duration: 24
 8361	enhanced bouncing child-sized dracula cloak	0		Effect: "Locks Like the Raven", Effect Duration: 33
 8362	pressed warmed devil-summoning hat	0		Effect: "Aloofah", Effect Duration: 23
-8363	unsweetened nitrogenated blurry pulsating shopkeeper beard	0		Effect: "Bubblin' Rage", Effect Duration: 24
+8363	unsweetened nitrogenated pulsating blurry shopkeeper beard	0		Effect: "Bubblin' Rage", Effect Duration: 24
 8364	vacuum-sealed spinning alien autoautopsy kit	0		Effect: "Icy Composition", Effect Duration: 44
 8365	galvanized polymerized novelty fruit hat	0		Effect: "Space Tripping", Effect Duration: 21
 8366	energized pressed deionized bouncing invisibility cream	0		Effect: "Rotten Memories", Effect Duration: 67
 8367	wet handful of stubble	0		Effect: "Virgo Rising", Effect Duration: 53
-8368	concentrated non-nitrogenated cold-filtered blinking gray blurry garbage juice slurpee	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 22
+8368	concentrated non-nitrogenated cold-filtered gray blurry blinking garbage juice slurpee	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 22
 8369	wet double-pickled green plunge-leg	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 60
 8370	improved funky eyepatch	0		Effect: "Hot Blooded", Effect Duration: 61
 8371	dry blinking red bucket of fish juice	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 51
 8372	improved galvanized flashy pirate dreadlocks	0		Effect: "Crimbo Epiphany", Effect Duration: 41
-8373	moist alkaline ghostly spinning captured boozles	0		Effect: "Hammertime", Effect Duration: 40
-8374	frozen frozen jittery teal drinks tray	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 40
+8373	moist alkaline spinning ghostly captured boozles	0		Effect: "Hammertime", Effect Duration: 40
+8374	frozen frozen teal jittery drinks tray	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 40
 8375	oxidized eyebrow lifter	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 20
 8376	submarine	0		Last Available: "2015-06"
 8377	small toothsome pixel lemon	2	awesome	Last Available: "2015-06"
@@ -8259,7 +8259,7 @@
 8385	cubic zirconia	0		Last Available: "2015-07"
 8386	spinning valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
-8388	blue blurry mana	0		Last Available: "2015-07"
+8388	blurry blue mana	0		Last Available: "2015-07"
 8389	jittery mana	0		Last Available: "2015-07"
 8390	green mana	0		Last Available: "2015-07"
 8391	bouncing mana	0		Last Available: "2015-07"
@@ -8280,7 +8280,7 @@
 8406	wobbly savory dry noodles	0		
 8407	bland massive mirror pestopiary	7	decent	
 8408	modified flattened ectoplasmic orbs	0		Effect: "Frozen Hands", Effect Duration: 17
-8409	enchanted decent miniature crudles	2	good	Effect: "Holiday Disappointment", Effect Duration: 35
+8409	enchanted miniature decent crudles	2	good	Effect: "Holiday Disappointment", Effect Duration: 35
 8410	flavorless agnolotti arboli	4	decent	
 8411	moldy spaghetti with ghost balls	3	crappy	
 8412	stale succulent marrow	3	decent	
@@ -8288,7 +8288,7 @@
 8414	snack-sized moldy blinking fusilli marrownarrow	2	crappy	
 8415	rotten suggestive strozzapreti	3	crappy	
 8416	teal Mountain Stream gastrique	0		
-8417	thick moldy narrow Mt. McLargeHuge oyster	5	crappy	
+8417	moldy thick narrow Mt. McLargeHuge oyster	5	crappy	
 8418	oyster sauce	0		
 8419	big toothsome huge linguini immondizia bianco	5	awesome	
 8420	bland blurry shells a la shellfish	3	decent	
@@ -8327,14 +8327,14 @@
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
-8456	pulsating cyan upside-down crystalline light bulb	0		Last Available: "2015-08"
+8456	upside-down pulsating cyan crystalline light bulb	0		Last Available: "2015-08"
 8457	shaking broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	rosewater-soaked wizardly high-temperature mining mask	0		Mysticality: +25, Stench Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	rosewater-soaked wizardly high-temperature mining mask	0		Mysticality: +25, Stench Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	flame-retardant fireproof megaphone of dire peril	0		Weapon Damage: +20, Hot Resistance: +1, Last Available: "2015-08"
 8460	normal mineapple	3	good	Last Available: "2015-08"
-8461	practically non-alcoholic tolerable Gold Velvet&trade; whiskey	1	good	Last Available: "2015-08"
+8461	tolerable practically non-alcoholic Gold Velvet&trade; whiskey	1	good	Last Available: "2015-08"
 8462	blurry SMOOCH soda	1	EPIC	Last Available: "2015-08"
-8463	decent tiny smelted roe	1	good	Last Available: "2015-08"
+8463	tiny decent smelted roe	1	good	Last Available: "2015-08"
 8464	perfectly mixed watered-down bouncing lavawater	2	EPIC	Last Available: "2015-08"
 8465	ionized basaltamander tongue	0		Effect: "Patched In", Effect Duration: 20, Last Available: "2015-08"
 8466	Annie Oakley's savvy lavalarva of Leguizamo	0		Mysticality Percent: +20, Critical Hit Percent: +20, Monster Level: +20, Last Available: "2015-08"
@@ -8349,10 +8349,10 @@
 8475	lousy yellow asbestos thermos	4	decent	Last Available: "2015-08"
 8476	pressed fuchsia shaking liquid rhinestones	0		Effect: "New and Improved", Effect Duration: 17, Last Available: "2015-08"
 8477	adequate super-sized disco biscuit	5	good	Last Available: "2015-08"
-8478	acceptable watered-down teal upside-down Quaatorade&trade;	2	good	Last Available: "2015-08"
-8479	pulsating maroon frightening Van der Graaf biker's hat of mayonnaise	0		Spooky Damage: +5, Sleaze Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk", Last Available: "2015-08"
-8480	dangerous Da Vinci's feathered headdress of the sweet-tooth	0		Experience (Mysticality): +5, Weapon Damage: +10, Candy Drop: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	lime green greasy supercharged banded electrician's hardhat	0		Damage Absorption: +100, Maximum MP Percent: +30, Sleaze Spell Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
+8478	watered-down acceptable upside-down teal Quaatorade&trade;	2	good	Last Available: "2015-08"
+8479	pulsating maroon frightening Van der Graaf biker's hat of mayonnaise	0		Spooky Damage: +5, Sleaze Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-08", Familiar Effect: "atk"
+8480	dangerous Da Vinci's feathered headdress of the sweet-tooth	0		Experience (Mysticality): +5, Weapon Damage: +10, Candy Drop: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	lime green greasy supercharged banded electrician's hardhat	0		Damage Absorption: +100, Maximum MP Percent: +30, Sleaze Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	green The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	blinking airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	jittery Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	wobbly Oprah's smooth velvet pants	0		Maximum MP Percent: +50, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	wobbly Oprah's smooth velvet pants	0		Maximum MP Percent: +50, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	resourceful smooth velvet shirt	0		Maximum MP: +50, Last Available: "2015-08"
 8492	huge personal trainer's smooth velvet hat	0		Experience Percent (Muscle): +10, Last Available: "2015-08"
 8493	smooth velvet pocket square of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2015-08"
@@ -8369,7 +8369,7 @@
 8495	baleful smooth velvet hanky	0		Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8496	blue MacGyver's crafty The One Mood Ring	0		Maximum MP: 110, Single Equip, Last Available: "2015-08"
 8497	ghostly gray Mr. Choch's bone	0		Last Available: "2015-08"
-8498	blinking skewed Mr. Cheeng's 'stache	0		Last Available: "2015-08"
+8498	skewed blinking Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	huge Saturday Night thermometer	0		Last Available: "2015-08"
 8500	shaking lime green the tongue of Smimmons	0		Last Available: "2015-08"
 8501	narrow Raul's guitar pick	0		Last Available: "2015-08"
@@ -8391,13 +8391,13 @@
 8517	stiffened SMOOCH bracers of doom	0		Damage Reduction: 1, Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8518	energetic SMOOCH kneepads	0		Maximum MP Percent: +20, Single Equip, Last Available: "2015-08"
 8519	green family-friendly SMOOCH spaulders	0		Sleaze Resistance: +1, Single Equip, Last Available: "2015-08"
-8520	blurry Tesla therapeutic SMOOCH codpiece	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	blurry Tesla therapeutic SMOOCH codpiece	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	pulsating pulsating sharpshooter's SMOOCH breastplate	0		Critical Hit Percent: +10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	blue fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	diet decent lava cake	1	good	Last Available: "2015-08"
-8526	big bland spinning pink slime	5	decent	
+8526	bland big spinning pink slime	5	decent	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	flavorless bite-sized maroon blinking devil hair pasta	1	decent	
@@ -8414,14 +8414,14 @@
 8541	drug cocktail sauce	0		
 8542	adequate Fettris	3	good	
 8543	bland skewed fusillocybin	3	decent	
-8544	tiny spoiled prescription noodles	1	crappy	
+8544	spoiled tiny prescription noodles	1	crappy	
 8545	compressed blood-drive sticker	1	good	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 40
 8546	galvanized improved teal upside-down bag of grain	0		Effect: "Egged On", Effect Duration: 62
 8547	concentrated blinking pocket maze	0		Effect: "Rosewater Mark", Effect Duration: 25
 8548	ionized enhanced shady shades	0		Effect: "Discomfited", Effect Duration: 66
 8549	alkaline aerosolized squeaky toy rose	0		Effect: "Can Has Cyborger", Effect Duration: 37
 8550	normal weird gazelle steak	3	good	
-8551	rotten gigantic sausage without a cause	7	crappy	
+8551	gigantic rotten sausage without a cause	7	crappy	
 8552	colloidal extra-galvanized face paint	0		Effect: "Rampage!", Effect Duration: 24
 8553	watered-down acceptable emergency margarita	2	good	
 8554	practically non-alcoholic smooth vintage smart drink	1	awesome	
@@ -8429,15 +8429,15 @@
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	galvanized nitrogenated Wickers bar	0		Effect: "Swimming Head", Effect Duration: 13
-8559	cold-filtered yellow narrow bakelite-covered bacon	0		Effect: "Impregnably Delicious", Effect Duration: 30
+8559	cold-filtered narrow yellow bakelite-covered bacon	0		Effect: "Impregnably Delicious", Effect Duration: 30
 8560	flattened Aerheads	0		Effect: "Super-Charged", Effect Duration: 49
 8561	extra-deionized double-warmed Wrotz	0		Effect: "Bureaucratized", Effect Duration: 59
 8562	quadruple-anodized upside-down Gabarbar	0		Effect: "Kindly Resolve", Effect Duration: 36
-8563	polarized skewed lime green fiberglass insulation	0		Effect: "Flamingly Floral", Effect Duration: 59
+8563	polarized lime green skewed fiberglass insulation	0		Effect: "Flamingly Floral", Effect Duration: 59
 8564	maroon shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	mirror blinking Temple Grandin's dangerous barrel lid of horror	0		Weapon Damage: +10, Familiar Weight: +7, Spooky Spell Damage: +25, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	teal squat wool barrel hoop earring of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2015-09"
-8567	ghostly vibrating Fonzie's bankruptcy barrel of the brazier	0		Experience (Moxie): +1, Maximum MP Percent: +10, Hot Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	ghostly vibrating Fonzie's bankruptcy barrel of the brazier	0		Experience (Moxie): +1, Maximum MP Percent: +10, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8475,7 +8475,7 @@
 8602	colloidal tumbling cuppa Yet tea	0		Effect: "A Contender", Effect Duration: 40, Last Available: "2015-09"
 8603	denatured magnetized cyan cuppa Boo tea	0		Effect: "There Is A Spoon", Effect Duration: 12, Last Available: "2015-09"
 8604	dry cuppa Nas tea	0		Effect: "Tingly Elbows", Effect Duration: 37, Last Available: "2015-09"
-8605	deionized nitrogenated narrow lime green cuppa Improprie tea	0		Effect: "White-boy Angst", Effect Duration: 18, Last Available: "2015-09"
+8605	deionized nitrogenated lime green narrow cuppa Improprie tea	0		Effect: "White-boy Angst", Effect Duration: 18, Last Available: "2015-09"
 8606	polymerized cuppa Frost tea	0		Effect: "Mitre Cut", Effect Duration: 65, Last Available: "2015-09"
 8607	extra-colloidal cuppa Toast tea	0		Effect: "Sweet, Nuts", Effect Duration: 67, Last Available: "2015-09"
 8608	anodized cuppa Net tea	0		Effect: "Good Karma", Effect Duration: 28, Last Available: "2015-09"
@@ -8495,14 +8495,14 @@
 8622	anodized chilled double-oxidized cuppa Mediocri tea	0		Effect: "Sugary Tongue", Effect Duration: 23, Last Available: "2015-09"
 8623	super-concentrated aerosolized cuppa Loyal tea	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 33, Last Available: "2015-09"
 8624	vaporized cuppa Activi tea	1	good	Last Available: "2015-09"
-8625	boiled fuchsia mirror cuppa Cruel tea	1		Effect: "Hypercubed", Effect Duration: 25, Last Available: "2015-09"
+8625	boiled mirror fuchsia cuppa Cruel tea	1		Effect: "Hypercubed", Effect Duration: 25, Last Available: "2015-09"
 8626	chilled galvanized cuppa Alacri tea	0		Effect: "Flexibili Tea", Effect Duration: 62, Last Available: "2015-09"
 8627	modified cuppa Vitali tea	0		Effect: "Crusty Head", Effect Duration: 63, Last Available: "2015-09"
 8628	extra-aerosolized modified red cuppa Mana tea	0		Effect: "Stuck That Way", Effect Duration: 29, Last Available: "2015-09"
 8629	boiled wet gray tumbling cuppa Monstrosi tea	0		Effect: "Heart of Lavender", Effect Duration: 46, Last Available: "2015-09"
 8630	concentrated upside-down cuppa Twen tea	0		Effect: "The Power of LOV", Effect Duration: 20, Last Available: "2015-09"
 8631	frozen quantum shaking cuppa Gill tea	0		Effect: "Crotchety, Pining", Effect Duration: 32, Last Available: "2015-09"
-8632	deionized extra-galvanized double-boiled blue spinning cuppa Uncertain tea	0		Effect: "Sepia Tan", Effect Duration: 40, Last Available: "2015-09"
+8632	deionized extra-galvanized double-boiled spinning blue cuppa Uncertain tea	0		Effect: "Sepia Tan", Effect Duration: 40, Last Available: "2015-09"
 8633	lime green cuppa Voraci tea	0		Last Available: "2015-09"
 8634	ghostly cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	twirling cuppa Royal tea	0		Last Available: "2015-09"
@@ -8511,7 +8511,7 @@
 8638	lightning-fast grievous Royal scepter of wisdom	0		Mysticality: +15, Weapon Damage Percent: +50, Initiative: +40, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	pulsating Ghost Dog Chow	0		Last Available: "2015-10"
-8641	miniature flavorless skewed bowl of eyeballs	2	decent	Last Available: "2015-10"
+8641	flavorless miniature skewed bowl of eyeballs	2	decent	Last Available: "2015-10"
 8642	moldy small special bowl of mummy guts	2	crappy	Effect: "Magically Fingered", Effect Duration: 40, Last Available: "2015-10"
 8643	decent tumbling bowl of maggots	3	good	Last Available: "2015-10"
 8644	mediocre blood and blood	3	decent	Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	fuchsia upside-down ear poison	0		
 8653	stink-penny	0		
 8654	toasty strapping hawk of the detective	0		Muscle: +5, Hot Damage: +5, Item Drop: +20
-8655	rotten bite-sized special wobbly hamlet sandwich	1	crappy	Effect: "Abyssal Sweat", Effect Duration: 30
+8655	special rotten bite-sized wobbly hamlet sandwich	1	crappy	Effect: "Abyssal Sweat", Effect Duration: 30
 8656	Othello's military jacket of the ox	0		Muscle: +20
 8657	Samson's Othello's dagger	0		Experience (Muscle): +5, Single Equip
 8658	ghostly Othello's handkerchief of Flo-Jo	0		Initiative: +100, Single Equip
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	nippy ghostly dagger of mayonnaise of Flo-Jo	0		Cold Damage: +10, Sleaze Spell Damage: +50, Initiative: +100
-8663	lousy watered-down ghost beer	2	decent	
+8663	watered-down lousy ghost beer	2	decent	
 8664	dangerous Othello set	0		Weapon Damage: +10
 8665	tumbling rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8547,7 +8547,7 @@
 8674	spinning teal mirror airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	pressed ghostly shoulder-warming lotion	0		Effect: "Horrid, Torrid", Effect Duration: 56, Last Available: "2015-11"
-8677	flavorless special iceberg lettuce	4	decent	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2015-11"
+8677	special flavorless iceberg lettuce	4	decent	Effect: "Holiday Disappointment", Effect Duration: 10, Last Available: "2015-11"
 8678	practically non-alcoholic artisanal ice wine	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8679	ghostly perfumed nippy Wal-Mart snowglobe of chilblains	0		Cold Damage: 35, Stench Resistance: +5, Last Available: "2015-11"
 8680	blurry manspreader's quilted personal trainer's Wal-Mart nametag	0		Experience Percent (Muscle): +10, Damage Absorption: +40, Monster Level: +10, Last Available: "2015-11"
@@ -8558,20 +8558,20 @@
 8685	yellow Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	olive perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	bellhop's hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	bad ice porter	4	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	bellhop's hat of James Dean	0		Experience (Moxie): +3, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	bad ice porter	4	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	improved nitrogenated exotic travel brochure	0		Effect: "The Power of Positive Thinking", Effect Duration: 22, Last Available: "2015-11"
 8691	lime green bag of foreign bribes	0		Last Available: "2015-11"
 8692	triple-diffused galvanized shampoo-conditioner	0		Effect: "Super-Charged", Effect Duration: 68, Last Available: "2015-11"
 8693	narrow hotel minibar key	0		Last Available: "2015-11"
-8694	upside-down jittery ice hotel bell	0		Last Available: "2015-11"
+8694	jittery upside-down ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered olive medicinal herbs	1		Last Available: "2016-01"
-8697	decent immense pulsating ice rice	7	good	Last Available: "2016-01"
+8697	immense decent pulsating ice rice	7	good	Last Available: "2016-01"
 8698	drinkable jittery iced plum wine	4	good	Last Available: "2016-01"
 8699	inspector's energetic arcane researcher's training belt	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Item Drop: +15, Single Equip, Last Available: "2016-01"
 8700	resourceful shellacked hardened training legwarmers	0		Damage Reduction: 20, Maximum MP: +50, Single Equip, Last Available: "2016-01"
-8701	family-friendly sharpshooter's training helmet of the boozehound	0		Critical Hit Percent: +10, Sleaze Resistance: +1, Booze Drop: +100, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	family-friendly sharpshooter's training helmet of the boozehound	0		Critical Hit Percent: +10, Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	spinning training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8589,7 +8589,7 @@
 8716	pickled abstraction: certainty	1		Effect: "Jammin'", Effect Duration: 40, Last Available: "2015-12"
 8717	vaporized teal abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	moldy bite-sized VYKEA meatballs	1	crappy	Last Available: "2015-11"
+8719	bite-sized moldy VYKEA meatballs	1	crappy	Last Available: "2015-11"
 8720	weak lousy VYKEA mead	2	decent	Last Available: "2015-11"
 8721	dry yellow VYKEA woadpaint	0		Effect: "You Know Where to Go", Effect Duration: 21, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8601,17 +8601,17 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	huge lard-coated dog trainer's VYKEA hex key of chilblains	0		Experience (familiar): +1, Cold Damage: +25, Sleaze Spell Damage: +25, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	normal gigantic jittery tin of submardines	8	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	drinkable strong bottle of norwhiskey	5	good	Last Available: "2015-11"
+8731	normal gigantic jittery tin of submardines	8	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	strong drinkable bottle of norwhiskey	5	good	Last Available: "2015-11"
 8733	mixed wobbly octolus oculus	1	good	Last Available: "2015-11"
 8734	fuchsia twirling manspreader's resourceful smartaleck's sardine can key	0		Moxie Percent: +30, Maximum MP: +50, Monster Level: +10, Last Available: "2015-11"
-8735	Jack Frost's Rosewater's norwhal helmet of the storm	0		Mysticality Percent: +30, Maximum MP Percent: +40, Cold Spell Damage: +50, Familiar Effect: "atk", Last Available: "2015-11"
+8735	Jack Frost's Rosewater's norwhal helmet of the storm	0		Mysticality Percent: +30, Maximum MP Percent: +40, Cold Spell Damage: +50, Last Available: "2015-11", Familiar Effect: "atk"
 8736	upside-down MacGyver's beefy octolus-skin cloak of the glutton	0		Muscle: +10, Maximum MP: +100, Food Drop: +100, Last Available: "2015-11"
-8737	weak lousy perfect cosmopolitan	2	decent	Last Available: "2015-11"
+8737	lousy weak perfect cosmopolitan	2	decent	Last Available: "2015-11"
 8738	perfectly mixed perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	enchanted extra-dry tolerable perfect dark and stormy	5	good	Effect: "Influence of Sphere", Effect Duration: 50, Last Available: "2015-11"
+8739	tolerable enchanted extra-dry perfect dark and stormy	5	good	Effect: "Influence of Sphere", Effect Duration: 50, Last Available: "2015-11"
 8740	aged skewed perfect mimosa	3	awesome	Last Available: "2015-11"
-8741	acceptable watered-down squat perfect old-fashioned	2	good	Last Available: "2015-11"
+8741	watered-down acceptable squat perfect old-fashioned	2	good	Last Available: "2015-11"
 8742	bad perfect paloma	3	decent	Last Available: "2015-11"
 8743	concentrated That 70s Cologne	0		Effect: "Scavengers Scavenging", Effect Duration: 26, Last Available: "2015-11"
 8744	wet aerosolized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 69, Last Available: "2015-11"
@@ -8621,7 +8621,7 @@
 8748	airplane tattoo	0		Last Available: "2015-11"
 8749	aerosolized fuchsia Deep Machine Tunnels snowglobe	0		Effect: "Boschface", Effect Duration: 30, Last Available: "2015-12"
 8750	quadruple-vacuum-sealed Vulcanized hemp candy necklace	0		Effect: "Banono", Effect Duration: 56, Last Available: "2015-12"
-8751	Vulcanized shaking mirror communal gobstopper	0		Effect: "Crotchety, Pining", Effect Duration: 17, Last Available: "2015-12"
+8751	Vulcanized mirror shaking communal gobstopper	0		Effect: "Crotchety, Pining", Effect Duration: 17, Last Available: "2015-12"
 8752	adequate Crimbo salad	4	good	Last Available: "2015-12"
 8753	bite-sized stale bread line	1	decent	Last Available: "2015-12"
 8754	delicious pulsating bark rootbeer	3	awesome	Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	mirror reindeer hammer of the blizzard	0		Cold Spell Damage: +25, Last Available: "2015-12"
 8783	skewed Samson's elf ploughshare	0		Experience (Muscle): +5, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	gray huge faded protest sign	0		Last Available: "2015-12"
 8788	blinking nasty-smelling moss	0		Last Available: "2015-12"
@@ -8663,12 +8663,12 @@
 8791	family-friendly reindeer sickle	0		Sleaze Resistance: +1, Last Available: "2015-12"
 8792	blurry face paint	0		Free Pull, Last Available: "2015-12"
 8793	spinning face paint	0		Free Pull, Last Available: "2015-12"
-8794	upside-down squat The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
+8794	squat upside-down The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	yellow Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	yellow plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
-8799	cyan tumbling bat-o-mite	0		Last Available: "2017-01"
+8799	tumbling cyan bat-o-mite	0		Last Available: "2017-01"
 8800	fuchsia ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
@@ -8683,7 +8683,7 @@
 8811	spinning red confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
-8814	narrow huge Bat-Aid&trade; bandage	0		Last Available: "2017-01"
+8814	huge narrow Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	flavorless snack-sized Kudzu salad	2	decent	Last Available: "2016-12"
 8817	distilled cyan Mansquito Serum	1		Last Available: "2016-12"
@@ -8693,17 +8693,17 @@
 8821	high-proof lousy squat The Mad Liquor	9	decent	Last Available: "2016-12"
 8822	hand-crafted upside-down Doc Clock's thyme cocktail	4	super EPIC	Last Available: "2016-12"
 8823	small normal Mr. Burnsger	2	good	Last Available: "2016-12"
-8824	powdered squat wobbly The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
+8824	powdered wobbly squat The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	blinking Tesla groovy The Jokester's gun of the brute	0		Muscle Percent: +30, Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	pulsating upside-down hardy padded extremely unsafe The Jokester's wig	0		Weapon Damage Percent: +100, Damage Absorption: +20, Maximum HP: +50, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8826	pulsating upside-down hardy padded extremely unsafe The Jokester's wig	0		Weapon Damage Percent: +100, Damage Absorption: +20, Maximum HP: +50, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	green prompt savvy strapping The Jokester's pants	0		Muscle: +5, Mysticality Percent: +20, Adventures: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
-8828	tarnished twirling cyan Jokester makeup	0		Effect: "Abominably Slippery", Effect Duration: 45, Last Available: "2016-12"
+8828	tarnished cyan twirling Jokester makeup	0		Effect: "Abominably Slippery", Effect Duration: 45, Last Available: "2016-12"
 8829	olive replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	triple-warmed pickled robin's egg	0		Effect: "Shawarma Warm War", Effect Duration: 24, Last Available: "2016-12"
-8834	small bland robin flan	2	decent	Last Available: "2016-12"
+8834	bland small robin flan	2	decent	Last Available: "2016-12"
 8835	bad spirit-forward bouncing robin nog	5	decent	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
@@ -8727,7 +8727,7 @@
 8855	pulsating nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
 8857	shaking nugget of nicksilver	0		Last Available: "2016-02"
-8858	fuchsia pulsating nugget of ticksilver	0		Last Available: "2016-02"
+8858	pulsating fuchsia nugget of ticksilver	0		Last Available: "2016-02"
 8859	Jeselnik's quicksilver ring	0		Sleaze Damage: +25, Single Equip, Last Available: "2016-02"
 8860	perfumed thicksilver ring of the sewer of bravery	0		Stench Damage: +25, Spooky Resistance: +5, Stench Resistance: +5, Single Equip, Last Available: "2016-02"
 8861	flame-retardant scandalous coward's wicksilver ring	0		Monster Level: -20, Sleaze Damage: +5, Hot Resistance: +1, Single Equip, Last Available: "2016-02"
@@ -8747,7 +8747,7 @@
 8875	inspector's family-friendly forbidden Shrub's Premium Baked Beans	0		Spell Damage Percent: +50, Sleaze Resistance: +1, Item Drop: +15, Last Available: "2016-02"
 8876	flavorless plate of Heimz Fortified Kidney Beans	3	decent	Last Available: "2016-02"
 8877	rotten jittery plate of Tesla's Electroplated Beans	4	crappy	Last Available: "2016-02"
-8878	half-sized toothsome plate of Mixed Garbanzos and Chickpeas	2	awesome	Last Available: "2016-02"
+8878	toothsome half-sized plate of Mixed Garbanzos and Chickpeas	2	awesome	Last Available: "2016-02"
 8879	rotten plate of Hellfire Spicy Beans	4	crappy	Last Available: "2016-02"
 8880	stale blurry plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
 8881	thick moldy plate of World's Blackest-Eyed Peas	5	crappy	Last Available: "2016-02"
@@ -8756,9 +8756,9 @@
 8884	massive normal plate of Val-U Brand Every Bean Salad	9	good	Last Available: "2016-02"
 8885	rotten plate of Shrub's Premium Baked Beans	3	crappy	Last Available: "2016-02"
 8886	skewed lard-coated Da Vinci's Fancy Jeff's pocket square	0		Experience (Mysticality): +5, Sleaze Spell Damage: +25, Last Available: "2016-02"
-8887	ribald Daisy's unclean bloomers of the storm of the detective	0		Maximum MP Percent: +40, Sleaze Damage: +10, Item Drop: +20, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	ribald Daisy's unclean bloomers of the storm of the detective	0		Maximum MP Percent: +40, Sleaze Damage: +10, Item Drop: +20, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	bouncing Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	family-friendly personal trainer's smartaleck's Amoon-Ra Cowtep's nemes	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	family-friendly personal trainer's smartaleck's Amoon-Ra Cowtep's nemes	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Sleaze Resistance: +1, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	wobbly wobbly Glenn's dice	0		Last Available: "2016-02"
 8891	knitted wool steel-toed savvy Former Sheriff Dan's tin star of mayonnaise	0		Mysticality Percent: +20, Damage Reduction: 9, Sleaze Spell Damage: +50, Cold Resistance: 4, Last Available: "2016-02"
 8892	gray El Vibrato restraints	0		Last Available: "2016-02"
@@ -8779,7 +8779,7 @@
 8907	oxidized ionized blue half-digested coal	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 66, Last Available: "2016-02"
 8908	dry tightly-wound spine	0		Effect: "Human-Machine Hybrid", Effect Duration: 63, Last Available: "2016-02"
 8909	miniature stale rotting beefsteak	2	decent	Last Available: "2016-02"
-8910	artisanal strong firemilk	5	EPIC	Last Available: "2016-02"
+8910	strong artisanal firemilk	5	EPIC	Last Available: "2016-02"
 8911	diffused bouncing spidercow eye-cluster	0		Effect: "It's Electric!", Effect Duration: 17, Last Available: "2016-02"
 8912	vaporized purple jittery moomy dust	1		Last Available: "2016-02"
 8913	skewed reassuring wholesome western-style skinning knife	0		Maximum HP Percent: +10, Spooky Resistance: +1, Last Available: "2016-02"
@@ -8867,12 +8867,12 @@
 8995	corrupted upside-down Greek fire	0		Effect: "Ermine Eyes", Effect Duration: 21, Last Available: "2016-03"
 8996	tumbling double-paned toasty coward's careful arcane researcher's ox-head shield	0		Experience Percent (Mysticality): +10, Monster Level: -30, Hot Damage: +5, Cold Resistance: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	inspector's personal trainer's dented scepter of the ox of the wise owl of horror	0		Muscle: +20, Mysticality: +20, Experience Percent (Muscle): +10, Spooky Spell Damage: +25, Item Drop: +15, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	spinning blinking up-at-dawn Usain Bolt's executive vibrating very pointy crown of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Meat Drop: +40, Initiative: +80, Adventures: +5, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	spinning blinking up-at-dawn Usain Bolt's executive vibrating very pointy crown of doom	0		Maximum MP Percent: +10, Spooky Spell Damage: +50, Meat Drop: +40, Initiative: +80, Adventures: +5, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	coward's deadly Sinatra's battle broom of Calamity Jane of courage	0		Experience (Moxie): +5, Weapon Damage: +5, Critical Hit Percent: +15, Monster Level: -20, Spooky Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	wobbly wool cool weightlifter's carpe of Calamity Jane	0		Muscle: +15, Moxie: +5, Critical Hit Percent: +15, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9002	skewed frightening ruddy codpiece of the brute of temperance	0		Muscle Percent: +30, Maximum HP Percent: +40, Spooky Damage: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	blurry brainy troutsers of Gandalf of the blizzard of doom	0		Mysticality: +5, Spell Critical Percent: +20, Cold Spell Damage: +25, Spooky Spell Damage: +50, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	blurry brainy troutsers of Gandalf of the blizzard of doom	0		Mysticality: +5, Spell Critical Percent: +20, Cold Spell Damage: +25, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	knitted lion tamer's Oprah's bass clarinet of mayonnaise	0		Maximum MP Percent: +50, Experience (familiar): +2, Sleaze Spell Damage: +50, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9005	upside-down greasy frosty Annie Oakley's banded fish hatchet	0		Damage Absorption: +100, Critical Hit Percent: +20, Cold Spell Damage: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	fireproof Temple Grandin's clever wicked tunac	0		Spell Damage: +5, Maximum MP: +20, Familiar Weight: +7, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	mirror internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	yummy huge gallon of milk	10	awesome	Last Available: "2016-05"
+9021	huge yummy gallon of milk	10	awesome	Last Available: "2016-05"
 9022	tumbling print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8899,9 +8899,9 @@
 9027	up-at-dawn Lo Pan's wholesome First Post shirt - Cir Senam	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Adventures: +5, Last Available: "2016-05"
 9028	narrow high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	adequate tiny star salad	1	good	
+9030	tiny adequate star salad	1	good	
 9031	green Thwaitgold moth statuette	0		
-9032	miniature toothsome fancy jittery bowl of Tastee-Wheet&trade;	2	awesome	Effect: "Wet Rub", Effect Duration: 30
+9032	miniature fancy toothsome jittery bowl of Tastee-Wheet&trade;	2	awesome	Effect: "Wet Rub", Effect Duration: 30
 9033	blinking Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	narrow tumbling Source essence	0		Last Available: "2016-06"
 9035	miniature spoiled browser cookie	2	crappy	Last Available: "2016-06"
@@ -8913,12 +8913,12 @@
 9041	twirling Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	shaking Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
-9044	spinning cyan Source terminal DRAM chip	0		Last Available: "2016-06"
+9044	cyan spinning Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	mirror Source terminal ASHRAM chip	0		Last Available: "2016-06"
-9049	fuchsia spinning Source terminal SCRAM chip	0		Last Available: "2016-06"
+9049	spinning fuchsia Source terminal SCRAM chip	0		Last Available: "2016-06"
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	blurry Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
@@ -8963,13 +8963,13 @@
 9091	occult Mr. Screege's spectacles	0		Spell Damage Percent: +25, Single Equip, Last Available: "2016-08"
 9092	ruddy studded Spookyraven signet of terror	0		Damage Absorption: +80, Maximum HP Percent: +40, Spooky Spell Damage: +10, Single Equip, Last Available: "2016-08"
 9093	arcane researcher's tie-dyed fannypack of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Single Equip, Last Available: "2016-08"
-9094	mirror fuchsia lightning-fast Temple Grandin's burnt snowpants	0		Familiar Weight: +7, Initiative: +40, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	mirror fuchsia lightning-fast Temple Grandin's burnt snowpants	0		Familiar Weight: +7, Initiative: +40, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	inspector's standards and practices guide	0		Item Drop: +15, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	spinning wobbly auspicious nasty lion tamer's Carpathian longsword	0		Experience (familiar): +2, Stench Damage: +5, Item Drop: +10, Last Available: "2016-08"
 9097	extremely unsafe Liam's mail of mayonnaise of the cheetah	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +50, Initiative: +60, Last Available: "2016-08"
 9098	gray Sherlock's studded thinker's Unfortunato's foolscap	0		Mysticality: +10, Damage Absorption: +80, Item Drop: +25, Last Available: "2016-08"
 9099	Thwaitgold cockroach statuette	0		
-9100	mirror twirling rad	0		
+9100	twirling mirror rad	0		
 9101	purification tablet	0		
 9102	curative Wrist-Boy	0		HP Regen Min: 3, HP Regen Max: 5
 9103	wobbly Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
@@ -8987,15 +8987,15 @@
 9115	anodized double-activated Drunk Uncles holo-record	0		Effect: "Gr8ness", Effect Duration: 57
 9116	huge time residue	0		Last Available: "2016-09"
 9117	repaid diaper of Calamity Jane	0		Critical Hit Percent: +15
-9118	maroon jittery shaking Riker's Search History	0		Last Available: "2016-09"
-9119	delicious extra-dry blinking blinking Shot of Kardashian Gin	5	awesome	Last Available: "2016-09"
+9118	shaking maroon jittery Riker's Search History	0		Last Available: "2016-09"
+9119	extra-dry delicious blinking blinking Shot of Kardashian Gin	5	awesome	Last Available: "2016-09"
 9120	twirling energetic Unstable Pointy Ears	0		Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2016-09"
 9121	tumbling Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
 9123	blinking School of Hard Knocks Diploma	0		
 9124	ghostly baby bark scorpion	0		
 9125	droppable microphone	0		
-9126	weak mediocre unidentified drink	2	decent	
+9126	mediocre weak unidentified drink	2	decent	
 9127	brawny KoL Con 13 T-shirt of the detective	0		Muscle Percent: +20, Item Drop: +20
 9128	coward's MacGyver's discarded swimming trunks of the wise owl	0		Mysticality: +20, Maximum MP: +100, Monster Level: -20
 9129	irradiated quantum diluted makeup	0		Effect: "Barbecue Saucy", Effect Duration: 60
@@ -9007,30 +9007,30 @@
 9135	smooth ghostly very whiskey	4	awesome	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	jittery li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	fuchsia shaking li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	shaking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	tumbling jittery li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	purple li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	shaking fuchsia li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	shaking li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	tumbling jittery li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	purple li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	dry liquefied hoarded candy wad	0		Effect: "Bureaucratized", Effect Duration: 56, Last Available: "2016-10"
 9147	nitrogenated ghostly Prunets	0		Effect: "Total Protonic Reversal", Effect Duration: 64
 9148	jittery Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	quadruple-energized mirror invisible string	0		Lasts Until Rollover, Effect: "Impregnably Delicious", Effect Duration: 24, Last Available: "2016-10"
 9151	liquefied dry invisible seam ripper	0		Lasts Until Rollover, Effect: "Flagrantly Fragrant", Effect Duration: 20, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	adequate small bouncing raw sweet potato	2	good	Last Available: "2016-11"
 9154	adequate raw beans	3	good	Last Available: "2016-11"
 9155	flavorless raw stuffing	3	decent	Last Available: "2016-11"
 9156	adequate spinning raw cranberry sauce	4	good	Last Available: "2016-11"
-9157	flavorless snack-sized raw turkey	2	decent	Last Available: "2016-11"
-9158	huge normal raw mincemeat	6	good	Last Available: "2016-11"
-9159	jumbo normal raw potato	5	good	Last Available: "2016-11"
-9160	moldy thick special raw gravy	5	crappy	Effect: "Boo Tea", Effect Duration: 20, Last Available: "2016-11"
-9161	big spoiled raw bread	5	crappy	Last Available: "2016-11"
+9157	snack-sized flavorless raw turkey	2	decent	Last Available: "2016-11"
+9158	normal huge raw mincemeat	6	good	Last Available: "2016-11"
+9159	normal jumbo raw potato	5	good	Last Available: "2016-11"
+9160	special thick moldy raw gravy	5	crappy	Effect: "Boo Tea", Effect Duration: 20, Last Available: "2016-11"
+9161	spoiled big raw bread	5	crappy	Last Available: "2016-11"
 9162	dangerous mini-marshmallow dispenser of the blizzard	0		Weapon Damage: +10, Cold Spell Damage: +25, Last Available: "2016-11"
 9163	vibrating studded quilted glass casserole dish	0		Damage Absorption: 120, Maximum MP Percent: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9038,30 +9038,30 @@
 9166	boiled shaking blurry turkey blaster	1		Last Available: "2016-11"
 9167	wobbly rock-hard beefcake's glass pie plate	0		Muscle: +25, Damage Reduction: 12, Last Available: "2016-11"
 9168	squat ghostly shaking potato masher of the wise owl of the storm	0		Mysticality: +20, Maximum MP Percent: +40, Last Available: "2016-11"
-9169	gray twirling gravy boat	0		Last Available: "2016-11"
+9169	twirling gray gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	tiny rotten sweet potatoes	1	crappy	Last Available: "2016-11"
+9171	rotten tiny sweet potatoes	1	crappy	Last Available: "2016-11"
 9172	stale bean casserole	4	decent	Last Available: "2016-11"
 9173	stale miniature baked stuffing	2	decent	Last Available: "2016-11"
-9174	moldy snack-sized cranberry cylinder	2	crappy	Last Available: "2016-11"
+9174	snack-sized moldy cranberry cylinder	2	crappy	Last Available: "2016-11"
 9175	spoiled maroon thanksgiving turkey	3	crappy	Last Available: "2016-11"
 9176	flavorless mince pie	4	decent	Last Available: "2016-11"
 9177	flavorless half-sized mashed potatoes	2	decent	Last Available: "2016-11"
-9178	snack-sized adequate warm gravy	2	good	Last Available: "2016-11"
+9178	adequate snack-sized warm gravy	2	good	Last Available: "2016-11"
 9179	yummy mirror bread roll	4	awesome	Last Available: "2016-11"
 9180	moldy leftovers	3	crappy	Last Available: "2016-11"
-9181	small adequate leftovers sandwich	2	good	Last Available: "2016-11"
-9182	tumbling maroon Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
+9181	adequate small leftovers sandwich	2	good	Last Available: "2016-11"
+9182	maroon tumbling Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	huge megacopia	0		Last Available: "2016-11"
 9185	cyan pilgrim hat	0		Last Available: "2016-11"
-9186	blurry spinning packet of thanksgarden seeds	0		Last Available: "2016-11"
+9186	spinning blurry packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	double-colloidal flattened eldritch concentrate	0		Effect: "On Pins and Needles", Effect Duration: 57, Last Available: "2016-11"
-9192	mediocre watered-down eldritch extract	2	decent	Last Available: "2016-11"
+9192	watered-down mediocre eldritch extract	2	decent	Last Available: "2016-11"
 9193	Usain Bolt's smelly Official Council Aide Pin	0		Stench Spell Damage: +10, Initiative: +80, Last Available: "2016-11"
 9194	practically non-alcoholic drinkable eldritch distillate	1	good	Last Available: "2016-11"
 9195	compressed eldritch essence	1		Last Available: "2016-11"
@@ -9085,17 +9085,17 @@
 9213	Herculean brawny candy necktie of chilblains	0		Muscle Percent: +20, Experience (Muscle): +1, Cold Damage: +25, Single Equip, Last Available: "2016-12"
 9214	executive Van der Graaf Socratic chocolate pocketwatch	0		Experience (Mysticality): +1, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2016-12"
 9215	broken chocolate pocketwatch	0		Last Available: "2016-12"
-9216	maroon ghostly interesting clod of dirt	0		
+9216	ghostly maroon interesting clod of dirt	0		
 9217	squat gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	flavorless animal part cracker	4	decent	Last Available: "2016-12"
-9220	bad extra-dry bouncing gingerbread wine	5	decent	Last Available: "2016-12"
+9220	extra-dry bad bouncing gingerbread wine	5	decent	Last Available: "2016-12"
 9221	spoiled blinking gingerbread mug	4	crappy	Last Available: "2016-12"
 9222	Da Vinci's gingerbread mask	0		Experience (Mysticality): +5, Last Available: "2016-12"
 9223	gravedigger's lion tamer's experienced gingerservo	0		Experience: +2, Experience (familiar): +2, Spooky Damage: +10, Single Equip, Last Available: "2016-12"
 9224	galvanized pressed narrow tainted icing	0		Effect: "A Contender", Effect Duration: 18, Last Available: "2016-12"
 9225	olive miser's gingerbeard	0		Meat Drop: +10, Single Equip, Last Available: "2016-12"
-9226	twirling mirror gingerbread smartphone	0		Last Available: "2016-12"
+9226	mirror twirling gingerbread smartphone	0		Last Available: "2016-12"
 9227	veiny gingerbread hoodie of the blizzard	0		Maximum HP: +10, Cold Spell Damage: +25, Sprinkle Drop: +15, Last Available: "2016-12"
 9228	green fortified gingerbread pistol of the cheetah	0		Damage Absorption: +60, Initiative: +60, Last Available: "2016-12"
 9229	skewed marzipan briefcase of bravery of the businessman	0		Spooky Resistance: +5, Meat Drop: +50, Lasts Until Rollover, Last Available: "2016-12"
@@ -9111,7 +9111,7 @@
 9239	smooth ginger beer	4	awesome	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	vacuum-sealed huge huge industrial frosting	0		Effect: "Tingly Biceps", Effect Duration: 60, Last Available: "2016-12"
-9242	liquefied polarized red twirling wobbly fake cocktail	0		Effect: "Vitali Tea", Effect Duration: 55, Last Available: "2016-12"
+9242	liquefied polarized wobbly twirling red fake cocktail	0		Effect: "Vitali Tea", Effect Duration: 55, Last Available: "2016-12"
 9243	perfectly mixed upside-down high-end ginger wine	4	EPIC	Last Available: "2016-12"
 9244	plastic bad vibe of Tarzan	0		Experience (Muscle): +3, Last Available: "2016-12"
 9245	medical-grade plastic angry vikings	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12"
@@ -9122,25 +9122,25 @@
 9250	extra-flattened pickled Inner Strength	0		Effect: "Eye of the Seal", Effect Duration: 28, Last Available: "2016-12"
 9251	activated aerosolized blurry Inner Truth	0		Effect: "Protection from Bad Stuff", Effect Duration: 21, Last Available: "2016-12"
 9252	adequate spiritual candy cane	3	good	Last Available: "2016-12"
-9253	irresponsibly strong drinkable spiritual eggnog	7	good	Last Available: "2016-12"
+9253	drinkable irresponsibly strong spiritual eggnog	7	good	Last Available: "2016-12"
 9254	moldy spiritual fruitcake	3	crappy	Last Available: "2016-12"
-9255	bland super-sized spinning squat cyan spiritual gingerbread	5	decent	Last Available: "2016-12"
+9255	bland super-sized squat spinning cyan spiritual gingerbread	5	decent	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
-9257	tumbling yellow chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
+9257	yellow tumbling chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
-9260	yellow pulsating No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
+9260	pulsating yellow No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	huge fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	bouncing briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
-9266	flattened twirling wobbly squat rock candy	0		Effect: "Libra Rising", Effect Duration: 66, Last Available: "2016-12"
-9267	half-sized yummy green-iced sweet roll	2	awesome	Last Available: "2016-12"
+9266	flattened wobbly twirling squat rock candy	0		Effect: "Libra Rising", Effect Duration: 66, Last Available: "2016-12"
+9267	yummy half-sized green-iced sweet roll	2	awesome	Last Available: "2016-12"
 9268	skewed sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	huge chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
-9271	ghostly jittery gray chakra sludge	0		
+9271	jittery ghostly gray chakra sludge	0		
 9272	jittery negative lump	0		
 9273	stylish Third Eye of dire peril	0		Moxie: +25, Weapon Damage: +20, Last Available: "2016-12"
 9274	Krampus Horn of the ox of the pedagogue	0		Muscle: +20, Experience: +3, Single Equip, Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	drinkable chakra-mental wine	4	good	Last Available: "2016-12"
 9277	diffused blinking chakra malt	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 41, Last Available: "2016-12"
 9278	adequate Black Angus blackburger	4	good	Last Available: "2016-12"
-9279	practically non-alcoholic delicious brandy	1	awesome	Last Available: "2016-12"
+9279	delicious practically non-alcoholic brandy	1	awesome	Last Available: "2016-12"
 9280	modified super-enhanced shaking ghostly potion of spiritual gunkifying	0		Effect: "Mushroom Samba", Effect Duration: 53, Last Available: "2016-12"
 9281	blinking electrified groovy bad vibroknife	0		Moxie Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12"
 9282	pulsating gravedigger's crystal belt buckle of temperance	0		Spooky Damage: +10, Sleaze Resistance: +5, Last Available: "2016-12"
@@ -9167,7 +9167,7 @@
 9295	distilled stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	normal toast with hot jelly	3	good	Last Available: "2017-01"
-9298	small moldy blinking toast with jelly	2	crappy	Last Available: "2017-01"
+9298	moldy small blinking toast with jelly	2	crappy	Last Available: "2017-01"
 9299	normal toast with jelly	4	good	Last Available: "2017-01"
 9300	normal toast with sleaze jelly	4	good	Last Available: "2017-01"
 9301	immense spoiled toast with stench jelly	10	crappy	Last Available: "2017-01"
@@ -9176,9 +9176,9 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	double-paned Tesla wax hand	0		Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2017-01"
 9306	jittery zippy energetic candle	0		Maximum MP Percent: +20, Initiative: +20, Lasts Until Rollover, Last Available: "2017-01"
-9307	tiny stale wax pancake	1	decent	Last Available: "2017-01"
+9307	stale tiny wax pancake	1	decent	Last Available: "2017-01"
 9308	Lo Pan's banded wax face	0		Damage Absorption: +100, Spell Critical Percent: +30, Last Available: "2017-01"
-9309	artisanal practically non-alcoholic jittery wax booze	1	super ultra EPIC	Last Available: "2017-01"
+9309	practically non-alcoholic artisanal jittery wax booze	1	super ultra EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	powdered huge sea jelly	1		Last Available: "2017-01"
 9312	diet spoiled huge sea truffle	1	crappy	Last Available: "2017-01"
@@ -9212,7 +9212,7 @@
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
-9343	wobbly jittery bottlecap	0		
+9343	jittery wobbly bottlecap	0		
 9344	discarded button	0		
 9345	twirling Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
@@ -9239,39 +9239,39 @@
 9367	mediocre narrow Phlegethon	3	decent	Last Available: "2017-03"
 9368	aged huge Siberian sunrise	3	awesome	Last Available: "2017-03"
 9369	delicious practically non-alcoholic blurry blurry mentholated wine	1	awesome	Last Available: "2017-03"
-9370	perfectly mixed irresponsibly strong low tide martini	7	EPIC	Last Available: "2017-03"
+9370	irresponsibly strong perfectly mixed low tide martini	7	EPIC	Last Available: "2017-03"
 9371	watered-down bad shroomtini	2	decent	Last Available: "2017-03"
-9372	fortified acceptable olive morning dew	5	good	Last Available: "2017-03"
-9373	high-proof hand-crafted whiskey squeeze	7	EPIC	Last Available: "2017-03"
+9372	acceptable fortified olive morning dew	5	good	Last Available: "2017-03"
+9373	hand-crafted high-proof whiskey squeeze	7	EPIC	Last Available: "2017-03"
 9374	artisanal bouncing great fashioned	3	EPIC	Last Available: "2017-03"
 9375	perfectly mixed triple-distilled Gnomish sagngria	9	EPIC	Last Available: "2017-03"
 9376	special artisanal squat vodka stinger	3	EPIC	Effect: "Once Bitten Twice Fried", Effect Duration: 5, Last Available: "2017-03"
 9377	enchanted tolerable extremely slippery nipple	4	good	Effect: "Walberg's Dim Bulb", Effect Duration: 20, Last Available: "2017-03"
-9378	smooth practically non-alcoholic fuchsia piscatini	1	awesome	Last Available: "2017-03"
+9378	practically non-alcoholic smooth fuchsia piscatini	1	awesome	Last Available: "2017-03"
 9379	lousy boozy Churchill	5	decent	Last Available: "2017-03"
 9380	bad practically non-alcoholic gray soilzerac	1	decent	Last Available: "2017-03"
 9381	mediocre high-proof London frog	9	decent	Last Available: "2017-03"
-9382	perfectly mixed practically non-alcoholic pulsating nothingtini	1	EPIC	Last Available: "2017-03"
-9383	hand-crafted practically non-alcoholic fuchsia eighth plague	1	EPIC	Last Available: "2017-03"
+9382	practically non-alcoholic perfectly mixed pulsating nothingtini	1	EPIC	Last Available: "2017-03"
+9383	practically non-alcoholic hand-crafted fuchsia eighth plague	1	EPIC	Last Available: "2017-03"
 9384	aged single entendre	4	awesome	Last Available: "2017-03"
-9385	weak lousy mirror blue reverse Tantalus	2	decent	Last Available: "2017-03"
+9385	lousy weak blue mirror reverse Tantalus	2	decent	Last Available: "2017-03"
 9386	hand-crafted elemental caipiroska	3	EPIC	Last Available: "2017-03"
 9387	lousy Feliz Navidad	4	decent	Last Available: "2017-03"
-9388	special bad watered-down Bloody Nora	2	decent	Effect: "Towering Strength", Effect Duration: 5, Last Available: "2017-03"
-9389	perfectly mixed bouncing twirling moreltini	4	EPIC	Last Available: "2017-03"
-9390	perfectly mixed watered-down hell in a bucket	2	EPIC	Last Available: "2017-03"
+9388	bad watered-down special Bloody Nora	2	decent	Effect: "Towering Strength", Effect Duration: 5, Last Available: "2017-03"
+9389	perfectly mixed twirling bouncing moreltini	4	EPIC	Last Available: "2017-03"
+9390	watered-down perfectly mixed hell in a bucket	2	EPIC	Last Available: "2017-03"
 9391	artisanal Newark	4	EPIC	Last Available: "2017-03"
 9392	perfectly mixed R'lyeh	4	EPIC	Last Available: "2017-03"
-9393	watered-down perfectly mixed Gnollish sangria	2	EPIC	Last Available: "2017-03"
-9394	bad triple-distilled vodka barracuda	8	decent	Last Available: "2017-03"
+9393	perfectly mixed watered-down Gnollish sangria	2	EPIC	Last Available: "2017-03"
+9394	triple-distilled bad vodka barracuda	8	decent	Last Available: "2017-03"
 9395	bad spinning Mysterious Island iced tea	3	decent	Last Available: "2017-03"
-9396	drinkable distilled drive-by shooting	5	good	Last Available: "2017-03"
+9396	distilled drinkable drive-by shooting	5	good	Last Available: "2017-03"
 9397	practically non-alcoholic drinkable gunner's daughter	1	good	Last Available: "2017-03"
-9398	perfectly mixed wobbly squat dirt julep	4	EPIC	Last Available: "2017-03"
+9398	perfectly mixed squat wobbly dirt julep	4	EPIC	Last Available: "2017-03"
 9399	hand-crafted tumbling Simepore slime	3	EPIC	Last Available: "2017-03"
-9400	aged weak Phil Collins	2	awesome	Last Available: "2017-03"
+9400	weak aged Phil Collins	2	awesome	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
-9402	red wobbly toggle switch (Bartend)	0		Familiar Weight: +5
+9402	wobbly red toggle switch (Bartend)	0		Familiar Weight: +5
 9403	skewed toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	mirror cyan Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9282,11 +9282,11 @@
 9410	Spacegate Research	0		Last Available: "2017-04"
 9411	wobbly alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
-9413	shaking mirror olive geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9413	mirror olive shaking geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9415	stale edible alien plant bit	3	decent	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
-9417	huge cyan alien plant sample	0		Last Available: "2017-04"
+9417	cyan huge alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	maroon fascinating alien plant sample	0		Last Available: "2017-04"
 9420	twisted alien plant goo	1		Effect: "Armor-Plated", Effect Duration: 50, Last Available: "2017-04"
@@ -9298,7 +9298,7 @@
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	purple fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	boiled alien animal goo	1		Last Available: "2017-04"
-9429	mirror yellow huge alien animal milk	0		Last Available: "2017-04"
+9429	huge mirror yellow alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	double-altered diffused alien medicine	0		Effect: "Ass Over Teakettle", Effect Duration: 25, Last Available: "2017-04"
@@ -9330,12 +9330,12 @@
 9458	blurry space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
-9461	gray blinking Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
+9461	blinking gray Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
-9463	wobbly ghostly Space Baby children's book	0		Last Available: "2017-04"
+9463	ghostly wobbly Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
-9466	massive spoiled Aldebaran sardines	8	crappy	Last Available: "2017-04"
+9466	spoiled massive Aldebaran sardines	8	crappy	Last Available: "2017-04"
 9467	drinkable Centauri fish wine	3	good	Last Available: "2017-04"
 9468	distilled oxygen	1		Last Available: "2017-04"
 9469	boxer's Spacegate scientist's insignia of the cougar	0		Moxie: +20, Muscle Percent: +10, Single Equip, Last Available: "2017-04"
@@ -9346,7 +9346,7 @@
 9474	decent thick alien sandwich	5	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	flattened blinking Spant eggs	0		Effect: "White Blooded", Effect Duration: 37
-9477	bouncing jittery Spacegate (open)	0		Lasts Until Rollover
+9477	jittery bouncing Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	modified diffused Daily Affirmation: Always be Collecting	0		Effect: "Shoesauce", Effect Duration: 45, Last Available: "2017-05"
 9480	electrified Daily Affirmation: Think Win-Lose	0		Effect: "Leash of Linguini", Effect Duration: 21, Last Available: "2017-05"
@@ -9372,7 +9372,7 @@
 9500	lime green blurry gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	up-at-dawn hardy wizardly plastic gundam	0		Mysticality: +25, Maximum HP: +50, Adventures: +5, Last Available: "2017-06"
-9503	upside-down jittery License to Chill	0		Last Available: "2017-07"
+9503	jittery upside-down License to Chill	0		Last Available: "2017-07"
 9504	Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	purple Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
@@ -9388,7 +9388,7 @@
 9516	pulsating meteoroid	0		Last Available: "2017-08"
 9517	mirror gray hardened Newton's wizardly meteortarboard	0		Mysticality: +25, Experience (Mysticality): +3, Damage Reduction: 3, Last Available: "2017-08"
 9518	Van der Graaf wholesome meteorite guard of horror	0		Maximum HP Percent: +10, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 9, Last Available: "2017-08"
-9519	twirling grievous meteorb of mayonnaise	0		Weapon Damage Percent: +50, Sleaze Spell Damage: +50, Lantern Element: "Hot", Last Available: "2017-08"
+9519	twirling grievous meteorb of mayonnaise	0		Weapon Damage Percent: +50, Sleaze Spell Damage: +50, Last Available: "2017-08", Lantern Element: "Hot"
 9520	bouncing huge vibrating Socratic asteroid belt	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Single Equip, Last Available: "2017-08"
 9521	MacGyver's meteorthopedic shoes of the wise owl of the empath	0		Mysticality: +20, Maximum MP: +100, Familiar Weight: +5, Single Equip, Last Available: "2017-08"
 9522	skewed forbidden shooting morning star of incineration of the businessman	0		Spell Damage Percent: +50, Hot Spell Damage: +50, Meat Drop: +50, Single Equip, Last Available: "2017-08"
@@ -9416,11 +9416,11 @@
 9544	ghostly O	0		Last Available: "2017-10"
 9545	lousy DUFRESNE Suds	3	decent	Last Available: "2017-09"
 9546	twirling lard-coated frosty mafia pinky ring	0		Cold Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip
-9547	smooth jittery gray pulsating flask of port	3	awesome	
+9547	smooth pulsating jittery gray flask of port	3	awesome	
 9548	teal steel-toed contract enforcement stick of incineration	0		Damage Reduction: 9, Hot Spell Damage: +50
 9549	rotten Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
-9550	bad practically non-alcoholic jug of booze	1	decent	Last Available: "2017-10"
-9551	polarized moist spinning mirror pair of candy glasses	0		Effect: "Extra Backbone", Effect Duration: 43, Last Available: "2017-10"
+9550	practically non-alcoholic bad jug of booze	1	decent	Last Available: "2017-10"
+9551	polarized moist mirror spinning pair of candy glasses	0		Effect: "Extra Backbone", Effect Duration: 43, Last Available: "2017-10"
 9552	frozen temporary X tattoos	0		Effect: "Bootyliciousness", Effect Duration: 52, Last Available: "2017-10"
 9553	dehydrated ghostly glyph of athleticism	1		Last Available: "2017-10"
 9554	green pair of scissors	0		Last Available: "2017-10"
@@ -9451,16 +9451,16 @@
 9579	big decent unfinished fruitcake	5	good	Last Available: "2017-12"
 9580	double-corrupted and cracker	0		Effect: "Pasta Oneness", Effect Duration: 58, Last Available: "2017-12"
 9581	distilled lousy bouncing neg grog	5	decent	Last Available: "2017-12"
-9582	moldy snack-sized half double fruitcake	2	crappy	Last Available: "2017-12"
-9583	bite-sized adequate lime green spinning hushed puppy	1	good	Last Available: "2017-12"
-9584	bland immense huge muffled muffuletta	7	decent	Last Available: "2017-12"
-9585	small stale shushed potatoes	2	decent	Last Available: "2017-12"
+9582	snack-sized moldy half double fruitcake	2	crappy	Last Available: "2017-12"
+9583	adequate bite-sized lime green spinning hushed puppy	1	good	Last Available: "2017-12"
+9584	immense bland huge muffled muffuletta	7	decent	Last Available: "2017-12"
+9585	stale small shushed potatoes	2	decent	Last Available: "2017-12"
 9586	purple Temple Grandin's plastic mime functionary	0		Familiar Weight: +7, Last Available: "2017-12"
 9587	upside-down hardy plastic mime scientist	0		Maximum HP: +50, Last Available: "2017-12"
 9588	pulsating stanky plastic mime soldier	0		Stench Spell Damage: +25, Last Available: "2017-12"
 9589	therapeutic plastic mime executive	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-12"
 9590	narrow prompt plastic The Silent Nightmare	0		Adventures: +3, Last Available: "2017-12"
-9591	yellow shaking locked mumming trunk	0		Free Pull, Last Available: "2017-12"
+9591	shaking yellow locked mumming trunk	0		Free Pull, Last Available: "2017-12"
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	blurry temperance whiskey	1	awesome	Last Available: "2017-11"
 9594	dry ionized blue spinning wishbone	0		Effect: "You Know What's Up", Effect Duration: 53, Last Available: "2017-11"
@@ -9491,7 +9491,7 @@
 9619	silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
 9621	cyan silent W	0		Last Available: "2017-12"
-9622	wobbly maroon silent X	0		Last Available: "2017-12"
+9622	maroon wobbly silent X	0		Last Available: "2017-12"
 9623	skewed silent Y	0		Last Available: "2017-12"
 9624	silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	huge donated candy	0		
 9665	anodized twirling digital honeypot	0		Effect: "Crimbo Nostalgia", Effect Duration: 42, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	huge arcane researcher's mime army insignia (infantry)	0		Experience Percent (Mysticality): +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	mime army insignia (intelligence) of the sewer	0		Stench Damage: +25, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	fuchsia fortified mime army insignia (espionage)	0		Damage Absorption: +60, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	huge arcane researcher's mime army insignia (infantry)	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	mime army insignia (intelligence) of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	fuchsia fortified mime army insignia (espionage)	0		Damage Absorption: +60, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	maroon mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	narrow mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	teal cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	tiny normal extra-toasted half sandwich	1	good	Last Available: "2018-12"
+9681	normal tiny extra-toasted half sandwich	1	good	Last Available: "2018-12"
 9682	lousy upside-down mulled hobo wine	3	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	pulsating shaking wicked burning paper hat of chilblains of the sweet-tooth	0		Spell Damage: +5, Cold Damage: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2018-12"
@@ -9573,13 +9573,13 @@
 9701	compressed purple squat pills	1		
 9702	dried pulsating furry pill	1		Effect: "Spiritually Awake", Effect Duration: 40
 9703	distilled wobbly blurry beefy pill	1		Effect: "Hip to Be Square Dancin'", Effect Duration: 45
-9704	denatured ghostly maroon excitement pill	1		
-9705	compressed gray narrow spinning vitamin G pill	1		
+9704	denatured maroon ghostly excitement pill	1		
+9705	compressed spinning narrow gray vitamin G pill	1		
 9706	diluted mirror cyan lucky-ish pill	1		
 9707	dried mirror dieting pill	1		
 9712	twirling Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
-9714	blinking mirror Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
+9714	mirror blinking Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	bouncing They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
@@ -9604,7 +9604,7 @@
 9736	mirror heart cozy	0		Last Available: "2018-02"
 9737	eaves droppers	0		Last Available: "2018-02"
 9738	blurry gray personal graffiti kit	0		Last Available: "2018-02"
-9739	upside-down purple Mysterious Red Box	0		Last Available: "2018-02"
+9739	purple upside-down Mysterious Red Box	0		Last Available: "2018-02"
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	tumbling Mysterious Blue Box	0		Last Available: "2018-02"
 9742	spinning Mysterious Black Box	0		Last Available: "2018-02"
@@ -9627,7 +9627,7 @@
 9759	Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
 9760	packet of tall grass seeds	0		Last Available: "2018-03"
 9761	gray Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
-9762	purple ghostly Globmule	0		Last Available: "2018-03"
+9762	ghostly purple Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
@@ -9653,7 +9653,7 @@
 9785	Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
 9787	blinking Mustardigrade	0		Last Available: "2018-03"
-9788	blurry maroon Ched	0		Last Available: "2018-03"
+9788	maroon blurry Ched	0		Last Available: "2018-03"
 9789	cyan spinning Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
@@ -9687,17 +9687,17 @@
 9819	skewed Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
-9822	tumbling huge shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9822	huge tumbling shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	ghostly muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
-9825	ghostly fuchsia razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9826	ghostly mirror smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9825	fuchsia ghostly razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9826	mirror ghostly smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
 9828	dehydrated bouncing magnificent oyster egg	1		
 9829	modified purple bouncing brilliant oyster egg	1		
 9830	diluted glistening oyster egg	1		Effect: "Flower Power", Effect Duration: 30
 9831	powdered scintillating oyster egg	1		
-9832	dehydrated skewed teal pearlescent oyster egg	1		Effect: "Stinking Cloud", Effect Duration: 40
+9832	dehydrated teal skewed pearlescent oyster egg	1		Effect: "Stinking Cloud", Effect Duration: 40
 9833	compressed blurry lustrous oyster egg	1		Effect: "Yeah, It's Just Gasoline", Effect Duration: 30
 9834	mixed blinking blinking gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
@@ -9728,15 +9728,15 @@
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	red LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	small rotten FantasyRealm turkey leg	2	crappy	Last Available: "2018-04"
-9863	watered-down bad shaking purple FantasyRealm mead	2	decent	Last Available: "2018-04"
+9863	bad watered-down purple shaking FantasyRealm mead	2	decent	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	huge hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	miniature special tasty druidic s'more	2	awesome	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 40, Last Available: "2018-04"
+9869	special tasty miniature druidic s'more	2	awesome	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 40, Last Available: "2018-04"
 9870	distilled sachet of powder	1		Last Available: "2018-04"
-9871	weak drinkable huge mourning wine	2	good	Last Available: "2018-04"
+9871	drinkable weak huge mourning wine	2	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	huge map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9744,8 +9744,8 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	bouncing bouncing map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	adequate denastified haunch	4	good	Last Available: "2018-04"
-9879	weak perfectly mixed pulsating bad rum and good cola	2	EPIC	Last Available: "2018-04"
-9880	anodized galvanized maroon blurry Potion of Heroism	0		Effect: "Mariachi Mood", Effect Duration: 53, Last Available: "2018-04"
+9879	perfectly mixed weak pulsating bad rum and good cola	2	EPIC	Last Available: "2018-04"
+9880	anodized galvanized blurry maroon Potion of Heroism	0		Effect: "Mariachi Mood", Effect Duration: 53, Last Available: "2018-04"
 9881	greedy Jeselnik's frightening leggings of the Spider Queen	0		Spooky Damage: +5, Sleaze Damage: +25, Meat Drop: +20, Last Available: "2018-04"
 9882	wobbly upside-down prompt Master Thief's utility belt of Gandalf of the glutton	0		Spell Critical Percent: +20, Food Drop: +100, Adventures: +3, Single Equip, Last Available: "2018-04"
 9883	executive sage Duke Vampire's regal cloak of courage	0		Mysticality Percent: +10, Spooky Resistance: +3, Meat Drop: +40, Last Available: "2018-04"
@@ -9765,14 +9765,14 @@
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	perfectly mixed weak two meat muck	2	EPIC	
 9899	normal bite-sized chocolate Ogre Chieftain	1	good	
-9900	adequate jumbo chocolate &quot;Phoenix&quot;	5	good	
+9900	jumbo adequate chocolate &quot;Phoenix&quot;	5	good	
 9901	rotten upside-down chocolate Spider Queen	3	crappy	
 9902	extra-dry perfectly mixed hipster cocktail	5	EPIC	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	squat lime green blinking God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	blurry God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	lime green blinking squat God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	blurry God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	wobbly Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,8 +9780,8 @@
 9912	teal A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	stale huge good guava	8	decent	
-9916	watered-down lousy gin and ginger	2	decent	
+9915	huge stale good guava	8	decent	
+9916	lousy watered-down gin and ginger	2	decent	
 9917	huge Thwaitgold chigger statuette	0		
 9918	dried gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9789,7 +9789,7 @@
 9921	blinking A Guide to Safari	0		Skill: "Experience Safari"
 9922	anodized polarized maroon Shielding Potion	0		Effect: "Cranberry Cordiality", Effect Duration: 12, Last Available: "2018-06"
 9923	non-concentrated chilled wobbly Punching Potion	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 16, Last Available: "2018-06"
-9924	lime green blinking Special Seasoning	0		Last Available: "2018-06"
+9924	blinking lime green Special Seasoning	0		Last Available: "2018-06"
 9925	dried Nightmare Fuel	1		Effect: "A Taste of Rainbow", Effect Duration: 25, Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
@@ -9818,7 +9818,7 @@
 9950	skewed Rosewater's pentagram bandana of the empath	0		Mysticality Percent: +30, Familiar Weight: +5, Last Available: "2018-09"
 9951	greasy skull ring	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	tasty low-calorie PB&J with the crusts cut off	1	awesome	Last Available: "2018-09"
+9953	low-calorie tasty PB&J with the crusts cut off	1	awesome	Last Available: "2018-09"
 9954	huge Socratic dorky glasses of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Single Equip, Last Available: "2018-09"
 9955	squat boxer's ponytail clip of Flo-Jo	0		Muscle Percent: +10, Initiative: +100, Last Available: "2018-09"
 9956	paint palette of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
@@ -9827,7 +9827,7 @@
 9959	squat cosmetic football of doom	0		Spooky Spell Damage: +50, Last Available: "2018-09"
 9960	fuchsia skewed frightening shoe ad T-shirt of extreme caution	0		Monster Level: -25, Spooky Damage: +5, Last Available: "2018-09"
 9961	blurry Tesla pump-up high-tops	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2018-09"
-9962	super-alkaline anodized magnetized squat blue runproof mascara	0		Effect: "Fratty Flavor", Effect Duration: 67, Last Available: "2018-09"
+9962	super-alkaline anodized magnetized blue squat runproof mascara	0		Effect: "Fratty Flavor", Effect Duration: 67, Last Available: "2018-09"
 9963	very small dress	0		Last Available: "2018-09"
 9964	chilly educational noticeable pumps	0		Experience: +1, Cold Damage: +5, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9837,18 +9837,18 @@
 9969	twirling Lo Pan's denim jacket of temperance	0		Spell Critical Percent: +30, Sleaze Resistance: +5, Last Available: "2018-09"
 9970	Lo Pan's sinister ratty knitted cap	0		Spell Damage: +10, Spell Critical Percent: +30, Last Available: "2018-09"
 9972	grievous intimidating chainsaw of the sweet-tooth	0		Weapon Damage Percent: +50, Candy Drop: +100, Lasts Until Rollover, Last Available: "2018-09"
-9973	acceptable watered-down ghostly party beer bomb	2	good	Last Available: "2018-09"
+9973	watered-down acceptable ghostly party beer bomb	2	good	Last Available: "2018-09"
 9974	decent sweet party mix	3	good	Last Available: "2018-09"
 9975	distilled cyan party balloon	1		Last Available: "2018-09"
 9976	healthy party pants of the detective	0		Maximum HP Percent: +20, Item Drop: +20, Last Available: "2018-09"
 9977	avaricious horrifying chaotic party whip	0		Spell Critical Percent: +10, Spooky Damage: +25, Meat Drop: +30, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	artisanal fancy watered-down TRIO cup of beer	2	EPIC	Effect: "Incredibly Hulking", Effect Duration: 45, Last Available: "2018-09"
+9979	watered-down fancy artisanal TRIO cup of beer	2	EPIC	Effect: "Incredibly Hulking", Effect Duration: 45, Last Available: "2018-09"
 9980	stale party platter for one	3	decent	Last Available: "2018-09"
 9981	mixed jittery Party-in-a-Can&trade;	1		Effect: "There Is A Spoon", Effect Duration: 15, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	green scandalous party crasher of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	squat Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9984	squat Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	upside-down Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	spinning fuchsia latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
@@ -9874,15 +9874,15 @@
 10008	sage mutant legs of the storm of the early riser	0		Mysticality Percent: +10, Maximum MP Percent: +40, Adventures: +7, Last Available: "2018-11"
 10009	bouncing Usain Bolt's groovy mutant crown of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3, Initiative: +80, Last Available: "2018-11"
 10010	toothsome ghostly ectoplasm	4	awesome	Last Available: "2018-11"
-10011	big moldy	5	crappy	Last Available: "2018-11"
+10011	moldy big	5	crappy	Last Available: "2018-11"
 10012	lousy bottle of vodka	3	decent	Last Available: "2018-11"
 10013	adequate squat pizza	4	good	Last Available: "2018-11"
 10014	acceptable martini	4	good	Last Available: "2018-11"
-10015	tiny flavorless bouncing cherry pie	1	decent	Last Available: "2018-11"
+10015	flavorless tiny bouncing cherry pie	1	decent	Last Available: "2018-11"
 10016	aged ghostly eggnog	4	awesome	Last Available: "2018-11"
 10017	squat glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	immense bland Hell ramen	9	decent	Last Available: "2018-11"
-10019	strong hand-crafted gimlet	5	EPIC	Last Available: "2018-11"
+10019	hand-crafted strong gimlet	5	EPIC	Last Available: "2018-11"
 10020	lousy shaking twice-haunted screwdriver	3	decent	Last Available: "2018-11"
 10021	moldy half-sized blue candy cane	2	crappy	Last Available: "2018-12"
 10022	extra-dry bad runny fermented egg	5	decent	Last Available: "2018-12"
@@ -9894,7 +9894,7 @@
 10028	flame-wreathed plastic orphan	0		Hot Spell Damage: +10, Last Available: "2018-12"
 10029	shaking Sinatra's plastic Abuela Crimbo	0		Experience (Moxie): +5, Last Available: "2018-12"
 10030	yule pup	0		Last Available: "2018-12"
-10031	spinning narrow Braindeer	0		Last Available: "2018-12"
+10031	narrow spinning Braindeer	0		Last Available: "2018-12"
 10032	upside-down Crimbo dog sweater	0		Familiar Weight: +5
 10033	Temple Grandin's pristine walrus tusk of Gandalf	0		Spell Critical Percent: +20, Familiar Weight: +7, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
@@ -9906,14 +9906,14 @@
 10040	moldy moosemeat pie	4	crappy	Last Available: "2018-12"
 10041	balanced antler	0		Item Drop: +5, Last Available: "2018-12"
 10042	wobbly dam of the bloodbag	0		Maximum HP: +100, Damage Reduction: 9, Last Available: "2018-12"
-10043	smooth watered-down beavermouth	2	awesome	Last Available: "2018-12"
+10043	watered-down smooth beavermouth	2	awesome	Last Available: "2018-12"
 10044	bad practically non-alcoholic green beaver punch (papaya)	1	decent	Last Available: "2018-12"
 10045	artisanal wobbly beaver punch (peach)	3	EPIC	Last Available: "2018-12"
 10046	hand-crafted fortified beaver punch (cherry)	5	EPIC	Last Available: "2018-12"
 10047	ribald sinister Canadian lantern	0		Spell Damage: +10, Sleaze Damage: +10, Last Available: "2018-12"
 10048	muskox-skin cap of James Dean	0		Experience (Moxie): +3, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	yummy diet green glass of raw eggs	1	awesome	Last Available: "2018-12"
+10050	diet yummy green glass of raw eggs	1	awesome	Last Available: "2018-12"
 10051	lousy punch-drunk punch	4	decent	Last Available: "2018-12"
 10052	dehydrated jittery body spradium	1		Last Available: "2018-12"
 10053	huge sizzling bauxite beret	0		Hot Damage: +10, Last Available: "2018-12"
@@ -9932,7 +9932,7 @@
 10066	perfectly mixed weak fuchsia beer	2	super ultra EPIC	Last Available: "2018-12"
 10067	tiny moldy yule gruel	1	crappy	Last Available: "2018-12"
 10068	perfectly mixed hot watered rum	3	EPIC	Last Available: "2018-12"
-10069	weak mediocre spinning bottle of Crimbognac	2	decent	Last Available: "2018-12"
+10069	mediocre weak spinning bottle of Crimbognac	2	decent	Last Available: "2018-12"
 10070	delicious super-sized Crimboysters Rockefeller	5	awesome	Last Available: "2018-12"
 10071	pickled tumbling Crimbeau de toilette	1		Effect: "Danish Cunning", Effect Duration: 15, Last Available: "2018-12"
 10072	squat Crimbo candle	0		Last Available: "2018-12"
@@ -9999,7 +9999,7 @@
 10133	twirling loofah ladle of the pedagogue of the blizzard	0		Experience: +3, Cold Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
 10134	blinking purple gravedigger's slick loofah legwarmers	0		Moxie: +10, Spooky Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
 10135	chaotic loofah lavalier of the cheetah	0		Spell Critical Percent: +10, Initiative: +60, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	modified spinning bouncing blinking loofah lumps	1		Last Available: "2022-12"
+10136	modified blinking bouncing spinning loofah lumps	1		Last Available: "2022-12"
 10137	corrupted ghostly chocolate-covered loofah	0		Effect: "Human-Orc Hybrid", Effect Duration: 65
 10138	flagstone flag of the blizzard of the boozehound	0		Cold Spell Damage: +25, Booze Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
 10139	foul-smelling Van der Graaf flagstone flail	0		Stench Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
@@ -10008,7 +10008,7 @@
 10142	ruddy Rosewater's flagstone fleece	0		Mysticality Percent: +30, Maximum HP Percent: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
 10143	flagstone fringe of terror of the sweet-tooth	0		Spooky Spell Damage: +10, Candy Drop: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	diluted bouncing spinning flagstone flagments	1		Effect: "Provocative Perkiness", Effect Duration: 50, Last Available: "2022-12"
-10145	chilled jittery spinning Flag by the Foot&trade;	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 43
+10145	chilled spinning jittery Flag by the Foot&trade;	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 43
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
 10148	smartaleck's cobbled-together Meat detector	0		Moxie Percent: +30, Lasts Until Rollover, Last Available: "2019-12"
@@ -10021,13 +10021,13 @@
 10155	adequate lime green elf army field rations	4	good	Last Available: "2019-12"
 10156	blurry gingernade	0		Last Available: "2019-12"
 10157	asbestos-lined personal trainer's discarded bowtie	0		Experience Percent (Muscle): +10, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2019-12"
-10158	irresponsibly strong perfectly mixed skewed martiny	9	EPIC	Last Available: "2019-12"
+10158	perfectly mixed irresponsibly strong skewed martiny	9	EPIC	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	dry irradiated licorice snake	0		Effect: "Izchak's Blessing", Effect Duration: 59
 10161	irradiated improved blinking virgin jello shot	0		Effect: "Slimily Speedy", Effect Duration: 18
 10162	frozen ionized tarnished wobbly mutated candy lump	0		Effect: "Super-Charged", Effect Duration: 49
 10163	warmed warmed skewed government-issued candy	0		Effect: "Super Accuracy", Effect Duration: 58
-10164	dry cyan squat Pneumo bar	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 62
+10164	dry squat cyan Pneumo bar	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 62
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	avaricious mansplainer's Lil' Doctor&trade; bag	0		Monster Level: +15, Meat Drop: +30, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	teal ghostly blood bag	0		
@@ -10035,13 +10035,13 @@
 10170	tolerable bottle of Sanguiovese	3	good	
 10171	half-sized adequate actual blood sausage	2	good	
 10172	watered-down smooth ghostly mulled blood	2	awesome	
-10173	small flavorless blood snowcone	2	decent	
+10173	flavorless small blood snowcone	2	decent	
 10174	lousy spirit-forward Red Russian	5	decent	
-10175	flavorless half-sized purple blood roll-up	2	decent	
+10175	half-sized flavorless purple blood roll-up	2	decent	
 10176	artisanal weak bottle of blood	2	super ultra mega EPIC	
 10177	moldy blood-soaked sponge cake	4	crappy	
-10178	boozy mediocre vampagne	5	decent	
-10179	bite-sized spoiled plain snowcone	1	crappy	
+10178	mediocre boozy vampagne	5	decent	
+10179	spoiled bite-sized plain snowcone	1	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
@@ -10065,7 +10065,7 @@
 10200	jittery jittery melty plastic grenade	0		Last Available: "2019-04"
 10201	watered-down bad bottle of dark rhum	2	decent	Last Available: "2019-04"
 10202	spirit-forward hand-crafted bouncing bottle of extra-dark rhum	5	EPIC	Last Available: "2019-04"
-10203	strong enchanted hand-crafted bottle of super-extra-dark rhum	5	EPIC	Effect: "Buttermilk Boogie", Effect Duration: 30, Last Available: "2019-04"
+10203	enchanted strong hand-crafted bottle of super-extra-dark rhum	5	EPIC	Effect: "Buttermilk Boogie", Effect Duration: 30, Last Available: "2019-04"
 10204	polarized pickled tumbling pirate shaving cream	0		Effect: "Shot in the Arse", Effect Duration: 24, Last Available: "2019-04"
 10205	green twirling MacGyver's educational conquistador's breastplate	0		Experience: +1, Maximum MP: +100, Last Available: "2019-04"
 10206	pulsating smartaleck's pirate pantaloons	0		Moxie Percent: +30, Item Drop: +5, Last Available: "2019-04"
@@ -10079,7 +10079,7 @@
 10214	double-anodized non-anodized spinning huge mint leaf	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 34, Last Available: "2019-04"
 10215	squat cocoa of youth	0		Last Available: "2019-04"
 10216	boiled skewed ice molecule	1		Last Available: "2019-04"
-10217	yellow mirror Red Roger's reliquary	0		Last Available: "2019-04"
+10217	mirror yellow Red Roger's reliquary	0		Last Available: "2019-04"
 10218	shaking Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
@@ -10094,11 +10094,11 @@
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	Lo Pan's piratical blunderbuss of the boozehound	0		Spell Critical Percent: +30, Booze Drop: +100, Last Available: "2019-04"
 10231	Usain Bolt's chaotic PirateRealm party hat of temperance	0		Spell Critical Percent: +10, Sleaze Resistance: +5, Initiative: +80, Last Available: "2019-04"
-10232	practically non-alcoholic mediocre Island Landslide	1	decent	Last Available: "2019-04"
-10233	triple-distilled hand-crafted Island Thunderstorm	6	EPIC	Last Available: "2019-04"
+10232	mediocre practically non-alcoholic Island Landslide	1	decent	Last Available: "2019-04"
+10233	hand-crafted triple-distilled Island Thunderstorm	6	EPIC	Last Available: "2019-04"
 10234	lousy Island Hurricane	3	decent	Last Available: "2019-04"
 10235	tolerable Skull Punch	3	good	Last Available: "2019-04"
-10236	bad irresponsibly strong pulsating Electric Punch	9	decent	Last Available: "2019-04"
+10236	irresponsibly strong bad pulsating Electric Punch	9	decent	Last Available: "2019-04"
 10237	watered-down hand-crafted cyan Smuggler's Punch	2	super ultra mega turbo EPIC	Last Available: "2019-04"
 10238	distilled lousy Scorpion Bowl	5	decent	Last Available: "2019-04"
 10239	mediocre Turtle Bowl	4	decent	Last Available: "2019-04"
@@ -10106,10 +10106,10 @@
 10241	vampyric cloake pattern	0		Free Pull
 10242	aromatic steel-toed boxer's vampyric cloake of the pedagogue of horror	0		Muscle Percent: +10, Experience: +3, Damage Reduction: 9, Spooky Spell Damage: +25, Stench Resistance: +1, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
-10244	flattened spinning jittery one piece of bubble gum	0		Effect: "Pork Power", Effect Duration: 27
+10244	flattened jittery spinning one piece of bubble gum	0		Effect: "Pork Power", Effect Duration: 27
 10245	narrow arcanoferric housing	0		
 10246	intact medium-wave antenna	0		
-10247	maroon tumbling 18-picohertz resonator crystal	0		
+10247	tumbling maroon 18-picohertz resonator crystal	0		
 10248	red squat blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
@@ -10147,14 +10147,14 @@
 10282	banded sage pirate cutlass of wisdom	0		Mysticality: +15, Mysticality Percent: +10, Damage Absorption: +100, Single Equip, Last Available: "2019-07"
 10283	groovy cool tricorn hat of the cougar	0		Moxie: 25, Moxie Percent: +10, Last Available: "2019-07"
 10284	blurry family-friendly Socratic Rosewater's swash buckle	0		Mysticality Percent: +30, Experience (Mysticality): +1, Sleaze Resistance: +1, Single Equip, Last Available: "2019-07"
-10285	upside-down blurry meteorite fragment	0		Last Available: "2019-07"
+10285	blurry upside-down meteorite fragment	0		Last Available: "2019-07"
 10286	jittery fireproof educational slick meteorite earring	0		Moxie: +10, Experience: +1, Hot Resistance: +3, Single Equip, Last Available: "2019-07"
 10287	frosty vibrating meteorite necklace of horror	0		Maximum MP Percent: +10, Cold Spell Damage: +10, Spooky Spell Damage: +25, Single Equip, Last Available: "2019-07"
 10288	skewed banded wicked meteorite ring of Leguizamo	0		Spell Damage: +5, Damage Absorption: +100, Monster Level: +20, Single Equip, Last Available: "2019-07"
-10289	tarnished adjusted mirror maroon Finnish Fish	0		Effect: "Crimbo Nostalgia", Effect Duration: 46
+10289	tarnished adjusted maroon mirror Finnish Fish	0		Effect: "Crimbo Nostalgia", Effect Duration: 46
 10290	ionized chocolate doubloon	0		Effect: "Pockets of Fire", Effect Duration: 66
 10291	experienced supercool driftwood beach comb of the ox	0		Muscle: +20, Moxie Percent: +20, Experience: +2, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
-10292	spinning red Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
+10292	red spinning Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	stick of firewood	0		Last Available: "2019-08"
 10294	flame-wreathed clever banded whittled tiara	0		Damage Absorption: +100, Maximum MP: +20, Hot Spell Damage: +10, Last Available: "2019-08"
 10295	jittery lightning-fast Jack Frost's whittled shorts of the overflowing toilet	0		Cold Spell Damage: +50, Stench Spell Damage: +50, Initiative: +40, Last Available: "2019-08"
@@ -10166,9 +10166,9 @@
 10301	careful rock-hard whittled fox figurine of the boozehound	0		Damage Reduction: 5, Monster Level: -10, Booze Drop: +100, Single Equip, Last Available: "2019-08"
 10302	lion tamer's whittled walking stick of the empath of courage of the sweet-tooth	0		Familiar Weight: +5, Experience (familiar): +2, Spooky Resistance: +3, Candy Drop: +100, Last Available: "2019-08"
 10303	toothsome campfire hot dog	4	awesome	Last Available: "2019-08"
-10304	special bland half-sized twirling campfire baked potato	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 45, Last Available: "2019-08"
+10304	half-sized special bland twirling campfire baked potato	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 45, Last Available: "2019-08"
 10305	delicious skewed campfire s'more	3	awesome	Last Available: "2019-08"
-10306	adequate low-calorie campfire beans	1	good	Last Available: "2019-08"
+10306	low-calorie adequate campfire beans	1	good	Last Available: "2019-08"
 10307	jumbo spoiled wobbly campfire stew	5	crappy	Last Available: "2019-08"
 10308	squat campfire coffee	1	awesome	Last Available: "2019-08"
 10309	magnetized leftover chocolate bar	0		Effect: "Chalk Outline", Effect Duration: 16
@@ -10193,22 +10193,22 @@
 10334	wobbly jittery unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	squat diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	decent super-sized bu&ntilde;uelos Jaliscos	5	good	Last Available: "2019-12"
+10337	super-sized decent bu&ntilde;uelos Jaliscos	5	good	Last Available: "2019-12"
 10338	adequate flan del mar	4	good	Last Available: "2019-12"
-10339	moldy thick Baja sopapilla	5	crappy	Last Available: "2019-12"
+10339	thick moldy Baja sopapilla	5	crappy	Last Available: "2019-12"
 10340	maroon Newton's plastic Mer-kin baker	0		Experience (Mysticality): +3, Last Available: "2019-12"
 10341	pulsating healthy plastic sea elf	0		Maximum HP Percent: +20, Last Available: "2019-12"
 10342	foul-smelling plastic yuleviathan	0		Stench Damage: +10, Last Available: "2019-12"
 10343	upside-down ruddy plastic dolphin &quot;orphan&quot;	0		Maximum HP Percent: +40, Single Equip, Last Available: "2019-12"
 10344	rock-hard plastic Dolph Bossin	0		Damage Reduction: 5, Last Available: "2019-12"
-10345	green blinking red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
+10345	blinking green red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	stale mana-coated yams	3	decent	Last Available: "2019-11"
 10347	flavorless snack-sized squat mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
-10348	toothsome fancy mana-fortified cranberry sauce	4	awesome	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2019-11"
+10348	fancy toothsome mana-fortified cranberry sauce	4	awesome	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2019-11"
 10349	spoiled immense mana-stuffed herbal stuffing	10	crappy	Last Available: "2019-11"
 10350	shaking human musk	0		Last Available: "2019-12"
 10351	cold-filtered quadruple-improved warmed shaking patch of extra-warm fur	0		Effect: "Mushroom Might", Effect Duration: 62, Last Available: "2019-12"
-10352	denatured bouncing ghostly industrial lubricant	1		Last Available: "2019-12"
+10352	denatured ghostly bouncing industrial lubricant	1		Last Available: "2019-12"
 10353	Vulcanized unfinished pleasure	0		Effect: "One For Tea", Effect Duration: 69, Last Available: "2019-12"
 10354	compressed shaking vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	pickled a bug's lymph	1		Effect: "Human-Human Hybrid", Effect Duration: 15, Last Available: "2019-12"
@@ -10216,18 +10216,18 @@
 10357	lousy boot flask	3	decent	Last Available: "2019-12"
 10358	anodized upside-down infernal snowball	0		Effect: "Super Speed", Effect Duration: 21, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	dried tumbling pulsating fish sauce	1		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 40, Last Available: "2019-12"
+10360	dried pulsating tumbling fish sauce	1		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 40, Last Available: "2019-12"
 10361	jumbo tasty guffin	5	awesome	Last Available: "2019-12"
 10362	vaporized wobbly squat Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	pickled blinking red non-Euclidean angle	1		Effect: "Heart of Lavender", Effect Duration: 35, Last Available: "2019-12"
+10364	pickled red blinking non-Euclidean angle	1		Effect: "Heart of Lavender", Effect Duration: 35, Last Available: "2019-12"
 10365	colloidal peppermint syrup	0		Effect: "Muscle Unbound", Effect Duration: 33, Last Available: "2019-12"
 10366	activated colloidal Mer-kin eyedrops	0		Effect: "Purpose", Effect Duration: 57, Last Available: "2019-12"
-10367	wet huge blinking extra-strength goo	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2019-12"
+10367	wet blinking huge extra-strength goo	0		Effect: "Sweet and Yellow", Effect Duration: 36, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
-10369	compressed gray pulsating narrow livid energy	1		Last Available: "2019-12"
+10369	compressed narrow gray pulsating livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	mixed skewed tumbling beggin' cologne	1		Last Available: "2019-12"
+10371	mixed tumbling skewed beggin' cologne	1		Last Available: "2019-12"
 10372	double-paned foul-smelling oxygenated eggnog helmet	0		Stench Damage: +10, Cold Resistance: +5, Adventure Underwater, Last Available: "2019-12"
 10373	hand-knitted diving booties	0		Last Available: "2019-12"
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	huge huge The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	ionized alkaline blinking spinning salty gumdrop	0		Effect: "The Halls of Mysticality", Effect Duration: 60, Last Available: "2019-12"
+10384	ionized alkaline spinning blinking salty gumdrop	0		Effect: "The Halls of Mysticality", Effect Duration: 60, Last Available: "2019-12"
 10385	stiffened boxer's ribbon candy ascot	0		Muscle Percent: +10, Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	huge intact anemone spike	0		Last Available: "2019-12"
@@ -10253,11 +10253,11 @@
 10394	smelly nippy Mer-kin rollpin	0		Cold Damage: +10, Stench Spell Damage: +10, Last Available: "2019-12"
 10395	spinning personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	bouncing tinsel fin	0		Familiar Weight: +5
-10397	decent snack-sized bowl of mernudo	2	good	Last Available: "2019-12"
+10397	snack-sized decent bowl of mernudo	2	good	Last Available: "2019-12"
 10398	acceptable fishelada	4	good	Last Available: "2019-12"
 10399	stale ojo de pez burrito	3	decent	Last Available: "2019-12"
 10400	upside-down waterlogged wood	0		Last Available: "2019-12"
-10401	mirror mirror blinking waterlogged cloth	0		Last Available: "2019-12"
+10401	mirror blinking mirror waterlogged cloth	0		Last Available: "2019-12"
 10402	waterlogged stuffing	0		Last Available: "2019-12"
 10403	ghostly wobbly waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
@@ -10283,7 +10283,7 @@
 10424	cyan lightning-fast wicked arcane researcher's Staff of the Peppermint Twist of the cheetah	0		Experience Percent (Mysticality): +10, Spell Damage: +5, Initiative: 100, Last Available: "2019-12"
 10425	thick adequate tempura and bean	5	good	Last Available: "2019-12"
 10426	perfectly mixed high-proof shaking salt plum sake	8	EPIC	Last Available: "2019-12"
-10427	energized upside-down skewed pressurized potion of possessiveness	0		Effect: "Provocative Perkiness", Effect Duration: 64, Last Available: "2019-12"
+10427	energized skewed upside-down pressurized potion of possessiveness	0		Effect: "Provocative Perkiness", Effect Duration: 64, Last Available: "2019-12"
 10428	polarized ionized bouncing almond	0		Effect: "Shot in the Arse", Effect Duration: 16
 10429	flattened cold-filtered handful of mixed nuts	0		Effect: "Tennis Elbow-wow", Effect Duration: 54, Last Available: "2019-12"
 10430	nutcracking pliers	0		
@@ -10293,16 +10293,16 @@
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	mirror lion tamer's resourceful slick Powerful Glove of the wise owl of chilblains	0		Mysticality: +20, Moxie: +10, Maximum MP: +50, Experience (familiar): +2, Cold Damage: +25, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
-10439	spinning yellow enhanced signal receiver	0		
-10440	cyan upside-down status cymbal	0		Last Available: "2020-02"
+10439	yellow spinning enhanced signal receiver	0		
+10440	upside-down cyan status cymbal	0		Last Available: "2020-02"
 10441	lime green veiny steel-toed personal trainer's Drip harness	0		Experience Percent (Muscle): +10, Damage Reduction: 9, Maximum HP: +10
 10442	up-at-dawn drippy truncheon	0		Adventures: +5, Single Equip
 10443	Driplet	0		
 10444	olive drippy snail shell	0		
-10445	bland immense drippy nugget	6	drippy	
+10445	immense bland drippy nugget	6	drippy	
 10446	artisanal glass of drippy wine	4	drippy	
 10447	immense spoiled blurry drippy caviar	7	drippy	
-10448	tiny special stale tumbling drippy plum(?)	1	drippy	Effect: "Reptilian Fortitude", Effect Duration: 25
+10448	stale special tiny tumbling drippy plum(?)	1	drippy	Effect: "Reptilian Fortitude", Effect Duration: 25
 10449	curative drippy stake	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
 10450	skewed The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10346,7 +10346,7 @@
 10489	decent mushroom filet	3	good	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	denatured red mushroom tea	1		Last Available: "2020-03"
-10492	watered-down drinkable upside-down lime green mushroom whiskey	2	good	Last Available: "2020-03"
+10492	watered-down drinkable lime green upside-down mushroom whiskey	2	good	Last Available: "2020-03"
 10493	aromatic Jack Frost's electrified mushroom cap	0		Cold Spell Damage: +50, Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-03"
 10494	skewed clever vibrating curative mushroom shield of the overflowing toilet	0		Maximum MP Percent: +10, Maximum MP: +20, Stench Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 6, Last Available: "2020-03"
 10495	vibrating fortified mushroom pants of the brute	0		Muscle Percent: +30, Damage Absorption: +60, Maximum MP Percent: +10, Item Drop: +5, Last Available: "2020-03"
@@ -10373,13 +10373,13 @@
 10516	drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	drippy ichor	0		
-10519	ghostly lime green drippy enzyme	0		
+10519	lime green ghostly drippy enzyme	0		
 10520	green drippy salt	0		
 10521	blinking drippy pigment	0		
 10522	drippy bromide	0		
 10523	upside-down drippy flux	0		
 10524	drippy stein	0		
-10525	smooth spirit-forward blue twirling drippy pilsner	5	drippy	
+10525	smooth spirit-forward twirling blue drippy pilsner	5	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10394,11 +10394,11 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	blinking beefy Guzzlr souvenir stein	0		Muscle: +10, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	artisanal practically non-alcoholic Ghiaccio Colada	1	super ultra mega turbo EPIC	Last Available: "2020-05"
+10541	practically non-alcoholic artisanal Ghiaccio Colada	1	super ultra mega turbo EPIC	Last Available: "2020-05"
 10542	hand-crafted bouncing lime green Sourfinger	4	EPIC	Last Available: "2020-05"
-10543	smooth upside-down spinning Nog-on-the-Cob	4	awesome	Last Available: "2020-05"
-10544	watered-down mediocre Steamboat	2	decent	Last Available: "2020-05"
-10545	fancy lousy watered-down huge Buttery Boy	2	decent	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 30, Last Available: "2020-05"
+10543	smooth spinning upside-down Nog-on-the-Cob	4	awesome	Last Available: "2020-05"
+10544	mediocre watered-down Steamboat	2	decent	Last Available: "2020-05"
+10545	watered-down lousy fancy huge Buttery Boy	2	decent	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 30, Last Available: "2020-05"
 10546	pulsating Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	skewed huge Rosewater's sage clown car key	0		Mysticality Percent: 40, Last Available: "2020-08"
 10548	wobbly knitted thinker's batting cage key of doom	0		Mysticality: +10, Spooky Spell Damage: +50, Cold Resistance: +3, Last Available: "2020-08"
@@ -10430,12 +10430,12 @@
 10574	blurry Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	activated tarnished salty drippy candy bar	0		Effect: "Triangle, Man", Effect Duration: 12
-10577	adjusted twirling fuchsia writhing drippy candy bar	0		Effect: "Metal Speed", Effect Duration: 40
+10577	adjusted fuchsia twirling writhing drippy candy bar	0		Effect: "Metal Speed", Effect Duration: 40
 10578	polarized wobbly gooey drippy candy bar	0		Effect: "Eyes of the Dragon", Effect Duration: 62
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	upside-down packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
-10582	blurry skewed SpinMaster&trade; lathe	0		Last Available: "2020-08"
+10582	skewed blurry SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	olive flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	birch battery of the empath of the overflowing toilet	0		Familiar Weight: +5, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08"
 10585	friendly Socratic cool ebony epee	0		Moxie: +5, Experience (Mysticality): +1, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
@@ -10452,7 +10452,7 @@
 10596	Usain Bolt's extremely unsafe Sinatra's purpleheart &quot;pants&quot;	0		Experience (Moxie): +5, Weapon Damage Percent: +100, Initiative: +80, Last Available: "2020-08"
 10597	wormwood stick	0		Last Available: "2020-08"
 10598	lion tamer's studded wicked strapping wormwood wedding ring of the bloodbag	0		Muscle: +5, Spell Damage: +5, Damage Absorption: +80, Maximum HP: +100, Experience (familiar): +2, Single Equip, Last Available: "2020-08"
-10599	mirror squat Dripwood slab	0		Last Available: "2020-08"
+10599	squat mirror Dripwood slab	0		Last Available: "2020-08"
 10600	drippy diadem	0		Last Available: "2020-08"
 10601	Thwaitgold slug statuette	0		
 10602	MacGyver's ert grey goo ring	0		Maximum MP: +100
@@ -10461,8 +10461,8 @@
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	magnetized nitrogenated Yeg's Motel toothbrush	0		Effect: "Big", Effect Duration: 57, Last Available: "2020-09"
 10607	super-magnetized spinning Yeg's Motel hand soap	0		Effect: "Nuts about Candy", Effect Duration: 42, Last Available: "2020-09"
-10608	narrow mirror Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	stale enchanted lime green Yeg's Motel pillow mint	3	decent	Effect: "Chief Executive Optimism", Effect Duration: 45, Last Available: "2020-09"
+10608	mirror narrow Yeg's Motel sewing kit	0		Last Available: "2020-09"
+10609	enchanted stale lime green Yeg's Motel pillow mint	3	decent	Effect: "Chief Executive Optimism", Effect Duration: 45, Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	nitrogenated alkaline quadruple-energized Yeg's Motel mouthwash	0		Effect: "Cute Vision", Effect Duration: 41, Last Available: "2020-09"
 10612	padded beefy Yeg's Motel shower cap	0		Muscle: +10, Damage Absorption: +20, Lasts Until Rollover, Last Available: "2020-09"
@@ -10479,7 +10479,7 @@
 10623	onyx king	0		Last Available: "2020-09"
 10624	purple onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
-10626	twirling lime green mirror onyx bishop	0		Last Available: "2020-09"
+10626	mirror twirling lime green onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
 10628	squat onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
@@ -10503,7 +10503,7 @@
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	blurry gregarious ghostling	0		Free Pull, Last Available: "2020-12"
-10650	mirror gray grinning ghostling	0		Free Pull, Last Available: "2020-12"
+10650	gray mirror grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	concentrated purple fortifying hot cocoa	0		Effect: "Elemental Flavor", Effect Duration: 65, Last Available: "2020-12"
@@ -10523,7 +10523,7 @@
 10667	clever plastic Crimbo cheer	0		Maximum MP: +20, Last Available: "2020-12"
 10668	coward's plastic Mirth	0		Monster Level: -20, Last Available: "2020-12"
 10669	healthy plastic Penny	0		Maximum HP Percent: +20, Last Available: "2020-12"
-10670	blinking mirror overflowing gift basket	0		Last Available: "2020-12"
+10670	mirror blinking overflowing gift basket	0		Last Available: "2020-12"
 10671	personalized wassail stein	0		Last Available: "2020-12"
 10672	tabletop candy dispenser	0		Last Available: "2020-12"
 10673	Da Vinci's neck wreath	0		Experience (Mysticality): [+5*event(December)], Single Equip, Last Available: "2020-12"
@@ -10574,20 +10574,20 @@
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	bad wobbly barrel-aged eggnog	3	decent	Last Available: "2020-12"
-10721	massive tasty hand-crafted candy cane	7	awesome	Last Available: "2020-12"
-10722	enchanted snack-sized flavorless drive-thru burger	2	decent	Effect: "Salamander In Your Stomach", Effect Duration: 25, Last Available: "2020-12"
+10721	tasty massive hand-crafted candy cane	7	awesome	Last Available: "2020-12"
+10722	flavorless enchanted snack-sized drive-thru burger	2	decent	Effect: "Salamander In Your Stomach", Effect Duration: 25, Last Available: "2020-12"
 10723	aged ghostly Boulevardier cocktail	3	awesome	Last Available: "2020-12"
 10724	concentrated Hotwire&trade; brand candy rope	0		Effect: "Gummiskin", Effect Duration: 40, Last Available: "2020-12"
 10725	normal diet bowl full of jelly	1	good	Last Available: "2020-12"
 10726	hand-crafted skewed Eye and a Twist	4	EPIC	Last Available: "2020-12"
-10727	oxidized tarnished purple blurry Chubby and Plump bar	0		Effect: "Stinkybeard", Effect Duration: 27, Last Available: "2020-12"
+10727	oxidized tarnished blurry purple Chubby and Plump bar	0		Effect: "Stinkybeard", Effect Duration: 27, Last Available: "2020-12"
 10728	mirror digibritches	0		Last Available: "2025-12"
 10729	upside-down packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
-10731	pulsating jittery fresh can of paint	0		Free Pull, Last Available: "2021-12"
+10731	jittery pulsating fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	jittery wobbly emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	jittery wobbly emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	twirling robo-battery	0		
 10736	twirling Thwaitgold listening bug statuette	0		
 10737	upside-down lime green power seed	0		Free Pull, Last Available: "2021-03"
@@ -10631,15 +10631,15 @@
 10775	super-irradiated aerosolized ionized narrow The Beast Within&trade; candle	0		Effect: "Drunk With Power", Effect Duration: 35, Last Available: "2021-08"
 10776	dry jittery Salsa Caliente&trade; candle	0		Effect: "Spiky Hair", Effect Duration: 23, Last Available: "2021-08"
 10777	non-anodized boiled nitrogenated Smoldering Clover&trade; candle	0		Effect: "Witch Breaded", Effect Duration: 46, Last Available: "2021-08"
-10778	concentrated Vulcanized bouncing shaking jittery Napalm In The Morning&trade; candle	0		Effect: "All Fired Up", Effect Duration: 19, Last Available: "2021-08"
+10778	concentrated Vulcanized shaking bouncing jittery Napalm In The Morning&trade; candle	0		Effect: "All Fired Up", Effect Duration: 19, Last Available: "2021-08"
 10779	steel-toed dance instructor's extra-large utility candle	0		Experience Percent (Moxie): +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2021-08"
 10780	ghostly perfumed runed taper candle of the wise owl	0		Mysticality: +20, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2021-08"
 10781	scandalous banded novelty sparkling candle of courage	0		Damage Absorption: +100, Sleaze Damage: +5, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2021-08"
 10782	teal executive gravedigger's Abracandalabra	0		Spooky Damage: +10, Meat Drop: +40, Lasts Until Rollover, Last Available: "2021-08"
 10783	Sherlock's fireproof extra-wide head candle	0		Hot Resistance: +3, Item Drop: +25, Lasts Until Rollover, Last Available: "2021-08"
 10784	energized nitrogenated activated natural magick candle	0		Effect: "Crimbo Flavor", Effect Duration: 63, Last Available: "2021-08"
-10785	corrupted Vulcanized tumbling skewed rainbow glitter candle	0		Effect: "Dreadful Heat", Effect Duration: 13, Last Available: "2021-08"
-10786	wet bouncing olive squat banana candle	0		Effect: "Supafly", Effect Duration: 19, Last Available: "2021-08"
+10785	corrupted Vulcanized skewed tumbling rainbow glitter candle	0		Effect: "Dreadful Heat", Effect Duration: 13, Last Available: "2021-08"
+10786	wet olive bouncing squat banana candle	0		Effect: "Supafly", Effect Duration: 19, Last Available: "2021-08"
 10787	vacuum-sealed olive ear candle	0		Effect: "Sealed Brain", Effect Duration: 46, Last Available: "2021-08"
 10788	pickled improved cold-filtered votive of confidence	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 28, Last Available: "2021-08"
 10789	water candle of the detective	0		Item Drop: +20, Water: 3, Lasts Until Rollover
@@ -10651,7 +10651,7 @@
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	olive mirror wool chaotic therapeutic veiny sinister industrial fire extinguisher of James Dean	0		Experience (Moxie): +3, Spell Damage: +10, Maximum HP: +10, Spell Critical Percent: +10, Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
-10798	blinking green bouncing The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
+10798	green blinking bouncing The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	blinking The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	green twirling bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
@@ -10661,7 +10661,7 @@
 10805	upside-down eggwater	1	EPIC	Last Available: "2021-12"
 10806	small rotten bread man	2	crappy	Last Available: "2021-12"
 10807	yummy green plain candy cane	4	awesome	Last Available: "2021-12"
-10808	rotten half-sized flour cookie	2	crappy	Last Available: "2021-12"
+10808	half-sized rotten flour cookie	2	crappy	Last Available: "2021-12"
 10809	narrow nasty plastic food lab	0		Stench Damage: +5, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of the glutton	0		Food Drop: +100, Single Equip, Last Available: "2021-12"
 10811	reassuring plastic chem lab	0		Spooky Resistance: +1, Single Equip, Last Available: "2021-12"
@@ -10678,12 +10678,12 @@
 10822	decent half-sized bone broth	2	good	Last Available: "2021-12"
 10823	normal ghostly squat star pop	4	good	Last Available: "2021-12"
 10824	watered-down bad Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
-10825	triple-distilled tolerable skewed Doc's Smartifying Wine	10	good	Last Available: "2021-12"
+10825	tolerable triple-distilled skewed Doc's Smartifying Wine	10	good	Last Available: "2021-12"
 10826	mediocre distilled Doc's Limbering Wine	5	decent	Last Available: "2021-12"
 10827	tolerable Doc's Medical-Grade Wine	3	good	Last Available: "2021-12"
 10828	compressed tumbling Homebodyl&trade;	1		Effect: "Become Intensely interested", Effect Duration: 30, Last Available: "2021-12"
 10829	dried skewed Extrovermectin&trade;	1		Effect: "You're Not Cooking", Effect Duration: 15, Last Available: "2021-12"
-10830	vaporized bouncing shaking Breathitin&trade;	1		Last Available: "2021-12"
+10830	vaporized shaking bouncing Breathitin&trade;	1		Last Available: "2021-12"
 10831	pickled Fleshazole&trade;	1		Effect: "Savage Beast Inside", Effect Duration: 40, Last Available: "2021-12"
 10832	improved quadruple-colloidal dry bouncing anti-burn cream	0		Effect: "Abyssal Blood", Effect Duration: 58, Last Available: "2021-12"
 10833	magnetized anti-freeze cream	0		Effect: "Tremella Tremens", Effect Duration: 41, Last Available: "2021-12"
@@ -10691,9 +10691,9 @@
 10835	anodized ionized anti-odor cream	0		Effect: "Coldfinger", Effect Duration: 59, Last Available: "2021-12"
 10836	flattened blurry anti-creep cream	0		Effect: "Cold, Dead Hands", Effect Duration: 49, Last Available: "2021-12"
 10837	irradiated pressed squat upside-down anti-pain cream	0		Effect: "Sticky Fingers", Effect Duration: 69, Last Available: "2021-12"
-10838	mediocre weak special wobbly Doc's Special Reserve Wine	2	decent	Effect: "Bread-Lined", Effect Duration: 10, Last Available: "2021-12"
+10838	mediocre special weak wobbly Doc's Special Reserve Wine	2	decent	Effect: "Bread-Lined", Effect Duration: 10, Last Available: "2021-12"
 10839	bland bread pie	4	decent	Last Available: "2021-12"
-10840	practically non-alcoholic delicious jittery clear Russian	1	awesome	Last Available: "2021-12"
+10840	delicious practically non-alcoholic jittery clear Russian	1	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	skewed Crimbo ball	0		Last Available: "2021-12"
@@ -10728,7 +10728,7 @@
 10872	dog trainer's pants	0		Experience (familiar): +1, Last Available: "2021-12"
 10873	mirror twirling censurious coward's Tesla can of mixed everything	0		Monster Level: -20, Sleaze Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
-10875	narrow olive the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10875	olive narrow the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	tiny bland meatball	1	decent	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
@@ -10737,7 +10737,7 @@
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
 10883	twisted astral energy drink	1		Effect: "Glo-Face", Effect Duration: 30
-10884	upside-down gray mint condition magnifying glass	0		Last Available: "2022-12"
+10884	gray upside-down mint condition magnifying glass	0		Last Available: "2022-12"
 10885	Jeselnik's manspreader's clever magnifying glass	0		Maximum MP: +20, Monster Level: +10, Sleaze Damage: +25, Last Available: "2022-12"
 10886	mediocre fortified void lager	5	decent	Last Available: "2022-12"
 10887	spoiled void burger	3	crappy	Last Available: "2022-12"
@@ -10765,11 +10765,11 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	activated flattened single-use dust mask	0		Effect: "Kissed By Fire", Effect Duration: 59, Last Available: "2022-05"
 10911	tarnished ionized ghostly gaffer's tape	0		Effect: "Rampage!", Effect Duration: 22, Last Available: "2022-05"
-10912	flavorless huge spinning 20-lb can of rice and beans	9	decent	Last Available: "2022-05"
+10912	huge flavorless spinning 20-lb can of rice and beans	9	decent	Last Available: "2022-05"
 10913	wobbly bar of freeze-dried water	1	EPIC	Last Available: "2022-05"
-10914	big stale expired MRE	5	decent	Last Available: "2022-05"
-10915	diet moldy red cool mint precipice bar	1	crappy	Last Available: "2022-05"
-10916	enchanted spoiled carrot cake precipice bar	4	crappy	Effect: "Tapped In", Effect Duration: 15, Last Available: "2022-05"
+10914	stale big expired MRE	5	decent	Last Available: "2022-05"
+10915	moldy diet red cool mint precipice bar	1	crappy	Last Available: "2022-05"
+10916	spoiled enchanted carrot cake precipice bar	4	crappy	Effect: "Tapped In", Effect Duration: 15, Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	spinning packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10779,15 +10779,15 @@
 10923	tasty fire-roasted lake trout	4	awesome	Last Available: "2022-06"
 10924	bland guilty sprout	4	decent	Last Available: "2022-06"
 10925	arcane researcher's experienced mother's necklace	0		Experience: +2, Experience Percent (Mysticality): +10, Last Available: "2022-06"
-10926	improved huge shaking trampled ticket stub	0		Effect: "Cold Hard Skin", Effect Duration: 34, Last Available: "2022-06"
+10926	improved shaking huge trampled ticket stub	0		Effect: "Cold Hard Skin", Effect Duration: 34, Last Available: "2022-06"
 10927	flattened gray twirling savings bond	0		Effect: "Mana Tea", Effect Duration: 66, Last Available: "2022-06"
 10928	squat designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	boiled shaking sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	mirror stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
-10934	bouncing teal dinosaur scale	0		
+10934	teal bouncing dinosaur scale	0		
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	Jim Carey's pterodactyl rifle	0		Monster Level: +25, Conditional Skill (Equipped): "Snipe Pterodactyl"
@@ -10809,10 +10809,10 @@
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	flattened cold-filtered autumn leaf	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 42, Last Available: "2022-10"
-10956	spirit-forward hand-crafted cyan AutumnFest ale	5	EPIC	Last Available: "2022-10"
+10956	hand-crafted spirit-forward cyan AutumnFest ale	5	EPIC	Last Available: "2022-10"
 10957	clever curative steel-toed autumn sweater-weather sweater	0		Damage Reduction: 9, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
 10958	ghostly auspicious Newton's Samson's boxer's autumn debris shield	0		Muscle Percent: +10, Experience (Muscle): +5, Experience (Mysticality): +3, Item Drop: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	huge stale autumn-spice donut	6	decent	Last Available: "2022-10"
+10959	stale huge autumn-spice donut	6	decent	Last Available: "2022-10"
 10960	alkaline dry wobbly ghostly gray autumn dollar	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 26, Last Available: "2022-10"
 10961	blinking ruddy wizardly weightlifter's autumn leaf pendant	0		Muscle: +15, Mysticality: +25, Maximum HP Percent: +40, Lasts Until Rollover, Last Available: "2022-10"
 10962	vaporized blurry autumn breeze	1		Last Available: "2022-10"
@@ -10824,36 +10824,36 @@
 10968	squat St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	adequate ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
-10971	enchanted huge adequate Jarlsberg's vegetable soup	10	good	Effect: "Gummibrain", Effect Duration: 40, Last Available: "2022-11"
-10972	flavorless immense roasted vegetable of Jarlsberg	7	decent	Last Available: "2022-11"
+10971	huge enchanted adequate Jarlsberg's vegetable soup	10	good	Effect: "Gummibrain", Effect Duration: 40, Last Available: "2022-11"
+10972	immense flavorless roasted vegetable of Jarlsberg	7	decent	Last Available: "2022-11"
 10973	decent St. Pete's sneaky smoothie	4	good	Last Available: "2022-11"
 10974	delicious low-calorie Pete's wiley whey bar	1	awesome	Last Available: "2022-11"
-10975	jumbo normal Pete's rich ricotta	5	good	Last Available: "2022-11"
+10975	normal jumbo Pete's rich ricotta	5	good	Last Available: "2022-11"
 10976	perfectly mixed Boris's beer	4	EPIC	Last Available: "2022-11"
 10977	flavorless yellow honey bun of Boris	3	decent	Last Available: "2022-11"
 10978	low-calorie moldy Boris's bread	1	crappy	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	narrow Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	upside-down Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	spinning Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	ghostly Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	yellow Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	narrow Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	upside-down Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	spinning Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	ghostly Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	yellow Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	adequate fancy maroon narrow baked veggie ricotta casserole	4	good	Effect: "Mental A-cue-ity", Effect Duration: 40, Last Available: "2022-11"
 10989	spoiled plain calzone	3	crappy	Last Available: "2022-11"
 10990	moldy roasted vegetable focaccia	4	crappy	Last Available: "2022-11"
-10991	adequate low-calorie fancy upside-down Pizza of Legend	1	good	Effect: "Pop-eyed", Effect Duration: 10, Last Available: "2022-11"
+10991	low-calorie adequate fancy upside-down Pizza of Legend	1	good	Effect: "Pop-eyed", Effect Duration: 10, Last Available: "2022-11"
 10992	fancy normal pulsating Calzone of Legend	3	good	Effect: "Shawarma Initiative", Effect Duration: 5, Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	blurry Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	purple Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	upside-down Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	upside-down teal Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	blurry Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	purple Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	upside-down Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	upside-down teal Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	pulsating cookbookbat book	0		Familiar Weight: +5
-10999	pulsating Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	flavorless tiny Deep Dish of Legend	1	decent	Last Available: "2022-11"
+10999	pulsating Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	tiny flavorless Deep Dish of Legend	1	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	ghostly government per-diem	0		
@@ -10868,7 +10868,7 @@
 11012	olive milk cap	0		
 11013	aged narrow Charleston Choo-Choo	3	awesome	
 11014	drinkable fuchsia Velvet Veil	4	good	
-11015	special artisanal watered-down Marltini	2	EPIC	Effect: "Bricked-In", Effect Duration: 45
+11015	watered-down artisanal special Marltini	2	EPIC	Effect: "Bricked-In", Effect Duration: 45
 11016	lousy Strong, Silent Type	3	decent	
 11017	tolerable Mysterious Stranger	3	good	
 11018	mediocre Champagne Shimmy	4	decent	
@@ -10890,7 +10890,7 @@
 11034	compressed pulsating chiffon carbage	1		Last Available: "2023-12"
 11035	colloidal colloidal chiffon lemon	0		Effect: "Flashing Eyes", Effect Duration: 19
 11036	bland jittery chocomotive	4	decent	Last Available: "2022-12"
-11037	big yummy freightcake	5	awesome	Last Available: "2022-12"
+11037	yummy big freightcake	5	awesome	Last Available: "2022-12"
 11038	watered-down hand-crafted cabooze	2	super EPIC	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	wool plastic passenger car	0		Cold Resistance: +1, Last Available: "2022-12"
@@ -10904,7 +10904,7 @@
 11048	Trainbot radar monocle	0		Single Equip
 11049	squat pile of Trainbot parts	0		
 11050	dry chilled Trainbot circuitry	0		Effect: "Turtle Power", Effect Duration: 60
-11051	double-flattened denatured olive upside-down Trainbot tubing	0		Effect: "Knightlife", Effect Duration: 38
+11051	double-flattened denatured upside-down olive Trainbot tubing	0		Effect: "Knightlife", Effect Duration: 38
 11052	alkaline polarized huge Trainbot plating	0		Effect: "Venomous Weapon", Effect Duration: 47
 11053	ionized Trainbot optics	0		Effect: "Dreadful Chill", Effect Duration: 50
 11054	warmed nitrogenated Trainbot servomotors	0		Effect: "Bonelording", Effect Duration: 30
@@ -10923,7 +10923,7 @@
 11067	distilled acceptable dregs of a Crimbo cocktail	5	good	
 11068	lost elf luggage	0		
 11069	upside-down Trainbot luggage hook	0		Single Equip
-11070	normal snack-sized jittery honey-drenched ham slice	2	good	
+11070	snack-sized normal jittery honey-drenched ham slice	2	good	
 11071	drinkable upside-down mostly-empty bottle of cookie wine	3	good	
 11072	flavorless super-sized skewed Crimbo food scraps	5	decent	
 11073	upside-down arm towel	0		Last Available: "2022-12"
@@ -10932,7 +10932,7 @@
 11076	Trainbot slag	0		
 11077	spinning industrially-crushed ice	0		Last Available: "2022-12"
 11078	toothsome maroon steamed oyster	3	awesome	
-11079	blue mirror really nice lump of coal	0		
+11079	mirror blue really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
@@ -10955,7 +10955,7 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
-11102	vaporized spinning jittery fruity pebble	1		Last Available: "2023-01"
+11102	vaporized jittery spinning fruity pebble	1		Last Available: "2023-01"
 11103	upside-down lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	squat milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
@@ -10972,21 +10972,21 @@
 11117	flattened galvanized glob of extra-green chlorophyll	0		Effect: "Steroid Boost", Effect Duration: 61, Last Available: "2023-02"
 11118	liquefied mushroom	0		Effect: "Cringle's Curative Carol", Effect Duration: 20, Last Available: "2023-02"
 11119	aerosolized triple-boiled five-fingered fern resin	0		Effect: "Deadly Flashing Blade", Effect Duration: 44, Last Available: "2023-02"
-11120	fancy spoiled miniature pulsating super good fruit	2	crappy	Effect: "Abyssal Blood", Effect Duration: 10, Last Available: "2023-02"
+11120	spoiled fancy miniature pulsating super good fruit	2	crappy	Effect: "Abyssal Blood", Effect Duration: 10, Last Available: "2023-02"
 11121	twisted energized spores	1		Effect: "'Roids of the Rhinoceros", Effect Duration: 35, Last Available: "2023-02"
-11122	shaking lightning-fast toasty hot pepper	0		Hot Damage: +5, Initiative: +40, Lantern Element: "Hot", Last Available: "2023-02"
+11122	shaking lightning-fast toasty hot pepper	0		Hot Damage: +5, Initiative: +40, Last Available: "2023-02", Lantern Element: "Hot"
 11123	denatured out-of-work circus flea	0		Effect: "Can Has Cyborger", Effect Duration: 30, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	oxidized fire ant pheromones	0		Effect: "Night Vision", Effect Duration: 24, Last Available: "2023-02"
 11126	denatured flapper fly	0		Effect: "Vanity Rage", Effect Duration: 14, Last Available: "2023-02"
-11127	irresponsibly strong special bad shot of wasp venom	7	decent	Effect: "Patience of the Tortoise", Effect Duration: 10, Last Available: "2023-02"
-11128	pickled pulsating shaking filled mosquito	0		Effect: "Extra Backbone", Effect Duration: 66, Last Available: "2023-02"
+11127	bad special irresponsibly strong shot of wasp venom	7	decent	Effect: "Patience of the Tortoise", Effect Duration: 10, Last Available: "2023-02"
+11128	pickled shaking pulsating filled mosquito	0		Effect: "Extra Backbone", Effect Duration: 66, Last Available: "2023-02"
 11129	colloidal double-chilled narrow shim of shame shale	0		Effect: "Your Favorite Flavor", Effect Duration: 40, Last Available: "2023-02"
 11130	ionized boiled jittery pebble of proud pyrite	0		Effect: "Really Deep Breath", Effect Duration: 55, Last Available: "2023-02"
 11131	triple-boiled spinning pile of gritty sand	0		Effect: "Heart of Green", Effect Duration: 32, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	cold-filtered spinning angry agate	0		Effect: "Purity of Spirit", Effect Duration: 44, Last Available: "2023-02"
-11134	super-pickled wobbly blurry lump of loyal latite	0		Effect: "Cat Class, Cat Style", Effect Duration: 11, Last Available: "2023-02"
+11134	super-pickled blurry wobbly lump of loyal latite	0		Effect: "Cat Class, Cat Style", Effect Duration: 11, Last Available: "2023-02"
 11135	decent shadow sausage	3	good	Last Available: "2023-03"
 11136	skewed ghostly smartaleck's brawny shadow skin	0		Muscle Percent: +20, Moxie Percent: +30, Last Available: "2023-03"
 11137	polarized denatured unsweetened shadow flame	0		Effect: "How to Scam Tourists", Effect Duration: 25, Last Available: "2023-03"
@@ -11011,7 +11011,7 @@
 11156	prompt uncursed arcane orb	0		Adventures: +3
 11157	machete of courage	0		Spooky Resistance: +3
 11158	uncursed machete of Leguizamo	0		Monster Level: +20
-11159	purple narrow mirror blanket	0		
+11159	mirror purple narrow blanket	0		
 11160	uncursed blanket	0		
 11161	vibrating Samson's slick medallion	0		Moxie: +10, Experience (Muscle): +5, Maximum MP Percent: +10
 11162	experienced uncursed medallion	0		Experience: +2
@@ -11059,7 +11059,7 @@
 11204	blurry replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	upside-down replica cotton candy cocoon	0		
 11206	wobbly zippy lard-coated replica Elvish sunglasses of dire peril of Gandalf	0		Weapon Damage: +20, Spell Critical Percent: +20, Sleaze Spell Damage: +25, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
-11207	wobbly green replica squamous polyp	0		
+11207	green wobbly replica squamous polyp	0		
 11208	replica stone sphere	0		
 11209	executive Sinatra's groovy replica Greatest American Pants	0		Moxie Percent: +10, Experience (Moxie): +5, Meat Drop: +40
 11210	replica organ grinder	0		
@@ -11100,7 +11100,7 @@
 11245	Jim Carey's manspreader's educational replica Cargo Cultist Shorts of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Monster Level: 35
 11246	blurry fortified educational strapping replica industrial fire extinguisher of dire peril of chilblains of horror	0		Muscle: +5, Experience: +1, Weapon Damage: +20, Damage Absorption: +60, Cold Damage: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 11247	spinning replica crystal ball	0		Initiative: +50
-11248	wobbly blurry replica emotion chip	0		Skill: "Replica Emotionally Chipped"
+11248	blurry wobbly replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	mirror flame-retardant therapeutic replica Jurassic Parka	0		Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 11250	narrow replica grey gosling	0		
 11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
@@ -11109,7 +11109,7 @@
 11254	blurry family-friendly smelly fortified padded replica Cincho de Mayo	0		Damage Absorption: 80, Stench Spell Damage: +10, Sleaze Resistance: +1, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11255	Thwaitgold splendor beetle statuette	0		
 11256	huge shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
-11257	wobbly twirling olive 2002 Mr. Store Catalog	0		Last Available: "2023-06"
+11257	olive twirling wobbly 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	jittery upside-down knitted lard-coated scorching nippy shellacked &quot;I survived Y2K&quot; T-Shirt	0		Damage Reduction: 7, Cold Damage: +10, Hot Damage: +25, Sleaze Spell Damage: +25, Cold Resistance: +3, Item Drop: +5, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
 11260	dangerous Newton's pro skateboard	0		Experience (Mysticality): +3, Weapon Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
@@ -11117,7 +11117,7 @@
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	ghostly Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	twirling Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	twirling Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	mirror Flash Liquidizer Ultra Dousing Accessory of doom	0		Spooky Spell Damage: +50, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	Sherlock's supercharged padded weightlifter's Amulet of Perpetual Darkness	0		Muscle: +15, Damage Absorption: +20, Maximum MP Percent: +30, Item Drop: +25, Last Available: "2023-06"
 11268	narrow Giant monolith	0		Last Available: "2023-06"
@@ -11125,7 +11125,7 @@
 11270	mirror VHS Tape	0		Last Available: "2023-06"
 11271	dry ionized scroll of minor invulnerability	0		Effect: "stats.enq", Effect Duration: 17, Last Available: "2023-06"
 11272	cyan Lapis Lazuli	0		Last Available: "2023-06"
-11273	ghostly jittery Eye Agate	0		Last Available: "2023-06"
+11273	jittery ghostly Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
 11276	dry scroll of protection from lycanthropes	0		Effect: "Like a Fish to Walter", Effect Duration: 18, Last Available: "2023-06"
@@ -11134,10 +11134,10 @@
 11279	lime green Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	jittery Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	weak perfectly mixed Sexy Cosmo	2	EPIC	Last Available: "2023-06"
-11283	huge narrow Souvenir Chopsticks	0		Last Available: "2023-06"
+11282	perfectly mixed weak Sexy Cosmo	2	EPIC	Last Available: "2023-06"
+11283	narrow huge Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	cyan sage red-soled high heels of the wise owl of the storm	0		Mysticality: +20, Mysticality Percent: +10, Maximum MP Percent: +40, Last Available: "2023-06"
-11285	big spoiled cyburger	5	crappy	Last Available: "2025-12"
+11285	spoiled big cyburger	5	crappy	Last Available: "2025-12"
 11286	teal ncle leg of the early riser	0		Adventures: +7
 11287	squat educational savvy rutabuga bag	0		Mysticality Percent: +20, Experience: +1
 11288	sizzling mesquito proboscis	0		Hot Damage: +10
@@ -11162,7 +11162,7 @@
 11307	flavorless spinning watermelon	3	decent	
 11308	watermelon seed	0		
 11309	water balloon	0		
-11310	jittery ghostly thriftshop coupon	0		
+11310	ghostly jittery thriftshop coupon	0		
 11311	flavorless shaking waffle	4	decent	
 11312	fixodent	0		
 11313	bouncing chilly cat o' nine teeth	0		Cold Damage: +5, Item Drop: +5
@@ -11174,17 +11174,17 @@
 11319	skewed medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	mediocre bottle of Cabernet Sauvignon	4	decent	
 11321	shaking executive reassuring occult baywatch	0		Spell Damage Percent: +25, Spooky Resistance: +1, Meat Drop: +40, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	altered narrow wobbly narrow concentrated cooking	1		Effect: "Vitali Tea", Effect Duration: 15
+11328	altered narrow narrow wobbly concentrated cooking	1		Effect: "Vitali Tea", Effect Duration: 15
 11329	compressed meat	1		Effect: "Burnt 'n' Turnt", Effect Duration: 45
 11330	altered pulsating red sparkling orb	1		
 11331	dehydrated hardening cream	1		Effect: "Meatwise", Effect Duration: 10
-11332	dried spinning red pool shark hair oil	1		
+11332	dried red spinning pool shark hair oil	1		
 11333	bouncing book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	bouncing Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11212,7 +11212,7 @@
 11357	friendly smoldering drape of the storm	0		Maximum MP Percent: +40, Familiar Weight: +3, Lasts Until Rollover
 11358	mirror smoldering leafcutter ant egg	0		
 11359	Annie Oakley's Sinatra's experienced leaf crown of the brute of horror	0		Muscle Percent: +30, Experience: +2, Experience (Moxie): +5, Critical Hit Percent: +20, Spooky Spell Damage: +25, Item Drop: +5
-11360	adequate huge blinking leafy browns	9	good	
+11360	huge adequate blinking leafy browns	9	good	
 11361	dry pulsating autumnic balm	0		Effect: "Sparkling Consciousness", Effect Duration: 36
 11362	altered non-boiled shaking coping juice	0		Effect: "Well-preserved", Effect Duration: 21
 11363	mirror Van der Graaf banded candy cane sword cane of the pedagogue of Calamity Jane of the sewer	0		Experience: +3, Damage Absorption: +100, Critical Hit Percent: +15, Stench Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11228,7 +11228,7 @@
 11373	Spring Bros. solenoid	0		
 11374	Spring Bros. ID badge	0		
 11375	lime green Boltsmann ID badge	0		
-11376	cyan twirling upside-down housekeeping automa-core	0		
+11376	twirling upside-down cyan housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	normal pickled bread	3	good	Last Available: "2023-12"
 11379	normal tumbling salted mutton	3	good	Last Available: "2023-12"
@@ -11242,7 +11242,7 @@
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
 11388	pirate encryption key charlie	0		Last Available: "2023-12"
 11389	pirate encryption key delta	0		Last Available: "2023-12"
-11390	blinking skewed wardrobe-o-matic	0		
+11390	skewed blinking wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
@@ -11274,7 +11274,7 @@
 11419	Sinatra's Elf Guard broom of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10, Last Available: "2023-12"
 11420	narrow manspreader's Crimbuccaneer tavern swab of the pedagogue of incineration	0		Experience: +3, Monster Level: +10, Hot Spell Damage: +50, Last Available: "2023-12"
 11421	wobbly Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	practically non-alcoholic lousy old-school pirate grog	1	decent	Last Available: "2023-12"
+11422	lousy practically non-alcoholic old-school pirate grog	1	decent	Last Available: "2023-12"
 11423	moldy grog nuts	4	crappy	Last Available: "2023-12"
 11424	aromatic baleful sawed-off blunderbuss of mayonnaise	0		Spell Damage: +25, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2023-12"
 11425	hand-crafted watered-down tumbling officer's nog	2	EPIC	Last Available: "2023-12"
@@ -11312,23 +11312,23 @@
 11457	energetic savvy Elvish underarmor of the storm	0		Mysticality Percent: +20, Maximum MP Percent: 60, Single Equip, Last Available: "2023-12"
 11458	medical-grade Socratic Crimbuccaneer bombjacket	0		Experience (Mysticality): +1, HP Regen Min: 7, HP Regen Max: 10, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	bland big sugarplum ration	5	decent	Last Available: "2023-12"
-11460	stale low-calorie special gingerbread nylons	1	decent	Effect: "Three Days Slow", Effect Duration: 10, Last Available: "2023-12"
-11461	half-sized moldy ghostly rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
+11460	low-calorie special stale gingerbread nylons	1	decent	Effect: "Three Days Slow", Effect Duration: 10, Last Available: "2023-12"
+11461	moldy half-sized ghostly rum-soaked fruitcake	2	crappy	Last Available: "2023-12"
 11462	decent lime	4	good	Last Available: "2023-12"
 11463	normal blue gingerbread pirate	4	good	Last Available: "2023-12"
-11464	stale miniature fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
+11464	miniature stale fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
 11465	tolerable weak mulled wine	2	good	Last Available: "2023-12"
 11466	tolerable watered-down Swedish coffee	2	good	Last Available: "2023-12"
-11467	fancy artisanal squat canteen of eggnog	3	super EPIC	Effect: "Moon'd", Effect Duration: 15, Last Available: "2023-12"
+11467	artisanal fancy squat canteen of eggnog	3	super EPIC	Effect: "Moon'd", Effect Duration: 15, Last Available: "2023-12"
 11468	perfectly mixed hot wine	4	EPIC	Last Available: "2023-12"
-11469	watered-down hand-crafted Jamaican coffee	2	EPIC	Last Available: "2023-12"
-11470	high-proof hand-crafted flask of egggrog	7	EPIC	Last Available: "2023-12"
+11469	hand-crafted watered-down Jamaican coffee	2	EPIC	Last Available: "2023-12"
+11470	hand-crafted high-proof flask of egggrog	7	EPIC	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	huge Black and White Apron Meal Kit	0		Last Available: "2024-12"
-11473	cyan mirror pirate encryption key (complete)	0		Last Available: "2023-12"
+11473	mirror cyan pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	lousy yule grog	3	decent	Last Available: "2023-12"
 11475	flavorless wet tack	3	decent	Last Available: "2023-12"
-11476	huge tasty whalecake	6	awesome	Last Available: "2023-12"
+11476	tasty huge whalecake	6	awesome	Last Available: "2023-12"
 11477	mansplainer's gunwale whalegun of the blizzard of the detective	0		Monster Level: +15, Cold Spell Damage: +25, Item Drop: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	mediocre weak and claret	2	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
@@ -11341,7 +11341,7 @@
 11486	olive huge Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
 11487	olive prank Crimbo card	0		Last Available: "2023-12"
 11488	thinker's Crimbuccaneer squirtblunderbuss of terror	0		Mysticality: +10, Spooky Spell Damage: +10, Last Available: "2023-12"
-11489	mirror twirling My First Paycheck envelope	0		Last Available: "2023-12"
+11489	twirling mirror My First Paycheck envelope	0		Last Available: "2023-12"
 11490	scorching chilly barnacle-encrusted sweater of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +5, Hot Damage: +25, Last Available: "2023-12"
 11491	lime green studded stylish Crimbuccaneer nose ring of the sweet-tooth	0		Moxie: +25, Damage Absorption: +80, Candy Drop: +100, Last Available: "2023-12"
 11492	narrow pet anchor	0		Last Available: "2023-12"
@@ -11371,7 +11371,7 @@
 11516	blinking adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	diluted blurry spinning adobe assortment	1		Effect: "Preternatural Greed", Effect Duration: 45, Last Available: "2024-12"
-11519	electrified huge squat adobe brittle	0		Effect: "Granolarrrgh", Effect Duration: 27
+11519	electrified squat huge adobe brittle	0		Effect: "Granolarrrgh", Effect Duration: 27
 11520	scorching healthy weightlifter's crepe paper phrygian cap	0		Muscle: +15, Maximum HP Percent: +20, Hot Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	quilted crepe paper parachute cape of the overflowing toilet of the cheetah	0		Damage Absorption: +40, Stench Spell Damage: +50, Initiative: +60, Last Available: "2025-12"
 11522	upside-down up-at-dawn miser's grievous crepe paper pie clip	0		Weapon Damage Percent: +50, Meat Drop: +10, Adventures: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
@@ -11382,8 +11382,8 @@
 11527	triple-corrupted altered pulsating crepe paper peanut candy	0		Effect: "Okee-Dokee Computer", Effect Duration: 11
 11528	huge petrified wood war pike of the pedagogue of James Dean	0		Experience: +3, Experience (Moxie): +3, Last Available: "2025-12"
 11529	toasty personal trainer's petrified wood waist protector	0		Experience Percent (Muscle): +10, Hot Damage: +5, Single Equip, Last Available: "2025-12"
-11530	family-friendly beefcake's petrified wood wizard's pouch	0		Muscle: +25, Sleaze Resistance: +1, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	energetic Samson's petrified wood water purifier	0		Experience (Muscle): +5, Maximum MP Percent: +20, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	family-friendly beefcake's petrified wood wizard's pouch	0		Muscle: +25, Sleaze Resistance: +1, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	energetic Samson's petrified wood water purifier	0		Experience (Muscle): +5, Maximum MP Percent: +20, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	nasty padded petrified wood whoopie panama	0		Damage Absorption: +20, Stench Damage: +5, Last Available: "2025-12"
 11533	prompt slick petrified wood walking pants	0		Moxie: +10, Adventures: +3, Last Available: "2025-12"
 11534	powdered purple petrified wood waste parts	1		Last Available: "2025-12"
@@ -11407,7 +11407,7 @@
 11552	fuchsia high-tension exoskeleton	0		
 11553	spinning ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
-11555	yellow wobbly ghostly quick-release belt pouch	0		Single Equip
+11555	wobbly ghostly yellow quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
 11557	blurry quick-release utility belt	0		Single Equip
 11558	motion sensor of Flo-Jo	0		Initiative: +100, Single Equip
@@ -11422,13 +11422,13 @@
 11567	asbestos-lined educational strapping Apriling band quad tom of the dark arts	0		Muscle: +5, Experience: +1, Spell Damage Percent: +100, Hot Resistance: +5, Lasts Until Rollover
 11568	chaotic MacGyver's dance instructor's supercool smooth Apriling band tuba	0		Moxie: +15, Moxie Percent: +20, Experience Percent (Moxie): +10, Maximum MP: +100, Spell Critical Percent: +10, Lasts Until Rollover
 11569	Sherlock's perfumed stiffened sinister Apriling band staff of chilblains of the sweet-tooth	0		Spell Damage: +10, Damage Reduction: 1, Cold Damage: +25, Stench Resistance: +5, Item Drop: +25, Candy Drop: +100, Lasts Until Rollover
-11570	blinking spinning Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
+11570	spinning blinking Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	mirror boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11572	squat olive Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	snack-sized stale upside-down yam	2	decent	Last Available: "2024-05"
+11572	olive squat Mayam Calendar	0		Free Pull, Last Available: "2024-05"
+11573	stale snack-sized upside-down yam	2	decent	Last Available: "2024-05"
 11574	tolerable yam martini	3	good	Last Available: "2024-05"
 11575	tolerable sweet potato o' mine	3	good	Last Available: "2024-05"
-11576	fortified smooth blurry skewed Southern yam	5	awesome	Last Available: "2024-05"
+11576	fortified smooth skewed blurry Southern yam	5	awesome	Last Available: "2024-05"
 11577	acceptable narrow sweet potato punch	4	good	Last Available: "2024-05"
 11578	miniature stale jittery Mayam spinach	2	decent	Last Available: "2024-05"
 11579	stale yam and swiss	4	decent	Last Available: "2024-05"
@@ -11441,8 +11441,8 @@
 11586	frightening MacGyver's yamtility belt of the wise owl	0		Mysticality: +20, Maximum MP: +100, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2024-05"
 11587	adequate spinning yam slider	4	good	Last Available: "2024-05"
 11588	huge flavorless yam mayo	6	decent	Last Available: "2024-05"
-11589	flavorless fancy thick yam burrito	5	decent	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2024-05"
-11590	blinking squat visual packet sniffer	0		Last Available: "2025-12"
+11589	flavorless thick fancy yam burrito	5	decent	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2024-05"
+11590	squat blinking visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	narrow Thwaitgold Illinigina illinoiensis model	0		
@@ -11453,25 +11453,25 @@
 11598	mini kiwi aioli	0		
 11599	nasty therapeutic mini kiwi silicon tiepin of the brute	0		Muscle Percent: +30, Stench Damage: +5, HP Regen Min: 5, HP Regen Max: 7
 11600	spinning mini kiwi tipi	0		
-11601	bland thick mini kiwi digitized cookies	5	decent	
+11601	thick bland mini kiwi digitized cookies	5	decent	
 11602	boozy bad enchanted mini kiwi intoxicating spirits	5	decent	Effect: "Space Tripping", Effect Duration: 45
 11603	non-electrified mini kiwi antimilitaristic hippy petition	0		Effect: "Smelly Pants", Effect Duration: 32
 11604	improved mini kiwi illicit antibiotic	0		Effect: "Pork Power", Effect Duration: 39
 11605	lard-coated baleful mini kiwi whipping stick	0		Spell Damage: +25, Sleaze Spell Damage: +25
 11606	mini kiwi icepick of terror	0		Spooky Spell Damage: +10
 11607	corrupted mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Fudgehound", Effect Duration: 13
-11608	blurry twirling packaged Roman Candelabra	0		Free Pull
+11608	twirling blurry packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
-11610	upside-down green ghostly protogenetic chunklet (synapse)	0		
+11610	upside-down ghostly green protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
-11612	blue pulsating huge protogenetic chunklet (flagellum)	0		
+11612	pulsating huge blue protogenetic chunklet (flagellum)	0		
 11613	protogenetic chunklet (elbow)	0		
 11614	protogenetic chunklet (lips)	0		
 11615	gravedigger's energetic brawny messenger bag RNA	0		Muscle Percent: +20, Maximum MP Percent: +20, Spooky Damage: +10
 11616	flagellate flagon	0		
 11617	blurry proto-proto-protozoa	0		
-11618	rotten special bacteria bisque	3	crappy	Effect: "Chauve-Souris Merde Fou", Effect Duration: 5
-11619	decent special ciliophora chowder	4	good	Effect: "Ghost Finger", Effect Duration: 10
+11618	special rotten bacteria bisque	3	crappy	Effect: "Chauve-Souris Merde Fou", Effect Duration: 5
+11619	special decent ciliophora chowder	4	good	Effect: "Ghost Finger", Effect Duration: 10
 11620	flavorless cream of chloroplasts	3	decent	
 11621	huge synaptic soup	0		
 11622	shaking muscular soup	0		
@@ -11479,7 +11479,7 @@
 11624	twirling elbow soup	0		
 11625	lip soup	0		
 11626	unevolved organism	0		Free Pull
-11627	blurry blue extra ooze	0		
+11627	blue blurry extra ooze	0		
 11628	extra DNA	0		Experience (familiar): +1
 11629	bouncing untorn tearaway pants package	0		Free Pull
 11630	cyan blinking prompt ruddy grievous arcane researcher's tearaway pants of horror	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Maximum HP Percent: +40, Spooky Spell Damage: +25, Adventures: +3, Conditional Skill (Equipped): "Tear Away your Pants!"
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	dog trainer's MacGyver's shellacked embers-only jacket	0		Damage Reduction: 7, Maximum MP: +100, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2024-09"
 11649	frosty bembershoot	0		Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-09"
-11650	special bite-sized toothsome blinking wheel of camembert	1	awesome	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2024-09"
+11650	bite-sized toothsome special blinking wheel of camembert	1	awesome	Effect: "Gyromitra Gymnastics", Effect Duration: 40, Last Available: "2024-09"
 11651	auspicious scorching hat of remembering of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +25, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-09"
 11652	blinking throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11530,13 +11530,13 @@
 11675	moldy peaza	3	crappy	Last Available: "2024-11"
 11676	yellow peace shooter	0		Last Available: "2024-11"
 11677	compressed ghostly spinning drenchrome 2.0	1		Last Available: "2025-12"
-11678	dehydrated green shaking blinking Synapse Blaster	1		Effect: "White-boy Angst", Effect Duration: 40, Last Available: "2025-12"
+11678	dehydrated shaking green blinking Synapse Blaster	1		Effect: "White-boy Angst", Effect Duration: 40, Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	huge red quantized familiar experience	0		
 11682	cold-filtered altered pea brittle	0		Effect: "Coy to the Hurled", Effect Duration: 58, Last Available: "2024-11"
-11683	tolerable weak peasco	2	good	Last Available: "2024-11"
-11684	small flavorless piece of cake	2	decent	Last Available: "2024-11"
+11683	weak tolerable peasco	2	good	Last Available: "2024-11"
+11684	flavorless small piece of cake	2	decent	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	bouncing ghostly Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	crafty silky pirate drawers of wisdom	0		Mysticality: +15, Maximum MP: +10, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	polymerized peppermint pegleg	0		Effect: "Poker Faced", Effect Duration: 43, Last Available: "2024-12"
-11710	acceptable enchanted skewed hard cocoa	3	good	Effect: "Less Pervious", Effect Duration: 25, Last Available: "2024-12"
+11710	enchanted acceptable skewed hard cocoa	3	good	Effect: "Less Pervious", Effect Duration: 25, Last Available: "2024-12"
 11711	spoiled blue salmagumdi	3	crappy	Last Available: "2024-12"
 11712	Socratic plastic Easter Island Bunny	0		Experience (Mysticality): +1, Last Available: "2024-12"
 11713	plastic St. Patrick of the ox	0		Muscle: +20, Last Available: "2024-12"
@@ -11574,15 +11574,15 @@
 11719	mirror Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	wobbly Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	adequate spinning squat coney haunch	3	good	Last Available: "2024-12"
+11722	adequate squat spinning coney haunch	3	good	Last Available: "2024-12"
 11723	energized blinking dark chocolate egg	0		Effect: "Perfect Hair", Effect Duration: 43, Last Available: "2024-12"
 11724	artisanal moai toai	4	EPIC	
 11725	censurious Fonzie's groovy moaiball	0		Moxie Percent: +10, Experience (Moxie): +1, Sleaze Resistance: +3, Last Available: "2024-12"
 11726	ghostly half-digested rat	0		Last Available: "2024-12"
-11727	anodized narrow mirror four-leaf potato sprout	0		Effect: "Well Owl Be!", Effect Duration: 55, Last Available: "2024-12"
+11727	anodized mirror narrow four-leaf potato sprout	0		Effect: "Well Owl Be!", Effect Duration: 55, Last Available: "2024-12"
 11728	mirror up-at-dawn Jack Frost's potato jacket of the detective	0		Cold Spell Damage: +50, Item Drop: +20, Adventures: +5, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
-11730	olive skewed Brandonian footlocker key	0		Last Available: "2024-12"
+11730	skewed olive Brandonian footlocker key	0		Last Available: "2024-12"
 11731	brainy beefcake's military orb	0		Muscle: +25, Mysticality: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	dry rum ball	0		Effect: "Spell Transfer Complete", Effect Duration: 14
 11733	gravy skin	0		Last Available: "2024-12"
@@ -11606,29 +11606,29 @@
 11751	triple-distilled enchanted perfectly mixed mechanically-mulled cider	8	EPIC	Effect: "Spooky Hands", Effect Duration: 50, Last Available: "2024-12"
 11752	delicious holiday trip around the world	4	awesome	Last Available: "2024-12"
 11753	flavorless skewed chocolate ostrich egg	3	decent	Last Available: "2024-12"
-11754	miniature stale maroon beef and cabbage	2	decent	Last Available: "2024-12"
+11754	stale miniature maroon beef and cabbage	2	decent	Last Available: "2024-12"
 11755	moldy candy rations	3	crappy	Last Available: "2024-12"
 11756	yummy twirling double-candied yams	3	awesome	Last Available: "2024-12"
-11757	tiny moldy Christmas ham	1	crappy	Last Available: "2024-12"
+11757	moldy tiny Christmas ham	1	crappy	Last Available: "2024-12"
 11758	rotten huge holiday smorgasbord	3	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	wobbly brainy bejazzled eyepatch	0		Mysticality: +5, Last Available: "2024-12"
-11761	tumbling Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	twirling How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	narrow Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	spinning mirror Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	tumbling Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	twirling How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	narrow Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	spinning mirror Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	friendly veiny egg gun of the ox of Gandalf	0		Muscle: +20, Maximum HP: +10, Spell Critical Percent: +20, Familiar Weight: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	tumbling foul-smelling vibrating weightlifter's army helmet of the scaredy-cat	0		Muscle: +15, Maximum MP Percent: +10, Monster Level: -15, Stench Damage: +10, Last Available: "2024-12"
 11774	bouncing candy egg deviler	0		Last Available: "2024-12"
 11775	spinning napkin	0		Last Available: "2024-12"
-11776	half-sized moldy Thanksgiving ration	2	crappy	Last Available: "2024-12"
+11776	moldy half-sized Thanksgiving ration	2	crappy	Last Available: "2024-12"
 11777	drinkable Easter eggnog	4	good	Last Available: "2024-12"
 11778	powdered twirling clovermint	1		Last Available: "2024-12"
 11779	green coward's hardy veiny Fonzie's nylon Christmas stockings	0		Experience (Moxie): +1, Maximum HP: 60, Monster Level: -20, Single Equip, Last Available: "2024-12"
@@ -11644,21 +11644,21 @@
 11789	0	0		Last Available: "2025-12"
 11790	twisted tumbling eXpand	1		Effect: "Benetton's Medley of Diversity", Effect Duration: 45, Last Available: "2025-12"
 11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
-11792	wobbly jittery datastick	0		Last Available: "2025-12"
+11792	jittery wobbly datastick	0		Last Available: "2025-12"
 11793	blurry dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	fuchsia shaking dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	maroon dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	pulsating dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	teal dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
-11799	maroon ghostly dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
+11799	ghostly maroon dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	squat dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
-11802	blurry olive dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
+11802	olive blurry dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	upside-down cybervisor	0		Last Available: "2025-12"
 11804	pulsating retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	olive blinking malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	blinking olive malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	pulsating 3d printed server room key	0		Last Available: "2025-12"
@@ -11666,7 +11666,7 @@
 11811	logic grenade	0		Last Available: "2025-12"
 11812	altered psilocyber mushroom	1		Last Available: "2025-12"
 11813	red squat dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
-11814	fuchsia wobbly dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
+11814	wobbly fuchsia dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	skewed dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
@@ -11698,7 +11698,7 @@
 11843	Observer source code	0		
 11844	blurry chill gherkin	0		
 11845	childrens' stapler	0		
-11846	bouncing squat plover's egg	0		
+11846	squat bouncing plover's egg	0		
 11847	flyswatter	0		
 11848	tumbling Thwaitgold cordyceps ant statuette	0		
 11849	heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11722,15 +11722,15 @@
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	mirror unironic knife	0		
-11870	upside-down pulsating bar dart	0		Last Available: "2025-03"
+11870	pulsating upside-down bar dart	0		Last Available: "2025-03"
 11871	mixed ghostly leprechaun antidepressant pill	1		Effect: "Adventurer's Best Friendship", Effect Duration: 15, Last Available: "2025-03"
 11872	rotten Heck ramen	3	crappy	Last Available: "2025-03"
 11873	flavorless half-sized red burrito	2	decent	Last Available: "2025-03"
-11874	decent thick small beer brat	5	good	Last Available: "2025-03"
+11874	thick decent small beer brat	5	good	Last Available: "2025-03"
 11875	stale peach pie	3	decent	Last Available: "2025-03"
 11876	flavorless incredible mini-pizza	4	decent	Last Available: "2025-03"
 11877	artisanal mirror Divine sidecar	3	EPIC	Last Available: "2025-03"
-11878	watered-down perfectly mixed pulsating fuchsia tangarita sidecar	2	EPIC	Last Available: "2025-03"
+11878	watered-down perfectly mixed fuchsia pulsating tangarita sidecar	2	EPIC	Last Available: "2025-03"
 11879	artisanal gimlet sidecar	3	EPIC	Last Available: "2025-03"
 11880	acceptable vodka stratocaster sidecar	3	good	Last Available: "2025-03"
 11881	acceptable special bouncing prussian cathouse sidecar	3	good	Effect: "[800]Chocolate Reign", Effect Duration: 30, Last Available: "2025-03"
@@ -11740,7 +11740,7 @@
 11885	jittery glob of wet paper	0		Last Available: "2025-04"
 11886	blinking spitball	0		Last Available: "2025-04"
 11887	flattened wet paper weights	0		Effect: "Nasty, Nasty Breath", Effect Duration: 54, Last Available: "2025-04"
-11888	watered-down delicious blinking Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
+11888	delicious watered-down blinking Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
 11889	adequate pile of wet dates	3	good	Last Available: "2025-04"
 11890	pulsating papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	blurry wet blanket	0		Last Available: "2025-04"
@@ -11750,7 +11750,7 @@
 11895	wet paper tiger	0		Last Available: "2025-04"
 11896	ghostly wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
-11898	anodized polarized bouncing mirror wet paper cup	0		Effect: "Pecan Pied Piper", Effect Duration: 39, Last Available: "2025-04"
+11898	anodized polarized mirror bouncing wet paper cup	0		Effect: "Pecan Pied Piper", Effect Duration: 39, Last Available: "2025-04"
 11899	triple-vacuum-sealed triple-adjusted twirling wet paperback	0		Effect: "Gummiheart", Effect Duration: 50, Last Available: "2025-04"
 11900	hale wet shower radio	0		Maximum HP: +20, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	wobbly wet shower stamp	0		Last Available: "2025-04"
@@ -11805,7 +11805,7 @@
 11950	baleful time cop top hat	0		Spell Damage: +25, Last Available: "2025-08"
 11951	red Stock Certificate	0		Last Available: "2025-08"
 11952	powdered mixed berry jelly	1		Last Available: "2025-08"
-11953	big moldy bouncing toast with mixed berry jelly	5	crappy	Last Available: "2025-08"
+11953	moldy big bouncing toast with mixed berry jelly	5	crappy	Last Available: "2025-08"
 11954	tasty cup of sugar	3	awesome	Last Available: "2025-08"
 11955	special stale mirror Susie's cupcake	3	decent	Effect: "Rootin' Around", Effect Duration: 25, Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
@@ -11822,7 +11822,7 @@
 11968	shaking blurry scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	twirling sea gel	0		
-11971	ionized energized shaking teal octopus ink bladder	0		Effect: "Stick Emporium Membership", Effect Duration: 52
+11971	ionized energized teal shaking octopus ink bladder	0		Effect: "Stick Emporium Membership", Effect Duration: 52
 11972	mirror durable dolphin whistle	0		
 11973	gray Thwaitgold lobster statuette	0		
 11974	blurry packaged Monodent of the Sea	0		Free Pull
@@ -11832,7 +11832,7 @@
 11986	pulsating lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	nasty coward's vibrating rock-hard sinister personal trainer's blood cubic zirconia	0		Experience Percent (Muscle): +10, Spell Damage: +10, Damage Reduction: 5, Maximum MP Percent: +10, Monster Level: -20, Stench Damage: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	compressed narrow blood thinner	1		Last Available: "2025-10"
-12045	special tolerable pheromone cocktail	4	good	Effect: "Neuromancy", Effect Duration: 40, Last Available: "2025-10"
+12045	tolerable special pheromone cocktail	4	good	Effect: "Neuromancy", Effect Duration: 40, Last Available: "2025-10"
 12046	immense normal upside-down spinal tapas	7	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	censurious shrunken head of the ox of the early riser	0		Muscle: +20, Sleaze Resistance: +3, Adventures: +7, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
@@ -11896,8 +11896,8 @@
 12138	flame-retardant smelly mansplainer's fistbone	0		Monster Level: +15, Stench Spell Damage: +10, Hot Resistance: +1, Last Available: "2025-12"
 12139	green up-at-dawn lightning-fast burnt bone belt of the ox	0		Muscle: +20, Initiative: +40, Adventures: +5, Single Equip, Last Available: "2025-12"
 12140	banded scorched skull trophy	0		Damage Absorption: +100, Last Available: "2025-12"
-12141	bland low-calorie wing bone	1	decent	Last Available: "2025-12"
-12142	practically non-alcoholic hand-crafted teal blinking weak skeleton venom	1	EPIC	Last Available: "2025-12"
+12141	low-calorie bland wing bone	1	decent	Last Available: "2025-12"
+12142	hand-crafted practically non-alcoholic blinking teal weak skeleton venom	1	EPIC	Last Available: "2025-12"
 12143	compressed green baked bone meal	1		Last Available: "2025-12"
 12144	plastic skeleton rib cage of the dark arts	0		Spell Damage Percent: +100, Last Available: "2025-12"
 12145	Sinatra's plastic skeleton skull	0		Experience (Moxie): +5, Last Available: "2025-12"
@@ -11910,13 +11910,13 @@
 12152	wicked scorched skeleton shirt of the brazier	0		Spell Damage: +5, Hot Spell Damage: +25, Last Available: "2025-12"
 12153	teal beefcake's beefy scorched skeleton pants	0		Muscle: 35, Last Available: "2025-12"
 12154	red messenger parrot egg	0		Last Available: "2025-12"
-12155	yellow tumbling buryable chest	0		Last Available: "2025-12"
+12155	tumbling yellow buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	blinking Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12161	cyan spinning Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
+12161	spinning cyan Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	snack-sized adequate traditional gingerloaf	2	good	Last Available: "2025-12"
 12172	hand-crafted Scotch and eggnog	3	EPIC	Last Available: "2025-12"
 12173	tarnished counterskeleton elixir	0		Effect: "Smoking like a Bandit", Effect Duration: 53, Last Available: "2025-12"
-12174	drinkable spirit-forward &quot;salvaged&quot; wine	5	good	Last Available: "2025-12"
+12174	spirit-forward drinkable &quot;salvaged&quot; wine	5	good	Last Available: "2025-12"
 12175	blue The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	super-sized adequate wedge of prize-winning cheese	5	good	Last Available: "2025-12"
@@ -11950,7 +11950,7 @@
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	improved gray Pork Elf mouthwash	0		Effect: "Twinklebritches", Effect Duration: 68, Last Available: "2026-03"
 12194	anodized alkaline Pork Elf deodorant	0		Effect: "Towering Strength", Effect Duration: 11, Last Available: "2026-03"
-12195	boiled mirror upside-down Pork Elf toothpaste	0		Effect: "Sugar Smacks", Effect Duration: 25, Last Available: "2026-03"
+12195	boiled upside-down mirror Pork Elf toothpaste	0		Effect: "Sugar Smacks", Effect Duration: 25, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
 12197	Jim Carey's and dress of vim and vigor	0		Maximum HP Percent: +50, Monster Level: +25, Last Available: "2026-03"
 12198	Socratic smooth and dress	0		Moxie: +15, Experience (Mysticality): +1, Last Available: "2026-03"
@@ -11961,10 +11961,10 @@
 12203	Annie Oakley's strapping dinosaur bone corset of the scaredy-cat	0		Muscle: +5, Critical Hit Percent: +20, Monster Level: -15, Last Available: "2026-03"
 12204	bad Pork Elf cough syrup	3	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
-12206	teal spinning Pork Elf medicine cabinet	0		Last Available: "2026-03"
+12206	spinning teal Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	tumbling Pork Elf toilet	0		Last Available: "2026-03"
-12209	half-sized normal rat pizza	2	good	Last Available: "2026-03"
+12209	normal half-sized rat pizza	2	good	Last Available: "2026-03"
 12210	pulsating Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	groovy brawny hoverboard of Calamity Jane	0		Muscle Percent: +20, Moxie Percent: +10, Critical Hit Percent: +15, Single Equip, Last Available: "2026-03"
 12212	resourceful supercharged left shark fin of terror	0		Maximum MP Percent: +30, Maximum MP: +50, Spooky Spell Damage: +10, Last Available: "2026-03"
@@ -11972,18 +11972,18 @@
 12214	vaporized lime green upside-down candy bone	1		Effect: "Oh Snap", Effect Duration: 40
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	bland half-sized discarded hot dog	2	decent	Last Available: "2026-04"
-12218	weak hand-crafted most of a beer	2	EPIC	Last Available: "2026-04"
+12217	half-sized bland discarded hot dog	2	decent	Last Available: "2026-04"
+12218	hand-crafted weak most of a beer	2	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
-12225	squat blue legendary noodles	0		Last Available: "2026-05"
-12226	enchanted decent can of tuna	3	good	Effect: "Like a Fish to Walter", Effect Duration: 15
+12225	blue squat legendary noodles	0		Last Available: "2026-05"
+12226	decent enchanted can of tuna	3	good	Effect: "Like a Fish to Walter", Effect Duration: 15
 12227	adequate alien salad	3	good	
 12228	rotten ratbatatouille	4	crappy	
-12229	super-sized moldy spinning onigiri	5	crappy	
+12229	moldy super-sized spinning onigiri	5	crappy	
 12230	flavorless crudit&eacute;s	3	decent	
 12231	low-calorie rotten sauced mutton	1	crappy	
-12232	low-calorie adequate upside-down hot honey ant	1	good	
+12232	adequate low-calorie upside-down hot honey ant	1	good	
 12233	normal fancy gray tomb aspic	4	good	Effect: "Just the Brown Ones", Effect Duration: 10
 12234	moldy bite-sized later tots	1	crappy	
 12235	flavorless Frutti di Scatoletta	4	decent	Last Available: "2026-05"
@@ -12005,7 +12005,7 @@
 12255	chilly sword	0		Cold Damage: +5
 12256	squat Sherlock's staff	0		Item Drop: +25
 12257	bouncing lute of the scaredy-cat	0		Monster Level: -15
-12258	olive shaking shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
+12258	shaking olive shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	skewed flame-retardant experienced brawny The Wizard's Android	0		Muscle Percent: +20, Experience: +2, Hot Resistance: +1
 12261	spinning flash paperwad	0		
@@ -12028,17 +12028,17 @@
 12278	anodized tumbling essential banana decoction	0		Effect: "Granolarrrgh", Effect Duration: 62, Last Available: "2026-07"
 12279	pickled anodized banana quintessence	0		Effect: "Jingle Jangle Jingle", Effect Duration: 35, Last Available: "2026-07"
 12280	practically non-alcoholic delicious wobbly Aesop Daiquiri	1	awesome	Last Available: "2026-07"
-12281	lousy fortified Monkey Congress	5	decent	Last Available: "2026-07"
-12282	spoiled huge yellow watermelon pie	8	crappy	Last Available: "2026-07"
+12281	fortified lousy Monkey Congress	5	decent	Last Available: "2026-07"
+12282	huge spoiled yellow watermelon pie	8	crappy	Last Available: "2026-07"
 12283	super-tarnished concentrated watermelon juice	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 54, Last Available: "2026-07"
 12284	corrupted Aqua Citrulanatae	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 69, Last Available: "2026-07"
 12285	delicious narrow Melonegroni	3	awesome	Last Available: "2026-07"
-12286	practically non-alcoholic smooth Melonade Spritz	1	awesome	Last Available: "2026-07"
+12286	smooth practically non-alcoholic Melonade Spritz	1	awesome	Last Available: "2026-07"
 12287	toothsome skewed quince pie	4	awesome	Last Available: "2026-07"
 12288	alkaline quince quaff	0		Effect: "Heart of Lavender", Effect Duration: 60, Last Available: "2026-07"
 12289	unsweetened upside-down Quickquince	0		Effect: "Video Game Hot Dog", Effect Duration: 23, Last Available: "2026-07"
 12290	drinkable Quiskey Sour	3	good	Last Available: "2026-07"
-12291	hand-crafted distilled Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
+12291	distilled hand-crafted Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
 12292	tolerable lime green Roth IPA	3	good	Last Available: "2026-08"
 12293	zippy underdraft protection of the blizzard	0		Cold Spell Damage: +25, Initiative: +20, Last Available: "2026-08"
 12294	huge solvent	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Blender_cafe_booze.txt
@@ -1,32 +1,32 @@
--1	drinkable triple-distilled tumbling Petite Porter	7	good	
+-1	triple-distilled drinkable tumbling Petite Porter	7	good	
 -2	drinkable Scrawny Stout	3	good	
 -3	delicious Infinitesimal IPA	3	awesome	
 -4	lousy purple eggnogtini	4	decent	
--5	special mediocre weak candycaine	2	decent	
+-5	special weak mediocre candycaine	2	decent	
 -6	hand-crafted huge braincracker sweet	3	EPIC	
 -16	drinkable practically non-alcoholic red fermented honey	1	good	
 -17	spirit-forward artisanal tumbling moons-shine	5	EPIC	
--18	watered-down drinkable gin	2	good	
+-18	drinkable watered-down gin	2	good	
 -19	perfectly mixed ecto-nog	4	EPIC	
 -20	watered-down smooth hot toady	2	awesome	
 -21	mediocre hot choculate	3	decent	
--49	practically non-alcoholic artisanal jittery Cyder	1	EPIC	
--50	drinkable fortified Oil Nog	5	good	
+-49	artisanal practically non-alcoholic jittery Cyder	1	EPIC	
+-50	fortified drinkable Oil Nog	5	good	
 -51	hand-crafted irresponsibly strong shaking Hi-Octane Peppermint Jet Fuel	6	EPIC	
 -58	special artisanal Grimacider	3	EPIC	
 -59	tolerable Isotope Nog	3	good	
--60	practically non-alcoholic tolerable tumbling Mutagin 'n' Tonic	1	good	
--70	mediocre watered-down bouncing Gin and Herring	2	decent	
+-60	tolerable practically non-alcoholic tumbling Mutagin 'n' Tonic	1	good	
+-70	watered-down mediocre bouncing Gin and Herring	2	decent	
 -71	artisanal ghostly Black and Tan and Red All Over	3	EPIC	
--72	hand-crafted watered-down ghostly Antarctic Ice Tea	2	EPIC	
+-72	watered-down hand-crafted ghostly Antarctic Ice Tea	2	EPIC	
 -76	perfectly mixed bouncing CRIMBCO Ribbon Candy Schnapps	4	EPIC	
 -77	hand-crafted CRIMBCO Egg Substitute Nog Substitute	3	EPIC	
 -78	drinkable narrow CRIMBCO Extreme Braincracker Sour	4	good	
 -82	artisanal cyan Horseradish-infused Vodka	3	EPIC	
--83	weak smooth squat Jerkitini	2	awesome	
+-83	smooth weak squat Jerkitini	2	awesome	
 -84	delicious weak Desert Island Iced Tea	2	awesome	
--88	acceptable watered-down Crimbo Saketini	2	good	
--89	mediocre watered-down narrow Crimboku Drop	2	decent	
+-88	watered-down acceptable Crimbo Saketini	2	good	
+-89	watered-down mediocre narrow Crimboku Drop	2	decent	
 -90	mediocre blurry Flaming Crimbo Log	4	decent	
 -107	artisanal Fortified Eggnog Slurry	4	EPIC	
 -108	acceptable purple tumbling tumbling Hot Buttered Rum	3	good	

--- a/data/TCRS/TCRS_Seal_Clubber_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Blender_cafe_food.txt
@@ -7,39 +7,39 @@
 -10	decent red twigs and gravel	4	good	
 -11	small flavorless shoots and leaves	2	decent	
 -12	small moldy bowl of unidentifiable goo	2	crappy	
--13	toothsome narrow upside-down gingerbread massacre	4	awesome	
+-13	toothsome upside-down narrow gingerbread massacre	4	awesome	
 -14	moldy It Came From Beyond Dessert	3	crappy	
 -15	spoiled vampire cake	3	crappy	
 -52	decent Soylent Red and Green	3	good	
--53	adequate miniature blurry Disc-Shaped Nutrition Unit	2	good	
+-53	miniature adequate blurry Disc-Shaped Nutrition Unit	2	good	
 -54	bland Gingerborg Hive	3	decent	
--61	snack-sized flavorless mirror Candy Cane Surprise	2	decent	
+-61	flavorless snack-sized mirror Candy Cane Surprise	2	decent	
 -62	decent mirror Grimdrop Chow Mein	4	good	
 -63	spoiled Grimgerbread House	3	crappy	
 -67	spoiled twirling Caviar Carbonara	3	crappy	
--68	half-sized stale Halibut Alfredo	2	decent	
+-68	stale half-sized Halibut Alfredo	2	decent	
 -69	bland Red Herring Velvet Cake	4	decent	
--73	enchanted big rotten CRIMBCO Reconstituted Gruel	5	crappy	
+-73	enchanted rotten big CRIMBCO Reconstituted Gruel	5	crappy	
 -74	thick moldy New and Improved CRIMBCO Reconstituted Gruel	5	crappy	
 -75	yummy CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	awesome	
 -79	adequate Brussels Sprout Stir-Fry	4	good	
 -80	decent Carrot, Cabbage, and Kale Pizza	3	good	
 -81	moldy Turnip and Rutabaga Pie	4	crappy	
 -85	flavorless Rainbow Spider Fun Roll	4	decent	
--86	normal snack-sized olive spinning Vegas Volcano Lava Roll	2	good	
--87	stale half-sized fuchsia Crazy Dragon Shogun Buddha Roll	2	decent	
--92	stale snack-sized fancy basic hot dog	2	decent	
--93	miniature flavorless savage macho dog	2	decent	
--94	small spoiled one with everything	2	crappy	
--95	adequate miniature wobbly sly dog	2	good	
--96	low-calorie moldy devil dog	1	crappy	
--97	special stale chilly dog	3	decent	
--98	decent half-sized special ghost dog	2	good	
+-86	snack-sized normal olive spinning Vegas Volcano Lava Roll	2	good	
+-87	half-sized stale fuchsia Crazy Dragon Shogun Buddha Roll	2	decent	
+-92	fancy snack-sized stale basic hot dog	2	decent	
+-93	flavorless miniature savage macho dog	2	decent	
+-94	spoiled small one with everything	2	crappy	
+-95	miniature adequate wobbly sly dog	2	good	
+-96	moldy low-calorie devil dog	1	crappy	
+-97	stale special chilly dog	3	decent	
+-98	special decent half-sized ghost dog	2	good	
 -99	decent junkyard dog	3	good	
 -100	stale miniature wet dog	2	decent	
--101	decent special purple sleeping dog	3	good	
--102	stale low-calorie blinking optimal dog	1	decent	
+-101	special decent purple sleeping dog	3	good	
+-102	low-calorie stale blinking optimal dog	1	decent	
 -103	delicious mirror video games hot dog	3	awesome	
--104	bland tiny squat wobbly Peppermint Nutrition Block	1	decent	
+-104	bland tiny wobbly squat Peppermint Nutrition Block	1	decent	
 -105	snack-sized moldy twirling Gingerbread Nutrition Block	2	crappy	
 -106	moldy Cinnamon Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Seal_Clubber_Marmot.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Marmot.txt
@@ -43,7 +43,7 @@
 44	worthless gewgaw	0		
 45	mirror worthless knick-knack	0		
 46	figurine	0		
-47	big special normal tumbling hot buttered roll	5	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 50
+47	big normal special tumbling hot buttered roll	5	good	Effect: "Blessing of the Creepy Pasta", Effect Duration: 50
 48	blinking heart of rock and roll	0		
 49	miniature decent huge bowl of cottage cheese	2	good	
 50	Rock and Roll Legend of temperance	0		Sleaze Resistance: +5, Class: "Accordion Thief", Song Duration: 10
@@ -82,12 +82,12 @@
 83	spinning twirling shaft	0		
 84	Orcish meat locker	0		
 85	shaking unlocked meat locker	0		
-86	bouncing olive key	0		
+86	olive bouncing key	0		
 87	fuchsia meat from yesterday	0		
 88	upside-down meat stack	0		
 89	squat sword hilt	0		
 90	helmet recipe	0		
-91	upside-down red pants kit	0		
+91	red upside-down pants kit	0		
 92	meatsmithing guide	0		
 93	inspector's basic meat sword	0		Item Drop: +15
 94	twirling toasty basic meat pants	0		Hot Damage: +5, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -98,10 +98,10 @@
 99	meat face	0		
 100	lifeless meat doll	0		
 101	meat golem	0		
-102	squat blinking shrunken head	0		
+102	blinking squat shrunken head	0		
 103	Oprah's therapeutic staff	0		Maximum MP Percent: +50, HP Regen Min: 5, HP Regen Max: 7
 104	ghostly scarecrow	0		
-105	adequate pulsating olive bowl of charms	4	good	
+105	adequate olive pulsating bowl of charms	4	good	
 106	ketchup	1	EPIC	
 107	catsup	1	good	
 108	stick	0		
@@ -121,7 +121,7 @@
 122	cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
 124	empty meat tank	0		
-125	jittery gray full meat tank	0		
+125	gray jittery full meat tank	0		
 126	blurry meat engine	0		
 127	narrow squat flame-retardant Gnollish autoplunger	0		Hot Resistance: +1
 128	Sinatra's meat pants	0		Experience (Moxie): +5, Familiar Effect: "2xPotato, cap 11"
@@ -157,7 +157,7 @@
 158	Gnollish pie tin	0		
 159	skewed wad of dough	0		
 160	pie crust	0		
-161	immense bland ghuol egg	8	decent	
+161	bland immense ghuol egg	8	decent	
 162	flavorless diet ghuol egg quiche	1	decent	
 163	wobbly skeleton bone of temperance	0		Sleaze Resistance: +5
 164	teal smart skull	0		
@@ -168,10 +168,10 @@
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	wobbly lihc eye	0		
 171	tasty lihc eye pie	4	awesome	
-172	squat mirror shaking gnoll lips	0		
+172	shaking mirror squat gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
-175	adequate special uncooked chorizo	3	good	Effect: "Frozen Hands", Effect Duration: 30
+175	special adequate uncooked chorizo	3	good	Effect: "Frozen Hands", Effect Duration: 30
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
@@ -181,7 +181,7 @@
 182	batgut	0		
 183	bat wing	0		
 184	bouncing briefcase	0		
-185	blue huge fat stacks of cash	0		
+185	huge blue fat stacks of cash	0		
 186	skewed bean	0		
 187	loose teeth	0		
 188	bat guano	0		
@@ -196,10 +196,10 @@
 198	rat appendix	0		
 199	friendly ring	0		Familiar Weight: +3
 200	decent rat appendix kabob	3	good	
-201	enchanted tasty bite-sized bat wing kabob	1	awesome	Effect: "Bored Stiff", Effect Duration: 25
+201	tasty enchanted bite-sized bat wing kabob	1	awesome	Effect: "Bored Stiff", Effect Duration: 25
 202	snack-sized spoiled carob chunks	2	crappy	
 203	herbs	0		
-204	enchanted stale carob chunk cookies	4	decent	Effect: "Puddingface", Effect Duration: 40
+204	stale enchanted carob chunk cookies	4	decent	Effect: "Puddingface", Effect Duration: 40
 205	spinning secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	good	
@@ -211,16 +211,16 @@
 213	bouncing friendly stylish filthy corduroys	0		Moxie: +25, Familiar Weight: +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	jittery padded filthy knitted dread sack	0		Damage Absorption: +20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	spoiled special carob brownies	3	crappy	Effect: "Full-Body Tan", Effect Duration: 25
-217	super-sized flavorless gray shaking herb brownies	5	decent	
-218	blinking gray hemp string	0		
+216	special spoiled carob brownies	3	crappy	Effect: "Full-Body Tan", Effect Duration: 25
+217	flavorless super-sized gray shaking herb brownies	5	decent	
+218	gray blinking hemp string	0		
 219	teal necklace chain	0		
 220	gnoll teeth	0		
 221	mirror wobbly Newton's gnoll-tooth necklace	0		Experience (Mysticality): +3
 222	phat turquoise bead	0		
 223	flame-retardant phat turquoise bracelet	0		Hot Resistance: +1
 224	twirling green Van der Graaf eyepatch	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "3xBarrr, cap 6"
-225	flavorless green squat tofu casserole	3	decent	
+225	flavorless squat green tofu casserole	3	decent	
 226	denatured huge can of Red Minotaur	1	crappy	Effect: "World's Shortest Giant", Effect Duration: 35
 227	jittery up-at-dawn Kentucky-fried meat sword	0		Adventures: +5
 228	lion tamer's Kentucky-fried meat staff	0		Experience (familiar): +2
@@ -233,19 +233,19 @@
 235	auspicious friendly Bigger Bugfinder Blade	0		Familiar Weight: +3, Item Drop: +10
 236	tumbling Queue Du Coq cocktailcrafting kit	0		
 237	drinkable bottle of gin	4	good	
-238	drinkable weak bottle of vodka	2	good	
+238	weak drinkable bottle of vodka	2	good	
 239	mirror crafty stiffened Orcish baseball cap	0		Damage Reduction: 1, Maximum MP: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	twirling lard-coated friendly Orcish cargo shorts	0		Familiar Weight: +3, Sleaze Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Herculean Orcish frat-paddle	0		Experience (Muscle): +1
 242	spoiled	4	crappy	
-243	adequate small grapefruit	2	good	
+243	small adequate grapefruit	2	good	
 244	moldy grapes	3	crappy	
 245	flavorless olive	4	decent	
 246	toothsome tomato	4	awesome	
 247	fermenting powder	0		
 248	artisanal salty dog	4	EPIC	
 249	hand-crafted bloody mary	4	EPIC	
-250	bad triple-distilled screwdriver	10	decent	
+250	triple-distilled bad screwdriver	10	decent	
 251	mediocre shaking martini	3	decent	
 252	practically non-alcoholic perfectly mixed bouncing bloody beer	1	EPIC	
 253	bad shot of schnapps	3	decent	
@@ -255,7 +255,7 @@
 257	practically non-alcoholic bad extra-spicy bloody mary	1	decent	
 258	upside-down dense meat stack	0		
 259	snake skin	0		
-260	enchanted bland big White Citadel fries	5	decent	Effect: "Far Out", Effect Duration: 25
+260	big bland enchanted White Citadel fries	5	decent	Effect: "Far Out", Effect Duration: 25
 261	flavorless gigantic mirror White Citadel burger	10	decent	
 262	adequate piece of wedding cake	3	good	
 263	decent low-calorie blue huge chocolate chips	1	good	
@@ -268,7 +268,7 @@
 270	blurry picket fence	0		
 271	powdered twirling yellow barbell	1		
 272	compressed pulsating bouncing concentrated magicalness pill	1		
-273	twisted huge green moxie weed	1		Effect: "Smoking like a Bandit", Effect Duration: 25
+273	twisted green huge moxie weed	1		Effect: "Smoking like a Bandit", Effect Duration: 25
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
@@ -297,7 +297,7 @@
 299	adjusted skewed pickle-flavored chewing gum	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 35
 300	cold-filtered jaba&ntilde;ero-flavored chewing gum	0		Effect: "Coy to the Hurled", Effect Duration: 28
 301	flat dough	0		
-302	spoiled half-sized Knob sausage	2	crappy	
+302	half-sized spoiled Knob sausage	2	crappy	
 303	small rotten ghostly Knob mushroom	2	crappy	
 304	twirling dry noodles	0		
 305	mirror chaotic Knob Goblin harem pants	0		Spell Critical Percent: +10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -318,10 +318,10 @@
 320	decent bat haggis	3	good	
 321	diet delicious twirling menudo	1	awesome	
 322	bland pulsating goat cheese	4	decent	
-323	low-calorie bland skewed plain pizza	1	decent	
+323	bland low-calorie skewed plain pizza	1	decent	
 324	rotten sausage pizza	4	crappy	
 325	massive normal spinning goat cheese pizza	10	good	
-326	fancy spoiled blinking mushroom pizza	3	crappy	Effect: "Innately Strong", Effect Duration: 15
+326	spoiled fancy blinking mushroom pizza	3	crappy	Effect: "Innately Strong", Effect Duration: 15
 327	ghostly goat	0		
 328	watered-down perfectly mixed bottle of whiskey	2	EPIC	
 329	squat frosty goat beard	0		Cold Spell Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
@@ -396,7 +396,7 @@
 398	ghostly aromatic hippopotamus pants	0		Stench Resistance: +1, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
 399	aromatic eXtreme mittens	0		Stench Resistance: +1
 400	handful of drink tickets	0		
-401	shaking upside-down Knob Kitchen grab-bag	0		
+401	upside-down shaking Knob Kitchen grab-bag	0		
 402	green swashbuckling pants of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "3xPotato, 1.5xFairy, cap 20"
 403	dog trainer's shoulder parrot	0		Experience (familiar): +1
 404	wobbly maroon studded acoustic guitarrr	0		Damage Absorption: +80
@@ -451,18 +451,18 @@
 453	tumbling sober pill	0		
 454	screwdriver	0		
 455	half-sized delicious jumbo olive	2	awesome	
-456	tolerable weak dry martini	2	good	
+456	weak tolerable dry martini	2	good	
 457	jittery ye olde golde frontes of the detective	0		Item Drop: +20, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
 460	blurry pixel	0		
-461	fuchsia twirling pixel	0		
+461	twirling fuchsia pixel	0		
 462	pixel	0		
 463	pixel	0		
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	fancy flavorless pixel pie	3	decent	Effect: "Biologically Shocked", Effect Duration: 25
+467	flavorless fancy pixel pie	3	decent	Effect: "Biologically Shocked", Effect Duration: 25
 468	ruby W	0		
 469	wussiness potion	0		
 470	bad bouncing Imp Ale	3	decent	
@@ -498,7 +498,7 @@
 500	Elf Farm Raffle ticket	0		
 501	spoiled tumbling Elfin shortbread	3	crappy	
 502	pagoda plans	0		
-503	spoiled thick twirling skewered cat appendix	5	crappy	
+503	thick spoiled twirling skewered cat appendix	5	crappy	
 504	evil arches	0		
 505	tumbling ghostly scandalous nasty gnatwing earring	0		Stench Damage: +5, Sleaze Damage: +5
 506	massive normal twirling Hell broth	7	good	
@@ -509,8 +509,8 @@
 511	green Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	small normal Boris's key lime pie	2	good	
-514	decent miniature Jarlsberg's key lime pie	2	good	
-515	bland snack-sized maroon bouncing tumbling Sneaky Pete's key lime pie	2	decent	
+514	miniature decent Jarlsberg's key lime pie	2	good	
+515	snack-sized bland bouncing maroon tumbling Sneaky Pete's key lime pie	2	decent	
 516	fuchsia Hey Deze map	0		
 517	educational bejeweled accordion strap	0		Experience: +1, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -552,10 +552,10 @@
 554	half-sized delicious wobbly pr0n cocktail	2	awesome	
 555	spinning miser's hale drywall axe	0		Maximum HP: +20, Meat Drop: +10
 556	Pine-Fresh air freshener of the glutton	0		Food Drop: +100
-557	practically non-alcoholic bad blurry whiskey and cola	1	decent	
-558	snack-sized rotten papaya taco	2	crappy	
+557	bad practically non-alcoholic blurry whiskey and cola	1	decent	
+558	rotten snack-sized papaya taco	2	crappy	
 559	twirling razor-sharp can lid	0		
-560	tiny stale stalk of asparagus	1	decent	
+560	stale tiny stalk of asparagus	1	decent	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	green sonar-in-a-biscuit	0		
@@ -563,17 +563,17 @@
 565	prompt hobo gloves	0		Adventures: +3, Single Equip
 566	blinking flame-retardant bum cheek	0		Hot Resistance: +1, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	jumbo decent red Double Bacon Beelzeburger	5	good	
-569	stale super-sized Lord of the Flies-sized fries	5	decent	
+568	decent jumbo red Double Bacon Beelzeburger	5	good	
+569	super-sized stale Lord of the Flies-sized fries	5	decent	
 570	moldy Chicken Sandwich	3	crappy	
 571	Jumbo Dr. Lucifer	1	good	
-572	snack-sized flavorless Children's Meal of the Damned	2	decent	
+572	flavorless snack-sized Children's Meal of the Damned	2	decent	
 573	stale squat noodles	4	decent	
 574	flavorless noodles	3	decent	
 575	bland big painful penne pasta	5	decent	
 576	delicious half-sized teal ravioli della hippy	2	awesome	
 577	delicious pr0n m4nic0tti	4	awesome	
-578	normal small twirling maroon Hell ramen	2	good	
+578	normal small maroon twirling Hell ramen	2	good	
 579	normal lime green boring spaghetti	3	good	
 580	skewed blinking sauce of the ages	0		
 581	schmancy cheese sauce	0		
@@ -585,7 +585,7 @@
 587	quadruple-activated triple-polarized blurry super-spiky hair gel	0		Effect: "Tomato Power", Effect Duration: 31
 588	blurry soft echo eyedrop antidote	0		
 589	yummy cocoa eggshell fragment	3	awesome	
-590	gigantic rotten cocoa eggshell fragment	6	crappy	
+590	rotten gigantic cocoa eggshell fragment	6	crappy	
 591	cocoa egg	0		
 592	maroon house	0		
 593	huge phonics down	0		
@@ -620,7 +620,7 @@
 622	narrow awful poetry journal	0		
 623	WA	0		
 624	twirling NG	0		
-625	tumbling skewed wang	0		
+625	skewed tumbling wang	0		
 626	Wand of Nagamar	0		
 627	ND	0		
 628	metallic A	0		
@@ -667,19 +667,19 @@
 669	tasty ghuol guolash	3	awesome	
 670	hardy lihc face	0		Maximum HP: +50, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	reassuring slick grave robbing shovel	0		Moxie: +10, Spooky Resistance: +1
-672	yummy half-sized cranberries	2	awesome	
-673	perfectly mixed watered-down huge vodka and cranberry	2	EPIC	
-674	delicious distilled whiskey	5	awesome	
+672	half-sized yummy cranberries	2	awesome	
+673	watered-down perfectly mixed huge vodka and cranberry	2	EPIC	
+674	distilled delicious whiskey	5	awesome	
 675	greasy skull of the Bonerdagon	0		Sleaze Spell Damage: +10
 676	dragonbone belt buckle	0		
 677	reassuring badass belt	0		Spooky Resistance: +1
 678	jittery chest of the Bonerdagon	0		
 679	smooth weak roll in the hay	2	awesome	
-680	acceptable fancy slap and tickle	4	good	Effect: "Strong Spirit", Effect Duration: 10
+680	fancy acceptable slap and tickle	4	good	Effect: "Strong Spirit", Effect Duration: 10
 681	hand-crafted slip 'n' slide	4	EPIC	
 682	watered-down artisanal teal a sump'm sump'm	2	EPIC	
-683	practically non-alcoholic drinkable horizontal tango	1	good	
-684	drinkable practically non-alcoholic green pink pony	1	good	
+683	drinkable practically non-alcoholic horizontal tango	1	good	
+684	practically non-alcoholic drinkable green pink pony	1	good	
 685	Rosewater's Mr. Shirt of the wise owl of James Dean	0		Mysticality: +20, Mysticality Percent: +30, Experience (Moxie): +3
 686	thinker's knuckles	0		Mysticality: +10
 687	quantum purple blood of the Wereseal	0		Effect: "From Nantucket", Effect Duration: 13
@@ -717,14 +717,14 @@
 721	jittery pulsating lion tamer's porquoise bracelet of the pedagogue	0		Experience: +3, Experience (familiar): +2
 722	huge jittery fuchsia smelly frosty studded porquoise ring	0		Damage Absorption: +80, Cold Spell Damage: +10, Stench Spell Damage: +10, Single Equip
 723	small tasty enchanted Knoll mushroom	2	awesome	Effect: "Spiky Frozen Hair", Effect Duration: 45
-724	thick normal huge mushroom	5	good	
+724	normal thick huge mushroom	5	good	
 725	one million meat pancakes	0		
 726	jittery narrow lightning-fast huge mirror shard	0		Initiative: +40
 727	hedge maze puzzle	0		
 728	hedge maze key	0		
 729	fishbowl	0		
 730	fishtank	0		
-731	pulsating skewed fish hose	0		
+731	skewed pulsating fish hose	0		
 732	olive hosed tank	0		
 733	hosed fishbowl	0		
 734	upside-down tumbling gravedigger's nippy studded makeshift SCUBA gear	0		Damage Absorption: +80, Cold Damage: +10, Spooky Damage: +10, Adventure Underwater
@@ -741,22 +741,22 @@
 746	stat script	0		
 747	narrow Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	delicious jumbo warm mushroom	5	awesome	
-750	gigantic rotten narrow mushroom quesadilla	6	crappy	
-751	snack-sized delicious cool mushroom	2	awesome	
-752	spoiled special cool mushroom casserole	4	crappy	Effect: "Venomous Weapon", Effect Duration: 25
-753	big fancy toothsome pointy mushroom	5	awesome	Effect: "Fireproof Lips", Effect Duration: 40
+749	jumbo delicious warm mushroom	5	awesome	
+750	rotten gigantic narrow mushroom quesadilla	6	crappy	
+751	delicious snack-sized cool mushroom	2	awesome	
+752	special spoiled cool mushroom casserole	4	crappy	Effect: "Venomous Weapon", Effect Duration: 25
+753	toothsome fancy big pointy mushroom	5	awesome	Effect: "Fireproof Lips", Effect Duration: 40
 754	rotten cream of pointy mushroom soup	3	crappy	
 755	decent gigantic red mushroom	9	good	
 756	bland massive skewed mushroom	10	decent	
-757	enchanted moldy blurry mushroom	3	crappy	Effect: "Tremella Tremens", Effect Duration: 30
+757	moldy enchanted blurry mushroom	3	crappy	Effect: "Tremella Tremens", Effect Duration: 30
 758	bland ghost cucumber	4	decent	
 759	dill	0		
 760	vinegar	0		
-761	green jittery brine	0		
+761	jittery green brine	0		
 762	watered-down smooth especially salty dog	2	awesome	
 763	twirling ghostly pickling solution	0		
-764	bland low-calorie spectral pickle	1	decent	
+764	low-calorie bland spectral pickle	1	decent	
 765	briny vinegar	0		
 766	teal ghost pickle on a stick	0		
 767	triple-pressed pickled blinking cologne of contempt	0		Effect: "No Worries", Effect Duration: 38
@@ -775,33 +775,33 @@
 780	cyan scroll of pasta summoning	0		
 781	colloidal mafia aria	0		Effect: "Cold Hands", Effect Duration: 57
 782	Mr. Exploiter	0		Last Available: "2009-12"
-783	tumbling twirling 'Villa' document	0		
-784	weak mediocre Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
+783	twirling tumbling 'Villa' document	0		
+784	mediocre weak Acqua Del Piatto Merlot	2	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	moldy miniature red strawberry	2	crappy	
 787	perfectly mixed practically non-alcoholic bottle of rum	1	EPIC	
 788	smooth strawberry daiquiri	3	awesome	
 789	smooth squat rum and cola	4	awesome	
-790	drinkable spirit-forward grog	5	good	
+790	spirit-forward drinkable grog	5	good	
 791	bouncing up-at-dawn Mafia bow tie of the businessman	0		Meat Drop: +50, Adventures: +5, Last Available: "2004-10"
 792	steel-toed Golden Mr. Accessory	0		Damage Reduction: 9, Softcore Only
 793	cold-filtered deionized bouncing oil of stability	0		Effect: "Weasels Underfoot", Effect Duration: 40
 794	extra-liquefied olive oil of slipperiness	0		Effect: "Mayeaugh", Effect Duration: 47
-795	bad strong purple Acque Luride Grezze Cabernet	5	decent	Last Available: "2004-10"
+795	strong bad purple Acque Luride Grezze Cabernet	5	decent	Last Available: "2004-10"
 796	skewed skewed cement shoes of the brute of horror of the early riser	0		Muscle Percent: +30, Spooky Spell Damage: +25, Adventures: +7, Last Available: "2004-10"
-797	tolerable watered-down rockin' wagon	2	good	
+797	watered-down tolerable rockin' wagon	2	good	
 798	bad fortified wobbly ocean motion	5	decent	
 799	tolerable irresponsibly strong fuzzbump	10	good	
 800	stale thick poutine	5	decent	
-801	bland half-sized tumbling Knob stir-fry	2	decent	
-804	small adequate twirling Knoll stir-fry	2	good	
+801	half-sized bland tumbling Knob stir-fry	2	decent	
+804	adequate small twirling Knoll stir-fry	2	good	
 805	rotten blinking stir-fry	4	crappy	
 806	flavorless twirling asparagus stir-fry	3	decent	
 807	toothsome olive stir-fry	4	awesome	
 808	bite-sized spoiled Knob sausage stir-fry	1	crappy	
 809	toothsome bat wing stir-fry	3	awesome	
 810	normal rat appendix stir-fry	4	good	
-811	tiny rotten tofu stir-fry	1	crappy	
+811	rotten tiny tofu stir-fry	1	crappy	
 812	miniature tasty pr0n stir-fry	2	awesome	
 813	decent jumbo Knob shells	5	good	
 814	decent b&auml;tzle	4	good	
@@ -815,7 +815,7 @@
 822	smoky potion	0		
 823	cloudy potion	0		
 824	huge effervescent potion	0		
-825	upside-down skewed fizzy potion	0		
+825	skewed upside-down fizzy potion	0		
 826	olive dark potion	0		
 827	murky potion	0		
 828	upside-down baby killer bee	0		
@@ -826,10 +826,10 @@
 833	mirror blurry shellacked vorpal blade	0		Damage Reduction: 7
 834	rosewater-soaked Sinatra's cornuthaum	0		Experience (Moxie): +5, Stench Resistance: +3, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	fuchsia miser's ring of aggravate monster	0		Meat Drop: +10
-836	thick normal mind flayer corpse	5	good	
+836	normal thick mind flayer corpse	5	good	
 837	strong drinkable shaking Uovo Marcio Shiraz	5	good	Last Available: "2004-10"
 838	wobbly lightning-fast rosewater-soaked Mafia stogie	0		Stench Resistance: +3, Initiative: +40, Last Available: "2004-10"
-839	mediocre yellow tumbling Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
+839	mediocre tumbling yellow Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
 840	blinking veiny banded Mafia violin case	0		Damage Absorption: +100, Maximum HP: +10, Last Available: "2004-10"
 841	tolerable tomato daiquiri	4	good	
 842	acceptable beertini	4	good	
@@ -840,14 +840,14 @@
 848	blinking hypodermic needle	0		Familiar Weight: +5
 849	Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
-851	shaking huge prosthetic forehead	0		Familiar Weight: +5
+851	huge shaking prosthetic forehead	0		Familiar Weight: +5
 852	upside-down shaker of salt	0		Familiar Weight: +5
 853	blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	huge shock collar	0		
 857	pulsating moonglasses	0		
-858	fuchsia upside-down palm-frond toupee	0		Familiar Weight: +5
+858	upside-down fuchsia palm-frond toupee	0		Familiar Weight: +5
 859	wobbly knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
@@ -891,14 +891,14 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	huge 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	bad huge tumbling Spasmi Dolorosi Del Rene Champagne	3	decent	Last Available: "2004-10"
+903	bad tumbling huge Spasmi Dolorosi Del Rene Champagne	3	decent	Last Available: "2004-10"
 904	ruddy school Mafia knickerbockers of the sewer of the glutton	0		Maximum HP Percent: +40, Stench Damage: +25, Food Drop: +100, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	oxidized Yummy Tummy bean	0		Effect: "Thunderheart", Effect Duration: 61
 906	improved tumbling blue Rock Pops	0		Effect: "Toothy Grin", Effect Duration: 13
 907	warmed yellow Mr. Mediocrebar	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 12
-908	denatured huge blue Cold Hots candy	0		Effect: "Space Cowboy", Effect Duration: 43
+908	denatured blue huge Cold Hots candy	0		Effect: "Space Cowboy", Effect Duration: 43
 909	wet tarnished olive Wint-O-Fresh mint	0		Effect: "Vinegavotte", Effect Duration: 41
-910	huge toothsome dwarf bread	9	awesome	
+910	toothsome huge dwarf bread	9	awesome	
 911	altered enhanced super-adjusted Senior Mints	0		Effect: "Cat Class, Cat Style", Effect Duration: 64
 912	vacuum-sealed pixellated candy heart	0		Effect: "Video Game Hot Dog", Effect Duration: 11
 913	pressed anodized kobold	0		Effect: "Gemini Rising", Effect Duration: 16
@@ -915,15 +915,15 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	deionized mirror Hawking's Elixir of Brilliance	0		Effect: "Weird Vibrations", Effect Duration: 67
-927	practically non-alcoholic mediocre Ferita Del Petto Zinfandel	1	decent	Last Available: "2006-12"
+927	mediocre practically non-alcoholic Ferita Del Petto Zinfandel	1	decent	Last Available: "2006-12"
 928	steel-toed fuzzy bracelets	0		Damage Reduction: 9
 929	MacGyver's arse-shooting crossbow	0		Maximum MP: +100
-931	hand-crafted extra-dry twirling spiced rum	5	EPIC	
+931	extra-dry hand-crafted twirling spiced rum	5	EPIC	
 932	mediocre practically non-alcoholic eggnog	1	decent	
 933	delicious candy cane	3	awesome	
 934	normal jumbo spinning gingerbread bugbear	5	good	
 935	wobbly zippy imitation nice watch	0		Initiative: +20, Single Equip, Last Available: "2004-12"
-936	blurry gray Hanukkimbo dreidl	0		Last Available: "2004-12"
+936	gray blurry Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
 938	red smooth plastic sword	0		Moxie: +15, Last Available: "2004-12"
 939	small Crimbo Pressie	0		Last Available: "2004-12"
@@ -936,8 +936,8 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	artisanal martini	3	super ultra EPIC	Last Available: "2004-12"
-949	weak perfectly mixed grogtini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
-950	delicious practically non-alcoholic cherry bomb	1	awesome	Last Available: "2004-12"
+949	perfectly mixed weak grogtini	2	super ultra mega turbo EPIC	Last Available: "2004-12"
+950	practically non-alcoholic delicious cherry bomb	1	awesome	Last Available: "2004-12"
 951	skewed extra special Crimbo stocking	0		Last Available: "2004-12"
 952	jittery hockey mask of Tarzan of the dark arts	0		Experience (Muscle): +3, Spell Damage Percent: +100, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
@@ -997,14 +997,14 @@
 1010	artisanal enchanted whiskey and soda	4	EPIC	Effect: "The Magical Mojomuscular Melody", Effect Duration: 50
 1011	lousy monkey wrench	3	decent	
 1012	watered-down mediocre wobbly tequila sunrise	2	decent	
-1013	strong lousy margarita	5	decent	
-1014	watered-down acceptable strawberry wine	2	good	
-1015	weak bad wine spritzer	2	decent	
+1013	lousy strong margarita	5	decent	
+1014	acceptable watered-down strawberry wine	2	good	
+1015	bad weak wine spritzer	2	decent	
 1016	aged blurry perpendicular hula	3	awesome	
 1017	artisanal jittery spinning ducha de oro	3	EPIC	
 1018	mediocre calle de miel	3	decent	
 1019	acceptable dry vodka martini	3	good	
-1020	practically non-alcoholic bad blinking squat old-fashioned	1	decent	
+1020	bad practically non-alcoholic blinking squat old-fashioned	1	decent	
 1021	aged blue tequila with training wheels	4	awesome	
 1022	delicious sangria	4	awesome	
 1023	aged vesper	3	awesome	Last Available: "2004-12"
@@ -1030,8 +1030,8 @@
 1044	spinning string of beads of the wise owl	0		Mysticality: +20
 1045	family-friendly plastic bottle opener	0		Sleaze Resistance: +1
 1046	blinking frightening grievous traffic cone	0		Weapon Damage Percent: +50, Spooky Damage: +5, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	practically non-alcoholic drinkable narrow N. O. Beer	1	good	
-1048	modified pulsating tumbling oyster egg	1		
+1047	drinkable practically non-alcoholic narrow N. O. Beer	1	good	
+1048	modified tumbling pulsating oyster egg	1		
 1049	mixed green oyster egg	1		Effect: "Mer-kinny Flavor", Effect Duration: 30
 1050	pickled skewed blue oyster egg	1		
 1051	jittery plastic oyster egg	0		
@@ -1046,21 +1046,21 @@
 1060	modified mauve oyster egg	1		Effect: "Stick Emporium Membership", Effect Duration: 40
 1061	denatured spinning twirling mauve oyster egg	1		Effect: "Marbles in Your Mouth", Effect Duration: 50
 1062	mixed mauve oyster egg	1		
-1063	narrow wobbly mauve plastic oyster egg	0		
-1064	powdered ghostly upside-down oyster egg	1		
+1063	wobbly narrow mauve plastic oyster egg	0		
+1064	powdered upside-down ghostly oyster egg	1		
 1065	modified mirror huge oyster egg	1		Effect: "Aries Rising", Effect Duration: 40
 1066	denatured pulsating oyster egg	1		
-1067	skewed huge plastic oyster egg	0		
+1067	huge skewed plastic oyster egg	0		
 1068	twisted huge oyster egg	1		
-1069	pickled blue squat oyster egg	1		
-1070	compressed narrow yellow oyster egg	1		
+1069	pickled squat blue oyster egg	1		
+1070	compressed yellow narrow oyster egg	1		
 1071	plastic oyster egg	0		
 1072	mixed off-white oyster egg	1		
 1073	compressed off-white oyster egg	1		
 1074	powdered off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	compressed blinking gray oyster egg	1		
-1077	compressed tumbling huge blinking oyster egg	1		Effect: "Human-Goblin Hybrid", Effect Duration: 35
+1076	compressed gray blinking oyster egg	1		
+1077	compressed huge tumbling blinking oyster egg	1		Effect: "Human-Goblin Hybrid", Effect Duration: 35
 1078	altered huge oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
@@ -1104,10 +1104,10 @@
 1118	narrow pregnant mushroom	0		
 1119	pregnant mushroom	0		
 1120	pregnant mushroom	0		
-1121	purple blinking inexplicably rock	0		
+1121	blinking purple inexplicably rock	0		
 1122	yellow fairy gravy	0		
 1123	lime green halfberd of the glutton	0		Food Drop: +100
-1124	cyan blinking small glove	0		
+1124	blinking cyan small glove	0		
 1125	wobbly prompt censurious wholesome glove	0		Maximum HP Percent: +10, Sleaze Resistance: +3, Adventures: +3
 1126	blue Newton's toothpick	0		Experience (Mysticality): +3, Single Equip
 1127	spinning lard-coated ninja sword	0		Sleaze Spell Damage: +25
@@ -1122,18 +1122,18 @@
 1136	frozen green lipstick	0		Effect: "One Foot Heavier", Effect Duration: 14
 1137	tumbling ghostly lard-coated Jim Carey's bicycle chain	0		Monster Level: +25, Sleaze Spell Damage: +25
 1138	mushroom fermenting solution	0		
-1139	distilled fancy acceptable gray mushroom wine	5	good	Effect: "Shortened", Effect Duration: 20
+1139	fancy acceptable distilled gray mushroom wine	5	good	Effect: "Shortened", Effect Duration: 20
 1140	tolerable irresponsibly strong icy mushroom wine	7	good	
-1141	boozy drinkable maroon mushroom wine	5	good	
+1141	drinkable boozy maroon mushroom wine	5	good	
 1142	lousy practically non-alcoholic pointy mushroom wine	1	decent	
 1143	weak acceptable flat mushroom wine	2	good	
 1144	delicious practically non-alcoholic cool mushroom wine	1	awesome	
-1145	special weak lousy knob mushroom wine	2	decent	Effect: "Nano-juiced", Effect Duration: 45
+1145	special lousy weak knob mushroom wine	2	decent	Effect: "Nano-juiced", Effect Duration: 45
 1146	mediocre knoll mushroom wine	3	decent	
 1147	artisanal mushroom wine	3	EPIC	
 1148	perfectly mixed practically non-alcoholic shot of flower schnapps	1	EPIC	
 1149	bland bite-sized jittery flower petal pie	1	decent	
-1150	weak tolerable bouncing pulsating lime green bottle of single-barrel whiskey	2	good	
+1150	tolerable weak bouncing pulsating lime green bottle of single-barrel whiskey	2	good	
 1151	tumbling crafty discarded plastic fork of extreme caution	0		Maximum MP: +10, Monster Level: -25
 1152	fuchsia gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	stale bouncing Retenez L'Herbe Pat&eacute;	3	decent	
@@ -1169,7 +1169,7 @@
 1184	cyan exotic orchid	0		
 1185	cyan long-stemmed rose	0		
 1186	gilded lily	0		
-1187	olive bouncing skewed deadly nightshade	0		
+1187	skewed bouncing olive deadly nightshade	0		
 1188	lotus	0		
 1189	can of asparagus	0		
 1190	bouncing dodecapede	0		
@@ -1183,7 +1183,7 @@
 1198	sabre-toothed lime	0		
 1199	huge bugbear	0		
 1200	moldy jumbo jittery mugcake	5	crappy	
-1201	immense delicious urinal cake	7	awesome	
+1201	delicious immense urinal cake	7	awesome	
 1202	spoiled Happy Birthday, Claude! cake	3	crappy	
 1203	fancy stale twirling personalized birthday cake	3	decent	Effect: "Egg-cellent Vocabulary", Effect Duration: 25
 1204	diet bland red three-tiered wedding cake	1	decent	
@@ -1203,7 +1203,7 @@
 1218	ghostly rat head balloon	0		Familiar Weight: -3
 1219	blurry mini-zeppelin	0		
 1220	narrow perfumed Mr. Balloon	0		Stench Resistance: +5
-1221	blurry lime green balloon	0		
+1221	lime green blurry balloon	0		
 1222	Samson's Mr. Eh?	0		Experience (Muscle): +5, Softcore Only
 1224	blinking fireproof dog trainer's steel shillelagh of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +1, Hot Resistance: +3
 1225	auspicious healthy steel skullcap of the sewer	0		Maximum HP Percent: +20, Stench Damage: +25, Item Drop: +10, Familiar Effect: "1xLep, 1xFairy, cap 22"
@@ -1233,10 +1233,10 @@
 1249	blinking steel-toed Boss Bat britches	0		Damage Reduction: 9, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	ghostly gravedigger's coward's Boss Bat bling	0		Monster Level: -20, Spooky Damage: +10
 1251	bland Knob shroomkabob	4	decent	
-1252	bland small narrow teal shroomkabob	2	decent	
+1252	bland small teal narrow shroomkabob	2	decent	
 1253	pile of jumping beans	0		
 1254	miniature adequate jumping bean burrito	2	good	
-1255	small tasty maroon jumping bean burrito	2	awesome	
+1255	tasty small maroon jumping bean burrito	2	awesome	
 1256	bland ghostly insanely jumping bean burrito	3	decent	
 1257	rotten miniature rat scrapple	2	crappy	
 1258	pail of pretentious paint	0		
@@ -1250,14 +1250,14 @@
 1266	rotten gloomy mushroom	3	crappy	
 1267	tumbling dead mimic	0		
 1268	pine wand	0		
-1269	bouncing teal ebony wand	0		
+1269	teal bouncing ebony wand	0		
 1270	hexagonal wand	0		
 1271	narrow aluminum wand	0		
 1272	marble wand	0		
 1273	reassuring magic lamp	0		Spooky Resistance: +1
 1274	pickled maroon upside-down Medicinal Herb's medicinal herbs	1		Effect: "Fastbreaker", Effect Duration: 35
 1275	dance instructor's basic meat skirt	0		Experience Percent (Moxie): +10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	weak smooth Otorian Battle Scar	2	awesome	
+1276	smooth weak Otorian Battle Scar	2	awesome	
 1277	Herculean basic meat kilt	0		Experience (Muscle): +1, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	Newton's meat skirt	0		Experience (Mysticality): +3, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	hardy meat kilt	0		Maximum HP: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1320,7 +1320,7 @@
 1336	Cloaca grenade	0		
 1338	Dyspepsi-Cola d-rations	0		
 1339	Cloaca-Cola c-rations	0		
-1340	upside-down huge Cloaca-Cola-issue combat knife	0		
+1340	huge upside-down Cloaca-Cola-issue combat knife	0		
 1341	Dyspepsi-Cola-issue canteen of the dark arts	0		Spell Damage Percent: +100, Single Equip
 1342	tumbling lime green picture of a dead guy's girlfriend	0		
 1343	twirling huge zombie pineal gland	0		Last Available: "2005-11"
@@ -1339,15 +1339,15 @@
 1356	huge bunny liver	0		
 1357	aged skewed Mt. Noob Pale Ale	4	awesome	
 1358	pirate zombie head	0		Last Available: "2005-11"
-1359	tumbling gray ninja pirate zombie robot head	0		Last Available: "2005-11"
+1359	gray tumbling ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	nasty disembodied smile	0		Stench Damage: +5, Single Equip
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	skewed blinking rhesus monkey	0		Familiar Weight: +5
-1365	super-sized flavorless special tofurkey leg	5	decent	Effect: "Greasy Visage", Effect Duration: 25
-1366	big normal tofurkey gravy	5	good	
-1367	half-sized bland special herbal stuffing	2	decent	Effect: "Larger", Effect Duration: 20
+1365	flavorless special super-sized tofurkey leg	5	decent	Effect: "Greasy Visage", Effect Duration: 25
+1366	normal big tofurkey gravy	5	good	
+1367	bland half-sized special herbal stuffing	2	decent	Effect: "Larger", Effect Duration: 20
 1368	decent can-shaped gelatinous cranberry sauce	4	good	
 1369	bland snack-sized yams	2	decent	
 1370	Newton's rhinestone cowboy shirt	0		Experience (Mysticality): +3
@@ -1394,7 +1394,7 @@
 1412	vacuum-sealed snowcone	0		Effect: "Sugary Tongue", Effect Duration: 46, Last Available: "2006-01"
 1413	ionized snowcone	0		Effect: "BOOsted", Effect Duration: 42, Last Available: "2006-01"
 1414	nitrogenated aerosolized snowcone	0		Effect: "Soles of Glass", Effect Duration: 14, Last Available: "2006-01"
-1415	Vulcanized tumbling skewed snowcone	0		Effect: "Natural 20", Effect Duration: 58, Last Available: "2006-01"
+1415	Vulcanized skewed tumbling snowcone	0		Effect: "Natural 20", Effect Duration: 58, Last Available: "2006-01"
 1416	tarnished vacuum-sealed ghostly snowcone	0		Effect: "Lemony Goodness", Effect Duration: 13, Last Available: "2006-01"
 1417	liquefied snowcone	0		Effect: "Always be Collecting", Effect Duration: 67, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
@@ -1411,7 +1411,7 @@
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	special tasty low-calorie olive jittery mushroom	1	awesome	Effect: "Ooh, Sweet!", Effect Duration: 10
+1432	special tasty low-calorie jittery olive mushroom	1	awesome	Effect: "Ooh, Sweet!", Effect Duration: 10
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	wobbly hot pink lipstick	0		Familiar Weight: +5
@@ -1429,14 +1429,14 @@
 1447	aerosolized irradiated red nuggets	0		Effect: "Mighty Shout", Effect Duration: 23
 1448	super-galvanized cold-filtered quantum stench nuggets	0		Effect: "Flambé-a-thon", Effect Duration: 68
 1449	polymerized sleaze nuggets	0		Effect: "Liquid Luck", Effect Duration: 63
-1450	compressed blurry blinking twinkly wad	1		
+1450	compressed blinking blurry twinkly wad	1		
 1451	distilled hot wad	1		
 1452	altered jittery spinning wad	1		
 1453	pickled tumbling wad	1		Effect: "Hopped Up on Goofballs", Effect Duration: 40
 1454	twisted stench wad	1		
 1455	denatured sleaze wad	1		
 1456	double daisy	0		
-1457	twirling shaking olive Goth Giant	0		
+1457	olive twirling shaking Goth Giant	0		
 1458	big bland twirling Valentine's Day cake	5	decent	
 1459	narrow arrow'd heart balloon	0		
 1460	velvet box	0		
@@ -1455,7 +1455,7 @@
 1473	spinning ball-and-chain	0		
 1474	huge automatic catapult	0		
 1475	teal pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	huge maroon goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	maroon huge goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	jittery plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	huge football helmet	0		Familiar Effect: "atk, cap 37"
@@ -1475,17 +1475,17 @@
 1493	deadly ridiculously overelaborate ninja weapon of incineration	0		Weapon Damage: +5, Hot Spell Damage: +50
 1494	super-polymerized vacuum-sealed wet sugar-coated pine cone	0		Effect: "Broberry Brotality", Effect Duration: 57, Last Available: "2020-09"
 1495	gray blinking family-friendly deadly traffic cone	0		Weapon Damage: +5, Sleaze Resistance: +1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	weak aged gloomy mushroom wine	2	awesome	
+1496	aged weak gloomy mushroom wine	2	awesome	
 1497	acceptable high-proof mushroom wine	6	good	
 1498	huge McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	chilled explosion-flavored chewing gum	0		Effect: "Fancy Feasted", Effect Duration: 37, Last Available: "2006-04"
-1502	twirling skewed clown hammer	0		Last Available: "2006-04"
+1502	skewed twirling clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	aerosolized mirror snowcone	0		Effect: "Thought", Effect Duration: 37, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	acceptable watered-down shaking calle de miel with a fly in it	2	good	Last Available: "2006-04"
+1506	watered-down acceptable shaking calle de miel with a fly in it	2	good	Last Available: "2006-04"
 1507	artisanal narrow rockin' wagon with a fly in it	3	EPIC	Last Available: "2006-04"
 1508	acceptable perpendicular hula with a fly in it	4	good	Last Available: "2006-04"
 1509	mediocre olive slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
@@ -1502,8 +1502,8 @@
 1521	Frank Gorshin trophy	0		
 1522	family-friendly rosewater-soaked Radio Free Jersey	0		Stench Resistance: +3, Sleaze Resistance: +1
 1523	bottle of used blood	0		
-1524	blue mirror wind-up chattering teeth	0		Last Available: "2006-04"
-1525	mirror mirror joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1524	mirror blue wind-up chattering teeth	0		Last Available: "2006-04"
+1525	mirror mirror joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	upside-down Temple Grandin's corkscrew of the businessman	0		Familiar Weight: +7, Meat Drop: +50, Last Available: "2006-04"
@@ -1532,34 +1532,34 @@
 1552	delicious bottle of Definit	3	awesome	
 1553	tolerable blinking bottle of Calcutta Emerald	3	good	
 1554	watered-down artisanal pulsating tumbling red bottle of Lieutenant Freeman	2	EPIC	
-1555	triple-distilled tolerable bottle of Jorge Sinsonte	10	good	
+1555	tolerable triple-distilled bottle of Jorge Sinsonte	10	good	
 1556	smooth skewed boxed champagne	3	awesome	
 1557	normal fancy kumquat	4	good	Effect: "Sludgesick", Effect Duration: 20
-1558	tasty pulsating bouncing tangerine	4	awesome	
+1558	tasty bouncing pulsating tangerine	4	awesome	
 1559	twirling tonic water	0		
 1560	rotten cocktail onion	4	crappy	
-1561	bland big raspberry	5	decent	
+1561	big bland raspberry	5	decent	
 1562	bland kiwi	4	decent	
 1563	mediocre wobbly whiskey bittersweet	4	decent	
 1564	bad mimosette	3	decent	
-1565	watered-down drinkable tequila sunset	2	good	
-1566	artisanal weak zmobie	2	EPIC	Wiki Name: "Zmobie (drink)"
-1567	practically non-alcoholic hand-crafted gin and tonic	1	super EPIC	
+1565	drinkable watered-down tequila sunset	2	good	
+1566	weak artisanal zmobie	2	EPIC	Wiki Name: "Zmobie (drink)"
+1567	hand-crafted practically non-alcoholic gin and tonic	1	super EPIC	
 1568	artisanal watered-down vodka and tonic	2	EPIC	
-1569	drinkable practically non-alcoholic vodka gibson	1	good	
+1569	practically non-alcoholic drinkable vodka gibson	1	good	
 1570	lousy gibson	4	decent	
 1571	smooth squat parisian cathouse	3	awesome	
 1572	smooth teal rabbit punch	3	awesome	
 1573	triple-distilled artisanal teal caipifruta	6	EPIC	
 1574	hand-crafted yellow teqiwila	3	EPIC	
-1575	perfectly mixed weak Divine	2	super ultra EPIC	
-1576	weak artisanal skewed Gordon Bennett	2	super ultra EPIC	
-1577	watered-down smooth tangarita	2	awesome	
-1578	artisanal watered-down mandarina colada	2	super ultra EPIC	
+1575	weak perfectly mixed Divine	2	super ultra EPIC	
+1576	artisanal weak skewed Gordon Bennett	2	super ultra EPIC	
+1577	smooth watered-down tangarita	2	awesome	
+1578	watered-down artisanal mandarina colada	2	super ultra EPIC	
 1579	drinkable gimlet	3	good	
 1580	tolerable brick road	4	good	
-1581	lousy irresponsibly strong vodka stratocaster	8	decent	
-1582	tolerable shaking squat Neuromancer	4	good	
+1581	irresponsibly strong lousy vodka stratocaster	8	decent	
+1582	tolerable squat shaking Neuromancer	4	good	
 1583	practically non-alcoholic artisanal pulsating prussian cathouse	1	super ultra mega turbo EPIC	
 1584	artisanal red Mae West	4	EPIC	
 1585	drinkable enchanted shaking Mon Tiki	4	good	Effect: "Space Cowboy", Effect Duration: 10
@@ -1569,9 +1569,9 @@
 1589	rotten Knoll lo mein	3	crappy	
 1590	normal squat lo mein	3	good	
 1591	rotten olive lo mein	4	crappy	
-1592	diet flavorless hot hi mein	1	decent	
+1592	flavorless diet hot hi mein	1	decent	
 1593	decent hi mein	4	good	
-1594	snack-sized bland spinning hi mein	2	decent	
+1594	bland snack-sized spinning hi mein	2	decent	
 1595	special decent hi mein	3	good	Effect: "Spell Transfer Complete", Effect Duration: 15
 1596	stale sleazy hi mein	3	decent	
 1597	spinning extremely unsafe Junior LAAAAME merit badge	0		Weapon Damage Percent: +100, Last Available: "2006-05"
@@ -1579,11 +1579,11 @@
 1599	spinning jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	drinkable tangarita with a fly in it	3	good	
 1601	perfectly mixed mandarina colada with a fly in it	3	EPIC	
-1602	weak perfectly mixed jittery prussian cathouse with a fly in it	2	EPIC	
+1602	perfectly mixed weak jittery prussian cathouse with a fly in it	2	EPIC	
 1603	lousy narrow narrow Mae West with a fly in it	4	decent	
-1604	twisted wobbly jittery lime green astronaut ice-cream	1		Effect: "Natural 20", Effect Duration: 45, Last Available: "2006-05"
+1604	twisted wobbly lime green jittery astronaut ice-cream	1		Effect: "Natural 20", Effect Duration: 45, Last Available: "2006-05"
 1605	delectable catalyst	0		
-1606	twisted huge blurry cyan ultimate wad	1		
+1606	twisted blurry huge cyan ultimate wad	1		
 1607	non-pressed blurry libation of liveliness	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 43
 1608	adjusted super-irradiated galvanized pulsating eyedrops of the ermine	0		Effect: "Items Are Forever", Effect Duration: 14
 1609	triple-altered frozen quadruple-dry perfume of prejudice	0		Effect: "Ghost Finger", Effect Duration: 38
@@ -1630,7 +1630,7 @@
 1650	cyan milk of magnesium	0		
 1651	adequate blurry foie gras	3	good	
 1652	quadruple-dry triple-polarized teal candy brain	0		Effect: "Work For Hours a Week", Effect Duration: 39, Last Available: "2020-09"
-1653	cyan fireproof electrified baleful jewel-eyed wizard hat	0		Spell Damage: +25, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	cyan fireproof electrified baleful jewel-eyed wizard hat	0		Spell Damage: +25, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	mirror pulsating sizzling dog trainer's wad of Crovacite	0		Experience (familiar): +1, Hot Damage: +10
 1655	collar of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25
 1656	fuchsia White Citadel Satisfaction Satchel	0		
@@ -1670,14 +1670,14 @@
 1690	lime green discarded bottlecap of the blizzard of the glutton	0		Cold Spell Damage: +25, Food Drop: +100, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	flame-retardant studded discarded torn-up glove	0		Damage Absorption: +80, Hot Resistance: +1, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	modified deionized salamander slurry	0		Effect: "Disco Inferno", Effect Duration: 35
-1693	Vulcanized blinking jittery mirror eyedrops of newt	0		Effect: "Yuletide Mutations", Effect Duration: 11
+1693	Vulcanized mirror blinking jittery eyedrops of newt	0		Effect: "Yuletide Mutations", Effect Duration: 11
 1694	double-magnetized Frogade	0		Effect: "Amplified Fabulousness", Effect Duration: 57
 1695	irradiated flattened improved narrow papotion of papower	0		Effect: "Extra Backbone", Effect Duration: 22
-1696	snack-sized fancy rotten royal jelly taco	2	crappy	Effect: "Yet tea", Effect Duration: 35
+1696	fancy snack-sized rotten royal jelly taco	2	crappy	Effect: "Yet tea", Effect Duration: 35
 1697	normal tofu taco	3	good	
 1698	decent jumping bean taco	3	good	
 1699	stale half-sized catgut taco	2	decent	
-1700	decent tiny upside-down goat cheese taco	1	good	
+1700	tiny decent upside-down goat cheese taco	1	good	
 1701	decent pr0n taco	4	good	
 1702	cold-filtered adjusted gray ghostly alphabet gum	0		Effect: "Frostbeard", Effect Duration: 21
 1703	Comma Chameleon egg	0		Free Pull
@@ -1745,21 +1745,21 @@
 1766	Spookyraven ballroom key	0		
 1767	maroon pack of chewing gum	0		
 1768	teal Gnomish toolbox	0		
-1769	low-calorie stale squat fricasseed brains	1	decent	
-1770	flavorless huge brains casserole	8	decent	
+1769	stale low-calorie squat fricasseed brains	1	decent	
+1770	huge flavorless brains casserole	8	decent	
 1771	butcherknife of the bloodbag	0		Maximum HP: +100
 1772	corn holder of chilblains	0		Cold Damage: +25
 1773	skewed prompt eggbeater	0		Adventures: +3
 1774	watered-down drinkable bottle of popskull	2	good	
 1775	blurry jittery dishrag of wisdom	0		Mysticality: +15
-1776	bland immense stale baguette	6	decent	
+1776	immense bland stale baguette	6	decent	
 1777	blurry leftovers of indeterminate origin	0		
-1778	decent small jittery dinner	2	good	
+1778	small decent jittery dinner	2	good	
 1779	olive spinning frosty katana	0		Cold Spell Damage: +10
 1780	dangerous ram stick	0		Weapon Damage: +10
 1781	dog trainer's enchantlers	0		Experience (familiar): +1, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	ram-battering staff of wisdom of the wise owl	0		Mysticality: 35
-1783	tasty upside-down skewed crazy Turkish delight	3	awesome	
+1783	tasty skewed upside-down crazy Turkish delight	3	awesome	
 1784	twirling prompt stylish Snow Queen Crown	0		Moxie: +25, Adventures: +3, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	ga-ga radio of the storm of bravery of the detective	0		Maximum MP Percent: +40, Spooky Resistance: +5, Item Drop: +20
 1786	red wobbly six pack of Mountain Stream	0		
@@ -1786,7 +1786,7 @@
 1807	sixth cervical vertebra	0		
 1808	squat seventh cervical vertebra	0		
 1809	spinning first thoracic vertebra	0		
-1810	blinking upside-down second thoracic vertebra	0		
+1810	upside-down blinking second thoracic vertebra	0		
 1811	olive third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
@@ -1819,7 +1819,7 @@
 1840	wobbly left second rib	0		
 1841	spinning yellow left third rib	0		
 1842	left fourth rib	0		
-1843	tumbling fuchsia left fifth rib	0		
+1843	fuchsia tumbling left fifth rib	0		
 1844	shaking left sixth rib	0		
 1845	maroon left seventh rib	0		
 1846	left eighth rib	0		
@@ -1847,7 +1847,7 @@
 1868	left humerus	0		
 1869	right humerus	0		
 1870	left radius	0		
-1871	maroon blinking bouncing right radius	0		
+1871	blinking bouncing maroon right radius	0		
 1872	narrow left ulna	0		
 1873	right ulna	0		
 1874	upside-down left femur	0		
@@ -1857,7 +1857,7 @@
 1878	left fibula	0		
 1879	right fibula	0		
 1880	tumbling left kneecap	0		
-1881	maroon narrow right kneecap	0		
+1881	narrow maroon right kneecap	0		
 1882	shaking left first front claw	0		
 1883	skewed left second front claw	0		
 1884	mirror left third front claw	0		
@@ -1869,7 +1869,7 @@
 1890	blinking left thumb	0		
 1891	right thumb	0		
 1892	blurry yellow left first rear claw	0		
-1893	spinning shaking left second rear claw	0		
+1893	shaking spinning left second rear claw	0		
 1894	pulsating narrow left third rear claw	0		
 1895	shaking left fourth rear claw	0		
 1896	right first rear claw	0		
@@ -1888,7 +1888,7 @@
 1911	gray wool foul-smelling studded clockwork staff	0		Damage Absorption: +80, Stench Damage: +10, Cold Resistance: +1
 1912	frightening wicked clockwork crossbow of doom	0		Spell Damage: +5, Spooky Damage: +5, Spooky Spell Damage: +50
 1913	clockwork handle	0		
-1914	blinking green clockwork rod	0		
+1914	green blinking clockwork rod	0		
 1915	squat clockwork shank	0		
 1916	shaking Lord Spookyraven's spectacles	0		
 1917	gray wallet	0		
@@ -1923,12 +1923,12 @@
 1946	pulsating wool smelly accordion pin	0		Stench Spell Damage: +10, Cold Resistance: +1, Class: "Accordion Thief", Single Equip
 1947	Da Vinci's worn tophat of the empath	0		Experience (Mysticality): +5, Familiar Weight: +5, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	mirror smooth tap shoes of incineration	0		Moxie: +15, Hot Spell Damage: +50, Single Equip
-1949	stale miniature jittery Manetwich	2	decent	
+1949	miniature stale jittery Manetwich	2	decent	
 1950	spinning bottle of Vangoghbitussin	0		
-1951	practically non-alcoholic bad bottle of Pinot Renoir	1	decent	
+1951	bad practically non-alcoholic bottle of Pinot Renoir	1	decent	
 1952	moldy small ghostly desiccated apricot	2	crappy	
 1953	mediocre flute of flat champagne	3	decent	
-1954	small flavorless squat dehydrated caviar	2	decent	
+1954	flavorless small squat dehydrated caviar	2	decent	
 1955	blinking styrofoam peanuts	0		
 1956	watered-down bad snifter of thoroughly aged brandy	2	decent	
 1957	quill pen	0		
@@ -1943,14 +1943,14 @@
 1966	maroon shellacked Amulet of Yendor of vim and vigor	0		Damage Reduction: 7, Maximum HP Percent: +50, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	bottle of perfume	0		Familiar Weight: +5
-1969	skewed twirling lime green spoon!	0		Familiar Weight: +5
+1969	twirling lime green skewed spoon!	0		Familiar Weight: +5
 1970	nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	green spinning energetic sage shrimp fork	0		Mysticality Percent: +10, Maximum MP Percent: +20
 1973	bouncing half of a memo	0		
 1974	cocoabo	0		
 1975	lime green baby gravy fairy	0		
-1976	pulsating blue gravy fairy	0		
+1976	blue pulsating gravy fairy	0		
 1977	ghostly gravy fairy	0		
 1978	gravy fairy	0		
 1979	gravy fairy	0		
@@ -1980,7 +1980,7 @@
 2003	Thorny Toad trading card	0		
 2004	bouncing Chori Zo trading card	0		
 2005	teal Morbidda trading card	0		
-2006	twirling tumbling Poison Oak trading card	0		
+2006	tumbling twirling Poison Oak trading card	0		
 2007	olive Princess Rutabaga trading card	0		
 2008	Roo trading card	0		
 2009	yellow Woldo trading card	0		
@@ -1998,8 +1998,8 @@
 2021	adequate blue strawberry pie	4	good	
 2022	adequate mirror lemon meringue pie	3	good	
 2023	yellow Genalen&trade; Bottle	1	crappy	
-2024	half-sized bland mixed wildflower greens	2	decent	
-2025	huge yummy upside-down handful of walnuts	10	awesome	
+2024	bland half-sized mixed wildflower greens	2	decent	
+2025	yummy huge upside-down handful of walnuts	10	awesome	
 2026	adequate upside-down nutty organic salad	4	good	
 2027	tiny normal super salad	1	good	
 2028	special spoiled jumbo blinking tofu wonton	5	crappy	Effect: "Je Ne Sais Porquoise", Effect Duration: 20
@@ -2014,19 +2014,19 @@
 2037	magnetized corrupted twirling wintergreen-flavored potato chips	0		Effect: "Headstrong", Effect Duration: 65
 2038	concentrated ennui-flavored potato chips	0		Effect: "Pharmaceutically Cool", Effect Duration: 18
 2039	x-ray specs	0		Last Available: "2011-12"
-2040	squat wobbly skewed patchouli oil bomb	0		
+2040	squat skewed wobbly patchouli oil bomb	0		
 2041	ferret bait	0		
 2042	exploding hacky-sack	0		
 2043	mirror hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	flavorless gigantic brain-meltingly-hot chicken wings	9	decent	
-2046	miniature adequate fancy ghostly frat brats	2	good	Effect: "Starry-Eyed", Effect Duration: 45
-2047	yummy diet knob ka-bobs	1	awesome	
+2046	adequate miniature fancy ghostly frat brats	2	good	Effect: "Starry-Eyed", Effect Duration: 45
+2047	diet yummy knob ka-bobs	1	awesome	
 2049	aged yellow can of Swiller	4	awesome	
 2050	broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
-2053	mirror pulsating maroon bust of Pallas	0		Familiar Weight: +5
+2053	maroon pulsating mirror bust of Pallas	0		Familiar Weight: +5
 2054	purple market map	0		
 2055	snake skin	0		
 2056	super-cold-filtered adder bladder	0		Effect: "Full Bottle in front of Me", Effect Duration: 63
@@ -2060,7 +2060,7 @@
 2084	pulsating can of starch	0		
 2085	compressed bottle of ultravitamins	1		
 2086	compressed huge purple bottle of cough syrup	1		Effect: "Angry like the Wolf", Effect Duration: 10
-2087	distilled spinning blue tube of hair oil	1		Effect: "Riboflavin'", Effect Duration: 20
+2087	distilled blue spinning tube of hair oil	1		Effect: "Riboflavin'", Effect Duration: 20
 2088	dry Daffy Taffy	0		Effect: "Eye of the Seal", Effect Duration: 48
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	fireproof steel-toed razor-sharp Socratic boxer's pilgrim shield	0		Muscle Percent: +10, Experience (Mysticality): +1, Weapon Damage Percent: +25, Damage Reduction: 10, Hot Resistance: +3, Softcore Only, Last Available: "2006-11"
@@ -2072,7 +2072,7 @@
 2096	altered guy made of bee pollen	1		
 2097	aromatic 17-ball	0		Stench Resistance: +1
 2098	huge filthy lucre	0		
-2099	tumbling olive hobo gristle	0		
+2099	olive tumbling hobo gristle	0		
 2100	shredded can label	0		
 2101	bloodstained briquette	0		
 2102	greasy dreadlock	0		
@@ -2091,7 +2091,7 @@
 2115	cyan lightning-fast prehistoric spear	0		Initiative: +40, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
 2117	Usain Bolt's Rosewater's fire	0		Mysticality Percent: +30, Initiative: +80, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
-2118	squat tumbling leaf tube	0		Last Available: "2006-12"
+2118	tumbling squat leaf tube	0		Last Available: "2006-12"
 2119	bouncing lit cigar	0		Last Available: "2011-12"
 2120	squat cool Grateful Undead T-shirt	0		Moxie: +5
 2121	wobbly padded ASCII shirt	0		Damage Absorption: +20
@@ -2114,23 +2114,23 @@
 2139	skewed toy mercenary	0		Last Available: "2006-12"
 2140	length of string	0		Last Available: "2011-12"
 2141	green toy wheel	0		Last Available: "2011-12"
-2142	cyan blinking block	0		Last Available: "2011-12"
+2142	blinking cyan block	0		Last Available: "2011-12"
 2143	blinking felt	0		Last Available: "2011-12"
 2144	evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
 2146	huge evil teddy bear	0		Last Available: "2006-12"
 2147	green evil teddy bear sewing kit	0		
 2148	twirling toothsome rock	0		
-2149	bland gigantic upside-down squat lime green frank	7	decent	Last Available: "2011-12"
+2149	bland gigantic upside-down lime green squat frank	7	decent	Last Available: "2011-12"
 2150	rotten blurry plate of franks and beans	3	crappy	Last Available: "2011-12"
-2151	weak artisanal shot of blackberry schnapps	2	EPIC	
+2151	artisanal weak shot of blackberry schnapps	2	EPIC	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	upside-down ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	spinning high-resistance ultrapolymer plating	0		Last Available: "2011-12"
-2158	wobbly blue servomechanical torsion facilitator	0		Last Available: "2011-12"
+2158	blue wobbly servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	squat bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
@@ -2154,25 +2154,25 @@
 2179	archaeologist's notebook	0		
 2180	amulet	0		
 2181	narrow chocolate lump	0		Last Available: "2011-12"
-2182	twirling bouncing Harold's hammer head	0		
+2182	bouncing twirling Harold's hammer head	0		
 2183	Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	toasty Kiss the Knob apron	0		Hot Damage: +5
 2186	unlit birthday cake	0		
 2187	ghostly lit birthday cake	0		
 2188	blinking flask of peppermint oil	1	good	Last Available: "2006-12"
-2189	triple-distilled tolerable flask of peppermint schnapps	9	good	Last Available: "2006-12"
+2189	tolerable triple-distilled flask of peppermint schnapps	9	good	Last Available: "2006-12"
 2190	maroon yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	cyan sheet music	0		Last Available: "2006-12"
-2193	fancy small flavorless candy stake	2	decent	Effect: "Helvella Health", Effect Duration: 40, Last Available: "2006-12"
+2193	fancy flavorless small candy stake	2	decent	Effect: "Helvella Health", Effect Duration: 40, Last Available: "2006-12"
 2194	lousy eggnog	4	decent	Last Available: "2006-12"
 2195	moldy unspeakable fruitcake	4	crappy	Last Available: "2006-12"
 2196	moldy small ghostly ghostly gingerbread horror	2	crappy	Last Available: "2006-12"
 2197	quadruple-activated ionized but probably evil chocolate	0		Effect: "Pork Power", Effect Duration: 25, Last Available: "2006-12"
-2198	flavorless miniature bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	decent special miniature skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	delicious tiny tombstone-shaped Crimboween cookie	1	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2198	miniature flavorless bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2199	decent miniature special skull-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2200	tiny delicious tombstone-shaped Crimboween cookie	1	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	pulsating plastic gift-wrapping vampire of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-12"
 2202	plastic yuletide troll of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-12"
 2203	Oprah's plastic skeletal reindeer	0		Maximum MP Percent: +50, Single Equip, Last Available: "2006-12"
@@ -2192,7 +2192,7 @@
 2217	normal super ka-bob	3	good	
 2218	normal beer basted brat	4	good	
 2219	squat rock-hard Tropical Crimbo Sword	0		Damage Reduction: 5, Last Available: "2006-12"
-2220	anodized lime green pulsating and Crimboween candy	0		Effect: "Tiki Temerity", Effect Duration: 44, Last Available: "2020-09"
+2220	anodized pulsating lime green and Crimboween candy	0		Effect: "Tiki Temerity", Effect Duration: 44, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	groovy slick liar's pants	0		Moxie: +10, Moxie Percent: +10, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	skewed asbestos-lined juggler's balls of the pedagogue	0		Experience: +3, Hot Resistance: +5, Softcore Only, Last Available: "2007-01"
@@ -2240,14 +2240,14 @@
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	Staff of Fats of the detective	0		Item Drop: +20
-2269	rotten small upside-down sausage wonton	2	crappy	
+2269	small rotten upside-down sausage wonton	2	crappy	
 2270	flame-wreathed friendly belt	0		Familiar Weight: +3, Hot Spell Damage: +10, Single Equip
 2271	mediocre strong bottle of Merlot	5	decent	
 2272	mediocre bottle of Port	3	decent	
-2273	perfectly mixed practically non-alcoholic bottle of Pinot Noir	1	EPIC	
+2273	practically non-alcoholic perfectly mixed bottle of Pinot Noir	1	EPIC	
 2274	spirit-forward bad bottle of Zinfandel	5	decent	
 2275	mediocre mirror bottle of Marsala	3	decent	
-2276	acceptable weak fuchsia bouncing bottle of Muscat	2	good	
+2276	acceptable weak bouncing fuchsia bottle of Muscat	2	good	
 2277	Fernswarthy's key	0		
 2278	narrow Fernswarthy's letter	0		
 2279	book	0		
@@ -2301,7 +2301,7 @@
 2327	vacuum-sealed can of paint	0		Effect: "Barking Mad", Effect Duration: 51
 2328	ghostly drum machine	0		
 2329	gray handful of confetti	0		
-2330	spinning cyan chocolate-covered diamond-studded roses	0		
+2330	cyan spinning chocolate-covered diamond-studded roses	0		
 2331	tumbling bouquet of circular saw blades	0		
 2332	diet stale olive Better Than Cuddling Cake	1	decent	
 2333	ninja snowman	0		
@@ -2310,11 +2310,11 @@
 2336	blurry zippy Jeselnik's pipe	0		Sleaze Damage: +25, Initiative: +20
 2337	upside-down reinforced beaded headband of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	decent spinning pudding	4	good	Wiki Name: "black pudding (food)"
-2339	drinkable triple-distilled Blackfly Chardonnay	9	good	
-2340	practically non-alcoholic hand-crafted & tan	1	EPIC	
+2339	triple-distilled drinkable Blackfly Chardonnay	9	good	
+2340	hand-crafted practically non-alcoholic & tan	1	EPIC	
 2341	pepper	0		
 2342	half-sized flavorless forest cake	2	decent	
-2343	stale gigantic forest ham	7	decent	
+2343	gigantic stale forest ham	7	decent	
 2344	extra-unsweetened filthworm hatchling scent gland	0		Effect: "Goldentongue", Effect Duration: 65
 2345	tarnished filthworm drone scent gland	0		Effect: "Barbecue Saucy", Effect Duration: 31
 2346	quantum dry filthworm royal guard scent gland	0		Effect: "Human-Demon Hybrid", Effect Duration: 33
@@ -2347,7 +2347,7 @@
 2373	rotten banana	3	crappy	
 2374	banana peel	0		
 2375	spoiled banana cream pie	3	crappy	
-2376	irresponsibly strong aged banana daiquiri	6	awesome	
+2376	aged irresponsibly strong banana daiquiri	6	awesome	
 2377	watered-down bad purple bungle in the jungle	2	decent	
 2378	banana spritzer	0		
 2379	quadruple-dry dry banana smoothie	0		Effect: "Improved Candy Vision", Effect Duration: 33
@@ -2375,7 +2375,7 @@
 2401	MacGyver's quilted beer bong	0		Damage Absorption: +40, Maximum MP: +100
 2402	red tumbling gauze garter	0		
 2403	barrel of gunpowder	0		
-2404	ghostly pulsating jam band flyers	0		
+2404	pulsating ghostly jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	pink bat eye	0		
@@ -2390,7 +2390,7 @@
 2416	Temple Grandin's bounty-hunting helmet	0		Familiar Weight: +7, Familiar Effect: "1.5xFairy, cap 25"
 2417	frightening bounty-hunting rifle	0		Spooky Damage: +5
 2418	Annie Oakley's bounty-hunting pants	0		Critical Hit Percent: +20, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	tarnished gray bouncing bottle of rhinoceros hormones	0		Effect: "You Know What's Up", Effect Duration: 55
+2419	tarnished bouncing gray bottle of rhinoceros hormones	0		Effect: "You Know What's Up", Effect Duration: 55
 2420	cold-filtered teeny-tiny magic scroll	0		Effect: "A Contender", Effect Duration: 50
 2421	enhanced bottle of pirate juice	0		Effect: "Salamander In Your Stomach", Effect Duration: 39
 2422	moist irradiated pet snacks	0		Effect: "Sweet Taste", Effect Duration: 45
@@ -2400,7 +2400,7 @@
 2426	deionized jittery fire flower	0		Effect: "Eyes Wide Propped", Effect Duration: 18
 2427	super-tarnished dry mirror freezerburned ice cube	0		Effect: "Orchid Blood", Effect Duration: 62
 2428	tarnished non-enhanced fake blood	0		Effect: "Tingly Biceps", Effect Duration: 31
-2429	modified warmed spinning purple Eau de Guaneau	0		Effect: "Kernel Panic!", Effect Duration: 24
+2429	modified warmed purple spinning Eau de Guaneau	0		Effect: "Kernel Panic!", Effect Duration: 24
 2430	deionized bag of lard	0		Effect: "The Spy Who Loved XP", Effect Duration: 26
 2431	moist colloidal green bottle of Mystic Shell	0		Effect: "Coy to the Hurled", Effect Duration: 48
 2432	flattened SPF 451 lip balm	0		Effect: "Jawin'", Effect Duration: 24
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	twirling Cobb's Knob map	0		
 2443	blue huge asbestos-lined hale pink glowstick	0		Maximum HP: +20, Hot Resistance: +5, Last Available: "2007-03"
-2444	watered-down artisanal huge Supernova Champagne	2	EPIC	
+2444	artisanal watered-down huge Supernova Champagne	2	EPIC	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	wobbly bad penguin egg	0		Free Pull
@@ -2439,7 +2439,7 @@
 2466	pompadour'd puppy	0		
 2467	shaking yellow suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
-2469	blurry mirror bundle of receipts	0		
+2469	mirror blurry bundle of receipts	0		
 2470	cork	0		
 2471	stardust	0		
 2472	narrow wilted lettuce	0		
@@ -2490,7 +2490,7 @@
 2517	ghostly yellow chain necklace of James Dean of terror	0		Experience (Moxie): +3, Spooky Spell Damage: +10
 2518	sawblade shield of the cheetah	0		Initiative: +60, Damage Reduction: 11
 2519	delicious McMillicancuddy's Special Lager	4	awesome	
-2520	weak enchanted aged melted Jell-o shot	2	awesome	Effect: "In the Limelight", Effect Duration: 15
+2520	aged weak enchanted melted Jell-o shot	2	awesome	Effect: "In the Limelight", Effect Duration: 15
 2521	drinkable maroon cruelty-free wine	4	good	
 2522	smooth jittery blurry thistle wine	3	awesome	
 2523	megatofu	0		
@@ -2500,12 +2500,12 @@
 2527	spoiled fuchsia fish lasagna	3	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	moldy gnatloaf	4	crappy	
-2530	yummy half-sized spinning gnatloaf casserole	2	awesome	
-2531	diet tasty fancy gnat lasagna	1	awesome	Effect: "Improved Candy Vision", Effect Duration: 25
+2530	half-sized yummy spinning gnatloaf casserole	2	awesome	
+2531	tasty fancy diet gnat lasagna	1	awesome	Effect: "Improved Candy Vision", Effect Duration: 25
 2532	skewed pork	0		
 2533	half-sized decent skewed blinking pork chop sandwiches	2	good	
 2534	toothsome big pork casserole	5	awesome	
-2535	rotten special pork lasagna	3	crappy	Effect: "Walberg's Dim Bulb", Effect Duration: 10
+2535	special rotten pork lasagna	3	crappy	Effect: "Walberg's Dim Bulb", Effect Duration: 10
 2536	canopic jar	0		
 2537	spice	0		
 2538	red bouncing organs	0		
@@ -2532,7 +2532,7 @@
 2559	aromatic razor-sharp Hammer of Smiting	0		Weapon Damage Percent: +25, Stench Resistance: +1, Class: "Seal Clubber"
 2560	gray 17-alarm Saucepan of James Dean of the early riser	0		Experience (Moxie): +3, Adventures: +7, Class: "Sauceror"
 2561	nippy steel-toed rock-hard Greek Pasta Spoon of Peril	0		Damage Reduction: 28, Cold Damage: +10, Class: "Pastamancer"
-2562	lime green ghostly half-rotten brain	0		
+2562	ghostly lime green half-rotten brain	0		
 2563	bonesaw	0		
 2564	green plus-sized phylactery	0		
 2565	can of Ghuol-B-Gone&trade;	0		
@@ -2545,11 +2545,11 @@
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
-2575	purple tumbling bronzed locust	0		
+2575	tumbling purple bronzed locust	0		
 2576	ghostly honey-dipped locust	0		
 2577	squat arcane researcher's beefy cactus quill	0		Muscle: +10, Experience Percent (Mysticality): +10
 2578	Van der Graaf crafty Staff of the Short Order Cook	0		Maximum MP: +10, Item Drop: +5, MP Regen Min: 5, MP Regen Max: 7
-2579	rotten snack-sized gray cactus fruit	2	crappy	
+2579	snack-sized rotten gray cactus fruit	2	crappy	
 2580	red frosty Da Vinci's scorpion whip	0		Experience (Mysticality): +5, Cold Spell Damage: +10
 2581	yellow handful of sand	0		
 2582	brick of sand	0		
@@ -2560,12 +2560,12 @@
 2587	groovy Corporal Fennel's Lonely Clubs Club Jacket	0		Moxie Percent: +10
 2588	blue Private Pepper's Lonely Hearts Club Jacket of terror	0		Spooky Spell Damage: +10
 2589	bland huge hot date	6	decent	
-2590	boozy artisanal enchanted distilled fortified wine	5	EPIC	Effect: "Flashing Eyes", Effect Duration: 25
+2590	enchanted artisanal boozy distilled fortified wine	5	EPIC	Effect: "Flashing Eyes", Effect Duration: 25
 2591	flavorless blinking tasty tart	3	decent	
 2592	Knob Goblin lunchbox	0		
-2593	normal jumbo Knob pasty	5	good	
+2593	jumbo normal Knob pasty	5	good	
 2594	tolerable spinning thermos full of Knob coffee	3	good	
-2595	chilled blinking shaking twirling Ben-Gal&trade; Balm	0		Effect: "Cheered Up", Effect Duration: 58
+2595	chilled blinking twirling shaking Ben-Gal&trade; Balm	0		Effect: "Cheered Up", Effect Duration: 58
 2596	maroon leathery cat skin	0		
 2597	leathery bat skin	0		
 2598	leathery rat skin	0		
@@ -2620,14 +2620,14 @@
 2647	fetid feather	0		
 2648	spinning flirtatious feather	0		
 2649	Lord Spookyraven's ear trumpet of horror	0		Spooky Spell Damage: +25, Single Equip
-2650	upside-down blurry green bottled pixie	0		Free Pull
+2650	blurry upside-down green bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	spoiled gigantic S.T.L.T.	6	crappy	Last Available: "2007-06"
 2653	bland honey-dew	4	decent	Last Available: "2007-06"
-2654	tolerable high-proof red skewed Xanadian	9	good	Last Available: "2007-06"
-2655	alkaline liquefied pulsating cyan skewed bottle of absinthe	0		Effect: "Human-Hobo Hybrid", Effect Duration: 50, Last Available: "2007-06"
+2654	high-proof tolerable skewed red Xanadian	9	good	Last Available: "2007-06"
+2655	alkaline liquefied pulsating skewed cyan bottle of absinthe	0		Effect: "Human-Hobo Hybrid", Effect Duration: 50, Last Available: "2007-06"
 2656	gray Annie Oakley's Drowsy Sword of the blizzard	0		Critical Hit Percent: +20, Cold Spell Damage: +25
-2657	snack-sized flavorless teal mirror escargotsicle	2	decent	Last Available: "2007-06"
+2657	snack-sized flavorless mirror teal escargotsicle	2	decent	Last Available: "2007-06"
 2658	watered-down special acceptable bottle of realpagne	2	good	Effect: "Mistified", Effect Duration: 5, Last Available: "2007-06"
 2659	ghostly albatross necklace of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2007-06"
 2660	dehydrated upside-down fuchsia not-a-pipe	1	good	Effect: "Sparkling Consciousness", Effect Duration: 5, Last Available: "2007-06"
@@ -2656,7 +2656,7 @@
 2683	Warehouse 23 crate	0		
 2684	pulsating fuchsia Jeselnik's arcane researcher's armgun	0		Experience Percent (Mysticality): +10, Sleaze Damage: +25
 2685	seashell necklace	0		
-2686	pulsating olive commemorative war stein	0		
+2686	olive pulsating commemorative war stein	0		
 2687	stone frisbee	0		
 2688	asbestos-lined steel-toed Fonzie's dreadlock whip	0		Experience (Moxie): +1, Damage Reduction: 9, Hot Resistance: +5
 2689	huge supercool beer-a-pult of the detective	0		Moxie Percent: +20, Item Drop: +20
@@ -2665,9 +2665,9 @@
 2692	mirror Usain Bolt's boxer's driftwood sculpture	0		Muscle Percent: +10, Initiative: +80
 2693	wicked cool massive sitar	0		Moxie: +5, Spell Damage: +5
 2694	censurious family-friendly thinker's stone baseball cap	0		Mysticality: +10, Sleaze Resistance: 4, Familiar Effect: "1xVolley, cap 48"
-2695	tolerable weak mirror cup of beer	2	good	
+2695	weak tolerable mirror cup of beer	2	good	
 2696	upside-down ovoid thing	0		
-2697	ghostly twirling duct tape	0		
+2697	twirling ghostly duct tape	0		
 2698	mirror duct tape wallet	0		
 2699	narrow MacGyver's clever duct tape shirt	0		Maximum MP: 120
 2700	twirling frightening nippy duct tape fedora	0		Cold Damage: +10, Spooky Damage: +5, Familiar Effect: "1xBarrr, 1xLep, cap 48"
@@ -2679,7 +2679,7 @@
 2706	mirror teal Fonzie's sage blackberry moccasins of dire peril	0		Mysticality Percent: +10, Experience (Moxie): +1, Weapon Damage: +20, Single Equip
 2707	pulsating lard-coated frightening extremely unsafe blackberry combat boots	0		Weapon Damage Percent: +100, Spooky Damage: +5, Sleaze Spell Damage: +25, Single Equip
 2708	frozen deionized shaking funky dried mushroom	0		Effect: "[800]Chocolate Reign", Effect Duration: 14
-2709	shaking yellow huge exotic parrot egg	0		
+2709	yellow huge shaking exotic parrot egg	0		
 2710	shaking cracker	0		Familiar Weight: +15
 2711	chilled facepaint	0		Effect: "Deadly Lampblade", Effect Duration: 17
 2712	moist pulsating sheepskin diploma	0		Effect: "Mathematically Precise", Effect Duration: 20
@@ -2694,7 +2694,7 @@
 2721	ruddy dangerous hand-carved staff of the cheetah	0		Weapon Damage: +10, Maximum HP Percent: +40, Initiative: +60
 2722	red wobbly horrifying Sinatra's Staff of the Greasefire of terror of temperance	0		Experience (Moxie): +5, Spooky Damage: +25, Spooky Spell Damage: +10, Sleaze Resistance: +5
 2723	huge cyan avaricious flame-retardant Staff of the Grand Flamb&eacute; of doom	0		Spooky Spell Damage: +50, Hot Resistance: +1, Meat Drop: +30
-2724	gigantic bland bowl of rye sprouts	9	decent	
+2724	bland gigantic bowl of rye sprouts	9	decent	
 2725	flavorless pulsating cob of corn	3	decent	
 2726	adequate snack-sized tumbling juniper berries	2	good	
 2727	moldy plum	3	crappy	
@@ -2703,20 +2703,20 @@
 2730	hand-crafted blurry plum wine	3	EPIC	
 2731	drinkable practically non-alcoholic wobbly shot of pear schnapps	1	good	
 2732	practically non-alcoholic hand-crafted jittery shot of peach schnapps	1	EPIC	
-2733	stale thick bunch of square grapes	5	decent	
-2734	toothsome snack-sized brown sugar cane	2	awesome	
+2733	thick stale bunch of square grapes	5	decent	
+2734	snack-sized toothsome brown sugar cane	2	awesome	
 2735	adequate sandwich of the gods	3	good	
-2736	lousy irresponsibly strong Pan-Dimensional Gargle Blaster	8	decent	
-2737	diluted jittery blurry green leopard-print barbell	1	awesome	
+2736	irresponsibly strong lousy Pan-Dimensional Gargle Blaster	8	decent	
+2737	diluted blurry jittery green leopard-print barbell	1	awesome	
 2738	blurry pile of smoking rags	0		
 2739	flattened super-quantum energized upside-down olive panty raider camouflage	0		Effect: "Aloofah", Effect Duration: 30
 2740	skewed hardened wicked Staff of the Walk-In Freezer of the sweet-tooth	0		Spell Damage: +5, Damage Reduction: 3, Candy Drop: +100
 2741	acceptable boilermaker	4	good	
 2742	decent half-sized steel lasagna	2	quest	
-2743	watered-down perfectly mixed steel margarita	2	quest	
+2743	perfectly mixed watered-down steel margarita	2	quest	
 2744	vaporized squat steel-scented air freshener	1		
 2745	anodized upside-down gremlin mutagen	0		Effect: "Pop-eyed", Effect Duration: 61
-2746	denatured shaking blinking extra-potent gremlin mutagen	0		Effect: "Nothing Is Impossible", Effect Duration: 56
+2746	denatured blinking shaking extra-potent gremlin mutagen	0		Effect: "Nothing Is Impossible", Effect Duration: 56
 2747	yellow chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of the dark arts	0		Spell Damage Percent: +100, Single Equip
 2749	ribald stiffened strapping Staff of the Grease Trap	0		Muscle: +5, Damage Reduction: 1, Sleaze Damage: +10
@@ -2737,7 +2737,7 @@
 2764	blue greedy frightening sharpshooter's Order of the Silver Wossname	0		Critical Hit Percent: +10, Spooky Damage: +5, Meat Drop: +20, Single Equip
 2765	huge Harold's bell	0		
 2766	bowling ball	0		
-2767	decent small green spinning Crimbo pie	2	good	
+2767	decent small spinning green Crimbo pie	2	good	
 2768	decent miniature pear tart	2	good	
 2769	delicious peach pie	4	awesome	
 2770	quantum chunk of rock salt	0		Effect: "Texas Elegance", Effect Duration: 38
@@ -2771,8 +2771,8 @@
 2798	wool vibrating Mudflap-Girl Earring	0		Maximum MP Percent: +10, Cold Resistance: +1, Single Equip
 2799	flame-wreathed weightlifter's Mudflap-Girl Necklace	0		Muscle: +15, Hot Spell Damage: +10, Single Equip
 2800	tumbling olive dangerous supercool Mudflap-Girl Ring	0		Moxie Percent: +20, Weapon Damage: +10, Single Equip
-2801	mirror twirling vial of Gnomochloric acid	0		
-2802	skewed lime green flask of Gnomochloric acid	0		
+2801	twirling mirror vial of Gnomochloric acid	0		
+2802	lime green skewed flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	vacuum-sealed modified vial of hamethyst juice	0		Effect: "Toast Tea", Effect Duration: 20
 2805	super-cold-filtered pickled vial of baconstone juice	0		Effect: "Just Aged Enough", Effect Duration: 17
@@ -2804,7 +2804,7 @@
 2831	shaking star key lime	0		
 2832	adequate pulsating digital key lime pie	4	good	
 2833	thick rotten upside-down star key lime pie	5	crappy	
-2834	foul-smelling toasty grievous bottle-rocket crossbow	0		Weapon Damage Percent: +50, Hot Damage: +5, Stench Damage: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2834	foul-smelling toasty grievous bottle-rocket crossbow	0		Weapon Damage Percent: +50, Hot Damage: +5, Stench Damage: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	knitted indie comic hipster glasses	0		Cold Resistance: +3, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	maroon mint-condition magic wand	0		Last Available: "2011-12"
@@ -2812,7 +2812,7 @@
 2839	ribald Periodical Paintbrush	0		Sleaze Damage: +10, Softcore Only
 2840	weak aged bottle of cooking sherry	2	awesome	
 2841	normal low-calorie spinning packet of ketchup	1	good	
-2842	hand-crafted mirror ghostly accidental cider	3	EPIC	
+2842	hand-crafted ghostly mirror accidental cider	3	EPIC	
 2843	normal snack-sized green dire fudgesicle	2	good	
 2844	frightening crafty groovy navel ring of navel gazing of the storm	0		Moxie Percent: +10, Maximum MP Percent: +40, Maximum MP: +10, Spooky Damage: +5, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2820,7 +2820,7 @@
 2847	chilly Dallas Dynasty Falcon Crest shield	0		Cold Damage: +5, Damage Reduction: 15
 2848	pulsating Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	extra-dry tolerable yellow moonberry wine cooler	5	good	
+2850	tolerable extra-dry yellow moonberry wine cooler	5	good	
 2851	yummy fine aged cheddarwurst	3	awesome	
 2852	branch from the Great Tree	0		
 2853	gray Phil Bunion's axe	0		
@@ -2915,7 +2915,7 @@
 2942	wet non-wet flattened chocolate filthy lucre	0		Effect: "Scrappy, Shadowy", Effect Duration: 53
 2943	nitrogenated Angry Farmer's Wife Candy	0		Effect: "Rat-Faced", Effect Duration: 66
 2945	crafty slick party hat	0		Moxie: +10, Maximum MP: +10, Familiar Effect: "4xLep, cap 7"
-2946	hardened V for Vivala mask of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	hardened V for Vivala mask of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
 2948	bad shot of rotgut	4	decent	
 2949	galvanized double-Vulcanized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Puddingskin", Effect Duration: 62
@@ -2924,10 +2924,10 @@
 2952	blinking stanky glowstick	0		Stench Spell Damage: +25, Item Drop: +5, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	Jeselnik's tip jar	0		Sleaze Damage: +25
-2955	gigantic flavorless yam candy	7	decent	
+2955	flavorless gigantic yam candy	7	decent	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	tasty small tube of cranberry Go-Goo	2	awesome	
+2958	small tasty tube of cranberry Go-Goo	2	awesome	
 2959	shaking up-at-dawn rum barrel charrrm bracelet	0		Adventures: +5
 2960	diet adequate single-serving herbal stuffing	1	good	
 2961	yummy packet of tofurkey gravy	3	awesome	
@@ -2937,15 +2937,15 @@
 2965	ghostly mizzenmast mop	0		
 2966	skewed Tom's of the Spanish Main Toothpaste	0		
 2967	enhanced blinking jittery Swabbie&trade; swab	0		Effect: "Mushroom Samba", Effect Duration: 16
-2968	double-warmed irradiated ghostly shaking Oil of Parrrlay	0		Effect: "Venomous Weapon", Effect Duration: 65
+2968	double-warmed irradiated shaking ghostly Oil of Parrrlay	0		Effect: "Venomous Weapon", Effect Duration: 65
 2969	moldy creamsicle	4	crappy	
-2970	practically non-alcoholic drinkable cream stout	1	good	
+2970	drinkable practically non-alcoholic cream stout	1	good	
 2971	blurry huge flame-wreathed savvy curmudgel	0		Mysticality Percent: +20, Hot Spell Damage: +10
 2972	grumpy man charrrm	0		
 2973	rosy-cheeked grumpy man charrrm bracelet	0		Maximum HP Percent: +30, Single Equip
 2974	tarrrnish charrrm	0		
 2975	Jim Carey's beefcake's tarrrnished charrrm bracelet	0		Muscle: +25, Monster Level: +25, Single Equip
-2976	bad watered-down bilge wine	2	decent	
+2976	watered-down bad bilge wine	2	decent	
 2977	pulsating curative witty rapier	0		HP Regen Min: 3, HP Regen Max: 5
 2978	extremely unsafe yohohoyo of the ox	0		Muscle: +20, Weapon Damage Percent: +100
 2979	tarnished pickled fish-liver oil	0		Effect: "Resilient Spirit", Effect Duration: 69
@@ -2962,7 +2962,7 @@
 2990	ghostly lard-coated educational clingfilm cap	0		Experience: +1, Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, cap 37"
 2991	blinking shellacked clingfilm slippers	0		Damage Reduction: 7, Single Equip
 2992	clingfilm tangle	0		
-2993	adequate miniature vinegar-soaked lemon slice	2	good	
+2993	miniature adequate vinegar-soaked lemon slice	2	good	
 2994	non-tarnished warmed purple true grit	0		Effect: "Big Meat Big Prizes", Effect Duration: 35
 2995	greedy asbestos-lined buoybottoms of Calamity Jane	0		Critical Hit Percent: +15, Hot Resistance: +5, Meat Drop: +20, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	tumbling curative grungy flannel shirt	0		HP Regen Min: 3, HP Regen Max: 5
@@ -2990,7 +2990,7 @@
 3018	gilded chest	0		
 3019	all-purpose cleaner	0		
 3020	handful of sawdust	0		
-3021	blinking pulsating stone triangle	0		
+3021	pulsating blinking stone triangle	0		
 3022	medium stone triangle	0		
 3023	jittery small stone triangle	0		
 3024	blue stone pyramid	0		
@@ -2998,10 +2998,10 @@
 3026	artisanal strong corpsetini	5	EPIC	
 3027	weak aged corpsedriver	2	awesome	
 3028	delicious huge Corpse Island iced tea	4	awesome	
-3029	lousy weak ghostly red-headed corpse	2	decent	
+3029	weak lousy ghostly red-headed corpse	2	decent	
 3030	tolerable practically non-alcoholic skewed twirling kamicorpse-ee	1	good	
 3031	aged corpsel	4	awesome	
-3032	practically non-alcoholic drinkable corpsebite	1	good	
+3032	drinkable practically non-alcoholic corpsebite	1	good	
 3033	rosy-cheeked pirate fledges	0		Maximum HP Percent: +30
 3034	piece of thirteen	0		
 3035	half-sized yummy pearl onion	2	awesome	
@@ -3017,7 +3017,7 @@
 3045	low-calorie flavorless nanite-infested gingerbread bugbear	1	decent	Last Available: "2007-12"
 3046	rotten immense nanite-infested candy cane	6	crappy	Last Available: "2020-09"
 3047	moldy fancy nanite-infested fruitcake	3	crappy	Effect: "Happy Trails", Effect Duration: 30, Last Available: "2007-12"
-3048	extra-dry tolerable nanite-infested eggnog	5	good	Last Available: "2007-12"
+3048	tolerable extra-dry nanite-infested eggnog	5	good	Last Available: "2007-12"
 3049	tumbling El Vibrato power sphere	0		
 3050	shellacked eyepatch	0		Damage Reduction: 7, Familiar Effect: "spooky atk, 1xBarrr"
 3051	frosty cutlass	0		Cold Spell Damage: +10
@@ -3043,12 +3043,12 @@
 3071	silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
-3074	skewed narrow polymorphic fastening apparatus	0		Last Available: "2007-12"
+3074	narrow skewed polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	huge laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	mirror Newton's marionette collective	0		Experience (Mysticality): +3, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3064,7 +3064,7 @@
 3092	handmade hobby horse of dire peril	0		Weapon Damage: +20, Last Available: "2007-12"
 3093	skewed forbidden ball-in-a-cup	0		Spell Damage Percent: +50, Last Available: "2007-12"
 3094	set of jacks of the brazier	0		Hot Spell Damage: +25, Last Available: "2007-12"
-3095	fancy bland purple laser-broiled pear	3	decent	Effect: "Human-Elf Hybrid", Effect Duration: 40, Last Available: "2007-12"
+3095	bland fancy purple laser-broiled pear	3	decent	Effect: "Human-Elf Hybrid", Effect Duration: 40, Last Available: "2007-12"
 3096	upside-down yellow asbestos-lined frightening polyalloy shield	0		Spooky Damage: +5, Hot Resistance: +5, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
@@ -3090,15 +3090,15 @@
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
-3121	olive tumbling divine champagne popper	0		Last Available: "2008-01"
-3122	huge yellow divine cracker	0		Last Available: "2008-01"
+3121	tumbling olive divine champagne popper	0		Last Available: "2008-01"
+3122	yellow huge divine cracker	0		Last Available: "2008-01"
 3123	maroon spinning divine champagne flute	0		Last Available: "2008-01"
 3124	magnetized shaking fruitfilm	0		Effect: "Smugness", Effect Duration: 36
 3125	dry piece of after eight	0		Effect: "Perfect Hair", Effect Duration: 16
-3126	ghostly olive hobo nickel	0		
+3126	olive ghostly hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
-3129	moldy blurry red roasted marshmallow	3	crappy	
+3129	moldy red blurry roasted marshmallow	3	crappy	
 3130	disc	0		Last Available: "2008-01"
 3131	rotten diet tin cup of mulligan stew	1	crappy	
 3132	hardened dance instructor's flamin' bindle	0		Experience Percent (Moxie): +10, Damage Reduction: 3
@@ -3147,9 +3147,9 @@
 3175	tasty half-sized evil noodles	2	awesome	
 3176	bland small ghostly yellow evil noodles	2	decent	
 3177	flavorless upside-down evil painful penne pasta	3	decent	
-3178	decent immense 3vi1 pr0n m4nic0tti	10	good	
-3179	small delicious evil ravioli della hippy	2	awesome	
-3180	thick yummy evil noodles	5	awesome	
+3178	immense decent 3vi1 pr0n m4nic0tti	10	good	
+3179	delicious small evil ravioli della hippy	2	awesome	
+3180	yummy thick evil noodles	5	awesome	
 3181	super-altered yellow evil potion of potency	0		Effect: "Patched In", Effect Duration: 41
 3182	unsweetened spinning evil libation of liveliness	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 57
 3183	deionized evil tomato juice of powerful power	0		Effect: "Crusty Head", Effect Duration: 60
@@ -3159,7 +3159,7 @@
 3187	super-galvanized concentrated blinking evil philter of phorce	0		Effect: "Prelude of Precision", Effect Duration: 66
 3188	lousy watered-down bouncing an evil sump'm sump'm	2	decent	
 3189	aged watered-down evil ducha de oro	2	awesome	
-3190	weak bad evil horizontal tango	2	decent	
+3190	bad weak evil horizontal tango	2	decent	
 3191	practically non-alcoholic drinkable evil roll in the hay	1	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	wobbly naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3194,7 +3194,7 @@
 3222	teal aromatic weightlifter's gatorskin umbrella	0		Muscle: +15, Stench Resistance: +1
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	triple-distilled mediocre bouncing bottle of sewage schnapps	7	decent	
+3225	mediocre triple-distilled bouncing bottle of sewage schnapps	7	decent	
 3226	perfectly mixed bottle of Ooze-O	4	EPIC	
 3227	spoiled C.H.U.M. chum	3	crappy	
 3228	flavorless squat unfortunate dumplings	3	decent	
@@ -3204,7 +3204,7 @@
 3232	adequate vanilla-frosted king cake	4	good	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
-3235	blue narrow noodle	0		
+3235	narrow blue noodle	0		
 3236	Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	pulsating Blizzards I Have Died In	0		Skill: "Snowclone"
@@ -3240,9 +3240,9 @@
 3268	corrupted blinking handful of Crotchety Pine needles	0		Effect: "Buggy Flavor", Effect Duration: 25
 3269	nitrogenated double-ionized lump of Saccharine Maple sap	0		Effect: "Human-Constellation Hybrid", Effect Duration: 37
 3270	dry purple handful of Laughing Willow bark	0		Effect: "From Nantucket", Effect Duration: 66
-3271	skewed family-friendly crotchety pants	0		Sleaze Resistance: +1, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	skewed family-friendly crotchety pants	0		Sleaze Resistance: +1, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	bouncing frightening Saccharine Maple pendant	0		Spooky Damage: +5, Conditional Skill (Equipped): "Spray Sap"
-3273	knitted willowy bonnet	0		Cold Resistance: +3, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	knitted willowy bonnet	0		Cold Resistance: +3, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	red flavored foot massage oil	0		Last Available: "2008-04"
 3275	bouncing dart	0		Last Available: "2008-04"
 3276	skewed black-and-blue light	0		Last Available: "2008-04"
@@ -3258,15 +3258,15 @@
 3286	smartaleck's Frosty's snowball sack	0		Moxie Percent: +30
 3287	teal quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
 3288	upside-down shimmering tendrils	0		Class: "Pastamancer"
-3289	bouncing shaking scintillating powder	0		Class: "Pastamancer"
+3289	shaking bouncing scintillating powder	0		Class: "Pastamancer"
 3290	abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	narrow adorable seal larva	0		
 3293	squat untamable turtle	0		
 3294	macaroni duck	0		
-3295	maroon skewed friendly cheez blob	0		
+3295	skewed maroon friendly cheez blob	0		
 3296	unusual disco ball	0		
-3297	jittery fuchsia stray chihuahua	0		
+3297	fuchsia jittery stray chihuahua	0		
 3298	pretty pink bow	0		
 3299	spinning smiley-face sticker	0		
 3300	farfalle bow tie	0		
@@ -3291,9 +3291,9 @@
 3319	scorching Mr. Joe's bangles	0		Hot Damage: +25, Single Equip
 3320	shaking brawny frayed rope belt	0		Muscle Percent: +20, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	extremely unsafe mayfly bait necklace of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: +40, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	extremely unsafe mayfly bait necklace of the storm	0		Weapon Damage Percent: +100, Maximum MP Percent: +40, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
-3324	spinning tumbling Frosty's frosty mug	0		
+3324	tumbling spinning Frosty's frosty mug	0		
 3325	mediocre ghostly jar of fermented pickle juice	3	decent	
 3326	dehydrated voodoo snuff	1	EPIC	
 3327	moldy diet ghostly wobbly extra-greasy slider	1	crappy	
@@ -3332,7 +3332,7 @@
 3360	spinning stinkbug	0		Last Available: "2008-06"
 3361	narrow yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	immense rotten mole mol&eacute;	10	crappy	Last Available: "2008-06"
+3363	rotten immense mole mol&eacute;	10	crappy	Last Available: "2008-06"
 3364	tolerable Morlock's Mark Bourbon	4	good	Last Available: "2008-06"
 3365	denatured aerosolized Climate Colada	0		Effect: "Hammered", Effect Duration: 61, Last Available: "2008-06"
 3366	electrified lime green digital underground potion	0		Effect: "Ruthlessly Efficient", Effect Duration: 51, Last Available: "2008-06"
@@ -3367,9 +3367,9 @@
 3395	huge maroon sizzling hale Hodgman's porkpie hat	0		Maximum HP: +20, Hot Damage: +10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	ghostly baleful Hodgman's lobsterskin pants of the dark arts	0		Spell Damage: +25, Spell Damage Percent: +100, Familiar Effect: "atk, 1xPotato"
 3397	beefcake's strapping Hodgman's bow tie	0		Muscle: 30, Single Equip
-3398	fancy bad Hodgman's blanket	4	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 35
+3398	bad fancy Hodgman's blanket	4	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 35
 3399	acceptable jar of squeeze	3	good	
-3400	big special bland spinning blue bowl of fishysoisse	5	decent	Effect: "Elemental Flavor", Effect Duration: 20
+3400	special bland big spinning blue bowl of fishysoisse	5	decent	Effect: "Elemental Flavor", Effect Duration: 20
 3401	alkaline corrupted enhanced huge wobbly deadly lampshade	0		Effect: "Ooh, Sweet!", Effect Duration: 33
 3402	pressed gray concentrated garbage juice	0		Effect: "Human-Orc Hybrid", Effect Duration: 40
 3403	lewd playing card	0		
@@ -3383,10 +3383,10 @@
 3411	upside-down weightlifter's Hodgman's cane	0		Muscle: +15
 3412	blurry Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
 3413	shaking Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
-3414	twirling spinning Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
+3414	spinning twirling Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	narrow box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	narrow box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	deionized sterno-flavored Hob-O	0		Effect: "Greased-Up Familiar", Effect Duration: 54
 3423	non-anodized frostbite-flavored Hob-O	0		Effect: "Loyal Tea", Effect Duration: 68
 3424	energized quantum upside-down squat fry-oil-flavored Hob-O	0		Effect: "Salsa Satanica", Effect Duration: 24
@@ -3404,7 +3404,7 @@
 3437	crafty sage Staff of the Black Kettle of horror	0		Mysticality Percent: +10, Maximum MP: +10, Spooky Spell Damage: +25
 3438	friendly chaotic Staff of the Well-Tempered Cauldron of the detective	0		Spell Critical Percent: +10, Familiar Weight: +3, Item Drop: +20
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	altered tumbling shaking prismatic wad	1	EPIC	Last Available: "2008-07"
+3440	altered shaking tumbling prismatic wad	1	EPIC	Last Available: "2008-07"
 3441	MacGyver's club of the five seasons	0		Maximum MP: +100, Last Available: "2008-07"
 3442	blinking reassuring rainbow crossbow	0		Spooky Resistance: +1, Last Available: "2008-07"
 3443	maroon kitten	0		
@@ -3422,7 +3422,7 @@
 3455	cotton candy bale	0		Last Available: "2008-08"
 3456	smartaleck's trusty torch	0		Moxie Percent: +30, Last Available: "2011-12"
 3457	grievous Junior Adventurer's merit badge	0		Weapon Damage Percent: +50
-3458	oxidized quadruple-alkaline blinking fuchsia STYX deodorant body spray	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 31
+3458	oxidized quadruple-alkaline fuchsia blinking STYX deodorant body spray	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 31
 3459	drinkable white-label gin	3	good	
 3460	adequate tin rations	4	good	
 3461	purple haiku challenge map	0		
@@ -3430,7 +3430,7 @@
 3463	lousy high-proof bottle of sake	10	decent	
 3464	round pebble	0		Item Drop: +5
 3465	stale huge Bash-&#332;s cereal	3	decent	Wiki Name: "Bash-Os cereal"
-3466	shaking fireproof sizzling stylish haiku katana	0		Moxie: +25, Hot Damage: +10, Hot Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	shaking fireproof sizzling stylish haiku katana	0		Moxie: +25, Hot Damage: +10, Hot Resistance: +3, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	shaking spinning fuchsia plastic baby of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2008-12"
 3469	normal tumbling blueberry-frosted king cake	3	good	Last Available: "2008-12"
@@ -3442,7 +3442,7 @@
 3475	quadruple-Vulcanized blurry blackberry polite	0		Effect: "Mental A-cue-ity", Effect Duration: 25
 3476	enhanced polymerized plum lozenge	0		Effect: "Night of the Nachos", Effect Duration: 63
 3477	triple-irradiated teal pear lozenge	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 67
-3478	double-dry activated lime green spinning narrow peach lozenge	0		Effect: "Ice Packed", Effect Duration: 57
+3478	double-dry activated spinning narrow lime green peach lozenge	0		Effect: "Ice Packed", Effect Duration: 57
 3479	balloon shield	0		Damage Reduction: 3
 3480	spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
@@ -3454,8 +3454,8 @@
 3487	rough fish scale	0		
 3488	wobbly pristine fish scale	0		
 3489	normal bite-sized beefy fish meat	1	good	Effect: "Fishy", Effect Duration: 5
-3490	snack-sized yummy glistening fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
-3491	gigantic bland slick fish meat	10	decent	Effect: "Fishy", Effect Duration: 5
+3490	yummy snack-sized glistening fish meat	2	awesome	Effect: "Fishy", Effect Duration: 5
+3491	bland gigantic slick fish meat	10	decent	Effect: "Fishy", Effect Duration: 5
 3492	hardened fish scimitar of extreme caution	0		Damage Reduction: 3, Monster Level: -25
 3493	shaking scorching Herculean fish stick	0		Experience (Muscle): +1, Hot Damage: +25
 3494	jittery boxer's fish bazooka of extreme caution	0		Muscle Percent: +10, Monster Level: -25
@@ -3467,7 +3467,7 @@
 3500	upside-down beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	delicious thick pulsating bouncing canap&eacute;s	5	awesome	
 3502	boiled narrow thermos of brew	1	awesome	Last Available: "2011-12"
-3503	enchanted artisanal glass of brandy	4	EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40, Last Available: "2011-12"
+3503	artisanal enchanted glass of brandy	4	EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40, Last Available: "2011-12"
 3504	huge French slippers	0		
 3505	LWA ring of courage	0		Spooky Resistance: +3
 3506	yellow LARP membership card	0		Last Available: "2008-10"
@@ -3520,7 +3520,7 @@
 3553	soggy seed packet	0		
 3554	glob of slime	0		
 3555	rotten skewed sea carrot	4	crappy	
-3556	adequate red mirror sea cucumber	4	good	
+3556	adequate mirror red sea cucumber	4	good	
 3557	snack-sized rotten yellow sea avocado	2	crappy	
 3558	decent tumbling sea lychee	3	good	
 3559	flavorless half-sized huge sea tangelo	2	decent	
@@ -3581,11 +3581,11 @@
 3615	upside-down olive rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	energized unstable DNA	0		Effect: "Spirit of Alph", Effect Duration: 18, Last Available: "2008-12"
-3618	bouncing The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	bouncing The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	ghostly wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	skewed pair of twitching claws	0		Last Available: "2008-12"
-3622	blurry skewed purple gnashing teeth	0		Last Available: "2008-12"
+3622	purple skewed blurry gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	parasitic claw of the sewer	0		Stench Damage: +25, Last Available: "2008-12"
 3625	MacGyver's parasitic tentacles	0		Maximum MP: +100, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
@@ -3602,21 +3602,21 @@
 3636	frightening patent shoes of doom	0		Spooky Damage: +5, Spooky Spell Damage: +50, Last Available: "2008-12"
 3637	experienced gray bow tie of wisdom	0		Mysticality: +15, Experience: +2, Last Available: "2008-12"
 3638	upside-down grievous penguin thesaurus of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Last Available: "2008-12"
-3639	normal special tiny twirling blob-shaped Crimbo cookie	1	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	special normal tiny twirling blob-shaped Crimbo cookie	1	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	jittery pufferfish spine	0		
 3644	chaotic depleted Grimacite kneecapping stick	0		Spell Critical Percent: +10, Last Available: "2007-06"
 3645	hand-crafted canteen of wine	3	EPIC	Last Available: "2008-12"
-3646	thick delicious elven <i>limbos</i> gingerbread	5	awesome	Last Available: "2008-12"
+3646	delicious thick elven <i>limbos</i> gingerbread	5	awesome	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
-3649	squat narrow skewed map to Madness Reef	0		
+3649	narrow skewed squat map to Madness Reef	0		
 3650	big rotten toast with jam	5	crappy	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	delicious practically non-alcoholic elven moonshine	1	awesome	Last Available: "2008-12"
-3653	decent immense knuckle sandwich	6	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	immense decent knuckle sandwich	6	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	lime green asbestos-lined psycho sweater of extreme caution	0		Monster Level: -25, Hot Resistance: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	Sherlock's plastic Mob Penguin	0		Item Drop: +25, Last Available: "2008-12"
@@ -3635,28 +3635,28 @@
 3669	Temple Grandin's glow-in-the-dark dart gun	0		Familiar Weight: +7, Last Available: "2009-01"
 3670	blinking blinking narrow glow-in-the-dark burrowgrub of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	rotten twirling teal can of franks 'n' beans	4	crappy	Last Available: "2010-12"
-3673	enchanted strong artisanal bottle of peppermint schnapps	5	EPIC	Effect: "French Bronilla Brogueishness", Effect Duration: 15, Last Available: "2010-12"
+3672	rotten teal twirling can of franks 'n' beans	4	crappy	Last Available: "2010-12"
+3673	artisanal enchanted strong bottle of peppermint schnapps	5	EPIC	Effect: "French Bronilla Brogueishness", Effect Duration: 15, Last Available: "2010-12"
 3674	twirling throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	red Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	wobbly fuchsia quilted diving muff	0		Damage Absorption: +40, Single Equip
 3678	smooth salinated mint julep	4	awesome	
 3679	upside-down ink bladder	0		
-3680	mirror blinking esca	0		
+3680	blinking mirror esca	0		
 3681	bubbling tempura batter	0		
 3682	pulsating globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
 3684	adequate tempura carrot	4	good	
 3685	thick adequate blinking tempura cucumber	5	good	
-3686	diet bland tempura avocado	1	decent	
+3686	bland diet tempura avocado	1	decent	
 3687	stale sea broccoli	3	decent	
 3688	tasty sea cauliflower	3	awesome	
 3689	special toothsome tempura broccoli	3	awesome	Effect: "Grape Expectations", Effect Duration: 5
 3690	normal super-sized tempura cauliflower	5	good	
 3691	flavorless sea blueberry	4	decent	
 3692	stale upside-down sea persimmon	3	decent	
-3693	oxidized red tumbling pressurized potion of perception	0		Effect: "Joy", Effect Duration: 15
+3693	oxidized tumbling red pressurized potion of perception	0		Effect: "Joy", Effect Duration: 15
 3694	moist ionized pressurized potion of proficiency	0		Effect: "Cock of the Walk", Effect Duration: 26
 3695	lime green Usain Bolt's Mer-kin digpick	0		Initiative: +80
 3696	anemone nematocyst	0		
@@ -3711,7 +3711,7 @@
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
-3749	ionized wet altered pulsating mirror concoction of clumsiness	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 16
+3749	ionized wet altered mirror pulsating concoction of clumsiness	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 16
 3750	greasy vampire pearl earring	0		Sleaze Spell Damage: +10, Single Equip
 3751	stale chocolate chip brownies	4	decent	
 3753	upside-down Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
@@ -3720,18 +3720,18 @@
 3756	wet huge love song of icy revenge	0		Effect: "Booooooze", Effect Duration: 14, Last Available: "2009-02"
 3757	triple-warmed altered love song of sugary cuteness	0		Effect: "Fastbreaker", Effect Duration: 28, Last Available: "2009-02"
 3758	corrupted love song of disturbing obsession	0		Effect: "A View to Some Meat", Effect Duration: 41, Last Available: "2009-02"
-3759	oxidized adjusted mirror bouncing love song of naughty innuendo	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 12, Last Available: "2009-02"
+3759	oxidized adjusted bouncing mirror love song of naughty innuendo	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 12, Last Available: "2009-02"
 3760	liquefied ionized breath mint	0		Effect: "A Contender", Effect Duration: 23
 3761	jittery dance instructor's vampire pearl ring	0		Experience Percent (Moxie): +10, Single Equip
 3762	vampire pearl necklace of the bloodbag	0		Maximum HP: +100, Single Equip
-3763	mediocre irresponsibly strong narrow slug of vodka	9	decent	
+3763	irresponsibly strong mediocre narrow slug of vodka	9	decent	
 3764	artisanal slug of rum	4	EPIC	
-3765	mediocre yellow blurry bouncing slug of shochu	3	decent	
+3765	mediocre blurry bouncing yellow slug of shochu	3	decent	
 3766	tolerable narrow screwdiver	4	good	
 3767	artisanal dew yoana lei	3	EPIC	
-3768	mediocre weak lychee chuhai	2	decent	
-3769	weak fancy artisanal blurry salacious screwdiver	2	EPIC	Effect: "Sludgesick", Effect Duration: 5
-3770	lousy watered-down dew yoana salacious lei	2	decent	
+3768	weak mediocre lychee chuhai	2	decent	
+3769	fancy artisanal weak blurry salacious screwdiver	2	EPIC	Effect: "Sludgesick", Effect Duration: 5
+3770	watered-down lousy dew yoana salacious lei	2	decent	
 3771	artisanal salacious lychee chuhai	4	EPIC	
 3772	drinkable blurry Alewife&trade; Ale	4	good	
 3773	blinking seaode	0		
@@ -3761,14 +3761,14 @@
 3806	Mer-kin prayerbeads	0		
 3807	dry energized Mer-kin hidepaint	0		Effect: "Hombre Muerto Caminando", Effect Duration: 38
 3808	wobbly Mer-kin trailmap	0		
-3809	blinking tumbling Mer-kin healscroll	0		
+3809	tumbling blinking Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	fuchsia Mer-kin stashbox	0		
 3812	normal chocolate-frosted king cake	3	good	Last Available: "2009-06"
 3813	spinning plastic baby of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	spinning half-height unicycle	0		Familiar Weight: +5
-3817	massive moldy bouncing sea radish	8	crappy	
+3817	moldy massive bouncing sea radish	8	crappy	
 3818	ghostly greedy halibut of Gandalf of the detective	0		Spell Critical Percent: +20, Item Drop: +20, Meat Drop: +20
 3819	eel sauce	0		
 3820	greasy water-polo mitt	0		Sleaze Spell Damage: +10, Single Equip
@@ -3784,10 +3784,10 @@
 3830	weightlifter's water-polo cap	0		Muscle: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	bad maroon Typical Tavern swill	3	decent	
 3832	smooth tropical swill	3	awesome	
-3833	high-proof fancy acceptable tumbling fruity girl swill	9	good	Effect: "Spooky Weapon", Effect Duration: 25
+3833	acceptable fancy high-proof tumbling fruity girl swill	9	good	Effect: "Spooky Weapon", Effect Duration: 25
 3834	smooth narrow shaking blended swill	3	awesome	
 3835	costume wardrobe	0		Softcore Only
-3836	huge yellow resourceful banded Elvish sunglasses of bravery	0		Damage Absorption: +100, Maximum MP: +50, Spooky Resistance: +5, Item Drop: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	huge yellow resourceful banded Elvish sunglasses of bravery	0		Damage Absorption: +100, Maximum MP: +50, Spooky Resistance: +5, Item Drop: +5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	strapping anniversary safety glass vest	0		Muscle: +5
 3838	anniversary burlap belt of the cougar	0		Moxie: +20
 3839	strapping anniversary balsa wood socks	0		Muscle: +5
@@ -3858,11 +3858,11 @@
 3906	purple figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
-3909	cyan blurry figurine of a charred seal	0		Class: "Seal Clubber"
-3910	cyan upside-down figurine of a seal	0		Class: "Seal Clubber"
+3909	blurry cyan figurine of a charred seal	0		Class: "Seal Clubber"
+3910	upside-down cyan figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	skewed imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	bad triple-distilled blended swill with a fly in it	7	decent	
+3913	triple-distilled bad blended swill with a fly in it	7	decent	
 3914	red turtle wax	0		
 3915	Jack Frost's turtle wax shield	0		Cold Spell Damage: +50, Damage Reduction: 2
 3916	turtle wax helmet of wisdom	0		Mysticality: +15, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -4032,7 +4032,7 @@
 4080	fireproof grisly shield of courage	0		Hot Resistance: +3, Spooky Resistance: +3, Slime Hates It: +1, Damage Reduction: 13
 4081	blurry flame-retardant occult corroded breeches	0		Spell Damage Percent: +25, Hot Resistance: +1, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	spinning wool stylish pernicious cudgel	0		Moxie: +25, Cold Resistance: +1, Slime Hates It: +1
-4083	jumbo special stale cupcake-in-a-cup	5	decent	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2009-06"
+4083	special jumbo stale cupcake-in-a-cup	5	decent	Effect: "Chorale of Companionship", Effect Duration: 5, Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	moldy half-sized lime green protein paste	2	crappy	Last Available: "2009-06"
 4086	Samson's cyber-mattock of the brazier	0		Experience (Muscle): +5, Hot Spell Damage: +25, Last Available: "2009-06"
@@ -4064,7 +4064,7 @@
 4112	mirror cyan reassuring horrifying bitter bowtie	0		Spooky Damage: +25, Spooky Resistance: +1, Last Available: "2009-06"
 4113	blurry baleful bewitching boots	0		Spell Damage: +25, Last Available: "2009-06"
 4114	pulsating secret from the future	0		Last Available: "2009-06"
-4115	skewed wobbly moist sack	0		
+4115	wobbly skewed moist sack	0		
 4116	rickety unicycle of vim and vigor of bravery of the boozehound	0		Maximum HP Percent: +50, Spooky Resistance: +5, Booze Drop: +100, Single Equip
 4117	inspector's knitted arcane researcher's crusty hula hoop	0		Experience Percent (Mysticality): +10, Cold Resistance: +3, Item Drop: +15, Single Equip
 4118	curative wholesome hardened Coily&trade;	0		Damage Reduction: 3, Maximum HP Percent: +10, HP Regen Min: 3, HP Regen Max: 5
@@ -4083,9 +4083,9 @@
 4131	pickled upside-down boot plant	1	decent	Effect: "Carol of the Bones", Effect Duration: 15, Last Available: "2009-06"
 4132	artisanal maroon sham champagne	3	EPIC	Last Available: "2009-06"
 4133	magnetized tumbling tempura air	0		Effect: "Crimbo Epiphany", Effect Duration: 11
-4134	flattened adjusted narrow green blurry pressurized potion of pneumaticity	0		Effect: "Elemental Saucesphere", Effect Duration: 12
+4134	flattened adjusted green narrow blurry pressurized potion of pneumaticity	0		Effect: "Elemental Saucesphere", Effect Duration: 12
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	clever Da Vinci's weightlifter's Bag o' Tricks of the boozehound	0		Muscle: +15, Experience (Mysticality): +5, Maximum MP: +20, Booze Drop: +100, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	clever Da Vinci's weightlifter's Bag o' Tricks of the boozehound	0		Muscle: +15, Experience (Mysticality): +5, Maximum MP: +20, Booze Drop: +100, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	ghostly pulsating slime stack	0		
 4138	wobbly a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4110,10 +4110,10 @@
 4158	rock	0		Last Available: "2009-09"
 4159	squat rock lobster	0		Last Available: "2009-09"
 4160	tolerable pulsating pebblebr&auml;u	4	good	Last Available: "2009-09"
-4161	half-sized spoiled rocky road ice cream	2	crappy	Last Available: "2009-09"
+4161	spoiled half-sized rocky road ice cream	2	crappy	Last Available: "2009-09"
 4162	spinning extra-strength rubber bands	0		Familiar Weight: +5
 4163	chilled irradiated polarized purple children of the candy corn	0		Effect: "Perception", Effect Duration: 53
-4164	quadruple-warmed lime green bouncing Good 'n' Slimy	0		Effect: "The Magic of LOV", Effect Duration: 31
+4164	quadruple-warmed bouncing lime green Good 'n' Slimy	0		Effect: "The Magic of LOV", Effect Duration: 31
 4165	red Sherlock's coward's Staff of the Soupbone of the dark arts	0		Spell Damage Percent: +100, Monster Level: -20, Item Drop: +25
 4166	bouncing Voluminous Radio Pants of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "2xGhoul, cap 37"
 4167	cyan Voluminous Radio Hat of Flo-Jo	0		Initiative: +100, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4138,7 +4138,7 @@
 4186	slime convention coupons	0		
 4187	slime convention pin of the businessman	0		Meat Drop: +50
 4188	slime convention t-shirt	0		
-4189	maroon jittery inverse geode	0		
+4189	jittery maroon inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	lime green sugar shirt of doom	0		Spooky Spell Damage: +50, Last Available: "2009-09"
 4192	sugar shard	0		Last Available: "2009-09"
@@ -4157,7 +4157,7 @@
 4205	Mer-kin wordquiz	0		
 4206	flame-retardant veiny brand new key	0		Maximum HP: +10, Hot Resistance: +1
 4207	shaking banded dorsal fin	0		Damage Absorption: +100, Damage Reduction: 13
-4208	twirling shaking twirling skate skates	0		
+4208	shaking twirling twirling skate skates	0		
 4209	purple skate skin	0		
 4210	roller skate decoy	0		
 4211	mermaid's purse	0		
@@ -4187,7 +4187,7 @@
 4235	narrow salt-shaker	0		
 4236	spinning can of sterno	0		
 4237	Rosewater's cheese-slicer	0		Mysticality Percent: +30
-4238	stale teal narrow beef jerky	4	decent	
+4238	stale narrow teal beef jerky	4	decent	
 4239	pipe wrench of the cougar	0		Moxie: +20
 4240	adjusted galvanized gun cleaning kit	0		Effect: "Clean-Shaven", Effect Duration: 54
 4241	chaotic sleep mask	0		Spell Critical Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4207,8 +4207,8 @@
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	non-warmed blinking sap	0		Effect: "Neuromancy", Effect Duration: 18, Last Available: "2009-10"
 4257	blurry petrified wood	0		Last Available: "2009-10"
-4258	rotten diet blurry chocolate-covered scarab beetle	1	crappy	Last Available: "2009-10"
-4259	weak acceptable yellow mulled cider	2	good	Last Available: "2009-10"
+4258	diet rotten blurry chocolate-covered scarab beetle	1	crappy	Last Available: "2009-10"
+4259	acceptable weak yellow mulled cider	2	good	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	mirror mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4249,15 +4249,15 @@
 4297	wobbly frosty clever slick Ass-Stompers of Violence	0		Moxie: +10, Maximum MP: +20, Cold Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	red Usain Bolt's strapping Brand of Violence of temperance	0		Muscle: +5, Sleaze Resistance: +5, Initiative: +80, Conditional Skill (Equipped): "Brand"
 4299	mirror medical-grade Novelty Belt Buckle of Violence of the cougar of the sweet-tooth	0		Moxie: +20, Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-4300	frightening hardy healthy Lens of Violence	0		Maximum HP Percent: +20, Maximum HP: +50, Spooky Damage: +5, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	frightening hardy healthy Lens of Violence	0		Maximum HP Percent: +20, Maximum HP: +50, Spooky Damage: +5, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	energetic Da Vinci's Pigsticker of Violence	0		Experience (Mysticality): +5, Maximum MP Percent: +20, Item Drop: +5
-4302	Van der Graaf resourceful Fonzie's Jodhpurs of Violence	0		Experience (Moxie): +1, Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	Van der Graaf resourceful Fonzie's Jodhpurs of Violence	0		Experience (Moxie): +1, Maximum MP: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	frosty chilly beefcake's Cold Stone of Hatred	0		Muscle: +25, Cold Damage: +5, Cold Spell Damage: +10, Conditional Skill (Equipped): "Chilling Grip"
 4304	spinning prompt aromatic careful Girdle of Hatred	0		Monster Level: -10, Stench Resistance: +1, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	gray up-at-dawn lard-coated wholesome Staff of Simmering Hatred	0		Maximum HP Percent: +10, Sleaze Spell Damage: +25, Adventures: +5
-4306	chilly razor-sharp Pantaloons of Hatred of temperance	0		Weapon Damage Percent: +25, Cold Damage: +5, Sleaze Resistance: +5, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	chilly razor-sharp Pantaloons of Hatred of temperance	0		Weapon Damage Percent: +25, Cold Damage: +5, Sleaze Resistance: +5, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	jittery lard-coated dog trainer's coward's Fuzzy Slippers of Hatred	0		Monster Level: -20, Experience (familiar): +1, Sleaze Spell Damage: +25, Single Equip
-4308	nippy healthy Lens of Hatred of the sweet-tooth	0		Maximum HP Percent: +20, Cold Damage: +10, Candy Drop: +100, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	nippy healthy Lens of Hatred of the sweet-tooth	0		Maximum HP Percent: +20, Cold Damage: +10, Candy Drop: +100, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	twirling smartaleck's Rosewater's Treads of Loathing of the overflowing toilet	0		Mysticality Percent: +30, Moxie Percent: +30, Stench Spell Damage: +50, Single Equip
 4310	squat chilly Tesla Scepter of Loathing of Leguizamo	0		Monster Level: +20, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10
 4311	miser's Da Vinci's Belt of Loathing of extreme caution	0		Experience (Mysticality): +5, Monster Level: -25, Meat Drop: +10, Single Equip
@@ -4289,7 +4289,7 @@
 4337	asbestos-lined plastic stocking mimic	0		Hot Resistance: +5, Last Available: "2009-12"
 4338	jittery Rosewater's plastic Don Crimbo	0		Mysticality Percent: +30, Last Available: "2009-12"
 4339	hardened plastic Crimbomination	0		Damage Reduction: 3, Last Available: "2009-12"
-4340	triple-frozen pressed tumbling ghostly Piddles	0		Effect: "Angry Bone", Effect Duration: 33, Last Available: "2009-12"
+4340	triple-frozen pressed ghostly tumbling Piddles	0		Effect: "Angry Bone", Effect Duration: 33, Last Available: "2009-12"
 4341	altered blurry BitterSweetTarts	0		Effect: "Mystic Circle", Effect Duration: 53, Last Available: "2009-12"
 4342	frozen dry triple-dry Polka Pop	0		Effect: "Items Are Forever", Effect Duration: 38, Last Available: "2009-12"
 4343	spinning Crimbuck	0		Last Available: "2009-12"
@@ -4310,7 +4310,7 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	narrow huge A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	decent expired can of franks 'n' beans	3	good	Last Available: "2009-12"
-4361	perfectly mixed spirit-forward twirling expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
+4361	spirit-forward perfectly mixed twirling expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	pressed activated spinning elven suicide capsule	0		Effect: "Clean-Shaven", Effect Duration: 55, Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	blue spinning passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	squat chaotic peanut brittle shield	0		Spell Critical Percent: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	stylish Red Rover BB gun of the bloodbag	0		Moxie: +25, Maximum HP: +100, Last Available: "2009-12"
-4391	red-and-green sweater of incineration	0		Hot Spell Damage: +50, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	red-and-green sweater of incineration	0		Hot Spell Damage: +50, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	ionized electrified twirling Crimbo peppermint bark	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 34, Last Available: "2009-12"
 4394	frozen quadruple-deionized Crimbo fudge	0		Effect: "Go-Gone", Effect Duration: 34, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	shaking squat flame-wreathed cheese sword	0		Hot Spell Damage: +10, Softcore Only, Last Available: "2010-01"
 4400	up-at-dawn cheese diaper	0		Adventures: +5, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	cheese wheel	0		Item Drop: +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	blinking cheese eye of horror	0		Spooky Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	blinking cheese eye of horror	0		Spooky Spell Damage: +25, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	blurry fuchsia resourceful hale stiffened Staff of Queso Escusado	0		Damage Reduction: 1, Maximum HP: +20, Maximum MP: +50, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4360,7 +4360,7 @@
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	narrow Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	tasty half-sized mirror quantum taco	0		Last Available: "2010-10"
+4412	half-sized tasty mirror quantum taco	0		Last Available: "2010-10"
 4413	mediocre Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	sealhide hood of the early riser	0		Adventures: +7, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4410,7 +4410,7 @@
 4462	polymerized oxidized jittery chocolate seal-clubbing club	0		Effect: "Go-Gone", Effect Duration: 13
 4463	extra-enhanced chocolate turtle totem	0		Effect: "Cringle's Curative Carol", Effect Duration: 30
 4464	ionized chilled cold-filtered chocolate pasta spoon	0		Effect: "In Vino Vires", Effect Duration: 28
-4465	dry squat narrow chocolate saucepan	0		Effect: "Winklered", Effect Duration: 59
+4465	dry narrow squat chocolate saucepan	0		Effect: "Winklered", Effect Duration: 59
 4466	double-modified huge blurry chocolate disco ball	0		Effect: "Abominably Slippery", Effect Duration: 30
 4467	tarnished wet huge chocolate stolen accordion	0		Effect: "Initiative and Let Die", Effect Duration: 55
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
@@ -4424,7 +4424,7 @@
 4476	bouncing BRICKO oyster	0		Last Available: "2010-02"
 4477	jittery BRICKO turtle	0		Last Available: "2010-02"
 4478	blinking BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	huge BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	yellow BRICKO airship	0		Last Available: "2010-02"
@@ -4444,7 +4444,7 @@
 4496	ghostly extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	anodized activated huge recording of The Ballad of Richie Thingfinder	0		Effect: "Appeteyes", Effect Duration: 23
 4498	alkaline super-chilled recording of Benetton's Medley of Diversity	0		Effect: "Your Eyes are Peeled!", Effect Duration: 14
-4499	nitrogenated tumbling purple squat recording of Elron's Explosive Etude	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 21
+4499	nitrogenated squat purple tumbling recording of Elron's Explosive Etude	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 21
 4500	improved shaking recording of Chorale of Companionship	0		Effect: "Stick Emporium Membership", Effect Duration: 33
 4501	irradiated ionized recording of Prelude of Precision	0		Effect: "Stimulated Brain", Effect Duration: 22
 4502	oxidized recording of Donho's Bubbly Ballad	0		Effect: "Sewer-Drenched", Effect Duration: 22
@@ -4460,9 +4460,9 @@
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	upside-down Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	normal tumbling Humpty Dumplings	3	good	Last Available: "2010-03"
-4515	jumbo moldy enchanted Lobster <i>qua</i> Grill	5	crappy	Effect: "Quaaaaaaa", Effect Duration: 50, Last Available: "2010-03"
-4516	weak artisanal missing wine	2	EPIC	Last Available: "2010-03"
-4517	fancy bland jittery matter custard	3	decent	Effect: "Enraged", Effect Duration: 25, Last Available: "2010-03"
+4515	enchanted jumbo moldy Lobster <i>qua</i> Grill	5	crappy	Effect: "Quaaaaaaa", Effect Duration: 50, Last Available: "2010-03"
+4516	artisanal weak missing wine	2	EPIC	Last Available: "2010-03"
+4517	bland fancy jittery matter custard	3	decent	Effect: "Enraged", Effect Duration: 25, Last Available: "2010-03"
 4518	corrupted dry comfit?	0		Effect: "Down With Chow", Effect Duration: 30, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	Sinatra's brainy flamingo mallet	0		Mysticality: +5, Experience (Moxie): +5, Last Available: "2010-03"
@@ -4471,16 +4471,16 @@
 4523	nippy quilted eye of the Tiger-lily	0		Damage Absorption: +40, Cold Damage: +10, Last Available: "2010-03"
 4524	olive shaking prompt extremely unsafe wig	0		Weapon Damage Percent: +100, Adventures: +3, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	stale donut	3	decent	Last Available: "2010-03"
-4526	snack-sized moldy bucket of honey	2	crappy	Last Available: "2010-03"
+4526	moldy snack-sized bucket of honey	2	crappy	Last Available: "2010-03"
 4527	family-friendly lion tamer's elephant stinger	0		Experience (familiar): +2, Sleaze Resistance: +1, Last Available: "2010-03"
 4528	decent huge dragon snaps	8	good	Last Available: "2010-03"
 4529	spinning up-at-dawn curative snapdragon pistil	0		Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	low-calorie flavorless rook cookie	1	decent	Last Available: "2010-03"
 4532	tasty narrow bishop cookie	4	awesome	Last Available: "2010-03"
-4533	half-sized fancy adequate gray knight cookie	2	good	Effect: "Pharmaceutically Cool", Effect Duration: 30, Last Available: "2010-03"
-4534	adequate half-sized king cookie	2	good	Last Available: "2010-03"
-4535	decent jumbo queen cookie	5	good	Effect: "Towering Strength", Last Available: "2010-03"
+4533	fancy half-sized adequate gray knight cookie	2	good	Effect: "Pharmaceutically Cool", Effect Duration: 30, Last Available: "2010-03"
+4534	half-sized adequate king cookie	2	good	Last Available: "2010-03"
+4535	jumbo decent queen cookie	5	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	fireproof insane tophat	0		Hot Resistance: +3, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 4538	occult helm of the knight of Flo-Jo	0		Spell Damage Percent: +25, Initiative: +100, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
@@ -4492,7 +4492,7 @@
 4544	narrow porpoise	0		Last Available: "2010-03"
 4545	narrow pocketwatch	0		Last Available: "2010-03"
 4546	yellow bandersnatch	0		Last Available: "2010-03"
-4547	shaking twirling caterpillar	0		Last Available: "2010-03"
+4547	twirling shaking caterpillar	0		Last Available: "2010-03"
 4548	green walrus	0		Last Available: "2010-03"
 4549	squat carpenter	0		Last Available: "2010-03"
 4550	dodo	0		Last Available: "2010-03"
@@ -4508,25 +4508,25 @@
 4560	upside-down map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	aged fancy shaking world's most unappetizing beverage	3	awesome	Effect: "Super Speed", Effect Duration: 50, Last Available: "2010-04"
+4563	fancy aged shaking world's most unappetizing beverage	3	awesome	Effect: "Super Speed", Effect Duration: 50, Last Available: "2010-04"
 4564	Oprah's slippery when wet shield	0		Maximum MP Percent: +50, Damage Reduction: 6, Last Available: "2010-04"
-4565	massive delicious raisin	6	awesome	Last Available: "2010-04"
+4565	delicious massive raisin	6	awesome	Last Available: "2010-04"
 4566	blue fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	jittery reassuring dangerous flyest of shirts	0		Weapon Damage: +10, Spooky Resistance: +1, Last Available: "2010-04"
 4568	normal a dance upon the palate	3	good	Last Available: "2010-04"
 4569	tasty prehistoric meteorite jawbreaker	4	awesome	Last Available: "2010-04"
 4570	blinking Crazyleg's razor	0		Last Available: "2010-04"
-4571	huge normal squirmy violent party snack	8	good	Last Available: "2010-04"
+4571	normal huge squirmy violent party snack	8	good	Last Available: "2010-04"
 4572	tumbling cool can-you-dig-it?	0		Moxie: +5, Last Available: "2010-04"
 4573	wobbly The Legendary Beat	0		Last Available: "2010-04"
 4574	yellow panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4578	jittery blinking meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
+4578	blinking jittery meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	electrified magnetized denatured Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Mint-Condition Breath", Effect Duration: 33, Last Available: "2010-04"
 4580	smartaleck's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Moxie Percent: +30, Last Available: "2010-04"
-4581	mirror careful occult T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Spell Damage Percent: +25, Monster Level: -10, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	mirror careful occult T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Spell Damage Percent: +25, Monster Level: -10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	cyan fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	moldy six wedges of goat cheese	3	crappy	
@@ -4545,12 +4545,12 @@
 4597	twirling 8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
-4600	blurry yellow skewed map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	perfectly mixed mirror red plastic cup of beer	3	EPIC	Last Available: "2010-06"
+4600	skewed blurry yellow map to the Kegger in the Woods	0		Last Available: "2010-06"
+4601	perfectly mixed red mirror plastic cup of beer	3	EPIC	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	tumbling bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	censurious brainy bottle of Goldschn&ouml;ckered	0		Mysticality: +5, Sleaze Resistance: +3, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	censurious brainy bottle of Goldschn&ouml;ckered	0		Mysticality: +5, Sleaze Resistance: +3, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	bland bouncing sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	enchanted drinkable soyburger juice	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4560,21 +4560,21 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	double-paned Crown of Thrones	0		Cold Resistance: +5, Softcore Only, Last Available: "2010-05"
-4615	artisanal enchanted Cinco Mayo Lager	3	EPIC	Effect: "One For Tea", Effect Duration: 30, Last Available: "2010-05"
+4615	enchanted artisanal Cinco Mayo Lager	3	EPIC	Effect: "One For Tea", Effect Duration: 30, Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
-4617	upside-down maroon pruning shears	0		Familiar Weight: +5
+4617	maroon upside-down pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
 4620	twirling motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	blinking Game Grid ticket	0		Last Available: "2010-06"
-4623	magnetized aerosolized pulsating blurry chocolate-covered caviar	0		Effect: "Rotten Memories", Effect Duration: 55, Last Available: "2020-09"
+4623	magnetized aerosolized blurry pulsating chocolate-covered caviar	0		Effect: "Rotten Memories", Effect Duration: 55, Last Available: "2020-09"
 4624	tiny normal bouncing red pawn cookie	1	good	Last Available: "2010-06"
 4625	powdered coffee pixie stick	1	good	Effect: "Berry Elemental", Effect Duration: 25, Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	wizardly plastic spider ring	0		Mysticality: +25, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	wizardly plastic spider ring	0		Mysticality: +25, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	blurry coward's plastic kazoo	0		Monster Level: -20, Last Available: "2010-06"
 4631	family-friendly inflatable baseball bat	0		Sleaze Resistance: +1, Last Available: "2010-06"
 4632	spinning googly-star hat of Gandalf of bravery	0		Spell Critical Percent: +20, Spooky Resistance: +5, Last Available: "2010-06", Familiar Effect: "atk"
@@ -4596,7 +4596,7 @@
 4648	shaking Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
 4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
 4650	tumbling fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
-4651	ghostly tumbling ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
+4651	tumbling ghostly ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	upside-down up-at-dawn rock-hard ironic knit cap	0		Damage Reduction: 5, Adventures: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	huge ironic sunglasses	0		Single Equip
 4654	tumbling wholesome ironic battle spoon	0		Maximum HP Percent: +10
@@ -4619,8 +4619,8 @@
 4671	lousy blinking booze-soaked cherry	3	decent	
 4672	shaking comfy pillow	0		
 4673	flavorless marshmallow	3	decent	
-4674	adequate jumbo special sponge cake	5	good	Effect: "Destructive Resolve", Effect Duration: 10
-4675	acceptable practically non-alcoholic gin-soaked blotter paper	1	good	
+4674	special adequate jumbo sponge cake	5	good	Effect: "Destructive Resolve", Effect Duration: 10
+4675	practically non-alcoholic acceptable gin-soaked blotter paper	1	good	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
@@ -4631,7 +4631,7 @@
 4683	twirling up-at-dawn pottery training pants of the empath	0		Familiar Weight: +5, Adventures: +5, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	shaking nasty pottery club	0		Stench Damage: +5, Last Available: "2010-09"
 4685	blinking up-at-dawn pottery yo-yo	0		Adventures: +5, Last Available: "2010-09"
-4686	maroon mirror pottery barn owl figurine	0		Last Available: "2010-09"
+4686	mirror maroon pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
 4688	fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
@@ -4660,7 +4660,7 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	tasty spinning lemon popsicle	4	awesome	
-4715	jumbo spoiled popsicle	5	crappy	
+4715	spoiled jumbo popsicle	5	crappy	
 4716	bland diet upside-down strawberry popsicle	1	decent	
 4717	bite-sized spoiled liver popsicle	1	crappy	
 4718	spinning mariachi hat of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "atk, cap 2"
@@ -4668,7 +4668,7 @@
 4720	upside-down organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	decent tiny liver and let pie	1	good	Last Available: "2010-10"
-4723	adequate thick blurry badass pie	5	good	Last Available: "2010-10"
+4723	thick adequate blurry badass pie	5	good	Last Available: "2010-10"
 4724	normal shoo-fish pie	4	good	Last Available: "2010-10"
 4725	normal piping organ pie	4	good	Last Available: "2010-10"
 4726	bland igloo pie	3	decent	Last Available: "2010-10"
@@ -4690,9 +4690,9 @@
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	jittery bone chips	0		Last Available: "2011-12"
 4744	adjusted chilled PlexiPips	0		Effect: "meat.enh", Effect Duration: 54
-4745	double-tarnished wet twirling huge Wax Flask	0		Effect: "Smoking like a Bandit", Effect Duration: 26
+4745	double-tarnished wet huge twirling Wax Flask	0		Effect: "Smoking like a Bandit", Effect Duration: 26
 4746	warmed narrow Pain Dip	0		Effect: "Frozen Shoulders", Effect Duration: 28
-4747	tasty half-sized bone meal	2	awesome	Last Available: "2010-10"
+4747	half-sized tasty bone meal	2	awesome	Last Available: "2010-10"
 4748	hand-crafted squat tumbling bone aperitif	4	EPIC	Last Available: "2010-10"
 4749	lime green foul-smelling bonerang	0		Stench Damage: +10, Last Available: "2010-10"
 4750	twirling squat bone and arrows of James Dean	0		Experience (Moxie): +3, Last Available: "2010-10"
@@ -4710,7 +4710,7 @@
 4762	blue huge pumpkin	0		Last Available: "2010-11"
 4763	moldy pumpkin pie	3	crappy	Last Available: "2010-11"
 4764	tolerable pumpkin beer	4	good	Last Available: "2010-11"
-4765	polymerized blurry upside-down pumpkin juice	0		Effect: "Chow Downed", Effect Duration: 38, Last Available: "2010-11"
+4765	polymerized upside-down blurry pumpkin juice	0		Effect: "Chow Downed", Effect Duration: 38, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	Jim Carey's cool shin gourds	0		Moxie: +5, Monster Level: +25, Single Equip, Last Available: "2010-11"
 4768	fuchsia Temple Grandin's resourceful Socratic Staff of the November Jack-O-Lantern	0		Experience (Mysticality): +1, Maximum MP: +50, Familiar Weight: +7, Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	huge Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	mirror Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	toothsome super-sized pulsating CRIMBCOIDS mints	5	awesome	Last Available: "2011-01"
+4818	super-sized toothsome pulsating CRIMBCOIDS mints	5	awesome	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	bland CRIMBCOLOAF	3	decent	Last Available: "2011-01"
 4821	decent circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,8 +4745,8 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	jittery robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	upside-down robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	decent gigantic shaking upside-down triangular CRIMBCOOKIE	10	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	moldy massive square CRIMBCOOKIE	6	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4839	gigantic decent shaking upside-down triangular CRIMBCOOKIE	10	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4840	massive moldy square CRIMBCOOKIE	6	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	wobbly red inspector's groovy bindlestocking of the businessman	0		Moxie Percent: +10, Item Drop: +15, Meat Drop: +50, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4773,7 +4773,7 @@
 4864	jittery jittery photocopier	0		Last Available: "2011-01"
 4865	lime green deluxe fax machine	0		Last Available: "2011-01"
 4866	pulsating Workytime Tea	0		Last Available: "2011-01"
-4867	yellow narrow paperclip sproinger	0		Last Available: "2011-01"
+4867	narrow yellow paperclip sproinger	0		Last Available: "2011-01"
 4868	spinning Sherlock's nippy supercool paperclip-on tie	0		Moxie Percent: +20, Cold Damage: +10, Item Drop: +25, Single Equip, Last Available: "2011-01"
 4869	horrifying Jack Frost's paperclip pants	0		Cold Spell Damage: +50, Spooky Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
 4870	careful banded paperclip turban of doom	0		Damage Absorption: +100, Monster Level: -10, Spooky Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
@@ -4784,13 +4784,13 @@
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	electrified chocolate bath ball	0		Effect: "Quantum of Moxie", Effect Duration: 46, Last Available: "2011-01"
 4877	quadruple-unsweetened deionized vacuum-sealed bacon bath ball	0		Effect: "Slimy Hands", Effect Duration: 19, Last Available: "2011-01"
-4878	concentrated bouncing spinning incense bath ball	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 62, Last Available: "2011-01"
+4878	concentrated spinning bouncing incense bath ball	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 62, Last Available: "2011-01"
 4879	moist myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Oriental Mysticism", Effect Duration: 35, Last Available: "2011-01"
 4880	pulsating CRIMBCO mug	0		Last Available: "2011-01"
 4881	bad CRIMBCO wine	3	decent	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	huge moldy toe jam toast	10	crappy	Last Available: "2011-01"
+4884	moldy huge toe jam toast	10	crappy	Last Available: "2011-01"
 4885	wobbly traffic jam	0		Last Available: "2011-01"
 4886	bland bouncing traffic jam toast	4	decent	Last Available: "2011-01"
 4887	ghostly space jam	0		Last Available: "2011-01"
@@ -4855,7 +4855,7 @@
 4952	aerosolized purple baggie of sugar	0		Effect: "Haunted Stomach", Effect Duration: 24
 4953	narrow supercharged veiny whalebone corset	0		Maximum HP: +10, Maximum MP Percent: +30, Single Equip
 4954	stylish oven mitts	0		Moxie: +25, Single Equip
-4955	bite-sized tasty twirling overcookie	1	awesome	
+4955	tasty bite-sized twirling overcookie	1	awesome	
 4956	diet flavorless philosopher's scone	1	decent	
 4957	enhanced triple-ionized diffused wobbly half-baked potion	0		Effect: "Gutterminded", Effect Duration: 18
 4958	upside-down red Usain Bolt's Knob Goblin deluxe scimitar	0		Initiative: +80
@@ -4865,10 +4865,10 @@
 4962	Temple Grandin's Sinatra's mysterious lapel pin	0		Experience (Moxie): +5, Familiar Weight: +7, Single Equip
 4963	narrow state loom	0		Familiar Weight: +10
 4964	Evilometer	0		
-4965	spinning blurry Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
+4965	blurry spinning Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
-4968	olive skewed Alice's Army Spearsman	0		Last Available: "2011-03"
+4968	skewed olive Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
 4970	green Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
@@ -4888,8 +4888,8 @@
 4985	bouncing Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
-4988	gray skewed Alice's Army Foil Swordsman	0		Last Available: "2011-03"
-4989	yellow twirling jittery Alice's Army Foil Spearsman	0		Last Available: "2011-03"
+4988	skewed gray Alice's Army Foil Swordsman	0		Last Available: "2011-03"
+4989	twirling yellow jittery Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	squat Alice's Army Foil Halberder	0		Last Available: "2011-03"
 4991	Alice's Army Foil Guard	0		Last Available: "2011-03"
 4992	ghostly Alice's Army Foil Wallman	0		Last Available: "2011-03"
@@ -4907,7 +4907,7 @@
 5004	lime green Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	pulsating Alice's Army Foil Dervish	0		Last Available: "2011-03"
-5007	shaking tumbling Alice's Army Foil Martyr	0		Last Available: "2011-03"
+5007	tumbling shaking Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	red blurry Single Alice's Army Foil	0		Last Available: "2011-03"
 5009	rosewater-soaked card sleeve	0		Stench Resistance: +3, Last Available: "2011-03"
 5010	evil eye	0		
@@ -4915,18 +4915,18 @@
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	toothsome wasabi pocky	3	awesome	Last Available: "2011-03"
 5014	decent tobiko pocky	3	good	Last Available: "2011-03"
-5015	super-sized moldy natto pocky	5	crappy	Last Available: "2011-03"
+5015	moldy super-sized natto pocky	5	crappy	Last Available: "2011-03"
 5016	hand-crafted wasabi-infused sake	3	EPIC	Last Available: "2011-03"
-5017	aged weak tobiko-infused sake	2	awesome	Last Available: "2011-03"
+5017	weak aged tobiko-infused sake	2	awesome	Last Available: "2011-03"
 5018	tolerable jittery blinking natto-infused sake	4	good	Last Available: "2011-03"
 5019	super-chilled non-magnetized wasabi marble soda	0		Effect: "Berry Thorny", Effect Duration: 18, Last Available: "2011-03"
 5020	modified maroon tobiko marble soda	0		Effect: "Turkey-Ambitious", Effect Duration: 41, Last Available: "2011-03"
 5021	frozen diffused natto marble soda	0		Effect: "Heart of Lavender", Effect Duration: 20, Last Available: "2011-03"
 5022	pulsating Alice's Army booster box	0		Last Available: "2011-03"
 5023	non-galvanized diffused elderly jawbreaker	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 50, Last Available: "2020-09"
-5024	perfectly mixed spirit-forward special marshmallow flamb&eacute;	5	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5, Last Available: "2011-03"
+5024	spirit-forward perfectly mixed special marshmallow flamb&eacute;	5	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5, Last Available: "2011-03"
 5025	perfectly mixed cranberry schnapps	3	EPIC	Last Available: "2011-03"
-5026	practically non-alcoholic delicious wobbly breaded beer	1	awesome	Last Available: "2011-03"
+5026	delicious practically non-alcoholic wobbly breaded beer	1	awesome	Last Available: "2011-03"
 5027	artisanal fuchsia soy cordial	3	super ultra mega EPIC	Last Available: "2011-03"
 5028	miser's Oprah's astral bludgeon of the brute	0		Muscle Percent: +30, Maximum MP Percent: +50, Meat Drop: +10
 5029	blurry frightening chaotic astral shield	0		Spell Critical Percent: +10, Spooky Damage: +5, Damage Reduction: 15
@@ -4965,15 +4965,15 @@
 5062	purple blinking voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	stale half-sized spaghetti con calaveras	2	decent	Last Available: "2011-04"
+5065	half-sized stale spaghetti con calaveras	2	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	delicious small popcorn	2	awesome	Last Available: "2011-04"
 5068	stale shaking chaos popcorn	3	decent	Last Available: "2011-04"
 5069	flame-retardant crafty Herculean hole	0		Experience (Muscle): +1, Maximum MP: +10, Hot Resistance: +1, Last Available: "2011-04"
 5070	pulsating innuendo	0		Last Available: "2011-04"
 5071	diet adequate s'more	0	good	Last Available: "2011-04"
-5072	narrow blinking diamond ring	0		Last Available: "2011-04"
-5073	watered-down delicious Russian Ice	2	awesome	Last Available: "2011-04"
+5072	blinking narrow diamond ring	0		Last Available: "2011-04"
+5073	delicious watered-down Russian Ice	2	awesome	Last Available: "2011-04"
 5074	avaricious clay ashtray	0		Meat Drop: +30, Damage Reduction: 3, Last Available: "2011-05"
 5075	yellow aromatic lanyard	0		Stench Resistance: +1, Single Equip, Last Available: "2011-05"
 5076	auspicious monster pants	0		Item Drop: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	artisanal Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
 5108	jittery fistful of ashes	0		
-5109	medical-grade stress ball	0		HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	medical-grade stress ball	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	reassuring Ultracolor&trade; shirt	0		Spooky Resistance: +1, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5020,7 +5020,7 @@
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
 5119	busted wings	0		
-5120	wobbly blue Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
+5120	blue wobbly Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	inspector's resourceful wicked Admiral's hat	0		Spell Damage: +5, Maximum MP: +50, Item Drop: +15, Last Available: "2011-05", Familiar Effect: "atk"
 5122	crafty Socratic groovy aviator's cap	0		Moxie Percent: +10, Experience (Mysticality): +1, Maximum MP: +10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	huge red frosty stylish mirrored aviator shades	0		Moxie: +25, Cold Spell Damage: +10, Single Equip, Last Available: "2011-05"
@@ -5038,14 +5038,14 @@
 5135	jittery E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
-5138	ghostly pulsating E.M.U. harness	0		Last Available: "2011-06"
+5138	pulsating ghostly E.M.U. harness	0		Last Available: "2011-06"
 5139	skewed carton of astral energy drinks	0		
-5140	compressed shaking twirling astral energy drink	1		Effect: "Sourpuss", Effect Duration: 10
+5140	compressed twirling shaking astral energy drink	1		Effect: "Sourpuss", Effect Duration: 10
 5141	ghostly Thwaitgold bee statuette	0		
 5142	blue moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
-5145	polymerized pulsating squat honeypot	0		Effect: "Ichorous Eyesight", Effect Duration: 24
+5145	polymerized squat pulsating honeypot	0		Effect: "Ichorous Eyesight", Effect Duration: 24
 5146	spoiled wild honey pie	3	crappy	
 5147	aged honey mead	3	awesome	
 5148	tumbling fireproof personal trainer's honey dipper of the dark arts	0		Experience Percent (Muscle): +10, Spell Damage Percent: +100, Hot Resistance: +3
@@ -5074,8 +5074,8 @@
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	high-proof drinkable pulsating Saison du Lune	8	good	Last Available: "2011-06"
-5175	watered-down tolerable upside-down Moonthril Schnapps	2	good	Last Available: "2011-06"
+5174	drinkable high-proof pulsating Saison du Lune	8	good	Last Available: "2011-06"
+5175	tolerable watered-down upside-down Moonthril Schnapps	2	good	Last Available: "2011-06"
 5176	lousy Wrecked Generator	3	decent	Last Available: "2011-06"
 5177	spoiled Spaghetti with Moonballs	3	crappy	Last Available: "2011-06"
 5178	decent Crepes a la Lune	4	good	Last Available: "2011-06"
@@ -5086,11 +5086,11 @@
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
-5186	green spinning tumbling Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
+5186	spinning tumbling green Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	alkaline alkaline unsweetened spinning honey stick	0		Effect: "Vanity Rage", Effect Duration: 34
 5189	Vulcanized mirror double-ice gum	0		Effect: "Hypercubed", Effect Duration: 18, Last Available: "2011-04"
-5190	huge deadly Operation Patriot Shield of the scaredy-cat of mayonnaise	0		Weapon Damage: +5, Monster Level: -15, Sleaze Spell Damage: +50, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	huge deadly Operation Patriot Shield of the scaredy-cat of mayonnaise	0		Weapon Damage: +5, Monster Level: -15, Sleaze Spell Damage: +50, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	enhanced corrupted data	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 58, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5104,7 +5104,7 @@
 5201	compressed twirling ectoplasmic paste	1	crappy	Last Available: "2011-08"
 5202	diluted narrow shaking greasy paste	1	EPIC	Effect: "Space Cadet", Effect Duration: 20, Last Available: "2011-08"
 5203	pickled bug paste	1	awesome	Effect: "Mathematically Precise", Effect Duration: 25, Last Available: "2011-08"
-5204	mixed pulsating squat hippy paste	1	good	Last Available: "2011-08"
+5204	mixed squat pulsating hippy paste	1	good	Last Available: "2011-08"
 5205	altered squat orc paste	1	EPIC	Effect: "Boo Tea", Effect Duration: 35, Last Available: "2011-08"
 5206	altered blurry demonic paste	1	EPIC	Last Available: "2011-08"
 5207	dehydrated narrow indescribably horrible paste	1	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 20, Last Available: "2011-08"
@@ -5115,7 +5115,7 @@
 5212	powdered spinning paste	1	good	Last Available: "2011-08"
 5213	diluted twirling Mer-kin paste	1	good	Last Available: "2011-08"
 5214	modified narrow slimy paste	1	EPIC	Last Available: "2011-08"
-5215	diluted bouncing green penguin paste	1	crappy	Last Available: "2011-08"
+5215	diluted green bouncing penguin paste	1	crappy	Last Available: "2011-08"
 5216	denatured elemental paste	1	decent	Last Available: "2011-08"
 5217	powdered green cosmic paste	1	decent	Effect: "Greasy Flavor", Effect Duration: 15, Last Available: "2011-08"
 5218	mixed skewed hobo paste	1	decent	Effect: "Leisurely Amblin'", Effect Duration: 20, Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	jittery fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	rotten half-sized fuchsia tumbling Ur-Donut	2	crappy	Last Available: "2011-09"
+5224	half-sized rotten tumbling fuchsia Ur-Donut	2	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	hand-crafted blurry bucket of wine	3	EPIC	Last Available: "2011-09"
@@ -5139,19 +5139,19 @@
 5236	frosty halo of temperance	0		Sleaze Resistance: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of Calamity Jane	0		Critical Hit Percent: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	tolerable Lumineux Limnio	4	good	Last Available: "2011-09"
-5239	mediocre boozy Morto Moreto	5	decent	Last Available: "2011-09"
-5240	mediocre enchanted weak Temps Tempranillo	2	decent	Last Available: "2011-09"
-5241	tolerable strong Bordeaux Marteaux	5	good	Last Available: "2011-09"
+5239	boozy mediocre Morto Moreto	5	decent	Last Available: "2011-09"
+5240	mediocre weak enchanted Temps Tempranillo	2	decent	Last Available: "2011-09"
+5241	strong tolerable Bordeaux Marteaux	5	good	Last Available: "2011-09"
 5242	hand-crafted Fromage Pinotage	3	EPIC	Last Available: "2011-09"
-5243	bad distilled Beignet Milgranet	5	decent	Last Available: "2011-09"
+5243	distilled bad Beignet Milgranet	5	decent	Last Available: "2011-09"
 5244	drinkable Muschat	3	good	Last Available: "2011-09"
 5245	moldy shaking cool jelly donut	4	crappy	Last Available: "2011-09"
-5246	adequate low-calorie shrapnel jelly donut	1	good	Last Available: "2011-09"
-5247	massive spoiled occult jelly donut	7	crappy	Last Available: "2011-09"
+5246	low-calorie adequate shrapnel jelly donut	1	good	Last Available: "2011-09"
+5247	spoiled massive occult jelly donut	7	crappy	Last Available: "2011-09"
 5248	flavorless maroon thyme jelly donut	3	decent	Last Available: "2011-09"
 5249	bland danish	4	decent	Last Available: "2011-09"
 5250	yummy smashed danish	4	awesome	Last Available: "2011-09"
-5251	enchanted normal forbidden danish	3	good	Effect: "Compensatory Cruelness", Effect Duration: 45, Last Available: "2011-09"
+5251	normal enchanted forbidden danish	3	good	Effect: "Compensatory Cruelness", Effect Duration: 45, Last Available: "2011-09"
 5252	bland cool cat claw	3	decent	Last Available: "2011-09"
 5253	half-sized yummy blunt cat claw	2	awesome	Last Available: "2011-09"
 5254	flavorless shadowy cat claw	3	decent	Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	huge slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy phish stick	3	crappy	Last Available: "2011-09"
-5299	blurry scorching smartaleck's plastic vampire fangs of Tarzan	0		Moxie Percent: +30, Experience (Muscle): +3, Hot Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	blurry scorching smartaleck's plastic vampire fangs of Tarzan	0		Moxie Percent: +30, Experience (Muscle): +3, Hot Damage: +25, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	bouncing bouncing Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	blurry your own heart	0		Last Available: "2011-10"
@@ -5251,7 +5251,7 @@
 5348	twirling A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
 5349	A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
-5351	tumbling spinning maroon A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
+5351	maroon spinning tumbling A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -5296,8 +5296,8 @@
 5393	scrap of paper	0		
 5394	sandpaper	0		
 5395	blinking peppermint sprout	0		Last Available: "2011-11"
-5396	adjusted diffused narrow lime green peppermint twist	0		Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2011-11"
-5397	bland fancy ghostly peppermint patty	4	decent	Effect: "Coming Up Roses", Effect Duration: 35, Last Available: "2011-11"
+5396	adjusted diffused lime green narrow peppermint twist	0		Effect: "Superhuman Sarcasm", Effect Duration: 35, Last Available: "2011-11"
+5397	fancy bland ghostly peppermint patty	4	decent	Effect: "Coming Up Roses", Effect Duration: 35, Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5308,9 +5308,9 @@
 5405	ruddy beefcake's cane-mail shirt of vim and vigor	0		Muscle: +25, Maximum HP Percent: 90, Last Available: "2011-12"
 5406	Jack Frost's hale veiny cane-mail pants	0		Maximum HP: 30, Cold Spell Damage: +50, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	smooth watered-down Vodka Matryoshka	2	awesome	Last Available: "2011-12"
-5408	hand-crafted watered-down Gin Mint	2	EPIC	Last Available: "2011-12"
+5408	watered-down hand-crafted Gin Mint	2	EPIC	Last Available: "2011-12"
 5409	lousy special Tequiz Navidad	3	decent	Effect: "Powder Power", Effect Duration: 5, Last Available: "2011-12"
-5410	acceptable upside-down olive Mint Yulep	4	good	Last Available: "2011-12"
+5410	acceptable olive upside-down Mint Yulep	4	good	Last Available: "2011-12"
 5411	artisanal Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	artisanal yellow huge Sangria de Menthe	3	EPIC	Last Available: "2011-12"
 5413	bouncing candycaine powder	0		Last Available: "2011-12"
@@ -5340,7 +5340,7 @@
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	tarnished deionized fluid of fudge-finding	0		Effect: "Musky", Effect Duration: 65, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	rotten bite-sized bouncing fudgesicle	1	crappy	Last Available: "2011-11"
+5440	bite-sized rotten bouncing fudgesicle	1	crappy	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5359,7 +5359,7 @@
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	aerosolized magnetized huge Fudgie Roll	0		Effect: "Man's Worst Enemy", Effect Duration: 33, Last Available: "2011-11"
 5458	rotten fudge bunny	3	crappy	Last Available: "2011-11"
-5459	spinning fuchsia fudge spork	0		Last Available: "2011-11"
+5459	fuchsia spinning fudge spork	0		Last Available: "2011-11"
 5460	narrow double-paned dangerous fudgecycle of the overflowing toilet	0		Weapon Damage: +10, Stench Spell Damage: +50, Cold Resistance: +5, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
@@ -5370,7 +5370,7 @@
 5467	electrified pressed resolution: be smarter	0		Effect: "Thanksgot", Effect Duration: 44, Last Available: "2012-01"
 5468	aerosolized resolution: be sexier	0		Effect: "Moose Wisdom", Effect Duration: 53, Last Available: "2012-01"
 5469	quantum improved polymerized resolution: be feistier	0		Effect: "Florid Cheeks", Effect Duration: 49, Last Available: "2012-01"
-5470	aerosolized oxidized gray upside-down resolution: be kinder	0		Effect: "Wet Willied", Effect Duration: 29, Last Available: "2012-01"
+5470	aerosolized oxidized upside-down gray resolution: be kinder	0		Effect: "Wet Willied", Effect Duration: 29, Last Available: "2012-01"
 5471	extra-galvanized oxidized alkaline resolution: be more adventurous	0		Effect: "Employee of the Month", Effect Duration: 69, Last Available: "2012-01"
 5472	extra-galvanized resolution: be luckier	0		Effect: "The Strength...  of the Future", Effect Duration: 58, Last Available: "2012-01"
 5473	skewed gummi ingot	0		Last Available: "2011-11"
@@ -5379,9 +5379,9 @@
 5476	alkaline tarnished squat gummi salamander	0		Effect: "Yet tea", Effect Duration: 45, Last Available: "2011-11"
 5477	aerosolized gummi snake	0		Effect: "Ooh, Sour!", Effect Duration: 18, Last Available: "2011-11"
 5478	electrified oxidized ghostly gummi canary	0		Effect: "Blessing of Charcoatl", Effect Duration: 14, Last Available: "2011-11"
-5479	small flavorless twirling gummi bear	2	decent	Last Available: "2011-11"
+5479	flavorless small twirling gummi bear	2	decent	Last Available: "2011-11"
 5480	flavorless gummi bear	4	decent	Last Available: "2011-11"
-5481	normal miniature gummi bear	2	good	Last Available: "2011-11"
+5481	miniature normal gummi bear	2	good	Last Available: "2011-11"
 5482	yummy jumbo drunki-bear	5	awesome	Last Available: "2011-11"
 5483	rotten drunki-bear	3	crappy	Last Available: "2011-11"
 5484	rotten diet lime green drunki-bear	1	crappy	Last Available: "2011-11"
@@ -5395,9 +5395,9 @@
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	pickled altered gummi trilobite	0		Effect: "Amorous", Effect Duration: 13, Last Available: "2011-11"
-5495	non-vacuum-sealed activated mirror fuchsia gummi ammonite	0		Effect: "Cat-Alyzed", Effect Duration: 23, Last Available: "2011-11"
+5495	non-vacuum-sealed activated fuchsia mirror gummi ammonite	0		Effect: "Cat-Alyzed", Effect Duration: 23, Last Available: "2011-11"
 5496	polarized ghostly gummi belemnite	0		Effect: "Really Deep Breath", Effect Duration: 53, Last Available: "2011-11"
-5497	blurry blinking all-year sucker	0		Last Available: "2011-11"
+5497	blinking blurry all-year sucker	0		Last Available: "2011-11"
 5498	twirling heart of dark chocolate	0		Last Available: "2011-11"
 5499	huge narrow boxer's Big Candy's tophat of bravery	0		Muscle Percent: +10, Spooky Resistance: +5, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
@@ -5410,7 +5410,7 @@
 5507	lousy Go-Wassail	3	decent	Last Available: "2011-11"
 5508	modified non-alkaline jittery Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Angry Bone", Effect Duration: 40, Last Available: "2011-11"
 5509	corrupted liquefied bottle of bubbles	0		Effect: "Preternatural Greed", Effect Duration: 56, Last Available: "2011-11"
-5510	double-polymerized ionized blinking ghostly blue wind-up meatcar	0		Effect: "Bark of the Dog", Effect Duration: 42, Last Available: "2011-11"
+5510	double-polymerized ionized blue ghostly blinking wind-up meatcar	0		Effect: "Bark of the Dog", Effect Duration: 42, Last Available: "2011-11"
 5511	twirling Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5418,7 +5418,7 @@
 5515	fuchsia pog #01 (spider)	0		Last Available: "2011-11"
 5516	pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	pog #03 (warwelf)	0		Last Available: "2011-11"
-5518	huge pulsating pog #04 (skleleton)	0		Last Available: "2011-11"
+5518	pulsating huge pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	twirling pog #07 (orcish frat boy)	0		Last Available: "2011-11"
@@ -5465,7 +5465,7 @@
 5562	rosewater-soaked nasty Rain-Doh violet bo	0		Stench Damage: +5, Stench Resistance: +3, Softcore Only, Last Available: "2012-02"
 5563	blurry Rain-Doh box	0		Last Available: "2012-02"
 5564	ghostly Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	gigantic tasty PB&BP	10	awesome	
+5565	tasty gigantic PB&BP	10	awesome	
 5566	decent club sandwich	4	good	
 5567	immense flavorless upside-down corned-beef Reuben	6	decent	
 5568	blurry frayed ninja rope	0		
@@ -5473,15 +5473,15 @@
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	hand-crafted high-proof tumbling pulsating Drac & Tan	9	EPIC	Last Available: "2012-03"
+5573	hand-crafted high-proof pulsating tumbling Drac & Tan	9	EPIC	Last Available: "2012-03"
 5574	watered-down acceptable squat tumbling Transylvania Sling	2	good	Last Available: "2012-03"
-5575	drinkable narrow wobbly Shot of the Living Dead	3	good	Last Available: "2012-03"
+5575	drinkable wobbly narrow Shot of the Living Dead	3	good	Last Available: "2012-03"
 5576	delicious narrow Buttery Knob	3	awesome	Last Available: "2012-03"
-5577	delicious irresponsibly strong Slippery Knob	7	awesome	Last Available: "2012-03"
+5577	irresponsibly strong delicious Slippery Knob	7	awesome	Last Available: "2012-03"
 5578	mediocre Flaming Knob	4	decent	Last Available: "2012-03"
-5579	tolerable high-proof Grasshopper	6	good	Last Available: "2012-03"
-5580	artisanal triple-distilled Locust	8	EPIC	Last Available: "2012-03"
-5581	hand-crafted fancy squat Plague of Locusts	3	EPIC	Effect: "Magically Delicious", Effect Duration: 50, Last Available: "2012-03"
+5579	high-proof tolerable Grasshopper	6	good	Last Available: "2012-03"
+5580	triple-distilled artisanal Locust	8	EPIC	Last Available: "2012-03"
+5581	fancy hand-crafted squat Plague of Locusts	3	EPIC	Effect: "Magically Delicious", Effect Duration: 50, Last Available: "2012-03"
 5582	lousy ghostly Red Dwarf	4	decent	Last Available: "2012-03"
 5583	aged cyan blinking Golden Mean	4	awesome	Last Available: "2012-03"
 5584	fortified perfectly mixed Green Giant	5	EPIC	Last Available: "2012-03"
@@ -5490,45 +5490,45 @@
 5587	drinkable jittery Aye Aye, Tooth Tooth	3	good	Last Available: "2012-03"
 5588	lousy Humanitini	3	decent	Last Available: "2012-03"
 5589	lousy narrow More Humanitini than Humanitini	4	decent	Last Available: "2012-03"
-5590	drinkable fortified enchanted red Oh, the Humanitini	5	good	Effect: "Moon'd", Effect Duration: 45, Last Available: "2012-03"
+5590	fortified enchanted drinkable red Oh, the Humanitini	5	good	Effect: "Moon'd", Effect Duration: 45, Last Available: "2012-03"
 5591	acceptable Great Older Fashioned	4	good	Last Available: "2012-03"
-5592	hand-crafted triple-distilled upside-down Fuzzy Tentacle	8	EPIC	Last Available: "2012-03"
+5592	triple-distilled hand-crafted upside-down Fuzzy Tentacle	8	EPIC	Last Available: "2012-03"
 5593	delicious cyan Crazymaker	4	awesome	Last Available: "2012-03"
-5594	watered-down drinkable Zoodriver	2	good	Last Available: "2012-03"
-5595	fancy smooth pulsating Sloe Comfortable Zoo	3	awesome	Effect: "Corruption of Wretched Wally", Effect Duration: 10, Last Available: "2012-03"
+5594	drinkable watered-down Zoodriver	2	good	Last Available: "2012-03"
+5595	smooth fancy pulsating Sloe Comfortable Zoo	3	awesome	Effect: "Corruption of Wretched Wally", Effect Duration: 10, Last Available: "2012-03"
 5596	acceptable Sloe Comfortable Zoo on Fire	4	good	Last Available: "2012-03"
 5597	perfectly mixed Suffering Sinner	4	EPIC	Last Available: "2012-03"
-5598	fancy bad Suppurating Sinner	3	decent	Effect: "Disdain of She-Who-Was", Effect Duration: 35, Last Available: "2012-03"
+5598	bad fancy Suppurating Sinner	3	decent	Effect: "Disdain of She-Who-Was", Effect Duration: 35, Last Available: "2012-03"
 5599	aged Sizzling Sinner	3	awesome	Last Available: "2012-03"
-5600	mediocre weak gray Firewater	2	decent	Last Available: "2012-03"
-5601	lousy practically non-alcoholic Earth and Firewater	1	decent	Last Available: "2012-03"
+5600	weak mediocre gray Firewater	2	decent	Last Available: "2012-03"
+5601	practically non-alcoholic lousy Earth and Firewater	1	decent	Last Available: "2012-03"
 5602	practically non-alcoholic artisanal Earth, Wind and Firewater	1	super ultra EPIC	Last Available: "2012-03"
-5603	aged watered-down Slimosa	2	awesome	Last Available: "2012-03"
-5604	perfectly mixed high-proof Extra-slimy Slimosa	10	EPIC	Last Available: "2012-03"
+5603	watered-down aged Slimosa	2	awesome	Last Available: "2012-03"
+5604	high-proof perfectly mixed Extra-slimy Slimosa	10	EPIC	Last Available: "2012-03"
 5605	tolerable huge Slimebite	4	good	Last Available: "2012-03"
 5606	perfectly mixed Cement Mixer	3	EPIC	Last Available: "2012-03"
 5607	lousy high-proof Jackhammer	9	decent	Last Available: "2012-03"
 5608	special watered-down hand-crafted mirror Dump Truck	2	EPIC	Effect: "20-20 Second Sight", Effect Duration: 20, Last Available: "2012-03"
 5609	drinkable ghostly Fauna Libre	3	good	Last Available: "2012-03"
 5610	artisanal Chakra Libre	3	EPIC	Last Available: "2012-03"
-5611	perfectly mixed weak bouncing Aura Libre	2	EPIC	Last Available: "2012-03"
-5612	watered-down smooth fuchsia upside-down Sazerorc	2	awesome	Last Available: "2012-03"
-5613	practically non-alcoholic drinkable green wobbly Sazuruk-hai	1	good	Last Available: "2012-03"
+5611	weak perfectly mixed bouncing Aura Libre	2	EPIC	Last Available: "2012-03"
+5612	watered-down smooth upside-down fuchsia Sazerorc	2	awesome	Last Available: "2012-03"
+5613	drinkable practically non-alcoholic green wobbly Sazuruk-hai	1	good	Last Available: "2012-03"
 5614	hand-crafted Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	smooth Green Velvet	4	awesome	Last Available: "2012-03"
 5616	bad Green Muslin	3	decent	Last Available: "2012-03"
 5617	aged blue Green Burlap	4	awesome	Last Available: "2012-03"
-5618	lousy high-proof Mohobo	9	decent	Last Available: "2012-03"
-5619	practically non-alcoholic lousy bouncing Moonshine Mohobo	1	decent	Last Available: "2012-03"
+5618	high-proof lousy Mohobo	9	decent	Last Available: "2012-03"
+5619	lousy practically non-alcoholic bouncing Moonshine Mohobo	1	decent	Last Available: "2012-03"
 5620	delicious Flaming Mohobo	4	awesome	Last Available: "2012-03"
 5621	drinkable watered-down Drunken Philosopher	2	good	Last Available: "2012-03"
 5622	hand-crafted Drunken Neurologist	3	EPIC	Last Available: "2012-03"
 5623	watered-down hand-crafted Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
 5624	aged tumbling Dark & Starry	3	awesome	Last Available: "2012-03"
-5625	extra-dry bad upside-down Black Hole	5	decent	Last Available: "2012-03"
+5625	bad extra-dry upside-down Black Hole	5	decent	Last Available: "2012-03"
 5626	fancy lousy Event Horizon	4	decent	Effect: "Hella Smart", Effect Duration: 35, Last Available: "2012-03"
 5627	smooth Herring Daiquiri	3	awesome	Last Available: "2012-03"
-5628	tolerable practically non-alcoholic Herring Wallbanger	1	good	Last Available: "2012-03"
+5628	practically non-alcoholic tolerable Herring Wallbanger	1	good	Last Available: "2012-03"
 5629	drinkable maroon Herringtini	3	good	Last Available: "2012-03"
 5630	lousy blurry Lollipop Drop	4	decent	Last Available: "2012-03"
 5631	bad wobbly Candy Alexander	4	decent	Last Available: "2012-03"
@@ -5575,7 +5575,7 @@
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
-5675	denatured narrow huge blinking watered-down Red Minotaur	1		
+5675	denatured huge narrow blinking watered-down Red Minotaur	1		
 5676	blurry pool torpedo	0		Last Available: "2012-05"
 5677	spinning Samson's Ze&trade; goggles	0		Experience (Muscle): +5, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
@@ -5583,7 +5583,7 @@
 5680	lost key	0		Last Available: "2012-05"
 5681	normal P.B.L.T.	4	good	
 5682	note from Clancy	0		Skill: "Request Sandwich"
-5683	twirling ghostly BURT	0		
+5683	ghostly twirling BURT	0		
 5684	handful of juicy garbage	0		
 5685	cyan bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
@@ -5633,28 +5633,28 @@
 5732	tumbling blank note	0		
 5733	eerily silent box	0		
 5734	miniature bland forbidden sausage	2	decent	
-5735	wobbly quilted Lord Flameface's cloak	0		Damage Absorption: +40, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5735	wobbly quilted Lord Flameface's cloak	0		Damage Absorption: +40, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	concentrated unsweetened pulsating Drizzlers&trade; Black Licorice	0		Effect: "Educated (Kinda)", Effect Duration: 16
 5737	dry dry daub-breaker	0		Effect: "Booing Radly", Effect Duration: 66, Last Available: "2020-09"
 5738	weightlifter's Camp Scout backpack	0		Muscle: +15, Softcore Only, Last Available: "2012-07"
 5739	jittery CSA fire-starting kit	0		Last Available: "2012-07"
-5740	bland jumbo bag of GORP	5	decent	Last Available: "2012-07"
+5740	jumbo bland bag of GORP	5	decent	Last Available: "2012-07"
 5741	artisanal water purification pills	3	EPIC	Last Available: "2012-07"
-5742	tumbling skewed Camp Scout pup tent	0		Last Available: "2012-07"
+5742	skewed tumbling Camp Scout pup tent	0		Last Available: "2012-07"
 5743	smooth practically non-alcoholic CSA scoutmaster's &quot;water&quot;	1	awesome	Last Available: "2012-07"
-5744	stale enchanted low-calorie blurry bag of GORF	1	decent	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2012-07"
+5744	low-calorie stale enchanted blurry bag of GORF	1	decent	Effect: "Wise Spirit", Effect Duration: 15, Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	moldy super-sized tumbling fuchsia bag of QWOP	5	crappy	Last Available: "2012-07"
+5746	super-sized moldy fuchsia tumbling bag of QWOP	5	crappy	Last Available: "2012-07"
 5747	improved CSA bravery badge	0		Effect: "Cancer Rising", Effect Duration: 64, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	bad CSA cheerfulness ration	4	decent	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	stale crappy brain	4	decent	
-5753	half-sized spoiled decent brain	2	crappy	
+5753	spoiled half-sized decent brain	2	crappy	
 5754	immense tasty twirling good brain	7	awesome	
-5755	snack-sized flavorless boss brain	2	decent	
-5756	bland jittery spinning hunter brain	4	decent	
+5755	flavorless snack-sized boss brain	2	decent	
+5756	bland spinning jittery hunter brain	4	decent	
 5758	wobbly greedy Newton's Staff of Holiday Sensations of the pedagogue	0		Experience: +3, Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2011-11"
 5759	inspector's hale staff	0		Maximum HP: +20, Item Drop: +15
 5760	mirror occult thinker's beefy staff	0		Muscle: +10, Mysticality: +10, Spell Damage Percent: +25
@@ -5674,7 +5674,7 @@
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	tumbling auspicious Barney's rake of the dark arts	0		Spell Damage Percent: +100, Item Drop: +10
-5778	snack-sized rotten enchanted purple idiot brain	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 45
+5778	rotten snack-sized enchanted purple idiot brain	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 45
 5779	squat wizardly keel-haulin' knife	0		Mysticality: +25
 5780	ice cream scoop of the glutton	0		Food Drop: +100
 5781	bad yellow jittery soft echo eyedrop antidote martini	4	decent	
@@ -5683,21 +5683,21 @@
 5784	weirdwood plank	0		
 5785	thick caulk	0		
 5786	hard screw	0		
-5787	fuchsia bouncing messy butt joint	0		
+5787	bouncing fuchsia messy butt joint	0		
 5788	jittery smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	gray box of bear arms	0		Last Available: "2012-09"
-5791	Fonzie's Herculean right bear arm	0		Experience (Muscle): +1, Experience (Moxie): +1, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	mansplainer's extremely unsafe left bear arm of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +100, Monster Level: +15, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	Fonzie's Herculean right bear arm	0		Experience (Muscle): +1, Experience (Moxie): +1, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	mansplainer's extremely unsafe left bear arm of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +100, Monster Level: +15, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	wool Hat O' Nine Tails	0		Cold Resistance: +1
 5794	super-Vulcanized non-unsweetened Enchanted Plunger	0		Effect: "Dragged Through the Coals", Effect Duration: 38
 5795	tarnished ionized anodized Enchanted Flyswatter	0		Effect: "The Solution", Effect Duration: 23
 5796	wet nitrogenated fuchsia Gearhead Goo	0		Effect: "Heart of Pink", Effect Duration: 14
 5797	moist Missing Eye Simulation Device	0		Effect: "Ghostly Shell", Effect Duration: 36
 5798	alkaline skewed Gnollish Crossdress	0		Effect: "The Grass...  Is Blue...", Effect Duration: 36
-5799	polarized squat skewed eldritch dough	0		Effect: "Go-Gone", Effect Duration: 26
-5800	flattened galvanized shaking wobbly olive Charity's choker	0		Effect: "Icy Composition", Effect Duration: 68
-5801	tarnished polarized narrow upside-down Smart Bone Dust	0		Effect: "Your Eyes are Peeled!", Effect Duration: 14
+5799	polarized skewed squat eldritch dough	0		Effect: "Go-Gone", Effect Duration: 26
+5800	flattened galvanized shaking olive wobbly Charity's choker	0		Effect: "Icy Composition", Effect Duration: 68
+5801	tarnished polarized upside-down narrow Smart Bone Dust	0		Effect: "Your Eyes are Peeled!", Effect Duration: 14
 5802	diffused perpendicular guano	0		Effect: "Less Pervious", Effect Duration: 68
 5803	moist White Chocolate Golem Seeds	0		Effect: "Black Lung", Effect Duration: 53
 5804	oxidized ionized Shivering Ch&egrave;vre	0		Effect: "Human-Elemental Hybrid", Effect Duration: 11
@@ -5713,7 +5713,7 @@
 5814	deionized blob of acid	0		Effect: "Jawin'", Effect Duration: 36
 5815	quadruple-anodized wet jittery flayed mind	0		Effect: "Whole Latte Love", Effect Duration: 50
 5816	galvanized energized kobold kibble	0		Effect: "Squid Squint", Effect Duration: 68
-5817	Vulcanized spinning upside-down forest spirit rattle	0		Effect: "Well-Swabbed Ear", Effect Duration: 12
+5817	Vulcanized upside-down spinning forest spirit rattle	0		Effect: "Well-Swabbed Ear", Effect Duration: 12
 5818	modified red pulsating Stone Golem pebbles	0		Effect: "Hammered", Effect Duration: 21
 5819	anodized triple-frozen wobbly skewed gravy fairy warlock hat	0		Effect: "World's Shortest Giant", Effect Duration: 57
 5820	irradiated bull blubber	0		Effect: "Corruption of Wretched Wally", Effect Duration: 22
@@ -5727,10 +5727,10 @@
 5828	polarized gilt perfume bottle	0		Effect: "Salty Mouth", Effect Duration: 13
 5829	concentrated polymerized huge janglin' bones	0		Effect: "Vanity Rage", Effect Duration: 38
 5830	boiled alkaline narrow pygmy papers	0		Effect: "Human-Hobo Hybrid", Effect Duration: 24
-5831	boiled skewed jittery purple pygmy dart	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 11
+5831	boiled purple jittery skewed pygmy dart	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 11
 5832	galvanized secret mummy herbs and spices	0		Effect: "Hot Hands", Effect Duration: 28
 5833	aerosolized brigand brittle	0		Effect: "Arabian Knighthood", Effect Duration: 64
-5834	altered teal shaking mirror holistic headache remedy	0		Effect: "Twinkly Weapon", Effect Duration: 16
+5834	altered mirror teal shaking holistic headache remedy	0		Effect: "Twinkly Weapon", Effect Duration: 16
 5835	dry dry scrunchie tourniquet	0		Effect: "Venomous Weapon", Effect Duration: 48
 5836	boiled chilled shaking embezzler's oil	0		Effect: "Macho Profundo", Effect Duration: 26
 5837	energized colloidal Fu Manchu Wax	0		Effect: "Meat the Flintstones", Effect Duration: 38
@@ -5738,7 +5738,7 @@
 5839	ionized chilled unsweetened yellow ravenous eye	0		Effect: "Hairy Palms", Effect Duration: 26
 5840	aerosolized huge Rogue Windmill Rouge	0		Effect: "Ghostly Shell", Effect Duration: 17
 5841	ionized twirling A muse-bouche	0		Effect: "Punch Another Day", Effect Duration: 29
-5842	diffused unsweetened tumbling spinning toothbrush	0		Effect: "Polka of Plenty", Effect Duration: 34
+5842	diffused unsweetened spinning tumbling toothbrush	0		Effect: "Polka of Plenty", Effect Duration: 34
 5843	vacuum-sealed cold-filtered extra-quantum pirate cream pie	0		Effect: "Pisces Rising", Effect Duration: 60
 5844	polarized pulsating una poca de gracia	0		Effect: "Thunderspell", Effect Duration: 34
 5845	triple-adjusted electrified compressed air canister	0		Effect: "Down With Chow", Effect Duration: 56
@@ -5746,20 +5746,20 @@
 5847	non-improved Vulcanized unholy water	0		Effect: "Weapon of Mass Destruction", Effect Duration: 53
 5848	anodized gray skewed Bangyomaman battle juice	0		Effect: "Meatwise", Effect Duration: 46
 5849	activated blue tumbling handyman &quot;hand soap&quot;	0		Effect: "Deeply Ironic", Effect Duration: 38
-5850	super-vacuum-sealed magnetized spinning yellow space marine flash grenade	0		Effect: "Joyful Resolve", Effect Duration: 48
+5850	super-vacuum-sealed magnetized yellow spinning space marine flash grenade	0		Effect: "Joyful Resolve", Effect Duration: 48
 5851	corrupted skewed temporary tribal tattoo	0		Effect: "Jammin'", Effect Duration: 69
 5852	adjusted moist improved oil-filled donut	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 44
-5853	boiled ghostly yellow stick-on gnome beard	0		Effect: "Strange Mental Acuity", Effect Duration: 49
-5854	vacuum-sealed green upside-down BRICKO stud	0		Effect: "The Power of Negative Thinking", Effect Duration: 17
+5853	boiled yellow ghostly stick-on gnome beard	0		Effect: "Strange Mental Acuity", Effect Duration: 49
+5854	vacuum-sealed upside-down green BRICKO stud	0		Effect: "The Power of Negative Thinking", Effect Duration: 17
 5855	pickled denatured Osk'r Chow	0		Effect: "Uncaged Power", Effect Duration: 28
 5856	quadruple-deionized polarized Scuba Snack	0		Effect: "Petit Forbearance", Effect Duration: 61
 5857	altered energized grey cube	0		Effect: "Oxygenated Blood", Effect Duration: 26
 5858	frozen liquefied teal votive candle	0		Effect: "Rat-Faced", Effect Duration: 62
 5859	dry vacuum-sealed dry purple booby trap	0		Effect: "Ack!  Barred!", Effect Duration: 69
-5860	extra-ionized activated jittery teal pulsating Agent Corrigan's cigarette	0		Effect: "Flaming Weapon", Effect Duration: 13
+5860	extra-ionized activated jittery pulsating teal Agent Corrigan's cigarette	0		Effect: "Flaming Weapon", Effect Duration: 13
 5861	vacuum-sealed good ash	0		Effect: "Night Vision", Effect Duration: 49
 5862	ghostly Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
-5863	mirror wobbly Rad Lib	0		Last Available: "2012-09"
+5863	wobbly mirror Rad Lib	0		Last Available: "2012-09"
 5864	lime green papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	improved papier-mochi	0		Effect: "init.enh", Effect Duration: 21, Last Available: "2012-09"
 5866	vacuum-sealed blue papier-m&acirc;chaeranthera	0		Effect: "The Rich Get Richer", Effect Duration: 24, Last Available: "2012-09"
@@ -5776,14 +5776,14 @@
 5877	huge narrow papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	green brainy Rainbow Jello Mould	0		Mysticality: +5
 5879	wobbly Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
-5880	wobbly squat packet of dragon's teeth	0		Last Available: "2012-10"
+5880	squat wobbly packet of dragon's teeth	0		Last Available: "2012-10"
 5881	twirling skeleton	0		Last Available: "2012-10"
 5882	skeleton skis of the cougar of the brazier of the detective	0		Moxie: +20, Hot Spell Damage: +25, Item Drop: +20, Single Equip, Last Available: "2012-10"
 5883	low-calorie spoiled skeleton quiche	1	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	bouncing tumbling friendly stiffened personal trainer's Bonestabber of the boozehound	0		Experience Percent (Muscle): +10, Damage Reduction: 1, Familiar Weight: +3, Booze Drop: +100, Last Available: "2012-10"
-5887	enchanted drinkable crystal skeleton vodka	4	good	Effect: "Livin' Large", Effect Duration: 35, Last Available: "2012-10"
+5887	drinkable enchanted crystal skeleton vodka	4	good	Effect: "Livin' Large", Effect Duration: 35, Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	pulsating careful auxiliary backbone	0		Monster Level: -10, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
@@ -5796,7 +5796,7 @@
 5897	compressed Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
-5900	fuchsia blinking jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
+5900	blinking fuchsia jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	narrow pulsating jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	pulsating jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	mirror BittyCar HotCar	0		Last Available: "2012-12"
-5928	Tesla brainwave-controlled unicorn horn	0		MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	Tesla brainwave-controlled unicorn horn	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	mirror bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	smelly healthy baleful plastic four-shadowed mime	0		Spell Damage: +25, Maximum HP Percent: +20, Stench Spell Damage: +10, Single Equip, Last Available: "2012-12"
@@ -5858,10 +5858,10 @@
 5960	plastic Father McGruber of temperance	0		Sleaze Resistance: +5, Last Available: "2012-12"
 5961	prompt plastic Hank North, Photojournalist	0		Adventures: +3, Last Available: "2012-12"
 5962	tumbling plastic blazing bat of terror	0		Spooky Spell Damage: +10, Last Available: "2012-12"
-5963	rosewater-soaked electronic dulcimer pants of the wise owl	0		Mysticality: +20, Stench Resistance: +3, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	rosewater-soaked electronic dulcimer pants of the wise owl	0		Mysticality: +20, Stench Resistance: +3, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	pulsating pulsating A-Boo clue	0		
 5965	padded groovy Frown Exerciser	0		Moxie Percent: +10, Damage Absorption: +20, Single Equip, Last Available: "2012-12"
-5966	blue pulsating twirling soul monocle	0		Single Equip
+5966	twirling blue pulsating soul monocle	0		Single Equip
 5967	soul doorbell	0		
 5968	spinning shaking soul coin	0		
 5969	yellow soul knife	0		
@@ -5881,7 +5881,7 @@
 5983	skewed vial of holy water	0		Last Available: "2013-02"
 5984	double-paned smelly forbidden cloth cap	0		Spell Damage Percent: +50, Stench Spell Damage: +10, Cold Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	gray double-paned lion tamer's forbidden iron dagger	0		Spell Damage Percent: +50, Experience (familiar): +2, Cold Resistance: +5, Last Available: "2013-02"
-5986	tasty maroon blurry hamburger	4	awesome	Last Available: "2013-02"
+5986	tasty blurry maroon hamburger	4	awesome	Last Available: "2013-02"
 5987	red dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	gray potion	0		Last Available: "2013-02"
@@ -5893,7 +5893,7 @@
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	perfectly mixed spirit-forward shining goblet	5	EPIC	Last Available: "2013-02"
+5998	spirit-forward perfectly mixed shining goblet	5	EPIC	Last Available: "2013-02"
 5999	huge fireball	0		Last Available: "2013-02"
 6000	prompt Sherlock's slick crown	0		Moxie: +10, Item Drop: +25, Adventures: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	rosy-cheeked studded sword of the overflowing toilet	0		Damage Absorption: +80, Maximum HP Percent: +30, Stench Spell Damage: +50, Last Available: "2013-02"
@@ -5951,7 +5951,7 @@
 6053	watered-down mediocre yellow Taco Dan's Taco Stand Chimichangarita	2	decent	Last Available: "2012-12"
 6054	quantum blinking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Riboflavin'", Effect Duration: 34, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	gray The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	gray The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	greedy auspicious Meatcleaver	0		Item Drop: +10, Meat Drop: +20, Last Available: "2013-12"
 6058	steel-toed Crimbo Elf bobble-head	0		Damage Reduction: 9, Last Available: "2012-12"
 6059	squat blue medical-grade Crimbo stogie-scented room odorizer	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-12"
@@ -5960,7 +5960,7 @@
 6062	Tesla Crimbo light-up Rudolph doll	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-12"
 6063	smooth Super Crimboman Ultra Mega Hypersword	0		Moxie: +15, Last Available: "2012-12"
 6064	sharp tin strip	0		
-6065	huge twirling wad of spider silk	0		
+6065	twirling huge wad of spider silk	0		
 6066	goblin collarbone	0		
 6067	lard-coated extremely unsafe Truthsayer	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Last Available: "2013-12"
 6068	loose blade	0		
@@ -5971,16 +5971,16 @@
 6073	tarnished super-oxidized shaking haggis-infused soap	0		Effect: "Sparkling Consciousness", Effect Duration: 42, Last Available: "2012-12"
 6074	colloidal magicberry tablets	0		Effect: "Quadrilled", Effect Duration: 17, Last Available: "2012-12"
 6075	super-warmed denatured cyan 37x37x37 puzzle cube	0		Effect: "Lifted Spirits", Effect Duration: 11, Last Available: "2012-12"
-6076	perfectly mixed triple-distilled squat McLeod's Hard Haggis-Ade	8	EPIC	Last Available: "2012-12"
+6076	triple-distilled perfectly mixed squat McLeod's Hard Haggis-Ade	8	EPIC	Last Available: "2012-12"
 6077	bland half-sized haggis-wrapped haggis-stuffed haggis	2	decent	Last Available: "2012-12"
 6078	shaking home robotics kit	0		Last Available: "2012-12"
 6079	spinning school calculator watch	0		Last Available: "2012-12"
-6080	hardy haggis socks	0		Maximum HP: +50, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	hardy haggis socks	0		Maximum HP: +50, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	green Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	red mirror actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
-6085	skewed cyan magnetic sculpture kit	0		Last Available: "2012-12"
+6085	cyan skewed magnetic sculpture kit	0		Last Available: "2012-12"
 6086	ruddy Microplushie: Otakulone	0		Maximum HP Percent: +40, Last Available: "2012-12"
 6087	maroon fortified Microplushie: Hippylase	0		Damage Absorption: +60, Last Available: "2012-12"
 6088	asbestos-lined Microplushie: Bropane	0		Hot Resistance: +5, Last Available: "2012-12"
@@ -6010,7 +6010,7 @@
 6112	zaibatsu lobby card	0		Last Available: "2013-12"
 6113	pulsating zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	zaibatsu level 2 card	0		Last Available: "2013-12"
-6115	shaking bouncing zaibatsu level 3 card	0		Last Available: "2013-12"
+6115	bouncing shaking zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	skewed CEO office card	0		Last Available: "2013-12"
 6117	teal test site key	0		Last Available: "2013-12"
 6118	goggles	0		Last Available: "2013-12"
@@ -6052,19 +6052,19 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	olive flickering pixel	0		Last Available: "2013-12"
 6157	narrow family-friendly wicked Byte	0		Spell Damage: +5, Sleaze Resistance: +1, Last Available: "2013-12"
-6158	anger blaster of Leguizamo	0		Monster Level: +20, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	inspector's doubt cannon	0		Item Drop: +15, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	mirror ribald fear condenser	0		Sleaze Damage: +10, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	mansplainer's regret hose	0		Monster Level: +15, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
-6162	jittery pulsating Young Man's Crew Sequester	0		Last Available: "2013-12"
+6158	anger blaster of Leguizamo	0		Monster Level: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	inspector's doubt cannon	0		Item Drop: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	mirror ribald fear condenser	0		Sleaze Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	mansplainer's regret hose	0		Monster Level: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6162	pulsating jittery Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	huge Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	olive up-at-dawn censurious commodore's hat	0		Sleaze Resistance: +3, Adventures: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
 6165	brawny naval trousers	0		Muscle Percent: +20, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	stiffened deck cannon of Flo-Jo	0		Damage Reduction: 1, Initiative: +100, Last Available: "2013-12"
 6167	teal bouncing censurious ornamental sextant	0		Sleaze Resistance: +3, Last Available: "2013-12"
 6168	executive forbidden Bloodbath	0		Spell Damage Percent: +50, Meat Drop: +40, Last Available: "2013-12"
-6169	weak artisanal Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
-6170	special delicious super-sized chum	5	awesome	Effect: "Polka of Plenty", Effect Duration: 25, Last Available: "2013-12"
+6169	artisanal weak Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
+6170	super-sized delicious special chum	5	awesome	Effect: "Polka of Plenty", Effect Duration: 25, Last Available: "2013-12"
 6171	improved blinking crude crudit&eacute;s	0		Effect: "Human-Constellation Hybrid", Effect Duration: 24
 6172	tarnished polarized purple candy crayons	0		Effect: "Bright!", Effect Duration: 15, Last Available: "2020-09"
 6173	huge avaricious supercool pixel grappling hook	0		Moxie Percent: +20, Meat Drop: +30
@@ -6079,45 +6079,45 @@
 6182	green cosmic cream	0		
 6183	cosmic fruit	0		
 6184	scorching fortified Socratic Jarlsberg's hat	0		Experience (Mysticality): +1, Damage Absorption: +60, Hot Damage: +25
-6185	rotten massive jittery consummate hard-boiled egg	8	crappy	
-6186	bland special consummate fried egg	3	decent	Effect: "Don't Step to Your Stepmother", Effect Duration: 10
-6187	stale super-sized consummate egg salad	5	decent	
+6185	massive rotten jittery consummate hard-boiled egg	8	crappy	
+6186	special bland consummate fried egg	3	decent	Effect: "Don't Step to Your Stepmother", Effect Duration: 10
+6187	super-sized stale consummate egg salad	5	decent	
 6188	normal tiny consummate bagel	1	good	
 6189	decent snack-sized tumbling tumbling consummate sliced bread	2	good	
-6190	decent half-sized consummate hot dog bun	2	good	
-6191	snack-sized bland consummate brownie	2	decent	
+6190	half-sized decent consummate hot dog bun	2	good	
+6191	bland snack-sized consummate brownie	2	decent	
 6192	flavorless consummate toast	3	decent	
 6193	extra-dry acceptable spinning passable stout	5	good	
-6194	snack-sized fancy rotten consummate soup	2	crappy	Effect: "Almost Cool", Effect Duration: 50
+6194	fancy snack-sized rotten consummate soup	2	crappy	Effect: "Almost Cool", Effect Duration: 50
 6195	spoiled consummate corn chips	4	crappy	
-6196	snack-sized flavorless consummate salad	2	decent	
+6196	flavorless snack-sized consummate salad	2	decent	
 6197	adequate snack-sized consummate salsa	2	good	
 6198	spoiled consummate sauerkraut	4	crappy	
 6199	tasty diet huge consummate cheese slice	1	awesome	
 6200	bland huge mirror consummate melted cheese	10	decent	
 6201	flavorless consummate bacon	3	decent	
 6202	low-calorie normal consummate meatloaf	1	good	
-6203	enchanted thick bland jittery consummate steak	5	decent	Effect: "Musky", Effect Duration: 30
+6203	bland thick enchanted jittery consummate steak	5	decent	Effect: "Musky", Effect Duration: 30
 6204	yummy consummate cuts	4	awesome	
-6205	bland massive consummate frankfurter	6	decent	
+6205	massive bland consummate frankfurter	6	decent	
 6206	normal consummate french fries	4	good	
 6207	adequate consummate baked potato	4	good	
 6208	hand-crafted twirling acceptable vodka	4	EPIC	
-6209	adequate immense consummate ice cream	8	good	
+6209	immense adequate consummate ice cream	8	good	
 6210	toothsome green consummate whipped cream	4	awesome	
-6211	yummy special consummate cream	3	awesome	Effect: "Human-Plant Hybrid", Effect Duration: 30
+6211	special yummy consummate cream	3	awesome	Effect: "Human-Plant Hybrid", Effect Duration: 30
 6212	spoiled consummate strawberries	3	crappy	
-6213	bland half-sized blue consummate sorbet	2	decent	
+6213	half-sized bland blue consummate sorbet	2	decent	
 6214	hand-crafted adequate rum	3	EPIC	
 6215	drinkable practically non-alcoholic mediocre lager	1	good	
 6216	diet stale purple immaculate grilled cheese	1	decent	
 6217	adequate purple immaculate ice cream sandwich	4	good	
-6218	decent snack-sized immaculate hot dog	2	good	
-6219	moldy half-sized immaculate egg salad sandwich	2	crappy	
-6220	delicious snack-sized green perfect sandwich	2	awesome	
+6218	snack-sized decent immaculate hot dog	2	good	
+6219	half-sized moldy immaculate egg salad sandwich	2	crappy	
+6220	snack-sized delicious green perfect sandwich	2	awesome	
 6221	moldy perfect chef salad	3	crappy	
-6222	rotten low-calorie perfect breakfast	1	crappy	
-6223	enchanted immense spoiled sublime deluxe hot dog	6	crappy	Effect: "Egg-stortionary Tactics", Effect Duration: 30
+6222	low-calorie rotten perfect breakfast	1	crappy	
+6223	spoiled immense enchanted sublime deluxe hot dog	6	crappy	Effect: "Egg-stortionary Tactics", Effect Duration: 30
 6224	special bland sublime stew	3	decent	Effect: "Buff as a Baobab", Effect Duration: 20
 6225	stale huge sublime nachos	8	decent	
 6226	flavorless Ultimate Breakfast Sandwich	3	decent	
@@ -6127,15 +6127,15 @@
 6230	tolerable weak Bologna Lambic	2	good	
 6231	bad weak Vodka Dog	2	decent	
 6232	spirit-forward mediocre Disappointed Russian	5	decent	
-6233	bad watered-down Chunky Mary	2	decent	
-6234	delicious boozy maroon Nachojito	5	awesome	
-6235	tolerable enchanted Le Roi	3	good	Effect: "Elemental Saucesphere", Effect Duration: 25
+6233	watered-down bad Chunky Mary	2	decent	
+6234	boozy delicious maroon Nachojito	5	awesome	
+6235	enchanted tolerable Le Roi	3	good	Effect: "Elemental Saucesphere", Effect Duration: 25
 6236	extra-dry smooth Over Easy Rider	5	awesome	
 6237	cosmic six-pack	0		
-6239	triple-polymerized squat wobbly maroon cube of ectoplasm	0		Effect: "Pie in the Sky", Effect Duration: 49
+6239	triple-polymerized wobbly maroon squat cube of ectoplasm	0		Effect: "Pie in the Sky", Effect Duration: 49
 6240	ionized alkaline blue Illuminati earpiece	0		Effect: "Motion", Effect Duration: 11
 6241	improved oxidized dry censored can label	0		Effect: "Full Bottle in front of Me", Effect Duration: 53
-6242	enhanced bouncing tumbling ectoplasm <i>au jus</i>	0		Effect: "Mushroom Melody", Effect Duration: 41
+6242	enhanced tumbling bouncing ectoplasm <i>au jus</i>	0		Effect: "Mushroom Melody", Effect Duration: 41
 6243	cold-filtered the kindest cut	0		Effect: "Squatting and Thrusting", Effect Duration: 23
 6244	alkaline colloidal cat's paw	0		Effect: "Fastbreaker", Effect Duration: 22
 6245	improved moist oxidized ASCII fu manchu	0		Effect: "PERL of Great Price", Effect Duration: 17
@@ -6160,7 +6160,7 @@
 6264	wool Staff of Fruit Salad of vim and vigor of the detective	0		Maximum HP Percent: +50, Cold Resistance: +1, Item Drop: +20, Jiggle: "Deal Some Prismatic Damage"
 6265	twirling ruddy razor-sharp savvy Staff of the Cream of the Cream	0		Mysticality Percent: +20, Weapon Damage Percent: +25, Maximum HP Percent: +40, Jiggle: "Attune to Monster's Essence"
 6266	huge narrow jar of protein powder	0		
-6267	moldy thick grain of protein powder	5	crappy	
+6267	thick moldy grain of protein powder	5	crappy	
 6268	ionized pickled polymerized spinning pec oil	0		Effect: "Ichorous Intensity", Effect Duration: 51
 6269	sizzling gym membership card	0		Hot Damage: +10
 6270	flattened colloidal liquefied Squat-Thrust Magazine	0		Effect: "Hobo Flavor", Effect Duration: 20
@@ -6182,11 +6182,11 @@
 6286	twirling scorching sinister Fonzie's Mark II Steam-Hat	0		Experience (Moxie): +1, Spell Damage: +10, Hot Damage: +25, Familiar Effect: "1xLep, cap 37"
 6287	blinking auspicious sinister Fonzie's Mark III Steam-Hat of Gandalf	0		Experience (Moxie): +1, Spell Damage: +10, Spell Critical Percent: +20, Item Drop: +10, Familiar Effect: "1xLep, cap 37"
 6288	tumbling double-paned energetic Rosewater's brawny Mark IV Steam-Hat of incineration	0		Muscle Percent: +20, Mysticality Percent: +30, Maximum MP Percent: +20, Hot Spell Damage: +50, Cold Resistance: +5, Familiar Effect: "1xLep, cap 37"
-6289	Oprah's razor-sharp experienced smartaleck's Mark V Steam-Hat of incineration	0		Moxie Percent: +30, Experience: +2, Weapon Damage Percent: +25, Maximum MP Percent: +50, Hot Spell Damage: +50, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	Oprah's razor-sharp experienced smartaleck's Mark V Steam-Hat of incineration	0		Moxie Percent: +30, Experience: +2, Weapon Damage Percent: +25, Maximum MP Percent: +50, Hot Spell Damage: +50, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	mirror steam-powered model rocketship	0		
 6291	huge smooth punk rock jacket of dire peril	0		Moxie: +15, Weapon Damage: +20
 6292	blurry arcane researcher's safety pin of Flo-Jo	0		Experience Percent (Mysticality): +10, Initiative: +100
-6293	half-sized flavorless special stolen sushi	2	decent	Effect: "Heart of Green", Effect Duration: 15
+6293	half-sized special flavorless stolen sushi	2	decent	Effect: "Heart of Green", Effect Duration: 15
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	ghostly cosmic bucket	0		Free Pull
@@ -6212,7 +6212,7 @@
 6316	frightening deep six-shooter of the wise owl	0		Mysticality: +20, Spooky Damage: +5
 6317	bouncing Sherlock's knitted sea chaps	0		Cold Resistance: +3, Item Drop: +25, Familiar Effect: "atk, 2xBarrr"
 6318	greedy Sinatra's sage sea holster	0		Mysticality Percent: +10, Experience (Moxie): +5, Meat Drop: +20, Single Equip
-6319	irradiated non-improved wobbly ghostly bouncing shavin' razor	0		Effect: "Mushroom Samba", Effect Duration: 50
+6319	irradiated non-improved ghostly wobbly bouncing shavin' razor	0		Effect: "Mushroom Samba", Effect Duration: 50
 6320	gray reassuring long-forgotten necklace	0		Spooky Resistance: +1
 6321	pearl	0		
 6322	wobbly sea lace	0		
@@ -6265,8 +6265,8 @@
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
 6371	artisanal ghostly can of the cheapest beer	4	EPIC	
-6372	practically non-alcoholic acceptable special shaking bottle of fruity &quot;wine&quot;	1	good	Effect: "Ass Over Teakettle", Effect Duration: 15
-6373	drinkable watered-down single swig of vodka	2	good	
+6372	acceptable practically non-alcoholic special shaking bottle of fruity &quot;wine&quot;	1	good	Effect: "Ass Over Teakettle", Effect Duration: 15
+6373	watered-down drinkable single swig of vodka	2	good	
 6374	blinking angry inch	0		
 6375	extremely unsafe testy toolbox	0		Weapon Damage Percent: +100
 6376	Jick-o-User	0		
@@ -6314,7 +6314,7 @@
 6419	irradiated polarized moth dust	0		Effect: "Demonic Taint", Effect Duration: 45
 6420	enhanced glob of spoiled mayo	0		Effect: "Void Between the Stars", Effect Duration: 18
 6421	tonic djinn	0		
-6422	decent big vampire chowder	5	good	
+6422	big decent vampire chowder	5	good	
 6423	ghostly Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6338,7 +6338,7 @@
 6443	tumbling nasty fortified Helps-You-Sleep	0		Damage Absorption: +60, Stench Damage: +5, Single Equip
 6444	ruddy stiffened smartaleck's Quiets-Your-Steps	0		Moxie Percent: +30, Damage Reduction: 1, Maximum HP Percent: +40, Single Equip
 6445	spinning fireproof beefcake's Protects-Your-Junk	0		Muscle: +25, Hot Resistance: +3, Single Equip
-6446	tolerable irresponsibly strong upside-down Gets-You-Drunk	7	good	
+6446	irresponsibly strong tolerable upside-down Gets-You-Drunk	7	good	
 6447	huge auspicious Temple Grandin's steel-toed Great Wolf's headband	0		Damage Reduction: 9, Familiar Weight: +7, Item Drop: +10, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	executive horrifying Great Wolf's left paw of the detective	0		Spooky Damage: +25, Item Drop: +20, Meat Drop: +40, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	Usain Bolt's Great Wolf's right paw of courage of temperance	0		Spooky Resistance: +3, Sleaze Resistance: +5, Initiative: +80, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6367,7 +6367,7 @@
 6472	Drunkula's bell	0		
 6473	foul-smelling scorching sinister Drunkula's ring of haze	0		Spell Damage: +10, Hot Damage: +25, Stench Damage: +10, Avoid Attack: 1, Single Equip
 6474	gravedigger's Drunkula's wineglass	0		Spooky Damage: +10
-6475	high-proof mediocre wobbly bottle of Bloodweiser	8	decent	
+6475	mediocre high-proof wobbly bottle of Bloodweiser	8	decent	
 6476	aromatic mansplainer's stiffened Unkillable Skeleton's skullcap	0		Damage Reduction: 1, Monster Level: +15, Stench Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	bouncing chaotic rock-hard Socratic Unkillable Skeleton's breastplate	0		Experience (Mysticality): +1, Damage Reduction: 5, Spell Critical Percent: +10, Class: "Turtle Tamer"
 6478	spinning censurious fortified brawny Unkillable Skeleton's shinguards	0		Muscle Percent: +20, Damage Absorption: +60, Sleaze Resistance: +3, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6383,14 +6383,14 @@
 6488	adequate Dreadsylvanian shepherd's pie	3	good	
 6489	music box parts	0		
 6490	ghostly unwound mechanical songbird	0		
-6491	blurry pulsating cyan tailfeathers	0		Familiar Weight: +5
+6491	pulsating blurry cyan tailfeathers	0		Familiar Weight: +5
 6492	wax banana	0		
 6493	blurry complicated lock impression	0		
 6494	replica key	0		
 6495	upside-down Dreadsylvania Auditor's badge of the overflowing toilet	0		Stench Spell Damage: +50, Kruegerand Drop: 5, Single Equip
 6496	green blood kiwi	0		
 6497	eau de mort	0		
-6498	special perfectly mixed spirit-forward bloody kiwitini	5	EPIC	Effect: "Devil Inside", Effect Duration: 45
+6498	spirit-forward perfectly mixed special bloody kiwitini	5	EPIC	Effect: "Devil Inside", Effect Duration: 45
 6499	narrow moon-amber	0		
 6500	polished moon-amber	0		
 6501	pulsating wizardly moon-amber necklace of wisdom of the boozehound	0		Mysticality: 40, Booze Drop: +100, Single Equip
@@ -6408,7 +6408,7 @@
 6513	double-paned warm fur	0		Cold Resistance: +5
 6514	snowstick of doom	0		Spooky Spell Damage: +50
 6515	skewed eerie fetish of the pedagogue	0		Experience: +3, Single Equip
-6516	special aged watered-down bouncing stinkwater	2	awesome	Effect: "Steroid Boost", Effect Duration: 30
+6516	watered-down special aged bouncing stinkwater	2	awesome	Effect: "Steroid Boost", Effect Duration: 30
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	rotten accidental mutton	3	crappy	
 6519	mirror Sinatra's drafty drawers of Tarzan	0		Experience (Muscle): +3, Experience (Moxie): +5, Familiar Effect: "1.5xVolley"
@@ -6421,7 +6421,7 @@
 6526	blinking wool chilly bag of unfinished business	0		Cold Damage: +5, Cold Resistance: +1
 6527	electrified supercool transparent pants	0		Moxie Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of the overflowing toilet	0		Stench Spell Damage: +50
-6529	artisanal practically non-alcoholic Thriller Ice	1	super ultra mega turbo EPIC	
+6529	practically non-alcoholic artisanal Thriller Ice	1	super ultra mega turbo EPIC	
 6530	skewed yellow up-at-dawn grandfather watch	0		Adventures: +5, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	razor-sharp spyglass of chilblains	0		Weapon Damage Percent: +25, Cold Damage: +25
@@ -6441,7 +6441,7 @@
 6547	Thwaitgold Goliath beetle statuette	0		
 6548	mirror cooling iron helmet	0		
 6549	blurry cooling iron breastplate	0		
-6550	cyan bouncing mirror cooling iron greaves	0		
+6550	mirror bouncing cyan cooling iron greaves	0		
 6551	mirror hot cluster	0		
 6552	cluster	0		
 6553	cluster	0		
@@ -6455,13 +6455,13 @@
 6561	teal adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	ghostly supercool hand of Mr. Cards	0		Moxie Percent: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	enchanted adequate small spinning Dreadsylvanian hot pocket	2	good	Effect: "Go-Gone", Effect Duration: 25
-6565	bland blinking squat Dreadsylvanian pocket	3	decent	
-6566	snack-sized normal Dreadsylvanian pocket	2	good	
+6564	adequate small enchanted spinning Dreadsylvanian hot pocket	2	good	Effect: "Go-Gone", Effect Duration: 25
+6565	bland squat blinking Dreadsylvanian pocket	3	decent	
+6566	normal snack-sized Dreadsylvanian pocket	2	good	
 6567	bland low-calorie Dreadsylvanian stink pocket	1	decent	
-6568	special tiny normal Dreadsylvanian sleaze pocket	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10
+6568	normal special tiny Dreadsylvanian sleaze pocket	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10
 6569	watered-down bad yellow Dreadsylvanian hot toddy	2	decent	
-6570	special artisanal shaking Dreadsylvanian cold-fashioned	4	super ultra mega EPIC	Effect: "Happy Salamander", Effect Duration: 10
+6570	artisanal special shaking Dreadsylvanian cold-fashioned	4	super ultra mega EPIC	Effect: "Happy Salamander", Effect Duration: 10
 6571	lousy fancy Dreadsylvanian grimlet	3	decent	Effect: "Disco State of Mind", Effect Duration: 25
 6572	bad practically non-alcoholic Dreadsylvanian dank and stormy	1	decent	
 6573	delicious Dreadsylvanian slithery nipple	3	awesome	
@@ -6490,24 +6490,24 @@
 6596	clockwork egg	0		
 6597	tumbling clockwork birdhouse	0		
 6598	clockwork disc	0		
-6599	twirling purple clockwork hand	0		
+6599	purple twirling clockwork hand	0		
 6600	bouncing clockwork hand	0		
 6601	spinning clockwork numeral I	0		
 6602	blinking clockwork numeral II	0		
-6603	fuchsia tumbling clockwork numeral III	0		
+6603	tumbling fuchsia clockwork numeral III	0		
 6604	clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	pulsating clockwork numeral VI	0		
 6607	jittery clockwork numeral VII	0		
 6608	twirling clockwork numeral VIII	0		
 6609	squat spinning clockwork numeral IX	0		
-6610	squat ghostly clockwork numeral X	0		
+6610	ghostly squat clockwork numeral X	0		
 6611	blinking clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	tolerable watered-down lime green Cold One	2	???	
-6616	bland snack-sized spaghetti breakfast	2	???	
+6616	snack-sized bland spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	wobbly folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	tolerable practically non-alcoholic lime green stepmom's booze	1	good	
 6653	surgical tape	0		
 6654	band T-shirt of Gandalf	0		Spell Critical Percent: +20
-6655	lousy weak narrow fountain 'soda'	2	decent	
+6655	weak lousy narrow fountain 'soda'	2	decent	
 6656	yellow pulsating illegal firecracker	0		
 6657	coward's baleful pickelhaube	0		Spell Damage: +25, Monster Level: -20, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	cold-filtered hair oil	0		Effect: "Smoking like a Bandit", Effect Duration: 41
@@ -6570,7 +6570,7 @@
 6678	miser's Yearbook Club Camera	0		Meat Drop: +10, Conditional Skill (Equipped): "Blinding Flash"
 6679	forbidden machete	0		Spell Damage Percent: +50
 6680	smooth triple-distilled Cursed Punch	10	awesome	
-6681	hand-crafted boozy Bowl of Scorpions	5	EPIC	
+6681	boozy hand-crafted Bowl of Scorpions	5	EPIC	
 6682	acceptable blue blinking Fog Murderer	3	good	
 6683	book of matches	0		
 6684	wobbly ghostly blinking hale surgical mask	0		Maximum HP: +20, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	wobbly bowler	0		
 6703	fancy bouncing imitation White Russian	1	awesome	Effect: "Human-Hobo Hybrid", Effect Duration: 30
 6704	tumbling ruddy weightlifter's short-handled mop	0		Muscle: +15, Maximum HP Percent: +40
-6705	bite-sized normal maroon jungle floor wax	1	good	
+6705	normal bite-sized maroon jungle floor wax	1	good	
 6706	fuchsia smirking shrunken head	0		
 6707	aerosolized colorful toad	0		Effect: "Joyful Resolve", Effect Duration: 65
 6708	bouncing crude voodoo doll	0		
@@ -6646,16 +6646,16 @@
 6754	beer bottle	0		
 6755	shaking beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	distilled hand-crafted tumbling can of Br&uuml;talbr&auml;u	5	EPIC	Last Available: "2013-09"
-6758	extra-dry perfectly mixed pulsating can of Drooling Monk	5	EPIC	Last Available: "2013-09"
+6757	hand-crafted distilled tumbling can of Br&uuml;talbr&auml;u	5	EPIC	Last Available: "2013-09"
+6758	perfectly mixed extra-dry pulsating can of Drooling Monk	5	EPIC	Last Available: "2013-09"
 6759	bad enchanted can of Impetuous Scofflaw	4	decent	Effect: "Innately Strong", Effect Duration: 40, Last Available: "2013-09"
 6760	perfectly mixed practically non-alcoholic purple bottle of Old Pugilist	1	super ultra mega turbo EPIC	Last Available: "2013-09"
-6761	high-proof drinkable fancy tumbling bottle of Professor Beer	10	good	Effect: "Army of One", Effect Duration: 10, Last Available: "2013-09"
+6761	fancy drinkable high-proof tumbling bottle of Professor Beer	10	good	Effect: "Army of One", Effect Duration: 10, Last Available: "2013-09"
 6762	mediocre bottle of Rapier Witbier	3	decent	Last Available: "2013-09"
 6763	smooth bottle of Race Car Red	3	awesome	Last Available: "2013-09"
 6764	strong lousy bottle of Greedy Dog	5	decent	Last Available: "2013-09"
-6765	practically non-alcoholic perfectly mixed bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Last Available: "2013-09"
-6766	green spinning tin beer can	0		
+6765	perfectly mixed practically non-alcoholic bottle of Lambada Lambic	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6766	spinning green tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	crappy	Last Available: "2013-09"
 6769	wholesome arcane researcher's tin tam of the wise owl	0		Mysticality: +20, Experience Percent (Mysticality): +10, Maximum HP Percent: +10, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
@@ -6668,13 +6668,13 @@
 6776	super-dry foetid seal tear	0		Effect: "Thunderspell", Effect Duration: 34
 6777	quantum frozen narrow pulsating seal sweat	0		Effect: "Sweet and Yellow", Effect Duration: 50
 6778	ionized alkaline huge boiling seal blood	0		Effect: "Stickler for Promptness", Effect Duration: 31
-6779	tumbling ghostly crystalline seal eye	0		Single Equip
+6779	ghostly tumbling crystalline seal eye	0		Single Equip
 6780	frosty studded sealhide shield of Flo-Jo	0		Cold Spell Damage: +10, Initiative: +100, Damage Reduction: 7
 6781	reassuring Van der Graaf scabrous seal epaulets	0		Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 6782	abyssal battle plans	0		
 6783	gray bouncing Oprah's hardened studded seal medal	0		Damage Absorption: +80, Damage Reduction: 3, Maximum MP Percent: +50
 6784	deanimated reanimator's coffin	0		Free Pull
-6785	olive twirling flask of embalming fluid	0		
+6785	twirling olive flask of embalming fluid	0		
 6788	blank diary	0		
 6789	squat boot knife	0		
 6790	broken beer bottle	0		
@@ -6691,11 +6691,11 @@
 6802	alkaline colloidal colloidal disco horoscope (Virgo)	0		Effect: "Shoesauce", Effect Duration: 66
 6803	improved disco horoscope (Libra)	0		Effect: "Texas Elegance", Effect Duration: 28
 6804	vacuum-sealed oxidized electrified maroon disco horoscope (Scorpio)	0		Effect: "Permanent Halloween", Effect Duration: 65
-6805	quadruple-diffused warmed wobbly huge disco horoscope (Sagittarius)	0		Effect: "Crusty Head", Effect Duration: 47
+6805	quadruple-diffused warmed huge wobbly disco horoscope (Sagittarius)	0		Effect: "Crusty Head", Effect Duration: 47
 6806	extra-vacuum-sealed purple disco horoscope (Capricorn)	0		Effect: "You Drank Fish Wine", Effect Duration: 37
 6807	sharpshooter's The Sagittarian's leisure pants of the businessman	0		Critical Hit Percent: +10, Meat Drop: +50, Familiar Effect: "atk, cap 18"
 6808	spinning toy accordion	0		Song Duration: 5
-6809	yellow twirling accordion	0		Song Duration: 10
+6809	twirling yellow accordion	0		Song Duration: 10
 6810	beer-battered accordion of mayonnaise	0		Sleaze Spell Damage: +50, Class: "Accordion Thief", Song Duration: 6
 6811	bouncing scandalous baritone accordion	0		Sleaze Damage: +5, Class: "Accordion Thief", Song Duration: 7
 6812	groovy mama's squeezebox	0		Moxie Percent: +10, Class: "Accordion Thief", Song Duration: 8
@@ -6726,7 +6726,7 @@
 6837	magnetized extra-irradiated Swizzler	0		Effect: "Always be Collecting", Effect Duration: 21
 6838	magnetized oxidized shaking ghostly Bugbearclaw Donut	0		Effect: "Sweet Tooth", Effect Duration: 34
 6839	modified jittery jam	0		Effect: "Simulation Stimulation", Effect Duration: 23
-6840	unsweetened quadruple-polymerized colloidal upside-down jittery Whenchamacallit bar	0		Effect: "Muddled", Effect Duration: 31
+6840	unsweetened quadruple-polymerized colloidal jittery upside-down Whenchamacallit bar	0		Effect: "Muddled", Effect Duration: 31
 6841	electrified denatured blue 8-bit banana	0		Effect: "Helvella Health", Effect Duration: 69
 6842	non-enhanced nitrogenated vial of blood simple syrup	0		Effect: "Inappropriate Spirit", Effect Duration: 20
 6843	double-tarnished pressed blurry bone bons	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 43
@@ -6737,7 +6737,7 @@
 6848	nippy security flashlight	0		Cold Damage: +10
 6849	tarnished Effermint&trade; tablets	0		Effect: "Jacked In", Effect Duration: 33
 6850	fireproof mansplainer's occult sturdy cane	0		Spell Damage Percent: +25, Monster Level: +15, Hot Resistance: +3
-6851	tumbling blinking huge bowl of candy	0		
+6851	blinking tumbling huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	yellow squat desert sightseeing pamphlet	0		
@@ -6746,11 +6746,11 @@
 6857	Rosewater's Cajun accordion	0		Mysticality Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	lightning-fast quirky accordion	0		Initiative: +40, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	zippy nasty Skipper's accordion	0		Stench Damage: +5, Initiative: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	wool smelly savvy sage Pantsgiving	0		Mysticality Percent: 30, Stench Spell Damage: +10, Cold Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6860	wool smelly savvy sage Pantsgiving	0		Mysticality Percent: 30, Stench Spell Damage: +10, Cold Resistance: +1, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	half-sized moldy can of sardines	2	crappy	Last Available: "2013-11"
 6862	big flavorless high-calorie sugar substitute	5	decent	Last Available: "2013-11"
 6863	moldy pulsating pat of butter	3	crappy	Last Available: "2013-11"
-6864	stale big dinner roll	5	decent	Last Available: "2013-11"
+6864	big stale dinner roll	5	decent	Last Available: "2013-11"
 6865	decent mashed potatoes	3	good	Last Available: "2013-11"
 6866	diet delicious huge whole turkey leg	1	awesome	Last Available: "2013-11"
 6867	flavorless deviled egg	3	decent	Last Available: "2013-11"
@@ -6791,7 +6791,7 @@
 6902	flask flops of James Dean of terror	0		Experience (Moxie): +3, Spooky Spell Damage: +10, Single Equip
 6903	unsweetened altered jittery wobbly nuts	0		Effect: "Crimbo Nostalgia", Effect Duration: 38, Last Available: "2013-12"
 6904	dry extra-concentrated bolts	0		Effect: "Shamboozled", Effect Duration: 59, Last Available: "2013-12"
-6905	stale thick narrow gingerbread robot	5	decent	Last Available: "2013-12"
+6905	thick stale narrow gingerbread robot	5	decent	Last Available: "2013-12"
 6906	normal small petit 4.1	2	good	Last Available: "2013-12"
 6907	spoiled nut-shaped Crimbo cookie	4	crappy	Last Available: "2023-06"
 6908	olive energetic plastic GORM-8	0		Maximum MP Percent: +20, Last Available: "2013-12"
@@ -6808,11 +6808,11 @@
 6919	liquefied upside-down warbear bearserker potion	0		Effect: "Mistified", Effect Duration: 68, Last Available: "2013-12"
 6920	liquefied wobbly warbear liquid overcoat	0		Effect: "Nightstalkin'", Effect Duration: 28, Last Available: "2013-12"
 6921	flavorless spinning warbear feasting bread	3	decent	Last Available: "2013-12"
-6922	decent small warbear warrior bread	2	good	Last Available: "2013-12"
+6922	small decent warbear warrior bread	2	good	Last Available: "2013-12"
 6923	bland warbear thermoregulator bread	4	decent	Last Available: "2013-12"
 6924	drinkable warbear feasting mead	4	good	Last Available: "2013-12"
 6925	acceptable warbear bearserker mead	3	good	Last Available: "2013-12"
-6926	strong tolerable warbear blizzard mead	5	good	Last Available: "2013-12"
+6926	tolerable strong warbear blizzard mead	5	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
 6928	Jeselnik's nippy warbear plain fedora of terror	0		Cold Damage: +10, Spooky Spell Damage: +10, Sleaze Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	ghostly Van der Graaf warbear feathered fedora	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6847,13 +6847,13 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	warbear foil hat of the pedagogue	0		Experience: +3, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	tumbling tumbling padded wizardly warbear oil pan	0		Mysticality: +25, Damage Absorption: +20, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	tumbling tumbling padded wizardly warbear oil pan	0		Mysticality: +25, Damage Absorption: +20, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	blinking thinker's warbear exhaust manifold	0		Mysticality: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	olive wobbly warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	upside-down warbear auto-anvil	0		Last Available: "2013-12"
 6966	warbear induction oven	0		Last Available: "2013-12"
-6967	mirror yellow warbear chemistry lab	0		Last Available: "2013-12"
+6967	yellow mirror warbear chemistry lab	0		Last Available: "2013-12"
 6968	warbear officer requisition box	0		Last Available: "2013-12"
 6969	spinning warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 6970	warbear drone assembler	0		Last Available: "2013-12"
@@ -6896,9 +6896,9 @@
 7007	low-calorie moldy Every Day is Like This Sundae	1	crappy	Last Available: "2013-12"
 7008	delicious Miserable Pie	3	awesome	Last Available: "2013-12"
 7009	decent half-sized This Charming Flan	2	good	Last Available: "2013-12"
-7010	watered-down aged Irish Coffee, English Heart	2	awesome	Last Available: "2013-12"
-7011	bad extra-dry ghostly Strikes Again Bigmouth	5	decent	Last Available: "2013-12"
-7012	smooth irresponsibly strong Paint A Vulgar Pitcher	10	awesome	Last Available: "2013-12"
+7010	aged watered-down Irish Coffee, English Heart	2	awesome	Last Available: "2013-12"
+7011	extra-dry bad ghostly Strikes Again Bigmouth	5	decent	Last Available: "2013-12"
+7012	irresponsibly strong smooth Paint A Vulgar Pitcher	10	awesome	Last Available: "2013-12"
 7013	bouncing Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	tumbling Handsome Devil	0		Last Available: "2013-12"
@@ -6918,8 +6918,8 @@
 7029	scandalous smartaleck's Shakespeare's Sister's Accordion of courage	0		Moxie Percent: +30, Sleaze Damage: +5, Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	boxer's third-hand lantern	0		Muscle Percent: +10
 7031	teal loose purse strings	0		
-7032	flavorless miniature skewed wobbly pickled egg	2	decent	
-7033	wobbly blurry cup of lukewarm tea	1	good	
+7032	flavorless miniature wobbly skewed pickled egg	2	decent	
+7033	blurry wobbly cup of lukewarm tea	1	good	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	tumbling warbear box	0		Last Available: "2013-12"
 7036	upside-down pulsating warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6932,11 +6932,11 @@
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	liquefied magnetized glass slipper	0		Effect: "Sugary World View", Effect Duration: 61, Last Available: "2014-12"
 7045	distilled antimatter wad	1	EPIC	Last Available: "2013-12"
-7046	liquefied magnetized mirror blinking warbear superpotion	0		Effect: "Empathy", Effect Duration: 45, Last Available: "2013-12"
+7046	liquefied magnetized blinking mirror warbear superpotion	0		Effect: "Empathy", Effect Duration: 45, Last Available: "2013-12"
 7047	nitrogenated corrupted shaking warbear liquid lasers	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 67, Last Available: "2013-12"
-7048	Vulcanized ionized shaking blinking warbear rejuvenation potion	0		Effect: "Simulation Stimulation", Effect Duration: 43, Last Available: "2013-12"
+7048	Vulcanized ionized blinking shaking warbear rejuvenation potion	0		Effect: "Simulation Stimulation", Effect Duration: 43, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	moldy big pulsating warbear gyro	5	crappy	Last Available: "2013-12"
+7050	big moldy pulsating warbear gyro	5	crappy	Last Available: "2013-12"
 7051	extra-tarnished upside-down recording of Rolando's Rondo of Resisto	0		Effect: "Cake Caked", Effect Duration: 26, Last Available: "2013-12"
 7052	blinking warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	wobbly warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6957,14 +6957,14 @@
 7068	anodized denatured narrow single of Donho's Bubbly Ballad	0		Effect: "Memories of Puppy Love", Effect Duration: 21
 7069	pulsating Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	thick stale snow berries	5	decent	Last Available: "2014-01"
+7071	stale thick snow berries	5	decent	Last Available: "2014-01"
 7072	moldy low-calorie ice harvest	1	crappy	Last Available: "2014-01"
 7073	modified irradiated frost flower	0		Effect: "Gemini Rising", Effect Duration: 19, Last Available: "2014-01"
 7074	quadruple-corrupted extra-chilled improved bouncing snow cleats	0		Effect: "One Foot Heavier", Effect Duration: 62, Last Available: "2014-01"
 7075	flattened pickled liquid ice pack	0		Effect: "Holiday Disappointment", Effect Duration: 57, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	adequate low-calorie pulsating gray snow crab	1	good	Last Available: "2014-01"
-7078	distilled lousy ghostly Ice Island Long Tea	5	decent	Last Available: "2014-01"
+7077	low-calorie adequate gray pulsating snow crab	1	good	Last Available: "2014-01"
+7078	lousy distilled ghostly Ice Island Long Tea	5	decent	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6989,12 +6989,12 @@
 7100	wobbly Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	compressed upside-down Five Second Energy&trade;	1		Effect: "Cruisin' for a Bruisin'", Effect Duration: 35, Last Available: "2014-12"
 7102	huge pixie axie	0		Last Available: "2014-12"
-7103	galvanized super-dry blinking squat powder	0		Effect: "Hella Tough", Effect Duration: 48, Last Available: "2014-12"
+7103	galvanized super-dry squat blinking powder	0		Effect: "Hella Tough", Effect Duration: 48, Last Available: "2014-12"
 7104	ghostly chilly licorice whip	0		Cold Damage: +5, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	watered-down drinkable snakebite	2	good	Last Available: "2014-12"
 7107	skewed Jeselnik's ribald candy stick	0		Sleaze Damage: 35, Last Available: "2014-12"
-7108	super-sized fancy rotten pecan	5	crappy	Effect: "Pasta Oneness", Effect Duration: 50, Last Available: "2014-12"
+7108	fancy super-sized rotten pecan	5	crappy	Effect: "Pasta Oneness", Effect Duration: 50, Last Available: "2014-12"
 7109	stale blurry pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	bland spinning candy mountain oyster	3	decent	Last Available: "2014-12"
@@ -7015,13 +7015,13 @@
 7126	non-quantum alkaline small gummi fin	0		Effect: "This Is Where You're a Viking", Effect Duration: 16, Last Available: "2014-12"
 7127	maroon scandalous chocolate cow bone	0		Sleaze Damage: +5, Last Available: "2014-12"
 7128	polarized adjusted gummi fang	0		Effect: "You Know Where to Go", Effect Duration: 22, Last Available: "2014-12"
-7129	rotten massive fancy leftover canap&eacute;s	7	crappy	Effect: "Shawarma Initiative", Effect Duration: 35, Last Available: "2014-12"
+7129	massive rotten fancy leftover canap&eacute;s	7	crappy	Effect: "Shawarma Initiative", Effect Duration: 35, Last Available: "2014-12"
 7130	watered-down acceptable yellow magnum of champagne	2	good	Last Available: "2014-12"
 7131	double-paned Van der Graaf savvy cow creamer	0		Mysticality Percent: +20, Cold Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7132	adjusted Outer Wolf&trade; cologne	0		Effect: "Human-Elemental Hybrid", Effect Duration: 31, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	lard-coated sage wolf whistle	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	big adequate witch's bread	5	good	Last Available: "2014-12"
+7134	lard-coated sage wolf whistle	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7135	adequate big witch's bread	5	good	Last Available: "2014-12"
 7136	super-pickled witch's brew	0		Effect: "Meadulla Oblongota", Effect Duration: 47, Last Available: "2014-12"
 7137	bouncing scorching slick witch's bra of the blizzard	0		Moxie: +10, Cold Spell Damage: +25, Hot Damage: +25, Last Available: "2014-12"
 7138	delicious mid-level medieval mead	3	awesome	Last Available: "2014-12"
@@ -7031,8 +7031,8 @@
 7142	cold-filtered hare brush	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 43, Last Available: "2014-12"
 7143	huge greasy ribald hare pin	0		Sleaze Damage: +10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	flavorless special small cinnamon cannoli	2	decent	Effect: "Abyssal Blood", Effect Duration: 25, Last Available: "2014-12"
-7146	mediocre practically non-alcoholic expensive champagne	1	decent	Last Available: "2014-12"
+7145	small special flavorless cinnamon cannoli	2	decent	Effect: "Abyssal Blood", Effect Duration: 25, Last Available: "2014-12"
+7146	practically non-alcoholic mediocre expensive champagne	1	decent	Last Available: "2014-12"
 7147	polarized Vulcanized squat polo trophy	0		Effect: "Briny Blood", Effect Duration: 58, Last Available: "2014-12"
 7148	teal oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7044,11 +7044,11 @@
 7155	parchment	0		Last Available: "2014-12"
 7156	blurry glass	0		Last Available: "2014-12"
 7157	family-friendly fireproof personal trainer's fire hose	0		Experience Percent (Muscle): +10, Hot Resistance: +3, Sleaze Resistance: +1, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	bland diet ghostly fireman's lunch	1	decent	Last Available: "2014-12"
+7158	diet bland ghostly fireman's lunch	1	decent	Last Available: "2014-12"
 7159	spinning Jeselnik's baleful Newton's plain paper hat	0		Experience (Mysticality): +3, Spell Damage: +25, Sleaze Damage: +25, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	flavorless narrow ice cream sandwich	4	decent	Last Available: "2014-12"
 7161	shaking up-at-dawn studded &quot;honey&quot; dipper of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Adventures: +5, Last Available: "2014-12"
-7162	bite-sized rotten plumber's lunch	1	crappy	Last Available: "2014-12"
+7162	rotten bite-sized plumber's lunch	1	crappy	Last Available: "2014-12"
 7163	smelly hardy skull gearshift knob of the empath	0		Maximum HP: +50, Familiar Weight: +5, Stench Spell Damage: +10, Last Available: "2014-12"
 7164	decent nachos of the night	4	good	Last Available: "2014-12"
 7165	wobbly twirling Lo Pan's Herculean Sketcherz&trade; of horror	0		Experience (Muscle): +1, Spell Critical Percent: +30, Spooky Spell Damage: +25, Last Available: "2014-12"
@@ -7057,10 +7057,10 @@
 7168	concentrated dry blurry wall	0		Effect: "Hot Blooded", Effect Duration: 55, Last Available: "2014-12"
 7169	bad high-proof tankard of ale	8	decent	Last Available: "2014-12"
 7170	irradiated scroll case	0		Effect: "Greedy Resolve", Effect Duration: 61, Last Available: "2014-12"
-7171	irradiated adjusted green squat jug of &quot;wine&quot;	0		Effect: "Gemini Rising", Effect Duration: 15, Last Available: "2014-12"
+7171	irradiated adjusted squat green jug of &quot;wine&quot;	0		Effect: "Gemini Rising", Effect Duration: 15, Last Available: "2014-12"
 7172	bouncing juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	bite-sized decent enchanted fuchsia humble pie	1	good	Effect: "Fustulent", Effect Duration: 5, Last Available: "2014-12"
+7174	decent bite-sized enchanted fuchsia humble pie	1	good	Effect: "Fustulent", Effect Duration: 5, Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	quadruple-polarized squat crappy waiter disguise	0		Effect: "Empty Inside", Effect Duration: 52
@@ -7073,7 +7073,7 @@
 7184	The Shield of Brook	0		
 7185	shaking Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	fancy lousy irresponsibly strong unnamed cocktail	10	decent	Effect: "Protection from Bad Stuff", Effect Duration: 25
+7187	lousy fancy irresponsibly strong unnamed cocktail	10	decent	Effect: "Protection from Bad Stuff", Effect Duration: 25
 7188	handful of tips	0		
 7189	smooth unrequired jacket	0		Moxie: +15
 7190	nippy tommy gun	0		Cold Damage: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7101,22 +7101,22 @@
 7212	Jefferson wings of the ox	0		Muscle: +20
 7213	fleetwood macaroni	0		
 7214	ghostly cheesy eagle sauce	0		
-7215	jumbo yummy fleetwood mac 'n' cheese	5	awesome	
+7215	yummy jumbo fleetwood mac 'n' cheese	5	awesome	
 7216	lynyrd skin	0		
 7217	wobbly lynyrdskin cap of the empath	0		Familiar Weight: +5, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	huge nippy lynyrdskin tunic	0		Cold Damage: +10
 7219	jittery lynyrdskin breeches of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	shaking cigarette lighter	0		
 7221	priceless diamond	0		
-7222	mediocre strong shaking Flamin' Whatshisname	5	decent	
+7222	strong mediocre shaking Flamin' Whatshisname	5	decent	
 7223	corrupted nitrogenated lynyrd musk	0		Effect: "Sugar Smacks", Effect Duration: 53
 7224	veiny experienced Kashmir sweater	0		Experience: +2, Maximum HP: +10
-7225	normal bite-sized special custard pie	1	good	Effect: "Mo' Hobo", Effect Duration: 20
+7225	special bite-sized normal custard pie	1	good	Effect: "Mo' Hobo", Effect Duration: 20
 7226	tea for one	1	good	
 7227	weak bad bottle of Evermore	2	decent	
 7228	box	0		
 7229	acceptable wine	3	good	
-7230	delicious practically non-alcoholic rum	1	awesome	
+7230	practically non-alcoholic delicious rum	1	awesome	
 7231	bad Murderer's Punch	4	decent	
 7232	decent velvet cake	3	good	
 7233	deionized enhanced squat letter	0		Effect: "Musky", Effect Duration: 17
@@ -7130,14 +7130,14 @@
 7241	frosty shoe of the empath	0		Familiar Weight: +5, Cold Spell Damage: +10, Single Equip
 7242	button	0		
 7243	button	0		
-7244	wet upside-down ghostly blood cells	0		Effect: "Broberry Brotality", Effect Duration: 45
+7244	wet ghostly upside-down blood cells	0		Effect: "Broberry Brotality", Effect Duration: 45
 7245	oxidized twirling eye	0		Effect: "Infernal Thirst", Effect Duration: 58
 7246	glark cable	0		
 7247	boxer's Red Fox glove of bravery	0		Muscle Percent: +10, Spooky Resistance: +5, Attacks Can't Miss, Single Equip
 7248	irradiated improved tumbling foxglove	0		Effect: "Alchemical, Brother", Effect Duration: 23
 7249	Thwaitgold dragonfly statuette	0		
 7250	greasy quilted Sneaky Pete's jacket of the brute of mayonnaise	0		Muscle Percent: +30, Damage Absorption: +40, Sleaze Spell Damage: 60, Softcore Only, Free Pull, Last Available: "2014-03"
-7251	mirror yellow jug of Sneaky Pete's Mojo	0		Free Pull
+7251	yellow mirror jug of Sneaky Pete's Mojo	0		Free Pull
 7252	fuchsia shot of Sneaky Pete's Mojo	0		Free Pull
 7253	red Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
@@ -7151,7 +7151,7 @@
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
 7264	photograph of a nugget	0		
-7265	gray jittery photograph of an ostrich egg	0		
+7265	jittery gray photograph of an ostrich egg	0		
 7266	disposable instant camera	0		
 7267	squat mansplainer's supercharged grievous Sneaky Pete's jacket (collar popped) of Gandalf	0		Weapon Damage Percent: +50, Maximum MP Percent: +30, Spell Critical Percent: +20, Monster Level: +15, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
@@ -7176,7 +7176,7 @@
 7287	forbidden deadly Gary Claybender's Time Screwer	0		Weapon Damage: +5, Spell Damage Percent: +50, Single Equip, Lasts Until Rollover
 7288	asbestos-lined dog trainer's Space Tourist palmdoctor	0		Experience (familiar): +1, Hot Resistance: +5, Lasts Until Rollover
 7289	asbestos-lined frightening Annie Oakley's amok putter	0		Critical Hit Percent: +20, Spooky Damage: +5, Hot Resistance: +5
-7290	small stale amok pudding	2	decent	
+7290	stale small amok pudding	2	decent	
 7291	wobbly deactivated putty buddy	0		
 7292	putty coat	0		Familiar Weight: +5
 7293	chilled can of V-11	0		Effect: "Marco Polarity", Effect Duration: 62, Last Available: "2014-03"
@@ -7210,7 +7210,7 @@
 7321	inspector's Stephen's lab coat of wisdom	0		Mysticality: +15, Item Drop: +15
 7322	super-chilled unsweetened lime green Stephen's secret formula	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 34
 7323	Jack Frost's Tesla Jacob's rung	0		Cold Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
-7324	dried mirror upside-down skewed battery	1		
+7324	dried mirror skewed upside-down battery	1		
 7325	special perfectly mixed snakebite	3	EPIC	Effect: "Remaining Alive", Effect Duration: 35
 7326	nippy rubber ribcage of the glutton	0		Cold Damage: +10, Food Drop: +100, Damage Reduction: 7
 7327	distilled jittery synthetic marrow	1		
@@ -7229,7 +7229,7 @@
 7340	huge groovy moose antlers	0		Moxie Percent: +10, Familiar Effect: "atk, 1xLep, cap 27"
 7341	magnetized tumbling moose thought	0		Effect: "Wet Jaw", Effect Duration: 59
 7342	fancy adequate moose chocolate	4	good	Effect: "Sleazy Jellied", Effect Duration: 35
-7343	acceptable distilled painting of a glass of wine	5	good	
+7343	distilled acceptable painting of a glass of wine	5	good	
 7344	oil painting of yourself	0		
 7345	blinking ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7252,7 +7252,7 @@
 7363	unsweetened liquefied bouncing bloodstain stick	0		Effect: "Pasta Oneness", Effect Duration: 59
 7364	narrow fabric softener	0		
 7365	deionized activated fabric hardener	0		Effect: "Disco State of Mind", Effect Duration: 33
-7366	triple-distilled tolerable yellow bottle of laundry sherry	10	good	
+7366	tolerable triple-distilled yellow bottle of laundry sherry	10	good	
 7367	diffused nitrogenated pickled olive industrial strength starch	0		Effect: "Stop the Presses!", Effect Duration: 67, Wiki Name: "industrial strength starch"
 7368	normal extra-flat panini	3	good	
 7369	double-nitrogenated mangled finger	0		Effect: "Cold Blooded", Effect Duration: 63
@@ -7261,7 +7261,7 @@
 7372	moldy thick tumbling pie man was not meant to eat	5	crappy	
 7373	teal sommelier's towel of terror	0		Spooky Spell Damage: +10
 7374	tarnished tastevin of the boozehound	0		Booze Drop: +100, Single Equip
-7375	half-sized moldy actual tapas	2	crappy	
+7375	moldy half-sized actual tapas	2	crappy	
 7376	ghast iron ingot	0		
 7377	padded arcane researcher's ghast iron cleaver	0		Experience Percent (Mysticality): +10, Damage Absorption: +20
 7378	stylish ghast iron Garibaldi of James Dean	0		Moxie: +25, Experience (Moxie): +3, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7283,14 +7283,14 @@
 7394	flattened oxidized Gene Tonic: Fish	0		Effect: "Witch's Brood", Effect Duration: 29, Last Available: "2014-04"
 7395	improved chilled Gene Tonic: Goblin	0		Effect: "Fortunate Resolve", Effect Duration: 21, Last Available: "2014-04"
 7396	warmed vacuum-sealed Gene Tonic: Pirate	0		Effect: "Deadly Flashing Blade", Effect Duration: 26, Last Available: "2014-04"
-7397	frozen red upside-down Gene Tonic: Plant	0		Effect: "Sweet, Nuts", Effect Duration: 61, Last Available: "2014-04"
+7397	frozen upside-down red Gene Tonic: Plant	0		Effect: "Sweet, Nuts", Effect Duration: 61, Last Available: "2014-04"
 7398	ionized Gene Tonic: Weird	0		Effect: "Gummibrain", Effect Duration: 22, Last Available: "2014-04"
 7399	dry concentrated Gene Tonic: Elf	0		Effect: "Ooh, Sweet!", Effect Duration: 18, Last Available: "2014-04"
 7400	triple-electrified concentrated Gene Tonic: Mer-kin	0		Effect: "Mushroom Moxiousness", Effect Duration: 44, Last Available: "2014-04"
 7401	triple-dry blue Gene Tonic: Slime	0		Effect: "Omphalotus Omnipresence", Effect Duration: 25, Last Available: "2014-04"
 7402	diffused polarized super-magnetized ghostly yellow Gene Tonic: Penguin	0		Effect: "Disdain of the War Snapper", Effect Duration: 35, Last Available: "2014-04"
 7403	aerosolized tarnished colloidal maroon Gene Tonic: Elemental	0		Effect: "Fan-Cooled", Effect Duration: 45, Last Available: "2014-04"
-7404	vacuum-sealed upside-down blinking Gene Tonic: Constellation	0		Effect: "Gonna Get You, Sucker", Effect Duration: 12, Last Available: "2014-04"
+7404	vacuum-sealed blinking upside-down Gene Tonic: Constellation	0		Effect: "Gonna Get You, Sucker", Effect Duration: 12, Last Available: "2014-04"
 7405	flattened Gene Tonic: Hobo	0		Effect: "Hella Smooth", Effect Duration: 34, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	blinking Steam Card: Dungeon Fist (#2)	0		
@@ -7321,29 +7321,29 @@
 7432	pickled polymerized yellow Omphalotus Omphaloskepsis mushroom	0		Effect: "Pasta Oneness", Effect Duration: 60, Last Available: "2014-05"
 7433	cold-filtered polymerized Gyromitra Dynomita mushroom	0		Effect: "Hombre Muerto Caminando", Effect Duration: 17, Last Available: "2014-05"
 7434	extra-flattened energized super-polymerized Helvella Haemophilia mushroom	0		Effect: "Poker Faced", Effect Duration: 66, Last Available: "2014-05"
-7435	denatured gray ghostly bouncing Stemonitis Staticus mushroom	0		Effect: "Baconstoned", Effect Duration: 27, Last Available: "2014-05"
+7435	denatured ghostly gray bouncing Stemonitis Staticus mushroom	0		Effect: "Baconstoned", Effect Duration: 27, Last Available: "2014-05"
 7436	cold-filtered pickled Tremella Tarantella mushroom	0		Effect: "Frostbeard", Effect Duration: 53, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	diet rotten Beefy Crunch Pastaco	1	crappy	Last Available: "2014-05"
 7439	stale snack-sized Brain Food Pastaco	2	decent	Last Available: "2014-05"
 7440	toothsome Cool Brunch Pastaco	4	awesome	Last Available: "2014-05"
-7441	rotten bite-sized twirling Medical Pastaco	1	crappy	Last Available: "2014-05"
+7441	bite-sized rotten twirling Medical Pastaco	1	crappy	Last Available: "2014-05"
 7442	flavorless Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	tasty cyan Ludovico Pastaco	3	awesome	Last Available: "2014-05"
 7444	hand-crafted overpowering mushroom wine	4	EPIC	Last Available: "2014-05"
 7445	mediocre upside-down complex mushroom wine	3	decent	Last Available: "2014-05"
-7446	distilled hand-crafted skewed blue smooth mushroom wine	5	EPIC	Last Available: "2014-05"
+7446	hand-crafted distilled skewed blue smooth mushroom wine	5	EPIC	Last Available: "2014-05"
 7447	practically non-alcoholic mediocre blood-red mushroom wine	1	decent	Last Available: "2014-05"
-7448	lousy watered-down skewed buzzing mushroom wine	2	decent	Last Available: "2014-05"
-7449	boozy lousy swirling mushroom wine	5	decent	Last Available: "2014-05"
+7448	watered-down lousy skewed buzzing mushroom wine	2	decent	Last Available: "2014-05"
+7449	lousy boozy swirling mushroom wine	5	decent	Last Available: "2014-05"
 7450	adequate Taco Dan's Basic Taco Dan Taco	3	good	Last Available: "2014-05"
 7451	rotten Taco Dan's Taco Fish Fish Taco	3	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	weak hand-crafted regular-size brogurt	2	EPIC	Last Available: "2014-05"
-7454	smooth irresponsibly strong super-size brogurt	7	awesome	Last Available: "2014-05"
+7453	hand-crafted weak regular-size brogurt	2	EPIC	Last Available: "2014-05"
+7454	irresponsibly strong smooth super-size brogurt	7	awesome	Last Available: "2014-05"
 7455	hand-crafted upside-down broberry brogurt	3	EPIC	Last Available: "2014-05"
-7456	weak perfectly mixed yellow brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7457	practically non-alcoholic delicious French bronilla brogurt	1	awesome	Last Available: "2014-05"
+7456	perfectly mixed weak yellow brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7457	delicious practically non-alcoholic French bronilla brogurt	1	awesome	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	upside-down Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7367,9 +7367,9 @@
 7478	pulsating possessed sugar cube	0		Last Available: "2014-05"
 7479	colloidal oxidized sugar fairy	0		Effect: "Mana Tea", Effect Duration: 48, Last Available: "2014-05"
 7480	anodized denatured vacuum-sealed sugar bunny	0		Effect: "Become Intensely interested", Effect Duration: 13, Last Available: "2014-05"
-7481	gray sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	drinkable practically non-alcoholic Rompedores de Fantasmas	1	good	
-7483	lousy fortified bouncing purple La Fantasma y La Oscuridad	5	decent	
+7481	gray sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7482	practically non-alcoholic drinkable Rompedores de Fantasmas	1	good	
+7483	fortified lousy bouncing purple La Fantasma y La Oscuridad	5	decent	
 7484	hand-crafted practically non-alcoholic Fantasma en la M&aacute;quina	1	super ultra EPIC	
 7485	loosening powder	0		
 7486	wobbly castoreum	0		
@@ -7398,14 +7398,14 @@
 7509	yummy snack-sized Mornington crescent roll	2	awesome	
 7510	pressed skewed eye shadow	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 23
 7511	crumbling wheel	0		
-7512	dry red spinning poppy	0		Effect: "Pyramid Power", Effect Duration: 29
+7512	dry spinning red poppy	0		Effect: "Pyramid Power", Effect Duration: 29
 7513	opium grenade	0		
 7514	horrifying MacGyver's duonoculars	0		Maximum MP: +100, Spooky Damage: +25, Single Equip
 7515	plastic rock	0		
-7516	pulsating spinning witch's spare house key	0		
+7516	spinning pulsating witch's spare house key	0		
 7517	deadly spider leg of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40
 7518	wand of pigification	0		
-7519	special tolerable skewed glass of bourbon	3	good	Effect: "Chalked Weapon", Effect Duration: 35
+7519	tolerable special skewed glass of bourbon	3	good	Effect: "Chalked Weapon", Effect Duration: 35
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	moldy lime green government cheese	3	crappy	Last Available: "2014-05"
 7522	narrow pair of government shades of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2014-05"
@@ -7418,7 +7418,7 @@
 7529	decent shaking loaf of alien bread	3	good	Last Available: "2014-05"
 7530	rotten grilled cheese sandwich	4	crappy	Last Available: "2014-05"
 7531	vaporized alien protein powder	1	crappy	Effect: "On the Shoulders of Giants", Effect Duration: 30, Last Available: "2014-05"
-7532	delicious weak rocket fuel	2	awesome	Last Available: "2014-05"
+7532	weak delicious rocket fuel	2	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	mediocre stealth bomber	4	decent	Last Available: "2014-05"
@@ -7428,8 +7428,8 @@
 7539	pulsating flame-wreathed space beast fur hat	0		Hot Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7540	space beast fur pants of the detective	0		Item Drop: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	huge family-friendly space beast fur whip	0		Sleaze Resistance: +1, Last Available: "2014-05"
-7542	narrow twirling space invader	0		Last Available: "2014-05"
-7543	Sinatra's space heater of the bloodbag	0		Experience (Moxie): +5, Maximum HP: +100, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7542	twirling narrow space invader	0		Last Available: "2014-05"
+7543	Sinatra's space heater of the bloodbag	0		Experience (Moxie): +5, Maximum HP: +100, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
 7545	weak perfectly mixed space port	2	EPIC	Last Available: "2014-05"
 7546	upside-down resourceful steel-toed space needle	0		Damage Reduction: 9, Maximum MP: +50, Last Available: "2014-05"
@@ -7451,7 +7451,7 @@
 7562	flattened musk turtle	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 36
 7563	denatured cold-filtered programmable turtle	0		Effect: "Far Out", Effect Duration: 37
 7564	ionized ghostly mocking turtle	0		Effect: "Marco Polarity", Effect Duration: 62
-7565	fancy spoiled jumbo purple ham steak	5	crappy	Effect: "Pisces in the Skyces", Effect Duration: 15
+7565	fancy jumbo spoiled purple ham steak	5	crappy	Effect: "Pisces in the Skyces", Effect Duration: 15
 7566	slick time-twitching toolbelt	0		Moxie: +10, Single Equip, Free Pull
 7567	wobbly Chroner	0		
 7568	fuchsia perfumed Newton's Time Lord Badge of Honor of the boozehound	0		Experience (Mysticality): +3, Stench Resistance: +5, Booze Drop: +100
@@ -7460,7 +7460,7 @@
 7571	frightening razor-sharp silent pea shooter	0		Weapon Damage Percent: +25, Spooky Damage: +5
 7572	spoiled D roll	3	crappy	
 7573	forbidden Sinatra's kiwi beak	0		Experience (Moxie): +5, Spell Damage Percent: +50
-7574	bad practically non-alcoholic jittery New Zealand iced tea	1	decent	
+7574	practically non-alcoholic bad jittery New Zealand iced tea	1	decent	
 7575	zippy stylish droll monocle	0		Moxie: +25, Initiative: +20, Single Equip
 7576	concentrated frozen blurry future drug: Muscularactum	0		Effect: "The Spy Who Loved XP", Effect Duration: 54
 7577	corrupted jittery future drug: Smartinex	0		Effect: "Very Clean Guns", Effect Duration: 29
@@ -7469,7 +7469,7 @@
 7580	boiled liquid shifting time weirdness	1		Effect: "Hyperoxygenated Blood", Effect Duration: 20
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	decent snack-sized rack of dinosaur ribs	2	good	
-7583	hand-crafted narrow upside-down scotch on the rocks	3	EPIC	
+7583	hand-crafted upside-down narrow scotch on the rocks	3	EPIC	
 7584	greedy toasty yabba dabba doo rag	0		Hot Damage: +5, Meat Drop: +20, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	jittery Usain Bolt's baleful wooly loincloth	0		Spell Damage: +25, Initiative: +80, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	tumbling tumbling helix fossil	0		
@@ -7480,20 +7480,20 @@
 7591	bad jittery thermos of &quot;whiskey&quot;	4	decent	Last Available: "2014-07"
 7592	irresponsibly strong aged Lucky Lindy	9	awesome	Last Available: "2014-07"
 7593	perfectly mixed Bee's Knees	4	EPIC	Last Available: "2014-07"
-7594	aged watered-down red Sockdollager	2	awesome	Last Available: "2014-07"
+7594	watered-down aged red Sockdollager	2	awesome	Last Available: "2014-07"
 7595	drinkable practically non-alcoholic lime green Ish Kabibble	1	good	Last Available: "2014-07"
 7596	fortified drinkable Hot Socks	5	good	Last Available: "2014-07"
 7597	bad upside-down Phonus Balonus	3	decent	Last Available: "2014-07"
 7598	lousy weak blue Flivver	2	decent	Last Available: "2014-07"
-7599	special weak acceptable Sloppy Jalopy	2	good	Effect: "Down With Chow", Effect Duration: 10, Last Available: "2014-07"
+7599	weak acceptable special Sloppy Jalopy	2	good	Effect: "Down With Chow", Effect Duration: 10, Last Available: "2014-07"
 7600	polymerized galvanized flame	0		Effect: "Limber as Mortimer", Effect Duration: 48
 7601	boiled magnetized temporary yak tattoo	0		Effect: "Mariachi Mood", Effect Duration: 11
 7602	diffused modified Fitspiration&trade; poster	0		Effect: "Sludgesick", Effect Duration: 55
 7603	dry neckbeard	0		Effect: "Brocolate Brostidigitation", Effect Duration: 13
-7604	Vulcanized pickled wobbly spinning artisanal hand-squeezed wheatgrass juice	0		Effect: "Bubblin' Rage", Effect Duration: 27
+7604	Vulcanized pickled spinning wobbly artisanal hand-squeezed wheatgrass juice	0		Effect: "Bubblin' Rage", Effect Duration: 27
 7605	improved pressed tarnished lime green punk patch	0		Effect: "Hustlin'", Effect Duration: 55
 7606	super-concentrated Vulcanized tumbling steampunk potion	0		Effect: "Sugar Smacks", Effect Duration: 43
-7607	frozen galvanized pressed bouncing upside-down vial of swamp vapors	0		Effect: "Using Protection", Effect Duration: 19
+7607	frozen galvanized pressed upside-down bouncing vial of swamp vapors	0		Effect: "Using Protection", Effect Duration: 19
 7608	vacuum-sealed red turtle mud	0		Effect: "Spirit of Alph", Effect Duration: 45
 7609	liquefied Redeye&trade; Eyedrops	0		Effect: "Hot Buttoned", Effect Duration: 62
 7610	nitrogenated flattened Dweebisol&trade; inhaler	0		Effect: "The Moxious Madrigal", Effect Duration: 17
@@ -7510,12 +7510,12 @@
 7621	activated teal ninja eyeblack	0		Effect: "Larger", Effect Duration: 30
 7622	colloidal squat button rouge	0		Effect: "Adventurer's Best Friendship", Effect Duration: 23
 7623	activated wet squat Red Army camouflage kit	0		Effect: "Perception", Effect Duration: 56
-7624	modified upside-down yellow lynyrd skinner toothblack	0		Effect: "All Glory To the Toad", Effect Duration: 21
+7624	modified yellow upside-down lynyrd skinner toothblack	0		Effect: "All Glory To the Toad", Effect Duration: 21
 7625	energized double-enhanced flask of rainwater	0		Effect: "All Branned Up", Effect Duration: 38
 7626	improved oyster badge	0		Effect: "Shawarma Warm War", Effect Duration: 61
 7627	activated plastic Jefferson wings	0		Effect: "Flambé-a-thon", Effect Duration: 65
 7628	chilled deionized wobbly dancing fan	0		Effect: "Wintergreen Warmongery", Effect Duration: 15
-7629	concentrated cyan blinking page of the Necrohobocon	0		Effect: "Sludgesick", Effect Duration: 32
+7629	concentrated blinking cyan page of the Necrohobocon	0		Effect: "Sludgesick", Effect Duration: 32
 7630	activated adjusted quadruple-diffused magic powder	0		Effect: "Libra Rising", Effect Duration: 34
 7631	aerosolized friar's tonsure	0		Effect: "Chalk Outline", Effect Duration: 51
 7632	colloidal super-energized non-polarized government-issue identification badge	0		Effect: "Takin' It Greasy", Effect Duration: 44
@@ -7546,7 +7546,7 @@
 7657	shaking fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	flame-retardant neoprene skullcap	0		Hot Resistance: +1, Familiar Effect: "atk, 1xFairy, cap 16"
-7660	super-quantum double-oxidized bouncing gray skewed goblin water	0		Effect: "Slippery Tongue", Effect Duration: 52
+7660	super-quantum double-oxidized gray skewed bouncing goblin water	0		Effect: "Slippery Tongue", Effect Duration: 52
 7661	dumb mud	0		
 7662	half-sized moldy shaking Sogg-Os	2	crappy	
 7663	scorching toasty careful Lord Soggyraven's Slippers	0		Monster Level: -10, Hot Damage: 30, Single Equip
@@ -7567,7 +7567,7 @@
 7678	careful 4-dimensional fez	0		Monster Level: -10, Familiar Effect: "atk, 1xLep, cap 12"
 7679	fuchsia throwing candy	0		
 7680	blinking super-absorbent tarp of Tarzan	0		Experience (Muscle): +3
-7681	practically non-alcoholic drinkable skewed purple unquiet spirits	1	good	
+7681	drinkable practically non-alcoholic purple skewed unquiet spirits	1	good	
 7682	pulsating Annie Oakley's banjo kazoo mount	0		Critical Hit Percent: +20, Single Equip
 7683	double-cold-filtered huge grass	0		Effect: "Hella Tough", Effect Duration: 18
 7684	olive weightlifter's Time Lord Participation Mug	0		Muscle: +15
@@ -7581,11 +7581,11 @@
 7692	skewed stylish hand whip of the sewer of mayonnaise	0		Moxie: +25, Stench Damage: +25, Sleaze Spell Damage: +50, Last Available: "2014-08"
 7693	hardy hale glow-in-the-dark necklace of the ox	0		Muscle: +20, Maximum HP: 70, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	studded cap gun of James Dean of the scaredy-cat	0		Experience (Moxie): +3, Damage Absorption: +80, Monster Level: -15, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	studded cap gun of James Dean of the scaredy-cat	0		Experience (Moxie): +3, Damage Absorption: +80, Monster Level: -15, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	miser's cassette player of the glutton	0		Meat Drop: +10, Food Drop: +100, Single Equip, Last Available: "2014-08"
 7697	tumbling chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	red rubber spider	0		Last Available: "2014-08"
-7699	gray blurry &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
+7699	blurry gray &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	dry Vulcanized confiscated comic book	0		Effect: "Wintergreen Warmongery", Effect Duration: 42, Last Available: "2014-08"
 7701	ionized confiscated cell phone	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 51, Last Available: "2014-08"
 7702	concentrated flattened confiscated love note	0		Effect: "Red-Shirted Escort", Effect Duration: 15, Last Available: "2014-08"
@@ -7595,11 +7595,11 @@
 7706	squat The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	nitrogenated enhanced rubber nubbin	0		Effect: "Happy Salamander", Effect Duration: 14, Last Available: "2014-08"
 7708	rosewater-soaked experienced rubber cape	0		Experience: +2, Stench Resistance: +3, Last Available: "2014-08"
-7709	smartaleck's thinker's Thor's Pliers of temperance	0		Mysticality: +10, Moxie Percent: +30, Sleaze Resistance: +5, Item Drop: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	smartaleck's thinker's Thor's Pliers of temperance	0		Mysticality: +10, Moxie Percent: +30, Sleaze Resistance: +5, Item Drop: +5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	unsweetened energized purple upside-down candy UFOs	0		Effect: "Boon of the War Snapper", Effect Duration: 18
 7711	blurry electrified resourceful water wings for babies	0		Maximum MP: +50, MP Regen Min: 3, MP Regen Max: 5
 7712	wobbly beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
-7713	small decent Strix stix	2	good	
+7713	decent small Strix stix	2	good	
 7714	shaking nippy Jim Carey's beefy vampire pellet	0		Muscle: +10, Monster Level: +25, Cold Damage: +10
 7715	hand-crafted fancy practically non-alcoholic mirror non-aged vinegar	1	EPIC	Effect: "Eyes for Miles", Effect Duration: 35
 7716	unsanitized scalpel of Calamity Jane	0		Critical Hit Percent: +15
@@ -7617,7 +7617,7 @@
 7728	warmed Freddie's blessing of Mercury	0		Effect: "Fancy Feasted", Effect Duration: 13
 7729	bouncing Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
-7731	wobbly narrow transmission from planet Xi	0		Last Available: "2014-09"
+7731	narrow wobbly transmission from planet Xi	0		Last Available: "2014-09"
 7732	spinning Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	Xiblaxian polymer	0		Last Available: "2014-09"
@@ -7642,8 +7642,8 @@
 7753	squat beefy Xiblaxian stealth cowl of Gandalf	0		Muscle: +10, Spell Critical Percent: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	blue personal trainer's Xiblaxian stealth trousers	0		Experience Percent (Muscle): +10, Item Drop: +5, Last Available: "2014-09"
 7755	shellacked Xiblaxian stealth vest of the sewer	0		Damage Reduction: 7, Stench Damage: +25, Last Available: "2014-09"
-7756	special spoiled big gray Xiblaxian ultraburrito	5	crappy	Effect: "Mushroom Magicalness", Effect Duration: 50, Last Available: "2014-09"
-7757	hand-crafted special Xiblaxian space-whiskey	4	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 5, Last Available: "2014-09"
+7756	big special spoiled gray Xiblaxian ultraburrito	5	crappy	Effect: "Mushroom Magicalness", Effect Duration: 50, Last Available: "2014-09"
+7757	special hand-crafted Xiblaxian space-whiskey	4	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 5, Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	unsweetened They liver	0		Effect: "The Best a Pirate Can Get", Effect Duration: 11, Last Available: "2014-09"
 7760	bland upside-down They liver popsicle	4	decent	Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	auspicious stanky Personal Ventilation Unit of the blizzard	0		Cold Spell Damage: +25, Stench Spell Damage: +25, Item Drop: +10, Single Equip, Last Available: "2014-10"
 7771	alkaline quadruple-liquefied ghostly spinning the most dangerous bait	0		Effect: "Fever From the Flavor", Effect Duration: 54, Last Available: "2014-10"
-7772	adequate thick &quot;meat&quot; stick	5	good	Last Available: "2014-10"
+7772	thick adequate &quot;meat&quot; stick	5	good	Last Available: "2014-10"
 7773	dehydrated transdermal smoke patch	1	good	Last Available: "2014-10"
 7774	skewed specialty ammo bandolier	0		Last Available: "2014-10"
 7775	censurious Annie Oakley's pair of plants of Flo-Jo	0		Critical Hit Percent: +20, Sleaze Resistance: +3, Initiative: +100, Last Available: "2014-10"
@@ -7668,12 +7668,12 @@
 7779	liquefied aerosolized experimental serum G-9	0		Effect: "Stop and Smell the Fudge", Effect Duration: 54, Last Available: "2014-10"
 7780	avaricious deadly heavy-duty clipboard of incineration	0		Weapon Damage: +5, Hot Spell Damage: +50, Meat Drop: +30, Damage Reduction: 8, Last Available: "2014-10"
 7781	rosewater-soaked ribald hale shellacked battery-powered drill	0		Damage Reduction: 7, Maximum HP: +20, Sleaze Damage: +10, Stench Resistance: +3, Last Available: "2014-10"
-7782	flavorless pulsating upside-down limp broccoli	3	decent	Last Available: "2014-10"
+7782	flavorless upside-down pulsating limp broccoli	3	decent	Last Available: "2014-10"
 7783	Usain Bolt's miser's Tesla hat	0		Meat Drop: +10, Initiative: +80, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	flattened anodized shaking monkey barf	0		Effect: "Cool, Catlike", Effect Duration: 58, Last Available: "2014-10"
 7785	boiled candy	0		Effect: "Quaaaaaaa", Effect Duration: 52, Last Available: "2014-10"
 7786	green greasy jangly bracelet of the ox of horror	0		Muscle: +20, Spooky Spell Damage: +25, Sleaze Spell Damage: +10, Last Available: "2014-10"
-7787	wobbly cuddly teddy bear of the early riser	0		Adventures: +7, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	wobbly cuddly teddy bear of the early riser	0		Adventures: +7, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	executive wool first-aid pouch	0		Cold Resistance: +1, Meat Drop: +40, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7682,8 +7682,8 @@
 7793	spinning bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	spoiled enchanted initiative shawarma	4	crappy	Effect: "Metal Speed", Effect Duration: 5, Last Available: "2014-10"
-7796	jumbo decent blurry warm war shawarma	5	good	Last Available: "2014-10"
-7797	bland mirror purple karma shawarma	4	decent	Last Available: "2014-10"
+7796	decent jumbo blurry warm war shawarma	5	good	Last Available: "2014-10"
+7797	bland purple mirror karma shawarma	4	decent	Last Available: "2014-10"
 7798	mediocre practically non-alcoholic Jungle Juice	1	decent	Last Available: "2014-10"
 7799	acceptable Amnesiac Ale	3	good	Last Available: "2014-10"
 7800	perfectly mixed tumbling Highest Bitter	3	EPIC	Last Available: "2014-10"
@@ -7722,7 +7722,7 @@
 7833	gore bucket	0		Last Available: "2014-10"
 7834	pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
-7836	narrow upside-down skewed GPS-tracking wristwatch	0		Last Available: "2014-10"
+7836	skewed upside-down narrow GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	Project T. L. B.	0		Last Available: "2014-10"
 7838	Agent Mauve	0		Last Available: "2014-10"
 7839	blurry special clip: tracers	0		Last Available: "2014-10"
@@ -7731,10 +7731,10 @@
 7842	spinning special clip: splatterers	0		Last Available: "2014-10"
 7843	blurry special clip: boneburners	0		Last Available: "2014-10"
 7844	upside-down special clip: graveburpers	0		Last Available: "2014-10"
-7845	ionized flattened quadruple-altered red wobbly perl necklace	0		Effect: "Souper Vengeful", Effect Duration: 31, Last Available: "2014-12"
+7845	ionized flattened quadruple-altered wobbly red perl necklace	0		Effect: "Souper Vengeful", Effect Duration: 31, Last Available: "2014-12"
 7846	anodized diffused double-boiled Fudge Fiber Armor Plating	0		Effect: "Blood-Rich", Effect Duration: 61, Last Available: "2014-12"
 7847	non-oxidized mirror ruby on canes	0		Effect: "Antsy in your Pantsy", Effect Duration: 25, Last Available: "2014-12"
-7848	adequate bite-sized petit fortran	1	good	Last Available: "2014-12"
+7848	bite-sized adequate petit fortran	1	good	Last Available: "2014-12"
 7849	stale narrow lime green java cookie	3	decent	Last Available: "2014-12"
 7850	toothsome cookie cookie	4	awesome	Last Available: "2014-12"
 7851	squat MacGyver's plastic exo-suited miner	0		Maximum MP: +100, Last Available: "2014-12"
@@ -7755,11 +7755,11 @@
 7866	shaking Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	spinning Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
-7869	blinking blurry Crimbot schematic: Crab Core	0		Last Available: "2014-12"
+7869	blurry blinking Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
-7873	maroon blinking Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
+7873	blinking maroon Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	jittery Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
@@ -7792,7 +7792,7 @@
 7903	jittery Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	red Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	recovered elf magazine	0		Last Available: "2014-12"
-7906	mirror maroon recovered elf toothbrush	0		Last Available: "2014-12"
+7906	maroon mirror recovered elf toothbrush	0		Last Available: "2014-12"
 7907	recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	fuchsia pulsating recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
@@ -7803,7 +7803,7 @@
 7914	dry enhanced twirling blurry Bit O' Quail Spleen	0		Effect: "Sweet Nostalgia", Effect Duration: 55
 7915	wet irradiated Take Eleven Bar	0		Effect: "Slightly Mutated", Effect Duration: 45
 7916	mimeplasm	0		
-7917	modified spinning purple BOOterfinger	0		Effect: "Super Accuracy", Effect Duration: 27
+7917	modified purple spinning BOOterfinger	0		Effect: "Super Accuracy", Effect Duration: 27
 7918	deionized upside-down Moonds	0		Effect: "Chorale of Companionship", Effect Duration: 12
 7919	super-liquefied improved narrow Big Punk	0		Effect: "Mer-kindliness", Effect Duration: 51
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
@@ -7811,9 +7811,9 @@
 7922	perfectly mixed bouncing Friendly Turkey	4	EPIC	Last Available: "2014-11"
 7923	lousy jittery Agitated Turkey	3	decent	Last Available: "2014-11"
 7924	artisanal Ambitious Turkey	4	EPIC	Last Available: "2014-11"
-7925	rotten enchanted bouncing tumbling neutron lollipop	4	crappy	Effect: "Izchak's Blessing", Effect Duration: 30, Last Available: "2014-12"
-7926	lousy practically non-alcoholic jittery gamma nog	1	decent	Last Available: "2014-12"
-7934	cyan wobbly sneaky wrapping paper	0		Last Available: "2014-12"
+7925	enchanted rotten bouncing tumbling neutron lollipop	4	crappy	Effect: "Izchak's Blessing", Effect Duration: 30, Last Available: "2014-12"
+7926	practically non-alcoholic lousy jittery gamma nog	1	decent	Last Available: "2014-12"
+7934	wobbly cyan sneaky wrapping paper	0		Last Available: "2014-12"
 7935	upside-down blue Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
@@ -7831,7 +7831,7 @@
 7949	hand-crafted glass of herbal tequila	3	EPIC	
 7950	twirling minin' dynamite	0		
 7951	purple supercharged plaid cowboy hat of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-7952	gray mirror lasso	0		
+7952	mirror gray lasso	0		
 7953	razor-sharp dangerous rusted-out shootin' iron of doom	0		Weapon Damage: +10, Weapon Damage Percent: +25, Spooky Spell Damage: +50
 7954	blinking rattler rattle	0		
 7955	skewed bag of money	0		
@@ -7858,7 +7858,7 @@
 7976	cotton bandages	0		
 7977	green silk bandages	0		
 7978	holy spring water	0		
-7979	shaking mirror spirit beer	0		
+7979	mirror shaking spirit beer	0		
 7980	twirling sacramental wine	0		
 7981	talisman of Thoth	0		
 7982	cure-all	0		
@@ -7881,17 +7881,17 @@
 7999	improved dry blinking choco-Crimbot	0		Effect: "Papowerful", Effect Duration: 51, Last Available: "2014-12"
 8000	magnetized smart watch	0		Effect: "Icy Demeanor", Effect Duration: 12, Last Available: "2014-12"
 8001	deionized augmented-reality shades	0		Effect: "The Halls of Muscularity", Effect Duration: 31, Last Available: "2014-12"
-8002	jittery mirror executive toy Crimbot mega face	0		Meat Drop: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
-8003	chaotic toy Crimbot power glove	0		Spell Critical Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	asbestos-lined toy Crimbot super fist	0		Hot Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	Sherlock's toy Crimbot rocket legs	0		Item Drop: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	jittery mirror executive toy Crimbot mega face	0		Meat Drop: +40, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
+8003	chaotic toy Crimbot power glove	0		Spell Critical Percent: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	asbestos-lined toy Crimbot super fist	0		Hot Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	Sherlock's toy Crimbot rocket legs	0		Item Drop: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	triple-pressed extra-aerosolized upside-down Crimbot battery	0		Effect: "Blood-Gorged", Effect Duration: 30, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	jittery Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	pulsating Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	mirror lard-coated Jim Carey's deadly Crimbomega drive chain	0		Weapon Damage: +5, Monster Level: +25, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	mirror lard-coated Jim Carey's deadly Crimbomega drive chain	0		Weapon Damage: +5, Monster Level: +25, Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7905,7 +7905,7 @@
 8023	fuchsia muscle stimulator	0		Last Available: "2015-01"
 8024	huge foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
-8026	blinking green ceiling fan	0		Last Available: "2015-01"
+8026	green blinking ceiling fan	0		Last Available: "2015-01"
 8027	squat antler chandelier	0		Last Available: "2015-01"
 8028	artificial skylight	0		Last Available: "2015-01"
 8029	blinking Swiss piggy bank	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	Tesla wholesome tope&eacute;	0		Maximum HP Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "3xBarrr, cap 12"
 8035	ghostly extremely unsafe topiary tights of the bloodbag	0		Weapon Damage Percent: +100, Maximum HP: +100
 8036	boxer's topiary necktie	0		Muscle Percent: +10
-8037	snack-sized spoiled bowl of topioca	2	crappy	
+8037	spoiled snack-sized bowl of topioca	2	crappy	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	jittery trusty whip	0		
@@ -7940,7 +7940,7 @@
 8059	Bananubis's Staff	0		Luck: -6
 8060	smelly sage The Joke Book of the Dead	0		Mysticality Percent: +10, Stench Spell Damage: +10, Luck: -6
 8061	olive The Clown Crown	0		Luck: -6
-8062	ghostly narrow coffee cup	0		Luck: -2
+8062	narrow ghostly coffee cup	0		Luck: -2
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	maroon monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	teal blinking banana	0		Familiar Weight: +5
@@ -7970,7 +7970,7 @@
 8095	avaricious wicker ticker of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +30, Single Equip, Last Available: "2016-12"
 8096	ghostly Oprah's shellacked wicker sticker	0		Damage Reduction: 7, Maximum MP Percent: +50, Last Available: "2016-12"
 8097	asbestos-lined wicker clicker of the empath	0		Familiar Weight: +5, Hot Resistance: +5, Last Available: "2016-12"
-8098	diluted twirling mirror wickerbits	1		Effect: "Mad at Science", Effect Duration: 50, Last Available: "2016-12"
+8098	diluted mirror twirling wickerbits	1		Effect: "Mad at Science", Effect Duration: 50, Last Available: "2016-12"
 8099	squat family-friendly therapeutic belt	0		Sleaze Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2016-12"
 8100	Rosewater's badge of extreme caution	0		Mysticality Percent: +30, Monster Level: -25, Single Equip, Last Available: "2016-12"
 8101	mirror Sherlock's dangerous bowl	0		Weapon Damage: +10, Item Drop: +25, Last Available: "2016-12"
@@ -7996,7 +7996,7 @@
 8121	Jeselnik's garland of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +25, Single Equip, Last Available: "2018-12"
 8122	manspreader's gunnysack of the glutton	0		Monster Level: +10, Food Drop: +100, Last Available: "2018-12"
 8123	teal medical-grade garibaldi of the sewer	0		Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-12"
-8124	teal skewed flame-retardant girdle of the bloodbag	0		Maximum HP: +100, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	teal skewed flame-retardant girdle of the bloodbag	0		Maximum HP: +100, Hot Resistance: +1, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	Van der Graaf grievous gloves	0		Weapon Damage Percent: +50, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2018-12"
 8126	pickled shaking smithereens	1		Last Available: "2018-12"
 8127	foul-smelling fiberglass fetish of bravery	0		Stench Damage: +10, Spooky Resistance: +5, Last Available: "2018-12"
@@ -8005,7 +8005,7 @@
 8130	reassuring supercool fiberglass frock	0		Moxie Percent: +20, Spooky Resistance: +1, Last Available: "2018-12"
 8131	upside-down censurious fiberglass fingerguard of the early riser	0		Sleaze Resistance: +3, Adventures: +7, Single Equip, Last Available: "2018-12"
 8132	upside-down inspector's fiberglass fedora of the storm	0		Maximum MP Percent: +40, Item Drop: +15, Last Available: "2018-12"
-8133	modified shaking huge blinking fiberglass fibers	1		Effect: "Three Days Slow", Effect Duration: 5, Last Available: "2018-12"
+8133	modified huge blinking shaking fiberglass fibers	1		Effect: "Three Days Slow", Effect Duration: 5, Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	talisman of Renenutet	0		
@@ -8059,16 +8059,16 @@
 8185	miser's The Crown of Ed the Undying of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +10, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	smooth practically non-alcoholic cyan Cherrytastrophe wine cooler	1	awesome	
-8189	weak perfectly mixed shaking Radberry Rip wine cooler	2	EPIC	
+8188	practically non-alcoholic smooth cyan Cherrytastrophe wine cooler	1	awesome	
+8189	perfectly mixed weak shaking Radberry Rip wine cooler	2	EPIC	
 8190	tolerable practically non-alcoholic narrow twirling Orangemageddon wine cooler	1	good	
 8191	bad spinning Breakfast Blast wine cooler	3	decent	
-8192	strong lousy wobbly Citrus Crush wine cooler	5	decent	
-8193	spoiled half-sized plain bagel	2	crappy	
-8194	moldy half-sized glob of cream cheese	2	crappy	
-8195	toothsome diet loaf of soda bread	1	awesome	
+8192	lousy strong wobbly Citrus Crush wine cooler	5	decent	
+8193	half-sized spoiled plain bagel	2	crappy	
+8194	half-sized moldy glob of cream cheese	2	crappy	
+8195	diet toothsome loaf of soda bread	1	awesome	
 8196	bland squat acceptable bagel	3	decent	
-8197	toothsome thick standard-issue cupcake	5	awesome	
+8197	thick toothsome standard-issue cupcake	5	awesome	
 8198	toothsome huge twirling ultra-deluxe cupcake	10	awesome	
 8199	squat hypnotic breadcrumbs	0		
 8200	spoiled popular tart	3	crappy	
@@ -8086,11 +8086,11 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	frightening Tesla rigging rope	0		Spooky Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-04"
 8214	altered nasty snuff	1	awesome	Last Available: "2015-04"
-8215	purple sewage-clogged pistol of the bloodbag of the scaredy-cat	0		Maximum HP: +100, Monster Level: -15, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8215	purple sewage-clogged pistol of the bloodbag of the scaredy-cat	0		Maximum HP: +100, Monster Level: -15, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	Vulcanized flattened twirling beard incense	0		Effect: "Blubbered Up", Effect Duration: 62, Last Available: "2015-04"
 8217	blurry zippy curative perfume-soaked bandana	0		Initiative: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	fancy toothsome toxo	3	awesome	Effect: "Heightened Senses", Effect Duration: 50, Last Available: "2015-04"
+8219	toothsome fancy toxo	3	awesome	Effect: "Heightened Senses", Effect Duration: 50, Last Available: "2015-04"
 8220	aged Lemonade-235	3	awesome	Last Available: "2015-04"
 8221	Da Vinci's boxer's isotophat	0		Muscle Percent: +10, Experience (Mysticality): +5, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	frightening sinister Three Mile Island shorts	0		Spell Damage: +10, Spooky Damage: +5, Last Available: "2015-04"
@@ -8099,7 +8099,7 @@
 8225	teal lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	jar of swamp honey	0		Last Available: "2015-04"
 8227	manspreader's medical-grade slick backwoods banjo	0		Moxie: +10, Monster Level: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04"
-8228	bouncing upside-down grody jug	0		Last Available: "2015-04"
+8228	upside-down bouncing grody jug	0		Last Available: "2015-04"
 8229	reassuring resourceful wholesome ratskin pajama pants	0		Maximum HP Percent: +10, Maximum MP: +50, Spooky Resistance: +1, Last Available: "2015-04"
 8230	dry chilled turtle voicebox	0		Effect: "Frog In Your Throat", Effect Duration: 68, Last Available: "2015-04"
 8231	double-paned fake washboard of the dark arts of Leguizamo	0		Spell Damage Percent: +100, Monster Level: +20, Cold Resistance: +5, Damage Reduction: 13, Last Available: "2015-04"
@@ -8112,13 +8112,13 @@
 8238	brain preservation fluid	0		Last Available: "2015-04"
 8239	upside-down keycard &alpha;	0		Last Available: "2015-04"
 8240	blue keycard &beta;	0		Last Available: "2015-04"
-8241	blinking narrow keycard &gamma;	0		Last Available: "2015-04"
-8242	cyan upside-down keycard &delta;	0		Last Available: "2015-04"
+8241	narrow blinking keycard &gamma;	0		Last Available: "2015-04"
+8242	upside-down cyan keycard &delta;	0		Last Available: "2015-04"
 8243	blue complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	prompt lube-shoes	0		Adventures: +3, Last Available: "2015-04"
 8245	skewed trash net	0		Last Available: "2015-04"
 8246	rosewater-soaked Rosewater's Dinsey mascot mask of the scaredy-cat	0		Mysticality Percent: +30, Monster Level: -15, Stench Resistance: +3, Last Available: "2015-04"
-8247	bland enchanted Dinsey food-cone	3	decent	Effect: "Moon-Eyed", Effect Duration: 20, Last Available: "2015-04"
+8247	enchanted bland Dinsey food-cone	3	decent	Effect: "Moon-Eyed", Effect Duration: 20, Last Available: "2015-04"
 8248	hand-crafted Dinsey Whinskey	4	EPIC	Last Available: "2015-04"
 8249	aerosolized corrupted spinning Dinsey face paint	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 38, Last Available: "2015-04"
 8250	skewed smooth fannypack of the ox	0		Muscle: +20, Moxie: +15, Last Available: "2015-04"
@@ -8139,9 +8139,9 @@
 8265	Mayoflex	0		Last Available: "2015-05"
 8266	prompt auspicious greasy hardy miracle whip	0		Maximum HP: +50, Sleaze Spell Damage: +10, Item Drop: +10, Adventures: +3, Lasts Until Rollover, Last Available: "2015-05"
 8267	red sphygmayomanometer of the storm	0		Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2015-05"
-8268	twirling gray tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
+8268	gray twirling tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	low-calorie spoiled unappetizing mayolus	1	crappy	Last Available: "2015-05"
+8270	spoiled low-calorie unappetizing mayolus	1	crappy	Last Available: "2015-05"
 8271	adequate uninteresting mayolus	3	good	Last Available: "2015-05"
 8272	rotten jumbo acceptable mayolus	5	crappy	Last Available: "2015-05"
 8273	rotten cyan enticing mayolus	3	crappy	Last Available: "2015-05"
@@ -8156,7 +8156,7 @@
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	improved electrified jittery Kokomo Resort Pass	0		Effect: "Moose Wisdom", Effect Duration: 11, Last Available: "2023-08"
-8285	shaking ghostly Mayo Minder&trade;	0		Last Available: "2015-05"
+8285	ghostly shaking Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	enhanced improved boiled Mayo de Mayo&trade; mayo	0		Effect: "Kissed By Fire", Effect Duration: 63
 8287	narrow puck	0		Free Pull, Last Available: "2015-06"
 8288	skewed kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
@@ -8170,10 +8170,10 @@
 8296	olive Thwaitgold caterpillar statuette	0		
 8297	super-flattened flattened dice	0		Effect: "Bureaucratized", Effect Duration: 55
 8298	maroon pixel	0		Last Available: "2015-06"
-8299	bouncing blinking pixel coin	0		Last Available: "2015-06"
+8299	blinking bouncing pixel coin	0		Last Available: "2015-06"
 8300	non-corrupted non-galvanized pulsating power pill	0		Effect: "Starry-Eyed", Effect Duration: 15, Last Available: "2015-06"
 8301	oxidized triple-galvanized lime green pixel star	0		Effect: "Tingling Feeling", Effect Duration: 36, Last Available: "2015-06"
-8302	special stale miniature pixel banana	2	decent	Effect: "substats.enh", Effect Duration: 25, Last Available: "2015-06"
+8302	stale special miniature pixel banana	2	decent	Effect: "substats.enh", Effect Duration: 25, Last Available: "2015-06"
 8303	lousy practically non-alcoholic yellow pixel beer	1	decent	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8228,7 +8228,7 @@
 8354	moist ionized nursery rhyme	0		Effect: "Hiding in Plain Sight", Effect Duration: 58
 8355	chilled aerosolized corrupted iron torso box	0		Effect: "Sparkling Consciousness", Effect Duration: 64
 8356	tarnished ghostly mercenary headband	0		Effect: "Stemonitis Storm", Effect Duration: 65
-8357	concentrated red spinning radioactive spider venom	0		Effect: "Twen Tea", Effect Duration: 60
+8357	concentrated spinning red radioactive spider venom	0		Effect: "Twen Tea", Effect Duration: 60
 8358	boiled magnetized jittery jittery x-ray mirror	0		Effect: "Human-Constellation Hybrid", Effect Duration: 15
 8359	improved deionized spinning wrestling mask	0		Effect: "Memento Moir&eacute;", Effect Duration: 21
 8360	chilled hawkface potion	0		Effect: "Dirty Pear", Effect Duration: 68
@@ -8237,7 +8237,7 @@
 8363	colloidal anodized lime green shopkeeper beard	0		Effect: "Category", Effect Duration: 18
 8364	quadruple-quantum twirling alien autoautopsy kit	0		Effect: "License to Punch", Effect Duration: 47
 8365	diffused chilled quadruple-anodized novelty fruit hat	0		Effect: "Bark of the Dog", Effect Duration: 62
-8366	anodized jittery green invisibility cream	0		Effect: "Tearful, Fearful", Effect Duration: 59
+8366	anodized green jittery invisibility cream	0		Effect: "Tearful, Fearful", Effect Duration: 59
 8367	alkaline twirling handful of stubble	0		Effect: "Meadulla Oblongota", Effect Duration: 48
 8368	tarnished tumbling olive garbage juice slurpee	0		Effect: "Florid Cheeks", Effect Duration: 30
 8369	deionized electrified plunge-leg	0		Effect: "Like a Fish to Walter", Effect Duration: 43
@@ -8249,9 +8249,9 @@
 8375	ionized chilled denatured pulsating eyebrow lifter	0		Effect: "Armored Innards", Effect Duration: 51
 8376	jittery submarine	0		Last Available: "2015-06"
 8377	stale tumbling pixel lemon	3	decent	Last Available: "2015-06"
-8378	watered-down fancy artisanal pixel daiquiri	2	EPIC	Effect: "Lit Up", Effect Duration: 40, Last Available: "2015-06"
+8378	artisanal fancy watered-down pixel daiquiri	2	EPIC	Effect: "Lit Up", Effect Duration: 40, Last Available: "2015-06"
 8379	chilled corrupted power pill	0		Effect: "familiar.enq", Effect Duration: 69, Last Available: "2015-06"
-8380	polarized mirror ghostly pixel potion	0		Effect: "Familial Ties", Effect Duration: 40, Last Available: "2015-06"
+8380	polarized ghostly mirror pixel potion	0		Effect: "Familial Ties", Effect Duration: 40, Last Available: "2015-06"
 8381	tumbling Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
 8383	blurry popular part	0		
@@ -8261,11 +8261,11 @@
 8387	mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
 8389	mana	0		Last Available: "2015-07"
-8390	huge gray mana	0		Last Available: "2015-07"
+8390	gray huge mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
 8393	pulsating hermit factoid	0		Last Available: "2015-07"
-8394	cyan squat The Emperor's dry cleaning	0		Last Available: "2015-07"
+8394	squat cyan The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	The Emperor's new hat of the empath	0		Familiar Weight: +5, Last Available: "2015-07"
 8396	lime green resourceful The Emperor's new shirt	0		Maximum MP: +50, Last Available: "2015-07"
 8397	blurry shellacked The Emperor's new pants	0		Damage Reduction: 7, Last Available: "2015-07"
@@ -8278,20 +8278,20 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	pulsating talking spade	0		Free Pull
 8406	bouncing savory dry noodles	0		
-8407	decent fancy pestopiary	3	good	Effect: "Impregnably Delicious", Effect Duration: 30
+8407	fancy decent pestopiary	3	good	Effect: "Impregnably Delicious", Effect Duration: 30
 8408	flattened flattened vacuum-sealed narrow ectoplasmic orbs	0		Effect: "Permafrosty", Effect Duration: 17
 8409	flavorless diet crudles	1	decent	
 8410	adequate low-calorie agnolotti arboli	1	good	
 8411	normal spaghetti with ghost balls	3	good	
-8412	flavorless big succulent marrow	5	decent	
-8413	spoiled massive salacious crumbs	9	crappy	
+8412	big flavorless succulent marrow	5	decent	
+8413	massive spoiled salacious crumbs	9	crappy	
 8414	normal super-sized upside-down fusilli marrownarrow	5	good	
 8415	snack-sized moldy blue suggestive strozzapreti	2	crappy	
 8416	bouncing Mountain Stream gastrique	0		
 8417	snack-sized flavorless Mt. McLargeHuge oyster	2	decent	
 8418	oyster sauce	0		
 8419	normal linguini immondizia bianco	3	good	
-8420	adequate half-sized shells a la shellfish	2	good	
+8420	half-sized adequate shells a la shellfish	2	good	
 8421	Jick's autograph	0		
 8422	squat high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8319,11 +8319,11 @@
 8445	lava globs	0		Last Available: "2015-08"
 8446	mirror SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
-8448	wobbly huge uncapped lava bottle	0		Last Available: "2015-08"
+8448	huge wobbly uncapped lava bottle	0		Last Available: "2015-08"
 8449	jittery uncapped lava bottle	0		Last Available: "2015-08"
 8450	huge capped lava bottle	0		Last Available: "2015-08"
 8451	bouncing capped lava bottle	0		Last Available: "2015-08"
-8452	bouncing blinking cyan capped lava bottle	0		Last Available: "2015-08"
+8452	blinking cyan bouncing capped lava bottle	0		Last Available: "2015-08"
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	mirror LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
@@ -8335,7 +8335,7 @@
 8461	mediocre Gold Velvet&trade; whiskey	3	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	normal smelted roe	4	good	Last Available: "2015-08"
-8464	fancy tolerable wobbly lavawater	4	good	Effect: "Favored by Lyle", Effect Duration: 30, Last Available: "2015-08"
+8464	tolerable fancy wobbly lavawater	4	good	Effect: "Favored by Lyle", Effect Duration: 30, Last Available: "2015-08"
 8465	warmed frozen anodized shaking basaltamander tongue	0		Effect: "Metal Speed", Effect Duration: 27, Last Available: "2015-08"
 8466	lavalarva of dire peril of the blizzard of the brazier	0		Weapon Damage: +20, Cold Spell Damage: +25, Hot Spell Damage: +25, Last Available: "2015-08"
 8467	veiny smartaleck's lava balaclava of Leguizamo	0		Moxie Percent: +30, Maximum HP: +10, Monster Level: +20, Last Available: "2015-08"
@@ -8347,16 +8347,16 @@
 8473	flame-retardant double-paned Jack Frost's heat-resistant gloves	0		Cold Spell Damage: +50, Cold Resistance: +5, Hot Resistance: +1, Single Equip, Last Available: "2015-08"
 8474	rotten small very hot lunch	2	crappy	Last Available: "2015-08"
 8475	aged fuchsia asbestos thermos	4	awesome	Last Available: "2015-08"
-8476	Vulcanized shaking tumbling liquid rhinestones	0		Effect: "Fan-Cooled", Effect Duration: 40, Last Available: "2015-08"
+8476	Vulcanized tumbling shaking liquid rhinestones	0		Effect: "Fan-Cooled", Effect Duration: 40, Last Available: "2015-08"
 8477	toothsome fuchsia disco biscuit	3	awesome	Last Available: "2015-08"
 8478	smooth triple-distilled pulsating Quaatorade&trade;	10	awesome	Last Available: "2015-08"
 8479	yellow weightlifter's biker's hat of Tarzan of the bloodbag	0		Muscle: +15, Experience (Muscle): +3, Maximum HP: +100, Last Available: "2015-08", Familiar Effect: "atk"
 8480	skewed skewed frightening smelly chilly feathered headdress	0		Cold Damage: +5, Stench Spell Damage: +10, Spooky Damage: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	frosty electrician's hardhat of the cougar of the blizzard	0		Moxie: +20, Cold Spell Damage: 35, Last Available: "2015-08", Familiar Effect: "atk"
 8482	pulsating Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
-8483	narrow mirror Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
+8483	mirror narrow Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
-8485	shaking huge huge &quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
+8485	huge shaking huge &quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	huge one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
@@ -8397,26 +8397,26 @@
 8523	fused fuse	0		Last Available: "2015-08"
 8524	jittery superheated	0		Last Available: "2015-08"
 8525	bite-sized flavorless lava cake	1	decent	Last Available: "2015-08"
-8526	big moldy pink slime	5	crappy	
+8526	moldy big pink slime	5	crappy	
 8527	ghostly Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	jumbo rotten mirror blurry devil hair pasta	5	crappy	
+8529	rotten jumbo mirror blurry devil hair pasta	5	crappy	
 8530	moldy jumbo spagecialetti	5	crappy	
 8531	Salsa Libre	0		
 8532	spinning good gravy	0		
 8533	teal illicit fish sauce	0		
-8534	huge toothsome libertagliatelle	6	awesome	
-8535	massive stale turkish mostaccioli	9	decent	
+8534	toothsome huge libertagliatelle	6	awesome	
+8535	stale massive turkish mostaccioli	9	decent	
 8536	moldy spinning linguini of the sea	3	crappy	
 8537	boiled corrupted pulsating Hersey&trade; SMOOCH	0		Effect: "Frog In Your Throat", Effect Duration: 50
 8539	Alexy sauce	0		
 8540	pulsating rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	moldy Fettris	3	crappy	
-8543	snack-sized spoiled narrow purple fusillocybin	2	crappy	
-8544	rotten small prescription noodles	2	crappy	
-8545	mixed pulsating upside-down blood-drive sticker	1	decent	
-8546	polymerized tumbling green shaking bag of grain	0		Effect: "Items Are Forever", Effect Duration: 44
+8543	spoiled snack-sized purple narrow fusillocybin	2	crappy	
+8544	small rotten prescription noodles	2	crappy	
+8545	mixed upside-down pulsating blood-drive sticker	1	decent	
+8546	polymerized shaking tumbling green bag of grain	0		Effect: "Items Are Forever", Effect Duration: 44
 8547	super-unsweetened dry double-vacuum-sealed pocket maze	0		Effect: "Neuromancy", Effect Duration: 69
 8548	unsweetened boiled shady shades	0		Effect: "Hopped Up on Goofballs", Effect Duration: 49
 8549	flattened tumbling squeaky toy rose	0		Effect: "Spiky Hair", Effect Duration: 21
@@ -8429,7 +8429,7 @@
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	ionized Wickers bar	0		Effect: "Jacked In", Effect Duration: 28
-8559	corrupted ionized blurry spinning tumbling bakelite-covered bacon	0		Effect: "Berry Statistical", Effect Duration: 26
+8559	corrupted ionized spinning tumbling blurry bakelite-covered bacon	0		Effect: "Berry Statistical", Effect Duration: 26
 8560	irradiated Aerheads	0		Effect: "Pisces in the Skyces", Effect Duration: 62
 8561	double-dry mirror Wrotz	0		Effect: "Petit Force", Effect Duration: 16
 8562	extra-dry tumbling Gabarbar	0		Effect: "Jerky, Boy", Effect Duration: 17
@@ -8450,7 +8450,7 @@
 8577	squat barnacled barrel	0		Last Available: "2015-09"
 8578	extra-dry tolerable bouncing bottle of Amontillado	5	good	Last Available: "2015-09"
 8579	irresponsibly strong smooth blinking barrel-aged martini	7	awesome	Last Available: "2015-09"
-8580	gigantic flavorless wobbly barrel pickle	10	decent	Last Available: "2015-09"
+8580	flavorless gigantic wobbly barrel pickle	10	decent	Last Available: "2015-09"
 8581	spoiled teal barrel cracker	3	crappy	Last Available: "2015-09"
 8582	dehydrated vibrating mushroom	1	awesome	Last Available: "2015-09"
 8583	powdered blinking mushroom	1	good	Effect: "Painted-On Bikini", Effect Duration: 20, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	barrel gun of the storm	0		Maximum MP Percent: +40, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	pulsating barrel beryl	0		Last Available: "2015-09"
-8589	fancy adequate mirror mirror water log	3	good	Effect: "Ode to Booze", Effect Duration: 45, Last Available: "2015-09"
+8589	adequate fancy mirror mirror water log	3	good	Effect: "Ode to Booze", Effect Duration: 45, Last Available: "2015-09"
 8590	cyan perfumed nasty barrelhead	0		Stench Damage: +5, Stench Resistance: +5, Last Available: "2015-09"
 8591	electrified crafty bottoms of the barrel	0		Maximum MP: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-09"
 8592	green crafty chest barrel of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +10, Last Available: "2015-09"
@@ -8470,16 +8470,16 @@
 8597	beefcake's barrel beryl nose ring of the empath	0		Muscle: +25, Familiar Weight: +5, Last Available: "2015-09"
 8598	jittery zippy miser's barrel beryl ring	0		Meat Drop: +10, Initiative: +20, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
-8600	skewed purple potted tea tree	0		Last Available: "2015-09"
+8600	purple skewed potted tea tree	0		Last Available: "2015-09"
 8601	quantum blurry cuppa Flamibili tea	0		Effect: "Lifted Spirits", Effect Duration: 64, Last Available: "2015-09"
 8602	moist boiled gray cuppa Yet tea	0		Effect: "meat.enh", Effect Duration: 36, Last Available: "2015-09"
 8603	enhanced dry skewed cuppa Boo tea	0		Effect: "Remaining Alive", Effect Duration: 55, Last Available: "2015-09"
 8604	boiled cuppa Nas tea	0		Effect: "Helvella Health", Effect Duration: 35, Last Available: "2015-09"
 8605	aerosolized moist cuppa Improprie tea	0		Effect: "Bonelording", Effect Duration: 51, Last Available: "2015-09"
 8606	alkaline cyan cuppa Frost tea	0		Effect: "Gr8ness", Effect Duration: 43, Last Available: "2015-09"
-8607	quadruple-adjusted tumbling narrow skewed cuppa Toast tea	0		Effect: "Shortened", Effect Duration: 68, Last Available: "2015-09"
+8607	quadruple-adjusted skewed narrow tumbling cuppa Toast tea	0		Effect: "Shortened", Effect Duration: 68, Last Available: "2015-09"
 8608	electrified dry deionized bouncing cuppa Net tea	0		Effect: "Psalm of Pointiness", Effect Duration: 33, Last Available: "2015-09"
-8609	warmed chilled olive jittery cuppa Proprie tea	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 54, Last Available: "2015-09"
+8609	warmed chilled jittery olive cuppa Proprie tea	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 54, Last Available: "2015-09"
 8610	ionized tarnished cuppa Morbidi tea	0		Effect: "Aries Rising", Effect Duration: 50, Last Available: "2015-09"
 8611	boiled cuppa Chari tea	0		Effect: "Hangdog", Effect Duration: 15, Last Available: "2015-09"
 8612	energized quadruple-concentrated fuchsia cuppa Serendipi tea	0		Effect: "substats.enh", Effect Duration: 50, Last Available: "2015-09"
@@ -8503,17 +8503,17 @@
 8630	frozen corrupted cuppa Twen tea	0		Effect: "Frostbeard", Effect Duration: 46, Last Available: "2015-09"
 8631	non-dry skewed cuppa Gill tea	0		Effect: "Mo' Hobo", Effect Duration: 56, Last Available: "2015-09"
 8632	super-anodized cuppa Uncertain tea	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 55, Last Available: "2015-09"
-8633	squat blinking red cuppa Voraci tea	0		Last Available: "2015-09"
+8633	red blinking squat cuppa Voraci tea	0		Last Available: "2015-09"
 8634	shaking cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
 8636	warmed improved cuppa Craft tea	0		Effect: "You're Rubber", Effect Duration: 42, Last Available: "2015-09"
 8637	aerosolized squat cuppa Insani tea	0		Effect: "Chalk Outline", Effect Duration: 12, Last Available: "2015-09"
 8638	maroon rosewater-soaked fireproof Royal scepter of terror	0		Spooky Spell Damage: +10, Hot Resistance: +3, Stench Resistance: +3, Last Available: "2015-09"
 8639	tumbling doghouse	0		Free Pull, Last Available: "2015-10"
-8640	blue shaking Ghost Dog Chow	0		Last Available: "2015-10"
-8641	bite-sized rotten huge bowl of eyeballs	1	crappy	Last Available: "2015-10"
+8640	shaking blue Ghost Dog Chow	0		Last Available: "2015-10"
+8641	rotten bite-sized huge bowl of eyeballs	1	crappy	Last Available: "2015-10"
 8642	bite-sized rotten jittery bowl of mummy guts	1	crappy	Last Available: "2015-10"
-8643	big normal bowl of maggots	5	good	Last Available: "2015-10"
+8643	normal big bowl of maggots	5	good	Last Available: "2015-10"
 8644	hand-crafted blood and blood	3	EPIC	Last Available: "2015-10"
 8645	weak tolerable pulsating Jack-O-Lantern beer	2	good	Last Available: "2015-10"
 8646	bad zombie	4	decent	Last Available: "2015-10"
@@ -8531,9 +8531,9 @@
 8658	Othello's handkerchief of wisdom	0		Mysticality: +15, Single Equip
 8659	alkaline polymerized energized bowl of Jeal-O	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25
 8660	grip key	0		
-8661	spinning skewed How to Play Othello	0		
+8661	skewed spinning How to Play Othello	0		
 8662	aromatic therapeutic ghostly dagger of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
-8663	acceptable watered-down wobbly ghost beer	2	good	
+8663	watered-down acceptable wobbly ghost beer	2	good	
 8664	wobbly scandalous Othello set	0		Sleaze Damage: +5
 8665	wobbly rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8547,7 +8547,7 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	liquefied anodized shoulder-warming lotion	0		Effect: "Spell Transfer Complete", Effect Duration: 53, Last Available: "2015-11"
-8677	special small decent maroon iceberg lettuce	2	good	Effect: "Morninja", Effect Duration: 50, Last Available: "2015-11"
+8677	small special decent maroon iceberg lettuce	2	good	Effect: "Morninja", Effect Duration: 50, Last Available: "2015-11"
 8678	bad ice wine	3	decent	Last Available: "2015-11"
 8679	teal mirror dog trainer's thinker's Wal-Mart snowglobe of the boozehound	0		Mysticality: +10, Experience (familiar): +1, Booze Drop: +100, Last Available: "2015-11"
 8680	frightening Wal-Mart nametag of the brazier of mayonnaise	0		Hot Spell Damage: +25, Spooky Damage: +5, Sleaze Spell Damage: +50, Last Available: "2015-11"
@@ -8557,9 +8557,9 @@
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	red perfect ice cube	0		Last Available: "2015-11"
-8687	blurry red pulsating The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
+8687	pulsating red blurry The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	bellhop's hat of the cougar	0		Moxie: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	perfectly mixed ice porter	3	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	perfectly mixed ice porter	3	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	non-anodized exotic travel brochure	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 41, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	concentrated quantum shampoo-conditioner	0		Effect: "Mushroom Samba", Effect Duration: 57, Last Available: "2015-11"
@@ -8567,7 +8567,7 @@
 8694	olive ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
 8696	diluted medicinal herbs	1		Last Available: "2016-01"
-8697	special snack-sized moldy ice rice	2	crappy	Effect: "Ichorous Eyesight", Effect Duration: 45, Last Available: "2016-01"
+8697	moldy snack-sized special ice rice	2	crappy	Effect: "Ichorous Eyesight", Effect Duration: 45, Last Available: "2016-01"
 8698	lousy iced plum wine	3	decent	Last Available: "2016-01"
 8699	wool careful sinister training belt	0		Spell Damage: +10, Monster Level: -10, Cold Resistance: +1, Single Equip, Last Available: "2016-01"
 8700	training legwarmers of the cougar of vim and vigor of horror	0		Moxie: +20, Maximum HP Percent: +50, Spooky Spell Damage: +25, Single Equip, Last Available: "2016-01"
@@ -8601,7 +8601,7 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	bouncing friendly VYKEA hex key of the brute of the sewer	0		Muscle Percent: +30, Familiar Weight: +3, Stench Damage: +25, Last Available: "2015-11"
 8730	wobbly VYKEA instructions	0		Last Available: "2015-11"
-8731	bland big tin of submardines	5	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	bland big tin of submardines	5	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	drinkable upside-down bottle of norwhiskey	4	good	Last Available: "2015-11"
 8733	pickled wobbly blue octolus oculus	1	decent	Last Available: "2015-11"
 8734	mansplainer's razor-sharp sardine can key of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +25, Monster Level: +15, Last Available: "2015-11"
@@ -8609,10 +8609,10 @@
 8736	coward's boxer's smooth octolus-skin cloak	0		Moxie: +15, Muscle Percent: +10, Monster Level: -20, Last Available: "2015-11"
 8737	hand-crafted tumbling perfect cosmopolitan	4	EPIC	Last Available: "2015-11"
 8738	aged perfect negroni	4	awesome	Last Available: "2015-11"
-8739	hand-crafted special practically non-alcoholic perfect dark and stormy	1	super ultra mega turbo EPIC	Effect: "Bilious Brains", Effect Duration: 30, Last Available: "2015-11"
-8740	high-proof fancy bad spinning perfect mimosa	9	decent	Effect: "Fancy Feasted", Effect Duration: 40, Last Available: "2015-11"
+8739	hand-crafted practically non-alcoholic special perfect dark and stormy	1	super ultra mega turbo EPIC	Effect: "Bilious Brains", Effect Duration: 30, Last Available: "2015-11"
+8740	high-proof bad fancy spinning perfect mimosa	9	decent	Effect: "Fancy Feasted", Effect Duration: 40, Last Available: "2015-11"
 8741	high-proof lousy perfect old-fashioned	10	decent	Last Available: "2015-11"
-8742	mediocre narrow spinning perfect paloma	4	decent	Last Available: "2015-11"
+8742	mediocre spinning narrow perfect paloma	4	decent	Last Available: "2015-11"
 8743	aerosolized magnetized triple-dry jittery That 70s Cologne	0		Effect: "Pwnd", Effect Duration: 45, Last Available: "2015-11"
 8744	quadruple-adjusted Wal-Mart &quot;diamond&quot; ring	0		Effect: "Angry Bone", Effect Duration: 54, Last Available: "2015-11"
 8745	diffused upside-down mirror Puffstone cigar	0		Effect: "Polar Express", Effect Duration: 41, Last Available: "2015-11"
@@ -8625,7 +8625,7 @@
 8752	diet flavorless gray Crimbo salad	1	decent	Last Available: "2015-12"
 8753	adequate lime green bread line	4	good	Last Available: "2015-12"
 8754	mediocre bark rootbeer	4	decent	Last Available: "2015-12"
-8755	perfectly mixed special pulsating upside-down ale	3	EPIC	Effect: "Tiki Temerity", Effect Duration: 15, Last Available: "2015-12"
+8755	special perfectly mixed upside-down pulsating ale	3	EPIC	Effect: "Tiki Temerity", Effect Duration: 15, Last Available: "2015-12"
 8756	Lo Pan's plastic Tammy the Tambourine Elf	0		Spell Critical Percent: +30, Last Available: "2015-12"
 8757	blurry mansplainer's plastic Rudolph the Red	0		Monster Level: +15, Last Available: "2015-12"
 8758	cool plastic Gaia'ajh-dsli Ak'lwej	0		Moxie: +5, Last Available: "2015-12"
@@ -8638,7 +8638,7 @@
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
 8766	watered-down perfectly mixed Gratitude chocolate (bourbon-filled)	2	EPIC	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
-8768	skewed blinking Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
+8768	blinking skewed Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
 8770	galvanized pitted sheet	0		Effect: "Sweet and Green", Effect Duration: 56, Last Available: "2015-12"
 8771	sparking robo-battery	0		Last Available: "2015-12"
@@ -8653,7 +8653,7 @@
 8781	avaricious pine cone necklace	0		Meat Drop: +30, Last Available: "2015-12"
 8782	electrified reindeer hammer	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-12"
 8783	prompt elf ploughshare	0		Adventures: +3, Last Available: "2015-12"
-8784	spinning spinning upside-down circle drum	0		Last Available: "2015-12"
+8784	upside-down spinning spinning circle drum	0		Last Available: "2015-12"
 8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	lime green faded protest sign	0		Last Available: "2015-12"
@@ -8666,7 +8666,7 @@
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	yellow Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	lime green huge plastic spoiler	0		
-8797	upside-down ghostly bat-oomerang	0		Last Available: "2017-01"
+8797	ghostly upside-down bat-oomerang	0		Last Available: "2017-01"
 8798	blinking bat-jute	0		Last Available: "2017-01"
 8799	narrow bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
@@ -8692,19 +8692,19 @@
 8820	vaporized The Author's ink	1		Last Available: "2016-02"
 8821	practically non-alcoholic lousy special olive The Mad Liquor	1	decent	Effect: "Super Vision", Effect Duration: 50, Last Available: "2016-12"
 8822	high-proof mediocre bouncing Doc Clock's thyme cocktail	10	decent	Last Available: "2016-12"
-8823	rotten gigantic special Mr. Burnsger	10	crappy	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2016-12"
-8824	twisted pulsating red The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	greedy ribald The Jokester's gun of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Meat Drop: +20, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	scorching experienced thinker's The Jokester's wig	0		Mysticality: +10, Experience: +2, Hot Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
-8827	electrified dangerous The Jokester's pants of the scaredy-cat	0		Weapon Damage: +10, Monster Level: -15, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8823	special gigantic rotten Mr. Burnsger	10	crappy	Effect: "Patent Alacrity", Effect Duration: 25, Last Available: "2016-12"
+8824	twisted red pulsating The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
+8825	greedy ribald The Jokester's gun of courage	0		Sleaze Damage: +10, Spooky Resistance: +3, Meat Drop: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	scorching experienced thinker's The Jokester's wig	0		Mysticality: +10, Experience: +2, Hot Damage: +25, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	electrified dangerous The Jokester's pants of the scaredy-cat	0		Weapon Damage: +10, Monster Level: -15, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	wet twirling Jokester makeup	0		Effect: "Fangs and Pangs", Effect Duration: 67, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	gray basking robin	0		Free Pull, Last Available: "2016-12"
-8832	upside-down olive domino mask	0		Familiar Weight: +5
+8832	olive upside-down domino mask	0		Familiar Weight: +5
 8833	pressed robin's egg	0		Effect: "Liquidy Smoky", Effect Duration: 46, Last Available: "2016-12"
-8834	miniature bland robin flan	2	decent	Last Available: "2016-12"
-8835	artisanal bouncing skewed robin nog	3	EPIC	Last Available: "2016-12"
+8834	bland miniature robin flan	2	decent	Last Available: "2016-12"
+8835	artisanal skewed bouncing robin nog	3	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	olive plaintive telegram	0		Last Available: "2016-02"
 8838	wobbly exploding gum	0		
@@ -8719,7 +8719,7 @@
 8847	quantum spinning red-hot jawbreaker	0		Effect: "One Very Clear Eye", Effect Duration: 23
 8848	boiled twirling question juice	0		Effect: "Mariachi Mood", Effect Duration: 40
 8849	aerosolized huge tube of villain	0		Effect: "Punch Another Day", Effect Duration: 30
-8850	ghostly friendly your cowboy boots	0		Familiar Weight: +3, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	ghostly friendly your cowboy boots	0		Familiar Weight: +3, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,14 +8746,14 @@
 8874	ribald mansplainer's energetic brainy Val-U Brand Every Bean Salad of vim and vigor	0		Mysticality: +5, Maximum HP Percent: +50, Maximum MP Percent: +20, Monster Level: +15, Sleaze Damage: +10, Last Available: "2016-02"
 8875	sizzling thinker's Shrub's Premium Baked Beans of James Dean	0		Mysticality: +10, Experience (Moxie): +3, Hot Damage: +10, Last Available: "2016-02"
 8876	normal spinning plate of Heimz Fortified Kidney Beans	3	good	Last Available: "2016-02"
-8877	small bland ghostly plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
+8877	bland small ghostly plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
 8878	super-sized moldy plate of Mixed Garbanzos and Chickpeas	5	crappy	Last Available: "2016-02"
-8879	flavorless bite-sized plate of Hellfire Spicy Beans	1	decent	Last Available: "2016-02"
+8879	bite-sized flavorless plate of Hellfire Spicy Beans	1	decent	Last Available: "2016-02"
 8880	immense moldy bouncing plate of Frigid Northern Beans	6	crappy	Last Available: "2016-02"
 8881	flavorless plate of World's Blackest-Eyed Peas	4	decent	Last Available: "2016-02"
-8882	adequate gigantic narrow plate of Trader Olaf's Exotic Stinkbeans	9	good	Last Available: "2016-02"
+8882	gigantic adequate narrow plate of Trader Olaf's Exotic Stinkbeans	9	good	Last Available: "2016-02"
 8883	yummy skewed plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	awesome	Last Available: "2016-02"
-8884	jumbo special decent narrow plate of Val-U Brand Every Bean Salad	5	good	Effect: "Steroid Boost", Effect Duration: 20, Last Available: "2016-02"
+8884	special decent jumbo narrow plate of Val-U Brand Every Bean Salad	5	good	Effect: "Steroid Boost", Effect Duration: 20, Last Available: "2016-02"
 8885	normal olive plate of Shrub's Premium Baked Beans	4	good	Last Available: "2016-02"
 8886	prompt resourceful Fancy Jeff's pocket square	0		Maximum MP: +50, Adventures: +3, Last Available: "2016-02"
 8887	fireproof Daisy's unclean bloomers of chilblains of doom	0		Cold Damage: +25, Spooky Spell Damage: +50, Hot Resistance: +3, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
@@ -8774,11 +8774,11 @@
 8902	quantum wobbly ghost bit	0		Effect: "Alacri Tea", Effect Duration: 11, Last Available: "2016-02"
 8903	quadruple-cold-filtered buzzard feather	0		Effect: "Moon'd", Effect Duration: 22, Last Available: "2016-02"
 8904	super-ionized lion musk	0		Effect: "Stenchtastic", Effect Duration: 38, Last Available: "2016-02"
-8905	decent tumbling ghostly fuchsia bear claw	3	good	Last Available: "2016-02"
+8905	decent fuchsia tumbling ghostly bear claw	3	good	Last Available: "2016-02"
 8906	boiled rattler gland	0		Effect: "Pyramid Power", Effect Duration: 54, Last Available: "2016-02"
 8907	activated vacuum-sealed half-digested coal	0		Effect: "Vitamin-Maxed", Effect Duration: 16, Last Available: "2016-02"
 8908	chilled quantum energized pulsating tightly-wound spine	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 15, Last Available: "2016-02"
-8909	normal special rotting beefsteak	4	good	Effect: "Ichorous Eyesight", Effect Duration: 30, Last Available: "2016-02"
+8909	special normal rotting beefsteak	4	good	Effect: "Ichorous Eyesight", Effect Duration: 30, Last Available: "2016-02"
 8910	hand-crafted weak huge firemilk	2	EPIC	Last Available: "2016-02"
 8911	flattened maroon blinking spidercow eye-cluster	0		Effect: "Wreathed in Smoke", Effect Duration: 56, Last Available: "2016-02"
 8912	vaporized moomy dust	1		Effect: "Burning Tongue", Effect Duration: 40, Last Available: "2016-02"
@@ -8794,8 +8794,8 @@
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
 8924	disc (black)	0		
-8925	maroon narrow disc (red)	0		
-8926	bouncing blue disc (green)	0		
+8925	narrow maroon disc (red)	0		
+8926	blue bouncing disc (green)	0		
 8927	disc (blue)	0		
 8928	disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
@@ -8819,11 +8819,11 @@
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
-8950	red jittery slicksilver spurs	0		Last Available: "2016-02"
+8950	jittery red slicksilver spurs	0		Last Available: "2016-02"
 8951	bouncing sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
 8953	ticksilver spurs	0		Last Available: "2016-02"
-8954	upside-down cyan mirror special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
+8954	cyan upside-down mirror special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
 8957	skewed Tales of the West: Snake Oiling	0		
@@ -8850,9 +8850,9 @@
 8978	moist patent aggression tonic	0		Effect: "Electrolit Up", Effect Duration: 54
 8979	corrupted cold-filtered patent sallowness tonic	0		Effect: "items.enh", Effect Duration: 66
 8980	Vulcanized extra-energized patent avarice tonic	0		Effect: "Gunky Dory", Effect Duration: 27
-8981	corrupted mirror gray patent alacrity tonic	0		Effect: "Block-Rockin' Beet", Effect Duration: 53
+8981	corrupted gray mirror patent alacrity tonic	0		Effect: "Block-Rockin' Beet", Effect Duration: 53
 8982	quadruple-energized corrupted marrow	0		Effect: "In Tuna", Effect Duration: 25
-8983	hand-crafted weak rodeo whiskey	2	EPIC	
+8983	weak hand-crafted rodeo whiskey	2	EPIC	
 8984	Thwaitgold scorpion statuette	0		
 8985	ribald real cowboy hat	0		Sleaze Damage: +10
 8986	blurry Memories of Cow Punching	0		Free Pull
@@ -8861,8 +8861,8 @@
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	blue do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	compressed blurry purple armored prawn	1		Last Available: "2016-03"
-8993	snack-sized adequate jumping horseradish	2	good	Last Available: "2016-03"
+8992	compressed purple blurry armored prawn	1		Last Available: "2016-03"
+8993	adequate snack-sized jumping horseradish	2	good	Last Available: "2016-03"
 8994	acceptable Sacramento wine	3	good	Last Available: "2016-03"
 8995	deionized Greek fire	0		Effect: "Dirty Pear", Effect Duration: 33, Last Available: "2016-03"
 8996	olive greedy family-friendly frightening ox-head shield of the wise owl of the early riser	0		Mysticality: +20, Spooky Damage: +5, Sleaze Resistance: +1, Meat Drop: +20, Adventures: +7, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
@@ -8899,13 +8899,13 @@
 9027	Usain Bolt's cool First Post shirt - Cir Senam of the cheetah	0		Moxie: +5, Initiative: 140, Last Available: "2016-05"
 9028	shaking high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	fuchsia no spoon	0		
-9030	adequate super-sized yellow star salad	5	good	
+9030	super-sized adequate yellow star salad	5	good	
 9031	jittery Thwaitgold moth statuette	0		
 9032	snack-sized rotten pulsating bowl of Tastee-Wheet&trade;	2	crappy	
 9033	squat Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	adequate browser cookie	3	good	Last Available: "2016-06"
-9036	weak mediocre hacked gibson	2	decent	Last Available: "2016-06"
+9036	mediocre weak hacked gibson	2	decent	Last Available: "2016-06"
 9037	perfumed Source shades	0		Stench Resistance: +5, Last Available: "2016-06"
 9038	bouncing software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8920,9 +8920,9 @@
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	fuchsia Source terminal SCRAM chip	0		Last Available: "2016-06"
 9050	upside-down Source terminal TRIGRAM chip	0		Last Available: "2016-06"
-9051	teal jittery Source terminal file: substats.enh	0		Last Available: "2016-06"
+9051	jittery teal Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
-9053	gray narrow Source terminal file: critical.enh	0		Last Available: "2016-06"
+9053	narrow gray Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	spinning Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
@@ -8934,7 +8934,7 @@
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	purple Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
-9065	blurry purple spinning Source terminal file: dram.ext	0		Last Available: "2016-06"
+9065	purple spinning blurry Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	pill	0		Last Available: "2016-06"
 9068	frightening hardened sage plastic detective badge of James Dean	0		Mysticality Percent: +10, Experience (Moxie): +3, Damage Reduction: 3, Spooky Damage: +5, Last Available: "2016-07"
@@ -8951,7 +8951,7 @@
 9079	stale immense hardboiled egg	6	decent	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	Sherlock's frosty medical-grade dance instructor's protonic accelerator pack of the cougar of the blizzard	0		Moxie: +20, Experience Percent (Moxie): +10, Cold Spell Damage: 35, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	Sherlock's frosty medical-grade dance instructor's protonic accelerator pack of the cougar of the blizzard	0		Moxie: +20, Experience Percent (Moxie): +10, Cold Spell Damage: 35, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	shaking almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	arcane researcher's Adventurer bobblehead	0		Experience Percent (Mysticality): +10, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,11 +8964,11 @@
 9092	yellow family-friendly horrifying Samson's Spookyraven signet	0		Experience (Muscle): +5, Spooky Damage: +25, Sleaze Resistance: +1, Single Equip, Last Available: "2016-08"
 9093	rosewater-soaked foul-smelling tie-dyed fannypack	0		Stench Damage: +10, Stench Resistance: +3, Single Equip, Last Available: "2016-08"
 9094	burnt snowpants of the cheetah of Flo-Jo	0		Initiative: 160, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	up-at-dawn standards and practices guide	0		Adventures: +5, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9095	up-at-dawn standards and practices guide	0		Adventures: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	toasty careful chaotic Carpathian longsword	0		Spell Critical Percent: +10, Monster Level: -10, Hot Damage: +5, Last Available: "2016-08"
 9097	Liam's mail of the brute of Leguizamo of incineration	0		Muscle Percent: +30, Monster Level: +20, Hot Spell Damage: +50, Last Available: "2016-08"
 9098	family-friendly double-paned gravedigger's Unfortunato's foolscap	0		Spooky Damage: +10, Cold Resistance: +5, Sleaze Resistance: +1, Last Available: "2016-08"
-9099	teal blinking Thwaitgold cockroach statuette	0		
+9099	blinking teal Thwaitgold cockroach statuette	0		
 9100	rad	0		
 9101	ghostly purification tablet	0		
 9102	Wrist-Boy of the wise owl	0		Mysticality: +20
@@ -8978,11 +8978,11 @@
 9106	huge yellow Rad-B-Gone (1 lb.)	0		
 9107	non-irradiated quantum diffused Rad-Pro (1 oz.)	0		Effect: "Crotchety, Pining", Effect Duration: 35
 9108	lead umbrella	0		
-9109	Vulcanized red squat Shrieking Weasel holo-record	0		Effect: "Square to be Hip", Effect Duration: 51
+9109	Vulcanized squat red Shrieking Weasel holo-record	0		Effect: "Square to be Hip", Effect Duration: 51
 9110	super-concentrated altered Power-Guy 2000 holo-record	0		Effect: "Puzzle Fury", Effect Duration: 64
 9111	quadruple-electrified Lucky Strikes holo-record	0		Effect: "So You Can Work More...", Effect Duration: 24
 9112	oxidized EMD holo-record	0		Effect: "Feline Ferocity", Effect Duration: 39
-9113	deionized irradiated purple narrow Superdrifter holo-record	0		Effect: "Jammin'", Effect Duration: 14
+9113	deionized irradiated narrow purple Superdrifter holo-record	0		Effect: "Jammin'", Effect Duration: 14
 9114	diffused corrupted The Pigs holo-record	0		Effect: "Scavengers Scavenging", Effect Duration: 32
 9115	dry Drunk Uncles holo-record	0		Effect: "Wet and Greedy", Effect Duration: 12
 9116	time residue	0		Last Available: "2016-09"
@@ -8990,7 +8990,7 @@
 9118	pulsating Riker's Search History	0		Last Available: "2016-09"
 9119	artisanal Shot of Kardashian Gin	4	EPIC	Last Available: "2016-09"
 9120	purple Van der Graaf Unstable Pointy Ears	0		MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2016-09"
-9121	blinking upside-down maroon Memory Disk, Alpha	0		Last Available: "2016-09"
+9121	upside-down blinking maroon Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	blurry Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
@@ -8998,7 +8998,7 @@
 9126	artisanal weak unidentified drink	2	EPIC	
 9127	tumbling Rosewater's KoL Con 13 T-shirt of terror	0		Mysticality Percent: +30, Spooky Spell Damage: +10
 9128	lard-coated Jeselnik's MacGyver's discarded swimming trunks	0		Maximum MP: +100, Sleaze Damage: +25, Sleaze Spell Damage: +25
-9129	flattened green narrow diluted makeup	0		Effect: "Burning Tongue", Effect Duration: 25
+9129	flattened narrow green diluted makeup	0		Effect: "Burning Tongue", Effect Duration: 25
 9130	liquefied charisma potion	0		Effect: "Ruthlessly Efficient", Effect Duration: 42
 9131	olive extremely confusing manual	0		
 9132	avaricious lard-coated pistol	0		Sleaze Spell Damage: +25, Meat Drop: +30
@@ -9007,12 +9007,12 @@
 9135	lousy weak very whiskey	2	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	lime green jittery blinking bouncing li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	bouncing blinking lime green jittery li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9140	upside-down li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	twirling mirror li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	mirror twirling li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9144	upside-down li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	super-cold-filtered colloidal tumbling hoarded candy wad	0		Effect: "Soles of Glass", Effect Duration: 46, Last Available: "2016-10"
@@ -9024,13 +9024,13 @@
 9152	narrow li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	delicious raw sweet potato	3	awesome	Last Available: "2016-11"
 9154	jumbo normal mirror raw beans	5	good	Last Available: "2016-11"
-9155	spoiled enchanted raw stuffing	3	crappy	Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2016-11"
-9156	bland half-sized raw cranberry sauce	2	decent	Last Available: "2016-11"
+9155	enchanted spoiled raw stuffing	3	crappy	Effect: "Demonic Flavor", Effect Duration: 30, Last Available: "2016-11"
+9156	half-sized bland raw cranberry sauce	2	decent	Last Available: "2016-11"
 9157	spoiled blue raw turkey	3	crappy	Last Available: "2016-11"
 9158	enchanted bland raw mincemeat	3	decent	Effect: "Kindly Resolve", Effect Duration: 50, Last Available: "2016-11"
-9159	miniature tasty raw potato	2	awesome	Last Available: "2016-11"
-9160	bite-sized decent raw gravy	1	good	Last Available: "2016-11"
-9161	half-sized tasty raw bread	2	awesome	Last Available: "2016-11"
+9159	tasty miniature raw potato	2	awesome	Last Available: "2016-11"
+9160	decent bite-sized raw gravy	1	good	Last Available: "2016-11"
+9161	tasty half-sized raw bread	2	awesome	Last Available: "2016-11"
 9162	blurry pulsating Jeselnik's hale mini-marshmallow dispenser	0		Maximum HP: +20, Sleaze Damage: +25, Last Available: "2016-11"
 9163	family-friendly wool glass casserole dish of the boozehound	0		Cold Resistance: +1, Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9042,11 +9042,11 @@
 9170	bread mold	0		Last Available: "2016-11"
 9171	stale sweet potatoes	3	decent	Last Available: "2016-11"
 9172	decent snack-sized bean casserole	2	good	Last Available: "2016-11"
-9173	miniature decent baked stuffing	2	good	Last Available: "2016-11"
+9173	decent miniature baked stuffing	2	good	Last Available: "2016-11"
 9174	flavorless cranberry cylinder	3	decent	Last Available: "2016-11"
 9175	stale ghostly thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	delicious mince pie	4	awesome	Last Available: "2016-11"
-9177	fancy spoiled mashed potatoes	3	crappy	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2016-11"
+9177	spoiled fancy mashed potatoes	3	crappy	Effect: "Influence of Sphere", Effect Duration: 45, Last Available: "2016-11"
 9178	diet moldy warm gravy	1	crappy	Last Available: "2016-11"
 9179	delicious wobbly bread roll	3	awesome	Last Available: "2016-11"
 9180	enchanted miniature tasty leftovers	2	awesome	Effect: "Feroci Tea", Effect Duration: 25, Last Available: "2016-11"
@@ -9061,14 +9061,14 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	chilled triple-colloidal jittery eldritch concentrate	0		Effect: "You Know When to Walk Away", Effect Duration: 19, Last Available: "2016-11"
-9192	weak fancy mediocre eldritch extract	2	decent	Effect: "Mint-Condition Breath", Effect Duration: 45, Last Available: "2016-11"
+9192	mediocre fancy weak eldritch extract	2	decent	Effect: "Mint-Condition Breath", Effect Duration: 45, Last Available: "2016-11"
 9193	energetic Official Council Aide Pin of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +20, Last Available: "2016-11"
-9194	practically non-alcoholic smooth eldritch distillate	1	awesome	Last Available: "2016-11"
+9194	smooth practically non-alcoholic eldritch distillate	1	awesome	Last Available: "2016-11"
 9195	powdered gray eldritch essence	1		Effect: "Red Misty-Eyed", Effect Duration: 30, Last Available: "2016-11"
 9196	spinning quilted Science Notebook	0		Damage Absorption: +40
 9197	personal trainer's eldritch hat of Tarzan of the empath	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Familiar Weight: +5, Last Available: "2016-11"
 9198	MacGyver's Rosewater's thinker's eldritch pants	0		Mysticality: +10, Mysticality Percent: +30, Maximum MP: +100, Last Available: "2016-11"
-9199	practically non-alcoholic mediocre eldritch elixir	1	decent	Last Available: "2016-11"
+9199	mediocre practically non-alcoholic eldritch elixir	1	decent	Last Available: "2016-11"
 9200	personal trainer's Quartet of Flare Masters Jacket of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20, Last Available: "2016-11"
 9201	mirror lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9086,7 +9086,7 @@
 9214	ghostly blurry reassuring chocolate pocketwatch of Calamity Jane of the businessman	0		Critical Hit Percent: +15, Spooky Resistance: +1, Meat Drop: +50, Single Equip, Last Available: "2016-12"
 9215	lime green broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	ghostly interesting clod of dirt	0		
-9217	squat skewed ghostly gingerbread restraining order	0		Last Available: "2016-12"
+9217	skewed squat ghostly gingerbread restraining order	0		Last Available: "2016-12"
 9218	skewed spinning sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	snack-sized adequate skewed animal part cracker	2	good	Last Available: "2016-12"
 9220	bad gingerbread wine	4	decent	Last Available: "2016-12"
@@ -9106,9 +9106,9 @@
 9234	pumpkin spice candle of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-12"
 9235	energized twirling gingerbread spice latte	0		Effect: "Memory of Strength", Effect Duration: 37, Last Available: "2016-12"
 9236	supercharged Samson's gingerbread gavel	0		Experience (Muscle): +5, Maximum MP Percent: +30, Last Available: "2016-12"
-9237	huge tumbling gingerbread cigarette	0		Last Available: "2016-12"
+9237	tumbling huge gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	watered-down delicious ginger beer	2	awesome	Last Available: "2016-12"
+9239	delicious watered-down ginger beer	2	awesome	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	anodized dry diffused industrial frosting	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 46, Last Available: "2016-12"
 9242	pressed tumbling fake cocktail	0		Effect: "Yuletide Industry", Effect Duration: 28, Last Available: "2016-12"
@@ -9121,10 +9121,10 @@
 9249	double-denatured alkaline Inner Wisdom	0		Effect: "Feline Ferocity", Effect Duration: 34, Last Available: "2016-12"
 9250	improved Inner Strength	0		Effect: "Mushroom Might", Effect Duration: 35, Last Available: "2016-12"
 9251	deionized alkaline tarnished Inner Truth	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 14, Last Available: "2016-12"
-9252	tiny delicious spiritual candy cane	1	awesome	Last Available: "2016-12"
-9253	tolerable triple-distilled bouncing spiritual eggnog	9	good	Last Available: "2016-12"
+9252	delicious tiny spiritual candy cane	1	awesome	Last Available: "2016-12"
+9253	triple-distilled tolerable bouncing spiritual eggnog	9	good	Last Available: "2016-12"
 9254	spoiled spiritual fruitcake	3	crappy	Last Available: "2016-12"
-9255	adequate half-sized blinking spiritual gingerbread	2	good	Last Available: "2016-12"
+9255	half-sized adequate blinking spiritual gingerbread	2	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	jittery My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,7 +9144,7 @@
 9272	negative lump	0		
 9273	spinning chaotic baleful Third Eye	0		Spell Damage: +25, Spell Critical Percent: +10, Last Available: "2016-12"
 9274	gravedigger's forbidden Krampus Horn	0		Spell Damage Percent: +50, Spooky Damage: +10, Single Equip, Last Available: "2016-12"
-9275	big rotten hambrosier	5	crappy	Last Available: "2016-12"
+9275	rotten big hambrosier	5	crappy	Last Available: "2016-12"
 9276	acceptable chakra-mental wine	4	good	Last Available: "2016-12"
 9277	improved chakra malt	0		Effect: "Slimily Speedy", Effect Duration: 39, Last Available: "2016-12"
 9278	bland pulsating Black Angus blackburger	4	decent	Last Available: "2016-12"
@@ -9163,20 +9163,20 @@
 9291	vaporized hot jelly	1		Effect: "Bananas!", Effect Duration: 30, Last Available: "2017-01"
 9292	diluted blurry jelly	1		Effect: "Shot in the Arse", Effect Duration: 30, Last Available: "2017-01"
 9293	boiled upside-down jelly	1		Effect: "Fiery Spirit", Effect Duration: 40, Last Available: "2017-01"
-9294	altered blue huge sleaze jelly	1		Last Available: "2017-01"
-9295	diluted blinking upside-down stench jelly	1		Effect: "Wax On Your Shoes", Effect Duration: 10, Last Available: "2017-01"
+9294	altered huge blue sleaze jelly	1		Last Available: "2017-01"
+9295	diluted upside-down blinking stench jelly	1		Effect: "Wax On Your Shoes", Effect Duration: 10, Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
-9297	flavorless small shaking toast with hot jelly	2	decent	Last Available: "2017-01"
+9297	small flavorless shaking toast with hot jelly	2	decent	Last Available: "2017-01"
 9298	adequate tumbling toast with jelly	4	good	Last Available: "2017-01"
 9299	adequate toast with jelly	3	good	Last Available: "2017-01"
 9300	bland massive toast with sleaze jelly	9	decent	Last Available: "2017-01"
-9301	jumbo adequate toast with stench jelly	5	good	Last Available: "2017-01"
+9301	adequate jumbo toast with stench jelly	5	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	skewed pewter candlestick	0		Familiar Weight: +10
 9305	medical-grade stiffened wax hand	0		Damage Reduction: 1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-01"
 9306	quilted candle of the glutton	0		Damage Absorption: +40, Food Drop: +100, Lasts Until Rollover, Last Available: "2017-01"
-9307	snack-sized stale wax pancake	2	decent	Last Available: "2017-01"
+9307	stale snack-sized wax pancake	2	decent	Last Available: "2017-01"
 9308	wax face of the overflowing toilet of the early riser	0		Stench Spell Damage: +50, Adventures: +7, Last Available: "2017-01"
 9309	lousy practically non-alcoholic ghostly wax booze	1	decent	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
@@ -9234,39 +9234,39 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	ghostly slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
-9365	lousy fortified literal grasshopper	5	decent	Last Available: "2017-03"
+9365	fortified lousy literal grasshopper	5	decent	Last Available: "2017-03"
 9366	artisanal blinking double entendre	4	EPIC	Last Available: "2017-03"
 9367	mediocre Phlegethon	4	decent	Last Available: "2017-03"
 9368	practically non-alcoholic smooth Siberian sunrise	1	awesome	Last Available: "2017-03"
-9369	practically non-alcoholic drinkable fuchsia mentholated wine	1	good	Last Available: "2017-03"
+9369	drinkable practically non-alcoholic fuchsia mentholated wine	1	good	Last Available: "2017-03"
 9370	delicious fuchsia low tide martini	4	awesome	Last Available: "2017-03"
 9371	artisanal spirit-forward shroomtini	5	EPIC	Last Available: "2017-03"
 9372	bad watered-down morning dew	2	decent	Last Available: "2017-03"
-9373	artisanal weak skewed whiskey squeeze	2	EPIC	Last Available: "2017-03"
-9374	high-proof bad great fashioned	7	decent	Last Available: "2017-03"
+9373	weak artisanal skewed whiskey squeeze	2	EPIC	Last Available: "2017-03"
+9374	bad high-proof great fashioned	7	decent	Last Available: "2017-03"
 9375	acceptable Gnomish sagngria	4	good	Last Available: "2017-03"
-9376	spirit-forward tolerable vodka stinger	5	good	Last Available: "2017-03"
+9376	tolerable spirit-forward vodka stinger	5	good	Last Available: "2017-03"
 9377	triple-distilled smooth extremely slippery nipple	10	awesome	Last Available: "2017-03"
 9378	lousy piscatini	4	decent	Last Available: "2017-03"
 9379	tolerable Churchill	3	good	Last Available: "2017-03"
-9380	mediocre watered-down soilzerac	2	decent	Last Available: "2017-03"
+9380	watered-down mediocre soilzerac	2	decent	Last Available: "2017-03"
 9381	mediocre London frog	3	decent	Last Available: "2017-03"
 9382	boozy acceptable nothingtini	5	good	Last Available: "2017-03"
-9383	smooth weak eighth plague	2	awesome	Last Available: "2017-03"
+9383	weak smooth eighth plague	2	awesome	Last Available: "2017-03"
 9384	perfectly mixed single entendre	3	EPIC	Last Available: "2017-03"
 9385	hand-crafted narrow yellow reverse Tantalus	3	EPIC	Last Available: "2017-03"
-9386	practically non-alcoholic artisanal elemental caipiroska	1	EPIC	Last Available: "2017-03"
-9387	bad high-proof Feliz Navidad	8	decent	Last Available: "2017-03"
+9386	artisanal practically non-alcoholic elemental caipiroska	1	EPIC	Last Available: "2017-03"
+9387	high-proof bad Feliz Navidad	8	decent	Last Available: "2017-03"
 9388	drinkable distilled Bloody Nora	5	good	Last Available: "2017-03"
-9389	acceptable irresponsibly strong moreltini	10	good	Last Available: "2017-03"
+9389	irresponsibly strong acceptable moreltini	10	good	Last Available: "2017-03"
 9390	drinkable mirror hell in a bucket	3	good	Last Available: "2017-03"
-9391	delicious practically non-alcoholic Newark	1	awesome	Last Available: "2017-03"
+9391	practically non-alcoholic delicious Newark	1	awesome	Last Available: "2017-03"
 9392	drinkable purple R'lyeh	3	good	Last Available: "2017-03"
 9393	mediocre Gnollish sangria	4	decent	Last Available: "2017-03"
 9394	perfectly mixed vodka barracuda	3	EPIC	Last Available: "2017-03"
-9395	acceptable practically non-alcoholic Mysterious Island iced tea	1	good	Last Available: "2017-03"
+9395	practically non-alcoholic acceptable Mysterious Island iced tea	1	good	Last Available: "2017-03"
 9396	drinkable drive-by shooting	3	good	Last Available: "2017-03"
-9397	hand-crafted watered-down gunner's daughter	2	EPIC	Last Available: "2017-03"
+9397	watered-down hand-crafted gunner's daughter	2	EPIC	Last Available: "2017-03"
 9398	watered-down tolerable ghostly dirt julep	2	good	Last Available: "2017-03"
 9399	lousy Simepore slime	3	decent	Last Available: "2017-03"
 9400	hand-crafted bouncing Phil Collins	3	EPIC	Last Available: "2017-03"
@@ -9285,12 +9285,12 @@
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9415	stale edible alien plant bit	3	decent	Last Available: "2017-04"
-9416	ghostly jittery alien plant fibers	0		Last Available: "2017-04"
+9416	jittery ghostly alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
 9420	boiled alien plant goo	1		Last Available: "2017-04"
-9421	red mirror blinking alien plant pod	0		Last Available: "2017-04"
+9421	mirror red blinking alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	rotten alien meat	3	crappy	Last Available: "2017-04"
 9424	alien toenails	0		Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	concentrated alien medicine	0		Effect: "Happy Trails", Effect Duration: 16, Last Available: "2017-04"
-9433	moldy miniature alien salad	2	crappy	Last Available: "2017-04"
+9433	miniature moldy alien salad	2	crappy	Last Available: "2017-04"
 9434	hand-crafted alien booze	3	EPIC	Last Available: "2017-04"
 9435	auspicious extremely unsafe alien mask of the blizzard	0		Weapon Damage Percent: +100, Cold Spell Damage: +25, Item Drop: +10, Last Available: "2017-04"
 9436	perfumed stanky Rosewater's alien spear	0		Mysticality Percent: +30, Stench Spell Damage: +25, Stench Resistance: +5, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	hale boxer's murderbot mask of the ox	0		Muscle: +20, Muscle Percent: +10, Maximum HP: +20, Avatar: "Murderbot", Last Available: "2017-04"
 9454	enhanced murderbot spring injector	0		Effect: "Pop-eyed", Effect Duration: 68, Last Available: "2017-04"
 9455	squat skewed miser's energetic murderbot whip	0		Maximum MP Percent: +20, Meat Drop: +10, Last Available: "2017-04"
-9456	huge scandalous murderbot plasma rifle of the sweet-tooth	0		Sleaze Damage: +5, Candy Drop: +100, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	huge scandalous murderbot plasma rifle of the sweet-tooth	0		Sleaze Damage: +5, Candy Drop: +100, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	shaking Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9335,7 +9335,7 @@
 9463	tumbling Space Baby children's book	0		Last Available: "2017-04"
 9464	lime green Space Baby bawbaw	0		Last Available: "2017-04"
 9465	purple Spacegate	0		Last Available: "2017-04"
-9466	normal small Aldebaran sardines	2	good	Last Available: "2017-04"
+9466	small normal Aldebaran sardines	2	good	Last Available: "2017-04"
 9467	weak perfectly mixed pulsating Centauri fish wine	2	EPIC	Last Available: "2017-04"
 9468	pickled spinning oxygen	1		Effect: "The Halls of Muscularity", Effect Duration: 35, Last Available: "2017-04"
 9469	sharpshooter's studded Spacegate scientist's insignia	0		Damage Absorption: +80, Critical Hit Percent: +10, Single Equip, Last Available: "2017-04"
@@ -9362,9 +9362,9 @@
 9490	energized Threatening Missive	0		Effect: "The Style... of the Future", Effect Duration: 29
 9491	Targeted Plague Vector	0		
 9492	spinning suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	bouncing scandalous Kremlin's Greatest Briefcase of vim and vigor of chilblains	0		Maximum HP Percent: +50, Cold Damage: +25, Sleaze Damage: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	bouncing scandalous Kremlin's Greatest Briefcase of vim and vigor of chilblains	0		Maximum HP Percent: +50, Cold Damage: +25, Sleaze Damage: +5, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	hand-crafted mirror basic martini	4	EPIC	Last Available: "2017-06"
-9495	irresponsibly strong lousy narrow improved martini	6	decent	Last Available: "2017-06"
+9495	lousy irresponsibly strong narrow improved martini	6	decent	Last Available: "2017-06"
 9496	mediocre pulsating splendid martini	3	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9414,9 +9414,9 @@
 9542	red exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	twirling purple X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	practically non-alcoholic enchanted drinkable DUFRESNE Suds	1	good	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2017-09"
+9545	drinkable enchanted practically non-alcoholic DUFRESNE Suds	1	good	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2017-09"
 9546	olive medical-grade mafia pinky ring of the detective	0		Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-9547	delicious watered-down flask of port	2	awesome	
+9547	watered-down delicious flask of port	2	awesome	
 9548	Jack Frost's curative contract enforcement stick	0		Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 9549	rotten Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
 9550	acceptable huge jug of booze	3	good	Last Available: "2017-10"
@@ -9434,10 +9434,10 @@
 9562	fuchsia blinking toasty chilly brawny protection stick of mayonnaise	0		Muscle Percent: +20, Cold Damage: +5, Hot Damage: +5, Sleaze Spell Damage: +50
 9563	triple-ionized twirling roll of meat	0		Effect: "Crimbo Nostalgia", Effect Duration: 69
 9564	beefy mafia thumb ring of Flo-Jo	0		Muscle: +10, Initiative: +100, Single Equip
-9565	enhanced activated green blurry cocoa chondrule	0		Effect: "Bells in the Batfry", Effect Duration: 56, Last Available: "2020-09"
+9565	enhanced activated blurry green cocoa chondrule	0		Effect: "Bells in the Batfry", Effect Duration: 56, Last Available: "2020-09"
 9566	frosty quilted mafia middle finger ring	0		Damage Absorption: +40, Cold Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	blinking zippy avaricious lion tamer's boxer's steel drivin' hammer	0		Muscle Percent: +10, Experience (familiar): +2, Meat Drop: +30, Initiative: +20
-9568	cyan wobbly piece of steel	0		
+9568	wobbly cyan piece of steel	0		
 9569	padded mafia pointer finger ring of horror	0		Damage Absorption: +20, Spooky Spell Damage: +25, Single Equip
 9570	huge friendly worksite credentials	0		Familiar Weight: +3, Single Equip
 9571	tumbling rosewater-soaked hale stylish wizardly negotiatin' hammer	0		Mysticality: +25, Moxie: +25, Maximum HP: +20, Stench Resistance: +3
@@ -9448,12 +9448,12 @@
 9576	huge hale mafia organizer badge	0		Maximum HP: +20, Single Equip
 9577	mafia filofax	0		
 9578	huge transparent nog	1	awesome	Last Available: "2017-12"
-9579	super-sized rotten unfinished fruitcake	5	crappy	Last Available: "2017-12"
+9579	rotten super-sized unfinished fruitcake	5	crappy	Last Available: "2017-12"
 9580	energized green and cracker	0		Effect: "Prideful Strut", Effect Duration: 48, Last Available: "2017-12"
 9581	hand-crafted watered-down neg grog	2	EPIC	Last Available: "2017-12"
 9582	normal ghostly half double fruitcake	4	good	Last Available: "2017-12"
-9583	decent gigantic huge hushed puppy	8	good	Last Available: "2017-12"
-9584	decent bite-sized narrow muffled muffuletta	1	good	Last Available: "2017-12"
+9583	gigantic decent huge hushed puppy	8	good	Last Available: "2017-12"
+9584	bite-sized decent narrow muffled muffuletta	1	good	Last Available: "2017-12"
 9585	low-calorie bland shushed potatoes	1	decent	Last Available: "2017-12"
 9586	wobbly censurious plastic mime functionary	0		Sleaze Resistance: +3, Last Available: "2017-12"
 9587	green upside-down skewed pulsating wholesome plastic mime scientist	0		Maximum HP Percent: +10, Last Available: "2017-12"
@@ -9484,7 +9484,7 @@
 9612	upside-down silent N	0		Last Available: "2017-12"
 9613	squat silent O	0		Last Available: "2017-12"
 9614	blinking silent P	0		Last Available: "2017-12"
-9615	skewed wobbly maroon silent Q	0		Last Available: "2017-12"
+9615	maroon skewed wobbly silent Q	0		Last Available: "2017-12"
 9616	blinking silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
@@ -9506,7 +9506,7 @@
 9634	squat vibrating cheerful pajama pants of the early riser	0		Maximum MP Percent: +10, Adventures: +7, Last Available: "2017-12"
 9635	blinking blinking The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
-9637	blurry spinning The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
+9637	spinning blurry The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	bouncing The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
@@ -9517,11 +9517,11 @@
 9645	The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	blinking The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	irresponsibly strong delicious ghostly twirling executive mime flask	9	awesome	Last Available: "2017-12"
+9648	delicious irresponsibly strong twirling ghostly executive mime flask	9	awesome	Last Available: "2017-12"
 9649	yummy nega-mushroom	3	awesome	Last Available: "2017-12"
 9650	artisanal weak nega-mushroom wine	2	EPIC	Last Available: "2017-12"
 9651	energized non-diffused Cheer-Up soda	0		Effect: "Coy to the Hurled", Effect Duration: 63, Last Available: "2017-12"
-9652	moldy massive mime army rations	9	crappy	Last Available: "2017-12"
+9652	massive moldy mime army rations	9	crappy	Last Available: "2017-12"
 9653	mediocre mime army wine	3	decent	Last Available: "2017-12"
 9654	modified blinking mime army superserum	1		Effect: "Bells in the Batfry", Effect Duration: 30, Last Available: "2017-12"
 9655	triple-vacuum-sealed pressed huge fuchsia mime army camouflage kit	0		Effect: "Coated Arms", Effect Duration: 69, Last Available: "2017-12"
@@ -9550,7 +9550,7 @@
 9678	pulsating blinking cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
-9681	half-sized moldy extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
+9681	moldy half-sized extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
 9682	acceptable mulled hobo wine	3	good	Last Available: "2018-12"
 9683	teal burning newspaper	0		Last Available: "2018-12"
 9684	blurry twirling careful steel-toed burning paper hat of the brute	0		Muscle Percent: +30, Damage Reduction: 9, Monster Level: -10, Lasts Until Rollover, Last Available: "2018-12"
@@ -9594,7 +9594,7 @@
 9726	shaking gravedigger's forbidden psychic's amulet	0		Spell Damage Percent: +50, Spooky Damage: +10, Last Available: "2018-02"
 9727	decent shaking heart-shaped candy whetstone	4	good	Last Available: "2018-02"
 9728	super-sized moldy Swedish massage fish	5	crappy	Last Available: "2018-02"
-9729	tolerable watered-down Third Base	2	good	Last Available: "2018-02"
+9729	watered-down tolerable Third Base	2	good	Last Available: "2018-02"
 9730	hand-crafted practically non-alcoholic Bustle Hustler	1	EPIC	Last Available: "2018-02"
 9731	flattened huge Fabiotion	0		Effect: "Reedy Pipes", Effect Duration: 27, Last Available: "2018-02"
 9732	flattened quadruple-unsweetened Bettie page	0		Effect: "Grape Expectations", Effect Duration: 61, Last Available: "2018-02"
@@ -9630,7 +9630,7 @@
 9762	Globmule	0		Last Available: "2018-03"
 9763	upside-down Bluzzard	0		Last Available: "2018-03"
 9764	huge Faux	0		Last Available: "2018-03"
-9765	red squat Sledgehamster	0		Last Available: "2018-03"
+9765	squat red Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	squat Dressage	0		Last Available: "2018-03"
@@ -9643,7 +9643,7 @@
 9775	teal Turtive	0		Last Available: "2018-03"
 9776	squat Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
-9778	ghostly jittery Waifuton	0		Last Available: "2018-03"
+9778	jittery ghostly Waifuton	0		Last Available: "2018-03"
 9779	Gorillape	0		Last Available: "2018-03"
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	Snoutlet	0		Last Available: "2018-03"
@@ -9653,18 +9653,18 @@
 9785	Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
 9787	tumbling Mustardigrade	0		Last Available: "2018-03"
-9788	jittery mirror Ched	0		Last Available: "2018-03"
+9788	mirror jittery Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	blue Bicycle	0		Last Available: "2018-03"
-9792	ghostly cyan Vamprey	0		Last Available: "2018-03"
+9792	cyan ghostly Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
 9794	Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
-9799	gray bouncing Amanitee	0		Last Available: "2018-03"
+9799	bouncing gray Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	huge Vulgure	0		Last Available: "2018-03"
 9802	twirling Squib	0		Last Available: "2018-03"
@@ -9743,8 +9743,8 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	blinking mirror map to the Cursed Village	0		Last Available: "2018-04"
 9877	twirling map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	moldy massive denastified haunch	9	crappy	Last Available: "2018-04"
-9879	watered-down special artisanal upside-down bad rum and good cola	2	EPIC	Effect: "Become Superficially interested", Effect Duration: 25, Last Available: "2018-04"
+9878	massive moldy denastified haunch	9	crappy	Last Available: "2018-04"
+9879	special watered-down artisanal upside-down bad rum and good cola	2	EPIC	Effect: "Become Superficially interested", Effect Duration: 25, Last Available: "2018-04"
 9880	triple-Vulcanized Vulcanized Potion of Heroism	0		Effect: "Elemental Flavor", Effect Duration: 33, Last Available: "2018-04"
 9881	Usain Bolt's veiny educational leggings of the Spider Queen	0		Experience: +1, Maximum HP: +10, Initiative: +80, Last Available: "2018-04"
 9882	rock-hard boxer's Master Thief's utility belt of the blizzard	0		Muscle Percent: +10, Damage Reduction: 5, Cold Spell Damage: +25, Single Equip, Last Available: "2018-04"
@@ -9764,7 +9764,7 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	huge notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	bad skewed two meat muck	3	decent	
-9899	jumbo bland twirling chocolate Ogre Chieftain	5	decent	
+9899	bland jumbo twirling chocolate Ogre Chieftain	5	decent	
 9900	flavorless chocolate &quot;Phoenix&quot;	4	decent	
 9901	bland chocolate Spider Queen	3	decent	
 9902	delicious hipster cocktail	4	awesome	
@@ -9783,22 +9783,22 @@
 9915	rotten spinning good guava	3	crappy	
 9916	artisanal twirling gin and ginger	3	EPIC	
 9917	upside-down Thwaitgold chigger statuette	0		
-9918	dried huge maroon gaseous gravy	1		
+9918	dried maroon huge gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	A Guide to Safari	0		Skill: "Experience Safari"
 9922	improved triple-polymerized jittery Shielding Potion	0		Effect: "Moon-Eyed", Effect Duration: 64, Last Available: "2018-06"
 9923	altered Punching Potion	0		Effect: "Mo' Hobo", Effect Duration: 57, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	modified bouncing cyan Nightmare Fuel	1		Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2018-06"
-9926	blinking huge Gathered Meat-Clip	0		Last Available: "2020-09"
+9925	modified cyan bouncing Nightmare Fuel	1		Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2018-06"
+9926	huge blinking Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	skewed Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	pulsating dog trainer's dance instructor's Brutal brogues of Leguizamo of Flo-Jo	0		Experience Percent (Moxie): +10, Monster Level: +20, Experience (familiar): +1, Initiative: +100, Lasts Until Rollover, Last Available: "2018-07"
 9930	fuchsia wobbly wobbly aromatic foul-smelling Tesla vibrating Draftsman's driving gloves	0		Maximum MP Percent: +10, Stench Damage: +10, Stench Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-07"
 9931	blurry purple bouncing perfumed gravedigger's occult Nouveau nosering of the sewer	0		Spell Damage Percent: +25, Stench Damage: +25, Spooky Damage: +10, Stench Resistance: +5, Lasts Until Rollover, Last Available: "2018-07"
 9932	wet sharkfin gumbo	0		Effect: "Stone-Faced", Effect Duration: 24, Last Available: "2018-07"
-9933	boiled boiled huge teal boiling broth	0		Effect: "Soles of Glass", Effect Duration: 20, Last Available: "2018-07"
+9933	boiled boiled teal huge boiling broth	0		Effect: "Soles of Glass", Effect Duration: 20, Last Available: "2018-07"
 9934	deionized cyan interrogative elixir	0		Effect: "Nuts about Candy", Effect Duration: 53, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	Bastille Battalion tattoo kit	0		Last Available: "2018-07"
@@ -9821,7 +9821,7 @@
 9953	rotten PB&J with the crusts cut off	4	crappy	Last Available: "2018-09"
 9954	fireproof energetic dorky glasses	0		Maximum MP Percent: +20, Hot Resistance: +3, Single Equip, Last Available: "2018-09"
 9955	Annie Oakley's brawny ponytail clip	0		Muscle Percent: +20, Critical Hit Percent: +20, Last Available: "2018-09"
-9956	paint palette of extreme caution	0		Monster Level: -25, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	paint palette of extreme caution	0		Monster Level: -25, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	pickled skewed Purple Beast energy drink	1		Last Available: "2018-09"
 9959	wobbly razor-sharp cosmetic football	0		Weapon Damage Percent: +25, Last Available: "2018-09"
@@ -9843,15 +9843,15 @@
 9976	skewed Jeselnik's Fonzie's party pants	0		Experience (Moxie): +1, Sleaze Damage: +25, Last Available: "2018-09"
 9977	flame-retardant resourceful brainy party whip	0		Mysticality: +5, Maximum MP: +50, Hot Resistance: +1, Last Available: "2018-09"
 9978	shaking Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	distilled acceptable TRIO cup of beer	5	good	Last Available: "2018-09"
+9979	acceptable distilled TRIO cup of beer	5	good	Last Available: "2018-09"
 9980	bland huge mirror party platter for one	4	decent	Last Available: "2018-09"
 9981	distilled Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	lightning-fast aromatic party crasher	0		Stench Resistance: +1, Initiative: +40, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9983	lightning-fast aromatic party crasher	0		Stench Resistance: +1, Initiative: +40, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	blurry Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	blinking party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	wobbly latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	ghostly Jack Frost's &quot;I Voted!&quot; sticker	0		Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-11"
@@ -9862,7 +9862,7 @@
 9995	experienced snakeskin jacket of the early riser	0		Experience: +2, Adventures: +7, Last Available: "2018-11"
 9996	slime glob	0		Last Available: "2018-11"
 9997	shaking jittery slime glob	0		Last Available: "2018-11"
-9998	blinking blue slime glob	0		Last Available: "2018-11"
+9998	blue blinking slime glob	0		Last Available: "2018-11"
 9999	lightning-fast slime waders of chilblains of the boozehound	0		Cold Damage: +25, Booze Drop: +100, Initiative: +40, Last Available: "2018-11"
 10001	aromatic ruddy healthy slime fedora	0		Maximum HP Percent: 60, Stench Resistance: +1, Last Available: "2018-11"
 10002	Tesla curative razor-sharp slime knuckles	0		Weapon Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-11"
@@ -9881,8 +9881,8 @@
 10015	adequate squat cherry pie	3	good	Last Available: "2018-11"
 10016	acceptable eggnog	4	good	Last Available: "2018-11"
 10017	ghostly glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	flavorless miniature fancy Hell ramen	2	decent	Effect: "Wings of the Grasshopper", Effect Duration: 30, Last Available: "2018-11"
-10019	tolerable watered-down maroon twirling gimlet	2	good	Last Available: "2018-11"
+10018	miniature flavorless fancy Hell ramen	2	decent	Effect: "Wings of the Grasshopper", Effect Duration: 30, Last Available: "2018-11"
+10019	tolerable watered-down twirling maroon gimlet	2	good	Last Available: "2018-11"
 10020	drinkable jittery twice-haunted screwdriver	3	good	Last Available: "2018-11"
 10021	snack-sized rotten candy cane	2	crappy	Last Available: "2018-12"
 10022	smooth weak teal runny fermented egg	2	awesome	Last Available: "2018-12"
@@ -9899,21 +9899,21 @@
 10033	Sinatra's stylish pristine walrus tusk	0		Moxie: +25, Experience (Moxie): +5, Last Available: "2018-12"
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	double-paned knitted scorching Staff of Frozen Lard of the glutton	0		Hot Damage: +25, Cold Resistance: 8, Food Drop: +100, Last Available: "2018-12"
-10036	huge bouncing bomb	0		Last Available: "2018-12"
+10036	bouncing huge bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	stale super-sized lime green jittery grilled mooseflank	5	decent	Last Available: "2018-12"
-10040	special normal moosemeat pie	4	good	Effect: "Coy to the Hurled", Effect Duration: 10, Last Available: "2018-12"
+10039	super-sized stale jittery lime green grilled mooseflank	5	decent	Last Available: "2018-12"
+10040	normal special moosemeat pie	4	good	Effect: "Coy to the Hurled", Effect Duration: 10, Last Available: "2018-12"
 10041	curative balanced antler	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
 10042	wholesome dam	0		Maximum HP Percent: +10, Damage Reduction: 9, Last Available: "2018-12"
 10043	acceptable olive beavermouth	3	good	Last Available: "2018-12"
-10044	lousy mirror lime green beaver punch (papaya)	4	decent	Last Available: "2018-12"
-10045	hand-crafted weak squat beaver punch (peach)	2	EPIC	Last Available: "2018-12"
-10046	watered-down mediocre beaver punch (cherry)	2	decent	Last Available: "2018-12"
+10044	lousy lime green mirror beaver punch (papaya)	4	decent	Last Available: "2018-12"
+10045	weak hand-crafted squat beaver punch (peach)	2	EPIC	Last Available: "2018-12"
+10046	mediocre watered-down beaver punch (cherry)	2	decent	Last Available: "2018-12"
 10047	tumbling Canadian lantern of the cougar of dire peril	0		Moxie: +20, Weapon Damage: +20, Last Available: "2018-12"
 10048	wobbly red Herculean muskox-skin cap	0		Experience (Muscle): +1, Last Available: "2018-12"
 10049	spinning Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	stale diet wobbly glass of raw eggs	1	decent	Last Available: "2018-12"
+10050	diet stale wobbly glass of raw eggs	1	decent	Last Available: "2018-12"
 10051	acceptable blurry punch-drunk punch	3	good	Last Available: "2018-12"
 10052	boiled mirror body spradium	1		Last Available: "2018-12"
 10053	upside-down greasy bauxite beret	0		Sleaze Spell Damage: +10, Last Available: "2018-12"
@@ -9930,17 +9930,17 @@
 10064	mirror jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	mediocre bouncing beer	4	decent	Last Available: "2018-12"
-10067	miniature moldy shaking yule gruel	2	crappy	Last Available: "2018-12"
-10068	drinkable weak hot watered rum	2	good	Last Available: "2018-12"
+10067	moldy miniature shaking yule gruel	2	crappy	Last Available: "2018-12"
+10068	weak drinkable hot watered rum	2	good	Last Available: "2018-12"
 10069	artisanal bottle of Crimbognac	4	EPIC	Last Available: "2018-12"
 10070	moldy gigantic Crimboysters Rockefeller	10	crappy	Last Available: "2018-12"
-10071	powdered huge bouncing Crimbeau de toilette	1		Effect: "Mitre Cut", Effect Duration: 25, Last Available: "2018-12"
+10071	powdered bouncing huge Crimbeau de toilette	1		Effect: "Mitre Cut", Effect Duration: 25, Last Available: "2018-12"
 10072	shaking Crimbo candle	0		Last Available: "2018-12"
 10073	twirling green Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10075	olive huge Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
+10075	huge olive Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10077	bouncing cyan squat Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
+10077	cyan squat bouncing Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	Jeselnik's therapeutic Crimbolex watch of bravery	0		Sleaze Damage: +25, Spooky Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-12"
 10080	narrow Crimbo tattoo kit	0		Last Available: "2018-12"
@@ -9961,22 +9961,22 @@
 10095	narrow groovy smooth marble mariachi hat	0		Moxie: +15, Moxie Percent: +10, Last Available: "2019-12"
 10096	compressed marble molecules	1		Last Available: "2019-12"
 10097	deionized dry Mallomarbles	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 66
-10098	upside-down supercharged sinister punching bag	0		Spell Damage: +10, Maximum MP Percent: +30, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	wobbly reassuring pith helmet of the ox	0		Muscle: +20, Spooky Resistance: +1, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	frightening mansplainer's poncho	0		Monster Level: +15, Spooky Damage: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	dog trainer's pendant of the blizzard	0		Experience (familiar): +1, Cold Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	mirror palazzos of the dark arts of terror	0		Spell Damage Percent: +100, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	tumbling padded pseudoaccordion of incineration	0		Damage Absorption: +20, Hot Spell Damage: +50, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	upside-down supercharged sinister punching bag	0		Spell Damage: +10, Maximum MP Percent: +30, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	wobbly reassuring pith helmet of the ox	0		Muscle: +20, Spooky Resistance: +1, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	frightening mansplainer's poncho	0		Monster Level: +15, Spooky Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	dog trainer's pendant of the blizzard	0		Experience (familiar): +1, Cold Spell Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	mirror palazzos of the dark arts of terror	0		Spell Damage Percent: +100, Spooky Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	tumbling padded pseudoaccordion of incineration	0		Damage Absorption: +20, Hot Spell Damage: +50, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	powdered blurry pieces	1		Last Available: "2020-12"
 10105	vacuum-sealed non-boiled ghostly Para-Pop	0		Effect: "Sauce Monocle", Effect Duration: 31
-10106	lime green aromatic quilted terra cotta truss	0		Damage Absorption: +40, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	Da Vinci's terra cotta trousers of bravery	0		Experience (Mysticality): +5, Spooky Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	coward's slick terra cotta tongs	0		Moxie: +10, Monster Level: -20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	ghostly medical-grade thinker's terra cotta train	0		Mysticality: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	Jeselnik's nippy terra cotta tie tack	0		Cold Damage: +10, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	manspreader's experienced terra cotta tambourine	0		Experience: +2, Monster Level: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	lime green aromatic quilted terra cotta truss	0		Damage Absorption: +40, Stench Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	Da Vinci's terra cotta trousers of bravery	0		Experience (Mysticality): +5, Spooky Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	coward's slick terra cotta tongs	0		Moxie: +10, Monster Level: -20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	ghostly medical-grade thinker's terra cotta train	0		Mysticality: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	Jeselnik's nippy terra cotta tie tack	0		Cold Damage: +10, Sleaze Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	manspreader's experienced terra cotta tambourine	0		Experience: +2, Monster Level: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	vaporized terra cotta tidbits	1		Last Available: "2020-12"
-10113	warmed dry purple narrow wobbly terra panna cotta	0		Effect: "On the Trolley", Effect Duration: 19
+10113	warmed dry narrow purple wobbly terra panna cotta	0		Effect: "On the Trolley", Effect Duration: 19
 10114	greedy velour voulge of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +20, Last Available: "2021-12"
 10115	double-paned supercharged velour vambraces	0		Maximum MP Percent: +30, Cold Resistance: +5, Single Equip, Last Available: "2021-12"
 10116	dog trainer's clever velour veil	0		Maximum MP: +20, Experience (familiar): +1, Single Equip, Last Available: "2021-12"
@@ -9991,22 +9991,22 @@
 10125	miser's groovy glass spectacles	0		Moxie Percent: +10, Meat Drop: +10, Single Equip, Last Available: "2021-12"
 10126	ghostly wool sinister glass shiv	0		Spell Damage: +10, Cold Resistance: +1, Last Available: "2021-12"
 10127	Temple Grandin's razor-sharp glass serape	0		Weapon Damage Percent: +25, Familiar Weight: +7, Last Available: "2021-12"
-10128	denatured ghostly huge glass shards	1		Last Available: "2021-12"
+10128	denatured huge ghostly glass shards	1		Last Available: "2021-12"
 10129	super-electrified huge hard candy	0		Effect: "Ogred and Oublietted", Effect Duration: 38
-10130	wobbly auspicious Jeselnik's loofah lumberjack's hat	0		Sleaze Damage: +25, Item Drop: +10, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	sizzling fortified loofah lei	0		Damage Absorption: +60, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	green stanky loofah lederhosen of extreme caution	0		Monster Level: -25, Stench Spell Damage: +25, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	coward's loofah ladle of the sewer	0		Monster Level: -20, Stench Damage: +25, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	supercharged loofah legwarmers of the boozehound	0		Maximum MP Percent: +30, Booze Drop: +100, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	spinning lightning-fast loofah lavalier of the empath	0		Familiar Weight: +5, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	wobbly auspicious Jeselnik's loofah lumberjack's hat	0		Sleaze Damage: +25, Item Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	sizzling fortified loofah lei	0		Damage Absorption: +60, Hot Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	green stanky loofah lederhosen of extreme caution	0		Monster Level: -25, Stench Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	coward's loofah ladle of the sewer	0		Monster Level: -20, Stench Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	supercharged loofah legwarmers of the boozehound	0		Maximum MP Percent: +30, Booze Drop: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	spinning lightning-fast loofah lavalier of the empath	0		Familiar Weight: +5, Initiative: +40, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	mixed loofah lumps	1		Last Available: "2022-12"
 10137	polarized shaking chocolate-covered loofah	0		Effect: "Human-Human Hybrid", Effect Duration: 25
-10138	horrifying stiffened flagstone flag	0		Damage Reduction: 1, Spooky Damage: +25, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	huge lightning-fast flagstone flail of Leguizamo	0		Monster Level: +20, Initiative: +40, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	resourceful wizardly flagstone flip-flops	0		Mysticality: +25, Maximum MP: +50, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	family-friendly quilted flagstone fez	0		Damage Absorption: +40, Sleaze Resistance: +1, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	olive extremely unsafe flagstone fleece of the glutton	0		Weapon Damage Percent: +100, Food Drop: +100, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	family-friendly rock-hard flagstone fringe	0		Damage Reduction: 5, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	horrifying stiffened flagstone flag	0		Damage Reduction: 1, Spooky Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	huge lightning-fast flagstone flail of Leguizamo	0		Monster Level: +20, Initiative: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	resourceful wizardly flagstone flip-flops	0		Mysticality: +25, Maximum MP: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	family-friendly quilted flagstone fez	0		Damage Absorption: +40, Sleaze Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	olive extremely unsafe flagstone fleece of the glutton	0		Weapon Damage Percent: +100, Food Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	family-friendly rock-hard flagstone fringe	0		Damage Reduction: 5, Sleaze Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	modified flagstone flagments	1		Last Available: "2022-12"
 10145	double-adjusted super-alkaline red Flag by the Foot&trade;	0		Effect: "Hombre Muerto Caminando", Effect Duration: 31
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	steel-toed elf army poncho	0		Damage Reduction: 9, Lasts Until Rollover, Last Available: "2019-12"
-10155	tasty snack-sized bouncing elf army field rations	2	awesome	Last Available: "2019-12"
+10155	snack-sized tasty bouncing elf army field rations	2	awesome	Last Available: "2019-12"
 10156	mirror gingernade	0		Last Available: "2019-12"
 10157	narrow cyan Sherlock's veiny discarded bowtie	0		Maximum HP: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2019-12"
 10158	hand-crafted fancy martiny	3	EPIC	Effect: "Crocodile Tear", Effect Duration: 20, Last Available: "2019-12"
@@ -10029,11 +10029,11 @@
 10163	ionized warmed bouncing government-issued candy	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 18
 10164	moist Pneumo bar	0		Effect: "Impregnably Delicious", Effect Duration: 64
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	lime green grievous Lil' Doctor&trade; bag of chilblains	0		Weapon Damage Percent: +50, Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	lime green grievous Lil' Doctor&trade; bag of chilblains	0		Weapon Damage Percent: +50, Cold Damage: +25, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blinking blood bag	0		
 10169	moldy bloodstick	3	crappy	
-10170	fortified mediocre bottle of Sanguiovese	5	decent	
-10171	spoiled half-sized actual blood sausage	2	crappy	
+10170	mediocre fortified bottle of Sanguiovese	5	decent	
+10171	half-sized spoiled actual blood sausage	2	crappy	
 10172	mediocre jittery upside-down mulled blood	4	decent	
 10173	bland purple blood snowcone	3	decent	
 10174	aged ghostly Red Russian	3	awesome	
@@ -10076,7 +10076,7 @@
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	normal snack-sized pineapple slab	2	good	Last Available: "2019-04"
 10213	adequate hibiscus petal	3	good	Last Available: "2019-04"
-10214	double-concentrated jittery tumbling lime green huge mint leaf	0		Effect: "Got Your Boots On", Effect Duration: 43, Last Available: "2019-04"
+10214	double-concentrated lime green jittery tumbling huge mint leaf	0		Effect: "Got Your Boots On", Effect Duration: 43, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	twisted narrow ice molecule	1		Last Available: "2019-04"
 10217	lime green Red Roger's reliquary	0		Last Available: "2019-04"
@@ -10099,12 +10099,12 @@
 10234	lousy wobbly Island Hurricane	3	decent	Last Available: "2019-04"
 10235	hand-crafted high-proof blinking Skull Punch	9	EPIC	Last Available: "2019-04"
 10236	hand-crafted Electric Punch	3	EPIC	Last Available: "2019-04"
-10237	practically non-alcoholic acceptable Smuggler's Punch	1	good	Last Available: "2019-04"
+10237	acceptable practically non-alcoholic Smuggler's Punch	1	good	Last Available: "2019-04"
 10238	watered-down mediocre Scorpion Bowl	2	decent	Last Available: "2019-04"
-10239	bad watered-down Turtle Bowl	2	decent	Last Available: "2019-04"
+10239	watered-down bad Turtle Bowl	2	decent	Last Available: "2019-04"
 10240	irresponsibly strong perfectly mixed Cobra Bowl	6	EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	censurious friendly Da Vinci's vampyric cloake of the dark arts	0		Experience (Mysticality): +5, Spell Damage Percent: +100, Familiar Weight: +3, Sleaze Resistance: +3, Item Drop: +5, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	censurious friendly Da Vinci's vampyric cloake of the dark arts	0		Experience (Mysticality): +5, Spell Damage Percent: +100, Familiar Weight: +3, Sleaze Resistance: +3, Item Drop: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	modified chilled one piece of bubble gum	0		Effect: "Feeling No Pain", Effect Duration: 27
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	scorching vibrating rosy-cheeked Fourth of May Cosplay Saber	0		Maximum HP Percent: +30, Maximum MP Percent: +10, Hot Damage: +25, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	scorching vibrating rosy-cheeked Fourth of May Cosplay Saber	0		Maximum HP Percent: +30, Maximum MP Percent: +10, Hot Damage: +25, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	mirror Thwaitgold nymph statuette	0		
-10254	blinking toasty Jim Carey's mansplainer's Annie Oakley's therapeutic rock-hard occult personal trainer's Samson's supercool weightlifter's hewn moon-rune spoon	0		Muscle: +15, Moxie Percent: +20, Experience (Muscle): +5, Experience Percent (Muscle): +10, Spell Damage Percent: +25, Damage Reduction: 5, Critical Hit Percent: +20, Monster Level: 40, Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	blinking toasty Jim Carey's mansplainer's Annie Oakley's therapeutic rock-hard occult personal trainer's Samson's supercool weightlifter's hewn moon-rune spoon	0		Muscle: +15, Moxie Percent: +20, Experience (Muscle): +5, Experience Percent (Muscle): +10, Spell Damage Percent: +25, Damage Reduction: 5, Critical Hit Percent: +20, Monster Level: 40, Hot Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	blinking Jeselnik's grievous personal trainer's Beach Comb	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	blinking Jeselnik's grievous personal trainer's Beach Comb	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Sleaze Damage: +25, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	gray small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10147,7 +10147,7 @@
 10282	blinking auspicious Samson's pirate cutlass of mayonnaise	0		Experience (Muscle): +5, Sleaze Spell Damage: +50, Item Drop: +10, Single Equip, Last Available: "2019-07"
 10283	scorching smartaleck's tricorn hat of the ox	0		Muscle: +20, Moxie Percent: +30, Hot Damage: +25, Last Available: "2019-07"
 10284	Lo Pan's hale swash buckle of the bloodbag	0		Maximum HP: 120, Spell Critical Percent: +30, Single Equip, Last Available: "2019-07"
-10285	blue skewed meteorite fragment	0		Last Available: "2019-07"
+10285	skewed blue meteorite fragment	0		Last Available: "2019-07"
 10286	wobbly prompt meteorite earring of the ox of incineration	0		Muscle: +20, Hot Spell Damage: +50, Adventures: +3, Single Equip, Last Available: "2019-07"
 10287	cyan scorching supercharged Herculean meteorite necklace	0		Experience (Muscle): +1, Maximum MP Percent: +30, Hot Damage: +25, Single Equip, Last Available: "2019-07"
 10288	stanky sizzling dangerous meteorite ring	0		Weapon Damage: +10, Hot Damage: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2019-07"
@@ -10168,7 +10168,7 @@
 10303	massive adequate squat campfire hot dog	9	good	Last Available: "2019-08"
 10304	bland campfire baked potato	3	decent	Last Available: "2019-08"
 10305	snack-sized rotten campfire s'more	2	crappy	Last Available: "2019-08"
-10306	fancy normal super-sized red campfire beans	5	good	Effect: "Nature's Bounty", Effect Duration: 45, Last Available: "2019-08"
+10306	super-sized fancy normal red campfire beans	5	good	Effect: "Nature's Bounty", Effect Duration: 45, Last Available: "2019-08"
 10307	normal gray campfire stew	4	good	Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	extra-vacuum-sealed energized leftover chocolate bar	0		Effect: "Shawarma Warm War", Effect Duration: 12
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	spoiled pulsating space chowder	3	crappy	
-10321	weak lousy space wine	2	decent	
+10321	lousy weak space wine	2	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	pulsating packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	maroon Pocket Professor memory chip	0		
@@ -10194,7 +10194,7 @@
 10335	blue diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	spoiled fancy wobbly bu&ntilde;uelos Jaliscos	3	crappy	Effect: "Smoking like a Bandit", Effect Duration: 50, Last Available: "2019-12"
-10338	adequate low-calorie flan del mar	1	good	Last Available: "2019-12"
+10338	low-calorie adequate flan del mar	1	good	Last Available: "2019-12"
 10339	decent gigantic Baja sopapilla	10	good	Last Available: "2019-12"
 10340	plastic Mer-kin baker of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2019-12"
 10341	scorching plastic sea elf	0		Hot Damage: +25, Last Available: "2019-12"
@@ -10203,22 +10203,22 @@
 10344	wobbly greedy plastic Dolph Bossin	0		Meat Drop: +20, Last Available: "2019-12"
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	decent twirling mana-coated yams	3	good	Last Available: "2019-11"
-10347	normal small enchanted blurry mana-basted tofurkey leg	2	good	Effect: "Ooh, Sweet!", Effect Duration: 10, Last Available: "2019-11"
-10348	tiny bland bouncing mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
+10347	enchanted normal small blurry mana-basted tofurkey leg	2	good	Effect: "Ooh, Sweet!", Effect Duration: 10, Last Available: "2019-11"
+10348	bland tiny bouncing mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
 10349	moldy mana-stuffed herbal stuffing	4	crappy	Last Available: "2019-11"
 10350	mirror human musk	0		Last Available: "2019-12"
 10351	Vulcanized jittery patch of extra-warm fur	0		Effect: "Uncaged Power", Effect Duration: 57, Last Available: "2019-12"
 10352	altered mirror huge industrial lubricant	1		Last Available: "2019-12"
-10353	nitrogenated aerosolized squat green bouncing unfinished pleasure	0		Effect: "Crocodile Tear", Effect Duration: 42, Last Available: "2019-12"
+10353	nitrogenated aerosolized squat bouncing green unfinished pleasure	0		Effect: "Crocodile Tear", Effect Duration: 42, Last Available: "2019-12"
 10354	twisted tumbling huge vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	powdered a bug's lymph	1		Last Available: "2019-12"
 10356	super-wet concentrated organic potpourri	0		Effect: "Ancient Protected", Effect Duration: 54, Last Available: "2019-12"
-10357	hand-crafted irresponsibly strong enchanted boot flask	9	EPIC	Effect: "Tasting the Rainbow", Effect Duration: 15, Last Available: "2019-12"
+10357	hand-crafted enchanted irresponsibly strong boot flask	9	EPIC	Effect: "Tasting the Rainbow", Effect Duration: 15, Last Available: "2019-12"
 10358	wet unsweetened shaking infernal snowball	0		Effect: "Flower Power", Effect Duration: 47, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	vaporized lime green jittery fish sauce	1		Last Available: "2019-12"
 10361	rotten immense purple guffin	7	crappy	Last Available: "2019-12"
-10362	dehydrated red ghostly twirling Shantix&trade;	1		Effect: "Beta Carotene Overdose", Effect Duration: 10, Last Available: "2019-12"
+10362	dehydrated red twirling ghostly Shantix&trade;	1		Effect: "Beta Carotene Overdose", Effect Duration: 10, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	diluted spinning green non-Euclidean angle	1		Last Available: "2019-12"
 10365	non-electrified tarnished polymerized blurry peppermint syrup	0		Effect: "Corona de la Salsa", Effect Duration: 27, Last Available: "2019-12"
@@ -10231,7 +10231,7 @@
 10372	vibrating forbidden oxygenated eggnog helmet	0		Spell Damage Percent: +50, Maximum MP Percent: +10, Adventure Underwater, Last Available: "2019-12"
 10373	huge hand-knitted diving booties	0		Last Available: "2019-12"
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
-10375	improved narrow maroon concentrated fish broth	0		Effect: "Natural 20", Effect Duration: 30, Last Available: "2019-12"
+10375	improved maroon narrow concentrated fish broth	0		Effect: "Natural 20", Effect Duration: 30, Last Available: "2019-12"
 10376	corrupted flattened liquid SONAR	0		Effect: "Tiki Thoughtfulness", Effect Duration: 49, Last Available: "2019-12"
 10377	skewed map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
 10378	Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
@@ -10242,7 +10242,7 @@
 10383	cyan soggy gingerbread chunk	0		Last Available: "2019-12"
 10384	deionized salty gumdrop	0		Effect: "Innately Wise", Effect Duration: 62, Last Available: "2019-12"
 10385	squat avaricious Sinatra's ribbon candy ascot	0		Experience (Moxie): +5, Meat Drop: +30, Single Equip, Last Available: "2019-12"
-10386	maroon jittery moist Crimbo spices	0		Last Available: "2019-12"
+10386	jittery maroon moist Crimbo spices	0		Last Available: "2019-12"
 10387	jittery intact anemone spike	0		Last Available: "2019-12"
 10388	squat shellacked anemoney clip	0		Damage Reduction: 7, Single Equip, Last Available: "2019-12"
 10389	wobbly runny icing	0		Last Available: "2019-12"
@@ -10253,12 +10253,12 @@
 10394	green stanky sinister Mer-kin rollpin	0		Spell Damage: +10, Stench Spell Damage: +25, Last Available: "2019-12"
 10395	fuchsia personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	gray tinsel fin	0		Familiar Weight: +5
-10397	snack-sized tasty bowl of mernudo	2	awesome	Last Available: "2019-12"
+10397	tasty snack-sized bowl of mernudo	2	awesome	Last Available: "2019-12"
 10398	hand-crafted fishelada	3	EPIC	Last Available: "2019-12"
 10399	diet bland ojo de pez burrito	1	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	narrow waterlogged cloth	0		Last Available: "2019-12"
-10402	huge narrow waterlogged stuffing	0		Last Available: "2019-12"
+10402	narrow huge waterlogged stuffing	0		Last Available: "2019-12"
 10403	waterlogged	0		Last Available: "2019-12"
 10404	waterlogged	0		Last Available: "2019-12"
 10405	hale nutcracker hat of the blizzard	0		Maximum HP: +20, Cold Spell Damage: +25, Last Available: "2019-12"
@@ -10271,9 +10271,9 @@
 10412	slick nutcracker cape	0		Moxie: +10, Item Drop: +5, Last Available: "2019-12"
 10413	Annie Oakley's electrified nutcracker epaulets	0		Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	rotten upside-down red salt plum	3	crappy	Last Available: "2019-12"
+10415	rotten red upside-down salt plum	3	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	snack-sized flavorless and bean	2	decent	Last Available: "2019-12"
+10417	flavorless snack-sized and bean	2	decent	Last Available: "2019-12"
 10418	vibrating steel-toed forbidden kelp-holly gun	0		Spell Damage Percent: +50, Damage Reduction: 9, Maximum MP Percent: +10, Last Available: "2019-12"
 10419	Yuleviathan necklace of vim and vigor of Gandalf	0		Maximum HP Percent: +50, Spell Critical Percent: +20, Single Equip, Last Available: "2019-12"
 10420	chaotic hardy peppermint spine	0		Maximum HP: +50, Spell Critical Percent: +10, Last Available: "2019-12"
@@ -10282,26 +10282,26 @@
 10423	rosewater-soaked kelp-holly drape of the overflowing toilet	0		Stench Spell Damage: +50, Stench Resistance: +3, Last Available: "2019-12"
 10424	medical-grade veiny wicked Staff of the Peppermint Twist of the pedagogue	0		Experience: +3, Spell Damage: +5, Maximum HP: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-12"
 10425	stale tempura and bean	3	decent	Last Available: "2019-12"
-10426	perfectly mixed watered-down salt plum sake	2	super EPIC	Last Available: "2019-12"
-10427	anodized dry green narrow upside-down pressurized potion of possessiveness	0		Effect: "Indescribable Flavor", Effect Duration: 32, Last Available: "2019-12"
+10426	watered-down perfectly mixed salt plum sake	2	super EPIC	Last Available: "2019-12"
+10427	anodized dry narrow upside-down green pressurized potion of possessiveness	0		Effect: "Indescribable Flavor", Effect Duration: 32, Last Available: "2019-12"
 10428	pressed unsweetened almond	0		Effect: "Electrolit Up", Effect Duration: 33
 10429	flattened handful of mixed nuts	0		Effect: "Always be Collecting", Effect Duration: 36, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	mirror bouncing shellacked studded Retrospecs of the detective	0		Damage Absorption: +80, Damage Reduction: 7, Item Drop: +20, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
-10433	red spinning shaking unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
+10432	mirror bouncing shellacked studded Retrospecs of the detective	0		Damage Absorption: +80, Damage Reduction: 7, Item Drop: +20, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10433	shaking red spinning unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	wobbly Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	scandalous stanky occult brainy Powerful Glove of the brazier	0		Mysticality: +5, Spell Damage Percent: +25, Hot Spell Damage: +25, Stench Spell Damage: +25, Sleaze Damage: +5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	scandalous stanky occult brainy Powerful Glove of the brazier	0		Mysticality: +5, Spell Damage Percent: +25, Hot Spell Damage: +25, Stench Spell Damage: +25, Sleaze Damage: +5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	upside-down enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	wobbly perfumed wool Drip harness of the detective	0		Cold Resistance: +1, Stench Resistance: +5, Item Drop: +20
 10442	squat beefy drippy truncheon	0		Muscle: +10, Single Equip
 10443	squat Driplet	0		
 10444	drippy snail shell	0		
-10445	stale huge wobbly drippy nugget	9	drippy	
-10446	tolerable watered-down glass of drippy wine	2	drippy	
-10447	diet rotten wobbly drippy caviar	1	drippy	
+10445	huge stale wobbly drippy nugget	9	drippy	
+10446	watered-down tolerable glass of drippy wine	2	drippy	
+10447	rotten diet wobbly drippy caviar	1	drippy	
 10448	spoiled red drippy plum(?)	3	drippy	
 10449	strapping drippy stake	0		Muscle: +5, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10369,7 +10369,7 @@
 10512	jittery nippy wicked chipped coffee mug	0		Spell Damage: +5, Cold Damage: +10, Last Available: "2020-04"
 10513	Left-Hand Man action figure of the bloodbag	0		Maximum HP: +100, Last Available: "2020-04"
 10514	drippy seed	0		
-10515	jittery skewed drippy grub	0		
+10515	skewed jittery drippy grub	0		
 10516	blinking drippy bezoar	0		
 10517	upside-down Drip Institute petri dish	0		
 10518	huge drippy ichor	0		
@@ -10379,12 +10379,12 @@
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	blinking drippy stein	0		
-10525	drinkable spirit-forward drippy pilsner	5	drippy	
+10525	spirit-forward drinkable drippy pilsner	5	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	lustrous drippy orb	0		
 10530	gray gory drippy orb of Leguizamo	0		Monster Level: +20
-10531	tumbling olive jittery annealed drippy orb	0		
+10531	jittery tumbling olive annealed drippy orb	0		
 10532	Guzzlr application	0		Free Pull
 10533	curative hale Guzzlr tablet	0		Maximum HP: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2020-05"
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
@@ -10397,7 +10397,7 @@
 10541	bad olive Ghiaccio Colada	4	decent	Last Available: "2020-05"
 10542	hand-crafted Sourfinger	4	EPIC	Last Available: "2020-05"
 10543	tolerable Nog-on-the-Cob	3	good	Last Available: "2020-05"
-10544	spirit-forward fancy tolerable Steamboat	5	good	Effect: "You Know Who to Call", Effect Duration: 30, Last Available: "2020-05"
+10544	tolerable spirit-forward fancy Steamboat	5	good	Effect: "You Know Who to Call", Effect Duration: 30, Last Available: "2020-05"
 10545	smooth triple-distilled Buttery Boy	6	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	dog trainer's supercharged clown car key	0		Maximum MP Percent: +30, Experience (familiar): +1, Last Available: "2020-08"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	scorching resourceful birch battery	0		Maximum MP: +50, Hot Damage: +25, Lasts Until Rollover, Last Available: "2020-08"
-10585	teal lightning-fast greasy wizardly ebony epee	0		Mysticality: +25, Sleaze Spell Damage: +10, Initiative: +40, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	rock-hard weeping willow wand of terror of the cheetah	0		Damage Reduction: 5, Spooky Spell Damage: +10, Initiative: +60, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	blurry miser's fireproof supercool beechwood blowgun	0		Moxie Percent: +20, Hot Resistance: +3, Meat Drop: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	teal lightning-fast greasy wizardly ebony epee	0		Mysticality: +25, Sleaze Spell Damage: +10, Initiative: +40, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	rock-hard weeping willow wand of terror of the cheetah	0		Damage Reduction: 5, Spooky Spell Damage: +10, Initiative: +60, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	blurry miser's fireproof supercool beechwood blowgun	0		Moxie Percent: +20, Hot Resistance: +3, Meat Drop: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	wobbly bouncing Jack Frost's Annie Oakley's maple magnet of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +20, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	bouncing inspector's foul-smelling hemlock helm of the brute	0		Muscle Percent: +30, Stench Damage: +10, Item Drop: +15, Last Available: "2020-08"
@@ -10474,7 +10474,7 @@
 10618	purple frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	gray nasty desk bell	0		Last Available: "2020-09"
-10621	skewed purple greasy desk bell	0		Last Available: "2020-09"
+10621	purple skewed greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
@@ -10510,8 +10510,8 @@
 10654	anodized boiling hot cocoa	0		Effect: "Smoking like a Bandit", Effect Duration: 49, Last Available: "2020-12"
 10655	energized cool hot cocoa	0		Effect: "Eyes Wide Propped", Effect Duration: 18, Last Available: "2020-12"
 10656	pressed ghostly overly-fancy hot cocoa	0		Effect: "You're Rubber", Effect Duration: 24, Last Available: "2020-12"
-10657	warmed boiled spinning maroon hot cocoa au beurre	0		Effect: "Innately Truthy", Effect Duration: 34, Last Available: "2020-12"
-10658	moist spinning teal hot cocoa with rainbow marshmallows	0		Effect: "Dreadful Smell", Effect Duration: 34, Last Available: "2020-12"
+10657	warmed boiled maroon spinning hot cocoa au beurre	0		Effect: "Innately Truthy", Effect Duration: 34, Last Available: "2020-12"
+10658	moist teal spinning hot cocoa with rainbow marshmallows	0		Effect: "Dreadful Smell", Effect Duration: 34, Last Available: "2020-12"
 10659	shaking Book of Old-Timey Carols of the glutton	0		Food Drop: [+100*event(December)], Last Available: "2020-12"
 10660	wobbly nasty Crimbo smile	0		Stench Damage: [+5*event(December)], Last Available: "2020-12"
 10661	SalesCo sample kit of Tarzan	0		Experience (Muscle): [+3*event(December)], Last Available: "2020-12"
@@ -10544,7 +10544,7 @@
 10688	spinning Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	bouncing bouncing Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	bouncing gray Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
-10691	bouncing mirror lime green food drive button	0		Single Equip, Last Available: "2020-12"
+10691	bouncing lime green mirror food drive button	0		Single Equip, Last Available: "2020-12"
 10692	booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	blinking candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
@@ -10575,11 +10575,11 @@
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	bad barrel-aged eggnog	4	decent	Last Available: "2020-12"
 10721	spoiled hand-crafted candy cane	3	crappy	Last Available: "2020-12"
-10722	delicious snack-sized drive-thru burger	2	awesome	Last Available: "2020-12"
+10722	snack-sized delicious drive-thru burger	2	awesome	Last Available: "2020-12"
 10723	lousy Boulevardier cocktail	4	decent	Last Available: "2020-12"
 10724	pressed enhanced Hotwire&trade; brand candy rope	0		Effect: "Lobos Fresh", Effect Duration: 30, Last Available: "2020-12"
 10725	moldy tiny bowl full of jelly	1	crappy	Last Available: "2020-12"
-10726	weak perfectly mixed bouncing Eye and a Twist	2	EPIC	Last Available: "2020-12"
+10726	perfectly mixed weak bouncing Eye and a Twist	2	EPIC	Last Available: "2020-12"
 10727	extra-polymerized extra-ionized tarnished Chubby and Plump bar	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 67, Last Available: "2020-12"
 10728	blue digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10596,23 +10596,23 @@
 10740	pickled corrupted ghostly battery (AA)	0		Effect: "Stimulated Brain", Effect Duration: 31, Last Available: "2021-03"
 10741	diffused cold-filtered battery (D)	0		Effect: "Always In Motion", Effect Duration: 11, Last Available: "2021-03"
 10742	oxidized enhanced shaking bouncing battery (9-Volt)	0		Effect: "Texas Elegance", Effect Duration: 25, Last Available: "2021-03"
-10743	chilled corrupted tumbling green battery (lantern)	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 39, Last Available: "2021-03"
+10743	chilled corrupted green tumbling battery (lantern)	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 39, Last Available: "2021-03"
 10744	concentrated wet twirling pulsating battery (car)	0		Effect: "The Dinsey Spirit", Effect Duration: 55, Last Available: "2021-03"
-10745	twirling blinking cryptocloak	0		Last Available: "2025-12"
+10745	blinking twirling cryptocloak	0		Last Available: "2025-12"
 10746	spinning marshmallow	0		
-10747	weak artisanal marshmallow bomb	2	EPIC	Last Available: "2021-03"
+10747	artisanal weak marshmallow bomb	2	EPIC	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	skewed shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	altered short beer	0		Effect: "Rave Concentration", Effect Duration: 37, Last Available: "2021-05"
 10753	flattened concentrated unsweetened cyan short stack of pancakes	0		Effect: "Dancing Prowess", Effect Duration: 14, Last Available: "2021-05"
 10754	improved short stick of butter	0		Effect: "Ack!  Barred!", Effect Duration: 47, Last Available: "2021-05"
 10755	improved nitrogenated extra-corrupted wobbly short glass of water	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 44, Last Available: "2021-05"
-10756	flattened denatured mirror yellow short	0		Effect: "Helping Comes Second", Effect Duration: 53, Last Available: "2021-05"
+10756	flattened denatured yellow mirror short	0		Effect: "Helping Comes Second", Effect Duration: 53, Last Available: "2021-05"
 10757	jittery Thwaitgold quantum bug statuette	0		
 10758	blurry quantum of familiar	0		
-10759	rock-hard familiar scrapbook of James Dean	0		Experience (Moxie): +3, Damage Reduction: 5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	rock-hard familiar scrapbook of James Dean	0		Experience (Moxie): +3, Damage Reduction: 5, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	upside-down packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	Jack Frost's nippy stiffened fedora-mounted fountain	0		Damage Reduction: 1, Cold Damage: +10, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-07"
@@ -10646,11 +10646,11 @@
 10790	spinning B. L. A. R. T. of the bloodbag	0		Maximum HP: +100, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	Thwaitgold fire beetle statuette	0		
 10792	empty nacho cheese can	0		Water: 1
-10793	shaking squat literal bucket hat	0		Water: 5
+10793	squat shaking literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	narrow packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	mansplainer's resourceful Oprah's Fonzie's stylish strapping industrial fire extinguisher	0		Muscle: +5, Moxie: +25, Experience (Moxie): +1, Maximum MP Percent: +50, Maximum MP: +50, Monster Level: +15, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	mansplainer's resourceful Oprah's Fonzie's stylish strapping industrial fire extinguisher	0		Muscle: +5, Moxie: +25, Experience (Moxie): +1, Maximum MP Percent: +50, Maximum MP: +50, Monster Level: +15, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	jittery The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,7 +10660,7 @@
 10804	Tesla Oprah's Daylight Shavings Helmet of wisdom	0		Mysticality: +15, Maximum MP Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2021-11"
 10805	eggwater	1	EPIC	Last Available: "2021-12"
 10806	decent bread man	3	good	Last Available: "2021-12"
-10807	bland small plain candy cane	2	decent	Last Available: "2021-12"
+10807	small bland plain candy cane	2	decent	Last Available: "2021-12"
 10808	stale flour cookie	4	decent	Last Available: "2021-12"
 10809	lard-coated plastic food lab	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2021-12"
 10810	therapeutic plastic nog lab	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2021-12"
@@ -10672,20 +10672,20 @@
 10816	fuchsia wool supercool groovy ice crown	0		Moxie Percent: 30, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2021-12"
 10817	jeans of Tarzan of doom of the cheetah	0		Experience (Muscle): +3, Spooky Spell Damage: +50, Initiative: +60, Lasts Until Rollover, Last Available: "2021-12"
 10818	blurry razor-sharp Rosewater's cool ice wrap	0		Moxie: +5, Mysticality Percent: +30, Weapon Damage Percent: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	stale snack-sized tofu pop	2	decent	Last Available: "2021-12"
-10820	bland bouncing narrow bowl of prescription candy	3	decent	Last Available: "2021-12"
+10819	snack-sized stale tofu pop	2	decent	Last Available: "2021-12"
+10820	bland narrow bouncing bowl of prescription candy	3	decent	Last Available: "2021-12"
 10821	stale half-sized fishcake	2	decent	Last Available: "2021-12"
 10822	spoiled bone broth	3	crappy	Last Available: "2021-12"
-10823	snack-sized spoiled star pop	2	crappy	Last Available: "2021-12"
+10823	spoiled snack-sized star pop	2	crappy	Last Available: "2021-12"
 10824	drinkable blinking Doc's Fortifying Wine	4	good	Last Available: "2021-12"
 10825	artisanal ghostly Doc's Smartifying Wine	3	EPIC	Last Available: "2021-12"
-10826	drinkable teal ghostly Doc's Limbering Wine	3	good	Last Available: "2021-12"
+10826	drinkable ghostly teal Doc's Limbering Wine	3	good	Last Available: "2021-12"
 10827	acceptable blinking Doc's Medical-Grade Wine	3	good	Last Available: "2021-12"
-10828	modified pulsating squat Homebodyl&trade;	1		Last Available: "2021-12"
+10828	modified squat pulsating Homebodyl&trade;	1		Last Available: "2021-12"
 10829	denatured narrow pulsating Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	pickled huge Breathitin&trade;	1		Last Available: "2021-12"
 10831	vaporized Fleshazole&trade;	1		Effect: "Quadrilled", Effect Duration: 40, Last Available: "2021-12"
-10832	cold-filtered quadruple-galvanized narrow bouncing anti-burn cream	0		Effect: "Ooh, Bitter!", Effect Duration: 21, Last Available: "2021-12"
+10832	cold-filtered quadruple-galvanized bouncing narrow anti-burn cream	0		Effect: "Ooh, Bitter!", Effect Duration: 21, Last Available: "2021-12"
 10833	cold-filtered moist anti-freeze cream	0		Effect: "Slimy Flavor", Effect Duration: 12, Last Available: "2021-12"
 10834	alkaline concentrated anti-goosebump cream	0		Effect: "Concentrated Concentration", Effect Duration: 20, Last Available: "2021-12"
 10835	colloidal triple-cold-filtered improved anti-odor cream	0		Effect: "This Is Where You're a Viking", Effect Duration: 27, Last Available: "2021-12"
@@ -10706,7 +10706,7 @@
 10850	goo magnet	0		Last Available: "2021-12"
 10851	jittery flame-wreathed cozy scarf	0		Hot Spell Damage: +10, Last Available: "2021-12"
 10852	normal huge Crimbo cookie	3	good	Last Available: "2023-06"
-10853	denatured purple shaking fleshy putty	0		Effect: "Action", Effect Duration: 44, Last Available: "2021-12"
+10853	denatured shaking purple fleshy putty	0		Effect: "Action", Effect Duration: 44, Last Available: "2021-12"
 10854	weightlifter's third ear	0		Muscle: +15, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
@@ -10714,7 +10714,7 @@
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	narrow projectile chemistry set	0		Last Available: "2021-12"
 10860	jittery green huge depleted Crimbonium football helmet of the pedagogue	0		Experience: +3, Last Available: "2021-12"
-10861	mirror blurry synthetic rock	0		Last Available: "2021-12"
+10861	blurry mirror synthetic rock	0		Last Available: "2021-12"
 10862	rotten &quot;caramel&quot;	4	crappy	Last Available: "2021-12"
 10863	blinking perfumed self-repairing earmuffs	0		Stench Resistance: +5, Last Available: "2021-12"
 10864	purple carnivorous potted plant of bravery	0		Spooky Resistance: +5, Last Available: "2021-12"
@@ -10723,13 +10723,13 @@
 10867	potato alarm clock	0		Last Available: "2021-12"
 10868	rotten lab-grown meat	3	crappy	Last Available: "2021-12"
 10869	forbidden fleece	0		Spell Damage Percent: +50, Last Available: "2021-12"
-10870	wobbly blue boxed gumball machine	0		Last Available: "2021-12"
+10870	blue wobbly boxed gumball machine	0		Last Available: "2021-12"
 10871	blue cloning kit	0		Last Available: "2021-12"
 10872	pants of the ox	0		Muscle: +20, Last Available: "2021-12"
 10873	wool Samson's can of mixed everything of the businessman	0		Experience (Muscle): +5, Cold Resistance: +1, Meat Drop: +50, Last Available: "2021-12"
 10874	jittery Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	small rotten meatball	2	crappy	Last Available: "2021-12"
+10876	rotten small meatball	2	crappy	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	jittery refurbished air fryer	0		Last Available: "2021-12"
@@ -10765,7 +10765,7 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	Vulcanized single-use dust mask	0		Effect: "White Knuckles", Effect Duration: 38, Last Available: "2022-05"
 10911	non-adjusted flattened tarnished upside-down gaffer's tape	0		Effect: "Cosmic Flavor", Effect Duration: 24, Last Available: "2022-05"
-10912	adequate jumbo fancy 20-lb can of rice and beans	5	good	Effect: "Heal Thy Nanoself", Effect Duration: 5, Last Available: "2022-05"
+10912	jumbo fancy adequate 20-lb can of rice and beans	5	good	Effect: "Heal Thy Nanoself", Effect Duration: 5, Last Available: "2022-05"
 10913	bar of freeze-dried water	1	crappy	Last Available: "2022-05"
 10914	stale expired MRE	3	decent	Last Available: "2022-05"
 10915	flavorless cool mint precipice bar	3	decent	Last Available: "2022-05"
@@ -10777,12 +10777,12 @@
 10921	lousy Dad's brandy	3	decent	Last Available: "2022-06"
 10922	skewed skewed grievous teacher's pen of the sewer	0		Weapon Damage Percent: +50, Stench Damage: +25, Last Available: "2022-06"
 10923	rotten bite-sized fire-roasted lake trout	1	crappy	Last Available: "2022-06"
-10924	stale big guilty sprout	5	decent	Last Available: "2022-06"
+10924	big stale guilty sprout	5	decent	Last Available: "2022-06"
 10925	horrifying careful mother's necklace	0		Monster Level: -10, Spooky Damage: +25, Last Available: "2022-06"
 10926	denatured trampled ticket stub	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 24, Last Available: "2022-06"
 10927	oxidized energized savings bond	0		Effect: "Standard Cheer", Effect Duration: 29, Last Available: "2022-06"
 10928	tumbling designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	pickled sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10798,14 +10798,14 @@
 10942	green dinosaur repellent	0		
 10943	frosty camouflage vest	0		Cold Spell Damage: +10
 10944	Dinodollar	0		
-10945	skewed red valuable dinosaur droppings	0		
+10945	red skewed valuable dinosaur droppings	0		
 10946	ghostly dinosaur pheromone kit	0		
 10947	resourceful clever awkward dinosaur research harness	0		Maximum MP: 70, Item Drop: +5
 10948	Samson's reflective vest	0		Experience (Muscle): +5
 10949	dog trainer's dinosaur	0		Experience (familiar): +1
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	purple tumbling packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	blinking Jurassic Parka of Gandalf of the cheetah	0		Spell Critical Percent: +20, Initiative: +60, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	blinking Jurassic Parka of Gandalf of the cheetah	0		Spell Critical Percent: +20, Initiative: +60, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	squat boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	wobbly autumn-aton	0		Last Available: "2022-10"
 10955	pressed autumn leaf	0		Effect: "Creepin' Up on You", Effect Duration: 43, Last Available: "2022-10"
@@ -10828,8 +10828,8 @@
 10972	snack-sized stale roasted vegetable of Jarlsberg	2	decent	Last Available: "2022-11"
 10973	normal St. Pete's sneaky smoothie	3	good	Last Available: "2022-11"
 10974	moldy wobbly Pete's wiley whey bar	4	crappy	Last Available: "2022-11"
-10975	adequate enchanted Pete's rich ricotta	4	good	Effect: "Ogred and Oublietted", Effect Duration: 45, Last Available: "2022-11"
-10976	weak hand-crafted ghostly Boris's beer	2	EPIC	Last Available: "2022-11"
+10975	enchanted adequate Pete's rich ricotta	4	good	Effect: "Ogred and Oublietted", Effect Duration: 45, Last Available: "2022-11"
+10976	hand-crafted weak ghostly Boris's beer	2	EPIC	Last Available: "2022-11"
 10977	bland honey bun of Boris	3	decent	Last Available: "2022-11"
 10978	small flavorless Boris's bread	2	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
@@ -10842,10 +10842,10 @@
 10986	ghostly Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	stale purple baked veggie ricotta casserole	3	decent	Last Available: "2022-11"
-10989	toothsome special narrow plain calzone	4	awesome	Effect: "Cold Blooded", Effect Duration: 30, Last Available: "2022-11"
+10989	special toothsome narrow plain calzone	4	awesome	Effect: "Cold Blooded", Effect Duration: 30, Last Available: "2022-11"
 10990	normal roasted vegetable focaccia	3	good	Last Available: "2022-11"
-10991	low-calorie bland Pizza of Legend	1	decent	Last Available: "2022-11"
-10992	tasty diet bouncing Calzone of Legend	1	awesome	Last Available: "2022-11"
+10991	bland low-calorie Pizza of Legend	1	decent	Last Available: "2022-11"
+10992	diet tasty bouncing Calzone of Legend	1	awesome	Last Available: "2022-11"
 10993	teal Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
 10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
@@ -10867,19 +10867,19 @@
 11011	gator shades of wisdom of temperance	0		Mysticality: +15, Sleaze Resistance: +5, Single Equip
 11012	tumbling milk cap	0		
 11013	artisanal Charleston Choo-Choo	3	EPIC	
-11014	bad watered-down Velvet Veil	2	decent	
+11014	watered-down bad Velvet Veil	2	decent	
 11015	hand-crafted Marltini	3	EPIC	
 11016	smooth Strong, Silent Type	3	awesome	
 11017	high-proof hand-crafted Mysterious Stranger	6	EPIC	
 11018	lousy Champagne Shimmy	4	decent	
 11019	the Sot's parcel	0		
-11020	pulsating shellacked thinker's ceramic cestus	0		Mysticality: +10, Damage Reduction: 7, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	huge smelly ceramic centurion shield of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Stench Spell Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	twirling shellacked hardened ceramic celery grater	0		Damage Reduction: 20, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	shaking dangerous ceramic celsiturometer of the ox of the early riser	0		Muscle: +20, Weapon Damage: +10, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	rosewater-soaked greasy ceramic cerecloth belt of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	upside-down lard-coated Jeselnik's curative ceramic cenobite's robe	0		Sleaze Damage: +25, Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
-11026	mixed mirror wobbly maroon ceramic scree	1		Effect: "You're Not Cooking", Effect Duration: 45, Last Available: "2023-12"
+11020	pulsating shellacked thinker's ceramic cestus	0		Mysticality: +10, Damage Reduction: 7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	huge smelly ceramic centurion shield of wisdom of Gandalf	0		Mysticality: +15, Spell Critical Percent: +20, Stench Spell Damage: +10, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	twirling shellacked hardened ceramic celery grater	0		Damage Reduction: 20, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	shaking dangerous ceramic celsiturometer of the ox of the early riser	0		Muscle: +20, Weapon Damage: +10, Adventures: +7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	rosewater-soaked greasy ceramic cerecloth belt of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Stench Resistance: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	upside-down lard-coated Jeselnik's curative ceramic cenobite's robe	0		Sleaze Damage: +25, Sleaze Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11026	mixed wobbly mirror maroon ceramic scree	1		Effect: "You're Not Cooking", Effect Duration: 45, Last Available: "2023-12"
 11027	non-polymerized lime green jittery extra-hard jawbreaker	0		Effect: "Bone Chilling", Effect Duration: 55
 11028	avaricious curative boxer's chiffon chevrons	0		Muscle Percent: +10, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-12"
 11029	Sherlock's fortified extremely unsafe chiffon chapeau	0		Weapon Damage Percent: +100, Damage Absorption: +60, Item Drop: +25, Last Available: "2023-12"
@@ -10904,7 +10904,7 @@
 11048	Trainbot radar monocle	0		Single Equip
 11049	upside-down pile of Trainbot parts	0		
 11050	concentrated ghostly Trainbot circuitry	0		Effect: "Whitened Teeth", Effect Duration: 30
-11051	tarnished yellow blurry Trainbot tubing	0		Effect: "Slimily Speedy", Effect Duration: 28
+11051	tarnished blurry yellow Trainbot tubing	0		Effect: "Slimily Speedy", Effect Duration: 28
 11052	nitrogenated warmed flattened lime green twirling Trainbot plating	0		Effect: "Pretending to Pretend", Effect Duration: 53
 11053	quantum Trainbot optics	0		Effect: "Super-Mega-Charged", Effect Duration: 24
 11054	warmed altered blurry Trainbot servomotors	0		Effect: "Mutated", Effect Duration: 25
@@ -10924,21 +10924,21 @@
 11068	lost elf luggage	0		
 11069	upside-down Trainbot luggage hook	0		Single Equip
 11070	decent olive honey-drenched ham slice	4	good	
-11071	perfectly mixed practically non-alcoholic teal mostly-empty bottle of cookie wine	1	EPIC	
-11072	decent jumbo Crimbo food scraps	5	good	
+11071	practically non-alcoholic perfectly mixed teal mostly-empty bottle of cookie wine	1	EPIC	
+11072	jumbo decent Crimbo food scraps	5	good	
 11073	ghostly arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
-11075	blinking blurry table-scraper	0		Single Equip
-11076	maroon bouncing pulsating Trainbot slag	0		
+11075	blurry blinking table-scraper	0		Single Equip
+11076	bouncing pulsating maroon Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	bland fancy steamed oyster	3	decent	Effect: "Gummiskin", Effect Duration: 25
+11078	fancy bland steamed oyster	3	decent	Effect: "Gummiskin", Effect Duration: 25
 11079	blurry really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	huge steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	perfectly mixed Crimbosmopolitan	4	EPIC	Last Available: "2022-12"
-11085	jumbo rotten fuchsia Crimbo dinner	5	crappy	Last Available: "2022-12"
+11085	rotten jumbo fuchsia Crimbo dinner	5	crappy	Last Available: "2022-12"
 11086	narrow ghostly overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	cyan The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10950,11 +10950,11 @@
 11094	pulsating wicked beefcake's grubby wool trousers of vim and vigor	0		Muscle: +25, Spell Damage: +5, Maximum HP Percent: +50
 11095	perfumed frightening rosy-cheeked studded grubby wool gloves	0		Damage Absorption: +80, Maximum HP Percent: +30, Spooky Damage: +5, Stench Resistance: +5, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	practically non-alcoholic perfectly mixed gray jittery nice warm beer	1	EPIC	
+11097	perfectly mixed practically non-alcoholic jittery gray nice warm beer	1	EPIC	
 11098	green grubby woolball	0		
 11099	spinning twirling Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
-11101	narrow tumbling groveling gravel	0		Last Available: "2023-01"
+11101	tumbling narrow groveling gravel	0		Last Available: "2023-01"
 11102	denatured ghostly fruity pebble	1		Last Available: "2023-01"
 11103	spinning lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
@@ -10987,7 +10987,7 @@
 11132	blinking hollow rock	0		Last Available: "2023-02"
 11133	Vulcanized wobbly angry agate	0		Effect: "Angry like the Wolf", Effect Duration: 19, Last Available: "2023-02"
 11134	improved diffused ghostly lump of loyal latite	0		Effect: "Hot Hands", Effect Duration: 63, Last Available: "2023-02"
-11135	special decent half-sized shadow sausage	2	good	Effect: "stats.enq", Effect Duration: 45, Last Available: "2023-03"
+11135	decent half-sized special shadow sausage	2	good	Effect: "stats.enq", Effect Duration: 45, Last Available: "2023-03"
 11136	pulsating toasty fortified shadow skin	0		Damage Absorption: +60, Hot Damage: +5, Last Available: "2023-03"
 11137	unsweetened wobbly shadow flame	0		Effect: "Ghost Finger", Effect Duration: 25, Last Available: "2023-03"
 11138	immense delicious shadow bread	8	awesome	Last Available: "2023-03"
@@ -10997,7 +10997,7 @@
 11142	huge shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
 11144	aged distilled shadow venom	5	awesome	Last Available: "2023-03"
-11145	dried mirror spinning shadow nectar	1		Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2023-03"
+11145	dried spinning mirror shadow nectar	1		Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2023-03"
 11146	Van der Graaf MacGyver's shadow stick of the bloodbag	0		Maximum HP: +100, Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-03"
 11147	pulsating wool mansplainer's bat paw	0		Monster Level: +15, Cold Resistance: +1
 11148	wicked uncursed bat paw	0		Spell Damage: +5
@@ -11035,10 +11035,10 @@
 11180	jittery maroon executive double-paned frosty shadow monocle	0		Cold Spell Damage: +10, Cold Resistance: +5, Meat Drop: +40, Single Equip
 11181	tumbling shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	delicious gigantic shadow hot dog	7	awesome	
-11183	perfectly mixed enchanted pulsating shadow martini	4	EPIC	Effect: "Cat Class, Cat Style", Effect Duration: 45
+11183	enchanted perfectly mixed pulsating shadow martini	4	EPIC	Effect: "Cat Class, Cat Style", Effect Duration: 45
 11184	mixed huge olive shadow pill	1		Effect: "Pisces in the Skyces", Effect Duration: 25
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	boiled shadow candy	0		Effect: "Just Aged Enough", Effect Duration: 38
 11189	cyan replica Mr. Accessory	0		
@@ -11075,12 +11075,12 @@
 11220	shaking replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shaking shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	blue coward's Rosewater's Cincho de Mayo of Gandalf of Leguizamo	0		Mysticality Percent: +30, Spell Critical Percent: +20, Monster Level: 0, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	blue coward's Rosewater's Cincho de Mayo of Gandalf of Leguizamo	0		Mysticality Percent: +30, Spell Critical Percent: +20, Monster Level: 0, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	purple blurry dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	tumbling replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
 11227	blurry replica Crimbo sapling	0		
-11228	spinning squat replica puck	0		
+11228	squat spinning replica puck	0		
 11229	replica Chateau Mantegna room key	0		
 11230	replica Deck of Every Card	0		
 11231	tumbling replica Source terminal	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	greasy arcane researcher's replica Jurassic Parka	0		Experience Percent (Mysticality): +10, Sleaze Spell Damage: +10
 11250	twirling replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	fuchsia replica Ten Dollars	0		
 11254	lightning-fast stanky coward's baleful replica Cincho de Mayo	0		Spell Damage: +25, Monster Level: -20, Stench Spell Damage: +25, Initiative: +40, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,19 +11112,19 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	prompt hardy Newton's beefcake's &quot;I survived Y2K&quot; T-Shirt of the empath of the overflowing toilet	0		Muscle: +25, Experience (Mysticality): +3, Maximum HP: +50, Familiar Weight: +5, Stench Spell Damage: +50, Adventures: +3, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	Usain Bolt's pro skateboard	0		Item Drop: +5, Initiative: +80, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	Usain Bolt's pro skateboard	0		Item Drop: +5, Initiative: +80, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	teal Mr. Accessaturday	0		Last Available: "2023-06"
 11262	ghostly Meat Butler	0		Last Available: "2023-06"
 11263	narrow Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	Flash Liquidizer Ultra Dousing Accessory of temperance	0		Sleaze Resistance: +5, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	Flash Liquidizer Ultra Dousing Accessory of temperance	0		Sleaze Resistance: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	upside-down Sherlock's rosewater-soaked extremely unsafe Newton's Amulet of Perpetual Darkness	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Stench Resistance: +3, Item Drop: +25, Last Available: "2023-06"
 11268	upside-down Giant monolith	0		Last Available: "2023-06"
 11269	blinking Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	squat VHS Tape	0		Last Available: "2023-06"
 11271	liquefied chilled scroll of minor invulnerability	0		Effect: "Billiards Belligerence", Effect Duration: 40, Last Available: "2023-06"
-11272	twirling fuchsia Lapis Lazuli	0		Last Available: "2023-06"
+11272	fuchsia twirling Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
@@ -11134,7 +11134,7 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	enchanted acceptable Sexy Cosmo	3	good	Effect: "Heightened Senses", Effect Duration: 30, Last Available: "2023-06"
+11282	acceptable enchanted Sexy Cosmo	3	good	Effect: "Heightened Senses", Effect Duration: 30, Last Available: "2023-06"
 11283	huge blurry Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	lightning-fast educational red-soled high heels of terror	0		Experience: +1, Spooky Spell Damage: +10, Initiative: +40, Last Available: "2023-06"
 11285	stale cyburger	3	decent	Last Available: "2025-12"
@@ -11199,10 +11199,10 @@
 11344	autumnic bomb	0		
 11345	shaking forest canopy bed	0		
 11346	wobbly day shortener	0		
-11347	twirling tumbling blinking extra time	0		
+11347	blinking twirling tumbling extra time	0		
 11348	tumbling jittery sizzling chilly autumnal aegis	0		Cold Damage: +5, Hot Damage: +10, Damage Reduction: 9
 11349	irradiated polymerized green distilled resin	0		Effect: "Saucegoggles", Effect Duration: 66
-11350	upside-down squat red super-heated leaf	0		
+11350	red squat upside-down super-heated leaf	0		
 11351	lit leaf lasso	0		
 11352	tied-up leaflet	0		
 11353	tied-up monstera	0		
@@ -11226,7 +11226,7 @@
 11371	shaking narrow clerical automa-core	0		
 11372	fuchsia handful of Boltsmann bearings	0		
 11373	Spring Bros. solenoid	0		
-11374	mirror bouncing Spring Bros. ID badge	0		
+11374	bouncing mirror Spring Bros. ID badge	0		
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
@@ -11253,7 +11253,7 @@
 11398	blurry military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	mediocre watered-down pulsating tumbling bouncing Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
+11401	mediocre watered-down tumbling pulsating bouncing Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
 11402	blinking blue Elf Army machine parts	0		Last Available: "2023-12"
 11403	blurry Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	greasy Crimbuccaneer lantern of the bloodbag of the cheetah	0		Maximum HP: +100, Sleaze Spell Damage: +10, Initiative: +60, Last Available: "2023-12"
@@ -11274,8 +11274,8 @@
 11419	red sage Elf Guard broom of wisdom	0		Mysticality: +15, Mysticality Percent: +10, Last Available: "2023-12"
 11420	maroon knitted Jim Carey's Fonzie's Crimbuccaneer tavern swab	0		Experience (Moxie): +1, Monster Level: +25, Cold Resistance: +3, Last Available: "2023-12"
 11421	shaking Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	triple-distilled tolerable old-school pirate grog	9	good	Last Available: "2023-12"
-11423	jumbo flavorless narrow grog nuts	5	decent	Last Available: "2023-12"
+11422	tolerable triple-distilled old-school pirate grog	9	good	Last Available: "2023-12"
+11423	flavorless jumbo narrow grog nuts	5	decent	Last Available: "2023-12"
 11424	blinking lion tamer's savvy sawed-off blunderbuss of the sewer	0		Mysticality Percent: +20, Experience (familiar): +2, Stench Damage: +25, Last Available: "2023-12"
 11425	smooth huge huge officer's nog	3	awesome	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	foul-smelling chilly hardy wholesome deadly Elf dessert spoon of doom	0		Weapon Damage: +5, Maximum HP Percent: +10, Maximum HP: +50, Cold Damage: +5, Stench Damage: +10, Spooky Spell Damage: +50, Last Available: "2023-12"
 11453	Elf Guard SCUBA tank of the empath of temperance	0		Familiar Weight: +5, Sleaze Resistance: +5, Last Available: "2023-12"
 11454	teal Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	narrow avaricious reassuring free boots	0		Spooky Resistance: +1, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	narrow avaricious reassuring free boots	0		Spooky Resistance: +1, Meat Drop: +30, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	bouncing greedy friendly curative Elvish underarmor	0		Familiar Weight: +3, Meat Drop: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-12"
 11458	supercharged supercool Crimbuccaneer bombjacket	0		Moxie Percent: +20, Maximum MP Percent: +30, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	normal pulsating sugarplum ration	3	good	Last Available: "2023-12"
 11460	delicious fancy gingerbread nylons	4	awesome	Effect: "All Branned Up", Effect Duration: 10, Last Available: "2023-12"
 11461	tasty big rum-soaked fruitcake	5	awesome	Last Available: "2023-12"
-11462	small tasty lime	2	awesome	Last Available: "2023-12"
-11463	normal small lime green gingerbread pirate	2	good	Last Available: "2023-12"
-11464	rotten big fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
+11462	tasty small lime	2	awesome	Last Available: "2023-12"
+11463	small normal lime green gingerbread pirate	2	good	Last Available: "2023-12"
+11464	big rotten fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
 11465	artisanal mulled wine	3	EPIC	Last Available: "2023-12"
 11466	perfectly mixed Swedish coffee	3	EPIC	Last Available: "2023-12"
 11467	high-proof tolerable wobbly canteen of eggnog	8	good	Last Available: "2023-12"
-11468	mediocre irresponsibly strong jittery hot wine	10	decent	Last Available: "2023-12"
+11468	irresponsibly strong mediocre jittery hot wine	10	decent	Last Available: "2023-12"
 11469	acceptable upside-down Jamaican coffee	3	good	Last Available: "2023-12"
 11470	perfectly mixed tumbling flask of egggrog	4	EPIC	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	skewed Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	acceptable irresponsibly strong wobbly yule grog	10	good	Last Available: "2023-12"
-11475	rotten huge wet tack	7	crappy	Last Available: "2023-12"
+11475	huge rotten wet tack	7	crappy	Last Available: "2023-12"
 11476	super-sized yummy spinning whalecake	5	awesome	Last Available: "2023-12"
-11477	teal perfumed hale smooth gunwale whalegun	0		Moxie: +15, Maximum HP: +20, Stench Resistance: +5, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
-11478	mediocre irresponsibly strong and claret	7	decent	Last Available: "2023-12"
+11477	teal perfumed hale smooth gunwale whalegun	0		Moxie: +15, Maximum HP: +20, Stench Resistance: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11478	irresponsibly strong mediocre and claret	7	decent	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	skewed lime green trick coin	0		Last Available: "2023-12"
-11481	mansplainer's Newton's Elf Guard squirtgun	0		Experience (Mysticality): +3, Monster Level: +15, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	mansplainer's Newton's Elf Guard squirtgun	0		Experience (Mysticality): +3, Monster Level: +15, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	wholesome sequin-encrusted sweater	0		Maximum HP Percent: +10, Last Available: "2023-12"
 11484	flame-wreathed supercharged replica Elf Guard medal of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Hot Spell Damage: +10, Last Available: "2023-12"
@@ -11346,7 +11346,7 @@
 11491	censurious steel-toed Crimbuccaneer nose ring of temperance	0		Damage Reduction: 9, Sleaze Resistance: 8, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	huge Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	lime green wobbly Elf Guard safety bear	0		Last Available: "2023-12"
+11494	wobbly lime green Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	dry bouncing military candy cane	0		Effect: "Tingly Wrists", Effect Duration: 24
 11503	denatured unsweetened groggipop	0		Effect: "Macho, Macho Dog", Effect Duration: 26
-11504	crafty weightlifter's moss mace	0		Muscle: +15, Maximum MP: +10, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	family-friendly beefy moss megaphone	0		Muscle: +10, Sleaze Resistance: +1, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	upside-down Sherlock's clever moss medal	0		Maximum MP: +20, Item Drop: +25, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	Usain Bolt's slick moss mitre	0		Moxie: +10, Initiative: +80, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	Herculean moss mantle of dire peril	0		Experience (Muscle): +1, Weapon Damage: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	crafty weightlifter's moss mace	0		Muscle: +15, Maximum MP: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	family-friendly beefy moss megaphone	0		Muscle: +10, Sleaze Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	upside-down Sherlock's clever moss medal	0		Maximum MP: +20, Item Drop: +25, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	Usain Bolt's slick moss mitre	0		Moxie: +10, Initiative: +80, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	Herculean moss mantle of dire peril	0		Experience (Muscle): +1, Weapon Damage: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	ruddy moss marlinspike of Flo-Jo	0		Maximum HP Percent: +40, Initiative: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	pickled moss mulch	1		Last Available: "2024-12"
 11511	modified moss floss	0		Effect: "Stinkybeard", Effect Duration: 28
@@ -11372,14 +11372,14 @@
 11517	ghostly adobe abaya	0		Last Available: "2024-12"
 11518	boiled adobe assortment	1		Effect: "Salty Dogs", Effect Duration: 5, Last Available: "2024-12"
 11519	nitrogenated mirror adobe brittle	0		Effect: "Engorged Weapon", Effect Duration: 37
-11520	resourceful sinister crepe paper phrygian cap of temperance	0		Spell Damage: +10, Maximum MP: +50, Sleaze Resistance: +5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	resourceful sinister crepe paper phrygian cap of temperance	0		Spell Damage: +10, Maximum MP: +50, Sleaze Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	maroon Annie Oakley's deadly crepe paper parachute cape of terror	0		Weapon Damage: +5, Critical Hit Percent: +20, Spooky Spell Damage: +10, Last Available: "2025-12"
-11522	twirling greasy crepe paper pie clip of chilblains of the sewer	0		Cold Damage: +25, Stench Damage: +25, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	frightening personal trainer's smartaleck's crepe paper puzzle cube	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Spooky Damage: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	shaking personal trainer's stylish crepe paper plunge camisole of the brute	0		Moxie: +25, Muscle Percent: +30, Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	wobbly aromatic resourceful crepe paper polka charm of mayonnaise	0		Maximum MP: +50, Sleaze Spell Damage: +50, Stench Resistance: +1, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
-11526	vaporized skewed red crepe paper pared cuttings	1		Last Available: "2025-12"
-11527	colloidal chilled huge blurry crepe paper peanut candy	0		Effect: "Okee-Dokee Computer", Effect Duration: 14
+11522	twirling greasy crepe paper pie clip of chilblains of the sewer	0		Cold Damage: +25, Stench Damage: +25, Sleaze Spell Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	frightening personal trainer's smartaleck's crepe paper puzzle cube	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Spooky Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	shaking personal trainer's stylish crepe paper plunge camisole of the brute	0		Moxie: +25, Muscle Percent: +30, Experience Percent (Muscle): +10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	wobbly aromatic resourceful crepe paper polka charm of mayonnaise	0		Maximum MP: +50, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11526	vaporized red skewed crepe paper pared cuttings	1		Last Available: "2025-12"
+11527	colloidal chilled blurry huge crepe paper peanut candy	0		Effect: "Okee-Dokee Computer", Effect Duration: 14
 11528	jittery steel-toed petrified wood war pike of extreme caution	0		Damage Reduction: 9, Monster Level: -25, Last Available: "2025-12"
 11529	mansplainer's petrified wood waist protector of the empath	0		Monster Level: +15, Familiar Weight: +5, Single Equip, Last Available: "2025-12"
 11530	savvy smooth petrified wood wizard's pouch	0		Moxie: +15, Mysticality Percent: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
@@ -11388,17 +11388,17 @@
 11533	skewed up-at-dawn petrified wood walking pants of vim and vigor	0		Maximum HP Percent: +50, Adventures: +5, Last Available: "2025-12"
 11534	modified skewed petrified wood waste parts	1		Last Available: "2025-12"
 11535	ionized squat petrified wood wafer praline	0		Effect: "Ocelot Eyes", Effect Duration: 16
-11536	artisanal boozy cybeer	5	EPIC	Last Available: "2025-12"
+11536	boozy artisanal cybeer	5	EPIC	Last Available: "2025-12"
 11537	blue ICEbox	0		Last Available: "2025-12"
-11538	mirror wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	mirror wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	twirling inspector's knitted Crimbuccaneer war standard	0		Cold Resistance: +3, Item Drop: +15, Last Available: "2023-12"
 11544	boxer's Elf Guard war standard of the empath	0		Muscle Percent: +10, Familiar Weight: +5, Last Available: "2023-12"
 11545	bouncing in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	narrow censurious stanky spring shoes of the pedagogue	0		Experience: +3, Stench Spell Damage: +25, Sleaze Resistance: +3, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	narrow censurious stanky spring shoes of the pedagogue	0		Experience: +3, Stench Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	galvanized jittery ultra-soft ferns	0		Effect: "Improprie Tea", Effect Duration: 59, Last Available: "2024-02"
 11548	non-pickled crunchy brush	0		Effect: "Superveiny 9000", Effect Duration: 66, Last Available: "2024-02"
 11549	blue smashed scientific equipment	0		
@@ -11409,7 +11409,7 @@
 11554	irresponsible-tension exoskeleton	0		
 11555	tumbling quick-release belt pouch	0		Single Equip
 11556	bouncing quick-release fannypack	0		Single Equip
-11557	huge shaking quick-release utility belt	0		Single Equip
+11557	shaking huge quick-release utility belt	0		Single Equip
 11558	Sinatra's motion sensor	0		Experience (Moxie): +5, Single Equip
 11559	teal focused magnetron pistol	0		Single Equip
 11560	wobbly packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
@@ -11425,13 +11425,13 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	stale small yam	2	decent	Last Available: "2024-05"
+11573	small stale yam	2	decent	Last Available: "2024-05"
 11574	special drinkable yam martini	4	good	Effect: "Held Closer", Effect Duration: 15, Last Available: "2024-05"
 11575	bad watered-down sweet potato o' mine	2	decent	Last Available: "2024-05"
 11576	practically non-alcoholic acceptable Southern yam	1	good	Last Available: "2024-05"
 11577	watered-down smooth sweet potato punch	2	awesome	Last Available: "2024-05"
 11578	decent mirror Mayam spinach	4	good	Last Available: "2024-05"
-11579	spoiled small pulsating narrow yam and swiss	2	crappy	Last Available: "2024-05"
+11579	small spoiled pulsating narrow yam and swiss	2	crappy	Last Available: "2024-05"
 11580	huge shaking Usain Bolt's rock-hard banded yam cannon	0		Damage Absorption: +100, Damage Reduction: 5, Initiative: +80, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11448,20 +11448,20 @@
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	massive stale mini kiwi	9	decent	Last Available: "2024-06"
 11595	lime green veiny experienced mini kiwi bikini of the scaredy-cat	0		Experience: +2, Maximum HP: +10, Monster Level: -15, Last Available: "2024-06"
-11596	lousy fancy weak mini kiwitini	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2024-06"
+11596	fancy lousy weak mini kiwitini	2	decent	Effect: "Happy Trails", Effect Duration: 20, Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
-11598	pulsating gray mini kiwi aioli	0		
+11598	gray pulsating mini kiwi aioli	0		
 11599	careful wizardly mini kiwi silicon tiepin of the sweet-tooth	0		Mysticality: +25, Monster Level: -10, Candy Drop: +100
 11600	mini kiwi tipi	0		
-11601	rotten massive mini kiwi digitized cookies	10	crappy	
-11602	fancy artisanal mini kiwi intoxicating spirits	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25
+11601	massive rotten mini kiwi digitized cookies	10	crappy	
+11602	artisanal fancy mini kiwi intoxicating spirits	4	EPIC	Effect: "Melancholy Burden", Effect Duration: 25
 11603	Vulcanized upside-down mini kiwi antimilitaristic hippy petition	0		Effect: "Become Superficially interested", Effect Duration: 18
-11604	cold-filtered jittery maroon mini kiwi illicit antibiotic	0		Effect: "Toast Tea", Effect Duration: 42
+11604	cold-filtered maroon jittery mini kiwi illicit antibiotic	0		Effect: "Toast Tea", Effect Duration: 42
 11605	rosewater-soaked mini kiwi whipping stick	0		Stench Resistance: +3, Item Drop: +5
 11606	blinking boxer's mini kiwi icepick	0		Muscle Percent: +10
 11607	ionized modified mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Disco Concentration", Effect Duration: 19
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	wobbly protogenetic chunklet (synapse)	0		
 11611	bouncing protogenetic chunklet (muscle)	0		
 11612	upside-down protogenetic chunklet (flagellum)	0		
@@ -11487,7 +11487,7 @@
 11632	teal Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	lousy distilled squat Colera Peste Nebbiolo	5	decent	
+11635	distilled lousy squat Colera Peste Nebbiolo	5	decent	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11510,7 +11510,7 @@
 11655	bouncing soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	teal boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	knitted wool bat wings of extreme caution	0		Monster Level: -25, Cold Resistance: 4, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	knitted wool bat wings of extreme caution	0		Monster Level: -25, Cold Resistance: 4, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	wool strapping monocle on a stick	0		Muscle: +5, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,10 +11523,10 @@
 11668	rosy-cheeked Sheriff badge of terror	0		Maximum HP Percent: +30, Spooky Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	medical-grade brawny Sheriff pistol	0		Muscle Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-10"
 11670	coward's Sheriff moustache of the ox	0		Muscle: +20, Monster Level: -20, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	cyan prompt rock-hard photo booth supply list	0		Damage Reduction: 5, Adventures: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	cyan prompt rock-hard photo booth supply list	0		Damage Reduction: 5, Adventures: +3, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	wobbly peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	huge tie-dye headband	0		
-11674	diet decent special whirled peas	1	good	Effect: "Cat Class, Cat Style", Effect Duration: 5, Last Available: "2024-11"
+11674	decent special diet whirled peas	1	good	Effect: "Cat Class, Cat Style", Effect Duration: 5, Last Available: "2024-11"
 11675	yummy peaza	3	awesome	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	modified gray drenchrome 2.0	1		Effect: "Human-Human Hybrid", Effect Duration: 10, Last Available: "2025-12"
@@ -11541,10 +11541,10 @@
 11686	blurry Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	blue huge TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	olive sinister deft pirate hook of Calamity Jane	0		Spell Damage: +10, Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2024-12"
-11689	wicked weightlifter's iron tricorn hat	0		Muscle: +15, Spell Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	wicked weightlifter's iron tricorn hat	0		Muscle: +15, Spell Damage: +5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	Temple Grandin's jolly roger flag	0		Familiar Weight: +7, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
-11692	blinking mirror pirrrate's currrse	0		Last Available: "2024-12"
+11692	mirror blinking pirrrate's currrse	0		Last Available: "2024-12"
 11693	acceptable weak tankard of spiced rum	2	good	Last Available: "2024-12"
 11694	fortified aged tankard of spiced Goldschlepper	5	awesome	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	red mirror mansplainer's potato jacket of the dark arts of incineration	0		Spell Damage Percent: +100, Monster Level: +15, Hot Spell Damage: +50, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	blurry Sinatra's military orb of the sweet-tooth	0		Experience (Moxie): +5, Candy Drop: +100, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	blurry Sinatra's military orb of the sweet-tooth	0		Experience (Moxie): +5, Candy Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	Vulcanized anodized cyan tumbling rum ball	0		Effect: "Disco Neuropathy", Effect Duration: 24
 11733	teal gravy skin	0		Last Available: "2024-12"
 11734	reassuring baleful gravyskin hat	0		Spell Damage: +25, Spooky Resistance: +1, Last Available: "2024-12"
@@ -11591,31 +11591,31 @@
 11736	pulsating lard-coated deadly gravyskin skirt	0		Weapon Damage: +5, Sleaze Spell Damage: +25, Last Available: "2024-12"
 11737	gravedigger's sizzling gravyskin pants	0		Hot Damage: +10, Spooky Damage: +10, Last Available: "2024-12"
 11738	warmed energized crystallized pumpkin spice	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 12, Last Available: "2024-12"
-11739	big decent room scale bean casserole	5	good	Last Available: "2024-12"
+11739	decent big room scale bean casserole	5	good	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	skewed ragged wool yarn	0		Last Available: "2024-12"
 11742	mirror therapeutic groovy cool perfect Christmas scarf	0		Moxie: [+5*event(December)], Moxie Percent: [+10*event(December)], HP Regen Min: [5*event(December)], HP Regen Max: [7*event(December)], Single Equip, Last Available: "2024-12"
-11743	rosewater-soaked padded snowman-enchanting tophat	0		Damage Absorption: +20, Stench Resistance: +3, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	rosewater-soaked padded snowman-enchanting tophat	0		Damage Absorption: +20, Stench Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	liquefied quantum squat LIDAR candle	0		Effect: "Sweet Nostalgia", Effect Duration: 29, Last Available: "2024-12"
 11745	Sherlock's wool Congressional Medal of Insanity of dire peril	0		Weapon Damage: +20, Cold Resistance: +1, Item Drop: +25, Last Available: "2024-12"
 11746	cyan pumpkin spice whorl	0		Last Available: "2024-12"
 11747	aged Easter grasshopper	3	awesome	Last Available: "2024-12"
 11748	drinkable Irish eggnog	4	good	Last Available: "2024-12"
-11749	strong bad canteen of jungle juice	5	decent	Last Available: "2024-12"
+11749	bad strong canteen of jungle juice	5	decent	Last Available: "2024-12"
 11750	watered-down acceptable blue turchucken	2	good	Last Available: "2024-12"
-11751	triple-distilled artisanal mechanically-mulled cider	9	EPIC	Last Available: "2024-12"
-11752	fancy acceptable watered-down shaking holiday trip around the world	2	good	Effect: "5 Pounds Lighter", Effect Duration: 10, Last Available: "2024-12"
-11753	decent fancy miniature chocolate ostrich egg	2	good	Effect: "X-Ray Vision", Effect Duration: 25, Last Available: "2024-12"
+11751	artisanal triple-distilled mechanically-mulled cider	9	EPIC	Last Available: "2024-12"
+11752	watered-down acceptable fancy shaking holiday trip around the world	2	good	Effect: "5 Pounds Lighter", Effect Duration: 10, Last Available: "2024-12"
+11753	fancy decent miniature chocolate ostrich egg	2	good	Effect: "X-Ray Vision", Effect Duration: 25, Last Available: "2024-12"
 11754	normal beef and cabbage	3	good	Last Available: "2024-12"
 11755	miniature spoiled candy rations	2	crappy	Last Available: "2024-12"
 11756	decent purple double-candied yams	3	good	Last Available: "2024-12"
-11757	rotten fuchsia bouncing Christmas ham	4	crappy	Last Available: "2024-12"
+11757	rotten bouncing fuchsia Christmas ham	4	crappy	Last Available: "2024-12"
 11758	delicious holiday smorgasbord	4	awesome	Last Available: "2024-12"
 11759	pulsating Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	MacGyver's bejazzled eyepatch	0		Maximum MP: +100, Last Available: "2024-12"
 11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11762	shaking Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	narrow skewed How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11763	skewed narrow How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
@@ -11624,7 +11624,7 @@
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	spinning moai statuette	0		Last Available: "2024-12"
-11772	ghostly fuchsia greasy groovy egg gun of James Dean of the blizzard	0		Moxie Percent: +10, Experience (Moxie): +3, Cold Spell Damage: +25, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	ghostly fuchsia greasy groovy egg gun of James Dean of the blizzard	0		Moxie Percent: +10, Experience (Moxie): +3, Cold Spell Damage: +25, Sleaze Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	lime green Oprah's hardy boxer's army helmet of the boozehound	0		Muscle Percent: +10, Maximum HP: +50, Maximum MP Percent: +50, Booze Drop: +100, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	skewed huge napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	diffused blurry deviled candy egg	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 54, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	Annie Oakley's crafty McHugeLarge duffel bag	0		Maximum MP: +10, Critical Hit Percent: +20, Last Available: "2025-01"
-11784	dog trainer's sinister McHugeLarge left pole of temperance	0		Spell Damage: +10, Experience (familiar): +1, Sleaze Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	narrow manspreader's Da Vinci's savvy McHugeLarge right pole	0		Mysticality Percent: +20, Experience (Mysticality): +5, Monster Level: +10, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	bouncing friendly fortified McHugeLarge left ski	0		Damage Absorption: +60, Familiar Weight: +3, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	manspreader's McHugeLarge right ski of the sewer	0		Monster Level: +10, Stench Damage: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	dog trainer's sinister McHugeLarge left pole of temperance	0		Spell Damage: +10, Experience (familiar): +1, Sleaze Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	narrow manspreader's Da Vinci's savvy McHugeLarge right pole	0		Mysticality Percent: +20, Experience (Mysticality): +5, Monster Level: +10, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	bouncing friendly fortified McHugeLarge left ski	0		Damage Absorption: +60, Familiar Weight: +3, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	manspreader's McHugeLarge right ski of the sewer	0		Monster Level: +10, Stench Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	1	0		Last Available: "2025-12"
 11789	pulsating 0	0		Last Available: "2025-12"
 11790	diluted bouncing eXpand	1		Effect: "Stuck-Up Hair", Effect Duration: 45, Last Available: "2025-12"
-11791	shaking cyan brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	shaking cyan brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	narrow dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	skewed cybervisor	0		Last Available: "2025-12"
 11804	squat retro floppy disk	0		Last Available: "2025-12"
 11805	squat pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11669,17 +11669,17 @@
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
-11817	twirling blurry dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
+11817	blurry twirling dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	jittery dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	upside-down squat dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11820	squat upside-down dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	gray blinking SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	blue OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	teal STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	spinning insignificant bit	0		Last Available: "2025-12"
-11825	mirror cyan parity bit	0		Familiar Weight: +5
+11825	cyan mirror parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	teal ghostly ninja rope	0		
@@ -11716,32 +11716,32 @@
 11861	maroon Leprecondo	0		Last Available: "2025-03"
 11862	mixed scoop of pre-workout powder	1		Effect: "One For Tea", Effect Duration: 35, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	acceptable weak pint of Leprechaun Stout	2	good	Last Available: "2025-03"
+11864	weak acceptable pint of Leprechaun Stout	2	good	Last Available: "2025-03"
 11865	modified phosphor traces	1		Effect: "Rage of the Reindeer", Effect Duration: 15, Last Available: "2025-03"
 11866	maroon crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	unironic knife	0		
-11870	upside-down tumbling bar dart	0		Last Available: "2025-03"
+11870	tumbling upside-down bar dart	0		Last Available: "2025-03"
 11871	dehydrated gray leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	normal Heck ramen	3	good	Last Available: "2025-03"
-11873	massive stale burrito	7	decent	Last Available: "2025-03"
+11873	stale massive burrito	7	decent	Last Available: "2025-03"
 11874	bite-sized moldy small beer brat	1	crappy	Last Available: "2025-03"
-11875	bland jumbo jittery peach pie	5	decent	Last Available: "2025-03"
+11875	jumbo bland jittery peach pie	5	decent	Last Available: "2025-03"
 11876	adequate incredible mini-pizza	3	good	Last Available: "2025-03"
-11877	tolerable watered-down Divine sidecar	2	good	Last Available: "2025-03"
+11877	watered-down tolerable Divine sidecar	2	good	Last Available: "2025-03"
 11878	watered-down tolerable tangarita sidecar	2	good	Last Available: "2025-03"
 11879	lousy spinning gimlet sidecar	4	decent	Last Available: "2025-03"
 11880	watered-down hand-crafted pulsating vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
 11881	distilled tolerable upside-down prussian cathouse sidecar	5	good	Last Available: "2025-03"
-11882	special hand-crafted fortified upside-down Mon Tiki sidecar	5	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 10, Last Available: "2025-03"
+11882	hand-crafted fortified special upside-down Mon Tiki sidecar	5	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 10, Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	gravedigger's educational April Shower Thoughts shield	0		Experience: +1, Spooky Damage: +10, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	altered wet paper weights	0		Effect: "Dancing Prowess", Effect Duration: 37, Last Available: "2025-04"
 11888	weak artisanal Three Sheets to the Wind	2	EPIC	Last Available: "2025-04"
-11889	low-calorie normal enchanted pile of wet dates	1	good	Effect: "You Know Who to Call", Effect Duration: 25, Last Available: "2025-04"
+11889	enchanted normal low-calorie pile of wet dates	1	good	Effect: "You Know Who to Call", Effect Duration: 25, Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	blurry wet blanket	0		Last Available: "2025-04"
 11892	narrow grievous wet shower cap	0		Weapon Damage Percent: +50, Last Available: "2025-04"
@@ -11756,7 +11756,7 @@
 11901	wet shower stamp	0		Last Available: "2025-04"
 11902	birthday bloon of Gandalf	0		Spell Critical Percent: +20
 11903	magnetized dry jawwetter	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 35
-11904	gray bouncing Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
+11904	bouncing gray Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
 11905	narrow Oprah's veiny wizardly Peridot of Peril	0		Mysticality: +25, Maximum HP: +10, Maximum MP Percent: +50, Single Equip, Last Available: "2025-06"
 11906	crafty terrycloth turban	0		Maximum MP: +10
 11907	ghostly wool jockey's hat	0		Cold Resistance: +1
@@ -11771,7 +11771,7 @@
 11916	olive flame-wreathed stylish bycocket	0		Hot Spell Damage: +10
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Damage Absorption: +4, Muscle: +1, Mysticality: +1, Maximum HP: +2, Maximum MP: +2, Hat Drop: +2, Cold Damage: +1, Spooky Damage: +1, Stench Spell Damage: +1, Sleaze Spell Damage: +1, Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Damage Absorption: +4, Muscle: +1, Mysticality: +1, Maximum HP: +2, Maximum MP: +2, Hat Drop: +2, Cold Damage: +1, Spooky Damage: +1, Stench Spell Damage: +1, Sleaze Spell Damage: +1, Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	gray Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11786,10 +11786,10 @@
 11931	nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	razor-sharp Allied Radio Backpack of vim and vigor of incineration	0		Weapon Damage Percent: +25, Maximum HP Percent: +50, Hot Spell Damage: +50, Conditional Skill (Equipped): "Call in an Airstrike"
-11934	red jittery orphaned baby skeleton	0		
+11934	jittery red orphaned baby skeleton	0		
 11935	squat green ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	stale half-sized Skeleton Wars rations	2	decent	
+11937	half-sized stale Skeleton Wars rations	2	decent	
 11938	mediocre maroon skeleton war fuel can	3	decent	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11805,12 +11805,12 @@
 11950	green time cop top hat of courage	0		Spooky Resistance: +3, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	denatured cyan mixed berry jelly	1		Last Available: "2025-08"
-11953	snack-sized adequate toast with mixed berry jelly	2	good	Last Available: "2025-08"
+11953	adequate snack-sized toast with mixed berry jelly	2	good	Last Available: "2025-08"
 11954	decent pulsating cup of sugar	3	good	Last Available: "2025-08"
-11955	yummy small Susie's cupcake	2	awesome	Last Available: "2025-08"
+11955	small yummy Susie's cupcake	2	awesome	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	chaotic sinister the gun of Calamity Jane	0		Spell Damage: +10, Critical Hit Percent: +15, Spell Critical Percent: +10, Last Available: "2025-08"
-11958	delicious watered-down jittery wine	2	awesome	Last Available: "2025-08"
+11958	watered-down delicious jittery wine	2	awesome	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	chilly undersea surveying goggles	0		Cold Damage: +5, Lasts Until Rollover
@@ -11821,31 +11821,31 @@
 11967	scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
-11970	green jittery sea gel	0		
+11970	jittery green sea gel	0		
 11971	vacuum-sealed diffused upside-down octopus ink bladder	0		Effect: "The Halls of Moxiousness", Effect Duration: 40
 11972	spinning durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	bouncing packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	sharpshooter's dentadent	0		Critical Hit Percent: +10
 11986	blinking lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	wobbly blue dance instructor's Newton's cool blood cubic zirconia of the wise owl of vim and vigor	0		Mysticality: +20, Moxie: +5, Experience (Mysticality): +3, Experience Percent (Moxie): +10, Maximum HP Percent: +50, Item Drop: +5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	wobbly blue dance instructor's Newton's cool blood cubic zirconia of the wise owl of vim and vigor	0		Mysticality: +20, Moxie: +5, Experience (Mysticality): +3, Experience Percent (Moxie): +10, Maximum HP Percent: +50, Item Drop: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	distilled blood thinner	1		Last Available: "2025-10"
 12045	fancy weak acceptable pheromone cocktail	2	good	Effect: "Oxygenated Blood", Effect Duration: 35, Last Available: "2025-10"
-12046	tasty half-sized spinal tapas	2	awesome	Last Available: "2025-10"
+12046	half-sized tasty spinal tapas	2	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	blinking up-at-dawn ribald shrunken head of the brute	0		Muscle Percent: +30, Sleaze Damage: +10, Adventures: +5, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	blinking up-at-dawn ribald shrunken head of the brute	0		Muscle Percent: +30, Sleaze Damage: +10, Adventures: +5, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	mirror small peppermint-flavored sugar walking crook	0		
 12051	blurry knucklebone	0		
 12052	aged Smoking Pope	4	awesome	
 12053	moldy prize turkey	3	crappy	
-12054	vaporized yellow mirror ghostly squat medicinal gruel	1		Effect: "Bread Burps", Effect Duration: 25
-12055	delicious half-sized full-sized pumpkin pie	2	awesome	Last Available: "2025-11"
-12056	lousy triple-distilled blinking yellow vodka cranberry sauce	6	decent	Last Available: "2025-11"
-12057	tarnished warmed deionized squat gray yammed candy	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2025-11"
-12058	low-calorie normal twirling treasure chestnut	1	good	Last Available: "2025-12"
+12054	vaporized mirror ghostly squat yellow medicinal gruel	1		Effect: "Bread Burps", Effect Duration: 25
+12055	half-sized delicious full-sized pumpkin pie	2	awesome	Last Available: "2025-11"
+12056	lousy triple-distilled yellow blinking vodka cranberry sauce	6	decent	Last Available: "2025-11"
+12057	tarnished warmed deionized gray squat yammed candy	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2025-11"
+12058	normal low-calorie twirling treasure chestnut	1	good	Last Available: "2025-12"
 12059	mediocre mulled butter rum	3	decent	Last Available: "2025-12"
 12060	pickled super-electrified cinnamon doubloon	0		Effect: "Peppermint Bite", Effect Duration: 47, Last Available: "2025-12"
 12061	purple plastic left skeleton arm of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2025-12"
@@ -11862,7 +11862,7 @@
 12072	Jack Frost's angelbone dice	0		Cold Spell Damage: +50, Single Equip, Last Available: "2026-12"
 12073	angelbone halo of Leguizamo of the sweet-tooth	0		Monster Level: +20, Candy Drop: +100, Last Available: "2026-12"
 12074	twisted angelbone fragments	1		Effect: "Swimming with Sharks", Effect Duration: 30, Last Available: "2026-12"
-12075	aerosolized extra-quantum squat blue biblically accurate gumdrops	0		Effect: "Haunted Liver", Effect Duration: 33
+12075	aerosolized extra-quantum blue squat biblically accurate gumdrops	0		Effect: "Haunted Liver", Effect Duration: 33
 12076	shaking devilbone helmet of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Last Available: "2026-12"
 12077	jittery deadly devilbone greaves	0		Weapon Damage: +5, Last Available: "2026-12"
 12078	Lo Pan's weightlifter's devilbone shinguards	0		Muscle: +15, Spell Critical Percent: +30, Single Equip, Last Available: "2026-12"
@@ -11879,9 +11879,9 @@
 12121	tumbling Crymbocurrency	0		Last Available: "2025-12"
 12122	Da Vinci's extra-thick Crimbo sweater	0		Experience (Mysticality): +5, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	practically non-alcoholic perfectly mixed Steve Abrams' Holiday Sampler Beer	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12124	perfectly mixed practically non-alcoholic Steve Abrams' Holiday Sampler Beer	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12125	lime green jittery crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	hand-crafted watered-down bottle of prize-winning rum	2	super EPIC	Last Available: "2025-12"
+12126	watered-down hand-crafted bottle of prize-winning rum	2	super EPIC	Last Available: "2025-12"
 12127	Usain Bolt's foul-smelling educational Santa-Slayer medal	0		Experience: +1, Stench Damage: +10, Initiative: +80, Single Equip, Last Available: "2025-12"
 12128	squat Skull of Claus	0		Last Available: "2025-12"
 12129	warmed pickled green boiling bone marrow	0		Effect: "Provocative Perkiness", Effect Duration: 23, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	flattened colloidal boiling synovial fluid	0		Effect: "Human-Plant Hybrid", Effect Duration: 51, Last Available: "2025-12"
 12132	wool steel-toed Fonzie's smoldering vertebra	0		Experience (Moxie): +1, Damage Reduction: 9, Cold Resistance: +1, Single Equip, Last Available: "2025-12"
 12133	blue seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	blue volatile bone bomb	0		Last Available: "2025-12"
 12137	up-at-dawn sharpshooter's ruddy hot boning knife	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Adventures: +5, Single Equip, Last Available: "2025-12"
 12138	twirling mirror Jim Carey's quilted fistbone of the pedagogue	0		Experience: +3, Damage Absorption: +40, Monster Level: +25, Last Available: "2025-12"
 12139	padded beefcake's burnt bone belt of Calamity Jane	0		Muscle: +25, Damage Absorption: +20, Critical Hit Percent: +15, Single Equip, Last Available: "2025-12"
 12140	Rosewater's scorched skull trophy	0		Mysticality Percent: +30, Last Available: "2025-12"
-12141	tasty half-sized wing bone	2	awesome	Last Available: "2025-12"
+12141	half-sized tasty wing bone	2	awesome	Last Available: "2025-12"
 12142	delicious triple-distilled weak skeleton venom	8	awesome	Last Available: "2025-12"
 12143	modified baked bone meal	1		Last Available: "2025-12"
 12144	plastic skeleton rib cage of the brute	0		Muscle Percent: +30, Last Available: "2025-12"
@@ -11926,18 +11926,18 @@
 12168	ghostly smooth vermiculite shield of the scaredy-cat	0		Moxie: +15, Monster Level: -15, Damage Reduction: 9, Last Available: "2025-12"
 12169	groovy ship's lantern	0		Moxie Percent: +10, Last Available: "2025-12"
 12170	jittery zippy studded heat-resistant harpoon pistol	0		Damage Absorption: +80, Initiative: +20, Last Available: "2025-12"
-12171	snack-sized normal traditional gingerloaf	2	good	Last Available: "2025-12"
-12172	special hand-crafted bouncing Scotch and eggnog	3	EPIC	Effect: "Bark of the Dog", Effect Duration: 20, Last Available: "2025-12"
+12171	normal snack-sized traditional gingerloaf	2	good	Last Available: "2025-12"
+12172	hand-crafted special bouncing Scotch and eggnog	3	EPIC	Effect: "Bark of the Dog", Effect Duration: 20, Last Available: "2025-12"
 12173	activated cold-filtered blinking bouncing counterskeleton elixir	0		Effect: "Cool Spirit", Effect Duration: 64, Last Available: "2025-12"
 12174	hand-crafted &quot;salvaged&quot; wine	4	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	bite-sized flavorless wedge of prize-winning cheese	1	decent	Last Available: "2025-12"
+12177	flavorless bite-sized wedge of prize-winning cheese	1	decent	Last Available: "2025-12"
 12178	chilled jittery gummi fingerbone	0		Effect: "Piratey Flavor", Effect Duration: 50
 12179	fuchsia avaricious wholesome glimmering crystal	0		Maximum HP Percent: +10, Meat Drop: +30, Last Available: "2025-12"
 12180	teal boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
-12182	jittery narrow Thwaitgold meat bee statuette	0		
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12182	narrow jittery Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
@@ -11959,8 +11959,8 @@
 12201	ruddy dinosaur bone club	0		Maximum HP Percent: +40, Last Available: "2026-03"
 12202	fireproof dinosaur skull helmet of dire peril	0		Weapon Damage: +20, Hot Resistance: +3, Last Available: "2026-03"
 12203	boxer's dinosaur bone corset of Tarzan of James Dean	0		Muscle Percent: +10, Experience (Muscle): +3, Experience (Moxie): +3, Last Available: "2026-03"
-12204	practically non-alcoholic tolerable Pork Elf cough syrup	1	good	Last Available: "2026-03"
-12205	jittery spinning Pork Elf neti pot	0		Last Available: "2026-03"
+12204	tolerable practically non-alcoholic Pork Elf cough syrup	1	good	Last Available: "2026-03"
+12205	spinning jittery Pork Elf neti pot	0		Last Available: "2026-03"
 12206	upside-down Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	narrow purple Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
@@ -11972,26 +11972,26 @@
 12214	twisted candy bone	1		
 12215	shaking wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	jumbo toothsome discarded hot dog	5	awesome	Last Available: "2026-04"
+12217	toothsome jumbo discarded hot dog	5	awesome	Last Available: "2026-04"
 12218	drinkable high-proof blurry most of a beer	7	good	Last Available: "2026-04"
-12222	red skewed pasta wand loot box	0		Free Pull, Last Available: "2026-05"
+12222	skewed red pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	wobbly legendary noodles	0		Last Available: "2026-05"
-12226	half-sized rotten can of tuna	2	crappy	
+12226	rotten half-sized can of tuna	2	crappy	
 12227	small moldy alien salad	2	crappy	
 12228	spoiled ratbatatouille	3	crappy	
 12229	delicious onigiri	4	awesome	
 12230	adequate crudit&eacute;s	4	good	
 12231	big bland sauced mutton	5	decent	
-12232	enchanted flavorless miniature hot honey ant	2	decent	Effect: "Heart of Yellow", Effect Duration: 15
+12232	enchanted miniature flavorless hot honey ant	2	decent	Effect: "Heart of Yellow", Effect Duration: 15
 12233	adequate miniature tomb aspic	2	good	
 12234	half-sized flavorless later tots	2	decent	
 12235	bland olive Frutti di Scatoletta	4	decent	Last Available: "2026-05"
-12236	fancy rotten Pesto alla Marziano	4	crappy	Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2026-05"
+12236	rotten fancy Pesto alla Marziano	4	crappy	Effect: "Leisurely Amblin'", Effect Duration: 40, Last Available: "2026-05"
 12237	moldy Arrattabbattabiata	3	crappy	Last Available: "2026-05"
-12238	half-sized spoiled bouncing pulsating red Orzo di Riso	2	crappy	Last Available: "2026-05"
-12239	bland half-sized Pasta Grimavera	2	decent	Last Available: "2026-05"
-12240	normal low-calorie Linguini Ubriacapa	1	good	Last Available: "2026-05"
+12238	half-sized spoiled red pulsating bouncing Orzo di Riso	2	crappy	Last Available: "2026-05"
+12239	half-sized bland Pasta Grimavera	2	decent	Last Available: "2026-05"
+12240	low-calorie normal Linguini Ubriacapa	1	good	Last Available: "2026-05"
 12241	normal small Formica e Pepe	2	good	Last Available: "2026-05"
 12242	bland Tubetto Gelatto	3	decent	Last Available: "2026-05"
 12243	rotten blinking Gnocci Domani	3	crappy	Last Available: "2026-05"
@@ -12000,7 +12000,7 @@
 12246	wobbly second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	nippy Space Soldier Helmet of courage	0		Cold Damage: +10, Spooky Resistance: +3
-12253	super-sized rotten upside-down premium turkey leg	5	crappy	
+12253	rotten super-sized upside-down premium turkey leg	5	crappy	
 12254	weak hand-crafted blue blinking styrofoam cup of mead	2	EPIC	
 12255	blurry spinning sword of the cheetah	0		Initiative: +60
 12256	staff of the brute	0		Muscle Percent: +30
@@ -12017,27 +12017,27 @@
 12267	Temple Grandin's flimsy plastic breastplate	0		Familiar Weight: +7
 12268	Tesla flimsy plastic shield	0		MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 3
 12269	red packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	supercool Portable Laughing Stock of the bloodbag of mayonnaise	0		Moxie Percent: +20, Maximum HP: +100, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	supercool Portable Laughing Stock of the bloodbag of mayonnaise	0		Moxie Percent: +20, Maximum HP: +100, Sleaze Spell Damage: +50, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	narrow ruddy Samson's Staff of Anachronistic Churning of Tarzan	0		Experience (Muscle): 8, Maximum HP Percent: +40
 12272	stale pulsating classic banana	4	decent	Last Available: "2026-07"
 12273	small adequate watermelon	2	good	Last Available: "2026-07"
-12274	gigantic stale quince	8	decent	Last Available: "2026-07"
+12274	stale gigantic quince	8	decent	Last Available: "2026-07"
 12275	spinning Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	normal gigantic classic banana pie	6	good	Last Available: "2026-07"
-12278	irradiated polarized twirling cyan essential banana decoction	0		Effect: "Cold Hard Skin", Effect Duration: 15, Last Available: "2026-07"
+12277	gigantic normal classic banana pie	6	good	Last Available: "2026-07"
+12278	irradiated polarized cyan twirling essential banana decoction	0		Effect: "Cold Hard Skin", Effect Duration: 15, Last Available: "2026-07"
 12279	nitrogenated wet banana quintessence	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 33, Last Available: "2026-07"
 12280	lousy ghostly Aesop Daiquiri	3	decent	Last Available: "2026-07"
 12281	perfectly mixed special Monkey Congress	3	EPIC	Effect: "Hot Hands", Effect Duration: 20, Last Available: "2026-07"
 12282	rotten watermelon pie	3	crappy	Last Available: "2026-07"
 12283	quantum moist pulsating blinking concentrated watermelon juice	0		Effect: "Marinated", Effect Duration: 60, Last Available: "2026-07"
-12284	electrified activated mirror squat Aqua Citrulanatae	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49, Last Available: "2026-07"
+12284	electrified activated squat mirror Aqua Citrulanatae	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49, Last Available: "2026-07"
 12285	high-proof acceptable mirror Melonegroni	8	good	Last Available: "2026-07"
-12286	weak tolerable Melonade Spritz	2	good	Last Available: "2026-07"
+12286	tolerable weak Melonade Spritz	2	good	Last Available: "2026-07"
 12287	moldy ghostly quince pie	3	crappy	Last Available: "2026-07"
 12288	cold-filtered jittery quince quaff	0		Effect: "Angry Bone", Effect Duration: 23, Last Available: "2026-07"
 12289	cold-filtered irradiated upside-down Quickquince	0		Effect: "Be a Mind Master", Effect Duration: 46, Last Available: "2026-07"
-12290	practically non-alcoholic perfectly mixed blinking Quiskey Sour	1	super EPIC	Last Available: "2026-07"
+12290	perfectly mixed practically non-alcoholic blinking Quiskey Sour	1	super EPIC	Last Available: "2026-07"
 12291	perfectly mixed high-proof Quincea&ntilde;era Cooler	9	EPIC	Last Available: "2026-07"
 12292	acceptable Roth IPA	4	good	Last Available: "2026-08"
 12293	scandalous brainy underdraft protection	0		Mysticality: +5, Sleaze Damage: +5, Last Available: "2026-08"
@@ -12054,11 +12054,11 @@
 12304	balance sheet	0		Last Available: "2026-08"
 12305	pressed invisible hand	0		Effect: "Sweet Nostalgia", Effect Duration: 19, Last Available: "2026-08"
 12306	unsweetened polymerized circle of overdraft protection scroll	0		Effect: "You Know What's Up", Effect Duration: 33, Last Available: "2026-08"
-12307	non-enhanced squat purple mint	0		Effect: "Fury of the Bells", Effect Duration: 32, Last Available: "2026-08"
+12307	non-enhanced purple squat mint	0		Effect: "Fury of the Bells", Effect Duration: 32, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	mixed toxic asset	1		Effect: "Egg-stortionary Tactics", Effect Duration: 5, Last Available: "2026-08"
-12311	dried green skewed intangible asset	1		Last Available: "2026-08"
-12312	modified squat cyan blurry liquid asset	1		Last Available: "2026-08"
+12311	dried skewed green intangible asset	1		Last Available: "2026-08"
+12312	modified squat blurry cyan liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Seal_Clubber_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Marmot_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	mediocre practically non-alcoholic shaking Petite Porter	1	decent	
+-1	practically non-alcoholic mediocre shaking Petite Porter	1	decent	
 -2	artisanal maroon Scrawny Stout	4	EPIC	
 -3	mediocre watered-down fuchsia Infinitesimal IPA	2	decent	
 -4	mediocre weak bouncing eggnogtini	2	decent	
 -5	mediocre candycaine	3	decent	
 -6	acceptable weak braincracker sweet	2	good	
--16	drinkable practically non-alcoholic bouncing purple fermented honey	1	good	
+-16	drinkable practically non-alcoholic purple bouncing fermented honey	1	good	
 -17	hand-crafted moons-shine	3	EPIC	
 -18	perfectly mixed gin	4	EPIC	
--19	high-proof smooth ecto-nog	8	awesome	
--20	hand-crafted practically non-alcoholic narrow olive hot toady	1	EPIC	
+-19	smooth high-proof ecto-nog	8	awesome	
+-20	practically non-alcoholic hand-crafted narrow olive hot toady	1	EPIC	
 -21	lousy watered-down hot choculate	2	decent	
--49	lousy practically non-alcoholic twirling Cyder	1	decent	
--50	perfectly mixed weak Oil Nog	2	EPIC	
+-49	practically non-alcoholic lousy twirling Cyder	1	decent	
+-50	weak perfectly mixed Oil Nog	2	EPIC	
 -51	delicious tumbling Hi-Octane Peppermint Jet Fuel	3	awesome	
--58	practically non-alcoholic bad Grimacider	1	decent	
--59	bad practically non-alcoholic pulsating Isotope Nog	1	decent	
+-58	bad practically non-alcoholic Grimacider	1	decent	
+-59	practically non-alcoholic bad pulsating Isotope Nog	1	decent	
 -60	bad Mutagin 'n' Tonic	3	decent	
 -70	hand-crafted squat Gin and Herring	4	EPIC	
--71	drinkable practically non-alcoholic Black and Tan and Red All Over	1	good	
+-71	practically non-alcoholic drinkable Black and Tan and Red All Over	1	good	
 -72	irresponsibly strong mediocre Antarctic Ice Tea	7	decent	
--76	aged fancy CRIMBCO Ribbon Candy Schnapps	3	awesome	
+-76	fancy aged CRIMBCO Ribbon Candy Schnapps	3	awesome	
 -77	bad blinking CRIMBCO Egg Substitute Nog Substitute	3	decent	
 -78	delicious twirling mirror CRIMBCO Extreme Braincracker Sour	3	awesome	
--82	aged triple-distilled Horseradish-infused Vodka	6	awesome	
+-82	triple-distilled aged Horseradish-infused Vodka	6	awesome	
 -83	special hand-crafted practically non-alcoholic Jerkitini	1	EPIC	
 -84	tolerable Desert Island Iced Tea	3	good	
--88	drinkable watered-down red Crimbo Saketini	2	good	
--89	artisanal weak skewed teal Crimboku Drop	2	EPIC	
+-88	watered-down drinkable red Crimbo Saketini	2	good	
+-89	artisanal weak teal skewed Crimboku Drop	2	EPIC	
 -90	drinkable Flaming Crimbo Log	3	good	
 -107	artisanal Fortified Eggnog Slurry	4	EPIC	
 -108	high-proof aged Hot Buttered Rum	8	awesome	
--109	fancy lousy Spicy Hot Chocolate	3	decent	
+-109	lousy fancy Spicy Hot Chocolate	3	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Marmot_cafe_food.txt
@@ -1,39 +1,39 @@
--1	moldy low-calorie shaking Peche a la Frog	1	crappy	
+-1	low-calorie moldy shaking Peche a la Frog	1	crappy	
 -2	tasty maroon As Jus Gezund Heit	4	awesome	
--3	half-sized moldy fuchsia Bouillabaise Coucher Avec Moi	2	crappy	
+-3	moldy half-sized fuchsia Bouillabaise Coucher Avec Moi	2	crappy	
 -7	adequate gumdrop chow mein	4	good	
 -8	rotten candy cane pizza	4	crappy	
 -9	flavorless jumbo olive gingerbread stir-fry	5	decent	
--10	big tasty twigs and gravel	5	awesome	
--11	moldy half-sized spinning shoots and leaves	2	crappy	
--12	flavorless immense shaking bowl of unidentifiable goo	9	decent	
+-10	tasty big twigs and gravel	5	awesome	
+-11	half-sized moldy spinning shoots and leaves	2	crappy	
+-12	immense flavorless shaking bowl of unidentifiable goo	9	decent	
 -13	small normal shaking gingerbread massacre	2	good	
 -14	miniature bland It Came From Beyond Dessert	2	decent	
 -15	bland vampire cake	4	decent	
--52	big stale olive twirling blurry Soylent Red and Green	5	decent	
--53	moldy super-sized special huge Disc-Shaped Nutrition Unit	5	crappy	
--54	immense fancy stale Gingerborg Hive	9	decent	
--61	decent super-sized Candy Cane Surprise	5	good	
+-52	stale big twirling olive blurry Soylent Red and Green	5	decent	
+-53	special moldy super-sized huge Disc-Shaped Nutrition Unit	5	crappy	
+-54	stale fancy immense Gingerborg Hive	9	decent	
+-61	super-sized decent Candy Cane Surprise	5	good	
 -62	delicious special Grimdrop Chow Mein	4	awesome	
--63	snack-sized adequate Grimgerbread House	2	good	
+-63	adequate snack-sized Grimgerbread House	2	good	
 -67	spoiled Caviar Carbonara	3	crappy	
 -68	fancy moldy Halibut Alfredo	4	crappy	
 -69	rotten jittery Red Herring Velvet Cake	4	crappy	
--73	thick moldy CRIMBCO Reconstituted Gruel	5	crappy	
+-73	moldy thick CRIMBCO Reconstituted Gruel	5	crappy	
 -74	decent tiny New and Improved CRIMBCO Reconstituted Gruel	1	good	
--75	small normal twirling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	good	
+-75	normal small twirling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	good	
 -79	tasty blue Brussels Sprout Stir-Fry	4	awesome	
--80	bite-sized moldy Carrot, Cabbage, and Kale Pizza	1	crappy	
+-80	moldy bite-sized Carrot, Cabbage, and Kale Pizza	1	crappy	
 -81	special adequate low-calorie Turnip and Rutabaga Pie	1	good	
 -85	moldy bite-sized Rainbow Spider Fun Roll	1	crappy	
 -86	bland jittery ghostly Vegas Volcano Lava Roll	3	decent	
 -87	normal bouncing Crazy Dragon Shogun Buddha Roll	4	good	
 -92	spoiled tumbling basic hot dog	3	crappy	
--93	adequate special immense savage macho dog	6	good	
+-93	immense special adequate savage macho dog	6	good	
 -94	normal one with everything	4	good	
 -95	adequate big sly dog	5	good	
 -96	bland small yellow devil dog	2	decent	
--97	rotten half-sized skewed chilly dog	2	crappy	
+-97	half-sized rotten skewed chilly dog	2	crappy	
 -98	rotten super-sized ghost dog	5	crappy	
 -99	bite-sized normal junkyard dog	1	good	
 -100	delicious wet dog	3	awesome	

--- a/data/TCRS/TCRS_Seal_Clubber_Mongoose.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Mongoose.txt
@@ -1,8 +1,8 @@
 1	mirror seal-clubbing club	0		
 2	maroon seal tooth	0		
 3	bouncing blinking helmet turtle of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "atk, cap 2"
-4	blinking olive turtle totem	0		
-5	teal twirling pasta spoon	0		
+4	olive blinking turtle totem	0		
+5	twirling teal pasta spoon	0		
 6	mirror friendly ravioli hat	0		Familiar Weight: +3, Familiar Effect: "atk, cap 2"
 7	twirling saucepan	0		
 8	spices	0		
@@ -29,7 +29,7 @@
 30	rock	0		
 31	seal-toothed rock	0		
 32	cyan crafty Bjorn's Hammer	0		Maximum MP: +10, Class: "Seal Clubber"
-33	wobbly cyan snorkel	0		Familiar Effect: "atk, cap 2"
+33	cyan wobbly snorkel	0		Familiar Effect: "atk, cap 2"
 34	narrow curative Dolphin King's crown	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 2xGhuol, cap 8"
 35	Knob Goblin scimitar of the scaredy-cat	0		Monster Level: -15
 36	skewed olive banded Knob Goblin tongs	0		Damage Absorption: +100
@@ -43,7 +43,7 @@
 44	worthless gewgaw	0		
 45	pulsating worthless knick-knack	0		
 46	fuchsia figurine	0		
-47	massive spoiled shaking hot buttered roll	10	crappy	
+47	spoiled massive shaking hot buttered roll	10	crappy	
 48	skewed heart of rock and roll	0		
 49	normal bowl of cottage cheese	4	good	
 50	purple mirror pulsating Rosewater's Rock and Roll Legend	0		Mysticality Percent: +30, Class: "Accordion Thief", Song Duration: 10
@@ -57,7 +57,7 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	jittery rosy-cheeked Mace of the Tortoise	0		Maximum HP Percent: +30, Class: "Turtle Tamer"
-61	normal fancy fortune cookie	3	good	Effect: "Emotion Sickness", Effect Duration: 40
+61	fancy normal fortune cookie	3	good	Effect: "Emotion Sickness", Effect Duration: 40
 62	purple oriole-feather headdress of the pedagogue	0		Experience: +3, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	shaking action figure head	0		
@@ -116,7 +116,7 @@
 117	lime green Gnollish plunger	0		
 118	jittery spring	0		
 119	mirror sprocket	0		
-120	pulsating skewed cog	0		
+120	skewed pulsating cog	0		
 121	sprocket assembly	0		
 122	yellow cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
@@ -175,7 +175,7 @@
 176	disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
-179	half-sized decent blurry yellow chorizo taco	2	good	
+179	decent half-sized blurry yellow chorizo taco	2	good	
 180	perfectly mixed ice-cold fotie	4	EPIC	
 181	baseball	0		
 182	batgut	0		
@@ -188,14 +188,14 @@
 189	guano coffee cup	0		
 191	wizardly batskin belt	0		Mysticality: +25
 192	batskin belt	0		
-193	blinking lime green birthday candle	0		
+193	lime green blinking birthday candle	0		
 194	Lo Pan's Mr. Accessory	0		Spell Critical Percent: +30, Softcore Only
 195	yellow skewed friendly eXtreme nose ring	0		Familiar Weight: +3
 196	disassembled clover	0		
 197	rat whisker	0		
 198	rat appendix	0		
 199	narrow stanky ring	0		Stench Spell Damage: +25
-200	decent diet tumbling rat appendix kabob	1	good	
+200	diet decent tumbling rat appendix kabob	1	good	
 201	yummy enchanted ghostly bat wing kabob	4	awesome	Effect: "Psalm of Pointiness", Effect Duration: 35
 202	bite-sized adequate maroon carob chunks	1	good	
 203	blue herbs	0		
@@ -205,13 +205,13 @@
 207	purple hippy herbal tea	1	good	
 208	mirror patchouli incense stick	0		
 209	fuchsia wad of tofu	0		
-210	twirling olive Feng Shui for Big Dumb Idiots	0		
+210	olive twirling Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
 212	windchimes	0		
 213	fireproof brainy filthy corduroys	0		Mysticality: +5, Hot Resistance: +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	filthy knitted dread sack of the pedagogue	0		Experience: +3, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	pulsating Uncle Jick's Brownie Mix	0		
-216	massive normal pulsating carob brownies	10	good	
+216	normal massive pulsating carob brownies	10	good	
 217	bland herb brownies	4	decent	
 218	hemp string	0		
 219	twirling necklace chain	0		
@@ -220,7 +220,7 @@
 222	jittery phat turquoise bead	0		
 223	phat turquoise bracelet of the bloodbag	0		Maximum HP: +100
 224	sage eyepatch	0		Mysticality Percent: +10, Familiar Effect: "3xBarrr, cap 6"
-225	normal immense tofu casserole	9	good	
+225	immense normal tofu casserole	9	good	
 226	denatured can of Red Minotaur	1	EPIC	
 227	wobbly ghostly Kentucky-fried meat sword of the wise owl	0		Mysticality: +20
 228	ghostly fortified Kentucky-fried meat staff	0		Damage Absorption: +60
@@ -237,22 +237,22 @@
 239	green frightening arcane researcher's Orcish baseball cap	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	wobbly therapeutic veiny Orcish cargo shorts	0		Maximum HP: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	upside-down toasty Orcish frat-paddle	0		Hot Damage: +5
-242	spoiled massive	9	crappy	
+242	massive spoiled	9	crappy	
 243	flavorless grapefruit	4	decent	
 244	rotten wobbly grapes	4	crappy	
 245	adequate olive	3	good	
 246	flavorless tomato	3	decent	
 247	fermenting powder	0		
 248	weak mediocre salty dog	2	decent	
-249	perfectly mixed distilled bloody mary	5	EPIC	
-250	hand-crafted watered-down olive screwdriver	2	EPIC	
-251	special lousy martini	4	decent	Effect: "Ghost Finger", Effect Duration: 40
+249	distilled perfectly mixed bloody mary	5	EPIC	
+250	watered-down hand-crafted olive screwdriver	2	EPIC	
+251	lousy special martini	4	decent	Effect: "Ghost Finger", Effect Duration: 40
 252	spirit-forward hand-crafted bloody beer	5	EPIC	
-253	enchanted tolerable weak shot of schnapps	2	good	Effect: "Sweet and Green", Effect Duration: 25
+253	weak tolerable enchanted shot of schnapps	2	good	Effect: "Sweet and Green", Effect Duration: 25
 254	drinkable weak gray shot of grapefruit schnapps	2	good	
-255	acceptable spirit-forward fine wine	5	good	
+255	spirit-forward acceptable fine wine	5	good	
 256	artisanal squat shot of tomato schnapps	3	EPIC	
-257	strong tolerable extra-spicy bloody mary	5	good	
+257	tolerable strong extra-spicy bloody mary	5	good	
 258	dense meat stack	0		
 259	snake skin	0		
 260	thick rotten White Citadel fries	5	crappy	
@@ -261,7 +261,7 @@
 263	moldy gigantic spinning chocolate chips	8	crappy	
 264	normal chocolate chip cookies	3	good	
 265	mirror ribald satin pants	0		Sleaze Damage: +10, Familiar Effect: "atk, 2xPotato, cap 10"
-266	weak mediocre bouncing blinking lightning	2	decent	
+266	mediocre weak bouncing blinking lightning	2	decent	
 267	green quilted mullet wig	0		Damage Absorption: +40, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	cool meat cowboy hat	0		Moxie: +5, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	olive wicked sword	0		Spell Damage: +5
@@ -297,7 +297,7 @@
 299	dry Vulcanized pickle-flavored chewing gum	0		Effect: "Physicali Tea", Effect Duration: 12
 300	energized jaba&ntilde;ero-flavored chewing gum	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 38
 301	pulsating flat dough	0		
-302	moldy small Knob sausage	2	crappy	
+302	small moldy Knob sausage	2	crappy	
 303	moldy bouncing Knob mushroom	3	crappy	
 304	dry noodles	0		
 305	Van der Graaf Knob Goblin harem pants	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -316,25 +316,25 @@
 318	moldy bean burrito	4	crappy	
 319	normal insanely bean burrito	3	good	
 320	yummy wobbly bat haggis	4	awesome	
-321	decent half-sized menudo	2	good	
-322	enchanted stale huge goat cheese	4	decent	Effect: "Insatiable Hunger", Effect Duration: 45
-323	stale jumbo plain pizza	5	decent	
-324	yummy miniature sausage pizza	2	awesome	
+321	half-sized decent menudo	2	good	
+322	stale enchanted huge goat cheese	4	decent	Effect: "Insatiable Hunger", Effect Duration: 45
+323	jumbo stale plain pizza	5	decent	
+324	miniature yummy sausage pizza	2	awesome	
 325	super-sized flavorless goat cheese pizza	5	decent	
-326	spoiled thick mushroom pizza	5	crappy	
+326	thick spoiled mushroom pizza	5	crappy	
 327	jittery goat	0		
 328	tolerable watered-down bottle of whiskey	2	good	
 329	hale goat beard	0		Maximum HP: +20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	decent	
-331	delicious watered-down blue Canadian	2	awesome	
+331	watered-down delicious blue Canadian	2	awesome	
 332	bland lemon	3	decent	
-333	delicious huge lime	8	awesome	
+333	huge delicious lime	8	awesome	
 334	bouncing spinning Temple Grandin's sabre teeth	0		Familiar Weight: +7
 335	blurry sabre-toothed lime cub	0		
 336	spinning veiny consolation ribbon	0		Maximum HP: +10
 337	ol' trophy	0		
 338	tenderizing hammer	0		
-339	purple blinking Cobb's Knob lab key	0		
+339	blinking purple Cobb's Knob lab key	0		
 340	nitrogenated wobbly Knob Goblin steroids	0		Effect: "Protection from Bad Stuff", Effect Duration: 23
 341	tarnished Knob Goblin love potion	0		Effect: "Sparkly!", Effect Duration: 69
 342	Knob Goblin stink bomb	0		
@@ -353,7 +353,7 @@
 355	lard-coated eXtreme scarf	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	huge skewed chaotic snowboarder pants	0		Spell Critical Percent: +10, Familiar Effect: "1xPotato, cap 25"
 357	shaking Mountain Stream soda	0		
-358	flavorless massive twirling twirling gr8ps	10	decent	
+358	massive flavorless twirling twirling gr8ps	10	decent	
 359	flavorless t8r tots	3	decent	
 360	miner's helmet of the businessman	0		Meat Drop: +50, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	crafty miner's pants	0		Maximum MP: +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -367,7 +367,7 @@
 369	asbestos sword hilt	0		
 370	skewed asbestos stick	0		
 371	spinning asbestos crossbow string	0		
-372	blue skewed chrome sword hilt	0		
+372	skewed blue chrome sword hilt	0		
 373	chrome stick	0		
 374	chrome crossbow string	0		
 375	wobbly linoleum meat stack	0		
@@ -413,11 +413,11 @@
 415	skewed Jeselnik's leotarrrd	0		Sleaze Damage: +25, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	supercharged safarrri hat	0		Maximum MP Percent: +30, Familiar Effect: "2xVolley, cap 22"
 417	wet squat henna tattoo	0		Effect: "Burning Ears", Effect Duration: 43
-418	enhanced quadruple-magnetized maroon spinning jittery Ferrigno's Elixir of Power	0		Effect: "Dances with Tweedles", Effect Duration: 12
+418	enhanced quadruple-magnetized spinning maroon jittery Ferrigno's Elixir of Power	0		Effect: "Dances with Tweedles", Effect Duration: 12
 419	colloidal oxidized serum of sarcasm	0		Effect: "Lobos Fresh", Effect Duration: 51
 420	polarized colloidal tomato juice of powerful power	0		Effect: "Celestial Body", Effect Duration: 21
 421	adjusted boiled diffused red philter of phorce	0		Effect: "Slightly Mutated", Effect Duration: 34
-422	altered galvanized huge twirling potion of potency	0		Effect: "Buttermilk Boogie", Effect Duration: 26
+422	altered galvanized twirling huge potion of potency	0		Effect: "Buttermilk Boogie", Effect Duration: 26
 423	concentrated quadruple-oxidized cordial of concentration	0		Effect: "Slime Time", Effect Duration: 28
 424	liquefied dry ointment of the occult	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 15
 425	activated oil of expertise	0		Effect: "Stone-Faced", Effect Duration: 13
@@ -425,7 +425,7 @@
 427	savvy box	0		Mysticality Percent: +20, Wiki Name: "box"
 428	nothing-in-the-box	0		
 429	bouncing bouncing beanbag chair	0		
-430	blurry red squat acid-squirting flower	0		Single Equip
+430	red squat blurry acid-squirting flower	0		Single Equip
 431	spinning clown shoes of Leguizamo	0		Monster Level: +20, Clowniness: 25
 432	horrifying bloody clown pants	0		Spooky Damage: +25, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
 433	ghostly skinny balloon	0		
@@ -441,7 +441,7 @@
 443	beer lens	0		
 444	lime green beer goggles	0		
 445	bouncing grievous box-in-the-box	0		Weapon Damage Percent: +50
-446	pulsating shaking nothing-in-the-box-in-the-box	0		
+446	shaking pulsating nothing-in-the-box-in-the-box	0		
 447	therapeutic box-in-the-box-in-the-box	0		HP Regen Min: 5, HP Regen Max: 7
 448	miser's stiffened foolscap fool's cap	0		Damage Reduction: 1, Meat Drop: +10, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	dance instructor's clown nose	0		Experience Percent (Moxie): +10, Clowniness: 25
@@ -455,7 +455,7 @@
 457	Jim Carey's ye olde golde frontes	0		Monster Level: +25, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
-460	narrow mirror pixel	0		
+460	mirror narrow pixel	0		
 461	tumbling pixel	0		
 462	pixel	0		
 463	pixel	0		
@@ -465,8 +465,8 @@
 467	half-sized yummy pixel pie	2	awesome	
 468	ruby W	0		
 469	wussiness potion	0		
-470	perfectly mixed practically non-alcoholic blurry cyan Imp Ale	1	EPIC	
-471	flavorless snack-sized jittery bouncing hot wing	2	decent	
+470	perfectly mixed practically non-alcoholic cyan blurry Imp Ale	1	EPIC	
+471	flavorless snack-sized bouncing jittery hot wing	2	decent	
 472	brawny diamond-studded cane	0		Muscle Percent: +20, Class: "Disco Bandit"
 473	crutch of the cougar	0		Moxie: +20
 474	cast	0		
@@ -495,7 +495,7 @@
 497	blinking gnatwing	0		
 498	flavorless teal papaya	3	decent	
 499	narrow grievous denim axe of terror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +10
-500	blurry tumbling Elf Farm Raffle ticket	0		
+500	tumbling blurry Elf Farm Raffle ticket	0		
 501	bland Elfin shortbread	3	decent	
 502	pulsating pagoda plans	0		
 503	super-sized moldy bouncing skewered cat appendix	5	crappy	
@@ -521,7 +521,7 @@
 523	rewinged stab bat	0		
 524	aged spinning papaya sling	3	awesome	
 525	grue egg	0		
-526	maroon ghostly Frobozz Real-Estate Company Instant House (TM)	0		
+526	ghostly maroon Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	blood-faced volleyball	0		
 529	ghostly fertilized ghuol egg	0		
@@ -549,10 +549,10 @@
 551	64067 scroll	0		
 552	blinking 64735 scroll	0		
 553	wobbly 31337 scroll	0		
-554	massive spoiled pr0n cocktail	10	crappy	
+554	spoiled massive pr0n cocktail	10	crappy	
 555	ghostly maroon studded baleful drywall axe	0		Spell Damage: +25, Damage Absorption: +80
 556	squat Sherlock's Pine-Fresh air freshener	0		Item Drop: +25
-557	acceptable extra-dry spinning whiskey and cola	5	good	
+557	extra-dry acceptable spinning whiskey and cola	5	good	
 558	stale immense papaya taco	9	decent	
 559	razor-sharp can lid	0		
 560	fancy delicious stalk of asparagus	3	awesome	Effect: "Aided and Abetted", Effect Duration: 35
@@ -564,22 +564,22 @@
 566	Lo Pan's bum cheek	0		Spell Critical Percent: +30, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	shaking hermit script	0		
 568	toothsome purple Double Bacon Beelzeburger	4	awesome	
-569	bite-sized decent special yellow Lord of the Flies-sized fries	1	good	Effect: "Yes, Can Haz", Effect Duration: 45
+569	decent special bite-sized yellow Lord of the Flies-sized fries	1	good	Effect: "Yes, Can Haz", Effect Duration: 45
 570	spoiled ghostly Chicken Sandwich	4	crappy	
 571	tumbling Jumbo Dr. Lucifer	1	decent	
 572	flavorless maroon Children's Meal of the Damned	3	decent	
 573	tiny yummy noodles	1	awesome	
-574	bland miniature noodles	2	decent	
-575	decent miniature twirling painful penne pasta	2	good	
+574	miniature bland noodles	2	decent	
+575	miniature decent twirling painful penne pasta	2	good	
 576	bland massive ravioli della hippy	10	decent	
 577	yummy pr0n m4nic0tti	3	awesome	
 578	delicious miniature Hell ramen	2	awesome	
-579	adequate small mirror narrow boring spaghetti	2	good	
+579	adequate small narrow mirror boring spaghetti	2	good	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	delicious bite-sized lime green fettucini Inconnu	1	awesome	
-584	delicious half-sized spaghetti with Skullheads	2	awesome	
+583	bite-sized delicious lime green fettucini Inconnu	1	awesome	
+584	half-sized delicious spaghetti with Skullheads	2	awesome	
 585	adequate big gnocchetti di Nietzsche	5	good	
 586	scandalous rock-hard ridiculously huge sword	0		Damage Reduction: 5, Sleaze Damage: +5
 587	liquefied tumbling fuchsia super-spiky hair gel	0		Effect: "Mushroom Samba", Effect Duration: 16
@@ -593,7 +593,7 @@
 595	scroll of drastic healing	0		
 596	blurry Newton's titanium assault umbrella	0		Experience (Mysticality): +3
 597	sharpshooter's Mohawk wig	0		Critical Hit Percent: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
-598	blue mirror the Slug Lord's map	0		
+598	mirror blue the Slug Lord's map	0		
 599	blinking blinking stylish pants of the Slug Lord	0		Moxie: +25, Familiar Effect: "stench atk, 3xPotato, cap 8"
 600	arcane researcher's Dr. Hobo's scalpel of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25
 601	huge Dr. Hobo's map	0		
@@ -615,12 +615,12 @@
 617	liquefied pulsating Angry Farmer candy	0		Effect: "Work For Hours a Week", Effect Duration: 19
 618	enhanced adjusted twirling Mick's IcyVapoHotness Rub	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 11
 619	bouncing crafty needle	0		Maximum MP: +10
-620	vacuum-sealed quantum jittery ghostly thin candle	0		Effect: "Expert Vacationer", Effect Duration: 39
+620	vacuum-sealed quantum ghostly jittery thin candle	0		Effect: "Expert Vacationer", Effect Duration: 39
 621	Warm Subject gift certificate	0		
 622	awful poetry journal	0		
 623	WA	0		
 624	NG	0		
-625	twirling blinking blue wang	0		
+625	twirling blue blinking wang	0		
 626	Wand of Nagamar	0		
 627	ND	0		
 628	metallic A	0		
@@ -636,12 +636,12 @@
 638	nippy asshat of chilblains	0		Cold Damage: 35, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	tasty miniature abominable snowcone	2	awesome	
 640	pulsating Ent cider	1	good	
-641	small delicious toast	2	awesome	
+641	delicious small toast	2	awesome	
 642	bouncing green skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	snack-sized fancy adequate fruitcake	2	good	Effect: "Vinegavotte", Effect Duration: 30
+646	fancy adequate snack-sized fruitcake	2	good	Effect: "Vinegavotte", Effect Duration: 30
 647	tumbling present	0		Last Available: "2004-11"
 648	sharpshooter's Crimbo sword	0		Critical Hit Percent: +10, Last Available: "2004-10"
 649	pulsating groovy Crimbo hat	0		Moxie Percent: +10, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
@@ -667,19 +667,19 @@
 669	bland olive upside-down ghuol guolash	3	decent	
 670	wobbly sharpshooter's lihc face	0		Critical Hit Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	olive crafty banded grave robbing shovel	0		Damage Absorption: +100, Maximum MP: +10
-672	tasty special diet cranberries	1	awesome	Effect: "Slippery Tongue", Effect Duration: 40
-673	perfectly mixed extra-dry vodka and cranberry	5	EPIC	
+672	diet special tasty cranberries	1	awesome	Effect: "Slippery Tongue", Effect Duration: 40
+673	extra-dry perfectly mixed vodka and cranberry	5	EPIC	
 674	mediocre whiskey	4	decent	
 675	Lo Pan's skull of the Bonerdagon	0		Spell Critical Percent: +30
 676	dragonbone belt buckle	0		
 677	mirror upside-down strapping badass belt	0		Muscle: +5
 678	ghostly chest of the Bonerdagon	0		
-679	practically non-alcoholic bad roll in the hay	1	decent	
+679	bad practically non-alcoholic roll in the hay	1	decent	
 680	artisanal jittery slap and tickle	3	EPIC	
 681	weak acceptable slip 'n' slide	2	good	
-682	distilled special bad squat a sump'm sump'm	5	decent	Effect: "Snobby", Effect Duration: 25
+682	bad distilled special squat a sump'm sump'm	5	decent	Effect: "Snobby", Effect Duration: 25
 683	aged purple horizontal tango	3	awesome	
-684	smooth irresponsibly strong special pink pony	10	awesome	Effect: "Techno Bliss", Effect Duration: 30
+684	special irresponsibly strong smooth pink pony	10	awesome	Effect: "Techno Bliss", Effect Duration: 30
 685	Sherlock's Mr. Shirt of Gandalf of bravery	0		Spell Critical Percent: +20, Spooky Resistance: +5, Item Drop: +25
 686	jittery rosewater-soaked knuckles	0		Stench Resistance: +3
 687	dry modified upside-down blood of the Wereseal	0		Effect: "Alpine Mintiness", Effect Duration: 54
@@ -731,11 +731,11 @@
 735	shaking mirror strapping easter egg balloon	0		Muscle: +5
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	shaking fuchsia stone tablet (Really Evil Rhythm)	0		
+738	fuchsia shaking stone tablet (Really Evil Rhythm)	0		
 739	tambourine bells	0		
 740	frightening tambourine	0		Spooky Damage: +5
 741	broken skull	0		
-742	adequate huge Knoll shroomkabob	7	good	
+742	huge adequate Knoll shroomkabob	7	good	
 743	decent mushroom	3	good	
 744	non-quantum hair spray	0		Effect: "The Rich Get Richer", Effect Duration: 34
 746	ghostly stat script	0		
@@ -746,7 +746,7 @@
 751	bland skewed cool mushroom	3	decent	
 752	bland cool mushroom casserole	3	decent	
 753	delicious jittery pointy mushroom	3	awesome	
-754	gigantic rotten cream of pointy mushroom soup	6	crappy	
+754	rotten gigantic cream of pointy mushroom soup	6	crappy	
 755	toothsome mirror mushroom	3	awesome	
 756	adequate mushroom	3	good	
 757	adequate blurry mushroom	3	good	
@@ -778,35 +778,35 @@
 783	'Villa' document	0		
 784	weak fancy drinkable Acqua Del Piatto Merlot	2	good	Effect: "Like a Fish to Walter", Effect Duration: 25, Last Available: "2004-10"
 785	raffle ticket	0		
-786	decent small strawberry	2	good	
+786	small decent strawberry	2	good	
 787	acceptable skewed bottle of rum	3	good	
 788	perfectly mixed strawberry daiquiri	4	EPIC	
 789	perfectly mixed rum and cola	4	EPIC	
-790	practically non-alcoholic drinkable grog	1	good	
+790	drinkable practically non-alcoholic grog	1	good	
 791	shaking grievous Mafia bow tie of the ox	0		Muscle: +20, Weapon Damage Percent: +50, Last Available: "2004-10"
 792	Golden Mr. Accessory of the wise owl	0		Mysticality: +20, Softcore Only
 793	activated modified oil of stability	0		Effect: "Thunderspell", Effect Duration: 40
 794	alkaline polymerized oil of slipperiness	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 33
-795	hand-crafted practically non-alcoholic Acque Luride Grezze Cabernet	1	super ultra mega turbo EPIC	Last Available: "2004-10"
+795	practically non-alcoholic hand-crafted Acque Luride Grezze Cabernet	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 796	auspicious rosy-cheeked cement shoes of the brute	0		Muscle Percent: +30, Maximum HP Percent: +30, Item Drop: +10, Last Available: "2004-10"
 797	hand-crafted rockin' wagon	4	EPIC	
-798	special drinkable weak ocean motion	2	good	Effect: "Tennis Elbow-wow", Effect Duration: 30
+798	weak drinkable special ocean motion	2	good	Effect: "Tennis Elbow-wow", Effect Duration: 30
 799	watered-down drinkable fuzzbump	2	good	
 800	toothsome poutine	4	awesome	
 801	jumbo adequate Knob stir-fry	5	good	
-804	moldy big red Knoll stir-fry	5	crappy	
-805	adequate enchanted stir-fry	4	good	Effect: "Omphalotus Omnipresence", Effect Duration: 5
+804	big moldy red Knoll stir-fry	5	crappy	
+805	enchanted adequate stir-fry	4	good	Effect: "Omphalotus Omnipresence", Effect Duration: 5
 806	enchanted stale asparagus stir-fry	3	decent	Effect: "Nightstalkin'", Effect Duration: 20
 807	yummy jumbo olive stir-fry	5	awesome	
 808	snack-sized bland Knob sausage stir-fry	2	decent	
 809	stale small special bat wing stir-fry	2	decent	Effect: "Hammered", Effect Duration: 50
-810	bite-sized spoiled blue rat appendix stir-fry	1	crappy	
-811	decent blurry gray wobbly tofu stir-fry	3	good	
+810	spoiled bite-sized blue rat appendix stir-fry	1	crappy	
+811	decent wobbly blurry gray tofu stir-fry	3	good	
 812	toothsome wobbly pr0n stir-fry	4	awesome	
-813	immense decent Knob shells	10	good	
+813	decent immense Knob shells	10	good	
 814	normal b&auml;tzle	3	good	
 815	moldy narrow ratini	3	crappy	
-816	snack-sized toothsome pulsating Knob stroganoff	2	awesome	
+816	toothsome snack-sized pulsating Knob stroganoff	2	awesome	
 817	stale menudo ravioli	4	decent	
 818	plus sign	0		
 819	milky potion	0		
@@ -815,26 +815,26 @@
 822	smoky potion	0		
 823	green cloudy potion	0		
 824	effervescent potion	0		
-825	yellow jittery wobbly fizzy potion	0		
+825	yellow wobbly jittery fizzy potion	0		
 826	dark potion	0		
 827	murky potion	0		
 828	baby killer bee	0		
 829	anti-anti-antidote	0		
-830	flavorless miniature blue royal jelly	2	decent	
+830	miniature flavorless blue royal jelly	2	decent	
 831	skewed small box	0		
 832	box	0		
 833	purple blinking Socratic vorpal blade	0		Experience (Mysticality): +1
 834	lime green gravedigger's Lo Pan's cornuthaum	0		Spell Critical Percent: +30, Spooky Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	maroon Da Vinci's ring of aggravate monster	0		Experience (Mysticality): +5
-836	delicious super-sized mind flayer corpse	5	awesome	
-837	hand-crafted weak Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
+836	super-sized delicious mind flayer corpse	5	awesome	
+837	weak hand-crafted Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
 838	pulsating squat flame-wreathed wicked Mafia stogie	0		Spell Damage: +5, Hot Spell Damage: +10, Last Available: "2004-10"
 839	smooth watered-down Maiali Sifilitici Pinot Noir	2	awesome	Last Available: "2004-10"
 840	greedy chaotic Mafia violin case	0		Spell Critical Percent: +10, Meat Drop: +20, Last Available: "2004-10"
 841	mediocre triple-distilled tomato daiquiri	10	decent	
 842	lousy beertini	3	decent	
 843	hand-crafted spirit-forward salty slug	5	EPIC	
-844	practically non-alcoholic tolerable papaya slung	1	good	
+844	tolerable practically non-alcoholic papaya slung	1	good	
 845	purple MAHI fez of the cheetah	0		Initiative: +60, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -845,7 +845,7 @@
 853	blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
 855	mirror balloon knife	0		Familiar Weight: +5
-856	wobbly ghostly shock collar	0		
+856	ghostly wobbly shock collar	0		
 857	moonglasses	0		
 858	blue palm-frond toupee	0		Familiar Weight: +5
 859	spinning knife and fork	0		Familiar Weight: +5
@@ -870,7 +870,7 @@
 879	activated ghostly bottle of goofballs	0		Effect: "Old Time Hydration", Effect Duration: 59
 880	lard-coated disbelief suspenders	0		Sleaze Spell Damage: +25
 881	steel-toed supportive bra	0		Damage Reduction: 9
-882	ghostly mirror Blatantly Canadian	0		
+882	mirror ghostly Blatantly Canadian	0		
 883	maple syrup	1	good	
 884	pulsating banded los chinos	0		Damage Absorption: +100, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	curative axe	0		HP Regen Min: 3, HP Regen Max: 5
@@ -891,14 +891,14 @@
 900	ghostly smile-sharpening stone	0		Familiar Weight: +5
 901	mirror espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	practically non-alcoholic delicious Spasmi Dolorosi Del Rene Champagne	1	awesome	Last Available: "2004-10"
+903	delicious practically non-alcoholic Spasmi Dolorosi Del Rene Champagne	1	awesome	Last Available: "2004-10"
 904	Jim Carey's energetic brainy school Mafia knickerbockers	0		Mysticality: +5, Maximum MP Percent: +20, Monster Level: +25, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	non-chilled magnetized pulsating Yummy Tummy bean	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 27
 906	electrified Rock Pops	0		Effect: "From Nantucket", Effect Duration: 47
 907	quadruple-tarnished galvanized super-aerosolized bouncing Mr. Mediocrebar	0		Effect: "EVISCERATE!", Effect Duration: 46
 908	nitrogenated wet shaking Cold Hots candy	0		Effect: "Scrappy, Shadowy", Effect Duration: 12
 909	concentrated anodized Wint-O-Fresh mint	0		Effect: "Innately Truthy", Effect Duration: 17
-910	rotten immense dwarf bread	9	crappy	
+910	immense rotten dwarf bread	9	crappy	
 911	galvanized double-magnetized Senior Mints	0		Effect: "Tiki Toughness", Effect Duration: 14
 912	denatured enhanced skewed pixellated candy heart	0		Effect: "Happy Salamander", Effect Duration: 18
 913	unsweetened polymerized kobold	0		Effect: "Neutered Nostrils", Effect Duration: 54
@@ -918,9 +918,9 @@
 927	artisanal high-proof Ferita Del Petto Zinfandel	8	EPIC	Last Available: "2006-12"
 928	miser's fuzzy bracelets	0		Meat Drop: +10
 929	pulsating blinking arse-shooting crossbow of the wise owl	0		Mysticality: +20
-931	weak artisanal lime green spiced rum	2	EPIC	
+931	artisanal weak lime green spiced rum	2	EPIC	
 932	acceptable eggnog	4	good	
-933	huge decent candy cane	8	good	
+933	decent huge candy cane	8	good	
 934	normal gray gingerbread bugbear	3	good	
 935	lime green vibrating imitation nice watch	0		Maximum MP Percent: +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -936,14 +936,14 @@
 946	jittery skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	smooth martini	3	awesome	Last Available: "2004-12"
-949	weak smooth skewed grogtini	2	awesome	Last Available: "2004-12"
-950	strong lousy cherry bomb	5	decent	Last Available: "2004-12"
+949	smooth weak skewed grogtini	2	awesome	Last Available: "2004-12"
+950	lousy strong cherry bomb	5	decent	Last Available: "2004-12"
 951	ghostly mirror extra special Crimbo stocking	0		Last Available: "2004-12"
 952	scandalous dance instructor's hockey mask	0		Experience Percent (Moxie): +10, Sleaze Damage: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	skewed orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	twirling blue hardy fez of etymology	0		Maximum HP: +50, Familiar Effect: "1xLep, cap 30"
-956	jumbo moldy carob chunk noodles	5	crappy	
+956	moldy jumbo carob chunk noodles	5	crappy	
 957	moldy chorizo brownies	3	crappy	
 958	normal chocolate and tomato pizza	3	good	
 959	flange	0		
@@ -993,7 +993,7 @@
 1006	bland cherry	3	decent	
 1007	skewed Newton's coconut shell	0		Experience (Mysticality): +3, Familiar Effect: "1xFairy, cap 7"
 1008	wobbly shaking chilly ice cubes	0		Cold Damage: +5
-1009	weak mediocre wobbly vodka martini	2	decent	
+1009	mediocre weak wobbly vodka martini	2	decent	
 1010	watered-down bad whiskey and soda	2	decent	
 1011	high-proof tolerable monkey wrench	8	good	
 1012	perfectly mixed strong tequila sunrise	5	EPIC	
@@ -1004,10 +1004,10 @@
 1017	hand-crafted ducha de oro	4	EPIC	
 1018	mediocre calle de miel	3	decent	
 1019	acceptable distilled dry vodka martini	5	good	
-1020	hand-crafted weak old-fashioned	2	EPIC	
+1020	weak hand-crafted old-fashioned	2	EPIC	
 1021	lousy tequila with training wheels	4	decent	
 1022	aged bouncing sangria	3	awesome	
-1023	mediocre enchanted vesper	4	decent	Effect: "Little Mouse Skull Buddy", Effect Duration: 40, Last Available: "2004-12"
+1023	enchanted mediocre vesper	4	decent	Effect: "Little Mouse Skull Buddy", Effect Duration: 40, Last Available: "2004-12"
 1024	acceptable gray narrow bodyslam	3	good	Last Available: "2004-12"
 1025	smooth ghostly sangria del diablo	3	awesome	Last Available: "2004-12"
 1026	upside-down Valentine	0		Free Pull
@@ -1044,12 +1044,12 @@
 1058	pickled mirror jittery puce oyster egg	1		Effect: "Empty Inside", Effect Duration: 45
 1059	puce plastic oyster egg	0		
 1060	diluted mauve oyster egg	1		
-1061	compressed teal mirror mauve oyster egg	1		
+1061	compressed mirror teal mauve oyster egg	1		
 1062	powdered mauve oyster egg	1		Effect: "The Sweats", Effect Duration: 20
-1063	ghostly tumbling mauve plastic oyster egg	0		
+1063	tumbling ghostly mauve plastic oyster egg	0		
 1064	pickled oyster egg	1		
 1065	pickled wobbly oyster egg	1		Effect: "Weird Flavor", Effect Duration: 40
-1066	mixed upside-down wobbly green oyster egg	1		Effect: "Orc Chops", Effect Duration: 25
+1066	mixed green wobbly upside-down oyster egg	1		Effect: "Orc Chops", Effect Duration: 25
 1067	plastic oyster egg	0		
 1068	altered twirling oyster egg	1		Effect: "Eyes Wide Propped", Effect Duration: 15
 1069	boiled ghostly gray oyster egg	1		
@@ -1089,7 +1089,7 @@
 1103	lime green squat unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
-1106	upside-down twirling clockwork chef head	0		
+1106	twirling upside-down clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	narrow clockwork detective skull	0		
 1109	clockwork bartender-head-in-the-box	0		
@@ -1102,7 +1102,7 @@
 1116	annoying pitchfork	0		Monster Level: +5
 1117	toasty curative Stupid University Diploma of the cheetah	0		Hot Damage: +5, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5
 1118	pregnant mushroom	0		
-1119	skewed ghostly pregnant mushroom	0		
+1119	ghostly skewed pregnant mushroom	0		
 1120	pregnant mushroom	0		
 1121	inexplicably rock	0		
 1122	blue fairy gravy	0		
@@ -1124,16 +1124,16 @@
 1138	mushroom fermenting solution	0		
 1139	drinkable mushroom wine	3	good	
 1140	artisanal icy mushroom wine	4	EPIC	
-1141	triple-distilled drinkable mushroom wine	9	good	
+1141	drinkable triple-distilled mushroom wine	9	good	
 1142	bad spirit-forward twirling pointy mushroom wine	5	decent	
 1143	tolerable blurry flat mushroom wine	3	good	
-1144	practically non-alcoholic artisanal green blurry cool mushroom wine	1	super ultra mega turbo EPIC	
+1144	artisanal practically non-alcoholic green blurry cool mushroom wine	1	super ultra mega turbo EPIC	
 1145	drinkable knob mushroom wine	4	good	
 1146	smooth knoll mushroom wine	4	awesome	
-1147	watered-down artisanal special jittery mushroom wine	2	EPIC	Effect: "Leo Rising", Effect Duration: 45
+1147	watered-down special artisanal jittery mushroom wine	2	EPIC	Effect: "Leo Rising", Effect Duration: 45
 1148	practically non-alcoholic drinkable blinking shot of flower schnapps	1	good	
 1149	yummy upside-down flower petal pie	3	awesome	
-1150	distilled enchanted hand-crafted bottle of single-barrel whiskey	5	EPIC	Effect: "Slimy Flavor", Effect Duration: 20
+1150	enchanted distilled hand-crafted bottle of single-barrel whiskey	5	EPIC	Effect: "Slimy Flavor", Effect Duration: 20
 1151	gray Sherlock's slick discarded plastic fork	0		Moxie: +10, Item Drop: +25
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	diet bland Retenez L'Herbe Pat&eacute;	1	decent	
@@ -1184,14 +1184,14 @@
 1199	bugbear	0		
 1200	moldy narrow mugcake	3	crappy	
 1201	adequate immense urinal cake	8	good	
-1202	snack-sized stale Happy Birthday, Claude! cake	2	decent	
-1203	bland small special skewed personalized birthday cake	2	decent	Effect: "Cold Jellied", Effect Duration: 15
-1204	adequate diet three-tiered wedding cake	1	good	
+1202	stale snack-sized Happy Birthday, Claude! cake	2	decent	
+1203	special small bland skewed personalized birthday cake	2	decent	Effect: "Cold Jellied", Effect Duration: 15
+1204	diet adequate three-tiered wedding cake	1	good	
 1205	decent babycakes	4	good	
 1206	rotten velvet cake	4	crappy	
 1207	rotten yellow congratulatory cake	4	crappy	
 1208	spoiled angel-food cake	3	crappy	
-1209	delicious snack-sized pulsating devil's-food cake	2	awesome	
+1209	snack-sized delicious pulsating devil's-food cake	2	awesome	
 1210	rotten birthday party jellybean cheesecake	3	crappy	
 1211	yellow balloon	0		
 1212	balloon	0		
@@ -1221,7 +1221,7 @@
 1237	tapped lotus	0		
 1238	yellow glowsticks	0		Familiar Weight: +5
 1239	iced-out bling	0		Familiar Weight: +5
-1240	bouncing teal limburger biker boots	0		Familiar Weight: +5
+1240	teal bouncing limburger biker boots	0		Familiar Weight: +5
 1241	carton of clove cigarettes	0		Familiar Weight: +5
 1242	deflated inflatable dodecapede	0		Free Pull, Last Available: "2011-12"
 1243	upside-down toy six-seater hovercraft	0		Familiar Weight: -5, Last Available: "2011-12"
@@ -1232,11 +1232,11 @@
 1248	lightning-fast rosewater-soaked supercool Bonerdagon necklace	0		Moxie Percent: +20, Stench Resistance: +3, Initiative: +40
 1249	veiny Boss Bat britches	0		Maximum HP: +10, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	Oprah's Boss Bat bling of the early riser	0		Maximum MP Percent: +50, Adventures: +7
-1251	big adequate Knob shroomkabob	5	good	
+1251	adequate big Knob shroomkabob	5	good	
 1252	spoiled shroomkabob	3	crappy	
 1253	squat pile of jumping beans	0		
 1254	bland fancy mirror jumping bean burrito	3	decent	Effect: "Buggy Flavor", Effect Duration: 15
-1255	spoiled immense jumping bean burrito	7	crappy	
+1255	immense spoiled jumping bean burrito	7	crappy	
 1256	stale insanely jumping bean burrito	4	decent	
 1257	normal rat scrapple	3	good	
 1258	pail of pretentious paint	0		
@@ -1257,7 +1257,7 @@
 1273	horrifying magic lamp	0		Spooky Damage: +25
 1274	dried Medicinal Herb's medicinal herbs	1		
 1275	blinking prompt basic meat skirt	0		Adventures: +3, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	practically non-alcoholic perfectly mixed gray Otorian Battle Scar	1	EPIC	
+1276	perfectly mixed practically non-alcoholic gray Otorian Battle Scar	1	EPIC	
 1277	hale basic meat kilt	0		Maximum HP: +20, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	skewed meat skirt of terror	0		Spooky Spell Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	jittery blue tumbling family-friendly meat kilt	0		Sleaze Resistance: +1, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1302,7 +1302,7 @@
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
 1320	moldy questionable taco	3	crappy	
-1321	olive ghostly Doc's Miracle Cure	0		Last Available: "2011-12"
+1321	ghostly olive Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	beefcake's time helmet	0		Muscle: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
 1324	maroon frosty time trousers	0		Cold Spell Damage: +10, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
@@ -1335,8 +1335,8 @@
 1352	acceptable mirror redrum	3	good	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	normal small fancy bowl of oriole's nest soup	2	good	Effect: "Carrrsmic", Effect Duration: 40
-1356	huge skewed bunny liver	0		
+1355	fancy small normal bowl of oriole's nest soup	2	good	Effect: "Carrrsmic", Effect Duration: 40
+1356	skewed huge bunny liver	0		
 1357	artisanal Mt. Noob Pale Ale	3	EPIC	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	pulsating ninja pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,7 +1346,7 @@
 1363	clockwork pirate skull	0		
 1364	huge rhesus monkey	0		Familiar Weight: +5
 1365	gigantic normal tofurkey leg	9	good	
-1366	super-sized decent narrow tofurkey gravy	5	good	
+1366	decent super-sized narrow tofurkey gravy	5	good	
 1367	stale herbal stuffing	3	decent	
 1368	small special spoiled bouncing can-shaped gelatinous cranberry sauce	2	crappy	Effect: "Dreams and Lights", Effect Duration: 10
 1369	decent yams	3	good	
@@ -1376,7 +1376,7 @@
 1394	doppelshifter	0		Last Available: "2005-12"
 1395	teddy bear	0		Last Available: "2005-12"
 1396	foul-smelling grievous duck-on-a-string	0		Weapon Damage Percent: +50, Stench Damage: +10, Last Available: "2005-12"
-1397	blurry squat toy soldier	0		Last Available: "2005-12"
+1397	squat blurry toy soldier	0		Last Available: "2005-12"
 1398	doll house	0		Last Available: "2005-12"
 1399	wobbly deadly toy train	0		Weapon Damage: +5, Single Equip, Last Available: "2005-12"
 1400	pulsating marionette of the ox	0		Muscle: +20, Last Available: "2005-12"
@@ -1385,7 +1385,7 @@
 1403	cyan shaking arcane researcher's can of fake snow	0		Experience Percent (Mysticality): +10, Last Available: "2005-12"
 1404	brainy colored-light &quot;necklace&quot;	0		Mysticality: +5, Last Available: "2005-12"
 1405	veiny tree skirt	0		Maximum HP: +10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	fancy tasty snack-sized wreath-shaped Crimbo cookie	2	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	snack-sized fancy tasty wreath-shaped Crimbo cookie	2	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	toothsome tumbling bell-shaped Crimbo cookie	3	awesome	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	flavorless ghostly skewed tree-shaped Crimbo cookie	4	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	bouncing blue Newton's Unionize The Elves sign	0		Experience (Mysticality): +3, Last Available: "2005-12"
@@ -1430,10 +1430,10 @@
 1448	colloidal teal stench nuggets	0		Effect: "Nuts about Candy", Effect Duration: 42
 1449	deionized fuchsia sleaze nuggets	0		Effect: "Ironclad", Effect Duration: 50
 1450	twisted upside-down twinkly wad	1		Effect: "Really Deep Breath", Effect Duration: 30
-1451	twisted blinking blurry hot wad	1		
-1452	pickled wobbly narrow red wad	1		
+1451	twisted blurry blinking hot wad	1		
+1452	pickled red wobbly narrow wad	1		
 1453	distilled bouncing wad	1		
-1454	dried shaking wobbly stench wad	1		Effect: "Tenacity of the Snapper", Effect Duration: 50
+1454	dried wobbly shaking stench wad	1		Effect: "Tenacity of the Snapper", Effect Duration: 50
 1455	denatured sleaze wad	1		Effect: "Coldfinger", Effect Duration: 10
 1456	wobbly double daisy	0		
 1457	Goth Giant	0		
@@ -1441,7 +1441,7 @@
 1459	arrow'd heart balloon	0		
 1460	upside-down velvet box	0		
 1461	squashed frog	0		
-1462	wobbly squat eye of newt	0		
+1462	squat wobbly eye of newt	0		
 1463	upside-down salamander spleen	0		
 1464	sleazy fairy gravy	0		
 1465	suede shortsword	0		
@@ -1467,7 +1467,7 @@
 1485	ghostly perfumed foul-smelling rabbit's foot	0		Stench Damage: +10, Stench Resistance: +5
 1486	massive bag of catnip	0		
 1487	hang glider	0		
-1488	blinking blurry March hat	0		Free Pull
+1488	blurry blinking March hat	0		Free Pull
 1489	dormouse	0		
 1490	aromatic Tesla chopsticks	0		Stench Resistance: +1, MP Regen Min: 7, MP Regen Max: 10
 1491	rice bowl of the sweet-tooth	0		Candy Drop: +100
@@ -1486,8 +1486,8 @@
 1504	aerosolized moist snowcone	0		Effect: "Strawberry Alarm", Effect Duration: 45, Last Available: "2006-04"
 1505	lime green ice cube with a fly in it	0		Last Available: "2006-04"
 1506	watered-down bad calle de miel with a fly in it	2	decent	Last Available: "2006-04"
-1507	watered-down bad rockin' wagon with a fly in it	2	decent	Last Available: "2006-04"
-1508	lousy spirit-forward fuchsia perpendicular hula with a fly in it	5	decent	Last Available: "2006-04"
+1507	bad watered-down rockin' wagon with a fly in it	2	decent	Last Available: "2006-04"
+1508	spirit-forward lousy fuchsia perpendicular hula with a fly in it	5	decent	Last Available: "2006-04"
 1509	weak bad mirror slap and tickle with a fly in it	2	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	purple beefcake's fake hand	0		Muscle: +25, Last Available: "2006-04"
@@ -1528,63 +1528,63 @@
 1548	steel-toed boxer's Gazpacho's Glacial Grimoire	0		Muscle Percent: +10, Damage Reduction: 9
 1549	MSG	0		
 1550	ghostly second-hand knockoff engagement ring of the sewer	0		Stench Damage: +25, Single Equip
-1551	perfectly mixed practically non-alcoholic tumbling bottle of Domesticated Turkey	1	EPIC	
+1551	practically non-alcoholic perfectly mixed tumbling bottle of Domesticated Turkey	1	EPIC	
 1552	lousy bottle of Definit	4	decent	
-1553	fortified acceptable bottle of Calcutta Emerald	5	good	
+1553	acceptable fortified bottle of Calcutta Emerald	5	good	
 1554	delicious weak bottle of Lieutenant Freeman	2	awesome	
 1555	artisanal special bottle of Jorge Sinsonte	4	EPIC	Effect: "Icy Composition", Effect Duration: 30
 1556	hand-crafted jittery boxed champagne	3	EPIC	
 1557	rotten kumquat	3	crappy	
 1558	normal tangerine	4	good	
 1559	skewed tonic water	0		
-1560	gigantic stale cocktail onion	8	decent	
+1560	stale gigantic cocktail onion	8	decent	
 1561	moldy blurry raspberry	4	crappy	
 1562	moldy huge pulsating kiwi	7	crappy	
-1563	mediocre watered-down whiskey bittersweet	2	decent	
-1564	perfectly mixed enchanted fortified mimosette	5	EPIC	Effect: "Turtle Titters", Effect Duration: 20
-1565	distilled smooth fancy tequila sunset	5	awesome	Effect: "Meat the Flintstones", Effect Duration: 35
+1563	watered-down mediocre whiskey bittersweet	2	decent	
+1564	enchanted perfectly mixed fortified mimosette	5	EPIC	Effect: "Turtle Titters", Effect Duration: 20
+1565	smooth distilled fancy tequila sunset	5	awesome	Effect: "Meat the Flintstones", Effect Duration: 35
 1566	aged zmobie	4	awesome	Wiki Name: "Zmobie (drink)"
 1567	lousy ghostly gin and tonic	4	decent	
 1568	perfectly mixed vodka and tonic	3	EPIC	
-1569	bad irresponsibly strong blinking vodka gibson	10	decent	
+1569	irresponsibly strong bad blinking vodka gibson	10	decent	
 1570	hand-crafted enchanted gibson	3	EPIC	Effect: "Barbecue Saucy", Effect Duration: 50
 1571	artisanal parisian cathouse	3	EPIC	
-1572	weak perfectly mixed squat rabbit punch	2	EPIC	
-1573	mediocre practically non-alcoholic caipifruta	1	decent	
+1572	perfectly mixed weak squat rabbit punch	2	EPIC	
+1573	practically non-alcoholic mediocre caipifruta	1	decent	
 1574	tolerable teqiwila	3	good	
 1575	hand-crafted Divine	3	EPIC	
 1576	drinkable watered-down Gordon Bennett	2	good	
-1577	bad spirit-forward pulsating tangarita	5	decent	
+1577	spirit-forward bad pulsating tangarita	5	decent	
 1578	delicious bouncing mandarina colada	4	awesome	
 1579	lousy huge gimlet	3	decent	
 1580	watered-down special tolerable fuchsia brick road	2	good	Effect: "Electrolit Up", Effect Duration: 50
-1581	mediocre boozy vodka stratocaster	5	decent	
+1581	boozy mediocre vodka stratocaster	5	decent	
 1582	delicious blinking Neuromancer	3	awesome	
 1583	bad olive prussian cathouse	4	decent	
 1584	drinkable weak Mae West	2	good	
 1585	artisanal Mon Tiki	4	EPIC	
-1586	hand-crafted practically non-alcoholic green teqiwila slammer	1	super ultra mega turbo EPIC	
+1586	practically non-alcoholic hand-crafted green teqiwila slammer	1	super ultra mega turbo EPIC	
 1587	flavorless Knob lo mein	4	decent	
 1588	bland bouncing asparagus lo mein	3	decent	
-1589	adequate half-sized Knoll lo mein	2	good	
+1589	half-sized adequate Knoll lo mein	2	good	
 1590	half-sized yummy ghostly lo mein	2	awesome	
 1591	low-calorie toothsome olive lo mein	1	awesome	
 1592	snack-sized bland blurry hot hi mein	2	decent	
 1593	flavorless hi mein	3	decent	
 1594	decent hi mein	3	good	
 1595	bland hi mein	3	decent	
-1596	stale tiny sleazy hi mein	1	decent	
+1596	tiny stale sleazy hi mein	1	decent	
 1597	bouncing extremely unsafe Junior LAAAAME merit badge	0		Weapon Damage Percent: +100, Last Available: "2006-05"
 1598	Senior LAAAAME merit badge of the bloodbag	0		Maximum HP: +100, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	hand-crafted tangarita with a fly in it	4	EPIC	
-1601	weak lousy mandarina colada with a fly in it	2	decent	
+1601	lousy weak mandarina colada with a fly in it	2	decent	
 1602	aged teal prussian cathouse with a fly in it	3	awesome	
 1603	drinkable Mae West with a fly in it	3	good	
 1604	modified huge astronaut ice-cream	1		Last Available: "2006-05"
 1605	fuchsia delectable catalyst	0		
-1606	mixed spinning spinning wobbly maroon ultimate wad	1		
-1607	pickled unsweetened gray spinning libation of liveliness	0		Effect: "Berry Critical", Effect Duration: 30
+1606	mixed maroon spinning spinning wobbly ultimate wad	1		
+1607	pickled unsweetened spinning gray libation of liveliness	0		Effect: "Berry Critical", Effect Duration: 30
 1608	oxidized eyedrops of the ermine	0		Effect: "Sugary World View", Effect Duration: 34
 1609	pressed altered perfume of prejudice	0		Effect: "Cold Hands", Effect Duration: 40
 1610	unsweetened frozen polarized huge blinking eyedrops of the ocelot	0		Effect: "Sweet Tooth", Effect Duration: 14
@@ -1611,16 +1611,16 @@
 1631	fuchsia beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	shaking Spanish fly	0		
-1634	hand-crafted fancy watered-down maroon blinking around the world	2	EPIC	Effect: "Almost Cool", Effect Duration: 5
-1635	pulsating red narrow scrumdiddlyumptious solution	0		
+1634	watered-down fancy hand-crafted blinking maroon around the world	2	EPIC	Effect: "Almost Cool", Effect Duration: 5
+1635	red pulsating narrow scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	ionized tarnished lotion of hotness	0		Effect: "Dexteri Tea", Effect Duration: 56
 1638	oxidized flattened maroon lotion of coldness	0		Effect: "Top Dog", Effect Duration: 64
 1639	deionized twirling lotion of spookiness	0		Effect: "Tearful, Fearful", Effect Duration: 28
 1640	ionized lotion of stench	0		Effect: "Sparkling Consciousness", Effect Duration: 34
 1641	tarnished energized red blinking lotion of sleaziness	0		Effect: "Human-Hobo Hybrid", Effect Duration: 35
-1642	lousy high-proof Grimacite Bock	7	decent	Last Available: "2008-11"
-1643	rotten bite-sized wedge of gray cheese	1	crappy	Last Available: "2008-11"
+1642	high-proof lousy Grimacite Bock	7	decent	Last Available: "2008-11"
+1643	bite-sized rotten wedge of gray cheese	1	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
@@ -1652,7 +1652,7 @@
 1672	olive swindleblossom	0		
 1673	medical-grade Da Vinci's grave robbing shovel	0		Experience (Mysticality): +5, HP Regen Min: 7, HP Regen Max: 10
 1674	red pulsating mirror superhero mask of the scaredy-cat	0		Monster Level: -15, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
-1675	narrow ghostly ore	0		
+1675	ghostly narrow ore	0		
 1676	styrofoam ore	0		
 1677	bubblewrap ore	0		
 1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
@@ -1671,10 +1671,10 @@
 1691	fuchsia blinking mansplainer's boxer's discarded torn-up glove	0		Muscle Percent: +10, Monster Level: +15, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	adjusted spinning salamander slurry	0		Effect: "Charrrming", Effect Duration: 34
 1693	tarnished twirling eyedrops of newt	0		Effect: "items.enh", Effect Duration: 56
-1694	corrupted frozen chilled skewed wobbly Frogade	0		Effect: "Salty Dogs", Effect Duration: 42
-1695	tarnished unsweetened jittery cyan papotion of papower	0		Effect: "Hammered", Effect Duration: 31
+1694	corrupted frozen chilled wobbly skewed Frogade	0		Effect: "Salty Dogs", Effect Duration: 42
+1695	tarnished unsweetened cyan jittery papotion of papower	0		Effect: "Hammered", Effect Duration: 31
 1696	moldy bite-sized royal jelly taco	1	crappy	
-1697	decent tiny tofu taco	1	good	
+1697	tiny decent tofu taco	1	good	
 1698	super-sized stale squat jumping bean taco	5	decent	
 1699	half-sized spoiled shaking catgut taco	2	crappy	
 1700	yummy special goat cheese taco	3	awesome	Effect: "Springy Fusilli", Effect Duration: 45
@@ -1750,11 +1750,11 @@
 1771	spinning butcherknife of the overflowing toilet	0		Stench Spell Damage: +50
 1772	studded corn holder	0		Damage Absorption: +80
 1773	spinning Fonzie's eggbeater	0		Experience (Moxie): +1
-1774	strong perfectly mixed bottle of popskull	5	EPIC	
+1774	perfectly mixed strong bottle of popskull	5	EPIC	
 1775	inspector's dishrag	0		Item Drop: +15
-1776	rotten mirror wobbly stale baguette	3	crappy	
+1776	rotten wobbly mirror stale baguette	3	crappy	
 1777	olive leftovers of indeterminate origin	0		
-1778	spoiled snack-sized pulsating dinner	2	crappy	
+1778	snack-sized spoiled pulsating dinner	2	crappy	
 1779	hardened katana	0		Damage Reduction: 3
 1780	ram stick of the early riser	0		Adventures: +7
 1781	medical-grade enchantlers	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1782,7 +1782,7 @@
 1803	second cervical vertebra	0		
 1804	purple third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
-1806	jittery spinning fifth cervical vertebra	0		
+1806	spinning jittery fifth cervical vertebra	0		
 1807	maroon sixth cervical vertebra	0		
 1808	seventh cervical vertebra	0		
 1809	narrow first thoracic vertebra	0		
@@ -1803,7 +1803,7 @@
 1824	fourth lumbar vertebra	0		
 1825	jittery fifth lumbar vertebra	0		
 1826	sixth lumbar vertebra	0		
-1827	lime green blinking seventh lumbar vertebra	0		
+1827	blinking lime green seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
 1829	mirror first caudal vertebra	0		
 1830	second caudal vertebra	0		
@@ -1866,13 +1866,13 @@
 1887	right second front claw	0		
 1888	lime green right third front claw	0		
 1889	right fourth front claw	0		
-1890	ghostly shaking left thumb	0		
+1890	shaking ghostly left thumb	0		
 1891	blinking right thumb	0		
 1892	left first rear claw	0		
 1893	lime green left second rear claw	0		
 1894	olive left third rear claw	0		
 1895	left fourth rear claw	0		
-1896	shaking yellow right first rear claw	0		
+1896	yellow shaking right first rear claw	0		
 1897	right second rear claw	0		
 1898	pulsating right third rear claw	0		
 1899	right fourth rear claw	0		
@@ -1925,8 +1925,8 @@
 1948	shaking fireproof occult tap shoes	0		Spell Damage Percent: +25, Hot Resistance: +3, Single Equip
 1949	normal Manetwich	3	good	
 1950	bottle of Vangoghbitussin	0		
-1951	artisanal practically non-alcoholic bottle of Pinot Renoir	1	EPIC	
-1952	toothsome low-calorie desiccated apricot	1	awesome	
+1951	practically non-alcoholic artisanal bottle of Pinot Renoir	1	EPIC	
+1952	low-calorie toothsome desiccated apricot	1	awesome	
 1953	mediocre purple flute of flat champagne	3	decent	
 1954	thick rotten blurry dehydrated caviar	5	crappy	
 1955	squat styrofoam peanuts	0		
@@ -1949,13 +1949,13 @@
 1972	fortified dance instructor's shrimp fork	0		Experience Percent (Moxie): +10, Damage Absorption: +60
 1973	half of a memo	0		
 1974	ghostly cocoabo	0		
-1975	upside-down blinking baby gravy fairy	0		
+1975	blinking upside-down baby gravy fairy	0		
 1976	gravy fairy	0		
 1977	gravy fairy	0		
 1978	gravy fairy	0		
 1979	gravy fairy	0		
 1980	sleazy gravy fairy	0		
-1981	skewed upside-down astral badger	0		
+1981	upside-down skewed astral badger	0		
 1982	skewed MagiMechTech MicroMechaMech	0		
 1983	skewed hand turkey	0		
 1984	snowy owl	0		
@@ -1996,13 +1996,13 @@
 2019	cream pie	0		Free Pull
 2020	bland lime green cherry pie	3	decent	
 2021	rotten big pulsating strawberry pie	5	crappy	
-2022	special bite-sized rotten olive lemon meringue pie	1	crappy	Effect: "Al Dente Inferno", Effect Duration: 45
+2022	rotten bite-sized special olive lemon meringue pie	1	crappy	Effect: "Al Dente Inferno", Effect Duration: 45
 2023	Genalen&trade; Bottle	1	good	
-2024	huge decent maroon mixed wildflower greens	7	good	
+2024	decent huge maroon mixed wildflower greens	7	good	
 2025	rotten jumbo handful of walnuts	5	crappy	
-2026	miniature tasty nutty organic salad	2	awesome	
+2026	tasty miniature nutty organic salad	2	awesome	
 2027	bland half-sized wobbly super salad	2	decent	
-2028	normal fancy tofu wonton	4	good	Effect: "Haunted Stomach", Effect Duration: 35
+2028	fancy normal tofu wonton	4	good	Effect: "Haunted Stomach", Effect Duration: 35
 2029	hippy protest button	0		Single Equip
 2030	jittery occult wizardly Lockenstock&trade; sandals	0		Mysticality: +25, Spell Damage Percent: +25, Single Equip
 2031	cool didgeridooka	0		Moxie: +5
@@ -2020,8 +2020,8 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	yummy brain-meltingly-hot chicken wings	4	awesome	
-2046	stale big twirling olive frat brats	5	decent	
-2047	half-sized rotten knob ka-bobs	2	crappy	
+2046	big stale twirling olive frat brats	5	decent	
+2047	rotten half-sized knob ka-bobs	2	crappy	
 2049	drinkable can of Swiller	3	good	
 2050	skewed broken wings	0		
 2051	sunken eyes	0		
@@ -2062,7 +2062,7 @@
 2086	pickled squat bottle of cough syrup	1		Effect: "Tearful, Fearful", Effect Duration: 20
 2087	diluted lime green tube of hair oil	1		
 2088	Vulcanized flattened energized narrow Daffy Taffy	0		Effect: "White Knuckles", Effect Duration: 12
-2089	cyan blinking Crimboween memo	0		Last Available: "2006-10"
+2089	blinking cyan Crimboween memo	0		Last Available: "2006-10"
 2090	lime green perfumed stiffened beefy pilgrim shield of the pedagogue of Tarzan	0		Muscle: +10, Experience: +3, Experience (Muscle): +3, Damage Reduction: 2, Stench Resistance: +5, Softcore Only, Last Available: "2006-11"
 2091	wobbly bath salts	0		
 2092	hand mirror	0		
@@ -2091,7 +2091,7 @@
 2115	squat gray prehistoric spear of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
 2117	pulsating electrified Samson's fire	0		Experience (Muscle): +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
-2118	shaking spinning leaf tube	0		Last Available: "2006-12"
+2118	spinning shaking leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	Fonzie's Grateful Undead T-shirt	0		Experience (Moxie): +1
 2121	mansplainer's ASCII shirt	0		Monster Level: +15
@@ -2120,13 +2120,13 @@
 2145	stuffing	0		Last Available: "2011-12"
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
-2148	wobbly bouncing mirror toothsome rock	0		
+2148	mirror wobbly bouncing toothsome rock	0		
 2149	flavorless frank	4	decent	Last Available: "2011-12"
-2150	rotten snack-sized plate of franks and beans	2	crappy	Last Available: "2011-12"
+2150	snack-sized rotten plate of franks and beans	2	crappy	Last Available: "2011-12"
 2151	irresponsibly strong tolerable shot of blackberry schnapps	10	good	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
-2154	cyan spinning huge twirling ion grid	0		Last Available: "2011-12"
+2154	cyan twirling huge spinning ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	tumbling high-resistance ultrapolymer plating	0		Last Available: "2011-12"
@@ -2165,13 +2165,13 @@
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	shaking sheet music	0		Last Available: "2006-12"
-2193	spoiled snack-sized blinking candy stake	2	crappy	Last Available: "2006-12"
-2194	aged high-proof eggnog	8	awesome	Last Available: "2006-12"
+2193	snack-sized spoiled blinking candy stake	2	crappy	Last Available: "2006-12"
+2194	high-proof aged eggnog	8	awesome	Last Available: "2006-12"
 2195	normal unspeakable fruitcake	3	good	Last Available: "2006-12"
 2196	big stale gingerbread horror	5	decent	Last Available: "2006-12"
 2197	dry enhanced but probably evil chocolate	0		Effect: "You're High as a Crow, Marty", Effect Duration: 41, Last Available: "2006-12"
-2198	decent half-sized bat-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	rotten bite-sized blinking skull-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2198	half-sized decent bat-shaped Crimboween cookie	2	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2199	bite-sized rotten blinking skull-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	stale tombstone-shaped Crimboween cookie	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	boxer's plastic gift-wrapping vampire	0		Muscle Percent: +10, Last Available: "2006-12"
 2202	hale plastic yuletide troll	0		Maximum HP: +20, Last Available: "2006-12"
@@ -2189,8 +2189,8 @@
 2214	tropical wrapping paper	0		Last Available: "2006-12"
 2215	Oprah's Tropical Crimbo Hat	0		Maximum MP Percent: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	Tropical Crimbo Shorts of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	toothsome big mirror shaking super ka-bob	5	awesome	
-2218	normal maroon mirror beer basted brat	3	good	
+2217	big toothsome shaking mirror super ka-bob	5	awesome	
+2218	normal mirror maroon beer basted brat	3	good	
 2219	razor-sharp Tropical Crimbo Sword	0		Weapon Damage Percent: +25, Last Available: "2006-12"
 2220	non-anodized narrow and Crimboween candy	0		Effect: "Salty Mouth", Effect Duration: 69, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2229,25 +2229,25 @@
 2255	green rosy-cheeked furry turtle	0		Maximum HP Percent: +30, Familiar Effect: "2xPotato, 2xFairy, cap 11"
 2256	spinning hardy furry earmuffs	0		Maximum HP: +50
 2257	upside-down frightening stiffened reinforced furry underpants	0		Damage Reduction: 1, Spooky Damage: +5
-2258	spinning jittery &quot;I Love Me, Vol. I&quot;	0		
+2258	jittery spinning &quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
 2260	hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	purple lion oil	0		
-2264	small special moldy blinking stunt nuts	2	crappy	Effect: "Stop and Smell the Fudge", Effect Duration: 20
+2264	special small moldy blinking stunt nuts	2	crappy	Effect: "Stop and Smell the Fudge", Effect Duration: 20
 2265	decent fancy small wet stew	2	good	Effect: "Human-Plant Hybrid", Effect Duration: 45
 2266	wet stunt nut stew	0		
 2267	gray Mega Gem	0		
 2268	narrow censurious Staff of Fats	0		Sleaze Resistance: +3
 2269	miniature adequate sausage wonton	2	good	
 2270	blue steel-toed belt of the ox	0		Muscle: +20, Damage Reduction: 9, Single Equip
-2271	irresponsibly strong aged bottle of Merlot	9	awesome	
-2272	delicious spirit-forward yellow bottle of Port	5	awesome	
-2273	drinkable irresponsibly strong bottle of Pinot Noir	6	good	
+2271	aged irresponsibly strong bottle of Merlot	9	awesome	
+2272	spirit-forward delicious yellow bottle of Port	5	awesome	
+2273	irresponsibly strong drinkable bottle of Pinot Noir	6	good	
 2274	perfectly mixed bottle of Zinfandel	3	EPIC	
-2275	tolerable fancy bottle of Marsala	3	good	Effect: "Elemental Saucesphere", Effect Duration: 35
-2276	fancy tolerable bottle of Muscat	3	good	Effect: "Starry-Eyed", Effect Duration: 20
+2275	fancy tolerable bottle of Marsala	3	good	Effect: "Elemental Saucesphere", Effect Duration: 35
+2276	tolerable fancy bottle of Muscat	3	good	Effect: "Starry-Eyed", Effect Duration: 20
 2277	Fernswarthy's key	0		
 2278	pulsating Fernswarthy's letter	0		
 2279	book	0		
@@ -2280,7 +2280,7 @@
 2306	altered candy heart	0		Effect: "Cringle's Curative Carol", Effect Duration: 29, Last Available: "2007-02"
 2307	quantum quantum blurry candy heart	0		Effect: "Preternatural Greed", Effect Duration: 34, Last Available: "2007-02"
 2308	extra-enhanced candy heart	0		Effect: "Reptilian Fortitude", Effect Duration: 22, Last Available: "2007-02"
-2309	wet adjusted narrow mirror candy heart	0		Effect: "Ponderous Potency", Effect Duration: 38, Last Available: "2007-02"
+2309	wet adjusted mirror narrow candy heart	0		Effect: "Ponderous Potency", Effect Duration: 38, Last Available: "2007-02"
 2310	bouncing candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
@@ -2299,7 +2299,7 @@
 2325	Staff of Ed	0		
 2326	twirling stone rose	0		
 2327	anodized can of paint	0		Effect: "Permafrosty", Effect Duration: 37
-2328	skewed spinning drum machine	0		
+2328	spinning skewed drum machine	0		
 2329	jittery skewed handful of confetti	0		
 2330	huge shaking chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
@@ -2313,7 +2313,7 @@
 2339	tolerable Blackfly Chardonnay	3	good	
 2340	tolerable bouncing & tan	4	good	
 2341	pulsating pepper	0		
-2342	huge spoiled forest cake	9	crappy	
+2342	spoiled huge forest cake	9	crappy	
 2343	decent huge forest ham	3	good	
 2344	concentrated pickled ghostly filthworm hatchling scent gland	0		Effect: "Hagg-ard", Effect Duration: 11
 2345	tarnished super-galvanized filthworm drone scent gland	0		Effect: "Hot Buttoned", Effect Duration: 36
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	bunch of bananas	0		
-2373	rotten mirror narrow banana	4	crappy	
+2373	rotten narrow mirror banana	4	crappy	
 2374	fuchsia twirling banana peel	0		
-2375	delicious small banana cream pie	2	awesome	
+2375	small delicious banana cream pie	2	awesome	
 2376	acceptable triple-distilled lime green banana daiquiri	7	good	
 2377	bad bungle in the jungle	4	decent	
 2378	shaking banana spritzer	0		
@@ -2386,7 +2386,7 @@
 2412	fuchsia sammich crust	0		
 2413	purple triffid bark	0		
 2414	teal lint	0		
-2415	blurry bouncing discarded pacifier	0		
+2415	bouncing blurry discarded pacifier	0		
 2416	curative bounty-hunting helmet	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1.5xFairy, cap 25"
 2417	mansplainer's bounty-hunting rifle	0		Monster Level: +15
 2418	beefcake's bounty-hunting pants	0		Muscle: +25, Familiar Effect: "1xPotato, 2xFairy, cap 25"
@@ -2495,17 +2495,17 @@
 2522	aged thistle wine	3	awesome	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	stale small narrow fish	2	decent	
+2525	small stale narrow fish	2	decent	
 2526	spoiled fish casserole	3	crappy	
 2527	tasty fish lasagna	4	awesome	
 2528	wobbly filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	moldy gnatloaf	4	crappy	
 2530	stale gnatloaf casserole	3	decent	
-2531	special adequate ghostly gnat lasagna	3	good	Effect: "Stinky Weapon", Effect Duration: 35
+2531	adequate special ghostly gnat lasagna	3	good	Effect: "Stinky Weapon", Effect Duration: 35
 2532	pork	0		
 2533	stale pork chop sandwiches	3	decent	
-2534	normal snack-sized pork casserole	2	good	
-2535	special thick moldy bouncing pork lasagna	5	crappy	Effect: "Physicali Tea", Effect Duration: 10
+2534	snack-sized normal pork casserole	2	good	
+2535	thick special moldy bouncing pork lasagna	5	crappy	Effect: "Physicali Tea", Effect Duration: 10
 2536	canopic jar	0		
 2537	twirling spice	0		
 2538	organs	0		
@@ -2514,7 +2514,7 @@
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	deionized enhanced lesser grodulated violet	0		Effect: "Loyal Tea", Effect Duration: 53, Last Available: "2007-05"
 2543	modified wobbly tin magnolia	0		Effect: "Nigh-Invincible", Effect Duration: 28, Last Available: "2007-05"
-2544	enhanced non-denatured wobbly cyan begpwnia	0		Effect: "Got Your Boots On", Effect Duration: 14, Last Available: "2007-05"
+2544	enhanced non-denatured cyan wobbly begpwnia	0		Effect: "Got Your Boots On", Effect Duration: 14, Last Available: "2007-05"
 2545	enhanced pickled upsy daisy	0		Effect: "Sweet and Red", Effect Duration: 61, Last Available: "2007-05"
 2546	deionized polymerized half-orchid	0		Effect: "Inner Dog", Effect Duration: 60, Last Available: "2007-05"
 2547	Lo Pan's tin star of terror	0		Spell Critical Percent: +30, Spooky Spell Damage: +10, Last Available: "2007-05"
@@ -2545,7 +2545,7 @@
 2572	blurry ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
-2575	huge fuchsia bronzed locust	0		
+2575	fuchsia huge bronzed locust	0		
 2576	honey-dipped locust	0		
 2577	ghostly studded cactus quill of doom	0		Damage Absorption: +80, Spooky Spell Damage: +50
 2578	miser's nasty smartaleck's Staff of the Short Order Cook	0		Moxie Percent: +30, Stench Damage: +5, Meat Drop: +10
@@ -2553,23 +2553,23 @@
 2580	double-paned boxer's scorpion whip	0		Muscle Percent: +10, Cold Resistance: +5
 2581	handful of sand	0		
 2582	blurry brick of sand	0		
-2583	tiny adequate centipede eggs	1	good	
+2583	adequate tiny centipede eggs	1	good	
 2584	knitted wonderwall shield	0		Cold Resistance: +3, Damage Reduction: 12
 2585	jittery experienced Colonel Mustard's Lonely Spades Club Jacket	0		Experience: +2
 2586	General Sage's Lonely Diamonds Club Jacket of the detective	0		Item Drop: +20
 2587	tumbling skewed Corporal Fennel's Lonely Clubs Club Jacket of the detective	0		Item Drop: +20
 2588	blinking sage Private Pepper's Lonely Hearts Club Jacket	0		Mysticality Percent: +10
 2589	decent hot date	3	good	
-2590	distilled enchanted artisanal olive distilled fortified wine	5	EPIC	Effect: "Springy Fusilli", Effect Duration: 35
-2591	spoiled massive tasty tart	7	crappy	
+2590	distilled artisanal enchanted olive distilled fortified wine	5	EPIC	Effect: "Springy Fusilli", Effect Duration: 35
+2591	massive spoiled tasty tart	7	crappy	
 2592	Knob Goblin lunchbox	0		
 2593	adequate low-calorie jittery blinking Knob pasty	1	good	
-2594	lousy irresponsibly strong narrow thermos full of Knob coffee	9	decent	
+2594	irresponsibly strong lousy narrow thermos full of Knob coffee	9	decent	
 2595	corrupted aerosolized jittery Ben-Gal&trade; Balm	0		Effect: "Dirge of Dreadfulness", Effect Duration: 15
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
 2598	leathery rat skin	0		
-2599	blurry upside-down Discount Telescope Warehouse gift certificate	0		
+2599	upside-down blurry Discount Telescope Warehouse gift certificate	0		
 2600	purple carbonated water lily	0		
 2601	knitted deadly strapping Staff of the Midnight Snack	0		Muscle: +5, Weapon Damage: +5, Cold Resistance: +3
 2602	purple frosty Jim Carey's Rosewater's Staff of Blood and Pudding	0		Mysticality Percent: +30, Monster Level: +25, Cold Spell Damage: +10
@@ -2583,7 +2583,7 @@
 2610	fortified extra-large palm-frond toupee	0		Damage Absorption: +60, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 2611	crafty palm-frond cloak	0		Maximum MP: +10
 2612	bouncing vinyl coin purse	0		
-2613	tumbling teal rocky raccoon	0		
+2613	teal tumbling rocky raccoon	0		
 2614	mojo filter	0		
 2615	bland big savoy truffle	5	decent	
 2616	Magi-Wipes	0		
@@ -2600,7 +2600,7 @@
 2627	veiny Rosewater's catskin cap	0		Mysticality Percent: +30, Maximum HP: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 45"
 2628	wobbly Tesla catskin buckler of the early riser	0		Adventures: +7, MP Regen Min: 7, MP Regen Max: 10, Damage Reduction: 11
 2629	stiffened wizardly tail o' nine cats	0		Mysticality: +25, Damage Reduction: 1
-2630	upside-down olive Hugo's Weaving Manual	0		
+2630	olive upside-down Hugo's Weaving Manual	0		
 2631	activated skewed gremlin juice	0		Effect: "Highland Sheen", Effect Duration: 46
 2632	anodized mother's helper	0		Effect: "Human-Penguin Hybrid", Effect Duration: 51
 2633	censurious scandalous pat-a-cake pendant	0		Sleaze Damage: +5, Sleaze Resistance: +3
@@ -2625,13 +2625,13 @@
 2652	normal S.T.L.T.	4	good	Last Available: "2007-06"
 2653	stale honey-dew	3	decent	Last Available: "2007-06"
 2654	perfectly mixed strong Xanadian	5	EPIC	Last Available: "2007-06"
-2655	quadruple-concentrated quadruple-ionized jittery squat bottle of absinthe	0		Effect: "Quiet 'n' Good", Effect Duration: 45, Last Available: "2007-06"
+2655	quadruple-concentrated quadruple-ionized squat jittery bottle of absinthe	0		Effect: "Quiet 'n' Good", Effect Duration: 45, Last Available: "2007-06"
 2656	twirling Van der Graaf Drowsy Sword of the scaredy-cat	0		Monster Level: -15, MP Regen Min: 5, MP Regen Max: 7
 2657	flavorless bouncing blurry escargotsicle	3	decent	Last Available: "2007-06"
 2658	bad bottle of realpagne	3	decent	Last Available: "2007-06"
 2659	yellow savvy albatross necklace	0		Mysticality Percent: +20, Single Equip, Last Available: "2007-06"
-2660	denatured shaking tumbling not-a-pipe	1	awesome	Last Available: "2007-06"
-2661	watered-down lousy flask of Amontillado	2	decent	Last Available: "2007-06"
+2660	denatured tumbling shaking not-a-pipe	1	awesome	Last Available: "2007-06"
+2661	lousy watered-down flask of Amontillado	2	decent	Last Available: "2007-06"
 2662	ball mask of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	Can-Can skirt of the cougar	0		Moxie: +20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	quadruple-colloidal tumbling sensitive poetry journal	0		Effect: "Cinnamouth", Effect Duration: 11, Last Available: "2007-06"
@@ -2651,7 +2651,7 @@
 2678	squat spectre scepter	0		
 2679	ionized deionized squat sparkler	0		Effect: "Puddingskin", Effect Duration: 53
 2680	wet concentrated blinking snake	0		Effect: "Crimbo Nostalgia", Effect Duration: 37, Wiki Name: "snake"
-2681	polymerized concentrated spinning blurry M-242	0		Effect: "The Smile of Mr. A.", Effect Duration: 33
+2681	polymerized concentrated blurry spinning M-242	0		Effect: "The Smile of Mr. A.", Effect Duration: 33
 2682	jittery detuned radio	0		
 2683	fuchsia Warehouse 23 crate	0		
 2684	toasty fortified armgun	0		Damage Absorption: +60, Hot Damage: +5
@@ -2667,7 +2667,7 @@
 2694	up-at-dawn Rosewater's stone baseball cap of the sewer	0		Mysticality Percent: +30, Stench Damage: +25, Adventures: +5, Familiar Effect: "1xVolley, cap 48"
 2695	acceptable cup of beer	3	good	
 2696	maroon ovoid thing	0		
-2697	narrow bouncing duct tape	0		
+2697	bouncing narrow duct tape	0		
 2698	wobbly duct tape wallet	0		
 2699	greedy healthy duct tape shirt	0		Maximum HP Percent: +20, Meat Drop: +20
 2700	ghostly Oprah's duct tape fedora of the businessman	0		Maximum MP Percent: +50, Meat Drop: +50, Familiar Effect: "1xBarrr, 1xLep, cap 48"
@@ -2679,10 +2679,10 @@
 2706	dangerous arcane researcher's wizardly blackberry moccasins	0		Mysticality: +25, Experience Percent (Mysticality): +10, Weapon Damage: +10, Single Equip
 2707	shaking fireproof electrified studded blackberry combat boots	0		Damage Absorption: +80, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 2708	colloidal super-dry olive funky dried mushroom	0		Effect: "Mushroom Moxiousness", Effect Duration: 27
-2709	purple blurry pulsating exotic parrot egg	0		
+2709	blurry pulsating purple exotic parrot egg	0		
 2710	mirror cracker	0		Familiar Weight: +15
 2711	flattened blurry yellow facepaint	0		Effect: "Rosewater Mark", Effect Duration: 13
-2712	dry wobbly narrow sheepskin diploma	0		Effect: "Hypercubed", Effect Duration: 11
+2712	dry narrow wobbly sheepskin diploma	0		Effect: "Hypercubed", Effect Duration: 11
 2713	non-chilled alkaline huge spinning Black Body&trade; spray	0		Effect: "Dexteri Tea", Effect Duration: 36
 2714	floorboard cruft	0		
 2715	pulsating sausage bomb	0		
@@ -2703,16 +2703,16 @@
 2730	mediocre plum wine	4	decent	
 2731	aged triple-distilled shot of pear schnapps	10	awesome	
 2732	lousy triple-distilled shot of peach schnapps	10	decent	
-2733	adequate snack-sized bunch of square grapes	2	good	
+2733	snack-sized adequate bunch of square grapes	2	good	
 2734	moldy brown sugar cane	4	crappy	
 2735	rotten blinking sandwich of the gods	3	crappy	
-2736	special watered-down lousy Pan-Dimensional Gargle Blaster	2	decent	Effect: "Space Cadet", Effect Duration: 5
+2736	lousy special watered-down Pan-Dimensional Gargle Blaster	2	decent	Effect: "Space Cadet", Effect Duration: 5
 2737	mixed blue leopard-print barbell	1	crappy	
 2738	pile of smoking rags	0		
 2739	anodized purple panty raider camouflage	0		Effect: "Mana Tea", Effect Duration: 23
 2740	stiffened Fonzie's Staff of the Walk-In Freezer of the wise owl	0		Mysticality: +20, Experience (Moxie): +1, Damage Reduction: 1
-2741	practically non-alcoholic perfectly mixed boilermaker	1	super ultra mega turbo EPIC	
-2742	special decent narrow steel lasagna	3	quest	Effect: "Always be Collecting", Effect Duration: 40
+2741	perfectly mixed practically non-alcoholic boilermaker	1	super ultra mega turbo EPIC	
+2742	decent special narrow steel lasagna	3	quest	Effect: "Always be Collecting", Effect Duration: 40
 2743	artisanal jittery steel margarita	3	quest	
 2744	boiled twirling steel-scented air freshener	1		
 2745	triple-pickled gremlin mutagen	0		Effect: "Your Interest is Peaked", Effect Duration: 62
@@ -2737,9 +2737,9 @@
 2764	squat Lo Pan's shellacked deadly Order of the Silver Wossname	0		Weapon Damage: +5, Damage Reduction: 7, Spell Critical Percent: +30, Single Equip
 2765	Harold's bell	0		
 2766	narrow bowling ball	0		
-2767	massive spoiled Crimbo pie	9	crappy	
-2768	big tasty pear tart	5	awesome	
-2769	small moldy peach pie	2	crappy	
+2767	spoiled massive Crimbo pie	9	crappy	
+2768	tasty big pear tart	5	awesome	
+2769	moldy small peach pie	2	crappy	
 2770	tarnished pressed chunk of rock salt	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 27
 2771	dry shaking handful of pine needles	0		Effect: "Stick Emporium Membership", Effect Duration: 34
 2772	blue steamy ruby	0		
@@ -2780,7 +2780,7 @@
 2807	flattened quadruple-adjusted bouncing flask of hamethyst juice	0		Effect: "Memory of Strength", Effect Duration: 16
 2808	polarized flask of baconstone juice	0		Effect: "Heal Thy Nanoself", Effect Duration: 14
 2809	polymerized flask of porquoise juice	0		Effect: "Patched In", Effect Duration: 19
-2810	double-modified nitrogenated lime green shaking jug of hamethyst juice	0		Effect: "Human-Hippy Hybrid", Effect Duration: 40
+2810	double-modified nitrogenated shaking lime green jug of hamethyst juice	0		Effect: "Human-Hippy Hybrid", Effect Duration: 40
 2811	non-chilled jug of baconstone juice	0		Effect: "Memory of Smarts", Effect Duration: 23
 2812	moist teal jug of porquoise juice	0		Effect: "Very Clean Teeth", Effect Duration: 18
 2813	wizardly Beret of the blizzard	0		Mysticality: +25, Cold Spell Damage: +25, Four Songs, Familiar Effect: "1xVolley, 1xLep"
@@ -2812,7 +2812,7 @@
 2839	prompt Periodical Paintbrush	0		Adventures: +3, Softcore Only
 2840	watered-down lousy bottle of cooking sherry	2	decent	
 2841	spoiled packet of ketchup	4	crappy	
-2842	perfectly mixed spirit-forward huge accidental cider	5	EPIC	
+2842	spirit-forward perfectly mixed huge accidental cider	5	EPIC	
 2843	flavorless fancy dire fudgesicle	4	decent	Effect: "The Magic of Sharing", Effect Duration: 50
 2844	executive rosy-cheeked dance instructor's weightlifter's navel ring of navel gazing	0		Muscle: +15, Experience Percent (Moxie): +10, Maximum HP Percent: +30, Meat Drop: +40, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2827,10 +2827,10 @@
 2854	bouquet of swamp roses	0		
 2855	steel-toed forbidden huge mosquito proboscis	0		Spell Damage Percent: +50, Damage Reduction: 9
 2856	boiled swamp lolly	0		Effect: "Cranberry Cordiality", Effect Duration: 22
-2857	energized olive narrow squat seegar butt	0		Effect: "Ooh, Sweet!", Effect Duration: 62
+2857	energized narrow olive squat seegar butt	0		Effect: "Ooh, Sweet!", Effect Duration: 62
 2858	squat bottled swamp gas	0		
 2859	witch wart of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50
-2860	huge normal swamp muck	8	good	
+2860	normal huge swamp muck	8	good	
 2861	thinker's leechknife of vim and vigor of terror	0		Mysticality: +10, Maximum HP Percent: +50, Spooky Spell Damage: +10
 2862	decomposed boot	0		
 2863	chilled dribbly candle	0		Effect: "Sugar Smacks", Effect Duration: 23
@@ -2917,20 +2917,20 @@
 2945	auspicious party hat of Flo-Jo	0		Item Drop: +10, Initiative: +100, Familiar Effect: "4xLep, cap 7"
 2946	mirror sharpshooter's V for Vivala mask of the pedagogue	0		Experience: +3, Critical Hit Percent: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	huge The Big Book of Pirate Insults	0		
-2948	practically non-alcoholic perfectly mixed skewed shot of rotgut	1	EPIC	
+2948	perfectly mixed practically non-alcoholic skewed shot of rotgut	1	EPIC	
 2949	Vulcanized double-polymerized wobbly blue jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Tearful, Fearful", Effect Duration: 64
 2950	pulsating Cap'm Caronch's Map	0		
 2951	narrow squat Orcish Frat House blueprints	0		
 2952	dog trainer's Sinatra's glowstick	0		Experience (Moxie): +5, Experience (familiar): +1, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	shaking tip jar of the storm	0		Maximum MP Percent: +40
-2955	tiny moldy yam candy	1	crappy	
+2955	moldy tiny yam candy	1	crappy	
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	spoiled upside-down tube of cranberry Go-Goo	4	crappy	
 2959	frightening rum barrel charrrm bracelet	0		Spooky Damage: +5
 2960	rotten single-serving herbal stuffing	4	crappy	
-2961	yummy miniature packet of tofurkey gravy	2	awesome	
+2961	miniature yummy packet of tofurkey gravy	2	awesome	
 2962	jumbo flavorless tofurkey nugget	5	decent	
 2963	mirror jittery rigging shampoo	0		
 2964	twirling ball polish	0		
@@ -2939,13 +2939,13 @@
 2967	super-quantum Swabbie&trade; swab	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 47
 2968	non-tarnished Oil of Parrrlay	0		Effect: "Cat-Alyzed", Effect Duration: 54
 2969	flavorless creamsicle	3	decent	
-2970	smooth watered-down cream stout	2	awesome	
+2970	watered-down smooth cream stout	2	awesome	
 2971	bouncing blinking up-at-dawn curmudgel of courage	0		Spooky Resistance: +3, Adventures: +5
 2972	grumpy man charrrm	0		
 2973	purple twirling grumpy man charrrm bracelet of the scaredy-cat	0		Monster Level: -15, Single Equip
 2974	tarrrnish charrrm	0		
 2975	frosty banded tarrrnished charrrm bracelet	0		Damage Absorption: +100, Cold Spell Damage: +10, Single Equip
-2976	lousy high-proof bilge wine	10	decent	
+2976	high-proof lousy bilge wine	10	decent	
 2977	witty rapier of doom	0		Spooky Spell Damage: +50
 2978	blinking squat wool yohohoyo of Flo-Jo	0		Cold Resistance: +1, Initiative: +100
 2979	pickled fish-liver oil	0		Effect: "Glittering Eyelashes", Effect Duration: 29
@@ -2962,7 +2962,7 @@
 2990	blue huge family-friendly asbestos-lined clingfilm cap	0		Hot Resistance: +5, Sleaze Resistance: +1, Familiar Effect: "1xVolley, cap 37"
 2991	fortified clingfilm slippers	0		Damage Absorption: +60, Single Equip
 2992	clingfilm tangle	0		
-2993	spoiled thick bouncing vinegar-soaked lemon slice	5	crappy	
+2993	thick spoiled bouncing vinegar-soaked lemon slice	5	crappy	
 2994	moist twirling true grit	0		Effect: "Hypercubed", Effect Duration: 52
 2995	narrow blurry ruddy Da Vinci's brawny buoybottoms	0		Muscle Percent: +20, Experience (Mysticality): +5, Maximum HP Percent: +40, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	blinking gravedigger's grungy flannel shirt	0		Spooky Damage: +10
@@ -2995,16 +2995,16 @@
 3023	jittery small stone triangle	0		
 3024	upside-down stone pyramid	0		
 3025	acceptable corpse on the beach	4	good	
-3026	tolerable upside-down olive corpsetini	4	good	
+3026	tolerable olive upside-down corpsetini	4	good	
 3027	strong lousy corpsedriver	5	decent	
 3028	delicious Corpse Island iced tea	3	awesome	
 3029	acceptable red-headed corpse	3	good	
-3030	watered-down acceptable spinning kamicorpse-ee	2	good	
+3030	acceptable watered-down spinning kamicorpse-ee	2	good	
 3031	tolerable corpsel	3	good	
-3032	watered-down acceptable wobbly corpsebite	2	good	
+3032	acceptable watered-down wobbly corpsebite	2	good	
 3033	purple pirate fledges of courage	0		Spooky Resistance: +3
 3034	gray piece of thirteen	0		
-3035	special normal small pearl onion	2	good	Effect: "Prince of Seaside Town", Effect Duration: 30
+3035	small special normal pearl onion	2	good	Effect: "Prince of Seaside Town", Effect Duration: 30
 3036	massive bland sea biscuit	7	decent	
 3037	artisanal bottle of rum	4	EPIC	
 3038	smooth bottle of black-label rum	3	awesome	
@@ -3048,7 +3048,7 @@
 3076	narrow laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	bouncing spinning Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	spinning bouncing Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	bouncing teddy borg	0		Last Available: "2007-12"
 3081	blinking marionette collective of the glutton	0		Food Drop: +100, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3056,7 +3056,7 @@
 3084	spinning blue extremely unsafe borg sock monkey	0		Weapon Damage Percent: +100, Last Available: "2007-12"
 3085	Jeselnik's dangerous roboduck-on-a-string	0		Weapon Damage: +10, Sleaze Damage: +25, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
-3087	upside-down ghostly upside-down teddy borg sewing kit	0		Last Available: "2007-12"
+3087	ghostly upside-down upside-down teddy borg sewing kit	0		Last Available: "2007-12"
 3088	sinister biomechanical crimborg helmet	0		Spell Damage: +10, Item Drop: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	tumbling Jeselnik's C.B.F.G. of bravery	0		Sleaze Damage: +25, Spooky Resistance: +5, Last Available: "2007-12"
 3090	friendly biomechanical crimborg leg armor of the brazier	0		Familiar Weight: +3, Hot Spell Damage: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
@@ -3088,12 +3088,12 @@
 3116	Hodgman	0		
 3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	huge divine noisemaker	0		Last Available: "2008-01"
-3119	mirror narrow divine can of silly string	0		Last Available: "2008-01"
+3119	narrow mirror divine can of silly string	0		Last Available: "2008-01"
 3120	mirror divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	skewed divine cracker	0		Last Available: "2008-01"
 3123	blue divine champagne flute	0		Last Available: "2008-01"
-3124	moist alkaline bouncing lime green fruitfilm	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 47
+3124	moist alkaline lime green bouncing fruitfilm	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 47
 3125	wet pressed vacuum-sealed piece of after eight	0		Effect: "Black Eyes", Effect Duration: 63
 3126	hobo nickel	0		
 3127	sandcastle	0		
@@ -3129,7 +3129,7 @@
 3157	El Vibrato drone	0		
 3158	squat sparking El Vibrato drone	0		
 3159	ionized twirling warm El Vibrato drone	0		Effect: "Liquid Luck", Effect Duration: 67
-3160	oxidized skewed skewed yellow humming El Vibrato drone	0		Effect: "Adventurer's Best Friendship", Effect Duration: 46
+3160	oxidized yellow skewed skewed humming El Vibrato drone	0		Effect: "Adventurer's Best Friendship", Effect Duration: 46
 3161	energized improved maroon El Vibrato drone	0		Effect: "Jelly Combed", Effect Duration: 24
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	squat El Vibrato energy spear	0		
@@ -3137,15 +3137,15 @@
 3165	broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	green augmented El Vibrato drone	0		
-3168	quantum spinning lime green seal eyeball	0		Effect: "Stenchtastic", Effect Duration: 30
-3169	diet fancy yummy turtle soup	1	awesome	Effect: "[598]A Little Bit Evil", Effect Duration: 50
+3168	quantum lime green spinning seal eyeball	0		Effect: "Stenchtastic", Effect Duration: 30
+3169	fancy yummy diet turtle soup	1	awesome	Effect: "[598]A Little Bit Evil", Effect Duration: 50
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	brainy evil paper umbrella	0		Mysticality: +5
 3173	quantum enhanced skewed tumbling evil vihuela	0		Effect: "From Nantucket", Effect Duration: 37
-3174	massive normal evil boring spaghetti	7	good	
+3174	normal massive evil boring spaghetti	7	good	
 3175	bland evil noodles	3	decent	
-3176	stale low-calorie narrow evil noodles	1	decent	
+3176	low-calorie stale narrow evil noodles	1	decent	
 3177	stale evil painful penne pasta	3	decent	
 3178	special tasty 3vi1 pr0n m4nic0tti	4	awesome	Effect: "Penguinny Flavor", Effect Duration: 25
 3179	decent bouncing evil ravioli della hippy	4	good	
@@ -3157,10 +3157,10 @@
 3185	energized adjusted evil ointment of the occult	0		Effect: "Wintergreen Warmongery", Effect Duration: 52
 3186	anodized twirling evil serum of sarcasm	0		Effect: "Bilious Brawn", Effect Duration: 28
 3187	extra-diffused ionized evil philter of phorce	0		Effect: "Human-Goblin Hybrid", Effect Duration: 16
-3188	watered-down acceptable an evil sump'm sump'm	2	good	
-3189	weak bad evil ducha de oro	2	decent	
+3188	acceptable watered-down an evil sump'm sump'm	2	good	
+3189	bad weak evil ducha de oro	2	decent	
 3190	drinkable evil horizontal tango	3	good	
-3191	artisanal practically non-alcoholic evil roll in the hay	1	super ultra mega turbo EPIC	
+3191	practically non-alcoholic artisanal evil roll in the hay	1	super ultra mega turbo EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3195,20 +3195,20 @@
 3223	sewer nuggets	0		
 3224	sewer wad	0		
 3225	perfectly mixed weak bottle of sewage schnapps	2	EPIC	
-3226	artisanal fortified bottle of Ooze-O	5	EPIC	
+3226	fortified artisanal bottle of Ooze-O	5	EPIC	
 3227	bland C.H.U.M. chum	3	decent	
 3228	bite-sized bland unfortunate dumplings	1	decent	
 3229	decaying goldfish liver	0		
 3230	quadruple-cold-filtered purple oil of oiliness	0		Effect: "Macho, Macho Dog", Effect Duration: 17
 3231	forbidden tattered paper crown	0		Spell Damage Percent: +50, Familiar Effect: "1xSombrero, cap 15"
-3232	snack-sized decent shaking lime green vanilla-frosted king cake	2	good	Last Available: "2008-03"
+3232	decent snack-sized shaking lime green vanilla-frosted king cake	2	good	Last Available: "2008-03"
 3233	mirror inflatable duck	0		
 3234	cyan water wings	0		Wiki Name: "water wings"
 3235	green noodle	0		
 3236	bouncing Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
-3239	skewed huge Maxing, Relaxing	0		Skill: "Maximum Chill"
+3239	huge skewed Maxing, Relaxing	0		Skill: "Maximum Chill"
 3240	blurry Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
@@ -3252,7 +3252,7 @@
 3280	narrow personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	spinning plasma ball	0		Last Available: "2008-04"
 3282	spinning coward's stick-on eyebrow piercing	0		Monster Level: -20, Last Available: "2008-04"
-3283	miniature rotten salad	2	crappy	
+3283	rotten miniature salad	2	crappy	
 3284	green squat C.H.U.M. lantern of the wise owl of the cheetah	0		Mysticality: +20, Initiative: +60
 3285	clever C.H.U.M. knife	0		Maximum MP: +20
 3286	Frosty's snowball sack of terror	0		Spooky Spell Damage: +10
@@ -3262,7 +3262,7 @@
 3290	abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
-3293	upside-down green untamable turtle	0		
+3293	green upside-down untamable turtle	0		
 3294	macaroni duck	0		
 3295	friendly cheez blob	0		
 3296	tumbling unusual disco ball	0		
@@ -3317,7 +3317,7 @@
 3345	squat air mattress	0		
 3346	filth-encrusted futon	0		
 3347	comfy coffin	0		
-3348	purple wobbly narrow mattress	0		
+3348	wobbly narrow purple mattress	0		
 3349	dinged-up triangle	0		
 3350	aged weak blurry Ralph IX cognac	2	awesome	
 3351	blurry llama lama cria	0		Free Pull, Last Available: "2008-06"
@@ -3325,7 +3325,7 @@
 3353	nitrogenated llama lama gong	0		Effect: "Kindly Resolve", Effect Duration: 62, Last Available: "2008-06"
 3354	toothsome banana-frosted king cake	4	awesome	Last Available: "2008-08"
 3355	blinking narrow wicked brown plastic baby	0		Spell Damage: +5, Single Equip, Last Available: "2008-08"
-3356	wobbly yellow plump juicy grub	0		Last Available: "2008-06"
+3356	yellow wobbly plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
 3358	blinking delectable fire ant	0		Last Available: "2008-06"
 3359	scrumptious ice ant	0		Last Available: "2008-06"
@@ -3333,13 +3333,13 @@
 3361	squat yummy death watch beetle	0		Last Available: "2008-06"
 3362	squat tasty louse	0		Last Available: "2008-06"
 3363	normal massive mole mol&eacute;	8	good	Last Available: "2008-06"
-3364	drinkable irresponsibly strong Morlock's Mark Bourbon	8	good	Last Available: "2008-06"
+3364	irresponsibly strong drinkable Morlock's Mark Bourbon	8	good	Last Available: "2008-06"
 3365	electrified non-polarized Climate Colada	0		Effect: "Aided and Abetted", Effect Duration: 20, Last Available: "2008-06"
 3366	corrupted upside-down digital underground potion	0		Effect: "Spookypants", Effect Duration: 24, Last Available: "2008-06"
-3367	wobbly red interesting-looking twig	0		Last Available: "2008-06"
+3367	red wobbly interesting-looking twig	0		Last Available: "2008-06"
 3368	modified glimmering roc feather	1	crappy	Effect: "Mushroom Moxiousness", Effect Duration: 35, Last Available: "2008-06"
 3369	diluted glimmering phoenix feather	1		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 40, Last Available: "2008-06"
-3370	powdered narrow twirling wobbly glimmering penguin feather	1		Last Available: "2008-06"
+3370	powdered twirling narrow wobbly glimmering penguin feather	1		Last Available: "2008-06"
 3371	boiled glimmering buzzard feather	1		Last Available: "2008-06"
 3372	distilled bouncing glimmering raven feather	1		Last Available: "2008-06"
 3373	compressed olive glimmering great tit feather	1		Last Available: "2008-06"
@@ -3385,7 +3385,7 @@
 3413	Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	narrow Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
-3416	lime green tumbling hobo fortress blueprints	0		
+3416	tumbling lime green hobo fortress blueprints	0		
 3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	Vulcanized lime green sterno-flavored Hob-O	0		Effect: "Pla-see-bo", Effect Duration: 33
 3423	galvanized frostbite-flavored Hob-O	0		Effect: "Neuroplastici Tea", Effect Duration: 26
@@ -3413,7 +3413,7 @@
 3446	blinking groovy prism necklace	0		Single Equip
 3447	lightning-fast quilted six-rainbow shield	0		Damage Absorption: +40, Initiative: +40, Damage Reduction: 12, Last Available: "2008-07"
 3448	rainbow bomb	0		Last Available: "2008-07"
-3449	tumbling narrow cotton candy cone	0		Last Available: "2008-08"
+3449	narrow tumbling cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	huge cotton candy smidgen	0		Last Available: "2008-08"
 3452	cotton candy skoshe	0		Last Available: "2008-08"
@@ -3422,8 +3422,8 @@
 3455	spinning cotton candy bale	0		Last Available: "2008-08"
 3456	cool trusty torch	0		Moxie: +5, Last Available: "2011-12"
 3457	Junior Adventurer's merit badge of mayonnaise	0		Sleaze Spell Damage: +50
-3458	non-flattened polymerized mirror bouncing STYX deodorant body spray	0		Effect: "Moon-Eyed", Effect Duration: 61
-3459	strong acceptable white-label gin	5	good	
+3458	non-flattened polymerized bouncing mirror STYX deodorant body spray	0		Effect: "Moon-Eyed", Effect Duration: 61
+3459	acceptable strong white-label gin	5	good	
 3460	flavorless upside-down tin rations	3	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
@@ -3455,13 +3455,13 @@
 3488	pristine fish scale	0		
 3489	small rotten beefy fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3490	decent glistening fish meat	3	good	Effect: "Fishy", Effect Duration: 5
-3491	half-sized spoiled slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
+3491	spoiled half-sized slick fish meat	2	crappy	Effect: "Fishy", Effect Duration: 5
 3492	bouncing wool fish scimitar of Leguizamo	0		Monster Level: +20, Cold Resistance: +1
 3493	dog trainer's slick fish stick	0		Moxie: +10, Experience (familiar): +1
 3494	hale fish bazooka of the brazier	0		Maximum HP: +20, Hot Spell Damage: +25
 3495	oxidized sea salt crystal	0		Effect: "Healthy Green Glow", Effect Duration: 15
 3496	quadruple-cold-filtered bazookafish bubble gum	0		Effect: "Altered Wavelengths", Effect Duration: 39
-3497	hand-crafted watered-down bottle of Pete's Sake	2	EPIC	
+3497	watered-down hand-crafted bottle of Pete's Sake	2	EPIC	
 3498	squat invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
@@ -3519,15 +3519,15 @@
 3552	jittery supercool savvy octopus's spade of the dark arts	0		Mysticality Percent: +20, Moxie Percent: +20, Spell Damage Percent: +100
 3553	fuchsia soggy seed packet	0		
 3554	glob of slime	0		
-3555	massive moldy tumbling sea carrot	7	crappy	
+3555	moldy massive tumbling sea carrot	7	crappy	
 3556	big bland sea cucumber	5	decent	
 3557	decent sea avocado	3	good	
 3558	adequate sea lychee	3	good	
 3559	decent tiny sea tangelo	1	good	
-3560	adequate gigantic pulsating sea honeydew	9	good	
+3560	gigantic adequate pulsating sea honeydew	9	good	
 3561	modified blinking pressurized potion of puissance	0		Effect: "Booing Radly", Effect Duration: 31
 3562	adjusted pressurized potion of perspicacity	0		Effect: "Quiet 'n' Good", Effect Duration: 60
-3563	chilled galvanized blue mirror pressurized potion of pulchritude	0		Effect: "Adrenaline Rush", Effect Duration: 36
+3563	chilled galvanized mirror blue pressurized potion of pulchritude	0		Effect: "Adrenaline Rush", Effect Duration: 36
 3564	artisanal blinking berry-infused sake	4	EPIC	
 3565	perfectly mixed lime green citrus-infused sake	3	EPIC	
 3566	acceptable special blurry melon-infused sake	4	good	Effect: "Here to Kick Ass", Effect Duration: 30
@@ -3537,7 +3537,7 @@
 3570	jittery smelly friendly electrified square sponge pants	0		Familiar Weight: +3, Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, 1xPotato"
 3571	flytrap pellet	0		
 3572	baby cuddlefish	0		
-3573	blurry green six-armed sweater	0		Familiar Weight: +5
+3573	green blurry six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	fuchsia sand dollar	0		
 3576	flytrap bezoar	0		
@@ -3547,16 +3547,16 @@
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	normal rice	3	good	
-3584	bite-sized normal irradiated candy cane	1	good	Last Available: "2008-12"
-3585	massive bland gingerbread mutant bugbear	8	decent	Last Available: "2008-12"
+3584	normal bite-sized irradiated candy cane	1	good	Last Available: "2008-12"
+3585	bland massive gingerbread mutant bugbear	8	decent	Last Available: "2008-12"
 3586	acceptable bouncing oozenog	3	good	Last Available: "2008-12"
 3587	pickled olive sugar plum	0		Effect: "Tingling Feeling", Effect Duration: 35, Last Available: "2008-12"
-3588	nitrogenated cold-filtered aerosolized blinking spinning sugar banana	0		Effect: "Cold Jellied", Effect Duration: 62, Last Available: "2008-12"
-3589	liquefied triple-polarized quadruple-dry twirling wobbly sugar lime	0		Effect: "Eau de Tortue", Effect Duration: 14, Last Available: "2008-12"
+3588	nitrogenated cold-filtered aerosolized spinning blinking sugar banana	0		Effect: "Cold Jellied", Effect Duration: 62, Last Available: "2008-12"
+3589	liquefied triple-polarized quadruple-dry wobbly twirling sugar lime	0		Effect: "Eau de Tortue", Effect Duration: 14, Last Available: "2008-12"
 3590	nitrogenated huge sugar cherry	0		Effect: "Liquid Courage", Effect Duration: 65, Last Available: "2008-12"
 3591	forbidden Mer-kin hookspear of the overflowing toilet	0		Spell Damage Percent: +50, Stench Spell Damage: +50
 3592	Mer-kin takebag	0		Item Drop: +5
-3593	upside-down red Mer-kin thingpouch	0		
+3593	red upside-down Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	dry blue Mer-kin fastjuice	0		Effect: "Stench Jellied", Effect Duration: 50
 3596	imitation crab crate	0		
@@ -3606,17 +3606,17 @@
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	dragonfish caviar	0		
-3643	blue squat pufferfish spine	0		
+3643	squat blue pufferfish spine	0		
 3644	skewed twirling depleted Grimacite kneecapping stick of the sweet-tooth	0		Candy Drop: +100, Last Available: "2007-06"
 3645	delicious shaking yellow canteen of wine	4	awesome	Last Available: "2008-12"
-3646	super-sized flavorless elven <i>limbos</i> gingerbread	5	decent	Last Available: "2008-12"
+3646	flavorless super-sized elven <i>limbos</i> gingerbread	5	decent	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	purple skewed map to Madness Reef	0		
 3650	adequate toast with jam	4	good	Last Available: "2008-12"
-3651	bouncing antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	bouncing antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	bad elven moonshine	4	decent	Last Available: "2008-12"
-3653	yummy half-sized knuckle sandwich	2	awesome	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	half-sized yummy knuckle sandwich	2	awesome	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	jittery foul-smelling cool psycho sweater	0		Moxie: +5, Stench Damage: +10, Last Available: "2008-12"
 3655	red fin-bit wax	0		Familiar Weight: +5
 3656	pulsating plastic Mob Penguin of the empath	0		Familiar Weight: +5, Last Available: "2008-12"
@@ -3635,13 +3635,13 @@
 3669	blinking upside-down thinker's glow-in-the-dark dart gun	0		Mysticality: +10, Last Available: "2009-01"
 3670	gray Jim Carey's glow-in-the-dark burrowgrub	0		Monster Level: +25, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	half-sized normal can of franks 'n' beans	2	good	Last Available: "2010-12"
-3673	triple-distilled acceptable bottle of peppermint schnapps	8	good	Last Available: "2010-12"
+3672	normal half-sized can of franks 'n' beans	2	good	Last Available: "2010-12"
+3673	acceptable triple-distilled bottle of peppermint schnapps	8	good	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	beefcake's diving muff	0		Muscle: +25, Single Equip
-3678	weak drinkable salinated mint julep	2	good	
+3678	drinkable weak salinated mint julep	2	good	
 3679	skewed wobbly ink bladder	0		
 3680	esca	0		
 3681	skewed bubbling tempura batter	0		
@@ -3649,11 +3649,11 @@
 3683	map to the Marinara Trench	0		
 3684	normal gigantic blurry tempura carrot	9	good	
 3685	delicious small tempura cucumber	2	awesome	
-3686	decent huge tempura avocado	7	good	
+3686	huge decent tempura avocado	7	good	
 3687	delicious jittery sea broccoli	3	awesome	
 3688	adequate olive sea cauliflower	3	good	
 3689	jumbo bland tempura broccoli	5	decent	
-3690	fancy rotten tempura cauliflower	4	crappy	Effect: "Flambé-a-thon", Effect Duration: 15
+3690	rotten fancy tempura cauliflower	4	crappy	Effect: "Flambé-a-thon", Effect Duration: 15
 3691	moldy maroon sea blueberry	4	crappy	
 3692	decent sea persimmon	3	good	
 3693	improved extra-vacuum-sealed pressurized potion of perception	0		Effect: "Twinklebritches", Effect Duration: 35
@@ -3665,7 +3665,7 @@
 3699	teflon ore	0		
 3700	vinyl ore	0		
 3701	map to Anemone Mine	0		
-3702	skewed fuchsia marine aquamarine	0		
+3702	fuchsia skewed marine aquamarine	0		
 3703	ghostly valve wheel	0		
 3704	waterlogged bootstraps	0		
 3705	bouncing sinister velcro broadsword of horror of the cheetah	0		Spell Damage: +10, Spooky Spell Damage: +25, Initiative: +60
@@ -3701,16 +3701,16 @@
 3735	fat wallet	0		
 3736	quilted supercool handwarmer	0		Moxie Percent: +20, Damage Absorption: +40, Single Equip
 3737	stanky smooth lighter	0		Moxie: +15, Stench Spell Damage: +25
-3738	adequate jumbo packet of beer nuts	5	good	
+3738	jumbo adequate packet of beer nuts	5	good	
 3739	Boozehounds Anonymous token	0		
-3740	skewed mirror handful of bees	0		
+3740	mirror skewed handful of bees	0		
 3741	bouncing spectral jelly	0		
 3742	altered galvanized jellyfish gel	0		Effect: "Mitre Cut", Effect Duration: 29
 3743	twirling spinning unstable quark	0		
 3744	huge software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
-3747	upside-down teal mother's secret recipe	0		Recipe: "white chocolate chip brownies"
+3747	teal upside-down mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	alkaline concoction of clumsiness	0		Effect: "Analog Drunk", Effect Duration: 34
 3750	red weightlifter's vampire pearl earring	0		Muscle: +15, Single Equip
 3751	flavorless chocolate chip brownies	3	decent	
@@ -3724,15 +3724,15 @@
 3760	alkaline breath mint	0		Effect: "Extra-Thick Blood", Effect Duration: 61
 3761	vampire pearl ring of the sweet-tooth	0		Candy Drop: +100, Single Equip
 3762	tumbling jittery therapeutic vampire pearl necklace	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
-3763	fancy perfectly mixed slug of vodka	4	EPIC	Effect: "Cold Throat", Effect Duration: 15
+3763	perfectly mixed fancy slug of vodka	4	EPIC	Effect: "Cold Throat", Effect Duration: 15
 3764	weak hand-crafted green slug of rum	2	EPIC	
 3765	smooth watered-down jittery slug of shochu	2	awesome	
-3766	distilled mediocre squat screwdiver	5	decent	
+3766	mediocre distilled squat screwdiver	5	decent	
 3767	aged dew yoana lei	3	awesome	
 3768	hand-crafted lychee chuhai	4	EPIC	
-3769	perfectly mixed watered-down salacious screwdiver	2	EPIC	
-3770	watered-down perfectly mixed huge dew yoana salacious lei	2	EPIC	
-3771	high-proof perfectly mixed blurry green salacious lychee chuhai	6	EPIC	
+3769	watered-down perfectly mixed salacious screwdiver	2	EPIC	
+3770	perfectly mixed watered-down huge dew yoana salacious lei	2	EPIC	
+3771	perfectly mixed high-proof blurry green salacious lychee chuhai	6	EPIC	
 3772	aged boozy Alewife&trade; Ale	5	awesome	
 3773	skewed seaode	0		
 3774	blurry map to the Dive Bar	0		
@@ -3740,14 +3740,14 @@
 3776	rosy-cheeked pink pinkslip slip of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3777	inspector's deadly sea salt scrubs	0		Weapon Damage: +5, Item Drop: +15
 3778	shaking dog trainer's forbidden amber aviator shades of Gandalf	0		Spell Damage Percent: +50, Spell Critical Percent: +20, Experience (familiar): +1, Single Equip
-3779	pressed non-altered shaking olive hair of the fish	0		Effect: "French Bronilla Brogueishness", Effect Duration: 55
+3779	pressed non-altered olive shaking hair of the fish	0		Effect: "French Bronilla Brogueishness", Effect Duration: 55
 3780	spinning blue MacGyver's nurse's hat of Gandalf of the boozehound	0		Maximum MP: +100, Spell Critical Percent: +20, Booze Drop: +100, Familiar Effect: "atk"
-3781	gray huge blank prescription sheet	0		
+3781	huge gray blank prescription sheet	0		
 3782	dried squat bottle of melodramamine	1		Effect: "[1342]Slicked-Back Do", Effect Duration: 50
 3783	modified skewed cyan bottle of extra-strength melodramamine	1		Effect: "Boon of She-Who-Was", Effect Duration: 50
 3784	paranormal ricotta	0		Class: "Pastamancer"
 3785	teal smoking talon	0		Class: "Pastamancer"
-3786	pulsating wobbly vampire glitter	0		Class: "Pastamancer"
+3786	wobbly pulsating vampire glitter	0		Class: "Pastamancer"
 3787	blinking wine-soaked bone chips	0		Class: "Pastamancer"
 3788	bouncing twirling crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
@@ -3764,9 +3764,9 @@
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	immense moldy chocolate-frosted king cake	7	crappy	Last Available: "2009-06"
+3812	moldy immense chocolate-frosted king cake	7	crappy	Last Available: "2009-06"
 3813	narrow dog trainer's plastic baby	0		Experience (familiar): +1, Single Equip, Last Available: "2009-06"
-3815	shaking narrow midget clownfish	0		
+3815	narrow shaking midget clownfish	0		
 3816	skewed half-height unicycle	0		Familiar Weight: +5
 3817	moldy sea radish	3	crappy	
 3818	zippy Oprah's slick halibut	0		Moxie: +10, Maximum MP Percent: +50, Initiative: +20
@@ -3782,11 +3782,11 @@
 3828	Grandma's Map	0		
 3829	fancy bland big tempura radish	5	decent	Effect: "Cautious Prowl", Effect Duration: 50
 3830	narrow blue wool water-polo cap	0		Cold Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr"
-3831	enchanted watered-down acceptable twirling Typical Tavern swill	2	good	Effect: "Graham Crackling", Effect Duration: 35
-3832	extra-dry perfectly mixed upside-down tropical swill	5	EPIC	
-3833	practically non-alcoholic tolerable upside-down fruity girl swill	1	good	
-3834	bad fancy blended swill	3	decent	Effect: "Ooh, Sweet!", Effect Duration: 25
-3835	purple upside-down twirling costume wardrobe	0		Softcore Only
+3831	enchanted acceptable watered-down twirling Typical Tavern swill	2	good	Effect: "Graham Crackling", Effect Duration: 35
+3832	perfectly mixed extra-dry upside-down tropical swill	5	EPIC	
+3833	tolerable practically non-alcoholic upside-down fruity girl swill	1	good	
+3834	fancy bad blended swill	3	decent	Effect: "Ooh, Sweet!", Effect Duration: 25
+3835	upside-down purple twirling costume wardrobe	0		Softcore Only
 3836	wool grievous beefcake's Elvish sunglasses	0		Muscle: +25, Weapon Damage Percent: +50, Cold Resistance: +1, Item Drop: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	blinking anniversary safety glass vest of the detective	0		Item Drop: +20
 3838	lime green chilly anniversary burlap belt	0		Cold Damage: +5
@@ -3812,7 +3812,7 @@
 3858	cool bone flute	0		Moxie: +5
 3859	infernal fife of Leguizamo	0		Monster Level: +20
 3860	perfumed charming flute	0		Stench Resistance: +5
-3861	lime green wobbly leaf of grass	0		
+3861	wobbly lime green leaf of grass	0		
 3862	Jim Carey's Tesla grass whistle	0		Monster Level: +25, MP Regen Min: 7, MP Regen Max: 10
 3863	executive dog trainer's plastic guitar	0		Experience (familiar): +1, Meat Drop: +40
 3864	finger cymbals of the blizzard	0		Cold Spell Damage: +25
@@ -3821,7 +3821,7 @@
 3867	squat supercharged quilted magilaser blastercannon	0		Damage Absorption: +40, Maximum MP Percent: +30
 3868	hanky&#363; of the wise owl of bravery	0		Mysticality: +20, Spooky Resistance: +5, Wiki Name: "frigid hankyu"
 3869	blinking wobbly gravedigger's studded ultimate ultimate frisbee	0		Damage Absorption: +80, Spooky Damage: +10
-3870	cyan twirling stolen office supplies	0		
+3870	twirling cyan stolen office supplies	0		
 3871	sharpshooter's groovy office-supply crossbow	0		Moxie Percent: +10, Critical Hit Percent: +10
 3872	pocket theremin of the detective	0		Item Drop: +20
 3873	manspreader's rave whistle of Leguizamo	0		Monster Level: 30
@@ -3830,7 +3830,7 @@
 3876	hellseal brain	0		
 3877	burst hellseal brain	0		
 3878	hellseal sinew	0		
-3879	blurry huge torn hellseal sinew	0		
+3879	huge blurry torn hellseal sinew	0		
 3880	hellseal disguise	0		
 3881	mansplainer's slick fouet de tortue-dressage	0		Moxie: +10, Monster Level: +15, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
@@ -3843,7 +3843,7 @@
 3889	non-anodized double-adjusted tarnished skewed vial of slime	0		Effect: "Cold Hard Skin", Effect Duration: 24
 3890	altered electrified maroon vial of violet slime	0		Effect: "Pasta Oneness", Effect Duration: 42
 3891	triple-activated diffused jittery vial of vermilion slime	0		Effect: "Craft Tea", Effect Duration: 17
-3892	chilled maroon ghostly vial of amber slime	0		Effect: "Bonelording", Effect Duration: 26
+3892	chilled ghostly maroon vial of amber slime	0		Effect: "Bonelording", Effect Duration: 26
 3893	deionized modified shaking vial of chartreuse slime	0		Effect: "Oiled Skin", Effect Duration: 22
 3894	polymerized ionized vial of teal slime	0		Effect: "Bootyliciousness", Effect Duration: 61
 3895	corrupted red vial of indigo slime	0		Effect: "Extra-Sharp Weapon", Effect Duration: 53
@@ -3861,8 +3861,8 @@
 3909	narrow figurine of a charred seal	0		Class: "Seal Clubber"
 3910	upside-down figurine of a seal	0		Class: "Seal Clubber"
 3911	lime green figurine of a slippery seal	0		Class: "Seal Clubber"
-3912	twirling mirror imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	watered-down aged blended swill with a fly in it	2	awesome	
+3912	mirror twirling imbued seal-blubber candle	0		Class: "Seal Clubber"
+3913	aged watered-down blended swill with a fly in it	2	awesome	
 3914	turtle wax	0		
 3915	spinning green mansplainer's turtle wax shield	0		Monster Level: +15, Damage Reduction: 2
 3916	narrow smelly turtle wax helmet	0		Stench Spell Damage: +10, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3911,7 +3911,7 @@
 3959	mirror yellow garish pinky ring of the storm	0		Maximum MP Percent: +40
 3960	double-paned designer sunglasses	0		Cold Resistance: +5, Single Equip
 3961	avaricious perfumed opera glasses	0		Stench Resistance: +5, Meat Drop: +30
-3962	blurry spinning designer handbag	0		
+3962	spinning blurry designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
 3965	tarnished quadruple-polarized blue cube of billiard chalk	0		Effect: "Burnt 'n' Turnt", Effect Duration: 21
@@ -3930,7 +3930,7 @@
 3978	green MacGyver's painted shield of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Damage Reduction: 7
 3979	sleeping wereturtle	0		
 3980	shell	0		
-3981	maroon narrow torquoise	0		
+3981	narrow maroon torquoise	0		
 3982	upside-down foul-smelling sinister torquoise ring	0		Spell Damage: +10, Stench Damage: +10, Single Equip
 3983	bouncing dueling turtle	0		
 3984	wool Rosewater's dueling banjo	0		Mysticality Percent: +30, Cold Resistance: +1
@@ -3987,7 +3987,7 @@
 4035	purple memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
 4037	adequate slimy sweetbreads	3	good	
-4038	weak acceptable blue slimy fermented bile bladder	2	good	
+4038	acceptable weak blue slimy fermented bile bladder	2	good	
 4039	mixed skewed slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	upside-down wool boxer's pig-iron helm	0		Muscle Percent: +10, Cold Resistance: +1, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	lime green Jack Frost's friendly grisly shield	0		Familiar Weight: +3, Cold Spell Damage: +50, Slime Hates It: +1, Damage Reduction: 13
 4081	brainy corroded breeches of James Dean	0		Mysticality: +5, Experience (Moxie): +3, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	jittery bouncing deadly pernicious cudgel of the scaredy-cat	0		Weapon Damage: +5, Monster Level: -15, Slime Hates It: +1
-4083	bland thick cupcake-in-a-cup	5	decent	Last Available: "2009-06"
+4083	thick bland cupcake-in-a-cup	5	decent	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	massive delicious protein paste	6	awesome	Last Available: "2009-06"
 4086	upside-down foul-smelling supercharged cyber-mattock	0		Maximum MP Percent: +30, Stench Damage: +10, Last Available: "2009-06"
@@ -4082,7 +4082,7 @@
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	compressed boot plant	1	awesome	Last Available: "2009-06"
 4132	acceptable watered-down sham champagne	2	good	Last Available: "2009-06"
-4133	galvanized altered narrow blinking tempura air	0		Effect: "5 Pounds Lighter", Effect Duration: 41
+4133	galvanized altered blinking narrow tempura air	0		Effect: "5 Pounds Lighter", Effect Duration: 41
 4134	irradiated warmed pulsating pressurized potion of pneumaticity	0		Effect: "Chorale of Companionship", Effect Duration: 28
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
 4136	horrifying Newton's smartaleck's Bag o' Tricks of the brute	0		Muscle Percent: +30, Moxie Percent: +30, Experience (Mysticality): +3, Spooky Damage: +25, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
@@ -4109,8 +4109,8 @@
 4157	spinning gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	tumbling rock lobster	0		Last Available: "2009-09"
-4160	fancy irresponsibly strong bad cyan twirling skewed pebblebr&auml;u	10	decent	Effect: "Well Owl Be!", Effect Duration: 40, Last Available: "2009-09"
-4161	rotten half-sized rocky road ice cream	2	crappy	Last Available: "2009-09"
+4160	fancy bad irresponsibly strong twirling skewed cyan pebblebr&auml;u	10	decent	Effect: "Well Owl Be!", Effect Duration: 40, Last Available: "2009-09"
+4161	half-sized rotten rocky road ice cream	2	crappy	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	colloidal tarnished children of the candy corn	0		Effect: "Papowerful", Effect Duration: 64
 4164	unsweetened pickled Good 'n' Slimy	0		Effect: "French Bronilla Brogueishness", Effect Duration: 25
@@ -4145,7 +4145,7 @@
 4193	skewed weightlifter's rave visor	0		Muscle: +15, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
 4194	baggy rave pants of the boozehound	0		Booze Drop: +100, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 4195	pacifier necklace of vim and vigor	0		Maximum HP Percent: +50, Single Equip
-4196	squat spinning pulsating sea cowbell	0		
+4196	pulsating spinning squat sea cowbell	0		
 4197	sea	0		
 4198	sea lasso	0		
 4199	Jeselnik's arcane researcher's sea cowboy hat of the brazier	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +25, Sleaze Damage: +25, Familiar Effect: "1xLep"
@@ -4153,7 +4153,7 @@
 4201	gill rings	0		Familiar Weight: +5
 4202	yellow urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
-4204	tumbling fuchsia Mer-kin cheatsheet	0		
+4204	fuchsia tumbling Mer-kin cheatsheet	0		
 4205	skewed Mer-kin wordquiz	0		
 4206	upside-down medical-grade educational brand new key	0		Experience: +1, HP Regen Min: 7, HP Regen Max: 10
 4207	weightlifter's dorsal fin	0		Muscle: +15, Damage Reduction: 13
@@ -4185,7 +4185,7 @@
 4233	wobbly hacienda key	0		
 4234	perfumed pat&eacute; knife	0		Stench Resistance: +5
 4235	bouncing salt-shaker	0		
-4236	blue wobbly can of sterno	0		
+4236	wobbly blue can of sterno	0		
 4237	sharpshooter's cheese-slicer	0		Critical Hit Percent: +10
 4238	bite-sized tasty blue beef jerky	1	awesome	
 4239	pipe wrench of the bloodbag	0		Maximum HP: +100
@@ -4197,11 +4197,11 @@
 4245	bookmark	0		
 4246	ivory cue ball of bravery	0		Spooky Resistance: +5
 4247	mediocre strong decanter of fine Scotch	5	decent	
-4248	altered blue blinking twirling expensive cigar	1		Effect: "Sticky Fingers", Effect Duration: 5
+4248	altered blinking blue twirling expensive cigar	1		Effect: "Sticky Fingers", Effect Duration: 5
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
-4251	wobbly maroon tumbling fish-oil smoke bomb	0		
-4252	dry purple upside-down vial of squid ink	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 69
+4251	maroon tumbling wobbly fish-oil smoke bomb	0		
+4252	dry upside-down purple vial of squid ink	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 69
 4253	double-alkaline boiled potion of speed	0		Effect: "The Power of LOV", Effect Duration: 58
 4254	twirling bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
@@ -4282,8 +4282,8 @@
 4330	decent huge candy kneecapping stick	4	good	Last Available: "2009-12"
 4331	stale licorice garrote	3	decent	Last Available: "2009-12"
 4332	tumbling sinister candy knuckles	0		Spell Damage: +10, Last Available: "2009-12"
-4333	bland miniature mirror jawbruiser	2	decent	Last Available: "2010-12"
-4334	polarized colloidal shaking blue chocolate car	0		Effect: "Broberry Brotality", Effect Duration: 27, Last Available: "2009-12"
+4333	miniature bland mirror jawbruiser	2	decent	Last Available: "2010-12"
+4334	polarized colloidal blue shaking chocolate car	0		Effect: "Broberry Brotality", Effect Duration: 27, Last Available: "2009-12"
 4335	mansplainer's plastic 11 Dealer	0		Monster Level: +15, Last Available: "2009-12"
 4336	plastic Crimbo Casino of doom	0		Spooky Spell Damage: +50, Last Available: "2009-12"
 4337	ghostly wizardly plastic stocking mimic	0		Mysticality: +25, Last Available: "2009-12"
@@ -4295,7 +4295,7 @@
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
 4345	string of Crimbo lights	0		Last Available: "2009-12"
-4346	twirling maroon plastic Crimbo reindeer	0		Last Available: "2009-12"
+4346	maroon twirling plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
 4349	occult snow hat	0		Spell Damage Percent: +25, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
@@ -4309,14 +4309,14 @@
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	mirror A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	diet stale expired can of franks 'n' beans	1	decent	Last Available: "2009-12"
+4360	stale diet expired can of franks 'n' beans	1	decent	Last Available: "2009-12"
 4361	artisanal narrow expired bottle of peppermint schnapps	3	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
-4363	shaking fuchsia elf resistance button	0		Last Available: "2009-12"
+4363	fuchsia shaking elf resistance button	0		Last Available: "2009-12"
 4364	polymerized fuchsia elven suicide capsule	0		Effect: "Briny Blood", Effect Duration: 28, Last Available: "2009-12"
-4365	delicious immense spinning penguin focaccia bread	8	awesome	Last Available: "2009-12"
+4365	immense delicious spinning penguin focaccia bread	8	awesome	Last Available: "2009-12"
 4366	hand-crafted herringcello	4	EPIC	Last Available: "2009-12"
-4367	delicious weak mirror elven cellocello	2	awesome	Last Available: "2009-12"
+4367	weak delicious mirror elven cellocello	2	awesome	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	blurry handful of headless bolts	0		Last Available: "2009-12"
 4370	huge bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4344,7 +4344,7 @@
 4392	fuchsia Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	improved Crimbo peppermint bark	0		Effect: "Elron's Explosive Etude", Effect Duration: 50, Last Available: "2009-12"
 4394	deionized pressed shaking Crimbo fudge	0		Effect: "Ocelot Eyes", Effect Duration: 64, Last Available: "2009-12"
-4395	improved double-oxidized bouncing red Crimbo pecan	0		Effect: "Staying Frosty", Effect Duration: 22, Last Available: "2009-12"
+4395	improved double-oxidized red bouncing Crimbo pecan	0		Effect: "Staying Frosty", Effect Duration: 22, Last Available: "2009-12"
 4396	Jack-in-the-box	0		Last Available: "2009-12"
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	twirling cheese ball	0		Last Available: "2010-01"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	bland quantum taco	0		Last Available: "2010-10"
-4413	drinkable irresponsibly strong shaking bouncing Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	irresponsibly strong drinkable shaking bouncing Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	squat sealhide hood of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	brainy sealhide leggings	0		Mysticality: +5, Familiar Effect: "1xVolley, cap 40"
@@ -4424,7 +4424,7 @@
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	wobbly BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	blurry BRICKO airship	0		Last Available: "2010-02"
@@ -4471,15 +4471,15 @@
 4523	purple wholesome smartaleck's eye of the Tiger-lily	0		Moxie Percent: +30, Maximum HP Percent: +10, Last Available: "2010-03"
 4524	vibrating wig of extreme caution	0		Maximum MP Percent: +10, Monster Level: -25, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	moldy donut	4	crappy	Last Available: "2010-03"
-4526	decent thick bucket of honey	5	good	Last Available: "2010-03"
+4526	thick decent bucket of honey	5	good	Last Available: "2010-03"
 4527	banded studded elephant stinger	0		Damage Absorption: 180, Last Available: "2010-03"
 4528	rotten dragon snaps	3	crappy	Last Available: "2010-03"
 4529	lard-coated snapdragon pistil of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +25, Last Available: "2010-03"
-4530	shaking blurry lime green puff of smoke	0		Last Available: "2010-03"
+4530	lime green blurry shaking puff of smoke	0		Last Available: "2010-03"
 4531	delicious green rook cookie	3	awesome	Last Available: "2010-03"
 4532	tasty enchanted jittery bishop cookie	3	awesome	Effect: "Wreathed in Smoke", Effect Duration: 35, Last Available: "2010-03"
-4533	bland huge knight cookie	9	decent	Last Available: "2010-03"
-4534	snack-sized adequate shaking king cookie	2	good	Last Available: "2010-03"
+4533	huge bland knight cookie	9	decent	Last Available: "2010-03"
+4534	adequate snack-sized shaking king cookie	2	good	Last Available: "2010-03"
 4535	bland queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	narrow electrified insane tophat	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4508,13 +4508,13 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	bouncing can of depilatory cream	0		Last Available: "2010-04"
 4562	twirling hair of the calf	0		Last Available: "2010-04"
-4563	hand-crafted boozy squat world's most unappetizing beverage	5	EPIC	Last Available: "2010-04"
+4563	boozy hand-crafted squat world's most unappetizing beverage	5	EPIC	Last Available: "2010-04"
 4564	blinking slippery when wet shield of the glutton	0		Food Drop: +100, Damage Reduction: 6, Last Available: "2010-04"
-4565	rotten half-sized raisin	2	crappy	Last Available: "2010-04"
+4565	half-sized rotten raisin	2	crappy	Last Available: "2010-04"
 4566	skewed fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	upside-down gravedigger's smelly flyest of shirts	0		Stench Spell Damage: +10, Spooky Damage: +10, Last Available: "2010-04"
-4568	flavorless snack-sized a dance upon the palate	2	decent	Last Available: "2010-04"
-4569	decent small prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
+4568	snack-sized flavorless a dance upon the palate	2	decent	Last Available: "2010-04"
+4569	small decent prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
 4570	blurry Crazyleg's razor	0		Last Available: "2010-04"
 4571	moldy squirmy violent party snack	4	crappy	Last Available: "2010-04"
 4572	can-you-dig-it? of the wise owl	0		Mysticality: +20, Last Available: "2010-04"
@@ -4526,12 +4526,12 @@
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	boiled dry unsweetened Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "For Your Brain Only", Effect Duration: 46, Last Available: "2010-04"
 4580	sharpshooter's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Critical Hit Percent: +10, Last Available: "2010-04"
-4581	ghostly tumbling wool Rosewater's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Mysticality Percent: +30, Cold Resistance: +1, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	ghostly tumbling wool Rosewater's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Mysticality Percent: +30, Cold Resistance: +1, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	gray fat bottom quark	0		Last Available: "2010-05"
 4583	jittery glob of skin	0		
 4584	tasty six wedges of goat cheese	3	awesome	
 4585	collection of objects	0		
-4586	green skewed boulder	0		
+4586	skewed green boulder	0		
 4587	goth	0		
 4588	brown pixel	0		
 4589	pixel whip of the cheetah	0		Initiative: +60
@@ -4606,7 +4606,7 @@
 4658	mirror map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	upside-down blackberry galoshes of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip
 4660	blinking wicked beefcake's trout fang	0		Muscle: +25, Spell Damage: +5, Last Available: "2010-09"
-4661	flavorless big poisonous caviar	5	decent	Last Available: "2010-09"
+4661	big flavorless poisonous caviar	5	decent	Last Available: "2010-09"
 4662	denatured aerosolized warmed wet venom duct	0		Effect: "Eagle Eyes", Effect Duration: 26, Last Available: "2010-09"
 4663	purple Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	avaricious padded Ellsbury's skull	0		Damage Absorption: +20, Meat Drop: +30, Last Available: "2010-09"
@@ -4616,10 +4616,10 @@
 4668	huge observational glasses of the brazier	0		Hot Spell Damage: +25
 4669	Socratic hilarious comedy prop	0		Experience (Mysticality): +1
 4670	beer-scented teddy bear	0		
-4671	high-proof drinkable booze-soaked cherry	9	good	
+4671	drinkable high-proof booze-soaked cherry	9	good	
 4672	huge comfy pillow	0		
 4673	huge spoiled marshmallow	9	crappy	
-4674	thick delicious fuchsia sponge cake	5	awesome	
+4674	delicious thick fuchsia sponge cake	5	awesome	
 4675	delicious twirling gin-soaked blotter paper	3	awesome	
 4676	purple tree-holed coin	0		
 4677	upside-down unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4661,7 +4661,7 @@
 4713	popsicle stick	0		
 4714	flavorless immense tumbling lemon popsicle	8	decent	
 4715	spoiled popsicle	3	crappy	
-4716	jumbo adequate jittery red strawberry popsicle	5	good	
+4716	adequate jumbo jittery red strawberry popsicle	5	good	
 4717	delicious small liver popsicle	2	awesome	
 4718	steel-toed mariachi hat	0		Damage Reduction: 9, Familiar Effect: "atk, cap 2"
 4719	twirling foul-smelling Hollandaise helmet	0		Stench Damage: +10, Familiar Effect: "atk, cap 2"
@@ -4671,7 +4671,7 @@
 4723	flavorless pulsating badass pie	3	decent	Last Available: "2010-10"
 4724	toothsome skewed shoo-fish pie	4	awesome	Last Available: "2010-10"
 4725	adequate piping organ pie	4	good	Last Available: "2010-10"
-4726	massive rotten igloo pie	6	crappy	Last Available: "2010-10"
+4726	rotten massive igloo pie	6	crappy	Last Available: "2010-10"
 4727	rotten spinning stomach turnover	4	crappy	Last Available: "2010-10"
 4728	adequate skewed dead lights pie	3	good	Last Available: "2010-10"
 4729	moldy small throbbing organ pie	2	crappy	Last Available: "2010-10"
@@ -4692,7 +4692,7 @@
 4744	super-aerosolized triple-colloidal bouncing PlexiPips	0		Effect: "Pasta Oneness", Effect Duration: 58
 4745	enhanced dry Wax Flask	0		Effect: "Cheered Up", Effect Duration: 38
 4746	ionized ghostly Pain Dip	0		Effect: "Woad Warrior", Effect Duration: 49
-4747	moldy huge narrow twirling bone meal	8	crappy	Last Available: "2010-10"
+4747	huge moldy twirling narrow bone meal	8	crappy	Last Available: "2010-10"
 4748	smooth bone aperitif	3	awesome	Last Available: "2010-10"
 4749	baleful bonerang	0		Spell Damage: +25, Last Available: "2010-10"
 4750	razor-sharp bone and arrows	0		Weapon Damage Percent: +25, Last Available: "2010-10"
@@ -4708,7 +4708,7 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	mirror pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
-4763	snack-sized decent pumpkin pie	2	good	Last Available: "2010-11"
+4763	decent snack-sized pumpkin pie	2	good	Last Available: "2010-11"
 4764	drinkable yellow pumpkin beer	3	good	Last Available: "2010-11"
 4765	chilled wet pumpkin juice	0		Effect: "Egg on your Face", Effect Duration: 35, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4726,7 +4726,7 @@
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	special bland blurry CRIMBCOIDS mints	4	decent	Effect: "Badger Underfoot", Effect Duration: 10, Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	small decent CRIMBCOLOAF	2	good	Last Available: "2011-01"
+4820	decent small CRIMBCOLOAF	2	good	Last Available: "2011-01"
 4821	decent circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	shellacked plastic CRIMBCO HQ	0		Damage Reduction: 7, Last Available: "2010-12"
 4823	teal clever plastic fax machine	0		Maximum MP: +20, Last Available: "2010-12"
@@ -4735,7 +4735,7 @@
 4826	huge Annie Oakley's plastic Best Game Ever	0		Critical Hit Percent: +20, Last Available: "2010-12"
 4827	hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	upside-down S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
-4829	ghostly green robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
+4829	green ghostly robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
@@ -4746,10 +4746,10 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	toothsome triangular CRIMBCOOKIE	4	awesome	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	small moldy spinning upside-down square CRIMBCOOKIE	2	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	moldy small upside-down spinning square CRIMBCOOKIE	2	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	occult Samson's wizardly bindlestocking	0		Mysticality: +25, Experience (Muscle): +5, Spell Damage Percent: +25, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
-4843	squat ghostly Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
+4843	ghostly squat Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	wobbly The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
 4845	blurry sinister Uncle Hobo's stocking cap of the overflowing toilet	0		Spell Damage: +10, Stench Spell Damage: +50, Familiar Effect: "atk", Last Available: "2010-12"
 4846	shaking scorching Uncle Hobo's epic beard of doom	0		Hot Damage: +25, Spooky Spell Damage: +50, Single Equip, Last Available: "2010-12"
@@ -4782,7 +4782,7 @@
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	bouncing gaudy key	0		
 4875	spinning BGE merchandise order form	0		Last Available: "2010-12"
-4876	extra-ionized adjusted modified skewed shaking chocolate bath ball	0		Effect: "Boilermade", Effect Duration: 62, Last Available: "2011-01"
+4876	extra-ionized adjusted modified shaking skewed chocolate bath ball	0		Effect: "Boilermade", Effect Duration: 62, Last Available: "2011-01"
 4877	boiled flattened olive bacon bath ball	0		Effect: "Thanksgot", Effect Duration: 55, Last Available: "2011-01"
 4878	diffused bouncing olive incense bath ball	0		Effect: "Creepypasted", Effect Duration: 27, Last Available: "2011-01"
 4879	unsweetened nitrogenated myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Meadulla Oblongota", Effect Duration: 25, Last Available: "2011-01"
@@ -4799,8 +4799,8 @@
 4890	sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	mirror slow jam collection	0		Last Available: "2011-01"
-4893	tumbling cyan BGE shotglass	0		Last Available: "2010-12"
-4894	tasty massive festive sausage	10	awesome	Last Available: "2011-01"
+4893	cyan tumbling BGE shotglass	0		Last Available: "2010-12"
+4894	massive tasty festive sausage	10	awesome	Last Available: "2011-01"
 4895	massive normal holiday cheese log	8	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	perfumed shellacked BGE 'ferocious fruit' shirt	0		Damage Reduction: 7, Stench Resistance: +5, Last Available: "2010-12"
@@ -4845,14 +4845,14 @@
 4942	Knob cake	0		
 4943	Knob cake pan	0		
 4944	shaking blinking Knob batter	0		
-4945	teal bouncing spinning Knob frosting	0		
+4945	teal spinning bouncing Knob frosting	0		
 4946	unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
 4948	upside-down GOTO	0		
 4949	colloidal electrified weremoose spit	0		Effect: "Carrrsmic", Effect Duration: 68
 4950	liquefied abominable blubber	0		Effect: "Cold Throat", Effect Duration: 46
 4951	occult flimsy clipboard	0		Spell Damage Percent: +25, Damage Reduction: 3
-4952	aerosolized shaking olive baggie of sugar	0		Effect: "Human-Orc Hybrid", Effect Duration: 40
+4952	aerosolized olive shaking baggie of sugar	0		Effect: "Human-Orc Hybrid", Effect Duration: 40
 4953	huge reassuring whalebone corset of James Dean	0		Experience (Moxie): +3, Spooky Resistance: +1, Single Equip
 4954	olive oven mitts of the scaredy-cat	0		Monster Level: -15, Single Equip
 4955	adequate overcookie	3	good	
@@ -4903,7 +4903,7 @@
 5000	Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	pulsating Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
-5003	fuchsia squat Alice's Army Foil Coward	0		Last Available: "2011-03"
+5003	squat fuchsia Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	mirror Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
@@ -4914,9 +4914,9 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	low-calorie spoiled wasabi pocky	1	crappy	Last Available: "2011-03"
-5014	low-calorie rotten tobiko pocky	1	crappy	Last Available: "2011-03"
+5014	rotten low-calorie tobiko pocky	1	crappy	Last Available: "2011-03"
 5015	rotten spinning natto pocky	4	crappy	Last Available: "2011-03"
-5016	practically non-alcoholic mediocre narrow wasabi-infused sake	1	decent	Last Available: "2011-03"
+5016	mediocre practically non-alcoholic narrow wasabi-infused sake	1	decent	Last Available: "2011-03"
 5017	lousy watered-down tobiko-infused sake	2	decent	Last Available: "2011-03"
 5018	bad distilled natto-infused sake	5	decent	Last Available: "2011-03"
 5019	altered blurry wasabi marble soda	0		Effect: "Pronounced Potency", Effect Duration: 24, Last Available: "2011-03"
@@ -4924,10 +4924,10 @@
 5021	diffused double-deionized pulsating natto marble soda	0		Effect: "Weird Vibrations", Effect Duration: 31, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	pressed ionized elderly jawbreaker	0		Effect: "The Spy Who Loved XP", Effect Duration: 29, Last Available: "2020-09"
-5024	distilled artisanal tumbling marshmallow flamb&eacute;	5	EPIC	Last Available: "2011-03"
+5024	artisanal distilled tumbling marshmallow flamb&eacute;	5	EPIC	Last Available: "2011-03"
 5025	delicious practically non-alcoholic cranberry schnapps	1	awesome	Last Available: "2011-03"
 5026	drinkable breaded beer	3	good	Last Available: "2011-03"
-5027	strong perfectly mixed narrow soy cordial	5	EPIC	Last Available: "2011-03"
+5027	perfectly mixed strong narrow soy cordial	5	EPIC	Last Available: "2011-03"
 5028	wobbly Usain Bolt's ribald careful astral bludgeon	0		Monster Level: -10, Sleaze Damage: +10, Initiative: +80
 5029	horrifying occult astral shield	0		Spell Damage Percent: +25, Spooky Damage: +25, Damage Reduction: 15
 5030	dog trainer's cool astral chapeau of the boozehound	0		Moxie: +5, Experience (familiar): +1, Booze Drop: +100, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4940,11 +4940,11 @@
 5037	flame-retardant resourceful astral statuette of the pedagogue	0		Experience: +3, Maximum MP: +50, Hot Resistance: +1
 5038	teal family-friendly Lo Pan's experienced astral pistol	0		Experience: +2, Spell Critical Percent: +30, Sleaze Resistance: +1
 5039	groovy slick astral mask	0		Moxie: +10, Moxie Percent: +10
-5040	twirling blue astral pet sweater	0		Familiar Weight: +10
+5040	blue twirling astral pet sweater	0		Familiar Weight: +10
 5041	huge Sinatra's astral shirt of the boozehound of the sweet-tooth	0		Experience (Moxie): +5, Booze Drop: +100, Candy Drop: +100
 5042	narrow Jack Frost's Tesla astral belt	0		Cold Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
 5043	flavorless astral hot dog	3		
-5044	lousy practically non-alcoholic astral pilsner	1		
+5044	practically non-alcoholic lousy astral pilsner	1		
 5045	astral hot dog dinner	0		
 5046	fuchsia astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4965,13 +4965,13 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	half-sized adequate fancy skewed spaghetti con calaveras	2	good	Effect: "Block-Rockin' Beet", Effect Duration: 10, Last Available: "2011-04"
+5065	fancy half-sized adequate skewed spaghetti con calaveras	2	good	Effect: "Block-Rockin' Beet", Effect Duration: 10, Last Available: "2011-04"
 5066	blurry s'more gun	0		Last Available: "2011-04"
 5067	moldy purple popcorn	3	crappy	Last Available: "2011-04"
 5068	delicious chaos popcorn	3	awesome	Last Available: "2011-04"
 5069	family-friendly lard-coated hole of the early riser	0		Sleaze Spell Damage: +25, Sleaze Resistance: +1, Adventures: +7, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	small moldy blue s'more	0	crappy	Last Available: "2011-04"
+5071	moldy small blue s'more	0	crappy	Last Available: "2011-04"
 5072	spinning diamond ring	0		Last Available: "2011-04"
 5073	aged Russian Ice	3	awesome	Last Available: "2011-04"
 5074	blinking crafty clay ashtray	0		Maximum MP: +10, Damage Reduction: 3, Last Available: "2011-05"
@@ -5006,7 +5006,7 @@
 5103	concentrated Nuclear Blastball	0		Effect: "The Power of Negative Thinking", Effect Duration: 15, Last Available: "2011-05"
 5104	energized nitrogenated skewed bouncing fish juice box	0		Effect: "Extra-Wet", Effect Duration: 61, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
-5106	bouncing huge hideous egg	0		Last Available: "2011-05"
+5106	huge bouncing hideous egg	0		Last Available: "2011-05"
 5107	practically non-alcoholic mediocre Jeppson's Malort	1	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	skewed tumbling olive stress ball of Leguizamo	0		Monster Level: +20, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
@@ -5026,7 +5026,7 @@
 5123	ghostly up-at-dawn mirrored aviator shades of Gandalf	0		Spell Critical Percent: +20, Adventures: +5, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
-5126	red mirror Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
+5126	mirror red Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
@@ -5045,7 +5045,7 @@
 5142	pulsating moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	shaking handful of honey	0		
-5145	liquefied ionized wet jittery gray honeypot	0		Effect: "Patience of the Tortoise", Effect Duration: 34
+5145	liquefied ionized wet gray jittery honeypot	0		Effect: "Patience of the Tortoise", Effect Duration: 34
 5146	delicious huge wild honey pie	4	awesome	
 5147	special tolerable honey mead	4	good	Effect: "Greased-Up Familiar", Effect Duration: 10
 5148	Jeselnik's nippy vibrating honey dipper	0		Maximum MP Percent: +10, Cold Damage: +10, Sleaze Damage: +25
@@ -5071,11 +5071,11 @@
 5168	distention pill	0		Last Available: "2011-06"
 5169	spinning spinning yellow elven medi-pack	0		Last Available: "2011-06"
 5170	super-electrified improved blinking transporter transponder	0		Effect: "Lifted Spirits", Effect Duration: 51, Last Available: "2011-06"
-5171	twirling narrow Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
+5171	narrow twirling Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	yellow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	bad strong Saison du Lune	5	decent	Last Available: "2011-06"
-5175	practically non-alcoholic artisanal Moonthril Schnapps	1	EPIC	Last Available: "2011-06"
+5175	artisanal practically non-alcoholic Moonthril Schnapps	1	EPIC	Last Available: "2011-06"
 5176	fancy bad Wrecked Generator	3	decent	Effect: "Curse of the Black Pearl Onion", Effect Duration: 40, Last Available: "2011-06"
 5177	normal Spaghetti with Moonballs	4	good	Last Available: "2011-06"
 5178	bland olive Crepes a la Lune	4	decent	Last Available: "2011-06"
@@ -5100,9 +5100,9 @@
 5197	skewed Marvelous Unitard of courage	0		Spooky Resistance: +3, Softcore Only, Last Available: "2011-07"
 5198	pickled gooey paste	1	EPIC	Effect: "Thunderheart", Effect Duration: 40, Last Available: "2011-08"
 5199	powdered blurry beastly paste	1	decent	Last Available: "2011-08"
-5200	vaporized cyan spinning paste	1	awesome	Last Available: "2011-08"
+5200	vaporized spinning cyan paste	1	awesome	Last Available: "2011-08"
 5201	compressed narrow ectoplasmic paste	1	good	Effect: "Arabian Knighthood", Effect Duration: 20, Last Available: "2011-08"
-5202	dried tumbling narrow greasy paste	1	crappy	Last Available: "2011-08"
+5202	dried narrow tumbling greasy paste	1	crappy	Last Available: "2011-08"
 5203	dried bug paste	1	decent	Last Available: "2011-08"
 5204	powdered narrow hippy paste	1	good	Last Available: "2011-08"
 5205	compressed orc paste	1	EPIC	Effect: "Standard Cheer", Effect Duration: 50, Last Available: "2011-08"
@@ -5128,33 +5128,33 @@
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	delicious enchanted bucket of wine	4	awesome	Effect: "Brain Freeze", Effect Duration: 40, Last Available: "2011-09"
-5228	rotten enchanted ultrafondue	4	crappy	Effect: "Ginger Snapped", Effect Duration: 5, Last Available: "2011-09"
+5228	enchanted rotten ultrafondue	4	crappy	Effect: "Ginger Snapped", Effect Duration: 5, Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
-5231	blue blinking crystal skull	0		Last Available: "2011-09"
+5231	blinking blue crystal skull	0		Last Available: "2011-09"
 5232	borrowed time	0		Last Available: "2011-09"
 5233	box of hammers	0		Last Available: "2011-09"
 5234	MacGyver's shining halo	0		Maximum MP: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5235	furry halo of the storm	0		Maximum MP Percent: +40, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	frosty halo of the sweet-tooth	0		Candy Drop: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	time halo of the boozehound	0		Booze Drop: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	tolerable weak Lumineux Limnio	2	good	Last Available: "2011-09"
+5238	weak tolerable Lumineux Limnio	2	good	Last Available: "2011-09"
 5239	perfectly mixed Morto Moreto	4	EPIC	Last Available: "2011-09"
 5240	drinkable Temps Tempranillo	4	good	Last Available: "2011-09"
 5241	acceptable boozy Bordeaux Marteaux	5	good	Last Available: "2011-09"
-5242	practically non-alcoholic mediocre blurry Fromage Pinotage	1	decent	Last Available: "2011-09"
+5242	mediocre practically non-alcoholic blurry Fromage Pinotage	1	decent	Last Available: "2011-09"
 5243	perfectly mixed Beignet Milgranet	3	EPIC	Last Available: "2011-09"
 5244	lousy Muschat	3	decent	Last Available: "2011-09"
-5245	big bland cool jelly donut	5	decent	Last Available: "2011-09"
+5245	bland big cool jelly donut	5	decent	Last Available: "2011-09"
 5246	decent blurry shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	flavorless occult jelly donut	4	decent	Last Available: "2011-09"
-5248	low-calorie normal thyme jelly donut	1	good	Last Available: "2011-09"
-5249	flavorless jumbo danish	5	decent	Last Available: "2011-09"
+5248	normal low-calorie thyme jelly donut	1	good	Last Available: "2011-09"
+5249	jumbo flavorless danish	5	decent	Last Available: "2011-09"
 5250	moldy blurry smashed danish	3	crappy	Last Available: "2011-09"
-5251	stale jumbo forbidden danish	5	decent	Last Available: "2011-09"
-5252	stale small cool cat claw	2	decent	Last Available: "2011-09"
+5251	jumbo stale forbidden danish	5	decent	Last Available: "2011-09"
+5252	small stale cool cat claw	2	decent	Last Available: "2011-09"
 5253	tasty huge blunt cat claw	10	awesome	Last Available: "2011-09"
-5254	normal massive shadowy cat claw	9	good	Last Available: "2011-09"
+5254	massive normal shadowy cat claw	9	good	Last Available: "2011-09"
 5255	spoiled cheezburger	3	crappy	Last Available: "2011-09"
 5256	miniature rotten toasted brie	2	crappy	Last Available: "2011-09"
 5257	triple-pressed alkaline gray potion of the field gar	0		Effect: "Spiky Hair", Effect Duration: 34, Last Available: "2011-09"
@@ -5165,16 +5165,16 @@
 5262	improved adjusted galvanized spinning cool cat elixir	0		Effect: "Vital", Effect Duration: 68, Last Available: "2011-09"
 5263	ionized extra-tarnished chilled potion of the captain's hammer	0		Effect: "substats.enh", Effect Duration: 45, Last Available: "2011-09"
 5264	double-galvanized potion of X-ray vision	0		Effect: "Inebriate Pride", Effect Duration: 33, Last Available: "2011-09"
-5265	pickled improved pickled shaking mirror twirling potion of the litterbox	0		Effect: "Extra Terrestrial", Effect Duration: 21, Last Available: "2011-09"
+5265	pickled improved pickled mirror shaking twirling potion of the litterbox	0		Effect: "Extra Terrestrial", Effect Duration: 21, Last Available: "2011-09"
 5266	ionized unsweetened twirling potion of animal rage	0		Effect: "In the Limelight", Effect Duration: 50, Last Available: "2011-09"
-5267	colloidal unsweetened purple upside-down potion of punctual companionship	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 59, Last Available: "2011-09"
+5267	colloidal unsweetened upside-down purple potion of punctual companionship	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 59, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	tumbling olive bobcat grenade	0		Last Available: "2011-09"
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	blurry broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
-5274	upside-down lime green boozebomb	0		Last Available: "2011-09"
+5274	lime green upside-down boozebomb	0		Last Available: "2011-09"
 5275	medical-grade hammerus	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-09"
 5276	spinning blunt icepick of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-09"
 5277	greasy fluorescent lightbulb	0		Sleaze Spell Damage: +10, Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	fuchsia spinning newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	spoiled snack-sized cyan phish stick	2	crappy	Last Available: "2011-09"
+5298	snack-sized spoiled cyan phish stick	2	crappy	Last Available: "2011-09"
 5299	spinning mirror aromatic beefy plastic vampire fangs of terror	0		Muscle: +10, Spooky Spell Damage: +10, Stench Resistance: +1, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5221,7 +5221,7 @@
 5318	corrupted Gummy Brains	0		Effect: "Rage of the Reindeer", Effect Duration: 53, Last Available: "2011-10"
 5319	nitrogenated alkaline ghostly Blood 'n' Plenty	0		Effect: "Mmmmmelon", Effect Duration: 20, Last Available: "2011-10"
 5320	alkaline green Lobos Mints	0		Effect: "Crocodile Tear", Effect Duration: 49, Last Available: "2011-10"
-5321	corrupted yellow twirling Sweet Sword	0		Effect: "Amplified Fabulousness", Effect Duration: 65, Last Available: "2011-10"
+5321	corrupted twirling yellow Sweet Sword	0		Effect: "Amplified Fabulousness", Effect Duration: 65, Last Available: "2011-10"
 5322	practically non-alcoholic aged Ecto-Cooler	1	awesome	Last Available: "2011-10"
 5323	watered-down bad Bartles and BRAAAINS wine cooler	2	decent	Last Available: "2011-10"
 5324	acceptable shaking Blood Light	3	good	Last Available: "2011-10"
@@ -5279,7 +5279,7 @@
 5376	wholesome plastic Big Candy of the sewer	0		Maximum HP Percent: +10, Stench Damage: +25, Last Available: "2011-12"
 5377	The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	narrow spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	diluted cyan blurry blinking groose grease	1	decent	Effect: "Christmessy", Effect Duration: 5, Last Available: "2012-12"
+5379	diluted blinking cyan blurry groose grease	1	decent	Effect: "Christmessy", Effect Duration: 5, Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
 5382	olive pearidot	0		Last Available: "2011-11"
@@ -5289,7 +5289,7 @@
 5386	Fonzie's ridiculous belt	0		Experience (Moxie): +1, Last Available: "2011-11"
 5387	olive jittery sinister ridiculous earring	0		Spell Damage: +10, Last Available: "2011-11"
 5388	electrified ridiculous sunglasses	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
-5389	special rotten tiny ridiculous sandwich	1	crappy	Effect: "White Blooded", Effect Duration: 35, Last Available: "2011-11"
+5389	rotten tiny special ridiculous sandwich	1	crappy	Effect: "White Blooded", Effect Duration: 35, Last Available: "2011-11"
 5390	drinkable ridiculous cocktail	3	good	Last Available: "2011-11"
 5391	fireproof brainy zombie monkey necklace	0		Mysticality: +5, Hot Resistance: +3
 5392	Thwaitgold butterfly statuette	0		
@@ -5309,10 +5309,10 @@
 5406	tumbling stanky crafty cane-mail pants of doom	0		Maximum MP: +10, Stench Spell Damage: +25, Spooky Spell Damage: +50, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	artisanal purple Vodka Matryoshka	3	EPIC	Last Available: "2011-12"
 5408	lousy maroon Gin Mint	3	decent	Last Available: "2011-12"
-5409	artisanal fortified narrow Tequiz Navidad	5	EPIC	Last Available: "2011-12"
+5409	fortified artisanal narrow Tequiz Navidad	5	EPIC	Last Available: "2011-12"
 5410	tolerable pulsating Mint Yulep	4	good	Last Available: "2011-12"
 5411	mediocre huge Crimbojito	4	decent	Last Available: "2011-12"
-5412	practically non-alcoholic hand-crafted Sangria de Menthe	1	super ultra mega turbo EPIC	Last Available: "2011-12"
+5412	hand-crafted practically non-alcoholic Sangria de Menthe	1	super ultra mega turbo EPIC	Last Available: "2011-12"
 5413	ghostly candycaine powder	0		Last Available: "2011-12"
 5414	green licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	cold-filtered boiled purple licorice root	0		Effect: "protect.enq", Effect Duration: 23, Last Available: "2011-12"
@@ -5340,7 +5340,7 @@
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	extra-denatured wet blinking fluid of fudge-finding	0		Effect: "Indescribable Flavor", Effect Duration: 42, Last Available: "2011-11"
 5439	jittery fudgepuck	0		Last Available: "2011-11"
-5440	massive normal fudgesicle	6	good	Last Available: "2011-11"
+5440	normal massive fudgesicle	6	good	Last Available: "2011-11"
 5441	blinking wand of fudge control	0		Last Available: "2011-11"
 5442	upside-down The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	ghostly miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5363,7 +5363,7 @@
 5460	greedy careful fudgecycle of the dark arts	0		Spell Damage Percent: +100, Monster Level: -10, Meat Drop: +20, Single Equip, Last Available: "2011-11"
 5461	tumbling fudge cube	0		Last Available: "2011-11"
 5462	pulsating blank fudge mold	0		Last Available: "2011-11"
-5463	cyan blinking Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	blinking cyan Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	non-chilled activated resolution: be wealthier	0		Effect: "Slightly Larger Than Usual", Effect Duration: 16, Last Available: "2012-01"
 5465	liquefied polarized yellow resolution: be happier	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 21, Last Available: "2012-01"
 5466	alkaline Vulcanized blurry resolution: be stronger	0		Effect: "Flamibili Tea", Effect Duration: 31, Last Available: "2012-01"
@@ -5374,8 +5374,8 @@
 5471	improved irradiated tumbling resolution: be more adventurous	0		Effect: "Mushroom Samba", Effect Duration: 58, Last Available: "2012-01"
 5472	denatured extra-Vulcanized resolution: be luckier	0		Effect: "Hella Smooth", Effect Duration: 28, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
-5474	cyan tumbling gummi ingot	0		Last Available: "2011-11"
-5475	mirror cyan gummi ingot	0		Last Available: "2011-11"
+5474	tumbling cyan gummi ingot	0		Last Available: "2011-11"
+5475	cyan mirror gummi ingot	0		Last Available: "2011-11"
 5476	improved cold-filtered jittery gummi salamander	0		Effect: "Pop-eyed", Effect Duration: 37, Last Available: "2011-11"
 5477	anodized huge gummi snake	0		Effect: "Earthen Fist", Effect Duration: 52, Last Available: "2011-11"
 5478	quadruple-electrified gummi canary	0		Effect: "Weapon of Mass Destruction", Effect Duration: 36, Last Available: "2011-11"
@@ -5394,9 +5394,9 @@
 5491	spinning trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	twirling belemnite candy mold	0		Last Available: "2011-11"
-5494	wet skewed blinking gummi trilobite	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 37, Last Available: "2011-11"
+5494	wet blinking skewed gummi trilobite	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 37, Last Available: "2011-11"
 5495	pickled wet gummi ammonite	0		Effect: "Cinnamouth", Effect Duration: 58, Last Available: "2011-11"
-5496	polarized narrow twirling gummi belemnite	0		Effect: "Bastard!", Effect Duration: 64, Last Available: "2011-11"
+5496	polarized twirling narrow gummi belemnite	0		Effect: "Bastard!", Effect Duration: 64, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	tumbling heart of dark chocolate	0		Last Available: "2011-11"
 5499	blinking beefcake's Big Candy's tophat of temperance	0		Muscle: +25, Sleaze Resistance: +5, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	rotten mirror jerky coins	3	crappy	Last Available: "2011-11"
-5507	triple-distilled perfectly mixed Go-Wassail	8	EPIC	Last Available: "2011-11"
+5507	perfectly mixed triple-distilled Go-Wassail	8	EPIC	Last Available: "2011-11"
 5508	concentrated alkaline Uncle Greenspan's Bathroom Finance Guide	0		Effect: "The Dinsey Way", Effect Duration: 24, Last Available: "2011-11"
 5509	improved bottle of bubbles	0		Effect: "Mushroom Might", Effect Duration: 19, Last Available: "2011-11"
 5510	moist super-vacuum-sealed ionized wind-up meatcar	0		Effect: "Serenity", Effect Duration: 64, Last Available: "2011-11"
@@ -5417,7 +5417,7 @@
 5514	blinking Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	pog #01 (spider)	0		Last Available: "2011-11"
 5516	wobbly upside-down pog #02 (Knob goblin)	0		Last Available: "2011-11"
-5517	green wobbly pog #03 (warwelf)	0		Last Available: "2011-11"
+5517	wobbly green pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	shaking pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	improved frozen Atomic Pop	0		Effect: "Turtle Titters", Effect Duration: 44, Last Available: "2020-09"
 5527	olive do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	decent tiny berries of suffering	1	good	Last Available: "2012-12"
+5529	tiny decent berries of suffering	1	good	Last Available: "2012-12"
 5530	vacuum-sealed baobab sap	0		Effect: "Heart of Orange", Effect Duration: 40, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
@@ -5444,7 +5444,7 @@
 5541	ghostly Vivian's Vitamin	0		Last Available: "2012-12"
 5542	cyan pink-belly slapper	0		Last Available: "2012-12"
 5543	manspreader's Sinatra's Leapin' Trousers	0		Experience (Moxie): +5, Monster Level: +10
-5544	practically non-alcoholic acceptable eggnog	1	good	Last Available: "2012-12"
+5544	acceptable practically non-alcoholic eggnog	1	good	Last Available: "2012-12"
 5545	tasty hamhock	3	awesome	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	skewed Clancy's sackbut	0		Last Available: "2012-12"
@@ -5454,7 +5454,7 @@
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	mansplainer's Trusty	0		Monster Level: +15
 5553	wobbly can of Rain-Doh	0		Last Available: "2012-02"
-5554	squat cyan empty Rain-Doh can	0		Last Available: "2012-02"
+5554	cyan squat empty Rain-Doh can	0		Last Available: "2012-02"
 5555	energized denatured fireclutch	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 26
 5556	frightening experienced Rain-Doh wings	0		Experience: +2, Spooky Damage: +5, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
@@ -5465,7 +5465,7 @@
 5562	ghostly nasty Rain-Doh violet bo of the cheetah	0		Stench Damage: +5, Initiative: +60, Softcore Only, Last Available: "2012-02"
 5563	blurry Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	adequate big gray tumbling PB&BP	5	good	
+5565	adequate big tumbling gray PB&BP	5	good	
 5566	spoiled club sandwich	3	crappy	
 5567	small normal corned-beef Reuben	2	good	
 5568	mirror frayed ninja rope	0		
@@ -5473,35 +5473,35 @@
 5570	loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	purple Thwaitgold stag beetle statuette	0		
-5573	practically non-alcoholic bad Drac & Tan	1	decent	Last Available: "2012-03"
+5573	bad practically non-alcoholic Drac & Tan	1	decent	Last Available: "2012-03"
 5574	bad Transylvania Sling	3	decent	Last Available: "2012-03"
 5575	smooth Shot of the Living Dead	4	awesome	Last Available: "2012-03"
-5576	perfectly mixed weak special huge Buttery Knob	2	EPIC	Effect: "Inner Warmth", Effect Duration: 30, Last Available: "2012-03"
+5576	special weak perfectly mixed huge Buttery Knob	2	EPIC	Effect: "Inner Warmth", Effect Duration: 30, Last Available: "2012-03"
 5577	smooth gray Slippery Knob	3	awesome	Last Available: "2012-03"
 5578	acceptable Flaming Knob	3	good	Last Available: "2012-03"
-5579	perfectly mixed triple-distilled Grasshopper	7	EPIC	Last Available: "2012-03"
+5579	triple-distilled perfectly mixed Grasshopper	7	EPIC	Last Available: "2012-03"
 5580	perfectly mixed Locust	3	EPIC	Last Available: "2012-03"
 5581	delicious mirror Plague of Locusts	3	awesome	Last Available: "2012-03"
 5582	strong acceptable ghostly Red Dwarf	5	good	Last Available: "2012-03"
 5583	hand-crafted Golden Mean	3	EPIC	Last Available: "2012-03"
 5584	tolerable Green Giant	3	good	Last Available: "2012-03"
 5585	triple-distilled mediocre Aye Aye	9	decent	Last Available: "2012-03"
-5586	artisanal distilled skewed Aye Aye, Captain	5	EPIC	Last Available: "2012-03"
-5587	watered-down acceptable Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
+5586	distilled artisanal skewed Aye Aye, Captain	5	EPIC	Last Available: "2012-03"
+5587	acceptable watered-down Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
 5588	delicious irresponsibly strong Humanitini	8	awesome	Last Available: "2012-03"
 5589	hand-crafted green shaking More Humanitini than Humanitini	3	EPIC	Last Available: "2012-03"
-5590	triple-distilled artisanal Oh, the Humanitini	10	EPIC	Last Available: "2012-03"
-5591	perfectly mixed triple-distilled spinning tumbling Great Older Fashioned	6	EPIC	Last Available: "2012-03"
+5590	artisanal triple-distilled Oh, the Humanitini	10	EPIC	Last Available: "2012-03"
+5591	triple-distilled perfectly mixed tumbling spinning Great Older Fashioned	6	EPIC	Last Available: "2012-03"
 5592	smooth Fuzzy Tentacle	3	awesome	Last Available: "2012-03"
 5593	drinkable strong mirror Crazymaker	5	good	Last Available: "2012-03"
-5594	weak mediocre enchanted Zoodriver	2	decent	Effect: "Grape Expectations", Effect Duration: 10, Last Available: "2012-03"
-5595	drinkable shaking jittery Sloe Comfortable Zoo	3	good	Last Available: "2012-03"
+5594	mediocre weak enchanted Zoodriver	2	decent	Effect: "Grape Expectations", Effect Duration: 10, Last Available: "2012-03"
+5595	drinkable jittery shaking Sloe Comfortable Zoo	3	good	Last Available: "2012-03"
 5596	watered-down hand-crafted Sloe Comfortable Zoo on Fire	2	EPIC	Last Available: "2012-03"
-5597	practically non-alcoholic hand-crafted Suffering Sinner	1	EPIC	Last Available: "2012-03"
-5598	weak hand-crafted Suppurating Sinner	2	EPIC	Last Available: "2012-03"
-5599	enchanted tolerable Sizzling Sinner	4	good	Effect: "Cravin' for a Ravin'", Effect Duration: 30, Last Available: "2012-03"
+5597	hand-crafted practically non-alcoholic Suffering Sinner	1	EPIC	Last Available: "2012-03"
+5598	hand-crafted weak Suppurating Sinner	2	EPIC	Last Available: "2012-03"
+5599	tolerable enchanted Sizzling Sinner	4	good	Effect: "Cravin' for a Ravin'", Effect Duration: 30, Last Available: "2012-03"
 5600	tolerable fancy Firewater	3	good	Effect: "Always In Motion", Effect Duration: 50, Last Available: "2012-03"
-5601	boozy drinkable Earth and Firewater	5	good	Last Available: "2012-03"
+5601	drinkable boozy Earth and Firewater	5	good	Last Available: "2012-03"
 5602	acceptable Earth, Wind and Firewater	4	good	Last Available: "2012-03"
 5603	tolerable practically non-alcoholic Slimosa	1	good	Last Available: "2012-03"
 5604	extra-dry mediocre Extra-slimy Slimosa	5	decent	Last Available: "2012-03"
@@ -5509,21 +5509,21 @@
 5606	practically non-alcoholic drinkable Cement Mixer	1	good	Last Available: "2012-03"
 5607	tolerable Jackhammer	4	good	Last Available: "2012-03"
 5608	drinkable blinking Dump Truck	3	good	Last Available: "2012-03"
-5609	bad high-proof Fauna Libre	8	decent	Last Available: "2012-03"
+5609	high-proof bad Fauna Libre	8	decent	Last Available: "2012-03"
 5610	watered-down artisanal Chakra Libre	2	EPIC	Last Available: "2012-03"
 5611	mediocre Aura Libre	4	decent	Last Available: "2012-03"
-5612	weak lousy Sazerorc	2	decent	Last Available: "2012-03"
+5612	lousy weak Sazerorc	2	decent	Last Available: "2012-03"
 5613	aged pulsating Sazuruk-hai	4	awesome	Last Available: "2012-03"
 5614	aged boozy Flaming Sazerorc	5	awesome	Last Available: "2012-03"
 5615	drinkable weak spinning Green Velvet	2	good	Last Available: "2012-03"
 5616	aged high-proof Green Muslin	6	awesome	Last Available: "2012-03"
 5617	lousy Green Burlap	4	decent	Last Available: "2012-03"
-5618	lousy triple-distilled green Mohobo	8	decent	Last Available: "2012-03"
+5618	triple-distilled lousy green Mohobo	8	decent	Last Available: "2012-03"
 5619	hand-crafted Moonshine Mohobo	3	EPIC	Last Available: "2012-03"
 5620	hand-crafted extra-dry upside-down Flaming Mohobo	5	EPIC	Last Available: "2012-03"
 5621	strong hand-crafted Drunken Philosopher	5	EPIC	Last Available: "2012-03"
-5622	irresponsibly strong bad Drunken Neurologist	10	decent	Last Available: "2012-03"
-5623	watered-down artisanal Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
+5622	bad irresponsibly strong Drunken Neurologist	10	decent	Last Available: "2012-03"
+5623	artisanal watered-down Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
 5624	watered-down mediocre Dark & Starry	2	decent	Last Available: "2012-03"
 5625	lousy spirit-forward red Black Hole	5	decent	Last Available: "2012-03"
 5626	drinkable weak Event Horizon	2	good	Last Available: "2012-03"
@@ -5536,9 +5536,9 @@
 5633	watered-down bad purple Caipiranha	2	decent	Last Available: "2012-03"
 5634	acceptable Flying Caipiranha	4	good	Last Available: "2012-03"
 5635	perfectly mixed watered-down Flaming Caipiranha	2	EPIC	Last Available: "2012-03"
-5636	weak tolerable Punchplanter	2	good	Last Available: "2012-03"
-5637	practically non-alcoholic aged Doublepunchplanter	1	awesome	Last Available: "2012-03"
-5638	mediocre watered-down Haymaker	2	decent	Last Available: "2012-03"
+5636	tolerable weak Punchplanter	2	good	Last Available: "2012-03"
+5637	aged practically non-alcoholic Doublepunchplanter	1	awesome	Last Available: "2012-03"
+5638	watered-down mediocre Haymaker	2	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	big bland fungus	5	decent	
@@ -5555,7 +5555,7 @@
 5652	upside-down Monster Manuel	0		Free Pull
 5653	lime green key-o-tron	0		
 5654	stale nailswurst	3	decent	
-5655	spirit-forward perfectly mixed used beer	5	EPIC	
+5655	perfectly mixed spirit-forward used beer	5	EPIC	
 5656	spinning Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5570,7 +5570,7 @@
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
-5670	stale tumbling bouncing fettucini &eacute;pines Inconnu	3	decent	
+5670	stale bouncing tumbling fettucini &eacute;pines Inconnu	3	decent	
 5671	artisanal gray slap and slap again	3	EPIC	
 5672	huge gunpowder burrito	2	good	
 5673	blinking teal beery blood	2	good	
@@ -5594,7 +5594,7 @@
 5691	pacification grenade	0		
 5692	mirror coward's quantum disintegrator pistol	0		Monster Level: -20
 5693	grievous phase-tuned shield generator belt	0		Weapon Damage Percent: +50, Single Equip
-5694	spinning wobbly skewed Thwaitgold woollybear statuette	0		
+5694	skewed wobbly spinning Thwaitgold woollybear statuette	0		
 5695	asbestos-lined bugbear detector	0		Hot Resistance: +5, Single Equip
 5696	bugbear purification pill	0		
 5697	1 Meat	0		
@@ -5627,8 +5627,8 @@
 5726	smooth hot daub bun of terror	0		Moxie: +15, Spooky Spell Damage: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5727	avaricious greedy hot daub stand	0		Meat Drop: 50, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	therapeutic cool foot-long hot daub	0		Moxie: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2012-07"
-5729	yellow ghostly ballpark hot daub	0		Last Available: "2012-07"
-5730	rotten enchanted olive angst burger	3	crappy	Effect: "Hammered", Effect Duration: 45
+5729	ghostly yellow ballpark hot daub	0		Last Available: "2012-07"
+5730	enchanted rotten olive angst burger	3	crappy	Effect: "Hammered", Effect Duration: 45
 5731	lousy practically non-alcoholic mirror 5-hour acrimony	1	decent	
 5732	cyan blank note	0		
 5733	eerily silent box	0		
@@ -5639,12 +5639,12 @@
 5738	Camp Scout backpack of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	stale miniature bag of GORP	2	decent	Last Available: "2012-07"
-5741	hand-crafted strong water purification pills	5	EPIC	Last Available: "2012-07"
+5741	strong hand-crafted water purification pills	5	EPIC	Last Available: "2012-07"
 5742	teal Camp Scout pup tent	0		Last Available: "2012-07"
 5743	bad CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
 5744	toothsome big bag of GORF	5	awesome	Last Available: "2012-07"
 5745	upside-down CSA discount card	0		Last Available: "2020-09"
-5746	rotten bite-sized ghostly bag of QWOP	1	crappy	Last Available: "2012-07"
+5746	bite-sized rotten ghostly bag of QWOP	1	crappy	Last Available: "2012-07"
 5747	adjusted CSA bravery badge	0		Effect: "Unrunnable Face", Effect Duration: 22, Last Available: "2012-07"
 5748	shaking CSA all-purpose soap	0		Last Available: "2012-07"
 5749	strong acceptable CSA cheerfulness ration	5	good	Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	super-sized decent decent brain	5	good	
 5754	normal massive shaking good brain	7	good	
 5755	bland half-sized boss brain	2	decent	
-5756	thick toothsome ghostly hunter brain	5	awesome	
+5756	toothsome thick ghostly hunter brain	5	awesome	
 5758	chaotic steel-toed Staff of Holiday Sensations of doom	0		Damage Reduction: 9, Spell Critical Percent: +10, Spooky Spell Damage: +50, Last Available: "2011-11"
 5759	rock-hard staff of courage	0		Damage Reduction: 5, Spooky Resistance: +3
 5760	twirling executive foul-smelling manspreader's staff	0		Monster Level: +10, Stench Damage: +10, Meat Drop: +40
@@ -5702,14 +5702,14 @@
 5803	extra-improved tumbling White Chocolate Golem Seeds	0		Effect: "No Vertigo", Effect Duration: 26
 5804	enhanced Shivering Ch&egrave;vre	0		Effect: "Corona de la Salsa", Effect Duration: 55
 5805	polarized super-improved breath mint	0		Effect: "Bricked-In", Effect Duration: 34
-5806	triple-adjusted tarnished pulsating blue spinning muesli	0		Effect: "Joy", Effect Duration: 19
+5806	triple-adjusted tarnished spinning blue pulsating muesli	0		Effect: "Joy", Effect Duration: 19
 5807	alkaline electrified unsweetened glass of warm milk	0		Effect: "Quantum of Moxie", Effect Duration: 32
 5808	modified huge glass of gnat milk	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 62
 5809	magnetized flattened upside-down Knob Goblin Mutagen	0		Effect: "Boon of She-Who-Was", Effect Duration: 20
 5810	diffused blurry Tears of the Quiet Healer	0		Effect: "Sleazy Weapon", Effect Duration: 41
 5811	cold-filtered cyan tube of lipstick	0		Effect: "Indescribable Flavor", Effect Duration: 43
 5812	ionized deionized shaking skelelton spine	0		Effect: "Starry-Eyed", Effect Duration: 68
-5813	improved improved pulsating mirror smut orc sunglasses	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 58
+5813	improved improved mirror pulsating smut orc sunglasses	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 58
 5814	dry flattened blob of acid	0		Effect: "Slime Time", Effect Duration: 16
 5815	denatured flayed mind	0		Effect: "Protection from Bad Stuff", Effect Duration: 52
 5816	quadruple-quantum double-tarnished wobbly kobold kibble	0		Effect: "Boon of the War Snapper", Effect Duration: 25
@@ -5737,7 +5737,7 @@
 5838	triple-irradiated corrupted ghostly Iiti Kitty Gumdrop	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 66
 5839	ionized shaking squat ravenous eye	0		Effect: "Okee-Dokee Computer", Effect Duration: 66
 5840	activated blurry Rogue Windmill Rouge	0		Effect: "Eagle Eyes", Effect Duration: 48
-5841	magnetized warmed gray squat A muse-bouche	0		Effect: "Block-Rockin' Beet", Effect Duration: 32
+5841	magnetized warmed squat gray A muse-bouche	0		Effect: "Block-Rockin' Beet", Effect Duration: 32
 5842	unsweetened altered toothbrush	0		Effect: "Thicker, Sicker", Effect Duration: 32
 5843	colloidal pirate cream pie	0		Effect: "Stench Jellied", Effect Duration: 66
 5844	ionized boiled blinking una poca de gracia	0		Effect: "One For Tea", Effect Duration: 39
@@ -5747,14 +5747,14 @@
 5848	wet Vulcanized gray Bangyomaman battle juice	0		Effect: "Ham-Fisted", Effect Duration: 34
 5849	polymerized blurry handyman &quot;hand soap&quot;	0		Effect: "Black Eyes", Effect Duration: 42
 5850	Vulcanized polymerized space marine flash grenade	0		Effect: "Nasty, Nasty Breath", Effect Duration: 68
-5851	alkaline super-dry shaking pulsating temporary tribal tattoo	0		Effect: "Ghostly Shell", Effect Duration: 65
+5851	alkaline super-dry pulsating shaking temporary tribal tattoo	0		Effect: "Ghostly Shell", Effect Duration: 65
 5852	deionized moist oil-filled donut	0		Effect: "Electrolit Up", Effect Duration: 40
 5853	altered cold-filtered twirling skewed stick-on gnome beard	0		Effect: "Spiro Gyro", Effect Duration: 12
 5854	ionized irradiated bouncing BRICKO stud	0		Effect: "Spiro Gyro", Effect Duration: 41
-5855	adjusted huge pulsating twirling Osk'r Chow	0		Effect: "Influence of Sphere", Effect Duration: 24
+5855	adjusted huge twirling pulsating Osk'r Chow	0		Effect: "Influence of Sphere", Effect Duration: 24
 5856	super-cold-filtered dry yellow Scuba Snack	0		Effect: "Proprie Tea", Effect Duration: 31
 5857	cold-filtered huge grey cube	0		Effect: "Blood-Gorged", Effect Duration: 33
-5858	dry irradiated denatured tumbling olive votive candle	0		Effect: "Vital", Effect Duration: 39
+5858	dry irradiated denatured olive tumbling votive candle	0		Effect: "Vital", Effect Duration: 39
 5859	unsweetened skewed booby trap	0		Effect: "Magically Fingered", Effect Duration: 34
 5860	vacuum-sealed anodized Agent Corrigan's cigarette	0		Effect: "You Can Taste the Darkness", Effect Duration: 51
 5861	ionized good ash	0		Effect: "Mer-kindliness", Effect Duration: 32
@@ -5762,7 +5762,7 @@
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	bouncing papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	electrified papier-mochi	0		Effect: "Balls of Ectoplasm", Effect Duration: 22, Last Available: "2012-09"
-5866	improved yellow squat papier-m&acirc;chaeranthera	0		Effect: "Extra-Sharp Weapon", Effect Duration: 33, Last Available: "2012-09"
+5866	improved squat yellow papier-m&acirc;chaeranthera	0		Effect: "Extra-Sharp Weapon", Effect Duration: 33, Last Available: "2012-09"
 5867	wet mirror papier-m&acirc;ch&eacute; toothpicks	0		Effect: "items.enh", Effect Duration: 66, Last Available: "2012-09"
 5868	energetic thinker's papier-m&acirc;ch&eacute;te	0		Mysticality: +10, Maximum MP Percent: +20, Last Available: "2012-09"
 5869	twirling dance instructor's papier-m&acirc;chine gun of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Last Available: "2012-09"
@@ -5873,7 +5873,7 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	pulsating record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	Samson's silent beret of incineration of the overflowing toilet	0		Experience (Muscle): +5, Hot Spell Damage: +50, Stench Spell Damage: +50, Familiar Effect: "1xVolley, cap 3"
-5978	enchanted tasty spinning slice of pizza	3	awesome	Effect: "Kissed By Fire", Effect Duration: 30, Last Available: "2013-02"
+5978	tasty enchanted spinning slice of pizza	3	awesome	Effect: "Kissed By Fire", Effect Duration: 30, Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	yellow cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
@@ -5881,11 +5881,11 @@
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	rosewater-soaked Lo Pan's cloth cap of the bloodbag	0		Maximum HP: +100, Spell Critical Percent: +30, Stench Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	steel-toed forbidden Newton's iron dagger	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Damage Reduction: 9, Last Available: "2013-02"
-5986	immense decent hamburger	8	good	Last Available: "2013-02"
+5986	decent immense hamburger	8	good	Last Available: "2013-02"
 5987	pulsating dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	mirror mirror potion	0		Last Available: "2013-02"
-5990	acceptable irresponsibly strong jittery bottle of wine	8	good	Last Available: "2013-02"
+5990	irresponsibly strong acceptable jittery bottle of wine	8	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
 5992	therapeutic cool iron helmet of James Dean	0		Moxie: +5, Experience (Moxie): +3, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	executive knitted lard-coated steel sword	0		Sleaze Spell Damage: +25, Cold Resistance: +3, Meat Drop: +40, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	dry blurry orcish hand lotion	0		Effect: "Feeling No Pain", Effect Duration: 47
 6016	flattened orcish rubber	0		Effect: "Egg on your Face", Effect Duration: 66
 6017	irradiated improved upside-down twirling orcish nailing lube	0		Effect: "Adorable Lookout", Effect Duration: 31
-6018	high-proof lousy mirror backwoods screwdriver	7	decent	
+6018	lousy high-proof mirror backwoods screwdriver	7	decent	
 6019	loadstone of Leguizamo	0		Monster Level: +20
 6020	executive Claybender glasses of incineration	0		Hot Spell Damage: +50, Meat Drop: +40, Single Equip
 6021	fireproof smartaleck's Duskwalker fangs	0		Moxie Percent: +30, Hot Resistance: +3
@@ -5933,7 +5933,7 @@
 6035	oxidized vial of The Glistening	0		Effect: "Inscrutable exoskeleton", Effect Duration: 41
 6036	acceptable artisanal limoncello	3	good	
 6037	wobbly ginger ale	0		
-6038	moldy low-calorie narrow incredible pizza	1	crappy	
+6038	low-calorie moldy narrow incredible pizza	1	crappy	
 6039	oil cap of dire peril of the sewer	0		Weapon Damage: +20, Stench Damage: +25, Familiar Effect: "cap 28"
 6040	zippy oil lamp of vim and vigor	0		Maximum HP Percent: +50, Initiative: +20
 6041	teal prompt oil slacks	0		Adventures: +3, Familiar Effect: "1xPotato, cap 30"
@@ -5946,12 +5946,12 @@
 6048	executive cool Misty Robe	0		Moxie: +5, Meat Drop: +40
 6049	fuchsia baleful savvy Misty Cape of doom	0		Mysticality Percent: +20, Spell Damage: +25, Spooky Spell Damage: +50
 6050	woimbook	0		Familiar Weight: +5
-6051	pulsating ghostly blinking green Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
+6051	pulsating green ghostly blinking Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	special rotten blurry Taco Dan's Taco Stand Taco	3	crappy	Effect: "Penguinny Flavor", Effect Duration: 5, Last Available: "2012-12"
 6053	drinkable Taco Dan's Taco Stand Chimichangarita	3	good	Last Available: "2012-12"
 6054	triple-polymerized concentrated altered Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Butt-Rock Hair", Effect Duration: 34, Last Available: "2012-12"
 6055	blinking psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	horrifying groovy Meatcleaver	0		Moxie Percent: +10, Spooky Damage: +25, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2012-12"
 6059	Crimbo stogie-scented room odorizer of the pedagogue	0		Experience: +3, Last Available: "2012-12"
@@ -5960,7 +5960,7 @@
 6062	deadly Crimbo light-up Rudolph doll	0		Weapon Damage: +5, Last Available: "2012-12"
 6063	lime green bouncing healthy Super Crimboman Ultra Mega Hypersword	0		Maximum HP Percent: +20, Last Available: "2012-12"
 6064	sharp tin strip	0		
-6065	mirror blurry wad of spider silk	0		
+6065	blurry mirror wad of spider silk	0		
 6066	goblin collarbone	0		
 6067	mansplainer's Truthsayer of horror	0		Monster Level: +15, Spooky Spell Damage: +25, Last Available: "2013-12"
 6068	loose blade	0		
@@ -6048,7 +6048,7 @@
 6151	carrot nose	0		Last Available: "2013-01"
 6152	adequate carrot cake	4	good	Last Available: "2013-01"
 6153	bad carrot claret	3	decent	Last Available: "2013-01"
-6154	altered pulsating ghostly carrot juice	1	crappy	Last Available: "2013-01"
+6154	altered ghostly pulsating carrot juice	1	crappy	Last Available: "2013-01"
 6155	red pixel power cell	0		Last Available: "2013-12"
 6156	blinking flickering pixel	0		Last Available: "2013-12"
 6157	green scandalous shellacked Byte	0		Damage Reduction: 7, Sleaze Damage: +5, Last Available: "2013-12"
@@ -6064,9 +6064,9 @@
 6167	Fonzie's ornamental sextant	0		Experience (Moxie): +1, Last Available: "2013-12"
 6168	Jeselnik's Bloodbath of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Last Available: "2013-12"
 6169	artisanal distilled Hundred Headed IPA	5	EPIC	Last Available: "2013-12"
-6170	decent big chum	5	good	Last Available: "2013-12"
+6170	big decent chum	5	good	Last Available: "2013-12"
 6171	pressed flattened crude crudit&eacute;s	0		Effect: "Dreadful Heat", Effect Duration: 56
-6172	chilled cyan squat candy crayons	0		Effect: "Badger Underfoot", Effect Duration: 26, Last Available: "2020-09"
+6172	chilled squat cyan candy crayons	0		Effect: "Badger Underfoot", Effect Duration: 26, Last Available: "2020-09"
 6173	mansplainer's shellacked pixel grappling hook	0		Damage Reduction: 7, Monster Level: +15
 6174	huge squat GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6080,14 +6080,14 @@
 6183	cosmic fruit	0		
 6184	lard-coated gravedigger's Jarlsberg's hat of horror	0		Spooky Damage: +10, Spooky Spell Damage: +25, Sleaze Spell Damage: +25
 6185	flavorless consummate hard-boiled egg	3	decent	
-6186	immense bland skewed consummate fried egg	9	decent	
-6187	jumbo stale red consummate egg salad	5	decent	
+6186	bland immense skewed consummate fried egg	9	decent	
+6187	stale jumbo red consummate egg salad	5	decent	
 6188	moldy consummate bagel	3	crappy	
 6189	toothsome pulsating consummate sliced bread	3	awesome	
-6190	jumbo bland consummate hot dog bun	5	decent	
+6190	bland jumbo consummate hot dog bun	5	decent	
 6191	flavorless wobbly consummate brownie	4	decent	
 6192	moldy big consummate toast	5	crappy	
-6193	tolerable practically non-alcoholic passable stout	1	good	
+6193	practically non-alcoholic tolerable passable stout	1	good	
 6194	diet stale consummate soup	1	decent	
 6195	adequate consummate corn chips	3	good	
 6196	adequate consummate salad	3	good	
@@ -6097,7 +6097,7 @@
 6200	rotten super-sized consummate melted cheese	5	crappy	
 6201	adequate cyan consummate bacon	3	good	
 6202	diet spoiled squat consummate meatloaf	1	crappy	
-6203	normal miniature consummate steak	2	good	
+6203	miniature normal consummate steak	2	good	
 6204	rotten consummate cuts	3	crappy	
 6205	miniature adequate blinking consummate frankfurter	2	good	
 6206	moldy consummate french fries	3	crappy	
@@ -6106,24 +6106,24 @@
 6209	rotten low-calorie consummate ice cream	1	crappy	
 6210	flavorless red consummate whipped cream	4	decent	
 6211	special flavorless consummate cream	3	decent	Effect: "Gummiskin", Effect Duration: 40
-6212	massive special moldy consummate strawberries	6	crappy	Effect: "Heart of Orange", Effect Duration: 35
+6212	moldy massive special consummate strawberries	6	crappy	Effect: "Heart of Orange", Effect Duration: 35
 6213	stale consummate sorbet	3	decent	
-6214	weak drinkable adequate rum	2	good	
-6215	watered-down hand-crafted mediocre lager	2	EPIC	
+6214	drinkable weak adequate rum	2	good	
+6215	hand-crafted watered-down mediocre lager	2	EPIC	
 6216	rotten immaculate grilled cheese	3	crappy	
 6217	normal immaculate ice cream sandwich	4	good	
-6218	decent big twirling immaculate hot dog	5	good	
+6218	big decent twirling immaculate hot dog	5	good	
 6219	flavorless thick yellow ghostly immaculate egg salad sandwich	5	decent	
 6220	bland red perfect sandwich	4	decent	
-6221	moldy miniature perfect chef salad	2	crappy	
+6221	miniature moldy perfect chef salad	2	crappy	
 6222	rotten narrow perfect breakfast	4	crappy	
-6223	gigantic bland yellow sublime deluxe hot dog	6	decent	
+6223	bland gigantic yellow sublime deluxe hot dog	6	decent	
 6224	moldy sublime stew	4	crappy	
 6225	bland sublime nachos	3	decent	
 6226	yummy tiny cyan Ultimate Breakfast Sandwich	1	awesome	
 6227	rotten super-sized Loaded Baked Potato	5	crappy	
 6228	decent Omega Sundae	4	good	
-6229	artisanal watered-down yellow bouncing Das Sauerlager	2	EPIC	
+6229	watered-down artisanal yellow bouncing Das Sauerlager	2	EPIC	
 6230	smooth watered-down Bologna Lambic	2	awesome	
 6231	lousy Vodka Dog	3	decent	
 6232	bad yellow Disappointed Russian	3	decent	
@@ -6142,7 +6142,7 @@
 6246	quadruple-chilled alkaline demonic surgical gloves	0		Effect: "Souper Vengeful", Effect Duration: 40
 6247	denatured adjusted extra-colloidal pulsating clip-on ninja tie	0		Effect: "Crimbo Nostalgia", Effect Duration: 61
 6248	irradiated ghostly gamer slurry	0		Effect: "Impregnably Delicious", Effect Duration: 60
-6249	teal ghostly dungeoneering kit	0		Last Available: "2013-02"
+6249	ghostly teal dungeoneering kit	0		Last Available: "2013-02"
 6250	aromatic gravedigger's electrified Socratic numberwang of the ox of horror	0		Muscle: +20, Experience (Mysticality): +1, Spooky Damage: +10, Spooky Spell Damage: +25, Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 6251	ionized scroll of Protection from Bad Stuff	0		Effect: "Going Ape", Effect Duration: 63, Last Available: "2013-02"
 6252	moist pickled scroll of Puddingskin	0		Effect: "Morninja", Effect Duration: 12, Last Available: "2013-02"
@@ -6167,7 +6167,7 @@
 6271	massive dumbbell	0		
 6272	huge Temple Grandin's penguin keychain of the early riser	0		Familiar Weight: +7, Adventures: +7, Damage Reduction: 10
 6273	polarized dry wobbly O'RLY manual	0		Effect: "Super-Electrified", Effect Duration: 28
-6274	drinkable watered-down open sauce	2	good	
+6274	watered-down drinkable open sauce	2	good	
 6275	turkey leg of Calamity Jane of chilblains	0		Critical Hit Percent: +15, Cold Damage: +25
 6276	smooth shaking Ye Olde Meade	3	awesome	
 6277	energized shaking Ye Olde Bawdy Limerick	0		Effect: "Crying, Dying", Effect Duration: 18
@@ -6188,7 +6188,7 @@
 6292	huge stanky Lo Pan's safety pin	0		Spell Critical Percent: +30, Stench Spell Damage: +25
 6293	flavorless squat stolen sushi	3	decent	
 6294	ghostly very overdue library book	0		
-6295	narrow cyan drum 'n' bass 'n' drum 'n' bass record	0		
+6295	cyan narrow drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	blurry fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	Thwaitgold firefly statuette	0		
@@ -6202,7 +6202,7 @@
 6306	Cosmic Calorie	0		Last Available: "2013-03"
 6307	ionized pulsating celestial olive oil	0		Effect: "Industrial Strength Starch", Effect Duration: 60, Last Available: "2013-03"
 6308	corrupted altered jittery celestial carrot juice	0		Effect: "Category", Effect Duration: 64, Last Available: "2013-03"
-6309	cold-filtered wobbly spinning celestial au jus	0		Effect: "Ooh, Sour!", Effect Duration: 28, Last Available: "2013-03"
+6309	cold-filtered spinning wobbly celestial au jus	0		Effect: "Ooh, Sour!", Effect Duration: 28, Last Available: "2013-03"
 6310	ionized aerosolized narrow celestial squid ink	0		Effect: "Busy Bein' Delicious", Effect Duration: 69, Last Available: "2013-03"
 6311	foul-smelling Uncle Buck	0		Stench Damage: +10, Softcore Only
 6312	narrow crate of fish meat	0		
@@ -6212,7 +6212,7 @@
 6316	lime green flame-wreathed hardened deep six-shooter	0		Damage Reduction: 3, Hot Spell Damage: +10
 6317	chaotic sea chaps of the early riser	0		Spell Critical Percent: +10, Adventures: +7, Familiar Effect: "atk, 2xBarrr"
 6318	greasy arcane researcher's sea holster of the cheetah	0		Experience Percent (Mysticality): +10, Sleaze Spell Damage: +10, Initiative: +60, Single Equip
-6319	aerosolized flattened blue blurry shavin' razor	0		Effect: "Fiery Spirit", Effect Duration: 36
+6319	aerosolized flattened blurry blue shavin' razor	0		Effect: "Fiery Spirit", Effect Duration: 36
 6320	red energetic long-forgotten necklace	0		Maximum MP Percent: +20
 6321	pulsating pearl	0		
 6322	red sea lace	0		
@@ -6263,10 +6263,10 @@
 6367	diffused shaking pulled taffy	0		Effect: "Tasting the Rainbow", Effect Duration: 16, Last Available: "2013-04"
 6368	gray Mer-kin hallpass	0		
 6369	lump of clay	0		
-6370	pulsating spinning twisted piece of wire	0		
-6371	boozy hand-crafted can of the cheapest beer	5	EPIC	
-6372	drinkable weak bottle of fruity &quot;wine&quot;	2	good	
-6373	practically non-alcoholic aged olive single swig of vodka	1	awesome	
+6370	spinning pulsating twisted piece of wire	0		
+6371	hand-crafted boozy can of the cheapest beer	5	EPIC	
+6372	weak drinkable bottle of fruity &quot;wine&quot;	2	good	
+6373	aged practically non-alcoholic olive single swig of vodka	1	awesome	
 6374	angry inch	0		
 6375	wholesome testy toolbox	0		Maximum HP Percent: +10
 6376	Jick-o-User	0		
@@ -6294,7 +6294,7 @@
 6399	cold-filtered dry blinking Boss Drops	0		Effect: "Piratey Flavor", Effect Duration: 11
 6400	Mer-kin lunchbox	0		
 6401	altered galvanized jittery tear	0		Effect: "Pride of the Vampire", Effect Duration: 56
-6402	enhanced cold-filtered activated jittery shaking jagged tooth	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 24
+6402	enhanced cold-filtered activated shaking jittery jagged tooth	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 24
 6403	concentrated extra-ionized aerosolized mirror grisly shell fragment	0		Effect: "Extra-Wet", Effect Duration: 33
 6404	energized cyan blurry violent pastilles	0		Effect: "Sweet Tooth", Effect Duration: 58
 6405	denatured worst candy	0		Effect: "Just the Brown Ones", Effect Duration: 53
@@ -6314,9 +6314,9 @@
 6419	cold-filtered wet lime green moth dust	0		Effect: "Appeteyes", Effect Duration: 68
 6420	modified dry glob of spoiled mayo	0		Effect: "Chalk Outline", Effect Duration: 19
 6421	tonic djinn	0		
-6422	flavorless huge gray vampire chowder	10	decent	
+6422	huge flavorless gray vampire chowder	10	decent	
 6423	twirling Tales of Dread	0		Free Pull
-6424	pulsating teal Dreadsylvanian skeleton key	0		
+6424	teal pulsating Dreadsylvanian skeleton key	0		
 6425	blurry Official Seal of Dreadsylvania	0		
 6426	stale Dreadsylvanian stew	3	decent	
 6427	perfectly mixed Dreadsylvanian	4	EPIC	
@@ -6325,7 +6325,7 @@
 6430	mirror studded Fonzie's dreadful fedora	0		Experience (Moxie): +1, Damage Absorption: +80, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	clever dreadful sweater	0		Maximum MP: +20, Kruegerand Drop: 5
 6432	bouncing Newton's dreadful glove	0		Experience (Mysticality): +3, Kruegerand Drop: 5
-6433	spinning teal ghostly Freddy Kruegerand	0		
+6433	spinning ghostly teal Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
 6435	Mark of the Werewolf	0		
 6436	Mark of the Zombie	0		
@@ -6360,11 +6360,11 @@
 6465	lard-coated quilted Mayor Ghost's gavel of Flo-Jo	0		Damage Absorption: +40, Sleaze Spell Damage: +25, Initiative: +100, Conditional Skill (Equipped): "Hammer Ghost"
 6466	extremely unsafe Herculean Mayor Ghost's sash of bravery	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Spooky Resistance: +5, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	yummy fancy snack-sized ghost pepper	2	awesome	Effect: "Orchid Blood", Effect Duration: 20
+6468	snack-sized yummy fancy ghost pepper	2	awesome	Effect: "Orchid Blood", Effect Duration: 20
 6469	chilly Van der Graaf smartaleck's Thunkula's drinking cap	0		Moxie Percent: +30, Cold Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	reassuring Jack Frost's brainy Drunkula's cape	0		Mysticality: +5, Cold Spell Damage: +50, Spooky Resistance: +1, Class: "Sauceror"
 6471	hardened Drunkula's silky pants of Flo-Jo of the early riser	0		Damage Reduction: 3, Initiative: +100, Adventures: +7, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
-6472	huge squat pulsating Drunkula's bell	0		
+6472	pulsating huge squat Drunkula's bell	0		
 6473	squat Jeselnik's Samson's experienced Drunkula's ring of haze	0		Experience: +2, Experience (Muscle): +5, Sleaze Damage: +25, Avoid Attack: 1, Single Equip
 6474	mansplainer's Drunkula's wineglass	0		Monster Level: +15
 6475	hand-crafted bottle of Bloodweiser	4	EPIC	
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	ghostly stinking agaricus	0		
-6488	immense flavorless gray Dreadsylvanian shepherd's pie	8	decent	
+6488	flavorless immense gray Dreadsylvanian shepherd's pie	8	decent	
 6489	blue shaking music box parts	0		
 6490	upside-down unwound mechanical songbird	0		
 6491	teal tailfeathers	0		Familiar Weight: +5
@@ -6394,7 +6394,7 @@
 6499	moon-amber	0		
 6500	skewed polished moon-amber	0		
 6501	aromatic therapeutic Newton's moon-amber necklace	0		Experience (Mysticality): +3, Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip
-6502	cyan twirling Dreadsylvanian seed pod	0		
+6502	twirling cyan Dreadsylvanian seed pod	0		
 6503	ghost pencil	0		
 6504	crafty boxer's hangman's hood of Calamity Jane	0		Muscle Percent: +10, Maximum MP: +10, Critical Hit Percent: +15
 6505	spinning lightning-fast ring finger ring of terror of courage	0		Spooky Spell Damage: +10, Spooky Resistance: +3, Initiative: +40, Single Equip
@@ -6409,7 +6409,7 @@
 6514	bouncing yellow Sinatra's snowstick	0		Experience (Moxie): +5
 6515	olive eerie fetish of the businessman	0		Meat Drop: +50, Single Equip
 6516	mediocre olive stinkwater	3	decent	
-6517	tumbling gray mirror dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
+6517	gray tumbling mirror dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	bite-sized stale accidental mutton	1	decent	
 6519	frightening drafty drawers of the sewer	0		Stench Damage: +25, Spooky Damage: +5, Familiar Effect: "1.5xVolley"
 6520	friendly groovy wolfskull mask	0		Moxie Percent: +10, Familiar Weight: +3, Familiar Effect: "spooky atk, 1xBarrr"
@@ -6417,7 +6417,7 @@
 6522	perfumed groping claw of dire peril	0		Weapon Damage: +20, Stench Resistance: +5
 6523	ghostly therapeutic vengeful spirit	0		HP Regen Min: 5, HP Regen Max: 7
 6524	BOOtonniere of the businessman	0		Meat Drop: +50, Single Equip
-6525	dry vacuum-sealed wobbly jittery skewed ghost thread	0		Effect: "Rave Nirvana", Effect Duration: 56
+6525	dry vacuum-sealed jittery skewed wobbly ghost thread	0		Effect: "Rave Nirvana", Effect Duration: 56
 6526	gravedigger's weightlifter's bag of unfinished business	0		Muscle: +15, Spooky Damage: +10
 6527	spinning squat clever brawny transparent pants	0		Muscle Percent: +20, Maximum MP: +20, Familiar Effect: "sleaze atk, 1xPotato"
 6528	purple Van der Graaf hothammer	0		MP Regen Min: 5, MP Regen Max: 7
@@ -6446,7 +6446,7 @@
 6552	ghostly cluster	0		
 6553	mirror cluster	0		
 6554	stench cluster	0		
-6555	purple twirling sleaze cluster	0		
+6555	twirling purple sleaze cluster	0		
 6556	pickled phial of hotness	0		Effect: "The Magic of Sharing", Effect Duration: 27
 6557	polarized dry phial of coldness	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 17
 6558	Vulcanized oxidized phial of spookiness	0		Effect: "Spiky Hair", Effect Duration: 45
@@ -6457,11 +6457,11 @@
 6563	banded hand of Mr. Cards	0		Damage Absorption: +100, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	toothsome Dreadsylvanian hot pocket	4	awesome	
 6565	adequate miniature narrow Dreadsylvanian pocket	2	good	
-6566	spoiled half-sized Dreadsylvanian pocket	2	crappy	
-6567	enchanted decent miniature Dreadsylvanian stink pocket	2	good	Effect: "Drenched With Filth", Effect Duration: 10
+6566	half-sized spoiled Dreadsylvanian pocket	2	crappy	
+6567	miniature enchanted decent Dreadsylvanian stink pocket	2	good	Effect: "Drenched With Filth", Effect Duration: 10
 6568	stale Dreadsylvanian sleaze pocket	4	decent	
 6569	perfectly mixed Dreadsylvanian hot toddy	4	super ultra mega EPIC	
-6570	lousy watered-down Dreadsylvanian cold-fashioned	2	decent	
+6570	watered-down lousy Dreadsylvanian cold-fashioned	2	decent	
 6571	hand-crafted jittery Dreadsylvanian grimlet	4	super ultra mega EPIC	
 6572	drinkable Dreadsylvanian dank and stormy	4	good	
 6573	artisanal practically non-alcoholic bouncing Dreadsylvanian slithery nipple	1	super ultra mega turbo EPIC	
@@ -6482,14 +6482,14 @@
 6588	Jim Carey's gnawed-up dog bone of the scaredy-cat	0		Monster Level: 10
 6589	Grey Guanon of doom	0		Spooky Spell Damage: +50
 6590	wobbly boxer's slick Engorged Sausages and You of bravery	0		Moxie: +10, Muscle Percent: +10, Spooky Resistance: +5
-6591	weak hand-crafted dream of a dog	2	EPIC	
+6591	hand-crafted weak dream of a dog	2	EPIC	
 6592	quilted supercool optimal spreadsheet of Tarzan	0		Moxie Percent: +20, Experience (Muscle): +3, Damage Absorption: +40
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
 6595	mixed tumbling purple epic cluster	1	good	
 6596	wobbly clockwork egg	0		
 6597	fuchsia clockwork birdhouse	0		
-6598	spinning fuchsia clockwork disc	0		
+6598	fuchsia spinning clockwork disc	0		
 6599	jittery clockwork hand	0		
 6600	clockwork hand	0		
 6601	clockwork numeral I	0		
@@ -6500,20 +6500,20 @@
 6606	clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
 6608	clockwork numeral VIII	0		
-6609	huge narrow clockwork numeral IX	0		
+6609	narrow huge clockwork numeral IX	0		
 6610	clockwork numeral X	0		
 6611	clockwork numeral XI	0		
 6612	tumbling clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	acceptable Cold One	4	???	
-6616	normal special spaghetti breakfast	4	???	Effect: "Prince of Seaside Town", Effect Duration: 35
+6616	special normal spaghetti breakfast	4	???	Effect: "Prince of Seaside Town", Effect Duration: 35
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	teal folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	spinning folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
-6622	cyan narrow folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
+6622	narrow cyan folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
 6623	maroon folder (yellow)	0		Muscle: +15, Moxie: +15, Last Available: "2013-08"
 6624	spinning folder (smiley face)	0		Experience (Muscle): +2, Last Available: "2013-08"
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
@@ -6525,13 +6525,13 @@
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	ghostly folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	tumbling folder (barbarian)	0		Last Available: "2013-08"
-6634	spinning maroon folder (rainbow unicorn)	0		Last Available: "2013-08"
+6634	maroon spinning folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	ghostly folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	huge folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	green folder (owl)	0		Last Available: "2013-08"
-6640	mirror narrow folder (Stinky Trash Kid)	0		Last Available: "2013-08"
+6640	narrow mirror folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
 6642	folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
 6643	folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	fortified acceptable stepmom's booze	5	good	
 6653	surgical tape	0		
 6654	purple band T-shirt of the empath	0		Familiar Weight: +5
-6655	high-proof artisanal fountain 'soda'	10	EPIC	
+6655	artisanal high-proof fountain 'soda'	10	EPIC	
 6656	cyan illegal firecracker	0		
 6657	blurry nasty steel-toed pickelhaube	0		Damage Reduction: 9, Stench Damage: +5, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	tarnished non-polymerized lime green hair oil	0		Effect: "Mana Tea", Effect Duration: 61
@@ -6571,7 +6571,7 @@
 6679	smooth machete	0		Moxie: +15
 6680	artisanal weak Cursed Punch	2	EPIC	
 6681	hand-crafted triple-distilled Bowl of Scorpions	9	EPIC	
-6682	practically non-alcoholic tolerable Fog Murderer	1	good	
+6682	tolerable practically non-alcoholic Fog Murderer	1	good	
 6683	bouncing book of matches	0		
 6684	ruddy surgical mask	0		Maximum HP Percent: +40, Surgeonosity: +1
 6685	Usain Bolt's head mirror	0		Initiative: +80, Surgeonosity: +1
@@ -6641,20 +6641,20 @@
 6749	spinning sizzling brainy boilgun	0		Mysticality: +5, Hot Damage: +10
 6750	Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	spinning packet of beer seeds	0		Last Available: "2013-09"
-6752	huge lime green handful of barley	0		
+6752	lime green huge handful of barley	0		
 6753	cluster of hops	0		
 6754	blue beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	tolerable practically non-alcoholic green ghostly can of Br&uuml;talbr&auml;u	1	good	Last Available: "2013-09"
-6758	tolerable practically non-alcoholic can of Drooling Monk	1	good	Last Available: "2013-09"
+6757	tolerable practically non-alcoholic ghostly green can of Br&uuml;talbr&auml;u	1	good	Last Available: "2013-09"
+6758	practically non-alcoholic tolerable can of Drooling Monk	1	good	Last Available: "2013-09"
 6759	mediocre ghostly can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
-6760	aged practically non-alcoholic jittery bottle of Old Pugilist	1	awesome	Last Available: "2013-09"
+6760	practically non-alcoholic aged jittery bottle of Old Pugilist	1	awesome	Last Available: "2013-09"
 6761	practically non-alcoholic artisanal bottle of Professor Beer	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6762	smooth skewed bottle of Rapier Witbier	3	awesome	Last Available: "2013-09"
 6763	acceptable bottle of Race Car Red	4	good	Last Available: "2013-09"
 6764	weak tolerable bottle of Greedy Dog	2	good	Last Available: "2013-09"
-6765	high-proof perfectly mixed squat bottle of Lambada Lambic	10	EPIC	Last Available: "2013-09"
+6765	perfectly mixed high-proof squat bottle of Lambada Lambic	10	EPIC	Last Available: "2013-09"
 6766	twirling tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
@@ -6667,8 +6667,8 @@
 6775	skewed tin lizzie	0		Last Available: "2013-09"
 6776	extra-improved warmed foetid seal tear	0		Effect: "Moon-Eyed", Effect Duration: 27
 6777	activated seal sweat	0		Effect: "Pisces in the Skyces", Effect Duration: 50
-6778	flattened tumbling huge boiling seal blood	0		Effect: "Thick, Sick", Effect Duration: 30
-6779	bouncing blurry ghostly crystalline seal eye	0		Single Equip
+6778	flattened huge tumbling boiling seal blood	0		Effect: "Thick, Sick", Effect Duration: 30
+6779	ghostly bouncing blurry crystalline seal eye	0		Single Equip
 6780	nippy quilted studded sealhide shield	0		Damage Absorption: +40, Cold Damage: +10, Damage Reduction: 7
 6781	Van der Graaf scabrous seal epaulets of the businessman	0		Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 6782	mirror abyssal battle plans	0		
@@ -6677,7 +6677,7 @@
 6785	flask of embalming fluid	0		
 6788	mirror squat blank diary	0		
 6789	fuchsia boot knife	0		
-6790	cyan shaking broken beer bottle	0		
+6790	shaking cyan broken beer bottle	0		
 6791	sharpened spoon	0		
 6792	candy knife	0		
 6793	bouncing soap knife	0		
@@ -6714,7 +6714,7 @@
 6825	alarm accordion of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Class: "Accordion Thief", Song Duration: 20
 6826	miser's curative All-Hallow's Steve's fright wig of terror	0		Spooky Spell Damage: +10, Meat Drop: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	resourceful KoL Con X Treasure Map of doom	0		Maximum MP: +50, Spooky Spell Damage: +50
-6828	artisanal extra-dry discocktail	5	EPIC	
+6828	extra-dry artisanal discocktail	5	EPIC	
 6829	flame-retardant KoL Con X Bingo Card	0		Hot Resistance: +1
 6830	boxer's Temporal Tempera Tube	0		Muscle Percent: +10
 6831	non-dry pressed electrified narrow Tallowcreme Halloween Pumpkin	0		Effect: "meat.enh", Effect Duration: 30
@@ -6729,7 +6729,7 @@
 6840	adjusted Whenchamacallit bar	0		Effect: "Familial Ties", Effect Duration: 29
 6841	nitrogenated pressed 8-bit banana	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 46
 6842	polymerized adjusted irradiated vial of blood simple syrup	0		Effect: "Tomato Power", Effect Duration: 56
-6843	wet altered upside-down maroon jittery bone bons	0		Effect: "Broberry Brotality", Effect Duration: 22
+6843	wet altered maroon jittery upside-down bone bons	0		Effect: "Broberry Brotality", Effect Duration: 22
 6844	dry ghostly ironic mint	0		Effect: "Human-Goblin Hybrid", Effect Duration: 69
 6845	blue unused walkie-talkie	0		Free Pull
 6846	tumbling walkie-talkie	0		Free Pull
@@ -6748,12 +6748,12 @@
 6859	zippy cool Skipper's accordion	0		Moxie: +5, Initiative: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6860	Sherlock's smelly Pantsgiving of Tarzan of the sweet-tooth	0		Experience (Muscle): +3, Stench Spell Damage: +10, Item Drop: +25, Candy Drop: +100, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
 6861	gigantic adequate can of sardines	7	good	Last Available: "2013-11"
-6862	super-sized stale fancy high-calorie sugar substitute	5	decent	Effect: "Brain Freeze", Effect Duration: 40, Last Available: "2013-11"
+6862	fancy stale super-sized high-calorie sugar substitute	5	decent	Effect: "Brain Freeze", Effect Duration: 40, Last Available: "2013-11"
 6863	normal pat of butter	3	good	Last Available: "2013-11"
 6864	tasty dinner roll	3	awesome	Last Available: "2013-11"
-6865	normal half-sized mashed potatoes	2	good	Last Available: "2013-11"
+6865	half-sized normal mashed potatoes	2	good	Last Available: "2013-11"
 6866	tasty whole turkey leg	3	awesome	Last Available: "2013-11"
-6867	moldy small ghostly deviled egg	2	crappy	Last Available: "2013-11"
+6867	small moldy ghostly deviled egg	2	crappy	Last Available: "2013-11"
 6868	alkaline extra-chilled blurry finger exerciser	0		Effect: "Bestial Sympathy", Effect Duration: 21, Last Available: "2013-11"
 6869	deionized energized polarized dented spoon	0		Effect: "Artificially Sweet", Effect Duration: 40, Last Available: "2013-11"
 6870	boiled love note	0		Effect: "Orc Chops", Effect Duration: 27, Last Available: "2013-11"
@@ -6789,17 +6789,17 @@
 6900	upside-down experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	therapeutic Da Vinci's flask flops	0		Experience (Mysticality): +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip
-6903	super-denatured corrupted upside-down mirror nuts	0		Effect: "Red-Shirted Escort", Effect Duration: 38, Last Available: "2013-12"
+6903	super-denatured corrupted mirror upside-down nuts	0		Effect: "Red-Shirted Escort", Effect Duration: 38, Last Available: "2013-12"
 6904	galvanized colloidal spinning bolts	0		Effect: "Extra Terrestrial", Effect Duration: 17, Last Available: "2013-12"
-6905	tiny adequate gingerbread robot	1	good	Last Available: "2013-12"
-6906	moldy massive wobbly petit 4.1	9	crappy	Last Available: "2013-12"
+6905	adequate tiny gingerbread robot	1	good	Last Available: "2013-12"
+6906	massive moldy wobbly petit 4.1	9	crappy	Last Available: "2013-12"
 6907	diet spoiled cyan nut-shaped Crimbo cookie	1	crappy	Last Available: "2023-06"
 6908	fortified plastic GORM-8	0		Damage Absorption: +60, Last Available: "2013-12"
 6909	MacGyver's plastic warbear	0		Maximum MP: +100, Last Available: "2013-12"
 6910	vibrating plastic Toybot	0		Maximum MP Percent: +10, Last Available: "2013-12"
 6911	chaotic plastic warbear fortress	0		Spell Critical Percent: +10, Last Available: "2013-12"
 6912	blurry mirror greasy Da Vinci's plastic K.R.A.M.P.U.S.	0		Experience (Mysticality): +5, Sleaze Spell Damage: +10, Last Available: "2013-12"
-6913	jittery gray warbear whosit	0		Last Available: "2013-12"
+6913	gray jittery warbear whosit	0		Last Available: "2013-12"
 6914	warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	stylish weightlifter's warbear hoverbelt of chilblains	0		Muscle: +15, Moxie: +25, Cold Damage: +25, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
@@ -6807,11 +6807,11 @@
 6918	super-colloidal denatured upside-down warbear wardance potion	0		Effect: "Deadly Flashing Blade", Effect Duration: 40, Last Available: "2013-12"
 6919	quadruple-moist polarized fuchsia warbear bearserker potion	0		Effect: "Whippin' It Good", Effect Duration: 14, Last Available: "2013-12"
 6920	energized warbear liquid overcoat	0		Effect: "Quiet 'n' Good", Effect Duration: 17, Last Available: "2013-12"
-6921	normal pulsating cyan warbear feasting bread	3	good	Last Available: "2013-12"
-6922	miniature special normal shaking warbear warrior bread	2	good	Effect: "Nas Tea", Effect Duration: 40, Last Available: "2013-12"
+6921	normal cyan pulsating warbear feasting bread	3	good	Last Available: "2013-12"
+6922	special normal miniature shaking warbear warrior bread	2	good	Effect: "Nas Tea", Effect Duration: 40, Last Available: "2013-12"
 6923	decent tumbling warbear thermoregulator bread	3	good	Last Available: "2013-12"
-6924	high-proof aged shaking warbear feasting mead	10	awesome	Last Available: "2013-12"
-6925	watered-down bad warbear bearserker mead	2	decent	Last Available: "2013-12"
+6924	aged high-proof shaking warbear feasting mead	10	awesome	Last Available: "2013-12"
+6925	bad watered-down warbear bearserker mead	2	decent	Last Available: "2013-12"
 6926	acceptable teal warbear blizzard mead	4	good	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
 6928	skewed healthy dangerous warbear plain fedora of the brazier	0		Weapon Damage: +10, Maximum HP Percent: +20, Hot Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
@@ -6896,7 +6896,7 @@
 7007	adequate small wobbly Every Day is Like This Sundae	2	good	Last Available: "2013-12"
 7008	rotten Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	miniature stale special This Charming Flan	2	decent	Effect: "Wolf's Bane", Effect Duration: 5, Last Available: "2013-12"
-7010	distilled acceptable upside-down Irish Coffee, English Heart	5	good	Last Available: "2013-12"
+7010	acceptable distilled upside-down Irish Coffee, English Heart	5	good	Last Available: "2013-12"
 7011	artisanal tumbling Strikes Again Bigmouth	3	EPIC	Last Available: "2013-12"
 7012	tolerable Paint A Vulgar Pitcher	3	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
@@ -6939,11 +6939,11 @@
 7050	stale warbear gyro	4	decent	Last Available: "2013-12"
 7051	diffused corrupted non-cold-filtered mirror squat recording of Rolando's Rondo of Resisto	0		Effect: "The Smile of Mr. A.", Effect Duration: 15, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
-7053	twirling upside-down warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
-7054	shaking squat warbear drone codes	0		Last Available: "2013-12"
+7053	upside-down twirling warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
+7054	squat shaking warbear drone codes	0		Last Available: "2013-12"
 7055	tasty shaking breakfast mess	4	awesome	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	normal fancy breakfast miracle	3	good	Effect: "Ruby-ous", Effect Duration: 30, Last Available: "2013-12"
+7057	fancy normal breakfast miracle	3	good	Effect: "Ruby-ous", Effect Duration: 30, Last Available: "2013-12"
 7058	enhanced boiled Cloaca Cola Polar	0		Effect: "Object Detection", Effect Duration: 31, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	pulsating festive warbear bank	0		Last Available: "2013-12"
@@ -6957,13 +6957,13 @@
 7068	activated chilled nitrogenated single of Donho's Bubbly Ballad	0		Effect: "Slime Time", Effect Duration: 64
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	bland fancy snow berries	4	decent	Effect: "Preternatural Greed", Effect Duration: 15, Last Available: "2014-01"
+7071	fancy bland snow berries	4	decent	Effect: "Preternatural Greed", Effect Duration: 15, Last Available: "2014-01"
 7072	spoiled ice harvest	3	crappy	Last Available: "2014-01"
 7073	unsweetened improved squat frost flower	0		Effect: "Salty Dogs", Effect Duration: 48, Last Available: "2014-01"
 7074	magnetized activated snow cleats	0		Effect: "Bestial Sympathy", Effect Duration: 25, Last Available: "2014-01"
-7075	frozen mirror narrow liquid ice pack	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 41, Last Available: "2014-01"
+7075	frozen narrow mirror liquid ice pack	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 41, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	tiny flavorless skewed snow crab	1	decent	Last Available: "2014-01"
+7077	flavorless tiny skewed snow crab	1	decent	Last Available: "2014-01"
 7078	drinkable Ice Island Long Tea	4	good	Last Available: "2014-01"
 7079	tumbling unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
@@ -6975,8 +6975,8 @@
 7086	narrow lime green asbestos-lined sharpshooter's bod-ice of Flo-Jo	0		Critical Hit Percent: +10, Hot Resistance: +5, Initiative: +100, Lasts Until Rollover, Last Available: "2014-01"
 7087	spinning rock-hard snow belt of the brute of the dark arts of extreme caution	0		Muscle Percent: +30, Spell Damage Percent: +100, Damage Reduction: 5, Monster Level: -25, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	friendly banded sage strapping ice nine	0		Muscle: +5, Mysticality Percent: +10, Damage Absorption: +100, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2014-01"
-7089	lime green wobbly snow fort	0		Last Available: "2014-01"
-7090	weak tolerable En Una Fila Tequila	2	good	
+7089	wobbly lime green snow fort	0		Last Available: "2014-01"
+7090	tolerable weak En Una Fila Tequila	2	good	
 7091	Skully's hot chocolate	1	good	
 7092	green shaking greedy warbear dress helmet of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +20, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	dance instructor's warbear dress bracers of the sewer	0		Experience Percent (Moxie): +10, Stench Damage: +25, Single Equip, Last Available: "2013-12"
@@ -6995,16 +6995,16 @@
 7106	fancy smooth snakebite	4	awesome	Effect: "Izchak's Blessing", Effect Duration: 40, Last Available: "2014-12"
 7107	clever Rosewater's candy stick	0		Mysticality Percent: +30, Maximum MP: +20, Last Available: "2014-12"
 7108	spoiled small pecan	2	crappy	Last Available: "2014-12"
-7109	adequate massive fuchsia pecan pie	6	good	Last Available: "2014-12"
+7109	massive adequate fuchsia pecan pie	6	good	Last Available: "2014-12"
 7110	mirror jittery chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	bland enchanted candy mountain oyster	4	decent	Effect: "Space Cowboy", Effect Duration: 45, Last Available: "2014-12"
-7112	special artisanal chocotini	3	EPIC	Effect: "Artificially Sweet", Effect Duration: 10, Last Available: "2014-12"
+7111	enchanted bland candy mountain oyster	4	decent	Effect: "Space Cowboy", Effect Duration: 45, Last Available: "2014-12"
+7112	artisanal special chocotini	3	EPIC	Effect: "Artificially Sweet", Effect Duration: 10, Last Available: "2014-12"
 7113	veiny dance instructor's Da Vinci's chocolate rabbit's foot	0		Experience (Mysticality): +5, Experience Percent (Moxie): +10, Maximum HP: +10, Last Available: "2014-12"
 7114	tasty upside-down candy carrot	3	awesome	Last Available: "2014-12"
 7115	rotten shaking candy carrot cake	4	crappy	Last Available: "2014-12"
 7116	lightning-fast Herculean carrot-on-a-stick	0		Experience (Muscle): +1, Initiative: +40, Last Available: "2014-12"
 7117	yellow savvy weasel stomping pants of Flo-Jo	0		Mysticality Percent: +20, Initiative: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	delicious big mulberry	5	awesome	Last Available: "2014-12"
+7118	big delicious mulberry	5	awesome	Last Available: "2014-12"
 7119	delicious mulled berry wine	3	awesome	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	lemon party hat of Leguizamo	0		Monster Level: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
@@ -7019,7 +7019,7 @@
 7130	tolerable practically non-alcoholic magnum of champagne	1	good	Last Available: "2014-12"
 7131	executive baleful sinister cow creamer	0		Spell Damage: 35, Meat Drop: +40, Last Available: "2014-12"
 7132	ionized diffused quadruple-aerosolized narrow red Outer Wolf&trade; cologne	0		Effect: "Dancing Prowess", Effect Duration: 30, Last Available: "2014-12"
-7133	cyan shaking lupine appetite hormones	0		Last Available: "2014-12"
+7133	shaking cyan lupine appetite hormones	0		Last Available: "2014-12"
 7134	blurry stanky wolf whistle of terror	0		Stench Spell Damage: +25, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	moldy witch's bread	4	crappy	Last Available: "2014-12"
 7136	extra-ionized upside-down witch's brew	0		Effect: "Sugar High", Effect Duration: 41, Last Available: "2014-12"
@@ -7031,7 +7031,7 @@
 7142	modified pressed Vulcanized hare brush	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 46, Last Available: "2014-12"
 7143	wicked dance instructor's hare pin	0		Experience Percent (Moxie): +10, Spell Damage: +5, Single Equip, Last Available: "2014-12"
 7144	tumbling odd coin	0		Last Available: "2014-12"
-7145	massive fancy yummy cinnamon cannoli	9	awesome	Effect: "Egg-stortionary Tactics", Effect Duration: 25, Last Available: "2014-12"
+7145	fancy massive yummy cinnamon cannoli	9	awesome	Effect: "Egg-stortionary Tactics", Effect Duration: 25, Last Available: "2014-12"
 7146	artisanal expensive champagne	4	EPIC	Last Available: "2014-12"
 7147	concentrated polo trophy	0		Effect: "Cold, Dead Hands", Effect Duration: 53, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7046,7 +7046,7 @@
 7157	curative hardy sinister fire hose	0		Spell Damage: +10, Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	adequate fireman's lunch	4	good	Last Available: "2014-12"
 7159	tumbling zippy dog trainer's fortified plain paper hat	0		Damage Absorption: +60, Experience (familiar): +1, Initiative: +20, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	half-sized special adequate huge ice cream sandwich	2	good	Effect: "Greasy Flavor", Effect Duration: 25, Last Available: "2014-12"
+7160	adequate special half-sized huge ice cream sandwich	2	good	Effect: "Greasy Flavor", Effect Duration: 25, Last Available: "2014-12"
 7161	squat smooth brainy &quot;honey&quot; dipper of the dark arts	0		Mysticality: +5, Moxie: +15, Spell Damage Percent: +100, Last Available: "2014-12"
 7162	miniature adequate yellow blinking plumber's lunch	2	good	Last Available: "2014-12"
 7163	teal shaking spinning reassuring deadly boxer's skull gearshift knob	0		Muscle Percent: +10, Weapon Damage: +5, Spooky Resistance: +1, Last Available: "2014-12"
@@ -7055,7 +7055,7 @@
 7166	bland snack-sized can of Adultwitch&trade;	2	decent	Last Available: "2014-12"
 7167	pressed smudge stick	0		Effect: "Fratty Flavor", Effect Duration: 20, Last Available: "2014-12"
 7168	denatured extra-wet wall	0		Effect: "init.enh", Effect Duration: 66, Last Available: "2014-12"
-7169	weak tolerable tankard of ale	2	good	Last Available: "2014-12"
+7169	tolerable weak tankard of ale	2	good	Last Available: "2014-12"
 7170	warmed scroll case	0		Effect: "On the Shoulders of Giants", Effect Duration: 53, Last Available: "2014-12"
 7171	magnetized tarnished jug of &quot;wine&quot;	0		Effect: "Influence of Sphere", Effect Duration: 64, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7068,7 +7068,7 @@
 7179	The First Pizza	0		
 7180	teal The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
-7182	gray spinning The Stankara Stone	0		
+7182	spinning gray The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
@@ -7101,23 +7101,23 @@
 7212	razor-sharp Jefferson wings	0		Weapon Damage Percent: +25
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	toothsome enchanted fleetwood mac 'n' cheese	3	awesome	Effect: "Is This Your Card?", Effect Duration: 50
+7215	enchanted toothsome fleetwood mac 'n' cheese	3	awesome	Effect: "Is This Your Card?", Effect Duration: 50
 7216	lynyrd skin	0		
 7217	skewed dangerous lynyrdskin cap	0		Weapon Damage: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	lynyrdskin tunic of incineration	0		Hot Spell Damage: +50
 7219	squat aromatic lynyrdskin breeches	0		Stench Resistance: +1, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	mirror cigarette lighter	0		
 7221	squat priceless diamond	0		
-7222	strong hand-crafted spinning Flamin' Whatshisname	5	EPIC	
+7222	hand-crafted strong spinning Flamin' Whatshisname	5	EPIC	
 7223	deionized double-cold-filtered shaking lynyrd musk	0		Effect: "Three Days Slow", Effect Duration: 60
 7224	tumbling fortified slick Kashmir sweater	0		Moxie: +10, Damage Absorption: +60
 7225	half-sized flavorless custard pie	2	decent	
 7226	tea for one	1	good	
-7227	weak perfectly mixed squat bottle of Evermore	2	EPIC	
+7227	perfectly mixed weak squat bottle of Evermore	2	EPIC	
 7228	box	0		
 7229	lousy ghostly wine	3	decent	
-7230	bad practically non-alcoholic rum	1	decent	
-7231	lousy weak Murderer's Punch	2	decent	
+7230	practically non-alcoholic bad rum	1	decent	
+7231	weak lousy Murderer's Punch	2	decent	
 7232	snack-sized stale olive velvet cake	2	decent	
 7233	electrified letter	0		Effect: "Nano-juiced", Effect Duration: 57
 7234	stiffened beefcake's book	0		Muscle: +25, Damage Reduction: 1
@@ -7149,12 +7149,12 @@
 7260	lime green firebomb	0		
 7261	knitted smelly frosty Sneaky Pete's basket	0		Cold Spell Damage: +10, Stench Spell Damage: +10, Cold Resistance: +3
 7262	&quot;I Love Me, Vol. I&quot;	0		
-7263	gray ghostly narrow photograph of a dog	0		
+7263	ghostly gray narrow photograph of a dog	0		
 7264	squat photograph of a nugget	0		
 7265	upside-down photograph of an ostrich egg	0		
 7266	mirror disposable instant camera	0		
 7267	baleful Samson's wizardly Sneaky Pete's jacket (collar popped) of the ox	0		Muscle: +20, Mysticality: +25, Experience (Muscle): +5, Spell Damage: +25, Softcore Only, Free Pull, Last Available: "2014-03"
-7268	blinking red Letter for Melvign the Gnome	0		
+7268	red blinking Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
 7270	twirling &quot;2 Love Me, Vol. 2&quot;	0		
 7271	Thinknerd Blind-Packed Toy	0		
@@ -7176,9 +7176,9 @@
 7287	asbestos-lined sharpshooter's Gary Claybender's Time Screwer	0		Critical Hit Percent: +10, Hot Resistance: +5, Single Equip, Lasts Until Rollover
 7288	scandalous Space Tourist palmdoctor of the sweet-tooth	0		Sleaze Damage: +5, Candy Drop: +100, Lasts Until Rollover
 7289	twirling dog trainer's hardy sage amok putter	0		Mysticality Percent: +10, Maximum HP: +50, Experience (familiar): +1
-7290	diet adequate amok pudding	1	good	
+7290	adequate diet amok pudding	1	good	
 7291	upside-down deactivated putty buddy	0		
-7292	olive wobbly putty coat	0		Familiar Weight: +5
+7292	wobbly olive putty coat	0		Familiar Weight: +5
 7293	deionized blurry can of V-11	0		Effect: "Antibiotic Saucesphere", Effect Duration: 49, Last Available: "2014-03"
 7294	rock-hard elevennis shoes of incineration	0		Damage Reduction: 5, Hot Spell Damage: +50, Last Available: "2014-03"
 7295	elevent	0		Last Available: "2014-03"
@@ -7196,7 +7196,7 @@
 7307	Lady Spookyraven's dancing shoes	0		
 7308	anodized eyebrow pencil	0		Effect: "Squatting and Thrusting", Effect Duration: 57
 7309	activated galvanized rosewater cream	0		Effect: "Stop the Presses!", Effect Duration: 17
-7310	colloidal improved activated squat gray bronzer	0		Effect: "Busy Bein' Delicious", Effect Duration: 52
+7310	colloidal improved activated gray squat bronzer	0		Effect: "Busy Bein' Delicious", Effect Duration: 52
 7311	perfumed Sinatra's elegant nightstick	0		Experience (Moxie): +5, Stench Resistance: +5
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	box of hickory chips	0		Familiar Weight: +5
@@ -7229,12 +7229,12 @@
 7340	deadly moose antlers	0		Weapon Damage: +5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	improved liquefied narrow moose thought	0		Effect: "Human-Pirate Hybrid", Effect Duration: 28
 7342	moldy half-sized spinning moose chocolate	2	crappy	
-7343	triple-distilled artisanal painting of a glass of wine	9	EPIC	
+7343	artisanal triple-distilled painting of a glass of wine	9	EPIC	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	fuchsia doll-eye amulet	0		Single Equip
 7347	Da Vinci's groovy ghost toga	0		Moxie Percent: +10, Experience (Mysticality): +5
-7348	low-calorie stale sheet cake	1	decent	
+7348	stale low-calorie sheet cake	1	decent	
 7349	upside-down ghost key	0		
 7350	squat ghostly picture of you	0		
 7351	twirling double-paned studded smooth Staff of the Electric Range	0		Moxie: +15, Damage Absorption: +80, Cold Resistance: +5
@@ -7254,7 +7254,7 @@
 7365	triple-boiled blinking cyan fabric hardener	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 28
 7366	artisanal bottle of laundry sherry	4	EPIC	
 7367	adjusted Vulcanized industrial strength starch	0		Effect: "Old Time Hydration", Effect Duration: 33, Wiki Name: "industrial strength starch"
-7368	snack-sized spoiled extra-flat panini	2	crappy	
+7368	spoiled snack-sized extra-flat panini	2	crappy	
 7369	modified altered narrow mangled finger	0		Effect: "Hardened Fabric", Effect Duration: 31
 7370	hand-crafted Psychotic Train wine	3	EPIC	
 7371	crazy hobo notebook	0		
@@ -7284,14 +7284,14 @@
 7395	unsweetened twirling Gene Tonic: Goblin	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 26, Last Available: "2014-04"
 7396	pickled galvanized Gene Tonic: Pirate	0		Effect: "Human-Hobo Hybrid", Effect Duration: 19, Last Available: "2014-04"
 7397	super-polymerized adjusted Gene Tonic: Plant	0		Effect: "Thaumodynamic", Effect Duration: 46, Last Available: "2014-04"
-7398	dry blurry twirling Gene Tonic: Weird	0		Effect: "Holiday Disappointment", Effect Duration: 65, Last Available: "2014-04"
+7398	dry twirling blurry Gene Tonic: Weird	0		Effect: "Holiday Disappointment", Effect Duration: 65, Last Available: "2014-04"
 7399	galvanized Gene Tonic: Elf	0		Effect: "Ack!  Barred!", Effect Duration: 24, Last Available: "2014-04"
 7400	aerosolized jittery Gene Tonic: Mer-kin	0		Effect: "Rad-ish", Effect Duration: 43, Last Available: "2014-04"
 7401	moist polarized Gene Tonic: Slime	0		Effect: "Pockets of Fire", Effect Duration: 27, Last Available: "2014-04"
 7402	nitrogenated double-ionized narrow Gene Tonic: Penguin	0		Effect: "Souper Vengeful", Effect Duration: 16, Last Available: "2014-04"
 7403	quadruple-polymerized Gene Tonic: Elemental	0		Effect: "The Style... of the Future", Effect Duration: 18, Last Available: "2014-04"
 7404	non-flattened flattened dry spinning Gene Tonic: Constellation	0		Effect: "Alacri Tea", Effect Duration: 60, Last Available: "2014-04"
-7405	energized modified spinning skewed Gene Tonic: Hobo	0		Effect: "Swordholder", Effect Duration: 11, Last Available: "2014-04"
+7405	energized modified skewed spinning Gene Tonic: Hobo	0		Effect: "Swordholder", Effect Duration: 11, Last Available: "2014-04"
 7406	upside-down Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
 7408	Steam Card: Dungeon Fist (#3)	0		
@@ -7326,25 +7326,25 @@
 7437	blue Pastaco shell	0		Last Available: "2014-05"
 7438	snack-sized bland Beefy Crunch Pastaco	2	decent	Last Available: "2014-05"
 7439	adequate Brain Food Pastaco	4	good	Last Available: "2014-05"
-7440	tasty snack-sized Cool Brunch Pastaco	2	awesome	Last Available: "2014-05"
+7440	snack-sized tasty Cool Brunch Pastaco	2	awesome	Last Available: "2014-05"
 7441	stale Medical Pastaco	4	decent	Last Available: "2014-05"
 7442	decent Energy Buzz Pastaco	4	good	Last Available: "2014-05"
 7443	yummy Ludovico Pastaco	3	awesome	Last Available: "2014-05"
 7444	artisanal enchanted overpowering mushroom wine	4	EPIC	Effect: "Pisces Rising", Effect Duration: 50, Last Available: "2014-05"
 7445	artisanal triple-distilled complex mushroom wine	10	EPIC	Last Available: "2014-05"
-7446	drinkable high-proof smooth mushroom wine	10	good	Last Available: "2014-05"
+7446	high-proof drinkable smooth mushroom wine	10	good	Last Available: "2014-05"
 7447	smooth blood-red mushroom wine	3	awesome	Last Available: "2014-05"
 7448	acceptable buzzing mushroom wine	3	good	Last Available: "2014-05"
 7449	triple-distilled acceptable swirling mushroom wine	7	good	Last Available: "2014-05"
 7450	adequate Taco Dan's Basic Taco Dan Taco	4	good	Last Available: "2014-05"
 7451	adequate Taco Dan's Taco Fish Fish Taco	4	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	practically non-alcoholic tolerable regular-size brogurt	1	good	Last Available: "2014-05"
+7453	tolerable practically non-alcoholic regular-size brogurt	1	good	Last Available: "2014-05"
 7454	tolerable super-size brogurt	4	good	Last Available: "2014-05"
-7455	lousy purple bouncing broberry brogurt	3	decent	Last Available: "2014-05"
+7455	lousy bouncing purple broberry brogurt	3	decent	Last Available: "2014-05"
 7456	drinkable brocolate brogurt	4	good	Last Available: "2014-05"
-7457	acceptable weak fancy French bronilla brogurt	2	good	Effect: "Voracious Gorging", Effect Duration: 30, Last Available: "2014-05"
-7458	blinking yellow History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
+7457	weak acceptable fancy French bronilla brogurt	2	good	Effect: "Voracious Gorging", Effect Duration: 30, Last Available: "2014-05"
+7458	yellow blinking History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	shaking industrial strength anti-fungal spray	0		Last Available: "2014-05"
@@ -7367,12 +7367,12 @@
 7478	blurry possessed sugar cube	0		Last Available: "2014-05"
 7479	diffused extra-tarnished narrow sugar fairy	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 62, Last Available: "2014-05"
 7480	tarnished irradiated sugar bunny	0		Effect: "Broken Bone Nubs", Effect Duration: 34, Last Available: "2014-05"
-7481	narrow sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	narrow sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	watered-down aged Rompedores de Fantasmas	2	awesome	
-7483	fortified tolerable huge La Fantasma y La Oscuridad	5	good	
+7483	tolerable fortified huge La Fantasma y La Oscuridad	5	good	
 7484	perfectly mixed Fantasma en la M&aacute;quina	4	EPIC	
-7485	upside-down mirror loosening powder	0		
-7486	huge bouncing ghostly castoreum	0		
+7485	mirror upside-down loosening powder	0		
+7486	ghostly huge bouncing castoreum	0		
 7487	mirror drain dissolver	0		
 7488	triple-distilled turpentine	0		
 7489	gray detartrated anhydrous sublicalc	0		
@@ -7405,7 +7405,7 @@
 7516	jittery witch's spare house key	0		
 7517	bouncing lightning-fast clever spider leg	0		Maximum MP: +20, Initiative: +40
 7518	wand of pigification	0		
-7519	practically non-alcoholic perfectly mixed special shaking glass of bourbon	1	EPIC	Effect: "Eldritch Concentration", Effect Duration: 45
+7519	special practically non-alcoholic perfectly mixed shaking glass of bourbon	1	EPIC	Effect: "Eldritch Concentration", Effect Duration: 45
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	adequate bouncing government cheese	3	good	Last Available: "2014-05"
 7522	twirling asbestos-lined pair of government shades	0		Hot Resistance: +5, Single Equip, Last Available: "2014-05"
@@ -7421,7 +7421,7 @@
 7532	delicious rocket fuel	3	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	triple-distilled mediocre stealth bomber	6	decent	Last Available: "2014-05"
+7535	mediocre triple-distilled stealth bomber	6	decent	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	jittery twitching space egg	0		Last Available: "2014-05"
 7538	green ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7437,23 +7437,23 @@
 7548	hot ashes	0		Last Available: "2014-06"
 7549	super-liquefied diffused green ash soda	0		Effect: "Gingerbread Robust", Effect Duration: 65, Last Available: "2014-06"
 7550	ionized extra-enhanced liquid smoke	0		Effect: "Big", Effect Duration: 29, Last Available: "2014-06"
-7551	non-cold-filtered squat huge dollop of barbecue sauce	0		Effect: "Heightened Senses", Effect Duration: 42, Last Available: "2014-06"
+7551	non-cold-filtered huge squat dollop of barbecue sauce	0		Effect: "Heightened Senses", Effect Duration: 42, Last Available: "2014-06"
 7552	extra-irradiated bowl of marinade	0		Effect: "Eyes All Black", Effect Duration: 39, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
 7554	polymerized ionized shaking bottle of lighter fluid	0		Effect: "Oiled Skin", Effect Duration: 42, Last Available: "2014-06"
 7555	twirling page	0		
 7556	elephant gift	0		
 7557	activated teal blood cells	0		Effect: "Bonelording", Effect Duration: 37
-7558	hand-crafted distilled wobbly wine	5	EPIC	
-7559	moist energized squat jittery gummi turtle	0		Effect: "Bubblin' Rage", Effect Duration: 58
+7558	distilled hand-crafted wobbly wine	5	EPIC	
+7559	moist energized jittery squat gummi turtle	0		Effect: "Bubblin' Rage", Effect Duration: 58
 7560	turtle-shaped rock	0		
 7561	denatured oxidized giraffe-necked turtle	0		Effect: "Human-Constellation Hybrid", Effect Duration: 65
-7562	liquefied bouncing wobbly cyan musk turtle	0		Effect: "Painted-On Bikini", Effect Duration: 28
+7562	liquefied wobbly bouncing cyan musk turtle	0		Effect: "Painted-On Bikini", Effect Duration: 28
 7563	super-liquefied wobbly programmable turtle	0		Effect: "Pop-eyed", Effect Duration: 51
 7564	polymerized quadruple-denatured fuchsia mocking turtle	0		Effect: "Chilblains of the Corn", Effect Duration: 43
 7565	special bland ham steak	4	decent	Effect: "Whole Latte Love", Effect Duration: 10
 7566	time-twitching toolbelt of chilblains	0		Cold Damage: +25, Single Equip, Free Pull
-7567	blurry lime green shaking Chroner	0		
+7567	lime green shaking blurry Chroner	0		
 7568	groovy stylish Time Lord Badge of Honor of James Dean	0		Moxie: +25, Moxie Percent: +10, Experience (Moxie): +3
 7569	red shaking toasty Tesla Time Bandit Badge of Courage of the cheetah	0		Hot Damage: +5, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10
 7570	modified Friendliness Beverage	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 58
@@ -7475,7 +7475,7 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	upside-down Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	extra-dry artisanal glass of &quot;milk&quot;	5	EPIC	Last Available: "2014-07"
+7589	artisanal extra-dry glass of &quot;milk&quot;	5	EPIC	Last Available: "2014-07"
 7590	tolerable weak cup of &quot;tea&quot;	2	good	Last Available: "2014-07"
 7591	drinkable special mirror thermos of &quot;whiskey&quot;	3	good	Effect: "Held Closer", Effect Duration: 15, Last Available: "2014-07"
 7592	delicious upside-down spinning Lucky Lindy	4	awesome	Last Available: "2014-07"
@@ -7485,7 +7485,7 @@
 7596	perfectly mixed Hot Socks	3	EPIC	Last Available: "2014-07"
 7597	perfectly mixed Phonus Balonus	3	EPIC	Last Available: "2014-07"
 7598	mediocre wobbly Flivver	3	decent	Last Available: "2014-07"
-7599	bad practically non-alcoholic upside-down ghostly Sloppy Jalopy	1	decent	Last Available: "2014-07"
+7599	practically non-alcoholic bad ghostly upside-down Sloppy Jalopy	1	decent	Last Available: "2014-07"
 7600	altered frozen flame	0		Effect: "Poker Faced", Effect Duration: 26
 7601	liquefied improved electrified temporary yak tattoo	0		Effect: "The Moxious Madrigal", Effect Duration: 42
 7602	pressed magnetized huge Fitspiration&trade; poster	0		Effect: "Truly Gritty", Effect Duration: 40
@@ -7511,7 +7511,7 @@
 7622	dry button rouge	0		Effect: "Smokin'", Effect Duration: 58
 7623	moist shaking Red Army camouflage kit	0		Effect: "Bone Chilling", Effect Duration: 31
 7624	anodized energized lynyrd skinner toothblack	0		Effect: "Burning Ears", Effect Duration: 29
-7625	magnetized altered fuchsia blinking flask of rainwater	0		Effect: "Fudge Headache", Effect Duration: 16
+7625	magnetized altered blinking fuchsia flask of rainwater	0		Effect: "Fudge Headache", Effect Duration: 16
 7626	alkaline pulsating olive oyster badge	0		Effect: "Pork Power", Effect Duration: 40
 7627	ionized magnetized blinking plastic Jefferson wings	0		Effect: "Cold Jellied", Effect Duration: 33
 7628	diffused tumbling dancing fan	0		Effect: "Twinklebritches", Effect Duration: 11
@@ -7552,7 +7552,7 @@
 7663	Jeselnik's Annie Oakley's Samson's Lord Soggyraven's Slippers	0		Experience (Muscle): +5, Critical Hit Percent: +20, Sleaze Damage: +25, Single Equip
 7664	quantum blue narrow Ancient Protector Soda	0		Effect: "[1609]Dancin' Fool", Effect Duration: 36
 7665	unsweetened improved liquid ice	0		Effect: "Wet Rub", Effect Duration: 68
-7666	distilled hand-crafted bouncing Wet Russian	5	EPIC	
+7666	hand-crafted distilled bouncing Wet Russian	5	EPIC	
 7667	bland filet of The Fish	3	decent	
 7668	green Thwaitgold spider statuette	0		
 7669	Jeselnik's medical-grade thunder down underwear of the sewer	0		Stench Damage: +25, Sleaze Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
@@ -7561,13 +7561,13 @@
 7672	tumbling law-abiding citizen cane of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
 7673	lousy huge legitimate business on the beach	3	decent	
 7674	cool hep waders	0		Moxie: +5, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	normal small bouncing mirror purple jive turkey leg	2	good	
+7675	normal small mirror purple bouncing jive turkey leg	2	good	
 7676	skewed nasty birdbone corset	0		Stench Damage: +5
 7677	nitrogenated wet gray candy cigarette	0		Effect: "Engorged Weapon", Effect Duration: 45
 7678	4-dimensional fez of incineration	0		Hot Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	family-friendly super-absorbent tarp	0		Sleaze Resistance: +1
-7681	mediocre triple-distilled bouncing unquiet spirits	10	decent	
+7681	triple-distilled mediocre bouncing unquiet spirits	10	decent	
 7682	lion tamer's banjo kazoo mount	0		Experience (familiar): +2, Single Equip
 7683	enhanced boiled upside-down grass	0		Effect: "Tenacity of the Snapper", Effect Duration: 66
 7684	gravedigger's Time Lord Participation Mug	0		Spooky Damage: +10
@@ -7584,13 +7584,13 @@
 7695	family-friendly cap gun of terror of bravery	0		Spooky Spell Damage: +10, Spooky Resistance: +5, Sleaze Resistance: +1, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	ruddy cassette player of the blizzard	0		Maximum HP Percent: +40, Cold Spell Damage: +25, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
-7698	teal blinking rubber spider	0		Last Available: "2014-08"
+7698	blinking teal rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	pickled improved red confiscated comic book	0		Effect: "Celestial Sheen", Effect Duration: 62, Last Available: "2014-08"
-7701	alkaline skewed teal confiscated cell phone	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 44, Last Available: "2014-08"
+7701	alkaline teal skewed confiscated cell phone	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 44, Last Available: "2014-08"
 7702	quantum confiscated love note	0		Effect: "Stickler for Promptness", Effect Duration: 65, Last Available: "2014-08"
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
-7704	cyan huge LCD game: Garbage River	0		Last Available: "2014-08"
+7704	huge cyan LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	quadruple-activated boiled rubber nubbin	0		Effect: "Memories of Puppy Love", Effect Duration: 37, Last Available: "2014-08"
@@ -7616,12 +7616,12 @@
 7727	denatured Burt's blessing of Bacchus	0		Effect: "Flaming Weapon", Effect Duration: 68
 7728	triple-deionized Freddie's blessing of Mercury	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 18
 7729	Chroner trigger	0		
-7730	purple jittery Xi Receiver Unit	0		Last Available: "2014-09"
+7730	jittery purple Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
 7732	pulsating Black Bart's Booty	0		Skill: "Pirate Bellow"
 7733	ghostly Xiblaxian circuitry	0		Last Available: "2014-09"
 7734	blurry Xiblaxian polymer	0		Last Available: "2014-09"
-7735	fuchsia pulsating Xiblaxian alloy	0		Last Available: "2014-09"
+7735	pulsating fuchsia Xiblaxian alloy	0		Last Available: "2014-09"
 7736	skewed Xiblaxian crystal	0		Last Available: "2014-09"
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
 7738	ghostly Xiblaxian cache locator simcode	0		Last Available: "2014-09"
@@ -7646,7 +7646,7 @@
 7757	tolerable tumbling Xiblaxian space-whiskey	3	good	Last Available: "2014-09"
 7758	upside-down upside-down Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	irradiated dry They liver	0		Effect: "The Halls of Muscularity", Effect Duration: 24, Last Available: "2014-09"
-7760	decent miniature They liver popsicle	2	good	Last Available: "2014-09"
+7760	miniature decent They liver popsicle	2	good	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7668,10 +7668,10 @@
 7779	ionized electrified concentrated huge experimental serum G-9	0		Effect: "Pop-eyed", Effect Duration: 40, Last Available: "2014-10"
 7780	yellow tumbling sinister dangerous heavy-duty clipboard of James Dean	0		Experience (Moxie): +3, Weapon Damage: +10, Spell Damage: +10, Damage Reduction: 8, Last Available: "2014-10"
 7781	upside-down horrifying Jim Carey's battery-powered drill of vim and vigor of bravery	0		Maximum HP Percent: +50, Monster Level: +25, Spooky Damage: +25, Spooky Resistance: +5, Last Available: "2014-10"
-7782	jumbo normal blinking limp broccoli	5	good	Last Available: "2014-10"
+7782	normal jumbo blinking limp broccoli	5	good	Last Available: "2014-10"
 7783	horrifying lion tamer's beefy hat	0		Muscle: +10, Experience (familiar): +2, Spooky Damage: +25, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	electrified moist gray pulsating monkey barf	0		Effect: "Morbidi Tea", Effect Duration: 11, Last Available: "2014-10"
-7785	dry blurry green candy	0		Effect: "Coldfinger", Effect Duration: 14, Last Available: "2014-10"
+7785	dry green blurry candy	0		Effect: "Coldfinger", Effect Duration: 14, Last Available: "2014-10"
 7786	fireproof padded smartaleck's jangly bracelet	0		Moxie Percent: +30, Damage Absorption: +20, Hot Resistance: +3, Last Available: "2014-10"
 7787	vibrating cuddly teddy bear	0		Maximum MP Percent: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	gray ice-cold Cloaca Zero	0		Last Available: "2014-10"
@@ -7683,10 +7683,10 @@
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	rotten tiny yellow initiative shawarma	1	crappy	Last Available: "2014-10"
 7796	flavorless warm war shawarma	4	decent	Last Available: "2014-10"
-7797	small spoiled karma shawarma	2	crappy	Last Available: "2014-10"
-7798	watered-down bad huge Jungle Juice	2	decent	Last Available: "2014-10"
+7797	spoiled small karma shawarma	2	crappy	Last Available: "2014-10"
+7798	bad watered-down huge Jungle Juice	2	decent	Last Available: "2014-10"
 7799	watered-down acceptable Amnesiac Ale	2	good	Last Available: "2014-10"
-7800	bad irresponsibly strong Highest Bitter	7	decent	Last Available: "2014-10"
+7800	irresponsibly strong bad Highest Bitter	7	decent	Last Available: "2014-10"
 7801	executive greedy mercenary pistol	0		Meat Drop: 60, Last Available: "2014-10"
 7802	dangerous mercenary rifle of the early riser	0		Weapon Damage: +10, Adventures: +7, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7696,9 +7696,9 @@
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
 7809	pulsating impure gasoline	0		
-7810	cyan bouncing narrow Z-Bone steak	0		
+7810	narrow cyan bouncing Z-Bone steak	0		
 7811	pulsating viral DNA	0		
-7812	pulsating lime green mirror tarnished bottlecap	0		
+7812	lime green mirror pulsating tarnished bottlecap	0		
 7813	spoiled special narrow seared dino steak	3	crappy	Effect: "Booing Radly", Effect Duration: 35
 7814	acceptable irresponsibly strong bottle of drinkin' gas	8	good	
 7815	handful of napalm	0		
@@ -7736,7 +7736,7 @@
 7847	tarnished polymerized ruby on canes	0		Effect: "Piratey Flavor", Effect Duration: 46, Last Available: "2014-12"
 7848	moldy huge red petit fortran	8	crappy	Last Available: "2014-12"
 7849	bland gray narrow java cookie	3	decent	Last Available: "2014-12"
-7850	low-calorie moldy enchanted cookie cookie	1	crappy	Effect: "Spooky Blur", Effect Duration: 25, Last Available: "2014-12"
+7850	enchanted moldy low-calorie cookie cookie	1	crappy	Effect: "Spooky Blur", Effect Duration: 25, Last Available: "2014-12"
 7851	veiny plastic exo-suited miner	0		Maximum HP: +10, Last Available: "2014-12"
 7852	greasy plastic semi-autonomous drill unit	0		Sleaze Spell Damage: +10, Last Available: "2014-12"
 7853	tumbling miser's plastic ambulatory robo-minecart	0		Meat Drop: +10, Last Available: "2014-12"
@@ -7808,11 +7808,11 @@
 7919	energized Big Punk	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 28
 7920	shaking fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	drinkable watered-down Friendly Turkey	2	good	Last Available: "2014-11"
+7922	watered-down drinkable Friendly Turkey	2	good	Last Available: "2014-11"
 7923	delicious fortified Agitated Turkey	5	awesome	Last Available: "2014-11"
 7924	practically non-alcoholic drinkable Ambitious Turkey	1	good	Last Available: "2014-11"
-7925	massive decent neutron lollipop	9	good	Last Available: "2014-12"
-7926	tolerable spirit-forward green gamma nog	5	good	Last Available: "2014-12"
+7925	decent massive neutron lollipop	9	good	Last Available: "2014-12"
+7926	spirit-forward tolerable green gamma nog	5	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
@@ -7820,14 +7820,14 @@
 7938	mixed shaking single atom	1	good	Effect: "Jawin'", Effect Duration: 35, Last Available: "2015-02"
 7939	huge Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
-7941	blurry mirror sleeve deuce	0		
+7941	mirror blurry sleeve deuce	0		
 7942	pocket ace	0		
-7943	bouncing upside-down nastygeist	0		
+7943	upside-down bouncing nastygeist	0		
 7944	tooth	0		
 7945	table	0		
 7946	ruddy weightlifter's outlaw bandana of the dark arts	0		Muscle: +15, Spell Damage Percent: +100, Maximum HP Percent: +40
 7947	bad whiskey in a broken glass	4	decent	
-7948	fortified fancy perfectly mixed skewed shot of mescal	5	EPIC	Effect: "Spooky Demeanor", Effect Duration: 35
+7948	fancy fortified perfectly mixed skewed shot of mescal	5	EPIC	Effect: "Spooky Demeanor", Effect Duration: 35
 7949	hand-crafted spirit-forward glass of herbal tequila	5	EPIC	
 7950	minin' dynamite	0		
 7951	huge knitted plaid cowboy hat of incineration	0		Hot Spell Damage: +50, Cold Resistance: +3, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7877,7 +7877,7 @@
 7995	wobbly dangerous boxer's pelerine	0		Muscle Percent: +10, Weapon Damage: +10, Last Available: "2015-12"
 7996	yellow horrifying nippy phantom mask	0		Cold Damage: +10, Spooky Damage: +25, Single Equip, Last Available: "2015-12"
 7997	dried red mirror polyesterene powder	1		Last Available: "2015-12"
-7998	vaporized narrow yellow blinking powder	1		Effect: "Salsa Satanica", Effect Duration: 10, Last Available: "2015-12"
+7998	vaporized yellow blinking narrow powder	1		Effect: "Salsa Satanica", Effect Duration: 10, Last Available: "2015-12"
 7999	double-unsweetened boiled diffused choco-Crimbot	0		Effect: "Busy Bein' Delicious", Effect Duration: 26, Last Available: "2014-12"
 8000	adjusted shaking shaking smart watch	0		Effect: "Crusty Head", Effect Duration: 33, Last Available: "2014-12"
 8001	colloidal cold-filtered huge augmented-reality shades	0		Effect: "Pumped Up", Effect Duration: 50, Last Available: "2014-12"
@@ -7895,7 +7895,7 @@
 8013	purple Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8016	Vulcanized shaking fuchsia fitness wristband	0		Effect: "Oily Flavor", Effect Duration: 49, Last Available: "2014-12"
+8016	Vulcanized fuchsia shaking fitness wristband	0		Effect: "Oily Flavor", Effect Duration: 49, Last Available: "2014-12"
 8017	ionized diffused spinning flask of tainted mining oil	0		Effect: "Super Vision", Effect Duration: 40, Last Available: "2014-12"
 8018	tarnished mirror and rain stick	0		Effect: "Human-Hobo Hybrid", Effect Duration: 42
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
@@ -7937,7 +7937,7 @@
 8056	skewed torch	0		
 8057	executive [spelunking test kit] of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +40
 8058	auspicious plasma rifle	0		Item Drop: +10
-8059	teal narrow upside-down Bananubis's Staff	0		Luck: -6
+8059	upside-down teal narrow Bananubis's Staff	0		Luck: -6
 8060	fuchsia narrow pulsating knitted greasy The Joke Book of the Dead	0		Sleaze Spell Damage: +10, Cold Resistance: +3, Luck: -6
 8061	green The Clown Crown	0		Luck: -6
 8062	blurry coffee cup	0		Luck: -2
@@ -7955,8 +7955,8 @@
 8074	twirling baleful Spelunker's fedora of the empath of the glutton	0		Spell Damage: +25, Familiar Weight: +5, Food Drop: +100, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	friendly hardy Sinatra's Spelunker's whip	0		Experience (Moxie): +5, Maximum HP: +50, Familiar Weight: +3, Last Available: "2015-12"
 8076	Sherlock's chaotic Spelunker's khakis of temperance	0		Spell Critical Percent: +10, Sleaze Resistance: +5, Item Drop: +25, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
-8077	tumbling blinking Spelunker's Guild prize sack	0		Last Available: "2015-12"
-8084	mirror lime green LOLmec statuette	0		Last Available: "2015-12"
+8077	blinking tumbling Spelunker's Guild prize sack	0		Last Available: "2015-12"
+8084	lime green mirror LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
@@ -8040,14 +8040,14 @@
 8166	greedy sizzling cr&ecirc;epy mask	0		Hot Damage: +10, Meat Drop: +20, Familiar Effect: "spooky atk, cap 5"
 8167	super-sized delicious baguette	5	awesome	
 8168	glob of icing	0		
-8169	deionized denatured blinking pulsating ginger snaps	0		Effect: "Tightly-Wound Spine", Effect Duration: 54
+8169	deionized denatured pulsating blinking ginger snaps	0		Effect: "Tightly-Wound Spine", Effect Duration: 54
 8170	alkaline mostly-broken sunglasses	0		Effect: "Good Motivator", Effect Duration: 39
 8171	perfectly mixed purple unflavored wine cooler	4	EPIC	
 8172	carton of snake milk	1	decent	
 8173	sewer snake of bravery	0		Spooky Resistance: +5
-8174	low-calorie tasty pigeon egg	1	awesome	
+8174	tasty low-calorie pigeon egg	1	awesome	
 8175	Newton's jaunty feather of the dark arts	0		Experience (Mysticality): +3, Spell Damage Percent: +100
-8176	aged practically non-alcoholic premium malt liquor	1	awesome	
+8176	practically non-alcoholic aged premium malt liquor	1	awesome	
 8177	Jim Carey's brown paper pants of vim and vigor	0		Maximum HP Percent: +50, Monster Level: +25
 8178	Oprah's hardened brown paper bag mask	0		Damage Reduction: 3, Maximum MP Percent: +50
 8179	purple flame-retardant ring of telling skeletons what to do	0		Hot Resistance: +1, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8060,12 +8060,12 @@
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	mediocre Cherrytastrophe wine cooler	4	decent	
-8189	tolerable irresponsibly strong Radberry Rip wine cooler	9	good	
+8189	irresponsibly strong tolerable Radberry Rip wine cooler	9	good	
 8190	artisanal Orangemageddon wine cooler	4	EPIC	
-8191	artisanal special Breakfast Blast wine cooler	3	EPIC	Effect: "Robocamo", Effect Duration: 45
-8192	high-proof lousy bouncing Citrus Crush wine cooler	8	decent	
+8191	special artisanal Breakfast Blast wine cooler	3	EPIC	Effect: "Robocamo", Effect Duration: 45
+8192	lousy high-proof bouncing Citrus Crush wine cooler	8	decent	
 8193	flavorless tumbling plain bagel	3	decent	
-8194	moldy fancy glob of cream cheese	3	crappy	Effect: "Eye of the Lihc", Effect Duration: 20
+8194	fancy moldy glob of cream cheese	3	crappy	Effect: "Eye of the Lihc", Effect Duration: 20
 8195	moldy teal loaf of soda bread	4	crappy	
 8196	flavorless acceptable bagel	3	decent	
 8197	normal standard-issue cupcake	3	good	
@@ -8074,7 +8074,7 @@
 8200	spoiled popular tart	4	crappy	
 8201	no-handed pie	0		
 8202	modified Doc Galaktik's Vitality Serum	0		Effect: "Blubbered Up", Effect Duration: 59
-8203	upside-down ghostly airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
+8203	ghostly upside-down airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
 8204	one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	FunFunds&trade;	0		Last Available: "2015-04"
 8206	yellow lion tamer's savvy expensive camera	0		Mysticality Percent: +20, Experience (familiar): +2, Single Equip, Last Available: "2015-04"
@@ -8087,11 +8087,11 @@
 8213	reassuring coward's rigging rope	0		Monster Level: -20, Spooky Resistance: +1, Last Available: "2015-04"
 8214	twisted nasty snuff	1	good	Last Available: "2015-04"
 8215	sewage-clogged pistol of the scaredy-cat of the boozehound	0		Monster Level: -15, Booze Drop: +100, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
-8216	super-chilled pressed pickled jittery maroon beard incense	0		Effect: "Ginger Snapped", Effect Duration: 39, Last Available: "2015-04"
+8216	super-chilled pressed pickled maroon jittery beard incense	0		Effect: "Ginger Snapped", Effect Duration: 39, Last Available: "2015-04"
 8217	squat hardy personal trainer's perfume-soaked bandana	0		Experience Percent (Muscle): +10, Maximum HP: +50, Single Equip, Last Available: "2015-04"
 8218	fuchsia toxic globule	0		Last Available: "2015-04"
 8219	bland low-calorie pulsating toxo	1	decent	Last Available: "2015-04"
-8220	bad fortified Lemonade-235	5	decent	Last Available: "2015-04"
+8220	fortified bad Lemonade-235	5	decent	Last Available: "2015-04"
 8221	skewed smelly stylish isotophat	0		Moxie: +25, Stench Spell Damage: +10, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	skewed red censurious savvy Three Mile Island shorts	0		Mysticality Percent: +20, Sleaze Resistance: +3, Last Available: "2015-04"
 8223	nasty energetic toxic mop	0		Maximum MP Percent: +20, Stench Damage: +5, Last Available: "2015-04"
@@ -8111,7 +8111,7 @@
 8237	yellow Dinsey's pants of the storm of Flo-Jo	0		Maximum MP Percent: +40, Initiative: +100, Last Available: "2015-04"
 8238	brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
-8240	upside-down tumbling keycard &beta;	0		Last Available: "2015-04"
+8240	tumbling upside-down keycard &beta;	0		Last Available: "2015-04"
 8241	narrow keycard &gamma;	0		Last Available: "2015-04"
 8242	fuchsia keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
@@ -8120,7 +8120,7 @@
 8246	bouncing friendly energetic Dinsey mascot mask of wisdom	0		Mysticality: +15, Maximum MP Percent: +20, Familiar Weight: +3, Last Available: "2015-04"
 8247	snack-sized toothsome blurry shaking Dinsey food-cone	2	awesome	Last Available: "2015-04"
 8248	aged Dinsey Whinskey	4	awesome	Last Available: "2015-04"
-8249	non-denatured mirror gray Dinsey face paint	0		Effect: "Educated (Sorta)", Effect Duration: 38, Last Available: "2015-04"
+8249	non-denatured gray mirror Dinsey face paint	0		Effect: "Educated (Sorta)", Effect Duration: 38, Last Available: "2015-04"
 8250	hale fannypack of wisdom	0		Mysticality: +15, Maximum HP: +20, Last Available: "2015-04"
 8251	maroon hardy personal trainer's Herculean Rosewater's boxer's slick garbage sticker	0		Moxie: +10, Muscle Percent: +10, Mysticality Percent: +30, Experience (Muscle): +1, Experience Percent (Muscle): +10, Maximum HP: +50, Last Available: "2015-04"
 8252	manspreader's stylish weightlifter's hazmat helmet of the empath of the boozehound	0		Muscle: +15, Moxie: +25, Monster Level: +10, Familiar Weight: +5, Booze Drop: +100, Last Available: "2015-04"
@@ -8142,13 +8142,13 @@
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	gray mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	spoiled unappetizing mayolus	3	crappy	Last Available: "2015-05"
-8271	diet flavorless uninteresting mayolus	1	decent	Last Available: "2015-05"
+8271	flavorless diet uninteresting mayolus	1	decent	Last Available: "2015-05"
 8272	spoiled acceptable mayolus	4	crappy	Last Available: "2015-05"
 8273	stale gigantic enticing mayolus	8	decent	Last Available: "2015-05"
 8274	tasty mouth-watering mayolus	3	awesome	Last Available: "2015-05"
-8275	wobbly spinning newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
+8275	spinning wobbly newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	jittery spinning mayo pump	0		Familiar Weight: +5
-8277	tumbling tumbling olive Essence of Bear	0		Skill: "Bear Essence"
+8277	tumbling olive tumbling Essence of Bear	0		Skill: "Bear Essence"
 8278	lousy wobbly Afternoon Delight	4	decent	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
@@ -8197,7 +8197,7 @@
 8323	triple-adjusted squat ghostly Cracklin' Oat Bran	0		Effect: "Eyes for Miles", Effect Duration: 42
 8324	polymerized blue disposable lighter	0		Effect: "In the Limelight", Effect Duration: 37
 8325	irradiated coal contact lenses	0		Effect: "Permanent Halloween", Effect Duration: 62
-8326	electrified altered ghostly jittery conjured ice cream	0		Effect: "Destructive Resolve", Effect Duration: 65
+8326	electrified altered jittery ghostly conjured ice cream	0		Effect: "Destructive Resolve", Effect Duration: 65
 8327	quadruple-modified lime green Iceberglar scarf	0		Effect: "Pronounced Potency", Effect Duration: 13
 8328	frozen unsweetened narrow icy hairspray	0		Effect: "Speed of the Internet", Effect Duration: 33
 8329	unsweetened extra-irradiated smellbook	0		Effect: "Strange Mental Acuity", Effect Duration: 14
@@ -8215,7 +8215,7 @@
 8341	double-boiled deionized pulsating warehouse clerk's glasses	0		Effect: "Berry Critical", Effect Duration: 32
 8342	polarized maroon baloney rotgut	0		Effect: "Lobos Fresh", Effect Duration: 46
 8343	super-polarized carton of gaspers	0		Effect: "Superioreo", Effect Duration: 15
-8344	non-enhanced flattened irradiated squat green tumbling bronze polish	0		Effect: "Tenacity of the Snapper", Effect Duration: 24
+8344	non-enhanced flattened irradiated green tumbling squat bronze polish	0		Effect: "Tenacity of the Snapper", Effect Duration: 24
 8345	cold-filtered mirror crident	0		Effect: "Boilermade", Effect Duration: 27
 8346	altered triple-Vulcanized colloidal spinning totally sweet mohawk helmet	0		Effect: "There Is A Spoon", Effect Duration: 47
 8347	aerosolized spray chrome	0		Effect: "Unusual Perspective", Effect Duration: 60
@@ -8225,18 +8225,18 @@
 8351	moist Vulcanized lump of goofball ore	0		Effect: "Stinky Hands", Effect Duration: 55
 8352	non-irradiated skeleton beans	0		Effect: "Bolts about Candy", Effect Duration: 68
 8353	pickled grimy lab coat	0		Effect: "Three Days Slow", Effect Duration: 58
-8354	denatured shaking bouncing nursery rhyme	0		Effect: "Amorous", Effect Duration: 39
+8354	denatured bouncing shaking nursery rhyme	0		Effect: "Amorous", Effect Duration: 39
 8355	denatured energized tumbling iron torso box	0		Effect: "Nuts about Candy", Effect Duration: 31
 8356	frozen activated mercenary headband	0		Effect: "Moon-Eyed", Effect Duration: 64
 8357	concentrated green radioactive spider venom	0		Effect: "Shamboozled", Effect Duration: 11
 8358	dry wobbly x-ray mirror	0		Effect: "Well-Lubed", Effect Duration: 16
-8359	pressed modified squat ghostly wrestling mask	0		Effect: "Mmmmmelon", Effect Duration: 60
+8359	pressed modified ghostly squat wrestling mask	0		Effect: "Mmmmmelon", Effect Duration: 60
 8360	triple-corrupted huge hawkface potion	0		Effect: "Superhuman Sarcasm", Effect Duration: 43
 8361	frozen adjusted blinking child-sized dracula cloak	0		Effect: "Spell Transfer Complete", Effect Duration: 25
 8362	boiled tumbling devil-summoning hat	0		Effect: "Antsy in your Pantsy", Effect Duration: 33
 8363	super-activated galvanized blurry shopkeeper beard	0		Effect: "Leo Rising", Effect Duration: 59
-8364	extra-moist blinking bouncing alien autoautopsy kit	0		Effect: "Tenacity of the Snapper", Effect Duration: 39
-8365	vacuum-sealed mirror wobbly novelty fruit hat	0		Effect: "Unrunnable Face", Effect Duration: 26
+8364	extra-moist bouncing blinking alien autoautopsy kit	0		Effect: "Tenacity of the Snapper", Effect Duration: 39
+8365	vacuum-sealed wobbly mirror novelty fruit hat	0		Effect: "Unrunnable Face", Effect Duration: 26
 8366	activated frozen blurry invisibility cream	0		Effect: "Sparkling Consciousness", Effect Duration: 59
 8367	warmed bouncing handful of stubble	0		Effect: "Electrolit Up", Effect Duration: 45
 8368	dry oxidized garbage juice slurpee	0		Effect: "Frigid Weapon", Effect Duration: 32
@@ -8263,7 +8263,7 @@
 8389	mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	blinking mana	0		Last Available: "2015-07"
-8392	pulsating cyan gift card	0		Last Available: "2015-07"
+8392	cyan pulsating gift card	0		Last Available: "2015-07"
 8393	maroon hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	blurry The Emperor's new hat of wisdom	0		Mysticality: +15, Last Available: "2015-07"
@@ -8277,26 +8277,26 @@
 8403	skewed medical-grade weightlifter's revolver	0		Muscle: +15, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-07"
 8404	blurry 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	huge talking spade	0		Free Pull
-8406	narrow cyan savory dry noodles	0		
+8406	cyan narrow savory dry noodles	0		
 8407	adequate pestopiary	4	good	
 8408	polarized bouncing ectoplasmic orbs	0		Effect: "Seriously Mutated", Effect Duration: 22
-8409	small bland mirror crudles	2	decent	
+8409	bland small mirror crudles	2	decent	
 8410	normal green agnolotti arboli	4	good	
-8411	normal thick lime green spaghetti with ghost balls	5	good	
+8411	thick normal lime green spaghetti with ghost balls	5	good	
 8412	bland pulsating succulent marrow	4	decent	
-8413	small spoiled salacious crumbs	2	crappy	
-8414	immense rotten fusilli marrownarrow	7	crappy	
+8413	spoiled small salacious crumbs	2	crappy	
+8414	rotten immense fusilli marrownarrow	7	crappy	
 8415	flavorless suggestive strozzapreti	3	decent	
 8416	Mountain Stream gastrique	0		
-8417	big toothsome mirror Mt. McLargeHuge oyster	5	awesome	
+8417	toothsome big mirror Mt. McLargeHuge oyster	5	awesome	
 8418	oyster sauce	0		
-8419	immense bland maroon linguini immondizia bianco	9	decent	
+8419	bland immense maroon linguini immondizia bianco	9	decent	
 8420	moldy shells a la shellfish	4	crappy	
 8421	Jick's autograph	0		
 8422	twirling high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
-8425	red upside-down New Age healing crystal	0		Last Available: "2015-08"
+8425	upside-down red New Age healing crystal	0		Last Available: "2015-08"
 8426	Volcoino	0		Last Available: "2015-08"
 8427	fizzing spore pod	0		
 8428	blinking spore pod	0		
@@ -8315,7 +8315,7 @@
 8441	full lava bottle	0		Last Available: "2015-08"
 8442	red viscous lava globs	0		Last Available: "2015-08"
 8443	lime green lava globs	0		Last Available: "2015-08"
-8444	upside-down blue lava globs	0		Last Available: "2015-08"
+8444	blue upside-down lava globs	0		Last Available: "2015-08"
 8445	lava globs	0		Last Available: "2015-08"
 8446	SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
@@ -8331,10 +8331,10 @@
 8457	huge broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	blinking gravedigger's high-temperature mining mask of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	wobbly crafty fireproof megaphone of wisdom	0		Mysticality: +15, Maximum MP: +10, Last Available: "2015-08"
-8460	adequate tiny twirling mineapple	1	good	Last Available: "2015-08"
-8461	drinkable watered-down lime green Gold Velvet&trade; whiskey	2	good	Last Available: "2015-08"
+8460	tiny adequate twirling mineapple	1	good	Last Available: "2015-08"
+8461	watered-down drinkable lime green Gold Velvet&trade; whiskey	2	good	Last Available: "2015-08"
 8462	upside-down SMOOCH soda	1	awesome	Last Available: "2015-08"
-8463	snack-sized normal squat smelted roe	2	good	Last Available: "2015-08"
+8463	normal snack-sized squat smelted roe	2	good	Last Available: "2015-08"
 8464	hand-crafted lavawater	3	EPIC	Last Available: "2015-08"
 8465	concentrated basaltamander tongue	0		Effect: "Rave Nirvana", Effect Duration: 52, Last Available: "2015-08"
 8466	vibrating slick lavalarva of Leguizamo	0		Moxie: +10, Maximum MP Percent: +10, Monster Level: +20, Last Available: "2015-08"
@@ -8397,7 +8397,7 @@
 8523	fused fuse	0		Last Available: "2015-08"
 8524	squat superheated	0		Last Available: "2015-08"
 8525	adequate red lava cake	3	good	Last Available: "2015-08"
-8526	decent snack-sized pink slime	2	good	
+8526	snack-sized decent pink slime	2	good	
 8527	lime green Devil's Elbow Hot Sauce	0		
 8528	narrow Special&trade; Sauce	0		
 8529	moldy devil hair pasta	4	crappy	
@@ -8412,15 +8412,15 @@
 8539	olive Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	adequate tiny Fettris	1	good	
-8543	diet flavorless fusillocybin	1	decent	
+8542	tiny adequate Fettris	1	good	
+8543	flavorless diet fusillocybin	1	decent	
 8544	decent prescription noodles	4	good	
 8545	pickled tumbling blood-drive sticker	1	decent	
 8546	wet bag of grain	0		Effect: "20-20 Second Sight", Effect Duration: 42
 8547	frozen shaking purple pocket maze	0		Effect: "Puddingface", Effect Duration: 11
-8548	triple-cold-filtered yellow blurry upside-down shady shades	0		Effect: "Black Eyes", Effect Duration: 55
+8548	triple-cold-filtered upside-down yellow blurry shady shades	0		Effect: "Black Eyes", Effect Duration: 55
 8549	colloidal diffused upside-down squeaky toy rose	0		Effect: "Ten out of Ten", Effect Duration: 28
-8550	yummy pulsating twirling weird gazelle steak	4	awesome	
+8550	yummy twirling pulsating weird gazelle steak	4	awesome	
 8551	decent blurry sausage without a cause	4	good	
 8552	alkaline unsweetened face paint	0		Effect: "Shredding, Sweating", Effect Duration: 17
 8553	hand-crafted skewed emergency margarita	4	super ultra mega EPIC	
@@ -8440,7 +8440,7 @@
 8567	hale personal trainer's bankruptcy barrel of terror	0		Experience Percent (Muscle): +10, Maximum HP: +20, Spooky Spell Damage: +10, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	cyan firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
-8570	yellow blurry tun	0		Last Available: "2015-09"
+8570	blurry yellow tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
 8572	barrel	0		Last Available: "2015-09"
 8573	green barrel	0		Last Available: "2015-09"
@@ -8449,15 +8449,15 @@
 8576	tumbling mouldering barrel	0		Last Available: "2015-09"
 8577	bouncing barnacled barrel	0		Last Available: "2015-09"
 8578	lousy bottle of Amontillado	4	decent	Last Available: "2015-09"
-8579	delicious high-proof twirling olive barrel-aged martini	6	awesome	Last Available: "2015-09"
+8579	high-proof delicious twirling olive barrel-aged martini	6	awesome	Last Available: "2015-09"
 8580	adequate barrel pickle	3	good	Last Available: "2015-09"
 8581	spoiled snack-sized upside-down barrel cracker	2	crappy	Last Available: "2015-09"
 8582	pickled huge vibrating mushroom	1	awesome	Last Available: "2015-09"
-8583	boiled huge cyan mushroom	1	good	Last Available: "2015-09"
+8583	boiled cyan huge mushroom	1	good	Last Available: "2015-09"
 8584	gray toasty KoL Con 12-gauge	0		Hot Damage: +5, Last Available: "2015-09"
 8585	lime green Golden Mr. Eh? of the cougar	0		Moxie: +20, Last Available: "2015-09"
 8586	hardened barrel gun	0		Damage Reduction: 3, Last Available: "2015-09"
-8587	maroon shaking squat barrel	0		Last Available: "2015-09"
+8587	shaking maroon squat barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
 8589	moldy water log	4	crappy	Last Available: "2015-09"
 8590	upside-down ribald resourceful barrelhead	0		Maximum MP: +50, Sleaze Damage: +10, Last Available: "2015-09"
@@ -8498,7 +8498,7 @@
 8625	twisted maroon cuppa Cruel tea	1		Last Available: "2015-09"
 8626	boiled dry narrow cuppa Alacri tea	0		Effect: "White Knuckles", Effect Duration: 36, Last Available: "2015-09"
 8627	corrupted super-ionized shaking pulsating cuppa Vitali tea	0		Effect: "Slimed Stomach", Effect Duration: 14, Last Available: "2015-09"
-8628	dry magnetized wobbly spinning squat maroon cuppa Mana tea	0		Effect: "Full Bottle in front of Me", Effect Duration: 33, Last Available: "2015-09"
+8628	dry magnetized maroon squat spinning wobbly cuppa Mana tea	0		Effect: "Full Bottle in front of Me", Effect Duration: 33, Last Available: "2015-09"
 8629	colloidal shaking red cuppa Monstrosi tea	0		Effect: "Fancy Feasted", Effect Duration: 63, Last Available: "2015-09"
 8630	nitrogenated lime green cuppa Twen tea	0		Effect: "You Know What's Up", Effect Duration: 58, Last Available: "2015-09"
 8631	modified energized green cuppa Gill tea	0		Effect: "Eye of the Seal", Effect Duration: 53, Last Available: "2015-09"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	up-at-dawn fireproof occult hawk	0		Spell Damage Percent: +25, Hot Resistance: +3, Adventures: +5
-8655	bland half-sized hamlet sandwich	2	decent	
+8655	half-sized bland hamlet sandwich	2	decent	
 8656	Othello's military jacket of vim and vigor	0		Maximum HP Percent: +50
 8657	baleful Othello's dagger	0		Spell Damage: +25, Single Equip
 8658	rock-hard Othello's handkerchief	0		Damage Reduction: 5, Single Equip
@@ -8547,8 +8547,8 @@
 8674	mirror airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	blurry one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	diffused ionized maroon shoulder-warming lotion	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 56, Last Available: "2015-11"
-8677	fancy miniature bland jittery iceberg lettuce	2	decent	Effect: "Ack!  Barred!", Effect Duration: 45, Last Available: "2015-11"
-8678	perfectly mixed enchanted practically non-alcoholic twirling ice wine	1	super ultra mega turbo EPIC	Effect: "Space Cadet", Effect Duration: 40, Last Available: "2015-11"
+8677	miniature bland fancy jittery iceberg lettuce	2	decent	Effect: "Ack!  Barred!", Effect Duration: 45, Last Available: "2015-11"
+8678	practically non-alcoholic enchanted perfectly mixed twirling ice wine	1	super ultra mega turbo EPIC	Effect: "Space Cadet", Effect Duration: 40, Last Available: "2015-11"
 8679	ruddy grievous Da Vinci's Wal-Mart snowglobe	0		Experience (Mysticality): +5, Weapon Damage Percent: +50, Maximum HP Percent: +40, Last Available: "2015-11"
 8680	shaking Usain Bolt's sinister Wal-Mart nametag of mayonnaise	0		Spell Damage: +10, Sleaze Spell Damage: +50, Initiative: +80, Last Available: "2015-11"
 8681	blinking Jeselnik's Jack Frost's boxer's Wal-Mart overalls	0		Muscle Percent: +10, Cold Spell Damage: +50, Sleaze Damage: +25, Last Available: "2015-11"
@@ -8559,14 +8559,14 @@
 8686	cyan perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	experienced bellhop's hat	0		Experience: +2, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	drinkable ice porter	3	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	drinkable ice porter	3	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	nitrogenated extra-galvanized enhanced exotic travel brochure	0		Effect: "Spirit Bubble", Effect Duration: 14, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	Vulcanized chilled triple-dry shampoo-conditioner	0		Effect: "Flagrantly Fragrant", Effect Duration: 51, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
-8696	dehydrated purple mirror medicinal herbs	1		Last Available: "2016-01"
+8696	dehydrated mirror purple medicinal herbs	1		Last Available: "2016-01"
 8697	stale ice rice	3	decent	Last Available: "2016-01"
 8698	drinkable twirling iced plum wine	3	good	Last Available: "2016-01"
 8699	shaking prompt groovy sage training belt	0		Mysticality Percent: +10, Moxie Percent: +10, Adventures: +3, Single Equip, Last Available: "2016-01"
@@ -8594,15 +8594,15 @@
 8721	cold-filtered VYKEA woadpaint	0		Effect: "Human-Machine Hybrid", Effect Duration: 28, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	narrow VYKEA blood rune	0		Last Available: "2015-11"
-8724	upside-down olive VYKEA lightning rune	0		Last Available: "2015-11"
+8724	olive upside-down VYKEA lightning rune	0		Last Available: "2015-11"
 8725	huge VYKEA plank	0		Last Available: "2015-11"
-8726	jittery mirror VYKEA rail	0		Last Available: "2015-11"
+8726	mirror jittery VYKEA rail	0		Last Available: "2015-11"
 8727	VYKEA bracket	0		Last Available: "2015-11"
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	studded forbidden VYKEA hex key of the brazier	0		Spell Damage Percent: +50, Damage Absorption: +80, Hot Spell Damage: +25, Last Available: "2015-11"
 8730	shaking VYKEA instructions	0		Last Available: "2015-11"
-8731	spoiled snack-sized tin of submardines	2	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
-8732	weak bad bottle of norwhiskey	2	decent	Last Available: "2015-11"
+8731	spoiled snack-sized tin of submardines	2	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8732	bad weak bottle of norwhiskey	2	decent	Last Available: "2015-11"
 8733	diluted squat skewed octolus oculus	1	good	Effect: "Uncucumbered", Effect Duration: 10, Last Available: "2015-11"
 8734	double-paned knitted stanky sardine can key	0		Stench Spell Damage: +25, Cold Resistance: 8, Last Available: "2015-11"
 8735	mansplainer's Tesla norwhal helmet of terror	0		Monster Level: +15, Spooky Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk", Last Available: "2015-11"
@@ -8615,7 +8615,7 @@
 8742	drinkable perfect paloma	4	good	Last Available: "2015-11"
 8743	pickled extra-concentrated ghostly gray That 70s Cologne	0		Effect: "The Halls of Mysticality", Effect Duration: 11, Last Available: "2015-11"
 8744	energized unsweetened ionized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Object Detection", Effect Duration: 47, Last Available: "2015-11"
-8745	galvanized spinning fuchsia blinking Puffstone cigar	0		Effect: "On a Roll", Effect Duration: 30, Last Available: "2015-11"
+8745	galvanized blinking spinning fuchsia Puffstone cigar	0		Effect: "On a Roll", Effect Duration: 30, Last Available: "2015-11"
 8746	triple-adjusted Conspiracy&trade; mascara	0		Effect: "Floundering", Effect Duration: 47, Last Available: "2015-11"
 8747	improved enhanced tumbling squat olive Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Strength of Ten Ettins", Effect Duration: 14, Last Available: "2015-11"
 8748	skewed airplane tattoo	0		Last Available: "2015-11"
@@ -8632,7 +8632,7 @@
 8759	grievous plastic Crimborgatron	0		Weapon Damage Percent: +50, Last Available: "2015-12"
 8760	savvy plastic Crimbodhisattva	0		Mysticality Percent: +20, Last Available: "2015-12"
 8761	bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
-8762	blue squat narrow stack of communist leaflets	0		Last Available: "2015-12"
+8762	blue narrow squat stack of communist leaflets	0		Last Available: "2015-12"
 8763	lime green BACON	0		Last Available: "2016-05"
 8764	blinking box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	teal Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
@@ -8653,7 +8653,7 @@
 8781	stanky pine cone necklace	0		Stench Spell Damage: +25, Last Available: "2015-12"
 8782	purple asbestos-lined reindeer hammer	0		Hot Resistance: +5, Last Available: "2015-12"
 8783	clever elf ploughshare	0		Maximum MP: +20, Last Available: "2015-12"
-8784	spinning squat circle drum	0		Last Available: "2015-12"
+8784	squat spinning circle drum	0		Last Available: "2015-12"
 8785	upside-down The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	spinning faded protest sign	0		Last Available: "2015-12"
 8787	blurry faded protest sign	0		Last Available: "2015-12"
@@ -8666,7 +8666,7 @@
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	narrow Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
-8797	bouncing pulsating twirling bat-oomerang	0		Last Available: "2017-01"
+8797	twirling bouncing pulsating bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
 8799	blurry bat-o-mite	0		Last Available: "2017-01"
 8800	ROM of Optimality	0		Skill: "Toggle Optimality"
@@ -8686,14 +8686,14 @@
 8814	spinning Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	moldy Kudzu salad	3	crappy	Last Available: "2016-12"
-8817	mixed fuchsia narrow tumbling Mansquito Serum	1		Last Available: "2016-12"
+8817	mixed narrow fuchsia tumbling Mansquito Serum	1		Last Available: "2016-12"
 8818	mediocre triple-distilled Miss Graves' vermouth	10	decent	Last Available: "2016-12"
 8819	spoiled diet The Plumber's mushroom stew	1	crappy	Last Available: "2016-12"
 8820	twisted The Author's ink	1		Last Available: "2016-02"
 8821	perfectly mixed watered-down The Mad Liquor	2	super ultra mega turbo EPIC	Last Available: "2016-12"
-8822	watered-down acceptable Doc Clock's thyme cocktail	2	good	Last Available: "2016-12"
-8823	super-sized adequate Mr. Burnsger	5	good	Last Available: "2016-12"
-8824	dried bouncing huge The Inquisitor's unidentifiable object	1		Effect: "Spookypants", Effect Duration: 20, Last Available: "2016-12"
+8822	acceptable watered-down Doc Clock's thyme cocktail	2	good	Last Available: "2016-12"
+8823	adequate super-sized Mr. Burnsger	5	good	Last Available: "2016-12"
+8824	dried huge bouncing The Inquisitor's unidentifiable object	1		Effect: "Spookypants", Effect Duration: 20, Last Available: "2016-12"
 8825	smelly electrified medical-grade The Jokester's gun	0		Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
 8826	pulsating executive gravedigger's energetic The Jokester's wig	0		Maximum MP Percent: +20, Spooky Damage: +10, Meat Drop: +40, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
 8827	shaking blue Usain Bolt's lion tamer's fortified The Jokester's pants	0		Damage Absorption: +60, Experience (familiar): +2, Initiative: +80, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
@@ -8704,9 +8704,9 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	improved robin's egg	0		Effect: "Eye of the Seal", Effect Duration: 48, Last Available: "2016-12"
 8834	rotten robin flan	3	crappy	Last Available: "2016-12"
-8835	weak special hand-crafted robin nog	2	EPIC	Effect: "Musky", Effect Duration: 10, Last Available: "2016-12"
+8835	special weak hand-crafted robin nog	2	EPIC	Effect: "Musky", Effect Duration: 10, Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
-8837	narrow purple plaintive telegram	0		Last Available: "2016-02"
+8837	purple narrow plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
 8839	cyan root beer barrel	0		
 8840	pressed double-altered wobbly Kudzu slaw	0		Effect: "Bats in the Belfry", Effect Duration: 18
@@ -8715,8 +8715,8 @@
 8843	diffused blinking can of drain cleaner	0		Effect: "Is This Your Card?", Effect Duration: 42
 8844	super-diffused The Author's inkwell	0		Effect: "Marco Polarity", Effect Duration: 24
 8845	electrified purple bag of random words	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 58
-8846	super-ionized bouncing cyan tube of pendulum lube	0		Effect: "Superheroic", Effect Duration: 27
-8847	altered adjusted mirror cyan red-hot jawbreaker	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 37
+8846	super-ionized cyan bouncing tube of pendulum lube	0		Effect: "Superheroic", Effect Duration: 27
+8847	altered adjusted cyan mirror red-hot jawbreaker	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 37
 8848	pressed non-wet colloidal question juice	0		Effect: "Puddingface", Effect Duration: 61
 8849	diffused tube of villain	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 41
 8850	olive asbestos-lined your cowboy boots	0		Hot Resistance: +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
@@ -8746,11 +8746,11 @@
 8874	green Sherlock's perfumed aromatic asbestos-lined occult Val-U Brand Every Bean Salad	0		Spell Damage Percent: +25, Hot Resistance: +5, Stench Resistance: 6, Item Drop: +25, Last Available: "2016-02"
 8875	prompt Shrub's Premium Baked Beans of the wise owl of the cheetah	0		Mysticality: +20, Initiative: +60, Adventures: +3, Last Available: "2016-02"
 8876	rotten plate of Heimz Fortified Kidney Beans	3	crappy	Last Available: "2016-02"
-8877	enchanted yummy green plate of Tesla's Electroplated Beans	3	awesome	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40, Last Available: "2016-02"
-8878	miniature stale squat plate of Mixed Garbanzos and Chickpeas	2	decent	Last Available: "2016-02"
+8877	yummy enchanted green plate of Tesla's Electroplated Beans	3	awesome	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 40, Last Available: "2016-02"
+8878	stale miniature squat plate of Mixed Garbanzos and Chickpeas	2	decent	Last Available: "2016-02"
 8879	moldy plate of Hellfire Spicy Beans	3	crappy	Last Available: "2016-02"
-8880	bland half-sized plate of Frigid Northern Beans	2	decent	Last Available: "2016-02"
-8881	half-sized tasty cyan plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
+8880	half-sized bland plate of Frigid Northern Beans	2	decent	Last Available: "2016-02"
+8881	tasty half-sized cyan plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
 8882	stale plate of Trader Olaf's Exotic Stinkbeans	3	decent	Last Available: "2016-02"
 8883	toothsome half-sized plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	awesome	Last Available: "2016-02"
 8884	bland plate of Val-U Brand Every Bean Salad	4	decent	Last Available: "2016-02"
@@ -8792,7 +8792,7 @@
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
-8923	spinning teal narrow disc (white)	0		
+8923	teal narrow spinning disc (white)	0		
 8924	blurry disc (black)	0		
 8925	disc (red)	0		
 8926	purple disc (green)	0		
@@ -8819,7 +8819,7 @@
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
-8950	spinning narrow slicksilver spurs	0		Last Available: "2016-02"
+8950	narrow spinning slicksilver spurs	0		Last Available: "2016-02"
 8951	sicksilver spurs	0		Last Available: "2016-02"
 8952	nicksilver spurs	0		Last Available: "2016-02"
 8953	bouncing ticksilver spurs	0		Last Available: "2016-02"
@@ -8841,29 +8841,29 @@
 8969	tumbling extremely unsafe eleven-gallon hat of chilblains	0		Weapon Damage Percent: +100, Cold Damage: +25
 8970	toy sixgun	0		
 8971	snake oil	0		
-8972	quantum huge squat skin oil	0		Effect: "Tasting the Rainbow", Effect Duration: 67
+8972	quantum squat huge skin oil	0		Effect: "Tasting the Rainbow", Effect Duration: 67
 8973	denatured unusual oil	0		Effect: "Dreadful Fear", Effect Duration: 25
 8974	chilled super-moist modified narrow eldritch oil	0		Effect: "BOOsted", Effect Duration: 59
 8975	exclusive club	0		
 8976	liquefied shaking spinning tumbling patent preventative tonic	0		Effect: "Frostbeard", Effect Duration: 30
 8977	pickled patent invisibility tonic	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 29
 8978	Vulcanized patent aggression tonic	0		Effect: "Destructive Resolve", Effect Duration: 65
-8979	colloidal aerosolized shaking olive patent sallowness tonic	0		Effect: "Flaming Weapon", Effect Duration: 37
-8980	ionized blinking huge patent avarice tonic	0		Effect: "Charrrming", Effect Duration: 52
+8979	colloidal aerosolized olive shaking patent sallowness tonic	0		Effect: "Flaming Weapon", Effect Duration: 37
+8980	ionized huge blinking patent avarice tonic	0		Effect: "Charrrming", Effect Duration: 52
 8981	alkaline extra-liquefied patent alacrity tonic	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 69
 8982	altered oxidized corrupted marrow	0		Effect: "Black Lung", Effect Duration: 51
-8983	enchanted perfectly mixed rodeo whiskey	3	EPIC	Effect: "Work For Hours a Week", Effect Duration: 20
+8983	perfectly mixed enchanted rodeo whiskey	3	EPIC	Effect: "Work For Hours a Week", Effect Duration: 20
 8984	Thwaitgold scorpion statuette	0		
 8985	real cowboy hat of James Dean	0		Experience (Moxie): +3
 8986	upside-down Memories of Cow Punching	0		Free Pull
 8987	Memories of Beanslinging	0		Free Pull
 8988	jittery narrow Memories of Snake Oiling	0		Free Pull
-8989	blurry ghostly Witchess Set	0		Free Pull, Last Available: "2016-03"
+8989	ghostly blurry Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	twisted mirror armored prawn	1		Effect: "Space Cowboy", Effect Duration: 20, Last Available: "2016-03"
 8993	adequate narrow jumping horseradish	4	good	Last Available: "2016-03"
-8994	mediocre pulsating skewed pulsating Sacramento wine	3	decent	Last Available: "2016-03"
+8994	mediocre skewed pulsating pulsating Sacramento wine	3	decent	Last Available: "2016-03"
 8995	colloidal upside-down Greek fire	0		Effect: "Serendipi Tea", Effect Duration: 25, Last Available: "2016-03"
 8996	auspicious supercharged fortified weightlifter's ox-head shield of terror	0		Muscle: +15, Damage Absorption: +60, Maximum MP Percent: +30, Spooky Spell Damage: +10, Item Drop: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	blinking perfumed rosewater-soaked mansplainer's MacGyver's boxer's dented scepter	0		Muscle Percent: +10, Maximum MP: +100, Monster Level: +15, Stench Resistance: 8, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8901,7 +8901,7 @@
 9029	no spoon	0		
 9030	toothsome pulsating star salad	4	awesome	
 9031	Thwaitgold moth statuette	0		
-9032	super-sized enchanted adequate bowl of Tastee-Wheet&trade;	5	good	Effect: "Frozen Shoulders", Effect Duration: 10
+9032	adequate enchanted super-sized bowl of Tastee-Wheet&trade;	5	good	Effect: "Frozen Shoulders", Effect Duration: 10
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	mirror Source essence	0		Last Available: "2016-06"
 9035	stale browser cookie	4	decent	Last Available: "2016-06"
@@ -8912,7 +8912,7 @@
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	shaking huge Source terminal SPAM chip	0		Last Available: "2016-06"
-9043	upside-down jittery Source terminal CRAM chip	0		Last Available: "2016-06"
+9043	jittery upside-down Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	blinking Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	shaking Source terminal INGRAM chip	0		Last Available: "2016-06"
@@ -8930,7 +8930,7 @@
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	narrow Source terminal file: turbo.edu	0		Last Available: "2016-06"
 9060	Source terminal file: familiar.ext	0		Last Available: "2016-06"
-9061	red huge Source terminal file: pram.ext	0		Last Available: "2016-06"
+9061	huge red Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	jittery Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
@@ -8980,7 +8980,7 @@
 9108	lead umbrella	0		
 9109	flattened Shrieking Weasel holo-record	0		Effect: "Punch Another Day", Effect Duration: 22
 9110	liquefied activated Power-Guy 2000 holo-record	0		Effect: "Deadly Flashing Blade", Effect Duration: 52
-9111	extra-magnetized activated yellow shaking Lucky Strikes holo-record	0		Effect: "Stinky Hands", Effect Duration: 55
+9111	extra-magnetized activated shaking yellow Lucky Strikes holo-record	0		Effect: "Stinky Hands", Effect Duration: 55
 9112	extra-adjusted moist EMD holo-record	0		Effect: "Mitre Cut", Effect Duration: 45
 9113	tarnished oxidized Superdrifter holo-record	0		Effect: "From Nantucket", Effect Duration: 41
 9114	altered enhanced nitrogenated The Pigs holo-record	0		Effect: "Blubbered Up", Effect Duration: 45
@@ -9004,7 +9004,7 @@
 9132	twirling pistol of the brute of Gandalf	0		Muscle Percent: +30, Spell Critical Percent: +20
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	flavorless maroon leftover pasty	3	decent	
-9135	hand-crafted special very whiskey	4	EPIC	Effect: "Supafly", Effect Duration: 35
+9135	special hand-crafted very whiskey	4	EPIC	Effect: "Supafly", Effect Duration: 35
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
 9138	skewed li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
@@ -9015,7 +9015,7 @@
 9143	twirling li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9146	enhanced anodized spinning blurry hoarded candy wad	0		Effect: "Disdain of the War Snapper", Effect Duration: 15, Last Available: "2016-10"
+9146	enhanced anodized blurry spinning hoarded candy wad	0		Effect: "Disdain of the War Snapper", Effect Duration: 15, Last Available: "2016-10"
 9147	activated polarized Prunets	0		Effect: "Neutered Nostrils", Effect Duration: 41
 9148	bouncing Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
@@ -9024,36 +9024,36 @@
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	delicious lime green raw sweet potato	3	awesome	Last Available: "2016-11"
 9154	small moldy pulsating raw beans	2	crappy	Last Available: "2016-11"
-9155	immense bland raw stuffing	6	decent	Last Available: "2016-11"
-9156	flavorless diet raw cranberry sauce	1	decent	Last Available: "2016-11"
+9155	bland immense raw stuffing	6	decent	Last Available: "2016-11"
+9156	diet flavorless raw cranberry sauce	1	decent	Last Available: "2016-11"
 9157	snack-sized stale raw turkey	2	decent	Last Available: "2016-11"
 9158	moldy raw mincemeat	4	crappy	Last Available: "2016-11"
-9159	thick rotten raw potato	5	crappy	Last Available: "2016-11"
+9159	rotten thick raw potato	5	crappy	Last Available: "2016-11"
 9160	adequate raw gravy	4	good	Last Available: "2016-11"
-9161	low-calorie delicious raw bread	1	awesome	Last Available: "2016-11"
+9161	delicious low-calorie raw bread	1	awesome	Last Available: "2016-11"
 9162	Usain Bolt's brainy mini-marshmallow dispenser	0		Mysticality: +5, Initiative: +80, Last Available: "2016-11"
 9163	manspreader's hardened glass casserole dish of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Monster Level: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	fortified Socratic can opener	0		Experience (Mysticality): +1, Damage Absorption: +60, Last Available: "2016-11"
-9166	mixed blinking red spinning tumbling turkey blaster	1		Last Available: "2016-11"
+9166	mixed spinning blinking tumbling red turkey blaster	1		Last Available: "2016-11"
 9167	clever glass pie plate of the sewer	0		Maximum MP: +20, Stench Damage: +25, Damage Reduction: 7, Last Available: "2016-11"
 9168	Newton's beefy potato masher	0		Muscle: +10, Experience (Mysticality): +3, Last Available: "2016-11"
 9169	spinning gravy boat	0		Last Available: "2016-11"
 9170	skewed bread mold	0		Last Available: "2016-11"
-9171	toothsome special massive sweet potatoes	10	awesome	Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2016-11"
-9172	spoiled enchanted bean casserole	3	crappy	Effect: "Less Pervious", Effect Duration: 40, Last Available: "2016-11"
+9171	toothsome massive special sweet potatoes	10	awesome	Effect: "Greedy Resolve", Effect Duration: 50, Last Available: "2016-11"
+9172	enchanted spoiled bean casserole	3	crappy	Effect: "Less Pervious", Effect Duration: 40, Last Available: "2016-11"
 9173	tasty spinning baked stuffing	3	awesome	Last Available: "2016-11"
 9174	spoiled cranberry cylinder	4	crappy	Last Available: "2016-11"
 9175	big normal jittery maroon thanksgiving turkey	5	good	Last Available: "2016-11"
-9176	snack-sized normal mince pie	2	good	Last Available: "2016-11"
-9177	decent immense spinning mashed potatoes	7	good	Last Available: "2016-11"
+9176	normal snack-sized mince pie	2	good	Last Available: "2016-11"
+9177	immense decent spinning mashed potatoes	7	good	Last Available: "2016-11"
 9178	spoiled warm gravy	3	crappy	Last Available: "2016-11"
-9179	jumbo adequate bread roll	5	good	Last Available: "2016-11"
+9179	adequate jumbo bread roll	5	good	Last Available: "2016-11"
 9180	bland yellow leftovers	4	decent	Last Available: "2016-11"
 9181	tiny decent leftovers sandwich	1	good	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
-9184	jittery ghostly megacopia	0		Last Available: "2016-11"
+9184	ghostly jittery megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
 9187	cashew	0		Last Available: "2016-11"
@@ -9063,16 +9063,16 @@
 9191	dry eldritch concentrate	0		Effect: "Stick Emporium Membership", Effect Duration: 51, Last Available: "2016-11"
 9192	acceptable squat eldritch extract	3	good	Last Available: "2016-11"
 9193	mirror Official Council Aide Pin of the storm of incineration	0		Maximum MP Percent: +40, Hot Spell Damage: +50, Last Available: "2016-11"
-9194	drinkable watered-down eldritch distillate	2	good	Last Available: "2016-11"
+9194	watered-down drinkable eldritch distillate	2	good	Last Available: "2016-11"
 9195	compressed pulsating upside-down eldritch essence	1		Last Available: "2016-11"
 9196	toasty Science Notebook	0		Hot Damage: +5
 9197	boxer's eldritch hat of the wise owl of doom	0		Mysticality: +20, Muscle Percent: +10, Spooky Spell Damage: +50, Last Available: "2016-11"
 9198	mirror nippy curative smartaleck's eldritch pants	0		Moxie Percent: +30, Cold Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-11"
-9199	lousy watered-down eldritch elixir	2	decent	Last Available: "2016-11"
+9199	watered-down lousy eldritch elixir	2	decent	Last Available: "2016-11"
 9200	pulsating wobbly Oprah's rock-hard Quartet of Flare Masters Jacket	0		Damage Reduction: 5, Maximum MP Percent: +50, Last Available: "2016-11"
 9201	spinning lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	upside-down tumbling Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	tumbling upside-down Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	shaking counterfeit city	0		Last Available: "2016-12"
 9205	jittery pulsating sprinkles	0		Last Available: "2016-12"
 9206	olive The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
@@ -9088,9 +9088,9 @@
 9216	blinking interesting clod of dirt	0		
 9217	yellow gingerbread restraining order	0		Last Available: "2016-12"
 9218	upside-down sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	tasty small animal part cracker	2	awesome	Last Available: "2016-12"
+9219	small tasty animal part cracker	2	awesome	Last Available: "2016-12"
 9220	bad gingerbread wine	3	decent	Last Available: "2016-12"
-9221	spoiled tiny gingerbread mug	1	crappy	Last Available: "2016-12"
+9221	tiny spoiled gingerbread mug	1	crappy	Last Available: "2016-12"
 9222	shellacked gingerbread mask	0		Damage Reduction: 7, Last Available: "2016-12"
 9223	jittery foul-smelling gingerservo of doom	0		Stench Damage: +10, Spooky Spell Damage: +50, Item Drop: +5, Single Equip, Last Available: "2016-12"
 9224	polarized gray tainted icing	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 49, Last Available: "2016-12"
@@ -9111,7 +9111,7 @@
 9239	acceptable ginger beer	3	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	liquefied polarized spinning industrial frosting	0		Effect: "Castaway Physique", Effect Duration: 12, Last Available: "2016-12"
-9242	enhanced jittery skewed fake cocktail	0		Effect: "Bilious Brains", Effect Duration: 53, Last Available: "2016-12"
+9242	enhanced skewed jittery fake cocktail	0		Effect: "Bilious Brains", Effect Duration: 53, Last Available: "2016-12"
 9243	tolerable high-end ginger wine	4	good	Last Available: "2016-12"
 9244	plastic bad vibe of the scaredy-cat	0		Monster Level: -15, Last Available: "2016-12"
 9245	wizardly plastic angry vikings	0		Mysticality: +25, Last Available: "2016-12"
@@ -9121,15 +9121,15 @@
 9249	pickled Vulcanized Inner Wisdom	0		Effect: "Berry Elemental", Effect Duration: 47, Last Available: "2016-12"
 9250	quantum moist dry Inner Strength	0		Effect: "Ocelot Eyes", Effect Duration: 26, Last Available: "2016-12"
 9251	electrified vacuum-sealed skewed blurry Inner Truth	0		Effect: "Tingly Biceps", Effect Duration: 39, Last Available: "2016-12"
-9252	small moldy spiritual candy cane	2	crappy	Last Available: "2016-12"
+9252	moldy small spiritual candy cane	2	crappy	Last Available: "2016-12"
 9253	tolerable spiritual eggnog	3	good	Last Available: "2016-12"
-9254	moldy small spiritual fruitcake	2	crappy	Last Available: "2016-12"
+9254	small moldy spiritual fruitcake	2	crappy	Last Available: "2016-12"
 9255	adequate spiritual gingerbread	3	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	mirror chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	upside-down Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
-9260	bouncing spinning No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
+9260	spinning bouncing No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	jittery Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
@@ -9146,8 +9146,8 @@
 9274	stiffened Krampus Horn of chilblains	0		Damage Reduction: 1, Cold Damage: +25, Single Equip, Last Available: "2016-12"
 9275	stale hambrosier	3	decent	Last Available: "2016-12"
 9276	practically non-alcoholic acceptable chakra-mental wine	1	good	Last Available: "2016-12"
-9277	aerosolized wet nitrogenated jittery blue chakra malt	0		Effect: "Mmmmmelon", Effect Duration: 16, Last Available: "2016-12"
-9278	gigantic decent Black Angus blackburger	7	good	Last Available: "2016-12"
+9277	aerosolized wet nitrogenated blue jittery chakra malt	0		Effect: "Mmmmmelon", Effect Duration: 16, Last Available: "2016-12"
+9278	decent gigantic Black Angus blackburger	7	good	Last Available: "2016-12"
 9279	smooth brandy	3	awesome	Last Available: "2016-12"
 9280	polymerized dry potion of spiritual gunkifying	0		Effect: "Blackberry Politeness", Effect Duration: 55, Last Available: "2016-12"
 9281	hardened bad vibroknife of the brute	0		Muscle Percent: +30, Damage Reduction: 3, Last Available: "2016-12"
@@ -9156,7 +9156,7 @@
 9284	studded dance instructor's saffron uttarasanga	0		Experience Percent (Moxie): +10, Damage Absorption: +80, Last Available: "2016-12"
 9285	wobbly Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
 9286	blinking eternal knot tattoo	0		Last Available: "2016-12"
-9287	bouncing upside-down pet bad vibe	0		Last Available: "2016-12"
+9287	upside-down bouncing pet bad vibe	0		Last Available: "2016-12"
 9288	shaking gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	rosewater-soaked Lo Pan's Uncle Crimbo's hat of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +30, Stench Resistance: +3, Last Available: "2016-12"
 9290	normal ghostly Eldritch snap	4	good	Last Available: "2017-01"
@@ -9187,7 +9187,7 @@
 9315	huge sharpshooter's recovered cufflinks	0		Critical Hit Percent: +10, Single Equip, Last Available: "2017-01"
 9316	purple heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	aerosolized vacuum-sealed lime green LOV Elixir #3	0		Effect: "Standard Issue Bravery", Effect Duration: 24, Last Available: "2017-02"
-9318	modified polarized ghostly olive LOV Elixir #6	0		Effect: "Crocodile Tear", Effect Duration: 31, Last Available: "2017-02"
+9318	modified polarized olive ghostly LOV Elixir #6	0		Effect: "Crocodile Tear", Effect Duration: 31, Last Available: "2017-02"
 9319	pickled LOV Elixir #9	0		Effect: "Rave Concentration", Effect Duration: 53, Last Available: "2017-02"
 9320	manspreader's dangerous slick LOV Eardigan	0		Moxie: +10, Weapon Damage: +10, Monster Level: +10, Lasts Until Rollover, Last Available: "2017-02"
 9321	mirror spinning blinking coward's wholesome LOV Epaulettes of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +10, Monster Level: -20, Lasts Until Rollover, Last Available: "2017-02"
@@ -9223,7 +9223,7 @@
 9351	peppermint sprig	0		Last Available: "2017-03"
 9352	jittery bottle of clam juice	0		Last Available: "2017-03"
 9353	cocktail mushroom	0		Last Available: "2017-03"
-9354	blurry twirling shot of granola liqueur	0		Last Available: "2017-03"
+9354	twirling blurry shot of granola liqueur	0		Last Available: "2017-03"
 9355	can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
@@ -9235,40 +9235,40 @@
 9363	spinning slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	acceptable squat literal grasshopper	3	good	Last Available: "2017-03"
-9366	drinkable practically non-alcoholic double entendre	1	good	Last Available: "2017-03"
+9366	practically non-alcoholic drinkable double entendre	1	good	Last Available: "2017-03"
 9367	tolerable Phlegethon	3	good	Last Available: "2017-03"
 9368	hand-crafted narrow Siberian sunrise	3	EPIC	Last Available: "2017-03"
 9369	watered-down acceptable huge mentholated wine	2	good	Last Available: "2017-03"
 9370	boozy artisanal low tide martini	5	EPIC	Last Available: "2017-03"
 9371	lousy shroomtini	3	decent	Last Available: "2017-03"
 9372	acceptable watered-down huge morning dew	2	good	Last Available: "2017-03"
-9373	watered-down hand-crafted whiskey squeeze	2	EPIC	Last Available: "2017-03"
-9374	mediocre fortified great fashioned	5	decent	Last Available: "2017-03"
+9373	hand-crafted watered-down whiskey squeeze	2	EPIC	Last Available: "2017-03"
+9374	fortified mediocre great fashioned	5	decent	Last Available: "2017-03"
 9375	fancy acceptable spinning Gnomish sagngria	4	good	Effect: "stats.enq", Effect Duration: 10, Last Available: "2017-03"
 9376	delicious vodka stinger	3	awesome	Last Available: "2017-03"
 9377	acceptable practically non-alcoholic extremely slippery nipple	1	good	Last Available: "2017-03"
 9378	mediocre strong upside-down piscatini	5	decent	Last Available: "2017-03"
 9379	artisanal ghostly Churchill	3	EPIC	Last Available: "2017-03"
-9380	bad watered-down soilzerac	2	decent	Last Available: "2017-03"
+9380	watered-down bad soilzerac	2	decent	Last Available: "2017-03"
 9381	mediocre London frog	3	decent	Last Available: "2017-03"
-9382	weak perfectly mixed green nothingtini	2	EPIC	Last Available: "2017-03"
+9382	perfectly mixed weak green nothingtini	2	EPIC	Last Available: "2017-03"
 9383	tolerable watered-down cyan eighth plague	2	good	Last Available: "2017-03"
-9384	mediocre practically non-alcoholic tumbling single entendre	1	decent	Last Available: "2017-03"
-9385	perfectly mixed weak reverse Tantalus	2	EPIC	Last Available: "2017-03"
-9386	weak drinkable huge elemental caipiroska	2	good	Last Available: "2017-03"
+9384	practically non-alcoholic mediocre tumbling single entendre	1	decent	Last Available: "2017-03"
+9385	weak perfectly mixed reverse Tantalus	2	EPIC	Last Available: "2017-03"
+9386	drinkable weak huge elemental caipiroska	2	good	Last Available: "2017-03"
 9387	mediocre Feliz Navidad	3	decent	Last Available: "2017-03"
 9388	weak perfectly mixed Bloody Nora	2	EPIC	Last Available: "2017-03"
 9389	bad enchanted moreltini	4	decent	Effect: "Hoity Toity", Effect Duration: 45, Last Available: "2017-03"
-9390	acceptable red twirling hell in a bucket	3	good	Last Available: "2017-03"
+9390	acceptable twirling red hell in a bucket	3	good	Last Available: "2017-03"
 9391	perfectly mixed squat Newark	4	EPIC	Last Available: "2017-03"
 9392	artisanal R'lyeh	3	EPIC	Last Available: "2017-03"
 9393	tolerable special Gnollish sangria	3	good	Effect: "Busy Bein' Delicious", Effect Duration: 45, Last Available: "2017-03"
-9394	mediocre boozy vodka barracuda	5	decent	Last Available: "2017-03"
-9395	artisanal spinning mirror Mysterious Island iced tea	3	EPIC	Last Available: "2017-03"
+9394	boozy mediocre vodka barracuda	5	decent	Last Available: "2017-03"
+9395	artisanal mirror spinning Mysterious Island iced tea	3	EPIC	Last Available: "2017-03"
 9396	bad drive-by shooting	3	decent	Last Available: "2017-03"
-9397	artisanal fortified gunner's daughter	5	EPIC	Last Available: "2017-03"
-9398	weak perfectly mixed dirt julep	2	EPIC	Last Available: "2017-03"
-9399	perfectly mixed weak Simepore slime	2	EPIC	Last Available: "2017-03"
+9397	fortified artisanal gunner's daughter	5	EPIC	Last Available: "2017-03"
+9398	perfectly mixed weak dirt julep	2	EPIC	Last Available: "2017-03"
+9399	weak perfectly mixed Simepore slime	2	EPIC	Last Available: "2017-03"
 9400	acceptable Phil Collins	3	good	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9292,14 +9292,14 @@
 9420	denatured fuchsia alien plant goo	1		Last Available: "2017-04"
 9421	bouncing alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	gigantic decent enchanted alien meat	6	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2017-04"
+9423	enchanted decent gigantic alien meat	6	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2017-04"
 9424	green alien toenails	0		Last Available: "2017-04"
 9425	shaking alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	compressed spinning alien animal goo	1		Last Available: "2017-04"
 9429	huge alien animal milk	0		Last Available: "2017-04"
-9430	huge blinking lime green spant egg casing	0		Last Available: "2017-04"
+9430	blinking huge lime green spant egg casing	0		Last Available: "2017-04"
 9431	upside-down murderbot data core	0		Last Available: "2017-04"
 9432	unsweetened alien medicine	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 48, Last Available: "2017-04"
 9433	adequate alien salad	4	good	Last Available: "2017-04"
@@ -9311,7 +9311,7 @@
 9439	smooth alien totem of the wise owl of the sweet-tooth	0		Mysticality: +20, Moxie: +15, Candy Drop: +100, Last Available: "2017-04"
 9440	bouncing flame-retardant horrifying grievous alien necklace	0		Weapon Damage Percent: +50, Spooky Damage: +25, Hot Resistance: +1, Last Available: "2017-04"
 9441	spant chitin	0		Last Available: "2017-04"
-9442	yellow pulsating spant tendon	0		Last Available: "2017-04"
+9442	pulsating yellow spant tendon	0		Last Available: "2017-04"
 9443	sharpshooter's vibrating spants	0		Maximum MP Percent: +10, Critical Hit Percent: +10, Last Available: "2017-04"
 9444	ghostly fireproof savvy spant shield	0		Mysticality Percent: +20, Hot Resistance: +3, Damage Reduction: 6, Last Available: "2017-04"
 9445	wicked spant shoulderpads of the early riser	0		Spell Damage: +5, Adventures: +7, Single Equip, Last Available: "2017-04"
@@ -9321,7 +9321,7 @@
 9449	murderbot component casing	0		Last Available: "2017-04"
 9450	fuchsia murderbot monofilament	0		Last Available: "2017-04"
 9451	extra-chilled Vulcanized corrupted murderbot shield unit	0		Effect: "Woad Warrior", Effect Duration: 51, Last Available: "2017-04"
-9452	narrow red tumbling murderbot live wire	0		Last Available: "2017-04"
+9452	tumbling narrow red murderbot live wire	0		Last Available: "2017-04"
 9453	stanky arcane researcher's beefcake's murderbot mask	0		Muscle: +25, Experience Percent (Mysticality): +10, Stench Spell Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
 9454	quadruple-alkaline modified murderbot spring injector	0		Effect: "Mathematically Precise", Effect Duration: 43, Last Available: "2017-04"
 9455	mirror Jim Carey's murderbot whip of the early riser	0		Monster Level: +25, Adventures: +7, Last Available: "2017-04"
@@ -9333,7 +9333,7 @@
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	mirror Procrastinator locker key	0		Last Available: "2017-04"
 9463	tumbling Space Baby children's book	0		Last Available: "2017-04"
-9464	huge yellow Space Baby bawbaw	0		Last Available: "2017-04"
+9464	yellow huge Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	normal Aldebaran sardines	4	good	Last Available: "2017-04"
 9467	acceptable Centauri fish wine	4	good	Last Available: "2017-04"
@@ -9345,7 +9345,7 @@
 9473	maroon Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	decent twirling alien sandwich	3	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
-9476	aerosolized non-oxidized cyan spinning Spant eggs	0		Effect: "Bananas!", Effect Duration: 40
+9476	aerosolized non-oxidized spinning cyan Spant eggs	0		Effect: "Bananas!", Effect Duration: 40
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	unsweetened skewed Daily Affirmation: Always be Collecting	0		Effect: "Feelin' Philosophical", Effect Duration: 30, Last Available: "2017-05"
@@ -9364,7 +9364,7 @@
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	extremely unsafe supercool Kremlin's Greatest Briefcase of Gandalf	0		Moxie Percent: +20, Weapon Damage Percent: +100, Spell Critical Percent: +20, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	artisanal basic martini	3	EPIC	Last Available: "2017-06"
-9495	mediocre distilled improved martini	5	decent	Last Available: "2017-06"
+9495	distilled mediocre improved martini	5	decent	Last Available: "2017-06"
 9496	bad triple-distilled wobbly splendid martini	7	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9385,7 +9385,7 @@
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	normal meteoreo	3	good	Last Available: "2017-08"
 9515	spirit-forward perfectly mixed mirror squat meadeorite	5	EPIC	Last Available: "2017-08"
-9516	wobbly ghostly meteoroid	0		Last Available: "2017-08"
+9516	ghostly wobbly meteoroid	0		Last Available: "2017-08"
 9517	prompt sharpshooter's weightlifter's meteortarboard	0		Muscle: +15, Critical Hit Percent: +10, Adventures: +3, Last Available: "2017-08"
 9518	rosy-cheeked arcane researcher's personal trainer's meteorite guard	0		Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Maximum HP Percent: +30, Damage Reduction: 9, Last Available: "2017-08"
 9519	tumbling bouncing personal trainer's meteorb of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Lantern Element: "Hot", Last Available: "2017-08"
@@ -9404,7 +9404,7 @@
 9532	olive pony: Shutterfly	0		Last Available: "2017-09"
 9533	pony: Pearjack	0		Last Available: "2017-09"
 9534	narrow pony: Uniquity	0		Last Available: "2017-09"
-9535	skewed maroon pony: Rosey Cake	0		Last Available: "2017-09"
+9535	maroon skewed pony: Rosey Cake	0		Last Available: "2017-09"
 9536	pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
@@ -9416,9 +9416,9 @@
 9544	O	0		Last Available: "2017-10"
 9545	lousy DUFRESNE Suds	3	decent	Last Available: "2017-09"
 9546	upside-down aromatic Da Vinci's mafia pinky ring	0		Experience (Mysticality): +5, Stench Resistance: +1, Single Equip
-9547	delicious spinning lime green flask of port	3	awesome	
+9547	delicious lime green spinning flask of port	3	awesome	
 9548	mirror foul-smelling careful contract enforcement stick	0		Monster Level: -10, Stench Damage: +10
-9549	thick tasty Hide-rox&trade; cookie	5	awesome	Last Available: "2017-10"
+9549	tasty thick Hide-rox&trade; cookie	5	awesome	Last Available: "2017-10"
 9550	lousy jug of booze	4	decent	Last Available: "2017-10"
 9551	deionized pair of candy glasses	0		Effect: "Human-Demon Hybrid", Effect Duration: 24, Last Available: "2017-10"
 9552	galvanized temporary X tattoos	0		Effect: "Piratey Flavor", Effect Duration: 17, Last Available: "2017-10"
@@ -9464,9 +9464,9 @@
 9592	mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	decent	Last Available: "2017-11"
 9594	quantum wishbone	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 43, Last Available: "2017-11"
-9595	mediocre special Racisto Ruidoso	3	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2017-11"
+9595	special mediocre Racisto Ruidoso	3	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	spoiled half-sized jittery yellow bran muffin	2	crappy	
+9597	half-sized spoiled yellow jittery bran muffin	2	crappy	
 9598	tasty blueberry muffin	3	awesome	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
@@ -9559,7 +9559,7 @@
 9687	sharpshooter's burning paper jorts of wisdom of Flo-Jo	0		Mysticality: +15, Critical Hit Percent: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2018-12"
 9688	Usain Bolt's ribald nasty burning paper crane	0		Stench Damage: +5, Sleaze Damage: +10, Initiative: +80, Lasts Until Rollover, Last Available: "2018-12"
 9689	January's Garbage Tote (unopened)	0		Free Pull, Last Available: "2018-01"
-9690	olive narrow January's Garbage Tote	0		Last Available: "2018-01"
+9690	narrow olive January's Garbage Tote	0		Last Available: "2018-01"
 9691	wobbly deceased crimbo tree	0		Last Available: "2018-01"
 9692	yellow Oprah's ruddy broken champagne bottle	0		Maximum HP Percent: +40, Maximum MP Percent: +50, Last Available: "2018-01"
 9693	experienced tinsel tights of the businessman	0		Experience: +2, Meat Drop: +50, Last Available: "2018-01"
@@ -9572,15 +9572,15 @@
 9700	jittery curative baleful novelty monorail ticket	0		Spell Damage: +25, HP Regen Min: 3, HP Regen Max: 5
 9701	compressed blue pills	1		Effect: "Cookie Backup", Effect Duration: 30
 9702	vaporized teal furry pill	1		
-9703	distilled maroon huge beefy pill	1		Effect: "Feet of Watermelon", Effect Duration: 40
-9704	altered blurry upside-down fuchsia excitement pill	1		
-9705	twisted twirling shaking vitamin G pill	1		
+9703	distilled huge maroon beefy pill	1		Effect: "Feet of Watermelon", Effect Duration: 40
+9704	altered blurry fuchsia upside-down excitement pill	1		
+9705	twisted shaking twirling vitamin G pill	1		
 9706	altered wobbly lucky-ish pill	1		Effect: "Pemmican't", Effect Duration: 30
 9707	diluted dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
-9715	olive jittery Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
+9715	jittery olive Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	squat Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
@@ -9592,7 +9592,7 @@
 9724	razor-sharp groovy psychic's crystal ball	0		Moxie Percent: +10, Weapon Damage Percent: +25, Last Available: "2018-02"
 9725	teal smelly psychic's pslacks of James Dean	0		Experience (Moxie): +3, Stench Spell Damage: +10, Last Available: "2018-02"
 9726	foul-smelling supercharged psychic's amulet	0		Maximum MP Percent: +30, Stench Damage: +10, Last Available: "2018-02"
-9727	rotten jumbo jittery shaking heart-shaped candy whetstone	5	crappy	Last Available: "2018-02"
+9727	rotten jumbo shaking jittery heart-shaped candy whetstone	5	crappy	Last Available: "2018-02"
 9728	decent Swedish massage fish	4	good	Last Available: "2018-02"
 9729	hand-crafted huge Third Base	3	EPIC	Last Available: "2018-02"
 9730	artisanal Bustle Hustler	3	EPIC	Last Available: "2018-02"
@@ -9607,12 +9607,12 @@
 9739	Mysterious Red Box	0		Last Available: "2018-02"
 9740	bouncing Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
-9742	blurry spinning Mysterious Black Box	0		Last Available: "2018-02"
+9742	spinning blurry Mysterious Black Box	0		Last Available: "2018-02"
 9743	polarized shaking gray rainbow jellybean	0		Effect: "You Drank Fish Wine", Effect Duration: 46
 9744	quadruple-dry activated pickled mystery lollipop	0		Effect: "Stuck-Up Hair", Effect Duration: 44
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	corrupted tarnished jittery tumbling rhinestone	0		Effect: "It's Soporiffic!", Effect Duration: 24
-9747	blinking huge 1,960 pok&eacute;dollar bill	0		
+9747	huge blinking 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	riboflavin	0		
 9750	jittery bronze	0		
@@ -9660,7 +9660,7 @@
 9792	pulsating Vamprey	0		Last Available: "2018-03"
 9793	ghostly Wullabye	0		Last Available: "2018-03"
 9794	Nursine	0		Last Available: "2018-03"
-9795	tumbling shaking Cantelope	0		Last Available: "2018-03"
+9795	shaking tumbling Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
 9797	spinning Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
@@ -9734,7 +9734,7 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	blinking ghostly hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	yummy gigantic druidic s'more	6	awesome	Last Available: "2018-04"
+9869	gigantic yummy druidic s'more	6	awesome	Last Available: "2018-04"
 9870	distilled olive sachet of powder	1		Last Available: "2018-04"
 9871	bad practically non-alcoholic skewed mourning wine	1	decent	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	flavorless tiny denastified haunch	1	decent	Last Available: "2018-04"
+9878	tiny flavorless denastified haunch	1	decent	Last Available: "2018-04"
 9879	aged squat bad rum and good cola	4	awesome	Last Available: "2018-04"
 9880	tarnished Potion of Heroism	0		Effect: "Bolts about Candy", Effect Duration: 44, Last Available: "2018-04"
 9881	coward's banded Socratic leggings of the Spider Queen	0		Experience (Mysticality): +1, Damage Absorption: +100, Monster Level: -20, Last Available: "2018-04"
@@ -9764,7 +9764,7 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	skewed notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	acceptable two meat muck	4	good	
-9899	spoiled half-sized chocolate Ogre Chieftain	2	crappy	
+9899	half-sized spoiled chocolate Ogre Chieftain	2	crappy	
 9900	spoiled chocolate &quot;Phoenix&quot;	3	crappy	
 9901	moldy fancy green wobbly chocolate Spider Queen	3	crappy	Effect: "Eyes of the Dragon", Effect Duration: 15
 9902	weak perfectly mixed hipster cocktail	2	EPIC	
@@ -9772,7 +9772,7 @@
 9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
 9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
 9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	huge narrow God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9907	narrow huge God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	skewed Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9781,7 +9781,7 @@
 9913	glued A-Boo clue	0		
 9914	huge crude oil congealer	0		
 9915	bland good guava	4	decent	
-9916	practically non-alcoholic perfectly mixed cyan gin and ginger	1	super ultra mega turbo EPIC	
+9916	perfectly mixed practically non-alcoholic cyan gin and ginger	1	super ultra mega turbo EPIC	
 9917	Thwaitgold chigger statuette	0		
 9918	denatured olive gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9837,13 +9837,13 @@
 9969	skewed mirror ghostly veiny wizardly denim jacket	0		Mysticality: +25, Maximum HP: +10, Last Available: "2018-09"
 9970	supercharged savvy ratty knitted cap	0		Mysticality Percent: +20, Maximum MP Percent: +30, Last Available: "2018-09"
 9972	flame-retardant intimidating chainsaw of the boozehound	0		Hot Resistance: +1, Booze Drop: +100, Lasts Until Rollover, Last Available: "2018-09"
-9973	delicious spirit-forward party beer bomb	5	awesome	Last Available: "2018-09"
+9973	spirit-forward delicious party beer bomb	5	awesome	Last Available: "2018-09"
 9974	decent sweet party mix	4	good	Last Available: "2018-09"
 9975	vaporized teal party balloon	1		Effect: "Permanent Halloween", Effect Duration: 10, Last Available: "2018-09"
 9976	Lo Pan's party pants of Leguizamo	0		Spell Critical Percent: +30, Monster Level: +20, Last Available: "2018-09"
 9977	lime green wholesome steel-toed party whip of the brazier	0		Damage Reduction: 9, Maximum HP Percent: +10, Hot Spell Damage: +25, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	aged weak TRIO cup of beer	2	awesome	Last Available: "2018-09"
+9979	weak aged TRIO cup of beer	2	awesome	Last Available: "2018-09"
 9980	normal party platter for one	4	good	Last Available: "2018-09"
 9981	denatured spinning Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	spinning party pup	0		Last Available: "2018-09"
@@ -9874,20 +9874,20 @@
 10008	greasy baleful weightlifter's mutant legs	0		Muscle: +15, Spell Damage: +25, Sleaze Spell Damage: +10, Last Available: "2018-11"
 10009	wobbly smelly wholesome studded mutant crown	0		Damage Absorption: +80, Maximum HP Percent: +10, Stench Spell Damage: +10, Last Available: "2018-11"
 10010	moldy small blurry ghostly ectoplasm	2	crappy	Last Available: "2018-11"
-10011	stale fancy	3	decent	Effect: "Good with the Ladies", Effect Duration: 30, Last Available: "2018-11"
+10011	fancy stale	3	decent	Effect: "Good with the Ladies", Effect Duration: 30, Last Available: "2018-11"
 10012	lousy mirror bottle of vodka	3	decent	Last Available: "2018-11"
 10013	diet bland pizza	1	decent	Last Available: "2018-11"
-10014	lousy extra-dry martini	5	decent	Last Available: "2018-11"
+10014	extra-dry lousy martini	5	decent	Last Available: "2018-11"
 10015	toothsome fancy mirror cherry pie	3	awesome	Effect: "Celestial Sheen", Effect Duration: 50, Last Available: "2018-11"
 10016	mediocre mirror eggnog	3	decent	Last Available: "2018-11"
 10017	jittery glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	flavorless snack-sized twirling Hell ramen	2	decent	Last Available: "2018-11"
-10019	bad high-proof gimlet	6	decent	Last Available: "2018-11"
+10019	high-proof bad gimlet	6	decent	Last Available: "2018-11"
 10020	fortified artisanal twice-haunted screwdriver	5	EPIC	Last Available: "2018-11"
 10021	half-sized adequate candy cane	2	good	Last Available: "2018-12"
-10022	extra-dry artisanal runny fermented egg	5	EPIC	Last Available: "2018-12"
-10023	snack-sized decent oldcake	2	good	Last Available: "2018-12"
-10024	massive normal bouncing traditional Crimbo cookie	10	good	Last Available: "2023-06"
+10022	artisanal extra-dry runny fermented egg	5	EPIC	Last Available: "2018-12"
+10023	decent snack-sized oldcake	2	good	Last Available: "2018-12"
+10024	normal massive bouncing traditional Crimbo cookie	10	good	Last Available: "2023-06"
 10025	tumbling Oprah's plastic wild beaver	0		Maximum MP Percent: +50, Last Available: "2018-12"
 10026	plastic reindeer of the dark arts	0		Spell Damage Percent: +100, Last Available: "2018-12"
 10027	lightning-fast plastic Caf&eacute; Elf	0		Initiative: +40, Last Available: "2018-12"
@@ -9914,33 +9914,33 @@
 10048	muskox-skin cap of the glutton	0		Food Drop: +100, Last Available: "2018-12"
 10049	bouncing Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	bland glass of raw eggs	3	decent	Last Available: "2018-12"
-10051	weak smooth punch-drunk punch	2	awesome	Last Available: "2018-12"
+10051	smooth weak punch-drunk punch	2	awesome	Last Available: "2018-12"
 10052	vaporized spinning purple body spradium	1		Last Available: "2018-12"
 10053	ruddy bauxite beret	0		Maximum HP Percent: +40, Last Available: "2018-12"
 10054	zippy bauxite boxers	0		Initiative: +20, Last Available: "2018-12"
 10055	flame-wreathed bauxite bow-tie	0		Hot Spell Damage: +10, Single Equip, Last Available: "2018-12"
-10056	green squat Boxing Day Pass	0		Last Available: "2018-12"
+10056	squat green Boxing Day Pass	0		Last Available: "2018-12"
 10057	ghostly Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	skewed green lightning-fast asbestos-lined hale dangerous Kramco Sausage-o-Matic&trade; of the early riser	0		Weapon Damage: +10, Maximum HP: +20, Hot Resistance: +5, Initiative: +40, Adventures: +7, Last Available: "2019-01"
 10059	blurry sausage casing	0		Last Available: "2019-01"
-10060	diet rotten sausage	1	crappy	Last Available: "2019-01"
+10060	rotten diet sausage	1	crappy	Last Available: "2019-01"
 10061	extremely unsafe red-hot sausage fork of the businessman	0		Weapon Damage Percent: +100, Meat Drop: +50, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	pulsating Toyleporter	0		Last Available: "2018-12"
-10066	artisanal weak beer	2	super ultra EPIC	Last Available: "2018-12"
+10066	weak artisanal beer	2	super ultra EPIC	Last Available: "2018-12"
 10067	rotten jittery yule gruel	3	crappy	Last Available: "2018-12"
-10068	mediocre weak hot watered rum	2	decent	Last Available: "2018-12"
+10068	weak mediocre hot watered rum	2	decent	Last Available: "2018-12"
 10069	practically non-alcoholic artisanal bottle of Crimbognac	1	super ultra mega turbo EPIC	Last Available: "2018-12"
-10070	massive normal Crimboysters Rockefeller	9	good	Last Available: "2018-12"
+10070	normal massive Crimboysters Rockefeller	9	good	Last Available: "2018-12"
 10071	denatured lime green Crimbeau de toilette	1		Last Available: "2018-12"
 10072	narrow Crimbo candle	0		Last Available: "2018-12"
 10073	blurry Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
-10074	jittery huge Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
+10074	huge jittery Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	purple Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
 10076	cyan Carol of the Hells (used)	0		Skill: "Carol of the Hells", Last Available: "2018-12"
-10077	blinking mirror Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
+10077	mirror blinking Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	olive Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	up-at-dawn Crimbolex watch of James Dean of horror	0		Experience (Moxie): +3, Spooky Spell Damage: +25, Adventures: +5, Single Equip, Last Available: "2018-12"
 10080	Crimbo tattoo kit	0		Last Available: "2018-12"
@@ -9951,7 +9951,7 @@
 10085	crafty chalk chinos of dire peril	0		Weapon Damage: +20, Maximum MP: +10, Last Available: "2019-12"
 10086	zippy chalk chapeau of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +20, Last Available: "2019-12"
 10087	aromatic curative chalk choker	0		Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2019-12"
-10088	mixed pulsating bouncing purple chalk chunks	1		Effect: "Fortunate Resolve", Effect Duration: 40, Last Available: "2019-12"
+10088	mixed bouncing pulsating purple chalk chunks	1		Effect: "Fortunate Resolve", Effect Duration: 40, Last Available: "2019-12"
 10089	concentrated Vulcanized candy chalk	0		Effect: "Slimily Strong", Effect Duration: 33
 10090	purple Usain Bolt's stanky marble maebari	0		Stench Spell Damage: +25, Initiative: +80, Last Available: "2019-12"
 10091	toasty marble mantle of wisdom	0		Mysticality: +15, Hot Damage: +5, Last Available: "2019-12"
@@ -10018,21 +10018,21 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	wholesome elf army poncho	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2019-12"
-10155	yummy low-calorie elf army field rations	1	awesome	Last Available: "2019-12"
+10155	low-calorie yummy elf army field rations	1	awesome	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	red fireproof discarded bowtie of the early riser	0		Hot Resistance: +3, Adventures: +7, Lasts Until Rollover, Last Available: "2019-12"
 10158	artisanal martiny	4	EPIC	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	magnetized colloidal oxidized olive licorice snake	0		Effect: "Cockroach Scurry", Effect Duration: 28
-10161	flattened magnetized pulsating blinking virgin jello shot	0		Effect: "Omphalotus Omnipresence", Effect Duration: 23
+10161	flattened magnetized blinking pulsating virgin jello shot	0		Effect: "Omphalotus Omnipresence", Effect Duration: 23
 10162	vacuum-sealed dry tumbling mutated candy lump	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 52
 10163	non-tarnished dry double-activated government-issued candy	0		Effect: "Elemental Mastery", Effect Duration: 68
 10164	galvanized twirling Pneumo bar	0		Effect: "The Style... of the Future", Effect Duration: 44
-10165	tumbling gray mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
+10165	gray tumbling mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	frightening padded Lil' Doctor&trade; bag	0		Damage Absorption: +20, Spooky Damage: +5, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	adequate bloodstick	4	good	
-10170	spirit-forward lousy green bottle of Sanguiovese	5	decent	
+10170	lousy spirit-forward green bottle of Sanguiovese	5	decent	
 10171	moldy actual blood sausage	4	crappy	
 10172	aged mulled blood	4	awesome	
 10173	rotten blood snowcone	3	crappy	
@@ -10041,7 +10041,7 @@
 10176	artisanal bottle of blood	4	EPIC	
 10177	toothsome mirror blood-soaked sponge cake	3	awesome	
 10178	weak perfectly mixed tumbling vampagne	2	super ultra mega turbo EPIC	
-10179	tasty special shaking plain snowcone	3	awesome	Effect: "You Liver", Effect Duration: 30
+10179	special tasty shaking plain snowcone	3	awesome	Effect: "You Liver", Effect Duration: 30
 10180	Booke of Vampyric Knowledge	0		
 10181	tumbling money bag	0		
 10182	money bag	0		
@@ -10050,7 +10050,7 @@
 10185	skewed bucket of Vampyre blood	0		
 10186	bouncing blood knife	0		Lasts Until Rollover
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
-10188	blurry red PirateRealm guest pass	0		Last Available: "2019-04"
+10188	red blurry PirateRealm guest pass	0		Last Available: "2019-04"
 10189	wobbly avaricious electrified PirateRealm eyepatch of horror	0		Spooky Spell Damage: +25, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-04"
 10190	tumbling bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	compass	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10095,12 +10095,12 @@
 10230	fortified Rosewater's piratical blunderbuss	0		Mysticality Percent: +30, Damage Absorption: +60, Last Available: "2019-04"
 10231	foul-smelling Temple Grandin's PirateRealm party hat of the bloodbag	0		Maximum HP: +100, Familiar Weight: +7, Stench Damage: +10, Last Available: "2019-04"
 10232	artisanal Island Landslide	4	EPIC	Last Available: "2019-04"
-10233	weak mediocre mirror wobbly Island Thunderstorm	2	decent	Last Available: "2019-04"
-10234	drinkable weak jittery bouncing Island Hurricane	2	good	Last Available: "2019-04"
+10233	mediocre weak mirror wobbly Island Thunderstorm	2	decent	Last Available: "2019-04"
+10234	weak drinkable jittery bouncing Island Hurricane	2	good	Last Available: "2019-04"
 10235	drinkable cyan Skull Punch	4	good	Last Available: "2019-04"
-10236	perfectly mixed practically non-alcoholic maroon Electric Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10236	practically non-alcoholic perfectly mixed maroon Electric Punch	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10237	bad practically non-alcoholic Smuggler's Punch	1	decent	Last Available: "2019-04"
-10238	artisanal practically non-alcoholic Scorpion Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10238	practically non-alcoholic artisanal Scorpion Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10239	bad distilled Turtle Bowl	5	decent	Last Available: "2019-04"
 10240	perfectly mixed Cobra Bowl	3	super EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
@@ -10111,7 +10111,7 @@
 10246	intact medium-wave antenna	0		
 10247	mirror 18-picohertz resonator crystal	0		
 10248	pulsating blown-out speaker cone	0		
-10249	mirror lime green wobbly overloaded short-pulse transistor	0		
+10249	lime green wobbly mirror overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
 10251	squat up-at-dawn smelly Fourth of May Cosplay Saber of the detective	0		Stench Spell Damage: +10, Item Drop: +20, Adventures: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
@@ -10125,7 +10125,7 @@
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	skewed pile of sand	0		Last Available: "2019-07"
 10262	olive pile of sand	0		Last Available: "2019-07"
-10263	maroon tumbling empty hourglass	0		Last Available: "2019-07"
+10263	tumbling maroon empty hourglass	0		Last Available: "2019-07"
 10264	purple wobbly hourglass	0		Last Available: "2019-07"
 10265	tumbling etched hourglass	0		Last Available: "2019-07"
 10266	polarized tarnished mirror magenta seashell	0		Effect: "Hombre Muerto Caminando", Effect Duration: 16, Last Available: "2019-07"
@@ -10134,7 +10134,7 @@
 10269	pickled blurry seashell	0		Effect: "Beta Carotene Overdose", Effect Duration: 56, Last Available: "2019-07"
 10270	double-tarnished quadruple-warmed upside-down seashell	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 64, Last Available: "2019-07"
 10271	spinning bunch of sea grapes	0		Last Available: "2019-07"
-10272	perfectly mixed enchanted blurry bottle of sea wine	4	EPIC	Effect: "Mariachi Mood", Effect Duration: 45, Last Available: "2019-07"
+10272	enchanted perfectly mixed blurry bottle of sea wine	4	EPIC	Effect: "Mariachi Mood", Effect Duration: 45, Last Available: "2019-07"
 10273	boiled spinning kelp	1		Last Available: "2019-07"
 10274	rock-hard Sinatra's smartaleck's supercool driftwood hat of the cougar of the dark arts of the businessman of the boozehound of Flo-Jo	0		Moxie: +20, Moxie Percent: 50, Experience (Moxie): +5, Spell Damage Percent: +100, Damage Reduction: 5, Meat Drop: +50, Booze Drop: +100, Initiative: +100, Lasts Until Rollover, Last Available: "2019-07"
 10275	lard-coated smelly MacGyver's crafty Socratic Herculean wizardly driftwood pants of the dark arts of the storm	0		Mysticality: +25, Experience (Muscle): +1, Experience (Mysticality): +1, Spell Damage Percent: +100, Maximum MP Percent: +40, Maximum MP: 110, Stench Spell Damage: +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2019-07"
@@ -10165,9 +10165,9 @@
 10300	clever deadly whittled owl figurine of wisdom	0		Mysticality: +15, Weapon Damage: +5, Maximum MP: +20, Single Equip, Last Available: "2019-08"
 10301	scandalous rosy-cheeked whittled fox figurine of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30, Sleaze Damage: +5, Single Equip, Last Available: "2019-08"
 10302	veiny Samson's whittled walking stick of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Experience (Muscle): +5, Maximum HP: +10, Last Available: "2019-08"
-10303	miniature special bland campfire hot dog	2	decent	Effect: "Permanent Halloween", Effect Duration: 40, Last Available: "2019-08"
+10303	special miniature bland campfire hot dog	2	decent	Effect: "Permanent Halloween", Effect Duration: 40, Last Available: "2019-08"
 10304	bland campfire baked potato	3	decent	Last Available: "2019-08"
-10305	enchanted stale upside-down campfire s'more	4	decent	Effect: "20/20 Vision", Effect Duration: 25, Last Available: "2019-08"
+10305	stale enchanted upside-down campfire s'more	4	decent	Effect: "20/20 Vision", Effect Duration: 25, Last Available: "2019-08"
 10306	spoiled campfire beans	3	crappy	Last Available: "2019-08"
 10307	spoiled half-sized campfire stew	2	crappy	Last Available: "2019-08"
 10308	red campfire coffee	1	awesome	Last Available: "2019-08"
@@ -10182,10 +10182,10 @@
 10317	signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	fuchsia Thwaitgold bombardier beetle statuette	0		
-10320	snack-sized tasty space chowder	2	awesome	
+10320	tasty snack-sized space chowder	2	awesome	
 10321	acceptable space wine	3	good	
 10322	teal The Imploded World	0		Skill: "Implode Universe"
-10323	jittery maroon packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
+10323	maroon jittery packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
@@ -10194,7 +10194,7 @@
 10335	wobbly diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bu&ntilde;uelos Jaliscos	4	decent	Last Available: "2019-12"
-10338	massive rotten wobbly flan del mar	7	crappy	Last Available: "2019-12"
+10338	rotten massive wobbly flan del mar	7	crappy	Last Available: "2019-12"
 10339	decent Baja sopapilla	4	good	Last Available: "2019-12"
 10340	blurry plastic Mer-kin baker of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2019-12"
 10341	chaotic plastic sea elf	0		Spell Critical Percent: +10, Last Available: "2019-12"
@@ -10204,27 +10204,27 @@
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	adequate small mana-coated yams	2	good	Last Available: "2019-11"
 10347	low-calorie moldy spinning mana-basted tofurkey leg	1	crappy	Last Available: "2019-11"
-10348	snack-sized rotten mana-fortified cranberry sauce	2	crappy	Last Available: "2019-11"
-10349	enchanted flavorless mana-stuffed herbal stuffing	4	decent	Effect: "Booing Radly", Effect Duration: 15, Last Available: "2019-11"
+10348	rotten snack-sized mana-fortified cranberry sauce	2	crappy	Last Available: "2019-11"
+10349	flavorless enchanted mana-stuffed herbal stuffing	4	decent	Effect: "Booing Radly", Effect Duration: 15, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	flattened energized patch of extra-warm fur	0		Effect: "White Knuckles", Effect Duration: 35, Last Available: "2019-12"
 10352	diluted industrial lubricant	1		Effect: "Marco Polarity", Effect Duration: 10, Last Available: "2019-12"
 10353	triple-flattened blue unfinished pleasure	0		Effect: "What's That Smell?", Effect Duration: 28, Last Available: "2019-12"
-10354	diluted maroon bouncing vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	diluted bouncing maroon vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	diluted a bug's lymph	1		Last Available: "2019-12"
 10356	oxidized non-wet cyan squat organic potpourri	0		Effect: "On the Shoulders of Giants", Effect Duration: 47, Last Available: "2019-12"
-10357	extra-dry acceptable boot flask	5	good	Last Available: "2019-12"
+10357	acceptable extra-dry boot flask	5	good	Last Available: "2019-12"
 10358	quadruple-pressed infernal snowball	0		Effect: "Is This Your Card?", Effect Duration: 66, Last Available: "2019-12"
 10359	fuchsia tumbling madness	0		Last Available: "2019-12"
 10360	boiled fish sauce	1		Last Available: "2019-12"
-10361	thick flavorless guffin	5	decent	Last Available: "2019-12"
+10361	flavorless thick guffin	5	decent	Last Available: "2019-12"
 10362	compressed green Shantix&trade;	1		Effect: "From Nantucket", Effect Duration: 5, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	denatured non-Euclidean angle	1		Effect: "Cold Throat", Effect Duration: 50, Last Available: "2019-12"
 10365	diffused irradiated lime green spinning peppermint syrup	0		Effect: "Sweet and Green", Effect Duration: 55, Last Available: "2019-12"
 10366	ionized adjusted Mer-kin eyedrops	0		Effect: "Full-Body Tan", Effect Duration: 25, Last Available: "2019-12"
 10367	wet anodized extra-strength goo	0		Effect: "Mo' Hobo", Effect Duration: 48, Last Available: "2019-12"
-10368	wobbly jittery envelope full of Meat	0		Last Available: "2019-12"
+10368	jittery wobbly envelope full of Meat	0		Last Available: "2019-12"
 10369	dehydrated jittery livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
 10371	diluted blinking beggin' cologne	1		Effect: "Destructive Resolve", Effect Duration: 40, Last Available: "2019-12"
@@ -10246,7 +10246,7 @@
 10387	intact anemone spike	0		Last Available: "2019-12"
 10388	stiffened anemoney clip	0		Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10389	purple runny icing	0		Last Available: "2019-12"
-10390	compressed blurry shaking super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	compressed shaking blurry super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	upside-down wobbly executive fortified icing poncho of Calamity Jane	0		Damage Absorption: +60, Critical Hit Percent: +15, Meat Drop: +40, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	quantum modified activated glob of salty molasses	0		Effect: "Wet Rub", Effect Duration: 22, Last Available: "2019-12"
@@ -10281,7 +10281,7 @@
 10422	lard-coated Rosewater's Crimbylow-rise jeans	0		Mysticality Percent: +30, Sleaze Spell Damage: +25, Last Available: "2019-12"
 10423	veiny beefy kelp-holly drape	0		Muscle: +10, Maximum HP: +10, Last Available: "2019-12"
 10424	ghostly perfumed electrified Sinatra's Staff of the Peppermint Twist of bravery	0		Experience (Moxie): +5, Spooky Resistance: +5, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-12"
-10425	half-sized adequate tempura and bean	2	good	Last Available: "2019-12"
+10425	adequate half-sized tempura and bean	2	good	Last Available: "2019-12"
 10426	mediocre salt plum sake	4	decent	Last Available: "2019-12"
 10427	cold-filtered pressurized potion of possessiveness	0		Effect: "Simulation Stimulation", Effect Duration: 57, Last Available: "2019-12"
 10428	cold-filtered spinning almond	0		Effect: "Sparkling Consciousness", Effect Duration: 52
@@ -10291,7 +10291,7 @@
 10432	shaking skewed mirror foul-smelling chilly steel-toed Retrospecs	0		Damage Reduction: 9, Cold Damage: +5, Stench Damage: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	squat unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	upside-down Bird-a-Day calendar	0		Last Available: "2020-01"
-10437	purple blinking mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
+10437	blinking purple mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	narrow fireproof horrifying forbidden deadly sage Powerful Glove	0		Mysticality Percent: +10, Weapon Damage: +5, Spell Damage Percent: +50, Spooky Damage: +25, Hot Resistance: +3, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	squat enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
@@ -10301,7 +10301,7 @@
 10444	drippy snail shell	0		
 10445	bland pulsating drippy nugget	3	drippy	
 10446	mediocre glass of drippy wine	3	drippy	
-10447	flavorless fancy fuchsia ghostly drippy caviar	4	drippy	Effect: "Hammered", Effect Duration: 10
+10447	flavorless fancy ghostly fuchsia drippy caviar	4	drippy	Effect: "Hammered", Effect Duration: 10
 10448	adequate drippy plum(?)	3	drippy	
 10449	squat razor-sharp drippy stake	0		Weapon Damage Percent: +25, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10343,10 +10343,10 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	red immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	bland shaking twirling mushroom filet	4	decent	Last Available: "2020-03"
+10489	bland twirling shaking mushroom filet	4	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	boiled skewed mushroom tea	1		Last Available: "2020-03"
-10492	bad watered-down mushroom whiskey	2	decent	Last Available: "2020-03"
+10492	watered-down bad mushroom whiskey	2	decent	Last Available: "2020-03"
 10493	Sherlock's lion tamer's mushroom cap of the detective	0		Experience (familiar): +2, Item Drop: 45, Last Available: "2020-03"
 10494	clever studded experienced mushroom shield of Calamity Jane	0		Experience: +2, Damage Absorption: +80, Maximum MP: +20, Critical Hit Percent: +15, Damage Reduction: 6, Last Available: "2020-03"
 10495	maroon rosy-cheeked Sinatra's mushroom pants of bravery of Flo-Jo	0		Experience (Moxie): +5, Maximum HP Percent: +30, Spooky Resistance: +5, Initiative: +100, Last Available: "2020-03"
@@ -10372,7 +10372,7 @@
 10515	drippy grub	0		
 10516	wobbly drippy bezoar	0		
 10517	shaking Drip Institute petri dish	0		
-10518	skewed blinking drippy ichor	0		
+10518	blinking skewed drippy ichor	0		
 10519	jittery drippy enzyme	0		
 10520	upside-down drippy salt	0		
 10521	drippy pigment	0		
@@ -10395,9 +10395,9 @@
 10539	wholesome Guzzlr souvenir stein	0		Maximum HP Percent: +10, Last Available: "2020-05"
 10540	red Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	special artisanal wobbly wobbly Ghiaccio Colada	4	EPIC	Effect: "Conspiratory Eyes", Effect Duration: 50, Last Available: "2020-05"
-10542	triple-distilled artisanal Sourfinger	6	EPIC	Last Available: "2020-05"
+10542	artisanal triple-distilled Sourfinger	6	EPIC	Last Available: "2020-05"
 10543	acceptable Nog-on-the-Cob	4	good	Last Available: "2020-05"
-10544	tolerable strong fuchsia Steamboat	5	good	Last Available: "2020-05"
+10544	strong tolerable fuchsia Steamboat	5	good	Last Available: "2020-05"
 10545	mediocre Buttery Boy	3	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	Jeselnik's hardened clown car key	0		Damage Reduction: 3, Sleaze Damage: +25, Last Available: "2020-08"
@@ -10425,17 +10425,17 @@
 10569	foul-smelling discarded bike lock key of Tarzan	0		Experience (Muscle): +3, Stench Damage: +10, Last Available: "2020-08"
 10570	jittery Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	deionized denatured pulsating lime green marshroom	0		Effect: "Initiative and Let Die", Effect Duration: 25
+10572	deionized denatured lime green pulsating marshroom	0		Effect: "Initiative and Let Die", Effect Duration: 25
 10573	green bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
-10576	double-enhanced upside-down teal narrow salty drippy candy bar	0		Effect: "Oh Snap", Effect Duration: 19
+10576	double-enhanced upside-down narrow teal salty drippy candy bar	0		Effect: "Oh Snap", Effect Duration: 19
 10577	flattened unsweetened writhing drippy candy bar	0		Effect: "Just the Brown Ones", Effect Duration: 68
 10578	anodized gooey drippy candy bar	0		Effect: "Grape Expectations", Effect Duration: 63
 10579	blurry baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
-10582	olive skewed SpinMaster&trade; lathe	0		Last Available: "2020-08"
+10582	skewed olive SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	skewed flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	foul-smelling banded birch battery	0		Damage Absorption: +100, Stench Damage: +10, Lasts Until Rollover, Last Available: "2020-08"
 10585	reassuring ribald ebony epee of the glutton	0		Sleaze Damage: +10, Spooky Resistance: +1, Food Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
@@ -10461,14 +10461,14 @@
 10605	pulsating Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	wet ghostly Yeg's Motel toothbrush	0		Effect: "Spooky Blur", Effect Duration: 26, Last Available: "2020-09"
 10607	oxidized Yeg's Motel hand soap	0		Effect: "Wise Spirit", Effect Duration: 68, Last Available: "2020-09"
-10608	squat gray Yeg's Motel sewing kit	0		Last Available: "2020-09"
+10608	gray squat Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	delicious mirror Yeg's Motel pillow mint	4	awesome	Last Available: "2020-09"
 10610	skewed Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	unsweetened denatured squat Yeg's Motel mouthwash	0		Effect: "Itchy Trigger Finger", Effect Duration: 59, Last Available: "2020-09"
 10612	stiffened Yeg's Motel shower cap of Leguizamo	0		Damage Reduction: 1, Monster Level: +20, Lasts Until Rollover, Last Available: "2020-09"
 10613	razor-sharp Yeg's Motel bathrobe of the sweet-tooth	0		Weapon Damage Percent: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2020-09"
 10614	cyan gravedigger's Rosewater's Yeg's Motel slippers	0		Mysticality Percent: +30, Spooky Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
-10615	pulsating green Yeg's Motel stationery	0		Last Available: "2020-09"
+10615	green pulsating Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	twirling maroon Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
@@ -10481,7 +10481,7 @@
 10625	onyx rook	0		Last Available: "2020-09"
 10626	jittery onyx bishop	0		Last Available: "2020-09"
 10627	bouncing onyx knight	0		Last Available: "2020-09"
-10628	twirling cyan blurry onyx pawn	0		Last Available: "2020-09"
+10628	blurry twirling cyan onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
 10630	alabaster queen	0		Last Available: "2020-09"
 10631	ghostly alabaster rook	0		Last Available: "2020-09"
@@ -10504,7 +10504,7 @@
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
 10649	gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
-10651	cyan tumbling greedy ghostling	0		Free Pull, Last Available: "2020-12"
+10651	tumbling cyan greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	squat subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	polymerized fortifying hot cocoa	0		Effect: "Healthy Bronze Glow", Effect Duration: 40, Last Available: "2020-12"
 10654	extra-adjusted polarized boiling hot cocoa	0		Effect: "Your Eyes are Peeled!", Effect Duration: 13, Last Available: "2020-12"
@@ -10568,15 +10568,15 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	blinking The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	gigantic adequate and pepper (stale)	10	good	Last Available: "2020-12"
+10715	adequate gigantic and pepper (stale)	10	good	Last Available: "2020-12"
 10716	delicious cranberry margarita (brackish)	3	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	red goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	fancy irresponsibly strong lousy barrel-aged eggnog	8	decent	Effect: "Pumped Up", Effect Duration: 30, Last Available: "2020-12"
+10720	irresponsibly strong lousy fancy barrel-aged eggnog	8	decent	Effect: "Pumped Up", Effect Duration: 30, Last Available: "2020-12"
 10721	small normal spinning hand-crafted candy cane	2	good	Last Available: "2020-12"
 10722	bland drive-thru burger	3	decent	Last Available: "2020-12"
-10723	acceptable triple-distilled Boulevardier cocktail	10	good	Last Available: "2020-12"
+10723	triple-distilled acceptable Boulevardier cocktail	10	good	Last Available: "2020-12"
 10724	tarnished polarized Hotwire&trade; brand candy rope	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 53, Last Available: "2020-12"
 10725	normal bowl full of jelly	4	good	Last Available: "2020-12"
 10726	artisanal gray Eye and a Twist	3	EPIC	Last Available: "2020-12"
@@ -10588,22 +10588,22 @@
 10732	gray blinking fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
 10734	squat skewed spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
-10735	upside-down mirror pulsating robo-battery	0		
+10735	upside-down pulsating mirror robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
-10737	olive blurry power seed	0		Free Pull, Last Available: "2021-03"
+10737	blurry olive power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
 10739	quantum quadruple-flattened battery (AAA)	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 22, Last Available: "2021-03"
 10740	colloidal battery (AA)	0		Effect: "Red Around the Gills", Effect Duration: 64, Last Available: "2021-03"
 10741	quantum battery (D)	0		Effect: "Towering Strength", Effect Duration: 65, Last Available: "2021-03"
 10742	moist twirling battery (9-Volt)	0		Effect: "Elron's Explosive Etude", Effect Duration: 12, Last Available: "2021-03"
-10743	galvanized quadruple-tarnished alkaline blue wobbly battery (lantern)	0		Effect: "Cock of the Walk", Effect Duration: 35, Last Available: "2021-03"
+10743	galvanized quadruple-tarnished alkaline wobbly blue battery (lantern)	0		Effect: "Cock of the Walk", Effect Duration: 35, Last Available: "2021-03"
 10744	cold-filtered battery (car)	0		Effect: "Object Detection", Effect Duration: 38, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	wobbly skewed marshmallow	0		
 10747	watered-down tolerable marshmallow bomb	2	good	Last Available: "2021-03"
 10748	bouncing packaged backup camera	0		Free Pull, Last Available: "2021-04"
 10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
-10750	twirling lime green shortest-order cook	0		Free Pull, Last Available: "2021-05"
+10750	lime green twirling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	non-tarnished short beer	0		Effect: "Sugar High", Effect Duration: 19, Last Available: "2021-05"
 10753	boiled unsweetened huge short stack of pancakes	0		Effect: "Heart of White", Effect Duration: 63, Last Available: "2021-05"
@@ -10638,7 +10638,7 @@
 10782	wicked Abracandalabra of the brazier	0		Spell Damage: +5, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
 10783	energetic extra-wide head candle of the boozehound	0		Maximum MP Percent: +20, Booze Drop: +100, Lasts Until Rollover, Last Available: "2021-08"
 10784	non-vacuum-sealed extra-improved natural magick candle	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 43, Last Available: "2021-08"
-10785	deionized pickled blue mirror rainbow glitter candle	0		Effect: "Executive Greed", Effect Duration: 54, Last Available: "2021-08"
+10785	deionized pickled mirror blue rainbow glitter candle	0		Effect: "Executive Greed", Effect Duration: 54, Last Available: "2021-08"
 10786	dry deionized narrow banana candle	0		Effect: "Dreadful Fear", Effect Duration: 42, Last Available: "2021-08"
 10787	tarnished dry jittery ear candle	0		Effect: "Full-Body Tan", Effect Duration: 34, Last Available: "2021-08"
 10788	anodized colloidal blurry votive of confidence	0		Effect: "The Halls of Mysticality", Effect Duration: 38, Last Available: "2021-08"
@@ -10659,9 +10659,9 @@
 10803	green packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	twirling hardy savvy Daylight Shavings Helmet of Leguizamo	0		Mysticality Percent: +20, Maximum HP: +50, Monster Level: +20, Last Available: "2021-11"
 10805	eggwater	1	EPIC	Last Available: "2021-12"
-10806	miniature rotten bread man	2	crappy	Last Available: "2021-12"
+10806	rotten miniature bread man	2	crappy	Last Available: "2021-12"
 10807	immense decent olive plain candy cane	9	good	Last Available: "2021-12"
-10808	special stale flour cookie	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 5, Last Available: "2021-12"
+10808	stale special flour cookie	4	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 5, Last Available: "2021-12"
 10809	plastic food lab of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2021-12"
 10811	skewed lion tamer's plastic chem lab	0		Experience (familiar): +2, Single Equip, Last Available: "2021-12"
@@ -10675,16 +10675,16 @@
 10819	yummy tofu pop	3	awesome	Last Available: "2021-12"
 10820	miniature normal ghostly bowl of prescription candy	2	good	Last Available: "2021-12"
 10821	normal jumbo fishcake	5	good	Last Available: "2021-12"
-10822	adequate snack-sized teal bone broth	2	good	Last Available: "2021-12"
+10822	snack-sized adequate teal bone broth	2	good	Last Available: "2021-12"
 10823	decent bouncing star pop	4	good	Last Available: "2021-12"
-10824	drinkable maroon blinking Doc's Fortifying Wine	3	good	Last Available: "2021-12"
+10824	drinkable blinking maroon Doc's Fortifying Wine	3	good	Last Available: "2021-12"
 10825	hand-crafted extra-dry Doc's Smartifying Wine	5	EPIC	Last Available: "2021-12"
 10826	mediocre squat Doc's Limbering Wine	4	decent	Last Available: "2021-12"
 10827	perfectly mixed Doc's Medical-Grade Wine	4	EPIC	Last Available: "2021-12"
-10828	mixed skewed jittery Homebodyl&trade;	1		Last Available: "2021-12"
-10829	pickled narrow blurry Extrovermectin&trade;	1		Effect: "The Magic of LOV", Effect Duration: 5, Last Available: "2021-12"
+10828	mixed jittery skewed Homebodyl&trade;	1		Last Available: "2021-12"
+10829	pickled blurry narrow Extrovermectin&trade;	1		Effect: "The Magic of LOV", Effect Duration: 5, Last Available: "2021-12"
 10830	mixed spinning Breathitin&trade;	1		Effect: "Gonna Get You, Sucker", Effect Duration: 20, Last Available: "2021-12"
-10831	altered huge upside-down blurry Fleshazole&trade;	1		Last Available: "2021-12"
+10831	altered blurry upside-down huge Fleshazole&trade;	1		Last Available: "2021-12"
 10832	galvanized double-polymerized anti-burn cream	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 17, Last Available: "2021-12"
 10833	magnetized anti-freeze cream	0		Effect: "Concentrated Concentration", Effect Duration: 32, Last Available: "2021-12"
 10834	magnetized quadruple-flattened upside-down anti-goosebump cream	0		Effect: "There Is A Spoon", Effect Duration: 67, Last Available: "2021-12"
@@ -10768,7 +10768,7 @@
 10912	stale 20-lb can of rice and beans	4	decent	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	awesome	Last Available: "2022-05"
 10914	spoiled expired MRE	3	crappy	Last Available: "2022-05"
-10915	moldy big squat cool mint precipice bar	5	crappy	Last Available: "2022-05"
+10915	big moldy squat cool mint precipice bar	5	crappy	Last Available: "2022-05"
 10916	flavorless carrot cake precipice bar	4	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
@@ -10776,7 +10776,7 @@
 10920	therapeutic June cleaver of the wise owl of terror	0		Mysticality: +20, Spooky Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Attacks Can't Miss, Last Available: "2022-06"
 10921	artisanal watered-down Dad's brandy	2	EPIC	Last Available: "2022-06"
 10922	teacher's pen of extreme caution of the businessman	0		Monster Level: -25, Meat Drop: +50, Last Available: "2022-06"
-10923	spoiled bite-sized teal fire-roasted lake trout	1	crappy	Last Available: "2022-06"
+10923	bite-sized spoiled teal fire-roasted lake trout	1	crappy	Last Available: "2022-06"
 10924	spoiled guilty sprout	3	crappy	Last Available: "2022-06"
 10925	Oprah's mother's necklace of the brazier	0		Maximum MP Percent: +50, Hot Spell Damage: +25, Last Available: "2022-06"
 10926	chilled altered trampled ticket stub	0		Effect: "The Two-Prong Crown", Effect Duration: 44, Last Available: "2022-06"
@@ -10786,7 +10786,7 @@
 10930	vaporized mirror sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	narrow stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
-10933	ghostly gray thick dinosaur	0		
+10933	gray ghostly thick dinosaur	0		
 10934	dinosaur scale	0		
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
@@ -10813,7 +10813,7 @@
 10957	lard-coated gravedigger's frosty autumn sweater-weather sweater	0		Cold Spell Damage: +10, Spooky Damage: +10, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-10"
 10958	blurry ribald ruddy wicked savvy autumn debris shield	0		Mysticality Percent: +20, Spell Damage: +5, Maximum HP Percent: +40, Sleaze Damage: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	decent blue tumbling autumn-spice donut	4	good	Last Available: "2022-10"
-10960	polymerized ghostly squat tumbling autumn dollar	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 16, Last Available: "2022-10"
+10960	polymerized squat tumbling ghostly autumn dollar	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 16, Last Available: "2022-10"
 10961	miser's manspreader's groovy autumn leaf pendant	0		Moxie Percent: +10, Monster Level: +10, Meat Drop: +10, Lasts Until Rollover, Last Available: "2022-10"
 10962	pickled huge autumn breeze	1		Last Available: "2022-10"
 10963	Vulcanized frozen shaking autumn years wisdom	0		Effect: "Pisces Rising", Effect Duration: 45, Last Available: "2022-10"
@@ -10823,19 +10823,19 @@
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	skewed St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	rotten diet spinning maroon ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
+10970	rotten diet maroon spinning ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
 10971	flavorless Jarlsberg's vegetable soup	3	decent	Last Available: "2022-11"
 10972	moldy roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
-10973	low-calorie spoiled yellow St. Pete's sneaky smoothie	1	crappy	Last Available: "2022-11"
+10973	spoiled low-calorie yellow St. Pete's sneaky smoothie	1	crappy	Last Available: "2022-11"
 10974	bland jittery Pete's wiley whey bar	3	decent	Last Available: "2022-11"
-10975	moldy blurry mirror Pete's rich ricotta	3	crappy	Last Available: "2022-11"
-10976	fancy lousy pulsating Boris's beer	3	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 45, Last Available: "2022-11"
-10977	rotten fancy honey bun of Boris	4	crappy	Effect: "Chain Chain Chains", Effect Duration: 15, Last Available: "2022-11"
+10975	moldy mirror blurry Pete's rich ricotta	3	crappy	Last Available: "2022-11"
+10976	lousy fancy pulsating Boris's beer	3	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 45, Last Available: "2022-11"
+10977	fancy rotten honey bun of Boris	4	crappy	Effect: "Chain Chain Chains", Effect Duration: 15, Last Available: "2022-11"
 10978	normal Boris's bread	4	good	Last Available: "2022-11"
-10979	narrow red Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10979	red narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	jittery twirling Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10982	twirling jittery Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
 10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
 10984	blurry Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
 10985	red Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
@@ -10850,10 +10850,10 @@
 10994	wobbly Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
 10995	tumbling Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
 10996	upside-down Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	ghostly purple Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10997	purple ghostly Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	huge Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	miniature bland green Deep Dish of Legend	2	decent	Last Available: "2022-11"
+11000	bland miniature green Deep Dish of Legend	2	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	wobbly government per-diem	0		
@@ -10866,11 +10866,11 @@
 11010	stale half-sized swamp haunch	2	decent	
 11011	blue healthy studded gator shades	0		Damage Absorption: +80, Maximum HP Percent: +20, Single Equip
 11012	milk cap	0		
-11013	fortified bad Charleston Choo-Choo	5	decent	
+11013	bad fortified Charleston Choo-Choo	5	decent	
 11014	acceptable Velvet Veil	4	good	
 11015	artisanal watered-down Marltini	2	EPIC	
 11016	drinkable Strong, Silent Type	3	good	
-11017	watered-down mediocre lime green bouncing Mysterious Stranger	2	decent	
+11017	watered-down mediocre bouncing lime green Mysterious Stranger	2	decent	
 11018	hand-crafted Champagne Shimmy	3	EPIC	
 11019	the Sot's parcel	0		
 11020	flame-retardant ceramic cestus of James Dean	0		Experience (Moxie): +3, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10922,13 +10922,13 @@
 11066	twirling Crimbo crystal shards	0		
 11067	acceptable dregs of a Crimbo cocktail	3	good	
 11068	lost elf luggage	0		
-11069	twirling blurry Trainbot luggage hook	0		Single Equip
+11069	blurry twirling Trainbot luggage hook	0		Single Equip
 11070	spoiled immense maroon honey-drenched ham slice	7	crappy	
-11071	drinkable watered-down lime green mostly-empty bottle of cookie wine	2	good	
+11071	watered-down drinkable lime green mostly-empty bottle of cookie wine	2	good	
 11072	rotten Crimbo food scraps	3	crappy	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
-11075	skewed narrow table-scraper	0		Single Equip
+11075	narrow skewed table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
 11078	snack-sized flavorless steamed oyster	2	decent	
@@ -10937,7 +10937,7 @@
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	mediocre blue narrow Crimbosmopolitan	3	decent	Last Available: "2022-12"
+11084	mediocre narrow blue Crimbosmopolitan	3	decent	Last Available: "2022-12"
 11085	tasty fancy Crimbo dinner	3	awesome	Effect: "Action", Effect Duration: 20, Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	upside-down train whistle	0		Last Available: "2022-12"
@@ -10972,8 +10972,8 @@
 11117	galvanized cold-filtered glob of extra-green chlorophyll	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 60, Last Available: "2023-02"
 11118	modified Vulcanized warmed yellow mushroom	0		Effect: "Mushroom Might", Effect Duration: 15, Last Available: "2023-02"
 11119	irradiated aerosolized tumbling five-fingered fern resin	0		Effect: "Slimily Sagacious", Effect Duration: 15, Last Available: "2023-02"
-11120	adequate huge super good fruit	9	good	Last Available: "2023-02"
-11121	dried red shaking energized spores	1		Last Available: "2023-02"
+11120	huge adequate super good fruit	9	good	Last Available: "2023-02"
+11121	dried shaking red energized spores	1		Last Available: "2023-02"
 11122	narrow quilted beefy hot pepper	0		Muscle: +10, Damage Absorption: +40, Lantern Element: "Hot", Last Available: "2023-02"
 11123	double-activated polymerized electrified pulsating fuchsia out-of-work circus flea	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 31, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	fortified acceptable shadow venom	5	good	Last Available: "2023-03"
+11144	acceptable fortified shadow venom	5	good	Last Available: "2023-03"
 11145	powdered shadow nectar	1		Effect: "Aided and Abetted", Effect Duration: 40, Last Available: "2023-03"
 11146	bouncing squat censurious nippy shadow stick of vim and vigor	0		Maximum HP Percent: +50, Cold Damage: +10, Sleaze Resistance: +3, Last Available: "2023-03"
 11147	stiffened sinister bat paw	0		Spell Damage: +10, Damage Reduction: 1
@@ -11022,7 +11022,7 @@
 11167	shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
-11170	maroon twirling shadow lighter	0		
+11170	twirling maroon shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	shadow snowflake	0		
 11173	shadow heart	0		
@@ -11034,8 +11034,8 @@
 11179	gray twirling bouncing frosty shadow hammer of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +10
 11180	twirling slick shadow monocle of Calamity Jane of mayonnaise	0		Moxie: +10, Critical Hit Percent: +15, Sleaze Spell Damage: +50, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	yummy special immense shadow hot dog	6	awesome	Effect: "Ocelot Eyes", Effect Duration: 40
-11183	practically non-alcoholic lousy shadow martini	1	decent	
+11182	immense yummy special shadow hot dog	6	awesome	Effect: "Ocelot Eyes", Effect Duration: 40
+11183	lousy practically non-alcoholic shadow martini	1	decent	
 11184	diluted narrow shadow pill	1		Effect: "Surreally Buff", Effect Duration: 30
 11185	pulsating shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
@@ -11059,7 +11059,7 @@
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	replica cotton candy cocoon	0		
 11206	jittery careful steel-toed grievous arcane researcher's replica Elvish sunglasses	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Damage Reduction: 9, Monster Level: -10, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
-11207	tumbling ghostly replica squamous polyp	0		
+11207	ghostly tumbling replica squamous polyp	0		
 11208	replica stone sphere	0		
 11209	wobbly wool stylish replica Greatest American Pants of the sewer	0		Moxie: +25, Stench Damage: +25, Cold Resistance: +1
 11210	replica organ grinder	0		
@@ -11115,7 +11115,7 @@
 11260	rosy-cheeked hardened pro skateboard	0		Damage Reduction: 3, Maximum HP Percent: +30, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
-11263	tumbling skewed Loathing Idol Microphone	0		Last Available: "2023-06"
+11263	skewed tumbling Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	narrow Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	olive Flash Liquidizer Ultra Dousing Accessory of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
@@ -11159,11 +11159,11 @@
 11304	replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	spoiled diet squat watermelon	1	crappy	
+11307	diet spoiled squat watermelon	1	crappy	
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	gray thriftshop coupon	0		
-11311	tasty bite-sized waffle	1	awesome	
+11311	bite-sized tasty waffle	1	awesome	
 11312	skewed fixodent	0		
 11313	huge Oprah's ruddy cat o' nine teeth	0		Maximum HP Percent: +40, Maximum MP Percent: +50
 11314	blue double-paned personal trainer's tooth cap	0		Experience Percent (Muscle): +10, Cold Resistance: +5
@@ -11174,7 +11174,7 @@
 11319	blinking medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	hand-crafted tumbling bottle of Cabernet Sauvignon	3	EPIC	
 11321	lime green aromatic curative baywatch of wisdom	0		Mysticality: +15, Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover
-11322	blue pulsating Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	pulsating blue Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
@@ -11182,7 +11182,7 @@
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	pickled concentrated cooking	1		Effect: "Think Win-Lose", Effect Duration: 20
 11329	vaporized shaking meat	1		
-11330	dehydrated narrow blurry sparkling orb	1		
+11330	dehydrated blurry narrow sparkling orb	1		
 11331	diluted yellow hardening cream	1		
 11332	boiled upside-down green pool shark hair oil	1		Effect: "Weird Flavor", Effect Duration: 50
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11232,7 +11232,7 @@
 11377	housekeeping robot	0		
 11378	bland miniature pickled bread	2	decent	Last Available: "2023-12"
 11379	flavorless salted mutton	4	decent	Last Available: "2023-12"
-11380	snack-sized decent blurry corned beet	2	good	Last Available: "2023-12"
+11380	decent snack-sized blurry corned beet	2	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11246,7 +11246,7 @@
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
-11394	squat tumbling crated wardrobe-o-matic	0		
+11394	tumbling squat crated wardrobe-o-matic	0		
 11395	miniature delicious jittery peppermint donut	2	awesome	
 11396	Elf Guard insignia (private) of the empath	0		Familiar Weight: +5, Last Available: "2023-12"
 11397	rosewater-soaked Crimbuccaneer fledges (mint)	0		Stench Resistance: +3, Last Available: "2023-12"
@@ -11263,7 +11263,7 @@
 11408	narrow Elf Guard MPC	0		Last Available: "2023-12"
 11409	Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	Jeselnik's Elf Guard commandeering gloves	0		Sleaze Damage: +25, Single Equip, Last Available: "2023-12"
-11411	corrupted shaking skewed Elf Guard eyedrops	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 22, Last Available: "2023-12"
+11411	corrupted skewed shaking Elf Guard eyedrops	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 22, Last Available: "2023-12"
 11412	blinking Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	shaking scorching lion tamer's Elf Guard officer's sidearm	0		Experience (familiar): +2, Hot Damage: +25, Last Available: "2023-12"
@@ -11277,9 +11277,9 @@
 11422	drinkable tumbling old-school pirate grog	3	good	Last Available: "2023-12"
 11423	normal pulsating grog nuts	3	good	Last Available: "2023-12"
 11424	extremely unsafe arcane researcher's Herculean sawed-off blunderbuss	0		Experience (Muscle): +1, Experience Percent (Mysticality): +10, Weapon Damage Percent: +100, Last Available: "2023-12"
-11425	special bad officer's nog	3	decent	Effect: "Joy", Effect Duration: 45, Last Available: "2023-12"
+11425	bad special officer's nog	3	decent	Effect: "Joy", Effect Duration: 45, Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	bland special jumbo sundae ration	5	decent	Effect: "Stop and Smell the Fudge", Effect Duration: 45, Last Available: "2023-12"
+11427	special jumbo bland sundae ration	5	decent	Effect: "Stop and Smell the Fudge", Effect Duration: 45, Last Available: "2023-12"
 11428	moldy peppermint tack	4	crappy	Last Available: "2023-12"
 11429	spinning blinking Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	stale whalesteak	3	decent	Last Available: "2023-12"
@@ -11313,13 +11313,13 @@
 11458	squat wobbly inspector's Oprah's Crimbuccaneer bombjacket	0		Maximum MP Percent: +50, Item Drop: +15, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	moldy small huge sugarplum ration	2	crappy	Last Available: "2023-12"
 11460	stale gingerbread nylons	3	decent	Last Available: "2023-12"
-11461	bite-sized yummy rum-soaked fruitcake	1	awesome	Last Available: "2023-12"
+11461	yummy bite-sized rum-soaked fruitcake	1	awesome	Last Available: "2023-12"
 11462	bland lime	3	decent	Last Available: "2023-12"
-11463	rotten super-sized gingerbread pirate	5	crappy	Last Available: "2023-12"
+11463	super-sized rotten gingerbread pirate	5	crappy	Last Available: "2023-12"
 11464	bland fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
 11465	tolerable mulled wine	3	good	Last Available: "2023-12"
 11466	drinkable Swedish coffee	3	good	Last Available: "2023-12"
-11467	aged boozy yellow canteen of eggnog	5	awesome	Last Available: "2023-12"
+11467	boozy aged yellow canteen of eggnog	5	awesome	Last Available: "2023-12"
 11468	lousy hot wine	3	decent	Last Available: "2023-12"
 11469	artisanal Jamaican coffee	4	EPIC	Last Available: "2023-12"
 11470	lousy flask of egggrog	4	decent	Last Available: "2023-12"
@@ -11338,7 +11338,7 @@
 11483	blue lion tamer's sequin-encrusted sweater	0		Experience (familiar): +2, Last Available: "2023-12"
 11484	stiffened slick replica Elf Guard medal of the wise owl	0		Mysticality: +20, Moxie: +10, Damage Reduction: 1, Last Available: "2023-12"
 11485	twirling Lil' Snowball Factory	0		Last Available: "2023-12"
-11486	gray skewed Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
+11486	skewed gray Elf Guard temporary (permanent) tattoo	0		Last Available: "2023-12"
 11487	pulsating prank Crimbo card	0		Last Available: "2023-12"
 11488	Sherlock's clever Crimbuccaneer squirtblunderbuss	0		Maximum MP: +20, Item Drop: +25, Last Available: "2023-12"
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
@@ -11346,12 +11346,12 @@
 11491	mirror greedy Van der Graaf baleful Crimbuccaneer nose ring	0		Spell Damage: +25, Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	blinking upside-down Elf Guard safety bear	0		Last Available: "2023-12"
+11494	upside-down blinking Elf Guard safety bear	0		Last Available: "2023-12"
 11495	huge kraken	0		Last Available: "2023-12"
 11496	blue precision snowball	0		Last Available: "2023-12"
 11497	lime green Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
-11499	teal mirror Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+11499	mirror teal Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	galvanized military candy cane	0		Effect: "Cat Class, Cat Style", Effect Duration: 30
@@ -11362,13 +11362,13 @@
 11507	reassuring medical-grade moss mitre	0		Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
 11508	jittery energetic baleful moss mantle	0		Spell Damage: +25, Maximum MP Percent: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	Sinatra's moss marlinspike of the cougar	0		Moxie: +20, Experience (Moxie): +5, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	diluted mirror twirling moss mulch	1		Last Available: "2024-12"
+11510	diluted twirling mirror moss mulch	1		Last Available: "2024-12"
 11511	diffused pressed shaking moss floss	0		Effect: "Horrid, Torrid", Effect Duration: 61
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	huge adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	skewed adobe abacus	0		Last Available: "2024-12"
 11515	adobe ayam	0		Last Available: "2024-12"
-11516	narrow teal adobe ascot	0		Single Equip, Last Available: "2024-12"
+11516	teal narrow adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	blurry adobe abaya	0		Last Available: "2024-12"
 11518	modified yellow skewed adobe assortment	1		Last Available: "2024-12"
 11519	pickled adobe brittle	0		Effect: "Become Superficially interested", Effect Duration: 56
@@ -11427,11 +11427,11 @@
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	low-calorie bland yam	1	decent	Last Available: "2024-05"
 11574	drinkable yam martini	4	good	Last Available: "2024-05"
-11575	tolerable practically non-alcoholic maroon sweet potato o' mine	1	good	Last Available: "2024-05"
-11576	high-proof acceptable purple upside-down Southern yam	9	good	Last Available: "2024-05"
+11575	practically non-alcoholic tolerable maroon sweet potato o' mine	1	good	Last Available: "2024-05"
+11576	high-proof acceptable upside-down purple Southern yam	9	good	Last Available: "2024-05"
 11577	smooth sweet potato punch	4	awesome	Last Available: "2024-05"
 11578	moldy Mayam spinach	3	crappy	Last Available: "2024-05"
-11579	decent snack-sized yellow yam and swiss	2	good	Last Available: "2024-05"
+11579	snack-sized decent yellow yam and swiss	2	good	Last Available: "2024-05"
 11580	knitted wholesome yam cannon of terror	0		Maximum HP Percent: +10, Spooky Spell Damage: +10, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2024-05"
 11581	skewed upside-down yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11439,9 +11439,9 @@
 11584	gray asbestos-lined gravedigger's careful furry yam buckler	0		Monster Level: -10, Spooky Damage: +10, Hot Resistance: +5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	fuchsia thanksgiving bomb	0		Last Available: "2024-05"
 11586	auspicious reassuring Temple Grandin's yamtility belt	0		Familiar Weight: +7, Spooky Resistance: +1, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-05"
-11587	moldy huge huge huge yam slider	7	crappy	Last Available: "2024-05"
+11587	huge moldy huge huge yam slider	7	crappy	Last Available: "2024-05"
 11588	decent yam mayo	3	good	Last Available: "2024-05"
-11589	decent massive yam burrito	10	good	Last Available: "2024-05"
+11589	massive decent yam burrito	10	good	Last Available: "2024-05"
 11590	yellow visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	upside-down aviator goggles	0		
@@ -11472,7 +11472,7 @@
 11617	proto-proto-protozoa	0		
 11618	small normal bacteria bisque	2	good	
 11619	bland bite-sized ciliophora chowder	1	decent	
-11620	moldy snack-sized bouncing cream of chloroplasts	2	crappy	
+11620	snack-sized moldy bouncing cream of chloroplasts	2	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11487,7 +11487,7 @@
 11632	gray Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	bad practically non-alcoholic skewed Colera Peste Nebbiolo	1	decent	
+11635	practically non-alcoholic bad skewed Colera Peste Nebbiolo	1	decent	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11536,7 +11536,7 @@
 11681	teal shaking quantized familiar experience	0		
 11682	dry pea brittle	0		Effect: "Sweet Tooth", Effect Duration: 60, Last Available: "2024-11"
 11683	drinkable high-proof peasco	10	good	Last Available: "2024-11"
-11684	tasty big red piece of cake	5	awesome	Last Available: "2024-11"
+11684	big tasty red piece of cake	5	awesome	Last Available: "2024-11"
 11685	gray handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	cyan huge TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11551,9 +11551,9 @@
 11696	blurry nasty governor's daughter's lace collar	0		Stench Damage: +5, Last Available: "2024-12"
 11697	narrow scandalous governor's daughter's petticoats	0		Sleaze Damage: +5, Last Available: "2024-12"
 11698	blurry supercharged governor's daughter's pearl hairpin	0		Maximum MP Percent: +30, Last Available: "2024-12"
-11699	huge red harpoon	0		Last Available: "2024-12"
+11699	red huge harpoon	0		Last Available: "2024-12"
 11700	jittery squat chili powder cutlass	0		Item Drop: +5, Last Available: "2024-12"
-11701	moldy huge Aztec tamale	8	crappy	Last Available: "2024-12"
+11701	huge moldy Aztec tamale	8	crappy	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	pulsating Usain Bolt's groggles	0		Initiative: +80, Last Available: "2024-12"
@@ -11561,7 +11561,7 @@
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	bouncing executive silky pirate drawers of the glutton	0		Meat Drop: +40, Food Drop: +100, Last Available: "2024-12"
 11708	huge profane eye patch	0		Sleaze Damage: +3
-11709	dry squat blurry peppermint pegleg	0		Effect: "Wreathed in Merriment", Effect Duration: 64, Last Available: "2024-12"
+11709	dry blurry squat peppermint pegleg	0		Effect: "Wreathed in Merriment", Effect Duration: 64, Last Available: "2024-12"
 11710	bad hard cocoa	4	decent	Last Available: "2024-12"
 11711	yummy special salmagumdi	3	awesome	Effect: "Appeteyes", Effect Duration: 30, Last Available: "2024-12"
 11712	fuchsia Jack Frost's plastic Easter Island Bunny	0		Cold Spell Damage: +50, Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	mirror banded gravyskin skirt of temperance	0		Damage Absorption: +100, Sleaze Resistance: +5, Last Available: "2024-12"
 11737	chaotic educational gravyskin pants	0		Experience: +1, Spell Critical Percent: +10, Last Available: "2024-12"
 11738	double-activated dry crystallized pumpkin spice	0		Effect: "Brocolate Brostidigitation", Effect Duration: 53, Last Available: "2024-12"
-11739	decent thick purple room scale bean casserole	5	good	Last Available: "2024-12"
+11739	thick decent purple room scale bean casserole	5	good	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	lime green therapeutic Herculean perfect Christmas scarf of vim and vigor	0		Experience (Muscle): [+1*event(December)], Maximum HP Percent: [+50*event(December)], HP Regen Min: [5*event(December)], HP Regen Max: [7*event(December)], Single Equip, Last Available: "2024-12"
@@ -11599,18 +11599,18 @@
 11744	corrupted jittery LIDAR candle	0		Effect: "Sticky Hands", Effect Duration: 51, Last Available: "2024-12"
 11745	bouncing ruddy occult brainy Congressional Medal of Insanity	0		Mysticality: +5, Spell Damage Percent: +25, Maximum HP Percent: +40, Last Available: "2024-12"
 11746	blinking pumpkin spice whorl	0		Last Available: "2024-12"
-11747	mediocre spirit-forward twirling Easter grasshopper	5	decent	Last Available: "2024-12"
+11747	spirit-forward mediocre twirling Easter grasshopper	5	decent	Last Available: "2024-12"
 11748	tolerable Irish eggnog	3	good	Last Available: "2024-12"
 11749	bad canteen of jungle juice	4	decent	Last Available: "2024-12"
-11750	artisanal fancy turchucken	3	EPIC	Effect: "Slimy Flavor", Effect Duration: 20, Last Available: "2024-12"
+11750	fancy artisanal turchucken	3	EPIC	Effect: "Slimy Flavor", Effect Duration: 20, Last Available: "2024-12"
 11751	acceptable high-proof squat mechanically-mulled cider	10	good	Last Available: "2024-12"
 11752	acceptable holiday trip around the world	3	good	Last Available: "2024-12"
 11753	toothsome chocolate ostrich egg	3	awesome	Last Available: "2024-12"
-11754	spoiled diet beef and cabbage	1	crappy	Last Available: "2024-12"
+11754	diet spoiled beef and cabbage	1	crappy	Last Available: "2024-12"
 11755	super-sized yummy blurry candy rations	5	awesome	Last Available: "2024-12"
 11756	stale double-candied yams	3	decent	Last Available: "2024-12"
-11757	jumbo decent Christmas ham	5	good	Last Available: "2024-12"
-11758	snack-sized delicious holiday smorgasbord	2	awesome	Last Available: "2024-12"
+11757	decent jumbo Christmas ham	5	good	Last Available: "2024-12"
+11758	delicious snack-sized holiday smorgasbord	2	awesome	Last Available: "2024-12"
 11759	narrow upside-down Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	spinning mansplainer's bejazzled eyepatch	0		Monster Level: +15, Last Available: "2024-12"
 11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11653,7 +11653,7 @@
 11798	dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	jittery dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
-11801	lime green jittery dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
+11801	jittery lime green dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	spinning dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	squat cybervisor	0		Last Available: "2025-12"
 11804	red retro floppy disk	0		Last Available: "2025-12"
@@ -11672,7 +11672,7 @@
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	narrow dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	blinking shaking dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11820	shaking blinking dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	huge SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	spinning OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
@@ -11687,11 +11687,11 @@
 11832	ninja carabiner	0		
 11833	quantum synthetic coffee	0		Effect: "Fizzier Than Light", Effect Duration: 34
 11834	polymerized wobbly iDrops	0		Effect: "Piratastic", Effect Duration: 63
-11835	spinning olive shame coil	0		
+11835	olive spinning shame coil	0		
 11836	skewed bouncing new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
-11839	yellow spinning scrape	0		
+11839	spinning yellow scrape	0		
 11840	phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
@@ -11714,9 +11714,9 @@
 11859	mosquito speakers	0		Monster Level: +5
 11860	blinking assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
-11862	mixed spinning huge scoop of pre-workout powder	1		Effect: "Memory of Strength", Effect Duration: 10, Last Available: "2025-03"
+11862	mixed huge spinning scoop of pre-workout powder	1		Effect: "Memory of Strength", Effect Duration: 10, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	triple-distilled aged pint of Leprechaun Stout	10	awesome	Last Available: "2025-03"
+11864	aged triple-distilled pint of Leprechaun Stout	10	awesome	Last Available: "2025-03"
 11865	denatured tumbling phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11724,17 +11724,17 @@
 11869	cyan unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	boiled leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	gigantic enchanted rotten Heck ramen	9	crappy	Effect: "Aquarius Rising", Effect Duration: 45, Last Available: "2025-03"
+11872	rotten enchanted gigantic Heck ramen	9	crappy	Effect: "Aquarius Rising", Effect Duration: 45, Last Available: "2025-03"
 11873	rotten super-sized burrito	5	crappy	Last Available: "2025-03"
 11874	rotten snack-sized small beer brat	2	crappy	Last Available: "2025-03"
 11875	stale snack-sized peach pie	2	decent	Last Available: "2025-03"
 11876	delicious thick incredible mini-pizza	5	awesome	Last Available: "2025-03"
 11877	bad Divine sidecar	4	decent	Last Available: "2025-03"
-11878	perfectly mixed weak tangarita sidecar	2	EPIC	Last Available: "2025-03"
-11879	extra-dry hand-crafted gimlet sidecar	5	EPIC	Last Available: "2025-03"
-11880	watered-down hand-crafted skewed vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
+11878	weak perfectly mixed tangarita sidecar	2	EPIC	Last Available: "2025-03"
+11879	hand-crafted extra-dry gimlet sidecar	5	EPIC	Last Available: "2025-03"
+11880	hand-crafted watered-down skewed vodka stratocaster sidecar	2	EPIC	Last Available: "2025-03"
 11881	drinkable huge prussian cathouse sidecar	4	good	Last Available: "2025-03"
-11882	high-proof mediocre shaking Mon Tiki sidecar	10	decent	Last Available: "2025-03"
+11882	mediocre high-proof shaking Mon Tiki sidecar	10	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	scandalous supercool April Shower Thoughts shield	0		Moxie Percent: +20, Sleaze Damage: +5, Damage Reduction: 6, Last Available: "2025-04"
 11885	blinking glob of wet paper	0		Last Available: "2025-04"
@@ -11749,9 +11749,9 @@
 11894	fortified wet shower shorts	0		Damage Absorption: +60, Last Available: "2025-04"
 11895	wet paper tiger	0		Last Available: "2025-04"
 11896	wet paper eye	0		Familiar Weight: +15
-11897	skewed spinning wet shower curtain	0		Last Available: "2025-04"
+11897	spinning skewed wet shower curtain	0		Last Available: "2025-04"
 11898	pressed wet paper cup	0		Effect: "Pie in the Sky", Effect Duration: 36, Last Available: "2025-04"
-11899	energized triple-wet huge fuchsia blurry wet paperback	0		Effect: "Cold Jellied", Effect Duration: 49, Last Available: "2025-04"
+11899	energized triple-wet fuchsia huge blurry wet paperback	0		Effect: "Cold Jellied", Effect Duration: 49, Last Available: "2025-04"
 11900	twirling horrifying wet shower radio	0		Spooky Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	wet shower stamp	0		Last Available: "2025-04"
 11902	spinning Lo Pan's birthday bloon	0		Spell Critical Percent: +30
@@ -11783,14 +11783,14 @@
 11928	really expensive stolen artifact	0		
 11929	jittery priceless stolen artifact	0		
 11930	blurry chocolate rations	0		
-11931	twirling wobbly nice nylon stockings	0		
+11931	wobbly twirling nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	Jim Carey's Da Vinci's Allied Radio Backpack of the sewer	0		Experience (Mysticality): +5, Monster Level: +25, Stench Damage: +25, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
 11935	pulsating ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	spoiled Skeleton Wars rations	3	crappy	
-11938	watered-down mediocre skeleton war fuel can	2	decent	
+11938	mediocre watered-down skeleton war fuel can	2	decent	
 11939	upside-down skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11807,16 +11807,16 @@
 11952	dehydrated blurry mixed berry jelly	1		Last Available: "2025-08"
 11953	flavorless spinning toast with mixed berry jelly	3	decent	Last Available: "2025-08"
 11954	toothsome jumbo cup of sugar	5	awesome	Last Available: "2025-08"
-11955	normal bite-sized spinning Susie's cupcake	1	good	Last Available: "2025-08"
+11955	bite-sized normal spinning Susie's cupcake	1	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	Usain Bolt's smelly supercharged the gun	0		Maximum MP Percent: +30, Stench Spell Damage: +10, Initiative: +80, Last Available: "2025-08"
-11958	triple-distilled perfectly mixed olive upside-down wine	10	EPIC	Last Available: "2025-08"
+11958	triple-distilled perfectly mixed upside-down olive wine	10	EPIC	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	smartaleck's undersea surveying goggles	0		Moxie Percent: +30, Lasts Until Rollover
-11963	lousy weak Ocean-Touched Rum	2	decent	
+11963	weak lousy Ocean-Touched Rum	2	decent	
 11964	diluted blue water-logged pill	1		Effect: "Antibiotic Saucesphere", Effect Duration: 20
-11965	huge flavorless spinning kelp puck	10	decent	
+11965	flavorless huge spinning kelp puck	10	decent	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
@@ -11833,20 +11833,20 @@
 11987	nippy Temple Grandin's MacGyver's crafty slick blood cubic zirconia of the cheetah	0		Moxie: +10, Maximum MP: 110, Familiar Weight: +7, Cold Damage: +10, Initiative: +60, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	dehydrated twirling twirling blood thinner	1		Last Available: "2025-10"
 12045	weak perfectly mixed pheromone cocktail	2	EPIC	Last Available: "2025-10"
-12046	spoiled low-calorie mirror spinal tapas	1	crappy	Last Available: "2025-10"
+12046	low-calorie spoiled mirror spinal tapas	1	crappy	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	Sherlock's brainy shrunken head of Gandalf	0		Mysticality: +5, Spell Critical Percent: +20, Item Drop: +25, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	tumbling stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	acceptable Smoking Pope	3	good	
-12053	rotten thick prize turkey	5	crappy	
+12053	thick rotten prize turkey	5	crappy	
 12054	boiled spinning medicinal gruel	1		
 12055	normal fancy bouncing full-sized pumpkin pie	3	good	Effect: "Burning Ears", Effect Duration: 20, Last Available: "2025-11"
-12056	aged fancy weak vodka cranberry sauce	2	awesome	Effect: "Dilated Pupils", Effect Duration: 45, Last Available: "2025-11"
+12056	fancy aged weak vodka cranberry sauce	2	awesome	Effect: "Dilated Pupils", Effect Duration: 45, Last Available: "2025-11"
 12057	enhanced blurry yellow yammed candy	0		Effect: "Fireproof Lips", Effect Duration: 53, Last Available: "2025-11"
 12058	special spoiled blurry treasure chestnut	4	crappy	Effect: "Yet tea", Effect Duration: 50, Last Available: "2025-12"
-12059	perfectly mixed practically non-alcoholic mulled butter rum	1	super ultra mega EPIC	Last Available: "2025-12"
+12059	practically non-alcoholic perfectly mixed mulled butter rum	1	super ultra mega EPIC	Last Available: "2025-12"
 12060	quantum cinnamon doubloon	0		Effect: "Radium Radicality", Effect Duration: 44, Last Available: "2025-12"
 12061	stylish plastic left skeleton arm	0		Moxie: +25, Last Available: "2025-12"
 12062	toasty plastic left skeleton leg	0		Hot Damage: +5, Last Available: "2025-12"
@@ -11896,14 +11896,14 @@
 12138	green greasy weightlifter's fistbone of chilblains	0		Muscle: +15, Cold Damage: +25, Sleaze Spell Damage: +10, Last Available: "2025-12"
 12139	auspicious nasty burnt bone belt of the wise owl	0		Mysticality: +20, Stench Damage: +5, Item Drop: +10, Single Equip, Last Available: "2025-12"
 12140	supercharged scorched skull trophy	0		Maximum MP Percent: +30, Last Available: "2025-12"
-12141	moldy miniature wing bone	2	crappy	Last Available: "2025-12"
-12142	perfectly mixed weak weak skeleton venom	2	EPIC	Last Available: "2025-12"
+12141	miniature moldy wing bone	2	crappy	Last Available: "2025-12"
+12142	weak perfectly mixed weak skeleton venom	2	EPIC	Last Available: "2025-12"
 12143	pickled blue baked bone meal	1		Effect: "Superheroic", Effect Duration: 5, Last Available: "2025-12"
 12144	fuchsia dance instructor's plastic skeleton rib cage	0		Experience Percent (Moxie): +10, Last Available: "2025-12"
 12145	jittery occult plastic skeleton skull	0		Spell Damage Percent: +25, Last Available: "2025-12"
 12146	olive asbestos-lined plastic skeleton Crimbo hat	0		Hot Resistance: +5, Last Available: "2025-12"
 12147	bouncing assembled plastic Santa skeleton	0		Last Available: "2025-12"
-12148	narrow green sleigh	0		Familiar Weight: +10
+12148	green narrow sleigh	0		Familiar Weight: +10
 12149	blinking undertakers' forceps	0		Last Available: "2025-12"
 12150	bone-polishing rag	0		Last Available: "2025-12"
 12151	hardy scorched skeleton mask of doom	0		Maximum HP: +50, Spooky Spell Damage: +50, Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	moldy traditional gingerloaf	4	crappy	Last Available: "2025-12"
 12172	smooth practically non-alcoholic Scotch and eggnog	1	awesome	Last Available: "2025-12"
 12173	denatured wobbly counterskeleton elixir	0		Effect: "Smoking like a Bandit", Effect Duration: 64, Last Available: "2025-12"
-12174	tolerable weak &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
+12174	weak tolerable &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	upside-down crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	super-sized flavorless wedge of prize-winning cheese	5	decent	Last Available: "2025-12"
@@ -11960,7 +11960,7 @@
 12202	greedy smartaleck's dinosaur skull helmet	0		Moxie Percent: +30, Meat Drop: +20, Last Available: "2026-03"
 12203	forbidden Fonzie's dinosaur bone corset of the empath	0		Experience (Moxie): +1, Spell Damage Percent: +50, Familiar Weight: +5, Last Available: "2026-03"
 12204	tolerable shaking Pork Elf cough syrup	3	good	Last Available: "2026-03"
-12205	twirling pulsating Pork Elf neti pot	0		Last Available: "2026-03"
+12205	pulsating twirling Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	skewed Pork Elf toilet	0		Last Available: "2026-03"
@@ -11969,7 +11969,7 @@
 12211	stanky hoverboard of Leguizamo of the boozehound	0		Monster Level: +20, Stench Spell Damage: +25, Booze Drop: +100, Single Equip, Last Available: "2026-03"
 12212	pulsating smelly experienced left shark fin of Calamity Jane	0		Experience: +2, Critical Hit Percent: +15, Stench Spell Damage: +10, Last Available: "2026-03"
 12213	careful fitness tracking bracelet	0		Monster Level: -10, Single Equip, Last Available: "2026-03"
-12214	twisted jittery squat bouncing candy bone	1		
+12214	twisted squat jittery bouncing candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	moldy discarded hot dog	4	crappy	Last Available: "2026-04"
@@ -11990,18 +11990,18 @@
 12236	yummy Pesto alla Marziano	4	awesome	Last Available: "2026-05"
 12237	flavorless half-sized Arrattabbattabiata	2	decent	Last Available: "2026-05"
 12238	adequate Orzo di Riso	3	good	Last Available: "2026-05"
-12239	big stale Pasta Grimavera	5	decent	Last Available: "2026-05"
+12239	stale big Pasta Grimavera	5	decent	Last Available: "2026-05"
 12240	adequate Linguini Ubriacapa	4	good	Last Available: "2026-05"
 12241	flavorless shaking Formica e Pepe	3	decent	Last Available: "2026-05"
-12242	normal tiny purple Tubetto Gelatto	1	good	Last Available: "2026-05"
-12243	half-sized yummy Gnocci Domani	2	awesome	Last Available: "2026-05"
+12242	tiny normal purple Tubetto Gelatto	1	good	Last Available: "2026-05"
+12243	yummy half-sized Gnocci Domani	2	awesome	Last Available: "2026-05"
 12244	gray Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	inspector's curative Space Soldier Helmet	0		Item Drop: +15, HP Regen Min: 3, HP Regen Max: 5
 12253	fancy moldy premium turkey leg	3	crappy	Effect: "Weird Vibrations", Effect Duration: 35
-12254	mediocre special practically non-alcoholic yellow styrofoam cup of mead	1	decent	Effect: "Like a Fish to Walter", Effect Duration: 50
+12254	special practically non-alcoholic mediocre yellow styrofoam cup of mead	1	decent	Effect: "Like a Fish to Walter", Effect Duration: 50
 12255	mirror sizzling sword	0		Hot Damage: +10
 12256	auspicious staff	0		Item Drop: +10
 12257	boxer's lute	0		Muscle Percent: +10
@@ -12023,22 +12023,22 @@
 12273	stale blurry watermelon	3	decent	Last Available: "2026-07"
 12274	delicious quince	3	awesome	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
-12276	mirror blurry Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
+12276	blurry mirror Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	normal fuchsia classic banana pie	3	good	Last Available: "2026-07"
 12278	Vulcanized enhanced essential banana decoction	0		Effect: "Sparkly!", Effect Duration: 36, Last Available: "2026-07"
 12279	boiled altered banana quintessence	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13, Last Available: "2026-07"
 12280	perfectly mixed Aesop Daiquiri	3	EPIC	Last Available: "2026-07"
-12281	practically non-alcoholic bad Monkey Congress	1	decent	Last Available: "2026-07"
-12282	decent tiny fancy watermelon pie	1	good	Effect: "Boilermade", Effect Duration: 10, Last Available: "2026-07"
+12281	bad practically non-alcoholic Monkey Congress	1	decent	Last Available: "2026-07"
+12282	decent fancy tiny watermelon pie	1	good	Effect: "Boilermade", Effect Duration: 10, Last Available: "2026-07"
 12283	magnetized huge concentrated watermelon juice	0		Effect: "Human-Slime Hybrid", Effect Duration: 51, Last Available: "2026-07"
 12284	dry ionized Aqua Citrulanatae	0		Effect: "Industrial Strength Starch", Effect Duration: 63, Last Available: "2026-07"
 12285	practically non-alcoholic mediocre upside-down Melonegroni	1	decent	Last Available: "2026-07"
 12286	watered-down artisanal Melonade Spritz	2	super EPIC	Last Available: "2026-07"
-12287	stale super-sized cyan ghostly spinning quince pie	5	decent	Last Available: "2026-07"
+12287	super-sized stale ghostly spinning cyan quince pie	5	decent	Last Available: "2026-07"
 12288	energized quince quaff	0		Effect: "You Know Who to Call", Effect Duration: 55, Last Available: "2026-07"
 12289	wet polymerized narrow Quickquince	0		Effect: "Rave Concentration", Effect Duration: 43, Last Available: "2026-07"
 12290	hand-crafted narrow Quiskey Sour	3	EPIC	Last Available: "2026-07"
-12291	weak drinkable cyan Quincea&ntilde;era Cooler	2	good	Last Available: "2026-07"
+12291	drinkable weak cyan Quincea&ntilde;era Cooler	2	good	Last Available: "2026-07"
 12292	hand-crafted Roth IPA	3	EPIC	Last Available: "2026-08"
 12293	nippy Sinatra's underdraft protection	0		Experience (Moxie): +5, Cold Damage: +10, Last Available: "2026-08"
 12294	bouncing solvent	0		Last Available: "2026-08"
@@ -12058,7 +12058,7 @@
 12308	savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	distilled toxic asset	1		Last Available: "2026-08"
-12311	modified cyan bouncing intangible asset	1		Last Available: "2026-08"
+12311	modified bouncing cyan intangible asset	1		Last Available: "2026-08"
 12312	diluted liquid asset	1		Effect: "This Is Where You're a Viking", Effect Duration: 10, Last Available: "2026-08"
 12313	gray gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Seal_Clubber_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Mongoose_cafe_booze.txt
@@ -1,21 +1,21 @@
 -1	irresponsibly strong tolerable ghostly Petite Porter	6	good	
--2	delicious fortified Scrawny Stout	5	awesome	
+-2	fortified delicious Scrawny Stout	5	awesome	
 -3	watered-down mediocre Infinitesimal IPA	2	decent	
 -4	artisanal eggnogtini	3	EPIC	
 -5	hand-crafted candycaine	3	EPIC	
 -6	bad braincracker sweet	3	decent	
 -16	fancy high-proof perfectly mixed huge fermented honey	10	EPIC	
 -17	bad moons-shine	4	decent	
--18	hand-crafted squat narrow gin	3	EPIC	
+-18	hand-crafted narrow squat gin	3	EPIC	
 -19	mediocre narrow ecto-nog	3	decent	
 -20	watered-down perfectly mixed hot toady	2	EPIC	
 -21	aged upside-down jittery hot choculate	4	awesome	
 -49	delicious Cyder	3	awesome	
--50	tolerable irresponsibly strong Oil Nog	7	good	
+-50	irresponsibly strong tolerable Oil Nog	7	good	
 -51	boozy drinkable Hi-Octane Peppermint Jet Fuel	5	good	
--58	bad fortified Grimacider	5	decent	
+-58	fortified bad Grimacider	5	decent	
 -59	fortified mediocre green Isotope Nog	5	decent	
--60	perfectly mixed special irresponsibly strong Mutagin 'n' Tonic	9	EPIC	
+-60	perfectly mixed irresponsibly strong special Mutagin 'n' Tonic	9	EPIC	
 -70	hand-crafted weak skewed Gin and Herring	2	EPIC	
 -71	mediocre wobbly Black and Tan and Red All Over	4	decent	
 -72	mediocre high-proof Antarctic Ice Tea	10	decent	
@@ -24,10 +24,10 @@
 -78	lousy ghostly CRIMBCO Extreme Braincracker Sour	3	decent	
 -82	drinkable weak squat Horseradish-infused Vodka	2	good	
 -83	tolerable maroon Jerkitini	3	good	
--84	hand-crafted distilled Desert Island Iced Tea	5	EPIC	
--88	high-proof mediocre Crimbo Saketini	7	decent	
+-84	distilled hand-crafted Desert Island Iced Tea	5	EPIC	
+-88	mediocre high-proof Crimbo Saketini	7	decent	
 -89	extra-dry mediocre pulsating Crimboku Drop	5	decent	
--90	tolerable fancy watered-down Flaming Crimbo Log	2	good	
+-90	fancy tolerable watered-down Flaming Crimbo Log	2	good	
 -107	perfectly mixed Fortified Eggnog Slurry	3	EPIC	
--108	spirit-forward lousy special squat Hot Buttered Rum	5	decent	
--109	lousy red pulsating Spicy Hot Chocolate	3	decent	
+-108	special lousy spirit-forward squat Hot Buttered Rum	5	decent	
+-109	lousy pulsating red Spicy Hot Chocolate	3	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Mongoose_cafe_food.txt
@@ -1,24 +1,24 @@
--1	flavorless massive ghostly Peche a la Frog	6	decent	
+-1	massive flavorless ghostly Peche a la Frog	6	decent	
 -2	thick decent As Jus Gezund Heit	5	good	
 -3	miniature moldy Bouillabaise Coucher Avec Moi	2	crappy	
 -7	decent gumdrop chow mein	4	good	
 -8	rotten jittery lime green candy cane pizza	3	crappy	
 -9	stale gingerbread stir-fry	3	decent	
 -10	spoiled twigs and gravel	3	crappy	
--11	decent jumbo shoots and leaves	5	good	
+-11	jumbo decent shoots and leaves	5	good	
 -12	adequate bowl of unidentifiable goo	3	good	
--13	special tasty gingerbread massacre	3	awesome	
--14	rotten half-sized It Came From Beyond Dessert	2	crappy	
--15	toothsome low-calorie special vampire cake	1	awesome	
+-13	tasty special gingerbread massacre	3	awesome	
+-14	half-sized rotten It Came From Beyond Dessert	2	crappy	
+-15	toothsome special low-calorie vampire cake	1	awesome	
 -52	normal thick Soylent Red and Green	5	good	
 -53	yummy blurry Disc-Shaped Nutrition Unit	3	awesome	
 -54	adequate tiny squat jittery Gingerborg Hive	1	good	
--61	miniature bland Candy Cane Surprise	2	decent	
+-61	bland miniature Candy Cane Surprise	2	decent	
 -62	bland small Grimdrop Chow Mein	2	decent	
--63	snack-sized moldy red Grimgerbread House	2	crappy	
+-63	moldy snack-sized red Grimgerbread House	2	crappy	
 -67	spoiled Caviar Carbonara	4	crappy	
 -68	adequate low-calorie Halibut Alfredo	1	good	
--69	normal diet wobbly purple Red Herring Velvet Cake	1	good	
+-69	diet normal wobbly purple Red Herring Velvet Cake	1	good	
 -73	moldy CRIMBCO Reconstituted Gruel	3	crappy	
 -74	small bland New and Improved CRIMBCO Reconstituted Gruel	2	decent	
 -75	yummy upside-down CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	awesome	
@@ -26,7 +26,7 @@
 -80	adequate diet cyan Carrot, Cabbage, and Kale Pizza	1	good	
 -81	big tasty huge Turnip and Rutabaga Pie	5	awesome	
 -85	decent Rainbow Spider Fun Roll	3	good	
--86	huge adequate Vegas Volcano Lava Roll	10	good	
+-86	adequate huge Vegas Volcano Lava Roll	10	good	
 -87	flavorless blurry Crazy Dragon Shogun Buddha Roll	3	decent	
 -92	flavorless super-sized skewed basic hot dog	5	decent	
 -93	half-sized delicious blinking savage macho dog	2	awesome	
@@ -36,10 +36,10 @@
 -97	moldy jittery chilly dog	4	crappy	
 -98	yummy ghost dog	3	awesome	
 -99	flavorless huge junkyard dog	4	decent	
--100	low-calorie rotten wet dog	1	crappy	
+-100	rotten low-calorie wet dog	1	crappy	
 -101	decent jittery sleeping dog	3	good	
--102	moldy snack-sized optimal dog	2	crappy	
--103	normal wobbly shaking video games hot dog	3	good	
+-102	snack-sized moldy optimal dog	2	crappy	
+-103	normal shaking wobbly video games hot dog	3	good	
 -104	stale Peppermint Nutrition Block	3	decent	
 -105	decent Gingerbread Nutrition Block	3	good	
 -106	big normal mirror Cinnamon Nutrition Block	5	good	

--- a/data/TCRS/TCRS_Seal_Clubber_Opossum.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Opossum.txt
@@ -54,10 +54,10 @@
 55	jaba&ntilde;ero pepper	0		
 56	hot sauce	0		
 57	censurious 5-Alarm Saucepan	0		Sleaze Resistance: +3, Class: "Sauceror"
-58	squat pulsating stone turtle	0		
+58	pulsating squat stone turtle	0		
 59	slingshot	0		
 60	sharpshooter's Mace of the Tortoise	0		Critical Hit Percent: +10, Class: "Turtle Tamer"
-61	decent miniature fortune cookie	2	good	
+61	miniature decent fortune cookie	2	good	
 62	mirror oriole-feather headdress of wisdom	0		Mysticality: +15, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -118,7 +118,7 @@
 119	sprocket	0		
 120	cog	0		
 121	ghostly sprocket assembly	0		
-122	ghostly narrow cog and sprocket assembly	0		
+122	narrow ghostly cog and sprocket assembly	0		
 123	Gnollish flyswatter	0		
 124	olive empty meat tank	0		
 125	full meat tank	0		
@@ -157,7 +157,7 @@
 158	upside-down Gnollish pie tin	0		
 159	wad of dough	0		
 160	pie crust	0		
-161	low-calorie normal ghuol egg	1	good	
+161	normal low-calorie ghuol egg	1	good	
 162	spoiled ghuol egg quiche	3	crappy	
 163	squat greasy skeleton bone	0		Sleaze Spell Damage: +10
 164	smart skull	0		
@@ -197,7 +197,7 @@
 199	yellow ring of the overflowing toilet	0		Stench Spell Damage: +50
 200	decent blurry rat appendix kabob	4	good	
 201	normal snack-sized bat wing kabob	2	good	
-202	toothsome tiny carob chunks	1	awesome	
+202	tiny toothsome carob chunks	1	awesome	
 203	upside-down herbs	0		
 204	adequate carob chunk cookies	3	good	
 205	secret blend of herbs and spices	0		
@@ -220,7 +220,7 @@
 222	phat turquoise bead	0		
 223	bouncing tumbling sage phat turquoise bracelet	0		Mysticality Percent: +10
 224	eyepatch of chilblains	0		Cold Damage: +25, Familiar Effect: "3xBarrr, cap 6"
-225	bland half-sized tofu casserole	2	decent	
+225	half-sized bland tofu casserole	2	decent	
 226	boiled narrow can of Red Minotaur	1	crappy	
 227	squat bouncing Kentucky-fried meat sword of the cougar	0		Moxie: +20
 228	twirling sage Kentucky-fried meat staff	0		Mysticality Percent: +10
@@ -239,11 +239,11 @@
 241	Orcish frat-paddle of chilblains	0		Cold Damage: +25
 242	spoiled ghostly	3	crappy	
 243	spoiled grapefruit	3	crappy	
-244	fancy tiny stale grapes	1	decent	Effect: "Loyal Tea", Effect Duration: 35
+244	tiny fancy stale grapes	1	decent	Effect: "Loyal Tea", Effect Duration: 35
 245	normal small olive	2	good	
 246	moldy tomato	4	crappy	
-247	spinning cyan fermenting powder	0		
-248	acceptable squat mirror salty dog	3	good	
+247	cyan spinning fermenting powder	0		
+248	acceptable mirror squat salty dog	3	good	
 249	acceptable ghostly bloody mary	3	good	
 250	mediocre irresponsibly strong screwdriver	7	decent	
 251	mediocre martini	3	decent	
@@ -257,8 +257,8 @@
 259	fuchsia snake skin	0		
 260	bite-sized adequate White Citadel fries	1	good	
 261	yummy White Citadel burger	3	awesome	
-262	big moldy piece of wedding cake	5	crappy	
-263	thick enchanted moldy chocolate chips	5	crappy	Effect: "Boon of the Storm Tortoise", Effect Duration: 20
+262	moldy big piece of wedding cake	5	crappy	
+263	moldy thick enchanted chocolate chips	5	crappy	Effect: "Boon of the Storm Tortoise", Effect Duration: 20
 264	normal jumbo chocolate chip cookies	5	good	
 265	dog trainer's satin pants	0		Experience (familiar): +1, Familiar Effect: "atk, 2xPotato, cap 10"
 266	acceptable triple-distilled shaking lightning	10	good	
@@ -311,14 +311,14 @@
 313	reassuring Crown of the Goblin King	0		Spooky Resistance: +1, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	adequate twirling bean burrito	4	good	
 315	moldy super-sized purple bean burrito	5	crappy	
-316	moldy massive upside-down insanely bean burrito	6	crappy	
+316	massive moldy upside-down insanely bean burrito	6	crappy	
 317	toothsome bean burrito	3	awesome	
 318	delicious shaking bean burrito	3	awesome	
-319	super-sized rotten enchanted insanely bean burrito	5	crappy	Effect: "Space Tripping", Effect Duration: 25
+319	super-sized enchanted rotten insanely bean burrito	5	crappy	Effect: "Space Tripping", Effect Duration: 25
 320	normal bat haggis	4	good	
 321	flavorless blue menudo	3	decent	
 322	adequate miniature spinning goat cheese	2	good	
-323	spoiled snack-sized plain pizza	2	crappy	
+323	snack-sized spoiled plain pizza	2	crappy	
 324	enchanted tasty sausage pizza	4	awesome	Effect: "stats.enq", Effect Duration: 10
 325	normal goat cheese pizza	3	good	
 326	half-sized delicious mushroom pizza	2	awesome	
@@ -328,9 +328,9 @@
 330	glass of goat's milk	1	decent	
 331	bad Canadian	4	decent	
 332	spoiled lemon	3	crappy	
-333	flavorless diet lime	1	decent	
+333	diet flavorless lime	1	decent	
 334	sabre teeth of the cheetah	0		Initiative: +60
-335	olive tumbling sabre-toothed lime cub	0		
+335	tumbling olive sabre-toothed lime cub	0		
 336	consolation ribbon of the empath	0		Familiar Weight: +5
 337	skewed ol' trophy	0		
 338	tenderizing hammer	0		
@@ -345,7 +345,7 @@
 347	Dyspepsi-Cola	0		
 348	blurry supercharged ninja mask	0		Maximum MP Percent: +30, Familiar Effect: "cold atk, 1xBarrr, cap 20"
 349	icy katana hilt	0		
-350	upside-down skewed hot katana blade	0		
+350	skewed upside-down hot katana blade	0		
 351	Sherlock's Van der Graaf icy-hot katana	0		Item Drop: +25, MP Regen Min: 5, MP Regen Max: 7
 352	ninja hot pants of the wise owl	0		Mysticality: +20, Familiar Effect: "hot atk, 3xPotato, cap 17"
 353	gray ninja stars	0		
@@ -413,7 +413,7 @@
 415	asbestos-lined leotarrrd	0		Hot Resistance: +5, Familiar Effect: "2xVolley, 2xPotato, cap 22"
 416	narrow mirror greasy safarrri hat	0		Sleaze Spell Damage: +10, Familiar Effect: "2xVolley, cap 22"
 417	enhanced henna tattoo	0		Effect: "Stemonitis Storm", Effect Duration: 57
-418	deionized mirror jittery Ferrigno's Elixir of Power	0		Effect: "Jungle Juiced", Effect Duration: 54
+418	deionized jittery mirror Ferrigno's Elixir of Power	0		Effect: "Jungle Juiced", Effect Duration: 54
 419	unsweetened pickled tumbling serum of sarcasm	0		Effect: "Memory of Smarts", Effect Duration: 41
 420	vacuum-sealed tomato juice of powerful power	0		Effect: "Sweet, Nuts", Effect Duration: 38
 421	irradiated philter of phorce	0		Effect: "Gummiheart", Effect Duration: 42
@@ -439,7 +439,7 @@
 441	chef-skull-in-the-box	0		
 442	bartender-skull-in-the-box	0		
 443	ghostly beer lens	0		
-444	blurry squat beer goggles	0		
+444	squat blurry beer goggles	0		
 445	wizardly box-in-the-box	0		Mysticality: +25
 446	narrow nothing-in-the-box-in-the-box	0		
 447	huge foul-smelling box-in-the-box-in-the-box	0		Stench Damage: +10
@@ -450,13 +450,13 @@
 452	cyan disease	0		
 453	ghostly sober pill	0		
 454	screwdriver	0		
-455	spoiled half-sized red jumbo olive	2	crappy	
-456	bad irresponsibly strong dry martini	10	decent	
+455	half-sized spoiled red jumbo olive	2	crappy	
+456	irresponsibly strong bad dry martini	10	decent	
 457	chilly ye olde golde frontes	0		Cold Damage: +5, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	pixel	0		
 460	wobbly pixel	0		
-461	bouncing olive pixel	0		
+461	olive bouncing pixel	0		
 462	pixel	0		
 463	narrow pixel	0		
 464	pixel potion	0		
@@ -466,7 +466,7 @@
 468	blinking ruby W	0		
 469	pulsating wussiness potion	0		
 470	high-proof tolerable mirror Imp Ale	8	good	
-471	miniature rotten fancy hot wing	2	crappy	Effect: "Artificially Sweet", Effect Duration: 45
+471	miniature fancy rotten hot wing	2	crappy	Effect: "Artificially Sweet", Effect Duration: 45
 472	upside-down perfumed diamond-studded cane	0		Stench Resistance: +5, Class: "Disco Bandit"
 473	narrow coward's crutch	0		Monster Level: -20
 474	cast	0		
@@ -498,7 +498,7 @@
 500	narrow Elf Farm Raffle ticket	0		
 501	rotten Elfin shortbread	4	crappy	
 502	shaking pagoda plans	0		
-503	bland special blinking skewered cat appendix	3	decent	Effect: "Oleaginous Soles", Effect Duration: 30
+503	special bland blinking skewered cat appendix	3	decent	Effect: "Oleaginous Soles", Effect Duration: 30
 504	evil arches	0		
 505	rosy-cheeked gnatwing earring of the boozehound	0		Maximum HP Percent: +30, Booze Drop: +100
 506	low-calorie delicious gray Hell broth	1	awesome	
@@ -540,7 +540,7 @@
 542	aromatic dangerous 1337 7r0uZ0RZ	0		Weapon Damage: +10, Stench Resistance: +1, Familiar Effect: "2xPotato, cap 27"
 543	stale Trollhouse cookies	4	decent	
 544	family-friendly talons of extreme caution	0		Monster Level: -25, Sleaze Resistance: +1
-545	diet rotten spinning twirling Spam Witch sammich	1	crappy	
+545	rotten diet spinning twirling Spam Witch sammich	1	crappy	
 546	purple meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -565,26 +565,26 @@
 567	hermit script	0		
 568	toothsome small purple Double Bacon Beelzeburger	2	awesome	
 569	rotten Lord of the Flies-sized fries	3	crappy	
-570	special rotten Chicken Sandwich	4	crappy	Effect: "The Q Is Talking To You", Effect Duration: 50
+570	rotten special Chicken Sandwich	4	crappy	Effect: "The Q Is Talking To You", Effect Duration: 50
 571	Jumbo Dr. Lucifer	1	crappy	
 572	delicious Children's Meal of the Damned	3	awesome	
-573	yummy diet spinning red noodles	1	awesome	
+573	yummy diet red spinning noodles	1	awesome	
 574	snack-sized delicious upside-down noodles	2	awesome	
 575	decent painful penne pasta	3	good	
 576	spoiled ravioli della hippy	3	crappy	
 577	yummy mirror pr0n m4nic0tti	4	awesome	
-578	special delicious super-sized upside-down Hell ramen	5	awesome	Effect: "Metal Speed", Effect Duration: 25
-579	low-calorie decent enchanted shaking boring spaghetti	1	good	Effect: "Petit Forbearance", Effect Duration: 45
+578	super-sized delicious special upside-down Hell ramen	5	awesome	Effect: "Metal Speed", Effect Duration: 25
+579	decent enchanted low-calorie shaking boring spaghetti	1	good	Effect: "Petit Forbearance", Effect Duration: 45
 580	ghostly sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	cyan Himalayan Hidalgo sauce	0		
 583	huge toothsome blurry fettucini Inconnu	8	awesome	
 584	moldy gigantic ghostly spaghetti with Skullheads	6	crappy	
-585	jumbo bland gnocchetti di Nietzsche	5	decent	
+585	bland jumbo gnocchetti di Nietzsche	5	decent	
 586	tumbling frosty lion tamer's ridiculously huge sword	0		Experience (familiar): +2, Cold Spell Damage: +10
 587	corrupted energized blue super-spiky hair gel	0		Effect: "Macho Profundo", Effect Duration: 65
 588	soft echo eyedrop antidote	0		
-589	snack-sized normal cocoa eggshell fragment	2	good	
+589	normal snack-sized cocoa eggshell fragment	2	good	
 590	delicious cocoa eggshell fragment	4	awesome	
 591	cocoa egg	0		
 592	house	0		
@@ -611,7 +611,7 @@
 613	plot hole	0		
 614	flattened wobbly probability potion	0		Effect: "It's Soporiffic!", Effect Duration: 68
 615	fuchsia blurry chaos butterfly	0		
-616	jittery narrow furry fur	0		
+616	narrow jittery furry fur	0		
 617	triple-irradiated triple-frozen irradiated pulsating yellow Angry Farmer candy	0		Effect: "Oleaginous Soles", Effect Duration: 33
 618	boiled activated altered squat Mick's IcyVapoHotness Rub	0		Effect: "Graham Crackling", Effect Duration: 40
 619	squat nasty needle	0		Stench Damage: +5
@@ -625,7 +625,7 @@
 627	huge ND	0		
 628	metallic A	0		
 629	eye of wisdom	0		Mysticality: +15
-630	twirling olive photoprotoneutron torpedo	0		
+630	olive twirling photoprotoneutron torpedo	0		
 631	jittery Fonzie's furry pants	0		Experience (Moxie): +1, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
 632	brawny disturbing fanfic	0		Muscle Percent: +20
 633	knitted stylish wolf mask	0		Moxie: +25, Cold Resistance: +3, Familiar Effect: "1xBarrr, HP regen, cap 37"
@@ -658,7 +658,7 @@
 660	groovy star pants	0		Moxie Percent: +10, Familiar Effect: "1xPotato, 2xGhuol, cap 41"
 661	shaking energetic star hat	0		Maximum MP Percent: +20, Familiar Effect: "0.5xVolley, 0.5xPotato, cap 41"
 662	stiffened star buckler	0		Damage Reduction: 11
-663	bouncing blue narrow star throwing star	0		
+663	blue bouncing narrow star throwing star	0		
 664	star starfish	0		
 665	bouncing wobbly Richard's star key	0		
 666	blue shaking Newton's sage steaming evil of mayonnaise	0		Mysticality Percent: +10, Experience (Mysticality): +3, Sleaze Spell Damage: +50
@@ -667,19 +667,19 @@
 669	low-calorie tasty ghuol guolash	1	awesome	
 670	purple careful lihc face	0		Monster Level: -10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	zippy manspreader's grave robbing shovel	0		Monster Level: +10, Initiative: +20
-672	thick adequate cranberries	5	good	
+672	adequate thick cranberries	5	good	
 673	bad extra-dry skewed shaking vodka and cranberry	5	decent	
-674	special tolerable whiskey	4	good	Effect: "Pill Power", Effect Duration: 5
+674	tolerable special whiskey	4	good	Effect: "Pill Power", Effect Duration: 5
 675	olive curative skull of the Bonerdagon	0		HP Regen Min: 3, HP Regen Max: 5
 676	dragonbone belt buckle	0		
 677	pulsating badass belt of the businessman	0		Meat Drop: +50
 678	chest of the Bonerdagon	0		
 679	bad roll in the hay	3	decent	
 680	artisanal huge slap and tickle	4	EPIC	
-681	mediocre extra-dry spinning ghostly slip 'n' slide	5	decent	
+681	mediocre extra-dry ghostly spinning slip 'n' slide	5	decent	
 682	perfectly mixed a sump'm sump'm	4	EPIC	
 683	practically non-alcoholic aged horizontal tango	1	awesome	
-684	lousy fancy upside-down spinning pink pony	3	decent	Effect: "Net Tea", Effect Duration: 25
+684	lousy fancy spinning upside-down pink pony	3	decent	Effect: "Net Tea", Effect Duration: 25
 685	auspicious lion tamer's Tesla Mr. Shirt	0		Experience (familiar): +2, Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10
 686	knuckles of terror	0		Spooky Spell Damage: +10
 687	boiled blood of the Wereseal	0		Effect: "Super Speed", Effect Duration: 12
@@ -717,7 +717,7 @@
 721	shellacked boxer's porquoise bracelet	0		Muscle Percent: +10, Damage Reduction: 7
 722	squat narrow chaotic hale smooth porquoise ring	0		Moxie: +15, Maximum HP: +20, Spell Critical Percent: +10, Single Equip
 723	decent thick Knoll mushroom	5	good	
-724	tiny spoiled mushroom	1	crappy	
+724	spoiled tiny mushroom	1	crappy	
 725	jittery one million meat pancakes	0		
 726	fortified huge mirror shard	0		Damage Absorption: +60
 727	upside-down hedge maze puzzle	0		
@@ -742,21 +742,21 @@
 747	Knob Goblin firecracker	0		
 748	bouncing gourd potion	0		
 749	stale warm mushroom	3	decent	
-750	moldy huge mushroom quesadilla	6	crappy	
+750	huge moldy mushroom quesadilla	6	crappy	
 751	spoiled spinning cool mushroom	3	crappy	
 752	big adequate cool mushroom casserole	5	good	
-753	miniature adequate squat pointy mushroom	2	good	
+753	adequate miniature squat pointy mushroom	2	good	
 754	adequate cream of pointy mushroom soup	3	good	
-755	normal immense mushroom	7	good	
+755	immense normal mushroom	7	good	
 756	diet stale mushroom	1	decent	
 757	bland mushroom	4	decent	
 758	flavorless low-calorie huge ghost cucumber	1	decent	
 759	gray dill	0		
 760	blinking vinegar	0		
 761	red brine	0		
-762	weak aged especially salty dog	2	awesome	
+762	aged weak especially salty dog	2	awesome	
 763	ghostly pickling solution	0		
-764	stale snack-sized spectral pickle	2	decent	
+764	snack-sized stale spectral pickle	2	decent	
 765	briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	liquefied double-unsweetened twirling cologne of contempt	0		Effect: "Stinky Weapon", Effect Duration: 34
@@ -778,10 +778,10 @@
 783	'Villa' document	0		
 784	lousy Acqua Del Piatto Merlot	4	decent	Last Available: "2004-10"
 785	raffle ticket	0		
-786	flavorless tiny strawberry	1	decent	
-787	perfectly mixed boozy narrow blurry bottle of rum	5	EPIC	
+786	tiny flavorless strawberry	1	decent	
+787	boozy perfectly mixed blurry narrow bottle of rum	5	EPIC	
 788	hand-crafted strawberry daiquiri	3	EPIC	
-789	enchanted artisanal rum and cola	3	EPIC	Effect: "Radiant Personality", Effect Duration: 30
+789	artisanal enchanted rum and cola	3	EPIC	Effect: "Radiant Personality", Effect Duration: 30
 790	drinkable grog	3	good	
 791	Rosewater's Mafia bow tie of Tarzan	0		Mysticality Percent: +30, Experience (Muscle): +3, Last Available: "2004-10"
 792	Golden Mr. Accessory of Tarzan	0		Experience (Muscle): +3, Softcore Only
@@ -790,20 +790,20 @@
 795	acceptable blinking Acque Luride Grezze Cabernet	4	good	Last Available: "2004-10"
 796	squat avaricious flame-retardant arcane researcher's cement shoes	0		Experience Percent (Mysticality): +10, Hot Resistance: +1, Meat Drop: +30, Last Available: "2004-10"
 797	drinkable huge rockin' wagon	3	good	
-798	special smooth ocean motion	3	awesome	Effect: "Uncucumbered", Effect Duration: 25
-799	special lousy practically non-alcoholic twirling fuzzbump	1	decent	Effect: "Winning Smile", Effect Duration: 25
-800	adequate snack-sized poutine	2	good	
+798	smooth special ocean motion	3	awesome	Effect: "Uncucumbered", Effect Duration: 25
+799	practically non-alcoholic lousy special twirling fuzzbump	1	decent	Effect: "Winning Smile", Effect Duration: 25
+800	snack-sized adequate poutine	2	good	
 801	moldy huge Knob stir-fry	7	crappy	
 804	moldy Knoll stir-fry	3	crappy	
 805	moldy small stir-fry	2	crappy	
 806	bland asparagus stir-fry	4	decent	
 807	delicious olive stir-fry	3	awesome	
-808	moldy gigantic special Knob sausage stir-fry	9	crappy	Effect: "Shredding, Sweating", Effect Duration: 50
-809	bland super-sized bat wing stir-fry	5	decent	
+808	moldy special gigantic Knob sausage stir-fry	9	crappy	Effect: "Shredding, Sweating", Effect Duration: 50
+809	super-sized bland bat wing stir-fry	5	decent	
 810	normal half-sized gray rat appendix stir-fry	2	good	
 811	spoiled tofu stir-fry	3	crappy	
-812	adequate gigantic upside-down pr0n stir-fry	8	good	
-813	immense decent Knob shells	8	good	
+812	gigantic adequate upside-down pr0n stir-fry	8	good	
+813	decent immense Knob shells	8	good	
 814	flavorless spinning b&auml;tzle	3	decent	
 815	stale ratini	3	decent	
 816	normal fancy Knob stroganoff	3	good	Effect: "Yes, Can Haz", Effect Duration: 50
@@ -817,10 +817,10 @@
 824	narrow effervescent potion	0		
 825	narrow fizzy potion	0		
 826	lime green dark potion	0		
-827	bouncing lime green murky potion	0		
+827	lime green bouncing murky potion	0		
 828	baby killer bee	0		
 829	tumbling anti-anti-antidote	0		
-830	big rotten royal jelly	5	crappy	
+830	rotten big royal jelly	5	crappy	
 831	small box	0		
 832	mirror box	0		
 833	blurry vorpal blade of temperance	0		Sleaze Resistance: +5
@@ -829,12 +829,12 @@
 836	special huge stale mind flayer corpse	8	decent	Effect: "Turtle Power", Effect Duration: 15
 837	delicious tumbling Uovo Marcio Shiraz	3	awesome	Last Available: "2004-10"
 838	purple hale Mafia stogie of the brazier	0		Maximum HP: +20, Hot Spell Damage: +25, Last Available: "2004-10"
-839	irresponsibly strong fancy perfectly mixed lime green Maiali Sifilitici Pinot Noir	6	EPIC	Effect: "Egged On", Effect Duration: 5, Last Available: "2004-10"
+839	fancy irresponsibly strong perfectly mixed lime green Maiali Sifilitici Pinot Noir	6	EPIC	Effect: "Egged On", Effect Duration: 5, Last Available: "2004-10"
 840	studded Mafia violin case of the overflowing toilet	0		Damage Absorption: +80, Stench Spell Damage: +50, Last Available: "2004-10"
 841	tolerable triple-distilled green tomato daiquiri	8	good	
 842	weak hand-crafted beertini	2	EPIC	
 843	lousy high-proof salty slug	9	decent	
-844	tolerable irresponsibly strong papaya slung	6	good	
+844	irresponsibly strong tolerable papaya slung	6	good	
 845	occult MAHI fez	0		Spell Damage Percent: +25, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	skewed pulsating heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -894,14 +894,14 @@
 903	aged Spasmi Dolorosi Del Rene Champagne	3	awesome	Last Available: "2004-10"
 904	Jim Carey's smooth school Mafia knickerbockers of the brute	0		Moxie: +15, Muscle Percent: +30, Monster Level: +25, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	ionized blinking Yummy Tummy bean	0		Effect: "Pride of the Vampire", Effect Duration: 48
-906	flattened ghostly pulsating Rock Pops	0		Effect: "Bilious Brawn", Effect Duration: 12
+906	flattened pulsating ghostly Rock Pops	0		Effect: "Bilious Brawn", Effect Duration: 12
 907	flattened gray Mr. Mediocrebar	0		Effect: "Deadly Lampblade", Effect Duration: 12
 908	super-Vulcanized Cold Hots candy	0		Effect: "Super Skill", Effect Duration: 14
 909	flattened Wint-O-Fresh mint	0		Effect: "Memento Moir&eacute;", Effect Duration: 46
 910	adequate huge skewed dwarf bread	8	good	
 911	diffused quadruple-enhanced Senior Mints	0		Effect: "Arcane in the Brain", Effect Duration: 18
 912	activated pixellated candy heart	0		Effect: "Eldritch Concentration", Effect Duration: 62
-913	corrupted adjusted alkaline cyan mirror shaking kobold	0		Effect: "Grumpy and Ornery", Effect Duration: 25
+913	corrupted adjusted alkaline mirror cyan shaking kobold	0		Effect: "Grumpy and Ornery", Effect Duration: 25
 914	twirling hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	chilly friendly intergalactic pom poms	0		Familiar Weight: +3, Cold Damage: +5
@@ -909,7 +909,7 @@
 918	banded Radio Free Baseball Cap	0		Damage Absorption: +100, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	lime green coward's Radio Free Pants	0		Monster Level: -20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	green skewed Radio Free Foil of the sweet-tooth	0		Candy Drop: +100, Last Available: "2006-07"
-921	fancy delicious radio button candy	3	awesome	Effect: "Weird Vibrations", Effect Duration: 45
+921	delicious fancy radio button candy	3	awesome	Effect: "Weird Vibrations", Effect Duration: 45
 922	greasy severed rocking horse head	0		Sleaze Spell Damage: +10
 923	huge broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
@@ -936,15 +936,15 @@
 946	skewed skewered lime	0		Last Available: "2004-12"
 947	purple skewered cherry	0		Last Available: "2004-12"
 948	perfectly mixed martini	3	super ultra EPIC	Last Available: "2004-12"
-949	practically non-alcoholic special aged grogtini	1	awesome	Effect: "Dancing Prowess", Effect Duration: 40, Last Available: "2004-12"
+949	aged practically non-alcoholic special grogtini	1	awesome	Effect: "Dancing Prowess", Effect Duration: 40, Last Available: "2004-12"
 950	bad cherry bomb	3	decent	Last Available: "2004-12"
 951	wobbly extra special Crimbo stocking	0		Last Available: "2004-12"
 952	Temple Grandin's Fonzie's hockey mask	0		Experience (Moxie): +1, Familiar Weight: +7, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
-953	spinning green penguin-smacking club	0		Familiar Damage: +15
+953	green spinning penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	fez of etymology of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1xLep, cap 30"
 956	flavorless carob chunk noodles	3	decent	
-957	rotten half-sized blinking jittery chorizo brownies	2	crappy	
+957	half-sized rotten blinking jittery chorizo brownies	2	crappy	
 958	flavorless chocolate and tomato pizza	3	decent	
 959	flange	0		
 960	clockwork key	0		
@@ -990,7 +990,7 @@
 1003	soda water	0		
 1004	high-proof artisanal enchanted bottle of tequila	6	EPIC	Effect: "Anytwo Five Elevenis?", Effect Duration: 30
 1005	drinkable teal boxed wine	3	good	
-1006	snack-sized toothsome cherry	2	awesome	
+1006	toothsome snack-sized cherry	2	awesome	
 1007	huge lard-coated coconut shell	0		Sleaze Spell Damage: +25, Familiar Effect: "1xFairy, cap 7"
 1008	dangerous ice cubes	0		Weapon Damage: +10
 1009	drinkable irresponsibly strong vodka martini	10	good	
@@ -1009,7 +1009,7 @@
 1022	delicious sangria	4	awesome	
 1023	watered-down perfectly mixed vesper	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1024	delicious bodyslam	3	awesome	Last Available: "2004-12"
-1025	bad extra-dry sangria del diablo	5	decent	Last Available: "2004-12"
+1025	extra-dry bad sangria del diablo	5	decent	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	huge whip kit	0		
 1028	jittery buckler buckle	0		
@@ -1030,19 +1030,19 @@
 1044	purple steel-toed string of beads	0		Damage Reduction: 9
 1045	gravedigger's plastic bottle opener	0		Spooky Damage: +10
 1046	Newton's traffic cone of wisdom	0		Mysticality: +15, Experience (Mysticality): +3, Last Available: "2005-03", Familiar Effect: "cap 15"
-1047	drinkable weak yellow N. O. Beer	2	good	
+1047	weak drinkable yellow N. O. Beer	2	good	
 1048	dried oyster egg	1		Effect: "Liquidy Smoky", Effect Duration: 50
 1049	dehydrated wobbly oyster egg	1		
 1050	dried maroon oyster egg	1		
 1051	plastic oyster egg	0		
 1052	twisted teal oyster egg	1		Effect: "Bugbear in Tooth and Claw", Effect Duration: 10
-1053	modified mirror blinking oyster egg	1		Effect: "No Vertigo", Effect Duration: 25
+1053	modified blinking mirror oyster egg	1		Effect: "No Vertigo", Effect Duration: 25
 1054	altered blurry wobbly oyster egg	1		
 1055	plastic oyster egg	0		
 1056	dried jittery puce oyster egg	1		
 1057	denatured shaking puce oyster egg	1		
 1058	dried wobbly cyan puce oyster egg	1		Effect: "In the Limelight", Effect Duration: 40
-1059	green wobbly puce plastic oyster egg	0		
+1059	wobbly green puce plastic oyster egg	0		
 1060	denatured mauve oyster egg	1		
 1061	modified ghostly mauve oyster egg	1		Effect: "It's Electric!", Effect Duration: 30
 1062	modified mauve oyster egg	1		
@@ -1051,7 +1051,7 @@
 1065	denatured oyster egg	1		
 1066	distilled oyster egg	1		
 1067	plastic oyster egg	0		
-1068	modified ghostly olive blurry oyster egg	1		
+1068	modified blurry ghostly olive oyster egg	1		
 1069	modified squat oyster egg	1		
 1070	denatured oyster egg	1		
 1071	cyan plastic oyster egg	0		
@@ -1061,19 +1061,19 @@
 1075	off-white plastic oyster egg	0		
 1076	mixed green oyster egg	1		
 1077	powdered oyster egg	1		
-1078	dehydrated lime green shaking oyster egg	1		
+1078	dehydrated shaking lime green oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
 1081	mirror emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
-1085	spinning blurry blinking clockwork widget	0		
+1085	blurry spinning blinking clockwork widget	0		
 1086	clockwork thingamajig	0		
 1087	clockwork doohickey	0		
 1088	skewed skewed clockwork clockwise dome	0		
 1089	clockwork spine	0		
-1090	shaking huge clockwork rings	0		
+1090	huge shaking clockwork rings	0		
 1091	clockwork claws	0		
 1092	clockwork sheet	0		
 1093	clockwork counterclockwise dome	0		
@@ -1122,25 +1122,25 @@
 1136	altered quantum lipstick	0		Effect: "Fangs and Pangs", Effect Duration: 34
 1137	nasty bicycle chain of James Dean	0		Experience (Moxie): +3, Stench Damage: +5
 1138	upside-down mushroom fermenting solution	0		
-1139	watered-down drinkable mushroom wine	2	good	
-1140	practically non-alcoholic artisanal icy mushroom wine	1	super ultra mega turbo EPIC	
+1139	drinkable watered-down mushroom wine	2	good	
+1140	artisanal practically non-alcoholic icy mushroom wine	1	super ultra mega turbo EPIC	
 1141	lousy mushroom wine	4	decent	
 1142	artisanal pointy mushroom wine	4	EPIC	
-1143	special high-proof bad flat mushroom wine	7	decent	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30
-1144	special distilled drinkable cool mushroom wine	5	good	Effect: "Feroci Tea", Effect Duration: 45
+1143	bad high-proof special flat mushroom wine	7	decent	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30
+1144	special drinkable distilled cool mushroom wine	5	good	Effect: "Feroci Tea", Effect Duration: 45
 1145	hand-crafted weak knob mushroom wine	2	EPIC	
-1146	practically non-alcoholic aged knoll mushroom wine	1	awesome	
+1146	aged practically non-alcoholic knoll mushroom wine	1	awesome	
 1147	artisanal mushroom wine	4	EPIC	
 1148	tolerable lime green shot of flower schnapps	4	good	
-1149	normal miniature flower petal pie	2	good	
+1149	miniature normal flower petal pie	2	good	
 1150	drinkable green bottle of single-barrel whiskey	4	good	
 1151	chilly boxer's discarded plastic fork	0		Muscle Percent: +10, Cold Damage: +5
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	tasty Retenez L'Herbe Pat&eacute;	4	awesome	
-1154	dehydrated shaking blue Breathetastic&trade; Premium Canned Air	1	good	Effect: "Coming Up Roses", Effect Duration: 10
+1154	dehydrated blue shaking Breathetastic&trade; Premium Canned Air	1	good	Effect: "Coming Up Roses", Effect Duration: 10
 1155	letter from King Ralph XI	0		
 1157	censurious wholeberd	0		Sleaze Resistance: +3
-1158	galvanized modified twirling bouncing fuchsia Meleegra&trade; pills	0		Effect: "Norwhalloped", Effect Duration: 55
+1158	galvanized modified bouncing fuchsia twirling Meleegra&trade; pills	0		Effect: "Norwhalloped", Effect Duration: 55
 1159	mariachi G-string	0		
 1160	energetic irate sombrero	0		Maximum MP Percent: +20, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
@@ -1167,7 +1167,7 @@
 1182	Venus flytrap	0		
 1183	twirling all-purpose flower	0		
 1184	exotic orchid	0		
-1185	ghostly olive long-stemmed rose	0		
+1185	olive ghostly long-stemmed rose	0		
 1186	gilded lily	0		
 1187	deadly nightshade	0		
 1188	lotus	0		
@@ -1182,20 +1182,20 @@
 1197	ghostly Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
-1200	miniature normal mugcake	2	good	
+1200	normal miniature mugcake	2	good	
 1201	moldy urinal cake	3	crappy	
-1202	diet toothsome spinning Happy Birthday, Claude! cake	1	awesome	
-1203	stale snack-sized personalized birthday cake	2	decent	
+1202	toothsome diet spinning Happy Birthday, Claude! cake	1	awesome	
+1203	snack-sized stale personalized birthday cake	2	decent	
 1204	fancy moldy three-tiered wedding cake	3	crappy	Effect: "Well-Oiled", Effect Duration: 40
 1205	bland babycakes	4	decent	
 1206	flavorless velvet cake	4	decent	
 1207	adequate half-sized congratulatory cake	2	good	
 1208	adequate narrow gray angel-food cake	3	good	
 1209	adequate squat devil's-food cake	4	good	
-1210	moldy half-sized birthday party jellybean cheesecake	2	crappy	
+1210	half-sized moldy birthday party jellybean cheesecake	2	crappy	
 1211	balloon	0		
 1212	balloon	0		
-1213	blinking teal heart-shaped balloon	0		
+1213	teal blinking heart-shaped balloon	0		
 1214	yellow anniversary balloon	0		
 1215	Mylar balloon	0		
 1216	Kevlar balloon	0		
@@ -1232,13 +1232,13 @@
 1248	huge educational Bonerdagon necklace of the blizzard of temperance	0		Experience: +1, Cold Spell Damage: +25, Sleaze Resistance: +5
 1249	Boss Bat britches of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	family-friendly slick Boss Bat bling	0		Moxie: +10, Sleaze Resistance: +1
-1251	immense flavorless Knob shroomkabob	10	decent	
+1251	flavorless immense Knob shroomkabob	10	decent	
 1252	moldy lime green shroomkabob	4	crappy	
 1253	purple pile of jumping beans	0		
 1254	toothsome jumping bean burrito	3	awesome	
 1255	massive spoiled jumping bean burrito	9	crappy	
 1256	decent insanely jumping bean burrito	3	good	
-1257	adequate big upside-down rat scrapple	5	good	
+1257	big adequate upside-down rat scrapple	5	good	
 1258	cyan pail of pretentious paint	0		
 1259	Oprah's brawny traffic cone	0		Muscle Percent: +20, Maximum MP Percent: +50, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
@@ -1248,7 +1248,7 @@
 1264	nose-bone fetish	0		Last Available: "2011-12"
 1265	shaking box of sunshine	0		Free Pull
 1266	decent immense gray gloomy mushroom	10	good	
-1267	ghostly bouncing dead mimic	0		
+1267	bouncing ghostly dead mimic	0		
 1268	pine wand	0		
 1269	ebony wand	0		
 1270	hexagonal wand	0		
@@ -1271,7 +1271,7 @@
 1287	narrow tumbling furry kilt of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 1288	Sherlock's gnauga hide skirt	0		Item Drop: +25, Familiar Effect: "2.5xFairy, cap 20"
 1289	maroon gnauga hide kilt	0		Item Drop: +5, Familiar Effect: "2.5xFairy, cap 20"
-1290	ionized galvanized cyan jittery wind-up clock	0		Effect: "A Few Extra Pounds", Effect Duration: 40
+1290	ionized galvanized jittery cyan wind-up clock	0		Effect: "A Few Extra Pounds", Effect Duration: 40
 1291	green executive Jekyllin hide belt	0		Meat Drop: +40, Softcore Only, Last Available: "2005-09"
 1292	skirt / kilt kit	0		
 1293	ring of adornment of the pedagogue	0		Experience: +3
@@ -1301,7 +1301,7 @@
 1317	blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	normal snack-sized questionable taco	2	good	
+1320	snack-sized normal questionable taco	2	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	gray petrified time	0		Last Available: "2005-10"
 1323	time helmet of the scaredy-cat	0		Monster Level: -15, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
@@ -1325,7 +1325,7 @@
 1342	ghostly picture of a dead guy's girlfriend	0		
 1343	zombie pineal gland	0		Last Available: "2005-11"
 1344	double-dry Gummi-Gnauga	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 17
-1345	modified wet twirling spinning Now and Earlier	0		Effect: "Loco Motives", Effect Duration: 53, Last Available: "2020-09"
+1345	modified wet spinning twirling Now and Earlier	0		Effect: "Loco Motives", Effect Duration: 53, Last Available: "2020-09"
 1346	vacuum-sealed colloidal Sugar Cog	0		Effect: "You're High as a Crow, Marty", Effect Duration: 68
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	green empty blowgun	0		Last Available: "2005-11"
@@ -1347,8 +1347,8 @@
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	flavorless diet enchanted spinning tofurkey leg	1	decent	Effect: "Cancer Rising", Effect Duration: 50
 1366	stale tofurkey gravy	4	decent	
-1367	fancy flavorless half-sized herbal stuffing	2	decent	Effect: "Extra-Wet", Effect Duration: 40
-1368	snack-sized decent can-shaped gelatinous cranberry sauce	2	good	
+1367	half-sized flavorless fancy herbal stuffing	2	decent	Effect: "Extra-Wet", Effect Duration: 40
+1368	decent snack-sized can-shaped gelatinous cranberry sauce	2	good	
 1369	massive delicious upside-down yams	7	awesome	
 1370	greasy rhinestone cowboy shirt	0		Sleaze Spell Damage: +10
 1371	perfumed gingham blouse	0		Stench Resistance: +5
@@ -1369,9 +1369,9 @@
 1387	block	0		
 1388	toy wheel	0		
 1389	yo-yo	0		Last Available: "2010-12"
-1390	huge gray top	0		Last Available: "2010-12"
+1390	gray huge top	0		Last Available: "2010-12"
 1391	ball	0		Last Available: "2010-12"
-1392	jittery tumbling kite	0		Last Available: "2005-12"
+1392	tumbling jittery kite	0		Last Available: "2005-12"
 1393	mirror pet rock	0		Last Available: "2005-12"
 1394	huge doppelshifter	0		Last Available: "2005-12"
 1395	teddy bear	0		Last Available: "2005-12"
@@ -1389,8 +1389,8 @@
 1407	spoiled small blurry bell-shaped Crimbo cookie	2	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	decent miniature tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	wizardly Unionize The Elves sign	0		Mysticality: +25, Last Available: "2005-12"
-1410	blurry huge sleeping snowy owl	0		Last Available: "2005-12"
-1411	maroon wobbly Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1410	huge blurry sleeping snowy owl	0		Last Available: "2005-12"
+1411	maroon wobbly Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	chilled spinning snowcone	0		Effect: "Egg-stortionary Tactics", Effect Duration: 50, Last Available: "2006-01"
 1413	alkaline cyan snowcone	0		Effect: "Hustlin'", Effect Duration: 53, Last Available: "2006-01"
 1414	double-pickled extra-boiled quadruple-flattened skewed jittery snowcone	0		Effect: "Nightstalkin'", Effect Duration: 65, Last Available: "2006-01"
@@ -1407,11 +1407,11 @@
 1425	hardy ice baby	0		Maximum HP: +50, Softcore Only, Last Available: "2006-02"
 1426	skewed shaking ice pick	0		Item Drop: +5, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	spinning horrifying Van der Graaf ice skates	0		Spooky Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	bland tiny grue egg omelette	1	decent	
+1428	tiny bland grue egg omelette	1	decent	
 1429	teal roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	bouncing pregnant mushroom	0		
-1432	small flavorless mushroom	2	decent	
+1432	flavorless small mushroom	2	decent	
 1433	mirror olive fruit bowl	0		
 1434	skewed fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1425,7 +1425,7 @@
 1443	enhanced galvanized sleaze powder	0		Effect: "Top Dog", Effect Duration: 64
 1444	quadruple-ionized galvanized modified twinkly nuggets	0		Effect: "Broken Bone Nubs", Effect Duration: 13
 1445	liquefied yellow hot nuggets	0		Effect: "Overstimulated", Effect Duration: 29
-1446	altered unsweetened mirror pulsating nuggets	0		Effect: "Black Eyes", Effect Duration: 17
+1446	altered unsweetened pulsating mirror nuggets	0		Effect: "Black Eyes", Effect Duration: 17
 1447	nitrogenated fuchsia nuggets	0		Effect: "Slime Time", Effect Duration: 56
 1448	activated ionized stench nuggets	0		Effect: "Some Cheese with Your Wine", Effect Duration: 26
 1449	double-polarized sleaze nuggets	0		Effect: "Innately Truthy", Effect Duration: 45
@@ -1441,7 +1441,7 @@
 1459	wobbly arrow'd heart balloon	0		
 1460	cyan velvet box	0		
 1461	squashed frog	0		
-1462	ghostly ghostly twirling eye of newt	0		
+1462	twirling ghostly ghostly eye of newt	0		
 1463	olive salamander spleen	0		
 1464	sleazy fairy gravy	0		
 1465	suede shortsword	0		
@@ -1477,7 +1477,7 @@
 1495	ghostly upside-down aromatic traffic cone of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	smooth gloomy mushroom wine	3	awesome	
 1497	bad mushroom wine	4	decent	
-1498	spinning McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	spinning McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	squat huge whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	Vulcanized shaking explosion-flavored chewing gum	0		Effect: "Radium Radicality", Effect Duration: 64, Last Available: "2006-04"
@@ -1489,7 +1489,7 @@
 1507	acceptable rockin' wagon with a fly in it	3	good	Last Available: "2006-04"
 1508	smooth huge perpendicular hula with a fly in it	3	awesome	Last Available: "2006-04"
 1509	practically non-alcoholic perfectly mixed slap and tickle with a fly in it	1	EPIC	Last Available: "2006-04"
-1510	upside-down tumbling bag of airline peanuts	0		Last Available: "2006-04"
+1510	tumbling upside-down bag of airline peanuts	0		Last Available: "2006-04"
 1511	savvy fake hand	0		Mysticality Percent: +20, Last Available: "2006-04"
 1512	dried wobbly Knob Goblin pet-buffing spray	1		
 1513	altered pulsating Knob Goblin learning pill	1		
@@ -1503,8 +1503,8 @@
 1522	narrow wizardly Radio Free Jersey of the glutton	0		Mysticality: +25, Food Drop: +100
 1523	lime green bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	blinking wobbly joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	tumbling pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	wobbly blinking joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	tumbling pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	gray smelly energetic corkscrew	0		Maximum MP Percent: +20, Stench Spell Damage: +10, Last Available: "2006-04"
 1529	jittery St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
@@ -1533,54 +1533,54 @@
 1553	hand-crafted bottle of Calcutta Emerald	3	EPIC	
 1554	delicious bottle of Lieutenant Freeman	4	awesome	
 1555	artisanal bottle of Jorge Sinsonte	3	EPIC	
-1556	mediocre practically non-alcoholic blinking boxed champagne	1	decent	
+1556	practically non-alcoholic mediocre blinking boxed champagne	1	decent	
 1557	rotten mirror squat kumquat	3	crappy	
 1558	snack-sized yummy huge tangerine	2	awesome	
-1559	spinning mirror mirror tonic water	0		
-1560	moldy teal mirror cocktail onion	4	crappy	
-1561	decent twirling teal raspberry	3	good	
+1559	mirror mirror spinning tonic water	0		
+1560	moldy mirror teal cocktail onion	4	crappy	
+1561	decent teal twirling raspberry	3	good	
 1562	flavorless kiwi	3	decent	
 1563	artisanal whiskey bittersweet	3	EPIC	
 1564	acceptable blurry mimosette	4	good	
 1565	acceptable enchanted spinning blinking tequila sunset	3	good	Effect: "You Can Taste the Darkness", Effect Duration: 45
 1566	mediocre zmobie	4	decent	Wiki Name: "Zmobie (drink)"
 1567	lousy gin and tonic	4	decent	
-1568	tolerable high-proof vodka and tonic	6	good	
-1569	acceptable practically non-alcoholic special wobbly vodka gibson	1	good	Effect: "Surreally Buff", Effect Duration: 10
+1568	high-proof tolerable vodka and tonic	6	good	
+1569	special acceptable practically non-alcoholic wobbly vodka gibson	1	good	Effect: "Surreally Buff", Effect Duration: 10
 1570	hand-crafted practically non-alcoholic jittery gibson	1	super EPIC	
-1571	lousy extra-dry parisian cathouse	5	decent	
-1572	high-proof lousy rabbit punch	10	decent	
-1573	mediocre jittery bouncing caipifruta	3	decent	
+1571	extra-dry lousy parisian cathouse	5	decent	
+1572	lousy high-proof rabbit punch	10	decent	
+1573	mediocre bouncing jittery caipifruta	3	decent	
 1574	bad teqiwila	4	decent	
 1575	artisanal Divine	3	EPIC	
 1576	aged high-proof tumbling Gordon Bennett	8	awesome	
-1577	hand-crafted extra-dry ghostly tangarita	5	EPIC	
+1577	extra-dry hand-crafted ghostly tangarita	5	EPIC	
 1578	bad mandarina colada	3	decent	
 1579	acceptable watered-down gimlet	2	good	
-1580	extra-dry acceptable brick road	5	good	
+1580	acceptable extra-dry brick road	5	good	
 1581	smooth practically non-alcoholic vodka stratocaster	1	awesome	
-1582	acceptable weak Neuromancer	2	good	
+1582	weak acceptable Neuromancer	2	good	
 1583	perfectly mixed watered-down prussian cathouse	2	super ultra EPIC	
 1584	acceptable spinning Mae West	4	good	
 1585	practically non-alcoholic artisanal mirror Mon Tiki	1	super ultra mega turbo EPIC	
 1586	bad ghostly teqiwila slammer	3	decent	
 1587	stale Knob lo mein	4	decent	
-1588	decent jumbo fancy asparagus lo mein	5	good	Effect: "Slimily Speedy", Effect Duration: 10
+1588	fancy jumbo decent asparagus lo mein	5	good	Effect: "Slimily Speedy", Effect Duration: 10
 1589	spoiled Knoll lo mein	4	crappy	
 1590	diet yummy lo mein	1	awesome	
-1591	snack-sized adequate olive lo mein	2	good	
-1592	moldy half-sized hot hi mein	2	crappy	
+1591	adequate snack-sized olive lo mein	2	good	
+1592	half-sized moldy hot hi mein	2	crappy	
 1593	delicious hi mein	3	awesome	
-1594	spoiled half-sized hi mein	2	crappy	
+1594	half-sized spoiled hi mein	2	crappy	
 1595	bite-sized toothsome olive hi mein	1	awesome	
 1596	moldy small narrow sleazy hi mein	2	crappy	
 1597	twirling Junior LAAAAME merit badge	0		Item Drop: +5, Last Available: "2006-05"
 1598	lightning-fast Senior LAAAAME merit badge	0		Initiative: +40, Last Available: "2006-05"
-1599	upside-down mirror jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	special delicious triple-distilled tangarita with a fly in it	10	awesome	Effect: "Tapped In", Effect Duration: 5
-1601	weak aged mandarina colada with a fly in it	2	awesome	
-1602	tolerable watered-down prussian cathouse with a fly in it	2	good	
-1603	extra-dry hand-crafted Mae West with a fly in it	5	EPIC	
+1599	mirror upside-down jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
+1600	triple-distilled special delicious tangarita with a fly in it	10	awesome	Effect: "Tapped In", Effect Duration: 5
+1601	aged weak mandarina colada with a fly in it	2	awesome	
+1602	watered-down tolerable prussian cathouse with a fly in it	2	good	
+1603	hand-crafted extra-dry Mae West with a fly in it	5	EPIC	
 1604	mixed shaking astronaut ice-cream	1		Effect: "stats.enq", Effect Duration: 30, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	modified ultimate wad	1		
@@ -1614,13 +1614,13 @@
 1634	perfectly mixed watered-down around the world	2	EPIC	
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
-1637	enhanced flattened non-cold-filtered twirling gray jittery lotion of hotness	0		Effect: "Nothing Is Impossible", Effect Duration: 29
+1637	enhanced flattened non-cold-filtered gray twirling jittery lotion of hotness	0		Effect: "Nothing Is Impossible", Effect Duration: 29
 1638	electrified super-dry purple lotion of coldness	0		Effect: "Familial Ties", Effect Duration: 57
 1639	super-boiled enhanced teal lotion of spookiness	0		Effect: "Pride of the Vampire", Effect Duration: 65
 1640	frozen twirling cyan lotion of stench	0		Effect: "Enraged", Effect Duration: 15
 1641	nitrogenated polarized liquefied lotion of sleaziness	0		Effect: "Yuletide Industry", Effect Duration: 62
-1642	bad watered-down Grimacite Bock	2	decent	Last Available: "2008-11"
-1643	snack-sized yummy wedge of gray cheese	2	awesome	Last Available: "2008-11"
+1642	watered-down bad Grimacite Bock	2	decent	Last Available: "2008-11"
+1643	yummy snack-sized wedge of gray cheese	2	awesome	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	skewed and sauce	0		
 1646	and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	flavorless red spinning foie gras	4	decent	
 1652	energized tarnished bouncing candy brain	0		Effect: "Think Win-Lose", Effect Duration: 50, Last Available: "2020-09"
-1653	red perfumed sinister jewel-eyed wizard hat of wisdom	0		Mysticality: +15, Spell Damage: +10, Stench Resistance: +5, Softcore Only, Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	red perfumed sinister jewel-eyed wizard hat of wisdom	0		Mysticality: +15, Spell Damage: +10, Stench Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	prompt wad of Crovacite of the brute	0		Muscle Percent: +30, Adventures: +3
 1655	crafty collar of the empath	0		Maximum MP: +10, Familiar Weight: +5
 1656	fuchsia White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	yellow bubblewrap ore	0		
-1678	huge shaking pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	shaking huge pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	MacGyver's Newton's sword	0		Experience (Mysticality): +3, Maximum MP: +100
 1680	gray pulsating deadly staff	0		Weapon Damage: +5, Item Drop: +5
 1681	spinning knitted Herculean bubblewrap sword	0		Experience (Muscle): +1, Cold Resistance: +3
@@ -1670,7 +1670,7 @@
 1690	banded quilted discarded bottlecap	0		Damage Absorption: 140, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	razor-sharp discarded torn-up glove of the brazier	0		Weapon Damage Percent: +25, Hot Spell Damage: +25, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
 1692	polymerized corrupted energized salamander slurry	0		Effect: "No Vertigo", Effect Duration: 24
-1693	adjusted jittery wobbly eyedrops of newt	0		Effect: "Unusual Perspective", Effect Duration: 26
+1693	adjusted wobbly jittery eyedrops of newt	0		Effect: "Unusual Perspective", Effect Duration: 26
 1694	quadruple-modified Frogade	0		Effect: "Bolts about Candy", Effect Duration: 32
 1695	double-adjusted flattened papotion of papower	0		Effect: "Frostbeard", Effect Duration: 62
 1696	normal fuchsia royal jelly taco	4	good	
@@ -1745,12 +1745,12 @@
 1766	upside-down teal Spookyraven ballroom key	0		
 1767	shaking pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	miniature rotten shaking huge fricasseed brains	2	crappy	
-1770	toothsome diet mirror brains casserole	1	awesome	
+1769	miniature rotten huge shaking fricasseed brains	2	crappy	
+1770	diet toothsome mirror brains casserole	1	awesome	
 1771	spinning butcherknife of the early riser	0		Adventures: +7
 1772	greedy corn holder	0		Meat Drop: +20
 1773	bouncing vibrating eggbeater	0		Maximum MP Percent: +10
-1774	weak delicious bottle of popskull	2	awesome	
+1774	delicious weak bottle of popskull	2	awesome	
 1775	bouncing wicked dishrag	0		Spell Damage: +5
 1776	yummy stale baguette	3	awesome	
 1777	leftovers of indeterminate origin	0		
@@ -1791,7 +1791,7 @@
 1812	fourth thoracic vertebra	0		
 1813	skewed fifth thoracic vertebra	0		
 1814	lime green sixth thoracic vertebra	0		
-1815	blurry ghostly seventh thoracic vertebra	0		
+1815	ghostly blurry seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
@@ -1838,7 +1838,7 @@
 1859	olive right ninth rib	0		
 1860	right tenth rib	0		
 1861	right eleventh rib	0		
-1862	spinning skewed right twelfth rib	0		
+1862	skewed spinning right twelfth rib	0		
 1863	animal pelvis	0		
 1864	cyan left scapula	0		
 1865	right scapula	0		
@@ -1849,22 +1849,22 @@
 1870	left radius	0		
 1871	ghostly right radius	0		
 1872	narrow left ulna	0		
-1873	blinking bouncing right ulna	0		
+1873	bouncing blinking right ulna	0		
 1874	left femur	0		
 1875	right femur	0		
 1876	squat left tibia	0		
-1877	purple jittery right tibia	0		
+1877	jittery purple right tibia	0		
 1878	left fibula	0		
 1879	upside-down right fibula	0		
 1880	skewed left kneecap	0		
 1881	ghostly skewed right kneecap	0		
 1882	blurry left first front claw	0		
 1883	pulsating left second front claw	0		
-1884	jittery blurry left third front claw	0		
+1884	blurry jittery left third front claw	0		
 1885	left fourth front claw	0		
 1886	right first front claw	0		
 1887	right second front claw	0		
-1888	squat upside-down pulsating blue right third front claw	0		
+1888	upside-down squat blue pulsating right third front claw	0		
 1889	shaking right fourth front claw	0		
 1890	left thumb	0		
 1891	right thumb	0		
@@ -1874,7 +1874,7 @@
 1895	left fourth rear claw	0		
 1896	blurry blinking right first rear claw	0		
 1897	right second rear claw	0		
-1898	olive spinning right third rear claw	0		
+1898	spinning olive right third rear claw	0		
 1899	right fourth rear claw	0		
 1900	twirling chilly 1-ball	0		Cold Damage: +5
 1901	twirling up-at-dawn friendly 2-ball	0		Familiar Weight: +3, Adventures: +5
@@ -1883,24 +1883,24 @@
 1904	wool toasty 5-ball	0		Hot Damage: +5, Cold Resistance: +1
 1905	cool 6-ball of the bloodbag	0		Moxie: +5, Maximum HP: +100
 1906	narrow cyan vibrating 7-ball	0		Maximum MP Percent: +10
-1907	fuchsia bouncing 8-ball	0		
+1907	bouncing fuchsia 8-ball	0		
 1910	careful extremely unsafe Rosewater's clockwork sword	0		Mysticality Percent: +30, Weapon Damage Percent: +100, Monster Level: -10
 1911	mansplainer's forbidden experienced clockwork staff	0		Experience: +2, Spell Damage Percent: +50, Monster Level: +15
 1912	greedy wool clockwork crossbow of the ox	0		Muscle: +20, Cold Resistance: +1, Meat Drop: +20
 1913	clockwork handle	0		
-1914	bouncing ghostly teal clockwork rod	0		
+1914	ghostly bouncing teal clockwork rod	0		
 1915	clockwork shank	0		
 1916	Lord Spookyraven's spectacles	0		
 1917	wallet	0		
 1918	coin purse	0		
-1919	upside-down teal English to A. F. U. E. Dictionary	0		
-1920	maroon shaking bouncing bizarre illegible sheet music	0		
+1919	teal upside-down English to A. F. U. E. Dictionary	0		
+1920	shaking maroon bouncing bizarre illegible sheet music	0		
 1921	blurry wakizashi of bravery	0		Spooky Resistance: +5
 1922	gob of wet hair	0		
 1923	blue roll of toilet paper	0		Free Pull
 1924	cyan tattered wolf standard	0		
 1925	tattered snake standard	0		
-1926	jittery skewed tumbling KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1926	skewed jittery tumbling KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	gray scary death orb	0		
 1928	tuning fork	0		
 1929	Jim Carey's greaves	0		Monster Level: +25, Familiar Effect: "1xBarrr"
@@ -1923,14 +1923,14 @@
 1946	ribald coward's accordion pin	0		Monster Level: -20, Sleaze Damage: +10, Class: "Accordion Thief", Single Equip
 1947	Lo Pan's worn tophat of the detective	0		Spell Critical Percent: +30, Item Drop: +20, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	lard-coated flame-wreathed tap shoes	0		Hot Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip
-1949	enchanted thick adequate wobbly Manetwich	5	good	Effect: "The Style... of the Future", Effect Duration: 30
+1949	adequate enchanted thick wobbly Manetwich	5	good	Effect: "The Style... of the Future", Effect Duration: 30
 1950	tumbling bottle of Vangoghbitussin	0		
 1951	practically non-alcoholic mediocre bottle of Pinot Renoir	1	decent	
 1952	moldy enchanted bouncing desiccated apricot	3	crappy	Effect: "Hagg-ard", Effect Duration: 30
 1953	tolerable weak flute of flat champagne	2	good	
 1954	normal dehydrated caviar	4	good	
 1955	huge styrofoam peanuts	0		
-1956	watered-down mediocre spinning snifter of thoroughly aged brandy	2	decent	
+1956	mediocre watered-down spinning snifter of thoroughly aged brandy	2	decent	
 1957	squat quill pen	0		
 1958	narrow inkwell	0		
 1959	tattered scrap of paper	0		
@@ -1977,7 +1977,7 @@
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
 2001	pulsating Vaso De Agua trading card	0		
 2002	wobbly The Grand Poo-Bah trading card	0		
-2003	skewed lime green pulsating Thorny Toad trading card	0		
+2003	lime green pulsating skewed Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	jittery tumbling Poison Oak trading card	0		
@@ -1993,7 +1993,7 @@
 2016	diamond necklace	0		
 2017	spade necklace	0		
 2018	maroon club necklace	0		
-2019	pulsating narrow cream pie	0		Free Pull
+2019	narrow pulsating cream pie	0		Free Pull
 2020	flavorless cherry pie	3	decent	
 2021	decent bite-sized strawberry pie	1	good	
 2022	small tasty lemon meringue pie	2	awesome	
@@ -2002,7 +2002,7 @@
 2025	rotten immense handful of walnuts	6	crappy	
 2026	decent nutty organic salad	3	good	
 2027	toothsome super salad	4	awesome	
-2028	half-sized moldy tofu wonton	2	crappy	
+2028	moldy half-sized tofu wonton	2	crappy	
 2029	hippy protest button	0		Single Equip
 2030	purple savvy weightlifter's Lockenstock&trade; sandals	0		Muscle: +15, Mysticality Percent: +20, Single Equip
 2031	lime green didgeridooka of the early riser	0		Adventures: +7
@@ -2015,18 +2015,18 @@
 2038	enhanced ennui-flavored potato chips	0		Effect: "Your Eyes are Peeled!", Effect Duration: 49
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	patchouli oil bomb	0		
-2041	twirling wobbly ferret bait	0		
+2041	wobbly twirling ferret bait	0		
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	skewed your father's MacGuffin diary	0		
 2045	stale brain-meltingly-hot chicken wings	4	decent	
-2046	big rotten enchanted shaking frat brats	5	crappy	Effect: "Also Schmeckt Zarathustra", Effect Duration: 35
+2046	big enchanted rotten shaking frat brats	5	crappy	Effect: "Also Schmeckt Zarathustra", Effect Duration: 35
 2047	normal diet knob ka-bobs	1	good	
-2049	practically non-alcoholic smooth jittery maroon can of Swiller	1	awesome	
+2049	practically non-alcoholic smooth maroon jittery can of Swiller	1	awesome	
 2050	broken wings	0		
-2051	bouncing shaking sunken eyes	0		
+2051	shaking bouncing sunken eyes	0		
 2052	shaking reassembled blackbird	0		
-2053	mirror purple bust of Pallas	0		Familiar Weight: +5
+2053	purple mirror bust of Pallas	0		Familiar Weight: +5
 2054	ghostly market map	0		
 2055	mirror snake skin	0		
 2056	colloidal corrupted electrified narrow adder bladder	0		Effect: "In the Slimelight", Effect Duration: 24
@@ -2038,7 +2038,7 @@
 2062	ghostly ribald shield of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10, Damage Reduction: 10
 2063	miniature flavorless blackberry	2	decent	
 2064	forged identification documents	0		
-2065	skewed cyan PADL Phone	0		
+2065	cyan skewed PADL Phone	0		
 2066	blinking beefy kick-ass kicks of the sewer	0		Muscle: +10, Stench Damage: +25, Single Equip
 2067	sake bomb	0		
 2068	tequila grenade	0		
@@ -2069,7 +2069,7 @@
 2093	bouncing wholesome hors d'oeuvre tray	0		Maximum HP Percent: +10, Damage Reduction: 5
 2094	adequate low-calorie ballroom blintz	1	good	
 2095	towel	0		
-2096	mixed lime green pulsating mirror guy made of bee pollen	1		
+2096	mixed lime green mirror pulsating guy made of bee pollen	1		
 2097	maroon coward's 17-ball	0		Monster Level: -20
 2098	filthy lucre	0		
 2099	hobo gristle	0		
@@ -2078,9 +2078,9 @@
 2102	greasy dreadlock	0		
 2103	vial of pirate sweat	0		
 2104	empty aftershave bottle	0		
-2105	spinning jittery coal button	0		
+2105	jittery spinning coal button	0		
 2106	burned-out arcanodiode	0		
-2107	blurry purple non-Euclidean hoof	0		
+2107	purple blurry non-Euclidean hoof	0		
 2108	rock	0		
 2109	stringy sinew	0		Last Available: "2011-12"
 2110	huge stick	0		Last Available: "2011-12"
@@ -2121,12 +2121,12 @@
 2146	huge evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	miniature rotten frank	2	crappy	Last Available: "2011-12"
+2149	rotten miniature frank	2	crappy	Last Available: "2011-12"
 2150	diet yummy blinking plate of franks and beans	1	awesome	Last Available: "2011-12"
 2151	drinkable shot of blackberry schnapps	3	good	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
-2154	blurry cyan pulsating ion grid	0		Last Available: "2011-12"
+2154	blurry pulsating cyan ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	red logic synthesizer	0		Last Available: "2011-12"
 2157	yellow high-resistance ultrapolymer plating	0		Last Available: "2011-12"
@@ -2145,21 +2145,21 @@
 2170	yellow MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
 2171	crafty astronaut pants of doom	0		Maximum MP: +10, Spooky Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	spinning toy jet pack of horror	0		Spooky Spell Damage: +25, Last Available: "2006-12"
-2173	ghostly squat triangular stone	0		
+2173	squat ghostly triangular stone	0		
 2174	mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	pulsating cracked stone sphere	0		
 2177	red rough stone sphere	0		
 2178	sizzling obsidian dagger	0		Hot Damage: +10
 2179	archaeologist's notebook	0		
-2180	mirror twirling amulet	0		
+2180	twirling mirror amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	ghostly Harold's hammer head	0		
 2183	Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	fireproof Kiss the Knob apron	0		Hot Resistance: +3
 2186	unlit birthday cake	0		
-2187	skewed red lit birthday cake	0		
+2187	red skewed lit birthday cake	0		
 2188	blinking flask of peppermint oil	1	EPIC	Last Available: "2006-12"
 2189	drinkable flask of peppermint schnapps	3	good	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
@@ -2167,7 +2167,7 @@
 2192	sheet music	0		Last Available: "2006-12"
 2193	normal gray candy stake	3	good	Last Available: "2006-12"
 2194	perfectly mixed eggnog	3	EPIC	Last Available: "2006-12"
-2195	snack-sized bland blinking unspeakable fruitcake	2	decent	Last Available: "2006-12"
+2195	bland snack-sized blinking unspeakable fruitcake	2	decent	Last Available: "2006-12"
 2196	huge stale huge gingerbread horror	9	decent	Last Available: "2006-12"
 2197	deionized blue but probably evil chocolate	0		Effect: "Vinegavotte", Effect Duration: 62, Last Available: "2006-12"
 2198	half-sized delicious bat-shaped Crimboween cookie	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
@@ -2214,7 +2214,7 @@
 2239	personal trainer's boxer's bad voodoo mask	0		Muscle Percent: +10, Experience Percent (Muscle): +10, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	bottle of alcohol	0		
 2241	Socratic pygmy spear	0		Experience (Mysticality): +1
-2242	double-tarnished wobbly bouncing ghostly pygmy pygment	0		Effect: "Ichorous Intensity", Effect Duration: 52
+2242	double-tarnished bouncing ghostly wobbly pygmy pygment	0		Effect: "Ichorous Intensity", Effect Duration: 52
 2243	skewed greasy wizardly headhunter necktie	0		Mysticality: +25, Sleaze Spell Damage: +10, Single Equip
 2244	medical-grade Rosewater's pointed stick	0		Mysticality Percent: +30, HP Regen Min: 7, HP Regen Max: 10
 2245	Socratic knobby helmet turtle	0		Experience (Mysticality): +1, Familiar Effect: "atk, 2xFairy, cap 5"
@@ -2230,7 +2230,7 @@
 2256	furry earmuffs of the sewer	0		Stench Damage: +25
 2257	huge mansplainer's rock-hard reinforced furry underpants	0		Damage Reduction: 5, Monster Level: +15
 2258	huge &quot;I Love Me, Vol. I&quot;	0		
-2259	shaking upside-down photograph of God	0		
+2259	upside-down shaking photograph of God	0		
 2260	hard rock candy	0		
 2261	wobbly hard-boiled ostrich egg	0		
 2262	bird rib	0		
@@ -2242,7 +2242,7 @@
 2268	Staff of Fats of the boozehound	0		Booze Drop: +100
 2269	bite-sized normal sausage wonton	1	good	
 2270	foul-smelling wholesome belt	0		Maximum HP Percent: +10, Stench Damage: +10, Single Equip
-2271	high-proof drinkable bottle of Merlot	10	good	
+2271	drinkable high-proof bottle of Merlot	10	good	
 2272	watered-down smooth bottle of Port	2	awesome	
 2273	perfectly mixed bottle of Pinot Noir	3	EPIC	
 2274	hand-crafted bottle of Zinfandel	3	EPIC	
@@ -2252,7 +2252,7 @@
 2278	Fernswarthy's letter	0		
 2279	blinking book	0		
 2280	Manual of Labor	0		
-2281	mirror blue Manual of Transmission	0		
+2281	blue mirror Manual of Transmission	0		
 2282	bouncing Manual of Dexterity	0		
 2283	ghostly ruddy seal-skull helmet	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
@@ -2274,13 +2274,13 @@
 2300	blinking fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	tumbling Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	tumbling Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	irradiated double-pickled tumbling candy heart	0		Effect: "Earthen Fist", Effect Duration: 35, Last Available: "2007-02"
 2305	energized pink candy heart	0		Effect: "In the Saucestream", Effect Duration: 26, Last Available: "2007-02"
 2306	wet triple-oxidized Vulcanized huge candy heart	0		Effect: "Helping Comes Second", Effect Duration: 23, Last Available: "2007-02"
 2307	triple-polymerized concentrated candy heart	0		Effect: "Sugary World View", Effect Duration: 50, Last Available: "2007-02"
 2308	energized oxidized double-chilled cyan candy heart	0		Effect: "Resilient Spirit", Effect Duration: 60, Last Available: "2007-02"
-2309	polarized liquefied dry shaking twirling candy heart	0		Effect: "Proprie Tea", Effect Duration: 42, Last Available: "2007-02"
+2309	polarized liquefied dry twirling shaking candy heart	0		Effect: "Proprie Tea", Effect Duration: 42, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	squat pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
@@ -2295,7 +2295,7 @@
 2321	worm-riding manual page 2	0		
 2322	worm-riding manual pages 3-15	0		
 2323	headpiece of the Staff of Ed	0		
-2324	squat teal Staff of Ed, almost	0		
+2324	teal squat Staff of Ed, almost	0		
 2325	Staff of Ed	0		
 2326	stone rose	0		
 2327	Vulcanized can of paint	0		Effect: "The Real Deal", Effect Duration: 40
@@ -2303,7 +2303,7 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	bouquet of circular saw blades	0		
-2332	spoiled enchanted blinking Better Than Cuddling Cake	4	crappy	Effect: "Twinkly Weapon", Effect Duration: 45
+2332	enchanted spoiled blinking Better Than Cuddling Cake	4	crappy	Effect: "Twinkly Weapon", Effect Duration: 45
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	upside-down upside-down rubber WWBBDD? bracelet	0		
@@ -2344,11 +2344,11 @@
 2370	natural fennel soda	0		
 2371	twirling smoke bomb	0		
 2372	wobbly bunch of bananas	0		
-2373	enchanted normal banana	3	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30
+2373	normal enchanted banana	3	good	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30
 2374	banana peel	0		
-2375	tasty massive mirror banana cream pie	6	awesome	
+2375	massive tasty mirror banana cream pie	6	awesome	
 2376	perfectly mixed banana daiquiri	3	EPIC	
-2377	smooth irresponsibly strong bungle in the jungle	9	awesome	
+2377	irresponsibly strong smooth bungle in the jungle	9	awesome	
 2378	banana spritzer	0		
 2379	corrupted galvanized banana smoothie	0		Effect: "Locks Like the Raven", Effect Duration: 13
 2380	upside-down dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2376,7 +2376,7 @@
 2402	gauze garter	0		
 2403	barrel of gunpowder	0		
 2404	ghostly jam band flyers	0		
-2405	ghostly narrow rock band flyers	0		
+2405	narrow ghostly rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	narrow pink bat eye	0		
 2408	worthless piece of glass	0		
@@ -2421,7 +2421,7 @@
 2447	purple bad penguin egg	0		Free Pull
 2448	tasteful bow tie	0		Familiar Weight: +5
 2449	six-pack of New Cloaca-Cola	0		
-2450	green twirling empty Cloaca-Cola bottle	0		
+2450	twirling green empty Cloaca-Cola bottle	0		
 2451	goatskin umbrella of chilblains	0		Cold Damage: +25
 2452	horrifying wool hat of the businessman	0		Spooky Damage: +25, Meat Drop: +50, Familiar Effect: "1xLep, cap 43"
 2453	Goodfella contract	0		Last Available: "2011-12"
@@ -2432,17 +2432,17 @@
 2458	Herculean barskin loincloth	0		Experience (Muscle): +1, Familiar Effect: "sleaze atk, 4xVolley, cap 6"
 2459	tighty whiteys of the pedagogue	0		Experience: +3, Familiar Effect: "sleaze atk, 3xVolley, cap 10"
 2460	wobbly wicked yak toupee	0		Spell Damage: +5, Familiar Effect: "atk, 1xPotato, cap 25"
-2462	spinning maroon ghostly odor extractor	0		Last Available: "2019-12"
+2462	spinning ghostly maroon odor extractor	0		Last Available: "2019-12"
 2463	spinning jittery Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	jumbo adequate bowl of Bounty-Os	5	good	
-2465	fortified bad wobbly upside-down Oreille Divis&eacute;e brandy	5	decent	
+2464	adequate jumbo bowl of Bounty-Os	5	good	
+2465	bad fortified wobbly upside-down Oreille Divis&eacute;e brandy	5	decent	
 2466	ghostly upside-down pompadour'd puppy	0		
 2467	blinking spinning suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	spinning bundle of receipts	0		
 2470	cork	0		
 2471	twirling olive stardust	0		
-2472	jittery skewed wilted lettuce	0		
+2472	skewed jittery wilted lettuce	0		
 2473	empty greasepaint tube	0		
 2474	clown skin	0		
 2475	ghostly knitted clown wig of wisdom	0		Mysticality: +15, Cold Resistance: +3, Clowniness: 50, Familiar Effect: "chromatic atk, 1xPotato, cap 12"
@@ -2490,13 +2490,13 @@
 2517	Jack Frost's fortified chain necklace	0		Damage Absorption: +60, Cold Spell Damage: +50
 2518	huge MacGyver's sawblade shield	0		Maximum MP: +100, Damage Reduction: 11
 2519	hand-crafted McMillicancuddy's Special Lager	3	EPIC	
-2520	weak delicious enchanted melted Jell-o shot	2	awesome	Effect: "Low on the Hog", Effect Duration: 35
+2520	weak enchanted delicious melted Jell-o shot	2	awesome	Effect: "Low on the Hog", Effect Duration: 35
 2521	perfectly mixed cruelty-free wine	3	EPIC	
 2522	mediocre spirit-forward thistle wine	5	decent	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	tasty fish	4	awesome	
-2526	flavorless fancy small fish casserole	2	decent	Effect: "Joyful Resolve", Effect Duration: 25
+2526	fancy small flavorless fish casserole	2	decent	Effect: "Joyful Resolve", Effect Duration: 25
 2527	adequate fish lasagna	3	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	yummy gnatloaf	3	awesome	
@@ -2504,7 +2504,7 @@
 2531	spoiled gnat lasagna	4	crappy	
 2532	blue pork	0		
 2533	tiny flavorless pork chop sandwiches	1	decent	
-2534	tiny moldy pork casserole	1	crappy	
+2534	moldy tiny pork casserole	1	crappy	
 2535	tasty pork lasagna	3	awesome	
 2536	canopic jar	0		
 2537	spice	0		
@@ -2549,7 +2549,7 @@
 2576	maroon honey-dipped locust	0		
 2577	asbestos-lined cactus quill of terror	0		Spooky Spell Damage: +10, Hot Resistance: +5
 2578	fireproof lard-coated Staff of the Short Order Cook of mayonnaise	0		Sleaze Spell Damage: 75, Hot Resistance: +3
-2579	super-sized moldy cactus fruit	5	crappy	
+2579	moldy super-sized cactus fruit	5	crappy	
 2580	ribald Jim Carey's scorpion whip	0		Monster Level: +25, Sleaze Damage: +10
 2581	handful of sand	0		
 2582	brick of sand	0		
@@ -2560,8 +2560,8 @@
 2587	lime green savvy Corporal Fennel's Lonely Clubs Club Jacket	0		Mysticality Percent: +20
 2588	tumbling Private Pepper's Lonely Hearts Club Jacket of the cheetah	0		Initiative: +60
 2589	bland hot date	3	decent	
-2590	irresponsibly strong lousy distilled fortified wine	8	decent	
-2591	stale tiny narrow tasty tart	1	decent	
+2590	lousy irresponsibly strong distilled fortified wine	8	decent	
+2591	tiny stale narrow tasty tart	1	decent	
 2592	gray Knob Goblin lunchbox	0		
 2593	decent tumbling Knob pasty	4	good	
 2594	practically non-alcoholic artisanal thermos full of Knob coffee	1	EPIC	
@@ -2585,9 +2585,9 @@
 2612	vinyl coin purse	0		
 2613	olive rocky raccoon	0		
 2614	mojo filter	0		
-2615	stale enchanted super-sized tumbling savoy truffle	5	decent	Effect: "Boilermade", Effect Duration: 20
+2615	stale super-sized enchanted tumbling savoy truffle	5	decent	Effect: "Boilermade", Effect Duration: 20
 2616	Magi-Wipes	0		
-2617	blinking wobbly boom	0		
+2617	wobbly blinking boom	0		
 2618	frosty Iiti Kitty phone charm	0		Cold Spell Damage: +10, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
 2620	stale immense blinking unidentified jerky	9	decent	
@@ -2622,12 +2622,12 @@
 2649	sharpshooter's Lord Spookyraven's ear trumpet	0		Critical Hit Percent: +10, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	adequate half-sized S.T.L.T.	2	good	Last Available: "2007-06"
-2653	normal enchanted blurry honey-dew	3	good	Effect: "Buzzard Breath", Effect Duration: 10, Last Available: "2007-06"
+2652	half-sized adequate S.T.L.T.	2	good	Last Available: "2007-06"
+2653	enchanted normal blurry honey-dew	3	good	Effect: "Buzzard Breath", Effect Duration: 10, Last Available: "2007-06"
 2654	delicious twirling Xanadian	3	awesome	Last Available: "2007-06"
 2655	quadruple-polarized pressed purple squat bottle of absinthe	0		Effect: "Category", Effect Duration: 66, Last Available: "2007-06"
 2656	Drowsy Sword of temperance of the detective	0		Sleaze Resistance: +5, Item Drop: +20
-2657	massive delicious shaking escargotsicle	10	awesome	Last Available: "2007-06"
+2657	delicious massive shaking escargotsicle	10	awesome	Last Available: "2007-06"
 2658	high-proof bad bottle of realpagne	8	decent	Last Available: "2007-06"
 2659	Lo Pan's albatross necklace	0		Spell Critical Percent: +30, Single Equip, Last Available: "2007-06"
 2660	vaporized not-a-pipe	1	good	Last Available: "2007-06"
@@ -2646,7 +2646,7 @@
 2673	spinning Bohemian rhapsody	0		Last Available: "2007-06"
 2674	pressed triple-concentrated oxidized skewed wobbly bottle of cat tonic	0		Effect: "Stinkybeard", Effect Duration: 18, Last Available: "2007-06"
 2675	modified blinking handful of moss	1		Effect: "Human-Demon Hybrid", Effect Duration: 35
-2676	dried bouncing shaking bit-o-cactus	1		
+2676	dried shaking bouncing bit-o-cactus	1		
 2677	distilled mirror protein powder	1		Effect: "Bureaucratized", Effect Duration: 5
 2678	spectre scepter	0		
 2679	magnetized blinking sparkler	0		Effect: "Amplified Fabulousness", Effect Duration: 13
@@ -2695,11 +2695,11 @@
 2722	jittery scandalous hale healthy Staff of the Greasefire of vim and vigor	0		Maximum HP Percent: 70, Maximum HP: +20, Sleaze Damage: +5
 2723	twirling Lo Pan's Staff of the Grand Flamb&eacute; of the brazier of the overflowing toilet	0		Spell Critical Percent: +30, Hot Spell Damage: +25, Stench Spell Damage: +50
 2724	moldy miniature bowl of rye sprouts	2	crappy	
-2725	bland low-calorie cob of corn	1	decent	
+2725	low-calorie bland cob of corn	1	decent	
 2726	normal enchanted ghostly juniper berries	3	good	Effect: "Arabian Knighthood", Effect Duration: 10
 2727	moldy plum	3	crappy	
-2728	gigantic rotten squat pear	10	crappy	
-2729	moldy immense peach	9	crappy	
+2728	rotten gigantic squat pear	10	crappy	
+2729	immense moldy peach	9	crappy	
 2730	acceptable enchanted plum wine	3	good	Effect: "PERL of Great Price", Effect Duration: 35
 2731	bad shot of pear schnapps	3	decent	
 2732	lousy shot of peach schnapps	3	decent	
@@ -2708,7 +2708,7 @@
 2735	huge flavorless sandwich of the gods	6	decent	
 2736	strong artisanal Pan-Dimensional Gargle Blaster	5	EPIC	
 2737	boiled bouncing leopard-print barbell	1	decent	
-2738	pulsating fuchsia pile of smoking rags	0		
+2738	fuchsia pulsating pile of smoking rags	0		
 2739	frozen pickled extra-tarnished shaking panty raider camouflage	0		Effect: "Healthy Blue Glow", Effect Duration: 49
 2740	Jack Frost's Newton's Staff of the Walk-In Freezer of the dark arts	0		Experience (Mysticality): +3, Spell Damage Percent: +100, Cold Spell Damage: +50
 2741	smooth boozy mirror boilermaker	5	awesome	
@@ -2737,7 +2737,7 @@
 2764	manspreader's brawny Order of the Silver Wossname of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Monster Level: +10, Single Equip
 2765	pulsating Harold's bell	0		
 2766	olive bowling ball	0		
-2767	fancy flavorless Crimbo pie	4	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20
+2767	flavorless fancy Crimbo pie	4	decent	Effect: "The Ballad of Richie Thingfinder", Effect Duration: 20
 2768	tasty mirror pear tart	4	awesome	
 2769	adequate jittery peach pie	3	good	
 2770	adjusted non-moist chunk of rock salt	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 35
@@ -2774,7 +2774,7 @@
 2801	mirror vial of Gnomochloric acid	0		
 2802	jittery ghostly flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
-2804	triple-vacuum-sealed flattened shaking huge vial of hamethyst juice	0		Effect: "Eyes for Miles", Effect Duration: 43
+2804	triple-vacuum-sealed flattened huge shaking vial of hamethyst juice	0		Effect: "Eyes for Miles", Effect Duration: 43
 2805	concentrated blurry vial of baconstone juice	0		Effect: "You Know Where to Go", Effect Duration: 14
 2806	chilled adjusted purple vial of porquoise juice	0		Effect: "Ponderous Potency", Effect Duration: 24
 2807	double-tarnished ghostly flask of hamethyst juice	0		Effect: "Is This Your Card?", Effect Duration: 31
@@ -2802,15 +2802,15 @@
 2829	skewed really dense meat stack	0		
 2830	spinning digital key lime	0		
 2831	olive blurry star key lime	0		
-2832	half-sized special tasty digital key lime pie	2	awesome	Effect: "Big Flaming Whip", Effect Duration: 20
-2833	gigantic adequate star key lime pie	8	good	
-2834	avaricious Tesla clever bottle-rocket crossbow	0		Maximum MP: +20, Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2832	tasty half-sized special digital key lime pie	2	awesome	Effect: "Big Flaming Whip", Effect Duration: 20
+2833	adequate gigantic star key lime pie	8	good	
+2834	avaricious Tesla clever bottle-rocket crossbow	0		Maximum MP: +20, Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	jittery stanky indie comic hipster glasses	0		Stench Spell Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	bouncing mint-condition magic wand	0		Last Available: "2011-12"
 2838	ghostly Oprah's glowstick of the sweet-tooth	0		Maximum MP Percent: +50, Candy Drop: +100, Last Available: "2007-08"
 2839	vibrating Periodical Paintbrush	0		Maximum MP Percent: +10, Softcore Only
-2840	drinkable high-proof bottle of cooking sherry	7	good	
+2840	high-proof drinkable bottle of cooking sherry	7	good	
 2841	moldy packet of ketchup	3	crappy	
 2842	smooth squat accidental cider	3	awesome	
 2843	moldy green dire fudgesicle	3	crappy	
@@ -2820,14 +2820,14 @@
 2847	blue strapping Dallas Dynasty Falcon Crest shield	0		Muscle: +5, Damage Reduction: 15
 2848	skewed Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	watered-down drinkable moonberry wine cooler	2	good	
+2850	drinkable watered-down moonberry wine cooler	2	good	
 2851	spoiled fine aged cheddarwurst	3	crappy	
 2852	branch from the Great Tree	0		
-2853	maroon tumbling Phil Bunion's axe	0		
+2853	tumbling maroon Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	olive reassuring Fonzie's huge mosquito proboscis	0		Experience (Moxie): +1, Spooky Resistance: +1
 2856	pressed activated swamp lolly	0		Effect: "Dirty Pear", Effect Duration: 68
-2857	dry mirror shaking seegar butt	0		Effect: "Pasta Oneness", Effect Duration: 28
+2857	dry shaking mirror seegar butt	0		Effect: "Pasta Oneness", Effect Duration: 28
 2858	bottled swamp gas	0		
 2859	friendly Jim Carey's witch wart	0		Monster Level: +25, Familiar Weight: +3
 2860	super-sized flavorless jittery swamp muck	5	decent	
@@ -2839,7 +2839,7 @@
 2866	Rosewater's shamanic beads of doom	0		Mysticality Percent: +30, Spooky Spell Damage: +50
 2867	nasty occult dilapidated wizard hat	0		Spell Damage Percent: +25, Stench Damage: +5, Familiar Effect: "cap 31"
 2868	super-pickled double-oxidized blurry pirate pamphlet	0		Effect: "Patent Avarice", Effect Duration: 48
-2869	galvanized altered twirling fuchsia pirate brochure	0		Effect: "Toast Tea", Effect Duration: 33
+2869	galvanized altered fuchsia twirling pirate brochure	0		Effect: "Toast Tea", Effect Duration: 33
 2870	double-polymerized pirate tract	0		Effect: "Stone-Faced", Effect Duration: 47
 2871	burnt flower	0		
 2872	razor-sharp groovy plastic Naughty Sorceress	0		Moxie Percent: +10, Weapon Damage Percent: +25
@@ -2912,10 +2912,10 @@
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	miniature stale blue Surprise Egg	2	decent	
 2941	double-diffused alkaline bouncing Steal This Candy	0		Effect: "Jawin'", Effect Duration: 69
-2942	aerosolized fuchsia bouncing chocolate filthy lucre	0		Effect: "Crud&eacute;", Effect Duration: 51
+2942	aerosolized bouncing fuchsia chocolate filthy lucre	0		Effect: "Crud&eacute;", Effect Duration: 51
 2943	anodized nitrogenated Angry Farmer's Wife Candy	0		Effect: "Cybernetic Muscles", Effect Duration: 30
 2945	fireproof Jack Frost's party hat	0		Cold Spell Damage: +50, Hot Resistance: +3, Familiar Effect: "4xLep, cap 7"
-2946	huge Temple Grandin's Herculean V for Vivala mask	0		Experience (Muscle): +1, Familiar Weight: +7, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	huge Temple Grandin's Herculean V for Vivala mask	0		Experience (Muscle): +1, Familiar Weight: +7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	tolerable shot of rotgut	3	good	
 2949	polymerized altered lime green upside-down jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Shredding, Sweating", Effect Duration: 27
@@ -2929,9 +2929,9 @@
 2957	rum barrel charrrm	0		
 2958	flavorless half-sized spinning tube of cranberry Go-Goo	2	decent	
 2959	Samson's rum barrel charrrm bracelet	0		Experience (Muscle): +5
-2960	snack-sized flavorless enchanted single-serving herbal stuffing	2	decent	Effect: "You Know Where to Go", Effect Duration: 50
+2960	snack-sized enchanted flavorless single-serving herbal stuffing	2	decent	Effect: "You Know Where to Go", Effect Duration: 50
 2961	moldy blurry packet of tofurkey gravy	3	crappy	
-2962	flavorless enchanted yellow tofurkey nugget	4	decent	Effect: "Blackberry Politeness", Effect Duration: 45
+2962	enchanted flavorless yellow tofurkey nugget	4	decent	Effect: "Blackberry Politeness", Effect Duration: 45
 2963	mirror rigging shampoo	0		
 2964	blurry ball polish	0		
 2965	gray ghostly mizzenmast mop	0		
@@ -2945,7 +2945,7 @@
 2973	energetic grumpy man charrrm bracelet	0		Maximum MP Percent: +20, Single Equip
 2974	shaking tarrrnish charrrm	0		
 2975	manspreader's tarrrnished charrrm bracelet of the wise owl	0		Mysticality: +20, Monster Level: +10, Single Equip
-2976	enchanted lousy bouncing bilge wine	4	decent	Effect: "Grrrrrrreat!", Effect Duration: 35
+2976	lousy enchanted bouncing bilge wine	4	decent	Effect: "Grrrrrrreat!", Effect Duration: 35
 2977	cyan witty rapier of bravery	0		Spooky Resistance: +5
 2978	friendly studded yohohoyo	0		Damage Absorption: +80, Familiar Weight: +3
 2979	moist denatured adjusted fish-liver oil	0		Effect: "Tiki Thoughtfulness", Effect Duration: 13
@@ -2987,17 +2987,17 @@
 3015	gilded key	0		
 3016	foot locker	0		
 3017	ornate chest	0		
-3018	narrow wobbly gilded chest	0		
+3018	wobbly narrow gilded chest	0		
 3019	spinning all-purpose cleaner	0		
 3020	handful of sawdust	0		
 3021	stone triangle	0		
 3022	medium stone triangle	0		
 3023	skewed small stone triangle	0		
 3024	stone pyramid	0		
-3025	bad special weak corpse on the beach	2	decent	Effect: "Minerva's Zen", Effect Duration: 15
+3025	bad weak special corpse on the beach	2	decent	Effect: "Minerva's Zen", Effect Duration: 15
 3026	perfectly mixed upside-down corpsetini	3	super EPIC	
 3027	delicious corpsedriver	4	awesome	
-3028	weak tolerable Corpse Island iced tea	2	good	
+3028	tolerable weak Corpse Island iced tea	2	good	
 3029	perfectly mixed red-headed corpse	3	EPIC	
 3030	perfectly mixed kamicorpse-ee	3	EPIC	
 3031	mediocre weak corpsel	2	decent	
@@ -3005,7 +3005,7 @@
 3033	dangerous pirate fledges	0		Weapon Damage: +10
 3034	piece of thirteen	0		
 3035	bland pearl onion	4	decent	
-3036	spoiled miniature jittery sea biscuit	2	crappy	
+3036	miniature spoiled jittery sea biscuit	2	crappy	
 3037	lousy watered-down bottle of rum	2	decent	
 3038	watered-down delicious wobbly bottle of black-label rum	2	awesome	
 3039	cannonball	0		
@@ -3013,9 +3013,9 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	adequate nanite-infested gingerbread bugbear	3	good	Last Available: "2007-12"
-3046	gigantic bland fancy nanite-infested candy cane	10	decent	Effect: "Big Meat Big Prizes", Effect Duration: 35, Last Available: "2020-09"
+3046	fancy gigantic bland nanite-infested candy cane	10	decent	Effect: "Big Meat Big Prizes", Effect Duration: 35, Last Available: "2020-09"
 3047	tasty nanite-infested fruitcake	3	awesome	Last Available: "2007-12"
 3048	weak aged nanite-infested eggnog	2	awesome	Last Available: "2007-12"
 3049	jittery El Vibrato power sphere	0		
@@ -3039,7 +3039,7 @@
 3067	dollhive	0		Last Available: "2007-12"
 3068	shaking toy deathbot	0		Last Available: "2007-12"
 3069	laser cannon	0		Last Available: "2007-12"
-3070	narrow blurry plexifoam chin strap	0		Last Available: "2007-12"
+3070	blurry narrow plexifoam chin strap	0		Last Available: "2007-12"
 3071	silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	carbonite visor	0		Last Available: "2007-12"
 3073	blue set of Unobtainium straps	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	twirling laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	cyan kevlateflocite helmet	0		Last Available: "2007-12"
-3079	huge Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	huge Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	mirror mirror teddy borg	0		Last Available: "2007-12"
 3081	smelly marionette collective	0		Stench Spell Damage: +10, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3064,12 +3064,12 @@
 3092	blinking steel-toed handmade hobby horse	0		Damage Reduction: 9, Last Available: "2007-12"
 3093	pulsating ball-in-a-cup of dire peril	0		Weapon Damage: +20, Last Available: "2007-12"
 3094	friendly set of jacks	0		Familiar Weight: +3, Last Available: "2007-12"
-3095	jumbo adequate green laser-broiled pear	5	good	Last Available: "2007-12"
+3095	adequate jumbo green laser-broiled pear	5	good	Last Available: "2007-12"
 3096	vibrating experienced polyalloy shield	0		Experience: +2, Maximum MP Percent: +10, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
 3099	ring	0		Last Available: "2007-12"
-3100	skewed bouncing yellow robotronic egg	0		Last Available: "2007-12"
+3100	yellow skewed bouncing robotronic egg	0		Last Available: "2007-12"
 3101	lime green rogue swarmer	0		Last Available: "2007-12"
 3102	fuchsia sawblade fragment	0		Last Available: "2007-12"
 3103	unstable laser battery	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	jittery Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	maroon divine noisemaker	0		Last Available: "2008-01"
 3119	teal divine can of silly string	0		Last Available: "2008-01"
 3120	olive divine blowout	0		Last Available: "2008-01"
@@ -3098,7 +3098,7 @@
 3126	gray hobo nickel	0		
 3127	sandcastle	0		
 3128	wobbly marshmallow	0		
-3129	gigantic decent red roasted marshmallow	9	good	
+3129	decent gigantic red roasted marshmallow	9	good	
 3130	disc	0		Last Available: "2008-01"
 3131	flavorless squat tin cup of mulligan stew	4	decent	
 3132	lime green skewed lard-coated flamin' bindle of bravery	0		Sleaze Spell Damage: +25, Spooky Resistance: +5
@@ -3145,7 +3145,7 @@
 3173	unsweetened nitrogenated olive evil vihuela	0		Effect: "Aries Rising", Effect Duration: 19
 3174	fancy delicious spinning evil boring spaghetti	3	awesome	Effect: "Full Bottle in front of Me", Effect Duration: 45
 3175	jumbo toothsome skewed evil noodles	5	awesome	
-3176	rotten thick maroon pulsating evil noodles	5	crappy	
+3176	thick rotten pulsating maroon evil noodles	5	crappy	
 3177	spoiled evil painful penne pasta	3	crappy	
 3178	bland bouncing twirling 3vi1 pr0n m4nic0tti	3	decent	
 3179	stale small evil ravioli della hippy	2	decent	
@@ -3156,10 +3156,10 @@
 3184	corrupted anodized huge evil eyedrops of the ermine	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 34
 3185	flattened ionized nitrogenated evil ointment of the occult	0		Effect: "Cheered Up", Effect Duration: 63
 3186	irradiated evil serum of sarcasm	0		Effect: "Baconstoned", Effect Duration: 63
-3187	unsweetened tumbling lime green evil philter of phorce	0		Effect: "Pharmaceutically Cool", Effect Duration: 68
+3187	unsweetened lime green tumbling evil philter of phorce	0		Effect: "Pharmaceutically Cool", Effect Duration: 68
 3188	weak hand-crafted an evil sump'm sump'm	2	super EPIC	
 3189	delicious enchanted evil ducha de oro	4	awesome	Effect: "items.enh", Effect Duration: 10
-3190	special hand-crafted cyan evil horizontal tango	4	EPIC	Effect: "Donho's Bubbly Ballad", Effect Duration: 50
+3190	hand-crafted special cyan evil horizontal tango	4	EPIC	Effect: "Donho's Bubbly Ballad", Effect Duration: 50
 3191	mediocre evil roll in the hay	4	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3172,7 +3172,7 @@
 3200	lump of diamond	0		
 3201	thick padded envelope	0		
 3202	miser's KoL Con IV Pole of Gandalf of incineration	0		Spell Critical Percent: +20, Hot Spell Damage: +50, Meat Drop: +10, Last Available: "2007-09"
-3203	jittery spinning dwarvish magazine	0		
+3203	spinning jittery dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
@@ -3195,7 +3195,7 @@
 3223	sewer nuggets	0		
 3224	wobbly sewer wad	0		
 3225	drinkable weak bottle of sewage schnapps	2	good	
-3226	watered-down tolerable squat bottle of Ooze-O	2	good	
+3226	tolerable watered-down squat bottle of Ooze-O	2	good	
 3227	flavorless thick C.H.U.M. chum	5	decent	
 3228	low-calorie moldy unfortunate dumplings	1	crappy	
 3229	wobbly decaying goldfish liver	0		
@@ -3232,7 +3232,7 @@
 3260	squat up-at-dawn double-paned dance instructor's Chester's moustache	0		Experience Percent (Moxie): +10, Cold Resistance: +5, Adventures: +5, Class: "Disco Bandit", Single Equip
 3261	scandalous brainy Chester's bag of candy	0		Mysticality: +5, Sleaze Damage: +5, Class: "Disco Bandit"
 3262	wobbly cool Chester's cutoffs of the dark arts	0		Moxie: +5, Spell Damage Percent: +100, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3252,7 +3252,7 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	bouncing stick-on eyebrow piercing of terror	0		Spooky Spell Damage: +10, Last Available: "2008-04"
-3283	massive flavorless fuchsia spinning salad	8	decent	
+3283	flavorless massive fuchsia spinning salad	8	decent	
 3284	skewed coward's Newton's C.H.U.M. lantern	0		Experience (Mysticality): +3, Monster Level: -20
 3285	hardened C.H.U.M. knife	0		Damage Reduction: 3
 3286	auspicious Frosty's snowball sack	0		Item Drop: +10
@@ -3291,9 +3291,9 @@
 3319	wholesome Mr. Joe's bangles	0		Maximum HP Percent: +10, Single Equip
 3320	bouncing occult frayed rope belt	0		Spell Damage Percent: +25, Single Equip
 3321	teal packet of mayfly bait	0		Last Available: "2008-05"
-3322	Sherlock's sizzling mayfly bait necklace	0		Hot Damage: +10, Item Drop: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	Sherlock's sizzling mayfly bait necklace	0		Hot Damage: +10, Item Drop: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	Ol' Scratch's salad fork	0		
-3324	spinning huge Frosty's frosty mug	0		
+3324	huge spinning Frosty's frosty mug	0		
 3325	watered-down aged wobbly jar of fermented pickle juice	2	awesome	
 3326	twisted voodoo snuff	1	decent	
 3327	decent special extra-greasy slider	3	good	Effect: "Boon of She-Who-Was", Effect Duration: 25
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	bouncing dead guy's piece of double-sided tape	0		
 3337	savvy dead guy's memento of the boozehound	0		Mysticality Percent: +20, Booze Drop: +100, Single Equip
-3338	low-calorie normal banquet	1	good	
+3338	normal low-calorie banquet	1	good	
 3339	sharpened hubcap	0		
 3340	jittery very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3319,11 +3319,11 @@
 3347	comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
-3350	special practically non-alcoholic lousy narrow Ralph IX cognac	1	decent	Effect: "Macho, Macho Dog", Effect Duration: 5
+3350	lousy special practically non-alcoholic narrow Ralph IX cognac	1	decent	Effect: "Macho, Macho Dog", Effect Duration: 5
 3351	gray pulsating llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	enhanced huge llama lama gong	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 58, Last Available: "2008-06"
-3354	spoiled low-calorie banana-frosted king cake	1	crappy	Last Available: "2008-08"
+3354	low-calorie spoiled banana-frosted king cake	1	crappy	Last Available: "2008-08"
 3355	ribald brown plastic baby	0		Sleaze Damage: +10, Single Equip, Last Available: "2008-08"
 3356	jittery plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3370,7 +3370,7 @@
 3398	practically non-alcoholic bad pulsating Hodgman's blanket	1	decent	
 3399	watered-down acceptable jar of squeeze	2	good	
 3400	tasty half-sized bowl of fishysoisse	2	awesome	
-3401	diffused red tumbling huge deadly lampshade	0		Effect: "Mushroom Might", Effect Duration: 46
+3401	diffused tumbling red huge deadly lampshade	0		Effect: "Mushroom Might", Effect Duration: 46
 3402	altered denatured shaking concentrated garbage juice	0		Effect: "Stone-Faced", Effect Duration: 22
 3403	gray lewd playing card	0		
 3404	aromatic chaotic hale deck of lewd playing cards	0		Maximum HP: +20, Spell Critical Percent: +10, Stench Resistance: +1
@@ -3386,12 +3386,12 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	colloidal activated sterno-flavored Hob-O	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 14
 3423	frozen frostbite-flavored Hob-O	0		Effect: "Rave Nirvana", Effect Duration: 22
 3424	altered fry-oil-flavored Hob-O	0		Effect: "Incredibly Hulking", Effect Duration: 57
 3425	liquefied tarnished extra-deionized skewed garbage-juice-flavored Hob-O	0		Effect: "Human-Slime Hybrid", Effect Duration: 49
-3426	quadruple-colloidal tumbling blinking strawberry-flavored Hob-O	0		Effect: "Puddingskin", Effect Duration: 68
+3426	quadruple-colloidal blinking tumbling strawberry-flavored Hob-O	0		Effect: "Puddingskin", Effect Duration: 68
 3427	roll of Hob-Os	0		
 3428	concentrated galvanized mirror Everlasting Deckswabber	0		Effect: "Wet Jaw", Effect Duration: 48
 3430	bindle of joy	0		
@@ -3404,7 +3404,7 @@
 3437	gray narrow up-at-dawn rosewater-soaked deadly Staff of the Black Kettle	0		Weapon Damage: +5, Stench Resistance: +3, Adventures: +5
 3438	fireproof razor-sharp Staff of the Well-Tempered Cauldron of the sewer	0		Weapon Damage Percent: +25, Stench Damage: +25, Hot Resistance: +3
 3439	Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	diluted skewed fuchsia prismatic wad	1	EPIC	Effect: "Pumped Up", Effect Duration: 40, Last Available: "2008-07"
+3440	diluted fuchsia skewed prismatic wad	1	EPIC	Effect: "Pumped Up", Effect Duration: 40, Last Available: "2008-07"
 3441	huge cyan club of the five seasons of the cheetah	0		Initiative: +60, Last Available: "2008-07"
 3442	spinning groovy rainbow crossbow	0		Moxie Percent: +10, Last Available: "2008-07"
 3443	kitten	0		
@@ -3423,17 +3423,17 @@
 3456	huge sage trusty torch	0		Mysticality Percent: +10, Last Available: "2011-12"
 3457	arcane researcher's Junior Adventurer's merit badge	0		Experience Percent (Mysticality): +10
 3458	galvanized skewed STYX deodorant body spray	0		Effect: "Smokin'", Effect Duration: 33
-3459	aged weak white-label gin	2	awesome	
-3460	decent small tin rations	2	good	
+3459	weak aged white-label gin	2	awesome	
+3460	small decent tin rations	2	good	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
 3463	special drinkable purple bottle of sake	4	good	Effect: "Unrunnable Face", Effect Duration: 15
 3464	occult round pebble	0		Spell Damage Percent: +25
 3465	decent Bash-&#332;s cereal	3	good	Wiki Name: "Bash-Os cereal"
-3466	family-friendly deadly Socratic haiku katana	0		Experience (Mysticality): +1, Weapon Damage: +5, Sleaze Resistance: +1, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	family-friendly deadly Socratic haiku katana	0		Experience (Mysticality): +1, Weapon Damage: +5, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	plastic baby of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2008-12"
-3469	super-sized flavorless blueberry-frosted king cake	5	decent	Last Available: "2008-12"
+3469	flavorless super-sized blueberry-frosted king cake	5	decent	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	mirror damp boot	0		
 3472	squat auspicious ribald personal trainer's Seasonal Beret	0		Experience Percent (Muscle): +10, Sleaze Damage: +10, Item Drop: +10, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3453,7 +3453,7 @@
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	ghostly pristine fish scale	0		
-3489	miniature adequate beefy fish meat	2	good	Effect: "Fishy", Effect Duration: 5
+3489	adequate miniature beefy fish meat	2	good	Effect: "Fishy", Effect Duration: 5
 3490	adequate glistening fish meat	3	good	Effect: "Fishy", Effect Duration: 5
 3491	bland blurry slick fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3492	perfumed grievous fish scimitar	0		Weapon Damage Percent: +50, Stench Resistance: +5
@@ -3465,13 +3465,13 @@
 3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3499	lime green skewed witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3500	maroon beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3501	stale huge fancy huge canap&eacute;s	6	decent	Effect: "Litterboxing", Effect Duration: 25
+3501	fancy stale huge huge canap&eacute;s	6	decent	Effect: "Litterboxing", Effect Duration: 25
 3502	compressed bouncing thermos of brew	1	EPIC	Effect: "Stands Alone", Effect Duration: 35, Last Available: "2011-12"
 3503	drinkable huge glass of brandy	4	good	Last Available: "2011-12"
 3504	French slippers	0		
 3505	LWA ring of the businessman	0		Meat Drop: +50
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	beefcake's scratch 'n' sniff sword	0		Muscle: +25, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3498,7 +3498,7 @@
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	shaking cactus monocle	0		Familiar Weight: +5
-3534	purple mirror Jawmaster 2000&trade;	0		Familiar Weight: +5
+3534	mirror purple Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	pulsating plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
@@ -3519,7 +3519,7 @@
 3552	frosty hale weightlifter's octopus's spade	0		Muscle: +15, Maximum HP: +20, Cold Spell Damage: +10
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	snack-sized bland squat red sea carrot	2	decent	
+3555	bland snack-sized red squat sea carrot	2	decent	
 3556	flavorless massive sea cucumber	10	decent	
 3557	miniature stale red tumbling sea avocado	2	decent	
 3558	stale sea lychee	4	decent	
@@ -3530,7 +3530,7 @@
 3563	colloidal energized blue pressurized potion of pulchritude	0		Effect: "Soles of Glass", Effect Duration: 22
 3564	tolerable red berry-infused sake	4	good	
 3565	delicious weak yellow citrus-infused sake	2	awesome	
-3566	mediocre watered-down melon-infused sake	2	decent	
+3566	watered-down mediocre melon-infused sake	2	decent	
 3567	slab of sponge	0		
 3568	narrow dangerous sponge helmet of the empath of the blizzard	0		Weapon Damage: +10, Familiar Weight: +5, Cold Spell Damage: +25, Familiar Effect: "atk, 1xFairy"
 3569	blue rosy-cheeked occult brawny spongy shield	0		Muscle Percent: +20, Spell Damage Percent: +25, Maximum HP Percent: +30, Damage Reduction: 14
@@ -3567,12 +3567,12 @@
 3601	cyan compass of the dark arts	0		Spell Damage Percent: +100
 3602	wobbly broken diving helmet	0		
 3603	porthole	0		
-3604	bouncing upside-down rivet	0		
+3604	upside-down bouncing rivet	0		
 3605	bubblin' stone	0		
 3606	Usain Bolt's manspreader's diving helmet of Gandalf	0		Spell Critical Percent: +20, Monster Level: +10, Initiative: +80, Familiar Effect: "0.5xPotato"
 3607	sizzling curative smooth aerated diving helmet	0		Moxie: +15, Hot Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	live nautical mine	0		
-3609	twirling red das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
+3609	red twirling das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	jittery imitation whetstone	0		
 3611	warmed quadruple-adjusted wobbly sea grease	0		Effect: "Feroci Tea", Effect Duration: 54
 3612	upside-down sturdy Crimbo crate	0		Last Available: "2008-12"
@@ -3581,7 +3581,7 @@
 3615	pulsating rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	flattened galvanized polymerized upside-down unstable DNA	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 24, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	cyan wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	red pair of twitching claws	0		Last Available: "2008-12"
@@ -3595,7 +3595,7 @@
 3629	jittery burrowgrub hive	0		Last Available: "2008-12"
 3630	Crimbo crate	0		Last Available: "2008-12"
 3631	quantum jittery Gummi-DNA	0		Effect: "Cold Blooded", Effect Duration: 45, Last Available: "2020-09"
-3632	twirling upside-down radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
+3632	upside-down twirling radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	squat squat elven socks of the bloodbag of Flo-Jo	0		Maximum HP: +100, Initiative: +100, Last Available: "2008-12"
 3634	executive chaotic elven gloves	0		Spell Critical Percent: +10, Meat Drop: +40, Last Available: "2008-12"
 3635	nippy festive holiday hat of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +10, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
@@ -3613,10 +3613,10 @@
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	jittery magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	yummy snack-sized squat toast with jam	2	awesome	Last Available: "2008-12"
-3651	squat antlers	0		Familiar Weight: +4, Last Available: "2008-12"
-3652	weak mediocre elven moonshine	2	decent	Last Available: "2008-12"
-3653	normal knuckle sandwich	4	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3650	snack-sized yummy squat toast with jam	2	awesome	Last Available: "2008-12"
+3651	squat antlers	0		Familiar Weight: +5, Last Available: "2008-12"
+3652	mediocre weak elven moonshine	2	decent	Last Available: "2008-12"
+3653	normal knuckle sandwich	4	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	hardy shellacked psycho sweater	0		Damage Reduction: 7, Maximum HP: +50, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	blurry green friendly plastic Mob Penguin	0		Familiar Weight: +3, Last Available: "2008-12"
@@ -3654,7 +3654,7 @@
 3688	moldy sea cauliflower	3	crappy	
 3689	bland pulsating tempura broccoli	3	decent	
 3690	flavorless bouncing tempura cauliflower	3	decent	
-3691	spoiled snack-sized sea blueberry	2	crappy	
+3691	snack-sized spoiled sea blueberry	2	crappy	
 3692	flavorless sea persimmon	4	decent	
 3693	ionized dry pressurized potion of perception	0		Effect: "Very Clean Guns", Effect Duration: 24
 3694	nitrogenated pressurized potion of proficiency	0		Effect: "[1701]Hip to the Jive", Effect Duration: 17
@@ -3691,7 +3691,7 @@
 3725	foggy glass globe	0		
 3726	blurry possessed tomato	0		
 3727	Nardz energy beverage	0		
-3728	wobbly skewed pile of coins	0		
+3728	skewed wobbly pile of coins	0		
 3729	squat hand grenegg	0		
 3730	blurry caret	0		
 3731	wicked glass gnoll eye	0		Spell Damage: +5
@@ -3701,10 +3701,10 @@
 3735	fat wallet	0		
 3736	pulsating greedy handwarmer of the bloodbag	0		Maximum HP: +100, Meat Drop: +20, Single Equip
 3737	lightning-fast weightlifter's lighter	0		Muscle: +15, Initiative: +40
-3738	tasty thick packet of beer nuts	5	awesome	
+3738	thick tasty packet of beer nuts	5	awesome	
 3739	Boozehounds Anonymous token	0		
 3740	teal handful of bees	0		
-3741	huge bouncing spectral jelly	0		
+3741	bouncing huge spectral jelly	0		
 3742	dry jellyfish gel	0		Effect: "Dilated Pupils", Effect Duration: 43
 3743	narrow unstable quark	0		
 3744	software glitch	0		
@@ -3714,7 +3714,7 @@
 3749	electrified deionized pulsating concoction of clumsiness	0		Effect: "Aries Rising", Effect Duration: 53
 3750	energetic vampire pearl earring	0		Maximum MP Percent: +20, Single Equip
 3751	bland diet chocolate chip brownies	1	decent	
-3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	cold-filtered jittery love song of vague ambiguity	0		Effect: "Adorable Lookout", Effect Duration: 39, Last Available: "2009-02"
 3755	activated squat love song of smoldering passion	0		Effect: "Blood-Rich", Effect Duration: 24, Last Available: "2009-02"
 3756	improved olive love song of icy revenge	0		Effect: "Glo-Face", Effect Duration: 62, Last Available: "2009-02"
@@ -3724,14 +3724,14 @@
 3760	activated denatured breath mint	0		Effect: "Leo Rising", Effect Duration: 47
 3761	baleful vampire pearl ring	0		Spell Damage: +25, Single Equip
 3762	sizzling vampire pearl necklace	0		Hot Damage: +10, Single Equip
-3763	distilled bad slug of vodka	5	decent	
-3764	weak lousy bouncing red slug of rum	2	decent	
+3763	bad distilled slug of vodka	5	decent	
+3764	lousy weak red bouncing slug of rum	2	decent	
 3765	tolerable slug of shochu	3	good	
-3766	watered-down aged spinning screwdiver	2	awesome	
+3766	aged watered-down spinning screwdiver	2	awesome	
 3767	irresponsibly strong lousy dew yoana lei	9	decent	
 3768	enchanted acceptable mirror lychee chuhai	3	good	Effect: "Nutrient-Rich", Effect Duration: 5
 3769	hand-crafted shaking salacious screwdiver	3	EPIC	
-3770	watered-down tolerable dew yoana salacious lei	2	good	
+3770	tolerable watered-down dew yoana salacious lei	2	good	
 3771	smooth narrow salacious lychee chuhai	3	awesome	
 3772	weak mediocre fancy narrow squat Alewife&trade; Ale	2	decent	Effect: "Boo Tea", Effect Duration: 40
 3773	seaode	0		
@@ -3745,7 +3745,7 @@
 3781	blank prescription sheet	0		
 3782	distilled bottle of melodramamine	1		
 3783	powdered bottle of extra-strength melodramamine	1		Effect: "Vitali Tea", Effect Duration: 30
-3784	jittery tumbling paranormal ricotta	0		Class: "Pastamancer"
+3784	tumbling jittery paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
 3787	spinning wine-soaked bone chips	0		Class: "Pastamancer"
@@ -3754,7 +3754,7 @@
 3799	teal squat Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
 3801	upside-down crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	tumbling maroon charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3802	maroon tumbling charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	narrow ghostly huge stiffened Mer-kin roundshield of terror of mayonnaise	0		Damage Reduction: 15, Spooky Spell Damage: +10, Sleaze Spell Damage: +50
 3804	foul-smelling chaotic Mer-kin breastplate	0		Spell Critical Percent: +10, Stench Damage: +10
 3805	shaking Sherlock's Mer-kin sneakmask of the empath	0		Familiar Weight: +5, Item Drop: +25, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3764,7 +3764,7 @@
 3809	olive Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	enchanted big spoiled chocolate-frosted king cake	5	crappy	Effect: "Big Ol' Glass of Rum", Effect Duration: 30, Last Available: "2009-06"
+3812	spoiled big enchanted chocolate-frosted king cake	5	crappy	Effect: "Big Ol' Glass of Rum", Effect Duration: 30, Last Available: "2009-06"
 3813	groovy plastic baby	0		Moxie Percent: +10, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
@@ -3780,14 +3780,14 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	ghostly plastic oyster egg	0		
 3828	jittery Grandma's Map	0		
-3829	snack-sized stale tempura radish	2	decent	
+3829	stale snack-sized tempura radish	2	decent	
 3830	water-polo cap of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xVolley, 1xBarrr"
 3831	perfectly mixed Typical Tavern swill	3	EPIC	
 3832	tolerable tropical swill	3	good	
-3833	practically non-alcoholic bad fruity girl swill	1	decent	
+3833	bad practically non-alcoholic fruity girl swill	1	decent	
 3834	acceptable blended swill	3	good	
 3835	huge costume wardrobe	0		Softcore Only
-3836	upside-down double-paned fortified Elvish sunglasses of the cougar of the sweet-tooth	0		Moxie: +20, Damage Absorption: +60, Cold Resistance: +5, Candy Drop: +100, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	upside-down double-paned fortified Elvish sunglasses of the cougar of the sweet-tooth	0		Moxie: +20, Damage Absorption: +60, Cold Resistance: +5, Candy Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	skewed shaking anniversary safety glass vest of James Dean	0		Experience (Moxie): +3
 3838	narrow Jack Frost's anniversary burlap belt	0		Cold Spell Damage: +50
 3839	therapeutic anniversary balsa wood socks	0		HP Regen Min: 5, HP Regen Max: 7
@@ -3830,7 +3830,7 @@
 3876	hellseal brain	0		
 3877	burst hellseal brain	0		
 3878	hellseal sinew	0		
-3879	narrow ghostly torn hellseal sinew	0		
+3879	ghostly narrow torn hellseal sinew	0		
 3880	hellseal disguise	0		
 3881	upside-down miser's fouet de tortue-dressage of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +10, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	huge encoded cult documents	0		
@@ -3885,7 +3885,7 @@
 3933	Tesla slick bad-ass club	0		Moxie: +10, MP Regen Min: 7, MP Regen Max: 10, Class: "Seal Clubber"
 3934	olive sealbone	0		
 3935	colloidal corrupted skewed hyperinflated seal lung	0		Effect: "Bonelording", Effect Duration: 22
-3936	activated ghostly purple scrap of shadow	0		Effect: "Strange Mental Acuity", Effect Duration: 15
+3936	activated purple ghostly scrap of shadow	0		Effect: "Strange Mental Acuity", Effect Duration: 15
 3937	non-deionized fustulent seal grulch	0		Effect: "Red Misty-Eyed", Effect Duration: 18
 3938	sinister club of corruption	0		Spell Damage: +10, Class: "Seal Clubber"
 3939	bouncing censurious corrupt club of corruption	0		Sleaze Resistance: +3, Class: "Seal Clubber"
@@ -3895,7 +3895,7 @@
 3943	clever forbidden infernal toilet brush	0		Spell Damage Percent: +50, Maximum MP: +20, Class: "Seal Clubber"
 3944	teal coward's strapping shadowy seal eye	0		Muscle: +5, Monster Level: -20, Class: "Seal Clubber"
 3945	curative oyster egg balloon	0		HP Regen Min: 3, HP Regen Max: 5
-3946	blurry cyan skewed Clan VIP Lounge invitation	0		Free Pull
+3946	cyan skewed blurry Clan VIP Lounge invitation	0		Free Pull
 3947	Clan VIP Lounge key	0		Free Pull
 3948	Meat	0		
 3949	treasure chest	0		
@@ -3952,7 +3952,7 @@
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	dehydrated agua de vida	1	decent	Last Available: "2009-06"
 4002	jittery family-friendly mansplainer's tortoboggan shield	0		Monster Level: +15, Sleaze Resistance: +1, Damage Reduction: 6
-4003	blinking blurry bottle of moontan lotion	0		
+4003	blurry blinking bottle of moontan lotion	0		
 4004	Sherlock's soup-chucks	0		Item Drop: +25
 4005	adjusted blurry ballast turtle	0		Effect: "Sated and Furious", Effect Duration: 44
 4006	ghostly memory of some amino acids	0		Last Available: "2009-06"
@@ -3979,7 +3979,7 @@
 4027	red jittery Rosewater's greaves of the pedagogue of chilblains	0		Mysticality Percent: +30, Experience: +3, Cold Damage: +25, Familiar Effect: "sleaze atk, 0.5xBarrr"
 4028	hardened studded club of the cheetah	0		Damage Absorption: +80, Damage Reduction: 3, Initiative: +60
 4029	memory of a grappling hook	0		Last Available: "2009-06"
-4030	teal twirling memory of a small stone block	0		Last Available: "2009-06"
+4030	twirling teal memory of a small stone block	0		Last Available: "2009-06"
 4031	bouncing memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
 4033	red memory of a stone half-circle	0		Last Available: "2009-06"
@@ -3987,8 +3987,8 @@
 4035	purple memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
 4037	decent slimy sweetbreads	4	good	
-4038	acceptable weak pulsating slimy fermented bile bladder	2	good	
-4039	twisted skewed tumbling slimy alveolus	1		
+4038	weak acceptable pulsating slimy fermented bile bladder	2	good	
+4039	twisted tumbling skewed slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	Da Vinci's Socratic pig-iron helm	0		Experience (Mysticality): 6, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
 4042	avaricious auspicious pig-iron shinguards	0		Item Drop: +10, Meat Drop: +30, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
@@ -4034,7 +4034,7 @@
 4082	chaotic pernicious cudgel of the bloodbag	0		Maximum HP: +100, Spell Critical Percent: +10, Slime Hates It: +1
 4083	normal cupcake-in-a-cup	4	good	Last Available: "2009-06"
 4084	wobbly pool of liquid	0		Last Available: "2009-06"
-4085	gigantic normal protein paste	6	good	Last Available: "2009-06"
+4085	normal gigantic protein paste	6	good	Last Available: "2009-06"
 4086	coward's cyber-mattock of the cheetah	0		Monster Level: -20, Initiative: +60, Last Available: "2009-06"
 4087	mirror facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4063,7 +4063,7 @@
 4111	spinning sinister smartaleck's brazen bracelet	0		Moxie Percent: +30, Spell Damage: +10, Last Available: "2009-06"
 4112	mansplainer's bitter bowtie of the empath	0		Monster Level: +15, Familiar Weight: +5, Last Available: "2009-06"
 4113	frosty bewitching boots	0		Cold Spell Damage: +10, Last Available: "2009-06"
-4114	bouncing squat secret from the future	0		Last Available: "2009-06"
+4114	squat bouncing secret from the future	0		Last Available: "2009-06"
 4115	tumbling moist sack	0		
 4116	perfumed aromatic hale rickety unicycle	0		Maximum HP: +20, Stench Resistance: 6, Single Equip
 4117	twirling zippy stiffened crusty hula hoop of wisdom	0		Mysticality: +15, Damage Reduction: 1, Initiative: +20, Single Equip
@@ -4085,7 +4085,7 @@
 4133	unsweetened tumbling tempura air	0		Effect: "Cold Jellied", Effect Duration: 15
 4134	ionized spinning pressurized potion of pneumaticity	0		Effect: "Tapped In", Effect Duration: 53
 4135	bouncing moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	zippy gravedigger's Oprah's Bag o' Tricks of the pedagogue	0		Experience: +3, Maximum MP Percent: +50, Spooky Damage: +10, Initiative: +20, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	zippy gravedigger's Oprah's Bag o' Tricks of the pedagogue	0		Experience: +3, Maximum MP Percent: +50, Spooky Damage: +10, Initiative: +20, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	jittery slime stack	0		
 4138	pulsating a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4095,13 +4095,13 @@
 4143	a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	wobbly Oprah's funny paper hat	0		Maximum MP Percent: +50, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	colloidal concentrated ionized blurry spinning sand	0		Effect: "Mo' Hobo", Effect Duration: 48
+4146	colloidal concentrated ionized spinning blurry sand	0		Effect: "Mo' Hobo", Effect Duration: 48
 4147	yellow rosy-cheeked wizardly charged magnet	0		Mysticality: +25, Maximum HP Percent: +30, Last Available: "2009-09"
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	ghostly quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	shaking lint	0		Last Available: "2011-12"
 4151	modified quantum dubious peppermint	0		Effect: "Sleazy Weapon", Effect Duration: 12, Last Available: "2020-09"
-4152	nitrogenated extra-tarnished pulsating spinning Elvish delight	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 25
+4152	nitrogenated extra-tarnished spinning pulsating Elvish delight	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 25
 4153	spinning rockfish stomach	0		Last Available: "2009-09"
 4154	bouncing live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
@@ -4109,7 +4109,7 @@
 4157	bouncing gravel	0		Last Available: "2009-09"
 4158	mirror rock	0		Last Available: "2009-09"
 4159	blurry rock lobster	0		Last Available: "2009-09"
-4160	weak lousy pebblebr&auml;u	2	decent	Last Available: "2009-09"
+4160	lousy weak pebblebr&auml;u	2	decent	Last Available: "2009-09"
 4161	toothsome pulsating rocky road ice cream	3	awesome	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	dry super-alkaline upside-down children of the candy corn	0		Effect: "Bandersnatched", Effect Duration: 17
@@ -4126,7 +4126,7 @@
 4174	rock necklace of the sweet-tooth	0		Candy Drop: +100, Single Equip
 4175	spaghetti cult robe	0		
 4176	blurry sugar sheet	0		Last Available: "2009-09"
-4177	pulsating blinking Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
+4177	blinking pulsating Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	lime green mirror sugar shotgun of bravery	0		Spooky Resistance: +5, Last Available: "2009-09"
 4179	weightlifter's sugar shillelagh	0		Muscle: +15, Last Available: "2009-09"
 4180	savvy sugar shank	0		Mysticality Percent: +20, Last Available: "2009-09"
@@ -4169,9 +4169,9 @@
 4217	groupie bra	0		
 4218	vacuum-sealed altered ghostly groupie spangles	0		Effect: "Sweet, Nuts", Effect Duration: 58
 4219	knitted beefcake's skate board	0		Muscle: +25, Cold Resistance: +3
-4220	skewed wobbly pulsating S.A.V.E. flyer	0		
+4220	wobbly skewed pulsating S.A.V.E. flyer	0		
 4221	yield shield of the scaredy-cat	0		Monster Level: -15, Damage Reduction: 6, Last Available: "2009-09"
-4222	shaking green map to the Skate Park	0		
+4222	green shaking map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	spinning blinking roller skate doll	0		
@@ -4196,9 +4196,9 @@
 4244	frightening leather-bound tome	0		Spooky Damage: +5
 4245	bookmark	0		
 4246	ivory cue ball of the sewer	0		Stench Damage: +25
-4247	hand-crafted high-proof huge decanter of fine Scotch	9	EPIC	
+4247	high-proof hand-crafted huge decanter of fine Scotch	9	EPIC	
 4248	modified cyan blinking expensive cigar	1		Effect: "Jacked In", Effect Duration: 25
-4249	bouncing red tophat	0		Familiar Weight: +5
+4249	red bouncing tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	energized double-ionized skewed tumbling vial of squid ink	0		Effect: "Gamer Rage", Effect Duration: 44
@@ -4206,9 +4206,9 @@
 4254	jittery bark	0		Last Available: "2009-10"
 4255	jittery Wolfman Nardz	0		Last Available: "2009-10"
 4256	tarnished energized extra-warmed blue sap	0		Effect: "Punch Another Day", Effect Duration: 42, Last Available: "2009-10"
-4257	green skewed petrified wood	0		Last Available: "2009-10"
-4258	tiny toothsome chocolate-covered scarab beetle	1	awesome	Last Available: "2009-10"
-4259	fancy aged wobbly mulled cider	4	awesome	Effect: "You Read The Manual", Effect Duration: 20, Last Available: "2009-10"
+4257	skewed green petrified wood	0		Last Available: "2009-10"
+4258	toothsome tiny chocolate-covered scarab beetle	1	awesome	Last Available: "2009-10"
+4259	aged fancy wobbly mulled cider	4	awesome	Effect: "You Read The Manual", Effect Duration: 20, Last Available: "2009-10"
 4260	ghostly wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	wobbly pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4222,7 +4222,7 @@
 4270	Newman's Own Trousers of Calamity Jane of Flo-Jo	0		Critical Hit Percent: +15, Initiative: +100, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato, cap 31"
 4271	narrow Tesla wizardly Volartta's bellbottoms	0		Mysticality: +25, MP Regen Min: 7, MP Regen Max: 10, Class: "Disco Bandit", Familiar Effect: "1xPotato, 1.5xFairy, cap 31"
 4272	fortified savvy Lederhosen of the Night	0		Mysticality Percent: +20, Damage Absorption: +60, Class: "Accordion Thief", Familiar Effect: "atk, 2xGhuol, cap 31"
-4273	colloidal denatured frozen jittery teal ribbon candy	0		Effect: "Preemptive Medicine", Effect Duration: 26, Last Available: "2020-09"
+4273	colloidal denatured frozen teal jittery ribbon candy	0		Effect: "Preemptive Medicine", Effect Duration: 26, Last Available: "2020-09"
 4274	Underworld acorn	0		Free Pull, Last Available: "2009-10"
 4275	Underworld trunk	0		Last Available: "2009-10"
 4276	upside-down Jeselnik's toasty Underworld truncheon of the detective	0		Hot Damage: +5, Sleaze Damage: +25, Item Drop: +20, Last Available: "2009-10"
@@ -4245,7 +4245,7 @@
 4293	rosy-cheeked Mer-kin dragnet of the brute of extreme caution	0		Muscle Percent: +30, Maximum HP Percent: +30, Monster Level: -25, Conditional Skill (Equipped): "Net Gain", Conditional Skill (Equipped): "Net Loss", Conditional Skill (Equipped): "Net Neutrality"
 4294	cyan shaking flame-retardant nasty Samson's Mer-kin switchblade	0		Experience (Muscle): +5, Stench Damage: +5, Hot Resistance: +1, Conditional Skill (Equipped): "Blade Sling", Conditional Skill (Equipped): "Blade Roller", Conditional Skill (Equipped): "Blade Runner"
 4295	crystal orb of spirit wrangling	0		
-4296	huge blinking depleted uranium seal figurine	0		
+4296	blinking huge depleted uranium seal figurine	0		
 4297	lard-coated stanky padded Ass-Stompers of Violence	0		Damage Absorption: +20, Stench Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	family-friendly Jeselnik's Jim Carey's Brand of Violence	0		Monster Level: +25, Sleaze Damage: +25, Sleaze Resistance: +1, Conditional Skill (Equipped): "Brand"
 4299	tumbling curative extremely unsafe Sinatra's Novelty Belt Buckle of Violence	0		Experience (Moxie): +5, Weapon Damage Percent: +100, HP Regen Min: 3, HP Regen Max: 5, Single Equip
@@ -4290,7 +4290,7 @@
 4338	plastic Don Crimbo of Gandalf	0		Spell Critical Percent: +20, Last Available: "2009-12"
 4339	toasty plastic Crimbomination	0		Hot Damage: +5, Last Available: "2009-12"
 4340	nitrogenated dry Piddles	0		Effect: "Alacri Tea", Effect Duration: 68, Last Available: "2009-12"
-4341	adjusted ghostly yellow BitterSweetTarts	0		Effect: "Pork Power", Effect Duration: 13, Last Available: "2009-12"
+4341	adjusted yellow ghostly BitterSweetTarts	0		Effect: "Pork Power", Effect Duration: 13, Last Available: "2009-12"
 4342	ionized spinning Polka Pop	0		Effect: "Human-Beast Hybrid", Effect Duration: 32, Last Available: "2009-12"
 4343	purple Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
@@ -4305,17 +4305,17 @@
 4353	Crimbough	0		Last Available: "2009-12"
 4354	squat A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	maroon A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
-4356	shaking red A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
+4356	red shaking A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	blinking A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	rotten expired can of franks 'n' beans	4	crappy	Last Available: "2009-12"
-4361	drinkable fortified shaking expired bottle of peppermint schnapps	5	good	Last Available: "2009-12"
+4361	fortified drinkable shaking expired bottle of peppermint schnapps	5	good	Last Available: "2009-12"
 4362	huge snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	quantum chilled olive elven suicide capsule	0		Effect: "Stuck-Up Hair", Effect Duration: 59, Last Available: "2009-12"
 4365	rotten twirling penguin focaccia bread	3	crappy	Last Available: "2009-12"
-4366	aged strong herringcello	5	awesome	Last Available: "2009-12"
+4366	strong aged herringcello	5	awesome	Last Available: "2009-12"
 4367	drinkable bouncing elven cellocello	3	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	beefy peanut brittle shield	0		Muscle: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	foul-smelling flame-wreathed Red Rover BB gun	0		Hot Spell Damage: +10, Stench Damage: +10, Last Available: "2009-12"
-4391	Annie Oakley's red-and-green sweater	0		Critical Hit Percent: +20, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	Annie Oakley's red-and-green sweater	0		Critical Hit Percent: +20, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	magnetized twirling Crimbo peppermint bark	0		Effect: "Bloodstain-Resistant", Effect Duration: 18, Last Available: "2009-12"
 4394	frozen squat lime green Crimbo fudge	0		Effect: "Strong Grip", Effect Duration: 42, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	twirling cheese sword	0		Item Drop: +5, Softcore Only, Last Available: "2010-01"
 4400	skewed cheese diaper of the dark arts	0		Spell Damage Percent: +100, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	Socratic cheese wheel	0		Experience (Mysticality): +1, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	wholesome cheese eye	0		Maximum HP Percent: +10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	wholesome cheese eye	0		Maximum HP Percent: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	frightening lion tamer's careful Staff of Queso Escusado	0		Monster Level: -10, Experience (familiar): +2, Spooky Damage: +5, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4380,7 +4380,7 @@
 4430	dangerous teddybear backpack	0		Weapon Damage: +10
 4431	NPZR chemistry set	0		Last Available: "2011-08"
 4432	deionized invisibility potion	0		Effect: "Become Intensely interested", Effect Duration: 68, Last Available: "2011-08"
-4433	alkaline teal huge irresistibility potion	0		Effect: "Weasels Underfoot", Effect Duration: 13, Last Available: "2011-08"
+4433	alkaline huge teal irresistibility potion	0		Effect: "Weasels Underfoot", Effect Duration: 13, Last Available: "2011-08"
 4434	moist wet irritability potion	0		Effect: "Adrenaline Rush", Effect Duration: 37, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
@@ -4393,7 +4393,7 @@
 4445	sizzling spangly mariachi pants	0		Hot Damage: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	banded arcane researcher's spangly mariachi vest	0		Experience Percent (Mysticality): +10, Damage Absorption: +100
 4447	spinning crafty spangly sombrero	0		Maximum MP: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	vaporized huge blinking Instant Karma	1	good	Effect: "Disco State of Mind", Effect Duration: 35
+4448	vaporized blinking huge Instant Karma	1	good	Effect: "Disco State of Mind", Effect Duration: 35
 4449	huge painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	healthy pointy hat	0		Maximum HP Percent: +20, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
@@ -4413,7 +4413,7 @@
 4465	adjusted chocolate saucepan	0		Effect: "Dreadful Sheen", Effect Duration: 22
 4466	extra-denatured nitrogenated tumbling chocolate disco ball	0		Effect: "Thought", Effect Duration: 19
 4467	extra-liquefied blinking chocolate stolen accordion	0		Effect: "In the Saucestream", Effect Duration: 50
-4468	pulsating Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	pulsating Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	mirror BRICKO eye brick	0		Last Available: "2010-02"
 4471	squat foul-smelling BRICKO hat	0		Stench Damage: +10, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
@@ -4424,7 +4424,7 @@
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	ghostly BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	blue BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4436,7 +4436,7 @@
 4488	maroon BRICKO trunk	0		Last Available: "2010-02"
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
-4491	upside-down green BRICKO brick	0		Last Available: "2010-02"
+4491	green upside-down BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
 4493	broken BRICKO brick	0		Last Available: "2010-02"
 4494	BRICKO reactor	0		Last Available: "2010-02"
@@ -4445,7 +4445,7 @@
 4497	wet recording of The Ballad of Richie Thingfinder	0		Effect: "Engorged Weapon", Effect Duration: 37
 4498	Vulcanized recording of Benetton's Medley of Diversity	0		Effect: "Hot Hands", Effect Duration: 33
 4499	moist altered olive recording of Elron's Explosive Etude	0		Effect: "Deadly Flashing Blade", Effect Duration: 12
-4500	double-liquefied tumbling jittery recording of Chorale of Companionship	0		Effect: "Lobos Fresh", Effect Duration: 32
+4500	double-liquefied jittery tumbling recording of Chorale of Companionship	0		Effect: "Lobos Fresh", Effect Duration: 32
 4501	anodized wobbly recording of Prelude of Precision	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 13
 4502	pickled magnetized quantum pulsating recording of Donho's Bubbly Ballad	0		Effect: "The Power of Negative Thinking", Effect Duration: 34
 4503	adjusted ghostly twirling recording of Inigo's Incantation of Inspiration	0		Effect: "Thunderheart", Effect Duration: 28, Last Available: "2010-02"
@@ -4455,14 +4455,14 @@
 4507	pulsating Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	warmed &quot;DRINK ME&quot; potion	0		Effect: "Fizzier Than Light", Effect Duration: 63, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	rotten miniature special walrus ice cream	2	crappy	Effect: "Flashing Eyes", Effect Duration: 30, Last Available: "2010-03"
-4511	enchanted diet flavorless beautiful soup	1	decent	Effect: "Aspect of the Twinklefairy", Effect Duration: 50, Last Available: "2010-03"
-4512	lime green tumbling bouncing eggman noodles	0		Last Available: "2010-03"
-4513	twirling blurry Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
+4510	rotten special miniature walrus ice cream	2	crappy	Effect: "Flashing Eyes", Effect Duration: 30, Last Available: "2010-03"
+4511	flavorless enchanted diet beautiful soup	1	decent	Effect: "Aspect of the Twinklefairy", Effect Duration: 50, Last Available: "2010-03"
+4512	bouncing lime green tumbling eggman noodles	0		Last Available: "2010-03"
+4513	blurry twirling Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	normal gigantic Humpty Dumplings	8	good	Last Available: "2010-03"
-4515	huge normal Lobster <i>qua</i> Grill	10	good	Last Available: "2010-03"
-4516	delicious strong missing wine	5	awesome	Last Available: "2010-03"
-4517	rotten snack-sized fancy gray matter custard	2	crappy	Effect: "Big Punkin'", Effect Duration: 20, Last Available: "2010-03"
+4515	normal huge Lobster <i>qua</i> Grill	10	good	Last Available: "2010-03"
+4516	strong delicious missing wine	5	awesome	Last Available: "2010-03"
+4517	rotten fancy snack-sized gray matter custard	2	crappy	Effect: "Big Punkin'", Effect Duration: 20, Last Available: "2010-03"
 4518	extra-concentrated denatured comfit?	0		Effect: "Shawarma Initiative", Effect Duration: 15, Last Available: "2010-03"
 4519	wobbly ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	skewed huge lard-coated flamingo mallet of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +25, Last Available: "2010-03"
@@ -4476,8 +4476,8 @@
 4528	rotten massive twirling dragon snaps	7	crappy	Last Available: "2010-03"
 4529	skewed Oprah's snapdragon pistil of the storm	0		Maximum MP Percent: 90, Last Available: "2010-03"
 4530	tumbling puff of smoke	0		Last Available: "2010-03"
-4531	moldy diet skewed tumbling rook cookie	1	crappy	Last Available: "2010-03"
-4532	enchanted decent lime green bishop cookie	3	good	Effect: "Disco Concentration", Effect Duration: 20, Last Available: "2010-03"
+4531	diet moldy tumbling skewed rook cookie	1	crappy	Last Available: "2010-03"
+4532	decent enchanted lime green bishop cookie	3	good	Effect: "Disco Concentration", Effect Duration: 20, Last Available: "2010-03"
 4533	adequate tumbling knight cookie	4	good	Last Available: "2010-03"
 4534	normal twirling king cookie	3	good	Last Available: "2010-03"
 4535	immense spoiled queen cookie	9	crappy	Effect: "Towering Strength", Last Available: "2010-03"
@@ -4508,28 +4508,28 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	weak hand-crafted world's most unappetizing beverage	2	EPIC	Last Available: "2010-04"
+4563	hand-crafted weak world's most unappetizing beverage	2	EPIC	Last Available: "2010-04"
 4564	weightlifter's slippery when wet shield	0		Muscle: +15, Damage Reduction: 6, Last Available: "2010-04"
 4565	flavorless skewed raisin	3	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	flame-retardant smartaleck's flyest of shirts	0		Moxie Percent: +30, Hot Resistance: +1, Last Available: "2010-04"
 4568	enchanted huge normal a dance upon the palate	9	good	Effect: "Turkey-Ambitious", Effect Duration: 40, Last Available: "2010-04"
-4569	toothsome immense special prehistoric meteorite jawbreaker	8	awesome	Effect: "Abyssal Tears", Effect Duration: 40, Last Available: "2010-04"
+4569	special immense toothsome prehistoric meteorite jawbreaker	8	awesome	Effect: "Abyssal Tears", Effect Duration: 40, Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	bland special red squirmy violent party snack	3	decent	Effect: "Chlorophyll Flavor", Effect Duration: 15, Last Available: "2010-04"
+4571	special bland red squirmy violent party snack	3	decent	Effect: "Chlorophyll Flavor", Effect Duration: 15, Last Available: "2010-04"
 4572	Samson's can-you-dig-it?	0		Experience (Muscle): +5, Last Available: "2010-04"
 4573	twirling The Legendary Beat	0		Last Available: "2010-04"
 4574	maroon panicked kernel	0		Free Pull, Last Available: "2010-04"
-4575	bouncing gray bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4575	gray bouncing bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	activated Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Stimulated Brain", Effect Duration: 40, Last Available: "2010-04"
 4580	blinking shaking experienced school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Experience: +2, Last Available: "2010-04"
-4581	mirror T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of Leguizamo of the boozehound	0		Monster Level: +20, Booze Drop: +100, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	mirror T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of Leguizamo of the boozehound	0		Monster Level: +20, Booze Drop: +100, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	cyan fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	fancy normal big narrow six wedges of goat cheese	5	good	Effect: "stats.enq", Effect Duration: 5
+4584	big fancy normal narrow six wedges of goat cheese	5	good	Effect: "stats.enq", Effect Duration: 5
 4585	maroon collection of objects	0		
 4586	boulder	0		
 4587	goth	0		
@@ -4550,9 +4550,9 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	Fonzie's supercool bottle of Goldschn&ouml;ckered	0		Moxie Percent: +20, Experience (Moxie): +1, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	Fonzie's supercool bottle of Goldschn&ouml;ckered	0		Moxie Percent: +20, Experience (Moxie): +1, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	moldy sun-dried tofu	3	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	perfectly mixed practically non-alcoholic shaking soyburger juice	1	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	practically non-alcoholic perfectly mixed shaking soyburger juice	1	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	maroon essential tofu	0		Last Available: "2010-08"
 4610	pickled quantum pulsating essential soy	0		Effect: "Oxygenated Blood", Effect Duration: 31, Last Available: "2010-08"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	twirling blue chaotic Crown of Thrones	0		Spell Critical Percent: +10, Softcore Only, Last Available: "2010-05"
-4615	artisanal weak Cinco Mayo Lager	2	super EPIC	Last Available: "2010-05"
+4615	weak artisanal Cinco Mayo Lager	2	super EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	spinning pruning shears	0		Familiar Weight: +5
 4618	spinning plastic cup of flat beer	0		
@@ -4569,12 +4569,12 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	huge Game Grid ticket	0		Last Available: "2010-06"
 4623	electrified cold-filtered chocolate-covered caviar	0		Effect: "Helping Comes Second", Effect Duration: 52, Last Available: "2020-09"
-4624	tasty thick pawn cookie	5	awesome	Last Available: "2010-06"
+4624	thick tasty pawn cookie	5	awesome	Last Available: "2010-06"
 4625	distilled blurry coffee pixie stick	1	good	Last Available: "2010-06"
 4626	olive superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	plastic spider ring of Flo-Jo	0		Initiative: +100, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	plastic spider ring of Flo-Jo	0		Initiative: +100, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	Sherlock's plastic kazoo	0		Item Drop: +25, Last Available: "2010-06"
 4631	stiffened inflatable baseball bat	0		Damage Reduction: 1, Last Available: "2010-06"
 4632	Jim Carey's weightlifter's googly-star hat	0		Muscle: +15, Monster Level: +25, Last Available: "2010-06", Familiar Effect: "atk"
@@ -4616,7 +4616,7 @@
 4668	observational glasses of terror	0		Spooky Spell Damage: +10
 4669	hilarious comedy prop of the boozehound	0		Booze Drop: +100
 4670	wobbly wobbly beer-scented teddy bear	0		
-4671	tolerable fancy blinking booze-soaked cherry	3	good	Effect: "Spell Transfer Complete", Effect Duration: 40
+4671	fancy tolerable blinking booze-soaked cherry	3	good	Effect: "Spell Transfer Complete", Effect Duration: 40
 4672	comfy pillow	0		
 4673	delicious big wobbly marshmallow	5	awesome	
 4674	bland mirror sponge cake	4	decent	
@@ -4651,30 +4651,30 @@
 4703	pulsating foul-smelling red-hot medallion	0		Stench Damage: +10, Single Equip, Last Available: "2010-09"
 4704	fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
-4706	tumbling teal jittery sinister tablet	0		
+4706	teal tumbling jittery sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
 4708	My First Shaker&trade;	0		
-4709	pulsating twirling hippo tutu	0		Last Available: "2011-09"
+4709	twirling pulsating hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	cyan sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	flavorless miniature lemon popsicle	2	decent	
-4715	massive decent enchanted tumbling red popsicle	9	good	Effect: "Vitali Tea", Effect Duration: 50
+4715	massive decent enchanted red tumbling popsicle	9	good	Effect: "Vitali Tea", Effect Duration: 50
 4716	snack-sized normal strawberry popsicle	2	good	
-4717	thick rotten mirror liver popsicle	5	crappy	
+4717	rotten thick mirror liver popsicle	5	crappy	
 4718	maroon mariachi hat of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, cap 2"
 4719	purple Tesla Hollandaise helmet	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, cap 2"
 4720	upside-down shaking cyan organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	twirling microwave stogie	0		Last Available: "2011-12"
-4722	huge flavorless liver and let pie	10	decent	Last Available: "2010-10"
-4723	normal big badass pie	5	good	Last Available: "2010-10"
+4722	flavorless huge liver and let pie	10	decent	Last Available: "2010-10"
+4723	big normal badass pie	5	good	Last Available: "2010-10"
 4724	delicious shoo-fish pie	3	awesome	Last Available: "2010-10"
-4725	immense flavorless enchanted piping organ pie	10	decent	Effect: "Hot Blooded", Effect Duration: 50, Last Available: "2010-10"
+4725	immense enchanted flavorless piping organ pie	10	decent	Effect: "Hot Blooded", Effect Duration: 50, Last Available: "2010-10"
 4726	half-sized moldy igloo pie	2	crappy	Last Available: "2010-10"
 4727	spoiled stomach turnover	3	crappy	Last Available: "2010-10"
 4728	flavorless dead lights pie	3	decent	Last Available: "2010-10"
-4729	snack-sized yummy throbbing organ pie	2	awesome	Last Available: "2010-10"
+4729	yummy snack-sized throbbing organ pie	2	awesome	Last Available: "2010-10"
 4730	blinking pulsating razor-sharp stop shield	0		Weapon Damage Percent: +25, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	blue sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4691,7 +4691,7 @@
 4743	bone chips	0		Last Available: "2011-12"
 4744	activated liquefied squat PlexiPips	0		Effect: "familiar.enq", Effect Duration: 33
 4745	enhanced tumbling Wax Flask	0		Effect: "Fire Inside", Effect Duration: 31
-4746	triple-anodized mirror squat green Pain Dip	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 48
+4746	triple-anodized mirror green squat Pain Dip	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 48
 4747	adequate bone meal	4	good	Last Available: "2010-10"
 4748	drinkable bone aperitif	3	good	Last Available: "2010-10"
 4749	twirling bonerang of courage	0		Spooky Resistance: +3, Last Available: "2010-10"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	decent pumpkin pie	3	good	Last Available: "2010-11"
-4764	spirit-forward acceptable pulsating jittery pumpkin beer	5	good	Last Available: "2010-11"
+4764	acceptable spirit-forward jittery pulsating pumpkin beer	5	good	Last Available: "2010-11"
 4765	adjusted pulsating pumpkin juice	0		Effect: "New and Improved", Effect Duration: 66, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	smelly energetic shin gourds	0		Maximum MP Percent: +20, Stench Spell Damage: +10, Single Equip, Last Available: "2010-11"
@@ -4745,7 +4745,7 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	blinking robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	miniature normal triangular CRIMBCOOKIE	2	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	normal miniature triangular CRIMBCOOKIE	2	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	bite-sized toothsome square CRIMBCOOKIE	1	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	dog trainer's Rosewater's bindlestocking of the boozehound	0		Mysticality Percent: +30, Experience (familiar): +1, Booze Drop: +100, Last Available: "2010-12"
 4842	teal sleeping stocking	0		Last Available: "2010-12"
@@ -4760,7 +4760,7 @@
 4851	chilled chocolate cigar	0		Effect: "Loco Motives", Effect Duration: 46, Last Available: "2010-12"
 4852	friendly gift-a-pult	0		Familiar Weight: +3, Last Available: "2010-12"
 4853	aerosolized extra-tarnished narrow holly-flavored Hob-O	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 39, Last Available: "2020-09"
-4854	bouncing spinning CRIMBCO scrip	0		Last Available: "2011-01"
+4854	spinning bouncing CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	ghostly paperclip	0		Last Available: "2011-01"
 4857	mirror bottle of Blank-Out	0		Last Available: "2011-01"
@@ -4787,7 +4787,7 @@
 4878	quadruple-Vulcanized diffused incense bath ball	0		Effect: "Hammertime", Effect Duration: 51, Last Available: "2011-01"
 4879	tarnished electrified improved myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Eagle Eyes", Effect Duration: 30, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	high-proof mediocre CRIMBCO wine	6	decent	Last Available: "2011-01"
+4881	mediocre high-proof CRIMBCO wine	6	decent	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	red toe jam	0		Last Available: "2011-01"
 4884	spoiled tiny toe jam toast	1	crappy	Last Available: "2011-01"
@@ -4800,8 +4800,8 @@
 4891	spinning bath ball gift set	0		Last Available: "2011-01"
 4892	spinning slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	tasty small teal festive sausage	2	awesome	Last Available: "2011-01"
-4895	massive decent holiday cheese log	9	good	Last Available: "2011-01"
+4894	small tasty teal festive sausage	2	awesome	Last Available: "2011-01"
+4895	decent massive holiday cheese log	9	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	huge mansplainer's crafty BGE 'ferocious fruit' shirt	0		Maximum MP: +10, Monster Level: +15, Last Available: "2010-12"
 4898	experienced smooth BGE 'cuddly critter' shirt	0		Moxie: +15, Experience: +2, Last Available: "2010-12"
@@ -4841,7 +4841,7 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	normal bite-sized wobbly Knob jelly donut	1	good	
+4941	bite-sized normal wobbly Knob jelly donut	1	good	
 4942	skewed Knob cake	0		
 4943	Knob cake pan	0		
 4944	lime green Knob batter	0		
@@ -4855,11 +4855,11 @@
 4952	magnetized aerosolized green baggie of sugar	0		Effect: "Venomous Weapon", Effect Duration: 38
 4953	Usain Bolt's personal trainer's whalebone corset	0		Experience Percent (Muscle): +10, Initiative: +80, Single Equip
 4954	narrow oven mitts of the pedagogue	0		Experience: +3, Single Equip
-4955	bland special overcookie	3	decent	Effect: "Smelly Pants", Effect Duration: 35
-4956	big flavorless mirror yellow philosopher's scone	5	decent	
+4955	special bland overcookie	3	decent	Effect: "Smelly Pants", Effect Duration: 35
+4956	big flavorless yellow mirror philosopher's scone	5	decent	
 4957	electrified quadruple-warmed ghostly half-baked potion	0		Effect: "Brother Smothers's Blessing", Effect Duration: 21
 4958	Annie Oakley's Knob Goblin deluxe scimitar	0		Critical Hit Percent: +20
-4959	stale bite-sized green Knob nuts	1	decent	
+4959	bite-sized stale green Knob nuts	1	decent	
 4960	hand-crafted Cobb's Knob Wurstbrau	3	EPIC	
 4961	red Subject 37 file	0		
 4962	mansplainer's MacGyver's mysterious lapel pin	0		Maximum MP: +100, Monster Level: +15, Single Equip
@@ -4883,7 +4883,7 @@
 4980	Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	blinking Alice's Army Horseman	0		Last Available: "2011-03"
 4982	skewed Alice's Army Coward	0		Last Available: "2011-03"
-4983	narrow blurry Alice's Army Cleric	0		Last Available: "2011-03"
+4983	blurry narrow Alice's Army Cleric	0		Last Available: "2011-03"
 4984	Alice's Army Sniper	0		Last Available: "2011-03"
 4985	Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
@@ -4915,9 +4915,9 @@
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	decent super-sized bouncing wasabi pocky	5	good	Last Available: "2011-03"
 5014	stale tobiko pocky	3	decent	Last Available: "2011-03"
-5015	decent miniature huge twirling squat natto pocky	2	good	Last Available: "2011-03"
-5016	delicious watered-down wasabi-infused sake	2	awesome	Last Available: "2011-03"
-5017	special tolerable upside-down tobiko-infused sake	3	good	Effect: "Sewer-Drenched", Effect Duration: 20, Last Available: "2011-03"
+5015	miniature decent squat huge twirling natto pocky	2	good	Last Available: "2011-03"
+5016	watered-down delicious wasabi-infused sake	2	awesome	Last Available: "2011-03"
+5017	tolerable special upside-down tobiko-infused sake	3	good	Effect: "Sewer-Drenched", Effect Duration: 20, Last Available: "2011-03"
 5018	lousy pulsating spinning natto-infused sake	4	decent	Last Available: "2011-03"
 5019	moist wasabi marble soda	0		Effect: "Ice Packed", Effect Duration: 43, Last Available: "2011-03"
 5020	dry flattened tobiko marble soda	0		Effect: "Vital", Effect Duration: 31, Last Available: "2011-03"
@@ -4965,7 +4965,7 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	red the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	tasty snack-sized spaghetti con calaveras	2	awesome	Last Available: "2011-04"
+5065	snack-sized tasty spaghetti con calaveras	2	awesome	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	diet decent popcorn	1	good	Last Available: "2011-04"
 5068	rotten squat chaos popcorn	4	crappy	Last Available: "2011-04"
@@ -4973,7 +4973,7 @@
 5070	ghostly innuendo	0		Last Available: "2011-04"
 5071	low-calorie delicious s'more	0	awesome	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
-5073	tolerable fortified Russian Ice	5	good	Last Available: "2011-04"
+5073	fortified tolerable Russian Ice	5	good	Last Available: "2011-04"
 5074	wobbly beefy clay ashtray	0		Muscle: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	blinking twirling lanyard of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2011-05"
 5076	Rosewater's monster pants	0		Mysticality Percent: +30, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
@@ -5007,9 +5007,9 @@
 5104	magnetized oxidized fish juice box	0		Effect: "Net Tea", Effect Duration: 68, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	upside-down hideous egg	0		Last Available: "2011-05"
-5107	perfectly mixed spinning squat Jeppson's Malort	4	EPIC	Last Available: "2011-06"
+5107	perfectly mixed squat spinning Jeppson's Malort	4	EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	Da Vinci's stress ball	0		Experience (Mysticality): +5, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	Da Vinci's stress ball	0		Experience (Mysticality): +5, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	lime green Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Temple Grandin's Ultracolor&trade; shirt	0		Familiar Weight: +7, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5032,7 +5032,7 @@
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	pickled energized skewed Ultrasoldier Serum	0		Effect: "Flagrantly Fragrant", Effect Duration: 55, Last Available: "2011-06"
-5132	adequate special elven hardtack	3	good	Effect: "Extra-Wet", Effect Duration: 35, Last Available: "2011-06"
+5132	special adequate elven hardtack	3	good	Effect: "Extra-Wet", Effect Duration: 35, Last Available: "2011-06"
 5133	irresponsibly strong mediocre elven squeeze	7	decent	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
@@ -5040,12 +5040,12 @@
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	jittery E.M.U. harness	0		Last Available: "2011-06"
 5139	wobbly carton of astral energy drinks	0		
-5140	distilled green narrow astral energy drink	1		Effect: "What's That Smell?", Effect Duration: 10
+5140	distilled narrow green astral energy drink	1		Effect: "What's That Smell?", Effect Duration: 10
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	gray E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
-5145	deionized lime green shaking squat honeypot	0		Effect: "Marco Polarity", Effect Duration: 59
+5145	deionized shaking squat lime green honeypot	0		Effect: "Marco Polarity", Effect Duration: 59
 5146	delicious wild honey pie	4	awesome	
 5147	artisanal watered-down honey mead	2	EPIC	
 5148	lightning-fast fireproof clever honey dipper	0		Maximum MP: +20, Hot Resistance: +3, Initiative: +40
@@ -5080,7 +5080,7 @@
 5177	delicious Spaghetti with Moonballs	4	awesome	Last Available: "2011-06"
 5178	moldy Crepes a la Lune	4	crappy	Last Available: "2011-06"
 5179	decent miniature spinning Moon Pie	2	good	Last Available: "2011-06"
-5180	deionized twirling teal Comet Pop	0		Effect: "Extra-Thick Blood", Effect Duration: 23, Last Available: "2011-06"
+5180	deionized teal twirling Comet Pop	0		Effect: "Extra-Thick Blood", Effect Duration: 23, Last Available: "2011-06"
 5181	galvanized Flan in the Moon	0		Effect: "Transcendental Wind", Effect Duration: 64, Last Available: "2011-06"
 5182	warmed 1/6th Pound Cake	0		Effect: "Inner Warmth", Effect Duration: 23, Last Available: "2011-06"
 5183	olive Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	aerosolized honey stick	0		Effect: "Inner Warmth", Effect Duration: 62
 5189	ionized double-ice gum	0		Effect: "Ichorous Intensity", Effect Duration: 39, Last Available: "2011-04"
-5190	huge gravedigger's curative Operation Patriot Shield of the businessman	0		Spooky Damage: +10, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	huge gravedigger's curative Operation Patriot Shield of the businessman	0		Spooky Damage: +10, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	magnetized corrupted data	0		Effect: "Graham Crackling", Effect Duration: 68, Last Available: "2011-06"
 5193	tumbling 11-inch knob sausage	0		
@@ -5098,36 +5098,36 @@
 5195	shaking Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	olive jittery Da Vinci's Great S-Cape	0		Experience (Mysticality): +5, Softcore Only, Last Available: "2011-07"
 5197	maroon supercharged Marvelous Unitard	0		Maximum MP Percent: +30, Softcore Only, Last Available: "2011-07"
-5198	boiled pulsating narrow spinning gooey paste	1	EPIC	Last Available: "2011-08"
+5198	boiled spinning narrow pulsating gooey paste	1	EPIC	Last Available: "2011-08"
 5199	modified beastly paste	1	good	Effect: "Mad at Science", Effect Duration: 20, Last Available: "2011-08"
 5200	dehydrated paste	1	good	Last Available: "2011-08"
 5201	twisted blinking ectoplasmic paste	1	EPIC	Last Available: "2011-08"
-5202	distilled upside-down tumbling greasy paste	1	crappy	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2011-08"
+5202	distilled tumbling upside-down greasy paste	1	crappy	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2011-08"
 5203	altered mirror huge bug paste	1	good	Last Available: "2011-08"
-5204	distilled squat ghostly hippy paste	1	crappy	Last Available: "2011-08"
+5204	distilled ghostly squat hippy paste	1	crappy	Last Available: "2011-08"
 5205	vaporized orc paste	1	EPIC	Last Available: "2011-08"
-5206	diluted spinning upside-down demonic paste	1	awesome	Last Available: "2011-08"
+5206	diluted upside-down spinning demonic paste	1	awesome	Last Available: "2011-08"
 5207	boiled indescribably horrible paste	1	good	Last Available: "2011-08"
 5208	boiled paste	1	awesome	Last Available: "2011-08"
 5209	compressed twirling goblin paste	1	decent	Last Available: "2011-08"
 5210	diluted squat olive pirate paste	1	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 20, Last Available: "2011-08"
-5211	distilled green spinning pulsating chlorophyll paste	1	awesome	Last Available: "2011-08"
-5212	dried squat maroon paste	1	decent	Last Available: "2011-08"
+5211	distilled pulsating spinning green chlorophyll paste	1	awesome	Last Available: "2011-08"
+5212	dried maroon squat paste	1	decent	Last Available: "2011-08"
 5213	dried mirror spinning Mer-kin paste	1	crappy	Last Available: "2011-08"
 5214	dried slimy paste	1	crappy	Last Available: "2011-08"
-5215	pickled wobbly huge penguin paste	1	good	Last Available: "2011-08"
+5215	pickled huge wobbly penguin paste	1	good	Last Available: "2011-08"
 5216	dehydrated mirror wobbly elemental paste	1	good	Last Available: "2011-08"
 5217	powdered shaking cosmic paste	1	decent	Last Available: "2011-08"
 5218	distilled hobo paste	1	awesome	Last Available: "2011-08"
-5219	altered twirling purple Crimbo paste	1	decent	Last Available: "2011-08"
+5219	altered purple twirling Crimbo paste	1	decent	Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	flavorless gigantic upside-down Ur-Donut	10	decent	Last Available: "2011-09"
-5225	tumbling teal The Bomb	0		Last Available: "2011-09"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5224	gigantic flavorless upside-down Ur-Donut	10	decent	Last Available: "2011-09"
+5225	teal tumbling The Bomb	0		Last Available: "2011-09"
 5226	blurry box of Familiar Jacks	0		Last Available: "2011-09"
-5227	practically non-alcoholic bad squat bucket of wine	1	decent	Last Available: "2011-09"
+5227	bad practically non-alcoholic squat bucket of wine	1	decent	Last Available: "2011-09"
 5228	immense adequate ghostly ultrafondue	9	good	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	green snowflake	0		Last Available: "2011-09"
@@ -5138,21 +5138,21 @@
 5235	executive furry halo	0		Meat Drop: +40, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	frosty halo of temperance	0		Sleaze Resistance: +5, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	smelly time halo	0		Stench Spell Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	drinkable strong Lumineux Limnio	5	good	Last Available: "2011-09"
-5239	irresponsibly strong lousy Morto Moreto	7	decent	Last Available: "2011-09"
+5238	strong drinkable Lumineux Limnio	5	good	Last Available: "2011-09"
+5239	lousy irresponsibly strong Morto Moreto	7	decent	Last Available: "2011-09"
 5240	bad watered-down Temps Tempranillo	2	decent	Last Available: "2011-09"
 5241	acceptable blurry Bordeaux Marteaux	3	good	Last Available: "2011-09"
 5242	high-proof delicious Fromage Pinotage	10	awesome	Last Available: "2011-09"
 5243	bad blinking Beignet Milgranet	4	decent	Last Available: "2011-09"
 5244	delicious Muschat	3	awesome	Last Available: "2011-09"
-5245	stale diet cool jelly donut	1	decent	Last Available: "2011-09"
+5245	diet stale cool jelly donut	1	decent	Last Available: "2011-09"
 5246	flavorless half-sized shrapnel jelly donut	2	decent	Last Available: "2011-09"
-5247	bland big occult jelly donut	5	decent	Last Available: "2011-09"
+5247	big bland occult jelly donut	5	decent	Last Available: "2011-09"
 5248	normal tiny thyme jelly donut	1	good	Last Available: "2011-09"
 5249	stale danish	3	decent	Last Available: "2011-09"
-5250	yummy small smashed danish	2	awesome	Last Available: "2011-09"
+5250	small yummy smashed danish	2	awesome	Last Available: "2011-09"
 5251	toothsome blurry forbidden danish	4	awesome	Last Available: "2011-09"
-5252	immense enchanted tasty cool cat claw	10	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 45, Last Available: "2011-09"
+5252	tasty enchanted immense cool cat claw	10	awesome	Effect: "Cruisin' for a Bruisin'", Effect Duration: 45, Last Available: "2011-09"
 5253	normal blunt cat claw	3	good	Last Available: "2011-09"
 5254	yummy shadowy cat claw	3	awesome	Last Available: "2011-09"
 5255	spoiled snack-sized cheezburger	2	crappy	Last Available: "2011-09"
@@ -5165,7 +5165,7 @@
 5262	non-dry double-wet cool cat elixir	0		Effect: "Sweetened and Fattened", Effect Duration: 24, Last Available: "2011-09"
 5263	galvanized oxidized bouncing potion of the captain's hammer	0		Effect: "Mistified", Effect Duration: 66, Last Available: "2011-09"
 5264	alkaline blue wobbly potion of X-ray vision	0		Effect: "Hot Jellied", Effect Duration: 36, Last Available: "2011-09"
-5265	extra-ionized jittery fuchsia potion of the litterbox	0		Effect: "Poker Faced", Effect Duration: 23, Last Available: "2011-09"
+5265	extra-ionized fuchsia jittery potion of the litterbox	0		Effect: "Poker Faced", Effect Duration: 23, Last Available: "2011-09"
 5266	pressed cold-filtered warmed tumbling potion of animal rage	0		Effect: "Boletus Swoletus", Effect Duration: 56, Last Available: "2011-09"
 5267	triple-tarnished quadruple-electrified jittery wobbly potion of punctual companionship	0		Effect: "Fastbreaker", Effect Duration: 62, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	careful broken clock	0		Monster Level: -10, Last Available: "2011-09"
 5282	ghostly upside-down executive dethklok	0		Meat Drop: +40, Last Available: "2011-09"
 5283	auspicious glacial clock	0		Item Drop: +10, Last Available: "2011-09"
-5284	gray Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	gray Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	jittery d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5194,12 +5194,12 @@
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	generic mana potion	0		Last Available: "2011-09"
 5293	upside-down generic restorative potion	0		Last Available: "2011-09"
-5294	ghostly green kobold treasure hoard	0		Last Available: "2011-09"
+5294	green ghostly kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	lime green slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	gigantic moldy phish stick	7	crappy	Last Available: "2011-09"
-5299	Usain Bolt's steel-toed plastic vampire fangs of the glutton	0		Damage Reduction: 9, Food Drop: +100, Initiative: +80, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5298	moldy gigantic phish stick	7	crappy	Last Available: "2011-09"
+5299	Usain Bolt's steel-toed plastic vampire fangs of the glutton	0		Damage Reduction: 9, Food Drop: +100, Initiative: +80, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	wobbly Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5219,15 +5219,15 @@
 5316	activated modified press-on ribs	0		Effect: "Fustulent", Effect Duration: 45, Last Available: "2011-10"
 5317	oxidized Rattlin' Chains	0		Effect: "Conspiratory Eyes", Effect Duration: 31, Last Available: "2011-10"
 5318	polymerized deionized altered Gummy Brains	0		Effect: "Dreadful Smell", Effect Duration: 48, Last Available: "2011-10"
-5319	cold-filtered adjusted cyan ghostly Blood 'n' Plenty	0		Effect: "Amorphous Cheer", Effect Duration: 50, Last Available: "2011-10"
-5320	polymerized irradiated bouncing wobbly Lobos Mints	0		Effect: "Hammertime", Effect Duration: 46, Last Available: "2011-10"
+5319	cold-filtered adjusted ghostly cyan Blood 'n' Plenty	0		Effect: "Amorphous Cheer", Effect Duration: 50, Last Available: "2011-10"
+5320	polymerized irradiated wobbly bouncing Lobos Mints	0		Effect: "Hammertime", Effect Duration: 46, Last Available: "2011-10"
 5321	ionized Vulcanized Sweet Sword	0		Effect: "Thunderheart", Effect Duration: 58, Last Available: "2011-10"
-5322	distilled artisanal upside-down yellow Ecto-Cooler	5	EPIC	Last Available: "2011-10"
+5322	artisanal distilled upside-down yellow Ecto-Cooler	5	EPIC	Last Available: "2011-10"
 5323	distilled acceptable Bartles and BRAAAINS wine cooler	5	good	Last Available: "2011-10"
 5324	lousy shaking Blood Light	3	decent	Last Available: "2011-10"
 5325	perfectly mixed Silver Bullet beer	3	EPIC	Last Available: "2011-10"
 5326	hand-crafted Bone's Farm &quot;wine&quot;	4	EPIC	Last Available: "2011-10"
-5327	pulsating skewed ghost protocol	0		Last Available: "2011-10"
+5327	skewed pulsating ghost protocol	0		Last Available: "2011-10"
 5328	alkaline oxidized sorority brain	0		Effect: "Big Meat Big Prizes", Effect Duration: 34, Last Available: "2011-10"
 5329	diffused activated cold-filtered twirling Nightstalker perfume	0		Effect: "Rushin' Hands", Effect Duration: 13, Last Available: "2011-10"
 5330	frozen shaking drum of pomade	0		Effect: "Stimulated Brain", Effect Duration: 39, Last Available: "2011-10"
@@ -5244,7 +5244,7 @@
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	watered-down lousy fancy The Cooler Out of Space	2	decent	Effect: "Ten out of Ten", Effect Duration: 5, Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5344	cyan jittery sorority girl's box	0		Last Available: "2011-10"
+5344	jittery cyan sorority girl's box	0		Last Available: "2011-10"
 5345	chilled adjusted upside-down Necbro wafers	0		Effect: "Dweeby", Effect Duration: 46, Last Available: "2020-09"
 5346	death blossom	0		
 5347	teal A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
@@ -5290,7 +5290,7 @@
 5387	experienced ridiculous earring	0		Experience: +2, Last Available: "2011-11"
 5388	cyan greedy ridiculous sunglasses	0		Meat Drop: +20, Last Available: "2011-11"
 5389	delicious ridiculous sandwich	3	awesome	Last Available: "2011-11"
-5390	weak aged ridiculous cocktail	2	awesome	Last Available: "2011-11"
+5390	aged weak ridiculous cocktail	2	awesome	Last Available: "2011-11"
 5391	prompt boxer's zombie monkey necklace	0		Muscle Percent: +10, Adventures: +3
 5392	jittery Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5307,13 +5307,13 @@
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	smelly foul-smelling rock-hard cane-mail shirt	0		Damage Reduction: 5, Stench Damage: +10, Stench Spell Damage: +10, Last Available: "2011-12"
 5406	rosewater-soaked sinister Newton's cane-mail pants	0		Experience (Mysticality): +3, Spell Damage: +10, Stench Resistance: +3, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	mediocre shaking pulsating Vodka Matryoshka	4	decent	Last Available: "2011-12"
-5408	triple-distilled delicious ghostly Gin Mint	9	awesome	Last Available: "2011-12"
+5407	mediocre pulsating shaking Vodka Matryoshka	4	decent	Last Available: "2011-12"
+5408	delicious triple-distilled ghostly Gin Mint	9	awesome	Last Available: "2011-12"
 5409	aged watered-down Tequiz Navidad	2	awesome	Last Available: "2011-12"
-5410	lousy irresponsibly strong red Mint Yulep	9	decent	Last Available: "2011-12"
+5410	irresponsibly strong lousy red Mint Yulep	9	decent	Last Available: "2011-12"
 5411	watered-down acceptable squat Crimbojito	2	good	Last Available: "2011-12"
-5412	drinkable practically non-alcoholic squat Sangria de Menthe	1	good	Last Available: "2011-12"
-5413	narrow blurry candycaine powder	0		Last Available: "2011-12"
+5412	practically non-alcoholic drinkable squat Sangria de Menthe	1	good	Last Available: "2011-12"
+5413	blurry narrow candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	corrupted dry licorice root	0		Effect: "Disco Inferno", Effect Duration: 35, Last Available: "2011-12"
 5416	boiled colloidal tarnished tumbling tumbling banana supersucker	0		Effect: "Rampage!", Effect Duration: 32, Last Available: "2011-11"
@@ -5338,7 +5338,7 @@
 5435	fudgecule	0		Last Available: "2011-11"
 5436	liquefied oxidized twirling fudge lily	0		Effect: "Mushroom Melody", Effect Duration: 51, Last Available: "2011-11"
 5437	spinning superheated fudge	0		Last Available: "2011-11"
-5438	electrified corrupted blurry spinning fluid of fudge-finding	0		Effect: "Disco Nirvana", Effect Duration: 68, Last Available: "2011-11"
+5438	electrified corrupted spinning blurry fluid of fudge-finding	0		Effect: "Disco Nirvana", Effect Duration: 68, Last Available: "2011-11"
 5439	squat fudgepuck	0		Last Available: "2011-11"
 5440	tasty fudgesicle	4	awesome	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
@@ -5363,14 +5363,14 @@
 5460	blinking Socratic fudgecycle of the detective of the glutton	0		Experience (Mysticality): +1, Item Drop: +20, Food Drop: +100, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	magnetized corrupted resolution: be wealthier	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 64, Last Available: "2012-01"
 5465	nitrogenated energized twirling yellow resolution: be happier	0		Effect: "Souper Vengeful", Effect Duration: 45, Last Available: "2012-01"
 5466	unsweetened activated upside-down resolution: be stronger	0		Effect: "Super-Electrified", Effect Duration: 19, Last Available: "2012-01"
 5467	quadruple-moist tumbling resolution: be smarter	0		Effect: "Here to Kick Ass", Effect Duration: 42, Last Available: "2012-01"
 5468	Vulcanized colloidal wobbly resolution: be sexier	0		Effect: "Sepia Tan", Effect Duration: 26, Last Available: "2012-01"
 5469	improved super-frozen deionized resolution: be feistier	0		Effect: "Astral Shell", Effect Duration: 46, Last Available: "2012-01"
-5470	enhanced adjusted alkaline purple shaking resolution: be kinder	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 28, Last Available: "2012-01"
+5470	enhanced adjusted alkaline shaking purple resolution: be kinder	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 28, Last Available: "2012-01"
 5471	quantum resolution: be more adventurous	0		Effect: "Badger Underfoot", Effect Duration: 69, Last Available: "2012-01"
 5472	denatured unsweetened ghostly resolution: be luckier	0		Effect: "Stuck That Way", Effect Duration: 36, Last Available: "2012-01"
 5473	purple jittery gummi ingot	0		Last Available: "2011-11"
@@ -5379,8 +5379,8 @@
 5476	aerosolized dry denatured blurry gummi salamander	0		Effect: "Ancestral Disapproval", Effect Duration: 41, Last Available: "2011-11"
 5477	polarized oxidized gummi snake	0		Effect: "Destructive Resolve", Effect Duration: 50, Last Available: "2011-11"
 5478	corrupted green gummi canary	0		Effect: "Cat Class, Cat Style", Effect Duration: 35, Last Available: "2011-11"
-5479	massive delicious gummi bear	9	awesome	Last Available: "2011-11"
-5480	miniature rotten special squat gummi bear	2	crappy	Effect: "Fever From the Flavor", Effect Duration: 35, Last Available: "2011-11"
+5479	delicious massive gummi bear	9	awesome	Last Available: "2011-11"
+5480	rotten special miniature squat gummi bear	2	crappy	Effect: "Fever From the Flavor", Effect Duration: 35, Last Available: "2011-11"
 5481	big spoiled gummi bear	5	crappy	Last Available: "2011-11"
 5482	big adequate drunki-bear	5	good	Last Available: "2011-11"
 5483	delicious drunki-bear	3	awesome	Last Available: "2011-11"
@@ -5432,9 +5432,9 @@
 5529	miniature decent shaking berries of suffering	2	good	Last Available: "2012-12"
 5530	diffused irradiated tumbling baobab sap	0		Effect: "Broken Fast", Effect Duration: 58, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
-5532	shaking fuchsia magnolia blossom	0		Last Available: "2012-12"
+5532	fuchsia shaking magnolia blossom	0		Last Available: "2012-12"
 5533	pickled ghostly Mortimer's nostrum	0		Effect: "Innately Wise", Effect Duration: 36, Last Available: "2012-12"
-5534	drinkable extra-dry Barulio's bottle	5	good	Last Available: "2012-12"
+5534	extra-dry drinkable Barulio's bottle	5	good	Last Available: "2012-12"
 5535	modified colloidal shaking Marvin's marvelous pill	0		Effect: "EVISCERATE!", Effect Duration: 37, Last Available: "2012-12"
 5536	jittery Winifred's whistle	0		Last Available: "2012-12"
 5537	jittery prose pen	0		Last Available: "2012-12"
@@ -5459,52 +5459,52 @@
 5556	squat fireproof toasty Rain-Doh wings	0		Hot Damage: +5, Hot Resistance: +3, Softcore Only, Last Available: "2012-02"
 5557	bouncing Rain-Doh agent	0		Last Available: "2012-02"
 5558	toasty Rain-Doh laser gun of the scaredy-cat	0		Monster Level: -15, Hot Damage: +5, Softcore Only, Last Available: "2012-02"
-5559	chaotic wicked Rain-Doh lantern	0		Spell Damage: +5, Spell Critical Percent: +10, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	chaotic wicked Rain-Doh lantern	0		Spell Damage: +5, Spell Critical Percent: +10, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	green Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	resourceful cool Rain-Doh violet bo	0		Moxie: +5, Maximum MP: +50, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	blinking Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	spoiled shaking PB&BP	3	crappy	
-5566	decent massive pulsating club sandwich	8	good	
-5567	huge adequate corned-beef Reuben	8	good	
+5566	massive decent pulsating club sandwich	8	good	
+5567	adequate huge corned-beef Reuben	8	good	
 5568	frayed ninja rope	0		
-5569	tumbling gray dull ninja crampons	0		
+5569	gray tumbling dull ninja crampons	0		
 5570	teal loose ninja carabiner	0		
 5571	teal Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	mediocre weak Drac & Tan	2	decent	Last Available: "2012-03"
-5574	perfectly mixed weak enchanted Transylvania Sling	2	EPIC	Effect: "Belch the Rainbow&trade;", Effect Duration: 40, Last Available: "2012-03"
-5575	acceptable practically non-alcoholic Shot of the Living Dead	1	good	Last Available: "2012-03"
+5573	weak mediocre Drac & Tan	2	decent	Last Available: "2012-03"
+5574	enchanted perfectly mixed weak Transylvania Sling	2	EPIC	Effect: "Belch the Rainbow&trade;", Effect Duration: 40, Last Available: "2012-03"
+5575	practically non-alcoholic acceptable Shot of the Living Dead	1	good	Last Available: "2012-03"
 5576	bad Buttery Knob	3	decent	Last Available: "2012-03"
 5577	artisanal enchanted wobbly Slippery Knob	4	EPIC	Effect: "Bone Chilling", Effect Duration: 30, Last Available: "2012-03"
 5578	weak smooth bouncing Flaming Knob	2	awesome	Last Available: "2012-03"
 5579	bad Grasshopper	3	decent	Last Available: "2012-03"
 5580	watered-down tolerable Locust	2	good	Last Available: "2012-03"
 5581	smooth watered-down Plague of Locusts	2	awesome	Last Available: "2012-03"
-5582	enchanted watered-down acceptable teal Red Dwarf	2	good	Effect: "Dilated Pupils", Effect Duration: 15, Last Available: "2012-03"
+5582	watered-down acceptable enchanted teal Red Dwarf	2	good	Effect: "Dilated Pupils", Effect Duration: 15, Last Available: "2012-03"
 5583	lousy Golden Mean	3	decent	Last Available: "2012-03"
-5584	irresponsibly strong drinkable Green Giant	7	good	Last Available: "2012-03"
+5584	drinkable irresponsibly strong Green Giant	7	good	Last Available: "2012-03"
 5585	distilled mediocre Aye Aye	5	decent	Last Available: "2012-03"
-5586	high-proof acceptable Aye Aye, Captain	9	good	Last Available: "2012-03"
-5587	mediocre watered-down Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
+5586	acceptable high-proof Aye Aye, Captain	9	good	Last Available: "2012-03"
+5587	watered-down mediocre Aye Aye, Tooth Tooth	2	decent	Last Available: "2012-03"
 5588	watered-down smooth blue Humanitini	2	awesome	Last Available: "2012-03"
-5589	practically non-alcoholic perfectly mixed More Humanitini than Humanitini	1	EPIC	Last Available: "2012-03"
-5590	mediocre strong Oh, the Humanitini	5	decent	Last Available: "2012-03"
+5589	perfectly mixed practically non-alcoholic More Humanitini than Humanitini	1	EPIC	Last Available: "2012-03"
+5590	strong mediocre Oh, the Humanitini	5	decent	Last Available: "2012-03"
 5591	hand-crafted practically non-alcoholic blurry Great Older Fashioned	1	EPIC	Last Available: "2012-03"
 5592	hand-crafted Fuzzy Tentacle	3	EPIC	Last Available: "2012-03"
-5593	spirit-forward fancy artisanal purple Crazymaker	5	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 50, Last Available: "2012-03"
+5593	fancy artisanal spirit-forward purple Crazymaker	5	EPIC	Effect: "Human-Weird Thing Hybrid", Effect Duration: 50, Last Available: "2012-03"
 5594	perfectly mixed squat Zoodriver	4	EPIC	Last Available: "2012-03"
-5595	extra-dry delicious tumbling Sloe Comfortable Zoo	5	awesome	Last Available: "2012-03"
+5595	delicious extra-dry tumbling Sloe Comfortable Zoo	5	awesome	Last Available: "2012-03"
 5596	perfectly mixed Sloe Comfortable Zoo on Fire	4	EPIC	Last Available: "2012-03"
 5597	drinkable Suffering Sinner	3	good	Last Available: "2012-03"
 5598	bad pulsating Suppurating Sinner	3	decent	Last Available: "2012-03"
-5599	boozy artisanal Sizzling Sinner	5	EPIC	Last Available: "2012-03"
-5600	hand-crafted irresponsibly strong Firewater	10	EPIC	Last Available: "2012-03"
+5599	artisanal boozy Sizzling Sinner	5	EPIC	Last Available: "2012-03"
+5600	irresponsibly strong hand-crafted Firewater	10	EPIC	Last Available: "2012-03"
 5601	lousy wobbly twirling Earth and Firewater	4	decent	Last Available: "2012-03"
 5602	tolerable weak Earth, Wind and Firewater	2	good	Last Available: "2012-03"
 5603	perfectly mixed Slimosa	3	EPIC	Last Available: "2012-03"
-5604	practically non-alcoholic acceptable fancy Extra-slimy Slimosa	1	good	Effect: "Rain Dancin'", Effect Duration: 50, Last Available: "2012-03"
+5604	fancy acceptable practically non-alcoholic Extra-slimy Slimosa	1	good	Effect: "Rain Dancin'", Effect Duration: 50, Last Available: "2012-03"
 5605	tolerable Slimebite	3	good	Last Available: "2012-03"
 5606	drinkable Cement Mixer	3	good	Last Available: "2012-03"
 5607	practically non-alcoholic delicious yellow Jackhammer	1	awesome	Last Available: "2012-03"
@@ -5512,35 +5512,35 @@
 5609	acceptable Fauna Libre	3	good	Last Available: "2012-03"
 5610	mediocre Chakra Libre	3	decent	Last Available: "2012-03"
 5611	mediocre Aura Libre	3	decent	Last Available: "2012-03"
-5612	bad tumbling blue Sazerorc	4	decent	Last Available: "2012-03"
+5612	bad blue tumbling Sazerorc	4	decent	Last Available: "2012-03"
 5613	tolerable wobbly Sazuruk-hai	4	good	Last Available: "2012-03"
-5614	watered-down aged special Flaming Sazerorc	2	awesome	Effect: "Industrial Strength Starch", Effect Duration: 15, Last Available: "2012-03"
-5615	hand-crafted irresponsibly strong Green Velvet	8	EPIC	Last Available: "2012-03"
+5614	watered-down special aged Flaming Sazerorc	2	awesome	Effect: "Industrial Strength Starch", Effect Duration: 15, Last Available: "2012-03"
+5615	irresponsibly strong hand-crafted Green Velvet	8	EPIC	Last Available: "2012-03"
 5616	acceptable high-proof Green Muslin	6	good	Last Available: "2012-03"
-5617	tolerable practically non-alcoholic Green Burlap	1	good	Last Available: "2012-03"
+5617	practically non-alcoholic tolerable Green Burlap	1	good	Last Available: "2012-03"
 5618	practically non-alcoholic bad Mohobo	1	decent	Last Available: "2012-03"
 5619	bad Moonshine Mohobo	3	decent	Last Available: "2012-03"
 5620	drinkable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	tolerable Drunken Philosopher	3	good	Last Available: "2012-03"
 5622	tolerable watered-down Drunken Neurologist	2	good	Last Available: "2012-03"
 5623	acceptable watered-down Drunken Astrophysicist	2	good	Last Available: "2012-03"
-5624	special hand-crafted practically non-alcoholic pulsating Dark & Starry	1	EPIC	Effect: "Seriously Mutated", Effect Duration: 10, Last Available: "2012-03"
-5625	watered-down lousy Black Hole	2	decent	Last Available: "2012-03"
+5624	practically non-alcoholic hand-crafted special pulsating Dark & Starry	1	EPIC	Effect: "Seriously Mutated", Effect Duration: 10, Last Available: "2012-03"
+5625	lousy watered-down Black Hole	2	decent	Last Available: "2012-03"
 5626	bad Event Horizon	4	decent	Last Available: "2012-03"
 5627	weak artisanal fancy skewed Herring Daiquiri	2	EPIC	Effect: "Devil Inside", Effect Duration: 10, Last Available: "2012-03"
 5628	tolerable fortified Herring Wallbanger	5	good	Last Available: "2012-03"
-5629	high-proof hand-crafted huge Herringtini	8	EPIC	Last Available: "2012-03"
+5629	hand-crafted high-proof huge Herringtini	8	EPIC	Last Available: "2012-03"
 5630	bad Lollipop Drop	4	decent	Last Available: "2012-03"
-5631	aged irresponsibly strong Candy Alexander	7	awesome	Last Available: "2012-03"
+5631	irresponsibly strong aged Candy Alexander	7	awesome	Last Available: "2012-03"
 5632	delicious practically non-alcoholic Candicaine	1	awesome	Last Available: "2012-03"
 5633	weak artisanal Caipiranha	2	EPIC	Last Available: "2012-03"
 5634	acceptable Flying Caipiranha	3	good	Last Available: "2012-03"
-5635	special practically non-alcoholic bad Flaming Caipiranha	1	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2012-03"
+5635	bad special practically non-alcoholic Flaming Caipiranha	1	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2012-03"
 5636	perfectly mixed Punchplanter	4	EPIC	Last Available: "2012-03"
-5637	watered-down bad Doublepunchplanter	2	decent	Last Available: "2012-03"
+5637	bad watered-down Doublepunchplanter	2	decent	Last Available: "2012-03"
 5638	drinkable Haymaker	3	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
-5640	shaking mirror crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
+5640	mirror shaking crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	decent red fungus	3	good	
 5642	poisoned dart	0		
 5643	double-moist altered olive stone wool	0		Effect: "Fancy Feasted", Effect Duration: 62
@@ -5555,7 +5555,7 @@
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	toothsome nailswurst	4	awesome	
-5655	watered-down perfectly mixed used beer	2	EPIC	
+5655	perfectly mixed watered-down used beer	2	EPIC	
 5656	twirling Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5618,7 +5618,7 @@
 5717	toothsome green shaking FDKOL hotcakes	3	awesome	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	moldy half-sized fiery wing	2	crappy	Last Available: "2012-07"
+5720	half-sized moldy fiery wing	2	crappy	Last Available: "2012-07"
 5721	mirror Jack Frost's wings of fire of the cheetah	0		Cold Spell Damage: +50, Initiative: +60, Last Available: "2012-07"
 5722	FDKOL fire hose of the wise owl	0		Mysticality: +20, Last Available: "2012-07"
 5723	pressed polymerized bottle of fire	0		Effect: "The Moxie of LOV", Effect Duration: 41, Last Available: "2012-07"
@@ -5628,18 +5628,18 @@
 5727	hot daub stand of the scaredy-cat of the blizzard	0		Monster Level: -15, Cold Spell Damage: +25, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	lard-coated personal trainer's foot-long hot daub	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +25, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	adequate small red angst burger	2	good	
-5731	lousy weak 5-hour acrimony	2	decent	
-5732	spinning blurry blank note	0		
+5730	small adequate red angst burger	2	good	
+5731	weak lousy 5-hour acrimony	2	decent	
+5732	blurry spinning blank note	0		
 5733	eerily silent box	0		
 5734	bland forbidden sausage	3	decent	
-5735	aromatic Lord Flameface's cloak	0		Stench Resistance: +1, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	aromatic Lord Flameface's cloak	0		Stench Resistance: +1, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	nitrogenated narrow Drizzlers&trade; Black Licorice	0		Effect: "Phairly Balanced", Effect Duration: 11
 5737	corrupted daub-breaker	0		Effect: "Eagle Eyes", Effect Duration: 67, Last Available: "2020-09"
 5738	lard-coated Camp Scout backpack	0		Sleaze Spell Damage: +25, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	special adequate blinking bag of GORP	3	good	Effect: "Gummi-Grin", Effect Duration: 15, Last Available: "2012-07"
-5741	drinkable practically non-alcoholic water purification pills	1	good	Last Available: "2012-07"
+5741	practically non-alcoholic drinkable water purification pills	1	good	Last Available: "2012-07"
 5742	squat Camp Scout pup tent	0		Last Available: "2012-07"
 5743	enchanted tolerable CSA scoutmaster's &quot;water&quot;	4	good	Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2012-07"
 5744	bland bag of GORF	3	decent	Last Available: "2012-07"
@@ -5650,7 +5650,7 @@
 5749	drinkable CSA cheerfulness ration	4	good	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	maroon Tales of the Word Realms	0		
-5752	moldy snack-sized crappy brain	2	crappy	
+5752	snack-sized moldy crappy brain	2	crappy	
 5753	rotten immense decent brain	7	crappy	
 5754	spoiled narrow good brain	3	crappy	
 5755	huge decent boss brain	7	good	
@@ -5659,25 +5659,25 @@
 5759	blue nasty brainy staff	0		Mysticality: +5, Stench Damage: +5
 5760	prompt lightning-fast padded staff	0		Damage Absorption: +20, Initiative: +40, Adventures: +3
 5761	up-at-dawn sharpshooter's dangerous Staff of the Scummy Sink	0		Weapon Damage: +10, Critical Hit Percent: +10, Adventures: +5, Slime Hates It: +1
-5762	purple blinking nose	0		
+5762	blinking purple nose	0		
 5763	Superhero Reboots of the sewer of the overflowing toilet	0		Stench Damage: +25, Stench Spell Damage: +50
 5764	bouncing boxer's fuzzy busby of horror	0		Muscle Percent: +10, Spooky Spell Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5765	squat personal trainer's weightlifter's fuzzy earmuffs	0		Muscle: +15, Experience Percent (Muscle): +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	Socratic thinker's fuzzy montera of the bloodbag	0		Mysticality: +10, Experience (Mysticality): +1, Maximum HP: +100, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	squat gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "block"
-5770	twirling huge gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "delevel"
+5768	squat gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	huge twirling gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	maroon Thwaitgold maggot statuette	0		
 5774	shaking talkative skull	0		
 5775	fuchsia fronts	0		Familiar Weight: +5
 5776	blinking narrow therapeutic steel-toed Barney's rake	0		Damage Reduction: 9, HP Regen Min: 5, HP Regen Max: 7
-5778	decent enchanted squat idiot brain	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 10
+5778	enchanted decent squat idiot brain	3	good	Effect: "Human-Penguin Hybrid", Effect Duration: 10
 5779	reassuring keel-haulin' knife	0		Spooky Resistance: +1
 5780	tumbling stanky ice cream scoop	0		Stench Spell Damage: +25
-5781	special tolerable practically non-alcoholic soft echo eyedrop antidote martini	1	good	Effect: "Liquid Luck", Effect Duration: 40
+5781	practically non-alcoholic special tolerable soft echo eyedrop antidote martini	1	good	Effect: "Liquid Luck", Effect Duration: 40
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	mirror weirdwood plank	0		
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bouncing bubblin' crude	0		
 5790	jittery box of bear arms	0		Last Available: "2012-09"
-5791	ribald right bear arm of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	skewed auspicious nasty frosty left bear arm	0		Cold Spell Damage: +10, Stench Damage: +5, Item Drop: +10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	ribald right bear arm of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	skewed auspicious nasty frosty left bear arm	0		Cold Spell Damage: +10, Stench Damage: +5, Item Drop: +10, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	blinking upside-down Hat O' Nine Tails of courage	0		Spooky Resistance: +3
 5794	deionized concentrated polymerized Enchanted Plunger	0		Effect: "Healthy Bronze Glow", Effect Duration: 49
 5795	moist extra-flattened shaking Enchanted Flyswatter	0		Effect: "Magically Fingered", Effect Duration: 67
@@ -5696,7 +5696,7 @@
 5797	chilled ionized Missing Eye Simulation Device	0		Effect: "Well-preserved", Effect Duration: 44
 5798	triple-pressed super-concentrated anodized Gnollish Crossdress	0		Effect: "Sleazy Hands", Effect Duration: 43
 5799	ionized bouncing eldritch dough	0		Effect: "Eau de Tortue", Effect Duration: 35
-5800	enhanced warmed maroon shaking Charity's choker	0		Effect: "Educated (Sorta)", Effect Duration: 29
+5800	enhanced warmed shaking maroon Charity's choker	0		Effect: "Educated (Sorta)", Effect Duration: 29
 5801	double-deionized Smart Bone Dust	0		Effect: "Ponderous Potency", Effect Duration: 49
 5802	warmed perpendicular guano	0		Effect: "Cold Hard Skin", Effect Duration: 62
 5803	pressed narrow White Chocolate Golem Seeds	0		Effect: "Think Win-Lose", Effect Duration: 58
@@ -5704,7 +5704,7 @@
 5805	cold-filtered maroon breath mint	0		Effect: "Snobby", Effect Duration: 54
 5806	enhanced extra-activated flattened pulsating muesli	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 58
 5807	anodized ghostly glass of warm milk	0		Effect: "Sparkly!", Effect Duration: 66
-5808	oxidized ghostly lime green glass of gnat milk	0		Effect: "Mitre Cut", Effect Duration: 35
+5808	oxidized lime green ghostly glass of gnat milk	0		Effect: "Mitre Cut", Effect Duration: 35
 5809	altered Knob Goblin Mutagen	0		Effect: "Petit Forbearance", Effect Duration: 24
 5810	nitrogenated Tears of the Quiet Healer	0		Effect: "Danish Cunning", Effect Duration: 45
 5811	deionized tube of lipstick	0		Effect: "Mystically Oiled", Effect Duration: 37
@@ -5748,7 +5748,7 @@
 5849	polarized flattened handyman &quot;hand soap&quot;	0		Effect: "Greasy Flavor", Effect Duration: 60
 5850	pickled modified space marine flash grenade	0		Effect: "BOOsted", Effect Duration: 38
 5851	modified temporary tribal tattoo	0		Effect: "Sweet Tooth", Effect Duration: 58
-5852	irradiated boiled tumbling blurry oil-filled donut	0		Effect: "Heart of White", Effect Duration: 43
+5852	irradiated boiled blurry tumbling oil-filled donut	0		Effect: "Heart of White", Effect Duration: 43
 5853	liquefied blurry stick-on gnome beard	0		Effect: "X-Ray Vision", Effect Duration: 56
 5854	Vulcanized BRICKO stud	0		Effect: "Feline Ferocity", Effect Duration: 26
 5855	concentrated Osk'r Chow	0		Effect: "Leisurely Amblin'", Effect Duration: 44
@@ -5758,7 +5758,7 @@
 5859	polarized quantum aerosolized booby trap	0		Effect: "Good Motivator", Effect Duration: 58
 5860	moist Agent Corrigan's cigarette	0		Effect: "You Know Where to Go", Effect Duration: 69
 5861	boiled colloidal good ash	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 64
-5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	triple-vacuum-sealed frozen triple-warmed twirling papier-mochi	0		Effect: "Quiet 'n' Good", Effect Duration: 13, Last Available: "2012-09"
@@ -5806,7 +5806,7 @@
 5908	bouncing ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	greedy wedding ring of incineration	0		Hot Spell Damage: +50, Meat Drop: +20, Single Equip
 5910	olive deactivated nanobots	0		Free Pull, Last Available: "2012-11"
-5911	cyan blurry nanorhino credit card	0		Last Available: "2012-11"
+5911	blurry cyan nanorhino credit card	0		Last Available: "2012-11"
 5912	MacGyver's Solstice Shield of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +100
 5913	frozen anodized skewed candy sushi set	0		Effect: "Capricorn Rising", Effect Duration: 48, Last Available: "2012-12"
 5914	dry super-dry tumbling sweet mochi ball	0		Effect: "Wet Rub", Effect Duration: 49, Last Available: "2012-12"
@@ -5822,8 +5822,8 @@
 5924	wobbly wobbly electrical thingamabob	0		Last Available: "2012-12"
 5925	purple shaking ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
-5927	cyan shaking BittyCar HotCar	0		Last Available: "2012-12"
-5928	stylish brainwave-controlled unicorn horn	0		Moxie: +25, Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2"
+5927	shaking cyan BittyCar HotCar	0		Last Available: "2012-12"
+5928	stylish brainwave-controlled unicorn horn	0		Moxie: +25, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	purple mirror bubble-wrap simulator	0		Last Available: "2012-12"
 5930	lime green blind-packed capsule toy	0		Last Available: "2012-12"
 5931	asbestos-lined therapeutic plastic four-shadowed mime of courage	0		Hot Resistance: +5, Spooky Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2012-12"
@@ -5858,8 +5858,8 @@
 5960	greasy plastic Father McGruber	0		Sleaze Spell Damage: +10, Last Available: "2012-12"
 5961	ribald plastic Hank North, Photojournalist	0		Sleaze Damage: +10, Last Available: "2012-12"
 5962	up-at-dawn plastic blazing bat	0		Adventures: +5, Last Available: "2012-12"
-5963	narrow prompt friendly electronic dulcimer pants	0		Familiar Weight: +3, Adventures: +3, Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2"
-5964	yellow wobbly A-Boo clue	0		
+5963	narrow prompt friendly electronic dulcimer pants	0		Familiar Weight: +3, Adventures: +3, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5964	wobbly yellow A-Boo clue	0		
 5965	mirror Sherlock's grievous Frown Exerciser	0		Weapon Damage Percent: +50, Item Drop: +25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	soul doorbell	0		
@@ -5889,7 +5889,7 @@
 5991	blinking round bomb	0		Last Available: "2013-02"
 5992	teal chilly banded grievous iron helmet	0		Weapon Damage Percent: +50, Damage Absorption: +100, Cold Damage: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	squat zippy stanky friendly steel sword	0		Familiar Weight: +3, Stench Spell Damage: +25, Initiative: +20, Last Available: "2013-02"
-5994	massive moldy whole roasted chicken	10	crappy	Last Available: "2013-02"
+5994	moldy massive whole roasted chicken	10	crappy	Last Available: "2013-02"
 5995	purple massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	oxidized dry olive orcish hand lotion	0		Effect: "Big Flaming Whip", Effect Duration: 28
 6016	irradiated boiled orcish rubber	0		Effect: "Discomfited", Effect Duration: 32
 6017	flattened orcish nailing lube	0		Effect: "20-20 Second Sight", Effect Duration: 59
-6018	tolerable distilled backwoods screwdriver	5	good	
+6018	distilled tolerable backwoods screwdriver	5	good	
 6019	loadstone of the overflowing toilet	0		Stench Spell Damage: +50
 6020	spinning miser's Claybender glasses of Calamity Jane	0		Critical Hit Percent: +15, Meat Drop: +10, Single Equip
 6021	ribald boxer's Duskwalker fangs	0		Muscle Percent: +10, Sleaze Damage: +10
@@ -5947,11 +5947,11 @@
 6049	bouncing sizzling experienced boxer's Misty Cape	0		Muscle Percent: +10, Experience: +2, Hot Damage: +10
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	decent huge Taco Dan's Taco Stand Taco	6	good	Last Available: "2012-12"
-6053	bad maroon narrow Taco Dan's Taco Stand Chimichangarita	4	decent	Last Available: "2012-12"
+6052	huge decent Taco Dan's Taco Stand Taco	6	good	Last Available: "2012-12"
+6053	bad narrow maroon Taco Dan's Taco Stand Chimichangarita	4	decent	Last Available: "2012-12"
 6054	non-magnetized mirror Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Prelude of Precision", Effect Duration: 36, Last Available: "2012-12"
 6055	jittery psychoanalytic jar	0		Last Available: "2013-12"
-6056	pulsating narrow The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	narrow pulsating The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	executive Samson's Meatcleaver	0		Experience (Muscle): +5, Meat Drop: +40, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of the glutton	0		Food Drop: +100, Last Available: "2012-12"
 6059	supercool Crimbo stogie-scented room odorizer	0		Moxie Percent: +20, Last Available: "2012-12"
@@ -5966,17 +5966,17 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	spinning confusing LED clock	0		Last Available: "2012-12"
 6073	activated pickled super-activated skewed haggis-infused soap	0		Effect: "Smoking like a Bandit", Effect Duration: 67, Last Available: "2012-12"
 6074	dry magicberry tablets	0		Effect: "Speed of the Internet", Effect Duration: 66, Last Available: "2012-12"
 6075	wet alkaline modified 37x37x37 puzzle cube	0		Effect: "Nothing Is Impossible", Effect Duration: 54, Last Available: "2012-12"
-6076	triple-distilled tolerable McLeod's Hard Haggis-Ade	6	good	Last Available: "2012-12"
+6076	tolerable triple-distilled McLeod's Hard Haggis-Ade	6	good	Last Available: "2012-12"
 6077	stale haggis-wrapped haggis-stuffed haggis	3	decent	Last Available: "2012-12"
 6078	huge home robotics kit	0		Last Available: "2012-12"
 6079	skewed school calculator watch	0		Last Available: "2012-12"
-6080	narrow forbidden haggis socks	0		Spell Damage Percent: +50, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	gray airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	narrow forbidden haggis socks	0		Spell Damage Percent: +50, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	gray airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6044,7 +6044,7 @@
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	huge MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
-6150	huge bouncing Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
+6150	bouncing huge Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	adequate enchanted carrot cake	3	good	Effect: "Some Cheese with Your Wine", Effect Duration: 20, Last Available: "2013-01"
 6153	boozy aged carrot claret	5	awesome	Last Available: "2013-01"
@@ -6052,10 +6052,10 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	bouncing teal flickering pixel	0		Last Available: "2013-12"
 6157	Tesla Byte of wisdom	0		Mysticality: +15, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
-6158	jittery razor-sharp anger blaster	0		Weapon Damage Percent: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	boxer's doubt cannon	0		Muscle Percent: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	Annie Oakley's fear condenser	0		Critical Hit Percent: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	narrow regret hose of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	jittery razor-sharp anger blaster	0		Weapon Damage Percent: +25, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	boxer's doubt cannon	0		Muscle Percent: +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	Annie Oakley's fear condenser	0		Critical Hit Percent: +20, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	narrow regret hose of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	blurry Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	olive Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	blue boxer's commodore's hat of the blizzard	0		Muscle Percent: +10, Cold Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
@@ -6069,7 +6069,7 @@
 6172	concentrated cold-filtered fuchsia candy crayons	0		Effect: "Chalked-Up Teeth", Effect Duration: 34, Last Available: "2020-09"
 6173	fireproof smelly pixel grappling hook	0		Stench Spell Damage: +10, Hot Resistance: +3
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
-6175	upside-down jittery lime green GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
+6175	jittery lime green upside-down GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	cosmic dough	0		
 6178	cosmic vegetable	0		
@@ -6080,8 +6080,8 @@
 6183	squat bouncing cosmic fruit	0		
 6184	twirling Da Vinci's supercool cool Jarlsberg's hat	0		Moxie: +5, Moxie Percent: +20, Experience (Mysticality): +5
 6185	rotten consummate hard-boiled egg	4	crappy	
-6186	enchanted moldy consummate fried egg	4	crappy	Effect: "Enraged", Effect Duration: 5
-6187	tasty small consummate egg salad	2	awesome	
+6186	moldy enchanted consummate fried egg	4	crappy	Effect: "Enraged", Effect Duration: 5
+6187	small tasty consummate egg salad	2	awesome	
 6188	adequate consummate bagel	3	good	
 6189	bland consummate sliced bread	3	decent	
 6190	flavorless consummate hot dog bun	3	decent	
@@ -6090,47 +6090,47 @@
 6193	acceptable passable stout	3	good	
 6194	enchanted spoiled blinking consummate soup	3	crappy	Effect: "Strong Spirit", Effect Duration: 20
 6195	spoiled miniature fancy mirror consummate corn chips	2	crappy	Effect: "Cat Class, Cat Style", Effect Duration: 35
-6196	flavorless immense consummate salad	10	decent	
+6196	immense flavorless consummate salad	10	decent	
 6197	spoiled diet consummate salsa	1	crappy	
-6198	delicious half-sized tumbling shaking consummate sauerkraut	2	awesome	
+6198	delicious half-sized shaking tumbling consummate sauerkraut	2	awesome	
 6199	massive enchanted rotten bouncing consummate cheese slice	9	crappy	Effect: "Hardened Fabric", Effect Duration: 40
 6200	decent consummate melted cheese	4	good	
-6201	special rotten tiny consummate bacon	1	crappy	Effect: "Deeply Ironic", Effect Duration: 45
+6201	tiny rotten special consummate bacon	1	crappy	Effect: "Deeply Ironic", Effect Duration: 45
 6202	yummy upside-down consummate meatloaf	4	awesome	
 6203	low-calorie toothsome upside-down consummate steak	1	awesome	
 6204	rotten consummate cuts	3	crappy	
 6205	bland consummate frankfurter	3	decent	
 6206	spoiled consummate french fries	3	crappy	
 6207	rotten blue spinning consummate baked potato	3	crappy	
-6208	acceptable high-proof acceptable vodka	9	good	
-6209	decent enchanted consummate ice cream	3	good	Effect: "Bootyliciousness", Effect Duration: 40
-6210	miniature fancy bland consummate whipped cream	2	decent	Effect: "Sugar, Hello", Effect Duration: 25
+6208	high-proof acceptable acceptable vodka	9	good	
+6209	enchanted decent consummate ice cream	3	good	Effect: "Bootyliciousness", Effect Duration: 40
+6210	fancy bland miniature consummate whipped cream	2	decent	Effect: "Sugar, Hello", Effect Duration: 25
 6211	decent cyan consummate cream	3	good	
-6212	big stale upside-down consummate strawberries	5	decent	
+6212	stale big upside-down consummate strawberries	5	decent	
 6213	spoiled immense consummate sorbet	10	crappy	
-6214	lousy practically non-alcoholic adequate rum	1	decent	
+6214	practically non-alcoholic lousy adequate rum	1	decent	
 6215	mediocre mediocre lager	4	decent	
 6216	decent immaculate grilled cheese	4	good	
 6217	thick rotten immaculate ice cream sandwich	5	crappy	
-6218	fancy stale pulsating immaculate hot dog	3	decent	Effect: "Fire Inside", Effect Duration: 5
+6218	stale fancy pulsating immaculate hot dog	3	decent	Effect: "Fire Inside", Effect Duration: 5
 6219	tasty immaculate egg salad sandwich	3	awesome	
 6220	adequate teal perfect sandwich	3	good	
-6221	special stale perfect chef salad	3	decent	Effect: "Memento Moir&eacute;", Effect Duration: 10
+6221	stale special perfect chef salad	3	decent	Effect: "Memento Moir&eacute;", Effect Duration: 10
 6222	diet delicious wobbly ghostly perfect breakfast	1	awesome	
 6223	spoiled sublime deluxe hot dog	4	crappy	
 6224	adequate sublime stew	4	good	
 6225	adequate pulsating sublime nachos	3	good	
-6226	stale small Ultimate Breakfast Sandwich	2	decent	
+6226	small stale Ultimate Breakfast Sandwich	2	decent	
 6227	decent enchanted huge Loaded Baked Potato	8	good	Effect: "Patched In", Effect Duration: 40
 6228	delicious super-sized Omega Sundae	5	awesome	
-6229	watered-down hand-crafted fancy Das Sauerlager	2	EPIC	Effect: "Afternoon Insight", Effect Duration: 45
+6229	fancy hand-crafted watered-down Das Sauerlager	2	EPIC	Effect: "Afternoon Insight", Effect Duration: 45
 6230	tolerable tumbling Bologna Lambic	4	good	
 6231	acceptable boozy Vodka Dog	5	good	
 6232	artisanal Disappointed Russian	3	EPIC	
 6233	perfectly mixed Chunky Mary	4	EPIC	
 6234	bad Nachojito	4	decent	
-6235	bad watered-down gray Le Roi	2	decent	
-6236	artisanal watered-down fancy Over Easy Rider	2	EPIC	Effect: "Locks Like the Raven", Effect Duration: 45
+6235	watered-down bad gray Le Roi	2	decent	
+6236	fancy artisanal watered-down Over Easy Rider	2	EPIC	Effect: "Locks Like the Raven", Effect Duration: 45
 6237	cosmic six-pack	0		
 6239	ionized diffused cube of ectoplasm	0		Effect: "Elemental Mastery", Effect Duration: 12
 6240	quadruple-wet Illuminati earpiece	0		Effect: "Red Around the Gills", Effect Duration: 28
@@ -6147,7 +6147,7 @@
 6251	nitrogenated scroll of Protection from Bad Stuff	0		Effect: "Fishily Speeding", Effect Duration: 27, Last Available: "2013-02"
 6252	nitrogenated mirror scroll of Puddingskin	0		Effect: "Sweet Taste", Effect Duration: 65, Last Available: "2013-02"
 6253	wobbly Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
-6254	spinning teal narrow Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
+6254	narrow spinning teal Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
 6255	Spellbook: Drescher's Annoying Noise	0		Skill: "Drescher's Annoying Noise"
 6256	dried gelatinous cube	0		
 6257	pile of dungeon junk	0		Familiar Weight: +5
@@ -6164,7 +6164,7 @@
 6268	warmed warmed boiled pec oil	0		Effect: "Fitter, Happier", Effect Duration: 19
 6269	vibrating gym membership card	0		Maximum MP Percent: +10
 6270	super-enhanced altered purple Squat-Thrust Magazine	0		Effect: "Weapon of Mass Destruction", Effect Duration: 45
-6271	huge red massive dumbbell	0		
+6271	red huge massive dumbbell	0		
 6272	jittery reassuring dog trainer's penguin keychain	0		Experience (familiar): +1, Spooky Resistance: +1, Damage Reduction: 10
 6273	irradiated blinking O'RLY manual	0		Effect: "20/20 Vision", Effect Duration: 40
 6274	tolerable tumbling open sauce	4	good	
@@ -6174,7 +6174,7 @@
 6278	gray Ye Olde Medieval Insult	0		
 6279	mirror pewter claymore of the glutton	0		Food Drop: +100
 6280	mansplainer's artisanal rice peeler	0		Monster Level: +15
-6281	fancy spoiled heirloom grape tomato	3	crappy	Effect: "Lifted Spirits", Effect Duration: 25
+6281	spoiled fancy heirloom grape tomato	3	crappy	Effect: "Lifted Spirits", Effect Duration: 25
 6282	chipotle wasabi cilantro aioli	0		
 6283	skewed narrow brown felt tophat of the ox	0		Muscle: +20, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6186,9 +6186,9 @@
 6290	steam-powered model rocketship	0		
 6291	yellow ghostly tumbling sage punk rock jacket of Leguizamo	0		Mysticality Percent: +10, Monster Level: +20
 6292	medical-grade quilted safety pin	0		Damage Absorption: +40, HP Regen Min: 7, HP Regen Max: 10
-6293	snack-sized spoiled stolen sushi	2	crappy	
+6293	spoiled snack-sized stolen sushi	2	crappy	
 6294	very overdue library book	0		
-6295	huge fuchsia drum 'n' bass 'n' drum 'n' bass record	0		
+6295	fuchsia huge drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	huge Thwaitgold firefly statuette	0		
@@ -6222,7 +6222,7 @@
 6326	MacGyver's pearl diver's ring of the businessman	0		Maximum MP: +100, Meat Drop: +50, Single Equip
 6327	Usain Bolt's Sinatra's pearl diver's necklace	0		Experience (Moxie): +5, Initiative: +80, Single Equip
 6328	skewed sushi doily	0		
-6329	spinning blinking scimitar cozy	0		
+6329	blinking spinning scimitar cozy	0		
 6330	pulsating fish stick cozy	0		
 6331	bazooka cozy	0		
 6332	frightening quilted cozy scimitar of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +40, Spooky Damage: +5
@@ -6248,12 +6248,12 @@
 6352	teal huge Rosewater's Mer-kin stopwatch	0		Mysticality Percent: +30, Initiative: +50
 6353	Mer-kin dreadscroll	0		
 6354	vacuum-sealed ionized Mer-kin smartjuice	0		Effect: "Memento Moir&eacute;", Effect Duration: 60
-6355	nitrogenated shaking green Mer-kin cooljuice	0		Effect: "Sepia Tan", Effect Duration: 32
+6355	nitrogenated green shaking Mer-kin cooljuice	0		Effect: "Sepia Tan", Effect Duration: 32
 6356	Mer-kin worktea	0		
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	wicked Mer-kin begsign	0		Spell Damage: +5, Meat Drop: +40
-6360	ghostly Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	ghostly Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	triple-galvanized pulled taffy	0		Effect: "Libra Rising", Effect Duration: 60, Last Available: "2013-04"
 6362	denatured teal pulled indigo taffy	0		Effect: "Mint-Condition Breath", Effect Duration: 28, Last Available: "2013-04"
 6363	double-pickled triple-tarnished magnetized pulled taffy	0		Effect: "Egg-stortionary Tactics", Effect Duration: 40, Last Available: "2013-04"
@@ -6264,7 +6264,7 @@
 6368	wobbly Mer-kin hallpass	0		
 6369	upside-down lump of clay	0		
 6370	twisted piece of wire	0		
-6371	fortified hand-crafted shaking can of the cheapest beer	5	EPIC	
+6371	hand-crafted fortified shaking can of the cheapest beer	5	EPIC	
 6372	perfectly mixed bottle of fruity &quot;wine&quot;	3	EPIC	
 6373	watered-down perfectly mixed single swig of vodka	2	EPIC	
 6374	mirror angry inch	0		
@@ -6308,10 +6308,10 @@
 6413	shaking Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	special rotten twirling flavorless gruel	3	crappy	Effect: "Morninja", Effect Duration: 30
-6416	yummy thick tumbling mana curds	5	awesome	
+6416	thick yummy tumbling mana curds	5	awesome	
 6417	twist of lime	0		
 6418	pencil stub	0		
-6419	dry skewed maroon moth dust	0		Effect: "Wallflowering", Effect Duration: 23
+6419	dry maroon skewed moth dust	0		Effect: "Wallflowering", Effect Duration: 23
 6420	alkaline lime green glob of spoiled mayo	0		Effect: "Yes, Can Haz", Effect Duration: 55
 6421	shaking tonic djinn	0		
 6422	bland special vampire chowder	3	decent	Effect: "Permanent Halloween", Effect Duration: 15
@@ -6319,7 +6319,7 @@
 6424	Dreadsylvanian skeleton key	0		
 6425	maroon Official Seal of Dreadsylvania	0		
 6426	normal Dreadsylvanian stew	3	good	
-6427	high-proof smooth teal Dreadsylvanian	6	awesome	
+6427	smooth high-proof teal Dreadsylvanian	6	awesome	
 6428	non-altered corrupted Dreadsylvanian flask	0		Effect: "Ass Over Teakettle", Effect Duration: 42
 6429	quadruple-magnetized aerosolized fuchsia Dreadsylvanian flask	0		Effect: "Wet Willied", Effect Duration: 28
 6430	occult Herculean dreadful fedora	0		Experience (Muscle): +1, Spell Damage Percent: +25, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6360,7 +6360,7 @@
 6465	Jeselnik's supercool beefy Mayor Ghost's gavel	0		Muscle: +10, Moxie Percent: +20, Sleaze Damage: +25, Conditional Skill (Equipped): "Hammer Ghost"
 6466	friendly mansplainer's crafty Mayor Ghost's sash	0		Maximum MP: +10, Monster Level: +15, Familiar Weight: +3, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	enchanted flavorless yellow ghost pepper	4	decent	Effect: "Human-Undead Hybrid", Effect Duration: 20
+6468	flavorless enchanted yellow ghost pepper	4	decent	Effect: "Human-Undead Hybrid", Effect Duration: 20
 6469	fuchsia spinning fireproof frightening Thunkula's drinking cap of the early riser	0		Spooky Damage: +5, Hot Resistance: +3, Adventures: +7, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	flame-retardant Drunkula's cape of the sweet-tooth of the cheetah	0		Hot Resistance: +1, Candy Drop: +100, Initiative: +60, Class: "Sauceror"
 6471	purple perfumed Drunkula's silky pants of the bloodbag of terror	0		Maximum HP: +100, Spooky Spell Damage: +10, Stench Resistance: +5, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
@@ -6390,7 +6390,7 @@
 6495	shaking frightening Dreadsylvania Auditor's badge	0		Spooky Damage: +5, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
-6498	acceptable watered-down bloody kiwitini	2	good	
+6498	watered-down acceptable bloody kiwitini	2	good	
 6499	moon-amber	0		
 6500	polished moon-amber	0		
 6501	up-at-dawn Socratic moon-amber necklace of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Adventures: +5, Single Equip
@@ -6410,7 +6410,7 @@
 6515	eerie fetish of the businessman	0		Meat Drop: +50, Single Equip
 6516	delicious blurry stinkwater	4	awesome	
 6517	bouncing ghostly dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	adequate snack-sized jittery olive accidental mutton	2	good	
+6518	snack-sized adequate jittery olive accidental mutton	2	good	
 6519	fuchsia prompt drafty drawers of the cougar	0		Moxie: +20, Adventures: +3, Familiar Effect: "1.5xVolley"
 6520	gravedigger's wolfskull mask of the glutton	0		Spooky Damage: +10, Food Drop: +100, Familiar Effect: "spooky atk, 1xBarrr"
 6521	lime green guts necklace of the ox	0		Muscle: +20, Single Equip
@@ -6449,21 +6449,21 @@
 6555	mirror jittery sleaze cluster	0		
 6556	pressed wet diffused phial of hotness	0		Effect: "Superveiny 9000", Effect Duration: 44
 6557	vacuum-sealed squat phial of coldness	0		Effect: "Gobliny Flavor", Effect Duration: 14
-6558	extra-concentrated pulsating ghostly maroon phial of spookiness	0		Effect: "Human-Hippy Hybrid", Effect Duration: 29
+6558	extra-concentrated pulsating maroon ghostly phial of spookiness	0		Effect: "Human-Hippy Hybrid", Effect Duration: 29
 6559	extra-Vulcanized non-flattened phial of stench	0		Effect: "Tenacity of the Snapper", Effect Duration: 20
 6560	ionized double-nitrogenated narrow phial of sleaziness	0		Effect: "Smugness", Effect Duration: 59
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	blinking mini-Mr. Accessory	0		Familiar Weight: +5
 6563	wool hand of Mr. Cards	0		Cold Resistance: +1, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	spoiled super-sized shaking yellow Dreadsylvanian hot pocket	5	crappy	
+6564	super-sized spoiled shaking yellow Dreadsylvanian hot pocket	5	crappy	
 6565	fancy flavorless twirling Dreadsylvanian pocket	4	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40
 6566	spoiled Dreadsylvanian pocket	3	crappy	
 6567	spoiled ghostly Dreadsylvanian stink pocket	3	crappy	
-6568	huge rotten Dreadsylvanian sleaze pocket	6	crappy	
-6569	lousy pulsating green Dreadsylvanian hot toddy	3	decent	
+6568	rotten huge Dreadsylvanian sleaze pocket	6	crappy	
+6569	lousy green pulsating Dreadsylvanian hot toddy	3	decent	
 6570	tolerable teal Dreadsylvanian cold-fashioned	3	good	
 6571	mediocre Dreadsylvanian grimlet	3	decent	
-6572	artisanal weak Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	
+6572	weak artisanal Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	
 6573	perfectly mixed Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	skewed flame-wreathed vibrating gnawed-up dog bone	0		Maximum MP Percent: +10, Hot Spell Damage: +10
 6589	asbestos-lined Grey Guanon	0		Hot Resistance: +5
 6590	up-at-dawn sharpshooter's supercool Engorged Sausages and You	0		Moxie Percent: +20, Critical Hit Percent: +10, Adventures: +5
-6591	enchanted lousy practically non-alcoholic dream of a dog	1	decent	Effect: "Meat the Flintstones", Effect Duration: 30
+6591	lousy practically non-alcoholic enchanted dream of a dog	1	decent	Effect: "Meat the Flintstones", Effect Duration: 30
 6592	bouncing scorching razor-sharp optimal spreadsheet of the cougar	0		Moxie: +20, Weapon Damage Percent: +25, Hot Damage: +25
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
@@ -6560,7 +6560,7 @@
 6668	Faraday cage	0		
 6669	modeling claymore	0		
 6670	clay homunculus	0		
-6671	corrupted dry teal twirling bouncing sodium pentasomething	0		Effect: "Cranberry Cordiality", Effect Duration: 67
+6671	corrupted dry twirling bouncing teal sodium pentasomething	0		Effect: "Cranberry Cordiality", Effect Duration: 67
 6672	grains of salt	0		
 6673	yellowcake bomb	0		
 6674	stinkbomb	0		
@@ -6583,7 +6583,7 @@
 6691	McClusky file (page 3)	0		
 6692	McClusky file (page 4)	0		
 6693	gray McClusky file (page 5)	0		
-6694	shaking pulsating boring binder clip	0		
+6694	pulsating shaking boring binder clip	0		
 6695	McClusky file (complete)	0		
 6696	bowling ball	0		
 6697	blue moss-covered stone sphere	0		
@@ -6613,7 +6613,7 @@
 6721	horrifying water bottle of the ox of the cougar	0		Muscle: +20, Moxie: +20, Spooky Damage: +25, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	super-Vulcanized pygmy phone number	0		Effect: "Extra-Wet", Effect Duration: 39
 6723	Boozehounds Anonymous token	0		
-6724	decent low-calorie exotic jungle fruit	1	good	
+6724	low-calorie decent exotic jungle fruit	1	good	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	squat tropical island souvenir crate	0		
@@ -6634,26 +6634,26 @@
 6742	olive pulsating censurious junk band	0		Sleaze Resistance: +3
 6743	ghostly sinister junk trunks	0		Spell Damage: +10, Familiar Effect: "cap 15"
 6744	junk-mail shirt of the pedagogue	0		Experience: +3
-6745	spoiled low-calorie mirror upside-down junk food	1	crappy	
-6746	tolerable high-proof junk yard	6	good	
+6745	low-calorie spoiled mirror upside-down junk food	1	crappy	
+6746	high-proof tolerable junk yard	6	good	
 6747	sharpshooter's swordzall of the scaredy-cat	0		Critical Hit Percent: +10, Monster Level: -15
 6748	Newton's arm buzzer	0		Experience (Mysticality): +3, Damage Reduction: 6
 6749	lion tamer's boilgun of the blizzard	0		Experience (familiar): +2, Cold Spell Damage: +25
-6750	blinking cyan Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
+6750	cyan blinking Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	packet of beer seeds	0		Last Available: "2013-09"
 6752	skewed shaking handful of barley	0		
 6753	cluster of hops	0		
 6754	beer bottle	0		
-6755	squat ghostly fuchsia beer label	0		
+6755	fuchsia ghostly squat beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	lousy mirror narrow can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
 6758	perfectly mixed shaking can of Drooling Monk	3	EPIC	Last Available: "2013-09"
-6759	tolerable weak can of Impetuous Scofflaw	2	good	Last Available: "2013-09"
-6760	artisanal triple-distilled narrow bottle of Old Pugilist	10	EPIC	Last Available: "2013-09"
+6759	weak tolerable can of Impetuous Scofflaw	2	good	Last Available: "2013-09"
+6760	triple-distilled artisanal narrow bottle of Old Pugilist	10	EPIC	Last Available: "2013-09"
 6761	high-proof lousy bouncing pulsating bottle of Professor Beer	10	decent	Last Available: "2013-09"
 6762	tolerable watered-down red bottle of Rapier Witbier	2	good	Last Available: "2013-09"
-6763	fancy acceptable bottle of Race Car Red	4	good	Effect: "Badger Underfoot", Effect Duration: 15, Last Available: "2013-09"
-6764	weak bad ghostly bottle of Greedy Dog	2	decent	Last Available: "2013-09"
+6763	acceptable fancy bottle of Race Car Red	4	good	Effect: "Badger Underfoot", Effect Duration: 15, Last Available: "2013-09"
+6764	bad weak ghostly bottle of Greedy Dog	2	decent	Last Available: "2013-09"
 6765	lousy bottle of Lambada Lambic	4	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
@@ -6714,14 +6714,14 @@
 6825	sharpshooter's alarm accordion of mayonnaise	0		Critical Hit Percent: +10, Sleaze Spell Damage: +50, Class: "Accordion Thief", Song Duration: 20
 6826	olive scandalous brainy strapping All-Hallow's Steve's fright wig	0		Muscle: +5, Mysticality: +5, Sleaze Damage: +5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	Tesla sage KoL Con X Treasure Map	0		Mysticality Percent: +10, MP Regen Min: 7, MP Regen Max: 10
-6828	mediocre weak discocktail	2	decent	
+6828	weak mediocre discocktail	2	decent	
 6829	KoL Con X Bingo Card of the overflowing toilet	0		Stench Spell Damage: +50
 6830	Temporal Tempera Tube of the pedagogue	0		Experience: +3
 6831	energized Tallowcreme Halloween Pumpkin	0		Effect: "Bricked-In", Effect Duration: 14
 6832	Way More Tears&trade; pepper spray	0		
 6833	alkaline flattened purple Milk Studs	0		Effect: "Frigid Weapon", Effect Duration: 63
 6834	polymerized box of Dweebs	0		Effect: "Larger", Effect Duration: 56
-6835	tarnished altered wobbly teal narrow bag of W&Ws	0		Effect: "Super Structure", Effect Duration: 26
+6835	tarnished altered wobbly narrow teal bag of W&Ws	0		Effect: "Super Structure", Effect Duration: 26
 6836	quadruple-liquefied PEEZ dispenser	0		Effect: "Berry Critical", Effect Duration: 11
 6837	pickled extra-nitrogenated squat tumbling Swizzler	0		Effect: "Remaining Alive", Effect Duration: 33
 6838	tarnished pulsating Bugbearclaw Donut	0		Effect: "The Wisdom... of the Future", Effect Duration: 30
@@ -6746,21 +6746,21 @@
 6857	maroon forbidden Cajun accordion	0		Spell Damage Percent: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	Newton's quirky accordion	0		Experience (Mysticality): +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	Sherlock's double-paned Skipper's accordion	0		Cold Resistance: +5, Item Drop: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	narrow coward's Fonzie's beefcake's Pantsgiving of the brazier	0		Muscle: +25, Experience (Moxie): +1, Monster Level: -20, Hot Spell Damage: +25, Softcore Only, Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25"
+6860	narrow coward's Fonzie's beefcake's Pantsgiving of the brazier	0		Muscle: +25, Experience (Moxie): +1, Monster Level: -20, Hot Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	moldy can of sardines	4	crappy	Last Available: "2013-11"
 6862	huge normal high-calorie sugar substitute	6	good	Last Available: "2013-11"
 6863	stale pat of butter	3	decent	Last Available: "2013-11"
-6864	stale enchanted dinner roll	4	decent	Effect: "Stench Jellied", Effect Duration: 40, Last Available: "2013-11"
-6865	jumbo spoiled mashed potatoes	5	crappy	Last Available: "2013-11"
+6864	enchanted stale dinner roll	4	decent	Effect: "Stench Jellied", Effect Duration: 40, Last Available: "2013-11"
+6865	spoiled jumbo mashed potatoes	5	crappy	Last Available: "2013-11"
 6866	decent snack-sized whole turkey leg	2	good	Last Available: "2013-11"
 6867	decent deviled egg	3	good	Last Available: "2013-11"
 6868	cold-filtered yellow finger exerciser	0		Effect: "Human-Orc Hybrid", Effect Duration: 44, Last Available: "2013-11"
 6869	liquefied blurry dented spoon	0		Effect: "Flame-Retardant Trousers", Effect Duration: 40, Last Available: "2013-11"
-6870	ionized yellow jittery love note	0		Effect: "Starry-Eyed", Effect Duration: 19, Last Available: "2013-11"
+6870	ionized jittery yellow love note	0		Effect: "Starry-Eyed", Effect Duration: 19, Last Available: "2013-11"
 6871	skewed huge school beer pull tab	0		Last Available: "2013-11"
 6872	irradiated energized extra-energized fuchsia nail file	0		Effect: "Slimy Flavor", Effect Duration: 32, Last Available: "2013-11"
 6873	liquefied candy wrapper	0		Effect: "Blubbered Up", Effect Duration: 45, Last Available: "2013-11"
-6874	shaking blinking gym membership card	0		Last Available: "2013-11"
+6874	blinking shaking gym membership card	0		Last Available: "2013-11"
 6875	aerosolized post-holiday sale coupon	0		Effect: "Polka of Plenty", Effect Duration: 24, Last Available: "2013-11"
 6876	tumbling dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
@@ -6771,7 +6771,7 @@
 6882	wobbly double-paned Tesla curative steel-toed power sock	0		Damage Reduction: 9, Cold Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2013-11"
 6883	smartaleck's slick wool sock of the brute of the brazier	0		Moxie: +10, Muscle Percent: +30, Moxie Percent: +30, Hot Spell Damage: +25, Single Equip, Last Available: "2013-11"
 6884	hardy occult moustache sock of Leguizamo of temperance	0		Spell Damage Percent: +25, Maximum HP: +50, Monster Level: +20, Sleaze Resistance: +5, Single Equip, Last Available: "2013-11"
-6885	ionized extra-polymerized narrow tumbling spirit gum	0		Effect: "Cock of the Walk", Effect Duration: 16
+6885	ionized extra-polymerized tumbling narrow spirit gum	0		Effect: "Cock of the Walk", Effect Duration: 16
 6886	spirit pillow	0		
 6887	blinking spirit sheet	0		
 6888	spirit mattress	0		
@@ -6786,13 +6786,13 @@
 6897	deionized adjusted galvanized Can of Spaghetto	0		Effect: "Puddingskin", Effect Duration: 67, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	fuchsia Thwaitgold ant statuette	0		
-6900	jittery shaking experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
+6900	shaking jittery experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	bouncing hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	blurry thinker's flask flops of the detective	0		Mysticality: +10, Item Drop: +20, Single Equip
-6903	chilled pulsating tumbling blurry nuts	0		Effect: "Remaining Alive", Effect Duration: 63, Last Available: "2013-12"
+6903	chilled tumbling pulsating blurry nuts	0		Effect: "Remaining Alive", Effect Duration: 63, Last Available: "2013-12"
 6904	adjusted ionized red bolts	0		Effect: "Hood Ridin'", Effect Duration: 25, Last Available: "2013-12"
 6905	decent jittery gingerbread robot	4	good	Last Available: "2013-12"
-6906	bland immense petit 4.1	7	decent	Last Available: "2013-12"
+6906	immense bland petit 4.1	7	decent	Last Available: "2013-12"
 6907	snack-sized spoiled nut-shaped Crimbo cookie	2	crappy	Last Available: "2023-06"
 6908	wizardly plastic GORM-8	0		Mysticality: +25, Last Available: "2013-12"
 6909	olive MacGyver's plastic warbear	0		Maximum MP: +100, Last Available: "2013-12"
@@ -6808,11 +6808,11 @@
 6919	denatured pressed warbear bearserker potion	0		Effect: "Compensatory Cruelness", Effect Duration: 34, Last Available: "2013-12"
 6920	flattened flattened warbear liquid overcoat	0		Effect: "Cinnamouth", Effect Duration: 20, Last Available: "2013-12"
 6921	jumbo flavorless jittery jittery warbear feasting bread	5	decent	Last Available: "2013-12"
-6922	half-sized moldy skewed warbear warrior bread	2	crappy	Last Available: "2013-12"
+6922	moldy half-sized skewed warbear warrior bread	2	crappy	Last Available: "2013-12"
 6923	adequate snack-sized twirling huge warbear thermoregulator bread	2	good	Last Available: "2013-12"
 6924	bad warbear feasting mead	3	decent	Last Available: "2013-12"
-6925	acceptable weak spinning warbear bearserker mead	2	good	Last Available: "2013-12"
-6926	watered-down delicious warbear blizzard mead	2	awesome	Last Available: "2013-12"
+6925	weak acceptable spinning warbear bearserker mead	2	good	Last Available: "2013-12"
+6926	delicious watered-down warbear blizzard mead	2	awesome	Last Available: "2013-12"
 6927	tumbling warbear helm fragment	0		Last Available: "2013-12"
 6928	huge wool toasty lion tamer's warbear plain fedora	0		Experience (familiar): +2, Hot Damage: +5, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	wobbly warbear feathered fedora of the cougar	0		Moxie: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6847,7 +6847,7 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	warbear foil hat	0		Item Drop: +5, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	thinker's warbear oil pan of Gandalf	0		Mysticality: +10, Spell Critical Percent: +20, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	thinker's warbear oil pan of Gandalf	0		Mysticality: +10, Spell Critical Percent: +20, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	greedy warbear exhaust manifold	0		Meat Drop: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	lime green warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,18 +6889,18 @@
 7000	skewed nasty Sinatra's die-cast Don Crimbo	0		Experience (Moxie): +5, Stench Damage: +5, Last Available: "2013-12"
 7001	huge smooth die-cast Uncle Hobo of the businessman	0		Moxie: +15, Meat Drop: +50, Last Available: "2013-12"
 7002	narrow shaking MacGyver's groovy die-cast Father Crimbo	0		Moxie Percent: +10, Maximum MP: +100, Last Available: "2013-12"
-7003	pulsating The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	pulsating The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	ionized non-warmed Flaskfull of Hollow	0		Effect: "Dreams and Lights", Effect Duration: 14, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	diluted handful of Smithereens	1	awesome	Last Available: "2013-12"
 7007	spoiled shaking Every Day is Like This Sundae	4	crappy	Last Available: "2013-12"
-7008	small moldy Miserable Pie	2	crappy	Last Available: "2013-12"
+7008	moldy small Miserable Pie	2	crappy	Last Available: "2013-12"
 7009	huge adequate This Charming Flan	7	good	Last Available: "2013-12"
 7010	weak tolerable Irish Coffee, English Heart	2	good	Last Available: "2013-12"
-7011	drinkable practically non-alcoholic shaking Strikes Again Bigmouth	1	good	Last Available: "2013-12"
+7011	practically non-alcoholic drinkable shaking Strikes Again Bigmouth	1	good	Last Available: "2013-12"
 7012	tolerable Paint A Vulgar Pitcher	4	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
-7014	cyan ghostly Louder Than Bomb	0		Last Available: "2013-12"
+7014	ghostly cyan Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
 7016	chilly hardened Work is a Four Letter Sword of terror of the businessman	0		Damage Reduction: 3, Cold Damage: +5, Spooky Spell Damage: +10, Meat Drop: +50, Last Available: "2013-12"
 7017	knitted Jeselnik's educational Staff of the Headmaster's Victuals of horror	0		Experience: +1, Spooky Spell Damage: +25, Sleaze Damage: +25, Cold Resistance: +3, Last Available: "2013-12"
@@ -6918,8 +6918,8 @@
 7029	grievous smartaleck's Shakespeare's Sister's Accordion of horror	0		Moxie Percent: +30, Weapon Damage Percent: +50, Spooky Spell Damage: +25, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	Lo Pan's third-hand lantern	0		Spell Critical Percent: +30
 7031	loose purse strings	0		
-7032	decent miniature pickled egg	2	good	
-7033	tumbling wobbly cup of lukewarm tea	1	decent	
+7032	miniature decent pickled egg	2	good	
+7033	wobbly tumbling cup of lukewarm tea	1	decent	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	huge warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
@@ -6931,7 +6931,7 @@
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	shaking warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	liquefied ionized glass slipper	0		Effect: "Ticking Clock", Effect Duration: 48, Last Available: "2014-12"
-7045	twisted shaking green antimatter wad	1	awesome	Effect: "Hammertime", Effect Duration: 15, Last Available: "2013-12"
+7045	twisted green shaking antimatter wad	1	awesome	Effect: "Hammertime", Effect Duration: 15, Last Available: "2013-12"
 7046	non-deionized warbear superpotion	0		Effect: "Haunted Liver", Effect Duration: 41, Last Available: "2013-12"
 7047	aerosolized quantum denatured yellow twirling warbear liquid lasers	0		Effect: "Triangle, Man", Effect Duration: 61, Last Available: "2013-12"
 7048	adjusted enhanced shaking warbear rejuvenation potion	0		Effect: "Cockroach Scurry", Effect Duration: 16, Last Available: "2013-12"
@@ -6941,7 +6941,7 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	moldy miniature enchanted breakfast mess	2	crappy	Effect: "Creepin' Up on You", Effect Duration: 10, Last Available: "2013-12"
+7055	enchanted miniature moldy breakfast mess	2	crappy	Effect: "Creepin' Up on You", Effect Duration: 10, Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	spoiled green narrow breakfast miracle	4	crappy	Last Available: "2013-12"
 7058	colloidal red Cloaca Cola Polar	0		Effect: "Gamer Rage", Effect Duration: 21, Last Available: "2013-12"
@@ -6964,19 +6964,19 @@
 7075	double-pickled liquid ice pack	0		Effect: "Puzzle Fury", Effect Duration: 57, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	flavorless snow crab	3	decent	Last Available: "2014-01"
-7078	distilled artisanal Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
+7078	artisanal distilled Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	jittery ice sculpture	0		Last Available: "2014-01"
 7081	spinning ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	ghostly frosty snow mobile	0		Cold Spell Damage: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	ghostly frosty snow mobile	0		Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	padded ice bucket	0		Damage Absorption: +20, Lasts Until Rollover, Last Available: "2014-01"
 7085	Sherlock's shellacked snow shovel	0		Damage Reduction: 7, Item Drop: +25, Lasts Until Rollover, Last Available: "2014-01"
 7086	mansplainer's beefy bod-ice of the cougar	0		Muscle: +10, Moxie: +20, Monster Level: +15, Lasts Until Rollover, Last Available: "2014-01"
 7087	blinking yellow asbestos-lined therapeutic Herculean snow belt of the overflowing toilet	0		Experience (Muscle): +1, Stench Spell Damage: +50, Hot Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	Jeselnik's rosy-cheeked ice nine of the empath of courage	0		Maximum HP Percent: +30, Familiar Weight: +5, Sleaze Damage: +25, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	fancy weak drinkable En Una Fila Tequila	2	good	Effect: "Perfect Hair", Effect Duration: 35
+7090	drinkable weak fancy En Una Fila Tequila	2	good	Effect: "Perfect Hair", Effect Duration: 35
 7091	Skully's hot chocolate	1	crappy	
 7092	upside-down smelly sage warbear dress helmet	0		Mysticality Percent: +10, Stench Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	tumbling gravedigger's Oprah's warbear dress bracers	0		Maximum MP Percent: +50, Spooky Damage: +10, Single Equip, Last Available: "2013-12"
@@ -6992,12 +6992,12 @@
 7103	chilled irradiated powder	0		Effect: "Well-Swabbed Ear", Effect Duration: 19, Last Available: "2014-12"
 7104	double-paned licorice whip	0		Cold Resistance: +5, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	hand-crafted watered-down squat tumbling snakebite	2	EPIC	Last Available: "2014-12"
+7106	watered-down hand-crafted tumbling squat snakebite	2	EPIC	Last Available: "2014-12"
 7107	frightening brawny candy stick	0		Muscle Percent: +20, Spooky Damage: +5, Last Available: "2014-12"
-7108	huge rotten wobbly pecan	9	crappy	Last Available: "2014-12"
+7108	rotten huge wobbly pecan	9	crappy	Last Available: "2014-12"
 7109	decent pecan pie	3	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	snack-sized decent olive candy mountain oyster	2	good	Last Available: "2014-12"
+7111	decent snack-sized olive candy mountain oyster	2	good	Last Available: "2014-12"
 7112	tolerable triple-distilled chocotini	10	good	Last Available: "2014-12"
 7113	mansplainer's Fonzie's chocolate rabbit's foot of Flo-Jo	0		Experience (Moxie): +1, Monster Level: +15, Initiative: +100, Last Available: "2014-12"
 7114	moldy candy carrot	4	crappy	Last Available: "2014-12"
@@ -7020,20 +7020,20 @@
 7131	spinning frosty crafty groovy cow creamer	0		Moxie Percent: +10, Maximum MP: +10, Cold Spell Damage: +10, Last Available: "2014-12"
 7132	tarnished Outer Wolf&trade; cologne	0		Effect: "Trash-Wrapped", Effect Duration: 64, Last Available: "2014-12"
 7133	upside-down lupine appetite hormones	0		Last Available: "2014-12"
-7134	lightning-fast wolf whistle of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +40, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	lightning-fast wolf whistle of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +40, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	stale witch's bread	3	decent	Last Available: "2014-12"
 7136	improved blurry witch's brew	0		Effect: "Burning Tongue", Effect Duration: 55, Last Available: "2014-12"
 7137	rock-hard witch's bra of chilblains of doom	0		Damage Reduction: 5, Cold Damage: +25, Spooky Spell Damage: +50, Last Available: "2014-12"
 7138	drinkable mid-level medieval mead	3	good	Last Available: "2014-12"
-7139	nitrogenated squat bouncing R&uuml;mpelstiltz	0		Effect: "Wax On Your Shoes", Effect Duration: 63, Last Available: "2014-12"
+7139	nitrogenated bouncing squat R&uuml;mpelstiltz	0		Effect: "Wax On Your Shoes", Effect Duration: 63, Last Available: "2014-12"
 7140	bouncing spinning wheel	0		Last Available: "2014-12"
-7141	Vulcanized twirling blue hi-octane carrot juice	0		Effect: "Hella Smart", Effect Duration: 45, Last Available: "2014-12"
+7141	Vulcanized blue twirling hi-octane carrot juice	0		Effect: "Hella Smart", Effect Duration: 45, Last Available: "2014-12"
 7142	frozen hare brush	0		Effect: "Snobby", Effect Duration: 31, Last Available: "2014-12"
 7143	ghostly lion tamer's Tesla hare pin	0		Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2014-12"
 7144	spinning odd coin	0		Last Available: "2014-12"
 7145	flavorless shaking maroon cinnamon cannoli	3	decent	Last Available: "2014-12"
-7146	aged enchanted expensive champagne	4	awesome	Effect: "Disco State of Mind", Effect Duration: 5, Last Available: "2014-12"
-7147	concentrated jittery purple polo trophy	0		Effect: "Sludgesick", Effect Duration: 69, Last Available: "2014-12"
+7146	enchanted aged expensive champagne	4	awesome	Effect: "Disco State of Mind", Effect Duration: 5, Last Available: "2014-12"
+7147	concentrated purple jittery polo trophy	0		Effect: "Sludgesick", Effect Duration: 69, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	olive rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
@@ -7046,9 +7046,9 @@
 7157	lion tamer's electrified fire hose of the bloodbag	0		Maximum HP: +100, Experience (familiar): +2, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	normal cyan fireman's lunch	3	good	Last Available: "2014-12"
 7159	knitted Herculean plain paper hat of the cougar	0		Moxie: +20, Experience (Muscle): +1, Cold Resistance: +3, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	thick moldy special ice cream sandwich	5	crappy	Effect: "Beta Carotene Overdose", Effect Duration: 5, Last Available: "2014-12"
+7160	special thick moldy ice cream sandwich	5	crappy	Effect: "Beta Carotene Overdose", Effect Duration: 5, Last Available: "2014-12"
 7161	smelly therapeutic &quot;honey&quot; dipper of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
-7162	flavorless enchanted plumber's lunch	3	decent	Effect: "Full-Body Tan", Effect Duration: 5, Last Available: "2014-12"
+7162	enchanted flavorless plumber's lunch	3	decent	Effect: "Full-Body Tan", Effect Duration: 5, Last Available: "2014-12"
 7163	avaricious hardy skull gearshift knob of Calamity Jane	0		Maximum HP: +50, Critical Hit Percent: +15, Meat Drop: +30, Last Available: "2014-12"
 7164	decent nachos of the night	3	good	Last Available: "2014-12"
 7165	knitted foul-smelling Sketcherz&trade; of the early riser	0		Stench Damage: +10, Cold Resistance: +3, Adventures: +7, Last Available: "2014-12"
@@ -7058,10 +7058,10 @@
 7169	weak delicious tankard of ale	2	awesome	Last Available: "2014-12"
 7170	super-vacuum-sealed scroll case	0		Effect: "Memento Moir&eacute;", Effect Duration: 23, Last Available: "2014-12"
 7171	non-polarized narrow jug of &quot;wine&quot;	0		Effect: "Fudge Headache", Effect Duration: 65, Last Available: "2014-12"
-7172	yellow spinning juggling ball	0		Last Available: "2014-12"
+7172	spinning yellow juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	stale fancy humble pie	4	decent	Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2014-12"
-7175	squat ghostly small golem	0		Last Available: "2014-12"
+7174	fancy stale humble pie	4	decent	Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2014-12"
+7175	ghostly squat small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	anodized crappy waiter disguise	0		Effect: "Old School Pompadour", Effect Duration: 53
 7178	Copperhead Charm	0		
@@ -7073,7 +7073,7 @@
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	triple-distilled artisanal unnamed cocktail	7	EPIC	
+7187	artisanal triple-distilled unnamed cocktail	7	EPIC	
 7188	handful of tips	0		
 7189	weightlifter's unrequired jacket	0		Muscle: +15
 7190	tommy gun of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7088,14 +7088,14 @@
 7199	blowdart	0		
 7200	aromatic Buddy Bjorn	0		Stench Resistance: +1, Softcore Only, Last Available: "2014-02"
 7201	miser's inspector's sizzling The Nuge's favorite crossbow	0		Hot Damage: +10, Item Drop: +15, Meat Drop: +10
-7202	stale big special sweet roll Alabama	5	decent	Effect: "Muscle Unbound", Effect Duration: 50
+7202	special big stale sweet roll Alabama	5	decent	Effect: "Muscle Unbound", Effect Duration: 50
 7203	Saturday Night Special of the storm	0		Maximum MP Percent: +40
 7204	lynyrd snare	0		
 7205	smelly fleetwood chain	0		Stench Spell Damage: +10
-7206	high-proof acceptable pulsating upside-down Green Manalishi	6	good	
+7206	high-proof acceptable upside-down pulsating Green Manalishi	6	good	
 7207	pulsating cyan careful blade	0		Monster Level: -10
 7208	blinking fire of unknown origin	0		
-7209	shaking blinking maroon pulsating eagle's milk	1	crappy	
+7209	shaking pulsating maroon blinking eagle's milk	1	crappy	
 7210	nitrogenated gray eagle feather	0		Effect: "Booing Radly", Effect Duration: 25
 7211	oxidized huge one pill	0		Effect: "Motion", Effect Duration: 18
 7212	therapeutic Jefferson wings	0		HP Regen Min: 5, HP Regen Max: 7
@@ -7115,8 +7115,8 @@
 7226	pulsating tea for one	1	good	
 7227	perfectly mixed blue bottle of Evermore	3	EPIC	
 7228	box	0		
-7229	acceptable high-proof wine	8	good	
-7230	artisanal weak rum	2	EPIC	
+7229	high-proof acceptable wine	8	good	
+7230	weak artisanal rum	2	EPIC	
 7231	tolerable Murderer's Punch	3	good	
 7232	spoiled enchanted jumbo wobbly velvet cake	5	crappy	Effect: "Weather, Man", Effect Duration: 20
 7233	cold-filtered letter	0		Effect: "Jingle Jangle Jingle", Effect Duration: 46
@@ -7143,7 +7143,7 @@
 7254	jittery really cocktail shaker	0		Familiar Weight: +5
 7255	acceptable mini-martini	4	good	
 7256	smoke grenade	0		
-7257	altered maroon pulsating skewed molotov soda	1	good	
+7257	altered pulsating maroon skewed molotov soda	1	good	
 7258	altered triple-Vulcanized pile of ashes	0		Effect: "Pumped Stomach", Effect Duration: 36
 7259	crate of firebombs	0		
 7260	huge firebomb	0		
@@ -7166,7 +7166,7 @@
 7277	aerosolized deionized improved robot grease	0		Effect: "Sugary World View", Effect Duration: 61
 7278	returned Thinknerd package	0		
 7279	enhanced pickled bouncing wind-up Whatsian robot	0		Effect: "Lit Up", Effect Duration: 24
-7280	polarized liquefied fuchsia huge wind-up vampire teeth	0		Effect: "Ninja, Please", Effect Duration: 37
+7280	polarized liquefied huge fuchsia wind-up vampire teeth	0		Effect: "Ninja, Please", Effect Duration: 37
 7281	quadruple-magnetized wobbly wind-up navigation droid	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 52
 7282	non-polymerized fuchsia wind-up owl	0		Effect: "Ooh, Sweet!", Effect Duration: 66
 7283	energized wind-up ensign	0		Effect: "Rootin' Around", Effect Duration: 29
@@ -7179,20 +7179,20 @@
 7290	adequate amok pudding	4	good	
 7291	deactivated putty buddy	0		
 7292	cyan putty coat	0		Familiar Weight: +5
-7293	irradiated energized upside-down bouncing can of V-11	0		Effect: "Techno Bliss", Effect Duration: 42, Last Available: "2014-03"
+7293	irradiated energized bouncing upside-down can of V-11	0		Effect: "Techno Bliss", Effect Duration: 42, Last Available: "2014-03"
 7294	double-paned chaotic elevennis shoes	0		Spell Critical Percent: +10, Cold Resistance: +5, Last Available: "2014-03"
 7295	upside-down elevent	0		Last Available: "2014-03"
 7296	pulsating spinning stanky forbidden elevenderizing hammer	0		Spell Damage Percent: +50, Stench Spell Damage: +25, Last Available: "2014-03"
 7297	skewed horrifying Professor What T-Shirt	0		Spooky Damage: +25
 7298	heavy-duty bendy straw	0		
-7299	huge tumbling pellet of plant food	0		
+7299	tumbling huge pellet of plant food	0		
 7300	wobbly sewing kit	0		
 7301	mirror Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	Lady Spookyraven's necklace	0		
 7304	telegram from Lady Spookyraven	0		
 7305	teal Lady Spookyraven's powder puff	0		
-7306	blue wobbly Lady Spookyraven's finest gown	0		
+7306	wobbly blue Lady Spookyraven's finest gown	0		
 7307	blurry Lady Spookyraven's dancing shoes	0		
 7308	extra-modified cold-filtered eyebrow pencil	0		Effect: "20/20 Vision", Effect Duration: 14
 7309	alkaline chilled electrified shaking skewed rosewater cream	0		Effect: "Jawin'", Effect Duration: 63
@@ -7228,7 +7228,7 @@
 7339	music box mechanism	0		
 7340	toasty moose antlers	0		Hot Damage: +5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	cold-filtered upside-down moose thought	0		Effect: "Nightstalkin'", Effect Duration: 28
-7342	stale small pulsating moose chocolate	2	decent	
+7342	small stale pulsating moose chocolate	2	decent	
 7343	strong hand-crafted bouncing painting of a glass of wine	5	EPIC	
 7344	squat oil painting of yourself	0		
 7345	ornate picture frame	0		
@@ -7246,7 +7246,7 @@
 7357	extra-polymerized modified coal dust	0		Effect: "Heightened Senses", Effect Duration: 18
 7358	perfumed wool Bram's choker of the brute	0		Muscle Percent: +30, Cold Resistance: +1, Stench Resistance: +5, Single Equip
 7359	plaid swatch	0		
-7360	twirling huge plaid bandage	0		
+7360	huge twirling plaid bandage	0		
 7361	smartaleck's plaid pocket square	0		Moxie Percent: +30
 7362	energetic wholesome plaid skirt	0		Maximum HP Percent: +10, Maximum MP Percent: +20, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	super-deionized blinking bloodstain stick	0		Effect: "Sleazy Jellied", Effect Duration: 34
@@ -7254,7 +7254,7 @@
 7365	deionized activated tumbling fabric hardener	0		Effect: "Filled with Magic", Effect Duration: 43
 7366	smooth bottle of laundry sherry	3	awesome	
 7367	ionized chilled industrial strength starch	0		Effect: "Voracious Gorging", Effect Duration: 15, Wiki Name: "industrial strength starch"
-7368	snack-sized delicious extra-flat panini	2	awesome	
+7368	delicious snack-sized extra-flat panini	2	awesome	
 7369	energized dry mangled finger	0		Effect: "Heart of White", Effect Duration: 60
 7370	irresponsibly strong perfectly mixed Psychotic Train wine	10	EPIC	
 7371	crazy hobo notebook	0		
@@ -7278,7 +7278,7 @@
 7389	warmed frozen pressed teal Gene Tonic: Insect	0		Effect: "Human-Goblin Hybrid", Effect Duration: 49, Last Available: "2014-04"
 7390	nitrogenated magnetized Gene Tonic: Hippy	0		Effect: "Prelude of Precision", Effect Duration: 39, Last Available: "2014-04"
 7391	polarized chilled pulsating Gene Tonic: Orc	0		Effect: "Polka of Plenty", Effect Duration: 54, Last Available: "2014-04"
-7392	adjusted colloidal maroon mirror Gene Tonic: Demon	0		Effect: "Meat the Flintstones", Effect Duration: 61, Last Available: "2014-04"
+7392	adjusted colloidal mirror maroon Gene Tonic: Demon	0		Effect: "Meat the Flintstones", Effect Duration: 61, Last Available: "2014-04"
 7393	super-unsweetened warmed Gene Tonic: Horror	0		Effect: "Bear Clawed", Effect Duration: 34, Last Available: "2014-04"
 7394	quadruple-diffused colloidal Gene Tonic: Fish	0		Effect: "Mucilaginous Muscle", Effect Duration: 22, Last Available: "2014-04"
 7395	anodized unsweetened spinning Gene Tonic: Goblin	0		Effect: "Memory of Resilience", Effect Duration: 24, Last Available: "2014-04"
@@ -7286,9 +7286,9 @@
 7397	galvanized green Gene Tonic: Plant	0		Effect: "Weepy, Creepy", Effect Duration: 47, Last Available: "2014-04"
 7398	dry Gene Tonic: Weird	0		Effect: "Spirit Bubble", Effect Duration: 14, Last Available: "2014-04"
 7399	moist galvanized denatured Gene Tonic: Elf	0		Effect: "Stuck That Way", Effect Duration: 54, Last Available: "2014-04"
-7400	non-liquefied quadruple-polarized extra-aerosolized skewed narrow Gene Tonic: Mer-kin	0		Effect: "Cinnamouth", Effect Duration: 52, Last Available: "2014-04"
+7400	non-liquefied quadruple-polarized extra-aerosolized narrow skewed Gene Tonic: Mer-kin	0		Effect: "Cinnamouth", Effect Duration: 52, Last Available: "2014-04"
 7401	improved unsweetened mirror Gene Tonic: Slime	0		Effect: "Horrid, Torrid", Effect Duration: 56, Last Available: "2014-04"
-7402	Vulcanized nitrogenated maroon blurry Gene Tonic: Penguin	0		Effect: "[1701]Hip to the Jive", Effect Duration: 58, Last Available: "2014-04"
+7402	Vulcanized nitrogenated blurry maroon Gene Tonic: Penguin	0		Effect: "[1701]Hip to the Jive", Effect Duration: 58, Last Available: "2014-04"
 7403	concentrated irradiated Gene Tonic: Elemental	0		Effect: "Hair on Your Chest", Effect Duration: 58, Last Available: "2014-04"
 7404	denatured blinking Gene Tonic: Constellation	0		Effect: "Slime Time", Effect Duration: 43, Last Available: "2014-04"
 7405	improved frozen narrow Gene Tonic: Hobo	0		Effect: "Strange Mental Acuity", Effect Duration: 46, Last Available: "2014-04"
@@ -7299,7 +7299,7 @@
 7410	Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
-7413	mirror maroon Steam Card: Meteoid (#2)	0		
+7413	maroon mirror Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
 7415	Steam Card: DemonStar (#1)	0		
 7416	olive Steam Card: DemonStar (#2)	0		
@@ -7327,22 +7327,22 @@
 7438	stale Beefy Crunch Pastaco	3	decent	Last Available: "2014-05"
 7439	spoiled Brain Food Pastaco	3	crappy	Last Available: "2014-05"
 7440	decent Cool Brunch Pastaco	4	good	Last Available: "2014-05"
-7441	stale bite-sized pulsating Medical Pastaco	1	decent	Last Available: "2014-05"
-7442	tasty enchanted fuchsia Energy Buzz Pastaco	4	awesome	Effect: "Omphalotus Omnipresence", Effect Duration: 5, Last Available: "2014-05"
-7443	half-sized normal Ludovico Pastaco	2	good	Last Available: "2014-05"
+7441	bite-sized stale pulsating Medical Pastaco	1	decent	Last Available: "2014-05"
+7442	enchanted tasty fuchsia Energy Buzz Pastaco	4	awesome	Effect: "Omphalotus Omnipresence", Effect Duration: 5, Last Available: "2014-05"
+7443	normal half-sized Ludovico Pastaco	2	good	Last Available: "2014-05"
 7444	lousy overpowering mushroom wine	4	decent	Last Available: "2014-05"
-7445	bad enchanted green pulsating complex mushroom wine	4	decent	Effect: "So You Can Work More...", Effect Duration: 45, Last Available: "2014-05"
+7445	bad enchanted pulsating green complex mushroom wine	4	decent	Effect: "So You Can Work More...", Effect Duration: 45, Last Available: "2014-05"
 7446	drinkable wobbly smooth mushroom wine	3	good	Last Available: "2014-05"
 7447	acceptable practically non-alcoholic blood-red mushroom wine	1	good	Last Available: "2014-05"
 7448	aged buzzing mushroom wine	3	awesome	Last Available: "2014-05"
-7449	watered-down special artisanal narrow swirling mushroom wine	2	super ultra mega turbo EPIC	Effect: "Three Days Slow", Effect Duration: 50, Last Available: "2014-05"
-7450	flavorless snack-sized upside-down Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
+7449	special artisanal watered-down narrow swirling mushroom wine	2	super ultra mega turbo EPIC	Effect: "Three Days Slow", Effect Duration: 50, Last Available: "2014-05"
+7450	snack-sized flavorless upside-down Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
 7451	toothsome Taco Dan's Taco Fish Fish Taco	3	awesome	Last Available: "2014-05"
 7452	bouncing Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	watered-down lousy regular-size brogurt	2	decent	Last Available: "2014-05"
 7454	delicious watered-down super-size brogurt	2	awesome	Last Available: "2014-05"
 7455	artisanal broberry brogurt	3	EPIC	Last Available: "2014-05"
-7456	practically non-alcoholic acceptable brocolate brogurt	1	good	Last Available: "2014-05"
+7456	acceptable practically non-alcoholic brocolate brogurt	1	good	Last Available: "2014-05"
 7457	bad practically non-alcoholic French bronilla brogurt	1	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
@@ -7363,13 +7363,13 @@
 7474	non-moist wet Yolo&trade; chocolates	0		Effect: "Poker Faced", Effect Duration: 27, Last Available: "2020-09"
 7475	squat cyan blurry string of moist beads of Tarzan	0		Experience (Muscle): +3, Last Available: "2014-05"
 7476	tumbling Ultimate Mind Destroyer	0		Last Available: "2014-05"
-7477	pressed olive jittery tumbling Meat-inflating powder	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25, Last Available: "2014-05"
+7477	pressed tumbling olive jittery Meat-inflating powder	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	ionized purple sugar fairy	0		Effect: "Become Superficially interested", Effect Duration: 39, Last Available: "2014-05"
 7480	deionized sugar bunny	0		Effect: "Musky", Effect Duration: 58, Last Available: "2014-05"
-7481	jittery red sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	hand-crafted practically non-alcoholic Rompedores de Fantasmas	1	super ultra EPIC	
-7483	triple-distilled bad La Fantasma y La Oscuridad	6	decent	
+7481	red jittery sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	practically non-alcoholic hand-crafted Rompedores de Fantasmas	1	super ultra EPIC	
+7483	bad triple-distilled La Fantasma y La Oscuridad	6	decent	
 7484	lousy tumbling Fantasma en la M&aacute;quina	3	decent	
 7485	blue loosening powder	0		
 7486	castoreum	0		
@@ -7381,7 +7381,7 @@
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	shaking bouncing wine bomb	0		
-7495	upside-down huge recipe: mortar-dissolving solution	0		
+7495	huge upside-down recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
 7498	pulsating Thwaitgold wheel bug statuette	0		
@@ -7415,13 +7415,13 @@
 7526	upside-down weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	perfumed Herculean government-issued night-vision goggles	0		Experience (Muscle): +1, Stench Resistance: +5, Single Equip, Last Available: "2014-05"
-7529	decent gigantic enchanted bouncing spinning loaf of alien bread	7	good	Effect: "Hoity Toity", Effect Duration: 30, Last Available: "2014-05"
+7529	gigantic enchanted decent bouncing spinning loaf of alien bread	7	good	Effect: "Hoity Toity", Effect Duration: 30, Last Available: "2014-05"
 7530	bland immense grilled cheese sandwich	8	decent	Last Available: "2014-05"
 7531	compressed alien protein powder	1	decent	Effect: "Video Game Hot Dog", Effect Duration: 50, Last Available: "2014-05"
-7532	distilled acceptable rocket fuel	5	good	Last Available: "2014-05"
+7532	acceptable distilled rocket fuel	5	good	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	perfectly mixed weak stealth bomber	2	EPIC	Last Available: "2014-05"
+7535	weak perfectly mixed stealth bomber	2	EPIC	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	wobbly twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7429,9 +7429,9 @@
 7540	forbidden space beast fur pants	0		Spell Damage Percent: +50, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	blinking Da Vinci's space beast fur whip	0		Experience (Mysticality): +5, Last Available: "2014-05"
 7542	pulsating space invader	0		Last Available: "2014-05"
-7543	prompt space heater of horror	0		Spooky Spell Damage: +25, Adventures: +3, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	prompt space heater of horror	0		Spooky Spell Damage: +25, Adventures: +3, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
-7545	spirit-forward drinkable ghostly space port	5	good	Last Available: "2014-05"
+7545	drinkable spirit-forward ghostly space port	5	good	Last Available: "2014-05"
 7546	stanky Fonzie's space needle	0		Experience (Moxie): +1, Stench Spell Damage: +25, Last Available: "2014-05"
 7547	chilled super-irradiated spinning buffed alien drugs	0		Effect: "Salsa Satanica", Effect Duration: 63, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7444,7 +7444,7 @@
 7555	page	0		
 7556	elephant gift	0		
 7557	polymerized colloidal dry jittery blood cells	0		Effect: "Took Eleven", Effect Duration: 34
-7558	irresponsibly strong lousy wine	10	decent	
+7558	lousy irresponsibly strong wine	10	decent	
 7559	diffused altered gummi turtle	0		Effect: "Mutated", Effect Duration: 52
 7560	turtle-shaped rock	0		
 7561	improved pressed giraffe-necked turtle	0		Effect: "One Very Clear Eye", Effect Duration: 48
@@ -7458,9 +7458,9 @@
 7569	sharpshooter's wholesome Time Bandit Badge of Courage of the wise owl	0		Mysticality: +20, Maximum HP Percent: +10, Critical Hit Percent: +10
 7570	extra-anodized Friendliness Beverage	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 39
 7571	huge silent pea shooter of the brazier of doom	0		Hot Spell Damage: +25, Spooky Spell Damage: +50
-7572	spoiled fancy D roll	3	crappy	Effect: "Ten out of Ten", Effect Duration: 30
+7572	fancy spoiled D roll	3	crappy	Effect: "Ten out of Ten", Effect Duration: 30
 7573	blinking strapping kiwi beak of the sweet-tooth	0		Muscle: +5, Candy Drop: +100
-7574	perfectly mixed triple-distilled New Zealand iced tea	8	EPIC	
+7574	triple-distilled perfectly mixed New Zealand iced tea	8	EPIC	
 7575	knitted droll monocle of doom	0		Spooky Spell Damage: +50, Cold Resistance: +3, Single Equip
 7576	quadruple-diffused polymerized squat future drug: Muscularactum	0		Effect: "Medieval Mage Mayhem", Effect Duration: 31
 7577	adjusted enhanced future drug: Smartinex	0		Effect: "Rushin' Hands", Effect Duration: 26
@@ -7477,14 +7477,14 @@
 7588	squat Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	acceptable red glass of &quot;milk&quot;	4	good	Last Available: "2014-07"
 7590	hand-crafted cup of &quot;tea&quot;	4	EPIC	Last Available: "2014-07"
-7591	weak drinkable thermos of &quot;whiskey&quot;	2	good	Last Available: "2014-07"
+7591	drinkable weak thermos of &quot;whiskey&quot;	2	good	Last Available: "2014-07"
 7592	drinkable Lucky Lindy	4	good	Last Available: "2014-07"
 7593	hand-crafted extra-dry red Bee's Knees	5	EPIC	Last Available: "2014-07"
-7594	practically non-alcoholic aged Sockdollager	1	awesome	Last Available: "2014-07"
-7595	aged mirror purple Ish Kabibble	3	awesome	Last Available: "2014-07"
+7594	aged practically non-alcoholic Sockdollager	1	awesome	Last Available: "2014-07"
+7595	aged purple mirror Ish Kabibble	3	awesome	Last Available: "2014-07"
 7596	practically non-alcoholic hand-crafted cyan Hot Socks	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7597	aged triple-distilled Phonus Balonus	10	awesome	Last Available: "2014-07"
-7598	mediocre practically non-alcoholic Flivver	1	decent	Last Available: "2014-07"
+7598	practically non-alcoholic mediocre Flivver	1	decent	Last Available: "2014-07"
 7599	weak lousy bouncing teal Sloppy Jalopy	2	decent	Last Available: "2014-07"
 7600	enhanced flame	0		Effect: "Pork Power", Effect Duration: 29
 7601	boiled chilled nitrogenated temporary yak tattoo	0		Effect: "Heart of Orange", Effect Duration: 52
@@ -7495,18 +7495,18 @@
 7606	polarized activated tumbling steampunk potion	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 69
 7607	moist Vulcanized vial of swamp vapors	0		Effect: "Poker Faced", Effect Duration: 15
 7608	super-ionized maroon jittery turtle mud	0		Effect: "In Vino Vires", Effect Duration: 47
-7609	deionized skewed red Redeye&trade; Eyedrops	0		Effect: "Hare-o-dynamic", Effect Duration: 42
+7609	deionized red skewed Redeye&trade; Eyedrops	0		Effect: "Hare-o-dynamic", Effect Duration: 42
 7610	Vulcanized Dweebisol&trade; inhaler	0		Effect: "Burning Hands", Effect Duration: 57
 7611	electrified Lewd Lemmy Hair Oil	0		Effect: "Be a Mind Master", Effect Duration: 68
 7612	quantum corrupted tomato soup poster	0		Effect: "Net Tea", Effect Duration: 16
-7613	deionized pulsating wobbly bubblin' chemistry solution	0		Effect: "Oleaginous Soles", Effect Duration: 58
+7613	deionized wobbly pulsating bubblin' chemistry solution	0		Effect: "Oleaginous Soles", Effect Duration: 58
 7614	polymerized galvanized voodoo glowskull	0		Effect: "Tingly Biceps", Effect Duration: 30
 7615	extra-aerosolized upside-down pygmy adder oil	0		Effect: "Flower Power", Effect Duration: 12
 7616	galvanized pygmy witchhazel	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 51
 7617	enhanced concentrated pulsating green short deposition	0		Effect: "Squid Squint", Effect Duration: 58
 7618	double-diffused straw pole	0		Effect: "It's Electric!", Effect Duration: 51
 7619	wet copperhead potion	0		Effect: "Beta Carotene Overdose", Effect Duration: 38
-7620	diffused oxidized wobbly purple ninja fear powder	0		Effect: "Human-Human Hybrid", Effect Duration: 56
+7620	diffused oxidized purple wobbly ninja fear powder	0		Effect: "Human-Human Hybrid", Effect Duration: 56
 7621	quantum ninja eyeblack	0		Effect: "Phoenix, Right?", Effect Duration: 63
 7622	flattened non-denatured skewed button rouge	0		Effect: "Tingly Biceps", Effect Duration: 21
 7623	double-galvanized Red Army camouflage kit	0		Effect: "Frog In Your Throat", Effect Duration: 58
@@ -7531,7 +7531,7 @@
 7642	ingot turtle	0		
 7643	bouncing duty umbrella	0		
 7644	upside-down pool skimmer	0		
-7645	lime green bouncing life preserver	0		
+7645	bouncing lime green life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
@@ -7546,7 +7546,7 @@
 7657	pulsating tumbling fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	yellow wobbly neoprene skullcap of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "atk, 1xFairy, cap 16"
-7660	chilled tumbling spinning goblin water	0		Effect: "You're Rubber", Effect Duration: 38
+7660	chilled spinning tumbling goblin water	0		Effect: "You're Rubber", Effect Duration: 38
 7661	squat dumb mud	0		
 7662	moldy enchanted Sogg-Os	4	crappy	Effect: "Red Misty-Eyed", Effect Duration: 45
 7663	chilly careful Fonzie's Lord Soggyraven's Slippers	0		Experience (Moxie): +1, Monster Level: -10, Cold Damage: +5, Single Equip
@@ -7581,7 +7581,7 @@
 7692	cool hand whip of the overflowing toilet of terror	0		Moxie: +5, Stench Spell Damage: +50, Spooky Spell Damage: +10, Last Available: "2014-08"
 7693	blinking glow-in-the-dark necklace of chilblains of the early riser	0		Cold Damage: +25, Item Drop: +5, Adventures: +7, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	Temple Grandin's therapeutic padded cap gun	0		Damage Absorption: +20, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	Temple Grandin's therapeutic padded cap gun	0		Damage Absorption: +20, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	blue cassette player of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +5, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,16 +7592,16 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	dry skewed rubber nubbin	0		Effect: "Icy Composition", Effect Duration: 16, Last Available: "2014-08"
 7708	wobbly coward's Fonzie's rubber cape	0		Experience (Moxie): +1, Monster Level: -20, Last Available: "2014-08"
-7709	blue chaotic smartaleck's Thor's Pliers of the cougar of doom	0		Moxie: +20, Moxie Percent: +30, Spell Critical Percent: +10, Spooky Spell Damage: +50, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	blue chaotic smartaleck's Thor's Pliers of the cougar of doom	0		Moxie: +20, Moxie Percent: +30, Spell Critical Percent: +10, Spooky Spell Damage: +50, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	enhanced non-denatured candy UFOs	0		Effect: "Salt Rockin'", Effect Duration: 54
 7711	tumbling ghostly flame-wreathed cool water wings for babies	0		Moxie: +5, Hot Spell Damage: +10
-7712	upside-down beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	upside-down beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	fancy rotten red Strix stix	3	crappy	Effect: "Hagg-ard", Effect Duration: 15
 7714	stiffened vampire pellet of the boozehound	0		Damage Reduction: 1, Item Drop: +5, Booze Drop: +100
-7715	high-proof acceptable pulsating tumbling non-aged vinegar	7	good	
+7715	acceptable high-proof pulsating tumbling non-aged vinegar	7	good	
 7716	healthy unsanitized scalpel	0		Maximum HP Percent: +20
 7717	auspicious gladiator tunica	0		Item Drop: +10
 7718	gray Oprah's Roman sadnals	0		Maximum MP Percent: +50, Single Equip
@@ -7630,7 +7630,7 @@
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	olive squat Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
 7743	squat Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
-7744	mirror blue Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
+7744	blue mirror Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
 7746	Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
 7747	Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
@@ -7642,13 +7642,13 @@
 7753	vibrating Xiblaxian stealth cowl of the blizzard	0		Maximum MP Percent: +10, Cold Spell Damage: +25, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	auspicious asbestos-lined Xiblaxian stealth trousers	0		Hot Resistance: +5, Item Drop: +10, Last Available: "2014-09"
 7755	upside-down shaking Xiblaxian stealth vest of the dark arts of incineration	0		Spell Damage Percent: +100, Hot Spell Damage: +50, Last Available: "2014-09"
-7756	thick normal Xiblaxian ultraburrito	5	good	Last Available: "2014-09"
+7756	normal thick Xiblaxian ultraburrito	5	good	Last Available: "2014-09"
 7757	artisanal ghostly Xiblaxian space-whiskey	3	super EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	non-improved They liver	0		Effect: "Video Game Hot Dog", Effect Duration: 60, Last Available: "2014-09"
 7760	spoiled They liver popsicle	3	crappy	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
-7762	mirror red holo-bomber	0		Last Available: "2014-09"
+7762	red mirror holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
 7764	pickled blurry residual zeal	1		Last Available: "2014-09"
 7765	Xiblaxian holo-wrist-puter of the pedagogue	0		Experience: +3, Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	mirror Da Vinci's Personal Ventilation Unit of doom of the detective	0		Experience (Mysticality): +5, Spooky Spell Damage: +50, Item Drop: +20, Single Equip, Last Available: "2014-10"
 7771	vacuum-sealed pickled green the most dangerous bait	0		Effect: "Dreadful Smell", Effect Duration: 58, Last Available: "2014-10"
-7772	special adequate skewed &quot;meat&quot; stick	3	good	Effect: "Boon of She-Who-Was", Effect Duration: 15, Last Available: "2014-10"
+7772	adequate special skewed &quot;meat&quot; stick	3	good	Effect: "Boon of She-Who-Was", Effect Duration: 15, Last Available: "2014-10"
 7773	pickled narrow transdermal smoke patch	1	awesome	Last Available: "2014-10"
 7774	squat specialty ammo bandolier	0		Last Available: "2014-10"
 7775	inspector's greasy pair of plants of extreme caution	0		Monster Level: -25, Sleaze Spell Damage: +10, Item Drop: +15, Last Available: "2014-10"
@@ -7670,10 +7670,10 @@
 7781	rosy-cheeked dangerous Fonzie's battery-powered drill of the pedagogue	0		Experience: +3, Experience (Moxie): +1, Weapon Damage: +10, Maximum HP Percent: +30, Last Available: "2014-10"
 7782	flavorless thick limp broccoli	5	decent	Last Available: "2014-10"
 7783	rock-hard Sinatra's hat of the pedagogue	0		Experience: +3, Experience (Moxie): +5, Damage Reduction: 5, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
-7784	enhanced pulsating cyan monkey barf	0		Effect: "Crusty Head", Effect Duration: 29, Last Available: "2014-10"
+7784	enhanced cyan pulsating monkey barf	0		Effect: "Crusty Head", Effect Duration: 29, Last Available: "2014-10"
 7785	ionized upside-down candy	0		Effect: "Pasty", Effect Duration: 33, Last Available: "2014-10"
 7786	prompt lard-coated scorching jangly bracelet	0		Hot Damage: +25, Sleaze Spell Damage: +25, Adventures: +3, Last Available: "2014-10"
-7787	strapping cuddly teddy bear	0		Muscle: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	strapping cuddly teddy bear	0		Muscle: +5, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	arcane researcher's first-aid pouch of wisdom	0		Mysticality: +15, Experience Percent (Mysticality): +10, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7681,12 +7681,12 @@
 7792	bouncing SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	skewed bottle-opener keycard	0		Last Available: "2014-10"
 7794	maroon Armory keycard	0		Last Available: "2014-10"
-7795	yummy half-sized initiative shawarma	2	awesome	Last Available: "2014-10"
-7796	adequate thick warm war shawarma	5	good	Last Available: "2014-10"
+7795	half-sized yummy initiative shawarma	2	awesome	Last Available: "2014-10"
+7796	thick adequate warm war shawarma	5	good	Last Available: "2014-10"
 7797	bland bouncing karma shawarma	3	decent	Last Available: "2014-10"
 7798	mediocre pulsating Jungle Juice	4	decent	Last Available: "2014-10"
 7799	delicious spinning Amnesiac Ale	4	awesome	Last Available: "2014-10"
-7800	artisanal fancy huge Highest Bitter	3	EPIC	Effect: "You Know What's Up", Effect Duration: 45, Last Available: "2014-10"
+7800	fancy artisanal huge Highest Bitter	3	EPIC	Effect: "You Know What's Up", Effect Duration: 45, Last Available: "2014-10"
 7801	frosty mercenary pistol of Tarzan	0		Experience (Muscle): +3, Cold Spell Damage: +10, Last Available: "2014-10"
 7802	huge experienced mercenary rifle of the early riser	0		Experience: +2, Adventures: +7, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7700,7 +7700,7 @@
 7811	ghostly viral DNA	0		
 7812	huge tarnished bottlecap	0		
 7813	stale seared dino steak	3	decent	
-7814	fancy weak lousy bottle of drinkin' gas	2	decent	Effect: "Partially Ghosted", Effect Duration: 50
+7814	fancy lousy weak bottle of drinkin' gas	2	decent	Effect: "Partially Ghosted", Effect Duration: 50
 7815	pulsating handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7716,7 +7716,7 @@
 7827	miniature adequate unidentifiable dried fruit	2	good	
 7828	perfectly mixed bouncing flat cider	3	EPIC	
 7829	avaricious greedy occult trench lighter	0		Spell Damage Percent: +25, Meat Drop: 50, Last Available: "2014-10"
-7830	quadruple-enhanced lime green squat experimental serum P-00	0		Effect: "Badger Underfoot", Effect Duration: 48, Last Available: "2014-10"
+7830	quadruple-enhanced squat lime green experimental serum P-00	0		Effect: "Badger Underfoot", Effect Duration: 48, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	blurry encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	corrupted electrified anodized perl necklace	0		Effect: "Sauce Monocle", Effect Duration: 68, Last Available: "2014-12"
 7846	triple-magnetized altered Fudge Fiber Armor Plating	0		Effect: "Educated (Sorta)", Effect Duration: 33, Last Available: "2014-12"
 7847	unsweetened ruby on canes	0		Effect: "The Power of LOV", Effect Duration: 42, Last Available: "2014-12"
-7848	snack-sized spoiled petit fortran	2	crappy	Last Available: "2014-12"
+7848	spoiled snack-sized petit fortran	2	crappy	Last Available: "2014-12"
 7849	bite-sized bland squat bouncing java cookie	1	decent	Last Available: "2014-12"
 7850	adequate cookie cookie	3	good	Last Available: "2014-12"
 7851	blurry stiffened plastic exo-suited miner	0		Damage Reduction: 1, Last Available: "2014-12"
@@ -7742,7 +7742,7 @@
 7853	purple plastic ambulatory robo-minecart of terror	0		Spooky Spell Damage: +10, Last Available: "2014-12"
 7854	fuchsia plastic Crimbot of wisdom	0		Mysticality: +15, Last Available: "2014-12"
 7855	cyan foul-smelling plastic Crimbomega	0		Stench Damage: +10, Last Available: "2014-12"
-7856	denatured bouncing shaking flask of mining oil	0		Effect: "Purity of Spirit", Effect Duration: 60, Last Available: "2014-12"
+7856	denatured shaking bouncing flask of mining oil	0		Effect: "Purity of Spirit", Effect Duration: 60, Last Available: "2014-12"
 7857	teal radiation-resistant helmet of the ox	0		Muscle: +20, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
 7858	shellacked servo-assisted exo-pants	0		Damage Reduction: 7, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	Oprah's smooth high-energy mining laser	0		Moxie: +15, Maximum MP Percent: +50, Last Available: "2014-12"
@@ -7778,14 +7778,14 @@
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
-7892	bouncing spinning Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
+7892	spinning bouncing Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	twirling Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	blurry maroon Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	huge Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
-7899	blurry gray Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
+7899	gray blurry Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	blinking Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
@@ -7812,7 +7812,7 @@
 7923	mediocre Agitated Turkey	3	decent	Last Available: "2014-11"
 7924	mediocre twirling Ambitious Turkey	3	decent	Last Available: "2014-11"
 7925	bland neutron lollipop	3	decent	Last Available: "2014-12"
-7926	bad twirling blue gamma nog	3	decent	Last Available: "2014-12"
+7926	bad blue twirling gamma nog	3	decent	Last Available: "2014-12"
 7934	squat sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	shaking picky tweezers	0		Last Available: "2015-02"
@@ -7827,8 +7827,8 @@
 7945	squat table	0		
 7946	coward's sharpshooter's personal trainer's outlaw bandana	0		Experience Percent (Muscle): +10, Critical Hit Percent: +10, Monster Level: -20
 7947	drinkable gray whiskey in a broken glass	3	good	
-7948	watered-down perfectly mixed shot of mescal	2	EPIC	
-7949	irresponsibly strong aged enchanted glass of herbal tequila	7	awesome	Effect: "Action", Effect Duration: 20
+7948	perfectly mixed watered-down shot of mescal	2	EPIC	
+7949	aged enchanted irresponsibly strong glass of herbal tequila	7	awesome	Effect: "Action", Effect Duration: 20
 7950	minin' dynamite	0		
 7951	lightning-fast Samson's plaid cowboy hat	0		Experience (Muscle): +5, Initiative: +40, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7839,7 +7839,7 @@
 7957	even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
-7960	red shaking copy of a jerk adventurer's father's diary	0		
+7960	shaking red copy of a jerk adventurer's father's diary	0		
 7961	spinning executive Annie Oakley's energetic Fonzie's Staff of Ed	0		Experience (Moxie): +1, Maximum MP Percent: +20, Critical Hit Percent: +20, Meat Drop: +40
 7962	Eye of Ed	0		
 7963	bouncing amulet	0		
@@ -7880,18 +7880,18 @@
 7998	dehydrated yellow powder	1		Effect: "Stinkybeard", Effect Duration: 20, Last Available: "2015-12"
 7999	liquefied tumbling choco-Crimbot	0		Effect: "The Strength...  of the Future", Effect Duration: 28, Last Available: "2014-12"
 8000	Vulcanized extra-improved olive smart watch	0		Effect: "Bilious Briskness", Effect Duration: 26, Last Available: "2014-12"
-8001	altered anodized squat fuchsia augmented-reality shades	0		Effect: "All Fired Up", Effect Duration: 46, Last Available: "2014-12"
-8002	pulsating mirror reassuring toy Crimbot mega face	0		Spooky Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12"
-8003	brainy toy Crimbot power glove	0		Mysticality: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	ruddy toy Crimbot super fist	0		Maximum HP Percent: +40, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of doom	0		Spooky Spell Damage: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8001	altered anodized fuchsia squat augmented-reality shades	0		Effect: "All Fired Up", Effect Duration: 46, Last Available: "2014-12"
+8002	pulsating mirror reassuring toy Crimbot mega face	0		Spooky Resistance: +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	brainy toy Crimbot power glove	0		Mysticality: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	ruddy toy Crimbot super fist	0		Maximum HP Percent: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of doom	0		Spooky Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	electrified shaking Crimbot battery	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 31, Last Available: "2014-12"
 8007	shaking Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	wobbly Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	yellow pulsating heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	tumbling huge Usain Bolt's stanky fortified Crimbomega drive chain	0		Damage Absorption: +60, Stench Spell Damage: +25, Initiative: +80, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	tumbling huge Usain Bolt's stanky fortified Crimbomega drive chain	0		Damage Absorption: +60, Stench Spell Damage: +25, Initiative: +80, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	blue Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7941,8 +7941,8 @@
 8060	executive Rosewater's The Joke Book of the Dead	0		Mysticality Percent: +30, Meat Drop: +40, Luck: -6
 8061	The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	yellow pulsating blinking Tales of Spelunking	0		Last Available: "2015-12"
-8064	teal bouncing monkey statuette	0		Free Pull, Last Available: "2015-12"
+8063	blinking pulsating yellow Tales of Spelunking	0		Last Available: "2015-12"
+8064	bouncing teal monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
 8066	pickled blinking	1	good	Last Available: "2015-12"
 8067	nuggets	0		
@@ -7996,7 +7996,7 @@
 8121	twirling Jeselnik's garland of the cheetah	0		Sleaze Damage: +25, Initiative: +60, Single Equip, Last Available: "2018-12"
 8122	dance instructor's gunnysack of Tarzan	0		Experience (Muscle): +3, Experience Percent (Moxie): +10, Last Available: "2018-12"
 8123	purple scandalous garibaldi of the glutton	0		Sleaze Damage: +5, Food Drop: +100, Last Available: "2018-12"
-8124	red jittery rosy-cheeked girdle of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	red jittery rosy-cheeked girdle of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	gloves of the brazier of horror	0		Hot Spell Damage: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2018-12"
 8126	compressed smithereens	1		Last Available: "2018-12"
 8127	huge forbidden dance instructor's fiberglass fetish	0		Experience Percent (Moxie): +10, Spell Damage Percent: +50, Last Available: "2018-12"
@@ -8023,7 +8023,7 @@
 8149	triple-vacuum-sealed Glo-Pop	0		Effect: "Human-Horror Hybrid", Effect Duration: 33
 8150	extra-activated quadruple-ionized irradiated sugar sphere	0		Effect: "Amorous", Effect Duration: 39
 8151	deionized ionized anodized wobbly Shrubble Bubble	0		Effect: "Highland Sheen", Effect Duration: 38
-8152	irradiated squat cyan polyeaster egg	0		Effect: "Piratastic", Effect Duration: 52
+8152	irradiated cyan squat polyeaster egg	0		Effect: "Piratastic", Effect Duration: 52
 8153	cold-filtered upside-down candy dish	0		Effect: "Work For Hours a Week", Effect Duration: 31
 8154	boiled mirror Spechunky bar	0		Effect: "Human-Insect Hybrid", Effect Duration: 48
 8155	tarnished quantum twirling talisman of Horus	0		Effect: "Your Eyes are Peeled!", Effect Duration: 15
@@ -8038,16 +8038,16 @@
 8164	purple Sherlock's remaindered axe of the sweet-tooth	0		Item Drop: +25, Candy Drop: +100
 8165	low-budget shield	0		Damage Reduction: 3
 8166	spinning Jeselnik's cr&ecirc;epy mask of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +25, Familiar Effect: "spooky atk, cap 5"
-8167	small adequate baguette	2	good	
+8167	adequate small baguette	2	good	
 8168	glob of icing	0		
 8169	corrupted corrupted spinning teal ginger snaps	0		Effect: "Familial Ties", Effect Duration: 55
 8170	anodized dry mostly-broken sunglasses	0		Effect: "Hairy Palms", Effect Duration: 13
 8171	mediocre unflavored wine cooler	3	decent	
 8172	spinning carton of snake milk	1	EPIC	
 8173	olive sewer snake of the pedagogue	0		Experience: +3
-8174	bland small purple pigeon egg	2	decent	
+8174	small bland purple pigeon egg	2	decent	
 8175	jaunty feather of the sewer of bravery	0		Stench Damage: +25, Spooky Resistance: +5
-8176	weak drinkable blurry premium malt liquor	2	good	
+8176	drinkable weak blurry premium malt liquor	2	good	
 8177	careful electrified brown paper pants	0		Monster Level: -10, MP Regen Min: 3, MP Regen Max: 5
 8178	shaking inspector's quilted brown paper bag mask	0		Damage Absorption: +40, Item Drop: +15
 8179	flame-retardant ring of telling skeletons what to do	0		Hot Resistance: +1, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8059,19 +8059,19 @@
 8185	shellacked hardened The Crown of Ed the Undying	0		Damage Reduction: 20, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	irresponsibly strong aged pulsating skewed Cherrytastrophe wine cooler	10	awesome	
+8188	aged irresponsibly strong skewed pulsating Cherrytastrophe wine cooler	10	awesome	
 8189	hand-crafted shaking Radberry Rip wine cooler	4	EPIC	
-8190	aged fancy practically non-alcoholic yellow Orangemageddon wine cooler	1	awesome	Effect: "Thought", Effect Duration: 50
+8190	fancy practically non-alcoholic aged yellow Orangemageddon wine cooler	1	awesome	Effect: "Thought", Effect Duration: 50
 8191	artisanal Breakfast Blast wine cooler	3	EPIC	
-8192	watered-down artisanal Citrus Crush wine cooler	2	EPIC	
-8193	snack-sized rotten special plain bagel	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30
+8192	artisanal watered-down Citrus Crush wine cooler	2	EPIC	
+8193	snack-sized special rotten plain bagel	2	crappy	Effect: "Abyssal Sweat", Effect Duration: 30
 8194	adequate glob of cream cheese	3	good	
-8195	jumbo flavorless loaf of soda bread	5	decent	
+8195	flavorless jumbo loaf of soda bread	5	decent	
 8196	normal acceptable bagel	3	good	
 8197	huge stale standard-issue cupcake	6	decent	
 8198	stale ultra-deluxe cupcake	3	decent	
-8199	shaking narrow hypnotic breadcrumbs	0		
-8200	rotten small popular tart	2	crappy	
+8199	narrow shaking hypnotic breadcrumbs	0		
+8200	small rotten popular tart	2	crappy	
 8201	mirror no-handed pie	0		
 8202	electrified pressed dry blue blinking Doc Galaktik's Vitality Serum	0		Effect: "Coy to the Hurled", Effect Duration: 35
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8086,12 +8086,12 @@
 8212	ghostly grogpagne	0		Last Available: "2021-07"
 8213	shellacked rigging rope of courage	0		Damage Reduction: 7, Spooky Resistance: +3, Last Available: "2015-04"
 8214	pickled nasty snuff	1	crappy	Effect: "Cheered Up", Effect Duration: 5, Last Available: "2015-04"
-8215	Temple Grandin's Oprah's sewage-clogged pistol	0		Maximum MP Percent: +50, Familiar Weight: +7, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
-8216	modified skewed spinning beard incense	0		Effect: "Ninja, Please", Effect Duration: 43, Last Available: "2015-04"
+8215	Temple Grandin's Oprah's sewage-clogged pistol	0		Maximum MP Percent: +50, Familiar Weight: +7, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8216	modified spinning skewed beard incense	0		Effect: "Ninja, Please", Effect Duration: 43, Last Available: "2015-04"
 8217	zippy perfume-soaked bandana of the bloodbag	0		Maximum HP: +100, Initiative: +20, Single Equip, Last Available: "2015-04"
-8218	mirror blinking toxic globule	0		Last Available: "2015-04"
+8218	blinking mirror toxic globule	0		Last Available: "2015-04"
 8219	bland toxo	3	decent	Last Available: "2015-04"
-8220	perfectly mixed practically non-alcoholic Lemonade-235	1	EPIC	Last Available: "2015-04"
+8220	practically non-alcoholic perfectly mixed Lemonade-235	1	EPIC	Last Available: "2015-04"
 8221	upside-down flame-retardant frosty isotophat	0		Cold Spell Damage: +10, Hot Resistance: +1, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	twirling aromatic Herculean Three Mile Island shorts	0		Experience (Muscle): +1, Stench Resistance: +1, Last Available: "2015-04"
 8223	Jim Carey's toxic mop of terror	0		Monster Level: +25, Spooky Spell Damage: +10, Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	slick lube-shoes	0		Moxie: +10, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	family-friendly lard-coated sizzling Dinsey mascot mask	0		Hot Damage: +10, Sleaze Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2015-04"
-8247	diet moldy Dinsey food-cone	1	crappy	Last Available: "2015-04"
+8247	moldy diet Dinsey food-cone	1	crappy	Last Available: "2015-04"
 8248	bad spinning Dinsey Whinskey	3	decent	Last Available: "2015-04"
 8249	galvanized Vulcanized Dinsey face paint	0		Effect: "Chunky", Effect Duration: 20, Last Available: "2015-04"
 8250	ribald weightlifter's fannypack	0		Muscle: +15, Sleaze Damage: +10, Last Available: "2015-04"
@@ -8134,16 +8134,16 @@
 8260	Mayo Clinic	0		Last Available: "2015-05"
 8261	blurry Mayonex	0		Last Available: "2015-05"
 8262	squat Mayodiol	0		Last Available: "2015-05"
-8263	spinning blue Mayostat	0		Last Available: "2015-05"
+8263	blue spinning Mayostat	0		Last Available: "2015-05"
 8264	Mayozapine	0		Last Available: "2015-05"
 8265	Mayoflex	0		Last Available: "2015-05"
 8266	ghostly smelly stylish miracle whip of the dark arts of Gandalf	0		Moxie: +25, Spell Damage Percent: +100, Spell Critical Percent: +20, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-05"
 8267	tumbling avaricious sphygmayomanometer	0		Meat Drop: +30, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	fuchsia mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	super-sized delicious unappetizing mayolus	5	awesome	Last Available: "2015-05"
+8270	delicious super-sized unappetizing mayolus	5	awesome	Last Available: "2015-05"
 8271	delicious uninteresting mayolus	3	awesome	Last Available: "2015-05"
-8272	low-calorie decent blue acceptable mayolus	1	good	Last Available: "2015-05"
+8272	decent low-calorie blue acceptable mayolus	1	good	Last Available: "2015-05"
 8273	normal blinking enticing mayolus	3	good	Last Available: "2015-05"
 8274	flavorless mouth-watering mayolus	4	decent	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8152,7 +8152,7 @@
 8278	drinkable huge Afternoon Delight	4	good	Last Available: "2015-04"
 8279	blurry Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
-8281	deionized tarnished shaking yellow Kokomo Resort Brand Suntan Oil	0		Effect: "Cosmic Flavor", Effect Duration: 36, Last Available: "2015-04"
+8281	deionized tarnished yellow shaking Kokomo Resort Brand Suntan Oil	0		Effect: "Cosmic Flavor", Effect Duration: 36, Last Available: "2015-04"
 8282	ghostly Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	mirror The Cocktail Shaker	0		Last Available: "2015-04"
 8284	quadruple-frozen jittery Kokomo Resort Pass	0		Effect: "Chief Executive Optimism", Effect Duration: 40, Last Available: "2023-08"
@@ -8180,9 +8180,9 @@
 8306	aerosolized sludgesicle	0		Effect: "Meatwise", Effect Duration: 38
 8307	triple-deionized super-warmed &Uuml;berraschthexengebr&auml;u	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 12
 8308	Vulcanized frozen piggy tattoo	0		Effect: "Just the Brown Ones", Effect Duration: 55
-8309	pickled teal wobbly baggie of regular-sized tardigrades	0		Effect: "Slimily Strong", Effect Duration: 26
+8309	pickled wobbly teal baggie of regular-sized tardigrades	0		Effect: "Slimily Strong", Effect Duration: 26
 8310	quadruple-improved non-dry shaking .epub file	0		Effect: "Hyperoffended", Effect Duration: 58
-8311	unsweetened alkaline cyan squat BUBBLE GUM	0		Effect: "You Drank Fish Wine", Effect Duration: 40
+8311	unsweetened alkaline squat cyan BUBBLE GUM	0		Effect: "You Drank Fish Wine", Effect Duration: 40
 8312	wet boiled hustler shades	0		Effect: "Overstimulated", Effect Duration: 16
 8313	triple-frozen Vulcanized jerky stick	0		Effect: "Magically Delicious", Effect Duration: 17
 8314	alkaline oxidized costume rental shop	0		Effect: "Baconstoned", Effect Duration: 28
@@ -8198,7 +8198,7 @@
 8324	aerosolized deionized disposable lighter	0		Effect: "Vital", Effect Duration: 26
 8325	enhanced activated mirror narrow coal contact lenses	0		Effect: "Human-Human Hybrid", Effect Duration: 48
 8326	pressed conjured ice cream	0		Effect: "Rave Concentration", Effect Duration: 43
-8327	anodized tarnished huge skewed Iceberglar scarf	0		Effect: "Rat-Faced", Effect Duration: 11
+8327	anodized tarnished skewed huge Iceberglar scarf	0		Effect: "Rat-Faced", Effect Duration: 11
 8328	unsweetened liquefied icy hairspray	0		Effect: "Weird Flavor", Effect Duration: 61
 8329	nitrogenated frozen smellbook	0		Effect: "Phoenix, Right?", Effect Duration: 48
 8330	triple-anodized yellow assassin's cheese knife	0		Effect: "Your Interest is Peaked", Effect Duration: 24
@@ -8221,7 +8221,7 @@
 8347	triple-tarnished blinking spray chrome	0		Effect: "The Power of LOV", Effect Duration: 31
 8348	deionized filthy monkey head	0		Effect: "The Solution", Effect Duration: 65
 8349	improved enhanced unsweetened hand of cards	0		Effect: "Is This Your Card?", Effect Duration: 25
-8350	magnetized blue squat huge damp bar rag	0		Effect: "Takin' It Greasy", Effect Duration: 31
+8350	magnetized huge blue squat damp bar rag	0		Effect: "Takin' It Greasy", Effect Duration: 31
 8351	activated lump of goofball ore	0		Effect: "[1701]Hip to the Jive", Effect Duration: 13
 8352	corrupted pulsating skeleton beans	0		Effect: "Red Misty-Eyed", Effect Duration: 55
 8353	warmed grimy lab coat	0		Effect: "[800]Chocolate Reign", Effect Duration: 25
@@ -8239,7 +8239,7 @@
 8365	vacuum-sealed aerosolized moist novelty fruit hat	0		Effect: "Oiled Skin", Effect Duration: 38
 8366	polymerized invisibility cream	0		Effect: "Rushin' Hands", Effect Duration: 49
 8367	alkaline handful of stubble	0		Effect: "Cold Hard Skin", Effect Duration: 63
-8368	liquefied twirling wobbly garbage juice slurpee	0		Effect: "Alpine Mintiness", Effect Duration: 12
+8368	liquefied wobbly twirling garbage juice slurpee	0		Effect: "Alpine Mintiness", Effect Duration: 12
 8369	alkaline vacuum-sealed plunge-leg	0		Effect: "Ode to Booze", Effect Duration: 62
 8370	vacuum-sealed huge funky eyepatch	0		Effect: "Chlorophyll Flavor", Effect Duration: 25
 8371	triple-modified bucket of fish juice	0		Effect: "damage.enh", Effect Duration: 68
@@ -8278,21 +8278,21 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	thick spoiled pestopiary	5	crappy	
+8407	spoiled thick pestopiary	5	crappy	
 8408	flattened lime green ectoplasmic orbs	0		Effect: "Rootin' Around", Effect Duration: 57
 8409	snack-sized adequate spinning ghostly crudles	2	good	
 8410	bite-sized decent agnolotti arboli	1	good	
-8411	flavorless gigantic bouncing spaghetti with ghost balls	9	decent	
+8411	gigantic flavorless bouncing spaghetti with ghost balls	9	decent	
 8412	decent succulent marrow	3	good	
 8413	super-sized normal salacious crumbs	5	good	
 8414	big decent blue fusilli marrownarrow	5	good	
-8415	enchanted flavorless suggestive strozzapreti	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 15
+8415	flavorless enchanted suggestive strozzapreti	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 15
 8416	Mountain Stream gastrique	0		
 8417	tasty Mt. McLargeHuge oyster	3	awesome	
-8418	spinning purple oyster sauce	0		
+8418	purple spinning oyster sauce	0		
 8419	rotten linguini immondizia bianco	3	crappy	
 8420	rotten shells a la shellfish	4	crappy	
-8421	skewed olive Jick's autograph	0		
+8421	olive skewed Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	spinning unsmoothed velvet	0		Last Available: "2015-08"
 8424	gray 1,970 carat	0		Last Available: "2015-08"
@@ -8328,28 +8328,28 @@
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	jittery crystalline light bulb	0		Last Available: "2015-08"
-8457	huge spinning broken high-temperature mining drill	0		Last Available: "2015-08"
+8457	spinning huge broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	inspector's beefy high-temperature mining mask	0		Muscle: +10, Item Drop: +15, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	ghostly mirror manspreader's sinister fireproof megaphone	0		Spell Damage: +10, Monster Level: +10, Last Available: "2015-08"
 8460	spoiled mineapple	4	crappy	Last Available: "2015-08"
-8461	smooth fancy practically non-alcoholic Gold Velvet&trade; whiskey	1	awesome	Effect: "Impregnably Delicious", Effect Duration: 5, Last Available: "2015-08"
+8461	smooth practically non-alcoholic fancy Gold Velvet&trade; whiskey	1	awesome	Effect: "Impregnably Delicious", Effect Duration: 5, Last Available: "2015-08"
 8462	blue SMOOCH soda	1	decent	Last Available: "2015-08"
-8463	diet normal smelted roe	1	good	Last Available: "2015-08"
+8463	normal diet smelted roe	1	good	Last Available: "2015-08"
 8464	acceptable blurry lavawater	3	good	Last Available: "2015-08"
 8465	wet squat basaltamander tongue	0		Effect: "familiar.enq", Effect Duration: 51, Last Available: "2015-08"
 8466	upside-down lightning-fast chilly lavalarva of the wise owl	0		Mysticality: +20, Cold Damage: +5, Initiative: +40, Last Available: "2015-08"
 8467	green lion tamer's lava balaclava of the blizzard of the glutton	0		Experience (familiar): +2, Cold Spell Damage: +25, Food Drop: +100, Last Available: "2015-08"
 8468	Annie Oakley's clever Socratic basaltamander buckler	0		Experience (Mysticality): +1, Maximum MP: +20, Critical Hit Percent: +20, Damage Reduction: 15, Last Available: "2015-08"
 8469	improved modified lava globs	0		Effect: "Broberry Brotality", Effect Duration: 41, Last Available: "2015-08"
-8470	delicious enchanted half-sized gooey lava globs	2	awesome	Effect: "Spookypants", Effect Duration: 40, Last Available: "2015-08"
+8470	enchanted half-sized delicious gooey lava globs	2	awesome	Effect: "Spookypants", Effect Duration: 40, Last Available: "2015-08"
 8471	tumbling beefy lava-proof pants of the brazier	0		Muscle: +10, Hot Spell Damage: +25, Last Available: "2015-08"
 8472	huge healthy heat-resistant necktie of the brazier	0		Maximum HP Percent: +20, Hot Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8473	tumbling curative wicked heat-resistant gloves of the cheetah	0		Spell Damage: +5, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2015-08"
-8474	stale thick very hot lunch	5	decent	Last Available: "2015-08"
+8474	thick stale very hot lunch	5	decent	Last Available: "2015-08"
 8475	practically non-alcoholic perfectly mixed purple asbestos thermos	1	super ultra mega turbo EPIC	Last Available: "2015-08"
 8476	colloidal spinning liquid rhinestones	0		Effect: "Angry like the Wolf", Effect Duration: 69, Last Available: "2015-08"
 8477	moldy immense disco biscuit	7	crappy	Last Available: "2015-08"
-8478	artisanal watered-down Quaatorade&trade;	2	EPIC	Last Available: "2015-08"
+8478	watered-down artisanal Quaatorade&trade;	2	EPIC	Last Available: "2015-08"
 8479	blinking aromatic foul-smelling deadly biker's hat	0		Weapon Damage: +5, Stench Damage: +10, Stench Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
 8480	upside-down chaotic feathered headdress of Gandalf of the glutton	0		Spell Critical Percent: 30, Food Drop: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	hale supercool electrician's hardhat of the overflowing toilet	0		Moxie Percent: +20, Maximum HP: +20, Stench Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8358,7 +8358,7 @@
 8484	cyan The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	ghostly squat airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	squat ghostly airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
 8490	cyan mirror smooth velvet pants of incineration	0		Hot Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
@@ -8377,7 +8377,7 @@
 8503	purple signed deuce	0		Last Available: "2015-08"
 8504	pulsating Lavalos core	0		Last Available: "2015-08"
 8505	half-melted hula girl	0		Last Available: "2015-08"
-8506	cyan squat glass ceiling fragments	0		Last Available: "2015-08"
+8506	squat cyan glass ceiling fragments	0		Last Available: "2015-08"
 8507	powdered SMOOCH coffee cup	1	decent	Last Available: "2015-08"
 8508	non-pressed dry quadruple-concentrated labrador cookie	0		Effect: "Hopped Up on Goofballs", Effect Duration: 61, Last Available: "2015-08"
 8509	skewed avaricious dog trainer's MacGyver's Mr. Cheeng's spectacles	0		Maximum MP: +100, Experience (familiar): +1, Meat Drop: +30, Single Equip, Last Available: "2015-08"
@@ -8401,13 +8401,13 @@
 8527	skewed Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	normal tumbling devil hair pasta	3	good	
-8530	flavorless big spinning spagecialetti	5	decent	
+8530	big flavorless spinning spagecialetti	5	decent	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	spoiled libertagliatelle	4	crappy	
 8535	stale turkish mostaccioli	4	decent	
-8536	special flavorless linguini of the sea	3	decent	Effect: "Bloodstain-Resistant", Effect Duration: 40
+8536	flavorless special linguini of the sea	3	decent	Effect: "Bloodstain-Resistant", Effect Duration: 40
 8537	extra-pickled blinking huge Hersey&trade; SMOOCH	0		Effect: "Sleazy Jellied", Effect Duration: 34
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
@@ -8420,8 +8420,8 @@
 8547	extra-aerosolized pocket maze	0		Effect: "Conspiratory Eyes", Effect Duration: 54
 8548	altered nitrogenated bouncing shady shades	0		Effect: "Weird Flavor", Effect Duration: 57
 8549	enhanced corrupted wobbly squeaky toy rose	0		Effect: "Chow Downed", Effect Duration: 35
-8550	bland thick weird gazelle steak	5	decent	
-8551	normal snack-sized sausage without a cause	2	good	
+8550	thick bland weird gazelle steak	5	decent	
+8551	snack-sized normal sausage without a cause	2	good	
 8552	irradiated bouncing face paint	0		Effect: "Jittery", Effect Duration: 63
 8553	bad emergency margarita	3	decent	
 8554	mediocre watered-down vintage smart drink	2	decent	
@@ -8459,7 +8459,7 @@
 8586	sharpshooter's barrel gun	0		Critical Hit Percent: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	immense rotten water log	10	crappy	Last Available: "2015-09"
+8589	rotten immense water log	10	crappy	Last Available: "2015-09"
 8590	manspreader's beefcake's barrelhead	0		Muscle: +25, Monster Level: +10, Last Available: "2015-09"
 8591	fortified bottoms of the barrel of the bloodbag	0		Damage Absorption: +60, Maximum HP: +100, Last Available: "2015-09"
 8592	gravedigger's chest barrel of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Last Available: "2015-09"
@@ -8476,14 +8476,14 @@
 8603	liquefied cuppa Boo tea	0		Effect: "Space Cadet", Effect Duration: 57, Last Available: "2015-09"
 8604	polarized cuppa Nas tea	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 46, Last Available: "2015-09"
 8605	unsweetened shaking cuppa Improprie tea	0		Effect: "Optimist Primal", Effect Duration: 65, Last Available: "2015-09"
-8606	tarnished boiled ghostly wobbly cuppa Frost tea	0		Effect: "All Branned Up", Effect Duration: 44, Last Available: "2015-09"
+8606	tarnished boiled wobbly ghostly cuppa Frost tea	0		Effect: "All Branned Up", Effect Duration: 44, Last Available: "2015-09"
 8607	modified wet bouncing cuppa Toast tea	0		Effect: "Top Dog", Effect Duration: 61, Last Available: "2015-09"
 8608	activated moist liquefied cuppa Net tea	0		Effect: "Spooky Weapon", Effect Duration: 12, Last Available: "2015-09"
 8609	Vulcanized lime green cuppa Proprie tea	0		Effect: "Hagg-ard", Effect Duration: 24, Last Available: "2015-09"
 8610	warmed ghostly cyan cuppa Morbidi tea	0		Effect: "Haunted Stomach", Effect Duration: 31, Last Available: "2015-09"
-8611	altered skewed lime green cuppa Chari tea	0		Effect: "Brain Freeze", Effect Duration: 64, Last Available: "2015-09"
+8611	altered lime green skewed cuppa Chari tea	0		Effect: "Brain Freeze", Effect Duration: 64, Last Available: "2015-09"
 8612	triple-deionized magnetized blurry cuppa Serendipi tea	0		Effect: "Fury of the Bells", Effect Duration: 18, Last Available: "2015-09"
-8613	frozen bouncing mirror cuppa Feroci tea	0		Effect: "Notably Lovely", Effect Duration: 62, Last Available: "2015-09"
+8613	frozen mirror bouncing cuppa Feroci tea	0		Effect: "Notably Lovely", Effect Duration: 62, Last Available: "2015-09"
 8614	ionized upside-down jittery cuppa Physicali tea	0		Effect: "Red Door Syndrome", Effect Duration: 13, Last Available: "2015-09"
 8615	energized super-frozen spinning cuppa Wit tea	0		Effect: "Hyperoffended", Effect Duration: 18, Last Available: "2015-09"
 8616	unsweetened twirling cuppa Neuroplastici tea	0		Effect: "Cookie Backup", Effect Duration: 62, Last Available: "2015-09"
@@ -8531,12 +8531,12 @@
 8658	wobbly supercharged Othello's handkerchief	0		Maximum MP Percent: +30, Single Equip
 8659	enhanced bowl of Jeal-O	0		Effect: "Wasabi With You", Effect Duration: 20
 8660	grip key	0		
-8661	teal blinking How to Play Othello	0		
+8661	blinking teal How to Play Othello	0		
 8662	toasty ghostly dagger of Tarzan of incineration	0		Experience (Muscle): +3, Hot Damage: +5, Hot Spell Damage: +50
 8663	acceptable ghost beer	3	good	
 8664	medical-grade Othello set	0		HP Regen Min: 7, HP Regen Max: 10
 8665	rotten tomato	0		
-8666	pulsating maroon Twelve Night Energy	0		
+8666	maroon pulsating Twelve Night Energy	0		
 8667	blinking teal asbestos-lined toasty stiffened Yorick	0		Damage Reduction: 1, Hot Damage: +5, Hot Resistance: +5
 8668	pulsating rose	0		
 8669	tulip	0		
@@ -8547,7 +8547,7 @@
 8674	ghostly airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	chilled ghostly shoulder-warming lotion	0		Effect: "Empty Inside", Effect Duration: 37, Last Available: "2015-11"
-8677	gigantic bland iceberg lettuce	9	decent	Last Available: "2015-11"
+8677	bland gigantic iceberg lettuce	9	decent	Last Available: "2015-11"
 8678	smooth cyan ice wine	4	awesome	Last Available: "2015-11"
 8679	squat mirror supercool Wal-Mart snowglobe of dire peril of Gandalf	0		Moxie Percent: +20, Weapon Damage: +20, Spell Critical Percent: +20, Last Available: "2015-11"
 8680	pulsating knitted vibrating Wal-Mart nametag of terror	0		Maximum MP Percent: +10, Spooky Spell Damage: +10, Cold Resistance: +3, Last Available: "2015-11"
@@ -8555,11 +8555,11 @@
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
-8685	blurry cyan Wal-Mart tattoo kit	0		Last Available: "2015-11"
+8685	cyan blurry Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	tumbling bellhop's hat of bravery	0		Spooky Resistance: +5, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	perfectly mixed wobbly ice porter	4	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	perfectly mixed wobbly ice porter	4	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	wet skewed exotic travel brochure	0		Effect: "Pumped Up", Effect Duration: 50, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	double-pickled non-Vulcanized tumbling shampoo-conditioner	0		Effect: "Jungle Juiced", Effect Duration: 39, Last Available: "2015-11"
@@ -8579,18 +8579,18 @@
 8706	blue machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	pulsating self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	boiled blinking abstraction: action	1		Last Available: "2015-12"
-8709	distilled narrow mirror abstraction: thought	1		Effect: "Coated Arms", Effect Duration: 50, Last Available: "2015-12"
+8709	distilled mirror narrow abstraction: thought	1		Effect: "Coated Arms", Effect Duration: 50, Last Available: "2015-12"
 8710	mixed red abstraction: sensation	1		Effect: "Moose Wisdom", Effect Duration: 10, Last Available: "2015-12"
 8711	twisted abstraction: purpose	1		Last Available: "2015-12"
 8712	vaporized narrow abstraction: category	1		Last Available: "2015-12"
 8713	boiled skewed abstraction: perception	1		Effect: "Human-Orc Hybrid", Effect Duration: 35, Last Available: "2015-12"
 8714	distilled purple abstraction: motion	1		Effect: "The Halls of Muscularity", Effect Duration: 45, Last Available: "2015-12"
-8715	powdered skewed pulsating abstraction: joy	1		Last Available: "2015-12"
+8715	powdered pulsating skewed abstraction: joy	1		Last Available: "2015-12"
 8716	twisted twirling abstraction: certainty	1		Last Available: "2015-12"
 8717	vaporized abstraction: comprehension	1		Effect: "Lemon Enlightenment", Effect Duration: 45, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	half-sized spoiled shaking VYKEA meatballs	2	crappy	Last Available: "2015-11"
-8720	watered-down acceptable VYKEA mead	2	good	Last Available: "2015-11"
+8720	acceptable watered-down VYKEA mead	2	good	Last Available: "2015-11"
 8721	modified polarized twirling VYKEA woadpaint	0		Effect: "Empty Inside", Effect Duration: 35, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	ghostly VYKEA blood rune	0		Last Available: "2015-11"
@@ -8598,11 +8598,11 @@
 8725	blinking VYKEA plank	0		Last Available: "2015-11"
 8726	narrow VYKEA rail	0		Last Available: "2015-11"
 8727	VYKEA bracket	0		Last Available: "2015-11"
-8728	spinning bouncing huge VYKEA dowel	0		Last Available: "2015-11"
+8728	bouncing spinning huge VYKEA dowel	0		Last Available: "2015-11"
 8729	blue resourceful cool beefcake's VYKEA hex key	0		Muscle: +25, Moxie: +5, Maximum MP: +50, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	decent fancy low-calorie mirror tin of submardines	1	good	Effect: "Pumped Stomach", Effect Duration: 50, Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	weak smooth bottle of norwhiskey	2	awesome	Last Available: "2015-11"
+8731	low-calorie decent fancy mirror tin of submardines	1	good	Effect: "Pumped Stomach", Effect Duration: 50, Wiki Name: "tin of submardines", Last Available: "2015-11"
+8732	smooth weak bottle of norwhiskey	2	awesome	Last Available: "2015-11"
 8733	diluted octolus oculus	1	good	Last Available: "2015-11"
 8734	mirror thinker's beefcake's sardine can key of Tarzan	0		Muscle: +25, Mysticality: +10, Experience (Muscle): +3, Last Available: "2015-11"
 8735	zippy Herculean brawny norwhal helmet	0		Muscle Percent: +20, Experience (Muscle): +1, Initiative: +20, Last Available: "2015-11", Familiar Effect: "atk"
@@ -8610,7 +8610,7 @@
 8737	bad practically non-alcoholic perfect cosmopolitan	1	decent	Last Available: "2015-11"
 8738	mediocre perfect negroni	3	decent	Last Available: "2015-11"
 8739	bad perfect dark and stormy	4	decent	Last Available: "2015-11"
-8740	irresponsibly strong hand-crafted perfect mimosa	9	EPIC	Last Available: "2015-11"
+8740	hand-crafted irresponsibly strong perfect mimosa	9	EPIC	Last Available: "2015-11"
 8741	hand-crafted perfect old-fashioned	3	EPIC	Last Available: "2015-11"
 8742	tolerable strong perfect paloma	5	good	Last Available: "2015-11"
 8743	frozen That 70s Cologne	0		Effect: "Tasting the Rainbow", Effect Duration: 38, Last Available: "2015-11"
@@ -8618,14 +8618,14 @@
 8745	colloidal Puffstone cigar	0		Effect: "Optimist Primal", Effect Duration: 64, Last Available: "2015-11"
 8746	improved Conspiracy&trade; mascara	0		Effect: "Hangdog", Effect Duration: 58, Last Available: "2015-11"
 8747	super-concentrated cold-filtered Spring Break Beach &quot;swimsuit&quot;	0		Effect: "White Knuckles", Effect Duration: 13, Last Available: "2015-11"
-8748	skewed blue airplane tattoo	0		Last Available: "2015-11"
+8748	blue skewed airplane tattoo	0		Last Available: "2015-11"
 8749	improved ghostly olive Deep Machine Tunnels snowglobe	0		Effect: "Petit Force", Effect Duration: 18, Last Available: "2015-12"
 8750	concentrated hemp candy necklace	0		Effect: "Swimming Head", Effect Duration: 63, Last Available: "2015-12"
 8751	deionized communal gobstopper	0		Effect: "Ichorous Intensity", Effect Duration: 30, Last Available: "2015-12"
-8752	immense normal Crimbo salad	6	good	Last Available: "2015-12"
+8752	normal immense Crimbo salad	6	good	Last Available: "2015-12"
 8753	delicious bread line	3	awesome	Last Available: "2015-12"
 8754	bad skewed bark rootbeer	3	decent	Last Available: "2015-12"
-8755	spirit-forward lousy twirling ale	5	decent	Last Available: "2015-12"
+8755	lousy spirit-forward twirling ale	5	decent	Last Available: "2015-12"
 8756	blue shaking slick plastic Tammy the Tambourine Elf	0		Moxie: +10, Last Available: "2015-12"
 8757	squat censurious plastic Rudolph the Red	0		Sleaze Resistance: +3, Last Available: "2015-12"
 8758	tumbling plastic Gaia'ajh-dsli Ak'lwej of James Dean	0		Experience (Moxie): +3, Last Available: "2015-12"
@@ -8648,13 +8648,13 @@
 8776	gray sizzling armband	0		Hot Damage: +10, Single Equip, Last Available: "2015-12"
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
-8779	squat huge pine cone	0		Last Available: "2015-12"
+8779	huge squat pine cone	0		Last Available: "2015-12"
 8780	iron chain	0		Last Available: "2015-12"
 8781	auspicious pine cone necklace	0		Item Drop: +10, Last Available: "2015-12"
 8782	blue wobbly blinking reindeer hammer of horror	0		Spooky Spell Damage: +25, Last Available: "2015-12"
 8783	vibrating elf ploughshare	0		Maximum MP Percent: +10, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	gray faded protest sign	0		Last Available: "2015-12"
 8787	red faded protest sign	0		Last Available: "2015-12"
 8788	fuchsia nasty-smelling moss	0		Last Available: "2015-12"
@@ -8685,7 +8685,7 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	skewed mirror Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	bite-sized rotten Kudzu salad	1	crappy	Last Available: "2016-12"
+8816	rotten bite-sized Kudzu salad	1	crappy	Last Available: "2016-12"
 8817	pickled spinning twirling Mansquito Serum	1		Last Available: "2016-12"
 8818	hand-crafted Miss Graves' vermouth	4	EPIC	Last Available: "2016-12"
 8819	stale special The Plumber's mushroom stew	4	decent	Effect: "Transcendental Wind", Effect Duration: 10, Last Available: "2016-12"
@@ -8694,9 +8694,9 @@
 8822	artisanal Doc Clock's thyme cocktail	3	super ultra EPIC	Last Available: "2016-12"
 8823	bland Mr. Burnsger	4	decent	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2016-12"
-8825	mirror knitted quilted Da Vinci's The Jokester's gun	0		Experience (Mysticality): +5, Damage Absorption: +40, Cold Resistance: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	The Jokester's wig of wisdom of vim and vigor of the bloodbag	0		Mysticality: +15, Maximum HP Percent: +50, Maximum HP: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol"
-8827	padded Fonzie's brainy The Jokester's pants	0		Mysticality: +5, Experience (Moxie): +1, Damage Absorption: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	mirror knitted quilted Da Vinci's The Jokester's gun	0		Experience (Mysticality): +5, Damage Absorption: +40, Cold Resistance: +3, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	The Jokester's wig of wisdom of vim and vigor of the bloodbag	0		Mysticality: +15, Maximum HP Percent: +50, Maximum HP: +100, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	padded Fonzie's brainy The Jokester's pants	0		Mysticality: +5, Experience (Moxie): +1, Damage Absorption: +20, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	electrified pickled chilled jittery Jokester makeup	0		Effect: "Improprie Tea", Effect Duration: 32, Last Available: "2016-12"
 8829	upside-down pulsating replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	deionized spinning robin's egg	0		Effect: "Gonna Get You, Sucker", Effect Duration: 38, Last Available: "2016-12"
 8834	normal robin flan	4	good	Last Available: "2016-12"
-8835	practically non-alcoholic drinkable robin nog	1	good	Last Available: "2016-12"
+8835	drinkable practically non-alcoholic robin nog	1	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8719,7 +8719,7 @@
 8847	quadruple-pressed irradiated unsweetened red-hot jawbreaker	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 20
 8848	unsweetened irradiated question juice	0		Effect: "Souper Vengeful", Effect Duration: 26
 8849	warmed chilled tube of villain	0		Effect: "Sealed Brain", Effect Duration: 11
-8850	manspreader's your cowboy boots	0		Monster Level: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	manspreader's your cowboy boots	0		Monster Level: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	gray inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	yellow mirror nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8747,7 +8747,7 @@
 8875	red asbestos-lined baleful Shrub's Premium Baked Beans of Calamity Jane	0		Spell Damage: +25, Critical Hit Percent: +15, Hot Resistance: +5, Last Available: "2016-02"
 8876	normal twirling plate of Heimz Fortified Kidney Beans	4	good	Last Available: "2016-02"
 8877	flavorless half-sized plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
-8878	stale immense plate of Mixed Garbanzos and Chickpeas	10	decent	Last Available: "2016-02"
+8878	immense stale plate of Mixed Garbanzos and Chickpeas	10	decent	Last Available: "2016-02"
 8879	bland plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	rotten plate of Frigid Northern Beans	3	crappy	Last Available: "2016-02"
 8881	delicious diet twirling plate of World's Blackest-Eyed Peas	1	awesome	Last Available: "2016-02"
@@ -8791,7 +8791,7 @@
 8919	LT&T tattoo kit	0		Last Available: "2016-02"
 8920	wobbly Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
-8922	huge spinning Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
+8922	spinning huge Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	pulsating disc (white)	0		
 8924	disc (black)	0		
 8925	disc (red)	0		
@@ -8826,7 +8826,7 @@
 8954	special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8955	mirror Tales of the West: Cow Punching	0		
 8956	Tales of the West: Beanslinging	0		
-8957	jittery teal Tales of the West: Snake Oiling	0		
+8957	teal jittery Tales of the West: Snake Oiling	0		
 8958	briefcase full of snakes	0		
 8959	spinning squat thinker's one-gallon hat of the early riser	0		Mysticality: +10, Adventures: +7
 8960	supercool weightlifter's two-gallon hat	0		Muscle: +15, Moxie Percent: +20
@@ -8899,7 +8899,7 @@
 9027	lime green beefy First Post shirt - Cir Senam of wisdom of dire peril	0		Muscle: +10, Mysticality: +15, Weapon Damage: +20, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	toothsome special shaking star salad	4	awesome	Effect: "Well-Swabbed Ear", Effect Duration: 45
+9030	special toothsome shaking star salad	4	awesome	Effect: "Well-Swabbed Ear", Effect Duration: 45
 9031	Thwaitgold moth statuette	0		
 9032	rotten bowl of Tastee-Wheet&trade;	3	crappy	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
@@ -8933,7 +8933,7 @@
 9061	mirror Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	pulsating Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
-9064	purple skewed Source terminal file: cram.ext	0		Last Available: "2016-06"
+9064	skewed purple Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	skewed pill	0		Last Available: "2016-06"
@@ -8951,7 +8951,7 @@
 9079	decent hardboiled egg	4	good	Last Available: "2016-07"
 9080	twirling detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	family-friendly frightening mansplainer's Lo Pan's brainy protonic accelerator pack of Flo-Jo	0		Mysticality: +5, Spell Critical Percent: +30, Monster Level: +15, Spooky Damage: +5, Sleaze Resistance: +1, Initiative: +100, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	family-friendly frightening mansplainer's Lo Pan's brainy protonic accelerator pack of Flo-Jo	0		Mysticality: +5, Spell Critical Percent: +30, Monster Level: +15, Spooky Damage: +5, Sleaze Resistance: +1, Initiative: +100, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	avaricious Adventurer bobblehead	0		Meat Drop: +30, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	Oprah's quilted beefy Spookyraven signet	0		Muscle: +10, Damage Absorption: +40, Maximum MP Percent: +50, Single Equip, Last Available: "2016-08"
 9093	blinking Lo Pan's therapeutic tie-dyed fannypack	0		Spell Critical Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2016-08"
 9094	squat steel-toed burnt snowpants of the businessman	0		Damage Reduction: 9, Meat Drop: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	beefcake's standards and practices guide	0		Muscle: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	beefcake's standards and practices guide	0		Muscle: +25, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	upside-down greasy friendly razor-sharp Carpathian longsword	0		Weapon Damage Percent: +25, Familiar Weight: +3, Sleaze Spell Damage: +10, Last Available: "2016-08"
 9097	Herculean smooth Liam's mail of the boozehound	0		Moxie: +15, Experience (Muscle): +1, Booze Drop: +100, Last Available: "2016-08"
 9098	purple prompt stylish Unfortunato's foolscap of the brute	0		Moxie: +25, Muscle Percent: +30, Adventures: +3, Last Available: "2016-08"
@@ -8974,7 +8974,7 @@
 9102	brainy Wrist-Boy	0		Mysticality: +5
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
-9105	tumbling olive compounded experience	0		Last Available: "2016-09"
+9105	olive tumbling compounded experience	0		Last Available: "2016-09"
 9106	Rad-B-Gone (1 lb.)	0		
 9107	denatured corrupted bouncing Rad-Pro (1 oz.)	0		Effect: "Aloofah", Effect Duration: 66
 9108	lead umbrella	0		
@@ -8988,14 +8988,14 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	tumbling Jeselnik's repaid diaper	0		Sleaze Damage: +25
 9118	ghostly Riker's Search History	0		Last Available: "2016-09"
-9119	watered-down mediocre blurry Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
+9119	mediocre watered-down blurry Shot of Kardashian Gin	2	decent	Last Available: "2016-09"
 9120	strapping Unstable Pointy Ears	0		Muscle: +5, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
-9122	spinning bouncing Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
+9122	bouncing spinning Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	upside-down fuchsia droppable microphone	0		
-9126	practically non-alcoholic bad ghostly unidentified drink	1	decent	
+9126	bad practically non-alcoholic ghostly unidentified drink	1	decent	
 9127	spinning asbestos-lined MacGyver's KoL Con 13 T-shirt	0		Maximum MP: +100, Hot Resistance: +5
 9128	auspicious mansplainer's Annie Oakley's discarded swimming trunks	0		Critical Hit Percent: +20, Monster Level: +15, Item Drop: +10
 9129	non-galvanized twirling diluted makeup	0		Effect: "Mmmmmelon", Effect Duration: 31
@@ -9007,30 +9007,30 @@
 9135	artisanal very whiskey	4	EPIC	
 9136	shaking li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	bouncing li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	purple li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	wobbly li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	gray li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	bouncing li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	purple li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	wobbly li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	gray li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	non-pickled cold-filtered huge hoarded candy wad	0		Effect: "Super Structure", Effect Duration: 48, Last Available: "2016-10"
 9147	Vulcanized colloidal Prunets	0		Effect: "Powdered", Effect Duration: 49
-9148	yellow spinning Twitching Television Tattoo	0		
+9148	spinning yellow Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	dry pickled invisible string	0		Lasts Until Rollover, Effect: "Certainty", Effect Duration: 35, Last Available: "2016-10"
 9151	vacuum-sealed invisible seam ripper	0		Lasts Until Rollover, Effect: "Lit Up", Effect Duration: 30, Last Available: "2016-10"
-9152	gray li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	gray li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	flavorless snack-sized skewed raw sweet potato	2	decent	Last Available: "2016-11"
 9154	diet normal raw beans	1	good	Last Available: "2016-11"
 9155	bland fancy blurry raw stuffing	3	decent	Effect: "Gingerbread Robust", Effect Duration: 35, Last Available: "2016-11"
 9156	adequate raw cranberry sauce	3	good	Last Available: "2016-11"
 9157	snack-sized bland raw turkey	2	decent	Last Available: "2016-11"
-9158	adequate half-sized raw mincemeat	2	good	Last Available: "2016-11"
+9158	half-sized adequate raw mincemeat	2	good	Last Available: "2016-11"
 9159	rotten raw potato	4	crappy	Last Available: "2016-11"
-9160	super-sized delicious blurry raw gravy	5	awesome	Last Available: "2016-11"
-9161	stale enchanted bite-sized raw bread	1	decent	Effect: "Floundering", Effect Duration: 35, Last Available: "2016-11"
+9160	delicious super-sized blurry raw gravy	5	awesome	Last Available: "2016-11"
+9161	enchanted bite-sized stale raw bread	1	decent	Effect: "Floundering", Effect Duration: 35, Last Available: "2016-11"
 9162	hardy mini-marshmallow dispenser of vim and vigor	0		Maximum HP Percent: +50, Maximum HP: +50, Last Available: "2016-11"
 9163	sizzling frosty clever glass casserole dish	0		Maximum MP: +20, Cold Spell Damage: +10, Hot Damage: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
@@ -9041,7 +9041,7 @@
 9169	blurry gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	delicious sweet potatoes	3	awesome	Last Available: "2016-11"
-9172	adequate jumbo bean casserole	5	good	Last Available: "2016-11"
+9172	jumbo adequate bean casserole	5	good	Last Available: "2016-11"
 9173	bland baked stuffing	4	decent	Last Available: "2016-11"
 9174	moldy diet cranberry cylinder	1	crappy	Last Available: "2016-11"
 9175	stale thanksgiving turkey	4	decent	Last Available: "2016-11"
@@ -9052,7 +9052,7 @@
 9180	adequate skewed leftovers	4	good	Last Available: "2016-11"
 9181	stale fancy leftovers sandwich	4	decent	Effect: "Wise Spirit", Effect Duration: 40, Last Available: "2016-11"
 9182	wobbly Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
-9183	huge shaking cornucopia	0		Last Available: "2016-11"
+9183	shaking huge cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	interesting clod of dirt	0		
 9217	lime green gingerbread restraining order	0		Last Available: "2016-12"
 9218	squat sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	half-sized rotten animal part cracker	2	crappy	Last Available: "2016-12"
+9219	rotten half-sized animal part cracker	2	crappy	Last Available: "2016-12"
 9220	drinkable gingerbread wine	3	good	Last Available: "2016-12"
 9221	normal fancy gingerbread mug	3	good	Effect: "Egg Burps", Effect Duration: 40, Last Available: "2016-12"
 9222	bouncing gingerbread mask of doom	0		Spooky Spell Damage: +50, Last Available: "2016-12"
@@ -9106,7 +9106,7 @@
 9234	olive vibrating pumpkin spice candle	0		Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2016-12"
 9235	wet flattened wobbly shaking gingerbread spice latte	0		Effect: "Superveiny 9000", Effect Duration: 47, Last Available: "2016-12"
 9236	wobbly maroon foul-smelling sage gingerbread gavel	0		Mysticality Percent: +10, Stench Damage: +10, Last Available: "2016-12"
-9237	pulsating skewed gingerbread cigarette	0		Last Available: "2016-12"
+9237	skewed pulsating gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	drinkable ginger beer	4	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
@@ -9122,9 +9122,9 @@
 9250	chilled quadruple-deionized bouncing Inner Strength	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 26, Last Available: "2016-12"
 9251	pickled ionized twirling Inner Truth	0		Effect: "Radiated and Grodiated", Effect Duration: 57, Last Available: "2016-12"
 9252	rotten spiritual candy cane	3	crappy	Last Available: "2016-12"
-9253	weak acceptable spiritual eggnog	2	good	Last Available: "2016-12"
+9253	acceptable weak spiritual eggnog	2	good	Last Available: "2016-12"
 9254	adequate blinking spiritual fruitcake	3	good	Last Available: "2016-12"
-9255	normal immense spiritual gingerbread	8	good	Last Available: "2016-12"
+9255	immense normal spiritual gingerbread	8	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	blue My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	negative lump	0		
 9273	ghostly Third Eye of dire peril of the empath	0		Weapon Damage: +20, Familiar Weight: +5, Last Available: "2016-12"
 9274	Annie Oakley's Krampus Horn of Flo-Jo	0		Critical Hit Percent: +20, Initiative: +100, Single Equip, Last Available: "2016-12"
-9275	spoiled big hambrosier	5	crappy	Last Available: "2016-12"
+9275	big spoiled hambrosier	5	crappy	Last Available: "2016-12"
 9276	bad high-proof chakra-mental wine	6	decent	Last Available: "2016-12"
 9277	unsweetened denatured wobbly chakra malt	0		Effect: "Fever From the Flavor", Effect Duration: 46, Last Available: "2016-12"
 9278	bland special Black Angus blackburger	3	decent	Effect: "Walberg's Dim Bulb", Effect Duration: 5, Last Available: "2016-12"
-9279	lousy watered-down brandy	2	decent	Last Available: "2016-12"
+9279	watered-down lousy brandy	2	decent	Last Available: "2016-12"
 9280	tarnished cold-filtered flattened potion of spiritual gunkifying	0		Effect: "Well-preserved", Effect Duration: 55, Last Available: "2016-12"
 9281	weightlifter's bad vibroknife of the pedagogue	0		Muscle: +15, Experience: +3, Last Available: "2016-12"
 9282	fuchsia double-paned savvy crystal belt buckle	0		Mysticality Percent: +20, Cold Resistance: +5, Last Available: "2016-12"
@@ -9176,11 +9176,11 @@
 9304	skewed pewter candlestick	0		Familiar Weight: +10
 9305	huge inspector's Jim Carey's wax hand	0		Monster Level: +25, Item Drop: +15, Last Available: "2017-01"
 9306	sage candle of Calamity Jane	0		Mysticality Percent: +10, Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2017-01"
-9307	tasty half-sized wax pancake	2	awesome	Last Available: "2017-01"
+9307	half-sized tasty wax pancake	2	awesome	Last Available: "2017-01"
 9308	twirling hale wicked wax face	0		Spell Damage: +5, Maximum HP: +20, Last Available: "2017-01"
 9309	enchanted tolerable wax booze	3	good	Effect: "Sludgesick", Effect Duration: 40, Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	vaporized red wobbly sea jelly	1		Last Available: "2017-01"
+9311	vaporized wobbly red sea jelly	1		Last Available: "2017-01"
 9312	miniature stale sea truffle	2	decent	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
@@ -9201,13 +9201,13 @@
 9329	magnetized dry eldritch alignment spray	0		Effect: "In the Slimelight", Effect Duration: 34, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	horrifying fortified eldritch hammer of the sewer	0		Damage Absorption: +60, Stench Damage: +25, Spooky Damage: +25, Last Available: "2017-01"
-9332	toothsome snack-sized eldritch mushroom	2	awesome	Last Available: "2017-03"
+9332	snack-sized toothsome eldritch mushroom	2	awesome	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	normal massive eldritch mushroom pizza	9	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	unsweetened twirling eldritch rub	0		Effect: "Heavily Breathing", Effect Duration: 47, Last Available: "2017-02"
-9338	maroon shaking HP-35 Calculator	0		
+9338	shaking maroon HP-35 Calculator	0		
 9339	shaking purple Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
@@ -9234,14 +9234,14 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	blurry imaginary lemon	0		Last Available: "2017-03"
-9365	special bad triple-distilled gray wobbly literal grasshopper	7	decent	Effect: "Helping Comes Second", Effect Duration: 5, Last Available: "2017-03"
+9365	bad special triple-distilled gray wobbly literal grasshopper	7	decent	Effect: "Helping Comes Second", Effect Duration: 5, Last Available: "2017-03"
 9366	mediocre double entendre	4	decent	Last Available: "2017-03"
 9367	drinkable weak Phlegethon	2	good	Last Available: "2017-03"
 9368	perfectly mixed Siberian sunrise	4	EPIC	Last Available: "2017-03"
-9369	watered-down hand-crafted mentholated wine	2	EPIC	Last Available: "2017-03"
-9370	perfectly mixed practically non-alcoholic low tide martini	1	EPIC	Last Available: "2017-03"
+9369	hand-crafted watered-down mentholated wine	2	EPIC	Last Available: "2017-03"
+9370	practically non-alcoholic perfectly mixed low tide martini	1	EPIC	Last Available: "2017-03"
 9371	tolerable yellow shroomtini	4	good	Last Available: "2017-03"
-9372	perfectly mixed practically non-alcoholic morning dew	1	EPIC	Last Available: "2017-03"
+9372	practically non-alcoholic perfectly mixed morning dew	1	EPIC	Last Available: "2017-03"
 9373	triple-distilled smooth whiskey squeeze	9	awesome	Last Available: "2017-03"
 9374	bad great fashioned	4	decent	Last Available: "2017-03"
 9375	perfectly mixed Gnomish sagngria	4	EPIC	Last Available: "2017-03"
@@ -9249,38 +9249,38 @@
 9377	drinkable weak extremely slippery nipple	2	good	Last Available: "2017-03"
 9378	mediocre piscatini	3	decent	Last Available: "2017-03"
 9379	acceptable watered-down gray Churchill	2	good	Last Available: "2017-03"
-9380	acceptable weak soilzerac	2	good	Last Available: "2017-03"
+9380	weak acceptable soilzerac	2	good	Last Available: "2017-03"
 9381	artisanal weak jittery London frog	2	EPIC	Last Available: "2017-03"
 9382	bad nothingtini	4	decent	Last Available: "2017-03"
 9383	acceptable eighth plague	3	good	Last Available: "2017-03"
 9384	hand-crafted single entendre	3	EPIC	Last Available: "2017-03"
 9385	drinkable upside-down blurry reverse Tantalus	3	good	Last Available: "2017-03"
-9386	perfectly mixed fancy blue elemental caipiroska	4	EPIC	Effect: "Pride of the Vampire", Effect Duration: 15, Last Available: "2017-03"
+9386	fancy perfectly mixed blue elemental caipiroska	4	EPIC	Effect: "Pride of the Vampire", Effect Duration: 15, Last Available: "2017-03"
 9387	smooth Feliz Navidad	4	awesome	Last Available: "2017-03"
 9388	perfectly mixed mirror Bloody Nora	4	EPIC	Last Available: "2017-03"
 9389	hand-crafted moreltini	4	EPIC	Last Available: "2017-03"
 9390	acceptable hell in a bucket	3	good	Last Available: "2017-03"
-9391	fortified drinkable jittery Newark	5	good	Last Available: "2017-03"
+9391	drinkable fortified jittery Newark	5	good	Last Available: "2017-03"
 9392	hand-crafted squat R'lyeh	4	EPIC	Last Available: "2017-03"
-9393	distilled tolerable tumbling Gnollish sangria	5	good	Last Available: "2017-03"
+9393	tolerable distilled tumbling Gnollish sangria	5	good	Last Available: "2017-03"
 9394	weak drinkable vodka barracuda	2	good	Last Available: "2017-03"
-9395	tolerable fortified Mysterious Island iced tea	5	good	Last Available: "2017-03"
+9395	fortified tolerable Mysterious Island iced tea	5	good	Last Available: "2017-03"
 9396	hand-crafted drive-by shooting	3	EPIC	Last Available: "2017-03"
 9397	watered-down artisanal gunner's daughter	2	EPIC	Last Available: "2017-03"
-9398	drinkable practically non-alcoholic dirt julep	1	good	Last Available: "2017-03"
+9398	practically non-alcoholic drinkable dirt julep	1	good	Last Available: "2017-03"
 9399	artisanal Simepore slime	3	EPIC	Last Available: "2017-03"
 9400	hand-crafted Phil Collins	3	EPIC	Last Available: "2017-03"
-9401	skewed purple unpowered Robortender	0		Free Pull, Last Available: "2017-03"
-9402	jittery green toggle switch (Bartend)	0		Familiar Weight: +5
-9403	tumbling bouncing blinking toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
+9401	purple skewed unpowered Robortender	0		Free Pull, Last Available: "2017-03"
+9402	green jittery toggle switch (Bartend)	0		Familiar Weight: +5
+9403	tumbling blinking bouncing toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	narrow shaking Spacegate access badge	0		Free Pull, Last Available: "2017-04"
-9405	upside-down skewed filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
+9405	skewed upside-down filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9409	blinking mirror high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9409	mirror blinking high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	fuchsia Spacegate Research	0		Last Available: "2017-04"
-9411	blinking purple alien rock sample	0		Last Available: "2017-04"
+9411	purple blinking alien rock sample	0		Last Available: "2017-04"
 9412	green alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9302,7 +9302,7 @@
 9430	blurry spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	activated alien medicine	0		Effect: "Hippy Flavor", Effect Duration: 51, Last Available: "2017-04"
-9433	thick moldy alien salad	5	crappy	Last Available: "2017-04"
+9433	moldy thick alien salad	5	crappy	Last Available: "2017-04"
 9434	watered-down bad pulsating alien booze	2	decent	Last Available: "2017-04"
 9435	gravedigger's therapeutic hardened alien mask	0		Damage Reduction: 3, Spooky Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-04"
 9436	lightning-fast Newton's alien spear of the businessman	0		Experience (Mysticality): +3, Meat Drop: +50, Initiative: +40, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	executive resourceful murderbot mask of extreme caution	0		Maximum MP: +50, Monster Level: -25, Meat Drop: +40, Avatar: "Murderbot", Last Available: "2017-04"
 9454	vacuum-sealed flattened murderbot spring injector	0		Effect: "Elemental Flavor", Effect Duration: 33, Last Available: "2017-04"
 9455	maroon bouncing smelly Tesla murderbot whip	0		Stench Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2017-04"
-9456	family-friendly murderbot plasma rifle of temperance	0		Sleaze Resistance: 6, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	family-friendly murderbot plasma rifle of temperance	0		Sleaze Resistance: 6, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	ghostly space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9362,9 +9362,9 @@
 9490	activated improved maroon Threatening Missive	0		Effect: "Here to Kick Ass", Effect Duration: 21
 9491	spinning Targeted Plague Vector	0		
 9492	twirling suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	foul-smelling flame-wreathed dog trainer's Kremlin's Greatest Briefcase	0		Experience (familiar): +1, Hot Spell Damage: +10, Stench Damage: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	acceptable practically non-alcoholic huge basic martini	1	good	Last Available: "2017-06"
-9495	mediocre tumbling blinking improved martini	4	decent	Last Available: "2017-06"
+9493	foul-smelling flame-wreathed dog trainer's Kremlin's Greatest Briefcase	0		Experience (familiar): +1, Hot Spell Damage: +10, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	practically non-alcoholic acceptable huge basic martini	1	good	Last Available: "2017-06"
+9495	mediocre blinking tumbling improved martini	4	decent	Last Available: "2017-06"
 9496	artisanal weak splendid martini	2	EPIC	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
@@ -9372,7 +9372,7 @@
 9500	gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	occult extremely unsafe experienced plastic gundam	0		Experience: +2, Weapon Damage Percent: +100, Spell Damage Percent: +25, Last Available: "2017-06"
-9503	blinking ghostly License to Chill	0		Last Available: "2017-07"
+9503	ghostly blinking License to Chill	0		Last Available: "2017-07"
 9504	Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
@@ -9388,7 +9388,7 @@
 9516	meteoroid	0		Last Available: "2017-08"
 9517	healthy meteortarboard of dire peril of the glutton	0		Weapon Damage: +20, Maximum HP Percent: +20, Food Drop: +100, Last Available: "2017-08"
 9518	knitted lard-coated rosy-cheeked meteorite guard	0		Maximum HP Percent: +30, Sleaze Spell Damage: +25, Cold Resistance: +3, Damage Reduction: 9, Last Available: "2017-08"
-9519	gray nasty scorching meteorb	0		Hot Damage: +25, Stench Damage: +5, Lantern Element: "Hot", Last Available: "2017-08"
+9519	gray nasty scorching meteorb	0		Hot Damage: +25, Stench Damage: +5, Last Available: "2017-08", Lantern Element: "Hot"
 9520	horrifying asteroid belt of mayonnaise	0		Spooky Damage: +25, Sleaze Spell Damage: +50, Single Equip, Last Available: "2017-08"
 9521	shaking foul-smelling hardy cool meteorthopedic shoes	0		Moxie: +5, Maximum HP: +50, Stench Damage: +10, Single Equip, Last Available: "2017-08"
 9522	twirling huge avaricious resourceful smooth shooting morning star	0		Moxie: +15, Maximum MP: +50, Meat Drop: +30, Single Equip, Last Available: "2017-08"
@@ -9401,7 +9401,7 @@
 9529	bouncing genie bottle	0		Last Available: "2017-09"
 9530	wobbly Lo Pan's brainy blessed rustproof +2 gray dragon scale mail of the boozehound	0		Mysticality: +5, Spell Critical Percent: +30, Booze Drop: +100, Last Available: "2023-09"
 9531	upside-down pony: Dusk Shiny	0		Last Available: "2017-09"
-9532	gray upside-down narrow pony: Shutterfly	0		Last Available: "2017-09"
+9532	upside-down gray narrow pony: Shutterfly	0		Last Available: "2017-09"
 9533	pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
@@ -9416,15 +9416,15 @@
 9544	O	0		Last Available: "2017-10"
 9545	mediocre high-proof DUFRESNE Suds	9	decent	Last Available: "2017-09"
 9546	mafia pinky ring of dire peril of terror	0		Weapon Damage: +20, Spooky Spell Damage: +10, Single Equip
-9547	enchanted hand-crafted flask of port	3	EPIC	Effect: "Angry Bone", Effect Duration: 50
+9547	hand-crafted enchanted flask of port	3	EPIC	Effect: "Angry Bone", Effect Duration: 50
 9548	careful contract enforcement stick of the glutton	0		Monster Level: -10, Food Drop: +100
 9549	moldy Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
 9550	tolerable pulsating ghostly jug of booze	3	good	Last Available: "2017-10"
 9551	nitrogenated dry pair of candy glasses	0		Effect: "Christmessy", Effect Duration: 51, Last Available: "2017-10"
 9552	ionized temporary X tattoos	0		Effect: "French Bronilla Brogueishness", Effect Duration: 69, Last Available: "2017-10"
-9553	altered ghostly red glyph of athleticism	1		Effect: "El Vibrations", Effect Duration: 45, Last Available: "2017-10"
+9553	altered red ghostly glyph of athleticism	1		Effect: "El Vibrations", Effect Duration: 45, Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
-9555	modified mirror red new habit	0		Effect: "Cute Vision", Effect Duration: 56, Last Available: "2017-10"
+9555	modified red mirror new habit	0		Effect: "Cute Vision", Effect Duration: 56, Last Available: "2017-10"
 9556	fuchsia bridge truss	0		Last Available: "2017-10"
 9557	avaricious beefy pearl necklace of the early riser	0		Muscle: +10, Meat Drop: +30, Adventures: +7, Single Equip, Last Available: "2017-10"
 9558	fuchsia amorphous blob	0		Last Available: "2017-11"
@@ -9450,10 +9450,10 @@
 9578	yellow transparent nog	1	good	Last Available: "2017-12"
 9579	moldy unfinished fruitcake	4	crappy	Last Available: "2017-12"
 9580	denatured and cracker	0		Effect: "Memory of Strength", Effect Duration: 33, Last Available: "2017-12"
-9581	acceptable practically non-alcoholic neg grog	1	good	Last Available: "2017-12"
+9581	practically non-alcoholic acceptable neg grog	1	good	Last Available: "2017-12"
 9582	stale half double fruitcake	3	decent	Last Available: "2017-12"
 9583	snack-sized bland hushed puppy	2	decent	Last Available: "2017-12"
-9584	rotten gigantic muffled muffuletta	10	crappy	Last Available: "2017-12"
+9584	gigantic rotten muffled muffuletta	10	crappy	Last Available: "2017-12"
 9585	toothsome shushed potatoes	3	awesome	Last Available: "2017-12"
 9586	skewed hardened plastic mime functionary	0		Damage Reduction: 3, Last Available: "2017-12"
 9587	bouncing baleful plastic mime scientist	0		Spell Damage: +25, Last Available: "2017-12"
@@ -9461,17 +9461,17 @@
 9589	green twirling stiffened plastic mime executive	0		Damage Reduction: 1, Last Available: "2017-12"
 9590	lard-coated plastic The Silent Nightmare	0		Sleaze Spell Damage: +25, Last Available: "2017-12"
 9591	purple squat locked mumming trunk	0		Free Pull, Last Available: "2017-12"
-9592	tumbling olive mumming trunk	0		Last Available: "2017-12"
+9592	olive tumbling mumming trunk	0		Last Available: "2017-12"
 9593	blue temperance whiskey	1	crappy	Last Available: "2017-11"
 9594	quadruple-adjusted yellow wishbone	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 33, Last Available: "2017-11"
-9595	special practically non-alcoholic delicious Racisto Ruidoso	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2017-11"
+9595	practically non-alcoholic special delicious Racisto Ruidoso	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2017-11"
 9596	spinning earthenware muffin tin	0		
-9597	bland jumbo ghostly bran muffin	5	decent	
-9598	super-sized adequate blueberry muffin	5	good	
+9597	jumbo bland ghostly bran muffin	5	decent	
+9598	adequate super-sized blueberry muffin	5	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	twirling silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
-9602	tumbling squat silent D	0		Last Available: "2017-12"
+9602	squat tumbling silent D	0		Last Available: "2017-12"
 9603	silent E	0		Last Available: "2017-12"
 9604	silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
@@ -9479,10 +9479,10 @@
 9607	silent I	0		Last Available: "2017-12"
 9608	silent J	0		Last Available: "2017-12"
 9609	pulsating silent K	0		Last Available: "2017-12"
-9610	squat squat bouncing silent L	0		Last Available: "2017-12"
+9610	bouncing squat squat silent L	0		Last Available: "2017-12"
 9611	silent M	0		Last Available: "2017-12"
 9612	pulsating silent N	0		Last Available: "2017-12"
-9613	jittery red silent O	0		Last Available: "2017-12"
+9613	red jittery silent O	0		Last Available: "2017-12"
 9614	silent P	0		Last Available: "2017-12"
 9615	blinking silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	warehouse key	0		Last Available: "2017-12"
 9628	maroon mime pocket probe	0		Last Available: "2017-12"
 9629	perfectly mixed special fuchsia stale cheer wine	4	EPIC	Effect: "Coated Arms", Effect Duration: 35, Last Available: "2017-12"
-9630	small normal blurry stale Cheer-E-Os	2	good	Last Available: "2017-12"
+9630	normal small blurry stale Cheer-E-Os	2	good	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	auspicious lion tamer's cheerful antler hat	0		Experience (familiar): +2, Item Drop: +10, Last Available: "2017-12"
 9633	foul-smelling hardened cheerful Crimbo sweater	0		Damage Reduction: 3, Stench Damage: +10, Last Available: "2017-12"
@@ -9518,11 +9518,11 @@
 9646	blurry The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	hand-crafted watered-down executive mime flask	2	EPIC	Last Available: "2017-12"
-9649	low-calorie stale nega-mushroom	1	decent	Last Available: "2017-12"
-9650	high-proof bad nega-mushroom wine	9	decent	Last Available: "2017-12"
+9649	stale low-calorie nega-mushroom	1	decent	Last Available: "2017-12"
+9650	bad high-proof nega-mushroom wine	9	decent	Last Available: "2017-12"
 9651	colloidal tarnished energized shaking Cheer-Up soda	0		Effect: "Human-Machine Hybrid", Effect Duration: 48, Last Available: "2017-12"
 9652	bland fuchsia mime army rations	3	decent	Last Available: "2017-12"
-9653	boozy artisanal mime army wine	5	EPIC	Last Available: "2017-12"
+9653	artisanal boozy mime army wine	5	EPIC	Last Available: "2017-12"
 9654	distilled spinning olive shaking mime army superserum	1		Last Available: "2017-12"
 9655	quantum corrupted bouncing mime army camouflage kit	0		Effect: "Gummi Badass", Effect Duration: 17, Last Available: "2017-12"
 9656	shaking wool Da Vinci's miming beret	0		Experience (Mysticality): +5, Cold Resistance: +1, Last Available: "2017-12"
@@ -9572,7 +9572,7 @@
 9700	reassuring dance instructor's novelty monorail ticket	0		Experience Percent (Moxie): +10, Spooky Resistance: +1
 9701	mixed squat ghostly pills	1		Effect: "The Solution", Effect Duration: 10
 9702	modified olive furry pill	1		Effect: "Deadly Flashing Blade", Effect Duration: 15
-9703	dehydrated cyan skewed beefy pill	1		Effect: "Slimy Hands", Effect Duration: 45
+9703	dehydrated skewed cyan beefy pill	1		Effect: "Slimy Hands", Effect Duration: 45
 9704	distilled blue excitement pill	1		
 9705	vaporized upside-down vitamin G pill	1		
 9706	pickled spinning lucky-ish pill	1		
@@ -9582,7 +9582,7 @@
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	pulsating Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
-9717	shaking maroon They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
+9717	maroon shaking They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	ghostly Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	zippy Samson's genie's turbane	0		Experience (Muscle): +5, Initiative: +20, Last Available: "2018-02"
 9720	purple greasy genie's scimitar of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2018-02"
@@ -9593,8 +9593,8 @@
 9725	psychic's pslacks of the dark arts of the businessman	0		Spell Damage Percent: +100, Meat Drop: +50, Last Available: "2018-02"
 9726	gray beefy psychic's amulet of the blizzard	0		Muscle: +10, Cold Spell Damage: +25, Last Available: "2018-02"
 9727	delicious heart-shaped candy whetstone	3	awesome	Last Available: "2018-02"
-9728	rotten half-sized fancy Swedish massage fish	2	crappy	Effect: "Overstimulated", Effect Duration: 10, Last Available: "2018-02"
-9729	delicious twirling olive Third Base	4	awesome	Last Available: "2018-02"
+9728	fancy half-sized rotten Swedish massage fish	2	crappy	Effect: "Overstimulated", Effect Duration: 10, Last Available: "2018-02"
+9729	delicious olive twirling Third Base	4	awesome	Last Available: "2018-02"
 9730	drinkable Bustle Hustler	4	good	Last Available: "2018-02"
 9731	boiled irradiated skewed Fabiotion	0		Effect: "Your Favorite Flavor", Effect Duration: 41, Last Available: "2018-02"
 9732	unsweetened ionized maroon Bettie page	0		Effect: "Blessing of Charcoatl", Effect Duration: 31, Last Available: "2018-02"
@@ -9692,8 +9692,8 @@
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	huge smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9827	shaking olive rocket	0		
-9828	mixed blinking pulsating red magnificent oyster egg	1		
+9827	olive shaking rocket	0		
+9828	mixed blinking red pulsating magnificent oyster egg	1		
 9829	altered mirror brilliant oyster egg	1		
 9830	dried tumbling purple glistening oyster egg	1		Effect: "Extra-Thick Blood", Effect Duration: 50
 9831	diluted wobbly scintillating oyster egg	1		
@@ -9725,7 +9725,7 @@
 9857	extra-wet boiled universal antivenin	0		Lasts Until Rollover, Effect: "Stands Alone", Effect Duration: 13, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	jittery LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9860	pulsating ghostly FantasyRealm tattoo kit	0		Last Available: "2018-04"
+9860	ghostly pulsating FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	adequate enchanted FantasyRealm turkey leg	3	good	Effect: "Hombre Muerto Caminando", Effect Duration: 30, Last Available: "2018-04"
 9863	perfectly mixed FantasyRealm mead	3	EPIC	Last Available: "2018-04"
@@ -9735,15 +9735,15 @@
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	adequate low-calorie druidic s'more	1	good	Last Available: "2018-04"
-9870	denatured squat upside-down sachet of powder	1		Last Available: "2018-04"
-9871	acceptable weak mourning wine	2	good	Last Available: "2018-04"
+9870	denatured upside-down squat sachet of powder	1		Last Available: "2018-04"
+9871	weak acceptable mourning wine	2	good	Last Available: "2018-04"
 9872	yellow sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	jittery map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	adequate huge denastified haunch	8	good	Last Available: "2018-04"
+9878	huge adequate denastified haunch	8	good	Last Available: "2018-04"
 9879	perfectly mixed bad rum and good cola	3	EPIC	Last Available: "2018-04"
 9880	alkaline blurry Potion of Heroism	0		Effect: "Lemony Goodness", Effect Duration: 54, Last Available: "2018-04"
 9881	stiffened leggings of the Spider Queen of extreme caution of temperance	0		Damage Reduction: 1, Monster Level: -25, Sleaze Resistance: +5, Last Available: "2018-04"
@@ -9763,16 +9763,16 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	watered-down artisanal two meat muck	2	EPIC	
+9898	artisanal watered-down two meat muck	2	EPIC	
 9899	flavorless diet chocolate Ogre Chieftain	1	decent	
-9900	super-sized flavorless chocolate &quot;Phoenix&quot;	5	decent	
+9900	flavorless super-sized chocolate &quot;Phoenix&quot;	5	decent	
 9901	spoiled chocolate Spider Queen	4	crappy	
 9902	weak acceptable hipster cocktail	2	good	
-9903	God Lobster's Scepter	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "small fairy/lep"
-9904	mirror God Lobster's Ring	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "sombrero"
-9905	yellow God Lobster's Rod	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	mirror God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	yellow God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	pulsating Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9780,8 +9780,8 @@
 9912	shaking A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
-9915	stale immense good guava	8	decent	
-9916	drinkable triple-distilled gin and ginger	8	good	
+9915	immense stale good guava	8	decent	
+9916	triple-distilled drinkable gin and ginger	8	good	
 9917	mirror Thwaitgold chigger statuette	0		
 9918	powdered mirror gaseous gravy	1		Effect: "Okee-Dokee Computer", Effect Duration: 40
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9821,13 +9821,13 @@
 9953	spoiled tiny PB&J with the crusts cut off	1	crappy	Last Available: "2018-09"
 9954	twirling razor-sharp stylish dorky glasses	0		Moxie: +25, Weapon Damage Percent: +25, Single Equip, Last Available: "2018-09"
 9955	nippy careful ponytail clip	0		Monster Level: -10, Cold Damage: +10, Last Available: "2018-09"
-9956	narrow therapeutic paint palette	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	narrow therapeutic paint palette	0		HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	diluted blurry Purple Beast energy drink	1		Effect: "Cold Hard Skin", Effect Duration: 30, Last Available: "2018-09"
 9959	squat cosmetic football of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-09"
 9960	squat shoe ad T-shirt of the cougar of the detective	0		Moxie: +20, Item Drop: +20, Last Available: "2018-09"
 9961	pump-up high-tops of the brazier	0		Hot Spell Damage: +25, Single Equip, Last Available: "2018-09"
-9962	magnetized skewed pulsating blue wobbly runproof mascara	0		Effect: "Kindly Resolve", Effect Duration: 32, Last Available: "2018-09"
+9962	magnetized pulsating skewed blue wobbly runproof mascara	0		Effect: "Kindly Resolve", Effect Duration: 32, Last Available: "2018-09"
 9963	very small dress	0		Last Available: "2018-09"
 9964	bouncing hardened noticeable pumps of extreme caution	0		Damage Reduction: 3, Monster Level: -25, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
@@ -9837,8 +9837,8 @@
 9969	olive manspreader's denim jacket of the bloodbag	0		Maximum HP: +100, Monster Level: +10, Last Available: "2018-09"
 9970	Jeselnik's Jim Carey's ratty knitted cap	0		Monster Level: +25, Sleaze Damage: +25, Last Available: "2018-09"
 9972	fuchsia family-friendly intimidating chainsaw of Gandalf	0		Spell Critical Percent: +20, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2018-09"
-9973	acceptable practically non-alcoholic party beer bomb	1	good	Last Available: "2018-09"
-9974	half-sized special stale blurry sweet party mix	2	decent	Effect: "Flambé-a-thon", Effect Duration: 10, Last Available: "2018-09"
+9973	practically non-alcoholic acceptable party beer bomb	1	good	Last Available: "2018-09"
+9974	stale special half-sized blurry sweet party mix	2	decent	Effect: "Flambé-a-thon", Effect Duration: 10, Last Available: "2018-09"
 9975	modified spinning party balloon	1		Last Available: "2018-09"
 9976	upside-down teal wool ruddy party pants	0		Maximum HP Percent: +40, Cold Resistance: +1, Last Available: "2018-09"
 9977	spinning rosewater-soaked sizzling nippy party whip	0		Cold Damage: +10, Hot Damage: +10, Stench Resistance: +3, Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	normal massive party platter for one	9	good	Last Available: "2018-09"
 9981	modified ghostly yellow Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	blinking party pup	0		Last Available: "2018-09"
-9983	ruddy wizardly party crasher	0		Mysticality: +25, Maximum HP Percent: +40, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	lime green squat ghostly Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
-9985	maroon spinning Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
+9983	ruddy wizardly party crasher	0		Mysticality: +25, Maximum HP Percent: +40, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	lime green squat ghostly Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9985	spinning maroon Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	skewed olive latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	skewed olive latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	jittery latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	squat stiffened &quot;I Voted!&quot; sticker	0		Damage Reduction: 1, Lasts Until Rollover, Last Available: "2018-11"
@@ -9873,7 +9873,7 @@
 10007	greedy sharpshooter's mutant arm of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +10, Meat Drop: +20, Last Available: "2018-11"
 10008	knitted deadly smooth mutant legs	0		Moxie: +15, Weapon Damage: +5, Cold Resistance: +3, Last Available: "2018-11"
 10009	zippy Jack Frost's crafty mutant crown	0		Maximum MP: +10, Cold Spell Damage: +50, Initiative: +20, Last Available: "2018-11"
-10010	rotten huge blue ghostly ectoplasm	7	crappy	Last Available: "2018-11"
+10010	huge rotten blue ghostly ectoplasm	7	crappy	Last Available: "2018-11"
 10011	moldy	3	crappy	Last Available: "2018-11"
 10012	irresponsibly strong tolerable huge bottle of vodka	8	good	Last Available: "2018-11"
 10013	flavorless fuchsia pizza	3	decent	Last Available: "2018-11"
@@ -9881,11 +9881,11 @@
 10015	half-sized decent narrow cherry pie	2	good	Last Available: "2018-11"
 10016	fancy bad squat eggnog	3	decent	Effect: "Jungle Juiced", Effect Duration: 5, Last Available: "2018-11"
 10017	huge glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	huge bland Hell ramen	10	decent	Last Available: "2018-11"
+10018	bland huge Hell ramen	10	decent	Last Available: "2018-11"
 10019	smooth gimlet	3	awesome	Last Available: "2018-11"
 10020	watered-down aged enchanted twice-haunted screwdriver	2	awesome	Effect: "Pharmaceutically Cool", Effect Duration: 40, Last Available: "2018-11"
 10021	flavorless candy cane	3	decent	Last Available: "2018-12"
-10022	bad practically non-alcoholic maroon twirling runny fermented egg	1	decent	Last Available: "2018-12"
+10022	practically non-alcoholic bad twirling maroon runny fermented egg	1	decent	Last Available: "2018-12"
 10023	decent oldcake	3	good	Last Available: "2018-12"
 10024	bland traditional Crimbo cookie	3	decent	Last Available: "2023-06"
 10025	plastic wild beaver of the dark arts	0		Spell Damage Percent: +100, Last Available: "2018-12"
@@ -9923,19 +9923,19 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	blurry manspreader's clever curative personal trainer's Kramco Sausage-o-Matic&trade; of the wise owl	0		Mysticality: +20, Experience Percent (Muscle): +10, Maximum MP: +20, Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	adequate thick sausage	5	good	Last Available: "2019-01"
+10060	thick adequate sausage	5	good	Last Available: "2019-01"
 10061	fuchsia boxer's red-hot sausage fork of the cougar	0		Moxie: +20, Muscle Percent: +10, Last Available: "2019-01"
 10062	upside-down bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	weak artisanal beer	2	super ultra EPIC	Last Available: "2018-12"
+10066	artisanal weak beer	2	super ultra EPIC	Last Available: "2018-12"
 10067	stale yule gruel	3	decent	Last Available: "2018-12"
 10068	bad hot watered rum	3	decent	Last Available: "2018-12"
 10069	lousy triple-distilled bottle of Crimbognac	8	decent	Last Available: "2018-12"
 10070	spoiled Crimboysters Rockefeller	3	crappy	Last Available: "2018-12"
-10071	twisted skewed tumbling twirling Crimbeau de toilette	1		Effect: "Well-Oiled", Effect Duration: 30, Last Available: "2018-12"
-10072	shaking tumbling spinning Crimbo candle	0		Last Available: "2018-12"
+10071	twisted skewed twirling tumbling Crimbeau de toilette	1		Effect: "Well-Oiled", Effect Duration: 30, Last Available: "2018-12"
+10072	tumbling spinning shaking Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	spinning Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10075	shaking Carol of the Hells	0		Skill: "Carol of the Hells", Last Available: "2018-12"
@@ -9951,7 +9951,7 @@
 10085	lard-coated smartaleck's chalk chinos	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Last Available: "2019-12"
 10086	twirling frightening therapeutic chalk chapeau	0		Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-12"
 10087	flame-retardant chalk choker of the sweet-tooth	0		Hot Resistance: +1, Candy Drop: +100, Single Equip, Last Available: "2019-12"
-10088	denatured shaking wobbly chalk chunks	1		Last Available: "2019-12"
+10088	denatured wobbly shaking chalk chunks	1		Last Available: "2019-12"
 10089	adjusted anodized candy chalk	0		Effect: "Hammered", Effect Duration: 23
 10090	flame-retardant electrified marble maebari	0		Hot Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-12"
 10091	Da Vinci's strapping marble mantle	0		Muscle: +5, Experience (Mysticality): +5, Last Available: "2019-12"
@@ -9959,22 +9959,22 @@
 10093	perfumed extremely unsafe marble mignonette bowl	0		Weapon Damage Percent: +100, Stench Resistance: +5, Last Available: "2019-12"
 10094	jittery dog trainer's marble medallion of incineration	0		Experience (familiar): +1, Hot Spell Damage: +50, Single Equip, Last Available: "2019-12"
 10095	ribald slick marble mariachi hat	0		Moxie: +10, Sleaze Damage: +10, Last Available: "2019-12"
-10096	diluted twirling lime green tumbling marble molecules	1		Last Available: "2019-12"
+10096	diluted lime green tumbling twirling marble molecules	1		Last Available: "2019-12"
 10097	flattened altered Mallomarbles	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 53
-10098	smelly punching bag of terror	0		Stench Spell Damage: +10, Spooky Spell Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	banded sinister pith helmet	0		Spell Damage: +10, Damage Absorption: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	lime green deadly brainy poncho	0		Mysticality: +5, Weapon Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	gravedigger's pendant of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	ghostly ribald stylish palazzos	0		Moxie: +25, Sleaze Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	pseudoaccordion of the sewer of doom	0		Stench Damage: +25, Spooky Spell Damage: +50, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	smelly punching bag of terror	0		Stench Spell Damage: +10, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	banded sinister pith helmet	0		Spell Damage: +10, Damage Absorption: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	lime green deadly brainy poncho	0		Mysticality: +5, Weapon Damage: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	gravedigger's pendant of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	ghostly ribald stylish palazzos	0		Moxie: +25, Sleaze Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	pseudoaccordion of the sewer of doom	0		Stench Damage: +25, Spooky Spell Damage: +50, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	compressed pieces	1		Effect: "Fudge Headache", Effect Duration: 50, Last Available: "2020-12"
 10105	ionized ghostly Para-Pop	0		Effect: "Net Tea", Effect Duration: 28
-10106	upside-down horrifying terra cotta truss of the sewer	0		Stench Damage: +25, Spooky Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	mirror gray smelly nasty terra cotta trousers	0		Stench Damage: +5, Stench Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	fuchsia weightlifter's terra cotta tongs	0		Muscle: +15, Item Drop: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	beefcake's terra cotta train of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	medical-grade padded terra cotta tie tack	0		Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	gravedigger's Da Vinci's terra cotta tambourine	0		Experience (Mysticality): +5, Spooky Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	upside-down horrifying terra cotta truss of the sewer	0		Stench Damage: +25, Spooky Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	mirror gray smelly nasty terra cotta trousers	0		Stench Damage: +5, Stench Spell Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	fuchsia weightlifter's terra cotta tongs	0		Muscle: +15, Item Drop: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	beefcake's terra cotta train of the scaredy-cat	0		Muscle: +25, Monster Level: -15, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	medical-grade padded terra cotta tie tack	0		Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	gravedigger's Da Vinci's terra cotta tambourine	0		Experience (Mysticality): +5, Spooky Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	mixed upside-down terra cotta tidbits	1		Last Available: "2020-12"
 10113	denatured mirror terra panna cotta	0		Effect: "Radiant Personality", Effect Duration: 17
 10114	smooth beefcake's velour voulge	0		Muscle: +25, Moxie: +15, Last Available: "2021-12"
@@ -9993,21 +9993,21 @@
 10127	scorching coward's glass serape	0		Monster Level: -20, Hot Damage: +25, Last Available: "2021-12"
 10128	distilled glass shards	1		Last Available: "2021-12"
 10129	alkaline cold-filtered hard candy	0		Effect: "Three Days Slow", Effect Duration: 24
-10130	maroon wicked groovy loofah lumberjack's hat	0		Moxie Percent: +10, Spell Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	foul-smelling loofah lei of bravery	0		Stench Damage: +10, Spooky Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	shellacked savvy loofah lederhosen	0		Mysticality Percent: +20, Damage Reduction: 7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	hale extremely unsafe loofah ladle	0		Weapon Damage Percent: +100, Maximum HP: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	censurious loofah legwarmers of the cougar	0		Moxie: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	double-paned Rosewater's loofah lavalier	0		Mysticality Percent: +30, Cold Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	boiled mirror spinning loofah lumps	1		Last Available: "2022-12"
+10130	maroon wicked groovy loofah lumberjack's hat	0		Moxie Percent: +10, Spell Damage: +5, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	foul-smelling loofah lei of bravery	0		Stench Damage: +10, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	shellacked savvy loofah lederhosen	0		Mysticality Percent: +20, Damage Reduction: 7, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	hale extremely unsafe loofah ladle	0		Weapon Damage Percent: +100, Maximum HP: +20, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	censurious loofah legwarmers of the cougar	0		Moxie: +20, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	double-paned Rosewater's loofah lavalier	0		Mysticality Percent: +30, Cold Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10136	boiled spinning mirror loofah lumps	1		Last Available: "2022-12"
 10137	galvanized jittery chocolate-covered loofah	0		Effect: "Hyperoxygenated Blood", Effect Duration: 36
-10138	razor-sharp flagstone flag of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	jittery gravedigger's flagstone flail of the pedagogue	0		Experience: +3, Spooky Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	olive educational flagstone flip-flops of the pedagogue	0		Experience: 4, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	lime green energetic educational flagstone fez	0		Experience: +1, Maximum MP Percent: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	bouncing teal deadly educational flagstone fleece	0		Experience: +1, Weapon Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	flagstone fringe of terror of the businessman	0		Spooky Spell Damage: +10, Meat Drop: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	mixed upside-down blue bouncing flagstone flagments	1		Effect: "Educated (Sorta)", Effect Duration: 45, Last Available: "2022-12"
+10138	razor-sharp flagstone flag of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +25, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	jittery gravedigger's flagstone flail of the pedagogue	0		Experience: +3, Spooky Damage: +10, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	olive educational flagstone flip-flops of the pedagogue	0		Experience: 4, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	lime green energetic educational flagstone fez	0		Experience: +1, Maximum MP Percent: +20, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	bouncing teal deadly educational flagstone fleece	0		Experience: +1, Weapon Damage: +5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	flagstone fringe of terror of the businessman	0		Spooky Spell Damage: +10, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10144	mixed blue bouncing upside-down flagstone flagments	1		Effect: "Educated (Sorta)", Effect Duration: 45, Last Available: "2022-12"
 10145	triple-dry aerosolized Flag by the Foot&trade;	0		Effect: "Crud&eacute;", Effect Duration: 45
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	mirror red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,7 +10018,7 @@
 10152	olive sew-on bandage	0		Last Available: "2019-12"
 10153	spinning really nice net	0		Last Available: "2019-12"
 10154	elf army poncho of extreme caution	0		Monster Level: -25, Lasts Until Rollover, Last Available: "2019-12"
-10155	decent special tumbling maroon elf army field rations	4	good	Effect: "Christmessy", Effect Duration: 5, Last Available: "2019-12"
+10155	special decent tumbling maroon elf army field rations	4	good	Effect: "Christmessy", Effect Duration: 5, Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	chilly veiny discarded bowtie	0		Maximum HP: +10, Cold Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
 10158	practically non-alcoholic acceptable martiny	1	good	Last Available: "2019-12"
@@ -10029,19 +10029,19 @@
 10163	liquefied alkaline government-issued candy	0		Effect: "Bored Stiff", Effect Duration: 23
 10164	magnetized moist Pneumo bar	0		Effect: "Hot Blooded", Effect Duration: 55
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	zippy extremely unsafe Lil' Doctor&trade; bag	0		Weapon Damage Percent: +100, Initiative: +20, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	zippy extremely unsafe Lil' Doctor&trade; bag	0		Weapon Damage Percent: +100, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	normal huge bloodstick	9	good	
 10170	strong tolerable bottle of Sanguiovese	5	good	
-10171	miniature adequate actual blood sausage	2	good	
+10171	adequate miniature actual blood sausage	2	good	
 10172	bad mulled blood	4	decent	
 10173	flavorless skewed blood snowcone	3	decent	
 10174	boozy lousy upside-down Red Russian	5	decent	
 10175	bland blood roll-up	4	decent	
 10176	tolerable huge bottle of blood	3	good	
-10177	spoiled super-sized wobbly blood-soaked sponge cake	5	crappy	
+10177	super-sized spoiled wobbly blood-soaked sponge cake	5	crappy	
 10178	artisanal gray vampagne	3	super EPIC	
-10179	bland bite-sized shaking plain snowcone	1	decent	
+10179	bite-sized bland shaking plain snowcone	1	decent	
 10180	Booke of Vampyric Knowledge	0		
 10181	squat money bag	0		
 10182	money bag	0		
@@ -10065,7 +10065,7 @@
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	lousy bottle of dark rhum	3	decent	Last Available: "2019-04"
 10202	tolerable bottle of extra-dark rhum	3	good	Last Available: "2019-04"
-10203	weak lousy bottle of super-extra-dark rhum	2	decent	Last Available: "2019-04"
+10203	lousy weak bottle of super-extra-dark rhum	2	decent	Last Available: "2019-04"
 10204	wet galvanized pirate shaving cream	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 59, Last Available: "2019-04"
 10205	twirling scandalous Oprah's conquistador's breastplate	0		Maximum MP Percent: +50, Sleaze Damage: +5, Last Available: "2019-04"
 10206	miser's Rosewater's pirate pantaloons	0		Mysticality Percent: +30, Meat Drop: +10, Last Available: "2019-04"
@@ -10074,7 +10074,7 @@
 10209	spinning teal windicle	0		Last Available: "2019-04"
 10210	narrow bouncing lion tamer's weightlifter's pirate radio ring	0		Muscle: +15, Experience (familiar): +2, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	normal half-sized twirling narrow pineapple slab	2	good	Last Available: "2019-04"
+10212	half-sized normal twirling narrow pineapple slab	2	good	Last Available: "2019-04"
 10213	decent hibiscus petal	4	good	Last Available: "2019-04"
 10214	Vulcanized double-dry huge mint leaf	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 57, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
@@ -10089,22 +10089,22 @@
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	Sherlock's plush sea serpent	0		Item Drop: +25, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	rotten small pirate fork	2		Last Available: "2019-04"
+10227	small rotten pirate fork	2		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	maroon up-at-dawn gravedigger's piratical blunderbuss	0		Spooky Damage: +10, Adventures: +5, Last Available: "2019-04"
 10231	blurry lightning-fast scandalous clever PirateRealm party hat	0		Maximum MP: +20, Sleaze Damage: +5, Initiative: +40, Last Available: "2019-04"
 10232	artisanal Island Landslide	4	EPIC	Last Available: "2019-04"
-10233	extra-dry hand-crafted Island Thunderstorm	5	EPIC	Last Available: "2019-04"
-10234	perfectly mixed weak Island Hurricane	2	super EPIC	Last Available: "2019-04"
+10233	hand-crafted extra-dry Island Thunderstorm	5	EPIC	Last Available: "2019-04"
+10234	weak perfectly mixed Island Hurricane	2	super EPIC	Last Available: "2019-04"
 10235	acceptable practically non-alcoholic yellow Skull Punch	1	good	Last Available: "2019-04"
 10236	hand-crafted Electric Punch	3	EPIC	Last Available: "2019-04"
-10237	hand-crafted maroon spinning Smuggler's Punch	3	super EPIC	Last Available: "2019-04"
-10238	perfectly mixed watered-down Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10237	hand-crafted spinning maroon Smuggler's Punch	3	super EPIC	Last Available: "2019-04"
+10238	watered-down perfectly mixed Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10239	drinkable Turtle Bowl	3	good	Last Available: "2019-04"
-10240	perfectly mixed weak upside-down Cobra Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10240	weak perfectly mixed upside-down Cobra Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	up-at-dawn occult razor-sharp vampyric cloake of the empath of the overflowing toilet	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Familiar Weight: +5, Stench Spell Damage: +50, Adventures: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	up-at-dawn occult razor-sharp vampyric cloake of the empath of the overflowing toilet	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Familiar Weight: +5, Stench Spell Damage: +50, Adventures: +5, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	double-warmed one piece of bubble gum	0		Effect: "Scarysauce", Effect Duration: 56
 10245	huge arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	rosewater-soaked supercool smooth Fourth of May Cosplay Saber	0		Moxie: +15, Moxie Percent: +20, Stench Resistance: +3, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	rosewater-soaked supercool smooth Fourth of May Cosplay Saber	0		Moxie: +15, Moxie Percent: +20, Stench Resistance: +3, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	wool scorching Jack Frost's Annie Oakley's hale forbidden Socratic experienced hewn moon-rune spoon of bravery of the glutton of Flo-Jo	0		Experience: +2, Experience (Mysticality): +1, Spell Damage Percent: +50, Maximum HP: +20, Critical Hit Percent: +20, Cold Spell Damage: +50, Hot Damage: +25, Cold Resistance: +1, Spooky Resistance: +5, Food Drop: +100, Initiative: +100, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	wool scorching Jack Frost's Annie Oakley's hale forbidden Socratic experienced hewn moon-rune spoon of bravery of the glutton of Flo-Jo	0		Experience: +2, Experience (Mysticality): +1, Spell Damage Percent: +50, Maximum HP: +20, Critical Hit Percent: +20, Cold Spell Damage: +50, Hot Damage: +25, Cold Resistance: +1, Spooky Resistance: +5, Food Drop: +100, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	red family-friendly beefcake's Beach Comb of vim and vigor	0		Muscle: +25, Maximum HP Percent: +50, Sleaze Resistance: +1, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	red family-friendly beefcake's Beach Comb of vim and vigor	0		Muscle: +25, Maximum HP Percent: +50, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10142,7 +10142,7 @@
 10277	foul-smelling hale brawny waders	0		Muscle Percent: +20, Maximum HP: +20, Stench Damage: +10, Last Available: "2019-07"
 10278	wobbly occult spearfish fishing spear of the blizzard of doom	0		Spell Damage Percent: +25, Cold Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2019-07"
 10279	jittery ribald Da Vinci's rabbitfish fin of the overflowing toilet	0		Experience (Mysticality): +5, Stench Spell Damage: +50, Sleaze Damage: +10, Single Equip, Last Available: "2019-07"
-10280	skewed pulsating piece of coral	0		Last Available: "2019-07"
+10280	pulsating skewed piece of coral	0		Last Available: "2019-07"
 10281	piece of driftwood	0		Last Available: "2019-07"
 10282	lard-coated smelly beefy pirate cutlass	0		Muscle: +10, Stench Spell Damage: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2019-07"
 10283	smartaleck's brawny tricorn hat of vim and vigor	0		Muscle Percent: +20, Moxie Percent: +30, Maximum HP Percent: +50, Last Available: "2019-07"
@@ -10166,10 +10166,10 @@
 10301	scandalous educational whittled fox figurine of the pedagogue	0		Experience: 4, Sleaze Damage: +5, Single Equip, Last Available: "2019-08"
 10302	olive scorching Annie Oakley's clever whittled walking stick of mayonnaise	0		Maximum MP: +20, Critical Hit Percent: +20, Hot Damage: +25, Sleaze Spell Damage: +50, Last Available: "2019-08"
 10303	rotten campfire hot dog	4	crappy	Last Available: "2019-08"
-10304	flavorless big campfire baked potato	5	decent	Last Available: "2019-08"
+10304	big flavorless campfire baked potato	5	decent	Last Available: "2019-08"
 10305	adequate campfire s'more	4	good	Last Available: "2019-08"
-10306	flavorless gigantic campfire beans	9	decent	Last Available: "2019-08"
-10307	flavorless fancy campfire stew	3	decent	Effect: "Top Dog", Effect Duration: 10, Last Available: "2019-08"
+10306	gigantic flavorless campfire beans	9	decent	Last Available: "2019-08"
+10307	fancy flavorless campfire stew	3	decent	Effect: "Top Dog", Effect Duration: 10, Last Available: "2019-08"
 10308	enchanted wobbly campfire coffee	1	EPIC	Effect: "Moon-Eyed", Effect Duration: 45, Last Available: "2019-08"
 10309	deionized ghostly olive leftover chocolate bar	0		Effect: "Whitened Teeth", Effect Duration: 66
 10310	rare Meat isotope	0		
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	fuchsia Thwaitgold bombardier beetle statuette	0		
 10320	tasty space chowder	4	awesome	
-10321	watered-down drinkable space wine	2	good	
+10321	drinkable watered-down space wine	2	good	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10194,29 +10194,29 @@
 10335	olive diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bu&ntilde;uelos Jaliscos	3	decent	Last Available: "2019-12"
-10338	normal big flan del mar	5	good	Last Available: "2019-12"
-10339	fancy moldy Baja sopapilla	4	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 20, Last Available: "2019-12"
+10338	big normal flan del mar	5	good	Last Available: "2019-12"
+10339	moldy fancy Baja sopapilla	4	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 20, Last Available: "2019-12"
 10340	brawny plastic Mer-kin baker	0		Muscle Percent: +20, Last Available: "2019-12"
 10341	maroon plastic sea elf of bravery	0		Spooky Resistance: +5, Last Available: "2019-12"
 10342	pulsating wholesome plastic yuleviathan	0		Maximum HP Percent: +10, Last Available: "2019-12"
 10343	tumbling plastic dolphin &quot;orphan&quot; of the wise owl	0		Mysticality: +20, Single Equip, Last Available: "2019-12"
 10344	plastic Dolph Bossin of courage	0		Spooky Resistance: +3, Last Available: "2019-12"
 10345	narrow red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	stale immense mana-coated yams	9	decent	Last Available: "2019-11"
+10346	immense stale mana-coated yams	9	decent	Last Available: "2019-11"
 10347	adequate huge mana-basted tofurkey leg	10	good	Last Available: "2019-11"
 10348	bland mana-fortified cranberry sauce	3	decent	Last Available: "2019-11"
-10349	snack-sized bland mana-stuffed herbal stuffing	2	decent	Last Available: "2019-11"
+10349	bland snack-sized mana-stuffed herbal stuffing	2	decent	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	corrupted patch of extra-warm fur	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 37, Last Available: "2019-12"
 10352	dehydrated narrow industrial lubricant	1		Effect: "Big Punkin'", Effect Duration: 45, Last Available: "2019-12"
 10353	anodized alkaline unfinished pleasure	0		Effect: "Human-Undead Hybrid", Effect Duration: 42, Last Available: "2019-12"
-10354	dehydrated blue narrow huge vial of humanoid growth hormone	1		Last Available: "2019-12"
+10354	dehydrated blue huge narrow vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	twisted jittery a bug's lymph	1		Last Available: "2019-12"
 10356	dry skewed organic potpourri	0		Effect: "Mana Tea", Effect Duration: 49, Last Available: "2019-12"
-10357	watered-down artisanal boot flask	2	EPIC	Last Available: "2019-12"
+10357	artisanal watered-down boot flask	2	EPIC	Last Available: "2019-12"
 10358	anodized irradiated mirror infernal snowball	0		Effect: "Smoking like a Bandit", Effect Duration: 67, Last Available: "2019-12"
 10359	upside-down madness	0		Last Available: "2019-12"
-10360	denatured blue blurry narrow fish sauce	1		Last Available: "2019-12"
+10360	denatured narrow blurry blue fish sauce	1		Last Available: "2019-12"
 10361	half-sized stale guffin	2	decent	Last Available: "2019-12"
 10362	altered maroon Shantix&trade;	1		Last Available: "2019-12"
 10363	teal goodberry	0		Last Available: "2019-12"
@@ -10233,7 +10233,7 @@
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
 10375	flattened double-chilled adjusted ghostly olive shaking concentrated fish broth	0		Effect: "Insatiable Hunger", Effect Duration: 16, Last Available: "2019-12"
 10376	unsweetened pressed blurry tumbling liquid SONAR	0		Effect: "Wet Rub", Effect Duration: 38, Last Available: "2019-12"
-10377	blurry twirling map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
+10377	twirling blurry map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
 10378	Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	nasty fortified brainy Dolph Bossin's Crimbo hat	0		Mysticality: +5, Damage Absorption: +60, Stench Damage: +5, Last Available: "2019-12"
 10380	The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
@@ -10253,9 +10253,9 @@
 10394	veiny healthy Mer-kin rollpin	0		Maximum HP Percent: +20, Maximum HP: +10, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	red tinsel fin	0		Familiar Weight: +5
-10397	half-sized adequate bowl of mernudo	2	good	Last Available: "2019-12"
+10397	adequate half-sized bowl of mernudo	2	good	Last Available: "2019-12"
 10398	strong mediocre jittery fishelada	5	decent	Last Available: "2019-12"
-10399	flavorless special ojo de pez burrito	3	decent	Effect: "Spooky Weapon", Effect Duration: 20, Last Available: "2019-12"
+10399	special flavorless ojo de pez burrito	3	decent	Effect: "Spooky Weapon", Effect Duration: 20, Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	skewed waterlogged cloth	0		Last Available: "2019-12"
 10402	upside-down waterlogged stuffing	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	huge nutcracker figurine	0		Last Available: "2019-12"
 10415	immense rotten salt plum	6	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	moldy small and bean	2	crappy	Last Available: "2019-12"
+10417	small moldy and bean	2	crappy	Last Available: "2019-12"
 10418	Samson's strapping kelp-holly gun of Gandalf	0		Muscle: +5, Experience (Muscle): +5, Spell Critical Percent: +20, Last Available: "2019-12"
 10419	maroon extremely unsafe Yuleviathan necklace of the ox	0		Muscle: +20, Weapon Damage Percent: +100, Single Equip, Last Available: "2019-12"
 10420	pulsating peppermint spine of the ox of the scaredy-cat	0		Muscle: +20, Monster Level: -15, Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	toasty Crimbylow-rise jeans of the sweet-tooth	0		Hot Damage: +5, Candy Drop: +100, Last Available: "2019-12"
 10423	curative fortified kelp-holly drape	0		Damage Absorption: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10424	wobbly huge green scandalous Da Vinci's Staff of the Peppermint Twist of the brazier of the early riser	0		Experience (Mysticality): +5, Hot Spell Damage: +25, Sleaze Damage: +5, Adventures: +7, Last Available: "2019-12"
-10425	huge normal tempura and bean	9	good	Last Available: "2019-12"
+10425	normal huge tempura and bean	9	good	Last Available: "2019-12"
 10426	artisanal salt plum sake	3	EPIC	Last Available: "2019-12"
 10427	dry ionized shaking pressurized potion of possessiveness	0		Effect: "Dance Interpreter", Effect Duration: 36, Last Available: "2019-12"
 10428	energized altered almond	0		Effect: "Stogied", Effect Duration: 52
 10429	colloidal shaking skewed handful of mixed nuts	0		Effect: "Carrion' On", Effect Duration: 63, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	flame-wreathed crafty wicked Retrospecs	0		Spell Damage: +5, Maximum MP: +10, Hot Spell Damage: +10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	flame-wreathed crafty wicked Retrospecs	0		Spell Damage: +5, Maximum MP: +10, Hot Spell Damage: +10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	jittery unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	shaking mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	dog trainer's baleful Socratic smartaleck's Powerful Glove of vim and vigor	0		Moxie Percent: +30, Experience (Mysticality): +1, Spell Damage: +25, Maximum HP Percent: +50, Experience (familiar): +1, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	dog trainer's baleful Socratic smartaleck's Powerful Glove of vim and vigor	0		Moxie Percent: +30, Experience (Mysticality): +1, Spell Damage: +25, Maximum HP Percent: +50, Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	nippy clever slick Drip harness	0		Moxie: +10, Maximum MP: +20, Cold Damage: +10
@@ -10336,12 +10336,12 @@
 10479	bouncing plastic doll legs	0		
 10480	blinking rubber baby doll	0		
 10481	huge Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
-10482	spinning ghostly packet of mushroom spores	0		Last Available: "2020-03"
+10482	ghostly spinning packet of mushroom spores	0		Last Available: "2020-03"
 10483	free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	squat free-range mushroom	0		Last Available: "2020-03"
-10487	huge pulsating immense free-range mushroom	0		Last Available: "2020-03"
+10487	pulsating huge immense free-range mushroom	0		Last Available: "2020-03"
 10488	fuchsia colossal free-range mushroom	0		Last Available: "2020-03"
 10489	stale mushroom filet	4	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
@@ -10353,7 +10353,7 @@
 10496	twirling energetic wicked mushroom badge of Gandalf of the businessman	0		Spell Damage: +5, Maximum MP Percent: +20, Spell Critical Percent: +20, Meat Drop: +50, Single Equip, Last Available: "2020-03"
 10497	house-sized mushroom	0		Last Available: "2020-03"
 10498	pristine piranha seed	0		Last Available: "2020-03"
-10499	spinning blinking plastic piranha pot	0		Familiar Weight: +5
+10499	blinking spinning plastic piranha pot	0		Familiar Weight: +5
 10500	ionized liquefied denatured piranha pollen	0		Effect: "You Drank Fish Wine", Effect Duration: 65, Last Available: "2020-03"
 10501	plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
 10502	tumbling sinistral homunculus	0		Free Pull, Last Available: "2020-04"
@@ -10384,7 +10384,7 @@
 10528	upside-down drippy orb	0		
 10529	lustrous drippy orb	0		
 10530	Da Vinci's gory drippy orb	0		Experience (Mysticality): +5
-10531	shaking wobbly annealed drippy orb	0		
+10531	wobbly shaking annealed drippy orb	0		
 10532	huge Guzzlr application	0		Free Pull
 10533	skewed greasy grievous Guzzlr tablet	0		Weapon Damage Percent: +50, Sleaze Spell Damage: +10, Last Available: "2020-05"
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
@@ -10394,11 +10394,11 @@
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	frightening Guzzlr souvenir stein	0		Spooky Damage: +5, Last Available: "2020-05"
 10540	lime green Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	high-proof tolerable shaking Ghiaccio Colada	8	good	Last Available: "2020-05"
+10541	tolerable high-proof shaking Ghiaccio Colada	8	good	Last Available: "2020-05"
 10542	smooth Sourfinger	4	awesome	Last Available: "2020-05"
 10543	hand-crafted weak upside-down maroon Nog-on-the-Cob	2	EPIC	Last Available: "2020-05"
 10544	acceptable Steamboat	3	good	Last Available: "2020-05"
-10545	aged high-proof mirror blurry Buttery Boy	7	awesome	Last Available: "2020-05"
+10545	high-proof aged blurry mirror Buttery Boy	7	awesome	Last Available: "2020-05"
 10546	shaking Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	wobbly Socratic groovy clown car key	0		Moxie Percent: +10, Experience (Mysticality): +1, Last Available: "2020-08"
 10548	olive huge auspicious electrified boxer's batting cage key	0		Muscle Percent: +10, Item Drop: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-08"
@@ -10424,7 +10424,7 @@
 10568	spinning greedy Jim Carey's resourceful deep-fried key	0		Maximum MP: +50, Monster Level: +25, Meat Drop: +20, Last Available: "2020-08"
 10569	razor-sharp discarded bike lock key of the dark arts	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Last Available: "2020-08"
 10570	Thwaitgold keyhole spider statuette	0		
-10571	blue skewed Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
+10571	skewed blue Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	aerosolized alkaline marshroom	0		Effect: "Clyde's Blessing", Effect Duration: 29
 10573	mirror bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
@@ -10438,15 +10438,15 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	MacGyver's brawny birch battery	0		Muscle Percent: +20, Maximum MP: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	jittery pulsating padded ebony epee of doom of the sweet-tooth	0		Damage Absorption: +20, Spooky Spell Damage: +50, Candy Drop: +100, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	scandalous electrified razor-sharp weeping willow wand	0		Weapon Damage Percent: +25, Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	huge resourceful Socratic beechwood blowgun of courage	0		Experience (Mysticality): +1, Maximum MP: +50, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	jittery pulsating padded ebony epee of doom of the sweet-tooth	0		Damage Absorption: +20, Spooky Spell Damage: +50, Candy Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	scandalous electrified razor-sharp weeping willow wand	0		Weapon Damage Percent: +25, Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	huge resourceful Socratic beechwood blowgun of courage	0		Experience (Mysticality): +1, Maximum MP: +50, Spooky Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	prompt experienced maple magnet of the detective	0		Experience: +2, Item Drop: +20, Adventures: +3, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	blinking upside-down curative hemlock helm of temperance of the businessman	0		Sleaze Resistance: +5, Meat Drop: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2020-08"
 10591	sweaty balsam	0		Last Available: "2020-08"
 10592	red Temple Grandin's rock-hard grievous balsam barrel	0		Weapon Damage Percent: +50, Damage Reduction: 5, Familiar Weight: +7, Last Available: "2020-08"
-10593	skewed teal redwood	0		Last Available: "2020-08"
+10593	teal skewed redwood	0		Last Available: "2020-08"
 10594	super-deionized ionized mirror redwood rain stick	0		Effect: "Celestial Vision", Effect Duration: 33, Last Available: "2020-08"
 10595	purpleheart logs	0		Last Available: "2020-08"
 10596	censurious sizzling purpleheart &quot;pants&quot; of the bloodbag	0		Maximum HP: +100, Hot Damage: +10, Sleaze Resistance: +3, Last Available: "2020-08"
@@ -10464,17 +10464,17 @@
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	flavorless Yeg's Motel pillow mint	3	decent	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	quantum bouncing squat Yeg's Motel mouthwash	0		Effect: "Musky", Effect Duration: 19, Last Available: "2020-09"
+10611	quantum squat bouncing Yeg's Motel mouthwash	0		Effect: "Musky", Effect Duration: 19, Last Available: "2020-09"
 10612	narrow studded Yeg's Motel shower cap of horror	0		Damage Absorption: +80, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-09"
 10613	zippy scorching Yeg's Motel bathrobe	0		Hot Damage: +25, Initiative: +20, Lasts Until Rollover, Last Available: "2020-09"
 10614	flame-wreathed Yeg's Motel slippers of chilblains	0		Cold Damage: +25, Hot Spell Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
 10616	jittery Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
-10618	maroon huge frost-rimed desk bell	0		Last Available: "2020-09"
+10618	huge maroon frost-rimed desk bell	0		Last Available: "2020-09"
 10619	pulsating blue uncanny desk bell	0		Last Available: "2020-09"
 10620	purple nasty desk bell	0		Last Available: "2020-09"
-10621	wobbly huge greasy desk bell	0		Last Available: "2020-09"
+10621	huge wobbly greasy desk bell	0		Last Available: "2020-09"
 10622	chess set	0		Last Available: "2020-09"
 10623	onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	ghostly bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	shaking mansplainer's Sinatra's Herculean Rosewater's Cargo Cultist Shorts	0		Mysticality Percent: +30, Experience (Muscle): +1, Experience (Moxie): +5, Monster Level: +15, Last Available: "2020-09"
 10637	bouncing complicated device	0		Last Available: "2020-09"
-10638	special practically non-alcoholic lousy huge flask of moonshine	1	decent	Effect: "Trivia Master", Effect Duration: 35, Last Available: "2020-09"
+10638	practically non-alcoholic special lousy huge flask of moonshine	1	decent	Effect: "Trivia Master", Effect Duration: 35, Last Available: "2020-09"
 10639	maroon extremely unsafe sea-worn candlestick of dire peril of Calamity Jane	0		Weapon Damage: +20, Weapon Damage Percent: +100, Critical Hit Percent: +15, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	extra-tarnished null-day exploit	0		Effect: "Joy", Effect Duration: 45, Last Available: "2025-12"
@@ -10509,7 +10509,7 @@
 10653	polarized maroon fortifying hot cocoa	0		Effect: "Vinegavotte", Effect Duration: 25, Last Available: "2020-12"
 10654	alkaline teal tumbling boiling hot cocoa	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 44, Last Available: "2020-12"
 10655	extra-polarized irradiated spinning cool hot cocoa	0		Effect: "Disco Concentration", Effect Duration: 37, Last Available: "2020-12"
-10656	magnetized tumbling jittery overly-fancy hot cocoa	0		Effect: "Hot Blooded", Effect Duration: 56, Last Available: "2020-12"
+10656	magnetized jittery tumbling overly-fancy hot cocoa	0		Effect: "Hot Blooded", Effect Duration: 56, Last Available: "2020-12"
 10657	Vulcanized moist hot cocoa au beurre	0		Effect: "Jelly Combed", Effect Duration: 14, Last Available: "2020-12"
 10658	triple-polymerized red hot cocoa with rainbow marshmallows	0		Effect: "Cold, Dead Hands", Effect Duration: 59, Last Available: "2020-12"
 10659	MacGyver's Book of Old-Timey Carols	0		Maximum MP: [+100*event(December)], Last Available: "2020-12"
@@ -10569,13 +10569,13 @@
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	stale and pepper (stale)	3	decent	Last Available: "2020-12"
-10716	practically non-alcoholic artisanal cranberry margarita (brackish)	1	EPIC	Last Available: "2020-12"
+10716	artisanal practically non-alcoholic cranberry margarita (brackish)	1	EPIC	Last Available: "2020-12"
 10717	twirling fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	pulsating goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	watered-down fancy tolerable barrel-aged eggnog	2	good	Effect: "Human-Slime Hybrid", Effect Duration: 25, Last Available: "2020-12"
-10721	half-sized stale enchanted twirling hand-crafted candy cane	2	decent	Effect: "Hammertime", Effect Duration: 45, Last Available: "2020-12"
-10722	small fancy yummy wobbly drive-thru burger	2	awesome	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2020-12"
+10720	fancy tolerable watered-down barrel-aged eggnog	2	good	Effect: "Human-Slime Hybrid", Effect Duration: 25, Last Available: "2020-12"
+10721	enchanted stale half-sized twirling hand-crafted candy cane	2	decent	Effect: "Hammertime", Effect Duration: 45, Last Available: "2020-12"
+10722	fancy yummy small wobbly drive-thru burger	2	awesome	Effect: "Stench Jellied", Effect Duration: 50, Last Available: "2020-12"
 10723	acceptable Boulevardier cocktail	3	good	Last Available: "2020-12"
 10724	triple-denatured huge Hotwire&trade; brand candy rope	0		Effect: "[1609]Dancin' Fool", Effect Duration: 55, Last Available: "2020-12"
 10725	stale bowl full of jelly	4	decent	Last Available: "2020-12"
@@ -10585,24 +10585,24 @@
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	bouncing crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
-10732	ghostly red fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10732	red ghostly fresh coat of paint	0		Last Available: "2021-12"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	shaking Thwaitgold listening bug statuette	0		
 10737	shaking power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
 10739	activated galvanized skewed battery (AAA)	0		Effect: "Mushroom Might", Effect Duration: 27, Last Available: "2021-03"
 10740	magnetized frozen battery (AA)	0		Effect: "Amplified Fabulousness", Effect Duration: 17, Last Available: "2021-03"
-10741	frozen triple-altered upside-down twirling battery (D)	0		Effect: "Paging Betty", Effect Duration: 23, Last Available: "2021-03"
+10741	frozen triple-altered twirling upside-down battery (D)	0		Effect: "Paging Betty", Effect Duration: 23, Last Available: "2021-03"
 10742	dry super-modified battery (9-Volt)	0		Effect: "Human-Constellation Hybrid", Effect Duration: 59, Last Available: "2021-03"
 10743	tarnished quadruple-enhanced battery (lantern)	0		Effect: "Ginger Snapped", Effect Duration: 16, Last Available: "2021-03"
-10744	tarnished wobbly teal battery (car)	0		Effect: "Spring Training", Effect Duration: 32, Last Available: "2021-03"
+10744	tarnished teal wobbly battery (car)	0		Effect: "Spring Training", Effect Duration: 32, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	weak special perfectly mixed marshmallow bomb	2	EPIC	Effect: "Muddled", Effect Duration: 10, Last Available: "2021-03"
+10747	special weak perfectly mixed marshmallow bomb	2	EPIC	Effect: "Muddled", Effect Duration: 10, Last Available: "2021-03"
 10748	skewed packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	squat tumbling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	quantum improved wobbly short beer	0		Effect: "Dance Interpreter", Effect Duration: 27, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	wet squat short	0		Effect: "Go-Gone", Effect Duration: 52, Last Available: "2021-05"
 10757	wobbly Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	teal familiar scrapbook of courage of the glutton	0		Spooky Resistance: +3, Food Drop: +100, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	teal familiar scrapbook of courage of the glutton	0		Spooky Resistance: +3, Food Drop: +100, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	narrow packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	upside-down clan underground fireworks shop	0		Last Available: "2021-07"
 10762	ghostly executive fedora-mounted fountain of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Meat Drop: +40, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,11 +10650,11 @@
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	narrow ghostly packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	Van der Graaf MacGyver's fortified personal trainer's Sinatra's industrial fire extinguisher of Leguizamo	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Damage Absorption: +60, Maximum MP: +100, Monster Level: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	Van der Graaf MacGyver's fortified personal trainer's Sinatra's industrial fire extinguisher of Leguizamo	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Damage Absorption: +60, Maximum MP: +100, Monster Level: +20, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	mirror The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
-10801	gray ghostly bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
+10801	ghostly gray bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
 10802	French-Transylvanian Dictionary	0		Familiar Weight: +5
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	twirling tumbling experienced Daylight Shavings Helmet of mayonnaise of temperance	0		Experience: +2, Sleaze Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2021-11"
@@ -10672,15 +10672,15 @@
 10816	miser's perfumed ice crown of bravery	0		Spooky Resistance: +5, Stench Resistance: +5, Meat Drop: +10, Lasts Until Rollover, Last Available: "2021-12"
 10817	smelly Lo Pan's jeans of the storm	0		Maximum MP Percent: +40, Spell Critical Percent: +30, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-12"
 10818	therapeutic quilted weightlifter's ice wrap	0		Muscle: +15, Damage Absorption: +40, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	fancy normal small ghostly tofu pop	2	good	Effect: "From Nantucket", Effect Duration: 35, Last Available: "2021-12"
+10819	normal small fancy ghostly tofu pop	2	good	Effect: "From Nantucket", Effect Duration: 35, Last Available: "2021-12"
 10820	snack-sized rotten bowl of prescription candy	2	crappy	Last Available: "2021-12"
-10821	spoiled snack-sized fishcake	2	crappy	Last Available: "2021-12"
+10821	snack-sized spoiled fishcake	2	crappy	Last Available: "2021-12"
 10822	rotten tiny bone broth	1	crappy	Last Available: "2021-12"
 10823	spoiled blurry star pop	3	crappy	Last Available: "2021-12"
 10824	hand-crafted distilled Doc's Fortifying Wine	5	EPIC	Last Available: "2021-12"
-10825	watered-down lousy enchanted Doc's Smartifying Wine	2	decent	Effect: "Reedy Pipes", Effect Duration: 20, Last Available: "2021-12"
+10825	enchanted watered-down lousy Doc's Smartifying Wine	2	decent	Effect: "Reedy Pipes", Effect Duration: 20, Last Available: "2021-12"
 10826	artisanal Doc's Limbering Wine	4	EPIC	Last Available: "2021-12"
-10827	special distilled bad bouncing Doc's Medical-Grade Wine	5	decent	Effect: "Chow Downed", Effect Duration: 35, Last Available: "2021-12"
+10827	distilled bad special bouncing Doc's Medical-Grade Wine	5	decent	Effect: "Chow Downed", Effect Duration: 35, Last Available: "2021-12"
 10828	compressed twirling Homebodyl&trade;	1		Effect: "Very Clean Teeth", Effect Duration: 20, Last Available: "2021-12"
 10829	boiled squat olive Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	modified Breathitin&trade;	1		Last Available: "2021-12"
@@ -10703,7 +10703,7 @@
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
 10848	extra-sweet chocolate and pear nog	3	good	Effect: "Hoity Toity", Effect Duration: 33
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
-10850	huge purple goo magnet	0		Last Available: "2021-12"
+10850	purple huge goo magnet	0		Last Available: "2021-12"
 10851	spinning sizzling cozy scarf	0		Hot Damage: +10, Last Available: "2021-12"
 10852	toothsome jittery huge Crimbo cookie	3	awesome	Last Available: "2023-06"
 10853	galvanized dry squat fleshy putty	0		Effect: "Petit Force", Effect Duration: 29, Last Available: "2021-12"
@@ -10712,7 +10712,7 @@
 10856	poisonsettia	0		Last Available: "2021-12"
 10857	sinister peppermint-scented socks	0		Spell Damage: +10, Last Available: "2021-12"
 10858	blinking the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10859	fuchsia skewed bouncing projectile chemistry set	0		Last Available: "2021-12"
+10859	bouncing skewed fuchsia projectile chemistry set	0		Last Available: "2021-12"
 10860	green executive depleted Crimbonium football helmet	0		Meat Drop: +40, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
 10862	spoiled enchanted &quot;caramel&quot;	4	crappy	Effect: "Voracious Gorging", Effect Duration: 45, Last Available: "2021-12"
@@ -10736,10 +10736,10 @@
 10880	compressed twirling fried air	1		Last Available: "2021-12"
 10881	upside-down 11-leaf clover	0		
 10882	upside-down skewed carton of astral energy drinks	0		
-10883	boiled jittery ghostly astral energy drink	1		Effect: "The Spy Who Loved XP", Effect Duration: 10
+10883	boiled ghostly jittery astral energy drink	1		Effect: "The Spy Who Loved XP", Effect Duration: 10
 10884	huge narrow mint condition magnifying glass	0		Last Available: "2022-12"
 10885	gray lightning-fast brawny magnifying glass of James Dean	0		Muscle Percent: +20, Experience (Moxie): +3, Initiative: +40, Last Available: "2022-12"
-10886	high-proof mediocre void lager	8	decent	Last Available: "2022-12"
+10886	mediocre high-proof void lager	8	decent	Last Available: "2022-12"
 10887	toothsome void burger	4	awesome	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	mirror vibrating healthy rock-hard Da Vinci's void shard	0		Experience (Mysticality): +5, Damage Reduction: 5, Maximum HP Percent: +20, Maximum MP Percent: +10, Last Available: "2022-12"
@@ -10765,11 +10765,11 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	irradiated blinking single-use dust mask	0		Effect: "Puzzle Fury", Effect Duration: 13, Last Available: "2022-05"
 10911	magnetized gaffer's tape	0		Effect: "Broken Fast", Effect Duration: 37, Last Available: "2022-05"
-10912	flavorless low-calorie spinning 20-lb can of rice and beans	1	decent	Last Available: "2022-05"
+10912	low-calorie flavorless spinning 20-lb can of rice and beans	1	decent	Last Available: "2022-05"
 10913	blinking bar of freeze-dried water	1	decent	Last Available: "2022-05"
-10914	moldy immense expired MRE	6	crappy	Last Available: "2022-05"
+10914	immense moldy expired MRE	6	crappy	Last Available: "2022-05"
 10915	spoiled cool mint precipice bar	3	crappy	Last Available: "2022-05"
-10916	spoiled diet carrot cake precipice bar	1	crappy	Last Available: "2022-05"
+10916	diet spoiled carrot cake precipice bar	1	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	fuchsia Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10780,9 +10780,9 @@
 10924	small flavorless skewed guilty sprout	2	decent	Last Available: "2022-06"
 10925	mother's necklace of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Last Available: "2022-06"
 10926	irradiated double-modified trampled ticket stub	0		Effect: "Punch Another Day", Effect Duration: 11, Last Available: "2022-06"
-10927	aerosolized pickled teal pulsating savings bond	0		Effect: "protect.enq", Effect Duration: 34, Last Available: "2022-06"
+10927	aerosolized pickled pulsating teal savings bond	0		Effect: "protect.enq", Effect Duration: 34, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	modified sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10798,14 +10798,14 @@
 10942	dinosaur repellent	0		
 10943	knitted camouflage vest	0		Cold Resistance: +3
 10944	huge Dinodollar	0		
-10945	jittery twirling valuable dinosaur droppings	0		
+10945	twirling jittery valuable dinosaur droppings	0		
 10946	dinosaur pheromone kit	0		
 10947	wool clever Herculean awkward dinosaur research harness	0		Experience (Muscle): +1, Maximum MP: +20, Cold Resistance: +1
 10948	ghostly reflective vest of the early riser	0		Adventures: +7
 10949	dinosaur of the cougar	0		Moxie: +20
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	teal wobbly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	narrow dangerous stylish Jurassic Parka	0		Moxie: +25, Weapon Damage: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	narrow dangerous stylish Jurassic Parka	0		Moxie: +25, Weapon Damage: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	squat autumn-aton	0		Last Available: "2022-10"
 10955	anodized unsweetened twirling autumn leaf	0		Effect: "In the Limelight", Effect Duration: 17, Last Available: "2022-10"
@@ -10816,43 +10816,43 @@
 10960	colloidal autumn dollar	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 55, Last Available: "2022-10"
 10961	energetic savvy autumn leaf pendant of the detective	0		Mysticality Percent: +20, Maximum MP Percent: +20, Item Drop: +20, Lasts Until Rollover, Last Available: "2022-10"
 10962	diluted mirror autumn breeze	1		Last Available: "2022-10"
-10963	tarnished squat yellow autumn years wisdom	0		Effect: "So Fresh and So Clean", Effect Duration: 60, Last Available: "2022-10"
+10963	tarnished yellow squat autumn years wisdom	0		Effect: "So Fresh and So Clean", Effect Duration: 60, Last Available: "2022-10"
 10964	tumbling familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	perfectly mixed Oopsie IPA	4	EPIC	Last Available: "2022-10"
 10966	mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	jittery Yeast of Boris	0		Last Available: "2022-11"
 10968	spinning St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	flavorless jumbo shaking ratatouille de Jarlsberg	5	decent	Last Available: "2022-11"
+10970	jumbo flavorless shaking ratatouille de Jarlsberg	5	decent	Last Available: "2022-11"
 10971	tiny normal Jarlsberg's vegetable soup	1	good	Last Available: "2022-11"
 10972	moldy roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
 10973	miniature decent St. Pete's sneaky smoothie	2	good	Last Available: "2022-11"
 10974	special stale half-sized Pete's wiley whey bar	2	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 45, Last Available: "2022-11"
-10975	decent low-calorie bouncing Pete's rich ricotta	1	good	Last Available: "2022-11"
+10975	low-calorie decent bouncing Pete's rich ricotta	1	good	Last Available: "2022-11"
 10976	perfectly mixed watered-down Boris's beer	2	EPIC	Last Available: "2022-11"
 10977	normal honey bun of Boris	4	good	Last Available: "2022-11"
 10978	jumbo adequate huge Boris's bread	5	good	Last Available: "2022-11"
-10979	olive Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	ghostly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	olive Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	ghostly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	normal spinning baked veggie ricotta casserole	4	good	Last Available: "2022-11"
 10989	yummy plain calzone	3	awesome	Last Available: "2022-11"
 10990	miniature bland fancy roasted vegetable focaccia	2	decent	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 10, Last Available: "2022-11"
 10991	bland squat Pizza of Legend	3	decent	Last Available: "2022-11"
 10992	yummy diet Calzone of Legend	1	awesome	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	blurry Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	blurry Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	spinning Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	huge tasty Deep Dish of Legend	6	awesome	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	upside-down drink chit	0		
@@ -10868,17 +10868,17 @@
 11012	milk cap	0		
 11013	fancy strong mediocre Charleston Choo-Choo	5	decent	Effect: "Bananas!", Effect Duration: 20
 11014	aged mirror Velvet Veil	4	awesome	
-11015	mediocre watered-down Marltini	2	decent	
-11016	bad watered-down twirling Strong, Silent Type	2	decent	
-11017	spirit-forward mediocre special bouncing Mysterious Stranger	5	decent	Effect: "Bloody-minded", Effect Duration: 5
-11018	hand-crafted triple-distilled Champagne Shimmy	8	EPIC	
+11015	watered-down mediocre Marltini	2	decent	
+11016	watered-down bad twirling Strong, Silent Type	2	decent	
+11017	special mediocre spirit-forward bouncing Mysterious Stranger	5	decent	Effect: "Bloody-minded", Effect Duration: 5
+11018	triple-distilled hand-crafted Champagne Shimmy	8	EPIC	
 11019	red the Sot's parcel	0		
-11020	beefy ceramic cestus of horror	0		Muscle: +10, Spooky Spell Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	aromatic Socratic ceramic centurion shield of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Stench Resistance: +1, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	censurious reassuring ceramic celery grater	0		Spooky Resistance: +1, Sleaze Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	narrow huge inspector's Van der Graaf ceramic celsiturometer of the early riser	0		Item Drop: +15, Adventures: +7, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	friendly stiffened ceramic cerecloth belt of the brazier	0		Damage Reduction: 1, Familiar Weight: +3, Hot Spell Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	upside-down scorching toasty crafty ceramic cenobite's robe	0		Maximum MP: +10, Hot Damage: 30, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	beefy ceramic cestus of horror	0		Muscle: +10, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	aromatic Socratic ceramic centurion shield of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Stench Resistance: +1, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	censurious reassuring ceramic celery grater	0		Spooky Resistance: +1, Sleaze Resistance: +3, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	narrow huge inspector's Van der Graaf ceramic celsiturometer of the early riser	0		Item Drop: +15, Adventures: +7, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	friendly stiffened ceramic cerecloth belt of the brazier	0		Damage Reduction: 1, Familiar Weight: +3, Hot Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	upside-down scorching toasty crafty ceramic cenobite's robe	0		Maximum MP: +10, Hot Damage: 30, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	vaporized ceramic scree	1		Last Available: "2023-12"
 11027	improved colloidal extra-hard jawbreaker	0		Effect: "Adorable Lookout", Effect Duration: 29
 11028	upside-down steel-toed chiffon chevrons of the empath of temperance	0		Damage Reduction: 9, Familiar Weight: +5, Sleaze Resistance: +5, Single Equip, Last Available: "2023-12"
@@ -10923,7 +10923,7 @@
 11067	tolerable tumbling dregs of a Crimbo cocktail	3	good	
 11068	ghostly lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
-11070	special stale huge honey-drenched ham slice	6	decent	Effect: "PERL of Great Price", Effect Duration: 10
+11070	huge special stale honey-drenched ham slice	6	decent	Effect: "PERL of Great Price", Effect Duration: 10
 11071	artisanal mostly-empty bottle of cookie wine	3	EPIC	
 11072	rotten blurry Crimbo food scraps	3	crappy	
 11073	arm towel	0		Last Available: "2022-12"
@@ -10931,7 +10931,7 @@
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	flavorless miniature steamed oyster	2	decent	
+11078	miniature flavorless steamed oyster	2	decent	
 11079	blue really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	gray steam unit	0		Last Available: "2022-12"
@@ -10960,7 +10960,7 @@
 11104	ghostly shaking milestone	0		Last Available: "2023-01"
 11105	mirror twirling bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
-11107	narrow blurry whet stone	0		Last Available: "2023-01"
+11107	blurry narrow whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
@@ -10974,9 +10974,9 @@
 11119	irradiated dry mirror five-fingered fern resin	0		Effect: "Got Your Boots On", Effect Duration: 62, Last Available: "2023-02"
 11120	yummy super good fruit	3	awesome	Last Available: "2023-02"
 11121	dried shaking energized spores	1		Effect: "Ooh, Salty!", Effect Duration: 5, Last Available: "2023-02"
-11122	jittery vibrating rock-hard hot pepper	0		Damage Reduction: 5, Maximum MP Percent: +10, Lantern Element: "Hot", Last Available: "2023-02"
+11122	jittery vibrating rock-hard hot pepper	0		Damage Reduction: 5, Maximum MP Percent: +10, Last Available: "2023-02", Lantern Element: "Hot"
 11123	super-pickled quantum huge out-of-work circus flea	0		Effect: "Faboooo", Effect Duration: 40, Last Available: "2023-02"
-11124	huge blue extra-grubby grub	0		Last Available: "2023-02"
+11124	blue huge extra-grubby grub	0		Last Available: "2023-02"
 11125	extra-liquefied fire ant pheromones	0		Effect: "Voracious Gorging", Effect Duration: 56, Last Available: "2023-02"
 11126	activated alkaline flapper fly	0		Effect: "Mariachi Mood", Effect Duration: 59, Last Available: "2023-02"
 11127	drinkable shot of wasp venom	3	good	Last Available: "2023-02"
@@ -10987,16 +10987,16 @@
 11132	ghostly hollow rock	0		Last Available: "2023-02"
 11133	concentrated extra-dry angry agate	0		Effect: "damage.enh", Effect Duration: 30, Last Available: "2023-02"
 11134	aerosolized lump of loyal latite	0		Effect: "Stogied", Effect Duration: 68, Last Available: "2023-02"
-11135	thick spoiled shadow sausage	5	crappy	Last Available: "2023-03"
+11135	spoiled thick shadow sausage	5	crappy	Last Available: "2023-03"
 11136	ruddy shadow skin of horror	0		Maximum HP Percent: +40, Spooky Spell Damage: +25, Last Available: "2023-03"
 11137	energized shadow flame	0		Effect: "Tapped In", Effect Duration: 61, Last Available: "2023-03"
 11138	miniature adequate mirror shadow bread	2	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	delicious watered-down lime green shadow fluid	2	awesome	Last Available: "2023-03"
+11140	watered-down delicious lime green shadow fluid	2	awesome	Last Available: "2023-03"
 11141	spinning shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	perfectly mixed fancy spinning shadow venom	3	EPIC	Effect: "Mystically Oiled", Effect Duration: 40, Last Available: "2023-03"
+11144	fancy perfectly mixed spinning shadow venom	3	EPIC	Effect: "Mystically Oiled", Effect Duration: 40, Last Available: "2023-03"
 11145	dehydrated shadow nectar	1		Effect: "Sticks and Stones", Effect Duration: 50, Last Available: "2023-03"
 11146	Da Vinci's Socratic shadow stick of doom	0		Experience (Mysticality): 6, Spooky Spell Damage: +50, Last Available: "2023-03"
 11147	rosewater-soaked chilly bat paw	0		Cold Damage: +5, Stench Resistance: +3
@@ -11017,7 +11017,7 @@
 11162	electrified uncursed medallion	0		MP Regen Min: 3, MP Regen Max: 5
 11163	Advanced Pig Skinning	0		
 11164	The Cheese Wizard's Companion	0		
-11165	narrow teal Jazz Agent sheet music	0		
+11165	teal narrow Jazz Agent sheet music	0		
 11166	narrow Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
@@ -11027,18 +11027,18 @@
 11172	shadow snowflake	0		
 11173	shadow heart	0		
 11174	wobbly shadow bucket	0		
-11175	blurry squat shadow wave	0		
+11175	squat blurry shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	yellow shadow chef's hat of the empath of the overflowing toilet of the cheetah	0		Familiar Weight: +5, Stench Spell Damage: +50, Initiative: +60
 11178	zippy clever quilted shadow trousers	0		Damage Absorption: +40, Maximum MP: +20, Initiative: +20
 11179	fuchsia tumbling electrified Da Vinci's shadow hammer	0		Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5
 11180	chilly brawny cool shadow monocle	0		Moxie: +5, Muscle Percent: +20, Cold Damage: +5, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	flavorless half-sized shadow hot dog	2	decent	
+11182	half-sized flavorless shadow hot dog	2	decent	
 11183	enchanted acceptable high-proof shadow martini	9	good	Effect: "Chilblains of the Corn", Effect Duration: 35
 11184	mixed blurry shadow pill	1		Effect: "Icy Composition", Effect Duration: 35
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	red monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	pickled skewed shadow candy	0		Effect: "Shot in the Arse", Effect Duration: 23
 11189	upside-down replica Mr. Accessory	0		
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	huge replica Order of the Green Thumb Order Form	0		
 11222	purple shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	occult smooth Cincho de Mayo of the cougar of the glutton	0		Moxie: 35, Spell Damage Percent: +25, Food Drop: +100, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	occult smooth Cincho de Mayo of the cougar of the glutton	0		Moxie: 35, Spell Damage Percent: +25, Food Drop: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	mirror dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	tumbling shaking replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11091,7 +11091,7 @@
 11236	wobbly replica unpowered Robortender	0		
 11237	pulsating wobbly replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
-11239	blue blurry huge replica God Lobster Egg	0		
+11239	blurry blue huge replica God Lobster Egg	0		
 11240	tumbling shellacked padded brainy replica Fourth of May Cosplay Saber	0		Mysticality: +5, Damage Absorption: +20, Damage Reduction: 7, Conditional Skill (Equipped): "Use the Force"
 11241	pulsating knitted foul-smelling healthy forbidden weightlifter's replica Kramco Sausage-o-Matic&trade;	0		Muscle: +15, Spell Damage Percent: +50, Maximum HP Percent: +20, Stench Damage: +10, Cold Resistance: +3
 11242	sharpshooter's resourceful shellacked brawny thinker's replica hewn moon-rune spoon of Tarzan of dire peril of the bloodbag of the overflowing toilet of mayonnaise of the boozehound	0		Mysticality: +10, Muscle Percent: +20, Experience (Muscle): +3, Weapon Damage: +20, Damage Reduction: 7, Maximum HP: +100, Maximum MP: +50, Critical Hit Percent: +10, Stench Spell Damage: +50, Sleaze Spell Damage: +50, Booze Drop: +100, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
@@ -11112,13 +11112,13 @@
 11257	tumbling 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	spinning executive dog trainer's friendly steel-toed personal trainer's Herculean &quot;I survived Y2K&quot; T-Shirt	0		Experience (Muscle): +1, Experience Percent (Muscle): +10, Damage Reduction: 9, Familiar Weight: +3, Experience (familiar): +1, Meat Drop: +40, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	wobbly razor-sharp pro skateboard of horror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	wobbly razor-sharp pro skateboard of horror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	narrow Mr. Accessaturday	0		Last Available: "2023-06"
 11262	blurry Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	green mirror toasty Flash Liquidizer Ultra Dousing Accessory	0		Hot Damage: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	green mirror toasty Flash Liquidizer Ultra Dousing Accessory	0		Hot Damage: +5, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	flame-retardant foul-smelling grievous Amulet of Perpetual Darkness of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25, Stench Damage: +10, Hot Resistance: +1, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11157,10 +11157,10 @@
 11302	souvenir flag	0		
 11303	shaking name change form	0		
 11304	replica sleeping patriotic eagle	0		
-11305	olive pulsating blinking boxed august scepter	0		Free Pull
+11305	olive blinking pulsating boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	rotten massive watermelon	10	crappy	
-11308	teal tumbling watermelon seed	0		
+11308	tumbling teal watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
 11311	toothsome half-sized spinning waffle	2	awesome	
@@ -11168,17 +11168,17 @@
 11313	wobbly fortified dance instructor's cat o' nine teeth	0		Experience Percent (Moxie): +10, Damage Absorption: +60
 11314	smooth tooth cap of incineration	0		Moxie: +15, Hot Spell Damage: +50
 11315	skewed Samson's toothy trousers of the businessman	0		Experience (Muscle): +5, Meat Drop: +50
-11316	miniature bland pulsating banana split	2	decent	
+11316	bland miniature pulsating banana split	2	decent	
 11317	handful of toilet paper	0		
 11318	mirror mirror Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	lousy triple-distilled green bottle of Cabernet Sauvignon	9	decent	
+11320	triple-distilled lousy green bottle of Cabernet Sauvignon	9	decent	
 11321	cyan padded baywatch of the pedagogue of Tarzan	0		Experience: +3, Experience (Muscle): +3, Damage Absorption: +20, Lasts Until Rollover
-11322	green Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	green Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	huge consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11326	huge yellow Thwaitgold fairyfly statue	0		
+11326	yellow huge Thwaitgold fairyfly statue	0		
 11327	blue residual chitin paste	0		Skill: "Chitinous Soul"
 11328	dehydrated concentrated cooking	1		Effect: "Pride of the Vampire", Effect Duration: 20
 11329	mixed meat	1		
@@ -11206,7 +11206,7 @@
 11351	lit leaf lasso	0		
 11352	fuchsia tied-up leaflet	0		
 11353	wobbly tied-up monstera	0		
-11354	bouncing skewed tied-up leaviathan	0		
+11354	skewed bouncing tied-up leaviathan	0		
 11355	gray impromptu torch of dire peril of incineration	0		Weapon Damage: +20, Hot Spell Damage: +50, Lasts Until Rollover
 11356	fireproof veiny fig leaf	0		Maximum HP: +10, Hot Resistance: +3, Lasts Until Rollover
 11357	bouncing curative Da Vinci's smoldering drape	0		Experience (Mysticality): +5, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover
@@ -11221,7 +11221,7 @@
 11366	jittery Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	twirling fuchsia Crimbuccaneer breeches	0		Last Available: "2023-12"
-11369	olive shaking narrow automa-bot parts	0		
+11369	shaking narrow olive automa-bot parts	0		
 11370	green security automa-core	0		
 11371	clerical automa-core	0		
 11372	handful of Boltsmann bearings	0		
@@ -11230,9 +11230,9 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	thick rotten ghostly pickled bread	5	crappy	Last Available: "2023-12"
+11378	rotten thick ghostly pickled bread	5	crappy	Last Available: "2023-12"
 11379	decent narrow salted mutton	3	good	Last Available: "2023-12"
-11380	bland special half-sized corned beet	2	decent	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 25, Last Available: "2023-12"
+11380	bland half-sized special corned beet	2	decent	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 25, Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	wobbly crated wardrobe-o-matic	0		
-11395	immense adequate pulsating peppermint donut	6	good	
+11395	adequate immense pulsating peppermint donut	6	good	
 11396	skewed Elf Guard insignia (private) of temperance	0		Sleaze Resistance: +5, Last Available: "2023-12"
 11397	cool Crimbuccaneer fledges (mint)	0		Moxie: +5, Last Available: "2023-12"
 11398	skewed military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	narrow miser's chaotic crafty Elf Guard clipboard	0		Maximum MP: +10, Spell Critical Percent: +10, Meat Drop: +10, Last Available: "2023-12"
 11435	pegfinger of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2023-12"
-11436	watered-down lousy huge blue and claret	2	decent	Last Available: "2023-12"
+11436	lousy watered-down huge blue and claret	2	decent	Last Available: "2023-12"
 11437	spinning sage Elf Guard and beret	0		Mysticality Percent: [+10*event(December)], Last Available: "2023-12"
 11438	skewed lightning-fast foul-smelling brawny shipwright's hammer	0		Muscle Percent: +20, Stench Damage: +10, Initiative: +40, Last Available: "2023-12"
 11439	narrow experienced savvy gunwale of mayonnaise	0		Mysticality Percent: +20, Experience: +2, Sleaze Spell Damage: +50, Damage Reduction: 9, Last Available: "2023-12"
@@ -11307,7 +11307,7 @@
 11452	olive bouncing avaricious greasy coward's Jim Carey's beefcake's Elf dessert spoon of the detective	0		Muscle: +25, Monster Level: 5, Sleaze Spell Damage: +10, Item Drop: +20, Meat Drop: +30, Last Available: "2023-12"
 11453	forbidden sinister Elf Guard SCUBA tank	0		Spell Damage: +10, Spell Damage Percent: +50, Last Available: "2023-12"
 11454	teal spinning Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	stiffened savvy free boots	0		Mysticality Percent: +20, Damage Reduction: 1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	stiffened savvy free boots	0		Mysticality Percent: +20, Damage Reduction: 1, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	green baby rigging snake	0		Last Available: "2023-12"
 11457	wool therapeutic sinister Elvish underarmor	0		Spell Damage: +10, Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2023-12"
 11458	twirling blinking razor-sharp smooth Crimbuccaneer bombjacket	0		Moxie: +15, Weapon Damage Percent: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
@@ -11319,21 +11319,21 @@
 11464	spoiled small fruit-stuffed rumcake	2	crappy	Last Available: "2023-12"
 11465	acceptable twirling mulled wine	3	good	Last Available: "2023-12"
 11466	tolerable spinning Swedish coffee	3	good	Last Available: "2023-12"
-11467	tolerable practically non-alcoholic canteen of eggnog	1	good	Last Available: "2023-12"
+11467	practically non-alcoholic tolerable canteen of eggnog	1	good	Last Available: "2023-12"
 11468	drinkable hot wine	3	good	Last Available: "2023-12"
 11469	bad Jamaican coffee	4	decent	Last Available: "2023-12"
-11470	enchanted lousy flask of egggrog	4	decent	Effect: "Abyssal Tears", Effect Duration: 40, Last Available: "2023-12"
+11470	lousy enchanted flask of egggrog	4	decent	Effect: "Abyssal Tears", Effect Duration: 40, Last Available: "2023-12"
 11471	purple Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	red pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	practically non-alcoholic delicious yule grog	1	awesome	Last Available: "2023-12"
 11475	normal huge wet tack	3	good	Last Available: "2023-12"
 11476	decent bouncing whalecake	4	good	Last Available: "2023-12"
-11477	Usain Bolt's auspicious lard-coated gunwale whalegun	0		Sleaze Spell Damage: +25, Item Drop: +10, Initiative: +80, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	perfectly mixed weak and claret	2	super ultra mega EPIC	Last Available: "2023-12"
+11477	Usain Bolt's auspicious lard-coated gunwale whalegun	0		Sleaze Spell Damage: +25, Item Drop: +10, Initiative: +80, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	weak perfectly mixed and claret	2	super ultra mega EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	Usain Bolt's Elf Guard squirtgun of chilblains	0		Cold Damage: +25, Initiative: +80, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	Usain Bolt's Elf Guard squirtgun of chilblains	0		Cold Damage: +25, Initiative: +80, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	upside-down chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	upside-down skewed educational sequin-encrusted sweater	0		Experience: +1, Last Available: "2023-12"
 11484	toasty stiffened replica Elf Guard medal	0		Damage Reduction: 1, Hot Damage: +5, Item Drop: +5, Last Available: "2023-12"
@@ -11344,7 +11344,7 @@
 11489	wobbly My First Paycheck envelope	0		Last Available: "2023-12"
 11490	huge squat rosewater-soaked mansplainer's wicked barnacle-encrusted sweater	0		Spell Damage: +5, Monster Level: +15, Stench Resistance: +3, Last Available: "2023-12"
 11491	coward's forbidden Crimbuccaneer nose ring of wisdom	0		Mysticality: +15, Spell Damage Percent: +50, Monster Level: -20, Last Available: "2023-12"
-11492	blurry mirror pet anchor	0		Last Available: "2023-12"
+11492	mirror blurry pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	gray Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
@@ -11353,14 +11353,14 @@
 11498	Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	shaking The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
-11501	ghostly tumbling pulsating Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
+11501	ghostly pulsating tumbling Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	pickled anodized maroon tumbling military candy cane	0		Effect: "Twen Tea", Effect Duration: 20
 11503	pressed jittery groggipop	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 38
-11504	blue quilted moss mace of the detective	0		Damage Absorption: +40, Item Drop: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	personal trainer's moss megaphone of Leguizamo	0		Experience Percent (Muscle): +10, Monster Level: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	wool stanky moss medal	0		Stench Spell Damage: +25, Cold Resistance: +1, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	asbestos-lined smelly moss mitre	0		Stench Spell Damage: +10, Hot Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	scorching electrified moss mantle	0		Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	blue quilted moss mace of the detective	0		Damage Absorption: +40, Item Drop: +20, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	personal trainer's moss megaphone of Leguizamo	0		Experience Percent (Muscle): +10, Monster Level: +20, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	wool stanky moss medal	0		Stench Spell Damage: +25, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	asbestos-lined smelly moss mitre	0		Stench Spell Damage: +10, Hot Resistance: +5, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	scorching electrified moss mantle	0		Hot Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	lightning-fast gravedigger's moss marlinspike	0		Spooky Damage: +10, Initiative: +40, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	dried upside-down moss mulch	1		Last Available: "2024-12"
 11511	alkaline squat moss floss	0		Effect: "Pumped Up", Effect Duration: 30
@@ -11372,33 +11372,33 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	dried adobe assortment	1		Effect: "Human-Penguin Hybrid", Effect Duration: 35, Last Available: "2024-12"
 11519	dry colloidal purple adobe brittle	0		Effect: "Optimist Primal", Effect Duration: 65
-11520	avaricious crepe paper phrygian cap of horror	0		Spooky Spell Damage: +25, Item Drop: +5, Meat Drop: +30, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	avaricious crepe paper phrygian cap of horror	0		Spooky Spell Damage: +25, Item Drop: +5, Meat Drop: +30, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	aromatic energetic rosy-cheeked crepe paper parachute cape	0		Maximum HP Percent: +30, Maximum MP Percent: +20, Stench Resistance: +1, Last Available: "2025-12"
-11522	auspicious Tesla crepe paper pie clip of the empath	0		Familiar Weight: +5, Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	Temple Grandin's smartaleck's crepe paper puzzle cube of the bloodbag	0		Moxie Percent: +30, Maximum HP: +100, Familiar Weight: +7, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	brawny crepe paper plunge camisole of the storm of the cheetah	0		Muscle Percent: +20, Maximum MP Percent: +40, Initiative: +60, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	hardy Da Vinci's crepe paper polka charm of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Maximum HP: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	auspicious Tesla crepe paper pie clip of the empath	0		Familiar Weight: +5, Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	Temple Grandin's smartaleck's crepe paper puzzle cube of the bloodbag	0		Moxie Percent: +30, Maximum HP: +100, Familiar Weight: +7, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	brawny crepe paper plunge camisole of the storm of the cheetah	0		Muscle Percent: +20, Maximum MP Percent: +40, Initiative: +60, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	hardy Da Vinci's crepe paper polka charm of the brute	0		Muscle Percent: +30, Experience (Mysticality): +5, Maximum HP: +50, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	vaporized blinking crepe paper pared cuttings	1		Effect: "Elvish", Effect Duration: 35, Last Available: "2025-12"
 11527	deionized crepe paper peanut candy	0		Effect: "Shawarma Warm War", Effect Duration: 15
 11528	rock-hard weightlifter's petrified wood war pike	0		Muscle: +15, Damage Reduction: 5, Last Available: "2025-12"
 11529	strapping petrified wood waist protector of the ox	0		Muscle: 25, Single Equip, Last Available: "2025-12"
-11530	huge sinister Sinatra's petrified wood wizard's pouch	0		Experience (Moxie): +5, Spell Damage: +10, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	wicked petrified wood water purifier of terror	0		Spell Damage: +5, Spooky Spell Damage: +10, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	huge sinister Sinatra's petrified wood wizard's pouch	0		Experience (Moxie): +5, Spell Damage: +10, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	wicked petrified wood water purifier of terror	0		Spell Damage: +5, Spooky Spell Damage: +10, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	avaricious petrified wood whoopie panama of chilblains	0		Cold Damage: +25, Meat Drop: +30, Last Available: "2025-12"
 11533	twirling rosewater-soaked rosy-cheeked petrified wood walking pants	0		Maximum HP Percent: +30, Stench Resistance: +3, Last Available: "2025-12"
-11534	compressed yellow huge petrified wood waste parts	1		Last Available: "2025-12"
+11534	compressed huge yellow petrified wood waste parts	1		Last Available: "2025-12"
 11535	corrupted super-cold-filtered petrified wood wafer praline	0		Effect: "One For Tea", Effect Duration: 38
-11536	lousy watered-down cybeer	2	decent	Last Available: "2025-12"
+11536	watered-down lousy cybeer	2	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	blinking wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	blinking wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	huge baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	lime green zippy banded Crimbuccaneer war standard	0		Damage Absorption: +100, Initiative: +20, Last Available: "2023-12"
 11544	upside-down ghostly stanky Elf Guard war standard of temperance	0		Stench Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	Usain Bolt's supercharged occult spring shoes	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Initiative: +80, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	Usain Bolt's supercharged occult spring shoes	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Initiative: +80, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	ionized ultra-soft ferns	0		Effect: "Retrograde Relaxation", Effect Duration: 40, Last Available: "2024-02"
 11548	extra-concentrated crunchy brush	0		Effect: "Mmmmmelon", Effect Duration: 44, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11422,13 +11422,13 @@
 11567	reassuring frightening Herculean Rosewater's Apriling band quad tom	0		Mysticality Percent: +30, Experience (Muscle): +1, Spooky Damage: +5, Spooky Resistance: +1, Lasts Until Rollover
 11568	upside-down fuchsia chaotic electrified padded Da Vinci's Apriling band tuba of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5, Damage Absorption: +20, Spell Critical Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover
 11569	shaking Sherlock's stanky Jack Frost's Tesla stiffened Fonzie's Apriling band staff	0		Experience (Moxie): +1, Damage Reduction: 1, Cold Spell Damage: +50, Stench Spell Damage: +25, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover
-11570	narrow tumbling yellow Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
+11570	yellow narrow tumbling Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	bland yam	4	decent	Last Available: "2024-05"
 11574	lousy yam martini	3	decent	Last Available: "2024-05"
 11575	artisanal sweet potato o' mine	3	EPIC	Last Available: "2024-05"
-11576	fancy delicious Southern yam	4	awesome	Effect: "Berry Thorny", Effect Duration: 15, Last Available: "2024-05"
+11576	delicious fancy Southern yam	4	awesome	Effect: "Berry Thorny", Effect Duration: 15, Last Available: "2024-05"
 11577	drinkable spinning sweet potato punch	3	good	Last Available: "2024-05"
 11578	half-sized bland Mayam spinach	2	decent	Last Available: "2024-05"
 11579	yummy yam and swiss	4	awesome	Last Available: "2024-05"
@@ -11453,15 +11453,15 @@
 11598	ghostly mini kiwi aioli	0		
 11599	lard-coated scorching stylish mini kiwi silicon tiepin	0		Moxie: +25, Hot Damage: +25, Sleaze Spell Damage: +25
 11600	mini kiwi tipi	0		
-11601	special moldy half-sized twirling mini kiwi digitized cookies	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 15
-11602	fancy watered-down bad mini kiwi intoxicating spirits	2	decent	Effect: "Uncanny Shot", Effect Duration: 35
+11601	half-sized special moldy twirling mini kiwi digitized cookies	2	crappy	Effect: "Turkey-Friendly", Effect Duration: 15
+11602	watered-down fancy bad mini kiwi intoxicating spirits	2	decent	Effect: "Uncanny Shot", Effect Duration: 35
 11603	non-altered deionized corrupted green mini kiwi antimilitaristic hippy petition	0		Effect: "Saucegoggles", Effect Duration: 23
 11604	galvanized diffused blurry mini kiwi illicit antibiotic	0		Effect: "Arresistible", Effect Duration: 33
 11605	squat Sherlock's Fonzie's mini kiwi whipping stick	0		Experience (Moxie): +1, Item Drop: +25
 11606	stiffened mini kiwi icepick	0		Damage Reduction: 1
 11607	double-altered cold-filtered mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Discomfited", Effect Duration: 48
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	mirror protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	blinking protogenetic chunklet (flagellum)	0		
@@ -11470,11 +11470,11 @@
 11615	toasty beefy messenger bag RNA of chilblains	0		Muscle: +10, Cold Damage: +25, Hot Damage: +5
 11616	huge flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	miniature flavorless mirror bacteria bisque	2	decent	
+11618	flavorless miniature mirror bacteria bisque	2	decent	
 11619	moldy ciliophora chowder	4	crappy	
 11620	normal bouncing cream of chloroplasts	4	good	
 11621	synaptic soup	0		
-11622	blinking huge muscular soup	0		
+11622	huge blinking muscular soup	0		
 11623	red flagellate soup	0		
 11624	elbow soup	0		
 11625	lip soup	0		
@@ -11487,7 +11487,7 @@
 11632	yellow Doll Moll violin case	0		
 11633	blurry Tina gun	0		Familiar Weight: +5
 11634	cyan tattoo gun	0		
-11635	smooth weak Colera Peste Nebbiolo	2	awesome	
+11635	weak smooth Colera Peste Nebbiolo	2	awesome	
 11636	longbox of Batfellow comics	0		
 11637	blurry Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11510,7 +11510,7 @@
 11655	ghostly soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	zippy toasty wicked bat wings	0		Spell Damage: +5, Hot Damage: +5, Initiative: +20, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	zippy toasty wicked bat wings	0		Spell Damage: +5, Hot Damage: +5, Initiative: +20, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	cyan ember egg	0		Last Available: "2024-09"
 11660	gray ember	0		Cold Resistance: +1
 11661	inspector's veiny monocle on a stick	0		Maximum HP: +10, Item Drop: +15, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,10 +11523,10 @@
 11668	Sheriff badge of doom of the cheetah	0		Spooky Spell Damage: +50, Initiative: +60, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	Oprah's Sheriff pistol of the detective	0		Maximum MP Percent: +50, Item Drop: +20, Lasts Until Rollover, Last Available: "2024-10"
 11670	nippy Sinatra's Sheriff moustache	0		Experience (Moxie): +5, Cold Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	blinking strapping photo booth supply list of courage	0		Muscle: +5, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	blinking strapping photo booth supply list of courage	0		Muscle: +5, Spooky Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	shaking tie-dye headband	0		
-11674	enchanted rotten thick whirled peas	5	crappy	Effect: "Turkey-Friendly", Effect Duration: 10, Last Available: "2024-11"
+11674	thick rotten enchanted whirled peas	5	crappy	Effect: "Turkey-Friendly", Effect Duration: 10, Last Available: "2024-11"
 11675	flavorless snack-sized peaza	2	decent	Last Available: "2024-11"
 11676	squat peace shooter	0		Last Available: "2024-11"
 11677	boiled upside-down drenchrome 2.0	1		Effect: "Pemmican't", Effect Duration: 50, Last Available: "2025-12"
@@ -11539,13 +11539,13 @@
 11684	adequate piece of cake	4	good	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
-11687	red bouncing TakerSpace letter of Marque	0		Last Available: "2024-12"
+11687	bouncing red TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	smelly deft pirate hook of wisdom	0		Mysticality: +15, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
-11689	yellow electrified iron tricorn hat of the cougar	0		Moxie: +20, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	yellow electrified iron tricorn hat of the cougar	0		Moxie: +20, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	supercool jolly roger flag	0		Moxie Percent: +20, Lasts Until Rollover, Last Available: "2024-12"
 11691	tumbling sleeping profane parrot	0		Last Available: "2024-12"
 11692	ghostly pirrrate's currrse	0		Last Available: "2024-12"
-11693	mediocre triple-distilled tankard of spiced rum	8	decent	Last Available: "2024-12"
+11693	triple-distilled mediocre tankard of spiced rum	8	decent	Last Available: "2024-12"
 11694	mediocre squat tankard of spiced Goldschlepper	4	decent	Last Available: "2024-12"
 11695	skewed packaged luxury garment	0		Last Available: "2024-12"
 11696	deadly governor's daughter's lace collar	0		Weapon Damage: +5, Last Available: "2024-12"
@@ -11558,12 +11558,12 @@
 11703	green pet rock	0		Last Available: "2024-12"
 11704	aromatic groggles	0		Stench Resistance: +1, Last Available: "2024-12"
 11705	maroon pirate dinghy	0		Last Available: "2024-12"
-11706	ghostly jittery anchor bomb	0		Last Available: "2024-12"
+11706	jittery ghostly anchor bomb	0		Last Available: "2024-12"
 11707	reassuring therapeutic silky pirate drawers	0		Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	ionized denatured peppermint pegleg	0		Effect: "Elemental Flavor", Effect Duration: 14, Last Available: "2024-12"
 11710	irresponsibly strong perfectly mixed hard cocoa	8	EPIC	Last Available: "2024-12"
-11711	moldy miniature salmagumdi	2	crappy	Last Available: "2024-12"
+11711	miniature moldy salmagumdi	2	crappy	Last Available: "2024-12"
 11712	twirling beefcake's plastic Easter Island Bunny	0		Muscle: +25, Last Available: "2024-12"
 11713	supercool plastic St. Patrick	0		Moxie Percent: +20, Last Available: "2024-12"
 11714	energetic Newton's plastic Colonel Brando	0		Experience (Mysticality): +3, Maximum MP Percent: +20, Last Available: "2024-12"
@@ -11576,14 +11576,14 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	stale coney haunch	3	decent	Last Available: "2024-12"
 11723	double-modified dark chocolate egg	0		Effect: "Frigid Weapon", Effect Duration: 24, Last Available: "2024-12"
-11724	irresponsibly strong drinkable moai toai	6	good	
+11724	drinkable irresponsibly strong moai toai	6	good	
 11725	olive greedy careful dance instructor's moaiball	0		Experience Percent (Moxie): +10, Monster Level: -10, Meat Drop: +20, Last Available: "2024-12"
 11726	teal half-digested rat	0		Last Available: "2024-12"
 11727	polymerized four-leaf potato sprout	0		Effect: "Super-Mega-Charged", Effect Duration: 45, Last Available: "2024-12"
 11728	ribald Jim Carey's potato jacket of terror	0		Monster Level: +25, Spooky Spell Damage: +10, Sleaze Damage: +10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	quilted Sinatra's military orb	0		Experience (Moxie): +5, Damage Absorption: +40, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	quilted Sinatra's military orb	0		Experience (Moxie): +5, Damage Absorption: +40, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	magnetized dry shaking ghostly rum ball	0		Effect: "Super Speed", Effect Duration: 64
 11733	huge gravy skin	0		Last Available: "2024-12"
 11734	auspicious gravyskin hat of dire peril	0		Weapon Damage: +20, Item Drop: +10, Last Available: "2024-12"
@@ -11591,40 +11591,40 @@
 11736	twirling fortified gravyskin skirt of Leguizamo	0		Damage Absorption: +60, Monster Level: +20, Last Available: "2024-12"
 11737	shaking knitted gravyskin pants of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +3, Last Available: "2024-12"
 11738	corrupted crystallized pumpkin spice	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 59, Last Available: "2024-12"
-11739	moldy small room scale bean casserole	2	crappy	Last Available: "2024-12"
+11739	small moldy room scale bean casserole	2	crappy	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	quilted grievous savvy perfect Christmas scarf	0		Mysticality Percent: [+20*event(December)], Weapon Damage Percent: [+50*event(December)], Damage Absorption: [+40*event(December)], Single Equip, Last Available: "2024-12"
-11743	perfumed educational snowman-enchanting tophat	0		Experience: +1, Stench Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	perfumed educational snowman-enchanting tophat	0		Experience: +1, Stench Resistance: +5, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	altered tarnished colloidal LIDAR candle	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 39, Last Available: "2024-12"
 11745	Socratic strapping Congressional Medal of Insanity of the pedagogue	0		Muscle: +5, Experience: +3, Experience (Mysticality): +1, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	perfectly mixed Easter grasshopper	3	EPIC	Last Available: "2024-12"
 11748	artisanal weak Irish eggnog	2	EPIC	Last Available: "2024-12"
 11749	irresponsibly strong tolerable blue canteen of jungle juice	10	good	Last Available: "2024-12"
-11750	perfectly mixed olive blinking turchucken	4	EPIC	Last Available: "2024-12"
+11750	perfectly mixed blinking olive turchucken	4	EPIC	Last Available: "2024-12"
 11751	mediocre irresponsibly strong mechanically-mulled cider	6	decent	Last Available: "2024-12"
 11752	irresponsibly strong perfectly mixed holiday trip around the world	10	EPIC	Last Available: "2024-12"
-11753	adequate miniature gray chocolate ostrich egg	2	good	Last Available: "2024-12"
-11754	low-calorie delicious tumbling beef and cabbage	1	awesome	Last Available: "2024-12"
+11753	miniature adequate gray chocolate ostrich egg	2	good	Last Available: "2024-12"
+11754	delicious low-calorie tumbling beef and cabbage	1	awesome	Last Available: "2024-12"
 11755	snack-sized toothsome candy rations	2	awesome	Last Available: "2024-12"
 11756	stale double-candied yams	4	decent	Last Available: "2024-12"
-11757	normal diet lime green Christmas ham	1	good	Last Available: "2024-12"
-11758	flavorless tiny skewed holiday smorgasbord	1	decent	Last Available: "2024-12"
+11757	diet normal lime green Christmas ham	1	good	Last Available: "2024-12"
+11758	tiny flavorless skewed holiday smorgasbord	1	decent	Last Available: "2024-12"
 11759	skewed Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	pulsating prompt bejazzled eyepatch	0		Adventures: +3, Last Available: "2024-12"
-11761	blurry Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	jittery How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	jittery How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	ghostly Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	purple mirror Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	blurry Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	jittery How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	jittery How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	ghostly Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	mirror purple Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	gray moai statuette	0		Last Available: "2024-12"
-11772	Sherlock's aromatic experienced egg gun of the cheetah	0		Experience: +2, Stench Resistance: +1, Item Drop: +25, Initiative: +60, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	Sherlock's aromatic experienced egg gun of the cheetah	0		Experience: +2, Stench Resistance: +1, Item Drop: +25, Initiative: +60, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	blurry zippy chaotic arcane researcher's sage army helmet	0		Mysticality Percent: +10, Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Initiative: +20, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	flattened tarnished pulsating blurry deviled candy egg	0		Effect: "Mighty Shout", Effect Duration: 17, Last Available: "2024-12"
 11782	skewed McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	cyan coward's cool McHugeLarge duffel bag	0		Moxie: +5, Monster Level: -20, Last Available: "2025-01"
-11784	Sherlock's hale McHugeLarge left pole of the scaredy-cat	0		Maximum HP: +20, Monster Level: -15, Item Drop: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	Jack Frost's Socratic sage McHugeLarge right pole	0		Mysticality Percent: +10, Experience (Mysticality): +1, Cold Spell Damage: +50, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	banded extremely unsafe McHugeLarge left ski	0		Weapon Damage Percent: +100, Damage Absorption: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	asbestos-lined McHugeLarge right ski of temperance	0		Hot Resistance: +5, Sleaze Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	Sherlock's hale McHugeLarge left pole of the scaredy-cat	0		Maximum HP: +20, Monster Level: -15, Item Drop: +25, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	Jack Frost's Socratic sage McHugeLarge right pole	0		Mysticality Percent: +10, Experience (Mysticality): +1, Cold Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	banded extremely unsafe McHugeLarge left ski	0		Weapon Damage Percent: +100, Damage Absorption: +100, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	asbestos-lined McHugeLarge right ski of temperance	0		Hot Resistance: +5, Sleaze Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	blurry 0	0		Last Available: "2025-12"
-11790	distilled upside-down wobbly yellow eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11790	distilled yellow wobbly upside-down eXpand	1		Last Available: "2025-12"
+11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	jittery datastick	0		Last Available: "2025-12"
 11793	yellow dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	huge CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	fuchsia 3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	squat parity bit	0		Familiar Weight: +5
 11826	shaking hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11699,7 +11699,7 @@
 11844	chill gherkin	0		
 11845	childrens' stapler	0		
 11846	spinning shaking plover's egg	0		
-11847	maroon bouncing blinking flyswatter	0		
+11847	maroon blinking bouncing flyswatter	0		
 11848	maroon Thwaitgold cordyceps ant statuette	0		
 11849	purple heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	huge sore	0		Cold Damage: +10, Cold Spell Damage: +10
@@ -11724,17 +11724,17 @@
 11869	red unironic knife	0		
 11870	tumbling teal bar dart	0		Last Available: "2025-03"
 11871	modified leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	yummy lime green bouncing Heck ramen	3	awesome	Last Available: "2025-03"
+11872	yummy bouncing lime green Heck ramen	3	awesome	Last Available: "2025-03"
 11873	decent lime green burrito	4	good	Last Available: "2025-03"
-11874	special toothsome small beer brat	4	awesome	Effect: "Seeing Colors", Effect Duration: 15, Last Available: "2025-03"
+11874	toothsome special small beer brat	4	awesome	Effect: "Seeing Colors", Effect Duration: 15, Last Available: "2025-03"
 11875	adequate peach pie	4	good	Last Available: "2025-03"
 11876	stale special incredible mini-pizza	4	decent	Effect: "Old School Pompadour", Effect Duration: 30, Last Available: "2025-03"
 11877	artisanal Divine sidecar	3	EPIC	Last Available: "2025-03"
 11878	tolerable wobbly tangarita sidecar	3	good	Last Available: "2025-03"
-11879	weak drinkable gimlet sidecar	2	good	Last Available: "2025-03"
+11879	drinkable weak gimlet sidecar	2	good	Last Available: "2025-03"
 11880	aged vodka stratocaster sidecar	4	awesome	Last Available: "2025-03"
 11881	hand-crafted prussian cathouse sidecar	3	EPIC	Last Available: "2025-03"
-11882	irresponsibly strong acceptable Mon Tiki sidecar	6	good	Last Available: "2025-03"
+11882	acceptable irresponsibly strong Mon Tiki sidecar	6	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	foul-smelling coward's April Shower Thoughts shield	0		Monster Level: -20, Stench Damage: +10, Damage Reduction: 6, Last Available: "2025-04"
 11885	wobbly glob of wet paper	0		Last Available: "2025-04"
@@ -11753,7 +11753,7 @@
 11898	dry liquefied wet paper cup	0		Effect: "Low on the Hog", Effect Duration: 58, Last Available: "2025-04"
 11899	altered wet paperback	0		Effect: "Bilious Brains", Effect Duration: 56, Last Available: "2025-04"
 11900	red wet shower radio	0		Item Drop: +5, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
-11901	cyan skewed wet shower stamp	0		Last Available: "2025-04"
+11901	skewed cyan wet shower stamp	0		Last Available: "2025-04"
 11902	savvy birthday bloon	0		Mysticality Percent: +20
 11903	enhanced cold-filtered unsweetened skewed green jawwetter	0		Effect: "Sweetened and Fattened", Effect Duration: 56
 11904	Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
@@ -11771,7 +11771,7 @@
 11916	vibrating stylish bycocket	0		Maximum MP Percent: +10
 11917	bouncing teal Thwaitgold mad hatterpillar statuette	0		
 11918	huge packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	jittery Axis HQ Code	0		
 11922	spinning yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	green confetti grenade	0		
-11937	enchanted toothsome massive jittery olive Skeleton Wars rations	9	awesome	Effect: "Adorable Lookout", Effect Duration: 10
+11937	toothsome enchanted massive jittery olive Skeleton Wars rations	9	awesome	Effect: "Adorable Lookout", Effect Duration: 10
 11938	bad skeleton war fuel can	4	decent	
 11939	blurry skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
@@ -11798,14 +11798,14 @@
 11943	bone pacifier	0		Familiar Weight: +5
 11944	squat blinking flame-retardant Annie Oakley's stylish Allied Forces insignia	0		Moxie: +25, Critical Hit Percent: +20, Hot Resistance: +1, Single Equip
 11945	Allied Tattoo Kit	0		
-11946	red mirror handheld Allied radio	0		
+11946	mirror red handheld Allied radio	0		
 11947	Axis codebook	0		
-11948	dry spinning lime green Life Goals Pamphlet	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 44, Last Available: "2025-08"
+11948	dry lime green spinning Life Goals Pamphlet	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 44, Last Available: "2025-08"
 11949	twirling greedy bully badge	0		Meat Drop: +20, Lasts Until Rollover, Last Available: "2025-08"
 11950	time cop top hat of courage	0		Spooky Resistance: +3, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	distilled twirling mixed berry jelly	1		Effect: "Tasting the Rainbow", Effect Duration: 20, Last Available: "2025-08"
-11953	normal gigantic special huge toast with mixed berry jelly	8	good	Effect: "Ermine Eyes", Effect Duration: 35, Last Available: "2025-08"
+11953	gigantic normal special huge toast with mixed berry jelly	8	good	Effect: "Ermine Eyes", Effect Duration: 35, Last Available: "2025-08"
 11954	decent cup of sugar	3	good	Last Available: "2025-08"
 11955	rotten gigantic upside-down yellow Susie's cupcake	9	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
@@ -11814,7 +11814,7 @@
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	flame-retardant undersea surveying goggles	0		Hot Resistance: +1, Lasts Until Rollover
-11963	mediocre practically non-alcoholic Ocean-Touched Rum	1	decent	
+11963	practically non-alcoholic mediocre Ocean-Touched Rum	1	decent	
 11964	altered gray water-logged pill	1		
 11965	moldy kelp puck	4	crappy	
 11966	red scroll of sea strength	0		
@@ -11826,21 +11826,21 @@
 11972	teal durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	teal unblemished pearl	0		
 11977	blinking padded dentadent	0		Damage Absorption: +20
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	chilly slick blood cubic zirconia of James Dean of Calamity Jane of the brazier	0		Moxie: +10, Experience (Moxie): +3, Critical Hit Percent: +15, Cold Damage: +5, Hot Spell Damage: +25, Item Drop: +5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	chilly slick blood cubic zirconia of James Dean of Calamity Jane of the brazier	0		Moxie: +10, Experience (Moxie): +3, Critical Hit Percent: +15, Cold Damage: +5, Hot Spell Damage: +25, Item Drop: +5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	distilled olive blood thinner	1		Last Available: "2025-10"
 12045	perfectly mixed watered-down squat pheromone cocktail	2	EPIC	Last Available: "2025-10"
 12046	delicious spinal tapas	4	awesome	Last Available: "2025-10"
 12047	squat shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	greasy shrunken head of James Dean of Flo-Jo	0		Experience (Moxie): +3, Sleaze Spell Damage: +10, Initiative: +100, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	greasy shrunken head of James Dean of Flo-Jo	0		Experience (Moxie): +3, Sleaze Spell Damage: +10, Initiative: +100, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	lousy Smoking Pope	3	decent	
-12053	flavorless miniature prize turkey	2	decent	
+12053	miniature flavorless prize turkey	2	decent	
 12054	dried medicinal gruel	1		Effect: "Dreadful Sheen", Effect Duration: 30
 12055	moldy full-sized pumpkin pie	4	crappy	Last Available: "2025-11"
 12056	lousy wobbly vodka cranberry sauce	3	decent	Last Available: "2025-11"
@@ -11870,7 +11870,7 @@
 12080	fortified devilbone flute of horror	0		Damage Absorption: +60, Spooky Spell Damage: +25, Last Available: "2026-12"
 12081	personal trainer's devilbone rosary	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2026-12"
 12082	mixed devilbone chunks	1		Effect: "Carol of the Bones", Effect Duration: 35, Last Available: "2026-12"
-12083	non-ionized jittery twirling Gehenna tattoo	0		Effect: "Danish Cunning", Effect Duration: 35
+12083	non-ionized twirling jittery Gehenna tattoo	0		Effect: "Danish Cunning", Effect Duration: 35
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
 12118	burnt radius	0		Last Available: "2025-12"
@@ -11879,7 +11879,7 @@
 12121	blue Crymbocurrency	0		Last Available: "2025-12"
 12122	coward's extra-thick Crimbo sweater	0		Monster Level: -20, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	mediocre watered-down Steve Abrams' Holiday Sampler Beer	2	decent	Last Available: "2025-12"
+12124	watered-down mediocre Steve Abrams' Holiday Sampler Beer	2	decent	Last Available: "2025-12"
 12125	jittery crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	watered-down bad bottle of prize-winning rum	2	decent	Last Available: "2025-12"
 12127	groovy beefcake's Santa-Slayer medal of the empath	0		Muscle: +25, Moxie Percent: +10, Familiar Weight: +5, Single Equip, Last Available: "2025-12"
@@ -11889,15 +11889,15 @@
 12131	enhanced boiling synovial fluid	0		Effect: "Saucemastery", Effect Duration: 53, Last Available: "2025-12"
 12132	brawny beefy smoldering vertebra of the wise owl	0		Muscle: +10, Mysticality: +20, Muscle Percent: +20, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
-12135	cyan blurry wobbly smoldering bone dust	0		Last Available: "2025-12"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12135	cyan wobbly blurry smoldering bone dust	0		Last Available: "2025-12"
 12136	wobbly volatile bone bomb	0		Last Available: "2025-12"
 12137	dance instructor's beefcake's hot boning knife of Tarzan	0		Muscle: +25, Experience (Muscle): +3, Experience Percent (Moxie): +10, Single Equip, Last Available: "2025-12"
 12138	Sherlock's Tesla extremely unsafe fistbone	0		Weapon Damage Percent: +100, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
 12139	auspicious razor-sharp personal trainer's burnt bone belt	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +25, Item Drop: +10, Single Equip, Last Available: "2025-12"
 12140	fuchsia mirror healthy scorched skull trophy	0		Maximum HP Percent: +20, Last Available: "2025-12"
 12141	moldy jumbo wing bone	5	crappy	Last Available: "2025-12"
-12142	weak drinkable ghostly weak skeleton venom	2	good	Last Available: "2025-12"
+12142	drinkable weak ghostly weak skeleton venom	2	good	Last Available: "2025-12"
 12143	vaporized jittery baked bone meal	1		Last Available: "2025-12"
 12144	inspector's plastic skeleton rib cage	0		Item Drop: +15, Last Available: "2025-12"
 12145	plastic skeleton skull	0		Item Drop: +5, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	gravedigger's ship's lantern	0		Spooky Damage: +10, Last Available: "2025-12"
 12170	gravedigger's heat-resistant harpoon pistol of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Damage: +10, Last Available: "2025-12"
 12171	delicious small traditional gingerloaf	2	awesome	Last Available: "2025-12"
-12172	bad special narrow Scotch and eggnog	3	decent	Effect: "Super-Charged", Effect Duration: 45, Last Available: "2025-12"
+12172	special bad narrow Scotch and eggnog	3	decent	Effect: "Super-Charged", Effect Duration: 45, Last Available: "2025-12"
 12173	chilled shaking counterskeleton elixir	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 43, Last Available: "2025-12"
 12174	perfectly mixed squat &quot;salvaged&quot; wine	3	EPIC	Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	quantum quadruple-cold-filtered gummi fingerbone	0		Effect: "Dreams and Lights", Effect Duration: 33
 12179	sizzling Socratic glimmering crystal	0		Experience (Mysticality): +1, Hot Damage: +10, Last Available: "2025-12"
 12180	bouncing boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	wobbly Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11964,16 +11964,16 @@
 12206	huge jittery Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	mirror Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	moldy skewed narrow twirling rat pizza	4	crappy	Last Available: "2026-03"
+12209	moldy narrow twirling skewed rat pizza	4	crappy	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	blurry mirror knitted Socratic thinker's hoverboard	0		Mysticality: +10, Experience (Mysticality): +1, Cold Resistance: +3, Single Equip, Last Available: "2026-03"
 12212	padded left shark fin of the brute of horror	0		Muscle Percent: +30, Damage Absorption: +20, Spooky Spell Damage: +25, Last Available: "2026-03"
 12213	green medical-grade fitness tracking bracelet	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2026-03"
-12214	powdered mirror tumbling candy bone	1		
+12214	powdered tumbling mirror candy bone	1		
 12215	twirling mirror wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	enchanted thick rotten spinning discarded hot dog	5	crappy	Effect: "Sugary World View", Effect Duration: 45, Last Available: "2026-04"
-12218	enchanted hand-crafted most of a beer	3	EPIC	Effect: "Melancholy Burden", Effect Duration: 45, Last Available: "2026-04"
+12218	hand-crafted enchanted most of a beer	3	EPIC	Effect: "Melancholy Burden", Effect Duration: 45, Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	red skewed legendary noodles	0		Last Available: "2026-05"
@@ -11981,13 +11981,13 @@
 12227	decent pulsating alien salad	4	good	
 12228	rotten ratbatatouille	3	crappy	
 12229	spoiled onigiri	3	crappy	
-12230	moldy small crudit&eacute;s	2	crappy	
-12231	rotten big squat cyan sauced mutton	5	crappy	
-12232	big delicious hot honey ant	5	awesome	
+12230	small moldy crudit&eacute;s	2	crappy	
+12231	big rotten squat cyan sauced mutton	5	crappy	
+12232	delicious big hot honey ant	5	awesome	
 12233	rotten super-sized twirling tomb aspic	5	crappy	
 12234	decent ghostly later tots	4	good	
 12235	gigantic moldy yellow Frutti di Scatoletta	8	crappy	Last Available: "2026-05"
-12236	spoiled fancy Pesto alla Marziano	4	crappy	Effect: "Sweet Nostalgia", Effect Duration: 5, Last Available: "2026-05"
+12236	fancy spoiled Pesto alla Marziano	4	crappy	Effect: "Sweet Nostalgia", Effect Duration: 5, Last Available: "2026-05"
 12237	adequate mirror Arrattabbattabiata	4	good	Last Available: "2026-05"
 12238	stale mirror Orzo di Riso	3	decent	Last Available: "2026-05"
 12239	spoiled Pasta Grimavera	4	crappy	Last Available: "2026-05"
@@ -12000,7 +12000,7 @@
 12246	blinking second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	Space Soldier Helmet of the sweet-tooth	0		Item Drop: +5, Candy Drop: +100
-12253	bland special premium turkey leg	3	decent	Effect: "Whitened Teeth", Effect Duration: 15
+12253	special bland premium turkey leg	3	decent	Effect: "Whitened Teeth", Effect Duration: 15
 12254	hand-crafted tumbling styrofoam cup of mead	3	EPIC	
 12255	knitted sword	0		Cold Resistance: +3
 12256	fuchsia staff of the blizzard	0		Cold Spell Damage: +25
@@ -12017,10 +12017,10 @@
 12267	flimsy plastic breastplate of the storm	0		Maximum MP Percent: +40
 12268	rock-hard flimsy plastic shield	0		Damage Reduction: 8
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	Usain Bolt's thinker's Portable Laughing Stock of the ox	0		Muscle: +20, Mysticality: +10, Initiative: +80, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	Usain Bolt's thinker's Portable Laughing Stock of the ox	0		Muscle: +20, Mysticality: +10, Initiative: +80, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	family-friendly beefcake's Staff of Anachronistic Churning of the detective	0		Muscle: +25, Sleaze Resistance: +1, Item Drop: +20
 12272	adequate classic banana	3	good	Last Available: "2026-07"
-12273	immense spoiled gray watermelon	6	crappy	Last Available: "2026-07"
+12273	spoiled immense gray watermelon	6	crappy	Last Available: "2026-07"
 12274	normal quince	3	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	narrow Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
@@ -12033,13 +12033,13 @@
 12283	modified adjusted narrow green concentrated watermelon juice	0		Effect: "Hobonic", Effect Duration: 38, Last Available: "2026-07"
 12284	anodized yellow Aqua Citrulanatae	0		Effect: "Loco Motives", Effect Duration: 52, Last Available: "2026-07"
 12285	tolerable Melonegroni	3	good	Last Available: "2026-07"
-12286	weak aged Melonade Spritz	2	awesome	Last Available: "2026-07"
-12287	jumbo bland quince pie	5	decent	Last Available: "2026-07"
+12286	aged weak Melonade Spritz	2	awesome	Last Available: "2026-07"
+12287	bland jumbo quince pie	5	decent	Last Available: "2026-07"
 12288	pressed quince quaff	0		Effect: "Be a Mind Master", Effect Duration: 27, Last Available: "2026-07"
 12289	energized modified Quickquince	0		Effect: "Toothy Grin", Effect Duration: 11, Last Available: "2026-07"
-12290	lousy boozy Quiskey Sour	5	decent	Last Available: "2026-07"
-12291	mediocre narrow upside-down Quincea&ntilde;era Cooler	3	decent	Last Available: "2026-07"
-12292	artisanal watered-down blue blurry Roth IPA	2	EPIC	Last Available: "2026-08"
+12290	boozy lousy Quiskey Sour	5	decent	Last Available: "2026-07"
+12291	mediocre upside-down narrow Quincea&ntilde;era Cooler	3	decent	Last Available: "2026-07"
+12292	watered-down artisanal blurry blue Roth IPA	2	EPIC	Last Available: "2026-08"
 12293	ribald underdraft protection of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	decent soybean futures	3	good	Last Available: "2026-08"
@@ -12059,6 +12059,6 @@
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	dried blinking toxic asset	1		Effect: "Paging Betty", Effect Duration: 30, Last Available: "2026-08"
 12311	powdered intangible asset	1		Last Available: "2026-08"
-12312	dehydrated blinking gray liquid asset	1		Last Available: "2026-08"
+12312	dehydrated gray blinking liquid asset	1		Last Available: "2026-08"
 12313	spinning gross prophet chrysalis	0		Last Available: "2026-08"
 12314	maroon cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Seal_Clubber_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Opossum_cafe_booze.txt
@@ -3,18 +3,18 @@
 -3	triple-distilled delicious Infinitesimal IPA	7	awesome	
 -4	mediocre eggnogtini	3	decent	
 -5	watered-down tolerable candycaine	2	good	
--6	artisanal watered-down braincracker sweet	2	EPIC	
--16	boozy lousy bouncing fermented honey	5	decent	
+-6	watered-down artisanal braincracker sweet	2	EPIC	
+-16	lousy boozy bouncing fermented honey	5	decent	
 -17	artisanal practically non-alcoholic gray moons-shine	1	EPIC	
 -18	artisanal gin	4	EPIC	
--19	extra-dry mediocre squat blue ecto-nog	5	decent	
--20	high-proof lousy fancy hot toady	6	decent	
+-19	mediocre extra-dry squat blue ecto-nog	5	decent	
+-20	lousy fancy high-proof hot toady	6	decent	
 -21	smooth olive hot choculate	4	awesome	
 -49	artisanal mirror Cyder	3	EPIC	
 -50	bad Oil Nog	3	decent	
 -51	mediocre Hi-Octane Peppermint Jet Fuel	3	decent	
 -58	aged squat Grimacider	3	awesome	
--59	triple-distilled smooth twirling Isotope Nog	8	awesome	
+-59	smooth triple-distilled twirling Isotope Nog	8	awesome	
 -60	acceptable high-proof Mutagin 'n' Tonic	9	good	
 -70	hand-crafted Gin and Herring	3	EPIC	
 -71	smooth pulsating Black and Tan and Red All Over	4	awesome	
@@ -22,11 +22,11 @@
 -76	practically non-alcoholic artisanal CRIMBCO Ribbon Candy Schnapps	1	EPIC	
 -77	delicious CRIMBCO Egg Substitute Nog Substitute	3	awesome	
 -78	tolerable boozy CRIMBCO Extreme Braincracker Sour	5	good	
--82	delicious special triple-distilled Horseradish-infused Vodka	8	awesome	
+-82	triple-distilled delicious special Horseradish-infused Vodka	8	awesome	
 -83	mediocre strong lime green Jerkitini	5	decent	
 -84	tolerable weak twirling Desert Island Iced Tea	2	good	
 -88	boozy aged Crimbo Saketini	5	awesome	
--89	watered-down tolerable Crimboku Drop	2	good	
+-89	tolerable watered-down Crimboku Drop	2	good	
 -90	hand-crafted Flaming Crimbo Log	4	EPIC	
 -107	aged blinking Fortified Eggnog Slurry	4	awesome	
 -108	hand-crafted maroon Hot Buttered Rum	3	EPIC	

--- a/data/TCRS/TCRS_Seal_Clubber_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Opossum_cafe_food.txt
@@ -1,45 +1,45 @@
--1	jumbo bland squat Peche a la Frog	5	decent	
+-1	bland jumbo squat Peche a la Frog	5	decent	
 -2	decent As Jus Gezund Heit	4	good	
 -3	immense decent Bouillabaise Coucher Avec Moi	7	good	
 -7	snack-sized flavorless gumdrop chow mein	2	decent	
 -8	adequate miniature candy cane pizza	2	good	
 -9	moldy teal gingerbread stir-fry	4	crappy	
 -10	decent bouncing twigs and gravel	4	good	
--11	bland miniature yellow shoots and leaves	2	decent	
+-11	miniature bland yellow shoots and leaves	2	decent	
 -12	rotten enchanted bowl of unidentifiable goo	4	crappy	
 -13	yummy yellow gingerbread massacre	3	awesome	
 -14	bland cyan It Came From Beyond Dessert	3	decent	
--15	tiny bland vampire cake	1	decent	
+-15	bland tiny vampire cake	1	decent	
 -52	snack-sized spoiled Soylent Red and Green	2	crappy	
 -53	decent Disc-Shaped Nutrition Unit	4	good	
 -54	bland Gingerborg Hive	3	decent	
--61	small normal Candy Cane Surprise	2	good	
+-61	normal small Candy Cane Surprise	2	good	
 -62	tasty jittery Grimdrop Chow Mein	3	awesome	
--63	miniature stale Grimgerbread House	2	decent	
+-63	stale miniature Grimgerbread House	2	decent	
 -67	moldy snack-sized Caviar Carbonara	2	crappy	
--68	snack-sized fancy adequate Halibut Alfredo	2	good	
+-68	adequate fancy snack-sized Halibut Alfredo	2	good	
 -69	bite-sized yummy Red Herring Velvet Cake	1	awesome	
--73	stale tiny CRIMBCO Reconstituted Gruel	1	decent	
+-73	tiny stale CRIMBCO Reconstituted Gruel	1	decent	
 -74	normal ghostly New and Improved CRIMBCO Reconstituted Gruel	3	good	
 -75	flavorless CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
 -79	decent Brussels Sprout Stir-Fry	3	good	
 -80	yummy jumbo Carrot, Cabbage, and Kale Pizza	5	awesome	
 -81	rotten Turnip and Rutabaga Pie	3	crappy	
--85	thick toothsome Rainbow Spider Fun Roll	5	awesome	
+-85	toothsome thick Rainbow Spider Fun Roll	5	awesome	
 -86	rotten special upside-down Vegas Volcano Lava Roll	3	crappy	
 -87	super-sized spoiled squat Crazy Dragon Shogun Buddha Roll	5	crappy	
--92	jumbo spoiled basic hot dog	5	crappy	
+-92	spoiled jumbo basic hot dog	5	crappy	
 -93	moldy squat savage macho dog	4	crappy	
 -94	gigantic spoiled one with everything	8	crappy	
 -95	stale sly dog	4	decent	
 -96	adequate devil dog	3	good	
 -97	moldy fuchsia chilly dog	4	crappy	
 -98	flavorless bite-sized ghost dog	1	decent	
--99	stale diet junkyard dog	1	decent	
+-99	diet stale junkyard dog	1	decent	
 -100	rotten wet dog	4	crappy	
 -101	normal teal sleeping dog	4	good	
 -102	bland twirling optimal dog	4	decent	
--103	bite-sized flavorless pulsating video games hot dog	1	decent	
--104	jumbo adequate Peppermint Nutrition Block	5	good	
--105	adequate miniature Gingerbread Nutrition Block	2	good	
+-103	flavorless bite-sized pulsating video games hot dog	1	decent	
+-104	adequate jumbo Peppermint Nutrition Block	5	good	
+-105	miniature adequate Gingerbread Nutrition Block	2	good	
 -106	rotten Cinnamon Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Seal_Clubber_Packrat.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Packrat.txt
@@ -20,8 +20,8 @@
 21	sweet ninja sword	0		
 22	blinking squat studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
-24	blinking wobbly ten-leaf clover	0		
-25	shaking squat meat paste	0		
+24	wobbly blinking ten-leaf clover	0		
+25	squat shaking meat paste	0		
 26	spinning Dolphin King's map	0		
 27	spider web	0		
 28	really spider web	0		
@@ -43,8 +43,8 @@
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	squat figurine	0		
-47	fancy rotten hot buttered roll	3	crappy	Effect: "Morbidi Tea", Effect Duration: 15
-48	lime green shaking heart of rock and roll	0		
+47	rotten fancy hot buttered roll	3	crappy	Effect: "Morbidi Tea", Effect Duration: 15
+48	shaking lime green heart of rock and roll	0		
 49	bland small bowl of cottage cheese	2	decent	
 50	tumbling Sinatra's Rock and Roll Legend	0		Experience (Moxie): +5, Class: "Accordion Thief", Song Duration: 10
 51	Knob Goblin Uberpants of dire peril	0		Weapon Damage: +20, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -171,7 +171,7 @@
 172	gnoll lips	0		
 173	taco shell	0		
 174	Gnollish casserole dish	0		
-175	super-sized adequate uncooked chorizo	5	good	
+175	adequate super-sized uncooked chorizo	5	good	
 176	blurry disembodied brain	0		
 177	brainy skull	0		
 178	detective skull	0		
@@ -196,7 +196,7 @@
 198	rat appendix	0		
 199	wobbly ring of the storm	0		Maximum MP Percent: +40
 200	moldy rat appendix kabob	3	crappy	
-201	bland fancy small bat wing kabob	2	decent	Effect: "Slimily Speedy", Effect Duration: 25
+201	fancy small bland bat wing kabob	2	decent	Effect: "Slimily Speedy", Effect Duration: 25
 202	massive normal carob chunks	7	good	
 203	herbs	0		
 204	big adequate upside-down carob chunk cookies	5	good	
@@ -211,7 +211,7 @@
 213	twirling wobbly flame-retardant gravedigger's filthy corduroys	0		Spooky Damage: +10, Hot Resistance: +1, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	green Da Vinci's filthy knitted dread sack	0		Experience (Mysticality): +5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	normal fancy carob brownies	3	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50
+216	fancy normal carob brownies	3	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 50
 217	rotten diet herb brownies	1	crappy	
 218	hemp string	0		
 219	squat necklace chain	0		
@@ -221,7 +221,7 @@
 223	healthy phat turquoise bracelet	0		Maximum HP Percent: +20
 224	lime green manspreader's eyepatch	0		Monster Level: +10, Familiar Effect: "3xBarrr, cap 6"
 225	snack-sized spoiled blinking tofu casserole	2	crappy	
-226	boiled purple shaking can of Red Minotaur	1	good	Effect: "Patience of the Tortoise", Effect Duration: 10
+226	boiled shaking purple can of Red Minotaur	1	good	Effect: "Patience of the Tortoise", Effect Duration: 10
 227	bouncing coward's Kentucky-fried meat sword	0		Monster Level: -20
 228	blurry Socratic Kentucky-fried meat staff	0		Experience (Mysticality): +1
 229	spinning Kentucky-fried meat crossbow of James Dean	0		Experience (Moxie): +3
@@ -232,7 +232,7 @@
 234	blurry Doc Galaktik's Homeopathic Elixir	0		
 235	narrow miser's occult Bigger Bugfinder Blade	0		Spell Damage Percent: +25, Meat Drop: +10
 236	upside-down Queue Du Coq cocktailcrafting kit	0		
-237	artisanal irresponsibly strong bottle of gin	6	EPIC	
+237	irresponsibly strong artisanal bottle of gin	6	EPIC	
 238	mediocre bottle of vodka	3	decent	
 239	upside-down fireproof Orcish baseball cap of the wise owl	0		Mysticality: +20, Hot Resistance: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	rosewater-soaked healthy Orcish cargo shorts	0		Maximum HP Percent: +20, Stench Resistance: +3, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
@@ -244,35 +244,35 @@
 246	rotten upside-down tomato	3	crappy	
 247	bouncing fermenting powder	0		
 248	smooth salty dog	4	awesome	
-249	special acceptable skewed bloody mary	4	good	Effect: "Heart of Pink", Effect Duration: 45
+249	acceptable special skewed bloody mary	4	good	Effect: "Heart of Pink", Effect Duration: 45
 250	drinkable tumbling screwdriver	4	good	
 251	smooth high-proof narrow martini	8	awesome	
 252	artisanal bloody beer	4	EPIC	
-253	artisanal enchanted jittery shot of schnapps	4	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 30
-254	watered-down bad mirror shot of grapefruit schnapps	2	decent	
+253	enchanted artisanal jittery shot of schnapps	4	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 30
+254	bad watered-down mirror shot of grapefruit schnapps	2	decent	
 255	smooth maroon jittery fine wine	3	awesome	
 256	watered-down acceptable shot of tomato schnapps	2	good	
-257	high-proof artisanal extra-spicy bloody mary	7	EPIC	
+257	artisanal high-proof extra-spicy bloody mary	7	EPIC	
 258	ghostly dense meat stack	0		
 259	snake skin	0		
 260	delicious skewed White Citadel fries	4	awesome	
-261	tiny flavorless narrow White Citadel burger	1	decent	
-262	small special normal tumbling fuchsia piece of wedding cake	2	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 25
+261	flavorless tiny narrow White Citadel burger	1	decent	
+262	small special normal fuchsia tumbling piece of wedding cake	2	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 25
 263	stale miniature special chocolate chips	2	decent	Effect: "X-Ray Vision", Effect Duration: 35
 264	small decent shaking chocolate chip cookies	2	good	
 265	aromatic satin pants	0		Stench Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
-266	artisanal irresponsibly strong lightning	9	EPIC	
+266	irresponsibly strong artisanal lightning	9	EPIC	
 267	ghostly Temple Grandin's mullet wig	0		Familiar Weight: +7, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	wizardly meat cowboy hat	0		Mysticality: +25, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	boxer's sword	0		Muscle Percent: +10
 270	picket fence	0		
-271	dried blurry fuchsia barbell	1		
+271	dried fuchsia blurry barbell	1		
 272	twisted concentrated magicalness pill	1		
 273	altered moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	altered purple jittery twirling extra-strength strongness elixir	1		
+277	altered twirling jittery purple extra-strength strongness elixir	1		
 278	boiled green jug-o-magicalness	1		
 279	modified suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
@@ -297,8 +297,8 @@
 299	triple-anodized twirling pickle-flavored chewing gum	0		Effect: "critical.enh", Effect Duration: 36
 300	dry tarnished jaba&ntilde;ero-flavored chewing gum	0		Effect: "Helping Comes Second", Effect Duration: 67
 301	flat dough	0		
-302	small decent Knob sausage	2	good	
-303	normal immense Knob mushroom	9	good	
+302	decent small Knob sausage	2	good	
+303	immense normal Knob mushroom	9	good	
 304	fuchsia dry noodles	0		
 305	therapeutic Knob Goblin harem pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	flame-retardant Knob Goblin harem veil	0		Hot Resistance: +1, Familiar Effect: "5xLep, cap 2"
@@ -312,9 +312,9 @@
 314	normal bean burrito	3	good	
 315	normal huge bean burrito	6	good	
 316	spoiled insanely bean burrito	3	crappy	
-317	enchanted tasty bean burrito	3	awesome	Effect: "Knightlife", Effect Duration: 15
+317	tasty enchanted bean burrito	3	awesome	Effect: "Knightlife", Effect Duration: 15
 318	small stale bean burrito	2	decent	
-319	normal fancy insanely bean burrito	4	good	Effect: "Slimed Stomach", Effect Duration: 50
+319	fancy normal insanely bean burrito	4	good	Effect: "Slimed Stomach", Effect Duration: 50
 320	snack-sized decent narrow bat haggis	2	good	
 321	bite-sized stale skewed menudo	1	decent	
 322	delicious enchanted tumbling goat cheese	3	awesome	Effect: "Lucky Cat Is Lucky", Effect Duration: 15
@@ -327,7 +327,7 @@
 329	vibrating goat beard	0		Maximum MP Percent: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	spinning glass of goat's milk	1	decent	
 331	acceptable Canadian	4	good	
-332	stale skewed cyan lemon	4	decent	
+332	stale cyan skewed lemon	4	decent	
 333	bland lime	3	decent	
 334	flame-retardant sabre teeth	0		Hot Resistance: +1
 335	sabre-toothed lime cub	0		
@@ -353,13 +353,13 @@
 355	ghostly eXtreme scarf of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	blurry banded snowboarder pants	0		Damage Absorption: +100, Familiar Effect: "1xPotato, cap 25"
 357	bouncing Mountain Stream soda	0		
-358	spoiled diet fancy gr8ps	1	crappy	Effect: "Crud&eacute;", Effect Duration: 15
-359	miniature normal special t8r tots	2	good	Effect: "Reedy Pipes", Effect Duration: 40
+358	diet spoiled fancy gr8ps	1	crappy	Effect: "Crud&eacute;", Effect Duration: 15
+359	normal miniature special t8r tots	2	good	Effect: "Reedy Pipes", Effect Duration: 40
 360	miner's helmet of chilblains	0		Cold Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	resourceful miner's pants	0		Maximum MP: +50, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	yellow baleful 7-Foot Dwarven mattock	0		Spell Damage: +25
 363	linoleum ore	0		
-364	bouncing cyan asbestos ore	0		
+364	cyan bouncing asbestos ore	0		
 365	gray chrome ore	0		
 366	linoleum sword hilt	0		
 367	twirling linoleum stick	0		
@@ -367,7 +367,7 @@
 369	maroon blurry asbestos sword hilt	0		
 370	asbestos stick	0		
 371	asbestos crossbow string	0		
-372	blinking blue chrome sword hilt	0		
+372	blue blinking chrome sword hilt	0		
 373	chrome stick	0		
 374	chrome crossbow string	0		
 375	linoleum meat stack	0		
@@ -438,7 +438,7 @@
 440	bartender-in-the-box	0		
 441	chef-skull-in-the-box	0		
 442	tumbling bartender-skull-in-the-box	0		
-443	tumbling lime green narrow beer lens	0		
+443	tumbling narrow lime green beer lens	0		
 444	beer goggles	0		
 445	cyan bouncing smooth box-in-the-box	0		Moxie: +15
 446	nothing-in-the-box-in-the-box	0		
@@ -450,7 +450,7 @@
 452	disease	0		
 453	sober pill	0		
 454	screwdriver	0		
-455	adequate gigantic yellow jumbo olive	7	good	
+455	gigantic adequate yellow jumbo olive	7	good	
 456	aged dry martini	4	awesome	
 457	prompt ye olde golde frontes	0		Adventures: +3, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
@@ -462,10 +462,10 @@
 464	shaking pixel potion	0		
 465	purple pixel potion	0		
 466	pixel potion	0		
-467	massive moldy pixel pie	6	crappy	
+467	moldy massive pixel pie	6	crappy	
 468	cyan ruby W	0		
 469	wussiness potion	0		
-470	practically non-alcoholic artisanal Imp Ale	1	EPIC	
+470	artisanal practically non-alcoholic Imp Ale	1	EPIC	
 471	normal hot wing	3	good	
 472	ghostly lard-coated diamond-studded cane	0		Sleaze Spell Damage: +25, Class: "Disco Bandit"
 473	crutch of the brazier	0		Hot Spell Damage: +25
@@ -496,21 +496,21 @@
 498	moldy tiny papaya	1	crappy	
 499	perfumed padded denim axe	0		Damage Absorption: +20, Stench Resistance: +5
 500	Elf Farm Raffle ticket	0		
-501	moldy half-sized Elfin shortbread	2	crappy	
+501	half-sized moldy Elfin shortbread	2	crappy	
 502	shaking pagoda plans	0		
 503	stale skewered cat appendix	3	decent	
 504	evil arches	0		
 505	narrow friendly hardened gnatwing earring	0		Damage Reduction: 3, Familiar Weight: +3
-506	adequate tiny Hell broth	1	good	
+506	tiny adequate Hell broth	1	good	
 507	shaking vibrating thunderrr guitarrr	0		Maximum MP Percent: +10
 508	sonata	0		
 509	Hey Deze nuts	0		
-510	narrow ghostly Boris's key lime	0		
+510	ghostly narrow Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	jittery Sneaky Pete's key lime	0		
 513	stale Boris's key lime pie	3	decent	
 514	spoiled narrow Jarlsberg's key lime pie	4	crappy	
-515	half-sized stale Sneaky Pete's key lime pie	2	decent	
+515	stale half-sized Sneaky Pete's key lime pie	2	decent	
 516	shaking Hey Deze map	0		
 517	family-friendly bejeweled accordion strap	0		Sleaze Resistance: +1, Class: "Accordion Thief"
 518	bouncing bouncing mystery juice	0		
@@ -540,7 +540,7 @@
 542	sinister 1337 7r0uZ0RZ of the cheetah	0		Spell Damage: +10, Initiative: +60, Familiar Effect: "2xPotato, cap 27"
 543	toothsome Trollhouse cookies	3	awesome	
 544	spinning rosy-cheeked steel-toed talons	0		Damage Reduction: 9, Maximum HP Percent: +30
-545	big rotten Spam Witch sammich	5	crappy	
+545	rotten big Spam Witch sammich	5	crappy	
 546	tumbling meat vortex	0		
 547	334 scroll	0		
 548	bouncing 668 scroll	0		
@@ -552,7 +552,7 @@
 554	miniature adequate pr0n cocktail	2	good	
 555	prompt Samson's drywall axe	0		Experience (Muscle): +5, Adventures: +3
 556	shaking reassuring Pine-Fresh air freshener	0		Spooky Resistance: +1
-557	high-proof tolerable whiskey and cola	10	good	
+557	tolerable high-proof whiskey and cola	10	good	
 558	yummy special green papaya taco	3	awesome	Effect: "Chauve-Souris Merde Fou", Effect Duration: 45
 559	razor-sharp can lid	0		
 560	spoiled stalk of asparagus	3	crappy	
@@ -563,16 +563,16 @@
 565	shellacked hobo gloves	0		Damage Reduction: 7, Single Equip
 566	tumbling Jeselnik's bum cheek	0		Sleaze Damage: +25, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	yellow hermit script	0		
-568	delicious diet Double Bacon Beelzeburger	1	awesome	
+568	diet delicious Double Bacon Beelzeburger	1	awesome	
 569	moldy Lord of the Flies-sized fries	4	crappy	
-570	decent enchanted miniature Chicken Sandwich	2	good	Effect: "Unusual Fashion Sense", Effect Duration: 10
+570	miniature enchanted decent Chicken Sandwich	2	good	Effect: "Unusual Fashion Sense", Effect Duration: 10
 571	Jumbo Dr. Lucifer	1	good	
 572	spoiled fuchsia Children's Meal of the Damned	3	crappy	
-573	jumbo delicious noodles	5	awesome	
+573	delicious jumbo noodles	5	awesome	
 574	tasty narrow noodles	3	awesome	
-575	bland half-sized painful penne pasta	2	decent	
+575	half-sized bland painful penne pasta	2	decent	
 576	bland miniature ravioli della hippy	2	decent	
-577	small stale pr0n m4nic0tti	2	decent	
+577	stale small pr0n m4nic0tti	2	decent	
 578	moldy Hell ramen	3	crappy	
 579	flavorless low-calorie boring spaghetti	1	decent	
 580	pulsating sauce of the ages	0		
@@ -584,9 +584,9 @@
 586	wobbly Van der Graaf ridiculously huge sword of courage	0		Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7
 587	non-diffused gray super-spiky hair gel	0		Effect: "Motion", Effect Duration: 15
 588	soft echo eyedrop antidote	0		
-589	moldy thick cocoa eggshell fragment	5	crappy	
+589	thick moldy cocoa eggshell fragment	5	crappy	
 590	moldy cocoa eggshell fragment	3	crappy	
-591	blurry cyan cocoa egg	0		
+591	cyan blurry cocoa egg	0		
 592	purple house	0		
 593	phonics down	0		
 594	horrifying amulet of extreme plot significance	0		Spooky Damage: +25
@@ -611,7 +611,7 @@
 613	yellow plot hole	0		
 614	non-boiled probability potion	0		Effect: "Tiki Temerity", Effect Duration: 30
 615	chaos butterfly	0		
-616	red mirror furry fur	0		
+616	mirror red furry fur	0		
 617	denatured magnetized Angry Farmer candy	0		Effect: "Extra-Thick Blood", Effect Duration: 11
 618	non-Vulcanized super-warmed frozen teal Mick's IcyVapoHotness Rub	0		Effect: "Rage of the Reindeer", Effect Duration: 58
 619	needle of dire peril	0		Weapon Damage: +20
@@ -634,7 +634,7 @@
 636	meat globe	0		
 637	wobbly toaster	0		
 638	Annie Oakley's healthy asshat	0		Maximum HP Percent: +20, Critical Hit Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	rotten ghostly bouncing abominable snowcone	3	crappy	
+639	rotten bouncing ghostly abominable snowcone	3	crappy	
 640	Ent cider	1	decent	
 641	flavorless toast	4	decent	
 642	skeleton key	0		
@@ -668,21 +668,21 @@
 670	tumbling careful lihc face	0		Monster Level: -10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	green ribald Newton's grave robbing shovel	0		Experience (Mysticality): +3, Sleaze Damage: +10
 672	stale cranberries	4	decent	
-673	watered-down drinkable vodka and cranberry	2	good	
-674	bad special whiskey	4	decent	Effect: "Ass Over Teakettle", Effect Duration: 40
+673	drinkable watered-down vodka and cranberry	2	good	
+674	special bad whiskey	4	decent	Effect: "Ass Over Teakettle", Effect Duration: 40
 675	bouncing Socratic skull of the Bonerdagon	0		Experience (Mysticality): +1
 676	dragonbone belt buckle	0		
 677	narrow pulsating Newton's badass belt	0		Experience (Mysticality): +3
 678	chest of the Bonerdagon	0		
 679	practically non-alcoholic acceptable wobbly roll in the hay	1	good	
-680	artisanal watered-down slap and tickle	2	EPIC	
-681	high-proof lousy jittery bouncing slip 'n' slide	8	decent	
-682	special smooth tumbling a sump'm sump'm	3	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 40
+680	watered-down artisanal slap and tickle	2	EPIC	
+681	lousy high-proof bouncing jittery slip 'n' slide	8	decent	
+682	smooth special tumbling a sump'm sump'm	3	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 40
 683	hand-crafted horizontal tango	4	EPIC	
 684	enchanted mediocre pink pony	4	decent	Effect: "Salty Mouth", Effect Duration: 25
 685	reassuring wool grievous Mr. Shirt	0		Weapon Damage Percent: +50, Cold Resistance: +1, Spooky Resistance: +1
 686	squat knuckles of the brute	0		Muscle Percent: +30
-687	diffused yellow upside-down blood of the Wereseal	0		Effect: "Nano-juiced", Effect Duration: 24
+687	diffused upside-down yellow blood of the Wereseal	0		Effect: "Nano-juiced", Effect Duration: 24
 688	blue gravedigger's pixel hat	0		Spooky Damage: +10, Familiar Effect: "atk, 2xVolley, cap 12"
 689	mansplainer's pixel pants	0		Monster Level: +15, Familiar Effect: "atk, 4xPotato, cap 12"
 690	twirling pixel sword of temperance	0		Sleaze Resistance: +5
@@ -724,8 +724,8 @@
 728	hedge maze key	0		
 729	cyan fishbowl	0		
 730	olive fishtank	0		
-731	cyan pulsating fish hose	0		
-732	squat fuchsia hosed tank	0		
+731	pulsating cyan fish hose	0		
+732	fuchsia squat hosed tank	0		
 733	hosed fishbowl	0		
 734	reassuring lion tamer's sage makeshift SCUBA gear	0		Mysticality Percent: +10, Experience (familiar): +2, Spooky Resistance: +1, Adventure Underwater
 735	grievous easter egg balloon	0		Weapon Damage Percent: +50
@@ -736,27 +736,27 @@
 740	blue tumbling tambourine of incineration	0		Hot Spell Damage: +50
 741	broken skull	0		
 742	flavorless pulsating Knoll shroomkabob	4	decent	
-743	bland big special mushroom	5	decent	Effect: "Rain Dancin'", Effect Duration: 10
+743	big special bland mushroom	5	decent	Effect: "Rain Dancin'", Effect Duration: 10
 744	altered frozen blinking hair spray	0		Effect: "Mucilaginous Mentalism", Effect Duration: 18
-746	pulsating blurry stat script	0		
+746	blurry pulsating stat script	0		
 747	Knob Goblin firecracker	0		
 748	maroon gourd potion	0		
 749	bland small warm mushroom	2	decent	
 750	flavorless mushroom quesadilla	3	decent	
 751	stale jittery cool mushroom	4	decent	
-752	adequate immense cool mushroom casserole	6	good	
+752	immense adequate cool mushroom casserole	6	good	
 753	spoiled narrow pointy mushroom	4	crappy	
 754	decent narrow green cream of pointy mushroom soup	4	good	
-755	bland fancy mushroom	4	decent	Effect: "Bored Stiff", Effect Duration: 45
+755	fancy bland mushroom	4	decent	Effect: "Bored Stiff", Effect Duration: 45
 756	bland fancy mushroom	4	decent	Effect: "Hammered", Effect Duration: 30
-757	decent special mushroom	4	good	Effect: "substats.enh", Effect Duration: 15
+757	special decent mushroom	4	good	Effect: "substats.enh", Effect Duration: 15
 758	spoiled upside-down ghost cucumber	4	crappy	
 759	dill	0		
 760	vinegar	0		
 761	shaking brine	0		
 762	perfectly mixed watered-down especially salty dog	2	EPIC	
 763	ghostly pickling solution	0		
-764	stale super-sized pulsating spectral pickle	5	decent	
+764	super-sized stale pulsating spectral pickle	5	decent	
 765	briny vinegar	0		
 766	lime green ghost pickle on a stick	0		
 767	deionized magnetized spinning cologne of contempt	0		Effect: "Transcendental Wind", Effect Duration: 17
@@ -776,9 +776,9 @@
 781	quantum blurry mafia aria	0		Effect: "Feroci Tea", Effect Duration: 63
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	bad practically non-alcoholic Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
+784	practically non-alcoholic bad Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
 785	raffle ticket	0		
-786	moldy low-calorie strawberry	1	crappy	
+786	low-calorie moldy strawberry	1	crappy	
 787	lousy bottle of rum	3	decent	
 788	perfectly mixed weak blurry strawberry daiquiri	2	EPIC	
 789	perfectly mixed weak rum and cola	2	EPIC	
@@ -790,24 +790,24 @@
 795	watered-down delicious bouncing Acque Luride Grezze Cabernet	2	awesome	Last Available: "2004-10"
 796	friendly rosy-cheeked cement shoes of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Familiar Weight: +3, Last Available: "2004-10"
 797	perfectly mixed practically non-alcoholic rockin' wagon	1	super ultra mega turbo EPIC	
-798	irresponsibly strong perfectly mixed ocean motion	8	EPIC	
+798	perfectly mixed irresponsibly strong ocean motion	8	EPIC	
 799	smooth fuzzbump	3	awesome	
 800	snack-sized adequate poutine	2	good	
-801	stale thick Knob stir-fry	5	decent	
-804	enchanted thick moldy wobbly Knoll stir-fry	5	crappy	Effect: "Healthy Bronze Glow", Effect Duration: 30
+801	thick stale Knob stir-fry	5	decent	
+804	thick enchanted moldy wobbly Knoll stir-fry	5	crappy	Effect: "Healthy Bronze Glow", Effect Duration: 30
 805	miniature decent stir-fry	2	good	
 806	normal asparagus stir-fry	3	good	
-807	diet stale olive stir-fry	1	decent	
+807	stale diet olive stir-fry	1	decent	
 808	jumbo flavorless Knob sausage stir-fry	5	decent	
 809	enchanted moldy bat wing stir-fry	4	crappy	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 15
 810	normal rat appendix stir-fry	4	good	
-811	miniature adequate tofu stir-fry	2	good	
+811	adequate miniature tofu stir-fry	2	good	
 812	miniature rotten pr0n stir-fry	2	crappy	
 813	normal Knob shells	3	good	
 814	decent b&auml;tzle	3	good	
-815	small flavorless ratini	2	decent	
+815	flavorless small ratini	2	decent	
 816	flavorless ghostly Knob stroganoff	4	decent	
-817	spoiled big special blinking menudo ravioli	5	crappy	Effect: "Squatting and Thrusting", Effect Duration: 45
+817	big special spoiled blinking menudo ravioli	5	crappy	Effect: "Squatting and Thrusting", Effect Duration: 45
 818	plus sign	0		
 819	milky potion	0		
 820	spinning swirly potion	0		
@@ -832,7 +832,7 @@
 839	weak drinkable Maiali Sifilitici Pinot Noir	2	good	Last Available: "2004-10"
 840	spinning scorching hale Mafia violin case	0		Maximum HP: +20, Hot Damage: +25, Last Available: "2004-10"
 841	artisanal spinning tomato daiquiri	3	EPIC	
-842	fancy mediocre irresponsibly strong beertini	6	decent	Effect: "Slippery Tongue", Effect Duration: 35
+842	irresponsibly strong fancy mediocre beertini	6	decent	Effect: "Slippery Tongue", Effect Duration: 35
 843	hand-crafted pulsating salty slug	3	EPIC	
 844	watered-down bad huge papaya slung	2	decent	
 845	MAHI fez of dire peril	0		Weapon Damage: +20, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -841,7 +841,7 @@
 849	Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
 851	prosthetic forehead	0		Familiar Weight: +5
-852	ghostly gray shaker of salt	0		Familiar Weight: +5
+852	gray ghostly shaker of salt	0		Familiar Weight: +5
 853	jittery blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
 855	twirling balloon knife	0		Familiar Weight: +5
@@ -856,7 +856,7 @@
 864	stinger	0		Familiar Weight: +5
 865	skewed lead necklace	0		Familiar Weight: +3
 866	upside-down shaving cream	0		
-867	corrupted galvanized fuchsia upside-down tumbling pine tar	0		Effect: "Provocative Perkiness", Effect Duration: 18
+867	corrupted galvanized tumbling upside-down fuchsia pine tar	0		Effect: "Provocative Perkiness", Effect Duration: 18
 869	blurry forest tears	0		
 870	mansplainer's fetus-smashing club	0		Monster Level: +15
 871	cyan meatcar model	0		Familiar Weight: +5
@@ -870,12 +870,12 @@
 879	quadruple-deionized nitrogenated blue bottle of goofballs	0		Effect: "Arresistible", Effect Duration: 17
 880	disbelief suspenders of James Dean	0		Experience (Moxie): +3
 881	supportive bra of dire peril	0		Weapon Damage: +20
-882	ghostly teal Blatantly Canadian	0		
+882	teal ghostly Blatantly Canadian	0		
 883	maple syrup	1	EPIC	
 884	mirror banded los chinos	0		Damage Absorption: +100, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	upside-down twirling axe of the brute	0		Muscle Percent: +30
 886	leaflet	0		
-887	upside-down maroon leaf	0		
+887	maroon upside-down leaf	0		
 888	maple leaf	0		
 889	balaclava of the wise owl	0		Mysticality: +20, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 890	bland balaclava baklava	3	decent	
@@ -898,7 +898,7 @@
 907	dry Mr. Mediocrebar	0		Effect: "Spooky Hands", Effect Duration: 20
 908	super-tarnished alkaline galvanized wobbly Cold Hots candy	0		Effect: "Ancient Protected", Effect Duration: 57
 909	extra-diffused corrupted Wint-O-Fresh mint	0		Effect: "Slimily Strong", Effect Duration: 42
-910	tasty bite-sized dwarf bread	1	awesome	
+910	bite-sized tasty dwarf bread	1	awesome	
 911	electrified jittery Senior Mints	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 34
 912	adjusted spinning pixellated candy heart	0		Effect: "Quaaaaaaa", Effect Duration: 58
 913	altered galvanized squat skewed kobold	0		Effect: "Impregnabili Tea", Effect Duration: 47
@@ -919,9 +919,9 @@
 928	fuzzy bracelets of the storm	0		Maximum MP Percent: +40
 929	upside-down thinker's arse-shooting crossbow	0		Mysticality: +10
 931	drinkable fortified spiced rum	5	good	
-932	bad weak eggnog	2	decent	
+932	weak bad eggnog	2	decent	
 933	adequate candy cane	4	good	
-934	jumbo rotten gingerbread bugbear	5	crappy	
+934	rotten jumbo gingerbread bugbear	5	crappy	
 935	lightning-fast imitation nice watch	0		Initiative: +40, Single Equip, Last Available: "2004-12"
 936	wobbly Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -936,7 +936,7 @@
 946	fuchsia tumbling skewered lime	0		Last Available: "2004-12"
 947	jittery skewered cherry	0		Last Available: "2004-12"
 948	irresponsibly strong hand-crafted martini	10	EPIC	Last Available: "2004-12"
-949	high-proof acceptable grogtini	7	good	Last Available: "2004-12"
+949	acceptable high-proof grogtini	7	good	Last Available: "2004-12"
 950	drinkable spinning cherry bomb	4	good	Last Available: "2004-12"
 951	twirling extra special Crimbo stocking	0		Last Available: "2004-12"
 952	Jim Carey's smartaleck's hockey mask	0		Moxie Percent: +30, Monster Level: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
@@ -949,7 +949,7 @@
 959	wobbly flange	0		
 960	mirror clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
-962	yellow twirling mirror pulsating velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
+962	twirling yellow mirror pulsating velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	sizzling mansplainer's plastic seal clubber	0		Monster Level: +15, Hot Damage: +10
 964	perfumed double-paned plastic turtle tamer	0		Cold Resistance: +5, Stench Resistance: +5
 965	skewed Herculean plastic pastamancer of extreme caution	0		Experience (Muscle): +1, Monster Level: -25
@@ -988,30 +988,30 @@
 1000	Meat maid	0		
 1002	dog trainer's Xlyinia's notebook	0		Experience (familiar): +1
 1003	soda water	0		
-1004	distilled hand-crafted bottle of tequila	5	EPIC	
-1005	practically non-alcoholic artisanal blinking boxed wine	1	EPIC	
-1006	rotten half-sized cherry	2	crappy	
+1004	hand-crafted distilled bottle of tequila	5	EPIC	
+1005	artisanal practically non-alcoholic blinking boxed wine	1	EPIC	
+1006	half-sized rotten cherry	2	crappy	
 1007	coconut shell of the wise owl	0		Mysticality: +20, Familiar Effect: "1xFairy, cap 7"
 1008	hardened ice cubes	0		Damage Reduction: 3
-1009	acceptable watered-down vodka martini	2	good	
+1009	watered-down acceptable vodka martini	2	good	
 1010	artisanal strong teal whiskey and soda	5	EPIC	
-1011	acceptable fancy monkey wrench	3	good	Effect: "Mucilaginous Mentalism", Effect Duration: 25
-1012	artisanal watered-down upside-down skewed tequila sunrise	2	EPIC	
-1013	delicious watered-down margarita	2	awesome	
-1014	mediocre watered-down strawberry wine	2	decent	
+1011	fancy acceptable monkey wrench	3	good	Effect: "Mucilaginous Mentalism", Effect Duration: 25
+1012	watered-down artisanal skewed upside-down tequila sunrise	2	EPIC	
+1013	watered-down delicious margarita	2	awesome	
+1014	watered-down mediocre strawberry wine	2	decent	
 1015	triple-distilled lousy wine spritzer	8	decent	
 1016	mediocre watered-down narrow perpendicular hula	2	decent	
-1017	watered-down artisanal fancy ducha de oro	2	EPIC	Effect: "Grrrrrrreat!", Effect Duration: 45
-1018	artisanal practically non-alcoholic calle de miel	1	super ultra mega turbo EPIC	
+1017	fancy artisanal watered-down ducha de oro	2	EPIC	Effect: "Grrrrrrreat!", Effect Duration: 45
+1018	practically non-alcoholic artisanal calle de miel	1	super ultra mega turbo EPIC	
 1019	watered-down acceptable dry vodka martini	2	good	
-1020	weak artisanal old-fashioned	2	EPIC	
+1020	artisanal weak old-fashioned	2	EPIC	
 1021	hand-crafted fortified tequila with training wheels	5	EPIC	
-1022	extra-dry lousy sangria	5	decent	
+1022	lousy extra-dry sangria	5	decent	
 1023	lousy vesper	4	decent	Last Available: "2004-12"
 1024	hand-crafted narrow bodyslam	3	super ultra EPIC	Last Available: "2004-12"
 1025	acceptable practically non-alcoholic sangria del diablo	1	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
-1027	tumbling ghostly whip kit	0		
+1027	ghostly tumbling whip kit	0		
 1028	blinking buckler buckle	0		
 1029	blinking crafty hippo whip	0		Maximum MP: +10
 1030	blinking smooth penguin whip	0		Moxie: +15
@@ -1043,7 +1043,7 @@
 1057	vaporized gray puce oyster egg	1		
 1058	boiled blurry puce oyster egg	1		
 1059	puce plastic oyster egg	0		
-1060	compressed cyan tumbling mauve oyster egg	1		
+1060	compressed tumbling cyan mauve oyster egg	1		
 1061	diluted red mauve oyster egg	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 40
 1062	vaporized huge mauve oyster egg	1		Effect: "Carrion' On", Effect Duration: 15
 1063	blinking mauve plastic oyster egg	0		
@@ -1061,7 +1061,7 @@
 1075	purple off-white plastic oyster egg	0		
 1076	dehydrated upside-down oyster egg	1		
 1077	mixed oyster egg	1		
-1078	distilled mirror pulsating oyster egg	1		
+1078	distilled pulsating mirror oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
 1081	ghostly ghostly emo roe	0		Free Pull, Last Available: "2005-04"
@@ -1078,7 +1078,7 @@
 1092	mirror clockwork sheet	0		
 1093	clockwork counterclockwise dome	0		
 1094	clockwork sphere	0		
-1095	green mirror deactivated MicroMechaMech	0		
+1095	mirror green deactivated MicroMechaMech	0		
 1096	shaking clockwork endoskeleton	0		
 1097	jittery clockwork hat of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 20"
 1098	squat energetic clockwork trench coat	0		Maximum MP Percent: +20
@@ -1091,14 +1091,14 @@
 1105	clockwork bartender head	0		
 1106	clockwork chef head	0		
 1107	clockwork maid head	0		
-1108	blinking tumbling clockwork detective skull	0		
+1108	tumbling blinking clockwork detective skull	0		
 1109	clockwork bartender-head-in-the-box	0		
-1110	blinking shaking skewed clockwork chef-head-in-the-box	0		
+1110	shaking blinking skewed clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
 1112	clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
 1114	blurry tisket	0		
-1115	narrow mirror tasket	0		
+1115	mirror narrow tasket	0		
 1116	lime green annoying pitchfork	0		Monster Level: +5
 1117	yellow chilly cool Stupid University Diploma of the cheetah	0		Moxie: +5, Cold Damage: +5, Initiative: +60
 1118	narrow pregnant mushroom	0		
@@ -1123,15 +1123,15 @@
 1137	skewed ghostly perfumed beefcake's bicycle chain	0		Muscle: +25, Stench Resistance: +5
 1138	mushroom fermenting solution	0		
 1139	enchanted hand-crafted mushroom wine	3	EPIC	Effect: "Fury of the Bells", Effect Duration: 30
-1140	fancy bad weak ghostly icy mushroom wine	2	decent	Effect: "Concentration", Effect Duration: 35
-1141	tolerable fancy mushroom wine	3	good	Effect: "Riboflavin'", Effect Duration: 5
+1140	bad fancy weak ghostly icy mushroom wine	2	decent	Effect: "Concentration", Effect Duration: 35
+1141	fancy tolerable mushroom wine	3	good	Effect: "Riboflavin'", Effect Duration: 5
 1142	acceptable huge pointy mushroom wine	4	good	
 1143	lousy flat mushroom wine	4	decent	
 1144	drinkable cool mushroom wine	3	good	
-1145	weak perfectly mixed knob mushroom wine	2	EPIC	
+1145	perfectly mixed weak knob mushroom wine	2	EPIC	
 1146	artisanal blurry knoll mushroom wine	3	EPIC	
 1147	special perfectly mixed mushroom wine	3	EPIC	Effect: "Mer-kinny Flavor", Effect Duration: 45
-1148	lousy weak shot of flower schnapps	2	decent	
+1148	weak lousy shot of flower schnapps	2	decent	
 1149	moldy diet flower petal pie	1	crappy	
 1150	perfectly mixed bouncing bottle of single-barrel whiskey	4	EPIC	
 1151	Temple Grandin's brawny discarded plastic fork	0		Muscle Percent: +20, Familiar Weight: +7
@@ -1160,7 +1160,7 @@
 1175	cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	magnetic field	0		
-1178	upside-down squat potted cactus	0		
+1178	squat upside-down potted cactus	0		
 1179	spinning ghostly daisy	0		
 1180	potted fern	0		
 1181	tulip	0		
@@ -1180,18 +1180,18 @@
 1195	spinning mirror apathetic lizardman doll	0		
 1196	yeti	0		
 1197	yellow Mob Penguin	0		
-1198	tumbling huge sabre-toothed lime	0		
+1198	huge tumbling sabre-toothed lime	0		
 1199	blurry bugbear	0		
-1200	diet spoiled mugcake	1	crappy	
+1200	spoiled diet mugcake	1	crappy	
 1201	miniature decent urinal cake	2	good	
-1202	decent super-sized jittery Happy Birthday, Claude! cake	5	good	
+1202	super-sized decent jittery Happy Birthday, Claude! cake	5	good	
 1203	bland personalized birthday cake	3	decent	
 1204	stale gigantic three-tiered wedding cake	6	decent	
 1205	fancy moldy babycakes	3	crappy	Effect: "Salad Days", Effect Duration: 30
 1206	moldy velvet cake	4	crappy	
 1207	snack-sized adequate congratulatory cake	2	good	
 1208	bland huge angel-food cake	3	decent	
-1209	bite-sized special normal devil's-food cake	1	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 25
+1209	special bite-sized normal devil's-food cake	1	good	Effect: "You Ate Some Hemp Candy", Effect Duration: 25
 1210	super-sized normal wobbly wobbly birthday party jellybean cheesecake	5	good	
 1211	balloon	0		
 1212	pulsating balloon	0		
@@ -1232,13 +1232,13 @@
 1248	ghostly Jim Carey's baleful Bonerdagon necklace of the pedagogue	0		Experience: +3, Spell Damage: +25, Monster Level: +25
 1249	stiffened Boss Bat britches	0		Damage Reduction: 1, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	scandalous Boss Bat bling of the cheetah	0		Sleaze Damage: +5, Initiative: +60
-1251	low-calorie flavorless Knob shroomkabob	1	decent	
+1251	flavorless low-calorie Knob shroomkabob	1	decent	
 1252	adequate shroomkabob	3	good	
 1253	pile of jumping beans	0		
 1254	bland jumping bean burrito	3	decent	
 1255	adequate gigantic jumping bean burrito	7	good	
 1256	moldy snack-sized upside-down insanely jumping bean burrito	2	crappy	
-1257	stale immense rat scrapple	10	decent	
+1257	immense stale rat scrapple	10	decent	
 1258	pail of pretentious paint	0		
 1259	prompt scorching traffic cone	0		Hot Damage: +25, Adventures: +3, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
@@ -1252,7 +1252,7 @@
 1268	blue pine wand	0		
 1269	ebony wand	0		
 1270	hexagonal wand	0		
-1271	narrow yellow aluminum wand	0		
+1271	yellow narrow aluminum wand	0		
 1272	marble wand	0		
 1273	nippy magic lamp	0		Cold Damage: +10
 1274	powdered gray ghostly Medicinal Herb's medicinal herbs	1		
@@ -1283,7 +1283,7 @@
 1299	greedy pirate hook	0		Meat Drop: +20
 1300	personal trainer's monster bait	0		Experience Percent (Muscle): +10, Single Equip
 1301	tarnished nitrogenated dry purple deodorant	0		Effect: "Stimulated Body", Effect Duration: 41
-1302	improved polymerized huge twirling maroon reodorant	0		Effect: "Enraged", Effect Duration: 56
+1302	improved polymerized maroon huge twirling reodorant	0		Effect: "Enraged", Effect Duration: 56
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
@@ -1323,7 +1323,7 @@
 1340	Cloaca-Cola-issue combat knife	0		
 1341	Dyspepsi-Cola-issue canteen of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
 1342	picture of a dead guy's girlfriend	0		
-1343	fuchsia skewed zombie pineal gland	0		Last Available: "2005-11"
+1343	skewed fuchsia zombie pineal gland	0		Last Available: "2005-11"
 1344	pressed Gummi-Gnauga	0		Effect: "Extra-Wet", Effect Duration: 18
 1345	nitrogenated Vulcanized Now and Earlier	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 53, Last Available: "2020-09"
 1346	super-tarnished Sugar Cog	0		Effect: "Elbow Sauce", Effect Duration: 45
@@ -1335,7 +1335,7 @@
 1352	drinkable redrum	4	good	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	diet rotten bowl of oriole's nest soup	1	crappy	
+1355	rotten diet bowl of oriole's nest soup	1	crappy	
 1356	bunny liver	0		
 1357	weak bad Mt. Noob Pale Ale	2	decent	
 1358	pirate zombie head	0		Last Available: "2005-11"
@@ -1345,7 +1345,7 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	mirror rhesus monkey	0		Familiar Weight: +5
-1365	moldy half-sized fancy tofurkey leg	2	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 40
+1365	half-sized moldy fancy tofurkey leg	2	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 40
 1366	big delicious bouncing tofurkey gravy	5	awesome	
 1367	normal herbal stuffing	3	good	
 1368	stale enchanted can-shaped gelatinous cranberry sauce	3	decent	Effect: "A View to Some Meat", Effect Duration: 50
@@ -1390,9 +1390,9 @@
 1408	normal tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign	0		Item Drop: +5, Last Available: "2005-12"
 1410	squat sleeping snowy owl	0		Last Available: "2005-12"
-1411	olive Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1411	olive Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	corrupted ghostly snowcone	0		Effect: "Serenity", Effect Duration: 65, Last Available: "2006-01"
-1413	polarized narrow upside-down blurry snowcone	0		Effect: "Locks Like the Raven", Effect Duration: 30, Last Available: "2006-01"
+1413	polarized blurry narrow upside-down snowcone	0		Effect: "Locks Like the Raven", Effect Duration: 30, Last Available: "2006-01"
 1414	magnetized activated tumbling spinning snowcone	0		Effect: "Ham-Fisted", Effect Duration: 60, Last Available: "2006-01"
 1415	concentrated alkaline snowcone	0		Effect: "Unusual Perspective", Effect Duration: 34, Last Available: "2006-01"
 1416	magnetized ionized upside-down snowcone	0		Effect: "Buzzard Breath", Effect Duration: 64, Last Available: "2006-01"
@@ -1411,7 +1411,7 @@
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	bouncing pregnant mushroom	0		
-1432	bite-sized normal mushroom	1	good	
+1432	normal bite-sized mushroom	1	good	
 1433	fruit bowl	0		
 1434	shaking fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1437,7 +1437,7 @@
 1455	boiled sleaze wad	1		Effect: "The Style... of the Future", Effect Duration: 5
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	half-sized decent blinking Valentine's Day cake	2	good	
+1458	decent half-sized blinking Valentine's Day cake	2	good	
 1459	arrow'd heart balloon	0		
 1460	blinking velvet box	0		
 1461	squashed frog	0		
@@ -1455,7 +1455,7 @@
 1473	ball-and-chain	0		
 1474	automatic catapult	0		
 1475	olive pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	skewed twirling goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	twirling skewed goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	pulsating salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	football helmet	0		Familiar Effect: "atk, cap 37"
@@ -1475,9 +1475,9 @@
 1493	cyan sharpshooter's ridiculously overelaborate ninja weapon of vim and vigor	0		Maximum HP Percent: +50, Critical Hit Percent: +10
 1494	concentrated anodized jittery sugar-coated pine cone	0		Effect: "There Wolf", Effect Duration: 16, Last Available: "2020-09"
 1495	zippy dance instructor's traffic cone	0		Experience Percent (Moxie): +10, Initiative: +20, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	bad triple-distilled gray gloomy mushroom wine	7	decent	
+1496	triple-distilled bad gray gloomy mushroom wine	7	decent	
 1497	hand-crafted bouncing mushroom wine	3	EPIC	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	oxidized polymerized explosion-flavored chewing gum	0		Effect: "Rage of the Reindeer", Effect Duration: 18, Last Available: "2006-04"
@@ -1494,7 +1494,7 @@
 1512	vaporized squat wobbly Knob Goblin pet-buffing spray	1		
 1513	mixed Knob Goblin learning pill	1		
 1514	denatured blinking Knob Goblin eyedrops	1		
-1515	compressed narrow narrow purple tumbling Knob Goblin nasal spray	1		
+1515	compressed narrow purple tumbling narrow Knob Goblin nasal spray	1		
 1516	KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1530,11 +1530,11 @@
 1550	crafty second-hand knockoff engagement ring	0		Maximum MP: +10, Single Equip
 1551	drinkable watered-down bottle of Domesticated Turkey	2	good	
 1552	special acceptable bottle of Definit	3	good	Effect: "Bark of the Dog", Effect Duration: 30
-1553	watered-down lousy bottle of Calcutta Emerald	2	decent	
+1553	lousy watered-down bottle of Calcutta Emerald	2	decent	
 1554	watered-down acceptable bottle of Lieutenant Freeman	2	good	
 1555	bad bottle of Jorge Sinsonte	3	decent	
 1556	hand-crafted boxed champagne	3	EPIC	
-1557	moldy huge kumquat	9	crappy	
+1557	huge moldy kumquat	9	crappy	
 1558	moldy teal tangerine	3	crappy	
 1559	jittery tonic water	0		
 1560	small normal ghostly cocktail onion	2	good	
@@ -1542,25 +1542,25 @@
 1562	decent kiwi	3	good	
 1563	acceptable squat whiskey bittersweet	4	good	
 1564	drinkable watered-down skewed mimosette	2	good	
-1565	irresponsibly strong aged tequila sunset	9	awesome	
+1565	aged irresponsibly strong tequila sunset	9	awesome	
 1566	artisanal zmobie	3	EPIC	Wiki Name: "Zmobie (drink)"
 1567	smooth gin and tonic	4	awesome	
 1568	weak fancy acceptable fuchsia vodka and tonic	2	good	Effect: "Fireproof Lips", Effect Duration: 35
 1569	bad vodka gibson	4	decent	
 1570	bad twirling gibson	4	decent	
-1571	tolerable watered-down parisian cathouse	2	good	
+1571	watered-down tolerable parisian cathouse	2	good	
 1572	mediocre rabbit punch	4	decent	
 1573	drinkable jittery blinking caipifruta	4	good	
-1574	smooth practically non-alcoholic teqiwila	1	awesome	
+1574	practically non-alcoholic smooth teqiwila	1	awesome	
 1575	acceptable Divine	3	good	
 1576	high-proof tolerable Gordon Bennett	6	good	
 1577	delicious tangarita	3	awesome	
-1578	lousy fortified jittery mandarina colada	5	decent	
+1578	fortified lousy jittery mandarina colada	5	decent	
 1579	tolerable gimlet	4	good	
-1580	practically non-alcoholic hand-crafted brick road	1	super ultra mega turbo EPIC	
-1581	acceptable special watered-down vodka stratocaster	2	good	Effect: "Deeply Ironic", Effect Duration: 45
+1580	hand-crafted practically non-alcoholic brick road	1	super ultra mega turbo EPIC	
+1581	watered-down acceptable special vodka stratocaster	2	good	Effect: "Deeply Ironic", Effect Duration: 45
 1582	delicious Neuromancer	4	awesome	
-1583	acceptable fortified jittery maroon prussian cathouse	5	good	
+1583	fortified acceptable jittery maroon prussian cathouse	5	good	
 1584	special watered-down lousy Mae West	2	decent	Effect: "Soles of Glass", Effect Duration: 40
 1585	acceptable Mon Tiki	4	good	
 1586	perfectly mixed teqiwila slammer	3	EPIC	
@@ -1570,9 +1570,9 @@
 1590	normal skewed lo mein	3	good	
 1591	yummy cyan olive lo mein	4	awesome	
 1592	toothsome hot hi mein	3	awesome	
-1593	stale gigantic pulsating hi mein	7	decent	
-1594	bland special spinning hi mein	3	decent	Effect: "Flamibili Tea", Effect Duration: 10
-1595	diet delicious twirling hi mein	1	awesome	
+1593	gigantic stale pulsating hi mein	7	decent	
+1594	special bland spinning hi mein	3	decent	Effect: "Flamibili Tea", Effect Duration: 10
+1595	delicious diet twirling hi mein	1	awesome	
 1596	normal huge sleazy hi mein	4	good	
 1597	greasy Junior LAAAAME merit badge	0		Sleaze Spell Damage: +10, Last Available: "2006-05"
 1598	Senior LAAAAME merit badge of the brute	0		Muscle Percent: +30, Last Available: "2006-05"
@@ -1604,7 +1604,7 @@
 1624	ionized extra-oxidized dry squat blue-frosted astral cupcake	0		Effect: "Certainty", Effect Duration: 29, Last Available: "2006-06"
 1625	electrified green-frosted astral cupcake	0		Effect: "Ruby-ous", Effect Duration: 35, Last Available: "2006-06"
 1626	boiled anodized aerosolized orange-frosted astral cupcake	0		Effect: "Snobby", Effect Duration: 40, Last Available: "2006-06"
-1627	triple-warmed pickled tumbling purple purple-frosted astral cupcake	0		Effect: "Metal Speed", Effect Duration: 50, Last Available: "2006-06"
+1627	triple-warmed pickled purple tumbling purple-frosted astral cupcake	0		Effect: "Metal Speed", Effect Duration: 50, Last Available: "2006-06"
 1628	modified super-liquefied pink-frosted astral cupcake	0		Effect: "critical.enh", Effect Duration: 62, Last Available: "2006-06"
 1629	raspberry beret of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	wobbly smartaleck's pixel shield	0		Moxie Percent: +30, Damage Reduction: 3
@@ -1615,10 +1615,10 @@
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	quantum corrupted lotion of hotness	0		Effect: "You're Not Cooking", Effect Duration: 32
-1638	vacuum-sealed deionized spinning blinking lotion of coldness	0		Effect: "Prelude of Precision", Effect Duration: 12
+1638	vacuum-sealed deionized blinking spinning lotion of coldness	0		Effect: "Prelude of Precision", Effect Duration: 12
 1639	anodized lotion of spookiness	0		Effect: "Starry-Eyed", Effect Duration: 20
 1640	magnetized vacuum-sealed huge lotion of stench	0		Effect: "Seriously Mutated", Effect Duration: 23
-1641	vacuum-sealed ghostly skewed lotion of sleaziness	0		Effect: "Thanksgot", Effect Duration: 26
+1641	vacuum-sealed skewed ghostly lotion of sleaziness	0		Effect: "Thanksgot", Effect Duration: 26
 1642	practically non-alcoholic bad Grimacite Bock	1	decent	Last Available: "2008-11"
 1643	moldy narrow wedge of gray cheese	4	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
@@ -1673,10 +1673,10 @@
 1693	deionized double-frozen eyedrops of newt	0		Effect: "Transcendental Wind", Effect Duration: 69
 1694	diffused enhanced yellow Frogade	0		Effect: "Puddingskin", Effect Duration: 56
 1695	frozen wobbly papotion of papower	0		Effect: "Voracious Gorging", Effect Duration: 37
-1696	fancy adequate royal jelly taco	3	good	Effect: "Painted-On Bikini", Effect Duration: 30
-1697	normal half-sized special tofu taco	2	good	Effect: "New Zeal", Effect Duration: 40
-1698	diet enchanted flavorless jumping bean taco	1	decent	Effect: "Wolf's Bane", Effect Duration: 45
-1699	jumbo normal huge catgut taco	5	good	
+1696	adequate fancy royal jelly taco	3	good	Effect: "Painted-On Bikini", Effect Duration: 30
+1697	special half-sized normal tofu taco	2	good	Effect: "New Zeal", Effect Duration: 40
+1698	flavorless diet enchanted jumping bean taco	1	decent	Effect: "Wolf's Bane", Effect Duration: 45
+1699	normal jumbo huge catgut taco	5	good	
 1700	rotten goat cheese taco	3	crappy	
 1701	decent pr0n taco	4	good	
 1702	tarnished ionized green blinking alphabet gum	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 42
@@ -1759,14 +1759,14 @@
 1780	shaking blurry Jeselnik's ram stick	0		Sleaze Damage: +25
 1781	double-paned enchantlers	0		Cold Resistance: +5, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	Herculean ram-battering staff of the brazier	0		Experience (Muscle): +1, Hot Spell Damage: +25
-1783	moldy snack-sized enchanted crazy Turkish delight	2	crappy	Effect: "Sludgesick", Effect Duration: 25
+1783	snack-sized enchanted moldy crazy Turkish delight	2	crappy	Effect: "Sludgesick", Effect Duration: 25
 1784	padded Snow Queen Crown of mayonnaise	0		Damage Absorption: +20, Sleaze Spell Damage: +50, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	thinker's ga-ga radio of the bloodbag of Gandalf	0		Mysticality: +10, Maximum HP: +100, Spell Critical Percent: +20
 1786	upside-down six pack of Mountain Stream	0		
 1787	pressed adjusted mirror bag of Cheat-Os	0		Effect: "Reedy Pipes", Effect Duration: 66
 1788	unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	weak perfectly mixed Ram's Face Lager	2	EPIC	
+1790	perfectly mixed weak Ram's Face Lager	2	EPIC	
 1791	skewed ram horns	0		
 1792	miser's horrifying Lo Pan's Travoltan trousers	0		Spell Critical Percent: +30, Spooky Damage: +25, Meat Drop: +10, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	resourceful pool cue of the cougar	0		Moxie: +20, Maximum MP: +50
@@ -1774,7 +1774,7 @@
 1795	mirror Counterclockwise Watch of Flo-Jo	0		Initiative: +100, Single Equip
 1796	bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
-1798	blurry blinking pile of animal bones	0		
+1798	blinking blurry pile of animal bones	0		
 1799	animal skull	0		
 1800	animal cranium	0		
 1801	spinning animal jawbone	0		
@@ -1792,7 +1792,7 @@
 1813	fifth thoracic vertebra	0		
 1814	sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
-1816	olive wobbly upside-down eighth thoracic vertebra	0		
+1816	upside-down wobbly olive eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	huge huge tenth thoracic vertebra	0		
 1819	ghostly eleventh thoracic vertebra	0		
@@ -1859,7 +1859,7 @@
 1880	jittery left kneecap	0		
 1881	fuchsia right kneecap	0		
 1882	left first front claw	0		
-1883	cyan huge left second front claw	0		
+1883	huge cyan left second front claw	0		
 1884	left third front claw	0		
 1885	left fourth front claw	0		
 1886	right first front claw	0		
@@ -1891,7 +1891,7 @@
 1914	clockwork rod	0		
 1915	red clockwork shank	0		
 1916	olive Lord Spookyraven's spectacles	0		
-1917	twirling red wallet	0		
+1917	red twirling wallet	0		
 1918	ghostly coin purse	0		
 1919	English to A. F. U. E. Dictionary	0		
 1920	bizarre illegible sheet music	0		
@@ -1923,19 +1923,19 @@
 1946	pulsating razor-sharp accordion pin of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +25, Class: "Accordion Thief", Single Equip
 1947	clever stylish worn tophat	0		Moxie: +25, Maximum MP: +20, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	green skewed wool Jeselnik's tap shoes	0		Sleaze Damage: +25, Cold Resistance: +1, Single Equip
-1949	huge adequate Manetwich	10	good	
+1949	adequate huge Manetwich	10	good	
 1950	upside-down bottle of Vangoghbitussin	0		
 1951	perfectly mixed bottle of Pinot Renoir	4	EPIC	
-1952	adequate massive pulsating desiccated apricot	7	good	
-1953	high-proof perfectly mixed flute of flat champagne	7	EPIC	
-1954	half-sized flavorless upside-down bouncing dehydrated caviar	2	decent	
+1952	massive adequate pulsating desiccated apricot	7	good	
+1953	perfectly mixed high-proof flute of flat champagne	7	EPIC	
+1954	flavorless half-sized upside-down bouncing dehydrated caviar	2	decent	
 1955	styrofoam peanuts	0		
 1956	tolerable snifter of thoroughly aged brandy	4	good	
 1957	shaking quill pen	0		
 1958	inkwell	0		
-1959	fuchsia blinking tattered scrap of paper	0		
+1959	blinking fuchsia tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
-1961	upside-down cyan can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
+1961	cyan upside-down can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	frozen fuchsia Bit O' Ectoplasm	0		Effect: "Crimbo Epiphany", Effect Duration: 69
 1963	dance card	0		
 1964	vibrating opera mask	0		Maximum MP Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
@@ -1965,7 +1965,7 @@
 1988	fuchsia wobbly angry cow	0		
 1989	Cheshire bitten	0		
 1990	wobbly yo-yo	0		
-1991	spinning huge rubber WWJD? bracelet	0		
+1991	huge spinning rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
 1993	wobbly rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
@@ -1981,7 +1981,7 @@
 2004	Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	fuchsia Poison Oak trading card	0		
-2007	narrow jittery purple Princess Rutabaga trading card	0		
+2007	purple jittery narrow Princess Rutabaga trading card	0		
 2008	spinning Roo trading card	0		
 2009	huge Woldo trading card	0		
 2010	The Snake trading card	0		
@@ -1999,10 +1999,10 @@
 2022	moldy jittery lemon meringue pie	4	crappy	
 2023	Genalen&trade; Bottle	1	good	
 2024	delicious cyan mixed wildflower greens	4	awesome	
-2025	small spoiled skewed handful of walnuts	2	crappy	
+2025	spoiled small skewed handful of walnuts	2	crappy	
 2026	flavorless spinning nutty organic salad	4	decent	
 2027	thick adequate ghostly super salad	5	good	
-2028	yummy bite-sized skewed tofu wonton	1	awesome	
+2028	bite-sized yummy skewed tofu wonton	1	awesome	
 2029	hippy protest button	0		Single Equip
 2030	greasy healthy Lockenstock&trade; sandals	0		Maximum HP Percent: +20, Sleaze Spell Damage: +10, Single Equip
 2031	dance instructor's didgeridooka	0		Experience Percent (Moxie): +10
@@ -2011,7 +2011,7 @@
 2034	wicker shield of the blizzard	0		Cold Spell Damage: +25, Damage Reduction: 11
 2035	shaking blue Marquis de Poivre soda	0		
 2036	unsweetened moist magnetized skewed skewed radium-flavored potato chips	0		Effect: "Mariachi Mood", Effect Duration: 40
-2037	colloidal extra-pickled bouncing squat wintergreen-flavored potato chips	0		Effect: "Compensatory Cruelness", Effect Duration: 23
+2037	colloidal extra-pickled squat bouncing wintergreen-flavored potato chips	0		Effect: "Compensatory Cruelness", Effect Duration: 23
 2038	pickled extra-modified ennui-flavored potato chips	0		Effect: "Mental A-cue-ity", Effect Duration: 36
 2039	jittery x-ray specs	0		Last Available: "2011-12"
 2040	bouncing patchouli oil bomb	0		
@@ -2020,8 +2020,8 @@
 2043	shaking hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	spoiled mirror purple brain-meltingly-hot chicken wings	3	crappy	
-2046	special decent frat brats	3	good	Effect: "Riboflavin'", Effect Duration: 35
-2047	immense decent knob ka-bobs	8	good	
+2046	decent special frat brats	3	good	Effect: "Riboflavin'", Effect Duration: 35
+2047	decent immense knob ka-bobs	8	good	
 2049	artisanal can of Swiller	3	EPIC	
 2050	spinning broken wings	0		
 2051	sunken eyes	0		
@@ -2122,11 +2122,11 @@
 2147	jittery evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	big bland frank	5	decent	Last Available: "2011-12"
-2150	spoiled massive plate of franks and beans	10	crappy	Last Available: "2011-12"
+2150	massive spoiled plate of franks and beans	10	crappy	Last Available: "2011-12"
 2151	acceptable shot of blackberry schnapps	3	good	
 2152	bouncing capacitor relay	0		Last Available: "2011-12"
 2153	blurry carbon nanotube frame	0		Last Available: "2011-12"
-2154	bouncing fuchsia ion grid	0		Last Available: "2011-12"
+2154	fuchsia bouncing ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
@@ -2164,11 +2164,11 @@
 2189	hand-crafted flask of peppermint schnapps	4	EPIC	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
-2192	narrow blinking maroon sheet music	0		Last Available: "2006-12"
-2193	flavorless gigantic candy stake	6	decent	Last Available: "2006-12"
+2192	maroon blinking narrow sheet music	0		Last Available: "2006-12"
+2193	gigantic flavorless candy stake	6	decent	Last Available: "2006-12"
 2194	hand-crafted eggnog	3	EPIC	Last Available: "2006-12"
-2195	stale huge unspeakable fruitcake	9	decent	Last Available: "2006-12"
-2196	normal low-calorie gingerbread horror	1	good	Last Available: "2006-12"
+2195	huge stale unspeakable fruitcake	9	decent	Last Available: "2006-12"
+2196	low-calorie normal gingerbread horror	1	good	Last Available: "2006-12"
 2197	aerosolized modified shaking but probably evil chocolate	0		Effect: "Bread-Lined", Effect Duration: 19, Last Available: "2006-12"
 2198	rotten bat-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	spoiled huge skull-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2204,7 +2204,7 @@
 2229	nitrogenated dry denatured toad horn	0		Effect: "Biologically Shocked", Effect Duration: 34, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	teal mote	0		
-2232	gray squat smudged alchemical recipe	0		
+2232	squat gray smudged alchemical recipe	0		
 2233	bow tie of bravery	0		Spooky Resistance: +5, Clowniness: 75
 2234	skewed curative calavera concertina	0		HP Regen Min: 3, HP Regen Max: 5, Song Duration: 7
 2235	perfumed ratarang of the empath	0		Familiar Weight: +5, Stench Resistance: +5
@@ -2240,13 +2240,13 @@
 2266	wet stunt nut stew	0		
 2267	squat Mega Gem	0		
 2268	aromatic Staff of Fats	0		Stench Resistance: +1
-2269	miniature bland sausage wonton	2	decent	
+2269	bland miniature sausage wonton	2	decent	
 2270	stiffened forbidden belt	0		Spell Damage Percent: +50, Damage Reduction: 1, Single Equip
 2271	lousy bottle of Merlot	3	decent	
-2272	practically non-alcoholic drinkable bottle of Port	1	good	
-2273	perfectly mixed weak bottle of Pinot Noir	2	EPIC	
+2272	drinkable practically non-alcoholic bottle of Port	1	good	
+2273	weak perfectly mixed bottle of Pinot Noir	2	EPIC	
 2274	tolerable bottle of Zinfandel	4	good	
-2275	hand-crafted fortified olive bottle of Marsala	5	EPIC	
+2275	fortified hand-crafted olive bottle of Marsala	5	EPIC	
 2276	bad weak bottle of Muscat	2	decent	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2274,7 +2274,7 @@
 2300	ghostly squat fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	twirling spinning worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	double-moist candy heart	0		Effect: "Frozen Hands", Effect Duration: 53, Last Available: "2007-02"
 2305	unsweetened pink candy heart	0		Effect: "Human-Elemental Hybrid", Effect Duration: 21, Last Available: "2007-02"
 2306	tarnished narrow candy heart	0		Effect: "PERL of Great Price", Effect Duration: 66, Last Available: "2007-02"
@@ -2282,7 +2282,7 @@
 2308	polymerized candy heart	0		Effect: "Stemonitis Storm", Effect Duration: 34, Last Available: "2007-02"
 2309	aerosolized corrupted candy heart	0		Effect: "Rushtacean'", Effect Duration: 69, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
-2311	wobbly twirling jittery pink candygram	0		Last Available: "2007-02"
+2311	wobbly jittery twirling pink candygram	0		Last Available: "2007-02"
 2312	candygram	0		Last Available: "2007-02"
 2313	candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
@@ -2295,7 +2295,7 @@
 2321	upside-down worm-riding manual page 2	0		
 2322	worm-riding manual pages 3-15	0		
 2323	blinking headpiece of the Staff of Ed	0		
-2324	wobbly yellow Staff of Ed, almost	0		
+2324	yellow wobbly Staff of Ed, almost	0		
 2325	narrow Staff of Ed	0		
 2326	stone rose	0		
 2327	aerosolized quantum unsweetened can of paint	0		Effect: "Briny Blood", Effect Duration: 60
@@ -2313,7 +2313,7 @@
 2339	mediocre triple-distilled jittery Blackfly Chardonnay	7	decent	
 2340	tolerable & tan	3	good	
 2341	blue shaking pepper	0		
-2342	spoiled half-sized forest cake	2	crappy	
+2342	half-sized spoiled forest cake	2	crappy	
 2343	spoiled twirling forest ham	3	crappy	
 2344	activated jittery filthworm hatchling scent gland	0		Effect: "Bored Stiff", Effect Duration: 30
 2345	quantum quadruple-anodized corrupted wobbly filthworm drone scent gland	0		Effect: "What's That Smell?", Effect Duration: 19
@@ -2395,10 +2395,10 @@
 2421	magnetized bottle of pirate juice	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 62
 2422	improved anodized blue skewed irradiated pet snacks	0		Effect: "Compensatory Cruelness", Effect Duration: 55
 2423	non-improved tarnished unsweetened bouncing Mick's IcyVapoHotness Inhaler	0		Effect: "Rave Concentration", Effect Duration: 13
-2424	unsweetened pressed cold-filtered lime green jittery cyclops eyedrops	0		Effect: "Crimbo Flavor", Effect Duration: 16
+2424	unsweetened pressed cold-filtered jittery lime green cyclops eyedrops	0		Effect: "Crimbo Flavor", Effect Duration: 16
 2425	anodized alkaline blinking can of spinach	0		Effect: "Stick Emporium Membership", Effect Duration: 58
 2426	diffused wobbly fire flower	0		Effect: "Concentration", Effect Duration: 27
-2427	wet alkaline blurry skewed freezerburned ice cube	0		Effect: "Frog In Your Throat", Effect Duration: 13
+2427	wet alkaline skewed blurry freezerburned ice cube	0		Effect: "Frog In Your Throat", Effect Duration: 13
 2428	ionized fake blood	0		Effect: "In Tuna", Effect Duration: 42
 2429	non-energized Vulcanized Eau de Guaneau	0		Effect: "The Magic of LOV", Effect Duration: 63
 2430	nitrogenated bag of lard	0		Effect: "Grumpy and Ornery", Effect Duration: 64
@@ -2409,10 +2409,10 @@
 2435	magnetized tumbling Dogsgotnonoz pills	0		Effect: "Memory of Attractiveness", Effect Duration: 28
 2436	diffused altered ghostly donkey flipbook	0		Effect: "Lemony Goodness", Effect Duration: 54
 2437	blinking New Cloaca-Cola	0		
-2438	spinning wobbly scented massage oil	0		
+2438	wobbly spinning scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
-2441	narrow gray Knob Goblin Encryption Key	0		
+2441	gray narrow Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	smelly Newton's pink glowstick	0		Experience (Mysticality): +3, Stench Spell Damage: +10, Last Available: "2007-03"
 2444	bad Supernova Champagne	3	decent	
@@ -2461,7 +2461,7 @@
 2488	blurry Annie Oakley's yak anorak	0		Critical Hit Percent: +20
 2489	stanky tuxedo shirt	0		Stench Spell Damage: +25
 2490	horrifying Herculean gnauga hide vest	0		Experience (Muscle): +1, Spooky Damage: +25
-2491	narrow ghostly shirt kit	0		
+2491	ghostly narrow shirt kit	0		
 2492	tropical orchid	0		
 2493	stick of dynamite	0		
 2494	Necrotelicomnicon of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15
@@ -2490,27 +2490,27 @@
 2517	miser's chain necklace of Leguizamo	0		Monster Level: +20, Meat Drop: +10
 2518	huge toasty sawblade shield	0		Hot Damage: +5, Damage Reduction: 11
 2519	drinkable watered-down cyan McMillicancuddy's Special Lager	2	good	
-2520	acceptable green skewed melted Jell-o shot	4	good	
-2521	lousy practically non-alcoholic green ghostly cruelty-free wine	1	decent	
+2520	acceptable skewed green melted Jell-o shot	4	good	
+2521	practically non-alcoholic lousy green ghostly cruelty-free wine	1	decent	
 2522	hand-crafted thistle wine	3	EPIC	
 2523	green megatofu	0		
 2524	huge displaced fish	0		
 2525	delicious fancy fish	4	awesome	Effect: "Carrrsmic", Effect Duration: 20
 2526	small stale fish casserole	2	decent	
-2527	fancy half-sized decent mirror teal fish lasagna	2	good	Effect: "Ooh, Sour!", Effect Duration: 50
+2527	fancy half-sized decent teal mirror fish lasagna	2	good	Effect: "Ooh, Sour!", Effect Duration: 50
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	bland squat gnatloaf	4	decent	
-2530	bland jittery red gnatloaf casserole	3	decent	
+2530	bland red jittery gnatloaf casserole	3	decent	
 2531	low-calorie moldy gnat lasagna	1	crappy	
 2532	pork	0		
-2533	decent immense pork chop sandwiches	6	good	
+2533	immense decent pork chop sandwiches	6	good	
 2534	jumbo moldy wobbly pork casserole	5	crappy	
 2535	spoiled pork lasagna	4	crappy	
 2536	canopic jar	0		
 2537	spice	0		
 2538	organs	0		
 2539	foul-smelling Ankh of Badahnkadh	0		Stench Damage: +10, Single Equip
-2540	lime green blurry tomb ratchet	0		
+2540	blurry lime green tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	colloidal pulsating lesser grodulated violet	0		Effect: "Greasy Visage", Effect Duration: 29, Last Available: "2007-05"
 2543	corrupted concentrated blurry tin magnolia	0		Effect: "Perfect Hair", Effect Duration: 33, Last Available: "2007-05"
@@ -2546,24 +2546,24 @@
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	blinking ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
-2576	mirror pulsating honey-dipped locust	0		
+2576	pulsating mirror honey-dipped locust	0		
 2577	steel-toed educational cactus quill	0		Experience: +1, Damage Reduction: 9
 2578	sizzling Da Vinci's Staff of the Short Order Cook of the sewer	0		Experience (Mysticality): +5, Hot Damage: +10, Stench Damage: +25
-2579	yummy low-calorie cactus fruit	1	awesome	
+2579	low-calorie yummy cactus fruit	1	awesome	
 2580	mirror ruddy savvy scorpion whip	0		Mysticality Percent: +20, Maximum HP Percent: +40
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	moldy half-sized centipede eggs	2	crappy	
+2583	half-sized moldy centipede eggs	2	crappy	
 2584	upside-down double-paned wonderwall shield	0		Cold Resistance: +5, Damage Reduction: 12
 2585	double-paned Colonel Mustard's Lonely Spades Club Jacket	0		Cold Resistance: +5
 2586	green Newton's General Sage's Lonely Diamonds Club Jacket	0		Experience (Mysticality): +3
 2587	baleful Corporal Fennel's Lonely Clubs Club Jacket	0		Spell Damage: +25
 2588	upside-down Private Pepper's Lonely Hearts Club Jacket of horror	0		Spooky Spell Damage: +25
-2589	bland immense huge hot date	9	decent	
+2589	immense bland huge hot date	9	decent	
 2590	perfectly mixed distilled fortified wine	3	EPIC	
-2591	moldy half-sized tasty tart	2	crappy	
+2591	half-sized moldy tasty tart	2	crappy	
 2592	green Knob Goblin lunchbox	0		
-2593	half-sized stale Knob pasty	2	decent	
+2593	stale half-sized Knob pasty	2	decent	
 2594	tolerable thermos full of Knob coffee	4	good	
 2595	electrified aerosolized mirror Ben-Gal&trade; Balm	0		Effect: "Nightlit", Effect Duration: 56
 2596	leathery cat skin	0		
@@ -2573,7 +2573,7 @@
 2600	upside-down carbonated water lily	0		
 2601	nippy vibrating forbidden Staff of the Midnight Snack	0		Spell Damage Percent: +50, Maximum MP Percent: +10, Cold Damage: +10
 2602	baleful strapping Staff of Blood and Pudding of Calamity Jane	0		Muscle: +5, Spell Damage: +25, Critical Hit Percent: +15
-2603	spinning shaking smoldering box	0		
+2603	shaking spinning smoldering box	0		
 2604	censurious Tuesday's ruby	0		Sleaze Resistance: +3
 2605	palm frond	0		
 2606	tumbling palm-frond fan	0		
@@ -2617,7 +2617,7 @@
 2644	twirling feather	0		
 2645	feather	0		
 2646	blue frightful feather	0		
-2647	blue huge fetid feather	0		
+2647	huge blue fetid feather	0		
 2648	flirtatious feather	0		
 2649	tumbling Lord Spookyraven's ear trumpet of wisdom	0		Mysticality: +15, Single Equip
 2650	huge bottled pixie	0		Free Pull
@@ -2627,11 +2627,11 @@
 2654	watered-down acceptable Xanadian	2	good	Last Available: "2007-06"
 2655	triple-irradiated bottle of absinthe	0		Effect: "Spooky Jellied", Effect Duration: 31, Last Available: "2007-06"
 2656	educational Drowsy Sword of doom	0		Experience: +1, Spooky Spell Damage: +50
-2657	tiny bland escargotsicle	1	decent	Last Available: "2007-06"
+2657	bland tiny escargotsicle	1	decent	Last Available: "2007-06"
 2658	artisanal bottle of realpagne	4	EPIC	Last Available: "2007-06"
 2659	brainy albatross necklace	0		Mysticality: +5, Single Equip, Last Available: "2007-06"
 2660	diluted not-a-pipe	1	good	Last Available: "2007-06"
-2661	watered-down artisanal enchanted squat flask of Amontillado	2	EPIC	Effect: "Ooh, Bitter!", Effect Duration: 40, Last Available: "2007-06"
+2661	artisanal watered-down enchanted squat flask of Amontillado	2	EPIC	Effect: "Ooh, Bitter!", Effect Duration: 40, Last Available: "2007-06"
 2662	jittery personal trainer's ball mask	0		Experience Percent (Muscle): +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	teal auspicious Can-Can skirt	0		Item Drop: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	wet sensitive poetry journal	0		Effect: "Human-Demon Hybrid", Effect Duration: 62, Last Available: "2007-06"
@@ -2641,9 +2641,9 @@
 2668	compressed mirror can-can-in-a-can	1		Last Available: "2007-06"
 2669	twisted blurry twirling patent antipsychotics	1		Effect: "World's Shortest Giant", Effect Duration: 20, Last Available: "2007-06"
 2670	vaporized Mariner's Friend cough drops	1		Effect: "Ready to Snap", Effect Duration: 30, Last Available: "2007-06"
-2671	artisanal ghostly bouncing maroon shot of nepenthe schnapps	4	EPIC	Last Available: "2007-06"
+2671	artisanal bouncing ghostly maroon shot of nepenthe schnapps	4	EPIC	Last Available: "2007-06"
 2672	blinking mirror library card	0		Last Available: "2007-06"
-2673	teal squat Bohemian rhapsody	0		Last Available: "2007-06"
+2673	squat teal Bohemian rhapsody	0		Last Available: "2007-06"
 2674	unsweetened blue bottle of cat tonic	0		Effect: "Gummi Badass", Effect Duration: 58, Last Available: "2007-06"
 2675	powdered blurry handful of moss	1		
 2676	twisted bit-o-cactus	1		
@@ -2694,16 +2694,16 @@
 2721	family-friendly Lo Pan's Rosewater's hand-carved staff	0		Mysticality Percent: +30, Spell Critical Percent: +30, Sleaze Resistance: +1
 2722	greedy horrifying flame-wreathed MacGyver's Staff of the Greasefire	0		Maximum MP: +100, Hot Spell Damage: +10, Spooky Damage: +25, Meat Drop: +20
 2723	skewed family-friendly sinister weightlifter's Staff of the Grand Flamb&eacute;	0		Muscle: +15, Spell Damage: +10, Sleaze Resistance: +1
-2724	bland fancy jittery bowl of rye sprouts	3	decent	Effect: "Elemental Saucesphere", Effect Duration: 10
-2725	small normal cob of corn	2	good	
-2726	thick special stale juniper berries	5	decent	Effect: "Fastbreaker", Effect Duration: 15
+2724	fancy bland jittery bowl of rye sprouts	3	decent	Effect: "Elemental Saucesphere", Effect Duration: 10
+2725	normal small cob of corn	2	good	
+2726	special stale thick juniper berries	5	decent	Effect: "Fastbreaker", Effect Duration: 15
 2727	moldy plum	3	crappy	
 2728	normal half-sized pear	2	good	
 2729	moldy peach	3	crappy	
 2730	tolerable blurry plum wine	4	good	
 2731	strong lousy shot of pear schnapps	5	decent	
 2732	bad irresponsibly strong jittery shot of peach schnapps	9	decent	
-2733	yummy enchanted bunch of square grapes	3	awesome	Effect: "Ooh, Umami!", Effect Duration: 10
+2733	enchanted yummy bunch of square grapes	3	awesome	Effect: "Ooh, Umami!", Effect Duration: 10
 2734	small rotten brown sugar cane	2	crappy	
 2735	flavorless shaking sandwich of the gods	3	decent	
 2736	mediocre Pan-Dimensional Gargle Blaster	3	decent	
@@ -2715,7 +2715,7 @@
 2742	decent diet bouncing steel lasagna	1	quest	
 2743	smooth steel margarita	4	quest	
 2744	boiled steel-scented air freshener	1		
-2745	super-pickled dry oxidized tumbling squat gremlin mutagen	0		Effect: "This Is Where You're a Viking", Effect Duration: 69
+2745	super-pickled dry oxidized squat tumbling gremlin mutagen	0		Effect: "This Is Where You're a Viking", Effect Duration: 69
 2746	corrupted enhanced extra-potent gremlin mutagen	0		Effect: "Inner Warmth", Effect Duration: 27
 2747	jittery chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	Sherlock's furniture dolly	0		Item Drop: +25, Single Equip
@@ -2739,7 +2739,7 @@
 2766	bowling ball	0		
 2767	adequate low-calorie Crimbo pie	1	good	
 2768	special rotten bouncing pear tart	4	crappy	Effect: "Dreadful Chill", Effect Duration: 30
-2769	massive flavorless shaking peach pie	6	decent	
+2769	flavorless massive shaking peach pie	6	decent	
 2770	warmed nitrogenated twirling chunk of rock salt	0		Effect: "No Vertigo", Effect Duration: 62
 2771	deionized anodized blurry handful of pine needles	0		Effect: "Muscularrr", Effect Duration: 65
 2772	blurry steamy ruby	0		
@@ -2776,7 +2776,7 @@
 2803	jug of Gnomochloric acid	0		
 2804	corrupted vial of hamethyst juice	0		Effect: "Mushroom Samba", Effect Duration: 57
 2805	chilled diffused spinning vial of baconstone juice	0		Effect: "Chilblains of the Corn", Effect Duration: 18
-2806	irradiated green pulsating vial of porquoise juice	0		Effect: "Sticky Hands", Effect Duration: 31
+2806	irradiated pulsating green vial of porquoise juice	0		Effect: "Sticky Hands", Effect Duration: 31
 2807	improved flask of hamethyst juice	0		Effect: "Slimily Speedy", Effect Duration: 32
 2808	corrupted flask of baconstone juice	0		Effect: "Frosty the Hitman", Effect Duration: 56
 2809	enhanced altered super-warmed blue flask of porquoise juice	0		Effect: "You're High as a Crow, Marty", Effect Duration: 54
@@ -2797,7 +2797,7 @@
 2824	pulsating gravedigger's Grimacite girdle of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Single Equip, Last Available: "2008-11"
 2825	shaking lard-coated Grimacite gown	0		Sleaze Spell Damage: +25, Last Available: "2008-11"
 2826	resourceful rosy-cheeked occult Staff of the Kitchen Floor	0		Spell Damage Percent: +25, Maximum HP Percent: +30, Maximum MP: +50
-2827	red shaking anniversary gift box	0		
+2827	shaking red anniversary gift box	0		
 2828	loaded dice	0		
 2829	red really dense meat stack	0		
 2830	twirling digital key lime	0		
@@ -2810,17 +2810,17 @@
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	nippy glowstick of wisdom	0		Mysticality: +15, Cold Damage: +10, Last Available: "2007-08"
 2839	smelly Periodical Paintbrush	0		Stench Spell Damage: +10, Softcore Only
-2840	perfectly mixed enchanted bottle of cooking sherry	3	EPIC	Effect: "Stimulated Brain", Effect Duration: 35
+2840	enchanted perfectly mixed bottle of cooking sherry	3	EPIC	Effect: "Stimulated Brain", Effect Duration: 35
 2841	rotten jumbo blurry packet of ketchup	5	crappy	
 2842	drinkable accidental cider	3	good	
 2843	flavorless dire fudgesicle	4	decent	
 2844	prompt perfumed wool nippy navel ring of navel gazing	0		Cold Damage: +10, Cold Resistance: +1, Stench Resistance: +5, Adventures: +3, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
-2846	huge skewed plastic bib	0		Last Available: "2011-12"
+2846	skewed huge plastic bib	0		Last Available: "2011-12"
 2847	prompt Dallas Dynasty Falcon Crest shield	0		Adventures: +3, Damage Reduction: 15
 2848	blinking Gnomitronic Hyperspatial Demodulizer	0		
 2849	twirling shrunken navigator head	0		
-2850	mediocre extra-dry twirling moonberry wine cooler	5	decent	
+2850	extra-dry mediocre twirling moonberry wine cooler	5	decent	
 2851	snack-sized moldy fine aged cheddarwurst	2	crappy	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2828,9 +2828,9 @@
 2855	lard-coated huge mosquito proboscis of the boozehound	0		Sleaze Spell Damage: +25, Booze Drop: +100
 2856	concentrated swamp lolly	0		Effect: "Powder Power", Effect Duration: 51
 2857	Vulcanized seegar butt	0		Effect: "Gonna Get You, Sucker", Effect Duration: 16
-2858	narrow mirror bottled swamp gas	0		
+2858	mirror narrow bottled swamp gas	0		
 2859	jittery witch wart of the blizzard of the boozehound	0		Cold Spell Damage: +25, Booze Drop: +100
-2860	decent half-sized swamp muck	2	good	
+2860	half-sized decent swamp muck	2	good	
 2861	auspicious hardened arcane researcher's leechknife	0		Experience Percent (Mysticality): +10, Damage Reduction: 3, Item Drop: +10
 2862	decomposed boot	0		
 2863	modified dribbly candle	0		Effect: "Toast Tea", Effect Duration: 40
@@ -2838,7 +2838,7 @@
 2865	Van der Graaf brainy beaver spear	0		Mysticality: +5, MP Regen Min: 5, MP Regen Max: 7
 2866	nasty arcane researcher's shamanic beads	0		Experience Percent (Mysticality): +10, Stench Damage: +5
 2867	mirror healthy wicked dilapidated wizard hat	0		Spell Damage: +5, Maximum HP Percent: +20, Familiar Effect: "cap 31"
-2868	double-deionized Vulcanized blinking shaking pirate pamphlet	0		Effect: "Gamer Rage", Effect Duration: 23
+2868	double-deionized Vulcanized shaking blinking pirate pamphlet	0		Effect: "Gamer Rage", Effect Duration: 23
 2869	moist frozen pirate brochure	0		Effect: "Turkey-Ambitious", Effect Duration: 33
 2870	wet colloidal moist pirate tract	0		Effect: "All Blued Up", Effect Duration: 67
 2871	burnt flower	0		
@@ -2924,14 +2924,14 @@
 2952	dance instructor's glowstick of the brazier	0		Experience Percent (Moxie): +10, Hot Spell Damage: +25, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	narrow squat wizardly tip jar	0		Mysticality: +25
-2955	special normal skewed yam candy	4	good	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40
+2955	normal special skewed yam candy	4	good	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40
 2956	cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	tiny decent ghostly tube of cranberry Go-Goo	1	good	
+2958	decent tiny ghostly tube of cranberry Go-Goo	1	good	
 2959	bouncing foul-smelling rum barrel charrrm bracelet	0		Stench Damage: +10
 2960	toothsome tumbling wobbly single-serving herbal stuffing	4	awesome	
-2961	spoiled massive packet of tofurkey gravy	9	crappy	
-2962	adequate small tofurkey nugget	2	good	
+2961	massive spoiled packet of tofurkey gravy	9	crappy	
+2962	small adequate tofurkey nugget	2	good	
 2963	rigging shampoo	0		
 2964	lime green ball polish	0		
 2965	mizzenmast mop	0		
@@ -2998,16 +2998,16 @@
 3026	artisanal corpsetini	3	super EPIC	
 3027	hand-crafted distilled corpsedriver	5	EPIC	
 3028	lousy Corpse Island iced tea	3	decent	
-3029	weak perfectly mixed special jittery red-headed corpse	2	EPIC	Effect: "Extra-Sharp Weapon", Effect Duration: 40
-3030	spirit-forward acceptable narrow green kamicorpse-ee	5	good	
+3029	perfectly mixed weak special jittery red-headed corpse	2	EPIC	Effect: "Extra-Sharp Weapon", Effect Duration: 40
+3030	acceptable spirit-forward green narrow kamicorpse-ee	5	good	
 3031	perfectly mixed corpsel	4	EPIC	
 3032	practically non-alcoholic tolerable bouncing corpsebite	1	good	
 3033	wizardly pirate fledges	0		Mysticality: +25
-3034	pulsating tumbling piece of thirteen	0		
-3035	moldy small pearl onion	2	crappy	
-3036	tiny moldy squat sea biscuit	1	crappy	
-3037	mediocre strong bottle of rum	5	decent	
-3038	hand-crafted irresponsibly strong blinking bottle of black-label rum	9	EPIC	
+3034	tumbling pulsating piece of thirteen	0		
+3035	small moldy pearl onion	2	crappy	
+3036	moldy tiny squat sea biscuit	1	crappy	
+3037	strong mediocre bottle of rum	5	decent	
+3038	irresponsibly strong hand-crafted blinking bottle of black-label rum	9	EPIC	
 3039	cannonball	0		
 3040	skewed voodoo skull	0		
 3041	joke scroll	0		
@@ -3026,7 +3026,7 @@
 3054	dry unsweetened upside-down purple candy heart	0		Effect: "Turtle Titters", Effect Duration: 29, Last Available: "2007-02"
 3055	magnetized skewed cymbal syrup	0		Free Pull, Effect: "Bone Chilling", Effect Duration: 41, Last Available: "2007-02"
 3056	Samson's metallic foil cat ears	0		Experience (Muscle): +5, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
-3057	bouncing upside-down nanofiber cloth	0		Last Available: "2007-12"
+3057	upside-down bouncing nanofiber cloth	0		Last Available: "2007-12"
 3058	squat iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
 3060	squat synthetic stuffing	0		Last Available: "2007-12"
@@ -3055,7 +3055,7 @@
 3083	maroon gray blob	0		Last Available: "2007-12"
 3084	borg sock monkey of extreme caution	0		Monster Level: -25, Last Available: "2007-12"
 3085	extremely unsafe roboduck-on-a-string of the scaredy-cat	0		Weapon Damage Percent: +100, Monster Level: -15, Last Available: "2007-12"
-3086	yellow blinking mylar scout drone	0		Last Available: "2007-12"
+3086	blinking yellow mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
 3088	narrow perfumed veiny biomechanical crimborg helmet	0		Maximum HP: +10, Stench Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	Da Vinci's experienced C.B.F.G.	0		Experience: +2, Experience (Mysticality): +5, Last Available: "2007-12"
@@ -3064,12 +3064,12 @@
 3092	ghostly blinking Lo Pan's handmade hobby horse	0		Spell Critical Percent: +30, Last Available: "2007-12"
 3093	Newton's ball-in-a-cup	0		Experience (Mysticality): +3, Last Available: "2007-12"
 3094	set of jacks of the early riser	0		Adventures: +7, Last Available: "2007-12"
-3095	gigantic decent laser-broiled pear	8	good	Last Available: "2007-12"
+3095	decent gigantic laser-broiled pear	8	good	Last Available: "2007-12"
 3096	ghostly family-friendly groovy polyalloy shield	0		Moxie Percent: +10, Sleaze Resistance: +1, Damage Reduction: 9, Last Available: "2007-12"
-3097	blue blinking fish scaler	0		Last Available: "2007-12"
+3097	blinking blue fish scaler	0		Last Available: "2007-12"
 3098	killing feather	0		Last Available: "2007-12"
 3099	skewed ring	0		Last Available: "2007-12"
-3100	yellow bouncing robotronic egg	0		Last Available: "2007-12"
+3100	bouncing yellow robotronic egg	0		Last Available: "2007-12"
 3101	rogue swarmer	0		Last Available: "2007-12"
 3102	sawblade fragment	0		Last Available: "2007-12"
 3103	pulsating unstable laser battery	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
 3118	blue divine noisemaker	0		Last Available: "2008-01"
 3119	skewed olive divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3116,7 +3116,7 @@
 3144	a torn paper strip	0		
 3145	El Vibrato translator	0		
 3146	El Vibrato punchcard (115 holes)	0		
-3147	tumbling jittery El Vibrato punchcard (97 holes)	0		
+3147	jittery tumbling El Vibrato punchcard (97 holes)	0		
 3148	shaking upside-down El Vibrato punchcard (129 holes)	0		
 3149	huge red El Vibrato punchcard (213 holes)	0		
 3150	El Vibrato punchcard (165 holes)	0		
@@ -3138,18 +3138,18 @@
 3166	maroon repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	enhanced jittery narrow seal eyeball	0		Effect: "Uncanny Shot", Effect Duration: 45
-3169	stale half-sized spinning turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	half-sized stale spinning turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	skewed nauseating reagent	0		
 3172	red zippy evil paper umbrella	0		Initiative: +20
 3173	improved evil vihuela	0		Effect: "Robocamo", Effect Duration: 34
 3174	toothsome fuchsia evil boring spaghetti	3	awesome	
-3175	huge stale evil noodles	6	decent	
+3175	stale huge evil noodles	6	decent	
 3176	adequate snack-sized evil noodles	2	good	
-3177	huge normal fancy spinning evil painful penne pasta	10	good	Effect: "Dirge of Dreadfulness", Effect Duration: 45
+3177	normal huge fancy spinning evil painful penne pasta	10	good	Effect: "Dirge of Dreadfulness", Effect Duration: 45
 3178	rotten 3vi1 pr0n m4nic0tti	3	crappy	
 3179	massive adequate ghostly evil ravioli della hippy	10	good	
-3180	stale immense evil noodles	6	decent	
+3180	immense stale evil noodles	6	decent	
 3181	aerosolized evil potion of potency	0		Effect: "Hammertime", Effect Duration: 40
 3182	liquefied cold-filtered evil libation of liveliness	0		Effect: "Charrrming", Effect Duration: 17
 3183	energized quadruple-cold-filtered evil tomato juice of powerful power	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 34
@@ -3160,7 +3160,7 @@
 3188	boozy perfectly mixed an evil sump'm sump'm	5	EPIC	
 3189	artisanal upside-down evil ducha de oro	4	EPIC	
 3190	lousy evil horizontal tango	4	decent	
-3191	fortified acceptable maroon evil roll in the hay	5	good	
+3191	acceptable fortified maroon evil roll in the hay	5	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3170,7 +3170,7 @@
 3198	tumbling El Vibrato trapezoid	0		
 3199	jittery lump of coal	0		
 3200	lump of diamond	0		
-3201	narrow yellow thick padded envelope	0		
+3201	yellow narrow thick padded envelope	0		
 3202	nasty chilly Lo Pan's KoL Con IV Pole	0		Spell Critical Percent: +30, Cold Damage: +5, Stench Damage: +5, Last Available: "2007-09"
 3203	tumbling dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
@@ -3194,10 +3194,10 @@
 3222	therapeutic Fonzie's gatorskin umbrella	0		Experience (Moxie): +1, HP Regen Min: 5, HP Regen Max: 7
 3223	sewer nuggets	0		
 3224	sewer wad	0		
-3225	drinkable irresponsibly strong pulsating bottle of sewage schnapps	7	good	
+3225	irresponsibly strong drinkable pulsating bottle of sewage schnapps	7	good	
 3226	acceptable bottle of Ooze-O	3	good	
 3227	enchanted moldy pulsating C.H.U.M. chum	4	crappy	Effect: "La Bamba", Effect Duration: 5
-3228	half-sized moldy unfortunate dumplings	2	crappy	
+3228	moldy half-sized unfortunate dumplings	2	crappy	
 3229	decaying goldfish liver	0		
 3230	electrified adjusted purple oil of oiliness	0		Effect: "Boilermade", Effect Duration: 11
 3231	pulsating tattered paper crown of the early riser	0		Adventures: +7, Familiar Effect: "1xSombrero, cap 15"
@@ -3209,7 +3209,7 @@
 3237	Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	mirror Maxing, Relaxing	0		Skill: "Maximum Chill"
-3240	yellow tumbling Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
+3240	tumbling yellow Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	skewed Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
@@ -3232,7 +3232,7 @@
 3260	squat Lo Pan's rosy-cheeked Chester's moustache of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Spell Critical Percent: +30, Class: "Disco Bandit", Single Equip
 3261	medical-grade Chester's bag of candy of the wise owl	0		Mysticality: +20, HP Regen Min: 7, HP Regen Max: 10, Class: "Disco Bandit"
 3262	horrifying clever Chester's cutoffs	0		Maximum MP: +20, Spooky Damage: +25, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	tumbling Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	tumbling Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3252,7 +3252,7 @@
 3280	gray tumbling personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	stick-on eyebrow piercing of courage	0		Spooky Resistance: +3, Last Available: "2008-04"
-3283	huge delicious ghostly salad	10	awesome	
+3283	delicious huge ghostly salad	10	awesome	
 3284	rosewater-soaked beefcake's C.H.U.M. lantern	0		Muscle: +25, Stench Resistance: +3
 3285	jittery Annie Oakley's C.H.U.M. knife	0		Critical Hit Percent: +20
 3286	Fonzie's Frosty's snowball sack	0		Experience (Moxie): +1
@@ -3292,7 +3292,7 @@
 3320	fuchsia healthy frayed rope belt	0		Maximum HP Percent: +20, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
 3322	scorching hardy mayfly bait necklace	0		Maximum HP: +50, Hot Damage: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
-3323	pulsating mirror Ol' Scratch's salad fork	0		
+3323	mirror pulsating Ol' Scratch's salad fork	0		
 3324	jittery Frosty's frosty mug	0		
 3325	drinkable jar of fermented pickle juice	4	good	
 3326	pickled twirling purple voodoo snuff	1	good	
@@ -3322,7 +3322,7 @@
 3350	lousy Ralph IX cognac	3	decent	
 3351	jittery fuchsia llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
-3353	anodized spinning pulsating llama lama gong	0		Effect: "Patched In", Effect Duration: 63, Last Available: "2008-06"
+3353	anodized pulsating spinning llama lama gong	0		Effect: "Patched In", Effect Duration: 63, Last Available: "2008-06"
 3354	adequate banana-frosted king cake	3	good	Last Available: "2008-08"
 3355	Van der Graaf brown plastic baby	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
@@ -3331,10 +3331,10 @@
 3359	scrumptious ice ant	0		Last Available: "2008-06"
 3360	yellow stinkbug	0		Last Available: "2008-06"
 3361	shaking yummy death watch beetle	0		Last Available: "2008-06"
-3362	jittery narrow tasty louse	0		Last Available: "2008-06"
-3363	spoiled tumbling narrow mole mol&eacute;	3	crappy	Last Available: "2008-06"
+3362	narrow jittery tasty louse	0		Last Available: "2008-06"
+3363	spoiled narrow tumbling mole mol&eacute;	3	crappy	Last Available: "2008-06"
 3364	watered-down smooth blurry Morlock's Mark Bourbon	2	awesome	Last Available: "2008-06"
-3365	frozen cyan squat Climate Colada	0		Effect: "Hagg-ard", Effect Duration: 25, Last Available: "2008-06"
+3365	frozen squat cyan Climate Colada	0		Effect: "Hagg-ard", Effect Duration: 25, Last Available: "2008-06"
 3366	alkaline twirling digital underground potion	0		Effect: "Hiding in Plain Sight", Effect Duration: 43, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	mixed glimmering roc feather	1	EPIC	Last Available: "2008-06"
@@ -3342,11 +3342,11 @@
 3370	mixed glimmering penguin feather	1		Effect: "Sugar, Hello", Effect Duration: 35, Last Available: "2008-06"
 3371	dried spinning glimmering buzzard feather	1		Last Available: "2008-06"
 3372	vaporized lime green glimmering raven feather	1		Effect: "Sugar Smacks", Effect Duration: 5, Last Available: "2008-06"
-3373	modified pulsating squat glimmering great tit feather	1		Last Available: "2008-06"
+3373	modified squat pulsating glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	upside-down yellow The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
-3377	wobbly shaking Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
+3377	shaking wobbly Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	upside-down Chorale of Companionship	0		Skill: "Chorale of Companionship"
 3379	mirror Prelude of Precision	0		Skill: "Prelude of Precision"
 3380	jittery Jim Carey's Ol' Scratch's infernal pitchfork of the storm	0		Maximum MP Percent: +40, Monster Level: +25
@@ -3368,8 +3368,8 @@
 3396	skewed yellow Jeselnik's curative Hodgman's lobsterskin pants	0		Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xPotato"
 3397	dance instructor's smartaleck's Hodgman's bow tie	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Single Equip
 3398	acceptable Hodgman's blanket	3	good	
-3399	practically non-alcoholic drinkable jar of squeeze	1	good	
-3400	moldy half-sized bowl of fishysoisse	2	crappy	
+3399	drinkable practically non-alcoholic jar of squeeze	1	good	
+3400	half-sized moldy bowl of fishysoisse	2	crappy	
 3401	boiled deadly lampshade	0		Effect: "Mystic Circle", Effect Duration: 59
 3402	vacuum-sealed denatured lime green concentrated garbage juice	0		Effect: "The Rich Get Richer", Effect Duration: 22
 3403	lewd playing card	0		
@@ -3391,7 +3391,7 @@
 3423	irradiated wobbly frostbite-flavored Hob-O	0		Effect: "The Best a Pirate Can Get", Effect Duration: 21
 3424	wet fry-oil-flavored Hob-O	0		Effect: "Blessing of Charcoatl", Effect Duration: 58
 3425	ionized moist mirror garbage-juice-flavored Hob-O	0		Effect: "Just Aged Enough", Effect Duration: 39
-3426	dry ionized blinking twirling fuchsia strawberry-flavored Hob-O	0		Effect: "Orc Chops", Effect Duration: 26
+3426	dry ionized fuchsia twirling blinking strawberry-flavored Hob-O	0		Effect: "Orc Chops", Effect Duration: 26
 3427	roll of Hob-Os	0		
 3428	electrified mirror Everlasting Deckswabber	0		Effect: "Fratty Flavor", Effect Duration: 56
 3430	skewed bindle of joy	0		
@@ -3412,7 +3412,7 @@
 3445	Junior Adventurer's kit	0		
 3446	groovy prism necklace	0		Single Equip
 3447	jittery smooth brainy six-rainbow shield	0		Mysticality: +5, Moxie: +15, Damage Reduction: 12, Last Available: "2008-07"
-3448	gray upside-down rainbow bomb	0		Last Available: "2008-07"
+3448	upside-down gray rainbow bomb	0		Last Available: "2008-07"
 3449	cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	shaking cotton candy smidgen	0		Last Available: "2008-08"
@@ -3424,7 +3424,7 @@
 3457	narrow Junior Adventurer's merit badge of the scaredy-cat	0		Monster Level: -15
 3458	pickled STYX deodorant body spray	0		Effect: "Thaumodynamic", Effect Duration: 58
 3459	mediocre upside-down white-label gin	3	decent	
-3460	normal fancy miniature tin rations	2	good	Effect: "Feet of Watermelon", Effect Duration: 15
+3460	fancy miniature normal tin rations	2	good	Effect: "Feet of Watermelon", Effect Duration: 15
 3461	haiku challenge map	0		
 3462	terrible poem	0		
 3463	weak lousy bottle of sake	2	decent	
@@ -3433,7 +3433,7 @@
 3466	banded Sinatra's strapping haiku katana	0		Muscle: +5, Experience (Moxie): +5, Damage Absorption: +100, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	upside-down bargain flash powder	0		
 3468	toasty plastic baby	0		Hot Damage: +5, Single Equip, Last Available: "2008-12"
-3469	stale snack-sized blueberry-frosted king cake	2	decent	Last Available: "2008-12"
+3469	snack-sized stale blueberry-frosted king cake	2	decent	Last Available: "2008-12"
 3470	blinking bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	jittery damp boot	0		
 3472	therapeutic Socratic Seasonal Beret of the scaredy-cat	0		Experience (Mysticality): +1, Monster Level: -15, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3454,8 +3454,8 @@
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
 3489	adequate beefy fish meat	3	good	Effect: "Fishy", Effect Duration: 5
-3490	enchanted bland bite-sized glistening fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
-3491	bite-sized stale ghostly green slick fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
+3490	enchanted bite-sized bland glistening fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
+3491	stale bite-sized green ghostly slick fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
 3492	aromatic knitted fish scimitar	0		Cold Resistance: +3, Stench Resistance: +1
 3493	maroon scorching Temple Grandin's fish stick	0		Familiar Weight: +7, Hot Damage: +25
 3494	red pulsating fish bazooka of Gandalf of temperance	0		Spell Critical Percent: +20, Sleaze Resistance: +5
@@ -3471,13 +3471,13 @@
 3504	squat French slippers	0		
 3505	lime green frosty LWA ring	0		Cold Spell Damage: +10
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	inspector's scratch 'n' sniff sword	0		Item Drop: +15, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	yellow scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	green scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
-3513	huge upside-down huge scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
+3513	huge huge upside-down scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	ghostly scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	Temple Grandin's savvy ganger bandana	0		Mysticality Percent: +20, Familiar Weight: +7, Familiar Effect: "atk"
 3516	tumbling eel skin	0		
@@ -3491,14 +3491,14 @@
 3524	magnetized eel battery	0		Effect: "Industrial Strength Starch", Effect Duration: 32
 3525	colloidal twirling temporary teardrop tattoo	0		Effect: "Cotton Mouthed", Effect Duration: 36
 3526	huge blinking brainy scratch 'n' sniff crossbow	0		Mysticality: +5, Last Available: "2008-11"
-3527	purple ghostly mutant rattlesnake egg	0		
+3527	ghostly purple mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
 3529	mutant cactus bud	0		
 3530	mutant gila monster egg	0		
 3531	jittery rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
 3533	cactus monocle	0		Familiar Weight: +5
-3534	wobbly squat upside-down Jawmaster 2000&trade;	0		Familiar Weight: +5
+3534	upside-down squat wobbly Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	pulsating plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
@@ -3519,10 +3519,10 @@
 3552	rock-hard wicked octopus's spade of the early riser	0		Spell Damage: +5, Damage Reduction: 5, Adventures: +7
 3553	soggy seed packet	0		
 3554	wobbly glob of slime	0		
-3555	miniature tasty sea carrot	2	awesome	
-3556	moldy snack-sized sea cucumber	2	crappy	
-3557	immense bland sea avocado	10	decent	
-3558	special flavorless sea lychee	3	decent	Effect: "Armor-Plated", Effect Duration: 40
+3555	tasty miniature sea carrot	2	awesome	
+3556	snack-sized moldy sea cucumber	2	crappy	
+3557	bland immense sea avocado	10	decent	
+3558	flavorless special sea lychee	3	decent	Effect: "Armor-Plated", Effect Duration: 40
 3559	rotten squat sea tangelo	4	crappy	
 3560	decent sea honeydew	4	good	
 3561	ionized pressurized potion of puissance	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 31
@@ -3535,8 +3535,8 @@
 3568	bouncing Oprah's curative sponge helmet of extreme caution	0		Maximum MP Percent: +50, Monster Level: -25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy"
 3569	wholesome weightlifter's spongy shield of the sweet-tooth	0		Muscle: +15, Maximum HP Percent: +10, Candy Drop: +100, Damage Reduction: 14
 3570	prompt Lo Pan's square sponge pants of the businessman	0		Spell Critical Percent: +30, Meat Drop: +50, Adventures: +3, Familiar Effect: "hot atk, 1xPotato"
-3571	tumbling ghostly flytrap pellet	0		
-3572	pulsating green baby cuddlefish	0		
+3571	ghostly tumbling flytrap pellet	0		
+3572	green pulsating baby cuddlefish	0		
 3573	shaking six-armed sweater	0		Familiar Weight: +5
 3574	wobbly slimy chest	0		
 3575	sand dollar	0		
@@ -3546,7 +3546,7 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	super-sized bland rice	5	decent	
+3582	bland super-sized rice	5	decent	
 3584	normal irradiated candy cane	4	good	Last Available: "2008-12"
 3585	tasty gingerbread mutant bugbear	3	awesome	Last Available: "2008-12"
 3586	fancy perfectly mixed oozenog	3	EPIC	Effect: "Powdered", Effect Duration: 15, Last Available: "2008-12"
@@ -3578,7 +3578,7 @@
 3612	mirror sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
-3615	skewed fuchsia rigid carapace	0		Last Available: "2008-12"
+3615	fuchsia skewed rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	non-liquefied triple-corrupted unstable DNA	0		Effect: "Cold Jellied", Effect Duration: 40, Last Available: "2008-12"
 3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
@@ -3592,7 +3592,7 @@
 3626	steel-toed parasitic headgnawer	0		Damage Reduction: 9, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	jittery slick parasitic strangleworm	0		Moxie: +10, Last Available: "2008-12"
 3628	gray pair of ragged claws	0		Last Available: "2008-12"
-3629	pulsating teal burrowgrub hive	0		Last Available: "2008-12"
+3629	teal pulsating burrowgrub hive	0		Last Available: "2008-12"
 3630	blurry Crimbo crate	0		Last Available: "2008-12"
 3631	polymerized Gummi-DNA	0		Effect: "The Magic of LOV", Effect Duration: 68, Last Available: "2020-09"
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
@@ -3609,14 +3609,14 @@
 3643	pufferfish spine	0		
 3644	flame-wreathed depleted Grimacite kneecapping stick	0		Hot Spell Damage: +10, Last Available: "2007-06"
 3645	artisanal purple canteen of wine	3	EPIC	Last Available: "2008-12"
-3646	spoiled fancy small elven <i>limbos</i> gingerbread	2	crappy	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2008-12"
+3646	fancy small spoiled elven <i>limbos</i> gingerbread	2	crappy	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2008-12"
 3647	olive elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	blinking map to Madness Reef	0		
-3650	gigantic flavorless mirror toast with jam	10	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	flavorless gigantic mirror toast with jam	10	decent	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	hand-crafted extra-dry elven moonshine	5	EPIC	Last Available: "2008-12"
-3653	special bland immense knuckle sandwich	6	decent	Effect: "Oriental Mysticism", Effect Duration: 35, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	special immense bland knuckle sandwich	6	decent	Effect: "Oriental Mysticism", Effect Duration: 35, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	squat arcane researcher's psycho sweater of bravery	0		Experience Percent (Mysticality): +10, Spooky Resistance: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	brawny plastic Mob Penguin	0		Muscle Percent: +20, Last Available: "2008-12"
@@ -3648,13 +3648,13 @@
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
 3684	tasty tempura carrot	3	awesome	
-3685	flavorless gigantic tempura cucumber	10	decent	
+3685	gigantic flavorless tempura cucumber	10	decent	
 3686	spoiled tempura avocado	3	crappy	
 3687	spoiled small tumbling sea broccoli	2	crappy	
 3688	moldy sea cauliflower	3	crappy	
-3689	decent enchanted blurry tempura broccoli	3	good	Effect: "Here to Kick Ass", Effect Duration: 5
+3689	enchanted decent blurry tempura broccoli	3	good	Effect: "Here to Kick Ass", Effect Duration: 5
 3690	flavorless bite-sized maroon tempura cauliflower	1	decent	
-3691	gigantic moldy olive sea blueberry	7	crappy	
+3691	moldy gigantic olive sea blueberry	7	crappy	
 3692	stale sea persimmon	4	decent	
 3693	galvanized blue pressurized potion of perception	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 38
 3694	vacuum-sealed extra-vacuum-sealed blurry pressurized potion of proficiency	0		Effect: "Cake Caked", Effect Duration: 65
@@ -3713,27 +3713,27 @@
 3747	blinking mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	adjusted irradiated tumbling concoction of clumsiness	0		Effect: "Flashing Eyes", Effect Duration: 17
 3750	Jack Frost's vampire pearl earring	0		Cold Spell Damage: +50, Single Equip
-3751	special toothsome skewed chocolate chip brownies	3	awesome	Effect: "Yuletide Mutations", Effect Duration: 30
-3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3751	toothsome special skewed chocolate chip brownies	3	awesome	Effect: "Yuletide Mutations", Effect Duration: 30
+3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	extra-corrupted triple-energized upside-down love song of vague ambiguity	0		Effect: "Cat Class, Cat Style", Effect Duration: 33, Last Available: "2009-02"
 3755	ionized love song of smoldering passion	0		Effect: "Takin' It Greasy", Effect Duration: 60, Last Available: "2009-02"
 3756	vacuum-sealed love song of icy revenge	0		Effect: "Electrolit Up", Effect Duration: 55, Last Available: "2009-02"
-3757	electrified skewed jittery love song of sugary cuteness	0		Effect: "Metal Speed", Effect Duration: 17, Last Available: "2009-02"
+3757	electrified jittery skewed love song of sugary cuteness	0		Effect: "Metal Speed", Effect Duration: 17, Last Available: "2009-02"
 3758	dry polymerized love song of disturbing obsession	0		Effect: "Squid Squint", Effect Duration: 56, Last Available: "2009-02"
 3759	concentrated love song of naughty innuendo	0		Effect: "Black Eyes", Effect Duration: 59, Last Available: "2009-02"
 3760	irradiated red breath mint	0		Effect: "Devil Inside", Effect Duration: 65
 3761	blinking gray vampire pearl ring of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
 3762	pulsating boxer's vampire pearl necklace	0		Muscle Percent: +10, Single Equip
-3763	irresponsibly strong artisanal green slug of vodka	6	EPIC	
+3763	artisanal irresponsibly strong green slug of vodka	6	EPIC	
 3764	aged slug of rum	3	awesome	
 3765	special perfectly mixed squat slug of shochu	3	EPIC	Effect: "Mortarfied", Effect Duration: 35
-3766	boozy mediocre blinking screwdiver	5	decent	
+3766	mediocre boozy blinking screwdiver	5	decent	
 3767	mediocre high-proof skewed dew yoana lei	6	decent	
 3768	drinkable upside-down lychee chuhai	3	good	
-3769	tolerable ghostly purple salacious screwdiver	4	good	
-3770	practically non-alcoholic hand-crafted dew yoana salacious lei	1	super ultra mega turbo EPIC	
+3769	tolerable purple ghostly salacious screwdiver	4	good	
+3770	hand-crafted practically non-alcoholic dew yoana salacious lei	1	super ultra mega turbo EPIC	
 3771	spirit-forward tolerable salacious lychee chuhai	5	good	
-3772	triple-distilled lousy Alewife&trade; Ale	8	decent	
+3772	lousy triple-distilled Alewife&trade; Ale	8	decent	
 3773	teal narrow seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3764,11 +3764,11 @@
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	gigantic flavorless chocolate-frosted king cake	10	decent	Last Available: "2009-06"
+3812	flavorless gigantic chocolate-frosted king cake	10	decent	Last Available: "2009-06"
 3813	bouncing chilly plastic baby	0		Cold Damage: +5, Single Equip, Last Available: "2009-06"
 3815	jittery midget clownfish	0		
 3816	huge half-height unicycle	0		Familiar Weight: +5
-3817	stale bite-sized sea radish	1	decent	
+3817	bite-sized stale sea radish	1	decent	
 3818	ghostly fireproof Fonzie's halibut of the storm	0		Experience (Moxie): +1, Maximum MP Percent: +40, Hot Resistance: +3
 3819	eel sauce	0		
 3820	water-polo mitt of the ox	0		Muscle: +20, Single Equip
@@ -3780,11 +3780,11 @@
 3826	skewed Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	snack-sized moldy tempura radish	2	crappy	
+3829	moldy snack-sized tempura radish	2	crappy	
 3830	baleful water-polo cap	0		Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	mediocre huge Typical Tavern swill	4	decent	
 3832	lousy tropical swill	4	decent	
-3833	mediocre special practically non-alcoholic fruity girl swill	1	decent	Effect: "Armored Innards", Effect Duration: 25
+3833	special mediocre practically non-alcoholic fruity girl swill	1	decent	Effect: "Armored Innards", Effect Duration: 25
 3834	hand-crafted spirit-forward fuchsia blended swill	5	EPIC	
 3835	costume wardrobe	0		Softcore Only
 3836	rosewater-soaked ribald hardy deadly Elvish sunglasses	0		Weapon Damage: +5, Maximum HP: +50, Sleaze Damage: +10, Stench Resistance: +3, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
@@ -3849,15 +3849,15 @@
 3895	super-liquefied vial of indigo slime	0		Effect: "Vented Spleen", Effect Duration: 45
 3896	electrified spinning vial of slime	0		Effect: "Tiki Temerity", Effect Duration: 36
 3897	chilled jittery vial of brown slime	0		Effect: "Big Meat Big Prizes", Effect Duration: 39
-3898	bouncing shaking purple bottle of G&uuml;-Gone	0		
+3898	shaking purple bouncing bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
 3902	ghostly figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	bouncing figurine of a baby seal	0		Class: "Seal Clubber"
 3904	squat figurine of an armored seal	0		Class: "Seal Clubber"
 3905	figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
-3907	ghostly jittery figurine of a shadowy seal	0		Class: "Seal Clubber"
-3908	shaking narrow figurine of a stinking seal	0		Class: "Seal Clubber"
+3907	jittery ghostly figurine of a shadowy seal	0		Class: "Seal Clubber"
+3908	narrow shaking figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
@@ -3883,7 +3883,7 @@
 3931	auspicious severed flipper of the pedagogue	0		Experience: +3, Item Drop: +10, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
 3933	Oprah's bad-ass club of chilblains	0		Maximum MP Percent: +50, Cold Damage: +25, Class: "Seal Clubber"
-3934	shaking squat sealbone	0		
+3934	squat shaking sealbone	0		
 3935	polarized hyperinflated seal lung	0		Effect: "Amorous Avarice", Effect Duration: 61
 3936	modified scrap of shadow	0		Effect: "Magically Delicious", Effect Duration: 50
 3937	warmed alkaline fustulent seal grulch	0		Effect: "Pride of the Vampire", Effect Duration: 65
@@ -3899,7 +3899,7 @@
 3947	Clan VIP Lounge key	0		Free Pull
 3948	Meat	0		
 3949	treasure chest	0		
-3950	bouncing purple huge key	0		
+3950	purple huge bouncing key	0		
 3951	Baron von Ratsworth	0		
 3952	pulsating monocle	0		
 3953	mink	0		
@@ -3913,7 +3913,7 @@
 3961	skewed nippy banded opera glasses	0		Damage Absorption: +100, Cold Damage: +10
 3962	designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
-3964	twirling olive cell phone	0		Familiar Weight: +10
+3964	olive twirling cell phone	0		Familiar Weight: +10
 3965	ionized cube of billiard chalk	0		Effect: "Well-Oiled", Effect Duration: 44
 3966	auspicious perfumed crafty hot-ass club	0		Maximum MP: +10, Stench Resistance: +5, Item Drop: +10, Class: "Seal Clubber"
 3967	jittery frosty careful wicked frigid-ass club	0		Spell Damage: +5, Monster Level: -10, Cold Spell Damage: +10, Class: "Seal Clubber"
@@ -3950,7 +3950,7 @@
 3998	huge fuchsia metrognome	0		Familiar Weight: +5
 3999	infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	compressed pulsating twirling agua de vida	1	decent	Last Available: "2009-06"
+4001	compressed twirling pulsating agua de vida	1	decent	Last Available: "2009-06"
 4002	Annie Oakley's tortoboggan shield of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +20, Damage Reduction: 6
 4003	upside-down bottle of moontan lotion	0		
 4004	executive soup-chucks	0		Meat Drop: +40
@@ -3987,7 +3987,7 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
 4037	bland slimy sweetbreads	3	decent	
-4038	hand-crafted fortified slimy fermented bile bladder	5	EPIC	
+4038	fortified hand-crafted slimy fermented bile bladder	5	EPIC	
 4039	modified shaking slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	frosty savvy pig-iron helm	0		Mysticality Percent: +20, Cold Spell Damage: +10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	cool ring of teleportation	0		Moxie: +5, Single Equip
 4052	glass of baboon milk	1	decent	Last Available: "2009-06"
 4053	banana milkshake	1	awesome	Last Available: "2009-06"
-4054	boozy artisanal White Hyborian	5	EPIC	Last Available: "2009-06"
+4054	artisanal boozy White Hyborian	5	EPIC	Last Available: "2009-06"
 4055	lightning-fast goblin hunting spear	0		Initiative: +40, Last Available: "2009-06"
 4056	ruddy goblin autoblowgun of bravery	0		Maximum HP Percent: +40, Spooky Resistance: +5, Last Available: "2009-06"
 4057	tribal beads of the early riser	0		Adventures: +7, Last Available: "2009-06"
@@ -4020,7 +4020,7 @@
 4068	essence of kink	0		Last Available: "2009-06"
 4069	tumbling essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
-4071	squat purple essence of fright	0		Last Available: "2009-06"
+4071	purple squat essence of fright	0		Last Available: "2009-06"
 4072	tumbling essence of	0		Last Available: "2009-06"
 4073	skewed Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
@@ -4032,7 +4032,7 @@
 4080	pulsating reassuring crafty grisly shield	0		Maximum MP: +10, Spooky Resistance: +1, Slime Hates It: +1, Damage Reduction: 13
 4081	auspicious sage corroded breeches	0		Mysticality Percent: +10, Item Drop: +10, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	narrow blue reassuring Van der Graaf pernicious cudgel	0		Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Slime Hates It: +1
-4083	diet flavorless cupcake-in-a-cup	1	decent	Last Available: "2009-06"
+4083	flavorless diet cupcake-in-a-cup	1	decent	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	stale shaking protein paste	4	decent	Last Available: "2009-06"
 4086	Tesla cyber-mattock of Gandalf	0		Spell Critical Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2009-06"
@@ -4088,7 +4088,7 @@
 4136	lime green thinker's Bag o' Tricks of the storm of the empath of incineration	0		Mysticality: +10, Maximum MP Percent: +40, Familiar Weight: +5, Hot Spell Damage: +50, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	blurry slime stack	0		
 4138	bouncing a rumpled paper strip	0		
-4139	shaking blue a creased paper strip	0		
+4139	blue shaking a creased paper strip	0		
 4140	ghostly a folded paper strip	0		
 4141	a crinkled paper strip	0		
 4142	bouncing a crumpled paper strip	0		
@@ -4149,7 +4149,7 @@
 4197	pulsating sea	0		
 4198	sea lasso	0		
 4199	teal up-at-dawn miser's smooth sea cowboy hat	0		Moxie: +15, Meat Drop: +10, Adventures: +5, Familiar Effect: "1xLep"
-4200	green skewed grouper fangirl	0		
+4200	skewed green grouper fangirl	0		
 4201	gill rings	0		Familiar Weight: +5
 4202	mirror urchin roe	0		
 4203	purple pet anemone	0		Familiar Weight: +5
@@ -4179,7 +4179,7 @@
 4227	bouncing hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
 4229	red amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
-4230	huge spinning bottle of Cochon Noir	0		Familiar Weight: +5
+4230	spinning huge bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	blinking ice skate doll	0		
 4233	hacienda key	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	huge can of sterno	0		
 4237	curative cheese-slicer	0		HP Regen Min: 3, HP Regen Max: 5
-4238	stale jumbo tumbling beef jerky	5	decent	
+4238	jumbo stale tumbling beef jerky	5	decent	
 4239	stiffened pipe wrench	0		Damage Reduction: 1
 4240	aerosolized jittery gun cleaning kit	0		Effect: "Wallflowering", Effect Duration: 69
 4241	careful sleep mask	0		Monster Level: -10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4207,12 +4207,12 @@
 4255	blurry Wolfman Nardz	0		Last Available: "2009-10"
 4256	denatured adjusted sap	0		Effect: "Remaining Alive", Effect Duration: 38, Last Available: "2009-10"
 4257	blue petrified wood	0		Last Available: "2009-10"
-4258	snack-sized delicious shaking maroon ghostly chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
+4258	delicious snack-sized maroon shaking ghostly chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
 4259	lousy mulled cider	3	decent	Last Available: "2009-10"
 4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4263	ghostly yellow Ax of L'rose	0		Last Available: "2009-10"
+4263	yellow ghostly Ax of L'rose	0		Last Available: "2009-10"
 4264	bouncing Temple Grandin's bark boxers	0		Familiar Weight: +7, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
 4265	careful bark beret	0		Monster Level: -10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	narrow knitted bark bracelet	0		Cold Resistance: +3, Single Equip
@@ -4279,8 +4279,8 @@
 4327	jittery prompt quilted La Hebilla del Cintur&oacute;n de Lopez of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +40, Adventures: +3, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	tasty thick candy kneecapping stick	5	awesome	Last Available: "2009-12"
-4331	normal snack-sized licorice garrote	2	good	Last Available: "2009-12"
+4330	thick tasty candy kneecapping stick	5	awesome	Last Available: "2009-12"
+4331	snack-sized normal licorice garrote	2	good	Last Available: "2009-12"
 4332	double-paned candy knuckles	0		Cold Resistance: +5, Last Available: "2009-12"
 4333	spoiled jawbruiser	4	crappy	Last Available: "2010-12"
 4334	improved olive squat chocolate car	0		Effect: "Ooh, Sweet!", Effect Duration: 43, Last Available: "2009-12"
@@ -4293,8 +4293,8 @@
 4341	denatured cold-filtered BitterSweetTarts	0		Effect: "All Is Forgiven", Effect Duration: 49, Last Available: "2009-12"
 4342	quantum energized Polka Pop	0		Effect: "Mucilaginous Mentalism", Effect Duration: 60, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
-4344	tumbling squat Crimbo wreath	0		Last Available: "2009-12"
-4345	twirling pulsating string of Crimbo lights	0		Last Available: "2009-12"
+4344	squat tumbling Crimbo wreath	0		Last Available: "2009-12"
+4345	pulsating twirling string of Crimbo lights	0		Last Available: "2009-12"
 4346	shaking plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	pulsating leftover Crimbo rations	0		Last Available: "2009-12"
@@ -4322,7 +4322,7 @@
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	blinking handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
-4373	twirling narrow grappling hook	0		Last Available: "2009-12"
+4373	narrow twirling grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
 4376	shaking Crimbomination Contraption	0		Last Available: "2009-12"
@@ -4344,7 +4344,7 @@
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	super-liquefied Vulcanized Crimbo peppermint bark	0		Effect: "Radium Radicality", Effect Duration: 29, Last Available: "2009-12"
 4394	alkaline moist energized Crimbo fudge	0		Effect: "Cranberry Cordiality", Effect Duration: 57, Last Available: "2009-12"
-4395	ionized concentrated wobbly upside-down Crimbo pecan	0		Effect: "Yuletide Sappiness", Effect Duration: 33, Last Available: "2009-12"
+4395	ionized concentrated upside-down wobbly Crimbo pecan	0		Effect: "Yuletide Sappiness", Effect Duration: 33, Last Available: "2009-12"
 4396	olive jittery Jack-in-the-box	0		Last Available: "2009-12"
 4397	narrow crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
@@ -4413,8 +4413,8 @@
 4465	extra-vacuum-sealed concentrated chocolate saucepan	0		Effect: "The Sweats", Effect Duration: 59
 4466	adjusted polarized narrow chocolate disco ball	0		Effect: "Sparkling Consciousness", Effect Duration: 55
 4467	nitrogenated chocolate stolen accordion	0		Effect: "Fudgehound", Effect Duration: 16
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
-4469	gray blurry BRICKO brick	0		Last Available: "2010-02"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4469	blurry gray BRICKO brick	0		Last Available: "2010-02"
 4470	twirling BRICKO eye brick	0		Last Available: "2010-02"
 4471	Sinatra's BRICKO hat	0		Experience (Moxie): +5, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
 4472	BRICKO pants of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
@@ -4456,13 +4456,13 @@
 4508	deionized &quot;DRINK ME&quot; potion	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 66, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
 4510	tiny spoiled purple walrus ice cream	1	crappy	Last Available: "2010-03"
-4511	flavorless snack-sized beautiful soup	2	decent	Last Available: "2010-03"
+4511	snack-sized flavorless beautiful soup	2	decent	Last Available: "2010-03"
 4512	wobbly eggman noodles	0		Last Available: "2010-03"
 4513	lime green Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	spoiled fuchsia Humpty Dumplings	4	crappy	Last Available: "2010-03"
 4515	flavorless squat Lobster <i>qua</i> Grill	3	decent	Last Available: "2010-03"
 4516	drinkable tumbling missing wine	4	good	Last Available: "2010-03"
-4517	spoiled enchanted ghostly matter custard	4	crappy	Effect: "Fire Inside", Effect Duration: 35, Last Available: "2010-03"
+4517	enchanted spoiled ghostly matter custard	4	crappy	Effect: "Fire Inside", Effect Duration: 35, Last Available: "2010-03"
 4518	tarnished moist aerosolized purple comfit?	0		Effect: "The Living Hitpoints", Effect Duration: 66, Last Available: "2010-03"
 4519	pulsating ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	maroon prompt crafty flamingo mallet	0		Maximum MP: +10, Adventures: +3, Last Available: "2010-03"
@@ -4471,13 +4471,13 @@
 4523	squat Samson's eye of the Tiger-lily of terror	0		Experience (Muscle): +5, Spooky Spell Damage: +10, Last Available: "2010-03"
 4524	shellacked wig of James Dean	0		Experience (Moxie): +3, Damage Reduction: 7, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	miniature decent donut	2	good	Last Available: "2010-03"
-4526	fancy big flavorless bucket of honey	5	decent	Effect: "New Zeal", Effect Duration: 5, Last Available: "2010-03"
+4526	flavorless fancy big bucket of honey	5	decent	Effect: "New Zeal", Effect Duration: 5, Last Available: "2010-03"
 4527	careful banded elephant stinger	0		Damage Absorption: +100, Monster Level: -10, Last Available: "2010-03"
 4528	bland bouncing dragon snaps	4	decent	Last Available: "2010-03"
 4529	squat nippy snapdragon pistil of the brute	0		Muscle Percent: +30, Cold Damage: +10, Last Available: "2010-03"
 4530	yellow puff of smoke	0		Last Available: "2010-03"
 4531	tasty half-sized rook cookie	2	awesome	Last Available: "2010-03"
-4532	low-calorie spoiled huge bishop cookie	1	crappy	Last Available: "2010-03"
+4532	spoiled low-calorie huge bishop cookie	1	crappy	Last Available: "2010-03"
 4533	flavorless knight cookie	3	decent	Last Available: "2010-03"
 4534	bland king cookie	3	decent	Last Available: "2010-03"
 4535	spoiled queen cookie	4	crappy	Effect: "Towering Strength", Last Available: "2010-03"
@@ -4505,7 +4505,7 @@
 4557	ghostly dollar sign	0		
 4558	equal sign	0		
 4559	record album	0		Last Available: "2010-04"
-4560	maroon spinning map to Professor Jacking's laboratory	0		Last Available: "2010-04"
+4560	spinning maroon map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	teal can of depilatory cream	0		Last Available: "2010-04"
 4562	wobbly hair of the calf	0		Last Available: "2010-04"
 4563	practically non-alcoholic mediocre pulsating world's most unappetizing beverage	1	decent	Last Available: "2010-04"
@@ -4513,7 +4513,7 @@
 4565	adequate huge raisin	3	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	savvy flyest of shirts of mayonnaise	0		Mysticality Percent: +20, Sleaze Spell Damage: +50, Last Available: "2010-04"
-4568	small rotten olive a dance upon the palate	2	crappy	Last Available: "2010-04"
+4568	rotten small olive a dance upon the palate	2	crappy	Last Available: "2010-04"
 4569	toothsome prehistoric meteorite jawbreaker	4	awesome	Last Available: "2010-04"
 4570	squat cyan Crazyleg's razor	0		Last Available: "2010-04"
 4571	adequate small squirmy violent party snack	2	good	Last Available: "2010-04"
@@ -4543,10 +4543,10 @@
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
 4597	8-Bit Power magazine	0		Last Available: "2010-07"
-4598	wobbly lime green pixel stopwatch	0		Last Available: "2010-07"
+4598	lime green wobbly pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	maroon map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	smooth weak plastic cup of beer	2	awesome	Last Available: "2010-06"
+4601	weak smooth plastic cup of beer	2	awesome	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	jittery keg	0		Last Available: "2010-06"
@@ -4555,7 +4555,7 @@
 4607	acceptable triple-distilled soyburger juice	10	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	tumbling respected companion biscuit	0		Last Available: "2010-08"
 4609	jittery essential tofu	0		Last Available: "2010-08"
-4610	quadruple-diffused moist jittery twirling essential soy	0		Effect: "Meatwise", Effect Duration: 65, Last Available: "2010-08"
+4610	quadruple-diffused moist twirling jittery essential soy	0		Effect: "Meatwise", Effect Duration: 65, Last Available: "2010-08"
 4611	dry wobbly essential cameraderie	0		Effect: "Pride of the Vampire", Effect Duration: 32, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	spinning yellow map to the Magic Commune	0		Last Available: "2010-08"
@@ -4564,13 +4564,13 @@
 4616	wobbly Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
-4619	narrow fuchsia frisbee	0		Free Pull, Last Available: "2011-12"
+4619	fuchsia narrow frisbee	0		Free Pull, Last Available: "2011-12"
 4620	blurry motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
-4623	altered wobbly skewed chocolate-covered caviar	0		Effect: "Guts Feeling", Effect Duration: 32, Last Available: "2020-09"
-4624	yummy big spinning pawn cookie	5	awesome	Last Available: "2010-06"
-4625	denatured jittery green coffee pixie stick	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 40, Last Available: "2010-06"
+4623	altered skewed wobbly chocolate-covered caviar	0		Effect: "Guts Feeling", Effect Duration: 32, Last Available: "2020-09"
+4624	big yummy spinning pawn cookie	5	awesome	Last Available: "2010-06"
+4625	denatured green jittery coffee pixie stick	1	good	Effect: "Omphalotus Omnipresence", Effect Duration: 40, Last Available: "2010-06"
 4626	blurry bouncing superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	yellow studded blackberry galoshes	0		Damage Absorption: +80, Single Equip
 4660	squat groovy trout fang of the empath	0		Moxie Percent: +10, Familiar Weight: +5, Last Available: "2010-09"
-4661	delicious low-calorie fancy poisonous caviar	1	awesome	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2010-09"
+4661	delicious fancy low-calorie poisonous caviar	1	awesome	Effect: "Magically Delicious", Effect Duration: 5, Last Available: "2010-09"
 4662	denatured twirling wet venom duct	0		Effect: "Ponderous Potency", Effect Duration: 17, Last Available: "2010-09"
 4663	blue Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	huge baleful Ellsbury's skull of vim and vigor	0		Spell Damage: +25, Maximum HP Percent: +50, Last Available: "2010-09"
@@ -4616,9 +4616,9 @@
 4668	rock-hard observational glasses	0		Damage Reduction: 5
 4669	blue hilarious comedy prop of the brute	0		Muscle Percent: +30
 4670	red beer-scented teddy bear	0		
-4671	weak lousy booze-soaked cherry	2	decent	
+4671	lousy weak booze-soaked cherry	2	decent	
 4672	yellow comfy pillow	0		
-4673	toothsome enchanted bite-sized marshmallow	1	awesome	Effect: "Magically Fingered", Effect Duration: 5
+4673	bite-sized toothsome enchanted marshmallow	1	awesome	Effect: "Magically Fingered", Effect Duration: 5
 4674	bland sponge cake	4	decent	
 4675	delicious gin-soaked blotter paper	3	awesome	
 4676	tree-holed coin	0		
@@ -4659,22 +4659,22 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	gray GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	twirling popsicle stick	0		
-4714	decent low-calorie lemon popsicle	1	good	
+4714	low-calorie decent lemon popsicle	1	good	
 4715	spoiled popsicle	4	crappy	
-4716	normal gigantic strawberry popsicle	10	good	
+4716	gigantic normal strawberry popsicle	10	good	
 4717	flavorless liver popsicle	3	decent	
 4718	inspector's mariachi hat	0		Item Drop: +15, Familiar Effect: "atk, cap 2"
 4719	olive squat auspicious Hollandaise helmet	0		Item Drop: +10, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	fuchsia microwave stogie	0		Last Available: "2011-12"
-4722	fancy half-sized delicious liver and let pie	2	awesome	Effect: "BOOsted", Effect Duration: 20, Last Available: "2010-10"
-4723	flavorless olive huge bouncing badass pie	3	decent	Last Available: "2010-10"
+4722	fancy delicious half-sized liver and let pie	2	awesome	Effect: "BOOsted", Effect Duration: 20, Last Available: "2010-10"
+4723	flavorless huge bouncing olive badass pie	3	decent	Last Available: "2010-10"
 4724	rotten shoo-fish pie	4	crappy	Last Available: "2010-10"
-4725	bland upside-down squat piping organ pie	4	decent	Last Available: "2010-10"
+4725	bland squat upside-down piping organ pie	4	decent	Last Available: "2010-10"
 4726	snack-sized bland igloo pie	2	decent	Last Available: "2010-10"
-4727	adequate huge huge stomach turnover	9	good	Last Available: "2010-10"
+4727	huge adequate huge stomach turnover	9	good	Last Available: "2010-10"
 4728	flavorless tumbling dead lights pie	3	decent	Last Available: "2010-10"
-4729	spoiled super-sized fancy green throbbing organ pie	5	crappy	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2010-10"
+4729	super-sized spoiled fancy green throbbing organ pie	5	crappy	Effect: "Educated (Kinda)", Effect Duration: 20, Last Available: "2010-10"
 4730	pulsating ruddy stop shield	0		Maximum HP Percent: +40, Damage Reduction: 6, Last Available: "2009-12"
 4731	red upside-down nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4685,7 +4685,7 @@
 4737	lightning-fast beer-soaked mop	0		Initiative: +40
 4738	mediocre shaking day-old beer	3	decent	
 4739	acceptable squat plain beer	4	good	
-4740	bad practically non-alcoholic overpriced &quot;imported&quot; beer	1	decent	
+4740	practically non-alcoholic bad overpriced &quot;imported&quot; beer	1	decent	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	blinking bone chips	0		Last Available: "2011-12"
@@ -4703,7 +4703,7 @@
 4755	padded boneana hammock of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	red bag of bones	0		Last Available: "2010-10"
 4757	olive Stabonic scroll	0		Last Available: "2010-10"
-4758	quantum activated bouncing twirling candy skeleton	0		Effect: "Ooh, Sweet!", Effect Duration: 20, Last Available: "2020-09"
+4758	quantum activated twirling bouncing candy skeleton	0		Effect: "Ooh, Sweet!", Effect Duration: 20, Last Available: "2020-09"
 4759	olive Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	pulsating olive packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	olive pumpkin	0		Last Available: "2010-11"
@@ -4719,21 +4719,21 @@
 4771	ginormous pumpkin	0		Last Available: "2010-11"
 4804	Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
-4806	narrow pulsating mirror Unmotivator: Success Warrior	0		Free Pull
+4806	mirror narrow pulsating Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	rotten huge CRIMBCOIDS mints	6	crappy	Last Available: "2011-01"
+4818	huge rotten CRIMBCOIDS mints	6	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	stale small gray CRIMBCOLOAF	2	decent	Last Available: "2011-01"
-4821	huge rotten circular CRIMBCOOKIE	6	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	rotten huge circular CRIMBCOOKIE	6	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	ghostly yellow Usain Bolt's plastic CRIMBCO HQ	0		Initiative: +80, Last Available: "2010-12"
 4823	Da Vinci's plastic fax machine	0		Experience (Mysticality): +5, Last Available: "2010-12"
 4824	plastic hobo elf of the bloodbag	0		Maximum HP: +100, Last Available: "2010-12"
 4825	mirror wizardly plastic Mr. Mination	0		Mysticality: +25, Last Available: "2010-12"
 4826	blinking stiffened plastic Best Game Ever	0		Damage Reduction: 1, Last Available: "2010-12"
-4827	spinning olive hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
+4827	olive spinning hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	squat robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
@@ -4784,7 +4784,7 @@
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	ionized denatured lime green chocolate bath ball	0		Effect: "Moon'd", Effect Duration: 33, Last Available: "2011-01"
 4877	deionized triple-chilled squat bacon bath ball	0		Effect: "Nuts about Candy", Effect Duration: 65, Last Available: "2011-01"
-4878	corrupted diffused altered gray blinking incense bath ball	0		Effect: "Slimy Flavor", Effect Duration: 64, Last Available: "2011-01"
+4878	corrupted diffused altered blinking gray incense bath ball	0		Effect: "Slimy Flavor", Effect Duration: 64, Last Available: "2011-01"
 4879	modified maroon myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Helvella Health", Effect Duration: 53, Last Available: "2011-01"
 4880	narrow CRIMBCO mug	0		Last Available: "2011-01"
 4881	bad CRIMBCO wine	3	decent	Last Available: "2011-01"
@@ -4801,7 +4801,7 @@
 4892	skewed slow jam collection	0		Last Available: "2011-01"
 4893	skewed BGE shotglass	0		Last Available: "2010-12"
 4894	rotten festive sausage	3	crappy	Last Available: "2011-01"
-4895	small normal holiday cheese log	2	good	Last Available: "2011-01"
+4895	normal small holiday cheese log	2	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	Herculean BGE 'ferocious fruit' shirt of Tarzan	0		Experience (Muscle): 4, Last Available: "2010-12"
 4898	cyan chilly strapping BGE 'cuddly critter' shirt	0		Muscle: +5, Cold Damage: +5, Last Available: "2010-12"
@@ -4856,7 +4856,7 @@
 4953	huge medical-grade whalebone corset of the brute	0		Muscle Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Single Equip
 4954	oven mitts of doom	0		Spooky Spell Damage: +50, Single Equip
 4955	normal gray overcookie	4	good	
-4956	tiny delicious mirror philosopher's scone	1	awesome	
+4956	delicious tiny mirror philosopher's scone	1	awesome	
 4957	corrupted wobbly half-baked potion	0		Effect: "Super-Mega-Charged", Effect Duration: 27
 4958	stylish Knob Goblin deluxe scimitar	0		Moxie: +25
 4959	moldy Knob nuts	3	crappy	
@@ -4914,19 +4914,19 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	diet decent maroon skewed wasabi pocky	1	good	Last Available: "2011-03"
-5014	enchanted miniature bland bouncing tobiko pocky	2	decent	Effect: "Uncucumbered", Effect Duration: 15, Last Available: "2011-03"
+5014	bland enchanted miniature bouncing tobiko pocky	2	decent	Effect: "Uncucumbered", Effect Duration: 15, Last Available: "2011-03"
 5015	spoiled bite-sized natto pocky	1	crappy	Last Available: "2011-03"
-5016	lousy enchanted wasabi-infused sake	3	decent	Effect: "Net Tea", Effect Duration: 15, Last Available: "2011-03"
-5017	drinkable watered-down tobiko-infused sake	2	good	Last Available: "2011-03"
-5018	mediocre fortified natto-infused sake	5	decent	Last Available: "2011-03"
+5016	enchanted lousy wasabi-infused sake	3	decent	Effect: "Net Tea", Effect Duration: 15, Last Available: "2011-03"
+5017	watered-down drinkable tobiko-infused sake	2	good	Last Available: "2011-03"
+5018	fortified mediocre natto-infused sake	5	decent	Last Available: "2011-03"
 5019	Vulcanized triple-pickled wasabi marble soda	0		Effect: "On a Roll", Effect Duration: 14, Last Available: "2011-03"
 5020	double-cold-filtered boiled altered narrow tobiko marble soda	0		Effect: "Marinated", Effect Duration: 65, Last Available: "2011-03"
 5021	chilled activated natto marble soda	0		Effect: "Stinky Hands", Effect Duration: 59, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	nitrogenated double-dry elderly jawbreaker	0		Effect: "Purpose", Effect Duration: 34, Last Available: "2020-09"
-5024	high-proof acceptable marshmallow flamb&eacute;	8	good	Last Available: "2011-03"
+5024	acceptable high-proof marshmallow flamb&eacute;	8	good	Last Available: "2011-03"
 5025	tolerable cranberry schnapps	3	good	Last Available: "2011-03"
-5026	fancy lousy breaded beer	4	decent	Effect: "Staying Frosty", Effect Duration: 10, Last Available: "2011-03"
+5026	lousy fancy breaded beer	4	decent	Effect: "Staying Frosty", Effect Duration: 10, Last Available: "2011-03"
 5027	drinkable soy cordial	3	good	Last Available: "2011-03"
 5028	prompt gravedigger's astral bludgeon of the bloodbag	0		Maximum HP: +100, Spooky Damage: +10, Adventures: +3
 5029	bouncing olive coward's supercharged astral shield	0		Maximum MP Percent: +30, Monster Level: -20, Damage Reduction: 15
@@ -4968,7 +4968,7 @@
 5065	miniature moldy pulsating spaghetti con calaveras	2	crappy	Last Available: "2011-04"
 5066	upside-down s'more gun	0		Last Available: "2011-04"
 5067	stale popcorn	3	decent	Last Available: "2011-04"
-5068	toothsome special huge chaos popcorn	3	awesome	Last Available: "2011-04"
+5068	special toothsome huge chaos popcorn	3	awesome	Last Available: "2011-04"
 5069	knitted veiny personal trainer's hole	0		Experience Percent (Muscle): +10, Maximum HP: +10, Cold Resistance: +3, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	massive flavorless wobbly s'more	0	decent	Last Available: "2011-04"
@@ -5020,7 +5020,7 @@
 5117	blurry reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
 5119	busted wings	0		
-5120	blurry teal Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
+5120	teal blurry Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	horrifying hardened Admiral's hat of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Spooky Damage: +25, Familiar Effect: "atk", Last Available: "2011-05"
 5122	blinking vibrating aviator's cap of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Maximum MP Percent: +10, Sleaze Spell Damage: +50, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	gray bouncing Usain Bolt's mirrored aviator shades of the cheetah	0		Initiative: 140, Single Equip, Last Available: "2011-05"
@@ -5033,7 +5033,7 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	Vulcanized gray Ultrasoldier Serum	0		Effect: "Human-Goblin Hybrid", Effect Duration: 21, Last Available: "2011-06"
 5132	yummy lime green elven hardtack	3	awesome	Last Available: "2011-06"
-5133	fancy bad spinning elven squeeze	3	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 35, Last Available: "2011-06"
+5133	bad fancy spinning elven squeeze	3	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 35, Last Available: "2011-06"
 5134	purple lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	squat E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5046,7 +5046,7 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	fuchsia handful of honey	0		
 5145	irradiated tarnished deionized honeypot	0		Effect: "Carrrsmic", Effect Duration: 23
-5146	special flavorless spinning wild honey pie	4	decent	Effect: "Kernel Panic!", Effect Duration: 5
+5146	flavorless special spinning wild honey pie	4	decent	Effect: "Kernel Panic!", Effect Duration: 5
 5147	hand-crafted honey mead	3	EPIC	
 5148	upside-down inspector's honey dipper of vim and vigor of the boozehound	0		Maximum HP Percent: +50, Item Drop: +15, Booze Drop: +100
 5149	narrow scandalous friendly sharpshooter's honeybritches	0		Critical Hit Percent: +10, Familiar Weight: +3, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
@@ -5074,12 +5074,12 @@
 5171	gray Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	spinning Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	bad practically non-alcoholic tumbling Saison du Lune	1	decent	Last Available: "2011-06"
+5174	practically non-alcoholic bad tumbling Saison du Lune	1	decent	Last Available: "2011-06"
 5175	lousy ghostly Moonthril Schnapps	4	decent	Last Available: "2011-06"
-5176	tolerable watered-down skewed Wrecked Generator	2	good	Last Available: "2011-06"
+5176	watered-down tolerable skewed Wrecked Generator	2	good	Last Available: "2011-06"
 5177	small spoiled Spaghetti with Moonballs	2	crappy	Last Available: "2011-06"
-5178	special flavorless Crepes a la Lune	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2011-06"
-5179	special yummy snack-sized skewed Moon Pie	2	awesome	Effect: "Yet tea", Effect Duration: 30, Last Available: "2011-06"
+5178	flavorless special Crepes a la Lune	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2011-06"
+5179	snack-sized yummy special skewed Moon Pie	2	awesome	Effect: "Yet tea", Effect Duration: 30, Last Available: "2011-06"
 5180	dry modified Comet Pop	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 32, Last Available: "2011-06"
 5181	concentrated deionized anodized huge Flan in the Moon	0		Effect: "Hoity Toity", Effect Duration: 67, Last Available: "2011-06"
 5182	non-dry spinning 1/6th Pound Cake	0		Effect: "Feeling No Pain", Effect Duration: 24, Last Available: "2011-06"
@@ -5093,8 +5093,8 @@
 5190	Jeselnik's chilly wizardly Operation Patriot Shield	0		Mysticality: +25, Cold Damage: +5, Sleaze Damage: +25, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	chilled teal pulsating corrupted data	0		Effect: "Stinky Hands", Effect Duration: 49, Last Available: "2011-06"
-5193	tumbling skewed 11-inch knob sausage	0		
-5194	cyan twirling exorcised sandwich	0		
+5193	skewed tumbling 11-inch knob sausage	0		
+5194	twirling cyan exorcised sandwich	0		
 5195	maroon Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	shaking hale Great S-Cape	0		Maximum HP: +20, Softcore Only, Last Available: "2011-07"
 5197	jittery slick Marvelous Unitard	0		Moxie: +10, Softcore Only, Last Available: "2011-07"
@@ -5103,19 +5103,19 @@
 5200	modified paste	1	good	Last Available: "2011-08"
 5201	distilled ectoplasmic paste	1	crappy	Effect: "Sugary World View", Effect Duration: 10, Last Available: "2011-08"
 5202	powdered olive greasy paste	1	awesome	Effect: "Ocelot Eyes", Effect Duration: 5, Last Available: "2011-08"
-5203	dehydrated squat blinking bug paste	1	awesome	Last Available: "2011-08"
+5203	dehydrated blinking squat bug paste	1	awesome	Last Available: "2011-08"
 5204	denatured green hippy paste	1	good	Last Available: "2011-08"
-5205	altered skewed bouncing blinking orc paste	1	good	Last Available: "2011-08"
+5205	altered blinking bouncing skewed orc paste	1	good	Last Available: "2011-08"
 5206	powdered lime green demonic paste	1	good	Last Available: "2011-08"
 5207	boiled lime green indescribably horrible paste	1	good	Effect: "It's Electric!", Effect Duration: 5, Last Available: "2011-08"
-5208	powdered wobbly pulsating paste	1	EPIC	Effect: "Pasty", Effect Duration: 35, Last Available: "2011-08"
+5208	powdered pulsating wobbly paste	1	EPIC	Effect: "Pasty", Effect Duration: 35, Last Available: "2011-08"
 5209	diluted goblin paste	1	good	Last Available: "2011-08"
 5210	powdered pirate paste	1	EPIC	Last Available: "2011-08"
 5211	denatured blue chlorophyll paste	1	awesome	Effect: "Partially Ghosted", Effect Duration: 35, Last Available: "2011-08"
 5212	denatured paste	1	EPIC	Last Available: "2011-08"
 5213	dried Mer-kin paste	1	awesome	Last Available: "2011-08"
 5214	pickled slimy paste	1	decent	Last Available: "2011-08"
-5215	diluted blinking fuchsia bouncing penguin paste	1	decent	Last Available: "2011-08"
+5215	diluted bouncing blinking fuchsia penguin paste	1	decent	Last Available: "2011-08"
 5216	powdered upside-down yellow elemental paste	1	good	Last Available: "2011-08"
 5217	altered bouncing cosmic paste	1	decent	Last Available: "2011-08"
 5218	altered cyan hobo paste	1	decent	Last Available: "2011-08"
@@ -5123,12 +5123,12 @@
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	ghostly Thwaitgold grasshopper statuette	0		
-5223	twirling narrow Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	narrow twirling Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	toothsome jittery Ur-Donut	3	awesome	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	aged boozy skewed bucket of wine	5	awesome	Last Available: "2011-09"
-5228	immense spoiled cyan pulsating ultrafondue	9	crappy	Last Available: "2011-09"
+5228	spoiled immense pulsating cyan ultrafondue	9	crappy	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
@@ -5139,19 +5139,19 @@
 5236	bouncing frosty halo of the cougar	0		Moxie: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	extremely unsafe time halo	0		Weapon Damage Percent: +100, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	delicious Lumineux Limnio	3	awesome	Last Available: "2011-09"
-5239	fancy drinkable jittery Morto Moreto	4	good	Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2011-09"
-5240	acceptable maroon upside-down spinning Temps Tempranillo	4	good	Last Available: "2011-09"
+5239	drinkable fancy jittery Morto Moreto	4	good	Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2011-09"
+5240	acceptable upside-down spinning maroon Temps Tempranillo	4	good	Last Available: "2011-09"
 5241	hand-crafted Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
-5242	irresponsibly strong delicious jittery Fromage Pinotage	10	awesome	Last Available: "2011-09"
+5242	delicious irresponsibly strong jittery Fromage Pinotage	10	awesome	Last Available: "2011-09"
 5243	triple-distilled mediocre Beignet Milgranet	6	decent	Last Available: "2011-09"
 5244	tolerable Muschat	3	good	Last Available: "2011-09"
 5245	normal squat cool jelly donut	4	good	Last Available: "2011-09"
 5246	yummy miniature shrapnel jelly donut	2	awesome	Last Available: "2011-09"
 5247	moldy occult jelly donut	4	crappy	Last Available: "2011-09"
-5248	snack-sized spoiled thyme jelly donut	2	crappy	Last Available: "2011-09"
-5249	diet tasty danish	1	awesome	Last Available: "2011-09"
+5248	spoiled snack-sized thyme jelly donut	2	crappy	Last Available: "2011-09"
+5249	tasty diet danish	1	awesome	Last Available: "2011-09"
 5250	normal smashed danish	3	good	Last Available: "2011-09"
-5251	fancy rotten forbidden danish	3	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 40, Last Available: "2011-09"
+5251	rotten fancy forbidden danish	3	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 40, Last Available: "2011-09"
 5252	normal super-sized mirror cool cat claw	5	good	Last Available: "2011-09"
 5253	spoiled lime green blunt cat claw	4	crappy	Last Available: "2011-09"
 5254	decent fancy shadowy cat claw	4	good	Effect: "Flower Power", Effect Duration: 30, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of chilblains	0		Cold Damage: +25, Last Available: "2011-09"
 5282	jittery beefy dethklok	0		Muscle: +10, Last Available: "2011-09"
 5283	studded glacial clock	0		Damage Absorption: +80, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5222,8 +5222,8 @@
 5319	non-colloidal Blood 'n' Plenty	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 47, Last Available: "2011-10"
 5320	deionized Lobos Mints	0		Effect: "World's Shortest Giant", Effect Duration: 63, Last Available: "2011-10"
 5321	adjusted boiled gray Sweet Sword	0		Effect: "Abominably Slippery", Effect Duration: 52, Last Available: "2011-10"
-5322	watered-down hand-crafted pulsating Ecto-Cooler	2	EPIC	Last Available: "2011-10"
-5323	special irresponsibly strong acceptable squat Bartles and BRAAAINS wine cooler	10	good	Effect: "Papowerful", Effect Duration: 20, Last Available: "2011-10"
+5322	hand-crafted watered-down pulsating Ecto-Cooler	2	EPIC	Last Available: "2011-10"
+5323	special acceptable irresponsibly strong squat Bartles and BRAAAINS wine cooler	10	good	Effect: "Papowerful", Effect Duration: 20, Last Available: "2011-10"
 5324	smooth Blood Light	3	awesome	Last Available: "2011-10"
 5325	tolerable Silver Bullet beer	3	good	Last Available: "2011-10"
 5326	drinkable Bone's Farm &quot;wine&quot;	4	good	Last Available: "2011-10"
@@ -5281,7 +5281,7 @@
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
 5379	pickled groose grease	1	good	Last Available: "2012-12"
 5380	lollipop stick	0		Last Available: "2011-11"
-5381	huge skewed bananagate	0		Last Available: "2011-11"
+5381	skewed huge bananagate	0		Last Available: "2011-11"
 5382	ghostly pearidot	0		Last Available: "2011-11"
 5383	huge ghostly tourmalime	0		Last Available: "2011-11"
 5384	red kumquartz	0		Last Available: "2011-11"
@@ -5311,8 +5311,8 @@
 5408	practically non-alcoholic delicious Gin Mint	1	awesome	Last Available: "2011-12"
 5409	perfectly mixed practically non-alcoholic Tequiz Navidad	1	super ultra mega turbo EPIC	Last Available: "2011-12"
 5410	practically non-alcoholic tolerable Mint Yulep	1	good	Last Available: "2011-12"
-5411	practically non-alcoholic special lousy Crimbojito	1	decent	Effect: "Fizzier Than Light", Effect Duration: 15, Last Available: "2011-12"
-5412	watered-down mediocre gray Sangria de Menthe	2	decent	Last Available: "2011-12"
+5411	lousy practically non-alcoholic special Crimbojito	1	decent	Effect: "Fizzier Than Light", Effect Duration: 15, Last Available: "2011-12"
+5412	mediocre watered-down gray Sangria de Menthe	2	decent	Last Available: "2011-12"
 5413	squat candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	altered licorice root	0		Effect: "Greedy Resolve", Effect Duration: 20, Last Available: "2011-12"
@@ -5355,15 +5355,15 @@
 5452	red avarice stone	0		Last Available: "2012-12"
 5453	gluttonous stone	0		Last Available: "2012-12"
 5454	jittery gummi ingot	0		Last Available: "2011-11"
-5455	wobbly yellow gummi ingot	0		Last Available: "2011-11"
+5455	yellow wobbly gummi ingot	0		Last Available: "2011-11"
 5456	bouncing gummi ingot	0		Last Available: "2011-11"
-5457	concentrated colloidal skewed cyan Fudgie Roll	0		Effect: "Cybernetic Muscles", Effect Duration: 29, Last Available: "2011-11"
+5457	concentrated colloidal cyan skewed Fudgie Roll	0		Effect: "Cybernetic Muscles", Effect Duration: 29, Last Available: "2011-11"
 5458	toothsome massive fudge bunny	8	awesome	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	lightning-fast crafty fudgecycle of doom	0		Maximum MP: +10, Spooky Spell Damage: +50, Initiative: +40, Single Equip, Last Available: "2011-11"
 5461	olive fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	unsweetened maroon resolution: be wealthier	0		Effect: "Glo-Face", Effect Duration: 45, Last Available: "2012-01"
 5465	flattened resolution: be happier	0		Effect: "X-Ray Vision", Effect Duration: 65, Last Available: "2012-01"
 5466	colloidal jittery resolution: be stronger	0		Effect: "Spiritually Awake", Effect Duration: 69, Last Available: "2012-01"
@@ -5372,7 +5372,7 @@
 5469	ionized dry denatured narrow resolution: be feistier	0		Effect: "Slimily Strong", Effect Duration: 61, Last Available: "2012-01"
 5470	anodized resolution: be kinder	0		Effect: "Bright!", Effect Duration: 47, Last Available: "2012-01"
 5471	enhanced resolution: be more adventurous	0		Effect: "Heart of Pink", Effect Duration: 16, Last Available: "2012-01"
-5472	Vulcanized narrow yellow resolution: be luckier	0		Effect: "Sweet and Red", Effect Duration: 40, Last Available: "2012-01"
+5472	Vulcanized yellow narrow resolution: be luckier	0		Effect: "Sweet and Red", Effect Duration: 40, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	maroon gummi ingot	0		Last Available: "2011-11"
 5475	cyan gummi ingot	0		Last Available: "2011-11"
@@ -5383,7 +5383,7 @@
 5480	immense toothsome gummi bear	9	awesome	Last Available: "2011-11"
 5481	adequate green gummi bear	3	good	Last Available: "2011-11"
 5482	snack-sized spoiled drunki-bear	2	crappy	Last Available: "2011-11"
-5483	miniature bland pulsating ghostly drunki-bear	2	decent	Last Available: "2011-11"
+5483	bland miniature pulsating ghostly drunki-bear	2	decent	Last Available: "2011-11"
 5484	rotten half-sized shaking drunki-bear	2	crappy	Last Available: "2011-11"
 5485	blurry frosty gummi bowtie	0		Cold Spell Damage: +10, Last Available: "2011-11"
 5486	wicked fudge pocket square	0		Spell Damage: +5, Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	nitrogenated vacuum-sealed irradiated Atomic Pop	0		Effect: "Ichorous Intensity", Effect Duration: 32, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	massive yummy squat purple berries of suffering	7	awesome	Last Available: "2012-12"
+5529	yummy massive squat purple berries of suffering	7	awesome	Last Available: "2012-12"
 5530	non-warmed blurry baobab sap	0		Effect: "Punchy, Murdery", Effect Duration: 29, Last Available: "2012-12"
 5531	cyan cup of hickory chicory	0		Last Available: "2012-12"
 5532	narrow magnolia blossom	0		Last Available: "2012-12"
@@ -5445,9 +5445,9 @@
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	blurry ghostly wizardly Leapin' Trousers of courage	0		Mysticality: +25, Spooky Resistance: +3
 5544	bad eggnog	3	decent	Last Available: "2012-12"
-5545	yummy diet green hamhock	1	awesome	Last Available: "2012-12"
+5545	diet yummy green hamhock	1	awesome	Last Available: "2012-12"
 5546	upside-down blurry The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
-5547	squat ghostly squat Clancy's sackbut	0		Last Available: "2012-12"
+5547	squat squat ghostly Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
 5549	maroon Clancy's crumhorn	0		Last Available: "2012-12"
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
@@ -5477,67 +5477,67 @@
 5574	artisanal fancy wobbly Transylvania Sling	4	EPIC	Effect: "Smokin'", Effect Duration: 10, Last Available: "2012-03"
 5575	hand-crafted practically non-alcoholic Shot of the Living Dead	1	super ultra EPIC	Last Available: "2012-03"
 5576	mediocre Buttery Knob	3	decent	Last Available: "2012-03"
-5577	practically non-alcoholic smooth Slippery Knob	1	awesome	Last Available: "2012-03"
+5577	smooth practically non-alcoholic Slippery Knob	1	awesome	Last Available: "2012-03"
 5578	strong drinkable Flaming Knob	5	good	Last Available: "2012-03"
 5579	tolerable practically non-alcoholic Grasshopper	1	good	Last Available: "2012-03"
-5580	weak smooth Locust	2	awesome	Last Available: "2012-03"
+5580	smooth weak Locust	2	awesome	Last Available: "2012-03"
 5581	tolerable Plague of Locusts	4	good	Last Available: "2012-03"
 5582	bad Red Dwarf	3	decent	Last Available: "2012-03"
 5583	acceptable Golden Mean	3	good	Last Available: "2012-03"
 5584	tolerable twirling Green Giant	3	good	Last Available: "2012-03"
-5585	fortified mediocre huge blue ghostly Aye Aye	5	decent	Last Available: "2012-03"
+5585	mediocre fortified huge ghostly blue Aye Aye	5	decent	Last Available: "2012-03"
 5586	perfectly mixed Aye Aye, Captain	3	EPIC	Last Available: "2012-03"
-5587	lousy enchanted twirling Aye Aye, Tooth Tooth	4	decent	Effect: "Mmmmmelon", Effect Duration: 50, Last Available: "2012-03"
+5587	enchanted lousy twirling Aye Aye, Tooth Tooth	4	decent	Effect: "Mmmmmelon", Effect Duration: 50, Last Available: "2012-03"
 5588	fancy delicious Humanitini	3	awesome	Effect: "Afternoon Insight", Effect Duration: 35, Last Available: "2012-03"
 5589	lousy skewed More Humanitini than Humanitini	3	decent	Last Available: "2012-03"
 5590	acceptable weak Oh, the Humanitini	2	good	Last Available: "2012-03"
 5591	lousy twirling Great Older Fashioned	4	decent	Last Available: "2012-03"
-5592	weak artisanal Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
-5593	special delicious pulsating Crazymaker	4	awesome	Effect: "Block-Rockin' Beet", Effect Duration: 40, Last Available: "2012-03"
+5592	artisanal weak Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5593	delicious special pulsating Crazymaker	4	awesome	Effect: "Block-Rockin' Beet", Effect Duration: 40, Last Available: "2012-03"
 5594	smooth Zoodriver	4	awesome	Last Available: "2012-03"
 5595	artisanal Sloe Comfortable Zoo	4	EPIC	Last Available: "2012-03"
 5596	bad yellow Sloe Comfortable Zoo on Fire	3	decent	Last Available: "2012-03"
 5597	lousy Suffering Sinner	4	decent	Last Available: "2012-03"
 5598	lousy upside-down wobbly Suppurating Sinner	4	decent	Last Available: "2012-03"
-5599	lousy weak bouncing Sizzling Sinner	2	decent	Last Available: "2012-03"
-5600	watered-down artisanal jittery Firewater	2	EPIC	Last Available: "2012-03"
+5599	weak lousy bouncing Sizzling Sinner	2	decent	Last Available: "2012-03"
+5600	artisanal watered-down jittery Firewater	2	EPIC	Last Available: "2012-03"
 5601	artisanal fancy Earth and Firewater	3	EPIC	Effect: "Ooh, Salty!", Effect Duration: 30, Last Available: "2012-03"
 5602	acceptable Earth, Wind and Firewater	4	good	Last Available: "2012-03"
 5603	aged watered-down Slimosa	2	awesome	Last Available: "2012-03"
 5604	weak acceptable Extra-slimy Slimosa	2	good	Last Available: "2012-03"
 5605	hand-crafted Slimebite	3	EPIC	Last Available: "2012-03"
 5606	tolerable Cement Mixer	3	good	Last Available: "2012-03"
-5607	drinkable high-proof Jackhammer	6	good	Last Available: "2012-03"
+5607	high-proof drinkable Jackhammer	6	good	Last Available: "2012-03"
 5608	artisanal distilled Dump Truck	5	EPIC	Last Available: "2012-03"
 5609	artisanal bouncing Fauna Libre	3	EPIC	Last Available: "2012-03"
-5610	lousy upside-down spinning Chakra Libre	3	decent	Last Available: "2012-03"
+5610	lousy spinning upside-down Chakra Libre	3	decent	Last Available: "2012-03"
 5611	smooth mirror tumbling Aura Libre	4	awesome	Last Available: "2012-03"
 5612	smooth Sazerorc	3	awesome	Last Available: "2012-03"
 5613	acceptable practically non-alcoholic Sazuruk-hai	1	good	Last Available: "2012-03"
-5614	watered-down bad Flaming Sazerorc	2	decent	Last Available: "2012-03"
+5614	bad watered-down Flaming Sazerorc	2	decent	Last Available: "2012-03"
 5615	mediocre watered-down blurry Green Velvet	2	decent	Last Available: "2012-03"
 5616	perfectly mixed shaking Green Muslin	3	EPIC	Last Available: "2012-03"
 5617	perfectly mixed Green Burlap	4	EPIC	Last Available: "2012-03"
 5618	artisanal mirror Mohobo	4	EPIC	Last Available: "2012-03"
-5619	hand-crafted fancy pulsating Moonshine Mohobo	3	EPIC	Effect: "Fire Inside", Effect Duration: 15, Last Available: "2012-03"
+5619	fancy hand-crafted pulsating Moonshine Mohobo	3	EPIC	Effect: "Fire Inside", Effect Duration: 15, Last Available: "2012-03"
 5620	mediocre Flaming Mohobo	3	decent	Last Available: "2012-03"
-5621	bad special mirror Drunken Philosopher	3	decent	Effect: "Aloofah", Effect Duration: 15, Last Available: "2012-03"
+5621	special bad mirror Drunken Philosopher	3	decent	Effect: "Aloofah", Effect Duration: 15, Last Available: "2012-03"
 5622	aged Drunken Neurologist	4	awesome	Last Available: "2012-03"
-5623	weak mediocre olive Drunken Astrophysicist	2	decent	Last Available: "2012-03"
-5624	weak lousy blinking narrow Dark & Starry	2	decent	Last Available: "2012-03"
+5623	mediocre weak olive Drunken Astrophysicist	2	decent	Last Available: "2012-03"
+5624	weak lousy narrow blinking Dark & Starry	2	decent	Last Available: "2012-03"
 5625	drinkable blue Black Hole	4	good	Last Available: "2012-03"
 5626	bad Event Horizon	3	decent	Last Available: "2012-03"
 5627	artisanal Herring Daiquiri	4	EPIC	Last Available: "2012-03"
 5628	tolerable fortified tumbling Herring Wallbanger	5	good	Last Available: "2012-03"
 5629	perfectly mixed Herringtini	3	EPIC	Last Available: "2012-03"
-5630	acceptable weak narrow Lollipop Drop	2	good	Last Available: "2012-03"
-5631	drinkable fortified Candy Alexander	5	good	Last Available: "2012-03"
+5630	weak acceptable narrow Lollipop Drop	2	good	Last Available: "2012-03"
+5631	fortified drinkable Candy Alexander	5	good	Last Available: "2012-03"
 5632	high-proof delicious ghostly Candicaine	10	awesome	Last Available: "2012-03"
 5633	delicious Caipiranha	3	awesome	Last Available: "2012-03"
 5634	watered-down delicious Flying Caipiranha	2	awesome	Last Available: "2012-03"
 5635	mediocre Flaming Caipiranha	3	decent	Last Available: "2012-03"
 5636	artisanal practically non-alcoholic Punchplanter	1	EPIC	Last Available: "2012-03"
-5637	high-proof perfectly mixed Doublepunchplanter	8	EPIC	Last Available: "2012-03"
+5637	perfectly mixed high-proof Doublepunchplanter	8	EPIC	Last Available: "2012-03"
 5638	practically non-alcoholic lousy Haymaker	1	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
@@ -5554,7 +5554,7 @@
 5651	olive jittery mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	special flavorless massive twirling narrow nailswurst	10	decent	Effect: "Arse-a'fire", Effect Duration: 20
+5654	massive special flavorless narrow twirling nailswurst	10	decent	Effect: "Arse-a'fire", Effect Duration: 20
 5655	tolerable used beer	3	good	
 5656	teal Huggler Radio	0		Free Pull
 5657	fuchsia fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
@@ -5570,7 +5570,7 @@
 5667	puppet strings	0		Free Pull
 5668	purple bagged &quot;L&quot;	0		
 5669	club	0		
-5670	moldy fancy fettucini &eacute;pines Inconnu	3	crappy	Effect: "Sweet and Red", Effect Duration: 20
+5670	fancy moldy fettucini &eacute;pines Inconnu	3	crappy	Effect: "Sweet and Red", Effect Duration: 20
 5671	artisanal special slap and slap again	3	EPIC	Effect: "Liquid Luck", Effect Duration: 10
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
@@ -5581,7 +5581,7 @@
 5678	soggy used band-aid	0		Last Available: "2012-05"
 5679	up-at-dawn stylish swimsuit of the wise owl	0		Mysticality: +20, Adventures: +5, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
-5681	moldy half-sized P.B.L.T.	2	crappy	
+5681	half-sized moldy P.B.L.T.	2	crappy	
 5682	squat note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	wobbly handful of juicy garbage	0		
@@ -5591,20 +5591,20 @@
 5688	skewed UV monocular of terror	0		Spooky Spell Damage: +10, Single Equip
 5689	huge drone self-destruct chip	0		
 5690	Jeff Goldblum larva	0		
-5691	wobbly huge pacification grenade	0		
+5691	huge wobbly pacification grenade	0		
 5692	quantum disintegrator pistol of the detective	0		Item Drop: +20
 5693	blurry hardy phase-tuned shield generator belt	0		Maximum HP: +50, Single Equip
 5694	upside-down Thwaitgold woollybear statuette	0		
 5695	slick bugbear detector	0		Moxie: +10, Single Equip
-5696	gray blurry bugbear purification pill	0		
+5696	blurry gray bugbear purification pill	0		
 5697	1 Meat	0		
 5698	steel-toed The Lost Glasses of bravery	0		Damage Reduction: 9, Spooky Resistance: +5, Single Equip
 5699	cyan The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	green The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	shaking mannequin	0		Familiar Weight: +5
-5703	blurry bouncing crayon shavings	0		Last Available: "2012-06"
-5704	upside-down shaking wax bugbear	0		Last Available: "2012-06"
+5703	bouncing blurry crayon shavings	0		Last Available: "2012-06"
+5704	shaking upside-down wax bugbear	0		Last Available: "2012-06"
 5705	curative Sinatra's wax hat	0		Experience (Moxie): +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
 5706	Van der Graaf wax pants of wisdom	0		Mysticality: +15, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
@@ -5615,7 +5615,7 @@
 5714	FDKOL tattoo	0		
 5715	fuchsia Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	half-sized decent shaking blue FDKOL hotcakes	2	good	Last Available: "2012-07"
+5717	half-sized decent blue shaking FDKOL hotcakes	2	good	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	decent fiery wing	3	good	Last Available: "2012-07"
@@ -5629,7 +5629,7 @@
 5728	narrow foot-long hot daub of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP: +100, Last Available: "2012-07"
 5729	blurry ballpark hot daub	0		Last Available: "2012-07"
 5730	yummy angst burger	4	awesome	
-5731	enchanted weak acceptable skewed 5-hour acrimony	2	good	Effect: "Salad Days", Effect Duration: 50
+5731	enchanted acceptable weak skewed 5-hour acrimony	2	good	Effect: "Salad Days", Effect Duration: 50
 5732	blank note	0		
 5733	huge eerily silent box	0		
 5734	decent forbidden sausage	4	good	
@@ -5637,14 +5637,14 @@
 5736	tarnished Drizzlers&trade; Black Licorice	0		Effect: "Metal Speed", Effect Duration: 54
 5737	dry blinking daub-breaker	0		Effect: "Melancholy Burden", Effect Duration: 48, Last Available: "2020-09"
 5738	tumbling Camp Scout backpack of the brazier	0		Hot Spell Damage: +25, Softcore Only, Last Available: "2012-07"
-5739	bouncing wobbly CSA fire-starting kit	0		Last Available: "2012-07"
+5739	wobbly bouncing CSA fire-starting kit	0		Last Available: "2012-07"
 5740	miniature flavorless cyan bag of GORP	2	decent	Last Available: "2012-07"
 5741	perfectly mixed water purification pills	4	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	special mediocre CSA scoutmaster's &quot;water&quot;	3	decent	Effect: "Aloofah", Effect Duration: 5, Last Available: "2012-07"
 5744	normal yellow bag of GORF	3	good	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	immense rotten bag of QWOP	9	crappy	Last Available: "2012-07"
+5746	rotten immense bag of QWOP	9	crappy	Last Available: "2012-07"
 5747	non-ionized CSA bravery badge	0		Effect: "Highland Sheen", Effect Duration: 44, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	perfectly mixed bouncing CSA cheerfulness ration	3	EPIC	Last Available: "2012-07"
@@ -5680,7 +5680,7 @@
 5781	artisanal soft echo eyedrop antidote martini	3	EPIC	
 5782	morningwood plank	0		
 5783	upside-down raging hardwood plank	0		
-5784	maroon blinking weirdwood plank	0		
+5784	blinking maroon weirdwood plank	0		
 5785	thick caulk	0		
 5786	hard screw	0		
 5787	messy butt joint	0		
@@ -5711,27 +5711,27 @@
 5812	adjusted colloidal mirror shaking skelelton spine	0		Effect: "Steroid Boost", Effect Duration: 28
 5813	Vulcanized modified wobbly smut orc sunglasses	0		Effect: "The Power of LOV", Effect Duration: 43
 5814	quadruple-warmed blob of acid	0		Effect: "[1609]Dancin' Fool", Effect Duration: 31
-5815	diffused frozen spinning ghostly flayed mind	0		Effect: "Quiet 'n' Good", Effect Duration: 47
+5815	diffused frozen ghostly spinning flayed mind	0		Effect: "Quiet 'n' Good", Effect Duration: 47
 5816	flattened irradiated kobold kibble	0		Effect: "Hood Ridin'", Effect Duration: 53
 5817	frozen modified mirror forest spirit rattle	0		Effect: "Twinkly Weapon", Effect Duration: 69
 5818	polymerized non-oxidized alkaline Stone Golem pebbles	0		Effect: "Mitre Cut", Effect Duration: 27
 5819	quantum tarnished diffused gravy fairy warlock hat	0		Effect: "Rave Nirvana", Effect Duration: 29
 5820	frozen Vulcanized cyan bull blubber	0		Effect: "Glittering Eyelashes", Effect Duration: 52
 5821	oxidized aerosolized wobbly frog lip-print	0		Effect: "You Liver", Effect Duration: 51
-5822	colloidal bouncing wobbly gazely stare	0		Effect: "Human-Human Hybrid", Effect Duration: 62
+5822	colloidal wobbly bouncing gazely stare	0		Effect: "Human-Human Hybrid", Effect Duration: 62
 5823	ionized skewed canopic jar	0		Effect: "There Wolf", Effect Duration: 33
 5824	altered green clove-flavored lip balm	0		Effect: "Always be Collecting", Effect Duration: 21
 5825	anodized activated huge Skullery Maid's Knee	0		Effect: "Bloody-minded", Effect Duration: 43
 5826	dry flattened zombie hollandaise	0		Effect: "Pwnd", Effect Duration: 54
 5827	concentrated modified skeletal banana	0		Effect: "Izchak's Blessing", Effect Duration: 41
-5828	enhanced ghostly bouncing gilt perfume bottle	0		Effect: "Cool Spirit", Effect Duration: 43
+5828	enhanced bouncing ghostly gilt perfume bottle	0		Effect: "Cool Spirit", Effect Duration: 43
 5829	oxidized adjusted twirling janglin' bones	0		Effect: "Feline Ferocity", Effect Duration: 50
 5830	wet quadruple-dry pygmy papers	0		Effect: "Norwhalloped", Effect Duration: 56
 5831	double-enhanced triple-irradiated skewed pygmy dart	0		Effect: "Blessing of Charcoatl", Effect Duration: 19
 5832	double-quantum galvanized secret mummy herbs and spices	0		Effect: "Shredding, Sweating", Effect Duration: 18
 5833	energized alkaline brigand brittle	0		Effect: "Spiro Gyro", Effect Duration: 27
 5834	double-irradiated anodized holistic headache remedy	0		Effect: "Lifted Spirits", Effect Duration: 16
-5835	triple-chilled skewed shaking scrunchie tourniquet	0		Effect: "Funky Coal Patina", Effect Duration: 14
+5835	triple-chilled shaking skewed scrunchie tourniquet	0		Effect: "Funky Coal Patina", Effect Duration: 14
 5836	pressed embezzler's oil	0		Effect: "Dexteri Tea", Effect Duration: 28
 5837	diffused non-deionized Fu Manchu Wax	0		Effect: "Berry Statistical", Effect Duration: 13
 5838	electrified Iiti Kitty Gumdrop	0		Effect: "Burnt 'n' Turnt", Effect Duration: 26
@@ -5740,7 +5740,7 @@
 5841	chilled polarized A muse-bouche	0		Effect: "Well Owl Be!", Effect Duration: 56
 5842	polarized Vulcanized blue toothbrush	0		Effect: "Cake Caked", Effect Duration: 42
 5843	activated pirate cream pie	0		Effect: "Updated", Effect Duration: 61
-5844	unsweetened lime green jittery una poca de gracia	0		Effect: "Marinated", Effect Duration: 31
+5844	unsweetened jittery lime green una poca de gracia	0		Effect: "Marinated", Effect Duration: 31
 5845	concentrated compressed air canister	0		Effect: "Antsy in your Pantsy", Effect Duration: 48
 5846	flattened moist salt water taffy	0		Effect: "One Foot Heavier", Effect Duration: 32
 5847	tarnished altered cyan unholy water	0		Effect: "Partially Ghosted", Effect Duration: 22
@@ -5758,7 +5758,7 @@
 5859	super-ionized tarnished irradiated teal booby trap	0		Effect: "Creepin' Up on You", Effect Duration: 51
 5860	modified adjusted twirling mirror Agent Corrigan's cigarette	0		Effect: "Radiated and Grodiated", Effect Duration: 67
 5861	dry tumbling good ash	0		Effect: "Rotten Memories", Effect Duration: 42
-5862	narrow Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	narrow Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	upside-down jittery Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	frozen oxidized blurry papier-mochi	0		Effect: "Feline Ferocity", Effect Duration: 37, Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	green sharpshooter's skeleton skis of doom of bravery	0		Critical Hit Percent: +10, Spooky Spell Damage: +50, Spooky Resistance: +5, Single Equip, Last Available: "2012-10"
-5883	miniature adequate skeleton quiche	2	good	Last Available: "2012-10"
+5883	adequate miniature skeleton quiche	2	good	Last Available: "2012-10"
 5884	purple skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	rosewater-soaked sizzling supercharged Sinatra's Bonestabber	0		Experience (Moxie): +5, Maximum MP Percent: +30, Hot Damage: +10, Stench Resistance: +3, Last Available: "2012-10"
@@ -5809,7 +5809,7 @@
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	toasty brawny Solstice Shield	0		Muscle Percent: +20, Hot Damage: +5
 5913	deionized mirror tumbling candy sushi set	0		Effect: "Greasy Flavor", Effect Duration: 44, Last Available: "2012-12"
-5914	Vulcanized extra-pressed gray mirror sweet mochi ball	0		Effect: "Wallflowering", Effect Duration: 31, Last Available: "2012-12"
+5914	Vulcanized extra-pressed mirror gray sweet mochi ball	0		Effect: "Wallflowering", Effect Duration: 31, Last Available: "2012-12"
 5915	aerosolized super-frozen beet-flavored Mr. Mediocrebar	0		Effect: "Artificially Sweet", Effect Duration: 69, Last Available: "2012-12"
 5916	electrified diffused narrow sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Always be Collecting", Effect Duration: 20, Last Available: "2012-12"
 5917	chilled cyan cabbage-flavored Mr. Mediocrebar	0		Effect: "You Read The Manual", Effect Duration: 53, Last Available: "2012-12"
@@ -5820,7 +5820,7 @@
 5922	cyan auspicious plastic MechaElf	0		Item Drop: +10, Last Available: "2012-12"
 5923	plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
-5925	jittery teal ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
+5925	teal jittery ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	red BittyCar HotCar	0		Last Available: "2012-12"
 5928	brainwave-controlled unicorn horn of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
@@ -5873,11 +5873,11 @@
 5975	skewed record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	wholesome supercool silent beret of doom	0		Moxie Percent: +20, Maximum HP Percent: +10, Spooky Spell Damage: +50, Familiar Effect: "1xVolley, cap 3"
-5978	enchanted tasty slice of pizza	3	awesome	Effect: "Stands Alone", Effect Duration: 25, Last Available: "2013-02"
+5978	tasty enchanted slice of pizza	3	awesome	Effect: "Stands Alone", Effect Duration: 25, Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
-5981	wobbly blurry star	0		Last Available: "2013-02"
-5982	practically non-alcoholic perfectly mixed tankard of ale	1	EPIC	Last Available: "2013-02"
+5981	blurry wobbly star	0		Last Available: "2013-02"
+5982	perfectly mixed practically non-alcoholic tankard of ale	1	EPIC	Last Available: "2013-02"
 5983	jittery vial of holy water	0		Last Available: "2013-02"
 5984	yellow stanky forbidden cloth cap of the glutton	0		Spell Damage Percent: +50, Stench Spell Damage: +25, Food Drop: +100, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	MacGyver's personal trainer's iron dagger of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Maximum MP: +100, Last Available: "2013-02"
@@ -5893,7 +5893,7 @@
 5995	teal upside-down massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	twirling potion	0		Last Available: "2013-02"
-5998	perfectly mixed strong blue shining goblet	5	EPIC	Last Available: "2013-02"
+5998	strong perfectly mixed blue shining goblet	5	EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
 6000	mansplainer's sharpshooter's crown of temperance	0		Critical Hit Percent: +10, Monster Level: +15, Sleaze Resistance: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	wobbly ruddy padded weightlifter's sword	0		Muscle: +15, Damage Absorption: +20, Maximum HP Percent: +40, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	anodized diffused orcish hand lotion	0		Effect: "Provocative Perkiness", Effect Duration: 62
 6016	activated orcish rubber	0		Effect: "Industrial Strength Starch", Effect Duration: 52
 6017	adjusted dry quantum orcish nailing lube	0		Effect: "Slimy Flavor", Effect Duration: 19
-6018	perfectly mixed practically non-alcoholic backwoods screwdriver	1	super EPIC	
+6018	practically non-alcoholic perfectly mixed backwoods screwdriver	1	super EPIC	
 6019	loadstone of the dark arts	0		Spell Damage Percent: +100
 6020	huge executive scorching Claybender glasses	0		Hot Damage: +25, Meat Drop: +40, Single Equip
 6021	Duskwalker fangs of the wise owl of courage	0		Mysticality: +20, Spooky Resistance: +3
@@ -5933,7 +5933,7 @@
 6035	polarized maroon vial of The Glistening	0		Effect: "Leo Rising", Effect Duration: 22
 6036	artisanal upside-down artisanal limoncello	4	EPIC	
 6037	yellow ginger ale	0		
-6038	snack-sized rotten incredible pizza	2	crappy	
+6038	rotten snack-sized incredible pizza	2	crappy	
 6039	skewed veiny stiffened oil cap	0		Damage Reduction: 1, Maximum HP: +10, Familiar Effect: "cap 28"
 6040	Sherlock's Da Vinci's oil lamp	0		Experience (Mysticality): +5, Item Drop: +25
 6041	tumbling extremely unsafe oil slacks	0		Weapon Damage Percent: +100, Familiar Effect: "1xPotato, cap 30"
@@ -5947,7 +5947,7 @@
 6049	perfumed Jack Frost's energetic Misty Cape	0		Maximum MP Percent: +20, Cold Spell Damage: +50, Stench Resistance: +5
 6050	skewed woimbook	0		Familiar Weight: +5
 6051	mirror Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	stale jumbo Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
+6052	jumbo stale Taco Dan's Taco Stand Taco	5	decent	Last Available: "2012-12"
 6053	distilled lousy skewed Taco Dan's Taco Stand Chimichangarita	5	decent	Last Available: "2012-12"
 6054	ionized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Jungle Juiced", Effect Duration: 62, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
@@ -5960,18 +5960,18 @@
 6062	skewed stiffened Crimbo light-up Rudolph doll	0		Damage Reduction: 1, Last Available: "2012-12"
 6063	medical-grade Super Crimboman Ultra Mega Hypersword	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2012-12"
 6064	sharp tin strip	0		
-6065	skewed tumbling wad of spider silk	0		
+6065	tumbling skewed wad of spider silk	0		
 6066	shaking shaking goblin collarbone	0		
 6067	chilly rosy-cheeked Truthsayer	0		Maximum HP Percent: +30, Cold Damage: +5, Last Available: "2013-12"
 6068	huge loose blade	0		
 6069	goblin bone hilt	0		
 6070	lime green sword blade	0		
-6071	upside-down Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	upside-down Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	confusing LED clock	0		Last Available: "2012-12"
-6073	diffused maroon spinning haggis-infused soap	0		Effect: "Some Cheese with Your Wine", Effect Duration: 46, Last Available: "2012-12"
+6073	diffused spinning maroon haggis-infused soap	0		Effect: "Some Cheese with Your Wine", Effect Duration: 46, Last Available: "2012-12"
 6074	wet magicberry tablets	0		Effect: "Towering Strength", Effect Duration: 38, Last Available: "2012-12"
 6075	tarnished magnetized 37x37x37 puzzle cube	0		Effect: "Hot Hands", Effect Duration: 57, Last Available: "2012-12"
-6076	irresponsibly strong drinkable fancy squat pulsating McLeod's Hard Haggis-Ade	7	good	Effect: "Drunk With Power", Effect Duration: 10, Last Available: "2012-12"
+6076	irresponsibly strong fancy drinkable pulsating squat McLeod's Hard Haggis-Ade	7	good	Effect: "Drunk With Power", Effect Duration: 10, Last Available: "2012-12"
 6077	rotten haggis-wrapped haggis-stuffed haggis	4	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -5997,11 +5997,11 @@
 6099	Thinknerd T-Shirt of Tarzan	0		Experience (Muscle): +3, Last Available: "2012-12"
 6100	narrow pile of useless robot parts	0		Last Available: "2012-12"
 6101	cyan homemade robot	0		Last Available: "2012-12"
-6102	blinking squat tumbling homemade robot gear	0		Last Available: "2012-12"
+6102	tumbling squat blinking homemade robot gear	0		Last Available: "2012-12"
 6103	bouncing Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
 6105	mirror Artist's Spatula of Despair	0		Last Available: "2013-12"
-6106	ghostly squat Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
+6106	squat ghostly Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	skewed zippy Ginsu&trade; of bravery	0		Spooky Resistance: +5, Initiative: +20, Last Available: "2013-12"
 6109	pulsating bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
@@ -6020,9 +6020,9 @@
 6122	cat statue	0		Last Available: "2013-12"
 6123	purple rhinoceros horn	0		Last Available: "2013-12"
 6124	lime green furry pink pillow	0		Last Available: "2013-12"
-6125	adjusted bouncing jittery bottle of limeade	0		Effect: "Good Motivator", Effect Duration: 59, Last Available: "2013-12"
+6125	adjusted jittery bouncing bottle of limeade	0		Effect: "Good Motivator", Effect Duration: 59, Last Available: "2013-12"
 6126	maroon Jack Frost's Socratic novelty tattoo sleeves	0		Experience (Mysticality): +1, Cold Spell Damage: +50, Single Equip, Last Available: "2013-12"
-6127	jittery red ghostly pair of rhinoceros horns	0		Last Available: "2013-12"
+6127	jittery ghostly red pair of rhinoceros horns	0		Last Available: "2013-12"
 6128	tumbling furry brown pillow	0		Last Available: "2013-12"
 6129	makeshift yakuza mask of James Dean	0		Experience (Moxie): +3, Last Available: "2013-12"
 6130	piece	0		Last Available: "2013-12"
@@ -6081,26 +6081,26 @@
 6184	auspicious supercharged occult Jarlsberg's hat	0		Spell Damage Percent: +25, Maximum MP Percent: +30, Item Drop: +10
 6185	normal jumbo consummate hard-boiled egg	5	good	
 6186	stale consummate fried egg	3	decent	
-6187	spoiled thick consummate egg salad	5	crappy	
+6187	thick spoiled consummate egg salad	5	crappy	
 6188	flavorless consummate bagel	4	decent	
 6189	adequate low-calorie twirling consummate sliced bread	1	good	
-6190	decent jumbo consummate hot dog bun	5	good	
+6190	jumbo decent consummate hot dog bun	5	good	
 6191	normal consummate brownie	3	good	
-6192	thick adequate consummate toast	5	good	
+6192	adequate thick consummate toast	5	good	
 6193	practically non-alcoholic bad mirror passable stout	1	decent	
 6194	stale half-sized blurry consummate soup	2	decent	
-6195	enchanted normal consummate corn chips	4	good	Effect: "Memory of Attractiveness", Effect Duration: 35
-6196	toothsome half-sized consummate salad	2	awesome	
+6195	normal enchanted consummate corn chips	4	good	Effect: "Memory of Attractiveness", Effect Duration: 35
+6196	half-sized toothsome consummate salad	2	awesome	
 6197	stale blinking consummate salsa	3	decent	
 6198	flavorless snack-sized consummate sauerkraut	2	decent	
 6199	spoiled consummate cheese slice	4	crappy	
 6200	adequate consummate melted cheese	4	good	
-6201	low-calorie moldy consummate bacon	1	crappy	
+6201	moldy low-calorie consummate bacon	1	crappy	
 6202	stale blinking shaking consummate meatloaf	3	decent	
-6203	thick rotten mirror consummate steak	5	crappy	
+6203	rotten thick mirror consummate steak	5	crappy	
 6204	stale squat consummate cuts	3	decent	
 6205	tiny spoiled consummate frankfurter	1	crappy	
-6206	jumbo stale consummate french fries	5	decent	
+6206	stale jumbo consummate french fries	5	decent	
 6207	toothsome consummate baked potato	3	awesome	
 6208	spirit-forward bad acceptable vodka	5	decent	
 6209	normal consummate ice cream	4	good	
@@ -6108,7 +6108,7 @@
 6211	massive yummy upside-down consummate cream	9	awesome	
 6212	low-calorie rotten consummate strawberries	1	crappy	
 6213	rotten small blinking consummate sorbet	2	crappy	
-6214	tolerable watered-down adequate rum	2	good	
+6214	watered-down tolerable adequate rum	2	good	
 6215	aged huge mediocre lager	3	awesome	
 6216	spoiled pulsating immaculate grilled cheese	3	crappy	
 6217	stale immaculate ice cream sandwich	3	decent	
@@ -6117,7 +6117,7 @@
 6220	special moldy big perfect sandwich	5	crappy	Effect: "Extra-Sharp Weapon", Effect Duration: 10
 6221	toothsome perfect chef salad	3	awesome	
 6222	tasty perfect breakfast	4	awesome	
-6223	miniature moldy purple sublime deluxe hot dog	2	crappy	
+6223	moldy miniature purple sublime deluxe hot dog	2	crappy	
 6224	normal jumbo sublime stew	5	good	
 6225	delicious blinking sublime nachos	3	awesome	
 6226	moldy Ultimate Breakfast Sandwich	3	crappy	
@@ -6127,10 +6127,10 @@
 6230	watered-down bad Bologna Lambic	2	decent	
 6231	tolerable practically non-alcoholic Vodka Dog	1	good	
 6232	acceptable weak upside-down Disappointed Russian	2	good	
-6233	watered-down perfectly mixed lime green Chunky Mary	2	EPIC	
+6233	perfectly mixed watered-down lime green Chunky Mary	2	EPIC	
 6234	smooth Nachojito	4	awesome	
-6235	irresponsibly strong delicious Le Roi	9	awesome	
-6236	drinkable irresponsibly strong tumbling wobbly green Over Easy Rider	10	good	
+6235	delicious irresponsibly strong Le Roi	9	awesome	
+6236	irresponsibly strong drinkable tumbling wobbly green Over Easy Rider	10	good	
 6237	cosmic six-pack	0		
 6239	boiled cube of ectoplasm	0		Effect: "Raging Animal", Effect Duration: 32
 6240	corrupted modified Illuminati earpiece	0		Effect: "Pumped Up", Effect Duration: 15
@@ -6140,7 +6140,7 @@
 6244	extra-altered Vulcanized polarized wobbly cat's paw	0		Effect: "Insulated Trousers", Effect Duration: 47
 6245	alkaline colloidal liquefied blurry ASCII fu manchu	0		Effect: "Pla-see-bo", Effect Duration: 67
 6246	dry diffused demonic surgical gloves	0		Effect: "So You Can Work More...", Effect Duration: 15
-6247	energized magnetized squat spinning clip-on ninja tie	0		Effect: "Mushroom Melody", Effect Duration: 61
+6247	energized magnetized spinning squat clip-on ninja tie	0		Effect: "Mushroom Melody", Effect Duration: 61
 6248	liquefied gamer slurry	0		Effect: "Blood-Gorged", Effect Duration: 62
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	tumbling prompt wool greasy Samson's brawny numberwang of vim and vigor	0		Muscle Percent: +20, Experience (Muscle): +5, Maximum HP Percent: +50, Sleaze Spell Damage: +10, Cold Resistance: +1, Adventures: +3, Single Equip
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	smooth Mer-kin begsign	0		Moxie: +15, Meat Drop: +40
-6360	blurry Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	blurry Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	flattened pulled taffy	0		Effect: "Fit To Be Tide", Effect Duration: 48, Last Available: "2013-04"
 6362	pickled pulled indigo taffy	0		Effect: "You Liver", Effect Duration: 61, Last Available: "2013-04"
 6363	polymerized enhanced narrow upside-down pulled taffy	0		Effect: "Feroci Tea", Effect Duration: 65, Last Available: "2013-04"
@@ -6264,7 +6264,7 @@
 6368	huge Mer-kin hallpass	0		
 6369	squat lump of clay	0		
 6370	twisted piece of wire	0		
-6371	spirit-forward hand-crafted can of the cheapest beer	5	EPIC	
+6371	hand-crafted spirit-forward can of the cheapest beer	5	EPIC	
 6372	acceptable upside-down bottle of fruity &quot;wine&quot;	3	good	
 6373	perfectly mixed shaking single swig of vodka	3	EPIC	
 6374	angry inch	0		
@@ -6278,7 +6278,7 @@
 6383	root beer	1	decent	
 6384	squat jigsaw blade	0		
 6385	huge wood screw	0		
-6386	spinning red balsa plank	0		
+6386	red spinning balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	extra-dry moist Mer-kin rocksalt	0		Effect: "Stuck-Up Hair", Effect Duration: 16
@@ -6312,12 +6312,12 @@
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	flattened flattened wet spinning moth dust	0		Effect: "Oriental Mysticism", Effect Duration: 20
-6420	dry fuchsia twirling wobbly glob of spoiled mayo	0		Effect: "Creepypasted", Effect Duration: 65
+6420	dry wobbly fuchsia twirling glob of spoiled mayo	0		Effect: "Creepypasted", Effect Duration: 65
 6421	tonic djinn	0		
-6422	flavorless thick fancy vampire chowder	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 10
+6422	flavorless fancy thick vampire chowder	5	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 10
 6423	Tales of Dread	0		Free Pull
 6424	jittery Dreadsylvanian skeleton key	0		
-6425	lime green jittery Official Seal of Dreadsylvania	0		
+6425	jittery lime green Official Seal of Dreadsylvania	0		
 6426	tasty fuchsia Dreadsylvanian stew	4	awesome	
 6427	acceptable mirror Dreadsylvanian	3	good	
 6428	galvanized frozen blinking Dreadsylvanian flask	0		Effect: "Alchemical, Brother", Effect Duration: 38
@@ -6353,7 +6353,7 @@
 6458	Usain Bolt's quilted HOA zombie eyes of the sweet-tooth	0		Damage Absorption: +40, Candy Drop: +100, Initiative: +80, Single Equip
 6459	HOA citation pad	0		
 6460	wriggling severed nose	0		
-6461	blurry teal nosy nose ringy ring	0		Familiar Weight: +15
+6461	teal blurry nosy nose ringy ring	0		Familiar Weight: +15
 6462	frosty Da Vinci's educational Mayor Ghost's toupee	0		Experience: +1, Experience (Mysticality): +5, Cold Spell Damage: +10, Class: "Pastamancer", Familiar Effect: "spooky atk, 1xBarrr"
 6463	wobbly double-paned Mayor Ghost's cloak of the brazier of bravery	0		Hot Spell Damage: +25, Cold Resistance: +5, Spooky Resistance: +5, Class: "Pastamancer"
 6464	zippy greedy flame-retardant Mayor Ghost's khakis	0		Hot Resistance: +1, Meat Drop: +20, Initiative: +20, Class: "Pastamancer", Familiar Effect: "1xPotato, HP regen"
@@ -6384,13 +6384,13 @@
 6489	skewed music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	gray bouncing tailfeathers	0		Familiar Weight: +5
-6492	jittery lime green wax banana	0		
+6492	lime green jittery wax banana	0		
 6493	mirror complicated lock impression	0		
 6494	spinning replica key	0		
 6495	mirror gravedigger's Dreadsylvania Auditor's badge	0		Spooky Damage: +10, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	upside-down eau de mort	0		
-6498	special spirit-forward perfectly mixed shaking bloody kiwitini	5	EPIC	Effect: "Purity of Spirit", Effect Duration: 45
+6498	spirit-forward special perfectly mixed shaking bloody kiwitini	5	EPIC	Effect: "Purity of Spirit", Effect Duration: 45
 6499	moon-amber	0		
 6500	polished moon-amber	0		
 6501	reassuring moon-amber necklace of the storm of the boozehound	0		Maximum MP Percent: +40, Spooky Resistance: +1, Booze Drop: +100, Single Equip
@@ -6421,15 +6421,15 @@
 6526	pulsating gray hale bag of unfinished business of the boozehound	0		Maximum HP: +20, Booze Drop: +100
 6527	narrow experienced transparent pants of bravery	0		Experience: +2, Spooky Resistance: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of the cheetah	0		Initiative: +60
-6529	watered-down smooth Thriller Ice	2	awesome	
+6529	smooth watered-down Thriller Ice	2	awesome	
 6530	pulsating grandfather watch of Tarzan	0		Experience (Muscle): +3, Single Equip
-6531	spinning gray muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
+6531	gray spinning muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	MacGyver's spyglass of the blizzard	0		Maximum MP: +100, Cold Spell Damage: +25
 6533	vial of hot blood of the cheetah	0		Initiative: +60, Single Equip
 6534	spinning remorseless knife of the glutton	0		Food Drop: +100
 6535	intimidating coiffure of the storm	0		Maximum MP Percent: +40, Familiar Effect: "hot afk, 1xPotato"
 6536	blurry prompt stanky cod cape	0		Stench Spell Damage: +25, Adventures: +3
-6537	adequate enchanted wobbly blood sausage	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 5
+6537	enchanted adequate wobbly blood sausage	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 5
 6538	huge gravedigger's steel-toed frying brainpan	0		Damage Reduction: 9, Spooky Damage: +10
 6539	ball and chain of dire peril of the boozehound	0		Weapon Damage: +20, Booze Drop: +100, Single Equip
 6540	razor-sharp dry bone	0		Weapon Damage Percent: +25
@@ -6459,22 +6459,22 @@
 6565	spoiled Dreadsylvanian pocket	3	crappy	
 6566	moldy twirling Dreadsylvanian pocket	3	crappy	
 6567	decent Dreadsylvanian stink pocket	3	good	
-6568	stale super-sized Dreadsylvanian sleaze pocket	5	decent	
+6568	super-sized stale Dreadsylvanian sleaze pocket	5	decent	
 6569	high-proof hand-crafted Dreadsylvanian hot toddy	10	EPIC	
 6570	drinkable special Dreadsylvanian cold-fashioned	4	good	Effect: "Shamboozled", Effect Duration: 35
-6571	weak acceptable Dreadsylvanian grimlet	2	good	
-6572	mediocre weak Dreadsylvanian dank and stormy	2	decent	
+6571	acceptable weak Dreadsylvanian grimlet	2	good	
+6572	weak mediocre Dreadsylvanian dank and stormy	2	decent	
 6573	perfectly mixed Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
 6575	blinking clusterbomb	0		
 6576	clusterbomb	0		
 6577	stench clusterbomb	0		
-6578	bouncing olive sleaze clusterbomb	0		
+6578	olive bouncing sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	blinking huge vicious spiked collar	0		Familiar Damage: +20
+6583	huge blinking vicious spiked collar	0		Familiar Damage: +20
 6584	shaking skewed hot dog wrapper of bravery	0		Spooky Resistance: +5
 6585	upside-down family-friendly shellacked debonair deboner	0		Damage Reduction: 7, Sleaze Resistance: +1
 6586	dry denatured chicle de salchicha	0		Effect: "Human-Elemental Hybrid", Effect Duration: 68
@@ -6482,9 +6482,9 @@
 6588	inspector's gnawed-up dog bone of the brazier	0		Hot Spell Damage: +25, Item Drop: +15
 6589	wobbly healthy Grey Guanon	0		Maximum HP Percent: +20
 6590	ribald frosty healthy Engorged Sausages and You	0		Maximum HP Percent: +20, Cold Spell Damage: +10, Sleaze Damage: +10
-6591	acceptable extra-dry dream of a dog	5	good	
+6591	extra-dry acceptable dream of a dog	5	good	
 6592	gray aromatic dangerous stylish optimal spreadsheet	0		Moxie: +25, Weapon Damage: +10, Stench Resistance: +1
-6593	bouncing huge defective Game Grid token	0		
+6593	huge bouncing defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
 6595	dehydrated epic cluster	1	good	
 6596	clockwork egg	0		
@@ -6544,10 +6544,10 @@
 6652	perfectly mixed shaking stepmom's booze	4	EPIC	
 6653	upside-down surgical tape	0		
 6654	wobbly band T-shirt of terror	0		Spooky Spell Damage: +10
-6655	practically non-alcoholic artisanal fountain 'soda'	1	EPIC	
+6655	artisanal practically non-alcoholic fountain 'soda'	1	EPIC	
 6656	skewed illegal firecracker	0		
 6657	Jeselnik's Newton's pickelhaube	0		Experience (Mysticality): +3, Sleaze Damage: +25, Familiar Effect: "atk, 1xFairy, cap 18"
-6658	magnetized maroon blinking hair oil	0		Effect: "Oth-Jeal-O", Effect Duration: 69
+6658	magnetized blinking maroon hair oil	0		Effect: "Oth-Jeal-O", Effect Duration: 69
 6659	pickled galvanized scrap	0		Effect: "Balls of Ectoplasm", Effect Duration: 39
 6660	tumbling school spirit socket set	0		
 6661	suspension bridge	0		
@@ -6557,7 +6557,7 @@
 6665	nippy deathchucks of the sewer	0		Cold Damage: +10, Stench Damage: +25
 6666	squat maroon eraser	0		
 6667	bouncing quasireligious sculpture	0		
-6668	twirling olive Faraday cage	0		
+6668	olive twirling Faraday cage	0		
 6669	teal modeling claymore	0		
 6670	clay homunculus	0		
 6671	quadruple-nitrogenated adjusted alkaline sodium pentasomething	0		Effect: "Old Time Hydration", Effect Duration: 69
@@ -6594,7 +6594,7 @@
 6702	skewed bowler	0		
 6703	imitation White Russian	1	decent	
 6704	inspector's short-handled mop of the empath	0		Familiar Weight: +5, Item Drop: +15
-6705	diet spoiled jungle floor wax	1	crappy	
+6705	spoiled diet jungle floor wax	1	crappy	
 6706	ghostly smirking shrunken head	0		
 6707	ionized pulsating colorful toad	0		Effect: "Shamboozled", Effect Duration: 44
 6708	green crude voodoo doll	0		
@@ -6611,7 +6611,7 @@
 6719	ghostly electrified midriff scrubs of wisdom	0		Mysticality: +15, MP Regen Min: 3, MP Regen Max: 5
 6720	pressed pill cup	0		Effect: "Carrrsmic", Effect Duration: 18
 6721	family-friendly frosty Van der Graaf water bottle	0		Cold Spell Damage: +10, Sleaze Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 40"
-6722	aerosolized wobbly huge pygmy phone number	0		Effect: "Uncucumbered", Effect Duration: 57
+6722	aerosolized huge wobbly pygmy phone number	0		Effect: "Uncucumbered", Effect Duration: 57
 6723	Boozehounds Anonymous token	0		
 6724	flavorless exotic jungle fruit	4	decent	
 6725	Shore Inc. Ship Trip Scrip	0		
@@ -6628,13 +6628,13 @@
 6736	Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	narrow jagged scrap	0		
-6739	altered ghostly yellow narrow squat bent scrap	0		Effect: "Hombre Muerto Caminando", Effect Duration: 39
+6739	altered narrow squat ghostly yellow bent scrap	0		Effect: "Hombre Muerto Caminando", Effect Duration: 39
 6740	molten scrap	0		
 6741	eternal car battery	0		
 6742	Sinatra's junk band	0		Experience (Moxie): +5
 6743	skewed wizardly junk trunks	0		Mysticality: +25, Familiar Effect: "cap 15"
 6744	sage junk-mail shirt	0		Mysticality Percent: +10
-6745	bite-sized spoiled fuchsia junk food	1	crappy	
+6745	spoiled bite-sized fuchsia junk food	1	crappy	
 6746	perfectly mixed junk yard	3	EPIC	
 6747	narrow fortified swordzall of the early riser	0		Damage Absorption: +60, Adventures: +7
 6748	Samson's arm buzzer	0		Experience (Muscle): +5, Damage Reduction: 6
@@ -6651,7 +6651,7 @@
 6759	perfectly mixed can of Impetuous Scofflaw	3	EPIC	Last Available: "2013-09"
 6760	perfectly mixed bottle of Old Pugilist	4	EPIC	Last Available: "2013-09"
 6761	weak delicious bottle of Professor Beer	2	awesome	Last Available: "2013-09"
-6762	watered-down tolerable green bottle of Rapier Witbier	2	good	Last Available: "2013-09"
+6762	tolerable watered-down green bottle of Rapier Witbier	2	good	Last Available: "2013-09"
 6763	artisanal weak bottle of Race Car Red	2	super ultra mega EPIC	Last Available: "2013-09"
 6764	delicious bottle of Greedy Dog	3	awesome	Last Available: "2013-09"
 6765	practically non-alcoholic lousy bottle of Lambada Lambic	1	decent	Last Available: "2013-09"
@@ -6688,7 +6688,7 @@
 6799	modified electrified disco horoscope (Gemini)	0		Effect: "Full-Body Tan", Effect Duration: 34
 6800	deionized disco horoscope (Cancer)	0		Effect: "Using Protection", Effect Duration: 46
 6801	pressed olive disco horoscope (Leo)	0		Effect: "Filled with Magic", Effect Duration: 68
-6802	ionized tarnished Vulcanized ghostly tumbling disco horoscope (Virgo)	0		Effect: "Weird Flavor", Effect Duration: 55
+6802	ionized tarnished Vulcanized tumbling ghostly disco horoscope (Virgo)	0		Effect: "Weird Flavor", Effect Duration: 55
 6803	non-cold-filtered disco horoscope (Libra)	0		Effect: "Mucilaginous Mentalism", Effect Duration: 44
 6804	electrified disco horoscope (Scorpio)	0		Effect: "Dreadful Sheen", Effect Duration: 30
 6805	galvanized tumbling disco horoscope (Sagittarius)	0		Effect: "Quadrilled", Effect Duration: 24
@@ -6748,10 +6748,10 @@
 6859	fireproof Samson's Skipper's accordion	0		Experience (Muscle): +5, Hot Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6860	mirror Sherlock's toasty hale forbidden Pantsgiving	0		Spell Damage Percent: +50, Maximum HP: +20, Hot Damage: +5, Item Drop: +25, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	adequate can of sardines	3	good	Last Available: "2013-11"
-6862	bite-sized rotten blinking high-calorie sugar substitute	1	crappy	Last Available: "2013-11"
-6863	normal diet pat of butter	1	good	Last Available: "2013-11"
+6862	rotten bite-sized blinking high-calorie sugar substitute	1	crappy	Last Available: "2013-11"
+6863	diet normal pat of butter	1	good	Last Available: "2013-11"
 6864	adequate dinner roll	4	good	Last Available: "2013-11"
-6865	miniature spoiled mashed potatoes	2	crappy	Last Available: "2013-11"
+6865	spoiled miniature mashed potatoes	2	crappy	Last Available: "2013-11"
 6866	rotten whole turkey leg	3	crappy	Last Available: "2013-11"
 6867	decent skewed deviled egg	3	good	Last Available: "2013-11"
 6868	chilled finger exerciser	0		Effect: "Dreams and Lights", Effect Duration: 54, Last Available: "2013-11"
@@ -6762,7 +6762,7 @@
 6873	non-pressed wobbly candy wrapper	0		Effect: "Badger Underfoot", Effect Duration: 37, Last Available: "2013-11"
 6874	pulsating gym membership card	0		Last Available: "2013-11"
 6875	cold-filtered moist post-holiday sale coupon	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 46, Last Available: "2013-11"
-6876	mirror blue dry cleaning receipt	0		Last Available: "2013-11"
+6876	blue mirror dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	tumbling pocket lint (green)	0		Last Available: "2013-11"
 6879	red pocket lint (white)	0		Last Available: "2013-11"
@@ -6793,7 +6793,7 @@
 6904	super-activated adjusted bouncing bolts	0		Effect: "Billiards Belligerence", Effect Duration: 60, Last Available: "2013-12"
 6905	stale gingerbread robot	4	decent	Last Available: "2013-12"
 6906	fancy adequate ghostly mirror petit 4.1	4	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 30, Last Available: "2013-12"
-6907	special bland half-sized nut-shaped Crimbo cookie	2	decent	Effect: "Educated (Kinda)", Effect Duration: 35, Last Available: "2023-06"
+6907	bland half-sized special nut-shaped Crimbo cookie	2	decent	Effect: "Educated (Kinda)", Effect Duration: 35, Last Available: "2023-06"
 6908	huge avaricious plastic GORM-8	0		Meat Drop: +30, Last Available: "2013-12"
 6909	shellacked plastic warbear	0		Damage Reduction: 7, Last Available: "2013-12"
 6910	blinking Fonzie's plastic Toybot	0		Experience (Moxie): +1, Last Available: "2013-12"
@@ -6809,10 +6809,10 @@
 6920	magnetized upside-down warbear liquid overcoat	0		Effect: "Morbidi Tea", Effect Duration: 37, Last Available: "2013-12"
 6921	stale skewed warbear feasting bread	3	decent	Last Available: "2013-12"
 6922	decent warbear warrior bread	4	good	Last Available: "2013-12"
-6923	normal jumbo warbear thermoregulator bread	5	good	Last Available: "2013-12"
-6924	bad practically non-alcoholic warbear feasting mead	1	decent	Last Available: "2013-12"
+6923	jumbo normal warbear thermoregulator bread	5	good	Last Available: "2013-12"
+6924	practically non-alcoholic bad warbear feasting mead	1	decent	Last Available: "2013-12"
 6925	practically non-alcoholic perfectly mixed warbear bearserker mead	1	super ultra mega turbo EPIC	Last Available: "2013-12"
-6926	smooth weak warbear blizzard mead	2	awesome	Last Available: "2013-12"
+6926	weak smooth warbear blizzard mead	2	awesome	Last Available: "2013-12"
 6927	lime green warbear helm fragment	0		Last Available: "2013-12"
 6928	scandalous hardy hardened warbear plain fedora	0		Damage Reduction: 3, Maximum HP: +50, Sleaze Damage: +5, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
 6929	resourceful warbear feathered fedora	0		Maximum MP: +50, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
@@ -6889,15 +6889,15 @@
 7000	huge executive Herculean die-cast Don Crimbo	0		Experience (Muscle): +1, Meat Drop: +40, Last Available: "2013-12"
 7001	shaking greasy healthy die-cast Uncle Hobo	0		Maximum HP Percent: +20, Sleaze Spell Damage: +10, Last Available: "2013-12"
 7002	skewed Socratic die-cast Father Crimbo of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Last Available: "2013-12"
-7003	huge The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	huge The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	dry Flaskfull of Hollow	0		Effect: "Scrappy, Shadowy", Effect Duration: 33, Last Available: "2013-12"
 7005	twirling lump of Brituminous coal	0		Last Available: "2013-12"
-7006	mixed shaking narrow handful of Smithereens	1	good	Effect: "Night Vision", Effect Duration: 50, Last Available: "2013-12"
-7007	normal half-sized Every Day is Like This Sundae	2	good	Last Available: "2013-12"
+7006	mixed narrow shaking handful of Smithereens	1	good	Effect: "Night Vision", Effect Duration: 50, Last Available: "2013-12"
+7007	half-sized normal Every Day is Like This Sundae	2	good	Last Available: "2013-12"
 7008	spoiled Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	decent bouncing This Charming Flan	4	good	Last Available: "2013-12"
-7010	watered-down hand-crafted Irish Coffee, English Heart	2	EPIC	Last Available: "2013-12"
-7011	acceptable practically non-alcoholic fancy Strikes Again Bigmouth	1	good	Effect: "Strong Grip", Effect Duration: 10, Last Available: "2013-12"
+7010	hand-crafted watered-down Irish Coffee, English Heart	2	EPIC	Last Available: "2013-12"
+7011	fancy acceptable practically non-alcoholic Strikes Again Bigmouth	1	good	Effect: "Strong Grip", Effect Duration: 10, Last Available: "2013-12"
 7012	drinkable Paint A Vulgar Pitcher	3	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6938,12 +6938,12 @@
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	stale warbear gyro	4	decent	Last Available: "2013-12"
 7051	non-ionized liquefied olive recording of Rolando's Rondo of Resisto	0		Effect: "Hot Buttoned", Effect Duration: 21, Last Available: "2013-12"
-7052	red spinning warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
+7052	spinning red warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	narrow warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
 7055	rotten breakfast mess	3	crappy	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	tiny bland breakfast miracle	1	decent	Last Available: "2013-12"
+7057	bland tiny breakfast miracle	1	decent	Last Available: "2013-12"
 7058	extra-aerosolized fuchsia Cloaca Cola Polar	0		Effect: "Graham Crackling", Effect Duration: 55, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	upside-down festive warbear bank	0		Last Available: "2013-12"
@@ -6957,7 +6957,7 @@
 7068	pressed frozen single of Donho's Bubbly Ballad	0		Effect: "Rave Concentration", Effect Duration: 11
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	snack-sized decent blinking snow berries	2	good	Last Available: "2014-01"
+7071	decent snack-sized blinking snow berries	2	good	Last Available: "2014-01"
 7072	low-calorie normal ice harvest	1	good	Last Available: "2014-01"
 7073	altered cold-filtered blinking frost flower	0		Effect: "Hiding in Plain Sight", Effect Duration: 61, Last Available: "2014-01"
 7074	electrified diffused snow cleats	0		Effect: "Hyperoxygenated Blood", Effect Duration: 41, Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	asbestos-lined Tesla electrified extremely unsafe snow belt	0		Weapon Damage Percent: +100, Hot Resistance: +5, MP Regen Min: 10, MP Regen Max: 15, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	shaking scandalous Jim Carey's ice nine of the overflowing toilet of horror	0		Monster Level: +25, Stench Spell Damage: +50, Spooky Spell Damage: +25, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2014-01"
 7089	spinning snow fort	0		Last Available: "2014-01"
-7090	perfectly mixed boozy ghostly En Una Fila Tequila	5	EPIC	
+7090	boozy perfectly mixed ghostly En Una Fila Tequila	5	EPIC	
 7091	spinning Skully's hot chocolate	1	crappy	
 7092	squat Fonzie's warbear dress helmet of the businessman	0		Experience (Moxie): +1, Meat Drop: +50, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	warbear dress bracers of chilblains of mayonnaise	0		Cold Damage: +25, Sleaze Spell Damage: +50, Single Equip, Last Available: "2013-12"
@@ -6988,7 +6988,7 @@
 7099	pint of sweat	0		Last Available: "2014-12"
 7100	Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	denatured tumbling twirling Five Second Energy&trade;	1		Last Available: "2014-12"
-7102	lime green skewed pixie axie	0		Last Available: "2014-12"
+7102	skewed lime green pixie axie	0		Last Available: "2014-12"
 7103	quantum energized tumbling powder	0		Effect: "Insulated Trousers", Effect Duration: 22, Last Available: "2014-12"
 7104	lime green licorice whip of the cheetah	0		Initiative: +60, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
@@ -7005,7 +7005,7 @@
 7116	brawny carrot-on-a-stick of Calamity Jane	0		Muscle Percent: +20, Critical Hit Percent: +15, Last Available: "2014-12"
 7117	Usain Bolt's ribald weasel stomping pants	0		Sleaze Damage: +10, Initiative: +80, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	adequate shaking mulberry	4	good	Last Available: "2014-12"
-7119	high-proof bad mulled berry wine	6	decent	Last Available: "2014-12"
+7119	bad high-proof mulled berry wine	6	decent	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	upside-down padded lemon party hat	0		Damage Absorption: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	banded lemon shirt	0		Damage Absorption: +100, Lasts Until Rollover, Last Available: "2014-12"
@@ -7015,7 +7015,7 @@
 7126	oxidized polarized flattened small gummi fin	0		Effect: "Hombre Muerto Caminando", Effect Duration: 42, Last Available: "2014-12"
 7127	tumbling rock-hard chocolate cow bone	0		Damage Reduction: 5, Last Available: "2014-12"
 7128	cold-filtered gummi fang	0		Effect: "Sticky Hands", Effect Duration: 36, Last Available: "2014-12"
-7129	spoiled massive leftover canap&eacute;s	9	crappy	Last Available: "2014-12"
+7129	massive spoiled leftover canap&eacute;s	9	crappy	Last Available: "2014-12"
 7130	acceptable magnum of champagne	3	good	Last Available: "2014-12"
 7131	Sherlock's ruddy cool cow creamer	0		Moxie: +5, Maximum HP Percent: +40, Item Drop: +25, Last Available: "2014-12"
 7132	dry chilled Outer Wolf&trade; cologne	0		Effect: "Superioreo", Effect Duration: 49, Last Available: "2014-12"
@@ -7031,8 +7031,8 @@
 7142	chilled moist denatured wobbly blinking hare brush	0		Effect: "Macho Profundo", Effect Duration: 60, Last Available: "2014-12"
 7143	Jack Frost's supercool hare pin	0		Moxie Percent: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7144	maroon odd coin	0		Last Available: "2014-12"
-7145	decent super-sized fancy cinnamon cannoli	5	good	Effect: "Litterboxing", Effect Duration: 30, Last Available: "2014-12"
-7146	perfectly mixed boozy expensive champagne	5	EPIC	Last Available: "2014-12"
+7145	decent fancy super-sized cinnamon cannoli	5	good	Effect: "Litterboxing", Effect Duration: 30, Last Available: "2014-12"
+7146	boozy perfectly mixed expensive champagne	5	EPIC	Last Available: "2014-12"
 7147	cold-filtered polo trophy	0		Effect: "Gr8ness", Effect Duration: 16, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7052,7 +7052,7 @@
 7163	jittery nippy chilly strapping skull gearshift knob	0		Muscle: +5, Cold Damage: 15, Last Available: "2014-12"
 7164	stale nachos of the night	4	decent	Last Available: "2014-12"
 7165	brawny stylish Sketcherz&trade; of the cougar	0		Moxie: 45, Muscle Percent: +20, Last Available: "2014-12"
-7166	huge yummy can of Adultwitch&trade;	7	awesome	Last Available: "2014-12"
+7166	yummy huge can of Adultwitch&trade;	7	awesome	Last Available: "2014-12"
 7167	liquefied blinking smudge stick	0		Effect: "Red Around the Gills", Effect Duration: 26, Last Available: "2014-12"
 7168	liquefied adjusted wall	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 37, Last Available: "2014-12"
 7169	lousy tankard of ale	4	decent	Last Available: "2014-12"
@@ -7111,13 +7111,13 @@
 7222	tolerable spirit-forward Flamin' Whatshisname	5	good	
 7223	oxidized unsweetened blinking lynyrd musk	0		Effect: "One Very Clear Eye", Effect Duration: 42
 7224	Samson's Kashmir sweater of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50
-7225	big enchanted rotten custard pie	5	crappy	Effect: "Slightly Larger Than Usual", Effect Duration: 45
+7225	enchanted big rotten custard pie	5	crappy	Effect: "Slightly Larger Than Usual", Effect Duration: 45
 7226	mirror tea for one	1	decent	
 7227	artisanal bottle of Evermore	4	EPIC	
 7228	squat box	0		
 7229	weak lousy wine	2	decent	
 7230	tolerable rum	4	good	
-7231	lousy practically non-alcoholic blurry Murderer's Punch	1	decent	
+7231	practically non-alcoholic lousy blurry Murderer's Punch	1	decent	
 7232	normal velvet cake	4	good	
 7233	super-aerosolized triple-energized activated letter	0		Effect: "Can't Smell Nothin'", Effect Duration: 53
 7234	electrified stiffened book	0		Damage Reduction: 1, MP Regen Min: 3, MP Regen Max: 5
@@ -7190,7 +7190,7 @@
 7301	Spookyraven billiards room key	0		
 7302	Spookyraven library key	0		
 7303	Lady Spookyraven's necklace	0		
-7304	shaking wobbly telegram from Lady Spookyraven	0		
+7304	wobbly shaking telegram from Lady Spookyraven	0		
 7305	Lady Spookyraven's powder puff	0		
 7306	Lady Spookyraven's finest gown	0		
 7307	blue Lady Spookyraven's dancing shoes	0		
@@ -7217,7 +7217,7 @@
 7328	cold-filtered blinking funny bone	0		Effect: "Heart of Yellow", Effect Duration: 68
 7329	skewed Da Vinci's thinker's half-melted spoon	0		Mysticality: +10, Experience (Mysticality): +5
 7330	modified the funk	1		
-7331	fancy bland bouncing gunky chicken	3	decent	Effect: "Swimming with Sharks", Effect Duration: 50
+7331	bland fancy bouncing gunky chicken	3	decent	Effect: "Swimming with Sharks", Effect Duration: 50
 7332	gravedigger's doll head	0		Spooky Damage: +10
 7333	droopy doll eye	0		
 7334	shaking voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7228,7 +7228,7 @@
 7339	blinking music box mechanism	0		
 7340	blinking moose antlers of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	activated double-colloidal moose thought	0		Effect: "Tingly Biceps", Effect Duration: 32
-7342	delicious diet fancy ghostly yellow moose chocolate	1	awesome	Effect: "Jingle Jangle Jingle", Effect Duration: 15
+7342	delicious fancy diet ghostly yellow moose chocolate	1	awesome	Effect: "Jingle Jangle Jingle", Effect Duration: 15
 7343	tolerable painting of a glass of wine	4	good	
 7344	oil painting of yourself	0		
 7345	blinking ornate picture frame	0		
@@ -7252,16 +7252,16 @@
 7363	tarnished bloodstain stick	0		Effect: "Stemonitis Storm", Effect Duration: 21
 7364	purple fabric softener	0		
 7365	deionized spinning fabric hardener	0		Effect: "Hustlin'", Effect Duration: 48
-7366	delicious boozy bottle of laundry sherry	5	awesome	
+7366	boozy delicious bottle of laundry sherry	5	awesome	
 7367	moist industrial strength starch	0		Effect: "The Moxie of LOV", Effect Duration: 11, Wiki Name: "industrial strength starch"
 7368	yummy extra-flat panini	3	awesome	
 7369	aerosolized frozen mangled finger	0		Effect: "Extra-Wet", Effect Duration: 24
-7370	extra-dry bad maroon Psychotic Train wine	5	decent	
+7370	bad extra-dry maroon Psychotic Train wine	5	decent	
 7371	crazy hobo notebook	0		
 7372	decent huge pie man was not meant to eat	4	good	
 7373	sommelier's towel of bravery	0		Spooky Resistance: +5
 7374	fireproof tarnished tastevin	0		Hot Resistance: +3, Single Equip
-7375	small adequate skewed actual tapas	2	good	
+7375	adequate small skewed actual tapas	2	good	
 7376	gray ghast iron ingot	0		
 7377	skewed rosewater-soaked chilly ghast iron cleaver	0		Cold Damage: +5, Stench Resistance: +3
 7378	padded thinker's ghast iron Garibaldi	0		Mysticality: +10, Damage Absorption: +20, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7280,7 +7280,7 @@
 7391	alkaline warmed shaking red Gene Tonic: Orc	0		Effect: "Feeling No Pain", Effect Duration: 59, Last Available: "2014-04"
 7392	unsweetened purple Gene Tonic: Demon	0		Effect: "Moose Wisdom", Effect Duration: 61, Last Available: "2014-04"
 7393	aerosolized denatured improved Gene Tonic: Horror	0		Effect: "Snobby", Effect Duration: 36, Last Available: "2014-04"
-7394	nitrogenated aerosolized upside-down bouncing Gene Tonic: Fish	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 18, Last Available: "2014-04"
+7394	nitrogenated aerosolized bouncing upside-down Gene Tonic: Fish	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 18, Last Available: "2014-04"
 7395	vacuum-sealed Gene Tonic: Goblin	0		Effect: "Sugary Tongue", Effect Duration: 66, Last Available: "2014-04"
 7396	altered warmed wobbly Gene Tonic: Pirate	0		Effect: "Human-Hobo Hybrid", Effect Duration: 45, Last Available: "2014-04"
 7397	non-corrupted Gene Tonic: Plant	0		Effect: "Squid Squint", Effect Duration: 50, Last Available: "2014-04"
@@ -7326,28 +7326,28 @@
 7437	Pastaco shell	0		Last Available: "2014-05"
 7438	small stale Beefy Crunch Pastaco	2	decent	Last Available: "2014-05"
 7439	stale massive Brain Food Pastaco	10	decent	Last Available: "2014-05"
-7440	rotten miniature Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
+7440	miniature rotten Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
 7441	stale Medical Pastaco	3	decent	Last Available: "2014-05"
 7442	special adequate Energy Buzz Pastaco	4	good	Effect: "The Power of Negative Thinking", Effect Duration: 35, Last Available: "2014-05"
 7443	decent tiny huge Ludovico Pastaco	1	good	Last Available: "2014-05"
 7444	bad overpowering mushroom wine	3	decent	Last Available: "2014-05"
 7445	weak delicious complex mushroom wine	2	awesome	Last Available: "2014-05"
-7446	artisanal fancy smooth mushroom wine	3	super EPIC	Effect: "Coldfinger", Effect Duration: 5, Last Available: "2014-05"
-7447	hand-crafted fancy extra-dry blood-red mushroom wine	5	EPIC	Effect: "Fitter, Happier", Effect Duration: 40, Last Available: "2014-05"
+7446	fancy artisanal smooth mushroom wine	3	super EPIC	Effect: "Coldfinger", Effect Duration: 5, Last Available: "2014-05"
+7447	fancy hand-crafted extra-dry blood-red mushroom wine	5	EPIC	Effect: "Fitter, Happier", Effect Duration: 40, Last Available: "2014-05"
 7448	perfectly mixed weak buzzing mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7449	practically non-alcoholic drinkable swirling mushroom wine	1	good	Last Available: "2014-05"
-7450	half-sized normal Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
-7451	stale diet enchanted Taco Dan's Taco Fish Fish Taco	1	decent	Effect: "Polka of Plenty", Effect Duration: 15, Last Available: "2014-05"
+7450	normal half-sized Taco Dan's Basic Taco Dan Taco	2	good	Last Available: "2014-05"
+7451	stale enchanted diet Taco Dan's Taco Fish Fish Taco	1	decent	Effect: "Polka of Plenty", Effect Duration: 15, Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	bad watered-down regular-size brogurt	2	decent	Last Available: "2014-05"
+7453	watered-down bad regular-size brogurt	2	decent	Last Available: "2014-05"
 7454	boozy acceptable super-size brogurt	5	good	Last Available: "2014-05"
-7455	watered-down tolerable broberry brogurt	2	good	Last Available: "2014-05"
+7455	tolerable watered-down broberry brogurt	2	good	Last Available: "2014-05"
 7456	acceptable twirling brocolate brogurt	3	good	Last Available: "2014-05"
 7457	hand-crafted French bronilla brogurt	3	EPIC	Last Available: "2014-05"
 7458	tumbling History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	red Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
-7461	shaking narrow industrial strength anti-fungal spray	0		Last Available: "2014-05"
+7461	narrow shaking industrial strength anti-fungal spray	0		Last Available: "2014-05"
 7462	Brogre brorts of the boozehound	0		Booze Drop: +100, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	bouncing dangerous Brogre brolo shirt	0		Weapon Damage: +10, Last Available: "2014-05"
 7464	veiny Brogre bucket hat	0		Maximum HP: +10, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
@@ -7366,14 +7366,14 @@
 7477	corrupted super-Vulcanized huge Meat-inflating powder	0		Effect: "Cold Jellied", Effect Duration: 16, Last Available: "2014-05"
 7478	huge possessed sugar cube	0		Last Available: "2014-05"
 7479	dry olive sugar fairy	0		Effect: "Human-Plant Hybrid", Effect Duration: 17, Last Available: "2014-05"
-7480	Vulcanized skewed tumbling purple sugar bunny	0		Effect: "Mana Tea", Effect Duration: 51, Last Available: "2014-05"
+7480	Vulcanized tumbling purple skewed sugar bunny	0		Effect: "Mana Tea", Effect Duration: 51, Last Available: "2014-05"
 7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	artisanal Rompedores de Fantasmas	4	EPIC	
-7483	watered-down hand-crafted La Fantasma y La Oscuridad	2	EPIC	
+7483	hand-crafted watered-down La Fantasma y La Oscuridad	2	EPIC	
 7484	watered-down artisanal Fantasma en la M&aacute;quina	2	EPIC	
 7485	loosening powder	0		
 7486	pulsating castoreum	0		
-7487	spinning wobbly drain dissolver	0		
+7487	wobbly spinning drain dissolver	0		
 7488	triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	ghostly triatomaceous dust	0		
@@ -7381,7 +7381,7 @@
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
-7495	blinking shaking blue recipe: mortar-dissolving solution	0		
+7495	blue blinking shaking recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
@@ -7395,7 +7395,7 @@
 7506	baleful book	0		Spell Damage: +25, Item Drop: +5
 7507	wobbly Usain Bolt's cloak	0		Initiative: +80
 7508	label	0		
-7509	half-sized decent Mornington crescent roll	2	good	
+7509	decent half-sized Mornington crescent roll	2	good	
 7510	diffused eye shadow	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 20
 7511	crumbling wheel	0		
 7512	polarized quantum modified upside-down poppy	0		Effect: "EVISCERATE!", Effect Duration: 20
@@ -7406,8 +7406,8 @@
 7517	jittery Da Vinci's spider leg of the businessman	0		Experience (Mysticality): +5, Meat Drop: +50
 7518	wand of pigification	0		
 7519	perfectly mixed glass of bourbon	3	EPIC	
-7520	blinking red burned government manual fragment	0		Last Available: "2014-05"
-7521	tiny normal blinking government cheese	1	good	Last Available: "2014-05"
+7520	red blinking burned government manual fragment	0		Last Available: "2014-05"
+7521	normal tiny blinking government cheese	1	good	Last Available: "2014-05"
 7522	scorching pair of government shades	0		Hot Damage: +25, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	warmed narrow government	0		Effect: "Slightly Larger Than Usual", Effect Duration: 58, Last Available: "2014-05"
@@ -7416,12 +7416,12 @@
 7527	narrow alien force field disruptor bean	0		Last Available: "2014-05"
 7528	wool government-issued night-vision goggles of horror	0		Spooky Spell Damage: +25, Cold Resistance: +1, Single Equip, Last Available: "2014-05"
 7529	stale miniature loaf of alien bread	2	decent	Last Available: "2014-05"
-7530	tiny delicious squat jittery grilled cheese sandwich	1	awesome	Last Available: "2014-05"
+7530	tiny delicious jittery squat grilled cheese sandwich	1	awesome	Last Available: "2014-05"
 7531	dried fuchsia ghostly huge alien protein powder	1	decent	Effect: "Seriously Mutated", Effect Duration: 45, Last Available: "2014-05"
-7532	watered-down artisanal rocket fuel	2	EPIC	Last Available: "2014-05"
+7532	artisanal watered-down rocket fuel	2	EPIC	Last Available: "2014-05"
 7533	fuchsia alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	fancy watered-down bad stealth bomber	2	decent	Effect: "Hammered", Effect Duration: 30, Last Available: "2014-05"
+7535	watered-down bad fancy stealth bomber	2	decent	Effect: "Hammered", Effect Duration: 30, Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	mirror ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7431,7 +7431,7 @@
 7542	space invader	0		Last Available: "2014-05"
 7543	dance instructor's space heater of doom	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +50, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	wobbly space bar	0		Last Available: "2014-05"
-7545	hand-crafted weak space port	2	EPIC	Last Available: "2014-05"
+7545	weak hand-crafted space port	2	EPIC	Last Available: "2014-05"
 7546	lard-coated brawny space needle	0		Muscle Percent: +20, Sleaze Spell Damage: +25, Last Available: "2014-05"
 7547	modified Vulcanized bouncing buffed alien drugs	0		Effect: "Guts Feeling", Effect Duration: 34, Last Available: "2014-05"
 7548	tumbling hot ashes	0		Last Available: "2014-06"
@@ -7468,8 +7468,8 @@
 7579	twitching time capsule	0		
 7580	distilled squat liquid shifting time weirdness	1		Effect: "Wax On Your Shoes", Effect Duration: 50
 7581	mirror shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	moldy snack-sized red rack of dinosaur ribs	2	crappy	
-7583	tolerable high-proof upside-down scotch on the rocks	7	good	
+7582	snack-sized moldy red rack of dinosaur ribs	2	crappy	
+7583	high-proof tolerable upside-down scotch on the rocks	7	good	
 7584	educational stylish yabba dabba doo rag	0		Moxie: +25, Experience: +1, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	studded wooly loincloth of Gandalf	0		Damage Absorption: +80, Spell Critical Percent: +20, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
@@ -7477,30 +7477,30 @@
 7588	bouncing Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	artisanal glass of &quot;milk&quot;	3	EPIC	Last Available: "2014-07"
 7590	drinkable practically non-alcoholic wobbly cup of &quot;tea&quot;	1	good	Last Available: "2014-07"
-7591	hand-crafted high-proof blurry thermos of &quot;whiskey&quot;	10	EPIC	Last Available: "2014-07"
+7591	high-proof hand-crafted blurry thermos of &quot;whiskey&quot;	10	EPIC	Last Available: "2014-07"
 7592	watered-down artisanal Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	drinkable tumbling Bee's Knees	3	good	Last Available: "2014-07"
 7594	tolerable Sockdollager	3	good	Last Available: "2014-07"
 7595	practically non-alcoholic tolerable squat Ish Kabibble	1	good	Last Available: "2014-07"
 7596	smooth spinning Hot Socks	3	awesome	Last Available: "2014-07"
-7597	lousy high-proof jittery Phonus Balonus	8	decent	Last Available: "2014-07"
+7597	high-proof lousy jittery Phonus Balonus	8	decent	Last Available: "2014-07"
 7598	acceptable practically non-alcoholic Flivver	1	good	Last Available: "2014-07"
-7599	special irresponsibly strong tolerable Sloppy Jalopy	9	good	Effect: "Emotion Sickness", Effect Duration: 20, Last Available: "2014-07"
+7599	irresponsibly strong special tolerable Sloppy Jalopy	9	good	Effect: "Emotion Sickness", Effect Duration: 20, Last Available: "2014-07"
 7600	wet super-denatured quantum blurry flame	0		Effect: "Boilermade", Effect Duration: 39
 7601	double-concentrated narrow temporary yak tattoo	0		Effect: "Bats in the Belfry", Effect Duration: 28
 7602	cold-filtered polymerized Fitspiration&trade; poster	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 23
-7603	pickled maroon bouncing neckbeard	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 11
+7603	pickled bouncing maroon neckbeard	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 11
 7604	chilled artisanal hand-squeezed wheatgrass juice	0		Effect: "Gleaming White Teeth", Effect Duration: 47
 7605	liquefied liquefied bouncing punk patch	0		Effect: "Hammered", Effect Duration: 64
 7606	electrified tumbling steampunk potion	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 33
 7607	double-flattened diffused yellow vial of swamp vapors	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 46
 7608	flattened liquefied ionized turtle mud	0		Effect: "Thunderspell", Effect Duration: 69
-7609	dry blue ghostly Redeye&trade; Eyedrops	0		Effect: "Ponderous Potency", Effect Duration: 58
+7609	dry ghostly blue Redeye&trade; Eyedrops	0		Effect: "Ponderous Potency", Effect Duration: 58
 7610	ionized oxidized pulsating Dweebisol&trade; inhaler	0		Effect: "Egg-stra Arm", Effect Duration: 61
 7611	frozen alkaline Lewd Lemmy Hair Oil	0		Effect: "The Two-Prong Crown", Effect Duration: 24
 7612	double-altered energized tomato soup poster	0		Effect: "Army of One", Effect Duration: 17
 7613	pickled mirror cyan bouncing bubblin' chemistry solution	0		Effect: "Fishy Fortification", Effect Duration: 16
-7614	nitrogenated adjusted spinning maroon voodoo glowskull	0		Effect: "Heavily Breathing", Effect Duration: 65
+7614	nitrogenated adjusted maroon spinning voodoo glowskull	0		Effect: "Heavily Breathing", Effect Duration: 65
 7615	altered pygmy adder oil	0		Effect: "Spell Transfer Complete", Effect Duration: 60
 7616	polymerized warmed alkaline pygmy witchhazel	0		Effect: "Hobonic", Effect Duration: 22
 7617	flattened ionized short deposition	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 27
@@ -7513,7 +7513,7 @@
 7624	non-electrified extra-irradiated skewed lynyrd skinner toothblack	0		Effect: "The Power of Positive Thinking", Effect Duration: 63
 7625	galvanized red flask of rainwater	0		Effect: "Standard Issue Bravery", Effect Duration: 51
 7626	activated triple-adjusted triple-alkaline ghostly oyster badge	0		Effect: "French Bronilla Brogueishness", Effect Duration: 47
-7627	tarnished ionized blinking squat plastic Jefferson wings	0		Effect: "Can't Smell Nothin'", Effect Duration: 33
+7627	tarnished ionized squat blinking plastic Jefferson wings	0		Effect: "Can't Smell Nothin'", Effect Duration: 33
 7628	aerosolized corrupted dancing fan	0		Effect: "Hairless and Airless", Effect Duration: 17
 7629	triple-polarized altered page of the Necrohobocon	0		Effect: "Eagle Eyes", Effect Duration: 43
 7630	flattened modified squat magic powder	0		Effect: "No Vertigo", Effect Duration: 67
@@ -7528,7 +7528,7 @@
 7639	oil shell of the cougar	0		Moxie: +20, Class: "Turtle Tamer"
 7640	supercharged extremely unsafe cool turtle shell	0		Moxie: +5, Weapon Damage Percent: +100, Maximum MP Percent: +30, Class: "Turtle Tamer"
 7641	purple shocked shell	0		Class: "Turtle Tamer"
-7642	narrow spinning ingot turtle	0		
+7642	spinning narrow ingot turtle	0		
 7643	duty umbrella	0		
 7644	huge pool skimmer	0		
 7645	life preserver	0		
@@ -7559,7 +7559,7 @@
 7670	twirling medical-grade beefy famous raincoat of the cougar	0		Muscle: +10, Moxie: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 7671	perfumed smelly lightning rod of vim and vigor	0		Maximum HP Percent: +50, Stench Spell Damage: +10, Stench Resistance: +5, Lasts Until Rollover
 7672	personal trainer's law-abiding citizen cane	0		Experience Percent (Muscle): +10, Single Equip
-7673	fancy smooth legitimate business on the beach	3	awesome	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 10
+7673	smooth fancy legitimate business on the beach	3	awesome	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 10
 7674	auspicious hep waders	0		Item Drop: +10, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	bland jive turkey leg	4	decent	
 7676	frightening birdbone corset	0		Spooky Damage: +5
@@ -7567,7 +7567,7 @@
 7678	fuchsia fortified 4-dimensional fez	0		Damage Absorption: +60, Familiar Effect: "atk, 1xLep, cap 12"
 7679	spinning throwing candy	0		
 7680	spinning blue super-absorbent tarp	0		Item Drop: +5
-7681	weak tolerable unquiet spirits	2	good	
+7681	tolerable weak unquiet spirits	2	good	
 7682	supercharged banjo kazoo mount	0		Maximum MP Percent: +30, Single Equip
 7683	tarnished pickled chilled grass	0		Effect: "Puddingskin", Effect Duration: 41
 7684	cyan supercool Time Lord Participation Mug	0		Moxie Percent: +20
@@ -7588,17 +7588,17 @@
 7699	upside-down &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	anodized frozen confiscated comic book	0		Effect: "Sharp Weapon", Effect Duration: 39, Last Available: "2014-08"
 7701	Vulcanized confiscated cell phone	0		Effect: "Morninja", Effect Duration: 28, Last Available: "2014-08"
-7702	liquefied polymerized squat maroon confiscated love note	0		Effect: "Armored Innards", Effect Duration: 36, Last Available: "2014-08"
+7702	liquefied polymerized maroon squat confiscated love note	0		Effect: "Armored Innards", Effect Duration: 36, Last Available: "2014-08"
 7703	bouncing LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	denatured rubber nubbin	0		Effect: "Stemonitis Storm", Effect Duration: 66, Last Available: "2014-08"
 7708	blinking blinking weightlifter's rubber cape of the dark arts	0		Muscle: +15, Spell Damage Percent: +100, Last Available: "2014-08"
 7709	spinning prompt coward's careful Thor's Pliers of doom	0		Monster Level: -30, Spooky Spell Damage: +50, Adventures: +3, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
-7710	concentrated spinning mirror candy UFOs	0		Effect: "Bear Clawed", Effect Duration: 47
+7710	concentrated mirror spinning candy UFOs	0		Effect: "Bear Clawed", Effect Duration: 47
 7711	Oprah's experienced water wings for babies	0		Experience: +2, Maximum MP Percent: +50
-7712	mirror beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	mirror beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	flavorless snack-sized Strix stix	2	decent	
 7714	ghostly hale stiffened vampire pellet of temperance	0		Damage Reduction: 1, Maximum HP: +20, Sleaze Resistance: +5
 7715	lousy practically non-alcoholic gray non-aged vinegar	1	decent	
@@ -7612,7 +7612,7 @@
 7723	Chroner cross	0		
 7724	blinking wicked pteruges	0		Spell Damage: +5, Familiar Effect: "1xFairy, atk, cap 25"
 7725	aerosolized alkaline upside-down Bruno's blessing of Mars	0		Effect: "Spell Transfer Complete", Effect Duration: 43
-7726	pickled huge upside-down fuchsia Dennis's blessing of Minerva	0		Effect: "Stop the Presses!", Effect Duration: 67
+7726	pickled huge fuchsia upside-down Dennis's blessing of Minerva	0		Effect: "Stop the Presses!", Effect Duration: 67
 7727	oxidized nitrogenated pressed Burt's blessing of Bacchus	0		Effect: "Frog In Your Throat", Effect Duration: 44
 7728	liquefied pickled Freddie's blessing of Mercury	0		Effect: "Dreadful Fear", Effect Duration: 61
 7729	Chroner trigger	0		
@@ -7642,15 +7642,15 @@
 7753	mirror cool Xiblaxian stealth cowl of the blizzard	0		Moxie: +5, Cold Spell Damage: +25, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	Xiblaxian stealth trousers of wisdom of dire peril	0		Mysticality: +15, Weapon Damage: +20, Last Available: "2014-09"
 7755	Jim Carey's Xiblaxian stealth vest of the overflowing toilet	0		Monster Level: +25, Stench Spell Damage: +50, Last Available: "2014-09"
-7756	immense decent Xiblaxian ultraburrito	10	good	Last Available: "2014-09"
+7756	decent immense Xiblaxian ultraburrito	10	good	Last Available: "2014-09"
 7757	weak lousy Xiblaxian space-whiskey	2	decent	Last Available: "2014-09"
 7758	olive blurry Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	concentrated extra-quantum They liver	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 18, Last Available: "2014-09"
-7760	stale miniature They liver popsicle	2	decent	Last Available: "2014-09"
+7760	miniature stale They liver popsicle	2	decent	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	twirling holo-bomber	0		Last Available: "2014-09"
 7763	ghostly holo-platoon	0		Last Available: "2014-09"
-7764	twisted blinking spinning residual zeal	1		Last Available: "2014-09"
+7764	twisted spinning blinking residual zeal	1		Last Available: "2014-09"
 7765	mirror quilted Xiblaxian holo-wrist-puter	0		Damage Absorption: +40, Last Available: "2014-09"
 7766	Herculean defective Golden Mr. Accessory of extreme caution of the blizzard	0		Experience (Muscle): +1, Monster Level: -25, Cold Spell Damage: +25
 7767	airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7658,7 +7658,7 @@
 7769	wobbly Coinspiracy	0		Last Available: "2014-10"
 7770	jittery purple Jeselnik's grievous wizardly Personal Ventilation Unit	0		Mysticality: +25, Weapon Damage Percent: +50, Sleaze Damage: +25, Single Equip, Last Available: "2014-10"
 7771	double-unsweetened cyan blurry the most dangerous bait	0		Effect: "Trufflin'", Effect Duration: 24, Last Available: "2014-10"
-7772	decent super-sized &quot;meat&quot; stick	5	good	Last Available: "2014-10"
+7772	super-sized decent &quot;meat&quot; stick	5	good	Last Available: "2014-10"
 7773	mixed shaking transdermal smoke patch	1	awesome	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	careful pair of plants of Leguizamo of horror	0		Monster Level: 10, Spooky Spell Damage: +25, Last Available: "2014-10"
@@ -7676,12 +7676,12 @@
 7787	twirling jittery cuddly teddy bear of temperance	0		Sleaze Resistance: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	Temple Grandin's vibrating first-aid pouch	0		Maximum MP Percent: +10, Familiar Weight: +7, Last Available: "2014-10"
-7790	teal bouncing khaki duffel bag	0		Last Available: "2014-10"
+7790	bouncing teal khaki duffel bag	0		Last Available: "2014-10"
 7791	aerosolized corrupted Vulcanized airborne mutagen	0		Effect: "Greedy Resolve", Effect Duration: 63, Last Available: "2014-10"
 7792	gray squat SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	blue bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	toothsome jumbo initiative shawarma	5	awesome	Last Available: "2014-10"
+7795	jumbo toothsome initiative shawarma	5	awesome	Last Available: "2014-10"
 7796	moldy warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	rotten bouncing karma shawarma	3	crappy	Last Available: "2014-10"
 7798	fortified artisanal Jungle Juice	5	EPIC	Last Available: "2014-10"
@@ -7701,7 +7701,7 @@
 7812	tarnished bottlecap	0		
 7813	spoiled enchanted seared dino steak	3	crappy	Effect: "Weird Flavor", Effect Duration: 25
 7814	drinkable watered-down bottle of drinkin' gas	2	good	
-7815	squat jittery handful of napalm	0		
+7815	jittery squat handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
 7818	99.44% pure math	0		
@@ -7713,7 +7713,7 @@
 7824	skewed up-at-dawn energetic Herculean iShield	0		Experience (Muscle): +1, Maximum MP Percent: +20, Adventures: +5, Damage Reduction: 6
 7825	lightning-fast sinister Newton's earbuds	0		Experience (Mysticality): +3, Spell Damage: +10, Initiative: +40, Single Equip
 7826	up-at-dawn supercharged iFlail of temperance	0		Maximum MP Percent: +30, Sleaze Resistance: +5, Adventures: +5
-7827	stale maroon blinking unidentifiable dried fruit	3	decent	
+7827	stale blinking maroon unidentifiable dried fruit	3	decent	
 7828	strong lousy flat cider	5	decent	
 7829	spinning Jack Frost's Annie Oakley's studded trench lighter	0		Damage Absorption: +80, Critical Hit Percent: +20, Cold Spell Damage: +50, Last Available: "2014-10"
 7830	pickled experimental serum P-00	0		Effect: "Become Superficially interested", Effect Duration: 11, Last Available: "2014-10"
@@ -7733,10 +7733,10 @@
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	denatured quadruple-energized perl necklace	0		Effect: "Man's Worst Enemy", Effect Duration: 34, Last Available: "2014-12"
 7846	colloidal shaking Fudge Fiber Armor Plating	0		Effect: "Jerky, Boy", Effect Duration: 56, Last Available: "2014-12"
-7847	tarnished adjusted skewed wobbly shaking ruby on canes	0		Effect: "Bone Chilling", Effect Duration: 49, Last Available: "2014-12"
+7847	tarnished adjusted wobbly shaking skewed ruby on canes	0		Effect: "Bone Chilling", Effect Duration: 49, Last Available: "2014-12"
 7848	spoiled half-sized petit fortran	2	crappy	Last Available: "2014-12"
-7849	half-sized adequate java cookie	2	good	Last Available: "2014-12"
-7850	enchanted stale cookie cookie	4	decent	Effect: "Demonic Flavor", Effect Duration: 40, Last Available: "2014-12"
+7849	adequate half-sized java cookie	2	good	Last Available: "2014-12"
+7850	stale enchanted cookie cookie	4	decent	Effect: "Demonic Flavor", Effect Duration: 40, Last Available: "2014-12"
 7851	stiffened plastic exo-suited miner	0		Damage Reduction: 1, Last Available: "2014-12"
 7852	smartaleck's plastic semi-autonomous drill unit	0		Moxie Percent: +30, Last Available: "2014-12"
 7853	grievous plastic ambulatory robo-minecart	0		Weapon Damage Percent: +50, Last Available: "2014-12"
@@ -7800,16 +7800,16 @@
 7911	recovered elf photo album	0		Last Available: "2014-12"
 7912	blurry recovered elf smartphone	0		Last Available: "2014-12"
 7913	Usain Bolt's asbestos-lined ruddy Size XI Wizard's Robe	0		Maximum HP Percent: +40, Hot Resistance: +5, Initiative: +80, Last Available: "2014-09"
-7914	ionized shaking wobbly Bit O' Quail Spleen	0		Effect: "Healthy Bronze Glow", Effect Duration: 24
+7914	ionized wobbly shaking Bit O' Quail Spleen	0		Effect: "Healthy Bronze Glow", Effect Duration: 24
 7915	polarized twirling Take Eleven Bar	0		Effect: "Pork Power", Effect Duration: 32
 7916	cyan mimeplasm	0		
 7917	non-colloidal anodized wet squat BOOterfinger	0		Effect: "Spiro Gyro", Effect Duration: 49
 7918	energized blurry Moonds	0		Effect: "Feline Ferocity", Effect Duration: 25
-7919	pressed ionized huge ghostly Big Punk	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 59
+7919	pressed ionized ghostly huge Big Punk	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 59
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	skewed turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	fortified smooth Friendly Turkey	5	awesome	Last Available: "2014-11"
-7923	perfectly mixed high-proof Agitated Turkey	6	EPIC	Last Available: "2014-11"
+7923	high-proof perfectly mixed Agitated Turkey	6	EPIC	Last Available: "2014-11"
 7924	mediocre Ambitious Turkey	3	decent	Last Available: "2014-11"
 7925	rotten neutron lollipop	4	crappy	Last Available: "2014-12"
 7926	delicious gamma nog	3	awesome	Last Available: "2014-12"
@@ -7829,7 +7829,7 @@
 7947	artisanal whiskey in a broken glass	3	EPIC	
 7948	perfectly mixed weak blinking shot of mescal	2	EPIC	
 7949	delicious squat glass of herbal tequila	3	awesome	
-7950	shaking fuchsia shaking minin' dynamite	0		
+7950	shaking shaking fuchsia minin' dynamite	0		
 7951	plaid cowboy hat of the pedagogue of the brazier	0		Experience: +3, Hot Spell Damage: +25, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	wobbly lasso	0		
 7953	baleful rusted-out shootin' iron of wisdom of the pedagogue	0		Mysticality: +15, Experience: +3, Spell Damage: +25
@@ -7842,7 +7842,7 @@
 7960	copy of a jerk adventurer's father's diary	0		
 7961	wobbly squat perfumed stanky weightlifter's Staff of Ed of wisdom	0		Muscle: +15, Mysticality: +15, Stench Spell Damage: +25, Stench Resistance: +5
 7962	Eye of Ed	0		
-7963	teal wobbly amulet	0		
+7963	wobbly teal amulet	0		
 7964	red gravedigger's Staff of Fats	0		Spooky Damage: +10
 7965	blurry Holy MacGuffin	0		
 7966	Ka coin	0		
@@ -7854,7 +7854,7 @@
 7972	powdered tumbling mummified fig	1	good	
 7973	dehydrated yellow wobbly mummified loaf of bread	1	good	
 7974	compressed mirror mummified beef haunch	1	decent	
-7975	fuchsia huge linen bandages	0		
+7975	huge fuchsia linen bandages	0		
 7976	wobbly cotton bandages	0		
 7977	squat silk bandages	0		
 7978	purple holy spring water	0		
@@ -7880,7 +7880,7 @@
 7998	powdered powder	1		Last Available: "2015-12"
 7999	frozen oxidized purple choco-Crimbot	0		Effect: "Can't Be a Chooser", Effect Duration: 12, Last Available: "2014-12"
 8000	moist huge smart watch	0		Effect: "Barking Mad", Effect Duration: 67, Last Available: "2014-12"
-8001	denatured magnetized shaking red augmented-reality shades	0		Effect: "Wet Jaw", Effect Duration: 23, Last Available: "2014-12"
+8001	denatured magnetized red shaking augmented-reality shades	0		Effect: "Wet Jaw", Effect Duration: 23, Last Available: "2014-12"
 8002	pulsating flame-wreathed toy Crimbot mega face	0		Hot Spell Damage: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
 8003	crafty toy Crimbot power glove	0		Maximum MP: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	Fonzie's toy Crimbot super fist	0		Experience (Moxie): +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
@@ -7888,7 +7888,7 @@
 8006	Vulcanized Crimbot battery	0		Effect: "Petit Forbearance", Effect Duration: 49, Last Available: "2014-12"
 8007	spinning Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8009	purple blurry Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8009	blurry purple Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	ghostly heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	scandalous Van der Graaf Crimbomega drive chain of chilblains	0		Cold Damage: +25, Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
@@ -7916,7 +7916,7 @@
 8034	blurry scorching healthy tope&eacute;	0		Maximum HP Percent: +20, Hot Damage: +25, Familiar Effect: "3xBarrr, cap 12"
 8035	squat jittery friendly topiary tights of the cougar	0		Moxie: +20, Familiar Weight: +3
 8036	topiary necktie of dire peril	0		Weapon Damage: +20
-8037	moldy super-sized purple bowl of topioca	5	crappy	
+8037	super-sized moldy purple bowl of topioca	5	crappy	
 8038	twirling topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	trusty whip	0		
@@ -8024,7 +8024,7 @@
 8150	boiled sugar sphere	0		Effect: "Burning Hands", Effect Duration: 17
 8151	enhanced Shrubble Bubble	0		Effect: "Nut-Rition", Effect Duration: 34
 8152	altered extra-ionized polyeaster egg	0		Effect: "Top Dog", Effect Duration: 20
-8153	unsweetened purple tumbling candy dish	0		Effect: "Strength of Ten Ettins", Effect Duration: 58
+8153	unsweetened tumbling purple candy dish	0		Effect: "Strength of Ten Ettins", Effect Duration: 58
 8154	tarnished blinking Spechunky bar	0		Effect: "Hustlin'", Effect Duration: 11
 8155	double-dry electrified shaking talisman of Horus	0		Effect: "Cool, Catlike", Effect Duration: 50
 8156	check to the Meatsmith	0		
@@ -8036,12 +8036,12 @@
 8162	ribald nippy skullcap	0		Cold Damage: +10, Sleaze Damage: +10, Familiar Effect: "1xVolley,cap 5"
 8163	upside-down double-paned Da Vinci's three-legged pants	0		Experience (Mysticality): +5, Cold Resistance: +5, Familiar Effect: "hot atk, cap 25"
 8164	Jim Carey's extremely unsafe remaindered axe	0		Weapon Damage Percent: +100, Monster Level: +25
-8165	narrow twirling low-budget shield	0		Damage Reduction: 3
+8165	twirling narrow low-budget shield	0		Damage Reduction: 3
 8166	blinking cr&ecirc;epy mask of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Familiar Effect: "spooky atk, cap 5"
-8167	bland special baguette	3	decent	Effect: "Protection from Bad Stuff", Effect Duration: 45
+8167	special bland baguette	3	decent	Effect: "Protection from Bad Stuff", Effect Duration: 45
 8168	blue glob of icing	0		
 8169	anodized mirror maroon ginger snaps	0		Effect: "Sweet Nostalgia", Effect Duration: 66
-8170	cold-filtered corrupted double-liquefied blue upside-down mostly-broken sunglasses	0		Effect: "Cranberry Cordiality", Effect Duration: 63
+8170	cold-filtered corrupted double-liquefied upside-down blue mostly-broken sunglasses	0		Effect: "Cranberry Cordiality", Effect Duration: 63
 8171	hand-crafted unflavored wine cooler	3	EPIC	
 8172	pulsating carton of snake milk	1	awesome	
 8173	sewer snake of vim and vigor	0		Maximum HP Percent: +50
@@ -8060,12 +8060,12 @@
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	teal spinning map to a hidden booze cache	0		
 8188	hand-crafted Cherrytastrophe wine cooler	3	EPIC	
-8189	mediocre practically non-alcoholic Radberry Rip wine cooler	1	decent	
-8190	watered-down aged upside-down Orangemageddon wine cooler	2	awesome	
-8191	perfectly mixed weak Breakfast Blast wine cooler	2	EPIC	
+8189	practically non-alcoholic mediocre Radberry Rip wine cooler	1	decent	
+8190	aged watered-down upside-down Orangemageddon wine cooler	2	awesome	
+8191	weak perfectly mixed Breakfast Blast wine cooler	2	EPIC	
 8192	perfectly mixed mirror Citrus Crush wine cooler	3	EPIC	
 8193	snack-sized bland jittery plain bagel	2	decent	
-8194	special decent snack-sized upside-down wobbly glob of cream cheese	2	good	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45
+8194	decent special snack-sized wobbly upside-down glob of cream cheese	2	good	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45
 8195	stale jumbo loaf of soda bread	5	decent	
 8196	snack-sized spoiled acceptable bagel	2	crappy	
 8197	spoiled fancy upside-down standard-issue cupcake	3	crappy	Effect: "Tennis Elbow-wow", Effect Duration: 45
@@ -8075,7 +8075,7 @@
 8201	no-handed pie	0		
 8202	dry chilled blue Doc Galaktik's Vitality Serum	0		Effect: "Sticks and Stones", Effect Duration: 12
 8203	yellow airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
-8204	shaking purple one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
+8204	purple shaking one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	FunFunds&trade;	0		Last Available: "2015-04"
 8206	lime green strapping expensive camera of the bloodbag	0		Muscle: +5, Maximum HP: +100, Single Equip, Last Available: "2015-04"
 8207	sunglasses	0		Single Equip, Last Available: "2015-04"
@@ -8085,13 +8085,13 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	Sherlock's rigging rope of courage	0		Spooky Resistance: +3, Item Drop: +25, Last Available: "2015-04"
-8214	dried fuchsia huge nasty snuff	1	good	Last Available: "2015-04"
+8214	dried huge fuchsia nasty snuff	1	good	Last Available: "2015-04"
 8215	sewage-clogged pistol of the storm of the brazier	0		Maximum MP Percent: +40, Hot Spell Damage: +25, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	activated polarized beard incense	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 12, Last Available: "2015-04"
 8217	nasty arcane researcher's perfume-soaked bandana	0		Experience Percent (Mysticality): +10, Stench Damage: +5, Single Equip, Last Available: "2015-04"
 8218	upside-down toxic globule	0		Last Available: "2015-04"
-8219	flavorless small tumbling lime green squat toxo	2	decent	Last Available: "2015-04"
-8220	mediocre enchanted Lemonade-235	3	decent	Effect: "Big Flaming Whip", Effect Duration: 35, Last Available: "2015-04"
+8219	flavorless small tumbling squat lime green toxo	2	decent	Last Available: "2015-04"
+8220	enchanted mediocre Lemonade-235	3	decent	Effect: "Big Flaming Whip", Effect Duration: 35, Last Available: "2015-04"
 8221	mirror censurious isotophat of the glutton	0		Sleaze Resistance: +3, Food Drop: +100, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	sharpshooter's educational Three Mile Island shorts	0		Experience: +1, Critical Hit Percent: +10, Last Available: "2015-04"
 8223	yellow scorching dangerous toxic mop	0		Weapon Damage: +10, Hot Damage: +25, Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	flame-retardant lube-shoes	0		Hot Resistance: +1, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	scorching razor-sharp Dinsey mascot mask of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Hot Damage: +25, Last Available: "2015-04"
-8247	small moldy Dinsey food-cone	2	crappy	Last Available: "2015-04"
+8247	moldy small Dinsey food-cone	2	crappy	Last Available: "2015-04"
 8248	perfectly mixed Dinsey Whinskey	3	EPIC	Last Available: "2015-04"
 8249	double-flattened electrified pressed Dinsey face paint	0		Effect: "critical.enh", Effect Duration: 11, Last Available: "2015-04"
 8250	sizzling fannypack of the brazier	0		Hot Damage: +10, Hot Spell Damage: +25, Last Available: "2015-04"
@@ -8143,7 +8143,7 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	decent unappetizing mayolus	3	good	Last Available: "2015-05"
 8271	special flavorless uninteresting mayolus	4	decent	Effect: "Headstrong", Effect Duration: 40, Last Available: "2015-05"
-8272	miniature normal enchanted blinking acceptable mayolus	2	good	Effect: "Springy Fusilli", Effect Duration: 35, Last Available: "2015-05"
+8272	miniature enchanted normal blinking acceptable mayolus	2	good	Effect: "Springy Fusilli", Effect Duration: 35, Last Available: "2015-05"
 8273	normal enticing mayolus	3	good	Last Available: "2015-05"
 8274	decent miniature mouth-watering mayolus	2	good	Last Available: "2015-05"
 8275	shaking newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
@@ -8195,15 +8195,15 @@
 8321	nitrogenated alkaline glove	0		Effect: "Bat Attitude", Effect Duration: 17
 8322	colloidal dry handful of fire	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 55
 8323	flattened polarized Cracklin' Oat Bran	0		Effect: "Using Protection", Effect Duration: 26
-8324	pickled diffused oxidized fuchsia upside-down disposable lighter	0		Effect: "Stuck-Up Hair", Effect Duration: 38
+8324	pickled diffused oxidized upside-down fuchsia disposable lighter	0		Effect: "Stuck-Up Hair", Effect Duration: 38
 8325	concentrated cold-filtered wobbly coal contact lenses	0		Effect: "Helvella Health", Effect Duration: 51
 8326	liquefied blurry conjured ice cream	0		Effect: "Yes, Can Haz", Effect Duration: 25
-8327	energized non-frozen blinking twirling Iceberglar scarf	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 65
+8327	energized non-frozen twirling blinking Iceberglar scarf	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 65
 8328	galvanized altered denatured icy hairspray	0		Effect: "Frisky Spirit", Effect Duration: 31
 8329	irradiated blinking smellbook	0		Effect: "Izchak's Blessing", Effect Duration: 39
 8330	activated quadruple-diffused assassin's cheese knife	0		Effect: "Floundering", Effect Duration: 16
 8331	wet filthy armor	0		Effect: "Bilious Briskness", Effect Duration: 51
-8332	energized vacuum-sealed liquefied wobbly red plague pie	0		Effect: "Amorous", Effect Duration: 41
+8332	energized vacuum-sealed liquefied red wobbly plague pie	0		Effect: "Amorous", Effect Duration: 41
 8333	deionized green batarang	0		Effect: "Hypercubed", Effect Duration: 46
 8334	Vulcanized pickled spare neck bolts	0		Effect: "Mutated", Effect Duration: 17
 8335	super-dry enhanced anodized grease trap	0		Effect: "Sparkly!", Effect Duration: 28
@@ -8212,7 +8212,7 @@
 8338	unsweetened warmed shaking Leonard's glasses	0		Effect: "Pasty", Effect Duration: 36
 8339	double-unsweetened blurry warehouse walkie-talkie	0		Effect: "Salad Days", Effect Duration: 60
 8340	frozen dry janitor's mop	0		Effect: "Gummiskin", Effect Duration: 37
-8341	irradiated spinning jittery warehouse clerk's glasses	0		Effect: "Vented Spleen", Effect Duration: 55
+8341	irradiated jittery spinning warehouse clerk's glasses	0		Effect: "Vented Spleen", Effect Duration: 55
 8342	super-concentrated spinning baloney rotgut	0		Effect: "Libra Rising", Effect Duration: 43
 8343	activated oxidized carton of gaspers	0		Effect: "Experimental Effect G-9", Effect Duration: 14
 8344	warmed bronze polish	0		Effect: "Supafly", Effect Duration: 49
@@ -8227,7 +8227,7 @@
 8353	dry flattened quadruple-dry narrow green grimy lab coat	0		Effect: "Adapt to Change Eventually", Effect Duration: 20
 8354	super-pressed dry nursery rhyme	0		Effect: "Nature's Bounty", Effect Duration: 20
 8355	dry ghostly iron torso box	0		Effect: "Boon of She-Who-Was", Effect Duration: 37
-8356	chilled quantum red skewed mercenary headband	0		Effect: "Lemony Goodness", Effect Duration: 32
+8356	chilled quantum skewed red mercenary headband	0		Effect: "Lemony Goodness", Effect Duration: 32
 8357	colloidal boiled radioactive spider venom	0		Effect: "Wax On Your Shoes", Effect Duration: 27
 8358	deionized polymerized deionized blinking x-ray mirror	0		Effect: "Elemental Mastery", Effect Duration: 35
 8359	extra-concentrated wrestling mask	0		Effect: "Gummiheart", Effect Duration: 33
@@ -8244,17 +8244,17 @@
 8370	triple-colloidal funky eyepatch	0		Effect: "White Blooded", Effect Duration: 39
 8371	nitrogenated triple-deionized pulsating cyan bucket of fish juice	0		Effect: "Fangs and Pangs", Effect Duration: 66
 8372	quantum irradiated jittery flashy pirate dreadlocks	0		Effect: "Thaumodynamic", Effect Duration: 35
-8373	chilled denatured mirror pulsating captured boozles	0		Effect: "World's Shortest Giant", Effect Duration: 41
+8373	chilled denatured pulsating mirror captured boozles	0		Effect: "World's Shortest Giant", Effect Duration: 41
 8374	unsweetened concentrated warmed huge drinks tray	0		Effect: "Permanent Halloween", Effect Duration: 20
 8375	chilled huge eyebrow lifter	0		Effect: "Christmessy", Effect Duration: 54
 8376	submarine	0		Last Available: "2015-06"
-8377	stale small tumbling pixel lemon	2	decent	Last Available: "2015-06"
+8377	small stale tumbling pixel lemon	2	decent	Last Available: "2015-06"
 8378	perfectly mixed weak pixel daiquiri	2	EPIC	Last Available: "2015-06"
 8379	denatured corrupted power pill	0		Effect: "Truly Gritty", Effect Duration: 32, Last Available: "2015-06"
 8380	triple-adjusted spinning pixel potion	0		Effect: "Impregnably Delicious", Effect Duration: 44, Last Available: "2015-06"
 8381	blinking Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
-8383	skewed blurry popular part	0		
+8383	blurry skewed popular part	0		
 8384	upside-down bubblegum heart	0		Last Available: "2015-07"
 8385	cubic zirconia	0		Last Available: "2015-07"
 8386	blurry valuable coin	0		Last Available: "2015-07"
@@ -8282,13 +8282,13 @@
 8408	oxidized improved blurry ectoplasmic orbs	0		Effect: "[1701]Hip to the Jive", Effect Duration: 56
 8409	decent blurry shaking crudles	4	good	
 8410	yummy agnolotti arboli	3	awesome	
-8411	normal small spinning spaghetti with ghost balls	2	good	
+8411	small normal spinning spaghetti with ghost balls	2	good	
 8412	small toothsome succulent marrow	2	awesome	
 8413	flavorless salacious crumbs	3	decent	
 8414	rotten tumbling fusilli marrownarrow	3	crappy	
 8415	normal diet shaking suggestive strozzapreti	1	good	
 8416	Mountain Stream gastrique	0		
-8417	diet stale special Mt. McLargeHuge oyster	1	decent	Effect: "Egg Burps", Effect Duration: 35
+8417	special stale diet Mt. McLargeHuge oyster	1	decent	Effect: "Egg Burps", Effect Duration: 35
 8418	blurry oyster sauce	0		
 8419	toothsome linguini immondizia bianco	4	awesome	
 8420	spoiled snack-sized narrow shells a la shellfish	2	crappy	
@@ -8296,7 +8296,7 @@
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
-8425	lime green bouncing New Age healing crystal	0		Last Available: "2015-08"
+8425	bouncing lime green New Age healing crystal	0		Last Available: "2015-08"
 8426	blurry Volcoino	0		Last Available: "2015-08"
 8427	upside-down fizzing spore pod	0		
 8428	ghostly spore pod	0		
@@ -8335,7 +8335,7 @@
 8461	lousy Gold Velvet&trade; whiskey	4	decent	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	gigantic adequate squat smelted roe	8	good	Last Available: "2015-08"
-8464	tolerable practically non-alcoholic lavawater	1	good	Last Available: "2015-08"
+8464	practically non-alcoholic tolerable lavawater	1	good	Last Available: "2015-08"
 8465	frozen warmed tumbling basaltamander tongue	0		Effect: "Phoenix, Right?", Effect Duration: 17, Last Available: "2015-08"
 8466	blue spinning foul-smelling stiffened lavalarva of doom	0		Damage Reduction: 1, Stench Damage: +10, Spooky Spell Damage: +50, Last Available: "2015-08"
 8467	upside-down jittery huge reassuring dog trainer's Herculean lava balaclava	0		Experience (Muscle): +1, Experience (familiar): +1, Spooky Resistance: +1, Last Available: "2015-08"
@@ -8346,10 +8346,10 @@
 8472	occult extremely unsafe heat-resistant necktie	0		Weapon Damage Percent: +100, Spell Damage Percent: +25, Single Equip, Last Available: "2015-08"
 8473	tumbling greedy Samson's heat-resistant gloves of the blizzard	0		Experience (Muscle): +5, Cold Spell Damage: +25, Meat Drop: +20, Single Equip, Last Available: "2015-08"
 8474	spoiled very hot lunch	4	crappy	Last Available: "2015-08"
-8475	perfectly mixed special asbestos thermos	4	EPIC	Effect: "Amorous", Effect Duration: 30, Last Available: "2015-08"
+8475	special perfectly mixed asbestos thermos	4	EPIC	Effect: "Amorous", Effect Duration: 30, Last Available: "2015-08"
 8476	activated wet cold-filtered twirling liquid rhinestones	0		Effect: "Covetous Robbery", Effect Duration: 59, Last Available: "2015-08"
-8477	spoiled small disco biscuit	2	crappy	Last Available: "2015-08"
-8478	aged practically non-alcoholic Quaatorade&trade;	1	awesome	Last Available: "2015-08"
+8477	small spoiled disco biscuit	2	crappy	Last Available: "2015-08"
+8478	practically non-alcoholic aged Quaatorade&trade;	1	awesome	Last Available: "2015-08"
 8479	supercool biker's hat of the wise owl of the boozehound	0		Mysticality: +20, Moxie Percent: +20, Booze Drop: +100, Familiar Effect: "atk", Last Available: "2015-08"
 8480	twirling lard-coated flame-wreathed Tesla feathered headdress	0		Hot Spell Damage: +10, Sleaze Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
 8481	lightning-fast Herculean electrician's hardhat of the boozehound	0		Experience (Muscle): +1, Booze Drop: +100, Initiative: +40, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8379,7 +8379,7 @@
 8505	half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
 8507	dried SMOOCH coffee cup	1	good	Effect: "Super-Charged", Effect Duration: 25, Last Available: "2015-08"
-8508	triple-chilled oxidized bouncing spinning labrador cookie	0		Effect: "Cat-Alyzed", Effect Duration: 13, Last Available: "2015-08"
+8508	triple-chilled oxidized spinning bouncing labrador cookie	0		Effect: "Cat-Alyzed", Effect Duration: 13, Last Available: "2015-08"
 8509	smelly beefy Mr. Cheeng's spectacles of doom	0		Muscle: +10, Stench Spell Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8510	padded grease cannon of Gandalf	0		Damage Absorption: +20, Spell Critical Percent: +20, Last Available: "2015-08"
 8511	galvanized non-aerosolized electrified demon makeup kit	0		Effect: "Corruption of Wretched Wally", Effect Duration: 46, Last Available: "2015-08"
@@ -8394,7 +8394,7 @@
 8520	careful dance instructor's SMOOCH codpiece	0		Experience Percent (Moxie): +10, Monster Level: -10, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	Van der Graaf SMOOCH breastplate	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
-8523	blinking skewed fused fuse	0		Last Available: "2015-08"
+8523	skewed blinking fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	toothsome lava cake	3	awesome	Last Available: "2015-08"
 8526	normal jumbo pink slime	5	good	
@@ -8405,11 +8405,11 @@
 8531	blue Salsa Libre	0		
 8532	mirror good gravy	0		
 8533	illicit fish sauce	0		
-8534	thick bland purple wobbly shaking libertagliatelle	5	decent	
+8534	thick bland shaking purple wobbly libertagliatelle	5	decent	
 8535	moldy turkish mostaccioli	3	crappy	
-8536	flavorless jumbo linguini of the sea	5	decent	
+8536	jumbo flavorless linguini of the sea	5	decent	
 8537	activated dry Hersey&trade; SMOOCH	0		Effect: "Ice Packed", Effect Duration: 30
-8539	wobbly spinning Alexy sauce	0		
+8539	spinning wobbly Alexy sauce	0		
 8540	skewed rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	stale Fettris	4	decent	
@@ -8420,11 +8420,11 @@
 8547	energized moist twirling pocket maze	0		Effect: "Stands Alone", Effect Duration: 55
 8548	extra-activated liquefied jittery blinking shady shades	0		Effect: "Hangdog", Effect Duration: 20
 8549	galvanized squeaky toy rose	0		Effect: "Jungle Juiced", Effect Duration: 65
-8550	delicious small weird gazelle steak	2	awesome	
+8550	small delicious weird gazelle steak	2	awesome	
 8551	moldy spinning sausage without a cause	3	crappy	
 8552	ionized extra-irradiated face paint	0		Effect: "Deadly Lampblade", Effect Duration: 49
 8553	perfectly mixed practically non-alcoholic spinning emergency margarita	1	super ultra mega turbo EPIC	
-8554	smooth watered-down vintage smart drink	2	awesome	
+8554	watered-down smooth vintage smart drink	2	awesome	
 8555	narrow a ten-percent bonus	0		
 8556	huge Thwaitgold termite statuette	0		
 8557	skewed tumbling The Emperor's new cookie	0		
@@ -8448,16 +8448,16 @@
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
-8578	bad special bottle of Amontillado	4	decent	Effect: "Black Lung", Effect Duration: 35, Last Available: "2015-09"
+8578	special bad bottle of Amontillado	4	decent	Effect: "Black Lung", Effect Duration: 35, Last Available: "2015-09"
 8579	smooth barrel-aged martini	3	awesome	Last Available: "2015-09"
 8580	toothsome blinking barrel pickle	4	awesome	Last Available: "2015-09"
 8581	miniature moldy barrel cracker	2	crappy	Last Available: "2015-09"
-8582	dried bouncing blinking vibrating mushroom	1	awesome	Effect: "Arse-a'fire", Effect Duration: 45, Last Available: "2015-09"
+8582	dried blinking bouncing vibrating mushroom	1	awesome	Effect: "Arse-a'fire", Effect Duration: 45, Last Available: "2015-09"
 8583	mixed purple wobbly mushroom	1	decent	Last Available: "2015-09"
 8584	spinning supercool KoL Con 12-gauge	0		Moxie Percent: +20, Last Available: "2015-09"
 8585	Golden Mr. Eh? of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2015-09"
 8586	tumbling barrel gun of temperance	0		Sleaze Resistance: +5, Last Available: "2015-09"
-8587	blurry green barrel	0		Last Available: "2015-09"
+8587	green blurry barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
 8589	yummy water log	3	awesome	Last Available: "2015-09"
 8590	maroon manspreader's barrelhead of the wise owl	0		Mysticality: +20, Monster Level: +10, Last Available: "2015-09"
@@ -8471,21 +8471,21 @@
 8598	cyan hardened barrel beryl ring of Gandalf	0		Damage Reduction: 3, Spell Critical Percent: +20, Last Available: "2015-09"
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
-8601	pressed dry huge jittery cuppa Flamibili tea	0		Effect: "Human-Goblin Hybrid", Effect Duration: 14, Last Available: "2015-09"
+8601	pressed dry jittery huge cuppa Flamibili tea	0		Effect: "Human-Goblin Hybrid", Effect Duration: 14, Last Available: "2015-09"
 8602	double-ionized non-altered cuppa Yet tea	0		Effect: "Moon'd", Effect Duration: 29, Last Available: "2015-09"
 8603	enhanced olive cuppa Boo tea	0		Effect: "Stregngth of the Gnome", Effect Duration: 31, Last Available: "2015-09"
 8604	polymerized improved cuppa Nas tea	0		Effect: "Swordholder", Effect Duration: 58, Last Available: "2015-09"
 8605	aerosolized mirror jittery cuppa Improprie tea	0		Effect: "Mystic Circle", Effect Duration: 39, Last Available: "2015-09"
-8606	adjusted yellow upside-down cuppa Frost tea	0		Effect: "Mystic Circle", Effect Duration: 11, Last Available: "2015-09"
+8606	adjusted upside-down yellow cuppa Frost tea	0		Effect: "Mystic Circle", Effect Duration: 11, Last Available: "2015-09"
 8607	colloidal cuppa Toast tea	0		Effect: "Ack!  Barred!", Effect Duration: 40, Last Available: "2015-09"
 8608	adjusted modified purple cuppa Net tea	0		Effect: "Sticky Hands", Effect Duration: 16, Last Available: "2015-09"
 8609	alkaline triple-energized cuppa Proprie tea	0		Effect: "Neuromancy", Effect Duration: 36, Last Available: "2015-09"
-8610	galvanized huge blurry cuppa Morbidi tea	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2015-09"
+8610	galvanized blurry huge cuppa Morbidi tea	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2015-09"
 8611	concentrated skewed cuppa Chari tea	0		Effect: "Springy Fusilli", Effect Duration: 42, Last Available: "2015-09"
 8612	non-liquefied cuppa Serendipi tea	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 12, Last Available: "2015-09"
 8613	dry cuppa Feroci tea	0		Effect: "Icy Demeanor", Effect Duration: 29, Last Available: "2015-09"
 8614	tarnished cuppa Physicali tea	0		Effect: "Dweeby", Effect Duration: 59, Last Available: "2015-09"
-8615	vacuum-sealed boiled squat upside-down mirror cuppa Wit tea	0		Effect: "Spookyravin'", Effect Duration: 46, Last Available: "2015-09"
+8615	vacuum-sealed boiled mirror squat upside-down cuppa Wit tea	0		Effect: "Spookyravin'", Effect Duration: 46, Last Available: "2015-09"
 8616	frozen pulsating cuppa Neuroplastici tea	0		Effect: "Pwnd", Effect Duration: 46, Last Available: "2015-09"
 8617	anodized cuppa Dexteri tea	0		Effect: "Spore-Wreathed", Effect Duration: 68, Last Available: "2015-09"
 8618	ionized double-alkaline frozen cuppa Flexibili tea	0		Effect: "Spiky Hair", Effect Duration: 34, Last Available: "2015-09"
@@ -8501,7 +8501,7 @@
 8628	dry wet cuppa Mana tea	0		Effect: "Nasty, Nasty Breath", Effect Duration: 44, Last Available: "2015-09"
 8629	altered chilled cuppa Monstrosi tea	0		Effect: "Oily Flavor", Effect Duration: 23, Last Available: "2015-09"
 8630	extra-pressed ionized cuppa Twen tea	0		Effect: "Surreally Buff", Effect Duration: 65, Last Available: "2015-09"
-8631	dry purple tumbling cuppa Gill tea	0		Effect: "For Your Brain Only", Effect Duration: 62, Last Available: "2015-09"
+8631	dry tumbling purple cuppa Gill tea	0		Effect: "For Your Brain Only", Effect Duration: 62, Last Available: "2015-09"
 8632	liquefied triple-diffused tarnished cuppa Uncertain tea	0		Effect: "Techno Bliss", Effect Duration: 22, Last Available: "2015-09"
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
 8634	jittery cuppa Sobrie tea	0		Last Available: "2015-09"
@@ -8513,11 +8513,11 @@
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	yummy bouncing bowl of eyeballs	3	awesome	Last Available: "2015-10"
 8642	stale bowl of mummy guts	3	decent	Last Available: "2015-10"
-8643	immense stale bowl of maggots	6	decent	Last Available: "2015-10"
+8643	stale immense bowl of maggots	6	decent	Last Available: "2015-10"
 8644	artisanal blood and blood	3	EPIC	Last Available: "2015-10"
 8645	perfectly mixed Jack-O-Lantern beer	3	EPIC	Last Available: "2015-10"
 8646	acceptable zombie	3	good	Last Available: "2015-10"
-8647	ghostly jittery Telltale&trade; rubber heart	0		Last Available: "2015-10"
+8647	jittery ghostly Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	olive plastic nightmare troll	0		Last Available: "2015-10"
 8650	tennis ball	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	huge Usain Bolt's rosy-cheeked groovy hawk	0		Moxie Percent: +10, Maximum HP Percent: +30, Initiative: +80
-8655	miniature flavorless hamlet sandwich	2	decent	
+8655	flavorless miniature hamlet sandwich	2	decent	
 8656	frosty Othello's military jacket	0		Cold Spell Damage: +10
 8657	Jim Carey's Othello's dagger	0		Monster Level: +25, Single Equip
 8658	stylish Othello's handkerchief	0		Moxie: +25, Single Equip
@@ -8538,7 +8538,7 @@
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
 8667	squat green lard-coated Yorick of the blizzard of doom	0		Cold Spell Damage: +25, Spooky Spell Damage: +50, Sleaze Spell Damage: +25
-8668	red blinking rose	0		
+8668	blinking red rose	0		
 8669	tulip	0		
 8670	tulip	0		
 8671	tulip	0		
@@ -8572,7 +8572,7 @@
 8699	upside-down up-at-dawn extremely unsafe Herculean training belt	0		Experience (Muscle): +1, Weapon Damage Percent: +100, Adventures: +5, Single Equip, Last Available: "2016-01"
 8700	stiffened beefcake's training legwarmers of the pedagogue	0		Muscle: +25, Experience: +3, Damage Reduction: 1, Single Equip, Last Available: "2016-01"
 8701	red veiny razor-sharp sage training helmet	0		Mysticality Percent: +10, Weapon Damage Percent: +25, Maximum HP: +10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
-8702	huge spinning training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
+8702	spinning huge training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	tumbling tumbling training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
@@ -8609,9 +8609,9 @@
 8736	studded octolus-skin cloak of dire peril of Gandalf	0		Weapon Damage: +20, Damage Absorption: +80, Spell Critical Percent: +20, Last Available: "2015-11"
 8737	mediocre perfect cosmopolitan	3	decent	Last Available: "2015-11"
 8738	perfectly mixed jittery perfect negroni	3	EPIC	Last Available: "2015-11"
-8739	tolerable practically non-alcoholic perfect dark and stormy	1	good	Last Available: "2015-11"
-8740	tolerable jittery cyan perfect mimosa	4	good	Last Available: "2015-11"
-8741	lousy weak gray perfect old-fashioned	2	decent	Last Available: "2015-11"
+8739	practically non-alcoholic tolerable perfect dark and stormy	1	good	Last Available: "2015-11"
+8740	tolerable cyan jittery perfect mimosa	4	good	Last Available: "2015-11"
+8741	weak lousy gray perfect old-fashioned	2	decent	Last Available: "2015-11"
 8742	smooth practically non-alcoholic skewed perfect paloma	1	awesome	Last Available: "2015-11"
 8743	denatured frozen corrupted That 70s Cologne	0		Effect: "Raging Animal", Effect Duration: 17, Last Available: "2015-11"
 8744	non-pressed bouncing Wal-Mart &quot;diamond&quot; ring	0		Effect: "Inner Dog", Effect Duration: 31, Last Available: "2015-11"
@@ -8622,7 +8622,7 @@
 8749	deionized Deep Machine Tunnels snowglobe	0		Effect: "Moose Wisdom", Effect Duration: 26, Last Available: "2015-12"
 8750	galvanized huge hemp candy necklace	0		Effect: "Mystic Circle", Effect Duration: 41, Last Available: "2015-12"
 8751	chilled communal gobstopper	0		Effect: "Arabian Knighthood", Effect Duration: 31, Last Available: "2015-12"
-8752	spoiled bite-sized Crimbo salad	1	crappy	Last Available: "2015-12"
+8752	bite-sized spoiled Crimbo salad	1	crappy	Last Available: "2015-12"
 8753	decent bread line	3	good	Last Available: "2015-12"
 8754	perfectly mixed upside-down bark rootbeer	3	EPIC	Last Available: "2015-12"
 8755	artisanal ale	4	EPIC	Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	stanky reindeer hammer	0		Stench Spell Damage: +25, Last Available: "2015-12"
 8783	executive elf ploughshare	0		Meat Drop: +40, Last Available: "2015-12"
 8784	tumbling tumbling circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	upside-down faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8683,30 +8683,30 @@
 8811	bouncing huge confidence-building hug	0		Last Available: "2017-01"
 8812	squat exploding kickball	0		Last Available: "2017-01"
 8813	jittery glob of Bat-Glue	0		Last Available: "2017-01"
-8814	tumbling blue Bat-Aid&trade; bandage	0		Last Available: "2017-01"
+8814	blue tumbling Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	spoiled Kudzu salad	3	crappy	Last Available: "2016-12"
 8817	modified squat squat Mansquito Serum	1		Last Available: "2016-12"
-8818	watered-down acceptable Miss Graves' vermouth	2	good	Last Available: "2016-12"
+8818	acceptable watered-down Miss Graves' vermouth	2	good	Last Available: "2016-12"
 8819	decent The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	dried The Author's ink	1		Last Available: "2016-02"
 8821	drinkable The Mad Liquor	3	good	Last Available: "2016-12"
-8822	aged weak Doc Clock's thyme cocktail	2	awesome	Last Available: "2016-12"
+8822	weak aged Doc Clock's thyme cocktail	2	awesome	Last Available: "2016-12"
 8823	spoiled Mr. Burnsger	4	crappy	Last Available: "2016-12"
 8824	powdered lime green The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	upside-down educational Rosewater's The Jokester's gun of the sweet-tooth	0		Mysticality Percent: +30, Experience: +1, Candy Drop: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
 8826	upside-down Usain Bolt's Da Vinci's The Jokester's wig of Gandalf	0		Experience (Mysticality): +5, Spell Critical Percent: +20, Initiative: +80, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	maroon Jack Frost's nippy dance instructor's The Jokester's pants	0		Experience Percent (Moxie): +10, Cold Damage: +10, Cold Spell Damage: +50, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
-8828	quadruple-warmed triple-pressed ghostly pulsating skewed Jokester makeup	0		Effect: "Wise Spirit", Effect Duration: 35, Last Available: "2016-12"
+8828	quadruple-warmed triple-pressed ghostly skewed pulsating Jokester makeup	0		Effect: "Wise Spirit", Effect Duration: 35, Last Available: "2016-12"
 8829	squat replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	domino mask	0		Familiar Weight: +5
 8833	frozen double-improved blinking robin's egg	0		Effect: "Deadly Lampblade", Effect Duration: 12, Last Available: "2016-12"
 8834	toothsome special squat robin flan	3	awesome	Effect: "Sizzling with Fury", Effect Duration: 10, Last Available: "2016-12"
-8835	bad weak robin nog	2	decent	Last Available: "2016-12"
+8835	weak bad robin nog	2	decent	Last Available: "2016-12"
 8836	spinning LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
-8837	tumbling pulsating plaintive telegram	0		Last Available: "2016-02"
+8837	pulsating tumbling plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
 8839	root beer barrel	0		
 8840	tarnished electrified Kudzu slaw	0		Effect: "Slimy Hands", Effect Duration: 55
@@ -8717,13 +8717,13 @@
 8845	alkaline flattened yellow bag of random words	0		Effect: "There Wolf", Effect Duration: 16
 8846	triple-polymerized quantum mirror fuchsia tube of pendulum lube	0		Effect: "Indescribable Flavor", Effect Duration: 26
 8847	quadruple-dry bouncing red-hot jawbreaker	0		Effect: "Adorable Lookout", Effect Duration: 27
-8848	dry aerosolized upside-down blurry question juice	0		Effect: "Cold Blooded", Effect Duration: 11
+8848	dry aerosolized blurry upside-down question juice	0		Effect: "Cold Blooded", Effect Duration: 11
 8849	polymerized tube of villain	0		Effect: "Cat Class, Cat Style", Effect Duration: 26
 8850	wholesome your cowboy boots	0		Maximum HP Percent: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	mirror inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
-8854	shaking narrow nugget of wicksilver	0		Last Available: "2016-02"
+8854	narrow shaking nugget of wicksilver	0		Last Available: "2016-02"
 8855	blurry nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
@@ -8745,16 +8745,16 @@
 8873	ghostly Pork 'n' Pork 'n' Pork 'n' Beans of the sweet-tooth	0		Candy Drop: +100, Last Available: "2016-02"
 8874	mirror lard-coated Jim Carey's stiffened slick Val-U Brand Every Bean Salad of the boozehound	0		Moxie: +10, Damage Reduction: 1, Monster Level: +25, Sleaze Spell Damage: +25, Booze Drop: +100, Last Available: "2016-02"
 8875	wobbly twirling weightlifter's Shrub's Premium Baked Beans of the storm of the brazier	0		Muscle: +15, Maximum MP Percent: +40, Hot Spell Damage: +25, Last Available: "2016-02"
-8876	half-sized bland plate of Heimz Fortified Kidney Beans	2	decent	Last Available: "2016-02"
+8876	bland half-sized plate of Heimz Fortified Kidney Beans	2	decent	Last Available: "2016-02"
 8877	flavorless plate of Tesla's Electroplated Beans	3	decent	Last Available: "2016-02"
-8878	super-sized spoiled plate of Mixed Garbanzos and Chickpeas	5	crappy	Last Available: "2016-02"
+8878	spoiled super-sized plate of Mixed Garbanzos and Chickpeas	5	crappy	Last Available: "2016-02"
 8879	bland plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	stale plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
 8881	super-sized moldy spinning shaking plate of World's Blackest-Eyed Peas	5	crappy	Last Available: "2016-02"
 8882	normal plate of Trader Olaf's Exotic Stinkbeans	3	good	Last Available: "2016-02"
-8883	jumbo yummy plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	awesome	Last Available: "2016-02"
-8884	big tasty twirling shaking purple plate of Val-U Brand Every Bean Salad	5	awesome	Last Available: "2016-02"
-8885	moldy miniature cyan plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
+8883	yummy jumbo plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	awesome	Last Available: "2016-02"
+8884	big tasty shaking twirling purple plate of Val-U Brand Every Bean Salad	5	awesome	Last Available: "2016-02"
+8885	miniature moldy cyan plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	Fancy Jeff's pocket square of the brazier of doom	0		Hot Spell Damage: +25, Spooky Spell Damage: +50, Last Available: "2016-02"
 8887	wobbly flame-wreathed lion tamer's Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Hot Spell Damage: +10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8762,7 +8762,7 @@
 8890	narrow Glenn's dice	0		Last Available: "2016-02"
 8891	Temple Grandin's Oprah's studded occult Former Sheriff Dan's tin star of the detective	0		Spell Damage Percent: +25, Damage Absorption: +80, Maximum MP Percent: +50, Familiar Weight: +7, Item Drop: +20, Last Available: "2016-02"
 8892	huge blinking El Vibrato restraints	0		Last Available: "2016-02"
-8893	blinking narrow Clara's bell	0		Last Available: "2016-02"
+8893	narrow blinking Clara's bell	0		Last Available: "2016-02"
 8894	reassuring Herculean Granny Hackleton's Gatling gun of the cougar	0		Moxie: +20, Experience (Muscle): +1, Spooky Resistance: +1, Last Available: "2016-02"
 8895	narrow buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	corrupted tumbling squat rattler gland	0		Effect: "Slimily Speedy", Effect Duration: 62, Last Available: "2016-02"
 8907	polymerized narrow squat half-digested coal	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 37, Last Available: "2016-02"
 8908	deionized tightly-wound spine	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 44, Last Available: "2016-02"
-8909	moldy low-calorie enchanted wobbly rotting beefsteak	1	crappy	Effect: "Preemptive Medicine", Effect Duration: 35, Last Available: "2016-02"
+8909	enchanted moldy low-calorie wobbly rotting beefsteak	1	crappy	Effect: "Preemptive Medicine", Effect Duration: 35, Last Available: "2016-02"
 8910	mediocre firemilk	3	decent	Last Available: "2016-02"
 8911	flattened shaking spidercow eye-cluster	0		Effect: "Browbeaten", Effect Duration: 60, Last Available: "2016-02"
 8912	compressed moomy dust	1		Effect: "Less Pervious", Effect Duration: 35, Last Available: "2016-02"
@@ -8846,9 +8846,9 @@
 8974	quantum moist eldritch oil	0		Effect: "New Zeal", Effect Duration: 51
 8975	exclusive club	0		
 8976	quadruple-moist patent preventative tonic	0		Effect: "Rat-Faced", Effect Duration: 65
-8977	boiled chilled jittery blurry twirling patent invisibility tonic	0		Effect: "Woad Warrior", Effect Duration: 54
+8977	boiled chilled twirling jittery blurry patent invisibility tonic	0		Effect: "Woad Warrior", Effect Duration: 54
 8978	enhanced diffused patent aggression tonic	0		Effect: "Innately Wise", Effect Duration: 22
-8979	dry red jittery patent sallowness tonic	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 60
+8979	dry jittery red patent sallowness tonic	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 60
 8980	nitrogenated polarized patent avarice tonic	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 27
 8981	concentrated colloidal patent alacrity tonic	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 50
 8982	polymerized vacuum-sealed narrow corrupted marrow	0		Effect: "Eagle Eyes", Effect Duration: 48
@@ -8863,7 +8863,7 @@
 8991	bouncing do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	compressed armored prawn	1		Last Available: "2016-03"
 8993	flavorless tiny upside-down jumping horseradish	1	decent	Last Available: "2016-03"
-8994	hand-crafted weak Sacramento wine	2	EPIC	Last Available: "2016-03"
+8994	weak hand-crafted Sacramento wine	2	EPIC	Last Available: "2016-03"
 8995	quantum bouncing Greek fire	0		Effect: "Pill Power", Effect Duration: 30, Last Available: "2016-03"
 8996	fireproof extremely unsafe arcane researcher's experienced ox-head shield of wisdom	0		Mysticality: +15, Experience: +2, Experience Percent (Mysticality): +10, Weapon Damage Percent: +100, Hot Resistance: +3, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	Usain Bolt's dog trainer's sharpshooter's sinister dented scepter of vim and vigor	0		Spell Damage: +10, Maximum HP Percent: +50, Critical Hit Percent: +10, Experience (familiar): +1, Initiative: +80, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8876,9 +8876,9 @@
 9004	flame-retardant ribald gravedigger's Fonzie's bass clarinet	0		Experience (Moxie): +1, Spooky Damage: +10, Sleaze Damage: +10, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9005	sharpshooter's MacGyver's veiny fortified fish hatchet	0		Damage Absorption: +60, Maximum HP: +10, Maximum MP: +100, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	reassuring tunac of the sewer of courage of the detective	0		Stench Damage: +25, Spooky Resistance: 4, Item Drop: +20, Lasts Until Rollover, Last Available: "2016-04"
-9007	spinning huge ghostly fishin' pole	0		Last Available: "2016-04"
+9007	spinning ghostly huge fishin' pole	0		Last Available: "2016-04"
 9008	non-adjusted polymerized wriggling worm	0		Effect: "Salty Dogs", Effect Duration: 39, Last Available: "2016-04"
-9009	high-proof lousy red bottle of Fishhead 900-Day IPA	9	decent	Last Available: "2016-04"
+9009	lousy high-proof red bottle of Fishhead 900-Day IPA	9	decent	Last Available: "2016-04"
 9010	liquefied high-test fishing line	0		Effect: "Mucilaginous Muscle", Effect Duration: 46, Last Available: "2016-04"
 9011	lard-coated fishin' hat	0		Sleaze Spell Damage: +25, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8905,9 +8905,9 @@
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	tasty browser cookie	4	awesome	Last Available: "2016-06"
-9036	bad spirit-forward jittery hacked gibson	5	decent	Last Available: "2016-06"
+9036	spirit-forward bad jittery hacked gibson	5	decent	Last Available: "2016-06"
 9037	skewed Usain Bolt's Source shades	0		Initiative: +80, Last Available: "2016-06"
-9038	narrow skewed software bug	0		Last Available: "2016-06"
+9038	skewed narrow software bug	0		Last Available: "2016-06"
 9039	mirror missing semicolon	0		Familiar Weight: +11
 9040	Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
@@ -8935,7 +8935,7 @@
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
 9064	Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	Source terminal file: dram.ext	0		Last Available: "2016-06"
-9066	tumbling red Source terminal file: tram.ext	0		Last Available: "2016-06"
+9066	red tumbling Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	pill	0		Last Available: "2016-06"
 9068	manspreader's padded Herculean plastic detective badge of the cougar	0		Moxie: +20, Experience (Muscle): +1, Damage Absorption: +20, Monster Level: +10, Last Available: "2016-07"
 9069	Van der Graaf veiny banded supercool bronze detective badge	0		Moxie Percent: +20, Damage Absorption: +100, Maximum HP: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-07"
@@ -8947,7 +8947,7 @@
 9075	alkaline quadruple-warmed blurry shoe gum	0		Effect: "You're Rubber", Effect Duration: 44, Last Available: "2016-07"
 9076	bouncing executive inspector's noir fedora of the cheetah	0		Item Drop: +15, Meat Drop: +40, Initiative: +60, Last Available: "2016-07"
 9077	cyan aromatic Jim Carey's MacGyver's trench coat	0		Maximum MP: +100, Monster Level: +25, Stench Resistance: +1, Last Available: "2016-07"
-9078	smooth watered-down Falcon&trade; Maltese Liquor	2	awesome	Last Available: "2016-07"
+9078	watered-down smooth Falcon&trade; Maltese Liquor	2	awesome	Last Available: "2016-07"
 9079	miniature moldy hardboiled egg	2	crappy	Last Available: "2016-07"
 9080	squat detective tattoo	0		Last Available: "2016-07"
 9081	spinning DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
@@ -8988,7 +8988,7 @@
 9116	yellow time residue	0		Last Available: "2016-09"
 9117	frosty repaid diaper	0		Cold Spell Damage: +10
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	drinkable practically non-alcoholic spinning Shot of Kardashian Gin	1	good	Last Available: "2016-09"
+9119	practically non-alcoholic drinkable spinning Shot of Kardashian Gin	1	good	Last Available: "2016-09"
 9120	Unstable Pointy Ears of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Last Available: "2016-09"
 9121	pulsating twirling Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
@@ -9020,15 +9020,15 @@
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	activated unsweetened invisible string	0		Lasts Until Rollover, Effect: "Pla-see-bo", Effect Duration: 30, Last Available: "2016-10"
-9151	unsweetened bouncing cyan narrow invisible seam ripper	0		Lasts Until Rollover, Effect: "Deep-Seated Rage", Effect Duration: 50, Last Available: "2016-10"
+9151	unsweetened narrow cyan bouncing invisible seam ripper	0		Lasts Until Rollover, Effect: "Deep-Seated Rage", Effect Duration: 50, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	bland small jittery raw sweet potato	2	decent	Last Available: "2016-11"
 9154	rotten raw beans	4	crappy	Last Available: "2016-11"
 9155	adequate twirling raw stuffing	4	good	Last Available: "2016-11"
 9156	adequate spinning raw cranberry sauce	3	good	Last Available: "2016-11"
-9157	gigantic tasty raw turkey	10	awesome	Last Available: "2016-11"
+9157	tasty gigantic raw turkey	10	awesome	Last Available: "2016-11"
 9158	rotten twirling raw mincemeat	4	crappy	Last Available: "2016-11"
-9159	stale big fancy shaking raw potato	5	decent	Effect: "Preternatural Greed", Effect Duration: 45, Last Available: "2016-11"
+9159	big stale fancy shaking raw potato	5	decent	Effect: "Preternatural Greed", Effect Duration: 45, Last Available: "2016-11"
 9160	normal half-sized raw gravy	2	good	Last Available: "2016-11"
 9161	delicious raw bread	3	awesome	Last Available: "2016-11"
 9162	frightening mini-marshmallow dispenser of the scaredy-cat	0		Monster Level: -15, Spooky Damage: +5, Last Available: "2016-11"
@@ -9042,9 +9042,9 @@
 9170	bread mold	0		Last Available: "2016-11"
 9171	thick normal sweet potatoes	5	good	Last Available: "2016-11"
 9172	stale squat bean casserole	3	decent	Last Available: "2016-11"
-9173	bland miniature shaking baked stuffing	2	decent	Last Available: "2016-11"
-9174	decent immense cranberry cylinder	7	good	Last Available: "2016-11"
-9175	massive moldy squat thanksgiving turkey	8	crappy	Last Available: "2016-11"
+9173	miniature bland shaking baked stuffing	2	decent	Last Available: "2016-11"
+9174	immense decent cranberry cylinder	7	good	Last Available: "2016-11"
+9175	moldy massive squat thanksgiving turkey	8	crappy	Last Available: "2016-11"
 9176	huge adequate mince pie	8	good	Last Available: "2016-11"
 9177	flavorless ghostly mashed potatoes	3	decent	Last Available: "2016-11"
 9178	decent warm gravy	3	good	Last Available: "2016-11"
@@ -9052,7 +9052,7 @@
 9180	decent leftovers	4	good	Last Available: "2016-11"
 9181	flavorless snack-sized bouncing leftovers sandwich	2	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
-9183	bouncing purple spinning cornucopia	0		Last Available: "2016-11"
+9183	purple spinning bouncing cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	teal wobbly pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
@@ -9061,7 +9061,7 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	pulsating eldritch effluvium	0		
 9191	aerosolized eldritch concentrate	0		Effect: "Human-Hippy Hybrid", Effect Duration: 19, Last Available: "2016-11"
-9192	practically non-alcoholic bad blue narrow eldritch extract	1	decent	Last Available: "2016-11"
+9192	practically non-alcoholic bad narrow blue eldritch extract	1	decent	Last Available: "2016-11"
 9193	huge lard-coated Official Council Aide Pin of the sweet-tooth	0		Sleaze Spell Damage: +25, Candy Drop: +100, Last Available: "2016-11"
 9194	artisanal eldritch distillate	4	EPIC	Last Available: "2016-11"
 9195	dried spinning eldritch essence	1		Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	lime green interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	jittery sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	half-sized rotten gray animal part cracker	2	crappy	Last Available: "2016-12"
+9219	rotten half-sized gray animal part cracker	2	crappy	Last Available: "2016-12"
 9220	hand-crafted fuchsia gingerbread wine	3	EPIC	Last Available: "2016-12"
 9221	adequate twirling gingerbread mug	3	good	Last Available: "2016-12"
 9222	yellow squat gingerbread mask of the boozehound	0		Booze Drop: +100, Last Available: "2016-12"
@@ -9111,8 +9111,8 @@
 9239	perfectly mixed ginger beer	4	EPIC	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	activated industrial frosting	0		Effect: "Weepy, Creepy", Effect Duration: 39, Last Available: "2016-12"
-9242	Vulcanized anodized pulsating teal ghostly fake cocktail	0		Effect: "You Can Taste the Darkness", Effect Duration: 26, Last Available: "2016-12"
-9243	irresponsibly strong acceptable special high-end ginger wine	9	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45, Last Available: "2016-12"
+9242	Vulcanized anodized ghostly pulsating teal fake cocktail	0		Effect: "You Can Taste the Darkness", Effect Duration: 26, Last Available: "2016-12"
+9243	special acceptable irresponsibly strong high-end ginger wine	9	good	Effect: "Medieval Mage Mayhem", Effect Duration: 45, Last Available: "2016-12"
 9244	beefy plastic bad vibe	0		Muscle: +10, Last Available: "2016-12"
 9245	plastic angry vikings of the sweet-tooth	0		Candy Drop: +100, Last Available: "2016-12"
 9246	huge Sinatra's plastic Knows About Chakras	0		Experience (Moxie): +5, Last Available: "2016-12"
@@ -9122,7 +9122,7 @@
 9250	quadruple-flattened pressed ghostly blinking Inner Strength	0		Effect: "Squirming Like a Toad", Effect Duration: 38, Last Available: "2016-12"
 9251	chilled Inner Truth	0		Effect: "So You Can Work More...", Effect Duration: 59, Last Available: "2016-12"
 9252	normal spiritual candy cane	4	good	Last Available: "2016-12"
-9253	high-proof special tolerable spiritual eggnog	6	good	Effect: "Human-Human Hybrid", Effect Duration: 5, Last Available: "2016-12"
+9253	high-proof tolerable special spiritual eggnog	6	good	Effect: "Human-Human Hybrid", Effect Duration: 5, Last Available: "2016-12"
 9254	normal miniature spiritual fruitcake	2	good	Last Available: "2016-12"
 9255	rotten jumbo bouncing spiritual gingerbread	5	crappy	Last Available: "2016-12"
 9256	ghostly chocolate puppy	0		Last Available: "2016-12"
@@ -9147,7 +9147,7 @@
 9275	flavorless hambrosier	4	decent	Last Available: "2016-12"
 9276	acceptable twirling chakra-mental wine	3	good	Last Available: "2016-12"
 9277	frozen chakra malt	0		Effect: "Strange Mental Acuity", Effect Duration: 52, Last Available: "2016-12"
-9278	bland diet maroon Black Angus blackburger	1	decent	Last Available: "2016-12"
+9278	diet bland maroon Black Angus blackburger	1	decent	Last Available: "2016-12"
 9279	spirit-forward tolerable brandy	5	good	Last Available: "2016-12"
 9280	polymerized irradiated potion of spiritual gunkifying	0		Effect: "Here's Mud in Your Eye", Effect Duration: 37, Last Available: "2016-12"
 9281	resourceful Sinatra's bad vibroknife	0		Experience (Moxie): +5, Maximum MP: +50, Last Available: "2016-12"
@@ -9162,26 +9162,26 @@
 9290	spoiled Eldritch snap	3	crappy	Last Available: "2017-01"
 9291	twisted shaking ghostly hot jelly	1		Effect: "Blood-Gorged", Effect Duration: 20, Last Available: "2017-01"
 9292	distilled wobbly wobbly jelly	1		Last Available: "2017-01"
-9293	diluted maroon upside-down jelly	1		Last Available: "2017-01"
+9293	diluted upside-down maroon jelly	1		Last Available: "2017-01"
 9294	vaporized sleaze jelly	1		Last Available: "2017-01"
 9295	modified stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	tasty super-sized toast with hot jelly	5	awesome	Last Available: "2017-01"
-9298	half-sized normal toast with jelly	2	good	Last Available: "2017-01"
+9298	normal half-sized toast with jelly	2	good	Last Available: "2017-01"
 9299	spoiled toast with jelly	4	crappy	Last Available: "2017-01"
 9300	moldy miniature toast with sleaze jelly	2	crappy	Last Available: "2017-01"
 9301	yummy bouncing toast with stench jelly	4	awesome	Last Available: "2017-01"
 9302	skewed twirling space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
-9304	ghostly squat pewter candlestick	0		Familiar Weight: +10
+9304	squat ghostly pewter candlestick	0		Familiar Weight: +10
 9305	educational supercool wax hand	0		Moxie Percent: +20, Experience: +1, Last Available: "2017-01"
 9306	shaking wizardly candle	0		Mysticality: +25, Item Drop: +5, Lasts Until Rollover, Last Available: "2017-01"
 9307	delicious snack-sized wax pancake	2	awesome	Last Available: "2017-01"
 9308	wax face of vim and vigor of the businessman	0		Maximum HP Percent: +50, Meat Drop: +50, Last Available: "2017-01"
 9309	lousy fuchsia wax booze	4	decent	Last Available: "2017-01"
-9310	lime green pulsating glob of melted wax	0		Last Available: "2017-01"
+9310	pulsating lime green glob of melted wax	0		Last Available: "2017-01"
 9311	distilled yellow ghostly sea jelly	1		Last Available: "2017-01"
-9312	decent big sea truffle	5	good	Last Available: "2017-01"
+9312	big decent sea truffle	5	good	Last Available: "2017-01"
 9313	cyan squat tarnished luggage key	0		Last Available: "2017-01"
 9314	jittery crushed steamer trunk	0		Last Available: "2017-01"
 9315	recovered cufflinks of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2017-01"
@@ -9195,7 +9195,7 @@
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	altered squat blinking LOV Echinacea Bouquet	1		Last Available: "2017-02"
+9326	altered blinking squat LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	flame-wreathed LOV Elephant	0		Hot Spell Damage: +10, Damage Reduction: 6, Last Available: "2017-02"
 9328	lard-coated eldritch scanner	0		Sleaze Spell Damage: +25, Last Available: "2017-02"
 9329	concentrated polymerized eldritch alignment spray	0		Effect: "items.enh", Effect Duration: 50, Last Available: "2017-02"
@@ -9208,7 +9208,7 @@
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	concentrated spinning eldritch rub	0		Effect: "Comprehensively Nourished", Effect Duration: 34, Last Available: "2017-02"
 9338	mirror HP-35 Calculator	0		
-9339	red ghostly Silver HP-35 Calculator	0		
+9339	ghostly red Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
@@ -9230,44 +9230,44 @@
 9358	spinning bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	blinking baby oil shooter	0		Last Available: "2017-03"
 9360	cyan blinking fish head	0		Last Available: "2017-03"
-9361	shaking wobbly skewed limepatch	0		Last Available: "2017-03"
+9361	shaking skewed wobbly limepatch	0		Last Available: "2017-03"
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	ghostly slime shooter	0		Last Available: "2017-03"
 9364	fuchsia imaginary lemon	0		Last Available: "2017-03"
-9365	weak tolerable literal grasshopper	2	good	Last Available: "2017-03"
+9365	tolerable weak literal grasshopper	2	good	Last Available: "2017-03"
 9366	watered-down hand-crafted upside-down double entendre	2	EPIC	Last Available: "2017-03"
-9367	fancy weak aged upside-down Phlegethon	2	awesome	Effect: "Unrunnable Face", Effect Duration: 25, Last Available: "2017-03"
+9367	aged weak fancy upside-down Phlegethon	2	awesome	Effect: "Unrunnable Face", Effect Duration: 25, Last Available: "2017-03"
 9368	hand-crafted Siberian sunrise	4	EPIC	Last Available: "2017-03"
 9369	hand-crafted mentholated wine	4	EPIC	Last Available: "2017-03"
 9370	smooth low tide martini	4	awesome	Last Available: "2017-03"
-9371	perfectly mixed extra-dry shroomtini	5	EPIC	Last Available: "2017-03"
+9371	extra-dry perfectly mixed shroomtini	5	EPIC	Last Available: "2017-03"
 9372	aged morning dew	4	awesome	Last Available: "2017-03"
 9373	hand-crafted practically non-alcoholic upside-down whiskey squeeze	1	EPIC	Last Available: "2017-03"
 9374	extra-dry hand-crafted great fashioned	5	EPIC	Last Available: "2017-03"
 9375	smooth Gnomish sagngria	3	awesome	Last Available: "2017-03"
 9376	hand-crafted vodka stinger	4	EPIC	Last Available: "2017-03"
 9377	watered-down perfectly mixed extremely slippery nipple	2	EPIC	Last Available: "2017-03"
-9378	weak bad piscatini	2	decent	Last Available: "2017-03"
+9378	bad weak piscatini	2	decent	Last Available: "2017-03"
 9379	hand-crafted Churchill	4	EPIC	Last Available: "2017-03"
 9380	lousy soilzerac	3	decent	Last Available: "2017-03"
 9381	artisanal London frog	4	EPIC	Last Available: "2017-03"
-9382	tolerable watered-down nothingtini	2	good	Last Available: "2017-03"
+9382	watered-down tolerable nothingtini	2	good	Last Available: "2017-03"
 9383	watered-down drinkable eighth plague	2	good	Last Available: "2017-03"
 9384	mediocre spinning single entendre	3	decent	Last Available: "2017-03"
 9385	perfectly mixed watered-down tumbling reverse Tantalus	2	EPIC	Last Available: "2017-03"
-9386	bad irresponsibly strong shaking olive elemental caipiroska	9	decent	Last Available: "2017-03"
+9386	bad irresponsibly strong olive shaking elemental caipiroska	9	decent	Last Available: "2017-03"
 9387	high-proof drinkable Feliz Navidad	10	good	Last Available: "2017-03"
 9388	bad blue Bloody Nora	4	decent	Last Available: "2017-03"
 9389	practically non-alcoholic artisanal blinking moreltini	1	EPIC	Last Available: "2017-03"
 9390	artisanal hell in a bucket	3	EPIC	Last Available: "2017-03"
-9391	drinkable narrow narrow green Newark	3	good	Last Available: "2017-03"
-9392	watered-down mediocre gray jittery R'lyeh	2	decent	Last Available: "2017-03"
+9391	drinkable narrow green narrow Newark	3	good	Last Available: "2017-03"
+9392	mediocre watered-down gray jittery R'lyeh	2	decent	Last Available: "2017-03"
 9393	acceptable Gnollish sangria	4	good	Last Available: "2017-03"
 9394	high-proof aged upside-down vodka barracuda	8	awesome	Last Available: "2017-03"
 9395	perfectly mixed skewed Mysterious Island iced tea	3	EPIC	Last Available: "2017-03"
 9396	spirit-forward perfectly mixed drive-by shooting	5	EPIC	Last Available: "2017-03"
-9397	drinkable weak gunner's daughter	2	good	Last Available: "2017-03"
-9398	watered-down smooth dirt julep	2	awesome	Last Available: "2017-03"
+9397	weak drinkable gunner's daughter	2	good	Last Available: "2017-03"
+9398	smooth watered-down dirt julep	2	awesome	Last Available: "2017-03"
 9399	watered-down drinkable Simepore slime	2	good	Last Available: "2017-03"
 9400	fortified hand-crafted Phil Collins	5	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9301,9 +9301,9 @@
 9429	bouncing blue alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	maroon murderbot data core	0		Last Available: "2017-04"
-9432	enhanced moist twirling maroon upside-down alien medicine	0		Effect: "On Pins and Needles", Effect Duration: 39, Last Available: "2017-04"
+9432	enhanced moist upside-down maroon twirling alien medicine	0		Effect: "On Pins and Needles", Effect Duration: 39, Last Available: "2017-04"
 9433	moldy snack-sized fancy alien salad	2	crappy	Effect: "You Know Where to Go", Effect Duration: 15, Last Available: "2017-04"
-9434	triple-distilled delicious pulsating alien booze	7	awesome	Last Available: "2017-04"
+9434	delicious triple-distilled pulsating alien booze	7	awesome	Last Available: "2017-04"
 9435	zippy sizzling Temple Grandin's alien mask	0		Familiar Weight: +7, Hot Damage: +10, Initiative: +20, Last Available: "2017-04"
 9436	miser's frosty friendly alien spear	0		Familiar Weight: +3, Cold Spell Damage: +10, Meat Drop: +10, Last Available: "2017-04"
 9437	upside-down chaotic alien blowgun of Tarzan of temperance	0		Experience (Muscle): +3, Spell Critical Percent: +10, Sleaze Resistance: +5, Last Available: "2017-04"
@@ -9323,7 +9323,7 @@
 9451	polarized polymerized deionized yellow murderbot shield unit	0		Effect: "Gummiskin", Effect Duration: 69, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	flame-retardant Jack Frost's murderbot mask of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +50, Hot Resistance: +1, Avatar: "Murderbot", Last Available: "2017-04"
-9454	liquefied shaking blinking murderbot spring injector	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 18, Last Available: "2017-04"
+9454	liquefied blinking shaking murderbot spring injector	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 18, Last Available: "2017-04"
 9455	huge veiny arcane researcher's murderbot whip	0		Experience Percent (Mysticality): +10, Maximum HP: +10, Last Available: "2017-04"
 9456	sizzling toasty murderbot plasma rifle	0		Hot Damage: 15, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
@@ -9331,11 +9331,11 @@
 9459	twirling bouncing Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	purple Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
-9462	shaking gray Procrastinator locker key	0		Last Available: "2017-04"
+9462	gray shaking Procrastinator locker key	0		Last Available: "2017-04"
 9463	gray Space Baby children's book	0		Last Available: "2017-04"
 9464	teal Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
-9466	enchanted miniature flavorless Aldebaran sardines	2	decent	Effect: "Saucemastery", Effect Duration: 10, Last Available: "2017-04"
+9466	flavorless miniature enchanted Aldebaran sardines	2	decent	Effect: "Saucemastery", Effect Duration: 10, Last Available: "2017-04"
 9467	drinkable Centauri fish wine	3	good	Last Available: "2017-04"
 9468	dehydrated oxygen	1		Last Available: "2017-04"
 9469	toasty ruddy Spacegate scientist's insignia	0		Maximum HP Percent: +40, Hot Damage: +5, Single Equip, Last Available: "2017-04"
@@ -9345,7 +9345,7 @@
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	huge rotten spinning alien sandwich	8	crappy	Last Available: "2017-04"
 9475	pulsating glitched malware	0		Last Available: "2025-12"
-9476	alkaline quadruple-moist squat yellow Spant eggs	0		Effect: "Spooky Demeanor", Effect Duration: 42
+9476	alkaline quadruple-moist yellow squat Spant eggs	0		Effect: "Spooky Demeanor", Effect Duration: 42
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	yellow New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	moist dry super-modified Daily Affirmation: Always be Collecting	0		Effect: "Sauce Monocle", Effect Duration: 54, Last Available: "2017-05"
@@ -9353,7 +9353,7 @@
 9481	nitrogenated Daily Affirmation: Be Superficially interested	0		Effect: "Bored Stiff", Effect Duration: 15, Last Available: "2017-05"
 9482	nitrogenated activated electrified Daily Affirmation: Adapt to Change Eventually	0		Effect: "Neutered Nostrils", Effect Duration: 56, Last Available: "2017-05"
 9483	polarized galvanized dry jittery Daily Affirmation: Be a Mind Master	0		Effect: "Slimily Sagacious", Effect Duration: 34, Last Available: "2017-05"
-9484	wet lime green pulsating Daily Affirmation: Work For Hours a Week	0		Effect: "Bear Clawed", Effect Duration: 57, Last Available: "2017-05"
+9484	wet pulsating lime green Daily Affirmation: Work For Hours a Week	0		Effect: "Bear Clawed", Effect Duration: 57, Last Available: "2017-05"
 9485	triple-polarized chilled blurry Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Marbles in Your Mouth", Effect Duration: 57, Last Available: "2017-05"
 9486	spoiled purple Affirmation Cookie	4	crappy	Last Available: "2017-05"
 9487	License To Kill	0		
@@ -9363,9 +9363,9 @@
 9491	blue Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	lightning-fast Herculean Rosewater's Kremlin's Greatest Briefcase	0		Mysticality Percent: +30, Experience (Muscle): +1, Initiative: +40, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	spirit-forward tolerable squat pulsating basic martini	5	good	Last Available: "2017-06"
-9495	irresponsibly strong acceptable blinking improved martini	9	good	Last Available: "2017-06"
-9496	irresponsibly strong special perfectly mixed splendid martini	6	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 30, Last Available: "2017-06"
+9494	tolerable spirit-forward squat pulsating basic martini	5	good	Last Available: "2017-06"
+9495	acceptable irresponsibly strong blinking improved martini	9	good	Last Available: "2017-06"
+9496	special perfectly mixed irresponsibly strong splendid martini	6	EPIC	Effect: "Compensatory Cruelness", Effect Duration: 30, Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	blinking tattoo gun	0		Last Available: "2017-06"
@@ -9383,8 +9383,8 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	half-sized stale meteoreo	2	decent	Last Available: "2017-08"
-9515	tolerable fancy wobbly meadeorite	3	good	Effect: "Healthy Bronze Glow", Effect Duration: 45, Last Available: "2017-08"
+9514	stale half-sized meteoreo	2	decent	Last Available: "2017-08"
+9515	fancy tolerable wobbly meadeorite	3	good	Effect: "Healthy Bronze Glow", Effect Duration: 45, Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	Annie Oakley's meteortarboard of James Dean of bravery	0		Experience (Moxie): +3, Critical Hit Percent: +20, Spooky Resistance: +5, Last Available: "2017-08"
 9518	maroon veiny meteorite guard of the bloodbag of the cheetah	0		Maximum HP: 110, Initiative: +60, Damage Reduction: 9, Last Available: "2017-08"
@@ -9419,12 +9419,12 @@
 9547	drinkable watered-down flask of port	2	good	
 9548	scandalous boxer's contract enforcement stick	0		Muscle Percent: +10, Sleaze Damage: +5
 9549	bland bite-sized Hide-rox&trade; cookie	1	decent	Last Available: "2017-10"
-9550	weak drinkable jug of booze	2	good	Last Available: "2017-10"
-9551	pressed activated blinking olive ghostly pair of candy glasses	0		Effect: "Aided and Abetted", Effect Duration: 33, Last Available: "2017-10"
+9550	drinkable weak jug of booze	2	good	Last Available: "2017-10"
+9551	pressed activated blinking ghostly olive pair of candy glasses	0		Effect: "Aided and Abetted", Effect Duration: 33, Last Available: "2017-10"
 9552	enhanced pickled jittery temporary X tattoos	0		Effect: "Lubed", Effect Duration: 31, Last Available: "2017-10"
-9553	powdered narrow bouncing glyph of athleticism	1		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 15, Last Available: "2017-10"
+9553	powdered bouncing narrow glyph of athleticism	1		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 15, Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
-9555	non-unsweetened diffused shaking lime green new habit	0		Effect: "Marbles in Your Mouth", Effect Duration: 53, Last Available: "2017-10"
+9555	non-unsweetened diffused lime green shaking new habit	0		Effect: "Marbles in Your Mouth", Effect Duration: 53, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
 9557	miser's wool medical-grade pearl necklace	0		Cold Resistance: +1, Meat Drop: +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-10"
 9558	amorphous blob	0		Last Available: "2017-11"
@@ -9446,7 +9446,7 @@
 9574	pantogram pants	0		Lasts Until Rollover, Last Available: "2017-11"
 9575	mirror reassuring sage mafia wedding ring	0		Mysticality Percent: +10, Spooky Resistance: +1, Single Equip
 9576	cyan shaking mansplainer's mafia organizer badge	0		Monster Level: +15, Single Equip
-9577	fuchsia wobbly mafia filofax	0		
+9577	wobbly fuchsia mafia filofax	0		
 9578	transparent nog	1	awesome	Last Available: "2017-12"
 9579	stale unfinished fruitcake	4	decent	Last Available: "2017-12"
 9580	quantum gray twirling and cracker	0		Effect: "Tearful, Fearful", Effect Duration: 32, Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	concentrated wishbone	0		Effect: "Stogied", Effect Duration: 60, Last Available: "2017-11"
 9595	drinkable weak Racisto Ruidoso	2	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	jumbo adequate shaking bran muffin	5	good	
+9597	adequate jumbo shaking bran muffin	5	good	
 9598	adequate pulsating blueberry muffin	4	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	skewed silent B	0		Last Available: "2017-12"
@@ -9495,10 +9495,10 @@
 9623	jittery silent Y	0		Last Available: "2017-12"
 9624	ghostly bouncing silent Z	0		Last Available: "2017-12"
 9625	blurry crystalline cheer	0		Last Available: "2017-12"
-9626	twirling yellow anti-earplugs	0		Last Available: "2017-12"
+9626	yellow twirling anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
-9629	practically non-alcoholic perfectly mixed spinning stale cheer wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
+9629	perfectly mixed practically non-alcoholic spinning stale cheer wine	1	super ultra mega turbo EPIC	Last Available: "2017-12"
 9630	stale stale Cheer-E-Os	3	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	lard-coated chaotic cheerful antler hat	0		Spell Critical Percent: +10, Sleaze Spell Damage: +25, Last Available: "2017-12"
@@ -9517,11 +9517,11 @@
 9645	upside-down The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	bouncing purple mime eraser	0		Last Available: "2017-12"
-9648	mediocre weak squat executive mime flask	2	decent	Last Available: "2017-12"
+9648	weak mediocre squat executive mime flask	2	decent	Last Available: "2017-12"
 9649	bland nega-mushroom	3	decent	Last Available: "2017-12"
-9650	perfectly mixed spirit-forward nega-mushroom wine	5	EPIC	Last Available: "2017-12"
+9650	spirit-forward perfectly mixed nega-mushroom wine	5	EPIC	Last Available: "2017-12"
 9651	warmed irradiated jittery Cheer-Up soda	0		Effect: "Tiki Thoughtfulness", Effect Duration: 14, Last Available: "2017-12"
-9652	rotten enchanted mirror mime army rations	4	crappy	Effect: "Fangs and Pangs", Effect Duration: 10, Last Available: "2017-12"
+9652	enchanted rotten mirror mime army rations	4	crappy	Effect: "Fangs and Pangs", Effect Duration: 10, Last Available: "2017-12"
 9653	hand-crafted mime army wine	4	super ultra EPIC	Last Available: "2017-12"
 9654	distilled mime army superserum	1		Last Available: "2017-12"
 9655	energized adjusted moist green mime army camouflage kit	0		Effect: "Faboooo", Effect Duration: 21, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	bouncing upside-down kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	stale extra-toasted half sandwich	4	decent	Last Available: "2018-12"
-9682	aged enchanted pulsating mulled hobo wine	4	awesome	Effect: "Items Are Forever", Effect Duration: 25, Last Available: "2018-12"
+9682	enchanted aged pulsating mulled hobo wine	4	awesome	Effect: "Items Are Forever", Effect Duration: 25, Last Available: "2018-12"
 9683	upside-down burning newspaper	0		Last Available: "2018-12"
 9684	lard-coated hardy personal trainer's burning paper hat	0		Experience Percent (Muscle): +10, Maximum HP: +50, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
 9685	dog trainer's stylish burning cape of James Dean	0		Moxie: +25, Experience (Moxie): +3, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2018-12"
@@ -9570,8 +9570,8 @@
 9698	anodized chilled gray hot button candy	0		Effect: "Prelude of Precision", Effect Duration: 54
 9699	avaricious savvy makeshift garbage shirt of bravery	0		Mysticality Percent: +20, Spooky Resistance: +5, Meat Drop: +30, Last Available: "2018-01"
 9700	dangerous novelty monorail ticket of the glutton	0		Weapon Damage: +10, Food Drop: +100
-9701	pickled tumbling huge pills	1		
-9702	mixed narrow cyan upside-down furry pill	1		Effect: "Scarysauce", Effect Duration: 45
+9701	pickled huge tumbling pills	1		
+9702	mixed upside-down cyan narrow furry pill	1		Effect: "Scarysauce", Effect Duration: 45
 9703	dried twirling purple beefy pill	1		
 9704	vaporized excitement pill	1		Effect: "Aloofah", Effect Duration: 35
 9705	altered huge vitamin G pill	1		
@@ -9592,7 +9592,7 @@
 9724	greedy ribald psychic's crystal ball	0		Sleaze Damage: +10, Meat Drop: +20, Last Available: "2018-02"
 9725	psychic's pslacks of dire peril of temperance	0		Weapon Damage: +20, Sleaze Resistance: +5, Last Available: "2018-02"
 9726	psychic's amulet of the sewer of the cheetah	0		Stench Damage: +25, Initiative: +60, Last Available: "2018-02"
-9727	moldy tiny heart-shaped candy whetstone	1	crappy	Last Available: "2018-02"
+9727	tiny moldy heart-shaped candy whetstone	1	crappy	Last Available: "2018-02"
 9728	spoiled Swedish massage fish	3	crappy	Last Available: "2018-02"
 9729	hand-crafted practically non-alcoholic enchanted Third Base	1	EPIC	Effect: "Think Win-Lose", Effect Duration: 50, Last Available: "2018-02"
 9730	mediocre Bustle Hustler	3	decent	Last Available: "2018-02"
@@ -9625,7 +9625,7 @@
 9757	ribald Mu cap	0		Sleaze Damage: +10
 9758	Thwaitgold metabug statuette	0		
 9759	upside-down Pok&eacute;fam Guide to Capturing All of Them	0		Free Pull, Last Available: "2018-03"
-9760	red skewed packet of tall grass seeds	0		Last Available: "2018-03"
+9760	skewed red packet of tall grass seeds	0		Last Available: "2018-03"
 9761	spinning Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	altered squat magnificent oyster egg	1		Effect: "El Tango de la Maldita Suegra", Effect Duration: 10
 9829	boiled brilliant oyster egg	1		
 9830	distilled pulsating glistening oyster egg	1		
-9831	twisted pulsating wobbly scintillating oyster egg	1		
+9831	twisted wobbly pulsating scintillating oyster egg	1		
 9832	mixed spinning pearlescent oyster egg	1		Effect: "Gamer Rage", Effect Duration: 10
 9833	vaporized lustrous oyster egg	1		Effect: "Three Days Slow", Effect Duration: 50
 9834	dried mirror mirror gleaming oyster egg	1		Effect: "Indescribable Flavor", Effect Duration: 45
@@ -9730,13 +9730,13 @@
 9862	normal FantasyRealm turkey leg	3	good	Last Available: "2018-04"
 9863	hand-crafted FantasyRealm mead	3	EPIC	Last Available: "2018-04"
 9864	spinning nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
-9865	squat blurry Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
+9865	blurry squat Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	blinking arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	jittery grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	flavorless druidic s'more	4	decent	Last Available: "2018-04"
 9870	compressed shaking lime green tumbling sachet of powder	1		Last Available: "2018-04"
-9871	artisanal watered-down olive mourning wine	2	EPIC	Last Available: "2018-04"
+9871	watered-down artisanal olive mourning wine	2	EPIC	Last Available: "2018-04"
 9872	maroon sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	spinning map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	adequate denastified haunch	3	good	Last Available: "2018-04"
-9879	acceptable practically non-alcoholic bad rum and good cola	1	good	Last Available: "2018-04"
+9879	practically non-alcoholic acceptable bad rum and good cola	1	good	Last Available: "2018-04"
 9880	diffused huge Potion of Heroism	0		Effect: "Cheered Up", Effect Duration: 35, Last Available: "2018-04"
 9881	jittery chilly leggings of the Spider Queen of the dark arts of the brazier	0		Spell Damage Percent: +100, Cold Damage: +5, Hot Spell Damage: +25, Last Available: "2018-04"
 9882	Jim Carey's stylish Master Thief's utility belt of the pedagogue	0		Moxie: +25, Experience: +3, Monster Level: +25, Single Equip, Last Available: "2018-04"
@@ -9765,7 +9765,7 @@
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	artisanal teal two meat muck	3	EPIC	
 9899	decent chocolate Ogre Chieftain	4	good	
-9900	adequate massive chocolate &quot;Phoenix&quot;	9	good	
+9900	massive adequate chocolate &quot;Phoenix&quot;	9	good	
 9901	normal chocolate Spider Queen	4	good	
 9902	hand-crafted ghostly hipster cocktail	3	EPIC	
 9903	blinking red God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
@@ -9781,7 +9781,7 @@
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	low-calorie bland good guava	1	decent	
-9916	watered-down acceptable gin and ginger	2	good	
+9916	acceptable watered-down gin and ginger	2	good	
 9917	Thwaitgold chigger statuette	0		
 9918	dehydrated huge gaseous gravy	1		
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9803,7 +9803,7 @@
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	upside-down Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	ghostly Bastille Battalion cheese wheel	0		Last Available: "2018-07"
-9938	mirror skewed fuchsia Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
+9938	fuchsia mirror skewed Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	green burglar/sleep mask	0		Last Available: "2018-07"
 9941	Thwaitgold masked hunter statuette	0		
@@ -9813,7 +9813,7 @@
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	practically non-alcoholic lousy Middle of the Road&trade; brand whiskey	1	decent	Last Available: "2018-09"
+9948	lousy practically non-alcoholic Middle of the Road&trade; brand whiskey	1	decent	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	crafty Da Vinci's pentagram bandana	0		Experience (Mysticality): +5, Maximum MP: +10, Last Available: "2018-09"
 9951	Lo Pan's skull ring	0		Spell Critical Percent: +30, Single Equip, Last Available: "2018-09"
@@ -9843,12 +9843,12 @@
 9976	shaking stiffened party pants	0		Damage Reduction: 1, Item Drop: +5, Last Available: "2018-09"
 9977	nasty medical-grade sage party whip	0		Mysticality Percent: +10, Stench Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-09"
 9978	spinning Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
-9979	fancy drinkable TRIO cup of beer	3	good	Effect: "Saucegoggles", Effect Duration: 50, Last Available: "2018-09"
+9979	drinkable fancy TRIO cup of beer	3	good	Effect: "Saucegoggles", Effect Duration: 50, Last Available: "2018-09"
 9980	moldy party platter for one	4	crappy	Last Available: "2018-09"
 9981	twisted bouncing Party-in-a-Can&trade;	1		Effect: "Stop and Smell the Fudge", Effect Duration: 50, Last Available: "2018-09"
-9982	mirror jittery party pup	0		Last Available: "2018-09"
+9982	jittery mirror party pup	0		Last Available: "2018-09"
 9983	Sherlock's Da Vinci's party crasher	0		Experience (Mysticality): +5, Item Drop: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	shaking Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9984	shaking Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	shaking purple Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
 9987	jittery latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
@@ -9860,7 +9860,7 @@
 9993	upside-down mirror wool Jim Carey's snakeskin thighboots	0		Monster Level: +25, Cold Resistance: +1, Last Available: "2018-11"
 9994	snakeskin cowboy hat of the cougar of extreme caution	0		Moxie: +20, Monster Level: -25, Last Available: "2018-11"
 9995	scorching slick snakeskin jacket	0		Moxie: +10, Hot Damage: +25, Last Available: "2018-11"
-9996	green wobbly slime glob	0		Last Available: "2018-11"
+9996	wobbly green slime glob	0		Last Available: "2018-11"
 9997	slime glob	0		Last Available: "2018-11"
 9998	skewed slime glob	0		Last Available: "2018-11"
 9999	squat supercool stylish slime waders of the scaredy-cat	0		Moxie: +25, Moxie Percent: +20, Monster Level: -15, Last Available: "2018-11"
@@ -9874,18 +9874,18 @@
 10008	scorching nippy mutant legs of the businessman	0		Cold Damage: +10, Hot Damage: +25, Meat Drop: +50, Last Available: "2018-11"
 10009	scandalous mutant crown of wisdom	0		Mysticality: +15, Sleaze Damage: +5, Item Drop: +5, Last Available: "2018-11"
 10010	normal ghostly ectoplasm	3	good	Last Available: "2018-11"
-10011	normal massive	7	good	Last Available: "2018-11"
-10012	lousy practically non-alcoholic bottle of vodka	1	decent	Last Available: "2018-11"
-10013	small bland pizza	2	decent	Last Available: "2018-11"
+10011	massive normal	7	good	Last Available: "2018-11"
+10012	practically non-alcoholic lousy bottle of vodka	1	decent	Last Available: "2018-11"
+10013	bland small pizza	2	decent	Last Available: "2018-11"
 10014	bad martini	3	decent	Last Available: "2018-11"
-10015	snack-sized normal cherry pie	2	good	Last Available: "2018-11"
+10015	normal snack-sized cherry pie	2	good	Last Available: "2018-11"
 10016	artisanal pulsating eggnog	3	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	half-sized normal Hell ramen	2	good	Last Available: "2018-11"
+10018	normal half-sized Hell ramen	2	good	Last Available: "2018-11"
 10019	practically non-alcoholic hand-crafted gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
 10020	practically non-alcoholic artisanal twice-haunted screwdriver	1	super ultra mega turbo EPIC	Last Available: "2018-11"
-10021	half-sized delicious candy cane	2	awesome	Last Available: "2018-12"
-10022	special perfectly mixed watered-down runny fermented egg	2	EPIC	Effect: "The Grass...  Is Blue...", Effect Duration: 20, Last Available: "2018-12"
+10021	delicious half-sized candy cane	2	awesome	Last Available: "2018-12"
+10022	watered-down perfectly mixed special runny fermented egg	2	EPIC	Effect: "The Grass...  Is Blue...", Effect Duration: 20, Last Available: "2018-12"
 10023	flavorless bouncing oldcake	4	decent	Last Available: "2018-12"
 10024	flavorless traditional Crimbo cookie	3	decent	Last Available: "2023-06"
 10025	plastic wild beaver of the pedagogue	0		Experience: +3, Last Available: "2018-12"
@@ -9906,10 +9906,10 @@
 10040	normal blinking moosemeat pie	3	good	Last Available: "2018-12"
 10041	grievous balanced antler	0		Weapon Damage Percent: +50, Last Available: "2018-12"
 10042	frightening dam	0		Spooky Damage: +5, Damage Reduction: 9, Last Available: "2018-12"
-10043	drinkable special blinking gray jittery beavermouth	4	good	Effect: "Pyromania", Effect Duration: 50, Last Available: "2018-12"
+10043	drinkable special gray blinking jittery beavermouth	4	good	Effect: "Pyromania", Effect Duration: 50, Last Available: "2018-12"
 10044	mediocre jittery beaver punch (papaya)	3	decent	Last Available: "2018-12"
 10045	bad beaver punch (peach)	3	decent	Last Available: "2018-12"
-10046	acceptable irresponsibly strong beaver punch (cherry)	8	good	Last Available: "2018-12"
+10046	irresponsibly strong acceptable beaver punch (cherry)	8	good	Last Available: "2018-12"
 10047	hardy experienced Canadian lantern	0		Experience: +2, Maximum HP: +50, Last Available: "2018-12"
 10048	blue mirror toasty muskox-skin cap	0		Hot Damage: +5, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9929,10 +9929,10 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	shaking jar of relish	0		Familiar Weight: +5
 10065	teal Toyleporter	0		Last Available: "2018-12"
-10066	acceptable special weak beer	2	good	Effect: "Elemental Saucesphere", Effect Duration: 20, Last Available: "2018-12"
+10066	special weak acceptable beer	2	good	Effect: "Elemental Saucesphere", Effect Duration: 20, Last Available: "2018-12"
 10067	rotten huge yule gruel	3	crappy	Last Available: "2018-12"
-10068	triple-distilled aged hot watered rum	10	awesome	Last Available: "2018-12"
-10069	practically non-alcoholic artisanal jittery bottle of Crimbognac	1	super ultra mega turbo EPIC	Last Available: "2018-12"
+10068	aged triple-distilled hot watered rum	10	awesome	Last Available: "2018-12"
+10069	artisanal practically non-alcoholic jittery bottle of Crimbognac	1	super ultra mega turbo EPIC	Last Available: "2018-12"
 10070	stale Crimboysters Rockefeller	4	decent	Last Available: "2018-12"
 10071	diluted Crimbeau de toilette	1		Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
@@ -9999,7 +9999,7 @@
 10133	prompt manspreader's loofah ladle	0		Monster Level: +10, Adventures: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
 10134	prompt sharpshooter's loofah legwarmers	0		Critical Hit Percent: +10, Adventures: +3, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
 10135	wobbly loofah lavalier of chilblains of mayonnaise	0		Cold Damage: +25, Sleaze Spell Damage: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
-10136	pickled bouncing yellow blinking loofah lumps	1		Last Available: "2022-12"
+10136	pickled yellow bouncing blinking loofah lumps	1		Last Available: "2022-12"
 10137	quantum moist chocolate-covered loofah	0		Effect: "Patched In", Effect Duration: 57
 10138	clever deadly flagstone flag	0		Weapon Damage: +5, Maximum MP: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
 10139	twirling jittery crafty flagstone flail of the overflowing toilet	0		Maximum MP: +10, Stench Spell Damage: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
@@ -10013,7 +10013,7 @@
 10147	twirling red-and-green microcamera	0		Familiar Weight: +5
 10148	cobbled-together Meat detector of the early riser	0		Adventures: +7, Lasts Until Rollover, Last Available: "2019-12"
 10149	unsweetened aerosolized adjusted tin thermos of chai	0		Effect: "Fastbreaker", Effect Duration: 20, Last Available: "2019-12"
-10150	mixed shaking cyan prototype stimulant	1		Last Available: "2019-12"
+10150	mixed cyan shaking prototype stimulant	1		Last Available: "2019-12"
 10151	twirling coward's tailored vest	0		Monster Level: -20, Lasts Until Rollover, Last Available: "2019-12"
 10152	upside-down sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
@@ -10021,7 +10021,7 @@
 10155	moldy elf army field rations	4	crappy	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	censurious beefcake's discarded bowtie	0		Muscle: +25, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2019-12"
-10158	perfectly mixed watered-down gray martiny	2	EPIC	Last Available: "2019-12"
+10158	watered-down perfectly mixed gray martiny	2	EPIC	Last Available: "2019-12"
 10159	mirror maroon tryptophan dart	0		Last Available: "2019-12"
 10160	corrupted licorice snake	0		Effect: "Fungal Fortification", Effect Duration: 56
 10161	vacuum-sealed cold-filtered virgin jello shot	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 45
@@ -10031,15 +10031,15 @@
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	cool Lil' Doctor&trade; bag	0		Moxie: +5, Item Drop: +5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	super-sized spoiled bloodstick	5	crappy	
-10170	tolerable practically non-alcoholic spinning bottle of Sanguiovese	1	good	
+10169	spoiled super-sized bloodstick	5	crappy	
+10170	practically non-alcoholic tolerable spinning bottle of Sanguiovese	1	good	
 10171	adequate gigantic actual blood sausage	8	good	
-10172	practically non-alcoholic acceptable mulled blood	1	good	
+10172	acceptable practically non-alcoholic mulled blood	1	good	
 10173	tiny flavorless blood snowcone	1	decent	
 10174	high-proof artisanal Red Russian	8	EPIC	
-10175	miniature moldy huge blood roll-up	2	crappy	
+10175	moldy miniature huge blood roll-up	2	crappy	
 10176	artisanal fuchsia bottle of blood	3	super EPIC	
-10177	adequate huge fancy blood-soaked sponge cake	9	good	Effect: "Eldritch Concentration", Effect Duration: 5
+10177	fancy huge adequate blood-soaked sponge cake	9	good	Effect: "Eldritch Concentration", Effect Duration: 5
 10178	mediocre weak vampagne	2	decent	
 10179	small stale upside-down plain snowcone	2	decent	
 10180	ghostly Booke of Vampyric Knowledge	0		
@@ -10075,10 +10075,10 @@
 10210	spinning greedy studded pirate radio ring	0		Damage Absorption: +80, Meat Drop: +20, Single Equip, Last Available: "2019-04"
 10211	cyan Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	jumbo tasty pineapple slab	5	awesome	Last Available: "2019-04"
-10213	fancy diet moldy hibiscus petal	1	crappy	Effect: "Charrrming", Effect Duration: 50, Last Available: "2019-04"
+10213	diet moldy fancy hibiscus petal	1	crappy	Effect: "Charrrming", Effect Duration: 50, Last Available: "2019-04"
 10214	modified activated ghostly huge mint leaf	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 58, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
-10216	distilled spinning shaking gray ice molecule	1		Last Available: "2019-04"
+10216	distilled gray shaking spinning ice molecule	1		Last Available: "2019-04"
 10217	red Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
@@ -10101,8 +10101,8 @@
 10236	special weak lousy Electric Punch	2	decent	Effect: "Sweet and Red", Effect Duration: 5, Last Available: "2019-04"
 10237	tolerable wobbly huge Smuggler's Punch	3	good	Last Available: "2019-04"
 10238	hand-crafted shaking Scorpion Bowl	4	EPIC	Last Available: "2019-04"
-10239	smooth special jittery Turtle Bowl	4	awesome	Effect: "Blessing of the Pervy Noodles", Effect Duration: 20, Last Available: "2019-04"
-10240	extra-dry acceptable Cobra Bowl	5	good	Last Available: "2019-04"
+10239	special smooth jittery Turtle Bowl	4	awesome	Effect: "Blessing of the Pervy Noodles", Effect Duration: 20, Last Available: "2019-04"
+10240	acceptable extra-dry Cobra Bowl	5	good	Last Available: "2019-04"
 10241	spinning purple vampyric cloake pattern	0		Free Pull
 10242	Usain Bolt's asbestos-lined stanky sinister vampyric cloake of temperance	0		Spell Damage: +10, Stench Spell Damage: +25, Hot Resistance: +5, Sleaze Resistance: +5, Initiative: +80, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
@@ -10167,16 +10167,16 @@
 10302	greedy family-friendly whittled walking stick of Tarzan of the detective	0		Experience (Muscle): +3, Sleaze Resistance: +1, Item Drop: +20, Meat Drop: +20, Last Available: "2019-08"
 10303	flavorless campfire hot dog	3	decent	Last Available: "2019-08"
 10304	flavorless squat campfire baked potato	4	decent	Last Available: "2019-08"
-10305	half-sized decent campfire s'more	2	good	Last Available: "2019-08"
-10306	miniature decent special campfire beans	2	good	Effect: "Deadly Flashing Blade", Effect Duration: 5, Last Available: "2019-08"
-10307	spoiled diet campfire stew	1	crappy	Last Available: "2019-08"
+10305	decent half-sized campfire s'more	2	good	Last Available: "2019-08"
+10306	special miniature decent campfire beans	2	good	Effect: "Deadly Flashing Blade", Effect Duration: 5, Last Available: "2019-08"
+10307	diet spoiled campfire stew	1	crappy	Last Available: "2019-08"
 10308	campfire coffee	1	EPIC	Last Available: "2019-08"
 10309	denatured liquefied leftover chocolate bar	0		Effect: "Initiative and Let Die", Effect Duration: 65
-10310	twirling skewed rare Meat isotope	0		
+10310	skewed twirling rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
 10312	twirling bundle of firewood	0		Last Available: "2019-08"
 10313	campfire smoke	0		
-10314	olive pulsating Murgatroyd diode	0		
+10314	pulsating olive Murgatroyd diode	0		
 10315	signal receiver	0		
 10316	blinking space shield	0		Damage Reduction: 9
 10317	signal jammer	0		Single Equip
@@ -10185,7 +10185,7 @@
 10320	decent wobbly space chowder	3	good	
 10321	delicious irresponsibly strong space wine	8	awesome	
 10322	The Imploded World	0		Skill: "Implode Universe"
-10323	shaking teal packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
+10323	teal shaking packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
 10325	Law of Averages	0		
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
@@ -10203,7 +10203,7 @@
 10344	plastic Dolph Bossin of horror	0		Spooky Spell Damage: +25, Last Available: "2019-12"
 10345	blinking red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	decent fancy bouncing mana-coated yams	3	good	Effect: "Chalked-Up Teeth", Effect Duration: 30, Last Available: "2019-11"
-10347	adequate miniature mana-basted tofurkey leg	2	good	Last Available: "2019-11"
+10347	miniature adequate mana-basted tofurkey leg	2	good	Last Available: "2019-11"
 10348	yummy mana-fortified cranberry sauce	3	awesome	Last Available: "2019-11"
 10349	normal mana-stuffed herbal stuffing	3	good	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
@@ -10213,7 +10213,7 @@
 10354	denatured skewed cyan vial of humanoid growth hormone	1		Effect: "Uncaged Power", Effect Duration: 40, Last Available: "2019-12"
 10355	dried lime green ghostly tumbling a bug's lymph	1		Last Available: "2019-12"
 10356	adjusted non-diffused concentrated organic potpourri	0		Effect: "Stinking Cloud", Effect Duration: 65, Last Available: "2019-12"
-10357	enchanted bad narrow boot flask	3	decent	Effect: "Itchy Trigger Finger", Effect Duration: 40, Last Available: "2019-12"
+10357	bad enchanted narrow boot flask	3	decent	Effect: "Itchy Trigger Finger", Effect Duration: 40, Last Available: "2019-12"
 10358	anodized alkaline flattened wobbly infernal snowball	0		Effect: "Sauce Monocle", Effect Duration: 34, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
 10360	diluted fish sauce	1		Effect: "Thick, Sick", Effect Duration: 45, Last Available: "2019-12"
@@ -10227,7 +10227,7 @@
 10368	lime green envelope full of Meat	0		Last Available: "2019-12"
 10369	vaporized red livid energy	1		Effect: "Sludgesick", Effect Duration: 35, Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	twisted maroon ghostly beggin' cologne	1		Effect: "Cheered Up", Effect Duration: 50, Last Available: "2019-12"
+10371	twisted ghostly maroon beggin' cologne	1		Effect: "Cheered Up", Effect Duration: 50, Last Available: "2019-12"
 10372	perfumed lion tamer's oxygenated eggnog helmet	0		Experience (familiar): +2, Stench Resistance: +5, Adventure Underwater, Last Available: "2019-12"
 10373	wobbly hand-knitted diving booties	0		Last Available: "2019-12"
 10374	red peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	denatured unsweetened blurry wobbly salty gumdrop	0		Effect: "Nano-juiced", Effect Duration: 69, Last Available: "2019-12"
+10384	denatured unsweetened wobbly blurry salty gumdrop	0		Effect: "Nano-juiced", Effect Duration: 69, Last Available: "2019-12"
 10385	sage thinker's ribbon candy ascot	0		Mysticality: +10, Mysticality Percent: +10, Single Equip, Last Available: "2019-12"
 10386	squat moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	tasty salt plum	4	awesome	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	spoiled gigantic gray and bean	7	crappy	Last Available: "2019-12"
+10417	gigantic spoiled gray and bean	7	crappy	Last Available: "2019-12"
 10418	tumbling knitted stylish kelp-holly gun of doom	0		Moxie: +25, Spooky Spell Damage: +50, Cold Resistance: +3, Last Available: "2019-12"
 10419	hardened Yuleviathan necklace of dire peril	0		Weapon Damage: +20, Damage Reduction: 3, Single Equip, Last Available: "2019-12"
 10420	Sherlock's careful peppermint spine	0		Monster Level: -10, Item Drop: +25, Last Available: "2019-12"
@@ -10281,8 +10281,8 @@
 10422	quilted deadly Crimbylow-rise jeans	0		Weapon Damage: +5, Damage Absorption: +40, Last Available: "2019-12"
 10423	green skewed perfumed mansplainer's kelp-holly drape	0		Monster Level: +15, Stench Resistance: +5, Last Available: "2019-12"
 10424	lard-coated sizzling Newton's Staff of the Peppermint Twist of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3, Hot Damage: +10, Sleaze Spell Damage: +25, Last Available: "2019-12"
-10425	thick bland ghostly lime green tempura and bean	5	decent	Last Available: "2019-12"
-10426	watered-down bad salt plum sake	2	decent	Last Available: "2019-12"
+10425	bland thick lime green ghostly tempura and bean	5	decent	Last Available: "2019-12"
+10426	bad watered-down salt plum sake	2	decent	Last Available: "2019-12"
 10427	ionized super-polarized pressurized potion of possessiveness	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 22, Last Available: "2019-12"
 10428	extra-activated deionized lime green almond	0		Effect: "Vitali Tea", Effect Duration: 57
 10429	moist handful of mixed nuts	0		Effect: "Jerky, Boy", Effect Duration: 62, Last Available: "2019-12"
@@ -10294,26 +10294,26 @@
 10437	ghostly mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	smelly chilly fortified arcane researcher's Da Vinci's Powerful Glove	0		Experience (Mysticality): +5, Experience Percent (Mysticality): +10, Damage Absorption: +60, Cold Damage: +5, Stench Spell Damage: +10, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
-10440	narrow teal status cymbal	0		Last Available: "2020-02"
+10440	teal narrow status cymbal	0		Last Available: "2020-02"
 10441	Jim Carey's baleful Drip harness of the cheetah	0		Spell Damage: +25, Monster Level: +25, Initiative: +60
 10442	jittery energetic drippy truncheon	0		Maximum MP Percent: +20, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	spoiled immense drippy nugget	6	drippy	
 10446	tolerable boozy glass of drippy wine	5	drippy	
-10447	rotten bite-sized drippy caviar	1	drippy	
+10447	bite-sized rotten drippy caviar	1	drippy	
 10448	decent drippy plum(?)	3	drippy	
 10449	curative drippy stake	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
-10452	blue upside-down mirror drippy shield	0		
+10452	upside-down blue mirror drippy shield	0		
 10453	olive The Fingernail of the Thing in the Basement	0		
 10454	coin	0		
 10455	mushroom	0		
 10456	deluxe mushroom	0		
 10457	super deluxe mushroom	0		
 10458	diffused fizzy soda	0		Effect: "Bright!", Effect Duration: 58
-10459	frozen skewed pulsating healthy juice	0		Effect: "Video Game Hot Dog", Effect Duration: 45
+10459	frozen pulsating skewed healthy juice	0		Effect: "Video Game Hot Dog", Effect Duration: 45
 10460	hammer	0		
 10461	hammer	0		
 10462	huge fire flower	0		
@@ -10337,7 +10337,7 @@
 10480	rubber baby doll	0		
 10481	squat Better Shrooms and Gardens catalog	0		Free Pull, Last Available: "2020-03"
 10482	packet of mushroom spores	0		Last Available: "2020-03"
-10483	bouncing mirror free-range mushroom	0		Last Available: "2020-03"
+10483	mirror bouncing free-range mushroom	0		Last Available: "2020-03"
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	bulky free-range mushroom	0		Last Available: "2020-03"
 10486	free-range mushroom	0		Last Available: "2020-03"
@@ -10345,7 +10345,7 @@
 10488	wobbly colossal free-range mushroom	0		Last Available: "2020-03"
 10489	flavorless upside-down mushroom filet	3	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
-10491	twisted purple huge mushroom tea	1		Last Available: "2020-03"
+10491	twisted huge purple mushroom tea	1		Last Available: "2020-03"
 10492	weak enchanted drinkable wobbly mushroom whiskey	2	good	Effect: "Bilious Briskness", Effect Duration: 40, Last Available: "2020-03"
 10493	resourceful Oprah's slick mushroom cap	0		Moxie: +10, Maximum MP Percent: +50, Maximum MP: +50, Last Available: "2020-03"
 10494	sharpshooter's supercharged personal trainer's mushroom shield of the scaredy-cat	0		Experience Percent (Muscle): +10, Maximum MP Percent: +30, Critical Hit Percent: +10, Monster Level: -15, Damage Reduction: 6, Last Available: "2020-03"
@@ -10379,8 +10379,8 @@
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
-10525	high-proof mediocre drippy pilsner	10	drippy	
-10526	green twirling drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
+10525	mediocre high-proof drippy pilsner	10	drippy	
+10526	twirling green drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	shaking lustrous drippy orb	0		
 10530	jittery gory drippy orb of the scaredy-cat	0		Monster Level: -15
@@ -10395,10 +10395,10 @@
 10539	chaotic Guzzlr souvenir stein	0		Spell Critical Percent: +10, Last Available: "2020-05"
 10540	maroon Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	mediocre Ghiaccio Colada	3	decent	Last Available: "2020-05"
-10542	enchanted lousy Sourfinger	3	decent	Effect: "Comprehensively Nourished", Effect Duration: 20, Last Available: "2020-05"
+10542	lousy enchanted Sourfinger	3	decent	Effect: "Comprehensively Nourished", Effect Duration: 20, Last Available: "2020-05"
 10543	fancy perfectly mixed fuchsia Nog-on-the-Cob	3	EPIC	Effect: "Greasy Flavor", Effect Duration: 5, Last Available: "2020-05"
 10544	acceptable twirling Steamboat	4	good	Last Available: "2020-05"
-10545	weak lousy Buttery Boy	2	decent	Last Available: "2020-05"
+10545	lousy weak Buttery Boy	2	decent	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	knitted electrified clown car key	0		Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-08"
 10548	ribald flame-wreathed batting cage key of James Dean	0		Experience (Moxie): +3, Hot Spell Damage: +10, Sleaze Damage: +10, Last Available: "2020-08"
@@ -10453,7 +10453,7 @@
 10597	bouncing wormwood stick	0		Last Available: "2020-08"
 10598	inspector's dance instructor's wormwood wedding ring of the scaredy-cat of the empath of bravery	0		Experience Percent (Moxie): +10, Monster Level: -15, Familiar Weight: +5, Spooky Resistance: +5, Item Drop: +15, Single Equip, Last Available: "2020-08"
 10599	blinking Dripwood slab	0		Last Available: "2020-08"
-10600	twirling blinking drippy diadem	0		Last Available: "2020-08"
+10600	blinking twirling drippy diadem	0		Last Available: "2020-08"
 10601	tumbling Thwaitgold slug statuette	0		
 10602	Fonzie's ert grey goo ring	0		Experience (Moxie): +1
 10603	fistful of wood shavings	0		
@@ -10484,7 +10484,7 @@
 10628	onyx pawn	0		Last Available: "2020-09"
 10629	ghostly alabaster king	0		Last Available: "2020-09"
 10630	alabaster queen	0		Last Available: "2020-09"
-10631	blurry narrow red alabaster rook	0		Last Available: "2020-09"
+10631	narrow red blurry alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
 10633	tumbling alabaster knight	0		Last Available: "2020-09"
 10634	alabaster pawn	0		Last Available: "2020-09"
@@ -10496,7 +10496,7 @@
 10640	Universal Seasoning	0		
 10641	alkaline jittery null-day exploit	0		Effect: "Balls of Ectoplasm", Effect Duration: 54, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	flavorless fancy green chocolate chip muffin	3	decent	Effect: "Arcane in the Brain", Effect Duration: 25
+10643	fancy flavorless green chocolate chip muffin	3	decent	Effect: "Arcane in the Brain", Effect Duration: 25
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10510,13 +10510,13 @@
 10654	alkaline jittery boiling hot cocoa	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 47, Last Available: "2020-12"
 10655	quantum triple-magnetized cool hot cocoa	0		Effect: "Stuck That Way", Effect Duration: 34, Last Available: "2020-12"
 10656	dry cyan overly-fancy hot cocoa	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 64, Last Available: "2020-12"
-10657	dry electrified maroon shaking hot cocoa au beurre	0		Effect: "Soles of Glass", Effect Duration: 14, Last Available: "2020-12"
+10657	dry electrified shaking maroon hot cocoa au beurre	0		Effect: "Soles of Glass", Effect Duration: 14, Last Available: "2020-12"
 10658	polymerized skewed hot cocoa with rainbow marshmallows	0		Effect: "Sticky Fingers", Effect Duration: 22, Last Available: "2020-12"
 10659	beefy Book of Old-Timey Carols	0		Muscle: [+10*event(December)], Last Available: "2020-12"
 10660	lime green Van der Graaf Crimbo smile	0		MP Regen Min: [5*event(December)], MP Regen Max: [7*event(December)], Last Available: "2020-12"
 10661	dog trainer's SalesCo sample kit	0		Experience (familiar): [+1*event(December)], Last Available: "2020-12"
 10662	corrupted super-frozen triple-chilled cyan candy harmonica	0		Effect: "Moose Wisdom", Effect Duration: 11, Last Available: "2020-12"
-10663	activated Vulcanized red bouncing sugar	0		Effect: "Strong Spirit", Effect Duration: 55, Last Available: "2020-12"
+10663	activated Vulcanized bouncing red sugar	0		Effect: "Strong Spirit", Effect Duration: 55, Last Available: "2020-12"
 10664	improved ionized multi-level marzipan	0		Effect: "Soles of Glass", Effect Duration: 55, Last Available: "2020-12"
 10665	coward's plastic Crimbo caroler	0		Monster Level: -20, Last Available: "2020-12"
 10666	flame-retardant plastic multi-level marketer	0		Hot Resistance: +1, Last Available: "2020-12"
@@ -10568,15 +10568,15 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	blue The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	miniature normal and pepper (stale)	2	good	Last Available: "2020-12"
-10716	distilled aged cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
+10715	normal miniature and pepper (stale)	2	good	Last Available: "2020-12"
+10716	aged distilled cranberry margarita (brackish)	5	awesome	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	bad practically non-alcoholic barrel-aged eggnog	1	decent	Last Available: "2020-12"
-10721	enchanted stale huge hand-crafted candy cane	3	decent	Effect: "Violent Night", Effect Duration: 5, Last Available: "2020-12"
+10720	practically non-alcoholic bad barrel-aged eggnog	1	decent	Last Available: "2020-12"
+10721	stale enchanted huge hand-crafted candy cane	3	decent	Effect: "Violent Night", Effect Duration: 5, Last Available: "2020-12"
 10722	rotten drive-thru burger	3	crappy	Last Available: "2020-12"
-10723	strong tolerable Boulevardier cocktail	5	good	Last Available: "2020-12"
+10723	tolerable strong Boulevardier cocktail	5	good	Last Available: "2020-12"
 10724	colloidal Hotwire&trade; brand candy rope	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 42, Last Available: "2020-12"
 10725	thick tasty bowl full of jelly	5	awesome	Last Available: "2020-12"
 10726	aged weak Eye and a Twist	2	awesome	Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	blinking crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fuchsia fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	lime green robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10608,7 +10608,7 @@
 10752	quantum short beer	0		Effect: "Fiery Spirit", Effect Duration: 69, Last Available: "2021-05"
 10753	cold-filtered huge short stack of pancakes	0		Effect: "Fury of the Bells", Effect Duration: 21, Last Available: "2021-05"
 10754	improved flattened modified maroon short stick of butter	0		Effect: "Stone-Faced", Effect Duration: 37, Last Available: "2021-05"
-10755	moist galvanized huge skewed short glass of water	0		Effect: "Fastbreaker", Effect Duration: 13, Last Available: "2021-05"
+10755	moist galvanized skewed huge short glass of water	0		Effect: "Fastbreaker", Effect Duration: 13, Last Available: "2021-05"
 10756	moist activated short	0		Effect: "Gummi Badass", Effect Duration: 16, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
@@ -10660,7 +10660,7 @@
 10804	MacGyver's Newton's Daylight Shavings Helmet of the cheetah	0		Experience (Mysticality): +3, Maximum MP: +100, Initiative: +60, Last Available: "2021-11"
 10805	blurry eggwater	1	awesome	Last Available: "2021-12"
 10806	low-calorie adequate bread man	1	good	Last Available: "2021-12"
-10807	tiny stale plain candy cane	1	decent	Last Available: "2021-12"
+10807	stale tiny plain candy cane	1	decent	Last Available: "2021-12"
 10808	flavorless flour cookie	4	decent	Last Available: "2021-12"
 10809	scorching plastic food lab	0		Hot Damage: +25, Single Equip, Last Available: "2021-12"
 10810	green blinking lard-coated plastic nog lab	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2021-12"
@@ -10673,12 +10673,12 @@
 10817	ghostly yellow friendly extremely unsafe Da Vinci's jeans	0		Experience (Mysticality): +5, Weapon Damage Percent: +100, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2021-12"
 10818	foul-smelling nippy sharpshooter's ice wrap	0		Critical Hit Percent: +10, Cold Damage: +10, Stench Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	delicious mirror tofu pop	3	awesome	Last Available: "2021-12"
-10820	gigantic yummy bowl of prescription candy	6	awesome	Last Available: "2021-12"
+10820	yummy gigantic bowl of prescription candy	6	awesome	Last Available: "2021-12"
 10821	moldy low-calorie fishcake	1	crappy	Last Available: "2021-12"
 10822	adequate bone broth	3	good	Last Available: "2021-12"
 10823	adequate jittery star pop	3	good	Last Available: "2021-12"
 10824	mediocre Doc's Fortifying Wine	3	decent	Last Available: "2021-12"
-10825	hand-crafted practically non-alcoholic Doc's Smartifying Wine	1	EPIC	Last Available: "2021-12"
+10825	practically non-alcoholic hand-crafted Doc's Smartifying Wine	1	EPIC	Last Available: "2021-12"
 10826	drinkable Doc's Limbering Wine	3	good	Last Available: "2021-12"
 10827	mediocre Doc's Medical-Grade Wine	3	decent	Last Available: "2021-12"
 10828	altered bouncing blue blinking jittery Homebodyl&trade;	1		Last Available: "2021-12"
@@ -10692,8 +10692,8 @@
 10836	anodized quadruple-diffused improved anti-creep cream	0		Effect: "Tingly Biceps", Effect Duration: 59, Last Available: "2021-12"
 10837	irradiated pickled anti-pain cream	0		Effect: "Hot Buttoned", Effect Duration: 34, Last Available: "2021-12"
 10838	drinkable Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
-10839	thick decent bread pie	5	good	Last Available: "2021-12"
-10840	enchanted bad clear Russian	3	decent	Effect: "Spooky Weapon", Effect Duration: 35, Last Available: "2021-12"
+10839	decent thick bread pie	5	good	Last Available: "2021-12"
+10840	bad enchanted clear Russian	3	decent	Effect: "Spooky Weapon", Effect Duration: 35, Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,17 +10705,17 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	skewed cozy scarf of the detective	0		Item Drop: +20, Last Available: "2021-12"
-10852	half-sized normal jittery huge Crimbo cookie	2	good	Last Available: "2023-06"
+10852	normal half-sized jittery huge Crimbo cookie	2	good	Last Available: "2023-06"
 10853	pickled activated fleshy putty	0		Effect: "Melancholy Burden", Effect Duration: 23, Last Available: "2021-12"
 10854	studded third ear	0		Damage Absorption: +80, Single Equip, Last Available: "2021-12"
 10855	huge festive egg sac	0		Last Available: "2021-12"
-10856	ghostly lime green poisonsettia	0		Last Available: "2021-12"
+10856	lime green ghostly poisonsettia	0		Last Available: "2021-12"
 10857	nippy peppermint-scented socks	0		Cold Damage: +10, Last Available: "2021-12"
 10858	the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	lime green projectile chemistry set	0		Last Available: "2021-12"
 10860	depleted Crimbonium football helmet of the dark arts	0		Spell Damage Percent: +100, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	stale tiny &quot;caramel&quot;	1	decent	Last Available: "2021-12"
+10862	tiny stale &quot;caramel&quot;	1	decent	Last Available: "2021-12"
 10863	clever self-repairing earmuffs	0		Maximum MP: +20, Last Available: "2021-12"
 10864	green jittery greasy carnivorous potted plant	0		Sleaze Spell Damage: +10, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
@@ -10727,9 +10727,9 @@
 10871	cloning kit	0		Last Available: "2021-12"
 10872	pants of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2021-12"
 10873	toasty rock-hard smooth can of mixed everything	0		Moxie: +15, Damage Reduction: 5, Hot Damage: +5, Last Available: "2021-12"
-10874	tumbling bouncing Site Alpha ID badge	0		Familiar Weight: +5
+10874	bouncing tumbling Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	adequate diet meatball	1	good	Last Available: "2021-12"
+10876	diet adequate meatball	1	good	Last Available: "2021-12"
 10877	maroon cloned monster	0		Last Available: "2021-12"
 10878	jittery meatball machine	0		Last Available: "2021-12"
 10879	ghostly refurbished air fryer	0		Last Available: "2021-12"
@@ -10739,7 +10739,7 @@
 10883	dried astral energy drink	1		Effect: "Celestial Body", Effect Duration: 25
 10884	mirror mint condition magnifying glass	0		Last Available: "2022-12"
 10885	ghostly Annie Oakley's magnifying glass of the brazier of the cheetah	0		Critical Hit Percent: +20, Hot Spell Damage: +25, Initiative: +60, Last Available: "2022-12"
-10886	acceptable watered-down void lager	2	good	Last Available: "2022-12"
+10886	watered-down acceptable void lager	2	good	Last Available: "2022-12"
 10887	decent void burger	3	good	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	perfumed stanky curative void shard of the cheetah	0		Stench Spell Damage: +25, Stench Resistance: +5, Initiative: +60, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2022-12"
@@ -10777,7 +10777,7 @@
 10921	distilled lousy Dad's brandy	5	decent	Last Available: "2022-06"
 10922	steel-toed teacher's pen of Calamity Jane	0		Damage Reduction: 9, Critical Hit Percent: +15, Last Available: "2022-06"
 10923	adequate fire-roasted lake trout	3	good	Last Available: "2022-06"
-10924	snack-sized yummy lime green guilty sprout	2	awesome	Last Available: "2022-06"
+10924	yummy snack-sized lime green guilty sprout	2	awesome	Last Available: "2022-06"
 10925	asbestos-lined mother's necklace of the detective	0		Hot Resistance: +5, Item Drop: +20, Last Available: "2022-06"
 10926	quantum diffused maroon trampled ticket stub	0		Effect: "Scavengers Scavenging", Effect Duration: 11, Last Available: "2022-06"
 10927	frozen gray savings bond	0		Effect: "Gummi Badass", Effect Duration: 35, Last Available: "2022-06"
@@ -10787,7 +10787,7 @@
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	jittery pulsating thick dinosaur	0		
-10934	narrow blinking dinosaur scale	0		
+10934	blinking narrow dinosaur scale	0		
 10935	cyan pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	rosy-cheeked pterodactyl rifle	0		Maximum HP Percent: +30, Conditional Skill (Equipped): "Snipe Pterodactyl"
@@ -10804,18 +10804,18 @@
 10948	pulsating padded reflective vest	0		Damage Absorption: +20
 10949	dinosaur of the cougar	0		Moxie: +20
 10950	huge Thwaitgold mosquito-in-amber statuette	0		
-10951	upside-down maroon packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
+10951	maroon upside-down packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
 10952	wobbly personal trainer's Jurassic Parka of the pedagogue	0		Experience: +3, Experience Percent (Muscle): +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	double-polymerized moist warmed autumn leaf	0		Effect: "Prideful Strut", Effect Duration: 61, Last Available: "2022-10"
-10956	lousy fortified AutumnFest ale	5	decent	Last Available: "2022-10"
+10956	fortified lousy AutumnFest ale	5	decent	Last Available: "2022-10"
 10957	fireproof sizzling autumn sweater-weather sweater of the storm	0		Maximum MP Percent: +40, Hot Damage: +10, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2022-10"
 10958	coward's Samson's autumn debris shield of the scaredy-cat of bravery	0		Experience (Muscle): +5, Monster Level: -35, Spooky Resistance: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	super-sized toothsome autumn-spice donut	5	awesome	Last Available: "2022-10"
-10960	galvanized blurry lime green autumn dollar	0		Effect: "Dragged Through the Coals", Effect Duration: 18, Last Available: "2022-10"
+10960	galvanized lime green blurry autumn dollar	0		Effect: "Dragged Through the Coals", Effect Duration: 18, Last Available: "2022-10"
 10961	foul-smelling grievous autumn leaf pendant of the detective	0		Weapon Damage Percent: +50, Stench Damage: +10, Item Drop: +20, Lasts Until Rollover, Last Available: "2022-10"
-10962	powdered blurry red autumn breeze	1		Last Available: "2022-10"
+10962	powdered red blurry autumn breeze	1		Last Available: "2022-10"
 10963	cold-filtered spinning autumn years wisdom	0		Effect: "Natural 20", Effect Duration: 16, Last Available: "2022-10"
 10964	familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	hand-crafted shaking Oopsie IPA	3	EPIC	Last Available: "2022-10"
@@ -10823,25 +10823,25 @@
 10967	lime green Yeast of Boris	0		Last Available: "2022-11"
 10968	pulsating St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	snack-sized flavorless ratatouille de Jarlsberg	2	decent	Last Available: "2022-11"
+10970	flavorless snack-sized ratatouille de Jarlsberg	2	decent	Last Available: "2022-11"
 10971	decent cyan Jarlsberg's vegetable soup	3	good	Last Available: "2022-11"
 10972	spoiled enchanted roasted vegetable of Jarlsberg	3	crappy	Effect: "Burning Tongue", Effect Duration: 40, Last Available: "2022-11"
-10973	normal small enchanted St. Pete's sneaky smoothie	2	good	Effect: "Amorous Avarice", Effect Duration: 30, Last Available: "2022-11"
+10973	small normal enchanted St. Pete's sneaky smoothie	2	good	Effect: "Amorous Avarice", Effect Duration: 30, Last Available: "2022-11"
 10974	bland small jittery Pete's wiley whey bar	2	decent	Last Available: "2022-11"
 10975	jumbo moldy Pete's rich ricotta	5	crappy	Last Available: "2022-11"
-10976	bad practically non-alcoholic jittery Boris's beer	1	decent	Last Available: "2022-11"
+10976	practically non-alcoholic bad jittery Boris's beer	1	decent	Last Available: "2022-11"
 10977	toothsome immense honey bun of Boris	6	awesome	Last Available: "2022-11"
 10978	low-calorie flavorless Boris's bread	1	decent	Last Available: "2022-11"
 10979	pulsating Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	green Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	mirror Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	huge squat Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10983	squat huge Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
 10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
 10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
-10988	gigantic spoiled baked veggie ricotta casserole	6	crappy	Last Available: "2022-11"
+10988	spoiled gigantic baked veggie ricotta casserole	6	crappy	Last Available: "2022-11"
 10989	spoiled low-calorie narrow red plain calzone	1	crappy	Last Available: "2022-11"
 10990	normal bouncing roasted vegetable focaccia	4	good	Last Available: "2022-11"
 10991	decent special Pizza of Legend	4	good	Effect: "Booze Goozles", Effect Duration: 45, Last Available: "2022-11"
@@ -10860,7 +10860,7 @@
 11004	cool prohie's hat	0		Moxie: +5
 11005	denatured deionized Vulcanized imported taffy	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 58
 11006	shaking wool savvy Charleston shoes	0		Mysticality Percent: +20, Cold Resistance: +1, Single Equip
-11007	mirror blurry booze bindle	0		
+11007	blurry mirror booze bindle	0		
 11008	squat Van der Graaf rare oboe of the businessman	0		Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7
 11009	boxer's bullet necklace of the detective	0		Muscle Percent: +10, Item Drop: +20, Single Equip
 11010	tasty swamp haunch	3	awesome	
@@ -10869,7 +10869,7 @@
 11013	lousy Charleston Choo-Choo	3	decent	
 11014	lousy watered-down bouncing Velvet Veil	2	decent	
 11015	smooth shaking Marltini	3	awesome	
-11016	drinkable practically non-alcoholic Strong, Silent Type	1	good	
+11016	practically non-alcoholic drinkable Strong, Silent Type	1	good	
 11017	acceptable green Mysterious Stranger	3	good	
 11018	perfectly mixed bouncing Champagne Shimmy	4	EPIC	
 11019	the Sot's parcel	0		
@@ -10889,9 +10889,9 @@
 11033	rosy-cheeked healthy dance instructor's chiffon chaps	0		Experience Percent (Moxie): +10, Maximum HP Percent: 50, Last Available: "2023-12"
 11034	diluted upside-down chiffon carbage	1		Last Available: "2023-12"
 11035	non-unsweetened chiffon lemon	0		Effect: "Happy Salamander", Effect Duration: 39
-11036	bland gigantic chocomotive	7	decent	Last Available: "2022-12"
+11036	gigantic bland chocomotive	7	decent	Last Available: "2022-12"
 11037	stale green freightcake	4	decent	Last Available: "2022-12"
-11038	lousy practically non-alcoholic cabooze	1	decent	Last Available: "2022-12"
+11038	practically non-alcoholic lousy cabooze	1	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	sharpshooter's plastic passenger car	0		Critical Hit Percent: +10, Last Available: "2022-12"
 11041	plastic dining car of the cougar	0		Moxie: +20, Last Available: "2022-12"
@@ -10905,14 +10905,14 @@
 11049	ghostly pile of Trainbot parts	0		
 11050	Vulcanized spinning Trainbot circuitry	0		Effect: "Full Bottle in front of Me", Effect Duration: 51
 11051	dry skewed Trainbot tubing	0		Effect: "Mushroom Magicalness", Effect Duration: 42
-11052	cold-filtered anodized narrow teal Trainbot plating	0		Effect: "Slimy Flavor", Effect Duration: 69
+11052	cold-filtered anodized teal narrow Trainbot plating	0		Effect: "Slimy Flavor", Effect Duration: 69
 11053	aerosolized Trainbot optics	0		Effect: "Elemental Mastery", Effect Duration: 43
 11054	non-Vulcanized lime green Trainbot servomotors	0		Effect: "Familial Ties", Effect Duration: 34
-11055	double-improved pulsating jittery Trainbot linkages	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 66
+11055	double-improved jittery pulsating Trainbot linkages	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 66
 11056	ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	spinning Trainbot harness of the cheetah	0		Initiative: +60
-11059	narrow olive ping-pong table	0		
+11059	olive narrow ping-pong table	0		
 11060	upside-down cyan Crimbo train emergency brake	0		
 11061	narrow Trainbot autoassembly module	0		
 11062	coward's wholesome quilted head-mounted Trainbot	0		Damage Absorption: +40, Maximum HP Percent: +10, Monster Level: -20, Last Available: "2022-12"
@@ -10925,18 +10925,18 @@
 11069	tumbling twirling Trainbot luggage hook	0		Single Equip
 11070	decent bite-sized honey-drenched ham slice	1	good	
 11071	weak perfectly mixed skewed mostly-empty bottle of cookie wine	2	EPIC	
-11072	spoiled super-sized ghostly Crimbo food scraps	5	crappy	
+11072	super-sized spoiled ghostly Crimbo food scraps	5	crappy	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	maroon table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	industrially-crushed ice	0		Last Available: "2022-12"
-11078	decent special half-sized steamed oyster	2	good	Effect: "Preemptive Medicine", Effect Duration: 35
+11078	half-sized decent special steamed oyster	2	good	Effect: "Preemptive Medicine", Effect Duration: 35
 11079	really nice lump of coal	0		
 11080	mirror deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	blue crystal Crimbo goblet	0		
-11083	upside-down gray crystal Crimbo platter	0		
+11083	gray upside-down crystal Crimbo platter	0		
 11084	high-proof bad Crimbosmopolitan	10	decent	Last Available: "2022-12"
 11085	flavorless small Crimbo dinner	2	decent	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
@@ -10955,17 +10955,17 @@
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	upside-down packet of rock seeds	0		Last Available: "2023-01"
 11101	wobbly groveling gravel	0		Last Available: "2023-01"
-11102	altered mirror tumbling fruity pebble	1		Last Available: "2023-01"
+11102	altered tumbling mirror fruity pebble	1		Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
 11108	twirling hard rock	0		Last Available: "2023-01"
-11109	spinning green twirling stalagmite	0		Last Available: "2023-01"
+11109	green spinning twirling stalagmite	0		Last Available: "2023-01"
 11110	fuchsia bouncing chocolate covered ping-pong ball	0		
-11112	adequate big pixel bread	5	good	
-11113	practically non-alcoholic bad pixel whiskey	1	decent	
+11112	big adequate pixel bread	5	good	
+11113	bad practically non-alcoholic pixel whiskey	1	decent	
 11114	blurry pixel rock	0		
 11115	blinking S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10979,9 +10979,9 @@
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	wet fire ant pheromones	0		Effect: "Got Your Boots On", Effect Duration: 41, Last Available: "2023-02"
 11126	modified flapper fly	0		Effect: "All Branned Up", Effect Duration: 67, Last Available: "2023-02"
-11127	drinkable practically non-alcoholic red shot of wasp venom	1	good	Last Available: "2023-02"
+11127	practically non-alcoholic drinkable red shot of wasp venom	1	good	Last Available: "2023-02"
 11128	chilled filled mosquito	0		Effect: "Chilblains of the Corn", Effect Duration: 62, Last Available: "2023-02"
-11129	quantum wobbly jittery shim of shame shale	0		Effect: "Fishily Speeding", Effect Duration: 54, Last Available: "2023-02"
+11129	quantum jittery wobbly shim of shame shale	0		Effect: "Fishily Speeding", Effect Duration: 54, Last Available: "2023-02"
 11130	pickled pebble of proud pyrite	0		Effect: "Innately Truthy", Effect Duration: 58, Last Available: "2023-02"
 11131	colloidal pile of gritty sand	0		Effect: "Human-Elemental Hybrid", Effect Duration: 24, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
@@ -10992,11 +10992,11 @@
 11137	boiled red shadow flame	0		Effect: "BOOsted", Effect Duration: 69, Last Available: "2023-03"
 11138	normal mirror shadow bread	4	good	Last Available: "2023-03"
 11139	wobbly shadow ice	0		Last Available: "2023-03"
-11140	fancy artisanal shadow fluid	3	EPIC	Effect: "Warm Shoulders", Effect Duration: 45, Last Available: "2023-03"
+11140	artisanal fancy shadow fluid	3	EPIC	Effect: "Warm Shoulders", Effect Duration: 45, Last Available: "2023-03"
 11141	ghostly upside-down shadow glass	0		Last Available: "2023-03"
 11142	cyan shadow brick	0		Last Available: "2023-03"
 11143	teal shadow sinew	0		Last Available: "2023-03"
-11144	spirit-forward drinkable shadow venom	5	good	Last Available: "2023-03"
+11144	drinkable spirit-forward shadow venom	5	good	Last Available: "2023-03"
 11145	denatured shadow nectar	1		Effect: "Engorged Weapon", Effect Duration: 40, Last Available: "2023-03"
 11146	hardy veiny shadow stick of Calamity Jane	0		Maximum HP: 60, Critical Hit Percent: +15, Last Available: "2023-03"
 11147	extremely unsafe educational bat paw	0		Experience: +1, Weapon Damage Percent: +100
@@ -11035,7 +11035,7 @@
 11180	bouncing maroon Usain Bolt's flame-retardant arcane researcher's shadow monocle	0		Experience Percent (Mysticality): +10, Hot Resistance: +1, Initiative: +80, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	adequate shadow hot dog	4	good	
-11183	lousy high-proof shadow martini	9	decent	
+11183	high-proof lousy shadow martini	9	decent	
 11184	diluted shadow pill	1		
 11185	shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
@@ -11070,14 +11070,14 @@
 11215	replica angel	0		
 11216	gray replica Camp Scout backpack of the overflowing toilet	0		Stench Spell Damage: +50
 11217	replica deactivated nanobots	0		
-11218	skewed jittery replica Apathargic Bandersnatch	0		
+11218	jittery skewed replica Apathargic Bandersnatch	0		
 11219	replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
-11221	upside-down green twirling replica Order of the Green Thumb Order Form	0		
+11221	twirling upside-down green replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	energetic padded Cincho de Mayo of temperance of the sweet-tooth	0		Damage Absorption: +20, Maximum MP Percent: +20, Sleaze Resistance: +5, Candy Drop: +100, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
-11225	spinning narrow replica Little Geneticist DNA-Splicing Lab	0		
+11225	narrow spinning replica Little Geneticist DNA-Splicing Lab	0		
 11226	blurry replica still grill	0		
 11227	replica Crimbo sapling	0		
 11228	replica puck	0		
@@ -11113,11 +11113,11 @@
 11258	Jeselnik's Jack Frost's resourceful slick &quot;I survived Y2K&quot; T-Shirt of the brute of the scaredy-cat	0		Moxie: +10, Muscle Percent: +30, Maximum MP: +50, Monster Level: -15, Cold Spell Damage: +50, Sleaze Damage: +25, Single Equip, Last Available: "2023-06"
 11259	twirling huge Letter from Carrie Bradshaw	0		Last Available: "2023-06"
 11260	blue rosy-cheeked pro skateboard of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
-11261	shaking blinking Mr. Accessaturday	0		Last Available: "2023-06"
+11261	blinking shaking Mr. Accessaturday	0		Last Available: "2023-06"
 11262	shaking Meat Butler	0		Last Available: "2023-06"
 11263	upside-down Loathing Idol Microphone	0		Last Available: "2023-06"
-11264	jittery gray Charter: Nellyville	0		Last Available: "2023-06"
-11265	jittery Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11264	gray jittery Charter: Nellyville	0		Last Available: "2023-06"
+11265	jittery Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
 11266	miser's Flash Liquidizer Ultra Dousing Accessory	0		Meat Drop: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	nasty educational boxer's Amulet of Perpetual Darkness of the businessman	0		Muscle Percent: +10, Experience: +1, Stench Damage: +5, Meat Drop: +50, Last Available: "2023-06"
 11268	yellow Giant monolith	0		Last Available: "2023-06"
@@ -11151,7 +11151,7 @@
 11296	twirling frosty sinister birdybug antenna	0		Spell Damage: +10, Cold Spell Damage: +10
 11297	reassuring kilopede skull of terror	0		Spooky Spell Damage: +10, Spooky Resistance: +1
 11298	frozen double-pressed corrupted haemolymphnode	0		Effect: "The Q Is Talking To You", Effect Duration: 24
-11299	dry jittery wobbly chitin powder paste	0		Effect: "Metal Speed", Effect Duration: 58
+11299	dry wobbly jittery chitin powder paste	0		Effect: "Metal Speed", Effect Duration: 58
 11300	spinning sleeping patriotic eagle	0		Free Pull
 11301	tumbling claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
@@ -11159,7 +11159,7 @@
 11304	shaking replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	immense spoiled watermelon	10	crappy	
+11307	spoiled immense watermelon	10	crappy	
 11308	watermelon seed	0		
 11309	tumbling water balloon	0		
 11310	thriftshop coupon	0		
@@ -11174,8 +11174,8 @@
 11319	yellow medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	practically non-alcoholic hand-crafted bottle of Cabernet Sauvignon	1	super ultra mega turbo EPIC	
 11321	blinking lion tamer's hardened supercool baywatch	0		Moxie Percent: +20, Damage Reduction: 3, Experience (familiar): +2, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	red Thwaitgold fairyfly statue	0		
@@ -11201,7 +11201,7 @@
 11346	spinning day shortener	0		
 11347	extra time	0		
 11348	energetic stylish autumnal aegis	0		Moxie: +25, Maximum MP Percent: +20, Damage Reduction: 9
-11349	triple-pickled corrupted pulsating blurry distilled resin	0		Effect: "Quaaaaaaa", Effect Duration: 36
+11349	triple-pickled corrupted blurry pulsating distilled resin	0		Effect: "Quaaaaaaa", Effect Duration: 36
 11350	super-heated leaf	0		
 11351	lit leaf lasso	0		
 11352	tied-up leaflet	0		
@@ -11247,13 +11247,13 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	squat crated wardrobe-o-matic	0		
-11395	fancy toothsome massive peppermint donut	8	awesome	Effect: "Fastbreaker", Effect Duration: 25
+11395	massive fancy toothsome peppermint donut	8	awesome	Effect: "Fastbreaker", Effect Duration: 25
 11396	Elf Guard insignia (private) of Flo-Jo	0		Initiative: +100, Last Available: "2023-12"
 11397	baleful Crimbuccaneer fledges (mint)	0		Spell Damage: +25, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
-11399	lime green bouncing Crimbuccaneer whale oil	0		Last Available: "2023-12"
+11399	bouncing lime green Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	hand-crafted weak Crimbuccaneer mologrog cocktail	2	EPIC	Last Available: "2023-12"
+11401	weak hand-crafted Crimbuccaneer mologrog cocktail	2	EPIC	Last Available: "2023-12"
 11402	wobbly Elf Army machine parts	0		Last Available: "2023-12"
 11403	blurry Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	Crimbuccaneer lantern of the overflowing toilet of bravery of the detective	0		Stench Spell Damage: +50, Spooky Resistance: +5, Item Drop: +20, Last Available: "2023-12"
@@ -11263,12 +11263,12 @@
 11408	narrow Elf Guard MPC	0		Last Available: "2023-12"
 11409	Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	Jeselnik's Elf Guard commandeering gloves	0		Sleaze Damage: +25, Single Equip, Last Available: "2023-12"
-11411	aerosolized colloidal maroon mirror Elf Guard eyedrops	0		Effect: "Boo Tea", Effect Duration: 21, Last Available: "2023-12"
+11411	aerosolized colloidal mirror maroon Elf Guard eyedrops	0		Effect: "Boo Tea", Effect Duration: 21, Last Available: "2023-12"
 11412	tumbling ghostly Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	green stanky Da Vinci's Elf Guard officer's sidearm	0		Experience (Mysticality): +5, Stench Spell Damage: +25, Last Available: "2023-12"
 11415	forbidden slick Elf Guard insignia (general)	0		Moxie: +10, Spell Damage Percent: +50, Single Equip, Last Available: "2023-12"
-11416	perfectly mixed practically non-alcoholic shaking Crimbow Rainbo	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11416	practically non-alcoholic perfectly mixed shaking Crimbow Rainbo	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	mirror Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	Usain Bolt's friendly Elf Guard broom	0		Familiar Weight: +3, Initiative: +80, Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	inspector's lard-coated Elf Guard clipboard of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +25, Item Drop: +15, Last Available: "2023-12"
 11435	pegfinger of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2023-12"
-11436	artisanal fancy and claret	3	EPIC	Effect: "Improved Candy Vision", Effect Duration: 30, Last Available: "2023-12"
+11436	fancy artisanal and claret	3	EPIC	Effect: "Improved Candy Vision", Effect Duration: 30, Last Available: "2023-12"
 11437	bouncing narrow ghostly scandalous Elf Guard and beret	0		Sleaze Damage: [+5*event(December)], Last Available: "2023-12"
 11438	fuchsia blinking asbestos-lined shipwright's hammer of wisdom of the scaredy-cat	0		Mysticality: +15, Monster Level: -15, Hot Resistance: +5, Last Available: "2023-12"
 11439	inspector's flame-wreathed sizzling gunwale	0		Hot Damage: +10, Hot Spell Damage: +10, Item Drop: +15, Damage Reduction: 9, Last Available: "2023-12"
@@ -11303,7 +11303,7 @@
 11448	upside-down brown pirate pants of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Last Available: "2023-12"
 11449	red Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11450	narrow The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
-11451	blurry huge punching mirror	0		Last Available: "2023-12"
+11451	huge blurry punching mirror	0		Last Available: "2023-12"
 11452	bouncing nippy clever hale grievous Herculean Elf dessert spoon of the ox	0		Muscle: +20, Experience (Muscle): +1, Weapon Damage Percent: +50, Maximum HP: +20, Maximum MP: +20, Cold Damage: +10, Last Available: "2023-12"
 11453	mansplainer's forbidden Elf Guard SCUBA tank	0		Spell Damage Percent: +50, Monster Level: +15, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
@@ -11315,23 +11315,23 @@
 11460	fancy stale super-sized gingerbread nylons	5	decent	Effect: "Mad at Science", Effect Duration: 10, Last Available: "2023-12"
 11461	stale mirror rum-soaked fruitcake	3	decent	Last Available: "2023-12"
 11462	moldy lime	3	crappy	Last Available: "2023-12"
-11463	stale thick mirror maroon gingerbread pirate	5	decent	Last Available: "2023-12"
+11463	thick stale maroon mirror gingerbread pirate	5	decent	Last Available: "2023-12"
 11464	bland fruit-stuffed rumcake	4	decent	Last Available: "2023-12"
-11465	extra-dry tolerable mulled wine	5	good	Last Available: "2023-12"
+11465	tolerable extra-dry mulled wine	5	good	Last Available: "2023-12"
 11466	hand-crafted Swedish coffee	4	EPIC	Last Available: "2023-12"
-11467	acceptable weak skewed canteen of eggnog	2	good	Last Available: "2023-12"
+11467	weak acceptable skewed canteen of eggnog	2	good	Last Available: "2023-12"
 11468	lousy fuchsia hot wine	4	decent	Last Available: "2023-12"
-11469	practically non-alcoholic artisanal Jamaican coffee	1	super ultra mega EPIC	Last Available: "2023-12"
+11469	artisanal practically non-alcoholic Jamaican coffee	1	super ultra mega EPIC	Last Available: "2023-12"
 11470	mediocre high-proof skewed flask of egggrog	8	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	narrow tumbling pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	hand-crafted yule grog	3	EPIC	Last Available: "2023-12"
-11475	low-calorie decent wet tack	1	good	Last Available: "2023-12"
+11475	decent low-calorie wet tack	1	good	Last Available: "2023-12"
 11476	adequate bouncing whalecake	3	good	Last Available: "2023-12"
 11477	MacGyver's extremely unsafe weightlifter's gunwale whalegun	0		Muscle: +15, Weapon Damage Percent: +100, Maximum MP: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	perfectly mixed bouncing blue and claret	4	EPIC	Last Available: "2023-12"
-11479	blurry green shaking rigging knot	0		Familiar Weight: +5
+11478	perfectly mixed blue bouncing and claret	4	EPIC	Last Available: "2023-12"
+11479	green shaking blurry rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	Elf Guard squirtgun of the wise owl of Flo-Jo	0		Mysticality: +20, Initiative: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
@@ -11354,7 +11354,7 @@
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	tumbling The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	huge Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11502	electrified polarized shaking huge military candy cane	0		Effect: "Conspiratory Eyes", Effect Duration: 44
+11502	electrified polarized huge shaking military candy cane	0		Effect: "Conspiratory Eyes", Effect Duration: 44
 11503	alkaline energized groggipop	0		Effect: "Wit Tea", Effect Duration: 21
 11504	wool moss mace of the cougar	0		Moxie: +20, Cold Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
 11505	manspreader's moss megaphone of the empath	0		Monster Level: +10, Familiar Weight: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
@@ -11386,9 +11386,9 @@
 11531	groovy thinker's petrified wood water purifier	0		Mysticality: +10, Moxie Percent: +10, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	cyan scandalous petrified wood whoopie panama of the wise owl	0		Mysticality: +20, Sleaze Damage: +5, Last Available: "2025-12"
 11533	Lo Pan's stylish petrified wood walking pants	0		Moxie: +25, Spell Critical Percent: +30, Last Available: "2025-12"
-11534	powdered jittery blue petrified wood waste parts	1		Last Available: "2025-12"
-11535	galvanized moist altered spinning squat petrified wood wafer praline	0		Effect: "Clean-Shaven", Effect Duration: 32
-11536	irresponsibly strong mediocre squat cybeer	9	decent	Last Available: "2025-12"
+11534	powdered blue jittery petrified wood waste parts	1		Last Available: "2025-12"
+11535	galvanized moist altered squat spinning petrified wood wafer praline	0		Effect: "Clean-Shaven", Effect Duration: 32
+11536	mediocre irresponsibly strong squat cybeer	9	decent	Last Available: "2025-12"
 11537	wobbly ICEbox	0		Last Available: "2025-12"
 11538	gray wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
 11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
@@ -11425,12 +11425,12 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	super-sized enchanted decent gray yam	5	good	Effect: "Eye of the Lihc", Effect Duration: 25, Last Available: "2024-05"
+11573	super-sized decent enchanted gray yam	5	good	Effect: "Eye of the Lihc", Effect Duration: 25, Last Available: "2024-05"
 11574	lousy yam martini	3	decent	Last Available: "2024-05"
-11575	perfectly mixed practically non-alcoholic sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
+11575	practically non-alcoholic perfectly mixed sweet potato o' mine	1	super ultra mega turbo EPIC	Last Available: "2024-05"
 11576	watered-down perfectly mixed Southern yam	2	EPIC	Last Available: "2024-05"
 11577	perfectly mixed squat sweet potato punch	3	EPIC	Last Available: "2024-05"
-11578	normal big cyan narrow Mayam spinach	5	good	Last Available: "2024-05"
+11578	big normal cyan narrow Mayam spinach	5	good	Last Available: "2024-05"
 11579	adequate yam and swiss	4	good	Last Available: "2024-05"
 11580	ghostly avaricious smelly thinker's yam cannon	0		Mysticality: +10, Stench Spell Damage: +10, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11439,14 +11439,14 @@
 11584	jittery resourceful groovy brainy furry yam buckler	0		Mysticality: +5, Moxie Percent: +10, Maximum MP: +50, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	gravedigger's hardy yamtility belt of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
-11587	spoiled thick yam slider	5	crappy	Last Available: "2024-05"
+11587	thick spoiled yam slider	5	crappy	Last Available: "2024-05"
 11588	spoiled upside-down yam mayo	3	crappy	Last Available: "2024-05"
 11589	adequate narrow yam burrito	4	good	Last Available: "2024-05"
-11590	maroon spinning upside-down visual packet sniffer	0		Last Available: "2025-12"
+11590	spinning upside-down maroon visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	adequate jumbo mirror mini kiwi	5	good	Last Available: "2024-06"
+11594	jumbo adequate mirror mini kiwi	5	good	Last Available: "2024-06"
 11595	padded mini kiwi bikini of the pedagogue of terror	0		Experience: +3, Damage Absorption: +20, Spooky Spell Damage: +10, Last Available: "2024-06"
 11596	mediocre wobbly mini kiwitini	3	decent	Last Available: "2024-06"
 11597	spinning mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
@@ -11454,7 +11454,7 @@
 11599	asbestos-lined experienced cool mini kiwi silicon tiepin	0		Moxie: +5, Experience: +2, Hot Resistance: +5
 11600	maroon twirling mini kiwi tipi	0		
 11601	bland tiny mini kiwi digitized cookies	1	decent	
-11602	watered-down bad mini kiwi intoxicating spirits	2	decent	
+11602	bad watered-down mini kiwi intoxicating spirits	2	decent	
 11603	boiled improved mini kiwi antimilitaristic hippy petition	0		Effect: "Human-Human Hybrid", Effect Duration: 24
 11604	super-aerosolized oxidized olive mini kiwi illicit antibiotic	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 26
 11605	friendly mini kiwi whipping stick of the brute	0		Muscle Percent: +30, Familiar Weight: +3
@@ -11484,7 +11484,7 @@
 11629	untorn tearaway pants package	0		Free Pull
 11630	bouncing frightening Temple Grandin's wholesome supercool tearaway pants of Flo-Jo	0		Moxie Percent: +20, Maximum HP Percent: +10, Familiar Weight: +7, Spooky Damage: +5, Initiative: +100, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	baby bodyguard	0		
-11632	blurry cyan Doll Moll violin case	0		
+11632	cyan blurry Doll Moll violin case	0		
 11633	blinking Tina gun	0		Familiar Weight: +5
 11634	mirror tattoo gun	0		
 11635	smooth huge Colera Peste Nebbiolo	4	awesome	
@@ -11494,7 +11494,7 @@
 11639	narrow Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	tumbling Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
-11642	ghostly blinking Sept-Ember Censer	0		Last Available: "2024-09"
+11642	blinking ghostly Sept-Ember Censer	0		Last Available: "2024-09"
 11643	Temple Grandin's blade of dismemberment	0		Familiar Weight: +7, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
 11645	wobbly Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
@@ -11535,7 +11535,7 @@
 11680	wobbly quantum watch	0		Adventures: +2
 11681	spinning quantized familiar experience	0		
 11682	ionized blue pea brittle	0		Effect: "Locks Like the Raven", Effect Duration: 37, Last Available: "2024-11"
-11683	irresponsibly strong hand-crafted peasco	10	EPIC	Last Available: "2024-11"
+11683	hand-crafted irresponsibly strong peasco	10	EPIC	Last Available: "2024-11"
 11684	rotten huge piece of cake	8	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
@@ -11574,7 +11574,7 @@
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
-11722	miniature tasty blinking coney haunch	2	awesome	Last Available: "2024-12"
+11722	tasty miniature blinking coney haunch	2	awesome	Last Available: "2024-12"
 11723	deionized quadruple-galvanized dark chocolate egg	0		Effect: "Eyes All Black", Effect Duration: 56, Last Available: "2024-12"
 11724	extra-dry acceptable moai toai	5	good	
 11725	spinning Jack Frost's careful moaiball of the ox	0		Muscle: +20, Monster Level: -10, Cold Spell Damage: +50, Last Available: "2024-12"
@@ -11584,7 +11584,7 @@
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
 11731	Sinatra's military orb of chilblains	0		Experience (Moxie): +5, Cold Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
-11732	polymerized twirling jittery rum ball	0		Effect: "Eyes for Miles", Effect Duration: 61
+11732	polymerized jittery twirling rum ball	0		Effect: "Eyes for Miles", Effect Duration: 61
 11733	gravy skin	0		Last Available: "2024-12"
 11734	dog trainer's savvy gravyskin hat	0		Mysticality Percent: +20, Experience (familiar): +1, Last Available: "2024-12"
 11735	Jack Frost's ruddy gravyskin buckler	0		Maximum HP Percent: +40, Cold Spell Damage: +50, Damage Reduction: 7, Last Available: "2024-12"
@@ -11600,29 +11600,29 @@
 11745	miser's rosewater-soaked Congressional Medal of Insanity of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +3, Meat Drop: +10, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	smooth Easter grasshopper	3	awesome	Last Available: "2024-12"
-11748	tolerable enchanted practically non-alcoholic twirling Irish eggnog	1	good	Effect: "Fudge Headache", Effect Duration: 30, Last Available: "2024-12"
+11748	tolerable practically non-alcoholic enchanted twirling Irish eggnog	1	good	Effect: "Fudge Headache", Effect Duration: 30, Last Available: "2024-12"
 11749	aged jittery canteen of jungle juice	4	awesome	Last Available: "2024-12"
-11750	spirit-forward delicious turchucken	5	awesome	Last Available: "2024-12"
+11750	delicious spirit-forward turchucken	5	awesome	Last Available: "2024-12"
 11751	hand-crafted fancy mechanically-mulled cider	3	EPIC	Effect: "Video Game Hot Dog", Effect Duration: 5, Last Available: "2024-12"
 11752	irresponsibly strong artisanal holiday trip around the world	6	EPIC	Last Available: "2024-12"
-11753	jumbo decent chocolate ostrich egg	5	good	Last Available: "2024-12"
+11753	decent jumbo chocolate ostrich egg	5	good	Last Available: "2024-12"
 11754	adequate jittery beef and cabbage	4	good	Last Available: "2024-12"
 11755	bland tiny candy rations	1	decent	Last Available: "2024-12"
-11756	yummy tumbling shaking green double-candied yams	4	awesome	Last Available: "2024-12"
+11756	yummy green tumbling shaking double-candied yams	4	awesome	Last Available: "2024-12"
 11757	normal red Christmas ham	4	good	Last Available: "2024-12"
 11758	rotten tumbling holiday smorgasbord	4	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	spinning wizardly bejazzled eyepatch	0		Mysticality: +25, Last Available: "2024-12"
-11761	blinking Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	gray How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	twirling Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	bouncing Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	blinking Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	blinking Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	gray How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	twirling Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	bouncing Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	blinking Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	greedy Sherlock's studded egg gun of James Dean	0		Experience (Moxie): +3, Damage Absorption: +80, Item Drop: +25, Meat Drop: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	twirling manspreader's dangerous groovy army helmet of horror	0		Moxie Percent: +10, Weapon Damage: +10, Monster Level: +10, Spooky Spell Damage: +25, Last Available: "2024-12"
@@ -11654,7 +11654,7 @@
 11799	squat dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
 11800	dedigitizer schematic: pocket GPU	0		Last Available: "2025-12"
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
-11802	huge shaking dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
+11802	shaking huge dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
@@ -11679,13 +11679,13 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	shaking hashing vise	0		Last Available: "2025-12"
-11827	blinking tumbling geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	tumbling blinking geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ghostly ninja rope	0		
 11831	ninja crampons	0		
 11832	ninja carabiner	0		
-11833	nitrogenated lime green upside-down synthetic coffee	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
+11833	nitrogenated upside-down lime green synthetic coffee	0		Effect: "Marbles in Your Mouth", Effect Duration: 19
 11834	corrupted spinning iDrops	0		Effect: "Loco Motives", Effect Duration: 42
 11835	shame coil	0		
 11836	new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
@@ -11723,15 +11723,15 @@
 11868	spoon	0		
 11869	unironic knife	0		
 11870	shaking bar dart	0		Last Available: "2025-03"
-11871	boiled bouncing mirror leprechaun antidepressant pill	1		Effect: "Phoenix, Right?", Effect Duration: 15, Last Available: "2025-03"
-11872	adequate squat twirling ghostly Heck ramen	4	good	Last Available: "2025-03"
+11871	boiled mirror bouncing leprechaun antidepressant pill	1		Effect: "Phoenix, Right?", Effect Duration: 15, Last Available: "2025-03"
+11872	adequate twirling squat ghostly Heck ramen	4	good	Last Available: "2025-03"
 11873	spoiled burrito	3	crappy	Last Available: "2025-03"
-11874	yummy small small beer brat	2	awesome	Last Available: "2025-03"
-11875	snack-sized spoiled peach pie	2	crappy	Last Available: "2025-03"
+11874	small yummy small beer brat	2	awesome	Last Available: "2025-03"
+11875	spoiled snack-sized peach pie	2	crappy	Last Available: "2025-03"
 11876	stale huge ghostly incredible mini-pizza	7	decent	Last Available: "2025-03"
 11877	bad bouncing Divine sidecar	3	decent	Last Available: "2025-03"
 11878	tolerable tangarita sidecar	4	good	Last Available: "2025-03"
-11879	high-proof perfectly mixed gimlet sidecar	6	EPIC	Last Available: "2025-03"
+11879	perfectly mixed high-proof gimlet sidecar	6	EPIC	Last Available: "2025-03"
 11880	lousy huge vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
 11881	bad olive prussian cathouse sidecar	4	decent	Last Available: "2025-03"
 11882	bad Mon Tiki sidecar	4	decent	Last Available: "2025-03"
@@ -11784,7 +11784,7 @@
 11929	huge priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	nice nylon stockings	0		
-11932	huge upside-down Allied Radio Backpack Pack	0		Free Pull
+11932	upside-down huge Allied Radio Backpack Pack	0		Free Pull
 11933	perfumed electrified thinker's Allied Radio Backpack	0		Mysticality: +10, Stench Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	spinning orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
@@ -11797,20 +11797,20 @@
 11942	M&ouml;bius ring	0		Last Available: "2025-08"
 11943	bone pacifier	0		Familiar Weight: +5
 11944	wholesome Herculean Rosewater's Allied Forces insignia	0		Mysticality Percent: +30, Experience (Muscle): +1, Maximum HP Percent: +10, Single Equip
-11945	ghostly huge Allied Tattoo Kit	0		
+11945	huge ghostly Allied Tattoo Kit	0		
 11946	handheld Allied radio	0		
 11947	fuchsia Axis codebook	0		
 11948	boiled blinking olive Life Goals Pamphlet	0		Effect: "Crusty Head", Effect Duration: 66, Last Available: "2025-08"
 11949	olive bully badge of the wise owl	0		Mysticality: +20, Lasts Until Rollover, Last Available: "2025-08"
 11950	narrow cool time cop top hat	0		Moxie: +5, Last Available: "2025-08"
-11951	pulsating jittery Stock Certificate	0		Last Available: "2025-08"
+11951	jittery pulsating Stock Certificate	0		Last Available: "2025-08"
 11952	powdered mixed berry jelly	1		Effect: "Joyful Resolve", Effect Duration: 50, Last Available: "2025-08"
 11953	normal diet narrow toast with mixed berry jelly	1	good	Last Available: "2025-08"
 11954	rotten cup of sugar	3	crappy	Last Available: "2025-08"
-11955	decent snack-sized pulsating Susie's cupcake	2	good	Last Available: "2025-08"
+11955	snack-sized decent pulsating Susie's cupcake	2	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	lime green executive the gun of James Dean of the overflowing toilet	0		Experience (Moxie): +3, Stench Spell Damage: +50, Meat Drop: +40, Last Available: "2025-08"
-11958	boozy lousy wine	5	decent	Last Available: "2025-08"
+11958	lousy boozy wine	5	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	olive strapping undersea surveying goggles	0		Muscle: +5, Lasts Until Rollover
@@ -11833,17 +11833,17 @@
 11987	wobbly ghostly foul-smelling padded sage weightlifter's blood cubic zirconia of the cougar of the brute	0		Muscle: +15, Moxie: +20, Muscle Percent: +30, Mysticality Percent: +10, Damage Absorption: +20, Stench Damage: +10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	pickled blood thinner	1		Effect: "Human-Demon Hybrid", Effect Duration: 45, Last Available: "2025-10"
 12045	bad pheromone cocktail	3	decent	Last Available: "2025-10"
-12046	yummy small twirling spinal tapas	2	awesome	Last Available: "2025-10"
+12046	small yummy twirling spinal tapas	2	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	energetic veiny baleful shrunken head	0		Spell Damage: +25, Maximum HP: +10, Maximum MP Percent: +20, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	practically non-alcoholic perfectly mixed Smoking Pope	1	super ultra mega turbo EPIC	
+12052	perfectly mixed practically non-alcoholic Smoking Pope	1	super ultra mega turbo EPIC	
 12053	decent shaking prize turkey	3	good	
 12054	compressed gray medicinal gruel	1		
-12055	flavorless miniature yellow bouncing full-sized pumpkin pie	2	decent	Last Available: "2025-11"
-12056	bad high-proof vodka cranberry sauce	8	decent	Last Available: "2025-11"
+12055	miniature flavorless yellow bouncing full-sized pumpkin pie	2	decent	Last Available: "2025-11"
+12056	high-proof bad vodka cranberry sauce	8	decent	Last Available: "2025-11"
 12057	wet squat yammed candy	0		Effect: "Chock Full o' Nanites", Effect Duration: 31, Last Available: "2025-11"
 12058	rotten skewed treasure chestnut	3	crappy	Last Available: "2025-12"
 12059	drinkable mulled butter rum	4	good	Last Available: "2025-12"
@@ -11885,8 +11885,8 @@
 12127	cyan forbidden Santa-Slayer medal of the cougar of Calamity Jane	0		Moxie: +20, Spell Damage Percent: +50, Critical Hit Percent: +15, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	vacuum-sealed chilled ionized narrow boiling bone marrow	0		Effect: "You Read The Manual", Effect Duration: 13, Last Available: "2025-12"
-12130	liquefied twirling gray boiling cerebrospinal fluid	0		Effect: "Educated (Sorta)", Effect Duration: 26, Last Available: "2025-12"
-12131	boiled cold-filtered huge cyan boiling synovial fluid	0		Effect: "Warm Shoulders", Effect Duration: 40, Last Available: "2025-12"
+12130	liquefied gray twirling boiling cerebrospinal fluid	0		Effect: "Educated (Sorta)", Effect Duration: 26, Last Available: "2025-12"
+12131	boiled cold-filtered cyan huge boiling synovial fluid	0		Effect: "Warm Shoulders", Effect Duration: 40, Last Available: "2025-12"
 12132	jittery wobbly toasty Van der Graaf smoldering vertebra of Leguizamo	0		Monster Level: +20, Hot Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
@@ -11938,13 +11938,13 @@
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	tumbling Thwaitgold meat bee statuette	0		
-12183	bouncing tumbling loose Meats	0		
+12183	tumbling bouncing loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	dinosaur bone fragment	0		Last Available: "2026-03"
 12187	Pork Elf pottery shard	0		Last Available: "2026-03"
 12188	bouncing 2015 landfill detritus	0		Last Available: "2026-03"
-12189	twirling wobbly olive intact dinosaur egg	0		Last Available: "2026-03"
+12189	twirling olive wobbly intact dinosaur egg	0		Last Available: "2026-03"
 12190	mirror fossilized cow femur	0		Familiar Weight: +5
 12191	blurry unopened Pork Elf toiletries kit	0		Last Available: "2026-03"
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
@@ -11964,12 +11964,12 @@
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	ghostly Pork Elf toilet	0		Last Available: "2026-03"
-12209	spoiled tiny blue rat pizza	1	crappy	Last Available: "2026-03"
+12209	tiny spoiled blue rat pizza	1	crappy	Last Available: "2026-03"
 12210	blinking Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	Sherlock's healthy hoverboard of the glutton	0		Maximum HP Percent: +20, Item Drop: +25, Food Drop: +100, Single Equip, Last Available: "2026-03"
 12212	avaricious quilted smartaleck's left shark fin	0		Moxie Percent: +30, Damage Absorption: +40, Meat Drop: +30, Last Available: "2026-03"
 12213	stylish fitness tracking bracelet	0		Moxie: +25, Single Equip, Last Available: "2026-03"
-12214	distilled blinking blue huge candy bone	1		
+12214	distilled huge blue blinking candy bone	1		
 12215	blurry wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	stale blurry discarded hot dog	4	decent	Last Available: "2026-04"
@@ -11977,23 +11977,23 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	jumbo bland special blinking can of tuna	5	decent	Effect: "Thick, Sick", Effect Duration: 35
-12227	miniature rotten bouncing skewed alien salad	2	crappy	
+12226	special bland jumbo blinking can of tuna	5	decent	Effect: "Thick, Sick", Effect Duration: 35
+12227	rotten miniature bouncing skewed alien salad	2	crappy	
 12228	rotten ratbatatouille	3	crappy	
-12229	flavorless special tumbling onigiri	3	decent	Effect: "Smoking like a Bandit", Effect Duration: 45
-12230	moldy huge squat crudit&eacute;s	9	crappy	
+12229	special flavorless tumbling onigiri	3	decent	Effect: "Smoking like a Bandit", Effect Duration: 45
+12230	huge moldy squat crudit&eacute;s	9	crappy	
 12231	decent big sauced mutton	5	good	
-12232	enchanted stale snack-sized lime green hot honey ant	2	decent	Effect: "Ghostly Shell", Effect Duration: 25
+12232	snack-sized enchanted stale lime green hot honey ant	2	decent	Effect: "Ghostly Shell", Effect Duration: 25
 12233	spoiled tomb aspic	3	crappy	
 12234	decent later tots	4	good	
 12235	yummy upside-down Frutti di Scatoletta	4	awesome	Last Available: "2026-05"
 12236	stale Pesto alla Marziano	3	decent	Last Available: "2026-05"
-12237	normal massive Arrattabbattabiata	9	good	Last Available: "2026-05"
+12237	massive normal Arrattabbattabiata	9	good	Last Available: "2026-05"
 12238	moldy Orzo di Riso	3	crappy	Last Available: "2026-05"
 12239	stale Pasta Grimavera	3	decent	Last Available: "2026-05"
 12240	snack-sized decent Linguini Ubriacapa	2	good	Last Available: "2026-05"
 12241	normal Formica e Pepe	4	good	Last Available: "2026-05"
-12242	gigantic moldy Tubetto Gelatto	6	crappy	Last Available: "2026-05"
+12242	moldy gigantic Tubetto Gelatto	6	crappy	Last Available: "2026-05"
 12243	moldy Gnocci Domani	4	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	maroon scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12001,7 +12001,7 @@
 12248	tumbling mega helmet	0		
 12252	Fonzie's sage Space Soldier Helmet	0		Mysticality Percent: +10, Experience (Moxie): +1
 12253	spoiled premium turkey leg	3	crappy	
-12254	extra-dry mediocre styrofoam cup of mead	5	decent	
+12254	mediocre extra-dry styrofoam cup of mead	5	decent	
 12255	wholesome sword	0		Maximum HP Percent: +10
 12256	Jack Frost's staff	0		Cold Spell Damage: +50
 12257	wobbly beefy lute	0		Muscle: +10
@@ -12020,15 +12020,15 @@
 12270	pulsating miser's reassuring smooth Portable Laughing Stock	0		Moxie: +15, Spooky Resistance: +1, Meat Drop: +10, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	censurious lion tamer's Staff of Anachronistic Churning of the sweet-tooth	0		Experience (familiar): +2, Sleaze Resistance: +3, Candy Drop: +100
 12272	decent squat classic banana	3	good	Last Available: "2026-07"
-12273	snack-sized decent watermelon	2	good	Last Available: "2026-07"
+12273	decent snack-sized watermelon	2	good	Last Available: "2026-07"
 12274	yummy mirror upside-down quince	4	awesome	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	massive decent pulsating classic banana pie	9	good	Last Available: "2026-07"
 12278	cold-filtered blurry essential banana decoction	0		Effect: "Beta Carotene Overdose", Effect Duration: 11, Last Available: "2026-07"
 12279	ionized denatured banana quintessence	0		Effect: "The Magic of Sharing", Effect Duration: 56, Last Available: "2026-07"
-12280	hand-crafted watered-down Aesop Daiquiri	2	EPIC	Last Available: "2026-07"
-12281	smooth special blue Monkey Congress	3	awesome	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2026-07"
+12280	watered-down hand-crafted Aesop Daiquiri	2	EPIC	Last Available: "2026-07"
+12281	special smooth blue Monkey Congress	3	awesome	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2026-07"
 12282	stale watermelon pie	4	decent	Last Available: "2026-07"
 12283	non-quantum concentrated watermelon juice	0		Effect: "Ooh, Bitter!", Effect Duration: 65, Last Available: "2026-07"
 12284	concentrated Aqua Citrulanatae	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 52, Last Available: "2026-07"
@@ -12049,7 +12049,7 @@
 12299	huge hedge fund clippers of dire peril of Flo-Jo	0		Weapon Damage: +20, Initiative: +100, Last Available: "2026-08"
 12300	tumbling narrow smelly selling shorts	0		Stench Spell Damage: +10, Last Available: "2026-08"
 12301	jittery bear tattoo	0		Last Available: "2026-08"
-12302	skewed yellow bull tattoo	0		Last Available: "2026-08"
+12302	yellow skewed bull tattoo	0		Last Available: "2026-08"
 12303	razor-sharp 401k ring of the businessman	0		Weapon Damage Percent: +25, Meat Drop: +50, Last Available: "2026-08"
 12304	balance sheet	0		Last Available: "2026-08"
 12305	vacuum-sealed double-enhanced tumbling invisible hand	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 31, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Packrat_cafe_booze.txt
@@ -8,26 +8,26 @@
 -17	mediocre irresponsibly strong wobbly moons-shine	9	decent	
 -18	bad watered-down gin	2	decent	
 -19	mediocre ecto-nog	4	decent	
--20	triple-distilled tolerable hot toady	8	good	
--21	lousy high-proof hot choculate	7	decent	
+-20	tolerable triple-distilled hot toady	8	good	
+-21	high-proof lousy hot choculate	7	decent	
 -49	mediocre practically non-alcoholic maroon Cyder	1	decent	
 -50	artisanal Oil Nog	3	EPIC	
 -51	practically non-alcoholic aged Hi-Octane Peppermint Jet Fuel	1	awesome	
--58	extra-dry mediocre Grimacider	5	decent	
--59	acceptable enchanted Isotope Nog	3	good	
+-58	mediocre extra-dry Grimacider	5	decent	
+-59	enchanted acceptable Isotope Nog	3	good	
 -60	lousy blurry Mutagin 'n' Tonic	3	decent	
 -70	artisanal Gin and Herring	3	EPIC	
 -71	artisanal practically non-alcoholic Black and Tan and Red All Over	1	EPIC	
 -72	drinkable Antarctic Ice Tea	3	good	
 -76	bad red CRIMBCO Ribbon Candy Schnapps	4	decent	
 -77	tolerable weak blinking CRIMBCO Egg Substitute Nog Substitute	2	good	
--78	artisanal boozy teal CRIMBCO Extreme Braincracker Sour	5	EPIC	
+-78	boozy artisanal teal CRIMBCO Extreme Braincracker Sour	5	EPIC	
 -82	aged distilled blurry Horseradish-infused Vodka	5	awesome	
 -83	delicious bouncing Jerkitini	4	awesome	
--84	weak hand-crafted Desert Island Iced Tea	2	EPIC	
--88	practically non-alcoholic bad Crimbo Saketini	1	decent	
+-84	hand-crafted weak Desert Island Iced Tea	2	EPIC	
+-88	bad practically non-alcoholic Crimbo Saketini	1	decent	
 -89	tolerable Crimboku Drop	4	good	
--90	acceptable high-proof blurry blurry Flaming Crimbo Log	9	good	
--107	watered-down tolerable twirling Fortified Eggnog Slurry	2	good	
+-90	high-proof acceptable blurry blurry Flaming Crimbo Log	9	good	
+-107	tolerable watered-down twirling Fortified Eggnog Slurry	2	good	
 -108	mediocre Hot Buttered Rum	3	decent	
 -109	aged wobbly Spicy Hot Chocolate	3	awesome	

--- a/data/TCRS/TCRS_Seal_Clubber_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Packrat_cafe_food.txt
@@ -5,20 +5,20 @@
 -8	flavorless candy cane pizza	3	decent	
 -9	toothsome gray gingerbread stir-fry	3	awesome	
 -10	miniature enchanted toothsome twigs and gravel	2	awesome	
--11	fancy bland shoots and leaves	3	decent	
+-11	bland fancy shoots and leaves	3	decent	
 -12	bland bowl of unidentifiable goo	3	decent	
 -13	decent thick narrow gingerbread massacre	5	good	
 -14	spoiled It Came From Beyond Dessert	3	crappy	
--15	normal super-sized vampire cake	5	good	
--52	tasty snack-sized Soylent Red and Green	2	awesome	
+-15	super-sized normal vampire cake	5	good	
+-52	snack-sized tasty Soylent Red and Green	2	awesome	
 -53	rotten Disc-Shaped Nutrition Unit	3	crappy	
 -54	moldy small Gingerborg Hive	2	crappy	
 -61	yummy Candy Cane Surprise	3	awesome	
 -62	decent tiny Grimdrop Chow Mein	1	good	
 -63	spoiled blinking Grimgerbread House	4	crappy	
--67	snack-sized rotten Caviar Carbonara	2	crappy	
+-67	rotten snack-sized Caviar Carbonara	2	crappy	
 -68	tiny flavorless tumbling Halibut Alfredo	1	decent	
--69	bland tiny twirling Red Herring Velvet Cake	1	decent	
+-69	tiny bland twirling Red Herring Velvet Cake	1	decent	
 -73	low-calorie moldy CRIMBCO Reconstituted Gruel	1	crappy	
 -74	moldy New and Improved CRIMBCO Reconstituted Gruel	4	crappy	
 -75	yummy CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	awesome	
@@ -26,20 +26,20 @@
 -80	bland half-sized ghostly Carrot, Cabbage, and Kale Pizza	2	decent	
 -81	normal upside-down Turnip and Rutabaga Pie	4	good	
 -85	moldy Rainbow Spider Fun Roll	4	crappy	
--86	bland thick Vegas Volcano Lava Roll	5	decent	
+-86	thick bland Vegas Volcano Lava Roll	5	decent	
 -87	normal gigantic Crazy Dragon Shogun Buddha Roll	8	good	
 -92	yummy bouncing basic hot dog	4	awesome	
 -93	flavorless teal savage macho dog	4	decent	
--94	half-sized bland shaking one with everything	2	decent	
+-94	bland half-sized shaking one with everything	2	decent	
 -95	flavorless sly dog	4	decent	
 -96	moldy devil dog	3	crappy	
--97	fancy snack-sized flavorless chilly dog	2	decent	
+-97	snack-sized fancy flavorless chilly dog	2	decent	
 -98	small decent ghost dog	2	good	
 -99	normal tiny junkyard dog	1	good	
 -100	normal wet dog	4	good	
 -101	spoiled teal sleeping dog	3	crappy	
--102	adequate big blinking optimal dog	5	good	
--103	moldy snack-sized video games hot dog	2	crappy	
+-102	big adequate blinking optimal dog	5	good	
+-103	snack-sized moldy video games hot dog	2	crappy	
 -104	massive rotten Peppermint Nutrition Block	7	crappy	
 -105	moldy Gingerbread Nutrition Block	4	crappy	
--106	massive stale Cinnamon Nutrition Block	8	decent	
+-106	stale massive Cinnamon Nutrition Block	8	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Platypus.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Platypus.txt
@@ -1,4 +1,4 @@
-1	wobbly huge seal-clubbing club	0		
+1	huge wobbly seal-clubbing club	0		
 2	seal tooth	0		
 3	steel-toed helmet turtle	0		Damage Reduction: 9, Familiar Effect: "atk, cap 2"
 4	turtle totem	0		
@@ -18,10 +18,10 @@
 19	chaotic asparagus knife	0		Spell Critical Percent: +10
 20	bouncing shaking Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
-22	pulsating blurry studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
+22	blurry pulsating studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
 24	ten-leaf clover	0		
-25	maroon squat meat paste	0		
+25	squat maroon meat paste	0		
 26	wobbly Dolphin King's map	0		
 27	spider web	0		
 28	squat really spider web	0		
@@ -40,7 +40,7 @@
 41	aged ice-cold Sir Schlitz	3	awesome	
 42	red hermit permit	0		
 43	green worthless trinket	0		
-44	huge bouncing worthless gewgaw	0		
+44	bouncing huge worthless gewgaw	0		
 45	lime green worthless knick-knack	0		
 46	figurine	0		
 47	moldy hot buttered roll	4	crappy	
@@ -113,7 +113,7 @@
 114	bouncing Oprah's dripping meat staff	0		Maximum MP Percent: +50
 115	cyan dripping meat crossbow of the overflowing toilet	0		Stench Spell Damage: +50
 116	bouncing steel-toed Bugfinder Blade of horror	0		Damage Reduction: 9, Spooky Spell Damage: +25
-117	upside-down huge Gnollish plunger	0		
+117	huge upside-down Gnollish plunger	0		
 118	spring	0		
 119	sprocket	0		
 120	cog	0		
@@ -171,7 +171,7 @@
 172	twirling gnoll lips	0		
 173	squat squat taco shell	0		
 174	Gnollish casserole dish	0		
-175	thick decent mirror uncooked chorizo	5	good	
+175	decent thick mirror uncooked chorizo	5	good	
 176	disembodied brain	0		
 177	green brainy skull	0		
 178	detective skull	0		
@@ -196,8 +196,8 @@
 198	rat appendix	0		
 199	shaking Usain Bolt's ring	0		Initiative: +80
 200	moldy rat appendix kabob	4	crappy	
-201	moldy small bat wing kabob	2	crappy	
-202	decent super-sized carob chunks	5	good	
+201	small moldy bat wing kabob	2	crappy	
+202	super-sized decent carob chunks	5	good	
 203	upside-down herbs	0		
 204	adequate gigantic carob chunk cookies	9	good	
 205	secret blend of herbs and spices	0		
@@ -210,12 +210,12 @@
 212	windchimes	0		
 213	shaking stiffened boxer's filthy corduroys	0		Muscle Percent: +10, Damage Reduction: 1, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	upside-down hardy filthy knitted dread sack	0		Maximum HP: +50, Familiar Effect: "1xVolley, 1xPotato, cap 15"
-215	blinking cyan Uncle Jick's Brownie Mix	0		
+215	cyan blinking Uncle Jick's Brownie Mix	0		
 216	decent carob brownies	4	good	
 217	yummy herb brownies	4	awesome	
 218	hemp string	0		
 219	wobbly necklace chain	0		
-220	fuchsia ghostly gnoll teeth	0		
+220	ghostly fuchsia gnoll teeth	0		
 221	toasty gnoll-tooth necklace	0		Hot Damage: +5
 222	phat turquoise bead	0		
 223	phat turquoise bracelet of incineration	0		Hot Spell Damage: +50
@@ -244,10 +244,10 @@
 246	moldy tomato	3	crappy	
 247	cyan fermenting powder	0		
 248	perfectly mixed wobbly salty dog	3	EPIC	
-249	practically non-alcoholic bad bloody mary	1	decent	
+249	bad practically non-alcoholic bloody mary	1	decent	
 250	lousy wobbly screwdriver	4	decent	
-251	lousy watered-down martini	2	decent	
-252	mediocre pulsating narrow green bloody beer	3	decent	
+251	watered-down lousy martini	2	decent	
+252	mediocre green narrow pulsating bloody beer	3	decent	
 253	hand-crafted jittery shot of schnapps	4	EPIC	
 254	artisanal shot of grapefruit schnapps	3	EPIC	
 255	hand-crafted fine wine	3	EPIC	
@@ -256,10 +256,10 @@
 258	dense meat stack	0		
 259	snake skin	0		
 260	bland White Citadel fries	3	decent	
-261	spoiled massive jittery narrow White Citadel burger	10	crappy	
+261	massive spoiled jittery narrow White Citadel burger	10	crappy	
 262	huge yummy piece of wedding cake	10	awesome	
 263	stale wobbly chocolate chips	3	decent	
-264	stale miniature chocolate chip cookies	2	decent	
+264	miniature stale chocolate chip cookies	2	decent	
 265	ghostly satin pants of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, 2xPotato, cap 10"
 266	mediocre yellow lightning	3	decent	
 267	mullet wig of the storm	0		Maximum MP Percent: +40, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -267,7 +267,7 @@
 269	friendly sword	0		Familiar Weight: +3
 270	picket fence	0		
 271	vaporized spinning barbell	1		
-272	pickled shaking fuchsia concentrated magicalness pill	1		
+272	pickled fuchsia shaking concentrated magicalness pill	1		
 273	modified moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
@@ -292,14 +292,14 @@
 294	huge savvy pail	0		Mysticality Percent: +20, Familiar Effect: "2xFairy, cap 7"
 295	Jim Carey's demonskin trousers	0		Monster Level: +25, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	mirror green shellacked dungeoneer's dungarees	0		Damage Reduction: 7, Familiar Effect: "stench atk, 4xPotato, cap 7"
-297	dry nitrogenated pulsating wobbly tamarind-flavored chewing gum	0		Effect: "Man's Worst Enemy", Effect Duration: 31
+297	dry nitrogenated wobbly pulsating tamarind-flavored chewing gum	0		Effect: "Man's Worst Enemy", Effect Duration: 31
 298	quantum huge blinking lime-and-chile-flavored chewing gum	0		Effect: "Happy Trails", Effect Duration: 46
 299	double-cold-filtered concentrated olive pickle-flavored chewing gum	0		Effect: "Extra Backbone", Effect Duration: 51
 300	unsweetened jaba&ntilde;ero-flavored chewing gum	0		Effect: "Cold Throat", Effect Duration: 63
 301	flat dough	0		
 302	bland Knob sausage	4	decent	
 303	tasty Knob mushroom	4	awesome	
-304	jittery blinking dry noodles	0		
+304	blinking jittery dry noodles	0		
 305	Annie Oakley's Knob Goblin harem pants	0		Critical Hit Percent: +20, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	experienced Knob Goblin harem veil	0		Experience: +2, Familiar Effect: "5xLep, cap 2"
 307	ionized tarnished Knob Goblin perfume	0		Effect: "Sugar, Hello", Effect Duration: 66
@@ -315,8 +315,8 @@
 317	decent bean burrito	3	good	
 318	half-sized toothsome bean burrito	2	awesome	
 319	bland green insanely bean burrito	3	decent	
-320	huge yummy bat haggis	6	awesome	
-321	jumbo spoiled menudo	5	crappy	
+320	yummy huge bat haggis	6	awesome	
+321	spoiled jumbo menudo	5	crappy	
 322	gigantic stale goat cheese	8	decent	
 323	thick normal plain pizza	5	good	
 324	spoiled immense sausage pizza	7	crappy	
@@ -326,9 +326,9 @@
 328	tolerable bottle of whiskey	3	good	
 329	slick goat beard	0		Moxie: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	pulsating glass of goat's milk	1	decent	
-331	watered-down lousy fancy Canadian	2	decent	Effect: "Inebriate Pride", Effect Duration: 25
-332	enchanted flavorless green lemon	3	decent	Effect: "Gingerbread Robust", Effect Duration: 10
-333	adequate big lime	5	good	
+331	lousy fancy watered-down Canadian	2	decent	Effect: "Inebriate Pride", Effect Duration: 25
+332	flavorless enchanted green lemon	3	decent	Effect: "Gingerbread Robust", Effect Duration: 10
+333	big adequate lime	5	good	
 334	sabre teeth of the businessman	0		Meat Drop: +50
 335	mirror sabre-toothed lime cub	0		
 336	consolation ribbon of Leguizamo	0		Monster Level: +20
@@ -363,14 +363,14 @@
 365	mirror blurry chrome ore	0		
 366	linoleum sword hilt	0		
 367	linoleum stick	0		
-368	tumbling teal linoleum crossbow string	0		
+368	teal tumbling linoleum crossbow string	0		
 369	asbestos sword hilt	0		
 370	asbestos stick	0		
 371	asbestos crossbow string	0		
 372	skewed chrome sword hilt	0		
 373	chrome stick	0		
 374	chrome crossbow string	0		
-375	gray upside-down linoleum meat stack	0		
+375	upside-down gray linoleum meat stack	0		
 376	asbestos meat stack	0		
 377	chrome meat stack	0		
 378	linoleum sword of Calamity Jane of the brazier	0		Critical Hit Percent: +15, Hot Spell Damage: +25
@@ -451,7 +451,7 @@
 453	teal sober pill	0		
 454	screwdriver	0		
 455	toothsome big maroon jumbo olive	5	awesome	
-456	perfectly mixed weak ghostly jittery dry martini	2	EPIC	
+456	weak perfectly mixed jittery ghostly dry martini	2	EPIC	
 457	tumbling mirror Fonzie's ye olde golde frontes	0		Experience (Moxie): +1, Class: "Disco Bandit", Single Equip
 458	blue continuum transfunctioner	0		
 459	skewed pixel	0		
@@ -461,7 +461,7 @@
 463	gray pixel	0		
 464	pixel potion	0		
 465	pixel potion	0		
-466	shaking red pixel potion	0		
+466	red shaking pixel potion	0		
 467	toothsome miniature pixel pie	2	awesome	
 468	ruby W	0		
 469	wussiness potion	0		
@@ -490,7 +490,7 @@
 492	smelly nippy chaps	0		Cold Damage: +10, Stench Spell Damage: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	mirror ketchup hound	0		
 494	bouncing brainy batblade	0		Mysticality: +5
-495	ghostly wobbly catgut	0		
+495	wobbly ghostly catgut	0		
 496	cat appendix	0		
 497	spinning gnatwing	0		
 498	stale papaya	3	decent	
@@ -524,7 +524,7 @@
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	twirling blood-faced volleyball	0		
-529	upside-down maroon fertilized ghuol egg	0		
+529	maroon upside-down fertilized ghuol egg	0		
 530	quadruple-cold-filtered deionized spray paint	0		Effect: "Sensation", Effect Duration: 39
 531	skewed upside-down medical-grade special sauce glove	0		HP Regen Min: 7, HP Regen Max: 10, Class: "Sauceror", Single Equip
 532	ghostly wizardly ladle of mystery	0		Mysticality: +25, Class: "Sauceror"
@@ -540,10 +540,10 @@
 542	hardy 1337 7r0uZ0RZ of terror	0		Maximum HP: +50, Spooky Spell Damage: +10, Familiar Effect: "2xPotato, cap 27"
 543	flavorless Trollhouse cookies	4	decent	
 544	spinning bouncing ribald crafty talons	0		Maximum MP: +10, Sleaze Damage: +10
-545	stale small Spam Witch sammich	2	decent	
+545	small stale Spam Witch sammich	2	decent	
 546	narrow meat vortex	0		
 547	bouncing 334 scroll	0		
-548	huge wobbly 668 scroll	0		
+548	wobbly huge 668 scroll	0		
 549	30669 scroll	0		
 550	33398 scroll	0		
 551	shaking 64067 scroll	0		
@@ -552,10 +552,10 @@
 554	rotten pr0n cocktail	3	crappy	
 555	tumbling shaking lightning-fast smartaleck's drywall axe	0		Moxie Percent: +30, Initiative: +40
 556	boxer's Pine-Fresh air freshener	0		Muscle Percent: +10
-557	distilled acceptable ghostly whiskey and cola	5	good	
-558	special spoiled huge papaya taco	3	crappy	Effect: "Red Around the Gills", Effect Duration: 45
+557	acceptable distilled ghostly whiskey and cola	5	good	
+558	spoiled special huge papaya taco	3	crappy	Effect: "Red Around the Gills", Effect Duration: 45
 559	razor-sharp can lid	0		
-560	normal fancy stalk of asparagus	4	good	Effect: "Hairy Palms", Effect Duration: 5
+560	fancy normal stalk of asparagus	4	good	Effect: "Hairy Palms", Effect Duration: 5
 561	pregnant mushroom	0		
 562	teal ratgut	0		
 563	blinking sonar-in-a-biscuit	0		
@@ -563,12 +563,12 @@
 565	hobo gloves of the businessman	0		Meat Drop: +50, Single Equip
 566	beefcake's bum cheek	0		Muscle: +25, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	upside-down hermit script	0		
-568	tasty immense Double Bacon Beelzeburger	8	awesome	
+568	immense tasty Double Bacon Beelzeburger	8	awesome	
 569	moldy yellow Lord of the Flies-sized fries	4	crappy	
-570	small rotten maroon squat Chicken Sandwich	2	crappy	
+570	rotten small squat maroon Chicken Sandwich	2	crappy	
 571	Jumbo Dr. Lucifer	1	good	
 572	rotten Children's Meal of the Damned	3	crappy	
-573	snack-sized bland noodles	2	decent	
+573	bland snack-sized noodles	2	decent	
 574	delicious noodles	3	awesome	
 575	tiny decent painful penne pasta	1	good	
 576	super-sized stale ravioli della hippy	5	decent	
@@ -584,7 +584,7 @@
 586	sizzling medical-grade ridiculously huge sword	0		Hot Damage: +10, HP Regen Min: 7, HP Regen Max: 10
 587	quadruple-vacuum-sealed deionized super-spiky hair gel	0		Effect: "You're Not Cooking", Effect Duration: 16
 588	soft echo eyedrop antidote	0		
-589	toothsome small cocoa eggshell fragment	2	awesome	
+589	small toothsome cocoa eggshell fragment	2	awesome	
 590	rotten cocoa eggshell fragment	4	crappy	
 591	blue cocoa egg	0		
 592	house	0		
@@ -604,7 +604,7 @@
 606	Tin Foil Immateria	0		
 607	Gauze Immateria	0		
 608	shaking Plastic Wrap Immateria	0		
-609	red mirror S.O.C.K.	0		
+609	mirror red S.O.C.K.	0		
 610	blurry procrastination potion	0		
 611	twirling D	0		
 612	original G	0		
@@ -617,7 +617,7 @@
 619	Da Vinci's needle	0		Experience (Mysticality): +5
 620	electrified thin candle	0		Effect: "Eagle Eyes", Effect Duration: 58
 621	Warm Subject gift certificate	0		
-622	narrow huge awful poetry journal	0		
+622	huge narrow awful poetry journal	0		
 623	WA	0		
 624	jittery NG	0		
 625	ghostly wang	0		
@@ -635,13 +635,13 @@
 637	toaster	0		
 638	supercharged asshat of James Dean	0		Experience (Moxie): +3, Maximum MP Percent: +30, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	thick flavorless abominable snowcone	5	decent	
-640	special maroon skewed narrow jittery Ent cider	1	crappy	Effect: "Aspect of the Twinklefairy", Effect Duration: 15
-641	miniature bland toast	2	decent	
+640	special narrow maroon jittery skewed Ent cider	1	crappy	Effect: "Aspect of the Twinklefairy", Effect Duration: 15
+641	bland miniature toast	2	decent	
 642	tumbling skeleton key	0		
 643	narrow skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	huge wrapping paper	0		Last Available: "2003-12"
-646	bland snack-sized twirling fruitcake	2	decent	
+646	snack-sized bland twirling fruitcake	2	decent	
 647	present	0		Last Available: "2004-11"
 648	smelly Crimbo sword	0		Stench Spell Damage: +10, Last Available: "2004-10"
 649	lime green Annie Oakley's Crimbo hat	0		Critical Hit Percent: +20, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
@@ -660,7 +660,7 @@
 662	tumbling star buckler of the brute	0		Muscle Percent: +30, Damage Reduction: 10
 663	star throwing star	0		
 664	red star starfish	0		
-665	shaking spinning Richard's star key	0		
+665	spinning shaking Richard's star key	0		
 666	twirling aromatic asbestos-lined slick steaming evil	0		Moxie: +10, Hot Resistance: +5, Stench Resistance: +1
 667	castle map	0		
 668	spiked femur of the overflowing toilet	0		Stench Spell Damage: +50
@@ -668,7 +668,7 @@
 670	miser's lihc face	0		Meat Drop: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	flame-wreathed personal trainer's grave robbing shovel	0		Experience Percent (Muscle): +10, Hot Spell Damage: +10
 672	gigantic normal cranberries	8	good	
-673	mediocre watered-down vodka and cranberry	2	decent	
+673	watered-down mediocre vodka and cranberry	2	decent	
 674	fortified aged red whiskey	5	awesome	
 675	mirror deadly skull of the Bonerdagon	0		Weapon Damage: +5
 676	dragonbone belt buckle	0		
@@ -676,10 +676,10 @@
 678	shaking chest of the Bonerdagon	0		
 679	tolerable roll in the hay	4	good	
 680	weak lousy slap and tickle	2	decent	
-681	bad practically non-alcoholic slip 'n' slide	1	decent	
+681	practically non-alcoholic bad slip 'n' slide	1	decent	
 682	artisanal a sump'm sump'm	3	EPIC	
 683	artisanal horizontal tango	3	EPIC	
-684	watered-down tolerable pink pony	2	good	
+684	tolerable watered-down pink pony	2	good	
 685	horrifying veiny hardened Mr. Shirt	0		Damage Reduction: 3, Maximum HP: +10, Spooky Damage: +25
 686	wicked knuckles	0		Spell Damage: +5
 687	boiled magnetized blood of the Wereseal	0		Effect: "Badger Underfoot", Effect Duration: 46
@@ -716,12 +716,12 @@
 720	reassuring porquoise necklace of Leguizamo	0		Monster Level: +20, Spooky Resistance: +1, Single Equip
 721	up-at-dawn porquoise bracelet of the brute	0		Muscle Percent: +30, Adventures: +5
 722	Jeselnik's arcane researcher's porquoise ring of the blizzard	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +25, Sleaze Damage: +25, Single Equip
-723	bland gigantic Knoll mushroom	10	decent	
+723	gigantic bland Knoll mushroom	10	decent	
 724	rotten mushroom	3	crappy	
 725	one million meat pancakes	0		
 726	MacGyver's huge mirror shard	0		Maximum MP: +100
 727	blinking hedge maze puzzle	0		
-728	green tumbling squat hedge maze key	0		
+728	squat green tumbling hedge maze key	0		
 729	fishbowl	0		
 730	fishtank	0		
 731	fish hose	0		
@@ -741,14 +741,14 @@
 746	stat script	0		
 747	tumbling Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	immense decent warm mushroom	8	good	
+749	decent immense warm mushroom	8	good	
 750	moldy tumbling mushroom quesadilla	3	crappy	
 751	spoiled cool mushroom	4	crappy	
 752	tiny normal cool mushroom casserole	1	good	
 753	yummy skewed ghostly pointy mushroom	3	awesome	
 754	adequate narrow cream of pointy mushroom soup	3	good	
 755	flavorless mushroom	3	decent	
-756	half-sized flavorless mushroom	2	decent	
+756	flavorless half-sized mushroom	2	decent	
 757	adequate super-sized mushroom	5	good	
 758	flavorless half-sized ghost cucumber	2	decent	
 759	dill	0		
@@ -779,10 +779,10 @@
 784	watered-down tolerable blurry Acqua Del Piatto Merlot	2	good	Last Available: "2004-10"
 785	raffle ticket	0		
 786	decent jittery strawberry	3	good	
-787	practically non-alcoholic aged bottle of rum	1	awesome	
+787	aged practically non-alcoholic bottle of rum	1	awesome	
 788	mediocre strawberry daiquiri	4	decent	
 789	artisanal rum and cola	3	EPIC	
-790	weak aged narrow grog	2	awesome	
+790	aged weak narrow grog	2	awesome	
 791	beefy Mafia bow tie of extreme caution	0		Muscle: +10, Monster Level: -25, Last Available: "2004-10"
 792	blurry electrified Golden Mr. Accessory	0		MP Regen Min: 3, MP Regen Max: 5, Softcore Only
 793	improved olive oil of stability	0		Effect: "Gunky Dory", Effect Duration: 57
@@ -792,21 +792,21 @@
 797	perfectly mixed rockin' wagon	3	EPIC	
 798	acceptable ocean motion	4	good	
 799	watered-down artisanal fuzzbump	2	EPIC	
-800	small decent poutine	2	good	
+800	decent small poutine	2	good	
 801	spoiled Knob stir-fry	3	crappy	
-804	diet tasty ghostly Knoll stir-fry	1	awesome	
+804	tasty diet ghostly Knoll stir-fry	1	awesome	
 805	adequate green stir-fry	3	good	
-806	thick bland asparagus stir-fry	5	decent	
-807	low-calorie fancy toothsome olive stir-fry	1	awesome	Effect: "Super Skill", Effect Duration: 45
-808	adequate special Knob sausage stir-fry	4	good	Effect: "The Power of Negative Thinking", Effect Duration: 10
+806	bland thick asparagus stir-fry	5	decent	
+807	fancy toothsome low-calorie olive stir-fry	1	awesome	Effect: "Super Skill", Effect Duration: 45
+808	special adequate Knob sausage stir-fry	4	good	Effect: "The Power of Negative Thinking", Effect Duration: 10
 809	flavorless skewed bat wing stir-fry	4	decent	
 810	stale rat appendix stir-fry	3	decent	
 811	spoiled tofu stir-fry	3	crappy	
 812	adequate wobbly pr0n stir-fry	4	good	
-813	tiny rotten fancy Knob shells	1	crappy	Effect: "Cold Hard Skin", Effect Duration: 45
-814	rotten special snack-sized teal b&auml;tzle	2	crappy	Effect: "Spooky Flavor", Effect Duration: 10
+813	rotten tiny fancy Knob shells	1	crappy	Effect: "Cold Hard Skin", Effect Duration: 45
+814	special snack-sized rotten teal b&auml;tzle	2	crappy	Effect: "Spooky Flavor", Effect Duration: 10
 815	bite-sized toothsome fancy gray ratini	1	awesome	Effect: "Thaumodynamic", Effect Duration: 35
-816	stale bite-sized squat maroon Knob stroganoff	1	decent	
+816	stale bite-sized maroon squat Knob stroganoff	1	decent	
 817	normal menudo ravioli	4	good	
 818	ghostly plus sign	0		
 819	milky potion	0		
@@ -845,8 +845,8 @@
 853	blundarrrbus	0		Familiar Weight: +5
 854	sucky decal	0		Familiar Weight: +5
 855	squat balloon knife	0		Familiar Weight: +5
-856	narrow blurry lime green shaking shock collar	0		
-857	bouncing tumbling moonglasses	0		
+856	shaking blurry lime green narrow shock collar	0		
+857	tumbling bouncing moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
@@ -867,7 +867,7 @@
 876	huge Usain Bolt's foul-smelling medical-grade incredibly dense meat gem	0		Stench Damage: +10, Initiative: +80, HP Regen Min: 7, HP Regen Max: 10
 877	ribald Talisman of Baio	0		Sleaze Damage: +10
 878	narrow deadly hypnodisk	0		Weapon Damage: +5
-879	triple-cold-filtered tumbling huge bottle of goofballs	0		Effect: "Tenacity of the Snapper", Effect Duration: 34
+879	triple-cold-filtered huge tumbling bottle of goofballs	0		Effect: "Tenacity of the Snapper", Effect Duration: 34
 880	MacGyver's disbelief suspenders	0		Maximum MP: +100
 881	asbestos-lined supportive bra	0		Hot Resistance: +5
 882	spinning Blatantly Canadian	0		
@@ -882,7 +882,7 @@
 891	Samson's Warehouse 23 bling	0		Experience (Muscle): +5
 892	knitted MacGyver's sage bugbear-smiting sword	0		Mysticality Percent: +10, Maximum MP: +100, Cold Resistance: +3
 893	distilled aged lumbering jack	5	awesome	
-894	bouncing cyan Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
+894	cyan bouncing Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	bouncing asbestos-lined Ms. Accessory	0		Hot Resistance: +5, Softcore Only
 896	Tesla Mr. Accessory Jr. of chilblains	0		Cold Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
@@ -898,7 +898,7 @@
 907	double-corrupted ionized red Mr. Mediocrebar	0		Effect: "Rain Dancin'", Effect Duration: 59
 908	denatured Cold Hots candy	0		Effect: "Okee-Dokee Computer", Effect Duration: 54
 909	frozen blinking Wint-O-Fresh mint	0		Effect: "Clyde's Blessing", Effect Duration: 29
-910	snack-sized moldy tumbling dwarf bread	2	crappy	
+910	moldy snack-sized tumbling dwarf bread	2	crappy	
 911	modified flattened Senior Mints	0		Effect: "Mariachi Mood", Effect Duration: 34
 912	extra-alkaline altered jittery pixellated candy heart	0		Effect: "Ponderous Potency", Effect Duration: 43
 913	chilled anodized kobold	0		Effect: "Mushroom Might", Effect Duration: 34
@@ -918,10 +918,10 @@
 927	artisanal practically non-alcoholic Ferita Del Petto Zinfandel	1	super ultra mega turbo EPIC	Last Available: "2006-12"
 928	inspector's fuzzy bracelets	0		Item Drop: +15
 929	Jack Frost's arse-shooting crossbow	0		Cold Spell Damage: +50
-931	practically non-alcoholic artisanal spiced rum	1	EPIC	
+931	artisanal practically non-alcoholic spiced rum	1	EPIC	
 932	lousy bouncing eggnog	3	decent	
 933	fancy stale olive candy cane	3	decent	Effect: "All Glory To the Toad", Effect Duration: 20
-934	stale jumbo mirror gingerbread bugbear	5	decent	
+934	jumbo stale mirror gingerbread bugbear	5	decent	
 935	manspreader's imitation nice watch	0		Monster Level: +10, Single Equip, Last Available: "2004-12"
 936	spinning Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -934,9 +934,9 @@
 944	bowlegged pants of Gandalf	0		Spell Critical Percent: +20, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
-947	teal ghostly skewered cherry	0		Last Available: "2004-12"
+947	ghostly teal skewered cherry	0		Last Available: "2004-12"
 948	artisanal martini	3	super ultra EPIC	Last Available: "2004-12"
-949	extra-dry drinkable blurry grogtini	5	good	Last Available: "2004-12"
+949	drinkable extra-dry blurry grogtini	5	good	Last Available: "2004-12"
 950	strong bad cherry bomb	5	decent	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	censurious hockey mask of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
@@ -944,12 +944,12 @@
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	fez of etymology of the ox	0		Muscle: +20, Familiar Effect: "1xLep, cap 30"
 956	adequate carob chunk noodles	3	good	
-957	toothsome big tumbling chorizo brownies	5	awesome	
+957	big toothsome tumbling chorizo brownies	5	awesome	
 958	flavorless half-sized chocolate and tomato pizza	2	decent	
 959	wobbly flange	0		
-960	shaking jittery clockwork key	0		
+960	jittery shaking clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
-962	skewed purple velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
+962	purple skewed velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	squat dance instructor's plastic seal clubber of extreme caution	0		Experience Percent (Moxie): +10, Monster Level: -25
 964	pulsating lard-coated nasty plastic turtle tamer	0		Stench Damage: +5, Sleaze Spell Damage: +25
 965	sage wizardly plastic pastamancer	0		Mysticality: +25, Mysticality Percent: +10
@@ -990,20 +990,20 @@
 1003	soda water	0		
 1004	perfectly mixed high-proof bottle of tequila	9	EPIC	
 1005	drinkable boxed wine	4	good	
-1006	tasty enchanted bouncing cherry	3	awesome	Effect: "Sparkly!", Effect Duration: 15
+1006	enchanted tasty bouncing cherry	3	awesome	Effect: "Sparkly!", Effect Duration: 15
 1007	huge sage coconut shell	0		Mysticality Percent: +10, Familiar Effect: "1xFairy, cap 7"
 1008	ice cubes of the empath	0		Familiar Weight: +5
-1009	tolerable fancy vodka martini	3	good	Effect: "Fratty Flavor", Effect Duration: 45
+1009	fancy tolerable vodka martini	3	good	Effect: "Fratty Flavor", Effect Duration: 45
 1010	lousy weak whiskey and soda	2	decent	
 1011	acceptable monkey wrench	3	good	
 1012	hand-crafted tequila sunrise	4	EPIC	
-1013	delicious high-proof squat margarita	7	awesome	
-1014	practically non-alcoholic acceptable strawberry wine	1	good	
+1013	high-proof delicious squat margarita	7	awesome	
+1014	acceptable practically non-alcoholic strawberry wine	1	good	
 1015	drinkable wine spritzer	3	good	
-1016	lousy practically non-alcoholic perpendicular hula	1	decent	
+1016	practically non-alcoholic lousy perpendicular hula	1	decent	
 1017	weak hand-crafted ducha de oro	2	EPIC	
 1018	tolerable calle de miel	3	good	
-1019	hand-crafted weak dry vodka martini	2	EPIC	
+1019	weak hand-crafted dry vodka martini	2	EPIC	
 1020	artisanal pulsating old-fashioned	3	EPIC	
 1021	tolerable tequila with training wheels	4	good	
 1022	tolerable blinking sangria	3	good	
@@ -1011,7 +1011,7 @@
 1024	tolerable practically non-alcoholic bouncing bodyslam	1	good	Last Available: "2004-12"
 1025	drinkable skewed sangria del diablo	4	good	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
-1027	huge squat whip kit	0		
+1027	squat huge whip kit	0		
 1028	wobbly blue buckler buckle	0		
 1029	jittery purple Sherlock's hippo whip	0		Item Drop: +25
 1030	penguin whip of the boozehound	0		Booze Drop: +100
@@ -1032,12 +1032,12 @@
 1046	greasy resourceful traffic cone	0		Maximum MP: +50, Sleaze Spell Damage: +10, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	watered-down bad N. O. Beer	2	decent	
 1048	distilled maroon oyster egg	1		Effect: "Slimily Speedy", Effect Duration: 30
-1049	dehydrated skewed squat skewed oyster egg	1		
+1049	dehydrated squat skewed skewed oyster egg	1		
 1050	twisted oyster egg	1		
 1051	yellow plastic oyster egg	0		
 1052	pickled teal mirror oyster egg	1		Effect: "Optimist Primal", Effect Duration: 45
 1053	diluted ghostly oyster egg	1		Effect: "Sticky Hands", Effect Duration: 30
-1054	dried green spinning oyster egg	1		
+1054	dried spinning green oyster egg	1		
 1055	squat plastic oyster egg	0		
 1056	mixed fuchsia puce oyster egg	1		
 1057	vaporized puce oyster egg	1		
@@ -1055,8 +1055,8 @@
 1069	boiled spinning oyster egg	1		
 1070	modified oyster egg	1		
 1071	blurry plastic oyster egg	0		
-1072	twisted tumbling wobbly purple narrow off-white oyster egg	1		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 45
-1073	compressed maroon squat wobbly off-white oyster egg	1		
+1072	twisted tumbling purple narrow wobbly off-white oyster egg	1		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 45
+1073	compressed maroon wobbly squat off-white oyster egg	1		
 1074	twisted off-white oyster egg	1		
 1075	spinning off-white plastic oyster egg	0		
 1076	dehydrated tumbling blue oyster egg	1		Effect: "Weasels Underfoot", Effect Duration: 30
@@ -1068,7 +1068,7 @@
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	bouncing personal raindrop	0		Free Pull, Last Available: "2005-04"
 1084	rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
-1085	upside-down shaking clockwork widget	0		
+1085	shaking upside-down clockwork widget	0		
 1086	clockwork thingamajig	0		
 1087	upside-down clockwork doohickey	0		
 1088	teal clockwork clockwise dome	0		
@@ -1101,7 +1101,7 @@
 1115	bouncing tasket	0		
 1116	annoying pitchfork	0		Monster Level: +5
 1117	ghostly tumbling shaking aromatic dog trainer's Stupid University Diploma of the pedagogue	0		Experience: +3, Experience (familiar): +1, Stench Resistance: +1
-1118	gray twirling pregnant mushroom	0		
+1118	twirling gray pregnant mushroom	0		
 1119	yellow pregnant mushroom	0		
 1120	pregnant mushroom	0		
 1121	inexplicably rock	0		
@@ -1125,23 +1125,23 @@
 1139	artisanal mushroom wine	3	EPIC	
 1140	hand-crafted watered-down purple icy mushroom wine	2	EPIC	
 1141	bad ghostly mushroom wine	3	decent	
-1142	watered-down lousy pointy mushroom wine	2	decent	
-1143	bad practically non-alcoholic wobbly skewed flat mushroom wine	1	decent	
+1142	lousy watered-down pointy mushroom wine	2	decent	
+1143	practically non-alcoholic bad wobbly skewed flat mushroom wine	1	decent	
 1144	boozy acceptable huge cool mushroom wine	5	good	
 1145	lousy knob mushroom wine	3	decent	
-1146	high-proof artisanal wobbly knoll mushroom wine	8	EPIC	
+1146	artisanal high-proof wobbly knoll mushroom wine	8	EPIC	
 1147	acceptable tumbling mushroom wine	4	good	
 1148	delicious fortified shot of flower schnapps	5	awesome	
-1149	immense flavorless skewed flower petal pie	8	decent	
+1149	flavorless immense skewed flower petal pie	8	decent	
 1150	bad watered-down bottle of single-barrel whiskey	2	decent	
 1151	smooth discarded plastic fork of doom	0		Moxie: +15, Spooky Spell Damage: +50
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	normal fancy tiny Retenez L'Herbe Pat&eacute;	1	good	Effect: "Chalked Weapon", Effect Duration: 30
+1153	tiny fancy normal Retenez L'Herbe Pat&eacute;	1	good	Effect: "Chalked Weapon", Effect Duration: 30
 1154	dehydrated bouncing Breathetastic&trade; Premium Canned Air	1	EPIC	
 1155	maroon pulsating letter from King Ralph XI	0		
 1157	blinking ghostly stylish wholeberd	0		Moxie: +25
 1158	unsweetened pickled dry Meleegra&trade; pills	0		Effect: "Wet Rub", Effect Duration: 12
-1159	twirling upside-down cyan mariachi G-string	0		
+1159	upside-down twirling cyan mariachi G-string	0		
 1160	stiffened irate sombrero	0		Damage Reduction: 1, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	pile of candy	0		
 1162	enhanced colloidal narrow handsomeness potion	0		Effect: "Comprehensively Nourished", Effect Duration: 41
@@ -1150,7 +1150,7 @@
 1165	hovering sombrero	0		
 1166	pulsating maracas	0		Familiar Weight: +5
 1167	tumbling plain brown wrapper	0		
-1168	tumbling squat less-than-three-shaped box	0		
+1168	squat tumbling less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	jittery coffin	0		
@@ -1187,18 +1187,18 @@
 1202	tiny adequate skewed Happy Birthday, Claude! cake	1	good	
 1203	bland personalized birthday cake	3	decent	
 1204	normal super-sized three-tiered wedding cake	5	good	
-1205	half-sized decent squat red babycakes	2	good	
-1206	bland massive velvet cake	9	decent	
+1205	decent half-sized red squat babycakes	2	good	
+1206	massive bland velvet cake	9	decent	
 1207	gigantic moldy twirling congratulatory cake	6	crappy	
-1208	special adequate angel-food cake	3	good	Effect: "Creepin' Up on You", Effect Duration: 50
+1208	adequate special angel-food cake	3	good	Effect: "Creepin' Up on You", Effect Duration: 50
 1209	spoiled devil's-food cake	4	crappy	
-1210	half-sized adequate tumbling birthday party jellybean cheesecake	2	good	
+1210	adequate half-sized tumbling birthday party jellybean cheesecake	2	good	
 1211	balloon	0		
 1212	bouncing balloon	0		
 1213	heart-shaped balloon	0		
 1214	mirror anniversary balloon	0		
 1215	Mylar balloon	0		
-1216	blue spinning Kevlar balloon	0		
+1216	spinning blue Kevlar balloon	0		
 1217	thought balloon	0		
 1218	rat head balloon	0		Familiar Weight: -3
 1219	mini-zeppelin	0		
@@ -1236,9 +1236,9 @@
 1252	flavorless shroomkabob	3	decent	
 1253	ghostly lime green pile of jumping beans	0		
 1254	stale jumping bean burrito	3	decent	
-1255	miniature delicious jumping bean burrito	2	awesome	
+1255	delicious miniature jumping bean burrito	2	awesome	
 1256	tiny delicious skewed insanely jumping bean burrito	1	awesome	
-1257	moldy gigantic fuchsia rat scrapple	10	crappy	
+1257	gigantic moldy fuchsia rat scrapple	10	crappy	
 1258	pail of pretentious paint	0		
 1259	Da Vinci's savvy traffic cone	0		Mysticality Percent: +20, Experience (Mysticality): +5, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	fuchsia wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
@@ -1273,7 +1273,7 @@
 1289	Jeselnik's gnauga hide kilt	0		Sleaze Damage: +25, Familiar Effect: "2.5xFairy, cap 20"
 1290	boiled blue wind-up clock	0		Effect: "Weasels Underfoot", Effect Duration: 29
 1291	Jekyllin hide belt of the empath	0		Familiar Weight: +5, Softcore Only, Last Available: "2005-09"
-1292	blurry pulsating skirt / kilt kit	0		
+1292	pulsating blurry skirt / kilt kit	0		
 1293	horrifying ring of adornment	0		Spooky Damage: +25
 1294	pulsating Rosewater's ring of increase damage of Leguizamo	0		Mysticality Percent: +30, Monster Level: +20
 1295	ring of gain strength of the businessman	0		Meat Drop: +50
@@ -1319,7 +1319,7 @@
 1335	Dyspepsi grenade	0		
 1336	tumbling Cloaca grenade	0		
 1338	lime green Dyspepsi-Cola d-rations	0		
-1339	ghostly yellow Cloaca-Cola c-rations	0		
+1339	yellow ghostly Cloaca-Cola c-rations	0		
 1340	narrow Cloaca-Cola-issue combat knife	0		
 1341	twirling weightlifter's Dyspepsi-Cola-issue canteen	0		Muscle: +15, Single Equip
 1342	picture of a dead guy's girlfriend	0		
@@ -1332,28 +1332,28 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	jittery hardened pinky ring	0		Damage Reduction: 3, Single Equip
-1352	high-proof drinkable maroon redrum	6	good	
+1352	drinkable high-proof maroon redrum	6	good	
 1353	shaking ninja pirate zombie robot	0		
 1354	shaking pile of pebbles	0		
 1355	tiny normal bowl of oriole's nest soup	1	good	
 1356	wobbly bunny liver	0		
-1357	perfectly mixed enchanted Mt. Noob Pale Ale	3	EPIC	Effect: "Turtle Titters", Effect Duration: 25
+1357	enchanted perfectly mixed Mt. Noob Pale Ale	3	EPIC	Effect: "Turtle Titters", Effect Duration: 25
 1358	bouncing pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
 1361	Newton's disembodied smile	0		Experience (Mysticality): +3, Single Equip
 1362	sausage	0		
 1363	jittery clockwork pirate skull	0		
-1364	tumbling huge gray rhesus monkey	0		Familiar Weight: +5
-1365	bite-sized adequate shaking tofurkey leg	1	good	
+1364	tumbling gray huge rhesus monkey	0		Familiar Weight: +5
+1365	adequate bite-sized shaking tofurkey leg	1	good	
 1366	flavorless thick tofurkey gravy	5	decent	
 1367	spoiled super-sized herbal stuffing	5	crappy	
-1368	fancy tiny flavorless can-shaped gelatinous cranberry sauce	1	decent	Effect: "Sewer-Drenched", Effect Duration: 50
-1369	moldy enchanted yams	3	crappy	Effect: "You Know When to Walk Away", Effect Duration: 20
+1368	flavorless tiny fancy can-shaped gelatinous cranberry sauce	1	decent	Effect: "Sewer-Drenched", Effect Duration: 50
+1369	enchanted moldy yams	3	crappy	Effect: "You Know When to Walk Away", Effect Duration: 20
 1370	skewed rhinestone cowboy shirt of the cheetah	0		Initiative: +60
 1371	ghostly gray energetic gingham blouse	0		Maximum MP Percent: +20
 1372	tumbling upside-down souvenir ski t-shirt of the wise owl	0		Mysticality: +20
-1373	tumbling lime green sweet nutcracker	0		Free Pull, Last Available: "2005-12"
+1373	lime green tumbling sweet nutcracker	0		Free Pull, Last Available: "2005-12"
 1374	upside-down mirror mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	cyan coward's plastic Crimbo wreath	0		Monster Level: -20, Single Equip, Last Available: "2005-12"
 1376	tumbling curative plastic Uncle Crimbo	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-12"
@@ -1377,7 +1377,7 @@
 1395	blurry teddy bear	0		Last Available: "2005-12"
 1396	squat lime green nippy groovy duck-on-a-string	0		Moxie Percent: +10, Cold Damage: +10, Last Available: "2005-12"
 1397	toy soldier	0		Last Available: "2005-12"
-1398	olive spinning doll house	0		Last Available: "2005-12"
+1398	spinning olive doll house	0		Last Available: "2005-12"
 1399	green blurry flame-retardant toy train	0		Hot Resistance: +1, Single Equip, Last Available: "2005-12"
 1400	wobbly yellow Annie Oakley's marionette	0		Critical Hit Percent: +20, Last Available: "2005-12"
 1401	sharpshooter's sock monkey	0		Critical Hit Percent: +10, Last Available: "2005-12"
@@ -1390,13 +1390,13 @@
 1408	small stale tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	mansplainer's Unionize The Elves sign	0		Monster Level: +15, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	boiled colloidal snowcone	0		Effect: "Human-Hippy Hybrid", Effect Duration: 28, Last Available: "2006-01"
 1413	vacuum-sealed blurry snowcone	0		Effect: "Stop the Presses!", Effect Duration: 26, Last Available: "2006-01"
 1414	anodized teal snowcone	0		Effect: "Vital", Effect Duration: 33, Last Available: "2006-01"
-1415	extra-diffused quantum jittery cyan snowcone	0		Effect: "A Few Extra Pounds", Effect Duration: 68, Last Available: "2006-01"
+1415	extra-diffused quantum cyan jittery snowcone	0		Effect: "A Few Extra Pounds", Effect Duration: 68, Last Available: "2006-01"
 1416	pressed upside-down shaking snowcone	0		Effect: "Protection from Bad Stuff", Effect Duration: 22, Last Available: "2006-01"
-1417	improved boiled huge teal snowcone	0		Effect: "Can't Smell Nothin'", Effect Duration: 61, Last Available: "2006-01"
+1417	improved boiled teal huge snowcone	0		Effect: "Can't Smell Nothin'", Effect Duration: 61, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
 1420	traffic cone of Tarzan of courage	0		Experience (Muscle): +3, Spooky Resistance: +3, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
@@ -1411,7 +1411,7 @@
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	jumbo adequate teal mushroom	5	good	
+1432	adequate jumbo teal mushroom	5	good	
 1433	fruit bowl	0		
 1434	fruit basket	0		
 1435	blinking hot pink lipstick	0		Familiar Weight: +5
@@ -1423,7 +1423,7 @@
 1441	diffused powder	0		Effect: "stats.enq", Effect Duration: 19
 1442	energized skewed stench powder	0		Effect: "Compensatory Cruelness", Effect Duration: 20
 1443	frozen anodized purple sleaze powder	0		Effect: "Quadrilled", Effect Duration: 60
-1444	warmed wobbly pulsating twinkly nuggets	0		Effect: "Be a Mind Master", Effect Duration: 59
+1444	warmed pulsating wobbly twinkly nuggets	0		Effect: "Be a Mind Master", Effect Duration: 59
 1445	boiled polymerized hot nuggets	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 35
 1446	ionized flattened blinking squat nuggets	0		Effect: "Cravin' for a Ravin'", Effect Duration: 31
 1447	tarnished altered gray nuggets	0		Effect: "Feeling No Pain", Effect Duration: 55
@@ -1432,12 +1432,12 @@
 1450	pickled twinkly wad	1		
 1451	dehydrated hot wad	1		Effect: "Blessing of the Pervy Noodles", Effect Duration: 35
 1452	pickled wad	1		Effect: "The Spy Who Loved XP", Effect Duration: 50
-1453	compressed skewed red wad	1		
+1453	compressed red skewed wad	1		
 1454	powdered stench wad	1		
 1455	mixed sleaze wad	1		
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	decent snack-sized Valentine's Day cake	2	good	
+1458	snack-sized decent Valentine's Day cake	2	good	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1475,15 +1475,15 @@
 1493	jittery shellacked Da Vinci's ridiculously overelaborate ninja weapon	0		Experience (Mysticality): +5, Damage Reduction: 7
 1494	triple-electrified sugar-coated pine cone	0		Effect: "Morninja", Effect Duration: 38, Last Available: "2020-09"
 1495	gray jittery chaotic groovy traffic cone	0		Moxie Percent: +10, Spell Critical Percent: +10, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	irresponsibly strong hand-crafted gloomy mushroom wine	10	EPIC	
+1496	hand-crafted irresponsibly strong gloomy mushroom wine	10	EPIC	
 1497	mediocre mushroom wine	3	decent	
-1498	gray McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	gray McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	oxidized quantum explosion-flavored chewing gum	0		Effect: "20/20 Vision", Effect Duration: 46, Last Available: "2006-04"
 1502	bouncing clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
-1504	non-aerosolized gray shaking snowcone	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 22, Last Available: "2006-04"
+1504	non-aerosolized shaking gray snowcone	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 22, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	extra-dry tolerable ghostly calle de miel with a fly in it	5	good	Last Available: "2006-04"
 1507	practically non-alcoholic perfectly mixed rockin' wagon with a fly in it	1	EPIC	Last Available: "2006-04"
@@ -1491,7 +1491,7 @@
 1509	perfectly mixed red slap and tickle with a fly in it	3	EPIC	Last Available: "2006-04"
 1510	blinking bag of airline peanuts	0		Last Available: "2006-04"
 1511	fuchsia fake hand of the early riser	0		Adventures: +7, Last Available: "2006-04"
-1512	mixed shaking maroon bouncing mirror Knob Goblin pet-buffing spray	1		
+1512	mixed maroon shaking bouncing mirror Knob Goblin pet-buffing spray	1		
 1513	mixed purple Knob Goblin learning pill	1		
 1514	distilled Knob Goblin eyedrops	1		
 1515	compressed Knob Goblin nasal spray	1		
@@ -1529,50 +1529,50 @@
 1549	mirror MSG	0		
 1550	veiny second-hand knockoff engagement ring	0		Maximum HP: +10, Single Equip
 1551	artisanal lime green bottle of Domesticated Turkey	3	EPIC	
-1552	mediocre fancy bottle of Definit	3	decent	Effect: "Human-Penguin Hybrid", Effect Duration: 20
+1552	fancy mediocre bottle of Definit	3	decent	Effect: "Human-Penguin Hybrid", Effect Duration: 20
 1553	lousy bottle of Calcutta Emerald	4	decent	
 1554	aged bottle of Lieutenant Freeman	4	awesome	
 1555	smooth blinking bottle of Jorge Sinsonte	4	awesome	
 1556	bad spirit-forward boxed champagne	5	decent	
-1557	normal low-calorie kumquat	1	good	
+1557	low-calorie normal kumquat	1	good	
 1558	adequate tangerine	3	good	
 1559	tonic water	0		
 1560	thick spoiled cocktail onion	5	crappy	
-1561	small flavorless fuchsia raspberry	2	decent	
-1562	big spoiled ghostly kiwi	5	crappy	
+1561	flavorless small fuchsia raspberry	2	decent	
+1562	spoiled big ghostly kiwi	5	crappy	
 1563	aged weak whiskey bittersweet	2	awesome	
 1564	acceptable mimosette	3	good	
 1565	acceptable twirling tequila sunset	3	good	
-1566	lousy irresponsibly strong zmobie	8	decent	Wiki Name: "Zmobie (drink)"
+1566	irresponsibly strong lousy zmobie	8	decent	Wiki Name: "Zmobie (drink)"
 1567	drinkable gin and tonic	3	good	
 1568	smooth vodka and tonic	3	awesome	
 1569	lousy vodka gibson	4	decent	
 1570	acceptable weak gibson	2	good	
 1571	tolerable triple-distilled parisian cathouse	8	good	
-1572	hand-crafted practically non-alcoholic blue jittery rabbit punch	1	super EPIC	
+1572	practically non-alcoholic hand-crafted blue jittery rabbit punch	1	super EPIC	
 1573	lousy caipifruta	4	decent	
 1574	mediocre teqiwila	4	decent	
 1575	mediocre Divine	4	decent	
-1576	tolerable watered-down blue Gordon Bennett	2	good	
+1576	watered-down tolerable blue Gordon Bennett	2	good	
 1577	perfectly mixed irresponsibly strong tangarita	6	EPIC	
 1578	tolerable distilled mandarina colada	5	good	
 1579	artisanal skewed gimlet	3	EPIC	
-1580	perfectly mixed weak brick road	2	super ultra EPIC	
+1580	weak perfectly mixed brick road	2	super ultra EPIC	
 1581	artisanal vodka stratocaster	3	EPIC	
 1582	bad Neuromancer	4	decent	
 1583	mediocre weak prussian cathouse	2	decent	
 1584	bad Mae West	4	decent	
-1585	watered-down drinkable Mon Tiki	2	good	
+1585	drinkable watered-down Mon Tiki	2	good	
 1586	weak smooth teqiwila slammer	2	awesome	
 1587	thick stale jittery Knob lo mein	5	decent	
-1588	stale massive asparagus lo mein	7	decent	
+1588	massive stale asparagus lo mein	7	decent	
 1589	jumbo yummy mirror Knoll lo mein	5	awesome	
 1590	normal shaking lo mein	3	good	
-1591	low-calorie bland special tumbling bouncing olive lo mein	1	decent	Effect: "Gutterminded", Effect Duration: 15
+1591	bland low-calorie special bouncing tumbling olive lo mein	1	decent	Effect: "Gutterminded", Effect Duration: 15
 1592	rotten hot hi mein	4	crappy	
 1593	moldy hi mein	4	crappy	
 1594	stale hi mein	3	decent	
-1595	rotten miniature hi mein	2	crappy	
+1595	miniature rotten hi mein	2	crappy	
 1596	moldy huge sleazy hi mein	4	crappy	
 1597	Junior LAAAAME merit badge	0		Item Drop: +5, Last Available: "2006-05"
 1598	yellow asbestos-lined Senior LAAAAME merit badge	0		Hot Resistance: +5, Last Available: "2006-05"
@@ -1580,7 +1580,7 @@
 1600	lousy tangarita with a fly in it	4	decent	
 1601	drinkable wobbly mandarina colada with a fly in it	3	good	
 1602	perfectly mixed shaking prussian cathouse with a fly in it	4	EPIC	
-1603	lousy special gray Mae West with a fly in it	4	decent	Effect: "Fishy Fortification", Effect Duration: 40
+1603	special lousy gray Mae West with a fly in it	4	decent	Effect: "Fishy Fortification", Effect Duration: 40
 1604	twisted astronaut ice-cream	1		Last Available: "2006-05"
 1605	squat cyan delectable catalyst	0		
 1606	modified ultimate wad	1		
@@ -1620,15 +1620,15 @@
 1640	galvanized boiled triple-improved huge lotion of stench	0		Effect: "Really Deep Breath", Effect Duration: 12
 1641	super-flattened huge lotion of sleaziness	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 51
 1642	acceptable watered-down narrow Grimacite Bock	2	good	Last Available: "2008-11"
-1643	special super-sized decent skewed wedge of gray cheese	5	good	Effect: "Cautious Prowl", Effect Duration: 5, Last Available: "2008-11"
+1643	decent special super-sized skewed wedge of gray cheese	5	good	Effect: "Cautious Prowl", Effect Duration: 5, Last Available: "2008-11"
 1644	huge hot and sauce	0		
 1645	spinning and sauce	0		
 1646	fuchsia and sauce	0		
 1647	stench and sauce	0		
-1648	blue huge sleazy and sauce	0		
+1648	huge blue sleazy and sauce	0		
 1649	brick	0		Free Pull
-1650	shaking ghostly milk of magnesium	0		
-1651	special half-sized decent shaking foie gras	2	good	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40
+1650	ghostly shaking milk of magnesium	0		
+1651	decent special half-sized shaking foie gras	2	good	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40
 1652	dry mirror candy brain	0		Effect: "On the Shoulders of Giants", Effect Duration: 50, Last Available: "2020-09"
 1653	huge Jeselnik's friendly therapeutic jewel-eyed wizard hat	0		Familiar Weight: +3, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	upside-down fortified experienced wad of Crovacite	0		Experience: +2, Damage Absorption: +60
@@ -1676,7 +1676,7 @@
 1696	adequate royal jelly taco	3	good	
 1697	stale tofu taco	3	decent	
 1698	spoiled jumping bean taco	3	crappy	
-1699	half-sized flavorless fuchsia catgut taco	2	decent	
+1699	flavorless half-sized fuchsia catgut taco	2	decent	
 1700	spoiled goat cheese taco	3	crappy	
 1701	small stale pr0n taco	2	decent	
 1702	electrified electrified alphabet gum	0		Effect: "Salad Days", Effect Duration: 15
@@ -1745,16 +1745,16 @@
 1766	Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	special snack-sized rotten wobbly fricasseed brains	2	crappy	Effect: "Sated and Furious", Effect Duration: 30
-1770	miniature yummy brains casserole	2	awesome	
+1769	rotten special snack-sized wobbly fricasseed brains	2	crappy	Effect: "Sated and Furious", Effect Duration: 30
+1770	yummy miniature brains casserole	2	awesome	
 1771	asbestos-lined butcherknife	0		Hot Resistance: +5
 1772	corn holder of temperance	0		Sleaze Resistance: +5
 1773	eggbeater of Flo-Jo	0		Initiative: +100
 1774	acceptable special triple-distilled bottle of popskull	6	good	Effect: "Weird Vibrations", Effect Duration: 25
 1775	bouncing blue dishrag of the sewer	0		Stench Damage: +25
-1776	tiny flavorless shaking twirling stale baguette	1	decent	
+1776	tiny flavorless twirling shaking stale baguette	1	decent	
 1777	skewed fuchsia leftovers of indeterminate origin	0		
-1778	gigantic enchanted rotten dinner	9	crappy	Effect: "Adrenaline Rush", Effect Duration: 20
+1778	enchanted gigantic rotten dinner	9	crappy	Effect: "Adrenaline Rush", Effect Duration: 20
 1779	bouncing chaotic katana	0		Spell Critical Percent: +10
 1780	sage ram stick	0		Mysticality Percent: +10
 1781	jittery reassuring enchantlers	0		Spooky Resistance: +1, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1763,10 +1763,10 @@
 1784	blue Tesla wicked Snow Queen Crown	0		Spell Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	bouncing Usain Bolt's zippy ga-ga radio of the dark arts	0		Spell Damage Percent: +100, Initiative: 100
 1786	six pack of Mountain Stream	0		
-1787	pressed wobbly squat maroon bag of Cheat-Os	0		Effect: "Blood-Gorged", Effect Duration: 52
+1787	pressed wobbly maroon squat bag of Cheat-Os	0		Effect: "Blood-Gorged", Effect Duration: 52
 1788	unrefined Mountain Stream syrup	0		
 1789	jittery mirror lime green Mob Penguin	0		
-1790	irresponsibly strong enchanted hand-crafted Ram's Face Lager	8	EPIC	Effect: "Grumpy and Ornery", Effect Duration: 30
+1790	enchanted irresponsibly strong hand-crafted Ram's Face Lager	8	EPIC	Effect: "Grumpy and Ornery", Effect Duration: 30
 1791	ram horns	0		
 1792	dog trainer's healthy Travoltan trousers of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Experience (familiar): +1, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	stanky Da Vinci's pool cue	0		Experience (Mysticality): +5, Stench Spell Damage: +25
@@ -1778,9 +1778,9 @@
 1799	fuchsia ghostly animal skull	0		
 1800	animal cranium	0		
 1801	animal jawbone	0		
-1802	blinking jittery fuchsia first cervical vertebra	0		
+1802	fuchsia jittery blinking first cervical vertebra	0		
 1803	second cervical vertebra	0		
-1804	maroon tumbling third cervical vertebra	0		
+1804	tumbling maroon third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
 1807	blinking sixth cervical vertebra	0		
@@ -1796,7 +1796,7 @@
 1817	ninth thoracic vertebra	0		
 1818	wobbly tenth thoracic vertebra	0		
 1819	squat eleventh thoracic vertebra	0		
-1820	pulsating yellow twelfth thoracic vertebra	0		
+1820	yellow pulsating twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
 1822	blinking second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
@@ -1867,7 +1867,7 @@
 1888	right third front claw	0		
 1889	right fourth front claw	0		
 1890	left thumb	0		
-1891	huge blinking right thumb	0		
+1891	blinking huge right thumb	0		
 1892	left first rear claw	0		
 1893	left second rear claw	0		
 1894	huge left third rear claw	0		
@@ -1925,9 +1925,9 @@
 1948	lime green mansplainer's strapping tap shoes	0		Muscle: +5, Monster Level: +15, Single Equip
 1949	adequate Manetwich	3	good	
 1950	gray bottle of Vangoghbitussin	0		
-1951	acceptable practically non-alcoholic mirror skewed bottle of Pinot Renoir	1	good	
+1951	practically non-alcoholic acceptable mirror skewed bottle of Pinot Renoir	1	good	
 1952	moldy desiccated apricot	4	crappy	
-1953	hand-crafted special flute of flat champagne	3	EPIC	Effect: "Some Cheese with Your Wine", Effect Duration: 20
+1953	special hand-crafted flute of flat champagne	3	EPIC	Effect: "Some Cheese with Your Wine", Effect Duration: 20
 1954	enchanted moldy dehydrated caviar	3	crappy	Effect: "Feet of Watermelon", Effect Duration: 50
 1955	styrofoam peanuts	0		
 1956	hand-crafted bouncing snifter of thoroughly aged brandy	4	EPIC	
@@ -1937,17 +1937,17 @@
 1960	spinning scroll of forbidden unspeakable evil	0		
 1961	teal can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	polymerized wobbly Bit O' Ectoplasm	0		Effect: "You're Not Cooking", Effect Duration: 23
-1963	spinning tumbling dance card	0		
+1963	tumbling spinning dance card	0		
 1964	aromatic opera mask	0		Stench Resistance: +1, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
 1966	frosty Amulet of Yendor of incineration	0		Cold Spell Damage: +10, Hot Spell Damage: +50, Single Equip, Last Available: "2011-12"
-1967	narrow spinning jitterbug larva	0		Free Pull, Last Available: "2007-10"
+1967	spinning narrow jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	maroon bottle of perfume	0		Familiar Weight: +5
-1969	pulsating maroon spoon!	0		Familiar Weight: +5
+1969	maroon pulsating spoon!	0		Familiar Weight: +5
 1970	nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	inspector's personal trainer's shrimp fork	0		Experience Percent (Muscle): +10, Item Drop: +15
-1973	wobbly blurry half of a memo	0		
+1973	blurry wobbly half of a memo	0		
 1974	cocoabo	0		
 1975	baby gravy fairy	0		
 1976	gravy fairy	0		
@@ -1984,7 +1984,7 @@
 2007	maroon Princess Rutabaga trading card	0		
 2008	Roo trading card	0		
 2009	Woldo trading card	0		
-2010	bouncing jittery The Snake trading card	0		
+2010	jittery bouncing The Snake trading card	0		
 2011	Nayztameetjoo trading card	0		
 2012	Arrrmetia trading card	0		
 2013	Serenity trading card	0		
@@ -1994,9 +1994,9 @@
 2017	lime green spade necklace	0		
 2018	upside-down club necklace	0		
 2019	tumbling cream pie	0		Free Pull
-2020	adequate tiny cherry pie	1	good	
+2020	tiny adequate cherry pie	1	good	
 2021	yummy yellow strawberry pie	3	awesome	
-2022	huge stale lemon meringue pie	7	decent	
+2022	stale huge lemon meringue pie	7	decent	
 2023	Genalen&trade; Bottle	1	decent	
 2024	bland huge mixed wildflower greens	3	decent	
 2025	flavorless handful of walnuts	3	decent	
@@ -2009,7 +2009,7 @@
 2032	twirling flame-retardant nasty bullet-proof corduroys	0		Stench Damage: +5, Hot Resistance: +1, Familiar Effect: "stench atk, 1xBarrr, cap 42"
 2033	round sunglasses of temperance	0		Sleaze Resistance: +5, Single Equip
 2034	Sherlock's wicker shield	0		Item Drop: +25, Damage Reduction: 11
-2035	jittery spinning Marquis de Poivre soda	0		
+2035	spinning jittery Marquis de Poivre soda	0		
 2036	modified red radium-flavored potato chips	0		Effect: "Ooh, Sweet!", Effect Duration: 27
 2037	irradiated modified wintergreen-flavored potato chips	0		Effect: "Burning Ears", Effect Duration: 68
 2038	super-activated polymerized green ennui-flavored potato chips	0		Effect: "Elbow Sauce", Effect Duration: 11
@@ -2020,7 +2020,7 @@
 2043	hemp net	0		
 2044	spinning your father's MacGuffin diary	0		
 2045	decent twirling brain-meltingly-hot chicken wings	3	good	
-2046	bland low-calorie fancy tumbling frat brats	1	decent	Effect: "Healthy Bronze Glow", Effect Duration: 20
+2046	fancy low-calorie bland tumbling frat brats	1	decent	Effect: "Healthy Bronze Glow", Effect Duration: 20
 2047	big rotten knob ka-bobs	5	crappy	
 2049	drinkable can of Swiller	4	good	
 2050	broken wings	0		
@@ -2028,7 +2028,7 @@
 2052	reassembled blackbird	0		
 2053	squat bust of Pallas	0		Familiar Weight: +5
 2054	squat market map	0		
-2055	ghostly squat snake skin	0		
+2055	squat ghostly snake skin	0		
 2056	triple-dry huge adder bladder	0		Effect: "Full of Wist", Effect Duration: 40
 2057	pension check	0		
 2058	wobbly picnic basket	0		
@@ -2059,7 +2059,7 @@
 2083	makeshift crane	0		
 2084	can of starch	0		
 2085	pickled skewed ghostly bouncing bottle of ultravitamins	1		
-2086	modified fuchsia bouncing blurry bottle of cough syrup	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
+2086	modified blurry fuchsia bouncing bottle of cough syrup	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
 2087	denatured tube of hair oil	1		Effect: "Sugar High", Effect Duration: 30
 2088	diffused denatured Daffy Taffy	0		Effect: "Sweetened and Fattened", Effect Duration: 59
 2089	Crimboween memo	0		Last Available: "2006-10"
@@ -2067,7 +2067,7 @@
 2091	pulsating bath salts	0		
 2092	hand mirror	0		
 2093	skewed extremely unsafe hors d'oeuvre tray	0		Weapon Damage Percent: +100, Damage Reduction: 5
-2094	snack-sized stale twirling ballroom blintz	2	decent	
+2094	stale snack-sized twirling ballroom blintz	2	decent	
 2095	fuchsia towel	0		
 2096	distilled guy made of bee pollen	1		Effect: "Slimily Strong", Effect Duration: 50
 2097	blinking Rosewater's 17-ball	0		Mysticality Percent: +30
@@ -2111,7 +2111,7 @@
 2136	Sherlock's vampire duck-on-a-string of terror	0		Spooky Spell Damage: +10, Item Drop: +25, Last Available: "2006-12"
 2137	hale toy crazy train	0		Maximum HP: +20, Single Equip, Last Available: "2006-12"
 2138	razor-tipped yo-yo	0		Last Available: "2010-12"
-2139	pulsating blurry toy mercenary	0		Last Available: "2006-12"
+2139	blurry pulsating toy mercenary	0		Last Available: "2006-12"
 2140	squat length of string	0		Last Available: "2011-12"
 2141	squat toy wheel	0		Last Available: "2011-12"
 2142	block	0		Last Available: "2011-12"
@@ -2121,7 +2121,7 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	spinning jittery toothsome rock	0		
-2149	huge stale frank	6	decent	Last Available: "2011-12"
+2149	stale huge frank	6	decent	Last Available: "2011-12"
 2150	normal plate of franks and beans	4	good	Last Available: "2011-12"
 2151	mediocre practically non-alcoholic huge shot of blackberry schnapps	1	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
@@ -2147,7 +2147,7 @@
 2172	ghostly toy jet pack of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	upside-down spinning mossy stone sphere	0		
-2175	cyan jittery smooth stone sphere	0		
+2175	jittery cyan smooth stone sphere	0		
 2176	cracked stone sphere	0		
 2177	mirror rough stone sphere	0		
 2178	twirling Herculean obsidian dagger	0		Experience (Muscle): +1
@@ -2155,7 +2155,7 @@
 2180	tumbling amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	bouncing maroon Harold's hammer handle	0		
+2183	maroon bouncing Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	wobbly squat electrified Kiss the Knob apron	0		MP Regen Min: 3, MP Regen Max: 5
 2186	unlit birthday cake	0		
@@ -2166,13 +2166,13 @@
 2191	book of carols	0		Last Available: "2006-12"
 2192	narrow sheet music	0		Last Available: "2006-12"
 2193	moldy olive squat candy stake	3	crappy	Last Available: "2006-12"
-2194	spirit-forward perfectly mixed enchanted olive eggnog	5	EPIC	Effect: "White-boy Angst", Effect Duration: 30, Last Available: "2006-12"
+2194	enchanted perfectly mixed spirit-forward olive eggnog	5	EPIC	Effect: "White-boy Angst", Effect Duration: 30, Last Available: "2006-12"
 2195	stale unspeakable fruitcake	3	decent	Last Available: "2006-12"
 2196	stale diet green gingerbread horror	1	decent	Last Available: "2006-12"
 2197	double-alkaline but probably evil chocolate	0		Effect: "Egg Burps", Effect Duration: 63, Last Available: "2006-12"
-2198	stale snack-sized jittery spinning bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	stale snack-sized spinning jittery bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	rotten skull-shaped Crimboween cookie	3	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	normal half-sized tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	half-sized normal tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	scorching plastic gift-wrapping vampire	0		Hot Damage: +25, Last Available: "2006-12"
 2202	plastic yuletide troll of the brute	0		Muscle Percent: +30, Last Available: "2006-12"
 2203	twirling plastic skeletal reindeer of the ox	0		Muscle: +20, Single Equip, Last Available: "2006-12"
@@ -2235,7 +2235,7 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	huge adequate stunt nuts	6	good	
+2264	adequate huge stunt nuts	6	good	
 2265	yummy wet stew	4	awesome	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
@@ -2243,10 +2243,10 @@
 2269	adequate blinking yellow sausage wonton	4	good	
 2270	Sinatra's belt of Leguizamo	0		Experience (Moxie): +5, Monster Level: +20, Single Equip
 2271	mediocre bottle of Merlot	3	decent	
-2272	smooth weak bottle of Port	2	awesome	
+2272	weak smooth bottle of Port	2	awesome	
 2273	weak perfectly mixed bottle of Pinot Noir	2	EPIC	
-2274	drinkable practically non-alcoholic bottle of Zinfandel	1	good	
-2275	aged triple-distilled bottle of Marsala	10	awesome	
+2274	practically non-alcoholic drinkable bottle of Zinfandel	1	good	
+2275	triple-distilled aged bottle of Marsala	10	awesome	
 2276	artisanal bottle of Muscat	3	EPIC	
 2277	squat Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2271,16 +2271,16 @@
 2297	vial of ectoplasm	0		
 2298	boock of darck magicks	0		
 2299	EZ-Play Harmonica Book	0		
-2300	pulsating mirror fingerless hobo gloves	0		
+2300	mirror pulsating fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	spinning worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	liquefied candy heart	0		Effect: "Goldentongue", Effect Duration: 42, Last Available: "2007-02"
 2305	magnetized tarnished altered bouncing pink candy heart	0		Effect: "Norwhalloped", Effect Duration: 35, Last Available: "2007-02"
 2306	altered modified blue candy heart	0		Effect: "Cringle's Curative Carol", Effect Duration: 15, Last Available: "2007-02"
 2307	irradiated candy heart	0		Effect: "Greased-Up Familiar", Effect Duration: 61, Last Available: "2007-02"
 2308	improved candy heart	0		Effect: "So Fresh and So Clean", Effect Duration: 59, Last Available: "2007-02"
-2309	quantum double-colloidal purple shaking candy heart	0		Effect: "Human-Orc Hybrid", Effect Duration: 66, Last Available: "2007-02"
+2309	quantum double-colloidal shaking purple candy heart	0		Effect: "Human-Orc Hybrid", Effect Duration: 66, Last Available: "2007-02"
 2310	candygram	0		Last Available: "2007-02"
 2311	twirling pink candygram	0		Last Available: "2007-02"
 2312	upside-down candygram	0		Last Available: "2007-02"
@@ -2295,7 +2295,7 @@
 2321	wobbly worm-riding manual page 2	0		
 2322	worm-riding manual pages 3-15	0		
 2323	headpiece of the Staff of Ed	0		
-2324	maroon upside-down Staff of Ed, almost	0		
+2324	upside-down maroon Staff of Ed, almost	0		
 2325	mirror Staff of Ed	0		
 2326	stone rose	0		
 2327	tarnished shaking can of paint	0		Effect: "Full of Wist", Effect Duration: 60
@@ -2303,7 +2303,7 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	green bouquet of circular saw blades	0		
-2332	moldy massive shaking Better Than Cuddling Cake	10	crappy	
+2332	massive moldy shaking Better Than Cuddling Cake	10	crappy	
 2333	maroon ninja snowman	0		
 2334	jittery Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
@@ -2314,9 +2314,9 @@
 2340	bad & tan	4	decent	
 2341	pepper	0		
 2342	flavorless ghostly forest cake	3	decent	
-2343	tiny stale forest ham	1	decent	
+2343	stale tiny forest ham	1	decent	
 2344	diffused filthworm hatchling scent gland	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 69
-2345	adjusted super-flattened bouncing blurry gray filthworm drone scent gland	0		Effect: "Gunky Dory", Effect Duration: 53
+2345	adjusted super-flattened gray blurry bouncing filthworm drone scent gland	0		Effect: "Gunky Dory", Effect Duration: 53
 2346	polymerized upside-down filthworm royal guard scent gland	0		Effect: "Stinky Hands", Effect Duration: 32
 2347	blinking heart of the filthworm queen	0		
 2348	water pipe bomb	0		
@@ -2352,7 +2352,7 @@
 2378	banana spritzer	0		
 2379	pressed banana smoothie	0		Effect: "Aquarius Rising", Effect Duration: 14
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
-2381	spinning twirling woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
+2381	twirling spinning woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	cyan class ring	0		
 2384	class ring	0		
@@ -2378,7 +2378,7 @@
 2404	jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
-2407	ghostly tumbling pink bat eye	0		
+2407	tumbling ghostly pink bat eye	0		
 2408	worthless piece of glass	0		
 2409	billy idol	0		
 2410	rag	0		
@@ -2390,11 +2390,11 @@
 2416	Temple Grandin's bounty-hunting helmet	0		Familiar Weight: +7, Familiar Effect: "1.5xFairy, cap 25"
 2417	careful bounty-hunting rifle	0		Monster Level: -10
 2418	pulsating executive bounty-hunting pants	0		Meat Drop: +40, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	quadruple-galvanized adjusted huge ghostly bottle of rhinoceros hormones	0		Effect: "Thunderheart", Effect Duration: 54
+2419	quadruple-galvanized adjusted ghostly huge bottle of rhinoceros hormones	0		Effect: "Thunderheart", Effect Duration: 54
 2420	corrupted jittery teeny-tiny magic scroll	0		Effect: "Serendipi Tea", Effect Duration: 57
 2421	double-ionized modified bottle of pirate juice	0		Effect: "Bootyliciousness", Effect Duration: 55
 2422	electrified altered irradiated pet snacks	0		Effect: "New Zeal", Effect Duration: 46
-2423	quadruple-flattened activated squat tumbling Mick's IcyVapoHotness Inhaler	0		Effect: "Mint-Condition Breath", Effect Duration: 28
+2423	quadruple-flattened activated tumbling squat Mick's IcyVapoHotness Inhaler	0		Effect: "Mint-Condition Breath", Effect Duration: 28
 2424	irradiated modified cyclops eyedrops	0		Effect: "Super-Mega-Charged", Effect Duration: 31
 2425	triple-pickled wobbly can of spinach	0		Effect: "Insatiable Hunger", Effect Duration: 22
 2426	quantum electrified non-irradiated fire flower	0		Effect: "Phorcefullness", Effect Duration: 18
@@ -2490,14 +2490,14 @@
 2517	shaking ribald padded chain necklace	0		Damage Absorption: +20, Sleaze Damage: +10
 2518	pulsating asbestos-lined sawblade shield	0		Hot Resistance: +5, Damage Reduction: 11
 2519	delicious McMillicancuddy's Special Lager	3	awesome	
-2520	perfectly mixed watered-down melted Jell-o shot	2	EPIC	
+2520	watered-down perfectly mixed melted Jell-o shot	2	EPIC	
 2521	perfectly mixed practically non-alcoholic cruelty-free wine	1	EPIC	
 2522	aged wobbly thistle wine	3	awesome	
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	adequate super-sized fish	5	good	
-2526	bite-sized decent fish casserole	1	good	
-2527	jumbo yummy squat fish lasagna	5	awesome	
+2525	super-sized adequate fish	5	good	
+2526	decent bite-sized fish casserole	1	good	
+2527	yummy jumbo squat fish lasagna	5	awesome	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	adequate mirror gnatloaf	4	good	
 2530	adequate gnatloaf casserole	4	good	
@@ -2560,15 +2560,15 @@
 2587	ghostly Temple Grandin's Corporal Fennel's Lonely Clubs Club Jacket	0		Familiar Weight: +7
 2588	Usain Bolt's Private Pepper's Lonely Hearts Club Jacket	0		Initiative: +80
 2589	miniature stale hot date	2	decent	
-2590	bad weak distilled fortified wine	2	decent	
+2590	weak bad distilled fortified wine	2	decent	
 2591	flavorless tasty tart	3	decent	
 2592	Knob Goblin lunchbox	0		
-2593	snack-sized enchanted normal Knob pasty	2	good	Effect: "Ooh, Bitter!", Effect Duration: 15
+2593	snack-sized normal enchanted Knob pasty	2	good	Effect: "Ooh, Bitter!", Effect Duration: 15
 2594	watered-down smooth huge thermos full of Knob coffee	2	awesome	
 2595	triple-irradiated double-pressed Ben-Gal&trade; Balm	0		Effect: "Adapt to Change Eventually", Effect Duration: 16
 2596	blue leathery cat skin	0		
 2597	leathery bat skin	0		
-2598	upside-down maroon leathery rat skin	0		
+2598	maroon upside-down leathery rat skin	0		
 2599	green Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	frosty Temple Grandin's resourceful Staff of the Midnight Snack	0		Maximum MP: +50, Familiar Weight: +7, Cold Spell Damage: +10
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	green mojo filter	0		
-2615	miniature adequate pulsating savoy truffle	2	good	
+2615	adequate miniature pulsating savoy truffle	2	good	
 2616	spinning yellow Magi-Wipes	0		
 2617	pulsating boom	0		
 2618	Socratic Iiti Kitty phone charm	0		Experience (Mysticality): +1, Single Equip
@@ -2623,12 +2623,12 @@
 2650	bottled pixie	0		Free Pull
 2651	yellow pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	normal S.T.L.T.	4	good	Last Available: "2007-06"
-2653	stale super-sized honey-dew	5	decent	Last Available: "2007-06"
+2653	super-sized stale honey-dew	5	decent	Last Available: "2007-06"
 2654	hand-crafted shaking Xanadian	4	EPIC	Last Available: "2007-06"
 2655	extra-irradiated upside-down bottle of absinthe	0		Effect: "Shamboozled", Effect Duration: 25, Last Available: "2007-06"
 2656	blinking experienced Drowsy Sword of the sweet-tooth	0		Experience: +2, Candy Drop: +100
-2657	flavorless tiny mirror escargotsicle	1	decent	Last Available: "2007-06"
-2658	weak tolerable bottle of realpagne	2	good	Last Available: "2007-06"
+2657	tiny flavorless mirror escargotsicle	1	decent	Last Available: "2007-06"
+2658	tolerable weak bottle of realpagne	2	good	Last Available: "2007-06"
 2659	fuchsia ghostly albatross necklace of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2007-06"
 2660	vaporized upside-down not-a-pipe	1	decent	Last Available: "2007-06"
 2661	acceptable flask of Amontillado	4	good	Last Available: "2007-06"
@@ -2638,16 +2638,16 @@
 2665	galvanized squat bottled inspiration	0		Effect: "Marinated", Effect Duration: 39, Last Available: "2007-06"
 2666	diffused dry bellhop bell	0		Effect: "Shawarma Initiative", Effect Duration: 56, Last Available: "2007-06"
 2667	flattened pulsating spiky collar	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 42, Last Available: "2007-06"
-2668	mixed twirling jittery can-can-in-a-can	1		Last Available: "2007-06"
+2668	mixed jittery twirling can-can-in-a-can	1		Last Available: "2007-06"
 2669	distilled spinning skewed patent antipsychotics	1		Last Available: "2007-06"
 2670	denatured skewed Mariner's Friend cough drops	1		Effect: "Squirming Like a Toad", Effect Duration: 15, Last Available: "2007-06"
-2671	practically non-alcoholic lousy shot of nepenthe schnapps	1	decent	Last Available: "2007-06"
+2671	lousy practically non-alcoholic shot of nepenthe schnapps	1	decent	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
-2674	double-oxidized wet blinking blue upside-down bottle of cat tonic	0		Effect: "Some Cheese with Your Wine", Effect Duration: 27, Last Available: "2007-06"
+2674	double-oxidized wet blinking upside-down blue bottle of cat tonic	0		Effect: "Some Cheese with Your Wine", Effect Duration: 27, Last Available: "2007-06"
 2675	compressed mirror handful of moss	1		Effect: "Human-Goblin Hybrid", Effect Duration: 30
-2676	vaporized wobbly spinning bit-o-cactus	1		Effect: "Vanity Rage", Effect Duration: 5
-2677	altered huge twirling purple protein powder	1		
+2676	vaporized spinning wobbly bit-o-cactus	1		Effect: "Vanity Rage", Effect Duration: 5
+2677	altered twirling purple huge protein powder	1		
 2678	spectre scepter	0		
 2679	chilled polarized sparkler	0		Effect: "Pisces Rising", Effect Duration: 19
 2680	pressed energized pulsating snake	0		Effect: "Marbles in Your Mouth", Effect Duration: 35, Wiki Name: "snake"
@@ -2665,7 +2665,7 @@
 2692	ghostly maroon scorching driftwood sculpture of Gandalf	0		Spell Critical Percent: +20, Hot Damage: +25
 2693	vibrating veiny massive sitar	0		Maximum HP: +10, Maximum MP Percent: +10
 2694	asbestos-lined Jim Carey's crafty stone baseball cap	0		Maximum MP: +10, Monster Level: +25, Hot Resistance: +5, Familiar Effect: "1xVolley, cap 48"
-2695	drinkable triple-distilled upside-down cup of beer	7	good	
+2695	triple-distilled drinkable upside-down cup of beer	7	good	
 2696	mirror ovoid thing	0		
 2697	duct tape	0		
 2698	huge duct tape wallet	0		
@@ -2694,15 +2694,15 @@
 2721	blurry mansplainer's Samson's hand-carved staff of terror	0		Experience (Muscle): +5, Monster Level: +15, Spooky Spell Damage: +10
 2722	sinister dance instructor's Sinatra's experienced Staff of the Greasefire	0		Experience: +2, Experience (Moxie): +5, Experience Percent (Moxie): +10, Spell Damage: +10
 2723	MacGyver's studded Da Vinci's Staff of the Grand Flamb&eacute;	0		Experience (Mysticality): +5, Damage Absorption: +80, Maximum MP: +100
-2724	adequate gigantic bowl of rye sprouts	6	good	
+2724	gigantic adequate bowl of rye sprouts	6	good	
 2725	rotten cob of corn	3	crappy	
 2726	stale juniper berries	3	decent	
 2727	moldy plum	3	crappy	
 2728	delicious pear	3	awesome	
 2729	flavorless small teal peach	2	decent	
 2730	practically non-alcoholic lousy plum wine	1	decent	
-2731	fancy drinkable practically non-alcoholic jittery shot of pear schnapps	1	good	Effect: "Virgo Rising", Effect Duration: 35
-2732	artisanal practically non-alcoholic shot of peach schnapps	1	EPIC	
+2731	drinkable fancy practically non-alcoholic jittery shot of pear schnapps	1	good	Effect: "Virgo Rising", Effect Duration: 35
+2732	practically non-alcoholic artisanal shot of peach schnapps	1	EPIC	
 2733	bland bunch of square grapes	3	decent	
 2734	stale brown sugar cane	3	decent	
 2735	delicious low-calorie narrow sandwich of the gods	1	awesome	
@@ -2717,7 +2717,7 @@
 2744	powdered mirror steel-scented air freshener	1		
 2745	boiled dry pulsating gremlin mutagen	0		Effect: "Sagittarius Rising", Effect Duration: 30
 2746	dry denatured huge shaking extra-potent gremlin mutagen	0		Effect: "Dreadful Chill", Effect Duration: 34
-2747	blinking wobbly maroon chunk of depleted Grimacite	0		Last Available: "2011-12"
+2747	maroon blinking wobbly chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	shaking veiny furniture dolly	0		Maximum HP: +10, Single Equip
 2749	olive aromatic personal trainer's educational Staff of the Grease Trap	0		Experience: +1, Experience Percent (Muscle): +10, Stench Resistance: +1
 2750	greasy beefcake's Uranium Omega of Temperance	0		Muscle: +25, Sleaze Spell Damage: +10, Single Equip
@@ -2739,7 +2739,7 @@
 2766	yellow bowling ball	0		
 2767	tiny normal Crimbo pie	1	good	
 2768	rotten pear tart	4	crappy	
-2769	super-sized delicious peach pie	5	awesome	
+2769	delicious super-sized peach pie	5	awesome	
 2770	pressed super-chilled chunk of rock salt	0		Effect: "Feeling No Pain", Effect Duration: 47
 2771	chilled diffused tarnished mirror handful of pine needles	0		Effect: "Stinking Cloud", Effect Duration: 17
 2772	steamy ruby	0		
@@ -2778,7 +2778,7 @@
 2805	wet vial of baconstone juice	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 31
 2806	alkaline vial of porquoise juice	0		Effect: "Greasy Flavor", Effect Duration: 26
 2807	polarized fuchsia flask of hamethyst juice	0		Effect: "Snobby", Effect Duration: 45
-2808	diffused squat pulsating flask of baconstone juice	0		Effect: "Pumped Stomach", Effect Duration: 39
+2808	diffused pulsating squat flask of baconstone juice	0		Effect: "Pumped Stomach", Effect Duration: 39
 2809	boiled tarnished flask of porquoise juice	0		Effect: "Nuts about Candy", Effect Duration: 15
 2810	deionized corrupted jug of hamethyst juice	0		Effect: "Warm Belly", Effect Duration: 37
 2811	electrified oxidized pulsating jug of baconstone juice	0		Effect: "Shamboozled", Effect Duration: 14
@@ -2806,7 +2806,7 @@
 2833	flavorless red star key lime pie	4	decent	
 2834	twirling smelly bottle-rocket crossbow of the pedagogue of the overflowing toilet	0		Experience: +3, Stench Spell Damage: 60, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	bouncing mirror studded indie comic hipster glasses	0		Damage Absorption: +80, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
-2836	red shaking blinking wizard action figure	0		Free Pull, Last Available: "2011-12"
+2836	blinking red shaking wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	narrow mint-condition magic wand	0		Last Available: "2011-12"
 2838	blurry nippy stiffened glowstick	0		Damage Reduction: 1, Cold Damage: +10, Last Available: "2007-08"
 2839	ghostly blurry Annie Oakley's Periodical Paintbrush	0		Critical Hit Percent: +20, Softcore Only
@@ -2820,19 +2820,19 @@
 2847	skewed Dallas Dynasty Falcon Crest shield of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 15
 2848	upside-down mirror Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	drinkable irresponsibly strong moonberry wine cooler	8	good	
+2850	irresponsibly strong drinkable moonberry wine cooler	8	good	
 2851	moldy fine aged cheddarwurst	4	crappy	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	chaotic huge mosquito proboscis of Tarzan	0		Experience (Muscle): +3, Spell Critical Percent: +10
 2856	improved liquefied tumbling swamp lolly	0		Effect: "What's That Smell?", Effect Duration: 13
-2857	improved concentrated pulsating teal seegar butt	0		Effect: "Healthy Red Glow", Effect Duration: 33
+2857	improved concentrated teal pulsating seegar butt	0		Effect: "Healthy Red Glow", Effect Duration: 33
 2858	mirror ghostly bottled swamp gas	0		
 2859	resourceful hardy witch wart	0		Maximum HP: +50, Maximum MP: +50
-2860	half-sized enchanted tasty swamp muck	2	awesome	Effect: "Yes, Can Haz", Effect Duration: 30
+2860	tasty enchanted half-sized swamp muck	2	awesome	Effect: "Yes, Can Haz", Effect Duration: 30
 2861	dog trainer's Temple Grandin's leechknife of the blizzard	0		Familiar Weight: +7, Experience (familiar): +1, Cold Spell Damage: +25
-2862	maroon mirror shaking decomposed boot	0		
+2862	mirror shaking maroon decomposed boot	0		
 2863	liquefied nitrogenated narrow dribbly candle	0		Effect: "Stinky Weapon", Effect Duration: 50
 2864	stolen meatpouch	0		
 2865	lightning-fast beaver spear of the early riser	0		Initiative: +40, Adventures: +7
@@ -2840,7 +2840,7 @@
 2867	cyan blinking Van der Graaf smooth dilapidated wizard hat	0		Moxie: +15, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cap 31"
 2868	flattened improved pirate pamphlet	0		Effect: "The Real Deal", Effect Duration: 26
 2869	double-unsweetened skewed pirate brochure	0		Effect: "Concentrated Concentration", Effect Duration: 61
-2870	deionized dry huge narrow pirate tract	0		Effect: "Bone Homie", Effect Duration: 61
+2870	deionized dry narrow huge pirate tract	0		Effect: "Bone Homie", Effect Duration: 61
 2871	burnt flower	0		
 2872	Temple Grandin's slick plastic Naughty Sorceress	0		Moxie: +10, Familiar Weight: +7
 2873	jittery stanky smelly plastic Ed the Undying	0		Stench Spell Damage: 35
@@ -2918,18 +2918,18 @@
 2946	jittery censurious Van der Graaf V for Vivala mask	0		Sleaze Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	perfectly mixed shot of rotgut	3	EPIC	
-2949	electrified pickled dry twirling pulsating jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Sepia Tan", Effect Duration: 47
+2949	electrified pickled dry pulsating twirling jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Sepia Tan", Effect Duration: 47
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
 2952	lion tamer's glowstick of horror	0		Experience (familiar): +2, Spooky Spell Damage: +25, Last Available: "2007-11"
 2953	charrrm bracelet	0		
 2954	friendly tip jar	0		Familiar Weight: +3
-2955	special snack-sized flavorless wobbly yam candy	2	decent	Effect: "Banono", Effect Duration: 40
+2955	flavorless special snack-sized wobbly yam candy	2	decent	Effect: "Banono", Effect Duration: 40
 2956	cocktail napkin	0		
 2957	skewed rum barrel charrrm	0		
-2958	tasty small tube of cranberry Go-Goo	2	awesome	
+2958	small tasty tube of cranberry Go-Goo	2	awesome	
 2959	wobbly cyan supercool rum barrel charrrm bracelet	0		Moxie Percent: +20
-2960	stale blinking narrow single-serving herbal stuffing	3	decent	
+2960	stale narrow blinking single-serving herbal stuffing	3	decent	
 2961	decent fuchsia packet of tofurkey gravy	3	good	
 2962	yummy tofurkey nugget	3	awesome	
 2963	rigging shampoo	0		
@@ -2938,8 +2938,8 @@
 2966	huge Tom's of the Spanish Main Toothpaste	0		
 2967	unsweetened Swabbie&trade; swab	0		Effect: "Full-Body Tan", Effect Duration: 32
 2968	moist Oil of Parrrlay	0		Effect: "Empty Inside", Effect Duration: 12
-2969	decent massive creamsicle	6	good	
-2970	fancy mediocre weak cream stout	2	decent	Effect: "Ocelot Eyes", Effect Duration: 40
+2969	massive decent creamsicle	6	good	
+2970	mediocre weak fancy cream stout	2	decent	Effect: "Ocelot Eyes", Effect Duration: 40
 2971	arcane researcher's curmudgel of the brazier	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +25
 2972	grumpy man charrrm	0		
 2973	smartaleck's grumpy man charrrm bracelet	0		Moxie Percent: +30, Single Equip
@@ -2949,11 +2949,11 @@
 2977	double-paned witty rapier	0		Cold Resistance: +5
 2978	blurry mansplainer's yohohoyo of incineration	0		Monster Level: +15, Hot Spell Damage: +50
 2979	ionized tarnished green fish-liver oil	0		Effect: "Horrid, Torrid", Effect Duration: 65
-2980	wobbly bouncing booty chest charrrm	0		
+2980	bouncing wobbly booty chest charrrm	0		
 2981	zippy booty chest charrrm bracelet	0		Initiative: +20, Single Equip
 2982	cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
-2984	pulsating wobbly copper ha'penny charrrm	0		
+2984	wobbly pulsating copper ha'penny charrrm	0		
 2985	educational copper ha'penny charrrm bracelet	0		Experience: +1
 2986	yellow spinning tongue charrrm	0		
 2987	narrow gravedigger's Jim Carey's tongue charrrm bracelet	0		Monster Level: +25, Spooky Damage: +10, Single Equip
@@ -2980,7 +2980,7 @@
 3008	bouncing Jeselnik's wizardly rainbow pearl ring	0		Mysticality: +25, Sleaze Damage: +25, Single Equip, Last Available: "2007-12"
 3009	Samson's Idol of Ak'gyxoth of the empath	0		Experience (Muscle): +5, Familiar Weight: +5
 3010	wobbly fuchsia frightening Emblem of Ak'gyxoth of Tarzan	0		Experience (Muscle): +3, Spooky Damage: +5
-3011	yellow upside-down sinister altar fragment	0		
+3011	upside-down yellow sinister altar fragment	0		
 3012	shimmering rainbow sand	0		
 3013	simple key	0		
 3014	tumbling yellow ornate key	0		
@@ -2989,7 +2989,7 @@
 3017	upside-down twirling ornate chest	0		
 3018	squat gilded chest	0		
 3019	all-purpose cleaner	0		
-3020	wobbly bouncing handful of sawdust	0		
+3020	bouncing wobbly handful of sawdust	0		
 3021	stone triangle	0		
 3022	medium stone triangle	0		
 3023	wobbly small stone triangle	0		
@@ -2999,14 +2999,14 @@
 3027	fortified smooth corpsedriver	5	awesome	
 3028	lousy Corpse Island iced tea	3	decent	
 3029	artisanal red-headed corpse	3	EPIC	
-3030	tolerable fancy triple-distilled yellow kamicorpse-ee	8	good	Effect: "Unusual Perspective", Effect Duration: 10
-3031	aged watered-down corpsel	2	awesome	
+3030	fancy triple-distilled tolerable yellow kamicorpse-ee	8	good	Effect: "Unusual Perspective", Effect Duration: 10
+3031	watered-down aged corpsel	2	awesome	
 3032	acceptable skewed corpsebite	3	good	
 3033	brainy pirate fledges	0		Mysticality: +5
 3034	piece of thirteen	0		
-3035	super-sized adequate pearl onion	5	good	
+3035	adequate super-sized pearl onion	5	good	
 3036	bland sea biscuit	3	decent	
-3037	strong tolerable bottle of rum	5	good	
+3037	tolerable strong bottle of rum	5	good	
 3038	watered-down bad bottle of black-label rum	2	decent	
 3039	maroon cannonball	0		
 3040	huge voodoo skull	0		
@@ -3016,7 +3016,7 @@
 3044	bouncing metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	thick flavorless special upside-down nanite-infested gingerbread bugbear	5	decent	Effect: "Glo-Face", Effect Duration: 15, Last Available: "2007-12"
 3046	stale squat nanite-infested candy cane	4	decent	Last Available: "2020-09"
-3047	diet rotten nanite-infested fruitcake	1	crappy	Last Available: "2007-12"
+3047	rotten diet nanite-infested fruitcake	1	crappy	Last Available: "2007-12"
 3048	distilled bad nanite-infested eggnog	5	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	avaricious eyepatch	0		Meat Drop: +30, Familiar Effect: "spooky atk, 1xBarrr"
@@ -3086,8 +3086,8 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	huge Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
-3118	lime green mirror divine noisemaker	0		Last Available: "2008-01"
+3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
+3118	mirror lime green divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	fuchsia divine blowout	0		Last Available: "2008-01"
 3121	tumbling divine champagne popper	0		Last Available: "2008-01"
@@ -3128,7 +3128,7 @@
 3156	upside-down El Vibrato punchcard (104 holes)	0		
 3157	El Vibrato drone	0		
 3158	wobbly spinning sparking El Vibrato drone	0		
-3159	super-quantum green spinning warm El Vibrato drone	0		Effect: "Innately Truthy", Effect Duration: 48
+3159	super-quantum spinning green warm El Vibrato drone	0		Effect: "Innately Truthy", Effect Duration: 48
 3160	boiled dry flattened humming El Vibrato drone	0		Effect: "Kissed By Fire", Effect Duration: 64
 3161	chilled moist squat El Vibrato drone	0		Effect: "Ichorous Intensity", Effect Duration: 35
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
@@ -3147,7 +3147,7 @@
 3175	small decent evil noodles	2	good	
 3176	stale lime green evil noodles	3	decent	
 3177	spoiled evil painful penne pasta	4	crappy	
-3178	half-sized adequate 3vi1 pr0n m4nic0tti	2	good	
+3178	adequate half-sized 3vi1 pr0n m4nic0tti	2	good	
 3179	stale evil ravioli della hippy	3	decent	
 3180	stale evil noodles	3	decent	
 3181	polarized quantum blinking evil potion of potency	0		Effect: "Walberg's Dim Bulb", Effect Duration: 28
@@ -3158,7 +3158,7 @@
 3186	denatured evil serum of sarcasm	0		Effect: "Stimulated Brain", Effect Duration: 52
 3187	frozen denatured evil philter of phorce	0		Effect: "[1609]Dancin' Fool", Effect Duration: 33
 3188	perfectly mixed blinking an evil sump'm sump'm	4	EPIC	
-3189	practically non-alcoholic artisanal evil ducha de oro	1	super ultra mega turbo EPIC	
+3189	artisanal practically non-alcoholic evil ducha de oro	1	super ultra mega turbo EPIC	
 3190	smooth evil horizontal tango	3	awesome	
 3191	acceptable lime green wobbly evil roll in the hay	4	good	
 3192	upside-down naughty origami kit	0		Last Available: "2008-02"
@@ -3175,7 +3175,7 @@
 3203	dwarvish magazine	0		
 3204	dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
-3206	spinning blinking dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
+3206	blinking spinning dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
 3208	jittery small laminated card	0		
 3209	laminated card	0		
@@ -3204,7 +3204,7 @@
 3232	rotten vanilla-frosted king cake	3	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	mirror water wings	0		Wiki Name: "water wings"
-3235	mirror huge noodle	0		
+3235	huge mirror noodle	0		
 3236	Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	jittery Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	wobbly Blizzards I Have Died In	0		Skill: "Snowclone"
@@ -3232,7 +3232,7 @@
 3260	Jim Carey's manspreader's Oprah's Chester's moustache	0		Maximum MP Percent: +50, Monster Level: 35, Class: "Disco Bandit", Single Equip
 3261	coward's Chester's bag of candy of the pedagogue	0		Experience: +3, Monster Level: -20, Class: "Disco Bandit"
 3262	olive razor-sharp Chester's cutoffs of the overflowing toilet	0		Weapon Damage Percent: +25, Stench Spell Damage: +50, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	gray Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	gray Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	wobbly bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3309,7 +3309,7 @@
 3337	foul-smelling dead guy's memento of doom	0		Stench Damage: +10, Spooky Spell Damage: +50, Single Equip
 3338	decent banquet	4	good	
 3339	sharpened hubcap	0		
-3340	maroon mirror very caltrop	0		
+3340	mirror maroon very caltrop	0		
 3341	The Six-Pack of Pain	0		
 3342	hobo monkey	0		
 3343	bindle	0		Familiar Weight: +5
@@ -3325,7 +3325,7 @@
 3353	corrupted unsweetened activated llama lama gong	0		Effect: "Sugar Smacks", Effect Duration: 19, Last Available: "2008-06"
 3354	spoiled banana-frosted king cake	3	crappy	Last Available: "2008-08"
 3355	beefy brown plastic baby	0		Muscle: +10, Single Equip, Last Available: "2008-08"
-3356	shaking jittery plump juicy grub	0		Last Available: "2008-06"
+3356	jittery shaking plump juicy grub	0		Last Available: "2008-06"
 3357	red shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	scrumptious ice ant	0		Last Available: "2008-06"
@@ -3338,7 +3338,7 @@
 3366	vacuum-sealed tarnished digital underground potion	0		Effect: "Stop and Smell the Fudge", Effect Duration: 68, Last Available: "2008-06"
 3367	purple interesting-looking twig	0		Last Available: "2008-06"
 3368	diluted glimmering roc feather	1	good	Last Available: "2008-06"
-3369	altered skewed squat glimmering phoenix feather	1		Last Available: "2008-06"
+3369	altered squat skewed glimmering phoenix feather	1		Last Available: "2008-06"
 3370	dried tumbling skewed glimmering penguin feather	1		Last Available: "2008-06"
 3371	mixed olive glimmering buzzard feather	1		Effect: "A Contender", Effect Duration: 20, Last Available: "2008-06"
 3372	twisted twirling green glimmering raven feather	1		Last Available: "2008-06"
@@ -3367,7 +3367,7 @@
 3395	censurious Hodgman's porkpie hat of James Dean	0		Experience (Moxie): +3, Sleaze Resistance: +3, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	lard-coated smartaleck's Hodgman's lobsterskin pants	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xPotato"
 3397	jittery Samson's Hodgman's bow tie of the blizzard	0		Experience (Muscle): +5, Cold Spell Damage: +25, Single Equip
-3398	mediocre boozy pulsating Hodgman's blanket	5	decent	
+3398	boozy mediocre pulsating Hodgman's blanket	5	decent	
 3399	lousy practically non-alcoholic jar of squeeze	1	decent	
 3400	stale upside-down bowl of fishysoisse	3	decent	
 3401	electrified colloidal deadly lampshade	0		Effect: "Black Lung", Effect Duration: 19
@@ -3429,7 +3429,7 @@
 3462	terrible poem	0		
 3463	smooth bottle of sake	3	awesome	
 3464	lard-coated round pebble	0		Sleaze Spell Damage: +25
-3465	diet yummy spinning Bash-&#332;s cereal	1	awesome	Wiki Name: "Bash-Os cereal"
+3465	yummy diet spinning Bash-&#332;s cereal	1	awesome	Wiki Name: "Bash-Os cereal"
 3466	flame-retardant stanky haiku katana of horror	0		Stench Spell Damage: +25, Spooky Spell Damage: +25, Hot Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	plastic baby of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2008-12"
@@ -3440,7 +3440,7 @@
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	altered skewed cranberry cordial	0		Effect: "Hot Blooded", Effect Duration: 41
 3475	double-alkaline flattened blackberry polite	0		Effect: "Yuletide Industry", Effect Duration: 16
-3476	irradiated polymerized cyan squat plum lozenge	0		Effect: "Dreadful Fear", Effect Duration: 49
+3476	irradiated polymerized squat cyan plum lozenge	0		Effect: "Dreadful Fear", Effect Duration: 49
 3477	ionized double-energized pulsating squat pear lozenge	0		Effect: "Holiday Bliss", Effect Duration: 11
 3478	extra-altered shaking shaking peach lozenge	0		Effect: "Fitter, Happier", Effect Duration: 54
 3479	balloon shield	0		Damage Reduction: 3
@@ -3465,13 +3465,13 @@
 3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3501	bland small squat spinning canap&eacute;s	2	decent	
+3501	bland small spinning squat canap&eacute;s	2	decent	
 3502	dehydrated wobbly thermos of brew	1	awesome	Last Available: "2011-12"
-3503	hand-crafted irresponsibly strong glass of brandy	9	EPIC	Last Available: "2011-12"
+3503	irresponsibly strong hand-crafted glass of brandy	9	EPIC	Last Available: "2011-12"
 3504	pulsating French slippers	0		
 3505	mirror LWA ring of extreme caution	0		Monster Level: -25
 3506	blurry LARP membership card	0		Last Available: "2008-10"
-3507	blurry Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	blurry Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	scratch 'n' sniff sword of wisdom	0		Mysticality: +15, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	fuchsia blinking scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3484,7 +3484,7 @@
 3517	stylish eelskin hat	0		Moxie: +25, Familiar Effect: "atk"
 3518	eelskin pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1xPotato, MP regen"
 3519	fuchsia resourceful eelskin shield	0		Maximum MP: +50, Damage Reduction: 13
-3520	olive jittery blurry shark tooth	0		
+3520	olive blurry jittery shark tooth	0		
 3521	dance instructor's shark tooth necklace of the boozehound	0		Experience Percent (Moxie): +10, Booze Drop: +100, Single Equip
 3522	blurry blue deadly brawny shark jumper	0		Muscle Percent: +20, Weapon Damage: +5
 3523	tarnished cyan shark cartilage	0		Effect: "Drunk With Power", Effect Duration: 25
@@ -3520,7 +3520,7 @@
 3553	soggy seed packet	0		
 3554	glob of slime	0		
 3555	flavorless huge sea carrot	4	decent	
-3556	rotten special sea cucumber	4	crappy	Effect: "Can't Smell Nothin'", Effect Duration: 50
+3556	special rotten sea cucumber	4	crappy	Effect: "Can't Smell Nothin'", Effect Duration: 50
 3557	bland sea avocado	4	decent	
 3558	adequate sea lychee	4	good	
 3559	spoiled sea tangelo	3	crappy	
@@ -3528,15 +3528,15 @@
 3561	denatured frozen deionized olive pressurized potion of puissance	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 38
 3562	electrified anodized pressurized potion of perspicacity	0		Effect: "Aquarius Rising", Effect Duration: 27
 3563	denatured Vulcanized tarnished wobbly cyan pressurized potion of pulchritude	0		Effect: "Meatwise", Effect Duration: 45
-3564	fancy irresponsibly strong hand-crafted squat berry-infused sake	9	EPIC	Effect: "Disdain of She-Who-Was", Effect Duration: 45
-3565	practically non-alcoholic perfectly mixed citrus-infused sake	1	super ultra mega turbo EPIC	
+3564	irresponsibly strong hand-crafted fancy squat berry-infused sake	9	EPIC	Effect: "Disdain of She-Who-Was", Effect Duration: 45
+3565	perfectly mixed practically non-alcoholic citrus-infused sake	1	super ultra mega turbo EPIC	
 3566	drinkable melon-infused sake	4	good	
 3567	spinning slab of sponge	0		
 3568	studded sponge helmet of wisdom of the boozehound	0		Mysticality: +15, Damage Absorption: +80, Booze Drop: +100, Familiar Effect: "atk, 1xFairy"
 3569	maroon aromatic hardy steel-toed spongy shield	0		Damage Reduction: 23, Maximum HP: +50, Stench Resistance: +1
 3570	inspector's hardy banded square sponge pants	0		Damage Absorption: +100, Maximum HP: +50, Item Drop: +15, Familiar Effect: "hot atk, 1xPotato"
 3571	flytrap pellet	0		
-3572	twirling lime green baby cuddlefish	0		
+3572	lime green twirling baby cuddlefish	0		
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	narrow sand dollar	0		
@@ -3548,7 +3548,7 @@
 3581	tumbling sushi-rolling mat	0		
 3582	yummy twirling rice	3	awesome	
 3584	adequate irradiated candy cane	4	good	Last Available: "2008-12"
-3585	huge normal gingerbread mutant bugbear	9	good	Last Available: "2008-12"
+3585	normal huge gingerbread mutant bugbear	9	good	Last Available: "2008-12"
 3586	drinkable oozenog	3	good	Last Available: "2008-12"
 3587	double-adjusted sugar plum	0		Effect: "Fratty Flavor", Effect Duration: 49, Last Available: "2008-12"
 3588	quadruple-pickled adjusted super-wet sugar banana	0		Effect: "Petit Force", Effect Duration: 33, Last Available: "2008-12"
@@ -3614,7 +3614,7 @@
 3648	bouncing magic dragonfish fry	0		
 3649	tumbling map to Madness Reef	0		
 3650	normal snack-sized toast with jam	2	good	Last Available: "2008-12"
-3651	bouncing antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	bouncing antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	bad elven moonshine	3	decent	Last Available: "2008-12"
 3653	flavorless wobbly knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	psycho sweater of the storm of the businessman	0		Maximum MP Percent: +40, Meat Drop: +50, Last Available: "2008-12"
@@ -3636,7 +3636,7 @@
 3670	glow-in-the-dark burrowgrub of Gandalf	0		Spell Critical Percent: +20, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	normal half-sized skewed bouncing can of franks 'n' beans	2	good	Last Available: "2010-12"
-3673	practically non-alcoholic mediocre bottle of peppermint schnapps	1	decent	Last Available: "2010-12"
+3673	mediocre practically non-alcoholic bottle of peppermint schnapps	1	decent	Last Available: "2010-12"
 3674	twirling throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	purple Mer-kin pressureglobe	0		
 3676	bouncing Mer-kin foodbucket	0		
@@ -3648,14 +3648,14 @@
 3682	globe of Deep Sauce	0		
 3683	narrow map to the Marinara Trench	0		
 3684	adequate tempura carrot	3	good	
-3685	adequate small tempura cucumber	2	good	
+3685	small adequate tempura cucumber	2	good	
 3686	spoiled tempura avocado	3	crappy	
-3687	bland tiny jittery sea broccoli	1	decent	
-3688	small bland sea cauliflower	2	decent	
+3687	tiny bland jittery sea broccoli	1	decent	
+3688	bland small sea cauliflower	2	decent	
 3689	stale narrow tempura broccoli	3	decent	
 3690	decent tempura cauliflower	4	good	
 3691	bite-sized tasty sea blueberry	1	awesome	
-3692	thick stale green sea persimmon	5	decent	
+3692	stale thick green sea persimmon	5	decent	
 3693	pickled quadruple-ionized pressurized potion of perception	0		Effect: "All Blued Up", Effect Duration: 46
 3694	deionized dry pressurized potion of proficiency	0		Effect: "Pharmaceutically Cool", Effect Duration: 49
 3695	jittery rock-hard Mer-kin digpick	0		Damage Reduction: 5
@@ -3714,7 +3714,7 @@
 3749	warmed oxidized concoction of clumsiness	0		Effect: "Cravin' for a Ravin'", Effect Duration: 31
 3750	pulsating lion tamer's vampire pearl earring	0		Experience (familiar): +2, Single Equip
 3751	spoiled thick chocolate chip brownies	5	crappy	
-3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	non-denatured polymerized love song of vague ambiguity	0		Effect: "Wet Willied", Effect Duration: 14, Last Available: "2009-02"
 3755	activated non-deionized love song of smoldering passion	0		Effect: "Abyssal Blood", Effect Duration: 37, Last Available: "2009-02"
 3756	triple-tarnished narrow love song of icy revenge	0		Effect: "Powdered", Effect Duration: 50, Last Available: "2009-02"
@@ -3726,12 +3726,12 @@
 3762	sinister vampire pearl necklace	0		Spell Damage: +10, Single Equip
 3763	high-proof artisanal mirror slug of vodka	7	EPIC	
 3764	tolerable spirit-forward slug of rum	5	good	
-3765	drinkable weak fancy slug of shochu	2	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 50
-3766	tolerable watered-down fancy screwdiver	2	good	Effect: "Blessing of Pikachutlotal", Effect Duration: 30
+3765	weak drinkable fancy slug of shochu	2	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 50
+3766	watered-down fancy tolerable screwdiver	2	good	Effect: "Blessing of Pikachutlotal", Effect Duration: 30
 3767	drinkable practically non-alcoholic dew yoana lei	1	good	
 3768	perfectly mixed skewed lychee chuhai	4	EPIC	
 3769	artisanal wobbly salacious screwdiver	3	EPIC	
-3770	perfectly mixed boozy dew yoana salacious lei	5	EPIC	
+3770	boozy perfectly mixed dew yoana salacious lei	5	EPIC	
 3771	perfectly mixed salacious lychee chuhai	4	EPIC	
 3772	artisanal practically non-alcoholic jittery Alewife&trade; Ale	1	EPIC	
 3773	seaode	0		
@@ -3748,7 +3748,7 @@
 3784	paranormal ricotta	0		Class: "Pastamancer"
 3785	ghostly smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
-3787	jittery upside-down wine-soaked bone chips	0		Class: "Pastamancer"
+3787	upside-down jittery wine-soaked bone chips	0		Class: "Pastamancer"
 3788	crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	blue narrow Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
@@ -3764,27 +3764,27 @@
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	special yummy huge shaking chocolate-frosted king cake	7	awesome	Effect: "Strong Spirit", Effect Duration: 45, Last Available: "2009-06"
+3812	yummy special huge shaking chocolate-frosted king cake	7	awesome	Effect: "Strong Spirit", Effect Duration: 45, Last Available: "2009-06"
 3813	frightening plastic baby	0		Spooky Damage: +5, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	special huge decent sea radish	6	good	Effect: "Chalked Weapon", Effect Duration: 10
+3817	decent special huge sea radish	6	good	Effect: "Chalked Weapon", Effect Duration: 10
 3818	bouncing upside-down perfumed beefy strapping halibut	0		Muscle: 15, Stench Resistance: +5
 3819	huge eel sauce	0		
 3820	pulsating water-polo mitt of Tarzan	0		Experience (Muscle): +3, Single Equip
-3821	wet energized modified skewed shaking syringe	0		Effect: "Disco Nirvana", Effect Duration: 57
+3821	wet energized modified shaking skewed syringe	0		Effect: "Disco Nirvana", Effect Duration: 57
 3822	wand	0		Familiar Effect: "fishy spells"
 3823	irradiated triple-liquefied pulsating wobbly wad of cotton	0		Effect: "Devil Inside", Effect Duration: 50
 3824	huge Grandma's Note	0		
 3825	Grandma's Fuchsia Yarn	0		
 3826	purple Grandma's Chartreuse Yarn	0		
-3827	shaking mirror plastic oyster egg	0		
+3827	mirror shaking plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	bland small spinning tempura radish	2	decent	
+3829	small bland spinning tempura radish	2	decent	
 3830	blue skewed brawny water-polo cap	0		Muscle Percent: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	aged weak Typical Tavern swill	2	awesome	
-3832	artisanal weak spinning tropical swill	2	EPIC	
-3833	lousy irresponsibly strong fruity girl swill	10	decent	
+3832	weak artisanal spinning tropical swill	2	EPIC	
+3833	irresponsibly strong lousy fruity girl swill	10	decent	
 3834	perfectly mixed blended swill	3	EPIC	
 3835	costume wardrobe	0		Softcore Only
 3836	scandalous toasty dog trainer's savvy Elvish sunglasses	0		Mysticality Percent: +20, Experience (familiar): +1, Hot Damage: +5, Sleaze Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
@@ -3842,11 +3842,11 @@
 3888	deionized adjusted deionized vial of slime	0		Effect: "Space Tripping", Effect Duration: 30
 3889	moist vial of slime	0		Effect: "Standard Cheer", Effect Duration: 34
 3890	tarnished quadruple-oxidized vial of violet slime	0		Effect: "damage.enh", Effect Duration: 35
-3891	double-electrified wet wobbly pulsating vial of vermilion slime	0		Effect: "Busy Bein' Delicious", Effect Duration: 32
+3891	double-electrified wet pulsating wobbly vial of vermilion slime	0		Effect: "Busy Bein' Delicious", Effect Duration: 32
 3892	activated vial of amber slime	0		Effect: "Slimily Strong", Effect Duration: 68
 3893	dry flattened vial of chartreuse slime	0		Effect: "Pemmican't", Effect Duration: 61
 3894	vacuum-sealed vial of teal slime	0		Effect: "Tea-hee", Effect Duration: 53
-3895	modified ionized bouncing narrow vial of indigo slime	0		Effect: "Updated", Effect Duration: 24
+3895	modified ionized narrow bouncing vial of indigo slime	0		Effect: "Updated", Effect Duration: 24
 3896	pressed deionized vial of slime	0		Effect: "Slippery Tongue", Effect Duration: 49
 3897	nitrogenated mirror vial of brown slime	0		Effect: "Eagle Eyes", Effect Duration: 42
 3898	bottle of G&uuml;-Gone	0		
@@ -3862,7 +3862,7 @@
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	blinking imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	tolerable practically non-alcoholic cyan blended swill with a fly in it	1	good	
+3913	practically non-alcoholic tolerable cyan blended swill with a fly in it	1	good	
 3914	squat wobbly turtle wax	0		
 3915	lime green sage turtle wax shield	0		Mysticality Percent: +10, Damage Reduction: 2
 3916	Jim Carey's turtle wax helmet	0		Monster Level: +25, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3914,7 +3914,7 @@
 3962	designer handbag	0		
 3963	upside-down Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	cell phone	0		Familiar Weight: +10
-3965	warmed diffused mirror bouncing spinning cube of billiard chalk	0		Effect: "Weapon of Mass Destruction", Effect Duration: 48
+3965	warmed diffused mirror spinning bouncing cube of billiard chalk	0		Effect: "Weapon of Mass Destruction", Effect Duration: 48
 3966	perfumed medical-grade hot-ass club of wisdom	0		Mysticality: +15, Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Class: "Seal Clubber"
 3967	censurious dangerous frigid-ass club of the overflowing toilet	0		Weapon Damage: +10, Stench Spell Damage: +50, Sleaze Resistance: +3, Class: "Seal Clubber"
 3968	electrified creepy-ass club of incineration of terror	0		Hot Spell Damage: +50, Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Class: "Seal Clubber"
@@ -3958,7 +3958,7 @@
 4006	memory of some amino acids	0		Last Available: "2009-06"
 4007	skewed memory of a C	0		Last Available: "2009-06"
 4008	upside-down memory of an A	0		Last Available: "2009-06"
-4009	blurry huge memory of a G	0		Last Available: "2009-06"
+4009	huge blurry memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	memory of a CG base pair	0		Last Available: "2009-06"
@@ -3986,7 +3986,7 @@
 4034	fuchsia memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	cyan caustic slime nodule	0		
-4037	immense bland slimy sweetbreads	9	decent	
+4037	bland immense slimy sweetbreads	9	decent	
 4038	lousy pulsating huge slimy fermented bile bladder	3	decent	
 4039	modified mirror slimy alveolus	1		Effect: "Rainbow Bright", Effect Duration: 30
 4040	twirling memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
@@ -4017,7 +4017,7 @@
 4065	yellow blurry Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	upside-down essence of heat	0		Last Available: "2009-06"
-4068	olive jittery essence of kink	0		Last Available: "2009-06"
+4068	jittery olive essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
@@ -4032,11 +4032,11 @@
 4080	jittery prompt dog trainer's grisly shield	0		Experience (familiar): +1, Adventures: +3, Slime Hates It: +1, Damage Reduction: 13
 4081	avaricious hardened corroded breeches	0		Damage Reduction: 3, Meat Drop: +30, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	manspreader's smooth pernicious cudgel	0		Moxie: +15, Monster Level: +10, Slime Hates It: +1
-4083	special decent cupcake-in-a-cup	3	good	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2009-06"
+4083	decent special cupcake-in-a-cup	3	good	Effect: "Stinking Cloud", Effect Duration: 30, Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
 4085	small tasty tumbling protein paste	2	awesome	Last Available: "2009-06"
 4086	spinning blurry personal trainer's cyber-mattock of the storm	0		Experience Percent (Muscle): +10, Maximum MP Percent: +40, Last Available: "2009-06"
-4087	wobbly maroon upside-down facehugging alien	0		Last Available: "2009-06"
+4087	maroon upside-down wobbly facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
 4089	triple-deionized mirror neurostim pill	0		Effect: "Snobby", Effect Duration: 65, Last Available: "2009-06"
 4090	adjusted improved physiostim pill	0		Effect: "Rainbow Bright", Effect Duration: 35, Last Available: "2009-06"
@@ -4063,7 +4063,7 @@
 4111	educational brazen bracelet of the bloodbag	0		Experience: +1, Maximum HP: +100, Last Available: "2009-06"
 4112	pulsating chilly wholesome bitter bowtie	0		Maximum HP Percent: +10, Cold Damage: +5, Last Available: "2009-06"
 4113	spinning bewitching boots of the scaredy-cat	0		Monster Level: -15, Last Available: "2009-06"
-4114	purple upside-down shaking secret from the future	0		Last Available: "2009-06"
+4114	shaking purple upside-down secret from the future	0		Last Available: "2009-06"
 4115	moist sack	0		
 4116	sharpshooter's Van der Graaf rickety unicycle of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 4117	forbidden sage beefy crusty hula hoop	0		Muscle: +10, Mysticality Percent: +10, Spell Damage Percent: +50, Single Equip
@@ -4071,7 +4071,7 @@
 4119	double-paned vibrating Herculean school flying disc	0		Experience (Muscle): +1, Maximum MP Percent: +10, Cold Resistance: +5, Damage Reduction: 14
 4120	jittery mirror Newton's lawn dart of the pedagogue of the overflowing toilet	0		Experience: +3, Experience (Mysticality): +3, Stench Spell Damage: +50
 4121	miser's arcane researcher's stylish wagon	0		Moxie: +25, Experience Percent (Mysticality): +10, Meat Drop: +10
-4122	skewed pulsating wad of slimy rags	0		
+4122	pulsating skewed wad of slimy rags	0		
 4123	up-at-dawn Fonzie's crown-shaped beanie of horror	0		Experience (Moxie): +1, Spooky Spell Damage: +25, Adventures: +5, Familiar Effect: "1xBarrr, 1xGhuol"
 4124	dance instructor's brainy hopping socks of the glutton	0		Mysticality: +5, Experience Percent (Moxie): +10, Food Drop: +100, Single Equip
 4125	pulsating sizzling wholesome poodle skirt of the cheetah	0		Maximum HP Percent: +10, Hot Damage: +10, Initiative: +60, Familiar Effect: "atk, 1xFairy"
@@ -4106,7 +4106,7 @@
 4154	pulsating live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
-4157	cyan twirling gravel	0		Last Available: "2009-09"
+4157	twirling cyan gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	bad strong upside-down pebblebr&auml;u	5	decent	Last Available: "2009-09"
@@ -4153,7 +4153,7 @@
 4201	pulsating gill rings	0		Familiar Weight: +5
 4202	jittery urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
-4204	green squat Mer-kin cheatsheet	0		
+4204	squat green Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
 4206	greasy razor-sharp brand new key	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10
 4207	resourceful dorsal fin	0		Maximum MP: +50, Damage Reduction: 13
@@ -4184,8 +4184,8 @@
 4232	wobbly ice skate doll	0		
 4233	hacienda key	0		
 4234	pat&eacute; knife of the pedagogue	0		Experience: +3
-4235	bouncing fuchsia salt-shaker	0		
-4236	jittery teal can of sterno	0		
+4235	fuchsia bouncing salt-shaker	0		
+4236	teal jittery can of sterno	0		
 4237	fuchsia fireproof cheese-slicer	0		Hot Resistance: +3
 4238	spoiled beef jerky	3	crappy	
 4239	veiny pipe wrench	0		Maximum HP: +10
@@ -4194,25 +4194,25 @@
 4242	steel-toed sock garters	0		Damage Reduction: 9, Single Equip
 4243	adjusted altered mariachi toothpaste	0		Effect: "Hennaliciousness", Effect Duration: 24
 4244	crafty leather-bound tome	0		Maximum MP: +10
-4245	mirror spinning bookmark	0		
+4245	spinning mirror bookmark	0		
 4246	ivory cue ball of doom	0		Spooky Spell Damage: +50
 4247	mediocre blinking decanter of fine Scotch	4	decent	
 4248	boiled expensive cigar	1		
 4249	pulsating tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
-4251	fuchsia bouncing fish-oil smoke bomb	0		
+4251	bouncing fuchsia fish-oil smoke bomb	0		
 4252	galvanized pressed squat vial of squid ink	0		Effect: "You're Rubber", Effect Duration: 60
 4253	oxidized adjusted mirror potion of speed	0		Effect: "Spell Transfer Complete", Effect Duration: 37
 4254	bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	activated sap	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 13, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	flavorless snack-sized shaking chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
-4259	lousy practically non-alcoholic mulled cider	1	decent	Last Available: "2009-10"
+4258	snack-sized flavorless shaking chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
+4259	practically non-alcoholic lousy mulled cider	1	decent	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4263	blurry blue Ax of L'rose	0		Last Available: "2009-10"
+4263	blue blurry Ax of L'rose	0		Last Available: "2009-10"
 4264	spinning huge Newton's bark boxers	0		Experience (Mysticality): +3, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
 4265	blurry Jack Frost's bark beret	0		Cold Spell Damage: +50, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	chaotic bark bracelet	0		Spell Critical Percent: +10, Single Equip
@@ -4228,7 +4228,7 @@
 4276	blinking curative rosy-cheeked Newton's Underworld truncheon	0		Experience (Mysticality): +3, Maximum HP Percent: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-10"
 4277	jittery lightning-fast rosewater-soaked wholesome Staff of the Woodfire	0		Maximum HP Percent: +10, Stench Resistance: +3, Initiative: +40, Last Available: "2009-10"
 4278	squat toasty Underworld flail of the bloodbag of the sweet-tooth	0		Maximum HP: +100, Hot Damage: +5, Candy Drop: +100, Last Available: "2009-10"
-4279	green ghostly ghostly Mer-kin cancerstick	0		
+4279	ghostly ghostly green Mer-kin cancerstick	0		
 4280	Mer-kin sawdust	0		
 4281	censurious steel-toed Mer-kin bunwig	0		Damage Reduction: 9, Sleaze Resistance: +3, Familiar Effect: "1xVolley"
 4282	crafty shellacked crappy Mer-kin mask of the scaredy-cat	0		Damage Reduction: 7, Maximum MP: +10, Monster Level: -15, Adventure Underwater, Familiar Effect: "hot atk, 1xBarrr"
@@ -4280,9 +4280,9 @@
 4328	mirror suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	super-sized tasty candy kneecapping stick	5	awesome	Last Available: "2009-12"
-4331	moldy thick maroon licorice garrote	5	crappy	Last Available: "2009-12"
+4331	thick moldy maroon licorice garrote	5	crappy	Last Available: "2009-12"
 4332	yellow candy knuckles of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2009-12"
-4333	delicious maroon huge tumbling jawbruiser	4	awesome	Last Available: "2010-12"
+4333	delicious maroon tumbling huge jawbruiser	4	awesome	Last Available: "2010-12"
 4334	nitrogenated skewed chocolate car	0		Effect: "Grumpy and Ornery", Effect Duration: 11, Last Available: "2009-12"
 4335	cyan Sinatra's plastic 11 Dealer	0		Experience (Moxie): +5, Last Available: "2009-12"
 4336	squat plastic Crimbo Casino of Flo-Jo	0		Initiative: +100, Last Available: "2009-12"
@@ -4309,7 +4309,7 @@
 4357	huge A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	purple pulsating A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	yummy tiny expired can of franks 'n' beans	1	awesome	Last Available: "2009-12"
+4360	tiny yummy expired can of franks 'n' beans	1	awesome	Last Available: "2009-12"
 4361	drinkable expired bottle of peppermint schnapps	4	good	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	gray elf resistance button	0		Last Available: "2009-12"
@@ -4355,13 +4355,13 @@
 4403	blinking medical-grade personal trainer's brainy Staff of Queso Escusado	0		Mysticality: +5, Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	huge The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
-4407	blurry pulsating green Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+4407	green blurry pulsating Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	shaking A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	blurry Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	wobbly purple The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	snack-sized yummy huge quantum taco	0		Last Available: "2010-10"
-4413	hand-crafted irresponsibly strong Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	yummy snack-sized huge quantum taco	0		Last Available: "2010-10"
+4413	irresponsibly strong hand-crafted Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	olive colorful plastic ball	0		Last Available: "2010-01"
 4415	squat sealhide hood	0		Item Drop: +5, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	skewed beefy sealhide leggings	0		Muscle: +10, Familiar Effect: "1xVolley, cap 40"
@@ -4410,10 +4410,10 @@
 4462	tarnished yellow chocolate seal-clubbing club	0		Effect: "Partially Ghosted", Effect Duration: 51
 4463	improved altered narrow chocolate turtle totem	0		Effect: "Voracious Gorging", Effect Duration: 41
 4464	energized chocolate pasta spoon	0		Effect: "Protection from Bad Stuff", Effect Duration: 63
-4465	oxidized concentrated fuchsia ghostly squat chocolate saucepan	0		Effect: "Cybernetic Muscles", Effect Duration: 68
+4465	oxidized concentrated ghostly squat fuchsia chocolate saucepan	0		Effect: "Cybernetic Muscles", Effect Duration: 68
 4466	dry twirling chocolate disco ball	0		Effect: "Strong Grip", Effect Duration: 46
 4467	activated denatured chocolate stolen accordion	0		Effect: "Izchak's Blessing", Effect Duration: 39
-4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
 4471	baleful BRICKO hat	0		Spell Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
@@ -4421,7 +4421,7 @@
 4473	BRICKO sword	0		Item Drop: +5, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
-4476	spinning skewed BRICKO oyster	0		Last Available: "2010-02"
+4476	skewed spinning BRICKO oyster	0		Last Available: "2010-02"
 4477	narrow BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
 4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
@@ -4440,7 +4440,7 @@
 4492	narrow BRICKO brick	0		Last Available: "2010-02"
 4493	squat broken BRICKO brick	0		Last Available: "2010-02"
 4494	bouncing BRICKO reactor	0		Last Available: "2010-02"
-4495	spinning ghostly BRICKO egg	0		Last Available: "2010-02"
+4495	ghostly spinning BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
 4497	boiled boiled triple-wet recording of The Ballad of Richie Thingfinder	0		Effect: "Stimulated Body", Effect Duration: 24
 4498	chilled electrified ghostly recording of Benetton's Medley of Diversity	0		Effect: "Puddingskin", Effect Duration: 44
@@ -4455,10 +4455,10 @@
 4507	purple Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	quantum super-diffused &quot;DRINK ME&quot; potion	0		Effect: "Resilient Spirit", Effect Duration: 49, Last Available: "2010-03"
 4509	shaking reflection of a map	0		Last Available: "2010-03"
-4510	big stale walrus ice cream	5	decent	Last Available: "2010-03"
+4510	stale big walrus ice cream	5	decent	Last Available: "2010-03"
 4511	normal beautiful soup	3	good	Last Available: "2010-03"
 4512	spinning huge eggman noodles	0		Last Available: "2010-03"
-4513	yellow skewed Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
+4513	skewed yellow Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	spoiled twirling Humpty Dumplings	3	crappy	Last Available: "2010-03"
 4515	bland yellow Lobster <i>qua</i> Grill	3	decent	Last Available: "2010-03"
 4516	practically non-alcoholic bad missing wine	1	decent	Last Available: "2010-03"
@@ -4471,14 +4471,14 @@
 4523	wool wicked eye of the Tiger-lily	0		Spell Damage: +5, Cold Resistance: +1, Last Available: "2010-03"
 4524	brainy weightlifter's wig	0		Muscle: +15, Mysticality: +5, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	normal mirror donut	4	good	Last Available: "2010-03"
-4526	diet rotten enchanted skewed bucket of honey	1	crappy	Effect: "Bloody-minded", Effect Duration: 20, Last Available: "2010-03"
+4526	rotten diet enchanted skewed bucket of honey	1	crappy	Effect: "Bloody-minded", Effect Duration: 20, Last Available: "2010-03"
 4527	frightening hardy elephant stinger	0		Maximum HP: +50, Spooky Damage: +5, Last Available: "2010-03"
 4528	flavorless dragon snaps	3	decent	Last Available: "2010-03"
 4529	skewed upside-down hardy snapdragon pistil of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	tiny bland rook cookie	1	decent	Last Available: "2010-03"
 4532	stale bishop cookie	3	decent	Last Available: "2010-03"
-4533	adequate half-sized knight cookie	2	good	Last Available: "2010-03"
+4533	half-sized adequate knight cookie	2	good	Last Available: "2010-03"
 4534	rotten king cookie	3	crappy	Last Available: "2010-03"
 4535	half-sized flavorless queen cookie	2	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	spinning fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4494,7 +4494,7 @@
 4546	narrow bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
-4549	blue tumbling carpenter	0		Last Available: "2010-03"
+4549	tumbling blue carpenter	0		Last Available: "2010-03"
 4550	purple dodo	0		Last Available: "2010-03"
 4551	educational detour shield	0		Experience: +1, Damage Reduction: 6, Last Available: "2010-03"
 4552	shaking left parenthesis	0		
@@ -4510,12 +4510,12 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	triple-distilled hand-crafted huge world's most unappetizing beverage	6	EPIC	Last Available: "2010-04"
 4564	slippery when wet shield of Calamity Jane	0		Critical Hit Percent: +15, Damage Reduction: 6, Last Available: "2010-04"
-4565	super-sized rotten raisin	5	crappy	Last Available: "2010-04"
+4565	rotten super-sized raisin	5	crappy	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	frightening thinker's flyest of shirts	0		Mysticality: +10, Spooky Damage: +5, Last Available: "2010-04"
-4568	delicious diet a dance upon the palate	1	awesome	Last Available: "2010-04"
-4569	adequate half-sized huge prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
-4570	olive huge spinning Crazyleg's razor	0		Last Available: "2010-04"
+4568	diet delicious a dance upon the palate	1	awesome	Last Available: "2010-04"
+4569	half-sized adequate huge prehistoric meteorite jawbreaker	2	good	Last Available: "2010-04"
+4570	huge spinning olive Crazyleg's razor	0		Last Available: "2010-04"
 4571	normal squirmy violent party snack	3	good	Last Available: "2010-04"
 4572	lime green huge hale can-you-dig-it?	0		Maximum HP: +20, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
@@ -4538,7 +4538,7 @@
 4590	squat nippy pixel chain whip	0		Cold Damage: +10, Last Available: "2010-07"
 4591	wobbly smooth pixel morning star	0		Moxie: +15, Last Available: "2010-07"
 4592	pixel orb	0		Last Available: "2010-07"
-4593	spinning huge pixellated moneybag	0		Last Available: "2010-07"
+4593	huge spinning pixellated moneybag	0		Last Available: "2010-07"
 4594	huge pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	tumbling map to Vanya's Castle	0		Last Available: "2010-07"
@@ -4602,7 +4602,7 @@
 4654	steel-toed ironic battle spoon	0		Damage Reduction: 9
 4655	twirling teal thinker's ironic jogging shorts of dire peril of temperance	0		Mysticality: +10, Weapon Damage: +20, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	upside-down ruddy mole skin notebook	0		Maximum HP Percent: +40
-4657	shaking lime green pair of jeans	0		Last Available: "2010-09"
+4657	lime green shaking pair of jeans	0		Last Available: "2010-09"
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	wobbly careful blackberry galoshes	0		Monster Level: -10, Single Equip
 4660	censurious manspreader's trout fang	0		Monster Level: +10, Sleaze Resistance: +3, Last Available: "2010-09"
@@ -4662,7 +4662,7 @@
 4714	normal upside-down lemon popsicle	4	good	
 4715	yummy popsicle	3	awesome	
 4716	rotten strawberry popsicle	3	crappy	
-4717	gigantic adequate liver popsicle	6	good	
+4717	adequate gigantic liver popsicle	6	good	
 4718	mariachi hat of James Dean	0		Experience (Moxie): +3, Familiar Effect: "atk, cap 2"
 4719	bouncing sinister Hollandaise helmet	0		Spell Damage: +10, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
@@ -4673,13 +4673,13 @@
 4725	adequate half-sized piping organ pie	2	good	Last Available: "2010-10"
 4726	bland igloo pie	3	decent	Last Available: "2010-10"
 4727	bland stomach turnover	3	decent	Last Available: "2010-10"
-4728	rotten miniature enchanted dead lights pie	2	crappy	Effect: "Carol of the Bones", Effect Duration: 25, Last Available: "2010-10"
+4728	enchanted rotten miniature dead lights pie	2	crappy	Effect: "Carol of the Bones", Effect Duration: 25, Last Available: "2010-10"
 4729	normal miniature throbbing organ pie	2	good	Last Available: "2010-10"
 4730	energetic stop shield	0		Maximum MP Percent: +20, Damage Reduction: 6, Last Available: "2009-12"
 4731	maroon nest egg	0		
 4732	red sleeping piano cat	0		Free Pull, Last Available: "2011-12"
 4733	yellow kitty sheet music	0		Familiar Weight: +5
-4734	squat jittery rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
+4734	jittery squat rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	prop sword	0		Familiar Weight: +5
 4736	wobbly tangle of rat tails	0		
 4737	brainy beer-soaked mop	0		Mysticality: +5
@@ -4689,7 +4689,7 @@
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
-4744	aerosolized galvanized ghostly maroon PlexiPips	0		Effect: "Category", Effect Duration: 56
+4744	aerosolized galvanized maroon ghostly PlexiPips	0		Effect: "Category", Effect Duration: 56
 4745	chilled anodized adjusted Wax Flask	0		Effect: "Libra Rising", Effect Duration: 52
 4746	diffused activated blurry Pain Dip	0		Effect: "Tea-hee", Effect Duration: 38
 4747	normal squat bone meal	4	good	Last Available: "2010-10"
@@ -4708,7 +4708,7 @@
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	upside-down pumpkin	0		Last Available: "2010-11"
 4762	purple huge pumpkin	0		Last Available: "2010-11"
-4763	normal half-sized upside-down pumpkin pie	2	good	Last Available: "2010-11"
+4763	half-sized normal upside-down pumpkin pie	2	good	Last Available: "2010-11"
 4764	extra-dry mediocre fancy squat pumpkin beer	5	decent	Effect: "Twinkly Weapon", Effect Duration: 15, Last Available: "2010-11"
 4765	warmed twirling pumpkin juice	0		Effect: "Neuromancy", Effect Duration: 39, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4722,12 +4722,12 @@
 4806	ghostly Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	upside-down upside-down bouncing Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	upside-down bouncing upside-down Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	bland purple CRIMBCOIDS mints	3	decent	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	rotten CRIMBCOLOAF	3	crappy	Last Available: "2011-01"
-4821	miniature bland circular CRIMBCOOKIE	2	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	bland miniature circular CRIMBCOOKIE	2	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	pulsating ribald plastic CRIMBCO HQ	0		Sleaze Damage: +10, Last Available: "2010-12"
 4823	blurry family-friendly plastic fax machine	0		Sleaze Resistance: +1, Last Available: "2010-12"
 4824	zippy plastic hobo elf	0		Initiative: +20, Last Available: "2010-12"
@@ -4761,7 +4761,7 @@
 4852	wool gift-a-pult	0		Cold Resistance: +1, Last Available: "2010-12"
 4853	moist adjusted shaking holly-flavored Hob-O	0		Effect: "Rave Concentration", Effect Duration: 52, Last Available: "2020-09"
 4854	ghostly CRIMBCO scrip	0		Last Available: "2011-01"
-4855	shaking bouncing Toot Oriole care package	0		
+4855	bouncing shaking Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	veiny CRIMBCO lanyard	0		Maximum HP: +10, Single Equip, Last Available: "2011-01"
@@ -4773,7 +4773,7 @@
 4864	twirling photocopier	0		Last Available: "2011-01"
 4865	deluxe fax machine	0		Last Available: "2011-01"
 4866	Workytime Tea	0		Last Available: "2011-01"
-4867	twirling fuchsia paperclip sproinger	0		Last Available: "2011-01"
+4867	fuchsia twirling paperclip sproinger	0		Last Available: "2011-01"
 4868	yellow ribald chilly paperclip-on tie of the overflowing toilet	0		Cold Damage: +5, Stench Spell Damage: +50, Sleaze Damage: +10, Single Equip, Last Available: "2011-01"
 4869	bouncing asbestos-lined nippy paperclip pants	0		Cold Damage: +10, Hot Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
 4870	executive censurious perfumed paperclip turban	0		Stench Resistance: +5, Sleaze Resistance: +3, Meat Drop: +40, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
@@ -4856,7 +4856,7 @@
 4953	auspicious whalebone corset of the brute	0		Muscle Percent: +30, Item Drop: +10, Single Equip
 4954	oven mitts of the storm	0		Maximum MP Percent: +40, Single Equip
 4955	flavorless overcookie	4	decent	
-4956	miniature spoiled blurry philosopher's scone	2	crappy	
+4956	spoiled miniature blurry philosopher's scone	2	crappy	
 4957	polarized warmed half-baked potion	0		Effect: "Ooh, Umami!", Effect Duration: 22
 4958	wobbly Knob Goblin deluxe scimitar of vim and vigor	0		Maximum HP Percent: +50
 4959	flavorless huge fuchsia Knob nuts	9	decent	
@@ -4882,12 +4882,12 @@
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
 4980	upside-down Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	narrow Alice's Army Horseman	0		Last Available: "2011-03"
-4982	squat narrow teal Alice's Army Coward	0		Last Available: "2011-03"
+4982	narrow teal squat Alice's Army Coward	0		Last Available: "2011-03"
 4983	Alice's Army Cleric	0		Last Available: "2011-03"
 4984	shaking Alice's Army Sniper	0		Last Available: "2011-03"
 4985	bouncing Alice's Army Dervish	0		Last Available: "2011-03"
 4986	blurry Alice's Army Martyr	0		Last Available: "2011-03"
-4987	lime green upside-down Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
+4987	upside-down lime green Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	upside-down Alice's Army Foil Swordsman	0		Last Available: "2011-03"
 4989	Alice's Army Foil Spearsman	0		Last Available: "2011-03"
 4990	Alice's Army Foil Halberder	0		Last Available: "2011-03"
@@ -4924,9 +4924,9 @@
 5021	alkaline blurry natto marble soda	0		Effect: "Covetous Robbery", Effect Duration: 50, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	flattened elderly jawbreaker	0		Effect: "Stuck That Way", Effect Duration: 64, Last Available: "2020-09"
-5024	weak perfectly mixed huge marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
-5025	bad extra-dry skewed cranberry schnapps	5	decent	Last Available: "2011-03"
-5026	fancy artisanal breaded beer	4	EPIC	Effect: "Frostbeard", Effect Duration: 30, Last Available: "2011-03"
+5024	perfectly mixed weak huge marshmallow flamb&eacute;	2	EPIC	Last Available: "2011-03"
+5025	extra-dry bad skewed cranberry schnapps	5	decent	Last Available: "2011-03"
+5026	artisanal fancy breaded beer	4	EPIC	Effect: "Frostbeard", Effect Duration: 30, Last Available: "2011-03"
 5027	smooth high-proof jittery soy cordial	7	awesome	Last Available: "2011-03"
 5028	nasty astral bludgeon of the blizzard of the detective	0		Cold Spell Damage: +25, Stench Damage: +5, Item Drop: +20
 5029	jittery Herculean astral shield of the cheetah	0		Experience (Muscle): +1, Initiative: +60, Damage Reduction: 15
@@ -4957,7 +4957,7 @@
 5054	twirling intriguing puzzle box	0		Last Available: "2011-04"
 5055	tumbling obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
-5057	warmed alkaline jittery blurry Atomic Comic	0		Effect: "Thickest, Sickest", Effect Duration: 17, Last Available: "2011-04"
+5057	warmed alkaline blurry jittery Atomic Comic	0		Effect: "Thickest, Sickest", Effect Duration: 17, Last Available: "2011-04"
 5058	vacuum-sealed warmed mirror Red Pill	0		Effect: "Al Dente Inferno", Effect Duration: 13, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
 5060	green ghostly mysterious present	0		Last Available: "2011-04"
@@ -4968,10 +4968,10 @@
 5065	diet decent spaghetti con calaveras	1	good	Last Available: "2011-04"
 5066	yellow s'more gun	0		Last Available: "2011-04"
 5067	rotten popcorn	4	crappy	Last Available: "2011-04"
-5068	fancy flavorless chaos popcorn	4	decent	Last Available: "2011-04"
+5068	flavorless fancy chaos popcorn	4	decent	Last Available: "2011-04"
 5069	wool stanky hole of bravery	0		Stench Spell Damage: +25, Cold Resistance: +1, Spooky Resistance: +5, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	normal bite-sized twirling pulsating s'more	0	good	Last Available: "2011-04"
+5071	bite-sized normal pulsating twirling s'more	0	good	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
 5073	tolerable Russian Ice	4	good	Last Available: "2011-04"
 5074	clay ashtray of horror	0		Spooky Spell Damage: +25, Damage Reduction: 3, Last Available: "2011-05"
@@ -5044,7 +5044,7 @@
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	wobbly E.M.U. Unit	0		Last Available: "2011-06"
-5144	squat purple handful of honey	0		
+5144	purple squat handful of honey	0		
 5145	double-colloidal pickled boiled tumbling honeypot	0		Effect: "Wit Tea", Effect Duration: 37
 5146	moldy huge mirror wild honey pie	7	crappy	
 5147	acceptable blurry honey mead	4	good	
@@ -5093,15 +5093,15 @@
 5190	bouncing Jim Carey's Operation Patriot Shield of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Monster Level: +25, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	yellow squirming egg sac	0		Last Available: "2011-06"
 5192	cold-filtered polarized corrupted data	0		Effect: "Spiky Frozen Hair", Effect Duration: 26, Last Available: "2011-06"
-5193	purple shaking skewed 11-inch knob sausage	0		
+5193	skewed purple shaking 11-inch knob sausage	0		
 5194	exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	up-at-dawn Great S-Cape	0		Adventures: +5, Softcore Only, Last Available: "2011-07"
 5197	Marvelous Unitard of the cheetah	0		Initiative: +60, Softcore Only, Last Available: "2011-07"
 5198	boiled gooey paste	1	decent	Last Available: "2011-08"
 5199	dehydrated pulsating beastly paste	1	good	Effect: "Spiro Gyro", Effect Duration: 50, Last Available: "2011-08"
-5200	dried mirror spinning paste	1	decent	Effect: "Sludgesick", Effect Duration: 35, Last Available: "2011-08"
-5201	powdered narrow ghostly ectoplasmic paste	1	awesome	Last Available: "2011-08"
+5200	dried spinning mirror paste	1	decent	Effect: "Sludgesick", Effect Duration: 35, Last Available: "2011-08"
+5201	powdered ghostly narrow ectoplasmic paste	1	awesome	Last Available: "2011-08"
 5202	modified spinning spinning greasy paste	1	decent	Last Available: "2011-08"
 5203	dried cyan ghostly bug paste	1	EPIC	Last Available: "2011-08"
 5204	powdered blurry hippy paste	1	EPIC	Last Available: "2011-08"
@@ -5109,12 +5109,12 @@
 5206	dried skewed shaking demonic paste	1	crappy	Effect: "Weather, Man", Effect Duration: 40, Last Available: "2011-08"
 5207	powdered lime green blurry indescribably horrible paste	1	decent	Last Available: "2011-08"
 5208	dehydrated paste	1	good	Last Available: "2011-08"
-5209	dehydrated tumbling cyan goblin paste	1	crappy	Last Available: "2011-08"
+5209	dehydrated cyan tumbling goblin paste	1	crappy	Last Available: "2011-08"
 5210	mixed wobbly pirate paste	1	EPIC	Last Available: "2011-08"
-5211	dehydrated ghostly ghostly blue chlorophyll paste	1	awesome	Last Available: "2011-08"
+5211	dehydrated ghostly blue ghostly chlorophyll paste	1	awesome	Last Available: "2011-08"
 5212	denatured paste	1	awesome	Last Available: "2011-08"
 5213	distilled wobbly Mer-kin paste	1	crappy	Effect: "Yet tea", Effect Duration: 50, Last Available: "2011-08"
-5214	diluted squat blue slimy paste	1	crappy	Last Available: "2011-08"
+5214	diluted blue squat slimy paste	1	crappy	Last Available: "2011-08"
 5215	dehydrated purple penguin paste	1	decent	Last Available: "2011-08"
 5216	altered huge pulsating elemental paste	1	good	Effect: "Red-Shirted Escort", Effect Duration: 15, Last Available: "2011-08"
 5217	diluted lime green cosmic paste	1	EPIC	Effect: "It's Soporiffic!", Effect Duration: 50, Last Available: "2011-08"
@@ -5123,7 +5123,7 @@
 5220	Teachings of the Fist	0		
 5221	green fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	spinning Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	spinning Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	normal Ur-Donut	3	good	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5142,23 +5142,23 @@
 5239	lousy Morto Moreto	4	decent	Last Available: "2011-09"
 5240	delicious high-proof Temps Tempranillo	8	awesome	Last Available: "2011-09"
 5241	artisanal Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
-5242	drinkable practically non-alcoholic Fromage Pinotage	1	good	Last Available: "2011-09"
+5242	practically non-alcoholic drinkable Fromage Pinotage	1	good	Last Available: "2011-09"
 5243	perfectly mixed Beignet Milgranet	3	EPIC	Last Available: "2011-09"
 5244	perfectly mixed Muschat	3	EPIC	Last Available: "2011-09"
 5245	adequate cool jelly donut	3	good	Last Available: "2011-09"
 5246	diet stale wobbly twirling shrapnel jelly donut	1	decent	Last Available: "2011-09"
 5247	spoiled occult jelly donut	3	crappy	Last Available: "2011-09"
-5248	thick spoiled fancy thyme jelly donut	5	crappy	Last Available: "2011-09"
+5248	spoiled thick fancy thyme jelly donut	5	crappy	Last Available: "2011-09"
 5249	rotten danish	3	crappy	Last Available: "2011-09"
-5250	decent diet smashed danish	1	good	Last Available: "2011-09"
+5250	diet decent smashed danish	1	good	Last Available: "2011-09"
 5251	bite-sized delicious forbidden danish	1	awesome	Last Available: "2011-09"
-5252	small toothsome spinning cool cat claw	2	awesome	Last Available: "2011-09"
+5252	toothsome small spinning cool cat claw	2	awesome	Last Available: "2011-09"
 5253	normal lime green blunt cat claw	4	good	Last Available: "2011-09"
 5254	small yummy shadowy cat claw	2	awesome	Last Available: "2011-09"
 5255	toothsome cheezburger	3	awesome	Last Available: "2011-09"
 5256	normal toasted brie	4	good	Last Available: "2011-09"
 5257	liquefied liquefied blue potion of the field gar	0		Effect: "Fruited", Effect Duration: 13, Last Available: "2011-09"
-5258	super-pressed polarized blinking blurry too legit potion	0		Effect: "Carol of the Bones", Effect Duration: 19, Last Available: "2011-09"
+5258	super-pressed polarized blurry blinking too legit potion	0		Effect: "Carol of the Bones", Effect Duration: 19, Last Available: "2011-09"
 5259	denatured Bright Water	0		Effect: "Tiki Thoughtfulness", Effect Duration: 68, Last Available: "2011-09"
 5260	galvanized cold-filtered water	0		Effect: "Hammertime", Effect Duration: 42, Last Available: "2011-09"
 5261	pickled deionized graveyard snowglobe	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 15, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	maroon stiffened broken clock	0		Damage Reduction: 1, Last Available: "2011-09"
 5282	Fonzie's dethklok	0		Experience (Moxie): +1, Last Available: "2011-09"
 5283	narrow squat savvy glacial clock	0		Mysticality Percent: +20, Last Available: "2011-09"
-5284	purple blurry Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	blurry purple Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5207,12 +5207,12 @@
 5304	stanky razor-sharp Chalice of the Malkovich Prince of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Stench Spell Damage: +25, Last Available: "2011-10"
 5305	Rosewater's Sceptre of the Torremolinos Prince	0		Mysticality Percent: +30, Last Available: "2011-10"
 5306	shaking Oprah's Medallion of the Ventrilo Prince	0		Maximum MP Percent: +50, Last Available: "2011-10"
-5307	yellow pulsating Haunted Sorority House staff guide	0		Last Available: "2011-10"
+5307	pulsating yellow Haunted Sorority House staff guide	0		Last Available: "2011-10"
 5308	ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
 5310	fuchsia shotgun shell	0		Last Available: "2011-10"
 5311	funhouse mirror	0		Last Available: "2011-10"
-5312	boiled non-frozen shaking skewed ghostly body paint	0		Effect: "Slimily Speedy", Effect Duration: 13, Last Available: "2011-10"
+5312	boiled non-frozen skewed shaking ghostly body paint	0		Effect: "Slimily Speedy", Effect Duration: 13, Last Available: "2011-10"
 5313	boiled triple-improved blinking necrotizing body spray	0		Effect: "Preemptive Medicine", Effect Duration: 57, Last Available: "2011-10"
 5314	liquefied chilled shaking bite-me-red lipstick	0		Effect: "Mucilaginous Muscle", Effect Duration: 14, Last Available: "2011-10"
 5315	ionized altered improved twirling whisker pencil	0		Effect: "Artificially Sweet", Effect Duration: 68, Last Available: "2011-10"
@@ -5221,12 +5221,12 @@
 5318	aerosolized quadruple-activated blurry Gummy Brains	0		Effect: "Mint-Condition Breath", Effect Duration: 52, Last Available: "2011-10"
 5319	super-galvanized alkaline Blood 'n' Plenty	0		Effect: "Pwnd", Effect Duration: 45, Last Available: "2011-10"
 5320	tarnished skewed Lobos Mints	0		Effect: "Eau de Tortue", Effect Duration: 24, Last Available: "2011-10"
-5321	super-energized flattened blinking gray Sweet Sword	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 23, Last Available: "2011-10"
+5321	super-energized flattened gray blinking Sweet Sword	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 23, Last Available: "2011-10"
 5322	extra-dry mediocre Ecto-Cooler	5	decent	Last Available: "2011-10"
-5323	hand-crafted enchanted practically non-alcoholic wobbly Bartles and BRAAAINS wine cooler	1	EPIC	Effect: "Muscularrr", Effect Duration: 40, Last Available: "2011-10"
-5324	practically non-alcoholic hand-crafted gray Blood Light	1	EPIC	Last Available: "2011-10"
-5325	artisanal watered-down Silver Bullet beer	2	EPIC	Last Available: "2011-10"
-5326	fancy perfectly mixed Bone's Farm &quot;wine&quot;	3	EPIC	Effect: "Stinking Cloud", Effect Duration: 40, Last Available: "2011-10"
+5323	enchanted practically non-alcoholic hand-crafted wobbly Bartles and BRAAAINS wine cooler	1	EPIC	Effect: "Muscularrr", Effect Duration: 40, Last Available: "2011-10"
+5324	hand-crafted practically non-alcoholic gray Blood Light	1	EPIC	Last Available: "2011-10"
+5325	watered-down artisanal Silver Bullet beer	2	EPIC	Last Available: "2011-10"
+5326	perfectly mixed fancy Bone's Farm &quot;wine&quot;	3	EPIC	Effect: "Stinking Cloud", Effect Duration: 40, Last Available: "2011-10"
 5327	jittery ghost protocol	0		Last Available: "2011-10"
 5328	colloidal cold-filtered sorority brain	0		Effect: "Egg Burps", Effect Duration: 58, Last Available: "2011-10"
 5329	wet red Nightstalker perfume	0		Effect: "There Is A Spoon", Effect Duration: 68, Last Available: "2011-10"
@@ -5340,7 +5340,7 @@
 5437	cyan superheated fudge	0		Last Available: "2011-11"
 5438	extra-moist fluid of fudge-finding	0		Effect: "Insatiable Hunger", Effect Duration: 41, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	immense moldy fudgesicle	9	crappy	Last Available: "2011-11"
+5440	moldy immense fudgesicle	9	crappy	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	squat The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5357,13 +5357,13 @@
 5454	jittery gummi ingot	0		Last Available: "2011-11"
 5455	pulsating gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
-5457	triple-diffused squat red Fudgie Roll	0		Effect: "Marinated", Effect Duration: 27, Last Available: "2011-11"
+5457	triple-diffused red squat Fudgie Roll	0		Effect: "Marinated", Effect Duration: 27, Last Available: "2011-11"
 5458	decent fudge bunny	4	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	pulsating up-at-dawn auspicious aromatic fudgecycle	0		Stench Resistance: +1, Item Drop: +10, Adventures: +5, Single Equip, Last Available: "2011-11"
 5461	bouncing fudge cube	0		Last Available: "2011-11"
 5462	blinking blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	pressed upside-down resolution: be wealthier	0		Effect: "It's Electric!", Effect Duration: 56, Last Available: "2012-01"
 5465	pressed double-ionized resolution: be happier	0		Effect: "Swordholder", Effect Duration: 41, Last Available: "2012-01"
 5466	frozen Vulcanized resolution: be stronger	0		Effect: "The Halls of Moxiousness", Effect Duration: 51, Last Available: "2012-01"
@@ -5371,17 +5371,17 @@
 5468	enhanced magnetized resolution: be sexier	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 57, Last Available: "2012-01"
 5469	flattened nitrogenated resolution: be feistier	0		Effect: "PERL of Great Price", Effect Duration: 21, Last Available: "2012-01"
 5470	galvanized super-diffused mirror resolution: be kinder	0		Effect: "Tin, Man", Effect Duration: 59, Last Available: "2012-01"
-5471	irradiated unsweetened wet shaking squat resolution: be more adventurous	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 56, Last Available: "2012-01"
+5471	irradiated unsweetened wet squat shaking resolution: be more adventurous	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 56, Last Available: "2012-01"
 5472	irradiated polarized resolution: be luckier	0		Effect: "Stick Emporium Membership", Effect Duration: 26, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
-5474	maroon blurry gummi ingot	0		Last Available: "2011-11"
+5474	blurry maroon gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	galvanized wet narrow gummi salamander	0		Effect: "damage.enh", Effect Duration: 44, Last Available: "2011-11"
 5477	super-alkaline activated huge gummi snake	0		Effect: "Spiky Hair", Effect Duration: 62, Last Available: "2011-11"
 5478	alkaline quantum gummi canary	0		Effect: "Walberg's Dim Bulb", Effect Duration: 29, Last Available: "2011-11"
-5479	enchanted moldy immense teal gummi bear	6	crappy	Effect: "Incredibly Hulking", Effect Duration: 30, Last Available: "2011-11"
+5479	enchanted immense moldy teal gummi bear	6	crappy	Effect: "Incredibly Hulking", Effect Duration: 30, Last Available: "2011-11"
 5480	stale purple gummi bear	4	decent	Last Available: "2011-11"
-5481	tiny adequate narrow ghostly gummi bear	1	good	Last Available: "2011-11"
+5481	adequate tiny narrow ghostly gummi bear	1	good	Last Available: "2011-11"
 5482	bland immense drunki-bear	10	decent	Last Available: "2011-11"
 5483	normal drunki-bear	3	good	Last Available: "2011-11"
 5484	moldy drunki-bear	3	crappy	Last Available: "2011-11"
@@ -5408,9 +5408,9 @@
 5505	upside-down pack of pogs	0		Last Available: "2011-11"
 5506	decent jerky coins	3	good	Last Available: "2011-11"
 5507	hand-crafted pulsating Go-Wassail	3	EPIC	Last Available: "2011-11"
-5508	concentrated maroon tumbling Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Holiday Bliss", Effect Duration: 14, Last Available: "2011-11"
-5509	super-vacuum-sealed red ghostly tumbling jittery bottle of bubbles	0		Effect: "Buggy Flavor", Effect Duration: 17, Last Available: "2011-11"
-5510	dry tumbling jittery wind-up meatcar	0		Effect: "Fever From the Flavor", Effect Duration: 61, Last Available: "2011-11"
+5508	concentrated tumbling maroon Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Holiday Bliss", Effect Duration: 14, Last Available: "2011-11"
+5509	super-vacuum-sealed jittery ghostly red tumbling bottle of bubbles	0		Effect: "Buggy Flavor", Effect Duration: 17, Last Available: "2011-11"
+5510	dry jittery tumbling wind-up meatcar	0		Effect: "Fever From the Flavor", Effect Duration: 61, Last Available: "2011-11"
 5511	Trivial Avocations Card: What?	0		Last Available: "2011-11"
 5512	Trivial Avocations Card: When?	0		Last Available: "2011-11"
 5513	Trivial Avocations Card: Who?	0		Last Available: "2011-11"
@@ -5429,17 +5429,17 @@
 5526	pickled tarnished double-cold-filtered Atomic Pop	0		Effect: "La Bamba", Effect Duration: 15, Last Available: "2020-09"
 5527	shaking do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	enchanted stale miniature berries of suffering	2	decent	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 35, Last Available: "2012-12"
+5529	miniature enchanted stale berries of suffering	2	decent	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 35, Last Available: "2012-12"
 5530	electrified double-dry tumbling baobab sap	0		Effect: "Ooh, Umami!", Effect Duration: 25, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
-5533	activated green tumbling Mortimer's nostrum	0		Effect: "Sludgesick", Effect Duration: 36, Last Available: "2012-12"
+5533	activated tumbling green Mortimer's nostrum	0		Effect: "Sludgesick", Effect Duration: 36, Last Available: "2012-12"
 5534	delicious red Barulio's bottle	4	awesome	Last Available: "2012-12"
 5535	extra-activated liquefied quantum Marvin's marvelous pill	0		Effect: "Carrion' On", Effect Duration: 22, Last Available: "2012-12"
 5536	teal Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	ghostly half-empty carton of milk	0		Last Available: "2012-12"
-5539	tumbling huge tumbling glass of warm water	0		Free Pull
+5539	tumbling tumbling huge glass of warm water	0		Free Pull
 5540	modified polarized desktop zen garden	0		Effect: "So Fresh and So Clean", Effect Duration: 46, Last Available: "2012-12"
 5541	yellow Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
@@ -5467,7 +5467,7 @@
 5564	green Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	moldy PB&BP	4	crappy	
 5566	toothsome bouncing club sandwich	4	awesome	
-5567	normal big cyan corned-beef Reuben	5	good	
+5567	big normal cyan corned-beef Reuben	5	good	
 5568	skewed frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	wobbly loose ninja carabiner	0		
@@ -5475,13 +5475,13 @@
 5572	Thwaitgold stag beetle statuette	0		
 5573	bad Drac & Tan	4	decent	Last Available: "2012-03"
 5574	mediocre weak Transylvania Sling	2	decent	Last Available: "2012-03"
-5575	lousy weak Shot of the Living Dead	2	decent	Last Available: "2012-03"
+5575	weak lousy Shot of the Living Dead	2	decent	Last Available: "2012-03"
 5576	artisanal practically non-alcoholic pulsating Buttery Knob	1	EPIC	Last Available: "2012-03"
-5577	tolerable weak squat Slippery Knob	2	good	Last Available: "2012-03"
+5577	weak tolerable squat Slippery Knob	2	good	Last Available: "2012-03"
 5578	smooth skewed Flaming Knob	3	awesome	Last Available: "2012-03"
 5579	enchanted bad yellow Grasshopper	3	decent	Effect: "Arabian Knighthood", Effect Duration: 30, Last Available: "2012-03"
 5580	high-proof acceptable Locust	9	good	Last Available: "2012-03"
-5581	hand-crafted distilled blue narrow Plague of Locusts	5	EPIC	Last Available: "2012-03"
+5581	distilled hand-crafted narrow blue Plague of Locusts	5	EPIC	Last Available: "2012-03"
 5582	lousy Red Dwarf	3	decent	Last Available: "2012-03"
 5583	practically non-alcoholic hand-crafted Golden Mean	1	EPIC	Last Available: "2012-03"
 5584	smooth watered-down Green Giant	2	awesome	Last Available: "2012-03"
@@ -5490,7 +5490,7 @@
 5587	mediocre Aye Aye, Tooth Tooth	4	decent	Last Available: "2012-03"
 5588	drinkable Humanitini	3	good	Last Available: "2012-03"
 5589	aged wobbly More Humanitini than Humanitini	3	awesome	Last Available: "2012-03"
-5590	tolerable irresponsibly strong blurry Oh, the Humanitini	7	good	Last Available: "2012-03"
+5590	irresponsibly strong tolerable blurry Oh, the Humanitini	7	good	Last Available: "2012-03"
 5591	weak lousy ghostly Great Older Fashioned	2	decent	Last Available: "2012-03"
 5592	acceptable watered-down green skewed Fuzzy Tentacle	2	good	Last Available: "2012-03"
 5593	drinkable yellow Crazymaker	3	good	Last Available: "2012-03"
@@ -5498,13 +5498,13 @@
 5595	lousy watered-down Sloe Comfortable Zoo	2	decent	Last Available: "2012-03"
 5596	smooth Sloe Comfortable Zoo on Fire	3	awesome	Last Available: "2012-03"
 5597	acceptable weak squat Suffering Sinner	2	good	Last Available: "2012-03"
-5598	weak lousy upside-down Suppurating Sinner	2	decent	Last Available: "2012-03"
+5598	lousy weak upside-down Suppurating Sinner	2	decent	Last Available: "2012-03"
 5599	aged Sizzling Sinner	3	awesome	Last Available: "2012-03"
 5600	irresponsibly strong special drinkable Firewater	7	good	Effect: "Meadulla Oblongota", Effect Duration: 10, Last Available: "2012-03"
 5601	lousy narrow Earth and Firewater	3	decent	Last Available: "2012-03"
 5602	artisanal Earth, Wind and Firewater	3	EPIC	Last Available: "2012-03"
 5603	bad weak Slimosa	2	decent	Last Available: "2012-03"
-5604	lousy practically non-alcoholic Extra-slimy Slimosa	1	decent	Last Available: "2012-03"
+5604	practically non-alcoholic lousy Extra-slimy Slimosa	1	decent	Last Available: "2012-03"
 5605	hand-crafted Slimebite	4	EPIC	Last Available: "2012-03"
 5606	fancy drinkable Cement Mixer	3	good	Effect: "Stuck That Way", Effect Duration: 40, Last Available: "2012-03"
 5607	mediocre Jackhammer	3	decent	Last Available: "2012-03"
@@ -5512,29 +5512,29 @@
 5609	bad watered-down tumbling Fauna Libre	2	decent	Last Available: "2012-03"
 5610	perfectly mixed skewed Chakra Libre	4	EPIC	Last Available: "2012-03"
 5611	perfectly mixed Aura Libre	3	EPIC	Last Available: "2012-03"
-5612	hand-crafted enchanted Sazerorc	3	EPIC	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2012-03"
+5612	enchanted hand-crafted Sazerorc	3	EPIC	Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2012-03"
 5613	delicious bouncing Sazuruk-hai	3	awesome	Last Available: "2012-03"
 5614	artisanal Flaming Sazerorc	4	EPIC	Last Available: "2012-03"
 5615	tolerable Green Velvet	3	good	Last Available: "2012-03"
 5616	hand-crafted weak Green Muslin	2	EPIC	Last Available: "2012-03"
 5617	aged Green Burlap	3	awesome	Last Available: "2012-03"
 5618	tolerable teal Mohobo	3	good	Last Available: "2012-03"
-5619	acceptable fortified mirror Moonshine Mohobo	5	good	Last Available: "2012-03"
+5619	fortified acceptable mirror Moonshine Mohobo	5	good	Last Available: "2012-03"
 5620	weak delicious Flaming Mohobo	2	awesome	Last Available: "2012-03"
-5621	weak acceptable cyan Drunken Philosopher	2	good	Last Available: "2012-03"
+5621	acceptable weak cyan Drunken Philosopher	2	good	Last Available: "2012-03"
 5622	bad squat Drunken Neurologist	3	decent	Last Available: "2012-03"
 5623	perfectly mixed watered-down squat Drunken Astrophysicist	2	EPIC	Last Available: "2012-03"
 5624	tolerable high-proof squat Dark & Starry	7	good	Last Available: "2012-03"
 5625	aged weak Black Hole	2	awesome	Last Available: "2012-03"
 5626	perfectly mixed maroon Event Horizon	4	EPIC	Last Available: "2012-03"
-5627	watered-down drinkable fancy Herring Daiquiri	2	good	Effect: "Slightly Mutated", Effect Duration: 50, Last Available: "2012-03"
+5627	drinkable fancy watered-down Herring Daiquiri	2	good	Effect: "Slightly Mutated", Effect Duration: 50, Last Available: "2012-03"
 5628	lousy skewed Herring Wallbanger	4	decent	Last Available: "2012-03"
 5629	artisanal Herringtini	3	EPIC	Last Available: "2012-03"
-5630	tolerable weak Lollipop Drop	2	good	Last Available: "2012-03"
+5630	weak tolerable Lollipop Drop	2	good	Last Available: "2012-03"
 5631	tolerable Candy Alexander	3	good	Last Available: "2012-03"
 5632	aged Candicaine	3	awesome	Last Available: "2012-03"
 5633	mediocre practically non-alcoholic Caipiranha	1	decent	Last Available: "2012-03"
-5634	delicious weak Flying Caipiranha	2	awesome	Last Available: "2012-03"
+5634	weak delicious Flying Caipiranha	2	awesome	Last Available: "2012-03"
 5635	drinkable Flaming Caipiranha	3	good	Last Available: "2012-03"
 5636	bad Punchplanter	4	decent	Last Available: "2012-03"
 5637	delicious distilled pulsating Doublepunchplanter	5	awesome	Last Available: "2012-03"
@@ -5555,7 +5555,7 @@
 5652	jittery Monster Manuel	0		Free Pull
 5653	purple key-o-tron	0		
 5654	decent nailswurst	4	good	
-5655	perfectly mixed watered-down special upside-down used beer	2	EPIC	Effect: "Sated and Furious", Effect Duration: 25
+5655	watered-down special perfectly mixed upside-down used beer	2	EPIC	Effect: "Sated and Furious", Effect Duration: 25
 5656	Huggler Radio	0		Free Pull
 5657	maroon fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	pulsating slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5565,7 +5565,7 @@
 5662	bouncing Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	microwave	0		Free Pull
 5664	pulsating pony keg	0		Free Pull
-5665	ghostly blue How to Tolerate Jerks	0		Skill: "Thick-Skinned"
+5665	blue ghostly How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	pulsating How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	huge puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
@@ -5574,7 +5574,7 @@
 5671	perfectly mixed slap and slap again	3	EPIC	
 5672	gunpowder burrito	2	good	
 5673	upside-down beery blood	2	good	
-5674	teal upside-down &quot;L&quot;	0		
+5674	upside-down teal &quot;L&quot;	0		
 5675	altered lime green watered-down Red Minotaur	1		
 5676	huge pool torpedo	0		Last Available: "2012-05"
 5677	jittery coward's Ze&trade; goggles	0		Monster Level: -20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
@@ -5638,8 +5638,8 @@
 5737	boiled non-ionized tumbling daub-breaker	0		Effect: "Fire Inside", Effect Duration: 20, Last Available: "2020-09"
 5738	Socratic Camp Scout backpack	0		Experience (Mysticality): +1, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
-5740	half-sized spoiled narrow bag of GORP	2	crappy	Last Available: "2012-07"
-5741	high-proof drinkable water purification pills	10	good	Last Available: "2012-07"
+5740	spoiled half-sized narrow bag of GORP	2	crappy	Last Available: "2012-07"
+5741	drinkable high-proof water purification pills	10	good	Last Available: "2012-07"
 5742	purple Camp Scout pup tent	0		Last Available: "2012-07"
 5743	lousy CSA scoutmaster's &quot;water&quot;	3	decent	Last Available: "2012-07"
 5744	flavorless bag of GORF	4	decent	Last Available: "2012-07"
@@ -5654,12 +5654,12 @@
 5753	gigantic rotten upside-down decent brain	8	crappy	
 5754	moldy good brain	3	crappy	
 5755	bland boss brain	3	decent	
-5756	bite-sized flavorless hunter brain	1	decent	
+5756	flavorless bite-sized hunter brain	1	decent	
 5758	squat fireproof scorching wicked Staff of Holiday Sensations	0		Spell Damage: +5, Hot Damage: +25, Hot Resistance: +3, Last Available: "2011-11"
 5759	curative hardy staff	0		Maximum HP: +50, HP Regen Min: 3, HP Regen Max: 5
 5760	reassuring hardened staff of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Spooky Resistance: +1
 5761	deadly Staff of the Scummy Sink of Gandalf of temperance	0		Weapon Damage: +5, Spell Critical Percent: +20, Sleaze Resistance: +5, Slime Hates It: +1
-5762	shaking lime green nose	0		
+5762	lime green shaking nose	0		
 5763	squat friendly Superhero Reboots of mayonnaise	0		Familiar Weight: +3, Sleaze Spell Damage: +50
 5764	purple inspector's wool fuzzy busby	0		Cold Resistance: +1, Item Drop: +15, Familiar Effect: "1.5xVolley, cap 32"
 5765	grievous fuzzy earmuffs of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Familiar Effect: "1.5xVolley, cap 32"
@@ -5669,12 +5669,12 @@
 5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
 5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
 5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	teal mirror gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5772	mirror teal gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	maroon Thwaitgold maggot statuette	0		
 5774	mirror bouncing talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	frosty occult Barney's rake	0		Spell Damage Percent: +25, Cold Spell Damage: +10
-5778	moldy snack-sized yellow idiot brain	2	crappy	
+5778	snack-sized moldy yellow idiot brain	2	crappy	
 5779	stylish keel-haulin' knife	0		Moxie: +25
 5780	steel-toed ice cream scoop	0		Damage Reduction: 9
 5781	smooth soft echo eyedrop antidote martini	3	awesome	
@@ -5697,9 +5697,9 @@
 5798	ionized Gnollish Crossdress	0		Effect: "Ginger Snapped", Effect Duration: 57
 5799	boiled eldritch dough	0		Effect: "New Zeal", Effect Duration: 61
 5800	altered activated squat Charity's choker	0		Effect: "Empathy", Effect Duration: 21
-5801	boiled squat blinking Smart Bone Dust	0		Effect: "One Foot Heavier", Effect Duration: 29
+5801	boiled blinking squat Smart Bone Dust	0		Effect: "One Foot Heavier", Effect Duration: 29
 5802	deionized polarized perpendicular guano	0		Effect: "Experimental Effect G-9", Effect Duration: 15
-5803	irradiated upside-down blue White Chocolate Golem Seeds	0		Effect: "Wasabi With You", Effect Duration: 44
+5803	irradiated blue upside-down White Chocolate Golem Seeds	0		Effect: "Wasabi With You", Effect Duration: 44
 5804	denatured non-dry Shivering Ch&egrave;vre	0		Effect: "Sweet Incentive", Effect Duration: 57
 5805	nitrogenated chilled pulsating breath mint	0		Effect: "Hammered", Effect Duration: 42
 5806	colloidal nitrogenated double-oxidized muesli	0		Effect: "Flamingly Floral", Effect Duration: 12
@@ -5726,7 +5726,7 @@
 5827	oxidized twirling skeletal banana	0		Effect: "Stuck-Up Hair", Effect Duration: 44
 5828	aerosolized pulsating gilt perfume bottle	0		Effect: "Bilious Briskness", Effect Duration: 65
 5829	activated janglin' bones	0		Effect: "Melancholy Burden", Effect Duration: 45
-5830	extra-ionized narrow bouncing blue pygmy papers	0		Effect: "Tingling Feeling", Effect Duration: 46
+5830	extra-ionized narrow blue bouncing pygmy papers	0		Effect: "Tingling Feeling", Effect Duration: 46
 5831	dry gray bouncing pygmy dart	0		Effect: "Cat-Alyzed", Effect Duration: 27
 5832	nitrogenated mirror mirror secret mummy herbs and spices	0		Effect: "Fiery Spirit", Effect Duration: 20
 5833	double-electrified chilled brigand brittle	0		Effect: "Ichorous Eyesight", Effect Duration: 58
@@ -5743,13 +5743,13 @@
 5844	diffused huge una poca de gracia	0		Effect: "Boon of the War Snapper", Effect Duration: 42
 5845	non-moist olive compressed air canister	0		Effect: "Optimist Primal", Effect Duration: 56
 5846	irradiated colloidal red salt water taffy	0		Effect: "Mathematically Precise", Effect Duration: 25
-5847	dry red jittery unholy water	0		Effect: "Rootin' Around", Effect Duration: 36
+5847	dry jittery red unholy water	0		Effect: "Rootin' Around", Effect Duration: 36
 5848	quadruple-adjusted Bangyomaman battle juice	0		Effect: "Your Eyes are Peeled!", Effect Duration: 47
 5849	wet jittery squat handyman &quot;hand soap&quot;	0		Effect: "Muddled", Effect Duration: 20
 5850	quantum space marine flash grenade	0		Effect: "[800]Chocolate Reign", Effect Duration: 33
 5851	pickled temporary tribal tattoo	0		Effect: "Blubbered Up", Effect Duration: 20
 5852	tarnished triple-colloidal oil-filled donut	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 24
-5853	activated dry ghostly narrow stick-on gnome beard	0		Effect: "Powder Power", Effect Duration: 13
+5853	activated dry narrow ghostly stick-on gnome beard	0		Effect: "Powder Power", Effect Duration: 13
 5854	adjusted liquefied BRICKO stud	0		Effect: "Industrial Strength Starch", Effect Duration: 25
 5855	liquefied boiled adjusted tumbling Osk'r Chow	0		Effect: "Sticks and Stones", Effect Duration: 25
 5856	frozen Vulcanized Scuba Snack	0		Effect: "BOOsted", Effect Duration: 41
@@ -5758,7 +5758,7 @@
 5859	dry energized colloidal booby trap	0		Effect: "Brocolate Brostidigitation", Effect Duration: 58
 5860	triple-vacuum-sealed frozen double-denatured Agent Corrigan's cigarette	0		Effect: "Magically Fingered", Effect Duration: 22
 5861	galvanized non-magnetized wobbly good ash	0		Effect: "Hot Buttoned", Effect Duration: 64
-5862	upside-down lime green Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	lime green upside-down Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	frozen double-chilled huge papier-mochi	0		Effect: "Very Clean Teeth", Effect Duration: 21, Last Available: "2012-09"
@@ -5779,11 +5779,11 @@
 5880	spinning packet of dragon's teeth	0		Last Available: "2012-10"
 5881	blinking skeleton	0		Last Available: "2012-10"
 5882	Newton's skeleton skis of the cougar of chilblains	0		Moxie: +20, Experience (Mysticality): +3, Cold Damage: +25, Single Equip, Last Available: "2012-10"
-5883	miniature stale special skeleton quiche	2	decent	Effect: "Patched In", Effect Duration: 45, Last Available: "2012-10"
+5883	stale special miniature skeleton quiche	2	decent	Effect: "Patched In", Effect Duration: 45, Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	cyan skeletal skiff	0		Last Available: "2012-10"
 5886	greedy Temple Grandin's Bonestabber of James Dean of courage	0		Experience (Moxie): +3, Familiar Weight: +7, Spooky Resistance: +3, Meat Drop: +20, Last Available: "2012-10"
-5887	triple-distilled hand-crafted crystal skeleton vodka	9	EPIC	Last Available: "2012-10"
+5887	hand-crafted triple-distilled crystal skeleton vodka	9	EPIC	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	blurry sage auxiliary backbone	0		Mysticality Percent: +10, Last Available: "2012-10"
 5890	bouncing skulldozer egg	0		Last Available: "2012-10"
@@ -5797,7 +5797,7 @@
 5898	fuchsia jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	red jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	fuchsia jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
-5901	bouncing squat jar of psychoses (The Old Man)	0		Last Available: "2013-12"
+5901	squat bouncing jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	pulsating jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
@@ -5824,7 +5824,7 @@
 5926	spinning BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
 5928	Da Vinci's brainwave-controlled unicorn horn	0		Experience (Mysticality): +5, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
-5929	ghostly skewed bubble-wrap simulator	0		Last Available: "2012-12"
+5929	skewed ghostly bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	jittery wool Samson's brainy plastic four-shadowed mime	0		Mysticality: +5, Experience (Muscle): +5, Cold Resistance: +1, Single Equip, Last Available: "2012-12"
 5932	rock-hard hardened plastic Bugbear Captain	0		Damage Reduction: 16, Single Equip, Last Available: "2012-12"
@@ -5873,7 +5873,7 @@
 5975	bouncing yellow record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	mirror bouncing record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	blinking inspector's medical-grade silent beret of extreme caution	0		Monster Level: -25, Item Drop: +15, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley, cap 3"
-5978	immense tasty enchanted slice of pizza	6	awesome	Effect: "Healthy Bronze Glow", Effect Duration: 35, Last Available: "2013-02"
+5978	tasty immense enchanted slice of pizza	6	awesome	Effect: "Healthy Bronze Glow", Effect Duration: 35, Last Available: "2013-02"
 5979	mirror huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
@@ -5894,7 +5894,7 @@
 5996	shaking extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	watered-down perfectly mixed shining goblet	2	super EPIC	Last Available: "2013-02"
-5999	shaking pulsating fireball	0		Last Available: "2013-02"
+5999	pulsating shaking fireball	0		Last Available: "2013-02"
 6000	Jeselnik's energetic stylish crown	0		Moxie: +25, Maximum MP Percent: +20, Sleaze Damage: +25, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	Usain Bolt's scandalous sword of temperance	0		Sleaze Damage: +5, Sleaze Resistance: +5, Initiative: +80, Last Available: "2013-02"
 6002	stanky Annie Oakley's Helm of the Scream Emperor of the wise owl	0		Mysticality: +20, Critical Hit Percent: +20, Stench Spell Damage: +25, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
@@ -5948,8 +5948,8 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	decent wobbly Taco Dan's Taco Stand Taco	3	good	Last Available: "2012-12"
-6053	mediocre practically non-alcoholic wobbly Taco Dan's Taco Stand Chimichangarita	1	decent	Last Available: "2012-12"
-6054	oxidized spinning narrow Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Eyes for Miles", Effect Duration: 26, Last Available: "2012-12"
+6053	practically non-alcoholic mediocre wobbly Taco Dan's Taco Stand Chimichangarita	1	decent	Last Available: "2012-12"
+6054	oxidized narrow spinning Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Eyes for Miles", Effect Duration: 26, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	spinning mirror blurry hardened Sinatra's Meatcleaver	0		Experience (Moxie): +5, Damage Reduction: 3, Last Available: "2013-12"
@@ -5966,11 +5966,11 @@
 6068	shaking loose blade	0		
 6069	mirror goblin bone hilt	0		
 6070	blinking sword blade	0		
-6071	green Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	green Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	skewed confusing LED clock	0		Last Available: "2012-12"
 6073	dry activated altered skewed jittery haggis-infused soap	0		Effect: "Feroci Tea", Effect Duration: 68, Last Available: "2012-12"
 6074	galvanized magicberry tablets	0		Effect: "Chief Executive Optimism", Effect Duration: 48, Last Available: "2012-12"
-6075	pickled upside-down narrow 37x37x37 puzzle cube	0		Effect: "Alpine Mintiness", Effect Duration: 46, Last Available: "2012-12"
+6075	pickled narrow upside-down 37x37x37 puzzle cube	0		Effect: "Alpine Mintiness", Effect Duration: 46, Last Available: "2012-12"
 6076	practically non-alcoholic lousy wobbly McLeod's Hard Haggis-Ade	1	decent	Last Available: "2012-12"
 6077	small moldy haggis-wrapped haggis-stuffed haggis	2	crappy	Last Available: "2012-12"
 6078	pulsating home robotics kit	0		Last Available: "2012-12"
@@ -6000,7 +6000,7 @@
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	Artist's Butterknife of Regret	0		Last Available: "2013-12"
-6105	wobbly jittery Artist's Spatula of Despair	0		Last Available: "2013-12"
+6105	jittery wobbly Artist's Spatula of Despair	0		Last Available: "2013-12"
 6106	Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	spinning Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	huge ruddy supercool Ginsu&trade;	0		Moxie Percent: +20, Maximum HP Percent: +40, Last Available: "2013-12"
@@ -6071,7 +6071,7 @@
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	huge GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	fuchsia cosmic egg	0		
-6177	mirror squat cosmic dough	0		
+6177	squat mirror cosmic dough	0		
 6178	ghostly cosmic vegetable	0		
 6179	cosmic cheese	0		
 6180	narrow cosmic potted meat product	0		
@@ -6080,55 +6080,55 @@
 6183	tumbling cosmic fruit	0		
 6184	Sherlock's hale occult Jarlsberg's hat	0		Spell Damage Percent: +25, Maximum HP: +20, Item Drop: +25
 6185	flavorless consummate hard-boiled egg	3	decent	
-6186	thick spoiled consummate fried egg	5	crappy	
+6186	spoiled thick consummate fried egg	5	crappy	
 6187	decent massive mirror consummate egg salad	9	good	
 6188	yummy consummate bagel	3	awesome	
 6189	small decent consummate sliced bread	2	good	
 6190	spoiled consummate hot dog bun	4	crappy	
 6191	delicious consummate brownie	4	awesome	
-6192	jumbo normal ghostly blue consummate toast	5	good	
+6192	normal jumbo ghostly blue consummate toast	5	good	
 6193	drinkable passable stout	3	good	
 6194	moldy consummate soup	3	crappy	
 6195	moldy consummate corn chips	3	crappy	
 6196	bland huge consummate salad	4	decent	
-6197	stale half-sized consummate salsa	2	decent	
-6198	spoiled bite-sized ghostly consummate sauerkraut	1	crappy	
+6197	half-sized stale consummate salsa	2	decent	
+6198	bite-sized spoiled ghostly consummate sauerkraut	1	crappy	
 6199	spoiled miniature blurry consummate cheese slice	2	crappy	
 6200	delicious low-calorie consummate melted cheese	1	awesome	
-6201	moldy wobbly bouncing wobbly consummate bacon	4	crappy	
-6202	decent miniature consummate meatloaf	2	good	
+6201	moldy wobbly wobbly bouncing consummate bacon	4	crappy	
+6202	miniature decent consummate meatloaf	2	good	
 6203	spoiled consummate steak	3	crappy	
-6204	thick normal bouncing consummate cuts	5	good	
+6204	normal thick bouncing consummate cuts	5	good	
 6205	enchanted moldy mirror consummate frankfurter	3	crappy	Effect: "Eyes of the Dragon", Effect Duration: 25
 6206	yummy lime green consummate french fries	3	awesome	
 6207	rotten miniature consummate baked potato	2	crappy	
 6208	lousy gray acceptable vodka	3	decent	
 6209	snack-sized bland consummate ice cream	2	decent	
 6210	super-sized normal consummate whipped cream	5	good	
-6211	moldy super-sized consummate cream	5	crappy	
+6211	super-sized moldy consummate cream	5	crappy	
 6212	half-sized spoiled consummate strawberries	2	crappy	
 6213	spoiled blinking consummate sorbet	3	crappy	
 6214	aged adequate rum	3	awesome	
 6215	acceptable mediocre lager	3	good	
 6216	small delicious immaculate grilled cheese	2	awesome	
 6217	spoiled immaculate ice cream sandwich	4	crappy	
-6218	enchanted adequate immaculate hot dog	4	good	Effect: "Dilated Pupils", Effect Duration: 25
+6218	adequate enchanted immaculate hot dog	4	good	Effect: "Dilated Pupils", Effect Duration: 25
 6219	decent immaculate egg salad sandwich	3	good	
-6220	rotten miniature perfect sandwich	2	crappy	
+6220	miniature rotten perfect sandwich	2	crappy	
 6221	gigantic stale blinking perfect chef salad	9	decent	
 6222	toothsome shaking perfect breakfast	3	awesome	
 6223	flavorless super-sized enchanted sublime deluxe hot dog	5	decent	Effect: "High Blood Chocolate Content", Effect Duration: 15
-6224	adequate snack-sized sublime stew	2	good	
-6225	spoiled enchanted jumbo sublime nachos	5	crappy	Effect: "Deadly Flashing Blade", Effect Duration: 45
+6224	snack-sized adequate sublime stew	2	good	
+6225	spoiled jumbo enchanted sublime nachos	5	crappy	Effect: "Deadly Flashing Blade", Effect Duration: 45
 6226	thick moldy tumbling Ultimate Breakfast Sandwich	5	crappy	
 6227	decent half-sized Loaded Baked Potato	2	good	
 6228	rotten special Omega Sundae	3	crappy	Effect: "Stregngth of the Gnome", Effect Duration: 20
-6229	weak acceptable Das Sauerlager	2	good	
+6229	acceptable weak Das Sauerlager	2	good	
 6230	lousy Bologna Lambic	4	decent	
 6231	lousy Vodka Dog	3	decent	
 6232	weak tolerable cyan Disappointed Russian	2	good	
 6233	triple-distilled acceptable Chunky Mary	6	good	
-6234	triple-distilled tolerable Nachojito	8	good	
+6234	tolerable triple-distilled Nachojito	8	good	
 6235	weak tolerable Le Roi	2	good	
 6236	acceptable huge Over Easy Rider	4	good	
 6237	cosmic six-pack	0		
@@ -6253,7 +6253,7 @@
 6357	blue Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	ghostly pulsating Mer-kin begsign of the scaredy-cat	0		Monster Level: -15, Meat Drop: +40
-6360	cyan bouncing Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	cyan bouncing Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	enhanced irradiated skewed pulled taffy	0		Effect: "Bored Stiff", Effect Duration: 59, Last Available: "2013-04"
 6362	anodized pulled indigo taffy	0		Effect: "Painted-On Bikini", Effect Duration: 11, Last Available: "2013-04"
 6363	pickled concentrated quantum pulled taffy	0		Effect: "Bandersnatched", Effect Duration: 36, Last Available: "2013-04"
@@ -6310,7 +6310,7 @@
 6415	spoiled narrow flavorless gruel	3	crappy	
 6416	stale low-calorie fuchsia mana curds	1	decent	
 6417	blurry twist of lime	0		
-6418	spinning lime green pencil stub	0		
+6418	lime green spinning pencil stub	0		
 6419	magnetized non-aerosolized non-frozen skewed moth dust	0		Effect: "Hagnk's Gratitude", Effect Duration: 57
 6420	Vulcanized dry wobbly glob of spoiled mayo	0		Effect: "Human-Fish Hybrid", Effect Duration: 35
 6421	tonic djinn	0		
@@ -6319,7 +6319,7 @@
 6424	yellow Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	yummy Dreadsylvanian stew	3	awesome	
-6427	weak delicious Dreadsylvanian	2	awesome	
+6427	delicious weak Dreadsylvanian	2	awesome	
 6428	modified unsweetened colloidal Dreadsylvanian flask	0		Effect: "Mushroom Moxiousness", Effect Duration: 66
 6429	tarnished huge gray Dreadsylvanian flask	0		Effect: "Toast Tea", Effect Duration: 69
 6430	slick dreadful fedora of the detective	0		Moxie: +10, Item Drop: +20, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6331,7 +6331,7 @@
 6436	Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
 6438	narrow Mark of the Vampire	0		
-6439	blinking spinning Mark of the Skeleton	0		
+6439	spinning blinking Mark of the Skeleton	0		
 6440	bouncing foul-smelling banded brainy Covers-Your-Head	0		Mysticality: +5, Damage Absorption: +100, Stench Damage: +10, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
 6441	ghostly censurious dangerous Drapes-You-Regally of the brazier	0		Weapon Damage: +10, Hot Spell Damage: +25, Sleaze Resistance: +3, Class: "Disco Bandit"
 6442	flame-retardant Warms-Your-Tush of mayonnaise of the detective	0		Sleaze Spell Damage: +50, Hot Resistance: +1, Item Drop: +20, Class: "Disco Bandit", Familiar Effect: "1xVolley, 1xPotato"
@@ -6409,8 +6409,8 @@
 6514	upside-down upside-down snowstick of the dark arts	0		Spell Damage Percent: +100
 6515	beefy eerie fetish	0		Muscle: +10, Single Equip
 6516	lousy stinkwater	4	decent	
-6517	mirror huge dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	huge decent accidental mutton	9	good	
+6517	huge mirror dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
+6518	decent huge accidental mutton	9	good	
 6519	stanky friendly drafty drawers	0		Familiar Weight: +3, Stench Spell Damage: +25, Familiar Effect: "1.5xVolley"
 6520	cyan Temple Grandin's forbidden wolfskull mask	0		Spell Damage Percent: +50, Familiar Weight: +7, Familiar Effect: "spooky atk, 1xBarrr"
 6521	teal ghostly blinking guts necklace of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip
@@ -6421,7 +6421,7 @@
 6526	brawny bag of unfinished business of Gandalf	0		Muscle Percent: +20, Spell Critical Percent: +20
 6527	upside-down teal scandalous Jack Frost's transparent pants	0		Cold Spell Damage: +50, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	dance instructor's hothammer	0		Experience Percent (Moxie): +10
-6529	artisanal enchanted fortified narrow Thriller Ice	5	EPIC	Effect: "Also Schmeckt Zarathustra", Effect Duration: 50
+6529	enchanted artisanal fortified narrow Thriller Ice	5	EPIC	Effect: "Also Schmeckt Zarathustra", Effect Duration: 50
 6530	ruddy grandfather watch	0		Maximum HP Percent: +40, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	blinking ruddy spyglass of the businessman	0		Maximum HP Percent: +40, Meat Drop: +50
@@ -6459,11 +6459,11 @@
 6565	rotten upside-down Dreadsylvanian pocket	4	crappy	
 6566	bland teal Dreadsylvanian pocket	3	decent	
 6567	decent Dreadsylvanian stink pocket	3	good	
-6568	half-sized flavorless Dreadsylvanian sleaze pocket	2	decent	
+6568	flavorless half-sized Dreadsylvanian sleaze pocket	2	decent	
 6569	mediocre triple-distilled Dreadsylvanian hot toddy	10	decent	
-6570	watered-down bad narrow Dreadsylvanian cold-fashioned	2	decent	
+6570	bad watered-down narrow Dreadsylvanian cold-fashioned	2	decent	
 6571	triple-distilled acceptable Dreadsylvanian grimlet	6	good	
-6572	watered-down hand-crafted yellow bouncing Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	
+6572	hand-crafted watered-down yellow bouncing Dreadsylvanian dank and stormy	2	super ultra mega turbo EPIC	
 6573	smooth Dreadsylvanian slithery nipple	4	awesome	
 6574	huge hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6502,7 +6502,7 @@
 6608	clockwork numeral VIII	0		
 6609	twirling clockwork numeral IX	0		
 6610	mirror clockwork numeral X	0		
-6611	cyan twirling clockwork numeral XI	0		
+6611	twirling cyan clockwork numeral XI	0		
 6612	clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
 6614	cuckoo clock	0		
@@ -6541,14 +6541,14 @@
 6649	warmed spinning Ogres and Oubliettes&trade; module	0		Effect: "Sticky Hands", Effect Duration: 69
 6650	shaking Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	drinkable weak stepmom's booze	2	good	
+6652	weak drinkable stepmom's booze	2	good	
 6653	jittery surgical tape	0		
 6654	band T-shirt of courage	0		Spooky Resistance: +3
 6655	lousy fountain 'soda'	3	decent	
-6656	blinking upside-down illegal firecracker	0		
+6656	upside-down blinking illegal firecracker	0		
 6657	mansplainer's strapping pickelhaube	0		Muscle: +5, Monster Level: +15, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	frozen hair oil	0		Effect: "Chalked Weapon", Effect Duration: 68
-6659	ionized tumbling fuchsia scrap	0		Effect: "Moon-Eyed", Effect Duration: 54
+6659	ionized fuchsia tumbling scrap	0		Effect: "Moon-Eyed", Effect Duration: 54
 6660	school spirit socket set	0		
 6661	huge suspension bridge	0		
 6662	frosty lion tamer's Temple Grandin's Staff of the Lunch Lady of the brazier	0		Familiar Weight: +7, Experience (familiar): +2, Cold Spell Damage: +10, Hot Spell Damage: +25
@@ -6563,7 +6563,7 @@
 6671	altered adjusted colloidal blurry pulsating sodium pentasomething	0		Effect: "Ruby-ous", Effect Duration: 36
 6672	yellow grains of salt	0		
 6673	yellowcake bomb	0		
-6674	mirror skewed stinkbomb	0		
+6674	skewed mirror stinkbomb	0		
 6675	moist superwater	0		Effect: "Well Owl Be!", Effect Duration: 66
 6676	maroon Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
@@ -6613,9 +6613,9 @@
 6721	scorching friendly Oprah's water bottle	0		Maximum MP Percent: +50, Familiar Weight: +3, Hot Damage: +25, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	deionized irradiated lime green pygmy phone number	0		Effect: "Chock Full o' Nanites", Effect Duration: 59
 6723	Boozehounds Anonymous token	0		
-6724	moldy small exotic jungle fruit	2	crappy	
+6724	small moldy exotic jungle fruit	2	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
-6726	blurry spinning dude ranch souvenir crate	0		
+6726	spinning blurry dude ranch souvenir crate	0		
 6727	wobbly tropical island souvenir crate	0		
 6728	wobbly ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
@@ -6635,7 +6635,7 @@
 6743	crafty junk trunks	0		Maximum MP: +10, Familiar Effect: "cap 15"
 6744	green junk-mail shirt of courage	0		Spooky Resistance: +3
 6745	yummy junk food	4	awesome	
-6746	drinkable weak junk yard	2	good	
+6746	weak drinkable junk yard	2	good	
 6747	foul-smelling swordzall of Gandalf	0		Spell Critical Percent: +20, Stench Damage: +10
 6748	Jim Carey's arm buzzer	0		Monster Level: +25, Damage Reduction: 6
 6749	frosty hale boilgun	0		Maximum HP: +20, Cold Spell Damage: +10
@@ -6648,13 +6648,13 @@
 6756	artisanal homebrew sampler	0		
 6757	mediocre fuchsia can of Br&uuml;talbr&auml;u	4	decent	Last Available: "2013-09"
 6758	drinkable ghostly can of Drooling Monk	3	good	Last Available: "2013-09"
-6759	practically non-alcoholic artisanal skewed can of Impetuous Scofflaw	1	EPIC	Last Available: "2013-09"
+6759	artisanal practically non-alcoholic skewed can of Impetuous Scofflaw	1	EPIC	Last Available: "2013-09"
 6760	hand-crafted upside-down bottle of Old Pugilist	4	EPIC	Last Available: "2013-09"
-6761	high-proof drinkable bottle of Professor Beer	10	good	Last Available: "2013-09"
+6761	drinkable high-proof bottle of Professor Beer	10	good	Last Available: "2013-09"
 6762	lousy shaking pulsating bottle of Rapier Witbier	3	decent	Last Available: "2013-09"
-6763	practically non-alcoholic bad bottle of Race Car Red	1	decent	Last Available: "2013-09"
-6764	weak hand-crafted bottle of Greedy Dog	2	super ultra mega EPIC	Last Available: "2013-09"
-6765	weak lousy bottle of Lambada Lambic	2	decent	Last Available: "2013-09"
+6763	bad practically non-alcoholic bottle of Race Car Red	1	decent	Last Available: "2013-09"
+6764	hand-crafted weak bottle of Greedy Dog	2	super ultra mega EPIC	Last Available: "2013-09"
+6765	lousy weak bottle of Lambada Lambic	2	decent	Last Available: "2013-09"
 6766	spinning tin beer can	0		
 6767	spinning artisanal homebrew gift package	0		
 6768	liquid bread	1	crappy	Last Available: "2013-09"
@@ -6667,7 +6667,7 @@
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	super-moist tumbling foetid seal tear	0		Effect: "Black Eyes", Effect Duration: 14
 6777	adjusted ionized seal sweat	0		Effect: "The Halls of Mysticality", Effect Duration: 39
-6778	Vulcanized blinking twirling boiling seal blood	0		Effect: "Whippin' It Good", Effect Duration: 45
+6778	Vulcanized twirling blinking boiling seal blood	0		Effect: "Whippin' It Good", Effect Duration: 45
 6779	crystalline seal eye	0		Single Equip
 6780	Rosewater's studded sealhide shield of the cougar	0		Moxie: +20, Mysticality Percent: +30, Damage Reduction: 7
 6781	frightening Jack Frost's scabrous seal epaulets	0		Cold Spell Damage: +50, Spooky Damage: +5, Single Equip
@@ -6714,7 +6714,7 @@
 6825	shaking horrifying wicked alarm accordion	0		Spell Damage: +5, Spooky Damage: +25, Class: "Accordion Thief", Song Duration: 20
 6826	up-at-dawn Rosewater's All-Hallow's Steve's fright wig of Leguizamo	0		Mysticality Percent: +30, Monster Level: +20, Adventures: +5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	rosewater-soaked dog trainer's KoL Con X Treasure Map	0		Experience (familiar): +1, Stench Resistance: +3
-6828	enchanted acceptable spinning discocktail	3	good	Effect: "Bats in the Belfry", Effect Duration: 5
+6828	acceptable enchanted spinning discocktail	3	good	Effect: "Bats in the Belfry", Effect Duration: 5
 6829	KoL Con X Bingo Card of the wise owl	0		Mysticality: +20
 6830	skewed greedy Temporal Tempera Tube	0		Meat Drop: +20
 6831	non-polarized Tallowcreme Halloween Pumpkin	0		Effect: "Alacri Tea", Effect Duration: 46
@@ -6722,7 +6722,7 @@
 6833	dry Milk Studs	0		Effect: "Celestial Vision", Effect Duration: 69
 6834	nitrogenated triple-dry yellow box of Dweebs	0		Effect: "High Blood Chocolate Content", Effect Duration: 14
 6835	flattened bag of W&Ws	0		Effect: "Al Dente Inferno", Effect Duration: 11
-6836	ionized skewed olive PEEZ dispenser	0		Effect: "Squatting and Thrusting", Effect Duration: 39
+6836	ionized olive skewed PEEZ dispenser	0		Effect: "Squatting and Thrusting", Effect Duration: 39
 6837	altered chilled wobbly Swizzler	0		Effect: "Broken Bone Nubs", Effect Duration: 13
 6838	concentrated tarnished Bugbearclaw Donut	0		Effect: "Tingly Elbows", Effect Duration: 31
 6839	quadruple-enhanced jam	0		Effect: "Funky Coal Patina", Effect Duration: 64
@@ -6749,12 +6749,12 @@
 6860	ghostly gray censurious Jack Frost's Socratic Pantsgiving of the blizzard	0		Experience (Mysticality): +1, Cold Spell Damage: 75, Sleaze Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	decent can of sardines	3	good	Last Available: "2013-11"
 6862	decent small high-calorie sugar substitute	2	good	Last Available: "2013-11"
-6863	rotten gigantic special pat of butter	9	crappy	Effect: "Cake Caked", Effect Duration: 15, Last Available: "2013-11"
+6863	gigantic special rotten pat of butter	9	crappy	Effect: "Cake Caked", Effect Duration: 15, Last Available: "2013-11"
 6864	big bland dinner roll	5	decent	Last Available: "2013-11"
 6865	decent bouncing mashed potatoes	3	good	Last Available: "2013-11"
-6866	moldy pulsating squat whole turkey leg	3	crappy	Last Available: "2013-11"
+6866	moldy squat pulsating whole turkey leg	3	crappy	Last Available: "2013-11"
 6867	miniature spoiled deviled egg	2	crappy	Last Available: "2013-11"
-6868	tarnished non-wet unsweetened bouncing gray upside-down finger exerciser	0		Effect: "Optimist Primal", Effect Duration: 68, Last Available: "2013-11"
+6868	tarnished non-wet unsweetened gray upside-down bouncing finger exerciser	0		Effect: "Optimist Primal", Effect Duration: 68, Last Available: "2013-11"
 6869	double-pickled anodized dented spoon	0		Effect: "Full of Wist", Effect Duration: 15, Last Available: "2013-11"
 6870	vacuum-sealed flattened love note	0		Effect: "The Moxie of LOV", Effect Duration: 63, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
@@ -6781,7 +6781,7 @@
 6892	wet spoonful of Linguine-Os	0		Effect: "Egged On", Effect Duration: 65, Last Available: "2013-11"
 6893	super-improved freezer-burned frost-bitten tortellini	0		Effect: "Cosmic Flavor", Effect Duration: 40, Last Available: "2013-11"
 6894	double-adjusted denatured blinking blob of Alphredo&trade;	0		Effect: "Dwarven Hardiness", Effect Duration: 32, Last Available: "2013-11"
-6895	flattened triple-alkaline spinning tumbling fuchsia handful of crafty noodles	0		Effect: "All Is Forgiven", Effect Duration: 38, Last Available: "2013-11"
+6895	flattened triple-alkaline fuchsia tumbling spinning handful of crafty noodles	0		Effect: "All Is Forgiven", Effect Duration: 38, Last Available: "2013-11"
 6896	corrupted extra-flattened pressed tangled mass of pasta	0		Effect: "Eye of the Lihc", Effect Duration: 18, Last Available: "2013-11"
 6897	dry magnetized Can of Spaghetto	0		Effect: "Oleaginous Soles", Effect Duration: 44, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
@@ -6790,10 +6790,10 @@
 6901	jittery hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	twirling flask flops of the boozehound of the glutton	0		Booze Drop: +100, Food Drop: +100, Single Equip
 6903	electrified nuts	0		Effect: "Pwnd", Effect Duration: 47, Last Available: "2013-12"
-6904	liquefied pressed cyan jittery bolts	0		Effect: "Macho Profundo", Effect Duration: 54, Last Available: "2013-12"
-6905	rotten huge gingerbread robot	9	crappy	Last Available: "2013-12"
+6904	liquefied pressed jittery cyan bolts	0		Effect: "Macho Profundo", Effect Duration: 54, Last Available: "2013-12"
+6905	huge rotten gingerbread robot	9	crappy	Last Available: "2013-12"
 6906	decent super-sized jittery petit 4.1	5	good	Last Available: "2013-12"
-6907	big moldy nut-shaped Crimbo cookie	5	crappy	Last Available: "2023-06"
+6907	moldy big nut-shaped Crimbo cookie	5	crappy	Last Available: "2023-06"
 6908	electrified plastic GORM-8	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 6909	thinker's plastic warbear	0		Mysticality: +10, Last Available: "2013-12"
 6910	dog trainer's plastic Toybot	0		Experience (familiar): +1, Last Available: "2013-12"
@@ -6808,11 +6808,11 @@
 6919	colloidal warbear bearserker potion	0		Effect: "Hobonic", Effect Duration: 15, Last Available: "2013-12"
 6920	extra-anodized aerosolized warbear liquid overcoat	0		Effect: "Frozen Shoulders", Effect Duration: 42, Last Available: "2013-12"
 6921	tasty small skewed warbear feasting bread	2	awesome	Last Available: "2013-12"
-6922	big moldy warbear warrior bread	5	crappy	Last Available: "2013-12"
-6923	spoiled big warbear thermoregulator bread	5	crappy	Last Available: "2013-12"
-6924	watered-down acceptable warbear feasting mead	2	good	Last Available: "2013-12"
-6925	smooth fortified warbear bearserker mead	5	awesome	Last Available: "2013-12"
-6926	triple-distilled perfectly mixed warbear blizzard mead	10	EPIC	Last Available: "2013-12"
+6922	moldy big warbear warrior bread	5	crappy	Last Available: "2013-12"
+6923	big spoiled warbear thermoregulator bread	5	crappy	Last Available: "2013-12"
+6924	acceptable watered-down warbear feasting mead	2	good	Last Available: "2013-12"
+6925	fortified smooth warbear bearserker mead	5	awesome	Last Available: "2013-12"
+6926	perfectly mixed triple-distilled warbear blizzard mead	10	EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
 6928	smelly warbear plain fedora of the wise owl of the detective	0		Mysticality: +20, Stench Spell Damage: +10, Item Drop: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	stanky warbear feathered fedora	0		Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6889,7 +6889,7 @@
 7000	wholesome die-cast Don Crimbo of the scaredy-cat	0		Maximum HP Percent: +10, Monster Level: -15, Last Available: "2013-12"
 7001	dance instructor's boxer's die-cast Uncle Hobo	0		Muscle Percent: +10, Experience Percent (Moxie): +10, Last Available: "2013-12"
 7002	crafty die-cast Father Crimbo of the detective	0		Maximum MP: +10, Item Drop: +20, Last Available: "2013-12"
-7003	tumbling The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	tumbling The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	magnetized Flaskfull of Hollow	0		Effect: "Spookypants", Effect Duration: 58, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	diluted narrow handful of Smithereens	1	good	Effect: "Black Eyes", Effect Duration: 35, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	flame-retardant Shakespeare's Sister's Accordion of the sewer of courage	0		Stench Damage: +25, Hot Resistance: +1, Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	ghostly frosty third-hand lantern	0		Cold Spell Damage: +10
 7031	pulsating loose purse strings	0		
-7032	stale gigantic squat pickled egg	6	decent	
+7032	gigantic stale squat pickled egg	6	decent	
 7033	cup of lukewarm tea	1	awesome	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6930,13 +6930,13 @@
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	wobbly warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	altered pulsating wobbly glass slipper	0		Effect: "Beastly Flavor", Effect Duration: 35, Last Available: "2014-12"
+7044	altered wobbly pulsating glass slipper	0		Effect: "Beastly Flavor", Effect Duration: 35, Last Available: "2014-12"
 7045	dehydrated skewed antimatter wad	1	crappy	Last Available: "2013-12"
-7046	double-frozen bouncing cyan squat warbear superpotion	0		Effect: "Can't Be a Chooser", Effect Duration: 15, Last Available: "2013-12"
+7046	double-frozen squat cyan bouncing warbear superpotion	0		Effect: "Can't Be a Chooser", Effect Duration: 15, Last Available: "2013-12"
 7047	super-polymerized extra-nitrogenated maroon warbear liquid lasers	0		Effect: "Disdain of She-Who-Was", Effect Duration: 47, Last Available: "2013-12"
 7048	frozen upside-down shaking warbear rejuvenation potion	0		Effect: "Innately Truthy", Effect Duration: 49, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	tasty half-sized warbear gyro	2	awesome	Last Available: "2013-12"
+7050	half-sized tasty warbear gyro	2	awesome	Last Available: "2013-12"
 7051	boiled shaking recording of Rolando's Rondo of Resisto	0		Effect: "Aquarius Rising", Effect Duration: 65, Last Available: "2013-12"
 7052	red warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6948,22 +6948,22 @@
 7059	shaking warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
 7061	grimstone mask	0		Last Available: "2014-12"
-7062	purple upside-down praying Grim Brother	0		Free Pull, Last Available: "2014-12"
+7062	upside-down purple praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	twirling hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	pickled grim fairy tale	1	good	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
-7067	dry skewed spinning single of Inigo's Incantation of Inspiration	0		Effect: "Wet and Greedy", Effect Duration: 62, Last Available: "2010-02"
+7067	dry spinning skewed single of Inigo's Incantation of Inspiration	0		Effect: "Wet and Greedy", Effect Duration: 62, Last Available: "2010-02"
 7068	modified single of Donho's Bubbly Ballad	0		Effect: "Leo Rising", Effect Duration: 32
-7069	wobbly squat yellow Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
+7069	squat wobbly yellow Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	upside-down packet of winter seeds	0		Last Available: "2014-01"
 7071	flavorless ghostly snow berries	4	decent	Last Available: "2014-01"
 7072	bland narrow ice harvest	4	decent	Last Available: "2014-01"
 7073	ionized frost flower	0		Effect: "Jammin'", Effect Duration: 43, Last Available: "2014-01"
 7074	pressed altered snow cleats	0		Effect: "Faboooo", Effect Duration: 31, Last Available: "2014-01"
-7075	polymerized yellow pulsating liquid ice pack	0		Effect: "Antsy in your Pantsy", Effect Duration: 62, Last Available: "2014-01"
+7075	polymerized pulsating yellow liquid ice pack	0		Effect: "Antsy in your Pantsy", Effect Duration: 62, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	big adequate snow crab	5	good	Last Available: "2014-01"
+7077	adequate big snow crab	5	good	Last Available: "2014-01"
 7078	perfectly mixed Ice Island Long Tea	3	super EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	mirror ice sculpture	0		Last Available: "2014-01"
@@ -6994,14 +6994,14 @@
 7105	upside-down anise-flavored venom	0		Last Available: "2014-12"
 7106	hand-crafted irresponsibly strong narrow snakebite	7	EPIC	Last Available: "2014-12"
 7107	mirror toasty brainy candy stick	0		Mysticality: +5, Hot Damage: +5, Last Available: "2014-12"
-7108	gigantic normal special pecan	8	good	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2014-12"
+7108	normal gigantic special pecan	8	good	Effect: "Medieval Mage Mayhem", Effect Duration: 20, Last Available: "2014-12"
 7109	stale pecan pie	3	decent	Last Available: "2014-12"
 7110	squat chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	yummy tiny candy mountain oyster	1	awesome	Last Available: "2014-12"
+7111	tiny yummy candy mountain oyster	1	awesome	Last Available: "2014-12"
 7112	lousy pulsating chocotini	4	decent	Last Available: "2014-12"
 7113	ribald dangerous personal trainer's chocolate rabbit's foot	0		Experience Percent (Muscle): +10, Weapon Damage: +10, Sleaze Damage: +10, Last Available: "2014-12"
 7114	small moldy upside-down candy carrot	2	crappy	Last Available: "2014-12"
-7115	stale special candy carrot cake	3	decent	Effect: "Think Win-Lose", Effect Duration: 20, Last Available: "2014-12"
+7115	special stale candy carrot cake	3	decent	Effect: "Think Win-Lose", Effect Duration: 20, Last Available: "2014-12"
 7116	olive carrot-on-a-stick of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Initiative: +60, Last Available: "2014-12"
 7117	fuchsia avaricious curative weasel stomping pants	0		Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	massive yummy mulberry	10	awesome	Last Available: "2014-12"
@@ -7021,7 +7021,7 @@
 7132	extra-wet denatured twirling Outer Wolf&trade; cologne	0		Effect: "Innately Wise", Effect Duration: 53, Last Available: "2014-12"
 7133	skewed lupine appetite hormones	0		Last Available: "2014-12"
 7134	wolf whistle of the ox of incineration	0		Muscle: +20, Hot Spell Damage: +50, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	enchanted bland witch's bread	4	decent	Effect: "Impregnably Delicious", Effect Duration: 50, Last Available: "2014-12"
+7135	bland enchanted witch's bread	4	decent	Effect: "Impregnably Delicious", Effect Duration: 50, Last Available: "2014-12"
 7136	extra-anodized magnetized witch's brew	0		Effect: "Squid Squint", Effect Duration: 47, Last Available: "2014-12"
 7137	blinking witch's bra of the dark arts of the sewer of terror	0		Spell Damage Percent: +100, Stench Damage: +25, Spooky Spell Damage: +10, Last Available: "2014-12"
 7138	acceptable mid-level medieval mead	3	good	Last Available: "2014-12"
@@ -7055,9 +7055,9 @@
 7166	spoiled bouncing can of Adultwitch&trade;	3	crappy	Last Available: "2014-12"
 7167	liquefied nitrogenated jittery smudge stick	0		Effect: "Slimed Stomach", Effect Duration: 41, Last Available: "2014-12"
 7168	moist cyan wall	0		Effect: "Bilious Briskness", Effect Duration: 24, Last Available: "2014-12"
-7169	watered-down mediocre tumbling tankard of ale	2	decent	Last Available: "2014-12"
+7169	mediocre watered-down tumbling tankard of ale	2	decent	Last Available: "2014-12"
 7170	triple-electrified altered scroll case	0		Effect: "Moon-Eyed", Effect Duration: 63, Last Available: "2014-12"
-7171	vacuum-sealed deionized ghostly mirror yellow jug of &quot;wine&quot;	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 46, Last Available: "2014-12"
+7171	vacuum-sealed deionized ghostly yellow mirror jug of &quot;wine&quot;	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 46, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
 7174	normal humble pie	3	good	Last Available: "2014-12"
@@ -7108,7 +7108,7 @@
 7219	lightning-fast lynyrdskin breeches	0		Initiative: +40, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	fancy practically non-alcoholic mediocre purple spinning Flamin' Whatshisname	1	decent	Effect: "Magically Delicious", Effect Duration: 40
+7222	fancy mediocre practically non-alcoholic purple spinning Flamin' Whatshisname	1	decent	Effect: "Magically Delicious", Effect Duration: 40
 7223	magnetized alkaline olive blinking lynyrd musk	0		Effect: "Well-Lubed", Effect Duration: 23
 7224	perfumed Kashmir sweater of the brute	0		Muscle Percent: +30, Stench Resistance: +5
 7225	flavorless custard pie	4	decent	
@@ -7118,7 +7118,7 @@
 7229	perfectly mixed wine	3	EPIC	
 7230	bad rum	4	decent	
 7231	bad Murderer's Punch	4	decent	
-7232	massive stale velvet cake	8	decent	
+7232	stale massive velvet cake	8	decent	
 7233	ionized letter	0		Effect: "Frozen Hands", Effect Duration: 62
 7234	clever book of the storm	0		Maximum MP Percent: +40, Maximum MP: +20
 7235	shaking gray toasty educational masque	0		Experience: +1, Hot Damage: +5, Single Equip
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	jittery tumbling really cocktail shaker	0		Familiar Weight: +5
-7255	artisanal irresponsibly strong mini-martini	8	EPIC	
+7255	irresponsibly strong artisanal mini-martini	8	EPIC	
 7256	blurry smoke grenade	0		
 7257	dried olive jittery molotov soda	1	good	
 7258	pickled chilled tumbling pile of ashes	0		Effect: "Briny Blood", Effect Duration: 13
@@ -7151,7 +7151,7 @@
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
 7264	photograph of a nugget	0		
-7265	skewed tumbling ghostly photograph of an ostrich egg	0		
+7265	ghostly tumbling skewed photograph of an ostrich egg	0		
 7266	purple disposable instant camera	0		
 7267	perfumed knitted horrifying resourceful Sneaky Pete's jacket (collar popped)	0		Maximum MP: +50, Spooky Damage: +25, Cold Resistance: +3, Stench Resistance: +5, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
@@ -7199,7 +7199,7 @@
 7310	flattened frozen bronzer	0		Effect: "Pie in the Sky", Effect Duration: 64
 7311	gray huge hardened Sinatra's elegant nightstick	0		Experience (Moxie): +5, Damage Reduction: 3
 7312	bouncing still grill	0		Free Pull, Last Available: "2014-06"
-7313	bouncing narrow fuchsia twirling box of hickory chips	0		Familiar Weight: +5
+7313	bouncing twirling narrow fuchsia box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
 7315	rickety rocking horse	0		
 7316	blue jack-in-the-box	0		
@@ -7214,7 +7214,7 @@
 7325	perfectly mixed snakebite	3	EPIC	
 7326	Oprah's supercool rubber ribcage	0		Moxie Percent: +20, Maximum MP Percent: +50, Damage Reduction: 7
 7327	compressed ghostly synthetic marrow	1		
-7328	deionized colloidal modified tumbling mirror funny bone	0		Effect: "Here's Mud in Your Eye", Effect Duration: 50
+7328	deionized colloidal modified mirror tumbling funny bone	0		Effect: "Here's Mud in Your Eye", Effect Duration: 50
 7329	Samson's half-melted spoon of bravery	0		Experience (Muscle): +5, Spooky Resistance: +5
 7330	compressed the funk	1		
 7331	enchanted flavorless gunky chicken	4	decent	Effect: "Burnt 'n' Turnt", Effect Duration: 40
@@ -7252,13 +7252,13 @@
 7363	dry jittery bloodstain stick	0		Effect: "Holiday Bliss", Effect Duration: 38
 7364	fabric softener	0		
 7365	oxidized extra-dry fabric hardener	0		Effect: "Rotten Memories", Effect Duration: 58
-7366	hand-crafted weak bottle of laundry sherry	2	EPIC	
+7366	weak hand-crafted bottle of laundry sherry	2	EPIC	
 7367	pickled aerosolized industrial strength starch	0		Effect: "Dreams and Lights", Effect Duration: 15, Wiki Name: "industrial strength starch"
-7368	bland half-sized extra-flat panini	2	decent	
+7368	half-sized bland extra-flat panini	2	decent	
 7369	super-cold-filtered boiled mangled finger	0		Effect: "Flexibili Tea", Effect Duration: 33
 7370	acceptable Psychotic Train wine	3	good	
 7371	crazy hobo notebook	0		
-7372	super-sized fancy rotten skewed pie man was not meant to eat	5	crappy	Effect: "Think Win-Lose", Effect Duration: 15
+7372	super-sized rotten fancy skewed pie man was not meant to eat	5	crappy	Effect: "Think Win-Lose", Effect Duration: 15
 7373	sommelier's towel of the wise owl	0		Mysticality: +20
 7374	Annie Oakley's tarnished tastevin	0		Critical Hit Percent: +20, Single Equip
 7375	tasty actual tapas	3	awesome	
@@ -7273,18 +7273,18 @@
 7384	improved red Gene Tonic: Dude	0		Effect: "Bananas!", Effect Duration: 46, Last Available: "2014-04"
 7385	unsweetened liquefied chilled Gene Tonic: Beast	0		Effect: "Corruption of Wretched Wally", Effect Duration: 60, Last Available: "2014-04"
 7386	unsweetened ghostly Gene Tonic: Construct	0		Effect: "Musky", Effect Duration: 36, Last Available: "2014-04"
-7387	warmed pulsating upside-down Gene Tonic: Undead	0		Effect: "Uncanny Shot", Effect Duration: 25, Last Available: "2014-04"
+7387	warmed upside-down pulsating Gene Tonic: Undead	0		Effect: "Uncanny Shot", Effect Duration: 25, Last Available: "2014-04"
 7388	anodized upside-down Gene Tonic: Humanoid	0		Effect: "French Bronilla Brogueishness", Effect Duration: 45, Last Available: "2014-04"
 7389	vacuum-sealed spinning Gene Tonic: Insect	0		Effect: "Rotten Memories", Effect Duration: 39, Last Available: "2014-04"
 7390	ionized bouncing Gene Tonic: Hippy	0		Effect: "Rampage!", Effect Duration: 40, Last Available: "2014-04"
-7391	extra-cold-filtered non-unsweetened gray squat Gene Tonic: Orc	0		Effect: "Protection from Bad Stuff", Effect Duration: 61, Last Available: "2014-04"
-7392	dry ghostly jittery Gene Tonic: Demon	0		Effect: "Brother Smothers's Blessing", Effect Duration: 63, Last Available: "2014-04"
+7391	extra-cold-filtered non-unsweetened squat gray Gene Tonic: Orc	0		Effect: "Protection from Bad Stuff", Effect Duration: 61, Last Available: "2014-04"
+7392	dry jittery ghostly Gene Tonic: Demon	0		Effect: "Brother Smothers's Blessing", Effect Duration: 63, Last Available: "2014-04"
 7393	nitrogenated Gene Tonic: Horror	0		Effect: "In Tuna", Effect Duration: 45, Last Available: "2014-04"
 7394	double-colloidal vacuum-sealed jittery mirror Gene Tonic: Fish	0		Effect: "Hairless and Airless", Effect Duration: 55, Last Available: "2014-04"
 7395	deionized liquefied double-wet Gene Tonic: Goblin	0		Effect: "Coated Arms", Effect Duration: 13, Last Available: "2014-04"
 7396	quadruple-irradiated enhanced Gene Tonic: Pirate	0		Effect: "Super Structure", Effect Duration: 25, Last Available: "2014-04"
 7397	polarized aerosolized polymerized Gene Tonic: Plant	0		Effect: "Florid Cheeks", Effect Duration: 55, Last Available: "2014-04"
-7398	flattened purple upside-down bouncing Gene Tonic: Weird	0		Effect: "A Contender", Effect Duration: 66, Last Available: "2014-04"
+7398	flattened upside-down bouncing purple Gene Tonic: Weird	0		Effect: "A Contender", Effect Duration: 66, Last Available: "2014-04"
 7399	quantum Gene Tonic: Elf	0		Effect: "Toothy Grin", Effect Duration: 22, Last Available: "2014-04"
 7400	colloidal shaking Gene Tonic: Mer-kin	0		Effect: "BOOsted", Effect Duration: 41, Last Available: "2014-04"
 7401	boiled Gene Tonic: Slime	0		Effect: "Winklered", Effect Duration: 48, Last Available: "2014-04"
@@ -7321,29 +7321,29 @@
 7432	polarized nitrogenated Omphalotus Omphaloskepsis mushroom	0		Effect: "Ooh, Sweet!", Effect Duration: 43, Last Available: "2014-05"
 7433	dry triple-modified Gyromitra Dynomita mushroom	0		Effect: "Whippin' It Good", Effect Duration: 38, Last Available: "2014-05"
 7434	ionized alkaline blurry ghostly Helvella Haemophilia mushroom	0		Effect: "Going Ape", Effect Duration: 14, Last Available: "2014-05"
-7435	deionized adjusted pulsating purple Stemonitis Staticus mushroom	0		Effect: "Extra Terrestrial", Effect Duration: 37, Last Available: "2014-05"
+7435	deionized adjusted purple pulsating Stemonitis Staticus mushroom	0		Effect: "Extra Terrestrial", Effect Duration: 37, Last Available: "2014-05"
 7436	unsweetened tumbling Tremella Tarantella mushroom	0		Effect: "Jingle Jangle Jingle", Effect Duration: 47, Last Available: "2014-05"
 7437	olive Pastaco shell	0		Last Available: "2014-05"
 7438	snack-sized rotten Beefy Crunch Pastaco	2	crappy	Last Available: "2014-05"
 7439	spoiled Brain Food Pastaco	4	crappy	Last Available: "2014-05"
-7440	delicious immense maroon Cool Brunch Pastaco	10	awesome	Last Available: "2014-05"
+7440	immense delicious maroon Cool Brunch Pastaco	10	awesome	Last Available: "2014-05"
 7441	moldy squat Medical Pastaco	3	crappy	Last Available: "2014-05"
-7442	jumbo decent Energy Buzz Pastaco	5	good	Last Available: "2014-05"
+7442	decent jumbo Energy Buzz Pastaco	5	good	Last Available: "2014-05"
 7443	flavorless Ludovico Pastaco	3	decent	Last Available: "2014-05"
 7444	hand-crafted weak overpowering mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
-7445	weak acceptable complex mushroom wine	2	good	Last Available: "2014-05"
+7445	acceptable weak complex mushroom wine	2	good	Last Available: "2014-05"
 7446	practically non-alcoholic hand-crafted smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	practically non-alcoholic smooth blood-red mushroom wine	1	awesome	Last Available: "2014-05"
 7448	delicious buzzing mushroom wine	4	awesome	Last Available: "2014-05"
-7449	strong delicious swirling mushroom wine	5	awesome	Last Available: "2014-05"
+7449	delicious strong swirling mushroom wine	5	awesome	Last Available: "2014-05"
 7450	flavorless Taco Dan's Basic Taco Dan Taco	3	decent	Last Available: "2014-05"
-7451	gigantic moldy Taco Dan's Taco Fish Fish Taco	7	crappy	Last Available: "2014-05"
+7451	moldy gigantic Taco Dan's Taco Fish Fish Taco	7	crappy	Last Available: "2014-05"
 7452	blinking Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	lousy regular-size brogurt	3	decent	Last Available: "2014-05"
 7454	artisanal super-size brogurt	3	EPIC	Last Available: "2014-05"
 7455	tolerable broberry brogurt	3	good	Last Available: "2014-05"
-7456	strong acceptable brocolate brogurt	5	good	Last Available: "2014-05"
-7457	triple-distilled enchanted perfectly mixed shaking gray French bronilla brogurt	8	EPIC	Effect: "Fitter, Happier", Effect Duration: 15, Last Available: "2014-05"
+7456	acceptable strong brocolate brogurt	5	good	Last Available: "2014-05"
+7457	perfectly mixed enchanted triple-distilled shaking gray French bronilla brogurt	8	EPIC	Effect: "Fitter, Happier", Effect Duration: 15, Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7358,7 +7358,7 @@
 7469	coward's rosy-cheeked extremely wet T-shirt of courage	0		Maximum HP Percent: +30, Monster Level: -20, Spooky Resistance: +3, Last Available: "2014-05"
 7470	knitted lion tamer's curative shrimp fork	0		Experience (familiar): +2, Cold Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-05"
 7471	dry aerosolized Vulcanized BROS Energy Drink	0		Effect: "Yuletide Industry", Effect Duration: 51, Last Available: "2014-05"
-7472	modified skewed narrow go-go potion	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 24, Last Available: "2014-05"
+7472	modified narrow skewed go-go potion	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 24, Last Available: "2014-05"
 7473	ionized bouncing shrimp cocktail	0		Effect: "Sticky Hands", Effect Duration: 19, Last Available: "2014-05"
 7474	chilled diffused Yolo&trade; chocolates	0		Effect: "Mercenary", Effect Duration: 28, Last Available: "2020-09"
 7475	string of moist beads of James Dean	0		Experience (Moxie): +3, Last Available: "2014-05"
@@ -7369,8 +7369,8 @@
 7480	chilled tarnished sugar bunny	0		Effect: "Ticking Clock", Effect Duration: 39, Last Available: "2014-05"
 7481	pulsating sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	hand-crafted olive Rompedores de Fantasmas	4	EPIC	
-7483	watered-down hand-crafted jittery La Fantasma y La Oscuridad	2	EPIC	
-7484	fancy artisanal upside-down Fantasma en la M&aacute;quina	3	EPIC	Effect: "Preemptive Medicine", Effect Duration: 25
+7483	hand-crafted watered-down jittery La Fantasma y La Oscuridad	2	EPIC	
+7484	artisanal fancy upside-down Fantasma en la M&aacute;quina	3	EPIC	Effect: "Preemptive Medicine", Effect Duration: 25
 7485	ghostly shaking loosening powder	0		
 7486	castoreum	0		
 7487	green drain dissolver	0		
@@ -7395,7 +7395,7 @@
 7506	Jim Carey's book of the early riser	0		Monster Level: +25, Adventures: +7
 7507	huge blurry banded cloak	0		Damage Absorption: +100
 7508	red label	0		
-7509	toothsome gigantic Mornington crescent roll	6	awesome	
+7509	gigantic toothsome Mornington crescent roll	6	awesome	
 7510	oxidized eye shadow	0		Effect: "Halloweeny", Effect Duration: 49
 7511	crumbling wheel	0		
 7512	pickled vacuum-sealed yellow poppy	0		Effect: "Pla-see-bo", Effect Duration: 39
@@ -7438,7 +7438,7 @@
 7549	super-cold-filtered ash soda	0		Effect: "Innately Truthy", Effect Duration: 30, Last Available: "2014-06"
 7550	super-ionized frozen narrow liquid smoke	0		Effect: "Rotten Memories", Effect Duration: 12, Last Available: "2014-06"
 7551	concentrated dollop of barbecue sauce	0		Effect: "Cake Caked", Effect Duration: 11, Last Available: "2014-06"
-7552	tarnished cyan blurry bowl of marinade	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 61, Last Available: "2014-06"
+7552	tarnished blurry cyan bowl of marinade	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 61, Last Available: "2014-06"
 7553	shaker of dry rub	0		Last Available: "2014-06"
 7554	moist bottle of lighter fluid	0		Effect: "Good Karma", Effect Duration: 47, Last Available: "2014-06"
 7555	page	0		
@@ -7447,11 +7447,11 @@
 7558	delicious practically non-alcoholic wine	1	awesome	
 7559	galvanized gummi turtle	0		Effect: "Spiro Gyro", Effect Duration: 55
 7560	turtle-shaped rock	0		
-7561	adjusted jittery tumbling blue giraffe-necked turtle	0		Effect: "Bear Clawed", Effect Duration: 31
+7561	adjusted jittery blue tumbling giraffe-necked turtle	0		Effect: "Bear Clawed", Effect Duration: 31
 7562	double-irradiated wet huge musk turtle	0		Effect: "Hare-o-dynamic", Effect Duration: 39
 7563	extra-dry boiled yellow jittery programmable turtle	0		Effect: "Creepypasted", Effect Duration: 63
 7564	pressed alkaline blue mocking turtle	0		Effect: "From Nantucket", Effect Duration: 25
-7565	immense stale ham steak	10	decent	
+7565	stale immense ham steak	10	decent	
 7566	narrow smelly time-twitching toolbelt	0		Stench Spell Damage: +10, Single Equip, Free Pull
 7567	Chroner	0		
 7568	cyan tumbling avaricious hale Samson's Time Lord Badge of Honor	0		Experience (Muscle): +5, Maximum HP: +20, Meat Drop: +30
@@ -7463,12 +7463,12 @@
 7574	tolerable pulsating New Zealand iced tea	4	good	
 7575	personal trainer's Newton's droll monocle	0		Experience (Mysticality): +3, Experience Percent (Muscle): +10, Single Equip
 7576	dry activated future drug: Muscularactum	0		Effect: "Yuletide Industry", Effect Duration: 68
-7577	corrupted shaking upside-down future drug: Smartinex	0		Effect: "Arse-a'fire", Effect Duration: 28
+7577	corrupted upside-down shaking future drug: Smartinex	0		Effect: "Arse-a'fire", Effect Duration: 28
 7578	oxidized pulsating future drug: Coolscaline	0		Effect: "Witch Breaded", Effect Duration: 66
 7579	twitching time capsule	0		
 7580	distilled mirror mirror liquid shifting time weirdness	1		
 7581	blinking shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	rotten miniature rack of dinosaur ribs	2	crappy	
+7582	miniature rotten rack of dinosaur ribs	2	crappy	
 7583	perfectly mixed weak jittery scotch on the rocks	2	super ultra EPIC	
 7584	cyan yabba dabba doo rag of vim and vigor of doom	0		Maximum HP Percent: +50, Spooky Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	prompt wooly loincloth of the sweet-tooth	0		Candy Drop: +100, Adventures: +3, Familiar Effect: "atk, 1xVolley, cap 27"
@@ -7477,15 +7477,15 @@
 7588	jittery Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	smooth glass of &quot;milk&quot;	4	awesome	Last Available: "2014-07"
 7590	aged cup of &quot;tea&quot;	3	awesome	Last Available: "2014-07"
-7591	bad practically non-alcoholic blue thermos of &quot;whiskey&quot;	1	decent	Last Available: "2014-07"
+7591	practically non-alcoholic bad blue thermos of &quot;whiskey&quot;	1	decent	Last Available: "2014-07"
 7592	hand-crafted watered-down Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
-7593	acceptable fancy Bee's Knees	4	good	Effect: "Dirty Pear", Effect Duration: 15, Last Available: "2014-07"
+7593	fancy acceptable Bee's Knees	4	good	Effect: "Dirty Pear", Effect Duration: 15, Last Available: "2014-07"
 7594	acceptable Sockdollager	4	good	Last Available: "2014-07"
 7595	mediocre Ish Kabibble	3	decent	Last Available: "2014-07"
 7596	bad extra-dry spinning Hot Socks	5	decent	Last Available: "2014-07"
 7597	tolerable Phonus Balonus	3	good	Last Available: "2014-07"
-7598	practically non-alcoholic hand-crafted fancy blurry Flivver	1	super ultra mega turbo EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2014-07"
-7599	high-proof aged Sloppy Jalopy	7	awesome	Last Available: "2014-07"
+7598	fancy practically non-alcoholic hand-crafted blurry Flivver	1	super ultra mega turbo EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2014-07"
+7599	aged high-proof Sloppy Jalopy	7	awesome	Last Available: "2014-07"
 7600	denatured anodized cold-filtered flame	0		Effect: "Slimy Hands", Effect Duration: 59
 7601	chilled deionized temporary yak tattoo	0		Effect: "Lit Up", Effect Duration: 19
 7602	liquefied cold-filtered Fitspiration&trade; poster	0		Effect: "Stands Alone", Effect Duration: 30
@@ -7528,7 +7528,7 @@
 7639	stylish oil shell	0		Moxie: +25, Class: "Turtle Tamer"
 7640	blinking gray squat extremely unsafe Rosewater's cool turtle shell	0		Moxie: +5, Mysticality Percent: +30, Weapon Damage Percent: +100, Class: "Turtle Tamer"
 7641	shocked shell	0		Class: "Turtle Tamer"
-7642	jittery twirling ingot turtle	0		
+7642	twirling jittery ingot turtle	0		
 7643	wobbly duty umbrella	0		
 7644	pool skimmer	0		
 7645	life preserver	0		
@@ -7541,7 +7541,7 @@
 7652	fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
-7655	jittery fuchsia squat fishbone fins	0		Single Equip
+7655	fuchsia squat jittery fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
@@ -7553,7 +7553,7 @@
 7664	ionized polymerized teal Ancient Protector Soda	0		Effect: "The Power of Negative Thinking", Effect Duration: 47
 7665	tarnished liquid ice	0		Effect: "Dreadful Sheen", Effect Duration: 20
 7666	acceptable purple skewed Wet Russian	4	good	
-7667	normal bite-sized filet of The Fish	1	good	
+7667	bite-sized normal filet of The Fish	1	good	
 7668	Thwaitgold spider statuette	0		
 7669	blinking greedy sizzling thunder down underwear of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +10, Meat Drop: +20, Lasts Until Rollover
 7670	ghostly lightning-fast censurious sharpshooter's famous raincoat	0		Critical Hit Percent: +10, Sleaze Resistance: +3, Initiative: +40, Lasts Until Rollover
@@ -7569,7 +7569,7 @@
 7680	stanky super-absorbent tarp	0		Stench Spell Damage: +25
 7681	weak lousy jittery unquiet spirits	2	decent	
 7682	bouncing blinking spinning forbidden banjo kazoo mount	0		Spell Damage Percent: +50, Single Equip
-7683	magnetized pulsating mirror red grass	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 51
+7683	magnetized red pulsating mirror grass	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 51
 7684	Time Lord Participation Mug of vim and vigor	0		Maximum HP Percent: +50
 7685	scandalous Time Bandit Time Towel of the dark arts	0		Spell Damage Percent: +100, Sleaze Damage: +5
 7686	greedy hardy Rosewater's Caveman Dan's favorite rock	0		Mysticality Percent: +30, Maximum HP: +50, Meat Drop: +20, Single Equip
@@ -7592,16 +7592,16 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	lime green The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	lime green The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	magnetized blinking rubber nubbin	0		Effect: "Afternoon Insight", Effect Duration: 31, Last Available: "2014-08"
 7708	narrow jittery asbestos-lined rubber cape of the sweet-tooth	0		Hot Resistance: +5, Candy Drop: +100, Last Available: "2014-08"
 7709	mirror wobbly careful Van der Graaf wicked Thor's Pliers of James Dean	0		Experience (Moxie): +3, Spell Damage: +5, Monster Level: -10, MP Regen Min: 5, MP Regen Max: 7, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	irradiated double-concentrated candy UFOs	0		Effect: "Purpose", Effect Duration: 14
 7711	family-friendly water wings for babies of the pedagogue	0		Experience: +3, Sleaze Resistance: +1
-7712	wobbly beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	wobbly beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	adequate Strix stix	4	good	
 7714	twirling jittery friendly medical-grade personal trainer's vampire pellet	0		Experience Percent (Muscle): +10, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10
-7715	watered-down tolerable shaking non-aged vinegar	2	good	
+7715	tolerable watered-down shaking non-aged vinegar	2	good	
 7716	skewed hardened unsanitized scalpel	0		Damage Reduction: 3
 7717	spinning padded gladiator tunica	0		Damage Absorption: +20
 7718	squat experienced Roman sadnals	0		Experience: +2, Single Equip
@@ -7612,8 +7612,8 @@
 7723	pulsating Chroner cross	0		
 7724	tumbling supercool pteruges	0		Moxie Percent: +20, Familiar Effect: "1xFairy, atk, cap 25"
 7725	aerosolized Bruno's blessing of Mars	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 12
-7726	extra-moist non-denatured tumbling jittery Dennis's blessing of Minerva	0		Effect: "Pretending to Pretend", Effect Duration: 15
-7727	pickled vacuum-sealed huge shaking blue Burt's blessing of Bacchus	0		Effect: "Salt Rockin'", Effect Duration: 22
+7726	extra-moist non-denatured jittery tumbling Dennis's blessing of Minerva	0		Effect: "Pretending to Pretend", Effect Duration: 15
+7727	pickled vacuum-sealed shaking huge blue Burt's blessing of Bacchus	0		Effect: "Salt Rockin'", Effect Duration: 22
 7728	pressed Freddie's blessing of Mercury	0		Effect: "Tin, Man", Effect Duration: 36
 7729	Chroner trigger	0		
 7730	twirling Xi Receiver Unit	0		Last Available: "2014-09"
@@ -7627,7 +7627,7 @@
 7738	wobbly Xiblaxian cache locator simcode	0		Last Available: "2014-09"
 7739	tumbling Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	skewed Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
-7741	blinking lime green tumbling Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
+7741	tumbling lime green blinking Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
 7743	Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
 7744	Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
@@ -7643,14 +7643,14 @@
 7754	avaricious Xiblaxian stealth trousers of the wise owl	0		Mysticality: +20, Meat Drop: +30, Last Available: "2014-09"
 7755	Sherlock's smelly Xiblaxian stealth vest	0		Stench Spell Damage: +10, Item Drop: +25, Last Available: "2014-09"
 7756	toothsome olive Xiblaxian ultraburrito	4	awesome	Last Available: "2014-09"
-7757	practically non-alcoholic tolerable Xiblaxian space-whiskey	1	good	Last Available: "2014-09"
+7757	tolerable practically non-alcoholic Xiblaxian space-whiskey	1	good	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	enhanced vacuum-sealed ghostly They liver	0		Effect: "Chilblains of the Corn", Effect Duration: 11, Last Available: "2014-09"
 7760	stale They liver popsicle	4	decent	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
-7764	vaporized green tumbling residual zeal	1		Last Available: "2014-09"
+7764	vaporized tumbling green residual zeal	1		Last Available: "2014-09"
 7765	Xiblaxian holo-wrist-puter of the businessman	0		Meat Drop: +50, Last Available: "2014-09"
 7766	scandalous rock-hard fortified defective Golden Mr. Accessory	0		Damage Absorption: +60, Damage Reduction: 5, Sleaze Damage: +5
 7767	airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7658,7 +7658,7 @@
 7769	yellow Coinspiracy	0		Last Available: "2014-10"
 7770	toasty nippy MacGyver's Personal Ventilation Unit	0		Maximum MP: +100, Cold Damage: +10, Hot Damage: +5, Single Equip, Last Available: "2014-10"
 7771	Vulcanized the most dangerous bait	0		Effect: "Eye of the Seal", Effect Duration: 32, Last Available: "2014-10"
-7772	snack-sized rotten &quot;meat&quot; stick	2	crappy	Last Available: "2014-10"
+7772	rotten snack-sized &quot;meat&quot; stick	2	crappy	Last Available: "2014-10"
 7773	pickled transdermal smoke patch	1	EPIC	Effect: "Improprie Tea", Effect Duration: 15, Last Available: "2014-10"
 7774	cyan specialty ammo bandolier	0		Last Available: "2014-10"
 7775	spinning blurry frightening clever pair of plants of the businessman	0		Maximum MP: +20, Spooky Damage: +5, Meat Drop: +50, Last Available: "2014-10"
@@ -7681,9 +7681,9 @@
 7792	pulsating SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	wobbly Armory keycard	0		Last Available: "2014-10"
-7795	bland small wobbly initiative shawarma	2	decent	Last Available: "2014-10"
-7796	toothsome jumbo warm war shawarma	5	awesome	Last Available: "2014-10"
-7797	flavorless snack-sized skewed karma shawarma	2	decent	Last Available: "2014-10"
+7795	small bland wobbly initiative shawarma	2	decent	Last Available: "2014-10"
+7796	jumbo toothsome warm war shawarma	5	awesome	Last Available: "2014-10"
+7797	snack-sized flavorless skewed karma shawarma	2	decent	Last Available: "2014-10"
 7798	tolerable Jungle Juice	3	good	Last Available: "2014-10"
 7799	boozy bad Amnesiac Ale	5	decent	Last Available: "2014-10"
 7800	mediocre Highest Bitter	3	decent	Last Available: "2014-10"
@@ -7714,7 +7714,7 @@
 7825	Temple Grandin's supercharged smooth earbuds	0		Moxie: +15, Maximum MP Percent: +30, Familiar Weight: +7, Single Equip
 7826	twirling skewed resourceful energetic arcane researcher's iFlail	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Maximum MP: +50
 7827	spoiled miniature unidentifiable dried fruit	2	crappy	
-7828	artisanal weak jittery flat cider	2	EPIC	
+7828	weak artisanal jittery flat cider	2	EPIC	
 7829	greasy Temple Grandin's thinker's trench lighter	0		Mysticality: +10, Familiar Weight: +7, Sleaze Spell Damage: +10, Last Available: "2014-10"
 7830	chilled aerosolized spinning experimental serum P-00	0		Effect: "Swordholder", Effect Duration: 19, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7766,7 +7766,7 @@
 7877	Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	blinking Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
-7880	blue twirling Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
+7880	twirling blue Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
@@ -7776,7 +7776,7 @@
 7887	Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
 7888	Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	huge huge Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
-7890	squat narrow mirror Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
+7890	narrow mirror squat Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
@@ -7805,11 +7805,11 @@
 7916	wobbly mimeplasm	0		
 7917	dry unsweetened shaking BOOterfinger	0		Effect: "Creepin' Up on You", Effect Duration: 69
 7918	pickled blue blinking Moonds	0		Effect: "Bandersnatched", Effect Duration: 38
-7919	liquefied blinking twirling blue Big Punk	0		Effect: "Uncaged Power", Effect Duration: 29
+7919	liquefied twirling blue blinking Big Punk	0		Effect: "Uncaged Power", Effect Duration: 29
 7920	twirling fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	watered-down lousy Friendly Turkey	2	decent	Last Available: "2014-11"
-7923	practically non-alcoholic bad Agitated Turkey	1	decent	Last Available: "2014-11"
+7923	bad practically non-alcoholic Agitated Turkey	1	decent	Last Available: "2014-11"
 7924	mediocre Ambitious Turkey	3	decent	Last Available: "2014-11"
 7925	snack-sized normal twirling neutron lollipop	2	good	Last Available: "2014-12"
 7926	hand-crafted watered-down skewed gamma nog	2	EPIC	Last Available: "2014-12"
@@ -7817,7 +7817,7 @@
 7935	Thwaitgold nit statuette	0		
 7936	teal picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	denatured tumbling yellow single atom	1	awesome	Effect: "Abominably Slippery", Effect Duration: 45, Last Available: "2015-02"
+7938	denatured yellow tumbling single atom	1	awesome	Effect: "Abominably Slippery", Effect Duration: 45, Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	purple sleeve deuce	0		
@@ -7838,7 +7838,7 @@
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	mirror even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
-7959	blinking yellow letter to Ed the Undying	0		
+7959	yellow blinking letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	greedy padded sinister supercool Staff of Ed	0		Moxie Percent: +20, Spell Damage: +10, Damage Absorption: +20, Meat Drop: +20
 7962	maroon Eye of Ed	0		
@@ -7852,7 +7852,7 @@
 7970	narrow boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
 7972	pickled skewed mummified fig	1	EPIC	
-7973	modified mirror blinking yellow mummified loaf of bread	1	EPIC	
+7973	modified yellow blinking mirror mummified loaf of bread	1	EPIC	
 7974	diluted upside-down narrow mummified beef haunch	1	crappy	
 7975	linen bandages	0		
 7976	bouncing cotton bandages	0		
@@ -7906,7 +7906,7 @@
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	bouncing bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
-8027	upside-down blurry antler chandelier	0		Last Available: "2015-01"
+8027	blurry upside-down antler chandelier	0		Last Available: "2015-01"
 8028	artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
@@ -7920,7 +7920,7 @@
 8038	blurry topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	fuchsia trusty whip	0		
-8041	skewed blue crumbling skull	0		
+8041	blue skewed crumbling skull	0		
 8042	purple rock	0		
 8043	twirling pot of the wise owl	0		Mysticality: +20
 8044	knitted spelunking fedora	0		Cold Resistance: +3
@@ -7939,9 +7939,9 @@
 8058	Da Vinci's plasma rifle	0		Experience (Mysticality): +5
 8059	Bananubis's Staff	0		Luck: -6
 8060	mirror cyan The Joke Book of the Dead of wisdom of the overflowing toilet	0		Mysticality: +15, Stench Spell Damage: +50, Luck: -6
-8061	blurry yellow The Clown Crown	0		Luck: -6
+8061	yellow blurry The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	upside-down jittery Tales of Spelunking	0		Last Available: "2015-12"
+8063	jittery upside-down Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
 8066	denatured fuchsia jittery	1	EPIC	Last Available: "2015-12"
@@ -7951,7 +7951,7 @@
 8070	shaking warehouse map page	0		
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
-8073	narrow pulsating Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
+8073	pulsating narrow Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
 8074	auspicious wholesome Spelunker's fedora of the brute	0		Muscle Percent: +30, Maximum HP Percent: +10, Item Drop: +10, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	executive lard-coated supercharged Spelunker's whip	0		Maximum MP Percent: +30, Sleaze Spell Damage: +25, Meat Drop: +40, Last Available: "2015-12"
 8076	nippy hardened Spelunker's khakis of the sweet-tooth	0		Damage Reduction: 3, Cold Damage: +10, Candy Drop: +100, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
@@ -7977,7 +7977,7 @@
 8102	nippy vibrating brooch	0		Maximum MP Percent: +10, Cold Damage: +10, Single Equip, Last Available: "2016-12"
 8103	thinker's breeches of the businessman	0		Mysticality: +10, Meat Drop: +50, Last Available: "2016-12"
 8104	skewed friendly backpack of doom	0		Familiar Weight: +3, Spooky Spell Damage: +50, Last Available: "2016-12"
-8105	mixed twirling narrow bits	1		Effect: "Liquidy Smoky", Effect Duration: 45, Last Available: "2016-12"
+8105	mixed narrow twirling bits	1		Effect: "Liquidy Smoky", Effect Duration: 45, Last Available: "2016-12"
 8106	smooth wizardly anvil	0		Mysticality: +25, Moxie: +15, Single Equip, Last Available: "2017-12"
 8107	akubra of the wise owl of the sweet-tooth	0		Mysticality: +20, Candy Drop: +100, Last Available: "2017-12"
 8108	grievous apron of the blizzard	0		Weapon Damage Percent: +50, Cold Spell Damage: +25, Single Equip, Last Available: "2017-12"
@@ -8017,7 +8017,7 @@
 8143	lime green Herculean obsidian nutcracker	0		Experience (Muscle): +1
 8144	talisman of Seshat	0		Free Pull
 8145	Temple Grandin's glass eye of the cheetah	0		Familiar Weight: +7, Initiative: +60, Single Equip
-8146	diffused teal blinking invisible potion	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 56
+8146	diffused blinking teal invisible potion	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 56
 8147	time shuriken	0		
 8148	up-at-dawn executive fireproof ninjammies	0		Hot Resistance: +3, Meat Drop: +40, Adventures: +5, Familiar Effect: "atk, 0.5xPotato, cap 25"
 8149	Vulcanized ionized green Glo-Pop	0		Effect: "Hagg-ard", Effect Duration: 55
@@ -8063,15 +8063,15 @@
 8189	practically non-alcoholic drinkable Radberry Rip wine cooler	1	good	
 8190	perfectly mixed Orangemageddon wine cooler	4	EPIC	
 8191	hand-crafted weak fancy skewed Breakfast Blast wine cooler	2	EPIC	Effect: "Salty Dogs", Effect Duration: 30
-8192	watered-down acceptable Citrus Crush wine cooler	2	good	
-8193	massive bland plain bagel	7	decent	
+8192	acceptable watered-down Citrus Crush wine cooler	2	good	
+8193	bland massive plain bagel	7	decent	
 8194	rotten shaking glob of cream cheese	3	crappy	
-8195	moldy big huge loaf of soda bread	5	crappy	
-8196	yummy small acceptable bagel	2	awesome	
+8195	big moldy huge loaf of soda bread	5	crappy	
+8196	small yummy acceptable bagel	2	awesome	
 8197	rotten half-sized standard-issue cupcake	2	crappy	
 8198	delicious ultra-deluxe cupcake	3	awesome	
 8199	tumbling hypnotic breadcrumbs	0		
-8200	stale pulsating skewed popular tart	3	decent	
+8200	stale skewed pulsating popular tart	3	decent	
 8201	blurry no-handed pie	0		
 8202	ionized super-altered bouncing Doc Galaktik's Vitality Serum	0		Effect: "The Best a Pirate Can Get", Effect Duration: 61
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8090,7 +8090,7 @@
 8216	Vulcanized beard incense	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 62, Last Available: "2015-04"
 8217	nippy clever perfume-soaked bandana	0		Maximum MP: +20, Cold Damage: +10, Single Equip, Last Available: "2015-04"
 8218	squat toxic globule	0		Last Available: "2015-04"
-8219	huge adequate toxo	6	good	Last Available: "2015-04"
+8219	adequate huge toxo	6	good	Last Available: "2015-04"
 8220	lousy Lemonade-235	4	decent	Last Available: "2015-04"
 8221	inspector's isotophat of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	purple upside-down nasty Three Mile Island shorts of chilblains	0		Cold Damage: +25, Stench Damage: +5, Last Available: "2015-04"
@@ -8136,20 +8136,20 @@
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	Mayostat	0		Last Available: "2015-05"
 8264	Mayozapine	0		Last Available: "2015-05"
-8265	narrow huge Mayoflex	0		Last Available: "2015-05"
+8265	huge narrow Mayoflex	0		Last Available: "2015-05"
 8266	gray lion tamer's medical-grade wicked miracle whip of the empath	0		Spell Damage: +5, Familiar Weight: +5, Experience (familiar): +2, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-05"
 8267	personal trainer's sphygmayomanometer	0		Experience Percent (Muscle): +10, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	decent small unappetizing mayolus	2	good	Last Available: "2015-05"
-8271	super-sized bland tumbling upside-down uninteresting mayolus	5	decent	Last Available: "2015-05"
+8270	small decent unappetizing mayolus	2	good	Last Available: "2015-05"
+8271	super-sized bland upside-down tumbling uninteresting mayolus	5	decent	Last Available: "2015-05"
 8272	jumbo delicious acceptable mayolus	5	awesome	Last Available: "2015-05"
 8273	bland enticing mayolus	4	decent	Last Available: "2015-05"
 8274	normal upside-down jittery mouth-watering mayolus	4	good	Last Available: "2015-05"
 8275	cyan newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	shaking mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
-8278	tolerable watered-down Afternoon Delight	2	good	Last Available: "2015-04"
+8278	watered-down tolerable Afternoon Delight	2	good	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	double-polymerized Kokomo Resort Brand Suntan Oil	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 68, Last Available: "2015-04"
@@ -8172,9 +8172,9 @@
 8298	pixel	0		Last Available: "2015-06"
 8299	pixel coin	0		Last Available: "2015-06"
 8300	ionized vacuum-sealed mirror yellow power pill	0		Effect: "Heavily Breathing", Effect Duration: 55, Last Available: "2015-06"
-8301	quantum alkaline blurry cyan pixel star	0		Effect: "A Few Extra Pounds", Effect Duration: 16, Last Available: "2015-06"
-8302	fancy small toothsome pulsating pixel banana	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 30, Last Available: "2015-06"
-8303	weak hand-crafted wobbly pixel beer	2	EPIC	Last Available: "2015-06"
+8301	quantum alkaline cyan blurry pixel star	0		Effect: "A Few Extra Pounds", Effect Duration: 16, Last Available: "2015-06"
+8302	small toothsome fancy pulsating pixel banana	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 30, Last Available: "2015-06"
+8303	hand-crafted weak wobbly pixel beer	2	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	mirror pumps	0		Last Available: "2015-06"
 8306	frozen unsweetened squat sludgesicle	0		Effect: "Certainty", Effect Duration: 65
@@ -8209,7 +8209,7 @@
 8335	ionized non-tarnished teal grease trap	0		Effect: "French Bronilla Brogueishness", Effect Duration: 21
 8336	frozen mirror shamanic ham	0		Effect: "Cold Blooded", Effect Duration: 45
 8337	moist wet flattened porkpocket	0		Effect: "Pwnd", Effect Duration: 14
-8338	energized red bouncing Leonard's glasses	0		Effect: "Corruption of Wretched Wally", Effect Duration: 23
+8338	energized bouncing red Leonard's glasses	0		Effect: "Corruption of Wretched Wally", Effect Duration: 23
 8339	concentrated warehouse walkie-talkie	0		Effect: "Eau de Tortue", Effect Duration: 20
 8340	pickled chilled janitor's mop	0		Effect: "No Vertigo", Effect Duration: 55
 8341	flattened polarized boiled tumbling warehouse clerk's glasses	0		Effect: "Transcendental Wind", Effect Duration: 62
@@ -8230,9 +8230,9 @@
 8356	flattened cold-filtered bouncing mercenary headband	0		Effect: "Feline Ferocity", Effect Duration: 50
 8357	improved jittery radioactive spider venom	0		Effect: "Old School Pompadour", Effect Duration: 51
 8358	unsweetened warmed squat x-ray mirror	0		Effect: "Stuck-Up Hair", Effect Duration: 69
-8359	oxidized polarized nitrogenated spinning jittery wrestling mask	0		Effect: "Boilermade", Effect Duration: 15
+8359	oxidized polarized nitrogenated jittery spinning wrestling mask	0		Effect: "Boilermade", Effect Duration: 15
 8360	denatured polarized shaking hawkface potion	0		Effect: "Disdain of the War Snapper", Effect Duration: 42
-8361	activated super-chilled huge green child-sized dracula cloak	0		Effect: "Big Flaming Whip", Effect Duration: 17
+8361	activated super-chilled green huge child-sized dracula cloak	0		Effect: "Big Flaming Whip", Effect Duration: 17
 8362	irradiated double-unsweetened narrow devil-summoning hat	0		Effect: "Yuletide Sappiness", Effect Duration: 22
 8363	enhanced blue shopkeeper beard	0		Effect: "Scarysauce", Effect Duration: 65
 8364	non-flattened purple alien autoautopsy kit	0		Effect: "Pharmaceutically Cool", Effect Duration: 14
@@ -8248,7 +8248,7 @@
 8374	galvanized irradiated flattened drinks tray	0		Effect: "In the Saucestream", Effect Duration: 59
 8375	flattened modified shaking eyebrow lifter	0		Effect: "Chain Chain Chains", Effect Duration: 44
 8376	submarine	0		Last Available: "2015-06"
-8377	stale diet pixel lemon	1	decent	Last Available: "2015-06"
+8377	diet stale pixel lemon	1	decent	Last Available: "2015-06"
 8378	drinkable irresponsibly strong pixel daiquiri	7	good	Last Available: "2015-06"
 8379	super-alkaline warmed teal power pill	0		Effect: "Very Clean Guns", Effect Duration: 34, Last Available: "2015-06"
 8380	ionized non-quantum unsweetened squat pixel potion	0		Effect: "Yes, Can Haz", Effect Duration: 49, Last Available: "2015-06"
@@ -8282,11 +8282,11 @@
 8408	tarnished boiled ectoplasmic orbs	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 68
 8409	spoiled crudles	3	crappy	
 8410	decent small agnolotti arboli	2	good	
-8411	spoiled small spaghetti with ghost balls	2	crappy	
+8411	small spoiled spaghetti with ghost balls	2	crappy	
 8412	flavorless succulent marrow	4	decent	
 8413	decent gigantic salacious crumbs	6	good	
 8414	stale blurry fusilli marrownarrow	3	decent	
-8415	thick decent olive suggestive strozzapreti	5	good	
+8415	decent thick olive suggestive strozzapreti	5	good	
 8416	wobbly twirling Mountain Stream gastrique	0		
 8417	flavorless miniature Mt. McLargeHuge oyster	2	decent	
 8418	oyster sauce	0		
@@ -8299,7 +8299,7 @@
 8425	New Age healing crystal	0		Last Available: "2015-08"
 8426	purple Volcoino	0		Last Available: "2015-08"
 8427	fizzing spore pod	0		
-8428	squat narrow spore pod	0		
+8428	narrow squat spore pod	0		
 8429	veiny spore pod	0		
 8430	jittery hard spore pod	0		
 8431	mirror spore pod	0		
@@ -8346,8 +8346,8 @@
 8472	narrow heat-resistant necktie of extreme caution of terror	0		Monster Level: -25, Spooky Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8473	spinning greedy resourceful clever heat-resistant gloves	0		Maximum MP: 70, Meat Drop: +20, Single Equip, Last Available: "2015-08"
 8474	normal very hot lunch	4	good	Last Available: "2015-08"
-8475	watered-down artisanal pulsating asbestos thermos	2	super EPIC	Last Available: "2015-08"
-8476	enhanced pressed double-galvanized tumbling blurry gray liquid rhinestones	0		Effect: "Faboooo", Effect Duration: 38, Last Available: "2015-08"
+8475	artisanal watered-down pulsating asbestos thermos	2	super EPIC	Last Available: "2015-08"
+8476	enhanced pressed double-galvanized blurry gray tumbling liquid rhinestones	0		Effect: "Faboooo", Effect Duration: 38, Last Available: "2015-08"
 8477	enchanted spoiled small disco biscuit	2	crappy	Effect: "Favored by Lyle", Effect Duration: 5, Last Available: "2015-08"
 8478	high-proof mediocre skewed Quaatorade&trade;	9	decent	Last Available: "2015-08"
 8479	maroon padded biker's hat of Tarzan of Leguizamo	0		Experience (Muscle): +3, Damage Absorption: +20, Monster Level: +20, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8396,8 +8396,8 @@
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	special immense flavorless blurry lava cake	10	decent	Effect: "You're Rubber", Effect Duration: 40, Last Available: "2015-08"
-8526	normal small fancy pink slime	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15
+8525	flavorless special immense blurry lava cake	10	decent	Effect: "You're Rubber", Effect Duration: 40, Last Available: "2015-08"
+8526	small fancy normal pink slime	2	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15
 8527	shaking yellow Devil's Elbow Hot Sauce	0		
 8528	squat Special&trade; Sauce	0		
 8529	spoiled huge huge devil hair pasta	10	crappy	
@@ -8405,17 +8405,17 @@
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	tumbling twirling illicit fish sauce	0		
-8534	thick adequate libertagliatelle	5	good	
+8534	adequate thick libertagliatelle	5	good	
 8535	moldy bouncing turkish mostaccioli	3	crappy	
-8536	moldy half-sized linguini of the sea	2	crappy	
+8536	half-sized moldy linguini of the sea	2	crappy	
 8537	nitrogenated irradiated pulsating wobbly Hersey&trade; SMOOCH	0		Effect: "Items Are Forever", Effect Duration: 54
 8539	Alexy sauce	0		
-8540	bouncing spinning rainbow sauce	0		
+8540	spinning bouncing rainbow sauce	0		
 8541	cyan drug cocktail sauce	0		
 8542	spoiled Fettris	3	crappy	
 8543	small bland fusillocybin	2	decent	
-8544	adequate miniature prescription noodles	2	good	
-8545	modified teal pulsating skewed blood-drive sticker	1	crappy	
+8544	miniature adequate prescription noodles	2	good	
+8545	modified skewed teal pulsating blood-drive sticker	1	crappy	
 8546	colloidal bag of grain	0		Effect: "Abyssal Sweat", Effect Duration: 31
 8547	nitrogenated pocket maze	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 46
 8548	polymerized narrow shady shades	0		Effect: "Metal Speed", Effect Duration: 45
@@ -8423,14 +8423,14 @@
 8550	adequate tumbling weird gazelle steak	3	good	
 8551	bland sausage without a cause	3	decent	
 8552	energized squat teal face paint	0		Effect: "Locks Like the Raven", Effect Duration: 22
-8553	perfectly mixed fancy practically non-alcoholic emergency margarita	1	super ultra mega turbo EPIC	Effect: "Thought", Effect Duration: 15
-8554	watered-down drinkable fancy pulsating shaking vintage smart drink	2	good	Effect: "Pronounced Potency", Effect Duration: 20
+8553	practically non-alcoholic perfectly mixed fancy emergency margarita	1	super ultra mega turbo EPIC	Effect: "Thought", Effect Duration: 15
+8554	fancy watered-down drinkable pulsating shaking vintage smart drink	2	good	Effect: "Pronounced Potency", Effect Duration: 20
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	activated dry magnetized tumbling ghostly Wickers bar	0		Effect: "Full-Body Tan", Effect Duration: 16
+8558	activated dry magnetized ghostly tumbling Wickers bar	0		Effect: "Full-Body Tan", Effect Duration: 16
 8559	adjusted anodized bakelite-covered bacon	0		Effect: "Extra-Sharp Weapon", Effect Duration: 51
-8560	non-galvanized flattened ionized teal blinking Aerheads	0		Effect: "Bilious Brawn", Effect Duration: 33
+8560	non-galvanized flattened ionized blinking teal Aerheads	0		Effect: "Bilious Brawn", Effect Duration: 33
 8561	unsweetened purple Wrotz	0		Effect: "The Moxie of LOV", Effect Duration: 61
 8562	Vulcanized dry spinning Gabarbar	0		Effect: "Memories of Puppy Love", Effect Duration: 62
 8563	wet concentrated moist ghostly upside-down fiberglass insulation	0		Effect: "Ghostly Shell", Effect Duration: 61
@@ -8438,7 +8438,7 @@
 8565	rock-hard supercool barrel lid of the cougar	0		Moxie: +20, Moxie Percent: +20, Damage Reduction: 14, Lasts Until Rollover, Last Available: "2015-09"
 8566	skewed flame-retardant scorching ruddy barrel hoop earring	0		Maximum HP Percent: +40, Hot Damage: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2015-09"
 8567	huge green toasty sharpshooter's bankruptcy barrel of the early riser	0		Critical Hit Percent: +10, Hot Damage: +5, Adventures: +7, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
-8568	wobbly narrow olive firkin	0		Last Available: "2015-09"
+8568	olive narrow wobbly firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	experienced barrel gun	0		Experience: +2, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	moldy fancy immense water log	10	crappy	Effect: "What's That Smell?", Effect Duration: 20, Last Available: "2015-09"
+8589	fancy immense moldy water log	10	crappy	Effect: "What's That Smell?", Effect Duration: 20, Last Available: "2015-09"
 8590	bouncing pulsating nasty ruddy barrelhead	0		Maximum HP Percent: +40, Stench Damage: +5, Last Available: "2015-09"
 8591	nippy bottoms of the barrel of the overflowing toilet	0		Cold Damage: +10, Stench Spell Damage: +50, Last Available: "2015-09"
 8592	stanky smooth chest barrel	0		Moxie: +15, Stench Spell Damage: +25, Last Available: "2015-09"
@@ -8477,14 +8477,14 @@
 8604	ionized skewed cuppa Nas tea	0		Effect: "The Smeezingtons", Effect Duration: 28, Last Available: "2015-09"
 8605	dry cuppa Improprie tea	0		Effect: "Arse-a'fire", Effect Duration: 13, Last Available: "2015-09"
 8606	irradiated chilled mirror cuppa Frost tea	0		Effect: "Eldritch Concentration", Effect Duration: 28, Last Available: "2015-09"
-8607	adjusted blinking shaking shaking cuppa Toast tea	0		Effect: "High Blood Chocolate Content", Effect Duration: 30, Last Available: "2015-09"
+8607	adjusted shaking blinking shaking cuppa Toast tea	0		Effect: "High Blood Chocolate Content", Effect Duration: 30, Last Available: "2015-09"
 8608	tarnished dry cuppa Net tea	0		Effect: "Innately Truthy", Effect Duration: 41, Last Available: "2015-09"
-8609	wet energized skewed maroon cuppa Proprie tea	0		Effect: "Libra Rising", Effect Duration: 36, Last Available: "2015-09"
+8609	wet energized maroon skewed cuppa Proprie tea	0		Effect: "Libra Rising", Effect Duration: 36, Last Available: "2015-09"
 8610	oxidized cuppa Morbidi tea	0		Effect: "Polar Express", Effect Duration: 27, Last Available: "2015-09"
 8611	frozen pressed pulsating cuppa Chari tea	0		Effect: "Stands Alone", Effect Duration: 53, Last Available: "2015-09"
 8612	irradiated cuppa Serendipi tea	0		Effect: "Billiards Belligerence", Effect Duration: 32, Last Available: "2015-09"
 8613	quantum unsweetened tumbling cuppa Feroci tea	0		Effect: "Kissed By Fire", Effect Duration: 62, Last Available: "2015-09"
-8614	enhanced magnetized wobbly blurry cuppa Physicali tea	0		Effect: "Ten out of Ten", Effect Duration: 53, Last Available: "2015-09"
+8614	enhanced magnetized blurry wobbly cuppa Physicali tea	0		Effect: "Ten out of Ten", Effect Duration: 53, Last Available: "2015-09"
 8615	electrified triple-diffused nitrogenated cuppa Wit tea	0		Effect: "Stick Emporium Membership", Effect Duration: 41, Last Available: "2015-09"
 8616	modified dry huge cuppa Neuroplastici tea	0		Effect: "Cool, Catlike", Effect Duration: 62, Last Available: "2015-09"
 8617	quadruple-electrified triple-enhanced cuppa Dexteri tea	0		Effect: "Gummibrain", Effect Duration: 30, Last Available: "2015-09"
@@ -8495,7 +8495,7 @@
 8622	extra-pressed blinking cuppa Mediocri tea	0		Effect: "Extra-Thick Blood", Effect Duration: 34, Last Available: "2015-09"
 8623	concentrated diffused cuppa Loyal tea	0		Effect: "Fungal Flambé", Effect Duration: 56, Last Available: "2015-09"
 8624	dried shaking cuppa Activi tea	1	crappy	Last Available: "2015-09"
-8625	altered mirror ghostly cuppa Cruel tea	1		Last Available: "2015-09"
+8625	altered ghostly mirror cuppa Cruel tea	1		Last Available: "2015-09"
 8626	galvanized cuppa Alacri tea	0		Effect: "Gutterminded", Effect Duration: 59, Last Available: "2015-09"
 8627	pickled adjusted cuppa Vitali tea	0		Effect: "Flexibili Tea", Effect Duration: 31, Last Available: "2015-09"
 8628	moist cold-filtered cuppa Mana tea	0		Effect: "In the Saucestream", Effect Duration: 26, Last Available: "2015-09"
@@ -8514,18 +8514,18 @@
 8641	rotten bowl of eyeballs	4	crappy	Last Available: "2015-10"
 8642	bland bowl of mummy guts	3	decent	Last Available: "2015-10"
 8643	thick spoiled bowl of maggots	5	crappy	Last Available: "2015-10"
-8644	triple-distilled lousy purple blood and blood	6	decent	Last Available: "2015-10"
-8645	hand-crafted high-proof bouncing Jack-O-Lantern beer	8	EPIC	Last Available: "2015-10"
-8646	tolerable irresponsibly strong squat zombie	7	good	Last Available: "2015-10"
+8644	lousy triple-distilled purple blood and blood	6	decent	Last Available: "2015-10"
+8645	high-proof hand-crafted bouncing Jack-O-Lantern beer	8	EPIC	Last Available: "2015-10"
+8646	irresponsibly strong tolerable squat zombie	7	good	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	spinning wind-up spider	0		Last Available: "2015-10"
-8649	tumbling pulsating plastic nightmare troll	0		Last Available: "2015-10"
+8649	pulsating tumbling plastic nightmare troll	0		Last Available: "2015-10"
 8650	tennis ball	0		Last Available: "2015-10"
 8651	rosewater-soaked crown of the wise owl of horror	0		Mysticality: +20, Spooky Spell Damage: +25, Stench Resistance: +3, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
 8653	stink-penny	0		
 8654	forbidden deadly hawk of the businessman	0		Weapon Damage: +5, Spell Damage Percent: +50, Meat Drop: +50
-8655	moldy snack-sized hamlet sandwich	2	crappy	
+8655	snack-sized moldy hamlet sandwich	2	crappy	
 8656	tumbling horrifying Othello's military jacket	0		Spooky Damage: +25
 8657	manspreader's Othello's dagger	0		Monster Level: +10, Single Equip
 8658	supercharged Othello's handkerchief	0		Maximum MP Percent: +30, Single Equip
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	wobbly How to Play Othello	0		
 8662	upside-down supercool ghostly dagger of the scaredy-cat of mayonnaise	0		Moxie Percent: +20, Monster Level: -15, Sleaze Spell Damage: +50
-8663	weak drinkable ghost beer	2	good	
+8663	drinkable weak ghost beer	2	good	
 8664	upside-down tumbling stanky Othello set	0		Stench Spell Damage: +25
 8665	rotten tomato	0		
 8666	purple Twelve Night Energy	0		
@@ -8546,9 +8546,9 @@
 8673	purple Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	modified shaking squat skewed fuchsia shoulder-warming lotion	0		Effect: "Swordholder", Effect Duration: 19, Last Available: "2015-11"
+8676	modified squat shaking fuchsia skewed shoulder-warming lotion	0		Effect: "Swordholder", Effect Duration: 19, Last Available: "2015-11"
 8677	moldy iceberg lettuce	4	crappy	Last Available: "2015-11"
-8678	artisanal weak upside-down ice wine	2	EPIC	Last Available: "2015-11"
+8678	weak artisanal upside-down ice wine	2	EPIC	Last Available: "2015-11"
 8679	careful Wal-Mart snowglobe of dire peril of the blizzard	0		Weapon Damage: +20, Monster Level: -10, Cold Spell Damage: +25, Last Available: "2015-11"
 8680	ghostly quilted grievous stylish Wal-Mart nametag	0		Moxie: +25, Weapon Damage Percent: +50, Damage Absorption: +40, Last Available: "2015-11"
 8681	twirling thinker's Wal-Mart overalls of wisdom of incineration	0		Mysticality: 25, Hot Spell Damage: +50, Last Available: "2015-11"
@@ -8573,7 +8573,7 @@
 8700	upside-down frosty chaotic personal trainer's training legwarmers	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2016-01"
 8701	rosewater-soaked steel-toed training helmet of Leguizamo	0		Damage Reduction: 9, Monster Level: +20, Stench Resistance: +3, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
-8703	yellow pulsating training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
+8703	pulsating yellow training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	huge X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
@@ -8583,7 +8583,7 @@
 8710	diluted huge abstraction: sensation	1		Last Available: "2015-12"
 8711	modified ghostly abstraction: purpose	1		Last Available: "2015-12"
 8712	vaporized blinking abstraction: category	1		Effect: "Preemptive Medicine", Effect Duration: 50, Last Available: "2015-12"
-8713	modified cyan ghostly blinking abstraction: perception	1		Last Available: "2015-12"
+8713	modified ghostly blinking cyan abstraction: perception	1		Last Available: "2015-12"
 8714	diluted abstraction: motion	1		Effect: "Belch the Rainbow&trade;", Effect Duration: 5, Last Available: "2015-12"
 8715	modified abstraction: joy	1		Last Available: "2015-12"
 8716	mixed abstraction: certainty	1		Last Available: "2015-12"
@@ -8601,16 +8601,16 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	up-at-dawn experienced VYKEA hex key of the sweet-tooth	0		Experience: +2, Candy Drop: +100, Adventures: +5, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	miniature yummy tin of submardines	2	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	yummy miniature tin of submardines	2	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	aged gray bottle of norwhiskey	4	awesome	Last Available: "2015-11"
 8733	denatured octolus oculus	1	EPIC	Effect: "Beastly Flavor", Effect Duration: 10, Last Available: "2015-11"
 8734	smelly mansplainer's Newton's sardine can key	0		Experience (Mysticality): +3, Monster Level: +15, Stench Spell Damage: +10, Last Available: "2015-11"
 8735	arcane researcher's personal trainer's norwhal helmet of incineration	0		Experience Percent (Muscle): +10, Experience Percent (Mysticality): +10, Hot Spell Damage: +50, Last Available: "2015-11", Familiar Effect: "atk"
 8736	scandalous wicked octolus-skin cloak of the dark arts	0		Spell Damage: +5, Spell Damage Percent: +100, Sleaze Damage: +5, Last Available: "2015-11"
 8737	hand-crafted perfect cosmopolitan	4	EPIC	Last Available: "2015-11"
-8738	fancy watered-down drinkable tumbling perfect negroni	2	good	Effect: "Good Karma", Effect Duration: 5, Last Available: "2015-11"
-8739	tolerable fortified perfect dark and stormy	5	good	Last Available: "2015-11"
-8740	weak mediocre cyan perfect mimosa	2	decent	Last Available: "2015-11"
+8738	fancy drinkable watered-down tumbling perfect negroni	2	good	Effect: "Good Karma", Effect Duration: 5, Last Available: "2015-11"
+8739	fortified tolerable perfect dark and stormy	5	good	Last Available: "2015-11"
+8740	mediocre weak cyan perfect mimosa	2	decent	Last Available: "2015-11"
 8741	bad perfect old-fashioned	3	decent	Last Available: "2015-11"
 8742	tolerable weak perfect paloma	2	good	Last Available: "2015-11"
 8743	polymerized That 70s Cologne	0		Effect: "Trash-Wrapped", Effect Duration: 50, Last Available: "2015-11"
@@ -8624,8 +8624,8 @@
 8751	quadruple-boiled electrified communal gobstopper	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 23, Last Available: "2015-12"
 8752	flavorless Crimbo salad	3	decent	Last Available: "2015-12"
 8753	yummy bread line	3	awesome	Last Available: "2015-12"
-8754	watered-down smooth mirror bark rootbeer	2	awesome	Last Available: "2015-12"
-8755	extra-dry tolerable narrow ale	5	good	Last Available: "2015-12"
+8754	smooth watered-down mirror bark rootbeer	2	awesome	Last Available: "2015-12"
+8755	tolerable extra-dry narrow ale	5	good	Last Available: "2015-12"
 8756	pulsating thinker's plastic Tammy the Tambourine Elf	0		Mysticality: +10, Last Available: "2015-12"
 8757	reassuring plastic Rudolph the Red	0		Spooky Resistance: +1, Last Available: "2015-12"
 8758	shaking sinister plastic Gaia'ajh-dsli Ak'lwej	0		Spell Damage: +10, Last Available: "2015-12"
@@ -8637,7 +8637,7 @@
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	maroon Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
 8766	tolerable Gratitude chocolate (bourbon-filled)	4	good	Last Available: "2016-02"
-8767	bouncing skewed Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
+8767	skewed bouncing Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	skewed Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
 8770	aerosolized diffused maroon pitted sheet	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 21, Last Available: "2015-12"
@@ -8654,7 +8654,7 @@
 8782	vibrating reindeer hammer	0		Maximum MP Percent: +10, Last Available: "2015-12"
 8783	wool elf ploughshare	0		Cold Resistance: +1, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8663,7 +8663,7 @@
 8791	gray reindeer sickle of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-12"
 8792	face paint	0		Free Pull, Last Available: "2015-12"
 8793	face paint	0		Free Pull, Last Available: "2015-12"
-8794	olive narrow The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
+8794	narrow olive The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	blurry bat-oomerang	0		Last Available: "2017-01"
@@ -8676,7 +8676,7 @@
 8804	high-grade	0		Last Available: "2017-01"
 8805	mirror high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	fuchsia high-grade explosives	0		Last Available: "2017-01"
-8807	blinking green experimental gene therapy	0		Last Available: "2017-01"
+8807	green blinking experimental gene therapy	0		Last Available: "2017-01"
 8808	ultracoagulator	0		Last Available: "2017-01"
 8809	self-defense training	0		Last Available: "2017-01"
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
@@ -8684,20 +8684,20 @@
 8812	exploding kickball	0		Last Available: "2017-01"
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
-8815	teal bouncing tumbling bat-bearing	0		Last Available: "2017-01"
+8815	bouncing teal tumbling bat-bearing	0		Last Available: "2017-01"
 8816	bland snack-sized Kudzu salad	2	decent	Last Available: "2016-12"
 8817	denatured tumbling tumbling Mansquito Serum	1		Last Available: "2016-12"
 8818	tolerable Miss Graves' vermouth	3	good	Last Available: "2016-12"
 8819	spoiled twirling The Plumber's mushroom stew	3	crappy	Last Available: "2016-12"
-8820	modified narrow bouncing yellow The Author's ink	1		Last Available: "2016-02"
-8821	special acceptable The Mad Liquor	3	good	Effect: "Hair on Your Chest", Effect Duration: 40, Last Available: "2016-12"
-8822	weak perfectly mixed blurry Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
+8820	modified yellow narrow bouncing The Author's ink	1		Last Available: "2016-02"
+8821	acceptable special The Mad Liquor	3	good	Effect: "Hair on Your Chest", Effect Duration: 40, Last Available: "2016-12"
+8822	perfectly mixed weak blurry Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
 8823	jumbo adequate twirling Mr. Burnsger	5	good	Last Available: "2016-12"
 8824	dried lime green The Inquisitor's unidentifiable object	1		Effect: "Memory of Smarts", Effect Duration: 10, Last Available: "2016-12"
 8825	scorching nippy hale The Jokester's gun	0		Maximum HP: +20, Cold Damage: +10, Hot Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
 8826	healthy razor-sharp The Jokester's wig of Calamity Jane	0		Weapon Damage Percent: +25, Maximum HP Percent: +20, Critical Hit Percent: +15, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	careful energetic The Jokester's pants of terror	0		Maximum MP Percent: +20, Monster Level: -10, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
-8828	moist squat jittery Jokester makeup	0		Effect: "Spooky Demeanor", Effect Duration: 20, Last Available: "2016-12"
+8828	moist jittery squat Jokester makeup	0		Effect: "Spooky Demeanor", Effect Duration: 20, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	ghostly battoo kit	0		Last Available: "2016-12"
 8831	maroon basking robin	0		Free Pull, Last Available: "2016-12"
@@ -8715,7 +8715,7 @@
 8843	vacuum-sealed non-dry blurry squat skewed purple can of drain cleaner	0		Effect: "Salsa Satanica", Effect Duration: 68
 8844	aerosolized ghostly The Author's inkwell	0		Effect: "Protection from Bad Stuff", Effect Duration: 20
 8845	warmed bag of random words	0		Effect: "Expert Vacationer", Effect Duration: 54
-8846	Vulcanized wobbly tumbling tube of pendulum lube	0		Effect: "Human-Penguin Hybrid", Effect Duration: 57
+8846	Vulcanized tumbling wobbly tube of pendulum lube	0		Effect: "Human-Penguin Hybrid", Effect Duration: 57
 8847	quadruple-vacuum-sealed cyan red-hot jawbreaker	0		Effect: "Meat the Flintstones", Effect Duration: 24
 8848	boiled question juice	0		Effect: "Saucemastery", Effect Duration: 46
 8849	magnetized tube of villain	0		Effect: "Beastly Flavor", Effect Duration: 48
@@ -8745,12 +8745,12 @@
 8873	Da Vinci's Pork 'n' Pork 'n' Pork 'n' Beans	0		Experience (Mysticality): +5, Last Available: "2016-02"
 8874	frosty veiny razor-sharp educational Val-U Brand Every Bean Salad of dire peril	0		Experience: +1, Weapon Damage: +20, Weapon Damage Percent: +25, Maximum HP: +10, Cold Spell Damage: +10, Last Available: "2016-02"
 8875	flame-wreathed Da Vinci's Shrub's Premium Baked Beans	0		Experience (Mysticality): +5, Hot Spell Damage: +10, Item Drop: +5, Last Available: "2016-02"
-8876	rotten twirling teal blurry plate of Heimz Fortified Kidney Beans	3	crappy	Last Available: "2016-02"
-8877	enchanted diet moldy plate of Tesla's Electroplated Beans	1	crappy	Effect: "Hella Tough", Effect Duration: 50, Last Available: "2016-02"
+8876	rotten teal twirling blurry plate of Heimz Fortified Kidney Beans	3	crappy	Last Available: "2016-02"
+8877	moldy diet enchanted plate of Tesla's Electroplated Beans	1	crappy	Effect: "Hella Tough", Effect Duration: 50, Last Available: "2016-02"
 8878	half-sized decent fuchsia plate of Mixed Garbanzos and Chickpeas	2	good	Last Available: "2016-02"
 8879	toothsome twirling plate of Hellfire Spicy Beans	3	awesome	Last Available: "2016-02"
 8880	stale plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
-8881	spoiled half-sized ghostly plate of World's Blackest-Eyed Peas	2	crappy	Last Available: "2016-02"
+8881	half-sized spoiled ghostly plate of World's Blackest-Eyed Peas	2	crappy	Last Available: "2016-02"
 8882	spoiled wobbly plate of Trader Olaf's Exotic Stinkbeans	4	crappy	Last Available: "2016-02"
 8883	spoiled big special maroon plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	crappy	Effect: "Chow Downed", Effect Duration: 5, Last Available: "2016-02"
 8884	tasty plate of Val-U Brand Every Bean Salad	3	awesome	Last Available: "2016-02"
@@ -8802,7 +8802,7 @@
 8930	enhanced chilled chilled demonic cow's blood	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 38, Last Available: "2016-02"
 8931	huge rinky-dink sixgun	0		Last Available: "2016-02"
 8932	makeshift sixgun	0		Last Available: "2016-02"
-8933	blurry huge custom sixgun	0		Last Available: "2016-02"
+8933	huge blurry custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
@@ -8820,7 +8820,7 @@
 8948	thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
 8949	wicksilver spurs	0		Last Available: "2016-02"
 8950	mirror slicksilver spurs	0		Last Available: "2016-02"
-8951	skewed shaking cyan sicksilver spurs	0		Last Available: "2016-02"
+8951	cyan shaking skewed sicksilver spurs	0		Last Available: "2016-02"
 8952	fuchsia nicksilver spurs	0		Last Available: "2016-02"
 8953	upside-down ticksilver spurs	0		Last Available: "2016-02"
 8954	special edition Batfellow comic	0		Free Pull, Last Available: "2016-12"
@@ -8844,7 +8844,7 @@
 8972	electrified altered skin oil	0		Effect: "Wit Tea", Effect Duration: 47
 8973	magnetized pickled unusual oil	0		Effect: "Frostbeard", Effect Duration: 56
 8974	dry eldritch oil	0		Effect: "Spiky Hair", Effect Duration: 42
-8975	bouncing lime green exclusive club	0		
+8975	lime green bouncing exclusive club	0		
 8976	quadruple-ionized patent preventative tonic	0		Effect: "Very Clean Guns", Effect Duration: 20
 8977	flattened super-activated patent invisibility tonic	0		Effect: "Bored Stiff", Effect Duration: 48
 8978	flattened non-improved patent aggression tonic	0		Effect: "Jelly Combed", Effect Duration: 50
@@ -8861,9 +8861,9 @@
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	skewed do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	altered blinking narrow armored prawn	1		Last Available: "2016-03"
-8993	immense bland jumping horseradish	8	decent	Last Available: "2016-03"
-8994	artisanal enchanted purple Sacramento wine	4	EPIC	Effect: "Nightstalkin'", Effect Duration: 5, Last Available: "2016-03"
+8992	altered narrow blinking armored prawn	1		Last Available: "2016-03"
+8993	bland immense jumping horseradish	8	decent	Last Available: "2016-03"
+8994	enchanted artisanal purple Sacramento wine	4	EPIC	Effect: "Nightstalkin'", Effect Duration: 5, Last Available: "2016-03"
 8995	nitrogenated maroon Greek fire	0		Effect: "Sweet Nostalgia", Effect Duration: 20, Last Available: "2016-03"
 8996	nippy Lo Pan's dance instructor's experienced ox-head shield of the pedagogue	0		Experience: 5, Experience Percent (Moxie): +10, Spell Critical Percent: +30, Cold Damage: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	double-paned greasy quilted Rosewater's dented scepter of the pedagogue	0		Mysticality Percent: +30, Experience: +3, Damage Absorption: +40, Sleaze Spell Damage: +10, Cold Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8877,8 +8877,8 @@
 9005	upside-down mirror greedy resourceful fish hatchet of dire peril of the sewer	0		Weapon Damage: +20, Maximum MP: +50, Stench Damage: +25, Meat Drop: +20, Lasts Until Rollover, Last Available: "2016-04"
 9006	extremely unsafe razor-sharp tunac of courage of Flo-Jo	0		Weapon Damage Percent: 125, Spooky Resistance: +3, Initiative: +100, Lasts Until Rollover, Last Available: "2016-04"
 9007	yellow fishin' pole	0		Last Available: "2016-04"
-9008	super-ionized magnetized huge fuchsia wriggling worm	0		Effect: "Amorous Avarice", Effect Duration: 32, Last Available: "2016-04"
-9009	weak acceptable bottle of Fishhead 900-Day IPA	2	good	Last Available: "2016-04"
+9008	super-ionized magnetized fuchsia huge wriggling worm	0		Effect: "Amorous Avarice", Effect Duration: 32, Last Available: "2016-04"
+9009	acceptable weak bottle of Fishhead 900-Day IPA	2	good	Last Available: "2016-04"
 9010	magnetized extra-alkaline mirror high-test fishing line	0		Effect: "Fancy Feasted", Effect Duration: 40, Last Available: "2016-04"
 9011	therapeutic fishin' hat	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-04"
 9012	tumbling Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8898,13 +8898,13 @@
 9026	spinning First Post shirt package	0		Last Available: "2016-05"
 9027	rosewater-soaked Oprah's Socratic First Post shirt - Cir Senam	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Stench Resistance: +3, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
-9029	mirror red no spoon	0		
+9029	red mirror no spoon	0		
 9030	stale pulsating star salad	3	decent	
 9031	Thwaitgold moth statuette	0		
 9032	spoiled bowl of Tastee-Wheet&trade;	3	crappy	
 9033	tumbling Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	wobbly Source essence	0		Last Available: "2016-06"
-9035	rotten thick browser cookie	5	crappy	Last Available: "2016-06"
+9035	thick rotten browser cookie	5	crappy	Last Available: "2016-06"
 9036	tolerable gray hacked gibson	4	good	Last Available: "2016-06"
 9037	manspreader's Source shades	0		Monster Level: +10, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8915,7 +8915,7 @@
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
 9044	spinning Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	gray Source terminal TRAM chip	0		Last Available: "2016-06"
-9046	jittery skewed Source terminal INGRAM chip	0		Last Available: "2016-06"
+9046	skewed jittery Source terminal INGRAM chip	0		Last Available: "2016-06"
 9047	Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	Source terminal SCRAM chip	0		Last Available: "2016-06"
@@ -8947,8 +8947,8 @@
 9075	non-aerosolized denatured shaking shoe gum	0		Effect: "Standard Cheer", Effect Duration: 47, Last Available: "2016-07"
 9076	veiny educational slick noir fedora	0		Moxie: +10, Experience: +1, Maximum HP: +10, Last Available: "2016-07"
 9077	trench coat of doom of the detective of the cheetah	0		Spooky Spell Damage: +50, Item Drop: +20, Initiative: +60, Last Available: "2016-07"
-9078	triple-distilled perfectly mixed jittery Falcon&trade; Maltese Liquor	7	EPIC	Last Available: "2016-07"
-9079	low-calorie stale gray hardboiled egg	1	decent	Last Available: "2016-07"
+9078	perfectly mixed triple-distilled jittery Falcon&trade; Maltese Liquor	7	EPIC	Last Available: "2016-07"
+9079	stale low-calorie gray hardboiled egg	1	decent	Last Available: "2016-07"
 9080	blurry detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	chilly Tesla clever deadly beefcake's protonic accelerator pack of Leguizamo	0		Muscle: +25, Weapon Damage: +5, Maximum MP: +20, Monster Level: +20, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
@@ -8988,9 +8988,9 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	spinning scandalous repaid diaper	0		Sleaze Damage: +5
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	perfectly mixed practically non-alcoholic Shot of Kardashian Gin	1	EPIC	Last Available: "2016-09"
+9119	practically non-alcoholic perfectly mixed Shot of Kardashian Gin	1	EPIC	Last Available: "2016-09"
 9120	narrow Da Vinci's Unstable Pointy Ears	0		Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2016-09"
-9121	spinning skewed Memory Disk, Alpha	0		Last Available: "2016-09"
+9121	skewed spinning Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	EPIC	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	red baby bark scorpion	0		
@@ -9025,11 +9025,11 @@
 9153	spoiled raw sweet potato	4	crappy	Last Available: "2016-11"
 9154	tiny delicious raw beans	1	awesome	Last Available: "2016-11"
 9155	special spoiled fuchsia raw stuffing	3	crappy	Effect: "Stench Jellied", Effect Duration: 40, Last Available: "2016-11"
-9156	gigantic stale raw cranberry sauce	6	decent	Last Available: "2016-11"
-9157	fancy moldy raw turkey	3	crappy	Effect: "Feline Ferocity", Effect Duration: 15, Last Available: "2016-11"
-9158	thick flavorless jittery blinking raw mincemeat	5	decent	Last Available: "2016-11"
+9156	stale gigantic raw cranberry sauce	6	decent	Last Available: "2016-11"
+9157	moldy fancy raw turkey	3	crappy	Effect: "Feline Ferocity", Effect Duration: 15, Last Available: "2016-11"
+9158	flavorless thick jittery blinking raw mincemeat	5	decent	Last Available: "2016-11"
 9159	spoiled raw potato	4	crappy	Last Available: "2016-11"
-9160	snack-sized rotten raw gravy	2	crappy	Last Available: "2016-11"
+9160	rotten snack-sized raw gravy	2	crappy	Last Available: "2016-11"
 9161	tasty raw bread	3	awesome	Last Available: "2016-11"
 9162	foul-smelling electrified mini-marshmallow dispenser	0		Stench Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-11"
 9163	experienced beefy glass casserole dish of the blizzard	0		Muscle: +10, Experience: +2, Cold Spell Damage: +25, Last Available: "2016-11"
@@ -9040,17 +9040,17 @@
 9168	fuchsia auspicious family-friendly potato masher	0		Sleaze Resistance: +1, Item Drop: +10, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	tasty half-sized tumbling sweet potatoes	2	awesome	Last Available: "2016-11"
+9171	half-sized tasty tumbling sweet potatoes	2	awesome	Last Available: "2016-11"
 9172	bland bean casserole	3	decent	Last Available: "2016-11"
 9173	miniature bland bouncing baked stuffing	2	decent	Last Available: "2016-11"
-9174	small enchanted moldy cranberry cylinder	2	crappy	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2016-11"
+9174	moldy enchanted small cranberry cylinder	2	crappy	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2016-11"
 9175	stale thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	miniature decent mince pie	2	good	Last Available: "2016-11"
 9177	stale mashed potatoes	4	decent	Last Available: "2016-11"
 9178	stale twirling warm gravy	3	decent	Last Available: "2016-11"
 9179	bland jittery bread roll	3	decent	Last Available: "2016-11"
-9180	toothsome half-sized leftovers	2	awesome	Last Available: "2016-11"
-9181	immense fancy rotten leftovers sandwich	8	crappy	Effect: "Coal-Powered", Effect Duration: 45, Last Available: "2016-11"
+9180	half-sized toothsome leftovers	2	awesome	Last Available: "2016-11"
+9181	fancy rotten immense leftovers sandwich	8	crappy	Effect: "Coal-Powered", Effect Duration: 45, Last Available: "2016-11"
 9182	olive Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	blue megacopia	0		Last Available: "2016-11"
@@ -9072,7 +9072,7 @@
 9200	forbidden supercool Quartet of Flare Masters Jacket	0		Moxie Percent: +20, Spell Damage Percent: +50, Last Available: "2016-11"
 9201	green lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	red shaking Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	shaking red Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	pulsating counterfeit city	0		Last Available: "2016-12"
 9205	wobbly sprinkles	0		Last Available: "2016-12"
 9206	The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
@@ -9088,7 +9088,7 @@
 9216	interesting clod of dirt	0		
 9217	squat gingerbread restraining order	0		Last Available: "2016-12"
 9218	yellow sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	super-sized decent animal part cracker	5	good	Last Available: "2016-12"
+9219	decent super-sized animal part cracker	5	good	Last Available: "2016-12"
 9220	acceptable gingerbread wine	4	good	Last Available: "2016-12"
 9221	moldy skewed gingerbread mug	3	crappy	Last Available: "2016-12"
 9222	forbidden gingerbread mask	0		Spell Damage Percent: +50, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	lightning-fast boxer's gingerbread gavel	0		Muscle Percent: +10, Initiative: +40, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gray gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	strong tolerable skewed ginger beer	5	good	Last Available: "2016-12"
+9239	tolerable strong skewed ginger beer	5	good	Last Available: "2016-12"
 9240	spinning spare chocolate parts	0		Last Available: "2016-12"
 9241	deionized cold-filtered industrial frosting	0		Effect: "The Halls of Moxiousness", Effect Duration: 16, Last Available: "2016-12"
 9242	flattened fake cocktail	0		Effect: "The Halls of Mysticality", Effect Duration: 43, Last Available: "2016-12"
@@ -9121,7 +9121,7 @@
 9249	diffused Inner Wisdom	0		Effect: "Ticking Clock", Effect Duration: 13, Last Available: "2016-12"
 9250	adjusted Inner Strength	0		Effect: "Creepypasted", Effect Duration: 16, Last Available: "2016-12"
 9251	flattened narrow Inner Truth	0		Effect: "Dreadful Chill", Effect Duration: 29, Last Available: "2016-12"
-9252	bland blurry cyan pulsating spiritual candy cane	3	decent	Last Available: "2016-12"
+9252	bland cyan blurry pulsating spiritual candy cane	3	decent	Last Available: "2016-12"
 9253	practically non-alcoholic bad spinning spiritual eggnog	1	decent	Last Available: "2016-12"
 9254	adequate blinking spiritual fruitcake	4	good	Last Available: "2016-12"
 9255	flavorless spiritual gingerbread	4	decent	Last Available: "2016-12"
@@ -9148,7 +9148,7 @@
 9276	mediocre huge chakra-mental wine	3	decent	Last Available: "2016-12"
 9277	super-diffused chakra malt	0		Effect: "Deep-Seated Rage", Effect Duration: 17, Last Available: "2016-12"
 9278	flavorless small Black Angus blackburger	2	decent	Last Available: "2016-12"
-9279	high-proof bad ghostly brandy	9	decent	Last Available: "2016-12"
+9279	bad high-proof ghostly brandy	9	decent	Last Available: "2016-12"
 9280	vacuum-sealed mirror potion of spiritual gunkifying	0		Effect: "Mana Tea", Effect Duration: 15, Last Available: "2016-12"
 9281	shaking gravedigger's Rosewater's bad vibroknife	0		Mysticality Percent: +30, Spooky Damage: +10, Last Available: "2016-12"
 9282	spinning crystal belt buckle of Calamity Jane of the scaredy-cat	0		Critical Hit Percent: +15, Monster Level: -15, Last Available: "2016-12"
@@ -9164,24 +9164,24 @@
 9292	mixed jelly	1		Last Available: "2017-01"
 9293	pickled squat jelly	1		Last Available: "2017-01"
 9294	modified sleaze jelly	1		Effect: "Musky", Effect Duration: 30, Last Available: "2017-01"
-9295	twisted fuchsia shaking stench jelly	1		Last Available: "2017-01"
+9295	twisted shaking fuchsia stench jelly	1		Last Available: "2017-01"
 9296	tumbling space planula	0		Free Pull, Last Available: "2017-01"
-9297	spoiled enchanted toast with hot jelly	3	crappy	Effect: "Dragged Through the Coals", Effect Duration: 40, Last Available: "2017-01"
+9297	enchanted spoiled toast with hot jelly	3	crappy	Effect: "Dragged Through the Coals", Effect Duration: 40, Last Available: "2017-01"
 9298	rotten gigantic toast with jelly	9	crappy	Last Available: "2017-01"
-9299	special tiny adequate toast with jelly	1	good	Effect: "Amorphous Cheer", Effect Duration: 15, Last Available: "2017-01"
-9300	rotten fancy green toast with sleaze jelly	4	crappy	Effect: "Cotton Mouthed", Effect Duration: 10, Last Available: "2017-01"
+9299	special adequate tiny toast with jelly	1	good	Effect: "Amorphous Cheer", Effect Duration: 15, Last Available: "2017-01"
+9300	fancy rotten green toast with sleaze jelly	4	crappy	Effect: "Cotton Mouthed", Effect Duration: 10, Last Available: "2017-01"
 9301	decent toast with stench jelly	4	good	Last Available: "2017-01"
 9302	squat space jellybicycle	0		Familiar Weight: +5
 9303	skewed hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	purple pewter candlestick	0		Familiar Weight: +10
 9305	shaking zippy rosewater-soaked wax hand	0		Stench Resistance: +3, Initiative: +20, Last Available: "2017-01"
 9306	candle of the wise owl of Tarzan	0		Mysticality: +20, Experience (Muscle): +3, Lasts Until Rollover, Last Available: "2017-01"
-9307	rotten small wax pancake	2	crappy	Last Available: "2017-01"
+9307	small rotten wax pancake	2	crappy	Last Available: "2017-01"
 9308	scandalous frightening wax face	0		Spooky Damage: +5, Sleaze Damage: +5, Last Available: "2017-01"
-9309	mediocre fancy wax booze	4	decent	Effect: "Helvella Health", Effect Duration: 25, Last Available: "2017-01"
+9309	fancy mediocre wax booze	4	decent	Effect: "Helvella Health", Effect Duration: 25, Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	diluted bouncing sea jelly	1		Last Available: "2017-01"
-9312	toothsome tiny maroon sea truffle	1	awesome	Last Available: "2017-01"
+9312	tiny toothsome maroon sea truffle	1	awesome	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	knitted recovered cufflinks	0		Cold Resistance: +3, Single Equip, Last Available: "2017-01"
@@ -9193,7 +9193,7 @@
 9321	Lo Pan's medical-grade LOV Epaulettes of James Dean	0		Experience (Moxie): +3, Spell Critical Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2017-02"
 9322	greedy lion tamer's dangerous LOV Earrings	0		Weapon Damage: +10, Experience (familiar): +2, Meat Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	huge LOV Enamorang	0		Last Available: "2017-02"
-9324	cyan shaking LOV Emotionizer	0		Last Available: "2017-02"
+9324	shaking cyan LOV Emotionizer	0		Last Available: "2017-02"
 9325	blue LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	powdered squat green LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	squat Lo Pan's LOV Elephant	0		Spell Critical Percent: +30, Damage Reduction: 6, Last Available: "2017-02"
@@ -9203,11 +9203,11 @@
 9331	Sherlock's Jack Frost's quilted eldritch hammer	0		Damage Absorption: +40, Cold Spell Damage: +50, Item Drop: +25, Last Available: "2017-01"
 9332	moldy tumbling eldritch mushroom	3	crappy	Last Available: "2017-03"
 9333	upside-down eldritch ichor	0		
-9334	moldy big eldritch mushroom pizza	5	crappy	Last Available: "2017-03"
+9334	big moldy eldritch mushroom pizza	5	crappy	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	twirling eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	diffused gray eldritch rub	0		Effect: "Neuroplastici Tea", Effect Duration: 38, Last Available: "2017-02"
-9338	spinning jittery HP-35 Calculator	0		
+9338	jittery spinning HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
@@ -9219,18 +9219,18 @@
 9347	pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	bottle of novelty hot sauce	0		Last Available: "2017-03"
-9350	jittery lime green elemental sugarcube	0		Last Available: "2017-03"
+9350	lime green jittery elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
 9352	gray bottle of clam juice	0		Last Available: "2017-03"
 9353	cocktail mushroom	0		Last Available: "2017-03"
 9354	ghostly shot of granola liqueur	0		Last Available: "2017-03"
 9355	blue can of cherry-flavored sterno	0		Last Available: "2017-03"
-9356	ghostly bouncing lump of ichor	0		Last Available: "2017-03"
+9356	bouncing ghostly lump of ichor	0		Last Available: "2017-03"
 9357	bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	skewed baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
-9361	bouncing ghostly limepatch	0		Last Available: "2017-03"
+9361	ghostly bouncing limepatch	0		Last Available: "2017-03"
 9362	purple blinking pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	imaginary lemon	0		Last Available: "2017-03"
@@ -9246,15 +9246,15 @@
 9374	lousy spirit-forward great fashioned	5	decent	Last Available: "2017-03"
 9375	mediocre skewed Gnomish sagngria	3	decent	Last Available: "2017-03"
 9376	tolerable vodka stinger	3	good	Last Available: "2017-03"
-9377	tolerable enchanted extremely slippery nipple	4	good	Effect: "Patched In", Effect Duration: 45, Last Available: "2017-03"
+9377	enchanted tolerable extremely slippery nipple	4	good	Effect: "Patched In", Effect Duration: 45, Last Available: "2017-03"
 9378	artisanal piscatini	4	EPIC	Last Available: "2017-03"
 9379	lousy Churchill	3	decent	Last Available: "2017-03"
 9380	delicious mirror soilzerac	4	awesome	Last Available: "2017-03"
 9381	weak lousy London frog	2	decent	Last Available: "2017-03"
-9382	practically non-alcoholic mediocre nothingtini	1	decent	Last Available: "2017-03"
+9382	mediocre practically non-alcoholic nothingtini	1	decent	Last Available: "2017-03"
 9383	bad weak eighth plague	2	decent	Last Available: "2017-03"
 9384	smooth fuchsia single entendre	3	awesome	Last Available: "2017-03"
-9385	irresponsibly strong acceptable special reverse Tantalus	8	good	Effect: "Shot in the Arse", Effect Duration: 10, Last Available: "2017-03"
+9385	acceptable irresponsibly strong special reverse Tantalus	8	good	Effect: "Shot in the Arse", Effect Duration: 10, Last Available: "2017-03"
 9386	delicious olive elemental caipiroska	3	awesome	Last Available: "2017-03"
 9387	delicious Feliz Navidad	3	awesome	Last Available: "2017-03"
 9388	artisanal practically non-alcoholic spinning Bloody Nora	1	EPIC	Last Available: "2017-03"
@@ -9264,13 +9264,13 @@
 9392	acceptable R'lyeh	3	good	Last Available: "2017-03"
 9393	triple-distilled tolerable jittery Gnollish sangria	10	good	Last Available: "2017-03"
 9394	delicious vodka barracuda	3	awesome	Last Available: "2017-03"
-9395	hand-crafted practically non-alcoholic pulsating Mysterious Island iced tea	1	EPIC	Last Available: "2017-03"
-9396	artisanal practically non-alcoholic drive-by shooting	1	EPIC	Last Available: "2017-03"
-9397	bad enchanted mirror gunner's daughter	3	decent	Effect: "Expert Vacationer", Effect Duration: 50, Last Available: "2017-03"
+9395	practically non-alcoholic hand-crafted pulsating Mysterious Island iced tea	1	EPIC	Last Available: "2017-03"
+9396	practically non-alcoholic artisanal drive-by shooting	1	EPIC	Last Available: "2017-03"
+9397	enchanted bad mirror gunner's daughter	3	decent	Effect: "Expert Vacationer", Effect Duration: 50, Last Available: "2017-03"
 9398	watered-down hand-crafted twirling dirt julep	2	EPIC	Last Available: "2017-03"
 9399	perfectly mixed Simepore slime	3	EPIC	Last Available: "2017-03"
 9400	drinkable Phil Collins	4	good	Last Available: "2017-03"
-9401	wobbly cyan unpowered Robortender	0		Free Pull, Last Available: "2017-03"
+9401	cyan wobbly unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	shaking Spacegate access badge	0		Free Pull, Last Available: "2017-04"
@@ -9303,7 +9303,7 @@
 9431	twirling mirror murderbot data core	0		Last Available: "2017-04"
 9432	oxidized alien medicine	0		Effect: "Goldentongue", Effect Duration: 55, Last Available: "2017-04"
 9433	moldy alien salad	4	crappy	Last Available: "2017-04"
-9434	bad pulsating squat alien booze	3	decent	Last Available: "2017-04"
+9434	bad squat pulsating alien booze	3	decent	Last Available: "2017-04"
 9435	fireproof curative alien mask of the cougar	0		Moxie: +20, Hot Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-04"
 9436	banded boxer's alien spear of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Damage Absorption: +100, Last Available: "2017-04"
 9437	flame-wreathed Jim Carey's razor-sharp alien blowgun	0		Weapon Damage Percent: +25, Monster Level: +25, Hot Spell Damage: +10, Last Available: "2017-04"
@@ -9383,7 +9383,7 @@
 9511	spinning Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	decent immense meteoreo	8	good	Last Available: "2017-08"
+9514	immense decent meteoreo	8	good	Last Available: "2017-08"
 9515	bad fancy practically non-alcoholic meadeorite	1	decent	Effect: "Souper Vengeful", Effect Duration: 30, Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	narrow Sherlock's quilted meteortarboard of the empath	0		Damage Absorption: +40, Familiar Weight: +5, Item Drop: +25, Last Available: "2017-08"
@@ -9395,7 +9395,7 @@
 9523	meteoroid	0		Last Available: "2017-08"
 9524	meteor shower cap	0		Familiar Weight: +5
 9525	Thwaitgold time fly statuette	0		
-9526	purple shaking perfectly fair coin	0		Last Available: "2017-11"
+9526	shaking purple perfectly fair coin	0		Last Available: "2017-11"
 9527	narrow Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	cyan corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	genie bottle	0		Last Available: "2017-09"
@@ -9409,7 +9409,7 @@
 9537	pocket wish	0		Last Available: "2023-09"
 9538	shaking dropped scrap of paper	0		
 9539	hunk of granite	0		
-9540	pulsating skewed shovelful of dirt	0		
+9540	skewed pulsating shovelful of dirt	0		
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
@@ -9418,7 +9418,7 @@
 9546	cyan studded Socratic mafia pinky ring	0		Experience (Mysticality): +1, Damage Absorption: +80, Single Equip
 9547	perfectly mixed flask of port	4	EPIC	
 9548	dog trainer's deadly contract enforcement stick	0		Weapon Damage: +5, Experience (familiar): +1
-9549	stale big Hide-rox&trade; cookie	5	decent	Last Available: "2017-10"
+9549	big stale Hide-rox&trade; cookie	5	decent	Last Available: "2017-10"
 9550	tolerable special spinning jug of booze	3	good	Effect: "Super-Mega-Ultra-Charged", Effect Duration: 50, Last Available: "2017-10"
 9551	anodized tumbling blue pair of candy glasses	0		Effect: "Using Protection", Effect Duration: 52, Last Available: "2017-10"
 9552	polarized ionized red temporary X tattoos	0		Effect: "All Glory To the Toad", Effect Duration: 11, Last Available: "2017-10"
@@ -9450,10 +9450,10 @@
 9578	transparent nog	1	good	Last Available: "2017-12"
 9579	bite-sized stale unfinished fruitcake	1	decent	Last Available: "2017-12"
 9580	super-electrified liquefied and cracker	0		Effect: "Held Closer", Effect Duration: 52, Last Available: "2017-12"
-9581	practically non-alcoholic mediocre squat neg grog	1	decent	Last Available: "2017-12"
+9581	mediocre practically non-alcoholic squat neg grog	1	decent	Last Available: "2017-12"
 9582	diet flavorless half double fruitcake	1	decent	Last Available: "2017-12"
-9583	decent super-sized hushed puppy	5	good	Last Available: "2017-12"
-9584	jumbo spoiled muffled muffuletta	5	crappy	Last Available: "2017-12"
+9583	super-sized decent hushed puppy	5	good	Last Available: "2017-12"
+9584	spoiled jumbo muffled muffuletta	5	crappy	Last Available: "2017-12"
 9585	adequate shushed potatoes	4	good	Last Available: "2017-12"
 9586	veiny plastic mime functionary	0		Maximum HP: +10, Last Available: "2017-12"
 9587	olive electrified plastic mime scientist	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2017-12"
@@ -9473,7 +9473,7 @@
 9601	silent C	0		Last Available: "2017-12"
 9602	silent D	0		Last Available: "2017-12"
 9603	gray silent E	0		Last Available: "2017-12"
-9604	shaking blurry silent F	0		Last Available: "2017-12"
+9604	blurry shaking silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
 9606	silent H	0		Last Available: "2017-12"
 9607	twirling silent I	0		Last Available: "2017-12"
@@ -9493,13 +9493,13 @@
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	pulsating silent Y	0		Last Available: "2017-12"
-9624	squat blurry silent Z	0		Last Available: "2017-12"
+9624	blurry squat silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	jittery anti-earplugs	0		Last Available: "2017-12"
 9627	blurry warehouse key	0		Last Available: "2017-12"
 9628	gray mime pocket probe	0		Last Available: "2017-12"
 9629	smooth wobbly stale cheer wine	3	awesome	Last Available: "2017-12"
-9630	bland bite-sized lime green stale Cheer-E-Os	1	decent	Last Available: "2017-12"
+9630	bite-sized bland lime green stale Cheer-E-Os	1	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	Sinatra's cheerful antler hat of the ox	0		Muscle: +20, Experience (Moxie): +5, Last Available: "2017-12"
 9633	ghostly lard-coated healthy cheerful Crimbo sweater	0		Maximum HP Percent: +20, Sleaze Spell Damage: +25, Last Available: "2017-12"
@@ -9507,7 +9507,7 @@
 9635	spinning The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	mirror The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
-9638	skewed olive The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
+9638	olive skewed The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9640	upside-down The Journal of Mime Science Vol. 3 (used)	0		Skill: "Quiet Judgement", Last Available: "2017-12"
 9641	blinking The Journal of Mime Science Vol. 4	0		Skill: "Silent Treatment", Last Available: "2017-12"
@@ -9547,7 +9547,7 @@
 9675	studded fortified mime army infiltration glove	0		Damage Absorption: 140, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
 9677	mime army challenge coin	0		Last Available: "2017-12"
-9678	blinking ghostly cheer extractor	0		Last Available: "2017-12"
+9678	ghostly blinking cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	stale extra-toasted half sandwich	3	decent	Last Available: "2018-12"
@@ -9567,12 +9567,12 @@
 9695	pulsating fireproof nippy Jim Carey's silent nightlight of the pedagogue	0		Experience: +3, Monster Level: +25, Cold Damage: +10, Hot Resistance: +3
 9696	nitrogenated Vulcanized bouncing sweetened reindeer fat	0		Effect: "Infernal Thirst", Effect Duration: 40
 9697	dry frozen Good 'n' Quiet	0		Effect: "Lemony Goodness", Effect Duration: 40
-9698	improved modified mirror pulsating olive hot button candy	0		Effect: "Slimy Hands", Effect Duration: 42
+9698	improved modified olive mirror pulsating hot button candy	0		Effect: "Slimy Hands", Effect Duration: 42
 9699	greasy crafty makeshift garbage shirt of the wise owl	0		Mysticality: +20, Maximum MP: +10, Sleaze Spell Damage: +10, Last Available: "2018-01"
 9700	frosty dog trainer's novelty monorail ticket	0		Experience (familiar): +1, Cold Spell Damage: +10
 9701	modified bouncing pills	1		Effect: "Warm Belly", Effect Duration: 25
 9702	modified furry pill	1		Effect: "Sourpuss", Effect Duration: 30
-9703	diluted huge pulsating beefy pill	1		
+9703	diluted pulsating huge beefy pill	1		
 9704	twisted mirror excitement pill	1		
 9705	compressed shaking vitamin G pill	1		
 9706	diluted lucky-ish pill	1		
@@ -9593,7 +9593,7 @@
 9725	frosty psychic's pslacks of Gandalf	0		Spell Critical Percent: +20, Cold Spell Damage: +10, Last Available: "2018-02"
 9726	twirling electrified stiffened psychic's amulet	0		Damage Reduction: 1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-02"
 9727	normal blue heart-shaped candy whetstone	3	good	Last Available: "2018-02"
-9728	decent tiny Swedish massage fish	1	good	Last Available: "2018-02"
+9728	tiny decent Swedish massage fish	1	good	Last Available: "2018-02"
 9729	watered-down delicious twirling Third Base	2	awesome	Last Available: "2018-02"
 9730	aged fuchsia Bustle Hustler	4	awesome	Last Available: "2018-02"
 9731	nitrogenated bouncing Fabiotion	0		Effect: "20-20 Second Sight", Effect Duration: 20, Last Available: "2018-02"
@@ -9609,7 +9609,7 @@
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	maroon Mysterious Black Box	0		Last Available: "2018-02"
 9743	cold-filtered blinking rainbow jellybean	0		Effect: "Human-Elemental Hybrid", Effect Duration: 54
-9744	Vulcanized gray jittery mystery lollipop	0		Effect: "Vital", Effect Duration: 44
+9744	Vulcanized jittery gray mystery lollipop	0		Effect: "Vital", Effect Duration: 44
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	nitrogenated cold-filtered rhinestone	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 32
 9747	blinking 1,960 pok&eacute;dollar bill	0		
@@ -9654,7 +9654,7 @@
 9786	upside-down Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	spinning Ched	0		Last Available: "2018-03"
-9789	maroon ghostly Gazelleton	0		Last Available: "2018-03"
+9789	ghostly maroon Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	upside-down Bicycle	0		Last Available: "2018-03"
 9792	mirror Vamprey	0		Last Available: "2018-03"
@@ -9670,7 +9670,7 @@
 9802	Squib	0		Last Available: "2018-03"
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
-9805	pulsating blurry Shudder	0		Last Available: "2018-03"
+9805	blurry pulsating Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
@@ -9679,11 +9679,11 @@
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
-9814	upside-down cyan Egnaro berry	0		Last Available: "2018-03"
+9814	cyan upside-down Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	mirror Nadsat berry	0		Last Available: "2018-03"
 9817	ghostly Jamocha berry	0		Last Available: "2018-03"
-9818	lime green ghostly Tapioc berry	0		Last Available: "2018-03"
+9818	ghostly lime green Tapioc berry	0		Last Available: "2018-03"
 9819	blinking Snarf berry	0		Last Available: "2018-03"
 9820	jittery Keese berry	0		Last Available: "2018-03"
 9821	shaking luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
@@ -9695,7 +9695,7 @@
 9827	rocket	0		
 9828	dehydrated maroon magnificent oyster egg	1		Effect: "Newt Gets In Your Eyes", Effect Duration: 30
 9829	dehydrated green brilliant oyster egg	1		
-9830	powdered spinning pulsating glistening oyster egg	1		Effect: "Starry-Eyed", Effect Duration: 35
+9830	powdered pulsating spinning glistening oyster egg	1		Effect: "Starry-Eyed", Effect Duration: 35
 9831	modified tumbling red scintillating oyster egg	1		
 9832	altered pearlescent oyster egg	1		
 9833	dehydrated lustrous oyster egg	1		
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	teal map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless denastified haunch	3	decent	Last Available: "2018-04"
-9879	perfectly mixed jittery pulsating bad rum and good cola	3	EPIC	Last Available: "2018-04"
+9879	perfectly mixed pulsating jittery bad rum and good cola	3	EPIC	Last Available: "2018-04"
 9880	irradiated galvanized Potion of Heroism	0		Effect: "Become Superficially interested", Effect Duration: 64, Last Available: "2018-04"
 9881	skewed blinking nasty shellacked leggings of the Spider Queen	0		Damage Reduction: 7, Stench Damage: +5, Item Drop: +5, Last Available: "2018-04"
 9882	knitted Newton's Master Thief's utility belt of the businessman	0		Experience (Mysticality): +3, Cold Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2018-04"
@@ -9763,10 +9763,10 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	delicious high-proof special spinning two meat muck	10	awesome	Effect: "Texas Elegance", Effect Duration: 25
+9898	delicious special high-proof spinning two meat muck	10	awesome	Effect: "Texas Elegance", Effect Duration: 25
 9899	flavorless maroon chocolate Ogre Chieftain	3	decent	
 9900	spoiled huge chocolate &quot;Phoenix&quot;	6	crappy	
-9901	adequate cyan squat chocolate Spider Queen	4	good	
+9901	adequate squat cyan chocolate Spider Queen	4	good	
 9902	smooth tumbling hipster cocktail	4	awesome	
 9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
@@ -9813,7 +9813,7 @@
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	bouncing deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	weak delicious Middle of the Road&trade; brand whiskey	2	awesome	Last Available: "2018-09"
+9948	delicious weak Middle of the Road&trade; brand whiskey	2	awesome	Last Available: "2018-09"
 9949	lime green neverending wallet chain	0		Last Available: "2018-09"
 9950	MacGyver's dangerous pentagram bandana	0		Weapon Damage: +10, Maximum MP: +100, Last Available: "2018-09"
 9951	olive Temple Grandin's skull ring	0		Familiar Weight: +7, Single Equip, Last Available: "2018-09"
@@ -9831,24 +9831,24 @@
 9963	bouncing blurry very small dress	0		Last Available: "2018-09"
 9964	teal tumbling smelly thinker's noticeable pumps	0		Mysticality: +10, Stench Spell Damage: +10, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	mediocre practically non-alcoholic everfull glass	1		Last Available: "2018-09"
+9966	practically non-alcoholic mediocre everfull glass	1		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
 9968	jam band bootleg	0		Last Available: "2018-09"
 9969	lard-coated denim jacket of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +25, Last Available: "2018-09"
 9970	mansplainer's deadly ratty knitted cap	0		Weapon Damage: +5, Monster Level: +15, Last Available: "2018-09"
 9972	MacGyver's slick intimidating chainsaw	0		Moxie: +10, Maximum MP: +100, Lasts Until Rollover, Last Available: "2018-09"
 9973	acceptable jittery party beer bomb	3	good	Last Available: "2018-09"
-9974	small bland huge maroon sweet party mix	2	decent	Last Available: "2018-09"
+9974	small bland maroon huge sweet party mix	2	decent	Last Available: "2018-09"
 9975	denatured party balloon	1		Last Available: "2018-09"
 9976	frightening wholesome party pants	0		Maximum HP Percent: +10, Spooky Damage: +5, Last Available: "2018-09"
 9977	skewed maroon lion tamer's wholesome steel-toed party whip	0		Damage Reduction: 9, Maximum HP Percent: +10, Experience (familiar): +2, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	lousy TRIO cup of beer	3	decent	Last Available: "2018-09"
-9980	decent fancy party platter for one	4	good	Effect: "Yuletide Sappiness", Effect Duration: 20, Last Available: "2018-09"
-9981	dried pulsating blue Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9980	fancy decent party platter for one	4	good	Effect: "Yuletide Sappiness", Effect Duration: 20, Last Available: "2018-09"
+9981	dried blue pulsating Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	ghostly party pup	0		Last Available: "2018-09"
 9983	ghostly foul-smelling party crasher of bravery	0		Stench Damage: +10, Spooky Resistance: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	tumbling party mouse hat	0		Familiar Weight: +5
 9987	ghostly latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
@@ -9877,15 +9877,15 @@
 10011	toothsome	3	awesome	Last Available: "2018-11"
 10012	bad spinning bottle of vodka	4	decent	Last Available: "2018-11"
 10013	moldy pizza	3	crappy	Last Available: "2018-11"
-10014	perfectly mixed watered-down martini	2	EPIC	Last Available: "2018-11"
+10014	watered-down perfectly mixed martini	2	EPIC	Last Available: "2018-11"
 10015	stale cherry pie	3	decent	Last Available: "2018-11"
 10016	bad huge jittery eggnog	4	decent	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	special moldy blinking Hell ramen	3	crappy	Effect: "Shawarma Warm War", Effect Duration: 50, Last Available: "2018-11"
+10018	moldy special blinking Hell ramen	3	crappy	Effect: "Shawarma Warm War", Effect Duration: 50, Last Available: "2018-11"
 10019	aged gimlet	3	awesome	Last Available: "2018-11"
 10020	smooth twice-haunted screwdriver	3	awesome	Last Available: "2018-11"
 10021	moldy candy cane	4	crappy	Last Available: "2018-12"
-10022	fortified lousy runny fermented egg	5	decent	Last Available: "2018-12"
+10022	lousy fortified runny fermented egg	5	decent	Last Available: "2018-12"
 10023	diet stale oldcake	1	decent	Last Available: "2018-12"
 10024	rotten traditional Crimbo cookie	3	crappy	Last Available: "2023-06"
 10025	boxer's plastic wild beaver	0		Muscle Percent: +10, Last Available: "2018-12"
@@ -9909,11 +9909,11 @@
 10043	hand-crafted beavermouth	4	EPIC	Last Available: "2018-12"
 10044	bad fortified beaver punch (papaya)	5	decent	Last Available: "2018-12"
 10045	acceptable blurry beaver punch (peach)	4	good	Last Available: "2018-12"
-10046	triple-distilled bad beaver punch (cherry)	6	decent	Last Available: "2018-12"
+10046	bad triple-distilled beaver punch (cherry)	6	decent	Last Available: "2018-12"
 10047	family-friendly scandalous Canadian lantern	0		Sleaze Damage: +5, Sleaze Resistance: +1, Last Available: "2018-12"
 10048	savvy muskox-skin cap	0		Mysticality Percent: +20, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	low-calorie enchanted tasty glass of raw eggs	1	awesome	Effect: "A Taste of Rainbow", Effect Duration: 30, Last Available: "2018-12"
+10050	low-calorie tasty enchanted glass of raw eggs	1	awesome	Effect: "A Taste of Rainbow", Effect Duration: 30, Last Available: "2018-12"
 10051	perfectly mixed punch-drunk punch	3	EPIC	Last Available: "2018-12"
 10052	diluted upside-down teal body spradium	1		Last Available: "2018-12"
 10053	bauxite beret of the empath	0		Familiar Weight: +5, Last Available: "2018-12"
@@ -9934,7 +9934,7 @@
 10068	lousy triple-distilled olive hot watered rum	8	decent	Last Available: "2018-12"
 10069	hand-crafted ghostly bottle of Crimbognac	3	EPIC	Last Available: "2018-12"
 10070	big rotten Crimboysters Rockefeller	5	crappy	Last Available: "2018-12"
-10071	vaporized red skewed blurry Crimbeau de toilette	1		Last Available: "2018-12"
+10071	vaporized skewed blurry red Crimbeau de toilette	1		Last Available: "2018-12"
 10072	shaking Crimbo candle	0		Last Available: "2018-12"
 10073	upside-down Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9943,7 +9943,7 @@
 10077	pulsating Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	bouncing frosty ruddy grievous Crimbolex watch	0		Weapon Damage Percent: +50, Maximum HP Percent: +40, Cold Spell Damage: +10, Single Equip, Last Available: "2018-12"
-10080	wobbly upside-down Crimbo tattoo kit	0		Last Available: "2018-12"
+10080	upside-down wobbly Crimbo tattoo kit	0		Last Available: "2018-12"
 10081	up-at-dawn family-friendly hand-knitted Crimbo socks of the glutton	0		Sleaze Resistance: +1, Food Drop: +100, Adventures: +5
 10082	lightning-fast curative chalk chlamys	0		Initiative: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
 10083	squat steel-toed chalk chain of the blizzard	0		Damage Reduction: 9, Cold Spell Damage: +25, Single Equip, Last Available: "2019-12"
@@ -9951,7 +9951,7 @@
 10085	blinking blue censurious chalk chinos of the sweet-tooth	0		Sleaze Resistance: +3, Candy Drop: +100, Last Available: "2019-12"
 10086	Tesla hale chalk chapeau	0		Maximum HP: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-12"
 10087	razor-sharp chalk choker of the bloodbag	0		Weapon Damage Percent: +25, Maximum HP: +100, Single Equip, Last Available: "2019-12"
-10088	dehydrated narrow blurry chalk chunks	1		Last Available: "2019-12"
+10088	dehydrated blurry narrow chalk chunks	1		Last Available: "2019-12"
 10089	irradiated nitrogenated red candy chalk	0		Effect: "Floundering", Effect Duration: 65
 10090	vibrating grievous marble maebari	0		Weapon Damage Percent: +50, Maximum MP Percent: +10, Last Available: "2019-12"
 10091	blue dog trainer's steel-toed marble mantle	0		Damage Reduction: 9, Experience (familiar): +1, Last Available: "2019-12"
@@ -9991,7 +9991,7 @@
 10125	wool glass spectacles of the pedagogue	0		Experience: +3, Cold Resistance: +1, Single Equip, Last Available: "2021-12"
 10126	huge nippy savvy glass shiv	0		Mysticality Percent: +20, Cold Damage: +10, Last Available: "2021-12"
 10127	narrow chilly glass serape of Leguizamo	0		Monster Level: +20, Cold Damage: +5, Last Available: "2021-12"
-10128	distilled maroon spinning glass shards	1		Last Available: "2021-12"
+10128	distilled spinning maroon glass shards	1		Last Available: "2021-12"
 10129	wet anodized squat pulsating hard candy	0		Effect: "Bilious Briskness", Effect Duration: 44
 10130	huge Van der Graaf hale loofah lumberjack's hat	0		Maximum HP: +20, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
 10131	huge mansplainer's rosy-cheeked loofah lei	0		Maximum HP Percent: +30, Monster Level: +15, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
@@ -10007,7 +10007,7 @@
 10141	bouncing Oprah's smooth flagstone fez	0		Moxie: +15, Maximum MP Percent: +50, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	ghostly inspector's dance instructor's flagstone fleece	0		Experience Percent (Moxie): +10, Item Drop: +15, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	stiffened Samson's flagstone fringe	0		Experience (Muscle): +5, Damage Reduction: 1, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	altered blinking blue flagstone flagments	1		Effect: "Mortarfied", Effect Duration: 15, Last Available: "2022-12"
+10144	altered blue blinking flagstone flagments	1		Effect: "Mortarfied", Effect Duration: 15, Last Available: "2022-12"
 10145	flattened ionized Flag by the Foot&trade;	0		Effect: "La Bamba", Effect Duration: 16
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,10 +10018,10 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	wobbly really nice net	0		Last Available: "2019-12"
 10154	dangerous elf army poncho	0		Weapon Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
-10155	moldy low-calorie elf army field rations	1	crappy	Last Available: "2019-12"
+10155	low-calorie moldy elf army field rations	1	crappy	Last Available: "2019-12"
 10156	lime green gingernade	0		Last Available: "2019-12"
 10157	discarded bowtie of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20, Lasts Until Rollover, Last Available: "2019-12"
-10158	boozy bad martiny	5	decent	Last Available: "2019-12"
+10158	bad boozy martiny	5	decent	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	warmed licorice snake	0		Effect: "The Q Is Talking To You", Effect Duration: 42
 10161	liquefied cold-filtered blurry virgin jello shot	0		Effect: "Almost Cool", Effect Duration: 14
@@ -10032,14 +10032,14 @@
 10166	huge blinking curative rock-hard Lil' Doctor&trade; bag	0		Damage Reduction: 5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	stale bloodstick	3	decent	
-10170	perfectly mixed teal huge bottle of Sanguiovese	4	EPIC	
+10170	perfectly mixed huge teal bottle of Sanguiovese	4	EPIC	
 10171	tiny toothsome actual blood sausage	1	awesome	
-10172	artisanal weak shaking blinking mulled blood	2	super EPIC	
-10173	decent bite-sized olive blood snowcone	1	good	
+10172	weak artisanal shaking blinking mulled blood	2	super EPIC	
+10173	bite-sized decent olive blood snowcone	1	good	
 10174	tolerable Red Russian	3	good	
 10175	rotten immense blood roll-up	10	crappy	
-10176	acceptable practically non-alcoholic bottle of blood	1	good	
-10177	enchanted flavorless blood-soaked sponge cake	4	decent	Effect: "Celestial Vision", Effect Duration: 5
+10176	practically non-alcoholic acceptable bottle of blood	1	good	
+10177	flavorless enchanted blood-soaked sponge cake	4	decent	Effect: "Celestial Vision", Effect Duration: 5
 10178	tolerable vampagne	4	good	
 10179	massive decent plain snowcone	10	good	
 10180	Booke of Vampyric Knowledge	0		
@@ -10052,7 +10052,7 @@
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
 10188	PirateRealm guest pass	0		Last Available: "2019-04"
 10189	flame-retardant friendly Herculean PirateRealm eyepatch	0		Experience (Muscle): +1, Familiar Weight: +3, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2019-04"
-10190	spinning cyan bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
+10190	cyan spinning bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10192	cyan skewed skull key	0		Lasts Until Rollover, Last Available: "2019-04"
 10193	curious anemometer	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10061,30 +10061,30 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	miniature tasty huge crabsicle	2	awesome	Last Available: "2019-04"
+10199	tasty miniature huge crabsicle	2	awesome	Last Available: "2019-04"
 10200	twirling melty plastic grenade	0		Last Available: "2019-04"
-10201	mediocre watered-down bottle of dark rhum	2	decent	Last Available: "2019-04"
+10201	watered-down mediocre bottle of dark rhum	2	decent	Last Available: "2019-04"
 10202	weak lousy bottle of extra-dark rhum	2	decent	Last Available: "2019-04"
-10203	triple-distilled tolerable bottle of super-extra-dark rhum	8	good	Last Available: "2019-04"
+10203	tolerable triple-distilled bottle of super-extra-dark rhum	8	good	Last Available: "2019-04"
 10204	flattened blue pirate shaving cream	0		Effect: "Oleaginous Soles", Effect Duration: 29, Last Available: "2019-04"
 10205	executive conquistador's breastplate of the bloodbag	0		Maximum HP: +100, Meat Drop: +40, Last Available: "2019-04"
 10206	foul-smelling nasty pirate pantaloons	0		Stench Damage: 15, Last Available: "2019-04"
 10207	red [glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
-10209	mirror shaking teal windicle	0		Last Available: "2019-04"
+10209	shaking mirror teal windicle	0		Last Available: "2019-04"
 10210	wholesome pirate radio ring of extreme caution	0		Maximum HP Percent: +10, Monster Level: -25, Single Equip, Last Available: "2019-04"
 10211	huge Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	moldy pineapple slab	4	crappy	Last Available: "2019-04"
-10213	decent small purple hibiscus petal	2	good	Last Available: "2019-04"
-10214	ionized electrified green upside-down huge mint leaf	0		Effect: "Human-Constellation Hybrid", Effect Duration: 58, Last Available: "2019-04"
+10213	small decent purple hibiscus petal	2	good	Last Available: "2019-04"
+10214	ionized electrified upside-down green huge mint leaf	0		Effect: "Human-Constellation Hybrid", Effect Duration: 58, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	diluted ghostly ice molecule	1		Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	skewed Red Roger's left hand	0		Last Available: "2019-04"
 10220	teal Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
-10221	teal bouncing Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
-10222	shaking blue Red Roger's skull	0		Last Available: "2019-04"
+10221	bouncing teal Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
+10222	blue shaking Red Roger's skull	0		Last Available: "2019-04"
 10223	boiled pewter shavings	1		Last Available: "2019-04"
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
@@ -10098,9 +10098,9 @@
 10233	aged Island Thunderstorm	3	awesome	Last Available: "2019-04"
 10234	weak aged enchanted squat Island Hurricane	2	awesome	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2019-04"
 10235	delicious ghostly Skull Punch	3	awesome	Last Available: "2019-04"
-10236	weak mediocre Electric Punch	2	decent	Last Available: "2019-04"
+10236	mediocre weak Electric Punch	2	decent	Last Available: "2019-04"
 10237	hand-crafted Smuggler's Punch	3	super EPIC	Last Available: "2019-04"
-10238	bad watered-down pulsating Scorpion Bowl	2	decent	Last Available: "2019-04"
+10238	watered-down bad pulsating Scorpion Bowl	2	decent	Last Available: "2019-04"
 10239	acceptable strong Turtle Bowl	5	good	Last Available: "2019-04"
 10240	lousy Cobra Bowl	3	decent	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
@@ -10117,7 +10117,7 @@
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
 10254	teal fireproof stanky flame-wreathed chaotic crafty vibrating medical-grade Socratic hewn moon-rune spoon of the scaredy-cat of the sewer of temperance	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Maximum MP: +10, Spell Critical Percent: +10, Monster Level: -15, Hot Spell Damage: +10, Stench Damage: +25, Stench Spell Damage: +25, Hot Resistance: +3, Sleaze Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
-10255	skewed red cartoon harpoon	0		Last Available: "2019-06"
+10255	red skewed cartoon harpoon	0		Last Available: "2019-06"
 10256	tumbling rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	narrow Beach Comb Box	0		Free Pull, Last Available: "2019-07"
 10258	auspicious thinker's Beach Comb of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
@@ -10169,7 +10169,7 @@
 10304	normal gray campfire baked potato	3	good	Last Available: "2019-08"
 10305	toothsome thick campfire s'more	5	awesome	Last Available: "2019-08"
 10306	bland campfire beans	4	decent	Last Available: "2019-08"
-10307	special half-sized moldy campfire stew	2	crappy	Effect: "Pronounced Potency", Effect Duration: 40, Last Available: "2019-08"
+10307	special moldy half-sized campfire stew	2	crappy	Effect: "Pronounced Potency", Effect Duration: 40, Last Available: "2019-08"
 10308	cyan campfire coffee	1	decent	Last Available: "2019-08"
 10309	corrupted skewed leftover chocolate bar	0		Effect: "The Wisdom... of the Future", Effect Duration: 15
 10310	twirling rare Meat isotope	0		
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bu&ntilde;uelos Jaliscos	4	decent	Last Available: "2019-12"
 10338	tasty tiny flan del mar	1	awesome	Last Available: "2019-12"
-10339	special toothsome jittery skewed Baja sopapilla	4	awesome	Effect: "Fishy", Effect Duration: 45, Last Available: "2019-12"
+10339	special toothsome skewed jittery Baja sopapilla	4	awesome	Effect: "Fishy", Effect Duration: 45, Last Available: "2019-12"
 10340	gravedigger's plastic Mer-kin baker	0		Spooky Damage: +10, Last Available: "2019-12"
 10341	mirror reassuring plastic sea elf	0		Spooky Resistance: +1, Last Available: "2019-12"
 10342	shaking tumbling auspicious plastic yuleviathan	0		Item Drop: +10, Last Available: "2019-12"
@@ -10205,18 +10205,18 @@
 10346	stale bite-sized mana-coated yams	1	decent	Last Available: "2019-11"
 10347	moldy spinning mana-basted tofurkey leg	3	crappy	Last Available: "2019-11"
 10348	massive moldy mana-fortified cranberry sauce	10	crappy	Last Available: "2019-11"
-10349	snack-sized yummy mana-stuffed herbal stuffing	2	awesome	Last Available: "2019-11"
+10349	yummy snack-sized mana-stuffed herbal stuffing	2	awesome	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	enhanced modified jittery pulsating patch of extra-warm fur	0		Effect: "Happy Salamander", Effect Duration: 64, Last Available: "2019-12"
 10352	powdered shaking industrial lubricant	1		Effect: "Astral Shell", Effect Duration: 10, Last Available: "2019-12"
 10353	liquefied wet unsweetened unfinished pleasure	0		Effect: "Cold Hands", Effect Duration: 62, Last Available: "2019-12"
 10354	powdered vial of humanoid growth hormone	1		Last Available: "2019-12"
-10355	boiled olive huge a bug's lymph	1		Last Available: "2019-12"
+10355	boiled huge olive a bug's lymph	1		Last Available: "2019-12"
 10356	alkaline double-boiled yellow organic potpourri	0		Effect: "Elemental Flavor", Effect Duration: 52, Last Available: "2019-12"
-10357	lousy distilled enchanted boot flask	5	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2019-12"
+10357	enchanted lousy distilled boot flask	5	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2019-12"
 10358	modified gray spinning infernal snowball	0		Effect: "You Drank Fish Wine", Effect Duration: 45, Last Available: "2019-12"
 10359	olive madness	0		Last Available: "2019-12"
-10360	distilled olive shaking fish sauce	1		Last Available: "2019-12"
+10360	distilled shaking olive fish sauce	1		Last Available: "2019-12"
 10361	rotten guffin	4	crappy	Last Available: "2019-12"
 10362	vaporized Shantix&trade;	1		Effect: "You Know Who to Call", Effect Duration: 15, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
@@ -10229,7 +10229,7 @@
 10370	micronova	0		Last Available: "2019-12"
 10371	pickled squat beggin' cologne	1		Effect: "Ack!  Barred!", Effect Duration: 25, Last Available: "2019-12"
 10372	shaking sinister oxygenated eggnog helmet of terror	0		Spell Damage: +10, Spooky Spell Damage: +10, Adventure Underwater, Last Available: "2019-12"
-10373	lime green mirror hand-knitted diving booties	0		Last Available: "2019-12"
+10373	mirror lime green hand-knitted diving booties	0		Last Available: "2019-12"
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
 10375	extra-magnetized blue concentrated fish broth	0		Effect: "Fudge Headache", Effect Duration: 65, Last Available: "2019-12"
 10376	alkaline vacuum-sealed liquid SONAR	0		Effect: "Unusual Fashion Sense", Effect Duration: 61, Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	normal salt plum	3	good	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	rotten thick and bean	5	crappy	Last Available: "2019-12"
+10417	thick rotten and bean	5	crappy	Last Available: "2019-12"
 10418	Van der Graaf beefy kelp-holly gun of courage	0		Muscle: +10, Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
 10419	squat rock-hard Yuleviathan necklace of the early riser	0		Damage Reduction: 5, Adventures: +7, Single Equip, Last Available: "2019-12"
 10420	hardened peppermint spine of the sewer	0		Damage Reduction: 3, Stench Damage: +25, Last Available: "2019-12"
@@ -10302,12 +10302,12 @@
 10445	decent wobbly drippy nugget	4	drippy	
 10446	mediocre glass of drippy wine	3	drippy	
 10447	spoiled drippy caviar	3	drippy	
-10448	diet decent drippy plum(?)	1	drippy	
+10448	decent diet drippy plum(?)	1	drippy	
 10449	experienced drippy stake	0		Experience: +2, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	narrow drippy khakis	0		
 10452	drippy shield	0		
-10453	skewed shaking The Fingernail of the Thing in the Basement	0		
+10453	shaking skewed The Fingernail of the Thing in the Basement	0		
 10454	coin	0		
 10455	narrow mushroom	0		
 10456	deluxe mushroom	0		
@@ -10379,7 +10379,7 @@
 10522	drippy bromide	0		
 10523	twirling drippy flux	0		
 10524	drippy stein	0		
-10525	fortified perfectly mixed drippy pilsner	5	drippy	
+10525	perfectly mixed fortified drippy pilsner	5	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	blurry drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10396,7 +10396,7 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	artisanal Ghiaccio Colada	4	EPIC	Last Available: "2020-05"
 10542	perfectly mixed blurry Sourfinger	3	EPIC	Last Available: "2020-05"
-10543	special extra-dry hand-crafted Nog-on-the-Cob	5	EPIC	Effect: "You Can Taste the Darkness", Effect Duration: 5, Last Available: "2020-05"
+10543	extra-dry special hand-crafted Nog-on-the-Cob	5	EPIC	Effect: "You Can Taste the Darkness", Effect Duration: 5, Last Available: "2020-05"
 10544	practically non-alcoholic bad Steamboat	1	decent	Last Available: "2020-05"
 10545	tolerable special Buttery Boy	3	good	Effect: "Extra Terrestrial", Effect Duration: 50, Last Available: "2020-05"
 10546	mirror Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10423,7 +10423,7 @@
 10567	Van der Graaf smartaleck's actual skeleton key	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-08"
 10568	huge lion tamer's brawny deep-fried key of Gandalf	0		Muscle Percent: +20, Spell Critical Percent: +20, Experience (familiar): +2, Last Available: "2020-08"
 10569	knitted dance instructor's discarded bike lock key	0		Experience Percent (Moxie): +10, Cold Resistance: +3, Last Available: "2020-08"
-10570	mirror huge Thwaitgold keyhole spider statuette	0		
+10570	huge mirror Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	quadruple-ionized altered quadruple-polymerized spinning marshroom	0		Effect: "The Power of Positive Thinking", Effect Duration: 41
 10573	bag of Iunion stones	0		Free Pull
@@ -10436,7 +10436,7 @@
 10580	dromedary drinking helmet	0		
 10581	wobbly ghostly packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	mirror SpinMaster&trade; lathe	0		Last Available: "2020-08"
-10583	olive mirror tumbling flimsy hardwood scraps	0		Last Available: "2020-08"
+10583	mirror olive tumbling flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	double-paned smartaleck's birch battery	0		Moxie Percent: +30, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2020-08"
 10585	squat mansplainer's supercharged ebony epee of terror	0		Maximum MP Percent: +30, Monster Level: +15, Spooky Spell Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
 10586	rosewater-soaked Oprah's grievous weeping willow wand	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Stench Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
@@ -10447,7 +10447,7 @@
 10591	sweaty balsam	0		Last Available: "2020-08"
 10592	blurry manspreader's balsam barrel of the dark arts of courage	0		Spell Damage Percent: +100, Monster Level: +10, Spooky Resistance: +3, Last Available: "2020-08"
 10593	redwood	0		Last Available: "2020-08"
-10594	extra-altered nitrogenated ionized squat pulsating redwood rain stick	0		Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2020-08"
+10594	extra-altered nitrogenated ionized pulsating squat redwood rain stick	0		Effect: "Prince of Seaside Town", Effect Duration: 45, Last Available: "2020-08"
 10595	blurry purpleheart logs	0		Last Available: "2020-08"
 10596	knitted baleful Rosewater's purpleheart &quot;pants&quot;	0		Mysticality Percent: +30, Spell Damage: +25, Cold Resistance: +3, Last Available: "2020-08"
 10597	red mirror wormwood stick	0		Last Available: "2020-08"
@@ -10462,9 +10462,9 @@
 10606	diffused blinking Yeg's Motel toothbrush	0		Effect: "Antibiotic Saucesphere", Effect Duration: 12, Last Available: "2020-09"
 10607	adjusted bouncing Yeg's Motel hand soap	0		Effect: "Quaaaaaaa", Effect Duration: 20, Last Available: "2020-09"
 10608	blue Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	delicious big Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
+10609	big delicious Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	non-oxidized tarnished huge cyan Yeg's Motel mouthwash	0		Effect: "Stimulated Brain", Effect Duration: 61, Last Available: "2020-09"
+10611	non-oxidized tarnished cyan huge Yeg's Motel mouthwash	0		Effect: "Stimulated Brain", Effect Duration: 61, Last Available: "2020-09"
 10612	lightning-fast hardy Yeg's Motel shower cap	0		Maximum HP: +50, Initiative: +40, Lasts Until Rollover, Last Available: "2020-09"
 10613	sage Yeg's Motel bathrobe of vim and vigor	0		Mysticality Percent: +10, Maximum HP Percent: +50, Lasts Until Rollover, Last Available: "2020-09"
 10614	upside-down maroon resourceful Yeg's Motel slippers	0		Maximum MP: +50, Item Drop: +5, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
@@ -10542,7 +10542,7 @@
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	jittery government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
-10689	ghostly jittery Crimbo Carol tattoo kit	0		Last Available: "2020-12"
+10689	jittery ghostly Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	huge skewed Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	shaking food drive button	0		Single Equip, Last Available: "2020-12"
 10692	huge booze drive button	0		Single Equip, Last Available: "2020-12"
@@ -10569,25 +10569,25 @@
 10713	gray The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	flavorless blurry and pepper (stale)	4	decent	Last Available: "2020-12"
-10716	acceptable practically non-alcoholic cranberry margarita (brackish)	1	good	Last Available: "2020-12"
+10716	practically non-alcoholic acceptable cranberry margarita (brackish)	1	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	watered-down acceptable barrel-aged eggnog	2	good	Last Available: "2020-12"
-10721	miniature bland shaking hand-crafted candy cane	2	decent	Last Available: "2020-12"
+10720	acceptable watered-down barrel-aged eggnog	2	good	Last Available: "2020-12"
+10721	bland miniature shaking hand-crafted candy cane	2	decent	Last Available: "2020-12"
 10722	miniature moldy drive-thru burger	2	crappy	Last Available: "2020-12"
-10723	mediocre shaking squat Boulevardier cocktail	4	decent	Last Available: "2020-12"
+10723	mediocre squat shaking Boulevardier cocktail	4	decent	Last Available: "2020-12"
 10724	deionized Hotwire&trade; brand candy rope	0		Effect: "Christmessy", Effect Duration: 28, Last Available: "2020-12"
 10725	normal bowl full of jelly	3	good	Last Available: "2020-12"
-10726	fancy artisanal Eye and a Twist	3	EPIC	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2020-12"
+10726	artisanal fancy Eye and a Twist	3	EPIC	Effect: "Guts Feeling", Effect Duration: 30, Last Available: "2020-12"
 10727	colloidal non-concentrated Chubby and Plump bar	0		Effect: "Bored Stiff", Effect Duration: 58, Last Available: "2020-12"
 10728	mirror digibritches	0		Last Available: "2025-12"
 10729	twirling packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	purple crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	twirling fresh coat of paint	0		Last Available: "2021-12"
-10733	blurry emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	pulsating twirling spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	blurry emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	pulsating twirling spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	bouncing robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	wobbly power seed	0		Free Pull, Last Available: "2021-03"
@@ -10613,7 +10613,7 @@
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
 10759	shaking weightlifter's familiar scrapbook of the early riser	0		Muscle: +15, Adventures: +7, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
-10760	twirling squat packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
+10760	squat twirling packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	mirror wobbly dog trainer's steel-toed studded fedora-mounted fountain	0		Damage Absorption: +80, Damage Reduction: 9, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2021-07"
 10763	stiffened wizardly sombrero-mounted sparkler of the storm	0		Mysticality: +25, Damage Reduction: 1, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2021-07"
@@ -10690,14 +10690,14 @@
 10834	polarized boiled anti-goosebump cream	0		Effect: "One Very Clear Eye", Effect Duration: 14, Last Available: "2021-12"
 10835	oxidized wobbly anti-odor cream	0		Effect: "Big Punkin'", Effect Duration: 54, Last Available: "2021-12"
 10836	super-dry anti-creep cream	0		Effect: "Crimbo Flavor", Effect Duration: 21, Last Available: "2021-12"
-10837	colloidal activated olive mirror anti-pain cream	0		Effect: "Lemony Goodness", Effect Duration: 42, Last Available: "2021-12"
-10838	acceptable fortified Doc's Special Reserve Wine	5	good	Last Available: "2021-12"
+10837	colloidal activated mirror olive anti-pain cream	0		Effect: "Lemony Goodness", Effect Duration: 42, Last Available: "2021-12"
+10838	fortified acceptable Doc's Special Reserve Wine	5	good	Last Available: "2021-12"
 10839	tasty massive bread pie	8	awesome	Last Available: "2021-12"
 10840	acceptable clear Russian	4	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	tumbling Crimbo ball	0		Last Available: "2021-12"
 10843	squat Crimbo ball	0		Last Available: "2021-12"
-10844	cyan shaking gooified animal matter	0		Last Available: "2021-12"
+10844	shaking cyan gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10715,7 +10715,7 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	bouncing Van der Graaf depleted Crimbonium football helmet	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	moldy half-sized narrow &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
+10862	half-sized moldy narrow &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
 10863	family-friendly self-repairing earmuffs	0		Sleaze Resistance: +1, Last Available: "2021-12"
 10864	mirror carnivorous potted plant of extreme caution	0		Monster Level: -25, Last Available: "2021-12"
 10865	yellow universal biscuit	0		Last Available: "2021-12"
@@ -10730,13 +10730,13 @@
 10874	blinking Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	stale meatball	4	decent	Last Available: "2021-12"
-10877	shaking narrow cloned monster	0		Last Available: "2021-12"
+10877	narrow shaking cloned monster	0		Last Available: "2021-12"
 10878	purple meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	pickled fried air	1		Effect: "Gemini Rising", Effect Duration: 25, Last Available: "2021-12"
 10881	blue 11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	pickled upside-down huge astral energy drink	1		
+10883	pickled huge upside-down astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	spinning fuchsia Temple Grandin's Lo Pan's thinker's magnifying glass	0		Mysticality: +10, Spell Critical Percent: +30, Familiar Weight: +7, Last Available: "2022-12"
 10886	delicious void lager	4	awesome	Last Available: "2022-12"
@@ -10750,7 +10750,7 @@
 10894	Thwaitgold protozoa statuette	0		
 10895	grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	grey down vest	0		Experience (familiar): +2
-10897	shaking blurry trojan horseshoe	0		Last Available: "2025-12"
+10897	blurry shaking trojan horseshoe	0		Last Available: "2025-12"
 10898	shaking undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
 10899	miser's smelly chaotic unbreakable umbrella (broken) of the sweet-tooth	0		Spell Critical Percent: +10, Stench Spell Damage: +10, Meat Drop: +10, Candy Drop: +100
 10900	MayDay&trade; contract	0		Free Pull, Last Available: "2022-05"
@@ -10765,18 +10765,18 @@
 10909	gray squat space blanket	0		Last Available: "2022-05"
 10910	double-deionized upside-down single-use dust mask	0		Effect: "Milk Studly", Effect Duration: 42, Last Available: "2022-05"
 10911	activated adjusted shaking gaffer's tape	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 31, Last Available: "2022-05"
-10912	small adequate 20-lb can of rice and beans	2	good	Last Available: "2022-05"
+10912	adequate small 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	squat bar of freeze-dried water	1	decent	Last Available: "2022-05"
 10914	decent snack-sized expired MRE	2	good	Last Available: "2022-05"
 10915	spoiled miniature twirling cool mint precipice bar	2	crappy	Last Available: "2022-05"
-10916	spoiled tiny carrot cake precipice bar	1	crappy	Last Available: "2022-05"
+10916	tiny spoiled carrot cake precipice bar	1	crappy	Last Available: "2022-05"
 10917	tumbling The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	blinking packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	narrow Sherlock's cool June cleaver of Gandalf	0		Moxie: +5, Spell Critical Percent: +20, Item Drop: +25, Attacks Can't Miss, Last Available: "2022-06"
 10921	lousy Dad's brandy	3	decent	Last Available: "2022-06"
 10922	fireproof Jeselnik's teacher's pen	0		Sleaze Damage: +25, Hot Resistance: +3, Last Available: "2022-06"
-10923	moldy snack-sized jittery fire-roasted lake trout	2	crappy	Last Available: "2022-06"
+10923	snack-sized moldy jittery fire-roasted lake trout	2	crappy	Last Available: "2022-06"
 10924	stale lime green guilty sprout	4	decent	Last Available: "2022-06"
 10925	narrow dangerous Socratic mother's necklace	0		Experience (Mysticality): +1, Weapon Damage: +10, Last Available: "2022-06"
 10926	frozen double-moist chilled trampled ticket stub	0		Effect: "substats.enh", Effect Duration: 16, Last Available: "2022-06"
@@ -10812,7 +10812,7 @@
 10956	delicious narrow AutumnFest ale	4	awesome	Last Available: "2022-10"
 10957	cyan fortified Socratic slick autumn sweater-weather sweater	0		Moxie: +10, Experience (Mysticality): +1, Damage Absorption: +60, Lasts Until Rollover, Last Available: "2022-10"
 10958	mirror nasty Oprah's baleful autumn debris shield of temperance	0		Spell Damage: +25, Maximum MP Percent: +50, Stench Damage: +5, Sleaze Resistance: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	fancy small toothsome autumn-spice donut	2	awesome	Effect: "Stimulated Body", Effect Duration: 50, Last Available: "2022-10"
+10959	toothsome fancy small autumn-spice donut	2	awesome	Effect: "Stimulated Body", Effect Duration: 50, Last Available: "2022-10"
 10960	polymerized autumn dollar	0		Effect: "Protection from Bad Stuff", Effect Duration: 52, Last Available: "2022-10"
 10961	olive avaricious manspreader's smooth autumn leaf pendant	0		Moxie: +15, Monster Level: +10, Meat Drop: +30, Lasts Until Rollover, Last Available: "2022-10"
 10962	dehydrated tumbling autumn breeze	1		Last Available: "2022-10"
@@ -10826,11 +10826,11 @@
 10970	immense spoiled ratatouille de Jarlsberg	7	crappy	Last Available: "2022-11"
 10971	rotten Jarlsberg's vegetable soup	3	crappy	Last Available: "2022-11"
 10972	moldy blurry roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
-10973	enchanted flavorless low-calorie St. Pete's sneaky smoothie	1	decent	Effect: "Chalked-Up Teeth", Effect Duration: 40, Last Available: "2022-11"
+10973	low-calorie flavorless enchanted St. Pete's sneaky smoothie	1	decent	Effect: "Chalked-Up Teeth", Effect Duration: 40, Last Available: "2022-11"
 10974	flavorless Pete's wiley whey bar	3	decent	Last Available: "2022-11"
 10975	jumbo stale upside-down Pete's rich ricotta	5	decent	Last Available: "2022-11"
 10976	drinkable high-proof green Boris's beer	10	good	Last Available: "2022-11"
-10977	half-sized stale red honey bun of Boris	2	decent	Last Available: "2022-11"
+10977	stale half-sized red honey bun of Boris	2	decent	Last Available: "2022-11"
 10978	super-sized bland Boris's bread	5	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	blurry Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
@@ -10844,7 +10844,7 @@
 10988	half-sized adequate maroon baked veggie ricotta casserole	2	good	Last Available: "2022-11"
 10989	toothsome fuchsia plain calzone	4	awesome	Last Available: "2022-11"
 10990	delicious roasted vegetable focaccia	3	awesome	Last Available: "2022-11"
-10991	tiny fancy rotten purple jittery Pizza of Legend	1	crappy	Effect: "Okee-Dokee Go!", Effect Duration: 50, Last Available: "2022-11"
+10991	fancy rotten tiny jittery purple Pizza of Legend	1	crappy	Effect: "Okee-Dokee Go!", Effect Duration: 50, Last Available: "2022-11"
 10992	low-calorie rotten Calzone of Legend	1	crappy	Last Available: "2022-11"
 10993	blinking Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
@@ -10853,7 +10853,7 @@
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	blurry Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	small adequate Deep Dish of Legend	2	good	Last Available: "2022-11"
+11000	adequate small Deep Dish of Legend	2	good	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	jittery drink chit	0		
 11003	government per-diem	0		
@@ -10867,11 +10867,11 @@
 11011	reassuring gator shades of Flo-Jo	0		Spooky Resistance: +1, Initiative: +100, Single Equip
 11012	milk cap	0		
 11013	acceptable Charleston Choo-Choo	3	good	
-11014	practically non-alcoholic delicious Velvet Veil	1	awesome	
-11015	irresponsibly strong tolerable Marltini	6	good	
+11014	delicious practically non-alcoholic Velvet Veil	1	awesome	
+11015	tolerable irresponsibly strong Marltini	6	good	
 11016	hand-crafted Strong, Silent Type	3	EPIC	
 11017	fortified artisanal Mysterious Stranger	5	EPIC	
-11018	aged special twirling tumbling Champagne Shimmy	3	awesome	Effect: "Weird Flavor", Effect Duration: 15
+11018	special aged tumbling twirling Champagne Shimmy	3	awesome	Effect: "Weird Flavor", Effect Duration: 15
 11019	lime green the Sot's parcel	0		
 11020	narrow wool slick ceramic cestus	0		Moxie: +10, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
 11021	pulsating shellacked baleful Newton's ceramic centurion shield	0		Experience (Mysticality): +3, Spell Damage: +25, Damage Reduction: 16, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
@@ -10879,7 +10879,7 @@
 11023	inspector's personal trainer's ceramic celsiturometer of courage	0		Experience Percent (Muscle): +10, Spooky Resistance: +3, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
 11024	bouncing toasty savvy ceramic cerecloth belt of the glutton	0		Mysticality Percent: +20, Hot Damage: +5, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
 11025	inspector's MacGyver's ceramic cenobite's robe of the scaredy-cat	0		Maximum MP: +100, Monster Level: -15, Item Drop: +15, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
-11026	diluted spinning squat ceramic scree	1		Effect: "The Spy Who Loved XP", Effect Duration: 35, Last Available: "2023-12"
+11026	diluted squat spinning ceramic scree	1		Effect: "The Spy Who Loved XP", Effect Duration: 35, Last Available: "2023-12"
 11027	polymerized super-warmed extra-hard jawbreaker	0		Effect: "Pill Power", Effect Duration: 11
 11028	foul-smelling hardy chiffon chevrons of extreme caution	0		Maximum HP: +50, Monster Level: -25, Stench Damage: +10, Single Equip, Last Available: "2023-12"
 11029	tumbling Van der Graaf chiffon chapeau of Leguizamo of the cheetah	0		Monster Level: +20, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	bouncing blinking energetic chiffon chaps of the storm of incineration	0		Maximum MP Percent: 60, Hot Spell Damage: +50, Last Available: "2023-12"
 11034	twisted blinking chiffon carbage	1		Effect: "White Blooded", Effect Duration: 35, Last Available: "2023-12"
 11035	polarized blurry chiffon lemon	0		Effect: "Danish Cunning", Effect Duration: 35
-11036	flavorless blinking green chocomotive	4	decent	Last Available: "2022-12"
+11036	flavorless green blinking chocomotive	4	decent	Last Available: "2022-12"
 11037	decent wobbly freightcake	3	good	Last Available: "2022-12"
 11038	lousy red cabooze	4	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
@@ -10900,7 +10900,7 @@
 11044	packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	model train set	0		Last Available: "2022-12"
 11046	green Crimbo training manual	0		
-11047	mirror fuchsia pulsating Abuela Crimbo's special magnet	0		
+11047	pulsating mirror fuchsia Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
 11050	polarized aerosolized Trainbot circuitry	0		Effect: "Aided and Abetted", Effect Duration: 21
@@ -10943,29 +10943,29 @@
 11087	train whistle	0		Last Available: "2022-12"
 11088	squat The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	skewed unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
-11090	narrow spinning half-height cigar	0		Familiar Weight: +5
+11090	spinning narrow half-height cigar	0		Familiar Weight: +5
 11091	grubby wool	0		
 11092	grubby wool hat of the blizzard of the sewer of temperance	0		Cold Spell Damage: +25, Stench Damage: +25, Sleaze Resistance: +5
 11093	ribald forbidden grubby wool scarf	0		Spell Damage Percent: +50, Sleaze Damage: +10, Single Equip
 11094	Oprah's supercharged Samson's grubby wool trousers	0		Experience (Muscle): +5, Maximum MP Percent: 80
 11095	tumbling supercharged dangerous grubby wool gloves of the brute of the sewer	0		Muscle Percent: +30, Weapon Damage: +10, Maximum MP Percent: +30, Stench Damage: +25, Single Equip
 11096	huge grubby wool beerwarmer	0		
-11097	practically non-alcoholic mediocre skewed nice warm beer	1	decent	
+11097	mediocre practically non-alcoholic skewed nice warm beer	1	decent	
 11098	grubby woolball	0		
-11099	ghostly narrow Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
+11099	narrow ghostly Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	blue groveling gravel	0		Last Available: "2023-01"
-11102	denatured spinning maroon fruity pebble	1		Last Available: "2023-01"
+11102	denatured maroon spinning fruity pebble	1		Last Available: "2023-01"
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
-11104	blurry ghostly milestone	0		Last Available: "2023-01"
+11104	ghostly blurry milestone	0		Last Available: "2023-01"
 11105	shaking bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	skewed chocolate covered ping-pong ball	0		
-11112	delicious snack-sized cyan pixel bread	2	awesome	
-11113	drinkable practically non-alcoholic pixel whiskey	1	good	
+11112	snack-sized delicious cyan pixel bread	2	awesome	
+11113	practically non-alcoholic drinkable pixel whiskey	1	good	
 11114	pixel rock	0		
 11115	purple S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10975,13 +10975,13 @@
 11120	normal maroon super good fruit	4	good	Last Available: "2023-02"
 11121	twisted energized spores	1		Last Available: "2023-02"
 11122	fireproof frightening hot pepper	0		Spooky Damage: +5, Hot Resistance: +3, Last Available: "2023-02", Lantern Element: "Hot"
-11123	boiled vacuum-sealed upside-down narrow skewed out-of-work circus flea	0		Effect: "Space Tripping", Effect Duration: 54, Last Available: "2023-02"
+11123	boiled vacuum-sealed narrow upside-down skewed out-of-work circus flea	0		Effect: "Space Tripping", Effect Duration: 54, Last Available: "2023-02"
 11124	ghostly extra-grubby grub	0		Last Available: "2023-02"
 11125	triple-unsweetened quadruple-adjusted blue fire ant pheromones	0		Effect: "Weapon of Mass Destruction", Effect Duration: 52, Last Available: "2023-02"
 11126	oxidized gray flapper fly	0		Effect: "Ham-Fisted", Effect Duration: 33, Last Available: "2023-02"
-11127	weak hand-crafted shot of wasp venom	2	EPIC	Last Available: "2023-02"
+11127	hand-crafted weak shot of wasp venom	2	EPIC	Last Available: "2023-02"
 11128	ionized filled mosquito	0		Effect: "Graham Crackling", Effect Duration: 38, Last Available: "2023-02"
-11129	activated flattened blinking tumbling shim of shame shale	0		Effect: "Petit Force", Effect Duration: 38, Last Available: "2023-02"
+11129	activated flattened tumbling blinking shim of shame shale	0		Effect: "Petit Force", Effect Duration: 38, Last Available: "2023-02"
 11130	nitrogenated pebble of proud pyrite	0		Effect: "Very Clean Guns", Effect Duration: 51, Last Available: "2023-02"
 11131	double-chilled aerosolized pile of gritty sand	0		Effect: "Swimming Head", Effect Duration: 14, Last Available: "2023-02"
 11132	cyan hollow rock	0		Last Available: "2023-02"
@@ -10990,9 +10990,9 @@
 11135	normal shadow sausage	3	good	Last Available: "2023-03"
 11136	foul-smelling steel-toed shadow skin	0		Damage Reduction: 9, Stench Damage: +10, Last Available: "2023-03"
 11137	triple-improved shadow flame	0		Effect: "A Contender", Effect Duration: 19, Last Available: "2023-03"
-11138	immense spoiled ghostly shadow bread	8	crappy	Last Available: "2023-03"
+11138	spoiled immense ghostly shadow bread	8	crappy	Last Available: "2023-03"
 11139	red shadow ice	0		Last Available: "2023-03"
-11140	drinkable weak shadow fluid	2	good	Last Available: "2023-03"
+11140	weak drinkable shadow fluid	2	good	Last Available: "2023-03"
 11141	purple shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11046,7 +11046,7 @@
 11191	replica hand turkey outline	0		
 11192	upside-down replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
-11194	lime green ghostly dedigitizer schematic: cyburger	0		Last Available: "2025-12"
+11194	ghostly lime green dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	jittery replica wax lips	0		Experience: +3
 11197	replica Tome of Snowcone Summoning	0		
@@ -11057,7 +11057,7 @@
 11202	reassuring double-paned replica V for Vivala mask	0		Cold Resistance: +5, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	aromatic fortified replica haiku katana of Flo-Jo	0		Damage Absorption: +60, Stench Resistance: +1, Initiative: +100, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
-11205	jittery tumbling replica cotton candy cocoon	0		
+11205	tumbling jittery replica cotton candy cocoon	0		
 11206	mirror executive Jeselnik's resourceful Da Vinci's replica Elvish sunglasses	0		Experience (Mysticality): +5, Maximum MP: +50, Sleaze Damage: +25, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
 11208	replica stone sphere	0		
@@ -11090,7 +11090,7 @@
 11235	replica space planula	0		
 11236	replica unpowered Robortender	0		
 11237	tumbling replica Neverending Party invitation envelope	0		
-11238	pulsating blurry replica January's Garbage Tote	0		
+11238	blurry pulsating replica January's Garbage Tote	0		
 11239	jittery replica God Lobster Egg	0		
 11240	frosty razor-sharp dance instructor's replica Fourth of May Cosplay Saber	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Cold Spell Damage: +10, Conditional Skill (Equipped): "Use the Force"
 11241	huge sizzling clever quilted boxer's replica Kramco Sausage-o-Matic&trade; of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Damage Absorption: +40, Maximum MP: +20, Hot Damage: +10
@@ -11111,33 +11111,33 @@
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
 11257	skewed 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	tumbling purple sizzling mansplainer's padded forbidden Sinatra's &quot;I survived Y2K&quot; T-Shirt of the brute	0		Muscle Percent: +30, Experience (Moxie): +5, Spell Damage Percent: +50, Damage Absorption: +20, Monster Level: +15, Hot Damage: +10, Single Equip, Last Available: "2023-06"
-11259	bouncing cyan Letter from Carrie Bradshaw	0		Last Available: "2023-06"
+11259	cyan bouncing Letter from Carrie Bradshaw	0		Last Available: "2023-06"
 11260	pro skateboard of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	wobbly wobbly Mr. Accessaturday	0		Last Available: "2023-06"
 11262	squat Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	spinning Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	spinning Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	blue lard-coated Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	upside-down horrifying toasty mansplainer's Amulet of Perpetual Darkness of James Dean	0		Experience (Moxie): +3, Monster Level: +15, Hot Damage: +5, Spooky Damage: +25, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
 11270	VHS Tape	0		Last Available: "2023-06"
 11271	wet yellow scroll of minor invulnerability	0		Effect: "Quantum of Moxie", Effect Duration: 64, Last Available: "2023-06"
-11272	blinking yellow Lapis Lazuli	0		Last Available: "2023-06"
+11272	yellow blinking Lapis Lazuli	0		Last Available: "2023-06"
 11273	Eye Agate	0		Last Available: "2023-06"
 11274	Azurite	0		Last Available: "2023-06"
 11275	Arrow (+1)	0		Last Available: "2023-06"
 11276	adjusted scroll of protection from lycanthropes	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 23, Last Available: "2023-06"
 11277	squat Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
-11279	pulsating blue bouncing Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
+11279	pulsating bouncing blue Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
 11282	watered-down delicious Sexy Cosmo	2	awesome	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	greedy coward's red-soled high heels of temperance	0		Monster Level: -20, Sleaze Resistance: +5, Meat Drop: +20, Last Available: "2023-06"
-11285	small stale huge cyburger	2	decent	Last Available: "2025-12"
+11285	stale small huge cyburger	2	decent	Last Available: "2025-12"
 11286	careful ncle leg	0		Monster Level: -10
 11287	wobbly flame-wreathed Socratic rutabuga bag	0		Experience (Mysticality): +1, Hot Spell Damage: +10
 11288	Van der Graaf mesquito proboscis	0		MP Regen Min: 5, MP Regen Max: 7
@@ -11152,7 +11152,7 @@
 11297	extremely unsafe cool kilopede skull	0		Moxie: +5, Weapon Damage Percent: +100
 11298	extra-irradiated liquefied shaking jittery haemolymphnode	0		Effect: "Net Tea", Effect Duration: 53
 11299	irradiated magnetized chitin powder paste	0		Effect: "Lit Up", Effect Duration: 47
-11300	blurry bouncing sleeping patriotic eagle	0		Free Pull
+11300	bouncing blurry sleeping patriotic eagle	0		Free Pull
 11301	bouncing claw-held flag	0		Familiar Weight: +5
 11302	squat souvenir flag	0		
 11303	name change form	0		
@@ -11174,12 +11174,12 @@
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	weak hand-crafted bottle of Cabernet Sauvignon	2	EPIC	
 11321	fortified baywatch of Gandalf of the businessman	0		Damage Absorption: +60, Spell Critical Percent: +20, Meat Drop: +50, Lasts Until Rollover
-11322	huge Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	tumbling teal Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	huge Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	teal tumbling Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	gray squat Thwaitgold fairyfly statue	0		
-11327	huge bouncing residual chitin paste	0		Skill: "Chitinous Soul"
+11327	bouncing huge residual chitin paste	0		Skill: "Chitinous Soul"
 11328	diluted spinning concentrated cooking	1		
 11329	diluted meat	1		
 11330	vaporized squat sparkling orb	1		Effect: "Tightly-Wound Spine", Effect Duration: 20
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	bouncing crated wardrobe-o-matic	0		
-11395	super-sized normal teal peppermint donut	5	good	
+11395	normal super-sized teal peppermint donut	5	good	
 11396	skewed smelly Elf Guard insignia (private)	0		Stench Spell Damage: +10, Last Available: "2023-12"
 11397	wholesome Crimbuccaneer fledges (mint)	0		Maximum HP Percent: +10, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11269,7 +11269,7 @@
 11414	resourceful sage Elf Guard officer's sidearm	0		Mysticality Percent: +10, Maximum MP: +50, Last Available: "2023-12"
 11415	blurry hardy experienced Elf Guard insignia (general)	0		Experience: +2, Maximum HP: +50, Single Equip, Last Available: "2023-12"
 11416	high-proof mediocre fuchsia Crimbow Rainbo	7	decent	Last Available: "2023-12"
-11417	upside-down tumbling Elf Guard strategic map	0		Last Available: "2023-12"
+11417	tumbling upside-down Elf Guard strategic map	0		Last Available: "2023-12"
 11418	blurry Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	Jeselnik's lion tamer's Elf Guard broom	0		Experience (familiar): +2, Sleaze Damage: +25, Last Available: "2023-12"
 11420	huge avaricious sizzling frosty Crimbuccaneer tavern swab	0		Cold Spell Damage: +10, Hot Damage: +10, Meat Drop: +30, Last Available: "2023-12"
@@ -11285,7 +11285,7 @@
 11430	rotten half-sized twirling whalesteak	2	crappy	Last Available: "2023-12"
 11431	Temple Grandin's steel-toed whalegun of the glutton	0		Damage Reduction: 9, Familiar Weight: +7, Food Drop: +100, Last Available: "2023-12"
 11432	bouncing Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
-11433	spinning lime green Elf Guard payroll bag	0		Last Available: "2023-12"
+11433	lime green spinning Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	grievous slick Elf Guard clipboard of doom	0		Moxie: +10, Weapon Damage Percent: +50, Spooky Spell Damage: +50, Last Available: "2023-12"
 11435	spinning hardened pegfinger	0		Damage Reduction: 3, Single Equip, Last Available: "2023-12"
 11436	perfectly mixed and claret	4	EPIC	Last Available: "2023-12"
@@ -11293,7 +11293,7 @@
 11438	foul-smelling resourceful baleful shipwright's hammer	0		Spell Damage: +25, Maximum MP: +50, Stench Damage: +10, Last Available: "2023-12"
 11439	fireproof wizardly gunwale of the empath	0		Mysticality: +25, Familiar Weight: +5, Hot Resistance: +3, Damage Reduction: 9, Last Available: "2023-12"
 11440	skewed green toasty Herculean stylish Kelflar vest	0		Moxie: +25, Experience (Muscle): +1, Hot Damage: +5, Last Available: "2023-12"
-11441	super-anodized wet tumbling ghostly whale cerebrospinal fluid	0		Effect: "Cinnamouth", Effect Duration: 63, Last Available: "2023-12"
+11441	super-anodized wet ghostly tumbling whale cerebrospinal fluid	0		Effect: "Cinnamouth", Effect Duration: 63, Last Available: "2023-12"
 11442	auspicious Temple Grandin's Crimbuccaneer runebone	0		Familiar Weight: +7, Item Drop: +10, Single Equip, Last Available: "2023-12"
 11443	twirling cannonbomb	0		Last Available: "2023-12"
 11444	rosy-cheeked Elf Guard mouthknife of the glutton	0		Maximum HP Percent: +30, Food Drop: +100, Last Available: "2023-12"
@@ -11313,25 +11313,25 @@
 11458	ghostly squat perfumed baleful Crimbuccaneer bombjacket	0		Spell Damage: +25, Stench Resistance: +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	massive rotten sugarplum ration	6	crappy	Last Available: "2023-12"
 11460	super-sized moldy gingerbread nylons	5	crappy	Last Available: "2023-12"
-11461	half-sized decent enchanted rum-soaked fruitcake	2	good	Effect: "The Living Hitpoints", Effect Duration: 15, Last Available: "2023-12"
+11461	enchanted half-sized decent rum-soaked fruitcake	2	good	Effect: "The Living Hitpoints", Effect Duration: 15, Last Available: "2023-12"
 11462	normal lime	3	good	Last Available: "2023-12"
 11463	moldy gingerbread pirate	3	crappy	Last Available: "2023-12"
 11464	bland blinking fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
 11465	mediocre mulled wine	4	decent	Last Available: "2023-12"
 11466	triple-distilled drinkable blinking Swedish coffee	9	good	Last Available: "2023-12"
-11467	strong smooth canteen of eggnog	5	awesome	Last Available: "2023-12"
+11467	smooth strong canteen of eggnog	5	awesome	Last Available: "2023-12"
 11468	special irresponsibly strong drinkable hot wine	6	good	Effect: "Polar Express", Effect Duration: 45, Last Available: "2023-12"
 11469	hand-crafted Jamaican coffee	4	EPIC	Last Available: "2023-12"
-11470	delicious spirit-forward flask of egggrog	5	awesome	Last Available: "2023-12"
+11470	spirit-forward delicious flask of egggrog	5	awesome	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	distilled tolerable yule grog	5	good	Last Available: "2023-12"
 11475	decent mirror wet tack	3	good	Last Available: "2023-12"
-11476	normal massive whalecake	9	good	Last Available: "2023-12"
+11476	massive normal whalecake	9	good	Last Available: "2023-12"
 11477	Usain Bolt's gunwale whalegun of Gandalf of extreme caution	0		Spell Critical Percent: +20, Monster Level: -25, Initiative: +80, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	lousy high-proof upside-down and claret	9	decent	Last Available: "2023-12"
-11479	olive bouncing rigging knot	0		Familiar Weight: +5
+11479	bouncing olive rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	twirling cyan educational Elf Guard squirtgun of the ox	0		Muscle: +20, Experience: +1, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	lime green chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
@@ -11388,7 +11388,7 @@
 11533	greasy experienced petrified wood walking pants	0		Experience: +2, Sleaze Spell Damage: +10, Last Available: "2025-12"
 11534	boiled wobbly mirror petrified wood waste parts	1		Last Available: "2025-12"
 11535	frozen modified petrified wood wafer praline	0		Effect: "Object Detection", Effect Duration: 60
-11536	practically non-alcoholic lousy gray cybeer	1	decent	Last Available: "2025-12"
+11536	lousy practically non-alcoholic gray cybeer	1	decent	Last Available: "2025-12"
 11537	lime green ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
 11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
@@ -11429,8 +11429,8 @@
 11574	tolerable practically non-alcoholic yam martini	1	good	Last Available: "2024-05"
 11575	practically non-alcoholic acceptable skewed sweet potato o' mine	1	good	Last Available: "2024-05"
 11576	tolerable mirror red Southern yam	4	good	Last Available: "2024-05"
-11577	perfectly mixed practically non-alcoholic shaking sweet potato punch	1	super ultra mega turbo EPIC	Last Available: "2024-05"
-11578	spoiled diet Mayam spinach	1	crappy	Last Available: "2024-05"
+11577	practically non-alcoholic perfectly mixed shaking sweet potato punch	1	super ultra mega turbo EPIC	Last Available: "2024-05"
+11578	diet spoiled Mayam spinach	1	crappy	Last Available: "2024-05"
 11579	snack-sized decent yam and swiss	2	good	Last Available: "2024-05"
 11580	avaricious chilly yam cannon of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11453,7 +11453,7 @@
 11598	huge mini kiwi aioli	0		
 11599	wobbly nippy Jim Carey's mini kiwi silicon tiepin of dire peril	0		Weapon Damage: +20, Monster Level: +25, Cold Damage: +10
 11600	huge mini kiwi tipi	0		
-11601	flavorless bite-sized enchanted mini kiwi digitized cookies	1	decent	Effect: "Action", Effect Duration: 20
+11601	flavorless enchanted bite-sized mini kiwi digitized cookies	1	decent	Effect: "Action", Effect Duration: 20
 11602	perfectly mixed mini kiwi intoxicating spirits	4	EPIC	
 11603	altered quantum mini kiwi antimilitaristic hippy petition	0		Effect: "Fungal Fortification", Effect Duration: 42
 11604	super-flattened double-flattened shaking mini kiwi illicit antibiotic	0		Effect: "The Strength...  of the Future", Effect Duration: 46
@@ -11471,7 +11471,7 @@
 11616	wobbly flagellate flagon	0		
 11617	skewed proto-proto-protozoa	0		
 11618	massive bland bacteria bisque	6	decent	
-11619	enchanted stale ciliophora chowder	4	decent	Effect: "Hyphemariffic", Effect Duration: 45
+11619	stale enchanted ciliophora chowder	4	decent	Effect: "Hyphemariffic", Effect Duration: 45
 11620	spoiled small cream of chloroplasts	2	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11487,7 +11487,7 @@
 11632	blue Doll Moll violin case	0		
 11633	Tina gun	0		Familiar Weight: +5
 11634	blinking blurry tattoo gun	0		
-11635	lousy watered-down Colera Peste Nebbiolo	2	decent	
+11635	watered-down lousy Colera Peste Nebbiolo	2	decent	
 11636	longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11527,7 +11527,7 @@
 11672	yellow peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	bland whirled peas	3	decent	Last Available: "2024-11"
-11675	moldy fancy wobbly peaza	4	crappy	Effect: "Inner Warmth", Effect Duration: 35, Last Available: "2024-11"
+11675	fancy moldy wobbly peaza	4	crappy	Effect: "Inner Warmth", Effect Duration: 35, Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	pickled twirling drenchrome 2.0	1		Last Available: "2025-12"
 11678	altered Synapse Blaster	1		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 15, Last Available: "2025-12"
@@ -11546,21 +11546,21 @@
 11691	bouncing sleeping profane parrot	0		Last Available: "2024-12"
 11692	olive pirrrate's currrse	0		Last Available: "2024-12"
 11693	perfectly mixed yellow tankard of spiced rum	3	EPIC	Last Available: "2024-12"
-11694	lousy spirit-forward tankard of spiced Goldschlepper	5	decent	Last Available: "2024-12"
+11694	spirit-forward lousy tankard of spiced Goldschlepper	5	decent	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	pulsating governor's daughter's lace collar	0		Item Drop: +5, Last Available: "2024-12"
 11697	ghostly green grievous governor's daughter's petticoats	0		Weapon Damage Percent: +50, Last Available: "2024-12"
 11698	stanky governor's daughter's pearl hairpin	0		Stench Spell Damage: +25, Last Available: "2024-12"
 11699	harpoon	0		Last Available: "2024-12"
 11700	bouncing Newton's chili powder cutlass	0		Experience (Mysticality): +3, Last Available: "2024-12"
-11701	thick decent Aztec tamale	5	good	Last Available: "2024-12"
+11701	decent thick Aztec tamale	5	good	Last Available: "2024-12"
 11702	blinking spinning jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	huge Herculean groggles	0		Experience (Muscle): +1, Last Available: "2024-12"
 11705	pirate dinghy	0		Last Available: "2024-12"
 11706	wobbly anchor bomb	0		Last Available: "2024-12"
 11707	scandalous horrifying silky pirate drawers	0		Spooky Damage: +25, Sleaze Damage: +5, Last Available: "2024-12"
-11708	tumbling olive profane eye patch	0		Sleaze Damage: +3
+11708	olive tumbling profane eye patch	0		Sleaze Damage: +3
 11709	nitrogenated ghostly peppermint pegleg	0		Effect: "Bored Stiff", Effect Duration: 54, Last Available: "2024-12"
 11710	bad blue hard cocoa	4	decent	Last Available: "2024-12"
 11711	bland snack-sized salmagumdi	2	decent	Last Available: "2024-12"
@@ -11576,7 +11576,7 @@
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	spoiled coney haunch	4	crappy	Last Available: "2024-12"
 11723	aerosolized bouncing dark chocolate egg	0		Effect: "Polka of Plenty", Effect Duration: 43, Last Available: "2024-12"
-11724	lousy blurry narrow moai toai	4	decent	
+11724	lousy narrow blurry moai toai	4	decent	
 11725	shellacked beefy moaiball of horror	0		Muscle: +10, Damage Reduction: 7, Spooky Spell Damage: +25, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	denatured four-leaf potato sprout	0		Effect: "Eyes of the Dragon", Effect Duration: 26, Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	grievous gravyskin skirt of chilblains	0		Weapon Damage Percent: +50, Cold Damage: +25, Last Available: "2024-12"
 11737	aromatic scandalous gravyskin pants	0		Sleaze Damage: +5, Stench Resistance: +1, Last Available: "2024-12"
 11738	nitrogenated crystallized pumpkin spice	0		Effect: "Extra-Sharp Weapon", Effect Duration: 45, Last Available: "2024-12"
-11739	stale massive skewed room scale bean casserole	10	decent	Last Available: "2024-12"
+11739	massive stale skewed room scale bean casserole	10	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	bouncing scandalous dangerous perfect Christmas scarf of courage	0		Weapon Damage: [+10*event(December)], Sleaze Damage: [+5*event(December)], Spooky Resistance: [+3*event(December)], Single Equip, Last Available: "2024-12"
@@ -11599,13 +11599,13 @@
 11744	chilled dry blue LIDAR candle	0		Effect: "Dreadful Sheen", Effect Duration: 14, Last Available: "2024-12"
 11745	miser's flame-wreathed Congressional Medal of Insanity of vim and vigor	0		Maximum HP Percent: +50, Hot Spell Damage: +10, Meat Drop: +10, Last Available: "2024-12"
 11746	mirror pumpkin spice whorl	0		Last Available: "2024-12"
-11747	weak tolerable blinking Easter grasshopper	2	good	Last Available: "2024-12"
-11748	acceptable triple-distilled Irish eggnog	7	good	Last Available: "2024-12"
+11747	tolerable weak blinking Easter grasshopper	2	good	Last Available: "2024-12"
+11748	triple-distilled acceptable Irish eggnog	7	good	Last Available: "2024-12"
 11749	drinkable enchanted fuchsia canteen of jungle juice	3	good	Effect: "'Roids of the Rhinoceros", Effect Duration: 40, Last Available: "2024-12"
-11750	artisanal watered-down turchucken	2	EPIC	Last Available: "2024-12"
+11750	watered-down artisanal turchucken	2	EPIC	Last Available: "2024-12"
 11751	aged watered-down mechanically-mulled cider	2	awesome	Last Available: "2024-12"
-11752	tolerable fancy squat upside-down holiday trip around the world	3	good	Effect: "Coldfinger", Effect Duration: 10, Last Available: "2024-12"
-11753	rotten thick chocolate ostrich egg	5	crappy	Last Available: "2024-12"
+11752	fancy tolerable squat upside-down holiday trip around the world	3	good	Effect: "Coldfinger", Effect Duration: 10, Last Available: "2024-12"
+11753	thick rotten chocolate ostrich egg	5	crappy	Last Available: "2024-12"
 11754	yummy beef and cabbage	3	awesome	Last Available: "2024-12"
 11755	rotten candy rations	4	crappy	Last Available: "2024-12"
 11756	enchanted spoiled huge double-candied yams	8	crappy	Effect: "Standard Cheer", Effect Duration: 20, Last Available: "2024-12"
@@ -11613,16 +11613,16 @@
 11758	thick normal holiday smorgasbord	5	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	stanky bejazzled eyepatch	0		Stench Spell Damage: +25, Last Available: "2024-12"
-11761	ghostly Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	wobbly How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	red How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	squat Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	ghostly Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	wobbly How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	red How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	squat Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	therapeutic stiffened studded egg gun of the empath	0		Damage Absorption: +80, Damage Reduction: 1, Familiar Weight: +5, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	hale Da Vinci's army helmet of bravery of the boozehound	0		Experience (Mysticality): +5, Maximum HP: +20, Spooky Resistance: +5, Booze Drop: +100, Last Available: "2024-12"
@@ -11648,7 +11648,7 @@
 11793	ghostly ghostly dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	narrow dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
-11796	purple jittery dedigitizer schematic: digibritches	0		Last Available: "2025-12"
+11796	jittery purple dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
@@ -11659,14 +11659,14 @@
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	mirror pocket GPU	0		Single Equip, Last Available: "2025-12"
 11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
-11807	mirror maroon CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
+11807	maroon mirror CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	green server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	vaporized psilocyber mushroom	1		Last Available: "2025-12"
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
-11814	bouncing twirling dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
+11814	twirling bouncing dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
@@ -11676,7 +11676,7 @@
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
-11824	gray squat insignificant bit	0		Last Available: "2025-12"
+11824	squat gray insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	wobbly hashing vise	0		Last Available: "2025-12"
 11827	blue geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
@@ -11713,7 +11713,7 @@
 11858	shaking glover liners	0		Pickpocket Chance: +10
 11859	twirling twirling mosquito speakers	0		Monster Level: +5
 11860	yellow assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
-11861	wobbly ghostly Leprecondo	0		Last Available: "2025-03"
+11861	ghostly wobbly Leprecondo	0		Last Available: "2025-03"
 11862	denatured wobbly scoop of pre-workout powder	1		Effect: "Spiritually Awake", Effect Duration: 15, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	mediocre fortified squat pint of Leprechaun Stout	5	decent	Last Available: "2025-03"
@@ -11724,14 +11724,14 @@
 11869	unironic knife	0		
 11870	yellow bar dart	0		Last Available: "2025-03"
 11871	denatured skewed leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	bite-sized normal Heck ramen	1	good	Last Available: "2025-03"
+11872	normal bite-sized Heck ramen	1	good	Last Available: "2025-03"
 11873	bland burrito	3	decent	Last Available: "2025-03"
-11874	special adequate diet small beer brat	1	good	Effect: "Carrion' On", Effect Duration: 40, Last Available: "2025-03"
+11874	diet special adequate small beer brat	1	good	Effect: "Carrion' On", Effect Duration: 40, Last Available: "2025-03"
 11875	moldy peach pie	3	crappy	Last Available: "2025-03"
-11876	thick decent incredible mini-pizza	5	good	Last Available: "2025-03"
+11876	decent thick incredible mini-pizza	5	good	Last Available: "2025-03"
 11877	drinkable Divine sidecar	4	good	Last Available: "2025-03"
 11878	mediocre tangarita sidecar	3	decent	Last Available: "2025-03"
-11879	bad triple-distilled lime green gimlet sidecar	6	decent	Last Available: "2025-03"
+11879	triple-distilled bad lime green gimlet sidecar	6	decent	Last Available: "2025-03"
 11880	hand-crafted triple-distilled vodka stratocaster sidecar	8	EPIC	Last Available: "2025-03"
 11881	drinkable prussian cathouse sidecar	4	good	Last Available: "2025-03"
 11882	hand-crafted Mon Tiki sidecar	4	EPIC	Last Available: "2025-03"
@@ -11742,7 +11742,7 @@
 11887	adjusted red wet paper weights	0		Effect: "Super-Electrified", Effect Duration: 45, Last Available: "2025-04"
 11888	weak aged spinning Three Sheets to the Wind	2	awesome	Last Available: "2025-04"
 11889	small rotten pile of wet dates	2	crappy	Last Available: "2025-04"
-11890	ghostly upside-down papier Mach 1 airplane	0		Last Available: "2025-04"
+11890	upside-down ghostly papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	purple wet blanket	0		Last Available: "2025-04"
 11892	maroon Jim Carey's wet shower cap	0		Monster Level: +25, Last Available: "2025-04"
 11893	mirror wet shower shoes of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2025-04"
@@ -11751,11 +11751,11 @@
 11896	wet paper eye	0		Familiar Weight: +15
 11897	wet shower curtain	0		Last Available: "2025-04"
 11898	oxidized pulsating wet paper cup	0		Effect: "Squatting and Thrusting", Effect Duration: 20, Last Available: "2025-04"
-11899	oxidized tumbling gray blurry wet paperback	0		Effect: "Corona de la Salsa", Effect Duration: 23, Last Available: "2025-04"
+11899	oxidized gray blurry tumbling wet paperback	0		Effect: "Corona de la Salsa", Effect Duration: 23, Last Available: "2025-04"
 11900	greedy wet shower radio	0		Meat Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	gray wet shower stamp	0		Last Available: "2025-04"
 11902	birthday bloon of the early riser	0		Adventures: +7
-11903	dry oxidized huge upside-down jawwetter	0		Effect: "You're High as a Crow, Marty", Effect Duration: 31
+11903	dry oxidized upside-down huge jawwetter	0		Effect: "You're High as a Crow, Marty", Effect Duration: 31
 11904	Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
 11905	crafty Peridot of Peril of the cougar of incineration	0		Moxie: +20, Maximum MP: +10, Hot Spell Damage: +50, Single Equip, Last Available: "2025-06"
 11906	double-paned terrycloth turban	0		Cold Resistance: +5
@@ -11775,20 +11775,20 @@
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
-11923	blurry shaking exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
+11923	shaking blurry exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
 11924	friendly Axis helmet of the blizzard	0		Familiar Weight: +3, Cold Spell Damage: +25
 11925	narrow careful Axis fatigues of the storm	0		Maximum MP Percent: +40, Monster Level: -10
 11926	blinking tumbling toasty Newton's Axis suspenders	0		Experience (Mysticality): +3, Hot Damage: +5, Single Equip
 11927	blinking jittery stolen artifact	0		
 11928	really expensive stolen artifact	0		
-11929	tumbling yellow priceless stolen artifact	0		
+11929	yellow tumbling priceless stolen artifact	0		
 11930	chocolate rations	0		
 11931	nice nylon stockings	0		
 11932	Allied Radio Backpack Pack	0		Free Pull
 11933	knitted thinker's brainy Allied Radio Backpack	0		Mysticality: 15, Cold Resistance: +3, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	blue orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
-11936	shaking olive confetti grenade	0		
+11936	olive shaking confetti grenade	0		
 11937	spoiled Skeleton Wars rations	3	crappy	
 11938	perfectly mixed gray skeleton war fuel can	4	EPIC	
 11939	skeleton war grenade	0		
@@ -11798,13 +11798,13 @@
 11943	bone pacifier	0		Familiar Weight: +5
 11944	Tesla shellacked Allied Forces insignia of the ox	0		Muscle: +20, Damage Reduction: 7, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11945	cyan Allied Tattoo Kit	0		
-11946	skewed green handheld Allied radio	0		
+11946	green skewed handheld Allied radio	0		
 11947	skewed Axis codebook	0		
 11948	ionized aerosolized ghostly Life Goals Pamphlet	0		Effect: "Seeing Colors", Effect Duration: 25, Last Available: "2025-08"
 11949	bully badge of the overflowing toilet	0		Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2025-08"
 11950	twirling ghostly asbestos-lined time cop top hat	0		Hot Resistance: +5, Last Available: "2025-08"
 11951	shaking Stock Certificate	0		Last Available: "2025-08"
-11952	distilled red ghostly upside-down mixed berry jelly	1		Last Available: "2025-08"
+11952	distilled upside-down ghostly red mixed berry jelly	1		Last Available: "2025-08"
 11953	stale toast with mixed berry jelly	3	decent	Last Available: "2025-08"
 11954	stale cup of sugar	3	decent	Last Available: "2025-08"
 11955	bland diet Susie's cupcake	1	decent	Last Available: "2025-08"
@@ -11839,7 +11839,7 @@
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
-12052	weak delicious Smoking Pope	2	awesome	
+12052	delicious weak Smoking Pope	2	awesome	
 12053	tasty spinning prize turkey	4	awesome	
 12054	compressed medicinal gruel	1		
 12055	massive flavorless full-sized pumpkin pie	6	decent	Last Available: "2025-11"
@@ -11862,7 +11862,7 @@
 12072	mirror upside-down savvy angelbone dice	0		Mysticality Percent: +20, Single Equip, Last Available: "2026-12"
 12073	Sherlock's brawny angelbone halo	0		Muscle Percent: +20, Item Drop: +25, Last Available: "2026-12"
 12074	modified angelbone fragments	1		Effect: "The Real Deal", Effect Duration: 30, Last Available: "2026-12"
-12075	diffused upside-down bouncing tumbling biblically accurate gumdrops	0		Effect: "Top Dog", Effect Duration: 53
+12075	diffused upside-down tumbling bouncing biblically accurate gumdrops	0		Effect: "Top Dog", Effect Duration: 53
 12076	hardy ruddy devilbone helmet	0		Maximum HP Percent: +40, Maximum HP: +50, Last Available: "2026-12"
 12077	miser's devilbone greaves	0		Meat Drop: +10, Last Available: "2026-12"
 12078	chaotic devilbone shinguards of temperance	0		Spell Critical Percent: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2026-12"
@@ -11881,7 +11881,7 @@
 12123	tumbling The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	perfectly mixed Steve Abrams' Holiday Sampler Beer	4	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	practically non-alcoholic drinkable bottle of prize-winning rum	1	good	Last Available: "2025-12"
+12126	drinkable practically non-alcoholic bottle of prize-winning rum	1	good	Last Available: "2025-12"
 12127	bouncing resourceful veiny Santa-Slayer medal of incineration	0		Maximum HP: +10, Maximum MP: +50, Hot Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12128	blurry Skull of Claus	0		Last Available: "2025-12"
 12129	pressed extra-Vulcanized boiling bone marrow	0		Effect: "Triangle, Man", Effect Duration: 23, Last Available: "2025-12"
@@ -11896,7 +11896,7 @@
 12138	fuchsia squat Jeselnik's beefy fistbone of chilblains	0		Muscle: +10, Cold Damage: +25, Sleaze Damage: +25, Last Available: "2025-12"
 12139	zippy Annie Oakley's burnt bone belt of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +20, Initiative: +20, Single Equip, Last Available: "2025-12"
 12140	scorched skull trophy of the wise owl	0		Mysticality: +20, Last Available: "2025-12"
-12141	bland huge wing bone	6	decent	Last Available: "2025-12"
+12141	huge bland wing bone	6	decent	Last Available: "2025-12"
 12142	artisanal weak skeleton venom	3	EPIC	Last Available: "2025-12"
 12143	mixed ghostly baked bone meal	1		Effect: "Tenacity of the Snapper", Effect Duration: 20, Last Available: "2025-12"
 12144	plastic skeleton rib cage of wisdom	0		Mysticality: +15, Last Available: "2025-12"
@@ -11911,7 +11911,7 @@
 12153	squat razor-sharp scorched skeleton pants of the brazier	0		Weapon Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2025-12"
 12154	messenger parrot egg	0		Last Available: "2025-12"
 12155	spinning buryable chest	0		Last Available: "2025-12"
-12156	jittery ghostly Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
+12156	ghostly jittery Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	spinning Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12158	ghostly Shanty: I'm Smarter Than a Drunken Sailor	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12159	mirror Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
@@ -11920,7 +11920,7 @@
 12162	Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	jittery Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
-12165	gray spinning Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
+12165	spinning gray Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12166	Crymbocurrency tattoo	0		Last Available: "2025-12"
 12167	jittery nippy careful fireproof bonesaw	0		Monster Level: -10, Cold Damage: +10, Last Available: "2025-12"
 12168	veiny thinker's vermiculite shield	0		Mysticality: +10, Maximum HP: +10, Damage Reduction: 9, Last Available: "2025-12"
@@ -11959,7 +11959,7 @@
 12201	therapeutic dinosaur bone club	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2026-03"
 12202	pulsating nippy dinosaur skull helmet of the brazier	0		Cold Damage: +10, Hot Spell Damage: +25, Last Available: "2026-03"
 12203	pulsating veiny quilted beefy dinosaur bone corset	0		Muscle: +10, Damage Absorption: +40, Maximum HP: +10, Last Available: "2026-03"
-12204	fancy weak tolerable Pork Elf cough syrup	2	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 20, Last Available: "2026-03"
+12204	tolerable weak fancy Pork Elf cough syrup	2	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 20, Last Available: "2026-03"
 12205	gray Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	upside-down Pork Elf sink	0		Last Available: "2026-03"
@@ -11973,35 +11973,35 @@
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	spoiled thick discarded hot dog	5	crappy	Last Available: "2026-04"
-12218	weak smooth gray most of a beer	2	awesome	Last Available: "2026-04"
+12218	smooth weak gray most of a beer	2	awesome	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	normal can of tuna	4	good	
 12227	rotten small green alien salad	2	crappy	
 12228	decent bouncing ratbatatouille	3	good	
-12229	half-sized rotten onigiri	2	crappy	
-12230	flavorless big crudit&eacute;s	5	decent	
+12229	rotten half-sized onigiri	2	crappy	
+12230	big flavorless crudit&eacute;s	5	decent	
 12231	massive tasty sauced mutton	6	awesome	
 12232	snack-sized rotten wobbly hot honey ant	2	crappy	
-12233	low-calorie stale blinking tomb aspic	1	decent	
+12233	stale low-calorie blinking tomb aspic	1	decent	
 12234	flavorless spinning skewed later tots	3	decent	
 12235	bland Frutti di Scatoletta	4	decent	Last Available: "2026-05"
-12236	huge spoiled Pesto alla Marziano	10	crappy	Last Available: "2026-05"
+12236	spoiled huge Pesto alla Marziano	10	crappy	Last Available: "2026-05"
 12237	huge spoiled mirror Arrattabbattabiata	7	crappy	Last Available: "2026-05"
 12238	stale Orzo di Riso	3	decent	Last Available: "2026-05"
 12239	spoiled ghostly Pasta Grimavera	4	crappy	Last Available: "2026-05"
 12240	normal Linguini Ubriacapa	3	good	Last Available: "2026-05"
 12241	rotten Formica e Pepe	3	crappy	Last Available: "2026-05"
 12242	half-sized stale Tubetto Gelatto	2	decent	Last Available: "2026-05"
-12243	snack-sized rotten fancy Gnocci Domani	2	crappy	Effect: "Bread Burps", Effect Duration: 45, Last Available: "2026-05"
+12243	rotten snack-sized fancy Gnocci Domani	2	crappy	Effect: "Bread Burps", Effect Duration: 45, Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	upside-down mega helmet	0		
 12252	pulsating lard-coated wizardly Space Soldier Helmet	0		Mysticality: +25, Sleaze Spell Damage: +25
 12253	tasty bite-sized premium turkey leg	1	awesome	
-12254	watered-down smooth fancy twirling styrofoam cup of mead	2	awesome	Effect: "Moon-Eyed", Effect Duration: 25
+12254	smooth fancy watered-down twirling styrofoam cup of mead	2	awesome	Effect: "Moon-Eyed", Effect Duration: 25
 12255	sword of the blizzard	0		Cold Spell Damage: +25
 12256	executive staff	0		Meat Drop: +40
 12257	ghostly savvy lute	0		Mysticality Percent: +20
@@ -12029,22 +12029,22 @@
 12279	galvanized banana quintessence	0		Effect: "Amorous Avarice", Effect Duration: 37, Last Available: "2026-07"
 12280	perfectly mixed Aesop Daiquiri	4	EPIC	Last Available: "2026-07"
 12281	practically non-alcoholic mediocre huge Monkey Congress	1	decent	Last Available: "2026-07"
-12282	special yummy low-calorie fuchsia watermelon pie	1	awesome	Effect: "The Smile of Mr. A.", Effect Duration: 50, Last Available: "2026-07"
+12282	special low-calorie yummy fuchsia watermelon pie	1	awesome	Effect: "The Smile of Mr. A.", Effect Duration: 50, Last Available: "2026-07"
 12283	dry blurry jittery concentrated watermelon juice	0		Effect: "Bilious Brawn", Effect Duration: 25, Last Available: "2026-07"
 12284	ionized activated pulsating Aqua Citrulanatae	0		Effect: "Mucilaginous Mentalism", Effect Duration: 23, Last Available: "2026-07"
 12285	artisanal Melonegroni	4	EPIC	Last Available: "2026-07"
-12286	extra-dry enchanted artisanal Melonade Spritz	5	EPIC	Effect: "You Can Really Taste the Dormouse", Effect Duration: 45, Last Available: "2026-07"
+12286	enchanted extra-dry artisanal Melonade Spritz	5	EPIC	Effect: "You Can Really Taste the Dormouse", Effect Duration: 45, Last Available: "2026-07"
 12287	small decent spinning quince pie	2	good	Last Available: "2026-07"
 12288	altered cyan quince quaff	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 35, Last Available: "2026-07"
 12289	adjusted colloidal blue Quickquince	0		Effect: "Chock Full o' Nanites", Effect Duration: 61, Last Available: "2026-07"
-12290	distilled drinkable Quiskey Sour	5	good	Last Available: "2026-07"
+12290	drinkable distilled Quiskey Sour	5	good	Last Available: "2026-07"
 12291	practically non-alcoholic tolerable Quincea&ntilde;era Cooler	1	good	Last Available: "2026-07"
-12292	triple-distilled acceptable pulsating blue shaking Roth IPA	7	good	Last Available: "2026-08"
+12292	acceptable triple-distilled pulsating shaking blue Roth IPA	7	good	Last Available: "2026-08"
 12293	underdraft protection of courage of the businessman	0		Spooky Resistance: +3, Meat Drop: +50, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	fancy bland soybean futures	4	decent	Effect: "Sensation", Effect Duration: 25, Last Available: "2026-08"
+12295	bland fancy soybean futures	4	decent	Effect: "Sensation", Effect Duration: 25, Last Available: "2026-08"
 12296	ionized housing bubble	0		Effect: "Quadrilled", Effect Duration: 57, Last Available: "2026-08"
-12297	unsweetened shaking skewed Pixie-Swordz	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
+12297	unsweetened skewed shaking Pixie-Swordz	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
 12298	skewed mirror stiffened sinister financial instrument	0		Spell Damage: +10, Damage Reduction: 1, Last Available: "2026-08"
 12299	squat quilted savvy hedge fund clippers	0		Mysticality Percent: +20, Damage Absorption: +40, Last Available: "2026-08"
 12300	selling shorts of Flo-Jo	0		Initiative: +100, Last Available: "2026-08"
@@ -12054,7 +12054,7 @@
 12304	balance sheet	0		Last Available: "2026-08"
 12305	activated invisible hand	0		Effect: "Danish Cunning", Effect Duration: 27, Last Available: "2026-08"
 12306	boiled bouncing circle of overdraft protection scroll	0		Effect: "Patent Avarice", Effect Duration: 20, Last Available: "2026-08"
-12307	magnetized ghostly bouncing mint	0		Effect: "Frog In Your Throat", Effect Duration: 13, Last Available: "2026-08"
+12307	magnetized bouncing ghostly mint	0		Effect: "Frog In Your Throat", Effect Duration: 13, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	blurry homeowner's loam	0		Last Available: "2026-08"
 12310	dehydrated toxic asset	1		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Platypus_cafe_booze.txt
@@ -1,5 +1,5 @@
 -1	mediocre Petite Porter	3	decent	
--2	triple-distilled bad gray Scrawny Stout	6	decent	
+-2	bad triple-distilled gray Scrawny Stout	6	decent	
 -3	enchanted mediocre jittery Infinitesimal IPA	3	decent	
 -4	drinkable eggnogtini	3	good	
 -5	tolerable candycaine	4	good	
@@ -7,11 +7,11 @@
 -16	perfectly mixed fermented honey	3	EPIC	
 -17	mediocre moons-shine	3	decent	
 -18	lousy gin	3	decent	
--19	drinkable practically non-alcoholic special upside-down ecto-nog	1	good	
+-19	special practically non-alcoholic drinkable upside-down ecto-nog	1	good	
 -20	bad practically non-alcoholic hot toady	1	decent	
 -21	lousy huge hot choculate	3	decent	
 -49	artisanal weak Cyder	2	EPIC	
--50	delicious watered-down spinning Oil Nog	2	awesome	
+-50	watered-down delicious spinning Oil Nog	2	awesome	
 -51	weak artisanal tumbling Hi-Octane Peppermint Jet Fuel	2	EPIC	
 -58	lousy Grimacider	4	decent	
 -59	lousy pulsating Isotope Nog	4	decent	
@@ -19,15 +19,15 @@
 -70	watered-down tolerable pulsating Gin and Herring	2	good	
 -71	lousy olive Black and Tan and Red All Over	4	decent	
 -72	watered-down lousy Antarctic Ice Tea	2	decent	
--76	tolerable distilled CRIMBCO Ribbon Candy Schnapps	5	good	
--77	weak bad CRIMBCO Egg Substitute Nog Substitute	2	decent	
--78	tolerable practically non-alcoholic CRIMBCO Extreme Braincracker Sour	1	good	
+-76	distilled tolerable CRIMBCO Ribbon Candy Schnapps	5	good	
+-77	bad weak CRIMBCO Egg Substitute Nog Substitute	2	decent	
+-78	practically non-alcoholic tolerable CRIMBCO Extreme Braincracker Sour	1	good	
 -82	perfectly mixed jittery Horseradish-infused Vodka	4	EPIC	
 -83	high-proof acceptable blurry Jerkitini	10	good	
 -84	bad tumbling Desert Island Iced Tea	3	decent	
 -88	perfectly mixed Crimbo Saketini	4	EPIC	
--89	perfectly mixed fancy irresponsibly strong Crimboku Drop	9	EPIC	
+-89	fancy perfectly mixed irresponsibly strong Crimboku Drop	9	EPIC	
 -90	triple-distilled drinkable Flaming Crimbo Log	7	good	
--107	delicious weak Fortified Eggnog Slurry	2	awesome	
+-107	weak delicious Fortified Eggnog Slurry	2	awesome	
 -108	acceptable twirling Hot Buttered Rum	3	good	
--109	watered-down mediocre Spicy Hot Chocolate	2	decent	
+-109	mediocre watered-down Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Platypus_cafe_food.txt
@@ -2,7 +2,7 @@
 -2	rotten huge gray As Jus Gezund Heit	6	crappy	
 -3	moldy jittery Bouillabaise Coucher Avec Moi	3	crappy	
 -7	delicious gumdrop chow mein	4	awesome	
--8	snack-sized yummy enchanted candy cane pizza	2	awesome	
+-8	enchanted yummy snack-sized candy cane pizza	2	awesome	
 -9	stale gingerbread stir-fry	4	decent	
 -10	bland jittery twigs and gravel	4	decent	
 -11	normal skewed shoots and leaves	4	good	
@@ -12,31 +12,31 @@
 -15	bland bouncing vampire cake	3	decent	
 -52	yummy upside-down Soylent Red and Green	3	awesome	
 -53	toothsome miniature Disc-Shaped Nutrition Unit	2	awesome	
--54	fancy spoiled thick Gingerborg Hive	5	crappy	
+-54	thick fancy spoiled Gingerborg Hive	5	crappy	
 -61	flavorless Candy Cane Surprise	3	decent	
 -62	bland narrow Grimdrop Chow Mein	3	decent	
 -63	decent Grimgerbread House	3	good	
 -67	normal Caviar Carbonara	3	good	
--68	tiny delicious green Halibut Alfredo	1	awesome	
+-68	delicious tiny green Halibut Alfredo	1	awesome	
 -69	jumbo rotten Red Herring Velvet Cake	5	crappy	
--73	normal massive CRIMBCO Reconstituted Gruel	7	good	
+-73	massive normal CRIMBCO Reconstituted Gruel	7	good	
 -74	gigantic adequate New and Improved CRIMBCO Reconstituted Gruel	8	good	
 -75	bland miniature green CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	2	decent	
 -79	moldy Brussels Sprout Stir-Fry	3	crappy	
 -80	adequate wobbly Carrot, Cabbage, and Kale Pizza	3	good	
 -81	yummy Turnip and Rutabaga Pie	3	awesome	
--85	rotten big bouncing Rainbow Spider Fun Roll	5	crappy	
+-85	big rotten bouncing Rainbow Spider Fun Roll	5	crappy	
 -86	moldy Vegas Volcano Lava Roll	3	crappy	
--87	delicious blinking ghostly Crazy Dragon Shogun Buddha Roll	4	awesome	
+-87	delicious ghostly blinking Crazy Dragon Shogun Buddha Roll	4	awesome	
 -92	decent squat basic hot dog	3	good	
--93	super-sized delicious pulsating savage macho dog	5	awesome	
--94	low-calorie tasty one with everything	1	awesome	
+-93	delicious super-sized pulsating savage macho dog	5	awesome	
+-94	tasty low-calorie one with everything	1	awesome	
 -95	normal sly dog	4	good	
--96	snack-sized rotten devil dog	2	crappy	
--97	miniature moldy chilly dog	2	crappy	
+-96	rotten snack-sized devil dog	2	crappy	
+-97	moldy miniature chilly dog	2	crappy	
 -98	bland ghost dog	4	decent	
 -99	adequate purple junkyard dog	3	good	
--100	normal enchanted small wet dog	2	good	
+-100	normal small enchanted wet dog	2	good	
 -101	moldy pulsating sleeping dog	4	crappy	
 -102	bland optimal dog	4	decent	
 -103	toothsome snack-sized video games hot dog	2	awesome	

--- a/data/TCRS/TCRS_Seal_Clubber_Vole.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Vole.txt
@@ -11,7 +11,7 @@
 11	stolen accordion	0		Song Duration: 5
 12	cyan blurry mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	compressed blinking moxie weed	1		Effect: "Fishily Speeding", Effect Duration: 40
-15	diluted blurry huge strongness elixir	1		Effect: "What's That Smell?", Effect Duration: 10
+15	diluted huge blurry strongness elixir	1		Effect: "What's That Smell?", Effect Duration: 10
 16	denatured maroon magicalness-in-a-can	1		Effect: "Vented Spleen", Effect Duration: 30
 17	jumbo moldy noodles	5	crappy	
 18	squat tortoise's blessing	0		
@@ -19,8 +19,8 @@
 20	pulsating Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
 22	studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
-23	pulsating twirling blue chewing gum on a string	0		
-24	squat skewed ten-leaf clover	0		
+23	twirling pulsating blue chewing gum on a string	0		
+24	skewed squat ten-leaf clover	0		
 25	meat paste	0		
 26	Dolphin King's map	0		
 27	spinning spider web	0		
@@ -37,7 +37,7 @@
 38	green Knob Goblin pants of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 5xPotato, cap 6"
 39	tumbling pretty flower	0		
 40	casino pass	0		
-41	fancy watered-down delicious ice-cold Sir Schlitz	2	awesome	Effect: "Protection from Bad Stuff", Effect Duration: 10
+41	watered-down delicious fancy ice-cold Sir Schlitz	2	awesome	Effect: "Protection from Bad Stuff", Effect Duration: 10
 42	upside-down blinking hermit permit	0		
 43	shaking gray worthless trinket	0		
 44	pulsating worthless gewgaw	0		
@@ -45,7 +45,7 @@
 46	blinking figurine	0		
 47	flavorless huge hot buttered roll	4	decent	
 48	heart of rock and roll	0		
-49	normal snack-sized bowl of cottage cheese	2	good	
+49	snack-sized normal bowl of cottage cheese	2	good	
 50	educational Rock and Roll Legend	0		Experience: +1, Class: "Accordion Thief", Song Duration: 10
 51	Knob Goblin Uberpants of doom	0		Spooky Spell Damage: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -57,7 +57,7 @@
 58	ghostly stone turtle	0		
 59	huge slingshot	0		
 60	Mace of the Tortoise of the scaredy-cat	0		Monster Level: -15, Class: "Turtle Tamer"
-61	moldy snack-sized blinking fortune cookie	2	crappy	
+61	snack-sized moldy blinking fortune cookie	2	crappy	
 62	resourceful oriole-feather headdress	0		Maximum MP: +50, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -70,14 +70,14 @@
 71	chilly stakes	0		Cold Damage: +5
 72	barskin hat of bravery	0		Spooky Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 13"
 73	barskin tent	0		
-74	twirling squat Temple map	0		
+74	squat twirling Temple map	0		
 75	wobbly sapling	0		
 76	Spooky-Gro fertilizer	0		
 77	spinning blurry nippy stick	0		Cold Damage: +10
 78	beefcake's pretty bouquet	0		Muscle: +25
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	tumbling fairy gravy boat	0		
-81	tolerable distilled ice-cold Willer	5	good	
+81	distilled tolerable ice-cold Willer	5	good	
 82	ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
@@ -100,7 +100,7 @@
 101	tumbling meat golem	0		
 102	shrunken head	0		
 103	squat lion tamer's rock-hard staff	0		Damage Reduction: 5, Experience (familiar): +2
-104	skewed ghostly scarecrow	0		
+104	ghostly skewed scarecrow	0		
 105	spoiled snack-sized bowl of charms	2	crappy	
 106	twirling ketchup	1	crappy	
 107	shaking catsup	1	awesome	
@@ -155,14 +155,14 @@
 156	twirling guild application	0		
 157	Dramatic&trade; range	0		
 158	Gnollish pie tin	0		
-159	ghostly jittery wad of dough	0		
+159	jittery ghostly wad of dough	0		
 160	pie crust	0		
 161	bland ghuol egg	3	decent	
 162	adequate squat ghuol egg quiche	3	good	
 163	fortified skeleton bone	0		Damage Absorption: +60
 164	smart skull	0		
 165	skewer	0		
-166	pulsating spinning ghuol ears	0		
+166	spinning pulsating ghuol ears	0		
 167	normal ghuol-ear kabob	4	good	
 168	ghostly teal bone rattle of James Dean	0		Experience (Moxie): +3
 169	upside-down bugbear beanie	0		Familiar Effect: "atk, cap 7"
@@ -185,7 +185,7 @@
 186	twirling shaking bean	0		
 187	loose teeth	0		
 188	bat guano	0		
-189	gray wobbly guano coffee cup	0		
+189	wobbly gray guano coffee cup	0		
 191	squat Da Vinci's batskin belt	0		Experience (Mysticality): +5
 192	twirling batskin belt	0		
 193	birthday candle	0		
@@ -196,13 +196,13 @@
 198	shaking rat appendix	0		
 199	purple ring of Gandalf	0		Spell Critical Percent: +20
 200	delicious rat appendix kabob	3	awesome	
-201	gigantic flavorless bat wing kabob	7	decent	
+201	flavorless gigantic bat wing kabob	7	decent	
 202	bland skewed carob chunks	4	decent	
 203	ghostly herbs	0		
 204	tiny bland carob chunk cookies	1	decent	
 205	huge secret blend of herbs and spices	0		
 206	piercing post	0		
-207	fancy olive narrow hippy herbal tea	1	crappy	Effect: "Healthy Red Glow", Effect Duration: 5
+207	fancy narrow olive hippy herbal tea	1	crappy	Effect: "Healthy Red Glow", Effect Duration: 5
 208	fuchsia patchouli incense stick	0		
 209	wad of tofu	0		
 210	jittery Feng Shui for Big Dumb Idiots	0		
@@ -210,17 +210,17 @@
 212	mirror windchimes	0		
 213	gray fireproof flame-wreathed filthy corduroys	0		Hot Spell Damage: +10, Hot Resistance: +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	purple Jack Frost's filthy knitted dread sack	0		Cold Spell Damage: +50, Familiar Effect: "1xVolley, 1xPotato, cap 15"
-215	bouncing shaking Uncle Jick's Brownie Mix	0		
+215	shaking bouncing Uncle Jick's Brownie Mix	0		
 216	adequate carob brownies	4	good	
 217	normal skewed maroon herb brownies	3	good	
 218	hemp string	0		
-219	shaking narrow necklace chain	0		
+219	narrow shaking necklace chain	0		
 220	gnoll teeth	0		
 221	frightening gnoll-tooth necklace	0		Spooky Damage: +5
 222	phat turquoise bead	0		
 223	thinker's phat turquoise bracelet	0		Mysticality: +10
 224	censurious eyepatch	0		Sleaze Resistance: +3, Familiar Effect: "3xBarrr, cap 6"
-225	gigantic stale pulsating blinking tofu casserole	10	decent	
+225	stale gigantic pulsating blinking tofu casserole	10	decent	
 226	distilled blurry can of Red Minotaur	1	decent	
 227	skewed mirror shaking Annie Oakley's Kentucky-fried meat sword	0		Critical Hit Percent: +20
 228	Kentucky-fried meat staff of James Dean	0		Experience (Moxie): +3
@@ -241,22 +241,22 @@
 243	flavorless blue grapefruit	4	decent	
 244	flavorless twirling grapes	3	decent	
 245	normal olive	3	good	
-246	flavorless half-sized wobbly tomato	2	decent	
+246	half-sized flavorless wobbly tomato	2	decent	
 247	cyan fermenting powder	0		
-248	watered-down lousy blinking squat salty dog	2	decent	
+248	lousy watered-down blinking squat salty dog	2	decent	
 249	acceptable bloody mary	3	good	
 250	acceptable screwdriver	4	good	
-251	lousy fancy martini	3	decent	Effect: "Meadulla Oblongota", Effect Duration: 30
+251	fancy lousy martini	3	decent	Effect: "Meadulla Oblongota", Effect Duration: 30
 252	lousy weak bloody beer	2	decent	
 253	tolerable huge shot of schnapps	3	good	
 254	artisanal shot of grapefruit schnapps	3	EPIC	
 255	lousy huge fine wine	4	decent	
 256	lousy pulsating shot of tomato schnapps	3	decent	
-257	mediocre high-proof extra-spicy bloody mary	9	decent	
+257	high-proof mediocre extra-spicy bloody mary	9	decent	
 258	dense meat stack	0		
 259	snake skin	0		
 260	spoiled ghostly White Citadel fries	3	crappy	
-261	half-sized flavorless White Citadel burger	2	decent	
+261	flavorless half-sized White Citadel burger	2	decent	
 262	flavorless piece of wedding cake	3	decent	
 263	stale chocolate chips	4	decent	
 264	normal chocolate chip cookies	3	good	
@@ -268,7 +268,7 @@
 270	spinning picket fence	0		
 271	twisted barbell	1		
 272	twisted jittery concentrated magicalness pill	1		
-273	dried fuchsia narrow moxie weed	1		
+273	dried narrow fuchsia moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	jittery mosquito larva	0		
 276	leprechaun hatchling	0		
@@ -297,7 +297,7 @@
 299	irradiated energized shaking blue pickle-flavored chewing gum	0		Effect: "Be a Mind Master", Effect Duration: 35
 300	pickled vacuum-sealed jittery jaba&ntilde;ero-flavored chewing gum	0		Effect: "Adventurer's Best Friendship", Effect Duration: 13
 301	flat dough	0		
-302	super-sized toothsome Knob sausage	5	awesome	
+302	toothsome super-sized Knob sausage	5	awesome	
 303	snack-sized decent upside-down Knob mushroom	2	good	
 304	cyan dry noodles	0		
 305	Sinatra's Knob Goblin harem pants	0		Experience (Moxie): +5, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
@@ -310,17 +310,17 @@
 312	toasty Knob Goblin visor	0		Hot Damage: +5, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	hardy Crown of the Goblin King	0		Maximum HP: +50, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	spoiled bean burrito	3	crappy	
-315	snack-sized delicious bean burrito	2	awesome	
-316	diet stale insanely bean burrito	1	decent	
+315	delicious snack-sized bean burrito	2	awesome	
+316	stale diet insanely bean burrito	1	decent	
 317	small spoiled lime green bean burrito	2	crappy	
-318	super-sized stale bean burrito	5	decent	
+318	stale super-sized bean burrito	5	decent	
 319	moldy insanely bean burrito	3	crappy	
-320	decent half-sized bat haggis	2	good	
+320	half-sized decent bat haggis	2	good	
 321	stale spinning menudo	4	decent	
 322	rotten goat cheese	4	crappy	
 323	spoiled plain pizza	3	crappy	
 324	delicious half-sized sausage pizza	2	awesome	
-325	spoiled bite-sized goat cheese pizza	1	crappy	
+325	bite-sized spoiled goat cheese pizza	1	crappy	
 326	bland mushroom pizza	4	decent	
 327	goat	0		
 328	perfectly mixed bottle of whiskey	3	EPIC	
@@ -348,7 +348,7 @@
 350	hot katana blade	0		
 351	Sinatra's icy-hot katana of chilblains	0		Experience (Moxie): +5, Cold Damage: +25
 352	ninja hot pants of the glutton	0		Food Drop: +100, Familiar Effect: "hot atk, 3xPotato, cap 17"
-353	lime green wobbly ninja stars	0		
+353	wobbly lime green ninja stars	0		
 354	purple twirling nunchaku of the bloodbag of Flo-Jo	0		Maximum HP: +100, Initiative: +100
 355	smooth eXtreme scarf	0		Moxie: +15, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	supercool snowboarder pants	0		Moxie Percent: +20, Familiar Effect: "1xPotato, cap 25"
@@ -450,7 +450,7 @@
 452	pulsating disease	0		
 453	sober pill	0		
 454	screwdriver	0		
-455	bite-sized decent jumbo olive	1	good	
+455	decent bite-sized jumbo olive	1	good	
 456	drinkable dry martini	4	good	
 457	grievous ye olde golde frontes	0		Weapon Damage Percent: +50, Class: "Disco Bandit", Single Equip
 458	twirling continuum transfunctioner	0		
@@ -462,11 +462,11 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
-467	moldy enchanted pixel pie	3	crappy	Effect: "Coy to the Hurled", Effect Duration: 35
+467	enchanted moldy pixel pie	3	crappy	Effect: "Coy to the Hurled", Effect Duration: 35
 468	ruby W	0		
 469	skewed wussiness potion	0		
-470	high-proof fancy lousy bouncing Imp Ale	8	decent	Effect: "Tiki Temerity", Effect Duration: 10
-471	rotten jumbo hot wing	5	crappy	
+470	fancy high-proof lousy bouncing Imp Ale	8	decent	Effect: "Tiki Temerity", Effect Duration: 10
+471	jumbo rotten hot wing	5	crappy	
 472	bouncing blue diamond-studded cane of courage	0		Spooky Resistance: +3, Class: "Disco Bandit"
 473	crutch of the glutton	0		Food Drop: +100
 474	cast	0		
@@ -491,14 +491,14 @@
 493	ghostly ketchup hound	0		
 494	coward's batblade	0		Monster Level: -20
 495	gray catgut	0		
-496	jittery squat cat appendix	0		
+496	squat jittery cat appendix	0		
 497	gnatwing	0		
 498	stale papaya	3	decent	
 499	huge maroon denim axe of the brazier of the sewer	0		Hot Spell Damage: +25, Stench Damage: +25
 500	blurry Elf Farm Raffle ticket	0		
 501	spoiled Elfin shortbread	4	crappy	
 502	twirling pagoda plans	0		
-503	tiny normal squat wobbly skewered cat appendix	1	good	
+503	normal tiny squat wobbly skewered cat appendix	1	good	
 504	jittery evil arches	0		
 505	Oprah's energetic gnatwing earring	0		Maximum MP Percent: 70
 506	yummy squat Hell broth	3	awesome	
@@ -510,7 +510,7 @@
 512	Sneaky Pete's key lime	0		
 513	rotten squat Boris's key lime pie	3	crappy	
 514	stale Jarlsberg's key lime pie	3	decent	
-515	massive rotten upside-down Sneaky Pete's key lime pie	6	crappy	
+515	rotten massive upside-down Sneaky Pete's key lime pie	6	crappy	
 516	Hey Deze map	0		
 517	bejeweled accordion strap of horror	0		Spooky Spell Damage: +25, Class: "Accordion Thief"
 518	blinking mystery juice	0		
@@ -521,10 +521,10 @@
 523	rewinged stab bat	0		
 524	hand-crafted upside-down papaya sling	3	EPIC	
 525	grue egg	0		
-526	green jittery Frobozz Real-Estate Company Instant House (TM)	0		
+526	jittery green Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
 528	bouncing blood-faced volleyball	0		
-529	blinking jittery fertilized ghuol egg	0		
+529	jittery blinking fertilized ghuol egg	0		
 530	galvanized denatured spray paint	0		Effect: "Lobos Fresh", Effect Duration: 16
 531	fortified special sauce glove	0		Damage Absorption: +60, Class: "Sauceror", Single Equip
 532	olive ladle of mystery of dire peril	0		Weapon Damage: +20, Class: "Sauceror"
@@ -568,10 +568,10 @@
 570	normal Chicken Sandwich	3	good	
 571	Jumbo Dr. Lucifer	1	good	
 572	bland Children's Meal of the Damned	3	decent	
-573	small rotten wobbly noodles	2	crappy	
+573	rotten small wobbly noodles	2	crappy	
 574	normal noodles	3	good	
-575	enchanted moldy jittery painful penne pasta	3	crappy	Effect: "Neutered Nostrils", Effect Duration: 15
-576	small toothsome ravioli della hippy	2	awesome	
+575	moldy enchanted jittery painful penne pasta	3	crappy	Effect: "Neutered Nostrils", Effect Duration: 15
+576	toothsome small ravioli della hippy	2	awesome	
 577	normal blinking pr0n m4nic0tti	3	good	
 578	decent Hell ramen	3	good	
 579	moldy boring spaghetti	4	crappy	
@@ -584,8 +584,8 @@
 586	chilly Rosewater's ridiculously huge sword	0		Mysticality Percent: +30, Cold Damage: +5
 587	wet super-spiky hair gel	0		Effect: "Inner Warmth", Effect Duration: 17
 588	maroon soft echo eyedrop antidote	0		
-589	huge spoiled upside-down cocoa eggshell fragment	9	crappy	
-590	adequate enchanted cyan cocoa eggshell fragment	4	good	Effect: "Fungal Flambé", Effect Duration: 5
+589	spoiled huge upside-down cocoa eggshell fragment	9	crappy	
+590	enchanted adequate cyan cocoa eggshell fragment	4	good	Effect: "Fungal Flambé", Effect Duration: 5
 591	pulsating cocoa egg	0		
 592	house	0		
 593	narrow phonics down	0		
@@ -606,7 +606,7 @@
 608	Plastic Wrap Immateria	0		
 609	S.O.C.K.	0		
 610	gray procrastination potion	0		
-611	shaking upside-down D	0		
+611	upside-down shaking D	0		
 612	original G	0		
 613	plot hole	0		
 614	magnetized liquefied huge probability potion	0		Effect: "World's Shortest Giant", Effect Duration: 41
@@ -634,9 +634,9 @@
 636	gray meat globe	0		
 637	toaster	0		
 638	dog trainer's resourceful asshat	0		Maximum MP: +50, Experience (familiar): +1, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	special decent abominable snowcone	3	good	Effect: "White Knuckles", Effect Duration: 5
+639	decent special abominable snowcone	3	good	Effect: "White Knuckles", Effect Duration: 5
 640	Ent cider	1	good	
-641	miniature flavorless toast	2	decent	
+641	flavorless miniature toast	2	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
@@ -651,7 +651,7 @@
 653	jittery intragalactic rowboat	0		
 654	star	0		
 655	line	0		
-656	wobbly squat star chart	0		
+656	squat wobbly star chart	0		
 657	weightlifter's star sword	0		Muscle: +15
 658	double-paned star crossbow	0		Cold Resistance: +5
 659	star staff of James Dean	0		Experience (Moxie): +3
@@ -669,20 +669,20 @@
 671	squat jittery razor-sharp grave robbing shovel of vim and vigor	0		Weapon Damage Percent: +25, Maximum HP Percent: +50
 672	normal ghostly cranberries	4	good	
 673	drinkable vodka and cranberry	3	good	
-674	weak hand-crafted whiskey	2	EPIC	
+674	hand-crafted weak whiskey	2	EPIC	
 675	perfumed skull of the Bonerdagon	0		Stench Resistance: +5
 676	twirling dragonbone belt buckle	0		
 677	tumbling censurious badass belt	0		Sleaze Resistance: +3
-678	jittery tumbling chest of the Bonerdagon	0		
-679	practically non-alcoholic drinkable roll in the hay	1	good	
+678	tumbling jittery chest of the Bonerdagon	0		
+679	drinkable practically non-alcoholic roll in the hay	1	good	
 680	acceptable skewed slap and tickle	3	good	
 681	delicious weak slip 'n' slide	2	awesome	
-682	distilled enchanted acceptable skewed a sump'm sump'm	5	good	Effect: "Fortunate Resolve", Effect Duration: 5
+682	enchanted distilled acceptable skewed a sump'm sump'm	5	good	Effect: "Fortunate Resolve", Effect Duration: 5
 683	aged horizontal tango	4	awesome	
 684	delicious pink pony	3	awesome	
 685	jittery hale educational Mr. Shirt of Flo-Jo	0		Experience: +1, Maximum HP: +20, Initiative: +100
 686	twirling Jack Frost's knuckles	0		Cold Spell Damage: +50
-687	cold-filtered wet fuchsia shaking blood of the Wereseal	0		Effect: "Hairless and Airless", Effect Duration: 12
+687	cold-filtered wet shaking fuchsia blood of the Wereseal	0		Effect: "Hairless and Airless", Effect Duration: 12
 688	pixel hat of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, 2xVolley, cap 12"
 689	blinking purple gravedigger's pixel pants	0		Spooky Damage: +10, Familiar Effect: "atk, 4xPotato, cap 12"
 690	mirror gray coward's pixel sword	0		Monster Level: -20
@@ -731,30 +731,30 @@
 735	hardened easter egg balloon	0		Damage Reduction: 3
 736	mirror stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	upside-down teal stone tablet (Really Evil Rhythm)	0		
+738	teal upside-down stone tablet (Really Evil Rhythm)	0		
 739	narrow tambourine bells	0		
 740	huge flame-retardant tambourine	0		Hot Resistance: +1
 741	broken skull	0		
 742	bite-sized spoiled Knoll shroomkabob	1	crappy	
 743	super-sized flavorless mushroom	5	decent	
 744	frozen non-alkaline huge hair spray	0		Effect: "Liquidy Smoky", Effect Duration: 64
-746	blinking upside-down stat script	0		
+746	upside-down blinking stat script	0		
 747	narrow wobbly Knob Goblin firecracker	0		
 748	blinking gourd potion	0		
 749	special normal bouncing warm mushroom	4	good	Effect: "Meadulla Oblongota", Effect Duration: 10
-750	bland miniature yellow mushroom quesadilla	2	decent	
+750	miniature bland yellow mushroom quesadilla	2	decent	
 751	decent blinking cool mushroom	3	good	
 752	normal pulsating cool mushroom casserole	4	good	
 753	spoiled pointy mushroom	4	crappy	
 754	flavorless wobbly cream of pointy mushroom soup	4	decent	
-755	flavorless diet narrow mushroom	1	decent	
+755	diet flavorless narrow mushroom	1	decent	
 756	snack-sized flavorless mushroom	2	decent	
-757	bland massive mushroom	10	decent	
+757	massive bland mushroom	10	decent	
 758	normal purple ghost cucumber	4	good	
 759	dill	0		
 760	twirling vinegar	0		
 761	squat brine	0		
-762	practically non-alcoholic drinkable especially salty dog	1	good	
+762	drinkable practically non-alcoholic especially salty dog	1	good	
 763	ghostly pickling solution	0		
 764	big yummy spectral pickle	5	awesome	
 765	briny vinegar	0		
@@ -763,7 +763,7 @@
 768	extremely unsafe spork	0		Weapon Damage Percent: +100
 769	voodoo doll of wisdom	0		Mysticality: +15
 770	purple careful padded basic meat fez	0		Damage Absorption: +20, Monster Level: -10, Familiar Effect: "3xLep, cap 11"
-771	huge wobbly shaking lime green tassel	0		
+771	wobbly huge shaking lime green tassel	0		
 772	narrow Temple Grandin's foon	0		Familiar Weight: +7
 773	wobbly zippy Jack Frost's basic meat spork	0		Cold Spell Damage: +50, Initiative: +20
 774	resourceful rock-hard basic meat foon	0		Damage Reduction: 5, Maximum MP: +50
@@ -790,8 +790,8 @@
 795	drinkable watered-down Acque Luride Grezze Cabernet	2	good	Last Available: "2004-10"
 796	upside-down Jeselnik's savvy cement shoes of the early riser	0		Mysticality Percent: +20, Sleaze Damage: +25, Adventures: +7, Last Available: "2004-10"
 797	drinkable rockin' wagon	4	good	
-798	fancy tolerable blurry ocean motion	3	good	Effect: "Crimbo Epiphany", Effect Duration: 20
-799	acceptable watered-down fuzzbump	2	good	
+798	tolerable fancy blurry ocean motion	3	good	Effect: "Crimbo Epiphany", Effect Duration: 20
+799	watered-down acceptable fuzzbump	2	good	
 800	half-sized delicious blue mirror poutine	2	awesome	
 801	bite-sized rotten Knob stir-fry	1	crappy	
 804	jumbo adequate bouncing Knoll stir-fry	5	good	
@@ -800,14 +800,14 @@
 807	moldy jittery olive stir-fry	4	crappy	
 808	enchanted toothsome Knob sausage stir-fry	4	awesome	Effect: "Chilblains of the Corn", Effect Duration: 25
 809	decent bat wing stir-fry	3	good	
-810	normal diet wobbly rat appendix stir-fry	1	good	
-811	tasty lime green blinking tofu stir-fry	4	awesome	
+810	diet normal wobbly rat appendix stir-fry	1	good	
+811	tasty blinking lime green tofu stir-fry	4	awesome	
 812	spoiled pr0n stir-fry	4	crappy	
 813	miniature rotten Knob shells	2	crappy	
 814	flavorless b&auml;tzle	4	decent	
 815	moldy ratini	3	crappy	
 816	flavorless tiny Knob stroganoff	1	decent	
-817	bland gigantic menudo ravioli	6	decent	
+817	gigantic bland menudo ravioli	6	decent	
 818	blurry plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
@@ -837,13 +837,13 @@
 844	perfectly mixed skewed papaya slung	3	EPIC	
 845	fireproof MAHI fez	0		Hot Resistance: +3, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
-848	tumbling cyan tumbling hypodermic needle	0		Familiar Weight: +5
+848	tumbling tumbling cyan hypodermic needle	0		Familiar Weight: +5
 849	upside-down Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
 851	prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
-853	mirror red blundarrrbus	0		Familiar Weight: +5
-854	maroon huge sucky decal	0		Familiar Weight: +5
+853	red mirror blundarrrbus	0		Familiar Weight: +5
+854	huge maroon sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
 857	jittery mirror moonglasses	0		
@@ -862,12 +862,12 @@
 871	meatcar model	0		Familiar Weight: +5
 872	Time Juice	0		Last Available: "2004-01"
 873	twirling rolling pin	0		
-874	blinking pulsating unrolling pin	0		
+874	pulsating blinking unrolling pin	0		
 875	perfumed gravedigger's beefy crazy bastard sword	0		Muscle: +10, Spooky Damage: +10, Stench Resistance: +5
 876	teal forbidden brainy incredibly dense meat gem of the businessman	0		Mysticality: +5, Spell Damage Percent: +50, Meat Drop: +50
 877	energetic Talisman of Baio	0		Maximum MP Percent: +20
 878	baleful hypnodisk	0		Spell Damage: +25
-879	vacuum-sealed bouncing lime green bottle of goofballs	0		Effect: "Cotton Mouthed", Effect Duration: 36
+879	vacuum-sealed lime green bouncing bottle of goofballs	0		Effect: "Cotton Mouthed", Effect Duration: 36
 880	toasty disbelief suspenders	0		Hot Damage: +5
 881	cool supportive bra	0		Moxie: +5
 882	Blatantly Canadian	0		
@@ -881,7 +881,7 @@
 890	tasty balaclava baklava	4	awesome	
 891	Warehouse 23 bling of the sweet-tooth	0		Candy Drop: +100
 892	jittery blurry bouncing stanky bugbear-smiting sword of the ox of bravery	0		Muscle: +20, Stench Spell Damage: +25, Spooky Resistance: +5
-893	acceptable fancy irresponsibly strong jittery lumbering jack	10	good	Effect: "Stands Alone", Effect Duration: 10
+893	irresponsibly strong fancy acceptable jittery lumbering jack	10	good	Effect: "Stands Alone", Effect Duration: 10
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	frosty Ms. Accessory	0		Cold Spell Damage: +10, Softcore Only
 896	huge Sherlock's baleful Mr. Accessory Jr.	0		Spell Damage: +25, Item Drop: +25, Softcore Only
@@ -898,7 +898,7 @@
 907	magnetized twirling Mr. Mediocrebar	0		Effect: "Chalky Hand", Effect Duration: 17
 908	magnetized Cold Hots candy	0		Effect: "Sticks and Stones", Effect Duration: 41
 909	nitrogenated Wint-O-Fresh mint	0		Effect: "Incensed", Effect Duration: 36
-910	jumbo adequate tumbling dwarf bread	5	good	
+910	adequate jumbo tumbling dwarf bread	5	good	
 911	activated improved aerosolized Senior Mints	0		Effect: "Jawin'", Effect Duration: 61
 912	quantum oxidized pulsating pixellated candy heart	0		Effect: "Dirty Pear", Effect Duration: 64
 913	super-irradiated boiled jittery kobold	0		Effect: "Glittering Eyelashes", Effect Duration: 53
@@ -915,10 +915,10 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	irradiated mirror Hawking's Elixir of Brilliance	0		Effect: "Natural 20", Effect Duration: 27
-927	aged spirit-forward Ferita Del Petto Zinfandel	5	awesome	Last Available: "2006-12"
+927	spirit-forward aged Ferita Del Petto Zinfandel	5	awesome	Last Available: "2006-12"
 928	healthy fuzzy bracelets	0		Maximum HP Percent: +20
 929	mirror Oprah's arse-shooting crossbow	0		Maximum MP Percent: +50
-931	lousy triple-distilled spiced rum	8	decent	
+931	triple-distilled lousy spiced rum	8	decent	
 932	aged weak eggnog	2	awesome	
 933	adequate shaking candy cane	3	good	
 934	diet bland mirror gingerbread bugbear	1	decent	
@@ -937,14 +937,14 @@
 947	green skewered cherry	0		Last Available: "2004-12"
 948	aged martini	4	awesome	Last Available: "2004-12"
 949	perfectly mixed shaking fuchsia grogtini	3	super ultra EPIC	Last Available: "2004-12"
-950	tolerable enchanted cherry bomb	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 50, Last Available: "2004-12"
+950	enchanted tolerable cherry bomb	3	good	Effect: "Slightly Larger Than Usual", Effect Duration: 50, Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	energetic fortified hockey mask	0		Damage Absorption: +60, Maximum MP Percent: +20, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	red orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	cyan weightlifter's fez of etymology	0		Muscle: +15, Familiar Effect: "1xLep, cap 30"
 956	adequate upside-down carob chunk noodles	3	good	
-957	snack-sized yummy chorizo brownies	2	awesome	
+957	yummy snack-sized chorizo brownies	2	awesome	
 958	flavorless massive pulsating chocolate and tomato pizza	9	decent	
 959	bouncing flange	0		
 960	blue clockwork key	0		
@@ -989,30 +989,30 @@
 1002	gray Xlyinia's notebook of the bloodbag	0		Maximum HP: +100
 1003	soda water	0		
 1004	mediocre bottle of tequila	4	decent	
-1005	fancy delicious practically non-alcoholic blinking boxed wine	1	awesome	Effect: "Weepy, Creepy", Effect Duration: 30
+1005	delicious practically non-alcoholic fancy blinking boxed wine	1	awesome	Effect: "Weepy, Creepy", Effect Duration: 30
 1006	toothsome cherry	4	awesome	
 1007	teal brainy coconut shell	0		Mysticality: +5, Familiar Effect: "1xFairy, cap 7"
 1008	Usain Bolt's ice cubes	0		Initiative: +80
 1009	hand-crafted pulsating vodka martini	3	EPIC	
 1010	lousy whiskey and soda	3	decent	
 1011	acceptable special monkey wrench	3	good	Effect: "Spooky Hands", Effect Duration: 5
-1012	enchanted aged tequila sunrise	3	awesome	Effect: "Crud&eacute;", Effect Duration: 20
-1013	tolerable special practically non-alcoholic shaking margarita	1	good	Effect: "Physicali Tea", Effect Duration: 20
+1012	aged enchanted tequila sunrise	3	awesome	Effect: "Crud&eacute;", Effect Duration: 20
+1013	tolerable practically non-alcoholic special shaking margarita	1	good	Effect: "Physicali Tea", Effect Duration: 20
 1014	artisanal strawberry wine	4	EPIC	
 1015	hand-crafted wine spritzer	4	EPIC	
 1016	artisanal perpendicular hula	4	EPIC	
-1017	strong acceptable ducha de oro	5	good	
+1017	acceptable strong ducha de oro	5	good	
 1018	bad maroon calle de miel	3	decent	
-1019	enchanted aged dry vodka martini	3	awesome	Effect: "Fortunate Resolve", Effect Duration: 40
+1019	aged enchanted dry vodka martini	3	awesome	Effect: "Fortunate Resolve", Effect Duration: 40
 1020	tolerable enchanted watered-down old-fashioned	2	good	Effect: "Mistified", Effect Duration: 10
-1021	distilled acceptable tequila with training wheels	5	good	
+1021	acceptable distilled tequila with training wheels	5	good	
 1022	tolerable sangria	4	good	
-1023	smooth triple-distilled vesper	7	awesome	Last Available: "2004-12"
-1024	acceptable watered-down bouncing bodyslam	2	good	Last Available: "2004-12"
+1023	triple-distilled smooth vesper	7	awesome	Last Available: "2004-12"
+1024	watered-down acceptable bouncing bodyslam	2	good	Last Available: "2004-12"
 1025	lousy sangria del diablo	3	decent	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	yellow whip kit	0		
-1028	fuchsia bouncing buckler buckle	0		
+1028	bouncing fuchsia buckler buckle	0		
 1029	coward's hippo whip	0		Monster Level: -20
 1030	cyan upside-down avaricious penguin whip	0		Meat Drop: +30
 1031	skewed fireproof yak whip	0		Hot Resistance: +3
@@ -1022,7 +1022,7 @@
 1035	avaricious penguin skin buckler	0		Meat Drop: +30, Damage Reduction: 5
 1036	lion tamer's yakskin buckler	0		Experience (familiar): +2, Damage Reduction: 5
 1037	gnauga hide buckler of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 5
-1038	triple-warmed double-corrupted irradiated blinking wobbly Connery's Elixir of Audacity	0		Effect: "Strange Mental Acuity", Effect Duration: 17
+1038	triple-warmed double-corrupted irradiated wobbly blinking Connery's Elixir of Audacity	0		Effect: "Strange Mental Acuity", Effect Duration: 17
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	acceptable jittery teal beer	3	good	
 1042	ghostly ghostly double-paned string of beads	0		Cold Resistance: +5
@@ -1030,7 +1030,7 @@
 1044	string of beads of horror	0		Spooky Spell Damage: +25
 1045	aromatic plastic bottle opener	0		Stench Resistance: +1
 1046	therapeutic educational traffic cone	0		Experience: +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	boozy bad gray shaking N. O. Beer	5	decent	
+1047	bad boozy gray shaking N. O. Beer	5	decent	
 1048	vaporized spinning oyster egg	1		Effect: "Red Misty-Eyed", Effect Duration: 30
 1049	mixed bouncing shaking oyster egg	1		
 1050	modified oyster egg	1		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 10
@@ -1051,7 +1051,7 @@
 1065	modified wobbly purple oyster egg	1		
 1066	mixed oyster egg	1		Effect: "Meatwise", Effect Duration: 30
 1067	plastic oyster egg	0		
-1068	denatured red upside-down oyster egg	1		
+1068	denatured upside-down red oyster egg	1		
 1069	distilled oyster egg	1		
 1070	dehydrated oyster egg	1		Effect: "Adrenaline Rush", Effect Duration: 50
 1071	plastic oyster egg	0		
@@ -1062,7 +1062,7 @@
 1076	twisted oyster egg	1		
 1077	compressed blue oyster egg	1		
 1078	diluted narrow oyster egg	1		Effect: "Be a Mind Master", Effect Duration: 35
-1079	spinning mirror plastic oyster egg	0		
+1079	mirror spinning plastic oyster egg	0		
 1080	oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -1076,7 +1076,7 @@
 1090	clockwork rings	0		
 1091	clockwork claws	0		
 1092	cyan clockwork sheet	0		
-1093	skewed mirror clockwork counterclockwise dome	0		
+1093	mirror skewed clockwork counterclockwise dome	0		
 1094	purple clockwork sphere	0		
 1095	twirling deactivated MicroMechaMech	0		
 1096	upside-down clockwork endoskeleton	0		
@@ -1113,7 +1113,7 @@
 1127	ninja sword of Gandalf	0		Spell Critical Percent: +20
 1128	teeny-tiny ninja stars	0		
 1129	stiffened sequined fez	0		Damage Reduction: 1, Familiar Effect: "1.75xLep, cap 20"
-1130	bouncing blue blank card	0		
+1130	blue bouncing blank card	0		
 1131	beet	0		Last Available: "2005-12"
 1132	Totally Gay Claymore	0		
 1133	star shirt of Flo-Jo	0		Initiative: +100
@@ -1126,13 +1126,13 @@
 1140	hand-crafted icy mushroom wine	3	EPIC	
 1141	perfectly mixed mushroom wine	4	EPIC	
 1142	bad pointy mushroom wine	4	decent	
-1143	perfectly mixed irresponsibly strong flat mushroom wine	7	EPIC	
+1143	irresponsibly strong perfectly mixed flat mushroom wine	7	EPIC	
 1144	acceptable distilled maroon cool mushroom wine	5	good	
 1145	smooth spinning knob mushroom wine	3	awesome	
 1146	acceptable knoll mushroom wine	3	good	
 1147	practically non-alcoholic aged mushroom wine	1	awesome	
-1148	aged special weak shot of flower schnapps	2	awesome	Effect: "Rad-ish", Effect Duration: 45
-1149	flavorless miniature skewed flower petal pie	2	decent	
+1148	weak special aged shot of flower schnapps	2	awesome	Effect: "Rad-ish", Effect Duration: 45
+1149	miniature flavorless skewed flower petal pie	2	decent	
 1150	perfectly mixed bottle of single-barrel whiskey	4	EPIC	
 1151	rosewater-soaked discarded plastic fork of Gandalf	0		Spell Critical Percent: +20, Stench Resistance: +3
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1145,14 +1145,14 @@
 1160	ghostly lard-coated irate sombrero	0		Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	blurry pile of candy	0		
 1162	irradiated flattened spinning handsomeness potion	0		Effect: "Simulation Stimulation", Effect Duration: 68
-1163	improved fuchsia huge marzipan skull	0		Effect: "Cotton Mouthed", Effect Duration: 36
+1163	improved huge fuchsia marzipan skull	0		Effect: "Cotton Mouthed", Effect Duration: 36
 1164	tumbling poultrygeist	0		
 1165	huge hovering sombrero	0		
 1166	maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
 1168	tumbling less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
-1170	pulsating fuchsia chocolate box	0		
+1170	fuchsia pulsating chocolate box	0		
 1171	mirror coffin	0		
 1172	asbestos box	0		
 1173	linoleum box	0		
@@ -1182,11 +1182,11 @@
 1197	teal Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
-1200	yummy massive mugcake	7	awesome	
+1200	massive yummy mugcake	7	awesome	
 1201	flavorless urinal cake	3	decent	
 1202	normal miniature yellow Happy Birthday, Claude! cake	2	good	
 1203	bland personalized birthday cake	4	decent	
-1204	decent miniature three-tiered wedding cake	2	good	
+1204	miniature decent three-tiered wedding cake	2	good	
 1205	miniature adequate babycakes	2	good	
 1206	adequate velvet cake	3	good	
 1207	toothsome mirror congratulatory cake	4	awesome	
@@ -1235,8 +1235,8 @@
 1251	tiny flavorless Knob shroomkabob	1	decent	
 1252	rotten massive shroomkabob	8	crappy	
 1253	pile of jumping beans	0		
-1254	spoiled purple mirror jumping bean burrito	3	crappy	
-1255	toothsome big jumping bean burrito	5	awesome	
+1254	spoiled mirror purple jumping bean burrito	3	crappy	
+1255	big toothsome jumping bean burrito	5	awesome	
 1256	tasty fancy huge insanely jumping bean burrito	4	awesome	Effect: "It's Electric!", Effect Duration: 25
 1257	flavorless thick rat scrapple	5	decent	
 1258	gray upside-down pail of pretentious paint	0		
@@ -1257,7 +1257,7 @@
 1273	magic lamp of vim and vigor	0		Maximum HP Percent: +50
 1274	twisted wobbly pulsating pulsating Medicinal Herb's medicinal herbs	1		Effect: "Optimist Primal", Effect Duration: 35
 1275	wobbly basic meat skirt of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	irresponsibly strong mediocre Otorian Battle Scar	6	decent	
+1276	mediocre irresponsibly strong Otorian Battle Scar	6	decent	
 1277	avaricious basic meat kilt	0		Meat Drop: +30, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	medical-grade meat skirt	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	meat kilt of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1301,7 +1301,7 @@
 1317	green blood flower	0		
 1318	lovecat tail	0		
 1319	squat plastic passion fruit	0		
-1320	tasty special squat questionable taco	3	awesome	Effect: "Bread-Lined", Effect Duration: 20
+1320	special tasty squat questionable taco	3	awesome	Effect: "Bread-Lined", Effect Duration: 20
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	yellow petrified time	0		Last Available: "2005-10"
 1323	time helmet of the glutton	0		Food Drop: +100, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
@@ -1320,7 +1320,7 @@
 1336	Cloaca grenade	0		
 1338	Dyspepsi-Cola d-rations	0		
 1339	Cloaca-Cola c-rations	0		
-1340	spinning shaking Cloaca-Cola-issue combat knife	0		
+1340	shaking spinning Cloaca-Cola-issue combat knife	0		
 1341	banded Dyspepsi-Cola-issue canteen	0		Damage Absorption: +100, Single Equip
 1342	blinking picture of a dead guy's girlfriend	0		
 1343	olive zombie pineal gland	0		Last Available: "2005-11"
@@ -1335,9 +1335,9 @@
 1352	tolerable redrum	3	good	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	low-calorie stale fuchsia bowl of oriole's nest soup	1	decent	
+1355	stale low-calorie fuchsia bowl of oriole's nest soup	1	decent	
 1356	bunny liver	0		
-1357	acceptable weak Mt. Noob Pale Ale	2	good	
+1357	weak acceptable Mt. Noob Pale Ale	2	good	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	bouncing ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	huge pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,14 +1346,14 @@
 1363	clockwork pirate skull	0		
 1364	teal rhesus monkey	0		Familiar Weight: +5
 1365	thick bland upside-down tofurkey leg	5	decent	
-1366	big special adequate tofurkey gravy	5	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 45
+1366	adequate big special tofurkey gravy	5	good	Effect: "Lucky Cat Is Lucky", Effect Duration: 45
 1367	flavorless herbal stuffing	3	decent	
 1368	half-sized flavorless can-shaped gelatinous cranberry sauce	2	decent	
 1369	stale enchanted mirror yams	3	decent	Effect: "You Liver", Effect Duration: 25
 1370	narrow rhinestone cowboy shirt of courage	0		Spooky Resistance: +3
 1371	blinking scandalous gingham blouse	0		Sleaze Damage: +5
 1372	souvenir ski t-shirt of the bloodbag	0		Maximum HP: +100
-1373	fuchsia ghostly sweet nutcracker	0		Free Pull, Last Available: "2005-12"
+1373	ghostly fuchsia sweet nutcracker	0		Free Pull, Last Available: "2005-12"
 1374	blinking mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	lion tamer's plastic Crimbo wreath	0		Experience (familiar): +2, Single Equip, Last Available: "2005-12"
 1376	perfumed plastic Uncle Crimbo	0		Stench Resistance: +5, Last Available: "2005-12"
@@ -1364,7 +1364,7 @@
 1382	magnetized chocolate	0		Effect: "Pharmaceutically Cool", Effect Duration: 24, Last Available: "2015-11"
 1383	squat length of string	0		
 1384	skewed googly eye	0		
-1385	blurry yellow stuffing	0		
+1385	yellow blurry stuffing	0		
 1386	bouncing felt	0		
 1387	block	0		
 1388	green toy wheel	0		
@@ -1385,8 +1385,8 @@
 1403	lion tamer's can of fake snow	0		Experience (familiar): +2, Last Available: "2005-12"
 1404	up-at-dawn colored-light &quot;necklace&quot;	0		Adventures: +5, Last Available: "2005-12"
 1405	greedy tree skirt	0		Meat Drop: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	gigantic decent wreath-shaped Crimbo cookie	7	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	bland bite-sized bell-shaped Crimbo cookie	1	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1406	decent gigantic wreath-shaped Crimbo cookie	7	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1407	bite-sized bland bell-shaped Crimbo cookie	1	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	normal tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	squat electrified Unionize The Elves sign	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2005-12"
 1410	blurry sleeping snowy owl	0		Last Available: "2005-12"
@@ -1419,7 +1419,7 @@
 1437	green useless powder	0		
 1438	boiled flattened ghostly twinkly powder	0		Effect: "Techno Bliss", Effect Duration: 61
 1439	vacuum-sealed fuchsia hot powder	0		Effect: "Motion", Effect Duration: 35
-1440	Vulcanized super-aerosolized galvanized twirling fuchsia powder	0		Effect: "Triangle, Man", Effect Duration: 42
+1440	Vulcanized super-aerosolized galvanized fuchsia twirling powder	0		Effect: "Triangle, Man", Effect Duration: 42
 1441	improved dry powder	0		Effect: "Snobby", Effect Duration: 60
 1442	magnetized boiled stench powder	0		Effect: "Aided and Abetted", Effect Duration: 16
 1443	magnetized boiled sleaze powder	0		Effect: "One Foot Heavier", Effect Duration: 56
@@ -1437,7 +1437,7 @@
 1455	denatured sleaze wad	1		Effect: "Wasabi With You", Effect Duration: 20
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	fancy stale gigantic bouncing Valentine's Day cake	7	decent	Effect: "Fustulent", Effect Duration: 5
+1458	stale gigantic fancy bouncing Valentine's Day cake	7	decent	Effect: "Fustulent", Effect Duration: 5
 1459	shaking arrow'd heart balloon	0		
 1460	mirror velvet box	0		
 1461	pulsating green squashed frog	0		
@@ -1462,7 +1462,7 @@
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	spinning union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	mirror paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
-1483	olive skewed troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
+1483	skewed olive troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	pulsating alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	teal asbestos-lined brawny rabbit's foot	0		Muscle Percent: +20, Hot Resistance: +5
 1486	massive bag of catnip	0		
@@ -1475,7 +1475,7 @@
 1493	zippy deadly ridiculously overelaborate ninja weapon	0		Weapon Damage: +5, Initiative: +20
 1494	oxidized sugar-coated pine cone	0		Effect: "Wintergreen Warmongery", Effect Duration: 17, Last Available: "2020-09"
 1495	fortified traffic cone	0		Damage Absorption: +60, Item Drop: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	practically non-alcoholic drinkable gloomy mushroom wine	1	good	
+1496	drinkable practically non-alcoholic gloomy mushroom wine	1	good	
 1497	bad mushroom wine	3	decent	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1494,7 +1494,7 @@
 1512	denatured twirling Knob Goblin pet-buffing spray	1		Effect: "Fiery Spirit", Effect Duration: 30
 1513	dehydrated Knob Goblin learning pill	1		
 1514	vaporized ghostly Knob Goblin eyedrops	1		
-1515	dried bouncing lime green upside-down Knob Goblin nasal spray	1		
+1515	dried lime green upside-down bouncing Knob Goblin nasal spray	1		
 1516	KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1533,34 +1533,34 @@
 1553	bad bottle of Calcutta Emerald	4	decent	
 1554	practically non-alcoholic acceptable wobbly bottle of Lieutenant Freeman	1	good	
 1555	mediocre mirror bottle of Jorge Sinsonte	4	decent	
-1556	weak special artisanal jittery lime green boxed champagne	2	EPIC	Effect: "All Branned Up", Effect Duration: 10
+1556	artisanal special weak lime green jittery boxed champagne	2	EPIC	Effect: "All Branned Up", Effect Duration: 10
 1557	rotten kumquat	4	crappy	
-1558	rotten thick tangerine	5	crappy	
+1558	thick rotten tangerine	5	crappy	
 1559	tonic water	0		
-1560	adequate bite-sized special cocktail onion	1	good	Effect: "Cosmic Flavor", Effect Duration: 40
+1560	bite-sized adequate special cocktail onion	1	good	Effect: "Cosmic Flavor", Effect Duration: 40
 1561	decent tiny raspberry	1	good	
-1562	small adequate lime green twirling kiwi	2	good	
+1562	adequate small lime green twirling kiwi	2	good	
 1563	weak bad huge whiskey bittersweet	2	decent	
 1564	bad mimosette	3	decent	
 1565	acceptable tequila sunset	3	good	
 1566	hand-crafted fuchsia zmobie	3	EPIC	Wiki Name: "Zmobie (drink)"
 1567	delicious irresponsibly strong gin and tonic	9	awesome	
-1568	perfectly mixed practically non-alcoholic fuchsia vodka and tonic	1	super EPIC	
+1568	practically non-alcoholic perfectly mixed fuchsia vodka and tonic	1	super EPIC	
 1569	mediocre jittery vodka gibson	3	decent	
-1570	fancy triple-distilled artisanal gibson	9	EPIC	Effect: "Icy Demeanor", Effect Duration: 30
-1571	extra-dry special hand-crafted narrow parisian cathouse	5	EPIC	Effect: "Space Cadet", Effect Duration: 15
+1570	fancy artisanal triple-distilled gibson	9	EPIC	Effect: "Icy Demeanor", Effect Duration: 30
+1571	special extra-dry hand-crafted narrow parisian cathouse	5	EPIC	Effect: "Space Cadet", Effect Duration: 15
 1572	fancy mediocre rabbit punch	3	decent	Effect: "Drenched With Filth", Effect Duration: 45
 1573	perfectly mixed caipifruta	4	EPIC	
 1574	drinkable teqiwila	4	good	
 1575	acceptable Divine	4	good	
 1576	bad practically non-alcoholic Gordon Bennett	1	decent	
 1577	practically non-alcoholic tolerable tangarita	1	good	
-1578	artisanal practically non-alcoholic cyan mandarina colada	1	super ultra mega turbo EPIC	
+1578	practically non-alcoholic artisanal cyan mandarina colada	1	super ultra mega turbo EPIC	
 1579	aged upside-down gimlet	3	awesome	
-1580	spirit-forward delicious brick road	5	awesome	
+1580	delicious spirit-forward brick road	5	awesome	
 1581	triple-distilled acceptable vodka stratocaster	9	good	
 1582	practically non-alcoholic drinkable narrow Neuromancer	1	good	
-1583	aged skewed shaking prussian cathouse	3	awesome	
+1583	aged shaking skewed prussian cathouse	3	awesome	
 1584	perfectly mixed Mae West	3	EPIC	
 1585	mediocre Mon Tiki	4	decent	
 1586	weak hand-crafted wobbly teqiwila slammer	2	super ultra EPIC	
@@ -1568,7 +1568,7 @@
 1588	bite-sized decent bouncing asparagus lo mein	1	good	
 1589	bland mirror Knoll lo mein	3	decent	
 1590	moldy half-sized lo mein	2	crappy	
-1591	snack-sized tasty olive lo mein	2	awesome	
+1591	tasty snack-sized olive lo mein	2	awesome	
 1592	moldy big fuchsia hot hi mein	5	crappy	
 1593	flavorless hi mein	3	decent	
 1594	bland tumbling mirror hi mein	4	decent	
@@ -1577,16 +1577,16 @@
 1597	hale Junior LAAAAME merit badge	0		Maximum HP: +20, Last Available: "2006-05"
 1598	Senior LAAAAME merit badge of chilblains	0		Cold Damage: +25, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	weak lousy tangarita with a fly in it	2	decent	
+1600	lousy weak tangarita with a fly in it	2	decent	
 1601	artisanal mandarina colada with a fly in it	3	EPIC	
 1602	watered-down lousy prussian cathouse with a fly in it	2	decent	
-1603	special high-proof lousy Mae West with a fly in it	7	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 40
+1603	high-proof special lousy Mae West with a fly in it	7	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 40
 1604	powdered astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	distilled ultimate wad	1		Effect: "Guts Feeling", Effect Duration: 30
 1607	Vulcanized libation of liveliness	0		Effect: "Booing Radly", Effect Duration: 66
 1608	ionized super-ionized narrow eyedrops of the ermine	0		Effect: "Hella Smooth", Effect Duration: 59
-1609	concentrated super-magnetized skewed huge perfume of prejudice	0		Effect: "Pwnd", Effect Duration: 19
+1609	concentrated super-magnetized huge skewed perfume of prejudice	0		Effect: "Pwnd", Effect Duration: 19
 1610	quantum non-quantum mirror eyedrops of the ocelot	0		Effect: "Venomous Weapon", Effect Duration: 36
 1611	quantum dry huge potent potion of potency	0		Effect: "The Magic of LOV", Effect Duration: 50
 1612	polarized concentrated cordial of concentration	0		Effect: "Preemptive Medicine", Effect Duration: 63
@@ -1595,23 +1595,23 @@
 1615	bouncing medical-grade Cerebral Cloche	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
 1616	beefcake's Cerebral Culottes	0		Muscle: +25, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	avaricious asbestos-lined banded Cerebral Crossbow	0		Damage Absorption: +100, Hot Resistance: +5, Meat Drop: +30, Last Available: "2006-06"
-1618	huge jittery purple ice stein	0		Last Available: "2006-06"
+1618	huge purple jittery ice stein	0		Last Available: "2006-06"
 1619	bouncing munchies pill	0		Last Available: "2006-06"
 1620	mirror maroon homeopathic healing powder	0		Last Available: "2006-06"
 1621	astral badger	0		Free Pull, Last Available: "2006-06"
 1622	tarnished tarnished astral mushroom	0		Effect: "Familial Ties", Effect Duration: 13, Last Available: "2006-06"
 1623	huge badger badge	0		Last Available: "2006-06"
 1624	polymerized skewed lime green blue-frosted astral cupcake	0		Effect: "Radium Radicality", Effect Duration: 12, Last Available: "2006-06"
-1625	corrupted gray ghostly green-frosted astral cupcake	0		Effect: "Preternatural Greed", Effect Duration: 37, Last Available: "2006-06"
+1625	corrupted ghostly gray green-frosted astral cupcake	0		Effect: "Preternatural Greed", Effect Duration: 37, Last Available: "2006-06"
 1626	activated improved orange-frosted astral cupcake	0		Effect: "Hot Blooded", Effect Duration: 57, Last Available: "2006-06"
 1627	polymerized purple-frosted astral cupcake	0		Effect: "BOOsted", Effect Duration: 59, Last Available: "2006-06"
 1628	oxidized pink-frosted astral cupcake	0		Effect: "Brother Smothers's Blessing", Effect Duration: 28, Last Available: "2006-06"
 1629	raspberry beret of the early riser	0		Adventures: +7, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	upside-down spinning manspreader's pixel shield	0		Monster Level: +10, Damage Reduction: 3
 1631	huge beer cartilage	0		
-1632	shaking blue Spanish fly trap	0		
+1632	blue shaking Spanish fly trap	0		
 1633	tumbling Spanish fly	0		
-1634	drinkable watered-down pulsating cyan around the world	2	good	
+1634	drinkable watered-down cyan pulsating around the world	2	good	
 1635	scrumdiddlyumptious solution	0		
 1636	spinning Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	oxidized bouncing spinning lotion of hotness	0		Effect: "Demonic Flavor", Effect Duration: 28
@@ -1620,7 +1620,7 @@
 1640	ionized irradiated concentrated blinking lotion of stench	0		Effect: "Ooh, Sweet!", Effect Duration: 60
 1641	concentrated galvanized huge lotion of sleaziness	0		Effect: "Scrappy, Shadowy", Effect Duration: 45
 1642	irresponsibly strong bad spinning Grimacite Bock	7	decent	Last Available: "2008-11"
-1643	massive moldy wedge of gray cheese	8	crappy	Last Available: "2008-11"
+1643	moldy massive wedge of gray cheese	8	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	squat and sauce	0		
 1646	and sauce	0		
@@ -1669,16 +1669,16 @@
 1689	ribbon of terror	0		Spooky Spell Damage: +10, Last Available: "2006-07"
 1690	Usain Bolt's ribald discarded bottlecap	0		Sleaze Damage: +10, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	jittery stanky Annie Oakley's discarded torn-up glove	0		Critical Hit Percent: +20, Stench Spell Damage: +25, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	alkaline enhanced flattened ghostly green salamander slurry	0		Effect: "Coming Up Roses", Effect Duration: 18
+1692	alkaline enhanced flattened green ghostly salamander slurry	0		Effect: "Coming Up Roses", Effect Duration: 18
 1693	quantum Vulcanized improved eyedrops of newt	0		Effect: "One Foot Heavier", Effect Duration: 24
 1694	moist alkaline mirror Frogade	0		Effect: "Stop and Smell the Fudge", Effect Duration: 13
 1695	non-quantum bouncing papotion of papower	0		Effect: "Fireproof Lips", Effect Duration: 63
 1696	normal royal jelly taco	4	good	
-1697	miniature decent tofu taco	2	good	
+1697	decent miniature tofu taco	2	good	
 1698	yummy diet mirror jumping bean taco	1	awesome	
 1699	rotten catgut taco	3	crappy	
 1700	bland blinking goat cheese taco	3	decent	
-1701	half-sized toothsome upside-down pr0n taco	2	awesome	
+1701	toothsome half-sized upside-down pr0n taco	2	awesome	
 1702	adjusted nitrogenated alphabet gum	0		Effect: "Thought", Effect Duration: 61
 1703	Comma Chameleon egg	0		Free Pull
 1704	tumbling shingle	0		
@@ -1759,7 +1759,7 @@
 1780	blinking tumbling executive ram stick	0		Meat Drop: +40
 1781	narrow banded enchantlers	0		Damage Absorption: +100, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	greasy dangerous ram-battering staff	0		Weapon Damage: +10, Sleaze Spell Damage: +10
-1783	normal super-sized crazy Turkish delight	5	good	
+1783	super-sized normal crazy Turkish delight	5	good	
 1784	shaking wicked Snow Queen Crown of the dark arts	0		Spell Damage: +5, Spell Damage Percent: +100, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	ruddy smooth ga-ga radio of the cheetah	0		Moxie: +15, Maximum HP Percent: +40, Initiative: +60
 1786	mirror six pack of Mountain Stream	0		
@@ -1770,7 +1770,7 @@
 1791	ram horns	0		
 1792	perfumed frightening dance instructor's Travoltan trousers	0		Experience Percent (Moxie): +10, Spooky Damage: +5, Stench Resistance: +5, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	aromatic arcane researcher's pool cue	0		Experience Percent (Mysticality): +10, Stench Resistance: +1
-1794	chilled corrupted spinning green jittery handful of hand chalk	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 12
+1794	chilled corrupted jittery green spinning handful of hand chalk	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 12
 1795	blue Counterclockwise Watch of the pedagogue	0		Experience: +3, Single Equip
 1796	bone collar	0		Familiar Weight: +5
 1797	misshapen animal skeleton	0		
@@ -1796,7 +1796,7 @@
 1817	skewed ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
 1819	blurry eleventh thoracic vertebra	0		
-1820	red wobbly twelfth thoracic vertebra	0		
+1820	wobbly red twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
 1822	second lumbar vertebra	0		
 1823	jittery third lumbar vertebra	0		
@@ -1821,20 +1821,20 @@
 1842	left fourth rib	0		
 1843	left fifth rib	0		
 1844	blinking left sixth rib	0		
-1845	blinking blurry left seventh rib	0		
-1846	narrow gray left eighth rib	0		
+1845	blurry blinking left seventh rib	0		
+1846	gray narrow left eighth rib	0		
 1847	left ninth rib	0		
 1848	left tenth rib	0		
 1849	left eleventh rib	0		
-1850	blinking gray left twelfth rib	0		
+1850	gray blinking left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
 1853	right third rib	0		
-1854	green skewed skewed right fourth rib	0		
+1854	skewed green skewed right fourth rib	0		
 1855	right fifth rib	0		
 1856	jittery right sixth rib	0		
 1857	pulsating right seventh rib	0		
-1858	pulsating squat right eighth rib	0		
+1858	squat pulsating right eighth rib	0		
 1859	right ninth rib	0		
 1860	right tenth rib	0		
 1861	right eleventh rib	0		
@@ -1898,8 +1898,8 @@
 1921	ghostly experienced wakizashi	0		Experience: +2
 1922	gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
-1924	blue tumbling tattered wolf standard	0		
-1925	bouncing tumbling tattered snake standard	0		
+1924	tumbling blue tattered wolf standard	0		
+1925	tumbling bouncing tattered snake standard	0		
 1926	maroon KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
 1928	squat tuning fork	0		
@@ -1930,8 +1930,8 @@
 1953	delicious blue flute of flat champagne	4	awesome	
 1954	normal ghostly dehydrated caviar	3	good	
 1955	styrofoam peanuts	0		
-1956	acceptable special weak huge snifter of thoroughly aged brandy	2	good	Effect: "Red Misty-Eyed", Effect Duration: 10
-1957	green huge quill pen	0		
+1956	weak acceptable special huge snifter of thoroughly aged brandy	2	good	Effect: "Red Misty-Eyed", Effect Duration: 10
+1957	huge green quill pen	0		
 1958	twirling inkwell	0		
 1959	lime green tattered scrap of paper	0		
 1960	pulsating scroll of forbidden unspeakable evil	0		
@@ -1939,7 +1939,7 @@
 1962	aerosolized bouncing Bit O' Ectoplasm	0		Effect: "Influence of Sphere", Effect Duration: 43
 1963	maroon dance card	0		
 1964	smooth opera mask	0		Moxie: +15, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
-1965	skewed fuchsia bottle of Monsieur Bubble	0		
+1965	fuchsia skewed bottle of Monsieur Bubble	0		
 1966	educational Amulet of Yendor of the wise owl	0		Mysticality: +20, Experience: +1, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	jittery bottle of perfume	0		Familiar Weight: +5
@@ -1953,14 +1953,14 @@
 1976	gravy fairy	0		
 1977	gravy fairy	0		
 1978	twirling gravy fairy	0		
-1979	pulsating red gravy fairy	0		
+1979	red pulsating gravy fairy	0		
 1980	tumbling narrow sleazy gravy fairy	0		
 1981	astral badger	0		
 1982	MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	snowy owl	0		
 1985	scary death orb	0		
-1986	yellow blurry mind flayer	0		
+1986	blurry yellow mind flayer	0		
 1987	undead elbow macaroni	0		
 1988	angry cow	0		
 1989	Cheshire bitten	0		
@@ -1982,7 +1982,7 @@
 2005	red Morbidda trading card	0		
 2006	twirling Poison Oak trading card	0		
 2007	Princess Rutabaga trading card	0		
-2008	blurry bouncing Roo trading card	0		
+2008	bouncing blurry Roo trading card	0		
 2009	Woldo trading card	0		
 2010	maroon The Snake trading card	0		
 2011	squat Nayztameetjoo trading card	0		
@@ -1999,10 +1999,10 @@
 2022	decent lemon meringue pie	3	good	
 2023	Genalen&trade; Bottle	1	EPIC	
 2024	spoiled twirling mixed wildflower greens	4	crappy	
-2025	small bland jittery handful of walnuts	2	decent	
+2025	bland small jittery handful of walnuts	2	decent	
 2026	flavorless nutty organic salad	3	decent	
 2027	jumbo bland fuchsia super salad	5	decent	
-2028	spoiled gigantic tofu wonton	8	crappy	
+2028	gigantic spoiled tofu wonton	8	crappy	
 2029	blinking hippy protest button	0		Single Equip
 2030	flame-retardant rosy-cheeked Lockenstock&trade; sandals	0		Maximum HP Percent: +30, Hot Resistance: +1, Single Equip
 2031	lightning-fast didgeridooka	0		Initiative: +40
@@ -2020,7 +2020,7 @@
 2043	hemp net	0		
 2044	red your father's MacGuffin diary	0		
 2045	miniature adequate ghostly brain-meltingly-hot chicken wings	2	good	
-2046	spoiled snack-sized frat brats	2	crappy	
+2046	snack-sized spoiled frat brats	2	crappy	
 2047	miniature normal knob ka-bobs	2	good	
 2049	hand-crafted can of Swiller	3	EPIC	
 2050	broken wings	0		
@@ -2067,9 +2067,9 @@
 2091	upside-down bath salts	0		
 2092	blurry hand mirror	0		
 2093	maroon deadly hors d'oeuvre tray	0		Weapon Damage: +5, Damage Reduction: 5
-2094	adequate miniature ballroom blintz	2	good	
+2094	miniature adequate ballroom blintz	2	good	
 2095	towel	0		
-2096	compressed jittery ghostly blinking guy made of bee pollen	1		Effect: "Venomous Weapon", Effect Duration: 10
+2096	compressed ghostly blinking jittery guy made of bee pollen	1		Effect: "Venomous Weapon", Effect Duration: 10
 2097	mirror deadly 17-ball	0		Weapon Damage: +5
 2098	filthy lucre	0		
 2099	hobo gristle	0		
@@ -2123,7 +2123,7 @@
 2148	toothsome rock	0		
 2149	moldy frank	4	crappy	Last Available: "2011-12"
 2150	bland plate of franks and beans	3	decent	Last Available: "2011-12"
-2151	weak tolerable shot of blackberry schnapps	2	good	
+2151	tolerable weak shot of blackberry schnapps	2	good	
 2152	yellow capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	ion grid	0		Last Available: "2011-12"
@@ -2145,7 +2145,7 @@
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
 2171	therapeutic astronaut pants of the overflowing toilet	0		Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	spinning experienced toy jet pack	0		Experience: +2, Last Available: "2006-12"
-2173	teal upside-down triangular stone	0		
+2173	upside-down teal triangular stone	0		
 2174	mirror mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	squat wobbly cracked stone sphere	0		
@@ -2158,7 +2158,7 @@
 2183	Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	knitted Kiss the Knob apron	0		Cold Resistance: +3
-2186	shaking red unlit birthday cake	0		
+2186	red shaking unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	good	Last Available: "2006-12"
 2189	perfectly mixed irresponsibly strong flask of peppermint schnapps	6	EPIC	Last Available: "2006-12"
@@ -2167,10 +2167,10 @@
 2192	sheet music	0		Last Available: "2006-12"
 2193	rotten enchanted candy stake	3	crappy	Effect: "Human-Elf Hybrid", Effect Duration: 35, Last Available: "2006-12"
 2194	weak tolerable eggnog	2	good	Last Available: "2006-12"
-2195	snack-sized moldy unspeakable fruitcake	2	crappy	Last Available: "2006-12"
+2195	moldy snack-sized unspeakable fruitcake	2	crappy	Last Available: "2006-12"
 2196	spoiled purple gingerbread horror	3	crappy	Last Available: "2006-12"
 2197	denatured blinking but probably evil chocolate	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 41, Last Available: "2006-12"
-2198	miniature bland bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	bland miniature bat-shaped Crimboween cookie	2	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	huge bland skull-shaped Crimboween cookie	6	decent	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	toothsome snack-sized narrow jittery tombstone-shaped Crimboween cookie	2	awesome	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	spinning forbidden plastic gift-wrapping vampire	0		Spell Damage Percent: +50, Last Available: "2006-12"
@@ -2185,12 +2185,12 @@
 2210	lightning-fast gravedigger's Tiki lighter	0		Spooky Damage: +10, Initiative: +40, Stat Tuning: "Moxie", Last Available: "2006-12"
 2211	sizzling deck of tropical cards of Tarzan	0		Experience (Muscle): +3, Hot Damage: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
 2212	family-friendly stanky tropical paperweight	0		Stench Spell Damage: +25, Sleaze Resistance: +1, Stat Tuning: "Muscle", Last Available: "2006-12"
-2213	maroon ghostly tropical Crimbo pressie	0		Last Available: "2006-12"
+2213	ghostly maroon tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
 2215	savvy Tropical Crimbo Hat	0		Mysticality Percent: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	aromatic Tropical Crimbo Shorts	0		Stench Resistance: +1, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	adequate super ka-bob	4	good	
-2218	huge decent ghostly beer basted brat	10	good	
+2218	decent huge ghostly beer basted brat	10	good	
 2219	scorching Tropical Crimbo Sword	0		Hot Damage: +25, Last Available: "2006-12"
 2220	double-concentrated wobbly and Crimboween candy	0		Effect: "Initiative and Let Die", Effect Duration: 40, Last Available: "2020-09"
 2221	huge Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2214,7 +2214,7 @@
 2239	dance instructor's bad voodoo mask of mayonnaise	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +50, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	bottle of alcohol	0		
 2241	rock-hard pygmy spear	0		Damage Reduction: 5
-2242	tarnished jittery ghostly pygmy pygment	0		Effect: "X-Ray Vision", Effect Duration: 62
+2242	tarnished ghostly jittery pygmy pygment	0		Effect: "X-Ray Vision", Effect Duration: 62
 2243	Lo Pan's Fonzie's headhunter necktie	0		Experience (Moxie): +1, Spell Critical Percent: +30, Single Equip
 2244	shaking up-at-dawn pointed stick of James Dean	0		Experience (Moxie): +3, Adventures: +5
 2245	shaking experienced knobby helmet turtle	0		Experience: +2, Familiar Effect: "atk, 2xFairy, cap 5"
@@ -2243,16 +2243,16 @@
 2269	decent ghostly sausage wonton	4	good	
 2270	bouncing smelly fortified belt	0		Damage Absorption: +60, Stench Spell Damage: +10, Single Equip
 2271	delicious skewed bottle of Merlot	4	awesome	
-2272	acceptable blurry yellow bottle of Port	3	good	
-2273	weak drinkable bottle of Pinot Noir	2	good	
+2272	acceptable yellow blurry bottle of Port	3	good	
+2273	drinkable weak bottle of Pinot Noir	2	good	
 2274	perfectly mixed bottle of Zinfandel	3	EPIC	
-2275	special drinkable huge purple bottle of Marsala	3	good	Effect: "Good Karma", Effect Duration: 15
+2275	drinkable special purple huge bottle of Marsala	3	good	Effect: "Good Karma", Effect Duration: 15
 2276	hand-crafted blinking bottle of Muscat	4	EPIC	
 2277	Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
-2279	wobbly narrow book	0		
+2279	narrow wobbly book	0		
 2280	tumbling Manual of Labor	0		
-2281	gray huge Manual of Transmission	0		
+2281	huge gray Manual of Transmission	0		
 2282	Manual of Dexterity	0		
 2283	asbestos-lined seal-skull helmet	0		Hot Resistance: +5, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
@@ -2263,7 +2263,7 @@
 2289	paperclip	0		
 2290	really house	0		
 2291	Non-Essential Amulet	0		
-2292	squat ghostly teal wine vinaigrette	0		
+2292	squat teal ghostly wine vinaigrette	0		
 2293	huge cup of strong herbal tea	0		
 2294	Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	green marinated stakes	0		
@@ -2309,15 +2309,15 @@
 2335	rubber WWBBDD? bracelet	0		
 2336	olive grievous pipe of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +50
 2337	careful reinforced beaded headband	0		Monster Level: -10, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	moldy half-sized pudding	2	crappy	Wiki Name: "black pudding (food)"
+2338	half-sized moldy pudding	2	crappy	Wiki Name: "black pudding (food)"
 2339	perfectly mixed extra-dry Blackfly Chardonnay	5	EPIC	
 2340	practically non-alcoholic artisanal & tan	1	EPIC	
 2341	skewed pepper	0		
-2342	huge bland ghostly forest cake	9	decent	
+2342	bland huge ghostly forest cake	9	decent	
 2343	spoiled forest ham	3	crappy	
 2344	non-dry filthworm hatchling scent gland	0		Effect: "Jawin'", Effect Duration: 58
 2345	anodized Vulcanized filthworm drone scent gland	0		Effect: "Macho, Macho Dog", Effect Duration: 59
-2346	warmed colloidal alkaline huge upside-down filthworm royal guard scent gland	0		Effect: "Incensed", Effect Duration: 55
+2346	warmed colloidal alkaline upside-down huge filthworm royal guard scent gland	0		Effect: "Incensed", Effect Duration: 55
 2347	green heart of the filthworm queen	0		
 2348	jittery water pipe bomb	0		
 2349	gas balloon	0		
@@ -2342,13 +2342,13 @@
 2368	shaking extremely unsafe flowing hippy skirt of the businessman	0		Weapon Damage Percent: +100, Meat Drop: +50, Familiar Effect: "stench atk, 1xFairy, cap 45"
 2369	filthy poultice	0		
 2370	natural fennel soda	0		
-2371	blurry spinning spinning smoke bomb	0		
+2371	spinning blurry spinning smoke bomb	0		
 2372	huge gray bunch of bananas	0		
 2373	moldy banana	4	crappy	
 2374	huge banana peel	0		
 2375	low-calorie decent banana cream pie	1	good	
 2376	tolerable banana daiquiri	3	good	
-2377	delicious extra-dry bungle in the jungle	5	awesome	
+2377	extra-dry delicious bungle in the jungle	5	awesome	
 2378	banana spritzer	0		
 2379	concentrated banana smoothie	0		Effect: "Memory of Attractiveness", Effect Duration: 14
 2380	narrow dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2378,7 +2378,7 @@
 2404	wobbly jam band flyers	0		
 2405	rock band flyers	0		
 2406	Panda outfit	0		Familiar Weight: +5, Item Drop: +5
-2407	purple squat pink bat eye	0		
+2407	squat purple pink bat eye	0		
 2408	gray worthless piece of glass	0		
 2409	billy idol	0		
 2410	rag	0		
@@ -2415,7 +2415,7 @@
 2441	Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	lion tamer's pink glowstick of the pedagogue	0		Experience: +3, Experience (familiar): +2, Last Available: "2007-03"
-2444	enchanted acceptable bouncing blurry Supernova Champagne	4	good	Effect: "Pwnd", Effect Duration: 20
+2444	enchanted acceptable blurry bouncing Supernova Champagne	4	good	Effect: "Pwnd", Effect Duration: 20
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	tumbling cyan hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	purple bad penguin egg	0		Free Pull
@@ -2424,7 +2424,7 @@
 2450	fuchsia pulsating empty Cloaca-Cola bottle	0		
 2451	goatskin umbrella of courage	0		Spooky Resistance: +3
 2452	deadly weightlifter's wool hat	0		Muscle: +15, Weapon Damage: +5, Familiar Effect: "1xLep, cap 43"
-2453	blinking skewed Goodfella contract	0		Last Available: "2011-12"
+2453	skewed blinking Goodfella contract	0		Last Available: "2011-12"
 2454	pulsating executive avaricious belt	0		Meat Drop: 70, Single Equip
 2455	narrow Herculean bar whip	0		Experience (Muscle): +1
 2456	barskin buckler of incineration	0		Hot Spell Damage: +50, Damage Reduction: 1
@@ -2435,9 +2435,9 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	rotten bowl of Bounty-Os	4	crappy	
-2465	boozy delicious Oreille Divis&eacute;e brandy	5	awesome	
+2465	delicious boozy Oreille Divis&eacute;e brandy	5	awesome	
 2466	cyan pompadour'd puppy	0		
-2467	squat red suede shoes	0		Familiar Weight: +5
+2467	red squat suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	tumbling bundle of receipts	0		
 2470	squat mirror cork	0		
@@ -2471,11 +2471,11 @@
 2498	huge molybdenum hammer	0		
 2499	bouncing molybdenum screwdriver	0		
 2500	jittery molybdenum pliers	0		
-2501	wobbly lime green molybdenum crescent wrench	0		
+2501	lime green wobbly molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
 2504	jittery precious piercing post	0		
-2505	upside-down spinning necklace chain	0		
+2505	spinning upside-down necklace chain	0		
 2506	squat beach glass bead	0		
 2507	clay peace-sign bead	0		
 2508	beach glass necklace of the scaredy-cat	0		Monster Level: -15
@@ -2492,20 +2492,20 @@
 2519	perfectly mixed McMillicancuddy's Special Lager	4	EPIC	
 2520	tolerable watered-down melted Jell-o shot	2	good	
 2521	lousy fuchsia cruelty-free wine	4	decent	
-2522	watered-down perfectly mixed mirror thistle wine	2	EPIC	
+2522	perfectly mixed watered-down mirror thistle wine	2	EPIC	
 2523	narrow megatofu	0		
 2524	displaced fish	0		
 2525	decent massive fish	8	good	
-2526	bland thick pulsating bouncing fish casserole	5	decent	
+2526	bland thick bouncing pulsating fish casserole	5	decent	
 2527	flavorless fish lasagna	3	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	super-sized decent gnatloaf	5	good	
-2530	bland half-sized upside-down gnatloaf casserole	2	decent	
+2530	half-sized bland upside-down gnatloaf casserole	2	decent	
 2531	stale twirling gnat lasagna	3	decent	
 2532	pork	0		
 2533	spoiled pork chop sandwiches	4	crappy	
 2534	stale jumbo maroon pork casserole	5	decent	
-2535	stale small pork lasagna	2	decent	
+2535	small stale pork lasagna	2	decent	
 2536	canopic jar	0		
 2537	ghostly spice	0		
 2538	spinning organs	0		
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	Samson's cactus quill of the empath	0		Experience (Muscle): +5, Familiar Weight: +5
 2578	greedy careful Staff of the Short Order Cook of James Dean	0		Experience (Moxie): +3, Monster Level: -10, Meat Drop: +20
-2579	huge tasty cactus fruit	8	awesome	
+2579	tasty huge cactus fruit	8	awesome	
 2580	foul-smelling scorpion whip of the blizzard	0		Cold Spell Damage: +25, Stench Damage: +10
 2581	handful of sand	0		
 2582	brick of sand	0		
@@ -2559,8 +2559,8 @@
 2586	smartaleck's General Sage's Lonely Diamonds Club Jacket	0		Moxie Percent: +30
 2587	toasty Corporal Fennel's Lonely Clubs Club Jacket	0		Hot Damage: +5
 2588	wholesome Private Pepper's Lonely Hearts Club Jacket	0		Maximum HP Percent: +10
-2589	rotten half-sized squat hot date	2	crappy	
-2590	mediocre fancy distilled fortified wine	3	decent	Effect: "Neuromancy", Effect Duration: 45
+2589	half-sized rotten squat hot date	2	crappy	
+2590	fancy mediocre distilled fortified wine	3	decent	Effect: "Neuromancy", Effect Duration: 45
 2591	moldy blurry tasty tart	3	crappy	
 2592	lime green Knob Goblin lunchbox	0		
 2593	bland huge Knob pasty	7	decent	
@@ -2568,7 +2568,7 @@
 2595	liquefied tumbling Ben-Gal&trade; Balm	0		Effect: "Warm Belly", Effect Duration: 11
 2596	squat bouncing leathery cat skin	0		
 2597	leathery bat skin	0		
-2598	jittery twirling leathery rat skin	0		
+2598	twirling jittery leathery rat skin	0		
 2599	Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	executive groovy Staff of the Midnight Snack of the wise owl	0		Mysticality: +20, Moxie Percent: +10, Meat Drop: +40
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	squat cyan squat rocky raccoon	0		
 2614	mojo filter	0		
-2615	rotten half-sized savoy truffle	2	crappy	
+2615	half-sized rotten savoy truffle	2	crappy	
 2616	huge Magi-Wipes	0		
 2617	mirror boom	0		
 2618	Tesla Iiti Kitty phone charm	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -2624,13 +2624,13 @@
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	normal bite-sized squat S.T.L.T.	1	good	Last Available: "2007-06"
 2653	stale honey-dew	3	decent	Last Available: "2007-06"
-2654	drinkable practically non-alcoholic Xanadian	1	good	Last Available: "2007-06"
+2654	practically non-alcoholic drinkable Xanadian	1	good	Last Available: "2007-06"
 2655	adjusted skewed bottle of absinthe	0		Effect: "Hair on Your Chest", Effect Duration: 22, Last Available: "2007-06"
 2656	prompt lightning-fast Drowsy Sword	0		Initiative: +40, Adventures: +3
-2657	immense adequate twirling escargotsicle	8	good	Last Available: "2007-06"
+2657	adequate immense twirling escargotsicle	8	good	Last Available: "2007-06"
 2658	high-proof lousy bottle of realpagne	8	decent	Last Available: "2007-06"
 2659	lime green wobbly ruddy albatross necklace	0		Maximum HP Percent: +40, Single Equip, Last Available: "2007-06"
-2660	compressed jittery blinking not-a-pipe	1	crappy	Last Available: "2007-06"
+2660	compressed blinking jittery not-a-pipe	1	crappy	Last Available: "2007-06"
 2661	drinkable flask of Amontillado	3	good	Last Available: "2007-06"
 2662	asbestos-lined ball mask	0		Hot Resistance: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	upside-down baleful Can-Can skirt	0		Spell Damage: +25, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
@@ -2641,17 +2641,17 @@
 2668	pickled ghostly can-can-in-a-can	1		Effect: "Blessing of Pikachutlotal", Effect Duration: 5, Last Available: "2007-06"
 2669	mixed pulsating patent antipsychotics	1		Last Available: "2007-06"
 2670	boiled maroon huge Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	smooth high-proof shot of nepenthe schnapps	7	awesome	Last Available: "2007-06"
+2671	high-proof smooth shot of nepenthe schnapps	7	awesome	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	spinning twirling Bohemian rhapsody	0		Last Available: "2007-06"
-2674	warmed ionized lime green tumbling bottle of cat tonic	0		Effect: "You Know Who to Call", Effect Duration: 68, Last Available: "2007-06"
+2674	warmed ionized tumbling lime green bottle of cat tonic	0		Effect: "You Know Who to Call", Effect Duration: 68, Last Available: "2007-06"
 2675	pickled green handful of moss	1		Effect: "Nigh-Invincible", Effect Duration: 35
 2676	powdered skewed narrow bit-o-cactus	1		
-2677	compressed tumbling cyan protein powder	1		
+2677	compressed cyan tumbling protein powder	1		
 2678	spectre scepter	0		
 2679	warmed sparkler	0		Effect: "Phairly Pheromonal", Effect Duration: 32
 2680	unsweetened red squat snake	0		Effect: "Florid Cheeks", Effect Duration: 49, Wiki Name: "snake"
-2681	nitrogenated lime green jittery M-242	0		Effect: "Musky", Effect Duration: 42
+2681	nitrogenated jittery lime green M-242	0		Effect: "Musky", Effect Duration: 42
 2682	detuned radio	0		
 2683	bouncing Warehouse 23 crate	0		
 2684	maroon miser's double-paned armgun	0		Cold Resistance: +5, Meat Drop: +10
@@ -2661,14 +2661,14 @@
 2688	Annie Oakley's hardy educational dreadlock whip	0		Experience: +1, Maximum HP: +50, Critical Hit Percent: +20
 2689	coward's brawny beer-a-pult	0		Muscle Percent: +20, Monster Level: -20
 2690	rosy-cheeked weightlifter's cast-iron legacy paddle	0		Muscle: +15, Maximum HP Percent: +30
-2691	miniature rotten lime green handful of nuts and berries	2	crappy	
+2691	rotten miniature lime green handful of nuts and berries	2	crappy	
 2692	asbestos-lined occult driftwood sculpture	0		Spell Damage Percent: +25, Hot Resistance: +5
 2693	shaking censurious padded massive sitar	0		Damage Absorption: +20, Sleaze Resistance: +3
 2694	friendly supercool stone baseball cap of temperance	0		Moxie Percent: +20, Familiar Weight: +3, Sleaze Resistance: +5, Familiar Effect: "1xVolley, cap 48"
 2695	lousy cup of beer	3	decent	
 2696	ovoid thing	0		
 2697	duct tape	0		
-2698	huge olive duct tape wallet	0		
+2698	olive huge duct tape wallet	0		
 2699	occult beefy duct tape shirt	0		Muscle: +10, Spell Damage Percent: +25
 2700	stanky toasty duct tape fedora	0		Hot Damage: +5, Stench Spell Damage: +25, Familiar Effect: "1xBarrr, 1xLep, cap 48"
 2701	Jack Frost's Van der Graaf duct tape sword	0		Cold Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7
@@ -2694,24 +2694,24 @@
 2721	jittery prompt chilly hand-carved staff of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5, Adventures: +3
 2722	skewed ribald crafty Sinatra's thinker's Staff of the Greasefire	0		Mysticality: +10, Experience (Moxie): +5, Maximum MP: +10, Sleaze Damage: +10
 2723	squat banded studded Socratic Staff of the Grand Flamb&eacute;	0		Experience (Mysticality): +1, Damage Absorption: 180
-2724	special decent bowl of rye sprouts	4	good	Effect: "Familial Ties", Effect Duration: 5
+2724	decent special bowl of rye sprouts	4	good	Effect: "Familial Ties", Effect Duration: 5
 2725	half-sized flavorless cob of corn	2	decent	
 2726	rotten juniper berries	3	crappy	
 2727	immense flavorless plum	6	decent	
 2728	normal pear	4	good	
 2729	bland twirling peach	3	decent	
-2730	aged practically non-alcoholic plum wine	1	awesome	
+2730	practically non-alcoholic aged plum wine	1	awesome	
 2731	tolerable weak fuchsia shot of pear schnapps	2	good	
 2732	enchanted mediocre triple-distilled shot of peach schnapps	7	decent	Effect: "'Roids of the Rhinoceros", Effect Duration: 5
 2733	rotten bunch of square grapes	3	crappy	
-2734	super-sized spoiled blue brown sugar cane	5	crappy	
+2734	spoiled super-sized blue brown sugar cane	5	crappy	
 2735	stale small twirling sandwich of the gods	2	decent	
 2736	bad weak maroon bouncing Pan-Dimensional Gargle Blaster	2	decent	
-2737	compressed squat olive leopard-print barbell	1	crappy	Effect: "Vitali Tea", Effect Duration: 5
+2737	compressed olive squat leopard-print barbell	1	crappy	Effect: "Vitali Tea", Effect Duration: 5
 2738	pile of smoking rags	0		
 2739	quadruple-unsweetened wet energized panty raider camouflage	0		Effect: "Creepypasted", Effect Duration: 58
 2740	greasy quilted Staff of the Walk-In Freezer of incineration	0		Damage Absorption: +40, Hot Spell Damage: +50, Sleaze Spell Damage: +10
-2741	bad fancy olive boilermaker	3	decent	Effect: "Infernal Thirst", Effect Duration: 5
+2741	fancy bad olive boilermaker	3	decent	Effect: "Infernal Thirst", Effect Duration: 5
 2742	flavorless steel lasagna	4	quest	
 2743	bad steel margarita	3	quest	
 2744	boiled steel-scented air freshener	1		
@@ -2735,7 +2735,7 @@
 2762	steel-toed hardened Orange Star of Sacrifice	0		Damage Reduction: 24, Single Equip
 2763	clever Pink Heart of Spirit of mayonnaise	0		Maximum MP: +20, Sleaze Spell Damage: +50, Single Equip
 2764	shaking lard-coated Jeselnik's Order of the Silver Wossname of the pedagogue	0		Experience: +3, Sleaze Damage: +25, Sleaze Spell Damage: +25, Single Equip
-2765	bouncing huge pulsating Harold's bell	0		
+2765	pulsating huge bouncing Harold's bell	0		
 2766	bowling ball	0		
 2767	fancy rotten Crimbo pie	4	crappy	Effect: "EVISCERATE!", Effect Duration: 35
 2768	rotten mirror pear tart	4	crappy	
@@ -2780,7 +2780,7 @@
 2807	super-cold-filtered flask of hamethyst juice	0		Effect: "Castaway Physique", Effect Duration: 29
 2808	enhanced pickled wobbly flask of baconstone juice	0		Effect: "Abyssal Tears", Effect Duration: 29
 2809	anodized double-flattened upside-down flask of porquoise juice	0		Effect: "Healthy Red Glow", Effect Duration: 14
-2810	ionized wobbly bouncing maroon jug of hamethyst juice	0		Effect: "Good with the Ladies", Effect Duration: 57
+2810	ionized bouncing maroon wobbly jug of hamethyst juice	0		Effect: "Good with the Ladies", Effect Duration: 57
 2811	denatured jug of baconstone juice	0		Effect: "Retrograde Relaxation", Effect Duration: 38
 2812	liquefied jug of porquoise juice	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 54
 2813	flame-wreathed friendly Beret	0		Familiar Weight: +3, Hot Spell Damage: +10, Four Songs, Familiar Effect: "1xVolley, 1xLep"
@@ -2811,7 +2811,7 @@
 2838	Fonzie's slick glowstick	0		Moxie: +10, Experience (Moxie): +1, Last Available: "2007-08"
 2839	asbestos-lined Periodical Paintbrush	0		Hot Resistance: +5, Softcore Only
 2840	hand-crafted bottle of cooking sherry	3	EPIC	
-2841	miniature enchanted decent spinning packet of ketchup	2	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
+2841	enchanted miniature decent spinning packet of ketchup	2	good	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
 2842	fancy acceptable accidental cider	4	good	Effect: "Tennis Elbow-wow", Effect Duration: 15
 2843	decent bouncing dire fudgesicle	4	good	
 2844	up-at-dawn friendly vibrating wholesome navel ring of navel gazing	0		Maximum HP Percent: +10, Maximum MP Percent: +10, Familiar Weight: +3, Adventures: +5, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2911,7 +2911,7 @@
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	bland red Surprise Egg	4	decent	
-2941	pickled warmed skewed gray mirror Steal This Candy	0		Effect: "Medieval Mage Mayhem", Effect Duration: 32
+2941	pickled warmed skewed mirror gray Steal This Candy	0		Effect: "Medieval Mage Mayhem", Effect Duration: 32
 2942	vacuum-sealed shaking chocolate filthy lucre	0		Effect: "Unusual Fashion Sense", Effect Duration: 14
 2943	deionized ghostly Angry Farmer's Wife Candy	0		Effect: "Innately Strong", Effect Duration: 33
 2945	prompt Sherlock's party hat	0		Item Drop: +25, Adventures: +3, Familiar Effect: "4xLep, cap 7"
@@ -2931,21 +2931,21 @@
 2959	executive rum barrel charrrm bracelet	0		Meat Drop: +40
 2960	huge decent single-serving herbal stuffing	8	good	
 2961	flavorless tumbling packet of tofurkey gravy	4	decent	
-2962	huge flavorless tofurkey nugget	8	decent	
+2962	flavorless huge tofurkey nugget	8	decent	
 2963	rigging shampoo	0		
 2964	shaking ball polish	0		
 2965	mirror mizzenmast mop	0		
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	flattened upside-down Swabbie&trade; swab	0		Effect: "Turkey-Agitated", Effect Duration: 67
 2968	oxidized dry Oil of Parrrlay	0		Effect: "Sagittarius Rising", Effect Duration: 61
-2969	bland immense green shaking bouncing creamsicle	8	decent	
-2970	fortified mediocre cream stout	5	decent	
+2969	immense bland shaking green bouncing creamsicle	8	decent	
+2970	mediocre fortified cream stout	5	decent	
 2971	pulsating gravedigger's curmudgel of bravery	0		Spooky Damage: +10, Spooky Resistance: +5
 2972	ghostly green grumpy man charrrm	0		
 2973	Annie Oakley's grumpy man charrrm bracelet	0		Critical Hit Percent: +20, Single Equip
 2974	green tarrrnish charrrm	0		
 2975	mirror Van der Graaf personal trainer's tarrrnished charrrm bracelet	0		Experience Percent (Muscle): +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-2976	lousy boozy bilge wine	5	decent	
+2976	boozy lousy bilge wine	5	decent	
 2977	witty rapier of the glutton	0		Food Drop: +100
 2978	jittery double-paned yohohoyo of the scaredy-cat	0		Monster Level: -15, Cold Resistance: +5
 2979	quadruple-moist fish-liver oil	0		Effect: "Hangdog", Effect Duration: 52
@@ -2961,14 +2961,14 @@
 2989	wobbly clingfilm trousers of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
 2990	blinking Usain Bolt's flame-retardant clingfilm cap	0		Hot Resistance: +1, Initiative: +80, Familiar Effect: "1xVolley, cap 37"
 2991	friendly clingfilm slippers	0		Familiar Weight: +3, Single Equip
-2992	maroon twirling squat clingfilm tangle	0		
+2992	maroon squat twirling clingfilm tangle	0		
 2993	rotten vinegar-soaked lemon slice	3	crappy	
 2994	concentrated diffused ghostly true grit	0		Effect: "Oth-Jeal-O", Effect Duration: 65
 2995	occult Rosewater's buoybottoms of the bloodbag	0		Mysticality Percent: +30, Spell Damage Percent: +25, Maximum HP: +100, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	shaking grungy flannel shirt of Leguizamo	0		Monster Level: +20
 2997	flame-retardant frosty grungy bandana	0		Cold Spell Damage: +10, Hot Resistance: +1, Familiar Effect: "1xVolley, 0.5xPotato, cap 37"
 2998	fuchsia Jeselnik's grassy cutlass	0		Sleaze Damage: +25
-2999	bouncing fuchsia Cap'm Caronch's nasty booty	0		
+2999	fuchsia bouncing Cap'm Caronch's nasty booty	0		
 3000	Cap'm Caronch's dentures	0		
 3001	huge Samson's pegleg	0		Experience (Muscle): +5, Single Equip
 3002	tumbling veiny lam&eacute; pants	0		Maximum HP: +10, Familiar Effect: "2xPotato, 1xLep, cap 25"
@@ -2991,23 +2991,23 @@
 3019	all-purpose cleaner	0		
 3020	wobbly handful of sawdust	0		
 3021	stone triangle	0		
-3022	pulsating mirror medium stone triangle	0		
+3022	mirror pulsating medium stone triangle	0		
 3023	small stone triangle	0		
 3024	stone pyramid	0		
-3025	bad practically non-alcoholic purple blurry corpse on the beach	1	decent	
+3025	bad practically non-alcoholic blurry purple corpse on the beach	1	decent	
 3026	tolerable irresponsibly strong corpsetini	7	good	
-3027	weak hand-crafted corpsedriver	2	super ultra mega EPIC	
+3027	hand-crafted weak corpsedriver	2	super ultra mega EPIC	
 3028	watered-down acceptable Corpse Island iced tea	2	good	
 3029	bad practically non-alcoholic red-headed corpse	1	decent	
 3030	bad kamicorpse-ee	3	decent	
 3031	aged huge corpsel	3	awesome	
-3032	mediocre practically non-alcoholic corpsebite	1	decent	
+3032	practically non-alcoholic mediocre corpsebite	1	decent	
 3033	zippy pirate fledges	0		Initiative: +20
 3034	piece of thirteen	0		
 3035	flavorless low-calorie pearl onion	1	decent	
-3036	normal bite-sized sea biscuit	1	good	
-3037	watered-down drinkable bottle of rum	2	good	
-3038	hand-crafted triple-distilled bottle of black-label rum	10	EPIC	
+3036	bite-sized normal sea biscuit	1	good	
+3037	drinkable watered-down bottle of rum	2	good	
+3038	triple-distilled hand-crafted bottle of black-label rum	10	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
@@ -3015,7 +3015,7 @@
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	huge metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	gigantic delicious twirling nanite-infested gingerbread bugbear	10	awesome	Last Available: "2007-12"
-3046	tiny normal nanite-infested candy cane	1	good	Last Available: "2020-09"
+3046	normal tiny nanite-infested candy cane	1	good	Last Available: "2020-09"
 3047	normal blue nanite-infested fruitcake	4	good	Last Available: "2007-12"
 3048	delicious weak spinning nanite-infested eggnog	2	awesome	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
@@ -3060,7 +3060,7 @@
 3088	blue crafty banded biomechanical crimborg helmet	0		Damage Absorption: +100, Maximum MP: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	jittery sizzling C.B.F.G. of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Last Available: "2007-12"
 3090	blinking skewed greedy reassuring biomechanical crimborg leg armor	0		Spooky Resistance: +1, Meat Drop: +20, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
-3091	ionized nitrogenated bouncing tumbling vitachoconutriment capsule	0		Effect: "Innately Wise", Effect Duration: 53, Last Available: "2007-12"
+3091	ionized nitrogenated tumbling bouncing vitachoconutriment capsule	0		Effect: "Innately Wise", Effect Duration: 53, Last Available: "2007-12"
 3092	ghostly shaking resourceful handmade hobby horse	0		Maximum MP: +50, Last Available: "2007-12"
 3093	maroon beefcake's ball-in-a-cup	0		Muscle: +25, Last Available: "2007-12"
 3094	twirling blinking occult set of jacks	0		Spell Damage Percent: +25, Last Available: "2007-12"
@@ -3078,7 +3078,7 @@
 3106	blinking therapeutic cyborg stompin' boot of the cougar of the overflowing toilet	0		Moxie: +20, Stench Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2007-12"
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	upside-down overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
-3109	jittery shaking Miniborg stomper	0		Last Available: "2007-12"
+3109	shaking jittery Miniborg stomper	0		Last Available: "2007-12"
 3110	purple Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
@@ -3093,7 +3093,7 @@
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	teal divine cracker	0		Last Available: "2008-01"
 3123	divine champagne flute	0		Last Available: "2008-01"
-3124	irradiated squat skewed fruitfilm	0		Effect: "Cravin' for a Ravin'", Effect Duration: 50
+3124	irradiated skewed squat fruitfilm	0		Effect: "Cravin' for a Ravin'", Effect Duration: 50
 3125	ionized piece of after eight	0		Effect: "Jingle Jangle Jingle", Effect Duration: 48
 3126	hobo nickel	0		
 3127	sandcastle	0		
@@ -3114,11 +3114,11 @@
 3142	beefcake's cup of infinite pencils	0		Muscle: +25
 3143	bouncing thinker's Hodgman's disgusting technicolor overcoat of the early riser	0		Mysticality: +10, Adventures: +7
 3144	blurry a torn paper strip	0		
-3145	fuchsia blurry El Vibrato translator	0		
+3145	blurry fuchsia El Vibrato translator	0		
 3146	ghostly El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
-3149	narrow mirror El Vibrato punchcard (213 holes)	0		
+3149	mirror narrow El Vibrato punchcard (213 holes)	0		
 3150	blinking El Vibrato punchcard (165 holes)	0		
 3151	pulsating El Vibrato punchcard (142 holes)	0		
 3152	ghostly El Vibrato punchcard (216 holes)	0		
@@ -3138,21 +3138,21 @@
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	tarnished diffused seal eyeball	0		Effect: "Cake Caked", Effect Duration: 48
-3169	jumbo rotten turtle soup	5	crappy	Effect: "[598]A Little Bit Evil"
+3169	rotten jumbo turtle soup	5	crappy	Effect: "[598]A Little Bit Evil"
 3170	spinning evil noodles	0		
 3171	blurry nauseating reagent	0		
 3172	gray steel-toed evil paper umbrella	0		Damage Reduction: 9
 3173	concentrated evil vihuela	0		Effect: "Gobliny Flavor", Effect Duration: 34
-3174	moldy super-sized evil boring spaghetti	5	crappy	
-3175	enchanted small tasty evil noodles	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 10
-3176	gigantic adequate wobbly ghostly evil noodles	9	good	
+3174	super-sized moldy evil boring spaghetti	5	crappy	
+3175	small tasty enchanted evil noodles	2	awesome	Effect: "The Halls of Mysticality", Effect Duration: 10
+3176	adequate gigantic wobbly ghostly evil noodles	9	good	
 3177	tiny moldy evil painful penne pasta	1	crappy	
 3178	yummy super-sized 3vi1 pr0n m4nic0tti	5	awesome	
 3179	tasty purple evil ravioli della hippy	4	awesome	
 3180	rotten olive evil noodles	3	crappy	
 3181	enhanced altered evil potion of potency	0		Effect: "New and Improved", Effect Duration: 26
 3182	corrupted evil libation of liveliness	0		Effect: "Squirming Like a Toad", Effect Duration: 15
-3183	dry mirror purple evil tomato juice of powerful power	0		Effect: "Fratty Flavor", Effect Duration: 14
+3183	dry purple mirror evil tomato juice of powerful power	0		Effect: "Fratty Flavor", Effect Duration: 14
 3184	energized evil eyedrops of the ermine	0		Effect: "Magically Delicious", Effect Duration: 36
 3185	dry wet mirror evil ointment of the occult	0		Effect: "Happy Trails", Effect Duration: 29
 3186	corrupted colloidal wobbly evil serum of sarcasm	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 17
@@ -3177,7 +3177,7 @@
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	dwarvish punchcard	0		
-3208	cyan jittery skewed small laminated card	0		
+3208	skewed cyan jittery small laminated card	0		
 3209	laminated card	0		
 3210	huge notbig laminated card	0		
 3211	ghostly unlarge laminated card	0		
@@ -3195,7 +3195,7 @@
 3223	sewer nuggets	0		
 3224	upside-down sewer wad	0		
 3225	acceptable bottle of sewage schnapps	3	good	
-3226	special hand-crafted narrow bottle of Ooze-O	4	EPIC	Effect: "Gr8ness", Effect Duration: 50
+3226	hand-crafted special narrow bottle of Ooze-O	4	EPIC	Effect: "Gr8ness", Effect Duration: 50
 3227	toothsome C.H.U.M. chum	4	awesome	
 3228	stale immense lime green unfortunate dumplings	9	decent	
 3229	decaying goldfish liver	0		
@@ -3214,7 +3214,7 @@
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	bouncing Summer Nights	0		Skill: "Grease Lightning"
-3245	pulsating tumbling Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
+3245	tumbling pulsating Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	mirror nasty groovy Ol' Scratch's ol' britches	0		Moxie Percent: +10, Stench Damage: +5, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
 3247	nasty educational Ol' Scratch's stovepipe hat	0		Experience: +1, Stench Damage: +5, Class: "Sauceror", Familiar Effect: "hot atk"
 3248	blue narrow brawny Ol' Scratch's ash can of the sewer of the cheetah	0		Muscle Percent: +20, Stench Damage: +25, Initiative: +60, Class: "Sauceror"
@@ -3237,7 +3237,7 @@
 3265	bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
-3268	cold-filtered blinking red handful of Crotchety Pine needles	0		Effect: "Industrial Strength Starch", Effect Duration: 57
+3268	cold-filtered red blinking handful of Crotchety Pine needles	0		Effect: "Industrial Strength Starch", Effect Duration: 57
 3269	extra-alkaline lump of Saccharine Maple sap	0		Effect: "Vinegavotte", Effect Duration: 52
 3270	triple-boiled ionized pulsating handful of Laughing Willow bark	0		Effect: "Stinky Hands", Effect Duration: 24
 3271	avaricious crotchety pants	0		Meat Drop: +30, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
@@ -3252,7 +3252,7 @@
 3280	fuchsia personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	family-friendly stick-on eyebrow piercing	0		Sleaze Resistance: +1, Last Available: "2008-04"
-3283	decent gigantic enchanted salad	10	good	Effect: "Impregnabili Tea", Effect Duration: 45
+3283	decent enchanted gigantic salad	10	good	Effect: "Impregnabili Tea", Effect Duration: 45
 3284	greedy C.H.U.M. lantern of the empath	0		Familiar Weight: +5, Meat Drop: +20
 3285	wobbly C.H.U.M. knife of the ox	0		Muscle: +20
 3286	teal boxer's Frosty's snowball sack	0		Muscle Percent: +10
@@ -3264,7 +3264,7 @@
 3292	skewed adorable seal larva	0		
 3293	squat purple untamable turtle	0		
 3294	blinking macaroni duck	0		
-3295	blue skewed huge friendly cheez blob	0		
+3295	blue huge skewed friendly cheez blob	0		
 3296	narrow unusual disco ball	0		
 3297	stray chihuahua	0		
 3298	pretty pink bow	0		
@@ -3296,7 +3296,7 @@
 3324	green Frosty's frosty mug	0		
 3325	bad blurry yellow jar of fermented pickle juice	3	decent	
 3326	powdered tumbling voodoo snuff	1	good	Effect: "Glittering Eyelashes", Effect Duration: 20
-3327	spoiled jumbo extra-greasy slider	5	crappy	
+3327	jumbo spoiled extra-greasy slider	5	crappy	
 3328	tumbling shaking clever energetic crumpled felt fedora	0		Maximum MP Percent: +20, Maximum MP: +20, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	huge censurious personal trainer's battered top-hat	0		Experience Percent (Muscle): +10, Sleaze Resistance: +3, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	Oprah's Socratic shapeless wide-brimmed hat	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3304,7 +3304,7 @@
 3332	shaking frightening banded hobo dungarees	0		Damage Absorption: +100, Spooky Damage: +5, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	careful patched suit-pants of the sweet-tooth	0		Monster Level: -10, Candy Drop: +100, Familiar Effect: "1xPotato, 0.5xFairy"
 3334	hobo stogie	0		Single Equip
-3335	blinking olive rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
+3335	olive blinking rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	arcane researcher's dead guy's memento of Leguizamo	0		Experience Percent (Mysticality): +10, Monster Level: +20, Single Equip
 3338	stale banquet	3	decent	
@@ -3319,7 +3319,7 @@
 3347	comfy coffin	0		
 3348	narrow mattress	0		
 3349	dinged-up triangle	0		
-3350	delicious extra-dry Ralph IX cognac	5	awesome	
+3350	extra-dry delicious Ralph IX cognac	5	awesome	
 3351	wobbly llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	frozen improved llama lama gong	0		Effect: "Frozen Shoulders", Effect Duration: 23, Last Available: "2008-06"
@@ -3332,7 +3332,7 @@
 3360	twirling stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	immense decent mole mol&eacute;	9	good	Last Available: "2008-06"
+3363	decent immense mole mol&eacute;	9	good	Last Available: "2008-06"
 3364	drinkable spirit-forward Morlock's Mark Bourbon	5	good	Last Available: "2008-06"
 3365	wet Climate Colada	0		Effect: "Overstimulated", Effect Duration: 69, Last Available: "2008-06"
 3366	extra-adjusted upside-down digital underground potion	0		Effect: "Familial Ties", Effect Duration: 31, Last Available: "2008-06"
@@ -3360,15 +3360,15 @@
 3388	Zombo's empty eye	0		
 3389	friendly Frosty's arm of vim and vigor	0		Maximum HP Percent: +50, Familiar Weight: +3
 3390	twirling prompt wool veiny Staff of the Deepest Freeze	0		Maximum HP: +10, Cold Resistance: +1, Adventures: +3
-3391	blinking twirling Frosty's iceball	0		
+3391	twirling blinking Frosty's iceball	0		
 3392	squat mirror chilly Oscus's garbage can lid	0		Cold Damage: +5, Damage Reduction: 15
 3393	Oscus's neverending soda	0		
 3394	nasty Oscus's flypaper pants of extreme caution	0		Monster Level: -25, Stench Damage: +5, Familiar Effect: "stench atk, 1xPotato"
 3395	Jeselnik's frosty Hodgman's porkpie hat	0		Cold Spell Damage: +10, Sleaze Damage: +25, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	pulsating manspreader's Hodgman's lobsterskin pants of the early riser	0		Monster Level: +10, Adventures: +7, Familiar Effect: "atk, 1xPotato"
 3397	healthy Hodgman's bow tie of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +20, Single Equip
-3398	practically non-alcoholic artisanal Hodgman's blanket	1	super ultra mega turbo EPIC	
-3399	watered-down bad jar of squeeze	2	decent	
+3398	artisanal practically non-alcoholic Hodgman's blanket	1	super ultra mega turbo EPIC	
+3399	bad watered-down jar of squeeze	2	decent	
 3400	snack-sized bland bowl of fishysoisse	2	decent	
 3401	colloidal non-concentrated deadly lampshade	0		Effect: "Vitamin-Maxed", Effect Duration: 42
 3402	ionized gray concentrated garbage juice	0		Effect: "Pyromania", Effect Duration: 28
@@ -3423,11 +3423,11 @@
 3456	aromatic trusty torch	0		Stench Resistance: +1, Last Available: "2011-12"
 3457	MacGyver's Junior Adventurer's merit badge	0		Maximum MP: +100
 3458	triple-electrified jittery STYX deodorant body spray	0		Effect: "Frostbeard", Effect Duration: 12
-3459	practically non-alcoholic perfectly mixed white-label gin	1	super ultra EPIC	
+3459	perfectly mixed practically non-alcoholic white-label gin	1	super ultra EPIC	
 3460	adequate big tin rations	5	good	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
-3463	hand-crafted watered-down pulsating bottle of sake	2	EPIC	
+3463	watered-down hand-crafted pulsating bottle of sake	2	EPIC	
 3464	spinning round pebble of the overflowing toilet	0		Stench Spell Damage: +50
 3465	stale Bash-&#332;s cereal	4	decent	Wiki Name: "Bash-Os cereal"
 3466	sizzling hardy thinker's haiku katana	0		Mysticality: +10, Maximum HP: +50, Hot Damage: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
@@ -3454,7 +3454,7 @@
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
 3489	stale half-sized beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
-3490	adequate diet glistening fish meat	1	good	Effect: "Fishy", Effect Duration: 5
+3490	diet adequate glistening fish meat	1	good	Effect: "Fishy", Effect Duration: 5
 3491	spoiled slick fish meat	4	crappy	Effect: "Fishy", Effect Duration: 5
 3492	resourceful grievous fish scimitar	0		Weapon Damage Percent: +50, Maximum MP: +50
 3493	Temple Grandin's fish stick of vim and vigor	0		Maximum HP Percent: +50, Familiar Weight: +7
@@ -3519,16 +3519,16 @@
 3552	pulsating inspector's mansplainer's octopus's spade of Flo-Jo	0		Monster Level: +15, Item Drop: +15, Initiative: +100
 3553	soggy seed packet	0		
 3554	glob of slime	0		
-3555	small tasty sea carrot	2	awesome	
-3556	flavorless gigantic sea cucumber	6	decent	
+3555	tasty small sea carrot	2	awesome	
+3556	gigantic flavorless sea cucumber	6	decent	
 3557	spoiled sea avocado	4	crappy	
 3558	decent sea lychee	4	good	
 3559	normal sea tangelo	3	good	
-3560	normal low-calorie sea honeydew	1	good	
+3560	low-calorie normal sea honeydew	1	good	
 3561	frozen polymerized pressurized potion of puissance	0		Effect: "Capricorn Rising", Effect Duration: 45
 3562	frozen non-moist dry jittery pressurized potion of perspicacity	0		Effect: "Bone Chilling", Effect Duration: 46
-3563	corrupted corrupted narrow shaking maroon pressurized potion of pulchritude	0		Effect: "Pharmaceutically Cool", Effect Duration: 43
-3564	acceptable weak berry-infused sake	2	good	
+3563	corrupted corrupted shaking narrow maroon pressurized potion of pulchritude	0		Effect: "Pharmaceutically Cool", Effect Duration: 43
+3564	weak acceptable berry-infused sake	2	good	
 3565	mediocre upside-down red citrus-infused sake	4	decent	
 3566	mediocre melon-infused sake	3	decent	
 3567	slab of sponge	0		
@@ -3546,9 +3546,9 @@
 3579	ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	twirling wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	adequate diet mirror blurry rice	1	good	
+3582	adequate diet blurry mirror rice	1	good	
 3584	thick delicious irradiated candy cane	5	awesome	Last Available: "2008-12"
-3585	special adequate gingerbread mutant bugbear	3	good	Effect: "Human-Elemental Hybrid", Effect Duration: 10, Last Available: "2008-12"
+3585	adequate special gingerbread mutant bugbear	3	good	Effect: "Human-Elemental Hybrid", Effect Duration: 10, Last Available: "2008-12"
 3586	artisanal enchanted oozenog	3	EPIC	Effect: "Vital", Effect Duration: 40, Last Available: "2008-12"
 3587	quadruple-magnetized twirling sugar plum	0		Effect: "Toast Tea", Effect Duration: 14, Last Available: "2008-12"
 3588	vacuum-sealed upside-down sugar banana	0		Effect: "Takin' It Greasy", Effect Duration: 34, Last Available: "2008-12"
@@ -3559,7 +3559,7 @@
 3593	Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	irradiated Mer-kin fastjuice	0		Effect: "Simulation Stimulation", Effect Duration: 54
-3596	shaking skewed red imitation crab crate	0		
+3596	shaking red skewed imitation crab crate	0		
 3597	imitation crab meat	0		
 3598	imitation crab zoea	0		
 3599	avaricious knitted curative moist sailor's cap	0		Cold Resistance: +3, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "stench atk"
@@ -3608,13 +3608,13 @@
 3642	dragonfish caviar	0		
 3643	jittery pufferfish spine	0		
 3644	depleted Grimacite kneecapping stick	0		Item Drop: +5, Last Available: "2007-06"
-3645	spirit-forward hand-crafted canteen of wine	5	EPIC	Last Available: "2008-12"
+3645	hand-crafted spirit-forward canteen of wine	5	EPIC	Last Available: "2008-12"
 3646	bland elven <i>limbos</i> gingerbread	4	decent	Last Available: "2008-12"
 3647	gray elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	flavorless toast with jam	4	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	perfectly mixed jittery elven moonshine	3	EPIC	Last Available: "2008-12"
 3653	rotten cyan knuckle sandwich	4	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	purple MacGyver's smartaleck's psycho sweater	0		Moxie Percent: +30, Maximum MP: +100, Last Available: "2008-12"
@@ -3634,7 +3634,7 @@
 3668	scandalous hale glow-in-the-dark wristwatch	0		Maximum HP: +20, Sleaze Damage: +5, Single Equip, Last Available: "2009-01"
 3669	pulsating flame-retardant glow-in-the-dark dart gun	0		Hot Resistance: +1, Last Available: "2009-01"
 3670	blue mansplainer's glow-in-the-dark burrowgrub	0		Monster Level: +15, Last Available: "2009-01"
-3671	skewed huge blue Uncle Crimbo's Rations	0		Last Available: "2010-12"
+3671	blue skewed huge Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	spoiled can of franks 'n' beans	4	crappy	Last Available: "2010-12"
 3673	strong smooth bottle of peppermint schnapps	5	awesome	Last Available: "2010-12"
 3674	yellow throbbing rage gland	0		Skill: "Vent Rage Gland"
@@ -3647,17 +3647,17 @@
 3681	jittery bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	decent massive bouncing tempura carrot	10	good	
-3685	normal miniature huge tempura cucumber	2	good	
+3684	massive decent bouncing tempura carrot	10	good	
+3685	miniature normal huge tempura cucumber	2	good	
 3686	moldy tempura avocado	3	crappy	
-3687	special spoiled sea broccoli	3	crappy	Effect: "So Fresh and So Clean", Effect Duration: 15
-3688	snack-sized moldy sea cauliflower	2	crappy	
+3687	spoiled special sea broccoli	3	crappy	Effect: "So Fresh and So Clean", Effect Duration: 15
+3688	moldy snack-sized sea cauliflower	2	crappy	
 3689	snack-sized normal tempura broccoli	2	good	
 3690	adequate tempura cauliflower	4	good	
 3691	tiny toothsome sea blueberry	1	awesome	
 3692	tasty pulsating twirling sea persimmon	4	awesome	
 3693	concentrated lime green pressurized potion of perception	0		Effect: "Square to be Hip", Effect Duration: 11
-3694	concentrated concentrated huge upside-down pressurized potion of proficiency	0		Effect: "Sugar, Hello", Effect Duration: 56
+3694	concentrated concentrated upside-down huge pressurized potion of proficiency	0		Effect: "Sugar, Hello", Effect Duration: 56
 3695	spinning razor-sharp Mer-kin digpick	0		Weapon Damage Percent: +25
 3696	skewed anemone nematocyst	0		
 3697	spinning high-pressure seltzer bottle	0		
@@ -3697,7 +3697,7 @@
 3731	glass gnoll eye of the scaredy-cat	0		Monster Level: -15
 3732	warmed chilled bouncing cigar butt	0		Effect: "Tennis Elbow-wow", Effect Duration: 17
 3733	wobbly foul-smelling manly bloomers of Leguizamo	0		Monster Level: +20, Stench Damage: +10, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
-3734	jittery mirror Colon Annihilation Hot Sauce	0		
+3734	mirror jittery Colon Annihilation Hot Sauce	0		
 3735	cyan fat wallet	0		
 3736	fortified Sinatra's handwarmer	0		Experience (Moxie): +5, Damage Absorption: +60, Single Equip
 3737	stanky Jim Carey's lighter	0		Monster Level: +25, Stench Spell Damage: +25
@@ -3713,7 +3713,7 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	irradiated mirror concoction of clumsiness	0		Effect: "Stogied", Effect Duration: 33
 3750	padded vampire pearl earring	0		Damage Absorption: +20, Single Equip
-3751	yummy tumbling gray chocolate chip brownies	4	awesome	
+3751	yummy gray tumbling chocolate chip brownies	4	awesome	
 3753	maroon Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	extra-magnetized galvanized huge skewed love song of vague ambiguity	0		Effect: "Mucilaginous Mentalism", Effect Duration: 35, Last Available: "2009-02"
 3755	diffused ionized love song of smoldering passion	0		Effect: "Sleazy Hands", Effect Duration: 36, Last Available: "2009-02"
@@ -3724,15 +3724,15 @@
 3760	colloidal frozen concentrated breath mint	0		Effect: "Hair on Your Chest", Effect Duration: 51
 3761	shaking wholesome vampire pearl ring	0		Maximum HP Percent: +10, Single Equip
 3762	twirling Usain Bolt's vampire pearl necklace	0		Initiative: +80, Single Equip
-3763	high-proof drinkable slug of vodka	10	good	
-3764	drinkable spirit-forward slug of rum	5	good	
+3763	drinkable high-proof slug of vodka	10	good	
+3764	spirit-forward drinkable slug of rum	5	good	
 3765	artisanal slug of shochu	4	EPIC	
 3766	triple-distilled mediocre screwdiver	10	decent	
 3767	fancy hand-crafted dew yoana lei	3	EPIC	Effect: "Sated and Furious", Effect Duration: 40
 3768	practically non-alcoholic acceptable shaking lychee chuhai	1	good	
-3769	tolerable triple-distilled special salacious screwdiver	8	good	Effect: "Feelin' Philosophical", Effect Duration: 5
+3769	triple-distilled tolerable special salacious screwdiver	8	good	Effect: "Feelin' Philosophical", Effect Duration: 5
 3770	drinkable dew yoana salacious lei	3	good	
-3771	special triple-distilled smooth salacious lychee chuhai	8	awesome	Effect: "Hypercubed", Effect Duration: 5
+3771	smooth triple-distilled special salacious lychee chuhai	8	awesome	Effect: "Hypercubed", Effect Duration: 5
 3772	mediocre Alewife&trade; Ale	3	decent	
 3773	seaode	0		
 3774	map to the Dive Bar	0		
@@ -3836,7 +3836,7 @@
 3882	encoded cult documents	0		
 3883	cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
-3885	galvanized spinning yellow vial of slime	0		Effect: "Ancestral Disapproval", Effect Duration: 69
+3885	galvanized yellow spinning vial of slime	0		Effect: "Ancestral Disapproval", Effect Duration: 69
 3886	modified super-oxidized spinning vial of slime	0		Effect: "Hombre Muerto Caminando", Effect Duration: 27
 3887	Vulcanized upside-down huge vial of slime	0		Effect: "Disco Neuropathy", Effect Duration: 53
 3888	galvanized concentrated wet huge vial of slime	0		Effect: "Improved Candy Vision", Effect Duration: 23
@@ -3844,7 +3844,7 @@
 3890	ionized triple-activated electrified jittery vial of violet slime	0		Effect: "Yuletide Mutations", Effect Duration: 68
 3891	ionized vial of vermilion slime	0		Effect: "Filled with Magic", Effect Duration: 43
 3892	pickled skewed vial of amber slime	0		Effect: "Eau de Tortue", Effect Duration: 58
-3893	diffused bouncing huge vial of chartreuse slime	0		Effect: "From Nantucket", Effect Duration: 66
+3893	diffused huge bouncing vial of chartreuse slime	0		Effect: "From Nantucket", Effect Duration: 66
 3894	triple-modified polarized blinking vial of teal slime	0		Effect: "Become Intensely interested", Effect Duration: 35
 3895	energized anodized quadruple-dry pulsating vial of indigo slime	0		Effect: "Violent Night", Effect Duration: 46
 3896	boiled energized spinning vial of slime	0		Effect: "Strong Grip", Effect Duration: 55
@@ -3854,7 +3854,7 @@
 3902	narrow figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	bouncing yellow figurine of a baby seal	0		Class: "Seal Clubber"
 3904	tumbling figurine of an armored seal	0		Class: "Seal Clubber"
-3905	olive narrow figurine of an seal	0		Class: "Seal Clubber"
+3905	narrow olive figurine of an seal	0		Class: "Seal Clubber"
 3906	figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	pulsating huge figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	pulsating figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	lousy triple-distilled cyan blended swill with a fly in it	9	decent	
+3913	triple-distilled lousy cyan blended swill with a fly in it	9	decent	
 3914	turtle wax	0		
 3915	green stiffened turtle wax shield	0		Damage Reduction: 3
 3916	Temple Grandin's turtle wax helmet	0		Familiar Weight: +7, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3878,7 +3878,7 @@
 3926	purple miser's flame-retardant spiky turtle shield	0		Hot Resistance: +1, Meat Drop: +10, Damage Reduction: 8
 3927	olive pulsating turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
-3929	skewed fuchsia grinning turtle	0		
+3929	fuchsia skewed grinning turtle	0		
 3930	quadruple-magnetized tainted seal's blood	0		Effect: "Here to Kick Ass", Effect Duration: 22
 3931	aromatic electrified severed flipper	0		Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
@@ -3899,7 +3899,7 @@
 3947	Clan VIP Lounge key	0		Free Pull
 3948	upside-down Meat	0		
 3949	tumbling treasure chest	0		
-3950	mirror red wobbly key	0		
+3950	wobbly red mirror key	0		
 3951	Baron von Ratsworth	0		
 3952	spinning monocle	0		
 3953	mink	0		
@@ -3987,7 +3987,7 @@
 4035	shaking memory of a crystal	0		Last Available: "2009-06"
 4036	yellow caustic slime nodule	0		
 4037	adequate slimy sweetbreads	3	good	
-4038	watered-down special perfectly mixed slimy fermented bile bladder	2	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 20
+4038	perfectly mixed special watered-down slimy fermented bile bladder	2	EPIC	Effect: "Human-Goblin Hybrid", Effect Duration: 20
 4039	altered wobbly slimy alveolus	1		
 4040	shaking memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	skewed stanky brainy pig-iron helm	0		Mysticality: +5, Stench Spell Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4019,7 +4019,7 @@
 4067	skewed essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	squat essence of	0		Last Available: "2009-06"
-4070	spinning skewed essence of stench	0		Last Available: "2009-06"
+4070	skewed spinning essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	lime green essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
@@ -4032,9 +4032,9 @@
 4080	greasy healthy grisly shield	0		Maximum HP Percent: +20, Sleaze Spell Damage: +10, Slime Hates It: +1, Damage Reduction: 13
 4081	forbidden strapping corroded breeches	0		Muscle: +5, Spell Damage Percent: +50, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	narrow supercool pernicious cudgel	0		Moxie Percent: +20, Item Drop: +5, Slime Hates It: +1
-4083	normal ghostly cyan cupcake-in-a-cup	4	good	Last Available: "2009-06"
+4083	normal cyan ghostly cupcake-in-a-cup	4	good	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	immense moldy protein paste	10	crappy	Last Available: "2009-06"
+4085	moldy immense protein paste	10	crappy	Last Available: "2009-06"
 4086	smelly Socratic cyber-mattock	0		Experience (Mysticality): +1, Stench Spell Damage: +10, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4056,7 +4056,7 @@
 4104	Rosewater's catseye marble	0		Mysticality Percent: +30
 4105	smelly bumboozer marble	0		Stench Spell Damage: +10
 4106	Fonzie's chamoisole	0		Experience (Moxie): +1
-4107	galvanized diffused cyan spinning ghostly bitter pill	0		Effect: "Kissed By Fire", Effect Duration: 29
+4107	galvanized diffused cyan ghostly spinning bitter pill	0		Effect: "Kissed By Fire", Effect Duration: 29
 4108	double-paned Sinatra's monstrous monocle	0		Experience (Moxie): +5, Cold Resistance: +5, Last Available: "2009-06"
 4109	shaking frosty Newton's musty moccasins	0		Experience (Mysticality): +3, Cold Spell Damage: +10, Last Available: "2009-06"
 4110	upside-down lion tamer's weightlifter's molten medallion	0		Muscle: +15, Experience (familiar): +2, Last Available: "2009-06"
@@ -4081,7 +4081,7 @@
 4129	squat sizzling crafty supercharged hardened slime belt	0		Maximum MP Percent: +30, Maximum MP: +10, Hot Damage: +10, Single Equip
 4130	spinning empty agua de vida bottle	0		Last Available: "2009-06"
 4131	altered maroon boot plant	1	decent	Last Available: "2009-06"
-4132	tolerable irresponsibly strong sham champagne	6	good	Last Available: "2009-06"
+4132	irresponsibly strong tolerable sham champagne	6	good	Last Available: "2009-06"
 4133	polarized aerosolized tempura air	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 15
 4134	tarnished altered upside-down gray huge pressurized potion of pneumaticity	0		Effect: "Omphalotus Omnipresence", Effect Duration: 16
 4135	narrow moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4138,7 +4138,7 @@
 4186	slime convention coupons	0		
 4187	flame-wreathed slime convention pin	0		Hot Spell Damage: +10
 4188	spinning slime convention t-shirt	0		
-4189	tumbling jittery inverse geode	0		
+4189	jittery tumbling inverse geode	0		
 4190	control crystal	0		Free Pull, Last Available: "2011-12"
 4191	vibrating sugar shirt	0		Maximum MP Percent: +10, Last Available: "2009-09"
 4192	sugar shard	0		Last Available: "2009-09"
@@ -4169,7 +4169,7 @@
 4217	mirror groupie bra	0		
 4218	non-frozen skewed upside-down groupie spangles	0		Effect: "Sharp Weapon", Effect Duration: 62
 4219	Socratic skate board of extreme caution	0		Experience (Mysticality): +1, Monster Level: -25
-4220	bouncing tumbling S.A.V.E. flyer	0		
+4220	tumbling bouncing S.A.V.E. flyer	0		
 4221	tumbling crafty yield shield	0		Maximum MP: +10, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
 4223	twirling squamous polyp	0		Free Pull, Last Available: "2011-12"
@@ -4178,7 +4178,7 @@
 4226	blinking dog trainer's Star of Bravery	0		Experience (familiar): +1, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	cyan bouncing amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	bouncing cyan amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4208,7 +4208,7 @@
 4256	non-unsweetened sap	0		Effect: "Neuroplastici Tea", Effect Duration: 32, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	stale chocolate-covered scarab beetle	3	decent	Last Available: "2009-10"
-4259	special practically non-alcoholic artisanal mulled cider	1	super ultra mega EPIC	Effect: "A Contender", Effect Duration: 15, Last Available: "2009-10"
+4259	special artisanal practically non-alcoholic mulled cider	1	super ultra mega EPIC	Effect: "A Contender", Effect Duration: 15, Last Available: "2009-10"
 4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
@@ -4303,10 +4303,10 @@
 4351	snow belly of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2009-12"
 4352	cyan pile of loose snow	0		Last Available: "2009-12"
 4353	red Crimbough	0		Last Available: "2009-12"
-4354	skewed bouncing A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
+4354	bouncing skewed A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	blurry A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
-4357	upside-down teal A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
+4357	teal upside-down A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	normal expired can of franks 'n' beans	3	good	Last Available: "2009-12"
@@ -4314,9 +4314,9 @@
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	non-flattened teal elven suicide capsule	0		Effect: "Moon'd", Effect Duration: 14, Last Available: "2009-12"
-4365	spoiled thick penguin focaccia bread	5	crappy	Last Available: "2009-12"
-4366	weak artisanal special herringcello	2	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 20, Last Available: "2009-12"
-4367	fortified artisanal blurry elven cellocello	5	EPIC	Last Available: "2009-12"
+4365	thick spoiled penguin focaccia bread	5	crappy	Last Available: "2009-12"
+4366	artisanal special weak herringcello	2	EPIC	Effect: "Blessing of Bulbazinalli", Effect Duration: 20, Last Available: "2009-12"
+4367	artisanal fortified blurry elven cellocello	5	EPIC	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
@@ -4360,7 +4360,7 @@
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	bland half-sized jittery quantum taco	0		Last Available: "2010-10"
+4412	half-sized bland jittery quantum taco	0		Last Available: "2010-10"
 4413	lousy Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	mirror fireproof sealhide hood	0		Hot Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4382,7 +4382,7 @@
 4432	alkaline ionized invisibility potion	0		Effect: "Squid Squint", Effect Duration: 52, Last Available: "2011-08"
 4433	flattened wet blurry irresistibility potion	0		Effect: "Flaming Weapon", Effect Duration: 45, Last Available: "2011-08"
 4434	adjusted galvanized irritability potion	0		Effect: "Pisces in the Skyces", Effect Duration: 54, Last Available: "2011-08"
-4436	mirror upside-down cube	0		Last Available: "2011-02"
+4436	upside-down mirror cube	0		Last Available: "2011-02"
 4438	tumbling hellseal whisker	0		
 4439	hellseal claw	0		
 4440	prompt guard turtle shell	0		Adventures: +3, Familiar Effect: "atk, 1xFairy, cap 40"
@@ -4410,7 +4410,7 @@
 4462	dry super-liquefied maroon mirror chocolate seal-clubbing club	0		Effect: "Goldentongue", Effect Duration: 44
 4463	double-vacuum-sealed wet boiled wobbly chocolate turtle totem	0		Effect: "Stogied", Effect Duration: 37
 4464	anodized chocolate pasta spoon	0		Effect: "Memory of Attractiveness", Effect Duration: 50
-4465	quadruple-tarnished nitrogenated tumbling gray chocolate saucepan	0		Effect: "Sugar High", Effect Duration: 39
+4465	quadruple-tarnished nitrogenated gray tumbling chocolate saucepan	0		Effect: "Sugar High", Effect Duration: 39
 4466	diffused quantum cyan chocolate disco ball	0		Effect: "Super-Electrified", Effect Duration: 42
 4467	galvanized ionized chocolate stolen accordion	0		Effect: "Fruited", Effect Duration: 50
 4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
@@ -4456,7 +4456,7 @@
 4508	tarnished narrow &quot;DRINK ME&quot; potion	0		Effect: "Saucemastery", Effect Duration: 36, Last Available: "2010-03"
 4509	spinning tumbling reflection of a map	0		Last Available: "2010-03"
 4510	tasty walrus ice cream	4	awesome	Last Available: "2010-03"
-4511	decent big enchanted blurry beautiful soup	5	good	Effect: "Hagg-ard", Effect Duration: 20, Last Available: "2010-03"
+4511	big decent enchanted blurry beautiful soup	5	good	Effect: "Hagg-ard", Effect Duration: 20, Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	gray Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	flavorless mirror Humpty Dumplings	3	decent	Last Available: "2010-03"
@@ -4470,7 +4470,7 @@
 4522	spinning Tiger-lily's milk	1	EPIC	Last Available: "2010-03"
 4523	shellacked personal trainer's eye of the Tiger-lily	0		Experience Percent (Muscle): +10, Damage Reduction: 7, Last Available: "2010-03"
 4524	shaking ghostly wicked thinker's wig	0		Mysticality: +10, Spell Damage: +5, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	small rotten donut	2	crappy	Last Available: "2010-03"
+4525	rotten small donut	2	crappy	Last Available: "2010-03"
 4526	spoiled bucket of honey	3	crappy	Last Available: "2010-03"
 4527	Annie Oakley's elephant stinger of temperance	0		Critical Hit Percent: +20, Sleaze Resistance: +5, Last Available: "2010-03"
 4528	moldy dragon snaps	3	crappy	Last Available: "2010-03"
@@ -4478,8 +4478,8 @@
 4530	upside-down puff of smoke	0		Last Available: "2010-03"
 4531	delicious huge lime green rook cookie	6	awesome	Last Available: "2010-03"
 4532	flavorless bishop cookie	4	decent	Last Available: "2010-03"
-4533	moldy huge tumbling knight cookie	9	crappy	Last Available: "2010-03"
-4534	delicious bite-sized king cookie	1	awesome	Last Available: "2010-03"
+4533	huge moldy tumbling knight cookie	9	crappy	Last Available: "2010-03"
+4534	bite-sized delicious king cookie	1	awesome	Last Available: "2010-03"
 4535	normal queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	squat educational insane tophat	0		Experience: +1, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4495,7 +4495,7 @@
 4547	pulsating jittery caterpillar	0		Last Available: "2010-03"
 4548	huge walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
-4550	narrow fuchsia dodo	0		Last Available: "2010-03"
+4550	fuchsia narrow dodo	0		Last Available: "2010-03"
 4551	squat detour shield of the detective	0		Item Drop: +20, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
 4553	shaking gray lowercase a	0		
@@ -4506,14 +4506,14 @@
 4558	equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
-4561	squat huge can of depilatory cream	0		Last Available: "2010-04"
+4561	huge squat can of depilatory cream	0		Last Available: "2010-04"
 4562	squat hair of the calf	0		Last Available: "2010-04"
-4563	practically non-alcoholic smooth world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
+4563	smooth practically non-alcoholic world's most unappetizing beverage	1	awesome	Last Available: "2010-04"
 4564	teal slippery when wet shield of the scaredy-cat	0		Monster Level: -15, Damage Reduction: 6, Last Available: "2010-04"
 4565	rotten raisin	3	crappy	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	flyest of shirts of vim and vigor of terror	0		Maximum HP Percent: +50, Spooky Spell Damage: +10, Last Available: "2010-04"
-4568	half-sized flavorless a dance upon the palate	2	decent	Last Available: "2010-04"
+4568	flavorless half-sized a dance upon the palate	2	decent	Last Available: "2010-04"
 4569	bland prehistoric meteorite jawbreaker	3	decent	Last Available: "2010-04"
 4570	teal Crazyleg's razor	0		Last Available: "2010-04"
 4571	moldy blinking squirmy violent party snack	4	crappy	Last Available: "2010-04"
@@ -4528,9 +4528,9 @@
 4580	shaking school Mafi<i>a kni</i>cke&frac12;&aelig; of the early riser	0		Adventures: +7, Last Available: "2010-04"
 4581	stanky brawny T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Muscle Percent: +20, Stench Spell Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
-4583	tumbling blinking cyan glob of skin	0		
-4584	delicious ghostly red six wedges of goat cheese	3	awesome	
-4585	huge mirror collection of objects	0		
+4583	cyan tumbling blinking glob of skin	0		
+4584	delicious red ghostly six wedges of goat cheese	3	awesome	
+4585	mirror huge collection of objects	0		
 4586	purple tumbling boulder	0		
 4587	yellow goth	0		
 4588	maroon brown pixel	0		
@@ -4558,7 +4558,7 @@
 4610	moist essential soy	0		Effect: "Berry Thorny", Effect Duration: 69, Last Available: "2010-08"
 4611	frozen essential cameraderie	0		Effect: "Joyful Resolve", Effect Duration: 58, Last Available: "2010-08"
 4612	skewed souvenir drawing	0		Last Available: "2010-08"
-4613	mirror wobbly map to the Magic Commune	0		Last Available: "2010-08"
+4613	wobbly mirror map to the Magic Commune	0		Last Available: "2010-08"
 4614	squat personal trainer's Crown of Thrones	0		Experience Percent (Muscle): +10, Softcore Only, Last Available: "2010-05"
 4615	bad Cinco Mayo Lager	3	decent	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
@@ -4569,7 +4569,7 @@
 4621	red Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	vacuum-sealed chocolate-covered caviar	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 51, Last Available: "2020-09"
-4624	enchanted flavorless pawn cookie	3	decent	Effect: "Impregnably Delicious", Effect Duration: 5, Last Available: "2010-06"
+4624	flavorless enchanted pawn cookie	3	decent	Effect: "Impregnably Delicious", Effect Duration: 5, Last Available: "2010-06"
 4625	compressed gray coffee pixie stick	1	decent	Effect: "Floundering", Effect Duration: 50, Last Available: "2010-06"
 4626	mirror superduperball	0		Last Available: "2010-06"
 4627	spinning blinking finger cuffs	0		Last Available: "2010-06"
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	blackberry galoshes of the businessman	0		Meat Drop: +50, Single Equip
 4660	Sherlock's Annie Oakley's trout fang	0		Critical Hit Percent: +20, Item Drop: +25, Last Available: "2010-09"
-4661	immense yummy ghostly poisonous caviar	9	awesome	Last Available: "2010-09"
+4661	yummy immense ghostly poisonous caviar	9	awesome	Last Available: "2010-09"
 4662	electrified wet venom duct	0		Effect: "Poker Faced", Effect Duration: 55, Last Available: "2010-09"
 4663	upside-down Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	gray deadly Ellsbury's skull of the scaredy-cat	0		Weapon Damage: +5, Monster Level: -15, Last Available: "2010-09"
@@ -4619,7 +4619,7 @@
 4671	artisanal booze-soaked cherry	3	EPIC	
 4672	comfy pillow	0		
 4673	spoiled blue squat marshmallow	3	crappy	
-4674	rotten massive blurry sponge cake	9	crappy	
+4674	massive rotten blurry sponge cake	9	crappy	
 4675	hand-crafted fortified gin-soaked blotter paper	5	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4631,7 +4631,7 @@
 4683	scandalous toasty pottery training pants	0		Hot Damage: +5, Sleaze Damage: +5, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	pottery club of the ox	0		Muscle: +20, Last Available: "2010-09"
 4685	gray rock-hard pottery yo-yo	0		Damage Reduction: 5, Last Available: "2010-09"
-4686	jittery teal jittery pottery barn owl figurine	0		Last Available: "2010-09"
+4686	jittery jittery teal pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
 4688	cyan fossilized serpent skull	0		Last Available: "2010-09"
 4689	pulsating fossilized baboon skull	0		Last Available: "2010-09"
@@ -4660,14 +4660,14 @@
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
 4714	stale lemon popsicle	4	decent	
-4715	decent jumbo narrow popsicle	5	good	
+4715	jumbo decent narrow popsicle	5	good	
 4716	decent tiny wobbly strawberry popsicle	1	good	
 4717	gigantic adequate liver popsicle	9	good	
 4718	jittery Jack Frost's mariachi hat	0		Cold Spell Damage: +50, Familiar Effect: "atk, cap 2"
 4719	crafty Hollandaise helmet	0		Maximum MP: +10, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	spoiled special squat liver and let pie	4	crappy	Effect: "Spirit Bubble", Effect Duration: 10, Last Available: "2010-10"
+4722	special spoiled squat liver and let pie	4	crappy	Effect: "Spirit Bubble", Effect Duration: 10, Last Available: "2010-10"
 4723	miniature bland olive badass pie	2	decent	Last Available: "2010-10"
 4724	big spoiled shoo-fish pie	5	crappy	Last Available: "2010-10"
 4725	tasty piping organ pie	3	awesome	Last Available: "2010-10"
@@ -4684,15 +4684,15 @@
 4736	tangle of rat tails	0		
 4737	boxer's beer-soaked mop	0		Muscle Percent: +10
 4738	triple-distilled delicious mirror tumbling day-old beer	8	awesome	
-4739	mediocre watered-down plain beer	2	decent	
-4740	fortified drinkable overpriced &quot;imported&quot; beer	5	good	
+4739	watered-down mediocre plain beer	2	decent	
+4740	drinkable fortified overpriced &quot;imported&quot; beer	5	good	
 4741	squat smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
 4744	flattened energized PlexiPips	0		Effect: "Larger", Effect Duration: 24
 4745	alkaline huge Wax Flask	0		Effect: "Towering Strength", Effect Duration: 21
 4746	alkaline super-deionized teal Pain Dip	0		Effect: "Memento Moir&eacute;", Effect Duration: 15
-4747	flavorless small bone meal	2	decent	Last Available: "2010-10"
+4747	small flavorless bone meal	2	decent	Last Available: "2010-10"
 4748	tolerable bone aperitif	4	good	Last Available: "2010-10"
 4749	bouncing bonerang of extreme caution	0		Monster Level: -25, Last Available: "2010-10"
 4750	sharpshooter's bone and arrows	0		Critical Hit Percent: +10, Last Available: "2010-10"
@@ -4718,13 +4718,13 @@
 4770	yellow Desert Bus pass	0		
 4771	ghostly ginormous pumpkin	0		Last Available: "2010-11"
 4804	Essence of Annoyance	0		Skill: "Summon Annoyance"
-4805	bouncing blurry Unmotivator: Crashed Orca	0		Free Pull
+4805	blurry bouncing Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	shaking Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	wobbly blurry Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	blurry wobbly Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	green Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	rotten miniature squat tumbling CRIMBCOIDS mints	2	crappy	Last Available: "2011-01"
+4818	miniature rotten squat tumbling CRIMBCOIDS mints	2	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	jumbo spoiled CRIMBCOLOAF	5	crappy	Last Available: "2011-01"
 4821	stale gigantic circular CRIMBCOOKIE	6	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4745,8 +4745,8 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	blue twirling shaking robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	big rotten skewed triangular CRIMBCOOKIE	5	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	moldy thick square CRIMBCOOKIE	5	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4839	rotten big skewed triangular CRIMBCOOKIE	5	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4840	thick moldy square CRIMBCOOKIE	5	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	fireproof personal trainer's Fonzie's bindlestocking	0		Experience (Moxie): +1, Experience Percent (Muscle): +10, Hot Resistance: +3, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	purple Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
@@ -4757,7 +4757,7 @@
 4848	friendly clever Uncle Hobo's fingerless tinsel gloves	0		Maximum MP: +20, Familiar Weight: +3, Single Equip, Last Available: "2010-12"
 4849	Jim Carey's educational Uncle Hobo's highest bough	0		Experience: +1, Monster Level: +25, Last Available: "2010-12"
 4850	wobbly healthy Uncle Hobo's belt of wisdom	0		Mysticality: +15, Maximum HP Percent: +20, Single Equip, Last Available: "2010-12"
-4851	anodized green mirror chocolate cigar	0		Effect: "Floundering", Effect Duration: 29, Last Available: "2010-12"
+4851	anodized mirror green chocolate cigar	0		Effect: "Floundering", Effect Duration: 29, Last Available: "2010-12"
 4852	fortified gift-a-pult	0		Damage Absorption: +60, Last Available: "2010-12"
 4853	deionized magnetized holly-flavored Hob-O	0		Effect: "Towering Strength", Effect Duration: 20, Last Available: "2020-09"
 4854	blurry CRIMBCO scrip	0		Last Available: "2011-01"
@@ -4778,7 +4778,7 @@
 4869	red paperclip pants of the brazier of the detective	0		Hot Spell Damage: +25, Item Drop: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
 4870	MacGyver's stiffened brawny paperclip turban	0		Muscle Percent: +20, Damage Reduction: 1, Maximum MP: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	shellacked paperclip cape	0		Damage Reduction: 7, Last Available: "2011-01"
-4872	shaking ghostly yellow glob of Blank-Out	0		Last Available: "2011-01"
+4872	ghostly shaking yellow glob of Blank-Out	0		Last Available: "2011-01"
 4873	lime green photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
 4875	twirling BGE merchandise order form	0		Last Available: "2010-12"
@@ -4790,11 +4790,11 @@
 4881	tolerable upside-down CRIMBCO wine	4	good	Last Available: "2011-01"
 4882	huge Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	blue toe jam	0		Last Available: "2011-01"
-4884	toothsome massive toe jam toast	7	awesome	Last Available: "2011-01"
+4884	massive toothsome toe jam toast	7	awesome	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	spoiled traffic jam toast	3	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	diet delicious space jam toast	1	awesome	Last Available: "2011-01"
+4888	delicious diet space jam toast	1	awesome	Last Available: "2011-01"
 4889	frozen alkaline wobbly motivational poster	0		Effect: "Shamboozled", Effect Duration: 24, Last Available: "2011-01"
 4890	blurry blurry sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
@@ -4838,10 +4838,10 @@
 4929	Uncle Crimbo's Sack	0		Last Available: "2011-01"
 4930	Folder Holder	0		Last Available: "2013-08"
 4937	a angel	0		Free Pull, Last Available: "2011-12"
-4938	skewed squat narrow quake of arrows	0		Last Available: "2011-12"
+4938	narrow skewed squat quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	small rotten Knob jelly donut	2	crappy	
+4941	rotten small Knob jelly donut	2	crappy	
 4942	Knob cake	0		
 4943	Knob cake pan	0		
 4944	blinking Knob batter	0		
@@ -4859,8 +4859,8 @@
 4956	spoiled small philosopher's scone	2	crappy	
 4957	energized polarized electrified half-baked potion	0		Effect: "Muddled", Effect Duration: 18
 4958	squat friendly Knob Goblin deluxe scimitar	0		Familiar Weight: +3
-4959	diet bland Knob nuts	1	decent	
-4960	aged irresponsibly strong Cobb's Knob Wurstbrau	6	awesome	
+4959	bland diet Knob nuts	1	decent	
+4960	irresponsibly strong aged Cobb's Knob Wurstbrau	6	awesome	
 4961	Subject 37 file	0		
 4962	upside-down brawny mysterious lapel pin of the pedagogue	0		Muscle Percent: +20, Experience: +3, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4872,8 +4872,8 @@
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
-4972	wobbly green Alice's Army Ninja	0		Last Available: "2011-03"
-4973	mirror shaking Alice's Army Alchemist	0		Last Available: "2011-03"
+4972	green wobbly Alice's Army Ninja	0		Last Available: "2011-03"
+4973	shaking mirror Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
@@ -4905,7 +4905,7 @@
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	wobbly Alice's Army Foil Cleric	0		Last Available: "2011-03"
-5005	narrow blurry Alice's Army Foil Sniper	0		Last Available: "2011-03"
+5005	blurry narrow Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	ghostly Alice's Army Foil Dervish	0		Last Available: "2011-03"
 5007	Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
@@ -4916,11 +4916,11 @@
 5013	normal low-calorie wasabi pocky	1	good	Last Available: "2011-03"
 5014	normal low-calorie tobiko pocky	1	good	Last Available: "2011-03"
 5015	toothsome natto pocky	3	awesome	Last Available: "2011-03"
-5016	hand-crafted triple-distilled wasabi-infused sake	6	EPIC	Last Available: "2011-03"
+5016	triple-distilled hand-crafted wasabi-infused sake	6	EPIC	Last Available: "2011-03"
 5017	artisanal maroon tobiko-infused sake	3	EPIC	Last Available: "2011-03"
-5018	lousy weak natto-infused sake	2	decent	Last Available: "2011-03"
+5018	weak lousy natto-infused sake	2	decent	Last Available: "2011-03"
 5019	deionized dry wasabi marble soda	0		Effect: "Okee-Dokee Go!", Effect Duration: 37, Last Available: "2011-03"
-5020	warmed red bouncing tobiko marble soda	0		Effect: "Pork Power", Effect Duration: 13, Last Available: "2011-03"
+5020	warmed bouncing red tobiko marble soda	0		Effect: "Pork Power", Effect Duration: 13, Last Available: "2011-03"
 5021	frozen irradiated blinking natto marble soda	0		Effect: "Celestial Sheen", Effect Duration: 27, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	dry elderly jawbreaker	0		Effect: "Antsy in your Pantsy", Effect Duration: 18, Last Available: "2020-09"
@@ -4943,7 +4943,7 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	Usain Bolt's lard-coated savvy astral shirt	0		Mysticality Percent: +20, Sleaze Spell Damage: +25, Initiative: +80
 5042	wicked cool astral belt	0		Moxie: +5, Spell Damage: +5
-5043	stale half-sized upside-down astral hot dog	2		
+5043	half-sized stale upside-down astral hot dog	2		
 5044	delicious shaking astral pilsner	4		
 5045	spinning astral hot dog dinner	0		
 5046	astral six-pack	0		
@@ -4965,13 +4965,13 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	blurry red Salsa de las Epocas	0		Last Available: "2011-04"
-5065	spoiled jumbo spaghetti con calaveras	5	crappy	Last Available: "2011-04"
+5065	jumbo spoiled spaghetti con calaveras	5	crappy	Last Available: "2011-04"
 5066	spinning skewed s'more gun	0		Last Available: "2011-04"
 5067	adequate mirror popcorn	3	good	Last Available: "2011-04"
 5068	tasty spinning chaos popcorn	3	awesome	Last Available: "2011-04"
 5069	shaking Jim Carey's hale hole of the pedagogue	0		Experience: +3, Maximum HP: +20, Monster Level: +25, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	low-calorie rotten s'more	0	crappy	Last Available: "2011-04"
+5071	rotten low-calorie s'more	0	crappy	Last Available: "2011-04"
 5072	tumbling diamond ring	0		Last Available: "2011-04"
 5073	drinkable Russian Ice	3	good	Last Available: "2011-04"
 5074	Jim Carey's clay ashtray	0		Monster Level: +25, Damage Reduction: 3, Last Available: "2011-05"
@@ -5015,7 +5015,7 @@
 5112	shaking My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
-5115	blurry blue hedge trimmers	0		
+5115	blue blurry hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
 5118	bird brain	0		
@@ -5032,8 +5032,8 @@
 5129	Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	dry Ultrasoldier Serum	0		Effect: "Less Pervious", Effect Duration: 43, Last Available: "2011-06"
-5132	stale big elven hardtack	5	decent	Last Available: "2011-06"
-5133	bad extra-dry elven squeeze	5	decent	Last Available: "2011-06"
+5132	big stale elven hardtack	5	decent	Last Available: "2011-06"
+5133	extra-dry bad elven squeeze	5	decent	Last Available: "2011-06"
 5134	blurry lunar isotope	0		Last Available: "2011-06"
 5135	upside-down E.M.U. joystick	0		Last Available: "2011-06"
 5136	maroon E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5042,7 +5042,7 @@
 5139	carton of astral energy drinks	0		
 5140	distilled astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
-5142	shaking twirling moon unit	0		Last Available: "2011-06"
+5142	twirling shaking moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	flattened pickled polymerized honeypot	0		Effect: "The Dinsey Way", Effect Duration: 46
@@ -5074,12 +5074,12 @@
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	perfectly mixed practically non-alcoholic wobbly Saison du Lune	1	super ultra EPIC	Last Available: "2011-06"
+5174	practically non-alcoholic perfectly mixed wobbly Saison du Lune	1	super ultra EPIC	Last Available: "2011-06"
 5175	drinkable practically non-alcoholic maroon Moonthril Schnapps	1	good	Last Available: "2011-06"
 5176	smooth Wrecked Generator	4	awesome	Last Available: "2011-06"
 5177	bland spinning Spaghetti with Moonballs	4	decent	Last Available: "2011-06"
 5178	delicious Crepes a la Lune	3	awesome	Last Available: "2011-06"
-5179	small adequate Moon Pie	2	good	Last Available: "2011-06"
+5179	adequate small Moon Pie	2	good	Last Available: "2011-06"
 5180	warmed Comet Pop	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 31, Last Available: "2011-06"
 5181	triple-boiled Flan in the Moon	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 57, Last Available: "2011-06"
 5182	improved flattened chilled tumbling 1/6th Pound Cake	0		Effect: "One Very Clear Eye", Effect Duration: 63, Last Available: "2011-06"
@@ -5102,19 +5102,19 @@
 5199	boiled shaking beastly paste	1	good	Effect: "Cold Hard Skin", Effect Duration: 30, Last Available: "2011-08"
 5200	dehydrated shaking paste	1	good	Last Available: "2011-08"
 5201	dehydrated ectoplasmic paste	1	good	Effect: "World's Shortest Giant", Effect Duration: 5, Last Available: "2011-08"
-5202	boiled shaking ghostly greasy paste	1	awesome	Effect: "Innately Truthy", Effect Duration: 15, Last Available: "2011-08"
+5202	boiled ghostly shaking greasy paste	1	awesome	Effect: "Innately Truthy", Effect Duration: 15, Last Available: "2011-08"
 5203	boiled skewed yellow bug paste	1	good	Last Available: "2011-08"
-5204	denatured green jittery shaking hippy paste	1	decent	Last Available: "2011-08"
+5204	denatured shaking jittery green hippy paste	1	decent	Last Available: "2011-08"
 5205	diluted orc paste	1	awesome	Last Available: "2011-08"
 5206	distilled pulsating demonic paste	1	decent	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 30, Last Available: "2011-08"
-5207	powdered wobbly yellow indescribably horrible paste	1	decent	Effect: "Pyramid Power", Effect Duration: 30, Last Available: "2011-08"
+5207	powdered yellow wobbly indescribably horrible paste	1	decent	Effect: "Pyramid Power", Effect Duration: 30, Last Available: "2011-08"
 5208	diluted paste	1	good	Last Available: "2011-08"
 5209	modified narrow goblin paste	1	good	Last Available: "2011-08"
 5210	modified teal pirate paste	1	good	Last Available: "2011-08"
 5211	powdered pulsating chlorophyll paste	1	good	Last Available: "2011-08"
 5212	denatured paste	1	crappy	Last Available: "2011-08"
 5213	compressed Mer-kin paste	1	good	Effect: "Black Eyes", Effect Duration: 50, Last Available: "2011-08"
-5214	compressed pulsating tumbling blurry slimy paste	1	crappy	Last Available: "2011-08"
+5214	compressed tumbling blurry pulsating slimy paste	1	crappy	Last Available: "2011-08"
 5215	modified squat penguin paste	1	EPIC	Effect: "The Halls of Mysticality", Effect Duration: 50, Last Available: "2011-08"
 5216	dried elemental paste	1	awesome	Effect: "Can't Be a Chooser", Effect Duration: 15, Last Available: "2011-08"
 5217	twisted skewed cosmic paste	1	decent	Effect: "Granolarrrgh", Effect Duration: 45, Last Available: "2011-08"
@@ -5128,8 +5128,8 @@
 5225	spinning wobbly The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	tolerable bucket of wine	3	good	Last Available: "2011-09"
-5228	jumbo adequate ultrafondue	5	good	Last Available: "2011-09"
-5229	jittery wobbly unbearable light	0		Last Available: "2011-09"
+5228	adequate jumbo ultrafondue	5	good	Last Available: "2011-09"
+5229	wobbly jittery unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
 5232	borrowed time	0		Last Available: "2011-09"
@@ -5138,23 +5138,23 @@
 5235	stylish furry halo	0		Moxie: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	spinning frosty halo of wisdom	0		Mysticality: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	twirling lion tamer's time halo	0		Experience (familiar): +2, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	drinkable practically non-alcoholic Lumineux Limnio	1	good	Last Available: "2011-09"
+5238	practically non-alcoholic drinkable Lumineux Limnio	1	good	Last Available: "2011-09"
 5239	acceptable narrow Morto Moreto	3	good	Last Available: "2011-09"
 5240	drinkable cyan Temps Tempranillo	3	good	Last Available: "2011-09"
-5241	watered-down artisanal Bordeaux Marteaux	2	EPIC	Last Available: "2011-09"
+5241	artisanal watered-down Bordeaux Marteaux	2	EPIC	Last Available: "2011-09"
 5242	acceptable Fromage Pinotage	4	good	Last Available: "2011-09"
-5243	weak lousy shaking Beignet Milgranet	2	decent	Last Available: "2011-09"
+5243	lousy weak shaking Beignet Milgranet	2	decent	Last Available: "2011-09"
 5244	delicious Muschat	4	awesome	Last Available: "2011-09"
 5245	bland cool jelly donut	3	decent	Last Available: "2011-09"
 5246	moldy shrapnel jelly donut	4	crappy	Last Available: "2011-09"
-5247	immense rotten occult jelly donut	9	crappy	Last Available: "2011-09"
+5247	rotten immense occult jelly donut	9	crappy	Last Available: "2011-09"
 5248	stale thyme jelly donut	3	decent	Last Available: "2011-09"
 5249	toothsome danish	4	awesome	Last Available: "2011-09"
-5250	normal miniature smashed danish	2	good	Last Available: "2011-09"
+5250	miniature normal smashed danish	2	good	Last Available: "2011-09"
 5251	rotten forbidden danish	3	crappy	Last Available: "2011-09"
 5252	snack-sized bland cool cat claw	2	decent	Last Available: "2011-09"
 5253	adequate blunt cat claw	3	good	Last Available: "2011-09"
-5254	bite-sized normal green shadowy cat claw	1	good	Last Available: "2011-09"
+5254	normal bite-sized green shadowy cat claw	1	good	Last Available: "2011-09"
 5255	stale miniature cheezburger	2	decent	Last Available: "2011-09"
 5256	decent toasted brie	3	good	Last Available: "2011-09"
 5257	liquefied colloidal wobbly potion of the field gar	0		Effect: "Elbow Sauce", Effect Duration: 69, Last Available: "2011-09"
@@ -5163,10 +5163,10 @@
 5260	frozen cyan cold-filtered water	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 63, Last Available: "2011-09"
 5261	frozen pulsating graveyard snowglobe	0		Effect: "Reptilian Fortitude", Effect Duration: 33, Last Available: "2011-09"
 5262	boiled cool cat elixir	0		Effect: "Moon'd", Effect Duration: 55, Last Available: "2011-09"
-5263	warmed oxidized jittery olive potion of the captain's hammer	0		Effect: "Stands Alone", Effect Duration: 41, Last Available: "2011-09"
+5263	warmed oxidized olive jittery potion of the captain's hammer	0		Effect: "Stands Alone", Effect Duration: 41, Last Available: "2011-09"
 5264	modified potion of X-ray vision	0		Effect: "Livin' Large", Effect Duration: 46, Last Available: "2011-09"
-5265	alkaline non-diffused twirling lime green potion of the litterbox	0		Effect: "Smelly Pants", Effect Duration: 45, Last Available: "2011-09"
-5266	irradiated magnetized cyan pulsating potion of animal rage	0		Effect: "Greasy Flavor", Effect Duration: 34, Last Available: "2011-09"
+5265	alkaline non-diffused lime green twirling potion of the litterbox	0		Effect: "Smelly Pants", Effect Duration: 45, Last Available: "2011-09"
+5266	irradiated magnetized pulsating cyan potion of animal rage	0		Effect: "Greasy Flavor", Effect Duration: 34, Last Available: "2011-09"
 5267	warmed yellow blurry potion of punctual companionship	0		Effect: "Ready to Snap", Effect Duration: 18, Last Available: "2011-09"
 5268	huge holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
@@ -5198,9 +5198,9 @@
 5295	tumbling newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	shaking dungeon dragon chest	0		Last Available: "2011-09"
-5298	stale huge phish stick	9	decent	Last Available: "2011-09"
+5298	huge stale phish stick	9	decent	Last Available: "2011-09"
 5299	flame-wreathed stylish plastic vampire fangs of temperance	0		Moxie: +25, Hot Spell Damage: +10, Sleaze Resistance: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
-5300	wobbly red Interview With You (a Vampire)	0		Last Available: "2011-10"
+5300	red wobbly Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	green ghostly Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	upside-down your own heart	0		Last Available: "2011-10"
 5303	tumbling Sword of the Brouhaha Prince of the bloodbag	0		Maximum HP: +100, Last Available: "2011-10"
@@ -5222,9 +5222,9 @@
 5319	denatured Blood 'n' Plenty	0		Effect: "Heart of Green", Effect Duration: 37, Last Available: "2011-10"
 5320	altered Lobos Mints	0		Effect: "Graham Crackling", Effect Duration: 29, Last Available: "2011-10"
 5321	extra-pickled spinning Sweet Sword	0		Effect: "Egg-stra Arm", Effect Duration: 58, Last Available: "2011-10"
-5322	weak perfectly mixed shaking Ecto-Cooler	2	EPIC	Last Available: "2011-10"
-5323	fancy tolerable mirror Bartles and BRAAAINS wine cooler	3	good	Effect: "Analog Drunk", Effect Duration: 35, Last Available: "2011-10"
-5324	lousy practically non-alcoholic enchanted Blood Light	1	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5, Last Available: "2011-10"
+5322	perfectly mixed weak shaking Ecto-Cooler	2	EPIC	Last Available: "2011-10"
+5323	tolerable fancy mirror Bartles and BRAAAINS wine cooler	3	good	Effect: "Analog Drunk", Effect Duration: 35, Last Available: "2011-10"
+5324	enchanted practically non-alcoholic lousy Blood Light	1	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5, Last Available: "2011-10"
 5325	acceptable Silver Bullet beer	3	good	Last Available: "2011-10"
 5326	artisanal weak Bone's Farm &quot;wine&quot;	2	EPIC	Last Available: "2011-10"
 5327	blurry ghost protocol	0		Last Available: "2011-10"
@@ -5290,7 +5290,7 @@
 5387	smelly ridiculous earring	0		Stench Spell Damage: +10, Last Available: "2011-11"
 5388	inspector's ridiculous sunglasses	0		Item Drop: +15, Last Available: "2011-11"
 5389	bland ridiculous sandwich	3	decent	Last Available: "2011-11"
-5390	fancy irresponsibly strong lousy ridiculous cocktail	8	decent	Effect: "Unusual Perspective", Effect Duration: 40, Last Available: "2011-11"
+5390	lousy irresponsibly strong fancy ridiculous cocktail	8	decent	Effect: "Unusual Perspective", Effect Duration: 40, Last Available: "2011-11"
 5391	olive beefy zombie monkey necklace of the pedagogue	0		Muscle: +10, Experience: +3
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5308,11 +5308,11 @@
 5405	jittery executive MacGyver's personal trainer's cane-mail shirt	0		Experience Percent (Muscle): +10, Maximum MP: +100, Meat Drop: +40, Last Available: "2011-12"
 5406	perfumed Oprah's cane-mail pants	0		Maximum MP Percent: +50, Stench Resistance: +5, Item Drop: +5, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	drinkable Vodka Matryoshka	4	good	Last Available: "2011-12"
-5408	extra-dry acceptable Gin Mint	5	good	Last Available: "2011-12"
+5408	acceptable extra-dry Gin Mint	5	good	Last Available: "2011-12"
 5409	hand-crafted Tequiz Navidad	4	EPIC	Last Available: "2011-12"
 5410	lousy Mint Yulep	3	decent	Last Available: "2011-12"
 5411	delicious Crimbojito	3	awesome	Last Available: "2011-12"
-5412	hand-crafted triple-distilled enchanted Sangria de Menthe	8	EPIC	Effect: "Cancer Rising", Effect Duration: 45, Last Available: "2011-12"
+5412	hand-crafted enchanted triple-distilled Sangria de Menthe	8	EPIC	Effect: "Cancer Rising", Effect Duration: 45, Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
 5414	gray licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	warmed licorice root	0		Effect: "Piratey Flavor", Effect Duration: 34, Last Available: "2011-12"
@@ -5340,13 +5340,13 @@
 5437	squat superheated fudge	0		Last Available: "2011-11"
 5438	cold-filtered pickled fluid of fudge-finding	0		Effect: "Morbidi Tea", Effect Duration: 67, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	adequate diet jittery fudgesicle	1	good	Last Available: "2011-11"
+5440	diet adequate jittery fudgesicle	1	good	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	jittery miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	liquefied twirling devilish folio	0		Effect: "Industrial Strength Starch", Effect Duration: 47, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
-5446	huge shaking red jar full of wind	0		Last Available: "2012-12"
+5446	shaking red huge jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
 5449	maroon twirling vanity stone	0		Last Available: "2012-12"
@@ -5371,7 +5371,7 @@
 5468	double-nitrogenated spinning resolution: be sexier	0		Effect: "Ready to Snap", Effect Duration: 18, Last Available: "2012-01"
 5469	modified denatured blurry resolution: be feistier	0		Effect: "Sweet Tooth", Effect Duration: 36, Last Available: "2012-01"
 5470	altered magnetized resolution: be kinder	0		Effect: "There Wolf", Effect Duration: 26, Last Available: "2012-01"
-5471	double-energized vacuum-sealed oxidized fuchsia wobbly resolution: be more adventurous	0		Effect: "Livin' Large", Effect Duration: 62, Last Available: "2012-01"
+5471	double-energized vacuum-sealed oxidized wobbly fuchsia resolution: be more adventurous	0		Effect: "Livin' Large", Effect Duration: 62, Last Available: "2012-01"
 5472	quadruple-vacuum-sealed spinning resolution: be luckier	0		Effect: "You Drank Fish Wine", Effect Duration: 33, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
@@ -5381,20 +5381,20 @@
 5478	deionized wobbly skewed gummi canary	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 58, Last Available: "2011-11"
 5479	stale gummi bear	4	decent	Last Available: "2011-11"
 5480	huge spoiled gummi bear	9	crappy	Last Available: "2011-11"
-5481	enchanted rotten half-sized gummi bear	2	crappy	Effect: "Moon-Eyed", Effect Duration: 40, Last Available: "2011-11"
+5481	rotten half-sized enchanted gummi bear	2	crappy	Effect: "Moon-Eyed", Effect Duration: 40, Last Available: "2011-11"
 5482	bland fancy drunki-bear	4	decent	Effect: "Sticky Fingers", Effect Duration: 20, Last Available: "2011-11"
 5483	jumbo spoiled drunki-bear	5	crappy	Last Available: "2011-11"
-5484	bland bite-sized jittery teal spinning drunki-bear	1	decent	Last Available: "2011-11"
+5484	bland bite-sized teal jittery spinning drunki-bear	1	decent	Last Available: "2011-11"
 5485	gummi bowtie of chilblains	0		Cold Damage: +25, Last Available: "2011-11"
 5486	beefcake's fudge pocket square	0		Muscle: +25, Last Available: "2011-11"
 5487	forbidden lollipop cufflinks	0		Spell Damage Percent: +50, Last Available: "2011-11"
 5488	trilobite fossil	0		Last Available: "2011-11"
-5489	blurry narrow ammonite fossil	0		Last Available: "2011-11"
+5489	narrow blurry ammonite fossil	0		Last Available: "2011-11"
 5490	narrow belemnite fossil	0		Last Available: "2011-11"
-5491	narrow blurry trilobite candy mold	0		Last Available: "2011-11"
+5491	blurry narrow trilobite candy mold	0		Last Available: "2011-11"
 5492	huge ammonite candy mold	0		Last Available: "2011-11"
 5493	mirror belemnite candy mold	0		Last Available: "2011-11"
-5494	energized blurry squat gummi trilobite	0		Effect: "Helping Comes Second", Effect Duration: 49, Last Available: "2011-11"
+5494	energized squat blurry gummi trilobite	0		Effect: "Helping Comes Second", Effect Duration: 49, Last Available: "2011-11"
 5495	extra-activated Vulcanized tumbling gummi ammonite	0		Effect: "White-boy Angst", Effect Duration: 45, Last Available: "2011-11"
 5496	cold-filtered gummi belemnite	0		Effect: "Bilious Brawn", Effect Duration: 24, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
@@ -5406,7 +5406,7 @@
 5503	blurry Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	bland ghostly blurry jerky coins	3	decent	Last Available: "2011-11"
+5506	bland blurry ghostly jerky coins	3	decent	Last Available: "2011-11"
 5507	lousy triple-distilled Go-Wassail	8	decent	Last Available: "2011-11"
 5508	ionized polarized Uncle Greenspan's Bathroom Finance Guide	0		Effect: "So Fresh and So Clean", Effect Duration: 13, Last Available: "2011-11"
 5509	adjusted bottle of bubbles	0		Effect: "Butt-Rock Hair", Effect Duration: 22, Last Available: "2011-11"
@@ -5418,7 +5418,7 @@
 5515	jittery pog #01 (spider)	0		Last Available: "2011-11"
 5516	pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	pog #03 (warwelf)	0		Last Available: "2011-11"
-5518	blurry mirror spinning pog #04 (skleleton)	0		Last Available: "2011-11"
+5518	spinning blurry mirror pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	blue pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	narrow pog #07 (orcish frat boy)	0		Last Available: "2011-11"
@@ -5434,7 +5434,7 @@
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	cyan pulsating magnolia blossom	0		Last Available: "2012-12"
 5533	polarized skewed Mortimer's nostrum	0		Effect: "Pyramid Power", Effect Duration: 32, Last Available: "2012-12"
-5534	mediocre triple-distilled Barulio's bottle	10	decent	Last Available: "2012-12"
+5534	triple-distilled mediocre Barulio's bottle	10	decent	Last Available: "2012-12"
 5535	diffused Marvin's marvelous pill	0		Effect: "The Power of Negative Thinking", Effect Duration: 27, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
@@ -5467,80 +5467,80 @@
 5564	purple wobbly Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	bland wobbly PB&BP	4	decent	
 5566	jumbo rotten club sandwich	5	crappy	
-5567	spoiled special corned-beef Reuben	3	crappy	Effect: "Punchy, Murdery", Effect Duration: 30
+5567	special spoiled corned-beef Reuben	3	crappy	Effect: "Punchy, Murdery", Effect Duration: 30
 5568	gray frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	red loose ninja carabiner	0		
 5571	blue Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
-5573	special acceptable triple-distilled shaking Drac & Tan	10	good	Effect: "Empty Inside", Effect Duration: 20, Last Available: "2012-03"
+5573	triple-distilled acceptable special shaking Drac & Tan	10	good	Effect: "Empty Inside", Effect Duration: 20, Last Available: "2012-03"
 5574	tolerable upside-down Transylvania Sling	3	good	Last Available: "2012-03"
 5575	aged enchanted watered-down Shot of the Living Dead	2	awesome	Effect: "Tingly Biceps", Effect Duration: 20, Last Available: "2012-03"
 5576	perfectly mixed triple-distilled skewed Buttery Knob	6	EPIC	Last Available: "2012-03"
 5577	strong tolerable Slippery Knob	5	good	Last Available: "2012-03"
-5578	irresponsibly strong lousy Flaming Knob	9	decent	Last Available: "2012-03"
-5579	watered-down hand-crafted Grasshopper	2	EPIC	Last Available: "2012-03"
+5578	lousy irresponsibly strong Flaming Knob	9	decent	Last Available: "2012-03"
+5579	hand-crafted watered-down Grasshopper	2	EPIC	Last Available: "2012-03"
 5580	tolerable Locust	3	good	Last Available: "2012-03"
 5581	delicious Plague of Locusts	3	awesome	Last Available: "2012-03"
 5582	acceptable wobbly Red Dwarf	3	good	Last Available: "2012-03"
-5583	bad practically non-alcoholic Golden Mean	1	decent	Last Available: "2012-03"
-5584	tolerable watered-down green Green Giant	2	good	Last Available: "2012-03"
+5583	practically non-alcoholic bad Golden Mean	1	decent	Last Available: "2012-03"
+5584	watered-down tolerable green Green Giant	2	good	Last Available: "2012-03"
 5585	drinkable triple-distilled Aye Aye	9	good	Last Available: "2012-03"
 5586	artisanal watered-down green Aye Aye, Captain	2	EPIC	Last Available: "2012-03"
 5587	tolerable practically non-alcoholic Aye Aye, Tooth Tooth	1	good	Last Available: "2012-03"
 5588	bad Humanitini	3	decent	Last Available: "2012-03"
 5589	hand-crafted More Humanitini than Humanitini	3	EPIC	Last Available: "2012-03"
-5590	special bad watered-down Oh, the Humanitini	2	decent	Effect: "Big Meat Big Prizes", Effect Duration: 40, Last Available: "2012-03"
+5590	special watered-down bad Oh, the Humanitini	2	decent	Effect: "Big Meat Big Prizes", Effect Duration: 40, Last Available: "2012-03"
 5591	aged Great Older Fashioned	3	awesome	Last Available: "2012-03"
-5592	tolerable high-proof Fuzzy Tentacle	6	good	Last Available: "2012-03"
+5592	high-proof tolerable Fuzzy Tentacle	6	good	Last Available: "2012-03"
 5593	aged Crazymaker	4	awesome	Last Available: "2012-03"
 5594	hand-crafted narrow Zoodriver	3	EPIC	Last Available: "2012-03"
 5595	hand-crafted pulsating Sloe Comfortable Zoo	4	EPIC	Last Available: "2012-03"
 5596	mediocre bouncing Sloe Comfortable Zoo on Fire	3	decent	Last Available: "2012-03"
-5597	enchanted mediocre Suffering Sinner	3	decent	Effect: "Raging Animal", Effect Duration: 45, Last Available: "2012-03"
-5598	artisanal red wobbly Suppurating Sinner	3	EPIC	Last Available: "2012-03"
+5597	mediocre enchanted Suffering Sinner	3	decent	Effect: "Raging Animal", Effect Duration: 45, Last Available: "2012-03"
+5598	artisanal wobbly red Suppurating Sinner	3	EPIC	Last Available: "2012-03"
 5599	bad Sizzling Sinner	4	decent	Last Available: "2012-03"
 5600	weak lousy shaking Firewater	2	decent	Last Available: "2012-03"
-5601	boozy artisanal fancy Earth and Firewater	5	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 45, Last Available: "2012-03"
+5601	fancy boozy artisanal Earth and Firewater	5	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 45, Last Available: "2012-03"
 5602	perfectly mixed Earth, Wind and Firewater	3	EPIC	Last Available: "2012-03"
-5603	weak lousy blurry Slimosa	2	decent	Last Available: "2012-03"
+5603	lousy weak blurry Slimosa	2	decent	Last Available: "2012-03"
 5604	smooth Extra-slimy Slimosa	4	awesome	Last Available: "2012-03"
-5605	irresponsibly strong mediocre Slimebite	9	decent	Last Available: "2012-03"
+5605	mediocre irresponsibly strong Slimebite	9	decent	Last Available: "2012-03"
 5606	bad lime green Cement Mixer	3	decent	Last Available: "2012-03"
-5607	watered-down acceptable huge Jackhammer	2	good	Last Available: "2012-03"
+5607	acceptable watered-down huge Jackhammer	2	good	Last Available: "2012-03"
 5608	tolerable Dump Truck	3	good	Last Available: "2012-03"
 5609	lousy spinning Fauna Libre	3	decent	Last Available: "2012-03"
 5610	weak smooth Chakra Libre	2	awesome	Last Available: "2012-03"
 5611	delicious Aura Libre	4	awesome	Last Available: "2012-03"
 5612	mediocre jittery Sazerorc	3	decent	Last Available: "2012-03"
 5613	drinkable Sazuruk-hai	3	good	Last Available: "2012-03"
-5614	delicious enchanted weak Flaming Sazerorc	2	awesome	Effect: "Creepypasted", Effect Duration: 50, Last Available: "2012-03"
+5614	weak delicious enchanted Flaming Sazerorc	2	awesome	Effect: "Creepypasted", Effect Duration: 50, Last Available: "2012-03"
 5615	spirit-forward acceptable twirling mirror Green Velvet	5	good	Last Available: "2012-03"
 5616	tolerable Green Muslin	4	good	Last Available: "2012-03"
-5617	weak special bad Green Burlap	2	decent	Effect: "Egg-headedness", Effect Duration: 5, Last Available: "2012-03"
+5617	special weak bad Green Burlap	2	decent	Effect: "Egg-headedness", Effect Duration: 5, Last Available: "2012-03"
 5618	acceptable Mohobo	3	good	Last Available: "2012-03"
 5619	spirit-forward tolerable Moonshine Mohobo	5	good	Last Available: "2012-03"
-5620	acceptable weak narrow wobbly Flaming Mohobo	2	good	Last Available: "2012-03"
-5621	tolerable watered-down Drunken Philosopher	2	good	Last Available: "2012-03"
+5620	weak acceptable wobbly narrow Flaming Mohobo	2	good	Last Available: "2012-03"
+5621	watered-down tolerable Drunken Philosopher	2	good	Last Available: "2012-03"
 5622	tolerable Drunken Neurologist	4	good	Last Available: "2012-03"
-5623	practically non-alcoholic bad Drunken Astrophysicist	1	decent	Last Available: "2012-03"
+5623	bad practically non-alcoholic Drunken Astrophysicist	1	decent	Last Available: "2012-03"
 5624	tolerable Dark & Starry	4	good	Last Available: "2012-03"
 5625	artisanal boozy Black Hole	5	EPIC	Last Available: "2012-03"
-5626	practically non-alcoholic mediocre Event Horizon	1	decent	Last Available: "2012-03"
+5626	mediocre practically non-alcoholic Event Horizon	1	decent	Last Available: "2012-03"
 5627	mediocre Herring Daiquiri	4	decent	Last Available: "2012-03"
 5628	high-proof hand-crafted Herring Wallbanger	8	EPIC	Last Available: "2012-03"
-5629	aged practically non-alcoholic Herringtini	1	awesome	Last Available: "2012-03"
+5629	practically non-alcoholic aged Herringtini	1	awesome	Last Available: "2012-03"
 5630	delicious practically non-alcoholic Lollipop Drop	1	awesome	Last Available: "2012-03"
 5631	strong hand-crafted Candy Alexander	5	EPIC	Last Available: "2012-03"
 5632	perfectly mixed weak Candicaine	2	EPIC	Last Available: "2012-03"
 5633	mediocre ghostly Caipiranha	3	decent	Last Available: "2012-03"
 5634	bad watered-down Flying Caipiranha	2	decent	Last Available: "2012-03"
-5635	perfectly mixed triple-distilled Flaming Caipiranha	7	EPIC	Last Available: "2012-03"
+5635	triple-distilled perfectly mixed Flaming Caipiranha	7	EPIC	Last Available: "2012-03"
 5636	weak bad Punchplanter	2	decent	Last Available: "2012-03"
 5637	acceptable jittery upside-down Doublepunchplanter	3	good	Last Available: "2012-03"
 5638	lousy tumbling Haymaker	3	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
-5640	skewed spinning crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
+5640	spinning skewed crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	decent fungus	4	good	
 5642	cyan poisoned dart	0		
 5643	frozen stone wool	0		Effect: "Hobonic", Effect Duration: 27
@@ -5555,7 +5555,7 @@
 5652	gray Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	flavorless bite-sized nailswurst	1	decent	
-5655	mediocre watered-down used beer	2	decent	
+5655	watered-down mediocre used beer	2	decent	
 5656	Huggler Radio	0		Free Pull
 5657	bouncing fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5563,7 +5563,7 @@
 5660	offensive moustache of the glutton	0		Food Drop: +100, Single Equip
 5661	beefcake's hairshirt	0		Muscle: +25
 5662	mirror Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
-5663	spinning blinking microwave	0		Free Pull
+5663	blinking spinning microwave	0		Free Pull
 5664	pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
@@ -5604,10 +5604,10 @@
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	narrow mannequin	0		Familiar Weight: +5
 5703	upside-down crayon shavings	0		Last Available: "2012-06"
-5704	mirror upside-down wax bugbear	0		Last Available: "2012-06"
+5704	upside-down mirror wax bugbear	0		Last Available: "2012-06"
 5705	greedy friendly wax hat	0		Familiar Weight: +3, Meat Drop: +20, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
 5706	manspreader's curative wax pants	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
-5707	fuchsia jittery blurry FDKOL commendation	0		Last Available: "2012-07"
+5707	blurry fuchsia jittery FDKOL commendation	0		Last Available: "2012-07"
 5708	cold-filtered polarized lime green drop of water-37	0		Effect: "Big Flaming Whip", Effect Duration: 65, Last Available: "2012-07"
 5709	upside-down blurry thinker's fireman's helmet of Calamity Jane	0		Mysticality: +10, Critical Hit Percent: +15, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	hardened fire axe	0		Damage Reduction: 3, Last Available: "2012-07"
@@ -5628,7 +5628,7 @@
 5727	skewed studded hot daub stand of chilblains	0		Damage Absorption: +80, Cold Damage: +25, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	curative veiny foot-long hot daub	0		Maximum HP: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	big moldy angst burger	5	crappy	
+5730	moldy big angst burger	5	crappy	
 5731	bad 5-hour acrimony	3	decent	
 5732	blank note	0		
 5733	eerily silent box	0		
@@ -5651,10 +5651,10 @@
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	flavorless mirror crappy brain	4	decent	
-5753	tasty snack-sized decent brain	2	awesome	
-5754	snack-sized delicious blinking good brain	2	awesome	
-5755	thick normal boss brain	5	good	
-5756	huge fancy bland skewed hunter brain	8	decent	Effect: "Neuromancy", Effect Duration: 5
+5753	snack-sized tasty decent brain	2	awesome	
+5754	delicious snack-sized blinking good brain	2	awesome	
+5755	normal thick boss brain	5	good	
+5756	fancy bland huge skewed hunter brain	8	decent	Effect: "Neuromancy", Effect Duration: 5
 5758	skewed chaotic supercool cool Staff of Holiday Sensations	0		Moxie: +5, Moxie Percent: +20, Spell Critical Percent: +10, Last Available: "2011-11"
 5759	blurry lard-coated Rosewater's staff	0		Mysticality Percent: +30, Sleaze Spell Damage: +25
 5760	Annie Oakley's rock-hard hardened staff	0		Damage Reduction: 16, Critical Hit Percent: +20
@@ -5674,7 +5674,7 @@
 5774	talkative skull	0		
 5775	jittery ghostly fronts	0		Familiar Weight: +5
 5776	blurry veiny hardened Barney's rake	0		Damage Reduction: 3, Maximum HP: +10
-5778	snack-sized bland gray idiot brain	2	decent	
+5778	bland snack-sized gray idiot brain	2	decent	
 5779	huge steel-toed keel-haulin' knife	0		Damage Reduction: 9
 5780	mirror supercharged ice cream scoop	0		Maximum MP Percent: +30
 5781	aged pulsating soft echo eyedrop antidote martini	4	awesome	
@@ -5733,17 +5733,17 @@
 5834	colloidal colloidal holistic headache remedy	0		Effect: "Lifted Spirits", Effect Duration: 32
 5835	improved gray scrunchie tourniquet	0		Effect: "Bandersnatched", Effect Duration: 23
 5836	quantum denatured wet shaking embezzler's oil	0		Effect: "From Nantucket", Effect Duration: 11
-5837	alkaline wobbly jittery Fu Manchu Wax	0		Effect: "Biologically Shocked", Effect Duration: 11
+5837	alkaline jittery wobbly Fu Manchu Wax	0		Effect: "Biologically Shocked", Effect Duration: 11
 5838	double-magnetized oxidized green pulsating Iiti Kitty Gumdrop	0		Effect: "Aries Rising", Effect Duration: 16
 5839	pickled galvanized ravenous eye	0		Effect: "Intimidating Mien", Effect Duration: 34
 5840	quadruple-nitrogenated double-deionized Rogue Windmill Rouge	0		Effect: "Pronounced Potency", Effect Duration: 55
-5841	magnetized vacuum-sealed wobbly yellow A muse-bouche	0		Effect: "Human-Demon Hybrid", Effect Duration: 50
+5841	magnetized vacuum-sealed yellow wobbly A muse-bouche	0		Effect: "Human-Demon Hybrid", Effect Duration: 50
 5842	ionized polymerized blurry toothbrush	0		Effect: "Radiated and Grodiated", Effect Duration: 55
 5843	diffused fuchsia pirate cream pie	0		Effect: "Meat the Flintstones", Effect Duration: 26
 5844	warmed dry skewed una poca de gracia	0		Effect: "Burning Tongue", Effect Duration: 52
 5845	aerosolized compressed air canister	0		Effect: "Poker Faced", Effect Duration: 57
 5846	modified triple-dry twirling salt water taffy	0		Effect: "Mint-Condition Breath", Effect Duration: 61
-5847	corrupted boiled yellow narrow unholy water	0		Effect: "Billiards Belligerence", Effect Duration: 55
+5847	corrupted boiled narrow yellow unholy water	0		Effect: "Billiards Belligerence", Effect Duration: 55
 5848	liquefied boiled mirror Bangyomaman battle juice	0		Effect: "Rad-ish", Effect Duration: 47
 5849	triple-pickled nitrogenated activated squat handyman &quot;hand soap&quot;	0		Effect: "One For Tea", Effect Duration: 27
 5850	adjusted adjusted space marine flash grenade	0		Effect: "Supafly", Effect Duration: 22
@@ -5773,26 +5773,26 @@
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	narrow papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
 5876	twirling papier-m&acirc;ch&eacute; bowl	0		Last Available: "2012-09"
-5877	tumbling narrow papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
+5877	narrow tumbling papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	pulsating rock-hard Rainbow Jello Mould	0		Damage Reduction: 5
 5879	Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	Samson's skeleton skis of the ox of courage	0		Muscle: +20, Experience (Muscle): +5, Spooky Resistance: +3, Single Equip, Last Available: "2012-10"
-5883	tasty gigantic teal skeleton quiche	9	awesome	Last Available: "2012-10"
+5883	gigantic tasty teal skeleton quiche	9	awesome	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	blue skeletal skiff	0		Last Available: "2012-10"
 5886	tumbling MacGyver's Oprah's rosy-cheeked Bonestabber of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30, Maximum MP Percent: +50, Maximum MP: +100, Last Available: "2012-10"
-5887	distilled smooth crystal skeleton vodka	5	awesome	Last Available: "2012-10"
+5887	smooth distilled crystal skeleton vodka	5	awesome	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	lime green supercool auxiliary backbone	0		Moxie Percent: +20, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	spinning tumbling ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
-5892	super-adjusted anodized green blurry that gum you like	0		Effect: "Wintry Breath", Effect Duration: 25
+5892	super-adjusted anodized blurry green that gum you like	0		Effect: "Wintry Breath", Effect Duration: 25
 5893	jittery dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	upside-down avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
-5896	blinking narrow canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
+5896	narrow blinking canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	twisted Unconscious Collective Dream Jar	1	awesome	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
@@ -5803,7 +5803,7 @@
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
 5906	upside-down pixel pill	0		
 5907	pixel energy tank	0		
-5908	jittery shaking ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
+5908	shaking jittery ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	huge cyan vibrating wicked wedding ring	0		Spell Damage: +5, Maximum MP Percent: +10, Single Equip
 5910	twirling deactivated nanobots	0		Free Pull, Last Available: "2012-11"
 5911	nanorhino credit card	0		Last Available: "2012-11"
@@ -5885,7 +5885,7 @@
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	olive potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	enchanted triple-distilled artisanal bottle of wine	8	EPIC	Effect: "Burning Tongue", Effect Duration: 50, Last Available: "2013-02"
+5990	triple-distilled enchanted artisanal bottle of wine	8	EPIC	Effect: "Burning Tongue", Effect Duration: 50, Last Available: "2013-02"
 5991	blinking round bomb	0		Last Available: "2013-02"
 5992	wool curative iron helmet of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	up-at-dawn careful supercharged steel sword	0		Maximum MP Percent: +30, Monster Level: -10, Adventures: +5, Last Available: "2013-02"
@@ -5893,7 +5893,7 @@
 5995	ghostly massive gemstone	0		Last Available: "2013-02"
 5996	bouncing extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	hand-crafted watered-down shining goblet	2	super EPIC	Last Available: "2013-02"
+5998	watered-down hand-crafted shining goblet	2	super EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
 6000	family-friendly extremely unsafe crown of the early riser	0		Weapon Damage Percent: +100, Sleaze Resistance: +1, Adventures: +7, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	fireproof occult sword of the detective	0		Spell Damage Percent: +25, Hot Resistance: +3, Item Drop: +20, Last Available: "2013-02"
@@ -5941,14 +5941,14 @@
 6043	boid	0		
 6044	woim	0		
 6045	Thwaitgold praying mantis statuette	0		
-6046	blinking shaking twirling BittyCar SoulCar	0		Last Available: "2012-12"
+6046	shaking blinking twirling BittyCar SoulCar	0		Last Available: "2012-12"
 6047	skewed horrifying Rosewater's Misty Cloak	0		Mysticality Percent: +30, Spooky Damage: +25
 6048	Usain Bolt's Misty Robe of temperance	0		Sleaze Resistance: +5, Initiative: +80
 6049	vibrating banded forbidden Misty Cape	0		Spell Damage Percent: +50, Damage Absorption: +100, Maximum MP Percent: +10
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	small decent Taco Dan's Taco Stand Taco	2	good	Last Available: "2012-12"
-6053	special spirit-forward hand-crafted Taco Dan's Taco Stand Chimichangarita	5	EPIC	Effect: "Bloody Bloody Bloody!", Effect Duration: 40, Last Available: "2012-12"
+6053	spirit-forward special hand-crafted Taco Dan's Taco Stand Chimichangarita	5	EPIC	Effect: "Bloody Bloody Bloody!", Effect Duration: 40, Last Available: "2012-12"
 6054	polymerized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Squatting and Thrusting", Effect Duration: 37, Last Available: "2012-12"
 6055	ghostly wobbly psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
@@ -5966,12 +5966,12 @@
 6068	blinking skewed loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	blinking shaking Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	shaking blinking Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	teal confusing LED clock	0		Last Available: "2012-12"
 6073	deionized spinning haggis-infused soap	0		Effect: "Oriental Mysticism", Effect Duration: 21, Last Available: "2012-12"
 6074	aerosolized warmed magicberry tablets	0		Effect: "Nature's Bounty", Effect Duration: 13, Last Available: "2012-12"
-6075	activated nitrogenated skewed fuchsia 37x37x37 puzzle cube	0		Effect: "The Real Deal", Effect Duration: 66, Last Available: "2012-12"
-6076	watered-down hand-crafted enchanted yellow McLeod's Hard Haggis-Ade	2	EPIC	Effect: "This Is Where You're a Viking", Effect Duration: 10, Last Available: "2012-12"
+6075	activated nitrogenated fuchsia skewed 37x37x37 puzzle cube	0		Effect: "The Real Deal", Effect Duration: 66, Last Available: "2012-12"
+6076	enchanted hand-crafted watered-down yellow McLeod's Hard Haggis-Ade	2	EPIC	Effect: "This Is Where You're a Viking", Effect Duration: 10, Last Available: "2012-12"
 6077	moldy haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -6037,8 +6037,8 @@
 6139	twirling crafty rubber gloves	0		Maximum MP: +10, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	pulsating triad summoning scroll	0		Last Available: "2013-12"
-6142	special massive bland roasted duck	6	decent	Effect: "Beta Carotene Overdose", Effect Duration: 45, Last Available: "2013-12"
-6143	diet rotten yellow dead meat bun	1	crappy	Last Available: "2013-12"
+6142	bland special massive roasted duck	6	decent	Effect: "Beta Carotene Overdose", Effect Duration: 45, Last Available: "2013-12"
+6143	rotten diet yellow dead meat bun	1	crappy	Last Available: "2013-12"
 6144	Oprah's cat collar	0		Maximum MP Percent: +50, Single Equip, Last Available: "2013-12"
 6145	hale razor-sharp suspicious-looking fedora	0		Weapon Damage Percent: +25, Maximum HP: +20, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6077,17 +6077,17 @@
 6180	blurry cosmic potted meat product	0		
 6181	mirror cosmic potato	0		
 6182	narrow cosmic cream	0		
-6183	twirling lime green spinning cosmic fruit	0		
+6183	lime green spinning twirling cosmic fruit	0		
 6184	blinking avaricious greedy aromatic Jarlsberg's hat	0		Stench Resistance: +1, Meat Drop: 50
 6185	stale massive consummate hard-boiled egg	6	decent	
-6186	half-sized bland consummate fried egg	2	decent	
+6186	bland half-sized consummate fried egg	2	decent	
 6187	bland massive consummate egg salad	7	decent	
-6188	super-sized decent consummate bagel	5	good	
+6188	decent super-sized consummate bagel	5	good	
 6189	bland consummate sliced bread	4	decent	
 6190	stale maroon consummate hot dog bun	3	decent	
 6191	stale yellow consummate brownie	3	decent	
-6192	yummy blinking tumbling consummate toast	4	awesome	
-6193	irresponsibly strong delicious narrow passable stout	10	awesome	
+6192	yummy tumbling blinking consummate toast	4	awesome	
+6193	delicious irresponsibly strong narrow passable stout	10	awesome	
 6194	flavorless blurry consummate soup	4	decent	
 6195	yummy miniature red consummate corn chips	2	awesome	
 6196	adequate consummate salad	3	good	
@@ -6098,38 +6098,38 @@
 6201	yummy consummate bacon	4	awesome	
 6202	rotten consummate meatloaf	3	crappy	
 6203	half-sized adequate consummate steak	2	good	
-6204	decent gigantic consummate cuts	7	good	
+6204	gigantic decent consummate cuts	7	good	
 6205	bland consummate frankfurter	4	decent	
 6206	spoiled mirror consummate french fries	3	crappy	
 6207	yummy consummate baked potato	3	awesome	
-6208	watered-down mediocre maroon acceptable vodka	2	decent	
+6208	mediocre watered-down maroon acceptable vodka	2	decent	
 6209	moldy consummate ice cream	4	crappy	
-6210	spoiled huge bouncing consummate whipped cream	10	crappy	
-6211	enchanted toothsome bouncing consummate cream	3	awesome	Effect: "Stinking Cloud", Effect Duration: 30
-6212	normal huge consummate strawberries	6	good	
+6210	huge spoiled bouncing consummate whipped cream	10	crappy	
+6211	toothsome enchanted bouncing consummate cream	3	awesome	Effect: "Stinking Cloud", Effect Duration: 30
+6212	huge normal consummate strawberries	6	good	
 6213	bite-sized moldy consummate sorbet	1	crappy	
 6214	hand-crafted adequate rum	3	EPIC	
 6215	watered-down acceptable mediocre lager	2	good	
 6216	moldy maroon wobbly immaculate grilled cheese	3	crappy	
-6217	adequate special low-calorie immaculate ice cream sandwich	1	good	Effect: "Think Win-Lose", Effect Duration: 30
-6218	bite-sized rotten immaculate hot dog	1	crappy	
-6219	stale miniature immaculate egg salad sandwich	2	decent	
+6217	adequate low-calorie special immaculate ice cream sandwich	1	good	Effect: "Think Win-Lose", Effect Duration: 30
+6218	rotten bite-sized immaculate hot dog	1	crappy	
+6219	miniature stale immaculate egg salad sandwich	2	decent	
 6220	yummy big perfect sandwich	5	awesome	
 6221	yummy perfect chef salad	3	awesome	
 6222	stale half-sized perfect breakfast	2	decent	
 6223	half-sized spoiled blue sublime deluxe hot dog	2	crappy	
-6224	small adequate tumbling sublime stew	2	good	
-6225	moldy special twirling sublime nachos	4	crappy	Effect: "Sweet and Green", Effect Duration: 20
+6224	adequate small tumbling sublime stew	2	good	
+6225	special moldy twirling sublime nachos	4	crappy	Effect: "Sweet and Green", Effect Duration: 20
 6226	bland skewed spinning Ultimate Breakfast Sandwich	3	decent	
 6227	tiny stale Loaded Baked Potato	1	decent	
 6228	adequate massive Omega Sundae	10	good	
 6229	weak mediocre Das Sauerlager	2	decent	
 6230	lousy Bologna Lambic	3	decent	
 6231	lousy blinking Vodka Dog	3	decent	
-6232	fancy watered-down artisanal Disappointed Russian	2	EPIC	Effect: "Glittering Eyelashes", Effect Duration: 20
+6232	watered-down artisanal fancy Disappointed Russian	2	EPIC	Effect: "Glittering Eyelashes", Effect Duration: 20
 6233	acceptable triple-distilled Chunky Mary	9	good	
 6234	lousy blinking ghostly Nachojito	3	decent	
-6235	practically non-alcoholic perfectly mixed skewed Le Roi	1	super ultra EPIC	
+6235	perfectly mixed practically non-alcoholic skewed Le Roi	1	super ultra EPIC	
 6236	acceptable shaking Over Easy Rider	3	good	
 6237	jittery olive cosmic six-pack	0		
 6239	ionized mirror olive cube of ectoplasm	0		Effect: "Holiday Bliss", Effect Duration: 29
@@ -6161,13 +6161,13 @@
 6265	energetic smooth slick Staff of the Cream of the Cream	0		Moxie: 25, Maximum MP Percent: +20, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
 6267	flavorless snack-sized shaking grain of protein powder	2	decent	
-6268	dry wobbly yellow pec oil	0		Effect: "Okee-Dokee Go!", Effect Duration: 61
+6268	dry yellow wobbly pec oil	0		Effect: "Okee-Dokee Go!", Effect Duration: 61
 6269	scorching gym membership card	0		Hot Damage: +25
-6270	super-diffused modified upside-down teal Squat-Thrust Magazine	0		Effect: "Drenched With Filth", Effect Duration: 37
+6270	super-diffused modified teal upside-down Squat-Thrust Magazine	0		Effect: "Drenched With Filth", Effect Duration: 37
 6271	shaking massive dumbbell	0		
 6272	toasty chilly penguin keychain	0		Cold Damage: +5, Hot Damage: +5, Damage Reduction: 10
 6273	flattened dry tumbling O'RLY manual	0		Effect: "Bustle Hustlin'", Effect Duration: 33
-6274	weak perfectly mixed bouncing open sauce	2	EPIC	
+6274	perfectly mixed weak bouncing open sauce	2	EPIC	
 6275	groovy turkey leg of vim and vigor	0		Moxie Percent: +10, Maximum HP Percent: +50
 6276	bad Ye Olde Meade	3	decent	
 6277	irradiated extra-polarized Ye Olde Bawdy Limerick	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 60
@@ -6195,7 +6195,7 @@
 6299	blurry model airship	0		
 6300	magnetized pressed mirror yellow Super Weight-Gain 9000	0		Effect: "Tingly Wrists", Effect Duration: 28
 6301	chilled quadruple-polymerized upside-down possibility potion	0		Effect: "Texas Elegance", Effect Duration: 45
-6302	skewed jittery eleven-foot pole	0		
+6302	jittery skewed eleven-foot pole	0		
 6303	blurry ring of Detect Boring Doors	0		
 6304	lime green wool medical-grade Da Vinci's cool Jarlsberg's pan (Cosmic portal mode) of Calamity Jane	0		Moxie: +5, Experience (Mysticality): +5, Critical Hit Percent: +15, Cold Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	ribald arcane researcher's groovy Jarlsberg's pan of mayonnaise of the boozehound	0		Moxie Percent: +10, Experience Percent (Mysticality): +10, Sleaze Damage: +10, Sleaze Spell Damage: +50, Booze Drop: +100, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6259,7 +6259,7 @@
 6363	cold-filtered shaking pulled taffy	0		Effect: "Orc Chops", Effect Duration: 51, Last Available: "2013-04"
 6364	activated moist jittery pulled taffy	0		Effect: "Berry Experiential", Effect Duration: 18, Last Available: "2013-04"
 6365	chilled chilled extra-colloidal pulled taffy	0		Effect: "Block-Rockin' Beet", Effect Duration: 57, Last Available: "2013-04"
-6366	quadruple-vacuum-sealed pulsating spinning ghostly pulled violet taffy	0		Effect: "Walberg's Dim Bulb", Effect Duration: 41, Last Available: "2013-04"
+6366	quadruple-vacuum-sealed spinning ghostly pulsating pulled violet taffy	0		Effect: "Walberg's Dim Bulb", Effect Duration: 41, Last Available: "2013-04"
 6367	improved pressed ionized blurry pulled taffy	0		Effect: "Boletus Swoletus", Effect Duration: 57, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
 6369	pulsating teal lump of clay	0		
@@ -6278,7 +6278,7 @@
 6383	enchanted root beer	1	decent	Effect: "Greased-Up Familiar", Effect Duration: 30
 6384	cyan jigsaw blade	0		
 6385	wood screw	0		
-6386	bouncing lime green balsa plank	0		
+6386	lime green bouncing balsa plank	0		
 6387	blob of wood glue	0		
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	aerosolized mirror Mer-kin rocksalt	0		Effect: "You Know Who to Call", Effect Duration: 68
@@ -6295,7 +6295,7 @@
 6400	Mer-kin lunchbox	0		
 6401	warmed skewed tear	0		Effect: "Boletus Swoletus", Effect Duration: 35
 6402	double-warmed ghostly jagged tooth	0		Effect: "Healthy Red Glow", Effect Duration: 19
-6403	warmed wobbly gray huge grisly shell fragment	0		Effect: "Destructive Resolve", Effect Duration: 30
+6403	warmed gray huge wobbly grisly shell fragment	0		Effect: "Destructive Resolve", Effect Duration: 30
 6404	moist alkaline squat spinning violent pastilles	0		Effect: "Gonna Get You, Sucker", Effect Duration: 22
 6405	alkaline irradiated vacuum-sealed huge worst candy	0		Effect: "White-boy Angst", Effect Duration: 20
 6406	ionized fudge-shaped hole in space-time	0		Effect: "White Blooded", Effect Duration: 29
@@ -6303,7 +6303,7 @@
 6408	corrupted stardust	0		
 6409	Star Spawn	0		
 6410	bow from beyond the stars	0		Familiar Weight: +5
-6411	narrow twirling KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
+6411	twirling narrow KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
 6413	jittery Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
@@ -6318,17 +6318,17 @@
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	purple Official Seal of Dreadsylvania	0		
-6426	miniature bland Dreadsylvanian stew	2	decent	
+6426	bland miniature Dreadsylvanian stew	2	decent	
 6427	aged Dreadsylvanian	4	awesome	
 6428	improved extra-unsweetened olive Dreadsylvanian flask	0		Effect: "Stregngth of the Gnome", Effect Duration: 28
-6429	magnetized energized teal upside-down Dreadsylvanian flask	0		Effect: "Broken Fast", Effect Duration: 17
+6429	magnetized energized upside-down teal Dreadsylvanian flask	0		Effect: "Broken Fast", Effect Duration: 17
 6430	tumbling up-at-dawn arcane researcher's dreadful fedora	0		Experience Percent (Mysticality): +10, Adventures: +5, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	fireproof dreadful sweater	0		Hot Resistance: +3, Kruegerand Drop: 5
 6432	cool dreadful glove	0		Moxie: +5, Kruegerand Drop: 5
 6433	bouncing Freddy Kruegerand	0		
 6434	Mark of the Bugbear	0		
 6435	pulsating Mark of the Werewolf	0		
-6436	blue narrow Mark of the Zombie	0		
+6436	narrow blue Mark of the Zombie	0		
 6437	tumbling Mark of the Ghost	0		
 6438	blinking Mark of the Vampire	0		
 6439	Mark of the Skeleton	0		
@@ -6338,7 +6338,7 @@
 6443	wicked Helps-You-Sleep of the overflowing toilet	0		Spell Damage: +5, Stench Spell Damage: +50, Single Equip
 6444	arcane researcher's thinker's Quiets-Your-Steps of Flo-Jo	0		Mysticality: +10, Experience Percent (Mysticality): +10, Initiative: +100, Single Equip
 6445	toasty Protects-Your-Junk of Tarzan	0		Experience (Muscle): +3, Hot Damage: +5, Single Equip
-6446	watered-down artisanal ghostly Gets-You-Drunk	2	EPIC	
+6446	artisanal watered-down ghostly Gets-You-Drunk	2	EPIC	
 6447	gravedigger's Jim Carey's Great Wolf's headband of the brute	0		Muscle Percent: +30, Monster Level: +25, Spooky Damage: +10, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	Lo Pan's crafty Great Wolf's left paw of the sweet-tooth	0		Maximum MP: +10, Spell Critical Percent: +30, Candy Drop: +100, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	gravedigger's Jack Frost's arcane researcher's Great Wolf's right paw	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +50, Spooky Damage: +10, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6390,7 +6390,7 @@
 6495	jittery perfumed Dreadsylvania Auditor's badge	0		Stench Resistance: +5, Kruegerand Drop: 5, Single Equip
 6496	fuchsia blood kiwi	0		
 6497	eau de mort	0		
-6498	tolerable strong wobbly bloody kiwitini	5	good	
+6498	strong tolerable wobbly bloody kiwitini	5	good	
 6499	moon-amber	0		
 6500	red polished moon-amber	0		
 6501	reassuring coward's moon-amber necklace of the storm	0		Maximum MP Percent: +40, Monster Level: -20, Spooky Resistance: +1, Single Equip
@@ -6408,7 +6408,7 @@
 6513	wobbly groovy warm fur	0		Moxie Percent: +10
 6514	scorching snowstick	0		Hot Damage: +25
 6515	wicked eerie fetish	0		Spell Damage: +5, Single Equip
-6516	watered-down smooth skewed maroon stinkwater	2	awesome	
+6516	smooth watered-down maroon skewed stinkwater	2	awesome	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	fancy moldy super-sized accidental mutton	5	crappy	Effect: "Dances with Tweedles", Effect Duration: 25
 6519	manspreader's Lo Pan's drafty drawers	0		Spell Critical Percent: +30, Monster Level: +10, Familiar Effect: "1.5xVolley"
@@ -6429,7 +6429,7 @@
 6534	ghostly lion tamer's remorseless knife	0		Experience (familiar): +2
 6535	ghostly sinister intimidating coiffure	0		Spell Damage: +10, Familiar Effect: "hot afk, 1xPotato"
 6536	asbestos-lined Temple Grandin's cod cape	0		Familiar Weight: +7, Hot Resistance: +5
-6537	diet tasty blood sausage	1	awesome	
+6537	tasty diet blood sausage	1	awesome	
 6538	lard-coated Sinatra's frying brainpan	0		Experience (Moxie): +5, Sleaze Spell Damage: +25
 6539	brainy ball and chain of the storm	0		Mysticality: +5, Maximum MP Percent: +40, Single Equip
 6540	friendly dry bone	0		Familiar Weight: +3
@@ -6449,7 +6449,7 @@
 6555	sleaze cluster	0		
 6556	super-moist phial of hotness	0		Effect: "Drunk With Power", Effect Duration: 18
 6557	flattened phial of coldness	0		Effect: "Spiritually Awake", Effect Duration: 54
-6558	modified squat maroon phial of spookiness	0		Effect: "It's Electric!", Effect Duration: 23
+6558	modified maroon squat phial of spookiness	0		Effect: "It's Electric!", Effect Duration: 23
 6559	super-dry phial of stench	0		Effect: "Pisces Rising", Effect Duration: 18
 6560	double-galvanized frozen boiled narrow phial of sleaziness	0		Effect: "Mer-kinny Flavor", Effect Duration: 27
 6561	wobbly adventurer clone egg	0		Free Pull, Last Available: "2013-06"
@@ -6460,11 +6460,11 @@
 6566	delicious Dreadsylvanian pocket	3	awesome	
 6567	adequate Dreadsylvanian stink pocket	3	good	
 6568	normal gigantic Dreadsylvanian sleaze pocket	9	good	
-6569	watered-down hand-crafted Dreadsylvanian hot toddy	2	super ultra mega turbo EPIC	
+6569	hand-crafted watered-down Dreadsylvanian hot toddy	2	super ultra mega turbo EPIC	
 6570	lousy Dreadsylvanian cold-fashioned	3	decent	
 6571	artisanal Dreadsylvanian grimlet	3	super ultra mega turbo EPIC	
-6572	extra-dry tolerable Dreadsylvanian dank and stormy	5	good	
-6573	lousy spirit-forward Dreadsylvanian slithery nipple	5	decent	
+6572	tolerable extra-dry Dreadsylvanian dank and stormy	5	good	
+6573	spirit-forward lousy Dreadsylvanian slithery nipple	5	decent	
 6574	hot clusterbomb	0		
 6575	upside-down clusterbomb	0		
 6576	spinning clusterbomb	0		
@@ -6473,8 +6473,8 @@
 6579	Dreadsylvanian Almanac page	0		
 6580	huge red length of fuse	0		
 6581	cyan dreadful box	0		
-6582	shaking huge Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	upside-down pulsating vicious spiked collar	0		Familiar Damage: +20
+6582	huge shaking Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
+6583	pulsating upside-down vicious spiked collar	0		Familiar Damage: +20
 6584	hot dog wrapper of horror	0		Spooky Spell Damage: +25
 6585	ruddy debonair deboner of bravery	0		Maximum HP Percent: +40, Spooky Resistance: +5
 6586	non-wet chicle de salchicha	0		Effect: "Pill Power", Effect Duration: 27
@@ -6482,7 +6482,7 @@
 6588	toasty dog trainer's gnawed-up dog bone	0		Experience (familiar): +1, Hot Damage: +5
 6589	flame-wreathed Grey Guanon	0		Hot Spell Damage: +10
 6590	ghostly Usain Bolt's clever smartaleck's Engorged Sausages and You	0		Moxie Percent: +30, Maximum MP: +20, Initiative: +80
-6591	practically non-alcoholic tolerable dream of a dog	1	good	
+6591	tolerable practically non-alcoholic dream of a dog	1	good	
 6592	miser's Herculean optimal spreadsheet of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Meat Drop: +10
 6593	defective Game Grid token	0		
 6594	shaking hot Dreadsylvanian cocoa	0		
@@ -6508,7 +6508,7 @@
 6614	cuckoo clock	0		
 6615	perfectly mixed Cold One	3	???	
 6616	delicious spaghetti breakfast	3	???	
-6617	skewed shaking teal over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
+6617	skewed teal shaking over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	triple-ionized quadruple-colloidal corrupted Ogres and Oubliettes&trade; module	0		Effect: "Bear Clawed", Effect Duration: 43
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	tolerable high-proof stepmom's booze	9	good	
+6652	high-proof tolerable stepmom's booze	9	good	
 6653	purple surgical tape	0		
 6654	educational band T-shirt	0		Experience: +1
 6655	high-proof mediocre huge fountain 'soda'	7	decent	
@@ -6571,7 +6571,7 @@
 6679	machete	0		Item Drop: +5
 6680	perfectly mixed watered-down Cursed Punch	2	EPIC	
 6681	delicious Bowl of Scorpions	4	awesome	
-6682	weak artisanal shaking Fog Murderer	2	super EPIC	
+6682	artisanal weak shaking Fog Murderer	2	super EPIC	
 6683	book of matches	0		
 6684	surgical mask of terror	0		Spooky Spell Damage: +10, Surgeonosity: +1
 6685	resourceful head mirror	0		Maximum MP: +50, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	blinking bowler	0		
 6703	imitation White Russian	1	crappy	
 6704	upside-down sizzling strapping short-handled mop	0		Muscle: +5, Hot Damage: +10
-6705	thick spoiled jungle floor wax	5	crappy	
+6705	spoiled thick jungle floor wax	5	crappy	
 6706	smirking shrunken head	0		
 6707	cold-filtered moist colorful toad	0		Effect: "Cotton Mouthed", Effect Duration: 25
 6708	crude voodoo doll	0		
@@ -6613,7 +6613,7 @@
 6721	huge wicked boxer's water bottle of mayonnaise	0		Muscle Percent: +10, Spell Damage: +5, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	flattened squat pygmy phone number	0		Effect: "Human-Insect Hybrid", Effect Duration: 50
 6723	Boozehounds Anonymous token	0		
-6724	toothsome half-sized exotic jungle fruit	2	awesome	
+6724	half-sized toothsome exotic jungle fruit	2	awesome	
 6725	lime green Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6634,7 +6634,7 @@
 6742	weightlifter's junk band	0		Muscle: +15
 6743	olive junk trunks of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "cap 15"
 6744	pulsating tumbling coward's junk-mail shirt	0		Monster Level: -20
-6745	miniature spoiled ghostly maroon junk food	2	crappy	
+6745	spoiled miniature maroon ghostly junk food	2	crappy	
 6746	lousy junk yard	3	decent	
 6747	Newton's swordzall of the sewer	0		Experience (Mysticality): +3, Stench Damage: +25
 6748	arm buzzer of dire peril	0		Weapon Damage: +20, Damage Reduction: 6
@@ -6642,16 +6642,16 @@
 6750	Gordon Beer's Beer Garden Catalog	0		Last Available: "2013-09"
 6751	packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
-6753	blinking blue cluster of hops	0		
+6753	blue blinking cluster of hops	0		
 6754	beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	acceptable can of Br&uuml;talbr&auml;u	3	good	Last Available: "2013-09"
-6758	triple-distilled hand-crafted olive tumbling huge can of Drooling Monk	9	EPIC	Last Available: "2013-09"
+6758	hand-crafted triple-distilled olive huge tumbling can of Drooling Monk	9	EPIC	Last Available: "2013-09"
 6759	hand-crafted can of Impetuous Scofflaw	4	EPIC	Last Available: "2013-09"
 6760	tolerable red bottle of Old Pugilist	3	good	Last Available: "2013-09"
 6761	watered-down mediocre bottle of Professor Beer	2	decent	Last Available: "2013-09"
-6762	artisanal practically non-alcoholic jittery upside-down bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6762	artisanal practically non-alcoholic upside-down jittery bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6763	acceptable narrow shaking bottle of Race Car Red	3	good	Last Available: "2013-09"
 6764	hand-crafted bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
 6765	tolerable triple-distilled bottle of Lambada Lambic	10	good	Last Available: "2013-09"
@@ -6692,7 +6692,7 @@
 6803	dry denatured upside-down disco horoscope (Libra)	0		Effect: "Ten out of Ten", Effect Duration: 65
 6804	energized ionized pulsating disco horoscope (Scorpio)	0		Effect: "Barbecue Saucy", Effect Duration: 41
 6805	frozen electrified disco horoscope (Sagittarius)	0		Effect: "Greasy Peasy", Effect Duration: 67
-6806	adjusted jittery narrow disco horoscope (Capricorn)	0		Effect: "X-Ray Vision", Effect Duration: 58
+6806	adjusted narrow jittery disco horoscope (Capricorn)	0		Effect: "X-Ray Vision", Effect Duration: 58
 6807	knitted vibrating The Sagittarian's leisure pants	0		Maximum MP Percent: +10, Cold Resistance: +3, Familiar Effect: "atk, cap 18"
 6808	shaking toy accordion	0		Song Duration: 5
 6809	ghostly accordion	0		Song Duration: 10
@@ -6728,7 +6728,7 @@
 6839	irradiated polymerized jam	0		Effect: "Analog Drunk", Effect Duration: 12
 6840	cold-filtered Whenchamacallit bar	0		Effect: "Cold Blooded", Effect Duration: 65
 6841	quadruple-denatured jittery 8-bit banana	0		Effect: "Takin' It Greasy", Effect Duration: 45
-6842	super-dry energized blinking maroon twirling vial of blood simple syrup	0		Effect: "Gunky Dory", Effect Duration: 27
+6842	super-dry energized twirling blinking maroon vial of blood simple syrup	0		Effect: "Gunky Dory", Effect Duration: 27
 6843	pickled blue bone bons	0		Effect: "Chalked Weapon", Effect Duration: 42
 6844	ionized ironic mint	0		Effect: "Heart of Green", Effect Duration: 20
 6845	unused walkie-talkie	0		Free Pull
@@ -6749,15 +6749,15 @@
 6860	green occult Pantsgiving of Leguizamo of extreme caution of the glutton	0		Spell Damage Percent: +25, Monster Level: -5, Food Drop: +100, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
 6861	adequate yellow can of sardines	3	good	Last Available: "2013-11"
 6862	rotten huge narrow high-calorie sugar substitute	3	crappy	Last Available: "2013-11"
-6863	big adequate mirror pat of butter	5	good	Last Available: "2013-11"
+6863	adequate big mirror pat of butter	5	good	Last Available: "2013-11"
 6864	moldy dinner roll	3	crappy	Last Available: "2013-11"
 6865	adequate mashed potatoes	3	good	Last Available: "2013-11"
 6866	spoiled green whole turkey leg	4	crappy	Last Available: "2013-11"
-6867	toothsome miniature squat deviled egg	2	awesome	Last Available: "2013-11"
+6867	miniature toothsome squat deviled egg	2	awesome	Last Available: "2013-11"
 6868	anodized finger exerciser	0		Effect: "Badger Underfoot", Effect Duration: 18, Last Available: "2013-11"
-6869	irradiated pulsating twirling dented spoon	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 68, Last Available: "2013-11"
+6869	irradiated twirling pulsating dented spoon	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 68, Last Available: "2013-11"
 6870	denatured love note	0		Effect: "Stemonitis Storm", Effect Duration: 40, Last Available: "2013-11"
-6871	pulsating bouncing school beer pull tab	0		Last Available: "2013-11"
+6871	bouncing pulsating school beer pull tab	0		Last Available: "2013-11"
 6872	polarized cyan nail file	0		Effect: "Cautious Prowl", Effect Duration: 43, Last Available: "2013-11"
 6873	warmed maroon candy wrapper	0		Effect: "Carol of the Bones", Effect Duration: 52, Last Available: "2013-11"
 6874	shaking gym membership card	0		Last Available: "2013-11"
@@ -6789,9 +6789,9 @@
 6900	mirror experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	olive hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	studded flask flops of the wise owl	0		Mysticality: +20, Damage Absorption: +80, Single Equip
-6903	pressed upside-down squat nuts	0		Effect: "Night of the Nachos", Effect Duration: 59, Last Available: "2013-12"
+6903	pressed squat upside-down nuts	0		Effect: "Night of the Nachos", Effect Duration: 59, Last Available: "2013-12"
 6904	super-quantum cold-filtered wobbly bolts	0		Effect: "Gr8ness", Effect Duration: 40, Last Available: "2013-12"
-6905	spoiled half-sized cyan skewed gingerbread robot	2	crappy	Last Available: "2013-12"
+6905	half-sized spoiled skewed cyan gingerbread robot	2	crappy	Last Available: "2013-12"
 6906	adequate petit 4.1	4	good	Last Available: "2013-12"
 6907	decent green nut-shaped Crimbo cookie	4	good	Last Available: "2023-06"
 6908	dog trainer's plastic GORM-8	0		Experience (familiar): +1, Last Available: "2013-12"
@@ -6807,9 +6807,9 @@
 6918	Vulcanized corrupted blinking warbear wardance potion	0		Effect: "Spooky Blur", Effect Duration: 64, Last Available: "2013-12"
 6919	ionized diffused warbear bearserker potion	0		Effect: "Destructive Resolve", Effect Duration: 17, Last Available: "2013-12"
 6920	galvanized enhanced dry warbear liquid overcoat	0		Effect: "Berry Statistical", Effect Duration: 53, Last Available: "2013-12"
-6921	stale super-sized mirror warbear feasting bread	5	decent	Last Available: "2013-12"
+6921	super-sized stale mirror warbear feasting bread	5	decent	Last Available: "2013-12"
 6922	massive rotten warbear warrior bread	9	crappy	Last Available: "2013-12"
-6923	flavorless huge squat warbear thermoregulator bread	3	decent	Last Available: "2013-12"
+6923	flavorless squat huge warbear thermoregulator bread	3	decent	Last Available: "2013-12"
 6924	artisanal warbear feasting mead	3	EPIC	Last Available: "2013-12"
 6925	weak drinkable warbear bearserker mead	2	good	Last Available: "2013-12"
 6926	practically non-alcoholic acceptable blurry warbear blizzard mead	1	good	Last Available: "2013-12"
@@ -6896,9 +6896,9 @@
 7007	tasty pulsating Every Day is Like This Sundae	3	awesome	Last Available: "2013-12"
 7008	adequate small Miserable Pie	2	good	Last Available: "2013-12"
 7009	normal This Charming Flan	3	good	Last Available: "2013-12"
-7010	mediocre boozy Irish Coffee, English Heart	5	decent	Last Available: "2013-12"
+7010	boozy mediocre Irish Coffee, English Heart	5	decent	Last Available: "2013-12"
 7011	watered-down artisanal Strikes Again Bigmouth	2	EPIC	Last Available: "2013-12"
-7012	delicious special watered-down skewed Paint A Vulgar Pitcher	2	awesome	Effect: "Fit To Be Tide", Effect Duration: 15, Last Available: "2013-12"
+7012	delicious watered-down special skewed Paint A Vulgar Pitcher	2	awesome	Effect: "Fit To Be Tide", Effect Duration: 15, Last Available: "2013-12"
 7013	narrow Golden Light	0		Last Available: "2013-12"
 7014	blinking Louder Than Bomb	0		Last Available: "2013-12"
 7015	fuchsia Handsome Devil	0		Last Available: "2013-12"
@@ -6918,12 +6918,12 @@
 7029	sage Shakespeare's Sister's Accordion of the dark arts of the glutton	0		Mysticality Percent: +10, Spell Damage Percent: +100, Food Drop: +100, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	third-hand lantern of temperance	0		Sleaze Resistance: +5
 7031	pulsating loose purse strings	0		
-7032	gigantic spoiled squat pickled egg	6	crappy	
+7032	spoiled gigantic squat pickled egg	6	crappy	
 7033	cup of lukewarm tea	1	awesome	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	blinking warbear box	0		Last Available: "2013-12"
 7036	ghostly warbear high-efficiency still	0		Last Available: "2013-12"
-7037	pulsating red warbear LP-ROM burner	0		Last Available: "2013-12"
+7037	red pulsating warbear LP-ROM burner	0		Last Available: "2013-12"
 7038	tumbling warbear gyrocopter	0		Last Available: "2013-12"
 7039	wet quantum squat warbear robo-camouflage unit	0		Effect: "Petit Forbearance", Effect Duration: 20, Last Available: "2013-12"
 7040	shaking warbear beeping telegram	0		Last Available: "2013-12"
@@ -6934,14 +6934,14 @@
 7045	altered bouncing antimatter wad	1	good	Effect: "Super Skill", Effect Duration: 15, Last Available: "2013-12"
 7046	oxidized dry aerosolized upside-down warbear superpotion	0		Effect: "Cockroach Scurry", Effect Duration: 58, Last Available: "2013-12"
 7047	dry shaking warbear liquid lasers	0		Effect: "Browbeaten", Effect Duration: 19, Last Available: "2013-12"
-7048	adjusted vacuum-sealed diffused cyan wobbly warbear rejuvenation potion	0		Effect: "Oiled Skin", Effect Duration: 39, Last Available: "2013-12"
+7048	adjusted vacuum-sealed diffused wobbly cyan warbear rejuvenation potion	0		Effect: "Oiled Skin", Effect Duration: 39, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	bland warbear gyro	4	decent	Last Available: "2013-12"
 7051	Vulcanized quadruple-denatured jittery recording of Rolando's Rondo of Resisto	0		Effect: "Greasy Flavor", Effect Duration: 24, Last Available: "2013-12"
 7052	pulsating warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	ghostly warbear drone codes	0		Last Available: "2013-12"
-7055	small normal huge breakfast mess	2	good	Last Available: "2013-12"
+7055	normal small huge breakfast mess	2	good	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	fancy decent big breakfast miracle	5	good	Effect: "Vitali Tea", Effect Duration: 20, Last Available: "2013-12"
 7058	colloidal super-modified Cloaca Cola Polar	0		Effect: "Stenchtastic", Effect Duration: 40, Last Available: "2013-12"
@@ -6952,7 +6952,7 @@
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	modified upside-down grim fairy tale	1	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 5, Last Available: "2014-12"
-7066	blurry jittery grimstone galoshes	0		Familiar Weight: +5
+7066	jittery blurry grimstone galoshes	0		Familiar Weight: +5
 7067	double-modified single of Inigo's Incantation of Inspiration	0		Effect: "Clyde's Blessing", Effect Duration: 46, Last Available: "2010-02"
 7068	irradiated denatured single of Donho's Bubbly Ballad	0		Effect: "Ruby-ous", Effect Duration: 12
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
@@ -6963,10 +6963,10 @@
 7074	ionized yellow snow cleats	0		Effect: "Tiki Thoughtfulness", Effect Duration: 57, Last Available: "2014-01"
 7075	dry nitrogenated wet tumbling liquid ice pack	0		Effect: "Hairless and Airless", Effect Duration: 39, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
-7077	miniature rotten snow crab	2	crappy	Last Available: "2014-01"
+7077	rotten miniature snow crab	2	crappy	Last Available: "2014-01"
 7078	lousy boozy Ice Island Long Tea	5	decent	Last Available: "2014-01"
 7079	jittery unfinished ice sculpture	0		Last Available: "2014-01"
-7080	green blurry ice sculpture	0		Last Available: "2014-01"
+7080	blurry green ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
 7083	snow mobile of mayonnaise	0		Sleaze Spell Damage: +50, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	pulsating sage snow belt of Tarzan of James Dean of the early riser	0		Mysticality Percent: +10, Experience (Muscle): +3, Experience (Moxie): +3, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	blurry steel-toed ice nine of the overflowing toilet of the detective	0		Damage Reduction: 9, Stench Spell Damage: +50, Item Drop: 25, Lasts Until Rollover, Last Available: "2014-01"
 7089	blinking snow fort	0		Last Available: "2014-01"
-7090	perfectly mixed weak En Una Fila Tequila	2	EPIC	
+7090	weak perfectly mixed En Una Fila Tequila	2	EPIC	
 7091	Skully's hot chocolate	1	good	
 7092	mirror ribald extremely unsafe warbear dress helmet	0		Weapon Damage Percent: +100, Sleaze Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	boxer's warbear dress bracers of doom	0		Muscle Percent: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2013-12"
@@ -6998,10 +6998,10 @@
 7109	thick flavorless yellow pecan pie	5	decent	Last Available: "2014-12"
 7110	maroon squat chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	super-sized stale fuchsia upside-down candy mountain oyster	5	decent	Last Available: "2014-12"
-7112	smooth practically non-alcoholic huge chocotini	1	awesome	Last Available: "2014-12"
+7112	practically non-alcoholic smooth huge chocotini	1	awesome	Last Available: "2014-12"
 7113	tumbling perfumed chaotic chocolate rabbit's foot of wisdom	0		Mysticality: +15, Spell Critical Percent: +10, Stench Resistance: +5, Last Available: "2014-12"
 7114	miniature adequate ghostly skewed candy carrot	2	good	Last Available: "2014-12"
-7115	tasty bite-sized special candy carrot cake	1	awesome	Effect: "Spooky Hands", Effect Duration: 10, Last Available: "2014-12"
+7115	tasty special bite-sized candy carrot cake	1	awesome	Effect: "Spooky Hands", Effect Duration: 10, Last Available: "2014-12"
 7116	lion tamer's fortified carrot-on-a-stick	0		Damage Absorption: +60, Experience (familiar): +2, Last Available: "2014-12"
 7117	cyan greasy chaotic weasel stomping pants	0		Spell Critical Percent: +10, Sleaze Spell Damage: +10, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	decent miniature huge mulberry	2	good	Last Available: "2014-12"
@@ -7016,7 +7016,7 @@
 7127	chocolate cow bone of the blizzard	0		Cold Spell Damage: +25, Last Available: "2014-12"
 7128	colloidal colloidal gummi fang	0		Effect: "Sauce Monocle", Effect Duration: 65, Last Available: "2014-12"
 7129	moldy miniature leftover canap&eacute;s	2	crappy	Last Available: "2014-12"
-7130	watered-down hand-crafted magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
+7130	hand-crafted watered-down magnum of champagne	2	super ultra mega turbo EPIC	Last Available: "2014-12"
 7131	mansplainer's personal trainer's Samson's cow creamer	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Monster Level: +15, Last Available: "2014-12"
 7132	quantum enhanced tumbling Outer Wolf&trade; cologne	0		Effect: "Phorcefullness", Effect Duration: 56, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
@@ -7031,7 +7031,7 @@
 7142	chilled hare brush	0		Effect: "Muddled", Effect Duration: 62, Last Available: "2014-12"
 7143	twirling coward's therapeutic hare pin	0		Monster Level: -20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	stale big cinnamon cannoli	5	decent	Last Available: "2014-12"
+7145	big stale cinnamon cannoli	5	decent	Last Available: "2014-12"
 7146	smooth expensive champagne	3	awesome	Last Available: "2014-12"
 7147	tarnished deionized boiled polo trophy	0		Effect: "Total Protonic Reversal", Effect Duration: 44, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
@@ -7050,9 +7050,9 @@
 7161	wool electrified slick &quot;honey&quot; dipper	0		Moxie: +10, Cold Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7162	moldy plumber's lunch	3	crappy	Last Available: "2014-12"
 7163	tumbling jittery scandalous arcane researcher's skull gearshift knob of the brazier	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +25, Sleaze Damage: +5, Last Available: "2014-12"
-7164	gigantic special decent squat nachos of the night	9	good	Effect: "Fireproof Lips", Effect Duration: 20, Last Available: "2014-12"
+7164	gigantic decent special squat nachos of the night	9	good	Effect: "Fireproof Lips", Effect Duration: 20, Last Available: "2014-12"
 7165	flame-wreathed chilly dangerous Sketcherz&trade;	0		Weapon Damage: +10, Cold Damage: +5, Hot Spell Damage: +10, Last Available: "2014-12"
-7166	jumbo normal can of Adultwitch&trade;	5	good	Last Available: "2014-12"
+7166	normal jumbo can of Adultwitch&trade;	5	good	Last Available: "2014-12"
 7167	dry narrow smudge stick	0		Effect: "Arresistible", Effect Duration: 44, Last Available: "2014-12"
 7168	liquefied ionized wall	0		Effect: "20-20 Second Sight", Effect Duration: 16, Last Available: "2014-12"
 7169	aged tankard of ale	4	awesome	Last Available: "2014-12"
@@ -7072,12 +7072,12 @@
 7183	Murphy's Rancid Black Flag	0		
 7184	huge The Shield of Brook	0		
 7185	huge Red Zeppelin ticket	0		
-7186	pulsating blinking Copperhead Charm (rampant)	0		
-7187	drinkable watered-down enchanted unnamed cocktail	2	good	Effect: "Stickler for Promptness", Effect Duration: 35
-7188	maroon skewed handful of tips	0		
+7186	blinking pulsating Copperhead Charm (rampant)	0		
+7187	enchanted drinkable watered-down unnamed cocktail	2	good	Effect: "Stickler for Promptness", Effect Duration: 35
+7188	skewed maroon handful of tips	0		
 7189	unrequired jacket of the glutton	0		Food Drop: +100
 7190	flame-wreathed tommy gun	0		Hot Spell Damage: +10, Conditional Skill (Equipped): "Unload Tommy Gun"
-7191	upside-down cyan drum of tommy ammo	0		
+7191	cyan upside-down drum of tommy ammo	0		
 7192	pulsating throwing knife	0		
 7193	teal throwing spoon	0		
 7194	throwing fork	0		
@@ -7101,22 +7101,22 @@
 7212	blinking arcane researcher's Jefferson wings	0		Experience Percent (Mysticality): +10
 7213	tumbling fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	rotten massive fleetwood mac 'n' cheese	6	crappy	
+7215	massive rotten fleetwood mac 'n' cheese	6	crappy	
 7216	lynyrd skin	0		
 7217	grievous lynyrdskin cap	0		Weapon Damage Percent: +50, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	ghostly shellacked lynyrdskin tunic	0		Damage Reduction: 7
 7219	Sinatra's lynyrdskin breeches	0		Experience (Moxie): +5, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	watered-down acceptable Flamin' Whatshisname	2	good	
+7222	acceptable watered-down Flamin' Whatshisname	2	good	
 7223	concentrated gray blurry lynyrd musk	0		Effect: "Phairly Pheromonal", Effect Duration: 14
 7224	ribald groovy Kashmir sweater	0		Moxie Percent: +10, Sleaze Damage: +10
 7225	moldy wobbly custard pie	4	crappy	
 7226	tea for one	1	EPIC	
-7227	practically non-alcoholic artisanal jittery bottle of Evermore	1	EPIC	
+7227	artisanal practically non-alcoholic jittery bottle of Evermore	1	EPIC	
 7228	olive narrow box	0		
 7229	tolerable wine	3	good	
-7230	artisanal watered-down rum	2	EPIC	
+7230	watered-down artisanal rum	2	EPIC	
 7231	triple-distilled smooth Murderer's Punch	8	awesome	
 7232	moldy huge velvet cake	9	crappy	
 7233	pickled warmed letter	0		Effect: "Hella Smooth", Effect Duration: 66
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	blurry Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	enchanted mediocre spirit-forward tumbling mini-martini	5	decent	Effect: "Grumpy and Ornery", Effect Duration: 25
+7255	spirit-forward mediocre enchanted tumbling mini-martini	5	decent	Effect: "Grumpy and Ornery", Effect Duration: 25
 7256	red smoke grenade	0		
 7257	twisted molotov soda	1	good	Effect: "Aries Rising", Effect Duration: 5
 7258	quantum lime green huge pile of ashes	0		Effect: "Once Bitten Twice Fried", Effect Duration: 52
@@ -7150,7 +7150,7 @@
 7261	greedy scandalous hale Sneaky Pete's basket	0		Maximum HP: +20, Sleaze Damage: +5, Meat Drop: +20
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	wobbly photograph of a dog	0		
-7264	yellow pulsating photograph of a nugget	0		
+7264	pulsating yellow photograph of a nugget	0		
 7265	pulsating photograph of an ostrich egg	0		
 7266	shaking disposable instant camera	0		
 7267	foul-smelling Sneaky Pete's jacket (collar popped) of chilblains of courage of bravery	0		Cold Damage: +25, Stench Damage: +10, Spooky Resistance: 8, Softcore Only, Free Pull, Last Available: "2014-03"
@@ -7181,7 +7181,7 @@
 7292	red putty coat	0		Familiar Weight: +5
 7293	frozen polymerized mirror can of V-11	0		Effect: "stats.enq", Effect Duration: 19, Last Available: "2014-03"
 7294	sage elevennis shoes of the detective	0		Mysticality Percent: +10, Item Drop: +20, Last Available: "2014-03"
-7295	tumbling blinking elevent	0		Last Available: "2014-03"
+7295	blinking tumbling elevent	0		Last Available: "2014-03"
 7296	chilly thinker's elevenderizing hammer	0		Mysticality: +10, Cold Damage: +5, Last Available: "2014-03"
 7297	red Newton's Professor What T-Shirt	0		Experience (Mysticality): +3
 7298	heavy-duty bendy straw	0		
@@ -7211,7 +7211,7 @@
 7322	unsweetened green Stephen's secret formula	0		Effect: "Bilious Brawn", Effect Duration: 36
 7323	zippy rock-hard Jacob's rung	0		Damage Reduction: 5, Initiative: +20
 7324	altered cyan jittery battery	1		
-7325	acceptable triple-distilled snakebite	9	good	
+7325	triple-distilled acceptable snakebite	9	good	
 7326	zippy miser's rubber ribcage	0		Meat Drop: +10, Initiative: +20, Damage Reduction: 7
 7327	denatured synthetic marrow	1		
 7328	electrified frozen funny bone	0		Effect: "Guts Feeling", Effect Duration: 31
@@ -7219,8 +7219,8 @@
 7330	dried the funk	1		Effect: "Hot Jellied", Effect Duration: 5
 7331	miniature moldy red gunky chicken	2	crappy	
 7332	energetic doll head	0		Maximum MP Percent: +20
-7333	tumbling olive narrow droopy doll eye	0		
-7334	jittery wobbly narrow voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
+7333	narrow olive tumbling droopy doll eye	0		
+7334	narrow jittery wobbly voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	fuchsia wizardly paddle-ball of Flo-Jo	0		Mysticality: +25, Initiative: +100
 7336	non-polarized energized sound effects record	0		Effect: "Piratey Flavor", Effect Duration: 56
 7337	alphabet block	0		
@@ -7230,16 +7230,16 @@
 7341	dry non-magnetized moose thought	0		Effect: "Lubed", Effect Duration: 68
 7342	bland moose chocolate	4	decent	
 7343	mediocre painting of a glass of wine	4	decent	
-7344	wobbly tumbling oil painting of yourself	0		
-7345	blurry spinning ornate picture frame	0		
+7344	tumbling wobbly oil painting of yourself	0		
+7345	spinning blurry ornate picture frame	0		
 7346	fuchsia doll-eye amulet	0		Single Equip
 7347	shaking lard-coated ghost toga of the detective	0		Sleaze Spell Damage: +25, Item Drop: +20
-7348	low-calorie moldy sheet cake	1	crappy	
+7348	moldy low-calorie sheet cake	1	crappy	
 7349	ghostly ghost key	0		
 7350	mirror picture of you	0		
 7351	squat fortified Staff of the Electric Range of dire peril of the sweet-tooth	0		Weapon Damage: +20, Damage Absorption: +60, Candy Drop: +100
 7352	spoiled thick deluxe layer cake	5	crappy	
-7353	blinking lime green chunk of hot iron	0		
+7353	lime green blinking chunk of hot iron	0		
 7354	drinkable red-hot boilermaker	3	good	
 7355	brainy coal shovel	0		Mysticality: +5, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	polymerized blinking hot coal	0		Effect: "Mutated", Effect Duration: 56
@@ -7255,7 +7255,7 @@
 7366	drinkable cyan bottle of laundry sherry	4	good	
 7367	diffused quantum double-dry industrial strength starch	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 47, Wiki Name: "industrial strength starch"
 7368	bland extra-flat panini	4	decent	
-7369	non-improved jittery squat mangled finger	0		Effect: "Gingerbread Robust", Effect Duration: 32
+7369	non-improved squat jittery mangled finger	0		Effect: "Gingerbread Robust", Effect Duration: 32
 7370	acceptable blurry Psychotic Train wine	4	good	
 7371	mirror crazy hobo notebook	0		
 7372	bland pie man was not meant to eat	3	decent	
@@ -7275,7 +7275,7 @@
 7386	magnetized pulsating Gene Tonic: Construct	0		Effect: "Spiky Frozen Hair", Effect Duration: 38, Last Available: "2014-04"
 7387	improved denatured extra-galvanized pulsating Gene Tonic: Undead	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 24, Last Available: "2014-04"
 7388	irradiated flattened unsweetened Gene Tonic: Humanoid	0		Effect: "Fancy Feasted", Effect Duration: 62, Last Available: "2014-04"
-7389	energized polarized maroon upside-down tumbling Gene Tonic: Insect	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 27, Last Available: "2014-04"
+7389	energized polarized tumbling upside-down maroon Gene Tonic: Insect	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 27, Last Available: "2014-04"
 7390	deionized cold-filtered improved Gene Tonic: Hippy	0		Effect: "Black Lung", Effect Duration: 40, Last Available: "2014-04"
 7391	liquefied diffused Gene Tonic: Orc	0		Effect: "Sweet Tooth", Effect Duration: 13, Last Available: "2014-04"
 7392	extra-adjusted Gene Tonic: Demon	0		Effect: "Rotten Memories", Effect Duration: 25, Last Available: "2014-04"
@@ -7327,11 +7327,11 @@
 7438	adequate tumbling Beefy Crunch Pastaco	3	good	Last Available: "2014-05"
 7439	decent cyan Brain Food Pastaco	3	good	Last Available: "2014-05"
 7440	flavorless Cool Brunch Pastaco	3	decent	Last Available: "2014-05"
-7441	half-sized normal Medical Pastaco	2	good	Last Available: "2014-05"
+7441	normal half-sized Medical Pastaco	2	good	Last Available: "2014-05"
 7442	flavorless Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	adequate Ludovico Pastaco	3	good	Last Available: "2014-05"
 7444	tolerable overpowering mushroom wine	3	good	Last Available: "2014-05"
-7445	smooth practically non-alcoholic gray blurry complex mushroom wine	1	awesome	Last Available: "2014-05"
+7445	practically non-alcoholic smooth gray blurry complex mushroom wine	1	awesome	Last Available: "2014-05"
 7446	mediocre maroon smooth mushroom wine	3	decent	Last Available: "2014-05"
 7447	weak aged upside-down blood-red mushroom wine	2	awesome	Last Available: "2014-05"
 7448	hand-crafted buzzing mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
@@ -7341,7 +7341,7 @@
 7452	upside-down Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	acceptable weak regular-size brogurt	2	good	Last Available: "2014-05"
 7454	artisanal blue super-size brogurt	3	EPIC	Last Available: "2014-05"
-7455	aged special weak broberry brogurt	2	awesome	Effect: "Egg on your Face", Effect Duration: 45, Last Available: "2014-05"
+7455	aged weak special broberry brogurt	2	awesome	Effect: "Egg on your Face", Effect Duration: 45, Last Available: "2014-05"
 7456	acceptable brocolate brogurt	3	good	Last Available: "2014-05"
 7457	drinkable French bronilla brogurt	4	good	Last Available: "2014-05"
 7458	tumbling History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
@@ -7360,7 +7360,7 @@
 7471	polarized cyan BROS Energy Drink	0		Effect: "Cautious Prowl", Effect Duration: 54, Last Available: "2014-05"
 7472	nitrogenated modified quantum go-go potion	0		Effect: "All Fired Up", Effect Duration: 13, Last Available: "2014-05"
 7473	non-chilled shrimp cocktail	0		Effect: "Horrid, Torrid", Effect Duration: 63, Last Available: "2014-05"
-7474	irradiated dry improved teal shaking Yolo&trade; chocolates	0		Effect: "Danish Cunning", Effect Duration: 15, Last Available: "2020-09"
+7474	irradiated dry improved shaking teal Yolo&trade; chocolates	0		Effect: "Danish Cunning", Effect Duration: 15, Last Available: "2020-09"
 7475	foul-smelling string of moist beads	0		Stench Damage: +10, Last Available: "2014-05"
 7476	Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	pickled ionized Meat-inflating powder	0		Effect: "Sweetened and Fattened", Effect Duration: 50, Last Available: "2014-05"
@@ -7368,16 +7368,16 @@
 7479	dry ionized sugar fairy	0		Effect: "Pill Power", Effect Duration: 58, Last Available: "2014-05"
 7480	energized ionized ghostly sugar bunny	0		Effect: "Antsy in your Pantsy", Effect Duration: 65, Last Available: "2014-05"
 7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	special mediocre green Rompedores de Fantasmas	4	decent	Effect: "Ooh, Sour!", Effect Duration: 50
-7483	perfectly mixed enchanted weak upside-down La Fantasma y La Oscuridad	2	EPIC	Effect: "Wet and Greedy", Effect Duration: 35
-7484	practically non-alcoholic drinkable Fantasma en la M&aacute;quina	1	good	
+7482	mediocre special green Rompedores de Fantasmas	4	decent	Effect: "Ooh, Sour!", Effect Duration: 50
+7483	weak perfectly mixed enchanted upside-down La Fantasma y La Oscuridad	2	EPIC	Effect: "Wet and Greedy", Effect Duration: 35
+7484	drinkable practically non-alcoholic Fantasma en la M&aacute;quina	1	good	
 7485	tumbling loosening powder	0		
 7486	tumbling blinking castoreum	0		
 7487	narrow drain dissolver	0		
 7488	shaking triple-distilled turpentine	0		
 7489	yellow detartrated anhydrous sublicalc	0		
 7490	triatomaceous dust	0		
-7491	artisanal fancy boozy bottle of Chateau de Vinegar	5	EPIC	Effect: "Hangdog", Effect Duration: 10
+7491	boozy fancy artisanal bottle of Chateau de Vinegar	5	EPIC	Effect: "Hangdog", Effect Duration: 10
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
@@ -7415,7 +7415,7 @@
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	resourceful quilted government-issued night-vision goggles	0		Damage Absorption: +40, Maximum MP: +50, Single Equip, Last Available: "2014-05"
-7529	adequate snack-sized loaf of alien bread	2	good	Last Available: "2014-05"
+7529	snack-sized adequate loaf of alien bread	2	good	Last Available: "2014-05"
 7530	snack-sized rotten cyan grilled cheese sandwich	2	crappy	Last Available: "2014-05"
 7531	dried alien protein powder	1	awesome	Last Available: "2014-05"
 7532	delicious huge rocket fuel	3	awesome	Last Available: "2014-05"
@@ -7424,13 +7424,13 @@
 7535	aged watered-down green stealth bomber	2	awesome	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
-7538	cyan squat ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
+7538	squat cyan ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
 7539	supercharged space beast fur hat	0		Maximum MP Percent: +30, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7540	scandalous space beast fur pants	0		Sleaze Damage: +5, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	inspector's space beast fur whip	0		Item Drop: +15, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	tumbling clever therapeutic space heater	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
-7544	red narrow upside-down space bar	0		Last Available: "2014-05"
+7544	upside-down narrow red space bar	0		Last Available: "2014-05"
 7545	high-proof hand-crafted space port	7	EPIC	Last Available: "2014-05"
 7546	cyan lightning-fast censurious space needle	0		Sleaze Resistance: +3, Initiative: +40, Last Available: "2014-05"
 7547	flattened vacuum-sealed tumbling buffed alien drugs	0		Effect: "Adrenaline Rush", Effect Duration: 37, Last Available: "2014-05"
@@ -7460,7 +7460,7 @@
 7571	yellow mirror fireproof experienced silent pea shooter	0		Experience: +2, Hot Resistance: +3
 7572	snack-sized spoiled D roll	2	crappy	
 7573	supercharged weightlifter's kiwi beak	0		Muscle: +15, Maximum MP Percent: +30
-7574	hand-crafted distilled upside-down New Zealand iced tea	5	EPIC	
+7574	distilled hand-crafted upside-down New Zealand iced tea	5	EPIC	
 7575	educational Rosewater's droll monocle	0		Mysticality Percent: +30, Experience: +1, Single Equip
 7576	enhanced future drug: Muscularactum	0		Effect: "Halloweeny", Effect Duration: 23
 7577	wet future drug: Smartinex	0		Effect: "Rave Concentration", Effect Duration: 12
@@ -7469,7 +7469,7 @@
 7580	dehydrated jittery liquid shifting time weirdness	1		Effect: "Frigid Weapon", Effect Duration: 30
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	normal rack of dinosaur ribs	3	good	
-7583	smooth lime green pulsating scotch on the rocks	3	awesome	
+7583	smooth pulsating lime green scotch on the rocks	3	awesome	
 7584	green rock-hard yabba dabba doo rag of vim and vigor	0		Damage Reduction: 5, Maximum HP Percent: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	manspreader's fortified wooly loincloth	0		Damage Absorption: +60, Monster Level: +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	narrow helix fossil	0		
@@ -7479,10 +7479,10 @@
 7590	lousy cup of &quot;tea&quot;	3	decent	Last Available: "2014-07"
 7591	aged thermos of &quot;whiskey&quot;	3	awesome	Last Available: "2014-07"
 7592	tolerable Lucky Lindy	3	good	Last Available: "2014-07"
-7593	aged fortified Bee's Knees	5	awesome	Last Available: "2014-07"
+7593	fortified aged Bee's Knees	5	awesome	Last Available: "2014-07"
 7594	hand-crafted Sockdollager	3	EPIC	Last Available: "2014-07"
 7595	aged triple-distilled Ish Kabibble	6	awesome	Last Available: "2014-07"
-7596	weak bad shaking Hot Socks	2	decent	Last Available: "2014-07"
+7596	bad weak shaking Hot Socks	2	decent	Last Available: "2014-07"
 7597	lousy Phonus Balonus	3	decent	Last Available: "2014-07"
 7598	special lousy pulsating Flivver	3	decent	Effect: "Sparkling Consciousness", Effect Duration: 25, Last Available: "2014-07"
 7599	watered-down lousy squat Sloppy Jalopy	2	decent	Last Available: "2014-07"
@@ -7490,19 +7490,19 @@
 7601	denatured liquefied temporary yak tattoo	0		Effect: "Pwnd", Effect Duration: 66
 7602	irradiated oxidized polymerized Fitspiration&trade; poster	0		Effect: "Minerva's Zen", Effect Duration: 19
 7603	unsweetened ghostly neckbeard	0		Effect: "The Dinsey Spirit", Effect Duration: 55
-7604	enhanced irradiated ghostly blurry artisanal hand-squeezed wheatgrass juice	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
+7604	enhanced irradiated blurry ghostly artisanal hand-squeezed wheatgrass juice	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
 7605	activated chilled punk patch	0		Effect: "Flaming Weapon", Effect Duration: 34
 7606	anodized magnetized steampunk potion	0		Effect: "Dreadful Sheen", Effect Duration: 27
 7607	wet boiled corrupted vial of swamp vapors	0		Effect: "Spooky Weapon", Effect Duration: 48
 7608	frozen turtle mud	0		Effect: "Litterboxing", Effect Duration: 24
-7609	quantum huge skewed Redeye&trade; Eyedrops	0		Effect: "Fastbreaker", Effect Duration: 12
+7609	quantum skewed huge Redeye&trade; Eyedrops	0		Effect: "Fastbreaker", Effect Duration: 12
 7610	aerosolized cold-filtered jittery Dweebisol&trade; inhaler	0		Effect: "Creepin' Up on You", Effect Duration: 32
 7611	polymerized Lewd Lemmy Hair Oil	0		Effect: "Boletus Swoletus", Effect Duration: 63
 7612	dry tomato soup poster	0		Effect: "Pretending to Pretend", Effect Duration: 67
 7613	anodized bubblin' chemistry solution	0		Effect: "Leash of Linguini", Effect Duration: 37
 7614	tarnished tarnished teal voodoo glowskull	0		Effect: "Ghostly Shell", Effect Duration: 57
 7615	flattened boiled pygmy adder oil	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 36
-7616	boiled oxidized ghostly narrow pygmy witchhazel	0		Effect: "Sweet and Green", Effect Duration: 50
+7616	boiled oxidized narrow ghostly pygmy witchhazel	0		Effect: "Sweet and Green", Effect Duration: 50
 7617	polarized short deposition	0		Effect: "Fortunate Resolve", Effect Duration: 33
 7618	anodized straw pole	0		Effect: "Whole Latte Love", Effect Duration: 18
 7619	ionized olive copperhead potion	0		Effect: "Slimy Flavor", Effect Duration: 32
@@ -7516,12 +7516,12 @@
 7627	concentrated plastic Jefferson wings	0		Effect: "Cold Throat", Effect Duration: 19
 7628	unsweetened bouncing dancing fan	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 39
 7629	denatured page of the Necrohobocon	0		Effect: "Raging Animal", Effect Duration: 66
-7630	energized blurry narrow skewed magic powder	0		Effect: "Spiky Hair", Effect Duration: 23
+7630	energized narrow blurry skewed magic powder	0		Effect: "Spiky Hair", Effect Duration: 23
 7631	moist nitrogenated friar's tonsure	0		Effect: "Spirit of Alph", Effect Duration: 64
 7632	adjusted government-issue identification badge	0		Effect: "Blood-Rich", Effect Duration: 69
 7633	altered alien hologram projector	0		Effect: "Riboflavin'", Effect Duration: 29
 7634	tarnished pressed maroon irradiated turtle	0		Effect: "Antibiotic Saucesphere", Effect Duration: 46
-7635	liquefied cold-filtered fuchsia jittery cigar box turtle	0		Effect: "Hairy Palms", Effect Duration: 34
+7635	liquefied cold-filtered jittery fuchsia cigar box turtle	0		Effect: "Hairy Palms", Effect Duration: 34
 7636	asbestos-lined strapping shellacked shell	0		Muscle: +5, Hot Resistance: +5, Class: "Turtle Tamer"
 7637	coward's pillow shell	0		Monster Level: -20, Class: "Turtle Tamer"
 7638	whatsit-covered turtle shell of Leguizamo	0		Monster Level: +20, Class: "Turtle Tamer"
@@ -7529,14 +7529,14 @@
 7640	ghostly arcane researcher's Socratic turtle shell of the ox	0		Muscle: +20, Experience (Mysticality): +1, Experience Percent (Mysticality): +10, Class: "Turtle Tamer"
 7641	narrow shocked shell	0		Class: "Turtle Tamer"
 7642	ingot turtle	0		
-7643	blinking upside-down duty umbrella	0		
+7643	upside-down blinking duty umbrella	0		
 7644	pool skimmer	0		
 7645	life preserver	0		
 7646	lightning milk	0		
 7647	spinning aquaconda brain	0		
 7648	bouncing thunder thigh	0		
 7649	cold-filtered unsweetened gourmet gourami oil	0		Effect: "No Worries", Effect Duration: 18
-7650	ionized aerosolized twirling fuchsia catfish whiskers	0		Effect: "Greedy Resolve", Effect Duration: 21
+7650	ionized aerosolized fuchsia twirling catfish whiskers	0		Effect: "Greedy Resolve", Effect Duration: 21
 7651	freshwater fishbone	0		
 7652	wobbly fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7547,7 +7547,7 @@
 7658	fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	upside-down arcane researcher's neoprene skullcap	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	pickled blue goblin water	0		Effect: "On the Trolley", Effect Duration: 45
-7661	mirror twirling dumb mud	0		
+7661	twirling mirror dumb mud	0		
 7662	normal Sogg-Os	4	good	
 7663	greasy stiffened Lord Soggyraven's Slippers of chilblains	0		Damage Reduction: 1, Cold Damage: +25, Sleaze Spell Damage: +10, Single Equip
 7664	liquefied polarized yellow mirror Ancient Protector Soda	0		Effect: "Elemental Mastery", Effect Duration: 27
@@ -7598,10 +7598,10 @@
 7709	family-friendly lard-coated ruddy banded Thor's Pliers	0		Damage Absorption: +100, Maximum HP Percent: +40, Sleaze Spell Damage: +25, Sleaze Resistance: +1, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	non-galvanized wobbly candy UFOs	0		Effect: "Cancer Rising", Effect Duration: 22
 7711	jittery zippy dangerous water wings for babies	0		Weapon Damage: +10, Initiative: +20
-7712	spinning fuchsia beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	fuchsia spinning beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	normal Strix stix	3	good	
 7714	blurry clever vampire pellet of wisdom of the early riser	0		Mysticality: +15, Maximum MP: +20, Adventures: +7
-7715	hand-crafted fancy non-aged vinegar	3	EPIC	Effect: "Hoity Toity", Effect Duration: 25
+7715	fancy hand-crafted non-aged vinegar	3	EPIC	Effect: "Hoity Toity", Effect Duration: 25
 7716	teal unsanitized scalpel of terror	0		Spooky Spell Damage: +10
 7717	mirror Sinatra's gladiator tunica	0		Experience (Moxie): +5
 7718	gray Herculean Roman sadnals	0		Experience (Muscle): +1, Single Equip
@@ -7612,7 +7612,7 @@
 7723	Chroner cross	0		
 7724	shaking savvy pteruges	0		Mysticality Percent: +20, Familiar Effect: "1xFairy, atk, cap 25"
 7725	tarnished Bruno's blessing of Mars	0		Effect: "Liquidy Smoky", Effect Duration: 43
-7726	triple-cold-filtered diffused mirror shaking Dennis's blessing of Minerva	0		Effect: "Always In Motion", Effect Duration: 46
+7726	triple-cold-filtered diffused shaking mirror Dennis's blessing of Minerva	0		Effect: "Always In Motion", Effect Duration: 46
 7727	colloidal flattened Burt's blessing of Bacchus	0		Effect: "Uncaged Power", Effect Duration: 24
 7728	warmed Freddie's blessing of Mercury	0		Effect: "Man's Worst Enemy", Effect Duration: 54
 7729	Chroner trigger	0		
@@ -7642,7 +7642,7 @@
 7753	Sherlock's smelly Xiblaxian stealth cowl	0		Stench Spell Damage: +10, Item Drop: +25, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	upside-down double-paned friendly Xiblaxian stealth trousers	0		Familiar Weight: +3, Cold Resistance: +5, Last Available: "2014-09"
 7755	electrified Xiblaxian stealth vest of the overflowing toilet	0		Stench Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-09"
-7756	decent wobbly lime green Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
+7756	decent lime green wobbly Xiblaxian ultraburrito	3	good	Last Available: "2014-09"
 7757	acceptable Xiblaxian space-whiskey	4	good	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	colloidal non-chilled shaking They liver	0		Effect: "Well Owl Be!", Effect Duration: 32, Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	gray reassuring dog trainer's rock-hard Personal Ventilation Unit	0		Damage Reduction: 5, Experience (familiar): +1, Spooky Resistance: +1, Single Equip, Last Available: "2014-10"
 7771	super-boiled narrow teal the most dangerous bait	0		Effect: "Deadly Flashing Blade", Effect Duration: 27, Last Available: "2014-10"
-7772	enchanted gigantic rotten narrow &quot;meat&quot; stick	9	crappy	Effect: "Rampage!", Effect Duration: 25, Last Available: "2014-10"
+7772	rotten gigantic enchanted narrow &quot;meat&quot; stick	9	crappy	Effect: "Rampage!", Effect Duration: 25, Last Available: "2014-10"
 7773	boiled teal transdermal smoke patch	1	awesome	Last Available: "2014-10"
 7774	ghostly specialty ammo bandolier	0		Last Available: "2014-10"
 7775	energetic stiffened cool pair of plants	0		Moxie: +5, Damage Reduction: 1, Maximum MP Percent: +20, Last Available: "2014-10"
@@ -7668,13 +7668,13 @@
 7779	super-corrupted experimental serum G-9	0		Effect: "Waxing", Effect Duration: 24, Last Available: "2014-10"
 7780	toasty heavy-duty clipboard of temperance of the cheetah	0		Hot Damage: +5, Sleaze Resistance: +5, Initiative: +60, Damage Reduction: 8, Last Available: "2014-10"
 7781	greedy shellacked wicked Socratic battery-powered drill	0		Experience (Mysticality): +1, Spell Damage: +5, Damage Reduction: 7, Meat Drop: +20, Last Available: "2014-10"
-7782	bland snack-sized special limp broccoli	2	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 35, Last Available: "2014-10"
+7782	snack-sized bland special limp broccoli	2	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 35, Last Available: "2014-10"
 7783	sizzling Van der Graaf shellacked hat	0		Damage Reduction: 7, Hot Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	double-adjusted blue bouncing monkey barf	0		Effect: "Memory of Speed", Effect Duration: 38, Last Available: "2014-10"
 7785	wet anodized candy	0		Effect: "Shredding, Sweating", Effect Duration: 67, Last Available: "2014-10"
 7786	spinning banded padded jangly bracelet of dire peril	0		Weapon Damage: +20, Damage Absorption: 120, Last Available: "2014-10"
 7787	shaking gray stanky cuddly teddy bear	0		Stench Spell Damage: +25, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
-7788	skewed huge ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7788	huge skewed ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	auspicious first-aid pouch of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +10, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	alkaline extra-quantum mirror airborne mutagen	0		Effect: "Cringle's Curative Carol", Effect Duration: 51, Last Available: "2014-10"
@@ -7685,12 +7685,12 @@
 7796	stale snack-sized tumbling warm war shawarma	2	decent	Last Available: "2014-10"
 7797	tiny tasty karma shawarma	1	awesome	Last Available: "2014-10"
 7798	bad pulsating Jungle Juice	3	decent	Last Available: "2014-10"
-7799	fortified mediocre Amnesiac Ale	5	decent	Last Available: "2014-10"
+7799	mediocre fortified Amnesiac Ale	5	decent	Last Available: "2014-10"
 7800	lousy Highest Bitter	3	decent	Last Available: "2014-10"
 7801	spinning stanky wholesome mercenary pistol	0		Maximum HP Percent: +10, Stench Spell Damage: +25, Last Available: "2014-10"
 7802	shaking dog trainer's sinister mercenary rifle	0		Spell Damage: +10, Experience (familiar): +1, Last Available: "2014-10"
 7803	tumbling Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
-7804	pulsating shaking Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
+7804	shaking pulsating Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	jittery pulsating Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	maroon TI-9000 calculator	0		
@@ -7703,7 +7703,7 @@
 7814	drinkable weak twirling bottle of drinkin' gas	2	good	
 7815	handful of napalm	0		
 7816	dove DNA	0		
-7817	teal narrow gelatinous meat mass	0		
+7817	narrow teal gelatinous meat mass	0		
 7818	spinning 99.44% pure math	0		
 7819	simple AI	0		
 7820	corrupted bird DNA	0		
@@ -7732,11 +7732,11 @@
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	improved corrupted electrified twirling perl necklace	0		Effect: "Faboooo", Effect Duration: 27, Last Available: "2014-12"
-7846	improved irradiated green jittery bouncing Fudge Fiber Armor Plating	0		Effect: "Quadrilled", Effect Duration: 25, Last Available: "2014-12"
+7846	improved irradiated bouncing jittery green Fudge Fiber Armor Plating	0		Effect: "Quadrilled", Effect Duration: 25, Last Available: "2014-12"
 7847	vacuum-sealed blurry ruby on canes	0		Effect: "Inner Dog", Effect Duration: 67, Last Available: "2014-12"
 7848	bland petit fortran	4	decent	Last Available: "2014-12"
-7849	half-sized delicious java cookie	2	awesome	Last Available: "2014-12"
-7850	gigantic moldy cookie cookie	7	crappy	Last Available: "2014-12"
+7849	delicious half-sized java cookie	2	awesome	Last Available: "2014-12"
+7850	moldy gigantic cookie cookie	7	crappy	Last Available: "2014-12"
 7851	baleful plastic exo-suited miner	0		Spell Damage: +25, Last Available: "2014-12"
 7852	plastic semi-autonomous drill unit of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2014-12"
 7853	quilted plastic ambulatory robo-minecart	0		Damage Absorption: +40, Last Available: "2014-12"
@@ -7802,17 +7802,17 @@
 7913	maroon greasy supercool thinker's Size XI Wizard's Robe	0		Mysticality: +10, Moxie Percent: +20, Sleaze Spell Damage: +10, Last Available: "2014-09"
 7914	double-aerosolized polymerized Bit O' Quail Spleen	0		Effect: "Bats in the Belfry", Effect Duration: 67
 7915	diffused narrow Take Eleven Bar	0		Effect: "Macho, Macho Dog", Effect Duration: 41
-7916	wobbly cyan pulsating mimeplasm	0		
+7916	cyan wobbly pulsating mimeplasm	0		
 7917	vacuum-sealed green BOOterfinger	0		Effect: "Sweet Incentive", Effect Duration: 21
 7918	Vulcanized twirling Moonds	0		Effect: "Fury of the Bells", Effect Duration: 21
 7919	anodized Big Punk	0		Effect: "Turkey-Ambitious", Effect Duration: 37
-7920	tumbling ghostly blinking fist turkey outline	0		Free Pull, Last Available: "2014-11"
+7920	tumbling blinking ghostly fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	ghostly turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	bad red Friendly Turkey	4	decent	Last Available: "2014-11"
 7923	bad twirling Agitated Turkey	3	decent	Last Available: "2014-11"
 7924	drinkable purple Ambitious Turkey	3	good	Last Available: "2014-11"
 7925	flavorless spinning neutron lollipop	4	decent	Last Available: "2014-12"
-7926	spirit-forward aged gamma nog	5	awesome	Last Available: "2014-12"
+7926	aged spirit-forward gamma nog	5	awesome	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	bouncing blurry Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
@@ -7828,7 +7828,7 @@
 7946	frosty chilly Socratic outlaw bandana	0		Experience (Mysticality): +1, Cold Damage: +5, Cold Spell Damage: +10
 7947	drinkable bouncing whiskey in a broken glass	4	good	
 7948	acceptable jittery shot of mescal	4	good	
-7949	drinkable triple-distilled glass of herbal tequila	10	good	
+7949	triple-distilled drinkable glass of herbal tequila	10	good	
 7950	minin' dynamite	0		
 7951	hardy fortified plaid cowboy hat	0		Damage Absorption: +60, Maximum HP: +50, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7880,7 +7880,7 @@
 7998	diluted huge powder	1		Last Available: "2015-12"
 7999	anodized magnetized lime green choco-Crimbot	0		Effect: "Dilated Pupils", Effect Duration: 12, Last Available: "2014-12"
 8000	liquefied huge smart watch	0		Effect: "Compensatory Cruelness", Effect Duration: 21, Last Available: "2014-12"
-8001	improved pulsating teal bouncing augmented-reality shades	0		Effect: "Hot Jellied", Effect Duration: 64, Last Available: "2014-12"
+8001	improved bouncing teal pulsating augmented-reality shades	0		Effect: "Hot Jellied", Effect Duration: 64, Last Available: "2014-12"
 8002	jittery curative toy Crimbot mega face	0		HP Regen Min: 3, HP Regen Max: 5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
 8003	huge toy Crimbot power glove of the ox	0		Muscle: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	squat stanky toy Crimbot super fist	0		Stench Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
@@ -8017,7 +8017,7 @@
 8143	Annie Oakley's obsidian nutcracker	0		Critical Hit Percent: +20
 8144	talisman of Seshat	0		Free Pull
 8145	lard-coated stylish glass eye	0		Moxie: +25, Sleaze Spell Damage: +25, Single Equip
-8146	alkaline bouncing green invisible potion	0		Effect: "Towering Strength", Effect Duration: 37
+8146	alkaline green bouncing invisible potion	0		Effect: "Towering Strength", Effect Duration: 37
 8147	wobbly time shuriken	0		
 8148	perfumed smooth wizardly ninjammies	0		Mysticality: +25, Moxie: +15, Stench Resistance: +5, Familiar Effect: "atk, 0.5xPotato, cap 25"
 8149	liquefied dry Glo-Pop	0		Effect: "Using Protection", Effect Duration: 66
@@ -8042,12 +8042,12 @@
 8168	blue glob of icing	0		
 8169	diffused ginger snaps	0		Effect: "Omphalotus Omnipresence", Effect Duration: 38
 8170	alkaline mostly-broken sunglasses	0		Effect: "Savage Beast Inside", Effect Duration: 52
-8171	practically non-alcoholic aged fancy pulsating unflavored wine cooler	1	awesome	Effect: "Oiled Skin", Effect Duration: 30
+8171	aged fancy practically non-alcoholic pulsating unflavored wine cooler	1	awesome	Effect: "Oiled Skin", Effect Duration: 30
 8172	carton of snake milk	1	EPIC	
 8173	jittery chilly sewer snake	0		Cold Damage: +5
-8174	small normal pigeon egg	2	good	
+8174	normal small pigeon egg	2	good	
 8175	spinning jaunty feather of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50
-8176	lousy practically non-alcoholic premium malt liquor	1	decent	
+8176	practically non-alcoholic lousy premium malt liquor	1	decent	
 8177	flame-retardant padded brown paper pants	0		Damage Absorption: +20, Hot Resistance: +1
 8178	cyan rosewater-soaked wicked brown paper bag mask	0		Spell Damage: +5, Stench Resistance: +3
 8179	lion tamer's ring of telling skeletons what to do	0		Experience (familiar): +2, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8060,16 +8060,16 @@
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	spinning map to a hidden booze cache	0		
 8188	hand-crafted Cherrytastrophe wine cooler	3	EPIC	
-8189	perfectly mixed weak Radberry Rip wine cooler	2	EPIC	
+8189	weak perfectly mixed Radberry Rip wine cooler	2	EPIC	
 8190	distilled acceptable Orangemageddon wine cooler	5	good	
 8191	acceptable triple-distilled bouncing Breakfast Blast wine cooler	9	good	
-8192	drinkable yellow pulsating Citrus Crush wine cooler	3	good	
+8192	drinkable pulsating yellow Citrus Crush wine cooler	3	good	
 8193	moldy plain bagel	4	crappy	
 8194	stale glob of cream cheese	4	decent	
 8195	bland olive loaf of soda bread	3	decent	
 8196	adequate miniature acceptable bagel	2	good	
-8197	jumbo tasty enchanted standard-issue cupcake	5	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
-8198	bite-sized tasty ultra-deluxe cupcake	1	awesome	
+8197	enchanted jumbo tasty standard-issue cupcake	5	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
+8198	tasty bite-sized ultra-deluxe cupcake	1	awesome	
 8199	hypnotic breadcrumbs	0		
 8200	miniature decent popular tart	2	good	
 8201	green no-handed pie	0		
@@ -8078,7 +8078,7 @@
 8204	one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
 8205	teal FunFunds&trade;	0		Last Available: "2015-04"
 8206	hardened expensive camera of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3, Single Equip, Last Available: "2015-04"
-8207	blue blurry sunglasses	0		Single Equip, Last Available: "2015-04"
+8207	blurry blue sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	deionized bouncing How to Avoid Scams	0		Effect: "Took Eleven", Effect Duration: 19, Last Available: "2015-04"
 8209	squat filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
 8210	bag of gross foreign snacks	0		Last Available: "2015-04"
@@ -8090,7 +8090,7 @@
 8216	altered nitrogenated huge mirror beard incense	0		Effect: "Sparkling Consciousness", Effect Duration: 69, Last Available: "2015-04"
 8217	tumbling skewed crafty energetic perfume-soaked bandana	0		Maximum MP Percent: +20, Maximum MP: +10, Single Equip, Last Available: "2015-04"
 8218	huge toxic globule	0		Last Available: "2015-04"
-8219	bland miniature enchanted toxo	2	decent	Effect: "Eye of the Lihc", Effect Duration: 50, Last Available: "2015-04"
+8219	miniature enchanted bland toxo	2	decent	Effect: "Eye of the Lihc", Effect Duration: 50, Last Available: "2015-04"
 8220	lousy triple-distilled Lemonade-235	8	decent	Last Available: "2015-04"
 8221	energetic isotophat of the sweet-tooth	0		Maximum MP Percent: +20, Candy Drop: +100, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	huge steel-toed experienced Three Mile Island shorts	0		Experience: +2, Damage Reduction: 9, Last Available: "2015-04"
@@ -8101,7 +8101,7 @@
 8227	double-paned backwoods banjo of dire peril of courage	0		Weapon Damage: +20, Cold Resistance: +5, Spooky Resistance: +3, Last Available: "2015-04"
 8228	blurry grody jug	0		Last Available: "2015-04"
 8229	Sherlock's razor-sharp ratskin pajama pants of the scaredy-cat	0		Weapon Damage Percent: +25, Monster Level: -15, Item Drop: +25, Last Available: "2015-04"
-8230	deionized polymerized blurry shaking turtle voicebox	0		Effect: "Here's Mud in Your Eye", Effect Duration: 58, Last Available: "2015-04"
+8230	deionized polymerized shaking blurry turtle voicebox	0		Effect: "Here's Mud in Your Eye", Effect Duration: 58, Last Available: "2015-04"
 8231	fake washboard of the cougar of the pedagogue of the scaredy-cat	0		Moxie: +20, Experience: +3, Monster Level: -15, Damage Reduction: 13, Last Available: "2015-04"
 8232	fuchsia miser's Dinsey's oculus of the wise owl	0		Mysticality: +20, Meat Drop: +10, Single Equip, Last Available: "2015-04"
 8233	resourceful Dinsey's radar dish	0		Maximum MP: +50, Damage Reduction: 15, Last Available: "2015-04"
@@ -8112,7 +8112,7 @@
 8238	brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
 8240	gray keycard &beta;	0		Last Available: "2015-04"
-8241	teal squat keycard &gamma;	0		Last Available: "2015-04"
+8241	squat teal keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
 8243	blinking complimentary Dinsey refreshments	0		Last Available: "2015-04"
 8244	thinker's lube-shoes	0		Mysticality: +10, Last Available: "2015-04"
@@ -8136,7 +8136,7 @@
 8262	Mayodiol	0		Last Available: "2015-05"
 8263	jittery Mayostat	0		Last Available: "2015-05"
 8264	squat Mayozapine	0		Last Available: "2015-05"
-8265	mirror wobbly Mayoflex	0		Last Available: "2015-05"
+8265	wobbly mirror Mayoflex	0		Last Available: "2015-05"
 8266	ruddy occult miracle whip of the blizzard of the businessman	0		Spell Damage Percent: +25, Maximum HP Percent: +40, Cold Spell Damage: +25, Meat Drop: +50, Lasts Until Rollover, Last Available: "2015-05"
 8267	horrifying sphygmayomanometer	0		Spooky Damage: +25, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
@@ -8172,7 +8172,7 @@
 8298	pixel	0		Last Available: "2015-06"
 8299	pixel coin	0		Last Available: "2015-06"
 8300	oxidized oxidized huge power pill	0		Effect: "Savage Beast Inside", Effect Duration: 66, Last Available: "2015-06"
-8301	concentrated bouncing twirling pixel star	0		Effect: "Hagg-ard", Effect Duration: 56, Last Available: "2015-06"
+8301	concentrated twirling bouncing pixel star	0		Effect: "Hagg-ard", Effect Duration: 56, Last Available: "2015-06"
 8302	stale squat pixel banana	3	decent	Last Available: "2015-06"
 8303	acceptable spinning pixel beer	3	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
@@ -8186,20 +8186,20 @@
 8312	super-Vulcanized quadruple-boiled pulsating hustler shades	0		Effect: "Papowerful", Effect Duration: 36
 8313	tarnished jerky stick	0		Effect: "Adapt to Change Eventually", Effect Duration: 46
 8314	magnetized electrified costume rental shop	0		Effect: "Joy", Effect Duration: 30
-8315	frozen teal blinking squat muscle oil	0		Effect: "Guts Feeling", Effect Duration: 14
+8315	frozen blinking teal squat muscle oil	0		Effect: "Guts Feeling", Effect Duration: 14
 8316	electrified blue bottle of Red-Out	0		Effect: "Just Aged Enough", Effect Duration: 25
 8317	aerosolized moist pickpocket protector	0		Effect: "Human-Plant Hybrid", Effect Duration: 25
 8318	magnetized flattened narrow sinister-looking cat	0		Effect: "Improved Candy Vision", Effect Duration: 69
 8319	deionized fuchsia jazzy cigarette holder	0		Effect: "Pisces in the Skyces", Effect Duration: 15
-8320	corrupted warmed blinking spinning one glove	0		Effect: "Larger", Effect Duration: 64
+8320	corrupted warmed spinning blinking one glove	0		Effect: "Larger", Effect Duration: 64
 8321	galvanized warmed huge glove	0		Effect: "Hot Buttoned", Effect Duration: 21
 8322	cold-filtered handful of fire	0		Effect: "Celestial Sheen", Effect Duration: 47
-8323	dry ionized unsweetened cyan wobbly Cracklin' Oat Bran	0		Effect: "Emotion Sickness", Effect Duration: 57
+8323	dry ionized unsweetened wobbly cyan Cracklin' Oat Bran	0		Effect: "Emotion Sickness", Effect Duration: 57
 8324	adjusted bouncing disposable lighter	0		Effect: "Healthy Blue Glow", Effect Duration: 44
 8325	oxidized chilled aerosolized coal contact lenses	0		Effect: "Frost Tea", Effect Duration: 55
 8326	deionized modified conjured ice cream	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 53
 8327	aerosolized denatured pulsating Iceberglar scarf	0		Effect: "Thick, Sick", Effect Duration: 33
-8328	frozen adjusted ghostly twirling icy hairspray	0		Effect: "Chorale of Companionship", Effect Duration: 46
+8328	frozen adjusted twirling ghostly icy hairspray	0		Effect: "Chorale of Companionship", Effect Duration: 46
 8329	electrified smellbook	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 13
 8330	polarized assassin's cheese knife	0		Effect: "[800]Chocolate Reign", Effect Duration: 26
 8331	altered shaking filthy armor	0		Effect: "Cotton Mouthed", Effect Duration: 25
@@ -8222,7 +8222,7 @@
 8348	concentrated blue filthy monkey head	0		Effect: "Sleazy Hands", Effect Duration: 41
 8349	quadruple-concentrated dry hand of cards	0		Effect: "Shortened", Effect Duration: 22
 8350	adjusted anodized shaking damp bar rag	0		Effect: "Icy Demeanor", Effect Duration: 40
-8351	enhanced pressed squat blue lump of goofball ore	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 17
+8351	enhanced pressed blue squat lump of goofball ore	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 17
 8352	oxidized polymerized wobbly skeleton beans	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 17
 8353	improved grimy lab coat	0		Effect: "Berry Defensive", Effect Duration: 32
 8354	dry gray squat nursery rhyme	0		Effect: "Gunky Dory", Effect Duration: 69
@@ -8235,7 +8235,7 @@
 8361	corrupted child-sized dracula cloak	0		Effect: "Educated (Sorta)", Effect Duration: 37
 8362	diffused devil-summoning hat	0		Effect: "Booing Radly", Effect Duration: 52
 8363	altered frozen deionized shopkeeper beard	0		Effect: "Preternatural Greed", Effect Duration: 46
-8364	deionized twirling skewed alien autoautopsy kit	0		Effect: "Mer-kindliness", Effect Duration: 62
+8364	deionized skewed twirling alien autoautopsy kit	0		Effect: "Mer-kindliness", Effect Duration: 62
 8365	flattened novelty fruit hat	0		Effect: "Stimulated Body", Effect Duration: 51
 8366	irradiated alkaline invisibility cream	0		Effect: "White Knuckles", Effect Duration: 61
 8367	denatured activated handful of stubble	0		Effect: "Comic Violence", Effect Duration: 64
@@ -8252,7 +8252,7 @@
 8378	lousy bouncing pixel daiquiri	3	decent	Last Available: "2015-06"
 8379	enhanced wobbly power pill	0		Effect: "Melancholy Burden", Effect Duration: 49, Last Available: "2015-06"
 8380	dry dry pixel potion	0		Effect: "Adorable Lookout", Effect Duration: 12, Last Available: "2015-06"
-8381	twirling blinking Pack of Every Card	0		Free Pull, Last Available: "2015-07"
+8381	blinking twirling Pack of Every Card	0		Free Pull, Last Available: "2015-07"
 8382	Deck of Every Card	0		Last Available: "2015-07"
 8383	popular part	0		
 8384	bubblegum heart	0		Last Available: "2015-07"
@@ -8264,7 +8264,7 @@
 8390	teal mana	0		Last Available: "2015-07"
 8391	mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
-8393	twirling shaking hermit factoid	0		Last Available: "2015-07"
+8393	shaking twirling hermit factoid	0		Last Available: "2015-07"
 8394	The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	lime green The Emperor's new hat of the dark arts	0		Spell Damage Percent: +100, Last Available: "2015-07"
 8396	blue asbestos-lined The Emperor's new shirt	0		Hot Resistance: +5, Last Available: "2015-07"
@@ -8284,13 +8284,13 @@
 8410	flavorless enchanted teal agnolotti arboli	3	decent	Effect: "Jammin'", Effect Duration: 30
 8411	bland spaghetti with ghost balls	4	decent	
 8412	stale upside-down succulent marrow	3	decent	
-8413	small delicious salacious crumbs	2	awesome	
-8414	special decent upside-down huge fusilli marrownarrow	3	good	Effect: "Flambé-a-thon", Effect Duration: 45
+8413	delicious small salacious crumbs	2	awesome	
+8414	special decent huge upside-down fusilli marrownarrow	3	good	Effect: "Flambé-a-thon", Effect Duration: 45
 8415	bite-sized decent suggestive strozzapreti	1	good	
 8416	twirling Mountain Stream gastrique	0		
 8417	decent bite-sized Mt. McLargeHuge oyster	1	good	
 8418	oyster sauce	0		
-8419	bland enchanted big blurry linguini immondizia bianco	5	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 30
+8419	enchanted big bland blurry linguini immondizia bianco	5	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 30
 8420	diet stale shells a la shellfish	1	decent	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8331,10 +8331,10 @@
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	huge hardy smartaleck's high-temperature mining mask	0		Moxie Percent: +30, Maximum HP: +50, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	shaking wobbly careful healthy fireproof megaphone	0		Maximum HP Percent: +20, Monster Level: -10, Last Available: "2015-08"
-8460	small normal mineapple	2	good	Last Available: "2015-08"
+8460	normal small mineapple	2	good	Last Available: "2015-08"
 8461	acceptable extra-dry Gold Velvet&trade; whiskey	5	good	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
-8463	decent small smelted roe	2	good	Last Available: "2015-08"
+8463	small decent smelted roe	2	good	Last Available: "2015-08"
 8464	tolerable lavawater	3	good	Last Available: "2015-08"
 8465	concentrated nitrogenated basaltamander tongue	0		Effect: "Analog Drunk", Effect Duration: 56, Last Available: "2015-08"
 8466	pulsating supercharged Sinatra's lavalarva of extreme caution	0		Experience (Moxie): +5, Maximum MP Percent: +30, Monster Level: -25, Last Available: "2015-08"
@@ -8360,7 +8360,7 @@
 8486	one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
-8489	pulsating twirling New Age hurting crystal	0		Last Available: "2015-08"
+8489	twirling pulsating New Age hurting crystal	0		Last Available: "2015-08"
 8490	nasty smooth velvet pants	0		Stench Damage: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	lime green smooth velvet shirt of the blizzard	0		Cold Spell Damage: +25, Last Available: "2015-08"
 8492	rock-hard smooth velvet hat	0		Damage Reduction: 5, Last Available: "2015-08"
@@ -8368,7 +8368,7 @@
 8494	smooth velvet socks of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8495	smooth velvet hanky of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
 8496	narrow miser's The One Mood Ring of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +10, Single Equip, Last Available: "2015-08"
-8497	spinning tumbling yellow Mr. Choch's bone	0		Last Available: "2015-08"
+8497	yellow spinning tumbling Mr. Choch's bone	0		Last Available: "2015-08"
 8498	Mr. Cheeng's 'stache	0		Last Available: "2015-08"
 8499	mirror Saturday Night thermometer	0		Last Available: "2015-08"
 8500	the tongue of Smimmons	0		Last Available: "2015-08"
@@ -8401,12 +8401,12 @@
 8527	bouncing Devil's Elbow Hot Sauce	0		
 8528	bouncing Special&trade; Sauce	0		
 8529	spoiled devil hair pasta	3	crappy	
-8530	snack-sized stale spagecialetti	2	decent	
+8530	stale snack-sized spagecialetti	2	decent	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	low-calorie rotten libertagliatelle	1	crappy	
-8535	snack-sized adequate turkish mostaccioli	2	good	
+8535	adequate snack-sized turkish mostaccioli	2	good	
 8536	adequate linguini of the sea	4	good	
 8537	vacuum-sealed shaking upside-down Hersey&trade; SMOOCH	0		Effect: "Creepin' Up on You", Effect Duration: 43
 8539	Alexy sauce	0		
@@ -8423,7 +8423,7 @@
 8550	half-sized normal weird gazelle steak	2	good	
 8551	flavorless sausage without a cause	3	decent	
 8552	magnetized maroon face paint	0		Effect: "Ooh, Sweet!", Effect Duration: 68
-8553	practically non-alcoholic bad emergency margarita	1	decent	
+8553	bad practically non-alcoholic emergency margarita	1	decent	
 8554	weak acceptable vintage smart drink	2	good	
 8555	a ten-percent bonus	0		
 8556	spinning Thwaitgold termite statuette	0		
@@ -8451,7 +8451,7 @@
 8578	drinkable bottle of Amontillado	4	good	Last Available: "2015-09"
 8579	tolerable barrel-aged martini	3	good	Last Available: "2015-09"
 8580	immense stale barrel pickle	9	decent	Last Available: "2015-09"
-8581	decent super-sized barrel cracker	5	good	Last Available: "2015-09"
+8581	super-sized decent barrel cracker	5	good	Last Available: "2015-09"
 8582	distilled bouncing vibrating mushroom	1	crappy	Effect: "Cold Jellied", Effect Duration: 40, Last Available: "2015-09"
 8583	diluted mushroom	1	good	Last Available: "2015-09"
 8584	KoL Con 12-gauge of dire peril	0		Weapon Damage: +20, Last Available: "2015-09"
@@ -8495,7 +8495,7 @@
 8622	quadruple-diffused cuppa Mediocri tea	0		Effect: "Thick, Sick", Effect Duration: 38, Last Available: "2015-09"
 8623	quantum cuppa Loyal tea	0		Effect: "Wet Rub", Effect Duration: 55, Last Available: "2015-09"
 8624	altered huge cuppa Activi tea	1	decent	Last Available: "2015-09"
-8625	pickled teal mirror bouncing cuppa Cruel tea	1		Last Available: "2015-09"
+8625	pickled bouncing teal mirror cuppa Cruel tea	1		Last Available: "2015-09"
 8626	non-corrupted lime green cuppa Alacri tea	0		Effect: "Demonic Flavor", Effect Duration: 48, Last Available: "2015-09"
 8627	corrupted mirror cuppa Vitali tea	0		Effect: "Souper Vengeful", Effect Duration: 57, Last Available: "2015-09"
 8628	quadruple-concentrated galvanized cuppa Mana tea	0		Effect: "Human-Demon Hybrid", Effect Duration: 53, Last Available: "2015-09"
@@ -8512,10 +8512,10 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	shaking Ghost Dog Chow	0		Last Available: "2015-10"
 8641	rotten bowl of eyeballs	3	crappy	Last Available: "2015-10"
-8642	massive delicious yellow blurry bowl of mummy guts	6	awesome	Last Available: "2015-10"
+8642	delicious massive yellow blurry bowl of mummy guts	6	awesome	Last Available: "2015-10"
 8643	low-calorie decent bowl of maggots	1	good	Last Available: "2015-10"
 8644	acceptable shaking blood and blood	3	good	Last Available: "2015-10"
-8645	weak lousy gray Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
+8645	lousy weak gray Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
 8646	artisanal wobbly zombie	3	EPIC	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	twirling stink-penny	0		
 8654	yellow bouncing dance instructor's hawk of Calamity Jane of incineration	0		Experience Percent (Moxie): +10, Critical Hit Percent: +15, Hot Spell Damage: +50
-8655	gigantic decent hamlet sandwich	6	good	
+8655	decent gigantic hamlet sandwich	6	good	
 8656	sizzling Othello's military jacket	0		Hot Damage: +10
 8657	blinking wool Othello's dagger	0		Cold Resistance: +1, Single Equip
 8658	purple wicked Othello's handkerchief	0		Spell Damage: +5, Single Equip
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	squat How to Play Othello	0		
 8662	jittery lard-coated ghostly dagger of Tarzan of the early riser	0		Experience (Muscle): +3, Sleaze Spell Damage: +25, Adventures: +7
-8663	irresponsibly strong smooth ghost beer	6	awesome	
+8663	smooth irresponsibly strong ghost beer	6	awesome	
 8664	mirror Othello set of doom	0		Spooky Spell Damage: +50
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8547,7 +8547,7 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	squat one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	dry boiled ghostly shoulder-warming lotion	0		Effect: "Pwnd", Effect Duration: 22, Last Available: "2015-11"
-8677	massive flavorless iceberg lettuce	7	decent	Last Available: "2015-11"
+8677	flavorless massive iceberg lettuce	7	decent	Last Available: "2015-11"
 8678	lousy ice wine	3	decent	Last Available: "2015-11"
 8679	aromatic Oprah's dance instructor's Wal-Mart snowglobe	0		Experience Percent (Moxie): +10, Maximum MP Percent: +50, Stench Resistance: +1, Last Available: "2015-11"
 8680	ghostly flame-retardant cool Wal-Mart nametag of the cougar	0		Moxie: 25, Hot Resistance: +1, Last Available: "2015-11"
@@ -8559,7 +8559,7 @@
 8686	twirling perfect ice cube	0		Last Available: "2015-11"
 8687	jittery The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	ribald bellhop's hat	0		Sleaze Damage: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	fortified drinkable ice porter	5	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	drinkable fortified ice porter	5	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	ionized super-flattened ghostly exotic travel brochure	0		Effect: "Sleazy Jellied", Effect Duration: 17, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	altered shaking shampoo-conditioner	0		Effect: "Gyromitra Gymnastics", Effect Duration: 28, Last Available: "2015-11"
@@ -8568,7 +8568,7 @@
 8695	upside-down Martialest Arts trophy	0		Last Available: "2016-01"
 8696	powdered medicinal herbs	1		Last Available: "2016-01"
 8697	decent ice rice	3	good	Last Available: "2016-01"
-8698	perfectly mixed jittery blurry iced plum wine	3	EPIC	Last Available: "2016-01"
+8698	perfectly mixed blurry jittery iced plum wine	3	EPIC	Last Available: "2016-01"
 8699	flame-retardant horrifying supercharged training belt	0		Maximum MP Percent: +30, Spooky Damage: +25, Hot Resistance: +1, Single Equip, Last Available: "2016-01"
 8700	lard-coated hale training legwarmers of the blizzard	0		Maximum HP: +20, Cold Spell Damage: +25, Sleaze Spell Damage: +25, Single Equip, Last Available: "2016-01"
 8701	avaricious auspicious fireproof training helmet	0		Hot Resistance: +3, Item Drop: +10, Meat Drop: +30, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
@@ -8580,17 +8580,17 @@
 8707	blurry self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	distilled mirror abstraction: action	1		Last Available: "2015-12"
 8709	denatured shaking abstraction: thought	1		Effect: "Hobo Flavor", Effect Duration: 20, Last Available: "2015-12"
-8710	mixed blinking blurry tumbling abstraction: sensation	1		Last Available: "2015-12"
+8710	mixed tumbling blurry blinking abstraction: sensation	1		Last Available: "2015-12"
 8711	altered bouncing huge abstraction: purpose	1		Effect: "Phairly Balanced", Effect Duration: 45, Last Available: "2015-12"
-8712	dried wobbly skewed abstraction: category	1		Last Available: "2015-12"
+8712	dried skewed wobbly abstraction: category	1		Last Available: "2015-12"
 8713	altered abstraction: perception	1		Effect: "Poker Faced", Effect Duration: 50, Last Available: "2015-12"
 8714	mixed pulsating abstraction: motion	1		Last Available: "2015-12"
 8715	mixed spinning abstraction: joy	1		Last Available: "2015-12"
 8716	denatured huge cyan abstraction: certainty	1		Last Available: "2015-12"
-8717	dried jittery purple abstraction: comprehension	1		Last Available: "2015-12"
+8717	dried purple jittery abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	bland VYKEA meatballs	3	decent	Last Available: "2015-11"
-8720	triple-distilled bad VYKEA mead	10	decent	Last Available: "2015-11"
+8720	bad triple-distilled VYKEA mead	10	decent	Last Available: "2015-11"
 8721	triple-oxidized ghostly VYKEA woadpaint	0		Effect: "Updated", Effect Duration: 32, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8608,11 +8608,11 @@
 8735	censurious healthy groovy norwhal helmet	0		Moxie Percent: +10, Maximum HP Percent: +20, Sleaze Resistance: +3, Familiar Effect: "atk", Last Available: "2015-11"
 8736	octolus-skin cloak of the wise owl of the cougar of extreme caution	0		Mysticality: +20, Moxie: +20, Monster Level: -25, Last Available: "2015-11"
 8737	tolerable tumbling perfect cosmopolitan	4	good	Last Available: "2015-11"
-8738	enchanted triple-distilled tolerable lime green perfect negroni	10	good	Effect: "Elron's Explosive Etude", Effect Duration: 20, Last Available: "2015-11"
-8739	high-proof hand-crafted perfect dark and stormy	6	EPIC	Last Available: "2015-11"
-8740	hand-crafted boozy pulsating blurry perfect mimosa	5	EPIC	Last Available: "2015-11"
+8738	triple-distilled enchanted tolerable lime green perfect negroni	10	good	Effect: "Elron's Explosive Etude", Effect Duration: 20, Last Available: "2015-11"
+8739	hand-crafted high-proof perfect dark and stormy	6	EPIC	Last Available: "2015-11"
+8740	boozy hand-crafted pulsating blurry perfect mimosa	5	EPIC	Last Available: "2015-11"
 8741	acceptable huge perfect old-fashioned	4	good	Last Available: "2015-11"
-8742	practically non-alcoholic artisanal blue perfect paloma	1	super ultra mega turbo EPIC	Last Available: "2015-11"
+8742	artisanal practically non-alcoholic blue perfect paloma	1	super ultra mega turbo EPIC	Last Available: "2015-11"
 8743	altered huge huge That 70s Cologne	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 33, Last Available: "2015-11"
 8744	chilled nitrogenated magnetized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Weather, Man", Effect Duration: 24, Last Available: "2015-11"
 8745	super-Vulcanized dry triple-oxidized blinking Puffstone cigar	0		Effect: "Comprehensively Nourished", Effect Duration: 31, Last Available: "2015-11"
@@ -8621,9 +8621,9 @@
 8748	airplane tattoo	0		Last Available: "2015-11"
 8749	irradiated upside-down Deep Machine Tunnels snowglobe	0		Effect: "Bats in the Belfry", Effect Duration: 52, Last Available: "2015-12"
 8750	ionized polarized hemp candy necklace	0		Effect: "Stands Alone", Effect Duration: 54, Last Available: "2015-12"
-8751	dry boiled jittery ghostly communal gobstopper	0		Effect: "Burnt 'n' Turnt", Effect Duration: 41, Last Available: "2015-12"
+8751	dry boiled ghostly jittery communal gobstopper	0		Effect: "Burnt 'n' Turnt", Effect Duration: 41, Last Available: "2015-12"
 8752	miniature spoiled ghostly Crimbo salad	2	crappy	Last Available: "2015-12"
-8753	tasty enchanted pulsating bread line	3	awesome	Effect: "Super Structure", Effect Duration: 45, Last Available: "2015-12"
+8753	enchanted tasty pulsating bread line	3	awesome	Effect: "Super Structure", Effect Duration: 45, Last Available: "2015-12"
 8754	watered-down lousy bark rootbeer	2	decent	Last Available: "2015-12"
 8755	perfectly mixed skewed ale	4	EPIC	Last Available: "2015-12"
 8756	teal dog trainer's plastic Tammy the Tambourine Elf	0		Experience (familiar): +1, Last Available: "2015-12"
@@ -8667,7 +8667,7 @@
 8795	skewed Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
-8798	lime green spinning bat-jute	0		Last Available: "2017-01"
+8798	spinning lime green bat-jute	0		Last Available: "2017-01"
 8799	mirror bat-o-mite	0		Last Available: "2017-01"
 8800	tumbling ROM of Optimality	0		Skill: "Toggle Optimality"
 8801	wobbly incriminating evidence	0		Last Available: "2017-01"
@@ -8685,12 +8685,12 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	tumbling bat-bearing	0		Last Available: "2017-01"
-8816	snack-sized spoiled Kudzu salad	2	crappy	Last Available: "2016-12"
+8816	spoiled snack-sized Kudzu salad	2	crappy	Last Available: "2016-12"
 8817	modified jittery Mansquito Serum	1		Effect: "Tingling Feeling", Effect Duration: 5, Last Available: "2016-12"
-8818	practically non-alcoholic lousy bouncing Miss Graves' vermouth	1	decent	Last Available: "2016-12"
+8818	lousy practically non-alcoholic bouncing Miss Graves' vermouth	1	decent	Last Available: "2016-12"
 8819	moldy squat The Plumber's mushroom stew	3	crappy	Last Available: "2016-12"
 8820	twisted blinking The Author's ink	1		Last Available: "2016-02"
-8821	artisanal tumbling ghostly The Mad Liquor	4	EPIC	Last Available: "2016-12"
+8821	artisanal ghostly tumbling The Mad Liquor	4	EPIC	Last Available: "2016-12"
 8822	artisanal fortified Doc Clock's thyme cocktail	5	EPIC	Last Available: "2016-12"
 8823	spoiled Mr. Burnsger	3	crappy	Last Available: "2016-12"
 8824	compressed twirling blurry The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	maroon domino mask	0		Familiar Weight: +5
 8833	warmed robin's egg	0		Effect: "Shawarma Warm War", Effect Duration: 56, Last Available: "2016-12"
 8834	decent robin flan	3	good	Last Available: "2016-12"
-8835	acceptable practically non-alcoholic shaking blinking robin nog	1	good	Last Available: "2016-12"
+8835	acceptable practically non-alcoholic blinking shaking robin nog	1	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	twirling plaintive telegram	0		Last Available: "2016-02"
 8838	wobbly exploding gum	0		
@@ -8717,8 +8717,8 @@
 8845	frozen corrupted bag of random words	0		Effect: "Mmmmmelon", Effect Duration: 61
 8846	unsweetened ionized yellow blurry tube of pendulum lube	0		Effect: "Hypercubed", Effect Duration: 56
 8847	frozen wobbly red-hot jawbreaker	0		Effect: "Unrunnable Face", Effect Duration: 47
-8848	energized wobbly squat question juice	0		Effect: "Sleazy Hands", Effect Duration: 34
-8849	electrified tumbling pulsating tube of villain	0		Effect: "Slimily Strong", Effect Duration: 32
+8848	energized squat wobbly question juice	0		Effect: "Sleazy Hands", Effect Duration: 34
+8849	electrified pulsating tumbling tube of villain	0		Effect: "Slimily Strong", Effect Duration: 32
 8850	upside-down teal slick your cowboy boots	0		Moxie: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
@@ -8726,7 +8726,7 @@
 8854	nugget of wicksilver	0		Last Available: "2016-02"
 8855	fuchsia nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
-8857	wobbly upside-down nugget of nicksilver	0		Last Available: "2016-02"
+8857	upside-down wobbly nugget of nicksilver	0		Last Available: "2016-02"
 8858	nugget of ticksilver	0		Last Available: "2016-02"
 8859	miser's quicksilver ring	0		Meat Drop: +10, Single Equip, Last Available: "2016-02"
 8860	thicksilver ring of the brute of chilblains of bravery	0		Muscle Percent: +30, Cold Damage: +25, Spooky Resistance: +5, Single Equip, Last Available: "2016-02"
@@ -8746,11 +8746,11 @@
 8874	greedy scorching studded Val-U Brand Every Bean Salad of the brute of courage	0		Muscle Percent: +30, Damage Absorption: +80, Hot Damage: +25, Spooky Resistance: +3, Meat Drop: +20, Last Available: "2016-02"
 8875	spinning Shrub's Premium Baked Beans of the pedagogue of James Dean of mayonnaise	0		Experience: +3, Experience (Moxie): +3, Sleaze Spell Damage: +50, Last Available: "2016-02"
 8876	flavorless plate of Heimz Fortified Kidney Beans	3	decent	Last Available: "2016-02"
-8877	snack-sized bland blinking blue plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
-8878	adequate enchanted low-calorie plate of Mixed Garbanzos and Chickpeas	1	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2016-02"
+8877	snack-sized bland blue blinking plate of Tesla's Electroplated Beans	2	decent	Last Available: "2016-02"
+8878	enchanted low-calorie adequate plate of Mixed Garbanzos and Chickpeas	1	good	Effect: "No Worries", Effect Duration: 15, Last Available: "2016-02"
 8879	decent plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
 8880	adequate plate of Frigid Northern Beans	4	good	Last Available: "2016-02"
-8881	thick toothsome pulsating plate of World's Blackest-Eyed Peas	5	awesome	Last Available: "2016-02"
+8881	toothsome thick pulsating plate of World's Blackest-Eyed Peas	5	awesome	Last Available: "2016-02"
 8882	stale plate of Trader Olaf's Exotic Stinkbeans	4	decent	Last Available: "2016-02"
 8883	stale spinning plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	decent	Last Available: "2016-02"
 8884	moldy wobbly plate of Val-U Brand Every Bean Salad	3	crappy	Last Available: "2016-02"
@@ -8774,11 +8774,11 @@
 8902	dry chilled tumbling ghost bit	0		Effect: "Dances with Tweedles", Effect Duration: 24, Last Available: "2016-02"
 8903	modified blurry buzzard feather	0		Effect: "Slippery Tongue", Effect Duration: 66, Last Available: "2016-02"
 8904	non-polymerized yellow lion musk	0		Effect: "Hagnk's Gratitude", Effect Duration: 60, Last Available: "2016-02"
-8905	stale gigantic bear claw	9	decent	Last Available: "2016-02"
+8905	gigantic stale bear claw	9	decent	Last Available: "2016-02"
 8906	liquefied Vulcanized altered rattler gland	0		Effect: "The Q Is Talking To You", Effect Duration: 66, Last Available: "2016-02"
 8907	triple-moist chilled half-digested coal	0		Effect: "init.enh", Effect Duration: 46, Last Available: "2016-02"
 8908	enhanced blurry tightly-wound spine	0		Effect: "Sludgesick", Effect Duration: 48, Last Available: "2016-02"
-8909	special super-sized decent rotting beefsteak	5	good	Effect: "Pill Power", Effect Duration: 50, Last Available: "2016-02"
+8909	super-sized special decent rotting beefsteak	5	good	Effect: "Pill Power", Effect Duration: 50, Last Available: "2016-02"
 8910	lousy narrow firemilk	4	decent	Last Available: "2016-02"
 8911	frozen unsweetened spidercow eye-cluster	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 59, Last Available: "2016-02"
 8912	denatured moomy dust	1		Last Available: "2016-02"
@@ -8847,7 +8847,7 @@
 8975	exclusive club	0		
 8976	activated wobbly patent preventative tonic	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 31
 8977	chilled non-anodized chilled patent invisibility tonic	0		Effect: "Yuletide Mutations", Effect Duration: 28
-8978	improved olive skewed patent aggression tonic	0		Effect: "Is This Your Card?", Effect Duration: 21
+8978	improved skewed olive patent aggression tonic	0		Effect: "Is This Your Card?", Effect Duration: 21
 8979	aerosolized shaking patent sallowness tonic	0		Effect: "Angry Bone", Effect Duration: 11
 8980	polarized oxidized huge patent avarice tonic	0		Effect: "Earthen Fist", Effect Duration: 25
 8981	improved ionized mirror patent alacrity tonic	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 28
@@ -8863,7 +8863,7 @@
 8991	blinking do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	dried tumbling yellow armored prawn	1		Effect: "damage.enh", Effect Duration: 20, Last Available: "2016-03"
 8993	stale maroon jumping horseradish	4	decent	Last Available: "2016-03"
-8994	mediocre distilled Sacramento wine	5	decent	Last Available: "2016-03"
+8994	distilled mediocre Sacramento wine	5	decent	Last Available: "2016-03"
 8995	frozen aerosolized Greek fire	0		Effect: "What's That Smell?", Effect Duration: 44, Last Available: "2016-03"
 8996	family-friendly frightening ruddy sinister personal trainer's ox-head shield	0		Experience Percent (Muscle): +10, Spell Damage: +10, Maximum HP Percent: +40, Spooky Damage: +5, Sleaze Resistance: +1, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	bouncing sizzling Annie Oakley's forbidden baleful dented scepter of the detective	0		Spell Damage: +25, Spell Damage Percent: +50, Critical Hit Percent: +20, Hot Damage: +10, Item Drop: +20, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8878,7 +8878,7 @@
 9006	Jack Frost's experienced strapping tunac of mayonnaise	0		Muscle: +5, Experience: +2, Cold Spell Damage: +50, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04"
 9007	fuchsia fishin' pole	0		Last Available: "2016-04"
 9008	anodized wriggling worm	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 68, Last Available: "2016-04"
-9009	watered-down artisanal wobbly bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
+9009	artisanal watered-down wobbly bottle of Fishhead 900-Day IPA	2	EPIC	Last Available: "2016-04"
 9010	modified high-test fishing line	0		Effect: "Chalked Weapon", Effect Duration: 16, Last Available: "2016-04"
 9011	jittery reassuring fishin' hat	0		Spooky Resistance: +1, Last Available: "2016-04"
 9012	twirling Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8900,12 +8900,12 @@
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
 9030	toothsome tiny star salad	1	awesome	
-9031	gray spinning Thwaitgold moth statuette	0		
+9031	spinning gray Thwaitgold moth statuette	0		
 9032	toothsome bowl of Tastee-Wheet&trade;	3	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	normal enchanted browser cookie	3	good	Effect: "Human-Goblin Hybrid", Effect Duration: 25, Last Available: "2016-06"
-9036	perfectly mixed practically non-alcoholic hacked gibson	1	super ultra mega turbo EPIC	Last Available: "2016-06"
+9036	practically non-alcoholic perfectly mixed hacked gibson	1	super ultra mega turbo EPIC	Last Available: "2016-06"
 9037	bouncing executive Source shades	0		Meat Drop: +40, Last Available: "2016-06"
 9038	purple software bug	0		Last Available: "2016-06"
 9039	upside-down missing semicolon	0		Familiar Weight: +11
@@ -8979,7 +8979,7 @@
 9107	electrified modified blurry huge upside-down Rad-Pro (1 oz.)	0		Effect: "Fungal Flambé", Effect Duration: 45
 9108	lead umbrella	0		
 9109	nitrogenated Shrieking Weasel holo-record	0		Effect: "Notably Lovely", Effect Duration: 61
-9110	extra-ionized huge twirling Power-Guy 2000 holo-record	0		Effect: "The Dinsey Way", Effect Duration: 56
+9110	extra-ionized twirling huge Power-Guy 2000 holo-record	0		Effect: "The Dinsey Way", Effect Duration: 56
 9111	diffused Lucky Strikes holo-record	0		Effect: "Buttermilk Boogie", Effect Duration: 39
 9112	extra-chilled EMD holo-record	0		Effect: "Wet Rub", Effect Duration: 49
 9113	quantum Superdrifter holo-record	0		Effect: "Sausage Festive", Effect Duration: 58
@@ -9002,8 +9002,8 @@
 9130	energized liquefied jittery charisma potion	0		Effect: "Meatwise", Effect Duration: 32
 9131	extremely confusing manual	0		
 9132	shaking occult savvy pistol	0		Mysticality Percent: +20, Spell Damage Percent: +25
-9133	maroon wobbly KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	spoiled small spinning leftover pasty	2	crappy	
+9133	wobbly maroon KoL Con 13 snowglobe	0		Last Available: "2016-10"
+9134	small spoiled spinning leftover pasty	2	crappy	
 9135	mediocre watered-down very whiskey	2	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9023,13 +9023,13 @@
 9151	pressed colloidal liquefied huge red invisible seam ripper	0		Lasts Until Rollover, Effect: "Ichorous Intensity", Effect Duration: 22, Last Available: "2016-10"
 9152	skewed li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	massive rotten huge raw sweet potato	10	crappy	Last Available: "2016-11"
-9154	enchanted delicious gigantic blinking raw beans	6	awesome	Effect: "Human-Machine Hybrid", Effect Duration: 45, Last Available: "2016-11"
-9155	fancy spoiled olive tumbling raw stuffing	4	crappy	Effect: "Dwarven Hardiness", Effect Duration: 25, Last Available: "2016-11"
+9154	delicious enchanted gigantic blinking raw beans	6	awesome	Effect: "Human-Machine Hybrid", Effect Duration: 45, Last Available: "2016-11"
+9155	fancy spoiled tumbling olive raw stuffing	4	crappy	Effect: "Dwarven Hardiness", Effect Duration: 25, Last Available: "2016-11"
 9156	adequate raw cranberry sauce	3	good	Last Available: "2016-11"
 9157	adequate shaking twirling raw turkey	3	good	Last Available: "2016-11"
 9158	moldy raw mincemeat	3	crappy	Last Available: "2016-11"
-9159	half-sized moldy raw potato	2	crappy	Last Available: "2016-11"
-9160	flavorless jumbo raw gravy	5	decent	Last Available: "2016-11"
+9159	moldy half-sized raw potato	2	crappy	Last Available: "2016-11"
+9160	jumbo flavorless raw gravy	5	decent	Last Available: "2016-11"
 9161	tiny normal skewed raw bread	1	good	Last Available: "2016-11"
 9162	steel-toed wizardly mini-marshmallow dispenser	0		Mysticality: +25, Damage Reduction: 9, Last Available: "2016-11"
 9163	avaricious inspector's glass casserole dish of the empath	0		Familiar Weight: +5, Item Drop: +15, Meat Drop: +30, Last Available: "2016-11"
@@ -9041,16 +9041,16 @@
 9169	spinning gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	moldy super-sized sweet potatoes	5	crappy	Last Available: "2016-11"
-9172	jumbo enchanted adequate squat gray bean casserole	5	good	Effect: "Unusual Perspective", Effect Duration: 5, Last Available: "2016-11"
+9172	enchanted adequate jumbo squat gray bean casserole	5	good	Effect: "Unusual Perspective", Effect Duration: 5, Last Available: "2016-11"
 9173	moldy jittery baked stuffing	4	crappy	Last Available: "2016-11"
 9174	normal bouncing cranberry cylinder	4	good	Last Available: "2016-11"
 9175	spoiled thanksgiving turkey	3	crappy	Last Available: "2016-11"
 9176	decent mince pie	3	good	Last Available: "2016-11"
-9177	huge flavorless mashed potatoes	8	decent	Last Available: "2016-11"
-9178	normal huge yellow warm gravy	7	good	Last Available: "2016-11"
+9177	flavorless huge mashed potatoes	8	decent	Last Available: "2016-11"
+9178	huge normal yellow warm gravy	7	good	Last Available: "2016-11"
 9179	rotten pulsating bread roll	4	crappy	Last Available: "2016-11"
-9180	tiny rotten special leftovers	1	crappy	Effect: "Quaaaaaaa", Effect Duration: 5, Last Available: "2016-11"
-9181	moldy bite-sized skewed leftovers sandwich	1	crappy	Last Available: "2016-11"
+9180	special tiny rotten leftovers	1	crappy	Effect: "Quaaaaaaa", Effect Duration: 5, Last Available: "2016-11"
+9181	bite-sized moldy skewed leftovers sandwich	1	crappy	Last Available: "2016-11"
 9182	skewed squat Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	jittery megacopia	0		Last Available: "2016-11"
@@ -9063,7 +9063,7 @@
 9191	Vulcanized quantum eldritch concentrate	0		Effect: "Savage Beast Inside", Effect Duration: 22, Last Available: "2016-11"
 9192	practically non-alcoholic aged mirror eldritch extract	1	awesome	Last Available: "2016-11"
 9193	rosewater-soaked ruddy Official Council Aide Pin	0		Maximum HP Percent: +40, Stench Resistance: +3, Last Available: "2016-11"
-9194	practically non-alcoholic tolerable eldritch distillate	1	good	Last Available: "2016-11"
+9194	tolerable practically non-alcoholic eldritch distillate	1	good	Last Available: "2016-11"
 9195	dried eldritch essence	1		Last Available: "2016-11"
 9196	skewed savvy Science Notebook	0		Mysticality Percent: +20
 9197	supercool weightlifter's eldritch hat of incineration	0		Muscle: +15, Moxie Percent: +20, Hot Spell Damage: +50, Last Available: "2016-11"
@@ -9108,7 +9108,7 @@
 9236	yellow rosy-cheeked gingerbread gavel of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	green gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	hand-crafted triple-distilled upside-down ginger beer	9	EPIC	Last Available: "2016-12"
+9239	triple-distilled hand-crafted upside-down ginger beer	9	EPIC	Last Available: "2016-12"
 9240	green spare chocolate parts	0		Last Available: "2016-12"
 9241	enhanced industrial frosting	0		Effect: "Your Interest is Peaked", Effect Duration: 29, Last Available: "2016-12"
 9242	magnetized huge fake cocktail	0		Effect: "Sweet and Green", Effect Duration: 61, Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	bouncing briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	narrow teethpick	0		Last Available: "2016-12"
 9266	diffused rock candy	0		Effect: "Pronounced Potency", Effect Duration: 14, Last Available: "2016-12"
-9267	gigantic rotten green-iced sweet roll	6	crappy	Last Available: "2016-12"
+9267	rotten gigantic green-iced sweet roll	6	crappy	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	ghostly wobbly chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9145,7 +9145,7 @@
 9273	scandalous Third Eye of terror	0		Spooky Spell Damage: +10, Sleaze Damage: +5, Last Available: "2016-12"
 9274	pulsating stanky Krampus Horn of terror	0		Stench Spell Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2016-12"
 9275	normal hambrosier	3	good	Last Available: "2016-12"
-9276	smooth weak chakra-mental wine	2	awesome	Last Available: "2016-12"
+9276	weak smooth chakra-mental wine	2	awesome	Last Available: "2016-12"
 9277	anodized squat chakra malt	0		Effect: "Celestial Sheen", Effect Duration: 53, Last Available: "2016-12"
 9278	special decent Black Angus blackburger	3	good	Effect: "Thickest, Sickest", Effect Duration: 20, Last Available: "2016-12"
 9279	boozy acceptable brandy	5	good	Last Available: "2016-12"
@@ -9157,7 +9157,7 @@
 9285	Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
 9286	eternal knot tattoo	0		Last Available: "2016-12"
 9287	pet bad vibe	0		Last Available: "2016-12"
-9288	cyan squat gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
+9288	squat cyan gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	maroon jittery bouncing chilly Uncle Crimbo's hat of Tarzan of Leguizamo	0		Experience (Muscle): +3, Monster Level: +20, Cold Damage: +5, Last Available: "2016-12"
 9290	snack-sized decent Eldritch snap	2	good	Last Available: "2017-01"
 9291	twisted hot jelly	1		Last Available: "2017-01"
@@ -9212,12 +9212,12 @@
 9340	narrow Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
-9343	blinking ghostly bottlecap	0		
+9343	ghostly blinking bottlecap	0		
 9344	tumbling discarded button	0		
 9345	Gummi-Memory	0		
 9346	shaking Thwaitgold amoeba statuette	0		
 9347	pickled grasshopper	0		Last Available: "2017-03"
-9348	jittery yellow bottle of an&iacute;s	0		Last Available: "2017-03"
+9348	yellow jittery bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	ghostly elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
@@ -9238,20 +9238,20 @@
 9366	hand-crafted double entendre	3	EPIC	Last Available: "2017-03"
 9367	drinkable Phlegethon	3	good	Last Available: "2017-03"
 9368	acceptable practically non-alcoholic Siberian sunrise	1	good	Last Available: "2017-03"
-9369	irresponsibly strong bad mentholated wine	8	decent	Last Available: "2017-03"
+9369	bad irresponsibly strong mentholated wine	8	decent	Last Available: "2017-03"
 9370	practically non-alcoholic delicious low tide martini	1	awesome	Last Available: "2017-03"
 9371	acceptable shroomtini	3	good	Last Available: "2017-03"
 9372	hand-crafted squat morning dew	3	EPIC	Last Available: "2017-03"
 9373	smooth whiskey squeeze	3	awesome	Last Available: "2017-03"
-9374	delicious enchanted great fashioned	3	awesome	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5, Last Available: "2017-03"
-9375	tolerable upside-down mirror Gnomish sagngria	3	good	Last Available: "2017-03"
-9376	weak bad vodka stinger	2	decent	Last Available: "2017-03"
+9374	enchanted delicious great fashioned	3	awesome	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 5, Last Available: "2017-03"
+9375	tolerable mirror upside-down Gnomish sagngria	3	good	Last Available: "2017-03"
+9376	bad weak vodka stinger	2	decent	Last Available: "2017-03"
 9377	acceptable extremely slippery nipple	3	good	Last Available: "2017-03"
 9378	artisanal blinking piscatini	3	EPIC	Last Available: "2017-03"
 9379	artisanal ghostly Churchill	3	EPIC	Last Available: "2017-03"
 9380	tolerable soilzerac	4	good	Last Available: "2017-03"
-9381	bad high-proof London frog	8	decent	Last Available: "2017-03"
-9382	fortified bad skewed nothingtini	5	decent	Last Available: "2017-03"
+9381	high-proof bad London frog	8	decent	Last Available: "2017-03"
+9382	bad fortified skewed nothingtini	5	decent	Last Available: "2017-03"
 9383	weak aged eighth plague	2	awesome	Last Available: "2017-03"
 9384	perfectly mixed single entendre	4	EPIC	Last Available: "2017-03"
 9385	irresponsibly strong acceptable huge reverse Tantalus	7	good	Last Available: "2017-03"
@@ -9259,15 +9259,15 @@
 9387	hand-crafted Feliz Navidad	3	EPIC	Last Available: "2017-03"
 9388	bad Bloody Nora	3	decent	Last Available: "2017-03"
 9389	artisanal moreltini	3	EPIC	Last Available: "2017-03"
-9390	weak hand-crafted hell in a bucket	2	EPIC	Last Available: "2017-03"
-9391	watered-down smooth Newark	2	awesome	Last Available: "2017-03"
+9390	hand-crafted weak hell in a bucket	2	EPIC	Last Available: "2017-03"
+9391	smooth watered-down Newark	2	awesome	Last Available: "2017-03"
 9392	acceptable R'lyeh	4	good	Last Available: "2017-03"
 9393	aged Gnollish sangria	3	awesome	Last Available: "2017-03"
 9394	artisanal vodka barracuda	3	EPIC	Last Available: "2017-03"
 9395	hand-crafted strong Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
 9396	acceptable drive-by shooting	3	good	Last Available: "2017-03"
 9397	watered-down drinkable shaking gunner's daughter	2	good	Last Available: "2017-03"
-9398	watered-down tolerable lime green dirt julep	2	good	Last Available: "2017-03"
+9398	tolerable watered-down lime green dirt julep	2	good	Last Available: "2017-03"
 9399	weak mediocre Simepore slime	2	decent	Last Available: "2017-03"
 9400	mediocre Phil Collins	3	decent	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9277,14 +9277,14 @@
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	blinking exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	gray rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
-9408	upside-down squat gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9408	squat upside-down gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	narrow high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	spinning Spacegate Research	0		Last Available: "2017-04"
 9411	alien rock sample	0		Last Available: "2017-04"
 9412	teal alien gemstone	0		Last Available: "2017-04"
 9413	spinning geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	spoiled gigantic edible alien plant bit	7	crappy	Last Available: "2017-04"
+9415	gigantic spoiled edible alien plant bit	7	crappy	Last Available: "2017-04"
 9416	olive alien plant fibers	0		Last Available: "2017-04"
 9417	squat alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9301,7 +9301,7 @@
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
-9432	deionized improved alkaline fuchsia squat narrow alien medicine	0		Effect: "Fangs and Pangs", Effect Duration: 27, Last Available: "2017-04"
+9432	deionized improved alkaline squat narrow fuchsia alien medicine	0		Effect: "Fangs and Pangs", Effect Duration: 27, Last Available: "2017-04"
 9433	rotten alien salad	3	crappy	Last Available: "2017-04"
 9434	perfectly mixed alien booze	3	EPIC	Last Available: "2017-04"
 9435	foul-smelling banded slick alien mask	0		Moxie: +10, Damage Absorption: +100, Stench Damage: +10, Last Available: "2017-04"
@@ -9335,7 +9335,7 @@
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	tumbling Space Baby bawbaw	0		Last Available: "2017-04"
 9465	ghostly Spacegate	0		Last Available: "2017-04"
-9466	decent snack-sized Aldebaran sardines	2	good	Last Available: "2017-04"
+9466	snack-sized decent Aldebaran sardines	2	good	Last Available: "2017-04"
 9467	bad extra-dry Centauri fish wine	5	decent	Last Available: "2017-04"
 9468	dehydrated red oxygen	1		Last Available: "2017-04"
 9469	grievous strapping Spacegate scientist's insignia	0		Muscle: +5, Weapon Damage Percent: +50, Single Equip, Last Available: "2017-04"
@@ -9355,7 +9355,7 @@
 9483	dry spinning fuchsia Daily Affirmation: Be a Mind Master	0		Effect: "Aloofah", Effect Duration: 36, Last Available: "2017-05"
 9484	triple-Vulcanized diffused Daily Affirmation: Work For Hours a Week	0		Effect: "Sugar Smacks", Effect Duration: 19, Last Available: "2017-05"
 9485	energized Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Prelude of Precision", Effect Duration: 15, Last Available: "2017-05"
-9486	moldy snack-sized Affirmation Cookie	2	crappy	Last Available: "2017-05"
+9486	snack-sized moldy Affirmation Cookie	2	crappy	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
@@ -9365,12 +9365,12 @@
 9493	censurious Annie Oakley's Kremlin's Greatest Briefcase of temperance	0		Critical Hit Percent: +20, Sleaze Resistance: 8, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	weak drinkable basic martini	2	good	Last Available: "2017-06"
 9495	perfectly mixed improved martini	3	EPIC	Last Available: "2017-06"
-9496	acceptable practically non-alcoholic splendid martini	1	good	Last Available: "2017-06"
+9496	practically non-alcoholic acceptable splendid martini	1	good	Last Available: "2017-06"
 9497	jittery exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
 9500	gun	0		Free Pull, Last Available: "2017-06"
-9501	maroon shaking gum	0		Free Pull, Last Available: "2017-06"
+9501	shaking maroon gum	0		Free Pull, Last Available: "2017-06"
 9502	toasty padded plastic gundam of Leguizamo	0		Damage Absorption: +20, Monster Level: +20, Hot Damage: +5, Last Available: "2017-06"
 9503	License to Chill	0		Last Available: "2017-07"
 9504	tumbling Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
@@ -9383,7 +9383,7 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	flavorless bite-sized teal meteoreo	1	decent	Last Available: "2017-08"
+9514	bite-sized flavorless teal meteoreo	1	decent	Last Available: "2017-08"
 9515	lousy meadeorite	4	decent	Last Available: "2017-08"
 9516	gray meteoroid	0		Last Available: "2017-08"
 9517	reassuring meteortarboard of the pedagogue of the empath	0		Experience: +3, Familiar Weight: +5, Spooky Resistance: +1, Last Available: "2017-08"
@@ -9395,10 +9395,10 @@
 9523	meteoroid	0		Last Available: "2017-08"
 9524	fuchsia meteor shower cap	0		Familiar Weight: +5
 9525	Thwaitgold time fly statuette	0		
-9526	green spinning mirror perfectly fair coin	0		Last Available: "2017-11"
+9526	spinning green mirror perfectly fair coin	0		Last Available: "2017-11"
 9527	upside-down Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	corked genie bottle	0		Free Pull, Last Available: "2017-09"
-9529	skewed gray genie bottle	0		Last Available: "2017-09"
+9529	gray skewed genie bottle	0		Last Available: "2017-09"
 9530	fireproof chilly blessed rustproof +2 gray dragon scale mail of the cheetah	0		Cold Damage: +5, Hot Resistance: +3, Initiative: +60, Last Available: "2023-09"
 9531	bouncing pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	pony: Shutterfly	0		Last Available: "2017-09"
@@ -9414,12 +9414,12 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	blurry X	0		Last Available: "2017-10"
 9544	squat O	0		Last Available: "2017-10"
-9545	drinkable triple-distilled DUFRESNE Suds	10	good	Last Available: "2017-09"
+9545	triple-distilled drinkable DUFRESNE Suds	10	good	Last Available: "2017-09"
 9546	mirror lightning-fast mafia pinky ring of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Single Equip
-9547	delicious practically non-alcoholic flask of port	1	awesome	
+9547	practically non-alcoholic delicious flask of port	1	awesome	
 9548	ghostly fireproof manspreader's contract enforcement stick	0		Monster Level: +10, Hot Resistance: +3
 9549	rotten huge Hide-rox&trade; cookie	4	crappy	Last Available: "2017-10"
-9550	hand-crafted practically non-alcoholic jug of booze	1	EPIC	Last Available: "2017-10"
+9550	practically non-alcoholic hand-crafted jug of booze	1	EPIC	Last Available: "2017-10"
 9551	quadruple-flattened pickled nitrogenated pair of candy glasses	0		Effect: "Speed of the Internet", Effect Duration: 27, Last Available: "2017-10"
 9552	warmed warmed gray temporary X tattoos	0		Effect: "Held Closer", Effect Duration: 37, Last Available: "2017-10"
 9553	compressed glyph of athleticism	1		Last Available: "2017-10"
@@ -9432,7 +9432,7 @@
 9560	O	0		Last Available: "2017-11"
 9561	spinning amorphous blob	0		Last Available: "2017-11"
 9562	stylish protection stick of James Dean of Calamity Jane of courage	0		Moxie: +25, Experience (Moxie): +3, Critical Hit Percent: +15, Spooky Resistance: +3
-9563	moist red narrow roll of meat	0		Effect: "Incensed", Effect Duration: 69
+9563	moist narrow red roll of meat	0		Effect: "Incensed", Effect Duration: 69
 9564	Lo Pan's mafia thumb ring of the businessman	0		Spell Critical Percent: +30, Meat Drop: +50, Single Equip
 9565	altered mirror cocoa chondrule	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 40, Last Available: "2020-09"
 9566	skewed greasy stiffened mafia middle finger ring	0		Damage Reduction: 1, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Show them your ring"
@@ -9483,7 +9483,7 @@
 9611	silent M	0		Last Available: "2017-12"
 9612	blinking silent N	0		Last Available: "2017-12"
 9613	spinning silent O	0		Last Available: "2017-12"
-9614	olive tumbling bouncing silent P	0		Last Available: "2017-12"
+9614	bouncing olive tumbling silent P	0		Last Available: "2017-12"
 9615	maroon silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
 9617	pulsating silent S	0		Last Available: "2017-12"
@@ -9493,13 +9493,13 @@
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	tumbling silent Y	0		Last Available: "2017-12"
-9624	jittery blinking silent Z	0		Last Available: "2017-12"
+9624	blinking jittery silent Z	0		Last Available: "2017-12"
 9625	blinking crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	wobbly mime pocket probe	0		Last Available: "2017-12"
 9629	perfectly mixed stale cheer wine	3	EPIC	Last Available: "2017-12"
-9630	special adequate miniature stale Cheer-E-Os	2	good	Effect: "Red Around the Gills", Effect Duration: 45, Last Available: "2017-12"
+9630	special miniature adequate stale Cheer-E-Os	2	good	Effect: "Red Around the Gills", Effect Duration: 45, Last Available: "2017-12"
 9631	huge cheer-o-gram	0		Last Available: "2017-12"
 9632	upside-down Sherlock's cheerful antler hat of the detective	0		Item Drop: 45, Last Available: "2017-12"
 9633	miser's rosewater-soaked cheerful Crimbo sweater	0		Stench Resistance: +3, Meat Drop: +10, Last Available: "2017-12"
@@ -9521,10 +9521,10 @@
 9649	stale immense nega-mushroom	9	decent	Last Available: "2017-12"
 9650	delicious nega-mushroom wine	4	awesome	Last Available: "2017-12"
 9651	moist alkaline Cheer-Up soda	0		Effect: "Radiant Personality", Effect Duration: 67, Last Available: "2017-12"
-9652	rotten immense mime army rations	8	crappy	Last Available: "2017-12"
+9652	immense rotten mime army rations	8	crappy	Last Available: "2017-12"
 9653	high-proof hand-crafted mime army wine	10	EPIC	Last Available: "2017-12"
 9654	dried maroon mime army superserum	1		Effect: "Limber as Mortimer", Effect Duration: 45, Last Available: "2017-12"
-9655	Vulcanized polarized shaking maroon mime army camouflage kit	0		Effect: "Human-Elf Hybrid", Effect Duration: 16, Last Available: "2017-12"
+9655	Vulcanized polarized maroon shaking mime army camouflage kit	0		Effect: "Human-Elf Hybrid", Effect Duration: 16, Last Available: "2017-12"
 9656	tumbling Sherlock's educational miming beret	0		Experience: +1, Item Drop: +25, Last Available: "2017-12"
 9657	blinking Sherlock's healthy miming shirt	0		Maximum HP Percent: +20, Item Drop: +25, Last Available: "2017-12"
 9658	mirror jittery lightning-fast deadly miming corduroys	0		Weapon Damage: +5, Initiative: +40, Last Available: "2017-12"
@@ -9565,16 +9565,16 @@
 9693	ghostly electrified tinsel tights of the wise owl	0		Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-01"
 9694	gravedigger's crafty dance instructor's wad of used tape	0		Experience Percent (Moxie): +10, Maximum MP: +10, Spooky Damage: +10, Last Available: "2018-01"
 9695	olive squat scorching vibrating curative savvy silent nightlight	0		Mysticality Percent: +20, Maximum MP Percent: +10, Hot Damage: +25, HP Regen Min: 3, HP Regen Max: 5
-9696	pickled oxidized yellow jittery sweetened reindeer fat	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 63
+9696	pickled oxidized jittery yellow sweetened reindeer fat	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 63
 9697	quantum tarnished gray Good 'n' Quiet	0		Effect: "Broken Fast", Effect Duration: 22
 9698	alkaline ghostly hot button candy	0		Effect: "Jacked In", Effect Duration: 21
 9699	lime green veiny steel-toed beefy makeshift garbage shirt	0		Muscle: +10, Damage Reduction: 9, Maximum HP: +10, Last Available: "2018-01"
 9700	energetic stiffened novelty monorail ticket	0		Damage Reduction: 1, Maximum MP Percent: +20
 9701	powdered pills	1		Effect: "Hella Smooth", Effect Duration: 5
 9702	pickled furry pill	1		Effect: "Uncucumbered", Effect Duration: 30
-9703	distilled gray ghostly beefy pill	1		
+9703	distilled ghostly gray beefy pill	1		
 9704	compressed excitement pill	1		
-9705	vaporized shaking spinning vitamin G pill	1		
+9705	vaporized spinning shaking vitamin G pill	1		
 9706	diluted upside-down lucky-ish pill	1		Effect: "Afternoon Insight", Effect Duration: 20
 9707	compressed dieting pill	1		Effect: "Ode to Booze", Effect Duration: 25
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
@@ -9593,7 +9593,7 @@
 9725	beefy psychic's pslacks of horror	0		Muscle: +10, Spooky Spell Damage: +25, Last Available: "2018-02"
 9726	avaricious toasty psychic's amulet	0		Hot Damage: +5, Meat Drop: +30, Last Available: "2018-02"
 9727	delicious heart-shaped candy whetstone	4	awesome	Last Available: "2018-02"
-9728	half-sized moldy Swedish massage fish	2	crappy	Last Available: "2018-02"
+9728	moldy half-sized Swedish massage fish	2	crappy	Last Available: "2018-02"
 9729	mediocre Third Base	4	decent	Last Available: "2018-02"
 9730	artisanal Bustle Hustler	4	EPIC	Last Available: "2018-02"
 9731	irradiated alkaline blurry Fabiotion	0		Effect: "Shortened", Effect Duration: 25, Last Available: "2018-02"
@@ -9605,7 +9605,7 @@
 9737	eaves droppers	0		Last Available: "2018-02"
 9738	blurry personal graffiti kit	0		Last Available: "2018-02"
 9739	Mysterious Red Box	0		Last Available: "2018-02"
-9740	squat twirling Mysterious Green Box	0		Last Available: "2018-02"
+9740	twirling squat Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	Mysterious Black Box	0		Last Available: "2018-02"
 9743	nitrogenated rainbow jellybean	0		Effect: "Wintry Breath", Effect Duration: 54
@@ -9632,7 +9632,7 @@
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
-9767	lime green skewed Pillowbug	0		Last Available: "2018-03"
+9767	skewed lime green Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
 9770	Carpricorn	0		Last Available: "2018-03"
@@ -9645,7 +9645,7 @@
 9777	jittery Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
 9779	Gorillape	0		Last Available: "2018-03"
-9780	cyan shaking wobbly Wendtigo	0		Last Available: "2018-03"
+9780	wobbly cyan shaking Wendtigo	0		Last Available: "2018-03"
 9781	Snoutlet	0		Last Available: "2018-03"
 9782	Ruffalo	0		Last Available: "2018-03"
 9783	Vaporpoise	0		Last Available: "2018-03"
@@ -9664,11 +9664,11 @@
 9796	Ungulant	0		Last Available: "2018-03"
 9797	bouncing Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
-9799	jittery narrow Amanitee	0		Last Available: "2018-03"
+9799	narrow jittery Amanitee	0		Last Available: "2018-03"
 9800	squat Smashmoth	0		Last Available: "2018-03"
 9801	Vulgure	0		Last Available: "2018-03"
 9802	Squib	0		Last Available: "2018-03"
-9803	blue narrow twirling Trafikoan	0		Last Available: "2018-03"
+9803	twirling blue narrow Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
 9805	twirling twirling Shudder	0		Last Available: "2018-03"
 9806	Glamare	0		Last Available: "2018-03"
@@ -9694,7 +9694,7 @@
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
 9828	pickled spinning magnificent oyster egg	1		Effect: "Ninja, Please", Effect Duration: 45
-9829	vaporized fuchsia shaking brilliant oyster egg	1		Effect: "Goldentongue", Effect Duration: 30
+9829	vaporized shaking fuchsia brilliant oyster egg	1		Effect: "Goldentongue", Effect Duration: 30
 9830	mixed teal glistening oyster egg	1		Effect: "Berry Thorny", Effect Duration: 15
 9831	twisted scintillating oyster egg	1		
 9832	denatured tumbling pearlescent oyster egg	1		
@@ -9727,9 +9727,9 @@
 9859	cyan LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	huge LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	bite-sized normal FantasyRealm turkey leg	1	good	Last Available: "2018-04"
-9863	hand-crafted weak FantasyRealm mead	2	EPIC	Last Available: "2018-04"
-9864	spinning shaking nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
+9862	normal bite-sized FantasyRealm turkey leg	1	good	Last Available: "2018-04"
+9863	weak hand-crafted FantasyRealm mead	2	EPIC	Last Available: "2018-04"
+9864	shaking spinning nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9763,10 +9763,10 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	wobbly notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	smooth practically non-alcoholic two meat muck	1	awesome	
+9898	practically non-alcoholic smooth two meat muck	1	awesome	
 9899	delicious chocolate Ogre Chieftain	3	awesome	
-9900	thick moldy chocolate &quot;Phoenix&quot;	5	crappy	
-9901	bland super-sized bouncing chocolate Spider Queen	5	decent	
+9900	moldy thick chocolate &quot;Phoenix&quot;	5	crappy	
+9901	super-sized bland bouncing chocolate Spider Queen	5	decent	
 9902	bad hipster cocktail	3	decent	
 9903	narrow God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
 9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
@@ -9781,7 +9781,7 @@
 9913	glued A-Boo clue	0		
 9914	bouncing crude oil congealer	0		
 9915	rotten massive good guava	9	crappy	
-9916	high-proof tolerable gin and ginger	10	good	
+9916	tolerable high-proof gin and ginger	10	good	
 9917	Thwaitgold chigger statuette	0		
 9918	compressed jittery gaseous gravy	1		
 9919	spinning SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9789,7 +9789,7 @@
 9921	A Guide to Safari	0		Skill: "Experience Safari"
 9922	Vulcanized energized twirling Shielding Potion	0		Effect: "Stinking Cloud", Effect Duration: 28, Last Available: "2018-06"
 9923	colloidal mirror gray Punching Potion	0		Effect: "Tasting the Rainbow", Effect Duration: 46, Last Available: "2018-06"
-9924	jittery wobbly Special Seasoning	0		Last Available: "2018-06"
+9924	wobbly jittery Special Seasoning	0		Last Available: "2018-06"
 9925	mixed Nightmare Fuel	1		Last Available: "2018-06"
 9926	blurry lime green Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
@@ -9822,13 +9822,13 @@
 9954	censurious dorky glasses of Gandalf	0		Spell Critical Percent: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2018-09"
 9955	padded ponytail clip of Calamity Jane	0		Damage Absorption: +20, Critical Hit Percent: +15, Last Available: "2018-09"
 9956	blinking olive deadly paint palette	0		Weapon Damage: +5, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
-9957	huge narrow unremarkable duffel bag	0		Last Available: "2018-09"
+9957	narrow huge unremarkable duffel bag	0		Last Available: "2018-09"
 9958	distilled jittery Purple Beast energy drink	1		Effect: "Slippery Tongue", Effect Duration: 45, Last Available: "2018-09"
 9959	cosmetic football of chilblains	0		Cold Damage: +25, Last Available: "2018-09"
 9960	yellow wholesome Herculean shoe ad T-shirt	0		Experience (Muscle): +1, Maximum HP Percent: +10, Last Available: "2018-09"
 9961	squat therapeutic pump-up high-tops	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-09"
 9962	tarnished dry runproof mascara	0		Effect: "You Can Taste the Darkness", Effect Duration: 66, Last Available: "2018-09"
-9963	wobbly tumbling very small dress	0		Last Available: "2018-09"
+9963	tumbling wobbly very small dress	0		Last Available: "2018-09"
 9964	supercool noticeable pumps of the businessman	0		Moxie Percent: +20, Meat Drop: +50, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
 9966	perfectly mixed maroon everfull glass	3		Last Available: "2018-09"
@@ -9837,7 +9837,7 @@
 9969	greasy razor-sharp denim jacket	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +10, Last Available: "2018-09"
 9970	squat asbestos-lined energetic ratty knitted cap	0		Maximum MP Percent: +20, Hot Resistance: +5, Last Available: "2018-09"
 9972	groovy intimidating chainsaw of bravery	0		Moxie Percent: +10, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2018-09"
-9973	weak perfectly mixed party beer bomb	2	EPIC	Last Available: "2018-09"
+9973	perfectly mixed weak party beer bomb	2	EPIC	Last Available: "2018-09"
 9974	normal half-sized sweet party mix	2	good	Last Available: "2018-09"
 9975	modified jittery party balloon	1		Last Available: "2018-09"
 9976	teal crafty energetic party pants	0		Maximum MP Percent: +20, Maximum MP: +10, Last Available: "2018-09"
@@ -9873,7 +9873,7 @@
 10007	deadly smartaleck's wizardly mutant arm	0		Mysticality: +25, Moxie Percent: +30, Weapon Damage: +5, Last Available: "2018-11"
 10008	therapeutic dangerous mutant legs of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-11"
 10009	prompt deadly supercool mutant crown	0		Moxie Percent: +20, Weapon Damage: +5, Adventures: +3, Last Available: "2018-11"
-10010	immense enchanted spoiled spinning ghostly ectoplasm	6	crappy	Effect: "Glittering Eyelashes", Effect Duration: 20, Last Available: "2018-11"
+10010	spoiled enchanted immense spinning ghostly ectoplasm	6	crappy	Effect: "Glittering Eyelashes", Effect Duration: 20, Last Available: "2018-11"
 10011	stale squat	4	decent	Last Available: "2018-11"
 10012	lousy bottle of vodka	3	decent	Last Available: "2018-11"
 10013	normal squat pizza	3	good	Last Available: "2018-11"
@@ -9882,11 +9882,11 @@
 10016	bad upside-down eggnog	3	decent	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	stale bite-sized Hell ramen	1	decent	Last Available: "2018-11"
-10019	watered-down artisanal gimlet	2	super ultra EPIC	Last Available: "2018-11"
+10019	artisanal watered-down gimlet	2	super ultra EPIC	Last Available: "2018-11"
 10020	acceptable twice-haunted screwdriver	4	good	Last Available: "2018-11"
 10021	delicious candy cane	3	awesome	Last Available: "2018-12"
 10022	drinkable huge runny fermented egg	3	good	Last Available: "2018-12"
-10023	adequate jittery purple oldcake	4	good	Last Available: "2018-12"
+10023	adequate purple jittery oldcake	4	good	Last Available: "2018-12"
 10024	moldy huge traditional Crimbo cookie	7	crappy	Last Available: "2023-06"
 10025	gravedigger's plastic wild beaver	0		Spooky Damage: +10, Last Available: "2018-12"
 10026	Newton's plastic reindeer	0		Experience (Mysticality): +3, Last Available: "2018-12"
@@ -9903,18 +9903,18 @@
 10037	bouncing plastic bazooka	0		Last Available: "2018-12"
 10038	wobbly mooseflank	0		Last Available: "2018-12"
 10039	spoiled jittery grilled mooseflank	3	crappy	Last Available: "2018-12"
-10040	small flavorless moosemeat pie	2	decent	Last Available: "2018-12"
+10040	flavorless small moosemeat pie	2	decent	Last Available: "2018-12"
 10041	blurry deadly balanced antler	0		Weapon Damage: +5, Last Available: "2018-12"
 10042	coward's dam	0		Monster Level: -20, Damage Reduction: 9, Last Available: "2018-12"
 10043	watered-down smooth beavermouth	2	awesome	Last Available: "2018-12"
 10044	tolerable irresponsibly strong fuchsia beaver punch (papaya)	9	good	Last Available: "2018-12"
-10045	acceptable triple-distilled pulsating beaver punch (peach)	6	good	Last Available: "2018-12"
+10045	triple-distilled acceptable pulsating beaver punch (peach)	6	good	Last Available: "2018-12"
 10046	boozy delicious beaver punch (cherry)	5	awesome	Last Available: "2018-12"
 10047	narrow narrow reassuring Canadian lantern of terror	0		Spooky Spell Damage: +10, Spooky Resistance: +1, Last Available: "2018-12"
 10048	olive personal trainer's muskox-skin cap	0		Experience Percent (Muscle): +10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	bite-sized tasty glass of raw eggs	1	awesome	Last Available: "2018-12"
-10051	smooth watered-down tumbling punch-drunk punch	2	awesome	Last Available: "2018-12"
+10050	tasty bite-sized glass of raw eggs	1	awesome	Last Available: "2018-12"
+10051	watered-down smooth tumbling punch-drunk punch	2	awesome	Last Available: "2018-12"
 10052	boiled jittery body spradium	1		Last Available: "2018-12"
 10053	bauxite beret of the glutton	0		Food Drop: +100, Last Available: "2018-12"
 10054	baleful bauxite boxers	0		Spell Damage: +25, Last Available: "2018-12"
@@ -9923,17 +9923,17 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	huge aromatic Tesla padded weightlifter's Kramco Sausage-o-Matic&trade; of temperance	0		Muscle: +15, Damage Absorption: +20, Stench Resistance: +1, Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-01"
 10059	ghostly sausage casing	0		Last Available: "2019-01"
-10060	small flavorless spinning sausage	2	decent	Last Available: "2019-01"
+10060	flavorless small spinning sausage	2	decent	Last Available: "2019-01"
 10061	supercool stylish red-hot sausage fork	0		Moxie: +25, Moxie Percent: +20, Last Available: "2019-01"
 10062	jittery bag of sausage links	0		Last Available: "2019-01"
 10063	teal sausage golem	0		Last Available: "2019-01"
 10064	blinking jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	delicious beer	4	awesome	Last Available: "2018-12"
-10067	adequate half-sized yule gruel	2	good	Last Available: "2018-12"
-10068	fortified lousy hot watered rum	5	decent	Last Available: "2018-12"
-10069	acceptable enchanted gray squat bottle of Crimbognac	3	good	Effect: "Pharmaceutically Cool", Effect Duration: 45, Last Available: "2018-12"
-10070	massive bland narrow Crimboysters Rockefeller	6	decent	Last Available: "2018-12"
+10067	half-sized adequate yule gruel	2	good	Last Available: "2018-12"
+10068	lousy fortified hot watered rum	5	decent	Last Available: "2018-12"
+10069	acceptable enchanted squat gray bottle of Crimbognac	3	good	Effect: "Pharmaceutically Cool", Effect Duration: 45, Last Available: "2018-12"
+10070	bland massive narrow Crimboysters Rockefeller	6	decent	Last Available: "2018-12"
 10071	dehydrated Crimbeau de toilette	1		Last Available: "2018-12"
 10072	ghostly Crimbo candle	0		Last Available: "2018-12"
 10073	upside-down Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9968,14 +9968,14 @@
 10102	padded smartaleck's palazzos	0		Moxie Percent: +30, Damage Absorption: +20, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10103	asbestos-lined pseudoaccordion of the dark arts	0		Spell Damage Percent: +100, Hot Resistance: +5, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	altered gray pieces	1		Last Available: "2020-12"
-10105	irradiated vacuum-sealed pulsating blinking Para-Pop	0		Effect: "Your Favorite Flavor", Effect Duration: 37
+10105	irradiated vacuum-sealed blinking pulsating Para-Pop	0		Effect: "Your Favorite Flavor", Effect Duration: 37
 10106	scorching chilly terra cotta truss	0		Cold Damage: +5, Hot Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10107	teal rosewater-soaked thinker's terra cotta trousers	0		Mysticality: +10, Stench Resistance: +3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10108	lard-coated careful terra cotta tongs	0		Monster Level: -10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10109	resourceful terra cotta train of the pedagogue	0		Experience: +3, Maximum MP: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10110	huge censurious veiny terra cotta tie tack	0		Maximum HP: +10, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10111	lightning-fast sage terra cotta tambourine	0		Mysticality Percent: +10, Initiative: +40, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10112	diluted blinking twirling huge terra cotta tidbits	1		Effect: "Butt-Rock Hair", Effect Duration: 40, Last Available: "2020-12"
+10112	diluted twirling huge blinking terra cotta tidbits	1		Effect: "Butt-Rock Hair", Effect Duration: 40, Last Available: "2020-12"
 10113	dry deionized ghostly terra panna cotta	0		Effect: "You're High as a Crow, Marty", Effect Duration: 22
 10114	squat studded Newton's velour voulge	0		Experience (Mysticality): +3, Damage Absorption: +80, Last Available: "2021-12"
 10115	stanky shellacked velour vambraces	0		Damage Reduction: 7, Stench Spell Damage: +25, Single Equip, Last Available: "2021-12"
@@ -10012,7 +10012,7 @@
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	olive red-and-green microcamera	0		Familiar Weight: +5
 10148	cobbled-together Meat detector of the storm	0		Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2019-12"
-10149	unsweetened cold-filtered ghostly bouncing tin thermos of chai	0		Effect: "Go-Gone", Effect Duration: 68, Last Available: "2019-12"
+10149	unsweetened cold-filtered bouncing ghostly tin thermos of chai	0		Effect: "Go-Gone", Effect Duration: 68, Last Available: "2019-12"
 10150	altered prototype stimulant	1		Effect: "Bloody Bloody Bloody!", Effect Duration: 20, Last Available: "2019-12"
 10151	shaking MacGyver's tailored vest	0		Maximum MP: +100, Lasts Until Rollover, Last Available: "2019-12"
 10152	green sew-on bandage	0		Last Available: "2019-12"
@@ -10028,24 +10028,24 @@
 10162	polarized mutated candy lump	0		Effect: "Tingly Wrists", Effect Duration: 30
 10163	warmed jittery government-issued candy	0		Effect: "Elemental Mastery", Effect Duration: 54
 10164	triple-chilled energized pressed jittery Pneumo bar	0		Effect: "Intimidating Mien", Effect Duration: 14
-10165	narrow maroon mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
+10165	maroon narrow mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	wobbly thinker's Lil' Doctor&trade; bag of wisdom	0		Mysticality: 25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	huge blood bag	0		
 10169	normal bloodstick	3	good	
 10170	lousy bottle of Sanguiovese	4	decent	
 10171	normal pulsating actual blood sausage	3	good	
 10172	hand-crafted mulled blood	3	EPIC	
-10173	super-sized stale blood snowcone	5	decent	
+10173	stale super-sized blood snowcone	5	decent	
 10174	fancy bad Red Russian	3	decent	Effect: "Improved Candy Vision", Effect Duration: 25
 10175	bland blood roll-up	4	decent	
 10176	delicious weak bottle of blood	2	awesome	
-10177	moldy special blood-soaked sponge cake	3	crappy	Effect: "Paging Betty", Effect Duration: 15
+10177	special moldy blood-soaked sponge cake	3	crappy	Effect: "Paging Betty", Effect Duration: 15
 10178	hand-crafted watered-down cyan vampagne	2	super ultra mega turbo EPIC	
 10179	yummy plain snowcone	4	awesome	
 10180	squat Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
-10183	narrow yellow twirling money bag	0		
+10183	yellow narrow twirling money bag	0		
 10184	Thwaitgold mosquito statuette	0		
 10185	pulsating bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
@@ -10064,9 +10064,9 @@
 10199	spoiled crabsicle	3	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	watered-down mediocre teal upside-down narrow bottle of dark rhum	2	decent	Last Available: "2019-04"
-10202	acceptable weak bottle of extra-dark rhum	2	good	Last Available: "2019-04"
+10202	weak acceptable bottle of extra-dark rhum	2	good	Last Available: "2019-04"
 10203	bad bottle of super-extra-dark rhum	4	decent	Last Available: "2019-04"
-10204	super-adjusted lime green tumbling pirate shaving cream	0		Effect: "20/20 Vision", Effect Duration: 19, Last Available: "2019-04"
+10204	super-adjusted tumbling lime green pirate shaving cream	0		Effect: "20/20 Vision", Effect Duration: 19, Last Available: "2019-04"
 10205	wool conquistador's breastplate of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +1, Last Available: "2019-04"
 10206	greasy pirate pantaloons of the wise owl	0		Mysticality: +20, Sleaze Spell Damage: +10, Last Available: "2019-04"
 10207	lime green [glitch season reward name]	0		
@@ -10078,7 +10078,7 @@
 10213	yummy spinning hibiscus petal	3	awesome	Last Available: "2019-04"
 10214	irradiated mirror huge mint leaf	0		Effect: "Rushtacean'", Effect Duration: 27, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
-10216	diluted gray narrow ice molecule	1		Last Available: "2019-04"
+10216	diluted narrow gray ice molecule	1		Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
@@ -10094,21 +10094,21 @@
 10229	bouncing ring	0		Single Equip, Last Available: "2019-04"
 10230	green aromatic double-paned piratical blunderbuss	0		Cold Resistance: +5, Stench Resistance: +1, Last Available: "2019-04"
 10231	energetic rock-hard PirateRealm party hat of James Dean	0		Experience (Moxie): +3, Damage Reduction: 5, Maximum MP Percent: +20, Last Available: "2019-04"
-10232	bad watered-down Island Landslide	2	decent	Last Available: "2019-04"
-10233	acceptable weak special blinking Island Thunderstorm	2	good	Effect: "Larger", Effect Duration: 25, Last Available: "2019-04"
-10234	smooth weak narrow gray Island Hurricane	2	awesome	Last Available: "2019-04"
+10232	watered-down bad Island Landslide	2	decent	Last Available: "2019-04"
+10233	acceptable special weak blinking Island Thunderstorm	2	good	Effect: "Larger", Effect Duration: 25, Last Available: "2019-04"
+10234	smooth weak gray narrow Island Hurricane	2	awesome	Last Available: "2019-04"
 10235	tolerable Skull Punch	4	good	Last Available: "2019-04"
-10236	hand-crafted triple-distilled fancy jittery Electric Punch	6	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 45, Last Available: "2019-04"
-10237	hand-crafted strong special Smuggler's Punch	5	EPIC	Effect: "Aided and Abetted", Effect Duration: 30, Last Available: "2019-04"
+10236	fancy hand-crafted triple-distilled jittery Electric Punch	6	EPIC	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 45, Last Available: "2019-04"
+10237	strong hand-crafted special Smuggler's Punch	5	EPIC	Effect: "Aided and Abetted", Effect Duration: 30, Last Available: "2019-04"
 10238	perfectly mixed Scorpion Bowl	3	super EPIC	Last Available: "2019-04"
 10239	lousy Turtle Bowl	4	decent	Last Available: "2019-04"
 10240	drinkable olive huge Cobra Bowl	3	good	Last Available: "2019-04"
 10241	tumbling vampyric cloake pattern	0		Free Pull
 10242	nippy manspreader's sage slick vampyric cloake of the storm	0		Moxie: +10, Mysticality Percent: +10, Maximum MP Percent: +40, Monster Level: +10, Cold Damage: +10, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	blinking plastic pirate hat	0		Familiar Weight: +5
-10244	energized huge maroon one piece of bubble gum	0		Effect: "Devil Inside", Effect Duration: 69
+10244	energized maroon huge one piece of bubble gum	0		Effect: "Devil Inside", Effect Duration: 69
 10245	wobbly olive arcanoferric housing	0		
-10246	teal shaking intact medium-wave antenna	0		
+10246	shaking teal intact medium-wave antenna	0		
 10247	18-picohertz resonator crystal	0		
 10248	squat blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
@@ -10152,7 +10152,7 @@
 10287	chilly manspreader's electrified meteorite necklace	0		Monster Level: +10, Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2019-07"
 10288	asbestos-lined arcane researcher's meteorite ring	0		Experience Percent (Mysticality): +10, Hot Resistance: +5, Item Drop: +5, Single Equip, Last Available: "2019-07"
 10289	modified Finnish Fish	0		Effect: "Pasty", Effect Duration: 37
-10290	dry magnetized tumbling teal chocolate doubloon	0		Effect: "Always In Motion", Effect Duration: 41
+10290	dry magnetized teal tumbling chocolate doubloon	0		Effect: "Always In Motion", Effect Duration: 41
 10291	careful manspreader's driftwood beach comb of the cougar	0		Moxie: +20, Monster Level: 0, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
 10292	Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	stick of firewood	0		Last Available: "2019-08"
@@ -10167,9 +10167,9 @@
 10302	lion tamer's hardy boxer's strapping whittled walking stick	0		Muscle: +5, Muscle Percent: +10, Maximum HP: +50, Experience (familiar): +2, Last Available: "2019-08"
 10303	bland campfire hot dog	3	decent	Last Available: "2019-08"
 10304	decent campfire baked potato	3	good	Last Available: "2019-08"
-10305	massive moldy blinking twirling campfire s'more	10	crappy	Last Available: "2019-08"
-10306	bite-sized normal campfire beans	1	good	Last Available: "2019-08"
-10307	miniature enchanted stale campfire stew	2	decent	Effect: "BOOsted", Effect Duration: 50, Last Available: "2019-08"
+10305	massive moldy twirling blinking campfire s'more	10	crappy	Last Available: "2019-08"
+10306	normal bite-sized campfire beans	1	good	Last Available: "2019-08"
+10307	miniature stale enchanted campfire stew	2	decent	Effect: "BOOsted", Effect Duration: 50, Last Available: "2019-08"
 10308	campfire coffee	1	crappy	Last Available: "2019-08"
 10309	ionized dry leftover chocolate bar	0		Effect: "Sweet Incentive", Effect Duration: 29
 10310	rare Meat isotope	0		
@@ -10179,7 +10179,7 @@
 10314	yellow Murgatroyd diode	0		
 10315	signal receiver	0		
 10316	blinking squat space shield	0		Damage Reduction: 9
-10317	teal shaking signal jammer	0		Single Equip
+10317	shaking teal signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
 10320	stale small space chowder	2	decent	
@@ -10201,10 +10201,10 @@
 10342	lard-coated plastic yuleviathan	0		Sleaze Spell Damage: +25, Last Available: "2019-12"
 10343	blurry plastic dolphin &quot;orphan&quot; of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2019-12"
 10344	mirror brainy plastic Dolph Bossin	0		Mysticality: +5, Last Available: "2019-12"
-10345	jittery narrow shaking red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	normal special maroon blurry mana-coated yams	3	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15, Last Available: "2019-11"
+10345	narrow jittery shaking red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
+10346	special normal maroon blurry mana-coated yams	3	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 15, Last Available: "2019-11"
 10347	normal purple mana-basted tofurkey leg	4	good	Last Available: "2019-11"
-10348	fancy small bland mana-fortified cranberry sauce	2	decent	Effect: "Healthy Red Glow", Effect Duration: 40, Last Available: "2019-11"
+10348	small fancy bland mana-fortified cranberry sauce	2	decent	Effect: "Healthy Red Glow", Effect Duration: 40, Last Available: "2019-11"
 10349	immense spoiled special spinning mana-stuffed herbal stuffing	7	crappy	Effect: "Inner Dog", Effect Duration: 40, Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	anodized Vulcanized patch of extra-warm fur	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2019-12"
@@ -10212,7 +10212,7 @@
 10353	pressed concentrated altered shaking unfinished pleasure	0		Effect: "Litterboxing", Effect Duration: 14, Last Available: "2019-12"
 10354	compressed jittery vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	pickled a bug's lymph	1		Last Available: "2019-12"
-10356	ionized jittery red narrow organic potpourri	0		Effect: "Meadulla Oblongota", Effect Duration: 64, Last Available: "2019-12"
+10356	ionized red narrow jittery organic potpourri	0		Effect: "Meadulla Oblongota", Effect Duration: 64, Last Available: "2019-12"
 10357	hand-crafted boot flask	3	EPIC	Last Available: "2019-12"
 10358	oxidized infernal snowball	0		Effect: "Stop and Smell the Fudge", Effect Duration: 66, Last Available: "2019-12"
 10359	jittery madness	0		Last Available: "2019-12"
@@ -10255,7 +10255,7 @@
 10396	tinsel fin	0		Familiar Weight: +5
 10397	tasty bowl of mernudo	3	awesome	Last Available: "2019-12"
 10398	tolerable blurry fishelada	4	good	Last Available: "2019-12"
-10399	moldy snack-sized mirror ojo de pez burrito	2	crappy	Last Available: "2019-12"
+10399	snack-sized moldy mirror ojo de pez burrito	2	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	purple waterlogged stuffing	0		Last Available: "2019-12"
@@ -10281,12 +10281,12 @@
 10422	wizardly Crimbylow-rise jeans of dire peril	0		Mysticality: +25, Weapon Damage: +20, Last Available: "2019-12"
 10423	narrow steel-toed kelp-holly drape of temperance	0		Damage Reduction: 9, Sleaze Resistance: +5, Last Available: "2019-12"
 10424	wholesome beefy Staff of the Peppermint Twist of the sewer of the detective	0		Muscle: +10, Maximum HP Percent: +10, Stench Damage: +25, Item Drop: +20, Last Available: "2019-12"
-10425	enchanted moldy twirling tempura and bean	4	crappy	Effect: "Physicali Tea", Effect Duration: 45, Last Available: "2019-12"
+10425	moldy enchanted twirling tempura and bean	4	crappy	Effect: "Physicali Tea", Effect Duration: 45, Last Available: "2019-12"
 10426	smooth salt plum sake	3	awesome	Last Available: "2019-12"
 10427	unsweetened fuchsia pressurized potion of possessiveness	0		Effect: "Chunky", Effect Duration: 44, Last Available: "2019-12"
 10428	cold-filtered dry skewed almond	0		Effect: "The Style... of the Future", Effect Duration: 18
 10429	altered handful of mixed nuts	0		Effect: "Chorale of Companionship", Effect Duration: 12, Last Available: "2019-12"
-10430	huge gray blinking nutcracking pliers	0		
+10430	huge blinking gray nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	mansplainer's sinister arcane researcher's Retrospecs	0		Experience Percent (Mysticality): +10, Spell Damage: +10, Monster Level: +15, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
@@ -10345,8 +10345,8 @@
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
 10489	miniature toothsome mushroom filet	2	awesome	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
-10491	altered shaking olive tumbling mushroom tea	1		Last Available: "2020-03"
-10492	strong lousy mushroom whiskey	5	decent	Last Available: "2020-03"
+10491	altered olive tumbling shaking mushroom tea	1		Last Available: "2020-03"
+10492	lousy strong mushroom whiskey	5	decent	Last Available: "2020-03"
 10493	shellacked mushroom cap of the cheetah of Flo-Jo	0		Damage Reduction: 7, Initiative: 160, Last Available: "2020-03"
 10494	twirling fuchsia dog trainer's Herculean smooth mushroom shield of the detective	0		Moxie: +15, Experience (Muscle): +1, Experience (familiar): +1, Item Drop: +20, Damage Reduction: 6, Last Available: "2020-03"
 10495	narrow cyan perfumed lard-coated Temple Grandin's healthy mushroom pants	0		Maximum HP Percent: +20, Familiar Weight: +7, Sleaze Spell Damage: +25, Stench Resistance: +5, Last Available: "2020-03"
@@ -10356,7 +10356,7 @@
 10499	plastic piranha pot	0		Familiar Weight: +5
 10500	ionized dry olive piranha pollen	0		Effect: "Certainty", Effect Duration: 38, Last Available: "2020-03"
 10501	spinning plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
-10502	jittery huge sinistral homunculus	0		Free Pull, Last Available: "2020-04"
+10502	huge jittery sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	beefcake's kettle bell	0		Muscle: +25, Last Available: "2020-04"
 10504	wicked glued-together crystal ball	0		Spell Damage: +5, Last Available: "2020-04"
 10505	blue dance instructor's martini dregs	0		Experience Percent (Moxie): +10, Last Available: "2020-04"
@@ -10370,7 +10370,7 @@
 10513	bouncing flame-retardant Left-Hand Man action figure	0		Hot Resistance: +1, Last Available: "2020-04"
 10514	twirling drippy seed	0		
 10515	drippy grub	0		
-10516	olive jittery drippy bezoar	0		
+10516	jittery olive drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	drippy ichor	0		
 10519	drippy enzyme	0		
@@ -10388,7 +10388,7 @@
 10532	Guzzlr application	0		Free Pull
 10533	quilted Guzzlr tablet of the detective	0		Damage Absorption: +40, Item Drop: +20, Last Available: "2020-05"
 10534	upside-down Guzzlr cocktail set	0		Last Available: "2020-05"
-10535	gray skewed Guzzlrbuck	0		Last Available: "2020-05"
+10535	skewed gray Guzzlrbuck	0		Last Available: "2020-05"
 10536	Guzzlr hat	0		Last Available: "2020-05"
 10537	spinning Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	lime green blurry Guzzlr pants	0		Last Available: "2020-05"
@@ -10396,9 +10396,9 @@
 10540	wobbly Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	tolerable weak shaking Ghiaccio Colada	2	good	Last Available: "2020-05"
 10542	drinkable watered-down Sourfinger	2	good	Last Available: "2020-05"
-10543	tolerable strong Nog-on-the-Cob	5	good	Last Available: "2020-05"
+10543	strong tolerable Nog-on-the-Cob	5	good	Last Available: "2020-05"
 10544	perfectly mixed Steamboat	3	EPIC	Last Available: "2020-05"
-10545	smooth watered-down Buttery Boy	2	awesome	Last Available: "2020-05"
+10545	watered-down smooth Buttery Boy	2	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	blinking Socratic clown car key of the storm	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Last Available: "2020-08"
 10548	blurry sizzling extremely unsafe deadly batting cage key	0		Weapon Damage: +5, Weapon Damage Percent: +100, Hot Damage: +10, Last Available: "2020-08"
@@ -10427,7 +10427,7 @@
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	magnetized marshroom	0		Effect: "Engorged Weapon", Effect Duration: 69
 10573	bag of Iunion stones	0		Free Pull
-10574	blurry yellow Iunion Crown	0		Last Available: "2020-06"
+10574	yellow blurry Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	ionized salty drippy candy bar	0		Effect: "Nature's Bounty", Effect Duration: 36
 10577	ionized quadruple-colloidal writhing drippy candy bar	0		Effect: "Angry Bone", Effect Duration: 19
@@ -10484,19 +10484,19 @@
 10628	onyx pawn	0		Last Available: "2020-09"
 10629	alabaster king	0		Last Available: "2020-09"
 10630	jittery alabaster queen	0		Last Available: "2020-09"
-10631	jittery tumbling alabaster rook	0		Last Available: "2020-09"
+10631	tumbling jittery alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
 10633	jittery alabaster knight	0		Last Available: "2020-09"
 10634	alabaster pawn	0		Last Available: "2020-09"
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	pulsating pulsating arcane researcher's wizardly Cargo Cultist Shorts of courage of bravery	0		Mysticality: +25, Experience Percent (Mysticality): +10, Spooky Resistance: 8, Last Available: "2020-09"
-10637	narrow red complicated device	0		Last Available: "2020-09"
+10637	red narrow complicated device	0		Last Available: "2020-09"
 10638	acceptable weak flask of moonshine	2	good	Last Available: "2020-09"
 10639	jittery lion tamer's Tesla sea-worn candlestick of the cougar	0		Moxie: +20, Experience (familiar): +2, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	oxidized concentrated null-day exploit	0		Effect: "Sparkly!", Effect Duration: 17, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	stale snack-sized chocolate chip muffin	2	decent	
+10643	snack-sized stale chocolate chip muffin	2	decent	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	purple Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10506,7 +10506,7 @@
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
-10653	super-unsweetened maroon pulsating fortifying hot cocoa	0		Effect: "Scorpio Rising", Effect Duration: 49, Last Available: "2020-12"
+10653	super-unsweetened pulsating maroon fortifying hot cocoa	0		Effect: "Scorpio Rising", Effect Duration: 49, Last Available: "2020-12"
 10654	nitrogenated boiling hot cocoa	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 18, Last Available: "2020-12"
 10655	deionized mirror cool hot cocoa	0		Effect: "Engorged Weapon", Effect Duration: 52, Last Available: "2020-12"
 10656	oxidized polarized olive overly-fancy hot cocoa	0		Effect: "Stands Alone", Effect Duration: 56, Last Available: "2020-12"
@@ -10525,7 +10525,7 @@
 10669	boxer's plastic Penny	0		Muscle Percent: +10, Last Available: "2020-12"
 10670	overflowing gift basket	0		Last Available: "2020-12"
 10671	personalized wassail stein	0		Last Available: "2020-12"
-10672	gray jittery tabletop candy dispenser	0		Last Available: "2020-12"
+10672	jittery gray tabletop candy dispenser	0		Last Available: "2020-12"
 10673	lime green supercool neck wreath	0		Moxie Percent: [+20*event(December)], Single Equip, Last Available: "2020-12"
 10674	MacGyver's shining star cap	0		Maximum MP: [+100*event(December)], Last Available: "2020-12"
 10675	ruddy nativity shorts	0		Maximum HP Percent: [+40*event(December)], Last Available: "2020-12"
@@ -10536,7 +10536,7 @@
 10680	blurry stiffened wine carrier	0		Damage Reduction: 1, Lasts Until Rollover, Last Available: "2020-12"
 10681	squat Fonzie's candy bucket	0		Experience (Moxie): +1, Lasts Until Rollover, Last Available: "2020-12"
 10682	super-adjusted prescription teeth whitener	0		Effect: "Hot Blooded", Effect Duration: 20, Last Available: "2020-12"
-10683	deionized ghostly skewed imported lemon lozenge	0		Effect: "Fudgehound", Effect Duration: 62, Last Available: "2020-12"
+10683	deionized skewed ghostly imported lemon lozenge	0		Effect: "Fudgehound", Effect Duration: 62, Last Available: "2020-12"
 10684	oxidized hermedisiac cologne	0		Effect: "Limber as Mortimer", Effect Duration: 57, Last Available: "2020-12"
 10685	tumbling government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
@@ -10569,17 +10569,17 @@
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	low-calorie stale and pepper (stale)	1	decent	Last Available: "2020-12"
-10716	practically non-alcoholic perfectly mixed cranberry margarita (brackish)	1	EPIC	Last Available: "2020-12"
+10716	perfectly mixed practically non-alcoholic cranberry margarita (brackish)	1	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	bouncing nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	boozy perfectly mixed barrel-aged eggnog	5	EPIC	Last Available: "2020-12"
+10720	perfectly mixed boozy barrel-aged eggnog	5	EPIC	Last Available: "2020-12"
 10721	spoiled special small hand-crafted candy cane	2	crappy	Effect: "Milk Studly", Effect Duration: 40, Last Available: "2020-12"
 10722	flavorless drive-thru burger	4	decent	Last Available: "2020-12"
-10723	enchanted artisanal Boulevardier cocktail	3	EPIC	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2020-12"
+10723	artisanal enchanted Boulevardier cocktail	3	EPIC	Effect: "Space Tripping", Effect Duration: 25, Last Available: "2020-12"
 10724	chilled Hotwire&trade; brand candy rope	0		Effect: "Cold Throat", Effect Duration: 67, Last Available: "2020-12"
 10725	small moldy bouncing bowl full of jelly	2	crappy	Last Available: "2020-12"
-10726	drinkable special Eye and a Twist	4	good	Effect: "Bright!", Effect Duration: 35, Last Available: "2020-12"
+10726	special drinkable Eye and a Twist	4	good	Effect: "Bright!", Effect Duration: 35, Last Available: "2020-12"
 10727	enhanced spinning squat teal Chubby and Plump bar	0		Effect: "Loyal Tea", Effect Duration: 37, Last Available: "2020-12"
 10728	blue digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10593,11 +10593,11 @@
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	shaking potted power plant	0		Last Available: "2021-03"
 10739	modified unsweetened battery (AAA)	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 31, Last Available: "2021-03"
-10740	oxidized maroon spinning battery (AA)	0		Effect: "Mystically Oiled", Effect Duration: 33, Last Available: "2021-03"
+10740	oxidized spinning maroon battery (AA)	0		Effect: "Mystically Oiled", Effect Duration: 33, Last Available: "2021-03"
 10741	extra-denatured battery (D)	0		Effect: "Moose Wisdom", Effect Duration: 44, Last Available: "2021-03"
 10742	wet battery (9-Volt)	0		Effect: "Banono", Effect Duration: 32, Last Available: "2021-03"
 10743	altered battery (lantern)	0		Effect: "Really Deep Breath", Effect Duration: 23, Last Available: "2021-03"
-10744	irradiated super-flattened tumbling huge battery (car)	0		Effect: "Weepy, Creepy", Effect Duration: 29, Last Available: "2021-03"
+10744	irradiated super-flattened huge tumbling battery (car)	0		Effect: "Weepy, Creepy", Effect Duration: 29, Last Available: "2021-03"
 10745	narrow cryptocloak	0		Last Available: "2025-12"
 10746	mirror marshmallow	0		
 10747	weak drinkable marshmallow bomb	2	good	Last Available: "2021-03"
@@ -10629,7 +10629,7 @@
 10773	Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	irradiated Scent of a Human&trade; candle	0		Effect: "Full of Wist", Effect Duration: 33, Last Available: "2021-08"
 10775	enhanced The Beast Within&trade; candle	0		Effect: "Memory of Resilience", Effect Duration: 54, Last Available: "2021-08"
-10776	flattened boiled purple blinking Salsa Caliente&trade; candle	0		Effect: "Okee-Dokee Go!", Effect Duration: 65, Last Available: "2021-08"
+10776	flattened boiled blinking purple Salsa Caliente&trade; candle	0		Effect: "Okee-Dokee Go!", Effect Duration: 65, Last Available: "2021-08"
 10777	ionized Smoldering Clover&trade; candle	0		Effect: "Rushtacean'", Effect Duration: 12, Last Available: "2021-08"
 10778	colloidal wet Napalm In The Morning&trade; candle	0		Effect: "Venomous Weapon", Effect Duration: 48, Last Available: "2021-08"
 10779	stanky extra-large utility candle of doom	0		Stench Spell Damage: +25, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2021-08"
@@ -10651,7 +10651,7 @@
 10795	pump grease	0		
 10796	narrow yellow packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
 10797	auspicious chaotic ruddy dangerous industrial fire extinguisher of wisdom of terror	0		Mysticality: +15, Weapon Damage: +10, Maximum HP Percent: +40, Spell Critical Percent: +10, Spooky Spell Damage: +10, Item Drop: +10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
-10798	wobbly jittery The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
+10798	jittery wobbly The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
 10801	fuchsia bottled Vampire Vintner	0		Free Pull, Last Available: "2021-10"
@@ -10660,8 +10660,8 @@
 10804	friendly medical-grade brawny Daylight Shavings Helmet	0		Muscle Percent: +20, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-11"
 10805	fancy eggwater	1	crappy	Effect: "Burning Hands", Effect Duration: 45, Last Available: "2021-12"
 10806	spoiled half-sized blue bread man	2	crappy	Last Available: "2021-12"
-10807	huge flavorless plain candy cane	9	decent	Last Available: "2021-12"
-10808	thick stale shaking flour cookie	5	decent	Last Available: "2021-12"
+10807	flavorless huge plain candy cane	9	decent	Last Available: "2021-12"
+10808	stale thick shaking flour cookie	5	decent	Last Available: "2021-12"
 10809	greasy plastic food lab	0		Sleaze Spell Damage: +10, Single Equip, Last Available: "2021-12"
 10810	upside-down coward's plastic nog lab	0		Monster Level: -20, Single Equip, Last Available: "2021-12"
 10811	blinking up-at-dawn plastic chem lab	0		Adventures: +5, Single Equip, Last Available: "2021-12"
@@ -10672,28 +10672,28 @@
 10816	blue manspreader's Lo Pan's curative ice crown	0		Spell Critical Percent: +30, Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2021-12"
 10817	narrow reassuring foul-smelling ruddy jeans	0		Maximum HP Percent: +40, Stench Damage: +10, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2021-12"
 10818	sharpshooter's electrified educational ice wrap	0		Experience: +1, Critical Hit Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	low-calorie flavorless blurry tofu pop	1	decent	Last Available: "2021-12"
-10820	bland gigantic huge bowl of prescription candy	8	decent	Last Available: "2021-12"
+10819	flavorless low-calorie blurry tofu pop	1	decent	Last Available: "2021-12"
+10820	gigantic bland huge bowl of prescription candy	8	decent	Last Available: "2021-12"
 10821	rotten fishcake	3	crappy	Last Available: "2021-12"
-10822	normal small bone broth	2	good	Last Available: "2021-12"
+10822	small normal bone broth	2	good	Last Available: "2021-12"
 10823	delicious star pop	3	awesome	Last Available: "2021-12"
 10824	perfectly mixed Doc's Fortifying Wine	3	EPIC	Last Available: "2021-12"
-10825	drinkable triple-distilled enchanted Doc's Smartifying Wine	10	good	Effect: "Bastard!", Effect Duration: 20, Last Available: "2021-12"
+10825	triple-distilled drinkable enchanted Doc's Smartifying Wine	10	good	Effect: "Bastard!", Effect Duration: 20, Last Available: "2021-12"
 10826	bad Doc's Limbering Wine	3	decent	Last Available: "2021-12"
 10827	weak lousy Doc's Medical-Grade Wine	2	decent	Last Available: "2021-12"
 10828	dried yellow huge Homebodyl&trade;	1		Last Available: "2021-12"
 10829	dried Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	denatured Breathitin&trade;	1		Effect: "Swimming Head", Effect Duration: 45, Last Available: "2021-12"
 10831	denatured squat Fleshazole&trade;	1		Last Available: "2021-12"
-10832	pressed twirling ghostly anti-burn cream	0		Effect: "Ginger Snapped", Effect Duration: 68, Last Available: "2021-12"
+10832	pressed ghostly twirling anti-burn cream	0		Effect: "Ginger Snapped", Effect Duration: 68, Last Available: "2021-12"
 10833	Vulcanized extra-tarnished anti-freeze cream	0		Effect: "Sleazy Jellied", Effect Duration: 64, Last Available: "2021-12"
 10834	modified cold-filtered yellow anti-goosebump cream	0		Effect: "Squirming Like a Toad", Effect Duration: 42, Last Available: "2021-12"
-10835	deionized mirror blurry anti-odor cream	0		Effect: "Crimbo Epiphany", Effect Duration: 23, Last Available: "2021-12"
+10835	deionized blurry mirror anti-odor cream	0		Effect: "Crimbo Epiphany", Effect Duration: 23, Last Available: "2021-12"
 10836	boiled quantum anti-creep cream	0		Effect: "Cookie Backup", Effect Duration: 55, Last Available: "2021-12"
-10837	super-quantum green bouncing anti-pain cream	0		Effect: "Coming Up Roses", Effect Duration: 35, Last Available: "2021-12"
+10837	super-quantum bouncing green anti-pain cream	0		Effect: "Coming Up Roses", Effect Duration: 35, Last Available: "2021-12"
 10838	hand-crafted Doc's Special Reserve Wine	3	EPIC	Last Available: "2021-12"
 10839	diet normal ghostly bread pie	1	good	Last Available: "2021-12"
-10840	acceptable weak clear Russian	2	good	Last Available: "2021-12"
+10840	weak acceptable clear Russian	2	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10711,7 +10711,7 @@
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	poisonsettia	0		Last Available: "2021-12"
 10857	blue scorching peppermint-scented socks	0		Hot Damage: +25, Last Available: "2021-12"
-10858	blue bouncing the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10858	bouncing blue the Crymbich Manuscript	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	Annie Oakley's depleted Crimbonium football helmet	0		Critical Hit Percent: +20, Last Available: "2021-12"
 10861	upside-down synthetic rock	0		Last Available: "2021-12"
@@ -10724,7 +10724,7 @@
 10868	delicious big lab-grown meat	5	awesome	Last Available: "2021-12"
 10869	jittery Annie Oakley's fleece	0		Critical Hit Percent: +20, Last Available: "2021-12"
 10870	olive boxed gumball machine	0		Last Available: "2021-12"
-10871	ghostly cyan cloning kit	0		Last Available: "2021-12"
+10871	cyan ghostly cloning kit	0		Last Available: "2021-12"
 10872	pants of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2021-12"
 10873	rosewater-soaked Jeselnik's can of mixed everything of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +25, Stench Resistance: +3, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
@@ -10765,22 +10765,22 @@
 10909	tumbling space blanket	0		Last Available: "2022-05"
 10910	oxidized pressed single-use dust mask	0		Effect: "Inappropriate Spirit", Effect Duration: 41, Last Available: "2022-05"
 10911	liquefied gaffer's tape	0		Effect: "Hot Hands", Effect Duration: 12, Last Available: "2022-05"
-10912	normal miniature twirling 20-lb can of rice and beans	2	good	Last Available: "2022-05"
+10912	miniature normal twirling 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	enchanted ghostly bar of freeze-dried water	1	crappy	Effect: "Anytwo Five Elevenis?", Effect Duration: 20, Last Available: "2022-05"
 10914	bland expired MRE	4	decent	Last Available: "2022-05"
-10915	moldy fancy cool mint precipice bar	4	crappy	Effect: "Eyes for Miles", Effect Duration: 5, Last Available: "2022-05"
+10915	fancy moldy cool mint precipice bar	4	crappy	Effect: "Eyes for Miles", Effect Duration: 5, Last Available: "2022-05"
 10916	rotten carrot cake precipice bar	4	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	gray rosewater-soaked smelly June cleaver of the dark arts	0		Spell Damage Percent: +100, Stench Spell Damage: +10, Stench Resistance: +3, Attacks Can't Miss, Last Available: "2022-06"
-10921	lousy special weak Dad's brandy	2	decent	Effect: "Meatwise", Effect Duration: 45, Last Available: "2022-06"
+10921	special lousy weak Dad's brandy	2	decent	Effect: "Meatwise", Effect Duration: 45, Last Available: "2022-06"
 10922	blinking up-at-dawn hale teacher's pen	0		Maximum HP: +20, Adventures: +5, Last Available: "2022-06"
-10923	snack-sized adequate fire-roasted lake trout	2	good	Last Available: "2022-06"
-10924	rotten tiny cyan tumbling guilty sprout	1	crappy	Last Available: "2022-06"
+10923	adequate snack-sized fire-roasted lake trout	2	good	Last Available: "2022-06"
+10924	tiny rotten cyan tumbling guilty sprout	1	crappy	Last Available: "2022-06"
 10925	Jack Frost's experienced mother's necklace	0		Experience: +2, Cold Spell Damage: +50, Last Available: "2022-06"
 10926	chilled liquefied mirror skewed trampled ticket stub	0		Effect: "Seriously Mutated", Effect Duration: 35, Last Available: "2022-06"
-10927	modified quadruple-activated green narrow huge savings bond	0		Effect: "The Halls of Mysticality", Effect Duration: 29, Last Available: "2022-06"
+10927	modified quadruple-activated green huge narrow savings bond	0		Effect: "The Halls of Mysticality", Effect Duration: 29, Last Available: "2022-06"
 10928	squat designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
 10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	mixed huge sweat-ade	1		Last Available: "2022-07"
@@ -10807,7 +10807,7 @@
 10951	wobbly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
 10952	wobbly chaotic resourceful Jurassic Parka	0		Maximum MP: +50, Spell Critical Percent: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
-10954	upside-down jittery autumn-aton	0		Last Available: "2022-10"
+10954	jittery upside-down autumn-aton	0		Last Available: "2022-10"
 10955	tarnished vacuum-sealed lime green autumn leaf	0		Effect: "Hammered", Effect Duration: 16, Last Available: "2022-10"
 10956	mediocre AutumnFest ale	3	decent	Last Available: "2022-10"
 10957	clever autumn sweater-weather sweater of the sewer of mayonnaise	0		Maximum MP: +20, Stench Damage: +25, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2022-10"
@@ -10823,14 +10823,14 @@
 10967	Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	adequate gigantic ratatouille de Jarlsberg	10	good	Last Available: "2022-11"
+10970	gigantic adequate ratatouille de Jarlsberg	10	good	Last Available: "2022-11"
 10971	decent Jarlsberg's vegetable soup	4	good	Last Available: "2022-11"
-10972	flavorless fancy half-sized roasted vegetable of Jarlsberg	2	decent	Effect: "Browbeaten", Effect Duration: 25, Last Available: "2022-11"
+10972	half-sized fancy flavorless roasted vegetable of Jarlsberg	2	decent	Effect: "Browbeaten", Effect Duration: 25, Last Available: "2022-11"
 10973	half-sized spoiled special St. Pete's sneaky smoothie	2	crappy	Effect: "Purpose", Effect Duration: 50, Last Available: "2022-11"
 10974	yummy Pete's wiley whey bar	4	awesome	Last Available: "2022-11"
-10975	immense bland Pete's rich ricotta	8	decent	Last Available: "2022-11"
+10975	bland immense Pete's rich ricotta	8	decent	Last Available: "2022-11"
 10976	bad Boris's beer	4	decent	Last Available: "2022-11"
-10977	decent super-sized honey bun of Boris	5	good	Last Available: "2022-11"
+10977	super-sized decent honey bun of Boris	5	good	Last Available: "2022-11"
 10978	stale Boris's bread	4	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
@@ -10841,7 +10841,7 @@
 10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
 10986	squat Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
 10987	twirling Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
-10988	spoiled massive upside-down baked veggie ricotta casserole	7	crappy	Last Available: "2022-11"
+10988	massive spoiled upside-down baked veggie ricotta casserole	7	crappy	Last Available: "2022-11"
 10989	delicious plain calzone	3	awesome	Last Available: "2022-11"
 10990	normal shaking shaking roasted vegetable focaccia	4	good	Last Available: "2022-11"
 10991	normal Pizza of Legend	4	good	Last Available: "2022-11"
@@ -10867,8 +10867,8 @@
 11011	stanky lion tamer's gator shades	0		Experience (familiar): +2, Stench Spell Damage: +25, Single Equip
 11012	milk cap	0		
 11013	artisanal Charleston Choo-Choo	3	EPIC	
-11014	acceptable weak Velvet Veil	2	good	
-11015	perfectly mixed weak Marltini	2	EPIC	
+11014	weak acceptable Velvet Veil	2	good	
+11015	weak perfectly mixed Marltini	2	EPIC	
 11016	bad olive Strong, Silent Type	3	decent	
 11017	bad Mysterious Stranger	4	decent	
 11018	hand-crafted Champagne Shimmy	3	EPIC	
@@ -10890,7 +10890,7 @@
 11034	altered mirror chiffon carbage	1		Last Available: "2023-12"
 11035	altered chiffon lemon	0		Effect: "Hood Ridin'", Effect Duration: 42
 11036	rotten chocomotive	3	crappy	Last Available: "2022-12"
-11037	stale miniature freightcake	2	decent	Last Available: "2022-12"
+11037	miniature stale freightcake	2	decent	Last Available: "2022-12"
 11038	drinkable cabooze	4	good	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	plastic passenger car of the bloodbag	0		Maximum HP: +100, Last Available: "2022-12"
@@ -10900,13 +10900,13 @@
 11044	shaking packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	pulsating model train set	0		Last Available: "2022-12"
 11046	Crimbo training manual	0		
-11047	maroon wobbly Abuela Crimbo's special magnet	0		
+11047	wobbly maroon Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
 11049	pile of Trainbot parts	0		
 11050	polymerized Trainbot circuitry	0		Effect: "Hairless and Airless", Effect Duration: 31
 11051	corrupted maroon Trainbot tubing	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 13
 11052	aerosolized tumbling Trainbot plating	0		Effect: "Sleazy Weapon", Effect Duration: 26
-11053	colloidal tarnished olive huge Trainbot optics	0		Effect: "Perfect Hair", Effect Duration: 12
+11053	colloidal tarnished huge olive Trainbot optics	0		Effect: "Perfect Hair", Effect Duration: 12
 11054	double-denatured triple-chilled narrow Trainbot servomotors	0		Effect: "Hypercubed", Effect Duration: 53
 11055	chilled pickled liquefied blurry Trainbot linkages	0		Effect: "Innately Truthy", Effect Duration: 46
 11056	mirror ping-pong paddle	0		Single Equip
@@ -10924,13 +10924,13 @@
 11068	lost elf luggage	0		
 11069	squat Trainbot luggage hook	0		Single Equip
 11070	adequate honey-drenched ham slice	4	good	
-11071	drinkable enchanted wobbly blinking mostly-empty bottle of cookie wine	3	good	Effect: "Mucilaginous Muscle", Effect Duration: 25
+11071	enchanted drinkable blinking wobbly mostly-empty bottle of cookie wine	3	good	Effect: "Mucilaginous Muscle", Effect Duration: 25
 11072	spoiled Crimbo food scraps	3	crappy	
 11073	arm towel	0		Last Available: "2022-12"
 11074	narrow ghostly automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	skewed Trainbot slag	0		
-11077	wobbly twirling industrially-crushed ice	0		Last Available: "2022-12"
+11077	twirling wobbly industrially-crushed ice	0		Last Available: "2022-12"
 11078	diet bland steamed oyster	1	decent	
 11079	tumbling really nice lump of coal	0		
 11080	ghostly jittery deactivated mini-Trainbot	0		Last Available: "2022-12"
@@ -10964,10 +10964,10 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	purple ghostly stalagmite	0		Last Available: "2023-01"
 11110	pulsating chocolate covered ping-pong ball	0		
-11112	big decent fuchsia pixel bread	5	good	
-11113	practically non-alcoholic special acceptable pixel whiskey	1	good	Effect: "Moose Wisdom", Effect Duration: 45
-11114	blinking pulsating wobbly pixel rock	0		
-11115	red wobbly S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
+11112	decent big fuchsia pixel bread	5	good	
+11113	special practically non-alcoholic acceptable pixel whiskey	1	good	Effect: "Moose Wisdom", Effect Duration: 45
+11114	wobbly blinking pulsating pixel rock	0		
+11115	wobbly red S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	frozen vacuum-sealed altered pulsating glob of extra-green chlorophyll	0		Effect: "Pharmaceutically Cool", Effect Duration: 38, Last Available: "2023-02"
 11118	enhanced pulsating mushroom	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 43, Last Available: "2023-02"
@@ -10979,7 +10979,7 @@
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	activated activated twirling fire ant pheromones	0		Effect: "Full of Wist", Effect Duration: 17, Last Available: "2023-02"
 11126	corrupted skewed bouncing flapper fly	0		Effect: "Extra-Wet", Effect Duration: 53, Last Available: "2023-02"
-11127	tolerable watered-down red shot of wasp venom	2	good	Last Available: "2023-02"
+11127	watered-down tolerable red shot of wasp venom	2	good	Last Available: "2023-02"
 11128	magnetized filled mosquito	0		Effect: "Chock Full o' Nanites", Effect Duration: 54, Last Available: "2023-02"
 11129	improved irradiated shim of shame shale	0		Effect: "Berry Berry Cold", Effect Duration: 55, Last Available: "2023-02"
 11130	unsweetened nitrogenated cyan pebble of proud pyrite	0		Effect: "Drenched With Filth", Effect Duration: 13, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	boiled alkaline angry agate	0		Effect: "Stop and Smell the Fudge", Effect Duration: 20, Last Available: "2023-02"
 11134	double-nitrogenated extra-cold-filtered lump of loyal latite	0		Effect: "Boo Tea", Effect Duration: 15, Last Available: "2023-02"
-11135	thick decent blue shadow sausage	5	good	Last Available: "2023-03"
+11135	decent thick blue shadow sausage	5	good	Last Available: "2023-03"
 11136	upside-down knitted shadow skin of Leguizamo	0		Monster Level: +20, Cold Resistance: +3, Last Available: "2023-03"
 11137	warmed blinking narrow shadow flame	0		Effect: "5 Pounds Lighter", Effect Duration: 26, Last Available: "2023-03"
 11138	moldy shadow bread	4	crappy	Last Available: "2023-03"
@@ -11028,7 +11028,7 @@
 11173	shadow heart	0		
 11174	narrow shadow bucket	0		
 11175	squat mirror shadow wave	0		
-11176	blurry tumbling Rufus's shadow lodestone	0		
+11176	tumbling blurry Rufus's shadow lodestone	0		
 11177	bouncing censurious family-friendly sage shadow chef's hat	0		Mysticality Percent: +10, Sleaze Resistance: 4
 11178	rosewater-soaked lard-coated smartaleck's shadow trousers	0		Moxie Percent: +30, Sleaze Spell Damage: +25, Stench Resistance: +3
 11179	twirling Van der Graaf shadow hammer of the bloodbag	0		Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7
@@ -11065,7 +11065,7 @@
 11210	replica organ grinder	0		
 11211	dog trainer's replica Juju Mojo Mask of Gandalf of doom	0		Spell Critical Percent: +20, Experience (familiar): +1, Spooky Spell Damage: +50, Single Equip
 11212	narrow wobbly studded Samson's beefcake's replica Operation Patriot Shield	0		Muscle: +25, Experience (Muscle): +5, Damage Absorption: +80, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
-11213	jittery narrow replica Libram of Resolutions	0		
+11213	narrow jittery replica Libram of Resolutions	0		
 11214	lion tamer's energetic replica plastic vampire fangs of the wise owl	0		Mysticality: +20, Maximum MP Percent: +20, Experience (familiar): +2, Single Equip, Conditional Skill (Equipped): "Feed"
 11215	replica angel	0		
 11216	blinking avaricious replica Camp Scout backpack	0		Meat Drop: +30
@@ -11082,7 +11082,7 @@
 11227	replica Crimbo sapling	0		
 11228	replica puck	0		
 11229	blinking blinking replica Chateau Mantegna room key	0		
-11230	bouncing pulsating replica Deck of Every Card	0		
+11230	pulsating bouncing replica Deck of Every Card	0		
 11231	replica Source terminal	0		
 11232	replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
@@ -11159,11 +11159,11 @@
 11304	replica sleeping patriotic eagle	0		
 11305	red boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	decent massive squat watermelon	8	good	
-11308	jittery bouncing squat watermelon seed	0		
+11307	massive decent squat watermelon	8	good	
+11308	squat bouncing jittery watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
-11311	rotten bite-sized waffle	1	crappy	
+11311	bite-sized rotten waffle	1	crappy	
 11312	skewed fixodent	0		
 11313	wobbly twirling lard-coated manspreader's cat o' nine teeth	0		Monster Level: +10, Sleaze Spell Damage: +25
 11314	sage tooth cap of incineration	0		Mysticality Percent: +10, Hot Spell Damage: +50
@@ -11172,7 +11172,7 @@
 11317	narrow handful of toilet paper	0		
 11318	mirror Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	enchanted lousy bottle of Cabernet Sauvignon	3	decent	Effect: "Marbles in Your Mouth", Effect Duration: 5
+11320	lousy enchanted bottle of Cabernet Sauvignon	3	decent	Effect: "Marbles in Your Mouth", Effect Duration: 5
 11321	blurry rosewater-soaked personal trainer's baywatch of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20, Stench Resistance: +3, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
@@ -11241,19 +11241,19 @@
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
 11388	purple pirate encryption key charlie	0		Last Available: "2023-12"
-11389	pulsating blue pirate encryption key delta	0		Last Available: "2023-12"
-11390	twirling spinning wardrobe-o-matic	0		
+11389	blue pulsating pirate encryption key delta	0		Last Available: "2023-12"
+11390	spinning twirling wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	delicious massive twirling peppermint donut	10	awesome	
+11395	massive delicious twirling peppermint donut	10	awesome	
 11396	supercool Elf Guard insignia (private)	0		Moxie Percent: +20, Last Available: "2023-12"
 11397	Crimbuccaneer fledges (mint) of Flo-Jo	0		Initiative: +100, Last Available: "2023-12"
 11398	skewed upside-down military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	blinking Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	watered-down smooth Crimbuccaneer mologrog cocktail	2	awesome	Last Available: "2023-12"
+11401	smooth watered-down Crimbuccaneer mologrog cocktail	2	awesome	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	Crimbuccaneer lantern of wisdom of Tarzan of dire peril	0		Mysticality: +15, Experience (Muscle): +3, Weapon Damage: +20, Last Available: "2023-12"
@@ -11274,7 +11274,7 @@
 11419	coward's smartaleck's Elf Guard broom	0		Moxie Percent: +30, Monster Level: -20, Last Available: "2023-12"
 11420	chaotic healthy thinker's Crimbuccaneer tavern swab	0		Mysticality: +10, Maximum HP Percent: +20, Spell Critical Percent: +10, Last Available: "2023-12"
 11421	shaking Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	special watered-down mediocre old-school pirate grog	2	decent	Effect: "The Q Is Talking To You", Effect Duration: 20, Last Available: "2023-12"
+11422	watered-down special mediocre old-school pirate grog	2	decent	Effect: "The Q Is Talking To You", Effect Duration: 20, Last Available: "2023-12"
 11423	bland pulsating grog nuts	4	decent	Last Available: "2023-12"
 11424	flame-retardant fortified sawed-off blunderbuss of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, Hot Resistance: +1, Last Available: "2023-12"
 11425	delicious officer's nog	3	awesome	Last Available: "2023-12"
@@ -11302,7 +11302,7 @@
 11447	medical-grade slick massive wrench of vim and vigor	0		Moxie: +10, Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11448	purple twirling spinning lightning-fast censurious brown pirate pants	0		Sleaze Resistance: +3, Initiative: +40, Last Available: "2023-12"
 11449	Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
-11450	blinking teal The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
+11450	teal blinking The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11451	punching mirror	0		Last Available: "2023-12"
 11452	shaking crafty medical-grade hardened razor-sharp Elf dessert spoon of the scaredy-cat of the cheetah	0		Weapon Damage Percent: +25, Damage Reduction: 3, Maximum MP: +10, Monster Level: -15, Initiative: +60, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11453	groovy Elf Guard SCUBA tank of Tarzan	0		Moxie Percent: +10, Experience (Muscle): +3, Last Available: "2023-12"
@@ -11311,24 +11311,24 @@
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	mirror bouncing ribald lion tamer's Annie Oakley's Elvish underarmor	0		Critical Hit Percent: +20, Experience (familiar): +2, Sleaze Damage: +10, Single Equip, Last Available: "2023-12"
 11458	upside-down lion tamer's Crimbuccaneer bombjacket of the storm	0		Maximum MP Percent: +40, Experience (familiar): +2, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	special bite-sized stale sugarplum ration	1	decent	Effect: "Tearful, Fearful", Effect Duration: 20, Last Available: "2023-12"
+11459	bite-sized special stale sugarplum ration	1	decent	Effect: "Tearful, Fearful", Effect Duration: 20, Last Available: "2023-12"
 11460	bland gingerbread nylons	3	decent	Last Available: "2023-12"
-11461	normal small rum-soaked fruitcake	2	good	Last Available: "2023-12"
+11461	small normal rum-soaked fruitcake	2	good	Last Available: "2023-12"
 11462	bland lime	3	decent	Last Available: "2023-12"
 11463	immense rotten spinning gingerbread pirate	10	crappy	Last Available: "2023-12"
 11464	flavorless snack-sized fruit-stuffed rumcake	2	decent	Last Available: "2023-12"
 11465	weak acceptable enchanted teal mulled wine	2	good	Effect: "Berry Defensive", Effect Duration: 35, Last Available: "2023-12"
-11466	enchanted drinkable extra-dry Swedish coffee	5	good	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2023-12"
+11466	extra-dry enchanted drinkable Swedish coffee	5	good	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2023-12"
 11467	extra-dry aged canteen of eggnog	5	awesome	Last Available: "2023-12"
-11468	drinkable practically non-alcoholic hot wine	1	good	Last Available: "2023-12"
+11468	practically non-alcoholic drinkable hot wine	1	good	Last Available: "2023-12"
 11469	acceptable practically non-alcoholic Jamaican coffee	1	good	Last Available: "2023-12"
 11470	practically non-alcoholic drinkable flask of egggrog	1	good	Last Available: "2023-12"
 11471	narrow fuchsia Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	twirling Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	jittery pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	weak artisanal yule grog	2	super EPIC	Last Available: "2023-12"
+11474	artisanal weak yule grog	2	super EPIC	Last Available: "2023-12"
 11475	stale squat wet tack	3	decent	Last Available: "2023-12"
-11476	diet moldy squat tumbling whalecake	1	crappy	Last Available: "2023-12"
+11476	moldy diet squat tumbling whalecake	1	crappy	Last Available: "2023-12"
 11477	Da Vinci's Newton's gunwale whalegun of courage	0		Experience (Mysticality): 8, Spooky Resistance: +3, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	acceptable huge and claret	3	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
@@ -11350,7 +11350,7 @@
 11495	spinning kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	jittery Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11498	blurry blinking Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
+11498	blinking blurry Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
@@ -11387,7 +11387,7 @@
 11532	pulsating personal trainer's petrified wood whoopie panama of bravery	0		Experience Percent (Muscle): +10, Spooky Resistance: +5, Last Available: "2025-12"
 11533	shaking green ribald frightening petrified wood walking pants	0		Spooky Damage: +5, Sleaze Damage: +10, Last Available: "2025-12"
 11534	distilled petrified wood waste parts	1		Last Available: "2025-12"
-11535	quadruple-adjusted flattened extra-irradiated tumbling red bouncing petrified wood wafer praline	0		Effect: "Tea-hee", Effect Duration: 20
+11535	quadruple-adjusted flattened extra-irradiated red tumbling bouncing petrified wood wafer praline	0		Effect: "Tea-hee", Effect Duration: 20
 11536	acceptable mirror cybeer	3	good	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
@@ -11401,7 +11401,7 @@
 11546	avaricious dance instructor's spring shoes of dire peril	0		Experience Percent (Moxie): +10, Weapon Damage: +20, Meat Drop: +30, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	activated wet ultra-soft ferns	0		Effect: "Full-Body Tan", Effect Duration: 58, Last Available: "2024-02"
 11548	non-colloidal twirling crunchy brush	0		Effect: "Punchy, Murdery", Effect Duration: 34, Last Available: "2024-02"
-11549	fuchsia jittery smashed scientific equipment	0		
+11549	jittery fuchsia smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
@@ -11427,11 +11427,11 @@
 11572	twirling Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	moldy teal yam	4	crappy	Last Available: "2024-05"
 11574	bad triple-distilled yam martini	10	decent	Last Available: "2024-05"
-11575	practically non-alcoholic tolerable sweet potato o' mine	1	good	Last Available: "2024-05"
+11575	tolerable practically non-alcoholic sweet potato o' mine	1	good	Last Available: "2024-05"
 11576	acceptable Southern yam	3	good	Last Available: "2024-05"
 11577	tolerable high-proof sweet potato punch	6	good	Last Available: "2024-05"
 11578	rotten Mayam spinach	4	crappy	Last Available: "2024-05"
-11579	toothsome thick yam and swiss	5	awesome	Last Available: "2024-05"
+11579	thick toothsome yam and swiss	5	awesome	Last Available: "2024-05"
 11580	Usain Bolt's weightlifter's yam cannon of mayonnaise	0		Muscle: +15, Sleaze Spell Damage: +50, Initiative: +80, Lasts Until Rollover, Last Available: "2024-05"
 11581	cyan yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	skewed yam battery	0		Last Available: "2024-05"
@@ -11441,7 +11441,7 @@
 11586	bouncing blinking deadly yamtility belt of dire peril of the sewer	0		Weapon Damage: 25, Stench Damage: +25, Lasts Until Rollover, Last Available: "2024-05"
 11587	rotten narrow yam slider	3	crappy	Last Available: "2024-05"
 11588	adequate yam mayo	4	good	Last Available: "2024-05"
-11589	spoiled diet yam burrito	1	crappy	Last Available: "2024-05"
+11589	diet spoiled yam burrito	1	crappy	Last Available: "2024-05"
 11590	twirling visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
@@ -11462,16 +11462,16 @@
 11607	electrified huge mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Twen Tea", Effect Duration: 19
 11608	packaged Roman Candelabra	0		Free Pull
 11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
-11610	squat olive jittery protogenetic chunklet (synapse)	0		
+11610	jittery squat olive protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
 11613	narrow protogenetic chunklet (elbow)	0		
 11614	upside-down protogenetic chunklet (lips)	0		
 11615	censurious Annie Oakley's messenger bag RNA of wisdom	0		Mysticality: +15, Critical Hit Percent: +20, Sleaze Resistance: +3
 11616	flagellate flagon	0		
-11617	spinning tumbling proto-proto-protozoa	0		
-11618	enchanted flavorless bacteria bisque	4	decent	Effect: "Spooky Jellied", Effect Duration: 30
-11619	flavorless half-sized enchanted lime green ciliophora chowder	2	decent	Effect: "Going Ape", Effect Duration: 35
+11617	tumbling spinning proto-proto-protozoa	0		
+11618	flavorless enchanted bacteria bisque	4	decent	Effect: "Spooky Jellied", Effect Duration: 30
+11619	enchanted flavorless half-sized lime green ciliophora chowder	2	decent	Effect: "Going Ape", Effect Duration: 35
 11620	toothsome cream of chloroplasts	4	awesome	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11535,8 +11535,8 @@
 11680	quantum watch	0		Adventures: +2
 11681	teal quantized familiar experience	0		
 11682	electrified super-improved pea brittle	0		Effect: "Phoenix, Right?", Effect Duration: 38, Last Available: "2024-11"
-11683	bad tumbling narrow peasco	4	decent	Last Available: "2024-11"
-11684	bite-sized tasty piece of cake	1	awesome	Last Available: "2024-11"
+11683	bad narrow tumbling peasco	4	decent	Last Available: "2024-11"
+11684	tasty bite-sized piece of cake	1	awesome	Last Available: "2024-11"
 11685	upside-down handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
@@ -11546,7 +11546,7 @@
 11691	bouncing sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
 11693	mediocre high-proof tankard of spiced rum	8	decent	Last Available: "2024-12"
-11694	smooth practically non-alcoholic tankard of spiced Goldschlepper	1	awesome	Last Available: "2024-12"
+11694	practically non-alcoholic smooth tankard of spiced Goldschlepper	1	awesome	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	beefcake's governor's daughter's lace collar	0		Muscle: +25, Last Available: "2024-12"
 11697	asbestos-lined governor's daughter's petticoats	0		Hot Resistance: +5, Last Available: "2024-12"
@@ -11575,8 +11575,8 @@
 11720	Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	Spirit of Christmas	0		Last Available: "2024-12"
 11722	flavorless mirror coney haunch	3	decent	Last Available: "2024-12"
-11723	pickled adjusted lime green twirling dark chocolate egg	0		Effect: "You Drank Fish Wine", Effect Duration: 62, Last Available: "2024-12"
-11724	artisanal fancy moai toai	3	EPIC	Effect: "On a Roll", Effect Duration: 45
+11723	pickled adjusted twirling lime green dark chocolate egg	0		Effect: "You Drank Fish Wine", Effect Duration: 62, Last Available: "2024-12"
+11724	fancy artisanal moai toai	3	EPIC	Effect: "On a Roll", Effect Duration: 45
 11725	reassuring nasty medical-grade moaiball	0		Stench Damage: +5, Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	colloidal ghostly four-leaf potato sprout	0		Effect: "Yuletide Mutations", Effect Duration: 28, Last Available: "2024-12"
@@ -11591,7 +11591,7 @@
 11736	fuchsia frosty gravyskin skirt of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +10, Last Available: "2024-12"
 11737	rosy-cheeked gravyskin pants of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +30, Last Available: "2024-12"
 11738	cold-filtered flattened crystallized pumpkin spice	0		Effect: "Balls of Ectoplasm", Effect Duration: 41, Last Available: "2024-12"
-11739	thick adequate room scale bean casserole	5	good	Last Available: "2024-12"
+11739	adequate thick room scale bean casserole	5	good	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	chilly ruddy hardened perfect Christmas scarf	0		Damage Reduction: [3*event(December)], Maximum HP Percent: [+40*event(December)], Cold Damage: [+5*event(December)], Single Equip, Last Available: "2024-12"
@@ -11607,7 +11607,7 @@
 11752	triple-distilled hand-crafted holiday trip around the world	6	EPIC	Last Available: "2024-12"
 11753	adequate chocolate ostrich egg	4	good	Last Available: "2024-12"
 11754	small normal beef and cabbage	2	good	Last Available: "2024-12"
-11755	small normal maroon upside-down candy rations	2	good	Last Available: "2024-12"
+11755	normal small upside-down maroon candy rations	2	good	Last Available: "2024-12"
 11756	flavorless big double-candied yams	5	decent	Last Available: "2024-12"
 11757	moldy jumbo Christmas ham	5	crappy	Last Available: "2024-12"
 11758	flavorless thick holiday smorgasbord	5	decent	Last Available: "2024-12"
@@ -11618,7 +11618,7 @@
 11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11764	jittery How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
 11765	twirling fuchsia Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	wobbly jittery Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	jittery wobbly Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	squat Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
@@ -11640,13 +11640,13 @@
 11785	pulsating Jack Frost's friendly McHugeLarge right pole of the overflowing toilet	0		Familiar Weight: +3, Cold Spell Damage: +50, Stench Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
 11786	pulsating fireproof McHugeLarge left ski of doom	0		Spooky Spell Damage: +50, Hot Resistance: +3, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
 11787	stanky McHugeLarge right ski of extreme caution	0		Monster Level: -25, Stench Spell Damage: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
-11788	fuchsia wobbly 1	0		Last Available: "2025-12"
+11788	wobbly fuchsia 1	0		Last Available: "2025-12"
 11789	jittery 0	0		Last Available: "2025-12"
 11790	vaporized eXpand	1		Effect: "Knightlife", Effect Duration: 15, Last Available: "2025-12"
 11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
-11794	cyan mirror dedigitizer schematic: malware injector	0		Last Available: "2025-12"
+11794	mirror cyan dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	jittery dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	spinning dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
@@ -11724,12 +11724,12 @@
 11869	blurry unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	pickled spinning leprechaun antidepressant pill	1		Last Available: "2025-03"
-11872	rotten small green Heck ramen	2	crappy	Last Available: "2025-03"
+11872	small rotten green Heck ramen	2	crappy	Last Available: "2025-03"
 11873	jumbo bland upside-down burrito	5	decent	Last Available: "2025-03"
-11874	special diet spoiled small beer brat	1	crappy	Effect: "Aquarius Rising", Effect Duration: 45, Last Available: "2025-03"
+11874	diet special spoiled small beer brat	1	crappy	Effect: "Aquarius Rising", Effect Duration: 45, Last Available: "2025-03"
 11875	yummy upside-down jittery peach pie	4	awesome	Last Available: "2025-03"
 11876	adequate incredible mini-pizza	4	good	Last Available: "2025-03"
-11877	watered-down aged Divine sidecar	2	awesome	Last Available: "2025-03"
+11877	aged watered-down Divine sidecar	2	awesome	Last Available: "2025-03"
 11878	tolerable tangarita sidecar	3	good	Last Available: "2025-03"
 11879	tolerable gimlet sidecar	3	good	Last Available: "2025-03"
 11880	bad mirror vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
@@ -11737,7 +11737,7 @@
 11882	tolerable Mon Tiki sidecar	3	good	Last Available: "2025-03"
 11883	tumbling Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	nippy clever April Shower Thoughts shield	0		Maximum MP: +20, Cold Damage: +10, Damage Reduction: 6, Last Available: "2025-04"
-11885	shaking mirror glob of wet paper	0		Last Available: "2025-04"
+11885	mirror shaking glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	energized wet paper weights	0		Effect: "Sourpuss", Effect Duration: 43, Last Available: "2025-04"
 11888	mediocre Three Sheets to the Wind	3	decent	Last Available: "2025-04"
@@ -11772,7 +11772,7 @@
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
 11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
-11920	pulsating gray flak shield	0		Damage Reduction: 9
+11920	gray pulsating flak shield	0		Damage Reduction: 9
 11921	bouncing Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
 11923	exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	cyan ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	huge adequate Skeleton Wars rations	6	good	
+11937	adequate huge Skeleton Wars rations	6	good	
 11938	bad purple skeleton war fuel can	3	decent	
 11939	skeleton war grenade	0		
 11940	yellow chocolate and nylons detector	0		
@@ -11807,22 +11807,22 @@
 11952	diluted tumbling upside-down mixed berry jelly	1		Last Available: "2025-08"
 11953	moldy toast with mixed berry jelly	3	crappy	Last Available: "2025-08"
 11954	normal cup of sugar	3	good	Last Available: "2025-08"
-11955	adequate diet Susie's cupcake	1	good	Last Available: "2025-08"
-11956	maroon spinning clock	0		Last Available: "2025-08"
+11955	diet adequate Susie's cupcake	1	good	Last Available: "2025-08"
+11956	spinning maroon clock	0		Last Available: "2025-08"
 11957	ghostly gravedigger's MacGyver's hardy the gun	0		Maximum HP: +50, Maximum MP: +100, Spooky Damage: +10, Last Available: "2025-08"
 11958	weak bad huge blurry wine	2	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	tumbling blue undersea surveying goggles of the ox	0		Muscle: +20, Lasts Until Rollover
-11963	watered-down tolerable Ocean-Touched Rum	2	good	
+11963	tolerable watered-down Ocean-Touched Rum	2	good	
 11964	mixed bouncing water-logged pill	1		Effect: "The Real Deal", Effect Duration: 40
 11965	moldy immense twirling kelp puck	7	crappy	
 11966	lime green scroll of sea strength	0		
 11967	scroll of sea smarts	0		
-11968	huge fuchsia scroll of sea smarm	0		
+11968	fuchsia huge scroll of sea smarm	0		
 11969	blue waterlogged scroll of healing	0		
 11970	olive sea gel	0		
-11971	pickled tarnished wobbly pulsating octopus ink bladder	0		Effect: "Peppermint Bite", Effect Duration: 47
+11971	pickled tarnished pulsating wobbly octopus ink bladder	0		Effect: "Peppermint Bite", Effect Duration: 47
 11972	durable dolphin whistle	0		
 11973	tumbling Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
@@ -11832,7 +11832,7 @@
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	Usain Bolt's horrifying supercharged strapping blood cubic zirconia of Gandalf of the brazier	0		Muscle: +5, Maximum MP Percent: +30, Spell Critical Percent: +20, Hot Spell Damage: +25, Spooky Damage: +25, Initiative: +80, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	dried upside-down blood thinner	1		Effect: "The Smile of Mr. A.", Effect Duration: 45, Last Available: "2025-10"
-12045	tolerable spirit-forward pheromone cocktail	5	good	Last Available: "2025-10"
+12045	spirit-forward tolerable pheromone cocktail	5	good	Last Available: "2025-10"
 12046	bland spinal tapas	3	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	mansplainer's Fonzie's shrunken head of terror	0		Experience (Moxie): +1, Monster Level: +15, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
@@ -11843,10 +11843,10 @@
 12053	tasty prize turkey	4	awesome	
 12054	mixed spinning huge medicinal gruel	1		Effect: "init.enh", Effect Duration: 25
 12055	stale full-sized pumpkin pie	4	decent	Last Available: "2025-11"
-12056	weak lousy special pulsating vodka cranberry sauce	2	decent	Effect: "White Knuckles", Effect Duration: 10, Last Available: "2025-11"
+12056	special weak lousy pulsating vodka cranberry sauce	2	decent	Effect: "White Knuckles", Effect Duration: 10, Last Available: "2025-11"
 12057	non-enhanced yammed candy	0		Effect: "Hennaliciousness", Effect Duration: 58, Last Available: "2025-11"
 12058	spoiled treasure chestnut	4	crappy	Last Available: "2025-12"
-12059	aged irresponsibly strong twirling mulled butter rum	6	awesome	Last Available: "2025-12"
+12059	irresponsibly strong aged twirling mulled butter rum	6	awesome	Last Available: "2025-12"
 12060	vacuum-sealed quadruple-liquefied maroon cinnamon doubloon	0		Effect: "La Bamba", Effect Duration: 57, Last Available: "2025-12"
 12061	maroon executive plastic left skeleton arm	0		Meat Drop: +40, Last Available: "2025-12"
 12062	personal trainer's plastic left skeleton leg	0		Experience Percent (Muscle): +10, Last Available: "2025-12"
@@ -11879,14 +11879,14 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	vibrating extra-thick Crimbo sweater	0		Maximum MP Percent: +10, Last Available: "2025-12"
 12123	cyan The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	acceptable fancy weak Steve Abrams' Holiday Sampler Beer	2	good	Effect: "Cold Hands", Effect Duration: 30, Last Available: "2025-12"
+12124	fancy acceptable weak Steve Abrams' Holiday Sampler Beer	2	good	Effect: "Cold Hands", Effect Duration: 30, Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	drinkable squat bottle of prize-winning rum	3	good	Last Available: "2025-12"
 12127	deadly Santa-Slayer medal of dire peril of courage	0		Weapon Damage: 25, Spooky Resistance: +3, Single Equip, Last Available: "2025-12"
 12128	pulsating Skull of Claus	0		Last Available: "2025-12"
 12129	adjusted ghostly boiling bone marrow	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 69, Last Available: "2025-12"
 12130	double-liquefied boiling cerebrospinal fluid	0		Effect: "The Q Is Talking To You", Effect Duration: 67, Last Available: "2025-12"
-12131	deionized spinning wobbly boiling synovial fluid	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 51, Last Available: "2025-12"
+12131	deionized wobbly spinning boiling synovial fluid	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 51, Last Available: "2025-12"
 12132	Jeselnik's supercharged rosy-cheeked smoldering vertebra	0		Maximum HP Percent: +30, Maximum MP Percent: +30, Sleaze Damage: +25, Single Equip, Last Available: "2025-12"
 12133	lime green seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
@@ -11897,7 +11897,7 @@
 12139	upside-down dance instructor's Newton's savvy burnt bone belt	0		Mysticality Percent: +20, Experience (Mysticality): +3, Experience Percent (Moxie): +10, Single Equip, Last Available: "2025-12"
 12140	teal shaking avaricious scorched skull trophy	0		Meat Drop: +30, Last Available: "2025-12"
 12141	rotten miniature wing bone	2	crappy	Last Available: "2025-12"
-12142	acceptable enchanted high-proof weak skeleton venom	6	good	Effect: "meat.enh", Effect Duration: 5, Last Available: "2025-12"
+12142	enchanted high-proof acceptable weak skeleton venom	6	good	Effect: "meat.enh", Effect Duration: 5, Last Available: "2025-12"
 12143	boiled blinking blinking baked bone meal	1		Last Available: "2025-12"
 12144	gray supercharged plastic skeleton rib cage	0		Maximum MP Percent: +30, Last Available: "2025-12"
 12145	chaotic plastic skeleton skull	0		Spell Critical Percent: +10, Last Available: "2025-12"
@@ -11917,7 +11917,7 @@
 12159	squat Shanty: I'm Smarter Than a Drunken Sailor (used)	0		Skill: "I'm Smarter Than a Drunken Sailor", Last Available: "2025-12"
 12160	Shanty: Look At That Drunken Sailor Dance	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
 12161	Shanty: Look At That Drunken Sailor Dance (used)	0		Skill: "Look At That Drunken Sailor Dance", Last Available: "2025-12"
-12162	huge jittery Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
+12162	jittery huge Shanty: Who's Going to Pay This Drunken Sailor?	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12163	narrow Shanty: Who's Going to Pay This Drunken Sailor? (used)	0		Skill: "Who's Going to Pay This Drunken Sailor?", Last Available: "2025-12"
 12164	Shanty: Only Dogs Love a Drunken Sailor	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
 12165	twirling Shanty: Only Dogs Love a Drunken Sailor (used)	0		Skill: "Only Dogs Love a Drunken Sailor", Last Available: "2025-12"
@@ -11929,7 +11929,7 @@
 12171	spoiled traditional gingerloaf	3	crappy	Last Available: "2025-12"
 12172	aged narrow Scotch and eggnog	4	awesome	Last Available: "2025-12"
 12173	aerosolized super-ionized counterskeleton elixir	0		Effect: "Stregngth of the Gnome", Effect Duration: 31, Last Available: "2025-12"
-12174	acceptable weak &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
+12174	weak acceptable &quot;salvaged&quot; wine	2	good	Last Available: "2025-12"
 12175	upside-down The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	decent squat squat lime green wedge of prize-winning cheese	3	good	Last Available: "2025-12"
@@ -11964,7 +11964,7 @@
 12206	blue Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	jittery wobbly Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	snack-sized bland rat pizza	2	decent	Last Available: "2026-03"
+12209	bland snack-sized rat pizza	2	decent	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	purple scorching toasty chilly hoverboard	0		Cold Damage: +5, Hot Damage: 30, Single Equip, Last Available: "2026-03"
 12212	twirling lion tamer's forbidden left shark fin of the boozehound	0		Spell Damage Percent: +50, Experience (familiar): +2, Booze Drop: +100, Last Available: "2026-03"
@@ -11972,28 +11972,28 @@
 12214	pickled lime green candy bone	1		
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	stale miniature discarded hot dog	2	decent	Last Available: "2026-04"
+12217	miniature stale discarded hot dog	2	decent	Last Available: "2026-04"
 12218	high-proof perfectly mixed upside-down cyan most of a beer	8	EPIC	Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	twirling legendary noodles	0		Last Available: "2026-05"
 12226	spoiled low-calorie blue can of tuna	1	crappy	
-12227	snack-sized fancy spoiled alien salad	2	crappy	Effect: "Violent Night", Effect Duration: 10
+12227	spoiled fancy snack-sized alien salad	2	crappy	Effect: "Violent Night", Effect Duration: 10
 12228	spoiled small narrow ratbatatouille	2	crappy	
-12229	big spoiled onigiri	5	crappy	
+12229	spoiled big onigiri	5	crappy	
 12230	decent tumbling crudit&eacute;s	4	good	
-12231	adequate super-sized sauced mutton	5	good	
+12231	super-sized adequate sauced mutton	5	good	
 12232	spoiled half-sized hot honey ant	2	crappy	
-12233	half-sized spoiled huge tomb aspic	2	crappy	
+12233	spoiled half-sized huge tomb aspic	2	crappy	
 12234	spoiled mirror later tots	3	crappy	
 12235	moldy Frutti di Scatoletta	4	crappy	Last Available: "2026-05"
 12236	moldy Pesto alla Marziano	4	crappy	Last Available: "2026-05"
 12237	rotten purple Arrattabbattabiata	3	crappy	Last Available: "2026-05"
-12238	miniature yummy twirling teal Orzo di Riso	2	awesome	Last Available: "2026-05"
-12239	normal gigantic Pasta Grimavera	9	good	Last Available: "2026-05"
+12238	yummy miniature twirling teal Orzo di Riso	2	awesome	Last Available: "2026-05"
+12239	gigantic normal Pasta Grimavera	9	good	Last Available: "2026-05"
 12240	special tiny flavorless Linguini Ubriacapa	1	decent	Effect: "Mistified", Effect Duration: 35, Last Available: "2026-05"
 12241	half-sized spoiled skewed Formica e Pepe	2	crappy	Last Available: "2026-05"
-12242	adequate massive Tubetto Gelatto	6	good	Last Available: "2026-05"
+12242	massive adequate Tubetto Gelatto	6	good	Last Available: "2026-05"
 12243	rotten Gnocci Domani	4	crappy	Last Available: "2026-05"
 12244	bouncing Thwaitgold wallet moth statuette	0		
 12245	cyan scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12020,26 +12020,26 @@
 12270	yellow crafty healthy Portable Laughing Stock of the sweet-tooth	0		Maximum HP Percent: +20, Maximum MP: +10, Candy Drop: +100, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	wicked deadly smooth Staff of Anachronistic Churning	0		Moxie: +15, Weapon Damage: +5, Spell Damage: +5
 12272	yummy classic banana	3	awesome	Last Available: "2026-07"
-12273	decent big watermelon	5	good	Last Available: "2026-07"
+12273	big decent watermelon	5	good	Last Available: "2026-07"
 12274	flavorless thick wobbly quince	5	decent	Last Available: "2026-07"
 12275	wobbly Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	moldy enchanted immense twirling classic banana pie	10	crappy	Effect: "Earthen Fist", Effect Duration: 50, Last Available: "2026-07"
 12278	oxidized deionized narrow essential banana decoction	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 67, Last Available: "2026-07"
 12279	diffused jittery banana quintessence	0		Effect: "Buggy Flavor", Effect Duration: 43, Last Available: "2026-07"
-12280	special lousy shaking Aesop Daiquiri	4	decent	Effect: "Celestial Body", Effect Duration: 45, Last Available: "2026-07"
+12280	lousy special shaking Aesop Daiquiri	4	decent	Effect: "Celestial Body", Effect Duration: 45, Last Available: "2026-07"
 12281	mediocre Monkey Congress	4	decent	Last Available: "2026-07"
 12282	tasty blurry watermelon pie	4	awesome	Last Available: "2026-07"
 12283	wet super-warmed yellow concentrated watermelon juice	0		Effect: "critical.enh", Effect Duration: 23, Last Available: "2026-07"
 12284	alkaline Aqua Citrulanatae	0		Effect: "Saucefingers", Effect Duration: 61, Last Available: "2026-07"
-12285	watered-down lousy Melonegroni	2	decent	Last Available: "2026-07"
+12285	lousy watered-down Melonegroni	2	decent	Last Available: "2026-07"
 12286	triple-distilled smooth Melonade Spritz	10	awesome	Last Available: "2026-07"
-12287	delicious gigantic quince pie	8	awesome	Last Available: "2026-07"
+12287	gigantic delicious quince pie	8	awesome	Last Available: "2026-07"
 12288	polarized super-frozen quince quaff	0		Effect: "The Moxie of LOV", Effect Duration: 34, Last Available: "2026-07"
-12289	dry blurry twirling Quickquince	0		Effect: "Kissed By Fire", Effect Duration: 20, Last Available: "2026-07"
+12289	dry twirling blurry Quickquince	0		Effect: "Kissed By Fire", Effect Duration: 20, Last Available: "2026-07"
 12290	bad Quiskey Sour	4	decent	Last Available: "2026-07"
 12291	perfectly mixed spirit-forward Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
-12292	triple-distilled special mediocre Roth IPA	9	decent	Effect: "Weird Vibrations", Effect Duration: 15, Last Available: "2026-08"
+12292	special mediocre triple-distilled Roth IPA	9	decent	Effect: "Weird Vibrations", Effect Duration: 15, Last Available: "2026-08"
 12293	pulsating veiny Rosewater's underdraft protection	0		Mysticality Percent: +30, Maximum HP: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	adequate soybean futures	3	good	Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Vole_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	perfectly mixed Petite Porter	3	EPIC	
 -2	bad Scrawny Stout	3	decent	
 -3	acceptable extra-dry Infinitesimal IPA	5	good	
--4	artisanal practically non-alcoholic eggnogtini	1	EPIC	
--5	aged triple-distilled candycaine	10	awesome	
+-4	practically non-alcoholic artisanal eggnogtini	1	EPIC	
+-5	triple-distilled aged candycaine	10	awesome	
 -6	aged braincracker sweet	3	awesome	
 -16	acceptable fermented honey	4	good	
 -17	weak perfectly mixed fuchsia moons-shine	2	EPIC	
 -18	bad gin	4	decent	
--19	triple-distilled tolerable ecto-nog	9	good	
+-19	tolerable triple-distilled ecto-nog	9	good	
 -20	drinkable upside-down hot toady	3	good	
--21	tolerable yellow mirror twirling hot choculate	4	good	
--49	watered-down tolerable Cyder	2	good	
--50	fancy tolerable huge huge Oil Nog	3	good	
+-21	tolerable yellow twirling mirror hot choculate	4	good	
+-49	tolerable watered-down Cyder	2	good	
+-50	tolerable fancy huge huge Oil Nog	3	good	
 -51	perfectly mixed purple Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	artisanal boozy Grimacider	5	EPIC	
--59	practically non-alcoholic tolerable Isotope Nog	1	good	
--60	special hand-crafted Mutagin 'n' Tonic	3	EPIC	
+-59	tolerable practically non-alcoholic Isotope Nog	1	good	
+-60	hand-crafted special Mutagin 'n' Tonic	3	EPIC	
 -70	bad maroon Gin and Herring	3	decent	
 -71	distilled lousy Black and Tan and Red All Over	5	decent	
 -72	drinkable Antarctic Ice Tea	4	good	
--76	spirit-forward acceptable CRIMBCO Ribbon Candy Schnapps	5	good	
+-76	acceptable spirit-forward CRIMBCO Ribbon Candy Schnapps	5	good	
 -77	hand-crafted CRIMBCO Egg Substitute Nog Substitute	4	EPIC	
 -78	drinkable upside-down tumbling CRIMBCO Extreme Braincracker Sour	3	good	
--82	smooth irresponsibly strong bouncing Horseradish-infused Vodka	10	awesome	
--83	delicious upside-down tumbling Jerkitini	3	awesome	
+-82	irresponsibly strong smooth bouncing Horseradish-infused Vodka	10	awesome	
+-83	delicious tumbling upside-down Jerkitini	3	awesome	
 -84	bad Desert Island Iced Tea	3	decent	
 -88	delicious weak Crimbo Saketini	2	awesome	
 -89	enchanted hand-crafted Crimboku Drop	3	EPIC	
 -90	artisanal irresponsibly strong Flaming Crimbo Log	10	EPIC	
--107	lousy practically non-alcoholic Fortified Eggnog Slurry	1	decent	
+-107	practically non-alcoholic lousy Fortified Eggnog Slurry	1	decent	
 -108	perfectly mixed Hot Buttered Rum	3	EPIC	
--109	drinkable fortified Spicy Hot Chocolate	5	good	
+-109	fortified drinkable Spicy Hot Chocolate	5	good	

--- a/data/TCRS/TCRS_Seal_Clubber_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Vole_cafe_food.txt
@@ -1,8 +1,8 @@
 -1	decent Peche a la Frog	3	good	
 -2	rotten As Jus Gezund Heit	3	crappy	
--3	jumbo bland Bouillabaise Coucher Avec Moi	5	decent	
--7	miniature flavorless ghostly gumdrop chow mein	2	decent	
--8	bite-sized toothsome squat candy cane pizza	1	awesome	
+-3	bland jumbo Bouillabaise Coucher Avec Moi	5	decent	
+-7	flavorless miniature ghostly gumdrop chow mein	2	decent	
+-8	toothsome bite-sized squat candy cane pizza	1	awesome	
 -9	moldy gingerbread stir-fry	3	crappy	
 -10	moldy shaking twigs and gravel	4	crappy	
 -11	bland shoots and leaves	4	decent	
@@ -11,35 +11,35 @@
 -14	yummy squat It Came From Beyond Dessert	3	awesome	
 -15	tiny yummy fancy mirror vampire cake	1	awesome	
 -52	bite-sized bland Soylent Red and Green	1	decent	
--53	bland pulsating wobbly Disc-Shaped Nutrition Unit	4	decent	
+-53	bland wobbly pulsating Disc-Shaped Nutrition Unit	4	decent	
 -54	snack-sized moldy Gingerborg Hive	2	crappy	
--61	adequate tiny Candy Cane Surprise	1	good	
+-61	tiny adequate Candy Cane Surprise	1	good	
 -62	moldy Grimdrop Chow Mein	4	crappy	
 -63	yummy Grimgerbread House	4	awesome	
 -67	adequate twirling Caviar Carbonara	3	good	
--68	tasty miniature Halibut Alfredo	2	awesome	
+-68	miniature tasty Halibut Alfredo	2	awesome	
 -69	fancy normal Red Herring Velvet Cake	3	good	
 -73	flavorless CRIMBCO Reconstituted Gruel	3	decent	
--74	tasty snack-sized New and Improved CRIMBCO Reconstituted Gruel	2	awesome	
+-74	snack-sized tasty New and Improved CRIMBCO Reconstituted Gruel	2	awesome	
 -75	stale teal CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
--79	adequate special big bouncing Brussels Sprout Stir-Fry	5	good	
+-79	special big adequate bouncing Brussels Sprout Stir-Fry	5	good	
 -80	snack-sized stale Carrot, Cabbage, and Kale Pizza	2	decent	
 -81	gigantic adequate mirror Turnip and Rutabaga Pie	10	good	
 -85	spoiled immense Rainbow Spider Fun Roll	8	crappy	
--86	spoiled small Vegas Volcano Lava Roll	2	crappy	
+-86	small spoiled Vegas Volcano Lava Roll	2	crappy	
 -87	stale Crazy Dragon Shogun Buddha Roll	4	decent	
 -92	rotten basic hot dog	3	crappy	
--93	stale half-sized savage macho dog	2	decent	
--94	super-sized decent skewed one with everything	5	good	
--95	fancy toothsome immense purple huge sly dog	10	awesome	
+-93	half-sized stale savage macho dog	2	decent	
+-94	decent super-sized skewed one with everything	5	good	
+-95	fancy immense toothsome purple huge sly dog	10	awesome	
 -96	stale devil dog	3	decent	
 -97	decent miniature chilly dog	2	good	
 -98	rotten special ghost dog	3	crappy	
 -99	decent green junkyard dog	3	good	
 -100	moldy wet dog	3	crappy	
 -101	bland sleeping dog	3	decent	
--102	enchanted decent huge twirling optimal dog	10	good	
+-102	huge enchanted decent twirling optimal dog	10	good	
 -103	snack-sized spoiled tumbling video games hot dog	2	crappy	
 -104	massive rotten skewed Peppermint Nutrition Block	7	crappy	
--105	miniature yummy Gingerbread Nutrition Block	2	awesome	
--106	normal low-calorie blinking jittery Cinnamon Nutrition Block	1	good	
+-105	yummy miniature Gingerbread Nutrition Block	2	awesome	
+-106	normal low-calorie jittery blinking Cinnamon Nutrition Block	1	good	

--- a/data/TCRS/TCRS_Seal_Clubber_Wallaby.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wallaby.txt
@@ -37,11 +37,11 @@
 38	jittery bouncing chilly Knob Goblin pants	0		Cold Damage: +5, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	blinking casino pass	0		
-41	mediocre watered-down enchanted ice-cold Sir Schlitz	2	decent	Effect: "Jacked In", Effect Duration: 15
+41	watered-down enchanted mediocre ice-cold Sir Schlitz	2	decent	Effect: "Jacked In", Effect Duration: 15
 42	hermit permit	0		
 43	worthless trinket	0		
 44	worthless gewgaw	0		
-45	yellow shaking worthless knick-knack	0		
+45	shaking yellow worthless knick-knack	0		
 46	narrow figurine	0		
 47	stale hot buttered roll	3	decent	
 48	pulsating heart of rock and roll	0		
@@ -57,12 +57,12 @@
 58	pulsating stone turtle	0		
 59	slingshot	0		
 60	sinister Mace of the Tortoise	0		Spell Damage: +10, Class: "Turtle Tamer"
-61	normal snack-sized fortune cookie	2	good	
+61	snack-sized normal fortune cookie	2	good	
 62	blurry Jim Carey's oriole-feather headdress	0		Monster Level: +25, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
 65	blue huge Mighty Bjorn action figure	0		
-66	blinking gray twig	0		
+66	gray blinking twig	0		
 67	spaghetti with rock-balls	0		
 68	padded deadly Pasta Spoon of Peril	0		Weapon Damage: +5, Damage Absorption: +20, Class: "Pastamancer"
 69	shaking Newbiesport&trade; tent	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	lion tamer's Da Vinci's staff	0		Experience (Mysticality): +5, Experience (familiar): +2
 104	scarecrow	0		
-105	low-calorie stale bowl of charms	1	decent	
+105	stale low-calorie bowl of charms	1	decent	
 106	enchanted shaking ketchup	1	decent	Effect: "On the Trolley", Effect Duration: 50
 107	catsup	1	EPIC	
 108	mirror stick	0		
@@ -140,7 +140,7 @@
 141	teal dingy dinghy	0		
 142	anticheese	0		
 143	cottage	0		
-144	wobbly squat fuchsia stone of eXtreme power	0		
+144	wobbly fuchsia squat stone of eXtreme power	0		
 145	bouncing barbed-wire fence	0		
 146	dinghy plans	0		
 147	blurry spinning wicked eXtreme meat sword	0		Spell Damage: +5
@@ -157,17 +157,17 @@
 158	spinning Gnollish pie tin	0		
 159	bouncing wad of dough	0		
 160	red pie crust	0		
-161	flavorless fancy pulsating blue ghuol egg	3	decent	Effect: "Altered Wavelengths", Effect Duration: 45
+161	fancy flavorless blue pulsating ghuol egg	3	decent	Effect: "Altered Wavelengths", Effect Duration: 45
 162	half-sized moldy twirling ghuol egg quiche	2	crappy	
 163	tumbling supercharged skeleton bone	0		Maximum MP Percent: +30
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	snack-sized normal spinning ghuol-ear kabob	2	good	
+167	normal snack-sized spinning ghuol-ear kabob	2	good	
 168	gravedigger's bone rattle	0		Spooky Damage: +10
 169	fuchsia bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	enchanted decent maroon lihc eye pie	3	good	Effect: "Permafrosty", Effect Duration: 20
+171	decent enchanted maroon lihc eye pie	3	good	Effect: "Permafrosty", Effect Duration: 20
 172	gnoll lips	0		
 173	bouncing taco shell	0		
 174	Gnollish casserole dish	0		
@@ -207,11 +207,11 @@
 209	wad of tofu	0		
 210	Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
-212	blurry pulsating windchimes	0		
+212	pulsating blurry windchimes	0		
 213	medical-grade padded filthy corduroys	0		Damage Absorption: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	smelly filthy knitted dread sack	0		Stench Spell Damage: +10, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	jumbo yummy gray pulsating carob brownies	5	awesome	
+216	yummy jumbo pulsating gray carob brownies	5	awesome	
 217	stale wobbly herb brownies	4	decent	
 218	hemp string	0		
 219	necklace chain	0		
@@ -237,29 +237,29 @@
 239	purple beefcake's Orcish baseball cap of temperance	0		Muscle: +25, Sleaze Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	smooth Orcish cargo shorts of horror	0		Moxie: +15, Spooky Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	fortified Orcish frat-paddle	0		Damage Absorption: +60
-242	fancy normal snack-sized	2	good	Effect: "Hare-o-dynamic", Effect Duration: 35
+242	fancy snack-sized normal	2	good	Effect: "Hare-o-dynamic", Effect Duration: 35
 243	bland grapefruit	3	decent	
-244	enchanted stale grapes	3	decent	Effect: "Just the Brown Ones", Effect Duration: 15
+244	stale enchanted grapes	3	decent	Effect: "Just the Brown Ones", Effect Duration: 15
 245	yummy olive	4	awesome	
-246	rotten enchanted tomato	3	crappy	Effect: "Always In Motion", Effect Duration: 35
+246	enchanted rotten tomato	3	crappy	Effect: "Always In Motion", Effect Duration: 35
 247	fermenting powder	0		
-248	enchanted delicious green salty dog	4	awesome	Effect: "Prideful Strut", Effect Duration: 45
+248	delicious enchanted green salty dog	4	awesome	Effect: "Prideful Strut", Effect Duration: 45
 249	artisanal watered-down bloody mary	2	EPIC	
 250	tolerable spinning screwdriver	4	good	
-251	tolerable weak martini	2	good	
-252	weak artisanal bloody beer	2	EPIC	
-253	lousy spirit-forward narrow shot of schnapps	5	decent	
-254	drinkable weak shot of grapefruit schnapps	2	good	
-255	watered-down mediocre lime green fine wine	2	decent	
+251	weak tolerable martini	2	good	
+252	artisanal weak bloody beer	2	EPIC	
+253	spirit-forward lousy narrow shot of schnapps	5	decent	
+254	weak drinkable shot of grapefruit schnapps	2	good	
+255	mediocre watered-down lime green fine wine	2	decent	
 256	smooth shot of tomato schnapps	3	awesome	
 257	watered-down tolerable extra-spicy bloody mary	2	good	
 258	green dense meat stack	0		
 259	snake skin	0		
 260	spoiled White Citadel fries	4	crappy	
-261	adequate blinking maroon White Citadel burger	4	good	
+261	adequate maroon blinking White Citadel burger	4	good	
 262	rotten special piece of wedding cake	3	crappy	Effect: "Wolf's Bane", Effect Duration: 35
-263	toothsome huge chocolate chips	8	awesome	
-264	rotten diet chocolate chip cookies	1	crappy	
+263	huge toothsome chocolate chips	8	awesome	
+264	diet rotten chocolate chip cookies	1	crappy	
 265	teal flame-retardant satin pants	0		Hot Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
 266	artisanal lightning	3	EPIC	
 267	fuchsia mullet wig of Flo-Jo	0		Initiative: +100, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
@@ -267,7 +267,7 @@
 269	sword of James Dean	0		Experience (Moxie): +3
 270	picket fence	0		
 271	dried jittery barbell	1		
-272	vaporized purple mirror concentrated magicalness pill	1		Effect: "Yuletide Mutations", Effect Duration: 50
+272	vaporized mirror purple concentrated magicalness pill	1		Effect: "Yuletide Mutations", Effect Duration: 50
 273	dehydrated spinning moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	shaking mosquito larva	0		
@@ -310,18 +310,18 @@
 312	ghostly supercool Knob Goblin visor	0		Moxie Percent: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	rosewater-soaked Crown of the Goblin King	0		Stench Resistance: +3, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	decent huge bean burrito	7	good	
-315	stale tiny bean burrito	1	decent	
+315	tiny stale bean burrito	1	decent	
 316	moldy insanely bean burrito	3	crappy	
 317	flavorless bean burrito	4	decent	
 318	rotten bean burrito	3	crappy	
-319	normal huge ghostly insanely bean burrito	3	good	
+319	normal ghostly huge insanely bean burrito	3	good	
 320	small decent bat haggis	2	good	
 321	decent menudo	3	good	
 322	snack-sized tasty goat cheese	2	awesome	
 323	half-sized rotten plain pizza	2	crappy	
 324	miniature bland spinning sausage pizza	2	decent	
 325	normal pulsating goat cheese pizza	3	good	
-326	small tasty squat mushroom pizza	2	awesome	
+326	tasty small squat mushroom pizza	2	awesome	
 327	blurry squat goat	0		
 328	mediocre watered-down bottle of whiskey	2	decent	
 329	dance instructor's goat beard	0		Experience Percent (Moxie): +10, Familiar Effect: "atk, 1xPotato, cap 15"
@@ -330,12 +330,12 @@
 332	small bland lemon	2	decent	
 333	enchanted miniature spoiled lime	2	crappy	Effect: "Polar Express", Effect Duration: 35
 334	executive sabre teeth	0		Meat Drop: +40
-335	ghostly blue sabre-toothed lime cub	0		
+335	blue ghostly sabre-toothed lime cub	0		
 336	squat forbidden consolation ribbon	0		Spell Damage Percent: +50
 337	pulsating blue ol' trophy	0		
 338	tenderizing hammer	0		
 339	mirror Cobb's Knob lab key	0		
-340	denatured warmed upside-down ghostly Knob Goblin steroids	0		Effect: "Earthen Fist", Effect Duration: 33
+340	denatured warmed ghostly upside-down Knob Goblin steroids	0		Effect: "Earthen Fist", Effect Duration: 33
 341	triple-deionized boiled wobbly twirling Knob Goblin love potion	0		Effect: "Irresistible Resolve", Effect Duration: 54
 342	Knob Goblin stink bomb	0		
 343	double-ionized oxidized squat Knob Goblin sharpening spray	0		Effect: "Human-Hobo Hybrid", Effect Duration: 40
@@ -354,7 +354,7 @@
 356	shaking fortified snowboarder pants	0		Damage Absorption: +60, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	stale shaking gr8ps	3	decent	
-359	small normal t8r tots	2	good	
+359	normal small t8r tots	2	good	
 360	greasy miner's helmet	0		Sleaze Spell Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	miner's pants of the detective	0		Item Drop: +20, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	cyan sizzling 7-Foot Dwarven mattock	0		Hot Damage: +10
@@ -372,7 +372,7 @@
 374	upside-down chrome crossbow string	0		
 375	linoleum meat stack	0		
 376	asbestos meat stack	0		
-377	olive spinning chrome meat stack	0		
+377	spinning olive chrome meat stack	0		
 378	linoleum sword of the ox of terror	0		Muscle: +20, Spooky Spell Damage: +10
 379	smelly linoleum staff of the ox	0		Muscle: +20, Stench Spell Damage: +10
 380	blinking flame-retardant friendly linoleum crossbow	0		Familiar Weight: +3, Hot Resistance: +1
@@ -454,9 +454,9 @@
 456	smooth watered-down tumbling dry martini	2	awesome	
 457	smooth ye olde golde frontes	0		Moxie: +15, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
-459	jittery ghostly pixel	0		
+459	ghostly jittery pixel	0		
 460	fuchsia pixel	0		
-461	teal huge pixel	0		
+461	huge teal pixel	0		
 462	bouncing jittery pixel	0		
 463	pixel	0		
 464	yellow wobbly pixel potion	0		
@@ -465,7 +465,7 @@
 467	big rotten pixel pie	5	crappy	
 468	ruby W	0		
 469	wussiness potion	0		
-470	watered-down lousy Imp Ale	2	decent	
+470	lousy watered-down Imp Ale	2	decent	
 471	adequate hot wing	3	good	
 472	green greedy diamond-studded cane	0		Meat Drop: +20, Class: "Disco Bandit"
 473	narrow yellow crutch of extreme caution	0		Monster Level: -25
@@ -493,15 +493,15 @@
 495	catgut	0		
 496	blurry cat appendix	0		
 497	gnatwing	0		
-498	bland fancy papaya	3	decent	Effect: "Can Has Cyborger", Effect Duration: 35
+498	fancy bland papaya	3	decent	Effect: "Can Has Cyborger", Effect Duration: 35
 499	stanky dangerous denim axe	0		Weapon Damage: +10, Stench Spell Damage: +25
 500	Elf Farm Raffle ticket	0		
-501	normal snack-sized Elfin shortbread	2	good	
+501	snack-sized normal Elfin shortbread	2	good	
 502	pagoda plans	0		
 503	flavorless blue skewered cat appendix	3	decent	
-504	tumbling cyan evil arches	0		
+504	cyan tumbling evil arches	0		
 505	forbidden gnatwing earring of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50
-506	bite-sized delicious Hell broth	1	awesome	
+506	delicious bite-sized Hell broth	1	awesome	
 507	lion tamer's thunderrr guitarrr	0		Experience (familiar): +2
 508	jittery yellow sonata	0		
 509	Hey Deze nuts	0		
@@ -538,9 +538,9 @@
 540	Vulcanized Tasty Fun Good rice candy	0		Effect: "Dances with Tweedles", Effect Duration: 48
 541	draggin' ball hat of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +5, Familiar Effect: "atk, 1xVolley, cap 25"
 542	Jeselnik's hale 1337 7r0uZ0RZ	0		Maximum HP: +20, Sleaze Damage: +25, Familiar Effect: "2xPotato, cap 27"
-543	big moldy twirling Trollhouse cookies	5	crappy	
+543	moldy big twirling Trollhouse cookies	5	crappy	
 544	miser's chilly talons	0		Cold Damage: +5, Meat Drop: +10
-545	tiny stale Spam Witch sammich	1	decent	
+545	stale tiny Spam Witch sammich	1	decent	
 546	skewed meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -563,29 +563,29 @@
 565	shaking Oprah's hobo gloves	0		Maximum MP Percent: +50, Single Equip
 566	grievous bum cheek	0		Weapon Damage Percent: +50, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	half-sized rotten Double Bacon Beelzeburger	2	crappy	
+568	rotten half-sized Double Bacon Beelzeburger	2	crappy	
 569	half-sized flavorless Lord of the Flies-sized fries	2	decent	
 570	adequate Chicken Sandwich	3	good	
 571	Jumbo Dr. Lucifer	1	decent	
 572	moldy diet squat Children's Meal of the Damned	1	crappy	
 573	bland snack-sized noodles	2	decent	
-574	bite-sized toothsome fancy noodles	1	awesome	Effect: "Well-preserved", Effect Duration: 20
+574	fancy toothsome bite-sized noodles	1	awesome	Effect: "Well-preserved", Effect Duration: 20
 575	stale huge painful penne pasta	8	decent	
-576	thick flavorless mirror ravioli della hippy	5	decent	
+576	flavorless thick mirror ravioli della hippy	5	decent	
 577	spoiled pr0n m4nic0tti	3	crappy	
 578	spoiled Hell ramen	4	crappy	
 579	decent huge boring spaghetti	7	good	
 580	sauce of the ages	0		
-581	yellow twirling schmancy cheese sauce	0		
+581	twirling yellow schmancy cheese sauce	0		
 582	skewed Himalayan Hidalgo sauce	0		
 583	gigantic flavorless tumbling fettucini Inconnu	6	decent	
 584	bland spaghetti with Skullheads	3	decent	
-585	small bland gnocchetti di Nietzsche	2	decent	
+585	bland small gnocchetti di Nietzsche	2	decent	
 586	therapeutic ridiculously huge sword of the boozehound	0		Booze Drop: +100, HP Regen Min: 5, HP Regen Max: 7
 587	oxidized vacuum-sealed narrow super-spiky hair gel	0		Effect: "Blood-Gorged", Effect Duration: 68
 588	soft echo eyedrop antidote	0		
-589	adequate diet red narrow cocoa eggshell fragment	1	good	
-590	immense spoiled cocoa eggshell fragment	7	crappy	
+589	diet adequate red narrow cocoa eggshell fragment	1	good	
+590	spoiled immense cocoa eggshell fragment	7	crappy	
 591	cocoa egg	0		
 592	house	0		
 593	phonics down	0		
@@ -634,14 +634,14 @@
 636	meat globe	0		
 637	upside-down toaster	0		
 638	ghostly healthy asshat of the empath	0		Maximum HP Percent: +20, Familiar Weight: +5, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	big toothsome abominable snowcone	5	awesome	
+639	toothsome big abominable snowcone	5	awesome	
 640	narrow Ent cider	1	crappy	
 641	moldy toast	3	crappy	
 642	skeleton key	0		
 643	wobbly skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	lime green wrapping paper	0		Last Available: "2003-12"
-646	low-calorie moldy fancy fruitcake	1	crappy	Effect: "Preternatural Greed", Effect Duration: 40
+646	low-calorie fancy moldy fruitcake	1	crappy	Effect: "Preternatural Greed", Effect Duration: 40
 647	present	0		Last Available: "2004-11"
 648	tumbling chilly Crimbo sword	0		Cold Damage: +5, Last Available: "2004-10"
 649	bouncing aromatic Crimbo hat	0		Stench Resistance: +1, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
@@ -660,15 +660,15 @@
 662	chaotic star buckler	0		Spell Critical Percent: +10, Damage Reduction: 10
 663	star throwing star	0		
 664	upside-down star starfish	0		
-665	mirror ghostly Richard's star key	0		
+665	ghostly mirror Richard's star key	0		
 666	pulsating skewed fireproof electrified wizardly steaming evil	0		Mysticality: +25, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5
 667	castle map	0		
 668	mirror spiked femur of the wise owl	0		Mysticality: +20
-669	delicious immense ghuol guolash	10	awesome	
+669	immense delicious ghuol guolash	10	awesome	
 670	red ribald lihc face	0		Sleaze Damage: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	toasty dance instructor's grave robbing shovel	0		Experience Percent (Moxie): +10, Hot Damage: +5
-672	big fancy bland cranberries	5	decent	Effect: "Bloody-minded", Effect Duration: 35
-673	acceptable squat yellow vodka and cranberry	3	good	
+672	bland big fancy cranberries	5	decent	Effect: "Bloody-minded", Effect Duration: 35
+673	acceptable yellow squat vodka and cranberry	3	good	
 674	drinkable whiskey	3	good	
 675	Jack Frost's skull of the Bonerdagon	0		Cold Spell Damage: +50
 676	dragonbone belt buckle	0		
@@ -679,7 +679,7 @@
 681	acceptable slip 'n' slide	3	good	
 682	acceptable a sump'm sump'm	3	good	
 683	tolerable horizontal tango	4	good	
-684	practically non-alcoholic mediocre pink pony	1	decent	
+684	mediocre practically non-alcoholic pink pony	1	decent	
 685	Jack Frost's rosy-cheeked Mr. Shirt of bravery	0		Maximum HP Percent: +30, Cold Spell Damage: +50, Spooky Resistance: +5
 686	zippy knuckles	0		Initiative: +20
 687	enhanced electrified blood of the Wereseal	0		Effect: "Broberry Brotality", Effect Duration: 47
@@ -716,13 +716,13 @@
 720	ruddy porquoise necklace of the brazier	0		Maximum HP Percent: +40, Hot Spell Damage: +25, Single Equip
 721	savvy porquoise bracelet of the wise owl	0		Mysticality: +20, Mysticality Percent: +20
 722	narrow mansplainer's porquoise ring of dire peril of courage	0		Weapon Damage: +20, Monster Level: +15, Spooky Resistance: +3, Single Equip
-723	spoiled half-sized red pulsating Knoll mushroom	2	crappy	
+723	spoiled half-sized pulsating red Knoll mushroom	2	crappy	
 724	bland mushroom	4	decent	
 725	one million meat pancakes	0		
 726	banded huge mirror shard	0		Damage Absorption: +100
 727	narrow hedge maze puzzle	0		
 728	wobbly hedge maze key	0		
-729	yellow shaking jittery fishbowl	0		
+729	jittery yellow shaking fishbowl	0		
 730	fishtank	0		
 731	fish hose	0		
 732	hosed tank	0		
@@ -731,23 +731,23 @@
 735	bouncing rosewater-soaked easter egg balloon	0		Stench Resistance: +3
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	huge upside-down stone tablet (Really Evil Rhythm)	0		
+738	upside-down huge stone tablet (Really Evil Rhythm)	0		
 739	cyan tambourine bells	0		
 740	electrified tambourine	0		MP Regen Min: 3, MP Regen Max: 5
 741	broken skull	0		
 742	delicious Knoll shroomkabob	4	awesome	
-743	big toothsome mushroom	5	awesome	
+743	toothsome big mushroom	5	awesome	
 744	aerosolized hair spray	0		Effect: "X-Ray Vision", Effect Duration: 11
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
-749	spoiled enchanted miniature warm mushroom	2	crappy	Effect: "Thaumodynamic", Effect Duration: 45
+749	enchanted miniature spoiled warm mushroom	2	crappy	Effect: "Thaumodynamic", Effect Duration: 45
 750	spoiled mushroom quesadilla	4	crappy	
 751	decent cool mushroom	4	good	
 752	decent massive cool mushroom casserole	10	good	
-753	jumbo moldy pointy mushroom	5	crappy	
+753	moldy jumbo pointy mushroom	5	crappy	
 754	tasty wobbly cream of pointy mushroom soup	4	awesome	
-755	tiny decent blue skewed shaking mushroom	1	good	
+755	decent tiny shaking skewed blue mushroom	1	good	
 756	moldy mushroom	3	crappy	
 757	decent mushroom	4	good	
 758	half-sized stale red ghost cucumber	2	decent	
@@ -795,21 +795,21 @@
 800	decent huge poutine	8	good	
 801	stale Knob stir-fry	4	decent	
 804	flavorless Knoll stir-fry	4	decent	
-805	toothsome special snack-sized stir-fry	2	awesome	Effect: "Permafrosty", Effect Duration: 30
+805	snack-sized toothsome special stir-fry	2	awesome	Effect: "Permafrosty", Effect Duration: 30
 806	stale asparagus stir-fry	4	decent	
-807	adequate fancy low-calorie olive stir-fry	1	good	Effect: "Deeply Ironic", Effect Duration: 40
-808	adequate immense Knob sausage stir-fry	10	good	
+807	fancy adequate low-calorie olive stir-fry	1	good	Effect: "Deeply Ironic", Effect Duration: 40
+808	immense adequate Knob sausage stir-fry	10	good	
 809	normal bat wing stir-fry	4	good	
-810	tasty wobbly squat rat appendix stir-fry	3	awesome	
+810	tasty squat wobbly rat appendix stir-fry	3	awesome	
 811	rotten tofu stir-fry	4	crappy	
 812	normal pr0n stir-fry	4	good	
 813	special bland narrow Knob shells	3	decent	Effect: "Highland Sheen", Effect Duration: 45
 814	bland skewed b&auml;tzle	4	decent	
 815	decent jittery ratini	4	good	
-816	enchanted moldy Knob stroganoff	4	crappy	Effect: "Oxygenated Blood", Effect Duration: 35
-817	fancy thick yummy spinning menudo ravioli	5	awesome	Effect: "Crimbo Epiphany", Effect Duration: 5
+816	moldy enchanted Knob stroganoff	4	crappy	Effect: "Oxygenated Blood", Effect Duration: 35
+817	thick fancy yummy spinning menudo ravioli	5	awesome	Effect: "Crimbo Epiphany", Effect Duration: 5
 818	teal plus sign	0		
-819	jittery wobbly milky potion	0		
+819	wobbly jittery milky potion	0		
 820	spinning swirly potion	0		
 821	squat bubbly potion	0		
 822	smoky potion	0		
@@ -827,7 +827,7 @@
 834	twirling Sinatra's cornuthaum of temperance	0		Experience (Moxie): +5, Sleaze Resistance: +5, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	ring of aggravate monster of the detective	0		Item Drop: +20
 836	bland blue mind flayer corpse	3	decent	
-837	weak artisanal spinning Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
+837	artisanal weak spinning Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
 838	medical-grade hardy Mafia stogie	0		Maximum HP: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2004-10"
 839	artisanal Maiali Sifilitici Pinot Noir	4	EPIC	Last Available: "2004-10"
 840	dangerous Mafia violin case of the ox	0		Muscle: +20, Weapon Damage: +10, Last Available: "2004-10"
@@ -876,13 +876,13 @@
 885	axe of bravery	0		Spooky Resistance: +5
 886	gray mirror leaflet	0		
 887	leaf	0		
-888	squat huge maple leaf	0		
+888	huge squat maple leaf	0		
 889	maroon Usain Bolt's balaclava	0		Initiative: +80, Familiar Effect: "cold atk, 1.5xLep, cap 12"
 890	yummy balaclava baklava	3	awesome	
 891	resourceful Warehouse 23 bling	0		Maximum MP: +50
 892	Oprah's dance instructor's Herculean bugbear-smiting sword	0		Experience (Muscle): +1, Experience Percent (Moxie): +10, Maximum MP Percent: +50
 893	mediocre blurry lumbering jack	4	decent	
-894	skewed blue Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
+894	blue skewed Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	Rosewater's Ms. Accessory	0		Mysticality Percent: +30, Softcore Only
 896	smelly occult Mr. Accessory Jr.	0		Spell Damage Percent: +25, Stench Spell Damage: +10, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
@@ -915,12 +915,12 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	quadruple-pickled blue Hawking's Elixir of Brilliance	0		Effect: "Pharmaceutically Cool", Effect Duration: 33
-927	delicious watered-down Ferita Del Petto Zinfandel	2	awesome	Last Available: "2006-12"
+927	watered-down delicious Ferita Del Petto Zinfandel	2	awesome	Last Available: "2006-12"
 928	hardy fuzzy bracelets	0		Maximum HP: +50
 929	wobbly forbidden arse-shooting crossbow	0		Spell Damage Percent: +50
 931	perfectly mixed strong spiced rum	5	EPIC	
 932	lousy eggnog	3	decent	
-933	bland miniature narrow cyan candy cane	2	decent	
+933	bland miniature cyan narrow candy cane	2	decent	
 934	moldy half-sized gingerbread bugbear	2	crappy	
 935	imitation nice watch of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -937,7 +937,7 @@
 947	ghostly skewered cherry	0		Last Available: "2004-12"
 948	drinkable skewed martini	4	good	Last Available: "2004-12"
 949	drinkable grogtini	3	good	Last Available: "2004-12"
-950	aged irresponsibly strong cherry bomb	6	awesome	Last Available: "2004-12"
+950	irresponsibly strong aged cherry bomb	6	awesome	Last Available: "2004-12"
 951	wobbly extra special Crimbo stocking	0		Last Available: "2004-12"
 952	squat friendly quilted hockey mask	0		Damage Absorption: +40, Familiar Weight: +3, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
@@ -945,8 +945,8 @@
 955	Tesla fez of etymology	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xLep, cap 30"
 956	bland twirling twirling carob chunk noodles	4	decent	
 957	tasty snack-sized chorizo brownies	2	awesome	
-958	spoiled gigantic purple squat chocolate and tomato pizza	7	crappy	
-959	maroon blurry flange	0		
+958	spoiled gigantic squat purple chocolate and tomato pizza	7	crappy	
+959	blurry maroon flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
 962	velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -988,14 +988,14 @@
 1000	pulsating Meat maid	0		
 1002	brawny Xlyinia's notebook	0		Muscle Percent: +20
 1003	soda water	0		
-1004	tolerable enchanted narrow bottle of tequila	4	good	Effect: "Shamboozled", Effect Duration: 5
+1004	enchanted tolerable narrow bottle of tequila	4	good	Effect: "Shamboozled", Effect Duration: 5
 1005	acceptable boxed wine	4	good	
 1006	small rotten cherry	2	crappy	
 1007	tumbling coconut shell of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xFairy, cap 7"
 1008	skewed razor-sharp ice cubes	0		Weapon Damage Percent: +25
 1009	lousy high-proof special vodka martini	7	decent	Effect: "Spooky Weapon", Effect Duration: 10
 1010	drinkable whiskey and soda	3	good	
-1011	high-proof tolerable wobbly monkey wrench	10	good	
+1011	tolerable high-proof wobbly monkey wrench	10	good	
 1012	weak hand-crafted tequila sunrise	2	EPIC	
 1013	tolerable margarita	4	good	
 1014	tolerable strawberry wine	3	good	
@@ -1008,11 +1008,11 @@
 1021	weak artisanal tequila with training wheels	2	EPIC	
 1022	hand-crafted sangria	3	EPIC	
 1023	smooth enchanted vesper	4	awesome	Effect: "Cautious Prowl", Effect Duration: 10, Last Available: "2004-12"
-1024	lousy watered-down squat bodyslam	2	decent	Last Available: "2004-12"
-1025	drinkable watered-down sangria del diablo	2	good	Last Available: "2004-12"
+1024	watered-down lousy squat bodyslam	2	decent	Last Available: "2004-12"
+1025	watered-down drinkable sangria del diablo	2	good	Last Available: "2004-12"
 1026	purple Valentine	0		Free Pull
 1027	squat whip kit	0		
-1028	blinking cyan buckler buckle	0		
+1028	cyan blinking buckler buckle	0		
 1029	pulsating Usain Bolt's hippo whip	0		Initiative: +80
 1030	stylish penguin whip	0		Moxie: +25
 1031	stanky yak whip	0		Stench Spell Damage: +25
@@ -1024,7 +1024,7 @@
 1037	weightlifter's gnauga hide buckler	0		Muscle: +15, Damage Reduction: 5
 1038	oxidized energized modified Connery's Elixir of Audacity	0		Effect: "Jelly Combed", Effect Duration: 26
 1040	blurry Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	aged practically non-alcoholic blurry beer	1	awesome	
+1041	practically non-alcoholic aged blurry beer	1	awesome	
 1042	string of beads of the sweet-tooth	0		Candy Drop: +100
 1043	wizardly string of beads	0		Mysticality: +25
 1044	string of beads of Leguizamo	0		Monster Level: +20
@@ -1033,17 +1033,17 @@
 1047	delicious N. O. Beer	3	awesome	
 1048	diluted maroon oyster egg	1		Effect: "Swimming Head", Effect Duration: 5
 1049	twisted cyan oyster egg	1		
-1050	denatured gray ghostly oyster egg	1		
+1050	denatured ghostly gray oyster egg	1		
 1051	upside-down huge plastic oyster egg	0		
 1052	powdered wobbly oyster egg	1		
 1053	diluted oyster egg	1		
 1054	dehydrated blue spinning oyster egg	1		
 1055	green plastic oyster egg	0		
 1056	compressed puce oyster egg	1		
-1057	boiled ghostly jittery puce oyster egg	1		
+1057	boiled jittery ghostly puce oyster egg	1		
 1058	denatured skewed puce oyster egg	1		Effect: "Good Karma", Effect Duration: 30
 1059	shaking puce plastic oyster egg	0		
-1060	modified jittery lime green mauve oyster egg	1		
+1060	modified lime green jittery mauve oyster egg	1		
 1061	powdered purple mauve oyster egg	1		
 1062	boiled shaking mauve oyster egg	1		Effect: "Marco Polarity", Effect Duration: 35
 1063	jittery mauve plastic oyster egg	0		
@@ -1051,7 +1051,7 @@
 1065	denatured oyster egg	1		Effect: "A Taste of Rainbow", Effect Duration: 35
 1066	twisted blinking oyster egg	1		
 1067	plastic oyster egg	0		
-1068	diluted squat wobbly oyster egg	1		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
+1068	diluted wobbly squat oyster egg	1		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
 1069	compressed cyan oyster egg	1		
 1070	compressed squat oyster egg	1		
 1071	green plastic oyster egg	0		
@@ -1059,7 +1059,7 @@
 1073	dehydrated jittery jittery off-white oyster egg	1		Effect: "Broken Bone Nubs", Effect Duration: 20
 1074	vaporized mirror off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	modified huge jittery ghostly oyster egg	1		
+1076	modified ghostly jittery huge oyster egg	1		
 1077	modified tumbling oyster egg	1		
 1078	mixed huge oyster egg	1		Effect: "Human-Slime Hybrid", Effect Duration: 15
 1079	plastic oyster egg	0		
@@ -1123,16 +1123,16 @@
 1137	Jim Carey's bicycle chain	0		Monster Level: +25, Item Drop: +5
 1138	mushroom fermenting solution	0		
 1139	lousy mushroom wine	3	decent	
-1140	drinkable practically non-alcoholic icy mushroom wine	1	good	
+1140	practically non-alcoholic drinkable icy mushroom wine	1	good	
 1141	mediocre mushroom wine	4	decent	
 1142	acceptable pointy mushroom wine	3	good	
-1143	tolerable weak flat mushroom wine	2	good	
+1143	weak tolerable flat mushroom wine	2	good	
 1144	delicious watered-down cool mushroom wine	2	awesome	
 1145	lousy knob mushroom wine	3	decent	
-1146	practically non-alcoholic lousy wobbly knoll mushroom wine	1	decent	
+1146	lousy practically non-alcoholic wobbly knoll mushroom wine	1	decent	
 1147	smooth mushroom wine	3	awesome	
 1148	lousy shot of flower schnapps	4	decent	
-1149	rotten special huge flower petal pie	8	crappy	Effect: "Egg on your Face", Effect Duration: 25
+1149	special rotten huge flower petal pie	8	crappy	Effect: "Egg on your Face", Effect Duration: 25
 1150	artisanal bottle of single-barrel whiskey	3	EPIC	
 1151	pulsating discarded plastic fork of Leguizamo of Flo-Jo	0		Monster Level: +20, Initiative: +100
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1168,7 +1168,7 @@
 1183	all-purpose flower	0		
 1184	exotic orchid	0		
 1185	long-stemmed rose	0		
-1186	gray spinning gilded lily	0		
+1186	spinning gray gilded lily	0		
 1187	deadly nightshade	0		
 1188	lotus	0		
 1189	blinking can of asparagus	0		
@@ -1187,19 +1187,19 @@
 1202	snack-sized yummy Happy Birthday, Claude! cake	2	awesome	
 1203	normal tumbling personalized birthday cake	4	good	
 1204	flavorless three-tiered wedding cake	4	decent	
-1205	half-sized stale babycakes	2	decent	
+1205	stale half-sized babycakes	2	decent	
 1206	half-sized bland velvet cake	2	decent	
-1207	toothsome small squat congratulatory cake	2	awesome	
+1207	small toothsome squat congratulatory cake	2	awesome	
 1208	normal angel-food cake	3	good	
 1209	spoiled devil's-food cake	4	crappy	
-1210	snack-sized bland gray birthday party jellybean cheesecake	2	decent	
+1210	bland snack-sized gray birthday party jellybean cheesecake	2	decent	
 1211	balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
 1214	anniversary balloon	0		
 1215	bouncing Mylar balloon	0		
 1216	twirling Kevlar balloon	0		
-1217	upside-down bouncing thought balloon	0		
+1217	bouncing upside-down thought balloon	0		
 1218	green rat head balloon	0		Familiar Weight: -3
 1219	mini-zeppelin	0		
 1220	Mr. Balloon of the pedagogue	0		Experience: +3
@@ -1255,7 +1255,7 @@
 1271	aluminum wand	0		
 1272	marble wand	0		
 1273	supercharged magic lamp	0		Maximum MP Percent: +30
-1274	mixed teal skewed Medicinal Herb's medicinal herbs	1		Effect: "Mortarfied", Effect Duration: 50
+1274	mixed skewed teal Medicinal Herb's medicinal herbs	1		Effect: "Mortarfied", Effect Duration: 50
 1275	bouncing educational basic meat skirt	0		Experience: +1, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	hand-crafted watered-down Otorian Battle Scar	2	EPIC	
 1277	lion tamer's basic meat kilt	0		Experience (familiar): +2, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1298,7 +1298,7 @@
 1314	scorching Baron von Ratsworth's tophat	0		Hot Damage: +25, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
 1315	dance instructor's rose-colored glasses	0		Experience Percent (Moxie): +10
 1316	facsimile dictionary	0		
-1317	maroon shaking blood flower	0		
+1317	shaking maroon blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
 1320	stale questionable taco	3	decent	
@@ -1347,7 +1347,7 @@
 1364	blurry rhesus monkey	0		Familiar Weight: +5
 1365	bite-sized enchanted moldy spinning tofurkey leg	1	crappy	Effect: "Tearful, Fearful", Effect Duration: 5
 1366	small decent tofurkey gravy	2	good	
-1367	gigantic normal herbal stuffing	8	good	
+1367	normal gigantic herbal stuffing	8	good	
 1368	stale small can-shaped gelatinous cranberry sauce	2	decent	
 1369	bland narrow yams	3	decent	
 1370	spinning Sinatra's rhinestone cowboy shirt	0		Experience (Moxie): +5
@@ -1390,7 +1390,7 @@
 1408	half-sized stale lime green tree-shaped Crimbo cookie	2	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	MacGyver's Unionize The Elves sign	0		Maximum MP: +100, Last Available: "2005-12"
 1410	olive sleeping snowy owl	0		Last Available: "2005-12"
-1411	blurry Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	blurry Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	polarized snowcone	0		Effect: "Hot Hands", Effect Duration: 66, Last Available: "2006-01"
 1413	nitrogenated boiled snowcone	0		Effect: "Joy", Effect Duration: 65, Last Available: "2006-01"
 1414	super-unsweetened narrow snowcone	0		Effect: "Cold Hands", Effect Duration: 54, Last Available: "2006-01"
@@ -1402,7 +1402,7 @@
 1420	flame-wreathed friendly traffic cone	0		Familiar Weight: +3, Hot Spell Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	upside-down Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
-1423	upside-down narrow iceberglet	0		Last Available: "2006-02"
+1423	narrow upside-down iceberglet	0		Last Available: "2006-02"
 1424	smartaleck's ice sickle of the businessman	0		Moxie Percent: +30, Meat Drop: +50, Softcore Only, Last Available: "2006-02"
 1425	banded ice baby	0		Damage Absorption: +100, Softcore Only, Last Available: "2006-02"
 1426	ice pick of the early riser	0		Adventures: +7, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
@@ -1412,15 +1412,15 @@
 1430	twirling pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
 1432	bland mushroom	3	decent	
-1433	purple upside-down fruit bowl	0		
+1433	upside-down purple fruit bowl	0		
 1434	fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
 1437	useless powder	0		
 1438	improved twinkly powder	0		Effect: "Jawin'", Effect Duration: 31
 1439	flattened moist narrow hot powder	0		Effect: "Favored by Lyle", Effect Duration: 27
-1440	liquefied super-enhanced twirling pulsating powder	0		Effect: "Sticks and Stones", Effect Duration: 18
-1441	oxidized twirling jittery powder	0		Effect: "Conspiratory Eyes", Effect Duration: 24
+1440	liquefied super-enhanced pulsating twirling powder	0		Effect: "Sticks and Stones", Effect Duration: 18
+1441	oxidized jittery twirling powder	0		Effect: "Conspiratory Eyes", Effect Duration: 24
 1442	anodized extra-frozen tumbling stench powder	0		Effect: "Phorcefullness", Effect Duration: 21
 1443	cold-filtered gray sleaze powder	0		Effect: "In the Limelight", Effect Duration: 36
 1444	energized dry twinkly nuggets	0		Effect: "Salamanderenity", Effect Duration: 59
@@ -1431,8 +1431,8 @@
 1449	Vulcanized dry olive shaking sleaze nuggets	0		Effect: "Ooh, Bitter!", Effect Duration: 44
 1450	mixed twinkly wad	1		
 1451	boiled bouncing hot wad	1		
-1452	twisted mirror jittery wad	1		
-1453	powdered wobbly tumbling wad	1		
+1452	twisted jittery mirror wad	1		
+1453	powdered tumbling wobbly wad	1		
 1454	compressed stench wad	1		
 1455	distilled sleaze wad	1		
 1456	shaking double daisy	0		
@@ -1451,21 +1451,21 @@
 1469	pulsating bill bec-de-bardiche glaive-guisarme	0		
 1470	green lead yo-yo	0		
 1471	slightly peevedbow	0		
-1472	teal bouncing tumbling sack of doorknobs	0		
+1472	teal tumbling bouncing sack of doorknobs	0		
 1473	ball-and-chain	0		
 1474	squat automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	maroon goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	plastic hard hat	0		Familiar Effect: "atk, cap 22"
-1478	mirror jittery salad bowl	0		Familiar Effect: "atk, cap 30"
-1479	gray upside-down football helmet	0		Familiar Effect: "atk, cap 37"
+1478	jittery mirror salad bowl	0		Familiar Effect: "atk, cap 30"
+1479	upside-down gray football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
 1482	paper-plate-mail pants	0		Familiar Effect: "hot atk, 2xBarrr, cap 20"
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	pulsating wobbly maroon boxer's beefcake's rabbit's foot	0		Muscle: +25, Muscle Percent: +10
-1486	bouncing red massive bag of catnip	0		
+1486	red bouncing massive bag of catnip	0		
 1487	spinning hang glider	0		
 1488	fuchsia March hat	0		Free Pull
 1489	dormouse	0		
@@ -1477,22 +1477,22 @@
 1495	stiffened razor-sharp traffic cone	0		Weapon Damage Percent: +25, Damage Reduction: 1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	triple-distilled acceptable gloomy mushroom wine	10	good	
 1497	spirit-forward tolerable mushroom wine	5	good	
-1498	twirling narrow McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	narrow twirling McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	maroon whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
-1501	concentrated double-denatured huge wobbly green explosion-flavored chewing gum	0		Effect: "Sticky Fingers", Effect Duration: 43, Last Available: "2006-04"
+1501	concentrated double-denatured green wobbly huge explosion-flavored chewing gum	0		Effect: "Sticky Fingers", Effect Duration: 43, Last Available: "2006-04"
 1502	huge clown hammer	0		Last Available: "2006-04"
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	extra-warmed snowcone	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 24, Last Available: "2006-04"
 1505	bouncing shaking ice cube with a fly in it	0		Last Available: "2006-04"
-1506	artisanal practically non-alcoholic calle de miel with a fly in it	1	EPIC	Last Available: "2006-04"
+1506	practically non-alcoholic artisanal calle de miel with a fly in it	1	EPIC	Last Available: "2006-04"
 1507	lousy practically non-alcoholic rockin' wagon with a fly in it	1	decent	Last Available: "2006-04"
-1508	special lousy perpendicular hula with a fly in it	3	decent	Effect: "Amorous Avarice", Effect Duration: 5, Last Available: "2006-04"
-1509	watered-down delicious skewed slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
+1508	lousy special perpendicular hula with a fly in it	3	decent	Effect: "Amorous Avarice", Effect Duration: 5, Last Available: "2006-04"
+1509	delicious watered-down skewed slap and tickle with a fly in it	2	awesome	Last Available: "2006-04"
 1510	spinning bag of airline peanuts	0		Last Available: "2006-04"
 1511	yellow quilted fake hand	0		Damage Absorption: +40, Last Available: "2006-04"
 1512	powdered Knob Goblin pet-buffing spray	1		Effect: "Full-Body Tan", Effect Duration: 40
-1513	twisted red twirling squat Knob Goblin learning pill	1		Effect: "Holiday Disappointment", Effect Duration: 35
+1513	twisted twirling squat red Knob Goblin learning pill	1		Effect: "Holiday Disappointment", Effect Duration: 35
 1514	altered ghostly Knob Goblin eyedrops	1		
 1515	dried shaking Knob Goblin nasal spray	1		
 1516	KWE-brand transistor radio	0		
@@ -1503,9 +1503,9 @@
 1522	upside-down jittery huge dog trainer's fortified Radio Free Jersey	0		Damage Absorption: +60, Experience (familiar): +1
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	upside-down joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1525	upside-down joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	tumbling pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
-1527	narrow yellow diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
+1527	yellow narrow diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	pulsating vibrating beefy corkscrew	0		Muscle: +10, Maximum MP Percent: +10, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
@@ -1513,7 +1513,7 @@
 1532	huge bouncing grass hat of the bloodbag	0		Maximum HP: +100, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	olive grass blade of the glutton	0		Food Drop: +100, Last Available: "2011-01"
 1534	raffle prize box	0		
-1536	green tumbling homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
+1536	tumbling green homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	gray groovy sparkly engagement ring	0		Moxie Percent: +10, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
@@ -1529,39 +1529,39 @@
 1549	MSG	0		
 1550	baleful second-hand knockoff engagement ring	0		Spell Damage: +25, Single Equip
 1551	acceptable mirror wobbly bottle of Domesticated Turkey	4	good	
-1552	hand-crafted weak huge bottle of Definit	2	EPIC	
+1552	weak hand-crafted huge bottle of Definit	2	EPIC	
 1553	drinkable pulsating bottle of Calcutta Emerald	3	good	
 1554	artisanal weak bottle of Lieutenant Freeman	2	EPIC	
 1555	delicious extra-dry yellow bottle of Jorge Sinsonte	5	awesome	
 1556	tolerable boxed champagne	3	good	
-1557	moldy small jittery kumquat	2	crappy	
-1558	toothsome diet tangerine	1	awesome	
+1557	small moldy jittery kumquat	2	crappy	
+1558	diet toothsome tangerine	1	awesome	
 1559	jittery tonic water	0		
-1560	bland red skewed cocktail onion	4	decent	
+1560	bland skewed red cocktail onion	4	decent	
 1561	adequate raspberry	3	good	
 1562	yummy blinking kiwi	3	awesome	
-1563	acceptable watered-down maroon whiskey bittersweet	2	good	
+1563	watered-down acceptable maroon whiskey bittersweet	2	good	
 1564	bad mimosette	3	decent	
 1565	bad tequila sunset	4	decent	
 1566	weak lousy mirror zmobie	2	decent	Wiki Name: "Zmobie (drink)"
 1567	lousy gin and tonic	4	decent	
 1568	tolerable practically non-alcoholic vodka and tonic	1	good	
 1569	high-proof aged vodka gibson	6	awesome	
-1570	practically non-alcoholic hand-crafted gibson	1	super EPIC	
+1570	hand-crafted practically non-alcoholic gibson	1	super EPIC	
 1571	watered-down aged parisian cathouse	2	awesome	
-1572	bad weak rabbit punch	2	decent	
+1572	weak bad rabbit punch	2	decent	
 1573	irresponsibly strong artisanal caipifruta	9	EPIC	
-1574	acceptable weak teqiwila	2	good	
+1574	weak acceptable teqiwila	2	good	
 1575	bad yellow Divine	3	decent	
 1576	weak smooth Gordon Bennett	2	awesome	
 1577	drinkable tangarita	3	good	
-1578	special hand-crafted practically non-alcoholic mandarina colada	1	super ultra mega turbo EPIC	Effect: "Eldritch Concentration", Effect Duration: 5
+1578	practically non-alcoholic hand-crafted special mandarina colada	1	super ultra mega turbo EPIC	Effect: "Eldritch Concentration", Effect Duration: 5
 1579	bad shaking gimlet	4	decent	
 1580	tolerable upside-down brick road	4	good	
 1581	perfectly mixed vodka stratocaster	3	EPIC	
 1582	weak acceptable Neuromancer	2	good	
 1583	watered-down perfectly mixed prussian cathouse	2	super ultra EPIC	
-1584	enchanted acceptable Mae West	4	good	Effect: "Punch Another Day", Effect Duration: 20
+1584	acceptable enchanted Mae West	4	good	Effect: "Punch Another Day", Effect Duration: 20
 1585	practically non-alcoholic perfectly mixed jittery Mon Tiki	1	super ultra mega turbo EPIC	
 1586	drinkable practically non-alcoholic mirror teqiwila slammer	1	good	
 1587	stale Knob lo mein	3	decent	
@@ -1569,7 +1569,7 @@
 1589	normal Knoll lo mein	4	good	
 1590	moldy gigantic lo mein	9	crappy	
 1591	flavorless olive lo mein	4	decent	
-1592	adequate half-sized upside-down hot hi mein	2	good	
+1592	half-sized adequate upside-down hot hi mein	2	good	
 1593	stale hi mein	3	decent	
 1594	adequate hi mein	4	good	
 1595	moldy hi mein	4	crappy	
@@ -1577,7 +1577,7 @@
 1597	tumbling banded Junior LAAAAME merit badge	0		Damage Absorption: +100, Last Available: "2006-05"
 1598	cyan horrifying Senior LAAAAME merit badge	0		Spooky Damage: +25, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	smooth triple-distilled tangarita with a fly in it	10	awesome	
+1600	triple-distilled smooth tangarita with a fly in it	10	awesome	
 1601	bad practically non-alcoholic fancy mandarina colada with a fly in it	1	decent	Effect: "Sparkling Consciousness", Effect Duration: 15
 1602	drinkable ghostly spinning prussian cathouse with a fly in it	4	good	
 1603	strong tolerable squat lime green Mae West with a fly in it	5	good	
@@ -1623,14 +1623,14 @@
 1643	rotten wedge of gray cheese	4	crappy	Last Available: "2008-11"
 1644	purple squat hot and sauce	0		
 1645	and sauce	0		
-1646	maroon bouncing and sauce	0		
+1646	bouncing maroon and sauce	0		
 1647	stench and sauce	0		
 1648	sleazy and sauce	0		
 1649	wobbly brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	enchanted adequate maroon foie gras	3	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 15
+1651	adequate enchanted maroon foie gras	3	good	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 15
 1652	denatured quantum blinking candy brain	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 55, Last Available: "2020-09"
-1653	scandalous occult strapping jewel-eyed wizard hat	0		Muscle: +5, Spell Damage Percent: +25, Sleaze Damage: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	scandalous occult strapping jewel-eyed wizard hat	0		Muscle: +5, Spell Damage Percent: +25, Sleaze Damage: +5, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	rock-hard wad of Crovacite of the brazier	0		Damage Reduction: 5, Hot Spell Damage: +25
 1655	censurious sharpshooter's collar	0		Critical Hit Percent: +10, Sleaze Resistance: +3
 1656	ghostly White Citadel Satisfaction Satchel	0		
@@ -1678,7 +1678,7 @@
 1698	rotten blue jumping bean taco	4	crappy	
 1699	normal tumbling catgut taco	3	good	
 1700	decent goat cheese taco	4	good	
-1701	tasty jumbo pr0n taco	5	awesome	
+1701	jumbo tasty pr0n taco	5	awesome	
 1702	alkaline alphabet gum	0		Effect: "Weepy, Creepy", Effect Duration: 51
 1703	gray Comma Chameleon egg	0		Free Pull
 1704	ghostly shingle	0		
@@ -1745,7 +1745,7 @@
 1766	Spookyraven ballroom key	0		
 1767	pulsating pack of chewing gum	0		
 1768	teal Gnomish toolbox	0		
-1769	tiny toothsome fricasseed brains	1	awesome	
+1769	toothsome tiny fricasseed brains	1	awesome	
 1770	flavorless huge brains casserole	10	decent	
 1771	lion tamer's butcherknife	0		Experience (familiar): +2
 1772	lime green tumbling perfumed corn holder	0		Stench Resistance: +5
@@ -1753,7 +1753,7 @@
 1774	practically non-alcoholic bad wobbly bottle of popskull	1	decent	
 1775	dishrag of the sweet-tooth	0		Candy Drop: +100
 1776	tiny yummy yellow stale baguette	1	awesome	
-1777	blurry fuchsia leftovers of indeterminate origin	0		
+1777	fuchsia blurry leftovers of indeterminate origin	0		
 1778	decent miniature dinner	2	good	
 1779	boxer's katana	0		Muscle Percent: +10
 1780	experienced ram stick	0		Experience: +2
@@ -1820,7 +1820,7 @@
 1841	left third rib	0		
 1842	left fourth rib	0		
 1843	yellow left fifth rib	0		
-1844	pulsating squat left sixth rib	0		
+1844	squat pulsating left sixth rib	0		
 1845	left seventh rib	0		
 1846	left eighth rib	0		
 1847	wobbly huge left ninth rib	0		
@@ -1842,7 +1842,7 @@
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
-1866	cyan ghostly left clavicle	0		
+1866	ghostly cyan left clavicle	0		
 1867	skewed right clavicle	0		
 1868	left humerus	0		
 1869	huge right humerus	0		
@@ -1853,7 +1853,7 @@
 1874	shaking left femur	0		
 1875	blue right femur	0		
 1876	left tibia	0		
-1877	huge blinking yellow right tibia	0		
+1877	yellow huge blinking right tibia	0		
 1878	left fibula	0		
 1879	right fibula	0		
 1880	ghostly left kneecap	0		
@@ -1870,7 +1870,7 @@
 1891	right thumb	0		
 1892	left first rear claw	0		
 1893	left second rear claw	0		
-1894	tumbling blinking left third rear claw	0		
+1894	blinking tumbling left third rear claw	0		
 1895	left fourth rear claw	0		
 1896	right first rear claw	0		
 1897	right second rear claw	0		
@@ -1900,7 +1900,7 @@
 1923	roll of toilet paper	0		Free Pull
 1924	tattered wolf standard	0		
 1925	tattered snake standard	0		
-1926	narrow twirling KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1926	twirling narrow KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
 1928	tuning fork	0		
 1929	spinning wholesome greaves	0		Maximum HP Percent: +10, Familiar Effect: "1xBarrr"
@@ -1927,7 +1927,7 @@
 1950	ghostly bottle of Vangoghbitussin	0		
 1951	drinkable bottle of Pinot Renoir	4	good	
 1952	spoiled desiccated apricot	3	crappy	
-1953	mediocre irresponsibly strong flute of flat champagne	7	decent	
+1953	irresponsibly strong mediocre flute of flat champagne	7	decent	
 1954	adequate skewed dehydrated caviar	3	good	
 1955	styrofoam peanuts	0		
 1956	aged practically non-alcoholic fuchsia snifter of thoroughly aged brandy	1	awesome	
@@ -1962,12 +1962,12 @@
 1985	scary death orb	0		
 1986	mind flayer	0		
 1987	undead elbow macaroni	0		
-1988	squat tumbling angry cow	0		
+1988	tumbling squat angry cow	0		
 1989	Cheshire bitten	0		
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
-1993	pulsating teal rubber WWSPD? bracelet	0		
+1993	teal pulsating rubber WWSPD? bracelet	0		
 1994	rubber WWtNSD? bracelet	0		
 1995	heart necklace	0		Free Pull
 1996	right half of a heart necklace	0		
@@ -1994,13 +1994,13 @@
 2017	huge spade necklace	0		
 2018	club necklace	0		
 2019	green cream pie	0		Free Pull
-2020	adequate low-calorie cherry pie	1	good	
+2020	low-calorie adequate cherry pie	1	good	
 2021	delicious strawberry pie	3	awesome	
 2022	flavorless lemon meringue pie	3	decent	
 2023	Genalen&trade; Bottle	1	decent	
 2024	delicious mixed wildflower greens	3	awesome	
-2025	bland small tumbling handful of walnuts	2	decent	
-2026	small delicious nutty organic salad	2	awesome	
+2025	small bland tumbling handful of walnuts	2	decent	
+2026	delicious small nutty organic salad	2	awesome	
 2027	decent half-sized super salad	2	good	
 2028	stale blinking tofu wonton	4	decent	
 2029	hippy protest button	0		Single Equip
@@ -2029,7 +2029,7 @@
 2053	skewed bust of Pallas	0		Familiar Weight: +5
 2054	twirling market map	0		
 2055	snake skin	0		
-2056	flattened tarnished squat spinning adder bladder	0		Effect: "Patched In", Effect Duration: 56
+2056	flattened tarnished spinning squat adder bladder	0		Effect: "Patched In", Effect Duration: 56
 2057	pension check	0		
 2058	picnic basket	0		
 2059	dry Black No. 2	0		Effect: "Livin' Large", Effect Duration: 66
@@ -2067,7 +2067,7 @@
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	hors d'oeuvre tray of temperance	0		Sleaze Resistance: +5, Damage Reduction: 5
-2094	immense spoiled ballroom blintz	9	crappy	
+2094	spoiled immense ballroom blintz	9	crappy	
 2095	towel	0		
 2096	altered guy made of bee pollen	1		
 2097	blinking 17-ball of the detective	0		Item Drop: +20
@@ -2110,8 +2110,8 @@
 2135	blinking alien blob	0		Last Available: "2006-12"
 2136	gray nasty beefy vampire duck-on-a-string	0		Muscle: +10, Stench Damage: +5, Last Available: "2006-12"
 2137	yellow Jack Frost's toy crazy train	0		Cold Spell Damage: +50, Single Equip, Last Available: "2006-12"
-2138	upside-down cyan razor-tipped yo-yo	0		Last Available: "2010-12"
-2139	fuchsia tumbling toy mercenary	0		Last Available: "2006-12"
+2138	cyan upside-down razor-tipped yo-yo	0		Last Available: "2010-12"
+2139	tumbling fuchsia toy mercenary	0		Last Available: "2006-12"
 2140	maroon length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
 2142	block	0		Last Available: "2011-12"
@@ -2126,7 +2126,7 @@
 2151	hand-crafted watered-down red shot of blackberry schnapps	2	EPIC	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
-2154	huge blinking ion grid	0		Last Available: "2011-12"
+2154	blinking huge ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	high-resistance ultrapolymer plating	0		Last Available: "2011-12"
@@ -2145,7 +2145,7 @@
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
 2171	inspector's Lo Pan's astronaut pants	0		Spell Critical Percent: +30, Item Drop: +15, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	lightning-fast toy jet pack	0		Initiative: +40, Last Available: "2006-12"
-2173	pulsating huge triangular stone	0		
+2173	huge pulsating triangular stone	0		
 2174	mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	yellow cracked stone sphere	0		
@@ -2161,12 +2161,12 @@
 2186	gray unlit birthday cake	0		
 2187	green lit birthday cake	0		
 2188	flask of peppermint oil	1	awesome	Last Available: "2006-12"
-2189	watered-down fancy bad flask of peppermint schnapps	2	decent	Effect: "Alpine Mintiness", Effect Duration: 10, Last Available: "2006-12"
+2189	watered-down bad fancy flask of peppermint schnapps	2	decent	Effect: "Alpine Mintiness", Effect Duration: 10, Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	spoiled tiny olive candy stake	1	crappy	Last Available: "2006-12"
-2194	drinkable watered-down eggnog	2	good	Last Available: "2006-12"
+2193	tiny spoiled olive candy stake	1	crappy	Last Available: "2006-12"
+2194	watered-down drinkable eggnog	2	good	Last Available: "2006-12"
 2195	adequate narrow unspeakable fruitcake	3	good	Last Available: "2006-12"
 2196	miniature stale gingerbread horror	2	decent	Last Available: "2006-12"
 2197	extra-nitrogenated energized but probably evil chocolate	0		Effect: "Wintry Breath", Effect Duration: 46, Last Available: "2006-12"
@@ -2182,14 +2182,14 @@
 2207	hardy Crimbo tiki necklace	0		Maximum HP: +50, Last Available: "2006-12"
 2208	pulsating weightlifter's bobble-hip hula elf doll of Leguizamo	0		Muscle: +15, Monster Level: +20, Last Available: "2006-12"
 2209	blinking Crimbo ukulele of the brute	0		Muscle Percent: +30, Last Available: "2006-12"
-2210	steel-toed Tiki lighter of the pedagogue	0		Experience: +3, Damage Reduction: 9, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	olive crafty deadly deck of tropical cards	0		Weapon Damage: +5, Maximum MP: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	maroon pulsating auspicious tropical paperweight of the pedagogue	0		Experience: +3, Item Drop: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	steel-toed Tiki lighter of the pedagogue	0		Experience: +3, Damage Reduction: 9, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	olive crafty deadly deck of tropical cards	0		Weapon Damage: +5, Maximum MP: +10, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	maroon pulsating auspicious tropical paperweight of the pedagogue	0		Experience: +3, Item Drop: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	purple tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
 2215	Tropical Crimbo Hat of wisdom	0		Mysticality: +15, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	squat Rosewater's Tropical Crimbo Shorts	0		Mysticality Percent: +30, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	diet moldy super ka-bob	1	crappy	
+2217	moldy diet super ka-bob	1	crappy	
 2218	bland beer basted brat	4	decent	
 2219	Herculean Tropical Crimbo Sword	0		Experience (Muscle): +1, Last Available: "2006-12"
 2220	concentrated super-magnetized green and Crimboween candy	0		Effect: "Mystically Oiled", Effect Duration: 56, Last Available: "2020-09"
@@ -2203,7 +2203,7 @@
 2228	cold-filtered polarized aerosolized red cosmic lemonade	0		Effect: "A Contender", Effect Duration: 63, Last Available: "2007-01"
 2229	ionized toad horn	0		Effect: "Toast Tea", Effect Duration: 20, Last Available: "2007-01"
 2230	pulsating icicle katana	0		Familiar Weight: +5
-2231	blurry mirror mote	0		
+2231	mirror blurry mote	0		
 2232	smudged alchemical recipe	0		
 2233	red Socratic bow tie	0		Experience (Mysticality): +1, Clowniness: 75
 2234	deadly calavera concertina	0		Weapon Damage: +5, Song Duration: 7
@@ -2231,7 +2231,7 @@
 2257	ghostly careful Socratic reinforced furry underpants	0		Experience (Mysticality): +1, Monster Level: -10
 2258	&quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
-2260	tumbling twirling hard rock candy	0		
+2260	twirling tumbling hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
@@ -2256,7 +2256,7 @@
 2282	Manual of Dexterity	0		
 2283	dangerous seal-skull helmet	0		Weapon Damage: +10, Familiar Effect: "atk, cap 2"
 2284	tumbling petrified noodles	0		
-2285	mirror blinking chisel	0		
+2285	blinking mirror chisel	0		
 2286	ghostly Eye of Ed	0		
 2287	Newton's Rosewater's glowstick	0		Mysticality Percent: +30, Experience (Mysticality): +3, Last Available: "2007-01"
 2288	narrow encoder ring	0		Single Equip
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	huge Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	pressed concentrated candy heart	0		Effect: "Walberg's Dim Bulb", Effect Duration: 46, Last Available: "2007-02"
 2305	nitrogenated ionized pink candy heart	0		Effect: "Superveiny 9000", Effect Duration: 42, Last Available: "2007-02"
 2306	vacuum-sealed quadruple-moist candy heart	0		Effect: "Butt-Rock Hair", Effect Duration: 53, Last Available: "2007-02"
@@ -2310,10 +2310,10 @@
 2336	Sherlock's savvy pipe	0		Mysticality Percent: +20, Item Drop: +25
 2337	lightning-fast reinforced beaded headband	0		Initiative: +40, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	bland huge pudding	10	decent	Wiki Name: "black pudding (food)"
-2339	weak acceptable Blackfly Chardonnay	2	good	
+2339	acceptable weak Blackfly Chardonnay	2	good	
 2340	delicious & tan	3	awesome	
 2341	bouncing bouncing pepper	0		
-2342	flavorless low-calorie forest cake	1	decent	
+2342	low-calorie flavorless forest cake	1	decent	
 2343	normal forest ham	3	good	
 2344	tarnished narrow lime green filthworm hatchling scent gland	0		Effect: "Eyes for Miles", Effect Duration: 44
 2345	polarized corrupted alkaline filthworm drone scent gland	0		Effect: "Grumpy and Ornery", Effect Duration: 69
@@ -2344,11 +2344,11 @@
 2370	pulsating olive natural fennel soda	0		
 2371	smoke bomb	0		
 2372	teal bunch of bananas	0		
-2373	yummy snack-sized blurry banana	2	awesome	
+2373	snack-sized yummy blurry banana	2	awesome	
 2374	banana peel	0		
-2375	big normal banana cream pie	5	good	
-2376	delicious practically non-alcoholic banana daiquiri	1	awesome	
-2377	tolerable extra-dry bungle in the jungle	5	good	
+2375	normal big banana cream pie	5	good	
+2376	practically non-alcoholic delicious banana daiquiri	1	awesome	
+2377	extra-dry tolerable bungle in the jungle	5	good	
 2378	tumbling banana spritzer	0		
 2379	non-alkaline enhanced wobbly banana smoothie	0		Effect: "Flamibili Tea", Effect Duration: 17
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2381,7 +2381,7 @@
 2407	pink bat eye	0		
 2408	worthless piece of glass	0		
 2409	billy idol	0		
-2410	blue jittery rag	0		
+2410	jittery blue rag	0		
 2411	broken petri dish	0		
 2412	twirling sammich crust	0		
 2413	blinking triffid bark	0		
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	skewed Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	flavorless gigantic fuchsia tumbling bowl of Bounty-Os	9	decent	
-2465	weak perfectly mixed lime green Oreille Divis&eacute;e brandy	2	super EPIC	
+2465	perfectly mixed weak lime green Oreille Divis&eacute;e brandy	2	super EPIC	
 2466	pompadour'd puppy	0		
 2467	blurry maroon suede shoes	0		Familiar Weight: +5
 2468	wobbly callused fingerbone	0		
@@ -2463,7 +2463,7 @@
 2490	Jim Carey's Da Vinci's gnauga hide vest	0		Experience (Mysticality): +5, Monster Level: +25
 2491	shirt kit	0		
 2492	bouncing tropical orchid	0		
-2493	spinning red stick of dynamite	0		
+2493	red spinning stick of dynamite	0		
 2494	prompt Necrotelicomnicon of the glutton	0		Food Drop: +100, Adventures: +3
 2495	weightlifter's Cookbook of the Damned of bravery	0		Muscle: +15, Spooky Resistance: +5
 2496	family-friendly double-paned Sinful Desires	0		Cold Resistance: +5, Sleaze Resistance: +1
@@ -2489,22 +2489,22 @@
 2516	flame-retardant deadly wrench bracelet	0		Weapon Damage: +5, Hot Resistance: +1
 2517	nippy chain necklace of chilblains	0		Cold Damage: 35
 2518	occult sawblade shield	0		Spell Damage Percent: +25, Damage Reduction: 11
-2519	watered-down mediocre McMillicancuddy's Special Lager	2	decent	
+2519	mediocre watered-down McMillicancuddy's Special Lager	2	decent	
 2520	aged wobbly melted Jell-o shot	3	awesome	
 2521	aged ghostly cruelty-free wine	4	awesome	
 2522	fortified tolerable purple thistle wine	5	good	
 2523	mirror megatofu	0		
 2524	displaced fish	0		
-2525	diet toothsome fish	1	awesome	
-2526	diet bland gray fish casserole	1	decent	
-2527	enchanted flavorless fish lasagna	3	decent	Effect: "Natural 20", Effect Duration: 45
+2525	toothsome diet fish	1	awesome	
+2526	bland diet gray fish casserole	1	decent	
+2527	flavorless enchanted fish lasagna	3	decent	Effect: "Natural 20", Effect Duration: 45
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	diet tasty blinking gnatloaf	1	awesome	
 2530	rotten gnatloaf casserole	3	crappy	
 2531	flavorless big skewed gnat lasagna	5	decent	
 2532	pork	0		
 2533	normal pork chop sandwiches	4	good	
-2534	snack-sized rotten pulsating pork casserole	2	crappy	
+2534	rotten snack-sized pulsating pork casserole	2	crappy	
 2535	toothsome pork lasagna	4	awesome	
 2536	upside-down canopic jar	0		
 2537	spice	0		
@@ -2521,7 +2521,7 @@
 2548	avaricious outrageous sombrero of the sweet-tooth	0		Meat Drop: +30, Candy Drop: +100, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	supercharged forbidden &quot;Humorous&quot; T-shirt	0		Spell Damage Percent: +50, Maximum MP Percent: +30, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
-2551	blinking green vial of mojo	0		
+2551	green blinking vial of mojo	0		
 2552	blinking reeds	0		
 2553	jittery turtle chain	0		
 2554	huge distilled seal blood	0		
@@ -2543,28 +2543,28 @@
 2570	ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	cyan blurry ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
-2573	skewed ghostly upside-down ant sickle	0		Familiar Effect: "spooky damage, meat"
+2573	upside-down skewed ghostly ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
 2576	purple honey-dipped locust	0		
 2577	frightening cactus quill of Gandalf	0		Spell Critical Percent: +20, Spooky Damage: +5
 2578	veiny grievous smartaleck's Staff of the Short Order Cook	0		Moxie Percent: +30, Weapon Damage Percent: +50, Maximum HP: +10
-2579	delicious big cactus fruit	5	awesome	
+2579	big delicious cactus fruit	5	awesome	
 2580	curative supercool scorpion whip	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	diet yummy centipede eggs	1	awesome	
+2583	yummy diet centipede eggs	1	awesome	
 2584	ghostly careful wonderwall shield	0		Monster Level: -10, Damage Reduction: 12
 2585	personal trainer's Colonel Mustard's Lonely Spades Club Jacket	0		Experience Percent (Muscle): +10
 2586	blurry General Sage's Lonely Diamonds Club Jacket of the cheetah	0		Initiative: +60
 2587	huge weightlifter's Corporal Fennel's Lonely Clubs Club Jacket	0		Muscle: +15
 2588	Private Pepper's Lonely Hearts Club Jacket of Calamity Jane	0		Critical Hit Percent: +15
-2589	miniature toothsome mirror hot date	2	awesome	
-2590	practically non-alcoholic drinkable special twirling distilled fortified wine	1	good	Effect: "Christmessy", Effect Duration: 25
-2591	gigantic adequate tasty tart	6	good	
+2589	toothsome miniature mirror hot date	2	awesome	
+2590	practically non-alcoholic special drinkable twirling distilled fortified wine	1	good	Effect: "Christmessy", Effect Duration: 25
+2591	adequate gigantic tasty tart	6	good	
 2592	Knob Goblin lunchbox	0		
 2593	adequate bouncing Knob pasty	4	good	
-2594	practically non-alcoholic tolerable thermos full of Knob coffee	1	good	
+2594	tolerable practically non-alcoholic thermos full of Knob coffee	1	good	
 2595	modified super-ionized irradiated Ben-Gal&trade; Balm	0		Effect: "Fangs and Pangs", Effect Duration: 16
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2615,7 +2615,7 @@
 2642	Maxwell's Silver Hammer of the brute of bravery	0		Muscle Percent: +30, Spooky Resistance: +5
 2643	foul-smelling happiness	0		Stench Damage: +10
 2644	upside-down feather	0		
-2645	blurry shaking feather	0		
+2645	shaking blurry feather	0		
 2646	frightful feather	0		
 2647	fetid feather	0		
 2648	flirtatious feather	0		
@@ -2627,7 +2627,7 @@
 2654	hand-crafted bouncing Xanadian	3	EPIC	Last Available: "2007-06"
 2655	alkaline moist bottle of absinthe	0		Effect: "Hobo Flavor", Effect Duration: 43, Last Available: "2007-06"
 2656	Drowsy Sword of vim and vigor of mayonnaise	0		Maximum HP Percent: +50, Sleaze Spell Damage: +50
-2657	rotten diet ghostly escargotsicle	1	crappy	Last Available: "2007-06"
+2657	diet rotten ghostly escargotsicle	1	crappy	Last Available: "2007-06"
 2658	lousy jittery bottle of realpagne	3	decent	Last Available: "2007-06"
 2659	yellow rosy-cheeked albatross necklace	0		Maximum HP Percent: +30, Single Equip, Last Available: "2007-06"
 2660	powdered not-a-pipe	1	awesome	Last Available: "2007-06"
@@ -2635,7 +2635,7 @@
 2662	ball mask of bravery	0		Spooky Resistance: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	electrified Can-Can skirt	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	deionized anodized sensitive poetry journal	0		Effect: "Spooky Demeanor", Effect Duration: 50, Last Available: "2007-06"
-2665	double-corrupted Vulcanized olive ghostly skewed bottled inspiration	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2007-06"
+2665	double-corrupted Vulcanized skewed olive ghostly bottled inspiration	0		Effect: "Make Meat FA$T!", Effect Duration: 29, Last Available: "2007-06"
 2666	flattened anodized bellhop bell	0		Effect: "Polar Express", Effect Duration: 25, Last Available: "2007-06"
 2667	nitrogenated dry alkaline upside-down yellow spiky collar	0		Effect: "Almost Cool", Effect Duration: 48, Last Available: "2007-06"
 2668	distilled fuchsia can-can-in-a-can	1		Last Available: "2007-06"
@@ -2649,7 +2649,7 @@
 2676	boiled blurry twirling bit-o-cactus	1		
 2677	powdered olive protein powder	1		
 2678	spectre scepter	0		
-2679	dry spinning twirling upside-down sparkler	0		Effect: "Hammered", Effect Duration: 62
+2679	dry twirling spinning upside-down sparkler	0		Effect: "Hammered", Effect Duration: 62
 2680	dry pickled snake	0		Effect: "Down With Chow", Effect Duration: 18, Wiki Name: "snake"
 2681	quadruple-corrupted ionized gray M-242	0		Effect: "Limber as Mortimer", Effect Duration: 25
 2682	detuned radio	0		
@@ -2694,30 +2694,30 @@
 2721	horrifying Sinatra's hand-carved staff of the bloodbag	0		Experience (Moxie): +5, Maximum HP: +100, Spooky Damage: +25
 2722	executive lard-coated Sinatra's Staff of the Greasefire of doom	0		Experience (Moxie): +5, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Meat Drop: +40
 2723	executive smooth Staff of the Grand Flamb&eacute; of Leguizamo	0		Moxie: +15, Monster Level: +20, Meat Drop: +40
-2724	toothsome diet spinning bowl of rye sprouts	1	awesome	
+2724	diet toothsome spinning bowl of rye sprouts	1	awesome	
 2725	decent mirror cob of corn	4	good	
 2726	adequate spinning juniper berries	4	good	
 2727	jumbo adequate plum	5	good	
 2728	normal pear	3	good	
-2729	big flavorless peach	5	decent	
+2729	flavorless big peach	5	decent	
 2730	tolerable spinning plum wine	4	good	
-2731	spirit-forward artisanal bouncing green shot of pear schnapps	5	EPIC	
+2731	artisanal spirit-forward bouncing green shot of pear schnapps	5	EPIC	
 2732	drinkable maroon spinning shot of peach schnapps	4	good	
 2733	decent bunch of square grapes	4	good	
-2734	bland thick blurry brown sugar cane	5	decent	
-2735	normal fancy huge sandwich of the gods	3	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 15
+2734	thick bland blurry brown sugar cane	5	decent	
+2735	fancy normal huge sandwich of the gods	3	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 15
 2736	bad practically non-alcoholic fuchsia ghostly Pan-Dimensional Gargle Blaster	1	decent	
-2737	mixed twirling wobbly leopard-print barbell	1	decent	
+2737	mixed wobbly twirling leopard-print barbell	1	decent	
 2738	huge pile of smoking rags	0		
 2739	wet flattened tarnished lime green panty raider camouflage	0		Effect: "Coal-Powered", Effect Duration: 23
 2740	steel-toed savvy Staff of the Walk-In Freezer of James Dean	0		Mysticality Percent: +20, Experience (Moxie): +3, Damage Reduction: 9
 2741	bad boilermaker	3	decent	
 2742	bite-sized flavorless steel lasagna	1	quest	
-2743	tolerable spirit-forward enchanted steel margarita	5	quest	Effect: "Litterboxing", Effect Duration: 15
+2743	tolerable enchanted spirit-forward steel margarita	5	quest	Effect: "Litterboxing", Effect Duration: 15
 2744	compressed steel-scented air freshener	1		
 2745	adjusted non-cold-filtered gremlin mutagen	0		Effect: "Red Door Syndrome", Effect Duration: 31
 2746	improved aerosolized wobbly extra-potent gremlin mutagen	0		Effect: "Booze Goozles", Effect Duration: 31
-2747	tumbling red chunk of depleted Grimacite	0		Last Available: "2011-12"
+2747	red tumbling chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	mansplainer's furniture dolly	0		Monster Level: +15, Single Equip
 2749	prompt Usain Bolt's Herculean Staff of the Grease Trap	0		Experience (Muscle): +1, Initiative: +80, Adventures: +3
 2750	chaotic Uranium Omega of Temperance of the pedagogue	0		Experience: +3, Spell Critical Percent: +10, Single Equip
@@ -2803,17 +2803,17 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	stale upside-down green digital key lime pie	4	decent	
-2833	big decent star key lime pie	5	good	
-2834	coward's curative Samson's bottle-rocket crossbow	0		Experience (Muscle): +5, Monster Level: -20, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2833	decent big star key lime pie	5	good	
+2834	coward's curative Samson's bottle-rocket crossbow	0		Experience (Muscle): +5, Monster Level: -20, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	spinning nasty indie comic hipster glasses	0		Stench Damage: +5, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
-2837	wobbly jittery mint-condition magic wand	0		Last Available: "2011-12"
+2837	jittery wobbly mint-condition magic wand	0		Last Available: "2011-12"
 2838	inspector's glowstick of horror	0		Spooky Spell Damage: +25, Item Drop: +15, Last Available: "2007-08"
 2839	rosy-cheeked Periodical Paintbrush	0		Maximum HP Percent: +30, Softcore Only
 2840	hand-crafted bottle of cooking sherry	4	EPIC	
 2841	decent spinning packet of ketchup	3	good	
 2842	weak lousy accidental cider	2	decent	
-2843	massive adequate dire fudgesicle	9	good	
+2843	adequate massive dire fudgesicle	9	good	
 2844	Jack Frost's supercharged deadly navel ring of navel gazing of Gandalf	0		Weapon Damage: +5, Maximum MP Percent: +30, Spell Critical Percent: +20, Cold Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2910,14 +2910,14 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	cyan Jacob's ladder	0		Familiar Weight: +5
 2939	blinking unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	huge bland Surprise Egg	7	decent	
+2940	bland huge Surprise Egg	7	decent	
 2941	wet corrupted jittery Steal This Candy	0		Effect: "Slightly Larger Than Usual", Effect Duration: 16
 2942	double-modified chocolate filthy lucre	0		Effect: "Slippery Tongue", Effect Duration: 69
 2943	super-oxidized unsweetened colloidal yellow upside-down Angry Farmer's Wife Candy	0		Effect: "Egg-headedness", Effect Duration: 34
 2945	blinking Sherlock's quilted party hat	0		Damage Absorption: +40, Item Drop: +25, Familiar Effect: "4xLep, cap 7"
-2946	toasty sharpshooter's V for Vivala mask	0		Critical Hit Percent: +10, Hot Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	toasty sharpshooter's V for Vivala mask	0		Critical Hit Percent: +10, Hot Damage: +5, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	green ghostly The Big Book of Pirate Insults	0		
-2948	irresponsibly strong artisanal pulsating shot of rotgut	6	EPIC	
+2948	artisanal irresponsibly strong pulsating shot of rotgut	6	EPIC	
 2949	corrupted Vulcanized shaking jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Analog Drunk", Effect Duration: 15
 2950	upside-down Cap'm Caronch's Map	0		
 2951	narrow Orcish Frat House blueprints	0		
@@ -2932,14 +2932,14 @@
 2960	toothsome single-serving herbal stuffing	3	awesome	
 2961	enchanted rotten packet of tofurkey gravy	4	crappy	Effect: "Steroid Boost", Effect Duration: 45
 2962	flavorless special tofurkey nugget	3	decent	Effect: "Ginger Snapped", Effect Duration: 40
-2963	jittery blue rigging shampoo	0		
+2963	blue jittery rigging shampoo	0		
 2964	ball polish	0		
 2965	tumbling mizzenmast mop	0		
-2966	pulsating purple Tom's of the Spanish Main Toothpaste	0		
+2966	purple pulsating Tom's of the Spanish Main Toothpaste	0		
 2967	extra-chilled modified Swabbie&trade; swab	0		Effect: "Helvella Health", Effect Duration: 24
 2968	modified moist twirling blurry Oil of Parrrlay	0		Effect: "Swimming Head", Effect Duration: 31
 2969	super-sized flavorless creamsicle	5	decent	
-2970	bad watered-down cream stout	2	decent	
+2970	watered-down bad cream stout	2	decent	
 2971	green nasty supercharged curmudgel	0		Maximum MP Percent: +30, Stench Damage: +5
 2972	grumpy man charrrm	0		
 2973	blurry supercool grumpy man charrrm bracelet	0		Moxie Percent: +20, Single Equip
@@ -2962,7 +2962,7 @@
 2990	ghostly electrified clingfilm cap of dire peril	0		Weapon Damage: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, cap 37"
 2991	twirling vibrating clingfilm slippers	0		Maximum MP Percent: +10, Single Equip
 2992	clingfilm tangle	0		
-2993	decent bite-sized spinning vinegar-soaked lemon slice	1	good	
+2993	bite-sized decent spinning vinegar-soaked lemon slice	1	good	
 2994	oxidized galvanized denatured gray true grit	0		Effect: "Puddingskin", Effect Duration: 28
 2995	Herculean savvy buoybottoms of temperance	0		Mysticality Percent: +20, Experience (Muscle): +1, Sleaze Resistance: +5, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	MacGyver's grungy flannel shirt	0		Maximum MP: +100
@@ -2998,14 +2998,14 @@
 3026	perfectly mixed huge corpsetini	3	super EPIC	
 3027	artisanal corpsedriver	3	super EPIC	
 3028	tolerable triple-distilled cyan Corpse Island iced tea	9	good	
-3029	acceptable extra-dry special green red-headed corpse	5	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 45
+3029	special extra-dry acceptable green red-headed corpse	5	good	Effect: "Cuts Like a Buttered Knife", Effect Duration: 45
 3030	bad jittery kamicorpse-ee	3	decent	
 3031	tolerable corpsel	3	good	
 3032	lousy corpsebite	3	decent	
 3033	blurry pirate fledges of extreme caution	0		Monster Level: -25
 3034	mirror piece of thirteen	0		
-3035	massive special normal pearl onion	7	good	Effect: "You're Rubber", Effect Duration: 40
-3036	adequate half-sized sea biscuit	2	good	
+3035	normal special massive pearl onion	7	good	Effect: "You're Rubber", Effect Duration: 40
+3036	half-sized adequate sea biscuit	2	good	
 3037	drinkable bottle of rum	4	good	
 3038	lousy bottle of black-label rum	3	decent	
 3039	cannonball	0		
@@ -3017,7 +3017,7 @@
 3045	adequate squat cyan nanite-infested gingerbread bugbear	4	good	Last Available: "2007-12"
 3046	bland nanite-infested candy cane	3	decent	Last Available: "2020-09"
 3047	bland nanite-infested fruitcake	4	decent	Last Available: "2007-12"
-3048	practically non-alcoholic fancy artisanal ghostly nanite-infested eggnog	1	super EPIC	Effect: "The Grass...  Is Blue...", Effect Duration: 15, Last Available: "2007-12"
+3048	fancy artisanal practically non-alcoholic ghostly nanite-infested eggnog	1	super EPIC	Effect: "The Grass...  Is Blue...", Effect Duration: 15, Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	auspicious eyepatch	0		Item Drop: +10, Familiar Effect: "spooky atk, 1xBarrr"
 3051	fortified cutlass	0		Damage Absorption: +60
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	brainy marionette collective	0		Mysticality: +5, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3064,7 +3064,7 @@
 3092	handmade hobby horse of terror	0		Spooky Spell Damage: +10, Last Available: "2007-12"
 3093	up-at-dawn ball-in-a-cup	0		Adventures: +5, Last Available: "2007-12"
 3094	mirror set of jacks of the bloodbag	0		Maximum HP: +100, Last Available: "2007-12"
-3095	massive flavorless laser-broiled pear	9	decent	Last Available: "2007-12"
+3095	flavorless massive laser-broiled pear	9	decent	Last Available: "2007-12"
 3096	twirling chilly Newton's polyalloy shield	0		Experience (Mysticality): +3, Cold Damage: +5, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	blurry killing feather	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	narrow old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	twirling divine can of silly string	0		Last Available: "2008-01"
 3120	wobbly divine blowout	0		Last Available: "2008-01"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	miniature bland roasted marshmallow	2	decent	
 3130	twirling disc	0		Last Available: "2008-01"
-3131	yummy immense tin cup of mulligan stew	10	awesome	
+3131	immense yummy tin cup of mulligan stew	10	awesome	
 3132	lime green baleful Herculean flamin' bindle	0		Experience (Muscle): +1, Spell Damage: +25
 3133	baleful freezin' bindle of the empath	0		Spell Damage: +25, Familiar Weight: +5
 3134	Jack Frost's manspreader's stinkin' bindle	0		Monster Level: +10, Cold Spell Damage: +50
@@ -3147,20 +3147,20 @@
 3175	low-calorie toothsome evil noodles	1	awesome	
 3176	adequate green evil noodles	4	good	
 3177	spoiled evil painful penne pasta	3	crappy	
-3178	stale half-sized 3vi1 pr0n m4nic0tti	2	decent	
+3178	half-sized stale 3vi1 pr0n m4nic0tti	2	decent	
 3179	spoiled enchanted evil ravioli della hippy	3	crappy	Effect: "Stinky Weapon", Effect Duration: 35
 3180	moldy spinning evil noodles	4	crappy	
 3181	galvanized cold-filtered lime green evil potion of potency	0		Effect: "Hustlin'", Effect Duration: 24
-3182	cold-filtered blurry mirror evil libation of liveliness	0		Effect: "Slimily Speedy", Effect Duration: 59
+3182	cold-filtered mirror blurry evil libation of liveliness	0		Effect: "Slimily Speedy", Effect Duration: 59
 3183	anodized evil tomato juice of powerful power	0		Effect: "The Moxie of LOV", Effect Duration: 65
-3184	liquefied energized wobbly pulsating evil eyedrops of the ermine	0		Effect: "BOOsted", Effect Duration: 37
+3184	liquefied energized pulsating wobbly evil eyedrops of the ermine	0		Effect: "BOOsted", Effect Duration: 37
 3185	liquefied evil ointment of the occult	0		Effect: "Feet of Watermelon", Effect Duration: 22
 3186	concentrated diffused unsweetened narrow evil serum of sarcasm	0		Effect: "Mystically Oiled", Effect Duration: 54
 3187	colloidal moist evil philter of phorce	0		Effect: "Meatwise", Effect Duration: 50
-3188	lousy triple-distilled an evil sump'm sump'm	10	decent	
+3188	triple-distilled lousy an evil sump'm sump'm	10	decent	
 3189	smooth evil ducha de oro	3	awesome	
 3190	watered-down acceptable evil horizontal tango	2	good	
-3191	triple-distilled delicious evil roll in the hay	7	awesome	
+3191	delicious triple-distilled evil roll in the hay	7	awesome	
 3192	bouncing naughty origami kit	0		Last Available: "2008-02"
 3193	shaking naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3183,7 +3183,7 @@
 3211	purple unlarge laminated card	0		
 3212	skewed dwarvish document	0		
 3213	bouncing dwarvish paper	0		
-3214	pulsating fuchsia dwarvish parchment	0		
+3214	fuchsia pulsating dwarvish parchment	0		
 3215	overcharged El Vibrato power sphere	0		
 3216	blinking Fly-By-Knight Heraldry form	0		Free Pull
 3217	El Vibrato Megadrone	0		
@@ -3194,12 +3194,12 @@
 3222	resourceful gatorskin umbrella of the brute	0		Muscle Percent: +30, Maximum MP: +50
 3223	sewer nuggets	0		
 3224	twirling sewer wad	0		
-3225	practically non-alcoholic bad bottle of sewage schnapps	1	decent	
+3225	bad practically non-alcoholic bottle of sewage schnapps	1	decent	
 3226	lousy bottle of Ooze-O	4	decent	
 3227	bland half-sized bouncing C.H.U.M. chum	2	decent	
-3228	adequate blurry olive unfortunate dumplings	3	good	
+3228	adequate olive blurry unfortunate dumplings	3	good	
 3229	jittery huge decaying goldfish liver	0		
-3230	pickled energized olive bouncing oil of oiliness	0		Effect: "Sweet Tooth", Effect Duration: 20
+3230	pickled energized bouncing olive oil of oiliness	0		Effect: "Sweet Tooth", Effect Duration: 20
 3231	Jim Carey's tattered paper crown	0		Monster Level: +25, Familiar Effect: "1xSombrero, cap 15"
 3232	rotten huge vanilla-frosted king cake	3	crappy	Last Available: "2008-03"
 3233	inflatable duck	0		
@@ -3232,7 +3232,7 @@
 3260	clever shellacked Chester's moustache of chilblains	0		Damage Reduction: 7, Maximum MP: +20, Cold Damage: +25, Class: "Disco Bandit", Single Equip
 3261	boxer's Chester's bag of candy of Calamity Jane	0		Muscle Percent: +10, Critical Hit Percent: +15, Class: "Disco Bandit"
 3262	smooth Chester's cutoffs	0		Moxie: +15, Item Drop: +5, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	blurry Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	blurry Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	mirror bag of Saccharine Maple saplings	0		
@@ -3240,10 +3240,10 @@
 3268	pressed flattened twirling handful of Crotchety Pine needles	0		Effect: "Quaaaaaaa", Effect Duration: 50
 3269	triple-cold-filtered frozen lump of Saccharine Maple sap	0		Effect: "Highland Sheen", Effect Duration: 47
 3270	irradiated non-ionized ghostly handful of Laughing Willow bark	0		Effect: "Neutered Nostrils", Effect Duration: 31
-3271	jittery healthy crotchety pants	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	jittery healthy crotchety pants	0		Maximum HP Percent: +20, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	healthy Saccharine Maple pendant	0		Maximum HP Percent: +20, Conditional Skill (Equipped): "Spray Sap"
-3273	olive lion tamer's willowy bonnet	0		Experience (familiar): +2, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
-3274	teal shaking flavored foot massage oil	0		Last Available: "2008-04"
+3273	olive lion tamer's willowy bonnet	0		Experience (familiar): +2, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3274	shaking teal flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
@@ -3263,7 +3263,7 @@
 3291	pulsating secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
 3293	untamable turtle	0		
-3294	spinning tumbling macaroni duck	0		
+3294	tumbling spinning macaroni duck	0		
 3295	shaking friendly cheez blob	0		
 3296	unusual disco ball	0		
 3297	stray chihuahua	0		
@@ -3291,7 +3291,7 @@
 3319	Mr. Joe's bangles of the wise owl	0		Mysticality: +20, Single Equip
 3320	personal trainer's frayed rope belt	0		Experience Percent (Muscle): +10, Single Equip
 3321	upside-down packet of mayfly bait	0		Last Available: "2008-05"
-3322	razor-sharp mayfly bait necklace of terror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	razor-sharp mayfly bait necklace of terror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	ghostly Ol' Scratch's salad fork	0		
 3324	green Frosty's frosty mug	0		
 3325	bad high-proof jar of fermented pickle juice	6	decent	
@@ -3304,7 +3304,7 @@
 3332	spinning avaricious smelly hobo dungarees	0		Stench Spell Damage: +10, Meat Drop: +30, Familiar Effect: "0.5xVolley, 1xPotato"
 3333	narrow supercool patched suit-pants of the overflowing toilet	0		Moxie Percent: +20, Stench Spell Damage: +50, Familiar Effect: "1xPotato, 0.5xFairy"
 3334	lime green hobo stogie	0		Single Equip
-3335	wobbly skewed bouncing rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
+3335	bouncing wobbly skewed rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	blue Jeselnik's supercharged dead guy's memento	0		Maximum MP Percent: +30, Sleaze Damage: +25, Single Equip
 3338	stale banquet	3	decent	
@@ -3327,7 +3327,7 @@
 3355	pulsating hardened brown plastic baby	0		Damage Reduction: 3, Single Equip, Last Available: "2008-08"
 3356	upside-down plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
-3358	pulsating olive delectable fire ant	0		Last Available: "2008-06"
+3358	olive pulsating delectable fire ant	0		Last Available: "2008-06"
 3359	scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
@@ -3337,12 +3337,12 @@
 3365	denatured Climate Colada	0		Effect: "Jungle Juiced", Effect Duration: 66, Last Available: "2008-06"
 3366	flattened digital underground potion	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 41, Last Available: "2008-06"
 3367	blurry olive blinking interesting-looking twig	0		Last Available: "2008-06"
-3368	twisted red bouncing tumbling glimmering roc feather	1	crappy	Last Available: "2008-06"
+3368	twisted tumbling bouncing red glimmering roc feather	1	crappy	Last Available: "2008-06"
 3369	dried cyan glimmering phoenix feather	1		Last Available: "2008-06"
 3370	dried blurry glimmering penguin feather	1		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 30, Last Available: "2008-06"
 3371	dried squat glimmering buzzard feather	1		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2008-06"
 3372	pickled blinking glimmering raven feather	1		Last Available: "2008-06"
-3373	modified mirror olive wobbly glimmering great tit feather	1		Effect: "Je Ne Sais Porquoise", Effect Duration: 25, Last Available: "2008-06"
+3373	modified wobbly olive mirror glimmering great tit feather	1		Effect: "Je Ne Sais Porquoise", Effect Duration: 25, Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	mirror The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
@@ -3360,7 +3360,7 @@
 3388	twirling Zombo's empty eye	0		
 3389	asbestos-lined clever Frosty's arm	0		Maximum MP: +20, Hot Resistance: +5
 3390	scandalous nasty stylish Staff of the Deepest Freeze	0		Moxie: +25, Stench Damage: +5, Sleaze Damage: +5
-3391	bouncing shaking Frosty's iceball	0		
+3391	shaking bouncing Frosty's iceball	0		
 3392	Oscus's garbage can lid of incineration	0		Hot Spell Damage: +50, Damage Reduction: 15
 3393	Oscus's neverending soda	0		
 3394	shaking executive friendly Oscus's flypaper pants	0		Familiar Weight: +3, Meat Drop: +40, Familiar Effect: "stench atk, 1xPotato"
@@ -3368,7 +3368,7 @@
 3396	scandalous Hodgman's lobsterskin pants of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +5, Familiar Effect: "atk, 1xPotato"
 3397	arcane researcher's Hodgman's bow tie of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15, Single Equip
 3398	drinkable practically non-alcoholic Hodgman's blanket	1	good	
-3399	distilled mediocre tumbling jar of squeeze	5	decent	
+3399	mediocre distilled tumbling jar of squeeze	5	decent	
 3400	stale bowl of fishysoisse	4	decent	
 3401	ionized polarized deadly lampshade	0		Effect: "Trivia Master", Effect Duration: 69
 3402	concentrated huge concentrated garbage juice	0		Effect: "Red Around the Gills", Effect Duration: 17
@@ -3386,9 +3386,9 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	green Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	green hobo fortress blueprints	0		
-3421	bouncing box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
-3422	vacuum-sealed unsweetened extra-modified fuchsia shaking sterno-flavored Hob-O	0		Effect: "Soles of Glass", Effect Duration: 34
-3423	oxidized triple-chilled upside-down maroon frostbite-flavored Hob-O	0		Effect: "Memories of Puppy Love", Effect Duration: 17
+3421	bouncing box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3422	vacuum-sealed unsweetened extra-modified shaking fuchsia sterno-flavored Hob-O	0		Effect: "Soles of Glass", Effect Duration: 34
+3423	oxidized triple-chilled maroon upside-down frostbite-flavored Hob-O	0		Effect: "Memories of Puppy Love", Effect Duration: 17
 3424	galvanized altered bouncing fry-oil-flavored Hob-O	0		Effect: "Aquarius Rising", Effect Duration: 67
 3425	dry garbage-juice-flavored Hob-O	0		Effect: "Resilient Spirit", Effect Duration: 20
 3426	polarized nitrogenated strawberry-flavored Hob-O	0		Effect: "Bubblin' Rage", Effect Duration: 34
@@ -3404,7 +3404,7 @@
 3437	wobbly Lo Pan's quilted supercool Staff of the Black Kettle	0		Moxie Percent: +20, Damage Absorption: +40, Spell Critical Percent: +30
 3438	hardened slick Staff of the Well-Tempered Cauldron of the blizzard	0		Moxie: +10, Damage Reduction: 3, Cold Spell Damage: +25
 3439	pulsating Rainbow's Gravity	0		Skill: "Rainbow Gravitation", Last Available: "2008-07"
-3440	vaporized lime green pulsating prismatic wad	1	good	Effect: "Pumped Stomach", Effect Duration: 15, Last Available: "2008-07"
+3440	vaporized pulsating lime green prismatic wad	1	good	Effect: "Pumped Stomach", Effect Duration: 15, Last Available: "2008-07"
 3441	sharpshooter's club of the five seasons	0		Critical Hit Percent: +10, Last Available: "2008-07"
 3442	rainbow crossbow of wisdom	0		Mysticality: +15, Last Available: "2008-07"
 3443	ghostly kitten	0		
@@ -3424,13 +3424,13 @@
 3457	maroon rock-hard Junior Adventurer's merit badge	0		Damage Reduction: 5
 3458	dry enhanced STYX deodorant body spray	0		Effect: "Human-Constellation Hybrid", Effect Duration: 46
 3459	lousy white-label gin	4	decent	
-3460	flavorless snack-sized wobbly spinning tin rations	2	decent	
+3460	flavorless snack-sized spinning wobbly tin rations	2	decent	
 3461	haiku challenge map	0		
 3462	tumbling skewed terrible poem	0		
 3463	practically non-alcoholic perfectly mixed lime green bottle of sake	1	EPIC	
 3464	prompt round pebble	0		Adventures: +3
 3465	toothsome Bash-&#332;s cereal	3	awesome	Wiki Name: "Bash-Os cereal"
-3466	crafty hardy padded haiku katana	0		Damage Absorption: +20, Maximum HP: +50, Maximum MP: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	crafty hardy padded haiku katana	0		Damage Absorption: +20, Maximum HP: +50, Maximum MP: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	plastic baby of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2008-12"
 3469	decent blueberry-frosted king cake	3	good	Last Available: "2008-12"
@@ -3451,7 +3451,7 @@
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	deionized altered squat glittery mascara	0		Effect: "Spookypants", Effect Duration: 25
 3486	dull fish scale	0		
-3487	blinking jittery rough fish scale	0		
+3487	jittery blinking rough fish scale	0		
 3488	wobbly bouncing pristine fish scale	0		
 3489	toothsome upside-down beefy fish meat	4	awesome	Effect: "Fishy", Effect Duration: 5
 3490	stale squat glistening fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
@@ -3471,7 +3471,7 @@
 3504	red French slippers	0		
 3505	sage LWA ring	0		Mysticality Percent: +10
 3506	ghostly skewed LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	green scratch 'n' sniff sword of the pedagogue	0		Experience: +3, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	tumbling blinking shaking scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3519,18 +3519,18 @@
 3552	manspreader's rosy-cheeked wicked octopus's spade	0		Spell Damage: +5, Maximum HP Percent: +30, Monster Level: +10
 3553	teal bouncing soggy seed packet	0		
 3554	glob of slime	0		
-3555	spoiled half-sized twirling sea carrot	2	crappy	
-3556	miniature toothsome enchanted sea cucumber	2	awesome	Effect: "Shawarma Initiative", Effect Duration: 25
+3555	half-sized spoiled twirling sea carrot	2	crappy	
+3556	enchanted miniature toothsome sea cucumber	2	awesome	Effect: "Shawarma Initiative", Effect Duration: 25
 3557	miniature bland sea avocado	2	decent	
 3558	decent small enchanted sea lychee	2	good	Effect: "Fever From the Flavor", Effect Duration: 10
-3559	stale snack-sized purple sea tangelo	2	decent	
+3559	snack-sized stale purple sea tangelo	2	decent	
 3560	stale sea honeydew	3	decent	
 3561	quadruple-polymerized wobbly pressurized potion of puissance	0		Effect: "Swordholder", Effect Duration: 61
 3562	wet pressurized potion of perspicacity	0		Effect: "Superveiny 9000", Effect Duration: 66
 3563	quantum extra-deionized pressurized potion of pulchritude	0		Effect: "Healthy Green Glow", Effect Duration: 28
-3564	watered-down tolerable special berry-infused sake	2	good	Effect: "Cat-Alyzed", Effect Duration: 45
-3565	practically non-alcoholic hand-crafted citrus-infused sake	1	super ultra mega turbo EPIC	
-3566	drinkable high-proof melon-infused sake	8	good	
+3564	tolerable special watered-down berry-infused sake	2	good	Effect: "Cat-Alyzed", Effect Duration: 45
+3565	hand-crafted practically non-alcoholic citrus-infused sake	1	super ultra mega turbo EPIC	
+3566	high-proof drinkable melon-infused sake	8	good	
 3567	slab of sponge	0		
 3568	pulsating skewed veiny stiffened wicked sponge helmet	0		Spell Damage: +5, Damage Reduction: 1, Maximum HP: +10, Familiar Effect: "atk, 1xFairy"
 3569	olive studded wizardly spongy shield of the cougar	0		Mysticality: +25, Moxie: +20, Damage Absorption: +80, Damage Reduction: 14
@@ -3581,7 +3581,7 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	dry blue unstable DNA	0		Effect: "The Real Deal", Effect Duration: 19, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	tumbling wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
@@ -3602,21 +3602,21 @@
 3636	sizzling hardened patent shoes	0		Damage Reduction: 3, Hot Damage: +10, Last Available: "2008-12"
 3637	Fonzie's smartaleck's gray bow tie	0		Moxie Percent: +30, Experience (Moxie): +1, Last Available: "2008-12"
 3638	groovy penguin thesaurus of James Dean	0		Moxie Percent: +10, Experience (Moxie): +3, Last Available: "2008-12"
-3639	big rotten blob-shaped Crimbo cookie	5	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	rotten big blob-shaped Crimbo cookie	5	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	mirror seaweed	0		
 3641	jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	squat blurry Socratic depleted Grimacite kneecapping stick	0		Experience (Mysticality): +1, Last Available: "2007-06"
 3645	bad canteen of wine	3	decent	Last Available: "2008-12"
-3646	decent low-calorie elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
+3646	low-calorie decent elven <i>limbos</i> gingerbread	1	good	Last Available: "2008-12"
 3647	jittery elven whittling knife	0		Last Available: "2008-12"
-3648	tumbling yellow magic dragonfish fry	0		
-3649	wobbly narrow map to Madness Reef	0		
+3648	yellow tumbling magic dragonfish fry	0		
+3649	narrow wobbly map to Madness Reef	0		
 3650	diet toothsome spinning toast with jam	1	awesome	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	artisanal practically non-alcoholic elven moonshine	1	super ultra EPIC	Last Available: "2008-12"
-3653	normal red knuckle sandwich	3	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	normal red knuckle sandwich	3	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	twirling perfumed Da Vinci's psycho sweater	0		Experience (Mysticality): +5, Stench Resistance: +5, Last Available: "2008-12"
 3655	blurry fin-bit wax	0		Familiar Weight: +5
 3656	huge rosy-cheeked plastic Mob Penguin	0		Maximum HP Percent: +30, Last Available: "2008-12"
@@ -3634,18 +3634,18 @@
 3668	thinker's glow-in-the-dark wristwatch of the storm	0		Mysticality: +10, Maximum MP Percent: +40, Single Equip, Last Available: "2009-01"
 3669	teal glow-in-the-dark dart gun of courage	0		Spooky Resistance: +3, Last Available: "2009-01"
 3670	shaking personal trainer's glow-in-the-dark burrowgrub	0		Experience Percent (Muscle): +10, Last Available: "2009-01"
-3671	bouncing skewed Uncle Crimbo's Rations	0		Last Available: "2010-12"
+3671	skewed bouncing Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	flavorless thick can of franks 'n' beans	5	decent	Last Available: "2010-12"
-3673	delicious triple-distilled bottle of peppermint schnapps	9	awesome	Last Available: "2010-12"
+3673	triple-distilled delicious bottle of peppermint schnapps	9	awesome	Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	Mer-kin foodbucket	0		
 3677	huge stylish diving muff	0		Moxie: +25, Single Equip
-3678	practically non-alcoholic mediocre salinated mint julep	1	decent	
+3678	mediocre practically non-alcoholic salinated mint julep	1	decent	
 3679	ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
-3682	maroon ghostly globe of Deep Sauce	0		
+3682	ghostly maroon globe of Deep Sauce	0		
 3683	blurry map to the Marinara Trench	0		
 3684	flavorless huge tempura carrot	9	decent	
 3685	decent tempura cucumber	3	good	
@@ -3714,7 +3714,7 @@
 3749	diffused colloidal concoction of clumsiness	0		Effect: "Cake Caked", Effect Duration: 42
 3750	Oprah's vampire pearl earring	0		Maximum MP Percent: +50, Single Equip
 3751	bland skewed chocolate chip brownies	3	decent	
-3753	twirling Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	twirling Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	cold-filtered fuchsia love song of vague ambiguity	0		Effect: "Sensation", Effect Duration: 39, Last Available: "2009-02"
 3755	warmed unsweetened love song of smoldering passion	0		Effect: "Liquidy Smoky", Effect Duration: 32, Last Available: "2009-02"
 3756	irradiated love song of icy revenge	0		Effect: "Holiday Bliss", Effect Duration: 21, Last Available: "2009-02"
@@ -3724,18 +3724,18 @@
 3760	aerosolized maroon breath mint	0		Effect: "Locks Like the Raven", Effect Duration: 51
 3761	educational vampire pearl ring	0		Experience: +1, Single Equip
 3762	hardened vampire pearl necklace	0		Damage Reduction: 3, Single Equip
-3763	weak artisanal mirror slug of vodka	2	EPIC	
+3763	artisanal weak mirror slug of vodka	2	EPIC	
 3764	aged purple slug of rum	3	awesome	
 3765	irresponsibly strong artisanal pulsating slug of shochu	8	EPIC	
 3766	drinkable yellow screwdiver	3	good	
 3767	aged dew yoana lei	3	awesome	
 3768	aged fancy weak blurry lychee chuhai	2	awesome	Effect: "Flame-Retardant Trousers", Effect Duration: 5
-3769	practically non-alcoholic hand-crafted huge salacious screwdiver	1	super ultra mega turbo EPIC	
+3769	hand-crafted practically non-alcoholic huge salacious screwdiver	1	super ultra mega turbo EPIC	
 3770	practically non-alcoholic drinkable dew yoana salacious lei	1	good	
 3771	bad pulsating salacious lychee chuhai	3	decent	
 3772	triple-distilled drinkable Alewife&trade; Ale	7	good	
-3773	skewed teal seaode	0		
-3774	bouncing lime green blinking map to the Dive Bar	0		
+3773	teal skewed seaode	0		
+3774	lime green blinking bouncing map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
 3776	chaotic brainy pink pinkslip slip	0		Mysticality: +5, Spell Critical Percent: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3777	knitted sea salt scrubs of courage	0		Cold Resistance: +3, Spooky Resistance: +3
@@ -3764,11 +3764,11 @@
 3809	Mer-kin healscroll	0		
 3810	jittery Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
-3812	adequate enchanted chocolate-frosted king cake	3	good	Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2009-06"
+3812	enchanted adequate chocolate-frosted king cake	3	good	Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2009-06"
 3813	plastic baby of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
-3816	huge bouncing half-height unicycle	0		Familiar Weight: +5
-3817	flavorless half-sized enchanted sea radish	2	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35
+3816	bouncing huge half-height unicycle	0		Familiar Weight: +5
+3817	half-sized flavorless enchanted sea radish	2	decent	Effect: "Well-Swabbed Ear", Effect Duration: 35
 3818	narrow auspicious Lo Pan's sharpshooter's halibut	0		Critical Hit Percent: +10, Spell Critical Percent: +30, Item Drop: +10
 3819	teal eel sauce	0		
 3820	jittery upside-down strapping water-polo mitt	0		Muscle: +5, Single Equip
@@ -3787,7 +3787,7 @@
 3833	perfectly mixed watered-down fruity girl swill	2	EPIC	
 3834	special aged blended swill	3	awesome	Effect: "Boon of the Storm Tortoise", Effect Duration: 45
 3835	costume wardrobe	0		Softcore Only
-3836	mirror wobbly aromatic padded razor-sharp Elvish sunglasses of temperance	0		Weapon Damage Percent: +25, Damage Absorption: +20, Stench Resistance: +1, Sleaze Resistance: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	mirror wobbly aromatic padded razor-sharp Elvish sunglasses of temperance	0		Weapon Damage Percent: +25, Damage Absorption: +20, Stench Resistance: +1, Sleaze Resistance: +5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	jittery blurry smooth anniversary safety glass vest	0		Moxie: +15
 3838	blinking mansplainer's anniversary burlap belt	0		Monster Level: +15
 3839	anniversary balsa wood socks of the scaredy-cat	0		Monster Level: -15
@@ -3826,7 +3826,7 @@
 3872	spinning pocket theremin of the detective	0		Item Drop: +20
 3873	twirling perfumed Socratic rave whistle	0		Experience (Mysticality): +1, Stench Resistance: +5
 3874	yellow hellseal hide	0		
-3875	upside-down purple shredded hellseal hide	0		
+3875	purple upside-down shredded hellseal hide	0		
 3876	wobbly hellseal brain	0		
 3877	wobbly burst hellseal brain	0		
 3878	blurry blurry hellseal sinew	0		
@@ -3838,7 +3838,7 @@
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	ionized adjusted mirror vial of slime	0		Effect: "Familial Ties", Effect Duration: 61
 3886	deionized jittery vial of slime	0		Effect: "Barbecue Saucy", Effect Duration: 28
-3887	unsweetened lime green bouncing vial of slime	0		Effect: "20/20 Vision", Effect Duration: 22
+3887	unsweetened bouncing lime green vial of slime	0		Effect: "20/20 Vision", Effect Duration: 22
 3888	super-vacuum-sealed pickled vial of slime	0		Effect: "Crud&eacute;", Effect Duration: 37
 3889	nitrogenated deionized squat vial of slime	0		Effect: "Super-Charged", Effect Duration: 13
 3890	concentrated pickled huge vial of violet slime	0		Effect: "Nuts about Candy", Effect Duration: 31
@@ -3847,7 +3847,7 @@
 3893	anodized huge vial of chartreuse slime	0		Effect: "Inner Warmth", Effect Duration: 19
 3894	aerosolized wobbly vial of teal slime	0		Effect: "On the Shoulders of Giants", Effect Duration: 53
 3895	corrupted ghostly vial of indigo slime	0		Effect: "Top Dog", Effect Duration: 43
-3896	Vulcanized corrupted squat lime green blinking vial of slime	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 61
+3896	Vulcanized corrupted lime green squat blinking vial of slime	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 61
 3897	pressed pickled vial of brown slime	0		Effect: "Fungal Fortification", Effect Duration: 14
 3898	fuchsia bottle of G&uuml;-Gone	0		
 3901	blurry seal-blubber candle	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	spinning figurine of a seal	0		Class: "Seal Clubber"
 3911	maroon figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	watered-down acceptable blended swill with a fly in it	2	good	
+3913	acceptable watered-down blended swill with a fly in it	2	good	
 3914	turtle wax	0		
 3915	twirling turtle wax shield of the businessman	0		Meat Drop: +50, Damage Reduction: 2
 3916	turtle wax helmet of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3878,7 +3878,7 @@
 3926	blue zippy Fonzie's spiky turtle shield	0		Experience (Moxie): +1, Initiative: +20, Damage Reduction: 8
 3927	turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
-3929	twirling tumbling grinning turtle	0		
+3929	tumbling twirling grinning turtle	0		
 3930	corrupted skewed tainted seal's blood	0		Effect: "Cotton Mouthed", Effect Duration: 37
 3931	lime green sharpshooter's resourceful severed flipper	0		Maximum MP: +50, Critical Hit Percent: +10, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
@@ -3950,7 +3950,7 @@
 3998	metrognome	0		Familiar Weight: +5
 3999	jittery infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
-4001	mixed wobbly shaking agua de vida	1	crappy	Last Available: "2009-06"
+4001	mixed shaking wobbly agua de vida	1	crappy	Last Available: "2009-06"
 4002	purple foul-smelling healthy tortoboggan shield	0		Maximum HP Percent: +20, Stench Damage: +10, Damage Reduction: 6
 4003	bottle of moontan lotion	0		
 4004	toasty soup-chucks	0		Hot Damage: +5
@@ -3986,8 +3986,8 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	green caustic slime nodule	0		
-4037	fancy normal slimy sweetbreads	4	good	Effect: "Good with the Ladies", Effect Duration: 20
-4038	boozy drinkable upside-down slimy fermented bile bladder	5	good	
+4037	normal fancy slimy sweetbreads	4	good	Effect: "Good with the Ladies", Effect Duration: 20
+4038	drinkable boozy upside-down slimy fermented bile bladder	5	good	
 4039	compressed slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	family-friendly pig-iron helm of dire peril	0		Weapon Damage: +20, Sleaze Resistance: +1, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4034,9 +4034,9 @@
 4082	prompt extremely unsafe pernicious cudgel	0		Weapon Damage Percent: +100, Adventures: +3, Slime Hates It: +1
 4083	normal bite-sized bouncing cupcake-in-a-cup	1	good	Last Available: "2009-06"
 4084	huge pool of liquid	0		Last Available: "2009-06"
-4085	normal tiny protein paste	1	good	Last Available: "2009-06"
+4085	tiny normal protein paste	1	good	Last Available: "2009-06"
 4086	rosy-cheeked brawny cyber-mattock	0		Muscle Percent: +20, Maximum HP Percent: +30, Last Available: "2009-06"
-4087	blue jittery facehugging alien	0		Last Available: "2009-06"
+4087	jittery blue facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
 4089	galvanized neurostim pill	0		Effect: "Emotion Sickness", Effect Duration: 47, Last Available: "2009-06"
 4090	denatured physiostim pill	0		Effect: "Scarysauce", Effect Duration: 21, Last Available: "2009-06"
@@ -4082,11 +4082,11 @@
 4130	upside-down empty agua de vida bottle	0		Last Available: "2009-06"
 4131	distilled twirling bouncing boot plant	1	decent	Last Available: "2009-06"
 4132	perfectly mixed sham champagne	4	EPIC	Last Available: "2009-06"
-4133	quantum altered purple twirling tempura air	0		Effect: "Icy Demeanor", Effect Duration: 45
-4134	activated enhanced narrow shaking pressurized potion of pneumaticity	0		Effect: "Souper Vengeful", Effect Duration: 15
+4133	quantum altered twirling purple tempura air	0		Effect: "Icy Demeanor", Effect Duration: 45
+4134	activated enhanced shaking narrow pressurized potion of pneumaticity	0		Effect: "Souper Vengeful", Effect Duration: 15
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	jittery squat Usain Bolt's Bag o' Tricks of the wise owl of the cougar of Flo-Jo	0		Mysticality: +20, Moxie: +20, Initiative: 180, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
-4137	spinning yellow slime stack	0		
+4136	jittery squat Usain Bolt's Bag o' Tricks of the wise owl of the cougar of Flo-Jo	0		Mysticality: +20, Moxie: +20, Initiative: 180, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4137	yellow spinning slime stack	0		
 4138	a rumpled paper strip	0		
 4139	skewed a creased paper strip	0		
 4140	jittery a folded paper strip	0		
@@ -4109,11 +4109,11 @@
 4157	gray gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	high-proof aged pebblebr&auml;u	10	awesome	Last Available: "2009-09"
-4161	decent low-calorie mirror rocky road ice cream	1	good	Last Available: "2009-09"
-4162	spinning pulsating extra-strength rubber bands	0		Familiar Weight: +5
+4160	aged high-proof pebblebr&auml;u	10	awesome	Last Available: "2009-09"
+4161	low-calorie decent mirror rocky road ice cream	1	good	Last Available: "2009-09"
+4162	pulsating spinning extra-strength rubber bands	0		Familiar Weight: +5
 4163	extra-modified children of the candy corn	0		Effect: "Gingerbread Robust", Effect Duration: 28
-4164	moist wobbly jittery Good 'n' Slimy	0		Effect: "Chain Chain Chains", Effect Duration: 26
+4164	moist jittery wobbly Good 'n' Slimy	0		Effect: "Chain Chain Chains", Effect Duration: 26
 4165	greedy strapping Staff of the Soupbone of terror	0		Muscle: +5, Spooky Spell Damage: +10, Meat Drop: +20
 4166	spinning lime green extremely unsafe Voluminous Radio Pants	0		Weapon Damage Percent: +100, Familiar Effect: "2xGhoul, cap 37"
 4167	dance instructor's Voluminous Radio Hat	0		Experience Percent (Moxie): +10, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4126,7 +4126,7 @@
 4174	dance instructor's rock necklace	0		Experience Percent (Moxie): +10, Single Equip
 4175	bouncing spaghetti cult robe	0		
 4176	sugar sheet	0		Last Available: "2009-09"
-4177	cyan spinning Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
+4177	spinning cyan Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	bouncing twirling avaricious sugar shotgun	0		Meat Drop: +30, Last Available: "2009-09"
 4179	studded sugar shillelagh	0		Damage Absorption: +80, Last Available: "2009-09"
 4180	twirling executive sugar shank	0		Meat Drop: +40, Last Available: "2009-09"
@@ -4151,7 +4151,7 @@
 4199	greasy MacGyver's banded sea cowboy hat	0		Damage Absorption: +100, Maximum MP: +100, Sleaze Spell Damage: +10, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
 4201	skewed gill rings	0		Familiar Weight: +5
-4202	huge pulsating urchin roe	0		
+4202	pulsating huge urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
 4204	Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
@@ -4196,7 +4196,7 @@
 4244	double-paned leather-bound tome	0		Cold Resistance: +5
 4245	narrow bookmark	0		
 4246	curative ivory cue ball	0		HP Regen Min: 3, HP Regen Max: 5
-4247	artisanal watered-down decanter of fine Scotch	2	super ultra mega EPIC	
+4247	watered-down artisanal decanter of fine Scotch	2	super ultra mega EPIC	
 4248	modified maroon expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	fisherman's sack	0		
@@ -4249,15 +4249,15 @@
 4297	purple fireproof electrified Ass-Stompers of Violence of extreme caution	0		Monster Level: -25, Hot Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	executive hardened razor-sharp Brand of Violence	0		Weapon Damage Percent: +25, Damage Reduction: 3, Meat Drop: +40, Conditional Skill (Equipped): "Brand"
 4299	shaking lime green toasty healthy Samson's Novelty Belt Buckle of Violence	0		Experience (Muscle): +5, Maximum HP Percent: +20, Hot Damage: +5, Single Equip
-4300	fireproof Lens of Violence of courage of the detective	0		Hot Resistance: +3, Spooky Resistance: +3, Item Drop: +20, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	fireproof Lens of Violence of courage of the detective	0		Hot Resistance: +3, Spooky Resistance: +3, Item Drop: +20, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	razor-sharp sage Pigsticker of Violence of Leguizamo	0		Mysticality Percent: +10, Weapon Damage Percent: +25, Monster Level: +20
-4302	Jeselnik's Jodhpurs of Violence of bravery of the early riser	0		Sleaze Damage: +25, Spooky Resistance: +5, Adventures: +7, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	Jeselnik's Jodhpurs of Violence of bravery of the early riser	0		Sleaze Damage: +25, Spooky Resistance: +5, Adventures: +7, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	wobbly chilly Cold Stone of Hatred of wisdom of the sewer	0		Mysticality: +15, Cold Damage: +5, Stench Damage: +25, Conditional Skill (Equipped): "Chilling Grip"
 4304	steel-toed weightlifter's Girdle of Hatred of the pedagogue	0		Muscle: +15, Experience: +3, Damage Reduction: 9, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	Van der Graaf medical-grade Staff of Simmering Hatred of wisdom	0		Mysticality: +15, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10
-4306	toasty Jack Frost's hardened Pantaloons of Hatred	0		Damage Reduction: 3, Cold Spell Damage: +50, Hot Damage: +5, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	toasty Jack Frost's hardened Pantaloons of Hatred	0		Damage Reduction: 3, Cold Spell Damage: +50, Hot Damage: +5, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	smelly chaotic Fuzzy Slippers of Hatred of wisdom	0		Mysticality: +15, Spell Critical Percent: +10, Stench Spell Damage: +10, Single Equip
-4308	maroon lightning-fast steel-toed stylish Lens of Hatred	0		Moxie: +25, Damage Reduction: 9, Initiative: +40, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	maroon lightning-fast steel-toed stylish Lens of Hatred	0		Moxie: +25, Damage Reduction: 9, Initiative: +40, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	Jeselnik's Annie Oakley's Treads of Loathing of wisdom	0		Mysticality: +15, Critical Hit Percent: +20, Sleaze Damage: +25, Single Equip
 4310	sage smooth cool Scepter of Loathing	0		Moxie: 20, Mysticality Percent: +10
 4311	narrow yellow lightning-fast avaricious healthy Belt of Loathing	0		Maximum HP Percent: +20, Meat Drop: +30, Initiative: +40, Single Equip
@@ -4279,10 +4279,10 @@
 4327	tumbling cyan healthy studded personal trainer's La Hebilla del Cintur&oacute;n de Lopez	0		Experience Percent (Muscle): +10, Damage Absorption: +80, Maximum HP Percent: +20, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	delicious diet candy kneecapping stick	1	awesome	Last Available: "2009-12"
-4331	tiny adequate pulsating licorice garrote	1	good	Last Available: "2009-12"
+4330	diet delicious candy kneecapping stick	1	awesome	Last Available: "2009-12"
+4331	adequate tiny pulsating licorice garrote	1	good	Last Available: "2009-12"
 4332	Herculean candy knuckles	0		Experience (Muscle): +1, Last Available: "2009-12"
-4333	toothsome fancy narrow jawbruiser	3	awesome	Effect: "Sucrose-Colored Glasses", Effect Duration: 30, Last Available: "2010-12"
+4333	fancy toothsome narrow jawbruiser	3	awesome	Effect: "Sucrose-Colored Glasses", Effect Duration: 30, Last Available: "2010-12"
 4334	nitrogenated concentrated chocolate car	0		Effect: "Abyssal Blood", Effect Duration: 48, Last Available: "2009-12"
 4335	huge therapeutic plastic 11 Dealer	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-12"
 4336	Jack Frost's plastic Crimbo Casino	0		Cold Spell Damage: +50, Last Available: "2009-12"
@@ -4316,14 +4316,14 @@
 4364	Vulcanized elven suicide capsule	0		Effect: "Compensatory Cruelness", Effect Duration: 14, Last Available: "2009-12"
 4365	spoiled red penguin focaccia bread	4	crappy	Last Available: "2009-12"
 4366	drinkable herringcello	3	good	Last Available: "2009-12"
-4367	bad special elven cellocello	3	decent	Effect: "The Halls of Moxiousness", Effect Duration: 25, Last Available: "2009-12"
+4367	special bad elven cellocello	3	decent	Effect: "The Halls of Moxiousness", Effect Duration: 25, Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	ghostly handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	upside-down grappling hook	0		Last Available: "2009-12"
-4374	twirling ghostly elf ear	0		Last Available: "2009-12"
+4374	ghostly twirling elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
 4376	Crimbomination Contraption	0		Last Available: "2009-12"
 4377	Annie Oakley's throwing wrench	0		Critical Hit Percent: +20, Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	rosewater-soaked peanut brittle shield	0		Stench Resistance: +3, Damage Reduction: 3, Last Available: "2009-12"
 4390	bouncing Newton's Red Rover BB gun of the detective	0		Experience (Mysticality): +3, Item Drop: +20, Last Available: "2009-12"
-4391	huge Van der Graaf red-and-green sweater	0		MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	huge Van der Graaf red-and-green sweater	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	blinking Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	double-aerosolized Crimbo peppermint bark	0		Effect: "Bubblin' Rage", Effect Duration: 67, Last Available: "2009-12"
 4394	colloidal Crimbo fudge	0		Effect: "Witch Breaded", Effect Duration: 19, Last Available: "2009-12"
@@ -4351,16 +4351,16 @@
 4399	Da Vinci's cheese sword	0		Experience (Mysticality): +5, Softcore Only, Last Available: "2010-01"
 4400	ghostly cheese diaper of James Dean	0		Experience (Moxie): +3, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	cheese wheel of dire peril	0		Weapon Damage: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	cheese eye of Tarzan	0		Experience (Muscle): +3, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	cheese eye of Tarzan	0		Experience (Muscle): +3, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	gray reassuring ruddy smartaleck's Staff of Queso Escusado	0		Moxie Percent: +30, Maximum HP Percent: +40, Spooky Resistance: +1, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	tumbling The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 4407	shaking Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
-4409	twirling fuchsia Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
+4409	fuchsia twirling Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	small moldy enchanted squat quantum taco	0		Effect: "Spore-Wreathed", Effect Duration: 10, Last Available: "2010-10"
+4412	moldy small enchanted squat quantum taco	0		Effect: "Spore-Wreathed", Effect Duration: 10, Last Available: "2010-10"
 4413	hand-crafted Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	blinking colorful plastic ball	0		Last Available: "2010-01"
 4415	medical-grade sealhide hood	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4393,7 +4393,7 @@
 4445	pulsating sharpshooter's spangly mariachi pants	0		Critical Hit Percent: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	deadly spangly mariachi vest of Flo-Jo	0		Weapon Damage: +5, Initiative: +100
 4447	personal trainer's spangly sombrero	0		Experience Percent (Muscle): +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	modified narrow bouncing Instant Karma	1	awesome	
+4448	modified bouncing narrow Instant Karma	1	awesome	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	huge prompt pointy hat	0		Adventures: +3, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
@@ -4410,10 +4410,10 @@
 4462	moist chocolate seal-clubbing club	0		Effect: "Carrrsmic", Effect Duration: 54
 4463	altered dry chocolate turtle totem	0		Effect: "protect.enq", Effect Duration: 44
 4464	alkaline deionized chocolate pasta spoon	0		Effect: "Butt-Rock Hair", Effect Duration: 67
-4465	chilled ghostly maroon narrow chocolate saucepan	0		Effect: "You're High as a Crow, Marty", Effect Duration: 67
+4465	chilled narrow ghostly maroon chocolate saucepan	0		Effect: "You're High as a Crow, Marty", Effect Duration: 67
 4466	irradiated ionized chocolate disco ball	0		Effect: "Sagittarius Rising", Effect Duration: 14
 4467	pickled fuchsia chocolate stolen accordion	0		Effect: "Frisky Spirit", Effect Duration: 49
-4468	blurry ghostly Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	ghostly blurry Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	huge BRICKO eye brick	0		Last Available: "2010-02"
 4471	pulsating steel-toed BRICKO hat	0		Damage Reduction: 9, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
@@ -4424,8 +4424,8 @@
 4476	ghostly BRICKO oyster	0		Last Available: "2010-02"
 4477	blinking BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
-4480	upside-down mirror BRICKO python	0		Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4480	mirror upside-down BRICKO python	0		Last Available: "2010-02"
 4481	red BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
 4483	BRICKO cathedral	0		Last Available: "2010-02"
@@ -4471,14 +4471,14 @@
 4523	olive double-paned eye of the Tiger-lily of the boozehound	0		Cold Resistance: +5, Booze Drop: +100, Last Available: "2010-03"
 4524	double-paned foul-smelling wig	0		Stench Damage: +10, Cold Resistance: +5, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
 4525	decent enchanted donut	4	good	Effect: "The Magical Mojomuscular Melody", Effect Duration: 10, Last Available: "2010-03"
-4526	delicious small bucket of honey	2	awesome	Last Available: "2010-03"
+4526	small delicious bucket of honey	2	awesome	Last Available: "2010-03"
 4527	sinister elephant stinger of Leguizamo	0		Spell Damage: +10, Monster Level: +20, Last Available: "2010-03"
 4528	bite-sized toothsome dragon snaps	1	awesome	Last Available: "2010-03"
 4529	Van der Graaf snapdragon pistil of the wise owl	0		Mysticality: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-03"
 4530	mirror puff of smoke	0		Last Available: "2010-03"
 4531	toothsome low-calorie rook cookie	1	awesome	Last Available: "2010-03"
 4532	moldy bishop cookie	3	crappy	Last Available: "2010-03"
-4533	spoiled huge blue knight cookie	9	crappy	Last Available: "2010-03"
+4533	huge spoiled blue knight cookie	9	crappy	Last Available: "2010-03"
 4534	spoiled king cookie	3	crappy	Last Available: "2010-03"
 4535	miniature decent queen cookie	2	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	green fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4511,10 +4511,10 @@
 4563	drinkable world's most unappetizing beverage	3	good	Last Available: "2010-04"
 4564	brainy slippery when wet shield	0		Mysticality: +5, Damage Reduction: 6, Last Available: "2010-04"
 4565	super-sized decent raisin	5	good	Last Available: "2010-04"
-4566	mirror lime green fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
+4566	lime green mirror fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	flyest of shirts of the storm of incineration	0		Maximum MP Percent: +40, Hot Spell Damage: +50, Last Available: "2010-04"
 4568	delicious red a dance upon the palate	4	awesome	Last Available: "2010-04"
-4569	massive moldy prehistoric meteorite jawbreaker	8	crappy	Last Available: "2010-04"
+4569	moldy massive prehistoric meteorite jawbreaker	8	crappy	Last Available: "2010-04"
 4570	mirror Crazyleg's razor	0		Last Available: "2010-04"
 4571	diet decent bouncing squirmy violent party snack	1	good	Last Available: "2010-04"
 4572	mirror dog trainer's can-you-dig-it?	0		Experience (familiar): +1, Last Available: "2010-04"
@@ -4523,17 +4523,17 @@
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
 4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4577	pulsating bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4578	spinning lime green meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
-4579	extra-galvanized wobbly gray spinning Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Vanity Rage", Effect Duration: 26, Last Available: "2010-04"
+4578	lime green spinning meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
+4579	extra-galvanized wobbly spinning gray Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Vanity Rage", Effect Duration: 26, Last Available: "2010-04"
 4580	Oprah's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Maximum MP Percent: +50, Last Available: "2010-04"
-4581	wobbly careful sage T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Mysticality Percent: +10, Monster Level: -10, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	wobbly careful sage T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Mysticality Percent: +10, Monster Level: -10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	wobbly fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	snack-sized flavorless six wedges of goat cheese	2	decent	
+4584	flavorless snack-sized six wedges of goat cheese	2	decent	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	goth	0		
-4588	wobbly blinking brown pixel	0		
+4588	blinking wobbly brown pixel	0		
 4589	Temple Grandin's pixel whip	0		Familiar Weight: +7
 4590	pixel chain whip of chilblains	0		Cold Damage: +25, Last Available: "2010-07"
 4591	smooth pixel morning star	0		Moxie: +15, Last Available: "2010-07"
@@ -4544,18 +4544,18 @@
 4596	twirling map to Vanya's Castle	0		Last Available: "2010-07"
 4597	jittery 8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
-4599	tumbling lime green bottle opener	0		Last Available: "2010-06"
+4599	lime green tumbling bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	practically non-alcoholic mediocre plastic cup of beer	1	decent	Last Available: "2010-06"
+4601	mediocre practically non-alcoholic plastic cup of beer	1	decent	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	mirror tumbling veiny bottle of Goldschn&ouml;ckered of the boozehound	0		Maximum HP: +10, Booze Drop: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	spoiled half-sized sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	mirror tumbling veiny bottle of Goldschn&ouml;ckered of the boozehound	0		Maximum HP: +10, Booze Drop: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4606	half-sized spoiled sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	hand-crafted shaking soyburger juice	3	EPIC	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	blinking respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
-4610	chilled boiled blue mirror narrow squat essential soy	0		Effect: "Creepin' Up on You", Effect Duration: 63, Last Available: "2010-08"
+4610	chilled boiled squat mirror narrow blue essential soy	0		Effect: "Creepin' Up on You", Effect Duration: 63, Last Available: "2010-08"
 4611	unsweetened quadruple-warmed ionized jittery essential cameraderie	0		Effect: "Mushroom Samba", Effect Duration: 46, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	green map to the Magic Commune	0		Last Available: "2010-08"
@@ -4566,15 +4566,15 @@
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
-4621	olive mirror Game Grid token	0		Last Available: "2010-06"
+4621	mirror olive Game Grid token	0		Last Available: "2010-06"
 4622	Game Grid ticket	0		Last Available: "2010-06"
-4623	quantum colloidal red squat chocolate-covered caviar	0		Effect: "Shawarma Warm War", Effect Duration: 19, Last Available: "2020-09"
+4623	quantum colloidal squat red chocolate-covered caviar	0		Effect: "Shawarma Warm War", Effect Duration: 19, Last Available: "2020-09"
 4624	normal fancy pawn cookie	3	good	Effect: "Greasy Visage", Effect Duration: 5, Last Available: "2010-06"
 4625	boiled coffee pixie stick	1	EPIC	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	shaking finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	foul-smelling plastic spider ring	0		Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	foul-smelling plastic spider ring	0		Stench Damage: +10, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	razor-sharp plastic kazoo	0		Weapon Damage Percent: +25, Last Available: "2010-06"
 4631	spinning prompt inflatable baseball bat	0		Adventures: +3, Last Available: "2010-06"
 4632	ghostly green googly-star hat of the ox of the glutton	0		Muscle: +20, Food Drop: +100, Familiar Effect: "atk", Last Available: "2010-06"
@@ -4616,7 +4616,7 @@
 4668	narrow observational glasses of the scaredy-cat	0		Monster Level: -15
 4669	mansplainer's hilarious comedy prop	0		Monster Level: +15
 4670	beer-scented teddy bear	0		
-4671	watered-down tolerable booze-soaked cherry	2	good	
+4671	tolerable watered-down booze-soaked cherry	2	good	
 4672	pulsating comfy pillow	0		
 4673	bite-sized decent marshmallow	1	good	
 4674	flavorless huge sponge cake	4	decent	
@@ -4667,13 +4667,13 @@
 4719	Hollandaise helmet of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "atk, cap 2"
 4720	bouncing organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	immense toothsome liver and let pie	9	awesome	Last Available: "2010-10"
+4722	toothsome immense liver and let pie	9	awesome	Last Available: "2010-10"
 4723	normal mirror pulsating badass pie	3	good	Last Available: "2010-10"
 4724	toothsome shoo-fish pie	3	awesome	Last Available: "2010-10"
-4725	special jumbo bland piping organ pie	5	decent	Effect: "Disco Concentration", Effect Duration: 50, Last Available: "2010-10"
+4725	bland jumbo special piping organ pie	5	decent	Effect: "Disco Concentration", Effect Duration: 50, Last Available: "2010-10"
 4726	small decent blinking igloo pie	2	good	Last Available: "2010-10"
 4727	bland stomach turnover	4	decent	Last Available: "2010-10"
-4728	massive normal blurry skewed dead lights pie	9	good	Last Available: "2010-10"
+4728	massive normal skewed blurry dead lights pie	9	good	Last Available: "2010-10"
 4729	bland throbbing organ pie	3	decent	Last Available: "2010-10"
 4730	experienced stop shield	0		Experience: +2, Damage Reduction: 6, Last Available: "2009-12"
 4731	tumbling nest egg	0		
@@ -4685,7 +4685,7 @@
 4737	jittery asbestos-lined beer-soaked mop	0		Hot Resistance: +5
 4738	drinkable jittery day-old beer	4	good	
 4739	drinkable plain beer	3	good	
-4740	hand-crafted high-proof overpriced &quot;imported&quot; beer	7	EPIC	
+4740	high-proof hand-crafted overpriced &quot;imported&quot; beer	7	EPIC	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	shaking bone chips	0		Last Available: "2011-12"
@@ -4716,16 +4716,16 @@
 4768	pulsating squat zippy wool healthy Staff of the November Jack-O-Lantern	0		Maximum HP Percent: +20, Cold Resistance: +1, Initiative: +20, Last Available: "2010-11"
 4769	pumpkin carriage	0		Last Available: "2010-11"
 4770	bouncing Desert Bus pass	0		
-4771	tumbling red ginormous pumpkin	0		Last Available: "2010-11"
+4771	red tumbling ginormous pumpkin	0		Last Available: "2010-11"
 4804	Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
 4806	Unmotivator: Success Warrior	0		Free Pull
 4807	blurry Unmotivator: Crashed Meat Car	0		Free Pull
 4810	shaking Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
-4811	upside-down twirling Holiday Fun!	0		Free Pull, Last Available: "2014-12"
+4811	twirling upside-down Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	moldy narrow CRIMBCOIDS mints	3	crappy	Last Available: "2011-01"
-4819	fuchsia twirling can of CRIMBCOLA	0		Last Available: "2010-12"
+4819	twirling fuchsia can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	yummy CRIMBCOLOAF	3	awesome	Last Available: "2011-01"
 4821	small decent circular CRIMBCOOKIE	2	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	fuchsia hale plastic CRIMBCO HQ	0		Maximum HP: +20, Last Available: "2010-12"
@@ -4733,17 +4733,17 @@
 4824	red plastic hobo elf of dire peril	0		Weapon Damage: +20, Last Available: "2010-12"
 4825	blinking plastic Mr. Mination of the storm	0		Maximum MP Percent: +40, Last Available: "2010-12"
 4826	plastic Best Game Ever of the brute	0		Muscle Percent: +30, Last Available: "2010-12"
-4827	yellow shaking hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
+4827	shaking yellow hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	tumbling S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
 4832	robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
-4833	green ghostly robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
+4833	ghostly green robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
 4835	robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
-4837	shaking twirling blurry robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
+4837	twirling blurry shaking robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	decent triangular CRIMBCOOKIE	4	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	moldy square CRIMBCOOKIE	4	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
@@ -4762,7 +4762,7 @@
 4853	irradiated improved holly-flavored Hob-O	0		Effect: "Coming Up Roses", Effect Duration: 45, Last Available: "2020-09"
 4854	mirror CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
-4856	shaking purple paperclip	0		Last Available: "2011-01"
+4856	purple shaking paperclip	0		Last Available: "2011-01"
 4857	jittery bottle of Blank-Out	0		Last Available: "2011-01"
 4858	wobbly healthy CRIMBCO lanyard	0		Maximum HP Percent: +20, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
@@ -4781,7 +4781,7 @@
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
 4874	gaudy key	0		
-4875	squat pulsating BGE merchandise order form	0		Last Available: "2010-12"
+4875	pulsating squat BGE merchandise order form	0		Last Available: "2010-12"
 4876	non-tarnished chocolate bath ball	0		Effect: "Rosewater Mark", Effect Duration: 34, Last Available: "2011-01"
 4877	improved alkaline bacon bath ball	0		Effect: "Wolf's Bane", Effect Duration: 15, Last Available: "2011-01"
 4878	magnetized incense bath ball	0		Effect: "Dreadful Fear", Effect Duration: 20, Last Available: "2011-01"
@@ -4790,17 +4790,17 @@
 4881	lousy CRIMBCO wine	3	decent	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	upside-down toe jam	0		Last Available: "2011-01"
-4884	enchanted bland snack-sized toe jam toast	2	decent	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2011-01"
+4884	snack-sized bland enchanted toe jam toast	2	decent	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	rotten traffic jam toast	4	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	rotten special space jam toast	4	crappy	Effect: "Amorphous Cheer", Effect Duration: 30, Last Available: "2011-01"
+4888	special rotten space jam toast	4	crappy	Effect: "Amorphous Cheer", Effect Duration: 30, Last Available: "2011-01"
 4889	electrified cold-filtered denatured spinning motivational poster	0		Effect: "Florid Cheeks", Effect Duration: 41, Last Available: "2011-01"
 4890	olive sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	normal fancy festive sausage	3	good	Effect: "Dances with Tweedles", Effect Duration: 15, Last Available: "2011-01"
+4894	fancy normal festive sausage	3	good	Effect: "Dances with Tweedles", Effect Duration: 15, Last Available: "2011-01"
 4895	bland huge huge holiday cheese log	7	decent	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	huge blurry lard-coated savvy BGE 'ferocious fruit' shirt	0		Mysticality Percent: +20, Sleaze Spell Damage: +25, Last Available: "2010-12"
@@ -4841,10 +4841,10 @@
 4938	quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	squat arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	diet spoiled Knob jelly donut	1	crappy	
+4941	spoiled diet Knob jelly donut	1	crappy	
 4942	Knob cake	0		
 4943	Knob cake pan	0		
-4944	gray jittery Knob batter	0		
+4944	jittery gray Knob batter	0		
 4945	Knob frosting	0		
 4946	unfrosted Knob cake	0		
 4947	Cobb's Knob Menagerie key	0		
@@ -4859,7 +4859,7 @@
 4956	spoiled mirror philosopher's scone	4	crappy	
 4957	extra-oxidized twirling maroon half-baked potion	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 29
 4958	up-at-dawn Knob Goblin deluxe scimitar	0		Adventures: +5
-4959	bite-sized stale Knob nuts	1	decent	
+4959	stale bite-sized Knob nuts	1	decent	
 4960	mediocre gray Cobb's Knob Wurstbrau	3	decent	
 4961	Subject 37 file	0		
 4962	fortified Sinatra's mysterious lapel pin	0		Experience (Moxie): +5, Damage Absorption: +60, Single Equip
@@ -4913,11 +4913,11 @@
 5010	evil eye	0		
 5011	blurry Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	decent tiny wasabi pocky	1	good	Last Available: "2011-03"
-5014	miniature moldy tumbling tobiko pocky	2	crappy	Last Available: "2011-03"
+5013	tiny decent wasabi pocky	1	good	Last Available: "2011-03"
+5014	moldy miniature tumbling tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	flavorless natto pocky	3	decent	Last Available: "2011-03"
 5016	acceptable lime green wasabi-infused sake	3	good	Last Available: "2011-03"
-5017	practically non-alcoholic bad tobiko-infused sake	1	decent	Last Available: "2011-03"
+5017	bad practically non-alcoholic tobiko-infused sake	1	decent	Last Available: "2011-03"
 5018	bad practically non-alcoholic fuchsia natto-infused sake	1	decent	Last Available: "2011-03"
 5019	diffused extra-alkaline ghostly wasabi marble soda	0		Effect: "Night Vision", Effect Duration: 35, Last Available: "2011-03"
 5020	denatured tobiko marble soda	0		Effect: "Aries Rising", Effect Duration: 18, Last Available: "2011-03"
@@ -4926,7 +4926,7 @@
 5023	polymerized maroon elderly jawbreaker	0		Effect: "Adrenaline Rush", Effect Duration: 32, Last Available: "2020-09"
 5024	perfectly mixed marshmallow flamb&eacute;	3	EPIC	Last Available: "2011-03"
 5025	delicious fortified jittery cranberry schnapps	5	awesome	Last Available: "2011-03"
-5026	extra-dry mediocre twirling breaded beer	5	decent	Last Available: "2011-03"
+5026	mediocre extra-dry twirling breaded beer	5	decent	Last Available: "2011-03"
 5027	artisanal soy cordial	3	super ultra mega EPIC	Last Available: "2011-03"
 5028	banded experienced astral bludgeon of the early riser	0		Experience: +2, Damage Absorption: +100, Adventures: +7
 5029	grievous strapping astral shield	0		Muscle: +5, Weapon Damage Percent: +50, Damage Reduction: 15
@@ -4943,8 +4943,8 @@
 5040	blinking astral pet sweater	0		Familiar Weight: +10
 5041	avaricious rosy-cheeked astral shirt of extreme caution	0		Maximum HP Percent: +30, Monster Level: -25, Meat Drop: +30
 5042	toasty astral belt of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +5
-5043	decent diet astral hot dog	1		
-5044	drinkable practically non-alcoholic upside-down astral pilsner	1		
+5043	diet decent astral hot dog	1		
+5044	practically non-alcoholic drinkable upside-down astral pilsner	1		
 5045	astral hot dog dinner	0		
 5046	wobbly astral six-pack	0		
 5047	yellow Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4967,7 +4967,7 @@
 5064	huge Salsa de las Epocas	0		Last Available: "2011-04"
 5065	stale bouncing spaghetti con calaveras	4	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	bland half-sized popcorn	2	decent	Last Available: "2011-04"
+5067	half-sized bland popcorn	2	decent	Last Available: "2011-04"
 5068	toothsome upside-down chaos popcorn	3	awesome	Last Available: "2011-04"
 5069	smooth hole of the sewer of Flo-Jo	0		Moxie: +15, Stench Damage: +25, Initiative: +100, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
@@ -4982,7 +4982,7 @@
 5079	squat frosty Van der Graaf helmet of the cougar	0		Moxie: +20, Cold Spell Damage: +10, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	flame-wreathed crutch	0		Hot Spell Damage: +10, Last Available: "2011-05"
 5081	smartaleck's shock belt	0		Moxie Percent: +30, Single Equip, Last Available: "2011-05"
-5082	chilled cold-filtered fuchsia twirling Okee-Dokee soda	0		Effect: "Strange Mental Acuity", Effect Duration: 33, Last Available: "2011-05"
+5082	chilled cold-filtered twirling fuchsia Okee-Dokee soda	0		Effect: "Strange Mental Acuity", Effect Duration: 33, Last Available: "2011-05"
 5083	Jack Frost's rubber band gun	0		Cold Spell Damage: +50, Last Available: "2011-05"
 5084	upside-down pulsating Samson's pin-stripe slacks	0		Experience (Muscle): +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	cyan clever gloves	0		Maximum MP: +20, Single Equip, Last Available: "2011-05"
@@ -5009,16 +5009,16 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	acceptable Jeppson's Malort	4	good	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	jittery smartaleck's stress ball	0		Moxie Percent: +30, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	jittery smartaleck's stress ball	0		Moxie Percent: +30, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	blurry Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	twirling greasy Ultracolor&trade; shirt	0		Sleaze Spell Damage: +10, Last Available: "2011-05"
 5112	jittery My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
-5113	bouncing upside-down spinning packet of orchid seeds	0		
+5113	spinning upside-down bouncing packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	reconstituted crow	0		Last Available: "2011-05"
-5118	olive ghostly bird brain	0		
+5118	ghostly olive bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
 5121	cool Admiral's hat of wisdom of Gandalf	0		Mysticality: +15, Moxie: +5, Spell Critical Percent: +20, Familiar Effect: "atk", Last Available: "2011-05"
@@ -5032,7 +5032,7 @@
 5129	cyan Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	cyan Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	tarnished extra-activated pulsating Ultrasoldier Serum	0		Effect: "Lemony Goodness", Effect Duration: 31, Last Available: "2011-06"
-5132	stale gigantic shaking elven hardtack	7	decent	Last Available: "2011-06"
+5132	gigantic stale shaking elven hardtack	7	decent	Last Available: "2011-06"
 5133	hand-crafted watered-down elven squeeze	2	EPIC	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	twirling green bouncing E.M.U. joystick	0		Last Available: "2011-06"
@@ -5067,8 +5067,8 @@
 5164	yellow mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	pulsating stiffened girl	0		Damage Reduction: 1, Last Available: "2011-06"
 5166	top hat and cane	0		Last Available: "2011-06"
-5167	purple shaking synthetic dog hair pill	0		Last Available: "2011-06"
-5168	mirror squat distention pill	0		Last Available: "2011-06"
+5167	shaking purple synthetic dog hair pill	0		Last Available: "2011-06"
+5168	squat mirror distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	non-Vulcanized blinking transporter transponder	0		Effect: "So Fresh and So Clean", Effect Duration: 54, Last Available: "2011-06"
 5171	Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
@@ -5076,10 +5076,10 @@
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	weak delicious Saison du Lune	2	awesome	Last Available: "2011-06"
 5175	smooth mirror Moonthril Schnapps	3	awesome	Last Available: "2011-06"
-5176	perfectly mixed distilled Wrecked Generator	5	EPIC	Last Available: "2011-06"
+5176	distilled perfectly mixed Wrecked Generator	5	EPIC	Last Available: "2011-06"
 5177	yummy miniature blue Spaghetti with Moonballs	2	awesome	Last Available: "2011-06"
 5178	decent Crepes a la Lune	4	good	Last Available: "2011-06"
-5179	flavorless teal shaking Moon Pie	3	decent	Last Available: "2011-06"
+5179	flavorless shaking teal Moon Pie	3	decent	Last Available: "2011-06"
 5180	magnetized wobbly Comet Pop	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 19, Last Available: "2011-06"
 5181	activated Vulcanized mirror Flan in the Moon	0		Effect: "Trash-Wrapped", Effect Duration: 40, Last Available: "2011-06"
 5182	tarnished triple-diffused 1/6th Pound Cake	0		Effect: "Coy to the Hurled", Effect Duration: 29, Last Available: "2011-06"
@@ -5090,11 +5090,11 @@
 5187	huge Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	adjusted improved blinking honey stick	0		Effect: "Trufflin'", Effect Duration: 46
 5189	dry double-ice gum	0		Effect: "Sweet Tooth", Effect Duration: 15, Last Available: "2011-04"
-5190	squat MacGyver's sinister Operation Patriot Shield of temperance	0		Spell Damage: +10, Maximum MP: +100, Sleaze Resistance: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	squat MacGyver's sinister Operation Patriot Shield of temperance	0		Spell Damage: +10, Maximum MP: +100, Sleaze Resistance: +5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	anodized Vulcanized huge corrupted data	0		Effect: "For Your Brain Only", Effect Duration: 20, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
-5194	ghostly purple upside-down exorcised sandwich	0		
+5194	purple upside-down ghostly exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	asbestos-lined Great S-Cape	0		Hot Resistance: +5, Softcore Only, Last Available: "2011-07"
 5197	Marvelous Unitard of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2011-07"
@@ -5106,7 +5106,7 @@
 5203	boiled upside-down bug paste	1	good	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2011-08"
 5204	dehydrated hippy paste	1	crappy	Effect: "Eagle Eyes", Effect Duration: 50, Last Available: "2011-08"
 5205	altered tumbling orc paste	1	decent	Last Available: "2011-08"
-5206	mixed blinking tumbling demonic paste	1	good	Last Available: "2011-08"
+5206	mixed tumbling blinking demonic paste	1	good	Last Available: "2011-08"
 5207	vaporized tumbling indescribably horrible paste	1	awesome	Effect: "Rave Concentration", Effect Duration: 30, Last Available: "2011-08"
 5208	pickled ghostly paste	1	awesome	Last Available: "2011-08"
 5209	powdered goblin paste	1	decent	Last Available: "2011-08"
@@ -5117,13 +5117,13 @@
 5214	mixed blue slimy paste	1	decent	Last Available: "2011-08"
 5215	altered tumbling penguin paste	1	good	Last Available: "2011-08"
 5216	dried elemental paste	1	EPIC	Effect: "It's Soporiffic!", Effect Duration: 30, Last Available: "2011-08"
-5217	powdered narrow bouncing cosmic paste	1	decent	Last Available: "2011-08"
+5217	powdered bouncing narrow cosmic paste	1	decent	Last Available: "2011-08"
 5218	powdered hobo paste	1	decent	Effect: "Turkey-Agitated", Effect Duration: 10, Last Available: "2011-08"
 5219	denatured pulsating Crimbo paste	1	crappy	Effect: "Ticking Clock", Effect Duration: 30, Last Available: "2011-08"
 5220	jittery Teachings of the Fist	0		
 5221	green narrow fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	lime green Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	lime green Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	stale jittery Ur-Donut	4	decent	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5140,11 +5140,11 @@
 5237	personal trainer's time halo	0		Experience Percent (Muscle): +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	lousy Lumineux Limnio	4	decent	Last Available: "2011-09"
 5239	mediocre blinking Morto Moreto	4	decent	Last Available: "2011-09"
-5240	watered-down hand-crafted Temps Tempranillo	2	EPIC	Last Available: "2011-09"
+5240	hand-crafted watered-down Temps Tempranillo	2	EPIC	Last Available: "2011-09"
 5241	perfectly mixed upside-down Bordeaux Marteaux	4	EPIC	Last Available: "2011-09"
 5242	drinkable Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	bad twirling wobbly Beignet Milgranet	3	decent	Last Available: "2011-09"
-5244	weak perfectly mixed Muschat	2	EPIC	Last Available: "2011-09"
+5244	perfectly mixed weak Muschat	2	EPIC	Last Available: "2011-09"
 5245	rotten cool jelly donut	4	crappy	Last Available: "2011-09"
 5246	moldy skewed mirror shrapnel jelly donut	4	crappy	Last Available: "2011-09"
 5247	adequate jittery occult jelly donut	4	good	Last Available: "2011-09"
@@ -5152,16 +5152,16 @@
 5249	rotten danish	4	crappy	Last Available: "2011-09"
 5250	half-sized flavorless smashed danish	2	decent	Last Available: "2011-09"
 5251	snack-sized toothsome fuchsia forbidden danish	2	awesome	Last Available: "2011-09"
-5252	spoiled low-calorie cool cat claw	1	crappy	Last Available: "2011-09"
+5252	low-calorie spoiled cool cat claw	1	crappy	Last Available: "2011-09"
 5253	tasty snack-sized blunt cat claw	2	awesome	Last Available: "2011-09"
-5254	fancy bland jittery shadowy cat claw	3	decent	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20, Last Available: "2011-09"
+5254	bland fancy jittery shadowy cat claw	3	decent	Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 20, Last Available: "2011-09"
 5255	stale cheezburger	3	decent	Last Available: "2011-09"
 5256	adequate upside-down toasted brie	4	good	Last Available: "2011-09"
 5257	non-ionized potion of the field gar	0		Effect: "Your Favorite Flavor", Effect Duration: 55, Last Available: "2011-09"
-5258	Vulcanized narrow blurry too legit potion	0		Effect: "Top Dog", Effect Duration: 48, Last Available: "2011-09"
+5258	Vulcanized blurry narrow too legit potion	0		Effect: "Top Dog", Effect Duration: 48, Last Available: "2011-09"
 5259	ionized Bright Water	0		Effect: "Elemental Mastery", Effect Duration: 18, Last Available: "2011-09"
 5260	colloidal fuchsia cold-filtered water	0		Effect: "Heart of Orange", Effect Duration: 28, Last Available: "2011-09"
-5261	frozen narrow spinning graveyard snowglobe	0		Effect: "Strong Spirit", Effect Duration: 15, Last Available: "2011-09"
+5261	frozen spinning narrow graveyard snowglobe	0		Effect: "Strong Spirit", Effect Duration: 15, Last Available: "2011-09"
 5262	concentrated anodized blue cool cat elixir	0		Effect: "Hardened Fabric", Effect Duration: 66, Last Available: "2011-09"
 5263	adjusted colloidal boiled potion of the captain's hammer	0		Effect: "In the Saucestream", Effect Duration: 53, Last Available: "2011-09"
 5264	liquefied ionized jittery potion of X-ray vision	0		Effect: "Tingly Elbows", Effect Duration: 16, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	stiffened broken clock	0		Damage Reduction: 1, Last Available: "2011-09"
 5282	weightlifter's dethklok	0		Muscle: +15, Last Available: "2011-09"
 5283	Van der Graaf glacial clock	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,8 +5199,8 @@
 5296	huge slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	yellow dungeon dragon chest	0		Last Available: "2011-09"
 5298	bland phish stick	3	decent	Last Available: "2011-09"
-5299	lion tamer's hale Da Vinci's plastic vampire fangs	0		Experience (Mysticality): +5, Maximum HP: +20, Experience (familiar): +2, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
-5300	blurry upside-down Interview With You (a Vampire)	0		Last Available: "2011-10"
+5299	lion tamer's hale Da Vinci's plastic vampire fangs	0		Experience (Mysticality): +5, Maximum HP: +20, Experience (familiar): +2, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5300	upside-down blurry Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
 5303	stylish Sword of the Brouhaha Prince	0		Moxie: +25, Last Available: "2011-10"
@@ -5220,14 +5220,14 @@
 5317	improved Rattlin' Chains	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 68, Last Available: "2011-10"
 5318	flattened colloidal Gummy Brains	0		Effect: "Ooh, Bitter!", Effect Duration: 35, Last Available: "2011-10"
 5319	cold-filtered adjusted blurry Blood 'n' Plenty	0		Effect: "Slightly Larger Than Usual", Effect Duration: 68, Last Available: "2011-10"
-5320	quantum polymerized red huge Lobos Mints	0		Effect: "Swimming with Sharks", Effect Duration: 46, Last Available: "2011-10"
+5320	quantum polymerized huge red Lobos Mints	0		Effect: "Swimming with Sharks", Effect Duration: 46, Last Available: "2011-10"
 5321	galvanized irradiated ghostly olive Sweet Sword	0		Effect: "Aquarius Rising", Effect Duration: 40, Last Available: "2011-10"
-5322	weak drinkable special Ecto-Cooler	2	good	Effect: "The Halls of Mysticality", Effect Duration: 5, Last Available: "2011-10"
-5323	perfectly mixed practically non-alcoholic Bartles and BRAAAINS wine cooler	1	EPIC	Last Available: "2011-10"
+5322	special drinkable weak Ecto-Cooler	2	good	Effect: "The Halls of Mysticality", Effect Duration: 5, Last Available: "2011-10"
+5323	practically non-alcoholic perfectly mixed Bartles and BRAAAINS wine cooler	1	EPIC	Last Available: "2011-10"
 5324	drinkable olive Blood Light	4	good	Last Available: "2011-10"
-5325	lousy watered-down Silver Bullet beer	2	decent	Last Available: "2011-10"
-5326	bad strong jittery Bone's Farm &quot;wine&quot;	5	decent	Last Available: "2011-10"
-5327	upside-down mirror ghost protocol	0		Last Available: "2011-10"
+5325	watered-down lousy Silver Bullet beer	2	decent	Last Available: "2011-10"
+5326	strong bad jittery Bone's Farm &quot;wine&quot;	5	decent	Last Available: "2011-10"
+5327	mirror upside-down ghost protocol	0		Last Available: "2011-10"
 5328	nitrogenated pickled sorority brain	0		Effect: "Old Time Hydration", Effect Duration: 51, Last Available: "2011-10"
 5329	aerosolized Nightstalker perfume	0		Effect: "Tingling Feeling", Effect Duration: 51, Last Available: "2011-10"
 5330	chilled tumbling drum of pomade	0		Effect: "Mucilaginous Muscle", Effect Duration: 69, Last Available: "2011-10"
@@ -5296,8 +5296,8 @@
 5393	scrap of paper	0		
 5394	sandpaper	0		
 5395	bouncing peppermint sprout	0		Last Available: "2011-11"
-5396	tarnished electrified jittery red peppermint twist	0		Effect: "Impregnabili Tea", Effect Duration: 51, Last Available: "2011-11"
-5397	fancy low-calorie flavorless wobbly peppermint patty	1	decent	Effect: "Shortened", Effect Duration: 35, Last Available: "2011-11"
+5396	tarnished electrified red jittery peppermint twist	0		Effect: "Impregnabili Tea", Effect Duration: 51, Last Available: "2011-11"
+5397	low-calorie fancy flavorless wobbly peppermint patty	1	decent	Effect: "Shortened", Effect Duration: 35, Last Available: "2011-11"
 5398	pulsating peppermint crook	0		Last Available: "2011-11"
 5399	skewed peppermint rhino baby	0		Last Available: "2011-11"
 5400	candy cane candygram	0		Last Available: "2011-12"
@@ -5309,10 +5309,10 @@
 5406	Oprah's cane-mail pants of courage of the cheetah	0		Maximum MP Percent: +50, Spooky Resistance: +3, Initiative: +60, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
 5407	perfectly mixed squat lime green Vodka Matryoshka	3	EPIC	Last Available: "2011-12"
 5408	bad extra-dry Gin Mint	5	decent	Last Available: "2011-12"
-5409	tolerable watered-down spinning Tequiz Navidad	2	good	Last Available: "2011-12"
-5410	aged strong Mint Yulep	5	awesome	Last Available: "2011-12"
+5409	watered-down tolerable spinning Tequiz Navidad	2	good	Last Available: "2011-12"
+5410	strong aged Mint Yulep	5	awesome	Last Available: "2011-12"
 5411	fancy weak acceptable Crimbojito	2	good	Effect: "Stuck That Way", Effect Duration: 10, Last Available: "2011-12"
-5412	weak drinkable yellow Sangria de Menthe	2	good	Last Available: "2011-12"
+5412	drinkable weak yellow Sangria de Menthe	2	good	Last Available: "2011-12"
 5413	upside-down candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	electrified licorice root	0		Effect: "Carrion' On", Effect Duration: 33, Last Available: "2011-12"
@@ -5320,7 +5320,7 @@
 5417	liquefied pear supersucker	0		Effect: "Healthy Green Glow", Effect Duration: 64, Last Available: "2011-11"
 5418	dry lime supersucker	0		Effect: "Astral Shell", Effect Duration: 43, Last Available: "2011-11"
 5419	polarized kumquat supersucker	0		Effect: "Blackberry Politeness", Effect Duration: 18, Last Available: "2011-11"
-5420	liquefied non-magnetized shaking cyan strawberry supersucker	0		Effect: "Beta Carotene Overdose", Effect Duration: 59, Last Available: "2011-11"
+5420	liquefied non-magnetized cyan shaking strawberry supersucker	0		Effect: "Beta Carotene Overdose", Effect Duration: 59, Last Available: "2011-11"
 5421	beefcake's bananarama bangle	0		Muscle: +25, Single Equip, Last Available: "2011-11"
 5422	pair of pearidot earrings of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2011-11"
 5423	skewed reassuring tourmalime tourniquet	0		Spooky Resistance: +1, Single Equip, Last Available: "2011-11"
@@ -5338,7 +5338,7 @@
 5435	olive jittery fudgecule	0		Last Available: "2011-11"
 5436	anodized fudge lily	0		Effect: "World's Shortest Giant", Effect Duration: 58, Last Available: "2011-11"
 5437	lime green superheated fudge	0		Last Available: "2011-11"
-5438	diffused flattened shaking spinning fluid of fudge-finding	0		Effect: "Liquid Courage", Effect Duration: 17, Last Available: "2011-11"
+5438	diffused flattened spinning shaking fluid of fudge-finding	0		Effect: "Liquid Courage", Effect Duration: 17, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	moldy special fudgesicle	4	crappy	Effect: "Balls of Ectoplasm", Effect Duration: 50, Last Available: "2011-11"
 5441	yellow wand of fudge control	0		Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	red groovy fudgecycle of terror	0		Moxie Percent: +10, Spooky Spell Damage: +10, Item Drop: +5, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	huge blank fudge mold	0		Last Available: "2011-11"
-5463	gray Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	gray Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	pickled resolution: be wealthier	0		Effect: "Demonic Taint", Effect Duration: 22, Last Available: "2012-01"
 5465	colloidal tarnished resolution: be happier	0		Effect: "Trufflin'", Effect Duration: 67, Last Available: "2012-01"
 5466	concentrated denatured teal resolution: be stronger	0		Effect: "Certainty", Effect Duration: 45, Last Available: "2012-01"
@@ -5372,15 +5372,15 @@
 5469	activated modified chilled resolution: be feistier	0		Effect: "Stickler for Promptness", Effect Duration: 35, Last Available: "2012-01"
 5470	altered resolution: be kinder	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 17, Last Available: "2012-01"
 5471	pressed ionized spinning resolution: be more adventurous	0		Effect: "Fustulent", Effect Duration: 35, Last Available: "2012-01"
-5472	quantum wobbly tumbling resolution: be luckier	0		Effect: "X-Ray Vision", Effect Duration: 41, Last Available: "2012-01"
+5472	quantum tumbling wobbly resolution: be luckier	0		Effect: "X-Ray Vision", Effect Duration: 41, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	jittery gummi ingot	0		Last Available: "2011-11"
 5476	vacuum-sealed gummi salamander	0		Effect: "Sweet Tooth", Effect Duration: 42, Last Available: "2011-11"
 5477	modified anodized gummi snake	0		Effect: "Oily Flavor", Effect Duration: 39, Last Available: "2011-11"
 5478	quadruple-ionized gummi canary	0		Effect: "Cat Class, Cat Style", Effect Duration: 27, Last Available: "2011-11"
-5479	fancy decent gummi bear	4	good	Effect: "Winning Smile", Effect Duration: 25, Last Available: "2011-11"
-5480	bland super-sized gummi bear	5	decent	Last Available: "2011-11"
+5479	decent fancy gummi bear	4	good	Effect: "Winning Smile", Effect Duration: 25, Last Available: "2011-11"
+5480	super-sized bland gummi bear	5	decent	Last Available: "2011-11"
 5481	thick adequate gummi bear	5	good	Last Available: "2011-11"
 5482	adequate drunki-bear	3	good	Last Available: "2011-11"
 5483	adequate low-calorie drunki-bear	1	good	Last Available: "2011-11"
@@ -5391,9 +5391,9 @@
 5488	trilobite fossil	0		Last Available: "2011-11"
 5489	shaking ammonite fossil	0		Last Available: "2011-11"
 5490	belemnite fossil	0		Last Available: "2011-11"
-5491	purple shaking trilobite candy mold	0		Last Available: "2011-11"
+5491	shaking purple trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
-5493	yellow squat belemnite candy mold	0		Last Available: "2011-11"
+5493	squat yellow belemnite candy mold	0		Last Available: "2011-11"
 5494	boiled pressed ghostly gummi trilobite	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 57, Last Available: "2011-11"
 5495	anodized cyan gummi ammonite	0		Effect: "Ooh, Sour!", Effect Duration: 24, Last Available: "2011-11"
 5496	concentrated flattened cyan gummi belemnite	0		Effect: "Dirty Pear", Effect Duration: 50, Last Available: "2011-11"
@@ -5406,7 +5406,7 @@
 5503	jittery mirror Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	stale jumbo jerky coins	5	decent	Last Available: "2011-11"
+5506	jumbo stale jerky coins	5	decent	Last Available: "2011-11"
 5507	drinkable Go-Wassail	4	good	Last Available: "2011-11"
 5508	quadruple-oxidized pulsating twirling Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Almost Cool", Effect Duration: 51, Last Available: "2011-11"
 5509	wet oxidized triple-liquefied purple bottle of bubbles	0		Effect: "Hustlin'", Effect Duration: 36, Last Available: "2011-11"
@@ -5444,8 +5444,8 @@
 5541	huge Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	wicked Da Vinci's Leapin' Trousers	0		Experience (Mysticality): +5, Spell Damage: +5
-5544	triple-distilled smooth eggnog	8	awesome	Last Available: "2012-12"
-5545	tiny flavorless hamhock	1	decent	Last Available: "2012-12"
+5544	smooth triple-distilled eggnog	8	awesome	Last Available: "2012-12"
+5545	flavorless tiny hamhock	1	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	mirror mirror Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5474,74 +5474,74 @@
 5571	Groar's fur	0		
 5572	ghostly Thwaitgold stag beetle statuette	0		
 5573	smooth squat Drac & Tan	3	awesome	Last Available: "2012-03"
-5574	triple-distilled hand-crafted Transylvania Sling	8	EPIC	Last Available: "2012-03"
-5575	strong acceptable huge Shot of the Living Dead	5	good	Last Available: "2012-03"
+5574	hand-crafted triple-distilled Transylvania Sling	8	EPIC	Last Available: "2012-03"
+5575	acceptable strong huge Shot of the Living Dead	5	good	Last Available: "2012-03"
 5576	aged Buttery Knob	4	awesome	Last Available: "2012-03"
-5577	artisanal weak Slippery Knob	2	EPIC	Last Available: "2012-03"
-5578	strong smooth Flaming Knob	5	awesome	Last Available: "2012-03"
+5577	weak artisanal Slippery Knob	2	EPIC	Last Available: "2012-03"
+5578	smooth strong Flaming Knob	5	awesome	Last Available: "2012-03"
 5579	artisanal Grasshopper	4	EPIC	Last Available: "2012-03"
 5580	perfectly mixed Locust	3	EPIC	Last Available: "2012-03"
 5581	hand-crafted Plague of Locusts	4	EPIC	Last Available: "2012-03"
-5582	mediocre weak Red Dwarf	2	decent	Last Available: "2012-03"
+5582	weak mediocre Red Dwarf	2	decent	Last Available: "2012-03"
 5583	aged spirit-forward Golden Mean	5	awesome	Last Available: "2012-03"
-5584	irresponsibly strong tolerable bouncing Green Giant	9	good	Last Available: "2012-03"
-5585	weak lousy shaking Aye Aye	2	decent	Last Available: "2012-03"
+5584	tolerable irresponsibly strong bouncing Green Giant	9	good	Last Available: "2012-03"
+5585	lousy weak shaking Aye Aye	2	decent	Last Available: "2012-03"
 5586	acceptable special narrow Aye Aye, Captain	3	good	Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2012-03"
 5587	drinkable Aye Aye, Tooth Tooth	4	good	Last Available: "2012-03"
 5588	hand-crafted huge Humanitini	4	EPIC	Last Available: "2012-03"
-5589	mediocre weak twirling More Humanitini than Humanitini	2	decent	Last Available: "2012-03"
-5590	spirit-forward mediocre Oh, the Humanitini	5	decent	Last Available: "2012-03"
+5589	weak mediocre twirling More Humanitini than Humanitini	2	decent	Last Available: "2012-03"
+5590	mediocre spirit-forward Oh, the Humanitini	5	decent	Last Available: "2012-03"
 5591	drinkable Great Older Fashioned	3	good	Last Available: "2012-03"
-5592	bad extra-dry fancy spinning Fuzzy Tentacle	5	decent	Effect: "Bread-Lined", Effect Duration: 5, Last Available: "2012-03"
+5592	fancy extra-dry bad spinning Fuzzy Tentacle	5	decent	Effect: "Bread-Lined", Effect Duration: 5, Last Available: "2012-03"
 5593	artisanal mirror Crazymaker	3	EPIC	Last Available: "2012-03"
 5594	delicious Zoodriver	4	awesome	Last Available: "2012-03"
-5595	acceptable watered-down Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
-5596	weak lousy special Sloe Comfortable Zoo on Fire	2	decent	Effect: "Tasting the Rainbow", Effect Duration: 20, Last Available: "2012-03"
-5597	mediocre watered-down Suffering Sinner	2	decent	Last Available: "2012-03"
+5595	watered-down acceptable Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
+5596	lousy weak special Sloe Comfortable Zoo on Fire	2	decent	Effect: "Tasting the Rainbow", Effect Duration: 20, Last Available: "2012-03"
+5597	watered-down mediocre Suffering Sinner	2	decent	Last Available: "2012-03"
 5598	artisanal blurry Suppurating Sinner	4	EPIC	Last Available: "2012-03"
-5599	extra-dry drinkable pulsating Sizzling Sinner	5	good	Last Available: "2012-03"
+5599	drinkable extra-dry pulsating Sizzling Sinner	5	good	Last Available: "2012-03"
 5600	weak delicious Firewater	2	awesome	Last Available: "2012-03"
 5601	bad Earth and Firewater	4	decent	Last Available: "2012-03"
-5602	triple-distilled lousy Earth, Wind and Firewater	6	decent	Last Available: "2012-03"
+5602	lousy triple-distilled Earth, Wind and Firewater	6	decent	Last Available: "2012-03"
 5603	hand-crafted Slimosa	3	EPIC	Last Available: "2012-03"
 5604	acceptable enchanted Extra-slimy Slimosa	3	good	Effect: "Sharpened Sweet Tooth", Effect Duration: 40, Last Available: "2012-03"
 5605	lousy practically non-alcoholic Slimebite	1	decent	Last Available: "2012-03"
-5606	aged extra-dry Cement Mixer	5	awesome	Last Available: "2012-03"
+5606	extra-dry aged Cement Mixer	5	awesome	Last Available: "2012-03"
 5607	perfectly mixed jittery Jackhammer	3	EPIC	Last Available: "2012-03"
 5608	bad practically non-alcoholic Dump Truck	1	decent	Last Available: "2012-03"
 5609	acceptable Fauna Libre	3	good	Last Available: "2012-03"
 5610	mediocre Chakra Libre	4	decent	Last Available: "2012-03"
-5611	weak tolerable Aura Libre	2	good	Last Available: "2012-03"
+5611	tolerable weak Aura Libre	2	good	Last Available: "2012-03"
 5612	drinkable Sazerorc	4	good	Last Available: "2012-03"
 5613	mediocre Sazuruk-hai	3	decent	Last Available: "2012-03"
-5614	triple-distilled perfectly mixed Flaming Sazerorc	6	EPIC	Last Available: "2012-03"
-5615	bad weak Green Velvet	2	decent	Last Available: "2012-03"
+5614	perfectly mixed triple-distilled Flaming Sazerorc	6	EPIC	Last Available: "2012-03"
+5615	weak bad Green Velvet	2	decent	Last Available: "2012-03"
 5616	lousy Green Muslin	3	decent	Last Available: "2012-03"
-5617	bad fortified Green Burlap	5	decent	Last Available: "2012-03"
+5617	fortified bad Green Burlap	5	decent	Last Available: "2012-03"
 5618	tolerable ghostly Mohobo	4	good	Last Available: "2012-03"
 5619	lousy skewed Moonshine Mohobo	3	decent	Last Available: "2012-03"
 5620	aged Flaming Mohobo	4	awesome	Last Available: "2012-03"
 5621	perfectly mixed Drunken Philosopher	3	EPIC	Last Available: "2012-03"
 5622	tolerable Drunken Neurologist	4	good	Last Available: "2012-03"
-5623	lousy extra-dry enchanted Drunken Astrophysicist	5	decent	Effect: "Uncaged Power", Effect Duration: 30, Last Available: "2012-03"
+5623	enchanted extra-dry lousy Drunken Astrophysicist	5	decent	Effect: "Uncaged Power", Effect Duration: 30, Last Available: "2012-03"
 5624	mediocre Dark & Starry	4	decent	Last Available: "2012-03"
 5625	acceptable Black Hole	3	good	Last Available: "2012-03"
-5626	distilled artisanal Event Horizon	5	EPIC	Last Available: "2012-03"
-5627	spirit-forward lousy Herring Daiquiri	5	decent	Last Available: "2012-03"
-5628	delicious distilled upside-down Herring Wallbanger	5	awesome	Last Available: "2012-03"
+5626	artisanal distilled Event Horizon	5	EPIC	Last Available: "2012-03"
+5627	lousy spirit-forward Herring Daiquiri	5	decent	Last Available: "2012-03"
+5628	distilled delicious upside-down Herring Wallbanger	5	awesome	Last Available: "2012-03"
 5629	enchanted artisanal Herringtini	4	EPIC	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 30, Last Available: "2012-03"
 5630	delicious Lollipop Drop	3	awesome	Last Available: "2012-03"
-5631	distilled artisanal Candy Alexander	5	EPIC	Last Available: "2012-03"
+5631	artisanal distilled Candy Alexander	5	EPIC	Last Available: "2012-03"
 5632	artisanal ghostly narrow Candicaine	4	EPIC	Last Available: "2012-03"
-5633	lousy weak Caipiranha	2	decent	Last Available: "2012-03"
+5633	weak lousy Caipiranha	2	decent	Last Available: "2012-03"
 5634	mediocre jittery Flying Caipiranha	3	decent	Last Available: "2012-03"
 5635	fancy weak tolerable Flaming Caipiranha	2	good	Effect: "Haunted Stomach", Effect Duration: 35, Last Available: "2012-03"
 5636	practically non-alcoholic tolerable Punchplanter	1	good	Last Available: "2012-03"
-5637	special tolerable Doublepunchplanter	3	good	Effect: "Mushroom Samba", Effect Duration: 5, Last Available: "2012-03"
+5637	tolerable special Doublepunchplanter	3	good	Effect: "Mushroom Samba", Effect Duration: 5, Last Available: "2012-03"
 5638	bad Haymaker	4	decent	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	gigantic flavorless fungus	7	decent	
+5641	flavorless gigantic fungus	7	decent	
 5642	poisoned dart	0		
 5643	super-polarized stone wool	0		Effect: "Army of One", Effect Duration: 14
 5644	stones	0		
@@ -5554,8 +5554,8 @@
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	shaking twirling Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	enchanted delicious wobbly nailswurst	3	awesome	Effect: "Simulation Stimulation", Effect Duration: 5
-5655	weak hand-crafted upside-down used beer	2	EPIC	
+5654	delicious enchanted wobbly nailswurst	3	awesome	Effect: "Simulation Stimulation", Effect Duration: 5
+5655	hand-crafted weak upside-down used beer	2	EPIC	
 5656	squat Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5568,7 +5568,7 @@
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
 5666	fuchsia How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
-5668	skewed shaking bagged &quot;L&quot;	0		
+5668	shaking skewed bagged &quot;L&quot;	0		
 5669	blurry club	0		
 5670	adequate fettucini &eacute;pines Inconnu	3	good	
 5671	watered-down hand-crafted slap and slap again	2	EPIC	
@@ -5632,19 +5632,19 @@
 5731	acceptable special 5-hour acrimony	3	good	Effect: "Mutated", Effect Duration: 40
 5732	tumbling blank note	0		
 5733	huge eerily silent box	0		
-5734	low-calorie flavorless forbidden sausage	1	decent	
-5735	Lord Flameface's cloak of mayonnaise	0		Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5734	flavorless low-calorie forbidden sausage	1	decent	
+5735	Lord Flameface's cloak of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	enhanced flattened Drizzlers&trade; Black Licorice	0		Effect: "Amorous Avarice", Effect Duration: 12
 5737	activated dry daub-breaker	0		Effect: "Hot Blooded", Effect Duration: 60, Last Available: "2020-09"
 5738	bouncing stiffened Camp Scout backpack	0		Damage Reduction: 1, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	normal bag of GORP	3	good	Last Available: "2012-07"
-5741	enchanted extra-dry smooth water purification pills	5	awesome	Effect: "Stinkybeard", Effect Duration: 50, Last Available: "2012-07"
+5741	extra-dry smooth enchanted water purification pills	5	awesome	Effect: "Stinkybeard", Effect Duration: 50, Last Available: "2012-07"
 5742	olive skewed Camp Scout pup tent	0		Last Available: "2012-07"
 5743	extra-dry mediocre huge CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
 5744	spoiled bag of GORF	4	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
-5746	moldy miniature pulsating bag of QWOP	2	crappy	Last Available: "2012-07"
+5746	miniature moldy pulsating bag of QWOP	2	crappy	Last Available: "2012-07"
 5747	magnetized fuchsia CSA bravery badge	0		Effect: "Shortened", Effect Duration: 26, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	acceptable squat blue CSA cheerfulness ration	4	good	Last Available: "2012-07"
@@ -5659,7 +5659,7 @@
 5759	upside-down bouncing coward's supercharged staff	0		Maximum MP Percent: +30, Monster Level: -20
 5760	nasty studded staff of James Dean	0		Experience (Moxie): +3, Damage Absorption: +80, Stench Damage: +5
 5761	Sherlock's Jim Carey's Van der Graaf Staff of the Scummy Sink	0		Monster Level: +25, Item Drop: +25, MP Regen Min: 5, MP Regen Max: 7, Slime Hates It: +1
-5762	tumbling huge nose	0		
+5762	huge tumbling nose	0		
 5763	padded Superhero Reboots of the blizzard	0		Damage Absorption: +20, Cold Spell Damage: +25
 5764	ghostly Da Vinci's thinker's fuzzy busby	0		Mysticality: +10, Experience (Mysticality): +5, Familiar Effect: "1.5xVolley, cap 32"
 5765	squat rock-hard occult fuzzy earmuffs	0		Spell Damage Percent: +25, Damage Reduction: 5, Familiar Effect: "1.5xVolley, cap 32"
@@ -5674,10 +5674,10 @@
 5774	bouncing talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
 5776	Barney's rake of Calamity Jane of terror	0		Critical Hit Percent: +15, Spooky Spell Damage: +10
-5778	moldy maroon tumbling idiot brain	3	crappy	
+5778	moldy tumbling maroon idiot brain	3	crappy	
 5779	keel-haulin' knife of the glutton	0		Food Drop: +100
 5780	brawny ice cream scoop	0		Muscle Percent: +20
-5781	irresponsibly strong mediocre tumbling soft echo eyedrop antidote martini	6	decent	
+5781	mediocre irresponsibly strong tumbling soft echo eyedrop antidote martini	6	decent	
 5782	blinking morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	spinning weirdwood plank	0		
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	lard-coated padded right bear arm	0		Damage Absorption: +20, Sleaze Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	wobbly family-friendly mansplainer's Samson's left bear arm	0		Experience (Muscle): +5, Monster Level: +15, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	lard-coated padded right bear arm	0		Damage Absorption: +20, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	wobbly family-friendly mansplainer's Samson's left bear arm	0		Experience (Muscle): +5, Monster Level: +15, Sleaze Resistance: +1, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	blurry experienced Hat O' Nine Tails	0		Experience: +2
 5794	dry Enchanted Plunger	0		Effect: "Hammered", Effect Duration: 32
 5795	galvanized blue Enchanted Flyswatter	0		Effect: "Vinegavotte", Effect Duration: 12
@@ -5746,7 +5746,7 @@
 5847	magnetized Vulcanized blue unholy water	0		Effect: "Here's Mud in Your Eye", Effect Duration: 63
 5848	non-wet Bangyomaman battle juice	0		Effect: "Knightlife", Effect Duration: 68
 5849	vacuum-sealed triple-warmed handyman &quot;hand soap&quot;	0		Effect: "Enraged", Effect Duration: 23
-5850	colloidal altered skewed red space marine flash grenade	0		Effect: "Bilious Brains", Effect Duration: 46
+5850	colloidal altered red skewed space marine flash grenade	0		Effect: "Bilious Brains", Effect Duration: 46
 5851	wet energized jittery temporary tribal tattoo	0		Effect: "Craft Tea", Effect Duration: 50
 5852	dry ghostly oil-filled donut	0		Effect: "Robocamo", Effect Duration: 19
 5853	improved stick-on gnome beard	0		Effect: "Human-Insect Hybrid", Effect Duration: 31
@@ -5758,12 +5758,12 @@
 5859	altered blue booby trap	0		Effect: "Favored by Lyle", Effect Duration: 29
 5860	vacuum-sealed upside-down Agent Corrigan's cigarette	0		Effect: "Liquid Courage", Effect Duration: 39
 5861	extra-tarnished good ash	0		Effect: "Man's Worst Enemy", Effect Duration: 20
-5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	mirror papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	liquefied double-aerosolized ghostly papier-mochi	0		Effect: "Hammertime", Effect Duration: 54, Last Available: "2012-09"
-5866	chilled galvanized dry fuchsia huge papier-m&acirc;chaeranthera	0		Effect: "Thunderheart", Effect Duration: 20, Last Available: "2012-09"
-5867	adjusted altered ionized huge bouncing papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Sewer-Drenched", Effect Duration: 52, Last Available: "2012-09"
+5866	chilled galvanized dry huge fuchsia papier-m&acirc;chaeranthera	0		Effect: "Thunderheart", Effect Duration: 20, Last Available: "2012-09"
+5867	adjusted altered ionized bouncing huge papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Sewer-Drenched", Effect Duration: 52, Last Available: "2012-09"
 5868	scorching papier-m&acirc;ch&eacute;te of the brute	0		Muscle Percent: +30, Hot Damage: +25, Last Available: "2012-09"
 5869	red quilted papier-m&acirc;chine gun of the empath	0		Damage Absorption: +40, Familiar Weight: +5, Last Available: "2012-09"
 5870	curative groovy papier-masque	0		Moxie Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2012-09"
@@ -5795,15 +5795,15 @@
 5896	ghostly ghostly canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	twisted Unconscious Collective Dream Jar	1	crappy	Effect: "Spiro Gyro", Effect Duration: 15, Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
-5899	red shaking narrow jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
+5899	narrow red shaking jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	blurry jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	skewed jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	huge red jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	fuchsia jar of psychoses (Jick)	0		Last Available: "2013-12"
-5906	wobbly spinning pixel pill	0		
+5906	spinning wobbly pixel pill	0		
 5907	pixel energy tank	0		
-5908	gray skewed ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
+5908	skewed gray ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	skewed electrified wedding ring	0		Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 5910	deactivated nanobots	0		Free Pull, Last Available: "2012-11"
 5911	nanorhino credit card	0		Last Available: "2012-11"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	brainwave-controlled unicorn horn of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	skewed purple frightening Annie Oakley's plastic four-shadowed mime of wisdom	0		Mysticality: +15, Critical Hit Percent: +20, Spooky Damage: +5, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	tumbling grievous plastic Father McGruber	0		Weapon Damage Percent: +50, Last Available: "2012-12"
 5961	chaotic plastic Hank North, Photojournalist	0		Spell Critical Percent: +10, Last Available: "2012-12"
 5962	fireproof plastic blazing bat	0		Hot Resistance: +3, Last Available: "2012-12"
-5963	cyan electronic dulcimer pants of the pedagogue of temperance	0		Experience: +3, Sleaze Resistance: +5, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	cyan electronic dulcimer pants of the pedagogue of temperance	0		Experience: +3, Sleaze Resistance: +5, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	gray razor-sharp dance instructor's Frown Exerciser	0		Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5881,15 +5881,15 @@
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	teal wholesome extremely unsafe Socratic cloth cap	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Maximum HP Percent: +10, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	red frightening sharpshooter's sage iron dagger	0		Mysticality Percent: +10, Critical Hit Percent: +10, Spooky Damage: +5, Last Available: "2013-02"
-5986	gigantic stale hamburger	7	decent	Last Available: "2013-02"
-5987	bouncing jittery dollar-sign bag	0		Last Available: "2013-02"
+5986	stale gigantic hamburger	7	decent	Last Available: "2013-02"
+5987	jittery bouncing dollar-sign bag	0		Last Available: "2013-02"
 5988	blurry potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	strong perfectly mixed green bottle of wine	5	EPIC	Last Available: "2013-02"
+5990	perfectly mixed strong green bottle of wine	5	EPIC	Last Available: "2013-02"
 5991	skewed round bomb	0		Last Available: "2013-02"
 5992	Fonzie's Socratic iron helmet of bravery	0		Experience (Mysticality): +1, Experience (Moxie): +1, Spooky Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	skewed double-paned ribald dangerous steel sword	0		Weapon Damage: +10, Sleaze Damage: +10, Cold Resistance: +5, Last Available: "2013-02"
-5994	rotten big whole roasted chicken	5	crappy	Last Available: "2013-02"
+5994	big rotten whole roasted chicken	5	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	wobbly potion	0		Last Available: "2013-02"
@@ -5933,7 +5933,7 @@
 6035	polarized enhanced vial of The Glistening	0		Effect: "Whole Latte Love", Effect Duration: 54
 6036	delicious spirit-forward artisanal limoncello	5	awesome	
 6037	ginger ale	0		
-6038	rotten enchanted jumbo incredible pizza	5	crappy	Effect: "Destructive Resolve", Effect Duration: 40
+6038	jumbo enchanted rotten incredible pizza	5	crappy	Effect: "Destructive Resolve", Effect Duration: 40
 6039	greedy friendly oil cap	0		Familiar Weight: +3, Meat Drop: +20, Familiar Effect: "cap 28"
 6040	jittery censurious greasy oil lamp	0		Sleaze Spell Damage: +10, Sleaze Resistance: +3
 6041	upside-down smelly oil slacks	0		Stench Spell Damage: +10, Familiar Effect: "1xPotato, cap 30"
@@ -5949,9 +5949,9 @@
 6051	tumbling Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	normal Taco Dan's Taco Stand Taco	3	good	Last Available: "2012-12"
 6053	strong drinkable Taco Dan's Taco Stand Chimichangarita	5	good	Last Available: "2012-12"
-6054	galvanized activated olive tumbling Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Phoenix, Right?", Effect Duration: 14, Last Available: "2012-12"
+6054	galvanized activated tumbling olive Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Phoenix, Right?", Effect Duration: 14, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	tumbling The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	tumbling The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	supercool wizardly Meatcleaver	0		Mysticality: +25, Moxie Percent: +20, Last Available: "2013-12"
 6058	ghostly sage Crimbo Elf bobble-head	0		Mysticality Percent: +10, Last Available: "2012-12"
 6059	wholesome Crimbo stogie-scented room odorizer	0		Maximum HP Percent: +10, Last Available: "2012-12"
@@ -5966,17 +5966,17 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	concentrated energized haggis-infused soap	0		Effect: "Nothing Is Impossible", Effect Duration: 59, Last Available: "2012-12"
 6074	quantum upside-down upside-down magicberry tablets	0		Effect: "Guts Feeling", Effect Duration: 43, Last Available: "2012-12"
 6075	colloidal 37x37x37 puzzle cube	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 18, Last Available: "2012-12"
 6076	mediocre McLeod's Hard Haggis-Ade	3	decent	Last Available: "2012-12"
-6077	stale snack-sized ghostly haggis-wrapped haggis-stuffed haggis	2	decent	Last Available: "2012-12"
+6077	snack-sized stale ghostly haggis-wrapped haggis-stuffed haggis	2	decent	Last Available: "2012-12"
 6078	wobbly home robotics kit	0		Last Available: "2012-12"
 6079	narrow school calculator watch	0		Last Available: "2012-12"
-6080	deadly haggis socks	0		Weapon Damage: +5, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	ghostly ghostly airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	deadly haggis socks	0		Weapon Damage: +5, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	ghostly ghostly airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	bouncing Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	huge actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	green abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	acceptable practically non-alcoholic Chinese beer	1	good	Last Available: "2013-12"
+6121	practically non-alcoholic acceptable Chinese beer	1	good	Last Available: "2013-12"
 6122	wobbly cat statue	0		Last Available: "2013-12"
 6123	ghostly rhinoceros horn	0		Last Available: "2013-12"
 6124	tumbling red furry pink pillow	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	spinning rubber gloves of chilblains	0		Cold Damage: +25, Last Available: "2013-12"
 6140	wobbly Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	snack-sized flavorless roasted duck	2	decent	Last Available: "2013-12"
+6142	flavorless snack-sized roasted duck	2	decent	Last Available: "2013-12"
 6143	rotten massive spinning dead meat bun	9	crappy	Last Available: "2013-12"
 6144	stiffened cat collar	0		Damage Reduction: 1, Single Equip, Last Available: "2013-12"
 6145	green frightening suspicious-looking fedora of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
@@ -6052,10 +6052,10 @@
 6155	cyan pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	narrow electrified crafty Byte	0		Maximum MP: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
-6158	therapeutic anger blaster	0		HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	ghostly gray Da Vinci's doubt cannon	0		Experience (Mysticality): +5, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	inspector's fear condenser	0		Item Drop: +15, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	shaking resourceful regret hose	0		Maximum MP: +50, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	therapeutic anger blaster	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	ghostly gray Da Vinci's doubt cannon	0		Experience (Mysticality): +5, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	inspector's fear condenser	0		Item Drop: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	shaking resourceful regret hose	0		Maximum MP: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	lime green Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	shaking green Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	blinking medical-grade commodore's hat of the detective	0		Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
@@ -6066,7 +6066,7 @@
 6169	tolerable high-proof Hundred Headed IPA	8	good	Last Available: "2013-12"
 6170	moldy chum	3	crappy	Last Available: "2013-12"
 6171	colloidal frozen wet crude crudit&eacute;s	0		Effect: "Experimental Effect G-9", Effect Duration: 51
-6172	colloidal huge red candy crayons	0		Effect: "Tasting the Rainbow", Effect Duration: 25, Last Available: "2020-09"
+6172	colloidal red huge candy crayons	0		Effect: "Tasting the Rainbow", Effect Duration: 25, Last Available: "2020-09"
 6173	gray medical-grade pixel grappling hook of doom	0		Spooky Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
@@ -6085,52 +6085,52 @@
 6188	super-sized tasty fuchsia consummate bagel	5	awesome	
 6189	small tasty consummate sliced bread	2	awesome	
 6190	bland lime green consummate hot dog bun	3	decent	
-6191	super-sized normal consummate brownie	5	good	
+6191	normal super-sized consummate brownie	5	good	
 6192	decent consummate toast	4	good	
 6193	drinkable passable stout	4	good	
 6194	toothsome consummate soup	4	awesome	
 6195	tasty bouncing consummate corn chips	3	awesome	
-6196	normal miniature blurry consummate salad	2	good	
+6196	miniature normal blurry consummate salad	2	good	
 6197	normal consummate salsa	4	good	
-6198	decent diet consummate sauerkraut	1	good	
+6198	diet decent consummate sauerkraut	1	good	
 6199	huge spoiled consummate cheese slice	8	crappy	
 6200	bland consummate melted cheese	4	decent	
 6201	flavorless jumbo consummate bacon	5	decent	
-6202	special spoiled consummate meatloaf	3	crappy	Effect: "Punchy, Murdery", Effect Duration: 25
+6202	spoiled special consummate meatloaf	3	crappy	Effect: "Punchy, Murdery", Effect Duration: 25
 6203	adequate consummate steak	3	good	
 6204	adequate consummate cuts	3	good	
 6205	tasty consummate frankfurter	3	awesome	
 6206	bland consummate french fries	3	decent	
-6207	adequate big consummate baked potato	5	good	
+6207	big adequate consummate baked potato	5	good	
 6208	drinkable acceptable vodka	3	good	
 6209	spoiled consummate ice cream	4	crappy	
 6210	spoiled consummate whipped cream	4	crappy	
 6211	flavorless ghostly consummate cream	3	decent	
 6212	yummy consummate strawberries	4	awesome	
 6213	bland miniature consummate sorbet	2	decent	
-6214	mediocre practically non-alcoholic squat adequate rum	1	decent	
+6214	practically non-alcoholic mediocre squat adequate rum	1	decent	
 6215	bad mediocre lager	4	decent	
-6216	fancy toothsome immaculate grilled cheese	4	awesome	Effect: "Hustlin'", Effect Duration: 25
+6216	toothsome fancy immaculate grilled cheese	4	awesome	Effect: "Hustlin'", Effect Duration: 25
 6217	rotten tumbling jittery immaculate ice cream sandwich	3	crappy	
-6218	decent immense immaculate hot dog	8	good	
+6218	immense decent immaculate hot dog	8	good	
 6219	bland immaculate egg salad sandwich	4	decent	
-6220	enchanted tasty olive perfect sandwich	3	awesome	Effect: "Meat the Flintstones", Effect Duration: 50
+6220	tasty enchanted olive perfect sandwich	3	awesome	Effect: "Meat the Flintstones", Effect Duration: 50
 6221	bland perfect chef salad	4	decent	
-6222	super-sized tasty fuchsia perfect breakfast	5	awesome	
+6222	tasty super-sized fuchsia perfect breakfast	5	awesome	
 6223	toothsome half-sized sublime deluxe hot dog	2	awesome	
 6224	spoiled sublime stew	4	crappy	
 6225	flavorless sublime nachos	3	decent	
-6226	special bland shaking Ultimate Breakfast Sandwich	4	decent	Effect: "Thicker, Sicker", Effect Duration: 15
+6226	bland special shaking Ultimate Breakfast Sandwich	4	decent	Effect: "Thicker, Sicker", Effect Duration: 15
 6227	rotten half-sized Loaded Baked Potato	2	crappy	
-6228	tasty cyan bouncing Omega Sundae	3	awesome	
+6228	tasty bouncing cyan Omega Sundae	3	awesome	
 6229	bad Das Sauerlager	3	decent	
-6230	delicious fuchsia spinning Bologna Lambic	4	awesome	
-6231	special perfectly mixed Vodka Dog	3	EPIC	Effect: "Hammered", Effect Duration: 10
-6232	lousy spirit-forward Disappointed Russian	5	decent	
+6230	delicious spinning fuchsia Bologna Lambic	4	awesome	
+6231	perfectly mixed special Vodka Dog	3	EPIC	Effect: "Hammered", Effect Duration: 10
+6232	spirit-forward lousy Disappointed Russian	5	decent	
 6233	triple-distilled acceptable Chunky Mary	6	good	
 6234	drinkable green Nachojito	3	good	
 6235	bad Le Roi	3	decent	
-6236	fortified aged wobbly Over Easy Rider	5	awesome	
+6236	aged fortified wobbly Over Easy Rider	5	awesome	
 6237	cosmic six-pack	0		
 6239	chilled cube of ectoplasm	0		Effect: "Here to Kick Ass", Effect Duration: 69
 6240	adjusted improved purple Illuminati earpiece	0		Effect: "Far Out", Effect Duration: 50
@@ -6139,7 +6139,7 @@
 6243	polarized quantum spinning the kindest cut	0		Effect: "Superheroic", Effect Duration: 37
 6244	ionized cat's paw	0		Effect: "A Few Extra Pounds", Effect Duration: 24
 6245	cold-filtered bouncing bouncing ASCII fu manchu	0		Effect: "Comic Violence", Effect Duration: 41
-6246	non-activated alkaline squat upside-down shaking demonic surgical gloves	0		Effect: "The Solution", Effect Duration: 69
+6246	non-activated alkaline upside-down squat shaking demonic surgical gloves	0		Effect: "The Solution", Effect Duration: 69
 6247	non-moist spinning clip-on ninja tie	0		Effect: "There Is A Spoon", Effect Duration: 31
 6248	frozen gamer slurry	0		Effect: "Dwarven Hardiness", Effect Duration: 11
 6249	dungeoneering kit	0		Last Available: "2013-02"
@@ -6160,18 +6160,18 @@
 6264	jittery up-at-dawn stiffened dance instructor's Staff of Fruit Salad	0		Experience Percent (Moxie): +10, Damage Reduction: 1, Adventures: +5, Jiggle: "Deal Some Prismatic Damage"
 6265	horrifying gravedigger's MacGyver's Staff of the Cream of the Cream	0		Maximum MP: +100, Spooky Damage: 35, Jiggle: "Attune to Monster's Essence"
 6266	spinning jar of protein powder	0		
-6267	toothsome low-calorie grain of protein powder	1	awesome	
+6267	low-calorie toothsome grain of protein powder	1	awesome	
 6268	pressed purple spinning pec oil	0		Effect: "Rosewater Mark", Effect Duration: 52
 6269	mirror scorching gym membership card	0		Hot Damage: +25
 6270	enhanced Squat-Thrust Magazine	0		Effect: "Fishily Speeding", Effect Duration: 14
 6271	red massive dumbbell	0		
 6272	wobbly upside-down auspicious penguin keychain of the wise owl	0		Mysticality: +20, Item Drop: +10, Damage Reduction: 10
 6273	non-quantum blue O'RLY manual	0		Effect: "In the Saucestream", Effect Duration: 19
-6274	watered-down drinkable open sauce	2	good	
+6274	drinkable watered-down open sauce	2	good	
 6275	reassuring turkey leg of temperance	0		Spooky Resistance: +1, Sleaze Resistance: +5
 6276	tolerable Ye Olde Meade	4	good	
 6277	modified purple twirling Ye Olde Bawdy Limerick	0		Effect: "Super Vision", Effect Duration: 53
-6278	tumbling mirror blurry Ye Olde Medieval Insult	0		
+6278	blurry tumbling mirror Ye Olde Medieval Insult	0		
 6279	ghostly pewter claymore of the blizzard	0		Cold Spell Damage: +25
 6280	artisanal rice peeler of the businessman	0		Meat Drop: +50
 6281	decent green heirloom grape tomato	4	good	
@@ -6182,13 +6182,13 @@
 6286	gray frightening supercool Mark II Steam-Hat of the pedagogue	0		Moxie Percent: +20, Experience: +3, Spooky Damage: +5, Familiar Effect: "1xLep, cap 37"
 6287	Sinatra's Mark III Steam-Hat of the pedagogue of incineration of bravery	0		Experience: +3, Experience (Moxie): +5, Hot Spell Damage: +50, Spooky Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6288	gravedigger's extremely unsafe Samson's smartaleck's Mark IV Steam-Hat of Tarzan	0		Moxie Percent: +30, Experience (Muscle): 8, Weapon Damage Percent: +100, Spooky Damage: +10, Familiar Effect: "1xLep, cap 37"
-6289	squat wool nippy steel-toed Mark V Steam-Hat of James Dean of the early riser	0		Experience (Moxie): +3, Damage Reduction: 9, Cold Damage: +10, Cold Resistance: +1, Adventures: +7, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	squat wool nippy steel-toed Mark V Steam-Hat of James Dean of the early riser	0		Experience (Moxie): +3, Damage Reduction: 9, Cold Damage: +10, Cold Resistance: +1, Adventures: +7, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	upside-down steam-powered model rocketship	0		
 6291	narrow pulsating hale Rosewater's punk rock jacket	0		Mysticality Percent: +30, Maximum HP: +20
 6292	electrified rosy-cheeked safety pin	0		Maximum HP Percent: +30, MP Regen Min: 3, MP Regen Max: 5
 6293	bland massive cyan stolen sushi	6	decent	
 6294	skewed very overdue library book	0		
-6295	huge fuchsia drum 'n' bass 'n' drum 'n' bass record	0		
+6295	fuchsia huge drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	upside-down fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	bouncing Thwaitgold firefly statuette	0		
@@ -6199,7 +6199,7 @@
 6303	huge ring of Detect Boring Doors	0		
 6304	jittery scorching quilted grievous stylish Jarlsberg's pan (Cosmic portal mode) of vim and vigor	0		Moxie: +25, Weapon Damage Percent: +50, Damage Absorption: +40, Maximum HP Percent: +50, Hot Damage: +25, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	bouncing dog trainer's Lo Pan's Herculean Jarlsberg's pan of dire peril of terror	0		Experience (Muscle): +1, Weapon Damage: +20, Spell Critical Percent: +30, Experience (familiar): +1, Spooky Spell Damage: +10, Softcore Only, Free Pull, Last Available: "2013-03"
-6306	blue upside-down Cosmic Calorie	0		Last Available: "2013-03"
+6306	upside-down blue Cosmic Calorie	0		Last Available: "2013-03"
 6307	deionized polymerized celestial olive oil	0		Effect: "Space Cadet", Effect Duration: 40, Last Available: "2013-03"
 6308	vacuum-sealed celestial carrot juice	0		Effect: "Memories of Puppy Love", Effect Duration: 54, Last Available: "2013-03"
 6309	electrified dry narrow celestial au jus	0		Effect: "New and Improved", Effect Duration: 39, Last Available: "2013-03"
@@ -6221,9 +6221,9 @@
 6325	inspector's foul-smelling aquamariner's necklace of the sewer	0		Stench Damage: 35, Item Drop: +15, Single Equip
 6326	green boxer's pearl diver's ring of the bloodbag	0		Muscle Percent: +10, Maximum HP: +100, Single Equip
 6327	blinking Sherlock's knitted pearl diver's necklace	0		Cold Resistance: +3, Item Drop: +25, Single Equip
-6328	spinning mirror sushi doily	0		
+6328	mirror spinning sushi doily	0		
 6329	scimitar cozy	0		
-6330	cyan twirling shaking fish stick cozy	0		
+6330	shaking twirling cyan fish stick cozy	0		
 6331	bazooka cozy	0		
 6332	inspector's vibrating rosy-cheeked cozy scimitar	0		Maximum HP Percent: +30, Maximum MP Percent: +10, Item Drop: +15
 6333	skewed flame-retardant electrified wizardly Staff of the Cozy Fish	0		Mysticality: +25, Hot Resistance: +1, MP Regen Min: 3, MP Regen Max: 5
@@ -6253,7 +6253,7 @@
 6357	blinking Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	pulsating sizzling Mer-kin begsign	0		Hot Damage: +10, Meat Drop: +40
-6360	twirling blurry Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	blurry twirling Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	non-flattened dry shaking pulled taffy	0		Effect: "Speed of the Internet", Effect Duration: 13, Last Available: "2013-04"
 6362	double-deionized wet shaking olive pulled indigo taffy	0		Effect: "Hyperoxygenated Blood", Effect Duration: 62, Last Available: "2013-04"
 6363	nitrogenated pulled taffy	0		Effect: "Human-Demon Hybrid", Effect Duration: 54, Last Available: "2013-04"
@@ -6264,7 +6264,7 @@
 6368	Mer-kin hallpass	0		
 6369	lump of clay	0		
 6370	twisted piece of wire	0		
-6371	perfectly mixed enchanted watered-down can of the cheapest beer	2	EPIC	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50
+6371	watered-down enchanted perfectly mixed can of the cheapest beer	2	EPIC	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50
 6372	hand-crafted bottle of fruity &quot;wine&quot;	4	EPIC	
 6373	lousy single swig of vodka	3	decent	
 6374	huge angry inch	0		
@@ -6307,7 +6307,7 @@
 6412	shaking skull	0		No Pull
 6413	teal Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
-6415	miniature spoiled blinking mirror flavorless gruel	2	crappy	
+6415	miniature spoiled mirror blinking flavorless gruel	2	crappy	
 6416	bland olive mana curds	3	decent	
 6417	skewed twist of lime	0		
 6418	teal pencil stub	0		
@@ -6360,14 +6360,14 @@
 6465	up-at-dawn nippy Mayor Ghost's gavel of James Dean	0		Experience (Moxie): +3, Cold Damage: +10, Adventures: +5, Conditional Skill (Equipped): "Hammer Ghost"
 6466	electrified therapeutic Da Vinci's Mayor Ghost's sash	0		Experience (Mysticality): +5, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	decent low-calorie ghost pepper	1	good	
+6468	low-calorie decent ghost pepper	1	good	
 6469	skewed up-at-dawn veiny Thunkula's drinking cap of dire peril	0		Weapon Damage: +20, Maximum HP: +10, Adventures: +5, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	gray horrifying Fonzie's Drunkula's cape of the sweet-tooth	0		Experience (Moxie): +1, Spooky Damage: +25, Candy Drop: +100, Class: "Sauceror"
 6471	clever Drunkula's silky pants of the cougar of Gandalf	0		Moxie: +20, Maximum MP: +20, Spell Critical Percent: +20, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 6472	Drunkula's bell	0		
 6473	blurry smelly scorching Drunkula's ring of haze of mayonnaise	0		Hot Damage: +25, Stench Spell Damage: +10, Sleaze Spell Damage: +50, Avoid Attack: 1, Single Equip
 6474	perfumed Drunkula's wineglass	0		Stench Resistance: +5
-6475	bad practically non-alcoholic bottle of Bloodweiser	1	decent	
+6475	practically non-alcoholic bad bottle of Bloodweiser	1	decent	
 6476	Usain Bolt's coward's Unkillable Skeleton's skullcap of the overflowing toilet	0		Monster Level: -20, Stench Spell Damage: +50, Initiative: +80, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	pulsating grievous personal trainer's Unkillable Skeleton's breastplate of Calamity Jane	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Critical Hit Percent: +15, Class: "Turtle Tamer"
 6478	wool steel-toed cool Unkillable Skeleton's shinguards	0		Moxie: +5, Damage Reduction: 9, Cold Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6410,18 +6410,18 @@
 6515	blinking brawny eerie fetish	0		Muscle Percent: +20, Single Equip
 6516	perfectly mixed strong cyan narrow stinkwater	5	EPIC	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	rotten huge squat accidental mutton	6	crappy	
+6518	huge rotten squat accidental mutton	6	crappy	
 6519	Socratic drafty drawers of terror	0		Experience (Mysticality): +1, Spooky Spell Damage: +10, Familiar Effect: "1.5xVolley"
 6520	baleful wolfskull mask of dire peril	0		Weapon Damage: +20, Spell Damage: +25, Familiar Effect: "spooky atk, 1xBarrr"
 6521	bouncing squat deadly guts necklace	0		Weapon Damage: +5, Single Equip
 6522	yellow squat supercharged healthy groping claw	0		Maximum HP Percent: +20, Maximum MP Percent: +30
 6523	squat stanky vengeful spirit	0		Stench Spell Damage: +25
 6524	experienced BOOtonniere	0		Experience: +2, Single Equip
-6525	double-activated red huge ghost thread	0		Effect: "Frisky Spirit", Effect Duration: 17
+6525	double-activated huge red ghost thread	0		Effect: "Frisky Spirit", Effect Duration: 17
 6526	curative bag of unfinished business of mayonnaise	0		Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 6527	hale Socratic transparent pants	0		Experience (Mysticality): +1, Maximum HP: +20, Familiar Effect: "sleaze atk, 1xPotato"
 6528	hothammer of vim and vigor	0		Maximum HP Percent: +50
-6529	irresponsibly strong delicious Thriller Ice	10	awesome	
+6529	delicious irresponsibly strong Thriller Ice	10	awesome	
 6530	steel-toed grandfather watch	0		Damage Reduction: 9, Single Equip
 6531	blue muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	frosty nippy spyglass	0		Cold Damage: +10, Cold Spell Damage: +10
@@ -6451,7 +6451,7 @@
 6557	polarized extra-altered phial of coldness	0		Effect: "Bananas!", Effect Duration: 25
 6558	modified shaking phial of spookiness	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 41
 6559	polymerized polarized blinking phial of stench	0		Effect: "Spiky Frozen Hair", Effect Duration: 46
-6560	frozen concentrated teal blurry phial of sleaziness	0		Effect: "Yuletide Industry", Effect Duration: 48
+6560	frozen concentrated blurry teal phial of sleaziness	0		Effect: "Yuletide Industry", Effect Duration: 48
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	purple mini-Mr. Accessory	0		Familiar Weight: +5
 6563	strapping hand of Mr. Cards	0		Muscle: +5, Conditional Skill (Equipped): "Throw a Mr. Card"
@@ -6461,7 +6461,7 @@
 6567	decent olive Dreadsylvanian stink pocket	4	good	
 6568	toothsome wobbly Dreadsylvanian sleaze pocket	3	awesome	
 6569	smooth watered-down mirror Dreadsylvanian hot toddy	2	awesome	
-6570	practically non-alcoholic bad Dreadsylvanian cold-fashioned	1	decent	
+6570	bad practically non-alcoholic Dreadsylvanian cold-fashioned	1	decent	
 6571	bad special Dreadsylvanian grimlet	4	decent	Effect: "Chow Downed", Effect Duration: 50
 6572	drinkable Dreadsylvanian dank and stormy	3	good	
 6573	boozy acceptable tumbling fuchsia Dreadsylvanian slithery nipple	5	good	
@@ -6474,10 +6474,10 @@
 6580	upside-down length of fuse	0		
 6581	green dreadful box	0		
 6582	skewed Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
-6583	skewed lime green vicious spiked collar	0		Familiar Damage: +20
+6583	lime green skewed vicious spiked collar	0		Familiar Damage: +20
 6584	Tesla hot dog wrapper	0		MP Regen Min: 7, MP Regen Max: 10
 6585	upside-down frightening occult debonair deboner	0		Spell Damage Percent: +25, Spooky Damage: +5
-6586	dry pressed yellow spinning chicle de salchicha	0		Effect: "Litterboxing", Effect Duration: 61
+6586	dry pressed spinning yellow chicle de salchicha	0		Effect: "Litterboxing", Effect Duration: 61
 6587	aromatic jar of frostigkraut	0		Stench Resistance: +1
 6588	wool smelly gnawed-up dog bone	0		Stench Spell Damage: +10, Cold Resistance: +1
 6589	Newton's Grey Guanon	0		Experience (Mysticality): +3
@@ -6506,7 +6506,7 @@
 6612	skewed clockwork numeral XII	0		
 6613	narrow lime green blinking clockwork cuckoo	0		
 6614	teal cuckoo clock	0		
-6615	artisanal practically non-alcoholic Cold One	1	???	
+6615	practically non-alcoholic artisanal Cold One	1	???	
 6616	normal super-sized spaghetti breakfast	5	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6519,7 +6519,7 @@
 6625	shaking folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	teal folder (D-Team)	0		Last Available: "2013-08"
-6628	shaking blinking lime green folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
+6628	blinking lime green shaking folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
@@ -6549,7 +6549,7 @@
 6657	coward's vibrating pickelhaube	0		Maximum MP Percent: +10, Monster Level: -20, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	double-enhanced shaking olive hair oil	0		Effect: "Hairless and Airless", Effect Duration: 26
 6659	quadruple-activated wet scrap	0		Effect: "Human-Insect Hybrid", Effect Duration: 25
-6660	bouncing squat school spirit socket set	0		
+6660	squat bouncing school spirit socket set	0		
 6661	jittery suspension bridge	0		
 6662	huge green therapeutic sinister brainy Staff of the Lunch Lady of the pedagogue	0		Mysticality: +5, Experience: +3, Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7
 6663	universal key	0		
@@ -6570,7 +6570,7 @@
 6678	Newton's Yearbook Club Camera	0		Experience (Mysticality): +3, Conditional Skill (Equipped): "Blinding Flash"
 6679	Fonzie's machete	0		Experience (Moxie): +1
 6680	spirit-forward lousy Cursed Punch	5	decent	
-6681	practically non-alcoholic perfectly mixed Bowl of Scorpions	1	EPIC	
+6681	perfectly mixed practically non-alcoholic Bowl of Scorpions	1	EPIC	
 6682	weak lousy Fog Murderer	2	decent	
 6683	book of matches	0		
 6684	Lo Pan's surgical mask	0		Spell Critical Percent: +30, Surgeonosity: +1
@@ -6591,12 +6591,12 @@
 6699	shaking crackling stone sphere	0		
 6700	olive scorched stone sphere	0		
 6701	wobbly stone triangle	0		
-6702	gray blinking narrow bowler	0		
+6702	blinking narrow gray bowler	0		
 6703	special imitation White Russian	1	good	Effect: "Category", Effect Duration: 25
 6704	cyan fireproof short-handled mop of Gandalf	0		Spell Critical Percent: +20, Hot Resistance: +3
 6705	normal jungle floor wax	3	good	
 6706	shaking smirking shrunken head	0		
-6707	altered non-alkaline tumbling gray colorful toad	0		Effect: "Concentrated Concentration", Effect Duration: 47
+6707	altered non-alkaline gray tumbling colorful toad	0		Effect: "Concentrated Concentration", Effect Duration: 47
 6708	crude voodoo doll	0		
 6709	green attorney's badge	0		Single Equip
 6710	occult smartaleck's pygmy briefs	0		Moxie Percent: +30, Spell Damage Percent: +25, Familiar Effect: "atk, 1xVolley, cap 41"
@@ -6613,7 +6613,7 @@
 6721	prompt flame-wreathed clever water bottle	0		Maximum MP: +20, Hot Spell Damage: +10, Adventures: +3, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	triple-polarized triple-magnetized red pygmy phone number	0		Effect: "Tea-hee", Effect Duration: 12
 6723	tumbling Boozehounds Anonymous token	0		
-6724	yummy gigantic exotic jungle fruit	6	awesome	
+6724	gigantic yummy exotic jungle fruit	6	awesome	
 6725	huge Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	blinking tropical island souvenir crate	0		
@@ -6635,7 +6635,7 @@
 6743	mansplainer's junk trunks	0		Monster Level: +15, Familiar Effect: "cap 15"
 6744	huge Jeselnik's junk-mail shirt	0		Sleaze Damage: +25
 6745	massive spoiled junk food	7	crappy	
-6746	acceptable high-proof junk yard	6	good	
+6746	high-proof acceptable junk yard	6	good	
 6747	narrow experienced swordzall of the sewer	0		Experience: +2, Stench Damage: +25
 6748	studded arm buzzer	0		Damage Absorption: +80, Damage Reduction: 6
 6749	Sherlock's coward's boilgun	0		Monster Level: -20, Item Drop: +25
@@ -6646,13 +6646,13 @@
 6754	wobbly beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	watered-down mediocre can of Br&uuml;talbr&auml;u	2	decent	Last Available: "2013-09"
+6757	mediocre watered-down can of Br&uuml;talbr&auml;u	2	decent	Last Available: "2013-09"
 6758	perfectly mixed distilled can of Drooling Monk	5	EPIC	Last Available: "2013-09"
-6759	fancy drinkable practically non-alcoholic can of Impetuous Scofflaw	1	good	Effect: "Super Structure", Effect Duration: 50, Last Available: "2013-09"
+6759	practically non-alcoholic drinkable fancy can of Impetuous Scofflaw	1	good	Effect: "Super Structure", Effect Duration: 50, Last Available: "2013-09"
 6760	smooth bottle of Old Pugilist	4	awesome	Last Available: "2013-09"
-6761	weak lousy bottle of Professor Beer	2	decent	Last Available: "2013-09"
+6761	lousy weak bottle of Professor Beer	2	decent	Last Available: "2013-09"
 6762	artisanal bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
-6763	weak lousy fancy blurry bottle of Race Car Red	2	decent	Effect: "Fire Inside", Effect Duration: 40, Last Available: "2013-09"
+6763	fancy lousy weak blurry bottle of Race Car Red	2	decent	Effect: "Fire Inside", Effect Duration: 40, Last Available: "2013-09"
 6764	bad watered-down spinning bottle of Greedy Dog	2	decent	Last Available: "2013-09"
 6765	bad bottle of Lambada Lambic	4	decent	Last Available: "2013-09"
 6766	tin beer can	0		
@@ -6681,10 +6681,10 @@
 6791	sharpened spoon	0		
 6792	shaking candy knife	0		
 6793	bouncing soap knife	0		
-6795	chilled teal shaking disco horoscope (Aquarius)	0		Effect: "Bread Burps", Effect Duration: 34
+6795	chilled shaking teal disco horoscope (Aquarius)	0		Effect: "Bread Burps", Effect Duration: 34
 6796	magnetized ionized purple upside-down disco horoscope (Pisces)	0		Effect: "Extra-Sharp Weapon", Effect Duration: 66
-6797	alkaline denatured fuchsia wobbly disco horoscope (Aries)	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 38
-6798	enhanced deionized dry blurry cyan bouncing disco horoscope (Taurus)	0		Effect: "Gummibrain", Effect Duration: 54
+6797	alkaline denatured wobbly fuchsia disco horoscope (Aries)	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 38
+6798	enhanced deionized dry blurry bouncing cyan disco horoscope (Taurus)	0		Effect: "Gummibrain", Effect Duration: 54
 6799	oxidized disco horoscope (Gemini)	0		Effect: "Bureaucratized", Effect Duration: 21
 6800	energized disco horoscope (Cancer)	0		Effect: "Memento Moir&eacute;", Effect Duration: 12
 6801	pressed dry cyan disco horoscope (Leo)	0		Effect: "Frosty the Hitman", Effect Duration: 16
@@ -6726,7 +6726,7 @@
 6837	cold-filtered Swizzler	0		Effect: "Uncanny Shot", Effect Duration: 42
 6838	cold-filtered anodized Bugbearclaw Donut	0		Effect: "Heightened Senses", Effect Duration: 19
 6839	tarnished purple jam	0		Effect: "Fudge Headache", Effect Duration: 45
-6840	pickled diffused teal ghostly Whenchamacallit bar	0		Effect: "Dilated Pupils", Effect Duration: 13
+6840	pickled diffused ghostly teal Whenchamacallit bar	0		Effect: "Dilated Pupils", Effect Duration: 13
 6841	vacuum-sealed warmed 8-bit banana	0		Effect: "Mushroom Samba", Effect Duration: 59
 6842	boiled energized jittery blurry vial of blood simple syrup	0		Effect: "Aloofah", Effect Duration: 24
 6843	irradiated bone bons	0		Effect: "Quantum of Moxie", Effect Duration: 62
@@ -6746,9 +6746,9 @@
 6857	miser's Cajun accordion	0		Meat Drop: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	ghostly medical-grade quirky accordion	0		HP Regen Min: 7, HP Regen Max: 10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery Usain Bolt's auspicious Skipper's accordion	0		Item Drop: +10, Initiative: +80, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	reassuring grievous Pantsgiving of the dark arts of the overflowing toilet	0		Weapon Damage Percent: +50, Spell Damage Percent: +100, Stench Spell Damage: +50, Spooky Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6860	reassuring grievous Pantsgiving of the dark arts of the overflowing toilet	0		Weapon Damage Percent: +50, Spell Damage Percent: +100, Stench Spell Damage: +50, Spooky Resistance: +1, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	stale can of sardines	3	decent	Last Available: "2013-11"
-6862	fancy snack-sized normal high-calorie sugar substitute	2	good	Effect: "Peppermint Bite", Effect Duration: 15, Last Available: "2013-11"
+6862	normal snack-sized fancy high-calorie sugar substitute	2	good	Effect: "Peppermint Bite", Effect Duration: 15, Last Available: "2013-11"
 6863	special bland narrow pat of butter	4	decent	Effect: "Rootin' Around", Effect Duration: 30, Last Available: "2013-11"
 6864	bland massive dinner roll	6	decent	Last Available: "2013-11"
 6865	yummy huge mashed potatoes	6	awesome	Last Available: "2013-11"
@@ -6759,7 +6759,7 @@
 6870	cold-filtered mirror love note	0		Effect: "Icy Composition", Effect Duration: 40, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	energized warmed nail file	0		Effect: "Unusual Perspective", Effect Duration: 54, Last Available: "2013-11"
-6873	alkaline energized tumbling huge candy wrapper	0		Effect: "Slimy Hands", Effect Duration: 27, Last Available: "2013-11"
+6873	alkaline energized huge tumbling candy wrapper	0		Effect: "Slimy Hands", Effect Duration: 27, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	boiled post-holiday sale coupon	0		Effect: "Remaining Alive", Effect Duration: 63, Last Available: "2013-11"
 6876	purple dry cleaning receipt	0		Last Available: "2013-11"
@@ -6807,7 +6807,7 @@
 6918	oxidized tarnished warbear wardance potion	0		Effect: "Make Meat FA$T!", Effect Duration: 67, Last Available: "2013-12"
 6919	energized boiled upside-down warbear bearserker potion	0		Effect: "Spore-Wreathed", Effect Duration: 34, Last Available: "2013-12"
 6920	quadruple-altered liquefied polarized olive warbear liquid overcoat	0		Effect: "Fudge Headache", Effect Duration: 12, Last Available: "2013-12"
-6921	fancy rotten small warbear feasting bread	2	crappy	Effect: "Super-Electrified", Effect Duration: 10, Last Available: "2013-12"
+6921	small rotten fancy warbear feasting bread	2	crappy	Effect: "Super-Electrified", Effect Duration: 10, Last Available: "2013-12"
 6922	normal warbear warrior bread	4	good	Last Available: "2013-12"
 6923	bland wobbly warbear thermoregulator bread	3	decent	Last Available: "2013-12"
 6924	drinkable warbear feasting mead	3	good	Last Available: "2013-12"
@@ -6847,8 +6847,8 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	wobbly jittery stanky warbear foil hat	0		Stench Spell Damage: +25, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	mansplainer's brawny warbear oil pan	0		Muscle Percent: +20, Monster Level: +15, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
-6962	huge gray warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
+6961	mansplainer's brawny warbear oil pan	0		Muscle Percent: +20, Monster Level: +15, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6962	gray huge warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	careful warbear exhaust manifold	0		Monster Level: -10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	gray warbear auto-anvil	0		Last Available: "2013-12"
@@ -6889,7 +6889,7 @@
 7000	Van der Graaf energetic die-cast Don Crimbo	0		Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12"
 7001	up-at-dawn wool die-cast Uncle Hobo	0		Cold Resistance: +1, Adventures: +5, Last Available: "2013-12"
 7002	forbidden personal trainer's die-cast Father Crimbo	0		Experience Percent (Muscle): +10, Spell Damage Percent: +50, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	moist blinking Flaskfull of Hollow	0		Effect: "Turkey-Agitated", Effect Duration: 40, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	dried handful of Smithereens	1	awesome	Effect: "Florid Cheeks", Effect Duration: 15, Last Available: "2013-12"
@@ -6898,7 +6898,7 @@
 7009	low-calorie delicious enchanted olive This Charming Flan	1	awesome	Effect: "Serenity", Effect Duration: 45, Last Available: "2013-12"
 7010	hand-crafted shaking Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
 7011	bad Strikes Again Bigmouth	4	decent	Last Available: "2013-12"
-7012	acceptable spirit-forward Paint A Vulgar Pitcher	5	good	Last Available: "2013-12"
+7012	spirit-forward acceptable Paint A Vulgar Pitcher	5	good	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	upside-down scorching chilly Shakespeare's Sister's Accordion of the overflowing toilet	0		Cold Damage: +5, Hot Damage: +25, Stench Spell Damage: +50, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	maroon steel-toed third-hand lantern	0		Damage Reduction: 9
 7031	loose purse strings	0		
-7032	stale diet upside-down pickled egg	1	decent	
+7032	diet stale upside-down pickled egg	1	decent	
 7033	cup of lukewarm tea	1	good	
 7034	fuchsia warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6930,7 +6930,7 @@
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	ionized galvanized jittery gray glass slipper	0		Effect: "Carrrsmic", Effect Duration: 27, Last Available: "2014-12"
+7044	ionized galvanized gray jittery glass slipper	0		Effect: "Carrrsmic", Effect Duration: 27, Last Available: "2014-12"
 7045	altered antimatter wad	1	good	Last Available: "2013-12"
 7046	liquefied warbear superpotion	0		Effect: "Sweet Nostalgia", Effect Duration: 63, Last Available: "2013-12"
 7047	altered upside-down warbear liquid lasers	0		Effect: "Cold, Dead Hands", Effect Duration: 59, Last Available: "2013-12"
@@ -6942,8 +6942,8 @@
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
 7055	decent squat breakfast mess	3	good	Last Available: "2013-12"
-7056	huge skewed warbear breakfast machine	0		Last Available: "2013-12"
-7057	flavorless miniature blurry breakfast miracle	2	decent	Last Available: "2013-12"
+7056	skewed huge warbear breakfast machine	0		Last Available: "2013-12"
+7057	miniature flavorless blurry breakfast miracle	2	decent	Last Available: "2013-12"
 7058	Vulcanized dry Cloaca Cola Polar	0		Effect: "Flagrantly Fragrant", Effect Duration: 68, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6951,7 +6951,7 @@
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	tumbling Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	twisted twirling skewed grim fairy tale	1	decent	Last Available: "2014-12"
+7065	twisted skewed twirling grim fairy tale	1	decent	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	quantum single of Inigo's Incantation of Inspiration	0		Effect: "Dexteri Tea", Effect Duration: 40, Last Available: "2010-02"
 7068	super-irradiated liquefied single of Donho's Bubbly Ballad	0		Effect: "Notably Lovely", Effect Duration: 13
@@ -6959,12 +6959,12 @@
 7070	wobbly packet of winter seeds	0		Last Available: "2014-01"
 7071	miniature decent snow berries	2	good	Last Available: "2014-01"
 7072	delicious shaking ice harvest	4	awesome	Last Available: "2014-01"
-7073	boiled red blurry skewed frost flower	0		Effect: "Thick, Sick", Effect Duration: 36, Last Available: "2014-01"
+7073	boiled red skewed blurry frost flower	0		Effect: "Thick, Sick", Effect Duration: 36, Last Available: "2014-01"
 7074	wet quadruple-pressed snow cleats	0		Effect: "Preemptive Medicine", Effect Duration: 43, Last Available: "2014-01"
 7075	cold-filtered liquid ice pack	0		Effect: "Compensatory Cruelness", Effect Duration: 45, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	rotten narrow snow crab	3	crappy	Last Available: "2014-01"
-7078	practically non-alcoholic drinkable twirling Ice Island Long Tea	1	good	Last Available: "2014-01"
+7078	drinkable practically non-alcoholic twirling Ice Island Long Tea	1	good	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	upside-down double-paned Temple Grandin's hardy hardened snow belt	0		Damage Reduction: 3, Maximum HP: +50, Familiar Weight: +7, Cold Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	tumbling wobbly asbestos-lined frosty steel-toed ice nine of incineration	0		Damage Reduction: 9, Cold Spell Damage: +10, Hot Spell Damage: +50, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
 7089	snow fort	0		Last Available: "2014-01"
-7090	perfectly mixed watered-down En Una Fila Tequila	2	EPIC	
+7090	watered-down perfectly mixed En Una Fila Tequila	2	EPIC	
 7091	Skully's hot chocolate	1	good	
 7092	huge twirling crafty warbear dress helmet of dire peril	0		Weapon Damage: +20, Maximum MP: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	red miser's warbear dress bracers of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +10, Single Equip, Last Available: "2013-12"
@@ -6994,7 +6994,7 @@
 7105	anise-flavored venom	0		Last Available: "2014-12"
 7106	watered-down delicious gray snakebite	2	awesome	Last Available: "2014-12"
 7107	sinister beefcake's candy stick	0		Muscle: +25, Spell Damage: +10, Last Available: "2014-12"
-7108	small rotten pecan	2	crappy	Last Available: "2014-12"
+7108	rotten small pecan	2	crappy	Last Available: "2014-12"
 7109	stale pecan pie	3	decent	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	rotten candy mountain oyster	3	crappy	Last Available: "2014-12"
@@ -7020,14 +7020,14 @@
 7131	rosewater-soaked shellacked cow creamer of temperance	0		Damage Reduction: 7, Stench Resistance: +3, Sleaze Resistance: +5, Last Available: "2014-12"
 7132	nitrogenated Outer Wolf&trade; cologne	0		Effect: "Berry Berry Cold", Effect Duration: 46, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	twirling censurious flame-wreathed wolf whistle	0		Hot Spell Damage: +10, Sleaze Resistance: +3, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7134	twirling censurious flame-wreathed wolf whistle	0		Hot Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	normal green witch's bread	3	good	Last Available: "2014-12"
-7136	anodized alkaline blurry twirling witch's brew	0		Effect: "Busy Bein' Delicious", Effect Duration: 28, Last Available: "2014-12"
+7136	anodized alkaline twirling blurry witch's brew	0		Effect: "Busy Bein' Delicious", Effect Duration: 28, Last Available: "2014-12"
 7137	frightening Temple Grandin's medical-grade witch's bra	0		Familiar Weight: +7, Spooky Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-12"
 7138	mediocre extra-dry mid-level medieval mead	5	decent	Last Available: "2014-12"
 7139	diffused olive R&uuml;mpelstiltz	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 19, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
-7141	chilled ghostly green hi-octane carrot juice	0		Effect: "Fizzier Than Light", Effect Duration: 48, Last Available: "2014-12"
+7141	chilled green ghostly hi-octane carrot juice	0		Effect: "Fizzier Than Light", Effect Duration: 48, Last Available: "2014-12"
 7142	extra-dry anodized electrified wobbly hare brush	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 53, Last Available: "2014-12"
 7143	rosy-cheeked beefy hare pin	0		Muscle: +10, Maximum HP Percent: +30, Single Equip, Last Available: "2014-12"
 7144	gray odd coin	0		Last Available: "2014-12"
@@ -7044,29 +7044,29 @@
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	blurry prompt supercharged boxer's fire hose	0		Muscle Percent: +10, Maximum MP Percent: +30, Adventures: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	snack-sized adequate fireman's lunch	2	good	Last Available: "2014-12"
+7158	adequate snack-sized fireman's lunch	2	good	Last Available: "2014-12"
 7159	fortified plain paper hat of chilblains of the brazier	0		Damage Absorption: +60, Cold Damage: +25, Hot Spell Damage: +25, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
 7160	toothsome tiny ice cream sandwich	1	awesome	Last Available: "2014-12"
 7161	greasy Sinatra's &quot;honey&quot; dipper of James Dean	0		Experience (Moxie): 8, Sleaze Spell Damage: +10, Last Available: "2014-12"
-7162	immense tasty blurry plumber's lunch	8	awesome	Last Available: "2014-12"
+7162	tasty immense blurry plumber's lunch	8	awesome	Last Available: "2014-12"
 7163	asbestos-lined flame-retardant skull gearshift knob of the scaredy-cat	0		Monster Level: -15, Hot Resistance: 6, Last Available: "2014-12"
 7164	rotten nachos of the night	4	crappy	Last Available: "2014-12"
 7165	stanky Jim Carey's Sketcherz&trade; of wisdom	0		Mysticality: +15, Monster Level: +25, Stench Spell Damage: +25, Last Available: "2014-12"
-7166	yummy narrow spinning can of Adultwitch&trade;	4	awesome	Last Available: "2014-12"
+7166	yummy spinning narrow can of Adultwitch&trade;	4	awesome	Last Available: "2014-12"
 7167	quantum tarnished huge smudge stick	0		Effect: "Unrunnable Face", Effect Duration: 56, Last Available: "2014-12"
 7168	super-pickled ghostly wall	0		Effect: "Prideful Strut", Effect Duration: 22, Last Available: "2014-12"
 7169	tolerable jittery tankard of ale	3	good	Last Available: "2014-12"
 7170	electrified liquefied pulsating teal scroll case	0		Effect: "The Smile of Mr. A.", Effect Duration: 12, Last Available: "2014-12"
-7171	polymerized tumbling narrow jug of &quot;wine&quot;	0		Effect: "Human-Hobo Hybrid", Effect Duration: 32, Last Available: "2014-12"
+7171	polymerized narrow tumbling jug of &quot;wine&quot;	0		Effect: "Human-Hobo Hybrid", Effect Duration: 32, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
 7174	yummy humble pie	3	awesome	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
-7177	quantum quadruple-deionized purple squat crappy waiter disguise	0		Effect: "Natural 20", Effect Duration: 28
+7177	quantum quadruple-deionized squat purple crappy waiter disguise	0		Effect: "Natural 20", Effect Duration: 28
 7178	Copperhead Charm	0		
 7179	red The First Pizza	0		
-7180	pulsating fuchsia The Lacrosse Stick of Lacoronado	0		
+7180	fuchsia pulsating The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	The Stankara Stone	0		
 7183	narrow Murphy's Rancid Black Flag	0		
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	upside-down Buddy Bjorn of courage	0		Spooky Resistance: +3, Softcore Only, Last Available: "2014-02"
 7201	veiny steel-toed The Nuge's favorite crossbow of the cougar	0		Moxie: +20, Damage Reduction: 9, Maximum HP: +10
-7202	small bland special sweet roll Alabama	2	decent	Effect: "Unusual Perspective", Effect Duration: 50
+7202	special small bland sweet roll Alabama	2	decent	Effect: "Unusual Perspective", Effect Duration: 50
 7203	ghostly baleful Saturday Night Special	0		Spell Damage: +25
 7204	lynyrd snare	0		
 7205	razor-sharp fleetwood chain	0		Weapon Damage Percent: +25
@@ -7107,8 +7107,8 @@
 7218	baleful lynyrdskin tunic	0		Spell Damage: +25
 7219	blurry greedy lynyrdskin breeches	0		Meat Drop: +20, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	shaking cigarette lighter	0		
-7221	cyan skewed priceless diamond	0		
-7222	hand-crafted boozy Flamin' Whatshisname	5	EPIC	
+7221	skewed cyan priceless diamond	0		
+7222	boozy hand-crafted Flamin' Whatshisname	5	EPIC	
 7223	denatured lynyrd musk	0		Effect: "Hair on Your Chest", Effect Duration: 19
 7224	double-paned chilly Kashmir sweater	0		Cold Damage: +5, Cold Resistance: +5
 7225	rotten custard pie	4	crappy	
@@ -7119,7 +7119,7 @@
 7230	bad rum	3	decent	
 7231	acceptable Murderer's Punch	3	good	
 7232	spoiled half-sized enchanted twirling velvet cake	2	crappy	Effect: "Orchid Blood", Effect Duration: 40
-7233	tarnished twirling shaking gray letter	0		Effect: "Arcane in the Brain", Effect Duration: 36
+7233	tarnished twirling gray shaking letter	0		Effect: "Arcane in the Brain", Effect Duration: 36
 7234	cyan Sherlock's beefy book	0		Muscle: +10, Item Drop: +25
 7235	lime green Sherlock's censurious masque	0		Sleaze Resistance: +3, Item Drop: +25, Single Equip
 7236	red-hot poker of the pedagogue	0		Experience: +3
@@ -7146,7 +7146,7 @@
 7257	twisted blurry molotov soda	1	awesome	
 7258	super-liquefied tumbling pile of ashes	0		Effect: "Patience of the Tortoise", Effect Duration: 14
 7259	crate of firebombs	0		
-7260	ghostly teal firebomb	0		
+7260	teal ghostly firebomb	0		
 7261	rosewater-soaked dog trainer's quilted Sneaky Pete's basket	0		Damage Absorption: +40, Experience (familiar): +1, Stench Resistance: +3
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	squat photograph of a dog	0		
@@ -7163,7 +7163,7 @@
 7274	plastic Duke Starkiller of the dark arts	0		Spell Damage Percent: +100
 7275	beefy plastic Gary Claybender	0		Muscle: +10
 7276	chaotic plastic Captain Kerkard	0		Spell Critical Percent: +10
-7277	concentrated blurry green robot grease	0		Effect: "Charrrming", Effect Duration: 43
+7277	concentrated green blurry robot grease	0		Effect: "Charrrming", Effect Duration: 43
 7278	returned Thinknerd package	0		
 7279	chilled tarnished wind-up Whatsian robot	0		Effect: "Bonelording", Effect Duration: 24
 7280	chilled wind-up vampire teeth	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 44
@@ -7195,7 +7195,7 @@
 7306	Lady Spookyraven's finest gown	0		
 7307	Lady Spookyraven's dancing shoes	0		
 7308	ionized adjusted eyebrow pencil	0		Effect: "Third Based", Effect Duration: 66
-7309	nitrogenated extra-quantum polarized fuchsia jittery rosewater cream	0		Effect: "Carrrsmic", Effect Duration: 31
+7309	nitrogenated extra-quantum polarized jittery fuchsia rosewater cream	0		Effect: "Carrrsmic", Effect Duration: 31
 7310	alkaline boiled teal bronzer	0		Effect: "Disdain of the War Snapper", Effect Duration: 36
 7311	shaking lightning-fast brawny elegant nightstick	0		Muscle Percent: +20, Initiative: +40
 7312	still grill	0		Free Pull, Last Available: "2014-06"
@@ -7217,24 +7217,24 @@
 7328	denatured funny bone	0		Effect: "Swimming Head", Effect Duration: 25
 7329	boxer's weightlifter's half-melted spoon	0		Muscle: +15, Muscle Percent: +10
 7330	mixed the funk	1		
-7331	small stale upside-down maroon gunky chicken	2	decent	
+7331	stale small maroon upside-down gunky chicken	2	decent	
 7332	pulsating weightlifter's doll head	0		Muscle: +15
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	Temple Grandin's manspreader's paddle-ball	0		Monster Level: +10, Familiar Weight: +7
 7336	aerosolized warmed shaking sound effects record	0		Effect: "Hair on Your Chest", Effect Duration: 31
 7337	pulsating alphabet block	0		
-7338	super-cold-filtered activated blurry gray dancer	0		Effect: "Musky", Effect Duration: 61
+7338	super-cold-filtered activated gray blurry dancer	0		Effect: "Musky", Effect Duration: 61
 7339	tumbling music box mechanism	0		
 7340	bouncing stanky moose antlers	0		Stench Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	non-frozen altered shaking moose thought	0		Effect: "Cybernetic Muscles", Effect Duration: 36
-7342	bland miniature moose chocolate	2	decent	
-7343	artisanal watered-down maroon painting of a glass of wine	2	EPIC	
+7342	miniature bland moose chocolate	2	decent	
+7343	watered-down artisanal maroon painting of a glass of wine	2	EPIC	
 7344	green oil painting of yourself	0		
 7345	squat ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	veiny ghost toga	0		Maximum HP: +10, Item Drop: +5
-7348	gigantic stale sheet cake	6	decent	
+7348	stale gigantic sheet cake	6	decent	
 7349	ghost key	0		
 7350	green picture of you	0		
 7351	Jeselnik's smelly educational Staff of the Electric Range	0		Experience: +1, Stench Spell Damage: +10, Sleaze Damage: +25
@@ -7252,7 +7252,7 @@
 7363	galvanized corrupted bloodstain stick	0		Effect: "Jungle Juiced", Effect Duration: 57
 7364	fabric softener	0		
 7365	non-pickled fabric hardener	0		Effect: "Pisces in the Skyces", Effect Duration: 25
-7366	bad irresponsibly strong huge bottle of laundry sherry	10	decent	
+7366	irresponsibly strong bad huge bottle of laundry sherry	10	decent	
 7367	corrupted enhanced industrial strength starch	0		Effect: "Strong Spirit", Effect Duration: 11, Wiki Name: "industrial strength starch"
 7368	super-sized moldy extra-flat panini	5	crappy	
 7369	aerosolized mangled finger	0		Effect: "Sticks and Stones", Effect Duration: 40
@@ -7284,7 +7284,7 @@
 7395	extra-corrupted wobbly Gene Tonic: Goblin	0		Effect: "Tasting the Rainbow", Effect Duration: 41, Last Available: "2014-04"
 7396	denatured upside-down Gene Tonic: Pirate	0		Effect: "Irresistible Resolve", Effect Duration: 44, Last Available: "2014-04"
 7397	galvanized Gene Tonic: Plant	0		Effect: "The Solution", Effect Duration: 51, Last Available: "2014-04"
-7398	wet concentrated upside-down squat Gene Tonic: Weird	0		Effect: "Powdered", Effect Duration: 60, Last Available: "2014-04"
+7398	wet concentrated squat upside-down Gene Tonic: Weird	0		Effect: "Powdered", Effect Duration: 60, Last Available: "2014-04"
 7399	galvanized ionized squat Gene Tonic: Elf	0		Effect: "Cool Spirit", Effect Duration: 25, Last Available: "2014-04"
 7400	boiled wet polarized wobbly Gene Tonic: Mer-kin	0		Effect: "The Dinsey Spirit", Effect Duration: 32, Last Available: "2014-04"
 7401	chilled jittery Gene Tonic: Slime	0		Effect: "Gummiskin", Effect Duration: 32, Last Available: "2014-04"
@@ -7305,7 +7305,7 @@
 7416	Steam Card: DemonStar (#2)	0		
 7417	Steam Card: DemonStar (#3)	0		
 7418	Steam Card: Jackass Plumber (#1)	0		
-7419	green mirror tumbling Steam Card: Jackass Plumber (#2)	0		
+7419	mirror tumbling green Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	pencil thin mushroom	0		Last Available: "2014-05"
 7422	mirror Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
@@ -7316,14 +7316,14 @@
 7427	polymerized huge sleight-of-hand mushroom	0		Effect: "Thanksgot", Effect Duration: 20, Last Available: "2014-05"
 7428	bouncing Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	Beach Buck	0		Last Available: "2014-05"
-7430	colloidal electrified teal wobbly upside-down Fun-Guy spore	0		Effect: "Pasta Oneness", Effect Duration: 59, Last Available: "2014-05"
-7431	activated denatured spinning upside-down ghostly Boletus Broletus mushroom	0		Effect: "Healthy Bronze Glow", Effect Duration: 34, Last Available: "2014-05"
+7430	colloidal electrified upside-down wobbly teal Fun-Guy spore	0		Effect: "Pasta Oneness", Effect Duration: 59, Last Available: "2014-05"
+7431	activated denatured ghostly upside-down spinning Boletus Broletus mushroom	0		Effect: "Healthy Bronze Glow", Effect Duration: 34, Last Available: "2014-05"
 7432	activated pressed teal Omphalotus Omphaloskepsis mushroom	0		Effect: "The Living Hitpoints", Effect Duration: 41, Last Available: "2014-05"
 7433	concentrated cold-filtered Gyromitra Dynomita mushroom	0		Effect: "Bored Stiff", Effect Duration: 67, Last Available: "2014-05"
 7434	galvanized mirror Helvella Haemophilia mushroom	0		Effect: "Good Motivator", Effect Duration: 64, Last Available: "2014-05"
 7435	warmed deionized twirling Stemonitis Staticus mushroom	0		Effect: "A Few Extra Pounds", Effect Duration: 48, Last Available: "2014-05"
 7436	super-pressed gray Tremella Tarantella mushroom	0		Effect: "Ancestral Disapproval", Effect Duration: 11, Last Available: "2014-05"
-7437	spinning blinking Pastaco shell	0		Last Available: "2014-05"
+7437	blinking spinning Pastaco shell	0		Last Available: "2014-05"
 7438	bland maroon Beefy Crunch Pastaco	4	decent	Last Available: "2014-05"
 7439	thick bland Brain Food Pastaco	5	decent	Last Available: "2014-05"
 7440	flavorless Cool Brunch Pastaco	3	decent	Last Available: "2014-05"
@@ -7333,14 +7333,14 @@
 7444	artisanal overpowering mushroom wine	4	EPIC	Last Available: "2014-05"
 7445	bad jittery complex mushroom wine	3	decent	Last Available: "2014-05"
 7446	drinkable smooth mushroom wine	3	good	Last Available: "2014-05"
-7447	drinkable special blood-red mushroom wine	4	good	Effect: "Punch Another Day", Effect Duration: 20, Last Available: "2014-05"
+7447	special drinkable blood-red mushroom wine	4	good	Effect: "Punch Another Day", Effect Duration: 20, Last Available: "2014-05"
 7448	perfectly mixed buzzing mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
 7449	artisanal swirling mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
 7450	moldy Taco Dan's Basic Taco Dan Taco	3	crappy	Last Available: "2014-05"
-7451	normal diet Taco Dan's Taco Fish Fish Taco	1	good	Last Available: "2014-05"
+7451	diet normal Taco Dan's Taco Fish Fish Taco	1	good	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	lousy practically non-alcoholic fuchsia regular-size brogurt	1	decent	Last Available: "2014-05"
-7454	practically non-alcoholic acceptable super-size brogurt	1	good	Last Available: "2014-05"
+7453	practically non-alcoholic lousy fuchsia regular-size brogurt	1	decent	Last Available: "2014-05"
+7454	acceptable practically non-alcoholic super-size brogurt	1	good	Last Available: "2014-05"
 7455	hand-crafted broberry brogurt	4	EPIC	Last Available: "2014-05"
 7456	strong artisanal brocolate brogurt	5	EPIC	Last Available: "2014-05"
 7457	tolerable ghostly fuchsia French bronilla brogurt	4	good	Last Available: "2014-05"
@@ -7367,7 +7367,7 @@
 7478	wobbly possessed sugar cube	0		Last Available: "2014-05"
 7479	modified mirror sugar fairy	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 51, Last Available: "2014-05"
 7480	alkaline upside-down sugar bunny	0		Effect: "Jawin'", Effect Duration: 66, Last Available: "2014-05"
-7481	tumbling sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	tumbling sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	aged Rompedores de Fantasmas	4	awesome	
 7483	perfectly mixed La Fantasma y La Oscuridad	3	EPIC	
 7484	practically non-alcoholic acceptable Fantasma en la M&aacute;quina	1	good	
@@ -7388,14 +7388,14 @@
 7499	warmed diffused boiled Hot 'n' Scarys	0		Effect: "Leo Rising", Effect Duration: 28
 7500	map	0		
 7501	blurry	0		
-7502	flattened pickled narrow wobbly Texas tea	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 66
+7502	flattened pickled wobbly narrow Texas tea	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 66
 7503	scandalous dark hamethyst ring	0		Sleaze Damage: +5
 7504	Annie Oakley's dark baconstone ring	0		Critical Hit Percent: +20
 7505	dark porquoise ring of the empath	0		Familiar Weight: +5
 7506	scorching book of the early riser	0		Hot Damage: +25, Adventures: +7
 7507	jittery huge groovy cloak	0		Moxie Percent: +10
 7508	label	0		
-7509	tasty low-calorie Mornington crescent roll	1	awesome	
+7509	low-calorie tasty Mornington crescent roll	1	awesome	
 7510	dry quantum eye shadow	0		Effect: "Turtle Power", Effect Duration: 53
 7511	crumbling wheel	0		
 7512	aerosolized ionized Vulcanized poppy	0		Effect: "There Is A Spoon", Effect Duration: 64
@@ -7405,7 +7405,7 @@
 7516	witch's spare house key	0		
 7517	perfumed crafty spider leg	0		Maximum MP: +10, Stench Resistance: +5
 7518	tumbling wand of pigification	0		
-7519	bad high-proof narrow glass of bourbon	7	decent	
+7519	high-proof bad narrow glass of bourbon	7	decent	
 7520	twirling burned government manual fragment	0		Last Available: "2014-05"
 7521	tasty government cheese	3	awesome	Last Available: "2014-05"
 7522	Van der Graaf pair of government shades	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2014-05"
@@ -7413,25 +7413,25 @@
 7524	dry corrupted government	0		Effect: "Can Has Cyborger", Effect Duration: 60, Last Available: "2014-05"
 7525	vacuum-sealed squat alien drugs	0		Effect: "Demonic Taint", Effect Duration: 56, Last Available: "2023-09"
 7526	weird space book	0		Last Available: "2014-05"
-7527	mirror skewed alien force field disruptor bean	0		Last Available: "2014-05"
+7527	skewed mirror alien force field disruptor bean	0		Last Available: "2014-05"
 7528	skewed stanky smartaleck's government-issued night-vision goggles	0		Moxie Percent: +30, Stench Spell Damage: +25, Single Equip, Last Available: "2014-05"
-7529	moldy thick loaf of alien bread	5	crappy	Last Available: "2014-05"
+7529	thick moldy loaf of alien bread	5	crappy	Last Available: "2014-05"
 7530	adequate gigantic grilled cheese sandwich	8	good	Last Available: "2014-05"
 7531	dehydrated skewed jittery alien protein powder	1	good	Effect: "You're High as a Crow, Marty", Effect Duration: 20, Last Available: "2014-05"
 7532	tolerable bouncing rocket fuel	3	good	Last Available: "2014-05"
-7533	twirling huge alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7533	huge twirling alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	blue alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	tolerable maroon stealth bomber	4	good	Last Available: "2014-05"
-7536	pulsating olive space beast fur	0		Last Available: "2014-05"
+7536	olive pulsating space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	skewed ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
 7539	lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7540	experienced space beast fur pants	0		Experience: +2, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	steel-toed space beast fur whip	0		Damage Reduction: 9, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	clever space heater of the cheetah	0		Maximum MP: +20, Initiative: +60, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	clever space heater of the cheetah	0		Maximum MP: +20, Initiative: +60, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
-7545	aged weak space port	2	awesome	Last Available: "2014-05"
+7545	weak aged space port	2	awesome	Last Available: "2014-05"
 7546	rock-hard wizardly space needle	0		Mysticality: +25, Damage Reduction: 5, Last Available: "2014-05"
 7547	super-flattened buffed alien drugs	0		Effect: "Rushtacean'", Effect Duration: 57, Last Available: "2014-05"
 7548	teal hot ashes	0		Last Available: "2014-06"
@@ -7444,11 +7444,11 @@
 7555	tumbling lime green page	0		
 7556	ghostly elephant gift	0		
 7557	denatured narrow blood cells	0		Effect: "Amorous Avarice", Effect Duration: 62
-7558	weak lousy enchanted wine	2	decent	Effect: "Nut-Rition", Effect Duration: 40
+7558	lousy weak enchanted wine	2	decent	Effect: "Nut-Rition", Effect Duration: 40
 7559	flattened triple-chilled gummi turtle	0		Effect: "Muddled", Effect Duration: 45
 7560	turtle-shaped rock	0		
 7561	wet boiled bouncing giraffe-necked turtle	0		Effect: "Memory of Smarts", Effect Duration: 28
-7562	warmed concentrated flattened bouncing cyan musk turtle	0		Effect: "You Know When to Walk Away", Effect Duration: 33
+7562	warmed concentrated flattened cyan bouncing musk turtle	0		Effect: "You Know When to Walk Away", Effect Duration: 33
 7563	wet diffused programmable turtle	0		Effect: "Greasy Peasy", Effect Duration: 42
 7564	warmed polymerized Vulcanized wobbly mocking turtle	0		Effect: "Venomous Weapon", Effect Duration: 60
 7565	flavorless ham steak	3	decent	
@@ -7456,11 +7456,11 @@
 7567	shaking Chroner	0		
 7568	narrow nippy medical-grade Time Lord Badge of Honor of the businessman	0		Cold Damage: +10, Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10
 7569	maroon Usain Bolt's electrified Time Bandit Badge of Courage	0		Item Drop: +5, Initiative: +80, MP Regen Min: 3, MP Regen Max: 5
-7570	vacuum-sealed squat mirror skewed Friendliness Beverage	0		Effect: "Thaumodynamic", Effect Duration: 17
+7570	vacuum-sealed skewed mirror squat Friendliness Beverage	0		Effect: "Thaumodynamic", Effect Duration: 17
 7571	silent pea shooter of wisdom of the wise owl	0		Mysticality: 35
 7572	spoiled maroon D roll	4	crappy	
 7573	Samson's kiwi beak of wisdom	0		Mysticality: +15, Experience (Muscle): +5
-7574	watered-down artisanal New Zealand iced tea	2	EPIC	
+7574	artisanal watered-down New Zealand iced tea	2	EPIC	
 7575	ghostly miser's droll monocle of wisdom	0		Mysticality: +15, Meat Drop: +10, Single Equip
 7576	warmed electrified tumbling future drug: Muscularactum	0		Effect: "Material Witness", Effect Duration: 45
 7577	quantum ionized future drug: Smartinex	0		Effect: "Superioreo", Effect Duration: 55
@@ -7475,7 +7475,7 @@
 7586	green blurry helix fossil	0		
 7587	squat S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	bad triple-distilled gray glass of &quot;milk&quot;	10	decent	Last Available: "2014-07"
+7589	triple-distilled bad gray glass of &quot;milk&quot;	10	decent	Last Available: "2014-07"
 7590	smooth cup of &quot;tea&quot;	4	awesome	Last Available: "2014-07"
 7591	hand-crafted thermos of &quot;whiskey&quot;	3	EPIC	Last Available: "2014-07"
 7592	mediocre Lucky Lindy	3	decent	Last Available: "2014-07"
@@ -7484,7 +7484,7 @@
 7595	practically non-alcoholic drinkable red Ish Kabibble	1	good	Last Available: "2014-07"
 7596	mediocre practically non-alcoholic shaking Hot Socks	1	decent	Last Available: "2014-07"
 7597	tolerable huge Phonus Balonus	3	good	Last Available: "2014-07"
-7598	weak perfectly mixed Flivver	2	EPIC	Last Available: "2014-07"
+7598	perfectly mixed weak Flivver	2	EPIC	Last Available: "2014-07"
 7599	lousy practically non-alcoholic Sloppy Jalopy	1	decent	Last Available: "2014-07"
 7600	altered squat flame	0		Effect: "Heart of Orange", Effect Duration: 11
 7601	aerosolized polarized corrupted temporary yak tattoo	0		Effect: "Pharmaceutically Cool", Effect Duration: 60
@@ -7493,11 +7493,11 @@
 7604	chilled artisanal hand-squeezed wheatgrass juice	0		Effect: "Elbow Sauce", Effect Duration: 18
 7605	wet punk patch	0		Effect: "Thunderheart", Effect Duration: 47
 7606	magnetized flattened narrow steampunk potion	0		Effect: "20/20 Vision", Effect Duration: 51
-7607	moist twirling ghostly vial of swamp vapors	0		Effect: "Super-Mega-Charged", Effect Duration: 33
+7607	moist ghostly twirling vial of swamp vapors	0		Effect: "Super-Mega-Charged", Effect Duration: 33
 7608	super-vacuum-sealed turtle mud	0		Effect: "Mushroom Samba", Effect Duration: 30
 7609	super-ionized super-deionized twirling Redeye&trade; Eyedrops	0		Effect: "All Is Forgiven", Effect Duration: 51
 7610	boiled electrified purple jittery Dweebisol&trade; inhaler	0		Effect: "Remaining Alive", Effect Duration: 26
-7611	polarized diffused purple ghostly Lewd Lemmy Hair Oil	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
+7611	polarized diffused ghostly purple Lewd Lemmy Hair Oil	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17
 7612	moist tomato soup poster	0		Effect: "Shot in the Arse", Effect Duration: 62
 7613	polarized concentrated bubblin' chemistry solution	0		Effect: "Celestial Vision", Effect Duration: 51
 7614	quantum unsweetened voodoo glowskull	0		Effect: "Optimist Primal", Effect Duration: 28
@@ -7505,7 +7505,7 @@
 7616	unsweetened activated blinking pygmy witchhazel	0		Effect: "Pork Power", Effect Duration: 17
 7617	aerosolized wet short deposition	0		Effect: "The Two-Prong Crown", Effect Duration: 22
 7618	deionized shaking straw pole	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 25
-7619	liquefied unsweetened shaking tumbling copperhead potion	0		Effect: "Weather, Man", Effect Duration: 63
+7619	liquefied unsweetened tumbling shaking copperhead potion	0		Effect: "Weather, Man", Effect Duration: 63
 7620	oxidized ninja fear powder	0		Effect: "Cool Spirit", Effect Duration: 45
 7621	colloidal galvanized ninja eyeblack	0		Effect: "Bananas!", Effect Duration: 59
 7622	triple-vacuum-sealed gray button rouge	0		Effect: "Remaining Alive", Effect Duration: 54
@@ -7516,7 +7516,7 @@
 7627	aerosolized warmed plastic Jefferson wings	0		Effect: "Fiery Spirit", Effect Duration: 44
 7628	super-quantum dancing fan	0		Effect: "items.enh", Effect Duration: 60
 7629	cold-filtered concentrated blue page of the Necrohobocon	0		Effect: "Minerva's Zen", Effect Duration: 44
-7630	energized spinning green huge magic powder	0		Effect: "Fishy Fortification", Effect Duration: 29
+7630	energized green huge spinning magic powder	0		Effect: "Fishy Fortification", Effect Duration: 29
 7631	triple-denatured concentrated jittery friar's tonsure	0		Effect: "Mint-Condition Breath", Effect Duration: 47
 7632	pickled pickled upside-down government-issue identification badge	0		Effect: "Cinnamouth", Effect Duration: 55
 7633	denatured irradiated blue alien hologram projector	0		Effect: "Uncanny Shot", Effect Duration: 19
@@ -7538,7 +7538,7 @@
 7649	anodized gourmet gourami oil	0		Effect: "Fishy Fortification", Effect Duration: 62
 7650	quadruple-unsweetened blue catfish whiskers	0		Effect: "Yes, Can Haz", Effect Duration: 28
 7651	twirling freshwater fishbone	0		
-7652	blue wobbly fishbone catcher's mitt	0		
+7652	wobbly blue fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
@@ -7551,7 +7551,7 @@
 7662	stale red Sogg-Os	4	decent	
 7663	veiny beefcake's Lord Soggyraven's Slippers of the blizzard	0		Muscle: +25, Maximum HP: +10, Cold Spell Damage: +25, Single Equip
 7664	irradiated Ancient Protector Soda	0		Effect: "Crimbo Nostalgia", Effect Duration: 44
-7665	polymerized red spinning liquid ice	0		Effect: "Joyful Resolve", Effect Duration: 24
+7665	polymerized spinning red liquid ice	0		Effect: "Joyful Resolve", Effect Duration: 24
 7666	hand-crafted fancy Wet Russian	3	EPIC	Effect: "Weapon of Mass Destruction", Effect Duration: 20
 7667	enchanted bland filet of The Fish	4	decent	Effect: "Melancholy Burden", Effect Duration: 5
 7668	purple Thwaitgold spider statuette	0		
@@ -7565,7 +7565,7 @@
 7676	birdbone corset of bravery	0		Spooky Resistance: +5
 7677	adjusted candy cigarette	0		Effect: "Magically Fingered", Effect Duration: 65
 7678	jittery energetic 4-dimensional fez	0		Maximum MP Percent: +20, Familiar Effect: "atk, 1xLep, cap 12"
-7679	cyan squat throwing candy	0		
+7679	squat cyan throwing candy	0		
 7680	maroon twirling steel-toed super-absorbent tarp	0		Damage Reduction: 9
 7681	acceptable unquiet spirits	3	good	
 7682	banjo kazoo mount of doom	0		Spooky Spell Damage: +50, Single Equip
@@ -7581,7 +7581,7 @@
 7692	wobbly lime green shaking rosy-cheeked fortified brawny hand whip	0		Muscle Percent: +20, Damage Absorption: +60, Maximum HP Percent: +30, Last Available: "2014-08"
 7693	blurry jittery blurry rosewater-soaked coward's glow-in-the-dark necklace of incineration	0		Monster Level: -20, Hot Spell Damage: +50, Stench Resistance: +3, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	asbestos-lined medical-grade cap gun of the storm	0		Maximum MP Percent: +40, Hot Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	asbestos-lined medical-grade cap gun of the storm	0		Maximum MP Percent: +40, Hot Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	wobbly Annie Oakley's ruddy cassette player	0		Maximum HP Percent: +40, Critical Hit Percent: +20, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	bouncing rubber spider	0		Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	Vulcanized adjusted mirror rubber nubbin	0		Effect: "Nothing Is Impossible", Effect Duration: 28, Last Available: "2014-08"
 7708	fuchsia inspector's wool rubber cape	0		Cold Resistance: +1, Item Drop: +15, Last Available: "2014-08"
-7709	asbestos-lined chaotic Newton's Socratic Thor's Pliers	0		Experience (Mysticality): 4, Spell Critical Percent: +10, Hot Resistance: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	asbestos-lined chaotic Newton's Socratic Thor's Pliers	0		Experience (Mysticality): 4, Spell Critical Percent: +10, Hot Resistance: +5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	triple-frozen candy UFOs	0		Effect: "Whole Latte Love", Effect Duration: 28
 7711	quilted sinister water wings for babies	0		Spell Damage: +10, Damage Absorption: +40
-7712	blinking beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
+7712	blinking beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	thick yummy Strix stix	5	awesome	
 7714	Tesla forbidden vampire pellet of bravery	0		Spell Damage Percent: +50, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10
 7715	bad wobbly non-aged vinegar	4	decent	
@@ -7643,7 +7643,7 @@
 7754	therapeutic supercool Xiblaxian stealth trousers	0		Moxie Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-09"
 7755	avaricious nasty Xiblaxian stealth vest	0		Stench Damage: +5, Meat Drop: +30, Last Available: "2014-09"
 7756	stale Xiblaxian ultraburrito	3	decent	Last Available: "2014-09"
-7757	fancy triple-distilled perfectly mixed Xiblaxian space-whiskey	9	EPIC	Effect: "Nas Tea", Effect Duration: 5, Last Available: "2014-09"
+7757	perfectly mixed fancy triple-distilled Xiblaxian space-whiskey	9	EPIC	Effect: "Nas Tea", Effect Duration: 5, Last Available: "2014-09"
 7758	tumbling spinning Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	cold-filtered liquefied squat They liver	0		Effect: "Saucemastery", Effect Duration: 25, Last Available: "2014-09"
 7760	spoiled They liver popsicle	3	crappy	Last Available: "2014-09"
@@ -7659,7 +7659,7 @@
 7770	perfumed vibrating shellacked Personal Ventilation Unit	0		Damage Reduction: 7, Maximum MP Percent: +10, Stench Resistance: +5, Single Equip, Last Available: "2014-10"
 7771	quantum lime green the most dangerous bait	0		Effect: "Block-Rockin' Beet", Effect Duration: 33, Last Available: "2014-10"
 7772	half-sized adequate &quot;meat&quot; stick	2	good	Last Available: "2014-10"
-7773	boiled wobbly shaking pulsating transdermal smoke patch	1	crappy	Effect: "Turkey-Friendly", Effect Duration: 50, Last Available: "2014-10"
+7773	boiled pulsating wobbly shaking transdermal smoke patch	1	crappy	Effect: "Turkey-Friendly", Effect Duration: 50, Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	shaking clever pair of plants of the ox of the businessman	0		Muscle: +20, Maximum MP: +20, Meat Drop: +50, Last Available: "2014-10"
 7776	wobbly Temple Grandin's Samson's Sasq&trade; watch of wisdom	0		Mysticality: +15, Experience (Muscle): +5, Familiar Weight: +7, Single Equip, Last Available: "2014-10"
@@ -7673,17 +7673,17 @@
 7784	non-pressed denatured tumbling monkey barf	0		Effect: "Proprie Tea", Effect Duration: 40, Last Available: "2014-10"
 7785	adjusted wet spinning candy	0		Effect: "Tightly-Wound Spine", Effect Duration: 24, Last Available: "2014-10"
 7786	quilted Herculean smartaleck's jangly bracelet	0		Moxie Percent: +30, Experience (Muscle): +1, Damage Absorption: +40, Last Available: "2014-10"
-7787	blurry wizardly cuddly teddy bear	0		Mysticality: +25, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	blurry wizardly cuddly teddy bear	0		Mysticality: +25, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	hardened first-aid pouch of terror	0		Damage Reduction: 3, Spooky Spell Damage: +10, Last Available: "2014-10"
 7790	pulsating khaki duffel bag	0		Last Available: "2014-10"
-7791	pickled upside-down bouncing airborne mutagen	0		Effect: "Greasy Flavor", Effect Duration: 42, Last Available: "2014-10"
-7792	bouncing green SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
+7791	pickled bouncing upside-down airborne mutagen	0		Effect: "Greasy Flavor", Effect Duration: 42, Last Available: "2014-10"
+7792	green bouncing SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	narrow Armory keycard	0		Last Available: "2014-10"
 7795	stale initiative shawarma	4	decent	Last Available: "2014-10"
 7796	decent half-sized jittery warm war shawarma	2	good	Last Available: "2014-10"
-7797	normal snack-sized blurry karma shawarma	2	good	Last Available: "2014-10"
+7797	snack-sized normal blurry karma shawarma	2	good	Last Available: "2014-10"
 7798	bad Jungle Juice	3	decent	Last Available: "2014-10"
 7799	weak tolerable tumbling Amnesiac Ale	2	good	Last Available: "2014-10"
 7800	acceptable pulsating Highest Bitter	3	good	Last Available: "2014-10"
@@ -7720,7 +7720,7 @@
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	squat encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	upside-down gore bucket	0		Last Available: "2014-10"
-7834	twirling blurry pack of smokes	0		Last Available: "2014-10"
+7834	blurry twirling pack of smokes	0		Last Available: "2014-10"
 7835	ESP suppression collar	0		Last Available: "2014-10"
 7836	GPS-tracking wristwatch	0		Last Available: "2014-10"
 7837	twirling Project T. L. B.	0		Last Available: "2014-10"
@@ -7734,8 +7734,8 @@
 7845	alkaline wobbly perl necklace	0		Effect: "Bells in the Batfry", Effect Duration: 23, Last Available: "2014-12"
 7846	pressed tarnished bouncing Fudge Fiber Armor Plating	0		Effect: "Memories of Puppy Love", Effect Duration: 37, Last Available: "2014-12"
 7847	double-enhanced anodized improved ruby on canes	0		Effect: "Tenacity of the Snapper", Effect Duration: 45, Last Available: "2014-12"
-7848	flavorless huge petit fortran	6	decent	Last Available: "2014-12"
-7849	snack-sized moldy special pulsating java cookie	2	crappy	Effect: "Liquidy Smoky", Effect Duration: 40, Last Available: "2014-12"
+7848	huge flavorless petit fortran	6	decent	Last Available: "2014-12"
+7849	moldy snack-sized special pulsating java cookie	2	crappy	Effect: "Liquidy Smoky", Effect Duration: 40, Last Available: "2014-12"
 7850	spoiled mirror cookie cookie	4	crappy	Last Available: "2014-12"
 7851	avaricious plastic exo-suited miner	0		Meat Drop: +30, Last Available: "2014-12"
 7852	lime green boxer's plastic semi-autonomous drill unit	0		Muscle Percent: +10, Last Available: "2014-12"
@@ -7751,7 +7751,7 @@
 7862	upside-down cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	Petite Paintbrush	0		Adventures: +1
-7865	jittery upside-down Crimbot schematic: Gun Face	0		Last Available: "2014-12"
+7865	upside-down jittery Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	red Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
@@ -7768,7 +7768,7 @@
 7879	Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
 7880	Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
-7882	ghostly squat Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
+7882	squat ghostly Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	tumbling Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	narrow Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	Crimbot schematic: Power Arm	0		Last Available: "2014-12"
@@ -7786,7 +7786,7 @@
 7897	shaking Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	shaking Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
-7900	green shaking pulsating Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
+7900	pulsating green shaking Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
@@ -7801,19 +7801,19 @@
 7912	recovered elf smartphone	0		Last Available: "2014-12"
 7913	brawny slick Size XI Wizard's Robe of horror	0		Moxie: +10, Muscle Percent: +20, Spooky Spell Damage: +25, Last Available: "2014-09"
 7914	concentrated galvanized diffused ghostly Bit O' Quail Spleen	0		Effect: "In Vino Vires", Effect Duration: 59
-7915	triple-electrified tarnished squat twirling huge green Take Eleven Bar	0		Effect: "Haunted Stomach", Effect Duration: 13
-7916	ghostly skewed fuchsia mimeplasm	0		
+7915	triple-electrified tarnished twirling huge green squat Take Eleven Bar	0		Effect: "Haunted Stomach", Effect Duration: 13
+7916	skewed ghostly fuchsia mimeplasm	0		
 7917	anodized pressed lime green BOOterfinger	0		Effect: "Cat-Alyzed", Effect Duration: 66
 7918	liquefied Moonds	0		Effect: "Armored Innards", Effect Duration: 36
 7919	magnetized flattened blurry Big Punk	0		Effect: "Stone-Faced", Effect Duration: 28
 7920	blurry wobbly fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	watered-down perfectly mixed Friendly Turkey	2	EPIC	Last Available: "2014-11"
+7922	perfectly mixed watered-down Friendly Turkey	2	EPIC	Last Available: "2014-11"
 7923	aged extra-dry Agitated Turkey	5	awesome	Last Available: "2014-11"
 7924	drinkable Ambitious Turkey	4	good	Last Available: "2014-11"
-7925	toothsome miniature neutron lollipop	2	awesome	Last Available: "2014-12"
+7925	miniature toothsome neutron lollipop	2	awesome	Last Available: "2014-12"
 7926	watered-down tolerable gamma nog	2	good	Last Available: "2014-12"
-7934	lime green shaking sneaky wrapping paper	0		Last Available: "2014-12"
+7934	shaking lime green sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	bouncing Crimbo Credit	0		
@@ -7827,8 +7827,8 @@
 7945	table	0		
 7946	Herculean beefy outlaw bandana of the pedagogue	0		Muscle: +10, Experience: +3, Experience (Muscle): +1
 7947	bad skewed whiskey in a broken glass	3	decent	
-7948	mediocre narrow jittery shot of mescal	4	decent	
-7949	acceptable practically non-alcoholic glass of herbal tequila	1	good	
+7948	mediocre jittery narrow shot of mescal	4	decent	
+7949	practically non-alcoholic acceptable glass of herbal tequila	1	good	
 7950	narrow minin' dynamite	0		
 7951	upside-down sharpshooter's grievous plaid cowboy hat	0		Weapon Damage Percent: +50, Critical Hit Percent: +10, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7851,9 +7851,9 @@
 7969	blinking beehive	0		
 7970	ghostly boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
-7972	mixed mirror upside-down mummified fig	1	awesome	Effect: "It's Electric!", Effect Duration: 25
+7972	mixed upside-down mirror mummified fig	1	awesome	Effect: "It's Electric!", Effect Duration: 25
 7973	vaporized shaking mummified loaf of bread	1	awesome	
-7974	boiled fuchsia bouncing mummified beef haunch	1	decent	
+7974	boiled bouncing fuchsia mummified beef haunch	1	decent	
 7975	jittery linen bandages	0		
 7976	gray cotton bandages	0		
 7977	purple silk bandages	0		
@@ -7881,17 +7881,17 @@
 7999	corrupted modified choco-Crimbot	0		Effect: "Sugar Smacks", Effect Duration: 32, Last Available: "2014-12"
 8000	extra-quantum narrow smart watch	0		Effect: "Ticking Clock", Effect Duration: 57, Last Available: "2014-12"
 8001	extra-flattened Vulcanized augmented-reality shades	0		Effect: "Bells in the Batfry", Effect Duration: 12, Last Available: "2014-12"
-8002	toy Crimbot mega face of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
-8003	wobbly ghostly hale toy Crimbot power glove	0		Maximum HP: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	pulsating boxer's toy Crimbot super fist	0		Muscle Percent: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	olive toy Crimbot rocket legs of terror	0		Spooky Spell Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	toy Crimbot mega face of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	wobbly ghostly hale toy Crimbot power glove	0		Maximum HP: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	pulsating boxer's toy Crimbot super fist	0		Muscle Percent: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	olive toy Crimbot rocket legs of terror	0		Spooky Spell Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	Vulcanized blurry Crimbot battery	0		Effect: "Tasting the Rainbow", Effect Duration: 30, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	jittery Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	blue heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	gray bouncing asbestos-lined wool Crimbomega drive chain of dire peril	0		Weapon Damage: +20, Cold Resistance: +1, Hot Resistance: +5, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	gray bouncing asbestos-lined wool Crimbomega drive chain of dire peril	0		Weapon Damage: +20, Cold Resistance: +1, Hot Resistance: +5, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	ghostly Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7900,7 +7900,7 @@
 8018	double-moist spinning pulsating and rain stick	0		Effect: "Alpine Mintiness", Effect Duration: 50
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	rotten Choco-Mint patty	4	crappy	Last Available: "2015-01"
-8021	aged practically non-alcoholic twirling hot mint schnocolate	1	awesome	Last Available: "2015-01"
+8021	practically non-alcoholic aged twirling hot mint schnocolate	1	awesome	Last Available: "2015-01"
 8022	mixed mirror homeopathic mint tea	1	crappy	Last Available: "2015-01"
 8023	lime green muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
@@ -7944,7 +7944,7 @@
 8063	maroon Tales of Spelunking	0		Last Available: "2015-12"
 8064	olive monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
-8066	modified maroon mirror	1	EPIC	Last Available: "2015-12"
+8066	modified mirror maroon	1	EPIC	Last Available: "2015-12"
 8067	nuggets	0		
 8068	ghostly Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	ghostly Stembridge sidearm	0		Familiar Weight: +5
@@ -7984,7 +7984,7 @@
 8109	squat pulsating hardened ascot of the scaredy-cat	0		Damage Reduction: 3, Monster Level: -15, Single Equip, Last Available: "2017-12"
 8110	twirling inspector's Samson's attache case	0		Experience (Muscle): +5, Item Drop: +15, Last Available: "2017-12"
 8111	shaking banded accordion of the bloodbag	0		Damage Absorption: +100, Maximum HP: +100, Song Duration: 10, Last Available: "2017-12"
-8112	pickled ghostly blurry tumbling aerosolized	1		Last Available: "2017-12"
+8112	pickled blurry tumbling ghostly aerosolized	1		Last Available: "2017-12"
 8113	blurry red smartaleck's wig of the businessman	0		Moxie Percent: +30, Meat Drop: +50, Last Available: "2017-12"
 8114	greasy educational winch crank	0		Experience: +1, Sleaze Spell Damage: +10, Single Equip, Last Available: "2017-12"
 8115	skewed gray prompt hardy widget	0		Maximum HP: +50, Adventures: +3, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	olive lion tamer's strapping garland	0		Muscle: +5, Experience (familiar): +2, Single Equip, Last Available: "2018-12"
 8122	hale gunnysack of the sewer	0		Maximum HP: +20, Stench Damage: +25, Last Available: "2018-12"
 8123	inspector's garibaldi of dire peril	0		Weapon Damage: +20, Item Drop: +15, Last Available: "2018-12"
-8124	Temple Grandin's girdle of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	Temple Grandin's girdle of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	skewed gravedigger's groovy gloves	0		Moxie Percent: +10, Spooky Damage: +10, Single Equip, Last Available: "2018-12"
 8126	diluted narrow smithereens	1		Effect: "Boon of She-Who-Was", Effect Duration: 40, Last Available: "2018-12"
 8127	shaking gravedigger's fiberglass fetish of terror	0		Spooky Damage: +10, Spooky Spell Damage: +10, Last Available: "2018-12"
@@ -8005,7 +8005,7 @@
 8130	greedy wizardly fiberglass frock	0		Mysticality: +25, Meat Drop: +20, Last Available: "2018-12"
 8131	red careful boxer's fiberglass fingerguard	0		Muscle Percent: +10, Monster Level: -10, Single Equip, Last Available: "2018-12"
 8132	toasty fiberglass fedora of chilblains	0		Cold Damage: +25, Hot Damage: +5, Last Available: "2018-12"
-8133	distilled bouncing maroon fiberglass fibers	1		Last Available: "2018-12"
+8133	distilled maroon bouncing fiberglass fibers	1		Last Available: "2018-12"
 8134	yellow bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	tumbling talisman of Renenutet	0		
@@ -8023,7 +8023,7 @@
 8149	extra-cold-filtered Glo-Pop	0		Effect: "Beta Carotene Overdose", Effect Duration: 46
 8150	unsweetened vacuum-sealed ionized mirror sugar sphere	0		Effect: "Burning Ears", Effect Duration: 44
 8151	quadruple-tarnished Shrubble Bubble	0		Effect: "Disdain of She-Who-Was", Effect Duration: 41
-8152	adjusted aerosolized gray spinning polyeaster egg	0		Effect: "Trash-Wrapped", Effect Duration: 37
+8152	adjusted aerosolized spinning gray polyeaster egg	0		Effect: "Trash-Wrapped", Effect Duration: 37
 8153	extra-moist candy dish	0		Effect: "Red Door Syndrome", Effect Duration: 49
 8154	frozen anodized Spechunky bar	0		Effect: "Ooh, Salty!", Effect Duration: 17
 8155	quantum aerosolized tumbling yellow talisman of Horus	0		Effect: "Notably Lovely", Effect Duration: 35
@@ -8059,19 +8059,19 @@
 8185	wobbly auspicious The Crown of Ed the Undying of dire peril	0		Weapon Damage: +20, Item Drop: +10, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	cyan Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	strong perfectly mixed Cherrytastrophe wine cooler	5	EPIC	
-8189	weak special bad Radberry Rip wine cooler	2	decent	Effect: "Livin' Large", Effect Duration: 30
-8190	drinkable weak upside-down Orangemageddon wine cooler	2	good	
-8191	drinkable watered-down Breakfast Blast wine cooler	2	good	
+8188	perfectly mixed strong Cherrytastrophe wine cooler	5	EPIC	
+8189	special bad weak Radberry Rip wine cooler	2	decent	Effect: "Livin' Large", Effect Duration: 30
+8190	weak drinkable upside-down Orangemageddon wine cooler	2	good	
+8191	watered-down drinkable Breakfast Blast wine cooler	2	good	
 8192	weak tolerable Citrus Crush wine cooler	2	good	
 8193	rotten small plain bagel	2	crappy	
-8194	bland gigantic huge glob of cream cheese	10	decent	
+8194	gigantic bland huge glob of cream cheese	10	decent	
 8195	flavorless fancy loaf of soda bread	3	decent	Effect: "Patent Prevention", Effect Duration: 5
-8196	snack-sized flavorless enchanted acceptable bagel	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50
-8197	gigantic spoiled standard-issue cupcake	10	crappy	
+8196	flavorless enchanted snack-sized acceptable bagel	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50
+8197	spoiled gigantic standard-issue cupcake	10	crappy	
 8198	moldy ultra-deluxe cupcake	4	crappy	
 8199	hypnotic breadcrumbs	0		
-8200	adequate bite-sized popular tart	1	good	
+8200	bite-sized adequate popular tart	1	good	
 8201	cyan no-handed pie	0		
 8202	unsweetened Doc Galaktik's Vitality Serum	0		Effect: "Cool, Catlike", Effect Duration: 29
 8203	blurry airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8086,7 +8086,7 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	asbestos-lined fortified rigging rope	0		Damage Absorption: +60, Hot Resistance: +5, Last Available: "2015-04"
 8214	powdered nasty snuff	1	awesome	Effect: "Blessing of Bulbazinalli", Effect Duration: 35, Last Available: "2015-04"
-8215	arcane researcher's sewage-clogged pistol of Gandalf	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +20, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8215	arcane researcher's sewage-clogged pistol of Gandalf	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +20, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	polarized polarized upside-down beard incense	0		Effect: "Spookyravin'", Effect Duration: 59, Last Available: "2015-04"
 8217	blinking boxer's perfume-soaked bandana of courage	0		Muscle Percent: +10, Spooky Resistance: +3, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
@@ -8143,9 +8143,9 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	bland unappetizing mayolus	3	decent	Last Available: "2015-05"
 8271	moldy skewed narrow uninteresting mayolus	3	crappy	Last Available: "2015-05"
-8272	adequate super-sized maroon acceptable mayolus	5	good	Last Available: "2015-05"
-8273	rotten tiny fancy purple spinning shaking enticing mayolus	1	crappy	Effect: "Cancer Rising", Effect Duration: 10, Last Available: "2015-05"
-8274	bland jumbo upside-down mouth-watering mayolus	5	decent	Last Available: "2015-05"
+8272	super-sized adequate maroon acceptable mayolus	5	good	Last Available: "2015-05"
+8273	rotten tiny fancy purple shaking spinning enticing mayolus	1	crappy	Effect: "Cancer Rising", Effect Duration: 10, Last Available: "2015-05"
+8274	jumbo bland upside-down mouth-watering mayolus	5	decent	Last Available: "2015-05"
 8275	blurry newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	magnetized flattened power pill	0		Effect: "Flambé-a-thon", Effect Duration: 65, Last Available: "2015-06"
 8301	irradiated twirling pixel star	0		Effect: "Trufflin'", Effect Duration: 33, Last Available: "2015-06"
-8302	diet toothsome pixel banana	1	awesome	Last Available: "2015-06"
+8302	toothsome diet pixel banana	1	awesome	Last Available: "2015-06"
 8303	watered-down perfectly mixed pixel beer	2	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8189,7 +8189,7 @@
 8315	colloidal non-aerosolized upside-down muscle oil	0		Effect: "Elron's Explosive Etude", Effect Duration: 33
 8316	liquefied vacuum-sealed bottle of Red-Out	0		Effect: "On the Shoulders of Giants", Effect Duration: 54
 8317	galvanized diffused red pickpocket protector	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 43
-8318	dry denatured mirror purple sinister-looking cat	0		Effect: "You're Rubber", Effect Duration: 29
+8318	dry denatured purple mirror sinister-looking cat	0		Effect: "You're Rubber", Effect Duration: 29
 8319	dry energized skewed jazzy cigarette holder	0		Effect: "Saucefingers", Effect Duration: 51
 8320	quadruple-Vulcanized one glove	0		Effect: "Chalked-Up Teeth", Effect Duration: 36
 8321	unsweetened glove	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 35
@@ -8199,13 +8199,13 @@
 8325	triple-polarized cold-filtered coal contact lenses	0		Effect: "Egg Burps", Effect Duration: 63
 8326	irradiated moist quantum conjured ice cream	0		Effect: "Compensatory Cruelness", Effect Duration: 32
 8327	pressed Iceberglar scarf	0		Effect: "Bureaucratized", Effect Duration: 45
-8328	polarized extra-magnetized adjusted squat yellow icy hairspray	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 49
+8328	polarized extra-magnetized adjusted yellow squat icy hairspray	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 49
 8329	chilled gray smellbook	0		Effect: "Incredibly Hulking", Effect Duration: 47
 8330	dry assassin's cheese knife	0		Effect: "Vented Spleen", Effect Duration: 51
 8331	flattened twirling filthy armor	0		Effect: "EVISCERATE!", Effect Duration: 21
 8332	dry plague pie	0		Effect: "Mo' Hobo", Effect Duration: 38
 8333	corrupted batarang	0		Effect: "Smokin'", Effect Duration: 69
-8334	enhanced ghostly blinking spare neck bolts	0		Effect: "Well-preserved", Effect Duration: 48
+8334	enhanced blinking ghostly spare neck bolts	0		Effect: "Well-preserved", Effect Duration: 48
 8335	energized warmed quantum grease trap	0		Effect: "Haunted Liver", Effect Duration: 23
 8336	vacuum-sealed boiled quadruple-warmed pulsating shamanic ham	0		Effect: "Sauce Monocle", Effect Duration: 68
 8337	pickled ionized porkpocket	0		Effect: "Slippery Tongue", Effect Duration: 58
@@ -8215,19 +8215,19 @@
 8341	ionized warehouse clerk's glasses	0		Effect: "Stemonitis Storm", Effect Duration: 45
 8342	dry baloney rotgut	0		Effect: "Colorful Gratitude", Effect Duration: 15
 8343	colloidal carton of gaspers	0		Effect: "Extra-Thick Blood", Effect Duration: 69
-8344	non-aerosolized vacuum-sealed squat purple jittery bronze polish	0		Effect: "Educated (Sorta)", Effect Duration: 32
+8344	non-aerosolized vacuum-sealed squat jittery purple bronze polish	0		Effect: "Educated (Sorta)", Effect Duration: 32
 8345	ionized magnetized blinking crident	0		Effect: "Hagnk's Gratitude", Effect Duration: 29
 8346	ionized spinning green totally sweet mohawk helmet	0		Effect: "Sated and Furious", Effect Duration: 16
 8347	polymerized frozen alkaline spray chrome	0		Effect: "Amorous", Effect Duration: 49
 8348	improved mirror filthy monkey head	0		Effect: "The Halls of Muscularity", Effect Duration: 15
 8349	magnetized boiled upside-down hand of cards	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 18
-8350	concentrated twirling huge damp bar rag	0		Effect: "Human-Elemental Hybrid", Effect Duration: 32
+8350	concentrated huge twirling damp bar rag	0		Effect: "Human-Elemental Hybrid", Effect Duration: 32
 8351	double-denatured jittery lump of goofball ore	0		Effect: "Human-Horror Hybrid", Effect Duration: 67
 8352	quadruple-cold-filtered skeleton beans	0		Effect: "Voracious Gorging", Effect Duration: 33
 8353	liquefied narrow grimy lab coat	0		Effect: "Lobos Fresh", Effect Duration: 32
 8354	liquefied pressed nursery rhyme	0		Effect: "Paging Betty", Effect Duration: 69
 8355	pickled warmed iron torso box	0		Effect: "Third Based", Effect Duration: 29
-8356	vacuum-sealed galvanized blurry upside-down mercenary headband	0		Effect: "Berry Critical", Effect Duration: 64
+8356	vacuum-sealed galvanized upside-down blurry mercenary headband	0		Effect: "Berry Critical", Effect Duration: 64
 8357	polarized quantum radioactive spider venom	0		Effect: "Hypercubed", Effect Duration: 25
 8358	vacuum-sealed x-ray mirror	0		Effect: "Starry-Eyed", Effect Duration: 46
 8359	polarized adjusted wrestling mask	0		Effect: "Leash of Linguini", Effect Duration: 13
@@ -8248,7 +8248,7 @@
 8374	quantum activated skewed drinks tray	0		Effect: "Headstrong", Effect Duration: 15
 8375	improved pressed wobbly eyebrow lifter	0		Effect: "OMG WTF", Effect Duration: 33
 8376	yellow submarine	0		Last Available: "2015-06"
-8377	miniature normal twirling ghostly pixel lemon	2	good	Last Available: "2015-06"
+8377	miniature normal ghostly twirling pixel lemon	2	good	Last Available: "2015-06"
 8378	hand-crafted twirling blue pixel daiquiri	3	EPIC	Last Available: "2015-06"
 8379	colloidal power pill	0		Effect: "Super-Electrified", Effect Duration: 20, Last Available: "2015-06"
 8380	super-alkaline cyan pixel potion	0		Effect: "Heart of Pink", Effect Duration: 40, Last Available: "2015-06"
@@ -8279,10 +8279,10 @@
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
 8407	rotten pestopiary	3	crappy	
-8408	colloidal wet activated spinning upside-down ectoplasmic orbs	0		Effect: "Bubblin' Rage", Effect Duration: 53
-8409	moldy immense crudles	9	crappy	
+8408	colloidal wet activated upside-down spinning ectoplasmic orbs	0		Effect: "Bubblin' Rage", Effect Duration: 53
+8409	immense moldy crudles	9	crappy	
 8410	decent agnolotti arboli	3	good	
-8411	decent wobbly narrow spaghetti with ghost balls	4	good	
+8411	decent narrow wobbly spaghetti with ghost balls	4	good	
 8412	spoiled succulent marrow	3	crappy	
 8413	bland salacious crumbs	4	decent	
 8414	delicious fusilli marrownarrow	4	awesome	
@@ -8291,7 +8291,7 @@
 8417	decent Mt. McLargeHuge oyster	3	good	
 8418	oyster sauce	0		
 8419	normal huge huge linguini immondizia bianco	9	good	
-8420	bland low-calorie shells a la shellfish	1	decent	
+8420	low-calorie bland shells a la shellfish	1	decent	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	yellow unsmoothed velvet	0		Last Available: "2015-08"
@@ -8324,7 +8324,7 @@
 8450	capped lava bottle	0		Last Available: "2015-08"
 8451	blinking capped lava bottle	0		Last Available: "2015-08"
 8452	capped lava bottle	0		Last Available: "2015-08"
-8453	blue spinning heat-resistant sheet	0		Last Available: "2015-08"
+8453	spinning blue heat-resistant sheet	0		Last Available: "2015-08"
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
 8455	huge New Age crystal	0		Last Available: "2015-08"
 8456	green crystalline light bulb	0		Last Available: "2015-08"
@@ -8345,11 +8345,11 @@
 8471	lava-proof pants of Tarzan of the glutton	0		Experience (Muscle): +3, Food Drop: +100, Last Available: "2015-08"
 8472	fortified heat-resistant necktie of Gandalf	0		Damage Absorption: +60, Spell Critical Percent: +20, Single Equip, Last Available: "2015-08"
 8473	narrow foul-smelling Lo Pan's heat-resistant gloves of dire peril	0		Weapon Damage: +20, Spell Critical Percent: +30, Stench Damage: +10, Single Equip, Last Available: "2015-08"
-8474	diet normal very hot lunch	1	good	Last Available: "2015-08"
-8475	acceptable watered-down blinking asbestos thermos	2	good	Last Available: "2015-08"
+8474	normal diet very hot lunch	1	good	Last Available: "2015-08"
+8475	watered-down acceptable blinking asbestos thermos	2	good	Last Available: "2015-08"
 8476	Vulcanized liquid rhinestones	0		Effect: "Sleazy Hands", Effect Duration: 60, Last Available: "2015-08"
-8477	adequate big disco biscuit	5	good	Last Available: "2015-08"
-8478	delicious spirit-forward blurry Quaatorade&trade;	5	awesome	Last Available: "2015-08"
+8477	big adequate disco biscuit	5	good	Last Available: "2015-08"
+8478	spirit-forward delicious blurry Quaatorade&trade;	5	awesome	Last Available: "2015-08"
 8479	scorching biker's hat of the sweet-tooth of the early riser	0		Hot Damage: +25, Candy Drop: +100, Adventures: +7, Familiar Effect: "atk", Last Available: "2015-08"
 8480	greedy veiny feathered headdress of incineration	0		Maximum HP: +10, Hot Spell Damage: +50, Meat Drop: +20, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
 8481	mansplainer's resourceful brainy electrician's hardhat	0		Mysticality: +5, Maximum MP: +50, Monster Level: +15, Familiar Effect: "atk", Last Available: "2015-08"
@@ -8374,9 +8374,9 @@
 8500	the tongue of Smimmons	0		Last Available: "2015-08"
 8501	skewed Raul's guitar pick	0		Last Available: "2015-08"
 8502	Pener's crisps	0		Last Available: "2015-08"
-8503	tumbling skewed signed deuce	0		Last Available: "2015-08"
+8503	skewed tumbling signed deuce	0		Last Available: "2015-08"
 8504	Lavalos core	0		Last Available: "2015-08"
-8505	bouncing wobbly half-melted hula girl	0		Last Available: "2015-08"
+8505	wobbly bouncing half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
 8507	denatured SMOOCH coffee cup	1	crappy	Last Available: "2015-08"
 8508	aerosolized chilled narrow labrador cookie	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 22, Last Available: "2015-08"
@@ -8398,21 +8398,21 @@
 8524	superheated	0		Last Available: "2015-08"
 8525	diet adequate lava cake	1	good	Last Available: "2015-08"
 8526	rotten pink slime	4	crappy	
-8527	pulsating tumbling Devil's Elbow Hot Sauce	0		
+8527	tumbling pulsating Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	toothsome upside-down devil hair pasta	3	awesome	
-8530	fancy moldy spagecialetti	4	crappy	Effect: "Greasy Peasy", Effect Duration: 20
+8530	moldy fancy spagecialetti	4	crappy	Effect: "Greasy Peasy", Effect Duration: 20
 8531	Salsa Libre	0		
 8532	spinning good gravy	0		
-8533	spinning squat illicit fish sauce	0		
+8533	squat spinning illicit fish sauce	0		
 8534	adequate libertagliatelle	4	good	
-8535	diet rotten spinning turkish mostaccioli	1	crappy	
+8535	rotten diet spinning turkish mostaccioli	1	crappy	
 8536	toothsome shaking linguini of the sea	4	awesome	
 8537	altered alkaline purple Hersey&trade; SMOOCH	0		Effect: "Balls of Ectoplasm", Effect Duration: 65
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	huge flavorless squat Fettris	8	decent	
+8542	flavorless huge squat Fettris	8	decent	
 8543	rotten blinking fusillocybin	3	crappy	
 8544	bland immense special prescription noodles	10	decent	Effect: "Mer-kinny Flavor", Effect Duration: 25
 8545	vaporized purple blood-drive sticker	1	awesome	
@@ -8449,9 +8449,9 @@
 8576	blurry mouldering barrel	0		Last Available: "2015-09"
 8577	blurry barnacled barrel	0		Last Available: "2015-09"
 8578	drinkable bottle of Amontillado	3	good	Last Available: "2015-09"
-8579	tolerable watered-down barrel-aged martini	2	good	Last Available: "2015-09"
+8579	watered-down tolerable barrel-aged martini	2	good	Last Available: "2015-09"
 8580	tasty barrel pickle	4	awesome	Last Available: "2015-09"
-8581	diet delicious narrow barrel cracker	1	awesome	Last Available: "2015-09"
+8581	delicious diet narrow barrel cracker	1	awesome	Last Available: "2015-09"
 8582	boiled yellow vibrating mushroom	1	EPIC	Last Available: "2015-09"
 8583	vaporized mushroom	1	decent	Effect: "Powdered", Effect Duration: 25, Last Available: "2015-09"
 8584	wobbly baleful KoL Con 12-gauge	0		Spell Damage: +25, Last Available: "2015-09"
@@ -8489,9 +8489,9 @@
 8616	warmed cuppa Neuroplastici tea	0		Effect: "Prince of Seaside Town", Effect Duration: 62, Last Available: "2015-09"
 8617	super-moist non-unsweetened cuppa Dexteri tea	0		Effect: "Grumpy and Ornery", Effect Duration: 44, Last Available: "2015-09"
 8618	vacuum-sealed yellow mirror cuppa Flexibili tea	0		Effect: "Prelude of Precision", Effect Duration: 47, Last Available: "2015-09"
-8619	galvanized flattened extra-polarized upside-down twirling cuppa Impregnabili tea	0		Effect: "Chari Tea", Effect Duration: 63, Last Available: "2015-09"
+8619	galvanized flattened extra-polarized twirling upside-down cuppa Impregnabili tea	0		Effect: "Chari Tea", Effect Duration: 63, Last Available: "2015-09"
 8620	dry cuppa Obscuri tea	0		Effect: "Magically Fingered", Effect Duration: 41, Last Available: "2015-09"
-8621	aerosolized tumbling jittery cuppa Irritabili tea	0		Effect: "Net Tea", Effect Duration: 47, Last Available: "2015-09"
+8621	aerosolized jittery tumbling cuppa Irritabili tea	0		Effect: "Net Tea", Effect Duration: 47, Last Available: "2015-09"
 8622	anodized dry cuppa Mediocri tea	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 53, Last Available: "2015-09"
 8623	moist activated cuppa Loyal tea	0		Effect: "Salty Dogs", Effect Duration: 41, Last Available: "2015-09"
 8624	pickled cuppa Activi tea	1	crappy	Last Available: "2015-09"
@@ -8503,20 +8503,20 @@
 8630	Vulcanized ionized cuppa Twen tea	0		Effect: "Spiro Gyro", Effect Duration: 17, Last Available: "2015-09"
 8631	non-boiled chilled spinning cuppa Gill tea	0		Effect: "Powder Power", Effect Duration: 26, Last Available: "2015-09"
 8632	boiled aerosolized tumbling cuppa Uncertain tea	0		Effect: "Gyromitra Gymnastics", Effect Duration: 52, Last Available: "2015-09"
-8633	ghostly shaking cuppa Voraci tea	0		Last Available: "2015-09"
+8633	shaking ghostly cuppa Voraci tea	0		Last Available: "2015-09"
 8634	fuchsia cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
-8636	dry activated cyan blurry cuppa Craft tea	0		Effect: "Spooky Flavor", Effect Duration: 19, Last Available: "2015-09"
+8636	dry activated blurry cyan cuppa Craft tea	0		Effect: "Spooky Flavor", Effect Duration: 19, Last Available: "2015-09"
 8637	super-activated modified maroon cuppa Insani tea	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 17, Last Available: "2015-09"
 8638	ghostly Royal scepter of the dark arts of the empath of horror	0		Spell Damage Percent: +100, Familiar Weight: +5, Spooky Spell Damage: +25, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	enchanted spoiled bowl of eyeballs	4	crappy	Effect: "Neutered Nostrils", Effect Duration: 10, Last Available: "2015-10"
+8641	spoiled enchanted bowl of eyeballs	4	crappy	Effect: "Neutered Nostrils", Effect Duration: 10, Last Available: "2015-10"
 8642	decent diet bowl of mummy guts	1	good	Last Available: "2015-10"
 8643	stale bowl of maggots	4	decent	Last Available: "2015-10"
 8644	tolerable blood and blood	3	good	Last Available: "2015-10"
 8645	aged Jack-O-Lantern beer	4	awesome	Last Available: "2015-10"
-8646	perfectly mixed spirit-forward zombie	5	EPIC	Last Available: "2015-10"
+8646	spirit-forward perfectly mixed zombie	5	EPIC	Last Available: "2015-10"
 8647	red Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	pulsating wind-up spider	0		Last Available: "2015-10"
 8649	tumbling plastic nightmare troll	0		Last Available: "2015-10"
@@ -8531,9 +8531,9 @@
 8658	bouncing Othello's handkerchief of the blizzard	0		Cold Spell Damage: +25, Single Equip
 8659	colloidal shaking bowl of Jeal-O	0		Effect: "Bandersnatched", Effect Duration: 69
 8660	green grip key	0		
-8661	teal blurry How to Play Othello	0		
+8661	blurry teal How to Play Othello	0		
 8662	Da Vinci's sage ghostly dagger of Leguizamo	0		Mysticality Percent: +10, Experience (Mysticality): +5, Monster Level: +20
-8663	weak artisanal ghost beer	2	EPIC	
+8663	artisanal weak ghost beer	2	EPIC	
 8664	fortified Othello set	0		Damage Absorption: +60
 8665	lime green rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8552,14 +8552,14 @@
 8679	occult Wal-Mart snowglobe of Tarzan of the brazier	0		Experience (Muscle): +3, Spell Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2015-11"
 8680	electrified MacGyver's fortified Wal-Mart nametag	0		Damage Absorption: +60, Maximum MP: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8681	bouncing razor-sharp brawny Wal-Mart overalls of the sweet-tooth	0		Muscle Percent: +20, Weapon Damage Percent: +25, Candy Drop: +100, Last Available: "2015-11"
-8682	mirror spinning To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
+8682	spinning mirror To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	foul-smelling bellhop's hat	0		Stench Damage: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	tolerable ice porter	4	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	tolerable ice porter	4	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	quadruple-warmed dry exotic travel brochure	0		Effect: "From Nantucket", Effect Duration: 38, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	altered tumbling wobbly shampoo-conditioner	0		Effect: "Sweet, Nuts", Effect Duration: 23, Last Available: "2015-11"
@@ -8573,7 +8573,7 @@
 8700	teal nippy Rosewater's training legwarmers of the ox	0		Muscle: +20, Mysticality Percent: +30, Cold Damage: +10, Single Equip, Last Available: "2016-01"
 8701	aromatic MacGyver's training helmet of the ox	0		Muscle: +20, Maximum MP: +100, Stench Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
-8703	blinking olive training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
+8703	olive blinking training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	red training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	tumbling machine elf capsule	0		Free Pull, Last Available: "2015-12"
@@ -8582,15 +8582,15 @@
 8709	dehydrated narrow abstraction: thought	1		Last Available: "2015-12"
 8710	dehydrated twirling abstraction: sensation	1		Last Available: "2015-12"
 8711	dried bouncing blinking abstraction: purpose	1		Effect: "Sleazy Hands", Effect Duration: 40, Last Available: "2015-12"
-8712	dehydrated blue twirling abstraction: category	1		Effect: "Empty Inside", Effect Duration: 15, Last Available: "2015-12"
+8712	dehydrated twirling blue abstraction: category	1		Effect: "Empty Inside", Effect Duration: 15, Last Available: "2015-12"
 8713	powdered narrow twirling abstraction: perception	1		Effect: "Chow Downed", Effect Duration: 40, Last Available: "2015-12"
 8714	distilled abstraction: motion	1		Last Available: "2015-12"
-8715	denatured mirror jittery abstraction: joy	1		Last Available: "2015-12"
+8715	denatured jittery mirror abstraction: joy	1		Last Available: "2015-12"
 8716	diluted abstraction: certainty	1		Last Available: "2015-12"
 8717	vaporized abstraction: comprehension	1		Last Available: "2015-12"
 8718	bouncing modern picture frame	0		Last Available: "2015-12"
 8719	massive spoiled wobbly VYKEA meatballs	9	crappy	Last Available: "2015-11"
-8720	acceptable high-proof VYKEA mead	6	good	Last Available: "2015-11"
+8720	high-proof acceptable VYKEA mead	6	good	Last Available: "2015-11"
 8721	galvanized quadruple-alkaline VYKEA woadpaint	0		Effect: "Third Based", Effect Duration: 20, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	shaking ghostly VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,7 +8601,7 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	sinister personal trainer's smooth VYKEA hex key	0		Moxie: +15, Experience Percent (Muscle): +10, Spell Damage: +10, Last Available: "2015-11"
 8730	skewed teal VYKEA instructions	0		Last Available: "2015-11"
-8731	half-sized adequate fuchsia tin of submardines	2	good	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	adequate half-sized fuchsia tin of submardines	2	good	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	smooth twirling bottle of norwhiskey	4	awesome	Last Available: "2015-11"
 8733	altered octolus oculus	1	awesome	Effect: "Dreadful Sheen", Effect Duration: 40, Last Available: "2015-11"
 8734	MacGyver's quilted Fonzie's sardine can key	0		Experience (Moxie): +1, Damage Absorption: +40, Maximum MP: +100, Last Available: "2015-11"
@@ -8611,17 +8611,17 @@
 8738	aged perfect negroni	3	awesome	Last Available: "2015-11"
 8739	drinkable perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	aged practically non-alcoholic perfect mimosa	1	awesome	Last Available: "2015-11"
-8741	weak mediocre special perfect old-fashioned	2	decent	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 10, Last Available: "2015-11"
+8741	special mediocre weak perfect old-fashioned	2	decent	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 10, Last Available: "2015-11"
 8742	delicious perfect paloma	3	awesome	Last Available: "2015-11"
 8743	energized wet shaking narrow That 70s Cologne	0		Effect: "Appeteyes", Effect Duration: 46, Last Available: "2015-11"
 8744	tarnished deionized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Smoky Third Eye", Effect Duration: 13, Last Available: "2015-11"
 8745	irradiated Puffstone cigar	0		Effect: "Jerky, Boy", Effect Duration: 13, Last Available: "2015-11"
 8746	Vulcanized Conspiracy&trade; mascara	0		Effect: "Well-Swabbed Ear", Effect Duration: 65, Last Available: "2015-11"
-8747	boiled pickled boiled squat purple Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Blessing of Charcoatl", Effect Duration: 17, Last Available: "2015-11"
+8747	boiled pickled boiled purple squat Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Blessing of Charcoatl", Effect Duration: 17, Last Available: "2015-11"
 8748	twirling airplane tattoo	0		Last Available: "2015-11"
 8749	dry Deep Machine Tunnels snowglobe	0		Effect: "Punchy, Murdery", Effect Duration: 59, Last Available: "2015-12"
 8750	extra-irradiated blurry twirling hemp candy necklace	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 64, Last Available: "2015-12"
-8751	electrified cold-filtered bouncing narrow maroon communal gobstopper	0		Effect: "Quaaaaaaa", Effect Duration: 22, Last Available: "2015-12"
+8751	electrified cold-filtered narrow maroon bouncing communal gobstopper	0		Effect: "Quaaaaaaa", Effect Duration: 22, Last Available: "2015-12"
 8752	snack-sized fancy decent Crimbo salad	2	good	Effect: "Sappy Blood", Effect Duration: 40, Last Available: "2015-12"
 8753	rotten bread line	3	crappy	Last Available: "2015-12"
 8754	drinkable practically non-alcoholic squat bark rootbeer	1	good	Last Available: "2015-12"
@@ -8654,8 +8654,8 @@
 8782	Sinatra's reindeer hammer	0		Experience (Moxie): +5, Last Available: "2015-12"
 8783	baleful elf ploughshare	0		Spell Damage: +25, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
-8786	spinning cyan faded protest sign	0		Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8786	cyan spinning faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	twirling nasty-smelling moss	0		Last Available: "2015-12"
 8789	book	0		Last Available: "2015-12"
@@ -8678,7 +8678,7 @@
 8806	high-grade explosives	0		Last Available: "2017-01"
 8807	bouncing shaking experimental gene therapy	0		Last Available: "2017-01"
 8808	ultracoagulator	0		Last Available: "2017-01"
-8809	cyan shaking self-defense training	0		Last Available: "2017-01"
+8809	shaking cyan self-defense training	0		Last Available: "2017-01"
 8810	blinking fingerprint dusting kit	0		Last Available: "2017-01"
 8811	huge bouncing confidence-building hug	0		Last Available: "2017-01"
 8812	exploding kickball	0		Last Available: "2017-01"
@@ -8690,13 +8690,13 @@
 8818	lousy bouncing Miss Graves' vermouth	4	decent	Last Available: "2016-12"
 8819	adequate The Plumber's mushroom stew	3	good	Last Available: "2016-12"
 8820	twisted shaking jittery The Author's ink	1		Last Available: "2016-02"
-8821	weak mediocre squat The Mad Liquor	2	decent	Last Available: "2016-12"
+8821	mediocre weak squat The Mad Liquor	2	decent	Last Available: "2016-12"
 8822	perfectly mixed high-proof Doc Clock's thyme cocktail	9	EPIC	Last Available: "2016-12"
-8823	small flavorless cyan pulsating Mr. Burnsger	2	decent	Last Available: "2016-12"
+8823	small flavorless pulsating cyan Mr. Burnsger	2	decent	Last Available: "2016-12"
 8824	altered mirror The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	stanky sharpshooter's grievous The Jokester's gun	0		Weapon Damage Percent: +50, Critical Hit Percent: +10, Stench Spell Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	perfumed gravedigger's vibrating The Jokester's wig	0		Maximum MP Percent: +10, Spooky Damage: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
-8827	sizzling chilly The Jokester's pants of incineration	0		Cold Damage: +5, Hot Damage: +10, Hot Spell Damage: +50, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	stanky sharpshooter's grievous The Jokester's gun	0		Weapon Damage Percent: +50, Critical Hit Percent: +10, Stench Spell Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	perfumed gravedigger's vibrating The Jokester's wig	0		Maximum MP Percent: +10, Spooky Damage: +10, Stench Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	sizzling chilly The Jokester's pants of incineration	0		Cold Damage: +5, Hot Damage: +10, Hot Spell Damage: +50, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	activated tarnished Jokester makeup	0		Effect: "Eau de Tortue", Effect Duration: 39, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8707,7 +8707,7 @@
 8835	lousy pulsating robin nog	4	decent	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	wobbly plaintive telegram	0		Last Available: "2016-02"
-8838	lime green pulsating exploding gum	0		
+8838	pulsating lime green exploding gum	0		
 8839	root beer barrel	0		
 8840	ionized anodized teal Kudzu slaw	0		Effect: "Ancestral Disapproval", Effect Duration: 46
 8841	flattened purple Mansquito's blood	0		Effect: "Eye of the Seal", Effect Duration: 45
@@ -8719,7 +8719,7 @@
 8847	dry activated red-hot jawbreaker	0		Effect: "Berry Thorny", Effect Duration: 35
 8848	concentrated flattened twirling question juice	0		Effect: "Dreadful Smell", Effect Duration: 19
 8849	oxidized cold-filtered spinning tube of villain	0		Effect: "Conspiratory Eyes", Effect Duration: 46
-8850	wholesome your cowboy boots	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	wholesome your cowboy boots	0		Maximum HP Percent: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	tumbling inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	twirling nugget of quicksilver	0		Last Available: "2016-02"
 8853	upside-down nugget of thicksilver	0		Last Available: "2016-02"
@@ -8750,7 +8750,7 @@
 8878	moldy plate of Mixed Garbanzos and Chickpeas	3	crappy	Last Available: "2016-02"
 8879	decent miniature plate of Hellfire Spicy Beans	2	good	Last Available: "2016-02"
 8880	normal tiny narrow plate of Frigid Northern Beans	1	good	Last Available: "2016-02"
-8881	fancy moldy plate of World's Blackest-Eyed Peas	3	crappy	Effect: "Wallflowering", Effect Duration: 50, Last Available: "2016-02"
+8881	moldy fancy plate of World's Blackest-Eyed Peas	3	crappy	Effect: "Wallflowering", Effect Duration: 50, Last Available: "2016-02"
 8882	small adequate plate of Trader Olaf's Exotic Stinkbeans	2	good	Last Available: "2016-02"
 8883	snack-sized spoiled plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
 8884	rotten shaking plate of Val-U Brand Every Bean Salad	3	crappy	Last Available: "2016-02"
@@ -8774,13 +8774,13 @@
 8902	boiled altered enhanced ghost bit	0		Effect: "Rampage!", Effect Duration: 39, Last Available: "2016-02"
 8903	diffused colloidal diffused spinning buzzard feather	0		Effect: "Preternatural Greed", Effect Duration: 59, Last Available: "2016-02"
 8904	energized energized gray lion musk	0		Effect: "Eyes Wide Propped", Effect Duration: 39, Last Available: "2016-02"
-8905	enchanted toothsome bear claw	4	awesome	Effect: "Heart of Green", Effect Duration: 30, Last Available: "2016-02"
+8905	toothsome enchanted bear claw	4	awesome	Effect: "Heart of Green", Effect Duration: 30, Last Available: "2016-02"
 8906	adjusted ionized double-enhanced bouncing rattler gland	0		Effect: "Mint-Condition Breath", Effect Duration: 52, Last Available: "2016-02"
-8907	altered pulsating olive half-digested coal	0		Effect: "Saucefingers", Effect Duration: 65, Last Available: "2016-02"
+8907	altered olive pulsating half-digested coal	0		Effect: "Saucefingers", Effect Duration: 65, Last Available: "2016-02"
 8908	warmed triple-activated tightly-wound spine	0		Effect: "Disco Inferno", Effect Duration: 13, Last Available: "2016-02"
 8909	flavorless rotting beefsteak	4	decent	Last Available: "2016-02"
 8910	lousy firemilk	4	decent	Last Available: "2016-02"
-8911	alkaline magnetized maroon huge huge spidercow eye-cluster	0		Effect: "Strength of Ten Ettins", Effect Duration: 22, Last Available: "2016-02"
+8911	alkaline magnetized huge huge maroon spidercow eye-cluster	0		Effect: "Strength of Ten Ettins", Effect Duration: 22, Last Available: "2016-02"
 8912	twisted moomy dust	1		Last Available: "2016-02"
 8913	narrow greasy frosty western-style skinning knife	0		Cold Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2016-02"
 8914	bouncing reliable sixgun	0		Last Available: "2016-02"
@@ -8796,9 +8796,9 @@
 8924	disc (black)	0		
 8925	disc (red)	0		
 8926	bouncing disc (green)	0		
-8927	twirling bouncing disc (blue)	0		
+8927	bouncing twirling disc (blue)	0		
 8928	yellow disc (yellow)	0		
-8929	skewed tumbling red-hot knucklebone	0		Last Available: "2016-02"
+8929	tumbling skewed red-hot knucklebone	0		Last Available: "2016-02"
 8930	alkaline twirling gray demonic cow's blood	0		Effect: "Turtle Power", Effect Duration: 34, Last Available: "2016-02"
 8931	olive tumbling rinky-dink sixgun	0		Last Available: "2016-02"
 8932	blinking makeshift sixgun	0		Last Available: "2016-02"
@@ -8842,7 +8842,7 @@
 8970	narrow toy sixgun	0		
 8971	snake oil	0		
 8972	pressed bouncing skin oil	0		Effect: "Thickest, Sickest", Effect Duration: 68
-8973	tarnished triple-anodized wobbly blinking unusual oil	0		Effect: "Thought", Effect Duration: 30
+8973	tarnished triple-anodized blinking wobbly unusual oil	0		Effect: "Thought", Effect Duration: 30
 8974	colloidal frozen shaking eldritch oil	0		Effect: "Squid Squint", Effect Duration: 34
 8975	shaking exclusive club	0		
 8976	quantum energized super-modified patent preventative tonic	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 36
@@ -8862,8 +8862,8 @@
 8990	bouncing electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	modified spinning green armored prawn	1		Effect: "Phairly Balanced", Effect Duration: 45, Last Available: "2016-03"
-8993	gigantic adequate skewed jumping horseradish	9	good	Last Available: "2016-03"
-8994	boozy lousy skewed fuchsia Sacramento wine	5	decent	Last Available: "2016-03"
+8993	adequate gigantic skewed jumping horseradish	9	good	Last Available: "2016-03"
+8994	lousy boozy skewed fuchsia Sacramento wine	5	decent	Last Available: "2016-03"
 8995	modified electrified green Greek fire	0		Effect: "Glo-Face", Effect Duration: 60, Last Available: "2016-03"
 8996	zippy Jeselnik's smelly sharpshooter's ox-head shield of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +10, Stench Spell Damage: +10, Sleaze Damage: +25, Initiative: +20, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	censurious family-friendly Van der Graaf Oprah's dented scepter of the overflowing toilet	0		Maximum MP Percent: +50, Stench Spell Damage: +50, Sleaze Resistance: 4, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8877,7 +8877,7 @@
 9005	gray squat narrow groovy fish hatchet of Leguizamo of the sewer of courage	0		Moxie Percent: +10, Monster Level: +20, Stench Damage: +25, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9006	scandalous coward's resourceful beefy tunac	0		Muscle: +10, Maximum MP: +50, Monster Level: -20, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2016-04"
 9007	twirling fishin' pole	0		Last Available: "2016-04"
-9008	flattened adjusted narrow blurry yellow wriggling worm	0		Effect: "Shamboozled", Effect Duration: 21, Last Available: "2016-04"
+9008	flattened adjusted yellow blurry narrow wriggling worm	0		Effect: "Shamboozled", Effect Duration: 21, Last Available: "2016-04"
 9009	lousy bottle of Fishhead 900-Day IPA	4	decent	Last Available: "2016-04"
 9010	tarnished diffused skewed high-test fishing line	0		Effect: "Concentration", Effect Duration: 49, Last Available: "2016-04"
 9011	shaking spinning strapping fishin' hat	0		Muscle: +5, Last Available: "2016-04"
@@ -8904,7 +8904,7 @@
 9032	moldy narrow bowl of Tastee-Wheet&trade;	3	crappy	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
-9035	super-sized stale ghostly browser cookie	5	decent	Last Available: "2016-06"
+9035	stale super-sized ghostly browser cookie	5	decent	Last Available: "2016-06"
 9036	tolerable hacked gibson	4	good	Last Available: "2016-06"
 9037	green baleful Source shades	0		Spell Damage: +25, Last Available: "2016-06"
 9038	cyan jittery software bug	0		Last Available: "2016-06"
@@ -8922,7 +8922,7 @@
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
 9051	Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	upside-down Source terminal file: damage.enh	0		Last Available: "2016-06"
-9053	squat yellow Source terminal file: critical.enh	0		Last Available: "2016-06"
+9053	yellow squat Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	purple Source terminal file: protect.enq	0		Last Available: "2016-06"
 9055	blinking Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	polarized shoe gum	0		Effect: "Perfect Hair", Effect Duration: 53, Last Available: "2016-07"
 9076	fuchsia fortified boxer's noir fedora of the scaredy-cat	0		Muscle Percent: +10, Damage Absorption: +60, Monster Level: -15, Last Available: "2016-07"
 9077	purple chilly MacGyver's ruddy trench coat	0		Maximum HP Percent: +40, Maximum MP: +100, Cold Damage: +5, Last Available: "2016-07"
-9078	acceptable weak narrow Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
-9079	low-calorie bland spinning hardboiled egg	1	decent	Last Available: "2016-07"
+9078	weak acceptable narrow Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
+9079	bland low-calorie spinning hardboiled egg	1	decent	Last Available: "2016-07"
 9080	spinning detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	lightning-fast gravedigger's energetic padded experienced wizardly protonic accelerator pack	0		Mysticality: +25, Experience: +2, Damage Absorption: +20, Maximum MP Percent: +20, Spooky Damage: +10, Initiative: +40, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	lightning-fast gravedigger's energetic padded experienced wizardly protonic accelerator pack	0		Mysticality: +25, Experience: +2, Damage Absorption: +20, Maximum MP Percent: +20, Spooky Damage: +10, Initiative: +40, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	blurry prompt Adventurer bobblehead	0		Adventures: +3, Last Available: "2016-11"
 9085	pulsating psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	executive Sherlock's Spookyraven signet of the early riser	0		Item Drop: +25, Meat Drop: +40, Adventures: +7, Single Equip, Last Available: "2016-08"
 9093	rosewater-soaked banded tie-dyed fannypack	0		Damage Absorption: +100, Stench Resistance: +3, Single Equip, Last Available: "2016-08"
 9094	flame-wreathed savvy burnt snowpants	0		Mysticality Percent: +20, Hot Spell Damage: +10, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	wholesome standards and practices guide	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9095	wholesome standards and practices guide	0		Maximum HP Percent: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	flame-wreathed dance instructor's arcane researcher's Carpathian longsword	0		Experience Percent (Mysticality): +10, Experience Percent (Moxie): +10, Hot Spell Damage: +10, Last Available: "2016-08"
 9097	bouncing veiny beefy Liam's mail of the scaredy-cat	0		Muscle: +10, Maximum HP: +10, Monster Level: -15, Last Available: "2016-08"
 9098	baleful cool Unfortunato's foolscap of the cheetah	0		Moxie: +5, Spell Damage: +25, Initiative: +60, Last Available: "2016-08"
@@ -8993,28 +8993,28 @@
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
-9124	narrow blinking baby bark scorpion	0		
+9124	blinking narrow baby bark scorpion	0		
 9125	bouncing droppable microphone	0		
-9126	hand-crafted jittery bouncing unidentified drink	3	EPIC	
+9126	hand-crafted bouncing jittery unidentified drink	3	EPIC	
 9127	wicked Da Vinci's KoL Con 13 T-shirt	0		Experience (Mysticality): +5, Spell Damage: +5
 9128	manspreader's studded discarded swimming trunks of the pedagogue	0		Experience: +3, Damage Absorption: +80, Monster Level: +10
-9129	adjusted unsweetened huge tumbling diluted makeup	0		Effect: "Cock of the Walk", Effect Duration: 68
+9129	adjusted unsweetened tumbling huge diluted makeup	0		Effect: "Cock of the Walk", Effect Duration: 68
 9130	adjusted nitrogenated upside-down charisma potion	0		Effect: "Turkey-Friendly", Effect Duration: 24
 9131	bouncing extremely confusing manual	0		
 9132	narrow inspector's pistol of the empath	0		Familiar Weight: +5, Item Drop: +15
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	moldy shaking leftover pasty	4	crappy	
-9135	mediocre spirit-forward enchanted very whiskey	5	decent	Effect: "It's Soporiffic!", Effect Duration: 40
+9135	spirit-forward enchanted mediocre very whiskey	5	decent	Effect: "It's Soporiffic!", Effect Duration: 40
 9136	huge li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	blinking squat li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	squat blinking li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9144	upside-down green li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	squat tumbling teal li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	tumbling teal squat li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	quadruple-tarnished altered huge hoarded candy wad	0		Effect: "Reptilian Fortitude", Effect Duration: 16, Last Available: "2016-10"
 9147	polarized magnetized Prunets	0		Effect: "Twinkly Weapon", Effect Duration: 26
 9148	Twitching Television Tattoo	0		
@@ -9022,14 +9022,14 @@
 9150	dry invisible string	0		Lasts Until Rollover, Effect: "Badger Underfoot", Effect Duration: 14, Last Available: "2016-10"
 9151	altered cold-filtered pulsating squat invisible seam ripper	0		Lasts Until Rollover, Effect: "Work For Hours a Week", Effect Duration: 50, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	adequate low-calorie raw sweet potato	1	good	Last Available: "2016-11"
+9153	low-calorie adequate raw sweet potato	1	good	Last Available: "2016-11"
 9154	tasty raw beans	3	awesome	Last Available: "2016-11"
 9155	stale raw stuffing	3	decent	Last Available: "2016-11"
-9156	rotten small raw cranberry sauce	2	crappy	Last Available: "2016-11"
+9156	small rotten raw cranberry sauce	2	crappy	Last Available: "2016-11"
 9157	stale raw turkey	4	decent	Last Available: "2016-11"
 9158	moldy huge raw mincemeat	9	crappy	Last Available: "2016-11"
 9159	bland enchanted gigantic raw potato	9	decent	Effect: "So Fresh and So Clean", Effect Duration: 15, Last Available: "2016-11"
-9160	huge toothsome raw gravy	7	awesome	Last Available: "2016-11"
+9160	toothsome huge raw gravy	7	awesome	Last Available: "2016-11"
 9161	spoiled raw bread	3	crappy	Last Available: "2016-11"
 9162	maroon beefy mini-marshmallow dispenser of the ox	0		Muscle: 30, Last Available: "2016-11"
 9163	spinning sharpshooter's glass casserole dish of the wise owl of the sewer	0		Mysticality: +20, Critical Hit Percent: +10, Stench Damage: +25, Last Available: "2016-11"
@@ -9040,16 +9040,16 @@
 9168	tumbling hale potato masher of the businessman	0		Maximum HP: +20, Meat Drop: +50, Last Available: "2016-11"
 9169	shaking gravy boat	0		Last Available: "2016-11"
 9170	mirror bread mold	0		Last Available: "2016-11"
-9171	stale diet sweet potatoes	1	decent	Last Available: "2016-11"
+9171	diet stale sweet potatoes	1	decent	Last Available: "2016-11"
 9172	moldy yellow wobbly bean casserole	4	crappy	Last Available: "2016-11"
 9173	spoiled baked stuffing	3	crappy	Last Available: "2016-11"
 9174	rotten cranberry cylinder	4	crappy	Last Available: "2016-11"
 9175	yummy tumbling thanksgiving turkey	4	awesome	Last Available: "2016-11"
 9176	stale tiny upside-down mince pie	1	decent	Last Available: "2016-11"
-9177	special huge normal mashed potatoes	7	good	Effect: "Unrunnable Face", Effect Duration: 5, Last Available: "2016-11"
+9177	normal special huge mashed potatoes	7	good	Effect: "Unrunnable Face", Effect Duration: 5, Last Available: "2016-11"
 9178	small flavorless warm gravy	2	decent	Last Available: "2016-11"
 9179	moldy bread roll	4	crappy	Last Available: "2016-11"
-9180	half-sized adequate leftovers	2	good	Last Available: "2016-11"
+9180	adequate half-sized leftovers	2	good	Last Available: "2016-11"
 9181	decent teal leftovers sandwich	3	good	Last Available: "2016-11"
 9182	olive Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9061,7 +9061,7 @@
 9189	narrow Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	jittery eldritch effluvium	0		
 9191	liquefied flattened eldritch concentrate	0		Effect: "Spiritually Awake", Effect Duration: 66, Last Available: "2016-11"
-9192	perfectly mixed blinking jittery eldritch extract	4	EPIC	Last Available: "2016-11"
+9192	perfectly mixed jittery blinking eldritch extract	4	EPIC	Last Available: "2016-11"
 9193	sizzling supercharged Official Council Aide Pin	0		Maximum MP Percent: +30, Hot Damage: +10, Last Available: "2016-11"
 9194	acceptable watered-down pulsating eldritch distillate	2	good	Last Available: "2016-11"
 9195	dehydrated eldritch essence	1		Last Available: "2016-11"
@@ -9071,7 +9071,7 @@
 9199	practically non-alcoholic drinkable eldritch elixir	1	good	Last Available: "2016-11"
 9200	pulsating gravedigger's Quartet of Flare Masters Jacket of the glutton	0		Spooky Damage: +10, Food Drop: +100, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
-9202	jittery ghostly Adventurer's Kit	0		
+9202	ghostly jittery Adventurer's Kit	0		
 9203	bouncing Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	purple counterfeit city	0		Last Available: "2016-12"
 9205	tumbling sprinkles	0		Last Available: "2016-12"
@@ -9090,7 +9090,7 @@
 9218	upside-down sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	normal animal part cracker	4	good	Last Available: "2016-12"
 9220	mediocre watered-down spinning gingerbread wine	2	decent	Last Available: "2016-12"
-9221	flavorless huge gingerbread mug	9	decent	Last Available: "2016-12"
+9221	huge flavorless gingerbread mug	9	decent	Last Available: "2016-12"
 9222	upside-down boxer's gingerbread mask	0		Muscle Percent: +10, Last Available: "2016-12"
 9223	sharpshooter's razor-sharp gingerservo of the businessman	0		Weapon Damage Percent: +25, Critical Hit Percent: +10, Meat Drop: +50, Single Equip, Last Available: "2016-12"
 9224	energized aerosolized liquefied spinning tainted icing	0		Effect: "Mucilaginous Muscle", Effect Duration: 21, Last Available: "2016-12"
@@ -9124,13 +9124,13 @@
 9252	spoiled spiritual candy cane	3	crappy	Last Available: "2016-12"
 9253	delicious fancy spiritual eggnog	4	awesome	Effect: "Supafly", Effect Duration: 45, Last Available: "2016-12"
 9254	stale pulsating spiritual fruitcake	3	decent	Last Available: "2016-12"
-9255	small moldy spiritual gingerbread	2	crappy	Last Available: "2016-12"
+9255	moldy small spiritual gingerbread	2	crappy	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
-9257	skewed tumbling chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
+9257	tumbling skewed chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
-9261	pulsating skewed maroon Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
+9261	maroon skewed pulsating Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	fruit-leather negatives	0		Last Available: "2016-12"
 9263	gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	blinking briefcase full of sprinkles	0		Last Available: "2016-12"
@@ -9145,7 +9145,7 @@
 9273	vibrating healthy Third Eye	0		Maximum HP Percent: +20, Maximum MP Percent: +10, Last Available: "2016-12"
 9274	nasty Krampus Horn of James Dean	0		Experience (Moxie): +3, Stench Damage: +5, Single Equip, Last Available: "2016-12"
 9275	decent hambrosier	3	good	Last Available: "2016-12"
-9276	practically non-alcoholic artisanal twirling chakra-mental wine	1	super ultra mega turbo EPIC	Last Available: "2016-12"
+9276	artisanal practically non-alcoholic twirling chakra-mental wine	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 9277	aerosolized chakra malt	0		Effect: "Weird Vibrations", Effect Duration: 13, Last Available: "2016-12"
 9278	low-calorie decent Black Angus blackburger	1	good	Last Available: "2016-12"
 9279	watered-down lousy tumbling brandy	2	decent	Last Available: "2016-12"
@@ -9160,7 +9160,7 @@
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	yellow brawny weightlifter's Uncle Crimbo's hat of the pedagogue	0		Muscle: +15, Muscle Percent: +20, Experience: +3, Last Available: "2016-12"
 9290	rotten big Eldritch snap	5	crappy	Last Available: "2017-01"
-9291	powdered mirror blinking hot jelly	1		Effect: "The Style... of the Future", Effect Duration: 20, Last Available: "2017-01"
+9291	powdered blinking mirror hot jelly	1		Effect: "The Style... of the Future", Effect Duration: 20, Last Available: "2017-01"
 9292	compressed fuchsia squat jelly	1		Last Available: "2017-01"
 9293	altered jelly	1		Effect: "Taurus Rising", Effect Duration: 15, Last Available: "2017-01"
 9294	pickled skewed sleaze jelly	1		Effect: "Hot Buttoned", Effect Duration: 15, Last Available: "2017-01"
@@ -9169,14 +9169,14 @@
 9297	toothsome diet toast with hot jelly	1	awesome	Last Available: "2017-01"
 9298	adequate mirror toast with jelly	3	good	Last Available: "2017-01"
 9299	jumbo adequate toast with jelly	5	good	Last Available: "2017-01"
-9300	decent super-sized toast with sleaze jelly	5	good	Last Available: "2017-01"
+9300	super-sized decent toast with sleaze jelly	5	good	Last Available: "2017-01"
 9301	moldy toast with stench jelly	3	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	wobbly hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	supercharged wax hand of horror	0		Maximum MP Percent: +30, Spooky Spell Damage: +25, Last Available: "2017-01"
 9306	Oprah's cool candle	0		Moxie: +5, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2017-01"
-9307	normal diet skewed bouncing wax pancake	1	good	Last Available: "2017-01"
+9307	diet normal bouncing skewed wax pancake	1	good	Last Available: "2017-01"
 9308	miser's wax face of Flo-Jo	0		Meat Drop: +10, Initiative: +100, Last Available: "2017-01"
 9309	tolerable mirror wax booze	4	good	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
@@ -9199,12 +9199,12 @@
 9327	LOV Elephant of dire peril	0		Weapon Damage: +20, Damage Reduction: 6, Last Available: "2017-02"
 9328	fortified eldritch scanner	0		Damage Absorption: +60, Last Available: "2017-02"
 9329	magnetized eldritch alignment spray	0		Effect: "Loco Motives", Effect Duration: 41, Last Available: "2017-02"
-9330	teal squat LOV Entrance Pass	0		Last Available: "2017-02"
+9330	squat teal LOV Entrance Pass	0		Last Available: "2017-02"
 9331	dangerous beefcake's eldritch hammer of the dark arts	0		Muscle: +25, Weapon Damage: +10, Spell Damage Percent: +100, Last Available: "2017-01"
 9332	spoiled immense blurry eldritch mushroom	9	crappy	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	stale snack-sized jittery pulsating purple eldritch mushroom pizza	2	decent	Last Available: "2017-03"
-9335	green pulsating eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
+9334	snack-sized stale pulsating purple jittery eldritch mushroom pizza	2	decent	Last Available: "2017-03"
+9335	pulsating green eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	deionized aerosolized narrow eldritch rub	0		Effect: "You're High as a Crow, Marty", Effect Duration: 46, Last Available: "2017-02"
 9338	HP-35 Calculator	0		
@@ -9216,7 +9216,7 @@
 9344	discarded button	0		
 9345	Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
-9347	skewed fuchsia twirling pickled grasshopper	0		Last Available: "2017-03"
+9347	twirling fuchsia skewed pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	elemental sugarcube	0		Last Available: "2017-03"
@@ -9234,21 +9234,21 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	shaking slime shooter	0		Last Available: "2017-03"
 9364	purple imaginary lemon	0		Last Available: "2017-03"
-9365	acceptable watered-down literal grasshopper	2	good	Last Available: "2017-03"
+9365	watered-down acceptable literal grasshopper	2	good	Last Available: "2017-03"
 9366	mediocre double entendre	4	decent	Last Available: "2017-03"
 9367	perfectly mixed boozy Phlegethon	5	EPIC	Last Available: "2017-03"
 9368	triple-distilled artisanal Siberian sunrise	10	EPIC	Last Available: "2017-03"
-9369	weak perfectly mixed mentholated wine	2	EPIC	Last Available: "2017-03"
+9369	perfectly mixed weak mentholated wine	2	EPIC	Last Available: "2017-03"
 9370	lousy bouncing low tide martini	3	decent	Last Available: "2017-03"
 9371	aged shroomtini	4	awesome	Last Available: "2017-03"
 9372	spirit-forward lousy mirror morning dew	5	decent	Last Available: "2017-03"
 9373	artisanal whiskey squeeze	3	EPIC	Last Available: "2017-03"
 9374	mediocre strong wobbly great fashioned	5	decent	Last Available: "2017-03"
-9375	weak fancy bad spinning Gnomish sagngria	2	decent	Effect: "Charrrming", Effect Duration: 40, Last Available: "2017-03"
+9375	bad weak fancy spinning Gnomish sagngria	2	decent	Effect: "Charrrming", Effect Duration: 40, Last Available: "2017-03"
 9376	fancy drinkable vodka stinger	4	good	Effect: "Cotton Mouthed", Effect Duration: 15, Last Available: "2017-03"
 9377	tolerable triple-distilled extremely slippery nipple	10	good	Last Available: "2017-03"
 9378	watered-down tolerable piscatini	2	good	Last Available: "2017-03"
-9379	acceptable practically non-alcoholic Churchill	1	good	Last Available: "2017-03"
+9379	practically non-alcoholic acceptable Churchill	1	good	Last Available: "2017-03"
 9380	weak bad ghostly soilzerac	2	decent	Last Available: "2017-03"
 9381	acceptable London frog	3	good	Last Available: "2017-03"
 9382	drinkable watered-down nothingtini	2	good	Last Available: "2017-03"
@@ -9257,19 +9257,19 @@
 9385	bad reverse Tantalus	3	decent	Last Available: "2017-03"
 9386	tolerable wobbly elemental caipiroska	4	good	Last Available: "2017-03"
 9387	lousy twirling Feliz Navidad	3	decent	Last Available: "2017-03"
-9388	watered-down artisanal Bloody Nora	2	EPIC	Last Available: "2017-03"
+9388	artisanal watered-down Bloody Nora	2	EPIC	Last Available: "2017-03"
 9389	bad practically non-alcoholic moreltini	1	decent	Last Available: "2017-03"
-9390	watered-down delicious olive hell in a bucket	2	awesome	Last Available: "2017-03"
-9391	watered-down artisanal Newark	2	EPIC	Last Available: "2017-03"
-9392	tolerable high-proof blinking R'lyeh	8	good	Last Available: "2017-03"
+9390	delicious watered-down olive hell in a bucket	2	awesome	Last Available: "2017-03"
+9391	artisanal watered-down Newark	2	EPIC	Last Available: "2017-03"
+9392	high-proof tolerable blinking R'lyeh	8	good	Last Available: "2017-03"
 9393	mediocre weak Gnollish sangria	2	decent	Last Available: "2017-03"
-9394	enchanted boozy drinkable vodka barracuda	5	good	Effect: "Petit Forbearance", Effect Duration: 5, Last Available: "2017-03"
+9394	boozy enchanted drinkable vodka barracuda	5	good	Effect: "Petit Forbearance", Effect Duration: 5, Last Available: "2017-03"
 9395	tolerable Mysterious Island iced tea	3	good	Last Available: "2017-03"
 9396	mediocre red drive-by shooting	3	decent	Last Available: "2017-03"
-9397	artisanal fancy gunner's daughter	3	EPIC	Effect: "Dances with Tweedles", Effect Duration: 5, Last Available: "2017-03"
+9397	fancy artisanal gunner's daughter	3	EPIC	Effect: "Dances with Tweedles", Effect Duration: 5, Last Available: "2017-03"
 9398	drinkable dirt julep	4	good	Last Available: "2017-03"
 9399	smooth watered-down Simepore slime	2	awesome	Last Available: "2017-03"
-9400	high-proof smooth Phil Collins	6	awesome	Last Available: "2017-03"
+9400	smooth high-proof Phil Collins	6	awesome	Last Available: "2017-03"
 9401	red unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	flavorless small blue edible alien plant bit	2	decent	Last Available: "2017-04"
+9415	small flavorless blue edible alien plant bit	2	decent	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	pulsating complex alien plant sample	0		Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	narrow inspector's knitted murderbot mask of the bloodbag	0		Maximum HP: +100, Cold Resistance: +3, Item Drop: +15, Avatar: "Murderbot", Last Available: "2017-04"
 9454	anodized moist lime green murderbot spring injector	0		Effect: "Horrid, Torrid", Effect Duration: 41, Last Available: "2017-04"
 9455	ribald fortified murderbot whip	0		Damage Absorption: +60, Sleaze Damage: +10, Last Available: "2017-04"
-9456	vibrating hardened murderbot plasma rifle	0		Damage Reduction: 3, Maximum MP Percent: +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	vibrating hardened murderbot plasma rifle	0		Damage Reduction: 3, Maximum MP Percent: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	blinking space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9349,7 +9349,7 @@
 9477	jittery Spacegate (open)	0		Lasts Until Rollover
 9478	blue New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	quantum Daily Affirmation: Always be Collecting	0		Effect: "Venomous Weapon", Effect Duration: 63, Last Available: "2017-05"
-9480	dry liquefied irradiated squat jittery huge Daily Affirmation: Think Win-Lose	0		Effect: "Third Based", Effect Duration: 55, Last Available: "2017-05"
+9480	dry liquefied irradiated jittery huge squat Daily Affirmation: Think Win-Lose	0		Effect: "Third Based", Effect Duration: 55, Last Available: "2017-05"
 9481	flattened deionized upside-down Daily Affirmation: Be Superficially interested	0		Effect: "Stinkybeard", Effect Duration: 26, Last Available: "2017-05"
 9482	moist denatured Daily Affirmation: Adapt to Change Eventually	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 25, Last Available: "2017-05"
 9483	Vulcanized corrupted spinning Daily Affirmation: Be a Mind Master	0		Effect: "Coal-Powered", Effect Duration: 64, Last Available: "2017-05"
@@ -9359,10 +9359,10 @@
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	bouncing Victor's Spoils	0		
-9490	nitrogenated altered yellow blinking Threatening Missive	0		Effect: "Brain Freeze", Effect Duration: 68
+9490	nitrogenated altered blinking yellow Threatening Missive	0		Effect: "Brain Freeze", Effect Duration: 68
 9491	narrow Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	nasty wholesome dance instructor's Kremlin's Greatest Briefcase	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	nasty wholesome dance instructor's Kremlin's Greatest Briefcase	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Stench Damage: +5, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	lousy basic martini	3	decent	Last Available: "2017-06"
 9495	hand-crafted improved martini	4	EPIC	Last Available: "2017-06"
 9496	perfectly mixed splendid martini	4	EPIC	Last Available: "2017-06"
@@ -9414,15 +9414,15 @@
 9542	bouncing exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	jittery upside-down X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	extra-dry tolerable wobbly DUFRESNE Suds	5	good	Last Available: "2017-09"
+9545	tolerable extra-dry wobbly DUFRESNE Suds	5	good	Last Available: "2017-09"
 9546	hale arcane researcher's mafia pinky ring	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Single Equip
 9547	enchanted tolerable lime green flask of port	4	good	Effect: "Aquarius Rising", Effect Duration: 30
 9548	spinning blue lion tamer's occult contract enforcement stick	0		Spell Damage Percent: +25, Experience (familiar): +2
-9549	yummy snack-sized Hide-rox&trade; cookie	2	awesome	Last Available: "2017-10"
-9550	fortified tolerable bouncing jug of booze	5	good	Last Available: "2017-10"
+9549	snack-sized yummy Hide-rox&trade; cookie	2	awesome	Last Available: "2017-10"
+9550	tolerable fortified bouncing jug of booze	5	good	Last Available: "2017-10"
 9551	quadruple-colloidal huge pair of candy glasses	0		Effect: "Brother Corsican's Blessing", Effect Duration: 12, Last Available: "2017-10"
 9552	energized frozen skewed temporary X tattoos	0		Effect: "Fungal Flambé", Effect Duration: 45, Last Available: "2017-10"
-9553	powdered purple jittery glyph of athleticism	1		Last Available: "2017-10"
+9553	powdered jittery purple glyph of athleticism	1		Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	flattened moist corrupted blinking new habit	0		Effect: "Stogied", Effect Duration: 64, Last Available: "2017-10"
 9556	squat bridge truss	0		Last Available: "2017-10"
@@ -9453,8 +9453,8 @@
 9581	mediocre neg grog	3	decent	Last Available: "2017-12"
 9582	adequate half double fruitcake	4	good	Last Available: "2017-12"
 9583	normal skewed hushed puppy	3	good	Last Available: "2017-12"
-9584	special snack-sized bland muffled muffuletta	2	decent	Effect: "Goldentongue", Effect Duration: 30, Last Available: "2017-12"
-9585	miniature normal shushed potatoes	2	good	Last Available: "2017-12"
+9584	bland special snack-sized muffled muffuletta	2	decent	Effect: "Goldentongue", Effect Duration: 30, Last Available: "2017-12"
+9585	normal miniature shushed potatoes	2	good	Last Available: "2017-12"
 9586	gravedigger's plastic mime functionary	0		Spooky Damage: +10, Last Available: "2017-12"
 9587	knitted plastic mime scientist	0		Cold Resistance: +3, Last Available: "2017-12"
 9588	olive wicked plastic mime soldier	0		Spell Damage: +5, Last Available: "2017-12"
@@ -9467,7 +9467,7 @@
 9595	hand-crafted Racisto Ruidoso	3	super ultra mega turbo EPIC	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	rotten cyan bran muffin	3	crappy	
-9598	moldy small blueberry muffin	2	crappy	
+9598	small moldy blueberry muffin	2	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	squat fuchsia silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9499,12 +9499,12 @@
 9627	squat spinning warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	acceptable stale cheer wine	4	good	Last Available: "2017-12"
-9630	thick moldy jittery blurry stale Cheer-E-Os	5	crappy	Last Available: "2017-12"
+9630	moldy thick jittery blurry stale Cheer-E-Os	5	crappy	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	spinning Sherlock's foul-smelling cheerful antler hat	0		Stench Damage: +10, Item Drop: +25, Last Available: "2017-12"
 9633	brawny brainy cheerful Crimbo sweater	0		Mysticality: +5, Muscle Percent: +20, Last Available: "2017-12"
 9634	cyan medical-grade arcane researcher's cheerful pajama pants	0		Experience Percent (Mysticality): +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-12"
-9635	blurry purple The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9635	purple blurry The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9636	The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
@@ -9522,7 +9522,7 @@
 9650	hand-crafted nega-mushroom wine	4	EPIC	Last Available: "2017-12"
 9651	improved Cheer-Up soda	0		Effect: "Toothy Grin", Effect Duration: 20, Last Available: "2017-12"
 9652	flavorless mime army rations	3	decent	Last Available: "2017-12"
-9653	lousy jittery narrow mime army wine	3	decent	Last Available: "2017-12"
+9653	lousy narrow jittery mime army wine	3	decent	Last Available: "2017-12"
 9654	twisted mime army superserum	1		Last Available: "2017-12"
 9655	quadruple-diffused mirror cyan mime army camouflage kit	0		Effect: "Punch Another Day", Effect Duration: 31, Last Available: "2017-12"
 9656	miser's dangerous miming beret	0		Weapon Damage: +10, Meat Drop: +10, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	bouncing donated candy	0		
 9665	super-adjusted spinning digital honeypot	0		Effect: "Square to be Hip", Effect Duration: 35, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	sinister mime army insignia (intelligence)	0		Spell Damage: +10, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	mime army insignia (espionage) of the ox	0		Muscle: +20, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	mime army insignia (infantry) of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	sinister mime army insignia (intelligence)	0		Spell Damage: +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	mime army insignia (espionage) of the ox	0		Muscle: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	jittery jittery mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9546,11 +9546,11 @@
 9674	mime army insignia (morale)	0		Single Equip, Last Available: "2017-12"
 9675	educational mime army infiltration glove of temperance	0		Experience: +1, Sleaze Resistance: +5, Single Equip, Last Available: "2017-12"
 9676	mime army shotglass	0		Last Available: "2017-12"
-9677	wobbly ghostly red mime army challenge coin	0		Last Available: "2017-12"
+9677	ghostly red wobbly mime army challenge coin	0		Last Available: "2017-12"
 9678	cheer extractor	0		Last Available: "2017-12"
 9679	tumbling kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	ghostly fireproof skip lid	0		Familiar Weight: +5
-9681	moldy small yellow extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
+9681	small moldy yellow extra-toasted half sandwich	2	crappy	Last Available: "2018-12"
 9682	tolerable mulled hobo wine	4	good	Last Available: "2018-12"
 9683	blinking burning newspaper	0		Last Available: "2018-12"
 9684	upside-down greasy Jack Frost's burning paper hat of the businessman	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-12"
@@ -9575,11 +9575,11 @@
 9703	modified beefy pill	1		
 9704	modified yellow excitement pill	1		
 9705	powdered vitamin G pill	1		
-9706	mixed jittery yellow tumbling lucky-ish pill	1		
+9706	mixed yellow tumbling jittery lucky-ish pill	1		
 9707	pickled narrow dieting pill	1		
 9712	skewed Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	squat How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
-9714	blinking twirling Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
+9714	twirling blinking Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	jittery Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
@@ -9656,7 +9656,7 @@
 9788	mirror Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
-9791	wobbly narrow Bicycle	0		Last Available: "2018-03"
+9791	narrow wobbly Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	Wullabye	0		Last Available: "2018-03"
 9794	Nursine	0		Last Available: "2018-03"
@@ -9699,7 +9699,7 @@
 9831	twisted scintillating oyster egg	1		
 9832	modified bouncing pearlescent oyster egg	1		Effect: "Cock of the Walk", Effect Duration: 35
 9833	pickled bouncing lustrous oyster egg	1		Effect: "Cancer Rising", Effect Duration: 20
-9834	compressed upside-down pulsating gleaming oyster egg	1		
+9834	compressed pulsating upside-down gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	upside-down rosewater-soaked dance instructor's FantasyRealm G. E. M. of extreme caution	0		Experience Percent (Moxie): +10, Monster Level: -25, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2018-04"
@@ -9726,9 +9726,9 @@
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	bouncing FantasyRealm tattoo kit	0		Last Available: "2018-04"
-9861	blurry jittery LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
+9861	jittery blurry LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	small bland lime green FantasyRealm turkey leg	2	decent	Last Available: "2018-04"
-9863	mediocre practically non-alcoholic FantasyRealm mead	1	decent	Last Available: "2018-04"
+9863	practically non-alcoholic mediocre FantasyRealm mead	1	decent	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	yellow Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	blue arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9736,7 +9736,7 @@
 9868	blinking grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	stale druidic s'more	4	decent	Last Available: "2018-04"
 9870	mixed sachet of powder	1		Effect: "Phairly Balanced", Effect Duration: 40, Last Available: "2018-04"
-9871	tolerable weak mourning wine	2	good	Last Available: "2018-04"
+9871	weak tolerable mourning wine	2	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	olive map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9781,7 +9781,7 @@
 9913	spinning glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	yummy good guava	3	awesome	
-9916	practically non-alcoholic artisanal gin and ginger	1	super ultra mega turbo EPIC	
+9916	artisanal practically non-alcoholic gin and ginger	1	super ultra mega turbo EPIC	
 9917	Thwaitgold chigger statuette	0		
 9918	boiled yellow gaseous gravy	1		Effect: "Ruthlessly Efficient", Effect Duration: 45
 9919	SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9790,7 +9790,7 @@
 9922	modified Shielding Potion	0		Effect: "Shot in the Arse", Effect Duration: 47, Last Available: "2018-06"
 9923	energized tumbling Punching Potion	0		Effect: "Bats in the Belfry", Effect Duration: 34, Last Available: "2018-06"
 9924	ghostly Special Seasoning	0		Last Available: "2018-06"
-9925	distilled jittery blue Nightmare Fuel	1		Last Available: "2018-06"
+9925	distilled blue jittery Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	olive Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9813,15 +9813,15 @@
 9945	twirling Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	drinkable watered-down ghostly Middle of the Road&trade; brand whiskey	2	good	Last Available: "2018-09"
+9948	watered-down drinkable ghostly Middle of the Road&trade; brand whiskey	2	good	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	bouncing censurious dance instructor's pentagram bandana	0		Experience Percent (Moxie): +10, Sleaze Resistance: +3, Last Available: "2018-09"
 9951	ghostly skull ring of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2018-09"
-9952	gray blurry electronics kit	0		Last Available: "2018-09"
+9952	blurry gray electronics kit	0		Last Available: "2018-09"
 9953	normal PB&J with the crusts cut off	4	good	Last Available: "2018-09"
 9954	supercharged strapping dorky glasses	0		Muscle: +5, Maximum MP Percent: +30, Single Equip, Last Available: "2018-09"
 9955	educational ponytail clip of Gandalf	0		Experience: +1, Spell Critical Percent: +20, Last Available: "2018-09"
-9956	aromatic paint palette	0		Stench Resistance: +1, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	aromatic paint palette	0		Stench Resistance: +1, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	mixed huge gray Purple Beast energy drink	1		Effect: "Browbeaten", Effect Duration: 5, Last Available: "2018-09"
 9959	cosmetic football of the cheetah	0		Initiative: +60, Last Available: "2018-09"
@@ -9847,16 +9847,16 @@
 9980	adequate bouncing party platter for one	4	good	Last Available: "2018-09"
 9981	pickled jittery Party-in-a-Can&trade;	1		Effect: "Tin, Man", Effect Duration: 45, Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	party crasher of the pedagogue of the storm	0		Experience: +3, Maximum MP Percent: +40, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9983	party crasher of the pedagogue of the storm	0		Experience: +3, Maximum MP Percent: +40, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	jittery latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	jittery latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	bouncing latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	wobbly voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	jittery &quot;I Voted!&quot; sticker of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-11"
 9991	absentee voter ballot	0		Last Available: "2018-11"
-9992	bouncing red snake skin	0		Last Available: "2018-11"
+9992	red bouncing snake skin	0		Last Available: "2018-11"
 9993	sharpshooter's snakeskin thighboots of Tarzan	0		Experience (Muscle): +3, Critical Hit Percent: +10, Last Available: "2018-11"
 9994	maroon toasty rock-hard snakeskin cowboy hat	0		Damage Reduction: 5, Hot Damage: +5, Last Available: "2018-11"
 9995	asbestos-lined chilly snakeskin jacket	0		Cold Damage: +5, Hot Resistance: +5, Last Available: "2018-11"
@@ -9873,12 +9873,12 @@
 10007	inspector's mutant arm of doom of the early riser	0		Spooky Spell Damage: +50, Item Drop: +15, Adventures: +7, Last Available: "2018-11"
 10008	Jim Carey's resourceful sage mutant legs	0		Mysticality Percent: +10, Maximum MP: +50, Monster Level: +25, Last Available: "2018-11"
 10009	sharpshooter's brainy mutant crown of the businessman	0		Mysticality: +5, Critical Hit Percent: +10, Meat Drop: +50, Last Available: "2018-11"
-10010	half-sized normal wobbly ghostly ectoplasm	2	good	Last Available: "2018-11"
-10011	immense tasty	10	awesome	Last Available: "2018-11"
-10012	acceptable weak green bottle of vodka	2	good	Last Available: "2018-11"
+10010	normal half-sized wobbly ghostly ectoplasm	2	good	Last Available: "2018-11"
+10011	tasty immense	10	awesome	Last Available: "2018-11"
+10012	weak acceptable green bottle of vodka	2	good	Last Available: "2018-11"
 10013	bland pizza	4	decent	Last Available: "2018-11"
 10014	hand-crafted fuchsia martini	3	EPIC	Last Available: "2018-11"
-10015	tiny decent cherry pie	1	good	Last Available: "2018-11"
+10015	decent tiny cherry pie	1	good	Last Available: "2018-11"
 10016	artisanal eggnog	4	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	adequate miniature Hell ramen	2	good	Last Available: "2018-11"
@@ -9886,8 +9886,8 @@
 10020	perfectly mixed weak twice-haunted screwdriver	2	EPIC	Last Available: "2018-11"
 10021	flavorless candy cane	4	decent	Last Available: "2018-12"
 10022	drinkable weak fancy runny fermented egg	2	good	Effect: "Memory of Resilience", Effect Duration: 50, Last Available: "2018-12"
-10023	toothsome small oldcake	2	awesome	Last Available: "2018-12"
-10024	rotten miniature pulsating traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
+10023	small toothsome oldcake	2	awesome	Last Available: "2018-12"
+10024	miniature rotten pulsating traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
 10025	slick plastic wild beaver	0		Moxie: +10, Last Available: "2018-12"
 10026	inspector's plastic reindeer	0		Item Drop: +15, Last Available: "2018-12"
 10027	plastic Caf&eacute; Elf of the blizzard	0		Cold Spell Damage: +25, Last Available: "2018-12"
@@ -9903,12 +9903,12 @@
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
 10039	stale grilled mooseflank	4	decent	Last Available: "2018-12"
-10040	flavorless diet moosemeat pie	1	decent	Last Available: "2018-12"
+10040	diet flavorless moosemeat pie	1	decent	Last Available: "2018-12"
 10041	bouncing auspicious balanced antler	0		Item Drop: +10, Last Available: "2018-12"
 10042	spinning sizzling dam	0		Hot Damage: +10, Damage Reduction: 9, Last Available: "2018-12"
-10043	delicious irresponsibly strong gray beavermouth	9	awesome	Last Available: "2018-12"
+10043	irresponsibly strong delicious gray beavermouth	9	awesome	Last Available: "2018-12"
 10044	lousy beaver punch (papaya)	4	decent	Last Available: "2018-12"
-10045	drinkable watered-down beaver punch (peach)	2	good	Last Available: "2018-12"
+10045	watered-down drinkable beaver punch (peach)	2	good	Last Available: "2018-12"
 10046	special perfectly mixed weak beaver punch (cherry)	2	EPIC	Effect: "'Roids of the Rhinoceros", Effect Duration: 30, Last Available: "2018-12"
 10047	Usain Bolt's Canadian lantern of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +80, Last Available: "2018-12"
 10048	Sherlock's muskox-skin cap	0		Item Drop: +25, Last Available: "2018-12"
@@ -9923,13 +9923,13 @@
 10057	Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	friendly dance instructor's brainy Kramco Sausage-o-Matic&trade; of terror of the businessman	0		Mysticality: +5, Experience Percent (Moxie): +10, Familiar Weight: +3, Spooky Spell Damage: +10, Meat Drop: +50, Last Available: "2019-01"
 10059	jittery huge sausage casing	0		Last Available: "2019-01"
-10060	stale jumbo sausage	5	decent	Last Available: "2019-01"
+10060	jumbo stale sausage	5	decent	Last Available: "2019-01"
 10061	auspicious manspreader's red-hot sausage fork	0		Monster Level: +10, Item Drop: +10, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	lime green sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	spinning Toyleporter	0		Last Available: "2018-12"
-10066	weak drinkable squat beer	2	good	Last Available: "2018-12"
+10066	drinkable weak squat beer	2	good	Last Available: "2018-12"
 10067	rotten bite-sized yule gruel	1	crappy	Last Available: "2018-12"
 10068	acceptable hot watered rum	4	good	Last Available: "2018-12"
 10069	delicious bottle of Crimbognac	4	awesome	Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	Usain Bolt's aromatic marble mariachi hat	0		Stench Resistance: +1, Initiative: +80, Last Available: "2019-12"
 10096	diluted marble molecules	1		Last Available: "2019-12"
 10097	galvanized Mallomarbles	0		Effect: "Fever From the Flavor", Effect Duration: 54
-10098	savvy cool punching bag	0		Moxie: +5, Mysticality Percent: +20, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	friendly stylish pith helmet	0		Moxie: +25, Familiar Weight: +3, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	narrow brawny poncho of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	frosty careful pendant	0		Monster Level: -10, Cold Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	frosty palazzos of the boozehound	0		Cold Spell Damage: +10, Booze Drop: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	squat chaotic personal trainer's pseudoaccordion	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	savvy cool punching bag	0		Moxie: +5, Mysticality Percent: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	friendly stylish pith helmet	0		Moxie: +25, Familiar Weight: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	narrow brawny poncho of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	frosty careful pendant	0		Monster Level: -10, Cold Spell Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	frosty palazzos of the boozehound	0		Cold Spell Damage: +10, Booze Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	squat chaotic personal trainer's pseudoaccordion	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	compressed bouncing pieces	1		Last Available: "2020-12"
 10105	activated Para-Pop	0		Effect: "Conspiratory Eyes", Effect Duration: 42
-10106	shellacked brainy terra cotta truss	0		Mysticality: +5, Damage Reduction: 7, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	arcane researcher's terra cotta trousers of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	shaking wobbly prompt therapeutic terra cotta tongs	0		Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	red foul-smelling terra cotta train of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	pulsating vibrating ruddy terra cotta tie tack	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	flame-retardant terra cotta tambourine of the dark arts	0		Spell Damage Percent: +100, Hot Resistance: +1, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	shellacked brainy terra cotta truss	0		Mysticality: +5, Damage Reduction: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	arcane researcher's terra cotta trousers of the brute	0		Muscle Percent: +30, Experience Percent (Mysticality): +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	shaking wobbly prompt therapeutic terra cotta tongs	0		Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	red foul-smelling terra cotta train of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	pulsating vibrating ruddy terra cotta tie tack	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	flame-retardant terra cotta tambourine of the dark arts	0		Spell Damage Percent: +100, Hot Resistance: +1, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	dehydrated tumbling terra cotta tidbits	1		Effect: "Salad Days", Effect Duration: 50, Last Available: "2020-12"
 10113	liquefied activated terra panna cotta	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 57
 10114	miser's rosewater-soaked velour voulge	0		Stench Resistance: +3, Meat Drop: +10, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	spinning aromatic glass serape of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Last Available: "2021-12"
 10128	denatured ghostly glass shards	1		Effect: "Dreadful Sheen", Effect Duration: 35, Last Available: "2021-12"
 10129	quadruple-pressed hard candy	0		Effect: "All Blued Up", Effect Duration: 21
-10130	quilted loofah lumberjack's hat of the brazier	0		Damage Absorption: +40, Hot Spell Damage: +25, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	blurry zippy loofah lei of vim and vigor	0		Maximum HP Percent: +50, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	upside-down blinking sinister loofah lederhosen of the brazier	0		Spell Damage: +10, Hot Spell Damage: +25, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	toasty strapping loofah ladle	0		Muscle: +5, Hot Damage: +5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	perfumed friendly loofah legwarmers	0		Familiar Weight: +3, Stench Resistance: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	bouncing padded weightlifter's loofah lavalier	0		Muscle: +15, Damage Absorption: +20, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	quilted loofah lumberjack's hat of the brazier	0		Damage Absorption: +40, Hot Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	blurry zippy loofah lei of vim and vigor	0		Maximum HP Percent: +50, Initiative: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	upside-down blinking sinister loofah lederhosen of the brazier	0		Spell Damage: +10, Hot Spell Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	toasty strapping loofah ladle	0		Muscle: +5, Hot Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	perfumed friendly loofah legwarmers	0		Familiar Weight: +3, Stench Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	bouncing padded weightlifter's loofah lavalier	0		Muscle: +15, Damage Absorption: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	denatured loofah lumps	1		Last Available: "2022-12"
 10137	super-unsweetened olive chocolate-covered loofah	0		Effect: "Healthy Bronze Glow", Effect Duration: 67
-10138	foul-smelling personal trainer's flagstone flag	0		Experience Percent (Muscle): +10, Stench Damage: +10, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	scandalous sage flagstone flail	0		Mysticality Percent: +10, Sleaze Damage: +5, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	flame-wreathed razor-sharp flagstone flip-flops	0		Weapon Damage Percent: +25, Hot Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	wool hale flagstone fez	0		Maximum HP: +20, Cold Resistance: +1, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	dangerous flagstone fleece of the early riser	0		Weapon Damage: +10, Adventures: +7, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	stanky chilly flagstone fringe	0		Cold Damage: +5, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	foul-smelling personal trainer's flagstone flag	0		Experience Percent (Muscle): +10, Stench Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	scandalous sage flagstone flail	0		Mysticality Percent: +10, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	flame-wreathed razor-sharp flagstone flip-flops	0		Weapon Damage Percent: +25, Hot Spell Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	wool hale flagstone fez	0		Maximum HP: +20, Cold Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	dangerous flagstone fleece of the early riser	0		Weapon Damage: +10, Adventures: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	stanky chilly flagstone fringe	0		Cold Damage: +5, Stench Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	powdered jittery flagstone flagments	1		Effect: "Items Are Forever", Effect Duration: 10, Last Available: "2022-12"
 10145	deionized shaking Flag by the Foot&trade;	0		Effect: "Carol of the Bones", Effect Duration: 33
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10021,7 +10021,7 @@
 10155	bland gray elf army field rations	3	decent	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	huge maroon frightening Annie Oakley's discarded bowtie	0		Critical Hit Percent: +20, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
-10158	drinkable watered-down yellow martiny	2	good	Last Available: "2019-12"
+10158	watered-down drinkable yellow martiny	2	good	Last Available: "2019-12"
 10159	purple tryptophan dart	0		Last Available: "2019-12"
 10160	cold-filtered deionized licorice snake	0		Effect: "Weasels Underfoot", Effect Duration: 40
 10161	electrified virgin jello shot	0		Effect: "Army of One", Effect Duration: 26
@@ -10029,28 +10029,28 @@
 10163	extra-denatured anodized government-issued candy	0		Effect: "Superioreo", Effect Duration: 49
 10164	frozen Pneumo bar	0		Effect: "Bubblin' Rage", Effect Duration: 53
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	slick Lil' Doctor&trade; bag of the detective	0		Moxie: +10, Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	slick Lil' Doctor&trade; bag of the detective	0		Moxie: +10, Item Drop: +20, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	thick stale huge bloodstick	5	decent	
+10169	stale thick huge bloodstick	5	decent	
 10170	special artisanal bottle of Sanguiovese	3	EPIC	Effect: "critical.enh", Effect Duration: 25
-10171	special massive decent actual blood sausage	7	good	Effect: "Gummiskin", Effect Duration: 20
-10172	mediocre weak mirror mulled blood	2	decent	
+10171	decent special massive actual blood sausage	7	good	Effect: "Gummiskin", Effect Duration: 20
+10172	weak mediocre mirror mulled blood	2	decent	
 10173	flavorless yellow blood snowcone	3	decent	
 10174	smooth Red Russian	4	awesome	
 10175	flavorless blood roll-up	4	decent	
-10176	drinkable watered-down pulsating bottle of blood	2	good	
+10176	watered-down drinkable pulsating bottle of blood	2	good	
 10177	miniature normal narrow blood-soaked sponge cake	2	good	
-10178	watered-down perfectly mixed vampagne	2	super ultra mega turbo EPIC	
+10178	perfectly mixed watered-down vampagne	2	super ultra mega turbo EPIC	
 10179	spoiled squat plain snowcone	3	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	shaking money bag	0		
 10182	money bag	0		
 10183	money bag	0		
 10184	Thwaitgold mosquito statuette	0		
-10185	pulsating gray bucket of Vampyre blood	0		
+10185	gray pulsating bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
 10187	blurry blurry PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
-10188	wobbly upside-down PirateRealm guest pass	0		Last Available: "2019-04"
+10188	upside-down wobbly PirateRealm guest pass	0		Last Available: "2019-04"
 10189	rosewater-soaked supercharged PirateRealm eyepatch of mayonnaise	0		Maximum MP Percent: +30, Sleaze Spell Damage: +50, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2019-04"
 10190	ghostly bloody harpoon	0		Weapon Damage Percent: +100, Lasts Until Rollover, Last Available: "2019-04"
 10191	compass	0		Lasts Until Rollover, Last Available: "2019-04"
@@ -10061,7 +10061,7 @@
 10196	skewed recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	jumbo moldy squat crabsicle	5	crappy	Last Available: "2019-04"
+10199	moldy jumbo squat crabsicle	5	crappy	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	irresponsibly strong perfectly mixed wobbly upside-down bottle of dark rhum	6	EPIC	Last Available: "2019-04"
 10202	acceptable huge bottle of extra-dark rhum	3	good	Last Available: "2019-04"
@@ -10073,13 +10073,13 @@
 10208	blurry signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	supercharged stylish pirate radio ring	0		Moxie: +25, Maximum MP Percent: +30, Single Equip, Last Available: "2019-04"
-10211	twirling skewed Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
+10211	skewed twirling Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	spoiled upside-down pineapple slab	4	crappy	Last Available: "2019-04"
 10213	adequate small hibiscus petal	2	good	Last Available: "2019-04"
 10214	colloidal triple-pressed flattened blurry huge mint leaf	0		Effect: "Elemental Flavor", Effect Duration: 13, Last Available: "2019-04"
 10215	wobbly olive cocoa of youth	0		Last Available: "2019-04"
 10216	vaporized green mirror ice molecule	1		Effect: "Bilious Briskness", Effect Duration: 25, Last Available: "2019-04"
-10217	blurry upside-down Red Roger's reliquary	0		Last Available: "2019-04"
+10217	upside-down blurry Red Roger's reliquary	0		Last Available: "2019-04"
 10218	spinning Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	shaking red Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
@@ -10102,9 +10102,9 @@
 10237	acceptable Smuggler's Punch	3	good	Last Available: "2019-04"
 10238	practically non-alcoholic perfectly mixed Scorpion Bowl	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10239	aged Turtle Bowl	3	awesome	Last Available: "2019-04"
-10240	strong aged Cobra Bowl	5	awesome	Last Available: "2019-04"
+10240	aged strong Cobra Bowl	5	awesome	Last Available: "2019-04"
 10241	teal vampyric cloake pattern	0		Free Pull
-10242	Tesla occult wicked supercool vampyric cloake of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Spell Damage: +5, Spell Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	Tesla occult wicked supercool vampyric cloake of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Spell Damage: +5, Spell Damage Percent: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	alkaline irradiated one piece of bubble gum	0		Effect: "Aries Rising", Effect Duration: 23
 10245	ghostly arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	purple blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	aromatic double-paned greasy Fourth of May Cosplay Saber	0		Sleaze Spell Damage: +10, Cold Resistance: +5, Stench Resistance: +1, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	aromatic double-paned greasy Fourth of May Cosplay Saber	0		Sleaze Spell Damage: +10, Cold Resistance: +5, Stench Resistance: +1, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	wobbly Thwaitgold nymph statuette	0		
-10254	executive scandalous frightening chaotic supercharged vibrating brawny hewn moon-rune spoon of wisdom of Tarzan of temperance of the detective	0		Mysticality: +15, Muscle Percent: +20, Experience (Muscle): +3, Maximum MP Percent: 40, Spell Critical Percent: +10, Spooky Damage: +5, Sleaze Damage: +5, Sleaze Resistance: +5, Item Drop: +20, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	executive scandalous frightening chaotic supercharged vibrating brawny hewn moon-rune spoon of wisdom of Tarzan of temperance of the detective	0		Mysticality: +15, Muscle Percent: +20, Experience (Muscle): +3, Maximum MP Percent: 40, Spell Critical Percent: +10, Spooky Damage: +5, Sleaze Damage: +5, Sleaze Resistance: +5, Item Drop: +20, Meat Drop: +40, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	narrow rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	teal zippy Jeselnik's razor-sharp Beach Comb	0		Weapon Damage Percent: +25, Sleaze Damage: +25, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	teal zippy Jeselnik's razor-sharp Beach Comb	0		Weapon Damage Percent: +25, Sleaze Damage: +25, Initiative: +20, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	jittery twirling small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10134,8 +10134,8 @@
 10269	activated seashell	0		Effect: "Cinnamouth", Effect Duration: 59, Last Available: "2019-07"
 10270	enhanced seashell	0		Effect: "Chalked-Up Teeth", Effect Duration: 29, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
-10272	lousy high-proof bottle of sea wine	7	decent	Last Available: "2019-07"
-10273	mixed blinking bouncing kelp	1		Effect: "Seal Clubbing Frenzy", Effect Duration: 15, Last Available: "2019-07"
+10272	high-proof lousy bottle of sea wine	7	decent	Last Available: "2019-07"
+10273	mixed bouncing blinking kelp	1		Effect: "Seal Clubbing Frenzy", Effect Duration: 15, Last Available: "2019-07"
 10274	Tesla supercharged veiny rosy-cheeked quilted dance instructor's savvy driftwood hat of wisdom of bravery	0		Mysticality: +15, Mysticality Percent: +20, Experience Percent (Moxie): +10, Damage Absorption: +40, Maximum HP Percent: +30, Maximum HP: +10, Maximum MP Percent: +30, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-07"
 10275	lightning-fast rosewater-soaked asbestos-lined Jeselnik's Temple Grandin's educational weightlifter's strapping driftwood pants of the ox	0		Muscle: 40, Experience: +1, Familiar Weight: +7, Sleaze Damage: +25, Hot Resistance: +5, Stench Resistance: +3, Initiative: +40, Lasts Until Rollover, Last Available: "2019-07"
 10276	censurious rosewater-soaked wool horrifying mansplainer's hale stiffened Fonzie's driftwood bracelet of bravery	0		Experience (Moxie): +1, Damage Reduction: 1, Maximum HP: +20, Monster Level: +15, Spooky Damage: +25, Cold Resistance: +1, Spooky Resistance: +5, Stench Resistance: +3, Sleaze Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10183,7 +10183,7 @@
 10318	cyan low-pressure oxygen tank	0		Single Equip
 10319	lime green Thwaitgold bombardier beetle statuette	0		
 10320	flavorless lime green space chowder	3	decent	
-10321	lousy twirling squat twirling space wine	4	decent	
+10321	lousy squat twirling twirling space wine	4	decent	
 10322	wobbly The Imploded World	0		Skill: "Implode Universe"
 10323	upside-down packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10193,8 +10193,8 @@
 10334	skewed unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	bite-sized moldy huge bu&ntilde;uelos Jaliscos	1	crappy	Last Available: "2019-12"
-10338	small decent flan del mar	2	good	Last Available: "2019-12"
+10337	moldy bite-sized huge bu&ntilde;uelos Jaliscos	1	crappy	Last Available: "2019-12"
+10338	decent small flan del mar	2	good	Last Available: "2019-12"
 10339	delicious yellow Baja sopapilla	3	awesome	Last Available: "2019-12"
 10340	Lo Pan's plastic Mer-kin baker	0		Spell Critical Percent: +30, Last Available: "2019-12"
 10341	pulsating ghostly electrified plastic sea elf	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-12"
@@ -10203,24 +10203,24 @@
 10344	MacGyver's plastic Dolph Bossin	0		Maximum MP: +100, Last Available: "2019-12"
 10345	skewed red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	decent diet purple mana-coated yams	1	good	Last Available: "2019-11"
-10347	spoiled tumbling blue mana-basted tofurkey leg	4	crappy	Last Available: "2019-11"
-10348	snack-sized moldy gray mana-fortified cranberry sauce	2	crappy	Last Available: "2019-11"
+10347	spoiled blue tumbling mana-basted tofurkey leg	4	crappy	Last Available: "2019-11"
+10348	moldy snack-sized gray mana-fortified cranberry sauce	2	crappy	Last Available: "2019-11"
 10349	adequate mana-stuffed herbal stuffing	3	good	Last Available: "2019-11"
 10350	green human musk	0		Last Available: "2019-12"
-10351	double-cold-filtered olive wobbly patch of extra-warm fur	0		Effect: "Fire Inside", Effect Duration: 64, Last Available: "2019-12"
+10351	double-cold-filtered wobbly olive patch of extra-warm fur	0		Effect: "Fire Inside", Effect Duration: 64, Last Available: "2019-12"
 10352	altered yellow industrial lubricant	1		Effect: "Become Intensely interested", Effect Duration: 30, Last Available: "2019-12"
 10353	pressed moist shaking unfinished pleasure	0		Effect: "Alpine Mintiness", Effect Duration: 45, Last Available: "2019-12"
 10354	distilled vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	dehydrated pulsating gray a bug's lymph	1		Last Available: "2019-12"
-10356	concentrated liquefied narrow lime green organic potpourri	0		Effect: "It Didn't Kill You", Effect Duration: 39, Last Available: "2019-12"
+10356	concentrated liquefied lime green narrow organic potpourri	0		Effect: "It Didn't Kill You", Effect Duration: 39, Last Available: "2019-12"
 10357	acceptable twirling boot flask	4	good	Last Available: "2019-12"
 10358	unsweetened concentrated infernal snowball	0		Effect: "Pecan Pied Piper", Effect Duration: 58, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	compressed purple jittery wobbly fish sauce	1		Effect: "The Dinsey Spirit", Effect Duration: 5, Last Available: "2019-12"
-10361	stale enchanted twirling guffin	4	decent	Effect: "Antarctic Memories", Effect Duration: 35, Last Available: "2019-12"
-10362	modified squat mirror Shantix&trade;	1		Last Available: "2019-12"
-10363	fuchsia bouncing goodberry	0		Last Available: "2019-12"
-10364	denatured shaking shaking fuchsia wobbly non-Euclidean angle	1		Effect: "Chari Tea", Effect Duration: 10, Last Available: "2019-12"
+10360	compressed purple wobbly jittery fish sauce	1		Effect: "The Dinsey Spirit", Effect Duration: 5, Last Available: "2019-12"
+10361	enchanted stale twirling guffin	4	decent	Effect: "Antarctic Memories", Effect Duration: 35, Last Available: "2019-12"
+10362	modified mirror squat Shantix&trade;	1		Last Available: "2019-12"
+10363	bouncing fuchsia goodberry	0		Last Available: "2019-12"
+10364	denatured fuchsia wobbly shaking shaking non-Euclidean angle	1		Effect: "Chari Tea", Effect Duration: 10, Last Available: "2019-12"
 10365	magnetized unsweetened pulsating peppermint syrup	0		Effect: "Carrrsmic", Effect Duration: 43, Last Available: "2019-12"
 10366	flattened deionized Mer-kin eyedrops	0		Effect: "[1609]Dancin' Fool", Effect Duration: 13, Last Available: "2019-12"
 10367	diffused concentrated energized extra-strength goo	0		Effect: "Berry Experiential", Effect Duration: 40, Last Available: "2019-12"
@@ -10230,7 +10230,7 @@
 10371	dried beggin' cologne	1		Effect: "Gyromitra Gymnastics", Effect Duration: 15, Last Available: "2019-12"
 10372	tumbling greedy wizardly oxygenated eggnog helmet	0		Mysticality: +25, Meat Drop: +20, Adventure Underwater, Last Available: "2019-12"
 10373	shaking purple hand-knitted diving booties	0		Last Available: "2019-12"
-10374	twirling squat peppermint harpoon gun	0		Last Available: "2019-12"
+10374	squat twirling peppermint harpoon gun	0		Last Available: "2019-12"
 10375	liquefied pressed tumbling concentrated fish broth	0		Effect: "[800]Chocolate Reign", Effect Duration: 27, Last Available: "2019-12"
 10376	denatured liquid SONAR	0		Effect: "Blood-Rich", Effect Duration: 44, Last Available: "2019-12"
 10377	spinning map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
@@ -10254,7 +10254,7 @@
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	spoiled bowl of mernudo	3	crappy	Last Available: "2019-12"
-10398	perfectly mixed watered-down fishelada	2	EPIC	Last Available: "2019-12"
+10398	watered-down perfectly mixed fishelada	2	EPIC	Last Available: "2019-12"
 10399	spoiled ojo de pez burrito	3	crappy	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	twirling waterlogged cloth	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	rotten salt plum	4	crappy	Last Available: "2019-12"
 10416	ghostly ghostly peppermint eel sauce	0		Last Available: "2019-12"
-10417	moldy jumbo and bean	5	crappy	Last Available: "2019-12"
+10417	jumbo moldy and bean	5	crappy	Last Available: "2019-12"
 10418	aromatic experienced cool kelp-holly gun	0		Moxie: +5, Experience: +2, Stench Resistance: +1, Last Available: "2019-12"
 10419	wholesome Socratic Yuleviathan necklace	0		Experience (Mysticality): +1, Maximum HP Percent: +10, Single Equip, Last Available: "2019-12"
 10420	rock-hard dance instructor's peppermint spine	0		Experience Percent (Moxie): +10, Damage Reduction: 5, Last Available: "2019-12"
@@ -10288,26 +10288,26 @@
 10429	non-anodized Vulcanized pulsating handful of mixed nuts	0		Effect: "Bright!", Effect Duration: 32, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	yellow ruddy wicked Retrospecs of Gandalf	0		Spell Damage: +5, Maximum HP Percent: +40, Spell Critical Percent: +20, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	yellow ruddy wicked Retrospecs of Gandalf	0		Spell Damage: +5, Maximum HP Percent: +40, Spell Critical Percent: +20, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	shaking frightening nasty coward's dance instructor's beefcake's Powerful Glove	0		Muscle: +25, Experience Percent (Moxie): +10, Monster Level: -20, Stench Damage: +5, Spooky Damage: +5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	shaking frightening nasty coward's dance instructor's beefcake's Powerful Glove	0		Muscle: +25, Experience Percent (Moxie): +10, Monster Level: -20, Stench Damage: +5, Spooky Damage: +5, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	jittery upside-down executive lard-coated Drip harness of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +25, Meat Drop: +40
 10442	drippy truncheon of the dark arts	0		Spell Damage Percent: +100, Single Equip
 10443	mirror Driplet	0		
 10444	drippy snail shell	0		
-10445	huge yummy huge drippy nugget	10	drippy	
-10446	watered-down delicious glass of drippy wine	2	drippy	
+10445	yummy huge huge drippy nugget	10	drippy	
+10446	delicious watered-down glass of drippy wine	2	drippy	
 10447	immense adequate drippy caviar	6	drippy	
-10448	miniature bland cyan ghostly drippy plum(?)	2	drippy	
+10448	bland miniature cyan ghostly drippy plum(?)	2	drippy	
 10449	resourceful drippy stake	0		Maximum MP: +50, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	mirror drippy khakis	0		
 10452	drippy shield	0		
-10453	tumbling jittery huge The Fingernail of the Thing in the Basement	0		
+10453	jittery tumbling huge The Fingernail of the Thing in the Basement	0		
 10454	coin	0		
 10455	pulsating cyan mushroom	0		
 10456	deluxe mushroom	0		
@@ -10343,10 +10343,10 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	massive enchanted adequate mushroom filet	6	good	Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2020-03"
+10489	adequate massive enchanted mushroom filet	6	good	Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	compressed mushroom tea	1		Last Available: "2020-03"
-10492	fancy triple-distilled tolerable mushroom whiskey	7	good	Effect: "Mystically Oiled", Effect Duration: 30, Last Available: "2020-03"
+10492	fancy tolerable triple-distilled mushroom whiskey	7	good	Effect: "Mystically Oiled", Effect Duration: 30, Last Available: "2020-03"
 10493	smelly mushroom cap of the storm of mayonnaise	0		Maximum MP Percent: +40, Stench Spell Damage: +10, Sleaze Spell Damage: +50, Last Available: "2020-03"
 10494	lightning-fast double-paned nippy cool mushroom shield	0		Moxie: +5, Cold Damage: +10, Cold Resistance: +5, Initiative: +40, Damage Reduction: 6, Last Available: "2020-03"
 10495	family-friendly scorching deadly Samson's mushroom pants	0		Experience (Muscle): +5, Weapon Damage: +5, Hot Damage: +25, Sleaze Resistance: +1, Last Available: "2020-03"
@@ -10372,7 +10372,7 @@
 10515	upside-down drippy grub	0		
 10516	blinking drippy bezoar	0		
 10517	Drip Institute petri dish	0		
-10518	jittery ghostly drippy ichor	0		
+10518	ghostly jittery drippy ichor	0		
 10519	cyan drippy enzyme	0		
 10520	drippy salt	0		
 10521	drippy pigment	0		
@@ -10382,7 +10382,7 @@
 10525	perfectly mixed fortified skewed drippy pilsner	5	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
-10529	bouncing blurry lustrous drippy orb	0		
+10529	blurry bouncing lustrous drippy orb	0		
 10530	nasty gory drippy orb	0		Stench Damage: +5
 10531	ghostly annealed drippy orb	0		
 10532	Guzzlr application	0		Free Pull
@@ -10394,11 +10394,11 @@
 10538	ghostly bouncing fuchsia Guzzlr pants	0		Last Available: "2020-05"
 10539	tumbling rosewater-soaked Guzzlr souvenir stein	0		Stench Resistance: +3, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	weak lousy Ghiaccio Colada	2	decent	Last Available: "2020-05"
+10541	lousy weak Ghiaccio Colada	2	decent	Last Available: "2020-05"
 10542	artisanal Sourfinger	4	EPIC	Last Available: "2020-05"
 10543	drinkable Nog-on-the-Cob	3	good	Last Available: "2020-05"
-10544	triple-distilled perfectly mixed blinking Steamboat	6	EPIC	Last Available: "2020-05"
-10545	weak artisanal Buttery Boy	2	EPIC	Last Available: "2020-05"
+10544	perfectly mixed triple-distilled blinking Steamboat	6	EPIC	Last Available: "2020-05"
+10545	artisanal weak Buttery Boy	2	EPIC	Last Available: "2020-05"
 10546	yellow Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	clown car key of the storm of the early riser	0		Maximum MP Percent: +40, Adventures: +7, Last Available: "2020-08"
 10548	medical-grade hardy grievous batting cage key	0		Weapon Damage Percent: +50, Maximum HP: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-08"
@@ -10430,7 +10430,7 @@
 10574	maroon Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	activated salty drippy candy bar	0		Effect: "Red Misty-Eyed", Effect Duration: 65
-10577	diffused skewed skewed maroon writhing drippy candy bar	0		Effect: "Vitali Tea", Effect Duration: 50
+10577	diffused skewed maroon skewed writhing drippy candy bar	0		Effect: "Vitali Tea", Effect Duration: 50
 10578	alkaline gooey drippy candy bar	0		Effect: "Black Eyes", Effect Duration: 69
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
@@ -10438,9 +10438,9 @@
 10582	red jittery SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	yellow bouncing squat Socratic birch battery of the dark arts	0		Experience (Mysticality): +1, Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2020-08"
-10585	razor-sharp experienced brawny ebony epee	0		Muscle Percent: +20, Experience: +2, Weapon Damage Percent: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	twirling fireproof gravedigger's weeping willow wand of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Hot Resistance: +3, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	studded sinister beechwood blowgun of the glutton	0		Spell Damage: +10, Damage Absorption: +80, Food Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	razor-sharp experienced brawny ebony epee	0		Muscle Percent: +20, Experience: +2, Weapon Damage Percent: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	twirling fireproof gravedigger's weeping willow wand of James Dean	0		Experience (Moxie): +3, Spooky Damage: +10, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	studded sinister beechwood blowgun of the glutton	0		Spell Damage: +10, Damage Absorption: +80, Food Drop: +100, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	occult cool maple magnet of incineration	0		Moxie: +5, Spell Damage Percent: +25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08"
 10589	squat Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	Van der Graaf hardened Herculean hemlock helm	0		Experience (Muscle): +1, Damage Reduction: 3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-08"
@@ -10462,7 +10462,7 @@
 10606	tarnished oxidized gray squat Yeg's Motel toothbrush	0		Effect: "Liquidy Smoky", Effect Duration: 40, Last Available: "2020-09"
 10607	polarized Yeg's Motel hand soap	0		Effect: "Pockets of Fire", Effect Duration: 13, Last Available: "2020-09"
 10608	huge narrow Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	enchanted flavorless narrow Yeg's Motel pillow mint	3	decent	Effect: "Don't Step to Your Stepmother", Effect Duration: 45, Last Available: "2020-09"
+10609	flavorless enchanted narrow Yeg's Motel pillow mint	3	decent	Effect: "Don't Step to Your Stepmother", Effect Duration: 45, Last Available: "2020-09"
 10610	huge Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	chilled nitrogenated Yeg's Motel mouthwash	0		Effect: "Coming Up Roses", Effect Duration: 39, Last Available: "2020-09"
 10612	Yeg's Motel shower cap of James Dean of the businessman	0		Experience (Moxie): +3, Meat Drop: +50, Lasts Until Rollover, Last Available: "2020-09"
@@ -10475,8 +10475,8 @@
 10619	uncanny desk bell	0		Last Available: "2020-09"
 10620	nasty desk bell	0		Last Available: "2020-09"
 10621	greasy desk bell	0		Last Available: "2020-09"
-10622	pulsating red chess set	0		Last Available: "2020-09"
-10623	shaking bouncing onyx king	0		Last Available: "2020-09"
+10622	red pulsating chess set	0		Last Available: "2020-09"
+10623	bouncing shaking onyx king	0		Last Available: "2020-09"
 10624	onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	ruddy rosy-cheeked Cargo Cultist Shorts of Calamity Jane of the sewer	0		Maximum HP Percent: 70, Critical Hit Percent: +15, Stench Damage: +25, Last Available: "2020-09"
 10637	wobbly complicated device	0		Last Available: "2020-09"
-10638	lousy triple-distilled flask of moonshine	7	decent	Last Available: "2020-09"
+10638	triple-distilled lousy flask of moonshine	7	decent	Last Available: "2020-09"
 10639	beefcake's strapping sea-worn candlestick of Tarzan	0		Muscle: 30, Experience (Muscle): +3, Last Available: "2020-09"
 10640	purple Universal Seasoning	0		
 10641	vacuum-sealed huge null-day exploit	0		Effect: "Fan-Cooled", Effect Duration: 49, Last Available: "2025-12"
@@ -10568,26 +10568,26 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	miniature spoiled blinking and pepper (stale)	2	crappy	Last Available: "2020-12"
+10715	spoiled miniature blinking and pepper (stale)	2	crappy	Last Available: "2020-12"
 10716	perfectly mixed cranberry margarita (brackish)	3	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
-10718	squat narrow tumbling nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
+10718	narrow squat tumbling nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	olive goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	drinkable barrel-aged eggnog	3	good	Last Available: "2020-12"
-10721	super-sized spoiled hand-crafted candy cane	5	crappy	Last Available: "2020-12"
-10722	normal massive drive-thru burger	9	good	Last Available: "2020-12"
+10721	spoiled super-sized hand-crafted candy cane	5	crappy	Last Available: "2020-12"
+10722	massive normal drive-thru burger	9	good	Last Available: "2020-12"
 10723	hand-crafted teal Boulevardier cocktail	3	EPIC	Last Available: "2020-12"
 10724	diffused Hotwire&trade; brand candy rope	0		Effect: "Vitamin-Maxed", Effect Duration: 23, Last Available: "2020-12"
 10725	stale tiny bowl full of jelly	1	decent	Last Available: "2020-12"
 10726	drinkable Eye and a Twist	3	good	Last Available: "2020-12"
-10727	pickled mirror teal Chubby and Plump bar	0		Effect: "Abyssal Blood", Effect Duration: 55, Last Available: "2020-12"
+10727	pickled teal mirror Chubby and Plump bar	0		Effect: "Abyssal Blood", Effect Duration: 55, Last Available: "2020-12"
 10728	shaking digibritches	0		Last Available: "2025-12"
 10729	packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	jittery crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	teal fresh coat of paint	0		Last Available: "2021-12"
-10733	narrow skewed emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	shaking spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	narrow skewed emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	shaking spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10600,9 +10600,9 @@
 10744	dry boiled wobbly battery (car)	0		Effect: "Surreally Buff", Effect Duration: 22, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	enchanted watered-down perfectly mixed marshmallow bomb	2	EPIC	Effect: "Okee-Dokee, Smokee", Effect Duration: 30, Last Available: "2021-03"
+10747	watered-down perfectly mixed enchanted marshmallow bomb	2	EPIC	Effect: "Okee-Dokee, Smokee", Effect Duration: 30, Last Available: "2021-03"
 10748	mirror packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	modified alkaline ionized lime green short beer	0		Effect: "Super-Charged", Effect Duration: 62, Last Available: "2021-05"
@@ -10610,9 +10610,9 @@
 10754	anodized galvanized short stick of butter	0		Effect: "Booze Goozles", Effect Duration: 28, Last Available: "2021-05"
 10755	pressed ionized short glass of water	0		Effect: "Sinuses For Miles", Effect Duration: 62, Last Available: "2021-05"
 10756	nitrogenated quadruple-denatured spinning short	0		Effect: "Top Dog", Effect Duration: 19, Last Available: "2021-05"
-10757	pulsating mirror Thwaitgold quantum bug statuette	0		
+10757	mirror pulsating Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	Da Vinci's supercool familiar scrapbook	0		Moxie Percent: +20, Experience (Mysticality): +5, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	Da Vinci's supercool familiar scrapbook	0		Moxie Percent: +20, Experience (Mysticality): +5, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	narrow packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	cyan squat clan underground fireworks shop	0		Last Available: "2021-07"
 10762	Oprah's occult dance instructor's fedora-mounted fountain	0		Experience Percent (Moxie): +10, Spell Damage Percent: +25, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,14 +10621,14 @@
 10765	rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	rocket	0		Last Available: "2021-07"
-10768	fancy massive adequate fire crackers	9	good	Effect: "Rainbow Bright", Effect Duration: 30, Last Available: "2021-07"
+10768	fancy adequate massive fire crackers	9	good	Effect: "Rainbow Bright", Effect Duration: 30, Last Available: "2021-07"
 10769	huge Arr, M80	0		Last Available: "2021-07"
 10770	dangerous Catherine Wheel of Leguizamo	0		Weapon Damage: +10, Monster Level: +20, Lasts Until Rollover, Last Available: "2021-07"
 10771	Jack Frost's rocket boots of the businessman	0		Cold Spell Damage: +50, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	smelly dog trainer's sparkler	0		Experience (familiar): +1, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-07"
 10773	skewed Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	polymerized Scent of a Human&trade; candle	0		Effect: "Slimy Hands", Effect Duration: 47, Last Available: "2021-08"
-10775	triple-boiled twirling maroon The Beast Within&trade; candle	0		Effect: "Disco Neuropathy", Effect Duration: 12, Last Available: "2021-08"
+10775	triple-boiled maroon twirling The Beast Within&trade; candle	0		Effect: "Disco Neuropathy", Effect Duration: 12, Last Available: "2021-08"
 10776	altered quadruple-deionized jittery Salsa Caliente&trade; candle	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 54, Last Available: "2021-08"
 10777	galvanized Smoldering Clover&trade; candle	0		Effect: "The Halls of Moxiousness", Effect Duration: 26, Last Available: "2021-08"
 10778	energized energized Napalm In The Morning&trade; candle	0		Effect: "Become Intensely interested", Effect Duration: 35, Last Available: "2021-08"
@@ -10647,10 +10647,10 @@
 10791	pulsating Thwaitgold fire beetle statuette	0		
 10792	jittery empty nacho cheese can	0		Water: 1
 10793	literal bucket hat	0		Water: 5
-10794	huge skewed rainproof barrel caulk	0		
+10794	skewed huge rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	upside-down executive avaricious auspicious perfumed dance instructor's educational industrial fire extinguisher	0		Experience: +1, Experience Percent (Moxie): +10, Stench Resistance: +5, Item Drop: +10, Meat Drop: 70, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	upside-down executive avaricious auspicious perfumed dance instructor's educational industrial fire extinguisher	0		Experience: +1, Experience Percent (Moxie): +10, Stench Resistance: +5, Item Drop: +10, Meat Drop: 70, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10661,7 +10661,7 @@
 10805	blurry eggwater	1	awesome	Last Available: "2021-12"
 10806	bland bread man	3	decent	Last Available: "2021-12"
 10807	tiny yummy plain candy cane	1	awesome	Last Available: "2021-12"
-10808	decent snack-sized flour cookie	2	good	Last Available: "2021-12"
+10808	snack-sized decent flour cookie	2	good	Last Available: "2021-12"
 10809	skewed quilted plastic food lab	0		Damage Absorption: +40, Single Equip, Last Available: "2021-12"
 10810	wobbly resourceful plastic nog lab	0		Maximum MP: +50, Single Equip, Last Available: "2021-12"
 10811	narrow plastic chem lab of mayonnaise	0		Sleaze Spell Damage: +50, Single Equip, Last Available: "2021-12"
@@ -10672,24 +10672,24 @@
 10816	green mirror aromatic forbidden baleful ice crown	0		Spell Damage: +25, Spell Damage Percent: +50, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2021-12"
 10817	skewed ribald smooth wizardly jeans	0		Mysticality: +25, Moxie: +15, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2021-12"
 10818	squat mansplainer's padded ice wrap of horror	0		Damage Absorption: +20, Monster Level: +15, Spooky Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	rotten fancy tofu pop	4	crappy	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 45, Last Available: "2021-12"
-10820	snack-sized tasty blurry bowl of prescription candy	2	awesome	Last Available: "2021-12"
+10819	fancy rotten tofu pop	4	crappy	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 45, Last Available: "2021-12"
+10820	tasty snack-sized blurry bowl of prescription candy	2	awesome	Last Available: "2021-12"
 10821	rotten narrow fishcake	3	crappy	Last Available: "2021-12"
-10822	super-sized adequate bone broth	5	good	Last Available: "2021-12"
+10822	adequate super-sized bone broth	5	good	Last Available: "2021-12"
 10823	flavorless star pop	3	decent	Last Available: "2021-12"
-10824	acceptable watered-down narrow Doc's Fortifying Wine	2	good	Last Available: "2021-12"
+10824	watered-down acceptable narrow Doc's Fortifying Wine	2	good	Last Available: "2021-12"
 10825	aged shaking Doc's Smartifying Wine	3	awesome	Last Available: "2021-12"
-10826	watered-down perfectly mixed maroon Doc's Limbering Wine	2	EPIC	Last Available: "2021-12"
-10827	lousy watered-down fancy squat Doc's Medical-Grade Wine	2	decent	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2021-12"
+10826	perfectly mixed watered-down maroon Doc's Limbering Wine	2	EPIC	Last Available: "2021-12"
+10827	fancy lousy watered-down squat Doc's Medical-Grade Wine	2	decent	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2021-12"
 10828	modified green Homebodyl&trade;	1		Last Available: "2021-12"
 10829	compressed blinking jittery Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	boiled blinking Breathitin&trade;	1		Last Available: "2021-12"
-10831	pickled purple blinking ghostly Fleshazole&trade;	1		Last Available: "2021-12"
+10831	pickled blinking ghostly purple Fleshazole&trade;	1		Last Available: "2021-12"
 10832	flattened cold-filtered anti-burn cream	0		Effect: "La Bamba", Effect Duration: 66, Last Available: "2021-12"
 10833	Vulcanized anti-freeze cream	0		Effect: "Human-Beast Hybrid", Effect Duration: 49, Last Available: "2021-12"
 10834	nitrogenated bouncing anti-goosebump cream	0		Effect: "Prelude of Precision", Effect Duration: 65, Last Available: "2021-12"
 10835	pickled moist skewed anti-odor cream	0		Effect: "Dancing Prowess", Effect Duration: 57, Last Available: "2021-12"
-10836	galvanized wobbly mirror anti-creep cream	0		Effect: "Permanent Halloween", Effect Duration: 16, Last Available: "2021-12"
+10836	galvanized mirror wobbly anti-creep cream	0		Effect: "Permanent Halloween", Effect Duration: 16, Last Available: "2021-12"
 10837	colloidal purple anti-pain cream	0		Effect: "Well-Swabbed Ear", Effect Duration: 19, Last Available: "2021-12"
 10838	aged Doc's Special Reserve Wine	4	awesome	Last Available: "2021-12"
 10839	rotten snack-sized bread pie	2	crappy	Last Available: "2021-12"
@@ -10720,7 +10720,7 @@
 10864	carnivorous potted plant of the cheetah	0		Initiative: +60, Last Available: "2021-12"
 10865	jittery universal biscuit	0		Last Available: "2021-12"
 10866	Jeselnik's yule hatchet	0		Sleaze Damage: +25, Last Available: "2021-12"
-10867	cyan tumbling potato alarm clock	0		Last Available: "2021-12"
+10867	tumbling cyan potato alarm clock	0		Last Available: "2021-12"
 10868	bland miniature lab-grown meat	2	decent	Last Available: "2021-12"
 10869	hardy fleece	0		Maximum HP: +50, Last Available: "2021-12"
 10870	skewed boxed gumball machine	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	shaking shellacked Herculean sage can of mixed everything	0		Mysticality Percent: +10, Experience (Muscle): +1, Damage Reduction: 7, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	flavorless bite-sized blinking meatball	1	decent	Last Available: "2021-12"
+10876	bite-sized flavorless blinking meatball	1	decent	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10739,7 +10739,7 @@
 10883	diluted huge narrow astral energy drink	1		Effect: "Blood-Gorged", Effect Duration: 5
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	ghostly up-at-dawn dance instructor's magnifying glass of the cheetah	0		Experience Percent (Moxie): +10, Initiative: +60, Adventures: +5, Last Available: "2022-12"
-10886	enchanted acceptable void lager	3	good	Effect: "Cheered Up", Effect Duration: 20, Last Available: "2022-12"
+10886	acceptable enchanted void lager	3	good	Effect: "Cheered Up", Effect Duration: 20, Last Available: "2022-12"
 10887	rotten void burger	3	crappy	Last Available: "2022-12"
 10888	tumbling void stone	0		Last Available: "2022-12"
 10889	manspreader's medical-grade therapeutic cool void shard	0		Moxie: +5, Monster Level: +10, HP Regen Min: 12, HP Regen Max: 17, Last Available: "2022-12"
@@ -10764,25 +10764,25 @@
 10908	electrified spare battery	0		Effect: "Mitre Cut", Effect Duration: 43, Last Available: "2022-05"
 10909	space blanket	0		Last Available: "2022-05"
 10910	polarized alkaline ionized ghostly single-use dust mask	0		Effect: "Happy Trails", Effect Duration: 39, Last Available: "2022-05"
-10911	polymerized extra-cold-filtered upside-down squat gaffer's tape	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 55, Last Available: "2022-05"
+10911	polymerized extra-cold-filtered squat upside-down gaffer's tape	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 55, Last Available: "2022-05"
 10912	yummy 20-lb can of rice and beans	3	awesome	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	EPIC	Last Available: "2022-05"
 10914	bland expired MRE	3	decent	Last Available: "2022-05"
-10915	rotten small cool mint precipice bar	2	crappy	Last Available: "2022-05"
+10915	small rotten cool mint precipice bar	2	crappy	Last Available: "2022-05"
 10916	normal gray carrot cake precipice bar	4	good	Last Available: "2022-05"
 10917	squat The Big Book of Every Skill	0		
 10918	yellow Thwaitgold harvestman statuette	0		
-10919	bouncing teal packaged June cleaver	0		Free Pull, Last Available: "2022-06"
+10919	teal bouncing packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	executive smartaleck's June cleaver of courage	0		Moxie Percent: +30, Spooky Resistance: +3, Meat Drop: +40, Attacks Can't Miss, Last Available: "2022-06"
 10921	delicious Dad's brandy	4	awesome	Last Available: "2022-06"
 10922	avaricious teacher's pen of the overflowing toilet	0		Stench Spell Damage: +50, Meat Drop: +30, Last Available: "2022-06"
 10923	snack-sized rotten shaking fire-roasted lake trout	2	crappy	Last Available: "2022-06"
 10924	moldy upside-down guilty sprout	3	crappy	Last Available: "2022-06"
 10925	ribald vibrating mother's necklace	0		Maximum MP Percent: +10, Sleaze Damage: +10, Last Available: "2022-06"
-10926	concentrated warmed jittery tumbling trampled ticket stub	0		Effect: "Down With Chow", Effect Duration: 38, Last Available: "2022-06"
-10927	chilled triple-pressed blinking huge savings bond	0		Effect: "Abyssal Blood", Effect Duration: 44, Last Available: "2022-06"
+10926	concentrated warmed tumbling jittery trampled ticket stub	0		Effect: "Down With Chow", Effect Duration: 38, Last Available: "2022-06"
+10927	chilled triple-pressed huge blinking savings bond	0		Effect: "Abyssal Blood", Effect Duration: 44, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	compressed bouncing sweat-ade	1		Effect: "Moose Wisdom", Effect Duration: 45, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	lime green squat stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10791,7 +10791,7 @@
 10935	pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	tumbling slick pterodactyl rifle	0		Moxie: +10, Conditional Skill (Equipped): "Snipe Pterodactyl"
-10938	shaking bouncing birdseed hat	0		
+10938	bouncing shaking birdseed hat	0		
 10939	flatusaur gasmask	0		
 10940	wobbly dinosaur dart	0		
 10941	ionized wet activated Dino DNAde&trade;	0		Effect: "Spiritually Awake", Effect Duration: 20
@@ -10805,7 +10805,7 @@
 10949	smartaleck's dinosaur	0		Moxie Percent: +30
 10950	huge Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	Herculean experienced Jurassic Parka	0		Experience: +2, Experience (Muscle): +1, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	Herculean experienced Jurassic Parka	0		Experience: +2, Experience (Muscle): +1, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	shaking boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	blinking autumn-aton	0		Last Available: "2022-10"
 10955	polarized green autumn leaf	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 56, Last Available: "2022-10"
@@ -10826,13 +10826,13 @@
 10970	bland ratatouille de Jarlsberg	3	decent	Last Available: "2022-11"
 10971	tasty Jarlsberg's vegetable soup	3	awesome	Last Available: "2022-11"
 10972	moldy roasted vegetable of Jarlsberg	3	crappy	Last Available: "2022-11"
-10973	flavorless miniature blurry St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
+10973	miniature flavorless blurry St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
 10974	yummy upside-down Pete's wiley whey bar	4	awesome	Last Available: "2022-11"
-10975	normal thick Pete's rich ricotta	5	good	Last Available: "2022-11"
+10975	thick normal Pete's rich ricotta	5	good	Last Available: "2022-11"
 10976	perfectly mixed blinking Boris's beer	3	EPIC	Last Available: "2022-11"
 10977	moldy huge honey bun of Boris	3	crappy	Last Available: "2022-11"
 10978	rotten teal Boris's bread	3	crappy	Last Available: "2022-11"
-10979	upside-down purple narrow Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10979	narrow purple upside-down Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	tumbling Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
@@ -10845,9 +10845,9 @@
 10989	moldy skewed plain calzone	4	crappy	Last Available: "2022-11"
 10990	normal twirling roasted vegetable focaccia	4	good	Last Available: "2022-11"
 10991	flavorless low-calorie gray Pizza of Legend	1	decent	Last Available: "2022-11"
-10992	snack-sized decent Calzone of Legend	2	good	Last Available: "2022-11"
+10992	decent snack-sized Calzone of Legend	2	good	Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	narrow gray Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10994	gray narrow Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
 10995	tumbling Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
 10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
 10997	upside-down Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
@@ -10866,19 +10866,19 @@
 11010	bland narrow swamp haunch	3	decent	
 11011	spinning perfumed gator shades of the sweet-tooth	0		Stench Resistance: +5, Candy Drop: +100, Single Equip
 11012	skewed milk cap	0		
-11013	enchanted lousy irresponsibly strong Charleston Choo-Choo	9	decent	Effect: "On a Roll", Effect Duration: 10
+11013	irresponsibly strong lousy enchanted Charleston Choo-Choo	9	decent	Effect: "On a Roll", Effect Duration: 10
 11014	weak perfectly mixed special Velvet Veil	2	EPIC	Effect: "Spooky Flavor", Effect Duration: 40
 11015	perfectly mixed strong olive Marltini	5	EPIC	
 11016	tolerable blue Strong, Silent Type	3	good	
 11017	acceptable Mysterious Stranger	3	good	
 11018	acceptable distilled Champagne Shimmy	5	good	
-11019	jittery fuchsia blurry the Sot's parcel	0		
-11020	upside-down ceramic cestus of the brute of the dark arts	0		Muscle Percent: +30, Spell Damage Percent: +100, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	wool smelly careful ceramic centurion shield	0		Monster Level: -10, Stench Spell Damage: +10, Cold Resistance: +1, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	blinking chilly Oprah's ceramic celery grater	0		Maximum MP Percent: +50, Cold Damage: +5, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	nasty electrified vibrating ceramic celsiturometer	0		Maximum MP Percent: +10, Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	squat prompt greedy quilted ceramic cerecloth belt	0		Damage Absorption: +40, Meat Drop: +20, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	executive nasty beefy ceramic cenobite's robe	0		Muscle: +10, Stench Damage: +5, Meat Drop: +40, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11019	fuchsia blurry jittery the Sot's parcel	0		
+11020	upside-down ceramic cestus of the brute of the dark arts	0		Muscle Percent: +30, Spell Damage Percent: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	wool smelly careful ceramic centurion shield	0		Monster Level: -10, Stench Spell Damage: +10, Cold Resistance: +1, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	blinking chilly Oprah's ceramic celery grater	0		Maximum MP Percent: +50, Cold Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	nasty electrified vibrating ceramic celsiturometer	0		Maximum MP Percent: +10, Stench Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	squat prompt greedy quilted ceramic cerecloth belt	0		Damage Absorption: +40, Meat Drop: +20, Adventures: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	executive nasty beefy ceramic cenobite's robe	0		Muscle: +10, Stench Damage: +5, Meat Drop: +40, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	modified upside-down ceramic scree	1		Last Available: "2023-12"
 11027	wet extra-hard jawbreaker	0		Effect: "Preemptive Medicine", Effect Duration: 61
 11028	chilly mansplainer's strapping chiffon chevrons	0		Muscle: +5, Monster Level: +15, Cold Damage: +5, Single Equip, Last Available: "2023-12"
@@ -10889,7 +10889,7 @@
 11033	stanky toasty chiffon chaps of vim and vigor	0		Maximum HP Percent: +50, Hot Damage: +5, Stench Spell Damage: +25, Last Available: "2023-12"
 11034	altered tumbling chiffon carbage	1		Last Available: "2023-12"
 11035	extra-flattened modified chiffon lemon	0		Effect: "Cybernetic Muscles", Effect Duration: 16
-11036	adequate half-sized narrow chocomotive	2	good	Last Available: "2022-12"
+11036	half-sized adequate narrow chocomotive	2	good	Last Available: "2022-12"
 11037	rotten freightcake	3	crappy	Last Available: "2022-12"
 11038	practically non-alcoholic bad cabooze	1	decent	Last Available: "2022-12"
 11039	mirror plastic caboose	0		Last Available: "2022-12"
@@ -10924,20 +10924,20 @@
 11068	lost elf luggage	0		
 11069	lime green Trainbot luggage hook	0		Single Equip
 11070	rotten honey-drenched ham slice	4	crappy	
-11071	high-proof bad blurry mostly-empty bottle of cookie wine	6	decent	
+11071	bad high-proof blurry mostly-empty bottle of cookie wine	6	decent	
 11072	flavorless yellow Crimbo food scraps	3	decent	
 11073	pulsating arm towel	0		Last Available: "2022-12"
 11074	blinking automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
 11076	Trainbot slag	0		
 11077	spinning industrially-crushed ice	0		Last Available: "2022-12"
-11078	snack-sized yummy steamed oyster	2	awesome	
+11078	yummy snack-sized steamed oyster	2	awesome	
 11079	upside-down really nice lump of coal	0		
 11080	spinning deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	pulsating spinning steam unit	0		Last Available: "2022-12"
 11082	red crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	spirit-forward perfectly mixed Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
+11084	perfectly mixed spirit-forward Crimbosmopolitan	5	EPIC	Last Available: "2022-12"
 11085	normal big Crimbo dinner	5	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10964,7 +10964,7 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	half-sized decent pixel bread	2	good	
+11112	decent half-sized pixel bread	2	good	
 11113	smooth pixel whiskey	3	awesome	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10972,8 +10972,8 @@
 11117	altered glob of extra-green chlorophyll	0		Effect: "Walberg's Dim Bulb", Effect Duration: 61, Last Available: "2023-02"
 11118	extra-electrified jittery yellow mushroom	0		Effect: "Your Interest is Peaked", Effect Duration: 43, Last Available: "2023-02"
 11119	wet five-fingered fern resin	0		Effect: "One For Tea", Effect Duration: 52, Last Available: "2023-02"
-11120	bland bite-sized super good fruit	1	decent	Last Available: "2023-02"
-11121	altered ghostly shaking energized spores	1		Last Available: "2023-02"
+11120	bite-sized bland super good fruit	1	decent	Last Available: "2023-02"
+11121	altered shaking ghostly energized spores	1		Last Available: "2023-02"
 11122	yellow hale thinker's hot pepper	0		Mysticality: +10, Maximum HP: +20, Lantern Element: "Hot", Last Available: "2023-02"
 11123	polarized oxidized out-of-work circus flea	0		Effect: "Analog Drunk", Effect Duration: 54, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
@@ -10986,7 +10986,7 @@
 11131	non-quantum cold-filtered pile of gritty sand	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 35, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	electrified Vulcanized angry agate	0		Effect: "Scavengers Scavenging", Effect Duration: 37, Last Available: "2023-02"
-11134	energized super-galvanized tumbling pulsating lump of loyal latite	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 55, Last Available: "2023-02"
+11134	energized super-galvanized pulsating tumbling lump of loyal latite	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 55, Last Available: "2023-02"
 11135	tiny yummy mirror shadow sausage	1	awesome	Last Available: "2023-03"
 11136	lime green energetic shadow skin of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +20, Last Available: "2023-03"
 11137	deionized alkaline shadow flame	0		Effect: "Frozen Shoulders", Effect Duration: 21, Last Available: "2023-03"
@@ -11018,7 +11018,7 @@
 11163	Advanced Pig Skinning	0		
 11164	huge The Cheese Wizard's Companion	0		
 11165	wobbly Jazz Agent sheet music	0		
-11166	teal narrow Thwaitgold anti-moth statuette	0		
+11166	narrow teal Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
 11168	pulsating closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
@@ -11027,7 +11027,7 @@
 11172	blue shadow snowflake	0		
 11173	shadow heart	0		
 11174	jittery shadow bucket	0		
-11175	narrow spinning shadow wave	0		
+11175	spinning narrow shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	ghostly groovy stylish shadow chef's hat of the early riser	0		Moxie: +25, Moxie Percent: +10, Adventures: +7
 11178	lightning-fast gravedigger's sinister shadow trousers	0		Spell Damage: +10, Spooky Damage: +10, Initiative: +40
@@ -11035,10 +11035,10 @@
 11180	shadow monocle of Gandalf of the sewer of Flo-Jo	0		Spell Critical Percent: +20, Stench Damage: +25, Initiative: +100, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	adequate shadow hot dog	4	good	
-11183	smooth boozy ghostly shadow martini	5	awesome	
+11183	boozy smooth ghostly shadow martini	5	awesome	
 11184	dehydrated shadow pill	1		Effect: "Jingle Jangle Jingle", Effect Duration: 30
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	Vulcanized shadow candy	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 54
 11189	replica Mr. Accessory	0		
@@ -11070,14 +11070,14 @@
 11215	replica angel	0		
 11216	brainy replica Camp Scout backpack	0		Mysticality: +5
 11217	bouncing replica deactivated nanobots	0		
-11218	shaking blinking replica Apathargic Bandersnatch	0		
+11218	blinking shaking replica Apathargic Bandersnatch	0		
 11219	bouncing replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
 11221	bouncing replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	aromatic sinister Cincho de Mayo of the empath	0		Spell Damage: +10, Familiar Weight: +5, Stench Resistance: +1, Item Drop: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	aromatic sinister Cincho de Mayo of the empath	0		Spell Damage: +10, Familiar Weight: +5, Stench Resistance: +1, Item Drop: +5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	twirling dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
-11225	upside-down red replica Little Geneticist DNA-Splicing Lab	0		
+11225	red upside-down replica Little Geneticist DNA-Splicing Lab	0		
 11226	blinking replica still grill	0		
 11227	squat shaking replica Crimbo sapling	0		
 11228	replica puck	0		
@@ -11103,7 +11103,7 @@
 11248	huge replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	scandalous replica Jurassic Parka of the dark arts	0		Spell Damage Percent: +100, Sleaze Damage: +5
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	pulsating replica Ten Dollars	0		
 11254	red healthy fortified boxer's replica Cincho de Mayo of Leguizamo	0		Muscle Percent: +10, Damage Absorption: +60, Maximum HP Percent: +20, Monster Level: +20, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	resourceful Sinatra's brainy &quot;I survived Y2K&quot; T-Shirt of the brazier of doom of the detective	0		Mysticality: +5, Experience (Moxie): +5, Maximum MP: +50, Hot Spell Damage: +25, Spooky Spell Damage: +50, Item Drop: +20, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	blurry prompt family-friendly pro skateboard	0		Sleaze Resistance: +1, Adventures: +3, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	blurry prompt family-friendly pro skateboard	0		Sleaze Resistance: +1, Adventures: +3, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	blinking Meat Butler	0		Last Available: "2023-06"
 11263	red Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
-11265	blue Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	spinning Flash Liquidizer Ultra Dousing Accessory of the ox	0		Muscle: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11265	blue Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11266	spinning Flash Liquidizer Ultra Dousing Accessory of the ox	0		Muscle: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	wool brawny beefcake's Amulet of Perpetual Darkness of wisdom	0		Muscle: +25, Mysticality: +15, Muscle Percent: +20, Cold Resistance: +1, Last Available: "2023-06"
 11268	skewed Giant monolith	0		Last Available: "2023-06"
 11269	teal Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11151,7 +11151,7 @@
 11296	Temple Grandin's birdybug antenna of the empath	0		Familiar Weight: 12
 11297	rock-hard forbidden kilopede skull	0		Spell Damage Percent: +50, Damage Reduction: 5
 11298	alkaline dry haemolymphnode	0		Effect: "Greasy Peasy", Effect Duration: 48
-11299	deionized huge ghostly chitin powder paste	0		Effect: "Destructive Resolve", Effect Duration: 69
+11299	deionized ghostly huge chitin powder paste	0		Effect: "Destructive Resolve", Effect Duration: 69
 11300	sleeping patriotic eagle	0		Free Pull
 11301	claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
@@ -11163,7 +11163,7 @@
 11308	spinning watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
-11311	big bland waffle	5	decent	
+11311	bland big waffle	5	decent	
 11312	fixodent	0		
 11313	auspicious lard-coated cat o' nine teeth	0		Sleaze Spell Damage: +25, Item Drop: +10
 11314	jittery zippy careful tooth cap	0		Monster Level: -10, Initiative: +20
@@ -11172,10 +11172,10 @@
 11317	ghostly handful of toilet paper	0		
 11318	blurry Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	acceptable practically non-alcoholic bottle of Cabernet Sauvignon	1	good	
+11320	practically non-alcoholic acceptable bottle of Cabernet Sauvignon	1	good	
 11321	jittery careful studded Herculean baywatch	0		Experience (Muscle): +1, Damage Absorption: +80, Monster Level: -10, Lasts Until Rollover
-11322	mirror Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	mirror Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	huge consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11201,7 +11201,7 @@
 11346	day shortener	0		
 11347	extra time	0		
 11348	ribald sage autumnal aegis	0		Mysticality Percent: +10, Sleaze Damage: +10, Damage Reduction: 9
-11349	warmed olive spinning distilled resin	0		Effect: "Coal-Powered", Effect Duration: 37
+11349	warmed spinning olive distilled resin	0		Effect: "Coal-Powered", Effect Duration: 37
 11350	blurry super-heated leaf	0		
 11351	lit leaf lasso	0		
 11352	pulsating tied-up leaflet	0		
@@ -11216,7 +11216,7 @@
 11361	aerosolized pressed autumnic balm	0		Effect: "Antibiotic Saucesphere", Effect Duration: 64
 11362	galvanized coping juice	0		Effect: "Castaway Physique", Effect Duration: 19
 11363	red auspicious rosewater-soaked savvy candy cane sword cane of the empath of incineration	0		Mysticality Percent: +20, Familiar Weight: +5, Hot Spell Damage: +50, Stench Resistance: +3, Item Drop: +10, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
-11364	blue pulsating wrapped candy cane sword cane	0		Free Pull
+11364	pulsating blue wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
@@ -11231,7 +11231,7 @@
 11376	mirror housekeeping automa-core	0		
 11377	spinning housekeeping robot	0		
 11378	yummy pickled bread	4	awesome	Last Available: "2023-12"
-11379	flavorless miniature salted mutton	2	decent	Last Available: "2023-12"
+11379	miniature flavorless salted mutton	2	decent	Last Available: "2023-12"
 11380	rotten corned beet	3	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11268,7 +11268,7 @@
 11413	twirling squat Elf Guard honor present	0		Last Available: "2023-12"
 11414	squat blinking lightning-fast foul-smelling Elf Guard officer's sidearm	0		Stench Damage: +10, Initiative: +40, Last Available: "2023-12"
 11415	jittery horrifying scorching Elf Guard insignia (general)	0		Hot Damage: +25, Spooky Damage: +25, Single Equip, Last Available: "2023-12"
-11416	drinkable practically non-alcoholic Crimbow Rainbo	1	good	Last Available: "2023-12"
+11416	practically non-alcoholic drinkable Crimbow Rainbo	1	good	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	blurry horrifying Elf Guard broom of the sweet-tooth	0		Spooky Damage: +25, Candy Drop: +100, Last Available: "2023-12"
@@ -11277,14 +11277,14 @@
 11422	aged skewed old-school pirate grog	3	awesome	Last Available: "2023-12"
 11423	stale miniature grog nuts	2	decent	Last Available: "2023-12"
 11424	prompt lion tamer's sawed-off blunderbuss of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Adventures: +3, Last Available: "2023-12"
-11425	artisanal practically non-alcoholic officer's nog	1	super ultra mega EPIC	Last Available: "2023-12"
+11425	practically non-alcoholic artisanal officer's nog	1	super ultra mega EPIC	Last Available: "2023-12"
 11426	narrow peppermint bomb	0		Last Available: "2023-12"
 11427	bland sundae ration	4	decent	Last Available: "2023-12"
 11428	huge moldy peppermint tack	7	crappy	Last Available: "2023-12"
 11429	spinning spinning Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	half-sized adequate whalesteak	2	good	Last Available: "2023-12"
+11430	adequate half-sized whalesteak	2	good	Last Available: "2023-12"
 11431	auspicious Oprah's whalegun of the pedagogue	0		Experience: +3, Maximum MP Percent: +50, Item Drop: +10, Last Available: "2023-12"
-11432	squat green Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
+11432	green squat Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	toasty MacGyver's stiffened Elf Guard clipboard	0		Damage Reduction: 1, Maximum MP: +100, Hot Damage: +5, Last Available: "2023-12"
 11435	dangerous pegfinger	0		Weapon Damage: +10, Single Equip, Last Available: "2023-12"
@@ -11307,7 +11307,7 @@
 11452	baleful experienced brainy Elf dessert spoon of the bloodbag of extreme caution of the overflowing toilet	0		Mysticality: +5, Experience: +2, Spell Damage: +25, Maximum HP: +100, Monster Level: -25, Stench Spell Damage: +50, Last Available: "2023-12"
 11453	weightlifter's Elf Guard SCUBA tank of temperance	0		Muscle: +15, Sleaze Resistance: +5, Last Available: "2023-12"
 11454	wobbly Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	jittery sinister slick free boots	0		Moxie: +10, Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	jittery sinister slick free boots	0		Moxie: +10, Spell Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	gray baby rigging snake	0		Last Available: "2023-12"
 11457	mirror lard-coated Lo Pan's chaotic Elvish underarmor	0		Spell Critical Percent: 40, Sleaze Spell Damage: +25, Single Equip, Last Available: "2023-12"
 11458	yellow Jim Carey's Herculean Crimbuccaneer bombjacket	0		Experience (Muscle): +1, Monster Level: +25, Combat Item Damage Percent: 100, Last Available: "2023-12"
@@ -11315,25 +11315,25 @@
 11460	adequate gingerbread nylons	3	good	Last Available: "2023-12"
 11461	bland rum-soaked fruitcake	4	decent	Last Available: "2023-12"
 11462	bland lime	4	decent	Last Available: "2023-12"
-11463	flavorless bite-sized twirling gingerbread pirate	1	decent	Last Available: "2023-12"
+11463	bite-sized flavorless twirling gingerbread pirate	1	decent	Last Available: "2023-12"
 11464	stale upside-down fruit-stuffed rumcake	4	decent	Last Available: "2023-12"
 11465	bad mulled wine	3	decent	Last Available: "2023-12"
 11466	hand-crafted fancy irresponsibly strong Swedish coffee	10	EPIC	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2023-12"
 11467	mediocre narrow canteen of eggnog	3	decent	Last Available: "2023-12"
-11468	hand-crafted boozy special jittery hot wine	5	EPIC	Effect: "Dance of the Sugar Fairy", Effect Duration: 40, Last Available: "2023-12"
+11468	boozy hand-crafted special jittery hot wine	5	EPIC	Effect: "Dance of the Sugar Fairy", Effect Duration: 40, Last Available: "2023-12"
 11469	smooth Jamaican coffee	3	awesome	Last Available: "2023-12"
 11470	lousy flask of egggrog	3	decent	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	mediocre high-proof tumbling yule grog	9	decent	Last Available: "2023-12"
+11474	high-proof mediocre tumbling yule grog	9	decent	Last Available: "2023-12"
 11475	yummy fuchsia wet tack	3	awesome	Last Available: "2023-12"
-11476	spoiled gigantic whalecake	7	crappy	Last Available: "2023-12"
-11477	greedy asbestos-lined occult gunwale whalegun	0		Spell Damage Percent: +25, Hot Resistance: +5, Meat Drop: +20, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
-11478	watered-down drinkable blinking and claret	2	good	Last Available: "2023-12"
+11476	gigantic spoiled whalecake	7	crappy	Last Available: "2023-12"
+11477	greedy asbestos-lined occult gunwale whalegun	0		Spell Damage Percent: +25, Hot Resistance: +5, Meat Drop: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11478	drinkable watered-down blinking and claret	2	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	fuchsia trick coin	0		Last Available: "2023-12"
-11481	lime green censurious foul-smelling Elf Guard squirtgun	0		Stench Damage: +10, Sleaze Resistance: +3, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	lime green censurious foul-smelling Elf Guard squirtgun	0		Stench Damage: +10, Sleaze Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	tumbling chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	yellow sequin-encrusted sweater of Flo-Jo	0		Initiative: +100, Last Available: "2023-12"
 11484	green lightning-fast Sherlock's electrified replica Elf Guard medal	0		Item Drop: +25, Initiative: +40, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
@@ -11356,13 +11356,13 @@
 11501	ghostly Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	quadruple-Vulcanized blinking military candy cane	0		Effect: "Hair on Your Chest", Effect Duration: 34
 11503	nitrogenated ionized fuchsia groggipop	0		Effect: "Painted-On Bikini", Effect Duration: 57
-11504	Da Vinci's moss mace of the cheetah	0		Experience (Mysticality): +5, Initiative: +60, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	razor-sharp Newton's moss megaphone	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	auspicious healthy moss medal	0		Maximum HP Percent: +20, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	moss mitre of the storm of the early riser	0		Maximum MP Percent: +40, Adventures: +7, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	lime green clever steel-toed moss mantle	0		Damage Reduction: 9, Maximum MP: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	Da Vinci's moss mace of the cheetah	0		Experience (Mysticality): +5, Initiative: +60, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	razor-sharp Newton's moss megaphone	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	auspicious healthy moss medal	0		Maximum HP Percent: +20, Item Drop: +10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	moss mitre of the storm of the early riser	0		Maximum MP Percent: +40, Adventures: +7, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	lime green clever steel-toed moss mantle	0		Damage Reduction: 9, Maximum MP: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	wholesome Sinatra's moss marlinspike	0		Experience (Moxie): +5, Maximum HP Percent: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	distilled fuchsia squat wobbly moss mulch	1		Last Available: "2024-12"
+11510	distilled wobbly squat fuchsia moss mulch	1		Last Available: "2024-12"
 11511	deionized ionized moss floss	0		Effect: "Goldentongue", Effect Duration: 20
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11372,12 +11372,12 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	dehydrated blurry adobe assortment	1		Effect: "Papowerful", Effect Duration: 45, Last Available: "2024-12"
 11519	improved adjusted adobe brittle	0		Effect: "Demonic Taint", Effect Duration: 28
-11520	executive toasty curative crepe paper phrygian cap	0		Hot Damage: +5, Meat Drop: +40, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	executive toasty curative crepe paper phrygian cap	0		Hot Damage: +5, Meat Drop: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	prompt Jack Frost's studded crepe paper parachute cape	0		Damage Absorption: +80, Cold Spell Damage: +50, Adventures: +3, Last Available: "2025-12"
-11522	Temple Grandin's quilted crepe paper pie clip of horror	0		Damage Absorption: +40, Familiar Weight: +7, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	tumbling spinning executive sharpshooter's Samson's crepe paper puzzle cube	0		Experience (Muscle): +5, Critical Hit Percent: +10, Meat Drop: +40, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	skewed Jeselnik's gravedigger's crepe paper plunge camisole of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Sleaze Damage: +25, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	jittery scandalous brainy crepe paper polka charm of the empath	0		Mysticality: +5, Familiar Weight: +5, Sleaze Damage: +5, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	Temple Grandin's quilted crepe paper pie clip of horror	0		Damage Absorption: +40, Familiar Weight: +7, Spooky Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	tumbling spinning executive sharpshooter's Samson's crepe paper puzzle cube	0		Experience (Muscle): +5, Critical Hit Percent: +10, Meat Drop: +40, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	skewed Jeselnik's gravedigger's crepe paper plunge camisole of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Sleaze Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	jittery scandalous brainy crepe paper polka charm of the empath	0		Mysticality: +5, Familiar Weight: +5, Sleaze Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	vaporized skewed crepe paper pared cuttings	1		Effect: "Patched In", Effect Duration: 40, Last Available: "2025-12"
 11527	oxidized ionized improved pulsating skewed crepe paper peanut candy	0		Effect: "Full of Vinegar", Effect Duration: 35
 11528	dog trainer's petrified wood war pike of horror	0		Experience (familiar): +1, Spooky Spell Damage: +25, Last Available: "2025-12"
@@ -11390,15 +11390,15 @@
 11535	super-magnetized oxidized shaking petrified wood wafer praline	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 28
 11536	hand-crafted cybeer	3	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	squat wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	green encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	squat wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	green encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
 11541	huge googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	greasy Crimbuccaneer war standard of the dark arts	0		Spell Damage Percent: +100, Sleaze Spell Damage: +10, Last Available: "2023-12"
 11544	mirror perfumed Elf Guard war standard of courage	0		Spooky Resistance: +3, Stench Resistance: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	mirror Samson's sage spring shoes	0		Mysticality Percent: +10, Experience (Muscle): +5, Item Drop: +5, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	mirror Samson's sage spring shoes	0		Mysticality Percent: +10, Experience (Muscle): +5, Item Drop: +5, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	pickled upside-down tumbling ultra-soft ferns	0		Effect: "Raging Animal", Effect Duration: 18, Last Available: "2024-02"
 11548	double-corrupted crunchy brush	0		Effect: "Your Interest is Peaked", Effect Duration: 41, Last Available: "2024-02"
 11549	squat smashed scientific equipment	0		
@@ -11425,12 +11425,12 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	mirror boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	adequate lime green jittery wobbly yam	3	good	Last Available: "2024-05"
+11573	adequate lime green wobbly jittery yam	3	good	Last Available: "2024-05"
 11574	bad yam martini	3	decent	Last Available: "2024-05"
-11575	fortified acceptable spinning tumbling sweet potato o' mine	5	good	Last Available: "2024-05"
-11576	acceptable watered-down Southern yam	2	good	Last Available: "2024-05"
+11575	fortified acceptable tumbling spinning sweet potato o' mine	5	good	Last Available: "2024-05"
+11576	watered-down acceptable Southern yam	2	good	Last Available: "2024-05"
 11577	bad sweet potato punch	4	decent	Last Available: "2024-05"
-11578	immense special adequate Mayam spinach	6	good	Effect: "Mana Tea", Effect Duration: 30, Last Available: "2024-05"
+11578	special immense adequate Mayam spinach	6	good	Effect: "Mana Tea", Effect Duration: 30, Last Available: "2024-05"
 11579	bite-sized yummy squat yam and swiss	1	awesome	Last Available: "2024-05"
 11580	Usain Bolt's perfumed yam cannon of Gandalf	0		Spell Critical Percent: +20, Stench Resistance: +5, Initiative: +80, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11448,12 +11448,12 @@
 11593	Thwaitgold Illinigina illinoiensis model	0		
 11594	decent super-sized mini kiwi	5	good	Last Available: "2024-06"
 11595	frightening mini kiwi bikini of dire peril of the early riser	0		Weapon Damage: +20, Spooky Damage: +5, Adventures: +7, Last Available: "2024-06"
-11596	special aged weak pulsating blurry mini kiwitini	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2024-06"
+11596	weak aged special blurry pulsating mini kiwitini	2	awesome	Effect: "Oh Snap", Effect Duration: 50, Last Available: "2024-06"
 11597	blue mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	teal mini kiwi aioli	0		
 11599	huge double-paned educational smooth mini kiwi silicon tiepin	0		Moxie: +15, Experience: +1, Cold Resistance: +5
 11600	tumbling mini kiwi tipi	0		
-11601	huge bland mini kiwi digitized cookies	6	decent	
+11601	bland huge mini kiwi digitized cookies	6	decent	
 11602	perfectly mixed mini kiwi intoxicating spirits	4	EPIC	
 11603	anodized modified mini kiwi antimilitaristic hippy petition	0		Effect: "Salt Rockin'", Effect Duration: 48
 11604	alkaline electrified mini kiwi illicit antibiotic	0		Effect: "Loco Motives", Effect Duration: 47
@@ -11461,7 +11461,7 @@
 11606	therapeutic mini kiwi icepick	0		HP Regen Min: 5, HP Regen Max: 7
 11607	dry shaking mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "The Halls of Moxiousness", Effect Duration: 63
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	blurry protogenetic chunklet (synapse)	0		
 11611	bouncing protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11502,7 +11502,7 @@
 11647	lime green structural ember	0		Last Available: "2024-09"
 11648	wobbly shaking lard-coated Fonzie's embers-only jacket of the pedagogue	0		Experience: +3, Experience (Moxie): +1, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-09"
 11649	twirling weightlifter's bembershoot	0		Muscle: +15, Lasts Until Rollover, Last Available: "2024-09"
-11650	snack-sized flavorless narrow wobbly wheel of camembert	2	decent	Last Available: "2024-09"
+11650	flavorless snack-sized wobbly narrow wheel of camembert	2	decent	Last Available: "2024-09"
 11651	bouncing rosy-cheeked thinker's hat of remembering of the overflowing toilet	0		Mysticality: +10, Maximum HP Percent: +30, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-09"
 11652	jittery throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	wobbly soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	stanky quilted bat wings of the overflowing toilet	0		Damage Absorption: +40, Stench Spell Damage: 75, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	stanky quilted bat wings of the overflowing toilet	0		Damage Absorption: +40, Stench Spell Damage: 75, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	pulsating ember	0		Cold Resistance: +1
 11661	blinking wobbly shellacked monocle on a stick of the ox	0		Muscle: +20, Damage Reduction: 7, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	pulsating veiny Sheriff badge of the overflowing toilet	0		Maximum HP: +10, Stench Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	experienced Sheriff pistol of terror	0		Experience: +2, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-10"
 11670	twirling Jim Carey's slick Sheriff moustache	0		Moxie: +10, Monster Level: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	photo booth supply list of wisdom of the detective	0		Mysticality: +15, Item Drop: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	photo booth supply list of wisdom of the detective	0		Mysticality: +15, Item Drop: +20, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	spinning tie-dye headband	0		
 11674	spoiled tumbling whirled peas	4	crappy	Last Available: "2024-11"
@@ -11536,15 +11536,15 @@
 11681	quantized familiar experience	0		
 11682	irradiated huge pea brittle	0		Effect: "items.enh", Effect Duration: 31, Last Available: "2024-11"
 11683	tolerable peasco	3	good	Last Available: "2024-11"
-11684	small decent piece of cake	2	good	Last Available: "2024-11"
-11685	maroon tumbling handful of split pea soup	0		Last Available: "2024-11"
+11684	decent small piece of cake	2	good	Last Available: "2024-11"
+11685	tumbling maroon handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
-11687	blinking purple TakerSpace letter of Marque	0		Last Available: "2024-12"
+11687	purple blinking TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	Oprah's personal trainer's deft pirate hook	0		Experience Percent (Muscle): +10, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2024-12"
-11689	tumbling healthy iron tricorn hat of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	tumbling healthy iron tricorn hat of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	jolly roger flag	0		Item Drop: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	wobbly sleeping profane parrot	0		Last Available: "2024-12"
-11692	huge jittery pirrrate's currrse	0		Last Available: "2024-12"
+11692	jittery huge pirrrate's currrse	0		Last Available: "2024-12"
 11693	watered-down mediocre special tankard of spiced rum	2	decent	Effect: "Greased-Up Familiar", Effect Duration: 10, Last Available: "2024-12"
 11694	perfectly mixed gray tankard of spiced Goldschlepper	3	EPIC	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
@@ -11561,7 +11561,7 @@
 11706	teal anchor bomb	0		Last Available: "2024-12"
 11707	avaricious silky pirate drawers of the glutton	0		Meat Drop: +30, Food Drop: +100, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
-11709	pickled tumbling ghostly olive peppermint pegleg	0		Effect: "Celestial Vision", Effect Duration: 32, Last Available: "2024-12"
+11709	pickled ghostly olive tumbling peppermint pegleg	0		Effect: "Celestial Vision", Effect Duration: 32, Last Available: "2024-12"
 11710	watered-down artisanal tumbling hard cocoa	2	EPIC	Last Available: "2024-12"
 11711	tasty salmagumdi	4	awesome	Last Available: "2024-12"
 11712	frosty plastic Easter Island Bunny	0		Cold Spell Damage: +10, Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	medical-grade smooth potato jacket of vim and vigor	0		Moxie: +15, Maximum HP Percent: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	jittery Brandonian footlocker key	0		Last Available: "2024-12"
-11731	aromatic brainy military orb	0		Mysticality: +5, Stench Resistance: +1, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	aromatic brainy military orb	0		Mysticality: +5, Stench Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	super-improved shaking rum ball	0		Effect: "The Rich Get Richer", Effect Duration: 48
 11733	gravy skin	0		Last Available: "2024-12"
 11734	maroon electrified brawny gravyskin hat	0		Muscle Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12"
@@ -11595,7 +11595,7 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	narrow ruddy steel-toed perfect Christmas scarf of extreme caution	0		Damage Reduction: [9*event(December)], Maximum HP Percent: [+40*event(December)], Monster Level: [-25*event(December)], Single Equip, Last Available: "2024-12"
-11743	baleful brainy snowman-enchanting tophat	0		Mysticality: +5, Spell Damage: +25, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	baleful brainy snowman-enchanting tophat	0		Mysticality: +5, Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	pickled energized tarnished LIDAR candle	0		Effect: "Comic Violence", Effect Duration: 20, Last Available: "2024-12"
 11745	frosty dog trainer's Congressional Medal of Insanity of the early riser	0		Experience (familiar): +1, Cold Spell Damage: +10, Adventures: +7, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
@@ -11604,27 +11604,27 @@
 11749	lousy olive canteen of jungle juice	4	decent	Last Available: "2024-12"
 11750	hand-crafted turchucken	3	EPIC	Last Available: "2024-12"
 11751	acceptable mechanically-mulled cider	3	good	Last Available: "2024-12"
-11752	weak tolerable holiday trip around the world	2	good	Last Available: "2024-12"
+11752	tolerable weak holiday trip around the world	2	good	Last Available: "2024-12"
 11753	flavorless red chocolate ostrich egg	3	decent	Last Available: "2024-12"
 11754	toothsome beef and cabbage	3	awesome	Last Available: "2024-12"
-11755	normal snack-sized candy rations	2	good	Last Available: "2024-12"
-11756	rotten jumbo double-candied yams	5	crappy	Last Available: "2024-12"
+11755	snack-sized normal candy rations	2	good	Last Available: "2024-12"
+11756	jumbo rotten double-candied yams	5	crappy	Last Available: "2024-12"
 11757	flavorless bouncing Christmas ham	4	decent	Last Available: "2024-12"
 11758	rotten squat holiday smorgasbord	3	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	sinister bejazzled eyepatch	0		Spell Damage: +10, Last Available: "2024-12"
-11761	ghostly Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	spinning Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	lime green How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	shaking Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	tumbling Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	narrow Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	ghostly Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	spinning Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	lime green How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	shaking Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	tumbling Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	narrow Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	spinning smelly sizzling Tesla egg gun of the wise owl	0		Mysticality: +20, Hot Damage: +10, Stench Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	spinning smelly sizzling Tesla egg gun of the wise owl	0		Mysticality: +20, Hot Damage: +10, Stench Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	huge prompt Lo Pan's occult army helmet of the businessman	0		Spell Damage Percent: +25, Spell Critical Percent: +30, Meat Drop: +50, Adventures: +3, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	spinning wobbly napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	anodized deviled candy egg	0		Effect: "Oxygenated Blood", Effect Duration: 47, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	bouncing Jack Frost's McHugeLarge duffel bag of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Last Available: "2025-01"
-11784	yellow coward's Oprah's grievous McHugeLarge left pole	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Monster Level: -20, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	squat olive executive Samson's McHugeLarge right pole of temperance	0		Experience (Muscle): +5, Sleaze Resistance: +5, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	ghostly crafty arcane researcher's McHugeLarge left ski	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	stylish strapping McHugeLarge right ski	0		Muscle: +5, Moxie: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	yellow coward's Oprah's grievous McHugeLarge left pole	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Monster Level: -20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	squat olive executive Samson's McHugeLarge right pole of temperance	0		Experience (Muscle): +5, Sleaze Resistance: +5, Meat Drop: +40, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	ghostly crafty arcane researcher's McHugeLarge left ski	0		Experience Percent (Mysticality): +10, Maximum MP: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	stylish strapping McHugeLarge right ski	0		Muscle: +5, Moxie: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	cyan 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	powdered eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	jittery datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	ghostly dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,10 +11658,10 @@
 11803	twirling cybervisor	0		Last Available: "2025-12"
 11804	huge retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
-11809	mirror red upside-down 3d printed server room key	0		Last Available: "2025-12"
+11809	upside-down red mirror 3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	altered tumbling psilocyber mushroom	1		Last Available: "2025-12"
@@ -11679,10 +11679,10 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	gray geofencing shield	0		Last Available: "2025-12"
-11829	olive narrow virtual cybertattoo	0		Last Available: "2025-12"
-11830	upside-down mirror ninja rope	0		
+11829	narrow olive virtual cybertattoo	0		Last Available: "2025-12"
+11830	mirror upside-down ninja rope	0		
 11831	ninja crampons	0		
 11832	ninja carabiner	0		
 11833	pressed ionized synthetic coffee	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 35
@@ -11691,7 +11691,7 @@
 11836	new-in-box toy Cupid bow	0		Free Pull, Last Available: "2025-02"
 11837	ghostly toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	ghostly heat arc	0		
-11839	upside-down wobbly scrape	0		
+11839	wobbly upside-down scrape	0		
 11840	phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
@@ -11706,7 +11706,7 @@
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	upside-down foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
-11854	blinking fuchsia grim cellophane	0		Combat Rate: -5
+11854	fuchsia blinking grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
@@ -11717,21 +11717,21 @@
 11862	pickled scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	acceptable narrow pint of Leprechaun Stout	3	good	Last Available: "2025-03"
-11865	denatured pulsating skewed phosphor traces	1		Last Available: "2025-03"
+11865	denatured skewed pulsating phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
 11868	spoon	0		
 11869	pulsating unironic knife	0		
-11870	blinking blurry bar dart	0		Last Available: "2025-03"
+11870	blurry blinking bar dart	0		Last Available: "2025-03"
 11871	diluted olive leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	moldy squat Heck ramen	3	crappy	Last Available: "2025-03"
 11873	bite-sized adequate burrito	1	good	Last Available: "2025-03"
 11874	fancy yummy small beer brat	4	awesome	Effect: "The Spy Who Loved XP", Effect Duration: 25, Last Available: "2025-03"
 11875	snack-sized rotten lime green peach pie	2	crappy	Last Available: "2025-03"
 11876	spoiled incredible mini-pizza	4	crappy	Last Available: "2025-03"
-11877	lousy practically non-alcoholic Divine sidecar	1	decent	Last Available: "2025-03"
+11877	practically non-alcoholic lousy Divine sidecar	1	decent	Last Available: "2025-03"
 11878	drinkable tangarita sidecar	4	good	Last Available: "2025-03"
-11879	watered-down hand-crafted gimlet sidecar	2	EPIC	Last Available: "2025-03"
+11879	hand-crafted watered-down gimlet sidecar	2	EPIC	Last Available: "2025-03"
 11880	acceptable blinking vodka stratocaster sidecar	4	good	Last Available: "2025-03"
 11881	lousy prussian cathouse sidecar	4	decent	Last Available: "2025-03"
 11882	triple-distilled artisanal red Mon Tiki sidecar	7	EPIC	Last Available: "2025-03"
@@ -11740,7 +11740,7 @@
 11885	narrow glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	modified pickled wet paper weights	0		Effect: "Crotchety, Pining", Effect Duration: 32, Last Available: "2025-04"
-11888	practically non-alcoholic artisanal ghostly Three Sheets to the Wind	1	EPIC	Last Available: "2025-04"
+11888	artisanal practically non-alcoholic ghostly Three Sheets to the Wind	1	EPIC	Last Available: "2025-04"
 11889	rotten twirling twirling pile of wet dates	4	crappy	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	blurry extremely unsafe stylish bycocket	0		Weapon Damage Percent: +100
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	twirling packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	narrow Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11804,7 +11804,7 @@
 11949	avaricious bully badge	0		Meat Drop: +30, Lasts Until Rollover, Last Available: "2025-08"
 11950	razor-sharp time cop top hat	0		Weapon Damage Percent: +25, Last Available: "2025-08"
 11951	skewed Stock Certificate	0		Last Available: "2025-08"
-11952	powdered ghostly maroon mixed berry jelly	1		Last Available: "2025-08"
+11952	powdered maroon ghostly mixed berry jelly	1		Last Available: "2025-08"
 11953	stale skewed toast with mixed berry jelly	3	decent	Last Available: "2025-08"
 11954	big normal pulsating cup of sugar	5	good	Last Available: "2025-08"
 11955	normal Susie's cupcake	3	good	Last Available: "2025-08"
@@ -11826,27 +11826,27 @@
 11972	durable dolphin whistle	0		
 11973	cyan blinking Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	shaking unblemished pearl	0		
 11977	jittery dentadent of Gandalf	0		Spell Critical Percent: +20
 11986	wobbly lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	ghostly gravedigger's smelly friendly ruddy blood cubic zirconia of the storm of Gandalf	0		Maximum HP Percent: +40, Maximum MP Percent: +40, Spell Critical Percent: +20, Familiar Weight: +3, Stench Spell Damage: +10, Spooky Damage: +10, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	ghostly gravedigger's smelly friendly ruddy blood cubic zirconia of the storm of Gandalf	0		Maximum HP Percent: +40, Maximum MP Percent: +40, Spell Critical Percent: +20, Familiar Weight: +3, Stench Spell Damage: +10, Spooky Damage: +10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	distilled blood thinner	1		Last Available: "2025-10"
-12045	practically non-alcoholic perfectly mixed tumbling bouncing pheromone cocktail	1	EPIC	Last Available: "2025-10"
+12045	perfectly mixed practically non-alcoholic tumbling bouncing pheromone cocktail	1	EPIC	Last Available: "2025-10"
 12046	stale huge spinal tapas	3	decent	Last Available: "2025-10"
 12047	twirling shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	MacGyver's Da Vinci's shrunken head of chilblains	0		Experience (Mysticality): +5, Maximum MP: +100, Cold Damage: +25, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	MacGyver's Da Vinci's shrunken head of chilblains	0		Experience (Mysticality): +5, Maximum MP: +100, Cold Damage: +25, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	gray stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	mirror knucklebone	0		
-12052	weak bad red Smoking Pope	2	decent	
-12053	tiny rotten prize turkey	1	crappy	
+12052	bad weak red Smoking Pope	2	decent	
+12053	rotten tiny prize turkey	1	crappy	
 12054	denatured blue medicinal gruel	1		Effect: "Barbecue Saucy", Effect Duration: 10
 12055	rotten full-sized pumpkin pie	3	crappy	Last Available: "2025-11"
 12056	tolerable maroon vodka cranberry sauce	3	good	Last Available: "2025-11"
 12057	nitrogenated yammed candy	0		Effect: "Deadly Flashing Blade", Effect Duration: 18, Last Available: "2025-11"
 12058	adequate green treasure chestnut	3	good	Last Available: "2025-12"
-12059	watered-down smooth mulled butter rum	2	awesome	Last Available: "2025-12"
+12059	smooth watered-down mulled butter rum	2	awesome	Last Available: "2025-12"
 12060	alkaline polarized cinnamon doubloon	0		Effect: "Eyes All Black", Effect Duration: 41, Last Available: "2025-12"
 12061	bouncing careful plastic left skeleton arm	0		Monster Level: -10, Last Available: "2025-12"
 12062	huge lime green wobbly beefcake's plastic left skeleton leg	0		Muscle: +25, Last Available: "2025-12"
@@ -11889,22 +11889,22 @@
 12131	dry magnetized boiling synovial fluid	0		Effect: "Cybernetic Muscles", Effect Duration: 32, Last Available: "2025-12"
 12132	avaricious aromatic rock-hard smoldering vertebra	0		Damage Reduction: 5, Stench Resistance: +1, Meat Drop: +30, Single Equip, Last Available: "2025-12"
 12133	bouncing seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	inspector's scorching chilly hot boning knife	0		Cold Damage: +5, Hot Damage: +25, Item Drop: +15, Single Equip, Last Available: "2025-12"
 12138	ribald forbidden fistbone of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Sleaze Damage: +10, Last Available: "2025-12"
 12139	electrified burnt bone belt of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2025-12"
 12140	skewed cool scorched skull trophy	0		Moxie: +5, Last Available: "2025-12"
-12141	small rotten wing bone	2	crappy	Last Available: "2025-12"
+12141	rotten small wing bone	2	crappy	Last Available: "2025-12"
 12142	special lousy weak skeleton venom	3	decent	Effect: "Weird Vibrations", Effect Duration: 40, Last Available: "2025-12"
-12143	mixed shaking red baked bone meal	1		Last Available: "2025-12"
+12143	mixed red shaking baked bone meal	1		Last Available: "2025-12"
 12144	boxer's plastic skeleton rib cage	0		Muscle Percent: +10, Last Available: "2025-12"
 12145	plastic skeleton skull of the ox	0		Muscle: +20, Last Available: "2025-12"
 12146	foul-smelling plastic skeleton Crimbo hat	0		Stench Damage: +10, Last Available: "2025-12"
 12147	bouncing assembled plastic Santa skeleton	0		Last Available: "2025-12"
 12148	sleigh	0		Familiar Weight: +10
-12149	shaking upside-down undertakers' forceps	0		Last Available: "2025-12"
+12149	upside-down shaking undertakers' forceps	0		Last Available: "2025-12"
 12150	mirror bone-polishing rag	0		Last Available: "2025-12"
 12151	wicked extremely unsafe scorched skeleton mask	0		Weapon Damage Percent: +100, Spell Damage: +5, Last Available: "2025-12"
 12152	friendly scorched skeleton shirt of the blizzard	0		Familiar Weight: +3, Cold Spell Damage: +25, Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	veiny beefcake's vermiculite shield	0		Muscle: +25, Maximum HP: +10, Damage Reduction: 9, Last Available: "2025-12"
 12169	rock-hard ship's lantern	0		Damage Reduction: 5, Last Available: "2025-12"
 12170	narrow avaricious boxer's heat-resistant harpoon pistol	0		Muscle Percent: +10, Meat Drop: +30, Last Available: "2025-12"
-12171	normal half-sized traditional gingerloaf	2	good	Last Available: "2025-12"
+12171	half-sized normal traditional gingerloaf	2	good	Last Available: "2025-12"
 12172	hand-crafted Scotch and eggnog	3	EPIC	Last Available: "2025-12"
 12173	adjusted counterskeleton elixir	0		Effect: "Chalky White Pallor", Effect Duration: 67, Last Available: "2025-12"
 12174	acceptable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	dry gray gummi fingerbone	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 58
 12179	spinning skewed blinking stiffened glimmering crystal of chilblains	0		Damage Reduction: 1, Cold Damage: +25, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	jittery loose Meats	0		
 12184	spinning Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11959,12 +11959,12 @@
 12201	brainy dinosaur bone club	0		Mysticality: +5, Last Available: "2026-03"
 12202	therapeutic shellacked dinosaur skull helmet	0		Damage Reduction: 7, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2026-03"
 12203	perfumed nasty arcane researcher's dinosaur bone corset	0		Experience Percent (Mysticality): +10, Stench Damage: +5, Stench Resistance: +5, Last Available: "2026-03"
-12204	enchanted acceptable red Pork Elf cough syrup	4	good	Effect: "Disco Inferno", Effect Duration: 5, Last Available: "2026-03"
+12204	acceptable enchanted red Pork Elf cough syrup	4	good	Effect: "Disco Inferno", Effect Duration: 5, Last Available: "2026-03"
 12205	blinking Pork Elf neti pot	0		Last Available: "2026-03"
 12206	spinning Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	adequate immense rat pizza	10	good	Last Available: "2026-03"
+12209	immense adequate rat pizza	10	good	Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	Lo Pan's stiffened smartaleck's hoverboard	0		Moxie Percent: +30, Damage Reduction: 1, Spell Critical Percent: +30, Single Equip, Last Available: "2026-03"
 12212	pulsating manspreader's left shark fin of the dark arts of the blizzard	0		Spell Damage Percent: +100, Monster Level: +10, Cold Spell Damage: +25, Last Available: "2026-03"
@@ -11977,31 +11977,31 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	bouncing legendary noodles	0		Last Available: "2026-05"
-12226	fancy decent small can of tuna	2	good	Effect: "Eye of the Seal", Effect Duration: 35
+12226	decent small fancy can of tuna	2	good	Effect: "Eye of the Seal", Effect Duration: 35
 12227	moldy alien salad	3	crappy	
-12228	miniature decent ratbatatouille	2	good	
+12228	decent miniature ratbatatouille	2	good	
 12229	jumbo moldy onigiri	5	crappy	
 12230	spoiled crudit&eacute;s	3	crappy	
-12231	rotten enchanted ghostly sauced mutton	3	crappy	Effect: "Punch Another Day", Effect Duration: 10
-12232	diet fancy flavorless hot honey ant	1	decent	Effect: "Jacked In", Effect Duration: 25
-12233	snack-sized adequate tomb aspic	2	good	
+12231	enchanted rotten ghostly sauced mutton	3	crappy	Effect: "Punch Another Day", Effect Duration: 10
+12232	fancy flavorless diet hot honey ant	1	decent	Effect: "Jacked In", Effect Duration: 25
+12233	adequate snack-sized tomb aspic	2	good	
 12234	normal enchanted later tots	3	good	Effect: "Super-Electrified", Effect Duration: 10
 12235	gigantic toothsome Frutti di Scatoletta	6	awesome	Last Available: "2026-05"
 12236	spoiled Pesto alla Marziano	3	crappy	Last Available: "2026-05"
 12237	flavorless Arrattabbattabiata	4	decent	Last Available: "2026-05"
-12238	enchanted yummy Orzo di Riso	3	awesome	Effect: "Gummibrain", Effect Duration: 15, Last Available: "2026-05"
-12239	adequate jumbo Pasta Grimavera	5	good	Last Available: "2026-05"
+12238	yummy enchanted Orzo di Riso	3	awesome	Effect: "Gummibrain", Effect Duration: 15, Last Available: "2026-05"
+12239	jumbo adequate Pasta Grimavera	5	good	Last Available: "2026-05"
 12240	decent Linguini Ubriacapa	3	good	Last Available: "2026-05"
-12241	decent bite-sized Formica e Pepe	1	good	Last Available: "2026-05"
+12241	bite-sized decent Formica e Pepe	1	good	Last Available: "2026-05"
 12242	rotten Tubetto Gelatto	3	crappy	Last Available: "2026-05"
-12243	huge bland Gnocci Domani	9	decent	Last Available: "2026-05"
+12243	bland huge Gnocci Domani	9	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	blue padded smooth Space Soldier Helmet	0		Moxie: +15, Damage Absorption: +20
 12253	spoiled premium turkey leg	4	crappy	
-12254	lousy distilled styrofoam cup of mead	5	decent	
+12254	distilled lousy styrofoam cup of mead	5	decent	
 12255	sword of the cougar	0		Moxie: +20
 12256	hale staff	0		Maximum HP: +20
 12257	veiny lute	0		Maximum HP: +10
@@ -12017,14 +12017,14 @@
 12267	Jim Carey's flimsy plastic breastplate	0		Monster Level: +25
 12268	lard-coated flimsy plastic shield	0		Sleaze Spell Damage: +25, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	bouncing stiffened fortified Portable Laughing Stock of incineration	0		Damage Absorption: +60, Damage Reduction: 1, Hot Spell Damage: +50, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	bouncing stiffened fortified Portable Laughing Stock of incineration	0		Damage Absorption: +60, Damage Reduction: 1, Hot Spell Damage: +50, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	skewed sizzling careful savvy Staff of Anachronistic Churning	0		Mysticality Percent: +20, Monster Level: -10, Hot Damage: +10
-12272	snack-sized stale classic banana	2	decent	Last Available: "2026-07"
-12273	half-sized stale watermelon	2	decent	Last Available: "2026-07"
+12272	stale snack-sized classic banana	2	decent	Last Available: "2026-07"
+12273	stale half-sized watermelon	2	decent	Last Available: "2026-07"
 12274	adequate quince	3	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	moldy big enchanted classic banana pie	5	crappy	Effect: "The Dinsey Spirit", Effect Duration: 40, Last Available: "2026-07"
+12277	big moldy enchanted classic banana pie	5	crappy	Effect: "The Dinsey Spirit", Effect Duration: 40, Last Available: "2026-07"
 12278	polarized red essential banana decoction	0		Effect: "Toast Tea", Effect Duration: 21, Last Available: "2026-07"
 12279	colloidal adjusted banana quintessence	0		Effect: "Arcane in the Brain", Effect Duration: 28, Last Available: "2026-07"
 12280	bad huge ghostly Aesop Daiquiri	3	decent	Last Available: "2026-07"
@@ -12034,15 +12034,15 @@
 12284	super-enhanced Aqua Citrulanatae	0		Effect: "Smoky Third Eye", Effect Duration: 12, Last Available: "2026-07"
 12285	artisanal Melonegroni	4	EPIC	Last Available: "2026-07"
 12286	tolerable skewed Melonade Spritz	4	good	Last Available: "2026-07"
-12287	snack-sized delicious quince pie	2	awesome	Last Available: "2026-07"
+12287	delicious snack-sized quince pie	2	awesome	Last Available: "2026-07"
 12288	modified squat quince quaff	0		Effect: "Slimily Strong", Effect Duration: 41, Last Available: "2026-07"
 12289	quantum Quickquince	0		Effect: "Thaumodynamic", Effect Duration: 61, Last Available: "2026-07"
 12290	drinkable Quiskey Sour	4	good	Last Available: "2026-07"
 12291	weak aged Quincea&ntilde;era Cooler	2	awesome	Last Available: "2026-07"
-12292	lousy practically non-alcoholic Roth IPA	1	decent	Last Available: "2026-08"
+12292	practically non-alcoholic lousy Roth IPA	1	decent	Last Available: "2026-08"
 12293	censurious brawny underdraft protection	0		Muscle Percent: +20, Sleaze Resistance: +3, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	snack-sized flavorless soybean futures	2	decent	Last Available: "2026-08"
+12295	flavorless snack-sized soybean futures	2	decent	Last Available: "2026-08"
 12296	dry gray housing bubble	0		Effect: "Memories of Puppy Love", Effect Duration: 68, Last Available: "2026-08"
 12297	altered Pixie-Swordz	0		Effect: "Mental A-cue-ity", Effect Duration: 31
 12298	shaking greedy financial instrument of the empath	0		Familiar Weight: +5, Meat Drop: +20, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wallaby_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	bad twirling Petite Porter	4	decent	
--2	weak delicious twirling Scrawny Stout	2	awesome	
+-2	delicious weak twirling Scrawny Stout	2	awesome	
 -3	lousy Infinitesimal IPA	3	decent	
 -4	tolerable eggnogtini	3	good	
 -5	delicious candycaine	3	awesome	
--6	enchanted mediocre spinning braincracker sweet	4	decent	
+-6	mediocre enchanted spinning braincracker sweet	4	decent	
 -16	tolerable fermented honey	3	good	
 -17	perfectly mixed moons-shine	3	EPIC	
 -18	drinkable boozy gin	5	good	
--19	tolerable high-proof ecto-nog	6	good	
+-19	high-proof tolerable ecto-nog	6	good	
 -20	bad hot toady	4	decent	
 -21	tolerable hot choculate	4	good	
 -49	watered-down drinkable narrow huge Cyder	2	good	
 -50	delicious Oil Nog	3	awesome	
 -51	tolerable Hi-Octane Peppermint Jet Fuel	3	good	
--58	extra-dry tolerable gray Grimacider	5	good	
+-58	tolerable extra-dry gray Grimacider	5	good	
 -59	acceptable watered-down green Isotope Nog	2	good	
--60	perfectly mixed enchanted Mutagin 'n' Tonic	3	EPIC	
--70	weak hand-crafted squat Gin and Herring	2	EPIC	
+-60	enchanted perfectly mixed Mutagin 'n' Tonic	3	EPIC	
+-70	hand-crafted weak squat Gin and Herring	2	EPIC	
 -71	drinkable twirling Black and Tan and Red All Over	4	good	
--72	hand-crafted practically non-alcoholic Antarctic Ice Tea	1	EPIC	
+-72	practically non-alcoholic hand-crafted Antarctic Ice Tea	1	EPIC	
 -76	mediocre CRIMBCO Ribbon Candy Schnapps	4	decent	
--77	watered-down aged mirror CRIMBCO Egg Substitute Nog Substitute	2	awesome	
+-77	aged watered-down mirror CRIMBCO Egg Substitute Nog Substitute	2	awesome	
 -78	artisanal skewed CRIMBCO Extreme Braincracker Sour	3	EPIC	
 -82	delicious fortified Horseradish-infused Vodka	5	awesome	
--83	irresponsibly strong perfectly mixed Jerkitini	7	EPIC	
+-83	perfectly mixed irresponsibly strong Jerkitini	7	EPIC	
 -84	lousy Desert Island Iced Tea	3	decent	
 -88	fortified lousy Crimbo Saketini	5	decent	
 -89	lousy Crimboku Drop	4	decent	
 -90	extra-dry drinkable Flaming Crimbo Log	5	good	
 -107	spirit-forward bad mirror Fortified Eggnog Slurry	5	decent	
--108	weak tolerable red Hot Buttered Rum	2	good	
--109	triple-distilled drinkable teal squat Spicy Hot Chocolate	6	good	
+-108	tolerable weak red Hot Buttered Rum	2	good	
+-109	drinkable triple-distilled teal squat Spicy Hot Chocolate	6	good	

--- a/data/TCRS/TCRS_Seal_Clubber_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wallaby_cafe_food.txt
@@ -1,42 +1,42 @@
 -1	rotten twirling Peche a la Frog	4	crappy	
 -2	decent snack-sized twirling As Jus Gezund Heit	2	good	
 -3	spoiled Bouillabaise Coucher Avec Moi	3	crappy	
--7	low-calorie adequate gumdrop chow mein	1	good	
--8	stale enchanted candy cane pizza	3	decent	
+-7	adequate low-calorie gumdrop chow mein	1	good	
+-8	enchanted stale candy cane pizza	3	decent	
 -9	immense rotten gingerbread stir-fry	8	crappy	
 -10	bland twigs and gravel	4	decent	
 -11	decent shoots and leaves	4	good	
 -12	decent bowl of unidentifiable goo	4	good	
--13	normal half-sized spinning gingerbread massacre	2	good	
+-13	half-sized normal spinning gingerbread massacre	2	good	
 -14	fancy tasty It Came From Beyond Dessert	4	awesome	
 -15	rotten mirror vampire cake	3	crappy	
--52	half-sized toothsome Soylent Red and Green	2	awesome	
--53	immense adequate Disc-Shaped Nutrition Unit	6	good	
+-52	toothsome half-sized Soylent Red and Green	2	awesome	
+-53	adequate immense Disc-Shaped Nutrition Unit	6	good	
 -54	low-calorie normal jittery Gingerborg Hive	1	good	
 -61	gigantic normal Candy Cane Surprise	10	good	
 -62	rotten upside-down Grimdrop Chow Mein	3	crappy	
 -63	tasty enchanted red Grimgerbread House	3	awesome	
--67	normal thick Caviar Carbonara	5	good	
--68	spoiled huge mirror Halibut Alfredo	9	crappy	
--69	stale big squat Red Herring Velvet Cake	5	decent	
+-67	thick normal Caviar Carbonara	5	good	
+-68	huge spoiled mirror Halibut Alfredo	9	crappy	
+-69	big stale squat Red Herring Velvet Cake	5	decent	
 -73	bite-sized flavorless CRIMBCO Reconstituted Gruel	1	decent	
--74	snack-sized moldy pulsating narrow New and Improved CRIMBCO Reconstituted Gruel	2	crappy	
+-74	moldy snack-sized pulsating narrow New and Improved CRIMBCO Reconstituted Gruel	2	crappy	
 -75	flavorless skewed CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	decent	
--79	super-sized yummy Brussels Sprout Stir-Fry	5	awesome	
+-79	yummy super-sized Brussels Sprout Stir-Fry	5	awesome	
 -80	bland tumbling Carrot, Cabbage, and Kale Pizza	4	decent	
 -81	tasty narrow Turnip and Rutabaga Pie	4	awesome	
 -85	stale shaking Rainbow Spider Fun Roll	4	decent	
 -86	moldy half-sized Vegas Volcano Lava Roll	2	crappy	
--87	bland big Crazy Dragon Shogun Buddha Roll	5	decent	
+-87	big bland Crazy Dragon Shogun Buddha Roll	5	decent	
 -92	enchanted stale basic hot dog	3	decent	
 -93	yummy blurry savage macho dog	4	awesome	
 -94	delicious one with everything	3	awesome	
 -95	decent sly dog	4	good	
 -96	moldy devil dog	4	crappy	
--97	fancy decent twirling chilly dog	3	good	
+-97	decent fancy twirling chilly dog	3	good	
 -98	moldy jittery ghost dog	4	crappy	
 -99	bland immense junkyard dog	7	decent	
--100	special miniature stale wet dog	2	decent	
+-100	stale miniature special wet dog	2	decent	
 -101	flavorless sleeping dog	3	decent	
 -102	rotten huge optimal dog	3	crappy	
 -103	bland narrow video games hot dog	3	decent	

--- a/data/TCRS/TCRS_Seal_Clubber_Wombat.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wombat.txt
@@ -43,9 +43,9 @@
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	pulsating figurine	0		
-47	spoiled red mirror hot buttered roll	3	crappy	
+47	spoiled mirror red hot buttered roll	3	crappy	
 48	narrow heart of rock and roll	0		
-49	jumbo stale narrow jittery bowl of cottage cheese	5	decent	
+49	stale jumbo narrow jittery bowl of cottage cheese	5	decent	
 50	green therapeutic Rock and Roll Legend	0		HP Regen Min: 5, HP Regen Max: 7, Class: "Accordion Thief", Song Duration: 10
 51	experienced Knob Goblin Uberpants	0		Experience: +2, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	banjo strings	0		
@@ -71,7 +71,7 @@
 72	barskin hat of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 13"
 73	gray barskin tent	0		
 74	Temple map	0		
-75	shaking ghostly sapling	0		
+75	ghostly shaking sapling	0		
 76	blinking pulsating Spooky-Gro fertilizer	0		
 77	smelly stick	0		Stench Spell Damage: +10
 78	pretty bouquet of Gandalf	0		Spell Critical Percent: +20
@@ -98,10 +98,10 @@
 99	meat face	0		
 100	lifeless meat doll	0		
 101	lime green meat golem	0		
-102	bouncing lime green shrunken head	0		
+102	lime green bouncing shrunken head	0		
 103	blue huge frightening frosty staff	0		Cold Spell Damage: +10, Spooky Damage: +5
 104	scarecrow	0		
-105	rotten big bowl of charms	5	crappy	
+105	big rotten bowl of charms	5	crappy	
 106	ketchup	1	decent	
 107	purple catsup	1	crappy	
 108	stick	0		
@@ -167,7 +167,7 @@
 168	nasty bone rattle	0		Stench Damage: +5
 169	pulsating bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
-171	gigantic toothsome special lihc eye pie	9	awesome	Effect: "No Vertigo", Effect Duration: 25
+171	toothsome special gigantic lihc eye pie	9	awesome	Effect: "No Vertigo", Effect Duration: 25
 172	gnoll lips	0		
 173	olive taco shell	0		
 174	Gnollish casserole dish	0		
@@ -176,7 +176,7 @@
 177	spinning brainy skull	0		
 178	ghostly detective skull	0		
 179	delicious half-sized chorizo taco	2	awesome	
-180	tolerable extra-dry ice-cold fotie	5	good	
+180	extra-dry tolerable ice-cold fotie	5	good	
 181	baseball	0		
 182	batgut	0		
 183	wobbly wobbly bat wing	0		
@@ -199,19 +199,19 @@
 201	normal bat wing kabob	4	good	
 202	spoiled carob chunks	3	crappy	
 203	herbs	0		
-204	normal miniature cyan carob chunk cookies	2	good	
+204	miniature normal cyan carob chunk cookies	2	good	
 205	secret blend of herbs and spices	0		
-206	twirling shaking piercing post	0		
+206	shaking twirling piercing post	0		
 207	hippy herbal tea	1	decent	
 208	patchouli incense stick	0		
 209	upside-down wad of tofu	0		
 210	pulsating Feng Shui for Big Dumb Idiots	0		
-211	wobbly lime green decorative fountain	0		
+211	lime green wobbly decorative fountain	0		
 212	windchimes	0		
 213	jittery perfumed scorching filthy corduroys	0		Hot Damage: +25, Stench Resistance: +5, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	Rosewater's filthy knitted dread sack	0		Mysticality Percent: +30, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	squat Uncle Jick's Brownie Mix	0		
-216	fancy moldy carob brownies	4	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 35
+216	moldy fancy carob brownies	4	crappy	Effect: "Your Eyes are Peeled!", Effect Duration: 35
 217	normal herb brownies	3	good	
 218	hemp string	0		
 219	skewed skewed necklace chain	0		
@@ -220,7 +220,7 @@
 222	phat turquoise bead	0		
 223	wicked phat turquoise bracelet	0		Spell Damage: +5
 224	wobbly red executive eyepatch	0		Meat Drop: +40, Familiar Effect: "3xBarrr, cap 6"
-225	miniature moldy tofu casserole	2	crappy	
+225	moldy miniature tofu casserole	2	crappy	
 226	dehydrated can of Red Minotaur	1	decent	Effect: "The Power of Negative Thinking", Effect Duration: 20
 227	mirror Tesla Kentucky-fried meat sword	0		MP Regen Min: 7, MP Regen Max: 10
 228	wobbly Kentucky-fried meat staff of the boozehound	0		Booze Drop: +100
@@ -238,27 +238,27 @@
 240	ghostly nippy Orcish cargo shorts of the blizzard	0		Cold Damage: +10, Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	horrifying Orcish frat-paddle	0		Spooky Damage: +25
 242	moldy small wobbly	2	crappy	
-243	enchanted bland miniature jittery grapefruit	2	decent	Effect: "Boo Tea", Effect Duration: 40
+243	miniature bland enchanted jittery grapefruit	2	decent	Effect: "Boo Tea", Effect Duration: 40
 244	normal grapes	4	good	
 245	spoiled fancy olive	3	crappy	Effect: "Hairless and Airless", Effect Duration: 50
 246	low-calorie moldy tomato	1	crappy	
 247	fermenting powder	0		
-248	practically non-alcoholic acceptable ghostly salty dog	1	good	
+248	acceptable practically non-alcoholic ghostly salty dog	1	good	
 249	drinkable yellow bloody mary	3	good	
-250	irresponsibly strong delicious blinking screwdriver	10	awesome	
+250	delicious irresponsibly strong blinking screwdriver	10	awesome	
 251	irresponsibly strong hand-crafted martini	9	EPIC	
-252	watered-down artisanal bloody beer	2	EPIC	
+252	artisanal watered-down bloody beer	2	EPIC	
 253	artisanal weak twirling shot of schnapps	2	EPIC	
-254	acceptable weak shot of grapefruit schnapps	2	good	
+254	weak acceptable shot of grapefruit schnapps	2	good	
 255	tolerable weak fine wine	2	good	
-256	tolerable watered-down shaking blurry shot of tomato schnapps	2	good	
+256	watered-down tolerable shaking blurry shot of tomato schnapps	2	good	
 257	mediocre extra-spicy bloody mary	4	decent	
 258	dense meat stack	0		
 259	blue snake skin	0		
-260	moldy miniature huge White Citadel fries	2	crappy	
+260	miniature moldy huge White Citadel fries	2	crappy	
 261	flavorless squat White Citadel burger	4	decent	
-262	fancy adequate snack-sized piece of wedding cake	2	good	Effect: "Mo' Hobo", Effect Duration: 15
-263	flavorless big chocolate chips	5	decent	
+262	adequate fancy snack-sized piece of wedding cake	2	good	Effect: "Mo' Hobo", Effect Duration: 15
+263	big flavorless chocolate chips	5	decent	
 264	bland big chocolate chip cookies	5	decent	
 265	stylish satin pants	0		Moxie: +25, Familiar Effect: "atk, 2xPotato, cap 10"
 266	perfectly mixed lightning	3	EPIC	
@@ -266,13 +266,13 @@
 268	meat cowboy hat of the bloodbag	0		Maximum HP: +100, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	wobbly family-friendly sword	0		Sleaze Resistance: +1
 270	picket fence	0		
-271	modified huge blue pulsating barbell	1		
+271	modified pulsating huge blue barbell	1		
 272	powdered green concentrated magicalness pill	1		Effect: "Booze Goozles", Effect Duration: 35
 273	boiled spinning moxie weed	1		
 274	spinning Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	powdered wobbly purple extra-strength strongness elixir	1		Effect: "Crocodile Tear", Effect Duration: 20
+277	powdered purple wobbly extra-strength strongness elixir	1		Effect: "Crocodile Tear", Effect Duration: 20
 278	pickled ghostly jug-o-magicalness	1		
 279	distilled tumbling suntan lotion of moxiousness	1		Effect: "Human-Constellation Hybrid", Effect Duration: 35
 280	Pick-O-Matic lockpicks	0		
@@ -283,7 +283,7 @@
 285	twirling groovy walrus-tusk earring	0		Moxie Percent: +10
 286	rosy-cheeked ring of half-assed regeneration	0		Maximum HP Percent: +30, Single Equip
 287	electrified Boris's ring	0		MP Regen Min: 3, MP Regen Max: 5
-288	huge ghostly potato sprout	0		
+288	ghostly huge potato sprout	0		
 289	Da Vinci's Jarlsberg's earring	0		Experience (Mysticality): +5
 290	frosty Sneaky Pete's breath spray	0		Cold Spell Damage: +10
 291	slick can of maces of chilblains	0		Moxie: +10, Cold Damage: +25
@@ -292,13 +292,13 @@
 294	mirror jittery smartaleck's pail	0		Moxie Percent: +30, Familiar Effect: "2xFairy, cap 7"
 295	demonskin trousers of terror	0		Spooky Spell Damage: +10, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	huge green dungeoneer's dungarees of chilblains	0		Cold Damage: +25, Familiar Effect: "stench atk, 4xPotato, cap 7"
-297	colloidal bouncing purple tamarind-flavored chewing gum	0		Effect: "Ooh, Bitter!", Effect Duration: 40
+297	colloidal purple bouncing tamarind-flavored chewing gum	0		Effect: "Ooh, Bitter!", Effect Duration: 40
 298	boiled triple-pickled ghostly lime-and-chile-flavored chewing gum	0		Effect: "You Know Who to Call", Effect Duration: 59
 299	extra-unsweetened cold-filtered pickle-flavored chewing gum	0		Effect: "Crying, Dying", Effect Duration: 50
 300	magnetized deionized warmed jaba&ntilde;ero-flavored chewing gum	0		Effect: "Puzzle Fury", Effect Duration: 53
 301	green flat dough	0		
-302	adequate immense Knob sausage	10	good	
-303	snack-sized tasty Knob mushroom	2	awesome	
+302	immense adequate Knob sausage	10	good	
+303	tasty snack-sized Knob mushroom	2	awesome	
 304	dry noodles	0		
 305	mirror Knob Goblin harem pants of Leguizamo	0		Monster Level: +20, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	groovy Knob Goblin harem veil	0		Moxie Percent: +10, Familiar Effect: "5xLep, cap 2"
@@ -309,20 +309,20 @@
 311	hill of beans	0		
 312	mirror Knob Goblin visor of the detective	0		Item Drop: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	jittery fireproof Crown of the Goblin King	0		Hot Resistance: +3, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	decent small bean burrito	2	good	
+314	small decent bean burrito	2	good	
 315	decent blinking bean burrito	3	good	
 316	bland skewed insanely bean burrito	3	decent	
 317	adequate bean burrito	3	good	
 318	bland bean burrito	3	decent	
-319	normal snack-sized enchanted insanely bean burrito	2	good	Effect: "Mushroom Moxiousness", Effect Duration: 20
+319	enchanted normal snack-sized insanely bean burrito	2	good	Effect: "Mushroom Moxiousness", Effect Duration: 20
 320	adequate bat haggis	4	good	
 321	toothsome menudo	4	awesome	
 322	adequate jumbo tumbling goat cheese	5	good	
-323	super-sized rotten special plain pizza	5	crappy	Effect: "Hare-o-dynamic", Effect Duration: 25
-324	massive flavorless purple sausage pizza	10	decent	
-325	bland low-calorie goat cheese pizza	1	decent	
+323	rotten special super-sized plain pizza	5	crappy	Effect: "Hare-o-dynamic", Effect Duration: 25
+324	flavorless massive purple sausage pizza	10	decent	
+325	low-calorie bland goat cheese pizza	1	decent	
 326	yummy huge mushroom pizza	10	awesome	
-327	pulsating blurry goat	0		
+327	blurry pulsating goat	0		
 328	acceptable fuchsia bottle of whiskey	3	good	
 329	double-paned goat beard	0		Cold Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 15"
 330	huge huge glass of goat's milk	1	good	
@@ -353,13 +353,13 @@
 355	eXtreme scarf of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	lightning-fast snowboarder pants	0		Initiative: +40, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	diet adequate gr8ps	1	good	
+358	adequate diet gr8ps	1	good	
 359	thick flavorless t8r tots	5	decent	
 360	mirror shellacked miner's helmet	0		Damage Reduction: 7, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	shaking stylish miner's pants	0		Moxie: +25, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	twirling 7-Foot Dwarven mattock of Tarzan	0		Experience (Muscle): +3
 363	linoleum ore	0		
-364	spinning shaking asbestos ore	0		
+364	shaking spinning asbestos ore	0		
 365	chrome ore	0		
 366	linoleum sword hilt	0		
 367	linoleum stick	0		
@@ -390,7 +390,7 @@
 392	olive horrifying chrome helmet turtle	0		Spooky Damage: +25, Familiar Effect: "cold atk, 1xFairy, cap 30"
 393	penguin skin	0		
 394	squat blinking gray yak skin	0		
-395	tumbling shaking hippopotamus skin	0		
+395	shaking tumbling hippopotamus skin	0		
 396	jittery blue family-friendly penguin shorts	0		Sleaze Resistance: +1, Familiar Effect: "cold atk, 1xGhuol, cap 30"
 397	narrow clever yakskin pants	0		Maximum MP: +20, Familiar Effect: "stench atk, 1xPotato, cap 35"
 398	wicked hippopotamus pants	0		Spell Damage: +5, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
@@ -418,7 +418,7 @@
 420	dry bouncing tomato juice of powerful power	0		Effect: "Cat-Alyzed", Effect Duration: 15
 421	double-improved corrupted philter of phorce	0		Effect: "Triangle, Man", Effect Duration: 54
 422	adjusted enhanced purple potion of potency	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 45
-423	modified polymerized ghostly huge skewed cordial of concentration	0		Effect: "Thickest, Sickest", Effect Duration: 17
+423	modified polymerized ghostly skewed huge cordial of concentration	0		Effect: "Thickest, Sickest", Effect Duration: 17
 424	pickled ointment of the occult	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 46
 425	energized polarized nitrogenated ghostly oil of expertise	0		Effect: "Provocative Perkiness", Effect Duration: 32
 426	vacuum-sealed liquefied maroon skewed potion of temporary gr8ness	0		Effect: "Nutrient-Rich", Effect Duration: 16
@@ -436,7 +436,7 @@
 438	chef-in-the-box	0		
 439	bartender skull	0		
 440	bartender-in-the-box	0		
-441	wobbly tumbling chef-skull-in-the-box	0		
+441	tumbling wobbly chef-skull-in-the-box	0		
 442	bartender-skull-in-the-box	0		
 443	beer lens	0		
 444	tumbling beer goggles	0		
@@ -446,23 +446,23 @@
 448	rosewater-soaked savvy foolscap fool's cap	0		Mysticality Percent: +20, Stench Resistance: +3, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	clown nose of the wise owl	0		Mysticality: +20, Clowniness: 25
 450	pretentious paintbrush	0		
-451	tumbling blurry pretentious palette	0		
+451	blurry tumbling pretentious palette	0		
 452	ghostly disease	0		
 453	sober pill	0		
 454	cyan screwdriver	0		
-455	small flavorless jumbo olive	2	decent	
-456	lousy triple-distilled maroon dry martini	9	decent	
+455	flavorless small jumbo olive	2	decent	
+456	triple-distilled lousy maroon dry martini	9	decent	
 457	flame-wreathed ye olde golde frontes	0		Hot Spell Damage: +10, Class: "Disco Bandit", Single Equip
-458	spinning twirling continuum transfunctioner	0		
+458	twirling spinning continuum transfunctioner	0		
 459	lime green pixel	0		
 460	pixel	0		
 461	pixel	0		
-462	squat wobbly pixel	0		
+462	wobbly squat pixel	0		
 463	pixel	0		
 464	pixel potion	0		
 465	gray pixel potion	0		
 466	pixel potion	0		
-467	bland massive pixel pie	7	decent	
+467	massive bland pixel pie	7	decent	
 468	ruby W	0		
 469	bouncing cyan wussiness potion	0		
 470	hand-crafted practically non-alcoholic Imp Ale	1	EPIC	
@@ -471,7 +471,7 @@
 473	huge twirling smelly crutch	0		Stench Spell Damage: +10
 474	cast	0		
 475	blinking rosy-cheeked mask of incineration	0		Maximum HP Percent: +30, Hot Spell Damage: +50, Familiar Effect: "sleaze atk, 1xBarrr, cap 15"
-476	bouncing squat hellion cube	0		
+476	squat bouncing hellion cube	0		
 477	squat arcane researcher's infernal insoles of vim and vigor	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +50
 478	evil arch	0		
 479	dodecagram	0		
@@ -490,7 +490,7 @@
 492	pulsating nippy rock-hard chaps	0		Damage Reduction: 5, Cold Damage: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	shaking mirror ketchup hound	0		
 494	skewed chaotic batblade	0		Spell Critical Percent: +10
-495	ghostly spinning fuchsia catgut	0		
+495	fuchsia spinning ghostly catgut	0		
 496	pulsating cat appendix	0		
 497	gnatwing	0		
 498	bland diet papaya	1	decent	
@@ -501,16 +501,16 @@
 503	decent skewered cat appendix	3	good	
 504	skewed evil arches	0		
 505	pulsating greasy crafty gnatwing earring	0		Maximum MP: +10, Sleaze Spell Damage: +10
-506	rotten snack-sized Hell broth	2	crappy	
+506	snack-sized rotten Hell broth	2	crappy	
 507	blue foul-smelling thunderrr guitarrr	0		Stench Damage: +10
 508	sonata	0		
 509	Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	huge Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	bland miniature ghostly Boris's key lime pie	2	decent	
+513	miniature bland ghostly Boris's key lime pie	2	decent	
 514	immense adequate Jarlsberg's key lime pie	9	good	
-515	stale thick Sneaky Pete's key lime pie	5	decent	
+515	thick stale Sneaky Pete's key lime pie	5	decent	
 516	yellow Hey Deze map	0		
 517	teal Socratic bejeweled accordion strap	0		Experience (Mysticality): +1, Class: "Accordion Thief"
 518	squat blurry mystery juice	0		
@@ -549,10 +549,10 @@
 551	64067 scroll	0		
 552	64735 scroll	0		
 553	31337 scroll	0		
-554	small flavorless pr0n cocktail	2	decent	
+554	flavorless small pr0n cocktail	2	decent	
 555	blurry Da Vinci's drywall axe of Calamity Jane	0		Experience (Mysticality): +5, Critical Hit Percent: +15
 556	red deadly Pine-Fresh air freshener	0		Weapon Damage: +5
-557	weak special perfectly mixed whiskey and cola	2	EPIC	Effect: "20-20 Second Sight", Effect Duration: 20
+557	special weak perfectly mixed whiskey and cola	2	EPIC	Effect: "20-20 Second Sight", Effect Duration: 20
 558	rotten tumbling papaya taco	3	crappy	
 559	razor-sharp can lid	0		
 560	stale fuchsia stalk of asparagus	3	decent	
@@ -562,27 +562,27 @@
 564	lousy Mad Train wine	3	decent	
 565	blurry squat hobo gloves of the wise owl	0		Mysticality: +20, Single Equip
 566	hale bum cheek	0		Maximum HP: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
-567	olive squat hermit script	0		
+567	squat olive hermit script	0		
 568	special moldy super-sized Double Bacon Beelzeburger	5	crappy	Effect: "Space Cadet", Effect Duration: 20
-569	yummy jittery red Lord of the Flies-sized fries	3	awesome	
+569	yummy red jittery Lord of the Flies-sized fries	3	awesome	
 570	moldy Chicken Sandwich	3	crappy	
 571	Jumbo Dr. Lucifer	1	EPIC	
 572	immense normal Children's Meal of the Damned	10	good	
 573	normal half-sized pulsating noodles	2	good	
-574	flavorless gigantic noodles	9	decent	
+574	gigantic flavorless noodles	9	decent	
 575	flavorless painful penne pasta	3	decent	
 576	spoiled ghostly ravioli della hippy	3	crappy	
 577	normal bite-sized pr0n m4nic0tti	1	good	
-578	half-sized special spoiled Hell ramen	2	crappy	Effect: "Stuck That Way", Effect Duration: 50
-579	miniature bland boring spaghetti	2	decent	
+578	spoiled half-sized special Hell ramen	2	crappy	Effect: "Stuck That Way", Effect Duration: 50
+579	bland miniature boring spaghetti	2	decent	
 580	squat sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	wobbly Himalayan Hidalgo sauce	0		
-583	big toothsome jittery fettucini Inconnu	5	awesome	
+583	toothsome big jittery fettucini Inconnu	5	awesome	
 584	normal small spaghetti with Skullheads	2	good	
 585	normal gnocchetti di Nietzsche	3	good	
 586	prompt ridiculously huge sword of the cougar	0		Moxie: +20, Adventures: +3
-587	enhanced unsweetened green blurry upside-down super-spiky hair gel	0		Effect: "Oiled Skin", Effect Duration: 31
+587	enhanced unsweetened upside-down blurry green super-spiky hair gel	0		Effect: "Oiled Skin", Effect Duration: 31
 588	soft echo eyedrop antidote	0		
 589	fancy bland cocoa eggshell fragment	4	decent	Effect: "Brother Smothers's Blessing", Effect Duration: 15
 590	adequate cocoa eggshell fragment	3	good	
@@ -612,7 +612,7 @@
 614	pressed unsweetened probability potion	0		Effect: "Squirming Like a Toad", Effect Duration: 50
 615	pulsating chaos butterfly	0		
 616	furry fur	0		
-617	triple-dry anodized teal skewed Angry Farmer candy	0		Effect: "Patched In", Effect Duration: 19
+617	triple-dry anodized skewed teal Angry Farmer candy	0		Effect: "Patched In", Effect Duration: 19
 618	vacuum-sealed dry blurry Mick's IcyVapoHotness Rub	0		Effect: "The Q Is Talking To You", Effect Duration: 20
 619	MacGyver's needle	0		Maximum MP: +100
 620	electrified extra-enhanced thin candle	0		Effect: "Memory of Attractiveness", Effect Duration: 60
@@ -644,8 +644,8 @@
 646	spoiled huge fruitcake	6	crappy	
 647	present	0		Last Available: "2004-11"
 648	twirling rosewater-soaked Crimbo sword	0		Stench Resistance: +3, Last Available: "2004-10"
-649	auspicious Crimbo hat	0		Item Drop: +10, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	blue chilly Crimbo pants	0		Cold Damage: +5, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	auspicious Crimbo hat	0		Item Drop: +10, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	blue chilly Crimbo pants	0		Cold Damage: +5, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	stanky exclusive ultra-rare item	0		Stench Spell Damage: +25
 652	yellow quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,22 +664,22 @@
 666	lion tamer's savvy steaming evil of bravery	0		Mysticality Percent: +20, Experience (familiar): +2, Spooky Resistance: +5
 667	castle map	0		
 668	shaking executive spiked femur	0		Meat Drop: +40
-669	stale small ghuol guolash	2	decent	
+669	small stale ghuol guolash	2	decent	
 670	purple tumbling friendly lihc face	0		Familiar Weight: +3, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	vibrating grave robbing shovel of the overflowing toilet	0		Maximum MP Percent: +10, Stench Spell Damage: +50
 672	decent cranberries	4	good	
-673	irresponsibly strong artisanal vodka and cranberry	7	EPIC	
+673	artisanal irresponsibly strong vodka and cranberry	7	EPIC	
 674	artisanal whiskey	3	EPIC	
 675	censurious skull of the Bonerdagon	0		Sleaze Resistance: +3
 676	green dragonbone belt buckle	0		
 677	chaotic badass belt	0		Spell Critical Percent: +10
 678	twirling chest of the Bonerdagon	0		
-679	smooth watered-down olive roll in the hay	2	awesome	
+679	watered-down smooth olive roll in the hay	2	awesome	
 680	hand-crafted slap and tickle	3	EPIC	
 681	practically non-alcoholic perfectly mixed slip 'n' slide	1	super ultra mega turbo EPIC	
 682	tolerable a sump'm sump'm	3	good	
 683	drinkable weak horizontal tango	2	good	
-684	practically non-alcoholic perfectly mixed pink pony	1	super ultra mega turbo EPIC	
+684	perfectly mixed practically non-alcoholic pink pony	1	super ultra mega turbo EPIC	
 685	skewed lard-coated Annie Oakley's Mr. Shirt of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +20, Sleaze Spell Damage: +25
 686	wobbly thinker's knuckles	0		Mysticality: +10
 687	boiled pulsating blood of the Wereseal	0		Effect: "Polar Express", Effect Duration: 57
@@ -716,12 +716,12 @@
 720	huge electrified hardy porquoise necklace	0		Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 721	blinking stiffened strapping porquoise bracelet	0		Muscle: +5, Damage Reduction: 1
 722	medical-grade studded groovy porquoise ring	0		Moxie Percent: +10, Damage Absorption: +80, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-723	decent big special Knoll mushroom	5	good	Effect: "Ass Over Teakettle", Effect Duration: 30
+723	special big decent Knoll mushroom	5	good	Effect: "Ass Over Teakettle", Effect Duration: 30
 724	spoiled jittery mushroom	3	crappy	
 725	one million meat pancakes	0		
 726	rock-hard huge mirror shard	0		Damage Reduction: 5
 727	yellow skewed hedge maze puzzle	0		
-728	blurry skewed hedge maze key	0		
+728	skewed blurry hedge maze key	0		
 729	fishbowl	0		
 730	pulsating fishtank	0		
 731	twirling fish hose	0		
@@ -735,19 +735,19 @@
 739	maroon tambourine bells	0		
 740	toasty tambourine	0		Hot Damage: +5
 741	broken skull	0		
-742	adequate big blue Knoll shroomkabob	5	good	
-743	miniature spoiled teal mushroom	2	crappy	
+742	big adequate blue Knoll shroomkabob	5	good	
+743	spoiled miniature teal mushroom	2	crappy	
 744	non-frozen energized huge hair spray	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 32
 746	stat script	0		
 747	Knob Goblin firecracker	0		
 748	upside-down blurry gourd potion	0		
-749	massive toothsome tumbling warm mushroom	8	awesome	
-750	stale fancy half-sized mushroom quesadilla	2	decent	Effect: "Saucegoggles", Effect Duration: 10
+749	toothsome massive tumbling warm mushroom	8	awesome	
+750	half-sized stale fancy mushroom quesadilla	2	decent	Effect: "Saucegoggles", Effect Duration: 10
 751	normal cool mushroom	4	good	
-752	stale tiny mirror cool mushroom casserole	1	decent	
+752	tiny stale mirror cool mushroom casserole	1	decent	
 753	bland pointy mushroom	3	decent	
 754	miniature normal cream of pointy mushroom soup	2	good	
-755	bite-sized stale mushroom	1	decent	
+755	stale bite-sized mushroom	1	decent	
 756	tasty squat mushroom	4	awesome	
 757	thick moldy mushroom	5	crappy	
 758	rotten ghost cucumber	4	crappy	
@@ -756,7 +756,7 @@
 761	brine	0		
 762	artisanal cyan especially salty dog	4	EPIC	
 763	olive ghostly pickling solution	0		
-764	bland thick spectral pickle	5	decent	
+764	thick bland spectral pickle	5	decent	
 765	briny vinegar	0		
 766	twirling pulsating ghost pickle on a stick	0		
 767	oxidized boiled bouncing cologne of contempt	0		Effect: "Heart of Orange", Effect Duration: 55
@@ -767,7 +767,7 @@
 772	weightlifter's foon	0		Muscle: +15
 773	experienced beefcake's basic meat spork	0		Muscle: +25, Experience: +2
 774	upside-down auspicious medical-grade basic meat foon	0		Item Drop: +10, HP Regen Min: 7, HP Regen Max: 10
-775	pulsating upside-down Yeti Protest Sign	0		
+775	upside-down pulsating Yeti Protest Sign	0		
 776	ghostly MacGyver's kneecapping stick	0		Maximum MP: +100
 777	mirror ribald iron pasta spoon	0		Sleaze Damage: +10
 778	blinking support cummerbund of terror	0		Spooky Spell Damage: +10
@@ -782,32 +782,32 @@
 787	mediocre bottle of rum	3	decent	
 788	artisanal strawberry daiquiri	4	EPIC	
 789	bad spinning rum and cola	3	decent	
-790	delicious watered-down special grog	2	awesome	Effect: "Gummi Badass", Effect Duration: 45
+790	special watered-down delicious grog	2	awesome	Effect: "Gummi Badass", Effect Duration: 45
 791	friendly stylish Mafia bow tie	0		Moxie: +25, Familiar Weight: +3, Last Available: "2004-10"
 792	flame-wreathed Golden Mr. Accessory	0		Hot Spell Damage: +10, Softcore Only
 793	enhanced moist double-activated pulsating oil of stability	0		Effect: "Perfect Hair", Effect Duration: 24
-794	chilled oxidized blurry jittery gray oil of slipperiness	0		Effect: "Extra Terrestrial", Effect Duration: 20
-795	acceptable high-proof upside-down red Acque Luride Grezze Cabernet	8	good	Last Available: "2004-10"
+794	chilled oxidized jittery blurry gray oil of slipperiness	0		Effect: "Extra Terrestrial", Effect Duration: 20
+795	acceptable high-proof red upside-down Acque Luride Grezze Cabernet	8	good	Last Available: "2004-10"
 796	lightning-fast knitted weightlifter's cement shoes	0		Muscle: +15, Cold Resistance: +3, Initiative: +40, Last Available: "2004-10"
 797	artisanal rockin' wagon	3	EPIC	
-798	weak acceptable ocean motion	2	good	
-799	fortified artisanal fuzzbump	5	EPIC	
-800	normal miniature poutine	2	good	
+798	acceptable weak ocean motion	2	good	
+799	artisanal fortified fuzzbump	5	EPIC	
+800	miniature normal poutine	2	good	
 801	moldy small Knob stir-fry	2	crappy	
 804	spoiled blurry Knoll stir-fry	4	crappy	
 805	bland stir-fry	3	decent	
-806	low-calorie delicious asparagus stir-fry	1	awesome	
+806	delicious low-calorie asparagus stir-fry	1	awesome	
 807	adequate miniature olive stir-fry	2	good	
-808	special snack-sized decent Knob sausage stir-fry	2	good	Effect: "Smoky Third Eye", Effect Duration: 35
+808	special decent snack-sized Knob sausage stir-fry	2	good	Effect: "Smoky Third Eye", Effect Duration: 35
 809	special flavorless bat wing stir-fry	4	decent	Effect: "Ass Over Teakettle", Effect Duration: 25
 810	rotten rat appendix stir-fry	4	crappy	
-811	fancy stale tofu stir-fry	3	decent	Effect: "Slightly Larger Than Usual", Effect Duration: 20
+811	stale fancy tofu stir-fry	3	decent	Effect: "Slightly Larger Than Usual", Effect Duration: 20
 812	flavorless pr0n stir-fry	3	decent	
 813	tasty Knob shells	3	awesome	
 814	toothsome diet b&auml;tzle	1	awesome	
 815	miniature bland bouncing ratini	2	decent	
 816	adequate gray Knob stroganoff	3	good	
-817	bland snack-sized gray menudo ravioli	2	decent	
+817	snack-sized bland gray menudo ravioli	2	decent	
 818	plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
@@ -829,16 +829,16 @@
 836	normal mind flayer corpse	3	good	
 837	bad upside-down Uovo Marcio Shiraz	3	decent	Last Available: "2004-10"
 838	Lo Pan's Mafia stogie of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +30, Last Available: "2004-10"
-839	watered-down bad Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
+839	bad watered-down Maiali Sifilitici Pinot Noir	2	decent	Last Available: "2004-10"
 840	executive greasy Mafia violin case	0		Sleaze Spell Damage: +10, Meat Drop: +40, Last Available: "2004-10"
 841	lousy tomato daiquiri	3	decent	
 842	practically non-alcoholic smooth blue beertini	1	awesome	
-843	practically non-alcoholic perfectly mixed salty slug	1	EPIC	
-844	drinkable extra-dry tumbling olive papaya slung	5	good	
+843	perfectly mixed practically non-alcoholic salty slug	1	EPIC	
+844	extra-dry drinkable tumbling olive papaya slung	5	good	
 845	Jeselnik's MAHI fez	0		Sleaze Damage: +25, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
-849	wobbly jittery Meat detector	0		Familiar Weight: +5
+849	jittery wobbly Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
 851	prosthetic forehead	0		Familiar Weight: +5
 852	shaker of salt	0		Familiar Weight: +5
@@ -857,11 +857,11 @@
 865	lead necklace	0		Familiar Weight: +3
 866	squat shaving cream	0		
 867	activated pine tar	0		Effect: "The Halls of Muscularity", Effect Duration: 29
-869	green spinning twirling forest tears	0		
+869	spinning twirling green forest tears	0		
 870	Temple Grandin's fetus-smashing club	0		Familiar Weight: +7
 871	twirling meatcar model	0		Familiar Weight: +5
 872	blinking Time Juice	0		Last Available: "2004-01"
-873	twirling pulsating rolling pin	0		
+873	pulsating twirling rolling pin	0		
 874	unrolling pin	0		
 875	dog trainer's medical-grade rock-hard crazy bastard sword	0		Damage Reduction: 5, Experience (familiar): +1, HP Regen Min: 7, HP Regen Max: 10
 876	jittery squat thinker's incredibly dense meat gem of James Dean of the early riser	0		Mysticality: +10, Experience (Moxie): +3, Adventures: +7
@@ -892,7 +892,7 @@
 901	red espresso maker	0		Familiar Weight: +5
 902	blue 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	hand-crafted weak cyan Spasmi Dolorosi Del Rene Champagne	2	super ultra mega EPIC	Last Available: "2004-10"
-904	sharpshooter's Tesla slick school Mafia knickerbockers	0		Moxie: +10, Critical Hit Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	sharpshooter's Tesla slick school Mafia knickerbockers	0		Moxie: +10, Critical Hit Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	colloidal electrified ghostly Yummy Tummy bean	0		Effect: "Bats in the Belfry", Effect Duration: 33
 906	galvanized quadruple-pickled Rock Pops	0		Effect: "Improved Candy Vision", Effect Duration: 42
 907	denatured concentrated Mr. Mediocrebar	0		Effect: "Dances with Tweedles", Effect Duration: 24
@@ -902,12 +902,12 @@
 911	wet denatured squat Senior Mints	0		Effect: "You Know Where to Go", Effect Duration: 17
 912	liquefied irradiated pixellated candy heart	0		Effect: "Rotten Memories", Effect Duration: 55
 913	chilled liquefied quantum pulsating kobold	0		Effect: "Greased-Up Familiar", Effect Duration: 69
-914	blinking yellow hand turkey outline	0		Free Pull, Last Available: "2004-11"
+914	yellow blinking hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	occult extremely unsafe intergalactic pom poms	0		Weapon Damage Percent: +100, Spell Damage Percent: +25
 917	Mob Penguin protection contract	0		
-918	nippy Radio Free Baseball Cap	0		Cold Damage: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	Radio Free Pants of the ox	0		Muscle: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	nippy Radio Free Baseball Cap	0		Cold Damage: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	Radio Free Pants of the ox	0		Muscle: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	upside-down smelly Radio Free Foil	0		Stench Spell Damage: +10, Last Available: "2006-07"
 921	decent shaking radio button candy	4	good	
 922	severed rocking horse head	0		Item Drop: +5
@@ -915,7 +915,7 @@
 924	teal crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	chilled ionized Hawking's Elixir of Brilliance	0		Effect: "Full of Wist", Effect Duration: 55
-927	perfectly mixed weak Ferita Del Petto Zinfandel	2	EPIC	Last Available: "2006-12"
+927	weak perfectly mixed Ferita Del Petto Zinfandel	2	EPIC	Last Available: "2006-12"
 928	fuzzy bracelets of bravery	0		Spooky Resistance: +5
 929	lard-coated arse-shooting crossbow	0		Sleaze Spell Damage: +25
 931	smooth spiced rum	4	awesome	
@@ -929,12 +929,12 @@
 939	gray narrow small Crimbo Pressie	0		Last Available: "2004-12"
 940	twirling bow	0		Last Available: "2004-12"
 941	shaking Crimbo stocking	0		Last Available: "2004-12"
-942	pulsating jittery hardened bowler	0		Damage Reduction: 3, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	pulsating jittery hardened bowler	0		Damage Reduction: 3, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	personal trainer's Samson's bow staff	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Last Available: "2004-12"
-944	shaking pulsating family-friendly bowlegged pants	0		Sleaze Resistance: +1, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	shaking pulsating family-friendly bowlegged pants	0		Sleaze Resistance: +1, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
-947	blurry maroon skewered cherry	0		Last Available: "2004-12"
+947	maroon blurry skewered cherry	0		Last Available: "2004-12"
 948	acceptable martini	4	good	Last Available: "2004-12"
 949	tolerable grogtini	3	good	Last Available: "2004-12"
 950	acceptable cherry bomb	3	good	Last Available: "2004-12"
@@ -996,17 +996,17 @@
 1009	weak aged vodka martini	2	awesome	
 1010	acceptable whiskey and soda	3	good	
 1011	tolerable monkey wrench	3	good	
-1012	artisanal irresponsibly strong shaking tequila sunrise	10	EPIC	
+1012	irresponsibly strong artisanal shaking tequila sunrise	10	EPIC	
 1013	lousy red margarita	4	decent	
-1014	tolerable weak strawberry wine	2	good	
+1014	weak tolerable strawberry wine	2	good	
 1015	drinkable wobbly wine spritzer	3	good	
 1016	drinkable perpendicular hula	3	good	
-1017	enchanted bad weak ducha de oro	2	decent	Effect: "Coated Arms", Effect Duration: 50
+1017	bad enchanted weak ducha de oro	2	decent	Effect: "Coated Arms", Effect Duration: 50
 1018	lousy green calle de miel	4	decent	
-1019	enchanted perfectly mixed high-proof red dry vodka martini	8	EPIC	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 30
+1019	enchanted high-proof perfectly mixed red dry vodka martini	8	EPIC	Effect: "Visions of the Deep Dark Deeps", Effect Duration: 30
 1020	mediocre watered-down old-fashioned	2	decent	
 1021	high-proof perfectly mixed tequila with training wheels	8	EPIC	
-1022	acceptable high-proof sangria	6	good	
+1022	high-proof acceptable sangria	6	good	
 1023	artisanal vesper	3	super ultra EPIC	Last Available: "2004-12"
 1024	smooth bodyslam	3	awesome	Last Available: "2004-12"
 1025	lousy sangria del diablo	4	decent	Last Available: "2004-12"
@@ -1029,10 +1029,10 @@
 1043	greasy string of beads	0		Sleaze Spell Damage: +10
 1044	Temple Grandin's string of beads	0		Familiar Weight: +7
 1045	dog trainer's plastic bottle opener	0		Experience (familiar): +1
-1046	chilly traffic cone of horror	0		Cold Damage: +5, Spooky Spell Damage: +25, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	chilly traffic cone of horror	0		Cold Damage: +5, Spooky Spell Damage: +25, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	acceptable twirling N. O. Beer	3	good	
 1048	boiled huge oyster egg	1		Effect: "Liquidy Smoky", Effect Duration: 35
-1049	altered blinking upside-down oyster egg	1		Effect: "Elemental Mastery", Effect Duration: 30
+1049	altered upside-down blinking oyster egg	1		Effect: "Elemental Mastery", Effect Duration: 30
 1050	modified oyster egg	1		
 1051	plastic oyster egg	0		
 1052	powdered blurry oyster egg	1		
@@ -1044,23 +1044,23 @@
 1058	boiled puce oyster egg	1		
 1059	mirror puce plastic oyster egg	0		
 1060	powdered mirror mirror mauve oyster egg	1		
-1061	vaporized purple huge mauve oyster egg	1		Effect: "Ponderous Potency", Effect Duration: 35
+1061	vaporized huge purple mauve oyster egg	1		Effect: "Ponderous Potency", Effect Duration: 35
 1062	denatured twirling mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
 1064	denatured narrow oyster egg	1		Effect: "Moon-Eyed", Effect Duration: 25
 1065	dehydrated teal oyster egg	1		
 1066	compressed blinking oyster egg	1		
-1067	red pulsating plastic oyster egg	0		
+1067	pulsating red plastic oyster egg	0		
 1068	boiled narrow oyster egg	1		
 1069	modified skewed oyster egg	1		
 1070	modified blinking oyster egg	1		
 1071	plastic oyster egg	0		
-1072	powdered mirror ghostly off-white oyster egg	1		Effect: "Hopped Up on Goofballs", Effect Duration: 40
+1072	powdered ghostly mirror off-white oyster egg	1		Effect: "Hopped Up on Goofballs", Effect Duration: 40
 1073	altered tumbling off-white oyster egg	1		Effect: "Twenty-three Squid, Ew", Effect Duration: 35
 1074	boiled off-white oyster egg	1		
-1075	blinking mirror off-white plastic oyster egg	0		
+1075	mirror blinking off-white plastic oyster egg	0		
 1076	dehydrated oyster egg	1		
-1077	distilled blurry fuchsia oyster egg	1		
+1077	distilled fuchsia blurry oyster egg	1		
 1078	distilled oyster egg	1		
 1079	plastic oyster egg	0		
 1080	narrow oyster basket	0		
@@ -1084,7 +1084,7 @@
 1098	hardy clockwork trench coat	0		Maximum HP: +50
 1099	occult clockwork pants	0		Spell Damage Percent: +25, Familiar Effect: "3xPotato, 1.5xGhuol, cap 20"
 1100	Samson's gnauga hide chaps	0		Experience (Muscle): +5, Familiar Effect: "atk, 4xBarrr, cap 20"
-1101	narrow ghostly false eyelashes	0		Familiar Weight: +5
+1101	ghostly narrow false eyelashes	0		Familiar Weight: +5
 1102	shaking targeting chip	0		
 1103	unwound clockwork grapefruit	0		
 1104	spinning Mountie hat	0		Familiar Weight: +5
@@ -1105,7 +1105,7 @@
 1119	pregnant mushroom	0		
 1120	pregnant mushroom	0		
 1121	inexplicably rock	0		
-1122	blue jittery fairy gravy	0		
+1122	jittery blue fairy gravy	0		
 1123	halfberd of the empath	0		Familiar Weight: +5
 1124	tumbling small glove	0		
 1125	flame-retardant lion tamer's glove of terror	0		Experience (familiar): +2, Spooky Spell Damage: +10, Hot Resistance: +1
@@ -1114,7 +1114,7 @@
 1128	teeny-tiny ninja stars	0		
 1129	twirling Sinatra's sequined fez	0		Experience (Moxie): +5, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
-1131	blinking green beet	0		Last Available: "2005-12"
+1131	green blinking beet	0		Last Available: "2005-12"
 1132	Totally Gay Claymore	0		
 1133	star shirt of bravery	0		Spooky Resistance: +5
 1134	cosmetics bag	0		
@@ -1123,16 +1123,16 @@
 1137	fireproof bicycle chain of the boozehound	0		Hot Resistance: +3, Booze Drop: +100
 1138	bouncing mushroom fermenting solution	0		
 1139	weak acceptable squat mushroom wine	2	good	
-1140	irresponsibly strong drinkable icy mushroom wine	6	good	
+1140	drinkable irresponsibly strong icy mushroom wine	6	good	
 1141	hand-crafted mushroom wine	4	EPIC	
 1142	lousy weak pointy mushroom wine	2	decent	
 1143	artisanal yellow flat mushroom wine	3	EPIC	
 1144	bad watered-down blue cool mushroom wine	2	decent	
 1145	lousy knob mushroom wine	3	decent	
-1146	practically non-alcoholic special artisanal tumbling knoll mushroom wine	1	super ultra mega turbo EPIC	Effect: "It's Electric!", Effect Duration: 5
+1146	artisanal special practically non-alcoholic tumbling knoll mushroom wine	1	super ultra mega turbo EPIC	Effect: "It's Electric!", Effect Duration: 5
 1147	drinkable mushroom wine	3	good	
 1148	strong perfectly mixed shot of flower schnapps	5	EPIC	
-1149	bland small green flower petal pie	2	decent	
+1149	small bland green flower petal pie	2	decent	
 1150	drinkable twirling bottle of single-barrel whiskey	3	good	
 1151	jittery weightlifter's discarded plastic fork of the storm	0		Muscle: +15, Maximum MP Percent: +40
 1152	pulsating gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1152,13 +1152,13 @@
 1167	plain brown wrapper	0		
 1168	squat less-than-three-shaped box	0		
 1169	narrow pulsating exactly-three-shaped box	0		
-1170	tumbling twirling chocolate box	0		
+1170	twirling tumbling chocolate box	0		
 1171	coffin	0		
 1172	tumbling yellow asbestos box	0		
 1173	linoleum box	0		
 1174	chrome box	0		
 1175	cryptic puzzle box	0		
-1176	blinking teal refrigerated biohazard container	0		
+1176	teal blinking refrigerated biohazard container	0		
 1177	magnetic field	0		
 1178	blinking huge potted cactus	0		
 1179	twirling daisy	0		
@@ -1170,7 +1170,7 @@
 1185	long-stemmed rose	0		
 1186	wobbly gilded lily	0		
 1187	deadly nightshade	0		
-1188	yellow skewed mirror lotus	0		
+1188	mirror yellow skewed lotus	0		
 1189	can of asparagus	0		
 1190	dodecapede	0		
 1191	tumbling ghuol whelp	0		
@@ -1183,16 +1183,16 @@
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
 1200	adequate big mirror mugcake	5	good	
-1201	massive flavorless huge teal urinal cake	9	decent	
+1201	massive flavorless teal huge urinal cake	9	decent	
 1202	flavorless purple Happy Birthday, Claude! cake	3	decent	
-1203	rotten massive mirror personalized birthday cake	7	crappy	
+1203	massive rotten mirror personalized birthday cake	7	crappy	
 1204	miniature normal three-tiered wedding cake	2	good	
-1205	low-calorie stale babycakes	1	decent	
-1206	thick stale bouncing velvet cake	5	decent	
+1205	stale low-calorie babycakes	1	decent	
+1206	stale thick bouncing velvet cake	5	decent	
 1207	bland super-sized congratulatory cake	5	decent	
 1208	normal angel-food cake	4	good	
 1209	spoiled miniature devil's-food cake	2	crappy	
-1210	immense stale mirror cyan birthday party jellybean cheesecake	6	decent	
+1210	immense stale cyan mirror birthday party jellybean cheesecake	6	decent	
 1211	olive balloon	0		
 1212	huge balloon	0		
 1213	pulsating heart-shaped balloon	0		
@@ -1233,14 +1233,14 @@
 1249	tumbling twirling executive Boss Bat britches	0		Meat Drop: +40, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	Boss Bat bling of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50
 1251	stale teal Knob shroomkabob	3	decent	
-1252	miniature fancy rotten shroomkabob	2	crappy	Effect: "Human-Fish Hybrid", Effect Duration: 25
+1252	fancy miniature rotten shroomkabob	2	crappy	Effect: "Human-Fish Hybrid", Effect Duration: 25
 1253	pile of jumping beans	0		
 1254	gigantic toothsome jumping bean burrito	10	awesome	
 1255	toothsome ghostly jumping bean burrito	3	awesome	
 1256	rotten blinking insanely jumping bean burrito	4	crappy	
 1257	thick flavorless rat scrapple	5	decent	
 1258	bouncing olive pail of pretentious paint	0		
-1259	executive baleful traffic cone	0		Spell Damage: +25, Meat Drop: +40, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	executive baleful traffic cone	0		Spell Damage: +25, Meat Drop: +40, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	denatured Hatorade	1		Effect: "Glo-Face", Effect Duration: 35
 1262	reassuring smartaleck's sage off-hand balloon	0		Mysticality Percent: +10, Moxie Percent: +30, Spooky Resistance: +1
@@ -1271,7 +1271,7 @@
 1287	blinking rosewater-soaked furry kilt	0		Stench Resistance: +3, Familiar Effect: "sleaze atk, 1xFairy, cap 37"
 1288	ghostly gnauga hide skirt of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "2.5xFairy, cap 20"
 1289	stylish gnauga hide kilt	0		Moxie: +25, Familiar Effect: "2.5xFairy, cap 20"
-1290	moist extra-liquefied jittery shaking wind-up clock	0		Effect: "Ironclad", Effect Duration: 54
+1290	moist extra-liquefied shaking jittery wind-up clock	0		Effect: "Ironclad", Effect Duration: 54
 1291	Jekyllin hide belt of mayonnaise	0		Sleaze Spell Damage: +50, Softcore Only, Last Available: "2005-09"
 1292	skirt / kilt kit	0		
 1293	experienced ring of adornment	0		Experience: +2
@@ -1282,12 +1282,12 @@
 1298	greedy ring of conflict	0		Meat Drop: +20, Single Equip
 1299	shaking Usain Bolt's pirate hook	0		Initiative: +80
 1300	thinker's monster bait	0		Mysticality: +10, Single Equip
-1301	boiled skewed lime green deodorant	0		Effect: "Norwhalloped", Effect Duration: 25
+1301	boiled lime green skewed deodorant	0		Effect: "Norwhalloped", Effect Duration: 25
 1302	moist corrupted reodorant	0		Effect: "Big Flaming Whip", Effect Duration: 26
 1303	Mjolnir Jr.	0		
 1304	teal doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	twirling zippy traffic cone of the cheetah	0		Initiative: 80, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	twirling zippy traffic cone of the cheetah	0		Initiative: 80, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	narrow calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	skewed unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	decent questionable taco	3	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	time helmet of extreme caution	0		Monster Level: -25, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	hardened time trousers	0		Damage Reduction: 3, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	time helmet of extreme caution	0		Monster Level: -25, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	hardened time trousers	0		Damage Reduction: 3, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	blinking Van der Graaf time sword	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2005-10"
 1326	Annie Oakley's Dyspepsi-Cola helmet	0		Critical Hit Percent: +20, Familiar Effect: "3xFairy, cap 7"
 1327	upside-down blinking Cloaca-Cola shield of horror	0		Spooky Spell Damage: +25, Damage Reduction: 4
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	flavorless bowl of oriole's nest soup	3	decent	
 1356	bunny liver	0		
-1357	fancy hand-crafted weak tumbling Mt. Noob Pale Ale	2	EPIC	Effect: "Drunk With Power", Effect Duration: 15
+1357	hand-crafted fancy weak tumbling Mt. Noob Pale Ale	2	EPIC	Effect: "Drunk With Power", Effect Duration: 15
 1358	bouncing pirate zombie head	0		Last Available: "2005-11"
 1359	tumbling ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1349,7 +1349,7 @@
 1366	bland tofurkey gravy	3	decent	
 1367	tasty herbal stuffing	4	awesome	
 1368	thick spoiled can-shaped gelatinous cranberry sauce	5	crappy	
-1369	half-sized enchanted decent tumbling yams	2	good	Effect: "Punch Another Day", Effect Duration: 20
+1369	enchanted half-sized decent tumbling yams	2	good	Effect: "Punch Another Day", Effect Duration: 20
 1370	cool rhinestone cowboy shirt	0		Moxie: +5
 1371	fuchsia stanky gingham blouse	0		Stench Spell Damage: +25
 1372	Herculean souvenir ski t-shirt	0		Experience (Muscle): +1
@@ -1362,7 +1362,7 @@
 1379	yellow mirror up-at-dawn plastic Crimbo reindeer	0		Adventures: +5, Single Equip, Last Available: "2005-12"
 1381	squat aspirin	0		Last Available: "2005-12"
 1382	anodized diffused mirror blue chocolate	0		Effect: "Badger Underfoot", Effect Duration: 53, Last Available: "2015-11"
-1383	green tumbling length of string	0		
+1383	tumbling green length of string	0		
 1384	googly eye	0		
 1385	stuffing	0		
 1386	ghostly felt	0		
@@ -1384,7 +1384,7 @@
 1402	MacGyver's rag doll	0		Maximum MP: +100, Last Available: "2005-12"
 1403	shaking smelly can of fake snow	0		Stench Spell Damage: +10, Last Available: "2005-12"
 1404	brawny colored-light &quot;necklace&quot;	0		Muscle Percent: +20, Last Available: "2005-12"
-1405	skewed energetic tree skirt	0		Maximum MP Percent: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	skewed energetic tree skirt	0		Maximum MP Percent: +20, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	adequate fuchsia wreath-shaped Crimbo cookie	4	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	moldy bouncing bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	delicious tree-shaped Crimbo cookie	3	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
@@ -1399,33 +1399,33 @@
 1417	irradiated nitrogenated snowcone	0		Effect: "Burning Hands", Effect Duration: 45, Last Available: "2006-01"
 1418	yellow Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	pulsating dog trainer's crafty traffic cone	0		Maximum MP: +10, Experience (familiar): +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
-1421	spinning olive Scandalously Skimpy Bikini	0		Four Songs, Single Equip
+1420	pulsating dog trainer's crafty traffic cone	0		Maximum MP: +10, Experience (familiar): +1, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1421	olive spinning Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	huge Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	yellow iceberglet	0		Last Available: "2006-02"
 1424	blurry shellacked dance instructor's ice sickle	0		Experience Percent (Moxie): +10, Damage Reduction: 7, Softcore Only, Last Available: "2006-02"
 1425	beefy ice baby	0		Muscle: +10, Softcore Only, Last Available: "2006-02"
-1426	narrow ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	narrow ice pick of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	nippy manspreader's ice skates	0		Monster Level: +10, Cold Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	snack-sized toothsome grue egg omelette	2	awesome	
+1428	toothsome snack-sized grue egg omelette	2	awesome	
 1429	roll of drink tickets	0		
 1430	spinning pregnant gloomy mushroom	0		
 1431	blinking pregnant mushroom	0		
-1432	half-sized decent mushroom	2	good	
+1432	decent half-sized mushroom	2	good	
 1433	blinking fruit bowl	0		
 1434	spinning blurry fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
 1437	useless powder	0		
-1438	colloidal spinning twirling twinkly powder	0		Effect: "Castaway Physique", Effect Duration: 34
+1438	colloidal twirling spinning twinkly powder	0		Effect: "Castaway Physique", Effect Duration: 34
 1439	quantum hot powder	0		Effect: "Walberg's Dim Bulb", Effect Duration: 35
 1440	pressed powder	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 27
 1441	pressed powder	0		Effect: "Hood Ridin'", Effect Duration: 58
 1442	energized wobbly stench powder	0		Effect: "Psalm of Pointiness", Effect Duration: 45
 1443	alkaline shaking sleaze powder	0		Effect: "Electrolit Up", Effect Duration: 26
-1444	electrified double-ionized narrow blurry twinkly nuggets	0		Effect: "White-boy Angst", Effect Duration: 19
+1444	electrified double-ionized blurry narrow twinkly nuggets	0		Effect: "White-boy Angst", Effect Duration: 19
 1445	galvanized polarized hot nuggets	0		Effect: "Expert Vacationer", Effect Duration: 57
-1446	triple-liquefied Vulcanized jittery lime green nuggets	0		Effect: "Halloweeny", Effect Duration: 56
+1446	triple-liquefied Vulcanized lime green jittery nuggets	0		Effect: "Halloweeny", Effect Duration: 56
 1447	denatured cold-filtered huge nuggets	0		Effect: "Itchy Trigger Finger", Effect Duration: 54
 1448	denatured super-electrified mirror stench nuggets	0		Effect: "Mucilaginous Muscle", Effect Duration: 33
 1449	enhanced pulsating mirror red sleaze nuggets	0		Effect: "Hood Ridin'", Effect Duration: 16
@@ -1437,7 +1437,7 @@
 1455	vaporized sleaze wad	1		
 1456	double daisy	0		
 1457	pulsating Goth Giant	0		
-1458	yummy snack-sized tumbling Valentine's Day cake	2	awesome	
+1458	snack-sized yummy tumbling Valentine's Day cake	2	awesome	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	squashed frog	0		
@@ -1450,12 +1450,12 @@
 1468	wobbly two-handed depthsword	0		
 1469	bill bec-de-bardiche glaive-guisarme	0		
 1470	blue lead yo-yo	0		
-1471	spinning pulsating slightly peevedbow	0		
+1471	pulsating spinning slightly peevedbow	0		
 1472	sack of doorknobs	0		
 1473	wobbly ball-and-chain	0		
 1474	automatic catapult	0		
 1475	fuchsia pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	narrow shaking goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	shaking narrow goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	skewed plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	jittery salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	mirror football helmet	0		Familiar Effect: "atk, cap 37"
@@ -1465,7 +1465,7 @@
 1483	troutpiece	0		Familiar Effect: "1xVolley, 1xBarrr, cap 27"
 1484	skewed alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	greedy veiny rabbit's foot	0		Maximum HP: +10, Meat Drop: +20
-1486	lime green jittery massive bag of catnip	0		
+1486	jittery lime green massive bag of catnip	0		
 1487	hang glider	0		
 1488	March hat	0		Free Pull
 1489	dormouse	0		
@@ -1474,9 +1474,9 @@
 1492	twirling Usain Bolt's ninja mop	0		Initiative: +80
 1493	pulsating Temple Grandin's thinker's ridiculously overelaborate ninja weapon	0		Mysticality: +10, Familiar Weight: +7
 1494	wet squat sugar-coated pine cone	0		Effect: "Analog Drunk", Effect Duration: 58, Last Available: "2020-09"
-1495	wool grievous traffic cone	0		Weapon Damage Percent: +50, Cold Resistance: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	wool grievous traffic cone	0		Weapon Damage Percent: +50, Cold Resistance: +1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	acceptable gloomy mushroom wine	4	good	
-1497	delicious weak mushroom wine	2	awesome	
+1497	weak delicious mushroom wine	2	awesome	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	blinking fake fake vomit	0		Last Available: "2006-04"
@@ -1485,8 +1485,8 @@
 1503	yellow rubber emo roe	0		Last Available: "2006-04"
 1504	nitrogenated snowcone	0		Effect: "New Zeal", Effect Duration: 49, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	triple-distilled acceptable calle de miel with a fly in it	10	good	Last Available: "2006-04"
-1507	perfectly mixed watered-down rockin' wagon with a fly in it	2	EPIC	Last Available: "2006-04"
+1506	acceptable triple-distilled calle de miel with a fly in it	10	good	Last Available: "2006-04"
+1507	watered-down perfectly mixed rockin' wagon with a fly in it	2	EPIC	Last Available: "2006-04"
 1508	hand-crafted perpendicular hula with a fly in it	3	EPIC	Last Available: "2006-04"
 1509	lousy slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
 1510	tumbling bag of airline peanuts	0		Last Available: "2006-04"
@@ -1504,81 +1504,81 @@
 1523	jittery bottle of used blood	0		
 1524	squat cyan wind-up chattering teeth	0		Last Available: "2006-04"
 1525	red joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	purple pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	purple pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	olive diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	spinning upside-down Annie Oakley's extremely unsafe corkscrew	0		Weapon Damage Percent: +100, Critical Hit Percent: +20, Last Available: "2006-04"
-1529	bouncing jittery St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
+1529	jittery bouncing St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	sizzling grass skirt	0		Hot Damage: +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	grass hat of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	sizzling grass skirt	0		Hot Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	grass hat of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	jittery family-friendly grass blade	0		Sleaze Resistance: +1, Last Available: "2011-01"
 1534	wobbly raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	mirror weegee sqouija	0		Last Available: "2011-12"
 1538	wizardly sparkly engagement ring	0		Mysticality: +25, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	inspector's Van der Graaf Grimacite goggles	0		Item Drop: +15, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	inspector's Van der Graaf Grimacite goggles	0		Item Drop: +15, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	pulsating ruddy experienced Grimacite glaive	0		Experience: +2, Maximum HP Percent: +40, Last Available: "2008-10"
-1542	purple Jeselnik's ribald Grimacite greaves	0		Sleaze Damage: 35, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	purple Jeselnik's ribald Grimacite greaves	0		Sleaze Damage: 35, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	stiffened Grimacite garter of the scaredy-cat	0		Damage Reduction: 1, Monster Level: -15, Last Available: "2008-10"
 1544	razor-sharp Grimacite galoshes of dire peril	0		Weapon Damage: +20, Weapon Damage Percent: +25, Last Available: "2008-10"
 1545	energetic Grimacite gorget of horror	0		Maximum MP Percent: +20, Spooky Spell Damage: +25, Last Available: "2008-10"
 1546	flame-retardant Grimacite guayabera	0		Hot Resistance: +1, Last Available: "2008-10"
 1547	Socratic Codex of Capsaicin Conjuration of Flo-Jo	0		Experience (Mysticality): +1, Initiative: +100
 1548	tumbling ruddy strapping Gazpacho's Glacial Grimoire	0		Muscle: +5, Maximum HP Percent: +40
-1549	teal mirror MSG	0		
+1549	mirror teal MSG	0		
 1550	rosewater-soaked second-hand knockoff engagement ring	0		Stench Resistance: +3, Single Equip
 1551	lousy bottle of Domesticated Turkey	3	decent	
 1552	acceptable pulsating bottle of Definit	4	good	
 1553	drinkable tumbling blinking bottle of Calcutta Emerald	3	good	
 1554	hand-crafted weak bottle of Lieutenant Freeman	2	EPIC	
 1555	distilled mediocre bottle of Jorge Sinsonte	5	decent	
-1556	perfectly mixed triple-distilled boxed champagne	8	EPIC	
+1556	triple-distilled perfectly mixed boxed champagne	8	EPIC	
 1557	spoiled shaking kumquat	3	crappy	
-1558	miniature delicious tangerine	2	awesome	
+1558	delicious miniature tangerine	2	awesome	
 1559	tonic water	0		
-1560	stale jumbo pulsating wobbly cocktail onion	5	decent	
+1560	jumbo stale wobbly pulsating cocktail onion	5	decent	
 1561	special spoiled raspberry	4	crappy	Effect: "Tiki Thoughtfulness", Effect Duration: 20
 1562	moldy kiwi	3	crappy	
-1563	strong artisanal whiskey bittersweet	5	EPIC	
+1563	artisanal strong whiskey bittersweet	5	EPIC	
 1564	tolerable weak mimosette	2	good	
 1565	artisanal tequila sunset	3	EPIC	
-1566	extra-dry lousy mirror wobbly zmobie	5	decent	Wiki Name: "Zmobie (drink)"
+1566	lousy extra-dry wobbly mirror zmobie	5	decent	Wiki Name: "Zmobie (drink)"
 1567	mediocre gin and tonic	3	decent	
-1568	perfectly mixed practically non-alcoholic squat vodka and tonic	1	super EPIC	
+1568	practically non-alcoholic perfectly mixed squat vodka and tonic	1	super EPIC	
 1569	artisanal triple-distilled blinking vodka gibson	9	EPIC	
-1570	bad weak gibson	2	decent	
+1570	weak bad gibson	2	decent	
 1571	tolerable olive parisian cathouse	4	good	
 1572	drinkable watered-down skewed rabbit punch	2	good	
 1573	drinkable caipifruta	3	good	
 1574	lousy teqiwila	3	decent	
 1575	irresponsibly strong hand-crafted squat Divine	9	EPIC	
-1576	high-proof lousy fancy olive Gordon Bennett	7	decent	Effect: "Shortened", Effect Duration: 50
-1577	hand-crafted strong squat tangarita	5	EPIC	
-1578	high-proof tolerable mandarina colada	7	good	
-1579	watered-down smooth blinking gimlet	2	awesome	
+1576	lousy high-proof fancy olive Gordon Bennett	7	decent	Effect: "Shortened", Effect Duration: 50
+1577	strong hand-crafted squat tangarita	5	EPIC	
+1578	tolerable high-proof mandarina colada	7	good	
+1579	smooth watered-down blinking gimlet	2	awesome	
 1580	mediocre brick road	4	decent	
 1581	drinkable vodka stratocaster	3	good	
 1582	perfectly mixed Neuromancer	4	EPIC	
 1583	acceptable weak prussian cathouse	2	good	
 1584	aged Mae West	3	awesome	
-1585	drinkable spirit-forward Mon Tiki	5	good	
+1585	spirit-forward drinkable Mon Tiki	5	good	
 1586	lousy distilled teqiwila slammer	5	decent	
 1587	adequate Knob lo mein	3	good	
 1588	rotten shaking asparagus lo mein	4	crappy	
-1589	special bite-sized rotten squat Knoll lo mein	1	crappy	Effect: "New Zeal", Effect Duration: 30
-1590	thick bland lo mein	5	decent	
-1591	snack-sized moldy olive lo mein	2	crappy	
-1592	adequate super-sized hot hi mein	5	good	
-1593	adequate fancy small hi mein	2	good	Effect: "Sweet and Yellow", Effect Duration: 30
-1594	jumbo moldy hi mein	5	crappy	
+1589	rotten special bite-sized squat Knoll lo mein	1	crappy	Effect: "New Zeal", Effect Duration: 30
+1590	bland thick lo mein	5	decent	
+1591	moldy snack-sized olive lo mein	2	crappy	
+1592	super-sized adequate hot hi mein	5	good	
+1593	fancy adequate small hi mein	2	good	Effect: "Sweet and Yellow", Effect Duration: 30
+1594	moldy jumbo hi mein	5	crappy	
 1595	rotten spinning red hi mein	3	crappy	
 1596	bland thick sleazy hi mein	5	decent	
 1597	upside-down rock-hard Junior LAAAAME merit badge	0		Damage Reduction: 5, Last Available: "2006-05"
 1598	sage Senior LAAAAME merit badge	0		Mysticality Percent: +10, Last Available: "2006-05"
 1599	shaking jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	practically non-alcoholic lousy tangarita with a fly in it	1	decent	
-1601	weak drinkable mandarina colada with a fly in it	2	good	
+1600	lousy practically non-alcoholic tangarita with a fly in it	1	decent	
+1601	drinkable weak mandarina colada with a fly in it	2	good	
 1602	smooth prussian cathouse with a fly in it	4	awesome	
 1603	watered-down mediocre Mae West with a fly in it	2	decent	
 1604	twisted astronaut ice-cream	1		Effect: "Antarctic Memories", Effect Duration: 15, Last Available: "2006-05"
@@ -1592,8 +1592,8 @@
 1612	moist boiled concentrated cordial of concentration	0		Effect: "White Knuckles", Effect Duration: 39
 1613	beefcake's coffin lid	0		Muscle: +25, Damage Reduction: 3
 1614	upside-down stiffened satin shield	0		Damage Reduction: 6
-1615	blurry gray skewed grievous Cerebral Cloche	0		Weapon Damage Percent: +50, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	nippy Cerebral Culottes	0		Cold Damage: +10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	blurry gray skewed grievous Cerebral Cloche	0		Weapon Damage Percent: +50, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	nippy Cerebral Culottes	0		Cold Damage: +10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	mansplainer's Van der Graaf occult Cerebral Crossbow	0		Spell Damage Percent: +25, Monster Level: +15, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1616,10 +1616,10 @@
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	polymerized magnetized pulsating lotion of hotness	0		Effect: "Filled with Magic", Effect Duration: 57
 1638	alkaline squat lotion of coldness	0		Effect: "Tomato Power", Effect Duration: 27
-1639	altered narrow ghostly lotion of spookiness	0		Effect: "Holiday Bliss", Effect Duration: 36
+1639	altered ghostly narrow lotion of spookiness	0		Effect: "Holiday Bliss", Effect Duration: 36
 1640	triple-liquefied blurry lotion of stench	0		Effect: "Partially Ghosted", Effect Duration: 55
 1641	super-activated magnetized lotion of sleaziness	0		Effect: "20/20 Vision", Effect Duration: 56
-1642	weak lousy Grimacite Bock	2	decent	Last Available: "2008-11"
+1642	lousy weak Grimacite Bock	2	decent	Last Available: "2008-11"
 1643	fancy stale snack-sized wedge of gray cheese	2	decent	Effect: "Yes, Can Haz", Effect Duration: 5, Last Available: "2008-11"
 1644	gray skewed hot and sauce	0		
 1645	and sauce	0		
@@ -1630,12 +1630,12 @@
 1650	milk of magnesium	0		
 1651	flavorless foie gras	3	decent	
 1652	polymerized candy brain	0		Effect: "Cranberry Cordiality", Effect Duration: 62, Last Available: "2020-09"
-1653	flame-retardant Da Vinci's strapping jewel-eyed wizard hat	0		Muscle: +5, Experience (Mysticality): +5, Hot Resistance: +1, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	flame-retardant Da Vinci's strapping jewel-eyed wizard hat	0		Muscle: +5, Experience (Mysticality): +5, Hot Resistance: +1, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	Fonzie's boxer's wad of Crovacite	0		Muscle Percent: +10, Experience (Moxie): +1
 1655	blue hardened collar of the empath	0		Damage Reduction: 3, Familiar Weight: +5
 1656	White Citadel Satisfaction Satchel	0		
 1657	onion shurikens	0		
-1658	tumbling skewed Cherry Cloaca Cola	0		
+1658	skewed tumbling Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
 1660	skewed Regular Cloaca Cola	0		
 1661	prompt Radio KoL Keychain	0		Adventures: +3
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	pulsating jittery styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	fuchsia horrifying grievous sword	0		Weapon Damage Percent: +50, Spooky Damage: +25
 1680	baleful sinister staff	0		Spell Damage: 35
 1681	red mansplainer's ruddy bubblewrap sword	0		Maximum HP Percent: +40, Monster Level: +15
@@ -1746,15 +1746,15 @@
 1767	pack of chewing gum	0		
 1768	Gnomish toolbox	0		
 1769	yummy fricasseed brains	3	awesome	
-1770	enchanted gigantic yummy brains casserole	6	awesome	Effect: "Cancer Rising", Effect Duration: 5
+1770	yummy gigantic enchanted brains casserole	6	awesome	Effect: "Cancer Rising", Effect Duration: 5
 1771	mirror upside-down brainy butcherknife	0		Mysticality: +5
 1772	dog trainer's corn holder	0		Experience (familiar): +1
 1773	weightlifter's eggbeater	0		Muscle: +15
 1774	watered-down tolerable pulsating olive bottle of popskull	2	good	
 1775	squat skewed resourceful dishrag	0		Maximum MP: +50
-1776	half-sized spoiled maroon stale baguette	2	crappy	
+1776	spoiled half-sized maroon stale baguette	2	crappy	
 1777	jittery leftovers of indeterminate origin	0		
-1778	moldy half-sized shaking dinner	2	crappy	
+1778	half-sized moldy shaking dinner	2	crappy	
 1779	katana of terror	0		Spooky Spell Damage: +10
 1780	blue flame-retardant ram stick	0		Hot Resistance: +1
 1781	dangerous enchantlers	0		Weapon Damage: +10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1766,9 +1766,9 @@
 1787	double-moist fuchsia bag of Cheat-Os	0		Effect: "Booze Goozles", Effect Duration: 67
 1788	unrefined Mountain Stream syrup	0		
 1789	tumbling Mob Penguin	0		
-1790	bad weak Ram's Face Lager	2	decent	
+1790	weak bad Ram's Face Lager	2	decent	
 1791	ram horns	0		
-1792	huge Jeselnik's dangerous Travoltan trousers of the storm	0		Weapon Damage: +10, Maximum MP Percent: +40, Sleaze Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	huge Jeselnik's dangerous Travoltan trousers of the storm	0		Weapon Damage: +10, Maximum MP Percent: +40, Sleaze Damage: +25, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	blinking toasty weightlifter's pool cue	0		Muscle: +15, Hot Damage: +5
 1794	corrupted ghostly handful of hand chalk	0		Effect: "Hella Smooth", Effect Duration: 13
 1795	Rosewater's Counterclockwise Watch	0		Mysticality Percent: +30, Single Equip
@@ -1790,7 +1790,7 @@
 1811	third thoracic vertebra	0		
 1812	twirling fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
-1814	shaking jittery sixth thoracic vertebra	0		
+1814	jittery shaking sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	pulsating eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
@@ -1832,7 +1832,7 @@
 1853	right third rib	0		
 1854	huge right fourth rib	0		
 1855	shaking right fifth rib	0		
-1856	tumbling blinking right sixth rib	0		
+1856	blinking tumbling right sixth rib	0		
 1857	right seventh rib	0		
 1858	right eighth rib	0		
 1859	purple right ninth rib	0		
@@ -1866,7 +1866,7 @@
 1887	right second front claw	0		
 1888	narrow right third front claw	0		
 1889	right fourth front claw	0		
-1890	mirror shaking left thumb	0		
+1890	shaking mirror left thumb	0		
 1891	right thumb	0		
 1892	ghostly left first rear claw	0		
 1893	purple left second rear claw	0		
@@ -1925,7 +1925,7 @@
 1948	yellow Temple Grandin's stiffened tap shoes	0		Damage Reduction: 1, Familiar Weight: +7, Single Equip
 1949	stale Manetwich	4	decent	
 1950	bottle of Vangoghbitussin	0		
-1951	watered-down delicious pulsating tumbling bottle of Pinot Renoir	2	awesome	
+1951	delicious watered-down tumbling pulsating bottle of Pinot Renoir	2	awesome	
 1952	toothsome desiccated apricot	3	awesome	
 1953	watered-down bad blinking flute of flat champagne	2	decent	
 1954	spoiled dehydrated caviar	3	crappy	
@@ -1975,7 +1975,7 @@
 1998	olive pack of KWE trading card	0		
 1999	stick of &quot;gum&quot;	0		
 2000	Das &Uuml;berk&uuml;hlraum trading card	0		
-2001	mirror blinking Vaso De Agua trading card	0		
+2001	blinking mirror Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	upside-down Thorny Toad trading card	0		
 2004	Chori Zo trading card	0		
@@ -1996,7 +1996,7 @@
 2019	cream pie	0		Free Pull
 2020	miniature moldy mirror cherry pie	2	crappy	
 2021	adequate strawberry pie	3	good	
-2022	big adequate fancy lemon meringue pie	5	good	Effect: "Charrrming", Effect Duration: 10
+2022	big fancy adequate lemon meringue pie	5	good	Effect: "Charrrming", Effect Duration: 10
 2023	Genalen&trade; Bottle	1	EPIC	
 2024	rotten mixed wildflower greens	3	crappy	
 2025	toothsome half-sized squat jittery handful of walnuts	2	awesome	
@@ -2065,7 +2065,7 @@
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	squat reassuring sizzling dog trainer's pilgrim shield of the brute of the storm	0		Muscle Percent: +30, Maximum MP Percent: +40, Experience (familiar): +1, Hot Damage: +10, Spooky Resistance: +1, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	squat bath salts	0		
-2092	jittery red hand mirror	0		
+2092	red jittery hand mirror	0		
 2093	hors d'oeuvre tray of the brute	0		Muscle Percent: +30, Damage Reduction: 5
 2094	delicious ballroom blintz	3	awesome	
 2095	towel	0		
@@ -2085,12 +2085,12 @@
 2109	stringy sinew	0		Last Available: "2011-12"
 2110	lime green stick	0		Last Available: "2011-12"
 2111	tooth	0		
-2112	teal wobbly leaf	0		Last Available: "2011-12"
+2112	wobbly teal leaf	0		Last Available: "2011-12"
 2113	spinning stanky wheel	0		Stench Spell Damage: +25, Last Available: "2006-12"
 2114	yo	0		Last Available: "2006-12"
 2115	blurry up-at-dawn prehistoric spear	0		Adventures: +5, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	skewed electrified brainy fire	0		Mysticality: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	skewed electrified brainy fire	0		Mysticality: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	maroon leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	squat Grateful Undead T-shirt of bravery	0		Spooky Resistance: +5
@@ -2118,7 +2118,7 @@
 2143	felt	0		Last Available: "2011-12"
 2144	mirror evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
-2146	green ghostly evil teddy bear	0		Last Available: "2006-12"
+2146	ghostly green evil teddy bear	0		Last Available: "2006-12"
 2147	mirror evil teddy bear sewing kit	0		
 2148	squat bouncing toothsome rock	0		
 2149	flavorless half-sized frank	2	decent	Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	gravedigger's Newton's toy ray gun	0		Experience (Mysticality): +3, Spooky Damage: +10, Last Available: "2006-12"
-2169	rosewater-soaked toy space helmet of the brazier	0		Hot Spell Damage: +25, Stench Resistance: +3, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	rosewater-soaked toy space helmet of the brazier	0		Hot Spell Damage: +25, Stench Resistance: +3, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	stylish astronaut pants of the overflowing toilet	0		Moxie: +25, Stench Spell Damage: +50, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	stylish astronaut pants of the overflowing toilet	0		Moxie: +25, Stench Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	toy jet pack of dire peril	0		Weapon Damage: +20, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	wobbly mossy stone sphere	0		
@@ -2155,7 +2155,7 @@
 2180	yellow amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	wobbly olive shaking Harold's hammer handle	0		
+2183	wobbly shaking olive Harold's hammer handle	0		
 2184	Harold's hammer	0		
 2185	squat shaking foul-smelling Kiss the Knob apron	0		Stench Damage: +10
 2186	unlit birthday cake	0		
@@ -2165,14 +2165,14 @@
 2190	blinking yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	tumbling book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	toothsome thick ghostly candy stake	5	awesome	Last Available: "2006-12"
+2193	thick toothsome ghostly candy stake	5	awesome	Last Available: "2006-12"
 2194	hand-crafted irresponsibly strong blinking eggnog	9	EPIC	Last Available: "2006-12"
 2195	big spoiled unspeakable fruitcake	5	crappy	Last Available: "2006-12"
 2196	yummy gigantic shaking gingerbread horror	7	awesome	Last Available: "2006-12"
 2197	concentrated colloidal chilled cyan skewed but probably evil chocolate	0		Effect: "Patent Prevention", Effect Duration: 28, Last Available: "2006-12"
 2198	spoiled snack-sized teal bat-shaped Crimboween cookie	2	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	decent shaking skull-shaped Crimboween cookie	3	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	flavorless miniature wobbly tombstone-shaped Crimboween cookie	2	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	miniature flavorless wobbly tombstone-shaped Crimboween cookie	2	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	plastic gift-wrapping vampire of dire peril	0		Weapon Damage: +20, Last Available: "2006-12"
 2202	aromatic plastic yuletide troll	0		Stench Resistance: +1, Last Available: "2006-12"
 2203	ghostly coward's plastic skeletal reindeer	0		Monster Level: -20, Single Equip, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	savvy Crimbo tiki necklace	0		Mysticality Percent: +20, Last Available: "2006-12"
 2208	shaking crafty dance instructor's bobble-hip hula elf doll	0		Experience Percent (Moxie): +10, Maximum MP: +10, Last Available: "2006-12"
 2209	skewed stiffened Crimbo ukulele	0		Damage Reduction: 1, Last Available: "2006-12"
-2210	rock-hard studded Tiki lighter	0		Damage Absorption: +80, Damage Reduction: 5, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	yellow Annie Oakley's personal trainer's deck of tropical cards	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	sage tropical paperweight of terror	0		Mysticality Percent: +10, Spooky Spell Damage: +10, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	rock-hard studded Tiki lighter	0		Damage Absorption: +80, Damage Reduction: 5, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	yellow Annie Oakley's personal trainer's deck of tropical cards	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	sage tropical paperweight of terror	0		Mysticality Percent: +10, Spooky Spell Damage: +10, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	huge tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	blurry tropical wrapping paper	0		Last Available: "2006-12"
-2215	weightlifter's Tropical Crimbo Hat	0		Muscle: +15, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	double-paned Tropical Crimbo Shorts	0		Cold Resistance: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	decent small super ka-bob	2	good	
-2218	half-sized spoiled beer basted brat	2	crappy	
+2215	weightlifter's Tropical Crimbo Hat	0		Muscle: +15, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	double-paned Tropical Crimbo Shorts	0		Cold Resistance: +5, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2217	small decent super ka-bob	2	good	
+2218	spoiled half-sized beer basted brat	2	crappy	
 2219	resourceful Tropical Crimbo Sword	0		Maximum MP: +50, Last Available: "2006-12"
 2220	improved polymerized and Crimboween candy	0		Effect: "Stop the Presses!", Effect Duration: 51, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	lard-coated mansplainer's liar's pants	0		Monster Level: +15, Sleaze Spell Damage: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	lard-coated mansplainer's liar's pants	0		Monster Level: +15, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	frosty dance instructor's juggler's balls	0		Experience Percent (Moxie): +10, Cold Spell Damage: +10, Softcore Only, Last Available: "2007-01"
 2224	manspreader's pink shirt	0		Monster Level: +10, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2240,16 +2240,16 @@
 2266	wobbly wet stunt nut stew	0		
 2267	jittery Mega Gem	0		
 2268	blinking cool Staff of Fats	0		Moxie: +5
-2269	miniature bland enchanted sausage wonton	2	decent	Effect: "Ghost Finger", Effect Duration: 15
+2269	bland enchanted miniature sausage wonton	2	decent	Effect: "Ghost Finger", Effect Duration: 15
 2270	narrow careful sage belt	0		Mysticality Percent: +10, Monster Level: -10, Single Equip
 2271	bad boozy bottle of Merlot	5	decent	
 2272	bad tumbling huge bottle of Port	4	decent	
-2273	perfectly mixed weak bottle of Pinot Noir	2	EPIC	
+2273	weak perfectly mixed bottle of Pinot Noir	2	EPIC	
 2274	acceptable bottle of Zinfandel	4	good	
 2275	weak hand-crafted bottle of Marsala	2	EPIC	
 2276	acceptable bottle of Muscat	4	good	
 2277	Fernswarthy's key	0		
-2278	upside-down narrow Fernswarthy's letter	0		
+2278	narrow upside-down Fernswarthy's letter	0		
 2279	book	0		
 2280	Manual of Labor	0		
 2281	Manual of Transmission	0		
@@ -2368,7 +2368,7 @@
 2394	frosty resourceful Danglin' Chad's loincloth	0		Maximum MP: +50, Cold Spell Damage: +10, Familiar Effect: "stench atk, 0.5xVolley"
 2395	Van der Graaf tube sock	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2396	chloroform rag	0		
-2397	tumbling blue depantsing bomb	0		
+2397	blue tumbling depantsing bomb	0		
 2398	blue spinning banded energy drink IV	0		Damage Absorption: +100, Single Equip
 2399	narrow quilted stylish Elmley shades	0		Moxie: +25, Damage Absorption: +40, Single Equip
 2400	blinking molotov cocktail cocktail	0		
@@ -2398,7 +2398,7 @@
 2424	deionized cyclops eyedrops	0		Effect: "Cold Blooded", Effect Duration: 68
 2425	colloidal triple-electrified upside-down can of spinach	0		Effect: "Heightened Senses", Effect Duration: 68
 2426	magnetized fire flower	0		Effect: "Berry Berry Cold", Effect Duration: 66
-2427	colloidal bouncing twirling freezerburned ice cube	0		Effect: "Bright!", Effect Duration: 39
+2427	colloidal twirling bouncing freezerburned ice cube	0		Effect: "Bright!", Effect Duration: 39
 2428	cold-filtered nitrogenated concentrated fake blood	0		Effect: "Bubblin' Rage", Effect Duration: 34
 2429	electrified bouncing Eau de Guaneau	0		Effect: "Taurus Rising", Effect Duration: 59
 2430	concentrated pressed deionized bag of lard	0		Effect: "Uncaged Power", Effect Duration: 18
@@ -2406,7 +2406,7 @@
 2432	extra-unsweetened polymerized SPF 451 lip balm	0		Effect: "Fishy Fortification", Effect Duration: 59
 2433	improved electrified bottle of antifreeze	0		Effect: "Lifted Spirits", Effect Duration: 67
 2434	oxidized enhanced ghostly eyedrops	0		Effect: "Yuletide Sappiness", Effect Duration: 26
-2435	modified enhanced ionized ghostly tumbling Dogsgotnonoz pills	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 37
+2435	modified enhanced ionized tumbling ghostly Dogsgotnonoz pills	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 37
 2436	aerosolized donkey flipbook	0		Effect: "French Bronilla Brogueishness", Effect Duration: 17
 2437	New Cloaca-Cola	0		
 2438	tumbling shaking scented massage oil	0		
@@ -2415,8 +2415,8 @@
 2441	Knob Goblin Encryption Key	0		
 2442	pulsating Cobb's Knob map	0		
 2443	nasty healthy pink glowstick	0		Maximum HP Percent: +20, Stench Damage: +5, Last Available: "2007-03"
-2444	special bad mirror olive Supernova Champagne	3	decent	Effect: "Army of One", Effect Duration: 20
-2445	shaking upside-down Deactivated O. A. F.	0		Last Available: "2007-04"
+2444	bad special olive mirror Supernova Champagne	3	decent	Effect: "Army of One", Effect Duration: 20
+2445	upside-down shaking Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
 2448	tasteful bow tie	0		Familiar Weight: +5
@@ -2435,12 +2435,12 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	moldy bowl of Bounty-Os	3	crappy	
-2465	hand-crafted weak Oreille Divis&eacute;e brandy	2	super EPIC	
+2465	weak hand-crafted Oreille Divis&eacute;e brandy	2	super EPIC	
 2466	teal pompadour'd puppy	0		
 2467	shaking suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
 2469	bundle of receipts	0		
-2470	gray narrow cork	0		
+2470	narrow gray cork	0		
 2471	stardust	0		
 2472	wilted lettuce	0		
 2473	empty greasepaint tube	0		
@@ -2492,20 +2492,20 @@
 2519	mediocre McMillicancuddy's Special Lager	3	decent	
 2520	enchanted tolerable lime green blurry melted Jell-o shot	3	good	Effect: "Empathy", Effect Duration: 20
 2521	weak hand-crafted olive cruelty-free wine	2	EPIC	
-2522	enchanted lousy weak thistle wine	2	decent	Effect: "Cold Throat", Effect Duration: 30
+2522	lousy enchanted weak thistle wine	2	decent	Effect: "Cold Throat", Effect Duration: 30
 2523	megatofu	0		
 2524	displaced fish	0		
-2525	diet adequate fish	1	good	
+2525	adequate diet fish	1	good	
 2526	yummy half-sized fish casserole	2	awesome	
 2527	normal huge teal fish lasagna	7	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	stale half-sized special gnatloaf	2	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 5
+2529	stale special half-sized gnatloaf	2	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 5
 2530	stale huge gnatloaf casserole	6	decent	
 2531	delicious gnat lasagna	3	awesome	
 2532	jittery pork	0		
 2533	stale pork chop sandwiches	3	decent	
 2534	delicious pork casserole	4	awesome	
-2535	spoiled huge pork lasagna	10	crappy	
+2535	huge spoiled pork lasagna	10	crappy	
 2536	canopic jar	0		
 2537	tumbling spice	0		
 2538	organs	0		
@@ -2514,11 +2514,11 @@
 2541	blinking Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	flattened extra-oxidized blinking lesser grodulated violet	0		Effect: "Stop the Presses!", Effect Duration: 60, Last Available: "2007-05"
 2543	liquefied cyan tin magnolia	0		Effect: "Purity of Spirit", Effect Duration: 37, Last Available: "2007-05"
-2544	pressed pulsating blue begpwnia	0		Effect: "Favored by Lyle", Effect Duration: 67, Last Available: "2007-05"
+2544	pressed blue pulsating begpwnia	0		Effect: "Favored by Lyle", Effect Duration: 67, Last Available: "2007-05"
 2545	wet upsy daisy	0		Effect: "Superheroic", Effect Duration: 12, Last Available: "2007-05"
 2546	dry modified half-orchid	0		Effect: "Berry Experiential", Effect Duration: 58, Last Available: "2007-05"
 2547	narrow electrified resourceful tin star	0		Maximum MP: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-05"
-2548	ghostly zippy outrageous sombrero of the boozehound	0		Booze Drop: +100, Initiative: +20, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	ghostly zippy outrageous sombrero of the boozehound	0		Booze Drop: +100, Initiative: +20, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	&quot;Humorous&quot; T-shirt of the bloodbag of the businessman	0		Maximum HP: +100, Meat Drop: +50, Last Available: "2007-05"
 2550	ghostly Peppercorns of Power	0		
 2551	teal vial of mojo	0		
@@ -2546,7 +2546,7 @@
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	narrow spinning maroon ant pick	0		Familiar Effect: "cold damage, meat"
 2575	bronzed locust	0		
-2576	tumbling wobbly honey-dipped locust	0		
+2576	wobbly tumbling honey-dipped locust	0		
 2577	dog trainer's cactus quill of horror	0		Experience (familiar): +1, Spooky Spell Damage: +25
 2578	gravedigger's brainy Staff of the Short Order Cook of extreme caution	0		Mysticality: +5, Monster Level: -25, Spooky Damage: +10
 2579	moldy huge blinking cactus fruit	6	crappy	
@@ -2560,11 +2560,11 @@
 2587	Socratic Corporal Fennel's Lonely Clubs Club Jacket	0		Experience (Mysticality): +1
 2588	extremely unsafe Private Pepper's Lonely Hearts Club Jacket	0		Weapon Damage Percent: +100
 2589	jumbo normal hot date	5	good	
-2590	practically non-alcoholic drinkable tumbling distilled fortified wine	1	good	
+2590	drinkable practically non-alcoholic tumbling distilled fortified wine	1	good	
 2591	bland spinning tasty tart	3	decent	
 2592	jittery Knob Goblin lunchbox	0		
-2593	diet yummy Knob pasty	1	awesome	
-2594	weak lousy thermos full of Knob coffee	2	decent	
+2593	yummy diet Knob pasty	1	awesome	
+2594	lousy weak thermos full of Knob coffee	2	decent	
 2595	denatured warmed jittery Ben-Gal&trade; Balm	0		Effect: "Tiki Temerity", Effect Duration: 15
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
@@ -2618,13 +2618,13 @@
 2645	feather	0		
 2646	frightful feather	0		
 2647	fetid feather	0		
-2648	ghostly wobbly flirtatious feather	0		
+2648	wobbly ghostly flirtatious feather	0		
 2649	wobbly Annie Oakley's Lord Spookyraven's ear trumpet	0		Critical Hit Percent: +20, Single Equip
 2650	blurry bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	snack-sized adequate S.T.L.T.	2	good	Last Available: "2007-06"
-2653	small delicious honey-dew	2	awesome	Last Available: "2007-06"
-2654	weak lousy Xanadian	2	decent	Last Available: "2007-06"
+2653	delicious small honey-dew	2	awesome	Last Available: "2007-06"
+2654	lousy weak Xanadian	2	decent	Last Available: "2007-06"
 2655	flattened non-deionized bottle of absinthe	0		Effect: "Fire Inside", Effect Duration: 46, Last Available: "2007-06"
 2656	curative Drowsy Sword of the brute	0		Muscle Percent: +30, HP Regen Min: 3, HP Regen Max: 5
 2657	rotten escargotsicle	3	crappy	Last Available: "2007-06"
@@ -2632,9 +2632,9 @@
 2659	lime green blurry albatross necklace of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2007-06"
 2660	modified not-a-pipe	1	crappy	Last Available: "2007-06"
 2661	bad purple flask of Amontillado	4	decent	Last Available: "2007-06"
-2662	foul-smelling ball mask	0		Stench Damage: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	wobbly Sinatra's Can-Can skirt	0		Experience (Moxie): +5, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
-2664	quantum modified blinking tumbling sensitive poetry journal	0		Effect: "Salsa Satanica", Effect Duration: 12, Last Available: "2007-06"
+2662	foul-smelling ball mask	0		Stench Damage: +10, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	wobbly Sinatra's Can-Can skirt	0		Experience (Moxie): +5, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2664	quantum modified tumbling blinking sensitive poetry journal	0		Effect: "Salsa Satanica", Effect Duration: 12, Last Available: "2007-06"
 2665	anodized mirror bottled inspiration	0		Effect: "Irresistible Resolve", Effect Duration: 42, Last Available: "2007-06"
 2666	oxidized olive bellhop bell	0		Effect: "There Is A Spoon", Effect Duration: 19, Last Available: "2007-06"
 2667	concentrated spiky collar	0		Effect: "Oily Flavor", Effect Duration: 58, Last Available: "2007-06"
@@ -2648,8 +2648,8 @@
 2675	dehydrated handful of moss	1		Effect: "Ooh, Bitter!", Effect Duration: 5
 2676	modified bit-o-cactus	1		
 2677	dried protein powder	1		
-2678	narrow tumbling yellow spectre scepter	0		
-2679	activated yellow narrow sparkler	0		Effect: "Big Flaming Whip", Effect Duration: 58
+2678	narrow yellow tumbling spectre scepter	0		
+2679	activated narrow yellow sparkler	0		Effect: "Big Flaming Whip", Effect Duration: 58
 2680	electrified snake	0		Effect: "Banono", Effect Duration: 62, Wiki Name: "snake"
 2681	nitrogenated extra-liquefied red M-242	0		Effect: "Ginger Snapped", Effect Duration: 24
 2682	detuned radio	0		
@@ -2695,28 +2695,28 @@
 2722	resourceful savvy Staff of the Greasefire of horror of mayonnaise	0		Mysticality Percent: +20, Maximum MP: +50, Spooky Spell Damage: +25, Sleaze Spell Damage: +50
 2723	pulsating medical-grade extremely unsafe supercool Staff of the Grand Flamb&eacute;	0		Moxie Percent: +20, Weapon Damage Percent: +100, HP Regen Min: 7, HP Regen Max: 10
 2724	decent bowl of rye sprouts	4	good	
-2725	bite-sized stale shaking teal cob of corn	1	decent	
+2725	stale bite-sized shaking teal cob of corn	1	decent	
 2726	spoiled juniper berries	4	crappy	
-2727	moldy thick enchanted plum	5	crappy	Effect: "Video Game Hot Dog", Effect Duration: 30
+2727	moldy enchanted thick plum	5	crappy	Effect: "Video Game Hot Dog", Effect Duration: 30
 2728	special decent pear	3	good	Effect: "Mystic Circle", Effect Duration: 20
 2729	stale peach	4	decent	
 2730	tolerable plum wine	3	good	
 2731	special bad shot of pear schnapps	3	decent	Effect: "Heart Aflame", Effect Duration: 20
 2732	hand-crafted weak shot of peach schnapps	2	EPIC	
-2733	flavorless lime green blinking bunch of square grapes	3	decent	
+2733	flavorless blinking lime green bunch of square grapes	3	decent	
 2734	jumbo adequate brown sugar cane	5	good	
-2735	flavorless low-calorie sandwich of the gods	1	decent	
+2735	low-calorie flavorless sandwich of the gods	1	decent	
 2736	aged twirling Pan-Dimensional Gargle Blaster	4	awesome	
-2737	distilled narrow maroon leopard-print barbell	1	good	
+2737	distilled maroon narrow leopard-print barbell	1	good	
 2738	pile of smoking rags	0		
 2739	oxidized blinking panty raider camouflage	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 40
 2740	upside-down Sherlock's double-paned medical-grade Staff of the Walk-In Freezer	0		Cold Resistance: +5, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10
 2741	drinkable enchanted red boilermaker	4	good	Effect: "Staying Frosty", Effect Duration: 35
-2742	rotten snack-sized steel lasagna	2	quest	
-2743	weak aged squat steel margarita	2	quest	
+2742	snack-sized rotten steel lasagna	2	quest	
+2743	aged weak squat steel margarita	2	quest	
 2744	mixed jittery steel-scented air freshener	1		
 2745	dry polarized jittery gremlin mutagen	0		Effect: "Peppermint Bite", Effect Duration: 19
-2746	boiled jittery blinking extra-potent gremlin mutagen	0		Effect: "Hammered", Effect Duration: 27
+2746	boiled blinking jittery extra-potent gremlin mutagen	0		Effect: "Hammered", Effect Duration: 27
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	upside-down brawny furniture dolly	0		Muscle Percent: +20, Single Equip
 2749	reassuring Oprah's hardy Staff of the Grease Trap	0		Maximum HP: +50, Maximum MP Percent: +50, Spooky Resistance: +1
@@ -2740,7 +2740,7 @@
 2767	stale diet Crimbo pie	1	decent	
 2768	toothsome tumbling pear tart	3	awesome	
 2769	diet flavorless jittery peach pie	1	decent	
-2770	frozen ionized frozen narrow olive chunk of rock salt	0		Effect: "Robocamo", Effect Duration: 48
+2770	frozen ionized frozen olive narrow chunk of rock salt	0		Effect: "Robocamo", Effect Duration: 48
 2771	anodized galvanized handful of pine needles	0		Effect: "Ass Over Teakettle", Effect Duration: 24
 2772	tumbling steamy ruby	0		
 2773	bouncing glacial sapphire	0		
@@ -2789,9 +2789,9 @@
 2816	vibrating forbidden Boxers of the wise owl	0		Mysticality: +20, Spell Damage Percent: +50, Maximum MP Percent: +10, Familiar Effect: "1xVolley, 1xLep"
 2817	reassuring coward's Jim Carey's Brooch	0		Monster Level: 5, Spooky Resistance: +1, Single Equip
 2818	green pulsating frosty wizardly Bracelet of the boozehound	0		Mysticality: +25, Cold Spell Damage: +10, Booze Drop: +100, Single Equip
-2819	Herculean Grimacite gasmask of chilblains	0		Experience (Muscle): +1, Cold Damage: +25, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	Herculean Grimacite gasmask of chilblains	0		Experience (Muscle): +1, Cold Damage: +25, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	teal frosty Grimacite gat of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +10, Last Available: "2008-11"
-2821	pulsating frosty cool Grimacite gaiters	0		Moxie: +5, Cold Spell Damage: +10, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	pulsating frosty cool Grimacite gaiters	0		Moxie: +5, Cold Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	rosewater-soaked horrifying Grimacite gauntlets	0		Spooky Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2008-11"
 2823	vibrating savvy Grimacite go-go boots	0		Mysticality Percent: +20, Maximum MP Percent: +10, Single Equip, Last Available: "2008-11"
 2824	skewed perfumed chilly Grimacite girdle	0		Cold Damage: +5, Stench Resistance: +5, Single Equip, Last Available: "2008-11"
@@ -2801,9 +2801,9 @@
 2828	loaded dice	0		
 2829	upside-down spinning really dense meat stack	0		
 2830	digital key lime	0		
-2831	bouncing lime green star key lime	0		
+2831	lime green bouncing star key lime	0		
 2832	normal pulsating digital key lime pie	4	good	
-2833	massive adequate special star key lime pie	9	good	Effect: "New and Improved", Effect Duration: 50
+2833	special adequate massive star key lime pie	9	good	Effect: "New and Improved", Effect Duration: 50
 2834	auspicious aromatic flame-wreathed bottle-rocket crossbow	0		Hot Spell Damage: +10, Stench Resistance: +1, Item Drop: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	banded indie comic hipster glasses	0		Damage Absorption: +100, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2823,7 +2823,7 @@
 2850	weak artisanal moonberry wine cooler	2	EPIC	
 2851	normal fine aged cheddarwurst	3	good	
 2852	narrow branch from the Great Tree	0		
-2853	bouncing yellow Phil Bunion's axe	0		
+2853	yellow bouncing Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
 2855	hale Samson's huge mosquito proboscis	0		Experience (Muscle): +5, Maximum HP: +20
 2856	polymerized galvanized swamp lolly	0		Effect: "Healthy Blue Glow", Effect Duration: 49
@@ -2838,9 +2838,9 @@
 2865	huge tumbling cyan arcane researcher's beaver spear of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15
 2866	executive stanky shamanic beads	0		Stench Spell Damage: +25, Meat Drop: +40
 2867	upside-down olive clever dilapidated wizard hat of the businessman	0		Maximum MP: +20, Meat Drop: +50, Familiar Effect: "cap 31"
-2868	polymerized non-cold-filtered spinning wobbly pirate pamphlet	0		Effect: "Healthy Red Glow", Effect Duration: 47
+2868	polymerized non-cold-filtered wobbly spinning pirate pamphlet	0		Effect: "Healthy Red Glow", Effect Duration: 47
 2869	magnetized pirate brochure	0		Effect: "Big", Effect Duration: 28
-2870	tarnished colloidal huge gray pirate tract	0		Effect: "Sludgesick", Effect Duration: 65
+2870	tarnished colloidal gray huge pirate tract	0		Effect: "Sludgesick", Effect Duration: 65
 2871	twirling burnt flower	0		
 2872	plastic Naughty Sorceress of the empath of the sweet-tooth	0		Familiar Weight: +5, Candy Drop: +100
 2873	quilted sage plastic Ed the Undying	0		Mysticality Percent: +10, Damage Absorption: +40
@@ -2910,7 +2910,7 @@
 2937	pulsating siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	red spinning unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	moldy big Surprise Egg	5	crappy	
+2940	big moldy Surprise Egg	5	crappy	
 2941	modified teal Steal This Candy	0		Effect: "All Glory To the Toad", Effect Duration: 59
 2942	aerosolized chocolate filthy lucre	0		Effect: "On the Trolley", Effect Duration: 52
 2943	irradiated Angry Farmer's Wife Candy	0		Effect: "Fit To Be Tide", Effect Duration: 13
@@ -2931,12 +2931,12 @@
 2959	lime green groovy rum barrel charrrm bracelet	0		Moxie Percent: +10
 2960	moldy narrow single-serving herbal stuffing	3	crappy	
 2961	spoiled packet of tofurkey gravy	3	crappy	
-2962	low-calorie rotten tofurkey nugget	1	crappy	
+2962	rotten low-calorie tofurkey nugget	1	crappy	
 2963	rigging shampoo	0		
 2964	upside-down ball polish	0		
 2965	mizzenmast mop	0		
 2966	huge Tom's of the Spanish Main Toothpaste	0		
-2967	liquefied double-electrified super-irradiated olive tumbling Swabbie&trade; swab	0		Effect: "Barking Mad", Effect Duration: 31
+2967	liquefied double-electrified super-irradiated tumbling olive Swabbie&trade; swab	0		Effect: "Barking Mad", Effect Duration: 31
 2968	aerosolized tarnished bouncing Oil of Parrrlay	0		Effect: "Coldfinger", Effect Duration: 63
 2969	flavorless small creamsicle	2	decent	
 2970	hand-crafted cream stout	3	EPIC	
@@ -2988,7 +2988,7 @@
 3016	foot locker	0		
 3017	ornate chest	0		
 3018	gilded chest	0		
-3019	yellow wobbly all-purpose cleaner	0		
+3019	wobbly yellow all-purpose cleaner	0		
 3020	olive handful of sawdust	0		
 3021	stone triangle	0		
 3022	teal medium stone triangle	0		
@@ -3000,7 +3000,7 @@
 3028	extra-dry bad Corpse Island iced tea	5	decent	
 3029	mediocre red-headed corpse	4	decent	
 3030	tolerable cyan kamicorpse-ee	4	good	
-3031	boozy perfectly mixed ghostly corpsel	5	EPIC	
+3031	perfectly mixed boozy ghostly corpsel	5	EPIC	
 3032	tolerable fuchsia corpsebite	3	good	
 3033	squat pirate fledges of dire peril	0		Weapon Damage: +20
 3034	piece of thirteen	0		
@@ -3013,11 +3013,11 @@
 3041	joke scroll	0		
 3042	mirror Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	tumbling metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	normal super-sized nanite-infested gingerbread bugbear	5	good	Last Available: "2007-12"
-3046	bite-sized spoiled nanite-infested candy cane	1	crappy	Last Available: "2020-09"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	super-sized normal nanite-infested gingerbread bugbear	5	good	Last Available: "2007-12"
+3046	spoiled bite-sized nanite-infested candy cane	1	crappy	Last Available: "2020-09"
 3047	bland nanite-infested fruitcake	4	decent	Last Available: "2007-12"
-3048	hand-crafted watered-down nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
+3048	watered-down hand-crafted nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	eyepatch of temperance	0		Sleaze Resistance: +5, Familiar Effect: "spooky atk, 1xBarrr"
 3051	cutlass of incineration	0		Hot Spell Damage: +50
@@ -3025,7 +3025,7 @@
 3053	yellow mood ring	0		Last Available: "2007-02"
 3054	anodized candy heart	0		Effect: "Ooh, Sour!", Effect Duration: 28, Last Available: "2007-02"
 3055	cold-filtered cymbal syrup	0		Free Pull, Effect: "Fishy Fortification", Effect Duration: 26, Last Available: "2007-02"
-3056	metallic foil cat ears of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	metallic foil cat ears of Tarzan	0		Experience (Muscle): +3, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	upside-down nanofiber cloth	0		Last Available: "2007-12"
 3058	ghostly gray iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	dog trainer's cool roboduck-on-a-string	0		Moxie: +5, Experience (familiar): +1, Last Available: "2007-12"
 3086	shaking mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	ribald sinister biomechanical crimborg helmet	0		Spell Damage: +10, Sleaze Damage: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	ribald sinister biomechanical crimborg helmet	0		Spell Damage: +10, Sleaze Damage: +10, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	dangerous C.B.F.G. of temperance	0		Weapon Damage: +10, Sleaze Resistance: +5, Last Available: "2007-12"
-3090	bouncing executive Jim Carey's biomechanical crimborg leg armor	0		Monster Level: +25, Meat Drop: +40, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	bouncing executive Jim Carey's biomechanical crimborg leg armor	0		Monster Level: +25, Meat Drop: +40, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	warmed mirror vitachoconutriment capsule	0		Effect: "White-boy Angst", Effect Duration: 21, Last Available: "2007-12"
 3092	upside-down handmade hobby horse of the early riser	0		Adventures: +7, Last Available: "2007-12"
 3093	wholesome ball-in-a-cup	0		Maximum HP Percent: +10, Last Available: "2007-12"
@@ -3068,7 +3068,7 @@
 3096	twirling Oprah's polyalloy shield of chilblains	0		Maximum MP Percent: +50, Cold Damage: +25, Damage Reduction: 9, Last Available: "2007-12"
 3097	maroon skewed fish scaler	0		Last Available: "2007-12"
 3098	upside-down killing feather	0		Last Available: "2007-12"
-3099	narrow jittery ring	0		Last Available: "2007-12"
+3099	jittery narrow ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	blinking rogue swarmer	0		Last Available: "2007-12"
 3102	spinning sawblade fragment	0		Last Available: "2007-12"
@@ -3098,9 +3098,9 @@
 3126	mirror hobo nickel	0		
 3127	blue sandcastle	0		
 3128	marshmallow	0		
-3129	big normal roasted marshmallow	5	good	
+3129	normal big roasted marshmallow	5	good	
 3130	yellow disc	0		Last Available: "2008-01"
-3131	thick toothsome tin cup of mulligan stew	5	awesome	
+3131	toothsome thick tin cup of mulligan stew	5	awesome	
 3132	upside-down auspicious chilly flamin' bindle	0		Cold Damage: +5, Item Drop: +10
 3133	Temple Grandin's extremely unsafe freezin' bindle	0		Weapon Damage Percent: +100, Familiar Weight: +7
 3134	Sinatra's brawny stinkin' bindle	0		Muscle Percent: +20, Experience (Moxie): +5
@@ -3115,11 +3115,11 @@
 3143	purple nasty medical-grade Hodgman's disgusting technicolor overcoat	0		Stench Damage: +5, HP Regen Min: 7, HP Regen Max: 10
 3144	a torn paper strip	0		
 3145	El Vibrato translator	0		
-3146	skewed teal El Vibrato punchcard (115 holes)	0		
+3146	teal skewed El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
 3149	blinking El Vibrato punchcard (213 holes)	0		
-3150	skewed fuchsia El Vibrato punchcard (165 holes)	0		
+3150	fuchsia skewed El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
 3152	jittery El Vibrato punchcard (216 holes)	0		
 3153	cyan El Vibrato punchcard (88 holes)	0		
@@ -3138,15 +3138,15 @@
 3166	tumbling repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	modified triple-unsweetened ghostly upside-down seal eyeball	0		Effect: "Heart of Lavender", Effect Duration: 19
-3169	normal small blue bouncing turtle soup	2	good	Effect: "[598]A Little Bit Evil"
+3169	small normal blue bouncing turtle soup	2	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	clever evil paper umbrella	0		Maximum MP: +20
 3173	polymerized evil vihuela	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 44
 3174	spoiled evil boring spaghetti	3	crappy	
-3175	super-sized normal ghostly evil noodles	5	good	
+3175	normal super-sized ghostly evil noodles	5	good	
 3176	normal evil noodles	3	good	
-3177	snack-sized stale pulsating evil painful penne pasta	2	decent	
+3177	stale snack-sized pulsating evil painful penne pasta	2	decent	
 3178	rotten red 3vi1 pr0n m4nic0tti	3	crappy	
 3179	rotten evil ravioli della hippy	4	crappy	
 3180	immense normal twirling evil noodles	10	good	
@@ -3158,7 +3158,7 @@
 3186	unsweetened evil serum of sarcasm	0		Effect: "Patched In", Effect Duration: 58
 3187	moist electrified wobbly evil philter of phorce	0		Effect: "Low on the Hog", Effect Duration: 18
 3188	hand-crafted an evil sump'm sump'm	3	EPIC	
-3189	hand-crafted extra-dry evil ducha de oro	5	EPIC	
+3189	extra-dry hand-crafted evil ducha de oro	5	EPIC	
 3190	drinkable evil horizontal tango	4	good	
 3191	lousy boozy evil roll in the hay	5	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
@@ -3168,7 +3168,7 @@
 3196	origami pasties of the empath	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-02"
 3197	veiny personal trainer's origami riding crop of doom	0		Experience Percent (Muscle): +10, Maximum HP: +10, Spooky Spell Damage: +50, Softcore Only, Last Available: "2008-02"
 3198	skewed El Vibrato trapezoid	0		
-3199	olive skewed jittery lump of coal	0		
+3199	olive jittery skewed lump of coal	0		
 3200	pulsating lump of diamond	0		
 3201	jittery thick padded envelope	0		
 3202	healthy KoL Con IV Pole of Calamity Jane of the brazier	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Hot Spell Damage: +25, Last Available: "2007-09"
@@ -3184,7 +3184,7 @@
 3212	maroon dwarvish document	0		
 3213	dwarvish paper	0		
 3214	dwarvish parchment	0		
-3215	teal huge overcharged El Vibrato power sphere	0		
+3215	huge teal overcharged El Vibrato power sphere	0		
 3216	huge Fly-By-Knight Heraldry form	0		Free Pull
 3217	tumbling El Vibrato Megadrone	0		
 3218	teal squat twirling veiny glowstick of the blizzard	0		Maximum HP: +10, Cold Spell Damage: +25, Last Available: "2008-02"
@@ -3194,14 +3194,14 @@
 3222	smelly hardened gatorskin umbrella	0		Damage Reduction: 3, Stench Spell Damage: +10
 3223	sewer nuggets	0		
 3224	squat sewer wad	0		
-3225	bad practically non-alcoholic bottle of sewage schnapps	1	decent	
-3226	weak drinkable bottle of Ooze-O	2	good	
+3225	practically non-alcoholic bad bottle of sewage schnapps	1	decent	
+3226	drinkable weak bottle of Ooze-O	2	good	
 3227	flavorless mirror C.H.U.M. chum	3	decent	
 3228	normal fuchsia unfortunate dumplings	4	good	
 3229	decaying goldfish liver	0		
 3230	enhanced colloidal blinking oil of oiliness	0		Effect: "Coldfinger", Effect Duration: 55
 3231	tattered paper crown of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xSombrero, cap 15"
-3232	decent bite-sized vanilla-frosted king cake	1	good	Last Available: "2008-03"
+3232	bite-sized decent vanilla-frosted king cake	1	good	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	spinning water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3233,7 +3233,7 @@
 3261	hardened Samson's Chester's bag of candy	0		Experience (Muscle): +5, Damage Reduction: 3, Class: "Disco Bandit"
 3262	Sherlock's rosy-cheeked Chester's cutoffs	0		Maximum HP Percent: +30, Item Drop: +25, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
 3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
-3264	bouncing mirror candygram	0		Last Available: "2008-04"
+3264	mirror bouncing candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	green bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
@@ -3261,7 +3261,7 @@
 3289	scintillating powder	0		Class: "Pastamancer"
 3290	abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
-3292	mirror yellow adorable seal larva	0		
+3292	yellow mirror adorable seal larva	0		
 3293	untamable turtle	0		
 3294	purple macaroni duck	0		
 3295	friendly cheez blob	0		
@@ -3275,7 +3275,7 @@
 3303	sombrero	0		Sombrero Bonus: +10
 3304	Argarggagarg's fang	0		
 3305	Safari Jack's moustache	0		
-3306	tumbling maroon Yakisoba's hat	0		
+3306	maroon tumbling Yakisoba's hat	0		
 3307	tumbling Heimandatz's heart	0		
 3308	Jocko Homo's head	0		
 3309	The Mariachi's guitar case	0		
@@ -3320,9 +3320,9 @@
 3348	maroon mattress	0		
 3349	dinged-up triangle	0		
 3350	practically non-alcoholic bad Ralph IX cognac	1	decent	
-3351	ghostly tumbling llama lama cria	0		Free Pull, Last Available: "2008-06"
+3351	tumbling ghostly llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	olive zen motorcycle	0		Last Available: "2008-06"
-3353	pressed pickled blinking fuchsia llama lama gong	0		Effect: "Blubbered Up", Effect Duration: 53, Last Available: "2008-06"
+3353	pressed pickled fuchsia blinking llama lama gong	0		Effect: "Blubbered Up", Effect Duration: 53, Last Available: "2008-06"
 3354	decent banana-frosted king cake	3	good	Last Available: "2008-08"
 3355	coward's brown plastic baby	0		Monster Level: -20, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
@@ -3332,7 +3332,7 @@
 3360	yellow stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	wobbly tasty louse	0		Last Available: "2008-06"
-3363	half-sized spoiled upside-down mole mol&eacute;	2	crappy	Last Available: "2008-06"
+3363	spoiled half-sized upside-down mole mol&eacute;	2	crappy	Last Available: "2008-06"
 3364	watered-down tolerable Morlock's Mark Bourbon	2	good	Last Available: "2008-06"
 3365	energized irradiated Climate Colada	0		Effect: "Elvish", Effect Duration: 31, Last Available: "2008-06"
 3366	altered digital underground potion	0		Effect: "The Strength...  of the Future", Effect Duration: 12, Last Available: "2008-06"
@@ -3360,9 +3360,9 @@
 3388	Zombo's empty eye	0		
 3389	dance instructor's Frosty's arm of the bloodbag	0		Experience Percent (Moxie): +10, Maximum HP: +100
 3390	squat Jeselnik's curative Staff of the Deepest Freeze	0		Sleaze Damage: +25, Item Drop: +5, HP Regen Min: 3, HP Regen Max: 5
-3391	bouncing squat Frosty's iceball	0		
+3391	squat bouncing Frosty's iceball	0		
 3392	Oscus's garbage can lid of doom	0		Spooky Spell Damage: +50, Damage Reduction: 15
-3393	tumbling twirling Oscus's neverending soda	0		
+3393	twirling tumbling Oscus's neverending soda	0		
 3394	blinking lightning-fast Oscus's flypaper pants of terror	0		Spooky Spell Damage: +10, Initiative: +40, Familiar Effect: "stench atk, 1xPotato"
 3395	red sizzling dangerous Hodgman's porkpie hat	0		Weapon Damage: +10, Hot Damage: +10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	baleful Hodgman's lobsterskin pants of Flo-Jo	0		Spell Damage: +25, Initiative: +100, Familiar Effect: "atk, 1xPotato"
@@ -3372,7 +3372,7 @@
 3400	spoiled bowl of fishysoisse	4	crappy	
 3401	double-electrified vacuum-sealed diffused deadly lampshade	0		Effect: "Thunderheart", Effect Duration: 19
 3402	electrified anodized concentrated garbage juice	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 48
-3403	huge blinking cyan lewd playing card	0		
+3403	cyan huge blinking lewd playing card	0		
 3404	Fonzie's beefcake's deck of lewd playing cards of the glutton	0		Muscle: +25, Experience (Moxie): +1, Food Drop: +100
 3405	mirror Tesla Hodgman's sock	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 3406	spinning huge occult Hodgman's varcolac paw	0		Spell Damage Percent: +25
@@ -3412,7 +3412,7 @@
 3445	Junior Adventurer's kit	0		
 3446	blinking groovy prism necklace	0		Single Equip
 3447	Rosewater's six-rainbow shield	0		Mysticality Percent: +30, Item Drop: +5, Damage Reduction: 12, Last Available: "2008-07"
-3448	blurry olive rainbow bomb	0		Last Available: "2008-07"
+3448	olive blurry rainbow bomb	0		Last Available: "2008-07"
 3449	lime green cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	huge cotton candy smidgen	0		Last Available: "2008-08"
@@ -3461,13 +3461,13 @@
 3494	Fonzie's wizardly fish bazooka	0		Mysticality: +25, Experience (Moxie): +1
 3495	Vulcanized Vulcanized sea salt crystal	0		Effect: "Litterboxing", Effect Duration: 66
 3496	anodized activated bazookafish bubble gum	0		Effect: "Hagnk's Gratitude", Effect Duration: 23
-3497	special drinkable huge bottle of Pete's Sake	4	good	Effect: "Toast Tea", Effect Duration: 50
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	squat blurry beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3497	drinkable special huge bottle of Pete's Sake	4	good	Effect: "Toast Tea", Effect Duration: 50
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	blurry squat beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	rotten canap&eacute;s	3	crappy	
 3502	modified thermos of brew	1	awesome	Effect: "Aspect of the Twinklefairy", Effect Duration: 35, Last Available: "2011-12"
-3503	weak drinkable pulsating twirling purple glass of brandy	2	good	Last Available: "2011-12"
+3503	drinkable weak purple twirling pulsating glass of brandy	2	good	Last Available: "2011-12"
 3504	pulsating French slippers	0		
 3505	strapping LWA ring	0		Muscle: +5
 3506	jittery teal tumbling LARP membership card	0		Last Available: "2008-10"
@@ -3489,7 +3489,7 @@
 3522	green scorching baleful shark jumper	0		Spell Damage: +25, Hot Damage: +25
 3523	pressed non-modified blinking shark cartilage	0		Effect: "Eye of the Lihc", Effect Duration: 44
 3524	liquefied eel battery	0		Effect: "Strong Spirit", Effect Duration: 49
-3525	moist improved blinking huge green temporary teardrop tattoo	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 67
+3525	moist improved green huge blinking temporary teardrop tattoo	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 67
 3526	squat narrow scratch 'n' sniff crossbow of courage	0		Spooky Resistance: +3, Last Available: "2008-11"
 3527	cyan mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
@@ -3510,8 +3510,8 @@
 3543	Rosewater's beefcake's depleted Grimacite gravy boat	0		Muscle: +25, Mysticality Percent: +30, Last Available: "2011-12"
 3544	asbestos-lined Oprah's depleted Grimacite weightlifting belt	0		Maximum MP Percent: +50, Hot Resistance: +5, Single Equip, Last Available: "2011-12"
 3545	boxer's depleted Grimacite grappling hook of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Single Equip, Last Available: "2011-12"
-3546	narrow miser's Sinatra's depleted Grimacite ninja mask	0		Experience (Moxie): +5, Meat Drop: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	depleted Grimacite shinguards of extreme caution of bravery	0		Monster Level: -25, Spooky Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	narrow miser's Sinatra's depleted Grimacite ninja mask	0		Experience (Moxie): +5, Meat Drop: +10, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	depleted Grimacite shinguards of extreme caution of bravery	0		Monster Level: -25, Spooky Resistance: +5, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	brainy beefcake's depleted Grimacite astrolabe	0		Muscle: +25, Mysticality: +5, Single Equip, Last Available: "2011-12"
 3549	Annie Oakley's Samson's KoL Con Cinco Pi&ntilde;ata Bat	0		Experience (Muscle): +5, Critical Hit Percent: +20, Softcore Only, Last Available: "2008-09"
 3550	propeller beanie of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, cap 7"
@@ -3521,7 +3521,7 @@
 3554	glob of slime	0		
 3555	stale immense blinking sea carrot	7	decent	
 3556	moldy teal sea cucumber	3	crappy	
-3557	flavorless half-sized jittery sea avocado	2	decent	
+3557	half-sized flavorless jittery sea avocado	2	decent	
 3558	adequate sea lychee	3	good	
 3559	adequate blinking sea tangelo	3	good	
 3560	moldy sea honeydew	4	crappy	
@@ -3535,20 +3535,20 @@
 3568	spinning wicked weightlifter's sponge helmet of temperance	0		Muscle: +15, Spell Damage: +5, Sleaze Resistance: +5, Familiar Effect: "atk, 1xFairy"
 3569	wholesome extremely unsafe spongy shield of temperance	0		Weapon Damage Percent: +100, Maximum HP Percent: +10, Sleaze Resistance: +5, Damage Reduction: 14
 3570	prompt hale arcane researcher's square sponge pants	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Adventures: +3, Familiar Effect: "hot atk, 1xPotato"
-3571	upside-down mirror flytrap pellet	0		
+3571	mirror upside-down flytrap pellet	0		
 3572	lime green baby cuddlefish	0		
 3573	six-armed sweater	0		Familiar Weight: +5
 3574	slimy chest	0		
 3575	sand dollar	0		
-3576	maroon jittery flytrap bezoar	0		
+3576	jittery maroon flytrap bezoar	0		
 3577	shaking bezoar ring	0		
 3578	candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	wobbly ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
-3580	pulsating maroon wriggling flytrap pellet	0		
+3580	maroon pulsating wriggling flytrap pellet	0		
 3581	tumbling sushi-rolling mat	0		
 3582	half-sized flavorless rice	2	decent	
 3584	stale blinking irradiated candy cane	4	decent	Last Available: "2008-12"
-3585	decent enchanted narrow gingerbread mutant bugbear	4	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10, Last Available: "2008-12"
+3585	enchanted decent narrow gingerbread mutant bugbear	4	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10, Last Available: "2008-12"
 3586	bad oozenog	3	decent	Last Available: "2008-12"
 3587	double-irradiated ionized alkaline sugar plum	0		Effect: "Can't Be a Chooser", Effect Duration: 52, Last Available: "2008-12"
 3588	quadruple-activated double-magnetized ionized sugar banana	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 29, Last Available: "2008-12"
@@ -3557,7 +3557,7 @@
 3591	upside-down asbestos-lined chaotic Mer-kin hookspear	0		Spell Critical Percent: +10, Hot Resistance: +5
 3592	upside-down Mer-kin takebag	0		Item Drop: +5
 3593	Mer-kin thingpouch	0		
-3594	blue wobbly Mer-kin killscroll	0		
+3594	wobbly blue Mer-kin killscroll	0		
 3595	improved blurry Mer-kin fastjuice	0		Effect: "Purity of Spirit", Effect Duration: 49
 3596	imitation crab crate	0		
 3597	imitation crab meat	0		
@@ -3588,8 +3588,8 @@
 3622	cyan gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	slick parasitic claw	0		Moxie: +10, Last Available: "2008-12"
-3625	dog trainer's parasitic tentacles	0		Experience (familiar): +1, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	blinking shaking Jim Carey's parasitic headgnawer	0		Monster Level: +25, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	dog trainer's parasitic tentacles	0		Experience (familiar): +1, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	blinking shaking Jim Carey's parasitic headgnawer	0		Monster Level: +25, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	tumbling double-paned parasitic strangleworm	0		Cold Resistance: +5, Last Available: "2008-12"
 3628	green blinking pair of ragged claws	0		Last Available: "2008-12"
 3629	upside-down burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	shaking radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	elven socks of the bloodbag of courage	0		Maximum HP: +100, Spooky Resistance: +3, Last Available: "2008-12"
 3634	Socratic elven gloves of the sewer	0		Experience (Mysticality): +1, Stench Damage: +25, Last Available: "2008-12"
-3635	Usain Bolt's avaricious festive holiday hat	0		Meat Drop: +30, Initiative: +80, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	Usain Bolt's avaricious festive holiday hat	0		Meat Drop: +30, Initiative: +80, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	stanky patent shoes of the early riser	0		Stench Spell Damage: +25, Adventures: +7, Last Available: "2008-12"
 3637	teal gravedigger's Newton's gray bow tie	0		Experience (Mysticality): +3, Spooky Damage: +10, Last Available: "2008-12"
 3638	chaotic penguin thesaurus of Gandalf	0		Spell Critical Percent: 30, Last Available: "2008-12"
@@ -3608,13 +3608,13 @@
 3642	dragonfish caviar	0		
 3643	pulsating pufferfish spine	0		
 3644	energetic depleted Grimacite kneecapping stick	0		Maximum MP Percent: +20, Last Available: "2007-06"
-3645	tolerable irresponsibly strong canteen of wine	9	good	Last Available: "2008-12"
-3646	normal mirror lime green elven <i>limbos</i> gingerbread	3	good	Last Available: "2008-12"
+3645	irresponsibly strong tolerable canteen of wine	9	good	Last Available: "2008-12"
+3646	normal lime green mirror elven <i>limbos</i> gingerbread	3	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	shaking magic dragonfish fry	0		
 3649	huge map to Madness Reef	0		
 3650	decent diet tumbling toast with jam	1	good	Last Available: "2008-12"
-3651	huge antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	huge antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	hand-crafted elven moonshine	3	EPIC	Last Available: "2008-12"
 3653	toothsome tumbling knuckle sandwich	3	awesome	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	shaking educational psycho sweater of extreme caution	0		Experience: +1, Monster Level: -25, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	tumbling Jim Carey's plastic strand of DNA	0		Monster Level: +25, Last Available: "2008-12"
 3660	blue healthy plastic chunk of depleted Grimacite	0		Maximum HP Percent: +20, Last Available: "2008-12"
 3661	skewed container of Putty	0		Last Available: "2009-01"
-3662	nasty Putty mitre	0		Stench Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	manspreader's Putty leotard	0		Monster Level: +10, Item Drop: +5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	nasty Putty mitre	0		Stench Damage: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	manspreader's Putty leotard	0		Monster Level: +10, Item Drop: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	Putty ball of the storm	0		Maximum MP Percent: +40, Softcore Only, Last Available: "2009-01"
 3665	narrow Putty sheet	0		Last Available: "2009-01"
 3666	supercharged Fonzie's Putty snake of the dark arts	0		Experience (Moxie): +1, Spell Damage Percent: +100, Maximum MP Percent: +30, Softcore Only, Last Available: "2009-01"
@@ -3635,26 +3635,26 @@
 3669	Newton's glow-in-the-dark dart gun	0		Experience (Mysticality): +3, Last Available: "2009-01"
 3670	fireproof glow-in-the-dark burrowgrub	0		Hot Resistance: +3, Last Available: "2009-01"
 3671	Uncle Crimbo's Rations	0		Last Available: "2010-12"
-3672	normal small red upside-down can of franks 'n' beans	2	good	Last Available: "2010-12"
+3672	small normal upside-down red can of franks 'n' beans	2	good	Last Available: "2010-12"
 3673	practically non-alcoholic acceptable ghostly bottle of peppermint schnapps	1	good	Last Available: "2010-12"
 3674	mirror throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	jittery mirror Mer-kin pressureglobe	0		
 3676	red Mer-kin foodbucket	0		
 3677	mirror Temple Grandin's diving muff	0		Familiar Weight: +7, Single Equip
-3678	lousy watered-down narrow salinated mint julep	2	decent	
+3678	watered-down lousy narrow salinated mint julep	2	decent	
 3679	ink bladder	0		
 3680	tumbling esca	0		
 3681	yellow bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	big stale tempura carrot	5	decent	
+3684	stale big tempura carrot	5	decent	
 3685	massive flavorless tempura cucumber	6	decent	
 3686	tiny stale tempura avocado	1	decent	
 3687	stale sea broccoli	3	decent	
 3688	flavorless sea cauliflower	3	decent	
 3689	gigantic flavorless tempura broccoli	7	decent	
 3690	normal spinning tempura cauliflower	3	good	
-3691	bland super-sized sea blueberry	5	decent	
+3691	super-sized bland sea blueberry	5	decent	
 3692	flavorless sea persimmon	3	decent	
 3693	denatured Vulcanized pressurized potion of perception	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 18
 3694	oxidized pressurized potion of proficiency	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 42
@@ -3685,7 +3685,7 @@
 3719	upside-down lantern	0		
 3720	decaying pole	0		
 3721	decaying paddle	0		
-3722	tumbling maroon tarnished ring	0		
+3722	maroon tumbling tarnished ring	0		
 3723	narrow tarnished rod	0		
 3724	mirror brittle plastic handle	0		
 3725	tumbling foggy glass globe	0		
@@ -3713,7 +3713,7 @@
 3747	bouncing mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	improved blurry concoction of clumsiness	0		Effect: "Eagle Eyes", Effect Duration: 15
 3750	avaricious vampire pearl earring	0		Meat Drop: +30, Single Equip
-3751	bland massive chocolate chip brownies	7	decent	
+3751	massive bland chocolate chip brownies	7	decent	
 3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	dry pulsating love song of vague ambiguity	0		Effect: "Proprie Tea", Effect Duration: 50, Last Available: "2009-02"
 3755	boiled modified love song of smoldering passion	0		Effect: "Wreathed in Merriment", Effect Duration: 60, Last Available: "2009-02"
@@ -3727,13 +3727,13 @@
 3763	delicious high-proof slug of vodka	9	awesome	
 3764	acceptable weak slug of rum	2	good	
 3765	mediocre slug of shochu	3	decent	
-3766	perfectly mixed weak olive screwdiver	2	EPIC	
+3766	weak perfectly mixed olive screwdiver	2	EPIC	
 3767	smooth dew yoana lei	4	awesome	
 3768	lousy irresponsibly strong red lychee chuhai	6	decent	
-3769	bad special salacious screwdiver	3	decent	Effect: "Bonelording", Effect Duration: 20
+3769	special bad salacious screwdiver	3	decent	Effect: "Bonelording", Effect Duration: 20
 3770	tolerable tumbling dew yoana salacious lei	4	good	
 3771	practically non-alcoholic artisanal gray salacious lychee chuhai	1	super ultra mega turbo EPIC	
-3772	bad boozy special maroon Alewife&trade; Ale	5	decent	Effect: "Melancholy Burden", Effect Duration: 30
+3772	boozy bad special maroon Alewife&trade; Ale	5	decent	Effect: "Melancholy Burden", Effect Duration: 30
 3773	tumbling seaode	0		
 3774	map to the Dive Bar	0		
 3775	blinking Mer-kin pinkslip	0		
@@ -3753,8 +3753,8 @@
 3789	huge twitching trigger finger	0		Class: "Pastamancer"
 3799	lime green Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	wobbly aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	bouncing crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	bouncing crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	skewed Jeselnik's Newton's brainy Mer-kin roundshield	0		Mysticality: +5, Experience (Mysticality): +3, Sleaze Damage: +25, Damage Reduction: 14
 3804	Mer-kin breastplate of Calamity Jane of Leguizamo	0		Critical Hit Percent: +15, Monster Level: +20
 3805	crafty Mer-kin sneakmask of mayonnaise	0		Maximum MP: +10, Sleaze Spell Damage: +50, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3763,7 +3763,7 @@
 3808	upside-down Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
-3811	green wobbly Mer-kin stashbox	0		
+3811	wobbly green Mer-kin stashbox	0		
 3812	miniature rotten chocolate-frosted king cake	2	crappy	Last Available: "2009-06"
 3813	gray plastic baby of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2009-06"
 3815	blinking midget clownfish	0		
@@ -3783,9 +3783,9 @@
 3829	super-sized yummy squat tempura radish	5	awesome	
 3830	water-polo cap of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	artisanal triple-distilled twirling Typical Tavern swill	8	EPIC	
-3832	bad fancy weak tropical swill	2	decent	Effect: "Human-Pirate Hybrid", Effect Duration: 40
+3832	fancy bad weak tropical swill	2	decent	Effect: "Human-Pirate Hybrid", Effect Duration: 40
 3833	hand-crafted narrow fruity girl swill	4	EPIC	
-3834	special perfectly mixed blended swill	4	EPIC	Effect: "Notably Lovely", Effect Duration: 5
+3834	perfectly mixed special blended swill	4	EPIC	Effect: "Notably Lovely", Effect Duration: 5
 3835	costume wardrobe	0		Softcore Only
 3836	studded smartaleck's beefcake's Elvish sunglasses of the dark arts	0		Muscle: +25, Moxie Percent: +30, Spell Damage Percent: +100, Damage Absorption: +80, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	gray beefy anniversary safety glass vest	0		Muscle: +10
@@ -3850,7 +3850,7 @@
 3896	dry triple-frozen huge vial of slime	0		Effect: "Danish Cunning", Effect Duration: 15
 3897	flattened aerosolized vial of brown slime	0		Effect: "Jelly Combed", Effect Duration: 53
 3898	bottle of G&uuml;-Gone	0		
-3901	mirror pulsating seal-blubber candle	0		Class: "Seal Clubber"
+3901	pulsating mirror seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	purple figurine of a baby seal	0		Class: "Seal Clubber"
 3904	skewed purple figurine of an armored seal	0		Class: "Seal Clubber"
@@ -3859,7 +3859,7 @@
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	skewed figurine of a charred seal	0		Class: "Seal Clubber"
-3910	teal jittery figurine of a seal	0		Class: "Seal Clubber"
+3910	jittery teal figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
 3913	boozy lousy blended swill with a fly in it	5	decent	
@@ -3895,7 +3895,7 @@
 3943	Oprah's wicked infernal toilet brush	0		Spell Damage: +5, Maximum MP Percent: +50, Class: "Seal Clubber"
 3944	nippy shadowy seal eye of Leguizamo	0		Monster Level: +20, Cold Damage: +10, Class: "Seal Clubber"
 3945	oyster egg balloon of courage	0		Spooky Resistance: +3
-3946	bouncing yellow Clan VIP Lounge invitation	0		Free Pull
+3946	yellow bouncing Clan VIP Lounge invitation	0		Free Pull
 3947	pulsating Clan VIP Lounge key	0		Free Pull
 3948	pulsating spinning Meat	0		
 3949	olive treasure chest	0		
@@ -3905,7 +3905,7 @@
 3953	mink	0		
 3954	teddy butler	0		
 3955	fuchsia martini	0		
-3956	blinking tumbling crazy bastard sword	0		
+3956	tumbling blinking crazy bastard sword	0		
 3957	tin of caviar	0		
 3958	shellacked bejeweled cufflinks	0		Damage Reduction: 7, Single Equip
 3959	occult garish pinky ring	0		Spell Damage Percent: +25
@@ -3918,11 +3918,11 @@
 3966	hot-ass club of the brazier of courage of the boozehound	0		Hot Spell Damage: +25, Spooky Resistance: +3, Booze Drop: +100, Class: "Seal Clubber"
 3967	spinning scorching occult Socratic frigid-ass club	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Hot Damage: +25, Class: "Seal Clubber"
 3968	pulsating frightening sizzling medical-grade creepy-ass club	0		Hot Damage: +10, Spooky Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Class: "Seal Clubber"
-3969	enhanced flattened ghostly skewed sizzling seal fat	0		Effect: "Frog In Your Throat", Effect Duration: 37
+3969	enhanced flattened skewed ghostly sizzling seal fat	0		Effect: "Frog In Your Throat", Effect Duration: 37
 3970	twirling Usain Bolt's scorching Abyssal ember	0		Hot Damage: +25, Initiative: +80, Class: "Seal Clubber"
 3971	polarized alkaline vacuum-sealed frost-rimed seal hide	0		Effect: "Spiro Gyro", Effect Duration: 57
 3972	medical-grade personal trainer's seal spine	0		Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10, Class: "Seal Clubber"
-3973	deionized nitrogenated ghostly purple upside-down seal lube	0		Effect: "Powdered", Effect Duration: 61
+3973	deionized nitrogenated upside-down purple ghostly seal lube	0		Effect: "Powdered", Effect Duration: 61
 3974	pulsating family-friendly veiny mannequin leg	0		Maximum HP: +10, Sleaze Resistance: +1, Class: "Seal Clubber"
 3975	upside-down personal trainer's Herculean padded tortoise	0		Experience (Muscle): +1, Experience Percent (Muscle): +10, Damage Reduction: 6
 3976	fuchsia stylish tortoboggan of extreme caution	0		Moxie: +25, Monster Level: -25, Single Equip
@@ -3956,7 +3956,7 @@
 4004	jittery Tesla soup-chucks	0		MP Regen Min: 7, MP Regen Max: 10
 4005	double-deionized tarnished ballast turtle	0		Effect: "Industrial Strength Starch", Effect Duration: 65
 4006	memory of some amino acids	0		Last Available: "2009-06"
-4007	twirling shaking memory of a C	0		Last Available: "2009-06"
+4007	shaking twirling memory of a C	0		Last Available: "2009-06"
 4008	spinning memory of an A	0		Last Available: "2009-06"
 4009	memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
@@ -3979,7 +3979,7 @@
 4027	flame-wreathed slick greaves of the sewer	0		Moxie: +10, Hot Spell Damage: +10, Stench Damage: +25, Familiar Effect: "sleaze atk, 0.5xBarrr"
 4028	bouncing Sinatra's Socratic club of Gandalf	0		Experience (Mysticality): +1, Experience (Moxie): +5, Spell Critical Percent: +20
 4029	memory of a grappling hook	0		Last Available: "2009-06"
-4030	lime green narrow memory of a small stone block	0		Last Available: "2009-06"
+4030	narrow lime green memory of a small stone block	0		Last Available: "2009-06"
 4031	memory of a stone block	0		Last Available: "2009-06"
 4032	memory of half a stone circle	0		Last Available: "2009-06"
 4033	memory of a stone half-circle	0		Last Available: "2009-06"
@@ -3988,22 +3988,22 @@
 4036	caustic slime nodule	0		
 4037	toothsome massive teal slimy sweetbreads	7	awesome	
 4038	acceptable slimy fermented bile bladder	3	good	
-4039	twisted maroon bouncing slimy alveolus	1		Effect: "Squirming Like a Toad", Effect Duration: 25
+4039	twisted bouncing maroon slimy alveolus	1		Effect: "Squirming Like a Toad", Effect Duration: 25
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	red flame-retardant Van der Graaf pig-iron helm	0		Hot Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	energetic pig-iron shinguards of bravery	0		Maximum MP Percent: +20, Spooky Resistance: +5, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	red flame-retardant Van der Graaf pig-iron helm	0		Hot Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	energetic pig-iron shinguards of bravery	0		Maximum MP Percent: +20, Spooky Resistance: +5, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	brawny pig-iron bracers of the ox	0		Muscle: +20, Muscle Percent: +20, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	wumpus-hair whip of the sewer	0		Stench Damage: +25, Last Available: "2009-06"
-4048	frightening wumpus-hair wig of Gandalf of the scaredy-cat	0		Spell Critical Percent: +20, Monster Level: -15, Spooky Damage: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	executive wumpus-hair loincloth of the sewer of terror	0		Stench Damage: +25, Spooky Spell Damage: +10, Meat Drop: +40, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	frightening wumpus-hair wig of Gandalf of the scaredy-cat	0		Spell Critical Percent: +20, Monster Level: -15, Spooky Damage: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	executive wumpus-hair loincloth of the sewer of terror	0		Stench Damage: +25, Spooky Spell Damage: +10, Meat Drop: +40, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	spinning reassuring wumpus-hair sweater of the glutton	0		Spooky Resistance: +1, Food Drop: +100, Last Available: "2009-06"
 4051	avaricious ring of teleportation	0		Meat Drop: +30, Single Equip
 4052	wobbly glass of baboon milk	1	awesome	Last Available: "2009-06"
 4053	banana milkshake	1	decent	Last Available: "2009-06"
-4054	artisanal strong narrow White Hyborian	5	EPIC	Last Available: "2009-06"
+4054	strong artisanal narrow White Hyborian	5	EPIC	Last Available: "2009-06"
 4055	ghostly horrifying goblin hunting spear	0		Spooky Damage: +25, Last Available: "2009-06"
 4056	lion tamer's therapeutic goblin autoblowgun	0		Experience (familiar): +2, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-06"
 4057	greedy tribal beads	0		Meat Drop: +20, Last Available: "2009-06"
@@ -4018,7 +4018,7 @@
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	blinking essence of heat	0		Last Available: "2009-06"
 4068	blurry essence of kink	0		Last Available: "2009-06"
-4069	teal wobbly essence of	0		Last Available: "2009-06"
+4069	wobbly teal essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
 4071	essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
@@ -4063,7 +4063,7 @@
 4111	brazen bracelet of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Initiative: +60, Last Available: "2009-06"
 4112	jittery gravedigger's Herculean bitter bowtie	0		Experience (Muscle): +1, Spooky Damage: +10, Last Available: "2009-06"
 4113	mirror double-paned bewitching boots	0		Cold Resistance: +5, Last Available: "2009-06"
-4114	narrow lime green secret from the future	0		Last Available: "2009-06"
+4114	lime green narrow secret from the future	0		Last Available: "2009-06"
 4115	moist sack	0		
 4116	slick rickety unicycle of the pedagogue of Calamity Jane	0		Moxie: +10, Experience: +3, Critical Hit Percent: +15, Single Equip
 4117	MacGyver's brawny crusty hula hoop of terror	0		Muscle Percent: +20, Maximum MP: +100, Spooky Spell Damage: +10, Single Equip
@@ -4089,7 +4089,7 @@
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
-4140	upside-down mirror a folded paper strip	0		
+4140	mirror upside-down a folded paper strip	0		
 4141	bouncing a crinkled paper strip	0		
 4142	upside-down a crumpled paper strip	0		
 4143	a ragged paper strip	0		
@@ -4098,8 +4098,8 @@
 4146	non-concentrated sand	0		Effect: "Frozen Hands", Effect Duration: 69
 4147	double-paned charged magnet of temperance	0		Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2009-09"
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
-4149	twirling shaking quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
-4150	ghostly pulsating mirror maroon lint	0		Last Available: "2011-12"
+4149	shaking twirling quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
+4150	pulsating ghostly mirror maroon lint	0		Last Available: "2011-12"
 4151	vacuum-sealed squat dubious peppermint	0		Effect: "Chow Downed", Effect Duration: 50, Last Available: "2020-09"
 4152	tarnished Vulcanized mirror Elvish delight	0		Effect: "Cold Jellied", Effect Duration: 37
 4153	rockfish stomach	0		Last Available: "2009-09"
@@ -4130,8 +4130,8 @@
 4178	tumbling blurry sugar shotgun of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2009-09"
 4179	electrified sugar shillelagh	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-09"
 4180	up-at-dawn sugar shank	0		Adventures: +5, Last Available: "2009-09"
-4181	Samson's sugar chapeau of terror of the glutton	0		Experience (Muscle): +5, Spooky Spell Damage: +10, Food Drop: +100, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	skewed sugar shorts of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	Samson's sugar chapeau of terror of the glutton	0		Experience (Muscle): +5, Spooky Spell Damage: +10, Food Drop: +100, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	skewed sugar shorts of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	squat slime convention swag bag	0		
 4185	red narrow slime convention flyers	0		
@@ -4178,16 +4178,16 @@
 4226	brawny Star of Bravery	0		Muscle Percent: +20, Single Equip
 4227	ghostly hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	huge jittery amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	huge jittery amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
-4231	red upside-down ice skate decoy	0		
+4231	upside-down red ice skate decoy	0		
 4232	shaking ice skate doll	0		
 4233	hacienda key	0		
 4234	skewed hale pat&eacute; knife	0		Maximum HP: +20
 4235	blue salt-shaker	0		
 4236	can of sterno	0		
 4237	healthy cheese-slicer	0		Maximum HP Percent: +20
-4238	huge moldy beef jerky	9	crappy	
+4238	moldy huge beef jerky	9	crappy	
 4239	jittery red healthy pipe wrench	0		Maximum HP Percent: +20
 4240	energized flattened polymerized gun cleaning kit	0		Effect: "Empathy", Effect Duration: 68
 4241	wobbly energetic sleep mask	0		Maximum MP Percent: +20, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4197,7 +4197,7 @@
 4245	bookmark	0		
 4246	ghostly ivory cue ball of the storm	0		Maximum MP Percent: +40
 4247	tolerable decanter of fine Scotch	3	good	
-4248	boiled bouncing lime green expensive cigar	1		
+4248	boiled lime green bouncing expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	huge fisherman's sack	0		
 4251	ghostly fish-oil smoke bomb	0		
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	stale chocolate-covered scarab beetle	3	decent	Last Available: "2009-10"
 4259	artisanal mulled cider	3	EPIC	Last Available: "2009-10"
-4260	shaking wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pulsating pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	shaking wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pulsating pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	blinking Ax of L'rose	0		Last Available: "2009-10"
-4264	brawny bark boxers	0		Muscle Percent: +20, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	bouncing Jim Carey's bark beret	0		Monster Level: +25, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	brawny bark boxers	0		Muscle Percent: +20, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	bouncing Jim Carey's bark beret	0		Monster Level: +25, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	smartaleck's bark bracelet	0		Moxie Percent: +30, Single Equip
 4267	ribald scorching Krakrox's Loincloth	0		Hot Damage: +25, Sleaze Damage: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	resourceful savvy Galapagosian Cuisses	0		Mysticality Percent: +20, Maximum MP: +50, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4282,8 +4282,8 @@
 4330	stale candy kneecapping stick	3	decent	Last Available: "2009-12"
 4331	bland huge licorice garrote	7	decent	Last Available: "2009-12"
 4332	frightening candy knuckles	0		Spooky Damage: +5, Last Available: "2009-12"
-4333	spoiled diet jittery jawbruiser	1	crappy	Last Available: "2010-12"
-4334	triple-polarized blurry skewed ghostly chocolate car	0		Effect: "Gr8ness", Effect Duration: 30, Last Available: "2009-12"
+4333	diet spoiled jittery jawbruiser	1	crappy	Last Available: "2010-12"
+4334	triple-polarized skewed ghostly blurry chocolate car	0		Effect: "Gr8ness", Effect Duration: 30, Last Available: "2009-12"
 4335	Herculean plastic 11 Dealer	0		Experience (Muscle): +1, Last Available: "2009-12"
 4336	energetic plastic Crimbo Casino	0		Maximum MP Percent: +20, Last Available: "2009-12"
 4337	baleful plastic stocking mimic	0		Spell Damage: +25, Last Available: "2009-12"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	jittery gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat of dire peril	0		Weapon Damage: +20, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	lion tamer's snow pants	0		Experience (familiar): +2, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	snow hat of dire peril	0		Weapon Damage: +20, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	lion tamer's snow pants	0		Experience (familiar): +2, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	ghostly beefcake's snow belly	0		Muscle: +25, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	blue Crimbough	0		Last Available: "2009-12"
@@ -4308,7 +4308,7 @@
 4356	A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
-4359	bouncing teal A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+4359	teal bouncing A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	rotten expired can of franks 'n' beans	3	crappy	Last Available: "2009-12"
 4361	bad olive expired bottle of peppermint schnapps	4	decent	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	aromatic pocketwatch on a chain of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Last Available: "2009-12"
 4386	studded cement sandals of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50, Single Equip, Last Available: "2009-12"
 4387	greedy careful night-vision goggles	0		Monster Level: -10, Meat Drop: +20, Single Equip, Last Available: "2009-12"
-4388	twirling fuchsia passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	fuchsia twirling passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	spinning strapping peanut brittle shield	0		Muscle: +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	nippy steel-toed Red Rover BB gun	0		Damage Reduction: 9, Cold Damage: +10, Last Available: "2009-12"
 4391	jittery extremely unsafe red-and-green sweater	0		Weapon Damage Percent: +100, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	executive cheese sword	0		Meat Drop: +40, Softcore Only, Last Available: "2010-01"
-4400	boxer's cheese diaper	0		Muscle Percent: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	boxer's cheese diaper	0		Muscle Percent: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	friendly cheese wheel	0		Familiar Weight: +3, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	shaking grievous cheese eye	0		Weapon Damage Percent: +50, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	blurry smelly vibrating Staff of Queso Escusado of the cougar	0		Moxie: +20, Maximum MP Percent: +10, Stench Spell Damage: +10, Softcore Only, Last Available: "2010-01"
@@ -4358,9 +4358,9 @@
 4407	Uncle Romulus	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 4408	A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	twirling Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
-4410	maroon skewed The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
+4410	skewed maroon The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	bland jumbo quantum taco	0		Last Available: "2010-10"
+4412	jumbo bland quantum taco	0		Last Available: "2010-10"
 4413	mediocre enchanted Schr&ouml;dinger's thermos	0		Effect: "Innately Truthy", Effect Duration: 5, Last Available: "2010-04"
 4414	spinning colorful plastic ball	0		Last Available: "2010-01"
 4415	upside-down sealhide hood of extreme caution	0		Monster Level: -25, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4382,21 +4382,21 @@
 4432	double-activated non-galvanized shaking olive invisibility potion	0		Effect: "Ice Packed", Effect Duration: 33, Last Available: "2011-08"
 4433	boiled polarized skewed irresistibility potion	0		Effect: "Red Misty-Eyed", Effect Duration: 35, Last Available: "2011-08"
 4434	altered diffused oxidized irritability potion	0		Effect: "Cool, Catlike", Effect Duration: 39, Last Available: "2011-08"
-4436	ghostly bouncing cube	0		Last Available: "2011-02"
+4436	bouncing ghostly cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
-4439	upside-down teal hellseal claw	0		
+4439	teal upside-down hellseal claw	0		
 4440	friendly guard turtle shell	0		Familiar Weight: +3, Familiar Effect: "atk, 1xFairy, cap 40"
 4441	MacGyver's crowbar	0		Maximum MP: +100
 4442	smelly spaghetti cult rosary	0		Stench Spell Damage: +10
 4443	deadly spaghetti cult mask	0		Weapon Damage: +5, Familiar Effect: "1xBarrr, 1xGhuol, cap 38"
-4444	squat wobbly guard turtle collar	0		Familiar Damage: +10
+4444	wobbly squat guard turtle collar	0		Familiar Damage: +10
 4445	spangly mariachi pants of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	twirling tumbling Lo Pan's Socratic spangly mariachi vest	0		Experience (Mysticality): +1, Spell Critical Percent: +30
 4447	medical-grade spangly sombrero	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4448	mixed tumbling Instant Karma	1	decent	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	blinking map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	mirror pointy hat of the ox	0		Muscle: +20, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	mirror pointy hat of the ox	0		Muscle: +20, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	squat quilted machetito	0		Damage Absorption: +40, Last Available: "2010-04"
 4453	Samson's lawnmower blade	0		Experience (Muscle): +5, Last Available: "2010-04"
 4454	huge grass clippings	0		Last Available: "2023-12"
@@ -4416,8 +4416,8 @@
 4468	upside-down Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	cyan BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	wizardly BRICKO hat	0		Mysticality: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	BRICKO pants of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	wizardly BRICKO hat	0		Mysticality: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	BRICKO pants of Tarzan	0		Experience (Muscle): +3, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	narrow Usain Bolt's BRICKO sword	0		Initiative: +80, Last Available: "2010-02"
 4474	jittery BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	decent	Last Available: "2010-03"
 4523	wizardly eye of the Tiger-lily of the sweet-tooth	0		Mysticality: +25, Candy Drop: +100, Last Available: "2010-03"
-4524	shaking fortified wig of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +60, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	special bland donut	4	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 25, Last Available: "2010-03"
+4524	shaking fortified wig of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +60, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	bland special donut	4	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 25, Last Available: "2010-03"
 4526	decent tiny bucket of honey	1	good	Last Available: "2010-03"
 4527	purple wobbly family-friendly elephant stinger of the businessman	0		Sleaze Resistance: +1, Meat Drop: +50, Last Available: "2010-03"
 4528	stale dragon snaps	3	decent	Last Available: "2010-03"
 4529	gray Sherlock's Van der Graaf snapdragon pistil	0		Item Drop: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	gigantic delicious teal rook cookie	10	awesome	Last Available: "2010-03"
-4532	half-sized rotten jittery bishop cookie	2	crappy	Last Available: "2010-03"
-4533	rotten small knight cookie	2	crappy	Last Available: "2010-03"
+4531	delicious gigantic teal rook cookie	10	awesome	Last Available: "2010-03"
+4532	rotten half-sized jittery bishop cookie	2	crappy	Last Available: "2010-03"
+4533	small rotten knight cookie	2	crappy	Last Available: "2010-03"
 4534	bland miniature bouncing king cookie	2	decent	Last Available: "2010-03"
 4535	super-sized rotten queen cookie	5	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	therapeutic insane tophat	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	chilly steel-toed helm of the knight	0		Damage Reduction: 9, Cold Damage: +5, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	therapeutic insane tophat	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	chilly steel-toed helm of the knight	0		Damage Reduction: 9, Cold Damage: +5, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	wristwatch of the knight of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, Single Equip, Last Available: "2010-03"
-4540	lard-coated toasty trousers of the knight	0		Hot Damage: +5, Sleaze Spell Damage: +25, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	lard-coated toasty trousers of the knight	0		Hot Damage: +5, Sleaze Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	hardy tophat	0		Maximum HP: +50, Familiar Effect: "1xBarrr, cap 25"
 4542	flame-retardant tie	0		Hot Resistance: +1, Single Equip
 4543	blurry double-paned tuxedo pants	0		Cold Resistance: +5, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4503,9 +4503,9 @@
 4555	upside-down left bracket	0		
 4556	right parenthesis	0		
 4557	upside-down dollar sign	0		
-4558	wobbly narrow equal sign	0		
+4558	narrow wobbly equal sign	0		
 4559	record album	0		Last Available: "2010-04"
-4560	teal upside-down pulsating map to Professor Jacking's laboratory	0		Last Available: "2010-04"
+4560	pulsating teal upside-down map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	skewed can of depilatory cream	0		Last Available: "2010-04"
 4562	squat hair of the calf	0		Last Available: "2010-04"
 4563	hand-crafted ghostly world's most unappetizing beverage	3	EPIC	Last Available: "2010-04"
@@ -4513,16 +4513,16 @@
 4565	flavorless raisin	4	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	green pulsating Jack Frost's flyest of shirts of Gandalf	0		Spell Critical Percent: +20, Cold Spell Damage: +50, Last Available: "2010-04"
-4568	moldy enchanted a dance upon the palate	3	crappy	Effect: "Ocelot Eyes", Effect Duration: 30, Last Available: "2010-04"
+4568	enchanted moldy a dance upon the palate	3	crappy	Effect: "Ocelot Eyes", Effect Duration: 30, Last Available: "2010-04"
 4569	immense decent upside-down prehistoric meteorite jawbreaker	7	good	Last Available: "2010-04"
 4570	tumbling pulsating Crazyleg's razor	0		Last Available: "2010-04"
-4571	enchanted jumbo decent wobbly squirmy violent party snack	5	good	Effect: "Vitali Tea", Effect Duration: 5, Last Available: "2010-04"
+4571	decent jumbo enchanted wobbly squirmy violent party snack	5	good	Effect: "Vitali Tea", Effect Duration: 5, Last Available: "2010-04"
 4572	resourceful can-you-dig-it?	0		Maximum MP: +50, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	maroon panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	green bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	cold-filtered non-deionized deionized blue Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Cold Hard Skin", Effect Duration: 63, Last Available: "2010-04"
 4580	school Mafi<i>a kni</i>cke&frac12;&aelig; of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2010-04"
@@ -4545,8 +4545,8 @@
 4597	8-Bit Power magazine	0		Last Available: "2010-07"
 4598	pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
-4600	shaking tumbling ghostly map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	boozy artisanal blurry plastic cup of beer	5	EPIC	Last Available: "2010-06"
+4600	ghostly shaking tumbling map to the Kegger in the Woods	0		Last Available: "2010-06"
+4601	artisanal boozy blurry plastic cup of beer	5	EPIC	Last Available: "2010-06"
 4602	blinking orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
@@ -4560,7 +4560,7 @@
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	electrified Crown of Thrones	0		MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2010-05"
-4615	weak drinkable Cinco Mayo Lager	2	good	Last Available: "2010-05"
+4615	drinkable weak Cinco Mayo Lager	2	good	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	tumbling pruning shears	0		Familiar Weight: +5
 4618	fuchsia wobbly plastic cup of flat beer	0		
@@ -4577,12 +4577,12 @@
 4629	plastic spider ring of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	healthy plastic kazoo	0		Maximum HP Percent: +20, Last Available: "2010-06"
 4631	mansplainer's inflatable baseball bat	0		Monster Level: +15, Last Available: "2010-06"
-4632	rosewater-soaked chaotic googly-star hat	0		Spell Critical Percent: +10, Stench Resistance: +3, Familiar Effect: "atk", Last Available: "2010-06"
+4632	rosewater-soaked chaotic googly-star hat	0		Spell Critical Percent: +10, Stench Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk"
 4633	vibrating weightlifter's googly-ball hat	0		Muscle: +15, Maximum MP Percent: +10, Last Available: "2010-06"
 4634	knitted vibrating googly-heart hat	0		Maximum MP Percent: +10, Cold Resistance: +3, Last Available: "2010-06"
 4635	hardy super-sweet boom box of the bloodbag	0		Maximum HP: 150, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	deadly Rosewater's sinister demon mask of the storm	0		Mysticality Percent: +30, Weapon Damage: +5, Maximum MP Percent: +40, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	deadly Rosewater's sinister demon mask of the storm	0		Mysticality Percent: +30, Weapon Damage: +5, Maximum MP Percent: +40, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	ghostly skewed gravedigger's studded streetfighting champion's belt of the early riser	0		Damage Absorption: +80, Spooky Damage: +10, Adventures: +7, Single Equip, Last Available: "2010-06"
 4639	Jeselnik's foul-smelling Van der Graaf Space Trip safety headphones	0		Stench Damage: +10, Sleaze Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2010-06"
 4640	upside-down up-at-dawn LARP carp	0		Adventures: +5
@@ -4594,15 +4594,15 @@
 4646	wobbly zippy foul-smelling Meteoid ice beam of incineration	0		Hot Spell Damage: +50, Stench Damage: +10, Initiative: +20, Last Available: "2011-12"
 4647	crafty smooth thinker's Dungeon Fist gauntlet	0		Mysticality: +10, Moxie: +15, Maximum MP: +10, Last Available: "2011-06"
 4648	bouncing Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	skewed chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
-4651	ghostly olive ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
+4649	skewed chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4651	olive ghostly ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	scorching Tesla ironic knit cap	0		Hot Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
 4654	therapeutic ironic battle spoon	0		HP Regen Min: 5, HP Regen Max: 7
 4655	tumbling sinister educational ironic jogging shorts of vim and vigor	0		Experience: +1, Spell Damage: +10, Maximum HP Percent: +50, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	blurry cyan boxer's mole skin notebook	0		Muscle Percent: +10
-4657	upside-down jittery pair of jeans	0		Last Available: "2010-09"
+4657	jittery upside-down pair of jeans	0		Last Available: "2010-09"
 4658	skewed map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	nippy blackberry galoshes	0		Cold Damage: +10, Single Equip
 4660	smelly deadly trout fang	0		Weapon Damage: +5, Stench Spell Damage: +10, Last Available: "2010-09"
@@ -4627,8 +4627,8 @@
 4679	mirror volcanic ash	0		
 4680	smoked potsherd	0		
 4681	pottery shield of Gandalf	0		Spell Critical Percent: +20, Damage Reduction: 3, Last Available: "2010-09"
-4682	sinister sage pottery hat	0		Mysticality Percent: +10, Spell Damage: +10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	foul-smelling wicked pottery training pants	0		Spell Damage: +5, Stench Damage: +10, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	sinister sage pottery hat	0		Mysticality Percent: +10, Spell Damage: +10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	foul-smelling wicked pottery training pants	0		Spell Damage: +5, Stench Damage: +10, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	pottery club of the storm	0		Maximum MP Percent: +40, Last Available: "2010-09"
 4685	pottery yo-yo of dire peril	0		Weapon Damage: +20, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	blinking supercharged thinker's Greatest American Pants of the businessman	0		Mysticality: +10, Maximum MP Percent: +30, Meat Drop: +50, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	blinking supercharged thinker's Greatest American Pants of the businessman	0		Mysticality: +10, Maximum MP Percent: +30, Meat Drop: +50, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	perfumed fossilized necklace	0		Stench Resistance: +5, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4659,15 +4659,15 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	spinning popsicle stick	0		
-4714	bland small narrow teal lemon popsicle	2	decent	
-4715	diet adequate popsicle	1	good	
+4714	small bland teal narrow lemon popsicle	2	decent	
+4715	adequate diet popsicle	1	good	
 4716	enchanted normal spinning strawberry popsicle	3	good	Effect: "Pisces in the Skyces", Effect Duration: 25
 4717	half-sized toothsome liver popsicle	2	awesome	
 4718	beefy mariachi hat	0		Muscle: +10, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of the detective	0		Item Drop: +20, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	super-sized special moldy squat liver and let pie	5	crappy	Effect: "Human-Orc Hybrid", Effect Duration: 45, Last Available: "2010-10"
+4722	special super-sized moldy squat liver and let pie	5	crappy	Effect: "Human-Orc Hybrid", Effect Duration: 45, Last Available: "2010-10"
 4723	stale pulsating badass pie	3	decent	Last Available: "2010-10"
 4724	normal massive blurry shoo-fish pie	9	good	Last Available: "2010-10"
 4725	yummy upside-down piping organ pie	3	awesome	Last Available: "2010-10"
@@ -4683,7 +4683,7 @@
 4735	narrow prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	yellow skewed beer-soaked mop of the storm	0		Maximum MP Percent: +40
-4738	tolerable watered-down day-old beer	2	good	
+4738	watered-down tolerable day-old beer	2	good	
 4739	weak lousy plain beer	2	decent	
 4740	bad pulsating overpriced &quot;imported&quot; beer	4	decent	
 4741	smiling rat	0		
@@ -4699,17 +4699,17 @@
 4751	prompt boning knife	0		Adventures: +3, Last Available: "2010-10"
 4752	purple sharpshooter's bone crusher	0		Critical Hit Percent: +10, Last Available: "2010-10"
 4753	yellow padded bone spurs	0		Damage Absorption: +20, Single Equip, Last Available: "2010-10"
-4754	blurry ruddy bonedanna of vim and vigor	0		Maximum HP Percent: 90, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	lion tamer's coward's boneana hammock	0		Monster Level: -20, Experience (familiar): +2, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	blurry ruddy bonedanna of vim and vigor	0		Maximum HP Percent: 90, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	lion tamer's coward's boneana hammock	0		Monster Level: -20, Experience (familiar): +2, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	spinning skewed bag of bones	0		Last Available: "2010-10"
 4757	mirror Stabonic scroll	0		Last Available: "2010-10"
 4758	tarnished polarized huge candy skeleton	0		Effect: "Fit To Be Tide", Effect Duration: 34, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	upside-down packet of pumpkin seeds	0		Last Available: "2010-11"
-4761	fuchsia shaking pumpkin	0		Last Available: "2010-11"
+4761	shaking fuchsia pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	adequate pumpkin pie	4	good	Last Available: "2010-11"
-4764	drinkable high-proof gray pumpkin beer	10	good	Last Available: "2010-11"
+4764	high-proof drinkable gray pumpkin beer	10	good	Last Available: "2010-11"
 4765	colloidal red pumpkin juice	0		Effect: "Third Based", Effect Duration: 24, Last Available: "2010-11"
 4766	squat pumpkin bomb	0		Last Available: "2010-11"
 4767	crafty shin gourds	0		Maximum MP: +10, Item Drop: +5, Single Equip, Last Available: "2010-11"
@@ -4724,8 +4724,8 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	green Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	twirling Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	huge bland CRIMBCOIDS mints	8	decent	Last Available: "2011-01"
-4819	huge yellow can of CRIMBCOLA	0		Last Available: "2010-12"
+4818	bland huge CRIMBCOIDS mints	8	decent	Last Available: "2011-01"
+4819	yellow huge can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	rotten CRIMBCOLOAF	3	crappy	Last Available: "2011-01"
 4821	toothsome circular CRIMBCOOKIE	3	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	greasy plastic CRIMBCO HQ	0		Sleaze Spell Damage: +10, Last Available: "2010-12"
@@ -4751,16 +4751,16 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	spinning The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	pulsating blue fireproof horrifying Uncle Hobo's stocking cap	0		Spooky Damage: +25, Hot Resistance: +3, Familiar Effect: "atk", Last Available: "2010-12"
+4845	pulsating blue fireproof horrifying Uncle Hobo's stocking cap	0		Spooky Damage: +25, Hot Resistance: +3, Last Available: "2010-12", Familiar Effect: "atk"
 4846	cyan mirror horrifying nasty Uncle Hobo's epic beard	0		Stench Damage: +5, Spooky Damage: +25, Single Equip, Last Available: "2010-12"
-4847	vibrating hardy Uncle Hobo's gift baggy pants	0		Maximum HP: +50, Maximum MP Percent: +10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	vibrating hardy Uncle Hobo's gift baggy pants	0		Maximum HP: +50, Maximum MP Percent: +10, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	huge deadly Uncle Hobo's fingerless tinsel gloves of the businessman	0		Weapon Damage: +5, Meat Drop: +50, Single Equip, Last Available: "2010-12"
 4849	blinking clever stiffened Uncle Hobo's highest bough	0		Damage Reduction: 1, Maximum MP: +20, Last Available: "2010-12"
 4850	nasty Uncle Hobo's belt of the brute	0		Muscle Percent: +30, Stench Damage: +5, Single Equip, Last Available: "2010-12"
 4851	oxidized chocolate cigar	0		Effect: "Spiro Gyro", Effect Duration: 41, Last Available: "2010-12"
 4852	baleful gift-a-pult	0		Spell Damage: +25, Last Available: "2010-12"
 4853	dry aerosolized squat holly-flavored Hob-O	0		Effect: "Aquarius Rising", Effect Duration: 32, Last Available: "2020-09"
-4854	lime green spinning CRIMBCO scrip	0		Last Available: "2011-01"
+4854	spinning lime green CRIMBCO scrip	0		Last Available: "2011-01"
 4855	huge Toot Oriole care package	0		
 4856	shaking lime green paperclip	0		Last Available: "2011-01"
 4857	wobbly bottle of Blank-Out	0		Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	wobbly foul-smelling fortified razor-sharp paperclip-on tie	0		Weapon Damage Percent: +25, Damage Absorption: +60, Stench Damage: +10, Single Equip, Last Available: "2011-01"
-4869	squat up-at-dawn steel-toed paperclip pants	0		Damage Reduction: 9, Adventures: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	skewed lightning-fast perfumed brainy paperclip turban	0		Mysticality: +5, Stench Resistance: +5, Initiative: +40, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	squat up-at-dawn steel-toed paperclip pants	0		Damage Reduction: 9, Adventures: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	skewed lightning-fast perfumed brainy paperclip turban	0		Mysticality: +5, Stench Resistance: +5, Initiative: +40, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	cyan scorching paperclip cape	0		Hot Damage: +25, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	upside-down photocopied monster	0		Last Available: "2011-01"
@@ -4787,10 +4787,10 @@
 4878	super-tarnished incense bath ball	0		Effect: "Mathematically Precise", Effect Duration: 59, Last Available: "2011-01"
 4879	vacuum-sealed ionized myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Arabian Knighthood", Effect Duration: 66, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	artisanal high-proof tumbling CRIMBCO wine	9	EPIC	Last Available: "2011-01"
+4881	high-proof artisanal tumbling CRIMBCO wine	9	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	enchanted huge stale spinning toe jam toast	6	decent	Effect: "Muscularrr", Effect Duration: 35, Last Available: "2011-01"
+4884	stale huge enchanted spinning toe jam toast	6	decent	Effect: "Muscularrr", Effect Duration: 35, Last Available: "2011-01"
 4885	maroon traffic jam	0		Last Available: "2011-01"
 4886	tiny yummy squat traffic jam toast	1	awesome	Last Available: "2011-01"
 4887	shaking space jam	0		Last Available: "2011-01"
@@ -4855,12 +4855,12 @@
 4952	boiled blurry baggie of sugar	0		Effect: "Trash-Wrapped", Effect Duration: 39
 4953	yellow careful wizardly whalebone corset	0		Mysticality: +25, Monster Level: -10, Single Equip
 4954	rosewater-soaked oven mitts	0		Stench Resistance: +3, Single Equip
-4955	snack-sized yummy mirror overcookie	2	awesome	
-4956	jumbo rotten philosopher's scone	5	crappy	
+4955	yummy snack-sized mirror overcookie	2	awesome	
+4956	rotten jumbo philosopher's scone	5	crappy	
 4957	unsweetened altered warmed narrow half-baked potion	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 35
 4958	fuchsia forbidden Knob Goblin deluxe scimitar	0		Spell Damage Percent: +50
 4959	bland Knob nuts	3	decent	
-4960	high-proof drinkable Cobb's Knob Wurstbrau	6	good	
+4960	drinkable high-proof Cobb's Knob Wurstbrau	6	good	
 4961	Subject 37 file	0		
 4962	spinning frightening padded mysterious lapel pin	0		Damage Absorption: +20, Spooky Damage: +5, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4870,13 +4870,13 @@
 4967	bouncing maroon Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	blurry Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
-4970	green jittery Alice's Army Guard	0		Last Available: "2011-03"
+4970	jittery green Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	skewed Alice's Army Page	0		Last Available: "2011-03"
 4975	upside-down Alice's Army Shieldmaiden	0		Last Available: "2011-03"
-4976	teal narrow Alice's Army Mad Bomber	0		Last Available: "2011-03"
+4976	narrow teal Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	squat Alice's Army Nurse	0		Last Available: "2011-03"
 4978	blinking Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	bouncing maroon Alice's Army Bowman	0		Last Available: "2011-03"
@@ -4913,12 +4913,12 @@
 5010	wobbly evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	tiny enchanted decent huge wasabi pocky	1	good	Effect: "Salamander In Your Stomach", Effect Duration: 5, Last Available: "2011-03"
+5013	enchanted tiny decent huge wasabi pocky	1	good	Effect: "Salamander In Your Stomach", Effect Duration: 5, Last Available: "2011-03"
 5014	moldy tobiko pocky	4	crappy	Last Available: "2011-03"
 5015	tasty natto pocky	3	awesome	Last Available: "2011-03"
-5016	watered-down bad wasabi-infused sake	2	decent	Last Available: "2011-03"
+5016	bad watered-down wasabi-infused sake	2	decent	Last Available: "2011-03"
 5017	lousy special pulsating tobiko-infused sake	4	decent	Effect: "Pisces in the Skyces", Effect Duration: 5, Last Available: "2011-03"
-5018	drinkable weak purple natto-infused sake	2	good	Last Available: "2011-03"
+5018	weak drinkable purple natto-infused sake	2	good	Last Available: "2011-03"
 5019	liquefied pickled mirror mirror wasabi marble soda	0		Effect: "Ready to Snap", Effect Duration: 51, Last Available: "2011-03"
 5020	energized green tobiko marble soda	0		Effect: "Impregnably Delicious", Effect Duration: 14, Last Available: "2011-03"
 5021	liquefied natto marble soda	0		Effect: "Whitened Teeth", Effect Duration: 26, Last Available: "2011-03"
@@ -4926,7 +4926,7 @@
 5023	boiled irradiated lime green elderly jawbreaker	0		Effect: "Magically Delicious", Effect Duration: 19, Last Available: "2020-09"
 5024	smooth blinking marshmallow flamb&eacute;	3	awesome	Last Available: "2011-03"
 5025	drinkable cranberry schnapps	3	good	Last Available: "2011-03"
-5026	irresponsibly strong tolerable jittery breaded beer	6	good	Last Available: "2011-03"
+5026	tolerable irresponsibly strong jittery breaded beer	6	good	Last Available: "2011-03"
 5027	delicious practically non-alcoholic fuchsia soy cordial	1	awesome	Last Available: "2011-03"
 5028	crafty savvy slick astral bludgeon	0		Moxie: +10, Mysticality Percent: +20, Maximum MP: +10
 5029	beefy astral shield of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15, Damage Reduction: 15
@@ -4949,9 +4949,9 @@
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	rosewater-soaked ruddy double-ice cap of Gandalf	0		Maximum HP Percent: +40, Spell Critical Percent: +20, Stench Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	rosewater-soaked ruddy double-ice cap of Gandalf	0		Maximum HP Percent: +40, Spell Critical Percent: +20, Stench Resistance: +3, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	zippy quilted double-ice box of the bloodbag	0		Damage Absorption: +40, Maximum HP: +100, Initiative: +20, Last Available: "2011-04"
-5051	flame-retardant stanky occult double-ice britches	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Hot Resistance: +1, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	flame-retardant stanky occult double-ice britches	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Hot Resistance: +1, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	skewed handful of numbers	0		Last Available: "2020-09"
 5053	lime green Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	tolerable spirit-forward Russian Ice	5	good	Last Available: "2011-04"
 5074	mirror olive flame-wreathed clay ashtray	0		Hot Spell Damage: +10, Damage Reduction: 3, Last Available: "2011-05"
 5075	wizardly lanyard	0		Mysticality: +25, Single Equip, Last Available: "2011-05"
-5076	yellow beefcake's monster pants	0		Muscle: +25, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	yellow beefcake's monster pants	0		Muscle: +25, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	pressed Pok&euml;mann band-aid	0		Effect: "Sleazy Weapon", Effect Duration: 17, Last Available: "2011-05"
-5079	hardened Van der Graaf helmet of the pedagogue	0		Experience: +3, Damage Reduction: 3, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	hardened Van der Graaf helmet of the pedagogue	0		Experience: +3, Damage Reduction: 3, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	deadly crutch	0		Weapon Damage: +5, Last Available: "2011-05"
 5081	blinking flame-wreathed shock belt	0		Hot Spell Damage: +10, Single Equip, Last Available: "2011-05"
 5082	liquefied Okee-Dokee soda	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 39, Last Available: "2011-05"
 5083	green upside-down twirling fireproof rubber band gun	0		Hot Resistance: +3, Last Available: "2011-05"
-5084	narrow smartaleck's pin-stripe slacks	0		Moxie Percent: +30, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	narrow smartaleck's pin-stripe slacks	0		Moxie Percent: +30, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	Van der Graaf gloves	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-05"
 5086	magnetized Vulcanized correction fluid	0		Effect: "Piratey Flavor", Effect Duration: 42, Last Available: "2011-05"
 5087	executive Pok&euml;mann figurine: Porkachu	0		Meat Drop: +40, Single Equip, Last Available: "2011-05"
@@ -5007,7 +5007,7 @@
 5104	tarnished fish juice box	0		Effect: "White Blooded", Effect Duration: 23, Last Available: "2011-05"
 5105	blurry paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	hand-crafted ghostly tumbling Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
+5107	hand-crafted tumbling ghostly Jeppson's Malort	3	super ultra EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	stress ball of chilblains	0		Cold Damage: +25, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	bouncing mirror horrifying Oprah's boxer's Admiral's hat	0		Muscle Percent: +10, Maximum MP Percent: +50, Spooky Damage: +25, Familiar Effect: "atk", Last Available: "2011-05"
-5122	bouncing up-at-dawn crafty stylish aviator's cap	0		Moxie: +25, Maximum MP: +10, Adventures: +5, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	bouncing mirror horrifying Oprah's boxer's Admiral's hat	0		Muscle Percent: +10, Maximum MP Percent: +50, Spooky Damage: +25, Last Available: "2011-05", Familiar Effect: "atk"
+5122	bouncing up-at-dawn crafty stylish aviator's cap	0		Moxie: +25, Maximum MP: +10, Adventures: +5, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	mirrored aviator shades of the detective	0		Item Drop: 25, Single Equip, Last Available: "2011-05"
 5124	red blurry Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5039,20 +5039,20 @@
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	teal E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
-5139	wobbly squat carton of astral energy drinks	0		
+5139	squat wobbly carton of astral energy drinks	0		
 5140	vaporized blinking astral energy drink	1		Effect: "Ironclad", Effect Duration: 5
 5141	Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
-5143	purple mirror E.M.U. Unit	0		Last Available: "2011-06"
+5143	mirror purple E.M.U. Unit	0		Last Available: "2011-06"
 5144	blue handful of honey	0		
 5145	pickled dry blinking honeypot	0		Effect: "Floundering", Effect Duration: 36
-5146	massive adequate wild honey pie	6	good	
+5146	adequate massive wild honey pie	6	good	
 5147	drinkable weak gray honey mead	2	good	
 5148	hardened sage honey dipper of the storm	0		Mysticality Percent: +10, Damage Reduction: 3, Maximum MP Percent: +40
 5149	Jim Carey's honeybritches of dire peril of the businessman	0		Weapon Damage: +20, Monster Level: +25, Meat Drop: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	spinning stiffened savvy honeycap of the detective	0		Mysticality Percent: +20, Damage Reduction: 1, Item Drop: +20, Familiar Effect: "1xPotato, cap 43"
-5151	twirling Moonthril Circlet of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	gravedigger's Moonthril Greaves	0		Spooky Damage: +10, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	twirling Moonthril Circlet of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	gravedigger's Moonthril Greaves	0		Spooky Damage: +10, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	Moonthril Flamberge of the sewer	0		Stench Damage: +25, Last Available: "2011-06"
 5154	boxer's Moonthril Longbow	0		Muscle Percent: +10, Last Available: "2011-06"
 5155	curative Moonthril Cuirass	0		HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2011-06"
@@ -5077,14 +5077,14 @@
 5174	delicious Saison du Lune	4	awesome	Last Available: "2011-06"
 5175	drinkable practically non-alcoholic blurry Moonthril Schnapps	1	good	Last Available: "2011-06"
 5176	bad blinking Wrecked Generator	3	decent	Last Available: "2011-06"
-5177	bland half-sized fancy Spaghetti with Moonballs	2	decent	Effect: "Ninja, Please", Effect Duration: 50, Last Available: "2011-06"
-5178	low-calorie adequate Crepes a la Lune	1	good	Last Available: "2011-06"
-5179	low-calorie spoiled Moon Pie	1	crappy	Last Available: "2011-06"
+5177	fancy half-sized bland Spaghetti with Moonballs	2	decent	Effect: "Ninja, Please", Effect Duration: 50, Last Available: "2011-06"
+5178	adequate low-calorie Crepes a la Lune	1	good	Last Available: "2011-06"
+5179	spoiled low-calorie Moon Pie	1	crappy	Last Available: "2011-06"
 5180	activated triple-polarized Comet Pop	0		Effect: "Wax On Your Shoes", Effect Duration: 46, Last Available: "2011-06"
 5181	altered aerosolized olive Flan in the Moon	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 42, Last Available: "2011-06"
 5182	frozen energized 1/6th Pound Cake	0		Effect: "Feroci Tea", Effect Duration: 23, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
-5184	squat red Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
+5184	red squat Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	ghostly Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
@@ -5103,7 +5103,7 @@
 5200	mixed spinning paste	1	crappy	Last Available: "2011-08"
 5201	mixed mirror ectoplasmic paste	1	good	Last Available: "2011-08"
 5202	twisted pulsating greasy paste	1	awesome	Effect: "Spell Transfer Complete", Effect Duration: 45, Last Available: "2011-08"
-5203	compressed spinning narrow pulsating bug paste	1	good	Last Available: "2011-08"
+5203	compressed narrow spinning pulsating bug paste	1	good	Last Available: "2011-08"
 5204	vaporized bouncing hippy paste	1	decent	Last Available: "2011-08"
 5205	distilled orc paste	1	awesome	Effect: "Mistified", Effect Duration: 45, Last Available: "2011-08"
 5206	powdered demonic paste	1	decent	Last Available: "2011-08"
@@ -5124,11 +5124,11 @@
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	wobbly bouncing Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	yummy jumbo Ur-Donut	5	awesome	Last Available: "2011-09"
+5224	jumbo yummy Ur-Donut	5	awesome	Last Available: "2011-09"
 5225	shaking green The Bomb	0		Last Available: "2011-09"
 5226	yellow box of Familiar Jacks	0		Last Available: "2011-09"
 5227	drinkable high-proof bucket of wine	7	good	Last Available: "2011-09"
-5228	huge moldy ultrafondue	9	crappy	Last Available: "2011-09"
+5228	moldy huge ultrafondue	9	crappy	Last Available: "2011-09"
 5229	unbearable light	0		Last Available: "2011-09"
 5230	snowflake	0		Last Available: "2011-09"
 5231	pulsating crystal skull	0		Last Available: "2011-09"
@@ -5138,23 +5138,23 @@
 5235	greedy furry halo	0		Meat Drop: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	frosty halo of the wise owl	0		Mysticality: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	Oprah's time halo	0		Maximum MP Percent: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	distilled mediocre Lumineux Limnio	5	decent	Last Available: "2011-09"
-5239	acceptable extra-dry Morto Moreto	5	good	Last Available: "2011-09"
+5238	mediocre distilled Lumineux Limnio	5	decent	Last Available: "2011-09"
+5239	extra-dry acceptable Morto Moreto	5	good	Last Available: "2011-09"
 5240	drinkable Temps Tempranillo	3	good	Last Available: "2011-09"
 5241	drinkable Bordeaux Marteaux	3	good	Last Available: "2011-09"
 5242	perfectly mixed mirror Fromage Pinotage	3	EPIC	Last Available: "2011-09"
 5243	lousy huge Beignet Milgranet	4	decent	Last Available: "2011-09"
-5244	high-proof lousy Muschat	10	decent	Last Available: "2011-09"
+5244	lousy high-proof Muschat	10	decent	Last Available: "2011-09"
 5245	adequate olive cool jelly donut	3	good	Last Available: "2011-09"
 5246	decent shrapnel jelly donut	3	good	Last Available: "2011-09"
-5247	special gigantic delicious occult jelly donut	8	awesome	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 10, Last Available: "2011-09"
-5248	rotten special thick thyme jelly donut	5	crappy	Last Available: "2011-09"
+5247	special delicious gigantic occult jelly donut	8	awesome	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 10, Last Available: "2011-09"
+5248	special thick rotten thyme jelly donut	5	crappy	Last Available: "2011-09"
 5249	gigantic adequate danish	6	good	Last Available: "2011-09"
 5250	rotten smashed danish	3	crappy	Last Available: "2011-09"
 5251	delicious blurry blurry forbidden danish	3	awesome	Last Available: "2011-09"
-5252	fancy flavorless tumbling cool cat claw	4	decent	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2011-09"
-5253	adequate jittery huge blurry blunt cat claw	3	good	Last Available: "2011-09"
-5254	small normal shadowy cat claw	2	good	Last Available: "2011-09"
+5252	flavorless fancy tumbling cool cat claw	4	decent	Effect: "Nigh-Invincible", Effect Duration: 10, Last Available: "2011-09"
+5253	adequate huge blurry jittery blunt cat claw	3	good	Last Available: "2011-09"
+5254	normal small shadowy cat claw	2	good	Last Available: "2011-09"
 5255	moldy half-sized cheezburger	2	crappy	Last Available: "2011-09"
 5256	decent toasted brie	3	good	Last Available: "2011-09"
 5257	non-irradiated chilled potion of the field gar	0		Effect: "Cookie Backup", Effect Duration: 61, Last Available: "2011-09"
@@ -5172,7 +5172,7 @@
 5269	bobcat grenade	0		Last Available: "2011-09"
 5270	chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
-5272	maroon spinning blinking noxious gas grenade	0		Last Available: "2011-09"
+5272	blinking spinning maroon noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	ghostly Tesla hammerus	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-09"
@@ -5189,7 +5189,7 @@
 5286	twirling d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
 5288	shaking d10	0		Last Available: "2011-09"
-5289	upside-down huge d12	0		Last Available: "2011-09"
+5289	huge upside-down d12	0		Last Available: "2011-09"
 5290	cyan d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
 5292	shaking generic mana potion	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	newborn kobold	0		Last Available: "2011-09"
 5296	mirror slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
-5298	fancy spoiled phish stick	4	crappy	Effect: "Craft Tea", Effect Duration: 40, Last Available: "2011-09"
+5298	spoiled fancy phish stick	4	crappy	Effect: "Craft Tea", Effect Duration: 40, Last Available: "2011-09"
 5299	squat executive Van der Graaf energetic plastic vampire fangs	0		Maximum MP Percent: +20, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	mirror Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5215,16 +5215,16 @@
 5312	moist enhanced electrified ghostly body paint	0		Effect: "Feet of Grapefruit", Effect Duration: 51, Last Available: "2011-10"
 5313	frozen moist necrotizing body spray	0		Effect: "Baconstoned", Effect Duration: 55, Last Available: "2011-10"
 5314	denatured magnetized wobbly bite-me-red lipstick	0		Effect: "Spiky Frozen Hair", Effect Duration: 62, Last Available: "2011-10"
-5315	tarnished pickled pulsating narrow whisker pencil	0		Effect: "Trufflin'", Effect Duration: 29, Last Available: "2011-10"
+5315	tarnished pickled narrow pulsating whisker pencil	0		Effect: "Trufflin'", Effect Duration: 29, Last Available: "2011-10"
 5316	aerosolized quadruple-altered bouncing press-on ribs	0		Effect: "Sweet and Yellow", Effect Duration: 41, Last Available: "2011-10"
 5317	flattened moist Rattlin' Chains	0		Effect: "Flagrantly Fragrant", Effect Duration: 42, Last Available: "2011-10"
 5318	extra-cold-filtered Gummy Brains	0		Effect: "In Vino Vires", Effect Duration: 58, Last Available: "2011-10"
 5319	pickled energized polymerized cyan Blood 'n' Plenty	0		Effect: "Swimming Head", Effect Duration: 53, Last Available: "2011-10"
 5320	boiled ghostly Lobos Mints	0		Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2011-10"
-5321	triple-pickled electrified blinking cyan Sweet Sword	0		Effect: "Smoking like a Bandit", Effect Duration: 29, Last Available: "2011-10"
-5322	fortified lousy Ecto-Cooler	5	decent	Last Available: "2011-10"
+5321	triple-pickled electrified cyan blinking Sweet Sword	0		Effect: "Smoking like a Bandit", Effect Duration: 29, Last Available: "2011-10"
+5322	lousy fortified Ecto-Cooler	5	decent	Last Available: "2011-10"
 5323	tolerable blinking Bartles and BRAAAINS wine cooler	3	good	Last Available: "2011-10"
-5324	practically non-alcoholic acceptable Blood Light	1	good	Last Available: "2011-10"
+5324	acceptable practically non-alcoholic Blood Light	1	good	Last Available: "2011-10"
 5325	aged squat Silver Bullet beer	3	awesome	Last Available: "2011-10"
 5326	bad Bone's Farm &quot;wine&quot;	3	decent	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	tarnished galvanized colloidal drum of pomade	0		Effect: "Antarctic Memories", Effect Duration: 59, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extremely unsafe extra-see-thru nightie	0		Weapon Damage Percent: +100, Last Available: "2011-10"
-5333	razor-sharp BRAINS shorts of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	razor-sharp BRAINS shorts of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	skewed wholesome Mesmereyes&trade; contact lenses	0		Maximum HP Percent: +10, Single Equip, Last Available: "2011-10"
 5335	wobbly Jack Frost's scrunchie	0		Cold Spell Damage: +50, Single Equip, Last Available: "2011-10"
-5336	reassuring gravedigger's extremely skinny jeans	0		Spooky Damage: +10, Spooky Resistance: +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	twirling greedy educational The Necbromancer's Hat	0		Experience: +1, Meat Drop: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	reassuring gravedigger's extremely skinny jeans	0		Spooky Damage: +10, Spooky Resistance: +1, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	twirling greedy educational The Necbromancer's Hat	0		Experience: +1, Meat Drop: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	scorching smooth The Necbromancer's Stein of the brazier	0		Moxie: +15, Hot Damage: +25, Hot Spell Damage: +25, Last Available: "2011-10"
-5339	nippy supercharged The Necbromancer's Shorts of the ox	0		Muscle: +20, Maximum MP Percent: +30, Cold Damage: +10, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	nippy supercharged The Necbromancer's Shorts of the ox	0		Muscle: +20, Maximum MP Percent: +30, Cold Damage: +10, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	fireproof horrifying The Necbromancer's Wizard Staff of Leguizamo	0		Monster Level: +20, Spooky Damage: +25, Hot Resistance: +3, Last Available: "2011-10"
 5341	jittery The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	delicious olive The Cooler Out of Space	4	awesome	Last Available: "2011-10"
@@ -5260,7 +5260,7 @@
 5357	skewed spinning Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	skewed Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-5360	olive upside-down Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
+5360	upside-down olive Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	skewed maroon The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
 5362	CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
@@ -5279,7 +5279,7 @@
 5376	bouncing baleful plastic Big Candy of temperance	0		Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2011-12"
 5377	yellow The Groose in the Hoose	0		Free Pull, Last Available: "2012-12"
 5378	spruce juice	0		Familiar Weight: +5, Last Available: "2012-12"
-5379	vaporized huge pulsating narrow groose grease	1	decent	Effect: "Crotchety, Pining", Effect Duration: 35, Last Available: "2012-12"
+5379	vaporized narrow pulsating huge groose grease	1	decent	Effect: "Crotchety, Pining", Effect Duration: 35, Last Available: "2012-12"
 5380	spinning lollipop stick	0		Last Available: "2011-11"
 5381	bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
@@ -5306,15 +5306,15 @@
 5403	twirling squat Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	squat Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	spinning auspicious banded cane-mail shirt of the wise owl	0		Mysticality: +20, Damage Absorption: +100, Item Drop: +10, Last Available: "2011-12"
-5406	medical-grade boxer's cane-mail pants of doom	0		Muscle Percent: +10, Spooky Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	medical-grade boxer's cane-mail pants of doom	0		Muscle Percent: +10, Spooky Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	acceptable Vodka Matryoshka	3	good	Last Available: "2011-12"
 5408	tolerable Gin Mint	3	good	Last Available: "2011-12"
 5409	irresponsibly strong mediocre Tequiz Navidad	6	decent	Last Available: "2011-12"
-5410	hand-crafted high-proof skewed bouncing Mint Yulep	9	EPIC	Last Available: "2011-12"
+5410	high-proof hand-crafted skewed bouncing Mint Yulep	9	EPIC	Last Available: "2011-12"
 5411	tolerable Crimbojito	3	good	Last Available: "2011-12"
 5412	artisanal jittery Sangria de Menthe	4	EPIC	Last Available: "2011-12"
 5413	candycaine powder	0		Last Available: "2011-12"
-5414	shaking maroon licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
+5414	maroon shaking licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	magnetized quadruple-colloidal tumbling licorice root	0		Effect: "Human-Plant Hybrid", Effect Duration: 45, Last Available: "2011-12"
 5416	altered Vulcanized twirling blurry banana supersucker	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 58, Last Available: "2011-11"
 5417	dry dry pulsating pear supersucker	0		Effect: "Eyes Wide Propped", Effect Duration: 69, Last Available: "2011-11"
@@ -5327,8 +5327,8 @@
 5424	aromatic kumquartz ring	0		Stench Resistance: +1, Single Equip, Last Available: "2011-11"
 5425	strawberyl necklace of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2011-11"
 5426	squat Rosewater's sucker bucket of the brazier	0		Mysticality Percent: +30, Hot Spell Damage: +25, Last Available: "2011-11"
-5427	sucker hakama of the cougar	0		Moxie: +20, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	sucker kabuto of bravery	0		Spooky Resistance: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	sucker hakama of the cougar	0		Moxie: +20, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	sucker kabuto of bravery	0		Spooky Resistance: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	double-paned sucker tachi	0		Cold Resistance: +5, Last Available: "2011-11"
 5430	ghostly sucker scaffold	0		Last Available: "2011-11"
 5431	fuchsia cinnamon troll doll	0		Last Available: "2011-11"
@@ -5358,13 +5358,13 @@
 5455	jittery mirror gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	ionized Fudgie Roll	0		Effect: "Boon of She-Who-Was", Effect Duration: 36, Last Available: "2011-11"
-5458	delicious massive fudge bunny	9	awesome	Last Available: "2011-11"
+5458	massive delicious fudge bunny	9	awesome	Last Available: "2011-11"
 5459	squat fudge spork	0		Last Available: "2011-11"
 5460	jittery extremely unsafe cool fudgecycle of the dark arts	0		Moxie: +5, Weapon Damage Percent: +100, Spell Damage Percent: +100, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	wobbly blank fudge mold	0		Last Available: "2011-11"
 5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
-5464	tarnished olive spinning tumbling resolution: be wealthier	0		Effect: "Gemini Rising", Effect Duration: 16, Last Available: "2012-01"
+5464	tarnished tumbling olive spinning resolution: be wealthier	0		Effect: "Gemini Rising", Effect Duration: 16, Last Available: "2012-01"
 5465	oxidized resolution: be happier	0		Effect: "Thaumodynamic", Effect Duration: 15, Last Available: "2012-01"
 5466	vacuum-sealed dry ghostly resolution: be stronger	0		Effect: "Sagittarius Rising", Effect Duration: 46, Last Available: "2012-01"
 5467	denatured electrified bouncing resolution: be smarter	0		Effect: "Glittering Eyelashes", Effect Duration: 33, Last Available: "2012-01"
@@ -5377,13 +5377,13 @@
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	corrupted pickled jittery gummi salamander	0		Effect: "Weepy, Creepy", Effect Duration: 69, Last Available: "2011-11"
-5477	non-boiled upside-down narrow gummi snake	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 54, Last Available: "2011-11"
+5477	non-boiled narrow upside-down gummi snake	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 54, Last Available: "2011-11"
 5478	anodized gummi canary	0		Effect: "Locks Like the Raven", Effect Duration: 49, Last Available: "2011-11"
-5479	adequate jumbo mirror gummi bear	5	good	Last Available: "2011-11"
+5479	jumbo adequate mirror gummi bear	5	good	Last Available: "2011-11"
 5480	adequate tumbling gummi bear	4	good	Last Available: "2011-11"
-5481	bite-sized decent wobbly gummi bear	1	good	Last Available: "2011-11"
-5482	enchanted small spoiled drunki-bear	2	crappy	Effect: "Unusual Perspective", Effect Duration: 10, Last Available: "2011-11"
-5483	super-sized decent drunki-bear	5	good	Last Available: "2011-11"
+5481	decent bite-sized wobbly gummi bear	1	good	Last Available: "2011-11"
+5482	small spoiled enchanted drunki-bear	2	crappy	Effect: "Unusual Perspective", Effect Duration: 10, Last Available: "2011-11"
+5483	decent super-sized drunki-bear	5	good	Last Available: "2011-11"
 5484	moldy jumbo drunki-bear	5	crappy	Last Available: "2011-11"
 5485	huge Temple Grandin's gummi bowtie	0		Familiar Weight: +7, Last Available: "2011-11"
 5486	skewed skewed fudge pocket square of the sweet-tooth	0		Candy Drop: +100, Last Available: "2011-11"
@@ -5399,14 +5399,14 @@
 5496	electrified quadruple-polarized deionized gummi belemnite	0		Effect: "Saucegoggles", Effect Duration: 62, Last Available: "2011-11"
 5497	purple all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	brawny Big Candy's tophat of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	brawny Big Candy's tophat of the scaredy-cat	0		Muscle Percent: +20, Monster Level: -15, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	yellow Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	skewed blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	small spoiled jerky coins	2	crappy	Last Available: "2011-11"
+5506	spoiled small jerky coins	2	crappy	Last Available: "2011-11"
 5507	special artisanal Go-Wassail	4	EPIC	Effect: "Jittery", Effect Duration: 5, Last Available: "2011-11"
 5508	tarnished flattened Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Ghostly Shell", Effect Duration: 63, Last Available: "2011-11"
 5509	boiled huge bottle of bubbles	0		Effect: "Can Has Cyborger", Effect Duration: 32, Last Available: "2011-11"
@@ -5453,13 +5453,13 @@
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
 5551	Clancy's lute	0		Last Available: "2012-12"
 5552	healthy Trusty	0		Maximum HP Percent: +20
-5553	jittery wobbly can of Rain-Doh	0		Last Available: "2012-02"
+5553	wobbly jittery can of Rain-Doh	0		Last Available: "2012-02"
 5554	blinking empty Rain-Doh can	0		Last Available: "2012-02"
 5555	tarnished fireclutch	0		Effect: "In a Lather", Effect Duration: 18
 5556	sage Rain-Doh wings of the wise owl	0		Mysticality: +20, Mysticality Percent: +10, Softcore Only, Last Available: "2012-02"
 5557	ghostly Rain-Doh agent	0		Last Available: "2012-02"
 5558	Herculean thinker's Rain-Doh laser gun	0		Mysticality: +10, Experience (Muscle): +1, Softcore Only, Last Available: "2012-02"
-5559	fuchsia ruddy Rain-Doh lantern of chilblains	0		Maximum HP Percent: +40, Cold Damage: +25, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	fuchsia ruddy Rain-Doh lantern of chilblains	0		Maximum HP Percent: +40, Cold Damage: +25, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	stanky weightlifter's Rain-Doh violet bo	0		Muscle: +15, Stench Spell Damage: +25, Softcore Only, Last Available: "2012-02"
@@ -5477,15 +5477,15 @@
 5574	weak smooth Transylvania Sling	2	awesome	Last Available: "2012-03"
 5575	lousy weak Shot of the Living Dead	2	decent	Last Available: "2012-03"
 5576	triple-distilled drinkable Buttery Knob	10	good	Last Available: "2012-03"
-5577	watered-down lousy Slippery Knob	2	decent	Last Available: "2012-03"
+5577	lousy watered-down Slippery Knob	2	decent	Last Available: "2012-03"
 5578	lousy Flaming Knob	4	decent	Last Available: "2012-03"
-5579	fancy smooth practically non-alcoholic Grasshopper	1	awesome	Effect: "One For Tea", Effect Duration: 10, Last Available: "2012-03"
+5579	smooth practically non-alcoholic fancy Grasshopper	1	awesome	Effect: "One For Tea", Effect Duration: 10, Last Available: "2012-03"
 5580	perfectly mixed boozy skewed Locust	5	EPIC	Last Available: "2012-03"
-5581	smooth practically non-alcoholic Plague of Locusts	1	awesome	Last Available: "2012-03"
+5581	practically non-alcoholic smooth Plague of Locusts	1	awesome	Last Available: "2012-03"
 5582	lousy ghostly Red Dwarf	4	decent	Last Available: "2012-03"
 5583	weak perfectly mixed maroon Golden Mean	2	EPIC	Last Available: "2012-03"
-5584	spirit-forward smooth Green Giant	5	awesome	Last Available: "2012-03"
-5585	distilled acceptable Aye Aye	5	good	Last Available: "2012-03"
+5584	smooth spirit-forward Green Giant	5	awesome	Last Available: "2012-03"
+5585	acceptable distilled Aye Aye	5	good	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	3	decent	Last Available: "2012-03"
 5587	delicious Aye Aye, Tooth Tooth	4	awesome	Last Available: "2012-03"
 5588	bad skewed Humanitini	3	decent	Last Available: "2012-03"
@@ -5495,50 +5495,50 @@
 5592	artisanal huge Fuzzy Tentacle	3	EPIC	Last Available: "2012-03"
 5593	artisanal practically non-alcoholic mirror Crazymaker	1	super ultra EPIC	Last Available: "2012-03"
 5594	acceptable practically non-alcoholic Zoodriver	1	good	Last Available: "2012-03"
-5595	tolerable weak Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
+5595	weak tolerable Sloe Comfortable Zoo	2	good	Last Available: "2012-03"
 5596	bad distilled Sloe Comfortable Zoo on Fire	5	decent	Last Available: "2012-03"
 5597	tolerable Suffering Sinner	4	good	Last Available: "2012-03"
-5598	artisanal irresponsibly strong special spinning pulsating Suppurating Sinner	8	EPIC	Effect: "The Halls of Moxiousness", Effect Duration: 40, Last Available: "2012-03"
+5598	special artisanal irresponsibly strong pulsating spinning Suppurating Sinner	8	EPIC	Effect: "The Halls of Moxiousness", Effect Duration: 40, Last Available: "2012-03"
 5599	acceptable Sizzling Sinner	3	good	Last Available: "2012-03"
 5600	bad fortified Firewater	5	decent	Last Available: "2012-03"
 5601	artisanal skewed Earth and Firewater	3	EPIC	Last Available: "2012-03"
-5602	weak smooth Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
+5602	smooth weak Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
 5603	mediocre upside-down Slimosa	4	decent	Last Available: "2012-03"
 5604	perfectly mixed boozy Extra-slimy Slimosa	5	EPIC	Last Available: "2012-03"
-5605	acceptable boozy Slimebite	5	good	Last Available: "2012-03"
+5605	boozy acceptable Slimebite	5	good	Last Available: "2012-03"
 5606	mediocre Cement Mixer	3	decent	Last Available: "2012-03"
-5607	weak bad Jackhammer	2	decent	Last Available: "2012-03"
-5608	fancy perfectly mixed Dump Truck	3	EPIC	Effect: "Appeteyes", Effect Duration: 30, Last Available: "2012-03"
+5607	bad weak Jackhammer	2	decent	Last Available: "2012-03"
+5608	perfectly mixed fancy Dump Truck	3	EPIC	Effect: "Appeteyes", Effect Duration: 30, Last Available: "2012-03"
 5609	drinkable pulsating Fauna Libre	3	good	Last Available: "2012-03"
 5610	triple-distilled perfectly mixed Chakra Libre	8	EPIC	Last Available: "2012-03"
 5611	triple-distilled lousy Aura Libre	9	decent	Last Available: "2012-03"
 5612	perfectly mixed Sazerorc	3	EPIC	Last Available: "2012-03"
-5613	fancy drinkable olive Sazuruk-hai	4	good	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2012-03"
+5613	drinkable fancy olive Sazuruk-hai	4	good	Effect: "Wallflowering", Effect Duration: 40, Last Available: "2012-03"
 5614	drinkable twirling Flaming Sazerorc	4	good	Last Available: "2012-03"
 5615	artisanal Green Velvet	3	EPIC	Last Available: "2012-03"
 5616	smooth blinking Green Muslin	3	awesome	Last Available: "2012-03"
-5617	boozy drinkable bouncing mirror Green Burlap	5	good	Last Available: "2012-03"
-5618	watered-down delicious Mohobo	2	awesome	Last Available: "2012-03"
-5619	fortified delicious upside-down green Moonshine Mohobo	5	awesome	Last Available: "2012-03"
+5617	boozy drinkable mirror bouncing Green Burlap	5	good	Last Available: "2012-03"
+5618	delicious watered-down Mohobo	2	awesome	Last Available: "2012-03"
+5619	fortified delicious green upside-down Moonshine Mohobo	5	awesome	Last Available: "2012-03"
 5620	hand-crafted Flaming Mohobo	4	EPIC	Last Available: "2012-03"
 5621	artisanal Drunken Philosopher	4	EPIC	Last Available: "2012-03"
-5622	perfectly mixed strong Drunken Neurologist	5	EPIC	Last Available: "2012-03"
+5622	strong perfectly mixed Drunken Neurologist	5	EPIC	Last Available: "2012-03"
 5623	aged Drunken Astrophysicist	3	awesome	Last Available: "2012-03"
 5624	drinkable Dark & Starry	3	good	Last Available: "2012-03"
-5625	bad triple-distilled enchanted Black Hole	6	decent	Effect: "Reptilian Fortitude", Effect Duration: 15, Last Available: "2012-03"
-5626	lousy triple-distilled Event Horizon	8	decent	Last Available: "2012-03"
-5627	lousy shaking purple Herring Daiquiri	4	decent	Last Available: "2012-03"
+5625	triple-distilled bad enchanted Black Hole	6	decent	Effect: "Reptilian Fortitude", Effect Duration: 15, Last Available: "2012-03"
+5626	triple-distilled lousy Event Horizon	8	decent	Last Available: "2012-03"
+5627	lousy purple shaking Herring Daiquiri	4	decent	Last Available: "2012-03"
 5628	perfectly mixed watered-down blurry Herring Wallbanger	2	EPIC	Last Available: "2012-03"
 5629	smooth Herringtini	3	awesome	Last Available: "2012-03"
 5630	aged practically non-alcoholic Lollipop Drop	1	awesome	Last Available: "2012-03"
-5631	lousy practically non-alcoholic Candy Alexander	1	decent	Last Available: "2012-03"
-5632	acceptable high-proof enchanted Candicaine	9	good	Effect: "Yes, Can Haz", Effect Duration: 25, Last Available: "2012-03"
+5631	practically non-alcoholic lousy Candy Alexander	1	decent	Last Available: "2012-03"
+5632	acceptable enchanted high-proof Candicaine	9	good	Effect: "Yes, Can Haz", Effect Duration: 25, Last Available: "2012-03"
 5633	acceptable huge Caipiranha	3	good	Last Available: "2012-03"
 5634	acceptable Flying Caipiranha	3	good	Last Available: "2012-03"
-5635	weak mediocre Flaming Caipiranha	2	decent	Last Available: "2012-03"
+5635	mediocre weak Flaming Caipiranha	2	decent	Last Available: "2012-03"
 5636	aged Punchplanter	4	awesome	Last Available: "2012-03"
 5637	aged blurry Doublepunchplanter	3	awesome	Last Available: "2012-03"
-5638	mediocre fancy practically non-alcoholic Haymaker	1	decent	Effect: "Lit Up", Effect Duration: 50, Last Available: "2012-03"
+5638	practically non-alcoholic fancy mediocre Haymaker	1	decent	Effect: "Lit Up", Effect Duration: 50, Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	twirling crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	adequate tumbling fungus	4	good	
@@ -5548,14 +5548,14 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	wobbly calendar of the early riser	0		Adventures: +7, Damage Reduction: 4
-5648	healthy dangerous Boris's Helm	0		Weapon Damage: +10, Maximum HP Percent: +20, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	healthy dangerous Boris's Helm	0		Weapon Damage: +10, Maximum HP Percent: +20, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	cool staph of homophones of the overflowing toilet	0		Moxie: +5, Stench Spell Damage: +50
-5650	jittery friendly stiffened beefy Boris's Helm (askew)	0		Muscle: +10, Damage Reduction: 1, Familiar Weight: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	jittery friendly stiffened beefy Boris's Helm (askew)	0		Muscle: +10, Damage Reduction: 1, Familiar Weight: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	skewed mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
-5654	snack-sized rotten nailswurst	2	crappy	
-5655	high-proof smooth used beer	9	awesome	
+5654	rotten snack-sized nailswurst	2	crappy	
+5655	smooth high-proof used beer	9	awesome	
 5656	squat Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5571,17 +5571,17 @@
 5668	bagged &quot;L&quot;	0		
 5669	mirror club	0		
 5670	low-calorie spoiled olive fettucini &eacute;pines Inconnu	1	crappy	
-5671	practically non-alcoholic drinkable huge slap and slap again	1	good	
+5671	drinkable practically non-alcoholic huge slap and slap again	1	good	
 5672	gunpowder burrito	2	good	
 5673	teal beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	distilled spinning tumbling watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	mirror brawny Ze&trade; goggles	0		Muscle Percent: +20, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	mirror brawny Ze&trade; goggles	0		Muscle Percent: +20, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	jittery groovy stylish swimsuit of chilblains	0		Moxie Percent: +10, Cold Damage: +25, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	jittery groovy stylish swimsuit of chilblains	0		Moxie Percent: +10, Cold Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	skewed lost key	0		Last Available: "2012-05"
-5681	half-sized stale squat P.B.L.T.	2	decent	
+5681	stale half-sized squat P.B.L.T.	2	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	handful of juicy garbage	0		
@@ -5605,17 +5605,17 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	pulsating crayon shavings	0		Last Available: "2012-06"
 5704	olive wax bugbear	0		Last Available: "2012-06"
-5705	squat jittery veiny thinker's wax hat	0		Mysticality: +10, Maximum HP: +10, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	executive scandalous wax pants	0		Sleaze Damage: +5, Meat Drop: +40, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	squat jittery veiny thinker's wax hat	0		Mysticality: +10, Maximum HP: +10, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	executive scandalous wax pants	0		Sleaze Damage: +5, Meat Drop: +40, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	tarnished drop of water-37	0		Effect: "Lifted Spirits", Effect Duration: 56, Last Available: "2012-07"
-5709	squat fireproof hale fireman's helmet	0		Maximum HP: +20, Hot Resistance: +3, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	squat fireproof hale fireman's helmet	0		Maximum HP: +20, Hot Resistance: +3, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	skewed fire axe of Gandalf	0		Spell Critical Percent: +20, Last Available: "2012-07"
 5713	huge Annie Oakley's studded dance instructor's fire extinguisher	0		Experience Percent (Moxie): +10, Damage Absorption: +80, Critical Hit Percent: +20, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	special moldy gigantic FDKOL hotcakes	6	crappy	Effect: "Toast Tea", Effect Duration: 5, Last Available: "2012-07"
+5717	gigantic special moldy FDKOL hotcakes	6	crappy	Effect: "Toast Tea", Effect Duration: 5, Last Available: "2012-07"
 5718	twirling hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
 5720	flavorless fiery wing	3	decent	Last Available: "2012-07"
@@ -5624,11 +5624,11 @@
 5723	dry bottle of fire	0		Effect: "Woad Warrior", Effect Duration: 30, Last Available: "2012-07"
 5724	shaking molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	hale hot daub bun of the storm	0		Maximum HP: +20, Maximum MP Percent: +40, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	avaricious crafty hot daub stand	0		Maximum MP: +10, Meat Drop: +30, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	hale hot daub bun of the storm	0		Maximum HP: +20, Maximum MP Percent: +40, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	avaricious crafty hot daub stand	0		Maximum MP: +10, Meat Drop: +30, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	jittery beefy foot-long hot daub of extreme caution	0		Muscle: +10, Monster Level: -25, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	huge adequate fuchsia angst burger	6	good	
+5730	adequate huge fuchsia angst burger	6	good	
 5731	bad 5-hour acrimony	4	decent	
 5732	blank note	0		
 5733	eerily silent box	0		
@@ -5639,18 +5639,18 @@
 5738	spinning smartaleck's Camp Scout backpack	0		Moxie Percent: +30, Softcore Only, Last Available: "2012-07"
 5739	upside-down CSA fire-starting kit	0		Last Available: "2012-07"
 5740	spoiled bag of GORP	4	crappy	Last Available: "2012-07"
-5741	delicious enchanted tumbling water purification pills	4	awesome	Effect: "Buggy Flavor", Effect Duration: 25, Last Available: "2012-07"
+5741	enchanted delicious tumbling water purification pills	4	awesome	Effect: "Buggy Flavor", Effect Duration: 25, Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	hand-crafted CSA scoutmaster's &quot;water&quot;	4	EPIC	Last Available: "2012-07"
-5744	flavorless small ghostly bag of GORF	2	decent	Last Available: "2012-07"
+5744	small flavorless ghostly bag of GORF	2	decent	Last Available: "2012-07"
 5745	gray CSA discount card	0		Last Available: "2020-09"
-5746	bite-sized spoiled bag of QWOP	1	crappy	Last Available: "2012-07"
+5746	spoiled bite-sized bag of QWOP	1	crappy	Last Available: "2012-07"
 5747	alkaline upside-down CSA bravery badge	0		Effect: "Scarysauce", Effect Duration: 65, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
 5749	irresponsibly strong drinkable CSA cheerfulness ration	9	good	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
-5752	massive bland shaking crappy brain	8	decent	
+5752	bland massive shaking crappy brain	8	decent	
 5753	rotten decent brain	3	crappy	
 5754	flavorless good brain	3	decent	
 5755	bland boss brain	4	decent	
@@ -5665,20 +5665,20 @@
 5765	blurry wicked fuzzy earmuffs of the boozehound	0		Spell Damage: +5, Booze Drop: +100, Familiar Effect: "1.5xVolley, cap 32"
 5766	huge resourceful weightlifter's fuzzy montera of the dark arts	0		Muscle: +15, Spell Damage Percent: +100, Maximum MP: +50, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	jittery gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	jittery gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	upside-down talkative skull	0		
 5775	wobbly fronts	0		Familiar Weight: +5
 5776	olive hale Barney's rake of the storm	0		Maximum HP: +20, Maximum MP Percent: +40
-5778	fancy delicious idiot brain	3	awesome	Effect: "Fit To Be Tide", Effect Duration: 40
+5778	delicious fancy idiot brain	3	awesome	Effect: "Fit To Be Tide", Effect Duration: 40
 5779	friendly keel-haulin' knife	0		Familiar Weight: +3
 5780	narrow ice cream scoop of the sweet-tooth	0		Candy Drop: +100
-5781	fancy boozy hand-crafted soft echo eyedrop antidote martini	5	EPIC	Effect: "Permafrosty", Effect Duration: 35
-5782	shaking green morningwood plank	0		
+5781	fancy hand-crafted boozy soft echo eyedrop antidote martini	5	EPIC	Effect: "Permafrosty", Effect Duration: 35
+5782	green shaking morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
 5785	thick caulk	0		
@@ -5697,7 +5697,7 @@
 5798	electrified pressed pulsating Gnollish Crossdress	0		Effect: "Sharp Weapon", Effect Duration: 41
 5799	chilled pulsating eldritch dough	0		Effect: "Dreadful Fear", Effect Duration: 19
 5800	extra-oxidized ionized blinking Charity's choker	0		Effect: "Ack!  Barred!", Effect Duration: 24
-5801	ionized squat skewed shaking Smart Bone Dust	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 46
+5801	ionized shaking squat skewed Smart Bone Dust	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 46
 5802	nitrogenated perpendicular guano	0		Effect: "Infernal Thirst", Effect Duration: 14
 5803	activated electrified spinning White Chocolate Golem Seeds	0		Effect: "Joy", Effect Duration: 37
 5804	non-irradiated altered magnetized Shivering Ch&egrave;vre	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 42
@@ -5705,7 +5705,7 @@
 5806	unsweetened irradiated muesli	0		Effect: "Yuletide Industry", Effect Duration: 18
 5807	altered wet glass of warm milk	0		Effect: "Hair on Your Chest", Effect Duration: 61
 5808	irradiated aerosolized polarized huge wobbly glass of gnat milk	0		Effect: "Morbidi Tea", Effect Duration: 45
-5809	colloidal polarized mirror squat Knob Goblin Mutagen	0		Effect: "Scorpio Rising", Effect Duration: 24
+5809	colloidal polarized squat mirror Knob Goblin Mutagen	0		Effect: "Scorpio Rising", Effect Duration: 24
 5810	oxidized warmed Tears of the Quiet Healer	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 58
 5811	dry alkaline squat tube of lipstick	0		Effect: "Human-Hobo Hybrid", Effect Duration: 60
 5812	adjusted upside-down skelelton spine	0		Effect: "Bone Chilling", Effect Duration: 68
@@ -5730,7 +5730,7 @@
 5831	denatured colloidal twirling pygmy dart	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 40
 5832	flattened pickled blue secret mummy herbs and spices	0		Effect: "Tenacity of the Snapper", Effect Duration: 56
 5833	frozen extra-adjusted skewed brigand brittle	0		Effect: "Serenity", Effect Duration: 68
-5834	diffused polymerized narrow spinning holistic headache remedy	0		Effect: "Blessing of Charcoatl", Effect Duration: 46
+5834	diffused polymerized spinning narrow holistic headache remedy	0		Effect: "Blessing of Charcoatl", Effect Duration: 46
 5835	unsweetened scrunchie tourniquet	0		Effect: "Metal Speed", Effect Duration: 52
 5836	ionized red embezzler's oil	0		Effect: "Celestial Body", Effect Duration: 37
 5837	pressed concentrated yellow Fu Manchu Wax	0		Effect: "Human-Horror Hybrid", Effect Duration: 25
@@ -5755,7 +5755,7 @@
 5856	vacuum-sealed extra-liquefied improved olive Scuba Snack	0		Effect: "Booooooze", Effect Duration: 17
 5857	quadruple-dry colloidal grey cube	0		Effect: "Okee-Dokee Go!", Effect Duration: 17
 5858	nitrogenated votive candle	0		Effect: "The Moxie of LOV", Effect Duration: 14
-5859	double-chilled moist bouncing narrow booby trap	0		Effect: "Extra Backbone", Effect Duration: 39
+5859	double-chilled moist narrow bouncing booby trap	0		Effect: "Extra Backbone", Effect Duration: 39
 5860	dry Agent Corrigan's cigarette	0		Effect: "You're Not Cooking", Effect Duration: 66
 5861	quadruple-vacuum-sealed pulsating good ash	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 41
 5862	tumbling Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
@@ -5767,8 +5767,8 @@
 5868	wool papier-m&acirc;ch&eacute;te of the cougar	0		Moxie: +20, Cold Resistance: +1, Last Available: "2012-09"
 5869	yellow huge prompt lightning-fast papier-m&acirc;chine gun	0		Initiative: +40, Adventures: +3, Last Available: "2012-09"
 5870	executive energetic papier-masque	0		Maximum MP Percent: +20, Meat Drop: +40, Single Equip, Last Available: "2012-09"
-5871	spinning rosewater-soaked papier-mitre of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +3, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	mirror maroon toasty steel-toed papier-m&acirc;churidars	0		Damage Reduction: 9, Hot Damage: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	spinning rosewater-soaked papier-mitre of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +3, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	mirror maroon toasty steel-toed papier-m&acirc;churidars	0		Damage Reduction: 9, Hot Damage: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	maroon papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	blinking teal papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,12 +5779,12 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	narrow skeleton	0		Last Available: "2012-10"
 5882	olive rock-hard forbidden razor-sharp skeleton skis	0		Weapon Damage Percent: +25, Spell Damage Percent: +50, Damage Reduction: 5, Single Equip, Last Available: "2012-10"
-5883	adequate special skeleton quiche	4	good	Effect: "All Glory To the Toad", Effect Duration: 50, Last Available: "2012-10"
+5883	special adequate skeleton quiche	4	good	Effect: "All Glory To the Toad", Effect Duration: 50, Last Available: "2012-10"
 5884	red skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	purple skeletal skiff	0		Last Available: "2012-10"
 5886	hale Sinatra's stylish Bonestabber of terror	0		Moxie: +25, Experience (Moxie): +5, Maximum HP: +20, Spooky Spell Damage: +10, Last Available: "2012-10"
 5887	lousy crystal skeleton vodka	3	decent	Last Available: "2012-10"
-5888	cyan spinning Lazybones&trade; recliner	0		Last Available: "2012-10"
+5888	spinning cyan Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	aromatic auxiliary backbone	0		Stench Resistance: +1, Last Available: "2012-10"
 5890	ghostly skulldozer egg	0		Last Available: "2012-10"
 5891	spinning ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
@@ -5823,7 +5823,7 @@
 5925	shaking ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	squat healthy brainwave-controlled unicorn horn	0		Maximum HP Percent: +20, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	squat healthy brainwave-controlled unicorn horn	0		Maximum HP Percent: +20, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	blinking bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	greedy savvy plastic four-shadowed mime of the overflowing toilet	0		Mysticality Percent: +20, Stench Spell Damage: +50, Meat Drop: +20, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	electrified plastic Father McGruber	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-12"
 5961	smartaleck's plastic Hank North, Photojournalist	0		Moxie Percent: +30, Last Available: "2012-12"
 5962	squat rosy-cheeked plastic blazing bat	0		Maximum HP Percent: +30, Last Available: "2012-12"
-5963	fortified electronic dulcimer pants of the detective	0		Damage Absorption: +60, Item Drop: +20, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	fortified electronic dulcimer pants of the detective	0		Damage Absorption: +60, Item Drop: +20, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	flame-retardant Frown Exerciser of extreme caution	0		Monster Level: -25, Hot Resistance: +1, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5879,7 +5879,7 @@
 5981	red star	0		Last Available: "2013-02"
 5982	aged tankard of ale	4	awesome	Last Available: "2013-02"
 5983	mirror vial of holy water	0		Last Available: "2013-02"
-5984	Temple Grandin's Oprah's savvy cloth cap	0		Mysticality Percent: +20, Maximum MP Percent: +50, Familiar Weight: +7, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	Temple Grandin's Oprah's savvy cloth cap	0		Mysticality Percent: +20, Maximum MP Percent: +50, Familiar Weight: +7, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	squat resourceful Herculean iron dagger of temperance	0		Experience (Muscle): +1, Maximum MP: +50, Sleaze Resistance: +5, Last Available: "2013-02"
 5986	rotten narrow hamburger	3	crappy	Last Available: "2013-02"
 5987	teal dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	jittery potion	0		Last Available: "2013-02"
 5990	hand-crafted cyan bottle of wine	4	EPIC	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	studded dangerous supercool iron helmet	0		Moxie Percent: +20, Weapon Damage: +10, Damage Absorption: +80, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	studded dangerous supercool iron helmet	0		Moxie Percent: +20, Weapon Damage: +10, Damage Absorption: +80, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	squat lightning-fast manspreader's Annie Oakley's steel sword	0		Critical Hit Percent: +20, Monster Level: +10, Initiative: +40, Last Available: "2013-02"
-5994	half-sized delicious whole roasted chicken	2	awesome	Last Available: "2013-02"
+5994	delicious half-sized whole roasted chicken	2	awesome	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	tolerable shining goblet	4	good	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	sizzling chaotic razor-sharp crown	0		Weapon Damage Percent: +25, Spell Critical Percent: +10, Hot Damage: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	sizzling chaotic razor-sharp crown	0		Weapon Damage Percent: +25, Spell Critical Percent: +10, Hot Damage: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	Usain Bolt's sword of Calamity Jane of the brazier	0		Critical Hit Percent: +15, Hot Spell Damage: +25, Initiative: +80, Last Available: "2013-02"
-6002	forbidden dance instructor's Fonzie's Helm of the Scream Emperor	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Spell Damage Percent: +50, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	forbidden dance instructor's Fonzie's Helm of the Scream Emperor	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Spell Damage Percent: +50, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	bouncing Usain Bolt's stylish Cloak of Dire Shadows of the cougar	0		Moxie: 45, Initiative: +80, Last Available: "2013-02"
 6004	jittery energetic strapping Sword of Dark Omens of Calamity Jane	0		Muscle: +5, Maximum MP Percent: +20, Critical Hit Percent: +15, Last Available: "2013-02"
 6005	prompt careful Shield of Icy Fate of terror	0		Monster Level: -10, Spooky Spell Damage: +10, Adventures: +3, Damage Reduction: 7, Last Available: "2013-02"
-6006	foul-smelling Greaves of the Murk Lord of the bloodbag of Flo-Jo	0		Maximum HP: +100, Stench Damage: +10, Initiative: +100, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	foul-smelling Greaves of the Murk Lord of the bloodbag of Flo-Jo	0		Maximum HP: +100, Stench Damage: +10, Initiative: +100, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	huge knitted hale Gauntlets of the Blood Moon of dire peril	0		Weapon Damage: +20, Maximum HP: +20, Cold Resistance: +3, Single Equip, Last Available: "2013-02"
 6008	lime green foul-smelling rosy-cheeked Da Vinci's Boots of Twilight Whispers	0		Experience (Mysticality): +5, Maximum HP Percent: +30, Stench Damage: +10, Single Equip, Last Available: "2013-02"
 6009	grievous stylish Belt of Howling Anger of the wise owl	0		Mysticality: +20, Moxie: +25, Weapon Damage Percent: +50, Single Equip, Last Available: "2013-02"
@@ -5912,7 +5912,7 @@
 6014	sage screwing pooch	0		Mysticality Percent: +10
 6015	enhanced orcish hand lotion	0		Effect: "Innately Strong", Effect Duration: 21
 6016	polymerized orcish rubber	0		Effect: "Taurus Rising", Effect Duration: 67
-6017	dry concentrated tumbling teal orcish nailing lube	0		Effect: "Haunted Stomach", Effect Duration: 39
+6017	dry concentrated teal tumbling orcish nailing lube	0		Effect: "Haunted Stomach", Effect Duration: 39
 6018	lousy backwoods screwdriver	4	decent	
 6019	loadstone of chilblains	0		Cold Damage: +25
 6020	upside-down Fonzie's Claybender glasses of the bloodbag	0		Experience (Moxie): +1, Maximum HP: +100, Single Equip
@@ -5932,7 +5932,7 @@
 6034	ghostly wobbly brainy troll britches of the sweet-tooth	0		Mysticality: +5, Candy Drop: +100, Familiar Effect: "1.5xPotato, cap 28"
 6035	irradiated vial of The Glistening	0		Effect: "Leisurely Amblin'", Effect Duration: 45
 6036	lousy twirling artisanal limoncello	3	decent	
-6037	blue jittery ghostly ginger ale	0		
+6037	jittery ghostly blue ginger ale	0		
 6038	adequate incredible pizza	4	good	
 6039	jittery Van der Graaf extremely unsafe oil cap	0		Weapon Damage Percent: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cap 28"
 6040	flame-wreathed oil lamp of chilblains	0		Cold Damage: +25, Hot Spell Damage: +10
@@ -5947,7 +5947,7 @@
 6049	manspreader's forbidden deadly Misty Cape	0		Weapon Damage: +5, Spell Damage Percent: +50, Monster Level: +10
 6050	blinking olive woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	enchanted bite-sized normal Taco Dan's Taco Stand Taco	1	good	Effect: "Colorful Gratitude", Effect Duration: 35, Last Available: "2012-12"
+6052	normal bite-sized enchanted Taco Dan's Taco Stand Taco	1	good	Effect: "Colorful Gratitude", Effect Duration: 35, Last Available: "2012-12"
 6053	acceptable Taco Dan's Taco Stand Chimichangarita	4	good	Last Available: "2012-12"
 6054	Vulcanized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Berry Defensive", Effect Duration: 60, Last Available: "2012-12"
 6055	purple psychoanalytic jar	0		Last Available: "2013-12"
@@ -5965,13 +5965,13 @@
 6067	wobbly ribald Truthsayer of dire peril	0		Weapon Damage: +20, Sleaze Damage: +10, Last Available: "2013-12"
 6068	ghostly loose blade	0		
 6069	goblin bone hilt	0		
-6070	bouncing narrow sword blade	0		
+6070	narrow bouncing sword blade	0		
 6071	blinking Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	warmed oxidized haggis-infused soap	0		Effect: "Wolf's Bane", Effect Duration: 25, Last Available: "2012-12"
 6074	energized magicberry tablets	0		Effect: "Ponderous Potency", Effect Duration: 42, Last Available: "2012-12"
 6075	chilled nitrogenated oxidized 37x37x37 puzzle cube	0		Effect: "Human-Goblin Hybrid", Effect Duration: 24, Last Available: "2012-12"
-6076	special aged jittery lime green McLeod's Hard Haggis-Ade	4	awesome	Effect: "Items Are Forever", Effect Duration: 30, Last Available: "2012-12"
+6076	aged special lime green jittery McLeod's Hard Haggis-Ade	4	awesome	Effect: "Items Are Forever", Effect Duration: 30, Last Available: "2012-12"
 6077	moldy haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
@@ -5979,7 +5979,7 @@
 6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
-6084	twirling wobbly Mr. Haggis	0		Last Available: "2012-12"
+6084	wobbly twirling Mr. Haggis	0		Last Available: "2012-12"
 6085	green magnetic sculpture kit	0		Last Available: "2012-12"
 6086	Oprah's Microplushie: Otakulone	0		Maximum MP Percent: +50, Last Available: "2012-12"
 6087	twirling curative Microplushie: Hippylase	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-12"
@@ -6016,10 +6016,10 @@
 6118	upside-down purple goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	hand-crafted practically non-alcoholic Chinese beer	1	EPIC	Last Available: "2013-12"
-6122	teal blinking cat statue	0		Last Available: "2013-12"
+6121	practically non-alcoholic hand-crafted Chinese beer	1	EPIC	Last Available: "2013-12"
+6122	blinking teal cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
-6124	pulsating gray furry pink pillow	0		Last Available: "2013-12"
+6124	gray pulsating furry pink pillow	0		Last Available: "2013-12"
 6125	moist jittery bottle of limeade	0		Effect: "Chunky", Effect Duration: 37, Last Available: "2013-12"
 6126	gravedigger's novelty tattoo sleeves of the empath	0		Familiar Weight: +5, Spooky Damage: +10, Single Equip, Last Available: "2013-12"
 6127	wobbly pair of rhinoceros horns	0		Last Available: "2013-12"
@@ -6037,16 +6037,16 @@
 6139	mirror resourceful rubber gloves	0		Maximum MP: +50, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	stale special half-sized roasted duck	2	decent	Effect: "Proprie Tea", Effect Duration: 45, Last Available: "2013-12"
-6143	small yummy dead meat bun	2	awesome	Last Available: "2013-12"
+6142	half-sized stale special roasted duck	2	decent	Effect: "Proprie Tea", Effect Duration: 45, Last Available: "2013-12"
+6143	yummy small dead meat bun	2	awesome	Last Available: "2013-12"
 6144	Jeselnik's cat collar	0		Sleaze Damage: +25, Single Equip, Last Available: "2013-12"
-6145	deadly dance instructor's suspicious-looking fedora	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
-6147	skewed tumbling Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
+6145	deadly dance instructor's suspicious-looking fedora	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6147	tumbling skewed Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	twirling Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
-6151	mirror spinning carrot nose	0		Last Available: "2013-01"
-6152	stale jumbo carrot cake	5	decent	Last Available: "2013-01"
+6151	spinning mirror carrot nose	0		Last Available: "2013-01"
+6152	jumbo stale carrot cake	5	decent	Last Available: "2013-01"
 6153	bad maroon carrot claret	3	decent	Last Available: "2013-01"
 6154	compressed ghostly skewed carrot juice	1	good	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
@@ -6056,10 +6056,10 @@
 6159	nasty doubt cannon	0		Stench Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
 6160	deadly fear condenser	0		Weapon Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
 6161	regret hose of the detective	0		Item Drop: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
-6162	blinking upside-down Young Man's Crew Sequester	0		Last Available: "2013-12"
+6162	upside-down blinking Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	red mirror toasty sharpshooter's commodore's hat	0		Critical Hit Percent: +10, Hot Damage: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	skewed chaotic naval trousers	0		Spell Critical Percent: +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	red mirror toasty sharpshooter's commodore's hat	0		Critical Hit Percent: +10, Hot Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	skewed chaotic naval trousers	0		Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	pulsating wizardly deck cannon of the brute	0		Mysticality: +25, Muscle Percent: +30, Last Available: "2013-12"
 6167	jittery shaking resourceful ornamental sextant	0		Maximum MP: +50, Last Available: "2013-12"
 6168	narrow inspector's sinister Bloodbath	0		Spell Damage: +10, Item Drop: +15, Last Available: "2013-12"
@@ -6083,11 +6083,11 @@
 6186	spoiled consummate fried egg	4	crappy	
 6187	bland huge consummate egg salad	4	decent	
 6188	decent consummate bagel	3	good	
-6189	super-sized delicious green consummate sliced bread	5	awesome	
+6189	delicious super-sized green consummate sliced bread	5	awesome	
 6190	adequate consummate hot dog bun	4	good	
-6191	delicious big olive tumbling consummate brownie	5	awesome	
+6191	big delicious olive tumbling consummate brownie	5	awesome	
 6192	diet rotten consummate toast	1	crappy	
-6193	hand-crafted weak passable stout	2	EPIC	
+6193	weak hand-crafted passable stout	2	EPIC	
 6194	adequate consummate soup	3	good	
 6195	decent small shaking consummate corn chips	2	good	
 6196	moldy consummate salad	3	crappy	
@@ -6095,36 +6095,36 @@
 6198	spoiled half-sized consummate sauerkraut	2	crappy	
 6199	rotten consummate cheese slice	3	crappy	
 6200	stale squat consummate melted cheese	4	decent	
-6201	adequate fancy narrow spinning consummate bacon	4	good	Effect: "Grape Expectations", Effect Duration: 15
+6201	fancy adequate narrow spinning consummate bacon	4	good	Effect: "Grape Expectations", Effect Duration: 15
 6202	flavorless consummate meatloaf	4	decent	
 6203	decent consummate steak	4	good	
 6204	yummy miniature mirror consummate cuts	2	awesome	
 6205	small flavorless consummate frankfurter	2	decent	
-6206	rotten half-sized spinning consummate french fries	2	crappy	
-6207	adequate miniature pulsating consummate baked potato	2	good	
+6206	half-sized rotten spinning consummate french fries	2	crappy	
+6207	miniature adequate pulsating consummate baked potato	2	good	
 6208	acceptable acceptable vodka	3	good	
 6209	rotten consummate ice cream	4	crappy	
 6210	tasty skewed consummate whipped cream	3	awesome	
 6211	moldy squat consummate cream	4	crappy	
-6212	stale wobbly purple consummate strawberries	3	decent	
+6212	stale purple wobbly consummate strawberries	3	decent	
 6213	bland consummate sorbet	3	decent	
 6214	aged jittery adequate rum	3	awesome	
 6215	smooth spirit-forward mediocre lager	5	awesome	
 6216	toothsome immaculate grilled cheese	3	awesome	
 6217	rotten immaculate ice cream sandwich	4	crappy	
-6218	enchanted adequate immense immaculate hot dog	7	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 25
-6219	delicious miniature immaculate egg salad sandwich	2	awesome	
+6218	immense adequate enchanted immaculate hot dog	7	good	Effect: "Anytwo Five Elevenis?", Effect Duration: 25
+6219	miniature delicious immaculate egg salad sandwich	2	awesome	
 6220	decent huge ghostly perfect sandwich	3	good	
-6221	yummy snack-sized perfect chef salad	2	awesome	
+6221	snack-sized yummy perfect chef salad	2	awesome	
 6222	adequate perfect breakfast	4	good	
 6223	spoiled sublime deluxe hot dog	4	crappy	
-6224	adequate special sublime stew	4	good	Effect: "Fit To Be Tide", Effect Duration: 50
-6225	stale half-sized twirling sublime nachos	2	decent	
+6224	special adequate sublime stew	4	good	Effect: "Fit To Be Tide", Effect Duration: 50
+6225	half-sized stale twirling sublime nachos	2	decent	
 6226	decent bite-sized Ultimate Breakfast Sandwich	1	good	
 6227	stale pulsating Loaded Baked Potato	4	decent	
 6228	delicious Omega Sundae	3	awesome	
-6229	high-proof perfectly mixed Das Sauerlager	9	EPIC	
-6230	special bad practically non-alcoholic Bologna Lambic	1	decent	Effect: "Human-Demon Hybrid", Effect Duration: 25
+6229	perfectly mixed high-proof Das Sauerlager	9	EPIC	
+6230	practically non-alcoholic special bad Bologna Lambic	1	decent	Effect: "Human-Demon Hybrid", Effect Duration: 25
 6231	hand-crafted boozy Vodka Dog	5	EPIC	
 6232	watered-down smooth Disappointed Russian	2	awesome	
 6233	perfectly mixed Chunky Mary	3	EPIC	
@@ -6142,7 +6142,7 @@
 6246	magnetized wobbly yellow demonic surgical gloves	0		Effect: "Frosty the Hitman", Effect Duration: 67
 6247	non-Vulcanized mirror clip-on ninja tie	0		Effect: "Rage of the Reindeer", Effect Duration: 69
 6248	double-colloidal narrow gamer slurry	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 15
-6249	upside-down twirling dungeoneering kit	0		Last Available: "2013-02"
+6249	twirling upside-down dungeoneering kit	0		Last Available: "2013-02"
 6250	greedy Sherlock's greasy wholesome numberwang of wisdom of the brute	0		Mysticality: +15, Muscle Percent: +30, Maximum HP Percent: +10, Sleaze Spell Damage: +10, Item Drop: +25, Meat Drop: +20, Single Equip
 6251	Vulcanized pressed chilled scroll of Protection from Bad Stuff	0		Effect: "Executive Greed", Effect Duration: 57, Last Available: "2013-02"
 6252	liquefied flattened ionized scroll of Puddingskin	0		Effect: "Mushroom Might", Effect Duration: 30, Last Available: "2013-02"
@@ -6160,7 +6160,7 @@
 6264	tumbling nippy Staff of Fruit Salad of Tarzan of incineration	0		Experience (Muscle): +3, Cold Damage: +10, Hot Spell Damage: +50, Jiggle: "Deal Some Prismatic Damage"
 6265	hardened Newton's Staff of the Cream of the Cream of the ox	0		Muscle: +20, Experience (Mysticality): +3, Damage Reduction: 3, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	huge toothsome grain of protein powder	9	awesome	
+6267	toothsome huge grain of protein powder	9	awesome	
 6268	energized pec oil	0		Effect: "Swordholder", Effect Duration: 52
 6269	maroon shaking personal trainer's gym membership card	0		Experience Percent (Muscle): +10
 6270	Vulcanized double-unsweetened skewed Squat-Thrust Magazine	0		Effect: "Dreadful Fear", Effect Duration: 34
@@ -6171,11 +6171,11 @@
 6275	jittery friendly baleful turkey leg	0		Spell Damage: +25, Familiar Weight: +3
 6276	bad Ye Olde Meade	3	decent	
 6277	oxidized denatured Ye Olde Bawdy Limerick	0		Effect: "protect.enq", Effect Duration: 20
-6278	narrow bouncing Ye Olde Medieval Insult	0		
+6278	bouncing narrow Ye Olde Medieval Insult	0		
 6279	coward's pewter claymore	0		Monster Level: -20
 6280	clever artisanal rice peeler	0		Maximum MP: +20
 6281	yummy heirloom grape tomato	4	awesome	
-6282	blurry teal chipotle wasabi cilantro aioli	0		
+6282	teal blurry chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of the empath	0		Familiar Weight: +5, Familiar Effect: "1xLep, cap 37"
 6284	pulsating gear	0		
 6285	yellow flame-retardant wool Mark I Steam-Hat	0		Cold Resistance: +1, Hot Resistance: +1, Familiar Effect: "1xLep, cap 37"
@@ -6186,7 +6186,7 @@
 6290	steam-powered model rocketship	0		
 6291	squat executive punk rock jacket of the wise owl	0		Mysticality: +20, Meat Drop: +40
 6292	huge lightning-fast foul-smelling safety pin	0		Stench Damage: +10, Initiative: +40
-6293	bite-sized bland stolen sushi	1	decent	
+6293	bland bite-sized stolen sushi	1	decent	
 6294	bouncing very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	ghostly cosmic bucket	0		Free Pull
@@ -6196,7 +6196,7 @@
 6300	Vulcanized Super Weight-Gain 9000	0		Effect: "Super-Charged", Effect Duration: 31
 6301	activated skewed possibility potion	0		Effect: "Once Bitten Twice Fried", Effect Duration: 12
 6302	narrow eleven-foot pole	0		
-6303	squat skewed ring of Detect Boring Doors	0		
+6303	skewed squat ring of Detect Boring Doors	0		
 6304	Jack Frost's hardy quilted Socratic brawny Jarlsberg's pan (Cosmic portal mode)	0		Muscle Percent: +20, Experience (Mysticality): +1, Damage Absorption: +40, Maximum HP: +50, Cold Spell Damage: +50, Softcore Only, Free Pull, Last Available: "2013-03"
 6305	yellow healthy stiffened wizardly Jarlsberg's pan of the sweet-tooth of Flo-Jo	0		Mysticality: +25, Damage Reduction: 1, Maximum HP Percent: +20, Candy Drop: +100, Initiative: +100, Softcore Only, Free Pull, Last Available: "2013-03"
 6306	Cosmic Calorie	0		Last Available: "2013-03"
@@ -6231,7 +6231,7 @@
 6335	wizardly sea mantle of courage	0		Mysticality: +25, Spooky Resistance: +3
 6336	blurry Van der Graaf beefy sea shawl	0		Muscle: +10, MP Regen Min: 5, MP Regen Max: 7, Spell Damage Percent: +150
 6337	ghostly blue banded sea cape of the bloodbag	0		Damage Absorption: +100, Maximum HP: +100, Initiative: +50, Critical Hit Percent: +15
-6338	bouncing yellow saltwaterbed	0		
+6338	yellow bouncing saltwaterbed	0		
 6339	careful banded muddy pirate hat	0		Damage Absorption: +100, Monster Level: -10, Familiar Effect: "1xFairy, cap 31"
 6340	gravedigger's weightlifter's floral-print skirt	0		Muscle: +15, Spooky Damage: +10, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	inspector's rosewater-soaked spectral axe	0		Stench Resistance: +3, Item Drop: +15
@@ -6240,7 +6240,7 @@
 6344	Mer-kin mouthsoap	0		
 6345	super-quantum super-dry huge Mer-kin strongjuice	0		Effect: "Super-Charged", Effect Duration: 62
 6346	Mer-kin fitbrine	0		
-6347	enhanced energized blurry pulsating Mer-kin ragejuice	0		Effect: "Castaway Physique", Effect Duration: 12
+6347	enhanced energized pulsating blurry Mer-kin ragejuice	0		Effect: "Castaway Physique", Effect Duration: 12
 6348	mansplainer's Mer-kin dragbelt	0		Monster Level: +15, Experience (Muscle): +20, Single Equip
 6349	red tumbling blurry censurious Mer-kin eyeglasses	0		Sleaze Resistance: +3, Experience (Mysticality): +20, Single Equip
 6350	cyan skewed greasy Mer-kin gutgirdle	0		Sleaze Spell Damage: +10, Experience (Moxie): +20, Single Equip
@@ -6264,16 +6264,16 @@
 6368	Mer-kin hallpass	0		
 6369	blurry lump of clay	0		
 6370	twisted piece of wire	0		
-6371	smooth weak can of the cheapest beer	2	awesome	
+6371	weak smooth can of the cheapest beer	2	awesome	
 6372	triple-distilled perfectly mixed fuchsia bottle of fruity &quot;wine&quot;	9	EPIC	
-6373	artisanal irresponsibly strong single swig of vodka	9	EPIC	
+6373	irresponsibly strong artisanal single swig of vodka	9	EPIC	
 6374	huge angry inch	0		
 6375	shaking chilly testy toolbox	0		Cold Damage: +5
 6376	purple Jick-o-User	0		
-6378	spinning blue eraser nubbin	0		
+6378	blue spinning eraser nubbin	0		
 6379	bouncing chlorine crystal	0		
 6380	energized ionized quantum ph balancer	0		Effect: "Yuletide Industry", Effect Duration: 18
-6381	modified galvanized mirror pulsating jittery maroon mysterious chemical residue	0		Effect: "Capricorn Rising", Effect Duration: 15
+6381	modified galvanized mirror maroon pulsating jittery mysterious chemical residue	0		Effect: "Capricorn Rising", Effect Duration: 15
 6382	nugget of sodium	0		
 6383	root beer	1	decent	
 6384	tumbling jigsaw blade	0		
@@ -6293,7 +6293,7 @@
 6398	glass	0		
 6399	activated nitrogenated oxidized Boss Drops	0		Effect: "Feroci Tea", Effect Duration: 47
 6400	Mer-kin lunchbox	0		
-6401	polarized nitrogenated bouncing pulsating tear	0		Effect: "Jacked In", Effect Duration: 59
+6401	polarized nitrogenated pulsating bouncing tear	0		Effect: "Jacked In", Effect Duration: 59
 6402	vacuum-sealed unsweetened jagged tooth	0		Effect: "Wistfully Nostalgic", Effect Duration: 52
 6403	ionized extra-galvanized spinning upside-down grisly shell fragment	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 61
 6404	energized violent pastilles	0		Effect: "You Drank Fish Wine", Effect Duration: 36
@@ -6314,11 +6314,11 @@
 6419	nitrogenated huge moth dust	0		Effect: "Dwarven Hardiness", Effect Duration: 52
 6420	irradiated glob of spoiled mayo	0		Effect: "Heavily Breathing", Effect Duration: 11
 6421	tonic djinn	0		
-6422	yummy thick vampire chowder	5	awesome	
+6422	thick yummy vampire chowder	5	awesome	
 6423	Tales of Dread	0		Free Pull
 6424	mirror Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	snack-sized delicious purple Dreadsylvanian stew	2	awesome	
+6426	delicious snack-sized purple Dreadsylvanian stew	2	awesome	
 6427	delicious Dreadsylvanian	3	awesome	
 6428	Vulcanized Dreadsylvanian flask	0		Effect: "Filled with Magic", Effect Duration: 33
 6429	energized dry Dreadsylvanian flask	0		Effect: "Greedy Resolve", Effect Duration: 69
@@ -6367,7 +6367,7 @@
 6472	bouncing Drunkula's bell	0		
 6473	olive arcane researcher's strapping Drunkula's ring of haze of the wise owl	0		Muscle: +5, Mysticality: +20, Experience Percent (Mysticality): +10, Avoid Attack: 1, Single Equip
 6474	lion tamer's Drunkula's wineglass	0		Experience (familiar): +2
-6475	irresponsibly strong perfectly mixed pulsating bottle of Bloodweiser	8	EPIC	
+6475	perfectly mixed irresponsibly strong pulsating bottle of Bloodweiser	8	EPIC	
 6476	inspector's dog trainer's groovy Unkillable Skeleton's skullcap	0		Moxie Percent: +10, Experience (familiar): +1, Item Drop: +15, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	Tesla clever smooth Unkillable Skeleton's breastplate	0		Moxie: +15, Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Class: "Turtle Tamer"
 6478	flame-retardant dangerous Unkillable Skeleton's shinguards of Gandalf	0		Weapon Damage: +10, Spell Critical Percent: +20, Hot Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,8 +6380,8 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	gray stinking agaricus	0		
-6488	delicious enchanted blurry Dreadsylvanian shepherd's pie	3	awesome	Effect: "Impregnably Delicious", Effect Duration: 5
-6489	cyan jittery blinking music box parts	0		
+6488	enchanted delicious blurry Dreadsylvanian shepherd's pie	3	awesome	Effect: "Impregnably Delicious", Effect Duration: 5
+6489	cyan blinking jittery music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
 6492	wax banana	0		
@@ -6391,7 +6391,7 @@
 6496	blood kiwi	0		
 6497	wobbly eau de mort	0		
 6498	mediocre bloody kiwitini	3	decent	
-6499	upside-down red moon-amber	0		
+6499	red upside-down moon-amber	0		
 6500	polished moon-amber	0		
 6501	ghostly Annie Oakley's MacGyver's razor-sharp moon-amber necklace	0		Weapon Damage Percent: +25, Maximum MP: +100, Critical Hit Percent: +20, Single Equip
 6502	Dreadsylvanian seed pod	0		
@@ -6404,7 +6404,7 @@
 6509	asbestos-lined Socratic cool iron breastplate	0		Experience (Mysticality): +1, Hot Resistance: +5
 6510	teal energetic healthy cool iron greaves	0		Maximum HP Percent: +20, Maximum MP Percent: +20, Familiar Effect: "atk, 1xBarrr"
 6511	rosewater-soaked ghost shawl of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3
-6512	cyan mirror skull capacitor	0		
+6512	mirror cyan skull capacitor	0		
 6513	squat greedy warm fur	0		Meat Drop: +20
 6514	skewed skewed asbestos-lined snowstick	0		Hot Resistance: +5
 6515	shaking eerie fetish of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
@@ -6421,7 +6421,7 @@
 6526	blurry Tesla bag of unfinished business of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10
 6527	blue MacGyver's transparent pants of the pedagogue	0		Experience: +3, Maximum MP: +100, Familiar Effect: "sleaze atk, 1xPotato"
 6528	careful hothammer	0		Monster Level: -10
-6529	watered-down bad Thriller Ice	2	decent	
+6529	bad watered-down Thriller Ice	2	decent	
 6530	rosewater-soaked grandfather watch	0		Stench Resistance: +3, Single Equip
 6531	squat muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	clever energetic spyglass	0		Maximum MP Percent: +20, Maximum MP: +20
@@ -6429,7 +6429,7 @@
 6534	savvy remorseless knife	0		Mysticality Percent: +20
 6535	wobbly family-friendly intimidating coiffure	0		Sleaze Resistance: +1, Familiar Effect: "hot afk, 1xPotato"
 6536	hardy fortified cod cape	0		Damage Absorption: +60, Maximum HP: +50
-6537	normal jumbo blood sausage	5	good	
+6537	jumbo normal blood sausage	5	good	
 6538	electrified frying brainpan of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5
 6539	Sherlock's Da Vinci's ball and chain	0		Experience (Mysticality): +5, Item Drop: +25, Single Equip
 6540	avaricious dry bone	0		Meat Drop: +30
@@ -6442,12 +6442,12 @@
 6548	cooling iron helmet	0		
 6549	cooling iron breastplate	0		
 6550	shaking cooling iron greaves	0		
-6551	teal jittery hot cluster	0		
+6551	jittery teal hot cluster	0		
 6552	cluster	0		
 6553	cluster	0		
 6554	stench cluster	0		
 6555	sleaze cluster	0		
-6556	frozen spinning upside-down phial of hotness	0		Effect: "Weepy, Creepy", Effect Duration: 36
+6556	frozen upside-down spinning phial of hotness	0		Effect: "Weepy, Creepy", Effect Duration: 36
 6557	magnetized galvanized phial of coldness	0		Effect: "Coming Up Roses", Effect Duration: 61
 6558	vacuum-sealed red phial of spookiness	0		Effect: "Feet of Watermelon", Effect Duration: 40
 6559	improved moist green phial of stench	0		Effect: "Gonna Get You, Sucker", Effect Duration: 57
@@ -6459,11 +6459,11 @@
 6565	yummy Dreadsylvanian pocket	3	awesome	
 6566	bland Dreadsylvanian pocket	3	decent	
 6567	bland massive Dreadsylvanian stink pocket	8	decent	
-6568	bland snack-sized Dreadsylvanian sleaze pocket	2	decent	
+6568	snack-sized bland Dreadsylvanian sleaze pocket	2	decent	
 6569	lousy Dreadsylvanian hot toddy	4	decent	
 6570	acceptable shaking Dreadsylvanian cold-fashioned	3	good	
-6571	watered-down smooth Dreadsylvanian grimlet	2	awesome	
-6572	watered-down lousy upside-down Dreadsylvanian dank and stormy	2	decent	
+6571	smooth watered-down Dreadsylvanian grimlet	2	awesome	
+6572	lousy watered-down upside-down Dreadsylvanian dank and stormy	2	decent	
 6573	mediocre Dreadsylvanian slithery nipple	4	decent	
 6574	lime green hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6507,7 +6507,7 @@
 6613	red clockwork cuckoo	0		
 6614	cuckoo clock	0		
 6615	lousy Cold One	3	???	
-6616	big bland spaghetti breakfast	5	???	
+6616	bland big spaghetti breakfast	5	???	
 6617	blurry over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	twirling folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6544,7 +6544,7 @@
 6652	tolerable stepmom's booze	4	good	
 6653	surgical tape	0		
 6654	bouncing censurious band T-shirt	0		Sleaze Resistance: +3
-6655	triple-distilled mediocre lime green fountain 'soda'	8	decent	
+6655	mediocre triple-distilled lime green fountain 'soda'	8	decent	
 6656	huge illegal firecracker	0		
 6657	maroon vibrating deadly pickelhaube	0		Weapon Damage: +5, Maximum MP Percent: +10, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	liquefied oxidized bouncing shaking hair oil	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 52
@@ -6570,8 +6570,8 @@
 6678	brawny Yearbook Club Camera	0		Muscle Percent: +20, Conditional Skill (Equipped): "Blinding Flash"
 6679	machete of dire peril	0		Weapon Damage: +20
 6680	mediocre Cursed Punch	3	decent	
-6681	irresponsibly strong perfectly mixed Bowl of Scorpions	6	EPIC	
-6682	bad weak special Fog Murderer	2	decent	Effect: "Very Clean Teeth", Effect Duration: 45
+6681	perfectly mixed irresponsibly strong Bowl of Scorpions	6	EPIC	
+6682	bad special weak Fog Murderer	2	decent	Effect: "Very Clean Teeth", Effect Duration: 45
 6683	book of matches	0		
 6684	therapeutic surgical mask	0		HP Regen Min: 5, HP Regen Max: 7, Surgeonosity: +1
 6685	frightening head mirror	0		Spooky Damage: +5, Surgeonosity: +1
@@ -6588,13 +6588,13 @@
 6696	mirror bowling ball	0		
 6697	moss-covered stone sphere	0		
 6698	skewed dripping stone sphere	0		
-6699	upside-down huge crackling stone sphere	0		
+6699	huge upside-down crackling stone sphere	0		
 6700	scorched stone sphere	0		
 6701	stone triangle	0		
 6702	blue bowler	0		
 6703	imitation White Russian	1	good	
 6704	wobbly groovy short-handled mop of the cheetah	0		Moxie Percent: +10, Initiative: +60
-6705	moldy thick jungle floor wax	5	crappy	
+6705	thick moldy jungle floor wax	5	crappy	
 6706	smirking shrunken head	0		
 6707	activated warmed colorful toad	0		Effect: "Goldentongue", Effect Duration: 34
 6708	upside-down crude voodoo doll	0		
@@ -6613,12 +6613,12 @@
 6721	asbestos-lined energetic dangerous water bottle	0		Weapon Damage: +10, Maximum MP Percent: +20, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	vacuum-sealed wobbly pygmy phone number	0		Effect: "Top Dog", Effect Duration: 62
 6723	Boozehounds Anonymous token	0		
-6724	toothsome low-calorie exotic jungle fruit	1	awesome	
+6724	low-calorie toothsome exotic jungle fruit	1	awesome	
 6725	blinking Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	bouncing ski resort souvenir crate	0		
-6729	narrow red UV-resistant compass	0		
+6729	red narrow UV-resistant compass	0		
 6730	funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
@@ -6646,19 +6646,19 @@
 6754	beer bottle	0		
 6755	wobbly beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	artisanal upside-down blue can of Br&uuml;talbr&auml;u	4	EPIC	Last Available: "2013-09"
+6757	artisanal blue upside-down can of Br&uuml;talbr&auml;u	4	EPIC	Last Available: "2013-09"
 6758	perfectly mixed practically non-alcoholic can of Drooling Monk	1	EPIC	Last Available: "2013-09"
-6759	acceptable spirit-forward can of Impetuous Scofflaw	5	good	Last Available: "2013-09"
+6759	spirit-forward acceptable can of Impetuous Scofflaw	5	good	Last Available: "2013-09"
 6760	acceptable bottle of Old Pugilist	3	good	Last Available: "2013-09"
 6761	smooth bottle of Professor Beer	4	awesome	Last Available: "2013-09"
-6762	practically non-alcoholic acceptable bottle of Rapier Witbier	1	good	Last Available: "2013-09"
+6762	acceptable practically non-alcoholic bottle of Rapier Witbier	1	good	Last Available: "2013-09"
 6763	irresponsibly strong hand-crafted bottle of Race Car Red	7	EPIC	Last Available: "2013-09"
 6764	acceptable squat bottle of Greedy Dog	3	good	Last Available: "2013-09"
 6765	spirit-forward drinkable bottle of Lambada Lambic	5	good	Last Available: "2013-09"
 6766	mirror tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
-6769	executive sizzling ruddy tin tam	0		Maximum HP Percent: +40, Hot Damage: +10, Meat Drop: +40, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	executive sizzling ruddy tin tam	0		Maximum HP Percent: +40, Hot Damage: +10, Meat Drop: +40, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	alkaline alkaline maroon tin cup	0		Effect: "Mitre Cut", Effect Duration: 35, Last Available: "2013-09"
 6771	upside-down executive rosy-cheeked Newton's tin foil	0		Experience (Mysticality): +3, Maximum HP Percent: +30, Meat Drop: +40, Last Available: "2013-09"
 6772	squat flame-wreathed sharpshooter's MacGyver's tin drum	0		Maximum MP: +100, Critical Hit Percent: +10, Hot Spell Damage: +10, Last Available: "2013-09"
@@ -6746,17 +6746,17 @@
 6857	blue Cajun accordion of courage	0		Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	pulsating quirky accordion of courage	0		Spooky Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	fuchsia nasty educational Skipper's accordion	0		Experience: +1, Stench Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	squat squat green executive Jack Frost's Jim Carey's personal trainer's Pantsgiving	0		Experience Percent (Muscle): +10, Monster Level: +25, Cold Spell Damage: +50, Meat Drop: +40, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	squat squat green executive Jack Frost's Jim Carey's personal trainer's Pantsgiving	0		Experience Percent (Muscle): +10, Monster Level: +25, Cold Spell Damage: +50, Meat Drop: +40, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	enchanted adequate super-sized blurry can of sardines	5	good	Effect: "Weird Vibrations", Effect Duration: 45, Last Available: "2013-11"
-6862	fancy bland high-calorie sugar substitute	4	decent	Effect: "Okee-Dokee, Smokee", Effect Duration: 5, Last Available: "2013-11"
+6862	bland fancy high-calorie sugar substitute	4	decent	Effect: "Okee-Dokee, Smokee", Effect Duration: 5, Last Available: "2013-11"
 6863	rotten pat of butter	4	crappy	Last Available: "2013-11"
 6864	miniature decent dinner roll	2	good	Last Available: "2013-11"
 6865	stale fuchsia mashed potatoes	4	decent	Last Available: "2013-11"
 6866	decent special spinning whole turkey leg	3	good	Effect: "Neuroplastici Tea", Effect Duration: 20, Last Available: "2013-11"
 6867	spoiled deviled egg	4	crappy	Last Available: "2013-11"
-6868	wet blurry shaking finger exerciser	0		Effect: "Fireproof Lips", Effect Duration: 29, Last Available: "2013-11"
+6868	wet shaking blurry finger exerciser	0		Effect: "Fireproof Lips", Effect Duration: 29, Last Available: "2013-11"
 6869	improved irradiated pulsating dented spoon	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 65, Last Available: "2013-11"
-6870	energized twirling upside-down ghostly love note	0		Effect: "Bread Burps", Effect Duration: 49, Last Available: "2013-11"
+6870	energized ghostly twirling upside-down love note	0		Effect: "Bread Burps", Effect Duration: 49, Last Available: "2013-11"
 6871	jittery school beer pull tab	0		Last Available: "2013-11"
 6872	pickled liquefied wobbly yellow nail file	0		Effect: "Stuck That Way", Effect Duration: 44, Last Available: "2013-11"
 6873	nitrogenated candy wrapper	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 67, Last Available: "2013-11"
@@ -6781,9 +6781,9 @@
 6892	colloidal spoonful of Linguine-Os	0		Effect: "Gummiskin", Effect Duration: 40, Last Available: "2013-11"
 6893	chilled deionized freezer-burned frost-bitten tortellini	0		Effect: "The Sweats", Effect Duration: 38, Last Available: "2013-11"
 6894	altered galvanized blob of Alphredo&trade;	0		Effect: "Clean-Shaven", Effect Duration: 52, Last Available: "2013-11"
-6895	cold-filtered pressed pulsating bouncing handful of crafty noodles	0		Effect: "The Halls of Moxiousness", Effect Duration: 24, Last Available: "2013-11"
+6895	cold-filtered pressed bouncing pulsating handful of crafty noodles	0		Effect: "The Halls of Moxiousness", Effect Duration: 24, Last Available: "2013-11"
 6896	concentrated ghostly tangled mass of pasta	0		Effect: "Red Door Syndrome", Effect Duration: 67, Last Available: "2013-11"
-6897	quadruple-activated maroon squat Can of Spaghetto	0		Effect: "Penguinny Flavor", Effect Duration: 13, Last Available: "2013-11"
+6897	quadruple-activated squat maroon Can of Spaghetto	0		Effect: "Penguinny Flavor", Effect Duration: 13, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
 6900	tumbling experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	cold-filtered spinning nuts	0		Effect: "In the Limelight", Effect Duration: 54, Last Available: "2013-12"
 6904	energized bolts	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 40, Last Available: "2013-12"
 6905	stale gingerbread robot	3	decent	Last Available: "2013-12"
-6906	stale bouncing blurry petit 4.1	4	decent	Last Available: "2013-12"
+6906	stale blurry bouncing petit 4.1	4	decent	Last Available: "2013-12"
 6907	spoiled fancy nut-shaped Crimbo cookie	4	crappy	Effect: "Memory of Resilience", Effect Duration: 35, Last Available: "2023-06"
 6908	brainy plastic GORM-8	0		Mysticality: +5, Last Available: "2013-12"
 6909	fortified plastic warbear	0		Damage Absorption: +60, Last Available: "2013-12"
@@ -6800,39 +6800,39 @@
 6911	skewed executive plastic warbear fortress	0		Meat Drop: +40, Last Available: "2013-12"
 6912	Jim Carey's plastic K.R.A.M.P.U.S. of the ox	0		Muscle: +20, Monster Level: +25, Last Available: "2013-12"
 6913	warbear whosit	0		Last Available: "2013-12"
-6914	bouncing red warbear hoverbelt piecepart	0		Last Available: "2013-12"
+6914	red bouncing warbear hoverbelt piecepart	0		Last Available: "2013-12"
 6915	horrifying supercool warbear hoverbelt of the empath	0		Moxie Percent: +20, Familiar Weight: +5, Spooky Damage: +25, Single Equip, Last Available: "2013-12"
 6916	warbear battery	0		Last Available: "2013-12"
 6917	warbear badge	0		Last Available: "2013-12"
-6918	polarized aerosolized mirror blinking warbear wardance potion	0		Effect: "The Rich Get Richer", Effect Duration: 49, Last Available: "2013-12"
+6918	polarized aerosolized blinking mirror warbear wardance potion	0		Effect: "The Rich Get Richer", Effect Duration: 49, Last Available: "2013-12"
 6919	nitrogenated wobbly warbear bearserker potion	0		Effect: "Weather, Man", Effect Duration: 41, Last Available: "2013-12"
 6920	aerosolized warbear liquid overcoat	0		Effect: "Liquidy Smoky", Effect Duration: 49, Last Available: "2013-12"
-6921	decent blinking gray warbear feasting bread	4	good	Last Available: "2013-12"
+6921	decent gray blinking warbear feasting bread	4	good	Last Available: "2013-12"
 6922	massive adequate warbear warrior bread	7	good	Last Available: "2013-12"
-6923	half-sized adequate mirror warbear thermoregulator bread	2	good	Last Available: "2013-12"
+6923	adequate half-sized mirror warbear thermoregulator bread	2	good	Last Available: "2013-12"
 6924	perfectly mixed watered-down warbear feasting mead	2	super EPIC	Last Available: "2013-12"
 6925	enchanted irresponsibly strong artisanal warbear bearserker mead	9	EPIC	Effect: "Protection from Bad Stuff", Effect Duration: 20, Last Available: "2013-12"
 6926	hand-crafted warbear blizzard mead	3	EPIC	Last Available: "2013-12"
 6927	ghostly warbear helm fragment	0		Last Available: "2013-12"
-6928	Usain Bolt's chaotic warbear plain fedora of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +10, Initiative: +80, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	squat zippy warbear feathered fedora	0		Initiative: +20, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	Jeselnik's hardy experienced warbear fedora	0		Experience: +2, Maximum HP: +50, Sleaze Damage: +25, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	cyan double-paned beefy warbear plain helm of courage	0		Muscle: +10, Cold Resistance: +5, Spooky Resistance: +3, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	veiny warbear spiked helm	0		Maximum HP: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	skewed executive censurious extremely unsafe warbear electro-spiked helm	0		Weapon Damage Percent: +100, Sleaze Resistance: +3, Meat Drop: +40, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	blurry gravedigger's manspreader's wizardly warbear plain ushanka	0		Mysticality: +25, Monster Level: +10, Spooky Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	MacGyver's warbear lined ushanka	0		Maximum MP: +100, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	rosewater-soaked sizzling warbear heated ushanka of the glutton	0		Hot Damage: +10, Stench Resistance: +3, Food Drop: +100, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	Usain Bolt's chaotic warbear plain fedora of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +10, Initiative: +80, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	squat zippy warbear feathered fedora	0		Initiative: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	Jeselnik's hardy experienced warbear fedora	0		Experience: +2, Maximum HP: +50, Sleaze Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	cyan double-paned beefy warbear plain helm of courage	0		Muscle: +10, Cold Resistance: +5, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	veiny warbear spiked helm	0		Maximum HP: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	skewed executive censurious extremely unsafe warbear electro-spiked helm	0		Weapon Damage Percent: +100, Sleaze Resistance: +3, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	blurry gravedigger's manspreader's wizardly warbear plain ushanka	0		Mysticality: +25, Monster Level: +10, Spooky Damage: +10, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	MacGyver's warbear lined ushanka	0		Maximum MP: +100, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	rosewater-soaked sizzling warbear heated ushanka of the glutton	0		Hot Damage: +10, Stench Resistance: +3, Food Drop: +100, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	scandalous stiffened warbear party pants of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	arcane researcher's warbear ceremonial party pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	blinking Usain Bolt's energetic warbear high festival pants of the overflowing toilet	0		Maximum MP Percent: +20, Stench Spell Damage: +50, Initiative: +80, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	perfumed horrifying Samson's warbear battle greaves	0		Experience (Muscle): +5, Spooky Damage: +25, Stench Resistance: +5, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	jittery shaking padded warbear officer greaves	0		Damage Absorption: +20, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	inspector's foul-smelling smartaleck's warbear bearserker greaves	0		Moxie Percent: +30, Stench Damage: +10, Item Drop: +15, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	wobbly scandalous frosty warbear johns of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Sleaze Damage: +5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	mansplainer's warbear fleece-lined johns	0		Monster Level: +15, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	chaotic arcane researcher's warbear johns of Flo-Jo	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Initiative: +100, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	scandalous stiffened warbear party pants of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	arcane researcher's warbear ceremonial party pants	0		Experience Percent (Mysticality): +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	blinking Usain Bolt's energetic warbear high festival pants of the overflowing toilet	0		Maximum MP Percent: +20, Stench Spell Damage: +50, Initiative: +80, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	perfumed horrifying Samson's warbear battle greaves	0		Experience (Muscle): +5, Spooky Damage: +25, Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	jittery shaking padded warbear officer greaves	0		Damage Absorption: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	inspector's foul-smelling smartaleck's warbear bearserker greaves	0		Moxie Percent: +30, Stench Damage: +10, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	wobbly scandalous frosty warbear johns of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	mansplainer's warbear fleece-lined johns	0		Monster Level: +15, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	chaotic arcane researcher's warbear johns of Flo-Jo	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +10, Initiative: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	bouncing warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	wobbly toasty warbear goggles of the scaredy-cat of terror	0		Monster Level: -15, Hot Damage: +5, Spooky Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6949	warbear snowblindness goggles of Tarzan	0		Experience (Muscle): +3, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	wobbly inspector's Jim Carey's warbear warscarf of the brazier	0		Monster Level: +25, Hot Spell Damage: +25, Item Drop: +15, Single Equip, Last Available: "2013-12"
 6957	spinning warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	lime green sinister warbear foil hat	0		Spell Damage: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	lime green sinister warbear foil hat	0		Spell Damage: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	fuchsia bouncing warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	censurious banded warbear oil pan	0		Damage Absorption: +100, Sleaze Resistance: +3, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	narrow warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6893,12 +6893,12 @@
 7004	cold-filtered frozen Flaskfull of Hollow	0		Effect: "Phoenix, Right?", Effect Duration: 60, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	denatured blurry jittery handful of Smithereens	1	awesome	Last Available: "2013-12"
-7007	immense yummy Every Day is Like This Sundae	9	awesome	Last Available: "2013-12"
-7008	spoiled enchanted Miserable Pie	3	crappy	Effect: "Powdered", Effect Duration: 5, Last Available: "2013-12"
+7007	yummy immense Every Day is Like This Sundae	9	awesome	Last Available: "2013-12"
+7008	enchanted spoiled Miserable Pie	3	crappy	Effect: "Powdered", Effect Duration: 5, Last Available: "2013-12"
 7009	massive rotten This Charming Flan	7	crappy	Last Available: "2013-12"
 7010	artisanal Irish Coffee, English Heart	3	EPIC	Last Available: "2013-12"
 7011	lousy blurry Strikes Again Bigmouth	3	decent	Last Available: "2013-12"
-7012	perfectly mixed practically non-alcoholic Paint A Vulgar Pitcher	1	super ultra mega turbo EPIC	Last Available: "2013-12"
+7012	practically non-alcoholic perfectly mixed Paint A Vulgar Pitcher	1	super ultra mega turbo EPIC	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	ghostly Louder Than Bomb	0		Last Available: "2013-12"
 7015	maroon Handsome Devil	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	Sherlock's scorching electrified razor-sharp Sheila Take a Crossbow	0		Weapon Damage Percent: +25, Hot Damage: +25, Item Drop: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 7019	stanky foul-smelling vibrating hardened A Light that Never Goes Out	0		Damage Reduction: 3, Maximum MP Percent: +10, Stench Damage: +10, Stench Spell Damage: +25, Last Available: "2013-12"
 7020	huge vibrating educational Half a Purse of the dark arts of the empath	0		Experience: +1, Spell Damage Percent: +100, Maximum MP Percent: +10, Familiar Weight: +5, Last Available: "2013-12"
-7021	jittery flame-retardant chaotic baleful Hairpiece On Fire of the boozehound	0		Spell Damage: +25, Spell Critical Percent: +10, Hot Resistance: +1, Booze Drop: +100, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	upside-down lightning-fast avaricious groovy Vicar's Tutu	0		Moxie Percent: +10, Item Drop: +5, Meat Drop: +30, Initiative: +40, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	jittery flame-retardant chaotic baleful Hairpiece On Fire of the boozehound	0		Spell Damage: +25, Spell Critical Percent: +10, Hot Resistance: +1, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	upside-down lightning-fast avaricious groovy Vicar's Tutu	0		Moxie Percent: +10, Item Drop: +5, Meat Drop: +30, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	ghostly prompt ribald friendly Hand in Glove	0		Familiar Weight: +3, Sleaze Damage: +10, Adventures: +3, Single Equip, Last Available: "2013-12"
 7024	grievous Meat Tenderizer is Murder of the bloodbag of doom	0		Weapon Damage Percent: +50, Maximum HP: +100, Spooky Spell Damage: +50, Class: "Seal Clubber", Last Available: "2013-12"
 7025	tumbling teal pulsating banded cool Ouija Board, Ouija Board of the businessman	0		Moxie: +5, Damage Absorption: +100, Meat Drop: +50, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	Van der Graaf Shakespeare's Sister's Accordion of bravery of the early riser	0		Spooky Resistance: +5, Adventures: +7, MP Regen Min: 5, MP Regen Max: 7, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	twirling cyan arcane researcher's third-hand lantern	0		Experience Percent (Mysticality): +10
 7031	shaking loose purse strings	0		
-7032	adequate bite-sized pickled egg	1	good	
+7032	bite-sized adequate pickled egg	1	good	
 7033	skewed cup of lukewarm tea	1	good	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
 7035	mirror warbear box	0		Last Available: "2013-12"
@@ -6928,7 +6928,7 @@
 7039	colloidal chilled nitrogenated pulsating warbear robo-camouflage unit	0		Effect: "Boo Tea", Effect Duration: 37, Last Available: "2013-12"
 7040	wobbly warbear beeping telegram	0		Last Available: "2013-12"
 7041	red warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
-7042	wobbly gray narrow narrow warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
+7042	narrow narrow gray wobbly warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	skewed warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	oxidized warmed upside-down glass slipper	0		Effect: "Ready to Snap", Effect Duration: 61, Last Available: "2014-12"
 7045	denatured mirror wobbly antimatter wad	1	good	Last Available: "2013-12"
@@ -6942,7 +6942,7 @@
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	blinking jittery warbear drone codes	0		Last Available: "2013-12"
 7055	stale special breakfast mess	4	decent	Effect: "Liquidy Smoky", Effect Duration: 30, Last Available: "2013-12"
-7056	upside-down jittery red warbear breakfast machine	0		Last Available: "2013-12"
+7056	red upside-down jittery warbear breakfast machine	0		Last Available: "2013-12"
 7057	decent small breakfast miracle	2	good	Last Available: "2013-12"
 7058	polarized spinning Cloaca Cola Polar	0		Effect: "Mariachi Mood", Effect Duration: 63, Last Available: "2013-12"
 7059	shaking warbear soda machine	0		Last Available: "2013-12"
@@ -6969,7 +6969,7 @@
 7080	shaking ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	tumbling snow machine	0		Last Available: "2014-01"
-7083	skewed dangerous snow mobile	0		Weapon Damage: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	skewed dangerous snow mobile	0		Weapon Damage: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	up-at-dawn ice bucket	0		Adventures: +5, Lasts Until Rollover, Last Available: "2014-01"
 7085	Jack Frost's arcane researcher's snow shovel	0		Experience Percent (Mysticality): +10, Cold Spell Damage: +50, Lasts Until Rollover, Last Available: "2014-01"
 7086	spinning cyan blurry sinister bod-ice of the cougar of the brute	0		Moxie: +20, Muscle Percent: +30, Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,16 +6978,16 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	hand-crafted En Una Fila Tequila	3	EPIC	
 7091	Skully's hot chocolate	1	EPIC	
-7092	warbear dress helmet of the detective of the businessman	0		Item Drop: +20, Meat Drop: +50, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	warbear dress helmet of the detective of the businessman	0		Item Drop: +20, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	blinking baleful warbear dress bracers of the brute	0		Muscle Percent: +30, Spell Damage: +25, Single Equip, Last Available: "2013-12"
-7094	olive arcane researcher's warbear dress greaves of bravery	0		Experience Percent (Mysticality): +10, Spooky Resistance: +5, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	lard-coated rock-hard sweatband	0		Damage Reduction: 5, Sleaze Spell Damage: +25, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	blinking Van der Graaf gym shorts of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	olive arcane researcher's warbear dress greaves of bravery	0		Experience Percent (Mysticality): +10, Spooky Resistance: +5, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	lard-coated rock-hard sweatband	0		Damage Reduction: 5, Sleaze Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	blinking Van der Graaf gym shorts of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	skewed jittery ankleweights of the wise owl of Gandalf	0		Mysticality: +20, Spell Critical Percent: +20, Single Equip, Last Available: "2014-12"
 7098	huge avaricious dog trainer's sweat socks of dire peril of Flo-Jo	0		Weapon Damage: +20, Experience (familiar): +1, Meat Drop: +30, Initiative: +100, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
-7100	huge skewed Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
-7101	modified upside-down fuchsia Five Second Energy&trade;	1		Last Available: "2014-12"
+7100	skewed huge Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
+7101	modified fuchsia upside-down Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	teal pixie axie	0		Last Available: "2014-12"
 7103	polymerized ionized powder	0		Effect: "Stench Jellied", Effect Duration: 60, Last Available: "2014-12"
 7104	squat licorice whip of the glutton	0		Food Drop: +100, Last Available: "2014-12"
@@ -6998,19 +6998,19 @@
 7109	bland small pecan pie	2	decent	Last Available: "2014-12"
 7110	olive chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	tasty miniature candy mountain oyster	2	awesome	Last Available: "2014-12"
-7112	mediocre extra-dry huge chocotini	5	decent	Last Available: "2014-12"
+7112	extra-dry mediocre huge chocotini	5	decent	Last Available: "2014-12"
 7113	mirror gravedigger's chocolate rabbit's foot of the pedagogue of temperance	0		Experience: +3, Spooky Damage: +10, Sleaze Resistance: +5, Last Available: "2014-12"
-7114	small special bland candy carrot	2	decent	Effect: "Experimental Effect G-9", Effect Duration: 25, Last Available: "2014-12"
+7114	special small bland candy carrot	2	decent	Effect: "Experimental Effect G-9", Effect Duration: 25, Last Available: "2014-12"
 7115	moldy upside-down candy carrot cake	4	crappy	Last Available: "2014-12"
 7116	jittery chaotic carrot-on-a-stick of the pedagogue	0		Experience: +3, Spell Critical Percent: +10, Last Available: "2014-12"
-7117	wobbly lion tamer's Van der Graaf weasel stomping pants	0		Experience (familiar): +2, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	bland jumbo huge pulsating mulberry	5	decent	Last Available: "2014-12"
-7119	drinkable strong mulled berry wine	5	good	Last Available: "2014-12"
+7117	wobbly lion tamer's Van der Graaf weasel stomping pants	0		Experience (familiar): +2, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7118	jumbo bland pulsating huge mulberry	5	decent	Last Available: "2014-12"
+7119	strong drinkable mulled berry wine	5	good	Last Available: "2014-12"
 7120	mirror lemony scales	0		Last Available: "2014-12"
-7121	auspicious lemon party hat	0		Item Drop: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	auspicious lemon party hat	0		Item Drop: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	blurry jittery sizzling lemon shirt	0		Hot Damage: +10, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of the ox	0		Muscle: +20, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
-7124	modified unsweetened bouncing ghostly lemonhead caviar	0		Effect: "Adrenaline Rush", Effect Duration: 28, Last Available: "2014-12"
+7123	lemon drop trousers of the ox	0		Muscle: +20, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7124	modified unsweetened ghostly bouncing lemonhead caviar	0		Effect: "Adrenaline Rush", Effect Duration: 28, Last Available: "2014-12"
 7125	bouncing electrified padded gummi sword	0		Damage Absorption: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12"
 7126	cold-filtered nitrogenated twirling small gummi fin	0		Effect: "Well-preserved", Effect Duration: 33, Last Available: "2014-12"
 7127	blurry Annie Oakley's chocolate cow bone	0		Critical Hit Percent: +20, Last Available: "2014-12"
@@ -7021,17 +7021,17 @@
 7132	ionized polymerized upside-down Outer Wolf&trade; cologne	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 42, Last Available: "2014-12"
 7133	blinking blurry lupine appetite hormones	0		Last Available: "2014-12"
 7134	mirror cyan wobbly Jeselnik's wolf whistle of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	bland super-sized pulsating witch's bread	5	decent	Last Available: "2014-12"
+7135	super-sized bland pulsating witch's bread	5	decent	Last Available: "2014-12"
 7136	liquefied vacuum-sealed modified huge witch's brew	0		Effect: "Hella Tough", Effect Duration: 38, Last Available: "2014-12"
 7137	huge wobbly rosy-cheeked supercool witch's bra of the wise owl	0		Mysticality: +20, Moxie Percent: +20, Maximum HP Percent: +30, Last Available: "2014-12"
-7138	strong artisanal mid-level medieval mead	5	EPIC	Last Available: "2014-12"
+7138	artisanal strong mid-level medieval mead	5	EPIC	Last Available: "2014-12"
 7139	galvanized alkaline R&uuml;mpelstiltz	0		Effect: "Devil Inside", Effect Duration: 14, Last Available: "2014-12"
 7140	blurry spinning wheel	0		Last Available: "2014-12"
 7141	vacuum-sealed oxidized non-tarnished spinning hi-octane carrot juice	0		Effect: "Turtle Titters", Effect Duration: 19, Last Available: "2014-12"
 7142	magnetized polarized hare brush	0		Effect: "Sweetened and Fattened", Effect Duration: 17, Last Available: "2014-12"
 7143	blurry prompt hare pin of temperance	0		Sleaze Resistance: +5, Adventures: +3, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	moldy huge bouncing huge cinnamon cannoli	9	crappy	Last Available: "2014-12"
+7145	moldy huge huge bouncing cinnamon cannoli	9	crappy	Last Available: "2014-12"
 7146	smooth practically non-alcoholic expensive champagne	1	awesome	Last Available: "2014-12"
 7147	modified shaking polo trophy	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 48, Last Available: "2014-12"
 7148	skewed oil painting	0		Last Available: "2014-12"
@@ -7043,10 +7043,10 @@
 7154	filling	0		Last Available: "2014-12"
 7155	huge parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	blurry healthy Fonzie's fire hose of the cheetah	0		Experience (Moxie): +1, Maximum HP Percent: +20, Initiative: +60, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	blurry healthy Fonzie's fire hose of the cheetah	0		Experience (Moxie): +1, Maximum HP Percent: +20, Initiative: +60, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	toothsome fireman's lunch	3	awesome	Last Available: "2014-12"
-7159	mansplainer's vibrating smartaleck's plain paper hat	0		Moxie Percent: +30, Maximum MP Percent: +10, Monster Level: +15, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	spoiled diet ice cream sandwich	1	crappy	Last Available: "2014-12"
+7159	mansplainer's vibrating smartaleck's plain paper hat	0		Moxie Percent: +30, Maximum MP Percent: +10, Monster Level: +15, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7160	diet spoiled ice cream sandwich	1	crappy	Last Available: "2014-12"
 7161	Jack Frost's friendly hardened &quot;honey&quot; dipper	0		Damage Reduction: 3, Familiar Weight: +3, Cold Spell Damage: +50, Last Available: "2014-12"
 7162	adequate olive plumber's lunch	3	good	Last Available: "2014-12"
 7163	ghostly flame-retardant scandalous skull gearshift knob of the glutton	0		Sleaze Damage: +5, Hot Resistance: +1, Food Drop: +100, Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	ionized quadruple-flattened blinking jug of &quot;wine&quot;	0		Effect: "Mushroom Moxiousness", Effect Duration: 13, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	fuchsia crappy camera	0		Last Available: "2014-12"
-7174	fancy super-sized delicious bouncing humble pie	5	awesome	Effect: "Chalky Hand", Effect Duration: 50, Last Available: "2014-12"
+7174	super-sized fancy delicious bouncing humble pie	5	awesome	Effect: "Chalky Hand", Effect Duration: 50, Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	liquefied vacuum-sealed gray crappy waiter disguise	0		Effect: "Alpine Mintiness", Effect Duration: 31
@@ -7088,11 +7088,11 @@
 7199	blowdart	0		
 7200	cyan ghostly Jack Frost's Buddy Bjorn	0		Cold Spell Damage: +50, Softcore Only, Last Available: "2014-02"
 7201	pulsating wool veiny weightlifter's The Nuge's favorite crossbow	0		Muscle: +15, Maximum HP: +10, Cold Resistance: +1
-7202	half-sized adequate sweet roll Alabama	2	good	
+7202	adequate half-sized sweet roll Alabama	2	good	
 7203	Saturday Night Special of vim and vigor	0		Maximum HP Percent: +50
 7204	huge lynyrd snare	0		
 7205	tumbling rosy-cheeked fleetwood chain	0		Maximum HP Percent: +30
-7206	mediocre watered-down olive Green Manalishi	2	decent	
+7206	watered-down mediocre olive Green Manalishi	2	decent	
 7207	blinking medical-grade blade	0		HP Regen Min: 7, HP Regen Max: 10
 7208	skewed fire of unknown origin	0		
 7209	fancy eagle's milk	1	decent	Effect: "Penguinny Flavor", Effect Duration: 15
@@ -7130,7 +7130,7 @@
 7241	chilly clever shoe	0		Maximum MP: +20, Cold Damage: +5, Single Equip
 7242	spinning button	0		
 7243	button	0		
-7244	electrified pulsating bouncing blood cells	0		Effect: "Sweetened and Fattened", Effect Duration: 13
+7244	electrified bouncing pulsating blood cells	0		Effect: "Sweetened and Fattened", Effect Duration: 13
 7245	non-modified activated colloidal tumbling eye	0		Effect: "Burning Ears", Effect Duration: 24
 7246	shaking glark cable	0		
 7247	Fonzie's Red Fox glove of incineration	0		Experience (Moxie): +1, Hot Spell Damage: +50, Attacks Can't Miss, Single Equip
@@ -7143,7 +7143,7 @@
 7254	bouncing really cocktail shaker	0		Familiar Weight: +5
 7255	lousy pulsating mini-martini	4	decent	
 7256	smoke grenade	0		
-7257	altered blinking lime green molotov soda	1	EPIC	
+7257	altered lime green blinking molotov soda	1	EPIC	
 7258	polymerized pile of ashes	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 37
 7259	twirling crate of firebombs	0		
 7260	firebomb	0		
@@ -7167,7 +7167,7 @@
 7278	returned Thinknerd package	0		
 7279	activated jittery upside-down wind-up Whatsian robot	0		Effect: "Fever From the Flavor", Effect Duration: 43
 7280	adjusted purple wind-up vampire teeth	0		Effect: "Purpose", Effect Duration: 50
-7281	pressed cyan skewed tumbling wind-up navigation droid	0		Effect: "Turkey-Agitated", Effect Duration: 56
+7281	pressed tumbling skewed cyan wind-up navigation droid	0		Effect: "Turkey-Agitated", Effect Duration: 56
 7282	adjusted wind-up owl	0		Effect: "Initiative and Let Die", Effect Duration: 14
 7283	double-flattened liquefied squat huge wind-up ensign	0		Effect: "Graham Crackling", Effect Duration: 59
 7284	nasty Lo Pan's crying statue earrings	0		Spell Critical Percent: +30, Stench Damage: +5, Single Equip, Lasts Until Rollover
@@ -7213,16 +7213,16 @@
 7324	diluted battery	1		
 7325	artisanal olive snakebite	4	EPIC	
 7326	ghostly prompt Newton's rubber ribcage	0		Experience (Mysticality): +3, Adventures: +3, Damage Reduction: 7
-7327	distilled tumbling blurry synthetic marrow	1		Effect: "Net Tea", Effect Duration: 35
+7327	distilled blurry tumbling synthetic marrow	1		Effect: "Net Tea", Effect Duration: 35
 7328	dry narrow blurry funny bone	0		Effect: "Cool, Catlike", Effect Duration: 14
 7329	purple scandalous half-melted spoon of temperance	0		Sleaze Damage: +5, Sleaze Resistance: +5
 7330	denatured the funk	1		
-7331	half-sized fancy decent gunky chicken	2	good	Effect: "The Real Deal", Effect Duration: 30
+7331	fancy half-sized decent gunky chicken	2	good	Effect: "The Real Deal", Effect Duration: 30
 7332	mirror reassuring doll head	0		Spooky Resistance: +1
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	pulsating tumbling Temple Grandin's smooth paddle-ball	0		Moxie: +15, Familiar Weight: +7
-7336	moist flattened jittery tumbling sound effects record	0		Effect: "Inner Dog", Effect Duration: 62
+7336	moist flattened tumbling jittery sound effects record	0		Effect: "Inner Dog", Effect Duration: 62
 7337	alphabet block	0		
 7338	quantum jittery dancer	0		Effect: "The Halls of Moxiousness", Effect Duration: 42
 7339	wobbly music box mechanism	0		
@@ -7234,7 +7234,7 @@
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	bouncing ghost toga of Calamity Jane of Flo-Jo	0		Critical Hit Percent: +15, Initiative: +100
-7348	bland immense sheet cake	6	decent	
+7348	immense bland sheet cake	6	decent	
 7349	twirling ghost key	0		
 7350	picture of you	0		
 7351	mansplainer's energetic Staff of the Electric Range of Calamity Jane	0		Maximum MP Percent: +20, Critical Hit Percent: +15, Monster Level: +15
@@ -7252,16 +7252,16 @@
 7363	polarized bloodstain stick	0		Effect: "Slimy Flavor", Effect Duration: 69
 7364	fabric softener	0		
 7365	flattened spinning fabric hardener	0		Effect: "Hammered", Effect Duration: 29
-7366	bad fancy bottle of laundry sherry	3	decent	Effect: "Hagnk's Gratitude", Effect Duration: 10
+7366	fancy bad bottle of laundry sherry	3	decent	Effect: "Hagnk's Gratitude", Effect Duration: 10
 7367	frozen colloidal twirling industrial strength starch	0		Effect: "Turkey-Friendly", Effect Duration: 23, Wiki Name: "industrial strength starch"
-7368	huge decent enchanted extra-flat panini	8	good	Effect: "Snobby", Effect Duration: 30
+7368	decent huge enchanted extra-flat panini	8	good	Effect: "Snobby", Effect Duration: 30
 7369	double-enhanced double-energized bouncing mangled finger	0		Effect: "Sticky Fingers", Effect Duration: 18
-7370	drinkable enchanted irresponsibly strong Psychotic Train wine	6	good	Effect: "Here's Mud in Your Eye", Effect Duration: 30
+7370	irresponsibly strong enchanted drinkable Psychotic Train wine	6	good	Effect: "Here's Mud in Your Eye", Effect Duration: 30
 7371	bouncing narrow crazy hobo notebook	0		
 7372	half-sized moldy pie man was not meant to eat	2	crappy	
 7373	wizardly sommelier's towel	0		Mysticality: +25
 7374	reassuring tarnished tastevin	0		Spooky Resistance: +1, Single Equip
-7375	thick stale actual tapas	5	decent	
+7375	stale thick actual tapas	5	decent	
 7376	ghast iron ingot	0		
 7377	fortified ghast iron cleaver of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100
 7378	Samson's ghast iron Garibaldi of the cougar	0		Moxie: +20, Experience (Muscle): +5, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7324,37 +7324,37 @@
 7435	double-modified Stemonitis Staticus mushroom	0		Effect: "Disco Neuropathy", Effect Duration: 12, Last Available: "2014-05"
 7436	liquefied wet Tremella Tarantella mushroom	0		Effect: "Whitened Teeth", Effect Duration: 48, Last Available: "2014-05"
 7437	skewed Pastaco shell	0		Last Available: "2014-05"
-7438	moldy fancy massive Beefy Crunch Pastaco	7	crappy	Effect: "Favored by Lyle", Effect Duration: 45, Last Available: "2014-05"
-7439	super-sized stale Brain Food Pastaco	5	decent	Last Available: "2014-05"
-7440	half-sized spoiled fancy fuchsia Cool Brunch Pastaco	2	crappy	Effect: "Coated Arms", Effect Duration: 45, Last Available: "2014-05"
+7438	fancy moldy massive Beefy Crunch Pastaco	7	crappy	Effect: "Favored by Lyle", Effect Duration: 45, Last Available: "2014-05"
+7439	stale super-sized Brain Food Pastaco	5	decent	Last Available: "2014-05"
+7440	half-sized fancy spoiled fuchsia Cool Brunch Pastaco	2	crappy	Effect: "Coated Arms", Effect Duration: 45, Last Available: "2014-05"
 7441	miniature flavorless Medical Pastaco	2	decent	Last Available: "2014-05"
 7442	rotten Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
-7443	huge adequate Ludovico Pastaco	10	good	Last Available: "2014-05"
+7443	adequate huge Ludovico Pastaco	10	good	Last Available: "2014-05"
 7444	perfectly mixed overpowering mushroom wine	3	super EPIC	Last Available: "2014-05"
 7445	hand-crafted complex mushroom wine	4	EPIC	Last Available: "2014-05"
 7446	lousy fancy smooth mushroom wine	3	decent	Effect: "Human-Beast Hybrid", Effect Duration: 10, Last Available: "2014-05"
 7447	bad blood-red mushroom wine	4	decent	Last Available: "2014-05"
 7448	mediocre buzzing mushroom wine	4	decent	Last Available: "2014-05"
-7449	watered-down artisanal fuchsia swirling mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
-7450	normal big fancy Taco Dan's Basic Taco Dan Taco	5	good	Effect: "Bored Stiff", Effect Duration: 15, Last Available: "2014-05"
+7449	artisanal watered-down fuchsia swirling mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7450	big fancy normal Taco Dan's Basic Taco Dan Taco	5	good	Effect: "Bored Stiff", Effect Duration: 15, Last Available: "2014-05"
 7451	rotten twirling Taco Dan's Taco Fish Fish Taco	4	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	spirit-forward smooth shaking regular-size brogurt	5	awesome	Last Available: "2014-05"
+7453	smooth spirit-forward shaking regular-size brogurt	5	awesome	Last Available: "2014-05"
 7454	acceptable tumbling super-size brogurt	4	good	Last Available: "2014-05"
-7455	special boozy hand-crafted teal broberry brogurt	5	EPIC	Effect: "Empty Inside", Effect Duration: 40, Last Available: "2014-05"
+7455	hand-crafted boozy special teal broberry brogurt	5	EPIC	Effect: "Empty Inside", Effect Duration: 40, Last Available: "2014-05"
 7456	bad brocolate brogurt	3	decent	Last Available: "2014-05"
-7457	hand-crafted extra-dry special French bronilla brogurt	5	EPIC	Effect: "Coated Arms", Effect Duration: 50, Last Available: "2014-05"
+7457	special extra-dry hand-crafted French bronilla brogurt	5	EPIC	Effect: "Coated Arms", Effect Duration: 50, Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
-7460	tumbling pulsating bouncing Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
+7460	bouncing tumbling pulsating Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	shaking foul-smelling Brogre brorts	0		Stench Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	shaking foul-smelling Brogre brorts	0		Stench Damage: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	Brogre brolo shirt of horror	0		Spooky Spell Damage: +25, Last Available: "2014-05"
-7464	aromatic Brogre bucket hat	0		Stench Resistance: +1, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	aromatic Brogre bucket hat	0		Stench Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	dog trainer's thinker's 8-billed baseball cap of wisdom	0		Mysticality: 25, Experience (familiar): +1, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	dog trainer's thinker's 8-billed baseball cap of wisdom	0		Mysticality: 25, Experience (familiar): +1, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	maroon foul-smelling mansplainer's stylish extremely wet T-shirt	0		Moxie: +25, Monster Level: +15, Stench Damage: +10, Last Available: "2014-05"
 7470	lard-coated boxer's shrimp fork of the wise owl	0		Mysticality: +20, Muscle Percent: +10, Sleaze Spell Damage: +25, Last Available: "2014-05"
 7471	galvanized liquefied dry BROS Energy Drink	0		Effect: "Oiled Skin", Effect Duration: 51, Last Available: "2014-05"
@@ -7362,14 +7362,14 @@
 7473	deionized colloidal shrimp cocktail	0		Effect: "Granolarrrgh", Effect Duration: 32, Last Available: "2014-05"
 7474	concentrated Yolo&trade; chocolates	0		Effect: "Memories of Puppy Love", Effect Duration: 48, Last Available: "2020-09"
 7475	narrow string of moist beads	0		Item Drop: +5, Last Available: "2014-05"
-7476	tumbling blue Ultimate Mind Destroyer	0		Last Available: "2014-05"
+7476	blue tumbling Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	nitrogenated nitrogenated teal Meat-inflating powder	0		Effect: "Magically Delicious", Effect Duration: 13, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	cold-filtered double-cold-filtered huge sugar fairy	0		Effect: "Chlorophyll Flavor", Effect Duration: 37, Last Available: "2014-05"
-7480	concentrated pressed gray shaking blinking sugar bunny	0		Effect: "Wax On Your Shoes", Effect Duration: 66, Last Available: "2014-05"
+7480	concentrated pressed shaking blinking gray sugar bunny	0		Effect: "Wax On Your Shoes", Effect Duration: 66, Last Available: "2014-05"
 7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	smooth weak upside-down Rompedores de Fantasmas	2	awesome	
-7483	perfectly mixed weak shaking La Fantasma y La Oscuridad	2	EPIC	
+7482	weak smooth upside-down Rompedores de Fantasmas	2	awesome	
+7483	weak perfectly mixed shaking La Fantasma y La Oscuridad	2	EPIC	
 7484	artisanal tumbling Fantasma en la M&aacute;quina	3	EPIC	
 7485	bouncing twirling loosening powder	0		
 7486	castoreum	0		
@@ -7417,7 +7417,7 @@
 7528	forbidden personal trainer's government-issued night-vision goggles	0		Experience Percent (Muscle): +10, Spell Damage Percent: +50, Single Equip, Last Available: "2014-05"
 7529	yummy massive olive loaf of alien bread	9	awesome	Last Available: "2014-05"
 7530	decent grilled cheese sandwich	3	good	Last Available: "2014-05"
-7531	powdered twirling gray alien protein powder	1	EPIC	Last Available: "2014-05"
+7531	powdered gray twirling alien protein powder	1	EPIC	Last Available: "2014-05"
 7532	acceptable rocket fuel	3	good	Last Available: "2014-05"
 7533	twirling alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	wobbly alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
@@ -7425,13 +7425,13 @@
 7536	squat space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	wobbly ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	red lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	medical-grade space beast fur pants	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	red lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	medical-grade space beast fur pants	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	upside-down groovy space beast fur whip	0		Moxie Percent: +10, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	stylish space heater of the scaredy-cat	0		Moxie: +25, Monster Level: -15, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
-7545	high-proof acceptable space port	10	good	Last Available: "2014-05"
+7545	acceptable high-proof space port	10	good	Last Available: "2014-05"
 7546	healthy space needle of horror	0		Maximum HP Percent: +20, Spooky Spell Damage: +25, Last Available: "2014-05"
 7547	boiled modified buffed alien drugs	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7445,7 +7445,7 @@
 7556	elephant gift	0		
 7557	tarnished blue blood cells	0		Effect: "Three Days Slow", Effect Duration: 21
 7558	mediocre wine	3	decent	
-7559	unsweetened green upside-down gummi turtle	0		Effect: "Feelin' Philosophical", Effect Duration: 19
+7559	unsweetened upside-down green gummi turtle	0		Effect: "Feelin' Philosophical", Effect Duration: 19
 7560	turtle-shaped rock	0		
 7561	pickled giraffe-necked turtle	0		Effect: "Liquid Courage", Effect Duration: 32
 7562	adjusted squat musk turtle	0		Effect: "Buzzard Breath", Effect Duration: 64
@@ -7458,7 +7458,7 @@
 7569	avaricious beefcake's Time Bandit Badge of Courage of the bloodbag	0		Muscle: +25, Maximum HP: +100, Meat Drop: +30
 7570	electrified polymerized double-aerosolized Friendliness Beverage	0		Effect: "Dreadful Smell", Effect Duration: 22
 7571	wobbly forbidden silent pea shooter of the early riser	0		Spell Damage Percent: +50, Adventures: +7
-7572	delicious snack-sized bouncing purple D roll	2	awesome	
+7572	delicious snack-sized purple bouncing D roll	2	awesome	
 7573	pulsating auspicious baleful kiwi beak	0		Spell Damage: +25, Item Drop: +10
 7574	perfectly mixed upside-down New Zealand iced tea	3	EPIC	
 7575	maroon ribald shellacked droll monocle	0		Damage Reduction: 7, Sleaze Damage: +10, Single Equip
@@ -7469,26 +7469,26 @@
 7580	altered ghostly liquid shifting time weirdness	1		
 7581	upside-down shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	decent rack of dinosaur ribs	4	good	
-7583	watered-down perfectly mixed fuchsia scotch on the rocks	2	super ultra EPIC	
+7583	perfectly mixed watered-down fuchsia scotch on the rocks	2	super ultra EPIC	
 7584	blurry executive strapping yabba dabba doo rag	0		Muscle: +5, Meat Drop: +40, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	blue sinister slick wooly loincloth	0		Moxie: +10, Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	perfectly mixed practically non-alcoholic tumbling glass of &quot;milk&quot;	1	EPIC	Last Available: "2014-07"
+7589	practically non-alcoholic perfectly mixed tumbling glass of &quot;milk&quot;	1	EPIC	Last Available: "2014-07"
 7590	tolerable cup of &quot;tea&quot;	3	good	Last Available: "2014-07"
-7591	bad fancy thermos of &quot;whiskey&quot;	4	decent	Effect: "Spiritually Awake", Effect Duration: 35, Last Available: "2014-07"
+7591	fancy bad thermos of &quot;whiskey&quot;	4	decent	Effect: "Spiritually Awake", Effect Duration: 35, Last Available: "2014-07"
 7592	artisanal Lucky Lindy	3	EPIC	Last Available: "2014-07"
-7593	mediocre weak enchanted blinking Bee's Knees	2	decent	Effect: "Spooky Hands", Effect Duration: 50, Last Available: "2014-07"
+7593	enchanted mediocre weak blinking Bee's Knees	2	decent	Effect: "Spooky Hands", Effect Duration: 50, Last Available: "2014-07"
 7594	lousy Sockdollager	3	decent	Last Available: "2014-07"
-7595	perfectly mixed weak Ish Kabibble	2	EPIC	Last Available: "2014-07"
+7595	weak perfectly mixed Ish Kabibble	2	EPIC	Last Available: "2014-07"
 7596	lousy Hot Socks	4	decent	Last Available: "2014-07"
 7597	artisanal Phonus Balonus	3	EPIC	Last Available: "2014-07"
-7598	triple-distilled aged Flivver	10	awesome	Last Available: "2014-07"
-7599	aged weak Sloppy Jalopy	2	awesome	Last Available: "2014-07"
+7598	aged triple-distilled Flivver	10	awesome	Last Available: "2014-07"
+7599	weak aged Sloppy Jalopy	2	awesome	Last Available: "2014-07"
 7600	polymerized activated shaking flame	0		Effect: "Bandersnatched", Effect Duration: 15
-7601	triple-quantum polarized ghostly shaking temporary yak tattoo	0		Effect: "Arresistible", Effect Duration: 47
-7602	warmed chilled lime green blinking Fitspiration&trade; poster	0		Effect: "Preemptive Medicine", Effect Duration: 34
+7601	triple-quantum polarized shaking ghostly temporary yak tattoo	0		Effect: "Arresistible", Effect Duration: 47
+7602	warmed chilled blinking lime green Fitspiration&trade; poster	0		Effect: "Preemptive Medicine", Effect Duration: 34
 7603	corrupted skewed neckbeard	0		Effect: "The Dinsey Spirit", Effect Duration: 55
 7604	Vulcanized Vulcanized ionized artisanal hand-squeezed wheatgrass juice	0		Effect: "Carrrsmic", Effect Duration: 58
 7605	boiled punk patch	0		Effect: "Fruited", Effect Duration: 20
@@ -7514,14 +7514,14 @@
 7625	nitrogenated pickled mirror flask of rainwater	0		Effect: "Dirge of Dreadfulness", Effect Duration: 60
 7626	unsweetened vacuum-sealed oyster badge	0		Effect: "Night of the Nachos", Effect Duration: 32
 7627	polymerized flattened gray plastic Jefferson wings	0		Effect: "Cookie Backup", Effect Duration: 27
-7628	corrupted tumbling maroon shaking dancing fan	0		Effect: "Taurus Rising", Effect Duration: 64
+7628	corrupted shaking tumbling maroon dancing fan	0		Effect: "Taurus Rising", Effect Duration: 64
 7629	boiled super-boiled page of the Necrohobocon	0		Effect: "Wallflowering", Effect Duration: 69
-7630	ionized cyan wobbly magic powder	0		Effect: "Pasta Oneness", Effect Duration: 63
+7630	ionized wobbly cyan magic powder	0		Effect: "Pasta Oneness", Effect Duration: 63
 7631	flattened jittery friar's tonsure	0		Effect: "Red Around the Gills", Effect Duration: 51
 7632	non-oxidized upside-down government-issue identification badge	0		Effect: "Drunk With Power", Effect Duration: 33
 7633	warmed boiled alien hologram projector	0		Effect: "Human-Fish Hybrid", Effect Duration: 38
 7634	double-unsweetened tarnished irradiated turtle	0		Effect: "Red Around the Gills", Effect Duration: 53
-7635	quadruple-quantum tumbling jittery cigar box turtle	0		Effect: "Fizzier Than Light", Effect Duration: 58
+7635	quadruple-quantum jittery tumbling cigar box turtle	0		Effect: "Fizzier Than Light", Effect Duration: 58
 7636	blue personal trainer's shellacked shell of doom	0		Experience Percent (Muscle): +10, Spooky Spell Damage: +50, Class: "Turtle Tamer"
 7637	mirror Newton's pillow shell	0		Experience (Mysticality): +3, Class: "Turtle Tamer"
 7638	sizzling whatsit-covered turtle shell	0		Hot Damage: +10, Class: "Turtle Tamer"
@@ -7536,7 +7536,7 @@
 7647	aquaconda brain	0		
 7648	thunder thigh	0		
 7649	moist gourmet gourami oil	0		Effect: "Healthy Red Glow", Effect Duration: 51
-7650	dry wobbly narrow catfish whiskers	0		Effect: "Antsy in your Pantsy", Effect Duration: 43
+7650	dry narrow wobbly catfish whiskers	0		Effect: "Antsy in your Pantsy", Effect Duration: 43
 7651	pulsating freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
 7653	olive fishbone kneepads	0		Initiative: +60, Single Equip
@@ -7552,7 +7552,7 @@
 7663	chilly Da Vinci's Lord Soggyraven's Slippers of doom	0		Experience (Mysticality): +5, Cold Damage: +5, Spooky Spell Damage: +50, Single Equip
 7664	nitrogenated Ancient Protector Soda	0		Effect: "Pemmican't", Effect Duration: 52
 7665	colloidal spinning liquid ice	0		Effect: "Jacked In", Effect Duration: 54
-7666	lousy distilled Wet Russian	5	decent	
+7666	distilled lousy Wet Russian	5	decent	
 7667	moldy wobbly filet of The Fish	3	crappy	
 7668	Thwaitgold spider statuette	0		
 7669	energetic arcane researcher's smooth thunder down underwear	0		Moxie: +15, Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Lasts Until Rollover
@@ -7561,7 +7561,7 @@
 7672	ruddy law-abiding citizen cane	0		Maximum HP Percent: +40, Single Equip
 7673	acceptable legitimate business on the beach	3	good	
 7674	veiny hep waders	0		Maximum HP: +10, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	miniature flavorless jive turkey leg	2	decent	
+7675	flavorless miniature jive turkey leg	2	decent	
 7676	birdbone corset of James Dean	0		Experience (Moxie): +3
 7677	vacuum-sealed anodized candy cigarette	0		Effect: "Black Lung", Effect Duration: 66
 7678	huge clever 4-dimensional fez	0		Maximum MP: +20, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7573,7 +7573,7 @@
 7684	careful Time Lord Participation Mug	0		Monster Level: -10
 7685	inspector's Tesla Time Bandit Time Towel	0		Item Drop: +15, MP Regen Min: 7, MP Regen Max: 10
 7686	censurious smelly scorching Caveman Dan's favorite rock	0		Hot Damage: +25, Stench Spell Damage: +10, Sleaze Resistance: +3, Single Equip
-7687	improved skewed fuchsia dog ointment	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 69
+7687	improved fuchsia skewed dog ointment	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 69
 7688	blinking lime green wool Temple Grandin's gumshoes	0		Familiar Weight: +7, Cold Resistance: +1, Single Equip
 7689	shellacked flapper floppers of terror	0		Damage Reduction: 7, Spooky Spell Damage: +10, Single Equip
 7690	Jack Frost's sneakeasies of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Single Equip
@@ -7587,12 +7587,12 @@
 7698	wobbly rubber spider	0		Last Available: "2014-08"
 7699	shaking blue twirling &quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	liquefied confiscated comic book	0		Effect: "Leo Rising", Effect Duration: 22, Last Available: "2014-08"
-7701	flattened alkaline purple skewed huge confiscated cell phone	0		Effect: "Spookyravin'", Effect Duration: 40, Last Available: "2014-08"
+7701	flattened alkaline skewed huge purple confiscated cell phone	0		Effect: "Spookyravin'", Effect Duration: 40, Last Available: "2014-08"
 7702	Vulcanized quadruple-moist confiscated love note	0		Effect: "Just the Brown Ones", Effect Duration: 25, Last Available: "2014-08"
 7703	pulsating LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	pulsating LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	upside-down lime green The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	lime green upside-down The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	warmed nitrogenated blinking tumbling rubber nubbin	0		Effect: "Muscle Unbound", Effect Duration: 31, Last Available: "2014-08"
 7708	beefy rubber cape of incineration	0		Muscle: +10, Hot Spell Damage: +50, Last Available: "2014-08"
 7709	lightning-fast coward's mansplainer's Thor's Pliers of the boozehound	0		Monster Level: -5, Booze Drop: +100, Initiative: +40, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
@@ -7601,7 +7601,7 @@
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	super-sized moldy Strix stix	5	crappy	
 7714	toasty Temple Grandin's Lo Pan's vampire pellet	0		Spell Critical Percent: +30, Familiar Weight: +7, Hot Damage: +5
-7715	enchanted drinkable non-aged vinegar	4	good	Effect: "Thought", Effect Duration: 45
+7715	drinkable enchanted non-aged vinegar	4	good	Effect: "Thought", Effect Duration: 45
 7716	auspicious unsanitized scalpel	0		Item Drop: +10
 7717	teal gladiator tunica of incineration	0		Hot Spell Damage: +50
 7718	occult Roman sadnals	0		Spell Damage Percent: +25, Single Equip
@@ -7609,7 +7609,7 @@
 7720	blue lightning-fast radiator heater shield	0		Initiative: +40, Damage Reduction: 6
 7721	wet skewed skewed salt wages	0		Effect: "Puzzle Fury", Effect Duration: 35
 7722	studded centurion helmet	0		Damage Absorption: +80, Familiar Effect: "1xFairy, atk, cap 25"
-7723	twirling huge Chroner cross	0		
+7723	huge twirling Chroner cross	0		
 7724	lime green skewed Jeselnik's pteruges	0		Sleaze Damage: +25, Familiar Effect: "1xFairy, atk, cap 25"
 7725	activated Bruno's blessing of Mars	0		Effect: "Make Meat FA$T!", Effect Duration: 18
 7726	deionized moist gray Dennis's blessing of Minerva	0		Effect: "New and Improved", Effect Duration: 61
@@ -7632,17 +7632,17 @@
 7743	Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
 7744	Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	huge mirror Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
-7746	yellow blinking Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
+7746	blinking yellow Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
 7747	Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	huge Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	blurry Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	padded Xiblaxian xeno-detection goggles	0		Damage Absorption: +20, Single Equip, Last Available: "2014-09"
-7753	executive rosy-cheeked Xiblaxian stealth cowl	0		Maximum HP Percent: +30, Meat Drop: +40, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	executive rosy-cheeked Xiblaxian stealth cowl	0		Maximum HP Percent: +30, Meat Drop: +40, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	lightning-fast Xiblaxian stealth trousers of terror	0		Spooky Spell Damage: +10, Initiative: +40, Last Available: "2014-09"
 7755	blurry quilted Xiblaxian stealth vest of the boozehound	0		Damage Absorption: +40, Booze Drop: +100, Last Available: "2014-09"
-7756	stale massive blinking Xiblaxian ultraburrito	10	decent	Last Available: "2014-09"
+7756	massive stale blinking Xiblaxian ultraburrito	10	decent	Last Available: "2014-09"
 7757	delicious weak wobbly Xiblaxian space-whiskey	2	awesome	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	oxidized They liver	0		Effect: "Buggy Flavor", Effect Duration: 44, Last Available: "2014-09"
@@ -7658,20 +7658,20 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	upside-down crafty steel-toed Personal Ventilation Unit of Gandalf	0		Damage Reduction: 9, Maximum MP: +10, Spell Critical Percent: +20, Single Equip, Last Available: "2014-10"
 7771	chilled the most dangerous bait	0		Effect: "Concentration", Effect Duration: 66, Last Available: "2014-10"
-7772	flavorless small wobbly &quot;meat&quot; stick	2	decent	Last Available: "2014-10"
+7772	small flavorless wobbly &quot;meat&quot; stick	2	decent	Last Available: "2014-10"
 7773	vaporized squat transdermal smoke patch	1	EPIC	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	beefcake's weightlifter's pair of plants of the sewer	0		Muscle: 40, Stench Damage: +25, Last Available: "2014-10"
 7776	teal Sasq&trade; watch of the sewer of the detective of the glutton	0		Stench Damage: +25, Item Drop: +20, Food Drop: +100, Single Equip, Last Available: "2014-10"
 7777	tumbling wool rock-hard studded smoker's cloak	0		Damage Absorption: +80, Damage Reduction: 5, Cold Resistance: +1, Last Available: "2014-10"
 7778	bouncing rosy-cheeked camouflage T-shirt of vim and vigor of incineration of mayonnaise	0		Maximum HP Percent: 80, Hot Spell Damage: +50, Sleaze Spell Damage: +50, Last Available: "2014-10"
-7779	warmed blinking cyan experimental serum G-9	0		Effect: "Mad at Science", Effect Duration: 28, Last Available: "2014-10"
+7779	warmed cyan blinking experimental serum G-9	0		Effect: "Mad at Science", Effect Duration: 28, Last Available: "2014-10"
 7780	careful therapeutic educational heavy-duty clipboard	0		Experience: +1, Monster Level: -10, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 8, Last Available: "2014-10"
 7781	chilly crafty dance instructor's experienced battery-powered drill	0		Experience: +2, Experience Percent (Moxie): +10, Maximum MP: +10, Cold Damage: +5, Last Available: "2014-10"
 7782	decent yellow limp broccoli	4	good	Last Available: "2014-10"
-7783	Usain Bolt's careful hat of the scaredy-cat	0		Monster Level: -25, Initiative: +80, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	Usain Bolt's careful hat of the scaredy-cat	0		Monster Level: -25, Initiative: +80, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	galvanized wet squat monkey barf	0		Effect: "Appeteyes", Effect Duration: 14, Last Available: "2014-10"
-7785	irradiated dry blurry blinking candy	0		Effect: "Petit Forbearance", Effect Duration: 55, Last Available: "2014-10"
+7785	irradiated dry blinking blurry candy	0		Effect: "Petit Forbearance", Effect Duration: 55, Last Available: "2014-10"
 7786	rosy-cheeked jangly bracelet of the scaredy-cat of the businessman	0		Maximum HP Percent: +30, Monster Level: -15, Meat Drop: +50, Last Available: "2014-10"
 7787	cuddly teddy bear of the pedagogue	0		Experience: +3, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
@@ -7682,7 +7682,7 @@
 7793	wobbly bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	flavorless blue bouncing initiative shawarma	4	decent	Last Available: "2014-10"
-7796	stale fancy bouncing warm war shawarma	3	decent	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2014-10"
+7796	fancy stale bouncing warm war shawarma	3	decent	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2014-10"
 7797	super-sized adequate spinning karma shawarma	5	good	Last Available: "2014-10"
 7798	artisanal shaking Jungle Juice	3	EPIC	Last Available: "2014-10"
 7799	triple-distilled artisanal bouncing blurry Amnesiac Ale	8	EPIC	Last Available: "2014-10"
@@ -7699,12 +7699,12 @@
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	normal fancy seared dino steak	4	good	Effect: "Crud&eacute;", Effect Duration: 30
+7813	fancy normal seared dino steak	4	good	Effect: "Crud&eacute;", Effect Duration: 30
 7814	aged triple-distilled blinking bottle of drinkin' gas	10	awesome	
 7815	handful of napalm	0		
 7816	pulsating dove DNA	0		
 7817	mirror gelatinous meat mass	0		
-7818	blinking skewed 99.44% pure math	0		
+7818	skewed blinking 99.44% pure math	0		
 7819	upside-down simple AI	0		
 7820	upside-down corrupted bird DNA	0		
 7821	shaking sentient meat mass	0		
@@ -7716,7 +7716,7 @@
 7827	decent unidentifiable dried fruit	3	good	
 7828	mediocre flat cider	3	decent	
 7829	up-at-dawn knitted shellacked trench lighter	0		Damage Reduction: 7, Cold Resistance: +3, Adventures: +5, Last Available: "2014-10"
-7830	extra-magnetized skewed spinning experimental serum P-00	0		Effect: "Pork Power", Effect Duration: 52, Last Available: "2014-10"
+7830	extra-magnetized spinning skewed experimental serum P-00	0		Effect: "Pork Power", Effect Duration: 52, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	squat encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	maroon gore bucket	0		Last Available: "2014-10"
@@ -7743,12 +7743,12 @@
 7854	yellow double-paned plastic Crimbot	0		Cold Resistance: +5, Last Available: "2014-12"
 7855	jittery grievous plastic Crimbomega	0		Weapon Damage Percent: +50, Last Available: "2014-12"
 7856	flattened flask of mining oil	0		Effect: "Mushroom Samba", Effect Duration: 39, Last Available: "2014-12"
-7857	scandalous radiation-resistant helmet	0		Sleaze Damage: +5, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	perfumed servo-assisted exo-pants	0		Stench Resistance: +5, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	scandalous radiation-resistant helmet	0		Sleaze Damage: +5, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	perfumed servo-assisted exo-pants	0		Stench Resistance: +5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	scorching high-energy mining laser of the empath	0		Familiar Weight: +5, Hot Damage: +25, Last Available: "2014-12"
 7860	blinking peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
-7862	pulsating fuchsia cylindrical mold	0		Last Available: "2014-12"
+7862	fuchsia pulsating cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	blue Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
@@ -7758,10 +7758,10 @@
 7869	twirling Crimbot schematic: Crab Core	0		Last Available: "2014-12"
 7870	Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
-7872	gray pulsating Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
+7872	pulsating gray Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	green Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	skewed Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
-7875	red pulsating Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
+7875	pulsating red Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
 7876	Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
@@ -7779,7 +7779,7 @@
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	blurry Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	ghostly Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
-7893	pulsating maroon Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
+7893	maroon pulsating Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
@@ -7808,9 +7808,9 @@
 7919	pickled tarnished twirling Big Punk	0		Effect: "Blubbered Up", Effect Duration: 52
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	aged watered-down Friendly Turkey	2	awesome	Last Available: "2014-11"
+7922	watered-down aged Friendly Turkey	2	awesome	Last Available: "2014-11"
 7923	weak tolerable pulsating Agitated Turkey	2	good	Last Available: "2014-11"
-7924	practically non-alcoholic tolerable Ambitious Turkey	1	good	Last Available: "2014-11"
+7924	tolerable practically non-alcoholic Ambitious Turkey	1	good	Last Available: "2014-11"
 7925	moldy massive jittery neutron lollipop	9	crappy	Last Available: "2014-12"
 7926	weak tolerable jittery gamma nog	2	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
@@ -7852,10 +7852,10 @@
 7970	wobbly boning knife	0		
 7971	cyan Aggressive Carrot	0		Free Pull
 7972	pickled jittery mummified fig	1	good	
-7973	vaporized skewed fuchsia mummified loaf of bread	1	awesome	Effect: "Corona de la Salsa", Effect Duration: 40
-7974	pickled green spinning mummified beef haunch	1	EPIC	
+7973	vaporized fuchsia skewed mummified loaf of bread	1	awesome	Effect: "Corona de la Salsa", Effect Duration: 40
+7974	pickled spinning green mummified beef haunch	1	EPIC	
 7975	linen bandages	0		
-7976	jittery ghostly cotton bandages	0		
+7976	ghostly jittery cotton bandages	0		
 7977	cyan silk bandages	0		
 7978	holy spring water	0		
 7979	spirit beer	0		
@@ -7879,9 +7879,9 @@
 7997	mixed narrow polyesterene powder	1		Effect: "[1609]Dancin' Fool", Effect Duration: 20, Last Available: "2015-12"
 7998	altered tumbling powder	1		Effect: "Boschface", Effect Duration: 20, Last Available: "2015-12"
 7999	quantum choco-Crimbot	0		Effect: "Blackberry Politeness", Effect Duration: 38, Last Available: "2014-12"
-8000	polymerized pulsating ghostly smart watch	0		Effect: "Red-Shirted Escort", Effect Duration: 45, Last Available: "2014-12"
-8001	corrupted blurry squat augmented-reality shades	0		Effect: "Standard Cheer", Effect Duration: 28, Last Available: "2014-12"
-8002	toy Crimbot mega face of the glutton	0		Food Drop: +100, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8000	polymerized ghostly pulsating smart watch	0		Effect: "Red-Shirted Escort", Effect Duration: 45, Last Available: "2014-12"
+8001	corrupted squat blurry augmented-reality shades	0		Effect: "Standard Cheer", Effect Duration: 28, Last Available: "2014-12"
+8002	toy Crimbot mega face of the glutton	0		Food Drop: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
 8003	healthy toy Crimbot power glove	0		Maximum HP Percent: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
 8004	purple skewed MacGyver's toy Crimbot super fist	0		Maximum MP: +100, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
 8005	mirror savvy toy Crimbot rocket legs	0		Mysticality Percent: +20, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
@@ -7893,14 +7893,14 @@
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	flame-wreathed clever Crimbomega drive chain of chilblains	0		Maximum MP: +20, Cold Damage: +25, Hot Spell Damage: +10, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	blinking Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
-8014	spinning twirling Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
+8014	twirling spinning Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8016	unsweetened fitness wristband	0		Effect: "World's Shortest Giant", Effect Duration: 58, Last Available: "2014-12"
 8017	modified flask of tainted mining oil	0		Effect: "Seriously Mutated", Effect Duration: 66, Last Available: "2014-12"
 8018	extra-moist wet and rain stick	0		Effect: "Fire Inside", Effect Duration: 18
 8019	spinning Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	decent Choco-Mint patty	4	good	Last Available: "2015-01"
-8021	watered-down perfectly mixed mirror hot mint schnocolate	2	EPIC	Last Available: "2015-01"
+8021	perfectly mixed watered-down mirror hot mint schnocolate	2	EPIC	Last Available: "2015-01"
 8022	twisted tumbling maroon homeopathic mint tea	1	awesome	Last Available: "2015-01"
 8023	cyan muscle stimulator	0		Last Available: "2015-01"
 8024	tumbling foreign language tapes	0		Last Available: "2015-01"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	janitor sponge	0		
 8073	yellow Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	lightning-fast flame-retardant quilted Spelunker's fedora	0		Damage Absorption: +40, Hot Resistance: +1, Initiative: +40, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	lightning-fast flame-retardant quilted Spelunker's fedora	0		Damage Absorption: +40, Hot Resistance: +1, Initiative: +40, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	Annie Oakley's padded Spelunker's whip	0		Damage Absorption: +20, Critical Hit Percent: +20, Item Drop: +5, Last Available: "2015-12"
-8076	shellacked Newton's Spelunker's khakis of Gandalf	0		Experience (Mysticality): +3, Damage Reduction: 7, Spell Critical Percent: +20, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	shellacked Newton's Spelunker's khakis of Gandalf	0		Experience (Mysticality): +3, Damage Reduction: 7, Spell Critical Percent: +20, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	ghostly Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	jittery squat Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7998,14 +7998,14 @@
 8123	executive Rosewater's garibaldi	0		Mysticality Percent: +30, Meat Drop: +40, Last Available: "2018-12"
 8124	Temple Grandin's girdle of the scaredy-cat	0		Monster Level: -15, Familiar Weight: +7, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	wool lard-coated gloves	0		Sleaze Spell Damage: +25, Cold Resistance: +1, Single Equip, Last Available: "2018-12"
-8126	pickled narrow upside-down smithereens	1		Last Available: "2018-12"
+8126	pickled upside-down narrow smithereens	1		Last Available: "2018-12"
 8127	lightning-fast mansplainer's fiberglass fetish	0		Monster Level: +15, Initiative: +40, Last Available: "2018-12"
 8128	spinning baleful fiberglass foil	0		Spell Damage: +25, Item Drop: +5, Last Available: "2018-12"
 8129	censurious wholesome fiberglass fannypack	0		Maximum HP Percent: +10, Sleaze Resistance: +3, Single Equip, Last Available: "2018-12"
 8130	squat medical-grade fiberglass frock of the blizzard	0		Cold Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-12"
 8131	auspicious stanky fiberglass fingerguard	0		Stench Spell Damage: +25, Item Drop: +10, Single Equip, Last Available: "2018-12"
 8132	dog trainer's fiberglass fedora of doom	0		Experience (familiar): +1, Spooky Spell Damage: +50, Last Available: "2018-12"
-8133	denatured blue shaking fiberglass fibers	1		Last Available: "2018-12"
+8133	denatured shaking blue fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	olive twirling winged yeti fur	0		
 8136	green talisman of Renenutet	0		
@@ -8021,7 +8021,7 @@
 8147	time shuriken	0		
 8148	spinning asbestos-lined vibrating ninjammies of the glutton	0		Maximum MP Percent: +10, Hot Resistance: +5, Food Drop: +100, Familiar Effect: "atk, 0.5xPotato, cap 25"
 8149	unsweetened quadruple-boiled Glo-Pop	0		Effect: "Quantum of Moxie", Effect Duration: 66
-8150	warmed pressed skewed teal sugar sphere	0		Effect: "Salamander In Your Stomach", Effect Duration: 63
+8150	warmed pressed teal skewed sugar sphere	0		Effect: "Salamander In Your Stomach", Effect Duration: 63
 8151	vacuum-sealed Shrubble Bubble	0		Effect: "Weird Flavor", Effect Duration: 50
 8152	triple-corrupted lime green polyeaster egg	0		Effect: "20-20 Second Sight", Effect Duration: 48
 8153	polymerized candy dish	0		Effect: "protect.enq", Effect Duration: 45
@@ -8038,11 +8038,11 @@
 8164	pulsating yellow strapping remaindered axe of dire peril	0		Muscle: +5, Weapon Damage: +20
 8165	mirror low-budget shield	0		Damage Reduction: 3
 8166	blurry bouncing forbidden smartaleck's cr&ecirc;epy mask	0		Moxie Percent: +30, Spell Damage Percent: +50, Familiar Effect: "spooky atk, cap 5"
-8167	half-sized spoiled baguette	2	crappy	
+8167	spoiled half-sized baguette	2	crappy	
 8168	glob of icing	0		
 8169	ionized huge ginger snaps	0		Effect: "Insulated Trousers", Effect Duration: 62
 8170	alkaline dry mostly-broken sunglasses	0		Effect: "Ack!  Barred!", Effect Duration: 69
-8171	smooth weak unflavored wine cooler	2	awesome	
+8171	weak smooth unflavored wine cooler	2	awesome	
 8172	carton of snake milk	1	decent	
 8173	ghostly sewer snake of the wise owl	0		Mysticality: +20
 8174	toothsome pigeon egg	4	awesome	
@@ -8056,7 +8056,7 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	asbestos-lined bread basket	0		Hot Resistance: +5
 8184	twirling pulsating Ed the Undying exhibit crate	0		
-8185	huge fortified The Crown of Ed the Undying of Calamity Jane	0		Damage Absorption: +60, Critical Hit Percent: +15, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	huge fortified The Crown of Ed the Undying of Calamity Jane	0		Damage Absorption: +60, Critical Hit Percent: +15, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	drinkable Cherrytastrophe wine cooler	3	good	
@@ -8064,11 +8064,11 @@
 8190	hand-crafted Orangemageddon wine cooler	3	EPIC	
 8191	smooth Breakfast Blast wine cooler	4	awesome	
 8192	aged Citrus Crush wine cooler	3	awesome	
-8193	adequate massive enchanted plain bagel	8	good	Effect: "Amorphous Cheer", Effect Duration: 10
+8193	massive adequate enchanted plain bagel	8	good	Effect: "Amorphous Cheer", Effect Duration: 10
 8194	decent bite-sized skewed purple glob of cream cheese	1	good	
 8195	rotten loaf of soda bread	4	crappy	
 8196	normal acceptable bagel	4	good	
-8197	snack-sized yummy standard-issue cupcake	2	awesome	
+8197	yummy snack-sized standard-issue cupcake	2	awesome	
 8198	flavorless ultra-deluxe cupcake	3	decent	
 8199	mirror hypnotic breadcrumbs	0		
 8200	tasty purple popular tart	3	awesome	
@@ -8090,9 +8090,9 @@
 8216	enhanced oxidized squat beard incense	0		Effect: "Standard Cheer", Effect Duration: 47, Last Available: "2015-04"
 8217	scorching perfume-soaked bandana of the overflowing toilet	0		Hot Damage: +25, Stench Spell Damage: +50, Single Equip, Last Available: "2015-04"
 8218	jittery toxic globule	0		Last Available: "2015-04"
-8219	snack-sized normal fuchsia toxo	2	good	Last Available: "2015-04"
+8219	normal snack-sized fuchsia toxo	2	good	Last Available: "2015-04"
 8220	bad practically non-alcoholic Lemonade-235	1	decent	Last Available: "2015-04"
-8221	greasy smelly isotophat	0		Stench Spell Damage: +10, Sleaze Spell Damage: +10, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	greasy smelly isotophat	0		Stench Spell Damage: +10, Sleaze Spell Damage: +10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Three Mile Island shorts of the bloodbag of the early riser	0		Maximum HP: +100, Adventures: +7, Last Available: "2015-04"
 8223	stanky Temple Grandin's toxic mop	0		Familiar Weight: +7, Stench Spell Damage: +25, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8110,8 +8110,8 @@
 8236	mirror teal Jim Carey's Dinsey's glove of Leguizamo	0		Monster Level: 45, Single Equip, Last Available: "2015-04"
 8237	shaking maroon Dinsey's pants of the cougar of Gandalf	0		Moxie: +20, Spell Critical Percent: +20, Last Available: "2015-04"
 8238	squat brain preservation fluid	0		Last Available: "2015-04"
-8239	jittery huge keycard &alpha;	0		Last Available: "2015-04"
-8240	upside-down narrow keycard &beta;	0		Last Available: "2015-04"
+8239	huge jittery keycard &alpha;	0		Last Available: "2015-04"
+8240	narrow upside-down keycard &beta;	0		Last Available: "2015-04"
 8241	narrow keycard &gamma;	0		Last Available: "2015-04"
 8242	blinking keycard &delta;	0		Last Available: "2015-04"
 8243	complimentary Dinsey refreshments	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	blurry trash net	0		Last Available: "2015-04"
 8246	blue foul-smelling Sinatra's Dinsey mascot mask of the overflowing toilet	0		Experience (Moxie): +5, Stench Damage: +10, Stench Spell Damage: +50, Last Available: "2015-04"
 8247	adequate Dinsey food-cone	4	good	Last Available: "2015-04"
-8248	extra-dry hand-crafted Dinsey Whinskey	5	EPIC	Last Available: "2015-04"
+8248	hand-crafted extra-dry Dinsey Whinskey	5	EPIC	Last Available: "2015-04"
 8249	cold-filtered blurry Dinsey face paint	0		Effect: "Barking Mad", Effect Duration: 28, Last Available: "2015-04"
 8250	wicked fannypack of the bloodbag	0		Spell Damage: +5, Maximum HP: +100, Last Available: "2015-04"
 8251	knitted therapeutic healthy shellacked fortified Newton's garbage sticker	0		Experience (Mysticality): +3, Damage Absorption: +60, Damage Reduction: 7, Maximum HP Percent: +20, Cold Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-04"
@@ -8140,9 +8140,9 @@
 8266	Usain Bolt's resourceful Socratic miracle whip of the cheetah	0		Experience (Mysticality): +1, Maximum MP: +50, Initiative: 140, Lasts Until Rollover, Last Available: "2015-05"
 8267	squat rosy-cheeked sphygmayomanometer	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2015-05"
 8268	tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
-8269	ghostly green shaking mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	adequate massive unappetizing mayolus	6	good	Last Available: "2015-05"
-8271	rotten special uninteresting mayolus	3	crappy	Effect: "Bastard!", Effect Duration: 20, Last Available: "2015-05"
+8269	shaking ghostly green mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
+8270	massive adequate unappetizing mayolus	6	good	Last Available: "2015-05"
+8271	special rotten uninteresting mayolus	3	crappy	Effect: "Bastard!", Effect Duration: 20, Last Available: "2015-05"
 8272	stale acceptable mayolus	4	decent	Last Available: "2015-05"
 8273	normal upside-down enticing mayolus	3	good	Last Available: "2015-05"
 8274	moldy gigantic mouth-watering mayolus	7	crappy	Last Available: "2015-05"
@@ -8174,7 +8174,7 @@
 8300	galvanized corrupted power pill	0		Effect: "Bells in the Batfry", Effect Duration: 64, Last Available: "2015-06"
 8301	flattened anodized squat pixel star	0		Effect: "Tingly Wrists", Effect Duration: 64, Last Available: "2015-06"
 8302	normal snack-sized pixel banana	2	good	Last Available: "2015-06"
-8303	artisanal weak green pixel beer	2	EPIC	Last Available: "2015-06"
+8303	weak artisanal green pixel beer	2	EPIC	Last Available: "2015-06"
 8304	narrow puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	aerosolized adjusted blinking sludgesicle	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 55
@@ -8213,11 +8213,11 @@
 8339	concentrated twirling warehouse walkie-talkie	0		Effect: "Rushin' Hands", Effect Duration: 54
 8340	anodized ghostly janitor's mop	0		Effect: "Memory of Resilience", Effect Duration: 54
 8341	adjusted warehouse clerk's glasses	0		Effect: "Bored Stiff", Effect Duration: 35
-8342	super-pickled polymerized gray squat baloney rotgut	0		Effect: "Extra-Sharp Weapon", Effect Duration: 69
+8342	super-pickled polymerized squat gray baloney rotgut	0		Effect: "Extra-Sharp Weapon", Effect Duration: 69
 8343	corrupted dry narrow tumbling carton of gaspers	0		Effect: "Salt Rockin'", Effect Duration: 59
 8344	warmed energized bronze polish	0		Effect: "Virgo Rising", Effect Duration: 11
 8345	liquefied dry crident	0		Effect: "Hair on Your Chest", Effect Duration: 15
-8346	corrupted magnetized squat red totally sweet mohawk helmet	0		Effect: "One For Tea", Effect Duration: 59
+8346	corrupted magnetized red squat totally sweet mohawk helmet	0		Effect: "One For Tea", Effect Duration: 59
 8347	enhanced spray chrome	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 22
 8348	electrified nitrogenated bouncing filthy monkey head	0		Effect: "Greasy Peasy", Effect Duration: 22
 8349	polymerized enhanced hand of cards	0		Effect: "Experimental Effect G-9", Effect Duration: 13
@@ -8226,15 +8226,15 @@
 8352	tarnished Vulcanized gray skeleton beans	0		Effect: "Berry Defensive", Effect Duration: 25
 8353	extra-adjusted triple-quantum modified blinking grimy lab coat	0		Effect: "Appeteyes", Effect Duration: 52
 8354	moist nitrogenated altered nursery rhyme	0		Effect: "Spring Training", Effect Duration: 48
-8355	energized unsweetened mirror mirror lime green iron torso box	0		Effect: "Gyromitra Gymnastics", Effect Duration: 41
-8356	non-ionized altered ghostly mirror teal mercenary headband	0		Effect: "Slippery Tongue", Effect Duration: 21
+8355	energized unsweetened mirror lime green mirror iron torso box	0		Effect: "Gyromitra Gymnastics", Effect Duration: 41
+8356	non-ionized altered mirror ghostly teal mercenary headband	0		Effect: "Slippery Tongue", Effect Duration: 21
 8357	unsweetened irradiated skewed radioactive spider venom	0		Effect: "Sticky Hands", Effect Duration: 32
 8358	adjusted narrow x-ray mirror	0		Effect: "Mushroom Might", Effect Duration: 36
 8359	dry tumbling wobbly wrestling mask	0		Effect: "In the Slimelight", Effect Duration: 41
 8360	super-colloidal denatured upside-down hawkface potion	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 22
 8361	denatured anodized adjusted twirling child-sized dracula cloak	0		Effect: "Radium Radicality", Effect Duration: 55
 8362	altered quadruple-colloidal mirror devil-summoning hat	0		Effect: "Petit Forbearance", Effect Duration: 29
-8363	concentrated magnetized dry spinning bouncing shopkeeper beard	0		Effect: "Fruited", Effect Duration: 14
+8363	concentrated magnetized dry bouncing spinning shopkeeper beard	0		Effect: "Fruited", Effect Duration: 14
 8364	oxidized purple alien autoautopsy kit	0		Effect: "Cotton Mouthed", Effect Duration: 55
 8365	magnetized novelty fruit hat	0		Effect: "Ooh, Sour!", Effect Duration: 55
 8366	enhanced green invisibility cream	0		Effect: "Pork Power", Effect Duration: 50
@@ -8249,7 +8249,7 @@
 8375	moist diffused shaking eyebrow lifter	0		Effect: "On a Roll", Effect Duration: 47
 8376	submarine	0		Last Available: "2015-06"
 8377	moldy pixel lemon	3	crappy	Last Available: "2015-06"
-8378	boozy artisanal spinning pixel daiquiri	5	EPIC	Last Available: "2015-06"
+8378	artisanal boozy spinning pixel daiquiri	5	EPIC	Last Available: "2015-06"
 8379	quadruple-galvanized power pill	0		Effect: "Leash of Linguini", Effect Duration: 11, Last Available: "2015-06"
 8380	improved colloidal pixel potion	0		Effect: "One For Tea", Effect Duration: 12, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8280,24 +8280,24 @@
 8406	jittery savory dry noodles	0		
 8407	moldy pestopiary	3	crappy	
 8408	modified denatured ectoplasmic orbs	0		Effect: "Crimbo Nostalgia", Effect Duration: 11
-8409	low-calorie bland crudles	1	decent	
+8409	bland low-calorie crudles	1	decent	
 8410	moldy super-sized agnolotti arboli	5	crappy	
 8411	normal low-calorie spaghetti with ghost balls	1	good	
-8412	yummy low-calorie succulent marrow	1	awesome	
+8412	low-calorie yummy succulent marrow	1	awesome	
 8413	stale salacious crumbs	3	decent	
 8414	adequate fusilli marrownarrow	3	good	
 8415	rotten spinning suggestive strozzapreti	4	crappy	
 8416	Mountain Stream gastrique	0		
 8417	immense spoiled pulsating Mt. McLargeHuge oyster	9	crappy	
 8418	mirror oyster sauce	0		
-8419	bland small tumbling linguini immondizia bianco	2	decent	
+8419	small bland tumbling linguini immondizia bianco	2	decent	
 8420	tasty shells a la shellfish	3	awesome	
 8421	shaking shaking Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
 8425	New Age healing crystal	0		Last Available: "2015-08"
-8426	twirling lime green Volcoino	0		Last Available: "2015-08"
+8426	lime green twirling Volcoino	0		Last Available: "2015-08"
 8427	spinning fizzing spore pod	0		
 8428	spore pod	0		
 8429	huge veiny spore pod	0		
@@ -8329,7 +8329,7 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	blinking broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	skewed cool high-temperature mining mask of the scaredy-cat	0		Moxie: +5, Monster Level: -15, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	skewed cool high-temperature mining mask of the scaredy-cat	0		Moxie: +5, Monster Level: -15, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	fireproof megaphone of courage of bravery	0		Spooky Resistance: 8, Last Available: "2015-08"
 8460	rotten jumbo mineapple	5	crappy	Last Available: "2015-08"
 8461	acceptable watered-down Gold Velvet&trade; whiskey	2	good	Last Available: "2015-08"
@@ -8341,18 +8341,18 @@
 8467	inspector's padded lava balaclava of mayonnaise	0		Damage Absorption: +20, Sleaze Spell Damage: +50, Item Drop: +15, Last Available: "2015-08"
 8468	rosewater-soaked toasty occult basaltamander buckler	0		Spell Damage Percent: +25, Hot Damage: +5, Stench Resistance: +3, Damage Reduction: 15, Last Available: "2015-08"
 8469	quantum lava globs	0		Effect: "You Ate Some Hemp Candy", Effect Duration: 19, Last Available: "2015-08"
-8470	spoiled tiny gooey lava globs	1	crappy	Last Available: "2015-08"
+8470	tiny spoiled gooey lava globs	1	crappy	Last Available: "2015-08"
 8471	wobbly wool lava-proof pants of horror	0		Spooky Spell Damage: +25, Cold Resistance: +1, Last Available: "2015-08"
 8472	aromatic hardened heat-resistant necktie	0		Damage Reduction: 3, Stench Resistance: +1, Single Equip, Last Available: "2015-08"
 8473	reassuring greasy padded heat-resistant gloves	0		Damage Absorption: +20, Sleaze Spell Damage: +10, Spooky Resistance: +1, Single Equip, Last Available: "2015-08"
-8474	immense moldy very hot lunch	6	crappy	Last Available: "2015-08"
-8475	weak perfectly mixed fancy asbestos thermos	2	super EPIC	Effect: "Using Protection", Effect Duration: 20, Last Available: "2015-08"
+8474	moldy immense very hot lunch	6	crappy	Last Available: "2015-08"
+8475	weak fancy perfectly mixed asbestos thermos	2	super EPIC	Effect: "Using Protection", Effect Duration: 20, Last Available: "2015-08"
 8476	boiled double-diffused blue liquid rhinestones	0		Effect: "Trivia Master", Effect Duration: 49, Last Available: "2015-08"
-8477	massive decent disco biscuit	8	good	Last Available: "2015-08"
+8477	decent massive disco biscuit	8	good	Last Available: "2015-08"
 8478	fancy lousy Quaatorade&trade;	3	decent	Effect: "Buzzard Breath", Effect Duration: 35, Last Available: "2015-08"
-8479	miser's Tesla energetic biker's hat	0		Maximum MP Percent: +20, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk", Last Available: "2015-08"
-8480	friendly medical-grade steel-toed feathered headdress	0		Damage Reduction: 9, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	steel-toed personal trainer's slick electrician's hardhat	0		Moxie: +10, Experience Percent (Muscle): +10, Damage Reduction: 9, Familiar Effect: "atk", Last Available: "2015-08"
+8479	miser's Tesla energetic biker's hat	0		Maximum MP Percent: +20, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk"
+8480	friendly medical-grade steel-toed feathered headdress	0		Damage Reduction: 9, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	steel-toed personal trainer's slick electrician's hardhat	0		Moxie: +10, Experience Percent (Muscle): +10, Damage Reduction: 9, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	pulsating Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	maroon The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	toasty smooth velvet pants	0		Hot Damage: +5, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	toasty smooth velvet pants	0		Hot Damage: +5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	gray greedy smooth velvet shirt	0		Meat Drop: +20, Last Available: "2015-08"
 8492	huge Newton's smooth velvet hat	0		Experience (Mysticality): +3, Last Available: "2015-08"
 8493	twirling careful smooth velvet pocket square	0		Monster Level: -10, Single Equip, Last Available: "2015-08"
@@ -8382,7 +8382,7 @@
 8508	Vulcanized labrador cookie	0		Effect: "Cranberry Cordiality", Effect Duration: 26, Last Available: "2015-08"
 8509	lion tamer's extremely unsafe Mr. Cheeng's spectacles of the pedagogue	0		Experience: +3, Weapon Damage Percent: +100, Experience (familiar): +2, Single Equip, Last Available: "2015-08"
 8510	gravedigger's resourceful grease cannon	0		Maximum MP: +50, Spooky Damage: +10, Last Available: "2015-08"
-8511	chilled Vulcanized altered ghostly wobbly demon makeup kit	0		Effect: "Twinkly Weapon", Effect Duration: 55, Last Available: "2015-08"
+8511	chilled Vulcanized altered wobbly ghostly demon makeup kit	0		Effect: "Twinkly Weapon", Effect Duration: 55, Last Available: "2015-08"
 8512	friendly smooth love of incineration	0		Moxie: +15, Familiar Weight: +3, Hot Spell Damage: +50, Last Available: "2015-08"
 8513	manspreader's padded Pener's drumstick of Calamity Jane	0		Damage Absorption: +20, Critical Hit Percent: +15, Monster Level: +10, Last Available: "2015-08"
 8514	yellow skewed avaricious fireproof deuce cape	0		Hot Resistance: +3, Meat Drop: +30, Last Available: "2015-08"
@@ -8391,9 +8391,9 @@
 8517	gray careful SMOOCH bracers of dire peril	0		Weapon Damage: +20, Monster Level: -10, Single Equip, Last Available: "2015-08"
 8518	smelly SMOOCH kneepads	0		Stench Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8519	teal SMOOCH spaulders of the cougar	0		Moxie: +20, Single Equip, Last Available: "2015-08"
-8520	extremely unsafe SMOOCH codpiece of Flo-Jo	0		Weapon Damage Percent: +100, Initiative: +100, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	extremely unsafe SMOOCH codpiece of Flo-Jo	0		Weapon Damage Percent: +100, Initiative: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	censurious SMOOCH breastplate	0		Sleaze Resistance: +3, Last Available: "2015-08"
-8522	teal spinning superduperheated	0		Last Available: "2015-08"
+8522	spinning teal superduperheated	0		Last Available: "2015-08"
 8523	spinning fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
 8525	spoiled gray tumbling lava cake	4	crappy	Last Available: "2015-08"
@@ -8416,11 +8416,11 @@
 8543	toothsome fusillocybin	4	awesome	
 8544	adequate bouncing prescription noodles	3	good	
 8545	pickled blood-drive sticker	1	good	
-8546	vacuum-sealed olive pulsating bag of grain	0		Effect: "Petit Forbearance", Effect Duration: 45
+8546	vacuum-sealed pulsating olive bag of grain	0		Effect: "Petit Forbearance", Effect Duration: 45
 8547	chilled galvanized pocket maze	0		Effect: "Highland Sheen", Effect Duration: 50
 8548	diffused wobbly shady shades	0		Effect: "Red-Shirted Escort", Effect Duration: 19
 8549	corrupted polarized wobbly squeaky toy rose	0		Effect: "Eyes All Black", Effect Duration: 38
-8550	fancy big bland tumbling maroon weird gazelle steak	5	decent	Effect: "Preemptive Medicine", Effect Duration: 30
+8550	fancy bland big maroon tumbling weird gazelle steak	5	decent	Effect: "Preemptive Medicine", Effect Duration: 30
 8551	bland massive upside-down sausage without a cause	6	decent	
 8552	moist face paint	0		Effect: "Feet of Watermelon", Effect Duration: 21
 8553	drinkable irresponsibly strong emergency margarita	8	good	
@@ -8429,22 +8429,22 @@
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	polarized polarized diffused Wickers bar	0		Effect: "Stop the Presses!", Effect Duration: 28
-8559	wet bouncing red bakelite-covered bacon	0		Effect: "Chari Tea", Effect Duration: 57
+8559	wet red bouncing bakelite-covered bacon	0		Effect: "Chari Tea", Effect Duration: 57
 8560	double-colloidal shaking Aerheads	0		Effect: "Down With Chow", Effect Duration: 63
 8561	energized super-electrified alkaline Wrotz	0		Effect: "Gleaming White Teeth", Effect Duration: 49
-8562	corrupted moist shaking jittery Gabarbar	0		Effect: "Banono", Effect Duration: 66
+8562	corrupted moist jittery shaking Gabarbar	0		Effect: "Banono", Effect Duration: 66
 8563	quadruple-liquefied fiberglass insulation	0		Effect: "Libra Rising", Effect Duration: 57
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	shaking up-at-dawn dog trainer's smooth barrel lid	0		Moxie: +15, Experience (familiar): +1, Adventures: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	teal greasy supercharged rosy-cheeked barrel hoop earring	0		Maximum HP Percent: +30, Maximum MP Percent: +30, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	prompt lightning-fast bankruptcy barrel of bravery	0		Spooky Resistance: +5, Initiative: +40, Adventures: +3, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	prompt lightning-fast bankruptcy barrel of bravery	0		Spooky Resistance: +5, Initiative: +40, Adventures: +3, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	weathered barrel	0		Last Available: "2015-09"
 8572	squat barrel	0		Last Available: "2015-09"
 8573	ghostly barrel	0		Last Available: "2015-09"
-8574	cyan squat moist barrel	0		Last Available: "2015-09"
+8574	squat cyan moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	twirling barnacled barrel	0		Last Available: "2015-09"
@@ -8452,14 +8452,14 @@
 8579	lousy barrel-aged martini	4	decent	Last Available: "2015-09"
 8580	normal snack-sized barrel pickle	2	good	Last Available: "2015-09"
 8581	moldy barrel cracker	4	crappy	Last Available: "2015-09"
-8582	denatured jittery blinking vibrating mushroom	1	EPIC	Effect: "Extra-Wet", Effect Duration: 45, Last Available: "2015-09"
-8583	powdered upside-down ghostly mushroom	1	EPIC	Last Available: "2015-09"
+8582	denatured blinking jittery vibrating mushroom	1	EPIC	Effect: "Extra-Wet", Effect Duration: 45, Last Available: "2015-09"
+8583	powdered ghostly upside-down mushroom	1	EPIC	Last Available: "2015-09"
 8584	sharpshooter's KoL Con 12-gauge	0		Critical Hit Percent: +10, Last Available: "2015-09"
 8585	teal Golden Mr. Eh? of extreme caution	0		Monster Level: -25, Last Available: "2015-09"
 8586	green aromatic barrel gun	0		Stench Resistance: +1, Last Available: "2015-09"
 8587	twirling barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	rotten half-sized water log	2	crappy	Last Available: "2015-09"
+8589	half-sized rotten water log	2	crappy	Last Available: "2015-09"
 8590	cool barrelhead of the businessman	0		Moxie: +5, Meat Drop: +50, Last Available: "2015-09"
 8591	blurry knitted slick bottoms of the barrel	0		Moxie: +10, Cold Resistance: +3, Last Available: "2015-09"
 8592	reassuring wizardly chest barrel	0		Mysticality: +25, Spooky Resistance: +1, Last Available: "2015-09"
@@ -8472,13 +8472,13 @@
 8599	map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
 8601	colloidal spinning cuppa Flamibili tea	0		Effect: "Very Clean Guns", Effect Duration: 22, Last Available: "2015-09"
-8602	enhanced maroon wobbly cuppa Yet tea	0		Effect: "Expert Vacationer", Effect Duration: 34, Last Available: "2015-09"
+8602	enhanced wobbly maroon cuppa Yet tea	0		Effect: "Expert Vacationer", Effect Duration: 34, Last Available: "2015-09"
 8603	modified corrupted dry cuppa Boo tea	0		Effect: "Billiards Belligerence", Effect Duration: 19, Last Available: "2015-09"
 8604	galvanized cuppa Nas tea	0		Effect: "Stregngth of the Gnome", Effect Duration: 21, Last Available: "2015-09"
 8605	colloidal corrupted cuppa Improprie tea	0		Effect: "Muddled", Effect Duration: 56, Last Available: "2015-09"
 8606	corrupted wet cuppa Frost tea	0		Effect: "Heart of Yellow", Effect Duration: 37, Last Available: "2015-09"
 8607	polymerized spinning cuppa Toast tea	0		Effect: "Cold as Ice", Effect Duration: 24, Last Available: "2015-09"
-8608	aerosolized purple pulsating cuppa Net tea	0		Effect: "Gutterminded", Effect Duration: 54, Last Available: "2015-09"
+8608	aerosolized pulsating purple cuppa Net tea	0		Effect: "Gutterminded", Effect Duration: 54, Last Available: "2015-09"
 8609	ionized cuppa Proprie tea	0		Effect: "Armored Innards", Effect Duration: 36, Last Available: "2015-09"
 8610	non-quantum squat cuppa Morbidi tea	0		Effect: "Barking Mad", Effect Duration: 12, Last Available: "2015-09"
 8611	wet chilled super-chilled cuppa Chari tea	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 15, Last Available: "2015-09"
@@ -8486,7 +8486,7 @@
 8613	corrupted spinning cuppa Feroci tea	0		Effect: "Gobliny Flavor", Effect Duration: 65, Last Available: "2015-09"
 8614	deionized extra-aerosolized cuppa Physicali tea	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 18, Last Available: "2015-09"
 8615	non-magnetized electrified super-pickled jittery cuppa Wit tea	0		Effect: "Carol of the Bones", Effect Duration: 43, Last Available: "2015-09"
-8616	enhanced ghostly lime green cuppa Neuroplastici tea	0		Effect: "Headstrong", Effect Duration: 67, Last Available: "2015-09"
+8616	enhanced lime green ghostly cuppa Neuroplastici tea	0		Effect: "Headstrong", Effect Duration: 67, Last Available: "2015-09"
 8617	warmed bouncing cuppa Dexteri tea	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 48, Last Available: "2015-09"
 8618	double-enhanced cuppa Flexibili tea	0		Effect: "Sausage Festive", Effect Duration: 57, Last Available: "2015-09"
 8619	nitrogenated bouncing shaking cuppa Impregnabili tea	0		Effect: "Human-Pirate Hybrid", Effect Duration: 42, Last Available: "2015-09"
@@ -8499,7 +8499,7 @@
 8626	warmed ionized shaking cuppa Alacri tea	0		Effect: "Spore-Wreathed", Effect Duration: 36, Last Available: "2015-09"
 8627	chilled lime green cuppa Vitali tea	0		Effect: "Hobo Flavor", Effect Duration: 51, Last Available: "2015-09"
 8628	frozen cuppa Mana tea	0		Effect: "Took Eleven", Effect Duration: 52, Last Available: "2015-09"
-8629	anodized pickled purple upside-down upside-down cuppa Monstrosi tea	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 32, Last Available: "2015-09"
+8629	anodized pickled upside-down purple upside-down cuppa Monstrosi tea	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 32, Last Available: "2015-09"
 8630	non-vacuum-sealed wobbly cuppa Twen tea	0		Effect: "Engorged Weapon", Effect Duration: 31, Last Available: "2015-09"
 8631	polymerized mirror cuppa Gill tea	0		Effect: "Hella Tough", Effect Duration: 36, Last Available: "2015-09"
 8632	polarized chilled cuppa Uncertain tea	0		Effect: "On Pins and Needles", Effect Duration: 55, Last Available: "2015-09"
@@ -8512,10 +8512,10 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	toothsome blue bowl of eyeballs	4	awesome	Last Available: "2015-10"
-8642	delicious half-sized bowl of mummy guts	2	awesome	Last Available: "2015-10"
+8642	half-sized delicious bowl of mummy guts	2	awesome	Last Available: "2015-10"
 8643	adequate big upside-down bowl of maggots	5	good	Last Available: "2015-10"
-8644	watered-down mediocre squat teal blood and blood	2	decent	Last Available: "2015-10"
-8645	artisanal watered-down Jack-O-Lantern beer	2	EPIC	Last Available: "2015-10"
+8644	watered-down mediocre teal squat blood and blood	2	decent	Last Available: "2015-10"
+8645	watered-down artisanal Jack-O-Lantern beer	2	EPIC	Last Available: "2015-10"
 8646	mediocre zombie	4	decent	Last Available: "2015-10"
 8647	spinning spinning Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	squat wind-up spider	0		Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	spinning stink-penny	0		
 8654	narrow perfumed dog trainer's careful hawk	0		Monster Level: -10, Experience (familiar): +1, Stench Resistance: +5
-8655	immense special stale purple hamlet sandwich	9	decent	Effect: "Chain Chain Chains", Effect Duration: 50
+8655	stale immense special purple hamlet sandwich	9	decent	Effect: "Chain Chain Chains", Effect Duration: 50
 8656	Othello's military jacket of temperance	0		Sleaze Resistance: +5
 8657	Othello's dagger of bravery	0		Spooky Resistance: +5, Single Equip
 8658	blurry wizardly Othello's handkerchief	0		Mysticality: +25, Single Equip
@@ -8546,7 +8546,7 @@
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	mirror airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	tarnished cold-filtered magnetized yellow shaking shoulder-warming lotion	0		Effect: "Elbow Sauce", Effect Duration: 52, Last Available: "2015-11"
+8676	tarnished cold-filtered magnetized shaking yellow shoulder-warming lotion	0		Effect: "Elbow Sauce", Effect Duration: 52, Last Available: "2015-11"
 8677	decent iceberg lettuce	4	good	Last Available: "2015-11"
 8678	watered-down bad ice wine	2	decent	Last Available: "2015-11"
 8679	flame-retardant mansplainer's Wal-Mart snowglobe of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +15, Hot Resistance: +1, Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	wobbly perfect ice cube	0		Last Available: "2015-11"
 8687	huge The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	twirling executive bellhop's hat	0		Meat Drop: +40, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	tolerable practically non-alcoholic skewed ice porter	1	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	twirling executive bellhop's hat	0		Meat Drop: +40, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	practically non-alcoholic tolerable skewed ice porter	1	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	electrified flattened olive exotic travel brochure	0		Effect: "Pisces Rising", Effect Duration: 22, Last Available: "2015-11"
 8691	skewed bag of foreign bribes	0		Last Available: "2015-11"
 8692	pressed mirror shampoo-conditioner	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 36, Last Available: "2015-11"
@@ -8571,7 +8571,7 @@
 8698	lousy triple-distilled iced plum wine	9	decent	Last Available: "2016-01"
 8699	mansplainer's experienced sage training belt	0		Mysticality Percent: +10, Experience: +2, Monster Level: +15, Single Equip, Last Available: "2016-01"
 8700	maroon auspicious educational training legwarmers of wisdom	0		Mysticality: +15, Experience: +1, Item Drop: +10, Single Equip, Last Available: "2016-01"
-8701	groovy slick strapping training helmet	0		Muscle: +5, Moxie: +10, Moxie Percent: +10, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	groovy slick strapping training helmet	0		Muscle: +5, Moxie: +10, Moxie Percent: +10, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	upside-down training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8601,15 +8601,15 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	greasy energetic boxer's VYKEA hex key	0		Muscle Percent: +10, Maximum MP Percent: +20, Sleaze Spell Damage: +10, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	flavorless big shaking cyan tin of submardines	5	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	big flavorless shaking cyan tin of submardines	5	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	acceptable fuchsia bottle of norwhiskey	4	good	Last Available: "2015-11"
 8733	boiled gray octolus oculus	1	awesome	Last Available: "2015-11"
 8734	mirror auspicious smartaleck's sardine can key of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Item Drop: +10, Last Available: "2015-11"
-8735	mirror lightning-fast frightening rock-hard norwhal helmet	0		Damage Reduction: 5, Spooky Damage: +5, Initiative: +40, Familiar Effect: "atk", Last Available: "2015-11"
+8735	mirror lightning-fast frightening rock-hard norwhal helmet	0		Damage Reduction: 5, Spooky Damage: +5, Initiative: +40, Last Available: "2015-11", Familiar Effect: "atk"
 8736	ghostly Temple Grandin's octolus-skin cloak of the dark arts of the sewer	0		Spell Damage Percent: +100, Familiar Weight: +7, Stench Damage: +25, Last Available: "2015-11"
 8737	watered-down drinkable bouncing perfect cosmopolitan	2	good	Last Available: "2015-11"
 8738	practically non-alcoholic mediocre perfect negroni	1	decent	Last Available: "2015-11"
-8739	special delicious perfect dark and stormy	4	awesome	Effect: "Ghost Finger", Effect Duration: 20, Last Available: "2015-11"
+8739	delicious special perfect dark and stormy	4	awesome	Effect: "Ghost Finger", Effect Duration: 20, Last Available: "2015-11"
 8740	smooth weak perfect mimosa	2	awesome	Last Available: "2015-11"
 8741	weak hand-crafted perfect old-fashioned	2	super ultra EPIC	Last Available: "2015-11"
 8742	mediocre watered-down perfect paloma	2	decent	Last Available: "2015-11"
@@ -8622,7 +8622,7 @@
 8749	energized magnetized Deep Machine Tunnels snowglobe	0		Effect: "Sugar, Hello", Effect Duration: 55, Last Available: "2015-12"
 8750	polymerized hemp candy necklace	0		Effect: "The Solution", Effect Duration: 38, Last Available: "2015-12"
 8751	enhanced ghostly twirling communal gobstopper	0		Effect: "Fishy Fortification", Effect Duration: 23, Last Available: "2015-12"
-8752	small moldy cyan Crimbo salad	2	crappy	Last Available: "2015-12"
+8752	moldy small cyan Crimbo salad	2	crappy	Last Available: "2015-12"
 8753	half-sized spoiled bread line	2	crappy	Last Available: "2015-12"
 8754	lousy bark rootbeer	4	decent	Last Available: "2015-12"
 8755	hand-crafted narrow ale	3	EPIC	Last Available: "2015-12"
@@ -8687,7 +8687,7 @@
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	yummy Kudzu salad	3	awesome	Last Available: "2016-12"
 8817	powdered gray Mansquito Serum	1		Last Available: "2016-12"
-8818	acceptable weak Miss Graves' vermouth	2	good	Last Available: "2016-12"
+8818	weak acceptable Miss Graves' vermouth	2	good	Last Available: "2016-12"
 8819	moldy The Plumber's mushroom stew	4	crappy	Last Available: "2016-12"
 8820	denatured The Author's ink	1		Last Available: "2016-02"
 8821	smooth The Mad Liquor	3	awesome	Last Available: "2016-12"
@@ -8695,20 +8695,20 @@
 8823	stale Mr. Burnsger	4	decent	Last Available: "2016-12"
 8824	diluted upside-down shaking The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	blurry Socratic weightlifter's The Jokester's gun of dire peril	0		Muscle: +15, Experience (Mysticality): +1, Weapon Damage: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	prompt banded The Jokester's wig of the early riser	0		Damage Absorption: +100, Adventures: 10, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8826	prompt banded The Jokester's wig of the early riser	0		Damage Absorption: +100, Adventures: 10, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
 8827	baleful Da Vinci's The Jokester's pants of the sewer	0		Experience (Mysticality): +5, Spell Damage: +25, Stench Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	non-corrupted Jokester makeup	0		Effect: "Nut-Rition", Effect Duration: 15, Last Available: "2016-12"
 8829	narrow replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	upside-down huge basking robin	0		Free Pull, Last Available: "2016-12"
-8832	blurry cyan domino mask	0		Familiar Weight: +5
+8832	cyan blurry domino mask	0		Familiar Weight: +5
 8833	aerosolized mirror robin's egg	0		Effect: "Ack!  Barred!", Effect Duration: 55, Last Available: "2016-12"
 8834	bland robin flan	3	decent	Last Available: "2016-12"
 8835	tolerable robin nog	4	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
-8839	gray pulsating root beer barrel	0		
+8839	pulsating gray root beer barrel	0		
 8840	diffused Kudzu slaw	0		Effect: "Stone-Faced", Effect Duration: 68
 8841	triple-diffused upside-down huge Mansquito's blood	0		Effect: "Liquidy Smoky", Effect Duration: 28
 8842	wet polymerized pulsating olive infrablack lipstick	0		Effect: "Hyperoffended", Effect Duration: 61
@@ -8748,7 +8748,7 @@
 8876	bland plate of Heimz Fortified Kidney Beans	4	decent	Last Available: "2016-02"
 8877	delicious plate of Tesla's Electroplated Beans	3	awesome	Last Available: "2016-02"
 8878	rotten plate of Mixed Garbanzos and Chickpeas	3	crappy	Last Available: "2016-02"
-8879	bland fancy ghostly plate of Hellfire Spicy Beans	4	decent	Effect: "Astral Shell", Effect Duration: 45, Last Available: "2016-02"
+8879	fancy bland ghostly plate of Hellfire Spicy Beans	4	decent	Effect: "Astral Shell", Effect Duration: 45, Last Available: "2016-02"
 8880	bland special twirling plate of Frigid Northern Beans	4	decent	Effect: "Antibiotic Saucesphere", Effect Duration: 10, Last Available: "2016-02"
 8881	tasty tumbling plate of World's Blackest-Eyed Peas	4	awesome	Last Available: "2016-02"
 8882	stale plate of Trader Olaf's Exotic Stinkbeans	4	decent	Last Available: "2016-02"
@@ -8756,9 +8756,9 @@
 8884	normal plate of Val-U Brand Every Bean Salad	4	good	Last Available: "2016-02"
 8885	spoiled jumbo blinking plate of Shrub's Premium Baked Beans	5	crappy	Last Available: "2016-02"
 8886	spinning banded Fancy Jeff's pocket square of vim and vigor	0		Damage Absorption: +100, Maximum HP Percent: +50, Last Available: "2016-02"
-8887	shaking rock-hard fortified Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, Damage Reduction: 5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	shaking rock-hard fortified Daisy's unclean bloomers of dire peril	0		Weapon Damage: +20, Damage Absorption: +60, Damage Reduction: 5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	teal Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	narrow nasty ruddy Amoon-Ra Cowtep's nemes of bravery	0		Maximum HP Percent: +40, Stench Damage: +5, Spooky Resistance: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	narrow nasty ruddy Amoon-Ra Cowtep's nemes of bravery	0		Maximum HP Percent: +40, Stench Damage: +5, Spooky Resistance: +5, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	aromatic frosty veiny cool Former Sheriff Dan's tin star of the wise owl	0		Mysticality: +20, Moxie: +5, Maximum HP: +10, Cold Spell Damage: +10, Stench Resistance: +1, Last Available: "2016-02"
 8892	wobbly El Vibrato restraints	0		Last Available: "2016-02"
@@ -8779,7 +8779,7 @@
 8907	Vulcanized concentrated anodized half-digested coal	0		Effect: "Salad Days", Effect Duration: 54, Last Available: "2016-02"
 8908	deionized tightly-wound spine	0		Effect: "Tomato Power", Effect Duration: 24, Last Available: "2016-02"
 8909	miniature adequate rotting beefsteak	2	good	Last Available: "2016-02"
-8910	watered-down hand-crafted bouncing red firemilk	2	EPIC	Last Available: "2016-02"
+8910	hand-crafted watered-down bouncing red firemilk	2	EPIC	Last Available: "2016-02"
 8911	liquefied shaking spidercow eye-cluster	0		Effect: "Square to be Hip", Effect Duration: 59, Last Available: "2016-02"
 8912	denatured moomy dust	1		Effect: "Marco Polarity", Effect Duration: 5, Last Available: "2016-02"
 8913	pulsating frosty Lo Pan's western-style skinning knife	0		Spell Critical Percent: +30, Cold Spell Damage: +10, Last Available: "2016-02"
@@ -8803,8 +8803,8 @@
 8931	twirling rinky-dink sixgun	0		Last Available: "2016-02"
 8932	tumbling makeshift sixgun	0		Last Available: "2016-02"
 8933	blinking custom sixgun	0		Last Available: "2016-02"
-8934	purple spinning baconstone-handled sixgun	0		Last Available: "2016-02"
-8935	squat teal porquoise-handled sixgun	0		Last Available: "2016-02"
+8934	spinning purple baconstone-handled sixgun	0		Last Available: "2016-02"
+8935	teal squat porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	tumbling mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
@@ -8862,23 +8862,23 @@
 8990	mirror electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	powdered ghostly armored prawn	1		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 35, Last Available: "2016-03"
-8993	special flavorless jumping horseradish	3	decent	Effect: "Crimbo Flavor", Effect Duration: 30, Last Available: "2016-03"
+8993	flavorless special jumping horseradish	3	decent	Effect: "Crimbo Flavor", Effect Duration: 30, Last Available: "2016-03"
 8994	boozy tolerable Sacramento wine	5	good	Last Available: "2016-03"
 8995	flattened skewed Greek fire	0		Effect: "Bolts about Candy", Effect Duration: 50, Last Available: "2016-03"
 8996	chaotic Annie Oakley's deadly Rosewater's ox-head shield of the brute	0		Muscle Percent: +30, Mysticality Percent: +30, Weapon Damage: +5, Critical Hit Percent: +20, Spell Critical Percent: +10, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	ruddy wholesome shellacked stylish dented scepter of the scaredy-cat	0		Moxie: +25, Damage Reduction: 7, Maximum HP Percent: 50, Monster Level: -15, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	wobbly foul-smelling coward's hardened Socratic very pointy crown of Flo-Jo	0		Experience (Mysticality): +1, Damage Reduction: 3, Monster Level: -20, Stench Damage: +10, Initiative: +100, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	wobbly foul-smelling coward's hardened Socratic very pointy crown of Flo-Jo	0		Experience (Mysticality): +1, Damage Reduction: 3, Monster Level: -20, Stench Damage: +10, Initiative: +100, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	scandalous Lo Pan's dangerous experienced battle broom of the scaredy-cat	0		Experience: +2, Weapon Damage: +10, Spell Critical Percent: +30, Monster Level: -15, Sleaze Damage: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	squat censurious horrifying frightening razor-sharp carpe	0		Weapon Damage Percent: +25, Spooky Damage: 30, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9002	inspector's reassuring mansplainer's beefy codpiece	0		Muscle: +10, Monster Level: +15, Spooky Resistance: +1, Item Drop: +15, Lasts Until Rollover, Last Available: "2016-04"
-9003	scorching electrified troutsers of incineration of doom	0		Hot Damage: +25, Hot Spell Damage: +50, Spooky Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	scorching electrified troutsers of incineration of doom	0		Hot Damage: +25, Hot Spell Damage: +50, Spooky Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	therapeutic curative bass clarinet of the dark arts of Gandalf	0		Spell Damage Percent: +100, Spell Critical Percent: +20, HP Regen Min: 8, HP Regen Max: 12, Lasts Until Rollover, Last Available: "2016-04"
 9005	ribald vibrating slick brainy fish hatchet	0		Mysticality: +5, Moxie: +10, Maximum MP Percent: +10, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	thinker's tunac of Tarzan of the overflowing toilet of temperance	0		Mysticality: +10, Experience (Muscle): +3, Stench Spell Damage: +50, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9007	skewed red fishin' pole	0		Last Available: "2016-04"
+9007	red skewed fishin' pole	0		Last Available: "2016-04"
 9008	flattened wriggling worm	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 32, Last Available: "2016-04"
-9009	lousy practically non-alcoholic ghostly bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
+9009	practically non-alcoholic lousy ghostly bottle of Fishhead 900-Day IPA	1	decent	Last Available: "2016-04"
 9010	pressed high-test fishing line	0		Effect: "The Strength...  of the Future", Effect Duration: 12, Last Available: "2016-04"
 9011	skewed mansplainer's fishin' hat	0		Monster Level: +15, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	teal internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	snack-sized normal gallon of milk	2	good	Last Available: "2016-05"
+9021	normal snack-sized gallon of milk	2	good	Last Available: "2016-05"
 9022	squat print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	mirror daily dungeon malware	0		Last Available: "2016-05"
@@ -8899,7 +8899,7 @@
 9027	gray aromatic reassuring Van der Graaf First Post shirt - Cir Senam	0		Spooky Resistance: +1, Stench Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	rotten special mirror star salad	4	crappy	Effect: "Oiled Skin", Effect Duration: 20
+9030	special rotten mirror star salad	4	crappy	Effect: "Oiled Skin", Effect Duration: 20
 9031	purple Thwaitgold moth statuette	0		
 9032	super-sized toothsome bowl of Tastee-Wheet&trade;	5	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
@@ -8924,7 +8924,7 @@
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	Source terminal file: protect.enq	0		Last Available: "2016-06"
-9055	cyan bouncing Source terminal file: stats.enq	0		Last Available: "2016-06"
+9055	bouncing cyan Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	spinning Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	maroon Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	ghostly Source terminal file: portscan.edu	0		Last Available: "2016-06"
@@ -8936,7 +8936,7 @@
 9064	wobbly cyan Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	skewed Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
-9067	mirror ghostly pill	0		Last Available: "2016-06"
+9067	ghostly mirror pill	0		Last Available: "2016-06"
 9068	auspicious MacGyver's therapeutic plastic detective badge of the dark arts	0		Spell Damage Percent: +100, Maximum MP: +100, Item Drop: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-07"
 9069	squat sizzling sharpshooter's ruddy bronze detective badge of the brazier	0		Maximum HP Percent: +40, Critical Hit Percent: +10, Hot Damage: +10, Hot Spell Damage: +25, Last Available: "2016-07"
 9070	double-paned Jim Carey's supercool detective badge of the businessman	0		Moxie Percent: +20, Monster Level: +25, Cold Resistance: +5, Meat Drop: +50, Last Available: "2016-07"
@@ -8947,7 +8947,7 @@
 9075	triple-energized corrupted fuchsia shoe gum	0		Effect: "Dirty Pear", Effect Duration: 47, Last Available: "2016-07"
 9076	wobbly chaotic grievous savvy noir fedora	0		Mysticality Percent: +20, Weapon Damage Percent: +50, Spell Critical Percent: +10, Last Available: "2016-07"
 9077	Jeselnik's ribald horrifying trench coat	0		Spooky Damage: +25, Sleaze Damage: 35, Last Available: "2016-07"
-9078	tolerable practically non-alcoholic Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
+9078	practically non-alcoholic tolerable Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
 9079	toothsome hardboiled egg	3	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	tumbling DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	tumbling asbestos-lined Mr. Screege's spectacles	0		Hot Resistance: +5, Single Equip, Last Available: "2016-08"
 9092	jittery reassuring Temple Grandin's hale Spookyraven signet	0		Maximum HP: +20, Familiar Weight: +7, Spooky Resistance: +1, Single Equip, Last Available: "2016-08"
 9093	Annie Oakley's beefy tie-dyed fannypack	0		Muscle: +10, Critical Hit Percent: +20, Single Equip, Last Available: "2016-08"
-9094	friendly thinker's burnt snowpants	0		Mysticality: +10, Familiar Weight: +3, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	friendly thinker's burnt snowpants	0		Mysticality: +10, Familiar Weight: +3, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	blurry wizardly standards and practices guide	0		Mysticality: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	Annie Oakley's strapping Carpathian longsword of Gandalf	0		Muscle: +5, Critical Hit Percent: +20, Spell Critical Percent: +20, Last Available: "2016-08"
 9097	blurry knitted ruddy Liam's mail of the pedagogue	0		Experience: +3, Maximum HP Percent: +40, Cold Resistance: +3, Last Available: "2016-08"
@@ -8978,7 +8978,7 @@
 9106	blurry Rad-B-Gone (1 lb.)	0		
 9107	ionized Rad-Pro (1 oz.)	0		Effect: "Shawarma Initiative", Effect Duration: 69
 9108	tumbling lead umbrella	0		
-9109	galvanized pickled red huge Shrieking Weasel holo-record	0		Effect: "Chorale of Companionship", Effect Duration: 17
+9109	galvanized pickled huge red Shrieking Weasel holo-record	0		Effect: "Chorale of Companionship", Effect Duration: 17
 9110	wet flattened Power-Guy 2000 holo-record	0		Effect: "OMG WTF", Effect Duration: 51
 9111	polarized quantum Lucky Strikes holo-record	0		Effect: "Big", Effect Duration: 58
 9112	improved EMD holo-record	0		Effect: "Hood Ridin'", Effect Duration: 58
@@ -9002,38 +9002,38 @@
 9130	galvanized charisma potion	0		Effect: "Christmessy", Effect Duration: 59
 9131	narrow extremely confusing manual	0		
 9132	huge fuchsia squat scandalous gravedigger's pistol	0		Spooky Damage: +10, Sleaze Damage: +5
-9133	jittery skewed twirling KoL Con 13 snowglobe	0		Last Available: "2016-10"
+9133	jittery twirling skewed KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	rotten leftover pasty	3	crappy	
 9135	high-proof bad very whiskey	9	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	ghostly li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	twirling li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	ghostly li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	twirling li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	oxidized hoarded candy wad	0		Effect: "Prideful Strut", Effect Duration: 28, Last Available: "2016-10"
 9147	colloidal non-improved altered Prunets	0		Effect: "Spooky Jellied", Effect Duration: 42
 9148	tumbling Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
-9150	warmed tumbling blinking invisible string	0		Lasts Until Rollover, Effect: "Space Tripping", Effect Duration: 58, Last Available: "2016-10"
+9150	warmed blinking tumbling invisible string	0		Lasts Until Rollover, Effect: "Space Tripping", Effect Duration: 58, Last Available: "2016-10"
 9151	deionized invisible seam ripper	0		Lasts Until Rollover, Effect: "Impregnably Delicious", Effect Duration: 54, Last Available: "2016-10"
-9152	fuchsia li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	fuchsia li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	stale half-sized raw sweet potato	2	decent	Last Available: "2016-11"
 9154	flavorless raw beans	3	decent	Last Available: "2016-11"
 9155	decent raw stuffing	4	good	Last Available: "2016-11"
 9156	normal raw cranberry sauce	4	good	Last Available: "2016-11"
 9157	moldy raw turkey	3	crappy	Last Available: "2016-11"
 9158	spoiled raw mincemeat	3	crappy	Last Available: "2016-11"
-9159	jumbo flavorless raw potato	5	decent	Last Available: "2016-11"
-9160	adequate thick raw gravy	5	good	Last Available: "2016-11"
+9159	flavorless jumbo raw potato	5	decent	Last Available: "2016-11"
+9160	thick adequate raw gravy	5	good	Last Available: "2016-11"
 9161	tasty raw bread	3	awesome	Last Available: "2016-11"
 9162	skewed vibrating mini-marshmallow dispenser of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +10, Last Available: "2016-11"
 9163	friendly Oprah's glass casserole dish of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Familiar Weight: +3, Last Available: "2016-11"
-9164	tumbling gray stuffing fluffer	0		Last Available: "2016-11"
+9164	gray tumbling stuffing fluffer	0		Last Available: "2016-11"
 9165	coward's can opener of the glutton	0		Monster Level: -20, Food Drop: +100, Last Available: "2016-11"
 9166	distilled turkey blaster	1		Last Available: "2016-11"
 9167	rosewater-soaked therapeutic glass pie plate	0		Stench Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 7, Last Available: "2016-11"
@@ -9047,7 +9047,7 @@
 9175	small flavorless skewed thanksgiving turkey	2	decent	Last Available: "2016-11"
 9176	half-sized decent huge mince pie	2	good	Last Available: "2016-11"
 9177	flavorless squat mashed potatoes	4	decent	Last Available: "2016-11"
-9178	bland snack-sized warm gravy	2	decent	Last Available: "2016-11"
+9178	snack-sized bland warm gravy	2	decent	Last Available: "2016-11"
 9179	flavorless maroon bread roll	4	decent	Last Available: "2016-11"
 9180	spoiled half-sized leftovers	2	crappy	Last Available: "2016-11"
 9181	normal thick leftovers sandwich	5	good	Last Available: "2016-11"
@@ -9061,14 +9061,14 @@
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	non-vacuum-sealed quadruple-corrupted ghostly eldritch concentrate	0		Effect: "Mushroom Magicalness", Effect Duration: 61, Last Available: "2016-11"
-9192	lousy fortified blinking eldritch extract	5	decent	Last Available: "2016-11"
+9192	fortified lousy blinking eldritch extract	5	decent	Last Available: "2016-11"
 9193	shaking tumbling lard-coated ruddy Official Council Aide Pin	0		Maximum HP Percent: +40, Sleaze Spell Damage: +25, Last Available: "2016-11"
-9194	weak drinkable eldritch distillate	2	good	Last Available: "2016-11"
-9195	pickled mirror tumbling blue eldritch essence	1		Last Available: "2016-11"
+9194	drinkable weak eldritch distillate	2	good	Last Available: "2016-11"
+9195	pickled tumbling mirror blue eldritch essence	1		Last Available: "2016-11"
 9196	smelly Science Notebook	0		Stench Spell Damage: +10
 9197	eldritch hat of Leguizamo of the overflowing toilet of the early riser	0		Monster Level: +20, Stench Spell Damage: +50, Adventures: +7, Last Available: "2016-11"
 9198	mirror ribald chaotic dangerous eldritch pants	0		Weapon Damage: +10, Spell Critical Percent: +10, Sleaze Damage: +10, Last Available: "2016-11"
-9199	acceptable watered-down olive eldritch elixir	2	good	Last Available: "2016-11"
+9199	watered-down acceptable olive eldritch elixir	2	good	Last Available: "2016-11"
 9200	fuchsia Samson's Quartet of Flare Masters Jacket of the boozehound	0		Experience (Muscle): +5, Booze Drop: +100, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9089,8 +9089,8 @@
 9217	fuchsia gingerbread restraining order	0		Last Available: "2016-12"
 9218	blurry sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	tiny bland animal part cracker	1	decent	Last Available: "2016-12"
-9220	watered-down perfectly mixed yellow shaking skewed gingerbread wine	2	EPIC	Last Available: "2016-12"
-9221	tiny flavorless spinning gingerbread mug	1	decent	Last Available: "2016-12"
+9220	perfectly mixed watered-down skewed yellow shaking gingerbread wine	2	EPIC	Last Available: "2016-12"
+9221	flavorless tiny spinning gingerbread mug	1	decent	Last Available: "2016-12"
 9222	aromatic gingerbread mask	0		Stench Resistance: +1, Last Available: "2016-12"
 9223	educational brainy gingerservo of the ox	0		Muscle: +20, Mysticality: +5, Experience: +1, Single Equip, Last Available: "2016-12"
 9224	irradiated pickled moist tainted icing	0		Effect: "Chari Tea", Effect Duration: 30, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	scandalous Da Vinci's gingerbread gavel	0		Experience (Mysticality): +5, Sleaze Damage: +5, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	practically non-alcoholic bad ginger beer	1	decent	Last Available: "2016-12"
+9239	bad practically non-alcoholic ginger beer	1	decent	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	super-activated industrial frosting	0		Effect: "Sugar Smacks", Effect Duration: 58, Last Available: "2016-12"
 9242	cold-filtered anodized ghostly fake cocktail	0		Effect: "Yet tea", Effect Duration: 63, Last Available: "2016-12"
@@ -9122,9 +9122,9 @@
 9250	super-cold-filtered magnetized double-diffused Inner Strength	0		Effect: "Your Favorite Flavor", Effect Duration: 57, Last Available: "2016-12"
 9251	liquefied polarized fuchsia Inner Truth	0		Effect: "Eau de Tortue", Effect Duration: 42, Last Available: "2016-12"
 9252	decent spiritual candy cane	3	good	Last Available: "2016-12"
-9253	acceptable practically non-alcoholic spiritual eggnog	1	good	Last Available: "2016-12"
+9253	practically non-alcoholic acceptable spiritual eggnog	1	good	Last Available: "2016-12"
 9254	decent spiritual fruitcake	3	good	Last Available: "2016-12"
-9255	toothsome half-sized spiritual gingerbread	2	awesome	Last Available: "2016-12"
+9255	half-sized toothsome spiritual gingerbread	2	awesome	Last Available: "2016-12"
 9256	wobbly chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	upside-down bouncing huge My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9147,8 +9147,8 @@
 9275	delicious red hambrosier	3	awesome	Last Available: "2016-12"
 9276	lousy chakra-mental wine	4	decent	Last Available: "2016-12"
 9277	irradiated cold-filtered blurry chakra malt	0		Effect: "Abyssal Tears", Effect Duration: 68, Last Available: "2016-12"
-9278	tasty super-sized special Black Angus blackburger	5	awesome	Effect: "Briny Blood", Effect Duration: 10, Last Available: "2016-12"
-9279	acceptable practically non-alcoholic special upside-down lime green brandy	1	good	Effect: "Orc Chops", Effect Duration: 45, Last Available: "2016-12"
+9278	super-sized special tasty Black Angus blackburger	5	awesome	Effect: "Briny Blood", Effect Duration: 10, Last Available: "2016-12"
+9279	special practically non-alcoholic acceptable upside-down lime green brandy	1	good	Effect: "Orc Chops", Effect Duration: 45, Last Available: "2016-12"
 9280	triple-cold-filtered corrupted skewed potion of spiritual gunkifying	0		Effect: "Chari Tea", Effect Duration: 35, Last Available: "2016-12"
 9281	pulsating cyan miser's occult bad vibroknife	0		Spell Damage Percent: +25, Meat Drop: +10, Last Available: "2016-12"
 9282	narrow Newton's crystal belt buckle of dire peril	0		Experience (Mysticality): +3, Weapon Damage: +20, Last Available: "2016-12"
@@ -9160,7 +9160,7 @@
 9288	gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	inspector's scandalous Uncle Crimbo's hat of extreme caution	0		Monster Level: -25, Sleaze Damage: +5, Item Drop: +15, Last Available: "2016-12"
 9290	adequate half-sized Eldritch snap	2	good	Last Available: "2017-01"
-9291	powdered twirling fuchsia hot jelly	1		Last Available: "2017-01"
+9291	powdered fuchsia twirling hot jelly	1		Last Available: "2017-01"
 9292	distilled huge jelly	1		Effect: "Scrappy, Shadowy", Effect Duration: 45, Last Available: "2017-01"
 9293	dried lime green jelly	1		Effect: "Fiery Spirit", Effect Duration: 45, Last Available: "2017-01"
 9294	dehydrated lime green sleaze jelly	1		Last Available: "2017-01"
@@ -9180,14 +9180,14 @@
 9308	Oprah's brainy wax face	0		Mysticality: +5, Maximum MP Percent: +50, Last Available: "2017-01"
 9309	mediocre wax booze	4	decent	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
-9311	diluted bouncing mirror sea jelly	1		Last Available: "2017-01"
+9311	diluted mirror bouncing sea jelly	1		Last Available: "2017-01"
 9312	moldy sea truffle	3	crappy	Last Available: "2017-01"
 9313	tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	wobbly avaricious recovered cufflinks	0		Meat Drop: +30, Single Equip, Last Available: "2017-01"
 9316	spinning heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	liquefied quadruple-adjusted LOV Elixir #3	0		Effect: "Wintry Breath", Effect Duration: 21, Last Available: "2017-02"
-9318	colloidal wobbly ghostly tumbling LOV Elixir #6	0		Effect: "Bats in the Belfry", Effect Duration: 49, Last Available: "2017-02"
+9318	colloidal ghostly tumbling wobbly LOV Elixir #6	0		Effect: "Bats in the Belfry", Effect Duration: 49, Last Available: "2017-02"
 9319	enhanced enhanced ionized blurry LOV Elixir #9	0		Effect: "Ginger Snapped", Effect Duration: 30, Last Available: "2017-02"
 9320	rosewater-soaked arcane researcher's brainy LOV Eardigan	0		Mysticality: +5, Experience Percent (Mysticality): +10, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2017-02"
 9321	ghostly toasty careful LOV Epaulettes	0		Monster Level: -10, Hot Damage: +5, Item Drop: +5, Lasts Until Rollover, Last Available: "2017-02"
@@ -9195,7 +9195,7 @@
 9323	squat LOV Enamorang	0		Last Available: "2017-02"
 9324	red upside-down LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	powdered tumbling mirror LOV Echinacea Bouquet	1		Last Available: "2017-02"
+9326	powdered mirror tumbling LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	red Socratic LOV Elephant	0		Experience (Mysticality): +1, Damage Reduction: 6, Last Available: "2017-02"
 9328	fuchsia skewed ribald eldritch scanner	0		Sleaze Damage: +10, Last Available: "2017-02"
 9329	frozen anodized tumbling eldritch alignment spray	0		Effect: "Protection from Bad Stuff", Effect Duration: 60, Last Available: "2017-02"
@@ -9203,7 +9203,7 @@
 9331	occult boxer's weightlifter's eldritch hammer	0		Muscle: +15, Muscle Percent: +10, Spell Damage Percent: +25, Last Available: "2017-01"
 9332	tasty eldritch mushroom	4	awesome	Last Available: "2017-03"
 9333	bouncing eldritch ichor	0		
-9334	tasty huge eldritch mushroom pizza	8	awesome	Last Available: "2017-03"
+9334	huge tasty eldritch mushroom pizza	8	awesome	Last Available: "2017-03"
 9335	twirling eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	skewed eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	denatured eldritch rub	0		Effect: "Eyes All Black", Effect Duration: 52, Last Available: "2017-02"
@@ -9236,34 +9236,34 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	bad watered-down literal grasshopper	2	decent	Last Available: "2017-03"
 9366	lousy double entendre	3	decent	Last Available: "2017-03"
-9367	bad boozy Phlegethon	5	decent	Last Available: "2017-03"
+9367	boozy bad Phlegethon	5	decent	Last Available: "2017-03"
 9368	bad Siberian sunrise	4	decent	Last Available: "2017-03"
 9369	bad huge mentholated wine	4	decent	Last Available: "2017-03"
-9370	strong artisanal spinning low tide martini	5	EPIC	Last Available: "2017-03"
+9370	artisanal strong spinning low tide martini	5	EPIC	Last Available: "2017-03"
 9371	acceptable shroomtini	3	good	Last Available: "2017-03"
-9372	perfectly mixed practically non-alcoholic twirling morning dew	1	EPIC	Last Available: "2017-03"
+9372	practically non-alcoholic perfectly mixed twirling morning dew	1	EPIC	Last Available: "2017-03"
 9373	drinkable whiskey squeeze	3	good	Last Available: "2017-03"
 9374	practically non-alcoholic tolerable great fashioned	1	good	Last Available: "2017-03"
-9375	lousy irresponsibly strong Gnomish sagngria	6	decent	Last Available: "2017-03"
+9375	irresponsibly strong lousy Gnomish sagngria	6	decent	Last Available: "2017-03"
 9376	watered-down artisanal bouncing vodka stinger	2	EPIC	Last Available: "2017-03"
 9377	drinkable mirror extremely slippery nipple	4	good	Last Available: "2017-03"
-9378	high-proof tolerable piscatini	10	good	Last Available: "2017-03"
+9378	tolerable high-proof piscatini	10	good	Last Available: "2017-03"
 9379	fancy hand-crafted Churchill	4	EPIC	Effect: "Devil Inside", Effect Duration: 20, Last Available: "2017-03"
 9380	hand-crafted soilzerac	3	EPIC	Last Available: "2017-03"
 9381	watered-down bad wobbly London frog	2	decent	Last Available: "2017-03"
-9382	acceptable practically non-alcoholic nothingtini	1	good	Last Available: "2017-03"
+9382	practically non-alcoholic acceptable nothingtini	1	good	Last Available: "2017-03"
 9383	tolerable pulsating eighth plague	4	good	Last Available: "2017-03"
-9384	practically non-alcoholic artisanal single entendre	1	EPIC	Last Available: "2017-03"
+9384	artisanal practically non-alcoholic single entendre	1	EPIC	Last Available: "2017-03"
 9385	aged bouncing reverse Tantalus	3	awesome	Last Available: "2017-03"
 9386	delicious elemental caipiroska	4	awesome	Last Available: "2017-03"
-9387	acceptable triple-distilled Feliz Navidad	6	good	Last Available: "2017-03"
-9388	bad weak Bloody Nora	2	decent	Last Available: "2017-03"
+9387	triple-distilled acceptable Feliz Navidad	6	good	Last Available: "2017-03"
+9388	weak bad Bloody Nora	2	decent	Last Available: "2017-03"
 9389	perfectly mixed moreltini	4	EPIC	Last Available: "2017-03"
 9390	perfectly mixed purple hell in a bucket	3	EPIC	Last Available: "2017-03"
 9391	bad Newark	4	decent	Last Available: "2017-03"
 9392	irresponsibly strong hand-crafted R'lyeh	10	EPIC	Last Available: "2017-03"
 9393	perfectly mixed Gnollish sangria	4	EPIC	Last Available: "2017-03"
-9394	tolerable irresponsibly strong vodka barracuda	10	good	Last Available: "2017-03"
+9394	irresponsibly strong tolerable vodka barracuda	10	good	Last Available: "2017-03"
 9395	perfectly mixed Mysterious Island iced tea	4	EPIC	Last Available: "2017-03"
 9396	aged narrow drive-by shooting	3	awesome	Last Available: "2017-03"
 9397	smooth gunner's daughter	3	awesome	Last Available: "2017-03"
@@ -9278,7 +9278,7 @@
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	jittery rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	green gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9409	cyan shaking high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9409	shaking cyan high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	green Spacegate Research	0		Last Available: "2017-04"
 9411	gray alien rock sample	0		Last Available: "2017-04"
 9412	maroon alien gemstone	0		Last Available: "2017-04"
@@ -9301,7 +9301,7 @@
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	red murderbot data core	0		Last Available: "2017-04"
-9432	galvanized non-tarnished electrified yellow huge alien medicine	0		Effect: "Booing Radly", Effect Duration: 52, Last Available: "2017-04"
+9432	galvanized non-tarnished electrified huge yellow alien medicine	0		Effect: "Booing Radly", Effect Duration: 52, Last Available: "2017-04"
 9433	tasty alien salad	3	awesome	Last Available: "2017-04"
 9434	artisanal alien booze	3	EPIC	Last Available: "2017-04"
 9435	friendly coward's alien mask of horror	0		Monster Level: -20, Familiar Weight: +3, Spooky Spell Damage: +25, Last Available: "2017-04"
@@ -9348,11 +9348,11 @@
 9476	frozen Spant eggs	0		Effect: "Healthy Green Glow", Effect Duration: 56
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	altered denatured squat shaking Daily Affirmation: Always be Collecting	0		Effect: "Impregnably Delicious", Effect Duration: 20, Last Available: "2017-05"
+9479	altered denatured shaking squat Daily Affirmation: Always be Collecting	0		Effect: "Impregnably Delicious", Effect Duration: 20, Last Available: "2017-05"
 9480	wet super-moist Daily Affirmation: Think Win-Lose	0		Effect: "Chorale of Companionship", Effect Duration: 59, Last Available: "2017-05"
 9481	wet mirror Daily Affirmation: Be Superficially interested	0		Effect: "Omphalotus Omnipresence", Effect Duration: 54, Last Available: "2017-05"
-9482	moist dry skewed spinning Daily Affirmation: Adapt to Change Eventually	0		Effect: "Tiki Thoughtfulness", Effect Duration: 39, Last Available: "2017-05"
-9483	chilled upside-down maroon spinning Daily Affirmation: Be a Mind Master	0		Effect: "Pisces Rising", Effect Duration: 42, Last Available: "2017-05"
+9482	moist dry spinning skewed Daily Affirmation: Adapt to Change Eventually	0		Effect: "Tiki Thoughtfulness", Effect Duration: 39, Last Available: "2017-05"
+9483	chilled maroon spinning upside-down Daily Affirmation: Be a Mind Master	0		Effect: "Pisces Rising", Effect Duration: 42, Last Available: "2017-05"
 9484	irradiated diffused twirling Daily Affirmation: Work For Hours a Week	0		Effect: "Warm Shoulders", Effect Duration: 49, Last Available: "2017-05"
 9485	improved frozen Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Heart of White", Effect Duration: 11, Last Available: "2017-05"
 9486	super-sized bland yellow Affirmation Cookie	5	decent	Last Available: "2017-05"
@@ -9381,14 +9381,14 @@
 9509	L.I.M.P. Stock Certificate	0		
 9510	Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
-9512	spinning ghostly Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
+9512	ghostly spinning Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	skewed Meteorite-Ade	0		Last Available: "2017-08"
 9514	adequate meteoreo	3	good	Last Available: "2017-08"
 9515	hand-crafted watered-down meadeorite	2	EPIC	Last Available: "2017-08"
 9516	bouncing meteoroid	0		Last Available: "2017-08"
 9517	knitted smartaleck's meteortarboard of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Cold Resistance: +3, Last Available: "2017-08"
 9518	squat dog trainer's meteorite guard of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5, Experience (familiar): +1, Damage Reduction: 9, Last Available: "2017-08"
-9519	yellow quilted baleful meteorb	0		Spell Damage: +25, Damage Absorption: +40, Lantern Element: "Hot", Last Available: "2017-08"
+9519	yellow quilted baleful meteorb	0		Spell Damage: +25, Damage Absorption: +40, Last Available: "2017-08", Lantern Element: "Hot"
 9520	fortified asteroid belt of wisdom	0		Mysticality: +15, Damage Absorption: +60, Single Equip, Last Available: "2017-08"
 9521	meteorthopedic shoes of bravery of the boozehound of the sweet-tooth	0		Spooky Resistance: +5, Booze Drop: +100, Candy Drop: +100, Single Equip, Last Available: "2017-08"
 9522	narrow supercharged forbidden shooting morning star of wisdom	0		Mysticality: +15, Spell Damage Percent: +50, Maximum MP Percent: +30, Single Equip, Last Available: "2017-08"
@@ -9496,7 +9496,7 @@
 9624	silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
-9627	blurry tumbling warehouse key	0		Last Available: "2017-12"
+9627	tumbling blurry warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	hand-crafted stale cheer wine	3	EPIC	Last Available: "2017-12"
 9630	normal stale Cheer-E-Os	4	good	Last Available: "2017-12"
@@ -9505,7 +9505,7 @@
 9633	cheerful Crimbo sweater of Tarzan of the early riser	0		Experience (Muscle): +3, Adventures: +7, Last Available: "2017-12"
 9634	shellacked savvy cheerful pajama pants	0		Mysticality Percent: +20, Damage Reduction: 7, Last Available: "2017-12"
 9635	gray The Journal of Mime Science Vol. 1	0		Skill: "Silent Hunter", Last Available: "2017-12"
-9636	twirling tumbling ghostly The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
+9636	ghostly twirling tumbling The Journal of Mime Science Vol. 1 (used)	0		Skill: "Silent Hunter", Last Available: "2017-12"
 9637	The Journal of Mime Science Vol. 2	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9638	The Journal of Mime Science Vol. 2 (used)	0		Skill: "Quiet Determination", Last Available: "2017-12"
 9639	The Journal of Mime Science Vol. 3	0		Skill: "Quiet Judgement", Last Available: "2017-12"
@@ -9517,12 +9517,12 @@
 9645	upside-down The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	bad strong executive mime flask	5	decent	Last Available: "2017-12"
-9649	normal special mirror nega-mushroom	4	good	Effect: "Boletus Swoletus", Effect Duration: 30, Last Available: "2017-12"
-9650	fancy artisanal tumbling nega-mushroom wine	3	EPIC	Effect: "Loyal Tea", Effect Duration: 35, Last Available: "2017-12"
+9648	strong bad executive mime flask	5	decent	Last Available: "2017-12"
+9649	special normal mirror nega-mushroom	4	good	Effect: "Boletus Swoletus", Effect Duration: 30, Last Available: "2017-12"
+9650	artisanal fancy tumbling nega-mushroom wine	3	EPIC	Effect: "Loyal Tea", Effect Duration: 35, Last Available: "2017-12"
 9651	triple-liquefied twirling Cheer-Up soda	0		Effect: "Become Superficially interested", Effect Duration: 39, Last Available: "2017-12"
-9652	bite-sized moldy mime army rations	1	crappy	Last Available: "2017-12"
-9653	high-proof smooth ghostly mime army wine	6	awesome	Last Available: "2017-12"
+9652	moldy bite-sized mime army rations	1	crappy	Last Available: "2017-12"
+9653	smooth high-proof ghostly mime army wine	6	awesome	Last Available: "2017-12"
 9654	distilled mime army superserum	1		Effect: "It's Electric!", Effect Duration: 50, Last Available: "2017-12"
 9655	diffused twirling mime army camouflage kit	0		Effect: "Action", Effect Duration: 36, Last Available: "2017-12"
 9656	foul-smelling healthy miming beret	0		Maximum HP Percent: +20, Stench Damage: +10, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	moist nitrogenated digital honeypot	0		Effect: "Psalm of Pointiness", Effect Duration: 40, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	bouncing ghostly Usain Bolt's mime army insignia (infantry)	0		Initiative: +80, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	Rosewater's mime army insignia (intelligence)	0		Mysticality Percent: +30, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	wicked mime army insignia (espionage)	0		Spell Damage: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	bouncing ghostly Usain Bolt's mime army insignia (infantry)	0		Initiative: +80, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	Rosewater's mime army insignia (intelligence)	0		Mysticality Percent: +30, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	wicked mime army insignia (espionage)	0		Spell Damage: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	twirling mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9559,7 +9559,7 @@
 9687	red flame-wreathed quilted stylish burning paper jorts	0		Moxie: +25, Damage Absorption: +40, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2018-12"
 9688	censurious Jeselnik's dance instructor's burning paper crane	0		Experience Percent (Moxie): +10, Sleaze Damage: +25, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2018-12"
 9689	January's Garbage Tote (unopened)	0		Free Pull, Last Available: "2018-01"
-9690	huge bouncing January's Garbage Tote	0		Last Available: "2018-01"
+9690	bouncing huge January's Garbage Tote	0		Last Available: "2018-01"
 9691	jittery deceased crimbo tree	0		Last Available: "2018-01"
 9692	jittery chaotic grievous broken champagne bottle	0		Weapon Damage Percent: +50, Spell Critical Percent: +10, Last Available: "2018-01"
 9693	cyan blurry pulsating frightening tinsel tights of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +5, Last Available: "2018-01"
@@ -9574,9 +9574,9 @@
 9702	powdered squat skewed furry pill	1		Effect: "Always be Collecting", Effect Duration: 5
 9703	dried beefy pill	1		Effect: "Cancer Rising", Effect Duration: 10
 9704	altered teal excitement pill	1		
-9705	distilled tumbling blue vitamin G pill	1		
+9705	distilled blue tumbling vitamin G pill	1		
 9706	powdered cyan lucky-ish pill	1		
-9707	mixed wobbly cyan dieting pill	1		
+9707	mixed cyan wobbly dieting pill	1		
 9712	wobbly Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
@@ -9592,13 +9592,13 @@
 9724	prompt psychic's crystal ball of temperance	0		Sleaze Resistance: +5, Adventures: +3, Last Available: "2018-02"
 9725	Lo Pan's psychic's pslacks of the brazier	0		Spell Critical Percent: +30, Hot Spell Damage: +25, Last Available: "2018-02"
 9726	executive scorching psychic's amulet	0		Hot Damage: +25, Meat Drop: +40, Last Available: "2018-02"
-9727	normal bite-sized red heart-shaped candy whetstone	1	good	Last Available: "2018-02"
+9727	bite-sized normal red heart-shaped candy whetstone	1	good	Last Available: "2018-02"
 9728	normal Swedish massage fish	3	good	Last Available: "2018-02"
 9729	acceptable triple-distilled Third Base	10	good	Last Available: "2018-02"
 9730	bad mirror Bustle Hustler	3	decent	Last Available: "2018-02"
 9731	colloidal pickled squat Fabiotion	0		Effect: "Well-preserved", Effect Duration: 58, Last Available: "2018-02"
 9732	quantum oxidized Bettie page	0		Effect: "Adventurer's Best Friendship", Effect Duration: 12, Last Available: "2018-02"
-9733	nitrogenated super-polymerized boiled fuchsia bouncing wobbly tonic o' Banderas	0		Effect: "Mental A-cue-ity", Effect Duration: 26, Last Available: "2018-02"
+9733	nitrogenated super-polymerized boiled fuchsia wobbly bouncing tonic o' Banderas	0		Effect: "Mental A-cue-ity", Effect Duration: 26, Last Available: "2018-02"
 9734	boiled wet spinning heather graham cracker	0		Effect: "Tin, Man", Effect Duration: 69, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
 9736	ghostly heart cozy	0		Last Available: "2018-02"
@@ -9636,7 +9636,7 @@
 9768	mirror Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
 9770	Carpricorn	0		Last Available: "2018-03"
-9771	yellow shaking Turpin	0		Last Available: "2018-03"
+9771	shaking yellow Turpin	0		Last Available: "2018-03"
 9772	Morphan	0		Last Available: "2018-03"
 9773	Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
@@ -9651,7 +9651,7 @@
 9783	Vaporpoise	0		Last Available: "2018-03"
 9784	wobbly Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
-9786	blinking pulsating Flan	0		Last Available: "2018-03"
+9786	pulsating blinking Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	Ched	0		Last Available: "2018-03"
 9789	Gazelleton	0		Last Available: "2018-03"
@@ -9679,7 +9679,7 @@
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
-9814	narrow huge Egnaro berry	0		Last Available: "2018-03"
+9814	huge narrow Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	blinking Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
@@ -9691,14 +9691,14 @@
 9823	muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	mirror razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9826	huge spinning smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9826	spinning huge smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	green rocket	0		
 9828	modified lime green magnificent oyster egg	1		
 9829	diluted brilliant oyster egg	1		
 9830	vaporized glistening oyster egg	1		Effect: "You Can Really Taste the Dormouse", Effect Duration: 40
-9831	dehydrated jittery twirling wobbly scintillating oyster egg	1		
+9831	dehydrated wobbly twirling jittery scintillating oyster egg	1		
 9832	diluted spinning pearlescent oyster egg	1		Effect: "A View to Some Meat", Effect Duration: 45
-9833	mixed pulsating shaking lustrous oyster egg	1		Effect: "Spirit of Alph", Effect Duration: 30
+9833	mixed shaking pulsating lustrous oyster egg	1		Effect: "Spirit of Alph", Effect Duration: 30
 9834	dried skewed gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9731,19 +9731,19 @@
 9863	special mediocre FantasyRealm mead	3	decent	Effect: "Sleazy Jellied", Effect Duration: 5, Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
-9866	blue blinking arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
+9866	blinking blue arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	flavorless super-sized gray druidic s'more	5	decent	Last Available: "2018-04"
+9869	super-sized flavorless gray druidic s'more	5	decent	Last Available: "2018-04"
 9870	diluted ghostly sachet of powder	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 10, Last Available: "2018-04"
-9871	acceptable enchanted mourning wine	4	good	Effect: "Cold Hands", Effect Duration: 45, Last Available: "2018-04"
+9871	enchanted acceptable mourning wine	4	good	Effect: "Cold Hands", Effect Duration: 45, Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	shaking map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	purple map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	fancy low-calorie stale lime green denastified haunch	1	decent	Effect: "Took Eleven", Effect Duration: 35, Last Available: "2018-04"
+9878	low-calorie stale fancy lime green denastified haunch	1	decent	Effect: "Took Eleven", Effect Duration: 35, Last Available: "2018-04"
 9879	lousy bad rum and good cola	4	decent	Last Available: "2018-04"
 9880	diffused Potion of Heroism	0		Effect: "Macho Profundo", Effect Duration: 13, Last Available: "2018-04"
 9881	yellow double-paned sharpshooter's resourceful leggings of the Spider Queen	0		Maximum MP: +50, Critical Hit Percent: +10, Cold Resistance: +5, Last Available: "2018-04"
@@ -9768,11 +9768,11 @@
 9900	bland chocolate &quot;Phoenix&quot;	3	decent	
 9901	moldy big green chocolate Spider Queen	5	crappy	
 9902	enchanted drinkable tumbling hipster cocktail	3	good	Effect: "Feeling No Pain", Effect Duration: 20
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	teal God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	teal God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	huge G	0		
 9910	Garland of Greatness	0		
@@ -9791,7 +9791,7 @@
 9923	altered adjusted Punching Potion	0		Effect: "Expert Vacationer", Effect Duration: 37, Last Available: "2018-06"
 9924	jittery blurry Special Seasoning	0		Last Available: "2018-06"
 9925	vaporized twirling Nightmare Fuel	1		Effect: "Pie in the Sky", Effect Duration: 50, Last Available: "2018-06"
-9926	fuchsia bouncing Gathered Meat-Clip	0		Last Available: "2020-09"
+9926	bouncing fuchsia Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	Tesla dance instructor's strapping Brutal brogues of dire peril	0		Muscle: +5, Experience Percent (Moxie): +10, Weapon Damage: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-07"
@@ -9804,8 +9804,8 @@
 9936	Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	teal Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
-9939	shaking wobbly kitten burglar	0		Free Pull, Last Available: "2018-07"
-9940	yellow squat burglar/sleep mask	0		Last Available: "2018-07"
+9939	wobbly shaking kitten burglar	0		Free Pull, Last Available: "2018-07"
+9940	squat yellow burglar/sleep mask	0		Last Available: "2018-07"
 9941	ghostly Thwaitgold masked hunter statuette	0		
 9942	Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
 9943	wobbly Neverending Party guest pass	0		Last Available: "2018-09"
@@ -9831,9 +9831,9 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	censurious extremely unsafe noticeable pumps	0		Weapon Damage Percent: +100, Sleaze Resistance: +3, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	irresponsibly strong mediocre everfull glass	6		Last Available: "2018-09"
+9966	mediocre irresponsibly strong everfull glass	6		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
-9968	cyan shaking jam band bootleg	0		Last Available: "2018-09"
+9968	shaking cyan jam band bootleg	0		Last Available: "2018-09"
 9969	therapeutic rosy-cheeked denim jacket	0		Maximum HP Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-09"
 9970	tumbling squat scorching friendly ratty knitted cap	0		Familiar Weight: +3, Hot Damage: +25, Last Available: "2018-09"
 9972	miser's Jack Frost's intimidating chainsaw	0		Cold Spell Damage: +50, Meat Drop: +10, Lasts Until Rollover, Last Available: "2018-09"
@@ -9880,7 +9880,7 @@
 10014	bad gray martini	4	decent	Last Available: "2018-11"
 10015	half-sized flavorless purple cherry pie	2	decent	Last Available: "2018-11"
 10016	smooth eggnog	3	awesome	Last Available: "2018-11"
-10017	spinning mirror glob of undifferentiated tissue	0		Last Available: "2018-11"
+10017	mirror spinning glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	rotten snack-sized blurry lime green Hell ramen	2	crappy	Last Available: "2018-11"
 10019	hand-crafted twirling gimlet	3	EPIC	Last Available: "2018-11"
 10020	hand-crafted mirror twice-haunted screwdriver	4	EPIC	Last Available: "2018-11"
@@ -9907,13 +9907,13 @@
 10041	Van der Graaf balanced antler	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
 10042	quilted dam	0		Damage Absorption: +40, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted beavermouth	3	EPIC	Last Available: "2018-12"
-10044	watered-down tolerable beaver punch (papaya)	2	good	Last Available: "2018-12"
+10044	tolerable watered-down beaver punch (papaya)	2	good	Last Available: "2018-12"
 10045	acceptable blinking beaver punch (peach)	4	good	Last Available: "2018-12"
-10046	hand-crafted weak mirror beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
+10046	weak hand-crafted mirror beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
 10047	skewed jittery rosewater-soaked dangerous Canadian lantern	0		Weapon Damage: +10, Stench Resistance: +3, Last Available: "2018-12"
 10048	jittery sharpshooter's muskox-skin cap	0		Critical Hit Percent: +10, Last Available: "2018-12"
 10049	twirling Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	moldy half-sized huge glass of raw eggs	2	crappy	Last Available: "2018-12"
+10050	half-sized moldy huge glass of raw eggs	2	crappy	Last Available: "2018-12"
 10051	bad punch-drunk punch	4	decent	Last Available: "2018-12"
 10052	powdered tumbling body spradium	1		Last Available: "2018-12"
 10053	supercool bauxite beret	0		Moxie Percent: +20, Last Available: "2018-12"
@@ -9929,12 +9929,12 @@
 10063	tumbling squat sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	fortified perfectly mixed olive beer	5	EPIC	Last Available: "2018-12"
+10066	perfectly mixed fortified olive beer	5	EPIC	Last Available: "2018-12"
 10067	stale half-sized yule gruel	2	decent	Last Available: "2018-12"
 10068	artisanal blinking hot watered rum	3	EPIC	Last Available: "2018-12"
 10069	hand-crafted fancy bottle of Crimbognac	4	EPIC	Effect: "Space Cadet", Effect Duration: 35, Last Available: "2018-12"
-10070	enchanted normal Crimboysters Rockefeller	4	good	Effect: "Icy Demeanor", Effect Duration: 40, Last Available: "2018-12"
-10071	boiled maroon blinking Crimbeau de toilette	1		Last Available: "2018-12"
+10070	normal enchanted Crimboysters Rockefeller	4	good	Effect: "Icy Demeanor", Effect Duration: 40, Last Available: "2018-12"
+10071	boiled blinking maroon Crimbeau de toilette	1		Last Available: "2018-12"
 10072	bouncing Crimbo candle	0		Last Available: "2018-12"
 10073	narrow Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
 10074	mirror Carol of the Bulls (used)	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9967,7 +9967,7 @@
 10101	Sherlock's pendant of the bloodbag	0		Maximum HP: +100, Item Drop: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10102	toasty strapping palazzos	0		Muscle: +5, Hot Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10103	blurry frosty hardened pseudoaccordion	0		Damage Reduction: 3, Cold Spell Damage: +10, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10104	dehydrated red huge pieces	1		Last Available: "2020-12"
+10104	dehydrated huge red pieces	1		Last Available: "2020-12"
 10105	flattened blinking Para-Pop	0		Effect: "Flambé-a-thon", Effect Duration: 48
 10106	upside-down censurious energetic terra cotta truss	0		Maximum MP Percent: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10107	gravedigger's terra cotta trousers of horror	0		Spooky Damage: +10, Spooky Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
@@ -10007,7 +10007,7 @@
 10141	teal scandalous chaotic flagstone fez	0		Spell Critical Percent: +10, Sleaze Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
 10142	hardy slick flagstone fleece	0		Moxie: +10, Maximum HP: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
 10143	green hardy educational flagstone fringe	0		Experience: +1, Maximum HP: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	distilled jittery narrow flagstone flagments	1		Effect: "Like a Fish to Walter", Effect Duration: 10, Last Available: "2022-12"
+10144	distilled narrow jittery flagstone flagments	1		Effect: "Like a Fish to Walter", Effect Duration: 10, Last Available: "2022-12"
 10145	magnetized extra-cold-filtered green Flag by the Foot&trade;	0		Effect: "Raging Animal", Effect Duration: 26
 10146	upside-down elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	blinking red-and-green microcamera	0		Familiar Weight: +5
@@ -10031,21 +10031,21 @@
 10165	pulsating mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	Lil' Doctor&trade; bag of Gandalf of the boozehound	0		Spell Critical Percent: +20, Booze Drop: +100, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	jittery blood bag	0		
-10169	decent thick bloodstick	5	good	
-10170	hand-crafted high-proof blue bottle of Sanguiovese	9	EPIC	
-10171	moldy snack-sized actual blood sausage	2	crappy	
+10169	thick decent bloodstick	5	good	
+10170	high-proof hand-crafted blue bottle of Sanguiovese	9	EPIC	
+10171	snack-sized moldy actual blood sausage	2	crappy	
 10172	hand-crafted weak mulled blood	2	super EPIC	
 10173	decent half-sized wobbly blood snowcone	2	good	
-10174	lousy practically non-alcoholic blinking Red Russian	1	decent	
-10175	normal tiny blood roll-up	1	good	
+10174	practically non-alcoholic lousy blinking Red Russian	1	decent	
+10175	tiny normal blood roll-up	1	good	
 10176	tolerable bottle of blood	3	good	
 10177	bland narrow blood-soaked sponge cake	3	decent	
-10178	extra-dry tolerable vampagne	5	good	
+10178	tolerable extra-dry vampagne	5	good	
 10179	flavorless snack-sized plain snowcone	2	decent	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
-10183	narrow bouncing money bag	0		
+10183	bouncing narrow money bag	0		
 10184	tumbling Thwaitgold mosquito statuette	0		
 10185	bucket of Vampyre blood	0		
 10186	blood knife	0		Lasts Until Rollover
@@ -10064,7 +10064,7 @@
 10199	low-calorie rotten crabsicle	1	crappy	Last Available: "2019-04"
 10200	squat melty plastic grenade	0		Last Available: "2019-04"
 10201	acceptable bottle of dark rhum	3	good	Last Available: "2019-04"
-10202	irresponsibly strong artisanal bottle of extra-dark rhum	6	EPIC	Last Available: "2019-04"
+10202	artisanal irresponsibly strong bottle of extra-dark rhum	6	EPIC	Last Available: "2019-04"
 10203	artisanal bottle of super-extra-dark rhum	3	EPIC	Last Available: "2019-04"
 10204	anodized pirate shaving cream	0		Effect: "Natural 20", Effect Duration: 60, Last Available: "2019-04"
 10205	wizardly conquistador's breastplate of the detective	0		Mysticality: +25, Item Drop: +20, Last Available: "2019-04"
@@ -10089,20 +10089,20 @@
 10224	blurry Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	shaking PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	plush sea serpent of James Dean	0		Experience (Moxie): +3, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	decent small narrow pirate fork	2		Last Available: "2019-04"
+10227	small decent narrow pirate fork	2		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	twirling cool piratical blunderbuss of terror	0		Moxie: +5, Spooky Spell Damage: +10, Last Available: "2019-04"
 10231	ghostly Oprah's slick beefy PirateRealm party hat	0		Muscle: +10, Moxie: +10, Maximum MP Percent: +50, Last Available: "2019-04"
-10232	lousy high-proof Island Landslide	6	decent	Last Available: "2019-04"
+10232	high-proof lousy Island Landslide	6	decent	Last Available: "2019-04"
 10233	artisanal Island Thunderstorm	3	EPIC	Last Available: "2019-04"
 10234	fancy lousy Island Hurricane	3	decent	Effect: "Frozen Hands", Effect Duration: 40, Last Available: "2019-04"
-10235	delicious watered-down Skull Punch	2	awesome	Last Available: "2019-04"
-10236	artisanal watered-down Electric Punch	2	super ultra EPIC	Last Available: "2019-04"
+10235	watered-down delicious Skull Punch	2	awesome	Last Available: "2019-04"
+10236	watered-down artisanal Electric Punch	2	super ultra EPIC	Last Available: "2019-04"
 10237	perfectly mixed skewed Smuggler's Punch	3	super EPIC	Last Available: "2019-04"
-10238	acceptable extra-dry Scorpion Bowl	5	good	Last Available: "2019-04"
+10238	extra-dry acceptable Scorpion Bowl	5	good	Last Available: "2019-04"
 10239	bad blue Turtle Bowl	3	decent	Last Available: "2019-04"
-10240	weak tolerable Cobra Bowl	2	good	Last Available: "2019-04"
+10240	tolerable weak Cobra Bowl	2	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	Lo Pan's sharpshooter's Herculean groovy vampyric cloake of bravery	0		Moxie Percent: +10, Experience (Muscle): +1, Critical Hit Percent: +10, Spell Critical Percent: +30, Spooky Resistance: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
@@ -10112,7 +10112,7 @@
 10247	maroon 18-picohertz resonator crystal	0		
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
-10250	squat jittery maroon Fourth of May Cosplay Saber kit	0		Free Pull
+10250	squat maroon jittery Fourth of May Cosplay Saber kit	0		Free Pull
 10251	double-paned Van der Graaf experienced Fourth of May Cosplay Saber	0		Experience: +2, Cold Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
@@ -10130,7 +10130,7 @@
 10265	etched hourglass	0		Last Available: "2019-07"
 10266	chilled concentrated magenta seashell	0		Effect: "Stop and Smell the Fudge", Effect Duration: 19, Last Available: "2019-07"
 10267	oxidized cyan seashell	0		Effect: "Ruby-ous", Effect Duration: 13, Last Available: "2019-07"
-10268	super-enhanced ionized huge upside-down gray seashell	0		Effect: "Inebriate Pride", Effect Duration: 54, Last Available: "2019-07"
+10268	super-enhanced ionized upside-down huge gray seashell	0		Effect: "Inebriate Pride", Effect Duration: 54, Last Available: "2019-07"
 10269	oxidized diffused spinning seashell	0		Effect: "Human-Hippy Hybrid", Effect Duration: 21, Last Available: "2019-07"
 10270	modified vacuum-sealed deionized huge olive seashell	0		Effect: "Puzzle Fury", Effect Duration: 60, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
@@ -10167,7 +10167,7 @@
 10302	censurious frosty manspreader's sinister whittled walking stick	0		Spell Damage: +10, Monster Level: +10, Cold Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2019-08"
 10303	stale yellow campfire hot dog	3	decent	Last Available: "2019-08"
 10304	normal big campfire baked potato	5	good	Last Available: "2019-08"
-10305	snack-sized tasty wobbly campfire s'more	2	awesome	Last Available: "2019-08"
+10305	tasty snack-sized wobbly campfire s'more	2	awesome	Last Available: "2019-08"
 10306	yummy thick campfire beans	5	awesome	Last Available: "2019-08"
 10307	delicious campfire stew	4	awesome	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
@@ -10182,8 +10182,8 @@
 10317	yellow signal jammer	0		Single Equip
 10318	narrow low-pressure oxygen tank	0		Single Equip
 10319	mirror Thwaitgold bombardier beetle statuette	0		
-10320	thick decent mirror space chowder	5	good	
-10321	triple-distilled bad space wine	8	decent	
+10320	decent thick mirror space chowder	5	good	
+10321	bad triple-distilled space wine	8	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	upside-down packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	mirror Pocket Professor memory chip	0		
@@ -10193,7 +10193,7 @@
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	fuchsia mirror diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	snack-sized rotten bu&ntilde;uelos Jaliscos	2	crappy	Last Available: "2019-12"
+10337	rotten snack-sized bu&ntilde;uelos Jaliscos	2	crappy	Last Available: "2019-12"
 10338	rotten ghostly flan del mar	4	crappy	Last Available: "2019-12"
 10339	rotten small Baja sopapilla	2	crappy	Last Available: "2019-12"
 10340	shaking Fonzie's plastic Mer-kin baker	0		Experience (Moxie): +1, Last Available: "2019-12"
@@ -10204,7 +10204,7 @@
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	moldy mana-coated yams	3	crappy	Last Available: "2019-11"
 10347	half-sized stale bouncing mana-basted tofurkey leg	2	decent	Last Available: "2019-11"
-10348	small decent mana-fortified cranberry sauce	2	good	Last Available: "2019-11"
+10348	decent small mana-fortified cranberry sauce	2	good	Last Available: "2019-11"
 10349	miniature adequate mana-stuffed herbal stuffing	2	good	Last Available: "2019-11"
 10350	spinning human musk	0		Last Available: "2019-12"
 10351	improved wobbly patch of extra-warm fur	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 64, Last Available: "2019-12"
@@ -10214,13 +10214,13 @@
 10355	powdered gray a bug's lymph	1		Last Available: "2019-12"
 10356	wet quadruple-deionized ionized green organic potpourri	0		Effect: "items.enh", Effect Duration: 40, Last Available: "2019-12"
 10357	acceptable boot flask	3	good	Last Available: "2019-12"
-10358	colloidal green squat infernal snowball	0		Effect: "Oriental Mysticism", Effect Duration: 41, Last Available: "2019-12"
+10358	colloidal squat green infernal snowball	0		Effect: "Oriental Mysticism", Effect Duration: 41, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	dried shaking tumbling fish sauce	1		Last Available: "2019-12"
+10360	dried tumbling shaking fish sauce	1		Last Available: "2019-12"
 10361	stale guffin	3	decent	Last Available: "2019-12"
 10362	vaporized Shantix&trade;	1		Effect: "Sticks and Stones", Effect Duration: 40, Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
-10364	pickled jittery ghostly non-Euclidean angle	1		Effect: "Smelly Pants", Effect Duration: 35, Last Available: "2019-12"
+10364	pickled ghostly jittery non-Euclidean angle	1		Effect: "Smelly Pants", Effect Duration: 35, Last Available: "2019-12"
 10365	concentrated adjusted super-wet upside-down peppermint syrup	0		Effect: "Dances with Tweedles", Effect Duration: 49, Last Available: "2019-12"
 10366	flattened huge Mer-kin eyedrops	0		Effect: "Unrunnable Face", Effect Duration: 69, Last Available: "2019-12"
 10367	oxidized extra-strength goo	0		Effect: "Ready to Snap", Effect Duration: 50, Last Available: "2019-12"
@@ -10245,7 +10245,7 @@
 10386	twirling moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
 10388	rosy-cheeked anemoney clip	0		Maximum HP Percent: +30, Single Equip, Last Available: "2019-12"
-10389	red pulsating runny icing	0		Last Available: "2019-12"
+10389	pulsating red runny icing	0		Last Available: "2019-12"
 10390	mixed pulsating super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	tumbling zippy boxer's icing poncho of the overflowing toilet	0		Muscle Percent: +10, Stench Spell Damage: +50, Initiative: +20, Last Available: "2019-12"
 10392	tumbling Mer-kin cookiestove	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	medical-grade nutcracker cape of the storm	0		Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-12"
 10413	skewed gray nutcracker epaulets of the boozehound of the glutton	0		Booze Drop: +100, Food Drop: +100, Single Equip, Last Available: "2019-12"
 10414	purple twirling nutcracker figurine	0		Last Available: "2019-12"
-10415	small rotten salt plum	2	crappy	Last Available: "2019-12"
+10415	rotten small salt plum	2	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	rotten and bean	3	crappy	Last Available: "2019-12"
 10418	fireproof smelly cool kelp-holly gun	0		Moxie: +5, Stench Spell Damage: +10, Hot Resistance: +3, Last Available: "2019-12"
@@ -10281,10 +10281,10 @@
 10422	medical-grade curative Crimbylow-rise jeans	0		HP Regen Min: 10, HP Regen Max: 15, Last Available: "2019-12"
 10423	skewed toasty strapping kelp-holly drape	0		Muscle: +5, Hot Damage: +5, Last Available: "2019-12"
 10424	aromatic curative hardy Staff of the Peppermint Twist of the ox	0		Muscle: +20, Maximum HP: +50, Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
-10425	snack-sized tasty upside-down tempura and bean	2	awesome	Last Available: "2019-12"
-10426	artisanal weak fuchsia salt plum sake	2	super EPIC	Last Available: "2019-12"
+10425	tasty snack-sized upside-down tempura and bean	2	awesome	Last Available: "2019-12"
+10426	weak artisanal fuchsia salt plum sake	2	super EPIC	Last Available: "2019-12"
 10427	moist pressurized potion of possessiveness	0		Effect: "Greasy Flavor", Effect Duration: 41, Last Available: "2019-12"
-10428	double-quantum squat purple almond	0		Effect: "Pronounced Potency", Effect Duration: 27
+10428	double-quantum purple squat almond	0		Effect: "Pronounced Potency", Effect Duration: 27
 10429	unsweetened irradiated handful of mixed nuts	0		Effect: "Fortunate Resolve", Effect Duration: 48, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	skewed Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
@@ -10302,7 +10302,7 @@
 10445	spoiled squat drippy nugget	4	drippy	
 10446	high-proof bad glass of drippy wine	6	drippy	
 10447	spoiled big drippy caviar	5	drippy	
-10448	bland massive drippy plum(?)	7	drippy	
+10448	massive bland drippy plum(?)	7	drippy	
 10449	hardened drippy stake	0		Damage Reduction: 3, Single Equip
 10450	tumbling The Eye of the Thing in the Basement	0		
 10451	upside-down drippy khakis	0		
@@ -10322,7 +10322,7 @@
 10465	pulsating boots	0		Single Equip
 10466	reassuring cape	0		Spooky Resistance: +1
 10467	wobbly stanky smelly back shell	0		Stench Spell Damage: 35
-10468	lime green ghostly spiky back shell	0		
+10468	ghostly lime green spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
 10470	Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
@@ -10346,7 +10346,7 @@
 10489	big bland bouncing mushroom filet	5	decent	Last Available: "2020-03"
 10490	teal huge mushroom slab	0		Last Available: "2020-03"
 10491	mixed blurry mushroom tea	1		Last Available: "2020-03"
-10492	weak drinkable mushroom whiskey	2	good	Last Available: "2020-03"
+10492	drinkable weak mushroom whiskey	2	good	Last Available: "2020-03"
 10493	studded quilted mushroom cap of vim and vigor	0		Damage Absorption: 120, Maximum HP Percent: +50, Last Available: "2020-03"
 10494	blurry tumbling knitted cool mushroom shield of the sewer of the glutton	0		Moxie: +5, Stench Damage: +25, Cold Resistance: +3, Food Drop: +100, Damage Reduction: 6, Last Available: "2020-03"
 10495	family-friendly toasty crafty extremely unsafe mushroom pants	0		Weapon Damage Percent: +100, Maximum MP: +10, Hot Damage: +5, Sleaze Resistance: +1, Last Available: "2020-03"
@@ -10368,7 +10368,7 @@
 10511	sinister pizza box	0		Spell Damage: +10, Damage Reduction: 6, Last Available: "2020-04"
 10512	double-paned chipped coffee mug of the cheetah	0		Cold Resistance: +5, Initiative: +60, Last Available: "2020-04"
 10513	pulsating groovy Left-Hand Man action figure	0		Moxie Percent: +10, Last Available: "2020-04"
-10514	red upside-down drippy seed	0		
+10514	upside-down red drippy seed	0		
 10515	drippy grub	0		
 10516	ghostly drippy bezoar	0		
 10517	yellow Drip Institute petri dish	0		
@@ -10396,10 +10396,10 @@
 10540	spinning Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	acceptable bouncing Ghiaccio Colada	4	good	Last Available: "2020-05"
 10542	tolerable fancy Sourfinger	4	good	Effect: "Fungal Fortification", Effect Duration: 30, Last Available: "2020-05"
-10543	perfectly mixed fancy Nog-on-the-Cob	4	EPIC	Effect: "Super Vision", Effect Duration: 15, Last Available: "2020-05"
-10544	acceptable triple-distilled mirror Steamboat	9	good	Last Available: "2020-05"
+10543	fancy perfectly mixed Nog-on-the-Cob	4	EPIC	Effect: "Super Vision", Effect Duration: 15, Last Available: "2020-05"
+10544	triple-distilled acceptable mirror Steamboat	9	good	Last Available: "2020-05"
 10545	mediocre Buttery Boy	3	decent	Last Available: "2020-05"
-10546	olive jittery Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
+10546	jittery olive Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	lard-coated vibrating clown car key	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, Last Available: "2020-08"
 10548	pulsating yellow friendly Jim Carey's Fonzie's batting cage key	0		Experience (Moxie): +1, Monster Level: +25, Familiar Weight: +3, Last Available: "2020-08"
 10549	padded grievous Rosewater's aqu&iacute;	0		Mysticality Percent: +30, Weapon Damage Percent: +50, Damage Absorption: +20, Last Available: "2020-08"
@@ -10459,7 +10459,7 @@
 10603	fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
-10606	pickled lime green narrow Yeg's Motel toothbrush	0		Effect: "stats.enq", Effect Duration: 27, Last Available: "2020-09"
+10606	pickled narrow lime green Yeg's Motel toothbrush	0		Effect: "stats.enq", Effect Duration: 27, Last Available: "2020-09"
 10607	deionized moist Yeg's Motel hand soap	0		Effect: "Stogied", Effect Duration: 64, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	adequate green Yeg's Motel pillow mint	4	good	Last Available: "2020-09"
@@ -10502,7 +10502,7 @@
 10646	narrow packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
 10647	Vampire Slicer trench cape	0		Muscle Percent: +30, Maximum HP: +50, Hot Resistance: +3, Cold Resistance: +3, Spooky Resistance: +3, Stench Resistance: +3, Sleaze Resistance: +3
 10648	box o' ghosts	0		Free Pull, Last Available: "2020-12"
-10649	red squat gregarious ghostling	0		Free Pull, Last Available: "2020-12"
+10649	squat red gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	shaking cyan grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	tumbling greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	subscription cocoa dispenser	0		Last Available: "2020-12"
@@ -10537,7 +10537,7 @@
 10681	toasty candy bucket	0		Hot Damage: +5, Lasts Until Rollover, Last Available: "2020-12"
 10682	extra-activated narrow prescription teeth whitener	0		Effect: "Mushroom Melody", Effect Duration: 62, Last Available: "2020-12"
 10683	Vulcanized imported lemon lozenge	0		Effect: "Bread-Lined", Effect Duration: 49, Last Available: "2020-12"
-10684	diffused pressed blurry upside-down hermedisiac cologne	0		Effect: "Wreathed in Smoke", Effect Duration: 19, Last Available: "2020-12"
+10684	diffused pressed upside-down blurry hermedisiac cologne	0		Effect: "Wreathed in Smoke", Effect Duration: 19, Last Available: "2020-12"
 10685	government food shipment	0		Last Available: "2020-12"
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	upside-down government candy shipment	0		Last Available: "2020-12"
@@ -10556,9 +10556,9 @@
 10700	Van der Graaf Satan hat of courage	0		Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Class: "Sauceror", Last Available: "2020-12"
 10701	personal trainer's supercool Crimbo stockings	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Class: "Disco Bandit", Last Available: "2020-12"
 10702	ruddy savvy poncho de azucar	0		Mysticality Percent: +20, Maximum HP Percent: +40, Class: "Accordion Thief", Last Available: "2020-12"
-10703	blinking skewed The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
+10703	skewed blinking The Night Before Crimbo, Ch. 1	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
 10704	The Night Before Crimbo, Ch. 1 (used)	0		Skill: "Long Winter's Nap", Last Available: "2020-12"
-10705	jittery lime green ghostly The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
+10705	lime green ghostly jittery The Night Before Crimbo, Ch. 2	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10706	The Night Before Crimbo, Ch. 2 (used)	0		Skill: "Bowl Full of Jelly", Last Available: "2020-12"
 10707	The Night Before Crimbo, Ch. 3	0		Skill: "Ashes and Soot", Last Available: "2020-12"
 10708	yellow The Night Before Crimbo, Ch. 3 (used)	0		Skill: "Ashes and Soot", Last Available: "2020-12"
@@ -10573,13 +10573,13 @@
 10717	purple fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	shaking nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	boozy bad barrel-aged eggnog	5	decent	Last Available: "2020-12"
+10720	bad boozy barrel-aged eggnog	5	decent	Last Available: "2020-12"
 10721	miniature stale hand-crafted candy cane	2	decent	Last Available: "2020-12"
 10722	moldy drive-thru burger	4	crappy	Last Available: "2020-12"
 10723	spirit-forward mediocre Boulevardier cocktail	5	decent	Last Available: "2020-12"
 10724	double-denatured spinning bouncing Hotwire&trade; brand candy rope	0		Effect: "Elron's Explosive Etude", Effect Duration: 59, Last Available: "2020-12"
 10725	stale bowl full of jelly	4	decent	Last Available: "2020-12"
-10726	bad practically non-alcoholic Eye and a Twist	1	decent	Last Available: "2020-12"
+10726	practically non-alcoholic bad Eye and a Twist	1	decent	Last Available: "2020-12"
 10727	double-magnetized Chubby and Plump bar	0		Effect: "Analog Drunk", Effect Duration: 48, Last Available: "2020-12"
 10728	wobbly digibritches	0		Last Available: "2025-12"
 10729	shaking packaged crystal ball	0		Free Pull, Last Available: "2021-01"
@@ -10588,7 +10588,7 @@
 10732	bouncing fresh coat of paint	0		Last Available: "2021-12"
 10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
 10734	upside-down spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
-10735	olive bouncing jittery robo-battery	0		
+10735	bouncing olive jittery robo-battery	0		
 10736	wobbly Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	potted power plant	0		Last Available: "2021-03"
@@ -10621,12 +10621,12 @@
 10765	olive rocket	0		Last Available: "2021-07"
 10766	shaking rocket	0		Last Available: "2021-07"
 10767	mirror mirror rocket	0		Last Available: "2021-07"
-10768	immense spoiled squat fire crackers	9	crappy	Last Available: "2021-07"
+10768	spoiled immense squat fire crackers	9	crappy	Last Available: "2021-07"
 10769	spinning Arr, M80	0		Last Available: "2021-07"
 10770	lime green lightning-fast extremely unsafe Catherine Wheel	0		Weapon Damage Percent: +100, Initiative: +40, Lasts Until Rollover, Last Available: "2021-07"
 10771	twirling shaking Sherlock's studded rocket boots	0		Damage Absorption: +80, Item Drop: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	razor-sharp arcane researcher's sparkler	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +25, Lasts Until Rollover, Last Available: "2021-07"
-10773	squat pulsating skewed Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
+10773	skewed squat pulsating Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	energized dry Scent of a Human&trade; candle	0		Effect: "Feelin' Philosophical", Effect Duration: 69, Last Available: "2021-08"
 10775	wet flattened The Beast Within&trade; candle	0		Effect: "Empathy", Effect Duration: 66, Last Available: "2021-08"
 10776	frozen Salsa Caliente&trade; candle	0		Effect: "Cold, Dead Hands", Effect Duration: 50, Last Available: "2021-08"
@@ -10672,7 +10672,7 @@
 10816	shaking vibrating Rosewater's ice crown of the brazier	0		Mysticality Percent: +30, Maximum MP Percent: +10, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-12"
 10817	lime green twirling asbestos-lined hardy smartaleck's jeans	0		Moxie Percent: +30, Maximum HP: +50, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2021-12"
 10818	Jeselnik's scandalous ice wrap of horror	0		Spooky Spell Damage: +25, Sleaze Damage: 30, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	low-calorie stale tofu pop	1	decent	Last Available: "2021-12"
+10819	stale low-calorie tofu pop	1	decent	Last Available: "2021-12"
 10820	adequate bowl of prescription candy	3	good	Last Available: "2021-12"
 10821	moldy miniature wobbly fishcake	2	crappy	Last Available: "2021-12"
 10822	flavorless bone broth	4	decent	Last Available: "2021-12"
@@ -10692,10 +10692,10 @@
 10836	super-galvanized anti-creep cream	0		Effect: "20-20 Second Sight", Effect Duration: 43, Last Available: "2021-12"
 10837	enhanced anti-pain cream	0		Effect: "Sepia Tan", Effect Duration: 19, Last Available: "2021-12"
 10838	acceptable Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
-10839	huge normal bread pie	7	good	Last Available: "2021-12"
-10840	special spirit-forward bad twirling clear Russian	5	decent	Effect: "Tomato Power", Effect Duration: 45, Last Available: "2021-12"
+10839	normal huge bread pie	7	good	Last Available: "2021-12"
+10840	bad spirit-forward special twirling clear Russian	5	decent	Effect: "Tomato Power", Effect Duration: 45, Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
-10842	red narrow Crimbo ball	0		Last Available: "2021-12"
+10842	narrow red Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
 10844	gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
@@ -10715,7 +10715,7 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	avaricious depleted Crimbonium football helmet	0		Meat Drop: +30, Last Available: "2021-12"
 10861	blinking synthetic rock	0		Last Available: "2021-12"
-10862	decent gigantic &quot;caramel&quot;	10	good	Last Available: "2021-12"
+10862	gigantic decent &quot;caramel&quot;	10	good	Last Available: "2021-12"
 10863	self-repairing earmuffs of Flo-Jo	0		Initiative: +100, Last Available: "2021-12"
 10864	brawny carnivorous potted plant	0		Muscle Percent: +20, Last Available: "2021-12"
 10865	universal biscuit	0		Last Available: "2021-12"
@@ -10729,7 +10729,7 @@
 10873	careful extremely unsafe can of mixed everything of mayonnaise	0		Weapon Damage Percent: +100, Monster Level: -10, Sleaze Spell Damage: +50, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	snack-sized tasty pulsating meatball	2	awesome	Last Available: "2021-12"
+10876	tasty snack-sized pulsating meatball	2	awesome	Last Available: "2021-12"
 10877	pulsating cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10765,24 +10765,24 @@
 10909	twirling space blanket	0		Last Available: "2022-05"
 10910	ionized electrified single-use dust mask	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 13, Last Available: "2022-05"
 10911	alkaline moist gaffer's tape	0		Effect: "Updated", Effect Duration: 17, Last Available: "2022-05"
-10912	normal small 20-lb can of rice and beans	2	good	Last Available: "2022-05"
+10912	small normal 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	awesome	Last Available: "2022-05"
-10914	adequate huge bouncing expired MRE	7	good	Last Available: "2022-05"
+10914	huge adequate bouncing expired MRE	7	good	Last Available: "2022-05"
 10915	stale thick bouncing cool mint precipice bar	5	decent	Last Available: "2022-05"
-10916	diet rotten carrot cake precipice bar	1	crappy	Last Available: "2022-05"
+10916	rotten diet carrot cake precipice bar	1	crappy	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	blue Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	olive skewed lightning-fast dog trainer's arcane researcher's June cleaver	0		Experience Percent (Mysticality): +10, Experience (familiar): +1, Initiative: +40, Attacks Can't Miss, Last Available: "2022-06"
 10921	special tolerable Dad's brandy	4	good	Effect: "Newt Gets In Your Eyes", Effect Duration: 5, Last Available: "2022-06"
 10922	squat scorching teacher's pen of mayonnaise	0		Hot Damage: +25, Sleaze Spell Damage: +50, Last Available: "2022-06"
-10923	decent half-sized fire-roasted lake trout	2	good	Last Available: "2022-06"
+10923	half-sized decent fire-roasted lake trout	2	good	Last Available: "2022-06"
 10924	half-sized spoiled guilty sprout	2	crappy	Last Available: "2022-06"
 10925	cyan prompt lion tamer's mother's necklace	0		Experience (familiar): +2, Adventures: +3, Last Available: "2022-06"
 10926	flattened oxidized mirror trampled ticket stub	0		Effect: "Brain Freeze", Effect Duration: 13, Last Available: "2022-06"
 10927	extra-energized extra-moist savings bond	0		Effect: "Wallflowering", Effect Duration: 23, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	dried sweat-ade	1		Last Available: "2022-07"
 10931	wobbly yellow unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10812,8 +10812,8 @@
 10956	perfectly mixed triple-distilled blurry AutumnFest ale	9	EPIC	Last Available: "2022-10"
 10957	wicked Herculean autumn sweater-weather sweater of wisdom	0		Mysticality: +15, Experience (Muscle): +1, Spell Damage: +5, Lasts Until Rollover, Last Available: "2022-10"
 10958	prompt gravedigger's Rosewater's autumn debris shield of dire peril	0		Mysticality Percent: +30, Weapon Damage: +20, Spooky Damage: +10, Adventures: +3, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	fancy flavorless autumn-spice donut	4	decent	Effect: "Supafly", Effect Duration: 10, Last Available: "2022-10"
-10960	cold-filtered quadruple-adjusted aerosolized gray twirling squat autumn dollar	0		Effect: "Human-Beast Hybrid", Effect Duration: 31, Last Available: "2022-10"
+10959	flavorless fancy autumn-spice donut	4	decent	Effect: "Supafly", Effect Duration: 10, Last Available: "2022-10"
+10960	cold-filtered quadruple-adjusted aerosolized squat twirling gray autumn dollar	0		Effect: "Human-Beast Hybrid", Effect Duration: 31, Last Available: "2022-10"
 10961	purple toasty studded forbidden autumn leaf pendant	0		Spell Damage Percent: +50, Damage Absorption: +80, Hot Damage: +5, Lasts Until Rollover, Last Available: "2022-10"
 10962	denatured autumn breeze	1		Last Available: "2022-10"
 10963	irradiated galvanized polarized blinking autumn years wisdom	0		Effect: "License to Punch", Effect Duration: 66, Last Available: "2022-10"
@@ -10829,30 +10829,30 @@
 10973	thick flavorless St. Pete's sneaky smoothie	5	decent	Last Available: "2022-11"
 10974	decent enchanted blurry Pete's wiley whey bar	3	good	Effect: "Ichorous Eyesight", Effect Duration: 30, Last Available: "2022-11"
 10975	normal Pete's rich ricotta	4	good	Last Available: "2022-11"
-10976	weak aged fuchsia wobbly Boris's beer	2	awesome	Last Available: "2022-11"
+10976	weak aged wobbly fuchsia Boris's beer	2	awesome	Last Available: "2022-11"
 10977	decent tiny mirror honey bun of Boris	1	good	Last Available: "2022-11"
 10978	rotten Boris's bread	4	crappy	Last Available: "2022-11"
-10979	wobbly shaking Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	huge Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	blinking Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	ghostly Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	wobbly shaking Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	huge Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	blinking Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	ghostly Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	adequate baked veggie ricotta casserole	3	good	Last Available: "2022-11"
-10989	super-sized flavorless plain calzone	5	decent	Last Available: "2022-11"
-10990	spoiled half-sized roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
+10989	flavorless super-sized plain calzone	5	decent	Last Available: "2022-11"
+10990	half-sized spoiled roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
 10991	spoiled Pizza of Legend	4	crappy	Last Available: "2022-11"
 10992	small moldy Calzone of Legend	2	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	blurry Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	skewed Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	blurry Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	skewed Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	upside-down cookbookbat book	0		Familiar Weight: +5
-10999	narrow Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	narrow Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	flavorless blurry Deep Dish of Legend	4	decent	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	squat drink chit	0		
@@ -10908,7 +10908,7 @@
 11052	moist concentrated Trainbot plating	0		Effect: "Human-Fish Hybrid", Effect Duration: 23
 11053	electrified Trainbot optics	0		Effect: "Powder Power", Effect Duration: 13
 11054	denatured bouncing Trainbot servomotors	0		Effect: "Cautious Prowl", Effect Duration: 12
-11055	pickled shaking blurry Trainbot linkages	0		Effect: "No Worries", Effect Duration: 38
+11055	pickled blurry shaking Trainbot linkages	0		Effect: "No Worries", Effect Duration: 38
 11056	ping-pong paddle	0		Single Equip
 11057	ping-pong ball	0		
 11058	Jack Frost's Trainbot harness	0		Cold Spell Damage: +50
@@ -10931,13 +10931,13 @@
 11075	table-scraper	0		Single Equip
 11076	spinning Trainbot slag	0		
 11077	blinking industrially-crushed ice	0		Last Available: "2022-12"
-11078	flavorless tiny cyan steamed oyster	1	decent	
+11078	tiny flavorless cyan steamed oyster	1	decent	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	tumbling upside-down crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	practically non-alcoholic fancy drinkable Crimbosmopolitan	1	good	Effect: "You're High as a Crow, Marty", Effect Duration: 50, Last Available: "2022-12"
+11084	fancy drinkable practically non-alcoholic Crimbosmopolitan	1	good	Effect: "You're High as a Crow, Marty", Effect Duration: 50, Last Available: "2022-12"
 11085	normal blurry Crimbo dinner	4	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10951,7 +10951,7 @@
 11095	ribald Annie Oakley's wizardly grubby wool gloves of horror	0		Mysticality: +25, Critical Hit Percent: +20, Spooky Spell Damage: +25, Sleaze Damage: +10, Single Equip
 11096	grubby wool beerwarmer	0		
 11097	acceptable nice warm beer	3	good	
-11098	shaking skewed grubby woolball	0		
+11098	skewed shaking grubby woolball	0		
 11099	blurry Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	ghostly packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
@@ -10959,10 +10959,10 @@
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	milestone	0		Last Available: "2023-01"
 11105	ghostly bolder boulder	0		Last Available: "2023-01"
-11106	upside-down maroon molehill mountain	0		Last Available: "2023-01"
+11106	maroon upside-down molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
-11109	teal twirling stalagmite	0		Last Available: "2023-01"
+11109	twirling teal stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
 11112	moldy twirling pixel bread	4	crappy	
 11113	smooth pixel whiskey	3	awesome	
@@ -10972,14 +10972,14 @@
 11117	improved glob of extra-green chlorophyll	0		Effect: "Prelude of Precision", Effect Duration: 16, Last Available: "2023-02"
 11118	pressed mushroom	0		Effect: "Christmessy", Effect Duration: 32, Last Available: "2023-02"
 11119	non-ionized non-activated five-fingered fern resin	0		Effect: "Funky Coal Patina", Effect Duration: 41, Last Available: "2023-02"
-11120	flavorless snack-sized upside-down super good fruit	2	decent	Last Available: "2023-02"
+11120	snack-sized flavorless upside-down super good fruit	2	decent	Last Available: "2023-02"
 11121	boiled blinking energized spores	1		Last Available: "2023-02"
-11122	twirling mirror greedy asbestos-lined hot pepper	0		Hot Resistance: +5, Meat Drop: +20, Lantern Element: "Hot", Last Available: "2023-02"
+11122	twirling mirror greedy asbestos-lined hot pepper	0		Hot Resistance: +5, Meat Drop: +20, Last Available: "2023-02", Lantern Element: "Hot"
 11123	pickled out-of-work circus flea	0		Effect: "Fudge Headache", Effect Duration: 20, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	warmed pressed jittery fire ant pheromones	0		Effect: "Slimily Strong", Effect Duration: 11, Last Available: "2023-02"
 11126	unsweetened teal flapper fly	0		Effect: "Brother Smothers's Blessing", Effect Duration: 58, Last Available: "2023-02"
-11127	hand-crafted fancy shot of wasp venom	4	EPIC	Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2023-02"
+11127	fancy hand-crafted shot of wasp venom	4	EPIC	Effect: "Your Eyes are Peeled!", Effect Duration: 30, Last Available: "2023-02"
 11128	oxidized red filled mosquito	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 54, Last Available: "2023-02"
 11129	boiled spinning shim of shame shale	0		Effect: "Super-Electrified", Effect Duration: 21, Last Available: "2023-02"
 11130	improved enhanced pebble of proud pyrite	0		Effect: "Crimbo Nostalgia", Effect Duration: 37, Last Available: "2023-02"
@@ -10990,7 +10990,7 @@
 11135	rotten pulsating shadow sausage	4	crappy	Last Available: "2023-03"
 11136	squat aromatic stiffened shadow skin	0		Damage Reduction: 1, Stench Resistance: +1, Last Available: "2023-03"
 11137	ionized oxidized shadow flame	0		Effect: "Cold Blooded", Effect Duration: 35, Last Available: "2023-03"
-11138	moldy immense bouncing shadow bread	8	crappy	Last Available: "2023-03"
+11138	immense moldy bouncing shadow bread	8	crappy	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	practically non-alcoholic delicious shadow fluid	1	awesome	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
@@ -11027,21 +11027,21 @@
 11172	shadow snowflake	0		
 11173	shadow heart	0		
 11174	shadow bucket	0		
-11175	skewed blurry shadow wave	0		
+11175	blurry skewed shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	supercharged studded smooth shadow chef's hat	0		Moxie: +15, Damage Absorption: +80, Maximum MP Percent: +30
 11178	toasty beefcake's shadow trousers of the storm	0		Muscle: +25, Maximum MP Percent: +40, Hot Damage: +5
 11179	wicked smartaleck's shadow hammer	0		Moxie Percent: +30, Spell Damage: +5
 11180	executive fortified savvy shadow monocle	0		Mysticality Percent: +20, Damage Absorption: +60, Meat Drop: +40, Single Equip
 11181	spinning shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	yummy diet shadow hot dog	1	awesome	
+11182	diet yummy shadow hot dog	1	awesome	
 11183	artisanal jittery shadow martini	4	EPIC	
 11184	compressed squat shadow pill	1		
 11185	blurry shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	activated shadow candy	0		Effect: "Stogied", Effect Duration: 32
-11189	teal blurry replica Mr. Accessory	0		
+11189	blurry teal replica Mr. Accessory	0		
 11190	teal replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
 11192	squat replica crimbo elfling	0		
@@ -11057,7 +11057,7 @@
 11202	zippy replica V for Vivala mask of mayonnaise	0		Sleaze Spell Damage: +50, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	razor-sharp Herculean replica haiku katana of the early riser	0		Experience (Muscle): +1, Weapon Damage Percent: +25, Adventures: +7, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
-11205	jittery purple replica cotton candy cocoon	0		
+11205	purple jittery replica cotton candy cocoon	0		
 11206	olive inspector's hardened brawny replica Elvish sunglasses of the dark arts	0		Muscle Percent: +20, Spell Damage Percent: +100, Damage Reduction: 3, Item Drop: +15, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
 11208	ghostly replica stone sphere	0		
@@ -11077,7 +11077,7 @@
 11222	shaking shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
 11223	avaricious healthy weightlifter's Cincho de Mayo of Tarzan	0		Muscle: +15, Experience (Muscle): +3, Maximum HP Percent: +20, Meat Drop: +30, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	shaking dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
-11225	skewed huge blurry replica Little Geneticist DNA-Splicing Lab	0		
+11225	blurry skewed huge replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
 11227	jittery replica Crimbo sapling	0		
 11228	replica puck	0		
@@ -11134,7 +11134,7 @@
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	tumbling Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	delicious watered-down Sexy Cosmo	2	awesome	Last Available: "2023-06"
+11282	watered-down delicious Sexy Cosmo	2	awesome	Last Available: "2023-06"
 11283	yellow Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	spinning avaricious flame-wreathed supercool red-soled high heels	0		Moxie Percent: +20, Hot Spell Damage: +10, Meat Drop: +30, Last Available: "2023-06"
 11285	tasty cyburger	4	awesome	Last Available: "2025-12"
@@ -11142,7 +11142,7 @@
 11287	padded strapping rutabuga bag	0		Muscle: +5, Damage Absorption: +20
 11288	rock-hard mesquito proboscis	0		Damage Reduction: 5
 11289	beefy senate fly thorax	0		Muscle: +10
-11290	vacuum-sealed quantum spinning twirling bug juice	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 28
+11290	vacuum-sealed quantum twirling spinning bug juice	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 28
 11291	knitted spider leg	0		Cold Resistance: +3
 11292	experienced beetle antenna	0		Experience: +2
 11293	blinking maroon electrified mantis skull	0		MP Regen Min: 3, MP Regen Max: 5
@@ -11172,7 +11172,7 @@
 11317	handful of toilet paper	0		
 11318	teal Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	perfectly mixed spirit-forward bottle of Cabernet Sauvignon	5	EPIC	
+11320	spirit-forward perfectly mixed bottle of Cabernet Sauvignon	5	EPIC	
 11321	greasy slick brainy baywatch	0		Mysticality: +5, Moxie: +10, Sleaze Spell Damage: +10, Lasts Until Rollover
 11322	cyan Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
@@ -11182,9 +11182,9 @@
 11327	purple residual chitin paste	0		Skill: "Chitinous Soul"
 11328	altered mirror concentrated cooking	1		
 11329	distilled meat	1		Effect: "Ancient Protected", Effect Duration: 35
-11330	pickled wobbly skewed lime green sparkling orb	1		Effect: "Sugar High", Effect Duration: 15
+11330	pickled wobbly lime green skewed sparkling orb	1		Effect: "Sugar High", Effect Duration: 15
 11331	pickled gray ghostly hardening cream	1		Effect: "Brocolate Brostidigitation", Effect Duration: 15
-11332	mixed bouncing maroon pool shark hair oil	1		
+11332	mixed maroon bouncing pool shark hair oil	1		
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	huge book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
@@ -11212,7 +11212,7 @@
 11357	upside-down Van der Graaf steel-toed smoldering drape	0		Damage Reduction: 9, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	therapeutic dance instructor's Da Vinci's weightlifter's leaf crown of the dark arts of the blizzard	0		Muscle: +15, Experience (Mysticality): +5, Experience Percent (Moxie): +10, Spell Damage Percent: +100, Cold Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7
-11360	flavorless miniature jittery leafy browns	2	decent	
+11360	miniature flavorless jittery leafy browns	2	decent	
 11361	quantum dry autumnic balm	0		Effect: "Sagittarius Rising", Effect Duration: 23
 11362	extra-pressed coping juice	0		Effect: "Remaining Alive", Effect Duration: 60
 11363	miser's asbestos-lined healthy slick candy cane sword cane of wisdom	0		Mysticality: +15, Moxie: +10, Maximum HP Percent: +20, Hot Resistance: +5, Meat Drop: +10, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11232,7 +11232,7 @@
 11377	housekeeping robot	0		
 11378	flavorless pickled bread	3	decent	Last Available: "2023-12"
 11379	normal fancy gray salted mutton	4	good	Effect: "Heart Aflame", Effect Duration: 10, Last Available: "2023-12"
-11380	snack-sized fancy rotten corned beet	2	crappy	Effect: "Dreadful Chill", Effect Duration: 20, Last Available: "2023-12"
+11380	rotten fancy snack-sized corned beet	2	crappy	Effect: "Dreadful Chill", Effect Duration: 20, Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11274,10 +11274,10 @@
 11419	blurry executive savvy Elf Guard broom	0		Mysticality Percent: +20, Meat Drop: +40, Last Available: "2023-12"
 11420	stiffened fortified Crimbuccaneer tavern swab of Flo-Jo	0		Damage Absorption: +60, Damage Reduction: 1, Initiative: +100, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	lousy high-proof pulsating old-school pirate grog	6	decent	Last Available: "2023-12"
+11422	high-proof lousy pulsating old-school pirate grog	6	decent	Last Available: "2023-12"
 11423	flavorless grog nuts	4	decent	Last Available: "2023-12"
 11424	reassuring fireproof scandalous sawed-off blunderbuss	0		Sleaze Damage: +5, Hot Resistance: +3, Spooky Resistance: +1, Last Available: "2023-12"
-11425	bad high-proof officer's nog	9	decent	Last Available: "2023-12"
+11425	high-proof bad officer's nog	9	decent	Last Available: "2023-12"
 11426	bouncing peppermint bomb	0		Last Available: "2023-12"
 11427	normal sundae ration	3	good	Last Available: "2023-12"
 11428	decent green jittery peppermint tack	4	good	Last Available: "2023-12"
@@ -11295,7 +11295,7 @@
 11440	lard-coated Van der Graaf fortified Kelflar vest	0		Damage Absorption: +60, Sleaze Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2023-12"
 11441	magnetized narrow whale cerebrospinal fluid	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 28, Last Available: "2023-12"
 11442	skewed wicked Crimbuccaneer runebone of the businessman	0		Spell Damage: +5, Meat Drop: +50, Single Equip, Last Available: "2023-12"
-11443	mirror red cannonbomb	0		Last Available: "2023-12"
+11443	red mirror cannonbomb	0		Last Available: "2023-12"
 11444	Elf Guard mouthknife of the overflowing toilet of the early riser	0		Stench Spell Damage: +50, Adventures: +7, Last Available: "2023-12"
 11445	narrow purple flame-retardant thinker's Crimbuccaneer fledges (disintegrating)	0		Mysticality: +10, Hot Resistance: +1, Single Equip, Last Available: "2023-12"
 11446	narrow lightning-fast Elf Guard fuel tank	0		Initiative: +40, Last Available: "2023-12"
@@ -11311,24 +11311,24 @@
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	wholesome Elvish underarmor of the pedagogue of the sweet-tooth	0		Experience: +3, Maximum HP Percent: +10, Candy Drop: +100, Single Equip, Last Available: "2023-12"
 11458	squat aromatic wicked Crimbuccaneer bombjacket	0		Spell Damage: +5, Stench Resistance: +1, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	massive bland twirling sugarplum ration	8	decent	Last Available: "2023-12"
+11459	bland massive twirling sugarplum ration	8	decent	Last Available: "2023-12"
 11460	adequate small gingerbread nylons	2	good	Last Available: "2023-12"
 11461	rotten thick fuchsia twirling rum-soaked fruitcake	5	crappy	Last Available: "2023-12"
-11462	spoiled diet lime	1	crappy	Last Available: "2023-12"
+11462	diet spoiled lime	1	crappy	Last Available: "2023-12"
 11463	spoiled squat gingerbread pirate	4	crappy	Last Available: "2023-12"
 11464	adequate blue fruit-stuffed rumcake	3	good	Last Available: "2023-12"
 11465	weak perfectly mixed shaking mulled wine	2	EPIC	Last Available: "2023-12"
-11466	practically non-alcoholic tolerable maroon Swedish coffee	1	good	Last Available: "2023-12"
+11466	tolerable practically non-alcoholic maroon Swedish coffee	1	good	Last Available: "2023-12"
 11467	weak perfectly mixed pulsating canteen of eggnog	2	super ultra mega EPIC	Last Available: "2023-12"
-11468	delicious watered-down hot wine	2	awesome	Last Available: "2023-12"
+11468	watered-down delicious hot wine	2	awesome	Last Available: "2023-12"
 11469	watered-down mediocre Jamaican coffee	2	decent	Last Available: "2023-12"
-11470	weak perfectly mixed flask of egggrog	2	super ultra mega EPIC	Last Available: "2023-12"
+11470	perfectly mixed weak flask of egggrog	2	super ultra mega EPIC	Last Available: "2023-12"
 11471	lime green Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	mirror pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	acceptable blurry yule grog	4	good	Last Available: "2023-12"
 11475	moldy maroon wet tack	3	crappy	Last Available: "2023-12"
-11476	half-sized adequate huge whalecake	2	good	Last Available: "2023-12"
+11476	adequate half-sized huge whalecake	2	good	Last Available: "2023-12"
 11477	zippy Annie Oakley's hardy gunwale whalegun	0		Maximum HP: +50, Critical Hit Percent: +20, Initiative: +20, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	acceptable and claret	3	good	Last Available: "2023-12"
 11479	bouncing rigging knot	0		Familiar Weight: +5
@@ -11382,8 +11382,8 @@
 11527	vacuum-sealed quadruple-unsweetened crepe paper peanut candy	0		Effect: "Macho Profundo", Effect Duration: 51
 11528	flame-wreathed beefcake's petrified wood war pike	0		Muscle: +25, Hot Spell Damage: +10, Last Available: "2025-12"
 11529	careful clever petrified wood waist protector	0		Maximum MP: +20, Monster Level: -10, Single Equip, Last Available: "2025-12"
-11530	wobbly Sinatra's petrified wood wizard's pouch of the brute	0		Muscle Percent: +30, Experience (Moxie): +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	gray hale Samson's petrified wood water purifier	0		Experience (Muscle): +5, Maximum HP: +20, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	wobbly Sinatra's petrified wood wizard's pouch of the brute	0		Muscle Percent: +30, Experience (Moxie): +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	gray hale Samson's petrified wood water purifier	0		Experience (Muscle): +5, Maximum HP: +20, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	hardy petrified wood whoopie panama of the cougar	0		Moxie: +20, Maximum HP: +50, Last Available: "2025-12"
 11533	pulsating knitted occult petrified wood walking pants	0		Spell Damage Percent: +25, Cold Resistance: +3, Last Available: "2025-12"
 11534	dried bouncing twirling petrified wood waste parts	1		Effect: "Fancy Feasted", Effect Duration: 30, Last Available: "2025-12"
@@ -11399,7 +11399,7 @@
 11544	gravedigger's Elf Guard war standard of the brute	0		Muscle Percent: +30, Spooky Damage: +10, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	clever arcane researcher's spring shoes of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Maximum MP: +20, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
-11547	improved altered unsweetened blinking green spinning ultra-soft ferns	0		Effect: "Cold, Dead Hands", Effect Duration: 54, Last Available: "2024-02"
+11547	improved altered unsweetened spinning green blinking ultra-soft ferns	0		Effect: "Cold, Dead Hands", Effect Duration: 54, Last Available: "2024-02"
 11548	activated electrified vacuum-sealed crunchy brush	0		Effect: "Lemony Goodness", Effect Duration: 50, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
@@ -11426,10 +11426,10 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	toothsome yam	4	awesome	Last Available: "2024-05"
-11574	lousy irresponsibly strong fuchsia yam martini	10	decent	Last Available: "2024-05"
+11574	irresponsibly strong lousy fuchsia yam martini	10	decent	Last Available: "2024-05"
 11575	artisanal blinking sweet potato o' mine	3	EPIC	Last Available: "2024-05"
 11576	delicious Southern yam	3	awesome	Last Available: "2024-05"
-11577	practically non-alcoholic mediocre tumbling sweet potato punch	1	decent	Last Available: "2024-05"
+11577	mediocre practically non-alcoholic tumbling sweet potato punch	1	decent	Last Available: "2024-05"
 11578	tasty Mayam spinach	4	awesome	Last Available: "2024-05"
 11579	stale yam and swiss	4	decent	Last Available: "2024-05"
 11580	spinning knitted studded yam cannon of the wise owl	0		Mysticality: +20, Damage Absorption: +80, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2024-05"
@@ -11442,7 +11442,7 @@
 11587	fancy rotten yam slider	4	crappy	Effect: "The Dinsey Way", Effect Duration: 10, Last Available: "2024-05"
 11588	low-calorie moldy yam mayo	1	crappy	Last Available: "2024-05"
 11589	immense bland yam burrito	9	decent	Last Available: "2024-05"
-11590	olive shaking visual packet sniffer	0		Last Available: "2025-12"
+11590	shaking olive visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	shaking aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
@@ -11453,7 +11453,7 @@
 11598	mini kiwi aioli	0		
 11599	wobbly executive foul-smelling dangerous mini kiwi silicon tiepin	0		Weapon Damage: +10, Stench Damage: +10, Meat Drop: +40
 11600	mini kiwi tipi	0		
-11601	adequate jumbo mini kiwi digitized cookies	5	good	
+11601	jumbo adequate mini kiwi digitized cookies	5	good	
 11602	drinkable mini kiwi intoxicating spirits	3	good	
 11603	wet mini kiwi antimilitaristic hippy petition	0		Effect: "Bilious Brains", Effect Duration: 21
 11604	nitrogenated electrified mini kiwi illicit antibiotic	0		Effect: "20-20 Second Sight", Effect Duration: 40
@@ -11470,9 +11470,9 @@
 11615	up-at-dawn Socratic messenger bag RNA of horror	0		Experience (Mysticality): +1, Spooky Spell Damage: +25, Adventures: +5
 11616	mirror flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	moldy low-calorie huge pulsating bacteria bisque	1	crappy	
+11618	moldy low-calorie pulsating huge bacteria bisque	1	crappy	
 11619	flavorless ciliophora chowder	3	decent	
-11620	moldy gigantic blurry cream of chloroplasts	8	crappy	
+11620	gigantic moldy blurry cream of chloroplasts	8	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	flagellate soup	0		
@@ -11529,7 +11529,7 @@
 11674	moldy skewed whirled peas	3	crappy	Last Available: "2024-11"
 11675	stale snack-sized peaza	2	decent	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
-11677	dehydrated mirror gray drenchrome 2.0	1		Last Available: "2025-12"
+11677	dehydrated gray mirror drenchrome 2.0	1		Last Available: "2025-12"
 11678	denatured tumbling pulsating Synapse Blaster	1		Last Available: "2025-12"
 11679	quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
@@ -11545,7 +11545,7 @@
 11690	sinister jolly roger flag	0		Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
 11691	skewed sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	weak acceptable tankard of spiced rum	2	good	Last Available: "2024-12"
+11693	acceptable weak tankard of spiced rum	2	good	Last Available: "2024-12"
 11694	extra-dry artisanal pulsating tankard of spiced Goldschlepper	5	EPIC	Last Available: "2024-12"
 11695	tumbling packaged luxury garment	0		Last Available: "2024-12"
 11696	governor's daughter's lace collar of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2024-12"
@@ -11562,7 +11562,7 @@
 11707	lion tamer's silky pirate drawers of James Dean	0		Experience (Moxie): +3, Experience (familiar): +2, Last Available: "2024-12"
 11708	yellow profane eye patch	0		Sleaze Damage: +3
 11709	extra-enhanced tarnished peppermint pegleg	0		Effect: "Powder Power", Effect Duration: 22, Last Available: "2024-12"
-11710	perfectly mixed watered-down enchanted upside-down hard cocoa	2	EPIC	Effect: "Physicali Tea", Effect Duration: 30, Last Available: "2024-12"
+11710	perfectly mixed enchanted watered-down upside-down hard cocoa	2	EPIC	Effect: "Physicali Tea", Effect Duration: 30, Last Available: "2024-12"
 11711	snack-sized adequate salmagumdi	2	good	Last Available: "2024-12"
 11712	forbidden plastic Easter Island Bunny	0		Spell Damage Percent: +50, Last Available: "2024-12"
 11713	perfumed plastic St. Patrick	0		Stench Resistance: +5, Last Available: "2024-12"
@@ -11579,7 +11579,7 @@
 11724	delicious moai toai	3	awesome	
 11725	shaking rosewater-soaked frosty moaiball of the pedagogue	0		Experience: +3, Cold Spell Damage: +10, Stench Resistance: +3, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
-11727	unsweetened magnetized wobbly red four-leaf potato sprout	0		Effect: "Down With Chow", Effect Duration: 28, Last Available: "2024-12"
+11727	unsweetened magnetized red wobbly four-leaf potato sprout	0		Effect: "Down With Chow", Effect Duration: 28, Last Available: "2024-12"
 11728	purple blinking tumbling auspicious veiny potato jacket of the brute	0		Muscle Percent: +30, Maximum HP: +10, Item Drop: +10, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	mirror Brandonian footlocker key	0		Last Available: "2024-12"
@@ -11599,15 +11599,15 @@
 11744	magnetized LIDAR candle	0		Effect: "Oriental Mysticism", Effect Duration: 18, Last Available: "2024-12"
 11745	huge ghostly hardy deadly Newton's Congressional Medal of Insanity	0		Experience (Mysticality): +3, Weapon Damage: +5, Maximum HP: +50, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	lousy practically non-alcoholic Easter grasshopper	1	decent	Last Available: "2024-12"
-11748	extra-dry acceptable Irish eggnog	5	good	Last Available: "2024-12"
+11747	practically non-alcoholic lousy Easter grasshopper	1	decent	Last Available: "2024-12"
+11748	acceptable extra-dry Irish eggnog	5	good	Last Available: "2024-12"
 11749	tolerable canteen of jungle juice	4	good	Last Available: "2024-12"
 11750	hand-crafted turchucken	3	EPIC	Last Available: "2024-12"
 11751	artisanal mechanically-mulled cider	4	EPIC	Last Available: "2024-12"
-11752	artisanal practically non-alcoholic holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
-11753	massive bland cyan chocolate ostrich egg	6	decent	Last Available: "2024-12"
+11752	practically non-alcoholic artisanal holiday trip around the world	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11753	bland massive cyan chocolate ostrich egg	6	decent	Last Available: "2024-12"
 11754	bland skewed beef and cabbage	3	decent	Last Available: "2024-12"
-11755	small decent candy rations	2	good	Last Available: "2024-12"
+11755	decent small candy rations	2	good	Last Available: "2024-12"
 11756	stale immense double-candied yams	8	decent	Last Available: "2024-12"
 11757	normal Christmas ham	4	good	Last Available: "2024-12"
 11758	normal narrow holiday smorgasbord	4	good	Last Available: "2024-12"
@@ -11616,9 +11616,9 @@
 11761	pulsating Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11763	How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	huge pulsating How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	pulsating huge How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	twirling Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	skewed blinking Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	blinking skewed Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
 11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
@@ -11629,7 +11629,7 @@
 11774	narrow candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
 11776	flavorless Thanksgiving ration	4	decent	Last Available: "2024-12"
-11777	watered-down tolerable cyan Easter eggnog	2	good	Last Available: "2024-12"
+11777	tolerable watered-down cyan Easter eggnog	2	good	Last Available: "2024-12"
 11778	compressed clovermint	1		Effect: "Coy to the Hurled", Effect Duration: 5, Last Available: "2024-12"
 11779	vibrating hale nylon Christmas stockings of the cougar of the pedagogue	0		Moxie: +20, Experience: +3, Maximum HP: +20, Maximum MP Percent: +10, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
@@ -11648,7 +11648,7 @@
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	upside-down dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
-11796	olive wobbly dedigitizer schematic: digibritches	0		Last Available: "2025-12"
+11796	wobbly olive dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
 11798	dedigitizer schematic: zero-trust tanktop	0		Last Available: "2025-12"
 11799	dedigitizer schematic: retro floppy disk	0		Last Available: "2025-12"
@@ -11674,8 +11674,8 @@
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
-11822	bouncing jittery OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
-11823	squat spinning fuchsia STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
+11822	jittery bouncing OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
+11823	fuchsia squat spinning STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	red hashing vise	0		Last Available: "2025-12"
@@ -11684,7 +11684,7 @@
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	ninja crampons	0		
-11832	teal ghostly ninja carabiner	0		
+11832	ghostly teal ninja carabiner	0		
 11833	non-nitrogenated jittery synthetic coffee	0		Effect: "Tingly Wrists", Effect Duration: 19
 11834	polarized iDrops	0		Effect: "Drunk With Power", Effect Duration: 11
 11835	ghostly shame coil	0		
@@ -11723,13 +11723,13 @@
 11868	spoon	0		
 11869	unironic knife	0		
 11870	squat bar dart	0		Last Available: "2025-03"
-11871	altered blurry purple leprechaun antidepressant pill	1		Last Available: "2025-03"
+11871	altered purple blurry leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	yummy Heck ramen	4	awesome	Last Available: "2025-03"
 11873	half-sized decent burrito	2	good	Last Available: "2025-03"
 11874	spoiled immense fancy small beer brat	8	crappy	Effect: "Clean-Shaven", Effect Duration: 40, Last Available: "2025-03"
-11875	toothsome gigantic peach pie	10	awesome	Last Available: "2025-03"
+11875	gigantic toothsome peach pie	10	awesome	Last Available: "2025-03"
 11876	stale incredible mini-pizza	4	decent	Last Available: "2025-03"
-11877	special bad Divine sidecar	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 35, Last Available: "2025-03"
+11877	bad special Divine sidecar	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 35, Last Available: "2025-03"
 11878	acceptable weak tangarita sidecar	2	good	Last Available: "2025-03"
 11879	perfectly mixed bouncing gimlet sidecar	4	EPIC	Last Available: "2025-03"
 11880	drinkable vodka stratocaster sidecar	3	good	Last Available: "2025-03"
@@ -11740,14 +11740,14 @@
 11885	jittery glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	denatured tarnished wet paper weights	0		Effect: "Petit Forbearance", Effect Duration: 31, Last Available: "2025-04"
-11888	lousy strong spinning Three Sheets to the Wind	5	decent	Last Available: "2025-04"
+11888	strong lousy spinning Three Sheets to the Wind	5	decent	Last Available: "2025-04"
 11889	massive decent shaking pile of wet dates	10	good	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	blinking curative wet shower cap	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-04"
 11893	teal mirror flame-wreathed wet shower shoes	0		Hot Spell Damage: +10, Last Available: "2025-04"
 11894	shaking wet shower shorts of Flo-Jo	0		Initiative: +100, Last Available: "2025-04"
-11895	shaking wobbly wet paper tiger	0		Last Available: "2025-04"
+11895	wobbly shaking wet paper tiger	0		Last Available: "2025-04"
 11896	green wet paper eye	0		Familiar Weight: +15
 11897	narrow wet shower curtain	0		Last Available: "2025-04"
 11898	nitrogenated wet paper cup	0		Effect: "PERL of Great Price", Effect Duration: 34, Last Available: "2025-04"
@@ -11794,12 +11794,12 @@
 11939	tumbling skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
-11942	red jittery M&ouml;bius ring	0		Last Available: "2025-08"
+11942	jittery red M&ouml;bius ring	0		Last Available: "2025-08"
 11943	bone pacifier	0		Familiar Weight: +5
 11944	reassuring nasty nippy Allied Forces insignia	0		Cold Damage: +10, Stench Damage: +5, Spooky Resistance: +1, Single Equip
 11945	blinking Allied Tattoo Kit	0		
 11946	tumbling handheld Allied radio	0		
-11947	blinking gray Axis codebook	0		
+11947	gray blinking Axis codebook	0		
 11948	energized nitrogenated narrow Life Goals Pamphlet	0		Effect: "Voracious Gorging", Effect Duration: 35, Last Available: "2025-08"
 11949	rosewater-soaked bully badge	0		Stench Resistance: +3, Lasts Until Rollover, Last Available: "2025-08"
 11950	mirror time cop top hat of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2025-08"
@@ -11814,7 +11814,7 @@
 11960	twirling really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	hardy undersea surveying goggles	0		Maximum HP: +50, Lasts Until Rollover
-11963	practically non-alcoholic acceptable Ocean-Touched Rum	1	good	
+11963	acceptable practically non-alcoholic Ocean-Touched Rum	1	good	
 11964	distilled pulsating water-logged pill	1		
 11965	big normal kelp puck	5	good	
 11966	squat bouncing scroll of sea strength	0		
@@ -11827,12 +11827,12 @@
 11973	Thwaitgold lobster statuette	0		
 11974	ghostly packaged Monodent of the Sea	0		Free Pull
 11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
-11976	narrow skewed blurry lime green unblemished pearl	0		
+11976	lime green narrow blurry skewed unblemished pearl	0		
 11977	beefy dentadent	0		Muscle: +10
 11986	narrow lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
 11987	flame-retardant smelly Temple Grandin's Tesla hale dance instructor's blood cubic zirconia	0		Experience Percent (Moxie): +10, Maximum HP: +20, Familiar Weight: +7, Stench Spell Damage: +10, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	diluted squat blood thinner	1		Effect: "Aspect of the Twinklefairy", Effect Duration: 20, Last Available: "2025-10"
-12045	mediocre practically non-alcoholic pheromone cocktail	1	decent	Last Available: "2025-10"
+12045	practically non-alcoholic mediocre pheromone cocktail	1	decent	Last Available: "2025-10"
 12046	low-calorie decent spinal tapas	1	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
 12048	shaking mansplainer's deadly smartaleck's shrunken head	0		Moxie Percent: +30, Weapon Damage: +5, Monster Level: +15, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
@@ -11840,7 +11840,7 @@
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	drinkable Smoking Pope	4	good	
-12053	big bland olive wobbly prize turkey	5	decent	
+12053	bland big wobbly olive prize turkey	5	decent	
 12054	dehydrated bouncing medicinal gruel	1		Effect: "Elron's Explosive Etude", Effect Duration: 50
 12055	flavorless full-sized pumpkin pie	3	decent	Last Available: "2025-11"
 12056	smooth vodka cranberry sauce	3	awesome	Last Available: "2025-11"
@@ -11869,7 +11869,7 @@
 12079	prompt devilbone corset	0		Adventures: +3, Last Available: "2026-12"
 12080	tumbling devilbone flute of extreme caution of the boozehound	0		Monster Level: -25, Booze Drop: +100, Last Available: "2026-12"
 12081	gravedigger's devilbone rosary	0		Spooky Damage: +10, Single Equip, Last Available: "2026-12"
-12082	distilled upside-down bouncing devilbone chunks	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 50, Last Available: "2026-12"
+12082	distilled bouncing upside-down devilbone chunks	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 50, Last Available: "2026-12"
 12083	polarized colloidal Gehenna tattoo	0		Effect: "Uncanny Shot", Effect Duration: 68
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	mirror burnt phalange	0		Last Available: "2025-12"
@@ -11879,18 +11879,18 @@
 12121	pulsating Crymbocurrency	0		Last Available: "2025-12"
 12122	occult extra-thick Crimbo sweater	0		Spell Damage Percent: +25, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	high-proof perfectly mixed Steve Abrams' Holiday Sampler Beer	6	EPIC	Last Available: "2025-12"
+12124	perfectly mixed high-proof Steve Abrams' Holiday Sampler Beer	6	EPIC	Last Available: "2025-12"
 12125	blue crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	smooth bottle of prize-winning rum	4	awesome	Last Available: "2025-12"
 12127	Fonzie's Santa-Slayer medal of the cougar of doom	0		Moxie: +20, Experience (Moxie): +1, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
-12129	improved dry skewed blue boiling bone marrow	0		Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2025-12"
+12129	improved dry blue skewed boiling bone marrow	0		Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2025-12"
 12130	diffused triple-magnetized mirror boiling cerebrospinal fluid	0		Effect: "Sleazy Jellied", Effect Duration: 47, Last Available: "2025-12"
 12131	electrified green boiling synovial fluid	0		Effect: "The Power of Positive Thinking", Effect Duration: 54, Last Available: "2025-12"
 12132	up-at-dawn fireproof supercharged smoldering vertebra	0		Maximum MP Percent: +30, Hot Resistance: +3, Adventures: +5, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
-12135	cyan shaking smoldering bone dust	0		Last Available: "2025-12"
+12135	shaking cyan smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	bouncing zippy forbidden grievous hot boning knife	0		Weapon Damage Percent: +50, Spell Damage Percent: +50, Initiative: +20, Single Equip, Last Available: "2025-12"
 12138	blue nasty supercharged fistbone of terror	0		Maximum MP Percent: +30, Stench Damage: +5, Spooky Spell Damage: +10, Last Available: "2025-12"
@@ -11927,10 +11927,10 @@
 12169	fuchsia squat fireproof ship's lantern	0		Hot Resistance: +3, Last Available: "2025-12"
 12170	squat Oprah's thinker's heat-resistant harpoon pistol	0		Mysticality: +10, Maximum MP Percent: +50, Last Available: "2025-12"
 12171	adequate traditional gingerloaf	3	good	Last Available: "2025-12"
-12172	mediocre fortified Scotch and eggnog	5	decent	Last Available: "2025-12"
+12172	fortified mediocre Scotch and eggnog	5	decent	Last Available: "2025-12"
 12173	dry counterskeleton elixir	0		Effect: "Sleazy Weapon", Effect Duration: 33, Last Available: "2025-12"
 12174	bad weak blurry &quot;salvaged&quot; wine	2	decent	Last Available: "2025-12"
-12175	wobbly gray skewed The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12175	skewed gray wobbly The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	stale tiny green tumbling wedge of prize-winning cheese	1	decent	Last Available: "2025-12"
 12178	triple-Vulcanized purple gummi fingerbone	0		Effect: "Spooky Flavor", Effect Duration: 21
@@ -11959,7 +11959,7 @@
 12201	fuchsia boxer's dinosaur bone club	0		Muscle Percent: +10, Last Available: "2026-03"
 12202	hale dinosaur skull helmet of the businessman	0		Maximum HP: +20, Meat Drop: +50, Last Available: "2026-03"
 12203	yellow greedy Jeselnik's smartaleck's dinosaur bone corset	0		Moxie Percent: +30, Sleaze Damage: +25, Meat Drop: +20, Last Available: "2026-03"
-12204	weak smooth Pork Elf cough syrup	2	awesome	Last Available: "2026-03"
+12204	smooth weak Pork Elf cough syrup	2	awesome	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	squat ghostly Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
@@ -11973,16 +11973,16 @@
 12215	wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	diet bland discarded hot dog	1	decent	Last Available: "2026-04"
-12218	hand-crafted triple-distilled most of a beer	6	EPIC	Last Available: "2026-04"
+12218	triple-distilled hand-crafted most of a beer	6	EPIC	Last Available: "2026-04"
 12222	tumbling pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	twirling legendary noodles	0		Last Available: "2026-05"
 12226	tasty can of tuna	4	awesome	
-12227	bite-sized bland tumbling alien salad	1	decent	
-12228	small flavorless ratbatatouille	2	decent	
+12227	bland bite-sized tumbling alien salad	1	decent	
+12228	flavorless small ratbatatouille	2	decent	
 12229	yummy onigiri	4	awesome	
 12230	moldy crudit&eacute;s	3	crappy	
-12231	immense tasty special sauced mutton	7	awesome	Effect: "Concentrated Concentration", Effect Duration: 45
+12231	special immense tasty sauced mutton	7	awesome	Effect: "Concentrated Concentration", Effect Duration: 45
 12232	normal blinking hot honey ant	4	good	
 12233	yummy tomb aspic	3	awesome	
 12234	half-sized rotten later tots	2	crappy	
@@ -11991,8 +11991,8 @@
 12237	normal Arrattabbattabiata	4	good	Last Available: "2026-05"
 12238	decent big Orzo di Riso	5	good	Last Available: "2026-05"
 12239	toothsome wobbly Pasta Grimavera	3	awesome	Last Available: "2026-05"
-12240	moldy snack-sized Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
-12241	fancy flavorless skewed blinking Formica e Pepe	3	decent	Effect: "Frigid Weapon", Effect Duration: 5, Last Available: "2026-05"
+12240	snack-sized moldy Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
+12241	flavorless fancy blinking skewed Formica e Pepe	3	decent	Effect: "Frigid Weapon", Effect Duration: 5, Last Available: "2026-05"
 12242	bland mirror Tubetto Gelatto	3	decent	Last Available: "2026-05"
 12243	decent Gnocci Domani	4	good	Last Available: "2026-05"
 12244	squat Thwaitgold wallet moth statuette	0		
@@ -12019,8 +12019,8 @@
 12269	tumbling packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	blurry Usain Bolt's therapeutic experienced Portable Laughing Stock	0		Experience: +2, Initiative: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	skewed sizzling Fonzie's Newton's Staff of Anachronistic Churning	0		Experience (Mysticality): +3, Experience (Moxie): +1, Hot Damage: +10
-12272	stale miniature classic banana	2	decent	Last Available: "2026-07"
-12273	flavorless immense huge wobbly watermelon	9	decent	Last Available: "2026-07"
+12272	miniature stale classic banana	2	decent	Last Available: "2026-07"
+12273	immense flavorless huge wobbly watermelon	9	decent	Last Available: "2026-07"
 12274	fancy flavorless quince	3	decent	Effect: "Badger Underfoot", Effect Duration: 30, Last Available: "2026-07"
 12275	blinking Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
@@ -12038,11 +12038,11 @@
 12288	super-Vulcanized mirror quince quaff	0		Effect: "Carrrsmic", Effect Duration: 52, Last Available: "2026-07"
 12289	nitrogenated magnetized wobbly Quickquince	0		Effect: "Moon-Eyed", Effect Duration: 11, Last Available: "2026-07"
 12290	delicious Quiskey Sour	3	awesome	Last Available: "2026-07"
-12291	perfectly mixed distilled Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
+12291	distilled perfectly mixed Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
 12292	artisanal Roth IPA	3	EPIC	Last Available: "2026-08"
 12293	ghostly smooth strapping underdraft protection	0		Muscle: +5, Moxie: +15, Last Available: "2026-08"
 12294	bouncing solvent	0		Last Available: "2026-08"
-12295	rotten fancy miniature soybean futures	2	crappy	Effect: "Okee-Dokee Computer", Effect Duration: 30, Last Available: "2026-08"
+12295	miniature rotten fancy soybean futures	2	crappy	Effect: "Okee-Dokee Computer", Effect Duration: 30, Last Available: "2026-08"
 12296	super-diffused shaking housing bubble	0		Effect: "Weird Vibrations", Effect Duration: 21, Last Available: "2026-08"
 12297	dry Pixie-Swordz	0		Effect: "Happy Salamander", Effect Duration: 59
 12298	scorching financial instrument of doom	0		Hot Damage: +25, Spooky Spell Damage: +50, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Seal_Clubber_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wombat_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	weak tolerable Petite Porter	2	good	
--2	lousy weak Scrawny Stout	2	decent	
+-1	tolerable weak Petite Porter	2	good	
+-2	weak lousy Scrawny Stout	2	decent	
 -3	tolerable Infinitesimal IPA	3	good	
--4	spirit-forward artisanal eggnogtini	5	EPIC	
--5	artisanal practically non-alcoholic candycaine	1	super ultra EPIC	
+-4	artisanal spirit-forward eggnogtini	5	EPIC	
+-5	practically non-alcoholic artisanal candycaine	1	super ultra EPIC	
 -6	weak bad teal braincracker sweet	2	decent	
 -16	hand-crafted pulsating fermented honey	4	EPIC	
--17	practically non-alcoholic hand-crafted moons-shine	1	EPIC	
--18	bad boozy purple gin	5	decent	
+-17	hand-crafted practically non-alcoholic moons-shine	1	EPIC	
+-18	boozy bad purple gin	5	decent	
 -19	drinkable squat blurry ecto-nog	4	good	
 -20	drinkable squat hot toady	3	good	
 -21	smooth hot choculate	3	awesome	
 -49	acceptable twirling Cyder	3	good	
--50	practically non-alcoholic tolerable Oil Nog	1	good	
+-50	tolerable practically non-alcoholic Oil Nog	1	good	
 -51	bad practically non-alcoholic upside-down Hi-Octane Peppermint Jet Fuel	1	decent	
 -58	high-proof acceptable Grimacider	9	good	
--59	watered-down perfectly mixed cyan jittery twirling Isotope Nog	2	EPIC	
+-59	perfectly mixed watered-down jittery twirling cyan Isotope Nog	2	EPIC	
 -60	artisanal spinning Mutagin 'n' Tonic	4	EPIC	
 -70	aged Gin and Herring	3	awesome	
 -71	aged ghostly Black and Tan and Red All Over	3	awesome	
 -72	acceptable upside-down Antarctic Ice Tea	3	good	
--76	enchanted drinkable CRIMBCO Ribbon Candy Schnapps	3	good	
+-76	drinkable enchanted CRIMBCO Ribbon Candy Schnapps	3	good	
 -77	lousy blinking CRIMBCO Egg Substitute Nog Substitute	4	decent	
 -78	extra-dry smooth twirling CRIMBCO Extreme Braincracker Sour	5	awesome	
 -82	perfectly mixed bouncing Horseradish-infused Vodka	3	EPIC	
--83	mediocre practically non-alcoholic narrow Jerkitini	1	decent	
+-83	practically non-alcoholic mediocre narrow Jerkitini	1	decent	
 -84	perfectly mixed Desert Island Iced Tea	4	EPIC	
--88	fortified bad Crimbo Saketini	5	decent	
+-88	bad fortified Crimbo Saketini	5	decent	
 -89	weak smooth pulsating skewed Crimboku Drop	2	awesome	
 -90	mediocre Flaming Crimbo Log	3	decent	
 -107	artisanal Fortified Eggnog Slurry	3	EPIC	
 -108	hand-crafted Hot Buttered Rum	4	EPIC	
--109	practically non-alcoholic perfectly mixed jittery Spicy Hot Chocolate	1	EPIC	
+-109	perfectly mixed practically non-alcoholic jittery Spicy Hot Chocolate	1	EPIC	

--- a/data/TCRS/TCRS_Seal_Clubber_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Seal_Clubber_Wombat_cafe_food.txt
@@ -1,43 +1,43 @@
--1	small flavorless Peche a la Frog	2	decent	
--2	spoiled snack-sized As Jus Gezund Heit	2	crappy	
+-1	flavorless small Peche a la Frog	2	decent	
+-2	snack-sized spoiled As Jus Gezund Heit	2	crappy	
 -3	flavorless Bouillabaise Coucher Avec Moi	3	decent	
 -7	delicious gumdrop chow mein	4	awesome	
--8	stale gigantic candy cane pizza	9	decent	
+-8	gigantic stale candy cane pizza	9	decent	
 -9	low-calorie spoiled pulsating gingerbread stir-fry	1	crappy	
 -10	flavorless twigs and gravel	4	decent	
 -11	moldy shoots and leaves	4	crappy	
--12	miniature spoiled shaking bowl of unidentifiable goo	2	crappy	
--13	normal half-sized gingerbread massacre	2	good	
+-12	spoiled miniature shaking bowl of unidentifiable goo	2	crappy	
+-13	half-sized normal gingerbread massacre	2	good	
 -14	flavorless It Came From Beyond Dessert	3	decent	
 -15	adequate vampire cake	3	good	
 -52	moldy low-calorie blue Soylent Red and Green	1	crappy	
 -53	flavorless twirling Disc-Shaped Nutrition Unit	4	decent	
 -54	rotten enchanted Gingerborg Hive	3	crappy	
--61	enchanted rotten Candy Cane Surprise	4	crappy	
+-61	rotten enchanted Candy Cane Surprise	4	crappy	
 -62	adequate Grimdrop Chow Mein	3	good	
 -63	flavorless Grimgerbread House	4	decent	
 -67	bland blue Caviar Carbonara	4	decent	
 -68	yummy Halibut Alfredo	4	awesome	
 -69	thick rotten Red Herring Velvet Cake	5	crappy	
 -73	rotten CRIMBCO Reconstituted Gruel	4	crappy	
--74	snack-sized adequate New and Improved CRIMBCO Reconstituted Gruel	2	good	
--75	toothsome upside-down green CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	awesome	
+-74	adequate snack-sized New and Improved CRIMBCO Reconstituted Gruel	2	good	
+-75	toothsome green upside-down CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	awesome	
 -79	delicious Brussels Sprout Stir-Fry	4	awesome	
 -80	snack-sized decent Carrot, Cabbage, and Kale Pizza	2	good	
--81	delicious jumbo yellow Turnip and Rutabaga Pie	5	awesome	
+-81	jumbo delicious yellow Turnip and Rutabaga Pie	5	awesome	
 -85	super-sized yummy Rainbow Spider Fun Roll	5	awesome	
 -86	normal Vegas Volcano Lava Roll	4	good	
 -87	stale wobbly Crazy Dragon Shogun Buddha Roll	3	decent	
 -92	stale basic hot dog	3	decent	
 -93	moldy narrow wobbly savage macho dog	3	crappy	
--94	half-sized tasty narrow one with everything	2	awesome	
+-94	tasty half-sized narrow one with everything	2	awesome	
 -95	toothsome sly dog	3	awesome	
 -96	bland devil dog	3	decent	
 -97	delicious chilly dog	4	awesome	
 -98	decent ghost dog	3	good	
 -99	adequate bouncing junkyard dog	3	good	
--100	flavorless special wet dog	3	decent	
--101	decent tiny sleeping dog	1	good	
+-100	special flavorless wet dog	3	decent	
+-101	tiny decent sleeping dog	1	good	
 -102	decent bite-sized upside-down optimal dog	1	good	
 -103	normal jumbo upside-down video games hot dog	5	good	
 -104	moldy jittery Peppermint Nutrition Block	3	crappy	

--- a/data/TCRS/TCRS_Turtle_Tamer_Blender.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Blender.txt
@@ -22,7 +22,7 @@
 23	pulsating chewing gum on a string	0		
 24	ten-leaf clover	0		
 25	meat paste	0		
-26	twirling purple Dolphin King's map	0		
+26	purple twirling Dolphin King's map	0		
 27	spider web	0		
 28	really spider web	0		
 29	really really spider web	0		
@@ -43,7 +43,7 @@
 44	pulsating worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	blue figurine	0		
-47	enchanted tiny rotten wobbly hot buttered roll	1	crappy	Effect: "From Nantucket", Effect Duration: 10
+47	tiny rotten enchanted wobbly hot buttered roll	1	crappy	Effect: "From Nantucket", Effect Duration: 10
 48	heart of rock and roll	0		
 49	delicious squat bowl of cottage cheese	3	awesome	
 50	clever Rock and Roll Legend	0		Maximum MP: +20, Class: "Accordion Thief", Song Duration: 10
@@ -57,7 +57,7 @@
 58	stone turtle	0		
 59	slingshot	0		
 60	Mace of the Tortoise of the detective	0		Item Drop: +20, Class: "Turtle Tamer"
-61	toothsome gigantic red fortune cookie	7	awesome	
+61	gigantic toothsome red fortune cookie	7	awesome	
 62	electrified oriole-feather headdress	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 3xVolley, cap 3"
 63	blue action figure body	0		
 64	bouncing action figure head	0		
@@ -152,7 +152,7 @@
 153	vibrating Ancient Saucehelm of the ox	0		Muscle: +20, Maximum MP Percent: +10, Class: "Sauceror", Familiar Effect: "3xGhuol, cap 25"
 154	purple wool educational Disco 'Fro Pick	0		Experience: +1, Cold Resistance: +1, Class: "Disco Bandit", Familiar Effect: "3xGhuol, cap 25"
 155	skewed up-at-dawn banded El Sombrero De Lopez	0		Damage Absorption: +100, Adventures: +5, Class: "Accordion Thief", Familiar Effect: "3xGhuol, cap 25"
-156	ghostly yellow guild application	0		
+156	yellow ghostly guild application	0		
 157	gray Dramatic&trade; range	0		
 158	Gnollish pie tin	0		
 159	mirror wad of dough	0		
@@ -167,16 +167,16 @@
 168	bone rattle of extreme caution	0		Monster Level: -25
 169	teal spinning bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	red blinking lihc eye	0		
-171	decent miniature lihc eye pie	2	good	
+171	miniature decent lihc eye pie	2	good	
 172	gnoll lips	0		
 173	ghostly taco shell	0		
 174	blinking Gnollish casserole dish	0		
-175	tiny moldy upside-down uncooked chorizo	1	crappy	
+175	moldy tiny upside-down uncooked chorizo	1	crappy	
 176	disembodied brain	0		
 177	olive jittery brainy skull	0		
 178	blue detective skull	0		
 179	small flavorless chorizo taco	2	decent	
-180	high-proof tolerable ice-cold fotie	6	good	
+180	tolerable high-proof ice-cold fotie	6	good	
 181	baseball	0		
 182	batgut	0		
 183	bat wing	0		
@@ -196,7 +196,7 @@
 198	rat appendix	0		
 199	prompt ring	0		Adventures: +3
 200	moldy rat appendix kabob	3	crappy	
-201	huge yummy bat wing kabob	10	awesome	
+201	yummy huge bat wing kabob	10	awesome	
 202	fancy rotten carob chunks	4	crappy	Effect: "Muscle Unbound", Effect Duration: 50
 203	herbs	0		
 204	toothsome pulsating carob chunk cookies	3	awesome	
@@ -207,12 +207,12 @@
 209	narrow wad of tofu	0		
 210	tumbling Feng Shui for Big Dumb Idiots	0		
 211	mirror bouncing decorative fountain	0		
-212	ghostly pulsating windchimes	0		
+212	pulsating ghostly windchimes	0		
 213	gray ruddy stylish filthy corduroys	0		Moxie: +25, Maximum HP Percent: +40, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	filthy knitted dread sack of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
 216	rotten half-sized carob brownies	2	crappy	
-217	big tasty green herb brownies	5	awesome	
+217	tasty big green herb brownies	5	awesome	
 218	spinning hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
@@ -255,10 +255,10 @@
 257	practically non-alcoholic aged extra-spicy bloody mary	1	awesome	
 258	dense meat stack	0		
 259	snake skin	0		
-260	miniature rotten squat White Citadel fries	2	crappy	
+260	rotten miniature squat White Citadel fries	2	crappy	
 261	low-calorie normal yellow White Citadel burger	1	good	
 262	rotten piece of wedding cake	4	crappy	
-263	tasty snack-sized chocolate chips	2	awesome	
+263	snack-sized tasty chocolate chips	2	awesome	
 264	normal chocolate chip cookies	3	good	
 265	Newton's satin pants	0		Experience (Mysticality): +3, Familiar Effect: "atk, 2xPotato, cap 10"
 266	irresponsibly strong lousy lightning	10	decent	
@@ -292,7 +292,7 @@
 294	energetic pail	0		Maximum MP Percent: +20, Familiar Effect: "2xFairy, cap 7"
 295	shaking mirror curative demonskin trousers	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "hot atk, 3xPotato, cap 17"
 296	cyan dungeoneer's dungarees of dire peril	0		Weapon Damage: +20, Familiar Effect: "stench atk, 4xPotato, cap 7"
-297	dry extra-warmed pulsating gray tamarind-flavored chewing gum	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 43
+297	dry extra-warmed gray pulsating tamarind-flavored chewing gum	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 43
 298	ionized huge lime-and-chile-flavored chewing gum	0		Effect: "Snobby", Effect Duration: 23
 299	non-improved pickle-flavored chewing gum	0		Effect: "Vented Spleen", Effect Duration: 54
 300	electrified adjusted jaba&ntilde;ero-flavored chewing gum	0		Effect: "Sewer-Drenched", Effect Duration: 57
@@ -311,19 +311,19 @@
 313	upside-down gravedigger's Crown of the Goblin King	0		Spooky Damage: +10, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	half-sized stale pulsating bean burrito	2	decent	
 315	stale bean burrito	3	decent	
-316	big normal insanely bean burrito	5	good	
-317	half-sized rotten bean burrito	2	crappy	
+316	normal big insanely bean burrito	5	good	
+317	rotten half-sized bean burrito	2	crappy	
 318	adequate bean burrito	4	good	
-319	special adequate insanely bean burrito	4	good	Effect: "Punchy, Murdery", Effect Duration: 5
+319	adequate special insanely bean burrito	4	good	Effect: "Punchy, Murdery", Effect Duration: 5
 320	tiny stale bat haggis	1	decent	
 321	bland upside-down menudo	3	decent	
 322	yummy fuchsia goat cheese	3	awesome	
-323	enchanted stale diet plain pizza	1	decent	Effect: "Tennis Elbow-wow", Effect Duration: 35
+323	enchanted diet stale plain pizza	1	decent	Effect: "Tennis Elbow-wow", Effect Duration: 35
 324	immense stale red sausage pizza	9	decent	
-325	spoiled big goat cheese pizza	5	crappy	
+325	big spoiled goat cheese pizza	5	crappy	
 326	decent enchanted diet mushroom pizza	1	good	Effect: "Sizzling with Fury", Effect Duration: 25
 327	goat	0		
-328	drinkable weak ghostly bottle of whiskey	2	good	
+328	weak drinkable ghostly bottle of whiskey	2	good	
 329	Newton's goat beard	0		Experience (Mysticality): +3, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	awesome	
 331	perfectly mixed watered-down spinning spinning Canadian	2	EPIC	
@@ -334,11 +334,11 @@
 336	horrifying consolation ribbon	0		Spooky Damage: +25
 337	ol' trophy	0		
 338	shaking tenderizing hammer	0		
-339	fuchsia bouncing Cobb's Knob lab key	0		
+339	bouncing fuchsia Cobb's Knob lab key	0		
 340	flattened ionized squat pulsating Knob Goblin steroids	0		Effect: "Mushroom Magicalness", Effect Duration: 13
 341	corrupted activated upside-down wobbly Knob Goblin love potion	0		Effect: "The Power of LOV", Effect Duration: 65
 342	twirling red Knob Goblin stink bomb	0		
-343	diffused irradiated tumbling bouncing Knob Goblin sharpening spray	0		Effect: "Ichorous Eyesight", Effect Duration: 32
+343	diffused irradiated bouncing tumbling Knob Goblin sharpening spray	0		Effect: "Ichorous Eyesight", Effect Duration: 32
 344	fuchsia Knob Goblin seltzer	0		
 345	Knob Goblin superseltzer	0		
 346	gray scrumptious reagent	0		
@@ -362,15 +362,15 @@
 364	ghostly jittery asbestos ore	0		
 365	twirling chrome ore	0		
 366	linoleum sword hilt	0		
-367	jittery mirror linoleum stick	0		
-368	blurry purple linoleum crossbow string	0		
+367	mirror jittery linoleum stick	0		
+368	purple blurry linoleum crossbow string	0		
 369	asbestos sword hilt	0		
 370	asbestos stick	0		
 371	asbestos crossbow string	0		
 372	shaking chrome sword hilt	0		
 373	chrome stick	0		
 374	chrome crossbow string	0		
-375	tumbling skewed linoleum meat stack	0		
+375	skewed tumbling linoleum meat stack	0		
 376	asbestos meat stack	0		
 377	bouncing chrome meat stack	0		
 378	wool supercharged linoleum sword	0		Maximum MP Percent: +30, Cold Resistance: +1
@@ -403,7 +403,7 @@
 405	wobbly sunken chest	0		
 406	pirate pelvis	0		
 407	maroon pirate skull	0		
-408	cyan blurry pirate skeleton	0		
+408	blurry cyan pirate skeleton	0		
 409	vial of patchouli oil	0		
 410	huge steel-toed sk8board	0		Damage Reduction: 9
 411	upside-down Jolly Roger charrrm	0		
@@ -424,7 +424,7 @@
 426	modified wet polymerized potion of temporary gr8ness	0		Effect: "Weasels Underfoot", Effect Duration: 29
 427	wobbly veiny box	0		Maximum HP: +10, Wiki Name: "box"
 428	twirling nothing-in-the-box	0		
-429	jittery squat beanbag chair	0		
+429	squat jittery beanbag chair	0		
 430	pulsating acid-squirting flower	0		Single Equip
 431	mirror rosy-cheeked clown shoes	0		Maximum HP Percent: +30, Clowniness: 25
 432	steel-toed bloody clown pants	0		Damage Reduction: 9, Clowniness: 25, Familiar Effect: "3xPotato, 2xFairy, cap 12"
@@ -451,7 +451,7 @@
 453	sober pill	0		
 454	blurry screwdriver	0		
 455	tasty snack-sized lime green jumbo olive	2	awesome	
-456	weak bad dry martini	2	decent	
+456	bad weak dry martini	2	decent	
 457	ye olde golde frontes of vim and vigor	0		Maximum HP Percent: +50, Class: "Disco Bandit", Single Equip
 458	lime green continuum transfunctioner	0		
 459	pixel	0		
@@ -466,7 +466,7 @@
 468	spinning ruby W	0		
 469	maroon wussiness potion	0		
 470	hand-crafted huge huge Imp Ale	3	EPIC	
-471	normal special jumbo hot wing	5	good	Effect: "Nigh-Invincible", Effect Duration: 20
+471	normal jumbo special hot wing	5	good	Effect: "Nigh-Invincible", Effect Duration: 20
 472	sharpshooter's diamond-studded cane	0		Critical Hit Percent: +10, Class: "Disco Bandit"
 473	stanky crutch	0		Stench Spell Damage: +25
 474	cast	0		
@@ -498,7 +498,7 @@
 500	Elf Farm Raffle ticket	0		
 501	spoiled narrow Elfin shortbread	3	crappy	
 502	pagoda plans	0		
-503	tasty tiny teal skewered cat appendix	1	awesome	
+503	tiny tasty teal skewered cat appendix	1	awesome	
 504	narrow evil arches	0		
 505	rosewater-soaked horrifying gnatwing earring	0		Spooky Damage: +25, Stench Resistance: +3
 506	adequate Hell broth	4	good	
@@ -519,7 +519,7 @@
 521	frightening kickback cookbook	0		Spooky Damage: +5
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	tolerable triple-distilled papaya sling	10	good	
+524	triple-distilled tolerable papaya sling	10	good	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -538,7 +538,7 @@
 540	unsweetened blue Tasty Fun Good rice candy	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 26
 541	lion tamer's ruddy draggin' ball hat	0		Maximum HP Percent: +40, Experience (familiar): +2, Familiar Effect: "atk, 1xVolley, cap 25"
 542	miser's 1337 7r0uZ0RZ of Tarzan	0		Experience (Muscle): +3, Meat Drop: +10, Familiar Effect: "2xPotato, cap 27"
-543	yummy half-sized Trollhouse cookies	2	awesome	
+543	half-sized yummy Trollhouse cookies	2	awesome	
 544	blinking wholesome Samson's talons	0		Experience (Muscle): +5, Maximum HP Percent: +10
 545	spoiled half-sized Spam Witch sammich	2	crappy	
 546	meat vortex	0		
@@ -547,27 +547,27 @@
 549	mirror 30669 scroll	0		
 550	33398 scroll	0		
 551	blurry 64067 scroll	0		
-552	red blurry 64735 scroll	0		
+552	blurry red 64735 scroll	0		
 553	31337 scroll	0		
-554	stale small pr0n cocktail	2	decent	
+554	small stale pr0n cocktail	2	decent	
 555	rosewater-soaked Oprah's drywall axe	0		Maximum MP Percent: +50, Stench Resistance: +3
 556	blurry wool Pine-Fresh air freshener	0		Cold Resistance: +1
 557	tolerable whiskey and cola	4	good	
 558	delicious papaya taco	4	awesome	
 559	razor-sharp can lid	0		
-560	spoiled miniature stalk of asparagus	2	crappy	
+560	miniature spoiled stalk of asparagus	2	crappy	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	pulsating jittery sonar-in-a-biscuit	0		
-564	high-proof drinkable squat Mad Train wine	6	good	
+564	drinkable high-proof squat Mad Train wine	6	good	
 565	hobo gloves of vim and vigor	0		Maximum HP Percent: +50, Single Equip
 566	inspector's bum cheek	0		Item Drop: +15, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	toothsome bite-sized Double Bacon Beelzeburger	1	awesome	
+568	bite-sized toothsome Double Bacon Beelzeburger	1	awesome	
 569	tasty small Lord of the Flies-sized fries	2	awesome	
-570	rotten half-sized Chicken Sandwich	2	crappy	
+570	half-sized rotten Chicken Sandwich	2	crappy	
 571	Jumbo Dr. Lucifer	1	good	
-572	rotten fancy blue Children's Meal of the Damned	4	crappy	Effect: "Flaming Weapon", Effect Duration: 40
+572	fancy rotten blue Children's Meal of the Damned	4	crappy	Effect: "Flaming Weapon", Effect Duration: 40
 573	moldy snack-sized skewed noodles	2	crappy	
 574	moldy noodles	4	crappy	
 575	big flavorless yellow painful penne pasta	5	decent	
@@ -579,7 +579,7 @@
 581	schmancy cheese sauce	0		
 582	pulsating Himalayan Hidalgo sauce	0		
 583	spoiled fettucini Inconnu	3	crappy	
-584	adequate snack-sized spaghetti with Skullheads	2	good	
+584	snack-sized adequate spaghetti with Skullheads	2	good	
 585	bland blue gnocchetti di Nietzsche	3	decent	
 586	Jack Frost's ridiculously huge sword of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50
 587	pickled pressed spinning super-spiky hair gel	0		Effect: "Optimist Primal", Effect Duration: 38
@@ -606,7 +606,7 @@
 608	Plastic Wrap Immateria	0		
 609	upside-down S.O.C.K.	0		
 610	procrastination potion	0		
-611	pulsating squat spinning D	0		
+611	squat pulsating spinning D	0		
 612	blue original G	0		
 613	plot hole	0		
 614	liquefied mirror probability potion	0		Effect: "Barking Mad", Effect Duration: 25
@@ -623,7 +623,7 @@
 625	teal wang	0		
 626	ghostly wobbly Wand of Nagamar	0		
 627	upside-down ND	0		
-628	blurry twirling metallic A	0		
+628	twirling blurry metallic A	0		
 629	beefcake's eye	0		Muscle: +25
 630	yellow photoprotoneutron torpedo	0		
 631	green upside-down arcane researcher's furry pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
@@ -641,11 +641,11 @@
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	small rotten fruitcake	2	crappy	
+646	rotten small fruitcake	2	crappy	
 647	present	0		Last Available: "2004-11"
 648	wobbly energetic Crimbo sword	0		Maximum MP Percent: +20, Last Available: "2004-10"
-649	blinking hardy Crimbo hat	0		Maximum HP: +50, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	greasy Crimbo pants	0		Sleaze Spell Damage: +10, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	blinking hardy Crimbo hat	0		Maximum HP: +50, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	greasy Crimbo pants	0		Sleaze Spell Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	jittery exclusive ultra-rare item of chilblains	0		Cold Damage: +25
 652	green quantum egg	0		
 653	ghostly intragalactic rowboat	0		
@@ -669,7 +669,7 @@
 671	twirling Da Vinci's grave robbing shovel of the wise owl	0		Mysticality: +20, Experience (Mysticality): +5
 672	adequate yellow cranberries	3	good	
 673	hand-crafted irresponsibly strong vodka and cranberry	9	EPIC	
-674	practically non-alcoholic acceptable whiskey	1	good	
+674	acceptable practically non-alcoholic whiskey	1	good	
 675	cyan flame-retardant skull of the Bonerdagon	0		Hot Resistance: +1
 676	dragonbone belt buckle	0		
 677	maroon resourceful badass belt	0		Maximum MP: +50
@@ -677,7 +677,7 @@
 679	lousy roll in the hay	3	decent	
 680	lousy maroon slap and tickle	3	decent	
 681	drinkable red slip 'n' slide	3	good	
-682	high-proof mediocre mirror a sump'm sump'm	9	decent	
+682	mediocre high-proof mirror a sump'm sump'm	9	decent	
 683	drinkable horizontal tango	3	good	
 684	hand-crafted pink pony	3	EPIC	
 685	double-paned smelly cool Mr. Shirt	0		Moxie: +5, Stench Spell Damage: +10, Cold Resistance: +5
@@ -716,8 +716,8 @@
 720	gravedigger's dog trainer's porquoise necklace	0		Experience (familiar): +1, Spooky Damage: +10, Single Equip
 721	yellow mansplainer's crafty porquoise bracelet	0		Maximum MP: +10, Monster Level: +15
 722	bouncing scandalous clever Fonzie's porquoise ring	0		Experience (Moxie): +1, Maximum MP: +20, Sleaze Damage: +5, Single Equip
-723	snack-sized decent ghostly spinning Knoll mushroom	2	good	
-724	big spoiled blinking bouncing mushroom	5	crappy	
+723	decent snack-sized spinning ghostly Knoll mushroom	2	good	
+724	spoiled big bouncing blinking mushroom	5	crappy	
 725	blurry one million meat pancakes	0		
 726	twirling wholesome huge mirror shard	0		Maximum HP Percent: +10
 727	yellow hedge maze puzzle	0		
@@ -735,28 +735,28 @@
 739	shaking tambourine bells	0		
 740	tambourine of the sewer	0		Stench Damage: +25
 741	ghostly broken skull	0		
-742	normal jumbo twirling Knoll shroomkabob	5	good	
+742	jumbo normal twirling Knoll shroomkabob	5	good	
 743	spoiled snack-sized mushroom	2	crappy	
 744	chilled altered hair spray	0		Effect: "Tingly Elbows", Effect Duration: 11
 746	blinking stat script	0		
 747	Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	spoiled cyan warm mushroom	3	crappy	
-750	bland half-sized mushroom quesadilla	2	decent	
-751	spoiled big cool mushroom	5	crappy	
-752	stale small cool mushroom casserole	2	decent	
+750	half-sized bland mushroom quesadilla	2	decent	
+751	big spoiled cool mushroom	5	crappy	
+752	small stale cool mushroom casserole	2	decent	
 753	super-sized moldy pointy mushroom	5	crappy	
 754	flavorless cream of pointy mushroom soup	3	decent	
-755	thick stale squat mushroom	5	decent	
+755	stale thick squat mushroom	5	decent	
 756	rotten narrow mushroom	4	crappy	
 757	moldy small mushroom	2	crappy	
 758	thick moldy tumbling ghost cucumber	5	crappy	
 759	blinking dill	0		
 760	spinning vinegar	0		
 761	teal brine	0		
-762	weak artisanal ghostly especially salty dog	2	EPIC	
+762	artisanal weak ghostly especially salty dog	2	EPIC	
 763	ghostly pickling solution	0		
-764	big bland shaking spectral pickle	5	decent	
+764	bland big shaking spectral pickle	5	decent	
 765	briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	improved cologne of contempt	0		Effect: "Quiet 'n' Good", Effect Duration: 47
@@ -776,10 +776,10 @@
 781	concentrated gray mafia aria	0		Effect: "Balls of Ectoplasm", Effect Duration: 44
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	red 'Villa' document	0		
-784	drinkable blinking twirling Acqua Del Piatto Merlot	4	good	Last Available: "2004-10"
+784	drinkable twirling blinking Acqua Del Piatto Merlot	4	good	Last Available: "2004-10"
 785	wobbly raffle ticket	0		
-786	toothsome small strawberry	2	awesome	
-787	bad high-proof bottle of rum	6	decent	
+786	small toothsome strawberry	2	awesome	
+787	high-proof bad bottle of rum	6	decent	
 788	weak lousy skewed strawberry daiquiri	2	decent	
 789	perfectly mixed rum and cola	3	EPIC	
 790	mediocre grog	3	decent	
@@ -792,27 +792,27 @@
 797	mediocre practically non-alcoholic shaking rockin' wagon	1	decent	
 798	boozy lousy ocean motion	5	decent	
 799	hand-crafted fuzzbump	3	EPIC	
-800	flavorless half-sized poutine	2	decent	
+800	half-sized flavorless poutine	2	decent	
 801	tiny flavorless Knob stir-fry	1	decent	
-804	special rotten squat Knoll stir-fry	3	crappy	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 25
+804	rotten special squat Knoll stir-fry	3	crappy	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 25
 805	flavorless maroon stir-fry	3	decent	
 806	yummy massive asparagus stir-fry	6	awesome	
 807	tasty gray olive stir-fry	4	awesome	
 808	tiny rotten upside-down Knob sausage stir-fry	1	crappy	
-809	yummy ghostly mirror bat wing stir-fry	3	awesome	
+809	yummy mirror ghostly bat wing stir-fry	3	awesome	
 810	moldy skewed rat appendix stir-fry	3	crappy	
-811	tiny normal olive tofu stir-fry	1	good	
+811	normal tiny olive tofu stir-fry	1	good	
 812	delicious pr0n stir-fry	3	awesome	
 813	adequate big Knob shells	5	good	
 814	adequate b&auml;tzle	3	good	
 815	adequate ratini	3	good	
-816	massive delicious upside-down skewed Knob stroganoff	6	awesome	
+816	massive delicious skewed upside-down Knob stroganoff	6	awesome	
 817	decent big menudo ravioli	5	good	
 818	plus sign	0		
 819	squat milky potion	0		
 820	mirror swirly potion	0		
 821	skewed bubbly potion	0		
-822	bouncing skewed smoky potion	0		
+822	skewed bouncing smoky potion	0		
 823	cloudy potion	0		
 824	effervescent potion	0		
 825	fizzy potion	0		
@@ -820,7 +820,7 @@
 827	murky potion	0		
 828	spinning baby killer bee	0		
 829	narrow anti-anti-antidote	0		
-830	yummy gigantic royal jelly	6	awesome	
+830	gigantic yummy royal jelly	6	awesome	
 831	mirror small box	0		
 832	box	0		
 833	veiny vorpal blade	0		Maximum HP: +10
@@ -834,7 +834,7 @@
 841	tolerable shaking tomato daiquiri	3	good	
 842	tolerable watered-down beertini	2	good	
 843	perfectly mixed salty slug	3	EPIC	
-844	hand-crafted watered-down papaya slung	2	EPIC	
+844	watered-down hand-crafted papaya slung	2	EPIC	
 845	MAHI fez of the brute	0		Muscle Percent: +30, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	mirror hypodermic needle	0		Familiar Weight: +5
@@ -854,7 +854,7 @@
 862	blinking magnifying glass	0		Familiar Weight: +5
 863	bouncing skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
-865	mirror bouncing lead necklace	0		Familiar Weight: +3
+865	bouncing mirror lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	modified pine tar	0		Effect: "Dirty Pear", Effect Duration: 54
 869	fuchsia forest tears	0		
@@ -881,7 +881,7 @@
 890	delicious balaclava baklava	3	awesome	
 891	skewed shellacked Warehouse 23 bling	0		Damage Reduction: 7
 892	Jack Frost's curative wicked bugbear-smiting sword	0		Spell Damage: +5, Cold Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
-893	practically non-alcoholic mediocre squat lumbering jack	1	decent	
+893	mediocre practically non-alcoholic squat lumbering jack	1	decent	
 894	twirling Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	gray narrow smelly Ms. Accessory	0		Stench Spell Damage: +10, Softcore Only
 896	rosewater-soaked Mr. Accessory Jr. of the cougar	0		Moxie: +20, Stench Resistance: +3, Softcore Only
@@ -892,22 +892,22 @@
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	watered-down perfectly mixed Spasmi Dolorosi Del Rene Champagne	2	super ultra mega EPIC	Last Available: "2004-10"
-904	narrow prompt reassuring school Mafia knickerbockers of wisdom	0		Mysticality: +15, Spooky Resistance: +1, Adventures: +3, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	narrow prompt reassuring school Mafia knickerbockers of wisdom	0		Mysticality: +15, Spooky Resistance: +1, Adventures: +3, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	diffused Yummy Tummy bean	0		Effect: "Super Speed", Effect Duration: 25
 906	polarized Rock Pops	0		Effect: "One Very Clear Eye", Effect Duration: 37
 907	polarized squat bouncing Mr. Mediocrebar	0		Effect: "New and Improved", Effect Duration: 44
 908	double-pressed ionized Cold Hots candy	0		Effect: "Gyromitra Gymnastics", Effect Duration: 42
 909	alkaline triple-activated upside-down Wint-O-Fresh mint	0		Effect: "Mint-Condition Breath", Effect Duration: 26
-910	enchanted flavorless big maroon dwarf bread	5	decent	Effect: "Boon of the Storm Tortoise", Effect Duration: 30
+910	big enchanted flavorless maroon dwarf bread	5	decent	Effect: "Boon of the Storm Tortoise", Effect Duration: 30
 911	boiled jittery Senior Mints	0		Effect: "Crusty Head", Effect Duration: 69
-912	ionized green bouncing pixellated candy heart	0		Effect: "Chain Chain Chains", Effect Duration: 44
+912	ionized bouncing green pixellated candy heart	0		Effect: "Chain Chain Chains", Effect Duration: 44
 913	ionized extra-polymerized yellow kobold	0		Effect: "Outer Wolf&trade;", Effect Duration: 35
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	blinking intergalactic pom poms of the detective of the glutton	0		Item Drop: +20, Food Drop: +100
 917	upside-down Mob Penguin protection contract	0		
-918	greasy Radio Free Baseball Cap	0		Sleaze Spell Damage: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	blurry twirling Radio Free Pants of horror	0		Spooky Spell Damage: +25, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	greasy Radio Free Baseball Cap	0		Sleaze Spell Damage: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	blurry twirling Radio Free Pants of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	maroon tumbling mirror Radio Free Foil of the empath	0		Familiar Weight: +5, Last Available: "2006-07"
 921	gigantic flavorless shaking yellow radio button candy	8	decent	
 922	upside-down severed rocking horse head of Calamity Jane	0		Critical Hit Percent: +15
@@ -918,9 +918,9 @@
 927	lousy Ferita Del Petto Zinfandel	3	decent	Last Available: "2006-12"
 928	jittery jittery fuzzy bracelets of doom	0		Spooky Spell Damage: +50
 929	arse-shooting crossbow of the overflowing toilet	0		Stench Spell Damage: +50
-931	special strong mediocre spiced rum	5	decent	Effect: "Electrolit Up", Effect Duration: 30
+931	strong special mediocre spiced rum	5	decent	Effect: "Electrolit Up", Effect Duration: 30
 932	perfectly mixed jittery eggnog	3	EPIC	
-933	jumbo adequate candy cane	5	good	
+933	adequate jumbo candy cane	5	good	
 934	toothsome gingerbread bugbear	3	awesome	
 935	stiffened imitation nice watch	0		Damage Reduction: 1, Single Equip, Last Available: "2004-12"
 936	bouncing Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	pulsating small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	mirror Crimbo stocking	0		Last Available: "2004-12"
-942	inspector's bowler	0		Item Drop: +15, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+942	inspector's bowler	0		Item Drop: +15, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	crafty bow staff of the overflowing toilet	0		Maximum MP: +10, Stench Spell Damage: +50, Last Available: "2004-12"
-944	therapeutic bowlegged pants	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	therapeutic bowlegged pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	squat skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	fuchsia skewered cherry	0		Last Available: "2004-12"
@@ -941,11 +941,11 @@
 951	purple extra special Crimbo stocking	0		Last Available: "2004-12"
 952	deadly brainy hockey mask	0		Mysticality: +5, Weapon Damage: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	upside-down penguin-smacking club	0		Familiar Damage: +15
-954	teal squat orphan baby yeti	0		Free Pull, Last Available: "2011-12"
+954	squat teal orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	Rosewater's fez of etymology	0		Mysticality Percent: +30, Familiar Effect: "1xLep, cap 30"
 956	fancy bland carob chunk noodles	3	decent	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 5
 957	massive adequate chorizo brownies	6	good	
-958	flavorless special bite-sized spinning chocolate and tomato pizza	1	decent	Effect: "The Halls of Muscularity", Effect Duration: 45
+958	flavorless bite-sized special spinning chocolate and tomato pizza	1	decent	Effect: "The Halls of Muscularity", Effect Duration: 45
 959	blue narrow flange	0		
 960	ghostly clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -989,7 +989,7 @@
 1002	spinning Xlyinia's notebook of the sweet-tooth	0		Candy Drop: +100
 1003	mirror soda water	0		
 1004	hand-crafted bottle of tequila	3	EPIC	
-1005	enchanted practically non-alcoholic tolerable shaking boxed wine	1	good	Effect: "Chalky White Pallor", Effect Duration: 30
+1005	tolerable enchanted practically non-alcoholic shaking boxed wine	1	good	Effect: "Chalky White Pallor", Effect Duration: 30
 1006	stale cherry	3	decent	
 1007	chilly coconut shell	0		Cold Damage: +5, Familiar Effect: "1xFairy, cap 7"
 1008	medical-grade ice cubes	0		HP Regen Min: 7, HP Regen Max: 10
@@ -1000,10 +1000,10 @@
 1013	hand-crafted watered-down margarita	2	EPIC	
 1014	bad strawberry wine	4	decent	
 1015	delicious wobbly wine spritzer	3	awesome	
-1016	distilled perfectly mixed perpendicular hula	5	EPIC	
-1017	practically non-alcoholic delicious upside-down ducha de oro	1	awesome	
+1016	perfectly mixed distilled perpendicular hula	5	EPIC	
+1017	delicious practically non-alcoholic upside-down ducha de oro	1	awesome	
 1018	perfectly mixed weak calle de miel	2	EPIC	
-1019	lousy triple-distilled dry vodka martini	10	decent	
+1019	triple-distilled lousy dry vodka martini	10	decent	
 1020	special artisanal old-fashioned	4	EPIC	Effect: "Shoesauce", Effect Duration: 20
 1021	aged tequila with training wheels	4	awesome	
 1022	mediocre sangria	3	decent	
@@ -1029,23 +1029,23 @@
 1043	maroon extremely unsafe string of beads	0		Weapon Damage Percent: +100
 1044	mansplainer's string of beads	0		Monster Level: +15
 1045	MacGyver's plastic bottle opener	0		Maximum MP: +100
-1046	ghostly traffic cone of the overflowing toilet of the cheetah	0		Stench Spell Damage: +50, Initiative: +60, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	ghostly traffic cone of the overflowing toilet of the cheetah	0		Stench Spell Damage: +50, Initiative: +60, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	tolerable N. O. Beer	3	good	
 1048	twisted blue pulsating oyster egg	1		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 20
 1049	denatured oyster egg	1		
 1050	boiled skewed oyster egg	1		
 1051	plastic oyster egg	0		
 1052	boiled oyster egg	1		
-1053	twisted ghostly tumbling oyster egg	1		Effect: "Bored Stiff", Effect Duration: 40
+1053	twisted tumbling ghostly oyster egg	1		Effect: "Bored Stiff", Effect Duration: 40
 1054	denatured oyster egg	1		
 1055	huge plastic oyster egg	0		
-1056	compressed blinking shaking puce oyster egg	1		
+1056	compressed shaking blinking puce oyster egg	1		
 1057	altered twirling puce oyster egg	1		
 1058	pickled bouncing puce oyster egg	1		
 1059	puce plastic oyster egg	0		
 1060	twisted ghostly mauve oyster egg	1		
 1061	mixed mauve oyster egg	1		
-1062	mixed squat green mirror mauve oyster egg	1		
+1062	mixed mirror green squat mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
 1064	mixed pulsating oyster egg	1		
 1065	diluted shaking huge oyster egg	1		
@@ -1061,7 +1061,7 @@
 1075	off-white plastic oyster egg	0		
 1076	vaporized oyster egg	1		
 1077	dried cyan oyster egg	1		Effect: "Radiated and Grodiated", Effect Duration: 15
-1078	distilled squat gray oyster egg	1		
+1078	distilled gray squat oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
@@ -1073,7 +1073,7 @@
 1087	clockwork doohickey	0		
 1088	clockwork clockwise dome	0		
 1089	mirror clockwork spine	0		
-1090	ghostly tumbling clockwork rings	0		
+1090	tumbling ghostly clockwork rings	0		
 1091	clockwork claws	0		
 1092	clockwork sheet	0		
 1093	narrow clockwork counterclockwise dome	0		
@@ -1089,7 +1089,7 @@
 1103	upside-down spinning unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
 1105	clockwork bartender head	0		
-1106	skewed narrow clockwork chef head	0		
+1106	narrow skewed clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	clockwork detective skull	0		
 1109	lime green wobbly clockwork bartender-head-in-the-box	0		
@@ -1111,7 +1111,7 @@
 1125	lion tamer's glove of Gandalf of the early riser	0		Spell Critical Percent: +20, Experience (familiar): +2, Adventures: +7
 1126	toothpick of the boozehound	0		Booze Drop: +100, Single Equip
 1127	energetic ninja sword	0		Maximum MP Percent: +20
-1128	tumbling blurry teeny-tiny ninja stars	0		
+1128	blurry tumbling teeny-tiny ninja stars	0		
 1129	sharpshooter's sequined fez	0		Critical Hit Percent: +10, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
 1131	beet	0		Last Available: "2005-12"
@@ -1123,20 +1123,20 @@
 1137	cyan wobbly ribald savvy bicycle chain	0		Mysticality Percent: +20, Sleaze Damage: +10
 1138	shaking mushroom fermenting solution	0		
 1139	artisanal watered-down red mushroom wine	2	EPIC	
-1140	strong bad jittery icy mushroom wine	5	decent	
-1141	drinkable enchanted watered-down mushroom wine	2	good	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40
-1142	enchanted lousy pointy mushroom wine	4	decent	Effect: "Antibiotic Saucesphere", Effect Duration: 15
+1140	bad strong jittery icy mushroom wine	5	decent	
+1141	watered-down drinkable enchanted mushroom wine	2	good	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 40
+1142	lousy enchanted pointy mushroom wine	4	decent	Effect: "Antibiotic Saucesphere", Effect Duration: 15
 1143	hand-crafted weak tumbling green flat mushroom wine	2	EPIC	
 1144	perfectly mixed cool mushroom wine	3	EPIC	
 1145	delicious watered-down wobbly knob mushroom wine	2	awesome	
-1146	perfectly mixed high-proof knoll mushroom wine	6	EPIC	
-1147	artisanal weak tumbling mushroom wine	2	EPIC	
+1146	high-proof perfectly mixed knoll mushroom wine	6	EPIC	
+1147	weak artisanal tumbling mushroom wine	2	EPIC	
 1148	acceptable skewed shot of flower schnapps	3	good	
 1149	rotten miniature cyan flower petal pie	2	crappy	
 1150	watered-down hand-crafted bottle of single-barrel whiskey	2	super ultra mega EPIC	
 1151	inspector's discarded plastic fork of the businessman	0		Item Drop: +15, Meat Drop: +50
 1152	wobbly olive gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	normal big Retenez L'Herbe Pat&eacute;	5	good	
+1153	big normal Retenez L'Herbe Pat&eacute;	5	good	
 1154	altered Breathetastic&trade; Premium Canned Air	1	awesome	
 1155	letter from King Ralph XI	0		
 1157	prompt wholeberd	0		Adventures: +3
@@ -1153,7 +1153,7 @@
 1168	spinning less-than-three-shaped box	0		
 1169	exactly-three-shaped box	0		
 1170	blurry chocolate box	0		
-1171	blinking ghostly ghostly fuchsia coffin	0		
+1171	ghostly ghostly fuchsia blinking coffin	0		
 1172	asbestos box	0		
 1173	linoleum box	0		
 1174	chrome box	0		
@@ -1188,10 +1188,10 @@
 1203	bland personalized birthday cake	4	decent	
 1204	yummy three-tiered wedding cake	3	awesome	
 1205	bite-sized decent babycakes	1	good	
-1206	stale diet velvet cake	1	decent	
-1207	decent special low-calorie congratulatory cake	1	good	Effect: "Slightly Mutated", Effect Duration: 25
-1208	half-sized moldy special spinning angel-food cake	2	crappy	Effect: "Human-Insect Hybrid", Effect Duration: 45
-1209	small adequate devil's-food cake	2	good	
+1206	diet stale velvet cake	1	decent	
+1207	special decent low-calorie congratulatory cake	1	good	Effect: "Slightly Mutated", Effect Duration: 25
+1208	half-sized special moldy spinning angel-food cake	2	crappy	Effect: "Human-Insect Hybrid", Effect Duration: 45
+1209	adequate small devil's-food cake	2	good	
 1210	toothsome tumbling bouncing birthday party jellybean cheesecake	3	awesome	
 1211	green balloon	0		
 1212	balloon	0		
@@ -1219,7 +1219,7 @@
 1235	pendant of the wise owl of the brute	0		Mysticality: +20, Muscle Percent: +30, Four Songs, Single Equip
 1236	deadly hockey stick of furious angry rage of the detective	0		Weapon Damage: +5, Item Drop: +20
 1237	tapped lotus	0		
-1238	twirling olive glowsticks	0		Familiar Weight: +5
+1238	olive twirling glowsticks	0		Familiar Weight: +5
 1239	twirling iced-out bling	0		Familiar Weight: +5
 1240	ghostly limburger biker boots	0		Familiar Weight: +5
 1241	upside-down carton of clove cigarettes	0		Familiar Weight: +5
@@ -1240,7 +1240,7 @@
 1256	toothsome upside-down insanely jumping bean burrito	3	awesome	
 1257	stale green rat scrapple	3	decent	
 1258	mirror pail of pretentious paint	0		
-1259	traffic cone of chilblains of horror	0		Cold Damage: +25, Spooky Spell Damage: +25, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	traffic cone of chilblains of horror	0		Cold Damage: +25, Spooky Spell Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	mixed upside-down Hatorade	1		
 1262	off-hand balloon of the ox of mayonnaise of the boozehound	0		Muscle: +20, Sleaze Spell Damage: +50, Booze Drop: +100
@@ -1257,7 +1257,7 @@
 1273	skewed sage magic lamp	0		Mysticality Percent: +10
 1274	dried ghostly Medicinal Herb's medicinal herbs	1		
 1275	gray basic meat skirt of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	watered-down lousy wobbly skewed Otorian Battle Scar	2	decent	
+1276	watered-down lousy skewed wobbly Otorian Battle Scar	2	decent	
 1277	studded basic meat kilt	0		Damage Absorption: +80, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	red quilted meat skirt	0		Damage Absorption: +40, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	cyan meat kilt of doom	0		Spooky Spell Damage: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	pulsating makeup kit	0		Familiar Weight: +15
-1306	up-at-dawn traffic cone of chilblains	0		Cold Damage: +25, Adventures: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	up-at-dawn traffic cone of chilblains	0		Cold Damage: +25, Adventures: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	purple calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	blurry attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	blurry blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	rotten super-sized pulsating questionable taco	5	crappy	
+1320	super-sized rotten pulsating questionable taco	5	crappy	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	purple petrified time	0		Last Available: "2005-10"
-1323	healthy time helmet	0		Maximum HP Percent: +20, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	mirror upside-down jittery nasty time trousers	0		Stench Damage: +5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	healthy time helmet	0		Maximum HP Percent: +20, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	mirror upside-down jittery nasty time trousers	0		Stench Damage: +5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	rock-hard time sword	0		Damage Reduction: 5, Last Available: "2005-10"
 1326	sharpshooter's Dyspepsi-Cola helmet	0		Critical Hit Percent: +10, Familiar Effect: "3xFairy, cap 7"
 1327	twirling steel-toed Cloaca-Cola shield	0		Damage Reduction: 13
@@ -1332,12 +1332,12 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	wobbly 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	upside-down greedy pinky ring	0		Meat Drop: +20, Single Equip
-1352	smooth irresponsibly strong redrum	8	awesome	
+1352	irresponsibly strong smooth redrum	8	awesome	
 1353	mirror ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	normal snack-sized bowl of oriole's nest soup	2	good	
 1356	bunny liver	0		
-1357	lousy weak Mt. Noob Pale Ale	2	decent	
+1357	weak lousy Mt. Noob Pale Ale	2	decent	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	blurry ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	blue pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,8 +1346,8 @@
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	small rotten tofurkey leg	2	crappy	
-1366	moldy gigantic tofurkey gravy	9	crappy	
-1367	tasty gigantic herbal stuffing	6	awesome	
+1366	gigantic moldy tofurkey gravy	9	crappy	
+1367	gigantic tasty herbal stuffing	6	awesome	
 1368	rotten can-shaped gelatinous cranberry sauce	3	crappy	
 1369	moldy snack-sized yams	2	crappy	
 1370	huge beefcake's rhinestone cowboy shirt	0		Muscle: +25
@@ -1384,34 +1384,34 @@
 1402	huge squat gray razor-sharp rag doll	0		Weapon Damage Percent: +25, Last Available: "2005-12"
 1403	boxer's can of fake snow	0		Muscle Percent: +10, Last Available: "2005-12"
 1404	beefy colored-light &quot;necklace&quot;	0		Muscle: +10, Last Available: "2005-12"
-1405	tree skirt of the brazier	0		Hot Spell Damage: +25, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	tree skirt of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	toothsome small wreath-shaped Crimbo cookie	2	awesome	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	huge spoiled cyan bell-shaped Crimbo cookie	8	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	normal tree-shaped Crimbo cookie	3	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	mirror pulsating purple brawny Unionize The Elves sign	0		Muscle Percent: +20, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	dry polymerized mirror snowcone	0		Effect: "Dreadful Smell", Effect Duration: 49, Last Available: "2006-01"
 1413	tarnished cyan snowcone	0		Effect: "Barbecue Saucy", Effect Duration: 60, Last Available: "2006-01"
 1414	dry unsweetened maroon snowcone	0		Effect: "Human-Constellation Hybrid", Effect Duration: 51, Last Available: "2006-01"
 1415	ionized liquefied snowcone	0		Effect: "Natural 20", Effect Duration: 63, Last Available: "2006-01"
-1416	triple-anodized nitrogenated quadruple-tarnished ghostly blue snowcone	0		Effect: "Comic Violence", Effect Duration: 58, Last Available: "2006-01"
+1416	triple-anodized nitrogenated quadruple-tarnished blue ghostly snowcone	0		Effect: "Comic Violence", Effect Duration: 58, Last Available: "2006-01"
 1417	unsweetened lime green snowcone	0		Effect: "Muscularrr", Effect Duration: 23, Last Available: "2006-01"
 1418	blinking blinking Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	skewed jittery quilted traffic cone of Calamity Jane	0		Damage Absorption: +40, Critical Hit Percent: +15, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1421	twirling skewed Scandalously Skimpy Bikini	0		Four Songs, Single Equip
+1420	skewed jittery quilted traffic cone of Calamity Jane	0		Damage Absorption: +40, Critical Hit Percent: +15, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1421	skewed twirling Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	narrow Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	blinking lion tamer's electrified ice sickle	0		Experience (familiar): +2, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2006-02"
 1425	ice baby of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2006-02"
-1426	brawny ice pick	0		Muscle Percent: +20, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	brawny ice pick	0		Muscle Percent: +20, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	auspicious asbestos-lined ice skates	0		Hot Resistance: +5, Item Drop: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	half-sized adequate grue egg omelette	2	good	
-1429	skewed gray roll of drink tickets	0		
+1429	gray skewed roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	tiny normal special mushroom	1	good	Effect: "PERL of Great Price", Effect Duration: 40
+1432	normal tiny special mushroom	1	good	Effect: "PERL of Great Price", Effect Duration: 40
 1433	twirling fruit bowl	0		
 1434	ghostly fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1421,9 +1421,9 @@
 1439	polarized gray hot powder	0		Effect: "Experimental Effect G-9", Effect Duration: 51
 1440	energized non-dry upside-down powder	0		Effect: "The Solution", Effect Duration: 54
 1441	super-concentrated nitrogenated powder	0		Effect: "Carrrsmic", Effect Duration: 23
-1442	quantum irradiated blurry jittery stench powder	0		Effect: "Spookyravin'", Effect Duration: 48
+1442	quantum irradiated jittery blurry stench powder	0		Effect: "Spookyravin'", Effect Duration: 48
 1443	double-pickled sleaze powder	0		Effect: "Chalky White Pallor", Effect Duration: 26
-1444	cold-filtered jittery purple spinning twinkly nuggets	0		Effect: "Rampage!", Effect Duration: 24
+1444	cold-filtered purple jittery spinning twinkly nuggets	0		Effect: "Rampage!", Effect Duration: 24
 1445	colloidal hot nuggets	0		Effect: "Appeteyes", Effect Duration: 31
 1446	irradiated quantum nuggets	0		Effect: "Whippin' It Good", Effect Duration: 67
 1447	cold-filtered nuggets	0		Effect: "Super Vision", Effect Duration: 11
@@ -1446,7 +1446,7 @@
 1464	wobbly sleazy fairy gravy	0		
 1465	suede shortsword	0		
 1466	bamboo bokuto	0		
-1467	blurry skewed blinking 25-meat staff	0		
+1467	blinking blurry skewed 25-meat staff	0		
 1468	two-handed depthsword	0		
 1469	lime green bill bec-de-bardiche glaive-guisarme	0		
 1470	mirror lead yo-yo	0		
@@ -1474,10 +1474,10 @@
 1492	hale ninja mop	0		Maximum HP: +20
 1493	Tesla Socratic ridiculously overelaborate ninja weapon	0		Experience (Mysticality): +1, MP Regen Min: 7, MP Regen Max: 10
 1494	energized jittery sugar-coated pine cone	0		Effect: "Petit Force", Effect Duration: 57, Last Available: "2020-09"
-1495	ribald traffic cone of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	ribald traffic cone of doom	0		Spooky Spell Damage: +50, Sleaze Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	lousy gloomy mushroom wine	3	decent	
 1497	smooth mushroom wine	3	awesome	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	bouncing fake fake vomit	0		Last Available: "2006-04"
 1501	cold-filtered pressed explosion-flavored chewing gum	0		Effect: "You Liver", Effect Duration: 45, Last Available: "2006-04"
@@ -1487,13 +1487,13 @@
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	bad calle de miel with a fly in it	3	decent	Last Available: "2006-04"
 1507	acceptable blurry rockin' wagon with a fly in it	3	good	Last Available: "2006-04"
-1508	practically non-alcoholic acceptable lime green perpendicular hula with a fly in it	1	good	Last Available: "2006-04"
-1509	enchanted artisanal practically non-alcoholic slap and tickle with a fly in it	1	EPIC	Effect: "You Know What's Up", Effect Duration: 35, Last Available: "2006-04"
+1508	acceptable practically non-alcoholic lime green perpendicular hula with a fly in it	1	good	Last Available: "2006-04"
+1509	practically non-alcoholic enchanted artisanal slap and tickle with a fly in it	1	EPIC	Effect: "You Know What's Up", Effect Duration: 35, Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	weightlifter's fake hand	0		Muscle: +15, Last Available: "2006-04"
 1512	powdered maroon jittery Knob Goblin pet-buffing spray	1		
 1513	twisted Knob Goblin learning pill	1		
-1514	dehydrated cyan wobbly skewed Knob Goblin eyedrops	1		Effect: "Sticks and Stones", Effect Duration: 5
+1514	dehydrated wobbly cyan skewed Knob Goblin eyedrops	1		Effect: "Sticks and Stones", Effect Duration: 5
 1515	dehydrated blinking Knob Goblin nasal spray	1		Effect: "Berry Statistical", Effect Duration: 50
 1516	fuchsia skewed KWE-brand transistor radio	0		
 1518	vampire heart	0		
@@ -1503,23 +1503,23 @@
 1522	reassuring scandalous Radio Free Jersey	0		Sleaze Damage: +5, Spooky Resistance: +1
 1523	tumbling bottle of used blood	0		
 1524	huge wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	twirling pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1526	twirling pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	olive asbestos-lined toasty corkscrew	0		Hot Damage: +5, Hot Resistance: +5, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	wobbly fake plastic grass	0		Last Available: "2011-01"
-1531	Usain Bolt's grass skirt	0		Initiative: +80, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	grass hat of the storm	0		Maximum MP Percent: +40, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	Usain Bolt's grass skirt	0		Initiative: +80, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	grass hat of the storm	0		Maximum MP Percent: +40, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	grass blade of the wise owl	0		Mysticality: +20, Last Available: "2011-01"
 1534	maroon raffle prize box	0		
 1536	pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	sparkly engagement ring of Gandalf	0		Spell Critical Percent: +20, Single Equip
 1539	spinning Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	twirling mirror Grimacite goggles of incineration of doom	0		Hot Spell Damage: +50, Spooky Spell Damage: +50, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	twirling mirror Grimacite goggles of incineration of doom	0		Hot Spell Damage: +50, Spooky Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	maroon Socratic savvy Grimacite glaive	0		Mysticality Percent: +20, Experience (Mysticality): +1, Last Available: "2008-10"
-1542	wobbly frosty fortified Grimacite greaves	0		Damage Absorption: +60, Cold Spell Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	wobbly frosty fortified Grimacite greaves	0		Damage Absorption: +60, Cold Spell Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	rosewater-soaked sizzling Grimacite garter	0		Hot Damage: +10, Stench Resistance: +3, Last Available: "2008-10"
 1544	teal ribald gravedigger's Grimacite galoshes	0		Spooky Damage: +10, Sleaze Damage: +10, Last Available: "2008-10"
 1545	fortified Grimacite gorget of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100, Last Available: "2008-10"
@@ -1532,45 +1532,45 @@
 1552	artisanal bottle of Definit	3	EPIC	
 1553	special acceptable bottle of Calcutta Emerald	4	good	Effect: "Oth-Jeal-O", Effect Duration: 45
 1554	drinkable bottle of Lieutenant Freeman	4	good	
-1555	practically non-alcoholic artisanal twirling bottle of Jorge Sinsonte	1	EPIC	
+1555	artisanal practically non-alcoholic twirling bottle of Jorge Sinsonte	1	EPIC	
 1556	practically non-alcoholic tolerable twirling boxed champagne	1	good	
 1557	tasty immense kumquat	9	awesome	
-1558	normal snack-sized tangerine	2	good	
+1558	snack-sized normal tangerine	2	good	
 1559	wobbly tonic water	0		
 1560	decent super-sized cocktail onion	5	good	
-1561	tasty super-sized tumbling raspberry	5	awesome	
+1561	super-sized tasty tumbling raspberry	5	awesome	
 1562	big bland kiwi	5	decent	
-1563	weak perfectly mixed whiskey bittersweet	2	EPIC	
+1563	perfectly mixed weak whiskey bittersweet	2	EPIC	
 1564	mediocre mimosette	4	decent	
 1565	acceptable tequila sunset	3	good	
 1566	bad maroon zmobie	4	decent	Wiki Name: "Zmobie (drink)"
 1567	strong perfectly mixed gin and tonic	5	EPIC	
-1568	artisanal weak spinning mirror vodka and tonic	2	EPIC	
+1568	weak artisanal spinning mirror vodka and tonic	2	EPIC	
 1569	drinkable vodka gibson	3	good	
 1570	artisanal gibson	4	EPIC	
-1571	tolerable narrow mirror parisian cathouse	3	good	
+1571	tolerable mirror narrow parisian cathouse	3	good	
 1572	extra-dry tolerable rabbit punch	5	good	
-1573	fancy smooth caipifruta	3	awesome	Effect: "Mortarfied", Effect Duration: 5
+1573	smooth fancy caipifruta	3	awesome	Effect: "Mortarfied", Effect Duration: 5
 1574	tolerable weak tumbling teqiwila	2	good	
-1575	bad triple-distilled mirror fuchsia Divine	10	decent	
-1576	hand-crafted watered-down Gordon Bennett	2	super ultra EPIC	
+1575	triple-distilled bad fuchsia mirror Divine	10	decent	
+1576	watered-down hand-crafted Gordon Bennett	2	super ultra EPIC	
 1577	watered-down perfectly mixed olive tangarita	2	super ultra EPIC	
-1578	hand-crafted wobbly upside-down mandarina colada	3	EPIC	
+1578	hand-crafted upside-down wobbly mandarina colada	3	EPIC	
 1579	delicious gimlet	3	awesome	
 1580	aged watered-down brick road	2	awesome	
 1581	artisanal practically non-alcoholic vodka stratocaster	1	super ultra mega turbo EPIC	
-1582	weak tolerable Neuromancer	2	good	
+1582	tolerable weak Neuromancer	2	good	
 1583	lousy prussian cathouse	3	decent	
-1584	acceptable fancy huge Mae West	4	good	Effect: "Beastly Flavor", Effect Duration: 45
+1584	fancy acceptable huge Mae West	4	good	Effect: "Beastly Flavor", Effect Duration: 45
 1585	strong artisanal Mon Tiki	5	EPIC	
-1586	perfectly mixed weak teqiwila slammer	2	super ultra EPIC	
-1587	big stale Knob lo mein	5	decent	
-1588	delicious fancy asparagus lo mein	4	awesome	Effect: "Burning Ears", Effect Duration: 15
-1589	yummy special Knoll lo mein	3	awesome	Effect: "In a Lather", Effect Duration: 35
-1590	immense normal lo mein	8	good	
-1591	rotten half-sized bouncing teal olive lo mein	2	crappy	
-1592	big bland skewed red hot hi mein	5	decent	
-1593	small bland pulsating hi mein	2	decent	
+1586	weak perfectly mixed teqiwila slammer	2	super ultra EPIC	
+1587	stale big Knob lo mein	5	decent	
+1588	fancy delicious asparagus lo mein	4	awesome	Effect: "Burning Ears", Effect Duration: 15
+1589	special yummy Knoll lo mein	3	awesome	Effect: "In a Lather", Effect Duration: 35
+1590	normal immense lo mein	8	good	
+1591	half-sized rotten bouncing teal olive lo mein	2	crappy	
+1592	big bland red skewed hot hi mein	5	decent	
+1593	bland small pulsating hi mein	2	decent	
 1594	adequate miniature hi mein	2	good	
 1595	decent fancy hi mein	4	good	Effect: "Kindly Resolve", Effect Duration: 30
 1596	moldy sleazy hi mein	3	crappy	
@@ -1579,21 +1579,21 @@
 1599	gray jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	high-proof mediocre tangarita with a fly in it	9	decent	
 1601	delicious mandarina colada with a fly in it	4	awesome	
-1602	acceptable wobbly blue shaking prussian cathouse with a fly in it	3	good	
-1603	delicious watered-down Mae West with a fly in it	2	awesome	
+1602	acceptable shaking wobbly blue prussian cathouse with a fly in it	3	good	
+1603	watered-down delicious Mae West with a fly in it	2	awesome	
 1604	dried upside-down astronaut ice-cream	1		Effect: "The Magical Mojomuscular Melody", Effect Duration: 45, Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	denatured upside-down ultimate wad	1		
 1607	irradiated energized libation of liveliness	0		Effect: "Covetous Robbery", Effect Duration: 28
 1608	non-boiled liquefied eyedrops of the ermine	0		Effect: "Mint-Condition Breath", Effect Duration: 61
-1609	extra-moist triple-tarnished tumbling ghostly perfume of prejudice	0		Effect: "There Wolf", Effect Duration: 24
+1609	extra-moist triple-tarnished ghostly tumbling perfume of prejudice	0		Effect: "There Wolf", Effect Duration: 24
 1610	nitrogenated eyedrops of the ocelot	0		Effect: "Cinnamouth", Effect Duration: 14
 1611	modified ionized potent potion of potency	0		Effect: "Deeply Ironic", Effect Duration: 18
 1612	improved oxidized pulsating concentrated cordial of concentration	0		Effect: "Smelly Pants", Effect Duration: 64
 1613	fuchsia vibrating coffin lid	0		Maximum MP Percent: +10, Damage Reduction: 3
 1614	narrow supercharged satin shield	0		Maximum MP Percent: +30, Damage Reduction: 5
-1615	pulsating miser's Cerebral Cloche	0		Meat Drop: +10, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	Cerebral Culottes of doom	0		Spooky Spell Damage: +50, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	pulsating miser's Cerebral Cloche	0		Meat Drop: +10, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	Cerebral Culottes of doom	0		Spooky Spell Damage: +50, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	pulsating veiny healthy experienced Cerebral Crossbow	0		Experience: +2, Maximum HP Percent: +20, Maximum HP: +10, Last Available: "2006-06"
 1618	olive ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1601,17 +1601,17 @@
 1621	bouncing astral badger	0		Free Pull, Last Available: "2006-06"
 1622	pressed extra-moist astral mushroom	0		Effect: "In the Limelight", Effect Duration: 52, Last Available: "2006-06"
 1623	pulsating badger badge	0		Last Available: "2006-06"
-1624	polymerized dry squat upside-down yellow blue-frosted astral cupcake	0		Effect: "Deep-Seated Rage", Effect Duration: 11, Last Available: "2006-06"
+1624	polymerized dry upside-down squat yellow blue-frosted astral cupcake	0		Effect: "Deep-Seated Rage", Effect Duration: 11, Last Available: "2006-06"
 1625	vacuum-sealed enhanced narrow jittery green-frosted astral cupcake	0		Effect: "Burning Ears", Effect Duration: 32, Last Available: "2006-06"
 1626	unsweetened orange-frosted astral cupcake	0		Effect: "Pumped Stomach", Effect Duration: 31, Last Available: "2006-06"
 1627	warmed purple-frosted astral cupcake	0		Effect: "Cotton Mouthed", Effect Duration: 65, Last Available: "2006-06"
-1628	electrified upside-down blurry pink-frosted astral cupcake	0		Effect: "Nature's Bounty", Effect Duration: 51, Last Available: "2006-06"
+1628	electrified blurry upside-down pink-frosted astral cupcake	0		Effect: "Nature's Bounty", Effect Duration: 51, Last Available: "2006-06"
 1629	raspberry beret of the businessman	0		Meat Drop: +50, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	extremely unsafe pixel shield	0		Weapon Damage Percent: +100, Damage Reduction: 3
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
-1633	gray squat Spanish fly	0		
-1634	fancy hand-crafted weak narrow around the world	2	EPIC	Effect: "Fire Inside", Effect Duration: 35
+1633	squat gray Spanish fly	0		
+1634	weak hand-crafted fancy narrow around the world	2	EPIC	Effect: "Fire Inside", Effect Duration: 35
 1635	teal scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	super-chilled warmed vacuum-sealed lotion of hotness	0		Effect: "Permafrosty", Effect Duration: 68
@@ -1630,7 +1630,7 @@
 1650	tumbling milk of magnesium	0		
 1651	low-calorie moldy foie gras	1	crappy	
 1652	Vulcanized activated skewed candy brain	0		Effect: "Shamboozled", Effect Duration: 35, Last Available: "2020-09"
-1653	sharpshooter's dance instructor's jewel-eyed wizard hat of the glutton	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Food Drop: +100, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	sharpshooter's dance instructor's jewel-eyed wizard hat of the glutton	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Food Drop: +100, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	spinning manspreader's Rosewater's wad of Crovacite	0		Mysticality Percent: +30, Monster Level: +10
 1655	spinning Tesla collar	0		Item Drop: +5, MP Regen Min: 7, MP Regen Max: 10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1655,7 +1655,7 @@
 1675	ore	0		
 1676	upside-down styrofoam ore	0		
 1677	bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	dog trainer's Temple Grandin's sword	0		Familiar Weight: +7, Experience (familiar): +1
 1680	staff of the scaredy-cat of the early riser	0		Monster Level: -15, Adventures: +7
 1681	smartaleck's boxer's bubblewrap sword	0		Muscle Percent: +10, Moxie Percent: +30
@@ -1674,12 +1674,12 @@
 1694	deionized super-polarized Frogade	0		Effect: "Liquidy Smoky", Effect Duration: 42
 1695	ionized papotion of papower	0		Effect: "Fit To Be Tide", Effect Duration: 50
 1696	stale royal jelly taco	3	decent	
-1697	flavorless big special tofu taco	5	decent	Effect: "Happy Trails", Effect Duration: 5
+1697	big special flavorless tofu taco	5	decent	Effect: "Happy Trails", Effect Duration: 5
 1698	flavorless jumping bean taco	4	decent	
-1699	yummy small catgut taco	2	awesome	
-1700	snack-sized adequate gray goat cheese taco	2	good	
-1701	snack-sized flavorless twirling pr0n taco	2	decent	
-1702	alkaline frozen twirling squat twirling alphabet gum	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 66
+1699	small yummy catgut taco	2	awesome	
+1700	adequate snack-sized gray goat cheese taco	2	good	
+1701	flavorless snack-sized twirling pr0n taco	2	decent	
+1702	alkaline frozen twirling twirling squat alphabet gum	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 66
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
 1705	bouncing flaregun	0		
@@ -1744,31 +1744,31 @@
 1765	Spookyraven gallery key	0		
 1766	huge tumbling Spookyraven ballroom key	0		
 1767	ghostly pack of chewing gum	0		
-1768	pulsating upside-down Gnomish toolbox	0		
-1769	snack-sized normal fricasseed brains	2	good	
-1770	massive spoiled brains casserole	9	crappy	
+1768	upside-down pulsating Gnomish toolbox	0		
+1769	normal snack-sized fricasseed brains	2	good	
+1770	spoiled massive brains casserole	9	crappy	
 1771	butcherknife of the businessman	0		Meat Drop: +50
 1772	wobbly flame-wreathed corn holder	0		Hot Spell Damage: +10
 1773	rosy-cheeked eggbeater	0		Maximum HP Percent: +30
 1774	mediocre irresponsibly strong bottle of popskull	9	decent	
 1775	razor-sharp dishrag	0		Weapon Damage Percent: +25
-1776	immense yummy stale baguette	7	awesome	
+1776	yummy immense stale baguette	7	awesome	
 1777	leftovers of indeterminate origin	0		
 1778	normal dinner	3	good	
 1779	steel-toed katana	0		Damage Reduction: 9
 1780	resourceful ram stick	0		Maximum MP: +50
 1781	enchantlers of incineration	0		Hot Spell Damage: +50, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	prompt Temple Grandin's ram-battering staff	0		Familiar Weight: +7, Adventures: +3
-1783	snack-sized special moldy crazy Turkish delight	2	crappy	Effect: "Beastly Flavor", Effect Duration: 30
+1783	moldy snack-sized special crazy Turkish delight	2	crappy	Effect: "Beastly Flavor", Effect Duration: 30
 1784	twirling vibrating Snow Queen Crown of bravery	0		Maximum MP Percent: +10, Spooky Resistance: +5, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	resourceful grievous dangerous ga-ga radio	0		Weapon Damage: +10, Weapon Damage Percent: +50, Maximum MP: +50
 1786	blinking six pack of Mountain Stream	0		
 1787	ionized blurry bag of Cheat-Os	0		Effect: "Jawin'", Effect Duration: 30
 1788	ghostly unrefined Mountain Stream syrup	0		
 1789	ghostly Mob Penguin	0		
-1790	drinkable strong pulsating Ram's Face Lager	5	good	
+1790	strong drinkable pulsating Ram's Face Lager	5	good	
 1791	upside-down ram horns	0		
-1792	prompt censurious occult Travoltan trousers	0		Spell Damage Percent: +25, Sleaze Resistance: +3, Adventures: +3, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	prompt censurious occult Travoltan trousers	0		Spell Damage Percent: +25, Sleaze Resistance: +3, Adventures: +3, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	aromatic Samson's pool cue	0		Experience (Muscle): +5, Stench Resistance: +1
 1794	Vulcanized handful of hand chalk	0		Effect: "Bandersnatched", Effect Duration: 58
 1795	teal Counterclockwise Watch of Tarzan	0		Experience (Muscle): +3, Single Equip
@@ -1779,7 +1779,7 @@
 1800	animal cranium	0		
 1801	animal jawbone	0		
 1802	upside-down first cervical vertebra	0		
-1803	narrow squat red second cervical vertebra	0		
+1803	squat red narrow second cervical vertebra	0		
 1804	shaking third cervical vertebra	0		
 1805	fourth cervical vertebra	0		
 1806	fifth cervical vertebra	0		
@@ -1794,11 +1794,11 @@
 1815	narrow seventh thoracic vertebra	0		
 1816	narrow eighth thoracic vertebra	0		
 1817	ghostly ninth thoracic vertebra	0		
-1818	ghostly blurry upside-down tenth thoracic vertebra	0		
+1818	blurry upside-down ghostly tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
 1820	blinking twelfth thoracic vertebra	0		
 1821	huge first lumbar vertebra	0		
-1822	narrow blue second lumbar vertebra	0		
+1822	blue narrow second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
 1825	twirling fifth lumbar vertebra	0		
@@ -1855,7 +1855,7 @@
 1876	left tibia	0		
 1877	maroon right tibia	0		
 1878	jittery left fibula	0		
-1879	ghostly squat right fibula	0		
+1879	squat ghostly right fibula	0		
 1880	shaking left kneecap	0		
 1881	yellow right kneecap	0		
 1882	ghostly left first front claw	0		
@@ -1925,9 +1925,9 @@
 1948	MacGyver's weightlifter's tap shoes	0		Muscle: +15, Maximum MP: +100, Single Equip
 1949	delicious Manetwich	3	awesome	
 1950	bottle of Vangoghbitussin	0		
-1951	tolerable fortified bottle of Pinot Renoir	5	good	
+1951	fortified tolerable bottle of Pinot Renoir	5	good	
 1952	delicious bite-sized ghostly desiccated apricot	1	awesome	
-1953	smooth triple-distilled flute of flat champagne	9	awesome	
+1953	triple-distilled smooth flute of flat champagne	9	awesome	
 1954	spoiled dehydrated caviar	3	crappy	
 1955	styrofoam peanuts	0		
 1956	lousy snifter of thoroughly aged brandy	3	decent	
@@ -1958,7 +1958,7 @@
 1981	twirling astral badger	0		
 1982	huge MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
-1984	blurry squat snowy owl	0		
+1984	squat blurry snowy owl	0		
 1985	scary death orb	0		
 1986	twirling mind flayer	0		
 1987	undead elbow macaroni	0		
@@ -1998,10 +1998,10 @@
 2021	decent snack-sized strawberry pie	2	good	
 2022	rotten lemon meringue pie	3	crappy	
 2023	Genalen&trade; Bottle	1	decent	
-2024	miniature decent huge mixed wildflower greens	2	good	
+2024	decent miniature huge mixed wildflower greens	2	good	
 2025	stale handful of walnuts	3	decent	
 2026	spoiled nutty organic salad	4	crappy	
-2027	delicious miniature fancy shaking huge super salad	2	awesome	Effect: "Items Are Forever", Effect Duration: 35
+2027	fancy miniature delicious shaking huge super salad	2	awesome	Effect: "Items Are Forever", Effect Duration: 35
 2028	tasty teal tofu wonton	4	awesome	
 2029	upside-down hippy protest button	0		Single Equip
 2030	flame-wreathed Lockenstock&trade; sandals of the sweet-tooth	0		Hot Spell Damage: +10, Candy Drop: +100, Single Equip
@@ -2019,7 +2019,7 @@
 2042	pulsating exploding hacky-sack	0		
 2043	hemp net	0		
 2044	mirror your father's MacGuffin diary	0		
-2045	half-sized bland brain-meltingly-hot chicken wings	2	decent	
+2045	bland half-sized brain-meltingly-hot chicken wings	2	decent	
 2046	spoiled frat brats	3	crappy	
 2047	yummy huge knob ka-bobs	3	awesome	
 2049	watered-down tolerable jittery can of Swiller	2	good	
@@ -2037,7 +2037,7 @@
 2061	ghostly blurry greasy helmet	0		Sleaze Spell Damage: +10, Familiar Effect: "1xFairy, cap 40"
 2062	perfumed cool shield	0		Moxie: +5, Stench Resistance: +5, Damage Reduction: 10
 2063	bland miniature blackberry	2	decent	
-2064	fuchsia shaking forged identification documents	0		
+2064	shaking fuchsia forged identification documents	0		
 2065	PADL Phone	0		
 2066	squat lard-coated MacGyver's kick-ass kicks	0		Maximum MP: +100, Sleaze Spell Damage: +25, Single Equip
 2067	huge sake bomb	0		
@@ -2060,14 +2060,14 @@
 2084	upside-down can of starch	0		
 2085	diluted tumbling bottle of ultravitamins	1		
 2086	altered blurry bottle of cough syrup	1		Effect: "Chunky", Effect Duration: 20
-2087	powdered lime green pulsating tube of hair oil	1		Effect: "Old School Pompadour", Effect Duration: 35
+2087	powdered pulsating lime green tube of hair oil	1		Effect: "Old School Pompadour", Effect Duration: 35
 2088	dry Daffy Taffy	0		Effect: "Fever From the Flavor", Effect Duration: 48
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	red smelly sharpshooter's brawny pilgrim shield of incineration of the sewer	0		Muscle Percent: +20, Critical Hit Percent: +10, Hot Spell Damage: +50, Stench Damage: +25, Stench Spell Damage: +10, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	tumbling bath salts	0		
 2092	hand mirror	0		
 2093	hors d'oeuvre tray of Calamity Jane	0		Critical Hit Percent: +15, Damage Reduction: 5
-2094	super-sized toothsome ballroom blintz	5	awesome	
+2094	toothsome super-sized ballroom blintz	5	awesome	
 2095	upside-down towel	0		
 2096	diluted upside-down guy made of bee pollen	1		
 2097	mirror padded 17-ball	0		Damage Absorption: +20
@@ -2080,17 +2080,17 @@
 2104	empty aftershave bottle	0		
 2105	blurry coal button	0		
 2106	burned-out arcanodiode	0		
-2107	tumbling blinking non-Euclidean hoof	0		
+2107	blinking tumbling non-Euclidean hoof	0		
 2108	rock	0		
 2109	maroon stringy sinew	0		Last Available: "2011-12"
-2110	fuchsia shaking stick	0		Last Available: "2011-12"
+2110	shaking fuchsia stick	0		Last Available: "2011-12"
 2111	tumbling tooth	0		
 2112	blinking leaf	0		Last Available: "2011-12"
 2113	jittery chilly wheel	0		Cold Damage: +5, Last Available: "2006-12"
 2114	yo	0		Last Available: "2006-12"
 2115	experienced prehistoric spear	0		Experience: +2, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	arcane researcher's fire of the dark arts	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +100, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	arcane researcher's fire of the dark arts	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +100, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	squat leaf tube	0		Last Available: "2006-12"
 2119	pulsating yellow lit cigar	0		Last Available: "2011-12"
 2120	tumbling hardened Grateful Undead T-shirt	0		Damage Reduction: 3
@@ -2118,11 +2118,11 @@
 2143	felt	0		Last Available: "2011-12"
 2144	evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
-2146	spinning gray evil teddy bear	0		Last Available: "2006-12"
+2146	gray spinning evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	upside-down toothsome rock	0		
-2149	immense adequate huge frank	6	good	Last Available: "2011-12"
-2150	stale skewed spinning plate of franks and beans	4	decent	Last Available: "2011-12"
+2149	adequate immense huge frank	6	good	Last Available: "2011-12"
+2150	stale spinning skewed plate of franks and beans	4	decent	Last Available: "2011-12"
 2151	lousy ghostly shot of blackberry schnapps	3	decent	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	red huge ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	twirling hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	red chilly toy ray gun of the storm	0		Maximum MP Percent: +40, Cold Damage: +5, Last Available: "2006-12"
-2169	blurry jittery narrow personal trainer's Sinatra's toy space helmet	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	blurry jittery narrow personal trainer's Sinatra's toy space helmet	0		Experience (Moxie): +5, Experience Percent (Muscle): +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	huge MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	lard-coated thinker's astronaut pants	0		Mysticality: +10, Sleaze Spell Damage: +25, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	lard-coated thinker's astronaut pants	0		Mysticality: +10, Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	lime green quilted toy jet pack	0		Damage Absorption: +40, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2155,7 +2155,7 @@
 2180	amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	blinking twirling pulsating Harold's hammer handle	0		
+2183	pulsating blinking twirling Harold's hammer handle	0		
 2184	upside-down Harold's hammer	0		
 2185	experienced Kiss the Knob apron	0		Experience: +2
 2186	twirling unlit birthday cake	0		
@@ -2182,19 +2182,19 @@
 2207	mansplainer's Crimbo tiki necklace	0		Monster Level: +15, Last Available: "2006-12"
 2208	bouncing fireproof bobble-hip hula elf doll of the blizzard	0		Cold Spell Damage: +25, Hot Resistance: +3, Last Available: "2006-12"
 2209	horrifying Crimbo ukulele	0		Spooky Damage: +25, Last Available: "2006-12"
-2210	horrifying vibrating Tiki lighter	0		Maximum MP Percent: +10, Spooky Damage: +25, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	dangerous deck of tropical cards of the businessman	0		Weapon Damage: +10, Meat Drop: +50, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	electrified tropical paperweight of the wise owl	0		Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	horrifying vibrating Tiki lighter	0		Maximum MP Percent: +10, Spooky Damage: +25, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	dangerous deck of tropical cards of the businessman	0		Weapon Damage: +10, Meat Drop: +50, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	electrified tropical paperweight of the wise owl	0		Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	miser's Tropical Crimbo Hat	0		Meat Drop: +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	twirling Tropical Crimbo Shorts of dire peril	0		Weapon Damage: +20, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	miser's Tropical Crimbo Hat	0		Meat Drop: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	twirling Tropical Crimbo Shorts of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	spoiled super ka-bob	3	crappy	
 2218	stale upside-down beer basted brat	3	decent	
 2219	padded Tropical Crimbo Sword	0		Damage Absorption: +20, Last Available: "2006-12"
 2220	extra-vacuum-sealed huge and Crimboween candy	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 33, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	Sherlock's therapeutic liar's pants	0		Item Drop: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	Sherlock's therapeutic liar's pants	0		Item Drop: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	Newton's juggler's balls of doom	0		Experience (Mysticality): +3, Spooky Spell Damage: +50, Softcore Only, Last Available: "2007-01"
 2224	upside-down Jack Frost's pink shirt	0		Cold Spell Damage: +50, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2235,16 +2235,16 @@
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	lion oil	0		
-2264	miniature moldy stunt nuts	2	crappy	
-2265	snack-sized toothsome wet stew	2	awesome	
+2264	moldy miniature stunt nuts	2	crappy	
+2265	toothsome snack-sized wet stew	2	awesome	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	savvy Staff of Fats	0		Mysticality Percent: +20
-2269	stale snack-sized sausage wonton	2	decent	
+2269	snack-sized stale sausage wonton	2	decent	
 2270	belt of the bloodbag of doom	0		Maximum HP: +100, Spooky Spell Damage: +50, Single Equip
-2271	mediocre extra-dry shaking bottle of Merlot	5	decent	
+2271	extra-dry mediocre shaking bottle of Merlot	5	decent	
 2272	weak tolerable bottle of Port	2	good	
-2273	bad watered-down bottle of Pinot Noir	2	decent	
+2273	watered-down bad bottle of Pinot Noir	2	decent	
 2274	artisanal twirling bottle of Zinfandel	3	EPIC	
 2275	aged bottle of Marsala	3	awesome	
 2276	hand-crafted fancy spinning bottle of Muscat	4	EPIC	Effect: "Wasabi With You", Effect Duration: 50
@@ -2257,7 +2257,7 @@
 2283	nasty seal-skull helmet	0		Stench Damage: +5, Familiar Effect: "atk, cap 2"
 2284	upside-down petrified noodles	0		
 2285	chisel	0		
-2286	ghostly tumbling Eye of Ed	0		
+2286	tumbling ghostly Eye of Ed	0		
 2287	wobbly glowstick of Tarzan of the bloodbag	0		Experience (Muscle): +3, Maximum HP: +100, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
 2289	paperclip	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	aerosolized magnetized candy heart	0		Effect: "Vinegavotte", Effect Duration: 58, Last Available: "2007-02"
 2305	modified colloidal pink candy heart	0		Effect: "Boo Tea", Effect Duration: 25, Last Available: "2007-02"
 2306	extra-liquefied candy heart	0		Effect: "Helvella Health", Effect Duration: 37, Last Available: "2007-02"
@@ -2283,7 +2283,7 @@
 2309	flattened mirror candy heart	0		Effect: "Ancient Protected", Effect Duration: 44, Last Available: "2007-02"
 2310	wobbly candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
-2312	ghostly tumbling candygram	0		Last Available: "2007-02"
+2312	tumbling ghostly candygram	0		Last Available: "2007-02"
 2313	blinking candygram	0		Last Available: "2007-02"
 2314	squat candygram	0		Last Available: "2007-02"
 2315	candygram	0		Last Available: "2007-02"
@@ -2313,7 +2313,7 @@
 2339	bad high-proof special Blackfly Chardonnay	9	decent	Effect: "Ooh, Bitter!", Effect Duration: 50
 2340	strong perfectly mixed blurry & tan	5	EPIC	
 2341	pepper	0		
-2342	adequate small pulsating pulsating forest cake	2	good	
+2342	small adequate pulsating pulsating forest cake	2	good	
 2343	rotten forest ham	3	crappy	
 2344	triple-chilled deionized filthworm hatchling scent gland	0		Effect: "Red-Shirted Escort", Effect Duration: 69
 2345	aerosolized super-vacuum-sealed filthworm drone scent gland	0		Effect: "Dreams and Lights", Effect Duration: 63
@@ -2330,7 +2330,7 @@
 2356	energized mirror tube of dread wax	0		Effect: "Sugar High", Effect Duration: 53
 2357	ghostly supercool thinker's Gaia beads	0		Mysticality: +10, Moxie Percent: +20
 2358	huge pink clay bead	0		
-2359	narrow blinking clay bead	0		
+2359	blinking narrow clay bead	0		
 2360	blurry blinking clay bead	0		
 2361	narrow supercharged Socratic hippy medical kit	0		Experience (Mysticality): +1, Maximum MP Percent: +30, Single Equip
 2362	asbestos-lined Slow Talkin' Elliot's dogtags of incineration	0		Hot Spell Damage: +50, Hot Resistance: +5
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	smoke bomb	0		
 2372	bunch of bananas	0		
-2373	bite-sized enchanted bland skewed banana	1	decent	Effect: "Brother Corsican's Blessing", Effect Duration: 10
+2373	enchanted bite-sized bland skewed banana	1	decent	Effect: "Brother Corsican's Blessing", Effect Duration: 10
 2374	banana peel	0		
-2375	big decent banana cream pie	5	good	
+2375	decent big banana cream pie	5	good	
 2376	mediocre banana daiquiri	3	decent	
 2377	lousy bungle in the jungle	3	decent	
 2378	banana spritzer	0		
@@ -2355,7 +2355,7 @@
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
 2382	class ring	0		
 2383	skewed class ring	0		
-2384	squat pulsating class ring	0		
+2384	pulsating squat class ring	0		
 2385	narrow bottle opener belt buckle	0		Single Equip
 2386	ghostly coward's sinister keg shield	0		Spell Damage: +10, Monster Level: -20, Damage Reduction: 11
 2387	Newton's finger	0		Experience (Mysticality): +3
@@ -2394,16 +2394,16 @@
 2420	Vulcanized galvanized teeny-tiny magic scroll	0		Effect: "Patent Avarice", Effect Duration: 20
 2421	nitrogenated twirling bottle of pirate juice	0		Effect: "Executive Greed", Effect Duration: 13
 2422	corrupted ionized blue irradiated pet snacks	0		Effect: "Irresistible Resolve", Effect Duration: 49
-2423	improved huge tumbling green Mick's IcyVapoHotness Inhaler	0		Effect: "Human-Goblin Hybrid", Effect Duration: 62
+2423	improved huge green tumbling Mick's IcyVapoHotness Inhaler	0		Effect: "Human-Goblin Hybrid", Effect Duration: 62
 2424	pickled energized cyclops eyedrops	0		Effect: "Got Your Boots On", Effect Duration: 53
 2425	aerosolized can of spinach	0		Effect: "Burnt 'n' Turnt", Effect Duration: 25
 2426	polarized anodized Vulcanized tumbling fire flower	0		Effect: "Pumped Stomach", Effect Duration: 12
 2427	boiled energized shaking freezerburned ice cube	0		Effect: "Tingling Feeling", Effect Duration: 15
-2428	triple-quantum chilled warmed tumbling blue fake blood	0		Effect: "Aided and Abetted", Effect Duration: 49
+2428	triple-quantum chilled warmed blue tumbling fake blood	0		Effect: "Aided and Abetted", Effect Duration: 49
 2429	moist non-warmed electrified Eau de Guaneau	0		Effect: "Joyful Resolve", Effect Duration: 53
 2430	energized extra-flattened altered bag of lard	0		Effect: "What's That Smell?", Effect Duration: 17
 2431	liquefied galvanized altered bottle of Mystic Shell	0		Effect: "Using Protection", Effect Duration: 42
-2432	pickled denatured teal mirror SPF 451 lip balm	0		Effect: "Worth Your Salt", Effect Duration: 31
+2432	pickled denatured mirror teal SPF 451 lip balm	0		Effect: "Worth Your Salt", Effect Duration: 31
 2433	alkaline tarnished bottle of antifreeze	0		Effect: "Eye of the Seal", Effect Duration: 21
 2434	ionized modified eyedrops	0		Effect: "Feeling No Pain", Effect Duration: 56
 2435	super-adjusted ionized frozen Dogsgotnonoz pills	0		Effect: "Briny Blood", Effect Duration: 28
@@ -2492,12 +2492,12 @@
 2519	bad McMillicancuddy's Special Lager	4	decent	
 2520	lousy twirling melted Jell-o shot	3	decent	
 2521	irresponsibly strong delicious cruelty-free wine	8	awesome	
-2522	weak drinkable thistle wine	2	good	
-2523	narrow gray megatofu	0		
+2522	drinkable weak thistle wine	2	good	
+2523	gray narrow megatofu	0		
 2524	displaced fish	0		
 2525	normal fish	4	good	
 2526	moldy small spinning cyan fish casserole	2	crappy	
-2527	spoiled bite-sized spinning gray fish lasagna	1	crappy	
+2527	bite-sized spoiled gray spinning fish lasagna	1	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	rotten gnatloaf	4	crappy	
 2530	low-calorie spoiled upside-down gnatloaf casserole	1	crappy	
@@ -2518,7 +2518,7 @@
 2545	diffused extra-ionized huge upsy daisy	0		Effect: "Barking Mad", Effect Duration: 15, Last Available: "2007-05"
 2546	activated pickled half-orchid	0		Effect: "Brocolate Brostidigitation", Effect Duration: 44, Last Available: "2007-05"
 2547	auspicious medical-grade tin star	0		Item Drop: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2007-05"
-2548	nasty outrageous sombrero of the early riser	0		Stench Damage: +5, Adventures: +7, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	nasty outrageous sombrero of the early riser	0		Stench Damage: +5, Adventures: +7, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	greedy knitted &quot;Humorous&quot; T-shirt	0		Cold Resistance: +3, Meat Drop: +20, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	bouncing vial of mojo	0		
@@ -2541,7 +2541,7 @@
 2568	bouncing Azazel's tutu	0		
 2569	altered blurry ant agonist	0		Effect: "Feet of Watermelon", Effect Duration: 15
 2570	twirling ant hoe	0		Familiar Effect: "sleaze damage, meat"
-2571	red spinning ant rake	0		Familiar Effect: "hot damage, meat"
+2571	spinning red ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	ant pick	0		Familiar Effect: "cold damage, meat"
@@ -2553,17 +2553,17 @@
 2580	family-friendly scorpion whip of the cougar	0		Moxie: +20, Sleaze Resistance: +1
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	yummy small centipede eggs	2	awesome	
+2583	small yummy centipede eggs	2	awesome	
 2584	yellow wobbly grievous wonderwall shield	0		Weapon Damage Percent: +50, Damage Reduction: 12
 2585	squat MacGyver's Colonel Mustard's Lonely Spades Club Jacket	0		Maximum MP: +100
 2586	bouncing teal electrified General Sage's Lonely Diamonds Club Jacket	0		MP Regen Min: 3, MP Regen Max: 5
 2587	maroon asbestos-lined Corporal Fennel's Lonely Clubs Club Jacket	0		Hot Resistance: +5
 2588	mirror dog trainer's Private Pepper's Lonely Hearts Club Jacket	0		Experience (familiar): +1
 2589	bland gray hot date	3	decent	
-2590	artisanal weak distilled fortified wine	2	EPIC	
+2590	weak artisanal distilled fortified wine	2	EPIC	
 2591	moldy tasty tart	3	crappy	
 2592	bouncing Knob Goblin lunchbox	0		
-2593	flavorless low-calorie Knob pasty	1	decent	
+2593	low-calorie flavorless Knob pasty	1	decent	
 2594	mediocre strong thermos full of Knob coffee	5	decent	
 2595	alkaline Ben-Gal&trade; Balm	0		Effect: "Ponderous Potency", Effect Duration: 66
 2596	blurry leathery cat skin	0		
@@ -2590,7 +2590,7 @@
 2617	narrow boom	0		
 2618	pulsating forbidden Iiti Kitty phone charm	0		Spell Damage Percent: +50, Single Equip
 2619	squat jar of swamp gas	0		Last Available: "2007-05"
-2620	moldy bite-sized unidentified jerky	1	crappy	
+2620	bite-sized moldy unidentified jerky	1	crappy	
 2621	cyan vibrating medical-grade nasty rat mask	0		Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	ghostly purple electrified ratskin belt of the sweet-tooth	0		Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 2623	teal Annie Oakley's energetic rattail whip	0		Maximum MP Percent: +20, Critical Hit Percent: +20
@@ -2601,7 +2601,7 @@
 2628	smooth catskin buckler of bravery	0		Moxie: +15, Spooky Resistance: +5, Damage Reduction: 11
 2629	tail o' nine cats of Gandalf of terror	0		Spell Critical Percent: +20, Spooky Spell Damage: +10
 2630	Hugo's Weaving Manual	0		
-2631	dry huge fuchsia gremlin juice	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 62
+2631	dry fuchsia huge gremlin juice	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 62
 2632	aerosolized cold-filtered wobbly mother's helper	0		Effect: "Metal Speed", Effect Duration: 41
 2633	up-at-dawn perfumed pat-a-cake pendant	0		Stench Resistance: +5, Adventures: +5
 2634	tumbling red mummy wrapping	0		
@@ -2623,26 +2623,26 @@
 2650	red bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	normal S.T.L.T.	4	good	Last Available: "2007-06"
-2653	immense stale honey-dew	10	decent	Last Available: "2007-06"
+2653	stale immense honey-dew	10	decent	Last Available: "2007-06"
 2654	artisanal teal Xanadian	4	EPIC	Last Available: "2007-06"
 2655	quadruple-anodized improved olive bottle of absinthe	0		Effect: "Frozen Shoulders", Effect Duration: 16, Last Available: "2007-06"
 2656	blurry Oprah's baleful Drowsy Sword	0		Spell Damage: +25, Maximum MP Percent: +50
-2657	jumbo bland escargotsicle	5	decent	Last Available: "2007-06"
-2658	bad distilled bottle of realpagne	5	decent	Last Available: "2007-06"
+2657	bland jumbo escargotsicle	5	decent	Last Available: "2007-06"
+2658	distilled bad bottle of realpagne	5	decent	Last Available: "2007-06"
 2659	Socratic albatross necklace	0		Experience (Mysticality): +1, Single Equip, Last Available: "2007-06"
 2660	mixed wobbly red not-a-pipe	1	crappy	Effect: "Blood-Gorged", Effect Duration: 35, Last Available: "2007-06"
 2661	bad flask of Amontillado	4	decent	Last Available: "2007-06"
-2662	healthy ball mask	0		Maximum HP Percent: +20, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	arcane researcher's Can-Can skirt	0		Experience Percent (Mysticality): +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2662	healthy ball mask	0		Maximum HP Percent: +20, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	arcane researcher's Can-Can skirt	0		Experience Percent (Mysticality): +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	moist teal sensitive poetry journal	0		Effect: "Robocamo", Effect Duration: 69, Last Available: "2007-06"
-2665	triple-warmed tumbling huge bottled inspiration	0		Effect: "Certainty", Effect Duration: 20, Last Available: "2007-06"
+2665	triple-warmed huge tumbling bottled inspiration	0		Effect: "Certainty", Effect Duration: 20, Last Available: "2007-06"
 2666	warmed bellhop bell	0		Effect: "Hella Smooth", Effect Duration: 65, Last Available: "2007-06"
 2667	ionized colloidal twirling spiky collar	0		Effect: "Adventurer's Best Friendship", Effect Duration: 39, Last Available: "2007-06"
 2668	denatured fuchsia spinning can-can-in-a-can	1		Last Available: "2007-06"
 2669	vaporized blurry patent antipsychotics	1		Effect: "Inappropriate Spirit", Effect Duration: 45, Last Available: "2007-06"
-2670	modified upside-down blinking olive Mariner's Friend cough drops	1		Last Available: "2007-06"
+2670	modified olive upside-down blinking Mariner's Friend cough drops	1		Last Available: "2007-06"
 2671	delicious shot of nepenthe schnapps	4	awesome	Last Available: "2007-06"
-2672	skewed cyan library card	0		Last Available: "2007-06"
+2672	cyan skewed library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	corrupted magnetized aerosolized bottle of cat tonic	0		Effect: "Memory of Resilience", Effect Duration: 39, Last Available: "2007-06"
 2675	twisted lime green handful of moss	1		
@@ -2668,13 +2668,13 @@
 2695	drinkable enchanted cup of beer	3	good	Effect: "Butt-Rock Hair", Effect Duration: 35
 2696	ovoid thing	0		
 2697	duct tape	0		
-2698	spinning shaking duct tape wallet	0		
+2698	shaking spinning duct tape wallet	0		
 2699	pulsating auspicious rock-hard duct tape shirt	0		Damage Reduction: 5, Item Drop: +10
 2700	narrow thinker's duct tape fedora of the brute	0		Mysticality: +10, Muscle Percent: +30, Familiar Effect: "1xBarrr, 1xLep, cap 48"
 2701	asbestos-lined duct tape sword of dire peril	0		Weapon Damage: +20, Hot Resistance: +5
 2702	mansplainer's Da Vinci's duct tape dockers	0		Experience (Mysticality): +5, Monster Level: +15, Familiar Effect: "1xPotato, 1xGhuol, cap 48"
 2703	blurry ghostly dance instructor's duct tape buckler	0		Experience Percent (Moxie): +10, Damage Reduction: 12
-2704	blurry teal shrinking powder	0		
+2704	teal blurry shrinking powder	0		
 2705	frightening stiffened smartaleck's blackberry slippers	0		Moxie Percent: +30, Damage Reduction: 1, Spooky Damage: +5, Single Equip
 2706	lard-coated Van der Graaf Rosewater's blackberry moccasins	0		Mysticality Percent: +30, Sleaze Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2707	gray gravedigger's blackberry combat boots of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Spooky Damage: +10, Single Equip
@@ -2683,12 +2683,12 @@
 2710	red cracker	0		Familiar Weight: +15
 2711	non-electrified narrow facepaint	0		Effect: "Ooh, Salty!", Effect Duration: 45
 2712	diffused sheepskin diploma	0		Effect: "Souper Vengeful", Effect Duration: 28
-2713	quantum tumbling squat Black Body&trade; spray	0		Effect: "Took Eleven", Effect Duration: 49
+2713	quantum squat tumbling Black Body&trade; spray	0		Effect: "Took Eleven", Effect Duration: 49
 2714	spinning floorboard cruft	0		
 2715	sausage bomb	0		
 2716	wobbly curative Fonzie's slick battered hubcap	0		Moxie: +10, Experience (Moxie): +1, HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 14
 2717	twirling inspector's occult educational hood ornament	0		Experience: +1, Spell Damage Percent: +25, Item Drop: +15
-2718	blinking spinning spare kidney	0		
+2718	spinning blinking spare kidney	0		
 2719	double-paned hand-carved bokken of the pedagogue of courage	0		Experience: +3, Cold Resistance: +5, Spooky Resistance: +3
 2720	twirling Van der Graaf hand-carved bow of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, MP Regen Min: 5, MP Regen Max: 7
 2721	rosy-cheeked Sinatra's hand-carved staff of James Dean	0		Experience (Moxie): 8, Maximum HP Percent: +30
@@ -2697,23 +2697,23 @@
 2724	adequate miniature bowl of rye sprouts	2	good	
 2725	stale miniature tumbling cob of corn	2	decent	
 2726	tasty blue juniper berries	4	awesome	
-2727	thick spoiled plum	5	crappy	
-2728	thick flavorless pear	5	decent	
+2727	spoiled thick plum	5	crappy	
+2728	flavorless thick pear	5	decent	
 2729	stale peach	3	decent	
 2730	drinkable blurry plum wine	3	good	
 2731	perfectly mixed green shot of pear schnapps	4	EPIC	
 2732	hand-crafted shot of peach schnapps	4	EPIC	
 2733	rotten blurry bunch of square grapes	4	crappy	
 2734	bland wobbly brown sugar cane	3	decent	
-2735	small moldy sandwich of the gods	2	crappy	
+2735	moldy small sandwich of the gods	2	crappy	
 2736	aged Pan-Dimensional Gargle Blaster	4	awesome	
 2737	twisted leopard-print barbell	1	decent	
 2738	pile of smoking rags	0		
 2739	Vulcanized narrow panty raider camouflage	0		Effect: "Mer-kinny Flavor", Effect Duration: 61
 2740	blinking maroon aromatic Herculean cool Staff of the Walk-In Freezer	0		Moxie: +5, Experience (Muscle): +1, Stench Resistance: +1
 2741	hand-crafted high-proof boilermaker	8	EPIC	
-2742	super-sized adequate steel lasagna	5	quest	
-2743	practically non-alcoholic perfectly mixed steel margarita	1	quest	
+2742	adequate super-sized steel lasagna	5	quest	
+2743	perfectly mixed practically non-alcoholic steel margarita	1	quest	
 2744	dried yellow steel-scented air freshener	1		
 2745	dry huge gremlin mutagen	0		Effect: "Barbecue Saucy", Effect Duration: 32
 2746	double-chilled concentrated blurry extra-potent gremlin mutagen	0		Effect: "Mystically Oiled", Effect Duration: 11
@@ -2789,29 +2789,29 @@
 2816	chaotic shellacked Boxers of the empath	0		Damage Reduction: 7, Spell Critical Percent: +10, Familiar Weight: +5, Familiar Effect: "1xVolley, 1xLep"
 2817	lion tamer's fortified Brooch of the blizzard	0		Damage Absorption: +60, Experience (familiar): +2, Cold Spell Damage: +25, Single Equip
 2818	perfumed Jim Carey's Bracelet of the sewer	0		Monster Level: +25, Stench Damage: +25, Stench Resistance: +5, Single Equip
-2819	chaotic Grimacite gasmask of incineration	0		Spell Critical Percent: +10, Hot Spell Damage: +50, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	chaotic Grimacite gasmask of incineration	0		Spell Critical Percent: +10, Hot Spell Damage: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	lime green chilly electrified Grimacite gat	0		Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2008-11"
-2821	shaking lard-coated Grimacite gaiters of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +25, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	shaking lard-coated Grimacite gaiters of incineration	0		Hot Spell Damage: +50, Sleaze Spell Damage: +25, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	executive Lo Pan's Grimacite gauntlets	0		Spell Critical Percent: +30, Meat Drop: +40, Single Equip, Last Available: "2008-11"
 2823	shaking frightening MacGyver's Grimacite go-go boots	0		Maximum MP: +100, Spooky Damage: +5, Single Equip, Last Available: "2008-11"
 2824	Grimacite girdle of the brazier of the glutton	0		Hot Spell Damage: +25, Food Drop: +100, Single Equip, Last Available: "2008-11"
 2825	spinning Annie Oakley's Grimacite gown	0		Critical Hit Percent: +20, Last Available: "2008-11"
 2826	nasty flame-wreathed Staff of the Kitchen Floor of the empath	0		Familiar Weight: +5, Hot Spell Damage: +10, Stench Damage: +5
 2827	gray huge anniversary gift box	0		
-2828	maroon wobbly loaded dice	0		
+2828	wobbly maroon loaded dice	0		
 2829	really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	moldy digital key lime pie	3	crappy	
-2833	enchanted bland small shaking star key lime pie	2	decent	Effect: "Powder Power", Effect Duration: 30
-2834	wool Jack Frost's bottle-rocket crossbow of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +50, Cold Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2833	enchanted small bland shaking star key lime pie	2	decent	Effect: "Powder Power", Effect Duration: 30
+2834	wool Jack Frost's bottle-rocket crossbow of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +50, Cold Resistance: +1, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	indie comic hipster glasses of mayonnaise	0		Sleaze Spell Damage: +50, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	squat wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	tumbling mint-condition magic wand	0		Last Available: "2011-12"
 2838	spinning executive sharpshooter's glowstick	0		Critical Hit Percent: +10, Meat Drop: +40, Last Available: "2007-08"
 2839	chaotic Periodical Paintbrush	0		Spell Critical Percent: +10, Softcore Only
 2840	aged weak bottle of cooking sherry	2	awesome	
-2841	fancy rotten super-sized packet of ketchup	5	crappy	Effect: "Human-Human Hybrid", Effect Duration: 50
+2841	rotten fancy super-sized packet of ketchup	5	crappy	Effect: "Human-Human Hybrid", Effect Duration: 50
 2842	perfectly mixed high-proof accidental cider	10	EPIC	
 2843	thick normal dire fudgesicle	5	good	
 2844	Temple Grandin's wholesome brainy navel ring of navel gazing of doom	0		Mysticality: +5, Maximum HP Percent: +10, Familiar Weight: +7, Spooky Spell Damage: +50, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2821,7 +2821,7 @@
 2848	pulsating Gnomitronic Hyperspatial Demodulizer	0		
 2849	ghostly shrunken navigator head	0		
 2850	hand-crafted weak squat moonberry wine cooler	2	EPIC	
-2851	immense stale enchanted fine aged cheddarwurst	9	decent	Effect: "Staying Frosty", Effect Duration: 25
+2851	stale immense enchanted fine aged cheddarwurst	9	decent	Effect: "Staying Frosty", Effect Duration: 25
 2852	tumbling tumbling branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
 2854	bouquet of swamp roses	0		
@@ -2915,7 +2915,7 @@
 2942	quantum polymerized chocolate filthy lucre	0		Effect: "Sweet and Green", Effect Duration: 66
 2943	polymerized polymerized liquefied Angry Farmer's Wife Candy	0		Effect: "Mucilaginous Muscle", Effect Duration: 47
 2945	MacGyver's strapping party hat	0		Muscle: +5, Maximum MP: +100, Familiar Effect: "4xLep, cap 7"
-2946	gravedigger's Da Vinci's V for Vivala mask	0		Experience (Mysticality): +5, Spooky Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	gravedigger's Da Vinci's V for Vivala mask	0		Experience (Mysticality): +5, Spooky Damage: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
 2948	strong smooth shot of rotgut	5	awesome	
 2949	diffused unsweetened moist jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 32
@@ -2924,14 +2924,14 @@
 2952	frosty glowstick of wisdom	0		Mysticality: +15, Cold Spell Damage: +10, Last Available: "2007-11"
 2953	upside-down charrrm bracelet	0		
 2954	maroon spinning executive tip jar	0		Meat Drop: +40
-2955	flavorless thick yam candy	5	decent	
+2955	thick flavorless yam candy	5	decent	
 2956	squat cocktail napkin	0		
 2957	skewed squat rum barrel charrrm	0		
 2958	half-sized adequate tube of cranberry Go-Goo	2	good	
 2959	bouncing rum barrel charrrm bracelet of incineration	0		Hot Spell Damage: +50
 2960	normal jittery single-serving herbal stuffing	4	good	
 2961	bland packet of tofurkey gravy	3	decent	
-2962	jumbo adequate tofurkey nugget	5	good	
+2962	adequate jumbo tofurkey nugget	5	good	
 2963	spinning rigging shampoo	0		
 2964	huge ball polish	0		
 2965	mizzenmast mop	0		
@@ -2939,7 +2939,7 @@
 2967	tarnished magnetized blinking twirling Swabbie&trade; swab	0		Effect: "Pumped Up", Effect Duration: 67
 2968	moist Oil of Parrrlay	0		Effect: "Bricked-In", Effect Duration: 58
 2969	super-sized normal creamsicle	5	good	
-2970	smooth weak cream stout	2	awesome	
+2970	weak smooth cream stout	2	awesome	
 2971	jittery mansplainer's beefy curmudgel	0		Muscle: +10, Monster Level: +15
 2972	green grumpy man charrrm	0		
 2973	sinister grumpy man charrrm bracelet	0		Spell Damage: +10, Single Equip
@@ -2962,7 +2962,7 @@
 2990	Van der Graaf clingfilm cap of doom	0		Spooky Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xVolley, cap 37"
 2991	jittery tumbling flame-wreathed clingfilm slippers	0		Hot Spell Damage: +10, Single Equip
 2992	blurry clingfilm tangle	0		
-2993	thick delicious wobbly vinegar-soaked lemon slice	5	awesome	
+2993	delicious thick wobbly vinegar-soaked lemon slice	5	awesome	
 2994	alkaline narrow purple true grit	0		Effect: "Towering Strength", Effect Duration: 67
 2995	blinking inspector's family-friendly gravedigger's buoybottoms	0		Spooky Damage: +10, Sleaze Resistance: +1, Item Drop: +15, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	grungy flannel shirt of the bloodbag	0		Maximum HP: +100
@@ -2994,12 +2994,12 @@
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
 3024	twirling stone pyramid	0		
-3025	mediocre special corpse on the beach	3	decent	Effect: "Inebriate Pride", Effect Duration: 10
+3025	special mediocre corpse on the beach	3	decent	Effect: "Inebriate Pride", Effect Duration: 10
 3026	drinkable corpsetini	3	good	
 3027	tolerable corpsedriver	3	good	
 3028	artisanal Corpse Island iced tea	4	EPIC	
-3029	lousy practically non-alcoholic red-headed corpse	1	decent	
-3030	acceptable watered-down purple kamicorpse-ee	2	good	
+3029	practically non-alcoholic lousy red-headed corpse	1	decent	
+3030	watered-down acceptable purple kamicorpse-ee	2	good	
 3031	bad practically non-alcoholic corpsel	1	decent	
 3032	delicious weak narrow blinking fuchsia corpsebite	2	awesome	
 3033	nippy pirate fledges	0		Cold Damage: +10
@@ -3007,13 +3007,13 @@
 3035	flavorless massive tumbling spinning pearl onion	10	decent	
 3036	normal squat sea biscuit	3	good	
 3037	drinkable bottle of rum	4	good	
-3038	weak artisanal olive bottle of black-label rum	2	EPIC	
-3039	green narrow ghostly cannonball	0		
+3038	artisanal weak olive bottle of black-label rum	2	EPIC	
+3039	green ghostly narrow cannonball	0		
 3040	green voodoo skull	0		
 3041	joke scroll	0		
 3042	spinning Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	cyan metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	rotten nanite-infested gingerbread bugbear	3	crappy	Last Available: "2007-12"
 3046	flavorless nanite-infested candy cane	4	decent	Last Available: "2020-09"
 3047	decent gray nanite-infested fruitcake	4	good	Last Available: "2007-12"
@@ -3025,14 +3025,14 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	corrupted candy heart	0		Effect: "Hella Tough", Effect Duration: 43, Last Available: "2007-02"
 3055	ionized oxidized ghostly cymbal syrup	0		Free Pull, Effect: "Liquid Courage", Effect Duration: 42, Last Available: "2007-02"
-3056	gravedigger's metallic foil cat ears	0		Spooky Damage: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	gravedigger's metallic foil cat ears	0		Spooky Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	spinning nanofiber cloth	0		Last Available: "2007-12"
 3058	skewed iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
 3060	bouncing skewed synthetic stuffing	0		Last Available: "2007-12"
 3061	toy hoverpad	0		Last Available: "2007-12"
-3062	green narrow LED block	0		Last Available: "2007-12"
-3063	lime green spinning tumbling shaking gyroscope	0		Last Available: "2010-12"
+3062	narrow green LED block	0		Last Available: "2007-12"
+3063	tumbling spinning lime green shaking gyroscope	0		Last Available: "2010-12"
 3064	stylish cyborg doll	0		Moxie: +25, Last Available: "2007-12"
 3065	buckyball	0		Last Available: "2010-12"
 3066	ghostly occult toy maglev monorail	0		Spell Damage Percent: +25, Single Equip, Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	jittery hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	pulsating kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	narrow narrow teddy borg	0		Last Available: "2007-12"
 3081	Samson's marionette collective	0		Experience (Muscle): +5, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	squat dangerous roboduck-on-a-string of the cougar	0		Moxie: +20, Weapon Damage: +10, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	Annie Oakley's beefy biomechanical crimborg helmet	0		Muscle: +10, Critical Hit Percent: +20, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	Annie Oakley's beefy biomechanical crimborg helmet	0		Muscle: +10, Critical Hit Percent: +20, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	Jack Frost's friendly C.B.F.G.	0		Familiar Weight: +3, Cold Spell Damage: +50, Last Available: "2007-12"
-3090	Usain Bolt's biomechanical crimborg leg armor of extreme caution	0		Monster Level: -25, Initiative: +80, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	Usain Bolt's biomechanical crimborg leg armor of extreme caution	0		Monster Level: -25, Initiative: +80, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	polymerized vitachoconutriment capsule	0		Effect: "Coming Up Roses", Effect Duration: 51, Last Available: "2007-12"
 3092	supercool handmade hobby horse	0		Moxie Percent: +20, Last Available: "2007-12"
 3093	forbidden ball-in-a-cup	0		Spell Damage Percent: +50, Last Available: "2007-12"
@@ -3081,12 +3081,12 @@
 3109	Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
 3111	Miniborg laser	0		Last Available: "2007-12"
-3112	blurry mirror Miniborg beeper	0		Last Available: "2007-12"
+3112	mirror blurry Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	narrow skewed old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
-3116	lime green narrow Hodgman	0		
-3117	ghostly Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3116	narrow lime green Hodgman	0		
+3117	ghostly Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	red divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3113,7 +3113,7 @@
 3141	perfumed panhandle panhandling hat	0		Stench Resistance: +5, Familiar Effect: "1xLep, cap 37"
 3142	careful cup of infinite pencils	0		Monster Level: -10
 3143	pulsating stanky dance instructor's Hodgman's disgusting technicolor overcoat	0		Experience Percent (Moxie): +10, Stench Spell Damage: +25
-3144	pulsating green a torn paper strip	0		
+3144	green pulsating a torn paper strip	0		
 3145	upside-down gray El Vibrato translator	0		
 3146	El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
@@ -3138,18 +3138,18 @@
 3166	repaired El Vibrato drone	0		
 3167	ghostly augmented El Vibrato drone	0		
 3168	ionized liquefied huge seal eyeball	0		Effect: "Toast Tea", Effect Duration: 64
-3169	small flavorless turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
+3169	flavorless small turtle soup	2	decent	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	wobbly nauseating reagent	0		
 3172	jittery scorching evil paper umbrella	0		Hot Damage: +25
 3173	diffused galvanized jittery yellow evil vihuela	0		Effect: "Tennis Elbow-wow", Effect Duration: 36
 3174	diet bland spinning spinning evil boring spaghetti	1	decent	
-3175	enchanted half-sized flavorless evil noodles	2	decent	Effect: "Material Witness", Effect Duration: 35
-3176	snack-sized normal mirror evil noodles	2	good	
+3175	half-sized enchanted flavorless evil noodles	2	decent	Effect: "Material Witness", Effect Duration: 35
+3176	normal snack-sized mirror evil noodles	2	good	
 3177	enchanted normal evil painful penne pasta	3	good	Effect: "Ooh, Bitter!", Effect Duration: 25
 3178	bland small 3vi1 pr0n m4nic0tti	2	decent	
 3179	snack-sized stale ghostly evil ravioli della hippy	2	decent	
-3180	immense tasty bouncing evil noodles	7	awesome	
+3180	tasty immense bouncing evil noodles	7	awesome	
 3181	ionized non-adjusted evil potion of potency	0		Effect: "Feroci Tea", Effect Duration: 43
 3182	galvanized triple-boiled green evil libation of liveliness	0		Effect: "Happy Trails", Effect Duration: 27
 3183	wet warmed tumbling evil tomato juice of powerful power	0		Effect: "Yet tea", Effect Duration: 53
@@ -3157,10 +3157,10 @@
 3185	double-aerosolized polarized evil ointment of the occult	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 34
 3186	extra-cold-filtered triple-pressed huge evil serum of sarcasm	0		Effect: "Steroid Boost", Effect Duration: 26
 3187	oxidized lime green evil philter of phorce	0		Effect: "Polar Express", Effect Duration: 51
-3188	perfectly mixed high-proof an evil sump'm sump'm	7	EPIC	
+3188	high-proof perfectly mixed an evil sump'm sump'm	7	EPIC	
 3189	fancy perfectly mixed mirror evil ducha de oro	3	EPIC	Effect: "Oily Flavor", Effect Duration: 15
-3190	special perfectly mixed evil horizontal tango	4	EPIC	Effect: "Sugar High", Effect Duration: 5
-3191	irresponsibly strong mediocre mirror evil roll in the hay	9	decent	
+3190	perfectly mixed special evil horizontal tango	4	EPIC	Effect: "Sugar High", Effect Duration: 5
+3191	mediocre irresponsibly strong mirror evil roll in the hay	9	decent	
 3192	ghostly naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	upside-down origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3194,10 +3194,10 @@
 3222	chilly banded gatorskin umbrella	0		Damage Absorption: +100, Cold Damage: +5
 3223	sewer nuggets	0		
 3224	spinning sewer wad	0		
-3225	weak hand-crafted bottle of sewage schnapps	2	EPIC	
+3225	hand-crafted weak bottle of sewage schnapps	2	EPIC	
 3226	artisanal practically non-alcoholic bottle of Ooze-O	1	EPIC	
 3227	decent C.H.U.M. chum	4	good	
-3228	decent super-sized bouncing unfortunate dumplings	5	good	
+3228	super-sized decent bouncing unfortunate dumplings	5	good	
 3229	mirror decaying goldfish liver	0		
 3230	irradiated oil of oiliness	0		Effect: "Material Witness", Effect Duration: 29
 3231	perfumed tattered paper crown	0		Stench Resistance: +5, Familiar Effect: "1xSombrero, cap 15"
@@ -3213,7 +3213,7 @@
 3241	bouncing Travels with Jerry	0		Skill: "Mudbath"
 3242	blurry Let Me Be!	0		Skill: "Raise Backup Dancer"
 3243	twirling Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
-3244	ghostly squat Summer Nights	0		Skill: "Grease Lightning"
+3244	squat ghostly Summer Nights	0		Skill: "Grease Lightning"
 3245	Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	jittery Jack Frost's Ol' Scratch's ol' britches of the detective	0		Cold Spell Damage: +50, Item Drop: +20, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
 3247	scorching Temple Grandin's Ol' Scratch's stovepipe hat	0		Familiar Weight: +7, Hot Damage: +25, Class: "Sauceror", Familiar Effect: "hot atk"
@@ -3232,17 +3232,17 @@
 3260	Chester's moustache of the wise owl of the businessman of the glutton	0		Mysticality: +20, Meat Drop: +50, Food Drop: +100, Class: "Disco Bandit", Single Equip
 3261	veiny personal trainer's Chester's bag of candy	0		Experience Percent (Muscle): +10, Maximum HP: +10, Class: "Disco Bandit"
 3262	blue quilted Chester's cutoffs of Gandalf	0		Damage Absorption: +40, Spell Critical Percent: +20, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	bouncing bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
 3267	bag of Laughing Willow saplings	0		
 3268	deionized handful of Crotchety Pine needles	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 21
 3269	Vulcanized anodized ionized twirling lump of Saccharine Maple sap	0		Effect: "Chunky", Effect Duration: 13
-3270	irradiated pulsating cyan huge handful of Laughing Willow bark	0		Effect: "Salsa Satanica", Effect Duration: 13
-3271	crotchety pants of the sweet-tooth	0		Candy Drop: +100, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3270	irradiated cyan pulsating huge handful of Laughing Willow bark	0		Effect: "Salsa Satanica", Effect Duration: 13
+3271	crotchety pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	cool Saccharine Maple pendant	0		Moxie: +5, Conditional Skill (Equipped): "Spray Sap"
-3273	experienced willowy bonnet	0		Experience: +2, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	experienced willowy bonnet	0		Experience: +2, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3291,7 +3291,7 @@
 3319	cyan prompt Mr. Joe's bangles	0		Adventures: +3, Single Equip
 3320	huge rosewater-soaked frayed rope belt	0		Stench Resistance: +3, Single Equip
 3321	packet of mayfly bait	0		Last Available: "2008-05"
-3322	ghostly red Jeselnik's mayfly bait necklace of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	ghostly red Jeselnik's mayfly bait necklace of Flo-Jo	0		Sleaze Damage: +25, Initiative: +100, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	perfectly mixed jar of fermented pickle juice	4	super EPIC	
@@ -3312,7 +3312,7 @@
 3340	jittery very caltrop	0		
 3341	twirling twirling The Six-Pack of Pain	0		
 3342	hobo monkey	0		
-3343	olive narrow bindle	0		Familiar Weight: +5
+3343	narrow olive bindle	0		Familiar Weight: +5
 3344	bed of coals	0		
 3345	air mattress	0		
 3346	filth-encrusted futon	0		
@@ -3326,7 +3326,7 @@
 3354	normal banana-frosted king cake	4	good	Last Available: "2008-08"
 3355	narrow sage brown plastic baby	0		Mysticality Percent: +10, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
-3357	blinking blue narrow shimmering moth	0		Last Available: "2008-06"
+3357	narrow blinking blue shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	jittery scrumptious ice ant	0		Last Available: "2008-06"
 3360	stinkbug	0		Last Available: "2008-06"
@@ -3337,16 +3337,16 @@
 3365	nitrogenated deionized Climate Colada	0		Effect: "Chlorophyll Flavor", Effect Duration: 59, Last Available: "2008-06"
 3366	non-altered non-dry upside-down digital underground potion	0		Effect: "5 Pounds Lighter", Effect Duration: 22, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	compressed jittery narrow glimmering roc feather	1	crappy	Last Available: "2008-06"
-3369	powdered upside-down green glimmering phoenix feather	1		Last Available: "2008-06"
+3368	compressed narrow jittery glimmering roc feather	1	crappy	Last Available: "2008-06"
+3369	powdered green upside-down glimmering phoenix feather	1		Last Available: "2008-06"
 3370	altered glimmering penguin feather	1		Last Available: "2008-06"
 3371	pickled blue glimmering buzzard feather	1		Last Available: "2008-06"
 3372	diluted gray glimmering raven feather	1		Last Available: "2008-06"
-3373	denatured mirror skewed glimmering great tit feather	1		Last Available: "2008-06"
+3373	denatured skewed mirror glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	skewed The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	tumbling Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
-3377	huge blinking Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
+3377	blinking huge Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	Chorale of Companionship	0		Skill: "Chorale of Companionship"
 3379	Prelude of Precision	0		Skill: "Prelude of Precision"
 3380	jittery avaricious nasty Ol' Scratch's infernal pitchfork	0		Stench Damage: +5, Meat Drop: +30
@@ -3386,7 +3386,7 @@
 3414	wobbly Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	tumbling hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	unsweetened deionized squat cyan sterno-flavored Hob-O	0		Effect: "Using Protection", Effect Duration: 42
 3423	ionized polarized upside-down blue frostbite-flavored Hob-O	0		Effect: "Ooh, Bitter!", Effect Duration: 30
 3424	moist corrupted fry-oil-flavored Hob-O	0		Effect: "I See Everything Thrice!", Effect Duration: 56
@@ -3423,14 +3423,14 @@
 3456	trusty torch of Flo-Jo	0		Initiative: +100, Last Available: "2011-12"
 3457	ghostly fortified Junior Adventurer's merit badge	0		Damage Absorption: +60
 3458	pressed boiled STYX deodorant body spray	0		Effect: "Impregnably Delicious", Effect Duration: 34
-3459	mediocre weak fancy mirror white-label gin	2	decent	Effect: "Sausage Festive", Effect Duration: 5
-3460	stale snack-sized skewed tin rations	2	decent	
+3459	fancy weak mediocre mirror white-label gin	2	decent	Effect: "Sausage Festive", Effect Duration: 5
+3460	snack-sized stale skewed tin rations	2	decent	
 3461	tumbling haiku challenge map	0		
 3462	terrible poem	0		
 3463	tolerable ghostly bottle of sake	3	good	
 3464	supercool round pebble	0		Moxie Percent: +20
 3465	special spoiled Bash-&#332;s cereal	3	crappy	Effect: "Amorous", Effect Duration: 35, Wiki Name: "Bash-Os cereal"
-3466	upside-down wobbly smelly toasty brawny haiku katana	0		Muscle Percent: +20, Hot Damage: +5, Stench Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	upside-down wobbly smelly toasty brawny haiku katana	0		Muscle Percent: +20, Hot Damage: +5, Stench Spell Damage: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	plastic baby of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2008-12"
 3469	bland blueberry-frosted king cake	3	decent	Last Available: "2008-12"
@@ -3445,7 +3445,7 @@
 3478	Vulcanized anodized squat peach lozenge	0		Effect: "Abyssal Sweat", Effect Duration: 34
 3479	olive balloon shield	0		Damage Reduction: 3
 3480	upside-down spot	0		
-3481	pulsating cyan uniclops egg	0		Free Pull, Last Available: "2009-10"
+3481	cyan pulsating uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	bouncing passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
 3484	eye 'n' horn shampoo	0		Familiar Weight: +5
@@ -3453,8 +3453,8 @@
 3486	pulsating dull fish scale	0		
 3487	huge rough fish scale	0		
 3488	spinning pristine fish scale	0		
-3489	jumbo bland beefy fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
-3490	jumbo decent mirror glistening fish meat	5	good	Effect: "Fishy", Effect Duration: 5
+3489	bland jumbo beefy fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
+3490	decent jumbo mirror glistening fish meat	5	good	Effect: "Fishy", Effect Duration: 5
 3491	bland huge jittery slick fish meat	8	decent	Effect: "Fishy", Effect Duration: 5
 3492	narrow coward's ruddy fish scimitar	0		Maximum HP Percent: +40, Monster Level: -20
 3493	banded fish stick of the early riser	0		Damage Absorption: +100, Adventures: +7
@@ -3462,16 +3462,16 @@
 3495	colloidal narrow sea salt crystal	0		Effect: "Destructive Resolve", Effect Duration: 55
 3496	aerosolized unsweetened gray bazookafish bubble gum	0		Effect: "Spooky Flavor", Effect Duration: 67
 3497	smooth bottle of Pete's Sake	3	awesome	
-3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	mirror witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	mirror witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	adequate green canap&eacute;s	3	good	
 3502	vaporized thermos of brew	1	decent	Last Available: "2011-12"
 3503	drinkable watered-down bouncing glass of brandy	2	good	Last Available: "2011-12"
 3504	skewed French slippers	0		
 3505	tumbling chilly LWA ring	0		Cold Damage: +5
-3506	twirling teal LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3506	teal twirling LARP membership card	0		Last Available: "2008-10"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	up-at-dawn scratch 'n' sniff sword	0		Adventures: +5, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	censurious personal trainer's depleted Grimacite gravy boat	0		Experience Percent (Muscle): +10, Sleaze Resistance: +3, Last Available: "2011-12"
 3544	bouncing boxer's depleted Grimacite weightlifting belt of extreme caution	0		Muscle Percent: +10, Monster Level: -25, Single Equip, Last Available: "2011-12"
 3545	huge wobbly lion tamer's dance instructor's depleted Grimacite grappling hook	0		Experience Percent (Moxie): +10, Experience (familiar): +2, Single Equip, Last Available: "2011-12"
-3546	wobbly extremely unsafe stylish depleted Grimacite ninja mask	0		Moxie: +25, Weapon Damage Percent: +100, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	narrow fireproof nippy depleted Grimacite shinguards	0		Cold Damage: +10, Hot Resistance: +3, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	wobbly extremely unsafe stylish depleted Grimacite ninja mask	0		Moxie: +25, Weapon Damage Percent: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	narrow fireproof nippy depleted Grimacite shinguards	0		Cold Damage: +10, Hot Resistance: +3, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	blue depleted Grimacite astrolabe of dire peril of the blizzard	0		Weapon Damage: +20, Cold Spell Damage: +25, Single Equip, Last Available: "2011-12"
 3549	bouncing KoL Con Cinco Pi&ntilde;ata Bat of James Dean of the sweet-tooth	0		Experience (Moxie): +3, Candy Drop: +100, Softcore Only, Last Available: "2008-09"
 3550	narrow blinking green family-friendly propeller beanie	0		Sleaze Resistance: +1, Familiar Effect: "atk, cap 7"
@@ -3521,9 +3521,9 @@
 3554	glob of slime	0		
 3555	stale sea carrot	4	decent	
 3556	bite-sized tasty sea cucumber	1	awesome	
-3557	bite-sized flavorless sea avocado	1	decent	
+3557	flavorless bite-sized sea avocado	1	decent	
 3558	bland blurry sea lychee	3	decent	
-3559	toothsome low-calorie sea tangelo	1	awesome	
+3559	low-calorie toothsome sea tangelo	1	awesome	
 3560	stale sea honeydew	3	decent	
 3561	flattened pressurized potion of puissance	0		Effect: "Human-Fish Hybrid", Effect Duration: 31
 3562	triple-modified concentrated mirror pressurized potion of perspicacity	0		Effect: "Hammertime", Effect Duration: 43
@@ -3546,7 +3546,7 @@
 3579	green ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
-3582	normal super-sized pulsating rice	5	good	
+3582	super-sized normal pulsating rice	5	good	
 3584	decent thick irradiated candy cane	5	good	Last Available: "2008-12"
 3585	toothsome gingerbread mutant bugbear	3	awesome	Last Available: "2008-12"
 3586	drinkable shaking oozenog	3	good	Last Available: "2008-12"
@@ -3581,15 +3581,15 @@
 3615	tumbling rigid carapace	0		Last Available: "2008-12"
 3616	blue pulsing flesh	0		Last Available: "2008-12"
 3617	moist chilled huge unstable DNA	0		Effect: "The Halls of Moxiousness", Effect Duration: 53, Last Available: "2008-12"
-3618	squat The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	squat The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	jittery skewed gnashing teeth	0		Last Available: "2008-12"
 3623	fuchsia chitinous pod	0		Last Available: "2008-12"
 3624	family-friendly parasitic claw	0		Sleaze Resistance: +1, Last Available: "2008-12"
-3625	dance instructor's parasitic tentacles	0		Experience Percent (Moxie): +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	parasitic headgnawer of the glutton	0		Food Drop: +100, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	dance instructor's parasitic tentacles	0		Experience Percent (Moxie): +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	parasitic headgnawer of the glutton	0		Food Drop: +100, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	stylish parasitic strangleworm	0		Moxie: +25, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,25 +3598,25 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	spinning lime green executive elven socks of the pedagogue	0		Experience: +3, Meat Drop: +40, Last Available: "2008-12"
 3634	flame-retardant rosy-cheeked elven gloves	0		Maximum HP Percent: +30, Hot Resistance: +1, Last Available: "2008-12"
-3635	toasty Da Vinci's festive holiday hat	0		Experience (Mysticality): +5, Hot Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	toasty Da Vinci's festive holiday hat	0		Experience (Mysticality): +5, Hot Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	blinking stanky patent shoes of chilblains	0		Cold Damage: +25, Stench Spell Damage: +25, Last Available: "2008-12"
 3637	hale gray bow tie of James Dean	0		Experience (Moxie): +3, Maximum HP: +20, Last Available: "2008-12"
 3638	brawny penguin thesaurus of the detective	0		Muscle Percent: +20, Item Drop: +20, Last Available: "2008-12"
-3639	gigantic rotten squat blob-shaped Crimbo cookie	8	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	rotten gigantic squat blob-shaped Crimbo cookie	8	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
-3642	gray skewed dragonfish caviar	0		
+3642	skewed gray dragonfish caviar	0		
 3643	tumbling pufferfish spine	0		
 3644	Da Vinci's depleted Grimacite kneecapping stick	0		Experience (Mysticality): +5, Last Available: "2007-06"
 3645	mediocre fancy canteen of wine	4	decent	Effect: "Old Time Hydration", Effect Duration: 40, Last Available: "2008-12"
-3646	fancy yummy elven <i>limbos</i> gingerbread	3	awesome	Effect: "Riboflavin'", Effect Duration: 35, Last Available: "2008-12"
+3646	yummy fancy elven <i>limbos</i> gingerbread	3	awesome	Effect: "Riboflavin'", Effect Duration: 35, Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	half-sized moldy toast with jam	2	crappy	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	drinkable elven moonshine	4	good	Last Available: "2008-12"
-3653	bland knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	bland knuckle sandwich	3	decent	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	Jeselnik's lion tamer's psycho sweater	0		Experience (familiar): +2, Sleaze Damage: +25, Last Available: "2008-12"
 3655	spinning fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of the cougar	0		Moxie: +20, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	rock-hard plastic strand of DNA	0		Damage Reduction: 5, Last Available: "2008-12"
 3660	red pulsating mansplainer's plastic chunk of depleted Grimacite	0		Monster Level: +15, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	maroon tumbling slick Putty mitre	0		Moxie: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	dance instructor's Putty leotard of the sewer	0		Experience Percent (Moxie): +10, Stench Damage: +25, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	maroon tumbling slick Putty mitre	0		Moxie: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	dance instructor's Putty leotard of the sewer	0		Experience Percent (Moxie): +10, Stench Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	bouncing vibrating Putty ball	0		Maximum MP Percent: +10, Softcore Only, Last Available: "2009-01"
 3665	blinking mirror shaking Putty sheet	0		Last Available: "2009-01"
 3666	fireproof Putty snake of the ox of extreme caution	0		Muscle: +20, Monster Level: -25, Hot Resistance: +3, Softcore Only, Last Available: "2009-01"
@@ -3647,14 +3647,14 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	shaking map to the Marinara Trench	0		
-3684	flavorless miniature tempura carrot	2	decent	
+3684	miniature flavorless tempura carrot	2	decent	
 3685	toothsome skewed tempura cucumber	3	awesome	
 3686	decent tempura avocado	4	good	
 3687	spoiled enchanted sea broccoli	4	crappy	Effect: "Turtle Power", Effect Duration: 30
 3688	moldy sea cauliflower	3	crappy	
 3689	moldy tempura broccoli	3	crappy	
 3690	delicious tempura cauliflower	4	awesome	
-3691	normal miniature sea blueberry	2	good	
+3691	miniature normal sea blueberry	2	good	
 3692	decent huge sea persimmon	3	good	
 3693	aerosolized wobbly pressurized potion of perception	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 17
 3694	modified ghostly huge pressurized potion of proficiency	0		Effect: "Salad Days", Effect Duration: 61
@@ -3664,7 +3664,7 @@
 3698	velcro ore	0		
 3699	jittery teflon ore	0		
 3700	vinyl ore	0		
-3701	green skewed twirling map to Anemone Mine	0		
+3701	twirling skewed green map to Anemone Mine	0		
 3702	wobbly marine aquamarine	0		
 3703	valve wheel	0		
 3704	purple waterlogged bootstraps	0		
@@ -3685,11 +3685,11 @@
 3719	squat lantern	0		
 3720	decaying pole	0		
 3721	bouncing decaying paddle	0		
-3722	pulsating purple tarnished ring	0		
+3722	purple pulsating tarnished ring	0		
 3723	cyan tarnished rod	0		
 3724	wobbly brittle plastic handle	0		
 3725	jittery skewed foggy glass globe	0		
-3726	spinning blue possessed tomato	0		
+3726	blue spinning possessed tomato	0		
 3727	ghostly Nardz energy beverage	0		
 3728	tumbling pile of coins	0		
 3729	hand grenegg	0		
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	skewed zippy gravedigger's handwarmer	0		Spooky Damage: +10, Initiative: +20, Single Equip
 3737	skewed steel-toed stylish lighter	0		Moxie: +25, Damage Reduction: 9
-3738	moldy snack-sized ghostly packet of beer nuts	2	crappy	
+3738	snack-sized moldy ghostly packet of beer nuts	2	crappy	
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
@@ -3711,22 +3711,22 @@
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
-3749	altered ionized dry wobbly spinning red concoction of clumsiness	0		Effect: "damage.enh", Effect Duration: 57
+3749	altered ionized dry red spinning wobbly concoction of clumsiness	0		Effect: "damage.enh", Effect Duration: 57
 3750	stanky vampire pearl earring	0		Stench Spell Damage: +25, Single Equip
 3751	stale chocolate chip brownies	3	decent	
-3753	pulsating Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	pulsating Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	moist galvanized altered bouncing love song of vague ambiguity	0		Effect: "Improprie Tea", Effect Duration: 54, Last Available: "2009-02"
 3755	super-activated denatured narrow love song of smoldering passion	0		Effect: "Muddled", Effect Duration: 14, Last Available: "2009-02"
 3756	flattened boiled love song of icy revenge	0		Effect: "Loyal Tea", Effect Duration: 14, Last Available: "2009-02"
-3757	oxidized skewed jittery narrow love song of sugary cuteness	0		Effect: "Vital", Effect Duration: 29, Last Available: "2009-02"
-3758	dry squat green love song of disturbing obsession	0		Effect: "Coming Up Roses", Effect Duration: 59, Last Available: "2009-02"
+3757	oxidized jittery skewed narrow love song of sugary cuteness	0		Effect: "Vital", Effect Duration: 29, Last Available: "2009-02"
+3758	dry green squat love song of disturbing obsession	0		Effect: "Coming Up Roses", Effect Duration: 59, Last Available: "2009-02"
 3759	triple-ionized polymerized love song of naughty innuendo	0		Effect: "Morninja", Effect Duration: 21, Last Available: "2009-02"
-3760	enhanced blurry bouncing breath mint	0		Effect: "Musky", Effect Duration: 14
+3760	enhanced bouncing blurry breath mint	0		Effect: "Musky", Effect Duration: 14
 3761	wobbly vampire pearl ring of the blizzard	0		Cold Spell Damage: +25, Single Equip
 3762	flame-wreathed vampire pearl necklace	0		Hot Spell Damage: +10, Single Equip
 3763	hand-crafted slug of vodka	3	EPIC	
 3764	tolerable slug of rum	3	good	
-3765	mediocre distilled slug of shochu	5	decent	
+3765	distilled mediocre slug of shochu	5	decent	
 3766	hand-crafted wobbly teal screwdiver	4	EPIC	
 3767	delicious weak upside-down dew yoana lei	2	awesome	
 3768	lousy lychee chuhai	3	decent	
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	narrow Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	pulsating shaking lime green crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	shaking pulsating lime green crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	squat gravedigger's nippy Mer-kin roundshield of doom	0		Cold Damage: +10, Spooky Damage: +10, Spooky Spell Damage: +50, Damage Reduction: 14
 3804	smelly Mer-kin breastplate of the brute	0		Muscle Percent: +30, Stench Spell Damage: +10
 3805	squat bouncing auspicious smooth Mer-kin sneakmask	0		Moxie: +15, Item Drop: +10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,9 +3768,9 @@
 3813	horrifying plastic baby	0		Spooky Damage: +25, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	spoiled diet sea radish	1	crappy	
+3817	diet spoiled sea radish	1	crappy	
 3818	MacGyver's clever halibut of the brute	0		Muscle Percent: +30, Maximum MP: 120
-3819	gray blinking eel sauce	0		
+3819	blinking gray eel sauce	0		
 3820	therapeutic water-polo mitt	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
 3821	boiled pressed extra-Vulcanized syringe	0		Effect: "Ghost Finger", Effect Duration: 60
 3822	wand	0		Familiar Effect: "fishy spells"
@@ -3782,12 +3782,12 @@
 3828	Grandma's Map	0		
 3829	bland lime green jittery tempura radish	4	decent	
 3830	stylish water-polo cap	0		Moxie: +25, Familiar Effect: "1xVolley, 1xBarrr"
-3831	practically non-alcoholic mediocre skewed Typical Tavern swill	1	decent	
-3832	practically non-alcoholic smooth tropical swill	1	awesome	
+3831	mediocre practically non-alcoholic skewed Typical Tavern swill	1	decent	
+3832	smooth practically non-alcoholic tropical swill	1	awesome	
 3833	perfectly mixed cyan fruity girl swill	3	EPIC	
 3834	mediocre blended swill	3	decent	
 3835	costume wardrobe	0		Softcore Only
-3836	smelly electrified dangerous Elvish sunglasses of the early riser	0		Weapon Damage: +10, Stench Spell Damage: +10, Adventures: +7, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	smelly electrified dangerous Elvish sunglasses of the early riser	0		Weapon Damage: +10, Stench Spell Damage: +10, Adventures: +7, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	beefcake's anniversary safety glass vest	0		Muscle: +25
 3838	jittery Jack Frost's anniversary burlap belt	0		Cold Spell Damage: +50
 3839	Herculean anniversary balsa wood socks	0		Experience (Muscle): +1
@@ -3862,7 +3862,7 @@
 3910	upside-down figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	watered-down enchanted drinkable blended swill with a fly in it	2	good	Effect: "Wet Rub", Effect Duration: 45
+3913	enchanted drinkable watered-down blended swill with a fly in it	2	good	Effect: "Wet Rub", Effect Duration: 45
 3914	turtle wax	0		
 3915	padded turtle wax shield	0		Damage Absorption: +20, Damage Reduction: 2
 3916	chaotic turtle wax helmet	0		Spell Critical Percent: +10, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3913,7 +3913,7 @@
 3961	yellow coward's chaotic opera glasses	0		Spell Critical Percent: +10, Monster Level: -20
 3962	bouncing designer handbag	0		
 3963	mirror Clan pool table	0		Free Pull, Last Available: "2009-05"
-3964	skewed olive cell phone	0		Familiar Weight: +10
+3964	olive skewed cell phone	0		Familiar Weight: +10
 3965	ionized tumbling cube of billiard chalk	0		Effect: "Pasta Oneness", Effect Duration: 24
 3966	wobbly inspector's personal trainer's hot-ass club of the bloodbag	0		Experience Percent (Muscle): +10, Maximum HP: +100, Item Drop: +15, Class: "Seal Clubber"
 3967	Oprah's Rosewater's frigid-ass club of the early riser	0		Mysticality Percent: +30, Maximum MP Percent: +50, Adventures: +7, Class: "Seal Clubber"
@@ -3937,7 +3937,7 @@
 3985	soup turtle	0		
 3986	samurai turtle	0		
 3987	shaking chaotic ruddy samurai turtle helmet	0		Maximum HP Percent: +40, Spell Critical Percent: +10, Familiar Effect: "atk, 1xPotato, cap 6"
-3988	squat blurry turtle shell	0		
+3988	blurry squat turtle shell	0		
 3989	turtle shell powder	0		
 3990	Tesla turtle shell helmet	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, cap 8"
 3991	slime-soaked hypophysis	0		Skill: "Slimy Sinews"
@@ -3959,7 +3959,7 @@
 4007	memory of a C	0		Last Available: "2009-06"
 4008	cyan memory of an A	0		Last Available: "2009-06"
 4009	tumbling memory of a G	0		Last Available: "2009-06"
-4010	jittery blinking memory of a T	0		Last Available: "2009-06"
+4010	blinking jittery memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
 4012	tumbling memory of a CG base pair	0		Last Available: "2009-06"
 4013	memory of a CT base pair	0		Last Available: "2009-06"
@@ -3968,7 +3968,7 @@
 4016	memory of a GT base pair	0		Last Available: "2009-06"
 4017	upside-down squirming Slime larva	0		
 4018	gravedigger's greaves	0		Spooky Damage: +10, Familiar Effect: "1xBarrr, cap 37"
-4019	upside-down blue upside-down undissolvable contact lenses	0		
+4019	upside-down upside-down blue undissolvable contact lenses	0		
 4020	Jeselnik's veiny piece of rebar	0		Maximum HP: +10, Sleaze Damage: +25
 4021	yellow ghostly ruddy padded shovel of incineration	0		Damage Absorption: +20, Maximum HP Percent: +40, Hot Spell Damage: +50
 4022	bouncing savvy necklace of the scaredy-cat of horror	0		Mysticality Percent: +20, Monster Level: -15, Spooky Spell Damage: +25
@@ -3986,24 +3986,24 @@
 4034	memory of an iron key	0		Last Available: "2009-06"
 4035	lime green memory of a crystal	0		Last Available: "2009-06"
 4036	blue caustic slime nodule	0		
-4037	half-sized yummy bouncing slimy sweetbreads	2	awesome	
+4037	yummy half-sized bouncing slimy sweetbreads	2	awesome	
 4038	artisanal slimy fermented bile bladder	3	EPIC	
 4039	compressed slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	cool pig-iron helm of the empath	0		Moxie: +5, Familiar Weight: +5, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	greedy Rosewater's pig-iron shinguards	0		Mysticality Percent: +30, Meat Drop: +20, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	cool pig-iron helm of the empath	0		Moxie: +5, Familiar Weight: +5, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	greedy Rosewater's pig-iron shinguards	0		Mysticality Percent: +30, Meat Drop: +20, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	rosewater-soaked foul-smelling pig-iron bracers	0		Stench Damage: +10, Stench Resistance: +3, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	purple wumpus-hair bolo	0		Last Available: "2009-06"
 4046	blue narrow wumpus-hair net	0		Last Available: "2009-06"
 4047	Jeselnik's wumpus-hair whip	0		Sleaze Damage: +25, Last Available: "2009-06"
-4048	huge Usain Bolt's curative Sinatra's wumpus-hair wig	0		Experience (Moxie): +5, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	greedy MacGyver's clever wumpus-hair loincloth	0		Maximum MP: 120, Meat Drop: +20, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	huge Usain Bolt's curative Sinatra's wumpus-hair wig	0		Experience (Moxie): +5, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	greedy MacGyver's clever wumpus-hair loincloth	0		Maximum MP: 120, Meat Drop: +20, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	Temple Grandin's wumpus-hair sweater of bravery	0		Familiar Weight: +7, Spooky Resistance: +5, Last Available: "2009-06"
 4051	sinister ring of teleportation	0		Spell Damage: +10, Single Equip
 4052	cyan glass of baboon milk	1	good	Last Available: "2009-06"
 4053	banana milkshake	1	crappy	Last Available: "2009-06"
-4054	tolerable spirit-forward fancy White Hyborian	5	good	Effect: "Become Intensely interested", Effect Duration: 25, Last Available: "2009-06"
+4054	spirit-forward tolerable fancy White Hyborian	5	good	Effect: "Become Intensely interested", Effect Duration: 25, Last Available: "2009-06"
 4055	fuchsia flame-retardant goblin hunting spear	0		Hot Resistance: +1, Last Available: "2009-06"
 4056	perfumed goblin autoblowgun of Gandalf	0		Spell Critical Percent: +20, Stench Resistance: +5, Last Available: "2009-06"
 4057	tribal beads of incineration	0		Hot Spell Damage: +50, Last Available: "2009-06"
@@ -4015,7 +4015,7 @@
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
-4066	twirling blue Ruby Rod	0		Last Available: "2009-06"
+4066	blue twirling Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
 4069	green essence of	0		Last Available: "2009-06"
@@ -4023,7 +4023,7 @@
 4071	essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
-4074	shaking shaking yellow multi-pass	0		Last Available: "2009-06"
+4074	shaking yellow shaking multi-pass	0		Last Available: "2009-06"
 4075	foul-smelling villainous scythe of doom	0		Stench Damage: +10, Spooky Spell Damage: +50, Slime Hates It: +2
 4076	nippy veiny baneful bandolier	0		Maximum HP: +10, Cold Damage: +10, Slime Hates It: +1
 4077	steel-toed banded diabolical crossbow	0		Damage Absorption: +100, Damage Reduction: 9, Slime Hates It: +1
@@ -4034,7 +4034,7 @@
 4082	energetic pernicious cudgel of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Slime Hates It: +1
 4083	big flavorless cupcake-in-a-cup	5	decent	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	small rotten protein paste	2	crappy	Last Available: "2009-06"
+4085	rotten small protein paste	2	crappy	Last Available: "2009-06"
 4086	curative experienced cyber-mattock	0		Experience: +2, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2009-06"
 4087	jittery facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4085,13 +4085,13 @@
 4133	flattened tempura air	0		Effect: "Afternoon Insight", Effect Duration: 67
 4134	super-Vulcanized nitrogenated squat pressurized potion of pneumaticity	0		Effect: "Object Detection", Effect Duration: 63
 4135	cyan moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	Da Vinci's experienced slick strapping Bag o' Tricks	0		Muscle: +5, Moxie: +10, Experience: +2, Experience (Mysticality): +5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	Da Vinci's experienced slick strapping Bag o' Tricks	0		Muscle: +5, Moxie: +10, Experience: +2, Experience (Mysticality): +5, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	slime stack	0		
 4138	olive a rumpled paper strip	0		
 4139	a creased paper strip	0		
 4140	blinking a folded paper strip	0		
 4141	a crinkled paper strip	0		
-4142	purple huge a crumpled paper strip	0		
+4142	huge purple a crumpled paper strip	0		
 4143	a ragged paper strip	0		
 4144	teal a ripped paper strip	0		
 4145	extremely unsafe funny paper hat	0		Weapon Damage Percent: +100, Familiar Effect: "1xVolley, 1xLep, cap 2"
@@ -4101,7 +4101,7 @@
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	fuchsia lint	0		Last Available: "2011-12"
 4151	ionized ghostly dubious peppermint	0		Effect: "Truly Gritty", Effect Duration: 66, Last Available: "2020-09"
-4152	energized adjusted green skewed Elvish delight	0		Effect: "Gummiskin", Effect Duration: 21
+4152	energized adjusted skewed green Elvish delight	0		Effect: "Gummiskin", Effect Duration: 21
 4153	rockfish stomach	0		Last Available: "2009-09"
 4154	live lobster	0		Last Available: "2011-12"
 4155	skewed wok lobster	0		Last Available: "2011-12"
@@ -4109,7 +4109,7 @@
 4157	gravel	0		Last Available: "2009-09"
 4158	squat rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
-4160	mediocre triple-distilled pebblebr&auml;u	9	decent	Last Available: "2009-09"
+4160	triple-distilled mediocre pebblebr&auml;u	9	decent	Last Available: "2009-09"
 4161	decent rocky road ice cream	3	good	Last Available: "2009-09"
 4162	extra-strength rubber bands	0		Familiar Weight: +5
 4163	tarnished upside-down children of the candy corn	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 20
@@ -4130,8 +4130,8 @@
 4178	fireproof sugar shotgun	0		Hot Resistance: +3, Last Available: "2009-09"
 4179	toasty sugar shillelagh	0		Hot Damage: +5, Last Available: "2009-09"
 4180	gray friendly sugar shank	0		Familiar Weight: +3, Last Available: "2009-09"
-4181	Jack Frost's Temple Grandin's stiffened sugar chapeau	0		Damage Reduction: 1, Familiar Weight: +7, Cold Spell Damage: +50, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	yellow therapeutic sugar shorts	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	Jack Frost's Temple Grandin's stiffened sugar chapeau	0		Damage Reduction: 1, Familiar Weight: +7, Cold Spell Damage: +50, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	yellow therapeutic sugar shorts	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4169,7 +4169,7 @@
 4217	twirling groupie bra	0		
 4218	tarnished activated oxidized groupie spangles	0		Effect: "Expert Vacationer", Effect Duration: 16
 4219	Socratic skate board of the pedagogue	0		Experience: +3, Experience (Mysticality): +1
-4220	olive spinning S.A.V.E. flyer	0		
+4220	spinning olive S.A.V.E. flyer	0		
 4221	Jack Frost's yield shield	0		Cold Spell Damage: +50, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
 4223	squamous polyp	0		Free Pull, Last Available: "2011-12"
@@ -4177,8 +4177,8 @@
 4225	roller skate doll	0		
 4226	pulsating perfumed Star of Bravery	0		Stench Resistance: +5, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
-4228	twirling fuchsia mirror perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4228	mirror twirling fuchsia perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	can of sterno	0		
 4237	wool cheese-slicer	0		Cold Resistance: +1
-4238	bite-sized adequate pulsating beef jerky	1	good	
+4238	adequate bite-sized pulsating beef jerky	1	good	
 4239	careful pipe wrench	0		Monster Level: -10
 4240	non-moist ionized blurry gun cleaning kit	0		Effect: "Unusual Perspective", Effect Duration: 19
 4241	greasy sleep mask	0		Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4207,14 +4207,14 @@
 4255	pulsating Wolfman Nardz	0		Last Available: "2009-10"
 4256	concentrated nitrogenated shaking sap	0		Effect: "Oleaginous Soles", Effect Duration: 24, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
-4258	stale half-sized chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
+4258	half-sized stale chocolate-covered scarab beetle	2	decent	Last Available: "2009-10"
 4259	acceptable mulled cider	4	good	Last Available: "2009-10"
-4260	mirror wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	mirror wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	purple bark boxers of chilblains	0		Cold Damage: +25, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	rosewater-soaked bark beret	0		Stench Resistance: +3, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	purple bark boxers of chilblains	0		Cold Damage: +25, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	rosewater-soaked bark beret	0		Stench Resistance: +3, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	red stylish bark bracelet	0		Moxie: +25, Single Equip
 4267	blue chaotic Socratic Krakrox's Loincloth	0		Experience (Mysticality): +1, Spell Critical Percent: +10, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	Da Vinci's smooth Galapagosian Cuisses	0		Moxie: +15, Experience (Mysticality): +5, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	dog trainer's banded arcane researcher's Ass-Stompers of Violence	0		Experience Percent (Mysticality): +10, Damage Absorption: +100, Experience (familiar): +1, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	miser's quilted Brand of Violence of extreme caution	0		Damage Absorption: +40, Monster Level: -25, Meat Drop: +10, Conditional Skill (Equipped): "Brand"
 4299	teal Temple Grandin's fortified brainy Novelty Belt Buckle of Violence	0		Mysticality: +5, Damage Absorption: +60, Familiar Weight: +7, Single Equip
-4300	avaricious flame-retardant sizzling Lens of Violence	0		Hot Damage: +10, Hot Resistance: +1, Meat Drop: +30, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	avaricious flame-retardant sizzling Lens of Violence	0		Hot Damage: +10, Hot Resistance: +1, Meat Drop: +30, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	Usain Bolt's fireproof Rosewater's Pigsticker of Violence	0		Mysticality Percent: +30, Hot Resistance: +3, Initiative: +80
-4302	greedy Annie Oakley's sharpshooter's Jodhpurs of Violence	0		Critical Hit Percent: 30, Meat Drop: +20, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	greedy Annie Oakley's sharpshooter's Jodhpurs of Violence	0		Critical Hit Percent: 30, Meat Drop: +20, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	ribald frightening Cold Stone of Hatred of vim and vigor	0		Maximum HP Percent: +50, Spooky Damage: +5, Sleaze Damage: +10, Conditional Skill (Equipped): "Chilling Grip"
 4304	spinning Usain Bolt's experienced beefy Girdle of Hatred	0		Muscle: +10, Experience: +2, Initiative: +80, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	flame-wreathed clever cool Staff of Simmering Hatred	0		Moxie: +5, Maximum MP: +20, Hot Spell Damage: +10
-4306	vibrating Pantaloons of Hatred of the sewer of the detective	0		Maximum MP Percent: +10, Stench Damage: +25, Item Drop: +20, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	vibrating Pantaloons of Hatred of the sewer of the detective	0		Maximum MP Percent: +10, Stench Damage: +25, Item Drop: +20, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	lime green electrified forbidden Fuzzy Slippers of Hatred of bravery	0		Spell Damage Percent: +50, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-4308	sharpshooter's clever Sinatra's Lens of Hatred	0		Experience (Moxie): +5, Maximum MP: +20, Critical Hit Percent: +10, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	sharpshooter's clever Sinatra's Lens of Hatred	0		Experience (Moxie): +5, Maximum MP: +20, Critical Hit Percent: +10, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	stanky Annie Oakley's Treads of Loathing of horror	0		Critical Hit Percent: +20, Stench Spell Damage: +25, Spooky Spell Damage: +25, Single Equip
 4310	blurry scorching manspreader's Scepter of Loathing of the blizzard	0		Monster Level: +10, Cold Spell Damage: +25, Hot Damage: +25
 4311	narrow smelly Oprah's hardy Belt of Loathing	0		Maximum HP: +50, Maximum MP Percent: +50, Stench Spell Damage: +10, Single Equip
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	upside-down gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat of the detective	0		Item Drop: +20, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	sinister snow pants	0		Spell Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	snow hat of the detective	0		Item Drop: +20, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	sinister snow pants	0		Spell Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	narrow snow belly of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2009-12"
 4352	squat pile of loose snow	0		Last Available: "2009-12"
 4353	olive Crimbough	0		Last Available: "2009-12"
@@ -4310,11 +4310,11 @@
 4358	squat A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	moldy expired can of franks 'n' beans	3	crappy	Last Available: "2009-12"
-4361	fancy hand-crafted expired bottle of peppermint schnapps	3	EPIC	Effect: "Norwhalloped", Effect Duration: 40, Last Available: "2009-12"
+4361	hand-crafted fancy expired bottle of peppermint schnapps	3	EPIC	Effect: "Norwhalloped", Effect Duration: 40, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
-4364	colloidal denatured blurry narrow elven suicide capsule	0		Effect: "Space Cadet", Effect Duration: 37, Last Available: "2009-12"
-4365	snack-sized fancy rotten penguin focaccia bread	2	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2009-12"
+4364	colloidal denatured narrow blurry elven suicide capsule	0		Effect: "Space Cadet", Effect Duration: 37, Last Available: "2009-12"
+4365	fancy snack-sized rotten penguin focaccia bread	2	crappy	Effect: "Sharpened Sweet Tooth", Effect Duration: 15, Last Available: "2009-12"
 4366	aged blue herringcello	4	awesome	Last Available: "2009-12"
 4367	acceptable elven cellocello	3	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
@@ -4337,21 +4337,21 @@
 4385	maroon wizardly pocketwatch on a chain of chilblains	0		Mysticality: +25, Cold Damage: +25, Last Available: "2009-12"
 4386	narrow deadly cement sandals of the glutton	0		Weapon Damage: +5, Food Drop: +100, Single Equip, Last Available: "2009-12"
 4387	upside-down experienced night-vision goggles of Leguizamo	0		Experience: +2, Monster Level: +20, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	peanut brittle shield of James Dean	0		Experience (Moxie): +3, Damage Reduction: 3, Last Available: "2009-12"
 4390	sage Red Rover BB gun of the cheetah	0		Mysticality Percent: +10, Initiative: +60, Last Available: "2009-12"
-4391	prompt red-and-green sweater	0		Adventures: +3, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	prompt red-and-green sweater	0		Adventures: +3, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	quadruple-unsweetened Crimbo peppermint bark	0		Effect: "Object Detection", Effect Duration: 40, Last Available: "2009-12"
 4394	boiled modified Crimbo fudge	0		Effect: "Slimily Speedy", Effect Duration: 26, Last Available: "2009-12"
-4395	modified blinking skewed Crimbo pecan	0		Effect: "Aided and Abetted", Effect Duration: 68, Last Available: "2009-12"
+4395	modified skewed blinking Crimbo pecan	0		Effect: "Aided and Abetted", Effect Duration: 68, Last Available: "2009-12"
 4396	Jack-in-the-box	0		Last Available: "2009-12"
 4397	blinking crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	hardy cheese sword	0		Maximum HP: +50, Softcore Only, Last Available: "2010-01"
-4400	huge cheese diaper of the sewer	0		Stench Damage: +25, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	huge cheese diaper of the sewer	0		Stench Damage: +25, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	bouncing cheese wheel of Gandalf	0		Spell Critical Percent: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	padded cheese eye	0		Damage Absorption: +20, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	padded cheese eye	0		Damage Absorption: +20, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	lime green shaking double-paned rosy-cheeked boxer's Staff of Queso Escusado	0		Muscle Percent: +10, Maximum HP Percent: +30, Cold Resistance: +5, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	rotten blinking narrow quantum taco	0		Last Available: "2010-10"
-4413	artisanal spirit-forward Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	spirit-forward artisanal Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	jittery upside-down inspector's sealhide hood	0		Item Drop: +15, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	mansplainer's sealhide leggings	0		Monster Level: +15, Familiar Effect: "1xVolley, cap 40"
@@ -4372,7 +4372,7 @@
 4421	deadly sealhide gloves	0		Weapon Damage: +5
 4422	deadly sealhide belt	0		Weapon Damage: +5
 4423	sealhide snare	0		
-4424	green squat puzzling trophy	0		
+4424	squat green puzzling trophy	0		
 4425	boiled sealhide seal doll	0		Effect: "Cravin' for a Ravin'", Effect Duration: 23
 4426	hymnal	0		Skill: "Canticle of Carboloading"
 4428	narrow therapeutic glowstick on a string	0		HP Regen Min: 5, HP Regen Max: 7
@@ -4396,7 +4396,7 @@
 4448	boiled mirror Instant Karma	1	awesome	Effect: "Smoking like a Bandit", Effect Duration: 25
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	blinking blurry map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	Da Vinci's pointy hat	0		Experience (Mysticality): +5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	Da Vinci's pointy hat	0		Experience (Mysticality): +5, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	asbestos-lined machetito	0		Hot Resistance: +5, Last Available: "2010-04"
 4453	lard-coated lawnmower blade	0		Sleaze Spell Damage: +25, Last Available: "2010-04"
 4454	lime green jittery wobbly grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	chilled extra-irradiated activated chocolate saucepan	0		Effect: "Frozen Hands", Effect Duration: 61
 4466	boiled chocolate disco ball	0		Effect: "Scarysauce", Effect Duration: 55
 4467	irradiated skewed chocolate stolen accordion	0		Effect: "Trivia Master", Effect Duration: 45
-4468	twirling Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	twirling Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	stiffened BRICKO hat	0		Damage Reduction: 1, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	Fonzie's BRICKO pants	0		Experience (Moxie): +1, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	stiffened BRICKO hat	0		Damage Reduction: 1, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	Fonzie's BRICKO pants	0		Experience (Moxie): +1, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	lime green savvy BRICKO sword	0		Mysticality Percent: +20, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	wobbly BRICKO oyster	0		Last Available: "2010-02"
 4477	ghostly BRICKO turtle	0		Last Available: "2010-02"
 4478	yellow BRICKO elephant	0		Last Available: "2010-02"
-4479	purple shaking BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	shaking purple BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4442,7 +4442,7 @@
 4494	olive BRICKO reactor	0		Last Available: "2010-02"
 4495	purple BRICKO egg	0		Last Available: "2010-02"
 4496	extra-heavy BRICKO brick	0		Familiar Weight: +5, Last Available: "2010-02"
-4497	denatured tarnished purple skewed recording of The Ballad of Richie Thingfinder	0		Effect: "Pecan Pied Piper", Effect Duration: 52
+4497	denatured tarnished skewed purple recording of The Ballad of Richie Thingfinder	0		Effect: "Pecan Pied Piper", Effect Duration: 52
 4498	adjusted liquefied recording of Benetton's Medley of Diversity	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 30
 4499	cold-filtered recording of Elron's Explosive Etude	0		Effect: "Pasta Oneness", Effect Duration: 57
 4500	cold-filtered oxidized blinking recording of Chorale of Companionship	0		Effect: "Mistified", Effect Duration: 17
@@ -4469,23 +4469,23 @@
 4521	croquet hedgehog	0		Last Available: "2010-03"
 4522	spinning fuchsia spinning Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	auspicious fortified eye of the Tiger-lily	0		Damage Absorption: +60, Item Drop: +10, Last Available: "2010-03"
-4524	coward's veiny wig	0		Maximum HP: +10, Monster Level: -20, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	special tasty jittery donut	3	awesome	Effect: "Improprie Tea", Effect Duration: 10, Last Available: "2010-03"
-4526	adequate olive blinking mirror bucket of honey	3	good	Last Available: "2010-03"
+4524	coward's veiny wig	0		Maximum HP: +10, Monster Level: -20, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4525	tasty special jittery donut	3	awesome	Effect: "Improprie Tea", Effect Duration: 10, Last Available: "2010-03"
+4526	adequate olive mirror blinking bucket of honey	3	good	Last Available: "2010-03"
 4527	avaricious sage elephant stinger	0		Mysticality Percent: +10, Meat Drop: +30, Last Available: "2010-03"
 4528	flavorless dragon snaps	3	decent	Last Available: "2010-03"
 4529	steel-toed brainy snapdragon pistil	0		Mysticality: +5, Damage Reduction: 9, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	flavorless olive rook cookie	4	decent	Last Available: "2010-03"
-4532	big bland bishop cookie	5	decent	Last Available: "2010-03"
+4532	bland big bishop cookie	5	decent	Last Available: "2010-03"
 4533	normal bite-sized knight cookie	1	good	Last Available: "2010-03"
 4534	flavorless mirror king cookie	3	decent	Last Available: "2010-03"
-4535	special rotten big blurry queen cookie	5	crappy	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
+4535	big rotten special blurry queen cookie	5	crappy	Effect: "Towering Strength", Effect Duration: 10, Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	insane tophat of the ox	0		Muscle: +20, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	huge avaricious arcane researcher's helm of the knight	0		Experience Percent (Mysticality): +10, Meat Drop: +30, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	insane tophat of the ox	0		Muscle: +20, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	huge avaricious arcane researcher's helm of the knight	0		Experience Percent (Mysticality): +10, Meat Drop: +30, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	Newton's wristwatch of the knight of the empath	0		Experience (Mysticality): +3, Familiar Weight: +5, Single Equip, Last Available: "2010-03"
-4540	padded groovy trousers of the knight	0		Moxie Percent: +10, Damage Absorption: +20, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	padded groovy trousers of the knight	0		Moxie Percent: +10, Damage Absorption: +20, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	curative tophat	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xBarrr, cap 25"
 4542	squat tie of Gandalf	0		Spell Critical Percent: +20, Single Equip
 4543	reassuring tuxedo pants	0		Spooky Resistance: +1, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4494,12 +4494,12 @@
 4546	purple bandersnatch	0		Last Available: "2010-03"
 4547	jittery cyan caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
-4549	blurry teal carpenter	0		Last Available: "2010-03"
+4549	teal blurry carpenter	0		Last Available: "2010-03"
 4550	wobbly dodo	0		Last Available: "2010-03"
 4551	Jim Carey's detour shield	0		Monster Level: +25, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
 4553	lowercase a	0		
-4554	wobbly yellow percent sign	0		
+4554	yellow wobbly percent sign	0		
 4555	spinning left bracket	0		
 4556	right parenthesis	0		
 4557	dollar sign	0		
@@ -4510,23 +4510,23 @@
 4562	hair of the calf	0		Last Available: "2010-04"
 4563	weak lousy world's most unappetizing beverage	2	decent	Last Available: "2010-04"
 4564	slippery when wet shield of the detective	0		Item Drop: +20, Damage Reduction: 6, Last Available: "2010-04"
-4565	snack-sized rotten narrow teal bouncing raisin	2	crappy	Last Available: "2010-04"
+4565	rotten snack-sized teal narrow bouncing raisin	2	crappy	Last Available: "2010-04"
 4566	pulsating fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	inspector's studded flyest of shirts	0		Damage Absorption: +80, Item Drop: +15, Last Available: "2010-04"
 4568	bland a dance upon the palate	3	decent	Last Available: "2010-04"
 4569	rotten prehistoric meteorite jawbreaker	3	crappy	Last Available: "2010-04"
 4570	blinking Crazyleg's razor	0		Last Available: "2010-04"
-4571	normal enchanted snack-sized fuchsia squirmy violent party snack	2	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 40, Last Available: "2010-04"
+4571	enchanted snack-sized normal fuchsia squirmy violent party snack	2	good	Effect: "Big Ol' Glass of Rum", Effect Duration: 40, Last Available: "2010-04"
 4572	Jeselnik's can-you-dig-it?	0		Sleaze Damage: +25, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	huge bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	pulsating bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	pulsating bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	boiled modified narrow Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Demonic Flavor", Effect Duration: 36, Last Available: "2010-04"
 4580	squat supercharged school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Maximum MP Percent: +30, Last Available: "2010-04"
-4581	miser's dangerous T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Weapon Damage: +10, Meat Drop: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	miser's dangerous T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Weapon Damage: +10, Meat Drop: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	bouncing fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	bland six wedges of goat cheese	4	decent	
@@ -4550,9 +4550,9 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	pulsating huge bronze handcuffs	0		Last Available: "2010-06"
 4604	bouncing keg	0		Last Available: "2010-06"
-4605	executive Tesla bottle of Goldschn&ouml;ckered	0		Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	rotten snack-sized sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	watered-down tolerable soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	executive Tesla bottle of Goldschn&ouml;ckered	0		Meat Drop: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4606	snack-sized rotten sun-dried tofu	2	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	tolerable watered-down soyburger juice	2	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	altered non-polymerized teal essential soy	0		Effect: "Grrrrrrreat!", Effect Duration: 67, Last Available: "2010-08"
@@ -4571,18 +4571,18 @@
 4623	moist ghostly shaking chocolate-covered caviar	0		Effect: "Ironclad", Effect Duration: 21, Last Available: "2020-09"
 4624	low-calorie spoiled pawn cookie	1	crappy	Last Available: "2010-06"
 4625	twisted coffee pixie stick	1	decent	Last Available: "2010-06"
-4626	huge narrow superduperball	0		Last Available: "2010-06"
+4626	narrow huge superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	wicked plastic spider ring	0		Spell Damage: +5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	wicked plastic spider ring	0		Spell Damage: +5, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	deadly plastic kazoo	0		Weapon Damage: +5, Last Available: "2010-06"
 4631	blurry banded inflatable baseball bat	0		Damage Absorption: +100, Last Available: "2010-06"
-4632	yellow Lo Pan's googly-star hat	0		Spell Critical Percent: +30, Item Drop: +5, Last Available: "2010-06", Familiar Effect: "atk"
+4632	yellow Lo Pan's googly-star hat	0		Spell Critical Percent: +30, Item Drop: +5, Familiar Effect: "atk", Last Available: "2010-06"
 4633	blinking boxer's googly-ball hat of the glutton	0		Muscle Percent: +10, Food Drop: +100, Last Available: "2010-06"
 4634	gravedigger's googly-heart hat of the businessman	0		Spooky Damage: +10, Meat Drop: +50, Last Available: "2010-06"
 4635	flame-wreathed arcane researcher's super-sweet boom box	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +10, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	inspector's scandalous supercool sinister demon mask	0		Moxie Percent: +20, Sleaze Damage: +5, Item Drop: +15, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	inspector's scandalous supercool sinister demon mask	0		Moxie Percent: +20, Sleaze Damage: +5, Item Drop: +15, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	Tesla Van der Graaf streetfighting champion's belt of incineration	0		Hot Spell Damage: +50, MP Regen Min: 12, MP Regen Max: 17, Single Equip, Last Available: "2010-06"
 4639	groovy Rosewater's slick Space Trip safety headphones	0		Moxie: +10, Mysticality Percent: +30, Moxie Percent: +10, Single Equip, Last Available: "2010-06"
 4640	hardy LARP carp	0		Maximum HP: +50
@@ -4594,8 +4594,8 @@
 4646	shaking Lo Pan's Fonzie's groovy Meteoid ice beam	0		Moxie Percent: +10, Experience (Moxie): +1, Spell Critical Percent: +30, Last Available: "2011-12"
 4647	frightening foul-smelling Oprah's Dungeon Fist gauntlet	0		Maximum MP Percent: +50, Stench Damage: +10, Spooky Damage: +5, Last Available: "2011-06"
 4648	red Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	narrow chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	red fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	narrow chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	red fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	red ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	ironic knit cap of horror of Flo-Jo	0		Spooky Spell Damage: +25, Initiative: +100, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	mirror ironic sunglasses	0		Single Equip
@@ -4618,22 +4618,22 @@
 4670	squat cyan beer-scented teddy bear	0		
 4671	artisanal booze-soaked cherry	3	EPIC	
 4672	olive comfy pillow	0		
-4673	normal half-sized marshmallow	2	good	
-4674	stale special sponge cake	3	decent	Effect: "Ice Packed", Effect Duration: 20
-4675	acceptable high-proof cyan gin-soaked blotter paper	7	good	
+4673	half-sized normal marshmallow	2	good	
+4674	special stale sponge cake	3	decent	Effect: "Ice Packed", Effect Duration: 20
+4675	high-proof acceptable cyan gin-soaked blotter paper	7	good	
 4676	tree-holed coin	0		
 4677	blinking unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	blinking sizzling pottery shield	0		Hot Damage: +10, Damage Reduction: 3, Last Available: "2010-09"
-4682	cool pottery hat of chilblains	0		Moxie: +5, Cold Damage: +25, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	scandalous supercharged pottery training pants	0		Maximum MP Percent: +30, Sleaze Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	cool pottery hat of chilblains	0		Moxie: +5, Cold Damage: +25, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	scandalous supercharged pottery training pants	0		Maximum MP Percent: +30, Sleaze Damage: +5, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	Fonzie's pottery club	0		Experience (Moxie): +1, Last Available: "2010-09"
 4685	skewed frosty pottery yo-yo	0		Cold Spell Damage: +10, Last Available: "2010-09"
 4686	blinking pottery barn owl figurine	0		Last Available: "2010-09"
 4687	ghostly fossilized bat skull	0		Last Available: "2010-09"
-4688	blurry squat fossilized serpent skull	0		Last Available: "2010-09"
+4688	squat blurry fossilized serpent skull	0		Last Available: "2010-09"
 4689	shaking fossilized baboon skull	0		Last Available: "2010-09"
 4690	fossilized wyrm skull	0		Last Available: "2010-09"
 4691	bouncing green fossilized wing	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	toasty quilted Greatest American Pants of the sewer	0		Damage Absorption: +40, Hot Damage: +5, Stench Damage: +25, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	toasty quilted Greatest American Pants of the sewer	0		Damage Absorption: +40, Hot Damage: +5, Stench Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	squat teal deadly fossilized necklace	0		Weapon Damage: +5, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4649,7 +4649,7 @@
 4701	waterlogged crate	0		Last Available: "2011-12"
 4702	archaeologing shovel	0		Last Available: "2011-12"
 4703	maroon Tesla red-hot medallion	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2010-09"
-4704	mirror wobbly fossilized demon skull	0		Last Available: "2010-09"
+4704	wobbly mirror fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
@@ -4659,7 +4659,7 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	olive GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	tiny bland lemon popsicle	1	decent	
+4714	bland tiny lemon popsicle	1	decent	
 4715	stale popsicle	3	decent	
 4716	stale strawberry popsicle	3	decent	
 4717	delicious ghostly liver popsicle	3	awesome	
@@ -4667,14 +4667,14 @@
 4719	Jeselnik's Hollandaise helmet	0		Sleaze Damage: +25, Familiar Effect: "atk, cap 2"
 4720	tumbling organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	tiny rotten shaking jittery liver and let pie	1	crappy	Last Available: "2010-10"
+4722	tiny rotten jittery shaking liver and let pie	1	crappy	Last Available: "2010-10"
 4723	bland badass pie	3	decent	Last Available: "2010-10"
 4724	super-sized moldy shoo-fish pie	5	crappy	Last Available: "2010-10"
-4725	stale half-sized blurry piping organ pie	2	decent	Last Available: "2010-10"
-4726	decent immense blinking igloo pie	6	good	Last Available: "2010-10"
+4725	half-sized stale blurry piping organ pie	2	decent	Last Available: "2010-10"
+4726	immense decent blinking igloo pie	6	good	Last Available: "2010-10"
 4727	stale stomach turnover	4	decent	Last Available: "2010-10"
 4728	normal blinking dead lights pie	4	good	Last Available: "2010-10"
-4729	stale spinning blurry throbbing organ pie	4	decent	Last Available: "2010-10"
+4729	stale blurry spinning throbbing organ pie	4	decent	Last Available: "2010-10"
 4730	shaking horrifying stop shield	0		Spooky Damage: +25, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	gray sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,13 +4683,13 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	upside-down tangle of rat tails	0		
 4737	beer-soaked mop of the sewer	0		Stench Damage: +25
-4738	distilled drinkable day-old beer	5	good	
+4738	drinkable distilled day-old beer	5	good	
 4739	bad pulsating plain beer	3	decent	
 4740	hand-crafted practically non-alcoholic overpriced &quot;imported&quot; beer	1	EPIC	
 4741	wobbly huge smiling rat	0		
 4742	bouncing rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
-4744	dry unsweetened shaking yellow PlexiPips	0		Effect: "Uncucumbered", Effect Duration: 54
+4744	dry unsweetened yellow shaking PlexiPips	0		Effect: "Uncucumbered", Effect Duration: 54
 4745	galvanized Wax Flask	0		Effect: "Stimulated Brain", Effect Duration: 14
 4746	colloidal blinking Pain Dip	0		Effect: "Dreadful Smell", Effect Duration: 62
 4747	moldy small bone meal	2	crappy	Last Available: "2010-10"
@@ -4699,8 +4699,8 @@
 4751	jittery fortified boning knife	0		Damage Absorption: +60, Last Available: "2010-10"
 4752	bone crusher of the sweet-tooth	0		Candy Drop: +100, Last Available: "2010-10"
 4753	blinking bone spurs of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2010-10"
-4754	blurry executive greedy bonedanna	0		Meat Drop: 60, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	sharpshooter's baleful boneana hammock	0		Spell Damage: +25, Critical Hit Percent: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	blurry executive greedy bonedanna	0		Meat Drop: 60, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	sharpshooter's baleful boneana hammock	0		Spell Damage: +25, Critical Hit Percent: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
 4758	Vulcanized altered spinning candy skeleton	0		Effect: "Cold Jellied", Effect Duration: 21, Last Available: "2020-09"
@@ -4709,7 +4709,7 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	normal pumpkin pie	3	good	Last Available: "2010-11"
-4764	perfectly mixed fancy pumpkin beer	3	EPIC	Effect: "Remaining Alive", Effect Duration: 40, Last Available: "2010-11"
+4764	fancy perfectly mixed pumpkin beer	3	EPIC	Effect: "Remaining Alive", Effect Duration: 40, Last Available: "2010-11"
 4765	diffused galvanized skewed pumpkin juice	0		Effect: "Snobby", Effect Duration: 26, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	Jack Frost's razor-sharp shin gourds	0		Weapon Damage Percent: +25, Cold Spell Damage: +50, Single Equip, Last Available: "2010-11"
@@ -4724,10 +4724,10 @@
 4810	yellow Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	tumbling shaking Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	lime green blurry Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	snack-sized toothsome mirror CRIMBCOIDS mints	2	awesome	Last Available: "2011-01"
+4818	toothsome snack-sized mirror CRIMBCOIDS mints	2	awesome	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	toothsome CRIMBCOLOAF	3	awesome	Last Available: "2011-01"
-4821	normal fancy circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	fancy normal circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	hardy plastic CRIMBCO HQ	0		Maximum HP: +50, Last Available: "2010-12"
 4823	plastic fax machine of the brute	0		Muscle Percent: +30, Last Available: "2010-12"
 4824	blue plastic hobo elf of the early riser	0		Adventures: +7, Last Available: "2010-12"
@@ -4745,15 +4745,15 @@
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	spoiled gigantic triangular CRIMBCOOKIE	6	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	gigantic spoiled triangular CRIMBCOOKIE	6	crappy	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	normal bouncing square CRIMBCOOKIE	4	good	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	frosty wicked bindlestocking of the cheetah	0		Spell Damage: +5, Cold Spell Damage: +10, Initiative: +60, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	twirling family-friendly Uncle Hobo's stocking cap of dire peril	0		Weapon Damage: +20, Sleaze Resistance: +1, Last Available: "2010-12", Familiar Effect: "atk"
+4845	twirling family-friendly Uncle Hobo's stocking cap of dire peril	0		Weapon Damage: +20, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2010-12"
 4846	baleful Uncle Hobo's epic beard of the bloodbag	0		Spell Damage: +25, Maximum HP: +100, Single Equip, Last Available: "2010-12"
-4847	blinking cyan rock-hard Uncle Hobo's gift baggy pants of the sweet-tooth	0		Damage Reduction: 5, Candy Drop: +100, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	blinking cyan rock-hard Uncle Hobo's gift baggy pants of the sweet-tooth	0		Damage Reduction: 5, Candy Drop: +100, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	rock-hard brawny Uncle Hobo's fingerless tinsel gloves	0		Muscle Percent: +20, Damage Reduction: 5, Single Equip, Last Available: "2010-12"
 4849	sinister Uncle Hobo's highest bough of extreme caution	0		Spell Damage: +10, Monster Level: -25, Last Available: "2010-12"
 4850	Socratic Uncle Hobo's belt of the brazier	0		Experience (Mysticality): +1, Hot Spell Damage: +25, Single Equip, Last Available: "2010-12"
@@ -4775,8 +4775,8 @@
 4866	Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	blurry razor-sharp dangerous paperclip-on tie of the ox	0		Muscle: +20, Weapon Damage: +10, Weapon Damage Percent: +25, Single Equip, Last Available: "2011-01"
-4869	friendly paperclip pants of bravery	0		Familiar Weight: +3, Spooky Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	spinning family-friendly paperclip turban of the ox of doom	0		Muscle: +20, Spooky Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	friendly paperclip pants of bravery	0		Familiar Weight: +3, Spooky Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	spinning family-friendly paperclip turban of the ox of doom	0		Muscle: +20, Spooky Spell Damage: +50, Sleaze Resistance: +1, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	fuchsia hardy paperclip cape	0		Maximum HP: +50, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4785,16 +4785,16 @@
 4876	galvanized pickled mirror chocolate bath ball	0		Effect: "Armored Innards", Effect Duration: 56, Last Available: "2011-01"
 4877	flattened olive bacon bath ball	0		Effect: "Fever From the Flavor", Effect Duration: 53, Last Available: "2011-01"
 4878	enhanced incense bath ball	0		Effect: "Wistfully Nostalgic", Effect Duration: 28, Last Available: "2011-01"
-4879	energized altered cyan shaking shaking myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Spooky Jellied", Effect Duration: 61, Last Available: "2011-01"
+4879	energized altered shaking shaking cyan myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Spooky Jellied", Effect Duration: 61, Last Available: "2011-01"
 4880	bouncing CRIMBCO mug	0		Last Available: "2011-01"
-4881	perfectly mixed weak CRIMBCO wine	2	EPIC	Last Available: "2011-01"
+4881	weak perfectly mixed CRIMBCO wine	2	EPIC	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	mirror toe jam	0		Last Available: "2011-01"
 4884	toothsome jumbo tumbling toe jam toast	5	awesome	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	toothsome low-calorie traffic jam toast	1	awesome	Last Available: "2011-01"
+4886	low-calorie toothsome traffic jam toast	1	awesome	Last Available: "2011-01"
 4887	green space jam	0		Last Available: "2011-01"
-4888	stale massive space jam toast	9	decent	Last Available: "2011-01"
+4888	massive stale space jam toast	9	decent	Last Available: "2011-01"
 4889	altered lime green motivational poster	0		Effect: "Heart of Lavender", Effect Duration: 38, Last Available: "2011-01"
 4890	spinning olive sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
@@ -4855,12 +4855,12 @@
 4952	triple-Vulcanized moist narrow baggie of sugar	0		Effect: "You Know Who to Call", Effect Duration: 58
 4953	yellow resourceful beefcake's whalebone corset	0		Muscle: +25, Maximum MP: +50, Single Equip
 4954	green oven mitts of doom	0		Spooky Spell Damage: +50, Single Equip
-4955	rotten massive overcookie	9	crappy	
+4955	massive rotten overcookie	9	crappy	
 4956	decent philosopher's scone	4	good	
 4957	galvanized non-flattened double-unsweetened upside-down pulsating half-baked potion	0		Effect: "Pasta Oneness", Effect Duration: 58
 4958	twirling Knob Goblin deluxe scimitar of the overflowing toilet	0		Stench Spell Damage: +50
-4959	bland jumbo Knob nuts	5	decent	
-4960	extra-dry aged Cobb's Knob Wurstbrau	5	awesome	
+4959	jumbo bland Knob nuts	5	decent	
+4960	aged extra-dry Cobb's Knob Wurstbrau	5	awesome	
 4961	ghostly Subject 37 file	0		
 4962	ghostly greedy Sherlock's mysterious lapel pin	0		Item Drop: +25, Meat Drop: +20, Single Equip
 4963	teal state loom	0		Familiar Weight: +10
@@ -4876,7 +4876,7 @@
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	Alice's Army Page	0		Last Available: "2011-03"
 4975	pulsating Alice's Army Shieldmaiden	0		Last Available: "2011-03"
-4976	twirling jittery Alice's Army Mad Bomber	0		Last Available: "2011-03"
+4976	jittery twirling Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
@@ -4903,7 +4903,7 @@
 5000	mirror Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	fuchsia narrow Alice's Army Foil Horseman	0		Last Available: "2011-03"
-5003	cyan jittery Alice's Army Foil Coward	0		Last Available: "2011-03"
+5003	jittery cyan Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	blue Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	pulsating Alice's Army Foil Dervish	0		Last Available: "2011-03"
@@ -4913,10 +4913,10 @@
 5010	evil eye	0		
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	miniature tasty wasabi pocky	2	awesome	Last Available: "2011-03"
+5013	tasty miniature wasabi pocky	2	awesome	Last Available: "2011-03"
 5014	diet rotten upside-down tobiko pocky	1	crappy	Last Available: "2011-03"
 5015	huge adequate shaking natto pocky	7	good	Last Available: "2011-03"
-5016	bad fortified ghostly wasabi-infused sake	5	decent	Last Available: "2011-03"
+5016	fortified bad ghostly wasabi-infused sake	5	decent	Last Available: "2011-03"
 5017	watered-down acceptable tobiko-infused sake	2	good	Last Available: "2011-03"
 5018	mediocre watered-down natto-infused sake	2	decent	Last Available: "2011-03"
 5019	unsweetened frozen wasabi marble soda	0		Effect: "Crimbo Nostalgia", Effect Duration: 41, Last Available: "2011-03"
@@ -4925,9 +4925,9 @@
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	ionized elderly jawbreaker	0		Effect: "Swordholder", Effect Duration: 67, Last Available: "2020-09"
 5024	acceptable marshmallow flamb&eacute;	4	good	Last Available: "2011-03"
-5025	acceptable watered-down cranberry schnapps	2	good	Last Available: "2011-03"
-5026	weak acceptable breaded beer	2	good	Last Available: "2011-03"
-5027	high-proof acceptable enchanted soy cordial	8	good	Effect: "Crusty Head", Effect Duration: 25, Last Available: "2011-03"
+5025	watered-down acceptable cranberry schnapps	2	good	Last Available: "2011-03"
+5026	acceptable weak breaded beer	2	good	Last Available: "2011-03"
+5027	high-proof enchanted acceptable soy cordial	8	good	Effect: "Crusty Head", Effect Duration: 25, Last Available: "2011-03"
 5028	baleful astral bludgeon of James Dean of incineration	0		Experience (Moxie): +3, Spell Damage: +25, Hot Spell Damage: +50
 5029	wizardly astral shield of Gandalf	0		Mysticality: +25, Spell Critical Percent: +20, Damage Reduction: 15
 5030	blurry grievous astral chapeau of Gandalf of the businessman	0		Weapon Damage Percent: +50, Spell Critical Percent: +20, Meat Drop: +50, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4946,12 +4946,12 @@
 5043	normal mirror astral hot dog	3		
 5044	acceptable skewed narrow astral pilsner	3		
 5045	astral hot dog dinner	0		
-5046	blurry gray astral six-pack	0		
+5046	gray blurry astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	green family-friendly reassuring double-ice cap of the blizzard	0		Cold Spell Damage: +25, Spooky Resistance: +1, Sleaze Resistance: +1, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	green family-friendly reassuring double-ice cap of the blizzard	0		Cold Spell Damage: +25, Spooky Resistance: +1, Sleaze Resistance: +1, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	MacGyver's energetic smooth double-ice box	0		Moxie: +15, Maximum MP Percent: +20, Maximum MP: +100, Last Available: "2011-04"
-5051	blurry scorching supercharged double-ice britches of the detective	0		Maximum MP Percent: +30, Hot Damage: +25, Item Drop: +20, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	blurry scorching supercharged double-ice britches of the detective	0		Maximum MP Percent: +30, Hot Damage: +25, Item Drop: +20, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
@@ -4976,15 +4976,15 @@
 5073	tolerable wobbly Russian Ice	3	good	Last Available: "2011-04"
 5074	huge huge clay ashtray of the cougar	0		Moxie: +20, Damage Reduction: 3, Last Available: "2011-05"
 5075	chilly lanyard	0		Cold Damage: +5, Single Equip, Last Available: "2011-05"
-5076	medical-grade monster pants	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	medical-grade monster pants	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	narrow box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	boiled warmed Pok&euml;mann band-aid	0		Effect: "Chilblains of the Corn", Effect Duration: 52, Last Available: "2011-05"
-5079	grievous savvy Van der Graaf helmet	0		Mysticality Percent: +20, Weapon Damage Percent: +50, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	grievous savvy Van der Graaf helmet	0		Mysticality Percent: +20, Weapon Damage Percent: +50, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	steel-toed crutch	0		Damage Reduction: 9, Last Available: "2011-05"
 5081	greedy shock belt	0		Meat Drop: +20, Single Equip, Last Available: "2011-05"
 5082	ionized alkaline twirling Okee-Dokee soda	0		Effect: "Down With Chow", Effect Duration: 64, Last Available: "2011-05"
 5083	fuchsia clever rubber band gun	0		Maximum MP: +20, Last Available: "2011-05"
-5084	teal ruddy pin-stripe slacks	0		Maximum HP Percent: +40, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	teal ruddy pin-stripe slacks	0		Maximum HP Percent: +40, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	Da Vinci's gloves	0		Experience (Mysticality): +5, Single Equip, Last Available: "2011-05"
 5086	boiled super-energized triple-enhanced spinning correction fluid	0		Effect: "Joyful Resolve", Effect Duration: 38, Last Available: "2011-05"
 5087	Pok&euml;mann figurine: Porkachu of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2011-05"
@@ -5009,7 +5009,7 @@
 5106	hideous egg	0		Last Available: "2011-05"
 5107	perfectly mixed practically non-alcoholic red Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	green Jeselnik's stress ball	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	green Jeselnik's stress ball	0		Sleaze Damage: +25, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	smartaleck's Ultracolor&trade; shirt	0		Moxie Percent: +30, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,19 +5021,19 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	electrified experienced Admiral's hat	0		Experience: +2, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-05", Familiar Effect: "atk"
-5122	friendly Lo Pan's medical-grade aviator's cap	0		Spell Critical Percent: +30, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	electrified experienced Admiral's hat	0		Experience: +2, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk", Last Available: "2011-05"
+5122	friendly Lo Pan's medical-grade aviator's cap	0		Spell Critical Percent: +30, Familiar Weight: +3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	narrow family-friendly mirrored aviator shades of the scaredy-cat	0		Monster Level: -15, Sleaze Resistance: +1, Single Equip, Last Available: "2011-05"
 5124	maroon Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
-5128	olive squat Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
-5129	squat shaking Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
+5128	squat olive Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
+5129	shaking squat Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	tarnished deionized Ultrasoldier Serum	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 12, Last Available: "2011-06"
 5132	rotten elven hardtack	3	crappy	Last Available: "2011-06"
-5133	drinkable distilled jittery spinning elven squeeze	5	good	Last Available: "2011-06"
+5133	distilled drinkable jittery spinning elven squeeze	5	good	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5046,13 +5046,13 @@
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
 5145	double-frozen ionized squat honeypot	0		Effect: "Mana Tea", Effect Duration: 41
-5146	big moldy wild honey pie	5	crappy	
+5146	moldy big wild honey pie	5	crappy	
 5147	bad triple-distilled honey mead	10	decent	
 5148	green mansplainer's Van der Graaf boxer's honey dipper	0		Muscle Percent: +10, Monster Level: +15, MP Regen Min: 5, MP Regen Max: 7
 5149	narrow thinker's honeybritches of courage of temperance	0		Mysticality: +10, Spooky Resistance: +3, Sleaze Resistance: +5, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	sharpshooter's hardy smartaleck's honeycap	0		Moxie Percent: +30, Maximum HP: +50, Critical Hit Percent: +10, Familiar Effect: "1xPotato, cap 43"
-5151	banded Moonthril Circlet	0		Damage Absorption: +100, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	tumbling personal trainer's Moonthril Greaves	0		Experience Percent (Muscle): +10, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	banded Moonthril Circlet	0		Damage Absorption: +100, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	tumbling personal trainer's Moonthril Greaves	0		Experience Percent (Muscle): +10, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	ghostly Moonthril Flamberge of the scaredy-cat	0		Monster Level: -15, Last Available: "2011-06"
 5154	wobbly smooth Moonthril Longbow	0		Moxie: +15, Last Available: "2011-06"
 5155	Temple Grandin's Moonthril Cuirass	0		Familiar Weight: +7, Softcore Only, Last Available: "2011-06"
@@ -5071,15 +5071,15 @@
 5168	distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
 5170	anodized jittery cyan transporter transponder	0		Effect: "Stinky Hands", Effect Duration: 19, Last Available: "2011-06"
-5171	spinning spinning skewed Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
+5171	spinning skewed spinning Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	squat Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	blurry elven magi-pack	0		Last Available: "2011-06"
 5174	drinkable Saison du Lune	3	good	Last Available: "2011-06"
-5175	delicious enchanted irresponsibly strong Moonthril Schnapps	10	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 10, Last Available: "2011-06"
+5175	enchanted irresponsibly strong delicious Moonthril Schnapps	10	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 10, Last Available: "2011-06"
 5176	hand-crafted blurry Wrecked Generator	3	super ultra mega EPIC	Last Available: "2011-06"
 5177	miniature toothsome Spaghetti with Moonballs	2	awesome	Last Available: "2011-06"
 5178	decent Crepes a la Lune	4	good	Last Available: "2011-06"
-5179	snack-sized moldy maroon Moon Pie	2	crappy	Last Available: "2011-06"
+5179	moldy snack-sized maroon Moon Pie	2	crappy	Last Available: "2011-06"
 5180	corrupted Comet Pop	0		Effect: "Fever From the Flavor", Effect Duration: 67, Last Available: "2011-06"
 5181	ionized corrupted squat Flan in the Moon	0		Effect: "Dirty Pear", Effect Duration: 31, Last Available: "2011-06"
 5182	ionized activated shaking 1/6th Pound Cake	0		Effect: "Whitened Teeth", Effect Duration: 19, Last Available: "2011-06"
@@ -5090,8 +5090,8 @@
 5187	upside-down Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	anodized adjusted pickled honey stick	0		Effect: "Ichorous Intensity", Effect Duration: 62
 5189	enhanced anodized double-ice gum	0		Effect: "Thunderspell", Effect Duration: 41, Last Available: "2011-04"
-5190	padded baleful Operation Patriot Shield of mayonnaise	0		Spell Damage: +25, Damage Absorption: +20, Sleaze Spell Damage: +50, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
-5191	cyan upside-down squirming egg sac	0		Last Available: "2011-06"
+5190	padded baleful Operation Patriot Shield of mayonnaise	0		Spell Damage: +25, Damage Absorption: +20, Sleaze Spell Damage: +50, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5191	upside-down cyan squirming egg sac	0		Last Available: "2011-06"
 5192	anodized vacuum-sealed anodized corrupted data	0		Effect: "Crud&eacute;", Effect Duration: 45, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
 5194	exorcised sandwich	0		
@@ -5115,7 +5115,7 @@
 5212	diluted twirling paste	1	crappy	Last Available: "2011-08"
 5213	powdered Mer-kin paste	1	awesome	Effect: "Emotion Sickness", Effect Duration: 5, Last Available: "2011-08"
 5214	dried slimy paste	1	crappy	Last Available: "2011-08"
-5215	diluted twirling wobbly penguin paste	1	EPIC	Last Available: "2011-08"
+5215	diluted wobbly twirling penguin paste	1	EPIC	Last Available: "2011-08"
 5216	twisted elemental paste	1	decent	Last Available: "2011-08"
 5217	modified cosmic paste	1	decent	Last Available: "2011-08"
 5218	compressed ghostly hobo paste	1	EPIC	Last Available: "2011-08"
@@ -5123,8 +5123,8 @@
 5220	skewed Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	cyan Thwaitgold grasshopper statuette	0		
-5223	tumbling Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	fancy bland jumbo Ur-Donut	5	decent	Effect: "Vanity Rage", Effect Duration: 45, Last Available: "2011-09"
+5223	tumbling Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5224	jumbo bland fancy Ur-Donut	5	decent	Effect: "Vanity Rage", Effect Duration: 45, Last Available: "2011-09"
 5225	pulsating The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	watered-down mediocre bucket of wine	2	decent	Last Available: "2011-09"
@@ -5138,11 +5138,11 @@
 5235	blurry wobbly dangerous furry halo	0		Weapon Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	veiny frosty halo	0		Maximum HP: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	squat smelly time halo	0		Stench Spell Damage: +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	watered-down perfectly mixed Lumineux Limnio	2	EPIC	Last Available: "2011-09"
+5238	perfectly mixed watered-down Lumineux Limnio	2	EPIC	Last Available: "2011-09"
 5239	smooth Morto Moreto	3	awesome	Last Available: "2011-09"
-5240	watered-down hand-crafted special twirling Temps Tempranillo	2	EPIC	Last Available: "2011-09"
+5240	hand-crafted watered-down special twirling Temps Tempranillo	2	EPIC	Last Available: "2011-09"
 5241	perfectly mixed practically non-alcoholic Bordeaux Marteaux	1	EPIC	Last Available: "2011-09"
-5242	irresponsibly strong lousy special Fromage Pinotage	8	decent	Effect: "Chalk Outline", Effect Duration: 5, Last Available: "2011-09"
+5242	special irresponsibly strong lousy Fromage Pinotage	8	decent	Effect: "Chalk Outline", Effect Duration: 5, Last Available: "2011-09"
 5243	drinkable triple-distilled huge Beignet Milgranet	8	good	Last Available: "2011-09"
 5244	perfectly mixed Muschat	4	EPIC	Last Available: "2011-09"
 5245	bland cool jelly donut	3	decent	Last Available: "2011-09"
@@ -5150,12 +5150,12 @@
 5247	super-sized bland occult jelly donut	5	decent	Last Available: "2011-09"
 5248	jumbo adequate thyme jelly donut	5	good	Last Available: "2011-09"
 5249	adequate danish	4	good	Last Available: "2011-09"
-5250	low-calorie toothsome blue smashed danish	1	awesome	Last Available: "2011-09"
-5251	super-sized special stale shaking upside-down forbidden danish	5	decent	Effect: "Shamboozled", Effect Duration: 35, Last Available: "2011-09"
+5250	toothsome low-calorie blue smashed danish	1	awesome	Last Available: "2011-09"
+5251	stale special super-sized shaking upside-down forbidden danish	5	decent	Effect: "Shamboozled", Effect Duration: 35, Last Available: "2011-09"
 5252	toothsome ghostly cool cat claw	3	awesome	Last Available: "2011-09"
 5253	rotten blunt cat claw	4	crappy	Last Available: "2011-09"
 5254	rotten shadowy cat claw	3	crappy	Last Available: "2011-09"
-5255	rotten mirror ghostly cheezburger	4	crappy	Last Available: "2011-09"
+5255	rotten ghostly mirror cheezburger	4	crappy	Last Available: "2011-09"
 5256	rotten toasted brie	3	crappy	Last Available: "2011-09"
 5257	ionized energized potion of the field gar	0		Effect: "Egg Burps", Effect Duration: 20, Last Available: "2011-09"
 5258	tarnished mirror too legit potion	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 14, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	broken clock of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-09"
 5282	frosty dethklok	0		Cold Spell Damage: +10, Last Available: "2011-09"
 5283	tumbling coward's glacial clock	0		Monster Level: -20, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	maroon d4	0		Last Available: "2011-09"
 5286	tumbling d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	bland jumbo phish stick	5	decent	Last Available: "2011-09"
-5299	teal hale baleful plastic vampire fangs of terror	0		Spell Damage: +25, Maximum HP: +20, Spooky Spell Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	teal hale baleful plastic vampire fangs of terror	0		Spell Damage: +25, Maximum HP: +20, Spooky Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5233,16 +5233,16 @@
 5330	double-polymerized electrified jittery red drum of pomade	0		Effect: "Scarysauce", Effect Duration: 48, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	boxer's extra-see-thru nightie	0		Muscle Percent: +10, Last Available: "2011-10"
-5333	chilly banded BRAINS shorts	0		Damage Absorption: +100, Cold Damage: +5, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	chilly banded BRAINS shorts	0		Damage Absorption: +100, Cold Damage: +5, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	razor-sharp Mesmereyes&trade; contact lenses	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2011-10"
 5335	greedy scrunchie	0		Meat Drop: +20, Single Equip, Last Available: "2011-10"
-5336	olive slick extremely skinny jeans of the cougar	0		Moxie: 30, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	olive crafty groovy The Necbromancer's Hat	0		Moxie Percent: +10, Maximum MP: +10, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	olive slick extremely skinny jeans of the cougar	0		Moxie: 30, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	olive crafty groovy The Necbromancer's Hat	0		Moxie Percent: +10, Maximum MP: +10, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	yellow jittery Sherlock's energetic The Necbromancer's Stein of Gandalf	0		Maximum MP Percent: +20, Spell Critical Percent: +20, Item Drop: +25, Last Available: "2011-10"
-5339	reassuring chilly dog trainer's The Necbromancer's Shorts	0		Experience (familiar): +1, Cold Damage: +5, Spooky Resistance: +1, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	reassuring chilly dog trainer's The Necbromancer's Shorts	0		Experience (familiar): +1, Cold Damage: +5, Spooky Resistance: +1, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	auspicious MacGyver's personal trainer's The Necbromancer's Wizard Staff	0		Experience Percent (Muscle): +10, Maximum MP: +100, Item Drop: +10, Last Available: "2011-10"
 5341	blinking The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	drinkable weak tumbling The Cooler Out of Space	2	good	Last Available: "2011-10"
+5342	weak drinkable tumbling The Cooler Out of Space	2	good	Last Available: "2011-10"
 5343	cyan The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	polarized spinning Necbro wafers	0		Effect: "Jawin'", Effect Duration: 16, Last Available: "2020-09"
@@ -5255,8 +5255,8 @@
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
-5355	cyan pulsating Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
-5356	upside-down skewed A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
+5355	pulsating cyan Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+5356	skewed upside-down A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	twirling Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 5359	narrow Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
@@ -5268,7 +5268,7 @@
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 5366	CRIMBCO Employee Handbook (chapter 5) (used)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 5367	Field Guide to Skeletal Anatomy (shredded)	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
-5368	squat mirror Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
+5368	mirror squat Ellsbury's journal (used)	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 5369	dog trainer's KoL Con 8-Bit power bracelet	0		Experience (familiar): +1, Last Available: "2011-09"
 5370	spinning boiler	0		
 5371	stuffed-shirt scarecrow	0		Free Pull, Last Available: "2011-11"
@@ -5284,7 +5284,7 @@
 5381	twirling bananagate	0		Last Available: "2011-11"
 5382	pearidot	0		Last Available: "2011-11"
 5383	twirling tourmalime	0		Last Available: "2011-11"
-5384	yellow skewed kumquartz	0		Last Available: "2011-11"
+5384	skewed yellow kumquartz	0		Last Available: "2011-11"
 5385	strawberyl	0		Last Available: "2011-11"
 5386	MacGyver's ridiculous belt	0		Maximum MP: +100, Last Available: "2011-11"
 5387	Jack Frost's ridiculous earring	0		Cold Spell Damage: +50, Last Available: "2011-11"
@@ -5306,12 +5306,12 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	foul-smelling Van der Graaf padded cane-mail shirt	0		Damage Absorption: +20, Stench Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-12"
-5406	quilted wicked cane-mail pants of wisdom	0		Mysticality: +15, Spell Damage: +5, Damage Absorption: +40, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	weak lousy narrow Vodka Matryoshka	2	decent	Last Available: "2011-12"
+5406	quilted wicked cane-mail pants of wisdom	0		Mysticality: +15, Spell Damage: +5, Damage Absorption: +40, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5407	lousy weak narrow Vodka Matryoshka	2	decent	Last Available: "2011-12"
 5408	aged Gin Mint	4	awesome	Last Available: "2011-12"
-5409	smooth teal pulsating Tequiz Navidad	3	awesome	Last Available: "2011-12"
+5409	smooth pulsating teal Tequiz Navidad	3	awesome	Last Available: "2011-12"
 5410	extra-dry lousy spinning Mint Yulep	5	decent	Last Available: "2011-12"
-5411	perfectly mixed pulsating skewed Crimbojito	3	EPIC	Last Available: "2011-12"
+5411	perfectly mixed skewed pulsating Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	perfectly mixed Sangria de Menthe	4	EPIC	Last Available: "2011-12"
 5413	wobbly candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	maroon kumquartz ring of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2011-11"
 5425	stanky strawberyl necklace	0		Stench Spell Damage: +25, Single Equip, Last Available: "2011-11"
 5426	twirling avaricious Tesla sucker bucket	0		Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-11"
-5427	mirror chilly sucker hakama	0		Cold Damage: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	tumbling resourceful sucker kabuto	0		Maximum MP: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	mirror chilly sucker hakama	0		Cold Damage: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	tumbling resourceful sucker kabuto	0		Maximum MP: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	narrow Temple Grandin's sucker tachi	0		Familiar Weight: +7, Last Available: "2011-11"
 5430	blinking sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5341,7 +5341,7 @@
 5438	liquefied fluid of fudge-finding	0		Effect: "Hairless and Airless", Effect Duration: 67, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	tiny normal huge fudgesicle	1	good	Last Available: "2011-11"
-5441	twirling mirror wand of fudge control	0		Last Available: "2011-11"
+5441	mirror twirling wand of fudge control	0		Last Available: "2011-11"
 5442	ghostly red The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	upside-down miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	corrupted super-moist devilish folio	0		Effect: "Sensation", Effect Duration: 24, Last Available: "2012-12"
@@ -5363,7 +5363,7 @@
 5460	blinking executive smooth fudgecycle of courage	0		Moxie: +15, Spooky Resistance: +3, Meat Drop: +40, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	lime green Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	lime green Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	cold-filtered activated twirling gray resolution: be wealthier	0		Effect: "You Know Who to Call", Effect Duration: 19, Last Available: "2012-01"
 5465	polymerized quadruple-nitrogenated blinking blinking resolution: be happier	0		Effect: "Feet of Watermelon", Effect Duration: 57, Last Available: "2012-01"
 5466	ionized wobbly resolution: be stronger	0		Effect: "A Few Extra Pounds", Effect Duration: 54, Last Available: "2012-01"
@@ -5384,7 +5384,7 @@
 5481	decent gummi bear	3	good	Last Available: "2011-11"
 5482	flavorless upside-down drunki-bear	3	decent	Last Available: "2011-11"
 5483	normal drunki-bear	3	good	Last Available: "2011-11"
-5484	stale miniature blurry drunki-bear	2	decent	Last Available: "2011-11"
+5484	miniature stale blurry drunki-bear	2	decent	Last Available: "2011-11"
 5485	padded gummi bowtie	0		Damage Absorption: +20, Last Available: "2011-11"
 5486	bouncing fudge pocket square of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2011-11"
 5487	upside-down prompt lollipop cufflinks	0		Adventures: +3, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	magnetized oxidized gummi belemnite	0		Effect: "Preemptive Medicine", Effect Duration: 23, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	green toasty Big Candy's tophat of Flo-Jo	0		Hot Damage: +5, Initiative: +100, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	green toasty Big Candy's tophat of Flo-Jo	0		Hot Damage: +5, Initiative: +100, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5407,7 +5407,7 @@
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	rotten narrow jerky coins	4	crappy	Last Available: "2011-11"
-5507	drinkable practically non-alcoholic squat Go-Wassail	1	good	Last Available: "2011-11"
+5507	practically non-alcoholic drinkable squat Go-Wassail	1	good	Last Available: "2011-11"
 5508	quadruple-cold-filtered boiled adjusted Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Ironclad", Effect Duration: 24, Last Available: "2011-11"
 5509	cold-filtered frozen tumbling bottle of bubbles	0		Effect: "Saucefingers", Effect Duration: 28, Last Available: "2011-11"
 5510	adjusted double-denatured upside-down wind-up meatcar	0		Effect: "Enraged", Effect Duration: 13, Last Available: "2011-11"
@@ -5427,14 +5427,14 @@
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
 5525	pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	magnetized ghostly Atomic Pop	0		Effect: "Heart of White", Effect Duration: 54, Last Available: "2020-09"
-5527	spinning ghostly do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
+5527	ghostly spinning do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	ghostly whimpering willow bark	0		Last Available: "2012-12"
-5529	adequate snack-sized berries of suffering	2	good	Last Available: "2012-12"
+5529	snack-sized adequate berries of suffering	2	good	Last Available: "2012-12"
 5530	extra-galvanized improved spinning baobab sap	0		Effect: "Frostbeard", Effect Duration: 51, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	corrupted Mortimer's nostrum	0		Effect: "Goldentongue", Effect Duration: 45, Last Available: "2012-12"
-5534	lousy huge upside-down Barulio's bottle	4	decent	Last Available: "2012-12"
+5534	lousy upside-down huge Barulio's bottle	4	decent	Last Available: "2012-12"
 5535	modified dry frozen Marvin's marvelous pill	0		Effect: "Dancing Prowess", Effect Duration: 49, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	upside-down prose pen	0		Last Available: "2012-12"
@@ -5445,7 +5445,7 @@
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	blinking extremely unsafe Leapin' Trousers	0		Weapon Damage Percent: +100, Item Drop: +5
 5544	drinkable strong gray jittery eggnog	5	good	Last Available: "2012-12"
-5545	huge stale hamhock	10	decent	Last Available: "2012-12"
+5545	stale huge hamhock	10	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5459,14 +5459,14 @@
 5556	yellow shaking crafty slick Rain-Doh wings	0		Moxie: +10, Maximum MP: +10, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	auspicious Rain-Doh laser gun of the pedagogue	0		Experience: +3, Item Drop: +10, Softcore Only, Last Available: "2012-02"
-5559	twirling tumbling ruddy Rain-Doh lantern of the cheetah	0		Maximum HP Percent: +40, Initiative: +60, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	twirling tumbling ruddy Rain-Doh lantern of the cheetah	0		Maximum HP Percent: +40, Initiative: +60, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	mirror Rain-Doh balls	0		Last Available: "2012-02"
 5561	skewed Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	frosty Tesla Rain-Doh violet bo	0		Cold Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2012-02"
 5563	cyan Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	bland PB&BP	4	decent	
-5566	bland immense blue club sandwich	10	decent	
+5566	immense bland blue club sandwich	10	decent	
 5567	normal corned-beef Reuben	3	good	
 5568	frayed ninja rope	0		
 5569	jittery dull ninja crampons	0		
@@ -5480,12 +5480,12 @@
 5577	lousy Slippery Knob	3	decent	Last Available: "2012-03"
 5578	artisanal Flaming Knob	3	EPIC	Last Available: "2012-03"
 5579	lousy Grasshopper	3	decent	Last Available: "2012-03"
-5580	enchanted drinkable Locust	3	good	Effect: "Loco Motives", Effect Duration: 45, Last Available: "2012-03"
+5580	drinkable enchanted Locust	3	good	Effect: "Loco Motives", Effect Duration: 45, Last Available: "2012-03"
 5581	practically non-alcoholic hand-crafted Plague of Locusts	1	super ultra EPIC	Last Available: "2012-03"
 5582	triple-distilled mediocre Red Dwarf	6	decent	Last Available: "2012-03"
 5583	lousy Golden Mean	4	decent	Last Available: "2012-03"
-5584	watered-down bad fuchsia huge Green Giant	2	decent	Last Available: "2012-03"
-5585	boozy acceptable Aye Aye	5	good	Last Available: "2012-03"
+5584	watered-down bad huge fuchsia Green Giant	2	decent	Last Available: "2012-03"
+5585	acceptable boozy Aye Aye	5	good	Last Available: "2012-03"
 5586	artisanal twirling Aye Aye, Captain	4	EPIC	Last Available: "2012-03"
 5587	lousy ghostly blurry Aye Aye, Tooth Tooth	4	decent	Last Available: "2012-03"
 5588	aged watered-down Humanitini	2	awesome	Last Available: "2012-03"
@@ -5495,67 +5495,67 @@
 5592	bad Fuzzy Tentacle	4	decent	Last Available: "2012-03"
 5593	drinkable Crazymaker	3	good	Last Available: "2012-03"
 5594	triple-distilled bad maroon Zoodriver	10	decent	Last Available: "2012-03"
-5595	fortified perfectly mixed Sloe Comfortable Zoo	5	EPIC	Last Available: "2012-03"
-5596	weak delicious yellow Sloe Comfortable Zoo on Fire	2	awesome	Last Available: "2012-03"
+5595	perfectly mixed fortified Sloe Comfortable Zoo	5	EPIC	Last Available: "2012-03"
+5596	delicious weak yellow Sloe Comfortable Zoo on Fire	2	awesome	Last Available: "2012-03"
 5597	artisanal irresponsibly strong narrow Suffering Sinner	8	EPIC	Last Available: "2012-03"
-5598	distilled artisanal gray huge Suppurating Sinner	5	EPIC	Last Available: "2012-03"
-5599	lousy triple-distilled Sizzling Sinner	6	decent	Last Available: "2012-03"
-5600	special spirit-forward drinkable Firewater	5	good	Effect: "Spring Training", Effect Duration: 25, Last Available: "2012-03"
+5598	artisanal distilled gray huge Suppurating Sinner	5	EPIC	Last Available: "2012-03"
+5599	triple-distilled lousy Sizzling Sinner	6	decent	Last Available: "2012-03"
+5600	special drinkable spirit-forward Firewater	5	good	Effect: "Spring Training", Effect Duration: 25, Last Available: "2012-03"
 5601	acceptable bouncing Earth and Firewater	4	good	Last Available: "2012-03"
-5602	bad weak green Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
+5602	weak bad green Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
 5603	acceptable Slimosa	4	good	Last Available: "2012-03"
-5604	practically non-alcoholic hand-crafted Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
-5605	artisanal squat blinking Slimebite	4	EPIC	Last Available: "2012-03"
+5604	hand-crafted practically non-alcoholic Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
+5605	artisanal blinking squat Slimebite	4	EPIC	Last Available: "2012-03"
 5606	acceptable Cement Mixer	3	good	Last Available: "2012-03"
-5607	bad watered-down lime green narrow twirling Jackhammer	2	decent	Last Available: "2012-03"
-5608	artisanal watered-down Dump Truck	2	EPIC	Last Available: "2012-03"
+5607	bad watered-down lime green twirling narrow Jackhammer	2	decent	Last Available: "2012-03"
+5608	watered-down artisanal Dump Truck	2	EPIC	Last Available: "2012-03"
 5609	smooth blinking Fauna Libre	4	awesome	Last Available: "2012-03"
 5610	drinkable weak Chakra Libre	2	good	Last Available: "2012-03"
-5611	lousy watered-down Aura Libre	2	decent	Last Available: "2012-03"
-5612	distilled tolerable blurry purple Sazerorc	5	good	Last Available: "2012-03"
+5611	watered-down lousy Aura Libre	2	decent	Last Available: "2012-03"
+5612	tolerable distilled purple blurry Sazerorc	5	good	Last Available: "2012-03"
 5613	drinkable watered-down Sazuruk-hai	2	good	Last Available: "2012-03"
-5614	enchanted delicious Flaming Sazerorc	3	awesome	Effect: "Tightly-Wound Spine", Effect Duration: 5, Last Available: "2012-03"
+5614	delicious enchanted Flaming Sazerorc	3	awesome	Effect: "Tightly-Wound Spine", Effect Duration: 5, Last Available: "2012-03"
 5615	perfectly mixed fortified Green Velvet	5	EPIC	Last Available: "2012-03"
-5616	watered-down mediocre Green Muslin	2	decent	Last Available: "2012-03"
+5616	mediocre watered-down Green Muslin	2	decent	Last Available: "2012-03"
 5617	artisanal Green Burlap	4	EPIC	Last Available: "2012-03"
 5618	mediocre weak blinking Mohobo	2	decent	Last Available: "2012-03"
 5619	artisanal weak Moonshine Mohobo	2	EPIC	Last Available: "2012-03"
 5620	acceptable Flaming Mohobo	3	good	Last Available: "2012-03"
 5621	strong artisanal tumbling Drunken Philosopher	5	EPIC	Last Available: "2012-03"
 5622	hand-crafted Drunken Neurologist	4	EPIC	Last Available: "2012-03"
-5623	bad weak Drunken Astrophysicist	2	decent	Last Available: "2012-03"
+5623	weak bad Drunken Astrophysicist	2	decent	Last Available: "2012-03"
 5624	distilled perfectly mixed Dark & Starry	5	EPIC	Last Available: "2012-03"
 5625	tolerable Black Hole	4	good	Last Available: "2012-03"
 5626	tolerable tumbling Event Horizon	3	good	Last Available: "2012-03"
 5627	aged practically non-alcoholic blue Herring Daiquiri	1	awesome	Last Available: "2012-03"
 5628	drinkable watered-down Herring Wallbanger	2	good	Last Available: "2012-03"
 5629	irresponsibly strong acceptable Herringtini	8	good	Last Available: "2012-03"
-5630	watered-down acceptable Lollipop Drop	2	good	Last Available: "2012-03"
+5630	acceptable watered-down Lollipop Drop	2	good	Last Available: "2012-03"
 5631	lousy practically non-alcoholic Candy Alexander	1	decent	Last Available: "2012-03"
-5632	watered-down drinkable Candicaine	2	good	Last Available: "2012-03"
+5632	drinkable watered-down Candicaine	2	good	Last Available: "2012-03"
 5633	mediocre fancy wobbly Caipiranha	4	decent	Effect: "Spooky Jellied", Effect Duration: 45, Last Available: "2012-03"
-5634	drinkable watered-down pulsating Flying Caipiranha	2	good	Last Available: "2012-03"
+5634	watered-down drinkable pulsating Flying Caipiranha	2	good	Last Available: "2012-03"
 5635	bad Flaming Caipiranha	3	decent	Last Available: "2012-03"
-5636	delicious weak Punchplanter	2	awesome	Last Available: "2012-03"
+5636	weak delicious Punchplanter	2	awesome	Last Available: "2012-03"
 5637	aged Doublepunchplanter	3	awesome	Last Available: "2012-03"
-5638	drinkable special olive Haymaker	4	good	Effect: "Strong Grip", Effect Duration: 25, Last Available: "2012-03"
+5638	special drinkable olive Haymaker	4	good	Effect: "Strong Grip", Effect Duration: 25, Last Available: "2012-03"
 5639	gray Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	huge crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	half-sized adequate teal fungus	2	good	
+5641	adequate half-sized teal fungus	2	good	
 5642	narrow poisoned dart	0		
 5643	deionized purple stone wool	0		Effect: "Disco Concentration", Effect Duration: 36
 5644	skewed stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	upside-down calendar of courage	0		Spooky Resistance: +3, Damage Reduction: 4
-5648	red bouncing Samson's groovy Boris's Helm	0		Moxie Percent: +10, Experience (Muscle): +5, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	red bouncing Samson's groovy Boris's Helm	0		Moxie Percent: +10, Experience (Muscle): +5, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	auspicious staph of homophones of the scaredy-cat	0		Monster Level: -15, Item Drop: +10
-5650	blurry prompt resourceful beefy Boris's Helm (askew)	0		Muscle: +10, Maximum MP: +50, Adventures: +3, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	blurry prompt resourceful beefy Boris's Helm (askew)	0		Muscle: +10, Maximum MP: +50, Adventures: +3, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	adequate blue nailswurst	3	good	
-5655	spirit-forward acceptable huge used beer	5	good	
+5655	acceptable spirit-forward huge used beer	5	good	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	green slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5577,9 +5577,9 @@
 5674	&quot;L&quot;	0		
 5675	compressed wobbly watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	fuchsia huge forbidden Ze&trade; goggles	0		Spell Damage Percent: +50, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	fuchsia huge forbidden Ze&trade; goggles	0		Spell Damage Percent: +50, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	tumbling soggy used band-aid	0		Last Available: "2012-05"
-5679	wobbly quilted strapping stylish swimsuit	0		Muscle: +5, Damage Absorption: +40, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	wobbly quilted strapping stylish swimsuit	0		Muscle: +5, Damage Absorption: +40, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	lost key	0		Last Available: "2012-05"
 5681	rotten P.B.L.T.	3	crappy	
 5682	blinking note from Clancy	0		Skill: "Request Sandwich"
@@ -5605,27 +5605,27 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	tumbling crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	huge up-at-dawn coward's wax hat	0		Monster Level: -20, Adventures: +5, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	ghostly dance instructor's wax pants of Flo-Jo	0		Experience Percent (Moxie): +10, Initiative: +100, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	huge up-at-dawn coward's wax hat	0		Monster Level: -20, Adventures: +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	ghostly dance instructor's wax pants of Flo-Jo	0		Experience Percent (Moxie): +10, Initiative: +100, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	ionized denatured super-flattened drop of water-37	0		Effect: "Heart of Green", Effect Duration: 49, Last Available: "2012-07"
-5709	inspector's Jim Carey's fireman's helmet	0		Monster Level: +25, Item Drop: +15, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	inspector's Jim Carey's fireman's helmet	0		Monster Level: +25, Item Drop: +15, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	squat steel-toed fire axe	0		Damage Reduction: 9, Last Available: "2012-07"
 5713	upside-down avaricious gravedigger's Annie Oakley's fire extinguisher	0		Critical Hit Percent: +20, Spooky Damage: +10, Meat Drop: +30, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	huge jittery Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	mirror Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	massive stale FDKOL hotcakes	7	decent	Last Available: "2012-07"
+5717	stale massive FDKOL hotcakes	7	decent	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
-5720	big special adequate fiery wing	5	good	Effect: "Berry Defensive", Effect Duration: 30, Last Available: "2012-07"
+5720	adequate big special fiery wing	5	good	Effect: "Berry Defensive", Effect Duration: 30, Last Available: "2012-07"
 5721	lightning-fast boxer's wings of fire	0		Muscle Percent: +10, Initiative: +40, Last Available: "2012-07"
 5722	rosewater-soaked FDKOL fire hose	0		Stench Resistance: +3, Last Available: "2012-07"
 5723	quadruple-altered ionized bottle of fire	0		Effect: "Disco Inferno", Effect Duration: 61, Last Available: "2012-07"
 5724	yellow molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	lime green grievous personal trainer's hot daub bun	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	fuchsia quilted smartaleck's hot daub stand	0		Moxie Percent: +30, Damage Absorption: +40, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	lime green grievous personal trainer's hot daub bun	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +50, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	fuchsia quilted smartaleck's hot daub stand	0		Moxie Percent: +30, Damage Absorption: +40, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	blinking double-paned foot-long hot daub of the early riser	0		Cold Resistance: +5, Adventures: +7, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	spoiled mirror angst burger	3	crappy	
@@ -5633,7 +5633,7 @@
 5732	olive blank note	0		
 5733	eerily silent box	0		
 5734	thick yummy forbidden sausage	5	awesome	
-5735	ghostly stanky Lord Flameface's cloak	0		Stench Spell Damage: +25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5735	ghostly stanky Lord Flameface's cloak	0		Stench Spell Damage: +25, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	triple-corrupted anodized Drizzlers&trade; Black Licorice	0		Effect: "Marinated", Effect Duration: 13
 5737	ionized blue daub-breaker	0		Effect: "Mer-kinny Flavor", Effect Duration: 37, Last Available: "2020-09"
 5738	Camp Scout backpack of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Last Available: "2012-07"
@@ -5653,8 +5653,8 @@
 5752	stale crappy brain	3	decent	
 5753	stale spinning red decent brain	4	decent	
 5754	spoiled good brain	3	crappy	
-5755	enchanted toothsome squat boss brain	3	awesome	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 10
-5756	decent small twirling maroon hunter brain	2	good	
+5755	toothsome enchanted squat boss brain	3	awesome	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 10
+5756	small decent twirling maroon hunter brain	2	good	
 5758	blinking sizzling Staff of Holiday Sensations of the wise owl of the detective	0		Mysticality: +20, Hot Damage: +10, Item Drop: +20, Last Available: "2011-11"
 5759	mansplainer's staff of James Dean	0		Experience (Moxie): +3, Monster Level: +15
 5760	resourceful educational staff of the blizzard	0		Experience: +1, Maximum MP: +50, Cold Spell Damage: +25
@@ -5665,11 +5665,11 @@
 5765	double-paned MacGyver's fuzzy earmuffs	0		Maximum MP: +100, Cold Resistance: +5, Familiar Effect: "1.5xVolley, cap 32"
 5766	Sherlock's padded fuzzy montera of the glutton	0		Damage Absorption: +20, Item Drop: +25, Food Drop: +100, Familiar Effect: "1.5xVolley, cap 32"
 5767	red Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	blinking Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5677,18 +5677,18 @@
 5778	massive decent idiot brain	8	good	
 5779	green keel-haulin' knife of the ox	0		Muscle: +20
 5780	Jim Carey's ice cream scoop	0		Monster Level: +25
-5781	mediocre watered-down ghostly soft echo eyedrop antidote martini	2	decent	
+5781	watered-down mediocre ghostly soft echo eyedrop antidote martini	2	decent	
 5782	twirling morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
 5785	thick caulk	0		
 5786	hard screw	0		
 5787	messy butt joint	0		
-5788	skewed ghostly smut orc keepsake box	0		
+5788	ghostly skewed smut orc keepsake box	0		
 5789	ghostly skewed bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	squat fuchsia fireproof right bear arm of Leguizamo	0		Monster Level: +20, Hot Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	Jeselnik's therapeutic left bear arm of the ox	0		Muscle: +20, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	squat fuchsia fireproof right bear arm of Leguizamo	0		Monster Level: +20, Hot Resistance: +3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	Jeselnik's therapeutic left bear arm of the ox	0		Muscle: +20, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	Hat O' Nine Tails of terror	0		Spooky Spell Damage: +10
 5794	corrupted improved wobbly shaking Enchanted Plunger	0		Effect: "Amplified Fabulousness", Effect Duration: 50
 5795	corrupted enhanced twirling Enchanted Flyswatter	0		Effect: "Ichorous Eyesight", Effect Duration: 42
@@ -5712,13 +5712,13 @@
 5813	super-chilled squat smut orc sunglasses	0		Effect: "Analog Drunk", Effect Duration: 37
 5814	modified liquefied spinning blob of acid	0		Effect: "Wings of the Grasshopper", Effect Duration: 58
 5815	adjusted skewed spinning flayed mind	0		Effect: "Eyes All Black", Effect Duration: 64
-5816	ionized pressed wobbly cyan kobold kibble	0		Effect: "Heart of Yellow", Effect Duration: 20
+5816	ionized pressed cyan wobbly kobold kibble	0		Effect: "Heart of Yellow", Effect Duration: 20
 5817	extra-dry alkaline irradiated forest spirit rattle	0		Effect: "Mercenary", Effect Duration: 22
 5818	dry fuchsia Stone Golem pebbles	0		Effect: "Disdain of the War Snapper", Effect Duration: 66
 5819	magnetized liquefied skewed spinning gravy fairy warlock hat	0		Effect: "Conspiratory Eyes", Effect Duration: 46
 5820	polymerized colloidal bull blubber	0		Effect: "Magically Delicious", Effect Duration: 49
 5821	vacuum-sealed anodized gray frog lip-print	0		Effect: "Egg-stra Arm", Effect Duration: 24
-5822	dry frozen pulsating shaking gazely stare	0		Effect: "Coming Up Roses", Effect Duration: 39
+5822	dry frozen shaking pulsating gazely stare	0		Effect: "Coming Up Roses", Effect Duration: 39
 5823	liquefied extra-boiled bouncing canopic jar	0		Effect: "Graham Crackling", Effect Duration: 17
 5824	nitrogenated vacuum-sealed denatured clove-flavored lip balm	0		Effect: "Strange Mental Acuity", Effect Duration: 21
 5825	vacuum-sealed mirror Skullery Maid's Knee	0		Effect: "Thunderheart", Effect Duration: 24
@@ -5727,21 +5727,21 @@
 5828	Vulcanized pulsating gilt perfume bottle	0		Effect: "Pumped Up", Effect Duration: 35
 5829	altered mirror janglin' bones	0		Effect: "Less Pervious", Effect Duration: 24
 5830	flattened pygmy papers	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 43
-5831	altered wobbly maroon pygmy dart	0		Effect: "Thick, Sick", Effect Duration: 30
+5831	altered maroon wobbly pygmy dart	0		Effect: "Thick, Sick", Effect Duration: 30
 5832	warmed secret mummy herbs and spices	0		Effect: "Partially Ghosted", Effect Duration: 12
 5833	non-unsweetened vacuum-sealed blinking brigand brittle	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 13
-5834	extra-ionized enhanced twirling maroon holistic headache remedy	0		Effect: "Robocamo", Effect Duration: 15
+5834	extra-ionized enhanced maroon twirling holistic headache remedy	0		Effect: "Robocamo", Effect Duration: 15
 5835	activated scrunchie tourniquet	0		Effect: "Empty Inside", Effect Duration: 46
 5836	flattened irradiated embezzler's oil	0		Effect: "Army of One", Effect Duration: 52
 5837	extra-quantum blue Fu Manchu Wax	0		Effect: "Bored Stiff", Effect Duration: 20
-5838	polarized narrow mirror Iiti Kitty Gumdrop	0		Effect: "Bored Stiff", Effect Duration: 60
+5838	polarized mirror narrow Iiti Kitty Gumdrop	0		Effect: "Bored Stiff", Effect Duration: 60
 5839	denatured extra-diffused ravenous eye	0		Effect: "Resilient Spirit", Effect Duration: 12
 5840	triple-dry enhanced narrow Rogue Windmill Rouge	0		Effect: "Serenity", Effect Duration: 17
 5841	dry enhanced tumbling A muse-bouche	0		Effect: "Tomato Power", Effect Duration: 43
 5842	extra-flattened adjusted toothbrush	0		Effect: "All Is Forgiven", Effect Duration: 66
-5843	non-adjusted squat ghostly pirate cream pie	0		Effect: "Memory of Speed", Effect Duration: 44
+5843	non-adjusted ghostly squat pirate cream pie	0		Effect: "Memory of Speed", Effect Duration: 44
 5844	boiled deionized cyan una poca de gracia	0		Effect: "Ginger Snapped", Effect Duration: 23
-5845	ionized narrow twirling compressed air canister	0		Effect: "Dweeby", Effect Duration: 48
+5845	ionized twirling narrow compressed air canister	0		Effect: "Dweeby", Effect Duration: 48
 5846	corrupted concentrated salt water taffy	0		Effect: "Hella Smooth", Effect Duration: 62
 5847	galvanized ionized unholy water	0		Effect: "Broken Fast", Effect Duration: 36
 5848	quadruple-warmed ionized Bangyomaman battle juice	0		Effect: "Castaway Physique", Effect Duration: 22
@@ -5752,13 +5752,13 @@
 5853	extra-energized jittery stick-on gnome beard	0		Effect: "Milk Studly", Effect Duration: 30
 5854	anodized upside-down BRICKO stud	0		Effect: "Heart of Lavender", Effect Duration: 38
 5855	tarnished Osk'r Chow	0		Effect: "Bestial Sympathy", Effect Duration: 59
-5856	triple-tarnished oxidized huge blurry lime green Scuba Snack	0		Effect: "Strong Grip", Effect Duration: 44
+5856	triple-tarnished oxidized lime green huge blurry Scuba Snack	0		Effect: "Strong Grip", Effect Duration: 44
 5857	extra-vacuum-sealed polarized grey cube	0		Effect: "Ticking Clock", Effect Duration: 23
-5858	non-oxidized energized jittery purple votive candle	0		Effect: "The Power of Negative Thinking", Effect Duration: 26
+5858	non-oxidized energized purple jittery votive candle	0		Effect: "The Power of Negative Thinking", Effect Duration: 26
 5859	non-moist extra-vacuum-sealed teal booby trap	0		Effect: "Hair on Your Chest", Effect Duration: 29
 5860	energized jittery Agent Corrigan's cigarette	0		Effect: "Elemental Saucesphere", Effect Duration: 28
 5861	alkaline nitrogenated aerosolized squat good ash	0		Effect: "The Grass...  Is Blue...", Effect Duration: 11
-5862	Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	polymerized cold-filtered deionized papier-mochi	0		Effect: "Took Eleven", Effect Duration: 64, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	narrow hardened papier-m&acirc;ch&eacute;te of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Last Available: "2012-09"
 5869	shaking Herculean papier-m&acirc;chine gun of the bloodbag	0		Experience (Muscle): +1, Maximum HP: +100, Last Available: "2012-09"
 5870	jittery flame-retardant papier-masque of the dark arts	0		Spell Damage Percent: +100, Hot Resistance: +1, Single Equip, Last Available: "2012-09"
-5871	prompt deadly papier-mitre	0		Weapon Damage: +5, Adventures: +3, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	blinking greasy papier-m&acirc;churidars of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +10, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	prompt deadly papier-mitre	0		Weapon Damage: +5, Adventures: +3, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	blinking greasy papier-m&acirc;churidars of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +10, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5810,7 +5810,7 @@
 5912	reassuring mansplainer's Solstice Shield	0		Monster Level: +15, Spooky Resistance: +1
 5913	pickled corrupted mirror candy sushi set	0		Effect: "Muscle Unbound", Effect Duration: 34, Last Available: "2012-12"
 5914	nitrogenated quantum sweet mochi ball	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 34, Last Available: "2012-12"
-5915	liquefied non-Vulcanized blurry bouncing beet-flavored Mr. Mediocrebar	0		Effect: "Sticks and Stones", Effect Duration: 46, Last Available: "2012-12"
+5915	liquefied non-Vulcanized bouncing blurry beet-flavored Mr. Mediocrebar	0		Effect: "Sticks and Stones", Effect Duration: 46, Last Available: "2012-12"
 5916	ionized sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 19, Last Available: "2012-12"
 5917	cold-filtered anodized cabbage-flavored Mr. Mediocrebar	0		Effect: "World's Shortest Giant", Effect Duration: 56, Last Available: "2012-12"
 5918	plastic animelf of horror	0		Spooky Spell Damage: +25, Last Available: "2012-12"
@@ -5820,10 +5820,10 @@
 5922	nasty plastic MechaElf	0		Stench Damage: +5, Last Available: "2012-12"
 5923	jittery plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
-5925	spinning twirling ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
+5925	twirling spinning ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	deadly brainwave-controlled unicorn horn	0		Weapon Damage: +5, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	deadly brainwave-controlled unicorn horn	0		Weapon Damage: +5, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	upside-down blind-packed capsule toy	0		Last Available: "2012-12"
 5931	sage smooth plastic four-shadowed mime of incineration	0		Moxie: +15, Mysticality Percent: +10, Hot Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	blinking double-paned plastic Father McGruber	0		Cold Resistance: +5, Last Available: "2012-12"
 5961	Samson's plastic Hank North, Photojournalist	0		Experience (Muscle): +5, Last Available: "2012-12"
 5962	flame-wreathed plastic blazing bat	0		Hot Spell Damage: +10, Last Available: "2012-12"
-5963	greasy lion tamer's electronic dulcimer pants	0		Experience (familiar): +2, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	greasy lion tamer's electronic dulcimer pants	0		Experience (familiar): +2, Sleaze Spell Damage: +10, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	shaking A-Boo clue	0		
 5965	blurry chaotic clever Frown Exerciser	0		Maximum MP: +20, Spell Critical Percent: +10, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5873,35 +5873,35 @@
 5975	wobbly record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	lime green record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	flame-retardant hardened silent beret of the ox	0		Muscle: +20, Damage Reduction: 3, Hot Resistance: +1, Familiar Effect: "1xVolley, cap 3"
-5978	stale fancy slice of pizza	4	decent	Effect: "Nas Tea", Effect Duration: 50, Last Available: "2013-02"
+5978	fancy stale slice of pizza	4	decent	Effect: "Nas Tea", Effect Duration: 50, Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	bad tumbling tankard of ale	4	decent	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	reassuring resourceful Socratic cloth cap	0		Experience (Mysticality): +1, Maximum MP: +50, Spooky Resistance: +1, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	reassuring resourceful Socratic cloth cap	0		Experience (Mysticality): +1, Maximum MP: +50, Spooky Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	skewed beefy iron dagger of Gandalf of the early riser	0		Muscle: +10, Spell Critical Percent: +20, Adventures: +7, Last Available: "2013-02"
 5986	adequate green hamburger	4	good	Last Available: "2013-02"
 5987	purple pulsating dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	triple-distilled tolerable bottle of wine	7	good	Last Available: "2013-02"
+5990	tolerable triple-distilled bottle of wine	7	good	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	fuchsia lightning-fast avaricious Socratic iron helmet	0		Experience (Mysticality): +1, Meat Drop: +30, Initiative: +40, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	fuchsia lightning-fast avaricious Socratic iron helmet	0		Experience (Mysticality): +1, Meat Drop: +30, Initiative: +40, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	executive ribald beefcake's steel sword	0		Muscle: +25, Sleaze Damage: +10, Meat Drop: +40, Last Available: "2013-02"
-5994	gigantic bland upside-down narrow green whole roasted chicken	6	decent	Last Available: "2013-02"
+5994	gigantic bland upside-down green narrow whole roasted chicken	6	decent	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	perfectly mixed strong bouncing shining goblet	5	EPIC	Last Available: "2013-02"
+5998	strong perfectly mixed bouncing shining goblet	5	EPIC	Last Available: "2013-02"
 5999	wobbly bouncing fireball	0		Last Available: "2013-02"
-6000	spinning upside-down frightening Oprah's crown of the wise owl	0		Mysticality: +20, Maximum MP Percent: +50, Spooky Damage: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	spinning upside-down frightening Oprah's crown of the wise owl	0		Mysticality: +20, Maximum MP Percent: +50, Spooky Damage: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	pulsating blinking purple gravedigger's MacGyver's sword of the sweet-tooth	0		Maximum MP: +100, Spooky Damage: +10, Candy Drop: +100, Last Available: "2013-02"
-6002	healthy educational cool Helm of the Scream Emperor	0		Moxie: +5, Experience: +1, Maximum HP Percent: +20, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	healthy educational cool Helm of the Scream Emperor	0		Moxie: +5, Experience: +1, Maximum HP Percent: +20, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	Sherlock's brawny beefcake's Cloak of Dire Shadows	0		Muscle: +25, Muscle Percent: +20, Item Drop: +25, Last Available: "2013-02"
 6004	narrow wobbly stanky scorching rock-hard Sword of Dark Omens	0		Damage Reduction: 5, Hot Damage: +25, Stench Spell Damage: +25, Last Available: "2013-02"
 6005	scorching wholesome Shield of Icy Fate of the cheetah	0		Maximum HP Percent: +10, Hot Damage: +25, Initiative: +60, Damage Reduction: 7, Last Available: "2013-02"
-6006	jittery Temple Grandin's crafty strapping Greaves of the Murk Lord	0		Muscle: +5, Maximum MP: +10, Familiar Weight: +7, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	jittery Temple Grandin's crafty strapping Greaves of the Murk Lord	0		Muscle: +5, Maximum MP: +10, Familiar Weight: +7, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	lard-coated crafty smooth Gauntlets of the Blood Moon	0		Moxie: +15, Maximum MP: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2013-02"
 6008	personal trainer's Boots of Twilight Whispers of the sewer of bravery	0		Experience Percent (Muscle): +10, Stench Damage: +25, Spooky Resistance: +5, Single Equip, Last Available: "2013-02"
 6009	twirling quilted personal trainer's brawny Belt of Howling Anger	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Damage Absorption: +40, Single Equip, Last Available: "2013-02"
@@ -5923,7 +5923,7 @@
 6025	moist aerosolized green ghostly Polysniff Perfume	0		Effect: "Improprie Tea", Effect Duration: 23
 6026	Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
-6028	blinking bouncing green Battlie Light Saver	0		
+6028	green blinking bouncing Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	dress pants of doom	0		Spooky Spell Damage: +50, Familiar Effect: "2xFairy, cap 28"
 6031	badge of authority of bravery	0		Spooky Resistance: +5, Single Equip
@@ -5949,9 +5949,9 @@
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	decent gigantic pulsating Taco Dan's Taco Stand Taco	6	good	Last Available: "2012-12"
 6053	tolerable Taco Dan's Taco Stand Chimichangarita	3	good	Last Available: "2012-12"
-6054	ionized chilled squat gray Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Kissed By Fire", Effect Duration: 32, Last Available: "2012-12"
+6054	ionized chilled gray squat Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Kissed By Fire", Effect Duration: 32, Last Available: "2012-12"
 6055	twirling psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	narrow Meatcleaver of extreme caution of the sweet-tooth	0		Monster Level: -25, Candy Drop: +100, Last Available: "2013-12"
 6058	nasty Crimbo Elf bobble-head	0		Stench Damage: +5, Last Available: "2012-12"
 6059	resourceful Crimbo stogie-scented room odorizer	0		Maximum MP: +50, Last Available: "2012-12"
@@ -5966,17 +5966,17 @@
 6068	loose blade	0		
 6069	goblin bone hilt	0		
 6070	ghostly sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	nitrogenated aerosolized haggis-infused soap	0		Effect: "A Taste of Rainbow", Effect Duration: 51, Last Available: "2012-12"
 6074	frozen magicberry tablets	0		Effect: "Sticky Hands", Effect Duration: 12, Last Available: "2012-12"
-6075	aerosolized flattened twirling ghostly 37x37x37 puzzle cube	0		Effect: "Unrunnable Face", Effect Duration: 54, Last Available: "2012-12"
-6076	artisanal practically non-alcoholic McLeod's Hard Haggis-Ade	1	EPIC	Last Available: "2012-12"
+6075	aerosolized flattened ghostly twirling 37x37x37 puzzle cube	0		Effect: "Unrunnable Face", Effect Duration: 54, Last Available: "2012-12"
+6076	practically non-alcoholic artisanal McLeod's Hard Haggis-Ade	1	EPIC	Last Available: "2012-12"
 6077	flavorless fuchsia haggis-wrapped haggis-stuffed haggis	3	decent	Last Available: "2012-12"
 6078	blurry fuchsia home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	Socratic haggis socks	0		Experience (Mysticality): +1, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	Socratic haggis socks	0		Experience (Mysticality): +1, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6008,7 +6008,7 @@
 6110	bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	jittery bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	upside-down zaibatsu lobby card	0		Last Available: "2013-12"
-6113	mirror mirror tumbling zaibatsu level 1 card	0		Last Available: "2013-12"
+6113	tumbling mirror mirror zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	jittery zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	CEO office card	0		Last Available: "2013-12"
@@ -6037,34 +6037,34 @@
 6139	spinning bouncing rubber gloves of the cougar	0		Moxie: +20, Last Available: "2013-12"
 6140	wobbly Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	snack-sized adequate fancy tumbling roasted duck	2	good	Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2013-12"
+6142	adequate snack-sized fancy tumbling roasted duck	2	good	Effect: "Glittering Eyelashes", Effect Duration: 45, Last Available: "2013-12"
 6143	decent spinning dead meat bun	3	good	Last Available: "2013-12"
 6144	brawny cat collar	0		Muscle Percent: +20, Single Equip, Last Available: "2013-12"
-6145	ghostly foul-smelling scorching suspicious-looking fedora	0		Hot Damage: +25, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	ghostly foul-smelling scorching suspicious-looking fedora	0		Hot Damage: +25, Stench Damage: +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	blue Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	blurry blinking MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	teal Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	half-sized decent carrot cake	2	good	Last Available: "2013-01"
+6152	decent half-sized carrot cake	2	good	Last Available: "2013-01"
 6153	mediocre enchanted carrot claret	3	decent	Effect: "Innately Strong", Effect Duration: 30, Last Available: "2013-01"
 6154	boiled skewed red carrot juice	1	decent	Last Available: "2013-01"
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	mirror flickering pixel	0		Last Available: "2013-12"
 6157	crafty hardy Byte	0		Maximum HP: +50, Maximum MP: +10, Last Available: "2013-12"
-6158	anger blaster of the sewer	0		Stench Damage: +25, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	jittery Temple Grandin's doubt cannon	0		Familiar Weight: +7, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	Sherlock's fear condenser	0		Item Drop: +25, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	crafty regret hose	0		Maximum MP: +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	anger blaster of the sewer	0		Stench Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	jittery Temple Grandin's doubt cannon	0		Familiar Weight: +7, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	Sherlock's fear condenser	0		Item Drop: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	crafty regret hose	0		Maximum MP: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	teal Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	tumbling Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	quilted commodore's hat of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	naval trousers of courage	0		Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	quilted commodore's hat of horror	0		Damage Absorption: +40, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	naval trousers of courage	0		Spooky Resistance: +3, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	frosty Annie Oakley's deck cannon	0		Critical Hit Percent: +20, Cold Spell Damage: +10, Last Available: "2013-12"
 6167	tumbling padded ornamental sextant	0		Damage Absorption: +20, Last Available: "2013-12"
 6168	perfumed lard-coated Bloodbath	0		Sleaze Spell Damage: +25, Stench Resistance: +5, Last Available: "2013-12"
 6169	irresponsibly strong artisanal Hundred Headed IPA	9	EPIC	Last Available: "2013-12"
-6170	low-calorie bland chum	1	decent	Last Available: "2013-12"
+6170	bland low-calorie chum	1	decent	Last Available: "2013-12"
 6171	enhanced crude crudit&eacute;s	0		Effect: "The Smeezingtons", Effect Duration: 31
 6172	diffused candy crayons	0		Effect: "Thick-Skinned", Effect Duration: 24, Last Available: "2020-09"
 6173	upside-down upside-down Socratic pixel grappling hook of James Dean	0		Experience (Mysticality): +1, Experience (Moxie): +3
@@ -6081,45 +6081,45 @@
 6184	wobbly executive knitted Newton's Jarlsberg's hat	0		Experience (Mysticality): +3, Cold Resistance: +3, Meat Drop: +40
 6185	bland small consummate hard-boiled egg	2	decent	
 6186	thick toothsome consummate fried egg	5	awesome	
-6187	moldy red tumbling consummate egg salad	3	crappy	
+6187	moldy tumbling red consummate egg salad	3	crappy	
 6188	fancy adequate pulsating consummate bagel	3	good	Effect: "Greased-Up Familiar", Effect Duration: 15
 6189	stale small consummate sliced bread	2	decent	
 6190	normal consummate hot dog bun	3	good	
-6191	half-sized stale squat consummate brownie	2	decent	
-6192	low-calorie normal consummate toast	1	good	
-6193	artisanal enchanted ghostly narrow passable stout	3	EPIC	Effect: "The Q Is Talking To You", Effect Duration: 30
+6191	stale half-sized squat consummate brownie	2	decent	
+6192	normal low-calorie consummate toast	1	good	
+6193	artisanal enchanted narrow ghostly passable stout	3	EPIC	Effect: "The Q Is Talking To You", Effect Duration: 30
 6194	normal wobbly consummate soup	4	good	
 6195	low-calorie flavorless jittery consummate corn chips	1	decent	
-6196	super-sized normal bouncing consummate salad	5	good	
+6196	normal super-sized bouncing consummate salad	5	good	
 6197	delicious maroon tumbling consummate salsa	4	awesome	
 6198	special rotten jittery consummate sauerkraut	4	crappy	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 45
-6199	miniature toothsome consummate cheese slice	2	awesome	
+6199	toothsome miniature consummate cheese slice	2	awesome	
 6200	stale consummate melted cheese	4	decent	
 6201	spoiled consummate bacon	3	crappy	
 6202	adequate consummate meatloaf	4	good	
 6203	decent consummate steak	3	good	
 6204	flavorless consummate cuts	3	decent	
 6205	flavorless consummate frankfurter	3	decent	
-6206	stale big blurry consummate french fries	5	decent	
+6206	big stale blurry consummate french fries	5	decent	
 6207	adequate consummate baked potato	4	good	
 6208	aged acceptable vodka	3	awesome	
-6209	moldy super-sized consummate ice cream	5	crappy	
+6209	super-sized moldy consummate ice cream	5	crappy	
 6210	rotten blurry consummate whipped cream	3	crappy	
 6211	moldy consummate cream	4	crappy	
 6212	flavorless blue consummate strawberries	3	decent	
 6213	spoiled jumbo consummate sorbet	5	crappy	
-6214	fancy hand-crafted adequate rum	4	EPIC	Effect: "Hot Jellied", Effect Duration: 30
+6214	hand-crafted fancy adequate rum	4	EPIC	Effect: "Hot Jellied", Effect Duration: 30
 6215	aged wobbly mediocre lager	3	awesome	
 6216	rotten immaculate grilled cheese	4	crappy	
 6217	moldy immaculate ice cream sandwich	4	crappy	
 6218	snack-sized toothsome immaculate hot dog	2	awesome	
 6219	adequate small purple immaculate egg salad sandwich	2	good	
-6220	tiny rotten perfect sandwich	1	crappy	
+6220	rotten tiny perfect sandwich	1	crappy	
 6221	moldy perfect chef salad	3	crappy	
-6222	thick stale teal perfect breakfast	5	decent	
+6222	stale thick teal perfect breakfast	5	decent	
 6223	flavorless enchanted sublime deluxe hot dog	3	decent	Effect: "Wintergreen Warmongery", Effect Duration: 15
 6224	decent sublime stew	3	good	
-6225	half-sized stale sublime nachos	2	decent	
+6225	stale half-sized sublime nachos	2	decent	
 6226	super-sized flavorless Ultimate Breakfast Sandwich	5	decent	
 6227	miniature flavorless Loaded Baked Potato	2	decent	
 6228	adequate Omega Sundae	3	good	
@@ -6128,9 +6128,9 @@
 6231	mediocre Vodka Dog	4	decent	
 6232	weak perfectly mixed Disappointed Russian	2	EPIC	
 6233	mediocre ghostly squat Chunky Mary	4	decent	
-6234	aged mirror maroon Nachojito	4	awesome	
-6235	fortified drinkable upside-down Le Roi	5	good	
-6236	artisanal enchanted huge Over Easy Rider	3	EPIC	Effect: "The Best a Pirate Can Get", Effect Duration: 25
+6234	aged maroon mirror Nachojito	4	awesome	
+6235	drinkable fortified upside-down Le Roi	5	good	
+6236	enchanted artisanal huge Over Easy Rider	3	EPIC	Effect: "The Best a Pirate Can Get", Effect Duration: 25
 6237	cosmic six-pack	0		
 6239	double-modified alkaline ghostly cube of ectoplasm	0		Effect: "One Foot Heavier", Effect Duration: 66
 6240	ionized Illuminati earpiece	0		Effect: "Ancient Protected", Effect Duration: 11
@@ -6141,7 +6141,7 @@
 6245	colloidal ASCII fu manchu	0		Effect: "Full-Body Tan", Effect Duration: 28
 6246	alkaline polarized pressed demonic surgical gloves	0		Effect: "Updated", Effect Duration: 46
 6247	enhanced deionized shaking clip-on ninja tie	0		Effect: "So Fresh and So Clean", Effect Duration: 18
-6248	extra-boiled spinning tumbling gamer slurry	0		Effect: "Beta Carotene Overdose", Effect Duration: 46
+6248	extra-boiled tumbling spinning gamer slurry	0		Effect: "Beta Carotene Overdose", Effect Duration: 46
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	frosty Van der Graaf MacGyver's supercharged smooth numberwang of wisdom	0		Mysticality: +15, Moxie: +15, Maximum MP Percent: +30, Maximum MP: +100, Cold Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 6251	deionized tumbling scroll of Protection from Bad Stuff	0		Effect: "Hella Tough", Effect Duration: 23, Last Available: "2013-02"
@@ -6167,14 +6167,14 @@
 6271	massive dumbbell	0		
 6272	skewed purple Oprah's experienced penguin keychain	0		Experience: +2, Maximum MP Percent: +50, Damage Reduction: 10
 6273	corrupted unsweetened O'RLY manual	0		Effect: "Mayeaugh", Effect Duration: 56
-6274	mediocre triple-distilled open sauce	6	decent	
+6274	triple-distilled mediocre open sauce	6	decent	
 6275	sinister dangerous turkey leg	0		Weapon Damage: +10, Spell Damage: +10
 6276	bad Ye Olde Meade	4	decent	
-6277	vacuum-sealed blinking twirling Ye Olde Bawdy Limerick	0		Effect: "Smugness", Effect Duration: 16
+6277	vacuum-sealed twirling blinking Ye Olde Bawdy Limerick	0		Effect: "Smugness", Effect Duration: 16
 6278	Ye Olde Medieval Insult	0		
 6279	lime green pewter claymore of Gandalf	0		Spell Critical Percent: +20
 6280	wobbly vibrating artisanal rice peeler	0		Maximum MP Percent: +10
-6281	big moldy heirloom grape tomato	5	crappy	
+6281	moldy big heirloom grape tomato	5	crappy	
 6282	chipotle wasabi cilantro aioli	0		
 6283	huge Lo Pan's brown felt tophat	0		Spell Critical Percent: +30, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6182,7 +6182,7 @@
 6286	olive bouncing scandalous supercharged Mark II Steam-Hat of mayonnaise	0		Maximum MP Percent: +30, Sleaze Damage: +5, Sleaze Spell Damage: +50, Familiar Effect: "1xLep, cap 37"
 6287	bouncing double-paned Annie Oakley's padded Sinatra's Mark III Steam-Hat	0		Experience (Moxie): +5, Damage Absorption: +20, Critical Hit Percent: +20, Cold Resistance: +5, Familiar Effect: "1xLep, cap 37"
 6288	chilly grievous Fonzie's experienced Mark IV Steam-Hat of doom	0		Experience: +2, Experience (Moxie): +1, Weapon Damage Percent: +50, Cold Damage: +5, Spooky Spell Damage: +50, Familiar Effect: "1xLep, cap 37"
-6289	knitted dog trainer's hardened sinister experienced Mark V Steam-Hat	0		Experience: +2, Spell Damage: +10, Damage Reduction: 3, Experience (familiar): +1, Cold Resistance: +3, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
+6289	knitted dog trainer's hardened sinister experienced Mark V Steam-Hat	0		Experience: +2, Spell Damage: +10, Damage Reduction: 3, Experience (familiar): +1, Cold Resistance: +3, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
 6290	shaking steam-powered model rocketship	0		
 6291	weightlifter's punk rock jacket of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50
 6292	flame-wreathed Jim Carey's safety pin	0		Monster Level: +25, Hot Spell Damage: +10
@@ -6240,7 +6240,7 @@
 6344	Mer-kin mouthsoap	0		
 6345	vacuum-sealed ionized ionized narrow Mer-kin strongjuice	0		Effect: "Quantum of Moxie", Effect Duration: 36
 6346	Mer-kin fitbrine	0		
-6347	ionized olive twirling Mer-kin ragejuice	0		Effect: "Heart of Lavender", Effect Duration: 68
+6347	ionized twirling olive Mer-kin ragejuice	0		Effect: "Heart of Lavender", Effect Duration: 68
 6348	teal Mer-kin dragbelt of the detective	0		Item Drop: +20, Experience (Muscle): +20, Single Equip
 6349	cool Mer-kin eyeglasses	0		Moxie: +5, Experience (Mysticality): +20, Single Equip
 6350	Mer-kin gutgirdle	0		Item Drop: +5, Experience (Moxie): +20, Single Equip
@@ -6253,7 +6253,7 @@
 6357	blinking Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	perfumed Mer-kin begsign	0		Stench Resistance: +5, Meat Drop: +40
-6360	purple Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	purple Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	enhanced bouncing pulled taffy	0		Effect: "Locks Like the Raven", Effect Duration: 33, Last Available: "2013-04"
 6362	pressed warmed pulled indigo taffy	0		Effect: "Aloofah", Effect Duration: 23, Last Available: "2013-04"
 6363	unsweetened nitrogenated pulsating blurry pulled taffy	0		Effect: "Bubblin' Rage", Effect Duration: 24, Last Available: "2013-04"
@@ -6261,12 +6261,12 @@
 6365	galvanized polymerized pulled taffy	0		Effect: "Space Tripping", Effect Duration: 21, Last Available: "2013-04"
 6366	energized pressed deionized bouncing pulled violet taffy	0		Effect: "Rotten Memories", Effect Duration: 67, Last Available: "2013-04"
 6367	wet pulled taffy	0		Effect: "Virgo Rising", Effect Duration: 53, Last Available: "2013-04"
-6368	blurry gray Mer-kin hallpass	0		
+6368	gray blurry Mer-kin hallpass	0		
 6369	green lump of clay	0		
 6370	twisted piece of wire	0		
 6371	mediocre skewed can of the cheapest beer	3	decent	
 6372	bad bottle of fruity &quot;wine&quot;	3	decent	
-6373	lousy ghostly spinning single swig of vodka	3	decent	
+6373	lousy spinning ghostly single swig of vodka	3	decent	
 6374	angry inch	0		
 6375	fireproof testy toolbox	0		Hot Resistance: +3
 6376	Jick-o-User	0		
@@ -6311,15 +6311,15 @@
 6416	stale mana curds	4	decent	
 6417	narrow twist of lime	0		
 6418	pencil stub	0		
-6419	warmed super-liquefied yellow blurry ghostly moth dust	0		Effect: "Sweet Taste", Effect Duration: 20
+6419	warmed super-liquefied blurry yellow ghostly moth dust	0		Effect: "Sweet Taste", Effect Duration: 20
 6420	concentrated blurry glob of spoiled mayo	0		Effect: "Booing Radly", Effect Duration: 29
 6421	tonic djinn	0		
-6422	jumbo rotten vampire chowder	5	crappy	
+6422	rotten jumbo vampire chowder	5	crappy	
 6423	Tales of Dread	0		Free Pull
 6424	ghostly Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	adequate Dreadsylvanian stew	4	good	
-6427	acceptable special spirit-forward Dreadsylvanian	5	good	Effect: "Blessing of Bulbazinalli", Effect Duration: 20
+6427	spirit-forward acceptable special Dreadsylvanian	5	good	Effect: "Blessing of Bulbazinalli", Effect Duration: 20
 6428	triple-warmed colloidal purple Dreadsylvanian flask	0		Effect: "Sausage Festive", Effect Duration: 54
 6429	altered irradiated Dreadsylvanian flask	0		Effect: "Weird Flavor", Effect Duration: 64
 6430	teal reassuring personal trainer's dreadful fedora	0		Experience Percent (Muscle): +10, Spooky Resistance: +1, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6338,7 +6338,7 @@
 6443	tumbling frosty educational Helps-You-Sleep	0		Experience: +1, Cold Spell Damage: +10, Single Equip
 6444	flame-retardant quilted Quiets-Your-Steps of bravery	0		Damage Absorption: +40, Hot Resistance: +1, Spooky Resistance: +5, Single Equip
 6445	steel-toed Protects-Your-Junk of the glutton	0		Damage Reduction: 9, Food Drop: +100, Single Equip
-6446	fancy lousy weak Gets-You-Drunk	2	decent	Effect: "Yuletide Industry", Effect Duration: 45
+6446	weak lousy fancy Gets-You-Drunk	2	decent	Effect: "Yuletide Industry", Effect Duration: 45
 6447	dog trainer's Newton's Great Wolf's headband of mayonnaise	0		Experience (Mysticality): +3, Experience (familiar): +1, Sleaze Spell Damage: +50, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	flame-wreathed fortified Great Wolf's left paw of incineration	0		Damage Absorption: +60, Hot Spell Damage: 60, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	knitted steel-toed padded Great Wolf's right paw	0		Damage Absorption: +20, Damage Reduction: 9, Cold Resistance: +3, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	twirling dreadful roast	0		
 6487	blinking stinking agaricus	0		
-6488	flavorless special Dreadsylvanian shepherd's pie	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 10
+6488	special flavorless Dreadsylvanian shepherd's pie	3	decent	Effect: "Disdain of the Storm Tortoise", Effect Duration: 10
 6489	music box parts	0		
 6490	wobbly unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6390,7 +6390,7 @@
 6495	baleful Dreadsylvania Auditor's badge	0		Spell Damage: +25, Kruegerand Drop: 5, Single Equip
 6496	blue blood kiwi	0		
 6497	ghostly gray eau de mort	0		
-6498	fancy perfectly mixed practically non-alcoholic skewed blinking bloody kiwitini	1	super ultra mega turbo EPIC	Effect: "Bread Burps", Effect Duration: 5
+6498	fancy practically non-alcoholic perfectly mixed skewed blinking bloody kiwitini	1	super ultra mega turbo EPIC	Effect: "Bread Burps", Effect Duration: 5
 6499	huge moon-amber	0		
 6500	shaking lime green polished moon-amber	0		
 6501	narrow asbestos-lined personal trainer's moon-amber necklace of extreme caution	0		Experience Percent (Muscle): +10, Monster Level: -25, Hot Resistance: +5, Single Equip
@@ -6408,7 +6408,7 @@
 6513	baleful warm fur	0		Spell Damage: +25
 6514	olive huge occult snowstick	0		Spell Damage Percent: +25
 6515	squat supercharged eerie fetish	0		Maximum MP Percent: +30, Single Equip
-6516	mediocre weak pulsating stinkwater	2	decent	
+6516	weak mediocre pulsating stinkwater	2	decent	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	stale accidental mutton	3	decent	
 6519	green savvy brawny drafty drawers	0		Muscle Percent: +20, Mysticality Percent: +20, Familiar Effect: "1.5xVolley"
@@ -6456,13 +6456,13 @@
 6562	upside-down mini-Mr. Accessory	0		Familiar Weight: +5
 6563	rosewater-soaked hand of Mr. Cards	0		Stench Resistance: +3, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	bland maroon Dreadsylvanian hot pocket	3	decent	
-6565	small flavorless blinking Dreadsylvanian pocket	2	decent	
-6566	normal teal squat Dreadsylvanian pocket	4	good	
+6565	flavorless small blinking Dreadsylvanian pocket	2	decent	
+6566	normal squat teal Dreadsylvanian pocket	4	good	
 6567	flavorless ghostly Dreadsylvanian stink pocket	3	decent	
 6568	stale Dreadsylvanian sleaze pocket	3	decent	
-6569	weak smooth special Dreadsylvanian hot toddy	2	awesome	Effect: "Corona de la Salsa", Effect Duration: 40
-6570	lousy special weak Dreadsylvanian cold-fashioned	2	decent	Effect: "Mer-kindliness", Effect Duration: 40
-6571	triple-distilled hand-crafted Dreadsylvanian grimlet	6	EPIC	
+6569	weak special smooth Dreadsylvanian hot toddy	2	awesome	Effect: "Corona de la Salsa", Effect Duration: 40
+6570	weak special lousy Dreadsylvanian cold-fashioned	2	decent	Effect: "Mer-kindliness", Effect Duration: 40
+6571	hand-crafted triple-distilled Dreadsylvanian grimlet	6	EPIC	
 6572	acceptable Dreadsylvanian dank and stormy	4	good	
 6573	aged Dreadsylvanian slithery nipple	4	awesome	
 6574	hot clusterbomb	0		
@@ -6471,7 +6471,7 @@
 6577	skewed stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	mirror Dreadsylvanian Almanac page	0		
-6580	shaking blinking length of fuse	0		
+6580	blinking shaking length of fuse	0		
 6581	dreadful box	0		
 6582	upside-down Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	vicious spiked collar	0		Familiar Damage: +20
@@ -6488,7 +6488,7 @@
 6594	blinking hot Dreadsylvanian cocoa	0		
 6595	dehydrated epic cluster	1	good	
 6596	pulsating blue clockwork egg	0		
-6597	bouncing yellow clockwork birdhouse	0		
+6597	yellow bouncing clockwork birdhouse	0		
 6598	clockwork disc	0		
 6599	pulsating clockwork hand	0		
 6600	clockwork hand	0		
@@ -6496,7 +6496,7 @@
 6602	tumbling clockwork numeral II	0		
 6603	cyan clockwork numeral III	0		
 6604	clockwork numeral IV	0		
-6605	narrow lime green clockwork numeral V	0		
+6605	lime green narrow clockwork numeral V	0		
 6606	clockwork numeral VI	0		
 6607	clockwork numeral VII	0		
 6608	clockwork numeral VIII	0		
@@ -6520,7 +6520,7 @@
 6626	folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	folder (D-Team)	0		Last Available: "2013-08"
 6628	bouncing folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
-6629	tumbling gray folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
+6629	gray tumbling folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	upside-down folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	shaking folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	spinning blue folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
@@ -6541,10 +6541,10 @@
 6649	modified electrified jittery Ogres and Oubliettes&trade; module	0		Effect: "Quadrilled", Effect Duration: 31
 6650	tumbling Mountain Stream Code Black Alert	0		
 6651	spinning twisted-up wet towel	0		
-6652	perfectly mixed extra-dry upside-down fuchsia stepmom's booze	5	EPIC	
+6652	perfectly mixed extra-dry fuchsia upside-down stepmom's booze	5	EPIC	
 6653	surgical tape	0		
 6654	band T-shirt of the bloodbag	0		Maximum HP: +100
-6655	special practically non-alcoholic bad wobbly fountain 'soda'	1	decent	Effect: "Abyssal Sweat", Effect Duration: 30
+6655	special bad practically non-alcoholic wobbly fountain 'soda'	1	decent	Effect: "Abyssal Sweat", Effect Duration: 30
 6656	illegal firecracker	0		
 6657	chilly careful pickelhaube	0		Monster Level: -10, Cold Damage: +5, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	pickled non-tarnished ghostly hair oil	0		Effect: "Red-Shirted Escort", Effect Duration: 62
@@ -6563,14 +6563,14 @@
 6671	chilled pickled sodium pentasomething	0		Effect: "Okee-Dokee Computer", Effect Duration: 60
 6672	mirror skewed grains of salt	0		
 6673	upside-down yellowcake bomb	0		
-6674	teal mirror spinning stinkbomb	0		
+6674	spinning teal mirror stinkbomb	0		
 6675	irradiated superwater	0		Effect: "Nature's Bounty", Effect Duration: 12
 6676	ghostly Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	lion tamer's Yearbook Club Camera	0		Experience (familiar): +2, Conditional Skill (Equipped): "Blinding Flash"
 6679	ghostly Samson's machete	0		Experience (Muscle): +5
 6680	bad blurry Cursed Punch	4	decent	
-6681	practically non-alcoholic artisanal Bowl of Scorpions	1	EPIC	
+6681	artisanal practically non-alcoholic Bowl of Scorpions	1	EPIC	
 6682	hand-crafted Fog Murderer	4	EPIC	
 6683	huge pulsating book of matches	0		
 6684	pulsating rosewater-soaked surgical mask	0		Stench Resistance: +3, Surgeonosity: +1
@@ -6583,7 +6583,7 @@
 6691	lime green McClusky file (page 3)	0		
 6692	McClusky file (page 4)	0		
 6693	narrow McClusky file (page 5)	0		
-6694	upside-down jittery boring binder clip	0		
+6694	jittery upside-down boring binder clip	0		
 6695	McClusky file (complete)	0		
 6696	olive bowling ball	0		
 6697	pulsating moss-covered stone sphere	0		
@@ -6594,10 +6594,10 @@
 6702	bowler	0		
 6703	fancy imitation White Russian	1	decent	Effect: "Frisky Spirit", Effect Duration: 5
 6704	spinning flame-wreathed wicked short-handled mop	0		Spell Damage: +5, Hot Spell Damage: +10
-6705	immense adequate jungle floor wax	9	good	
+6705	adequate immense jungle floor wax	9	good	
 6706	smirking shrunken head	0		
 6707	wet non-unsweetened electrified twirling colorful toad	0		Effect: "Dances with Tweedles", Effect Duration: 60
-6708	yellow huge crude voodoo doll	0		
+6708	huge yellow crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
 6710	gray tumbling Tesla pygmy briefs of incineration	0		Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
@@ -6616,7 +6616,7 @@
 6724	tasty exotic jungle fruit	3	awesome	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
-6727	bouncing blinking tropical island souvenir crate	0		
+6727	blinking bouncing tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
 6729	huge UV-resistant compass	0		
 6730	funky junk key	0		
@@ -6646,19 +6646,19 @@
 6754	pulsating beer bottle	0		
 6755	jittery olive beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	bad wobbly upside-down can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
+6757	bad upside-down wobbly can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
 6758	bad practically non-alcoholic can of Drooling Monk	1	decent	Last Available: "2013-09"
-6759	lousy watered-down squat can of Impetuous Scofflaw	2	decent	Last Available: "2013-09"
+6759	watered-down lousy squat can of Impetuous Scofflaw	2	decent	Last Available: "2013-09"
 6760	mediocre triple-distilled mirror bottle of Old Pugilist	9	decent	Last Available: "2013-09"
 6761	acceptable high-proof bottle of Professor Beer	10	good	Last Available: "2013-09"
-6762	aged irresponsibly strong bouncing blinking bottle of Rapier Witbier	8	awesome	Last Available: "2013-09"
+6762	aged irresponsibly strong blinking bouncing bottle of Rapier Witbier	8	awesome	Last Available: "2013-09"
 6763	smooth bottle of Race Car Red	4	awesome	Last Available: "2013-09"
-6764	special delicious bottle of Greedy Dog	3	awesome	Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2013-09"
+6764	delicious special bottle of Greedy Dog	3	awesome	Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2013-09"
 6765	acceptable purple bottle of Lambada Lambic	4	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	bouncing artisanal homebrew gift package	0		
 6768	liquid bread	1	decent	Last Available: "2013-09"
-6769	up-at-dawn electrified tin tam of courage	0		Spooky Resistance: +3, Adventures: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	up-at-dawn electrified tin tam of courage	0		Spooky Resistance: +3, Adventures: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	aerosolized wobbly tin cup	0		Effect: "Strawberry Alarm", Effect Duration: 40, Last Available: "2013-09"
 6771	censurious careful tin foil of the bloodbag	0		Maximum HP: +100, Monster Level: -10, Sleaze Resistance: +3, Last Available: "2013-09"
 6772	Herculean groovy tin drum of the glutton	0		Moxie Percent: +10, Experience (Muscle): +1, Food Drop: +100, Last Available: "2013-09"
@@ -6685,7 +6685,7 @@
 6796	frozen quantum denatured yellow disco horoscope (Pisces)	0		Effect: "Antsy in your Pantsy", Effect Duration: 62
 6797	warmed mirror disco horoscope (Aries)	0		Effect: "Buttermilk Boogie", Effect Duration: 33
 6798	polymerized disco horoscope (Taurus)	0		Effect: "Paging Betty", Effect Duration: 47
-6799	galvanized cyan tumbling disco horoscope (Gemini)	0		Effect: "Shawarma Initiative", Effect Duration: 63
+6799	galvanized tumbling cyan disco horoscope (Gemini)	0		Effect: "Shawarma Initiative", Effect Duration: 63
 6800	diffused extra-wet fuchsia disco horoscope (Cancer)	0		Effect: "Morbidi Tea", Effect Duration: 27
 6801	moist Vulcanized disco horoscope (Leo)	0		Effect: "Ack!  Barred!", Effect Duration: 12
 6802	triple-corrupted disco horoscope (Virgo)	0		Effect: "Dreadful Heat", Effect Duration: 18
@@ -6746,13 +6746,13 @@
 6857	shaking toasty Cajun accordion	0		Hot Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	pulsating fuchsia chaotic quirky accordion	0		Spell Critical Percent: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	family-friendly veiny Skipper's accordion	0		Maximum HP: +10, Sleaze Resistance: +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	perfumed Pantsgiving of James Dean of the sewer of bravery	0		Experience (Moxie): +3, Stench Damage: +25, Spooky Resistance: +5, Stench Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6860	perfumed Pantsgiving of James Dean of the sewer of bravery	0		Experience (Moxie): +3, Stench Damage: +25, Spooky Resistance: +5, Stench Resistance: +5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	normal can of sardines	3	good	Last Available: "2013-11"
 6862	decent high-calorie sugar substitute	4	good	Last Available: "2013-11"
 6863	decent maroon pat of butter	3	good	Last Available: "2013-11"
 6864	decent squat dinner roll	3	good	Last Available: "2013-11"
 6865	yummy mashed potatoes	3	awesome	Last Available: "2013-11"
-6866	toothsome jumbo whole turkey leg	5	awesome	Last Available: "2013-11"
+6866	jumbo toothsome whole turkey leg	5	awesome	Last Available: "2013-11"
 6867	yummy low-calorie deviled egg	1	awesome	Last Available: "2013-11"
 6868	cold-filtered mirror finger exerciser	0		Effect: "Puzzle Fury", Effect Duration: 26, Last Available: "2013-11"
 6869	vacuum-sealed vacuum-sealed tumbling dented spoon	0		Effect: "Motion", Effect Duration: 53, Last Available: "2013-11"
@@ -6785,15 +6785,15 @@
 6896	double-pickled electrified tangled mass of pasta	0		Effect: "Disco Neuropathy", Effect Duration: 40, Last Available: "2013-11"
 6897	chilled pulsating Can of Spaghetto	0		Effect: "Work For Hours a Week", Effect Duration: 35, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
-6899	olive huge Thwaitgold ant statuette	0		
+6899	huge olive Thwaitgold ant statuette	0		
 6900	experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	mansplainer's thinker's flask flops	0		Mysticality: +10, Monster Level: +15, Single Equip
-6903	adjusted non-flattened huge narrow nuts	0		Effect: "Grrrrrrreat!", Effect Duration: 50, Last Available: "2013-12"
+6903	adjusted non-flattened narrow huge nuts	0		Effect: "Grrrrrrreat!", Effect Duration: 50, Last Available: "2013-12"
 6904	activated concentrated bolts	0		Effect: "Perfect Hair", Effect Duration: 56, Last Available: "2013-12"
 6905	flavorless tiny gingerbread robot	1	decent	Last Available: "2013-12"
 6906	stale wobbly petit 4.1	3	decent	Last Available: "2013-12"
-6907	half-sized flavorless nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
+6907	flavorless half-sized nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
 6908	smartaleck's plastic GORM-8	0		Moxie Percent: +30, Last Available: "2013-12"
 6909	perfumed plastic warbear	0		Stench Resistance: +5, Last Available: "2013-12"
 6910	Herculean plastic Toybot	0		Experience (Muscle): +1, Last Available: "2013-12"
@@ -6810,29 +6810,29 @@
 6921	moldy diet warbear feasting bread	1	crappy	Last Available: "2013-12"
 6922	diet rotten pulsating warbear warrior bread	1	crappy	Last Available: "2013-12"
 6923	toothsome snack-sized warbear thermoregulator bread	2	awesome	Last Available: "2013-12"
-6924	bad watered-down warbear feasting mead	2	decent	Last Available: "2013-12"
+6924	watered-down bad warbear feasting mead	2	decent	Last Available: "2013-12"
 6925	perfectly mixed warbear bearserker mead	3	EPIC	Last Available: "2013-12"
 6926	artisanal warbear blizzard mead	4	EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	Jeselnik's therapeutic warbear plain fedora of extreme caution	0		Monster Level: -25, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	extremely unsafe warbear feathered fedora	0		Weapon Damage Percent: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	zippy ribald smelly warbear fedora	0		Stench Spell Damage: +10, Sleaze Damage: +10, Initiative: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	narrow occult groovy warbear plain helm of extreme caution	0		Moxie Percent: +10, Spell Damage Percent: +25, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	jittery supercharged warbear spiked helm	0		Maximum MP Percent: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	flame-wreathed padded wizardly warbear electro-spiked helm	0		Mysticality: +25, Damage Absorption: +20, Hot Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	lime green Usain Bolt's supercharged vibrating warbear plain ushanka	0		Maximum MP Percent: 40, Initiative: +80, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	mirror Annie Oakley's warbear lined ushanka	0		Critical Hit Percent: +20, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	miser's stiffened warbear heated ushanka of bravery	0		Damage Reduction: 1, Spooky Resistance: +5, Meat Drop: +10, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	Jeselnik's therapeutic warbear plain fedora of extreme caution	0		Monster Level: -25, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	extremely unsafe warbear feathered fedora	0		Weapon Damage Percent: +100, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	zippy ribald smelly warbear fedora	0		Stench Spell Damage: +10, Sleaze Damage: +10, Initiative: +20, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	narrow occult groovy warbear plain helm of extreme caution	0		Moxie Percent: +10, Spell Damage Percent: +25, Monster Level: -25, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	jittery supercharged warbear spiked helm	0		Maximum MP Percent: +30, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	flame-wreathed padded wizardly warbear electro-spiked helm	0		Mysticality: +25, Damage Absorption: +20, Hot Spell Damage: +10, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	lime green Usain Bolt's supercharged vibrating warbear plain ushanka	0		Maximum MP Percent: 40, Initiative: +80, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	mirror Annie Oakley's warbear lined ushanka	0		Critical Hit Percent: +20, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	miser's stiffened warbear heated ushanka of bravery	0		Damage Reduction: 1, Spooky Resistance: +5, Meat Drop: +10, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	spinning chaotic Fonzie's strapping warbear party pants	0		Muscle: +5, Experience (Moxie): +1, Spell Critical Percent: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	warbear ceremonial party pants of chilblains	0		Cold Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	blurry Usain Bolt's reassuring warbear high festival pants of the blizzard	0		Cold Spell Damage: +25, Spooky Resistance: +1, Initiative: +80, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	Sherlock's wool steel-toed warbear battle greaves	0		Damage Reduction: 9, Cold Resistance: +1, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	ghostly warbear officer greaves of Flo-Jo	0		Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	spinning stanky Newton's warbear bearserker greaves of Calamity Jane	0		Experience (Mysticality): +3, Critical Hit Percent: +15, Stench Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	blue skewed auspicious beefy warbear johns of bravery	0		Muscle: +10, Spooky Resistance: +5, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	hale warbear fleece-lined johns	0		Maximum HP: +20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	inspector's asbestos-lined Herculean warbear johns	0		Experience (Muscle): +1, Hot Resistance: +5, Item Drop: +15, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	spinning chaotic Fonzie's strapping warbear party pants	0		Muscle: +5, Experience (Moxie): +1, Spell Critical Percent: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	warbear ceremonial party pants of chilblains	0		Cold Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	blurry Usain Bolt's reassuring warbear high festival pants of the blizzard	0		Cold Spell Damage: +25, Spooky Resistance: +1, Initiative: +80, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	Sherlock's wool steel-toed warbear battle greaves	0		Damage Reduction: 9, Cold Resistance: +1, Item Drop: +25, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	ghostly warbear officer greaves of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	spinning stanky Newton's warbear bearserker greaves of Calamity Jane	0		Experience (Mysticality): +3, Critical Hit Percent: +15, Stench Spell Damage: +25, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	blue skewed auspicious beefy warbear johns of bravery	0		Muscle: +10, Spooky Resistance: +5, Item Drop: +10, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	hale warbear fleece-lined johns	0		Maximum HP: +20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	inspector's asbestos-lined Herculean warbear johns	0		Experience (Muscle): +1, Hot Resistance: +5, Item Drop: +15, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	tumbling chaotic studded Rosewater's warbear goggles	0		Mysticality Percent: +30, Damage Absorption: +80, Spell Critical Percent: +10, Single Equip, Last Available: "2013-12"
 6949	slick warbear snowblindness goggles	0		Moxie: +10, Single Equip, Last Available: "2013-12"
@@ -6845,14 +6845,14 @@
 6956	huge aromatic frightening warbear warscarf of Calamity Jane	0		Critical Hit Percent: +15, Spooky Damage: +5, Stench Resistance: +1, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	skewed tumbling warbear foil hat of the empath	0		Familiar Weight: +5, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	skewed tumbling warbear foil hat of the empath	0		Familiar Weight: +5, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	shaking warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	tumbling chilly personal trainer's warbear oil pan	0		Experience Percent (Muscle): +10, Cold Damage: +5, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	tumbling chilly personal trainer's warbear oil pan	0		Experience Percent (Muscle): +10, Cold Damage: +5, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	mirror red warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	mirror rosewater-soaked warbear exhaust manifold	0		Stench Resistance: +3, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	gray warbear auto-anvil	0		Last Available: "2013-12"
-6966	blinking tumbling gray skewed warbear induction oven	0		Last Available: "2013-12"
+6966	gray blinking skewed tumbling warbear induction oven	0		Last Available: "2013-12"
 6967	warbear chemistry lab	0		Last Available: "2013-12"
 6968	lime green warbear officer requisition box	0		Last Available: "2013-12"
 6969	wobbly warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6889,15 +6889,15 @@
 7000	thinker's die-cast Don Crimbo of James Dean	0		Mysticality: +10, Experience (Moxie): +3, Last Available: "2013-12"
 7001	wobbly wool weightlifter's die-cast Uncle Hobo	0		Muscle: +15, Cold Resistance: +1, Last Available: "2013-12"
 7002	skewed die-cast Father Crimbo of the brute of temperance	0		Muscle Percent: +30, Sleaze Resistance: +5, Last Available: "2013-12"
-7003	blurry The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	blurry The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	enhanced moist double-modified pulsating Flaskfull of Hollow	0		Effect: "Sugary Tongue", Effect Duration: 54, Last Available: "2013-12"
 7005	upside-down lump of Brituminous coal	0		Last Available: "2013-12"
 7006	modified cyan handful of Smithereens	1	decent	Last Available: "2013-12"
 7007	flavorless spinning Every Day is Like This Sundae	3	decent	Last Available: "2013-12"
-7008	spoiled huge pulsating Miserable Pie	10	crappy	Last Available: "2013-12"
+7008	huge spoiled pulsating Miserable Pie	10	crappy	Last Available: "2013-12"
 7009	stale This Charming Flan	3	decent	Last Available: "2013-12"
-7010	fancy artisanal Irish Coffee, English Heart	3	EPIC	Effect: "Quantum of Moxie", Effect Duration: 45, Last Available: "2013-12"
-7011	lousy practically non-alcoholic Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
+7010	artisanal fancy Irish Coffee, English Heart	3	EPIC	Effect: "Quantum of Moxie", Effect Duration: 45, Last Available: "2013-12"
+7011	practically non-alcoholic lousy Strikes Again Bigmouth	1	decent	Last Available: "2013-12"
 7012	triple-distilled bad Paint A Vulgar Pitcher	6	decent	Last Available: "2013-12"
 7013	Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	mirror ruddy deadly smartaleck's Sheila Take a Crossbow of dire peril	0		Moxie Percent: +30, Weapon Damage: 25, Maximum HP Percent: +40, Last Available: "2013-12"
 7019	careful energetic cool A Light that Never Goes Out of the bloodbag	0		Moxie: +5, Maximum HP: +100, Maximum MP Percent: +20, Monster Level: -10, Last Available: "2013-12"
 7020	asbestos-lined veiny dangerous Half a Purse of the cougar	0		Moxie: +20, Weapon Damage: +10, Maximum HP: +10, Hot Resistance: +5, Last Available: "2013-12"
-7021	blurry executive foul-smelling clever hardened Hairpiece On Fire	0		Damage Reduction: 3, Maximum MP: +20, Stench Damage: +10, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	tumbling greasy Van der Graaf clever Vicar's Tutu of the businessman	0		Maximum MP: +20, Sleaze Spell Damage: +10, Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	blurry executive foul-smelling clever hardened Hairpiece On Fire	0		Damage Reduction: 3, Maximum MP: +20, Stench Damage: +10, Meat Drop: +40, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	tumbling greasy Van der Graaf clever Vicar's Tutu of the businessman	0		Maximum MP: +20, Sleaze Spell Damage: +10, Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	double-paned rosy-cheeked groovy Hand in Glove	0		Moxie Percent: +10, Maximum HP Percent: +30, Cold Resistance: +5, Single Equip, Last Available: "2013-12"
 7024	double-paned Van der Graaf Meat Tenderizer is Murder of the bloodbag	0		Maximum HP: +100, Cold Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Class: "Seal Clubber", Last Available: "2013-12"
 7025	skewed aromatic sinister Ouija Board, Ouija Board of the sweet-tooth	0		Spell Damage: +10, Stench Resistance: +1, Candy Drop: +100, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6918,24 +6918,24 @@
 7029	manspreader's savvy Shakespeare's Sister's Accordion of extreme caution	0		Mysticality Percent: +20, Monster Level: -15, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	chaotic third-hand lantern	0		Spell Critical Percent: +10
 7031	green loose purse strings	0		
-7032	toothsome fancy miniature jittery pickled egg	2	awesome	Effect: "Wet Rub", Effect Duration: 30
+7032	miniature fancy toothsome jittery pickled egg	2	awesome	Effect: "Wet Rub", Effect Duration: 30
 7033	blinking cup of lukewarm tea	1	decent	
 7034	narrow tumbling warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
 7036	warbear high-efficiency still	0		Last Available: "2013-12"
 7037	warbear LP-ROM burner	0		Last Available: "2013-12"
-7038	tumbling blinking warbear gyrocopter	0		Last Available: "2013-12"
+7038	blinking tumbling warbear gyrocopter	0		Last Available: "2013-12"
 7039	Vulcanized aerosolized narrow warbear robo-camouflage unit	0		Effect: "Bootyliciousness", Effect Duration: 56, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	twirling warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	shaking warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
-7044	pickled spinning cyan glass slipper	0		Effect: "The Spy Who Loved XP", Effect Duration: 14, Last Available: "2014-12"
+7044	pickled cyan spinning glass slipper	0		Effect: "The Spy Who Loved XP", Effect Duration: 14, Last Available: "2014-12"
 7045	twisted huge antimatter wad	1	awesome	Last Available: "2013-12"
 7046	polarized pickled shaking warbear superpotion	0		Effect: "Hot Blooded", Effect Duration: 29, Last Available: "2013-12"
 7047	oxidized galvanized upside-down warbear liquid lasers	0		Effect: "Healthy Blue Glow", Effect Duration: 44, Last Available: "2013-12"
 7048	extra-magnetized alkaline mirror warbear rejuvenation potion	0		Effect: "Black Eyes", Effect Duration: 25, Last Available: "2013-12"
-7049	fuchsia spinning broken warbear gyrocopter	0		Last Available: "2013-12"
+7049	spinning fuchsia broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	moldy low-calorie warbear gyro	1	crappy	Last Available: "2013-12"
 7051	denatured irradiated blurry recording of Rolando's Rondo of Resisto	0		Effect: "Ghost Finger", Effect Duration: 30, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
@@ -6943,7 +6943,7 @@
 7054	wobbly warbear drone codes	0		Last Available: "2013-12"
 7055	fancy adequate breakfast mess	3	good	Effect: "Hangdog", Effect Duration: 50, Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
-7057	normal low-calorie breakfast miracle	1	good	Last Available: "2013-12"
+7057	low-calorie normal breakfast miracle	1	good	Last Available: "2013-12"
 7058	dry extra-galvanized Cloaca Cola Polar	0		Effect: "Slimily Strong", Effect Duration: 22, Last Available: "2013-12"
 7059	ghostly warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6957,7 +6957,7 @@
 7068	double-dry single of Donho's Bubbly Ballad	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 66
 7069	shaking Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	ghostly packet of winter seeds	0		Last Available: "2014-01"
-7071	stale miniature snow berries	2	decent	Last Available: "2014-01"
+7071	miniature stale snow berries	2	decent	Last Available: "2014-01"
 7072	jumbo spoiled ice harvest	5	crappy	Last Available: "2014-01"
 7073	moist diffused extra-aerosolized frost flower	0		Effect: "Danish Cunning", Effect Duration: 21, Last Available: "2014-01"
 7074	diffused huge olive snow cleats	0		Effect: "No Vertigo", Effect Duration: 40, Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	skewed ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	supercool snow mobile	0		Moxie Percent: +20, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	supercool snow mobile	0		Moxie Percent: +20, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	greasy ice bucket	0		Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	family-friendly Lo Pan's snow shovel	0		Spell Critical Percent: +30, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2014-01"
 7086	stanky Oprah's bod-ice of temperance	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,38 +6978,38 @@
 7089	upside-down blurry snow fort	0		Last Available: "2014-01"
 7090	mediocre En Una Fila Tequila	3	decent	
 7091	Skully's hot chocolate	1	good	
-7092	studded warbear dress helmet of terror	0		Damage Absorption: +80, Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	studded warbear dress helmet of terror	0		Damage Absorption: +80, Spooky Spell Damage: +10, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	arcane researcher's warbear dress bracers of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Single Equip, Last Available: "2013-12"
-7094	mirror fuchsia lightning-fast Temple Grandin's warbear dress greaves	0		Familiar Weight: +7, Initiative: +40, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	careful vibrating sweatband	0		Maximum MP Percent: +10, Monster Level: -10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	spinning wobbly auspicious lion tamer's gym shorts	0		Experience (familiar): +2, Item Drop: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	mirror fuchsia lightning-fast Temple Grandin's warbear dress greaves	0		Familiar Weight: +7, Initiative: +40, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	careful vibrating sweatband	0		Maximum MP Percent: +10, Monster Level: -10, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	spinning wobbly auspicious lion tamer's gym shorts	0		Experience (familiar): +2, Item Drop: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	extremely unsafe ankleweights of mayonnaise	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7098	gray Sherlock's studded thinker's sweat socks of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Damage Absorption: +80, Item Drop: +25, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
-7100	mirror twirling Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
+7100	twirling mirror Jerks' Health&trade; Magazine	0		Last Available: "2014-12"
 7101	altered Five Second Energy&trade;	1		Last Available: "2014-12"
 7102	pixie axie	0		Last Available: "2014-12"
 7103	ionized wet wobbly powder	0		Effect: "The Living Hitpoints", Effect Duration: 14, Last Available: "2014-12"
 7104	skewed Rosewater's licorice whip	0		Mysticality Percent: +30, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	weak hand-crafted snakebite	2	EPIC	Last Available: "2014-12"
+7106	hand-crafted weak snakebite	2	EPIC	Last Available: "2014-12"
 7107	arcane researcher's slick candy stick	0		Moxie: +10, Experience Percent (Mysticality): +10, Last Available: "2014-12"
 7108	tasty pecan	3	awesome	Last Available: "2014-12"
-7109	moldy massive blinking pecan pie	10	crappy	Last Available: "2014-12"
+7109	massive moldy blinking pecan pie	10	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	small moldy candy mountain oyster	2	crappy	Last Available: "2014-12"
-7112	irresponsibly strong lousy chocotini	10	decent	Last Available: "2014-12"
+7111	moldy small candy mountain oyster	2	crappy	Last Available: "2014-12"
+7112	lousy irresponsibly strong chocotini	10	decent	Last Available: "2014-12"
 7113	therapeutic smartaleck's stylish chocolate rabbit's foot	0		Moxie: +25, Moxie Percent: +30, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
-7114	stale tiny candy carrot	1	decent	Last Available: "2014-12"
-7115	snack-sized enchanted stale candy carrot cake	2	decent	Effect: "Astral Shell", Effect Duration: 30, Last Available: "2014-12"
+7114	tiny stale candy carrot	1	decent	Last Available: "2014-12"
+7115	stale snack-sized enchanted candy carrot cake	2	decent	Effect: "Astral Shell", Effect Duration: 30, Last Available: "2014-12"
 7116	huge friendly forbidden carrot-on-a-stick	0		Spell Damage Percent: +50, Familiar Weight: +3, Last Available: "2014-12"
-7117	avaricious frosty weasel stomping pants	0		Cold Spell Damage: +10, Meat Drop: +30, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	avaricious frosty weasel stomping pants	0		Cold Spell Damage: +10, Meat Drop: +30, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	low-calorie normal jittery maroon mulberry	1	good	Last Available: "2014-12"
-7119	delicious extra-dry blinking blinking mulled berry wine	5	awesome	Last Available: "2014-12"
+7119	extra-dry delicious blinking blinking mulled berry wine	5	awesome	Last Available: "2014-12"
 7120	twirling lemony scales	0		Last Available: "2014-12"
-7121	tumbling Rosewater's lemon party hat	0		Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	tumbling Rosewater's lemon party hat	0		Mysticality Percent: +30, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	perfumed lemon shirt	0		Stench Resistance: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	blinking educational lemon drop trousers	0		Experience: +1, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	blinking educational lemon drop trousers	0		Experience: +1, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	dry polymerized frozen lime green lemonhead caviar	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 59, Last Available: "2014-12"
 7125	supercool gummi sword of Calamity Jane	0		Moxie Percent: +20, Critical Hit Percent: +15, Last Available: "2014-12"
 7126	Vulcanized wet magnetized small gummi fin	0		Effect: "Heightened Senses", Effect Duration: 21, Last Available: "2014-12"
@@ -7018,20 +7018,20 @@
 7129	small flavorless leftover canap&eacute;s	2	decent	Last Available: "2014-12"
 7130	smooth magnum of champagne	3	awesome	Last Available: "2014-12"
 7131	wobbly nasty vibrating cow creamer of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +10, Stench Damage: +5, Last Available: "2014-12"
-7132	diffused flattened bouncing upside-down Outer Wolf&trade; cologne	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 14, Last Available: "2014-12"
-7133	wobbly shaking blue lupine appetite hormones	0		Last Available: "2014-12"
-7134	curative wolf whistle of the scaredy-cat	0		Monster Level: -15, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7132	diffused flattened upside-down bouncing Outer Wolf&trade; cologne	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 14, Last Available: "2014-12"
+7133	blue shaking wobbly lupine appetite hormones	0		Last Available: "2014-12"
+7134	curative wolf whistle of the scaredy-cat	0		Monster Level: -15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	adequate ghostly witch's bread	4	good	Last Available: "2014-12"
 7136	polymerized altered witch's brew	0		Effect: "Strength of Ten Ettins", Effect Duration: 59, Last Available: "2014-12"
 7137	jittery executive weightlifter's witch's bra of the sewer	0		Muscle: +15, Stench Damage: +25, Meat Drop: +40, Last Available: "2014-12"
-7138	perfectly mixed practically non-alcoholic fuchsia shaking mid-level medieval mead	1	EPIC	Last Available: "2014-12"
+7138	practically non-alcoholic perfectly mixed shaking fuchsia mid-level medieval mead	1	EPIC	Last Available: "2014-12"
 7139	polarized polarized R&uuml;mpelstiltz	0		Effect: "Crimbo Epiphany", Effect Duration: 35, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	denatured activated shaking hi-octane carrot juice	0		Effect: "Bubblin' Rage", Effect Duration: 23, Last Available: "2014-12"
 7142	polarized tumbling jittery hare brush	0		Effect: "Towering Strength", Effect Duration: 30, Last Available: "2014-12"
 7143	miser's deadly hare pin	0		Weapon Damage: +5, Meat Drop: +10, Single Equip, Last Available: "2014-12"
 7144	purple odd coin	0		Last Available: "2014-12"
-7145	huge moldy cinnamon cannoli	7	crappy	Last Available: "2014-12"
+7145	moldy huge cinnamon cannoli	7	crappy	Last Available: "2014-12"
 7146	bad expensive champagne	3	decent	Last Available: "2014-12"
 7147	nitrogenated ghostly polo trophy	0		Effect: "Total Protonic Reversal", Effect Duration: 64, Last Available: "2014-12"
 7148	jittery oil painting	0		Last Available: "2014-12"
@@ -7043,24 +7043,24 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	spinning glass	0		Last Available: "2014-12"
-7157	fireproof thinker's fire hose of vim and vigor	0		Mysticality: +10, Maximum HP Percent: +50, Hot Resistance: +3, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	huge normal fireman's lunch	6	good	Last Available: "2014-12"
-7159	resourceful plain paper hat of Tarzan of horror	0		Experience (Muscle): +3, Maximum MP: +50, Spooky Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	special moldy thick ice cream sandwich	5	crappy	Effect: "Boo Tea", Effect Duration: 20, Last Available: "2014-12"
+7157	fireproof thinker's fire hose of vim and vigor	0		Mysticality: +10, Maximum HP Percent: +50, Hot Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7158	normal huge fireman's lunch	6	good	Last Available: "2014-12"
+7159	resourceful plain paper hat of Tarzan of horror	0		Experience (Muscle): +3, Maximum MP: +50, Spooky Spell Damage: +25, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7160	special thick moldy ice cream sandwich	5	crappy	Effect: "Boo Tea", Effect Duration: 20, Last Available: "2014-12"
 7161	therapeutic stiffened &quot;honey&quot; dipper of mayonnaise	0		Damage Reduction: 1, Sleaze Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7162	stale thick plumber's lunch	5	decent	Last Available: "2014-12"
 7163	vibrating studded quilted skull gearshift knob	0		Damage Absorption: 120, Maximum MP Percent: +10, Last Available: "2014-12"
-7164	spoiled immense special nachos of the night	7	crappy	Effect: "Disdain of She-Who-Was", Effect Duration: 35, Last Available: "2014-12"
+7164	spoiled special immense nachos of the night	7	crappy	Effect: "Disdain of She-Who-Was", Effect Duration: 35, Last Available: "2014-12"
 7165	avaricious miser's Sketcherz&trade; of the pedagogue	0		Experience: +3, Meat Drop: 40, Last Available: "2014-12"
-7166	bite-sized bland enchanted blurry shaking can of Adultwitch&trade;	1	decent	Effect: "Old School Pompadour", Effect Duration: 25, Last Available: "2014-12"
+7166	bite-sized bland enchanted shaking blurry can of Adultwitch&trade;	1	decent	Effect: "Old School Pompadour", Effect Duration: 25, Last Available: "2014-12"
 7167	aerosolized wobbly smudge stick	0		Effect: "Tearful, Fearful", Effect Duration: 28, Last Available: "2014-12"
-7168	galvanized shaking squat ghostly wall	0		Effect: "Cockroach Scurry", Effect Duration: 13, Last Available: "2014-12"
+7168	galvanized ghostly shaking squat wall	0		Effect: "Cockroach Scurry", Effect Duration: 13, Last Available: "2014-12"
 7169	drinkable twirling tankard of ale	4	good	Last Available: "2014-12"
 7170	tarnished Vulcanized scroll case	0		Effect: "Riboflavin'", Effect Duration: 24, Last Available: "2014-12"
 7171	triple-aerosolized polymerized tarnished jug of &quot;wine&quot;	0		Effect: "Ermine Eyes", Effect Duration: 32, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	moldy snack-sized humble pie	2	crappy	Last Available: "2014-12"
+7174	snack-sized moldy humble pie	2	crappy	Last Available: "2014-12"
 7175	maroon small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	irradiated corrupted crappy waiter disguise	0		Effect: "Quadrilled", Effect Duration: 66
@@ -7072,7 +7072,7 @@
 7183	Murphy's Rancid Black Flag	0		
 7184	huge The Shield of Brook	0		
 7185	cyan Red Zeppelin ticket	0		
-7186	blurry spinning Copperhead Charm (rampant)	0		
+7186	spinning blurry Copperhead Charm (rampant)	0		
 7187	artisanal unnamed cocktail	3	EPIC	
 7188	handful of tips	0		
 7189	unrequired jacket of the brute	0		Muscle Percent: +30
@@ -7101,19 +7101,19 @@
 7212	pulsating mirror resourceful Jefferson wings	0		Maximum MP: +50
 7213	fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	normal super-sized special fleetwood mac 'n' cheese	5	good	Effect: "Shortened", Effect Duration: 45
-7216	maroon ghostly lynyrd skin	0		
+7215	special super-sized normal fleetwood mac 'n' cheese	5	good	Effect: "Shortened", Effect Duration: 45
+7216	ghostly maroon lynyrd skin	0		
 7217	squat lynyrdskin cap of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	razor-sharp lynyrdskin tunic	0		Weapon Damage Percent: +25
 7219	Tesla lynyrdskin breeches	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	bouncing cigarette lighter	0		
 7221	blinking priceless diamond	0		
-7222	enchanted mediocre Flamin' Whatshisname	4	decent	Effect: "Scrappy, Shadowy", Effect Duration: 25
+7222	mediocre enchanted Flamin' Whatshisname	4	decent	Effect: "Scrappy, Shadowy", Effect Duration: 25
 7223	quantum liquefied lynyrd musk	0		Effect: "Tomato Power", Effect Duration: 36
 7224	narrow scorching Kashmir sweater of terror	0		Hot Damage: +25, Spooky Spell Damage: +10
 7225	flavorless olive custard pie	4	decent	
-7226	enchanted twirling mirror tea for one	1	good	Effect: "Shawarma Initiative", Effect Duration: 10
-7227	artisanal weak bottle of Evermore	2	EPIC	
+7226	enchanted mirror twirling tea for one	1	good	Effect: "Shawarma Initiative", Effect Duration: 10
+7227	weak artisanal bottle of Evermore	2	EPIC	
 7228	green box	0		
 7229	mediocre strong wine	5	decent	
 7230	drinkable rum	4	good	
@@ -7128,7 +7128,7 @@
 7239	studded beefcake's shirt	0		Muscle: +25, Damage Absorption: +80
 7240	energetic experienced coat	0		Experience: +2, Maximum MP Percent: +20
 7241	huge huge Tesla wizardly shoe	0		Mysticality: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip
-7242	twirling wobbly twirling button	0		
+7242	wobbly twirling twirling button	0		
 7243	upside-down button	0		
 7244	dry blood cells	0		Effect: "Psalm of Pointiness", Effect Duration: 32
 7245	anodized altered anodized eye	0		Effect: "Kindly Resolve", Effect Duration: 27
@@ -7141,12 +7141,12 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	distilled acceptable spinning cyan squat mini-martini	5	good	
+7255	acceptable distilled squat spinning cyan mini-martini	5	good	
 7256	smoke grenade	0		
 7257	compressed yellow tumbling molotov soda	1	decent	Effect: "Swimming Head", Effect Duration: 25
 7258	pressed polarized pile of ashes	0		Effect: "Sweet and Red", Effect Duration: 13
 7259	crate of firebombs	0		
-7260	yellow pulsating firebomb	0		
+7260	pulsating yellow firebomb	0		
 7261	veiny Rosewater's Sneaky Pete's basket of the blizzard	0		Mysticality Percent: +30, Maximum HP: +10, Cold Spell Damage: +25
 7262	huge &quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
@@ -7157,7 +7157,7 @@
 7268	skewed Letter for Melvign the Gnome	0		
 7269	huge Professor What garment	0		
 7270	&quot;2 Love Me, Vol. 2&quot;	0		
-7271	ghostly jittery gray Thinknerd Blind-Packed Toy	0		
+7271	jittery ghostly gray Thinknerd Blind-Packed Toy	0		
 7272	jittery experienced plastic Professor What	0		Experience: +2
 7273	plastic Jared the Duskwalker of the bloodbag	0		Maximum HP: +100
 7274	educational plastic Duke Starkiller	0		Experience: +1
@@ -7213,7 +7213,7 @@
 7324	distilled battery	1		
 7325	smooth snakebite	3	awesome	
 7326	twirling smelly rubber ribcage of temperance	0		Stench Spell Damage: +10, Sleaze Resistance: +5, Damage Reduction: 7
-7327	altered blurry bouncing synthetic marrow	1		
+7327	altered bouncing blurry synthetic marrow	1		
 7328	ionized anodized funny bone	0		Effect: "Patent Prevention", Effect Duration: 15
 7329	manspreader's fortified half-melted spoon	0		Damage Absorption: +60, Monster Level: +10
 7330	compressed the funk	1		Effect: "It Tickles!  It Tickles!", Effect Duration: 40
@@ -7235,10 +7235,10 @@
 7346	doll-eye amulet	0		Single Equip
 7347	rosy-cheeked forbidden ghost toga	0		Spell Damage Percent: +50, Maximum HP Percent: +30
 7348	bite-sized normal sheet cake	1	good	
-7349	squat narrow ghost key	0		
+7349	narrow squat ghost key	0		
 7350	picture of you	0		
 7351	asbestos-lined dangerous Sinatra's Staff of the Electric Range	0		Experience (Moxie): +5, Weapon Damage: +10, Hot Resistance: +5
-7352	rotten half-sized fancy deluxe layer cake	2	crappy	Effect: "Drenched With Filth", Effect Duration: 25
+7352	fancy half-sized rotten deluxe layer cake	2	crappy	Effect: "Drenched With Filth", Effect Duration: 25
 7353	chunk of hot iron	0		
 7354	artisanal gray jittery red-hot boilermaker	4	EPIC	
 7355	Jack Frost's coal shovel	0		Cold Spell Damage: +50, Conditional Skill (Equipped): "Shovel Hot Coal"
@@ -7258,10 +7258,10 @@
 7369	electrified altered blurry blurry mangled finger	0		Effect: "Uncucumbered", Effect Duration: 16
 7370	irresponsibly strong perfectly mixed Psychotic Train wine	7	EPIC	
 7371	crazy hobo notebook	0		
-7372	thick bland olive pie man was not meant to eat	5	decent	
+7372	bland thick olive pie man was not meant to eat	5	decent	
 7373	ribald sommelier's towel	0		Sleaze Damage: +10
 7374	bouncing Newton's tarnished tastevin	0		Experience (Mysticality): +3, Single Equip
-7375	immense decent actual tapas	9	good	
+7375	decent immense actual tapas	9	good	
 7376	squat ghast iron ingot	0		
 7377	energetic dance instructor's ghast iron cleaver	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20
 7378	fuchsia gravedigger's cool ghast iron Garibaldi	0		Moxie: +5, Spooky Damage: +10, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7280,15 +7280,15 @@
 7391	ionized Gene Tonic: Orc	0		Effect: "Army of One", Effect Duration: 23, Last Available: "2014-04"
 7392	polymerized Gene Tonic: Demon	0		Effect: "The Halls of Moxiousness", Effect Duration: 43, Last Available: "2014-04"
 7393	tarnished chilled Gene Tonic: Horror	0		Effect: "Arse-a'fire", Effect Duration: 42, Last Available: "2014-04"
-7394	polymerized blurry narrow Gene Tonic: Fish	0		Effect: "Buzzard Breath", Effect Duration: 57, Last Available: "2014-04"
+7394	polymerized narrow blurry Gene Tonic: Fish	0		Effect: "Buzzard Breath", Effect Duration: 57, Last Available: "2014-04"
 7395	ionized quadruple-polarized spinning Gene Tonic: Goblin	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 58, Last Available: "2014-04"
 7396	chilled Gene Tonic: Pirate	0		Effect: "Clyde's Blessing", Effect Duration: 63, Last Available: "2014-04"
 7397	pickled non-colloidal Gene Tonic: Plant	0		Effect: "Big Meat Big Prizes", Effect Duration: 51, Last Available: "2014-04"
-7398	oxidized wobbly red Gene Tonic: Weird	0		Effect: "Crimbo Flavor", Effect Duration: 48, Last Available: "2014-04"
+7398	oxidized red wobbly Gene Tonic: Weird	0		Effect: "Crimbo Flavor", Effect Duration: 48, Last Available: "2014-04"
 7399	diffused aerosolized blurry wobbly tumbling Gene Tonic: Elf	0		Effect: "Creepypasted", Effect Duration: 25, Last Available: "2014-04"
 7400	electrified colloidal wet fuchsia Gene Tonic: Mer-kin	0		Effect: "Hagnk's Gratitude", Effect Duration: 66, Last Available: "2014-04"
 7401	extra-corrupted Gene Tonic: Slime	0		Effect: "Musky", Effect Duration: 52, Last Available: "2014-04"
-7402	quantum super-frozen Vulcanized red wobbly Gene Tonic: Penguin	0		Effect: "Strength of Ten Ettins", Effect Duration: 44, Last Available: "2014-04"
+7402	quantum super-frozen Vulcanized wobbly red Gene Tonic: Penguin	0		Effect: "Strength of Ten Ettins", Effect Duration: 44, Last Available: "2014-04"
 7403	magnetized quantum skewed Gene Tonic: Elemental	0		Effect: "Become Intensely interested", Effect Duration: 58, Last Available: "2014-04"
 7404	dry mirror cyan Gene Tonic: Constellation	0		Effect: "Patent Prevention", Effect Duration: 53, Last Available: "2014-04"
 7405	non-deionized improved Gene Tonic: Hobo	0		Effect: "Holiday Bliss", Effect Duration: 23, Last Available: "2014-04"
@@ -7299,7 +7299,7 @@
 7410	Steam Card: Space Trip (#2)	0		
 7411	wobbly Steam Card: Space Trip (#3)	0		
 7412	Steam Card: Meteoid (#1)	0		
-7413	shaking mirror olive Steam Card: Meteoid (#2)	0		
+7413	mirror olive shaking Steam Card: Meteoid (#2)	0		
 7414	Steam Card: Meteoid (#3)	0		
 7415	Steam Card: DemonStar (#1)	0		
 7416	Steam Card: DemonStar (#2)	0		
@@ -7325,8 +7325,8 @@
 7436	ionized bouncing mirror Tremella Tarantella mushroom	0		Effect: "Wistfully Nostalgic", Effect Duration: 29, Last Available: "2014-05"
 7437	blurry Pastaco shell	0		Last Available: "2014-05"
 7438	spoiled Beefy Crunch Pastaco	3	crappy	Last Available: "2014-05"
-7439	toothsome bite-sized Brain Food Pastaco	1	awesome	Last Available: "2014-05"
-7440	big flavorless special Cool Brunch Pastaco	5	decent	Effect: "Tomato Power", Effect Duration: 15, Last Available: "2014-05"
+7439	bite-sized toothsome Brain Food Pastaco	1	awesome	Last Available: "2014-05"
+7440	big special flavorless Cool Brunch Pastaco	5	decent	Effect: "Tomato Power", Effect Duration: 15, Last Available: "2014-05"
 7441	jumbo spoiled upside-down Medical Pastaco	5	crappy	Last Available: "2014-05"
 7442	flavorless cyan Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	moldy Ludovico Pastaco	4	crappy	Last Available: "2014-05"
@@ -7334,27 +7334,27 @@
 7445	drinkable twirling complex mushroom wine	3	good	Last Available: "2014-05"
 7446	drinkable smooth mushroom wine	4	good	Last Available: "2014-05"
 7447	tolerable tumbling blood-red mushroom wine	4	good	Last Available: "2014-05"
-7448	artisanal high-proof cyan buzzing mushroom wine	9	EPIC	Last Available: "2014-05"
+7448	high-proof artisanal cyan buzzing mushroom wine	9	EPIC	Last Available: "2014-05"
 7449	smooth swirling mushroom wine	3	awesome	Last Available: "2014-05"
-7450	tasty thick Taco Dan's Basic Taco Dan Taco	5	awesome	Last Available: "2014-05"
+7450	thick tasty Taco Dan's Basic Taco Dan Taco	5	awesome	Last Available: "2014-05"
 7451	tasty diet Taco Dan's Taco Fish Fish Taco	1	awesome	Last Available: "2014-05"
 7452	upside-down Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	perfectly mixed squat regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	lousy super-size brogurt	4	decent	Last Available: "2014-05"
 7455	artisanal broberry brogurt	3	EPIC	Last Available: "2014-05"
-7456	delicious weak brocolate brogurt	2	awesome	Last Available: "2014-05"
+7456	weak delicious brocolate brogurt	2	awesome	Last Available: "2014-05"
 7457	tolerable practically non-alcoholic French bronilla brogurt	1	good	Last Available: "2014-05"
 7458	blurry History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
-7461	gray blinking industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Brogre brorts of doom	0		Spooky Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7461	blinking gray industrial strength anti-fungal spray	0		Last Available: "2014-05"
+7462	Brogre brorts of doom	0		Spooky Spell Damage: +50, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	ghostly wobbly friendly Brogre brolo shirt	0		Familiar Weight: +3, Last Available: "2014-05"
-7464	grievous Brogre bucket hat	0		Weapon Damage Percent: +50, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	grievous Brogre bucket hat	0		Weapon Damage Percent: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	Tesla energetic rosy-cheeked 8-billed baseball cap	0		Maximum HP Percent: +30, Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	Tesla energetic rosy-cheeked 8-billed baseball cap	0		Maximum HP Percent: +30, Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	quilted boxer's extremely wet T-shirt of the cougar	0		Moxie: +20, Muscle Percent: +10, Damage Absorption: +40, Last Available: "2014-05"
 7470	healthy groovy savvy shrimp fork	0		Mysticality Percent: +20, Moxie Percent: +10, Maximum HP Percent: +20, Last Available: "2014-05"
 7471	alkaline vacuum-sealed wobbly blurry BROS Energy Drink	0		Effect: "Expert Vacationer", Effect Duration: 42, Last Available: "2014-05"
@@ -7363,12 +7363,12 @@
 7474	colloidal Yolo&trade; chocolates	0		Effect: "Flame-Retardant Trousers", Effect Duration: 69, Last Available: "2020-09"
 7475	executive string of moist beads	0		Meat Drop: +40, Last Available: "2014-05"
 7476	blinking Ultimate Mind Destroyer	0		Last Available: "2014-05"
-7477	quadruple-dry triple-improved bouncing jittery Meat-inflating powder	0		Effect: "Tightly-Wound Spine", Effect Duration: 26, Last Available: "2014-05"
+7477	quadruple-dry triple-improved jittery bouncing Meat-inflating powder	0		Effect: "Tightly-Wound Spine", Effect Duration: 26, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	modified diffused sugar fairy	0		Effect: "Shoesauce", Effect Duration: 45, Last Available: "2014-05"
 7480	electrified sugar bunny	0		Effect: "Leash of Linguini", Effect Duration: 21, Last Available: "2014-05"
-7481	skewed sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
-7482	practically non-alcoholic acceptable Rompedores de Fantasmas	1	good	
+7481	skewed sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7482	acceptable practically non-alcoholic Rompedores de Fantasmas	1	good	
 7483	watered-down tolerable La Fantasma y La Oscuridad	2	good	
 7484	bad enchanted teal Fantasma en la M&aacute;quina	4	decent	Effect: "The Halls of Moxiousness", Effect Duration: 5
 7485	lime green loosening powder	0		
@@ -7401,12 +7401,12 @@
 7512	unsweetened poppy	0		Effect: "Sticks and Stones", Effect Duration: 49
 7513	twirling opium grenade	0		
 7514	ribald duonoculars of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +10, Single Equip
-7515	huge jittery plastic rock	0		
+7515	jittery huge plastic rock	0		
 7516	pulsating witch's spare house key	0		
 7517	mirror gray hardened Newton's spider leg	0		Experience (Mysticality): +3, Damage Reduction: 3
 7518	wand of pigification	0		
 7519	perfectly mixed twirling glass of bourbon	3	EPIC	
-7520	bouncing huge burned government manual fragment	0		Last Available: "2014-05"
+7520	huge bouncing burned government manual fragment	0		Last Available: "2014-05"
 7521	stale government cheese	3	decent	Last Available: "2014-05"
 7522	skewed foul-smelling pair of government shades	0		Stench Damage: +10, Single Equip, Last Available: "2014-05"
 7523	lime green space junk	0		Last Available: "2014-05"
@@ -7425,15 +7425,15 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	maroon nippy space beast fur hat	0		Cold Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	wobbly wool space beast fur pants	0		Cold Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	maroon nippy space beast fur hat	0		Cold Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	wobbly wool space beast fur pants	0		Cold Resistance: +1, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	twirling zippy space beast fur whip	0		Initiative: +20, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	medical-grade smartaleck's space heater	0		Moxie Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	medical-grade smartaleck's space heater	0		Moxie Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	ghostly space bar	0		Last Available: "2014-05"
 7545	lousy space port	3	decent	Last Available: "2014-05"
 7546	twirling lard-coated frosty space needle	0		Cold Spell Damage: +10, Sleaze Spell Damage: +25, Last Available: "2014-05"
-7547	extra-denatured jittery pulsating gray buffed alien drugs	0		Effect: "Almost Cool", Effect Duration: 20, Last Available: "2014-05"
+7547	extra-denatured pulsating jittery gray buffed alien drugs	0		Effect: "Almost Cool", Effect Duration: 20, Last Available: "2014-05"
 7548	teal hot ashes	0		Last Available: "2014-06"
 7549	corrupted tarnished ash soda	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 59, Last Available: "2014-06"
 7550	moist liquefied improved liquid smoke	0		Effect: "Stemonitis Storm", Effect Duration: 43, Last Available: "2014-06"
@@ -7451,12 +7451,12 @@
 7562	adjusted adjusted musk turtle	0		Effect: "The Q Is Talking To You", Effect Duration: 43
 7563	adjusted programmable turtle	0		Effect: "Vented Spleen", Effect Duration: 36
 7564	quantum liquefied skewed mocking turtle	0		Effect: "Gutterminded", Effect Duration: 24
-7565	huge bland ham steak	6	decent	
+7565	bland huge ham steak	6	decent	
 7566	huge stanky time-twitching toolbelt	0		Stench Spell Damage: +25, Single Equip, Free Pull
 7567	gray Chroner	0		
 7568	fireproof lion tamer's manspreader's Time Lord Badge of Honor	0		Monster Level: +10, Experience (familiar): +2, Hot Resistance: +3
 7569	wool smartaleck's Time Bandit Badge of Courage of the sewer	0		Moxie Percent: +30, Stench Damage: +25, Cold Resistance: +1
-7570	warmed diffused dry red mirror Friendliness Beverage	0		Effect: "Ruthlessly Efficient", Effect Duration: 45
+7570	warmed diffused dry mirror red Friendliness Beverage	0		Effect: "Ruthlessly Efficient", Effect Duration: 45
 7571	wobbly tumbling avaricious toasty silent pea shooter	0		Hot Damage: +5, Meat Drop: +30
 7572	tasty D roll	3	awesome	
 7573	twirling up-at-dawn gravedigger's kiwi beak	0		Spooky Damage: +10, Adventures: +5
@@ -7468,22 +7468,22 @@
 7579	twitching time capsule	0		
 7580	pickled liquid shifting time weirdness	1		Effect: "Fratty Flavor", Effect Duration: 10
 7581	bouncing shifting time weirdness	0		Adventures: +4, PvP Fights: +4
-7582	moldy snack-sized rack of dinosaur ribs	2	crappy	
-7583	practically non-alcoholic artisanal lime green spinning scotch on the rocks	1	super ultra mega turbo EPIC	
+7582	snack-sized moldy rack of dinosaur ribs	2	crappy	
+7583	artisanal practically non-alcoholic lime green spinning scotch on the rocks	1	super ultra mega turbo EPIC	
 7584	huge family-friendly steel-toed yabba dabba doo rag	0		Damage Reduction: 9, Sleaze Resistance: +1, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	pulsating stiffened brainy wooly loincloth	0		Mysticality: +5, Damage Reduction: 1, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	purple helix fossil	0		
 7587	upside-down S.S. Ticket	0		Familiar Weight: +5
 7588	pulsating Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	hand-crafted triple-distilled fancy glass of &quot;milk&quot;	8	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2014-07"
-7590	lousy enchanted weak narrow cup of &quot;tea&quot;	2	decent	Effect: "Oriental Mysticism", Effect Duration: 10, Last Available: "2014-07"
-7591	hand-crafted practically non-alcoholic yellow shaking thermos of &quot;whiskey&quot;	1	EPIC	Last Available: "2014-07"
-7592	mediocre fancy fortified Lucky Lindy	5	decent	Effect: "Toast Tea", Effect Duration: 35, Last Available: "2014-07"
+7589	fancy hand-crafted triple-distilled glass of &quot;milk&quot;	8	EPIC	Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2014-07"
+7590	weak lousy enchanted narrow cup of &quot;tea&quot;	2	decent	Effect: "Oriental Mysticism", Effect Duration: 10, Last Available: "2014-07"
+7591	hand-crafted practically non-alcoholic shaking yellow thermos of &quot;whiskey&quot;	1	EPIC	Last Available: "2014-07"
+7592	mediocre fortified fancy Lucky Lindy	5	decent	Effect: "Toast Tea", Effect Duration: 35, Last Available: "2014-07"
 7593	hand-crafted blurry Bee's Knees	4	EPIC	Last Available: "2014-07"
-7594	drinkable spinning blue Sockdollager	4	good	Last Available: "2014-07"
+7594	drinkable blue spinning Sockdollager	4	good	Last Available: "2014-07"
 7595	acceptable Ish Kabibble	4	good	Last Available: "2014-07"
-7596	tolerable fancy Hot Socks	4	good	Effect: "Gonna Get You, Sucker", Effect Duration: 5, Last Available: "2014-07"
-7597	lousy triple-distilled Phonus Balonus	7	decent	Last Available: "2014-07"
+7596	fancy tolerable Hot Socks	4	good	Effect: "Gonna Get You, Sucker", Effect Duration: 5, Last Available: "2014-07"
+7597	triple-distilled lousy Phonus Balonus	7	decent	Last Available: "2014-07"
 7598	mediocre practically non-alcoholic ghostly Flivver	1	decent	Last Available: "2014-07"
 7599	bad teal Sloppy Jalopy	3	decent	Last Available: "2014-07"
 7600	diffused flame	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 57
@@ -7508,12 +7508,12 @@
 7619	double-diffused super-enhanced narrow copperhead potion	0		Effect: "Sugar, Hello", Effect Duration: 30
 7620	quadruple-polarized ninja fear powder	0		Effect: "Amplified Fabulousness", Effect Duration: 45
 7621	altered cyan ninja eyeblack	0		Effect: "Snobby", Effect Duration: 19
-7622	boiled irradiated pressed wobbly maroon button rouge	0		Effect: "Electrolit Up", Effect Duration: 24
+7622	boiled irradiated pressed maroon wobbly button rouge	0		Effect: "Electrolit Up", Effect Duration: 24
 7623	vacuum-sealed polarized corrupted skewed Red Army camouflage kit	0		Effect: "Twinklebritches", Effect Duration: 38
 7624	polarized lynyrd skinner toothblack	0		Effect: "Stenchtastic", Effect Duration: 64
 7625	polarized galvanized flask of rainwater	0		Effect: "In the Saucestream", Effect Duration: 22
 7626	vacuum-sealed lime green oyster badge	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 30
-7627	moist skewed purple plastic Jefferson wings	0		Effect: "Twen Tea", Effect Duration: 48
+7627	moist purple skewed plastic Jefferson wings	0		Effect: "Twen Tea", Effect Duration: 48
 7628	pressed ghostly green dancing fan	0		Effect: "Sauce Monocle", Effect Duration: 16
 7629	oxidized blurry wobbly page of the Necrohobocon	0		Effect: "Shawarma Warm War", Effect Duration: 34
 7630	magnetized corrupted maroon magic powder	0		Effect: "License to Punch", Effect Duration: 38
@@ -7559,7 +7559,7 @@
 7670	maroon Van der Graaf dangerous famous raincoat of James Dean	0		Experience (Moxie): +3, Weapon Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover
 7671	resourceful energetic wizardly lightning rod	0		Mysticality: +25, Maximum MP Percent: +20, Maximum MP: +50, Lasts Until Rollover
 7672	narrow cool law-abiding citizen cane	0		Moxie: +5, Single Equip
-7673	irresponsibly strong artisanal twirling legitimate business on the beach	10	EPIC	
+7673	artisanal irresponsibly strong twirling legitimate business on the beach	10	EPIC	
 7674	shellacked hep waders	0		Damage Reduction: 7, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	bland jive turkey leg	3	decent	
 7676	maroon Herculean birdbone corset	0		Experience (Muscle): +1
@@ -7573,7 +7573,7 @@
 7684	shaking pulsating Sinatra's Time Lord Participation Mug	0		Experience (Moxie): +5
 7685	Sherlock's Time Bandit Time Towel of the sweet-tooth	0		Item Drop: +25, Candy Drop: +100
 7686	stanky brawny Caveman Dan's favorite rock of the sewer	0		Muscle Percent: +20, Stench Damage: +25, Stench Spell Damage: +25, Single Equip
-7687	adjusted purple mirror dog ointment	0		Effect: "Blessing of Charcoatl", Effect Duration: 65
+7687	adjusted mirror purple dog ointment	0		Effect: "Blessing of Charcoatl", Effect Duration: 65
 7688	green miser's careful gumshoes	0		Monster Level: -10, Meat Drop: +10, Single Equip
 7689	purple miser's banded flapper floppers	0		Damage Absorption: +100, Meat Drop: +10, Single Equip
 7690	squat chaotic sneakeasies of the detective	0		Spell Critical Percent: +10, Item Drop: +20, Single Equip
@@ -7581,7 +7581,7 @@
 7692	tumbling executive coward's hand whip of the wise owl	0		Mysticality: +20, Monster Level: -20, Meat Drop: +40, Last Available: "2014-08"
 7693	blinking Newton's glow-in-the-dark necklace of incineration of the glutton	0		Experience (Mysticality): +3, Hot Spell Damage: +50, Food Drop: +100, Last Available: "2014-08"
 7694	green Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	wobbly dangerous Fonzie's cap gun of the empath	0		Experience (Moxie): +1, Weapon Damage: +10, Familiar Weight: +5, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	wobbly dangerous Fonzie's cap gun of the empath	0		Experience (Moxie): +1, Weapon Damage: +10, Familiar Weight: +5, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	jittery dance instructor's cassette player of courage	0		Experience Percent (Moxie): +10, Spooky Resistance: +3, Single Equip, Last Available: "2014-08"
 7697	pulsating chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7592,14 +7592,14 @@
 7703	wobbly LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	skewed LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	cyan The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	cyan The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	chilled oxidized rubber nubbin	0		Effect: "Adorable Lookout", Effect Duration: 18, Last Available: "2014-08"
 7708	ghostly lion tamer's supercool rubber cape	0		Moxie Percent: +20, Experience (familiar): +2, Last Available: "2014-08"
-7709	maroon MacGyver's therapeutic hale rosy-cheeked Thor's Pliers	0		Maximum HP Percent: +30, Maximum HP: +20, Maximum MP: +100, HP Regen Min: 5, HP Regen Max: 7, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	maroon MacGyver's therapeutic hale rosy-cheeked Thor's Pliers	0		Maximum HP Percent: +30, Maximum HP: +20, Maximum MP: +100, HP Regen Min: 5, HP Regen Max: 7, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	aerosolized polarized candy UFOs	0		Effect: "Rootin' Around", Effect Duration: 66
 7711	weightlifter's water wings for babies of the glutton	0		Muscle: +15, Food Drop: +100
-7712	twirling beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	flavorless bite-sized Strix stix	1	decent	
+7712	twirling beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7713	bite-sized flavorless Strix stix	1	decent	
 7714	blinking mirror sizzling vampire pellet of the storm of Gandalf	0		Maximum MP Percent: +40, Spell Critical Percent: +20, Hot Damage: +10
 7715	practically non-alcoholic lousy non-aged vinegar	1	decent	
 7716	supercool unsanitized scalpel	0		Moxie Percent: +20
@@ -7624,8 +7624,8 @@
 7735	Xiblaxian alloy	0		Last Available: "2014-09"
 7736	mirror Xiblaxian crystal	0		Last Available: "2014-09"
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
-7738	gray blurry Xiblaxian cache locator simcode	0		Last Available: "2014-09"
-7739	upside-down purple Xiblaxian holo-training simcode	0		Last Available: "2014-09"
+7738	blurry gray Xiblaxian cache locator simcode	0		Last Available: "2014-09"
+7739	purple upside-down Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	tumbling Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	spinning Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
@@ -7639,16 +7639,16 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	gray Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	savvy Xiblaxian xeno-detection goggles	0		Mysticality Percent: +20, Single Equip, Last Available: "2014-09"
-7753	tumbling knitted forbidden Xiblaxian stealth cowl	0		Spell Damage Percent: +50, Cold Resistance: +3, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	tumbling knitted forbidden Xiblaxian stealth cowl	0		Spell Damage Percent: +50, Cold Resistance: +3, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	family-friendly supercharged Xiblaxian stealth trousers	0		Maximum MP Percent: +30, Sleaze Resistance: +1, Last Available: "2014-09"
 7755	shellacked cool Xiblaxian stealth vest	0		Moxie: +5, Damage Reduction: 7, Last Available: "2014-09"
 7756	massive moldy Xiblaxian ultraburrito	9	crappy	Last Available: "2014-09"
-7757	distilled hand-crafted Xiblaxian space-whiskey	5	EPIC	Last Available: "2014-09"
+7757	hand-crafted distilled Xiblaxian space-whiskey	5	EPIC	Last Available: "2014-09"
 7758	teal Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	galvanized shaking They liver	0		Effect: "Irresistible Resolve", Effect Duration: 55, Last Available: "2014-09"
 7760	decent They liver popsicle	4	good	Last Available: "2014-09"
 7761	gray holo-tank	0		Last Available: "2014-09"
-7762	purple ghostly holo-bomber	0		Last Available: "2014-09"
+7762	ghostly purple holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
 7764	twisted residual zeal	1		Effect: "Biologically Shocked", Effect Duration: 15, Last Available: "2014-09"
 7765	extremely unsafe Xiblaxian holo-wrist-puter	0		Weapon Damage Percent: +100, Last Available: "2014-09"
@@ -7669,24 +7669,24 @@
 7780	avaricious dangerous heavy-duty clipboard of the empath	0		Weapon Damage: +10, Familiar Weight: +5, Meat Drop: +30, Damage Reduction: 8, Last Available: "2014-10"
 7781	mansplainer's groovy battery-powered drill of chilblains of the boozehound	0		Moxie Percent: +10, Monster Level: +15, Cold Damage: +25, Booze Drop: +100, Last Available: "2014-10"
 7782	bland squat limp broccoli	3	decent	Last Available: "2014-10"
-7783	Tesla Rosewater's slick hat	0		Moxie: +10, Mysticality Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7783	Tesla Rosewater's slick hat	0		Moxie: +10, Mysticality Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	ionized twirling monkey barf	0		Effect: "Pumped Up", Effect Duration: 28, Last Available: "2014-10"
 7785	cold-filtered candy	0		Effect: "Angry Bone", Effect Duration: 23, Last Available: "2014-10"
 7786	sizzling Samson's jangly bracelet of doom	0		Experience (Muscle): +5, Hot Damage: +10, Spooky Spell Damage: +50, Last Available: "2014-10"
-7787	blinking supercool cuddly teddy bear	0		Moxie Percent: +20, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
-7788	blurry maroon ice-cold Cloaca Zero	0		Last Available: "2014-10"
+7787	blinking supercool cuddly teddy bear	0		Moxie Percent: +20, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7788	maroon blurry ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	cyan spinning Temple Grandin's Socratic first-aid pouch	0		Experience (Mysticality): +1, Familiar Weight: +7, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	ionized airborne mutagen	0		Effect: "Eyes All Black", Effect Duration: 52, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	thick yummy initiative shawarma	5	awesome	Last Available: "2014-10"
+7795	yummy thick initiative shawarma	5	awesome	Last Available: "2014-10"
 7796	flavorless teal warm war shawarma	4	decent	Last Available: "2014-10"
 7797	rotten ghostly karma shawarma	4	crappy	Last Available: "2014-10"
-7798	practically non-alcoholic artisanal enchanted Jungle Juice	1	EPIC	Effect: "Psalm of Pointiness", Effect Duration: 10, Last Available: "2014-10"
-7799	aged strong Amnesiac Ale	5	awesome	Last Available: "2014-10"
-7800	mediocre strong skewed Highest Bitter	5	decent	Last Available: "2014-10"
+7798	enchanted artisanal practically non-alcoholic Jungle Juice	1	EPIC	Effect: "Psalm of Pointiness", Effect Duration: 10, Last Available: "2014-10"
+7799	strong aged Amnesiac Ale	5	awesome	Last Available: "2014-10"
+7800	strong mediocre skewed Highest Bitter	5	decent	Last Available: "2014-10"
 7801	bouncing Usain Bolt's mercenary pistol of the cheetah	0		Initiative: 140, Last Available: "2014-10"
 7802	blinking nasty strapping mercenary rifle	0		Muscle: +5, Stench Damage: +5, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7700,20 +7700,20 @@
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	normal seared dino steak	4	good	
-7814	mediocre high-proof bottle of drinkin' gas	7	decent	
-7815	tumbling blurry handful of napalm	0		
+7814	high-proof mediocre bottle of drinkin' gas	7	decent	
+7815	blurry tumbling handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
 7818	blurry 99.44% pure math	0		
 7819	skewed simple AI	0		
 7820	corrupted bird DNA	0		
 7821	sentient meat mass	0		
-7822	tumbling huge zombie dinosaur egg	0		
+7822	huge tumbling zombie dinosaur egg	0		
 7823	ghostly french-fry grabber	0		Familiar Weight: +5
 7824	avaricious wool iShield of mayonnaise	0		Sleaze Spell Damage: +50, Cold Resistance: +1, Meat Drop: +30, Damage Reduction: 6
 7825	fuchsia ghostly stanky lion tamer's friendly earbuds	0		Familiar Weight: +3, Experience (familiar): +2, Stench Spell Damage: +25, Single Equip
 7826	mirror ghostly greedy double-paned vibrating iFlail	0		Maximum MP Percent: +10, Cold Resistance: +5, Meat Drop: +20
-7827	tiny yummy unidentifiable dried fruit	1	awesome	
+7827	yummy tiny unidentifiable dried fruit	1	awesome	
 7828	perfectly mixed weak flat cider	2	EPIC	
 7829	miser's reassuring trench lighter of temperance	0		Spooky Resistance: +1, Sleaze Resistance: +5, Meat Drop: +10, Last Available: "2014-10"
 7830	activated quadruple-polarized experimental serum P-00	0		Effect: "Spooky Flavor", Effect Duration: 25, Last Available: "2014-10"
@@ -7743,8 +7743,8 @@
 7854	fuchsia sinister plastic Crimbot	0		Spell Damage: +10, Last Available: "2014-12"
 7855	groovy plastic Crimbomega	0		Moxie Percent: +10, Last Available: "2014-12"
 7856	improved bouncing flask of mining oil	0		Effect: "Ready to Snap", Effect Duration: 14, Last Available: "2014-12"
-7857	sharpshooter's radiation-resistant helmet	0		Critical Hit Percent: +10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	foul-smelling servo-assisted exo-pants	0		Stench Damage: +10, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	sharpshooter's radiation-resistant helmet	0		Critical Hit Percent: +10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	foul-smelling servo-assisted exo-pants	0		Stench Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	grievous high-energy mining laser of Flo-Jo	0		Weapon Damage Percent: +50, Initiative: +100, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	red nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7766,22 +7766,22 @@
 7877	bouncing bouncing Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	pulsating Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
-7880	maroon blurry Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
+7880	blurry maroon Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
 7881	Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
-7882	upside-down wobbly Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
+7882	wobbly upside-down Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	squat Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
 7885	spinning Crimbot schematic: Power Arm	0		Last Available: "2014-12"
 7886	Crimbot schematic: Wrecking Ball	0		Last Available: "2014-12"
-7887	shaking jittery Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
+7887	jittery shaking Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
 7888	narrow Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
-7889	wobbly jittery Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
+7889	jittery wobbly Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	narrow Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
-7892	fuchsia bouncing Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
+7892	bouncing fuchsia Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	jittery Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
-7895	ghostly maroon Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
+7895	maroon ghostly Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	squat Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
@@ -7791,7 +7791,7 @@
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
-7905	squat blinking lime green recovered elf magazine	0		Last Available: "2014-12"
+7905	lime green blinking squat recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
 7907	blurry recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	wobbly recovered elf underpants	0		Last Available: "2014-12"
@@ -7808,10 +7808,10 @@
 7919	wet modified Big Punk	0		Effect: "Bear Clawed", Effect Duration: 39
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	blinking turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	smooth weak fancy maroon Friendly Turkey	2	awesome	Effect: "Cosmic Flavor", Effect Duration: 35, Last Available: "2014-11"
-7923	distilled lousy special wobbly Agitated Turkey	5	decent	Effect: "Violent Night", Effect Duration: 25, Last Available: "2014-11"
-7924	weak bad lime green Ambitious Turkey	2	decent	Last Available: "2014-11"
-7925	fancy half-sized rotten neutron lollipop	2	crappy	Effect: "L'instinct F&eacute;lin", Effect Duration: 40, Last Available: "2014-12"
+7922	weak fancy smooth maroon Friendly Turkey	2	awesome	Effect: "Cosmic Flavor", Effect Duration: 35, Last Available: "2014-11"
+7923	lousy distilled special wobbly Agitated Turkey	5	decent	Effect: "Violent Night", Effect Duration: 25, Last Available: "2014-11"
+7924	bad weak lime green Ambitious Turkey	2	decent	Last Available: "2014-11"
+7925	rotten half-sized fancy neutron lollipop	2	crappy	Effect: "L'instinct F&eacute;lin", Effect Duration: 40, Last Available: "2014-12"
 7926	acceptable gamma nog	3	good	Last Available: "2014-12"
 7934	squat sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7828,7 +7828,7 @@
 7946	resourceful vibrating Socratic outlaw bandana	0		Experience (Mysticality): +1, Maximum MP Percent: +10, Maximum MP: +50
 7947	acceptable whiskey in a broken glass	4	good	
 7948	acceptable shot of mescal	3	good	
-7949	practically non-alcoholic bad glass of herbal tequila	1	decent	
+7949	bad practically non-alcoholic glass of herbal tequila	1	decent	
 7950	skewed minin' dynamite	0		
 7951	manspreader's plaid cowboy hat of the businessman	0		Monster Level: +10, Meat Drop: +50, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7839,7 +7839,7 @@
 7957	even more tinsel	0		Familiar Weight: +5
 7958	spinning box of Crimbo decorations	0		
 7959	squat letter to Ed the Undying	0		
-7960	skewed fuchsia copy of a jerk adventurer's father's diary	0		
+7960	fuchsia skewed copy of a jerk adventurer's father's diary	0		
 7961	blurry smelly Staff of Ed of James Dean of the blizzard of the sweet-tooth	0		Experience (Moxie): +3, Cold Spell Damage: +25, Stench Spell Damage: +10, Candy Drop: +100
 7962	pulsating Eye of Ed	0		
 7963	amulet	0		
@@ -7876,22 +7876,22 @@
 7994	double-paned Temple Grandin's pepper mill	0		Familiar Weight: +7, Cold Resistance: +5, Last Available: "2015-12"
 7995	chaotic pelerine of courage	0		Spell Critical Percent: +10, Spooky Resistance: +3, Last Available: "2015-12"
 7996	narrow censurious supercool phantom mask	0		Moxie Percent: +20, Sleaze Resistance: +3, Single Equip, Last Available: "2015-12"
-7997	altered maroon twirling spinning polyesterene powder	1		Effect: "Icy Composition", Effect Duration: 40, Last Available: "2015-12"
-7998	altered pulsating upside-down powder	1		Last Available: "2015-12"
+7997	altered spinning maroon twirling polyesterene powder	1		Effect: "Icy Composition", Effect Duration: 40, Last Available: "2015-12"
+7998	altered upside-down pulsating powder	1		Last Available: "2015-12"
 7999	denatured shaking choco-Crimbot	0		Effect: "Liquid Courage", Effect Duration: 59, Last Available: "2014-12"
 8000	altered alkaline cold-filtered smart watch	0		Effect: "Fastbreaker", Effect Duration: 66, Last Available: "2014-12"
 8001	cold-filtered purple augmented-reality shades	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 22, Last Available: "2014-12"
-8002	toy Crimbot mega face of the empath	0		Familiar Weight: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
-8003	Herculean toy Crimbot power glove	0		Experience (Muscle): +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	wool toy Crimbot super fist	0		Cold Resistance: +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	nippy toy Crimbot rocket legs	0		Cold Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	toy Crimbot mega face of the empath	0		Familiar Weight: +5, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	Herculean toy Crimbot power glove	0		Experience (Muscle): +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	wool toy Crimbot super fist	0		Cold Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	nippy toy Crimbot rocket legs	0		Cold Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	frozen Crimbot battery	0		Effect: "Chain Chain Chains", Effect Duration: 42, Last Available: "2014-12"
 8007	blinking Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	bouncing Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	censurious deadly Crimbomega drive chain of temperance	0		Weapon Damage: +5, Sleaze Resistance: 8, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	censurious deadly Crimbomega drive chain of temperance	0		Weapon Damage: +5, Sleaze Resistance: 8, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	shaking squat Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	bouncing Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7910,7 +7910,7 @@
 8028	artificial skylight	0		Last Available: "2015-01"
 8029	shaking Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
-8031	spinning narrow stationery set	0		Last Available: "2015-01"
+8031	narrow spinning stationery set	0		Last Available: "2015-01"
 8032	upside-down calligraphy pen	0		Free Pull, Last Available: "2015-01"
 8033	alpine watercolor set	0		Last Available: "2015-01"
 8034	reassuring tope&eacute; of Gandalf	0		Spell Critical Percent: +20, Spooky Resistance: +1, Familiar Effect: "3xBarrr, cap 12"
@@ -7952,9 +7952,9 @@
 8071	tumbling warehouse inventory page	0		
 8072	squat janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	avaricious toasty wicked Spelunker's fedora	0		Spell Damage: +5, Hot Damage: +5, Meat Drop: +30, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	avaricious toasty wicked Spelunker's fedora	0		Spell Damage: +5, Hot Damage: +5, Meat Drop: +30, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	red ribald fortified sage Spelunker's whip	0		Mysticality Percent: +10, Damage Absorption: +60, Sleaze Damage: +10, Last Available: "2015-12"
-8076	shaking rosy-cheeked studded arcane researcher's Spelunker's khakis	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Maximum HP Percent: +30, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	shaking rosy-cheeked studded arcane researcher's Spelunker's khakis	0		Experience Percent (Mysticality): +10, Damage Absorption: +80, Maximum HP Percent: +30, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7984,7 +7984,7 @@
 8109	blinking Jack Frost's ascot of the dark arts	0		Spell Damage Percent: +100, Cold Spell Damage: +50, Single Equip, Last Available: "2017-12"
 8110	supercharged attache case of the sewer	0		Maximum MP Percent: +30, Stench Damage: +25, Last Available: "2017-12"
 8111	bouncing miser's accordion of the cheetah	0		Meat Drop: +10, Initiative: +60, Song Duration: 10, Last Available: "2017-12"
-8112	compressed spinning huge red aerosolized	1		Last Available: "2017-12"
+8112	compressed red huge spinning aerosolized	1		Last Available: "2017-12"
 8113	Lo Pan's wig of the brute	0		Muscle Percent: +30, Spell Critical Percent: +30, Last Available: "2017-12"
 8114	medical-grade winch crank	0		Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-12"
 8115	greasy ruddy widget	0		Maximum HP Percent: +40, Sleaze Spell Damage: +10, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	prompt beefy garland	0		Muscle: +10, Adventures: +3, Single Equip, Last Available: "2018-12"
 8122	gunnysack of dire peril of extreme caution	0		Weapon Damage: +20, Monster Level: -25, Last Available: "2018-12"
 8123	teal shellacked strapping garibaldi	0		Muscle: +5, Damage Reduction: 7, Last Available: "2018-12"
-8124	yellow Sinatra's girdle of the early riser	0		Experience (Moxie): +5, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	yellow Sinatra's girdle of the early riser	0		Experience (Moxie): +5, Adventures: +7, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	gloves of the scaredy-cat of the overflowing toilet	0		Monster Level: -15, Stench Spell Damage: +50, Single Equip, Last Available: "2018-12"
 8126	distilled fuchsia smithereens	1		Last Available: "2018-12"
 8127	blinking Jim Carey's healthy fiberglass fetish	0		Maximum HP Percent: +20, Monster Level: +25, Last Available: "2018-12"
@@ -8006,7 +8006,7 @@
 8131	therapeutic forbidden fiberglass fingerguard	0		Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-12"
 8132	family-friendly supercharged fiberglass fedora	0		Maximum MP Percent: +30, Sleaze Resistance: +1, Last Available: "2018-12"
 8133	boiled twirling fiberglass fibers	1		Last Available: "2018-12"
-8134	purple blinking bottle of lovebug pheromones	0		Free Pull
+8134	blinking purple bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	blinking bouncing spinning talisman of Renenutet	0		
 8138	rubber spatula of vim and vigor	0		Maximum HP Percent: +50
@@ -8042,7 +8042,7 @@
 8168	teal ghostly glob of icing	0		
 8169	polarized double-polymerized ginger snaps	0		Effect: "Cotton Mouthed", Effect Duration: 40
 8170	anodized chilled mostly-broken sunglasses	0		Effect: "Bloodstain-Resistant", Effect Duration: 11
-8171	artisanal watered-down unflavored wine cooler	2	EPIC	
+8171	watered-down artisanal unflavored wine cooler	2	EPIC	
 8172	ghostly carton of snake milk	1	good	
 8173	sewer snake of Calamity Jane	0		Critical Hit Percent: +15
 8174	spoiled big pigeon egg	5	crappy	
@@ -8056,27 +8056,27 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	twirling fuchsia miser's bread basket	0		Meat Drop: +10
 8184	Ed the Undying exhibit crate	0		
-8185	squat lion tamer's stylish The Crown of Ed the Undying	0		Moxie: +25, Experience (familiar): +2, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	squat lion tamer's stylish The Crown of Ed the Undying	0		Moxie: +25, Experience (familiar): +2, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	maroon map to a hidden booze cache	0		
 8188	acceptable Cherrytastrophe wine cooler	3	good	
-8189	tolerable weak Radberry Rip wine cooler	2	good	
+8189	weak tolerable Radberry Rip wine cooler	2	good	
 8190	acceptable wobbly Orangemageddon wine cooler	3	good	
-8191	aged practically non-alcoholic narrow upside-down Breakfast Blast wine cooler	1	awesome	
+8191	practically non-alcoholic aged upside-down narrow Breakfast Blast wine cooler	1	awesome	
 8192	artisanal Citrus Crush wine cooler	3	EPIC	
-8193	stale low-calorie plain bagel	1	decent	
+8193	low-calorie stale plain bagel	1	decent	
 8194	stale huge glob of cream cheese	9	decent	
 8195	adequate green loaf of soda bread	4	good	
 8196	stale blue acceptable bagel	4	decent	
 8197	adequate tiny standard-issue cupcake	1	good	
-8198	fancy miniature bland ultra-deluxe cupcake	2	decent	Effect: "You Can Really Taste the Dormouse", Effect Duration: 50
+8198	fancy bland miniature ultra-deluxe cupcake	2	decent	Effect: "You Can Really Taste the Dormouse", Effect Duration: 50
 8199	yellow spinning hypnotic breadcrumbs	0		
 8200	adequate half-sized jittery jittery popular tart	2	good	
 8201	no-handed pie	0		
 8202	energized bouncing Doc Galaktik's Vitality Serum	0		Effect: "The Magic of Sharing", Effect Duration: 37
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
 8204	tumbling one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
-8205	twirling green FunFunds&trade;	0		Last Available: "2015-04"
+8205	green twirling FunFunds&trade;	0		Last Available: "2015-04"
 8206	pulsating smartaleck's expensive camera	0		Moxie Percent: +30, Item Drop: +5, Single Equip, Last Available: "2015-04"
 8207	green sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	unsweetened tarnished How to Avoid Scams	0		Effect: "Egg-stra Arm", Effect Duration: 19, Last Available: "2015-04"
@@ -8085,18 +8085,18 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	asbestos-lined Temple Grandin's rigging rope	0		Familiar Weight: +7, Hot Resistance: +5, Last Available: "2015-04"
-8214	mixed upside-down spinning nasty snuff	1	good	Effect: "Hennaliciousness", Effect Duration: 15, Last Available: "2015-04"
-8215	squat zippy lion tamer's sewage-clogged pistol	0		Experience (familiar): +2, Initiative: +20, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8214	mixed spinning upside-down nasty snuff	1	good	Effect: "Hennaliciousness", Effect Duration: 15, Last Available: "2015-04"
+8215	squat zippy lion tamer's sewage-clogged pistol	0		Experience (familiar): +2, Initiative: +20, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	altered galvanized quadruple-galvanized beard incense	0		Effect: "Vital", Effect Duration: 46, Last Available: "2015-04"
 8217	mirror yellow crafty beefcake's perfume-soaked bandana	0		Muscle: +25, Maximum MP: +10, Single Equip, Last Available: "2015-04"
 8218	shaking toxic globule	0		Last Available: "2015-04"
 8219	spoiled toxo	4	crappy	Last Available: "2015-04"
 8220	delicious Lemonade-235	4	awesome	Last Available: "2015-04"
-8221	lard-coated isotophat of courage	0		Sleaze Spell Damage: +25, Spooky Resistance: +3, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8221	lard-coated isotophat of courage	0		Sleaze Spell Damage: +25, Spooky Resistance: +3, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	stylish Three Mile Island shorts of the glutton	0		Moxie: +25, Food Drop: +100, Last Available: "2015-04"
 8223	perfumed hale toxic mop	0		Maximum HP: +20, Stench Resistance: +5, Last Available: "2015-04"
 8224	teal inert sludgepuppy	0		Last Available: "2015-04"
-8225	pulsating skewed lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
+8225	skewed pulsating lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	blurry jar of swamp honey	0		Last Available: "2015-04"
 8227	family-friendly reassuring backwoods banjo of the detective	0		Spooky Resistance: +1, Sleaze Resistance: +1, Item Drop: +20, Last Available: "2015-04"
 8228	mirror grody jug	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	jittery spinning lube-shoes of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-04"
 8245	narrow trash net	0		Last Available: "2015-04"
 8246	wool deadly Dinsey mascot mask of horror	0		Weapon Damage: +5, Spooky Spell Damage: +25, Cold Resistance: +1, Last Available: "2015-04"
-8247	small decent maroon tumbling Dinsey food-cone	2	good	Last Available: "2015-04"
+8247	decent small tumbling maroon Dinsey food-cone	2	good	Last Available: "2015-04"
 8248	delicious red squat Dinsey Whinskey	4	awesome	Last Available: "2015-04"
 8249	polymerized moist shaking Dinsey face paint	0		Effect: "Peppermint Bite", Effect Duration: 45, Last Available: "2015-04"
 8250	chilly fannypack of the overflowing toilet	0		Cold Damage: +5, Stench Spell Damage: +50, Last Available: "2015-04"
@@ -8145,7 +8145,7 @@
 8271	decent uninteresting mayolus	4	good	Last Available: "2015-05"
 8272	flavorless acceptable mayolus	4	decent	Last Available: "2015-05"
 8273	bland spinning enticing mayolus	4	decent	Last Available: "2015-05"
-8274	decent half-sized narrow mouth-watering mayolus	2	good	Last Available: "2015-05"
+8274	half-sized decent narrow mouth-watering mayolus	2	good	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	wobbly mayo pump	0		Familiar Weight: +5
 8277	Essence of Bear	0		Skill: "Bear Essence"
@@ -8191,9 +8191,9 @@
 8317	aerosolized concentrated mirror pickpocket protector	0		Effect: "Haunted Liver", Effect Duration: 38
 8318	denatured upside-down sinister-looking cat	0		Effect: "In Vino Vires", Effect Duration: 56
 8319	vacuum-sealed chilled chilled red jazzy cigarette holder	0		Effect: "Mucilaginous Mentalism", Effect Duration: 22
-8320	vacuum-sealed blue twirling blinking one glove	0		Effect: "Healthy Red Glow", Effect Duration: 40
+8320	vacuum-sealed twirling blinking blue one glove	0		Effect: "Healthy Red Glow", Effect Duration: 40
 8321	adjusted denatured glove	0		Effect: "Boo Tea", Effect Duration: 67
-8322	polarized bouncing skewed handful of fire	0		Effect: "Work For Hours a Week", Effect Duration: 13
+8322	polarized skewed bouncing handful of fire	0		Effect: "Work For Hours a Week", Effect Duration: 13
 8323	electrified upside-down Cracklin' Oat Bran	0		Effect: "Heightened Senses", Effect Duration: 30
 8324	enhanced frozen disposable lighter	0		Effect: "Mer-kindliness", Effect Duration: 18
 8325	ionized coal contact lenses	0		Effect: "Hammered", Effect Duration: 39
@@ -8201,11 +8201,11 @@
 8327	quadruple-energized deionized Iceberglar scarf	0		Effect: "Using Protection", Effect Duration: 43
 8328	vacuum-sealed huge icy hairspray	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 14
 8329	dry skewed smellbook	0		Effect: "Oh Snap", Effect Duration: 60
-8330	diffused green narrow assassin's cheese knife	0		Effect: "Lemon Enlightenment", Effect Duration: 61
+8330	diffused narrow green assassin's cheese knife	0		Effect: "Lemon Enlightenment", Effect Duration: 61
 8331	dry concentrated filthy armor	0		Effect: "Eau de Tortue", Effect Duration: 48
 8332	magnetized triple-aerosolized plague pie	0		Effect: "Human-Human Hybrid", Effect Duration: 62
 8333	altered irradiated denatured green batarang	0		Effect: "Purity of Spirit", Effect Duration: 21
-8334	ionized jittery wobbly spare neck bolts	0		Effect: "damage.enh", Effect Duration: 48
+8334	ionized wobbly jittery spare neck bolts	0		Effect: "damage.enh", Effect Duration: 48
 8335	polarized squat grease trap	0		Effect: "Wet and Greedy", Effect Duration: 54
 8336	polarized purple shamanic ham	0		Effect: "Human-Slime Hybrid", Effect Duration: 25
 8337	pickled porkpocket	0		Effect: "Brother Corsican's Blessing", Effect Duration: 52
@@ -8223,7 +8223,7 @@
 8349	chilled huge hand of cards	0		Effect: "Puzzle Fury", Effect Duration: 12
 8350	quadruple-anodized activated shaking damp bar rag	0		Effect: "Enraged", Effect Duration: 67
 8351	cold-filtered quadruple-improved warmed shaking lump of goofball ore	0		Effect: "Mushroom Might", Effect Duration: 62
-8352	denatured bouncing ghostly skeleton beans	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 11
+8352	denatured ghostly bouncing skeleton beans	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 11
 8353	Vulcanized grimy lab coat	0		Effect: "One For Tea", Effect Duration: 69
 8354	pickled denatured shaking nursery rhyme	0		Effect: "Broken Bone Nubs", Effect Duration: 30
 8355	aerosolized ionized iron torso box	0		Effect: "Whitened Teeth", Effect Duration: 15
@@ -8235,10 +8235,10 @@
 8361	concentrated cyan child-sized dracula cloak	0		Effect: "Knightlife", Effect Duration: 49
 8362	adjusted squat devil-summoning hat	0		Effect: "Sourpuss", Effect Duration: 60
 8363	super-polymerized blue shopkeeper beard	0		Effect: "Dreadful Smell", Effect Duration: 21
-8364	concentrated blinking red alien autoautopsy kit	0		Effect: "Stinky Weapon", Effect Duration: 63
+8364	concentrated red blinking alien autoautopsy kit	0		Effect: "Stinky Weapon", Effect Duration: 63
 8365	colloidal novelty fruit hat	0		Effect: "Muscle Unbound", Effect Duration: 33
 8366	activated colloidal invisibility cream	0		Effect: "Purpose", Effect Duration: 57
-8367	wet huge blinking handful of stubble	0		Effect: "Sweet and Yellow", Effect Duration: 36
+8367	wet blinking huge handful of stubble	0		Effect: "Sweet and Yellow", Effect Duration: 36
 8368	wet liquefied garbage juice slurpee	0		Effect: "Remaining Alive", Effect Duration: 67
 8369	Vulcanized quantum denatured plunge-leg	0		Effect: "Flaming Weapon", Effect Duration: 54
 8370	ionized funky eyepatch	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 47
@@ -8246,7 +8246,7 @@
 8372	vacuum-sealed galvanized flashy pirate dreadlocks	0		Effect: "Painted-On Bikini", Effect Duration: 65
 8373	non-boiled captured boozles	0		Effect: "Unusual Fashion Sense", Effect Duration: 52
 8374	wet drinks tray	0		Effect: "Healthy Red Glow", Effect Duration: 69
-8375	concentrated aerosolized tumbling upside-down eyebrow lifter	0		Effect: "Three Days Slow", Effect Duration: 26
+8375	concentrated aerosolized upside-down tumbling eyebrow lifter	0		Effect: "Three Days Slow", Effect Duration: 26
 8376	gray submarine	0		Last Available: "2015-06"
 8377	flavorless pixel lemon	4	decent	Last Available: "2015-06"
 8378	bad pixel daiquiri	4	decent	Last Available: "2015-06"
@@ -8281,7 +8281,7 @@
 8407	gigantic stale pestopiary	10	decent	
 8408	magnetized improved ectoplasmic orbs	0		Effect: "Tin, Man", Effect Duration: 39
 8409	rotten crudles	4	crappy	
-8410	flavorless miniature agnolotti arboli	2	decent	
+8410	miniature flavorless agnolotti arboli	2	decent	
 8411	miniature adequate spaghetti with ghost balls	2	good	
 8412	adequate thick twirling succulent marrow	5	good	
 8413	normal salacious crumbs	4	good	
@@ -8298,7 +8298,7 @@
 8424	cyan 1,970 carat	0		Last Available: "2015-08"
 8425	maroon New Age healing crystal	0		Last Available: "2015-08"
 8426	shaking Volcoino	0		Last Available: "2015-08"
-8427	upside-down skewed fizzing spore pod	0		
+8427	skewed upside-down fizzing spore pod	0		
 8428	spore pod	0		
 8429	veiny spore pod	0		
 8430	hard spore pod	0		
@@ -8310,7 +8310,7 @@
 8436	LavaCo Lamp&trade; of the empath of the sewer	0		Familiar Weight: +5, Stench Damage: +25, Last Available: "2015-08"
 8437	avaricious chaotic LavaCo Lamp&trade;	0		Spell Critical Percent: +10, Meat Drop: +30, Last Available: "2015-08"
 8438	mirror thin wire	0		Last Available: "2015-08"
-8439	spinning yellow insulated wire	0		Last Available: "2015-08"
+8439	yellow spinning insulated wire	0		Last Available: "2015-08"
 8440	upside-down cyan empty lava bottle	0		Last Available: "2015-08"
 8441	lime green full lava bottle	0		Last Available: "2015-08"
 8442	viscous lava globs	0		Last Available: "2015-08"
@@ -8329,9 +8329,9 @@
 8455	narrow New Age crystal	0		Last Available: "2015-08"
 8456	narrow crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	frightening experienced high-temperature mining mask	0		Experience: +2, Spooky Damage: +5, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	frightening experienced high-temperature mining mask	0		Experience: +2, Spooky Damage: +5, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	family-friendly Oprah's fireproof megaphone	0		Maximum MP Percent: +50, Sleaze Resistance: +1, Last Available: "2015-08"
-8460	rotten bite-sized mineapple	1	crappy	Last Available: "2015-08"
+8460	bite-sized rotten mineapple	1	crappy	Last Available: "2015-08"
 8461	hand-crafted Gold Velvet&trade; whiskey	3	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	good	Last Available: "2015-08"
 8463	normal smelted roe	4	good	Last Available: "2015-08"
@@ -8346,13 +8346,13 @@
 8472	heat-resistant necktie of doom of the cheetah	0		Spooky Spell Damage: +50, Initiative: +60, Single Equip, Last Available: "2015-08"
 8473	red rosewater-soaked razor-sharp heat-resistant gloves of the blizzard	0		Weapon Damage Percent: +25, Cold Spell Damage: +25, Stench Resistance: +3, Single Equip, Last Available: "2015-08"
 8474	tasty very hot lunch	3	awesome	Last Available: "2015-08"
-8475	mediocre weak jittery asbestos thermos	2	decent	Last Available: "2015-08"
+8475	weak mediocre jittery asbestos thermos	2	decent	Last Available: "2015-08"
 8476	concentrated ionized liquid rhinestones	0		Effect: "Coming Up Roses", Effect Duration: 33, Last Available: "2015-08"
 8477	massive normal disco biscuit	7	good	Last Available: "2015-08"
 8478	perfectly mixed weak twirling Quaatorade&trade;	2	EPIC	Last Available: "2015-08"
-8479	blinking pulsating double-paned energetic thinker's biker's hat	0		Mysticality: +10, Maximum MP Percent: +20, Cold Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk"
-8480	spinning blurry rosewater-soaked lard-coated sage feathered headdress	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, Stench Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	twirling Newton's electrician's hardhat of wisdom of the brute	0		Mysticality: +15, Muscle Percent: +30, Experience (Mysticality): +3, Last Available: "2015-08", Familiar Effect: "atk"
+8479	blinking pulsating double-paned energetic thinker's biker's hat	0		Mysticality: +10, Maximum MP Percent: +20, Cold Resistance: +5, Familiar Effect: "atk", Last Available: "2015-08"
+8480	spinning blurry rosewater-soaked lard-coated sage feathered headdress	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, Stench Resistance: +3, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	twirling Newton's electrician's hardhat of wisdom of the brute	0		Mysticality: +15, Muscle Percent: +30, Experience (Mysticality): +3, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	lime green Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	jittery Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	grievous smooth velvet pants	0		Weapon Damage Percent: +50, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	grievous smooth velvet pants	0		Weapon Damage Percent: +50, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	twirling smooth velvet shirt of horror	0		Spooky Spell Damage: +25, Last Available: "2015-08"
 8492	upside-down lime green smooth velvet hat of Flo-Jo	0		Initiative: +100, Last Available: "2015-08"
 8493	stanky smooth velvet pocket square	0		Stench Spell Damage: +25, Single Equip, Last Available: "2015-08"
@@ -8391,13 +8391,13 @@
 8517	zippy auspicious SMOOCH bracers	0		Item Drop: +10, Initiative: +20, Single Equip, Last Available: "2015-08"
 8518	energetic SMOOCH kneepads	0		Maximum MP Percent: +20, Single Equip, Last Available: "2015-08"
 8519	ghostly lime green personal trainer's SMOOCH spaulders	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2015-08"
-8520	green Newton's smooth SMOOCH codpiece	0		Moxie: +15, Experience (Mysticality): +3, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	green Newton's smooth SMOOCH codpiece	0		Moxie: +15, Experience (Mysticality): +3, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	blinking zippy SMOOCH breastplate	0		Initiative: +20, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	upside-down fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	thick adequate blue twirling lava cake	5	good	Last Available: "2015-08"
-8526	bland miniature pink slime	2	decent	
+8525	adequate thick twirling blue lava cake	5	good	Last Available: "2015-08"
+8526	miniature bland pink slime	2	decent	
 8527	purple mirror Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	decent devil hair pasta	3	good	
@@ -8405,16 +8405,16 @@
 8531	squat Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
-8534	gigantic rotten skewed skewed libertagliatelle	7	crappy	
+8534	rotten gigantic skewed skewed libertagliatelle	7	crappy	
 8535	flavorless turkish mostaccioli	3	decent	
 8536	normal mirror linguini of the sea	3	good	
 8537	flattened Hersey&trade; SMOOCH	0		Effect: "Patience of the Tortoise", Effect Duration: 40
 8539	blinking Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
-8542	yummy lime green bouncing Fettris	4	awesome	
-8543	adequate upside-down spinning fusillocybin	4	good	
-8544	miniature moldy prescription noodles	2	crappy	
+8542	yummy bouncing lime green Fettris	4	awesome	
+8543	adequate spinning upside-down fusillocybin	4	good	
+8544	moldy miniature prescription noodles	2	crappy	
 8545	diluted huge blood-drive sticker	1	decent	
 8546	corrupted pulsating pulsating bag of grain	0		Effect: "Pie in the Sky", Effect Duration: 21
 8547	aerosolized huge skewed pocket maze	0		Effect: "Bestial Sympathy", Effect Duration: 61
@@ -8424,12 +8424,12 @@
 8551	tasty squat sausage without a cause	3	awesome	
 8552	super-tarnished blurry face paint	0		Effect: "Kindly Resolve", Effect Duration: 23
 8553	drinkable bouncing emergency margarita	3	good	
-8554	spirit-forward artisanal vintage smart drink	5	super ultra EPIC	
+8554	artisanal spirit-forward vintage smart drink	5	super ultra EPIC	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	skewed The Emperor's new cookie	0		
 8558	deionized Wickers bar	0		Effect: "Creepin' Up on You", Effect Duration: 20
-8559	diffused altered mirror bouncing bakelite-covered bacon	0		Effect: "Mmmmmelon", Effect Duration: 63
+8559	diffused altered bouncing mirror bakelite-covered bacon	0		Effect: "Mmmmmelon", Effect Duration: 63
 8560	magnetized non-liquefied blurry Aerheads	0		Effect: "Can Has Cyborger", Effect Duration: 43
 8561	boiled Wrotz	0		Effect: "Human-Hippy Hybrid", Effect Duration: 38
 8562	ionized red Gabarbar	0		Effect: "Human-Elf Hybrid", Effect Duration: 56
@@ -8437,7 +8437,7 @@
 8564	twirling shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	greasy lion tamer's educational barrel lid	0		Experience: +1, Experience (familiar): +2, Sleaze Spell Damage: +10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Van der Graaf dangerous barrel hoop earring of the ox	0		Muscle: +20, Weapon Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2015-09"
-8567	squat twirling careful Annie Oakley's beefcake's bankruptcy barrel	0		Muscle: +25, Critical Hit Percent: +20, Monster Level: -10, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	squat twirling careful Annie Oakley's beefcake's bankruptcy barrel	0		Muscle: +25, Critical Hit Percent: +20, Monster Level: -10, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8450,16 +8450,16 @@
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	perfectly mixed wobbly bottle of Amontillado	3	EPIC	Last Available: "2015-09"
 8579	extra-dry hand-crafted barrel-aged martini	5	EPIC	Last Available: "2015-09"
-8580	big stale barrel pickle	5	decent	Last Available: "2015-09"
-8581	jumbo normal upside-down barrel cracker	5	good	Last Available: "2015-09"
-8582	diluted blurry skewed vibrating mushroom	1	decent	Effect: "Oiled Skin", Effect Duration: 5, Last Available: "2015-09"
+8580	stale big barrel pickle	5	decent	Last Available: "2015-09"
+8581	normal jumbo upside-down barrel cracker	5	good	Last Available: "2015-09"
+8582	diluted skewed blurry vibrating mushroom	1	decent	Effect: "Oiled Skin", Effect Duration: 5, Last Available: "2015-09"
 8583	compressed olive mushroom	1	good	Last Available: "2015-09"
 8584	foul-smelling KoL Con 12-gauge	0		Stench Damage: +10, Last Available: "2015-09"
 8585	Golden Mr. Eh? of James Dean	0		Experience (Moxie): +3, Last Available: "2015-09"
 8586	shaking wobbly manspreader's barrel gun	0		Monster Level: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	normal half-sized water log	2	good	Last Available: "2015-09"
+8589	half-sized normal water log	2	good	Last Available: "2015-09"
 8590	avaricious barrelhead of the detective	0		Item Drop: +20, Meat Drop: +30, Last Available: "2015-09"
 8591	blue nasty clever bottoms of the barrel	0		Maximum MP: +20, Stench Damage: +5, Last Available: "2015-09"
 8592	chest barrel of dire peril of vim and vigor	0		Weapon Damage: +20, Maximum HP Percent: +50, Last Available: "2015-09"
@@ -8469,7 +8469,7 @@
 8596	Usain Bolt's extremely unsafe barrel beryl choker	0		Weapon Damage Percent: +100, Initiative: +80, Last Available: "2015-09"
 8597	Usain Bolt's stiffened barrel beryl nose ring	0		Damage Reduction: 1, Initiative: +80, Last Available: "2015-09"
 8598	studded wicked barrel beryl ring	0		Spell Damage: +5, Damage Absorption: +80, Last Available: "2015-09"
-8599	mirror squat map to the Biggest Barrel	0		Last Available: "2015-09"
+8599	squat mirror map to the Biggest Barrel	0		Last Available: "2015-09"
 8600	potted tea tree	0		Last Available: "2015-09"
 8601	galvanized diffused cuppa Flamibili tea	0		Effect: "Booze Goozles", Effect Duration: 27, Last Available: "2015-09"
 8602	dry polymerized cuppa Yet tea	0		Effect: "Mo' Hobo", Effect Duration: 34, Last Available: "2015-09"
@@ -8489,14 +8489,14 @@
 8616	colloidal diffused cuppa Neuroplastici tea	0		Effect: "Smoky Third Eye", Effect Duration: 39, Last Available: "2015-09"
 8617	super-boiled warmed cuppa Dexteri tea	0		Effect: "Hot Jellied", Effect Duration: 63, Last Available: "2015-09"
 8618	alkaline mirror spinning cuppa Flexibili tea	0		Effect: "One Foot Heavier", Effect Duration: 21, Last Available: "2015-09"
-8619	boiled warmed teal spinning cuppa Impregnabili tea	0		Effect: "All Is Forgiven", Effect Duration: 24, Last Available: "2015-09"
+8619	boiled warmed spinning teal cuppa Impregnabili tea	0		Effect: "All Is Forgiven", Effect Duration: 24, Last Available: "2015-09"
 8620	dry cuppa Obscuri tea	0		Effect: "Tomato Power", Effect Duration: 56, Last Available: "2015-09"
 8621	electrified shaking cuppa Irritabili tea	0		Effect: "Helping Comes Second", Effect Duration: 68, Last Available: "2015-09"
 8622	electrified corrupted cuppa Mediocri tea	0		Effect: "Super Speed", Effect Duration: 69, Last Available: "2015-09"
 8623	boiled polarized cuppa Loyal tea	0		Effect: "Enraged", Effect Duration: 34, Last Available: "2015-09"
-8624	dehydrated purple narrow spinning cuppa Activi tea	1	awesome	Last Available: "2015-09"
+8624	dehydrated narrow purple spinning cuppa Activi tea	1	awesome	Last Available: "2015-09"
 8625	modified cuppa Cruel tea	1		Last Available: "2015-09"
-8626	polymerized moist twirling mirror lime green cuppa Alacri tea	0		Effect: "init.enh", Effect Duration: 49, Last Available: "2015-09"
+8626	polymerized moist mirror twirling lime green cuppa Alacri tea	0		Effect: "init.enh", Effect Duration: 49, Last Available: "2015-09"
 8627	ionized cuppa Vitali tea	0		Effect: "Burning Tongue", Effect Duration: 50, Last Available: "2015-09"
 8628	colloidal super-galvanized Vulcanized squat cuppa Mana tea	0		Effect: "Gleaming White Teeth", Effect Duration: 55, Last Available: "2015-09"
 8629	irradiated altered quantum cuppa Monstrosi tea	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 34, Last Available: "2015-09"
@@ -8511,7 +8511,7 @@
 8638	skewed wool manspreader's wizardly Royal scepter	0		Mysticality: +25, Monster Level: +10, Cold Resistance: +1, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	enchanted stale bowl of eyeballs	3	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25, Last Available: "2015-10"
+8641	stale enchanted bowl of eyeballs	3	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25, Last Available: "2015-10"
 8642	toothsome bowl of mummy guts	3	awesome	Last Available: "2015-10"
 8643	moldy bowl of maggots	3	crappy	Last Available: "2015-10"
 8644	acceptable weak blurry blood and blood	2	good	Last Available: "2015-10"
@@ -8520,7 +8520,7 @@
 8647	lime green Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	blurry plastic nightmare troll	0		Last Available: "2015-10"
-8650	mirror gray tennis ball	0		Last Available: "2015-10"
+8650	gray mirror tennis ball	0		Last Available: "2015-10"
 8651	nippy extremely unsafe crown of the brute	0		Muscle Percent: +30, Weapon Damage Percent: +100, Cold Damage: +10, Familiar Effect: "atk, 1xGhuol, cap 27"
 8652	ear poison	0		
 8653	purple stink-penny	0		
@@ -8552,26 +8552,26 @@
 8679	chilly arcane researcher's slick Wal-Mart snowglobe	0		Moxie: +10, Experience Percent (Mysticality): +10, Cold Damage: +5, Last Available: "2015-11"
 8680	squat inspector's aromatic smartaleck's Wal-Mart nametag	0		Moxie Percent: +30, Stench Resistance: +1, Item Drop: +15, Last Available: "2015-11"
 8681	rosy-cheeked quilted Wal-Mart overalls of the overflowing toilet	0		Damage Absorption: +40, Maximum HP Percent: +30, Stench Spell Damage: +50, Last Available: "2015-11"
-8682	pulsating olive To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
+8682	olive pulsating To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	cyan The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	bouncing perfect ice cube	0		Last Available: "2015-11"
 8687	shaking The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	huge occult bellhop's hat	0		Spell Damage Percent: +25, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	mediocre ice porter	3	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	huge occult bellhop's hat	0		Spell Damage Percent: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	mediocre ice porter	3	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	chilled pickled exotic travel brochure	0		Effect: "Familial Ties", Effect Duration: 56, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	ionized teal shampoo-conditioner	0		Effect: "The Halls of Muscularity", Effect Duration: 63, Last Available: "2015-11"
 8693	shaking hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	blue Martialest Arts trophy	0		Last Available: "2016-01"
-8696	boiled spinning upside-down medicinal herbs	1		Last Available: "2016-01"
+8696	boiled upside-down spinning medicinal herbs	1		Last Available: "2016-01"
 8697	immense rotten bouncing ice rice	7	crappy	Last Available: "2016-01"
 8698	aged iced plum wine	3	awesome	Last Available: "2016-01"
 8699	Tesla steel-toed deadly training belt	0		Weapon Damage: +5, Damage Reduction: 9, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2016-01"
 8700	chaotic boxer's slick training legwarmers	0		Moxie: +10, Muscle Percent: +10, Spell Critical Percent: +10, Single Equip, Last Available: "2016-01"
-8701	vibrating boxer's training helmet of doom	0		Muscle Percent: +10, Maximum MP Percent: +10, Spooky Spell Damage: +50, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	vibrating boxer's training helmet of doom	0		Muscle Percent: +10, Maximum MP Percent: +10, Spooky Spell Damage: +50, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	gray training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	blurry training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	cyan training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8584,12 +8584,12 @@
 8711	boiled lime green abstraction: purpose	1		Effect: "Twinkly Weapon", Effect Duration: 10, Last Available: "2015-12"
 8712	distilled abstraction: category	1		Last Available: "2015-12"
 8713	vaporized abstraction: perception	1		Last Available: "2015-12"
-8714	dried tumbling upside-down abstraction: motion	1		Last Available: "2015-12"
+8714	dried upside-down tumbling abstraction: motion	1		Last Available: "2015-12"
 8715	modified spinning abstraction: joy	1		Last Available: "2015-12"
 8716	distilled spinning abstraction: certainty	1		Last Available: "2015-12"
 8717	compressed abstraction: comprehension	1		Effect: "Squirming Like a Toad", Effect Duration: 15, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	snack-sized spoiled VYKEA meatballs	2	crappy	Last Available: "2015-11"
+8719	spoiled snack-sized VYKEA meatballs	2	crappy	Last Available: "2015-11"
 8720	bad wobbly VYKEA mead	3	decent	Last Available: "2015-11"
 8721	aerosolized oxidized green VYKEA woadpaint	0		Effect: "Emotion Sickness", Effect Duration: 65, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
@@ -8597,19 +8597,19 @@
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	skewed VYKEA rail	0		Last Available: "2015-11"
-8727	purple blurry VYKEA bracket	0		Last Available: "2015-11"
+8727	blurry purple VYKEA bracket	0		Last Available: "2015-11"
 8728	mirror VYKEA dowel	0		Last Available: "2015-11"
 8729	upside-down toasty MacGyver's boxer's VYKEA hex key	0		Muscle Percent: +10, Maximum MP: +100, Hot Damage: +5, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	enchanted moldy jittery pulsating tin of submardines	3	crappy	Effect: "Eyes for Miles", Effect Duration: 15, Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	enchanted moldy jittery pulsating tin of submardines	3	crappy	Effect: "Eyes for Miles", Effect Duration: 15, Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	practically non-alcoholic artisanal bottle of norwhiskey	1	EPIC	Last Available: "2015-11"
-8733	altered wobbly jittery octolus oculus	1	EPIC	Effect: "Fireproof Lips", Effect Duration: 30, Last Available: "2015-11"
+8733	altered jittery wobbly octolus oculus	1	EPIC	Effect: "Fireproof Lips", Effect Duration: 30, Last Available: "2015-11"
 8734	Socratic strapping sardine can key of terror	0		Muscle: +5, Experience (Mysticality): +1, Spooky Spell Damage: +10, Last Available: "2015-11"
-8735	twirling asbestos-lined cool norwhal helmet of the overflowing toilet	0		Moxie: +5, Stench Spell Damage: +50, Hot Resistance: +5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	twirling asbestos-lined cool norwhal helmet of the overflowing toilet	0		Moxie: +5, Stench Spell Damage: +50, Hot Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	twirling lard-coated lion tamer's hardy octolus-skin cloak	0		Maximum HP: +50, Experience (familiar): +2, Sleaze Spell Damage: +25, Last Available: "2015-11"
-8737	practically non-alcoholic mediocre lime green upside-down perfect cosmopolitan	1	decent	Last Available: "2015-11"
+8737	mediocre practically non-alcoholic upside-down lime green perfect cosmopolitan	1	decent	Last Available: "2015-11"
 8738	acceptable watered-down perfect negroni	2	good	Last Available: "2015-11"
-8739	extra-dry delicious bouncing perfect dark and stormy	5	awesome	Last Available: "2015-11"
+8739	delicious extra-dry bouncing perfect dark and stormy	5	awesome	Last Available: "2015-11"
 8740	delicious perfect mimosa	3	awesome	Last Available: "2015-11"
 8741	smooth watered-down perfect old-fashioned	2	awesome	Last Available: "2015-11"
 8742	tolerable extra-dry spinning perfect paloma	5	good	Last Available: "2015-11"
@@ -8624,7 +8624,7 @@
 8751	Vulcanized quadruple-improved ionized jittery communal gobstopper	0		Effect: "Omphalotus Omnipresence", Effect Duration: 30, Last Available: "2015-12"
 8752	spoiled Crimbo salad	3	crappy	Last Available: "2015-12"
 8753	stale jumbo bread line	5	decent	Last Available: "2015-12"
-8754	bad spirit-forward bark rootbeer	5	decent	Last Available: "2015-12"
+8754	spirit-forward bad bark rootbeer	5	decent	Last Available: "2015-12"
 8755	acceptable ale	3	good	Last Available: "2015-12"
 8756	lime green groovy plastic Tammy the Tambourine Elf	0		Moxie Percent: +10, Last Available: "2015-12"
 8757	green plastic Rudolph the Red of the empath	0		Familiar Weight: +5, Last Available: "2015-12"
@@ -8647,15 +8647,15 @@
 8775	steel-toed coarse hemp socks	0		Damage Reduction: 9, Single Equip, Last Available: "2015-12"
 8776	jittery frosty armband	0		Cold Spell Damage: +10, Single Equip, Last Available: "2015-12"
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
-8778	bouncing shaking jittery nuclear stockpile	0		Last Available: "2015-12"
+8778	shaking bouncing jittery nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
 8780	ghostly iron chain	0		Last Available: "2015-12"
 8781	pine cone necklace of James Dean	0		Experience (Moxie): +3, Last Available: "2015-12"
 8782	teal horrifying reindeer hammer	0		Spooky Damage: +25, Last Available: "2015-12"
 8783	therapeutic elf ploughshare	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	skewed tumbling The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
-8786	bouncing squat olive faded protest sign	0		Last Available: "2015-12"
+8785	skewed tumbling The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8786	olive bouncing squat faded protest sign	0		Last Available: "2015-12"
 8787	olive faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
 8789	book	0		Last Available: "2015-12"
@@ -8666,11 +8666,11 @@
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	plastic spoiler	0		
-8797	mirror olive bat-oomerang	0		Last Available: "2017-01"
-8798	blinking green bouncing bat-jute	0		Last Available: "2017-01"
+8797	olive mirror bat-oomerang	0		Last Available: "2017-01"
+8798	green blinking bouncing bat-jute	0		Last Available: "2017-01"
 8799	blinking bat-o-mite	0		Last Available: "2017-01"
 8800	ghostly ROM of Optimality	0		Skill: "Toggle Optimality"
-8801	twirling green incriminating evidence	0		Last Available: "2017-01"
+8801	green twirling incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
 8803	kidnapped orphan	0		Last Available: "2017-01"
 8804	ghostly high-grade	0		Last Available: "2017-01"
@@ -8682,31 +8682,31 @@
 8810	fingerprint dusting kit	0		Last Available: "2017-01"
 8811	confidence-building hug	0		Last Available: "2017-01"
 8812	blinking exploding kickball	0		Last Available: "2017-01"
-8813	teal wobbly glob of Bat-Glue	0		Last Available: "2017-01"
+8813	wobbly teal glob of Bat-Glue	0		Last Available: "2017-01"
 8814	spinning Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	upside-down bat-bearing	0		Last Available: "2017-01"
 8816	stale super-sized Kudzu salad	5	decent	Last Available: "2016-12"
 8817	boiled red Mansquito Serum	1		Effect: "Pisces in the Skyces", Effect Duration: 50, Last Available: "2016-12"
-8818	mediocre shaking spinning Miss Graves' vermouth	4	decent	Last Available: "2016-12"
+8818	mediocre spinning shaking Miss Graves' vermouth	4	decent	Last Available: "2016-12"
 8819	bland special blinking The Plumber's mushroom stew	4	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2016-12"
 8820	altered blinking The Author's ink	1		Last Available: "2016-02"
 8821	delicious narrow The Mad Liquor	4	awesome	Last Available: "2016-12"
 8822	perfectly mixed watered-down Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
-8823	normal squat ghostly Mr. Burnsger	4	good	Last Available: "2016-12"
+8823	normal ghostly squat Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	dehydrated The Inquisitor's unidentifiable object	1		Effect: "Loco Motives", Effect Duration: 50, Last Available: "2016-12"
-8825	skewed lightning-fast greasy forbidden The Jokester's gun	0		Spell Damage Percent: +50, Sleaze Spell Damage: +10, Initiative: +40, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	zippy sizzling wholesome The Jokester's wig	0		Maximum HP Percent: +10, Hot Damage: +10, Initiative: +20, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
-8827	gravedigger's hardy Sinatra's The Jokester's pants	0		Experience (Moxie): +5, Maximum HP: +50, Spooky Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	skewed lightning-fast greasy forbidden The Jokester's gun	0		Spell Damage Percent: +50, Sleaze Spell Damage: +10, Initiative: +40, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	zippy sizzling wholesome The Jokester's wig	0		Maximum HP Percent: +10, Hot Damage: +10, Initiative: +20, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	gravedigger's hardy Sinatra's The Jokester's pants	0		Experience (Moxie): +5, Maximum HP: +50, Spooky Damage: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	wet Jokester makeup	0		Effect: "Pwnd", Effect Duration: 47, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
-8830	bouncing shaking battoo kit	0		Last Available: "2016-12"
+8830	shaking bouncing battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	bouncing domino mask	0		Familiar Weight: +5
 8833	magnetized robin's egg	0		Effect: "Tremella Tremens", Effect Duration: 41, Last Available: "2016-12"
-8834	half-sized bland robin flan	2	decent	Last Available: "2016-12"
+8834	bland half-sized robin flan	2	decent	Last Available: "2016-12"
 8835	lousy robin nog	3	decent	Last Available: "2016-12"
 8836	blurry LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
-8837	upside-down squat plaintive telegram	0		Last Available: "2016-02"
+8837	squat upside-down plaintive telegram	0		Last Available: "2016-02"
 8838	wobbly exploding gum	0		
 8839	root beer barrel	0		
 8840	diffused warmed jittery Kudzu slaw	0		Effect: "Souper Vengeful", Effect Duration: 11
@@ -8716,15 +8716,15 @@
 8844	dry The Author's inkwell	0		Effect: "Nothing Is Impossible", Effect Duration: 66
 8845	enhanced non-warmed ghostly bag of random words	0		Effect: "Human-Horror Hybrid", Effect Duration: 65
 8846	chilled double-irradiated wet tube of pendulum lube	0		Effect: "Brain Freeze", Effect Duration: 56
-8847	energized warmed ghostly mirror pulsating red-hot jawbreaker	0		Effect: "Unrunnable Face", Effect Duration: 60
+8847	energized warmed mirror pulsating ghostly red-hot jawbreaker	0		Effect: "Unrunnable Face", Effect Duration: 60
 8848	galvanized twirling question juice	0		Effect: "Bottle in front of Me", Effect Duration: 43
 8849	boiled teal tube of villain	0		Effect: "Buzzard Breath", Effect Duration: 44
-8850	blurry nasty your cowboy boots	0		Stench Damage: +5, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	blurry nasty your cowboy boots	0		Stench Damage: +5, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	blurry inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
 8854	nugget of wicksilver	0		Last Available: "2016-02"
-8855	mirror tumbling nugget of slicksilver	0		Last Available: "2016-02"
+8855	tumbling mirror nugget of slicksilver	0		Last Available: "2016-02"
 8856	pulsating nugget of sicksilver	0		Last Available: "2016-02"
 8857	huge nugget of nicksilver	0		Last Available: "2016-02"
 8858	squat nugget of ticksilver	0		Last Available: "2016-02"
@@ -8750,15 +8750,15 @@
 8878	decent plate of Mixed Garbanzos and Chickpeas	4	good	Last Available: "2016-02"
 8879	adequate twirling plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
 8880	bland gigantic squat plate of Frigid Northern Beans	7	decent	Last Available: "2016-02"
-8881	moldy enchanted massive plate of World's Blackest-Eyed Peas	10	crappy	Effect: "Uncanny Shot", Effect Duration: 5, Last Available: "2016-02"
-8882	small delicious plate of Trader Olaf's Exotic Stinkbeans	2	awesome	Last Available: "2016-02"
+8881	moldy massive enchanted plate of World's Blackest-Eyed Peas	10	crappy	Effect: "Uncanny Shot", Effect Duration: 5, Last Available: "2016-02"
+8882	delicious small plate of Trader Olaf's Exotic Stinkbeans	2	awesome	Last Available: "2016-02"
 8883	moldy plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	crappy	Last Available: "2016-02"
-8884	spoiled miniature bouncing plate of Val-U Brand Every Bean Salad	2	crappy	Last Available: "2016-02"
+8884	miniature spoiled bouncing plate of Val-U Brand Every Bean Salad	2	crappy	Last Available: "2016-02"
 8885	small rotten plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	Samson's cool Fancy Jeff's pocket square	0		Moxie: +5, Experience (Muscle): +5, Last Available: "2016-02"
-8887	family-friendly deadly Daisy's unclean bloomers	0		Weapon Damage: +5, Sleaze Resistance: +1, Item Drop: +5, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	family-friendly deadly Daisy's unclean bloomers	0		Weapon Damage: +5, Sleaze Resistance: +1, Item Drop: +5, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	narrow frosty Amoon-Ra Cowtep's nemes of wisdom of Tarzan	0		Mysticality: +15, Experience (Muscle): +3, Cold Spell Damage: +10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	narrow frosty Amoon-Ra Cowtep's nemes of wisdom of Tarzan	0		Mysticality: +15, Experience (Muscle): +3, Cold Spell Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	bouncing Glenn's dice	0		Last Available: "2016-02"
 8891	twirling lime green family-friendly lard-coated careful thinker's Former Sheriff Dan's tin star of the brute	0		Mysticality: +10, Muscle Percent: +30, Monster Level: -10, Sleaze Spell Damage: +25, Sleaze Resistance: +1, Last Available: "2016-02"
 8892	narrow El Vibrato restraints	0		Last Available: "2016-02"
@@ -8772,16 +8772,16 @@
 8900	gun parts	0		Last Available: "2016-02"
 8901	Vulcanized bouncing triggerfingerbone	0		Effect: "Eau de Tortue", Effect Duration: 46, Last Available: "2016-02"
 8902	pressed activated ghost bit	0		Effect: "Human-Constellation Hybrid", Effect Duration: 67, Last Available: "2016-02"
-8903	flattened green mirror buzzard feather	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 14, Last Available: "2016-02"
+8903	flattened mirror green buzzard feather	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 14, Last Available: "2016-02"
 8904	adjusted oxidized pulsating mirror lion musk	0		Effect: "Cold Blooded", Effect Duration: 20, Last Available: "2016-02"
 8905	bland bite-sized bear claw	1	decent	Last Available: "2016-02"
 8906	wet ionized rattler gland	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 48, Last Available: "2016-02"
-8907	colloidal olive blinking half-digested coal	0		Effect: "Thick-Skinned", Effect Duration: 25, Last Available: "2016-02"
+8907	colloidal blinking olive half-digested coal	0		Effect: "Thick-Skinned", Effect Duration: 25, Last Available: "2016-02"
 8908	extra-ionized tightly-wound spine	0		Effect: "Squirming Like a Toad", Effect Duration: 11, Last Available: "2016-02"
 8909	delicious rotting beefsteak	3	awesome	Last Available: "2016-02"
 8910	mediocre firemilk	4	decent	Last Available: "2016-02"
 8911	tarnished ionized ghostly spidercow eye-cluster	0		Effect: "Rampage!", Effect Duration: 22, Last Available: "2016-02"
-8912	modified blurry gray twirling moomy dust	1		Last Available: "2016-02"
+8912	modified gray twirling blurry moomy dust	1		Last Available: "2016-02"
 8913	wobbly therapeutic strapping western-style skinning knife	0		Muscle: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	red rosewater-soaked steel knuckles	0		Stench Resistance: +3, Last Available: "2016-02"
@@ -8803,7 +8803,7 @@
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
 8932	mirror makeshift sixgun	0		Last Available: "2016-02"
 8933	custom sixgun	0		Last Available: "2016-02"
-8934	bouncing teal baconstone-handled sixgun	0		Last Available: "2016-02"
+8934	teal bouncing baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
@@ -8812,7 +8812,7 @@
 8940	coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
-8943	blurry skewed shuddering cow skull	0		Last Available: "2016-02"
+8943	skewed blurry shuddering cow skull	0		Last Available: "2016-02"
 8944	rhinestone cowhorn	0		Familiar Weight: +5
 8945	cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
@@ -8852,27 +8852,27 @@
 8980	magnetized narrow patent avarice tonic	0		Effect: "Sinuses For Miles", Effect Duration: 31
 8981	magnetized vacuum-sealed squat olive patent alacrity tonic	0		Effect: "Moon'd", Effect Duration: 64
 8982	quadruple-corrupted corrupted marrow	0		Effect: "Guts Feeling", Effect Duration: 47
-8983	aged watered-down spinning rodeo whiskey	2	awesome	
+8983	watered-down aged spinning rodeo whiskey	2	awesome	
 8984	ghostly Thwaitgold scorpion statuette	0		
 8985	real cowboy hat of the empath	0		Familiar Weight: +5
 8986	yellow Memories of Cow Punching	0		Free Pull
 8987	Memories of Beanslinging	0		Free Pull
-8988	narrow maroon Memories of Snake Oiling	0		Free Pull
+8988	maroon narrow Memories of Snake Oiling	0		Free Pull
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	upside-down do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	distilled pulsating armored prawn	1		Last Available: "2016-03"
-8993	flavorless big jumping horseradish	5	decent	Last Available: "2016-03"
+8993	big flavorless jumping horseradish	5	decent	Last Available: "2016-03"
 8994	artisanal blurry Sacramento wine	3	EPIC	Last Available: "2016-03"
 8995	anodized purple Greek fire	0		Effect: "Down With Chow", Effect Duration: 58, Last Available: "2016-03"
 8996	upside-down flame-retardant scandalous ox-head shield of the cougar of Leguizamo of Flo-Jo	0		Moxie: +20, Monster Level: +20, Sleaze Damage: +5, Hot Resistance: +1, Initiative: +100, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	upside-down teal wool toasty MacGyver's Newton's dented scepter of the sweet-tooth	0		Experience (Mysticality): +3, Maximum MP: +100, Hot Damage: +5, Cold Resistance: +1, Candy Drop: +100, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	pulsating Rosewater's very pointy crown of Leguizamo of the empath of the boozehound of the sweet-tooth	0		Mysticality Percent: +30, Monster Level: +20, Familiar Weight: +5, Booze Drop: +100, Candy Drop: +100, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	pulsating Rosewater's very pointy crown of Leguizamo of the empath of the boozehound of the sweet-tooth	0		Mysticality Percent: +30, Monster Level: +20, Familiar Weight: +5, Booze Drop: +100, Candy Drop: +100, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	pulsating double-paned supercharged supercool cool weightlifter's battle broom	0		Muscle: +15, Moxie: +5, Moxie Percent: +20, Maximum MP Percent: +30, Cold Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	auspicious rosy-cheeked carpe of the bloodbag of the early riser	0		Maximum HP Percent: +30, Maximum HP: +100, Item Drop: +10, Adventures: +7, Lasts Until Rollover, Last Available: "2016-04"
 9002	veiny shellacked codpiece of the wise owl of the scaredy-cat	0		Mysticality: +20, Damage Reduction: 7, Maximum HP: +10, Monster Level: -15, Lasts Until Rollover, Last Available: "2016-04"
-9003	ghostly zippy careful hardened troutsers of the sewer	0		Damage Reduction: 3, Monster Level: -10, Stench Damage: +25, Initiative: +20, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	ghostly zippy careful hardened troutsers of the sewer	0		Damage Reduction: 3, Monster Level: -10, Stench Damage: +25, Initiative: +20, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	yellow asbestos-lined dog trainer's slick brainy bass clarinet	0		Mysticality: +5, Moxie: +10, Experience (familiar): +1, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
 9005	wool rock-hard wicked educational fish hatchet	0		Experience: +1, Spell Damage: +5, Damage Reduction: 5, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9006	sharpshooter's tunac of Tarzan of vim and vigor of the overflowing toilet	0		Experience (Muscle): +3, Maximum HP Percent: +50, Critical Hit Percent: +10, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	upside-down plus one	0		Last Available: "2016-05"
-9021	normal miniature gallon of milk	2	good	Last Available: "2016-05"
+9021	miniature normal gallon of milk	2	good	Last Available: "2016-05"
 9022	bouncing print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
@@ -8898,13 +8898,13 @@
 9026	mirror First Post shirt package	0		Last Available: "2016-05"
 9027	ghostly twirling chilly dog trainer's Tesla First Post shirt - Cir Senam	0		Experience (familiar): +1, Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-05"
 9028	twirling high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
-9029	jittery bouncing no spoon	0		
+9029	bouncing jittery no spoon	0		
 9030	flavorless star salad	3	decent	
 9031	Thwaitgold moth statuette	0		
-9032	huge adequate bowl of Tastee-Wheet&trade;	8	good	
-9033	upside-down huge Source terminal	0		Free Pull, Last Available: "2016-06"
+9032	adequate huge bowl of Tastee-Wheet&trade;	8	good	
+9033	huge upside-down Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	pulsating Source essence	0		Last Available: "2016-06"
-9035	adequate snack-sized browser cookie	2	good	Last Available: "2016-06"
+9035	snack-sized adequate browser cookie	2	good	Last Available: "2016-06"
 9036	acceptable jittery hacked gibson	4	good	Last Available: "2016-06"
 9037	Source shades of Flo-Jo	0		Initiative: +100, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
@@ -8920,11 +8920,11 @@
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	squat Source terminal SCRAM chip	0		Last Available: "2016-06"
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
-9051	olive upside-down Source terminal file: substats.enh	0		Last Available: "2016-06"
+9051	upside-down olive Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	huge Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	Source terminal file: protect.enq	0		Last Available: "2016-06"
-9055	olive spinning Source terminal file: stats.enq	0		Last Available: "2016-06"
+9055	spinning olive Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	huge Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	blurry Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
@@ -8948,10 +8948,10 @@
 9076	up-at-dawn executive Van der Graaf noir fedora	0		Meat Drop: +40, Adventures: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2016-07"
 9077	spinning trench coat of chilblains of the overflowing toilet of the boozehound	0		Cold Damage: +25, Stench Spell Damage: +50, Booze Drop: +100, Last Available: "2016-07"
 9078	artisanal maroon Falcon&trade; Maltese Liquor	3	EPIC	Last Available: "2016-07"
-9079	delicious super-sized blue mirror hardboiled egg	5	awesome	Last Available: "2016-07"
+9079	delicious super-sized mirror blue hardboiled egg	5	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	nasty Lo Pan's smooth weightlifter's protonic accelerator pack of the brute of bravery	0		Muscle: +15, Moxie: +15, Muscle Percent: +30, Spell Critical Percent: +30, Stench Damage: +5, Spooky Resistance: +5, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	nasty Lo Pan's smooth weightlifter's protonic accelerator pack of the brute of bravery	0		Muscle: +15, Moxie: +15, Muscle Percent: +30, Spell Critical Percent: +30, Stench Damage: +5, Spooky Resistance: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	twirling almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	groovy Adventurer bobblehead	0		Moxie Percent: +10, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	cyan Mr. Screege's spectacles of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2016-08"
 9092	narrow fireproof strapping Spookyraven signet of the overflowing toilet	0		Muscle: +5, Stench Spell Damage: +50, Hot Resistance: +3, Single Equip, Last Available: "2016-08"
 9093	blurry lightning-fast tie-dyed fannypack of the storm	0		Maximum MP Percent: +40, Initiative: +40, Single Equip, Last Available: "2016-08"
-9094	jittery nasty burnt snowpants of wisdom	0		Mysticality: +15, Stench Damage: +5, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	quilted standards and practices guide	0		Damage Absorption: +40, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9094	jittery nasty burnt snowpants of wisdom	0		Mysticality: +15, Stench Damage: +5, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	quilted standards and practices guide	0		Damage Absorption: +40, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	squat dangerous Carpathian longsword of wisdom of extreme caution	0		Mysticality: +15, Weapon Damage: +10, Monster Level: -25, Last Available: "2016-08"
 9097	chilly smooth weightlifter's Liam's mail	0		Muscle: +15, Moxie: +15, Cold Damage: +5, Last Available: "2016-08"
 9098	Da Vinci's Unfortunato's foolscap of wisdom of the pedagogue	0		Mysticality: +15, Experience: +3, Experience (Mysticality): +5, Last Available: "2016-08"
@@ -9005,25 +9005,25 @@
 9133	spinning KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	tasty wobbly leftover pasty	3	awesome	
 9135	perfectly mixed very whiskey	3	EPIC	
-9136	ghostly skewed li'l orphan tot	0		Free Pull, Last Available: "2016-10"
+9136	skewed ghostly li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	ghostly li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	cyan li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	ghostly li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	cyan li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	twirling li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	nitrogenated extra-warmed lime green hoarded candy wad	0		Effect: "Celestial Vision", Effect Duration: 29, Last Available: "2016-10"
 9147	denatured galvanized Prunets	0		Effect: "Familial Ties", Effect Duration: 51
 9148	Twitching Television Tattoo	0		
 9149	twirling baby scorpion	0		Familiar Weight: +10
 9150	ionized galvanized invisible string	0		Lasts Until Rollover, Effect: "Marco Polarity", Effect Duration: 60, Last Available: "2016-10"
 9151	enhanced polarized pulsating invisible seam ripper	0		Lasts Until Rollover, Effect: "Comprehensively Nourished", Effect Duration: 68, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	yummy green raw sweet potato	3	awesome	Last Available: "2016-11"
-9154	spoiled big raw beans	5	crappy	Last Available: "2016-11"
+9154	big spoiled raw beans	5	crappy	Last Available: "2016-11"
 9155	half-sized spoiled twirling raw stuffing	2	crappy	Last Available: "2016-11"
 9156	diet adequate raw cranberry sauce	1	good	Last Available: "2016-11"
 9157	bland raw turkey	3	decent	Last Available: "2016-11"
@@ -9047,9 +9047,9 @@
 9175	normal super-sized thanksgiving turkey	5	good	Last Available: "2016-11"
 9176	enchanted stale mince pie	3	decent	Effect: "Paging Betty", Effect Duration: 25, Last Available: "2016-11"
 9177	delicious mashed potatoes	3	awesome	Last Available: "2016-11"
-9178	flavorless immense twirling warm gravy	9	decent	Last Available: "2016-11"
-9179	adequate huge shaking bread roll	6	good	Last Available: "2016-11"
-9180	delicious diet leftovers	1	awesome	Last Available: "2016-11"
+9178	immense flavorless twirling warm gravy	9	decent	Last Available: "2016-11"
+9179	huge adequate shaking bread roll	6	good	Last Available: "2016-11"
+9180	diet delicious leftovers	1	awesome	Last Available: "2016-11"
 9181	moldy narrow leftovers sandwich	3	crappy	Last Available: "2016-11"
 9182	spinning Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
@@ -9059,9 +9059,9 @@
 9187	cashew	0		Last Available: "2016-11"
 9188	jittery bomb of unknown origin	0		Last Available: "2016-11"
 9189	olive Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
-9190	red spinning eldritch effluvium	0		
+9190	spinning red eldritch effluvium	0		
 9191	irradiated tumbling eldritch concentrate	0		Effect: "Adapt to Change Eventually", Effect Duration: 55, Last Available: "2016-11"
-9192	watered-down drinkable eldritch extract	2	good	Last Available: "2016-11"
+9192	drinkable watered-down eldritch extract	2	good	Last Available: "2016-11"
 9193	huge dog trainer's Official Council Aide Pin of the detective	0		Experience (familiar): +1, Item Drop: +20, Last Available: "2016-11"
 9194	special tolerable ghostly eldritch distillate	3	good	Effect: "Hyphemariffic", Effect Duration: 30, Last Available: "2016-11"
 9195	powdered eldritch essence	1		Last Available: "2016-11"
@@ -9089,7 +9089,7 @@
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	spoiled narrow animal part cracker	3	crappy	Last Available: "2016-12"
-9220	drinkable high-proof wobbly gingerbread wine	6	good	Last Available: "2016-12"
+9220	high-proof drinkable wobbly gingerbread wine	6	good	Last Available: "2016-12"
 9221	decent twirling gingerbread mug	4	good	Last Available: "2016-12"
 9222	upside-down cool gingerbread mask	0		Moxie: +5, Last Available: "2016-12"
 9223	censurious sizzling Herculean gingerservo	0		Experience (Muscle): +1, Hot Damage: +10, Sleaze Resistance: +3, Single Equip, Last Available: "2016-12"
@@ -9126,7 +9126,7 @@
 9254	yummy blurry spiritual fruitcake	3	awesome	Last Available: "2016-12"
 9255	decent spiritual gingerbread	4	good	Last Available: "2016-12"
 9256	huge chocolate puppy	0		Last Available: "2016-12"
-9257	twirling olive wobbly chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
+9257	olive twirling wobbly chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	upside-down jittery My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	twirling teethpick	0		Last Available: "2016-12"
 9266	quadruple-activated mirror rock candy	0		Effect: "Pharmaceutically Cool", Effect Duration: 36, Last Available: "2016-12"
-9267	snack-sized toothsome green-iced sweet roll	2	awesome	Last Available: "2016-12"
+9267	toothsome snack-sized green-iced sweet roll	2	awesome	Last Available: "2016-12"
 9268	narrow sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	mirror no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9162,15 +9162,15 @@
 9290	normal mirror Eldritch snap	4	good	Last Available: "2017-01"
 9291	dried hot jelly	1		Effect: "Biologically Shocked", Effect Duration: 20, Last Available: "2017-01"
 9292	boiled fuchsia jelly	1		Effect: "Cheered Up", Effect Duration: 15, Last Available: "2017-01"
-9293	powdered huge squat gray jelly	1		Last Available: "2017-01"
+9293	powdered gray squat huge jelly	1		Last Available: "2017-01"
 9294	compressed bouncing sleaze jelly	1		Last Available: "2017-01"
 9295	vaporized stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	decent toast with hot jelly	3	good	Last Available: "2017-01"
 9298	normal toast with jelly	4	good	Last Available: "2017-01"
-9299	yummy tiny toast with jelly	1	awesome	Last Available: "2017-01"
+9299	tiny yummy toast with jelly	1	awesome	Last Available: "2017-01"
 9300	snack-sized decent toast with sleaze jelly	2	good	Last Available: "2017-01"
-9301	moldy special toast with stench jelly	3	crappy	Effect: "Inner Dog", Effect Duration: 50, Last Available: "2017-01"
+9301	special moldy toast with stench jelly	3	crappy	Effect: "Inner Dog", Effect Duration: 50, Last Available: "2017-01"
 9302	pulsating space jellybicycle	0		Familiar Weight: +5
 9303	hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	narrow pewter candlestick	0		Familiar Weight: +10
@@ -9179,9 +9179,9 @@
 9307	flavorless spinning wax pancake	3	decent	Last Available: "2017-01"
 9308	strapping wax face of the blizzard	0		Muscle: +5, Cold Spell Damage: +25, Last Available: "2017-01"
 9309	perfectly mixed wax booze	4	EPIC	Last Available: "2017-01"
-9310	jittery ghostly glob of melted wax	0		Last Available: "2017-01"
+9310	ghostly jittery glob of melted wax	0		Last Available: "2017-01"
 9311	twisted shaking sea jelly	1		Last Available: "2017-01"
-9312	adequate tiny sea truffle	1	good	Last Available: "2017-01"
+9312	tiny adequate sea truffle	1	good	Last Available: "2017-01"
 9313	bouncing tarnished luggage key	0		Last Available: "2017-01"
 9314	blurry crushed steamer trunk	0		Last Available: "2017-01"
 9315	skewed occult recovered cufflinks	0		Spell Damage Percent: +25, Single Equip, Last Available: "2017-01"
@@ -9194,12 +9194,12 @@
 9322	frightening padded LOV Earrings of temperance	0		Damage Absorption: +20, Spooky Damage: +5, Sleaze Resistance: +5, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
-9325	skewed spinning LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
+9325	spinning skewed LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	dehydrated LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	groovy LOV Elephant	0		Moxie Percent: +10, Damage Reduction: 6, Last Available: "2017-02"
 9328	narrow smooth eldritch scanner	0		Moxie: +15, Last Available: "2017-02"
 9329	activated eldritch alignment spray	0		Effect: "Seeing Colors", Effect Duration: 51, Last Available: "2017-02"
-9330	wobbly pulsating LOV Entrance Pass	0		Last Available: "2017-02"
+9330	pulsating wobbly LOV Entrance Pass	0		Last Available: "2017-02"
 9331	Usain Bolt's therapeutic brainy eldritch hammer	0		Mysticality: +5, Initiative: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2017-01"
 9332	stale snack-sized upside-down spinning eldritch mushroom	2	decent	Last Available: "2017-03"
 9333	bouncing eldritch ichor	0		
@@ -9239,17 +9239,17 @@
 9367	mediocre Phlegethon	3	decent	Last Available: "2017-03"
 9368	practically non-alcoholic lousy Siberian sunrise	1	decent	Last Available: "2017-03"
 9369	practically non-alcoholic acceptable upside-down mentholated wine	1	good	Last Available: "2017-03"
-9370	artisanal high-proof low tide martini	7	EPIC	Last Available: "2017-03"
+9370	high-proof artisanal low tide martini	7	EPIC	Last Available: "2017-03"
 9371	hand-crafted distilled shroomtini	5	EPIC	Last Available: "2017-03"
 9372	perfectly mixed high-proof spinning morning dew	8	EPIC	Last Available: "2017-03"
 9373	tolerable whiskey squeeze	3	good	Last Available: "2017-03"
 9374	watered-down mediocre great fashioned	2	decent	Last Available: "2017-03"
-9375	weak bad lime green Gnomish sagngria	2	decent	Last Available: "2017-03"
-9376	lousy cyan twirling upside-down vodka stinger	4	decent	Last Available: "2017-03"
-9377	aged triple-distilled extremely slippery nipple	6	awesome	Last Available: "2017-03"
+9375	bad weak lime green Gnomish sagngria	2	decent	Last Available: "2017-03"
+9376	lousy twirling upside-down cyan vodka stinger	4	decent	Last Available: "2017-03"
+9377	triple-distilled aged extremely slippery nipple	6	awesome	Last Available: "2017-03"
 9378	aged piscatini	3	awesome	Last Available: "2017-03"
 9379	aged tumbling Churchill	3	awesome	Last Available: "2017-03"
-9380	fortified hand-crafted narrow soilzerac	5	EPIC	Last Available: "2017-03"
+9380	hand-crafted fortified narrow soilzerac	5	EPIC	Last Available: "2017-03"
 9381	practically non-alcoholic drinkable London frog	1	good	Last Available: "2017-03"
 9382	tolerable spirit-forward nothingtini	5	good	Last Available: "2017-03"
 9383	drinkable triple-distilled bouncing eighth plague	10	good	Last Available: "2017-03"
@@ -9259,16 +9259,16 @@
 9387	mediocre Feliz Navidad	4	decent	Last Available: "2017-03"
 9388	lousy triple-distilled Bloody Nora	7	decent	Last Available: "2017-03"
 9389	perfectly mixed moreltini	4	EPIC	Last Available: "2017-03"
-9390	acceptable blinking skewed hell in a bucket	4	good	Last Available: "2017-03"
+9390	acceptable skewed blinking hell in a bucket	4	good	Last Available: "2017-03"
 9391	mediocre Newark	4	decent	Last Available: "2017-03"
 9392	high-proof hand-crafted R'lyeh	9	EPIC	Last Available: "2017-03"
-9393	hand-crafted practically non-alcoholic gray Gnollish sangria	1	EPIC	Last Available: "2017-03"
+9393	practically non-alcoholic hand-crafted gray Gnollish sangria	1	EPIC	Last Available: "2017-03"
 9394	weak acceptable vodka barracuda	2	good	Last Available: "2017-03"
-9395	extra-dry perfectly mixed Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
+9395	perfectly mixed extra-dry Mysterious Island iced tea	5	EPIC	Last Available: "2017-03"
 9396	aged drive-by shooting	4	awesome	Last Available: "2017-03"
-9397	practically non-alcoholic perfectly mixed enchanted gunner's daughter	1	EPIC	Effect: "Sugary Tongue", Effect Duration: 35, Last Available: "2017-03"
-9398	irresponsibly strong artisanal dirt julep	9	EPIC	Last Available: "2017-03"
-9399	hand-crafted high-proof Simepore slime	10	EPIC	Last Available: "2017-03"
+9397	practically non-alcoholic enchanted perfectly mixed gunner's daughter	1	EPIC	Effect: "Sugary Tongue", Effect Duration: 35, Last Available: "2017-03"
+9398	artisanal irresponsibly strong dirt julep	9	EPIC	Last Available: "2017-03"
+9399	high-proof hand-crafted Simepore slime	10	EPIC	Last Available: "2017-03"
 9400	mediocre Phil Collins	3	decent	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
@@ -9284,7 +9284,7 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	tumbling geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	fancy half-sized decent edible alien plant bit	2	good	Effect: "Heavily Breathing", Effect Duration: 20, Last Available: "2017-04"
+9415	fancy decent half-sized edible alien plant bit	2	good	Effect: "Heavily Breathing", Effect Duration: 20, Last Available: "2017-04"
 9416	blinking alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	jittery complex alien plant sample	0		Last Available: "2017-04"
@@ -9297,7 +9297,7 @@
 9425	tumbling alien zoological sample	0		Last Available: "2017-04"
 9426	jittery complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	denatured upside-down pulsating mirror alien animal goo	1		Last Available: "2017-04"
+9428	denatured mirror upside-down pulsating alien animal goo	1		Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	squat spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
@@ -9320,12 +9320,12 @@
 9448	murderbot power cell	0		Last Available: "2017-04"
 9449	teal murderbot component casing	0		Last Available: "2017-04"
 9450	ghostly murderbot monofilament	0		Last Available: "2017-04"
-9451	irradiated double-enhanced twirling tumbling murderbot shield unit	0		Effect: "You're High as a Crow, Marty", Effect Duration: 68, Last Available: "2017-04"
+9451	irradiated double-enhanced tumbling twirling murderbot shield unit	0		Effect: "You're High as a Crow, Marty", Effect Duration: 68, Last Available: "2017-04"
 9452	wobbly ghostly murderbot live wire	0		Last Available: "2017-04"
 9453	asbestos-lined double-paned rock-hard murderbot mask	0		Damage Reduction: 5, Cold Resistance: +5, Hot Resistance: +5, Avatar: "Murderbot", Last Available: "2017-04"
 9454	moist modified murderbot spring injector	0		Effect: "Heart of Yellow", Effect Duration: 63, Last Available: "2017-04"
 9455	healthy murderbot whip of the brazier	0		Maximum HP Percent: +20, Hot Spell Damage: +25, Last Available: "2017-04"
-9456	knitted ribald murderbot plasma rifle	0		Sleaze Damage: +10, Cold Resistance: +3, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	knitted ribald murderbot plasma rifle	0		Sleaze Damage: +10, Cold Resistance: +3, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	jittery Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9337,12 +9337,12 @@
 9465	Spacegate	0		Last Available: "2017-04"
 9466	flavorless half-sized Aldebaran sardines	2	decent	Last Available: "2017-04"
 9467	artisanal fancy squat Centauri fish wine	3	EPIC	Effect: "Moon'd", Effect Duration: 15, Last Available: "2017-04"
-9468	twisted tumbling bouncing oxygen	1		Last Available: "2017-04"
+9468	twisted bouncing tumbling oxygen	1		Last Available: "2017-04"
 9469	vibrating sinister Spacegate scientist's insignia	0		Spell Damage: +10, Maximum MP Percent: +10, Single Equip, Last Available: "2017-04"
 9470	vibrating dance instructor's Spacegate military insignia	0		Experience Percent (Moxie): +10, Maximum MP Percent: +10, Single Equip, Last Available: "2017-04"
 9471	dog trainer's vibrating cool Spacegate diplomat's insignia	0		Moxie: +5, Maximum MP Percent: +10, Experience (familiar): +1, Single Equip, Last Available: "2017-04"
 9472	huge Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
-9473	cyan mirror Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
+9473	mirror cyan Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	spoiled alien sandwich	3	crappy	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	polymerized Spant eggs	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 33
@@ -9354,15 +9354,15 @@
 9482	deionized maroon Daily Affirmation: Adapt to Change Eventually	0		Effect: "Leisurely Amblin'", Effect Duration: 42, Last Available: "2017-05"
 9483	pickled cyan Daily Affirmation: Be a Mind Master	0		Effect: "Pwnd", Effect Duration: 23, Last Available: "2017-05"
 9484	unsweetened enhanced Daily Affirmation: Work For Hours a Week	0		Effect: "Cat-Alyzed", Effect Duration: 50, Last Available: "2017-05"
-9485	aerosolized chilled mirror lime green Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Lemony Goodness", Effect Duration: 65, Last Available: "2017-05"
-9486	diet bland huge olive Affirmation Cookie	1	decent	Last Available: "2017-05"
+9485	aerosolized chilled lime green mirror Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Lemony Goodness", Effect Duration: 65, Last Available: "2017-05"
+9486	diet bland olive huge Affirmation Cookie	1	decent	Last Available: "2017-05"
 9487	olive License To Kill	0		
 9488	Thwaitgold bug statuette	0		
-9489	mirror twirling Victor's Spoils	0		
+9489	twirling mirror Victor's Spoils	0		
 9490	oxidized Threatening Missive	0		Effect: "Ghostly Shell", Effect Duration: 60
 9491	lime green Targeted Plague Vector	0		
 9492	narrow suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	supercharged experienced Kremlin's Greatest Briefcase of the brazier	0		Experience: +2, Maximum MP Percent: +30, Hot Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	supercharged experienced Kremlin's Greatest Briefcase of the brazier	0		Experience: +2, Maximum MP Percent: +30, Hot Spell Damage: +25, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	perfectly mixed basic martini	3	EPIC	Last Available: "2017-06"
 9495	perfectly mixed improved martini	4	EPIC	Last Available: "2017-06"
 9496	drinkable fuchsia splendid martini	3	good	Last Available: "2017-06"
@@ -9378,23 +9378,23 @@
 9506	tumbling upside-down Lazenby's Life Lesson	0		Free Pull
 9507	purple LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	tumbling Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
-9509	spinning pulsating blurry L.I.M.P. Stock Certificate	0		
+9509	blurry pulsating spinning L.I.M.P. Stock Certificate	0		
 9510	bouncing Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	mirror Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	rotten spinning blinking meteoreo	3	crappy	Last Available: "2017-08"
+9514	rotten blinking spinning meteoreo	3	crappy	Last Available: "2017-08"
 9515	drinkable watered-down upside-down meadeorite	2	good	Last Available: "2017-08"
 9516	blinking meteoroid	0		Last Available: "2017-08"
 9517	reassuring friendly meteortarboard of horror	0		Familiar Weight: +3, Spooky Spell Damage: +25, Spooky Resistance: +1, Last Available: "2017-08"
 9518	blurry ruddy wholesome steel-toed meteorite guard	0		Damage Reduction: 18, Maximum HP Percent: 50, Last Available: "2017-08"
-9519	squat beefy meteorb of extreme caution	0		Muscle: +10, Monster Level: -25, Last Available: "2017-08", Lantern Element: "Hot"
+9519	squat beefy meteorb of extreme caution	0		Muscle: +10, Monster Level: -25, Lantern Element: "Hot", Last Available: "2017-08"
 9520	scorching healthy asteroid belt	0		Maximum HP Percent: +20, Hot Damage: +25, Single Equip, Last Available: "2017-08"
 9521	quilted meteorthopedic shoes of the overflowing toilet of the cheetah	0		Damage Absorption: +40, Stench Spell Damage: +50, Initiative: +60, Single Equip, Last Available: "2017-08"
 9522	upside-down up-at-dawn miser's grievous shooting morning star	0		Weapon Damage Percent: +50, Meat Drop: +10, Adventures: +5, Single Equip, Last Available: "2017-08"
-9523	olive narrow meteoroid	0		Last Available: "2017-08"
+9523	narrow olive meteoroid	0		Last Available: "2017-08"
 9524	meteor shower cap	0		Familiar Weight: +5
-9525	yellow shaking Thwaitgold time fly statuette	0		
+9525	shaking yellow Thwaitgold time fly statuette	0		
 9526	perfectly fair coin	0		Last Available: "2017-11"
 9527	pulsating Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	huge corked genie bottle	0		Free Pull, Last Available: "2017-09"
@@ -9405,7 +9405,7 @@
 9533	pony: Pearjack	0		Last Available: "2017-09"
 9534	purple pony: Uniquity	0		Last Available: "2017-09"
 9535	pony: Rosey Cake	0		Last Available: "2017-09"
-9536	fuchsia pulsating pony: Spectrum Dash	0		Last Available: "2017-09"
+9536	pulsating fuchsia pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
 9539	mirror hunk of granite	0		
@@ -9424,7 +9424,7 @@
 9552	double-deionized Vulcanized fuchsia temporary X tattoos	0		Effect: "5 Pounds Lighter", Effect Duration: 66, Last Available: "2017-10"
 9553	dehydrated spinning glyph of athleticism	1		Effect: "Hammertime", Effect Duration: 45, Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
-9555	extra-pressed pressed vacuum-sealed yellow wobbly ghostly new habit	0		Effect: "Virgo Rising", Effect Duration: 16, Last Available: "2017-10"
+9555	extra-pressed pressed vacuum-sealed wobbly ghostly yellow new habit	0		Effect: "Virgo Rising", Effect Duration: 16, Last Available: "2017-10"
 9556	bridge truss	0		Last Available: "2017-10"
 9557	blurry flame-retardant knitted nippy pearl necklace	0		Cold Damage: +10, Cold Resistance: +3, Hot Resistance: +1, Single Equip, Last Available: "2017-10"
 9558	amorphous blob	0		Last Available: "2017-11"
@@ -9454,7 +9454,7 @@
 9582	stale half double fruitcake	4	decent	Last Available: "2017-12"
 9583	flavorless green hushed puppy	4	decent	Last Available: "2017-12"
 9584	rotten muffled muffuletta	3	crappy	Last Available: "2017-12"
-9585	bite-sized normal shushed potatoes	1	good	Last Available: "2017-12"
+9585	normal bite-sized shushed potatoes	1	good	Last Available: "2017-12"
 9586	knitted plastic mime functionary	0		Cold Resistance: +3, Last Available: "2017-12"
 9587	spinning hardened plastic mime scientist	0		Damage Reduction: 3, Last Available: "2017-12"
 9588	toasty plastic mime soldier	0		Hot Damage: +5, Last Available: "2017-12"
@@ -9467,7 +9467,7 @@
 9595	watered-down drinkable blurry tumbling Racisto Ruidoso	2	good	Last Available: "2017-11"
 9596	tumbling earthenware muffin tin	0		
 9597	decent jumbo mirror bran muffin	5	good	
-9598	thick spoiled blueberry muffin	5	crappy	
+9598	spoiled thick blueberry muffin	5	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	spinning silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9479,9 +9479,9 @@
 9607	silent I	0		Last Available: "2017-12"
 9608	twirling blurry silent J	0		Last Available: "2017-12"
 9609	silent K	0		Last Available: "2017-12"
-9610	ghostly upside-down green silent L	0		Last Available: "2017-12"
+9610	upside-down ghostly green silent L	0		Last Available: "2017-12"
 9611	silent M	0		Last Available: "2017-12"
-9612	huge blue pulsating silent N	0		Last Available: "2017-12"
+9612	pulsating huge blue silent N	0		Last Available: "2017-12"
 9613	silent O	0		Last Available: "2017-12"
 9614	silent P	0		Last Available: "2017-12"
 9615	silent Q	0		Last Available: "2017-12"
@@ -9496,7 +9496,7 @@
 9624	twirling silent Z	0		Last Available: "2017-12"
 9625	crystalline cheer	0		Last Available: "2017-12"
 9626	anti-earplugs	0		Last Available: "2017-12"
-9627	blurry blue warehouse key	0		Last Available: "2017-12"
+9627	blue blurry warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
 9629	artisanal bouncing stale cheer wine	4	EPIC	Last Available: "2017-12"
 9630	rotten blinking cyan stale Cheer-E-Os	4	crappy	Last Available: "2017-12"
@@ -9518,10 +9518,10 @@
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
 9648	mediocre executive mime flask	4	decent	Last Available: "2017-12"
-9649	fancy flavorless nega-mushroom	4	decent	Effect: "Sizzling with Fury", Effect Duration: 5, Last Available: "2017-12"
+9649	flavorless fancy nega-mushroom	4	decent	Effect: "Sizzling with Fury", Effect Duration: 5, Last Available: "2017-12"
 9650	practically non-alcoholic hand-crafted blinking nega-mushroom wine	1	super ultra EPIC	Last Available: "2017-12"
 9651	electrified colloidal Cheer-Up soda	0		Effect: "Joy", Effect Duration: 47, Last Available: "2017-12"
-9652	moldy thick blinking mime army rations	5	crappy	Last Available: "2017-12"
+9652	thick moldy blinking mime army rations	5	crappy	Last Available: "2017-12"
 9653	bad mime army wine	4	decent	Last Available: "2017-12"
 9654	boiled mime army superserum	1		Effect: "Faboooo", Effect Duration: 20, Last Available: "2017-12"
 9655	triple-altered electrified mime army camouflage kit	0		Effect: "Preternatural Greed", Effect Duration: 57, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	polarized magnetized fuchsia tumbling digital honeypot	0		Effect: "Fancy Feasted", Effect Duration: 14, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	upside-down lion tamer's mime army insignia (infantry)	0		Experience (familiar): +2, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	rosewater-soaked mime army insignia (intelligence)	0		Stench Resistance: +3, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	skewed Fonzie's mime army insignia (espionage)	0		Experience (Moxie): +1, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	upside-down lion tamer's mime army insignia (infantry)	0		Experience (familiar): +2, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	rosewater-soaked mime army insignia (intelligence)	0		Stench Resistance: +3, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	skewed Fonzie's mime army insignia (espionage)	0		Experience (Moxie): +1, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	spinning mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	narrow tumbling mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	huge mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9570,7 +9570,7 @@
 9698	colloidal wet blue hot button candy	0		Effect: "Turkey-Ambitious", Effect Duration: 64
 9699	blinking Sherlock's extremely unsafe makeshift garbage shirt of chilblains	0		Weapon Damage Percent: +100, Cold Damage: +25, Item Drop: +25, Last Available: "2018-01"
 9700	tumbling censurious novelty monorail ticket of courage	0		Spooky Resistance: +3, Sleaze Resistance: +3
-9701	mixed narrow wobbly pills	1		Effect: "Human-Machine Hybrid", Effect Duration: 15
+9701	mixed wobbly narrow pills	1		Effect: "Human-Machine Hybrid", Effect Duration: 15
 9702	distilled furry pill	1		
 9703	diluted spinning beefy pill	1		
 9704	denatured huge excitement pill	1		
@@ -9593,7 +9593,7 @@
 9725	Fonzie's groovy psychic's pslacks	0		Moxie Percent: +10, Experience (Moxie): +1, Last Available: "2018-02"
 9726	ghostly resourceful fortified psychic's amulet	0		Damage Absorption: +60, Maximum MP: +50, Last Available: "2018-02"
 9727	stale narrow heart-shaped candy whetstone	4	decent	Last Available: "2018-02"
-9728	miniature spoiled mirror Swedish massage fish	2	crappy	Last Available: "2018-02"
+9728	spoiled miniature mirror Swedish massage fish	2	crappy	Last Available: "2018-02"
 9729	hand-crafted Third Base	3	EPIC	Last Available: "2018-02"
 9730	mediocre olive Bustle Hustler	4	decent	Last Available: "2018-02"
 9731	galvanized adjusted Fabiotion	0		Effect: "Going Ape", Effect Duration: 41, Last Available: "2018-02"
@@ -9633,7 +9633,7 @@
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
 9767	narrow Pillowbug	0		Last Available: "2018-03"
-9768	mirror spinning Dressage	0		Last Available: "2018-03"
+9768	spinning mirror Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
 9770	Carpricorn	0		Last Available: "2018-03"
 9771	Turpin	0		Last Available: "2018-03"
@@ -9657,9 +9657,9 @@
 9789	Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
 9791	Bicycle	0		Last Available: "2018-03"
-9792	wobbly jittery Vamprey	0		Last Available: "2018-03"
+9792	jittery wobbly Vamprey	0		Last Available: "2018-03"
 9793	blurry Wullabye	0		Last Available: "2018-03"
-9794	shaking fuchsia Nursine	0		Last Available: "2018-03"
+9794	fuchsia shaking Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	maroon Ungulant	0		Last Available: "2018-03"
 9797	pulsating Caramel	0		Last Available: "2018-03"
@@ -9667,7 +9667,7 @@
 9799	ghostly maroon Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	squat Vulgure	0		Last Available: "2018-03"
-9802	blurry olive Squib	0		Last Available: "2018-03"
+9802	olive blurry Squib	0		Last Available: "2018-03"
 9803	upside-down Trafikoan	0		Last Available: "2018-03"
 9804	pulsating Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
@@ -9711,7 +9711,7 @@
 9843	toasty experienced &quot;Remember the Trees&quot; Shirt of the storm	0		Experience: +2, Maximum MP Percent: +40, Hot Damage: +5
 9844	blurry FantasyRealm key	0		Last Available: "2018-04"
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
-9846	bouncing squat tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
+9846	squat bouncing tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	tumbling LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	LyleCo premium rope	0		Last Available: "2018-04"
@@ -9727,8 +9727,8 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	narrow LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	bite-sized stale FantasyRealm turkey leg	1	decent	Last Available: "2018-04"
-9863	aged weak FantasyRealm mead	2	awesome	Last Available: "2018-04"
+9862	stale bite-sized FantasyRealm turkey leg	1	decent	Last Available: "2018-04"
+9863	weak aged FantasyRealm mead	2	awesome	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9742,7 +9742,7 @@
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
 9875	wobbly map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
-9877	mirror tumbling map to the Sprawling Cemetery	0		Last Available: "2018-04"
+9877	tumbling mirror map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	half-sized decent fuchsia pulsating denastified haunch	2	good	Last Available: "2018-04"
 9879	artisanal bad rum and good cola	3	EPIC	Last Available: "2018-04"
 9880	energized Potion of Heroism	0		Effect: "Billiards Belligerence", Effect Duration: 50, Last Available: "2018-04"
@@ -9763,24 +9763,24 @@
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	ghostly dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
-9898	weak smooth mirror bouncing two meat muck	2	awesome	
+9898	smooth weak mirror bouncing two meat muck	2	awesome	
 9899	moldy twirling chocolate Ogre Chieftain	3	crappy	
 9900	flavorless chocolate &quot;Phoenix&quot;	3	decent	
 9901	small stale chocolate Spider Queen	2	decent	
 9902	practically non-alcoholic acceptable hipster cocktail	1	good	
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	blinking wobbly God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	blinking wobbly God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
 9911	mirror gattoo	0		
 9912	fuchsia skewed A-Boo glue	0		
 9913	glued A-Boo clue	0		
-9914	maroon squat crude oil congealer	0		
-9915	decent fancy gray good guava	4	good	Effect: "Salad Days", Effect Duration: 20
+9914	squat maroon crude oil congealer	0		
+9915	fancy decent gray good guava	4	good	Effect: "Salad Days", Effect Duration: 20
 9916	watered-down perfectly mixed jittery gin and ginger	2	EPIC	
 9917	Thwaitgold chigger statuette	0		
 9918	powdered lime green gaseous gravy	1		
@@ -9798,7 +9798,7 @@
 9930	mirror Van der Graaf MacGyver's rosy-cheeked occult Draftsman's driving gloves	0		Spell Damage Percent: +25, Maximum HP Percent: +30, Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2018-07"
 9931	ribald nasty arcane researcher's Nouveau nosering of chilblains	0		Experience Percent (Mysticality): +10, Cold Damage: +25, Stench Damage: +5, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2018-07"
 9932	colloidal sharkfin gumbo	0		Effect: "Pwnd", Effect Duration: 41, Last Available: "2018-07"
-9933	unsweetened frozen skewed narrow boiling broth	0		Effect: "Analog Drunk", Effect Duration: 65, Last Available: "2018-07"
+9933	unsweetened frozen narrow skewed boiling broth	0		Effect: "Analog Drunk", Effect Duration: 65, Last Available: "2018-07"
 9934	frozen interrogative elixir	0		Effect: "Rotten Memories", Effect Duration: 30, Last Available: "2018-07"
 9935	shaking Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	narrow Bastille Battalion tattoo kit	0		Last Available: "2018-07"
@@ -9812,7 +9812,7 @@
 9944	reassuring foul-smelling PARTY HARD T-shirt of horror	0		Stench Damage: +10, Spooky Spell Damage: +25, Spooky Resistance: +1, Last Available: "2018-09"
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
-9947	twirling purple gas can	0		Last Available: "2018-09"
+9947	purple twirling gas can	0		Last Available: "2018-09"
 9948	tolerable squat Middle of the Road&trade; brand whiskey	4	good	Last Available: "2018-09"
 9949	tumbling neverending wallet chain	0		Last Available: "2018-09"
 9950	prompt baleful pentagram bandana	0		Spell Damage: +25, Adventures: +3, Last Available: "2018-09"
@@ -9821,7 +9821,7 @@
 9953	moldy big bouncing PB&J with the crusts cut off	5	crappy	Last Available: "2018-09"
 9954	Rosewater's dorky glasses of Tarzan	0		Mysticality Percent: +30, Experience (Muscle): +3, Single Equip, Last Available: "2018-09"
 9955	fuchsia mirror smooth ponytail clip of the storm	0		Moxie: +15, Maximum MP Percent: +40, Last Available: "2018-09"
-9956	perfumed paint palette	0		Stench Resistance: +5, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	perfumed paint palette	0		Stench Resistance: +5, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	mixed ghostly pulsating Purple Beast energy drink	1		Last Available: "2018-09"
 9959	Jack Frost's cosmetic football	0		Cold Spell Damage: +50, Last Available: "2018-09"
@@ -9837,7 +9837,7 @@
 9969	scorching coward's denim jacket	0		Monster Level: -20, Hot Damage: +25, Last Available: "2018-09"
 9970	twirling reassuring horrifying ratty knitted cap	0		Spooky Damage: +25, Spooky Resistance: +1, Last Available: "2018-09"
 9972	mirror ribald horrifying intimidating chainsaw	0		Spooky Damage: +25, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2018-09"
-9973	spirit-forward acceptable gray party beer bomb	5	good	Last Available: "2018-09"
+9973	acceptable spirit-forward gray party beer bomb	5	good	Last Available: "2018-09"
 9974	moldy enchanted blurry sweet party mix	3	crappy	Effect: "Oth-Jeal-O", Effect Duration: 10, Last Available: "2018-09"
 9975	powdered shaking blue party balloon	1		Last Available: "2018-09"
 9976	yellow pulsating frosty groovy party pants	0		Moxie Percent: +10, Cold Spell Damage: +10, Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	spoiled low-calorie tumbling party platter for one	1	crappy	Last Available: "2018-09"
 9981	diluted Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	wool MacGyver's party crasher	0		Maximum MP: +100, Cold Resistance: +1, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
-9985	mirror yellow Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
+9983	wool MacGyver's party crasher	0		Maximum MP: +100, Cold Resistance: +1, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9985	yellow mirror Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	pulsating party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	mirror mirror educational &quot;I Voted!&quot; sticker	0		Experience: +1, Lasts Until Rollover, Last Available: "2018-11"
@@ -9875,15 +9875,15 @@
 10009	Newton's Socratic mutant crown of extreme caution	0		Experience (Mysticality): 4, Monster Level: -25, Last Available: "2018-11"
 10010	yummy bite-sized ghostly ectoplasm	1	awesome	Last Available: "2018-11"
 10011	rotten pulsating	4	crappy	Last Available: "2018-11"
-10012	artisanal fortified bottle of vodka	5	EPIC	Last Available: "2018-11"
+10012	fortified artisanal bottle of vodka	5	EPIC	Last Available: "2018-11"
 10013	spoiled bouncing pizza	3	crappy	Last Available: "2018-11"
-10014	watered-down bad martini	2	decent	Last Available: "2018-11"
+10014	bad watered-down martini	2	decent	Last Available: "2018-11"
 10015	thick bland cherry pie	5	decent	Last Available: "2018-11"
 10016	delicious spinning eggnog	4	awesome	Last Available: "2018-11"
 10017	lime green glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	spoiled Hell ramen	3	crappy	Last Available: "2018-11"
-10019	practically non-alcoholic perfectly mixed gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
-10020	lousy boozy twice-haunted screwdriver	5	decent	Last Available: "2018-11"
+10019	perfectly mixed practically non-alcoholic gimlet	1	super ultra mega turbo EPIC	Last Available: "2018-11"
+10020	boozy lousy twice-haunted screwdriver	5	decent	Last Available: "2018-11"
 10021	spoiled snack-sized candy cane	2	crappy	Last Available: "2018-12"
 10022	high-proof acceptable shaking runny fermented egg	8	good	Last Available: "2018-12"
 10023	jumbo moldy oldcake	5	crappy	Last Available: "2018-12"
@@ -9897,7 +9897,7 @@
 10031	jittery Braindeer	0		Last Available: "2018-12"
 10032	Crimbo dog sweater	0		Familiar Weight: +5
 10033	huge fireproof flame-retardant pristine walrus tusk	0		Hot Resistance: 4, Last Available: "2018-12"
-10034	mirror cyan thick walrus blubber	0		Last Available: "2018-12"
+10034	cyan mirror thick walrus blubber	0		Last Available: "2018-12"
 10035	knitted nasty Tesla wizardly Staff of Frozen Lard	0		Mysticality: +25, Stench Damage: +5, Cold Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-12"
 10036	bomb	0		Last Available: "2018-12"
 10037	huge narrow olive plastic bazooka	0		Last Available: "2018-12"
@@ -9925,7 +9925,7 @@
 10059	sausage casing	0		Last Available: "2019-01"
 10060	rotten gigantic sausage	8	crappy	Last Available: "2019-01"
 10061	cyan upside-down foul-smelling Herculean red-hot sausage fork	0		Experience (Muscle): +1, Stench Damage: +10, Last Available: "2019-01"
-10062	squat pulsating bag of sausage links	0		Last Available: "2019-01"
+10062	pulsating squat bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
@@ -9933,7 +9933,7 @@
 10067	flavorless yule gruel	4	decent	Last Available: "2018-12"
 10068	tolerable hot watered rum	4	good	Last Available: "2018-12"
 10069	weak mediocre blurry bottle of Crimbognac	2	decent	Last Available: "2018-12"
-10070	stale thick Crimboysters Rockefeller	5	decent	Last Available: "2018-12"
+10070	thick stale Crimboysters Rockefeller	5	decent	Last Available: "2018-12"
 10071	mixed bouncing green Crimbeau de toilette	1		Last Available: "2018-12"
 10072	blurry Crimbo candle	0		Last Available: "2018-12"
 10073	blinking Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9961,21 +9961,21 @@
 10095	extremely unsafe brainy marble mariachi hat	0		Mysticality: +5, Weapon Damage Percent: +100, Last Available: "2019-12"
 10096	diluted marble molecules	1		Last Available: "2019-12"
 10097	energized super-polarized aerosolized Mallomarbles	0		Effect: "Stimulated Body", Effect Duration: 32
-10098	bouncing reassuring Van der Graaf punching bag	0		Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	sizzling rosy-cheeked pith helmet	0		Maximum HP Percent: +30, Hot Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	gravedigger's Rosewater's poncho	0		Mysticality Percent: +30, Spooky Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	crafty beefy pendant	0		Muscle: +10, Maximum MP: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	upside-down gravedigger's healthy palazzos	0		Maximum HP Percent: +20, Spooky Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	smelly careful pseudoaccordion	0		Monster Level: -10, Stench Spell Damage: +10, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	bouncing reassuring Van der Graaf punching bag	0		Spooky Resistance: +1, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	sizzling rosy-cheeked pith helmet	0		Maximum HP Percent: +30, Hot Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	gravedigger's Rosewater's poncho	0		Mysticality Percent: +30, Spooky Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	crafty beefy pendant	0		Muscle: +10, Maximum MP: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	upside-down gravedigger's healthy palazzos	0		Maximum HP Percent: +20, Spooky Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	smelly careful pseudoaccordion	0		Monster Level: -10, Stench Spell Damage: +10, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	dried wobbly pieces	1		Last Available: "2020-12"
-10105	double-modified spinning huge Para-Pop	0		Effect: "Kindly Resolve", Effect Duration: 11
-10106	nasty coward's terra cotta truss	0		Monster Level: -20, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	stylish terra cotta trousers of Leguizamo	0		Moxie: +25, Monster Level: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	skewed chilly ruddy terra cotta tongs	0		Maximum HP Percent: +40, Cold Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	dangerous terra cotta train of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	Van der Graaf terra cotta tie tack of the boozehound	0		Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	terra cotta tambourine of wisdom of the boozehound	0		Mysticality: +15, Booze Drop: +100, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10112	distilled blinking tumbling terra cotta tidbits	1		Last Available: "2020-12"
+10105	double-modified huge spinning Para-Pop	0		Effect: "Kindly Resolve", Effect Duration: 11
+10106	nasty coward's terra cotta truss	0		Monster Level: -20, Stench Damage: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	stylish terra cotta trousers of Leguizamo	0		Moxie: +25, Monster Level: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	skewed chilly ruddy terra cotta tongs	0		Maximum HP Percent: +40, Cold Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	dangerous terra cotta train of the brute	0		Muscle Percent: +30, Weapon Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	Van der Graaf terra cotta tie tack of the boozehound	0		Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	terra cotta tambourine of wisdom of the boozehound	0		Mysticality: +15, Booze Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10112	distilled tumbling blinking terra cotta tidbits	1		Last Available: "2020-12"
 10113	altered blue terra panna cotta	0		Effect: "Phairly Pheromonal", Effect Duration: 24
 10114	narrow spinning electrified rock-hard velour voulge	0		Damage Reduction: 5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2021-12"
 10115	maroon wool velour vambraces of wisdom	0		Mysticality: +15, Cold Resistance: +1, Single Equip, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	Jim Carey's beefy glass serape	0		Muscle: +10, Monster Level: +25, Last Available: "2021-12"
 10128	compressed upside-down squat glass shards	1		Effect: "Reptilian Fortitude", Effect Duration: 45, Last Available: "2021-12"
 10129	wet unsweetened hard candy	0		Effect: "Celestial Vision", Effect Duration: 29
-10130	padded loofah lumberjack's hat of the detective	0		Damage Absorption: +20, Item Drop: +20, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	stanky wholesome loofah lei	0		Maximum HP Percent: +10, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	toasty nippy loofah lederhosen	0		Cold Damage: +10, Hot Damage: +5, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	electrified loofah ladle of Flo-Jo	0		Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	squat toasty mansplainer's loofah legwarmers	0		Monster Level: +15, Hot Damage: +5, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	squat flame-retardant loofah lavalier of chilblains	0		Cold Damage: +25, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	padded loofah lumberjack's hat of the detective	0		Damage Absorption: +20, Item Drop: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	stanky wholesome loofah lei	0		Maximum HP Percent: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	toasty nippy loofah lederhosen	0		Cold Damage: +10, Hot Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	electrified loofah ladle of Flo-Jo	0		Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	squat toasty mansplainer's loofah legwarmers	0		Monster Level: +15, Hot Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	squat flame-retardant loofah lavalier of chilblains	0		Cold Damage: +25, Hot Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	diluted loofah lumps	1		Last Available: "2022-12"
 10137	triple-magnetized double-vacuum-sealed chocolate-covered loofah	0		Effect: "Cautious Prowl", Effect Duration: 19
-10138	flame-retardant mansplainer's flagstone flag	0		Monster Level: +15, Hot Resistance: +1, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	green lightning-fast flagstone flail of the ox	0		Muscle: +20, Initiative: +40, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	Fonzie's beefy flagstone flip-flops	0		Muscle: +10, Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	stiffened slick flagstone fez	0		Moxie: +10, Damage Reduction: 1, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	teal blinking Jack Frost's flagstone fleece of Flo-Jo	0		Cold Spell Damage: +50, Initiative: +100, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	clever experienced flagstone fringe	0		Experience: +2, Maximum MP: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	flame-retardant mansplainer's flagstone flag	0		Monster Level: +15, Hot Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	green lightning-fast flagstone flail of the ox	0		Muscle: +20, Initiative: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	Fonzie's beefy flagstone flip-flops	0		Muscle: +10, Experience (Moxie): +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	stiffened slick flagstone fez	0		Moxie: +10, Damage Reduction: 1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	teal blinking Jack Frost's flagstone fleece of Flo-Jo	0		Cold Spell Damage: +50, Initiative: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	clever experienced flagstone fringe	0		Experience: +2, Maximum MP: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	diluted flagstone flagments	1		Effect: "Jerky, Boy", Effect Duration: 50, Last Available: "2022-12"
 10145	moist unsweetened Flag by the Foot&trade;	0		Effect: "The Dinsey Spirit", Effect Duration: 32
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,10 +10018,10 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	teal really nice net	0		Last Available: "2019-12"
 10154	red elf army poncho of courage	0		Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2019-12"
-10155	adequate yellow tumbling elf army field rations	4	good	Last Available: "2019-12"
+10155	adequate tumbling yellow elf army field rations	4	good	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	electrified discarded bowtie of the early riser	0		Adventures: +7, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2019-12"
-10158	practically non-alcoholic perfectly mixed martiny	1	EPIC	Last Available: "2019-12"
+10158	perfectly mixed practically non-alcoholic martiny	1	EPIC	Last Available: "2019-12"
 10159	blinking tryptophan dart	0		Last Available: "2019-12"
 10160	cold-filtered pressed oxidized licorice snake	0		Effect: "Some Cheese with Your Wine", Effect Duration: 69
 10161	double-chilled spinning cyan virgin jello shot	0		Effect: "You're Rubber", Effect Duration: 56
@@ -10029,21 +10029,21 @@
 10163	polymerized government-issued candy	0		Effect: "Nuts about Candy", Effect Duration: 28
 10164	triple-modified Pneumo bar	0		Effect: "Turtle Power", Effect Duration: 33
 10165	ghostly wobbly mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	fuchsia dangerous beefy Lil' Doctor&trade; bag	0		Muscle: +10, Weapon Damage: +10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	fuchsia dangerous beefy Lil' Doctor&trade; bag	0		Muscle: +10, Weapon Damage: +10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	rotten diet purple narrow bloodstick	1	crappy	
-10170	enchanted acceptable bottle of Sanguiovese	3	good	Effect: "Joy", Effect Duration: 30
-10171	adequate snack-sized actual blood sausage	2	good	
+10169	diet rotten narrow purple bloodstick	1	crappy	
+10170	acceptable enchanted bottle of Sanguiovese	3	good	Effect: "Joy", Effect Duration: 30
+10171	snack-sized adequate actual blood sausage	2	good	
 10172	hand-crafted mulled blood	3	EPIC	
 10173	decent blood snowcone	4	good	
-10174	drinkable spirit-forward Red Russian	5	good	
+10174	spirit-forward drinkable Red Russian	5	good	
 10175	spoiled massive blue blood roll-up	8	crappy	
-10176	practically non-alcoholic drinkable bottle of blood	1	good	
-10177	adequate super-sized blood-soaked sponge cake	5	good	
-10178	smooth strong vampagne	5	awesome	
-10179	tasty half-sized plain snowcone	2	awesome	
+10176	drinkable practically non-alcoholic bottle of blood	1	good	
+10177	super-sized adequate blood-soaked sponge cake	5	good	
+10178	strong smooth vampagne	5	awesome	
+10179	half-sized tasty plain snowcone	2	awesome	
 10180	shaking Booke of Vampyric Knowledge	0		
-10181	shaking teal money bag	0		
+10181	teal shaking money bag	0		
 10182	money bag	0		
 10183	pulsating ghostly money bag	0		
 10184	Thwaitgold mosquito statuette	0		
@@ -10061,9 +10061,9 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	massive adequate crabsicle	7	good	Last Available: "2019-04"
+10199	adequate massive crabsicle	7	good	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	practically non-alcoholic perfectly mixed huge bottle of dark rhum	1	EPIC	Last Available: "2019-04"
+10201	perfectly mixed practically non-alcoholic huge bottle of dark rhum	1	EPIC	Last Available: "2019-04"
 10202	smooth bottle of extra-dark rhum	4	awesome	Last Available: "2019-04"
 10203	acceptable bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
 10204	anodized vacuum-sealed polarized pirate shaving cream	0		Effect: "Izchak's Blessing", Effect Duration: 35, Last Available: "2019-04"
@@ -10087,24 +10087,24 @@
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	compressed bouncing pewter shavings	1		Last Available: "2019-04"
 10224	fuchsia Red Roger tattoo kit	0		Last Available: "2019-04"
-10225	squat blue PirateRealm fun-a-log	0		Last Available: "2019-04"
+10225	blue squat PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	wicked plush sea serpent	0		Spell Damage: +5, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	adequate pirate fork	3		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	spinning ring	0		Single Equip, Last Available: "2019-04"
 10230	greasy scandalous piratical blunderbuss	0		Sleaze Damage: +5, Sleaze Spell Damage: +10, Last Available: "2019-04"
 10231	dog trainer's Van der Graaf PirateRealm party hat of the boozehound	0		Experience (familiar): +1, Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-04"
-10232	practically non-alcoholic artisanal upside-down Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
-10233	fancy aged gray Island Thunderstorm	4	awesome	Effect: "Just the Brown Ones", Effect Duration: 10, Last Available: "2019-04"
-10234	practically non-alcoholic mediocre Island Hurricane	1	decent	Last Available: "2019-04"
+10232	artisanal practically non-alcoholic upside-down Island Landslide	1	super ultra mega turbo EPIC	Last Available: "2019-04"
+10233	aged fancy gray Island Thunderstorm	4	awesome	Effect: "Just the Brown Ones", Effect Duration: 10, Last Available: "2019-04"
+10234	mediocre practically non-alcoholic Island Hurricane	1	decent	Last Available: "2019-04"
 10235	tolerable Skull Punch	4	good	Last Available: "2019-04"
 10236	fancy perfectly mixed Electric Punch	3	EPIC	Effect: "Gummiskin", Effect Duration: 30, Last Available: "2019-04"
 10237	drinkable Smuggler's Punch	4	good	Last Available: "2019-04"
 10238	tolerable yellow Scorpion Bowl	3	good	Last Available: "2019-04"
 10239	extra-dry mediocre squat Turtle Bowl	5	decent	Last Available: "2019-04"
-10240	enchanted weak acceptable olive Cobra Bowl	2	good	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2019-04"
+10240	acceptable weak enchanted olive Cobra Bowl	2	good	Effect: "Filled with Magic", Effect Duration: 30, Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	spinning censurious MacGyver's fortified Rosewater's vampyric cloake of doom	0		Mysticality Percent: +30, Damage Absorption: +60, Maximum MP: +100, Spooky Spell Damage: +50, Sleaze Resistance: +3, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	spinning censurious MacGyver's fortified Rosewater's vampyric cloake of doom	0		Mysticality Percent: +30, Damage Absorption: +60, Maximum MP: +100, Spooky Spell Damage: +50, Sleaze Resistance: +3, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	quadruple-vacuum-sealed chilled double-irradiated jittery one piece of bubble gum	0		Effect: "Salt Rockin'", Effect Duration: 13
 10245	arcanoferric housing	0		
@@ -10113,24 +10113,24 @@
 10248	upside-down blown-out speaker cone	0		
 10249	mirror overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	aromatic Oprah's deadly Fourth of May Cosplay Saber	0		Weapon Damage: +5, Maximum MP Percent: +50, Stench Resistance: +1, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	aromatic Oprah's deadly Fourth of May Cosplay Saber	0		Weapon Damage: +5, Maximum MP Percent: +50, Stench Resistance: +1, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	olive Thwaitgold nymph statuette	0		
-10254	pulsating zippy executive family-friendly Jeselnik's nippy supercharged studded savvy brawny beefy hewn moon-rune spoon of the blizzard	0		Muscle: +10, Muscle Percent: +20, Mysticality Percent: +20, Damage Absorption: +80, Maximum MP Percent: +30, Cold Damage: +10, Cold Spell Damage: +25, Sleaze Damage: +25, Sleaze Resistance: +1, Meat Drop: +40, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	pulsating zippy executive family-friendly Jeselnik's nippy supercharged studded savvy brawny beefy hewn moon-rune spoon of the blizzard	0		Muscle: +10, Muscle Percent: +20, Mysticality Percent: +20, Damage Absorption: +80, Maximum MP Percent: +30, Cold Damage: +10, Cold Spell Damage: +25, Sleaze Damage: +25, Sleaze Resistance: +1, Meat Drop: +40, Initiative: +20, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	squat rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	bouncing Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	olive shaking aromatic stiffened Beach Comb of Calamity Jane	0		Damage Reduction: 1, Critical Hit Percent: +15, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	olive shaking aromatic stiffened Beach Comb of Calamity Jane	0		Damage Reduction: 1, Critical Hit Percent: +15, Stench Resistance: +1, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	grain of sand	0		Last Available: "2019-07"
 10260	skewed small pile of sand	0		Last Available: "2019-07"
 10261	spinning pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
 10264	mirror hourglass	0		Last Available: "2019-07"
-10265	wobbly bouncing etched hourglass	0		Last Available: "2019-07"
+10265	bouncing wobbly etched hourglass	0		Last Available: "2019-07"
 10266	moist polymerized mirror magenta seashell	0		Effect: "Hairless and Airless", Effect Duration: 55, Last Available: "2019-07"
 10267	pressed cyan seashell	0		Effect: "Hella Smart", Effect Duration: 52, Last Available: "2019-07"
-10268	nitrogenated twirling fuchsia gray seashell	0		Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2019-07"
+10268	nitrogenated fuchsia twirling gray seashell	0		Effect: "You're High as a Crow, Marty", Effect Duration: 30, Last Available: "2019-07"
 10269	oxidized wet corrupted seashell	0		Effect: "The Halls of Mysticality", Effect Duration: 52, Last Available: "2019-07"
 10270	super-polarized modified seashell	0		Effect: "Takin' It Greasy", Effect Duration: 26, Last Available: "2019-07"
 10271	bouncing bunch of sea grapes	0		Last Available: "2019-07"
@@ -10165,7 +10165,7 @@
 10300	spinning narrow censurious therapeutic whittled owl figurine of the businessman	0		Sleaze Resistance: +3, Meat Drop: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-08"
 10301	chaotic stiffened thinker's whittled fox figurine	0		Mysticality: +10, Damage Reduction: 1, Spell Critical Percent: +10, Single Equip, Last Available: "2019-08"
 10302	Annie Oakley's veiny Samson's whittled walking stick of Calamity Jane	0		Experience (Muscle): +5, Maximum HP: +10, Critical Hit Percent: 35, Last Available: "2019-08"
-10303	snack-sized spoiled campfire hot dog	2	crappy	Last Available: "2019-08"
+10303	spoiled snack-sized campfire hot dog	2	crappy	Last Available: "2019-08"
 10304	adequate campfire baked potato	4	good	Last Available: "2019-08"
 10305	normal gray campfire s'more	3	good	Last Available: "2019-08"
 10306	rotten squat campfire beans	3	crappy	Last Available: "2019-08"
@@ -10182,7 +10182,7 @@
 10317	signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	mirror Thwaitgold bombardier beetle statuette	0		
-10320	stale jumbo space chowder	5	decent	
+10320	jumbo stale space chowder	5	decent	
 10321	lousy twirling space wine	3	decent	
 10322	wobbly The Imploded World	0		Skill: "Implode Universe"
 10323	mirror packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	adequate bu&ntilde;uelos Jaliscos	3	good	Last Available: "2019-12"
 10338	decent flan del mar	4	good	Last Available: "2019-12"
-10339	decent massive twirling olive Baja sopapilla	6	good	Last Available: "2019-12"
+10339	decent massive olive twirling Baja sopapilla	6	good	Last Available: "2019-12"
 10340	red plastic Mer-kin baker of the sewer	0		Stench Damage: +25, Last Available: "2019-12"
 10341	auspicious plastic sea elf	0		Item Drop: +10, Last Available: "2019-12"
 10342	blurry skewed cyan perfumed plastic yuleviathan	0		Stench Resistance: +5, Last Available: "2019-12"
@@ -10213,7 +10213,7 @@
 10354	diluted pulsating vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	compressed bouncing a bug's lymph	1		Last Available: "2019-12"
 10356	flattened ionized organic potpourri	0		Effect: "Boo Tea", Effect Duration: 28, Last Available: "2019-12"
-10357	practically non-alcoholic aged shaking shaking boot flask	1	awesome	Last Available: "2019-12"
+10357	aged practically non-alcoholic shaking shaking boot flask	1	awesome	Last Available: "2019-12"
 10358	moist infernal snowball	0		Effect: "Turkey-Agitated", Effect Duration: 21, Last Available: "2019-12"
 10359	skewed madness	0		Last Available: "2019-12"
 10360	vaporized squat ghostly fish sauce	1		Effect: "Cock of the Walk", Effect Duration: 25, Last Available: "2019-12"
@@ -10230,9 +10230,9 @@
 10371	compressed huge beggin' cologne	1		Last Available: "2019-12"
 10372	frightening stylish oxygenated eggnog helmet	0		Moxie: +25, Spooky Damage: +5, Adventure Underwater, Last Available: "2019-12"
 10373	spinning hand-knitted diving booties	0		Last Available: "2019-12"
-10374	gray narrow peppermint harpoon gun	0		Last Available: "2019-12"
+10374	narrow gray peppermint harpoon gun	0		Last Available: "2019-12"
 10375	vacuum-sealed jittery concentrated fish broth	0		Effect: "Moon-Eyed", Effect Duration: 12, Last Available: "2019-12"
-10376	cold-filtered super-polymerized shaking ghostly liquid SONAR	0		Effect: "Space Cadet", Effect Duration: 41, Last Available: "2019-12"
+10376	cold-filtered super-polymerized ghostly shaking liquid SONAR	0		Effect: "Space Cadet", Effect Duration: 41, Last Available: "2019-12"
 10377	map to Dolph Bossin's hideout	0		Free Pull, Last Available: "2019-12"
 10378	skewed Dolph Bossin's charity note	0		Free Pull, Last Available: "2019-12"
 10379	wobbly knitted Samson's Herculean Dolph Bossin's Crimbo hat	0		Experience (Muscle): 6, Cold Resistance: +3, Last Available: "2019-12"
@@ -10240,7 +10240,7 @@
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	bouncing Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	altered spinning pulsating salty gumdrop	0		Effect: "Influence of Sphere", Effect Duration: 12, Last Available: "2019-12"
+10384	altered pulsating spinning salty gumdrop	0		Effect: "Influence of Sphere", Effect Duration: 12, Last Available: "2019-12"
 10385	Jim Carey's ribbon candy ascot of incineration	0		Monster Level: +25, Hot Spell Damage: +50, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
@@ -10253,8 +10253,8 @@
 10394	supercharged Mer-kin rollpin of the businessman	0		Maximum MP Percent: +30, Meat Drop: +50, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	squat narrow tinsel fin	0		Familiar Weight: +5
-10397	miniature flavorless bowl of mernudo	2	decent	Last Available: "2019-12"
-10398	hand-crafted weak fishelada	2	EPIC	Last Available: "2019-12"
+10397	flavorless miniature bowl of mernudo	2	decent	Last Available: "2019-12"
+10398	weak hand-crafted fishelada	2	EPIC	Last Available: "2019-12"
 10399	toothsome ojo de pez burrito	3	awesome	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	rotten salt plum	3	crappy	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	spoiled special super-sized and bean	5	crappy	Effect: "Overstimulated", Effect Duration: 30, Last Available: "2019-12"
+10417	super-sized spoiled special and bean	5	crappy	Effect: "Overstimulated", Effect Duration: 30, Last Available: "2019-12"
 10418	squat reassuring stiffened kelp-holly gun of terror	0		Damage Reduction: 1, Spooky Spell Damage: +10, Spooky Resistance: +1, Last Available: "2019-12"
 10419	cyan blinking stiffened boxer's Yuleviathan necklace	0		Muscle Percent: +10, Damage Reduction: 1, Single Equip, Last Available: "2019-12"
 10420	huge maroon scorching sage peppermint spine	0		Mysticality Percent: +10, Hot Damage: +25, Last Available: "2019-12"
@@ -10288,11 +10288,11 @@
 10429	double-moist handful of mixed nuts	0		Effect: "Ripping, Dripping", Effect Duration: 23, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	clever cool Retrospecs	0		Moxie: +5, Maximum MP: +20, Item Drop: +5, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	clever cool Retrospecs	0		Moxie: +5, Maximum MP: +20, Item Drop: +5, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	olive Bird-a-Day calendar	0		Last Available: "2020-01"
-10437	wobbly squat mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	scorching Fonzie's brawny thinker's Powerful Glove of vim and vigor	0		Mysticality: +10, Muscle Percent: +20, Experience (Moxie): +1, Maximum HP Percent: +50, Hot Damage: +25, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10437	squat wobbly mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
+10438	scorching Fonzie's brawny thinker's Powerful Glove of vim and vigor	0		Mysticality: +10, Muscle Percent: +20, Experience (Moxie): +1, Maximum HP Percent: +50, Hot Damage: +25, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
 10440	mirror status cymbal	0		Last Available: "2020-02"
 10441	curative banded Drip harness of Flo-Jo	0		Damage Absorption: +100, Initiative: +100, HP Regen Min: 3, HP Regen Max: 5
@@ -10345,8 +10345,8 @@
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
 10489	moldy mushroom filet	3	crappy	Last Available: "2020-03"
 10490	tumbling mushroom slab	0		Last Available: "2020-03"
-10491	dried wobbly squat mushroom tea	1		Last Available: "2020-03"
-10492	watered-down hand-crafted skewed tumbling mushroom whiskey	2	EPIC	Last Available: "2020-03"
+10491	dried squat wobbly mushroom tea	1		Last Available: "2020-03"
+10492	hand-crafted watered-down skewed tumbling mushroom whiskey	2	EPIC	Last Available: "2020-03"
 10493	foul-smelling wholesome savvy mushroom cap	0		Mysticality Percent: +20, Maximum HP Percent: +10, Stench Damage: +10, Last Available: "2020-03"
 10494	blue blurry scorching mansplainer's Sinatra's smooth mushroom shield	0		Moxie: +15, Experience (Moxie): +5, Monster Level: +15, Hot Damage: +25, Damage Reduction: 6, Last Available: "2020-03"
 10495	baleful dance instructor's mushroom pants of Gandalf of the businessman	0		Experience Percent (Moxie): +10, Spell Damage: +25, Spell Critical Percent: +20, Meat Drop: +50, Last Available: "2020-03"
@@ -10395,9 +10395,9 @@
 10539	supercool Guzzlr souvenir stein	0		Moxie Percent: +20, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	tolerable blurry Ghiaccio Colada	3	good	Last Available: "2020-05"
-10542	weak bad Sourfinger	2	decent	Last Available: "2020-05"
+10542	bad weak Sourfinger	2	decent	Last Available: "2020-05"
 10543	acceptable Nog-on-the-Cob	3	good	Last Available: "2020-05"
-10544	distilled bad Steamboat	5	decent	Last Available: "2020-05"
+10544	bad distilled Steamboat	5	decent	Last Available: "2020-05"
 10545	perfectly mixed blinking Buttery Boy	4	EPIC	Last Available: "2020-05"
 10546	narrow Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	pulsating rosy-cheeked clown car key of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30, Last Available: "2020-08"
@@ -10429,7 +10429,7 @@
 10573	bag of Iunion stones	0		Free Pull
 10574	bouncing Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
-10576	double-alkaline huge fuchsia salty drippy candy bar	0		Effect: "familiar.enq", Effect Duration: 53
+10576	double-alkaline fuchsia huge salty drippy candy bar	0		Effect: "familiar.enq", Effect Duration: 53
 10577	quadruple-vacuum-sealed writhing drippy candy bar	0		Effect: "Dwarven Hardiness", Effect Duration: 66
 10578	adjusted gooey drippy candy bar	0		Effect: "Warm Belly", Effect Duration: 18
 10579	tumbling baby camelCalf	0		Free Pull, Last Available: "2020-07"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	mansplainer's banded birch battery	0		Damage Absorption: +100, Monster Level: +15, Lasts Until Rollover, Last Available: "2020-08"
-10585	olive arcane researcher's weightlifter's ebony epee of James Dean	0		Muscle: +15, Experience (Moxie): +3, Experience Percent (Mysticality): +10, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	greedy auspicious weeping willow wand of the businessman	0		Item Drop: +10, Meat Drop: 70, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	blue friendly steel-toed beechwood blowgun of the glutton	0		Damage Reduction: 9, Familiar Weight: +3, Food Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	olive arcane researcher's weightlifter's ebony epee of James Dean	0		Muscle: +15, Experience (Moxie): +3, Experience Percent (Mysticality): +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	greedy auspicious weeping willow wand of the businessman	0		Item Drop: +10, Meat Drop: 70, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	blue friendly steel-toed beechwood blowgun of the glutton	0		Damage Reduction: 9, Familiar Weight: +3, Food Drop: +100, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	mirror lion tamer's maple magnet of the bloodbag of the brazier	0		Maximum HP: +100, Experience (familiar): +2, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	hemlock helm of the cougar of temperance of the detective	0		Moxie: +20, Sleaze Resistance: +5, Item Drop: +20, Last Available: "2020-08"
@@ -10460,9 +10460,9 @@
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	super-cold-filtered squat Yeg's Motel toothbrush	0		Effect: "Eagle Eyes", Effect Duration: 67, Last Available: "2020-09"
-10607	dry dry tumbling squat Yeg's Motel hand soap	0		Effect: "Hagg-ard", Effect Duration: 44, Last Available: "2020-09"
+10607	dry dry squat tumbling Yeg's Motel hand soap	0		Effect: "Hagg-ard", Effect Duration: 44, Last Available: "2020-09"
 10608	mirror Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	flavorless half-sized Yeg's Motel pillow mint	2	decent	Last Available: "2020-09"
+10609	half-sized flavorless Yeg's Motel pillow mint	2	decent	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	modified pickled magnetized Yeg's Motel mouthwash	0		Effect: "Moose Wisdom", Effect Duration: 13, Last Available: "2020-09"
 10612	Yeg's Motel shower cap of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Lasts Until Rollover, Last Available: "2020-09"
@@ -10491,12 +10491,12 @@
 10635	blurry bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	squat Usain Bolt's family-friendly medical-grade forbidden Cargo Cultist Shorts	0		Spell Damage Percent: +50, Sleaze Resistance: +1, Initiative: +80, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	watered-down enchanted hand-crafted huge flask of moonshine	2	EPIC	Effect: "Sweet Tooth", Effect Duration: 10, Last Available: "2020-09"
+10638	enchanted hand-crafted watered-down huge flask of moonshine	2	EPIC	Effect: "Sweet Tooth", Effect Duration: 10, Last Available: "2020-09"
 10639	wobbly lard-coated shellacked cool sea-worn candlestick	0		Moxie: +5, Damage Reduction: 7, Sleaze Spell Damage: +25, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	cold-filtered jittery null-day exploit	0		Effect: "Dreadful Smell", Effect Duration: 38, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	delicious small chocolate chip muffin	2	awesome	
+10643	small delicious chocolate chip muffin	2	awesome	
 10644	bouncing Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10569,7 +10569,7 @@
 10713	bouncing The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	narrow The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	big normal and pepper (stale)	5	good	Last Available: "2020-12"
-10716	watered-down artisanal squat cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
+10716	artisanal watered-down squat cranberry margarita (brackish)	2	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	squat nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	pulsating maroon goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
@@ -10580,14 +10580,14 @@
 10724	modified non-ionized jittery blue Hotwire&trade; brand candy rope	0		Effect: "Elbow Sauce", Effect Duration: 65, Last Available: "2020-12"
 10725	bland half-sized bowl full of jelly	2	decent	Last Available: "2020-12"
 10726	bad Eye and a Twist	3	decent	Last Available: "2020-12"
-10727	irradiated nitrogenated gray blinking blurry Chubby and Plump bar	0		Effect: "Rad-ish", Effect Duration: 39, Last Available: "2020-12"
+10727	irradiated nitrogenated blinking blurry gray Chubby and Plump bar	0		Effect: "Rad-ish", Effect Duration: 39, Last Available: "2020-12"
 10728	olive digibritches	0		Last Available: "2025-12"
 10729	tumbling packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	blinking emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	pulsating spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	blinking emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	pulsating spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	robo-battery	0		
 10736	maroon Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10600,28 +10600,28 @@
 10744	colloidal flattened battery (car)	0		Effect: "Rad-ish", Effect Duration: 25, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	blurry marshmallow	0		
-10747	tolerable practically non-alcoholic marshmallow bomb	1	good	Last Available: "2021-03"
+10747	practically non-alcoholic tolerable marshmallow bomb	1	good	Last Available: "2021-03"
 10748	upside-down packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	wobbly blurry plate	0		Familiar Weight: +5
 10752	electrified cold-filtered short beer	0		Effect: "Chorale of Companionship", Effect Duration: 12, Last Available: "2021-05"
 10753	quadruple-adjusted twirling cyan short stack of pancakes	0		Effect: "There Wolf", Effect Duration: 48, Last Available: "2021-05"
-10754	wet ionized quantum skewed huge short stick of butter	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 13, Last Available: "2021-05"
+10754	wet ionized quantum huge skewed short stick of butter	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 13, Last Available: "2021-05"
 10755	concentrated oxidized short glass of water	0		Effect: "Voracious Gorging", Effect Duration: 42, Last Available: "2021-05"
 10756	alkaline unsweetened short	0		Effect: "All Branned Up", Effect Duration: 21, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	twirling aromatic familiar scrapbook of extreme caution	0		Monster Level: -25, Stench Resistance: +1, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	twirling aromatic familiar scrapbook of extreme caution	0		Monster Level: -25, Stench Resistance: +1, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	teal clan underground fireworks shop	0		Last Available: "2021-07"
 10762	narrow red Samson's Herculean brainy fedora-mounted fountain	0		Mysticality: +5, Experience (Muscle): 6, Lasts Until Rollover, Last Available: "2021-07"
 10763	friendly wholesome boxer's sombrero-mounted sparkler	0		Muscle Percent: +10, Maximum HP Percent: +10, Familiar Weight: +3, Lasts Until Rollover, Last Available: "2021-07"
 10764	gray energetic Rosewater's savvy porkpie-mounted popper	0		Mysticality Percent: 50, Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2021-07"
 10765	tumbling rocket	0		Last Available: "2021-07"
-10766	upside-down maroon huge jittery rocket	0		Last Available: "2021-07"
+10766	huge upside-down jittery maroon rocket	0		Last Available: "2021-07"
 10767	ghostly rocket	0		Last Available: "2021-07"
-10768	normal gigantic fire crackers	10	good	Last Available: "2021-07"
+10768	gigantic normal fire crackers	10	good	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	weightlifter's Catherine Wheel of the scaredy-cat	0		Muscle: +15, Monster Level: -15, Lasts Until Rollover, Last Available: "2021-07"
 10771	frightening rocket boots of the early riser	0		Spooky Damage: +5, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10630,7 +10630,7 @@
 10774	diffused galvanized maroon Scent of a Human&trade; candle	0		Effect: "So Fresh and So Clean", Effect Duration: 65, Last Available: "2021-08"
 10775	aerosolized The Beast Within&trade; candle	0		Effect: "Bread-Lined", Effect Duration: 69, Last Available: "2021-08"
 10776	polarized galvanized spinning Salsa Caliente&trade; candle	0		Effect: "5 Pounds Lighter", Effect Duration: 50, Last Available: "2021-08"
-10777	altered maroon skewed Smoldering Clover&trade; candle	0		Effect: "Buff as a Baobab", Effect Duration: 55, Last Available: "2021-08"
+10777	altered skewed maroon Smoldering Clover&trade; candle	0		Effect: "Buff as a Baobab", Effect Duration: 55, Last Available: "2021-08"
 10778	ionized Napalm In The Morning&trade; candle	0		Effect: "Super Accuracy", Effect Duration: 51, Last Available: "2021-08"
 10779	tumbling narrow wool extra-large utility candle of James Dean	0		Experience (Moxie): +3, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
 10780	reassuring Samson's runed taper candle	0		Experience (Muscle): +5, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	upside-down packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	scorching MacGyver's industrial fire extinguisher of the bloodbag of Gandalf of chilblains of the overflowing toilet	0		Maximum HP: +100, Maximum MP: +100, Spell Critical Percent: +20, Cold Damage: +25, Hot Damage: +25, Stench Spell Damage: +50, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	scorching MacGyver's industrial fire extinguisher of the bloodbag of Gandalf of chilblains of the overflowing toilet	0		Maximum HP: +100, Maximum MP: +100, Spell Critical Percent: +20, Cold Damage: +25, Hot Damage: +25, Stench Spell Damage: +50, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	mirror The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,7 +10660,7 @@
 10804	ghostly asbestos-lined foul-smelling baleful Daylight Shavings Helmet	0		Spell Damage: +25, Stench Damage: +10, Hot Resistance: +5, Last Available: "2021-11"
 10805	wobbly eggwater	1	good	Last Available: "2021-12"
 10806	adequate bread man	3	good	Last Available: "2021-12"
-10807	spoiled tumbling blinking plain candy cane	3	crappy	Last Available: "2021-12"
+10807	spoiled blinking tumbling plain candy cane	3	crappy	Last Available: "2021-12"
 10808	spoiled wobbly flour cookie	3	crappy	Last Available: "2021-12"
 10809	spinning rosy-cheeked plastic food lab	0		Maximum HP Percent: +30, Single Equip, Last Available: "2021-12"
 10810	plastic nog lab of vim and vigor	0		Maximum HP Percent: +50, Single Equip, Last Available: "2021-12"
@@ -10675,18 +10675,18 @@
 10819	normal snack-sized tofu pop	2	good	Last Available: "2021-12"
 10820	rotten maroon bowl of prescription candy	3	crappy	Last Available: "2021-12"
 10821	moldy fishcake	3	crappy	Last Available: "2021-12"
-10822	snack-sized fancy decent bone broth	2	good	Effect: "Meat the Flintstones", Effect Duration: 25, Last Available: "2021-12"
+10822	fancy snack-sized decent bone broth	2	good	Effect: "Meat the Flintstones", Effect Duration: 25, Last Available: "2021-12"
 10823	rotten star pop	4	crappy	Last Available: "2021-12"
 10824	bad Doc's Fortifying Wine	4	decent	Last Available: "2021-12"
-10825	watered-down acceptable Doc's Smartifying Wine	2	good	Last Available: "2021-12"
+10825	acceptable watered-down Doc's Smartifying Wine	2	good	Last Available: "2021-12"
 10826	delicious purple Doc's Limbering Wine	3	awesome	Last Available: "2021-12"
 10827	bad Doc's Medical-Grade Wine	3	decent	Last Available: "2021-12"
 10828	boiled upside-down Homebodyl&trade;	1		Last Available: "2021-12"
-10829	dehydrated green jittery Extrovermectin&trade;	1		Last Available: "2021-12"
+10829	dehydrated jittery green Extrovermectin&trade;	1		Last Available: "2021-12"
 10830	twisted wobbly Breathitin&trade;	1		Last Available: "2021-12"
 10831	twisted Fleshazole&trade;	1		Effect: "Busy Bein' Delicious", Effect Duration: 10, Last Available: "2021-12"
 10832	quadruple-improved skewed anti-burn cream	0		Effect: "Nut-Rition", Effect Duration: 39, Last Available: "2021-12"
-10833	moist yellow skewed anti-freeze cream	0		Effect: "Bastard!", Effect Duration: 68, Last Available: "2021-12"
+10833	moist skewed yellow anti-freeze cream	0		Effect: "Bastard!", Effect Duration: 68, Last Available: "2021-12"
 10834	altered unsweetened ionized anti-goosebump cream	0		Effect: "There Wolf", Effect Duration: 32, Last Available: "2021-12"
 10835	non-colloidal super-unsweetened huge anti-odor cream	0		Effect: "Booing Radly", Effect Duration: 37, Last Available: "2021-12"
 10836	nitrogenated anti-creep cream	0		Effect: "Thickest, Sickest", Effect Duration: 36, Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	goo magnet	0		Last Available: "2021-12"
 10851	experienced cozy scarf	0		Experience: +2, Last Available: "2021-12"
-10852	huge spoiled huge Crimbo cookie	6	crappy	Last Available: "2023-06"
+10852	spoiled huge huge Crimbo cookie	6	crappy	Last Available: "2023-06"
 10853	concentrated narrow fleshy putty	0		Effect: "Spore-Wreathed", Effect Duration: 30, Last Available: "2021-12"
 10854	reassuring third ear	0		Spooky Resistance: +1, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
@@ -10768,21 +10768,21 @@
 10912	delicious miniature 20-lb can of rice and beans	2	awesome	Last Available: "2022-05"
 10913	special huge bar of freeze-dried water	1	EPIC	Effect: "Starry-Eyed", Effect Duration: 15, Last Available: "2022-05"
 10914	tasty gray expired MRE	3	awesome	Last Available: "2022-05"
-10915	diet adequate cool mint precipice bar	1	good	Last Available: "2022-05"
+10915	adequate diet cool mint precipice bar	1	good	Last Available: "2022-05"
 10916	low-calorie flavorless spinning carrot cake precipice bar	1	decent	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
-10919	upside-down ghostly packaged June cleaver	0		Free Pull, Last Available: "2022-06"
+10919	ghostly upside-down packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	executive ribald beefcake's June cleaver	0		Muscle: +25, Sleaze Damage: +10, Meat Drop: +40, Attacks Can't Miss, Last Available: "2022-06"
 10921	weak lousy Dad's brandy	2	decent	Last Available: "2022-06"
 10922	blurry fortified teacher's pen of the sweet-tooth	0		Damage Absorption: +60, Candy Drop: +100, Last Available: "2022-06"
-10923	moldy bite-sized shaking shaking fire-roasted lake trout	1	crappy	Last Available: "2022-06"
+10923	bite-sized moldy shaking shaking fire-roasted lake trout	1	crappy	Last Available: "2022-06"
 10924	rotten pulsating guilty sprout	4	crappy	Last Available: "2022-06"
 10925	fuchsia Fonzie's groovy mother's necklace	0		Moxie Percent: +10, Experience (Moxie): +1, Last Available: "2022-06"
 10926	aerosolized frozen huge trampled ticket stub	0		Effect: "Tapped In", Effect Duration: 56, Last Available: "2022-06"
 10927	non-irradiated ghostly savings bond	0		Effect: "Your Interest is Peaked", Effect Duration: 32, Last Available: "2022-06"
 10928	wobbly designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	bouncing designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	bouncing designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	twisted blinking sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10805,7 +10805,7 @@
 10949	banded dinosaur	0		Damage Absorption: +100
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	supercharged Fonzie's Jurassic Parka	0		Experience (Moxie): +1, Maximum MP Percent: +30, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	supercharged Fonzie's Jurassic Parka	0		Experience (Moxie): +1, Maximum MP Percent: +30, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	jittery autumn-aton	0		Last Available: "2022-10"
 10955	Vulcanized tumbling autumn leaf	0		Effect: "Dreadful Fear", Effect Duration: 44, Last Available: "2022-10"
@@ -10815,7 +10815,7 @@
 10959	thick rotten autumn-spice donut	5	crappy	Last Available: "2022-10"
 10960	corrupted alkaline autumn dollar	0		Effect: "Slippery Tongue", Effect Duration: 25, Last Available: "2022-10"
 10961	dangerous Fonzie's experienced autumn leaf pendant	0		Experience: +2, Experience (Moxie): +1, Weapon Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
-10962	diluted wobbly gray autumn breeze	1		Effect: "Chari Tea", Effect Duration: 30, Last Available: "2022-10"
+10962	diluted gray wobbly autumn breeze	1		Effect: "Chari Tea", Effect Duration: 30, Last Available: "2022-10"
 10963	warmed narrow autumn years wisdom	0		Effect: "Natural 20", Effect Duration: 63, Last Available: "2022-10"
 10964	blue mirror familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	acceptable enchanted Oopsie IPA	3	good	Effect: "Concentrated Concentration", Effect Duration: 35, Last Available: "2022-10"
@@ -10823,37 +10823,37 @@
 10967	upside-down Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	stale tiny jittery huge ratatouille de Jarlsberg	1	decent	Last Available: "2022-11"
+10970	stale tiny huge jittery ratatouille de Jarlsberg	1	decent	Last Available: "2022-11"
 10971	flavorless Jarlsberg's vegetable soup	4	decent	Last Available: "2022-11"
-10972	flavorless upside-down mirror roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
-10973	enchanted bland spinning St. Pete's sneaky smoothie	3	decent	Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2022-11"
+10972	flavorless mirror upside-down roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
+10973	bland enchanted spinning St. Pete's sneaky smoothie	3	decent	Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2022-11"
 10974	decent mirror Pete's wiley whey bar	3	good	Last Available: "2022-11"
 10975	rotten skewed Pete's rich ricotta	3	crappy	Last Available: "2022-11"
-10976	drinkable weak Boris's beer	2	good	Last Available: "2022-11"
-10977	delicious special honey bun of Boris	3	awesome	Effect: "Antarctic Memories", Effect Duration: 40, Last Available: "2022-11"
+10976	weak drinkable Boris's beer	2	good	Last Available: "2022-11"
+10977	special delicious honey bun of Boris	3	awesome	Effect: "Antarctic Memories", Effect Duration: 40, Last Available: "2022-11"
 10978	tiny adequate Boris's bread	1	good	Last Available: "2022-11"
-10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	mirror shaking Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	squat Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	spinning Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	twirling Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	mirror shaking Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	squat Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	spinning Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	spoiled baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
 10989	rotten jittery plain calzone	3	crappy	Last Available: "2022-11"
 10990	moldy blue roasted vegetable focaccia	3	crappy	Last Available: "2022-11"
 10991	moldy Pizza of Legend	4	crappy	Last Available: "2022-11"
-10992	massive bland Calzone of Legend	7	decent	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10992	bland massive Calzone of Legend	7	decent	Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	spoiled half-sized Deep Dish of Legend	2	crappy	Last Available: "2022-11"
+10999	Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+11000	half-sized spoiled Deep Dish of Legend	2	crappy	Last Available: "2022-11"
 11001	fuchsia deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10863,22 +10863,22 @@
 11007	booze bindle	0		
 11008	Herculean groovy rare oboe	0		Moxie Percent: +10, Experience (Muscle): +1
 11009	horrifying flame-wreathed bullet necklace	0		Hot Spell Damage: +10, Spooky Damage: +25, Single Equip
-11010	delicious diet swamp haunch	1	awesome	
+11010	diet delicious swamp haunch	1	awesome	
 11011	gator shades of chilblains of the businessman	0		Cold Damage: +25, Meat Drop: +50, Single Equip
 11012	milk cap	0		
 11013	drinkable skewed Charleston Choo-Choo	4	good	
 11014	smooth Velvet Veil	4	awesome	
 11015	tolerable upside-down Marltini	4	good	
-11016	practically non-alcoholic tolerable narrow Strong, Silent Type	1	good	
-11017	acceptable huge twirling Mysterious Stranger	3	good	
+11016	tolerable practically non-alcoholic narrow Strong, Silent Type	1	good	
+11017	acceptable twirling huge Mysterious Stranger	3	good	
 11018	bad weak narrow Champagne Shimmy	2	decent	
 11019	spinning the Sot's parcel	0		
-11020	MacGyver's ruddy ceramic cestus	0		Maximum HP Percent: +40, Maximum MP: +100, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	smartaleck's boxer's ceramic centurion shield of the sweet-tooth	0		Muscle Percent: +10, Moxie Percent: +30, Candy Drop: +100, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	ghostly wobbly smelly energetic ceramic celery grater	0		Maximum MP Percent: +20, Stench Spell Damage: +10, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	wool coward's weightlifter's ceramic celsiturometer	0		Muscle: +15, Monster Level: -20, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	auspicious horrifying ceramic cerecloth belt of Leguizamo	0		Monster Level: +20, Spooky Damage: +25, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	gray upside-down careful ceramic cenobite's robe of the detective of the early riser	0		Monster Level: -10, Item Drop: +20, Adventures: +7, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	MacGyver's ruddy ceramic cestus	0		Maximum HP Percent: +40, Maximum MP: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	smartaleck's boxer's ceramic centurion shield of the sweet-tooth	0		Muscle Percent: +10, Moxie Percent: +30, Candy Drop: +100, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	ghostly wobbly smelly energetic ceramic celery grater	0		Maximum MP Percent: +20, Stench Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	wool coward's weightlifter's ceramic celsiturometer	0		Muscle: +15, Monster Level: -20, Cold Resistance: +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	auspicious horrifying ceramic cerecloth belt of Leguizamo	0		Monster Level: +20, Spooky Damage: +25, Item Drop: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	gray upside-down careful ceramic cenobite's robe of the detective of the early riser	0		Monster Level: -10, Item Drop: +20, Adventures: +7, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	dried bouncing ceramic scree	1		Last Available: "2023-12"
 11027	activated skewed extra-hard jawbreaker	0		Effect: "Spiritually Awake", Effect Duration: 63
 11028	horrifying Temple Grandin's chiffon chevrons of the dark arts	0		Spell Damage Percent: +100, Familiar Weight: +7, Spooky Damage: +25, Single Equip, Last Available: "2023-12"
@@ -10913,7 +10913,7 @@
 11057	wobbly ping-pong ball	0		
 11058	occult Trainbot harness	0		Spell Damage Percent: +25
 11059	tumbling maroon ping-pong table	0		
-11060	twirling huge Crimbo train emergency brake	0		
+11060	huge twirling Crimbo train emergency brake	0		
 11061	huge Trainbot autoassembly module	0		
 11062	inspector's gravedigger's steel-toed head-mounted Trainbot	0		Damage Reduction: 9, Spooky Damage: +10, Item Drop: +15, Last Available: "2022-12"
 11063	scorching Temple Grandin's dance instructor's leg-mounted Trainbots	0		Experience Percent (Moxie): +10, Familiar Weight: +7, Hot Damage: +25, Last Available: "2022-12"
@@ -10925,19 +10925,19 @@
 11069	Trainbot luggage hook	0		Single Equip
 11070	rotten honey-drenched ham slice	4	crappy	
 11071	artisanal mostly-empty bottle of cookie wine	4	EPIC	
-11072	small toothsome Crimbo food scraps	2	awesome	
+11072	toothsome small Crimbo food scraps	2	awesome	
 11073	arm towel	0		Last Available: "2022-12"
 11074	wobbly automatic wine thief	0		Single Equip
 11075	wobbly table-scraper	0		Single Equip
 11076	huge Trainbot slag	0		
 11077	red industrially-crushed ice	0		Last Available: "2022-12"
-11078	stale low-calorie steamed oyster	1	decent	
+11078	low-calorie stale steamed oyster	1	decent	
 11079	really nice lump of coal	0		
 11080	pulsating deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	gray steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	blinking crystal Crimbo platter	0		
-11084	acceptable weak Crimbosmopolitan	2	good	Last Available: "2022-12"
+11084	weak acceptable Crimbosmopolitan	2	good	Last Available: "2022-12"
 11085	huge adequate fuchsia Crimbo dinner	6	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
@@ -10949,8 +10949,8 @@
 11093	Tesla sage grubby wool scarf	0		Mysticality Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11094	upside-down nasty stiffened smooth grubby wool trousers	0		Moxie: +15, Damage Reduction: 1, Stench Damage: +5
 11095	Usain Bolt's frightening scorching clever grubby wool gloves	0		Maximum MP: +20, Hot Damage: +25, Spooky Damage: +5, Initiative: +80, Single Equip
-11096	skewed ghostly skewed grubby wool beerwarmer	0		
-11097	watered-down acceptable nice warm beer	2	good	
+11096	skewed skewed ghostly grubby wool beerwarmer	0		
+11097	acceptable watered-down nice warm beer	2	good	
 11098	grubby woolball	0		
 11099	blinking blinking Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	ghostly upside-down packet of rock seeds	0		Last Available: "2023-01"
@@ -10959,7 +10959,7 @@
 11103	lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	blinking milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
-11106	twirling blue molehill mountain	0		Last Available: "2023-01"
+11106	blue twirling molehill mountain	0		Last Available: "2023-01"
 11107	whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
@@ -10968,13 +10968,13 @@
 11113	lousy weak pixel whiskey	2	decent	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
-11116	red huge S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
+11116	huge red S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	frozen glob of extra-green chlorophyll	0		Effect: "Mayeaugh", Effect Duration: 45, Last Available: "2023-02"
 11118	moist triple-colloidal mushroom	0		Effect: "Flame-Retardant Trousers", Effect Duration: 28, Last Available: "2023-02"
 11119	frozen quantum five-fingered fern resin	0		Effect: "Adapt to Change Eventually", Effect Duration: 42, Last Available: "2023-02"
-11120	flavorless small huge super good fruit	2	decent	Last Available: "2023-02"
+11120	small flavorless huge super good fruit	2	decent	Last Available: "2023-02"
 11121	mixed energized spores	1		Last Available: "2023-02"
-11122	baleful hot pepper of the glutton	0		Spell Damage: +25, Food Drop: +100, Last Available: "2023-02", Lantern Element: "Hot"
+11122	baleful hot pepper of the glutton	0		Spell Damage: +25, Food Drop: +100, Lantern Element: "Hot", Last Available: "2023-02"
 11123	diffused pulsating out-of-work circus flea	0		Effect: "Ooh, Umami!", Effect Duration: 48, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	alkaline fire ant pheromones	0		Effect: "Fungal Fortification", Effect Duration: 62, Last Available: "2023-02"
@@ -10987,7 +10987,7 @@
 11132	skewed hollow rock	0		Last Available: "2023-02"
 11133	deionized extra-irradiated angry agate	0		Effect: "Mistified", Effect Duration: 15, Last Available: "2023-02"
 11134	cold-filtered aerosolized wobbly pulsating lump of loyal latite	0		Effect: "Disco Inferno", Effect Duration: 59, Last Available: "2023-02"
-11135	enchanted bland half-sized shadow sausage	2	decent	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2023-03"
+11135	bland half-sized enchanted shadow sausage	2	decent	Effect: "Toothy Grin", Effect Duration: 35, Last Available: "2023-03"
 11136	veiny shadow skin of the brazier	0		Maximum HP: +10, Hot Spell Damage: +25, Last Available: "2023-03"
 11137	electrified ghostly shadow flame	0		Effect: "Itchy Trigger Finger", Effect Duration: 31, Last Available: "2023-03"
 11138	adequate shadow bread	4	good	Last Available: "2023-03"
@@ -10997,7 +10997,7 @@
 11142	maroon shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
 11144	acceptable shadow venom	3	good	Last Available: "2023-03"
-11145	compressed skewed yellow shadow nectar	1		Effect: "Pockets of Fire", Effect Duration: 10, Last Available: "2023-03"
+11145	compressed yellow skewed shadow nectar	1		Effect: "Pockets of Fire", Effect Duration: 10, Last Available: "2023-03"
 11146	lard-coated resourceful shadow stick of temperance	0		Maximum MP: +50, Sleaze Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2023-03"
 11147	careful slick bat paw	0		Moxie: +10, Monster Level: -10
 11148	uncursed bat paw of the brute	0		Muscle Percent: +30
@@ -11034,12 +11034,12 @@
 11179	stylish shadow hammer of Flo-Jo	0		Moxie: +25, Initiative: +100
 11180	skewed fuchsia dog trainer's coward's Tesla shadow monocle	0		Monster Level: -20, Experience (familiar): +1, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	stale huge shadow hot dog	9	decent	
-11183	acceptable weak shadow martini	2	good	
-11184	pickled wobbly shaking tumbling shadow pill	1		
+11182	huge stale shadow hot dog	9	decent	
+11183	weak acceptable shadow martini	2	good	
+11184	pickled tumbling shaking wobbly shadow pill	1		
 11185	blurry jittery shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
-11187	bouncing wobbly monkey glove	0		Free Pull, Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11187	wobbly bouncing monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	polarized aerosolized wet shadow candy	0		Effect: "Antsy in your Pantsy", Effect Duration: 40
 11189	pulsating replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
@@ -11070,12 +11070,12 @@
 11215	replica angel	0		
 11216	grievous replica Camp Scout backpack	0		Weapon Damage Percent: +50
 11217	spinning replica deactivated nanobots	0		
-11218	mirror pulsating replica Apathargic Bandersnatch	0		
+11218	pulsating mirror replica Apathargic Bandersnatch	0		
 11219	blurry spinning replica Smith's Tome	0		
 11220	replica over-the-shoulder Folder Holder	0		
 11221	pulsating replica Order of the Green Thumb Order Form	0		
 11222	bouncing shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	censurious smooth Cincho de Mayo of the bloodbag of mayonnaise	0		Moxie: +15, Maximum HP: +100, Sleaze Spell Damage: +50, Sleaze Resistance: +3, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	censurious smooth Cincho de Mayo of the bloodbag of mayonnaise	0		Moxie: +15, Maximum HP: +100, Sleaze Spell Damage: +50, Sleaze Resistance: +3, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	cyan replica Little Geneticist DNA-Splicing Lab	0		
 11226	tumbling replica still grill	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	zippy dog trainer's replica Jurassic Parka	0		Experience (familiar): +1, Initiative: +20
 11250	fuchsia replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	inspector's hardy smartaleck's replica Cincho de Mayo of courage	0		Moxie Percent: +30, Maximum HP: +50, Spooky Resistance: +3, Item Drop: +15, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	hale wicked deadly supercool &quot;I survived Y2K&quot; T-Shirt of the dark arts of Leguizamo	0		Moxie Percent: +20, Weapon Damage: +5, Spell Damage: +5, Spell Damage Percent: +100, Maximum HP: +20, Monster Level: +20, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	pro skateboard of the boozehound of Flo-Jo	0		Booze Drop: +100, Initiative: +100, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	pro skateboard of the boozehound of Flo-Jo	0		Booze Drop: +100, Initiative: +100, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
-11262	red shaking Meat Butler	0		Last Available: "2023-06"
+11262	shaking red Meat Butler	0		Last Available: "2023-06"
 11263	red Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	red Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	twirling studded Flash Liquidizer Ultra Dousing Accessory	0		Damage Absorption: +80, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11266	twirling studded Flash Liquidizer Ultra Dousing Accessory	0		Damage Absorption: +80, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	wool toasty nippy Amulet of Perpetual Darkness of extreme caution	0		Monster Level: -25, Cold Damage: +10, Hot Damage: +5, Cold Resistance: +1, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	narrow Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11134,15 +11134,15 @@
 11279	fuchsia Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	pulsating maroon Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	drinkable practically non-alcoholic bouncing Sexy Cosmo	1	good	Last Available: "2023-06"
+11282	practically non-alcoholic drinkable bouncing Sexy Cosmo	1	good	Last Available: "2023-06"
 11283	upside-down Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	blurry lard-coated ribald dance instructor's red-soled high heels	0		Experience Percent (Moxie): +10, Sleaze Damage: +10, Sleaze Spell Damage: +25, Last Available: "2023-06"
-11285	half-sized moldy cyburger	2	crappy	Last Available: "2025-12"
+11285	moldy half-sized cyburger	2	crappy	Last Available: "2025-12"
 11286	stiffened ncle leg	0		Damage Reduction: 1
 11287	aromatic frosty rutabuga bag	0		Cold Spell Damage: +10, Stench Resistance: +1
 11288	beefy mesquito proboscis	0		Muscle: +10
 11289	mansplainer's senate fly thorax	0		Monster Level: +15
-11290	anodized enhanced ghostly narrow bug juice	0		Effect: "Graham Crackling", Effect Duration: 56
+11290	anodized enhanced narrow ghostly bug juice	0		Effect: "Graham Crackling", Effect Duration: 56
 11291	green spider leg of Calamity Jane	0		Critical Hit Percent: +15
 11292	lime green MacGyver's beetle antenna	0		Maximum MP: +100
 11293	huge squat mantis skull of the wise owl	0		Mysticality: +20
@@ -11174,15 +11174,15 @@
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	perfectly mixed huge bottle of Cabernet Sauvignon	3	EPIC	
 11321	lard-coated baywatch of the empath of the blizzard	0		Familiar Weight: +5, Cold Spell Damage: +25, Sleaze Spell Damage: +25, Lasts Until Rollover
-11322	shaking Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	shaking Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	twirling Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	modified pulsating concentrated cooking	1		Effect: "Human-Fish Hybrid", Effect Duration: 30
 11329	twisted meat	1		
-11330	pickled blurry yellow shaking sparkling orb	1		
+11330	pickled shaking blurry yellow sparkling orb	1		
 11331	altered hardening cream	1		
 11332	dried pool shark hair oil	1		Effect: "Executive Greed", Effect Duration: 40
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11261,7 +11261,7 @@
 11406	tumbling Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	narrow razor-sharp Crimbuccaneer shirt	0		Weapon Damage Percent: [+25*event(December)], Last Available: "2023-12"
 11408	Elf Guard MPC	0		Last Available: "2023-12"
-11409	teal pulsating Crimbuccaneer piece of 12	0		Last Available: "2023-12"
+11409	pulsating teal Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	resourceful Elf Guard commandeering gloves	0		Maximum MP: +50, Single Equip, Last Available: "2023-12"
 11411	magnetized aerosolized fuchsia mirror Elf Guard eyedrops	0		Effect: "On the Shoulders of Giants", Effect Duration: 19, Last Available: "2023-12"
 11412	Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
@@ -11307,33 +11307,33 @@
 11452	narrow family-friendly gravedigger's coward's clever smartaleck's Elf dessert spoon of dire peril	0		Moxie Percent: +30, Weapon Damage: +20, Maximum MP: +20, Monster Level: -20, Spooky Damage: +10, Sleaze Resistance: +1, Last Available: "2023-12"
 11453	greasy vibrating Elf Guard SCUBA tank	0		Maximum MP Percent: +10, Sleaze Spell Damage: +10, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	gravedigger's wholesome free boots	0		Maximum HP Percent: +10, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	gravedigger's wholesome free boots	0		Maximum HP Percent: +10, Spooky Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	twirling baby rigging snake	0		Last Available: "2023-12"
 11457	upside-down double-paned fortified Fonzie's Elvish underarmor	0		Experience (Moxie): +1, Damage Absorption: +60, Cold Resistance: +5, Single Equip, Last Available: "2023-12"
 11458	steel-toed Crimbuccaneer bombjacket of the pedagogue	0		Experience: +3, Damage Reduction: 9, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	thick spoiled shaking sugarplum ration	5	crappy	Last Available: "2023-12"
-11460	decent massive lime green gingerbread nylons	10	good	Last Available: "2023-12"
-11461	decent miniature rum-soaked fruitcake	2	good	Last Available: "2023-12"
-11462	normal fancy lime	4	good	Effect: "Yuletide Mutations", Effect Duration: 35, Last Available: "2023-12"
+11459	spoiled thick shaking sugarplum ration	5	crappy	Last Available: "2023-12"
+11460	massive decent lime green gingerbread nylons	10	good	Last Available: "2023-12"
+11461	miniature decent rum-soaked fruitcake	2	good	Last Available: "2023-12"
+11462	fancy normal lime	4	good	Effect: "Yuletide Mutations", Effect Duration: 35, Last Available: "2023-12"
 11463	adequate gingerbread pirate	4	good	Last Available: "2023-12"
 11464	bland gigantic fruit-stuffed rumcake	7	decent	Last Available: "2023-12"
 11465	hand-crafted mulled wine	3	EPIC	Last Available: "2023-12"
 11466	acceptable Swedish coffee	4	good	Last Available: "2023-12"
-11467	irresponsibly strong mediocre twirling canteen of eggnog	7	decent	Last Available: "2023-12"
-11468	watered-down bad hot wine	2	decent	Last Available: "2023-12"
-11469	tolerable distilled wobbly spinning Jamaican coffee	5	good	Last Available: "2023-12"
-11470	practically non-alcoholic delicious wobbly flask of egggrog	1	awesome	Last Available: "2023-12"
+11467	mediocre irresponsibly strong twirling canteen of eggnog	7	decent	Last Available: "2023-12"
+11468	bad watered-down hot wine	2	decent	Last Available: "2023-12"
+11469	distilled tolerable wobbly spinning Jamaican coffee	5	good	Last Available: "2023-12"
+11470	delicious practically non-alcoholic wobbly flask of egggrog	1	awesome	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	olive Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	bouncing pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	strong tolerable yule grog	5	good	Last Available: "2023-12"
-11475	half-sized decent wet tack	2	good	Last Available: "2023-12"
+11475	decent half-sized wet tack	2	good	Last Available: "2023-12"
 11476	stale whalecake	4	decent	Last Available: "2023-12"
-11477	red miser's sinister gunwale whalegun of the cougar	0		Moxie: +20, Spell Damage: +10, Meat Drop: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11477	red miser's sinister gunwale whalegun of the cougar	0		Moxie: +20, Spell Damage: +10, Meat Drop: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	acceptable and claret	3	good	Last Available: "2023-12"
 11479	upside-down blinking rigging knot	0		Familiar Weight: +5
 11480	gray trick coin	0		Last Available: "2023-12"
-11481	foul-smelling frosty Elf Guard squirtgun	0		Cold Spell Damage: +10, Stench Damage: +10, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	foul-smelling frosty Elf Guard squirtgun	0		Cold Spell Damage: +10, Stench Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	narrow chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	Jim Carey's sequin-encrusted sweater	0		Monster Level: +25, Last Available: "2023-12"
 11484	wobbly spinning studded razor-sharp replica Elf Guard medal of the detective	0		Weapon Damage Percent: +25, Damage Absorption: +80, Item Drop: +20, Last Available: "2023-12"
@@ -11354,15 +11354,15 @@
 11499	narrow Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11500	olive The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	ghostly Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11502	vacuum-sealed polymerized wobbly narrow red military candy cane	0		Effect: "Well-Oiled", Effect Duration: 55
+11502	vacuum-sealed polymerized wobbly red narrow military candy cane	0		Effect: "Well-Oiled", Effect Duration: 55
 11503	extra-galvanized groggipop	0		Effect: "Simulation Stimulation", Effect Duration: 40
-11504	red moss mace of the scaredy-cat of the businessman	0		Monster Level: -15, Meat Drop: +50, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	manspreader's wicked moss megaphone	0		Spell Damage: +5, Monster Level: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	shaking Jack Frost's moss medal of Leguizamo	0		Monster Level: +20, Cold Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	upside-down manspreader's clever moss mitre	0		Maximum MP: +20, Monster Level: +10, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	fuchsia fireproof boxer's moss mantle	0		Muscle Percent: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	red moss mace of the scaredy-cat of the businessman	0		Monster Level: -15, Meat Drop: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	manspreader's wicked moss megaphone	0		Spell Damage: +5, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	shaking Jack Frost's moss medal of Leguizamo	0		Monster Level: +20, Cold Spell Damage: +50, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	upside-down manspreader's clever moss mitre	0		Maximum MP: +20, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	fuchsia fireproof boxer's moss mantle	0		Muscle Percent: +10, Hot Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	moss marlinspike of the empath of the sweet-tooth	0		Familiar Weight: +5, Candy Drop: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	denatured cyan blurry moss mulch	1		Effect: "Lubed", Effect Duration: 35, Last Available: "2024-12"
+11510	denatured blurry cyan moss mulch	1		Effect: "Lubed", Effect Duration: 35, Last Available: "2024-12"
 11511	polymerized adjusted moss floss	0		Effect: "Highland Sheen", Effect Duration: 42
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	red adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11371,41 +11371,41 @@
 11516	adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	huge adobe abaya	0		Last Available: "2024-12"
 11518	dehydrated adobe assortment	1		Last Available: "2024-12"
-11519	non-enhanced cyan jittery adobe brittle	0		Effect: "Cranberry Cordiality", Effect Duration: 25
-11520	maroon shaking Fonzie's crepe paper phrygian cap of the wise owl of extreme caution	0		Mysticality: +20, Experience (Moxie): +1, Monster Level: -25, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11519	non-enhanced jittery cyan adobe brittle	0		Effect: "Cranberry Cordiality", Effect Duration: 25
+11520	maroon shaking Fonzie's crepe paper phrygian cap of the wise owl of extreme caution	0		Mysticality: +20, Experience (Moxie): +1, Monster Level: -25, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	frosty veiny healthy crepe paper parachute cape	0		Maximum HP Percent: +20, Maximum HP: +10, Cold Spell Damage: +10, Last Available: "2025-12"
-11522	twirling hardened arcane researcher's crepe paper pie clip of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Damage Reduction: 3, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	narrow Van der Graaf energetic banded crepe paper puzzle cube	0		Damage Absorption: +100, Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	forbidden groovy crepe paper plunge camisole of horror	0		Moxie Percent: +10, Spell Damage Percent: +50, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	blinking lightning-fast inspector's cool crepe paper polka charm	0		Moxie: +5, Item Drop: +15, Initiative: +40, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
-11526	pickled red blurry crepe paper pared cuttings	1		Last Available: "2025-12"
+11522	twirling hardened arcane researcher's crepe paper pie clip of the cougar	0		Moxie: +20, Experience Percent (Mysticality): +10, Damage Reduction: 3, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	narrow Van der Graaf energetic banded crepe paper puzzle cube	0		Damage Absorption: +100, Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	forbidden groovy crepe paper plunge camisole of horror	0		Moxie Percent: +10, Spell Damage Percent: +50, Spooky Spell Damage: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	blinking lightning-fast inspector's cool crepe paper polka charm	0		Moxie: +5, Item Drop: +15, Initiative: +40, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11526	pickled blurry red crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	alkaline crepe paper peanut candy	0		Effect: "Down With Chow", Effect Duration: 47
 11528	purple blurry stanky chilly petrified wood war pike	0		Cold Damage: +5, Stench Spell Damage: +25, Last Available: "2025-12"
 11529	electrified energetic petrified wood waist protector	0		Maximum MP Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2025-12"
-11530	double-paned grievous petrified wood wizard's pouch	0		Weapon Damage Percent: +50, Cold Resistance: +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	chilly petrified wood water purifier of the bloodbag	0		Maximum HP: +100, Cold Damage: +5, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	double-paned grievous petrified wood wizard's pouch	0		Weapon Damage Percent: +50, Cold Resistance: +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	chilly petrified wood water purifier of the bloodbag	0		Maximum HP: +100, Cold Damage: +5, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	foul-smelling studded petrified wood whoopie panama	0		Damage Absorption: +80, Stench Damage: +10, Last Available: "2025-12"
 11533	narrow auspicious frosty petrified wood walking pants	0		Cold Spell Damage: +10, Item Drop: +10, Last Available: "2025-12"
 11534	dried petrified wood waste parts	1		Last Available: "2025-12"
 11535	galvanized triple-moist maroon jittery petrified wood wafer praline	0		Effect: "Disco Concentration", Effect Duration: 44
 11536	drinkable watered-down enchanted bouncing cybeer	2	good	Effect: "Pemmican't", Effect Duration: 35, Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	shaking wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	shaking wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
 11541	tumbling googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	Jeselnik's beefcake's Crimbuccaneer war standard	0		Muscle: +25, Sleaze Damage: +25, Last Available: "2023-12"
 11544	zippy Oprah's Elf Guard war standard	0		Maximum MP Percent: +50, Initiative: +20, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	miser's clever supercool spring shoes	0		Moxie Percent: +20, Maximum MP: +20, Meat Drop: +10, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	miser's clever supercool spring shoes	0		Moxie Percent: +20, Maximum MP: +20, Meat Drop: +10, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	pressed ultra-soft ferns	0		Effect: "Izchak's Blessing", Effect Duration: 25, Last Available: "2024-02"
 11548	ionized alkaline deionized skewed crunchy brush	0		Effect: "Sweet Taste", Effect Duration: 14, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
-11552	skewed spinning blurry high-tension exoskeleton	0		
-11553	jittery huge ultra-high-tension exoskeleton	0		
+11552	blurry spinning skewed high-tension exoskeleton	0		
+11553	huge jittery ultra-high-tension exoskeleton	0		
 11554	irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
@@ -11439,7 +11439,7 @@
 11584	up-at-dawn hale grievous furry yam buckler	0		Weapon Damage Percent: +50, Maximum HP: +20, Adventures: +5, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	rosewater-soaked Annie Oakley's yamtility belt of Leguizamo	0		Critical Hit Percent: +20, Monster Level: +20, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2024-05"
-11587	rotten half-sized yam slider	2	crappy	Last Available: "2024-05"
+11587	half-sized rotten yam slider	2	crappy	Last Available: "2024-05"
 11588	toothsome bite-sized yam mayo	1	awesome	Last Available: "2024-05"
 11589	big stale yam burrito	5	decent	Last Available: "2024-05"
 11590	cyan visual packet sniffer	0		Last Available: "2025-12"
@@ -11461,18 +11461,18 @@
 11606	mirror mini kiwi icepick of the pedagogue	0		Experience: +3
 11607	chilled extra-polarized mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Human-Plant Hybrid", Effect Duration: 33
 11608	mirror packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	teal protogenetic chunklet (synapse)	0		
 11611	olive protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
 11613	protogenetic chunklet (elbow)	0		
-11614	squat blinking protogenetic chunklet (lips)	0		
+11614	blinking squat protogenetic chunklet (lips)	0		
 11615	frightening messenger bag RNA of vim and vigor of the scaredy-cat	0		Maximum HP Percent: +50, Monster Level: -15, Spooky Damage: +5
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	spoiled jumbo bacteria bisque	5	crappy	
 11619	bland ciliophora chowder	4	decent	
-11620	moldy blinking narrow cream of chloroplasts	4	crappy	
+11620	moldy narrow blinking cream of chloroplasts	4	crappy	
 11621	synaptic soup	0		
 11622	muscular soup	0		
 11623	upside-down spinning flagellate soup	0		
@@ -11490,7 +11490,7 @@
 11635	watered-down mediocre Colera Peste Nebbiolo	2	decent	
 11636	longbox of Batfellow comics	0		
 11637	shaking Thwaitgold shield bug statuette	0		
-11638	red shaking bodyguard badge	0		
+11638	shaking red bodyguard badge	0		
 11639	olive Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
 11641	boxed Sept-Ember Censer	0		Free Pull, Last Available: "2024-09"
@@ -11510,8 +11510,8 @@
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	wobbly boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	clever wholesome dangerous bat wings	0		Weapon Damage: +10, Maximum HP Percent: +10, Maximum MP: +20, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
-11659	spinning huge ember egg	0		Last Available: "2024-09"
+11658	clever wholesome dangerous bat wings	0		Weapon Damage: +10, Maximum HP Percent: +10, Maximum MP: +20, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11659	huge spinning ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	spinning chilly monocle on a stick of chilblains	0		Cold Damage: 30, Lasts Until Rollover, Last Available: "2024-10"
 11662	stiffened fortified plastic pipe	0		Damage Absorption: +60, Damage Reduction: 1, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	stiffened Sheriff badge of Flo-Jo	0		Damage Reduction: 1, Initiative: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	perfumed rosewater-soaked Sheriff pistol	0		Stench Resistance: 8, Lasts Until Rollover, Last Available: "2024-10"
 11670	extremely unsafe Sinatra's Sheriff moustache	0		Experience (Moxie): +5, Weapon Damage Percent: +100, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	dance instructor's photo booth supply list of the wise owl	0		Mysticality: +20, Experience Percent (Moxie): +10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	dance instructor's photo booth supply list of the wise owl	0		Mysticality: +20, Experience Percent (Moxie): +10, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	jittery peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	delicious blinking ghostly whirled peas	3	awesome	Last Available: "2024-11"
@@ -11541,7 +11541,7 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	green TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	olive hardy forbidden deft pirate hook	0		Spell Damage Percent: +50, Maximum HP: +50, Lasts Until Rollover, Last Available: "2024-12"
-11689	energetic arcane researcher's iron tricorn hat	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	energetic arcane researcher's iron tricorn hat	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	mirror jolly roger flag of the blizzard	0		Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	Tesla electrified wicked potato jacket	0		Spell Damage: +5, MP Regen Min: 10, MP Regen Max: 15, Last Available: "2024-12"
 11729	mirror traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Van der Graaf occult military orb	0		Spell Damage Percent: +25, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	Van der Graaf occult military orb	0		Spell Damage Percent: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	energized ghostly rum ball	0		Effect: "Billiards Belligerence", Effect Duration: 32
 11733	gravy skin	0		Last Available: "2024-12"
 11734	deadly gravyskin hat of the early riser	0		Weapon Damage: +5, Adventures: +7, Last Available: "2024-12"
@@ -11595,55 +11595,55 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ghostly ragged wool yarn	0		Last Available: "2024-12"
 11742	scandalous perfect Christmas scarf of the wise owl of mayonnaise	0		Mysticality: [+20*event(December)], Sleaze Damage: [+5*event(December)], Sleaze Spell Damage: [+50*event(December)], Single Equip, Last Available: "2024-12"
-11743	frightening rosy-cheeked snowman-enchanting tophat	0		Maximum HP Percent: +30, Spooky Damage: +5, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	frightening rosy-cheeked snowman-enchanting tophat	0		Maximum HP Percent: +30, Spooky Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	quadruple-aerosolized LIDAR candle	0		Effect: "Petit Forbearance", Effect Duration: 37, Last Available: "2024-12"
 11745	sinister experienced Congressional Medal of Insanity of courage	0		Experience: +2, Spell Damage: +10, Spooky Resistance: +3, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
 11747	perfectly mixed weak shaking Easter grasshopper	2	EPIC	Last Available: "2024-12"
 11748	weak perfectly mixed Irish eggnog	2	EPIC	Last Available: "2024-12"
 11749	acceptable canteen of jungle juice	3	good	Last Available: "2024-12"
-11750	perfectly mixed weak turchucken	2	EPIC	Last Available: "2024-12"
+11750	weak perfectly mixed turchucken	2	EPIC	Last Available: "2024-12"
 11751	delicious mechanically-mulled cider	3	awesome	Last Available: "2024-12"
 11752	perfectly mixed cyan holiday trip around the world	3	super ultra EPIC	Last Available: "2024-12"
 11753	adequate chocolate ostrich egg	4	good	Last Available: "2024-12"
 11754	flavorless beef and cabbage	3	decent	Last Available: "2024-12"
 11755	huge toothsome candy rations	8	awesome	Last Available: "2024-12"
 11756	moldy blurry double-candied yams	3	crappy	Last Available: "2024-12"
-11757	small flavorless Christmas ham	2	decent	Last Available: "2024-12"
+11757	flavorless small Christmas ham	2	decent	Last Available: "2024-12"
 11758	decent holiday smorgasbord	4	good	Last Available: "2024-12"
 11759	olive Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bouncing upside-down padded bejazzled eyepatch	0		Damage Absorption: +20, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	spinning Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	yellow How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	pulsating How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	jittery Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	blurry Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	spinning Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	yellow How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	pulsating How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	jittery Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	blurry Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	Sherlock's lion tamer's sinister egg gun of the overflowing toilet	0		Spell Damage: +10, Experience (familiar): +2, Stench Spell Damage: +50, Item Drop: +25, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	Sherlock's lion tamer's sinister egg gun of the overflowing toilet	0		Spell Damage: +10, Experience (familiar): +2, Stench Spell Damage: +50, Item Drop: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	sizzling energetic hardened Fonzie's army helmet	0		Experience (Moxie): +1, Damage Reduction: 3, Maximum MP Percent: +20, Hot Damage: +10, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	purple napkin	0		Last Available: "2024-12"
 11776	adequate Thanksgiving ration	3	good	Last Available: "2024-12"
-11777	weak fancy hand-crafted Easter eggnog	2	super ultra mega turbo EPIC	Effect: "Heart of White", Effect Duration: 10, Last Available: "2024-12"
+11777	fancy hand-crafted weak Easter eggnog	2	super ultra mega turbo EPIC	Effect: "Heart of White", Effect Duration: 10, Last Available: "2024-12"
 11778	distilled ghostly clovermint	1		Effect: "Employee of the Month", Effect Duration: 50, Last Available: "2024-12"
 11779	knitted smartaleck's nylon Christmas stockings of the scaredy-cat	0		Moxie Percent: +30, Monster Level: -15, Cold Resistance: +3, Item Drop: +5, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	triple-enhanced green deviled candy egg	0		Effect: "Meatwise", Effect Duration: 32, Last Available: "2024-12"
 11782	pulsating tumbling lime green McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	blinking chaotic McHugeLarge duffel bag of the detective	0		Spell Critical Percent: +10, Item Drop: +20, Last Available: "2025-01"
-11784	horrifying mansplainer's savvy McHugeLarge left pole	0		Mysticality Percent: +20, Monster Level: +15, Spooky Damage: +25, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	flame-retardant flame-wreathed Da Vinci's McHugeLarge right pole	0		Experience (Mysticality): +5, Hot Spell Damage: +10, Hot Resistance: +1, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	lard-coated McHugeLarge left ski of mayonnaise	0		Sleaze Spell Damage: 75, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	personal trainer's McHugeLarge right ski of incineration	0		Experience Percent (Muscle): +10, Hot Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
-11788	bouncing spinning 1	0		Last Available: "2025-12"
+11784	horrifying mansplainer's savvy McHugeLarge left pole	0		Mysticality Percent: +20, Monster Level: +15, Spooky Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	flame-retardant flame-wreathed Da Vinci's McHugeLarge right pole	0		Experience (Mysticality): +5, Hot Spell Damage: +10, Hot Resistance: +1, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	lard-coated McHugeLarge left ski of mayonnaise	0		Sleaze Spell Damage: 75, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	personal trainer's McHugeLarge right ski of incineration	0		Experience Percent (Muscle): +10, Hot Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11788	spinning bouncing 1	0		Last Available: "2025-12"
 11789	gray 0	0		Last Available: "2025-12"
 11790	altered twirling eXpand	1		Effect: "Third Based", Effect Duration: 15, Last Available: "2025-12"
-11791	maroon brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	maroon brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,14 +11658,14 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	pulsating retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	jittery server room key	0		Last Available: "2025-12"
 11809	twirling 3d printed server room key	0		Last Available: "2025-12"
 11810	dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	olive logic grenade	0		Last Available: "2025-12"
 11812	compressed psilocyber mushroom	1		Last Available: "2025-12"
-11813	upside-down blinking dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
+11813	blinking upside-down dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
@@ -11675,11 +11675,11 @@
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	pulsating OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
-11823	twirling mirror STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
+11823	mirror twirling STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	blue hashing vise	0		Last Available: "2025-12"
-11827	spinning geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	spinning geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11716,7 +11716,7 @@
 11861	fuchsia Leprecondo	0		Last Available: "2025-03"
 11862	twisted bouncing scoop of pre-workout powder	1		Effect: "Burning Tongue", Effect Duration: 35, Last Available: "2025-03"
 11863	twirling table tennis ball	0		Last Available: "2025-03"
-11864	acceptable watered-down pint of Leprechaun Stout	2	good	Last Available: "2025-03"
+11864	watered-down acceptable pint of Leprechaun Stout	2	good	Last Available: "2025-03"
 11865	dehydrated tumbling phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11725,12 +11725,12 @@
 11870	lime green bar dart	0		Last Available: "2025-03"
 11871	denatured ghostly leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	moldy Heck ramen	4	crappy	Last Available: "2025-03"
-11873	miniature moldy maroon burrito	2	crappy	Last Available: "2025-03"
-11874	adequate jumbo teal small beer brat	5	good	Last Available: "2025-03"
+11873	moldy miniature maroon burrito	2	crappy	Last Available: "2025-03"
+11874	jumbo adequate teal small beer brat	5	good	Last Available: "2025-03"
 11875	normal immense peach pie	9	good	Last Available: "2025-03"
 11876	toothsome half-sized incredible mini-pizza	2	awesome	Last Available: "2025-03"
-11877	watered-down hand-crafted wobbly Divine sidecar	2	EPIC	Last Available: "2025-03"
-11878	artisanal fortified tangarita sidecar	5	EPIC	Last Available: "2025-03"
+11877	hand-crafted watered-down wobbly Divine sidecar	2	EPIC	Last Available: "2025-03"
+11878	fortified artisanal tangarita sidecar	5	EPIC	Last Available: "2025-03"
 11879	bad gimlet sidecar	3	decent	Last Available: "2025-03"
 11880	acceptable vodka stratocaster sidecar	3	good	Last Available: "2025-03"
 11881	weak mediocre prussian cathouse sidecar	2	decent	Last Available: "2025-03"
@@ -11749,7 +11749,7 @@
 11894	mirror wet shower shorts of the ox	0		Muscle: +20, Last Available: "2025-04"
 11895	wet paper tiger	0		Last Available: "2025-04"
 11896	olive wet paper eye	0		Familiar Weight: +15
-11897	tumbling ghostly wet shower curtain	0		Last Available: "2025-04"
+11897	ghostly tumbling wet shower curtain	0		Last Available: "2025-04"
 11898	non-alkaline wet paper cup	0		Effect: "Squid Squint", Effect Duration: 23, Last Available: "2025-04"
 11899	deionized wet paperback	0		Effect: "Crud&eacute;", Effect Duration: 12, Last Available: "2025-04"
 11900	groovy wet shower radio	0		Moxie Percent: +10, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
@@ -11769,9 +11769,9 @@
 11914	pulsating electrified imposing pilgrim's hat	0		MP Regen Min: 3, MP Regen Max: 5
 11915	blinking crown of thorns	0		
 11916	supercharged stylish bycocket	0		Maximum MP Percent: +30
-11917	blurry olive Thwaitgold mad hatterpillar statuette	0		
+11917	olive blurry Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	blinking huge flak shield	0		Damage Reduction: 9
 11921	jittery Axis HQ Code	0		
 11922	skewed shaking yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,8 +11789,8 @@
 11934	orphaned baby skeleton	0		
 11935	narrow ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	enchanted diet adequate Skeleton Wars rations	1	good	Effect: "Tightly-Wound Spine", Effect Duration: 40
-11938	weak mediocre skeleton war fuel can	2	decent	
+11937	enchanted adequate diet Skeleton Wars rations	1	good	Effect: "Tightly-Wound Spine", Effect Duration: 40
+11938	mediocre weak skeleton war fuel can	2	decent	
 11939	skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11807,35 +11807,35 @@
 11952	diluted green pulsating mixed berry jelly	1		Last Available: "2025-08"
 11953	flavorless toast with mixed berry jelly	3	decent	Last Available: "2025-08"
 11954	small tasty pulsating yellow cup of sugar	2	awesome	Last Available: "2025-08"
-11955	rotten fancy Susie's cupcake	3	crappy	Effect: "Appeteyes", Effect Duration: 45, Last Available: "2025-08"
+11955	fancy rotten Susie's cupcake	3	crappy	Effect: "Appeteyes", Effect Duration: 45, Last Available: "2025-08"
 11956	ghostly clock	0		Last Available: "2025-08"
 11957	flame-retardant medical-grade the gun of bravery	0		Hot Resistance: +1, Spooky Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-08"
 11958	lousy wine	4	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
-11961	bouncing gray sand penny	0		
+11961	gray bouncing sand penny	0		
 11962	healthy undersea surveying goggles	0		Maximum HP Percent: +20, Lasts Until Rollover
 11963	weak mediocre Ocean-Touched Rum	2	decent	
 11964	mixed water-logged pill	1		Effect: "Destructive Resolve", Effect Duration: 5
-11965	huge flavorless kelp puck	9	decent	
+11965	flavorless huge kelp puck	9	decent	
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
-11968	squat yellow scroll of sea smarm	0		
+11968	yellow squat scroll of sea smarm	0		
 11969	waterlogged scroll of healing	0		
 11970	pulsating sea gel	0		
 11971	boiled octopus ink bladder	0		Effect: "Flagrantly Fragrant", Effect Duration: 44
 11972	skewed durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	forbidden dentadent	0		Spell Damage Percent: +50
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	auspicious nasty manspreader's rock-hard groovy brainy blood cubic zirconia	0		Mysticality: +5, Moxie Percent: +10, Damage Reduction: 5, Monster Level: +10, Stench Damage: +5, Item Drop: +10, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	auspicious nasty manspreader's rock-hard groovy brainy blood cubic zirconia	0		Mysticality: +5, Moxie Percent: +10, Damage Reduction: 5, Monster Level: +10, Stench Damage: +5, Item Drop: +10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	pickled blood thinner	1		Last Available: "2025-10"
 12045	mediocre pheromone cocktail	4	decent	Last Available: "2025-10"
 12046	toothsome teal spinal tapas	4	awesome	Last Available: "2025-10"
 12047	wobbly blue shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	Jeselnik's Oprah's shrunken head of the detective	0		Maximum MP Percent: +50, Sleaze Damage: +25, Item Drop: +20, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	Jeselnik's Oprah's shrunken head of the detective	0		Maximum MP Percent: +50, Sleaze Damage: +25, Item Drop: +20, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	shaking stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	fuchsia small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
@@ -11845,7 +11845,7 @@
 12055	spoiled big huge full-sized pumpkin pie	5	crappy	Last Available: "2025-11"
 12056	acceptable irresponsibly strong vodka cranberry sauce	10	good	Last Available: "2025-11"
 12057	aerosolized yammed candy	0		Effect: "The Magic of Sharing", Effect Duration: 32, Last Available: "2025-11"
-12058	snack-sized normal treasure chestnut	2	good	Last Available: "2025-12"
+12058	normal snack-sized treasure chestnut	2	good	Last Available: "2025-12"
 12059	hand-crafted blue mulled butter rum	3	EPIC	Last Available: "2025-12"
 12060	double-concentrated super-improved ionized ghostly cinnamon doubloon	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 52, Last Available: "2025-12"
 12061	rosewater-soaked plastic left skeleton arm	0		Stench Resistance: +3, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	enhanced boiled frozen bouncing boiling synovial fluid	0		Effect: "Army of One", Effect Duration: 36, Last Available: "2025-12"
 12132	greasy careful educational smoldering vertebra	0		Experience: +1, Monster Level: -10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2025-12"
 12133	huge seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	red smoldering bone dust	0		Last Available: "2025-12"
-12136	twirling blurry volatile bone bomb	0		Last Available: "2025-12"
+12136	blurry twirling volatile bone bomb	0		Last Available: "2025-12"
 12137	crafty hot boning knife of Tarzan of mayonnaise	0		Experience (Muscle): +3, Maximum MP: +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2025-12"
 12138	tumbling scandalous frightening stanky fistbone	0		Stench Spell Damage: +25, Spooky Damage: +5, Sleaze Damage: +5, Last Available: "2025-12"
 12139	mirror prompt baleful burnt bone belt of mayonnaise	0		Spell Damage: +25, Sleaze Spell Damage: +50, Adventures: +3, Single Equip, Last Available: "2025-12"
 12140	squat Da Vinci's scorched skull trophy	0		Experience (Mysticality): +5, Last Available: "2025-12"
-12141	miniature toothsome wing bone	2	awesome	Last Available: "2025-12"
+12141	toothsome miniature wing bone	2	awesome	Last Available: "2025-12"
 12142	smooth distilled weak skeleton venom	5	awesome	Last Available: "2025-12"
 12143	twisted blurry baked bone meal	1		Last Available: "2025-12"
 12144	manspreader's plastic skeleton rib cage	0		Monster Level: +10, Last Available: "2025-12"
@@ -11929,14 +11929,14 @@
 12171	rotten snack-sized traditional gingerloaf	2	crappy	Last Available: "2025-12"
 12172	delicious watered-down green Scotch and eggnog	2	awesome	Last Available: "2025-12"
 12173	quadruple-modified counterskeleton elixir	0		Effect: "Shoesauce", Effect Duration: 38, Last Available: "2025-12"
-12174	boozy hand-crafted huge &quot;salvaged&quot; wine	5	EPIC	Last Available: "2025-12"
+12174	hand-crafted boozy huge &quot;salvaged&quot; wine	5	EPIC	Last Available: "2025-12"
 12175	squat The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
-12177	miniature yummy wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
+12177	yummy miniature wedge of prize-winning cheese	2	awesome	Last Available: "2025-12"
 12178	double-quantum narrow gummi fingerbone	0		Effect: "Healthy Red Glow", Effect Duration: 15
 12179	avaricious rosy-cheeked glimmering crystal	0		Maximum HP Percent: +30, Meat Drop: +30, Last Available: "2025-12"
 12180	squat boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	skewed ghostly loose Meats	0		
 12184	ghostly Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11959,12 +11959,12 @@
 12201	dangerous dinosaur bone club	0		Weapon Damage: +10, Last Available: "2026-03"
 12202	spinning extremely unsafe dinosaur skull helmet of courage	0		Weapon Damage Percent: +100, Spooky Resistance: +3, Last Available: "2026-03"
 12203	blinking shaking nasty veiny arcane researcher's dinosaur bone corset	0		Experience Percent (Mysticality): +10, Maximum HP: +10, Stench Damage: +5, Last Available: "2026-03"
-12204	fortified bad skewed Pork Elf cough syrup	5	decent	Last Available: "2026-03"
+12204	bad fortified skewed Pork Elf cough syrup	5	decent	Last Available: "2026-03"
 12205	Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	red Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	half-sized normal skewed rat pizza	2	good	Last Available: "2026-03"
+12209	normal half-sized skewed rat pizza	2	good	Last Available: "2026-03"
 12210	maroon Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	vibrating dance instructor's hoverboard of the bloodbag	0		Experience Percent (Moxie): +10, Maximum HP: +100, Maximum MP Percent: +10, Single Equip, Last Available: "2026-03"
 12212	miser's supercharged experienced left shark fin	0		Experience: +2, Maximum MP Percent: +30, Meat Drop: +10, Last Available: "2026-03"
@@ -11977,23 +11977,23 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	stale thick pulsating olive can of tuna	5	decent	
+12226	thick stale pulsating olive can of tuna	5	decent	
 12227	small yummy shaking alien salad	2	awesome	
 12228	normal huge tumbling ratbatatouille	8	good	
-12229	super-sized moldy purple onigiri	5	crappy	
+12229	moldy super-sized purple onigiri	5	crappy	
 12230	adequate jumbo crudit&eacute;s	5	good	
-12231	bland bite-sized sauced mutton	1	decent	
-12232	snack-sized stale hot honey ant	2	decent	
-12233	fancy big rotten tomb aspic	5	crappy	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 15
+12231	bite-sized bland sauced mutton	1	decent	
+12232	stale snack-sized hot honey ant	2	decent	
+12233	rotten big fancy tomb aspic	5	crappy	Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 15
 12234	enchanted stale later tots	4	decent	Effect: "Extra-Wet", Effect Duration: 45
-12235	toothsome tiny jittery Frutti di Scatoletta	1	awesome	Last Available: "2026-05"
+12235	tiny toothsome jittery Frutti di Scatoletta	1	awesome	Last Available: "2026-05"
 12236	rotten Pesto alla Marziano	3	crappy	Last Available: "2026-05"
 12237	stale jumbo Arrattabbattabiata	5	decent	Last Available: "2026-05"
-12238	diet normal gray jittery Orzo di Riso	1	good	Last Available: "2026-05"
+12238	normal diet jittery gray Orzo di Riso	1	good	Last Available: "2026-05"
 12239	tasty half-sized blinking Pasta Grimavera	2	awesome	Last Available: "2026-05"
-12240	thick bland Linguini Ubriacapa	5	decent	Last Available: "2026-05"
+12240	bland thick Linguini Ubriacapa	5	decent	Last Available: "2026-05"
 12241	half-sized tasty Formica e Pepe	2	awesome	Last Available: "2026-05"
-12242	flavorless ghostly wobbly Tubetto Gelatto	3	decent	Last Available: "2026-05"
+12242	flavorless wobbly ghostly Tubetto Gelatto	3	decent	Last Available: "2026-05"
 12243	bland Gnocci Domani	3	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	mirror scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12008,7 +12008,7 @@
 12258	teal shrink-wrapped Cup of 13s	0		Free Pull, Last Available: "2026-07"
 12259	Cup of 13s	0		Booze Drop: +60, MP Regen Min: 4, MP Regen Max: 8, HP Regen Min: 8, HP Regen Max: 13, Last Available: "2026-07"
 12260	maroon studded Fonzie's thinker's The Wizard's Android	0		Mysticality: +10, Experience (Moxie): +1, Damage Absorption: +80
-12261	maroon twirling flash paperwad	0		
+12261	twirling maroon flash paperwad	0		
 12262	juggling ball	0		
 12263	foul-smelling Lo Pan's tactical jester's cap	0		Spell Critical Percent: +30, Stench Damage: +10, Combat Item Damage Percent: 50
 12264	single-use sword	0		
@@ -12017,24 +12017,24 @@
 12267	Rosewater's flimsy plastic breastplate	0		Mysticality Percent: +30
 12268	personal trainer's flimsy plastic shield	0		Experience Percent (Muscle): +10, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	up-at-dawn Tesla thinker's Portable Laughing Stock	0		Mysticality: +10, Adventures: +5, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	up-at-dawn Tesla thinker's Portable Laughing Stock	0		Mysticality: +10, Adventures: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	wobbly family-friendly asbestos-lined forbidden Staff of Anachronistic Churning	0		Spell Damage Percent: +50, Hot Resistance: +5, Sleaze Resistance: +1
 12272	normal blinking classic banana	3	good	Last Available: "2026-07"
-12273	massive normal watermelon	7	good	Last Available: "2026-07"
+12273	normal massive watermelon	7	good	Last Available: "2026-07"
 12274	stale quince	4	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	squat Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	tasty diet classic banana pie	1	awesome	Last Available: "2026-07"
 12278	polarized shaking essential banana decoction	0		Effect: "Radiated and Grodiated", Effect Duration: 49, Last Available: "2026-07"
 12279	adjusted alkaline banana quintessence	0		Effect: "Rosewater Mark", Effect Duration: 22, Last Available: "2026-07"
-12280	aged watered-down tumbling Aesop Daiquiri	2	awesome	Last Available: "2026-07"
+12280	watered-down aged tumbling Aesop Daiquiri	2	awesome	Last Available: "2026-07"
 12281	acceptable watered-down Monkey Congress	2	good	Last Available: "2026-07"
 12282	toothsome watermelon pie	3	awesome	Last Available: "2026-07"
 12283	nitrogenated frozen lime green spinning concentrated watermelon juice	0		Effect: "Fangs and Pangs", Effect Duration: 38, Last Available: "2026-07"
 12284	double-anodized Aqua Citrulanatae	0		Effect: "Fungal Fortification", Effect Duration: 31, Last Available: "2026-07"
 12285	mediocre practically non-alcoholic blinking Melonegroni	1	decent	Last Available: "2026-07"
 12286	hand-crafted Melonade Spritz	3	EPIC	Last Available: "2026-07"
-12287	stale half-sized narrow quince pie	2	decent	Last Available: "2026-07"
+12287	half-sized stale narrow quince pie	2	decent	Last Available: "2026-07"
 12288	liquefied chilled narrow quince quaff	0		Effect: "Spiritually Awake", Effect Duration: 18, Last Available: "2026-07"
 12289	tarnished magnetized twirling Quickquince	0		Effect: "Ichorous Intensity", Effect Duration: 18, Last Available: "2026-07"
 12290	lousy Quiskey Sour	3	decent	Last Available: "2026-07"
@@ -12052,7 +12052,7 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	horrifying 401k ring of courage	0		Spooky Damage: +25, Spooky Resistance: +3, Last Available: "2026-08"
 12304	skewed balance sheet	0		Last Available: "2026-08"
-12305	double-quantum pressed lime green twirling ghostly narrow invisible hand	0		Effect: "Spooky Hands", Effect Duration: 52, Last Available: "2026-08"
+12305	double-quantum pressed twirling ghostly lime green narrow invisible hand	0		Effect: "Spooky Hands", Effect Duration: 52, Last Available: "2026-08"
 12306	ionized moist dry circle of overdraft protection scroll	0		Effect: "Frigid Weapon", Effect Duration: 36, Last Available: "2026-08"
 12307	alkaline energized mint	0		Effect: "Gyromitra Gymnastics", Effect Duration: 67, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Turtle_Tamer_Blender_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Blender_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	smooth high-proof Petite Porter	8	awesome	
--2	practically non-alcoholic mediocre Scrawny Stout	1	decent	
+-1	high-proof smooth Petite Porter	8	awesome	
+-2	mediocre practically non-alcoholic Scrawny Stout	1	decent	
 -3	weak tolerable blinking Infinitesimal IPA	2	good	
 -4	perfectly mixed eggnogtini	3	EPIC	
 -5	aged watered-down candycaine	2	awesome	
 -6	delicious olive braincracker sweet	3	awesome	
--16	hand-crafted fortified fermented honey	5	EPIC	
+-16	fortified hand-crafted fermented honey	5	EPIC	
 -17	artisanal pulsating moons-shine	4	EPIC	
--18	bad distilled gin	5	decent	
--19	triple-distilled smooth pulsating bouncing ecto-nog	10	awesome	
+-18	distilled bad gin	5	decent	
+-19	smooth triple-distilled pulsating bouncing ecto-nog	10	awesome	
 -20	delicious watered-down hot toady	2	awesome	
--21	weak drinkable hot choculate	2	good	
--49	fortified acceptable blinking tumbling Cyder	5	good	
--50	irresponsibly strong perfectly mixed Oil Nog	6	EPIC	
--51	practically non-alcoholic perfectly mixed Hi-Octane Peppermint Jet Fuel	1	EPIC	
+-21	drinkable weak hot choculate	2	good	
+-49	fortified acceptable tumbling blinking Cyder	5	good	
+-50	perfectly mixed irresponsibly strong Oil Nog	6	EPIC	
+-51	perfectly mixed practically non-alcoholic Hi-Octane Peppermint Jet Fuel	1	EPIC	
 -58	artisanal Grimacider	4	EPIC	
 -59	bad Isotope Nog	3	decent	
--60	watered-down lousy squat Mutagin 'n' Tonic	2	decent	
+-60	lousy watered-down squat Mutagin 'n' Tonic	2	decent	
 -70	acceptable watered-down Gin and Herring	2	good	
--71	aged fancy irresponsibly strong Black and Tan and Red All Over	8	awesome	
+-71	irresponsibly strong aged fancy Black and Tan and Red All Over	8	awesome	
 -72	artisanal upside-down Antarctic Ice Tea	3	EPIC	
--76	delicious fortified CRIMBCO Ribbon Candy Schnapps	5	awesome	
+-76	fortified delicious CRIMBCO Ribbon Candy Schnapps	5	awesome	
 -77	bad CRIMBCO Egg Substitute Nog Substitute	3	decent	
--78	artisanal fortified CRIMBCO Extreme Braincracker Sour	5	EPIC	
+-78	fortified artisanal CRIMBCO Extreme Braincracker Sour	5	EPIC	
 -82	lousy Horseradish-infused Vodka	3	decent	
 -83	hand-crafted Jerkitini	4	EPIC	
 -84	aged Desert Island Iced Tea	4	awesome	
--88	watered-down acceptable Crimbo Saketini	2	good	
--89	acceptable watered-down Crimboku Drop	2	good	
+-88	acceptable watered-down Crimbo Saketini	2	good	
+-89	watered-down acceptable Crimboku Drop	2	good	
 -90	artisanal watered-down Flaming Crimbo Log	2	EPIC	
 -107	artisanal Fortified Eggnog Slurry	4	EPIC	
 -108	delicious squat Hot Buttered Rum	4	awesome	
--109	bad practically non-alcoholic Spicy Hot Chocolate	1	decent	
+-109	practically non-alcoholic bad Spicy Hot Chocolate	1	decent	

--- a/data/TCRS/TCRS_Turtle_Tamer_Blender_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Blender_cafe_food.txt
@@ -1,19 +1,19 @@
 -1	gigantic adequate Peche a la Frog	8	good	
 -2	moldy diet As Jus Gezund Heit	1	crappy	
--3	flavorless snack-sized fancy blinking Bouillabaise Coucher Avec Moi	2	decent	
+-3	snack-sized fancy flavorless blinking Bouillabaise Coucher Avec Moi	2	decent	
 -7	rotten blue gumdrop chow mein	3	crappy	
 -8	rotten half-sized candy cane pizza	2	crappy	
--9	miniature moldy gingerbread stir-fry	2	crappy	
+-9	moldy miniature gingerbread stir-fry	2	crappy	
 -10	rotten twigs and gravel	3	crappy	
 -11	bland snack-sized shoots and leaves	2	decent	
 -12	spoiled bowl of unidentifiable goo	3	crappy	
 -13	spoiled gingerbread massacre	3	crappy	
--14	super-sized flavorless It Came From Beyond Dessert	5	decent	
+-14	flavorless super-sized It Came From Beyond Dessert	5	decent	
 -15	moldy diet vampire cake	1	crappy	
 -52	big spoiled purple Soylent Red and Green	5	crappy	
 -53	low-calorie spoiled Disc-Shaped Nutrition Unit	1	crappy	
 -54	moldy Gingerborg Hive	3	crappy	
--61	spoiled fancy skewed Candy Cane Surprise	3	crappy	
+-61	fancy spoiled skewed Candy Cane Surprise	3	crappy	
 -62	rotten twirling Grimdrop Chow Mein	3	crappy	
 -63	tasty Grimgerbread House	4	awesome	
 -67	delicious Caviar Carbonara	4	awesome	
@@ -23,20 +23,20 @@
 -74	immense rotten pulsating New and Improved CRIMBCO Reconstituted Gruel	7	crappy	
 -75	normal mirror CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	good	
 -79	bland Brussels Sprout Stir-Fry	3	decent	
--80	tiny bland Carrot, Cabbage, and Kale Pizza	1	decent	
--81	moldy huge tumbling Turnip and Rutabaga Pie	7	crappy	
--85	snack-sized normal Rainbow Spider Fun Roll	2	good	
+-80	bland tiny Carrot, Cabbage, and Kale Pizza	1	decent	
+-81	huge moldy tumbling Turnip and Rutabaga Pie	7	crappy	
+-85	normal snack-sized Rainbow Spider Fun Roll	2	good	
 -86	yummy jittery Vegas Volcano Lava Roll	3	awesome	
--87	decent low-calorie spinning tumbling Crazy Dragon Shogun Buddha Roll	1	good	
--92	stale thick basic hot dog	5	decent	
+-87	low-calorie decent spinning tumbling Crazy Dragon Shogun Buddha Roll	1	good	
+-92	thick stale basic hot dog	5	decent	
 -93	adequate savage macho dog	3	good	
 -94	moldy one with everything	4	crappy	
--95	tasty half-sized sly dog	2	awesome	
+-95	half-sized tasty sly dog	2	awesome	
 -96	miniature moldy ghostly devil dog	2	crappy	
--97	decent half-sized spinning chilly dog	2	good	
+-97	half-sized decent spinning chilly dog	2	good	
 -98	adequate ghost dog	3	good	
--99	decent gigantic junkyard dog	10	good	
--100	delicious half-sized wet dog	2	awesome	
+-99	gigantic decent junkyard dog	10	good	
+-100	half-sized delicious wet dog	2	awesome	
 -101	moldy twirling sleeping dog	3	crappy	
 -102	stale enchanted optimal dog	4	decent	
 -103	moldy video games hot dog	3	crappy	

--- a/data/TCRS/TCRS_Turtle_Tamer_Marmot.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Marmot.txt
@@ -12,8 +12,8 @@
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
 14	dehydrated moxie weed	1		
 15	twisted strongness elixir	1		
-16	twisted jittery tumbling magicalness-in-a-can	1		
-17	low-calorie bland noodles	1	decent	
+16	twisted tumbling jittery magicalness-in-a-can	1		
+17	bland low-calorie noodles	1	decent	
 18	tortoise's blessing	0		
 19	forbidden asparagus knife	0		Spell Damage Percent: +50
 20	huge Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -36,8 +36,8 @@
 37	smooth viking helmet	0		Moxie: +15, Familiar Effect: "atk, cap 5"
 38	weightlifter's Knob Goblin pants	0		Muscle: +15, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
-40	squat wobbly skewed casino pass	0		
-41	smooth watered-down fancy ice-cold Sir Schlitz	2	awesome	Effect: "Ruthlessly Efficient", Effect Duration: 15
+40	squat skewed wobbly casino pass	0		
+41	watered-down smooth fancy ice-cold Sir Schlitz	2	awesome	Effect: "Ruthlessly Efficient", Effect Duration: 15
 42	hermit permit	0		
 43	mirror worthless trinket	0		
 44	worthless gewgaw	0		
@@ -65,7 +65,7 @@
 66	twig	0		
 67	jittery spaghetti with rock-balls	0		
 68	avaricious Pasta Spoon of Peril of the cheetah	0		Meat Drop: +30, Initiative: +60, Class: "Pastamancer"
-69	shaking twirling green Newbiesport&trade; tent	0		
+69	green shaking twirling Newbiesport&trade; tent	0		
 70	wobbly bar skin	0		
 71	executive stakes	0		Meat Drop: +40
 72	barskin hat of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "atk, 1xVolley, cap 13"
@@ -77,7 +77,7 @@
 78	Jim Carey's pretty bouquet	0		Monster Level: +25
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	fairy gravy boat	0		
-81	watered-down fancy mediocre ice-cold Willer	2	decent	Effect: "Livin' Large", Effect Duration: 15
+81	mediocre fancy watered-down ice-cold Willer	2	decent	Effect: "Livin' Large", Effect Duration: 15
 82	huge ring	0		
 83	shaft	0		
 84	pulsating Orcish meat locker	0		
@@ -95,7 +95,7 @@
 96	double-paned dope gangsta bling-bling	0		Cold Resistance: +5
 97	energetic pimpin' meat hat of the brazier	0		Maximum MP Percent: +20, Hot Spell Damage: +25, Familiar Effect: "sleaze atk, 1xVolley, cap 13"
 98	huge dried face	0		
-99	tumbling olive meat face	0		
+99	olive tumbling meat face	0		
 100	lifeless meat doll	0		
 101	meat golem	0		
 102	shrunken head	0		
@@ -114,7 +114,7 @@
 115	cyan lightning-fast dripping meat crossbow	0		Initiative: +40
 116	censurious extremely unsafe Bugfinder Blade	0		Weapon Damage Percent: +100, Sleaze Resistance: +3
 117	Gnollish plunger	0		
-118	squat tumbling spring	0		
+118	tumbling squat spring	0		
 119	bouncing sprocket	0		
 120	squat cog	0		
 121	wobbly sprocket assembly	0		
@@ -157,7 +157,7 @@
 158	blue wobbly Gnollish pie tin	0		
 159	wad of dough	0		
 160	squat pie crust	0		
-161	stale enchanted low-calorie ghuol egg	1	decent	Effect: "Larger", Effect Duration: 20
+161	low-calorie stale enchanted ghuol egg	1	decent	Effect: "Larger", Effect Duration: 20
 162	flavorless immense ghuol egg quiche	8	decent	
 163	smartaleck's skeleton bone	0		Moxie Percent: +30
 164	smart skull	0		
@@ -175,10 +175,10 @@
 176	disembodied brain	0		
 177	pulsating brainy skull	0		
 178	detective skull	0		
-179	rotten special chorizo taco	4	crappy	Effect: "Elbow Sauce", Effect Duration: 40
+179	special rotten chorizo taco	4	crappy	Effect: "Elbow Sauce", Effect Duration: 40
 180	tolerable ice-cold fotie	3	good	
 181	narrow baseball	0		
-182	twirling bouncing batgut	0		
+182	bouncing twirling batgut	0		
 183	bat wing	0		
 184	briefcase	0		
 185	fat stacks of cash	0		
@@ -191,27 +191,27 @@
 193	birthday candle	0		
 194	ruddy Mr. Accessory	0		Maximum HP Percent: +40, Softcore Only
 195	smartaleck's eXtreme nose ring	0		Moxie Percent: +30
-196	skewed ghostly ghostly disassembled clover	0		
+196	ghostly ghostly skewed disassembled clover	0		
 197	rat whisker	0		
 198	rat appendix	0		
 199	scandalous ring	0		Sleaze Damage: +5
-200	delicious tiny rat appendix kabob	1	awesome	
+200	tiny delicious rat appendix kabob	1	awesome	
 201	adequate low-calorie pulsating bat wing kabob	1	good	
-202	super-sized moldy carob chunks	5	crappy	
+202	moldy super-sized carob chunks	5	crappy	
 203	herbs	0		
-204	fancy normal carob chunk cookies	4	good	Effect: "Loco Motives", Effect Duration: 5
+204	normal fancy carob chunk cookies	4	good	Effect: "Loco Motives", Effect Duration: 5
 205	spinning secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	good	
 208	huge patchouli incense stick	0		
-209	huge blurry wad of tofu	0		
+209	blurry huge wad of tofu	0		
 210	yellow Feng Shui for Big Dumb Idiots	0		
 211	decorative fountain	0		
 212	twirling windchimes	0		
 213	jittery censurious shellacked filthy corduroys	0		Damage Reduction: 7, Sleaze Resistance: +3, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	Newton's filthy knitted dread sack	0		Experience (Mysticality): +3, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	yummy gigantic carob brownies	9	awesome	
+216	gigantic yummy carob brownies	9	awesome	
 217	normal herb brownies	3	good	
 218	hemp string	0		
 219	squat necklace chain	0		
@@ -237,17 +237,17 @@
 239	tumbling yellow scandalous Orcish baseball cap of the cougar	0		Moxie: +20, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	jittery aromatic sage Orcish cargo shorts	0		Mysticality Percent: +10, Stench Resistance: +1, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	ghostly experienced Orcish frat-paddle	0		Experience: +2
-242	half-sized moldy	2	crappy	
-243	yummy immense grapefruit	9	awesome	
+242	moldy half-sized	2	crappy	
+243	immense yummy grapefruit	9	awesome	
 244	rotten low-calorie grapes	1	crappy	
-245	decent special small cyan olive	2	good	Effect: "Meadulla Oblongota", Effect Duration: 40
-246	super-sized toothsome tomato	5	awesome	
+245	special small decent cyan olive	2	good	Effect: "Meadulla Oblongota", Effect Duration: 40
+246	toothsome super-sized tomato	5	awesome	
 247	fermenting powder	0		
 248	artisanal shaking salty dog	4	EPIC	
 249	practically non-alcoholic artisanal bloody mary	1	EPIC	
-250	tolerable practically non-alcoholic fancy screwdriver	1	good	Effect: "Goldentongue", Effect Duration: 10
+250	fancy practically non-alcoholic tolerable screwdriver	1	good	Effect: "Goldentongue", Effect Duration: 10
 251	bad martini	3	decent	
-252	artisanal practically non-alcoholic squat skewed spinning bloody beer	1	EPIC	
+252	practically non-alcoholic artisanal skewed spinning squat bloody beer	1	EPIC	
 253	perfectly mixed irresponsibly strong shot of schnapps	10	EPIC	
 254	hand-crafted shot of grapefruit schnapps	4	EPIC	
 255	mediocre irresponsibly strong fine wine	6	decent	
@@ -255,13 +255,13 @@
 257	acceptable purple extra-spicy bloody mary	3	good	
 258	dense meat stack	0		
 259	snake skin	0		
-260	special flavorless White Citadel fries	3	decent	Effect: "Hobo Flavor", Effect Duration: 45
-261	rotten tiny blinking White Citadel burger	1	crappy	
+260	flavorless special White Citadel fries	3	decent	Effect: "Hobo Flavor", Effect Duration: 45
+261	tiny rotten blinking White Citadel burger	1	crappy	
 262	adequate red piece of wedding cake	3	good	
 263	spoiled chocolate chips	3	crappy	
 264	delicious chocolate chip cookies	4	awesome	
 265	wobbly flame-retardant satin pants	0		Hot Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
-266	hand-crafted weak lightning	2	EPIC	
+266	weak hand-crafted lightning	2	EPIC	
 267	manspreader's mullet wig	0		Monster Level: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	meat cowboy hat of the detective	0		Item Drop: +20, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	upside-down sage sword	0		Mysticality Percent: +10
@@ -271,7 +271,7 @@
 273	boiled moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mirror mosquito larva	0		
-276	fuchsia bouncing leprechaun hatchling	0		
+276	bouncing fuchsia leprechaun hatchling	0		
 277	vaporized extra-strength strongness elixir	1		
 278	dried narrow jug-o-magicalness	1		
 279	pickled blinking suntan lotion of moxiousness	1		
@@ -310,22 +310,22 @@
 312	cyan ribald Knob Goblin visor	0		Sleaze Damage: +10, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	spinning Crown of the Goblin King of the cougar	0		Moxie: +20, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	flavorless special narrow bean burrito	3	decent	Effect: "Riboflavin'", Effect Duration: 30
-315	fancy diet delicious bean burrito	1	awesome	Effect: "The Moxie of LOV", Effect Duration: 45
+315	diet delicious fancy bean burrito	1	awesome	Effect: "The Moxie of LOV", Effect Duration: 45
 316	spoiled insanely bean burrito	3	crappy	
 317	adequate bean burrito	3	good	
 318	flavorless upside-down bean burrito	4	decent	
 319	rotten spinning insanely bean burrito	4	crappy	
-320	flavorless small bat haggis	2	decent	
-321	miniature special stale menudo	2	decent	Effect: "Analog Drunk", Effect Duration: 5
+320	small flavorless bat haggis	2	decent	
+321	stale miniature special menudo	2	decent	Effect: "Analog Drunk", Effect Duration: 5
 322	stale goat cheese	3	decent	
 323	bland miniature plain pizza	2	decent	
 324	jumbo spoiled blinking sausage pizza	5	crappy	
 325	special flavorless goat cheese pizza	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 35
 326	stale mushroom pizza	3	decent	
 327	goat	0		
-328	high-proof tolerable ghostly bottle of whiskey	10	good	
+328	tolerable high-proof ghostly bottle of whiskey	10	good	
 329	gray avaricious goat beard	0		Meat Drop: +30, Familiar Effect: "atk, 1xPotato, cap 15"
-330	spinning cyan glass of goat's milk	1	awesome	
+330	cyan spinning glass of goat's milk	1	awesome	
 331	delicious tumbling Canadian	3	awesome	
 332	diet stale olive lemon	1	decent	
 333	moldy lime	3	crappy	
@@ -354,14 +354,14 @@
 356	nasty snowboarder pants	0		Stench Damage: +5, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
 358	bland gr8ps	3	decent	
-359	snack-sized stale pulsating t8r tots	2	decent	
+359	stale snack-sized pulsating t8r tots	2	decent	
 360	maroon miner's helmet of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	Annie Oakley's miner's pants	0		Critical Hit Percent: +20, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	gray dance instructor's 7-Foot Dwarven mattock	0		Experience Percent (Moxie): +10
 363	linoleum ore	0		
 364	asbestos ore	0		
 365	huge tumbling chrome ore	0		
-366	ghostly upside-down pulsating linoleum sword hilt	0		
+366	upside-down pulsating ghostly linoleum sword hilt	0		
 367	linoleum stick	0		
 368	linoleum crossbow string	0		
 369	asbestos sword hilt	0		
@@ -414,7 +414,7 @@
 416	Temple Grandin's safarrri hat	0		Familiar Weight: +7, Familiar Effect: "2xVolley, cap 22"
 417	moist ghostly henna tattoo	0		Effect: "Wings of the Grasshopper", Effect Duration: 18
 418	extra-modified denatured Ferrigno's Elixir of Power	0		Effect: "Witch's Brood", Effect Duration: 58
-419	tarnished gray bouncing serum of sarcasm	0		Effect: "You Know What's Up", Effect Duration: 55
+419	tarnished bouncing gray serum of sarcasm	0		Effect: "You Know What's Up", Effect Duration: 55
 420	cold-filtered tomato juice of powerful power	0		Effect: "A Contender", Effect Duration: 50
 421	enhanced philter of phorce	0		Effect: "Salamander In Your Stomach", Effect Duration: 39
 422	moist potion of potency	0		Effect: "Sweet Taste", Effect Duration: 45
@@ -458,7 +458,7 @@
 460	pixel	0		
 461	pixel	0		
 462	pixel	0		
-463	red ghostly pixel	0		
+463	ghostly red pixel	0		
 464	pixel potion	0		
 465	pixel potion	0		
 466	pixel potion	0		
@@ -496,7 +496,7 @@
 498	yummy papaya	3	awesome	
 499	horrifying Temple Grandin's denim axe	0		Familiar Weight: +7, Spooky Damage: +25
 500	spinning Elf Farm Raffle ticket	0		
-501	snack-sized normal Elfin shortbread	2	good	
+501	normal snack-sized Elfin shortbread	2	good	
 502	red pagoda plans	0		
 503	massive stale skewered cat appendix	10	decent	
 504	gray evil arches	0		
@@ -508,8 +508,8 @@
 510	skewed Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	stale enchanted tumbling Boris's key lime pie	4	decent	Effect: "Wet Rub", Effect Duration: 25
-514	huge stale yellow Jarlsberg's key lime pie	8	decent	
+513	enchanted stale tumbling Boris's key lime pie	4	decent	Effect: "Wet Rub", Effect Duration: 25
+514	stale huge yellow Jarlsberg's key lime pie	8	decent	
 515	rotten blue Sneaky Pete's key lime pie	4	crappy	
 516	Hey Deze map	0		
 517	ghostly yellow Rosewater's bejeweled accordion strap	0		Mysticality Percent: +30, Class: "Accordion Thief"
@@ -538,18 +538,18 @@
 540	electrified polarized pulsating spinning Tasty Fun Good rice candy	0		Effect: "Rain Dancin'", Effect Duration: 33
 541	supercharged wicked draggin' ball hat	0		Spell Damage: +5, Maximum MP Percent: +30, Familiar Effect: "atk, 1xVolley, cap 25"
 542	shaking lion tamer's 1337 7r0uZ0RZ of the cougar	0		Moxie: +20, Experience (familiar): +2, Familiar Effect: "2xPotato, cap 27"
-543	bite-sized moldy lime green blurry Trollhouse cookies	1	crappy	
+543	moldy bite-sized lime green blurry Trollhouse cookies	1	crappy	
 544	personal trainer's talons of the pedagogue	0		Experience: +3, Experience Percent (Muscle): +10
-545	miniature moldy mirror Spam Witch sammich	2	crappy	
+545	moldy miniature mirror Spam Witch sammich	2	crappy	
 546	tumbling meat vortex	0		
 547	334 scroll	0		
 548	cyan 668 scroll	0		
 549	30669 scroll	0		
-550	twirling bouncing 33398 scroll	0		
+550	bouncing twirling 33398 scroll	0		
 551	64067 scroll	0		
 552	skewed 64735 scroll	0		
 553	31337 scroll	0		
-554	big bland special pr0n cocktail	5	decent	Effect: "Black Lung", Effect Duration: 20
+554	special bland big pr0n cocktail	5	decent	Effect: "Black Lung", Effect Duration: 20
 555	medical-grade fortified drywall axe	0		Damage Absorption: +60, HP Regen Min: 7, HP Regen Max: 10
 556	steel-toed Pine-Fresh air freshener	0		Damage Reduction: 9
 557	bad whiskey and cola	3	decent	
@@ -569,12 +569,12 @@
 571	Jumbo Dr. Lucifer	1	decent	
 572	adequate Children's Meal of the Damned	3	good	
 573	decent noodles	4	good	
-574	miniature adequate noodles	2	good	
+574	adequate miniature noodles	2	good	
 575	adequate upside-down painful penne pasta	3	good	
 576	moldy ghostly ravioli della hippy	4	crappy	
 577	stale squat pr0n m4nic0tti	4	decent	
 578	yummy fancy Hell ramen	3	awesome	Effect: "Florid Cheeks", Effect Duration: 25
-579	rotten snack-sized gray boring spaghetti	2	crappy	
+579	snack-sized rotten gray boring spaghetti	2	crappy	
 580	red sauce of the ages	0		
 581	yellow schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
@@ -585,12 +585,12 @@
 587	altered activated shaking super-spiky hair gel	0		Effect: "Well-preserved", Effect Duration: 40
 588	blue soft echo eyedrop antidote	0		
 589	bland huge cocoa eggshell fragment	6	decent	
-590	adequate super-sized enchanted cocoa eggshell fragment	5	good	Effect: "Flashing Eyes", Effect Duration: 25
-591	blinking wobbly cocoa egg	0		
+590	enchanted adequate super-sized cocoa eggshell fragment	5	good	Effect: "Flashing Eyes", Effect Duration: 25
+591	wobbly blinking cocoa egg	0		
 592	house	0		
 593	phonics down	0		
 594	spinning dog trainer's amulet of extreme plot significance	0		Experience (familiar): +1
-595	blinking twirling scroll of drastic healing	0		
+595	twirling blinking scroll of drastic healing	0		
 596	maroon titanium assault umbrella of the blizzard	0		Cold Spell Damage: +25
 597	fortified Mohawk wig	0		Damage Absorption: +60, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
 598	the Slug Lord's map	0		
@@ -602,7 +602,7 @@
 604	Penultimate Fantasy chest	0		
 605	narrow Tissue Paper Immateria	0		
 606	skewed Tin Foil Immateria	0		
-607	pulsating jittery Gauze Immateria	0		
+607	jittery pulsating Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
 609	bouncing S.O.C.K.	0		
 610	gray procrastination potion	0		
@@ -613,7 +613,7 @@
 615	chaos butterfly	0		
 616	pulsating furry fur	0		
 617	unsweetened super-pressed ionized Angry Farmer candy	0		Effect: "Bored Stiff", Effect Duration: 65
-618	nitrogenated aerosolized bouncing teal upside-down Mick's IcyVapoHotness Rub	0		Effect: "Chain Chain Chains", Effect Duration: 20
+618	nitrogenated aerosolized teal upside-down bouncing Mick's IcyVapoHotness Rub	0		Effect: "Chain Chain Chains", Effect Duration: 20
 619	needle of the cougar	0		Moxie: +20
 620	chilled jittery thin candle	0		Effect: "Leo Rising", Effect Duration: 30
 621	blue Warm Subject gift certificate	0		
@@ -621,7 +621,7 @@
 623	WA	0		
 624	NG	0		
 625	wang	0		
-626	spinning wobbly Wand of Nagamar	0		
+626	wobbly spinning Wand of Nagamar	0		
 627	narrow ND	0		
 628	metallic A	0		
 629	bouncing Newton's eye	0		Experience (Mysticality): +3
@@ -634,22 +634,22 @@
 636	upside-down twirling meat globe	0		
 637	teal toaster	0		
 638	Van der Graaf strapping asshat	0		Muscle: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	jumbo decent abominable snowcone	5	good	
+639	decent jumbo abominable snowcone	5	good	
 640	Ent cider	1	decent	
 641	spoiled toast	3	crappy	
 642	shaking skeleton key	0		
 643	skeleton key ring	0		
 644	blurry Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	small decent fruitcake	2	good	
+646	decent small fruitcake	2	good	
 647	present	0		Last Available: "2004-11"
 648	spinning Crimbo sword of the brazier	0		Hot Spell Damage: +25, Last Available: "2004-10"
-649	Crimbo hat of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	blurry upside-down green smelly Crimbo pants	0		Stench Spell Damage: +10, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	Crimbo hat of horror	0		Spooky Spell Damage: +25, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	blurry upside-down green smelly Crimbo pants	0		Stench Spell Damage: +10, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	groovy exclusive ultra-rare item	0		Moxie Percent: +10
 652	quantum egg	0		
 653	intragalactic rowboat	0		
-654	red skewed star	0		
+654	skewed red star	0		
 655	pulsating skewed cyan line	0		
 656	gray star chart	0		
 657	teal mirror padded star sword	0		Damage Absorption: +20
@@ -658,7 +658,7 @@
 660	Samson's star pants	0		Experience (Muscle): +5, Familiar Effect: "1xPotato, 2xGhuol, cap 41"
 661	upside-down scorching star hat	0		Hot Damage: +25, Familiar Effect: "0.5xVolley, 0.5xPotato, cap 41"
 662	twirling lard-coated star buckler	0		Sleaze Spell Damage: +25, Damage Reduction: 10
-663	squat ghostly star throwing star	0		
+663	ghostly squat star throwing star	0		
 664	star starfish	0		
 665	Richard's star key	0		
 666	greasy scandalous grievous steaming evil	0		Weapon Damage Percent: +50, Sleaze Damage: +5, Sleaze Spell Damage: +10
@@ -679,7 +679,7 @@
 681	weak artisanal slip 'n' slide	2	EPIC	
 682	lousy irresponsibly strong ghostly a sump'm sump'm	9	decent	
 683	hand-crafted horizontal tango	4	EPIC	
-684	lousy watered-down fuchsia pulsating pink pony	2	decent	
+684	watered-down lousy fuchsia pulsating pink pony	2	decent	
 685	lard-coated Oprah's groovy Mr. Shirt	0		Moxie Percent: +10, Maximum MP Percent: +50, Sleaze Spell Damage: +25
 686	olive pulsating sharpshooter's knuckles	0		Critical Hit Percent: +10
 687	magnetized Vulcanized squat blood of the Wereseal	0		Effect: "Bread Burps", Effect Duration: 51
@@ -703,7 +703,7 @@
 706	mirror teal porquoise	0		
 707	pulsating pork elf goodies sack	0		
 708	ring setting	0		
-709	shaking huge yellow jewelry-making pliers	0		
+709	yellow huge shaking jewelry-making pliers	0		
 711	quilted educational hamethyst earring	0		Experience: +1, Damage Absorption: +40
 712	pulsating clever studded strapping hamethyst necklace	0		Muscle: +5, Damage Absorption: +80, Maximum MP: +20, Single Equip
 713	Jeselnik's scorching hamethyst bracelet	0		Hot Damage: +25, Sleaze Damage: +25, Single Equip
@@ -716,7 +716,7 @@
 720	squat supercool beefy porquoise necklace	0		Muscle: +10, Moxie Percent: +20, Single Equip
 721	ruddy porquoise bracelet of the cheetah	0		Maximum HP Percent: +40, Initiative: +60
 722	red wobbly Sinatra's porquoise ring of terror of temperance	0		Experience (Moxie): +5, Spooky Spell Damage: +10, Sleaze Resistance: +5, Single Equip
-723	miniature adequate huge cyan Knoll mushroom	2	good	
+723	adequate miniature cyan huge Knoll mushroom	2	good	
 724	bland gigantic mushroom	9	decent	
 725	pulsating one million meat pancakes	0		
 726	tumbling veiny huge mirror shard	0		Maximum HP: +10
@@ -736,17 +736,17 @@
 740	skewed crafty tambourine	0		Maximum MP: +10
 741	pulsating broken skull	0		
 742	decent half-sized Knoll shroomkabob	2	good	
-743	half-sized tasty mushroom	2	awesome	
+743	tasty half-sized mushroom	2	awesome	
 744	moist hair spray	0		Effect: "Speed of the Internet", Effect Duration: 21
 746	blinking shaking stat script	0		
 747	yellow Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	adequate warm mushroom	3	good	
-750	moldy special huge mushroom quesadilla	3	crappy	Effect: "Employee of the Month", Effect Duration: 40
+750	special moldy huge mushroom quesadilla	3	crappy	Effect: "Employee of the Month", Effect Duration: 40
 751	adequate cool mushroom	4	good	
 752	bland cool mushroom casserole	3	decent	
 753	spoiled mirror pointy mushroom	4	crappy	
-754	diet tasty huge cream of pointy mushroom soup	1	awesome	
+754	tasty diet huge cream of pointy mushroom soup	1	awesome	
 755	stale shaking mushroom	3	decent	
 756	rotten twirling mushroom	4	crappy	
 757	flavorless blurry mushroom	4	decent	
@@ -791,8 +791,8 @@
 796	chaotic forbidden Fonzie's cement shoes	0		Experience (Moxie): +1, Spell Damage Percent: +50, Spell Critical Percent: +10, Last Available: "2004-10"
 797	practically non-alcoholic artisanal rockin' wagon	1	super ultra mega turbo EPIC	
 798	mediocre ocean motion	3	decent	
-799	lousy extra-dry fuzzbump	5	decent	
-800	tasty miniature olive tumbling poutine	2	awesome	
+799	extra-dry lousy fuzzbump	5	decent	
+800	miniature tasty olive tumbling poutine	2	awesome	
 801	flavorless diet mirror Knob stir-fry	1	decent	
 804	spoiled Knoll stir-fry	4	crappy	
 805	spoiled stir-fry	4	crappy	
@@ -800,14 +800,14 @@
 807	adequate spinning olive stir-fry	4	good	
 808	yummy Knob sausage stir-fry	3	awesome	
 809	decent bat wing stir-fry	3	good	
-810	flavorless jumbo rat appendix stir-fry	5	decent	
+810	jumbo flavorless rat appendix stir-fry	5	decent	
 811	delicious tofu stir-fry	3	awesome	
 812	yummy red pr0n stir-fry	3	awesome	
 813	jumbo spoiled Knob shells	5	crappy	
 814	delicious snack-sized b&auml;tzle	2	awesome	
 815	decent twirling ratini	3	good	
-816	normal jumbo Knob stroganoff	5	good	
-817	small normal menudo ravioli	2	good	
+816	jumbo normal Knob stroganoff	5	good	
+817	normal small menudo ravioli	2	good	
 818	skewed plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
@@ -817,7 +817,7 @@
 824	effervescent potion	0		
 825	fizzy potion	0		
 826	dark potion	0		
-827	squat blue murky potion	0		
+827	blue squat murky potion	0		
 828	upside-down baby killer bee	0		
 829	blue anti-anti-antidote	0		
 830	rotten royal jelly	3	crappy	
@@ -831,10 +831,10 @@
 838	shaking horrifying crafty Mafia stogie	0		Maximum MP: +10, Spooky Damage: +25, Last Available: "2004-10"
 839	artisanal Maiali Sifilitici Pinot Noir	4	EPIC	Last Available: "2004-10"
 840	stanky chilly Mafia violin case	0		Cold Damage: +5, Stench Spell Damage: +25, Last Available: "2004-10"
-841	practically non-alcoholic aged spinning tomato daiquiri	1	awesome	
-842	hand-crafted mirror ghostly beertini	3	EPIC	
-843	weak hand-crafted green salty slug	2	EPIC	
-844	drinkable special papaya slung	4	good	Effect: "Sated and Furious", Effect Duration: 30
+841	aged practically non-alcoholic spinning tomato daiquiri	1	awesome	
+842	hand-crafted ghostly mirror beertini	3	EPIC	
+843	hand-crafted weak green salty slug	2	EPIC	
+844	special drinkable papaya slung	4	good	Effect: "Sated and Furious", Effect Duration: 30
 845	padded MAHI fez	0		Damage Absorption: +20, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	pulsating hypodermic needle	0		Familiar Weight: +5
@@ -862,12 +862,12 @@
 871	squat meatcar model	0		Familiar Weight: +5
 872	gray Time Juice	0		Last Available: "2004-01"
 873	rolling pin	0		
-874	wobbly gray unrolling pin	0		
+874	gray wobbly unrolling pin	0		
 875	fireproof quilted extremely unsafe crazy bastard sword	0		Weapon Damage Percent: +100, Damage Absorption: +40, Hot Resistance: +3
 876	veiny incredibly dense meat gem of the bloodbag of terror	0		Maximum HP: 110, Spooky Spell Damage: +10
 877	thinker's Talisman of Baio	0		Mysticality: +10
 878	educational hypnodisk	0		Experience: +1
-879	activated quadruple-galvanized pulsating bouncing bottle of goofballs	0		Effect: "So You Can Work More...", Effect Duration: 25
+879	activated quadruple-galvanized bouncing pulsating bottle of goofballs	0		Effect: "So You Can Work More...", Effect Duration: 25
 880	shaking lard-coated disbelief suspenders	0		Sleaze Spell Damage: +25
 881	avaricious supportive bra	0		Meat Drop: +30
 882	Blatantly Canadian	0		
@@ -881,7 +881,7 @@
 890	decent balaclava baklava	3	good	
 891	blurry olive wool Warehouse 23 bling	0		Cold Resistance: +1
 892	purple toasty bugbear-smiting sword of the businessman of the cheetah	0		Hot Damage: +5, Meat Drop: +50, Initiative: +60
-893	fancy bad triple-distilled lumbering jack	8	decent	Effect: "Papowerful", Effect Duration: 40
+893	triple-distilled bad fancy lumbering jack	8	decent	Effect: "Papowerful", Effect Duration: 40
 894	narrow Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	upside-down Sherlock's Ms. Accessory	0		Item Drop: +25, Softcore Only
 896	huge MacGyver's rosy-cheeked Mr. Accessory Jr.	0		Maximum HP Percent: +30, Maximum MP: +100, Softcore Only
@@ -891,37 +891,37 @@
 900	mirror smile-sharpening stone	0		Familiar Weight: +5
 901	upside-down espresso maker	0		Familiar Weight: +5
 902	squat 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	mediocre special Spasmi Dolorosi Del Rene Champagne	4	decent	Effect: "Liquidy Smoky", Effect Duration: 20, Last Available: "2004-10"
-904	bouncing lard-coated Van der Graaf sage school Mafia knickerbockers	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+903	special mediocre Spasmi Dolorosi Del Rene Champagne	4	decent	Effect: "Liquidy Smoky", Effect Duration: 20, Last Available: "2004-10"
+904	bouncing lard-coated Van der Graaf sage school Mafia knickerbockers	0		Mysticality Percent: +10, Sleaze Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	quantum diffused spinning Yummy Tummy bean	0		Effect: "Hot Buttoned", Effect Duration: 42
 906	denatured jittery teal Rock Pops	0		Effect: "Wintry Breath", Effect Duration: 46
 907	electrified Mr. Mediocrebar	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 61
 908	modified Cold Hots candy	0		Effect: "Human-Human Hybrid", Effect Duration: 53
 909	polymerized unsweetened jittery Wint-O-Fresh mint	0		Effect: "Black Lung", Effect Duration: 16
-910	rotten bite-sized maroon dwarf bread	1	crappy	
+910	bite-sized rotten maroon dwarf bread	1	crappy	
 911	wet Senior Mints	0		Effect: "Sludgesick", Effect Duration: 57
 912	galvanized olive pixellated candy heart	0		Effect: "Heart of Lavender", Effect Duration: 12
 913	pickled blinking kobold	0		Effect: "Meatwise", Effect Duration: 22
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	wobbly yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	blurry greedy baleful intergalactic pom poms	0		Spell Damage: +25, Meat Drop: +20
-917	shaking wobbly Mob Penguin protection contract	0		
-918	Radio Free Baseball Cap of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	blinking careful Radio Free Pants	0		Monster Level: -10, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+917	wobbly shaking Mob Penguin protection contract	0		
+918	Radio Free Baseball Cap of incineration	0		Hot Spell Damage: +50, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	blinking careful Radio Free Pants	0		Monster Level: -10, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	Radio Free Foil of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-07"
 921	flavorless radio button candy	3	decent	
 922	thinker's severed rocking horse head	0		Mysticality: +10
 923	jittery broken cellular phone	0		Last Available: "2004-01"
-924	squat pulsating crimbo elfling	0		Free Pull, Last Available: "2011-12"
+924	pulsating squat crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	chilled triple-cold-filtered Hawking's Elixir of Brilliance	0		Effect: "Top Dog", Effect Duration: 67
-927	delicious enchanted squat Ferita Del Petto Zinfandel	4	awesome	Effect: "Aquarius Rising", Effect Duration: 10, Last Available: "2006-12"
+927	enchanted delicious squat Ferita Del Petto Zinfandel	4	awesome	Effect: "Aquarius Rising", Effect Duration: 10, Last Available: "2006-12"
 928	lime green fuzzy bracelets of the brute	0		Muscle Percent: +30
 929	prompt arse-shooting crossbow	0		Adventures: +3
-931	enchanted drinkable high-proof tumbling spiced rum	7	good	Effect: "Lubed", Effect Duration: 20
-932	mediocre practically non-alcoholic eggnog	1	decent	
+931	high-proof enchanted drinkable tumbling spiced rum	7	good	Effect: "Lubed", Effect Duration: 20
+932	practically non-alcoholic mediocre eggnog	1	decent	
 933	bland yellow candy cane	4	decent	
-934	fancy stale snack-sized gingerbread bugbear	2	decent	Effect: "Overstimulated", Effect Duration: 10
+934	stale snack-sized fancy gingerbread bugbear	2	decent	Effect: "Overstimulated", Effect Duration: 10
 935	twirling flame-wreathed imitation nice watch	0		Hot Spell Damage: +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -929,23 +929,23 @@
 939	pulsating small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	jittery Crimbo stocking	0		Last Available: "2004-12"
-942	reassuring bowler	0		Spooky Resistance: +1, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	reassuring bowler	0		Spooky Resistance: +1, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	fortified baleful bow staff	0		Spell Damage: +25, Damage Absorption: +60, Last Available: "2004-12"
-944	yellow supercool bowlegged pants	0		Moxie Percent: +20, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	yellow supercool bowlegged pants	0		Moxie Percent: +20, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	bad martini	4	decent	Last Available: "2004-12"
-949	lousy irresponsibly strong fancy grogtini	10	decent	Effect: "Pronounced Potency", Effect Duration: 50, Last Available: "2004-12"
-950	smooth special cherry bomb	4	awesome	Effect: "Corona de la Salsa", Effect Duration: 20, Last Available: "2004-12"
+949	irresponsibly strong lousy fancy grogtini	10	decent	Effect: "Pronounced Potency", Effect Duration: 50, Last Available: "2004-12"
+950	special smooth cherry bomb	4	awesome	Effect: "Corona de la Salsa", Effect Duration: 20, Last Available: "2004-12"
 951	skewed extra special Crimbo stocking	0		Last Available: "2004-12"
 952	blinking stanky hockey mask	0		Stench Spell Damage: +25, Item Drop: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	fez of etymology of the glutton	0		Food Drop: +100, Familiar Effect: "1xLep, cap 30"
-956	rotten gigantic carob chunk noodles	9	crappy	
+956	gigantic rotten carob chunk noodles	9	crappy	
 957	snack-sized stale chorizo brownies	2	decent	
-958	tasty small chocolate and tomato pizza	2	awesome	
+958	small tasty chocolate and tomato pizza	2	awesome	
 959	shaking flange	0		
 960	clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -988,18 +988,18 @@
 1000	Meat maid	0		
 1002	wobbly huge Fonzie's Xlyinia's notebook	0		Experience (Moxie): +1
 1003	wobbly soda water	0		
-1004	irresponsibly strong mediocre bottle of tequila	9	decent	
+1004	mediocre irresponsibly strong bottle of tequila	9	decent	
 1005	bad strong boxed wine	5	decent	
 1006	spoiled cherry	3	crappy	
 1007	yellow ghostly arcane researcher's coconut shell	0		Experience Percent (Mysticality): +10, Familiar Effect: "1xFairy, cap 7"
 1008	nippy ice cubes	0		Cold Damage: +10
 1009	lousy vodka martini	3	decent	
-1010	practically non-alcoholic perfectly mixed blue jittery whiskey and soda	1	EPIC	
+1010	perfectly mixed practically non-alcoholic jittery blue whiskey and soda	1	EPIC	
 1011	acceptable teal monkey wrench	3	good	
 1012	enchanted hand-crafted mirror tequila sunrise	3	EPIC	Effect: "Standard Issue Bravery", Effect Duration: 25
 1013	lousy watered-down fancy green margarita	2	decent	Effect: "Material Witness", Effect Duration: 40
 1014	perfectly mixed fancy mirror strawberry wine	3	EPIC	Effect: "Ancient Protected", Effect Duration: 45
-1015	enchanted bad wine spritzer	4	decent	Effect: "Mental A-cue-ity", Effect Duration: 40
+1015	bad enchanted wine spritzer	4	decent	Effect: "Mental A-cue-ity", Effect Duration: 40
 1016	lousy perpendicular hula	4	decent	
 1017	delicious ducha de oro	3	awesome	
 1018	artisanal calle de miel	4	EPIC	
@@ -1008,7 +1008,7 @@
 1021	drinkable blinking tequila with training wheels	3	good	
 1022	tolerable fancy sangria	4	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 10
 1023	acceptable vesper	4	good	Last Available: "2004-12"
-1024	artisanal triple-distilled blue bodyslam	6	EPIC	Last Available: "2004-12"
+1024	triple-distilled artisanal blue bodyslam	6	EPIC	Last Available: "2004-12"
 1025	enchanted tolerable pulsating sangria del diablo	3	good	Effect: "Busy Bein' Delicious", Effect Duration: 35, Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	whip kit	0		
@@ -1029,7 +1029,7 @@
 1043	gray groovy string of beads	0		Moxie Percent: +10
 1044	frightening string of beads	0		Spooky Damage: +5
 1045	plastic bottle opener of dire peril	0		Weapon Damage: +20
-1046	narrow scandalous energetic traffic cone	0		Maximum MP Percent: +20, Sleaze Damage: +5, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	narrow scandalous energetic traffic cone	0		Maximum MP Percent: +20, Sleaze Damage: +5, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	mediocre N. O. Beer	3	decent	
 1048	pickled pulsating oyster egg	1		
 1049	powdered tumbling oyster egg	1		
@@ -1043,21 +1043,21 @@
 1057	vaporized lime green puce oyster egg	1		Effect: "The Wisdom... of the Future", Effect Duration: 5
 1058	dried blinking puce oyster egg	1		
 1059	puce plastic oyster egg	0		
-1060	distilled pulsating skewed mauve oyster egg	1		
+1060	distilled skewed pulsating mauve oyster egg	1		
 1061	dried mauve oyster egg	1		
 1062	dehydrated upside-down mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
 1064	twisted oyster egg	1		
-1065	mixed pulsating maroon oyster egg	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 20
+1065	mixed maroon pulsating oyster egg	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 20
 1066	powdered bouncing oyster egg	1		
 1067	plastic oyster egg	0		
-1068	powdered olive spinning oyster egg	1		
+1068	powdered spinning olive oyster egg	1		
 1069	dehydrated shaking oyster egg	1		Effect: "Good Karma", Effect Duration: 5
 1070	compressed oyster egg	1		
 1071	plastic oyster egg	0		
 1072	mixed teal off-white oyster egg	1		
 1073	modified off-white oyster egg	1		
-1074	twisted red jittery skewed off-white oyster egg	1		
+1074	twisted red skewed jittery off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	distilled huge oyster egg	1		
 1077	modified oyster egg	1		
@@ -1072,14 +1072,14 @@
 1086	clockwork thingamajig	0		
 1087	yellow clockwork doohickey	0		
 1088	clockwork clockwise dome	0		
-1089	jittery twirling clockwork spine	0		
+1089	twirling jittery clockwork spine	0		
 1090	fuchsia clockwork rings	0		
 1091	olive clockwork claws	0		
 1092	clockwork sheet	0		
 1093	skewed clockwork counterclockwise dome	0		
 1094	clockwork sphere	0		
 1095	purple deactivated MicroMechaMech	0		
-1096	upside-down yellow clockwork endoskeleton	0		
+1096	yellow upside-down clockwork endoskeleton	0		
 1097	shellacked clockwork hat	0		Damage Reduction: 7, Familiar Effect: "atk, 1xVolley, cap 20"
 1098	cool clockwork trench coat	0		Moxie: +5
 1099	lard-coated clockwork pants	0		Sleaze Spell Damage: +25, Familiar Effect: "3xPotato, 1.5xGhuol, cap 20"
@@ -1122,17 +1122,17 @@
 1136	Vulcanized mirror lipstick	0		Effect: "Cringle's Curative Carol", Effect Duration: 62
 1137	spinning chilly bicycle chain of chilblains	0		Cold Damage: 30
 1138	ghostly mushroom fermenting solution	0		
-1139	watered-down mediocre mushroom wine	2	decent	
-1140	aged distilled upside-down icy mushroom wine	5	awesome	
+1139	mediocre watered-down mushroom wine	2	decent	
+1140	distilled aged upside-down icy mushroom wine	5	awesome	
 1141	drinkable mushroom wine	3	good	
-1142	high-proof tolerable twirling pointy mushroom wine	8	good	
-1143	high-proof perfectly mixed flat mushroom wine	9	EPIC	
+1142	tolerable high-proof twirling pointy mushroom wine	8	good	
+1143	perfectly mixed high-proof flat mushroom wine	9	EPIC	
 1144	mediocre cool mushroom wine	4	decent	
 1145	weak artisanal knob mushroom wine	2	EPIC	
 1146	practically non-alcoholic drinkable knoll mushroom wine	1	good	
 1147	watered-down artisanal mushroom wine	2	EPIC	
-1148	delicious watered-down shot of flower schnapps	2	awesome	
-1149	normal low-calorie flower petal pie	1	good	
+1148	watered-down delicious shot of flower schnapps	2	awesome	
+1149	low-calorie normal flower petal pie	1	good	
 1150	delicious bottle of single-barrel whiskey	3	awesome	
 1151	dog trainer's MacGyver's discarded plastic fork	0		Maximum MP: +100, Experience (familiar): +1
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1158,7 +1158,7 @@
 1173	linoleum box	0		
 1174	chrome box	0		
 1175	cryptic puzzle box	0		
-1176	yellow ghostly refrigerated biohazard container	0		
+1176	ghostly yellow refrigerated biohazard container	0		
 1177	upside-down magnetic field	0		
 1178	potted cactus	0		
 1179	daisy	0		
@@ -1190,7 +1190,7 @@
 1205	decent babycakes	4	good	
 1206	moldy squat velvet cake	3	crappy	
 1207	flavorless squat congratulatory cake	4	decent	
-1208	rotten miniature angel-food cake	2	crappy	
+1208	miniature rotten angel-food cake	2	crappy	
 1209	fancy stale devil's-food cake	3	decent	Effect: "[800]Chocolate Reign", Effect Duration: 35
 1210	bland birthday party jellybean cheesecake	3	decent	
 1211	balloon	0		
@@ -1233,14 +1233,14 @@
 1249	maroon Van der Graaf Boss Bat britches	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	smartaleck's beefy Boss Bat bling	0		Muscle: +10, Moxie Percent: +30
 1251	flavorless Knob shroomkabob	3	decent	
-1252	low-calorie stale shroomkabob	1	decent	
-1253	shaking narrow pile of jumping beans	0		
+1252	stale low-calorie shroomkabob	1	decent	
+1253	narrow shaking pile of jumping beans	0		
 1254	adequate snack-sized mirror jumping bean burrito	2	good	
-1255	stale miniature mirror jumping bean burrito	2	decent	
+1255	miniature stale mirror jumping bean burrito	2	decent	
 1256	flavorless bite-sized insanely jumping bean burrito	1	decent	
-1257	thick moldy rat scrapple	5	crappy	
+1257	moldy thick rat scrapple	5	crappy	
 1258	pail of pretentious paint	0		
-1259	Da Vinci's traffic cone of the cheetah	0		Experience (Mysticality): +5, Initiative: +60, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	Da Vinci's traffic cone of the cheetah	0		Experience (Mysticality): +5, Initiative: +60, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	squat wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	modified narrow Hatorade	1		
 1262	Oprah's off-hand balloon of Leguizamo of Flo-Jo	0		Maximum MP Percent: +50, Monster Level: +20, Initiative: +100
@@ -1257,7 +1257,7 @@
 1273	knitted magic lamp	0		Cold Resistance: +3
 1274	twisted red Medicinal Herb's medicinal herbs	1		
 1275	bouncing basic meat skirt of doom	0		Spooky Spell Damage: +50, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	weak mediocre skewed Otorian Battle Scar	2	decent	
+1276	mediocre weak skewed Otorian Battle Scar	2	decent	
 1277	upside-down basic meat kilt of the businessman	0		Meat Drop: +50, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	foul-smelling meat skirt	0		Stench Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	Oprah's meat kilt	0		Maximum MP Percent: +50, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	wicked deadly traffic cone	0		Weapon Damage: +5, Spell Damage: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	wicked deadly traffic cone	0		Weapon Damage: +5, Spell Damage: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	miniature decent questionable taco	2	good	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	flame-retardant time helmet	0		Hot Resistance: +1, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	spinning tumbling up-at-dawn time trousers	0		Adventures: +5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	flame-retardant time helmet	0		Hot Resistance: +1, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	spinning tumbling up-at-dawn time trousers	0		Adventures: +5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	ghostly time sword of Tarzan	0		Experience (Muscle): +3, Last Available: "2005-10"
 1326	studded Dyspepsi-Cola helmet	0		Damage Absorption: +80, Familiar Effect: "3xFairy, cap 7"
 1327	ghostly wobbly ribald Cloaca-Cola shield	0		Sleaze Damage: +10, Damage Reduction: 4
@@ -1346,8 +1346,8 @@
 1363	clockwork pirate skull	0		
 1364	pulsating rhesus monkey	0		Familiar Weight: +5
 1365	stale snack-sized tofurkey leg	2	decent	
-1366	super-sized bland tofurkey gravy	5	decent	
-1367	fancy decent herbal stuffing	3	good	Effect: "Patent Avarice", Effect Duration: 5
+1366	bland super-sized tofurkey gravy	5	decent	
+1367	decent fancy herbal stuffing	3	good	Effect: "Patent Avarice", Effect Duration: 5
 1368	bite-sized normal upside-down huge can-shaped gelatinous cranberry sauce	1	good	
 1369	delicious blinking yams	4	awesome	
 1370	upside-down frosty rhinestone cowboy shirt	0		Cold Spell Damage: +10
@@ -1374,7 +1374,7 @@
 1392	kite	0		Last Available: "2005-12"
 1393	pet rock	0		Last Available: "2005-12"
 1394	doppelshifter	0		Last Available: "2005-12"
-1395	huge maroon teddy bear	0		Last Available: "2005-12"
+1395	maroon huge teddy bear	0		Last Available: "2005-12"
 1396	ghostly baleful duck-on-a-string of the dark arts	0		Spell Damage: +25, Spell Damage Percent: +100, Last Available: "2005-12"
 1397	toy soldier	0		Last Available: "2005-12"
 1398	doll house	0		Last Available: "2005-12"
@@ -1384,34 +1384,34 @@
 1402	dance instructor's rag doll	0		Experience Percent (Moxie): +10, Last Available: "2005-12"
 1403	can of fake snow of extreme caution	0		Monster Level: -25, Last Available: "2005-12"
 1404	narrow shaking Temple Grandin's colored-light &quot;necklace&quot;	0		Familiar Weight: +7, Last Available: "2005-12"
-1405	toasty tree skirt	0		Hot Damage: +5, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	spoiled twirling mirror wreath-shaped Crimbo cookie	4	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1405	toasty tree skirt	0		Hot Damage: +5, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1406	spoiled mirror twirling wreath-shaped Crimbo cookie	4	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	special spoiled bell-shaped Crimbo cookie	4	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	spoiled tree-shaped Crimbo cookie	4	crappy	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	wizardly Unionize The Elves sign	0		Mysticality: +25, Last Available: "2005-12"
 1410	pulsating sleeping snowy owl	0		Last Available: "2005-12"
 1411	upside-down Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
-1412	activated concentrated skewed blurry snowcone	0		Effect: "Brother Smothers's Blessing", Effect Duration: 18, Last Available: "2006-01"
+1412	activated concentrated blurry skewed snowcone	0		Effect: "Brother Smothers's Blessing", Effect Duration: 18, Last Available: "2006-01"
 1413	polymerized energized shaking snowcone	0		Effect: "Mariachi Mood", Effect Duration: 61, Last Available: "2006-01"
-1414	corrupted twirling spinning snowcone	0		Effect: "Memento Moir&eacute;", Effect Duration: 69, Last Available: "2006-01"
+1414	corrupted spinning twirling snowcone	0		Effect: "Memento Moir&eacute;", Effect Duration: 69, Last Available: "2006-01"
 1415	oxidized snowcone	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 60, Last Available: "2006-01"
 1416	liquefied snowcone	0		Effect: "Sinuses For Miles", Effect Duration: 20, Last Available: "2006-01"
 1417	nitrogenated chilled snowcone	0		Effect: "Slimy Hands", Effect Duration: 26, Last Available: "2006-01"
 1418	mirror Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	ghostly teddy bear sewing kit	0		Last Available: "2006-01"
-1420	manspreader's experienced traffic cone	0		Experience: +2, Monster Level: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	manspreader's experienced traffic cone	0		Experience: +2, Monster Level: +10, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	narrow Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	upside-down banded ice sickle of mayonnaise	0		Damage Absorption: +100, Sleaze Spell Damage: +50, Softcore Only, Last Available: "2006-02"
 1425	blue ice baby of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2006-02"
-1426	stanky ice pick	0		Stench Spell Damage: +25, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	stanky ice pick	0		Stench Spell Damage: +25, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	jittery flame-wreathed ruddy ice skates	0		Maximum HP Percent: +40, Hot Spell Damage: +10, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	decent half-sized grue egg omelette	2	good	
 1429	roll of drink tickets	0		
 1430	upside-down pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	decent small special mushroom	2	good	Effect: "Rat-Faced", Effect Duration: 30
+1432	small decent special mushroom	2	good	Effect: "Rat-Faced", Effect Duration: 30
 1433	fruit bowl	0		
 1434	red fruit basket	0		
 1435	hot pink lipstick	0		Familiar Weight: +5
@@ -1427,7 +1427,7 @@
 1445	aerosolized triple-dry hot nuggets	0		Effect: "Ticking Clock", Effect Duration: 24
 1446	electrified nuggets	0		Effect: "Boschface", Effect Duration: 41
 1447	vacuum-sealed squat nuggets	0		Effect: "Craft Tea", Effect Duration: 64
-1448	irradiated wobbly upside-down stench nuggets	0		Effect: "Total Protonic Reversal", Effect Duration: 68
+1448	irradiated upside-down wobbly stench nuggets	0		Effect: "Total Protonic Reversal", Effect Duration: 68
 1449	ionized gray sleaze nuggets	0		Effect: "Halloweeny", Effect Duration: 53
 1450	twisted twinkly wad	1		Effect: "Industrial Strength Starch", Effect Duration: 30
 1451	twisted yellow hot wad	1		
@@ -1437,7 +1437,7 @@
 1455	vaporized twirling sleaze wad	1		Effect: "Strong Grip", Effect Duration: 10
 1456	double daisy	0		
 1457	Goth Giant	0		
-1458	thick bland fuchsia blinking Valentine's Day cake	5	decent	
+1458	bland thick fuchsia blinking Valentine's Day cake	5	decent	
 1459	arrow'd heart balloon	0		
 1460	velvet box	0		
 1461	purple squashed frog	0		
@@ -1447,7 +1447,7 @@
 1465	huge suede shortsword	0		
 1466	shaking bamboo bokuto	0		
 1467	25-meat staff	0		
-1468	fuchsia shaking spinning two-handed depthsword	0		
+1468	shaking fuchsia spinning two-handed depthsword	0		
 1469	tumbling bill bec-de-bardiche glaive-guisarme	0		
 1470	jittery lead yo-yo	0		
 1471	jittery shaking slightly peevedbow	0		
@@ -1457,7 +1457,7 @@
 1475	blurry pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	teal plastic hard hat	0		Familiar Effect: "atk, cap 22"
-1478	lime green spinning narrow salad bowl	0		Familiar Effect: "atk, cap 30"
+1478	spinning narrow lime green salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	football helmet	0		Familiar Effect: "atk, cap 37"
 1480	chain-mail monokini	0		Familiar Effect: "sleaze atk, 4xBarrr, cap 7"
 1481	union scalemail pants	0		Familiar Effect: "2xBarrr, cap 12"
@@ -1474,7 +1474,7 @@
 1492	lion tamer's ninja mop	0		Experience (familiar): +2
 1493	shaking scorching Herculean ridiculously overelaborate ninja weapon	0		Experience (Muscle): +1, Hot Damage: +25
 1494	irradiated non-quantum jittery sugar-coated pine cone	0		Effect: "Well-Oiled", Effect Duration: 69, Last Available: "2020-09"
-1495	greasy traffic cone of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	greasy traffic cone of chilblains	0		Cold Damage: +25, Sleaze Spell Damage: +10, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	mediocre gloomy mushroom wine	3	decent	
 1497	mediocre mushroom wine	3	decent	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
@@ -1488,7 +1488,7 @@
 1506	acceptable yellow calle de miel with a fly in it	4	good	Last Available: "2006-04"
 1507	acceptable rockin' wagon with a fly in it	4	good	Last Available: "2006-04"
 1508	lousy perpendicular hula with a fly in it	3	decent	Last Available: "2006-04"
-1509	lousy practically non-alcoholic slap and tickle with a fly in it	1	decent	Last Available: "2006-04"
+1509	practically non-alcoholic lousy slap and tickle with a fly in it	1	decent	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	nasty fake hand	0		Stench Damage: +5, Last Available: "2006-04"
 1512	modified Knob Goblin pet-buffing spray	1		
@@ -1503,23 +1503,23 @@
 1522	censurious Radio Free Jersey of the detective	0		Sleaze Resistance: +3, Item Drop: +20
 1523	bottle of used blood	0		
 1524	teal wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
-1526	blurry pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1526	blurry pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	flame-retardant groovy corkscrew	0		Moxie Percent: +10, Hot Resistance: +1, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	grass skirt of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	toasty grass hat	0		Hot Damage: +5, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	grass skirt of terror	0		Spooky Spell Damage: +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	toasty grass hat	0		Hot Damage: +5, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	grass blade of Leguizamo	0		Monster Level: +20, Last Available: "2011-01"
 1534	blurry raffle prize box	0		
 1536	wobbly homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	wobbly weegee sqouija	0		Last Available: "2011-12"
 1538	tumbling educational sparkly engagement ring	0		Experience: +1, Single Equip
 1539	tumbling Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	nasty Grimacite goggles of temperance	0		Stench Damage: +5, Sleaze Resistance: +5, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	nasty Grimacite goggles of temperance	0		Stench Damage: +5, Sleaze Resistance: +5, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	cool beefcake's Grimacite glaive	0		Muscle: +25, Moxie: +5, Last Available: "2008-10"
-1542	deadly Grimacite greaves of Flo-Jo	0		Weapon Damage: +5, Initiative: +100, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	deadly Grimacite greaves of Flo-Jo	0		Weapon Damage: +5, Initiative: +100, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	upside-down perfumed ribald Grimacite garter	0		Sleaze Damage: +10, Stench Resistance: +5, Last Available: "2008-10"
 1544	spinning mansplainer's ruddy Grimacite galoshes	0		Maximum HP Percent: +40, Monster Level: +15, Last Available: "2008-10"
 1545	maroon lard-coated forbidden Grimacite gorget	0		Spell Damage Percent: +50, Sleaze Spell Damage: +25, Last Available: "2008-10"
@@ -1529,10 +1529,10 @@
 1549	green MSG	0		
 1550	spinning smartaleck's second-hand knockoff engagement ring	0		Moxie Percent: +30, Single Equip
 1551	lousy bottle of Domesticated Turkey	3	decent	
-1552	lousy watered-down special green tumbling bottle of Definit	2	decent	Effect: "Flaming Weapon", Effect Duration: 35
+1552	special watered-down lousy tumbling green bottle of Definit	2	decent	Effect: "Flaming Weapon", Effect Duration: 35
 1553	drinkable practically non-alcoholic bottle of Calcutta Emerald	1	good	
-1554	perfectly mixed spirit-forward bottle of Lieutenant Freeman	5	EPIC	
-1555	fancy bad skewed bottle of Jorge Sinsonte	4	decent	Effect: "Slime Time", Effect Duration: 25
+1554	spirit-forward perfectly mixed bottle of Lieutenant Freeman	5	EPIC	
+1555	bad fancy skewed bottle of Jorge Sinsonte	4	decent	Effect: "Slime Time", Effect Duration: 25
 1556	smooth mirror red boxed champagne	4	awesome	
 1557	snack-sized rotten yellow kumquat	2	crappy	
 1558	decent tumbling tangerine	3	good	
@@ -1542,44 +1542,44 @@
 1562	adequate kiwi	3	good	
 1563	bad whiskey bittersweet	3	decent	
 1564	artisanal fancy mimosette	3	EPIC	Effect: "Bootyliciousness", Effect Duration: 10
-1565	watered-down tolerable tequila sunset	2	good	
+1565	tolerable watered-down tequila sunset	2	good	
 1566	acceptable zmobie	4	good	Wiki Name: "Zmobie (drink)"
 1567	enchanted artisanal gin and tonic	4	EPIC	Effect: "Prince of Seaside Town", Effect Duration: 30
 1568	lousy yellow vodka and tonic	4	decent	
 1569	triple-distilled acceptable vodka gibson	6	good	
 1570	bad practically non-alcoholic gibson	1	decent	
-1571	mediocre spirit-forward parisian cathouse	5	decent	
+1571	spirit-forward mediocre parisian cathouse	5	decent	
 1572	bad watered-down rabbit punch	2	decent	
-1573	aged weak mirror caipifruta	2	awesome	
-1574	lousy fortified teqiwila	5	decent	
-1575	special practically non-alcoholic artisanal Divine	1	super ultra mega turbo EPIC	Effect: "Aquarius Rising", Effect Duration: 50
+1573	weak aged mirror caipifruta	2	awesome	
+1574	fortified lousy teqiwila	5	decent	
+1575	artisanal special practically non-alcoholic Divine	1	super ultra mega turbo EPIC	Effect: "Aquarius Rising", Effect Duration: 50
 1576	aged Gordon Bennett	3	awesome	
-1577	distilled hand-crafted tangarita	5	EPIC	
-1578	distilled lousy mandarina colada	5	decent	
+1577	hand-crafted distilled tangarita	5	EPIC	
+1578	lousy distilled mandarina colada	5	decent	
 1579	acceptable high-proof gimlet	6	good	
-1580	enchanted practically non-alcoholic smooth brick road	1	awesome	Effect: "Drunk With Power", Effect Duration: 20
+1580	smooth enchanted practically non-alcoholic brick road	1	awesome	Effect: "Drunk With Power", Effect Duration: 20
 1581	tolerable vodka stratocaster	4	good	
 1582	delicious Neuromancer	4	awesome	
-1583	hand-crafted watered-down prussian cathouse	2	super ultra EPIC	
+1583	watered-down hand-crafted prussian cathouse	2	super ultra EPIC	
 1584	lousy Mae West	3	decent	
 1585	bad spinning Mon Tiki	4	decent	
 1586	acceptable teqiwila slammer	3	good	
-1587	bland diet Knob lo mein	1	decent	
-1588	spoiled low-calorie pulsating asparagus lo mein	1	crappy	
+1587	diet bland Knob lo mein	1	decent	
+1588	low-calorie spoiled pulsating asparagus lo mein	1	crappy	
 1589	rotten Knoll lo mein	4	crappy	
-1590	super-sized spoiled lo mein	5	crappy	
-1591	miniature flavorless spinning olive lo mein	2	decent	
-1592	flavorless massive hot hi mein	10	decent	
+1590	spoiled super-sized lo mein	5	crappy	
+1591	flavorless miniature spinning olive lo mein	2	decent	
+1592	massive flavorless hot hi mein	10	decent	
 1593	tasty hi mein	4	awesome	
 1594	spoiled massive hi mein	9	crappy	
-1595	tasty immense hi mein	9	awesome	
-1596	super-sized flavorless purple sleazy hi mein	5	decent	
+1595	immense tasty hi mein	9	awesome	
+1596	flavorless super-sized purple sleazy hi mein	5	decent	
 1597	Sinatra's Junior LAAAAME merit badge	0		Experience (Moxie): +5, Last Available: "2006-05"
 1598	smooth Senior LAAAAME merit badge	0		Moxie: +15, Last Available: "2006-05"
 1599	fuchsia jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	bad tumbling tangarita with a fly in it	3	decent	
-1601	weak mediocre mandarina colada with a fly in it	2	decent	
-1602	weak aged prussian cathouse with a fly in it	2	awesome	
+1601	mediocre weak mandarina colada with a fly in it	2	decent	
+1602	aged weak prussian cathouse with a fly in it	2	awesome	
 1603	lousy shaking Mae West with a fly in it	3	decent	
 1604	distilled astronaut ice-cream	1		Last Available: "2006-05"
 1605	huge delectable catalyst	0		
@@ -1592,14 +1592,14 @@
 1612	diffused extra-galvanized vacuum-sealed concentrated cordial of concentration	0		Effect: "Kindly Resolve", Effect Duration: 65
 1613	coffin lid of the brazier	0		Hot Spell Damage: +25, Damage Reduction: 3
 1614	padded satin shield	0		Damage Absorption: +20, Damage Reduction: 5
-1615	upside-down olive therapeutic Cerebral Cloche	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	Usain Bolt's Cerebral Culottes	0		Initiative: +80, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	upside-down olive therapeutic Cerebral Cloche	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	Usain Bolt's Cerebral Culottes	0		Initiative: +80, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	frightening nasty studded Cerebral Crossbow	0		Damage Absorption: +80, Stench Damage: +5, Spooky Damage: +5, Last Available: "2006-06"
 1618	bouncing ice stein	0		Last Available: "2006-06"
 1619	ghostly munchies pill	0		Last Available: "2006-06"
 1620	homeopathic healing powder	0		Last Available: "2006-06"
 1621	skewed astral badger	0		Free Pull, Last Available: "2006-06"
-1622	warmed blurry purple skewed astral mushroom	0		Effect: "Once Bitten Twice Fried", Effect Duration: 19, Last Available: "2006-06"
+1622	warmed purple skewed blurry astral mushroom	0		Effect: "Once Bitten Twice Fried", Effect Duration: 19, Last Available: "2006-06"
 1623	badger badge	0		Last Available: "2006-06"
 1624	oxidized blue-frosted astral cupcake	0		Effect: "Old Time Hydration", Effect Duration: 69, Last Available: "2006-06"
 1625	triple-anodized green-frosted astral cupcake	0		Effect: "Yuletide Mutations", Effect Duration: 20, Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	blinking Spanish fly	0		
-1634	weak bad around the world	2	decent	
+1634	bad weak around the world	2	decent	
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	extra-modified cold-filtered lotion of hotness	0		Effect: "Industrial Strength Starch", Effect Duration: 18
@@ -1619,7 +1619,7 @@
 1639	adjusted nitrogenated twirling lotion of spookiness	0		Effect: "Egg-stortionary Tactics", Effect Duration: 13
 1640	liquefied oxidized lotion of stench	0		Effect: "Super-Mega-Charged", Effect Duration: 17
 1641	modified lotion of sleaziness	0		Effect: "Big Meat Big Prizes", Effect Duration: 45
-1642	practically non-alcoholic bad Grimacite Bock	1	decent	Last Available: "2008-11"
+1642	bad practically non-alcoholic Grimacite Bock	1	decent	Last Available: "2008-11"
 1643	miniature bland jittery wedge of gray cheese	2	decent	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	decent foie gras	3	good	
 1652	concentrated polymerized candy brain	0		Effect: "Booze Goozles", Effect Duration: 56, Last Available: "2020-09"
-1653	Van der Graaf padded razor-sharp jewel-eyed wizard hat	0		Weapon Damage Percent: +25, Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	Van der Graaf padded razor-sharp jewel-eyed wizard hat	0		Weapon Damage Percent: +25, Damage Absorption: +20, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	lime green asbestos-lined wad of Crovacite of extreme caution	0		Monster Level: -25, Hot Resistance: +5
 1655	auspicious collar of the scaredy-cat	0		Monster Level: -15, Item Drop: +10
 1656	White Citadel Satisfaction Satchel	0		
@@ -1647,15 +1647,15 @@
 1667	frosty Cat-Herding Prod	0		Cold Spell Damage: +10
 1668	forbidden star boomerang	0		Spell Damage Percent: +50
 1669	Temple Grandin's star stiletto	0		Familiar Weight: +7
-1670	blinking blinking narrow fraudwort	0		
+1670	narrow blinking blinking fraudwort	0		
 1671	shysterweed	0		
 1672	teal twirling swindleblossom	0		
 1673	horrifying cool grave robbing shovel	0		Moxie: +5, Spooky Damage: +25
 1674	twirling superhero mask of wisdom	0		Mysticality: +15, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
 1675	red ore	0		
 1676	styrofoam ore	0		
-1677	fuchsia wobbly bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1677	wobbly fuchsia bubblewrap ore	0		
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	upside-down lightning-fast sword of James Dean	0		Experience (Moxie): +3, Initiative: +40
 1680	mirror blinking scandalous Fonzie's staff	0		Experience (Moxie): +1, Sleaze Damage: +5
 1681	Oprah's strapping bubblewrap sword	0		Muscle: +5, Maximum MP Percent: +50
@@ -1669,11 +1669,11 @@
 1689	ribbon of the sewer	0		Stench Damage: +25, Last Available: "2006-07"
 1690	quilted wizardly discarded bottlecap	0		Mysticality: +25, Damage Absorption: +40, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	resourceful Rosewater's discarded torn-up glove	0		Mysticality Percent: +30, Maximum MP: +50, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	quadruple-cold-filtered twirling upside-down mirror salamander slurry	0		Effect: "Influence of Sphere", Effect Duration: 33
+1692	quadruple-cold-filtered upside-down twirling mirror salamander slurry	0		Effect: "Influence of Sphere", Effect Duration: 33
 1693	oxidized tumbling red eyedrops of newt	0		Effect: "Joy", Effect Duration: 15
 1694	moist ionized Frogade	0		Effect: "Cock of the Walk", Effect Duration: 26
 1695	triple-corrupted lime green papotion of papower	0		Effect: "Armor-Plated", Effect Duration: 47
-1696	special decent royal jelly taco	3	good	Effect: "All Blued Up", Effect Duration: 15
+1696	decent special royal jelly taco	3	good	Effect: "All Blued Up", Effect Duration: 15
 1697	decent tofu taco	4	good	
 1698	normal jumbo jumping bean taco	5	good	
 1699	toothsome catgut taco	3	awesome	
@@ -1725,7 +1725,7 @@
 1746	reassuring smelly Temple Grandin's Super Magic Power Sword X	0		Familiar Weight: +7, Stench Spell Damage: +10, Spooky Resistance: +1
 1747	resourceful Da Vinci's soylent staff	0		Experience (Mysticality): +5, Maximum MP: +50
 1748	frosty goulauncher of extreme caution	0		Monster Level: -25, Cold Spell Damage: +10
-1749	pulsating mirror defective skull	0		Last Available: "2011-12"
+1749	mirror pulsating defective skull	0		Last Available: "2011-12"
 1750	greasy Gnollish pie server	0		Sleaze Spell Damage: +10
 1751	Annie Oakley's Gnollish slotted spoon	0		Critical Hit Percent: +20
 1752	perfumed Knob Goblin spatula	0		Stench Resistance: +5
@@ -1741,16 +1741,16 @@
 1762	weightlifter's foon of fearfulness of the detective	0		Muscle: +15, Item Drop: +20
 1763	bouncing upside-down gray groovy brawny foon of fleshiness	0		Muscle Percent: +20, Moxie Percent: +10
 1764	Spookyraven library key	0		
-1765	bouncing yellow blurry Spookyraven gallery key	0		
+1765	blurry bouncing yellow Spookyraven gallery key	0		
 1766	narrow Spookyraven ballroom key	0		
 1767	maroon pack of chewing gum	0		
 1768	Gnomish toolbox	0		
-1769	small toothsome fancy blurry fricasseed brains	2	awesome	Effect: "Sludgesick", Effect Duration: 5
-1770	spoiled miniature brains casserole	2	crappy	
+1769	fancy toothsome small blurry fricasseed brains	2	awesome	Effect: "Sludgesick", Effect Duration: 5
+1770	miniature spoiled brains casserole	2	crappy	
 1771	shellacked butcherknife	0		Damage Reduction: 7
 1772	blurry fireproof corn holder	0		Hot Resistance: +3
 1773	blinking healthy eggbeater	0		Maximum HP Percent: +20
-1774	perfectly mixed weak bottle of popskull	2	EPIC	
+1774	weak perfectly mixed bottle of popskull	2	EPIC	
 1775	ribald dishrag	0		Sleaze Damage: +10
 1776	decent jittery stale baguette	3	good	
 1777	upside-down leftovers of indeterminate origin	0		
@@ -1759,7 +1759,7 @@
 1780	curative ram stick	0		HP Regen Min: 3, HP Regen Max: 5
 1781	personal trainer's enchantlers	0		Experience Percent (Muscle): +10, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	lightning-fast wizardly ram-battering staff	0		Mysticality: +25, Initiative: +40
-1783	stale massive squat crazy Turkish delight	9	decent	
+1783	massive stale squat crazy Turkish delight	9	decent	
 1784	wobbly zippy crafty Snow Queen Crown	0		Maximum MP: +10, Initiative: +20, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	spinning tumbling Annie Oakley's electrified ga-ga radio of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5
 1786	six pack of Mountain Stream	0		
@@ -1768,7 +1768,7 @@
 1789	Mob Penguin	0		
 1790	artisanal distilled Ram's Face Lager	5	EPIC	
 1791	shaking ram horns	0		
-1792	tumbling Sherlock's Travoltan trousers of Tarzan of the blizzard	0		Experience (Muscle): +3, Cold Spell Damage: +25, Item Drop: +25, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	tumbling Sherlock's Travoltan trousers of Tarzan of the blizzard	0		Experience (Muscle): +3, Cold Spell Damage: +25, Item Drop: +25, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	rosy-cheeked beefy pool cue	0		Muscle: +10, Maximum HP Percent: +30
 1794	double-anodized blue handful of hand chalk	0		Effect: "Sugary Tongue", Effect Duration: 50
 1795	squat MacGyver's Counterclockwise Watch	0		Maximum MP: +100, Single Equip
@@ -1785,7 +1785,7 @@
 1806	fifth cervical vertebra	0		
 1807	sixth cervical vertebra	0		
 1808	wobbly seventh cervical vertebra	0		
-1809	blinking tumbling first thoracic vertebra	0		
+1809	tumbling blinking first thoracic vertebra	0		
 1810	second thoracic vertebra	0		
 1811	fuchsia third thoracic vertebra	0		
 1812	fourth thoracic vertebra	0		
@@ -1853,7 +1853,7 @@
 1874	left femur	0		
 1875	right femur	0		
 1876	left tibia	0		
-1877	fuchsia narrow right tibia	0		
+1877	narrow fuchsia right tibia	0		
 1878	left fibula	0		
 1879	right fibula	0		
 1880	left kneecap	0		
@@ -1923,14 +1923,14 @@
 1946	Oprah's occult accordion pin	0		Spell Damage Percent: +25, Maximum MP Percent: +50, Class: "Accordion Thief", Single Equip
 1947	executive stanky worn tophat	0		Stench Spell Damage: +25, Meat Drop: +40, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	razor-sharp tap shoes of chilblains	0		Weapon Damage Percent: +25, Cold Damage: +25, Single Equip
-1949	flavorless miniature Manetwich	2	decent	
+1949	miniature flavorless Manetwich	2	decent	
 1950	huge bottle of Vangoghbitussin	0		
-1951	artisanal irresponsibly strong bottle of Pinot Renoir	9	EPIC	
+1951	irresponsibly strong artisanal bottle of Pinot Renoir	9	EPIC	
 1952	stale tiny desiccated apricot	1	decent	
 1953	tolerable flute of flat champagne	3	good	
 1954	normal small jittery dehydrated caviar	2	good	
 1955	styrofoam peanuts	0		
-1956	extra-dry tolerable snifter of thoroughly aged brandy	5	good	
+1956	tolerable extra-dry snifter of thoroughly aged brandy	5	good	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	olive tattered scrap of paper	0		
@@ -1979,7 +1979,7 @@
 2002	The Grand Poo-Bah trading card	0		
 2003	Thorny Toad trading card	0		
 2004	blinking Chori Zo trading card	0		
-2005	skewed gray Morbidda trading card	0		
+2005	gray skewed Morbidda trading card	0		
 2006	Poison Oak trading card	0		
 2007	Princess Rutabaga trading card	0		
 2008	Roo trading card	0		
@@ -1994,15 +1994,15 @@
 2017	spade necklace	0		
 2018	skewed club necklace	0		
 2019	lime green cream pie	0		Free Pull
-2020	tasty low-calorie tumbling cherry pie	1	awesome	
+2020	low-calorie tasty tumbling cherry pie	1	awesome	
 2021	moldy strawberry pie	3	crappy	
 2022	rotten lemon meringue pie	4	crappy	
 2023	mirror Genalen&trade; Bottle	1	decent	
-2024	delicious bite-sized mixed wildflower greens	1	awesome	
-2025	adequate diet handful of walnuts	1	good	
-2026	small moldy pulsating nutty organic salad	2	crappy	
-2027	moldy teal squat super salad	4	crappy	
-2028	spoiled snack-sized tofu wonton	2	crappy	
+2024	bite-sized delicious mixed wildflower greens	1	awesome	
+2025	diet adequate handful of walnuts	1	good	
+2026	moldy small pulsating nutty organic salad	2	crappy	
+2027	moldy squat teal super salad	4	crappy	
+2028	snack-sized spoiled tofu wonton	2	crappy	
 2029	hippy protest button	0		Single Equip
 2030	greasy Lockenstock&trade; sandals of the boozehound	0		Sleaze Spell Damage: +10, Booze Drop: +100, Single Equip
 2031	didgeridooka of the early riser	0		Adventures: +7
@@ -2021,7 +2021,7 @@
 2044	upside-down your father's MacGuffin diary	0		
 2045	moldy brain-meltingly-hot chicken wings	3	crappy	
 2046	flavorless frat brats	4	decent	
-2047	enchanted rotten blinking mirror tumbling knob ka-bobs	3	crappy	Effect: "Brother Smothers's Blessing", Effect Duration: 15
+2047	enchanted rotten mirror blinking tumbling knob ka-bobs	3	crappy	Effect: "Brother Smothers's Blessing", Effect Duration: 15
 2049	mediocre enchanted can of Swiller	3	decent	Effect: "Bonelording", Effect Duration: 35
 2050	broken wings	0		
 2051	sunken eyes	0		
@@ -2036,7 +2036,7 @@
 2060	electrified banded sword	0		Damage Absorption: +100, MP Regen Min: 3, MP Regen Max: 5
 2061	friendly helmet	0		Familiar Weight: +3, Familiar Effect: "1xFairy, cap 40"
 2062	nippy fortified shield	0		Damage Absorption: +60, Cold Damage: +10, Damage Reduction: 10
-2063	decent miniature blackberry	2	good	
+2063	miniature decent blackberry	2	good	
 2064	forged identification documents	0		
 2065	twirling fuchsia PADL Phone	0		
 2066	gravedigger's boxer's kick-ass kicks	0		Muscle Percent: +10, Spooky Damage: +10, Single Equip
@@ -2058,7 +2058,7 @@
 2082	spinning toothbrush	0		
 2083	wobbly makeshift crane	0		
 2084	can of starch	0		
-2085	twisted lime green narrow bottle of ultravitamins	1		Effect: "Mystic Circle", Effect Duration: 20
+2085	twisted narrow lime green bottle of ultravitamins	1		Effect: "Mystic Circle", Effect Duration: 20
 2086	dried fuchsia upside-down bottle of cough syrup	1		Effect: "Ooh, Salty!", Effect Duration: 25
 2087	twisted skewed tube of hair oil	1		
 2088	activated pickled Daffy Taffy	0		Effect: "Leisurely Amblin'", Effect Duration: 33
@@ -2067,7 +2067,7 @@
 2091	gray bath salts	0		
 2092	hand mirror	0		
 2093	miser's hors d'oeuvre tray	0		Meat Drop: +10, Damage Reduction: 5
-2094	bland big fuchsia ballroom blintz	5	decent	
+2094	big bland fuchsia ballroom blintz	5	decent	
 2095	blue towel	0		
 2096	vaporized yellow ghostly guy made of bee pollen	1		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 40
 2097	blurry wobbly 17-ball of the storm	0		Maximum MP Percent: +40
@@ -2090,7 +2090,7 @@
 2114	pulsating yo	0		Last Available: "2006-12"
 2115	skewed wobbly prehistoric spear of the ox	0		Muscle: +20, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	inspector's arcane researcher's fire	0		Experience Percent (Mysticality): +10, Item Drop: +15, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	inspector's arcane researcher's fire	0		Experience Percent (Mysticality): +10, Item Drop: +15, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	mirror lit cigar	0		Last Available: "2011-12"
 2120	purple Oprah's Grateful Undead T-shirt	0		Maximum MP Percent: +50
@@ -2101,7 +2101,7 @@
 2126	blue bronze breastplate of the overflowing toilet of the glutton	0		Stench Spell Damage: +50, Food Drop: +100
 2127	gray avaricious hat hacker T-shirt of the sweet-tooth	0		Meat Drop: +30, Candy Drop: +100
 2128	vampire collar	0		Single Equip
-2129	pulsating huge possessed top	0		Last Available: "2010-12"
+2129	huge pulsating possessed top	0		Last Available: "2010-12"
 2130	fireproof killer rag doll	0		Hot Resistance: +3, Last Available: "2006-12"
 2131	upside-down tree-eating kite	0		Last Available: "2006-12"
 2132	maroon hardened incredibly marionette	0		Damage Reduction: 3, Last Available: "2006-12"
@@ -2119,11 +2119,11 @@
 2144	evil googly eye	0		Last Available: "2011-12"
 2145	stuffing	0		Last Available: "2011-12"
 2146	evil teddy bear	0		Last Available: "2006-12"
-2147	teal blinking wobbly jittery evil teddy bear sewing kit	0		
+2147	teal wobbly blinking jittery evil teddy bear sewing kit	0		
 2148	pulsating toothsome rock	0		
-2149	stale enchanted immense olive frank	9	decent	Effect: "Greased-Up Familiar", Effect Duration: 50, Last Available: "2011-12"
+2149	stale immense enchanted olive frank	9	decent	Effect: "Greased-Up Familiar", Effect Duration: 50, Last Available: "2011-12"
 2150	bite-sized bland plate of franks and beans	1	decent	Last Available: "2011-12"
-2151	aged special fortified shot of blackberry schnapps	5	awesome	Effect: "Preemptive Medicine", Effect Duration: 50
+2151	aged fortified special shot of blackberry schnapps	5	awesome	Effect: "Preemptive Medicine", Effect Duration: 50
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	pulsating ion grid	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	bouncing ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	cyan hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	gray twirling lion tamer's rock-hard toy ray gun	0		Damage Reduction: 5, Experience (familiar): +2, Last Available: "2006-12"
-2169	Socratic toy space helmet of the sweet-tooth	0		Experience (Mysticality): +1, Candy Drop: +100, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	Socratic toy space helmet of the sweet-tooth	0		Experience (Mysticality): +1, Candy Drop: +100, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	bouncing experienced astronaut pants of Leguizamo	0		Experience: +2, Monster Level: +20, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	bouncing experienced astronaut pants of Leguizamo	0		Experience: +2, Monster Level: +20, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	tumbling toy jet pack of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	upside-down mossy stone sphere	0		
@@ -2168,9 +2168,9 @@
 2193	normal teal candy stake	3	good	Last Available: "2006-12"
 2194	smooth huge eggnog	3	awesome	Last Available: "2006-12"
 2195	special yummy twirling unspeakable fruitcake	3	awesome	Effect: "Puddingface", Effect Duration: 50, Last Available: "2006-12"
-2196	spoiled massive mirror gingerbread horror	7	crappy	Last Available: "2006-12"
+2196	massive spoiled mirror gingerbread horror	7	crappy	Last Available: "2006-12"
 2197	diffused flattened but probably evil chocolate	0		Effect: "Broken Bone Nubs", Effect Duration: 64, Last Available: "2006-12"
-2198	decent huge bat-shaped Crimboween cookie	7	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	huge decent bat-shaped Crimboween cookie	7	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	moldy jumbo skull-shaped Crimboween cookie	5	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	bland twirling tombstone-shaped Crimboween cookie	3	decent	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	plastic gift-wrapping vampire of doom	0		Spooky Spell Damage: +50, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	shaking banded Crimbo tiki necklace	0		Damage Absorption: +100, Last Available: "2006-12"
 2208	shaking twirling twirling perfumed lard-coated bobble-hip hula elf doll	0		Sleaze Spell Damage: +25, Stench Resistance: +5, Last Available: "2006-12"
 2209	purple toasty Crimbo ukulele	0		Hot Damage: +5, Last Available: "2006-12"
-2210	scandalous boxer's Tiki lighter	0		Muscle Percent: +10, Sleaze Damage: +5, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	Jack Frost's vibrating deck of tropical cards	0		Maximum MP Percent: +10, Cold Spell Damage: +50, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	skewed avaricious tropical paperweight of the businessman	0		Meat Drop: 80, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	scandalous boxer's Tiki lighter	0		Muscle Percent: +10, Sleaze Damage: +5, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	Jack Frost's vibrating deck of tropical cards	0		Maximum MP Percent: +10, Cold Spell Damage: +50, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	skewed avaricious tropical paperweight of the businessman	0		Meat Drop: 80, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	cyan tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	hale Tropical Crimbo Hat	0		Maximum HP: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	Tropical Crimbo Shorts of the brute	0		Muscle Percent: +30, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	hale Tropical Crimbo Hat	0		Maximum HP: +20, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	Tropical Crimbo Shorts of the brute	0		Muscle Percent: +30, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	spoiled super ka-bob	3	crappy	
-2218	delicious massive jittery blue beer basted brat	8	awesome	
+2218	massive delicious jittery blue beer basted brat	8	awesome	
 2219	wobbly fuchsia chaotic Tropical Crimbo Sword	0		Spell Critical Percent: +10, Last Available: "2006-12"
 2220	colloidal enhanced maroon and Crimboween candy	0		Effect: "Floundering", Effect Duration: 47, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	Da Vinci's liar's pants of the overflowing toilet	0		Experience (Mysticality): +5, Stench Spell Damage: +50, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	Da Vinci's liar's pants of the overflowing toilet	0		Experience (Mysticality): +5, Stench Spell Damage: +50, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	skewed mansplainer's juggler's balls of chilblains	0		Monster Level: +15, Cold Damage: +25, Softcore Only, Last Available: "2007-01"
 2224	sharpshooter's pink shirt	0		Critical Hit Percent: +10, Softcore Only, Last Available: "2007-01"
 2225	pulsating familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2235,7 +2235,7 @@
 2261	hard-boiled ostrich egg	0		
 2262	mirror bird rib	0		
 2263	lion oil	0		
-2264	special snack-sized decent stunt nuts	2	good	Effect: "Rainbow Bright", Effect Duration: 35
+2264	snack-sized decent special stunt nuts	2	good	Effect: "Rainbow Bright", Effect Duration: 35
 2265	spoiled wet stew	3	crappy	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
@@ -2243,10 +2243,10 @@
 2269	flavorless sausage wonton	4	decent	
 2270	yellow mirror personal trainer's belt of the bloodbag	0		Experience Percent (Muscle): +10, Maximum HP: +100, Single Equip
 2271	tolerable twirling bottle of Merlot	4	good	
-2272	fancy mediocre practically non-alcoholic bottle of Port	1	decent	Effect: "Spooky Weapon", Effect Duration: 15
-2273	watered-down aged bottle of Pinot Noir	2	awesome	
-2274	drinkable blurry mirror bottle of Zinfandel	4	good	
-2275	weak drinkable bottle of Marsala	2	good	
+2272	practically non-alcoholic mediocre fancy bottle of Port	1	decent	Effect: "Spooky Weapon", Effect Duration: 15
+2273	aged watered-down bottle of Pinot Noir	2	awesome	
+2274	drinkable mirror blurry bottle of Zinfandel	4	good	
+2275	drinkable weak bottle of Marsala	2	good	
 2276	bad bottle of Muscat	4	decent	
 2277	Fernswarthy's key	0		
 2278	gray Fernswarthy's letter	0		
@@ -2310,14 +2310,14 @@
 2336	horrifying wizardly pipe	0		Mysticality: +25, Spooky Damage: +25
 2337	asbestos-lined reinforced beaded headband	0		Hot Resistance: +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	decent tiny jittery pudding	1	good	Wiki Name: "black pudding (food)"
-2339	artisanal weak Blackfly Chardonnay	2	EPIC	
+2339	weak artisanal Blackfly Chardonnay	2	EPIC	
 2340	perfectly mixed tumbling & tan	4	EPIC	
 2341	blurry pepper	0		
 2342	miniature moldy forest cake	2	crappy	
 2343	normal spinning forest ham	3	good	
 2344	quadruple-alkaline anodized blinking filthworm hatchling scent gland	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 28
-2345	corrupted skewed twirling filthworm drone scent gland	0		Effect: "Chock Full o' Nanites", Effect Duration: 64
-2346	enhanced modified shaking yellow upside-down filthworm royal guard scent gland	0		Effect: "Jingle Jangle Jingle", Effect Duration: 41
+2345	corrupted twirling skewed filthworm drone scent gland	0		Effect: "Chock Full o' Nanites", Effect Duration: 64
+2346	enhanced modified shaking upside-down yellow filthworm royal guard scent gland	0		Effect: "Jingle Jangle Jingle", Effect Duration: 41
 2347	mirror heart of the filthworm queen	0		
 2348	water pipe bomb	0		
 2349	gas balloon	0		
@@ -2330,7 +2330,7 @@
 2356	tarnished non-quantum tube of dread wax	0		Effect: "Alacri Tea", Effect Duration: 18
 2357	blue zippy mansplainer's Gaia beads	0		Monster Level: +15, Initiative: +20
 2358	pink clay bead	0		
-2359	huge narrow clay bead	0		
+2359	narrow huge clay bead	0		
 2360	jittery clay bead	0		
 2361	twirling avaricious quilted hippy medical kit	0		Damage Absorption: +40, Meat Drop: +30, Single Equip
 2362	therapeutic Slow Talkin' Elliot's dogtags of doom	0		Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7
@@ -2347,8 +2347,8 @@
 2373	flavorless banana	3	decent	
 2374	banana peel	0		
 2375	super-sized stale narrow banana cream pie	5	decent	
-2376	practically non-alcoholic drinkable fancy banana daiquiri	1	good	Effect: "Bubblin' Rage", Effect Duration: 40
-2377	fortified hand-crafted skewed wobbly bungle in the jungle	5	EPIC	
+2376	drinkable practically non-alcoholic fancy banana daiquiri	1	good	Effect: "Bubblin' Rage", Effect Duration: 40
+2377	hand-crafted fortified skewed wobbly bungle in the jungle	5	EPIC	
 2378	banana spritzer	0		
 2379	deionized moist moist purple banana smoothie	0		Effect: "The Power of Negative Thinking", Effect Duration: 11
 2380	pulsating spinning dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2469,7 +2469,7 @@
 2496	ghostly Sinful Desires of extreme caution of the boozehound	0		Monster Level: -25, Booze Drop: +100
 2497	huge molybdenum magnet	0		
 2498	molybdenum hammer	0		
-2499	squat tumbling purple molybdenum screwdriver	0		
+2499	squat purple tumbling molybdenum screwdriver	0		
 2500	shaking molybdenum pliers	0		
 2501	molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
@@ -2489,23 +2489,23 @@
 2516	tumbling MacGyver's wrench bracelet of temperance	0		Maximum MP: +100, Sleaze Resistance: +5
 2517	jittery nippy Jim Carey's chain necklace	0		Monster Level: +25, Cold Damage: +10
 2518	smelly sawblade shield	0		Stench Spell Damage: +10, Damage Reduction: 11
-2519	strong drinkable McMillicancuddy's Special Lager	5	good	
+2519	drinkable strong McMillicancuddy's Special Lager	5	good	
 2520	perfectly mixed special melted Jell-o shot	4	EPIC	Effect: "Spiritually Awake", Effect Duration: 35
-2521	mediocre spirit-forward cruelty-free wine	5	decent	
+2521	spirit-forward mediocre cruelty-free wine	5	decent	
 2522	drinkable upside-down thistle wine	4	good	
 2523	megatofu	0		
-2524	shaking olive displaced fish	0		
+2524	olive shaking displaced fish	0		
 2525	stale fish	3	decent	
-2526	snack-sized moldy fish casserole	2	crappy	
+2526	moldy snack-sized fish casserole	2	crappy	
 2527	snack-sized bland fish lasagna	2	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	stale spinning gnatloaf	3	decent	
 2530	decent big gnatloaf casserole	5	good	
-2531	flavorless low-calorie gnat lasagna	1	decent	
+2531	low-calorie flavorless gnat lasagna	1	decent	
 2532	narrow pork	0		
 2533	fancy half-sized adequate gray pork chop sandwiches	2	good	Effect: "Pharmaceutically Cool", Effect Duration: 30
 2534	half-sized adequate pork casserole	2	good	
-2535	decent jumbo pork lasagna	5	good	
+2535	jumbo decent pork lasagna	5	good	
 2536	canopic jar	0		
 2537	spice	0		
 2538	organs	0		
@@ -2514,11 +2514,11 @@
 2541	tumbling Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	irradiated aerosolized blinking lesser grodulated violet	0		Effect: "Spiky Hair", Effect Duration: 14, Last Available: "2007-05"
 2543	liquefied tin magnolia	0		Effect: "Thaumodynamic", Effect Duration: 51, Last Available: "2007-05"
-2544	extra-deionized deionized skewed narrow begpwnia	0		Effect: "Bandersnatched", Effect Duration: 56, Last Available: "2007-05"
+2544	extra-deionized deionized narrow skewed begpwnia	0		Effect: "Bandersnatched", Effect Duration: 56, Last Available: "2007-05"
 2545	non-magnetized galvanized narrow upsy daisy	0		Effect: "Stickler for Promptness", Effect Duration: 35, Last Available: "2007-05"
 2546	flattened ionized frozen yellow half-orchid	0		Effect: "Peppermint Bite", Effect Duration: 11, Last Available: "2007-05"
 2547	shaking twirling wholesome Socratic tin star	0		Experience (Mysticality): +1, Maximum HP Percent: +10, Last Available: "2007-05"
-2548	green outrageous sombrero of the detective of the early riser	0		Item Drop: +20, Adventures: +7, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	green outrageous sombrero of the detective of the early riser	0		Item Drop: +20, Adventures: +7, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	squat asbestos-lined &quot;Humorous&quot; T-shirt of the brazier	0		Hot Spell Damage: +25, Hot Resistance: +5, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	shaking vial of mojo	0		
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	Van der Graaf studded cactus quill	0		Damage Absorption: +80, MP Regen Min: 5, MP Regen Max: 7
 2578	jittery blinking MacGyver's wholesome baleful Staff of the Short Order Cook	0		Spell Damage: +25, Maximum HP Percent: +10, Maximum MP: +100
-2579	half-sized rotten cactus fruit	2	crappy	
+2579	rotten half-sized cactus fruit	2	crappy	
 2580	flame-retardant brawny scorpion whip	0		Muscle Percent: +20, Hot Resistance: +1
 2581	mirror handful of sand	0		
 2582	cyan brick of sand	0		
@@ -2570,7 +2570,7 @@
 2597	twirling leathery bat skin	0		
 2598	leathery rat skin	0		
 2599	Discount Telescope Warehouse gift certificate	0		
-2600	skewed yellow blurry carbonated water lily	0		
+2600	skewed blurry yellow carbonated water lily	0		
 2601	red mirror horrifying padded occult Staff of the Midnight Snack	0		Spell Damage Percent: +25, Damage Absorption: +20, Spooky Damage: +25
 2602	sizzling clever Staff of Blood and Pudding of extreme caution	0		Maximum MP: +20, Monster Level: -25, Hot Damage: +10
 2603	tumbling smoldering box	0		
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	adequate enchanted savoy truffle	3	good	Effect: "One For Tea", Effect Duration: 30
+2615	enchanted adequate savoy truffle	3	good	Effect: "One For Tea", Effect Duration: 30
 2616	Magi-Wipes	0		
 2617	maroon upside-down boom	0		
 2618	Iiti Kitty phone charm of bravery	0		Spooky Resistance: +5, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	fancy immense moldy twirling unidentified jerky	9	crappy	Effect: "Good with the Ladies", Effect Duration: 50
+2620	moldy immense fancy twirling unidentified jerky	9	crappy	Effect: "Good with the Ladies", Effect Duration: 50
 2621	scandalous lion tamer's nasty rat mask	0		Experience (familiar): +2, Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	blinking Rosewater's ratskin belt of incineration	0		Mysticality Percent: +30, Hot Spell Damage: +50, Single Equip
 2623	blurry scorching mansplainer's rattail whip	0		Monster Level: +15, Hot Damage: +25
@@ -2632,15 +2632,15 @@
 2659	cyan ghostly shaking shellacked albatross necklace	0		Damage Reduction: 7, Single Equip, Last Available: "2007-06"
 2660	dried jittery red not-a-pipe	1	good	Last Available: "2007-06"
 2661	drinkable flask of Amontillado	4	good	Last Available: "2007-06"
-2662	wobbly nasty ball mask	0		Stench Damage: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	reassuring Can-Can skirt	0		Spooky Resistance: +1, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	wobbly nasty ball mask	0		Stench Damage: +5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	reassuring Can-Can skirt	0		Spooky Resistance: +1, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	warmed pulsating sensitive poetry journal	0		Effect: "Lemon Enlightenment", Effect Duration: 57, Last Available: "2007-06"
 2665	nitrogenated bottled inspiration	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 67, Last Available: "2007-06"
 2666	aerosolized extra-wet bellhop bell	0		Effect: "Alchemical, Brother", Effect Duration: 45, Last Available: "2007-06"
 2667	energized improved improved spiky collar	0		Effect: "Savage Beast Inside", Effect Duration: 29, Last Available: "2007-06"
-2668	vaporized pulsating jittery can-can-in-a-can	1		Effect: "Proprie Tea", Effect Duration: 5, Last Available: "2007-06"
+2668	vaporized jittery pulsating can-can-in-a-can	1		Effect: "Proprie Tea", Effect Duration: 5, Last Available: "2007-06"
 2669	pickled patent antipsychotics	1		Last Available: "2007-06"
-2670	dehydrated blurry spinning teal Mariner's Friend cough drops	1		Effect: "Stands Alone", Effect Duration: 30, Last Available: "2007-06"
+2670	dehydrated spinning teal blurry Mariner's Friend cough drops	1		Effect: "Stands Alone", Effect Duration: 30, Last Available: "2007-06"
 2671	lousy blinking shot of nepenthe schnapps	3	decent	Last Available: "2007-06"
 2672	shaking library card	0		Last Available: "2007-06"
 2673	gray Bohemian rhapsody	0		Last Available: "2007-06"
@@ -2656,7 +2656,7 @@
 2683	twirling Warehouse 23 crate	0		
 2684	shaking Oprah's veiny armgun	0		Maximum HP: +10, Maximum MP Percent: +50
 2685	blinking seashell necklace	0		
-2686	maroon mirror commemorative war stein	0		
+2686	mirror maroon commemorative war stein	0		
 2687	stone frisbee	0		
 2688	dreadlock whip of the brute of the dark arts of the brazier	0		Muscle Percent: +30, Spell Damage Percent: +100, Hot Spell Damage: +25
 2689	aromatic wizardly beer-a-pult	0		Mysticality: +25, Stench Resistance: +1
@@ -2665,7 +2665,7 @@
 2692	ruddy driftwood sculpture of the cougar	0		Moxie: +20, Maximum HP Percent: +40
 2693	extremely unsafe Rosewater's massive sitar	0		Mysticality Percent: +30, Weapon Damage Percent: +100
 2694	blue vibrating stone baseball cap of vim and vigor of the cheetah	0		Maximum HP Percent: +50, Maximum MP Percent: +10, Initiative: +60, Familiar Effect: "1xVolley, cap 48"
-2695	artisanal strong cup of beer	5	EPIC	
+2695	strong artisanal cup of beer	5	EPIC	
 2696	ovoid thing	0		
 2697	duct tape	0		
 2698	twirling duct tape wallet	0		
@@ -2705,17 +2705,17 @@
 2732	perfectly mixed pulsating shot of peach schnapps	4	EPIC	
 2733	bite-sized bland bunch of square grapes	1	decent	
 2734	decent blue brown sugar cane	4	good	
-2735	spoiled thick sandwich of the gods	5	crappy	
+2735	thick spoiled sandwich of the gods	5	crappy	
 2736	lousy Pan-Dimensional Gargle Blaster	3	decent	
 2737	distilled leopard-print barbell	1	crappy	
 2738	red pile of smoking rags	0		
 2739	wet gray panty raider camouflage	0		Effect: "Virgo Rising", Effect Duration: 59
 2740	resourceful energetic banded Staff of the Walk-In Freezer	0		Damage Absorption: +100, Maximum MP Percent: +20, Maximum MP: +50
-2741	drinkable watered-down huge boilermaker	2	good	
+2741	watered-down drinkable huge boilermaker	2	good	
 2742	enchanted decent steel lasagna	3	quest	Effect: "All Blued Up", Effect Duration: 10
 2743	drinkable weak steel margarita	2	quest	
 2744	denatured olive steel-scented air freshener	1		
-2745	double-tarnished wet twirling huge gremlin mutagen	0		Effect: "Smoking like a Bandit", Effect Duration: 26
+2745	double-tarnished wet huge twirling gremlin mutagen	0		Effect: "Smoking like a Bandit", Effect Duration: 26
 2746	warmed narrow extra-potent gremlin mutagen	0		Effect: "Frozen Shoulders", Effect Duration: 28
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	tumbling squat sinister furniture dolly	0		Spell Damage: +10, Single Equip
@@ -2739,13 +2739,13 @@
 2766	bowling ball	0		
 2767	thick moldy Crimbo pie	5	crappy	
 2768	tasty gigantic fuchsia pear tart	10	awesome	
-2769	massive flavorless peach pie	7	decent	
-2770	super-improved unsweetened spinning fuchsia chunk of rock salt	0		Effect: "Mercenary", Effect Duration: 25
+2769	flavorless massive peach pie	7	decent	
+2770	super-improved unsweetened fuchsia spinning chunk of rock salt	0		Effect: "Mercenary", Effect Duration: 25
 2771	magnetized denatured jittery handful of pine needles	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 12
 2772	steamy ruby	0		
 2773	ghostly glacial sapphire	0		
 2774	shaking unearthly onyx	0		
-2775	wobbly red effluvious emerald	0		
+2775	red wobbly effluvious emerald	0		
 2776	twirling tawdry amethyst	0		
 2777	blurry inspector's extremely unsafe filigreed hamethyst earring	0		Weapon Damage Percent: +100, Item Drop: +15
 2778	Tesla stylish weightlifter's filigreed hamethyst necklace	0		Muscle: +15, Moxie: +25, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -2782,16 +2782,16 @@
 2809	corrupted altered flask of porquoise juice	0		Effect: "Warm Shoulders", Effect Duration: 40
 2810	non-chilled huge jug of hamethyst juice	0		Effect: "Human-Constellation Hybrid", Effect Duration: 33
 2811	diffused mirror jug of baconstone juice	0		Effect: "Bilious Brawn", Effect Duration: 17
-2812	boiled fuchsia pulsating jug of porquoise juice	0		Effect: "Stinkybeard", Effect Duration: 15
+2812	boiled pulsating fuchsia jug of porquoise juice	0		Effect: "Stinkybeard", Effect Duration: 15
 2813	padded Beret of the sewer	0		Damage Absorption: +20, Stench Damage: +25, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	jittery blurry Jack Frost's vibrating Bludgeon of Leguizamo	0		Maximum MP Percent: +10, Monster Level: +20, Cold Spell Damage: +50
 2815	knitted resourceful Bunker of the wise owl	0		Mysticality: +20, Maximum MP: +50, Cold Resistance: +3, Damage Reduction: 15
 2816	crafty Boxers of the businessman of the cheetah	0		Maximum MP: +10, Meat Drop: +50, Initiative: +60, Familiar Effect: "1xVolley, 1xLep"
 2817	blue up-at-dawn sharpshooter's Brooch of bravery	0		Critical Hit Percent: +10, Spooky Resistance: +5, Adventures: +5, Single Equip
 2818	pulsating horrifying electrified groovy Bracelet	0		Moxie Percent: +10, Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-2819	smelly crafty Grimacite gasmask	0		Maximum MP: +10, Stench Spell Damage: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	smelly crafty Grimacite gasmask	0		Maximum MP: +10, Stench Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	upside-down prompt Grimacite gat of chilblains	0		Cold Damage: +25, Adventures: +3, Last Available: "2008-11"
-2821	flame-wreathed Grimacite gaiters of the cougar	0		Moxie: +20, Hot Spell Damage: +10, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	flame-wreathed Grimacite gaiters of the cougar	0		Moxie: +20, Hot Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	lime green Jack Frost's Grimacite gauntlets of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Single Equip, Last Available: "2008-11"
 2823	coward's cool Grimacite go-go boots	0		Moxie: +5, Monster Level: -20, Single Equip, Last Available: "2008-11"
 2824	pulsating yellow studded sinister Grimacite girdle	0		Spell Damage: +10, Damage Absorption: +80, Single Equip, Last Available: "2008-11"
@@ -2801,17 +2801,17 @@
 2828	yellow loaded dice	0		
 2829	really dense meat stack	0		
 2830	digital key lime	0		
-2831	shaking skewed star key lime	0		
-2832	miniature toothsome digital key lime pie	2	awesome	
+2831	skewed shaking star key lime	0		
+2832	toothsome miniature digital key lime pie	2	awesome	
 2833	half-sized tasty jittery star key lime pie	2	awesome	
-2834	horrifying electrified rosy-cheeked bottle-rocket crossbow	0		Maximum HP Percent: +30, Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2834	horrifying electrified rosy-cheeked bottle-rocket crossbow	0		Maximum HP Percent: +30, Spooky Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	cyan smartaleck's indie comic hipster glasses	0		Moxie Percent: +30, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	jittery mint-condition magic wand	0		Last Available: "2011-12"
 2838	upside-down executive brawny glowstick	0		Muscle Percent: +20, Meat Drop: +40, Last Available: "2007-08"
 2839	shaking upside-down Periodical Paintbrush of Tarzan	0		Experience (Muscle): +3, Softcore Only
-2840	mediocre irresponsibly strong bottle of cooking sherry	6	decent	
-2841	small spoiled wobbly red packet of ketchup	2	crappy	
+2840	irresponsibly strong mediocre bottle of cooking sherry	6	decent	
+2841	spoiled small wobbly red packet of ketchup	2	crappy	
 2842	irresponsibly strong lousy accidental cider	10	decent	
 2843	normal dire fudgesicle	4	good	
 2844	blinking chilly hale stiffened quilted navel ring of navel gazing	0		Damage Absorption: +40, Damage Reduction: 1, Maximum HP: +20, Cold Damage: +5, Single Equip, Softcore Only, Last Available: "2007-09"
@@ -2820,7 +2820,7 @@
 2847	dangerous Dallas Dynasty Falcon Crest shield	0		Weapon Damage: +10, Damage Reduction: 15
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
-2850	acceptable fancy high-proof tumbling moonberry wine cooler	10	good	Effect: "Tingly Wrists", Effect Duration: 50
+2850	high-proof acceptable fancy tumbling moonberry wine cooler	10	good	Effect: "Tingly Wrists", Effect Duration: 50
 2851	normal fine aged cheddarwurst	4	good	
 2852	branch from the Great Tree	0		
 2853	Phil Bunion's axe	0		
@@ -2840,7 +2840,7 @@
 2867	yellow narrow dilapidated wizard hat of wisdom of vim and vigor	0		Mysticality: +15, Maximum HP Percent: +50, Familiar Effect: "cap 31"
 2868	polarized chilled spinning pirate pamphlet	0		Effect: "Stands Alone", Effect Duration: 46
 2869	concentrated chilled upside-down pirate brochure	0		Effect: "Snobby", Effect Duration: 50
-2870	chilled blurry purple pirate tract	0		Effect: "Inner Warmth", Effect Duration: 28
+2870	chilled purple blurry pirate tract	0		Effect: "Inner Warmth", Effect Duration: 28
 2871	burnt flower	0		
 2872	plastic Naughty Sorceress of Gandalf of chilblains	0		Spell Critical Percent: +20, Cold Damage: +25
 2873	blurry friendly wizardly plastic Ed the Undying	0		Mysticality: +25, Familiar Weight: +3
@@ -2910,14 +2910,14 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	bite-sized bland upside-down Surprise Egg	1	decent	
+2940	bland bite-sized upside-down Surprise Egg	1	decent	
 2941	pressed Steal This Candy	0		Effect: "Oh Snap", Effect Duration: 58
 2942	adjusted chocolate filthy lucre	0		Effect: "Bilious Briskness", Effect Duration: 19
 2943	electrified skewed Angry Farmer's Wife Candy	0		Effect: "Notably Lovely", Effect Duration: 68
 2945	MacGyver's grievous party hat	0		Weapon Damage Percent: +50, Maximum MP: +100, Familiar Effect: "4xLep, cap 7"
-2946	reassuring smartaleck's V for Vivala mask	0		Moxie Percent: +30, Spooky Resistance: +1, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	reassuring smartaleck's V for Vivala mask	0		Moxie Percent: +30, Spooky Resistance: +1, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	weak fancy drinkable shot of rotgut	2	good	Effect: "Shamboozled", Effect Duration: 50
+2948	fancy drinkable weak shot of rotgut	2	good	Effect: "Shamboozled", Effect Duration: 50
 2949	nitrogenated diffused tarnished jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "critical.enh", Effect Duration: 68
 2950	twirling Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2927,10 +2927,10 @@
 2955	tasty bite-sized twirling yam candy	1	awesome	
 2956	cocktail napkin	0		
 2957	wobbly rum barrel charrrm	0		
-2958	gigantic moldy red tube of cranberry Go-Goo	8	crappy	
+2958	moldy gigantic red tube of cranberry Go-Goo	8	crappy	
 2959	miser's rum barrel charrrm bracelet	0		Meat Drop: +10
-2960	miniature rotten single-serving herbal stuffing	2	crappy	
-2961	normal diet packet of tofurkey gravy	1	good	
+2960	rotten miniature single-serving herbal stuffing	2	crappy	
+2961	diet normal packet of tofurkey gravy	1	good	
 2962	normal tofurkey nugget	4	good	
 2963	narrow rigging shampoo	0		
 2964	ball polish	0		
@@ -2939,13 +2939,13 @@
 2967	electrified Swabbie&trade; swab	0		Effect: "In the Limelight", Effect Duration: 42
 2968	nitrogenated skewed olive Oil of Parrrlay	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 57
 2969	low-calorie adequate creamsicle	1	good	
-2970	watered-down lousy green cream stout	2	decent	
+2970	lousy watered-down green cream stout	2	decent	
 2971	gravedigger's dangerous curmudgel	0		Weapon Damage: +10, Spooky Damage: +10
 2972	grumpy man charrrm	0		
 2973	red sizzling grumpy man charrrm bracelet	0		Hot Damage: +10, Single Equip
 2974	tarrrnish charrrm	0		
 2975	Temple Grandin's tarrrnished charrrm bracelet of doom	0		Familiar Weight: +7, Spooky Spell Damage: +50, Single Equip
-2976	delicious special bilge wine	3	awesome	Effect: "Elemental Saucesphere", Effect Duration: 40
+2976	special delicious bilge wine	3	awesome	Effect: "Elemental Saucesphere", Effect Duration: 40
 2977	manspreader's witty rapier	0		Monster Level: +10
 2978	up-at-dawn yohohoyo of Tarzan	0		Experience (Muscle): +3, Adventures: +5
 2979	activated enhanced fish-liver oil	0		Effect: "Hot Blooded", Effect Duration: 13
@@ -2957,12 +2957,12 @@
 2985	bouncing smooth copper ha'penny charrrm bracelet	0		Moxie: +15
 2986	tongue charrrm	0		
 2987	Sherlock's stanky tongue charrrm bracelet	0		Stench Spell Damage: +25, Item Drop: +25, Single Equip
-2988	gray skewed bit of clingfilm	0		
+2988	skewed gray bit of clingfilm	0		
 2989	yellow jittery twirling deadly clingfilm trousers	0		Weapon Damage: +5, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
 2990	squat asbestos-lined extremely unsafe clingfilm cap	0		Weapon Damage Percent: +100, Hot Resistance: +5, Familiar Effect: "1xVolley, cap 37"
 2991	supercool clingfilm slippers	0		Moxie Percent: +20, Single Equip
 2992	ghostly clingfilm tangle	0		
-2993	bland bite-sized vinegar-soaked lemon slice	1	decent	
+2993	bite-sized bland vinegar-soaked lemon slice	1	decent	
 2994	non-diffused true grit	0		Effect: "Polka Face", Effect Duration: 32
 2995	cyan pulsating Annie Oakley's educational wizardly buoybottoms	0		Mysticality: +25, Experience: +1, Critical Hit Percent: +20, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	squat stanky grungy flannel shirt	0		Stench Spell Damage: +25
@@ -2987,7 +2987,7 @@
 3015	gilded key	0		
 3016	foot locker	0		
 3017	ornate chest	0		
-3018	blinking jittery gilded chest	0		
+3018	jittery blinking gilded chest	0		
 3019	all-purpose cleaner	0		
 3020	handful of sawdust	0		
 3021	stone triangle	0		
@@ -3001,7 +3001,7 @@
 3029	bad blurry red-headed corpse	3	decent	
 3030	artisanal triple-distilled kamicorpse-ee	6	EPIC	
 3031	drinkable watered-down corpsel	2	good	
-3032	distilled artisanal corpsebite	5	EPIC	
+3032	artisanal distilled corpsebite	5	EPIC	
 3033	fireproof pirate fledges	0		Hot Resistance: +3
 3034	spinning piece of thirteen	0		
 3035	rotten immense yellow pearl onion	7	crappy	
@@ -3013,7 +3013,7 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	red metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3044	red metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	toothsome jittery nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
 3046	bland nanite-infested candy cane	3	decent	Last Available: "2020-09"
 3047	toothsome nanite-infested fruitcake	3	awesome	Last Available: "2007-12"
@@ -3025,7 +3025,7 @@
 3053	mood ring	0		Last Available: "2007-02"
 3054	quantum blurry candy heart	0		Effect: "Shoesauce", Effect Duration: 21, Last Available: "2007-02"
 3055	enhanced huge cymbal syrup	0		Free Pull, Effect: "Celestial Body", Effect Duration: 30, Last Available: "2007-02"
-3056	scorching metallic foil cat ears	0		Hot Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	scorching metallic foil cat ears	0		Hot Damage: +25, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
 3059	huge theoretical string	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	laser targeting chip	0		Last Available: "2007-12"
 3077	blue hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	spinning dog trainer's marionette collective	0		Experience (familiar): +1, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	sharpshooter's roboduck-on-a-string of dire peril	0		Weapon Damage: +20, Critical Hit Percent: +10, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	bouncing fuchsia flame-wreathed forbidden biomechanical crimborg helmet	0		Spell Damage Percent: +50, Hot Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	bouncing fuchsia flame-wreathed forbidden biomechanical crimborg helmet	0		Spell Damage Percent: +50, Hot Spell Damage: +10, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	Usain Bolt's Sherlock's C.B.F.G.	0		Item Drop: +25, Initiative: +80, Last Available: "2007-12"
-3090	Herculean brainy biomechanical crimborg leg armor	0		Mysticality: +5, Experience (Muscle): +1, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	Herculean brainy biomechanical crimborg leg armor	0		Mysticality: +5, Experience (Muscle): +1, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	colloidal vitachoconutriment capsule	0		Effect: "Very Clean Guns", Effect Duration: 42, Last Available: "2007-12"
 3092	handmade hobby horse of the sewer	0		Stench Damage: +25, Last Available: "2007-12"
 3093	skewed ball-in-a-cup of the brazier	0		Hot Spell Damage: +25, Last Available: "2007-12"
@@ -3092,7 +3092,7 @@
 3120	blue wobbly divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
 3122	divine cracker	0		Last Available: "2008-01"
-3123	huge red divine champagne flute	0		Last Available: "2008-01"
+3123	red huge divine champagne flute	0		Last Available: "2008-01"
 3124	colloidal pressed fruitfilm	0		Effect: "Human-Slime Hybrid", Effect Duration: 47
 3125	diffused ionized piece of after eight	0		Effect: "Sleazy Jellied", Effect Duration: 24
 3126	hobo nickel	0		
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	low-calorie decent roasted marshmallow	1	good	
 3130	disc	0		Last Available: "2008-01"
-3131	flavorless half-sized yellow tin cup of mulligan stew	2	decent	
+3131	half-sized flavorless yellow tin cup of mulligan stew	2	decent	
 3132	jittery mansplainer's veiny flamin' bindle	0		Maximum HP: +10, Monster Level: +15
 3133	friendly thinker's freezin' bindle	0		Mysticality: +10, Familiar Weight: +3
 3134	Tesla stinkin' bindle of doom	0		Spooky Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
@@ -3134,11 +3134,11 @@
 3162	mirror El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	El Vibrato energy spear	0		
 3164	El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
-3165	maroon spinning broken El Vibrato drone	0		
+3165	spinning maroon broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	activated triple-Vulcanized extra-Vulcanized seal eyeball	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 66
-3169	tasty snack-sized spinning turtle soup	2	awesome	Effect: "[598]A Little Bit Evil"
+3169	snack-sized tasty spinning turtle soup	2	awesome	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	scandalous evil paper umbrella	0		Sleaze Damage: +5
@@ -3155,11 +3155,11 @@
 3183	extra-liquefied evil tomato juice of powerful power	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 60
 3184	unsweetened blinking evil eyedrops of the ermine	0		Effect: "Warm Belly", Effect Duration: 46
 3185	colloidal colloidal evil ointment of the occult	0		Effect: "Neuromancy", Effect Duration: 37
-3186	alkaline tumbling green spinning evil serum of sarcasm	0		Effect: "Your Interest is Peaked", Effect Duration: 49
+3186	alkaline spinning tumbling green evil serum of sarcasm	0		Effect: "Your Interest is Peaked", Effect Duration: 49
 3187	activated evil philter of phorce	0		Effect: "Spirit Bubble", Effect Duration: 36
-3188	watered-down lousy spinning an evil sump'm sump'm	2	decent	
-3189	tolerable triple-distilled evil ducha de oro	8	good	
-3190	perfectly mixed boozy huge evil horizontal tango	5	EPIC	
+3188	lousy watered-down spinning an evil sump'm sump'm	2	decent	
+3189	triple-distilled tolerable evil ducha de oro	8	good	
+3190	boozy perfectly mixed huge evil horizontal tango	5	EPIC	
 3191	drinkable evil roll in the hay	4	good	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3193,15 +3193,15 @@
 3221	jittery gator skin	0		
 3222	electrified supercharged gatorskin umbrella	0		Maximum MP Percent: +30, MP Regen Min: 3, MP Regen Max: 5
 3223	sewer nuggets	0		
-3224	fuchsia tumbling sewer wad	0		
+3224	tumbling fuchsia sewer wad	0		
 3225	irresponsibly strong tolerable bottle of sewage schnapps	9	good	
 3226	aged weak bottle of Ooze-O	2	awesome	
 3227	normal blurry C.H.U.M. chum	3	good	
-3228	enchanted moldy cyan unfortunate dumplings	4	crappy	Effect: "Empty Inside", Effect Duration: 45
+3228	moldy enchanted cyan unfortunate dumplings	4	crappy	Effect: "Empty Inside", Effect Duration: 45
 3229	huge decaying goldfish liver	0		
 3230	extra-chilled fuchsia oil of oiliness	0		Effect: "Ghost Finger", Effect Duration: 29
 3231	tattered paper crown of the cougar	0		Moxie: +20, Familiar Effect: "1xSombrero, cap 15"
-3232	normal small vanilla-frosted king cake	2	good	Last Available: "2008-03"
+3232	small normal vanilla-frosted king cake	2	good	Last Available: "2008-03"
 3233	teal inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	twirling noodle	0		
@@ -3240,9 +3240,9 @@
 3268	triple-irradiated activated squat handful of Crotchety Pine needles	0		Effect: "Tasting the Rainbow", Effect Duration: 44
 3269	double-ionized double-chilled lime green lump of Saccharine Maple sap	0		Effect: "Astral Shell", Effect Duration: 41
 3270	flattened altered huge handful of Laughing Willow bark	0		Effect: "Oxygenated Blood", Effect Duration: 26
-3271	mirror crotchety pants of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	mirror crotchety pants of the brazier	0		Hot Spell Damage: +25, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	stiffened Saccharine Maple pendant	0		Damage Reduction: 1, Conditional Skill (Equipped): "Spray Sap"
-3273	wobbly fortified willowy bonnet	0		Damage Absorption: +60, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	wobbly fortified willowy bonnet	0		Damage Absorption: +60, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3250,9 +3250,9 @@
 3278	beefcake's studded belt	0		Muscle: +25, Last Available: "2008-04"
 3279	personal massager	0		Last Available: "2008-04"
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
-3281	narrow maroon plasma ball	0		Last Available: "2008-04"
+3281	maroon narrow plasma ball	0		Last Available: "2008-04"
 3282	ghostly shaking fireproof stick-on eyebrow piercing	0		Hot Resistance: +3, Last Available: "2008-04"
-3283	snack-sized normal salad	2	good	
+3283	normal snack-sized salad	2	good	
 3284	executive brainy C.H.U.M. lantern	0		Mysticality: +5, Meat Drop: +40
 3285	narrow yellow chilly C.H.U.M. knife	0		Cold Damage: +5
 3286	resourceful Frosty's snowball sack	0		Maximum MP: +50
@@ -3291,7 +3291,7 @@
 3319	blinking flame-wreathed Mr. Joe's bangles	0		Hot Spell Damage: +10, Single Equip
 3320	miser's frayed rope belt	0		Meat Drop: +10, Single Equip
 3321	bouncing packet of mayfly bait	0		Last Available: "2008-05"
-3322	hale Samson's mayfly bait necklace	0		Experience (Muscle): +5, Maximum HP: +20, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	hale Samson's mayfly bait necklace	0		Experience (Muscle): +5, Maximum HP: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	bouncing Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	tolerable jar of fermented pickle juice	3	good	
@@ -3320,10 +3320,10 @@
 3348	twirling mattress	0		
 3349	dinged-up triangle	0		
 3350	enchanted artisanal Ralph IX cognac	3	super ultra mega turbo EPIC	Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 20
-3351	spinning maroon tumbling llama lama cria	0		Free Pull, Last Available: "2008-06"
+3351	maroon spinning tumbling llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	super-activated llama lama gong	0		Effect: "Vitali Tea", Effect Duration: 68, Last Available: "2008-06"
-3354	toothsome snack-sized banana-frosted king cake	2	awesome	Last Available: "2008-08"
+3354	snack-sized toothsome banana-frosted king cake	2	awesome	Last Available: "2008-08"
 3355	blurry brown plastic baby of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2008-08"
 3356	skewed plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3367,8 +3367,8 @@
 3395	blinking therapeutic educational Hodgman's porkpie hat	0		Experience: +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	blinking narrow inspector's nasty Hodgman's lobsterskin pants	0		Stench Damage: +5, Item Drop: +15, Familiar Effect: "atk, 1xPotato"
 3397	ghostly brawny Hodgman's bow tie of Flo-Jo	0		Muscle Percent: +20, Initiative: +100, Single Equip
-3398	acceptable practically non-alcoholic Hodgman's blanket	1	good	
-3399	special tolerable fortified jar of squeeze	5	good	Effect: "Morninja", Effect Duration: 40
+3398	practically non-alcoholic acceptable Hodgman's blanket	1	good	
+3399	special fortified tolerable jar of squeeze	5	good	Effect: "Morninja", Effect Duration: 40
 3400	rotten diet bowl of fishysoisse	1	crappy	
 3401	ionized deadly lampshade	0		Effect: "In the Saucestream", Effect Duration: 46
 3402	electrified concentrated garbage juice	0		Effect: "The Dinsey Spirit", Effect Duration: 27
@@ -3381,17 +3381,17 @@
 3409	knitted Hodgman's garbage sticker	0		Cold Resistance: +3
 3410	upside-down olive baleful Hodgman's detector	0		Spell Damage: +25
 3411	Usain Bolt's Hodgman's cane	0		Initiative: +80
-3412	huge yellow Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
+3412	yellow huge Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
 3413	bouncing Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	ghostly Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	blurry hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	Vulcanized warmed mirror sterno-flavored Hob-O	0		Effect: "Egg Burps", Effect Duration: 34
 3423	flattened ionized frostbite-flavored Hob-O	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 61
 3424	dry pressed fry-oil-flavored Hob-O	0		Effect: "Cockroach Scurry", Effect Duration: 39
 3425	anodized extra-anodized garbage-juice-flavored Hob-O	0		Effect: "Tennis Elbow-wow", Effect Duration: 18
-3426	frozen irradiated teal jittery narrow strawberry-flavored Hob-O	0		Effect: "Spirit of Alph", Effect Duration: 54
+3426	frozen irradiated jittery teal narrow strawberry-flavored Hob-O	0		Effect: "Spirit of Alph", Effect Duration: 54
 3427	lime green roll of Hob-Os	0		
 3428	adjusted teal upside-down Everlasting Deckswabber	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 38
 3430	huge bindle of joy	0		
@@ -3423,14 +3423,14 @@
 3456	educational trusty torch	0		Experience: +1, Last Available: "2011-12"
 3457	huge greasy Junior Adventurer's merit badge	0		Sleaze Spell Damage: +10
 3458	aerosolized tarnished skewed STYX deodorant body spray	0		Effect: "Memory of Resilience", Effect Duration: 57
-3459	distilled drinkable spinning fuchsia white-label gin	5	good	
+3459	drinkable distilled fuchsia spinning white-label gin	5	good	
 3460	immense yummy narrow tin rations	8	awesome	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
 3463	acceptable bottle of sake	3	good	
 3464	vibrating round pebble	0		Maximum MP Percent: +10
-3465	enchanted bland huge Bash-&#332;s cereal	8	decent	Effect: "Feline Ferocity", Effect Duration: 15, Wiki Name: "Bash-Os cereal"
-3466	twirling Samson's brainy haiku katana of Leguizamo	0		Mysticality: +5, Experience (Muscle): +5, Monster Level: +20, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3465	enchanted huge bland Bash-&#332;s cereal	8	decent	Effect: "Feline Ferocity", Effect Duration: 15, Wiki Name: "Bash-Os cereal"
+3466	twirling Samson's brainy haiku katana of Leguizamo	0		Mysticality: +5, Experience (Muscle): +5, Monster Level: +20, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	veiny plastic baby	0		Maximum HP: +10, Single Equip, Last Available: "2008-12"
 3469	flavorless tiny blueberry-frosted king cake	1	decent	Last Available: "2008-12"
@@ -3454,7 +3454,7 @@
 3487	rough fish scale	0		
 3488	cyan pristine fish scale	0		
 3489	small flavorless beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
-3490	flavorless enchanted glistening fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
+3490	enchanted flavorless glistening fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
 3491	stale tumbling slick fish meat	4	decent	Effect: "Fishy", Effect Duration: 5
 3492	ruddy fish scimitar of the detective	0		Maximum HP Percent: +40, Item Drop: +20
 3493	frosty Jim Carey's fish stick	0		Monster Level: +25, Cold Spell Damage: +10
@@ -3462,12 +3462,12 @@
 3495	non-vacuum-sealed activated fuchsia mirror sea salt crystal	0		Effect: "Cat-Alyzed", Effect Duration: 23
 3496	polarized ghostly bazookafish bubble gum	0		Effect: "Really Deep Breath", Effect Duration: 53
 3497	perfectly mixed blinking bottle of Pete's Sake	4	EPIC	
-3498	twirling invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	narrow huge witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	twirling invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	huge narrow witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	half-sized stale canap&eacute;s	2	decent	
 3502	dehydrated pulsating thermos of brew	1	good	Last Available: "2011-12"
-3503	perfectly mixed practically non-alcoholic glass of brandy	1	super ultra mega EPIC	Last Available: "2011-12"
+3503	practically non-alcoholic perfectly mixed glass of brandy	1	super ultra mega EPIC	Last Available: "2011-12"
 3504	French slippers	0		
 3505	skewed rosy-cheeked LWA ring	0		Maximum HP Percent: +30
 3506	LARP membership card	0		Last Available: "2008-10"
@@ -3510,8 +3510,8 @@
 3543	twirling avaricious depleted Grimacite gravy boat of the pedagogue	0		Experience: +3, Meat Drop: +30, Last Available: "2011-12"
 3544	shaking inspector's wholesome depleted Grimacite weightlifting belt	0		Maximum HP Percent: +10, Item Drop: +15, Single Equip, Last Available: "2011-12"
 3545	stanky depleted Grimacite grappling hook of chilblains	0		Cold Damage: +25, Stench Spell Damage: +25, Single Equip, Last Available: "2011-12"
-3546	bouncing depleted Grimacite ninja mask of the pedagogue of doom	0		Experience: +3, Spooky Spell Damage: +50, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	Usain Bolt's Jack Frost's depleted Grimacite shinguards	0		Cold Spell Damage: +50, Initiative: +80, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	bouncing depleted Grimacite ninja mask of the pedagogue of doom	0		Experience: +3, Spooky Spell Damage: +50, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	Usain Bolt's Jack Frost's depleted Grimacite shinguards	0		Cold Spell Damage: +50, Initiative: +80, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	mirror jittery bouncing frightening depleted Grimacite astrolabe of chilblains	0		Cold Damage: +25, Spooky Damage: +5, Single Equip, Last Available: "2011-12"
 3549	purple energetic hardened KoL Con Cinco Pi&ntilde;ata Bat	0		Damage Reduction: 3, Maximum MP Percent: +20, Softcore Only, Last Available: "2008-09"
 3550	ghostly electrified propeller beanie	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, cap 7"
@@ -3520,7 +3520,7 @@
 3553	mirror soggy seed packet	0		
 3554	glob of slime	0		
 3555	moldy huge sea carrot	3	crappy	
-3556	rotten gigantic skewed sea cucumber	9	crappy	
+3556	gigantic rotten skewed sea cucumber	9	crappy	
 3557	yummy sea avocado	3	awesome	
 3558	normal green sea lychee	4	good	
 3559	rotten diet sea tangelo	1	crappy	
@@ -3528,8 +3528,8 @@
 3561	energized colloidal teal pressurized potion of puissance	0		Effect: "Cancer Rising", Effect Duration: 49
 3562	diffused extra-energized wobbly pressurized potion of perspicacity	0		Effect: "Blessing of Charcoatl", Effect Duration: 50
 3563	flattened oxidized blurry pressurized potion of pulchritude	0		Effect: "PERL of Great Price", Effect Duration: 42
-3564	practically non-alcoholic bad ghostly berry-infused sake	1	decent	
-3565	high-proof artisanal citrus-infused sake	10	EPIC	
+3564	bad practically non-alcoholic ghostly berry-infused sake	1	decent	
+3565	artisanal high-proof citrus-infused sake	10	EPIC	
 3566	perfectly mixed melon-infused sake	4	EPIC	
 3567	upside-down slab of sponge	0		
 3568	blurry zippy Oprah's sponge helmet of the ox	0		Muscle: +20, Maximum MP Percent: +50, Initiative: +20, Familiar Effect: "atk, 1xFairy"
@@ -3552,7 +3552,7 @@
 3586	mediocre oozenog	4	decent	Last Available: "2008-12"
 3587	polarized deionized jittery sugar plum	0		Effect: "Sinuses For Miles", Effect Duration: 52, Last Available: "2008-12"
 3588	dry skewed sugar banana	0		Effect: "Empty Inside", Effect Duration: 55, Last Available: "2008-12"
-3589	non-warmed huge narrow sugar lime	0		Effect: "Ninja, Please", Effect Duration: 69, Last Available: "2008-12"
+3589	non-warmed narrow huge sugar lime	0		Effect: "Ninja, Please", Effect Duration: 69, Last Available: "2008-12"
 3590	quadruple-concentrated red sugar cherry	0		Effect: "Ginger Snapped", Effect Duration: 42, Last Available: "2008-12"
 3591	nasty Mer-kin hookspear of horror	0		Stench Damage: +5, Spooky Spell Damage: +25
 3592	upside-down Mer-kin takebag	0		Item Drop: +5
@@ -3574,22 +3574,22 @@
 3608	mirror live nautical mine	0		
 3609	ghostly das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
-3611	anodized quadruple-diffused liquefied shaking bouncing sea grease	0		Effect: "Eagle Eyes", Effect Duration: 39
-3612	fuchsia upside-down sturdy Crimbo crate	0		Last Available: "2008-12"
+3611	anodized quadruple-diffused liquefied bouncing shaking sea grease	0		Effect: "Eagle Eyes", Effect Duration: 39
+3612	upside-down fuchsia sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	green wobbly battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	teal pulsing flesh	0		Last Available: "2008-12"
 3617	quadruple-pressed blue unstable DNA	0		Effect: "La Bamba", Effect Duration: 61, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	bouncing wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	tumbling nippy parasitic claw	0		Cold Damage: +10, Last Available: "2008-12"
-3625	upside-down rosy-cheeked parasitic tentacles	0		Maximum HP Percent: +30, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	brainy parasitic headgnawer	0		Mysticality: +5, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	upside-down rosy-cheeked parasitic tentacles	0		Maximum HP Percent: +30, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	brainy parasitic headgnawer	0		Mysticality: +5, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	squat steel-toed parasitic strangleworm	0		Damage Reduction: 9, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	maroon burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	supercharged Da Vinci's elven socks	0		Experience (Mysticality): +5, Maximum MP Percent: +30, Last Available: "2008-12"
 3634	prompt elven gloves of chilblains	0		Cold Damage: +25, Adventures: +3, Last Available: "2008-12"
-3635	inspector's banded festive holiday hat	0		Damage Absorption: +100, Item Drop: +15, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	inspector's banded festive holiday hat	0		Damage Absorption: +100, Item Drop: +15, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	huge Usain Bolt's Temple Grandin's patent shoes	0		Familiar Weight: +7, Initiative: +80, Last Available: "2008-12"
 3637	perfumed educational gray bow tie	0		Experience: +1, Stench Resistance: +5, Last Available: "2008-12"
 3638	gray squat occult penguin thesaurus of the overflowing toilet	0		Spell Damage Percent: +25, Stench Spell Damage: +50, Last Available: "2008-12"
@@ -3609,14 +3609,14 @@
 3643	wobbly pufferfish spine	0		
 3644	lime green Jim Carey's depleted Grimacite kneecapping stick	0		Monster Level: +25, Last Available: "2007-06"
 3645	acceptable canteen of wine	4	good	Last Available: "2008-12"
-3646	jumbo adequate elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
+3646	adequate jumbo elven <i>limbos</i> gingerbread	5	good	Last Available: "2008-12"
 3647	shaking elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	adequate enchanted toast with jam	3	good	Effect: "Liquid Courage", Effect Duration: 20, Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	bad elven moonshine	3	decent	Last Available: "2008-12"
-3653	decent bite-sized knuckle sandwich	1	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	bite-sized decent knuckle sandwich	1	good	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	Sinatra's groovy psycho sweater	0		Moxie Percent: +10, Experience (Moxie): +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	shaking scorching plastic Mob Penguin	0		Hot Damage: +25, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	smelly plastic strand of DNA	0		Stench Spell Damage: +10, Last Available: "2008-12"
 3660	clever plastic chunk of depleted Grimacite	0		Maximum MP: +20, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	olive wicked Putty mitre	0		Spell Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	resourceful stiffened Putty leotard	0		Damage Reduction: 1, Maximum MP: +50, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	olive wicked Putty mitre	0		Spell Damage: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	resourceful stiffened Putty leotard	0		Damage Reduction: 1, Maximum MP: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	executive Putty ball	0		Meat Drop: +40, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	miser's asbestos-lined shellacked Putty snake	0		Damage Reduction: 7, Hot Resistance: +5, Meat Drop: +10, Softcore Only, Last Available: "2009-01"
@@ -3641,18 +3641,18 @@
 3675	blinking narrow Mer-kin pressureglobe	0		
 3676	blurry Mer-kin foodbucket	0		
 3677	spinning Samson's diving muff	0		Experience (Muscle): +5, Single Equip
-3678	weak smooth salinated mint julep	2	awesome	
+3678	smooth weak salinated mint julep	2	awesome	
 3679	ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
-3683	twirling ghostly map to the Marinara Trench	0		
-3684	flavorless snack-sized tempura carrot	2	decent	
-3685	miniature enchanted decent cyan tempura cucumber	2	good	Effect: "Litterboxing", Effect Duration: 50
-3686	half-sized yummy tempura avocado	2	awesome	
+3683	ghostly twirling map to the Marinara Trench	0		
+3684	snack-sized flavorless tempura carrot	2	decent	
+3685	miniature decent enchanted cyan tempura cucumber	2	good	Effect: "Litterboxing", Effect Duration: 50
+3686	yummy half-sized tempura avocado	2	awesome	
 3687	yummy twirling sea broccoli	3	awesome	
 3688	normal sea cauliflower	3	good	
-3689	huge enchanted yummy tempura broccoli	7	awesome	Effect: "The Dinsey Spirit", Effect Duration: 45
+3689	huge yummy enchanted tempura broccoli	7	awesome	Effect: "The Dinsey Spirit", Effect Duration: 45
 3690	special bland narrow tempura cauliflower	3	decent	Effect: "The Grass...  Is Blue...", Effect Duration: 40
 3691	miniature stale sea blueberry	2	decent	
 3692	half-sized adequate mirror sea persimmon	2	good	
@@ -3662,7 +3662,7 @@
 3696	pulsating anemone nematocyst	0		
 3697	lime green high-pressure seltzer bottle	0		
 3698	velcro ore	0		
-3699	wobbly gray teflon ore	0		
+3699	gray wobbly teflon ore	0		
 3700	vinyl ore	0		
 3701	map to Anemone Mine	0		
 3702	marine aquamarine	0		
@@ -3691,7 +3691,7 @@
 3725	foggy glass globe	0		
 3726	possessed tomato	0		
 3727	Nardz energy beverage	0		
-3728	narrow skewed mirror pile of coins	0		
+3728	skewed mirror narrow pile of coins	0		
 3729	hand grenegg	0		
 3730	red caret	0		
 3731	resourceful glass gnoll eye	0		Maximum MP: +50
@@ -3705,35 +3705,35 @@
 3739	jittery Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
-3742	galvanized tumbling skewed jellyfish gel	0		Effect: "Sugary World View", Effect Duration: 64
+3742	galvanized skewed tumbling jellyfish gel	0		Effect: "Sugary World View", Effect Duration: 64
 3743	unstable quark	0		
 3744	blurry software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
-3746	tumbling fuchsia vampire pearl	0		
+3746	fuchsia tumbling vampire pearl	0		
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	Vulcanized electrified concoction of clumsiness	0		Effect: "Updated", Effect Duration: 58
 3750	toasty vampire pearl earring	0		Hot Damage: +5, Single Equip
-3751	diet decent chocolate chip brownies	1	good	
+3751	decent diet chocolate chip brownies	1	good	
 3753	huge Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	concentrated twirling love song of vague ambiguity	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 32, Last Available: "2009-02"
 3755	triple-enhanced quadruple-anodized love song of smoldering passion	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 11, Last Available: "2009-02"
-3756	quantum jittery spinning love song of icy revenge	0		Effect: "Burnt 'n' Turnt", Effect Duration: 22, Last Available: "2009-02"
+3756	quantum spinning jittery love song of icy revenge	0		Effect: "Burnt 'n' Turnt", Effect Duration: 22, Last Available: "2009-02"
 3757	quantum maroon love song of sugary cuteness	0		Effect: "This Is Where You're a Viking", Effect Duration: 30, Last Available: "2009-02"
 3758	adjusted galvanized wobbly love song of disturbing obsession	0		Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2009-02"
 3759	extra-dry extra-anodized extra-energized love song of naughty innuendo	0		Effect: "Thunderheart", Effect Duration: 38, Last Available: "2009-02"
 3760	flattened mirror breath mint	0		Effect: "Super-Electrified", Effect Duration: 13
 3761	vampire pearl ring of the wise owl	0		Mysticality: +20, Single Equip
 3762	vibrating vampire pearl necklace	0		Maximum MP Percent: +10, Single Equip
-3763	lousy practically non-alcoholic blurry slug of vodka	1	decent	
-3764	weak acceptable slug of rum	2	good	
+3763	practically non-alcoholic lousy blurry slug of vodka	1	decent	
+3764	acceptable weak slug of rum	2	good	
 3765	artisanal slug of shochu	4	EPIC	
 3766	artisanal weak green screwdiver	2	EPIC	
 3767	drinkable dew yoana lei	4	good	
 3768	acceptable lychee chuhai	3	good	
-3769	tolerable watered-down twirling salacious screwdiver	2	good	
+3769	watered-down tolerable twirling salacious screwdiver	2	good	
 3770	mediocre enchanted spinning dew yoana salacious lei	3	decent	Effect: "Mortarfied", Effect Duration: 40
-3771	high-proof bad olive salacious lychee chuhai	8	decent	
-3772	drinkable enchanted weak huge Alewife&trade; Ale	2	good	Effect: "Memory of Strength", Effect Duration: 50
+3771	bad high-proof olive salacious lychee chuhai	8	decent	
+3772	weak drinkable enchanted huge Alewife&trade; Ale	2	good	Effect: "Memory of Strength", Effect Duration: 50
 3773	narrow seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3748,13 +3748,13 @@
 3784	paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
-3787	fuchsia bouncing wine-soaked bone chips	0		Class: "Pastamancer"
+3787	bouncing fuchsia wine-soaked bone chips	0		Class: "Pastamancer"
 3788	jittery crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
-3800	wobbly olive shaking aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	narrow upside-down crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3800	shaking olive wobbly aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
+3801	upside-down narrow crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	up-at-dawn family-friendly hale Mer-kin roundshield	0		Maximum HP: +20, Sleaze Resistance: +1, Adventures: +5, Damage Reduction: 14
 3804	auspicious Mer-kin breastplate of Gandalf	0		Spell Critical Percent: +20, Item Drop: +10
 3805	sinister Mer-kin sneakmask of the storm	0		Spell Damage: +10, Maximum MP Percent: +40, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3764,7 +3764,7 @@
 3809	twirling Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	yellow Mer-kin stashbox	0		
-3812	stale jumbo wobbly chocolate-frosted king cake	5	decent	Last Available: "2009-06"
+3812	jumbo stale wobbly chocolate-frosted king cake	5	decent	Last Available: "2009-06"
 3813	Van der Graaf plastic baby	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2009-06"
 3815	jittery midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
@@ -3787,7 +3787,7 @@
 3833	smooth fruity girl swill	4	awesome	
 3834	artisanal skewed blended swill	3	EPIC	
 3835	costume wardrobe	0		Softcore Only
-3836	shaking aromatic scandalous Sinatra's Elvish sunglasses	0		Experience (Moxie): +5, Sleaze Damage: +5, Stench Resistance: +1, Item Drop: +5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	shaking aromatic scandalous Sinatra's Elvish sunglasses	0		Experience (Moxie): +5, Sleaze Damage: +5, Stench Resistance: +1, Item Drop: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	wool anniversary safety glass vest	0		Cold Resistance: +1
 3838	spinning savvy anniversary burlap belt	0		Mysticality Percent: +20
 3839	yellow reassuring anniversary balsa wood socks	0		Spooky Resistance: +1
@@ -3831,7 +3831,7 @@
 3877	huge narrow burst hellseal brain	0		
 3878	green hellseal sinew	0		
 3879	wobbly torn hellseal sinew	0		
-3880	wobbly squat hellseal disguise	0		
+3880	squat wobbly hellseal disguise	0		
 3881	twirling greedy fouet de tortue-dressage of James Dean	0		Experience (Moxie): +3, Meat Drop: +20, Conditional Skill (Equipped): "Apprivoisez la tortue"
 3882	encoded cult documents	0		
 3883	cult memo	0		
@@ -3850,7 +3850,7 @@
 3896	diffused diffused vial of slime	0		Effect: "You Liver", Effect Duration: 34
 3897	wet ionized vial of brown slime	0		Effect: "Walberg's Dim Bulb", Effect Duration: 55
 3898	bottle of G&uuml;-Gone	0		
-3901	pulsating narrow seal-blubber candle	0		Class: "Seal Clubber"
+3901	narrow pulsating seal-blubber candle	0		Class: "Seal Clubber"
 3902	pulsating figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	figurine of a baby seal	0		Class: "Seal Clubber"
 3904	fuchsia figurine of an armored seal	0		Class: "Seal Clubber"
@@ -3862,7 +3862,7 @@
 3910	narrow figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
-3913	watered-down perfectly mixed blended swill with a fly in it	2	EPIC	
+3913	perfectly mixed watered-down blended swill with a fly in it	2	EPIC	
 3914	olive turtle wax	0		
 3915	personal trainer's turtle wax shield	0		Experience Percent (Muscle): +10, Damage Reduction: 2
 3916	hale turtle wax helmet	0		Maximum HP: +20, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
@@ -3935,7 +3935,7 @@
 3983	skewed dueling turtle	0		
 3984	double-paned forbidden dueling banjo	0		Spell Damage Percent: +50, Cold Resistance: +5
 3985	gray soup turtle	0		
-3986	maroon blurry samurai turtle	0		
+3986	blurry maroon samurai turtle	0		
 3987	red lion tamer's samurai turtle helmet of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Familiar Effect: "atk, 1xPotato, cap 6"
 3988	turtle shell	0		
 3989	gray turtle shell powder	0		
@@ -3990,15 +3990,15 @@
 4038	bad slimy fermented bile bladder	3	decent	
 4039	modified pulsating slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	shaking friendly baleful pig-iron helm	0		Spell Damage: +25, Familiar Weight: +3, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	ruddy brawny pig-iron shinguards	0		Muscle Percent: +20, Maximum HP Percent: +40, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	shaking friendly baleful pig-iron helm	0		Spell Damage: +25, Familiar Weight: +3, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	ruddy brawny pig-iron shinguards	0		Muscle Percent: +20, Maximum HP Percent: +40, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	tumbling careful pig-iron bracers of Tarzan	0		Experience (Muscle): +3, Monster Level: -10, Single Equip, Last Available: "2009-06"
 4044	tumbling wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	squat wumpus-hair whip of the brazier	0		Hot Spell Damage: +25, Last Available: "2009-06"
-4048	wobbly scandalous hale brainy wumpus-hair wig	0		Mysticality: +5, Maximum HP: +20, Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	gravedigger's Oprah's wumpus-hair loincloth of the sweet-tooth	0		Maximum MP Percent: +50, Spooky Damage: +10, Candy Drop: +100, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	wobbly scandalous hale brainy wumpus-hair wig	0		Mysticality: +5, Maximum HP: +20, Sleaze Damage: +5, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	gravedigger's Oprah's wumpus-hair loincloth of the sweet-tooth	0		Maximum MP Percent: +50, Spooky Damage: +10, Candy Drop: +100, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	MacGyver's wumpus-hair sweater of the businessman	0		Maximum MP: +100, Meat Drop: +50, Last Available: "2009-06"
 4051	stanky ring of teleportation	0		Stench Spell Damage: +25, Single Equip
 4052	skewed glass of baboon milk	1	good	Last Available: "2009-06"
@@ -4014,7 +4014,7 @@
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
-4065	huge twirling Spacefleet Communicator Badge	0		Last Available: "2009-06"
+4065	twirling huge Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
@@ -4034,7 +4034,7 @@
 4082	green crafty dance instructor's pernicious cudgel	0		Experience Percent (Moxie): +10, Maximum MP: +10, Slime Hates It: +1
 4083	bland red cupcake-in-a-cup	3	decent	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	diet tasty cyan skewed protein paste	1	awesome	Last Available: "2009-06"
+4085	tasty diet cyan skewed protein paste	1	awesome	Last Available: "2009-06"
 4086	manspreader's smooth cyber-mattock	0		Moxie: +15, Monster Level: +10, Last Available: "2009-06"
 4087	maroon facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4081,11 +4081,11 @@
 4129	rosy-cheeked boxer's hardened slime belt of the cougar	0		Moxie: +20, Muscle Percent: +10, Maximum HP Percent: +30, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	boiled skewed jittery boot plant	1	EPIC	Last Available: "2009-06"
-4132	artisanal special teal sham champagne	4	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 40, Last Available: "2009-06"
-4133	pickled bouncing narrow blurry tempura air	0		Effect: "Sugar, Hello", Effect Duration: 24
+4132	special artisanal teal sham champagne	4	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 40, Last Available: "2009-06"
+4133	pickled blurry narrow bouncing tempura air	0		Effect: "Sugar, Hello", Effect Duration: 24
 4134	boiled boiled vacuum-sealed gray shaking pressurized potion of pneumaticity	0		Effect: "Good Motivator", Effect Duration: 28
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	upside-down frightening personal trainer's Bag o' Tricks of James Dean of Leguizamo	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Monster Level: +20, Spooky Damage: +5, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	upside-down frightening personal trainer's Bag o' Tricks of James Dean of Leguizamo	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Monster Level: +20, Spooky Damage: +5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	gray slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4112,7 +4112,7 @@
 4160	triple-distilled hand-crafted mirror pebblebr&auml;u	7	EPIC	Last Available: "2009-09"
 4161	spoiled gigantic rocky road ice cream	10	crappy	Last Available: "2009-09"
 4162	pulsating jittery extra-strength rubber bands	0		Familiar Weight: +5
-4163	alkaline pulsating huge children of the candy corn	0		Effect: "Slimy Hands", Effect Duration: 27
+4163	alkaline huge pulsating children of the candy corn	0		Effect: "Slimy Hands", Effect Duration: 27
 4164	modified olive Good 'n' Slimy	0		Effect: "Spirit Bubble", Effect Duration: 29
 4165	asbestos-lined flame-wreathed dance instructor's Staff of the Soupbone	0		Experience Percent (Moxie): +10, Hot Spell Damage: +10, Hot Resistance: +5
 4166	Jim Carey's Voluminous Radio Pants	0		Monster Level: +25, Familiar Effect: "2xGhoul, cap 37"
@@ -4130,8 +4130,8 @@
 4178	beefcake's sugar shotgun	0		Muscle: +25, Last Available: "2009-09"
 4179	tumbling Socratic sugar shillelagh	0		Experience (Mysticality): +1, Last Available: "2009-09"
 4180	blue sugar shank of the sweet-tooth	0		Candy Drop: +100, Last Available: "2009-09"
-4181	dog trainer's mansplainer's sugar chapeau of the brute	0		Muscle Percent: +30, Monster Level: +15, Experience (familiar): +1, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	green smooth sugar shorts	0		Moxie: +15, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	dog trainer's mansplainer's sugar chapeau of the brute	0		Muscle Percent: +30, Monster Level: +15, Experience (familiar): +1, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	green smooth sugar shorts	0		Moxie: +15, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	jittery slime convention flyers	0		
@@ -4172,13 +4172,13 @@
 4220	green S.A.V.E. flyer	0		
 4221	MacGyver's yield shield	0		Maximum MP: +100, Damage Reduction: 6, Last Available: "2009-09"
 4222	map to the Skate Park	0		
-4223	bouncing huge squamous polyp	0		Free Pull, Last Available: "2011-12"
+4223	huge bouncing squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
 4225	roller skate doll	0		
 4226	Star of Bravery of extreme caution	0		Monster Level: -25, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	shaking perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	mirror amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	mirror amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	squat can of sterno	0		
 4237	sharpshooter's cheese-slicer	0		Critical Hit Percent: +10
-4238	rotten half-sized ghostly squat beef jerky	2	crappy	
+4238	half-sized rotten ghostly squat beef jerky	2	crappy	
 4239	squat maroon dance instructor's pipe wrench	0		Experience Percent (Moxie): +10
 4240	ionized alkaline blue gun cleaning kit	0		Effect: "Motion", Effect Duration: 11
 4241	sizzling sleep mask	0		Hot Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4207,14 +4207,14 @@
 4255	tumbling Wolfman Nardz	0		Last Available: "2009-10"
 4256	aerosolized aerosolized sap	0		Effect: "items.enh", Effect Duration: 62, Last Available: "2009-10"
 4257	blurry petrified wood	0		Last Available: "2009-10"
-4258	yummy miniature chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
+4258	miniature yummy chocolate-covered scarab beetle	2	awesome	Last Available: "2009-10"
 4259	special bad mulled cider	3	decent	Effect: "Eye of the Lihc", Effect Duration: 35, Last Available: "2009-10"
-4260	jittery wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	squat mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	jittery wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	squat mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	olive jittery Ax of L'rose	0		Last Available: "2009-10"
-4264	shellacked bark boxers	0		Damage Reduction: 7, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	twirling wholesome bark beret	0		Maximum HP Percent: +10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	shellacked bark boxers	0		Damage Reduction: 7, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	twirling wholesome bark beret	0		Maximum HP Percent: +10, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	narrow huge Jack Frost's bark bracelet	0		Cold Spell Damage: +50, Single Equip
 4267	knitted foul-smelling Krakrox's Loincloth	0		Stench Damage: +10, Cold Resistance: +3, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	fortified dangerous Galapagosian Cuisses	0		Weapon Damage: +10, Damage Absorption: +60, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	rosewater-soaked toasty savvy Ass-Stompers of Violence	0		Mysticality Percent: +20, Hot Damage: +5, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	mirror Jeselnik's friendly MacGyver's Brand of Violence	0		Maximum MP: +100, Familiar Weight: +3, Sleaze Damage: +25, Conditional Skill (Equipped): "Brand"
 4299	up-at-dawn inspector's Jeselnik's Novelty Belt Buckle of Violence	0		Sleaze Damage: +25, Item Drop: +15, Adventures: +5, Single Equip
-4300	padded grievous Lens of Violence of the dark arts	0		Weapon Damage Percent: +50, Spell Damage Percent: +100, Damage Absorption: +20, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	padded grievous Lens of Violence of the dark arts	0		Weapon Damage Percent: +50, Spell Damage Percent: +100, Damage Absorption: +20, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	Jim Carey's Samson's Pigsticker of Violence of the cheetah	0		Experience (Muscle): +5, Monster Level: +25, Initiative: +60
-4302	Tesla Jodhpurs of Violence of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	Tesla Jodhpurs of Violence of wisdom of Flo-Jo	0		Mysticality: +15, Initiative: +100, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	mirror gravedigger's Newton's Cold Stone of Hatred of the cougar	0		Moxie: +20, Experience (Mysticality): +3, Spooky Damage: +10, Conditional Skill (Equipped): "Chilling Grip"
 4304	banded strapping Girdle of Hatred of wisdom	0		Muscle: +5, Mysticality: +15, Damage Absorption: +100, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	skewed wholesome steel-toed Fonzie's Staff of Simmering Hatred	0		Experience (Moxie): +1, Damage Reduction: 9, Maximum HP Percent: +10
-4306	scorching sharpshooter's Pantaloons of Hatred of wisdom	0		Mysticality: +15, Critical Hit Percent: +10, Hot Damage: +25, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	scorching sharpshooter's Pantaloons of Hatred of wisdom	0		Mysticality: +15, Critical Hit Percent: +10, Hot Damage: +25, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	therapeutic Fuzzy Slippers of Hatred of the ox of Gandalf	0		Muscle: +20, Spell Critical Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip
-4308	foul-smelling Lens of Hatred of the ox of the cheetah	0		Muscle: +20, Stench Damage: +10, Initiative: +60, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	foul-smelling Lens of Hatred of the ox of the cheetah	0		Muscle: +20, Stench Damage: +10, Initiative: +60, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	narrow inspector's sinister Samson's Treads of Loathing	0		Experience (Muscle): +5, Spell Damage: +10, Item Drop: +15, Single Equip
 4310	blinking Scepter of Loathing of the sewer of courage of Flo-Jo	0		Stench Damage: +25, Spooky Resistance: +3, Initiative: +100
 4311	maroon auspicious Belt of Loathing of the bloodbag of the overflowing toilet	0		Maximum HP: +100, Stench Spell Damage: +50, Item Drop: +10, Single Equip
@@ -4280,7 +4280,7 @@
 4328	shaking suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	tasty snack-sized candy kneecapping stick	2	awesome	Last Available: "2009-12"
-4331	tasty tiny maroon ghostly licorice garrote	1	awesome	Last Available: "2009-12"
+4331	tiny tasty maroon ghostly licorice garrote	1	awesome	Last Available: "2009-12"
 4332	blinking skewed smartaleck's candy knuckles	0		Moxie Percent: +30, Last Available: "2009-12"
 4333	adequate huge jawbruiser	3	good	Last Available: "2010-12"
 4334	irradiated chocolate car	0		Effect: "Thanksgot", Effect Duration: 45, Last Available: "2009-12"
@@ -4293,13 +4293,13 @@
 4341	anodized altered upside-down BitterSweetTarts	0		Effect: "Sappy Blood", Effect Duration: 26, Last Available: "2009-12"
 4342	super-Vulcanized non-improved activated Polka Pop	0		Effect: "Took Eleven", Effect Duration: 39, Last Available: "2009-12"
 4343	green Crimbuck	0		Last Available: "2009-12"
-4344	purple shaking Crimbo wreath	0		Last Available: "2009-12"
+4344	shaking purple Crimbo wreath	0		Last Available: "2009-12"
 4345	blinking string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	blinking leftover Crimbo rations	0		Last Available: "2009-12"
-4349	snow hat of the sewer	0		Stench Damage: +25, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	squat mansplainer's snow pants	0		Monster Level: +15, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	snow hat of the sewer	0		Stench Damage: +25, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	squat mansplainer's snow pants	0		Monster Level: +15, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	snow belly of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2009-12"
 4352	jittery pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4309,8 +4309,8 @@
 4357	skewed A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	upside-down squat A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	tumbling A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	low-calorie adequate expired can of franks 'n' beans	1	good	Last Available: "2009-12"
-4361	hand-crafted special expired bottle of peppermint schnapps	3	EPIC	Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2009-12"
+4360	adequate low-calorie expired can of franks 'n' beans	1	good	Last Available: "2009-12"
+4361	special hand-crafted expired bottle of peppermint schnapps	3	EPIC	Effect: "Berry Berry Cold", Effect Duration: 50, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	tumbling elf resistance button	0		Last Available: "2009-12"
 4364	cold-filtered polarized red elven suicide capsule	0		Effect: "Remaining Alive", Effect Duration: 18, Last Available: "2009-12"
@@ -4320,7 +4320,7 @@
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
-4371	shaking ghostly handful of wires	0		Last Available: "2009-12"
+4371	ghostly shaking handful of wires	0		Last Available: "2009-12"
 4372	shaking chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	blinking elf ear	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	perfumed Lo Pan's pocketwatch on a chain	0		Spell Critical Percent: +30, Stench Resistance: +5, Last Available: "2009-12"
 4386	foul-smelling Fonzie's cement sandals	0		Experience (Moxie): +1, Stench Damage: +10, Single Equip, Last Available: "2009-12"
 4387	inspector's hardened night-vision goggles	0		Damage Reduction: 3, Item Drop: +15, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	frosty peanut brittle shield	0		Cold Spell Damage: +10, Damage Reduction: 3, Last Available: "2009-12"
 4390	energetic Red Rover BB gun of the glutton	0		Maximum MP Percent: +20, Food Drop: +100, Last Available: "2009-12"
-4391	shaking careful red-and-green sweater	0		Monster Level: -10, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	shaking careful red-and-green sweater	0		Monster Level: -10, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	polymerized wobbly Crimbo peppermint bark	0		Effect: "Heart of Green", Effect Duration: 58, Last Available: "2009-12"
 4394	adjusted spinning Crimbo fudge	0		Effect: "Memory of Smarts", Effect Duration: 29, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	huge crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	fireproof cheese sword	0		Hot Resistance: +3, Softcore Only, Last Available: "2010-01"
-4400	careful cheese diaper	0		Monster Level: -10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	careful cheese diaper	0		Monster Level: -10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	smartaleck's cheese wheel	0		Moxie Percent: +30, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	ruddy cheese eye	0		Maximum HP Percent: +40, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	ruddy cheese eye	0		Maximum HP Percent: +40, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	tumbling miser's hale Staff of Queso Escusado of the pedagogue	0		Experience: +3, Maximum HP: +20, Meat Drop: +10, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4360,7 +4360,7 @@
 4409	squat Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	special small bland quantum taco	0		Effect: "Poker Faced", Effect Duration: 5, Last Available: "2010-10"
+4412	small special bland quantum taco	0		Effect: "Poker Faced", Effect Duration: 5, Last Available: "2010-10"
 4413	tolerable Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	pulsating colorful plastic ball	0		Last Available: "2010-01"
 4415	twirling prompt sealhide hood	0		Adventures: +3, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4396,7 +4396,7 @@
 4448	powdered Instant Karma	1	good	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	tumbling lime green scorching pointy hat	0		Hot Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	tumbling lime green scorching pointy hat	0		Hot Damage: +25, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	ghostly razor-sharp machetito	0		Weapon Damage Percent: +25, Last Available: "2010-04"
 4453	lawnmower blade of the sweet-tooth	0		Candy Drop: +100, Last Available: "2010-04"
 4454	tumbling grass clippings	0		Last Available: "2023-12"
@@ -4416,15 +4416,15 @@
 4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	blue BRICKO brick	0		Last Available: "2010-02"
 4470	fuchsia BRICKO eye brick	0		Last Available: "2010-02"
-4471	aromatic BRICKO hat	0		Stench Resistance: +1, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	BRICKO pants of vim and vigor	0		Maximum HP Percent: +50, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	aromatic BRICKO hat	0		Stench Resistance: +1, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	BRICKO pants of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	friendly BRICKO sword	0		Familiar Weight: +3, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	wobbly BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	bouncing BRICKO turtle	0		Last Available: "2010-02"
 4478	spinning BRICKO elephant	0		Last Available: "2010-02"
-4479	bouncing mirror BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	bouncing mirror BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	squat BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	gray BRICKO airship	0		Last Available: "2010-02"
@@ -4436,7 +4436,7 @@
 4488	BRICKO trunk	0		Last Available: "2010-02"
 4489	gilded BRICKO brick	0		Last Available: "2010-02"
 4490	ghostly gilded BRICKO chalice	0		Last Available: "2010-02"
-4491	blurry cyan pulsating BRICKO brick	0		Last Available: "2010-02"
+4491	pulsating blurry cyan BRICKO brick	0		Last Available: "2010-02"
 4492	BRICKO brick	0		Last Available: "2010-02"
 4493	blurry broken BRICKO brick	0		Last Available: "2010-02"
 4494	BRICKO reactor	0		Last Available: "2010-02"
@@ -4455,22 +4455,22 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	magnetized denatured improved &quot;DRINK ME&quot; potion	0		Effect: "Ogred and Oublietted", Effect Duration: 33, Last Available: "2010-03"
 4509	huge reflection of a map	0		Last Available: "2010-03"
-4510	snack-sized rotten walrus ice cream	2	crappy	Last Available: "2010-03"
-4511	stale snack-sized beautiful soup	2	decent	Last Available: "2010-03"
+4510	rotten snack-sized walrus ice cream	2	crappy	Last Available: "2010-03"
+4511	snack-sized stale beautiful soup	2	decent	Last Available: "2010-03"
 4512	huge eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	normal Humpty Dumplings	3	good	Last Available: "2010-03"
 4515	immense decent skewed Lobster <i>qua</i> Grill	10	good	Last Available: "2010-03"
-4516	aged special watered-down bouncing missing wine	2	awesome	Effect: "Steroid Boost", Effect Duration: 30, Last Available: "2010-03"
-4517	delicious bite-sized matter custard	1	awesome	Last Available: "2010-03"
+4516	watered-down special aged bouncing missing wine	2	awesome	Effect: "Steroid Boost", Effect Duration: 30, Last Available: "2010-03"
+4517	bite-sized delicious matter custard	1	awesome	Last Available: "2010-03"
 4518	ionized non-dry huge comfit?	0		Effect: "Just the Brown Ones", Effect Duration: 48, Last Available: "2010-03"
 4519	mirror ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	strapping flamingo mallet of the sweet-tooth	0		Muscle: +5, Candy Drop: +100, Last Available: "2010-03"
 4521	shaking croquet hedgehog	0		Last Available: "2010-03"
 4522	special Tiger-lily's milk	1	decent	Effect: "Rad-ish", Effect Duration: 25, Last Available: "2010-03"
 4523	nippy eye of the Tiger-lily of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +10, Last Available: "2010-03"
-4524	thinker's wig of the brazier	0		Mysticality: +10, Hot Spell Damage: +25, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	stale half-sized donut	2	decent	Last Available: "2010-03"
+4524	thinker's wig of the brazier	0		Mysticality: +10, Hot Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	half-sized stale donut	2	decent	Last Available: "2010-03"
 4526	adequate blinking bucket of honey	3	good	Last Available: "2010-03"
 4527	electrified supercool elephant stinger	0		Moxie Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-03"
 4528	tasty dragon snaps	4	awesome	Last Available: "2010-03"
@@ -4482,10 +4482,10 @@
 4534	spoiled king cookie	3	crappy	Last Available: "2010-03"
 4535	gigantic normal teal queen cookie	6	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	scorching insane tophat	0		Hot Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	greasy helm of the knight of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	scorching insane tophat	0		Hot Damage: +25, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	greasy helm of the knight of Calamity Jane	0		Critical Hit Percent: +15, Sleaze Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	careful Fonzie's wristwatch of the knight	0		Experience (Moxie): +1, Monster Level: -10, Single Equip, Last Available: "2010-03"
-4540	greedy stylish trousers of the knight	0		Moxie: +25, Meat Drop: +20, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	greedy stylish trousers of the knight	0		Moxie: +25, Meat Drop: +20, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	avaricious tophat	0		Meat Drop: +30, Familiar Effect: "1xBarrr, cap 25"
 4542	wool tie	0		Cold Resistance: +1, Single Equip
 4543	aromatic tuxedo pants	0		Stench Resistance: +1, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4495,7 +4495,7 @@
 4547	caterpillar	0		Last Available: "2010-03"
 4548	mirror walrus	0		Last Available: "2010-03"
 4549	blurry carpenter	0		Last Available: "2010-03"
-4550	bouncing mirror cyan dodo	0		Last Available: "2010-03"
+4550	mirror bouncing cyan dodo	0		Last Available: "2010-03"
 4551	mirror medical-grade detour shield	0		HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 6, Last Available: "2010-03"
 4552	left parenthesis	0		
 4553	lowercase a	0		
@@ -4513,20 +4513,20 @@
 4565	bland squat blinking raisin	3	decent	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	chaotic flyest of shirts of the cougar	0		Moxie: +20, Spell Critical Percent: +10, Last Available: "2010-04"
-4568	tiny special normal a dance upon the palate	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10, Last Available: "2010-04"
-4569	rotten half-sized yellow prehistoric meteorite jawbreaker	2	crappy	Last Available: "2010-04"
+4568	normal special tiny a dance upon the palate	1	good	Effect: "Cletus's Canticle of Celerity", Effect Duration: 10, Last Available: "2010-04"
+4569	half-sized rotten yellow prehistoric meteorite jawbreaker	2	crappy	Last Available: "2010-04"
 4570	lime green Crazyleg's razor	0		Last Available: "2010-04"
 4571	spoiled squirmy violent party snack	3	crappy	Last Available: "2010-04"
 4572	lime green can-you-dig-it? of courage	0		Spooky Resistance: +3, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	cyan meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	quadruple-boiled blurry Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Bureaucratized", Effect Duration: 55, Last Available: "2010-04"
 4580	scorching school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Hot Damage: +25, Last Available: "2010-04"
-4581	auspicious rock-hard T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Damage Reduction: 5, Item Drop: +10, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	auspicious rock-hard T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Damage Reduction: 5, Item Drop: +10, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	moldy six wedges of goat cheese	3	crappy	
@@ -4550,17 +4550,17 @@
 4602	blinking orquette's phone number	0		Last Available: "2010-06"
 4603	tumbling fuchsia bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	savvy bottle of Goldschn&ouml;ckered of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	savvy bottle of Goldschn&ouml;ckered of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	bland sun-dried tofu	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	drinkable practically non-alcoholic special soyburger juice	1	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	twirling respected companion biscuit	0		Last Available: "2010-08"
-4609	spinning squat essential tofu	0		Last Available: "2010-08"
-4610	polymerized squat ghostly essential soy	0		Effect: "Starry-Eyed", Effect Duration: 61, Last Available: "2010-08"
+4609	squat spinning essential tofu	0		Last Available: "2010-08"
+4610	polymerized ghostly squat essential soy	0		Effect: "Starry-Eyed", Effect Duration: 61, Last Available: "2010-08"
 4611	vacuum-sealed wet blinking essential cameraderie	0		Effect: "Bandersnatched", Effect Duration: 24, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	Tesla Crown of Thrones	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2010-05"
-4615	watered-down tolerable lime green Cinco Mayo Lager	2	good	Last Available: "2010-05"
+4615	tolerable watered-down lime green Cinco Mayo Lager	2	good	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	wobbly plastic cup of flat beer	0		
@@ -4574,15 +4574,15 @@
 4626	superduperball	0		Last Available: "2010-06"
 4627	bouncing finger cuffs	0		Last Available: "2010-06"
 4628	ghostly parachute guy	0		Last Available: "2010-06"
-4629	arcane researcher's plastic spider ring	0		Experience Percent (Mysticality): +10, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	arcane researcher's plastic spider ring	0		Experience Percent (Mysticality): +10, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	Da Vinci's plastic kazoo	0		Experience (Mysticality): +5, Last Available: "2010-06"
 4631	inflatable baseball bat of chilblains	0		Cold Damage: +25, Last Available: "2010-06"
-4632	hale googly-star hat of Flo-Jo	0		Maximum HP: +20, Initiative: +100, Familiar Effect: "atk", Last Available: "2010-06"
+4632	hale googly-star hat of Flo-Jo	0		Maximum HP: +20, Initiative: +100, Last Available: "2010-06", Familiar Effect: "atk"
 4633	shaking therapeutic cool googly-ball hat	0		Moxie: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-06"
 4634	olive vibrating shellacked googly-heart hat	0		Damage Reduction: 7, Maximum MP Percent: +10, Last Available: "2010-06"
 4635	friendly crafty super-sweet boom box	0		Maximum MP: +10, Familiar Weight: +3, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	sizzling dangerous sinister demon mask of courage	0		Weapon Damage: +10, Hot Damage: +10, Spooky Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	sizzling dangerous sinister demon mask of courage	0		Weapon Damage: +10, Hot Damage: +10, Spooky Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	narrow brawny wizardly streetfighting champion's belt of the scaredy-cat	0		Mysticality: +25, Muscle Percent: +20, Monster Level: -15, Single Equip, Last Available: "2010-06"
 4639	padded experienced Space Trip safety headphones of vim and vigor	0		Experience: +2, Damage Absorption: +20, Maximum HP Percent: +50, Single Equip, Last Available: "2010-06"
 4640	hale LARP carp	0		Maximum HP: +20
@@ -4594,9 +4594,9 @@
 4646	green twirling resourceful hale stiffened Meteoid ice beam	0		Damage Reduction: 1, Maximum HP: +20, Maximum MP: +50, Last Available: "2011-12"
 4647	double-paned Rosewater's Dungeon Fist gauntlet of the brazier	0		Mysticality Percent: +30, Hot Spell Damage: +25, Cold Resistance: +5, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
-4651	ghostly upside-down ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4651	upside-down ghostly ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	lime green greedy scandalous ironic knit cap	0		Sleaze Damage: +5, Meat Drop: +20, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
 4654	ironic battle spoon of Gandalf	0		Spell Critical Percent: +20
@@ -4619,7 +4619,7 @@
 4671	distilled acceptable squat booze-soaked cherry	5	good	
 4672	comfy pillow	0		
 4673	bland marshmallow	3	decent	
-4674	spoiled snack-sized fancy sponge cake	2	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 15
+4674	fancy spoiled snack-sized sponge cake	2	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 15
 4675	perfectly mixed high-proof spinning gin-soaked blotter paper	6	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	slick pottery shield	0		Moxie: +10, Damage Reduction: 3, Last Available: "2010-09"
-4682	blinking blue foul-smelling pottery hat of the boozehound	0		Stench Damage: +10, Booze Drop: +100, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	Sherlock's grievous pottery training pants	0		Weapon Damage Percent: +50, Item Drop: +25, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	blinking blue foul-smelling pottery hat of the boozehound	0		Stench Damage: +10, Booze Drop: +100, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	Sherlock's grievous pottery training pants	0		Weapon Damage Percent: +50, Item Drop: +25, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	wobbly ghostly blinking hale pottery club	0		Maximum HP: +20, Last Available: "2010-09"
 4685	pottery yo-yo of the scaredy-cat	0		Monster Level: -15, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	upside-down fossilized torso	0		Last Available: "2010-09"
 4694	upside-down fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	family-friendly chaotic Greatest American Pants of the cougar	0		Moxie: +20, Spell Critical Percent: +10, Sleaze Resistance: +1, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	family-friendly chaotic Greatest American Pants of the cougar	0		Moxie: +20, Spell Critical Percent: +10, Sleaze Resistance: +1, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	green asbestos-lined fossilized necklace	0		Hot Resistance: +5, Last Available: "2010-09"
 4698	spinning imp air	0		
 4699	bus pass	0		
@@ -4658,21 +4658,21 @@
 4710	squat tumbling immense ballet shoes	0		Familiar Weight: +5
 4711	twirling sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
-4713	squat skewed popsicle stick	0		
-4714	tasty tiny wobbly lemon popsicle	1	awesome	
-4715	super-sized rotten popsicle	5	crappy	
+4713	skewed squat popsicle stick	0		
+4714	tiny tasty wobbly lemon popsicle	1	awesome	
+4715	rotten super-sized popsicle	5	crappy	
 4716	rotten strawberry popsicle	4	crappy	
 4717	decent bite-sized liver popsicle	1	good	
 4718	frightening mariachi hat	0		Spooky Damage: +5, Familiar Effect: "atk, cap 2"
 4719	frosty Hollandaise helmet	0		Cold Spell Damage: +10, Familiar Effect: "atk, cap 2"
 4720	ghostly organ grinder	0		Free Pull, Last Available: "2011-12"
-4721	red twirling microwave stogie	0		Last Available: "2011-12"
+4721	twirling red microwave stogie	0		Last Available: "2011-12"
 4722	moldy jittery liver and let pie	3	crappy	Last Available: "2010-10"
 4723	immense decent badass pie	9	good	Last Available: "2010-10"
 4724	stale shoo-fish pie	3	decent	Last Available: "2010-10"
 4725	flavorless piping organ pie	3	decent	Last Available: "2010-10"
-4726	gigantic moldy igloo pie	6	crappy	Last Available: "2010-10"
-4727	snack-sized delicious fuchsia stomach turnover	2	awesome	Last Available: "2010-10"
+4726	moldy gigantic igloo pie	6	crappy	Last Available: "2010-10"
+4727	delicious snack-sized fuchsia stomach turnover	2	awesome	Last Available: "2010-10"
 4728	stale dead lights pie	3	decent	Last Available: "2010-10"
 4729	bland throbbing organ pie	4	decent	Last Available: "2010-10"
 4730	teal nasty stop shield	0		Stench Damage: +5, Damage Reduction: 6, Last Available: "2009-12"
@@ -4684,8 +4684,8 @@
 4736	tangle of rat tails	0		
 4737	skewed Herculean beer-soaked mop	0		Experience (Muscle): +1
 4738	tolerable yellow day-old beer	3	good	
-4739	lousy blurry cyan plain beer	3	decent	
-4740	fancy triple-distilled smooth overpriced &quot;imported&quot; beer	7	awesome	Effect: "Took Eleven", Effect Duration: 20
+4739	lousy cyan blurry plain beer	3	decent	
+4740	smooth triple-distilled fancy overpriced &quot;imported&quot; beer	7	awesome	Effect: "Took Eleven", Effect Duration: 20
 4741	pulsating smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	bone chips	0		Last Available: "2011-12"
@@ -4693,14 +4693,14 @@
 4745	non-Vulcanized ionized Wax Flask	0		Effect: "Sweet Taste", Effect Duration: 25
 4746	galvanized pulsating Pain Dip	0		Effect: "Mushroom Magicalness", Effect Duration: 63
 4747	moldy miniature bone meal	2	crappy	Last Available: "2010-10"
-4748	acceptable high-proof bone aperitif	8	good	Last Available: "2010-10"
+4748	high-proof acceptable bone aperitif	8	good	Last Available: "2010-10"
 4749	bonerang of chilblains	0		Cold Damage: +25, Last Available: "2010-10"
 4750	teal Samson's bone and arrows	0		Experience (Muscle): +5, Last Available: "2010-10"
 4751	boxer's boning knife	0		Muscle Percent: +10, Last Available: "2010-10"
 4752	bone crusher of bravery	0		Spooky Resistance: +5, Last Available: "2010-10"
 4753	tumbling brawny bone spurs	0		Muscle Percent: +20, Single Equip, Last Available: "2010-10"
-4754	lard-coated ruddy bonedanna	0		Maximum HP Percent: +40, Sleaze Spell Damage: +25, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	shaking perfumed padded boneana hammock	0		Damage Absorption: +20, Stench Resistance: +5, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	lard-coated ruddy bonedanna	0		Maximum HP Percent: +40, Sleaze Spell Damage: +25, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	shaking perfumed padded boneana hammock	0		Damage Absorption: +20, Stench Resistance: +5, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	tumbling Stabonic scroll	0		Last Available: "2010-10"
 4758	warmed pulsating candy skeleton	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 67, Last Available: "2020-09"
@@ -4709,7 +4709,7 @@
 4761	tumbling pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	adequate pumpkin pie	3	good	Last Available: "2010-11"
-4764	lousy strong pumpkin beer	5	decent	Last Available: "2010-11"
+4764	strong lousy pumpkin beer	5	decent	Last Available: "2010-11"
 4765	electrified unsweetened huge tumbling pumpkin juice	0		Effect: "Mad at Science", Effect Duration: 50, Last Available: "2010-11"
 4766	spinning green pumpkin bomb	0		Last Available: "2010-11"
 4767	coward's manspreader's shin gourds	0		Monster Level: -10, Single Equip, Last Available: "2010-11"
@@ -4724,7 +4724,7 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	bouncing Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	rotten bite-sized gray CRIMBCOIDS mints	1	crappy	Last Available: "2011-01"
+4818	bite-sized rotten gray CRIMBCOIDS mints	1	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	rotten CRIMBCOLOAF	3	crappy	Last Available: "2011-01"
 4821	yummy circular CRIMBCOOKIE	4	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4746,14 +4746,14 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	flavorless triangular CRIMBCOOKIE	3	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	spoiled tiny jittery square CRIMBCOOKIE	1	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	tiny spoiled jittery square CRIMBCOOKIE	1	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	blue manspreader's cool bindlestocking of terror	0		Moxie: +5, Monster Level: +10, Spooky Spell Damage: +10, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	blurry Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	flame-wreathed Uncle Hobo's stocking cap of the glutton	0		Hot Spell Damage: +10, Food Drop: +100, Familiar Effect: "atk", Last Available: "2010-12"
+4845	flame-wreathed Uncle Hobo's stocking cap of the glutton	0		Hot Spell Damage: +10, Food Drop: +100, Last Available: "2010-12", Familiar Effect: "atk"
 4846	boxer's Uncle Hobo's epic beard	0		Muscle Percent: +10, Item Drop: +5, Single Equip, Last Available: "2010-12"
-4847	twirling scorching thinker's Uncle Hobo's gift baggy pants	0		Mysticality: +10, Hot Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	twirling scorching thinker's Uncle Hobo's gift baggy pants	0		Mysticality: +10, Hot Damage: +25, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	Oprah's Uncle Hobo's fingerless tinsel gloves of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +50, Single Equip, Last Available: "2010-12"
 4849	careful Uncle Hobo's highest bough of the bloodbag	0		Maximum HP: +100, Monster Level: -10, Last Available: "2010-12"
 4850	mansplainer's occult Uncle Hobo's belt	0		Spell Damage Percent: +25, Monster Level: +15, Single Equip, Last Available: "2010-12"
@@ -4762,7 +4762,7 @@
 4853	tarnished extra-enhanced holly-flavored Hob-O	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 65, Last Available: "2020-09"
 4854	yellow squat CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
-4856	huge blurry paperclip	0		Last Available: "2011-01"
+4856	blurry huge paperclip	0		Last Available: "2011-01"
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	lightning-fast CRIMBCO lanyard	0		Initiative: +40, Single Equip, Last Available: "2011-01"
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	huge Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	Van der Graaf hardy paperclip-on tie of the boozehound	0		Maximum HP: +50, Booze Drop: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-01"
-4869	miser's wizardly paperclip pants	0		Mysticality: +25, Meat Drop: +10, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	sharpshooter's extremely unsafe paperclip turban of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Critical Hit Percent: +10, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	miser's wizardly paperclip pants	0		Mysticality: +25, Meat Drop: +10, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	sharpshooter's extremely unsafe paperclip turban of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Critical Hit Percent: +10, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	ribald paperclip cape	0		Sleaze Damage: +10, Last Available: "2011-01"
 4872	glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4860,14 +4860,14 @@
 4957	energized jittery half-baked potion	0		Effect: "Sticky Hands", Effect Duration: 27
 4958	miser's Knob Goblin deluxe scimitar	0		Meat Drop: +10
 4959	tasty Knob nuts	3	awesome	
-4960	artisanal watered-down Cobb's Knob Wurstbrau	2	EPIC	
+4960	watered-down artisanal Cobb's Knob Wurstbrau	2	EPIC	
 4961	tumbling tumbling Subject 37 file	0		
 4962	miser's Jim Carey's mysterious lapel pin	0		Monster Level: +25, Meat Drop: +10, Single Equip
 4963	blinking state loom	0		Familiar Weight: +10
 4964	olive wobbly Evilometer	0		
 4965	upside-down Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	Pack of Alice's Army Cards	0		Last Available: "2011-03"
-4967	mirror yellow Alice's Army Swordsman	0		Last Available: "2011-03"
+4967	yellow mirror Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	spinning Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
@@ -4879,7 +4879,7 @@
 4976	wobbly Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	purple Alice's Army Nurse	0		Last Available: "2011-03"
 4978	spinning Alice's Army Hammerman	0		Last Available: "2011-03"
-4979	mirror red Alice's Army Bowman	0		Last Available: "2011-03"
+4979	red mirror Alice's Army Bowman	0		Last Available: "2011-03"
 4980	narrow Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	purple Alice's Army Coward	0		Last Available: "2011-03"
@@ -4901,7 +4901,7 @@
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	jittery Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	blinking Alice's Army Foil Bowman	0		Last Available: "2011-03"
-5001	narrow pulsating Alice's Army Foil Lanceman	0		Last Available: "2011-03"
+5001	pulsating narrow Alice's Army Foil Lanceman	0		Last Available: "2011-03"
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
@@ -4927,7 +4927,7 @@
 5024	smooth special marshmallow flamb&eacute;	3	awesome	Effect: "Berry Defensive", Effect Duration: 20, Last Available: "2011-03"
 5025	acceptable cranberry schnapps	4	good	Last Available: "2011-03"
 5026	strong acceptable breaded beer	5	good	Last Available: "2011-03"
-5027	triple-distilled aged soy cordial	6	awesome	Last Available: "2011-03"
+5027	aged triple-distilled soy cordial	6	awesome	Last Available: "2011-03"
 5028	sharpshooter's supercharged Socratic astral bludgeon	0		Experience (Mysticality): +1, Maximum MP Percent: +30, Critical Hit Percent: +10
 5029	scandalous smartaleck's astral shield	0		Moxie Percent: +30, Sleaze Damage: +5, Damage Reduction: 15
 5030	mansplainer's shellacked savvy astral chapeau	0		Mysticality Percent: +20, Damage Reduction: 7, Monster Level: +15, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4944,14 +4944,14 @@
 5041	pulsating Temple Grandin's beefy astral shirt of mayonnaise	0		Muscle: +10, Familiar Weight: +7, Sleaze Spell Damage: +50
 5042	wholesome astral belt of the overflowing toilet	0		Maximum HP Percent: +10, Stench Spell Damage: +50
 5043	rotten astral hot dog	3		
-5044	perfectly mixed weak astral pilsner	2		
+5044	weak perfectly mixed astral pilsner	2		
 5045	astral hot dog dinner	0		
 5046	blinking mirror astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
-5048	shaking blinking shard of double-ice	0		Last Available: "2011-04"
-5049	chaotic Herculean double-ice cap of the scaredy-cat	0		Experience (Muscle): +1, Spell Critical Percent: +10, Monster Level: -15, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5048	blinking shaking shard of double-ice	0		Last Available: "2011-04"
+5049	chaotic Herculean double-ice cap of the scaredy-cat	0		Experience (Muscle): +1, Spell Critical Percent: +10, Monster Level: -15, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	pulsating rosewater-soaked reassuring double-ice box of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Resistance: +1, Stench Resistance: +3, Last Available: "2011-04"
-5051	upside-down foul-smelling grievous double-ice britches of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +50, Stench Damage: +10, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	upside-down foul-smelling grievous double-ice britches of the wise owl	0		Mysticality: +20, Weapon Damage Percent: +50, Stench Damage: +10, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	blinking handful of numbers	0		Last Available: "2020-09"
 5053	wobbly Lars the Cyberian	0		Last Available: "2011-04"
 5054	ghostly intriguing puzzle box	0		Last Available: "2011-04"
@@ -4965,26 +4965,26 @@
 5062	twirling voodoo doll	0		Last Available: "2011-04"
 5063	the finger	0		Last Available: "2011-04"
 5064	red Salsa de las Epocas	0		Last Available: "2011-04"
-5065	rotten enchanted spaghetti con calaveras	3	crappy	Effect: "5 Pounds Lighter", Effect Duration: 35, Last Available: "2011-04"
+5065	enchanted rotten spaghetti con calaveras	3	crappy	Effect: "5 Pounds Lighter", Effect Duration: 35, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	decent skewed popcorn	4	good	Last Available: "2011-04"
 5068	half-sized stale narrow chaos popcorn	2	decent	Last Available: "2011-04"
 5069	pulsating lion tamer's vibrating hole of James Dean	0		Experience (Moxie): +3, Maximum MP Percent: +10, Experience (familiar): +2, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
-5071	thick stale s'more	0	decent	Last Available: "2011-04"
+5071	stale thick s'more	0	decent	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
 5073	high-proof lousy Russian Ice	10	decent	Last Available: "2011-04"
 5074	bouncing brainy clay ashtray	0		Mysticality: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	toasty lanyard	0		Hot Damage: +5, Single Equip, Last Available: "2011-05"
-5076	banded monster pants	0		Damage Absorption: +100, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	banded monster pants	0		Damage Absorption: +100, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	gray pulsating box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	cold-filtered dry ghostly Pok&euml;mann band-aid	0		Effect: "Takin' It Greasy", Effect Duration: 64, Last Available: "2011-05"
-5079	electrified Van der Graaf helmet of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	electrified Van der Graaf helmet of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	frightening crutch	0		Spooky Damage: +5, Last Available: "2011-05"
 5081	therapeutic shock belt	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2011-05"
 5082	vacuum-sealed cold-filtered pickled Okee-Dokee soda	0		Effect: "Spooky Hands", Effect Duration: 65, Last Available: "2011-05"
 5083	flame-retardant rubber band gun	0		Hot Resistance: +1, Last Available: "2011-05"
-5084	double-paned pin-stripe slacks	0		Cold Resistance: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	double-paned pin-stripe slacks	0		Cold Resistance: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	Oprah's gloves	0		Maximum MP Percent: +50, Single Equip, Last Available: "2011-05"
 5086	energized dry blinking correction fluid	0		Effect: "Improprie Tea", Effect Duration: 47, Last Available: "2011-05"
 5087	olive wool Pok&euml;mann figurine: Porkachu	0		Cold Resistance: +1, Single Equip, Last Available: "2011-05"
@@ -5003,13 +5003,13 @@
 5100	wobbly sinister Pok&euml;mann figurine: Frank	0		Spell Damage: +10, Single Equip, Last Available: "2011-05"
 5101	upside-down smelly Pok&euml;mann figurine: Moog	0		Stench Spell Damage: +10, Single Equip, Last Available: "2011-05"
 5102	adjusted huge willyweed	0		Effect: "Human-Slime Hybrid", Effect Duration: 65, Last Available: "2011-05"
-5103	galvanized super-dry blinking squat Nuclear Blastball	0		Effect: "Hella Tough", Effect Duration: 48, Last Available: "2011-05"
+5103	galvanized super-dry squat blinking Nuclear Blastball	0		Effect: "Hella Tough", Effect Duration: 48, Last Available: "2011-05"
 5104	quadruple-warmed ghostly fish juice box	0		Effect: "La Bamba", Effect Duration: 41, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	practically non-alcoholic delicious skewed Jeppson's Malort	1	awesome	Last Available: "2011-06"
+5107	delicious practically non-alcoholic skewed Jeppson's Malort	1	awesome	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	blurry sage stress ball	0		Mysticality Percent: +10, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	blurry sage stress ball	0		Mysticality Percent: +10, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	spinning occult Ultracolor&trade; shirt	0		Spell Damage Percent: +25, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	maroon busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	jittery Temple Grandin's Sinatra's Herculean Admiral's hat	0		Experience (Muscle): +1, Experience (Moxie): +5, Familiar Weight: +7, Familiar Effect: "atk", Last Available: "2011-05"
-5122	horrifying hardened personal trainer's aviator's cap	0		Experience Percent (Muscle): +10, Damage Reduction: 3, Spooky Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	jittery Temple Grandin's Sinatra's Herculean Admiral's hat	0		Experience (Muscle): +1, Experience (Moxie): +5, Familiar Weight: +7, Last Available: "2011-05", Familiar Effect: "atk"
+5122	horrifying hardened personal trainer's aviator's cap	0		Experience Percent (Muscle): +10, Damage Reduction: 3, Spooky Damage: +25, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	sinister mirrored aviator shades of the empath	0		Spell Damage: +10, Familiar Weight: +5, Single Equip, Last Available: "2011-05"
 5124	Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	shaking Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	teal family-friendly scandalous honey dipper of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, Sleaze Resistance: +1
 5149	smooth honeybritches of Gandalf of horror	0		Moxie: +15, Spell Critical Percent: +20, Spooky Spell Damage: +25, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	rosewater-soaked banded dance instructor's honeycap	0		Experience Percent (Moxie): +10, Damage Absorption: +100, Stench Resistance: +3, Familiar Effect: "1xPotato, cap 43"
-5151	blinking wool Moonthril Circlet	0		Cold Resistance: +1, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	narrow knitted Moonthril Greaves	0		Cold Resistance: +3, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	blinking wool Moonthril Circlet	0		Cold Resistance: +1, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	narrow knitted Moonthril Greaves	0		Cold Resistance: +3, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	ghostly Herculean Moonthril Flamberge	0		Experience (Muscle): +1, Last Available: "2011-06"
 5154	savvy Moonthril Longbow	0		Mysticality Percent: +20, Last Available: "2011-06"
 5155	razor-sharp Moonthril Cuirass	0		Weapon Damage Percent: +25, Softcore Only, Last Available: "2011-06"
@@ -5074,13 +5074,13 @@
 5171	green Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	bouncing Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	perfectly mixed practically non-alcoholic fuchsia Saison du Lune	1	super ultra EPIC	Last Available: "2011-06"
+5174	practically non-alcoholic perfectly mixed fuchsia Saison du Lune	1	super ultra EPIC	Last Available: "2011-06"
 5175	lousy Moonthril Schnapps	3	decent	Last Available: "2011-06"
 5176	bad distilled Wrecked Generator	5	decent	Last Available: "2011-06"
 5177	normal Spaghetti with Moonballs	4	good	Last Available: "2011-06"
 5178	fancy adequate Crepes a la Lune	3	good	Effect: "Angry Bone", Effect Duration: 20, Last Available: "2011-06"
 5179	delicious Moon Pie	3	awesome	Last Available: "2011-06"
-5180	deionized vacuum-sealed flattened shaking blurry Comet Pop	0		Effect: "Insatiable Hunger", Effect Duration: 45, Last Available: "2011-06"
+5180	deionized vacuum-sealed flattened blurry shaking Comet Pop	0		Effect: "Insatiable Hunger", Effect Duration: 45, Last Available: "2011-06"
 5181	polarized oxidized deionized Flan in the Moon	0		Effect: "Educated (Kinda)", Effect Duration: 19, Last Available: "2011-06"
 5182	frozen cold-filtered modified jittery 1/6th Pound Cake	0		Effect: "Cool Spirit", Effect Duration: 38, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	aerosolized magnetized spinning honey stick	0		Effect: "Video Game Hot Dog", Effect Duration: 21
 5189	colloidal pressed ghostly double-ice gum	0		Effect: "Cancer Rising", Effect Duration: 17, Last Available: "2011-04"
-5190	Van der Graaf thinker's Operation Patriot Shield of terror	0		Mysticality: +10, Spooky Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	Van der Graaf thinker's Operation Patriot Shield of terror	0		Mysticality: +10, Spooky Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	alkaline extra-warmed corrupted data	0		Effect: "Artificially Sweet", Effect Duration: 59, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5102,13 +5102,13 @@
 5199	vaporized beastly paste	1	decent	Last Available: "2011-08"
 5200	compressed paste	1	decent	Last Available: "2011-08"
 5201	powdered ectoplasmic paste	1	crappy	Last Available: "2011-08"
-5202	distilled blinking wobbly greasy paste	1	crappy	Last Available: "2011-08"
+5202	distilled wobbly blinking greasy paste	1	crappy	Last Available: "2011-08"
 5203	distilled bug paste	1	crappy	Last Available: "2011-08"
 5204	compressed hippy paste	1	decent	Last Available: "2011-08"
 5205	powdered huge orc paste	1	decent	Last Available: "2011-08"
 5206	boiled blurry demonic paste	1	good	Last Available: "2011-08"
-5207	dried jittery blinking purple indescribably horrible paste	1	awesome	Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2011-08"
-5208	compressed skewed maroon paste	1	decent	Effect: "Hippy Flavor", Effect Duration: 40, Last Available: "2011-08"
+5207	dried purple jittery blinking indescribably horrible paste	1	awesome	Effect: "Extra-Sharp Weapon", Effect Duration: 30, Last Available: "2011-08"
+5208	compressed maroon skewed paste	1	decent	Effect: "Hippy Flavor", Effect Duration: 40, Last Available: "2011-08"
 5209	modified blurry goblin paste	1	good	Effect: "Fishy Fortification", Effect Duration: 10, Last Available: "2011-08"
 5210	powdered skewed pirate paste	1	EPIC	Effect: "Heightened Senses", Effect Duration: 5, Last Available: "2011-08"
 5211	denatured spinning spinning chlorophyll paste	1	decent	Last Available: "2011-08"
@@ -5117,7 +5117,7 @@
 5214	pickled ghostly slimy paste	1	EPIC	Effect: "Aries Rising", Effect Duration: 5, Last Available: "2011-08"
 5215	compressed penguin paste	1	EPIC	Last Available: "2011-08"
 5216	twisted narrow elemental paste	1	crappy	Last Available: "2011-08"
-5217	pickled pulsating wobbly cosmic paste	1	crappy	Effect: "Ooh, Salty!", Effect Duration: 10, Last Available: "2011-08"
+5217	pickled wobbly pulsating cosmic paste	1	crappy	Effect: "Ooh, Salty!", Effect Duration: 10, Last Available: "2011-08"
 5218	diluted huge hobo paste	1	EPIC	Effect: "Rage of the Reindeer", Effect Duration: 25, Last Available: "2011-08"
 5219	altered jittery ghostly Crimbo paste	1	crappy	Last Available: "2011-08"
 5220	shaking Teachings of the Fist	0		
@@ -5138,24 +5138,24 @@
 5235	skewed furry halo of doom	0		Spooky Spell Damage: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	Herculean frosty halo	0		Experience (Muscle): +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	spinning dance instructor's time halo	0		Experience Percent (Moxie): +10, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	mediocre weak Lumineux Limnio	2	decent	Last Available: "2011-09"
-5239	lousy watered-down red Morto Moreto	2	decent	Last Available: "2011-09"
+5238	weak mediocre Lumineux Limnio	2	decent	Last Available: "2011-09"
+5239	watered-down lousy red Morto Moreto	2	decent	Last Available: "2011-09"
 5240	tolerable Temps Tempranillo	3	good	Last Available: "2011-09"
 5241	bad Bordeaux Marteaux	4	decent	Last Available: "2011-09"
-5242	fancy tolerable Fromage Pinotage	4	good	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 50, Last Available: "2011-09"
+5242	tolerable fancy Fromage Pinotage	4	good	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 50, Last Available: "2011-09"
 5243	drinkable weak Beignet Milgranet	2	good	Last Available: "2011-09"
-5244	triple-distilled smooth upside-down ghostly Muschat	10	awesome	Last Available: "2011-09"
+5244	smooth triple-distilled ghostly upside-down Muschat	10	awesome	Last Available: "2011-09"
 5245	flavorless cool jelly donut	3	decent	Last Available: "2011-09"
-5246	stale low-calorie shrapnel jelly donut	1	decent	Last Available: "2011-09"
+5246	low-calorie stale shrapnel jelly donut	1	decent	Last Available: "2011-09"
 5247	decent occult jelly donut	3	good	Last Available: "2011-09"
-5248	rotten immense tumbling thyme jelly donut	9	crappy	Last Available: "2011-09"
+5248	immense rotten tumbling thyme jelly donut	9	crappy	Last Available: "2011-09"
 5249	thick adequate danish	5	good	Last Available: "2011-09"
 5250	massive rotten smashed danish	7	crappy	Last Available: "2011-09"
 5251	stale forbidden danish	3	decent	Last Available: "2011-09"
 5252	moldy fuchsia cool cat claw	3	crappy	Last Available: "2011-09"
-5253	diet normal red blunt cat claw	1	good	Last Available: "2011-09"
+5253	normal diet red blunt cat claw	1	good	Last Available: "2011-09"
 5254	rotten shadowy cat claw	4	crappy	Last Available: "2011-09"
-5255	small rotten green cheezburger	2	crappy	Last Available: "2011-09"
+5255	rotten small green cheezburger	2	crappy	Last Available: "2011-09"
 5256	flavorless toasted brie	3	decent	Last Available: "2011-09"
 5257	pressed quantum potion of the field gar	0		Effect: "Holiday Bliss", Effect Duration: 35, Last Available: "2011-09"
 5258	boiled polymerized too legit potion	0		Effect: "Violent Night", Effect Duration: 67, Last Available: "2011-09"
@@ -5165,7 +5165,7 @@
 5262	denatured cool cat elixir	0		Effect: "Fungal Fortification", Effect Duration: 13, Last Available: "2011-09"
 5263	pressed potion of the captain's hammer	0		Effect: "Eye of the Seal", Effect Duration: 60, Last Available: "2011-09"
 5264	improved potion of X-ray vision	0		Effect: "Superheroic", Effect Duration: 17, Last Available: "2011-09"
-5265	diffused altered gray jittery potion of the litterbox	0		Effect: "Yuletide Sappiness", Effect Duration: 38, Last Available: "2011-09"
+5265	diffused altered jittery gray potion of the litterbox	0		Effect: "Yuletide Sappiness", Effect Duration: 38, Last Available: "2011-09"
 5266	quantum potion of animal rage	0		Effect: "Simulation Stimulation", Effect Duration: 34, Last Available: "2011-09"
 5267	magnetized aerosolized unsweetened squat potion of punctual companionship	0		Effect: "Uncanny Shot", Effect Duration: 13, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	mirror slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	tumbling dungeon dragon chest	0		Last Available: "2011-09"
 5298	normal phish stick	3	good	Last Available: "2011-09"
-5299	asbestos-lined electrified personal trainer's plastic vampire fangs	0		Experience Percent (Muscle): +10, Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	asbestos-lined electrified personal trainer's plastic vampire fangs	0		Experience Percent (Muscle): +10, Hot Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	gray narrow Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5221,11 +5221,11 @@
 5318	boiled corrupted wobbly Gummy Brains	0		Effect: "Cravin' for a Ravin'", Effect Duration: 19, Last Available: "2011-10"
 5319	altered Blood 'n' Plenty	0		Effect: "Mo' Hobo", Effect Duration: 21, Last Available: "2011-10"
 5320	quantum denatured Lobos Mints	0		Effect: "In Tuna", Effect Duration: 36, Last Available: "2011-10"
-5321	oxidized cold-filtered cyan tumbling Sweet Sword	0		Effect: "Carrion' On", Effect Duration: 68, Last Available: "2011-10"
+5321	oxidized cold-filtered tumbling cyan Sweet Sword	0		Effect: "Carrion' On", Effect Duration: 68, Last Available: "2011-10"
 5322	aged lime green Ecto-Cooler	3	awesome	Last Available: "2011-10"
 5323	lousy Bartles and BRAAAINS wine cooler	4	decent	Last Available: "2011-10"
 5324	lousy skewed Blood Light	3	decent	Last Available: "2011-10"
-5325	perfectly mixed special Silver Bullet beer	3	EPIC	Effect: "Remaining Alive", Effect Duration: 35, Last Available: "2011-10"
+5325	special perfectly mixed Silver Bullet beer	3	EPIC	Effect: "Remaining Alive", Effect Duration: 35, Last Available: "2011-10"
 5326	smooth Bone's Farm &quot;wine&quot;	3	awesome	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	diffused sorority brain	0		Effect: "Berry Defensive", Effect Duration: 14, Last Available: "2011-10"
@@ -5233,16 +5233,16 @@
 5330	wet deionized drum of pomade	0		Effect: "Chorale of Companionship", Effect Duration: 21, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	extra-see-thru nightie of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-10"
-5333	sizzling BRAINS shorts of the wise owl	0		Mysticality: +20, Hot Damage: +10, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	sizzling BRAINS shorts of the wise owl	0		Mysticality: +20, Hot Damage: +10, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	twirling medical-grade Mesmereyes&trade; contact lenses	0		HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2011-10"
 5335	scrunchie of incineration	0		Hot Spell Damage: +50, Single Equip, Last Available: "2011-10"
-5336	blurry extremely skinny jeans of bravery of the boozehound	0		Spooky Resistance: +5, Booze Drop: +100, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	spinning Annie Oakley's thinker's The Necbromancer's Hat	0		Mysticality: +10, Critical Hit Percent: +20, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	blurry extremely skinny jeans of bravery of the boozehound	0		Spooky Resistance: +5, Booze Drop: +100, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	spinning Annie Oakley's thinker's The Necbromancer's Hat	0		Mysticality: +10, Critical Hit Percent: +20, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	friendly careful fortified The Necbromancer's Stein	0		Damage Absorption: +60, Monster Level: -10, Familiar Weight: +3, Last Available: "2011-10"
-5339	shaking smelly Tesla smartaleck's The Necbromancer's Shorts	0		Moxie Percent: +30, Stench Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	shaking smelly Tesla smartaleck's The Necbromancer's Shorts	0		Moxie Percent: +30, Stench Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	huge nasty shellacked arcane researcher's The Necbromancer's Wizard Staff	0		Experience Percent (Mysticality): +10, Damage Reduction: 7, Stench Damage: +5, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	smooth fancy The Cooler Out of Space	4	awesome	Effect: "Sleazy Jellied", Effect Duration: 35, Last Available: "2011-10"
+5342	fancy smooth The Cooler Out of Space	4	awesome	Effect: "Sleazy Jellied", Effect Duration: 35, Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	unsweetened blinking Necbro wafers	0		Effect: "Stimulated Brain", Effect Duration: 20, Last Available: "2020-09"
@@ -5262,7 +5262,7 @@
 5359	Inigo's Incantation of Inspiration (crumpled)	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 5360	Tales of a Kansas Toymaker (used)	0		Skill: "Toynado", Last Available: "2010-12"
 5361	The Joy of Wassailing (used)	0		Skill: "Wassail", Last Available: "2010-12"
-5362	upside-down blurry CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
+5362	blurry upside-down CRIMBCO Employee Handbook (chapter 1) (used)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 5363	bouncing CRIMBCO Employee Handbook (chapter 2) (used)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 5364	narrow CRIMBCO Employee Handbook (chapter 3) (used)	0		Skill: "Lunch Break", Last Available: "2011-01"
 5365	CRIMBCO Employee Handbook (chapter 4) (used)	0		Skill: "Offensive Joke", Last Available: "2011-01"
@@ -5289,7 +5289,7 @@
 5386	ridiculous belt of the brute	0		Muscle Percent: +30, Last Available: "2011-11"
 5387	squat fireproof ridiculous earring	0		Hot Resistance: +3, Last Available: "2011-11"
 5388	skewed huge ridiculous sunglasses of incineration	0		Hot Spell Damage: +50, Last Available: "2011-11"
-5389	adequate massive ridiculous sandwich	9	good	Last Available: "2011-11"
+5389	massive adequate ridiculous sandwich	9	good	Last Available: "2011-11"
 5390	hand-crafted ridiculous cocktail	3	EPIC	Last Available: "2011-11"
 5391	arcane researcher's supercool zombie monkey necklace	0		Moxie Percent: +20, Experience Percent (Mysticality): +10
 5392	Thwaitgold butterfly statuette	0		
@@ -5304,14 +5304,14 @@
 5401	blue peppermint parasol	0		Last Available: "2011-11"
 5402	ghostly yellow slick candy cane	0		Moxie: +10, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
-5404	upside-down blinking Peppermint Pip Packet	0		Last Available: "2011-11"
+5404	blinking upside-down Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	double-paned quilted cane-mail shirt of Gandalf	0		Damage Absorption: +40, Spell Critical Percent: +20, Cold Resistance: +5, Last Available: "2011-12"
-5406	forbidden cool brainy cane-mail pants	0		Mysticality: +5, Moxie: +5, Spell Damage Percent: +50, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
-5407	fancy smooth blinking Vodka Matryoshka	3	awesome	Effect: "Rave Nirvana", Effect Duration: 50, Last Available: "2011-12"
+5406	forbidden cool brainy cane-mail pants	0		Mysticality: +5, Moxie: +5, Spell Damage Percent: +50, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
+5407	smooth fancy blinking Vodka Matryoshka	3	awesome	Effect: "Rave Nirvana", Effect Duration: 50, Last Available: "2011-12"
 5408	bad Gin Mint	3	decent	Last Available: "2011-12"
-5409	fortified delicious Tequiz Navidad	5	awesome	Last Available: "2011-12"
+5409	delicious fortified Tequiz Navidad	5	awesome	Last Available: "2011-12"
 5410	drinkable spinning Mint Yulep	3	good	Last Available: "2011-12"
-5411	practically non-alcoholic hand-crafted Crimbojito	1	super ultra mega turbo EPIC	Last Available: "2011-12"
+5411	hand-crafted practically non-alcoholic Crimbojito	1	super ultra mega turbo EPIC	Last Available: "2011-12"
 5412	hand-crafted Sangria de Menthe	4	EPIC	Last Available: "2011-12"
 5413	teal candycaine powder	0		Last Available: "2011-12"
 5414	gray licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -5327,15 +5327,15 @@
 5424	yellow educational kumquartz ring	0		Experience: +1, Single Equip, Last Available: "2011-11"
 5425	thinker's strawberyl necklace	0		Mysticality: +10, Single Equip, Last Available: "2011-11"
 5426	double-paned sucker bucket of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +5, Last Available: "2011-11"
-5427	chaotic sucker hakama	0		Spell Critical Percent: +10, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	pulsating hardy sucker kabuto	0		Maximum HP: +50, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	chaotic sucker hakama	0		Spell Critical Percent: +10, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	pulsating hardy sucker kabuto	0		Maximum HP: +50, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	sucker tachi of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-11"
 5430	blinking sucker scaffold	0		Last Available: "2011-11"
 5431	narrow cinnamon troll doll	0		Last Available: "2011-11"
 5432	yellow grape troll doll	0		Last Available: "2011-11"
 5433	raspberry troll doll	0		Last Available: "2011-11"
 5434	DNOTC Box	0		Last Available: "2017-12"
-5435	ghostly bouncing gray fudgecule	0		Last Available: "2011-11"
+5435	ghostly gray bouncing fudgecule	0		Last Available: "2011-11"
 5436	cold-filtered pickled fudge lily	0		Effect: "Frostbeard", Effect Duration: 53, Last Available: "2011-11"
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	vacuum-sealed nitrogenated pickled fluid of fudge-finding	0		Effect: "Human-Demon Hybrid", Effect Duration: 35, Last Available: "2011-11"
@@ -5358,7 +5358,7 @@
 5455	upside-down gummi ingot	0		Last Available: "2011-11"
 5456	yellow gummi ingot	0		Last Available: "2011-11"
 5457	magnetized Vulcanized Fudgie Roll	0		Effect: "Strong Spirit", Effect Duration: 30, Last Available: "2011-11"
-5458	fancy rotten fudge bunny	3	crappy	Effect: "White-boy Angst", Effect Duration: 25, Last Available: "2011-11"
+5458	rotten fancy fudge bunny	3	crappy	Effect: "White-boy Angst", Effect Duration: 25, Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	upside-down arcane researcher's Fonzie's fudgecycle of the glutton	0		Experience (Moxie): +1, Experience Percent (Mysticality): +10, Food Drop: +100, Single Equip, Last Available: "2011-11"
 5461	fuchsia fudge cube	0		Last Available: "2011-11"
@@ -5369,21 +5369,21 @@
 5466	pickled shaking resolution: be stronger	0		Effect: "Hella Smooth", Effect Duration: 65, Last Available: "2012-01"
 5467	moist resolution: be smarter	0		Effect: "Dwarven Hardiness", Effect Duration: 40, Last Available: "2012-01"
 5468	activated huge resolution: be sexier	0		Effect: "Orc Chops", Effect Duration: 29, Last Available: "2012-01"
-5469	nitrogenated polarized wobbly narrow resolution: be feistier	0		Effect: "Tiki Temerity", Effect Duration: 12, Last Available: "2012-01"
+5469	nitrogenated polarized narrow wobbly resolution: be feistier	0		Effect: "Tiki Temerity", Effect Duration: 12, Last Available: "2012-01"
 5470	tarnished resolution: be kinder	0		Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2012-01"
 5471	wet energized resolution: be more adventurous	0		Effect: "Bloodstain-Resistant", Effect Duration: 56, Last Available: "2012-01"
-5472	magnetized upside-down spinning resolution: be luckier	0		Effect: "So You Can Work More...", Effect Duration: 27, Last Available: "2012-01"
+5472	magnetized spinning upside-down resolution: be luckier	0		Effect: "So You Can Work More...", Effect Duration: 27, Last Available: "2012-01"
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
 5476	tarnished ghostly gummi salamander	0		Effect: "PERL of Great Price", Effect Duration: 23, Last Available: "2011-11"
 5477	energized skewed gummi snake	0		Effect: "Chilblains of the Corn", Effect Duration: 46, Last Available: "2011-11"
 5478	dry pulsating gummi canary	0		Effect: "Buzzard Breath", Effect Duration: 39, Last Available: "2011-11"
-5479	big spoiled gummi bear	5	crappy	Last Available: "2011-11"
+5479	spoiled big gummi bear	5	crappy	Last Available: "2011-11"
 5480	spoiled small gummi bear	2	crappy	Last Available: "2011-11"
 5481	adequate gray gummi bear	4	good	Last Available: "2011-11"
 5482	tiny stale drunki-bear	1	decent	Last Available: "2011-11"
-5483	thick spoiled purple bouncing drunki-bear	5	crappy	Last Available: "2011-11"
+5483	thick spoiled bouncing purple drunki-bear	5	crappy	Last Available: "2011-11"
 5484	normal low-calorie drunki-bear	1	good	Last Available: "2011-11"
 5485	hale gummi bowtie	0		Maximum HP: +20, Last Available: "2011-11"
 5486	wobbly fudge pocket square of the bloodbag	0		Maximum HP: +100, Last Available: "2011-11"
@@ -5399,14 +5399,14 @@
 5496	boiled tarnished pickled gummi belemnite	0		Effect: "Strange Mental Acuity", Effect Duration: 33, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	wholesome fortified Big Candy's tophat	0		Damage Absorption: +60, Maximum HP Percent: +10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	wholesome fortified Big Candy's tophat	0		Damage Absorption: +60, Maximum HP Percent: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	tumbling Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	yellow Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
 5503	blinking squat Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
-5506	enchanted adequate big jerky coins	5	good	Effect: "Phairly Balanced", Effect Duration: 10, Last Available: "2011-11"
+5506	big adequate enchanted jerky coins	5	good	Effect: "Phairly Balanced", Effect Duration: 10, Last Available: "2011-11"
 5507	drinkable ghostly Go-Wassail	3	good	Last Available: "2011-11"
 5508	vacuum-sealed frozen maroon Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Arabian Knighthood", Effect Duration: 31, Last Available: "2011-11"
 5509	polarized upside-down teal bottle of bubbles	0		Effect: "Happy Trails", Effect Duration: 62, Last Available: "2011-11"
@@ -5416,7 +5416,7 @@
 5513	Trivial Avocations Card: Who?	0		Last Available: "2011-11"
 5514	Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	pog #01 (spider)	0		Last Available: "2011-11"
-5516	pulsating spinning pog #02 (Knob goblin)	0		Last Available: "2011-11"
+5516	spinning pulsating pog #02 (Knob goblin)	0		Last Available: "2011-11"
 5517	pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	skewed pog #05 (ninja snowman)	0		Last Available: "2011-11"
@@ -5426,7 +5426,7 @@
 5523	pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
 5525	purple pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
-5526	modified wobbly spinning Atomic Pop	0		Effect: "Void Between the Stars", Effect Duration: 39, Last Available: "2020-09"
+5526	modified spinning wobbly Atomic Pop	0		Effect: "Void Between the Stars", Effect Duration: 39, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	spinning whimpering willow bark	0		Last Available: "2012-12"
 5529	decent shaking berries of suffering	3	good	Last Available: "2012-12"
@@ -5455,17 +5455,17 @@
 5552	Trusty of the cougar	0		Moxie: +20
 5553	can of Rain-Doh	0		Last Available: "2012-02"
 5554	empty Rain-Doh can	0		Last Available: "2012-02"
-5555	galvanized tumbling lime green fireclutch	0		Effect: "Powdered", Effect Duration: 67
+5555	galvanized lime green tumbling fireclutch	0		Effect: "Powdered", Effect Duration: 67
 5556	vibrating Rain-Doh wings of Flo-Jo	0		Maximum MP Percent: +10, Initiative: +100, Softcore Only, Last Available: "2012-02"
 5557	blue Rain-Doh agent	0		Last Available: "2012-02"
 5558	ruddy experienced Rain-Doh laser gun	0		Experience: +2, Maximum HP Percent: +40, Softcore Only, Last Available: "2012-02"
-5559	blinking family-friendly sizzling Rain-Doh lantern	0		Hot Damage: +10, Sleaze Resistance: +1, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	blinking family-friendly sizzling Rain-Doh lantern	0		Hot Damage: +10, Sleaze Resistance: +1, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	blue Rain-Doh balls	0		Last Available: "2012-02"
 5561	pulsating Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	chaotic boxer's Rain-Doh violet bo	0		Muscle Percent: +10, Spell Critical Percent: +10, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	ghostly Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	fancy spoiled jumbo purple PB&BP	5	crappy	Effect: "Pisces in the Skyces", Effect Duration: 15
+5565	fancy jumbo spoiled purple PB&BP	5	crappy	Effect: "Pisces in the Skyces", Effect Duration: 15
 5566	normal club sandwich	4	good	
 5567	flavorless wobbly corned-beef Reuben	4	decent	
 5568	fuchsia frayed ninja rope	0		
@@ -5476,15 +5476,15 @@
 5573	extra-dry bad Drac & Tan	5	decent	Last Available: "2012-03"
 5574	practically non-alcoholic bad jittery Transylvania Sling	1	decent	Last Available: "2012-03"
 5575	hand-crafted Shot of the Living Dead	4	EPIC	Last Available: "2012-03"
-5576	watered-down perfectly mixed Buttery Knob	2	EPIC	Last Available: "2012-03"
+5576	perfectly mixed watered-down Buttery Knob	2	EPIC	Last Available: "2012-03"
 5577	drinkable Slippery Knob	3	good	Last Available: "2012-03"
 5578	lousy Flaming Knob	3	decent	Last Available: "2012-03"
-5579	hand-crafted watered-down Grasshopper	2	EPIC	Last Available: "2012-03"
-5580	acceptable practically non-alcoholic Locust	1	good	Last Available: "2012-03"
+5579	watered-down hand-crafted Grasshopper	2	EPIC	Last Available: "2012-03"
+5580	practically non-alcoholic acceptable Locust	1	good	Last Available: "2012-03"
 5581	high-proof tolerable Plague of Locusts	10	good	Last Available: "2012-03"
-5582	weak perfectly mixed Red Dwarf	2	EPIC	Last Available: "2012-03"
+5582	perfectly mixed weak Red Dwarf	2	EPIC	Last Available: "2012-03"
 5583	hand-crafted upside-down narrow Golden Mean	3	EPIC	Last Available: "2012-03"
-5584	weak hand-crafted Green Giant	2	EPIC	Last Available: "2012-03"
+5584	hand-crafted weak Green Giant	2	EPIC	Last Available: "2012-03"
 5585	artisanal jittery Aye Aye	3	EPIC	Last Available: "2012-03"
 5586	perfectly mixed tumbling Aye Aye, Captain	4	EPIC	Last Available: "2012-03"
 5587	hand-crafted Aye Aye, Tooth Tooth	3	EPIC	Last Available: "2012-03"
@@ -5494,26 +5494,26 @@
 5591	bad jittery Great Older Fashioned	4	decent	Last Available: "2012-03"
 5592	irresponsibly strong aged Fuzzy Tentacle	9	awesome	Last Available: "2012-03"
 5593	perfectly mixed Crazymaker	4	EPIC	Last Available: "2012-03"
-5594	aged watered-down red Zoodriver	2	awesome	Last Available: "2012-03"
-5595	practically non-alcoholic drinkable lime green Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
+5594	watered-down aged red Zoodriver	2	awesome	Last Available: "2012-03"
+5595	drinkable practically non-alcoholic lime green Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
 5596	fortified drinkable Sloe Comfortable Zoo on Fire	5	good	Last Available: "2012-03"
 5597	bad upside-down Suffering Sinner	3	decent	Last Available: "2012-03"
-5598	weak lousy blue Suppurating Sinner	2	decent	Last Available: "2012-03"
+5598	lousy weak blue Suppurating Sinner	2	decent	Last Available: "2012-03"
 5599	weak acceptable special Sizzling Sinner	2	good	Effect: "Down With Chow", Effect Duration: 10, Last Available: "2012-03"
-5600	weak delicious Firewater	2	awesome	Last Available: "2012-03"
-5601	special practically non-alcoholic drinkable Earth and Firewater	1	good	Effect: "Cringle's Curative Carol", Effect Duration: 25, Last Available: "2012-03"
+5600	delicious weak Firewater	2	awesome	Last Available: "2012-03"
+5601	special drinkable practically non-alcoholic Earth and Firewater	1	good	Effect: "Cringle's Curative Carol", Effect Duration: 25, Last Available: "2012-03"
 5602	watered-down perfectly mixed Earth, Wind and Firewater	2	EPIC	Last Available: "2012-03"
 5603	fancy aged Slimosa	4	awesome	Effect: "Morninja", Effect Duration: 50, Last Available: "2012-03"
 5604	acceptable spinning Extra-slimy Slimosa	4	good	Last Available: "2012-03"
 5605	perfectly mixed practically non-alcoholic Slimebite	1	super ultra EPIC	Last Available: "2012-03"
 5606	tolerable tumbling Cement Mixer	4	good	Last Available: "2012-03"
-5607	mediocre irresponsibly strong Jackhammer	6	decent	Last Available: "2012-03"
+5607	irresponsibly strong mediocre Jackhammer	6	decent	Last Available: "2012-03"
 5608	delicious tumbling Dump Truck	4	awesome	Last Available: "2012-03"
-5609	triple-distilled tolerable Fauna Libre	6	good	Last Available: "2012-03"
+5609	tolerable triple-distilled Fauna Libre	6	good	Last Available: "2012-03"
 5610	aged special Chakra Libre	3	awesome	Effect: "Space Tripping", Effect Duration: 30, Last Available: "2012-03"
 5611	artisanal huge Aura Libre	3	EPIC	Last Available: "2012-03"
 5612	bad Sazerorc	3	decent	Last Available: "2012-03"
-5613	lousy special distilled jittery Sazuruk-hai	5	decent	Effect: "Pyromania", Effect Duration: 30, Last Available: "2012-03"
+5613	special lousy distilled jittery Sazuruk-hai	5	decent	Effect: "Pyromania", Effect Duration: 30, Last Available: "2012-03"
 5614	hand-crafted Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	drinkable watered-down gray Green Velvet	2	good	Last Available: "2012-03"
 5616	smooth Green Muslin	3	awesome	Last Available: "2012-03"
@@ -5532,13 +5532,13 @@
 5629	mediocre upside-down Herringtini	3	decent	Last Available: "2012-03"
 5630	practically non-alcoholic mediocre Lollipop Drop	1	decent	Last Available: "2012-03"
 5631	drinkable Candy Alexander	3	good	Last Available: "2012-03"
-5632	weak bad Candicaine	2	decent	Last Available: "2012-03"
+5632	bad weak Candicaine	2	decent	Last Available: "2012-03"
 5633	weak lousy ghostly Caipiranha	2	decent	Last Available: "2012-03"
 5634	artisanal blurry Flying Caipiranha	4	EPIC	Last Available: "2012-03"
 5635	perfectly mixed Flaming Caipiranha	4	EPIC	Last Available: "2012-03"
 5636	boozy bad Punchplanter	5	decent	Last Available: "2012-03"
-5637	bad spirit-forward mirror lime green Doublepunchplanter	5	decent	Last Available: "2012-03"
-5638	irresponsibly strong perfectly mixed Haymaker	10	EPIC	Last Available: "2012-03"
+5637	spirit-forward bad lime green mirror Doublepunchplanter	5	decent	Last Available: "2012-03"
+5638	perfectly mixed irresponsibly strong Haymaker	10	EPIC	Last Available: "2012-03"
 5639	ghostly Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	normal upside-down fungus	3	good	
@@ -5548,14 +5548,14 @@
 5645	upside-down the Nostril of the Serpent	0		
 5646	narrow calendar fragment	0		
 5647	occult calendar	0		Spell Damage Percent: +25, Damage Reduction: 4
-5648	purple boxer's Boris's Helm of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	purple boxer's Boris's Helm of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	skewed smartaleck's beefy staph of homophones	0		Muscle: +10, Moxie Percent: +30
-5650	maroon shaking lard-coated personal trainer's Boris's Helm (askew) of mayonnaise	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: 75, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	maroon shaking lard-coated personal trainer's Boris's Helm (askew) of mayonnaise	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: 75, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
-5653	blue pulsating key-o-tron	0		
-5654	bland massive nailswurst	8	decent	
-5655	acceptable high-proof used beer	7	good	
+5653	pulsating blue key-o-tron	0		
+5654	massive bland nailswurst	8	decent	
+5655	high-proof acceptable used beer	7	good	
 5656	Huggler Radio	0		Free Pull
 5657	shaking fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5577,9 +5577,9 @@
 5674	&quot;L&quot;	0		
 5675	pickled pulsating watered-down Red Minotaur	1		
 5676	twirling pool torpedo	0		Last Available: "2012-05"
-5677	Ze&trade; goggles of the glutton	0		Food Drop: +100, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	Ze&trade; goggles of the glutton	0		Food Drop: +100, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	fuchsia flame-wreathed supercool stylish swimsuit	0		Moxie Percent: +20, Hot Spell Damage: +10, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	fuchsia flame-wreathed supercool stylish swimsuit	0		Moxie Percent: +20, Hot Spell Damage: +10, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	blinking lost key	0		Last Available: "2012-05"
 5681	stale low-calorie purple skewed P.B.L.T.	1	decent	
 5682	pulsating note from Clancy	0		Skill: "Request Sandwich"
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	ghostly crayon shavings	0		Last Available: "2012-06"
 5704	red wax bugbear	0		Last Available: "2012-06"
-5705	spinning scorching strapping wax hat	0		Muscle: +5, Hot Damage: +25, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	squat hale wax pants of the wise owl	0		Mysticality: +20, Maximum HP: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	spinning scorching strapping wax hat	0		Muscle: +5, Hot Damage: +25, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	squat hale wax pants of the wise owl	0		Mysticality: +20, Maximum HP: +20, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	boiled concentrated drop of water-37	0		Effect: "Adventurer's Best Friendship", Effect Duration: 13, Last Available: "2012-07"
-5709	smartaleck's thinker's fireman's helmet	0		Mysticality: +10, Moxie Percent: +30, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	smartaleck's thinker's fireman's helmet	0		Mysticality: +10, Moxie Percent: +30, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	wobbly fire axe of wisdom	0		Mysticality: +15, Last Available: "2012-07"
 5713	scandalous studded brawny fire extinguisher	0		Muscle Percent: +20, Damage Absorption: +80, Sleaze Damage: +5, Last Available: "2012-07"
 5714	shaking FDKOL tattoo	0		
@@ -5624,37 +5624,37 @@
 5723	flattened ionized cold-filtered wobbly bottle of fire	0		Effect: "Hobo Flavor", Effect Duration: 61, Last Available: "2012-07"
 5724	molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	auspicious dog trainer's hot daub bun	0		Experience (familiar): +1, Item Drop: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	beefy hot daub stand of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	auspicious dog trainer's hot daub bun	0		Experience (familiar): +1, Item Drop: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	beefy hot daub stand of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	hardy dance instructor's foot-long hot daub	0		Experience Percent (Moxie): +10, Maximum HP: +50, Last Available: "2012-07"
 5729	bouncing ballpark hot daub	0		Last Available: "2012-07"
 5730	decent angst burger	3	good	
 5731	irresponsibly strong artisanal narrow wobbly 5-hour acrimony	7	EPIC	
 5732	spinning blank note	0		
 5733	eerily silent box	0		
-5734	immense fancy rotten forbidden sausage	6	crappy	Effect: "Far Out", Effect Duration: 40
-5735	MacGyver's Lord Flameface's cloak	0		Maximum MP: +100, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5734	rotten fancy immense forbidden sausage	6	crappy	Effect: "Far Out", Effect Duration: 40
+5735	MacGyver's Lord Flameface's cloak	0		Maximum MP: +100, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	polymerized narrow Drizzlers&trade; Black Licorice	0		Effect: "Toothy Grin", Effect Duration: 17
 5737	triple-moist corrupted daub-breaker	0		Effect: "Abyssal Sweat", Effect Duration: 61, Last Available: "2020-09"
 5738	gray chaotic Camp Scout backpack	0		Spell Critical Percent: +10, Softcore Only, Last Available: "2012-07"
 5739	ghostly CSA fire-starting kit	0		Last Available: "2012-07"
-5740	snack-sized flavorless bag of GORP	2	decent	Last Available: "2012-07"
+5740	flavorless snack-sized bag of GORP	2	decent	Last Available: "2012-07"
 5741	artisanal water purification pills	3	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	practically non-alcoholic smooth CSA scoutmaster's &quot;water&quot;	1	awesome	Last Available: "2012-07"
+5743	smooth practically non-alcoholic CSA scoutmaster's &quot;water&quot;	1	awesome	Last Available: "2012-07"
 5744	decent mirror bag of GORF	3	good	Last Available: "2012-07"
 5745	teal CSA discount card	0		Last Available: "2020-09"
 5746	stale jumbo bag of QWOP	5	decent	Last Available: "2012-07"
 5747	quadruple-pressed irradiated CSA bravery badge	0		Effect: "Deadly Lampblade", Effect Duration: 31, Last Available: "2012-07"
 5748	narrow CSA all-purpose soap	0		Last Available: "2012-07"
-5749	mediocre practically non-alcoholic CSA cheerfulness ration	1	decent	Last Available: "2012-07"
+5749	practically non-alcoholic mediocre CSA cheerfulness ration	1	decent	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	Tales of the Word Realms	0		
 5752	bland special massive tumbling crappy brain	9	decent	Effect: "Stimulated Body", Effect Duration: 25
-5753	gigantic normal fancy decent brain	8	good	Effect: "Human-Constellation Hybrid", Effect Duration: 5
+5753	normal fancy gigantic decent brain	8	good	Effect: "Human-Constellation Hybrid", Effect Duration: 5
 5754	snack-sized tasty blue good brain	2	awesome	
 5755	normal boss brain	3	good	
-5756	spoiled big special gray hunter brain	5	crappy	Effect: "Mushroom Magicalness", Effect Duration: 50
+5756	big special spoiled gray hunter brain	5	crappy	Effect: "Mushroom Magicalness", Effect Duration: 50
 5758	dance instructor's brainy Staff of Holiday Sensations	0		Mysticality: +5, Experience Percent (Moxie): +10, Item Drop: +5, Last Available: "2011-11"
 5759	mansplainer's sinister staff	0		Spell Damage: +10, Monster Level: +15
 5760	upside-down padded Socratic staff of horror	0		Experience (Mysticality): +1, Damage Absorption: +20, Spooky Spell Damage: +25
@@ -5665,11 +5665,11 @@
 5765	censurious fuzzy earmuffs of doom	0		Spooky Spell Damage: +50, Sleaze Resistance: +3, Familiar Effect: "1.5xVolley, cap 32"
 5766	Fonzie's Rosewater's fuzzy montera of Leguizamo	0		Mysticality Percent: +30, Experience (Moxie): +1, Monster Level: +20, Familiar Effect: "1.5xVolley, cap 32"
 5767	upside-down Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	ghostly spinning gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	ghostly spinning gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	skewed talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5678,7 +5678,7 @@
 5779	scorching keel-haulin' knife	0		Hot Damage: +25
 5780	ice cream scoop of Tarzan	0		Experience (Muscle): +3
 5781	mediocre irresponsibly strong soft echo eyedrop antidote martini	8	decent	
-5782	pulsating upside-down morningwood plank	0		
+5782	upside-down pulsating morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	shaking weirdwood plank	0		
 5785	thick caulk	0		
@@ -5687,13 +5687,13 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	up-at-dawn frosty right bear arm	0		Cold Spell Damage: +10, Adventures: +5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	rock-hard dangerous slick left bear arm	0		Moxie: +10, Weapon Damage: +10, Damage Reduction: 5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	up-at-dawn frosty right bear arm	0		Cold Spell Damage: +10, Adventures: +5, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	rock-hard dangerous slick left bear arm	0		Moxie: +10, Weapon Damage: +10, Damage Reduction: 5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	spinning groovy Hat O' Nine Tails	0		Moxie Percent: +10
 5794	galvanized Enchanted Plunger	0		Effect: "Innately Strong", Effect Duration: 52
 5795	galvanized quadruple-altered Enchanted Flyswatter	0		Effect: "The Spy Who Loved XP", Effect Duration: 16
 5796	irradiated blurry Gearhead Goo	0		Effect: "Bilious Brawn", Effect Duration: 17
-5797	energized deionized purple pulsating mirror Missing Eye Simulation Device	0		Effect: "Phairly Balanced", Effect Duration: 19
+5797	energized deionized mirror pulsating purple Missing Eye Simulation Device	0		Effect: "Phairly Balanced", Effect Duration: 19
 5798	quadruple-anodized Vulcanized non-diffused Gnollish Crossdress	0		Effect: "Cool Spirit", Effect Duration: 58
 5799	quadruple-unsweetened aerosolized teal eldritch dough	0		Effect: "Polka of Plenty", Effect Duration: 34
 5800	galvanized tumbling Charity's choker	0		Effect: "In the Saucestream", Effect Duration: 58
@@ -5732,7 +5732,7 @@
 5833	magnetized triple-alkaline cyan brigand brittle	0		Effect: "Helvella Health", Effect Duration: 39
 5834	galvanized vacuum-sealed holistic headache remedy	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 16
 5835	polarized concentrated scrunchie tourniquet	0		Effect: "Blood-Gorged", Effect Duration: 40
-5836	adjusted upside-down skewed narrow embezzler's oil	0		Effect: "Rat-Faced", Effect Duration: 40
+5836	adjusted skewed upside-down narrow embezzler's oil	0		Effect: "Rat-Faced", Effect Duration: 40
 5837	vacuum-sealed electrified blurry Fu Manchu Wax	0		Effect: "Feet of Watermelon", Effect Duration: 53
 5838	cold-filtered blinking Iiti Kitty Gumdrop	0		Effect: "Blackberry Politeness", Effect Duration: 51
 5839	magnetized blurry ravenous eye	0		Effect: "Hippy Flavor", Effect Duration: 17
@@ -5748,14 +5748,14 @@
 5849	Vulcanized extra-denatured narrow lime green handyman &quot;hand soap&quot;	0		Effect: "You're Not Cooking", Effect Duration: 35
 5850	enhanced space marine flash grenade	0		Effect: "Stands Alone", Effect Duration: 58
 5851	altered colloidal tarnished squat temporary tribal tattoo	0		Effect: "Hot Hands", Effect Duration: 56
-5852	diffused magnetized narrow cyan oil-filled donut	0		Effect: "Educated (Sorta)", Effect Duration: 21
+5852	diffused magnetized cyan narrow oil-filled donut	0		Effect: "Educated (Sorta)", Effect Duration: 21
 5853	nitrogenated stick-on gnome beard	0		Effect: "Stimulated Brain", Effect Duration: 40
 5854	diffused tarnished blinking BRICKO stud	0		Effect: "Pumped Up", Effect Duration: 63
 5855	polarized Osk'r Chow	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 59
 5856	anodized Scuba Snack	0		Effect: "Burnt 'n' Turnt", Effect Duration: 18
 5857	quantum spinning bouncing grey cube	0		Effect: "Top Dog", Effect Duration: 48
 5858	oxidized activated boiled wobbly votive candle	0		Effect: "Army of One", Effect Duration: 52
-5859	quantum gray huge huge booby trap	0		Effect: "Space Cadet", Effect Duration: 49
+5859	quantum huge gray huge booby trap	0		Effect: "Space Cadet", Effect Duration: 49
 5860	warmed cyan Agent Corrigan's cigarette	0		Effect: "Mer-kindliness", Effect Duration: 39
 5861	nitrogenated moist narrow good ash	0		Effect: "Strawberry Alarm", Effect Duration: 51
 5862	Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
@@ -5767,8 +5767,8 @@
 5868	Lo Pan's Oprah's papier-m&acirc;ch&eacute;te	0		Maximum MP Percent: +50, Spell Critical Percent: +30, Last Available: "2012-09"
 5869	blinking blurry healthy papier-m&acirc;chine gun of the early riser	0		Maximum HP Percent: +20, Adventures: +7, Last Available: "2012-09"
 5870	flame-wreathed Temple Grandin's papier-masque	0		Familiar Weight: +7, Hot Spell Damage: +10, Single Equip, Last Available: "2012-09"
-5871	papier-mitre of James Dean of the boozehound	0		Experience (Moxie): +3, Booze Drop: +100, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	Jeselnik's Socratic papier-m&acirc;churidars	0		Experience (Mysticality): +1, Sleaze Damage: +25, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	papier-mitre of James Dean of the boozehound	0		Experience (Moxie): +3, Booze Drop: +100, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	Jeselnik's Socratic papier-m&acirc;churidars	0		Experience (Mysticality): +1, Sleaze Damage: +25, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	blinking maroon papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	blurry packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	miser's nippy ruddy skeleton skis	0		Maximum HP Percent: +40, Cold Damage: +10, Meat Drop: +10, Single Equip, Last Available: "2012-10"
-5883	bite-sized decent skeleton quiche	1	good	Last Available: "2012-10"
+5883	decent bite-sized skeleton quiche	1	good	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	lightning-fast weightlifter's Bonestabber of the cougar of horror	0		Muscle: +15, Moxie: +20, Spooky Spell Damage: +25, Initiative: +40, Last Available: "2012-10"
@@ -5801,18 +5801,18 @@
 5902	jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
 5903	jittery jar of psychoses (The Meatsmith)	0		Last Available: "2013-12"
 5905	jar of psychoses (Jick)	0		Last Available: "2013-12"
-5906	mirror maroon pixel pill	0		
+5906	maroon mirror pixel pill	0		
 5907	pixel energy tank	0		
-5908	pulsating fuchsia ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
+5908	fuchsia pulsating ChibiBuddy&trade; (on)	0		Last Available: "2012-12"
 5909	asbestos-lined crafty wedding ring	0		Maximum MP: +10, Hot Resistance: +5, Single Equip
 5910	squat deactivated nanobots	0		Free Pull, Last Available: "2012-11"
 5911	cyan nanorhino credit card	0		Last Available: "2012-11"
 5912	Temple Grandin's savvy Solstice Shield	0		Mysticality Percent: +20, Familiar Weight: +7
 5913	anodized electrified candy sushi set	0		Effect: "Thick, Sick", Effect Duration: 33, Last Available: "2012-12"
-5914	dry enhanced blurry twirling sweet mochi ball	0		Effect: "Sweet Nostalgia", Effect Duration: 55, Last Available: "2012-12"
+5914	dry enhanced twirling blurry sweet mochi ball	0		Effect: "Sweet Nostalgia", Effect Duration: 55, Last Available: "2012-12"
 5915	wet irradiated beet-flavored Mr. Mediocrebar	0		Effect: "Slightly Mutated", Effect Duration: 45, Last Available: "2012-12"
 5916	irradiated unsweetened sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Tenacity of the Snapper", Effect Duration: 57, Last Available: "2012-12"
-5917	modified spinning purple cabbage-flavored Mr. Mediocrebar	0		Effect: "Super Accuracy", Effect Duration: 27, Last Available: "2012-12"
+5917	modified purple spinning cabbage-flavored Mr. Mediocrebar	0		Effect: "Super Accuracy", Effect Duration: 27, Last Available: "2012-12"
 5918	plastic animelf of temperance	0		Sleaze Resistance: +5, Last Available: "2012-12"
 5919	narrow groovy plastic ChibiBuddy&trade;	0		Moxie Percent: +10, Last Available: "2012-12"
 5920	coward's plastic taco-clad Crimbo elf	0		Monster Level: -20, Last Available: "2012-12"
@@ -5820,10 +5820,10 @@
 5922	bouncing horrifying plastic MechaElf	0		Spooky Damage: +25, Last Available: "2012-12"
 5923	jittery plastic ingot	0		Last Available: "2012-12"
 5924	electrical thingamabob	0		Last Available: "2012-12"
-5925	tumbling bouncing ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	huge jittery BittyCar MeatCar	0		Last Available: "2012-12"
+5925	bouncing tumbling ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
+5926	jittery huge BittyCar MeatCar	0		Last Available: "2012-12"
 5927	bouncing BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	brainwave-controlled unicorn horn of the bloodbag	0		Maximum HP: +100, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	squat huge blind-packed capsule toy	0		Last Available: "2012-12"
 5931	gravedigger's hardy plastic four-shadowed mime of bravery	0		Maximum HP: +50, Spooky Damage: +10, Spooky Resistance: +5, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	upside-down plastic Father McGruber of the brazier	0		Hot Spell Damage: +25, Last Available: "2012-12"
 5961	plastic Hank North, Photojournalist of the early riser	0		Adventures: +7, Last Available: "2012-12"
 5962	horrifying plastic blazing bat	0		Spooky Damage: +25, Last Available: "2012-12"
-5963	avaricious electronic dulcimer pants of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +30, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	avaricious electronic dulcimer pants of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +30, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	narrow A-Boo clue	0		
 5965	hardened slick Frown Exerciser	0		Moxie: +10, Damage Reduction: 3, Single Equip, Last Available: "2012-12"
 5966	huge soul monocle	0		Single Equip
@@ -5874,20 +5874,20 @@
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	green stanky silent beret of the boozehound of the glutton	0		Stench Spell Damage: +25, Booze Drop: +100, Food Drop: +100, Familiar Effect: "1xVolley, cap 3"
 5978	stale slice of pizza	4	decent	Last Available: "2013-02"
-5979	shaking mirror huge coin	0		Last Available: "2013-02"
+5979	mirror shaking huge coin	0		Last Available: "2013-02"
 5980	twirling cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	acceptable fancy tankard of ale	4	good	Effect: "Clyde's Blessing", Effect Duration: 40, Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	beefcake's cloth cap of the brazier of bravery	0		Muscle: +25, Hot Spell Damage: +25, Spooky Resistance: +5, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	beefcake's cloth cap of the brazier of bravery	0		Muscle: +25, Hot Spell Damage: +25, Spooky Resistance: +5, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	blinking Sherlock's veiny hardened iron dagger	0		Damage Reduction: 3, Maximum HP: +10, Item Drop: +25, Last Available: "2013-02"
-5986	delicious half-sized hamburger	2	awesome	Last Available: "2013-02"
+5986	half-sized delicious hamburger	2	awesome	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	red potion	0		Last Available: "2013-02"
 5989	lime green potion	0		Last Available: "2013-02"
-5990	fortified delicious lime green bottle of wine	5	awesome	Last Available: "2013-02"
+5990	delicious fortified lime green bottle of wine	5	awesome	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	jittery sharpshooter's electrified iron helmet of the glutton	0		Critical Hit Percent: +10, Food Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	jittery sharpshooter's electrified iron helmet of the glutton	0		Critical Hit Percent: +10, Food Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	zippy supercharged steel sword of the brute	0		Muscle Percent: +30, Maximum MP Percent: +30, Initiative: +20, Last Available: "2013-02"
 5994	rotten whole roasted chicken	4	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	shaking potion	0		Last Available: "2013-02"
 5998	watered-down tolerable shining goblet	2	good	Last Available: "2013-02"
 5999	blinking fireball	0		Last Available: "2013-02"
-6000	flame-wreathed stylish crown of the bloodbag	0		Moxie: +25, Maximum HP: +100, Hot Spell Damage: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	flame-wreathed stylish crown of the bloodbag	0		Moxie: +25, Maximum HP: +100, Hot Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	therapeutic hardened personal trainer's sword	0		Experience Percent (Muscle): +10, Damage Reduction: 3, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-02"
-6002	jittery mirror horrifying extremely unsafe Helm of the Scream Emperor of terror	0		Weapon Damage Percent: +100, Spooky Damage: +25, Spooky Spell Damage: +10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	jittery mirror horrifying extremely unsafe Helm of the Scream Emperor of terror	0		Weapon Damage Percent: +100, Spooky Damage: +25, Spooky Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	arcane researcher's thinker's Cloak of Dire Shadows of James Dean	0		Mysticality: +10, Experience (Moxie): +3, Experience Percent (Mysticality): +10, Last Available: "2013-02"
 6004	crafty healthy Sword of Dark Omens of the cougar	0		Moxie: +20, Maximum HP Percent: +20, Maximum MP: +10, Last Available: "2013-02"
 6005	sizzling wizardly Shield of Icy Fate of dire peril	0		Mysticality: +25, Weapon Damage: +20, Hot Damage: +10, Damage Reduction: 7, Last Available: "2013-02"
-6006	upside-down wool Greaves of the Murk Lord of extreme caution of doom	0		Monster Level: -25, Spooky Spell Damage: +50, Cold Resistance: +1, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	upside-down wool Greaves of the Murk Lord of extreme caution of doom	0		Monster Level: -25, Spooky Spell Damage: +50, Cold Resistance: +1, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	frosty forbidden smooth Gauntlets of the Blood Moon	0		Moxie: +15, Spell Damage Percent: +50, Cold Spell Damage: +10, Single Equip, Last Available: "2013-02"
 6008	veiny ruddy healthy Boots of Twilight Whispers	0		Maximum HP Percent: 60, Maximum HP: +10, Single Equip, Last Available: "2013-02"
 6009	jittery lightning-fast fireproof scandalous Belt of Howling Anger	0		Sleaze Damage: +5, Hot Resistance: +3, Initiative: +40, Single Equip, Last Available: "2013-02"
@@ -5921,7 +5921,7 @@
 6023	fuchsia double-paned wholesome Whoompa Fur Pants	0		Maximum HP Percent: +10, Cold Resistance: +5, Familiar Effect: "atk, cap 27"
 6024	huge nasty Whatsian Ionic Pliers	0		Stench Damage: +5
 6025	adjusted chilled Polysniff Perfume	0		Effect: "Knightlife", Effect Duration: 27
-6026	blinking green Duskwalker syringe	0		
+6026	green blinking Duskwalker syringe	0		
 6027	squat Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	blinking T.U.R.D.S. Key	0		
@@ -5951,7 +5951,7 @@
 6053	delicious Taco Dan's Taco Stand Chimichangarita	4	awesome	Last Available: "2012-12"
 6054	liquefied ionized double-tarnished red Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Old Time Hydration", Effect Duration: 52, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	upside-down therapeutic studded Meatcleaver	0		Damage Absorption: +80, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12"
 6058	weightlifter's Crimbo Elf bobble-head	0		Muscle: +15, Last Available: "2012-12"
 6059	Crimbo stogie-scented room odorizer of the cheetah	0		Initiative: +60, Last Available: "2012-12"
@@ -5960,7 +5960,7 @@
 6062	narrow ghostly Crimbo light-up Rudolph doll of the boozehound	0		Booze Drop: +100, Last Available: "2012-12"
 6063	zippy Super Crimboman Ultra Mega Hypersword	0		Initiative: +20, Last Available: "2012-12"
 6064	maroon sharp tin strip	0		
-6065	blinking teal wad of spider silk	0		
+6065	teal blinking wad of spider silk	0		
 6066	goblin collarbone	0		
 6067	electrified wizardly Truthsayer	0		Mysticality: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 6068	loose blade	0		
@@ -5971,15 +5971,15 @@
 6073	double-vacuum-sealed blinking haggis-infused soap	0		Effect: "Bolts about Candy", Effect Duration: 41, Last Available: "2012-12"
 6074	polymerized quadruple-denatured non-enhanced blinking magicberry tablets	0		Effect: "Sausage Festive", Effect Duration: 24, Last Available: "2012-12"
 6075	magnetized 37x37x37 puzzle cube	0		Effect: "Flower Power", Effect Duration: 66, Last Available: "2012-12"
-6076	artisanal bouncing tumbling McLeod's Hard Haggis-Ade	4	EPIC	Last Available: "2012-12"
+6076	artisanal tumbling bouncing McLeod's Hard Haggis-Ade	4	EPIC	Last Available: "2012-12"
 6077	moldy jittery haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
 6078	squat home robotics kit	0		Last Available: "2012-12"
 6079	shaking school calculator watch	0		Last Available: "2012-12"
-6080	MacGyver's haggis socks	0		Maximum MP: +100, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	gray airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	MacGyver's haggis socks	0		Maximum MP: +100, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	gray airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	teal Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	upside-down actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
-6084	upside-down lime green Mr. Haggis	0		Last Available: "2012-12"
+6084	lime green upside-down Mr. Haggis	0		Last Available: "2012-12"
 6085	magnetic sculpture kit	0		Last Available: "2012-12"
 6086	mansplainer's Microplushie: Otakulone	0		Monster Level: +15, Last Available: "2012-12"
 6087	savvy Microplushie: Hippylase	0		Mysticality Percent: +20, Last Available: "2012-12"
@@ -6016,10 +6016,10 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	drinkable watered-down Chinese beer	2	good	Last Available: "2013-12"
+6121	watered-down drinkable Chinese beer	2	good	Last Available: "2013-12"
 6122	cat statue	0		Last Available: "2013-12"
 6123	teal rhinoceros horn	0		Last Available: "2013-12"
-6124	teal skewed furry pink pillow	0		Last Available: "2013-12"
+6124	skewed teal furry pink pillow	0		Last Available: "2013-12"
 6125	altered double-deionized bottle of limeade	0		Effect: "Going Ape", Effect Duration: 44, Last Available: "2013-12"
 6126	auspicious Herculean novelty tattoo sleeves	0		Experience (Muscle): +1, Item Drop: +10, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
@@ -6040,30 +6040,30 @@
 6142	normal narrow roasted duck	3	good	Last Available: "2013-12"
 6143	half-sized flavorless cyan dead meat bun	2	decent	Last Available: "2013-12"
 6144	blue cat collar of the early riser	0		Adventures: +7, Single Equip, Last Available: "2013-12"
-6145	personal trainer's suspicious-looking fedora of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	personal trainer's suspicious-looking fedora of wisdom	0		Mysticality: +15, Experience Percent (Muscle): +10, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	narrow Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
 6152	flavorless enchanted purple carrot cake	4	decent	Effect: "The Power of Positive Thinking", Effect Duration: 50, Last Available: "2013-01"
-6153	acceptable high-proof carrot claret	10	good	Last Available: "2013-01"
+6153	high-proof acceptable carrot claret	10	good	Last Available: "2013-01"
 6154	diluted carrot juice	1	crappy	Last Available: "2013-01"
-6155	huge cyan pixel power cell	0		Last Available: "2013-12"
+6155	cyan huge pixel power cell	0		Last Available: "2013-12"
 6156	skewed flickering pixel	0		Last Available: "2013-12"
 6157	resourceful educational Byte	0		Experience: +1, Maximum MP: +50, Last Available: "2013-12"
-6158	teal smelly anger blaster	0		Stench Spell Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	bouncing doubt cannon of dire peril	0		Weapon Damage: +20, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	wobbly Jeselnik's fear condenser	0		Sleaze Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	grievous regret hose	0		Weapon Damage Percent: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	teal smelly anger blaster	0		Stench Spell Damage: +10, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	bouncing doubt cannon of dire peril	0		Weapon Damage: +20, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	wobbly Jeselnik's fear condenser	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	grievous regret hose	0		Weapon Damage Percent: +50, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	ghostly wool commodore's hat of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	pulsating dog trainer's naval trousers	0		Experience (familiar): +1, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	ghostly wool commodore's hat of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	pulsating dog trainer's naval trousers	0		Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	wool deck cannon of doom	0		Spooky Spell Damage: +50, Cold Resistance: +1, Last Available: "2013-12"
 6167	upside-down maroon ruddy ornamental sextant	0		Maximum HP Percent: +40, Last Available: "2013-12"
 6168	skewed Bloodbath of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: +50, Last Available: "2013-12"
-6169	bad watered-down ghostly Hundred Headed IPA	2	decent	Last Available: "2013-12"
+6169	watered-down bad ghostly Hundred Headed IPA	2	decent	Last Available: "2013-12"
 6170	snack-sized adequate chum	2	good	Last Available: "2013-12"
 6171	enhanced tumbling crude crudit&eacute;s	0		Effect: "Nano-juiced", Effect Duration: 17
 6172	energized improved candy crayons	0		Effect: "Superioreo", Effect Duration: 42, Last Available: "2020-09"
@@ -6080,11 +6080,11 @@
 6183	lime green cosmic fruit	0		
 6184	chilly dog trainer's Jarlsberg's hat of the overflowing toilet	0		Experience (familiar): +1, Cold Damage: +5, Stench Spell Damage: +50
 6185	decent consummate hard-boiled egg	3	good	
-6186	snack-sized moldy consummate fried egg	2	crappy	
-6187	bland jumbo consummate egg salad	5	decent	
+6186	moldy snack-sized consummate fried egg	2	crappy	
+6187	jumbo bland consummate egg salad	5	decent	
 6188	bite-sized adequate cyan consummate bagel	1	good	
-6189	snack-sized delicious shaking consummate sliced bread	2	awesome	
-6190	low-calorie flavorless narrow twirling consummate hot dog bun	1	decent	
+6189	delicious snack-sized shaking consummate sliced bread	2	awesome	
+6190	flavorless low-calorie narrow twirling consummate hot dog bun	1	decent	
 6191	rotten spinning consummate brownie	3	crappy	
 6192	spoiled big wobbly consummate toast	5	crappy	
 6193	watered-down lousy passable stout	2	decent	
@@ -6095,25 +6095,25 @@
 6198	toothsome huge twirling consummate sauerkraut	10	awesome	
 6199	normal consummate cheese slice	4	good	
 6200	spoiled consummate melted cheese	3	crappy	
-6201	adequate half-sized consummate bacon	2	good	
+6201	half-sized adequate consummate bacon	2	good	
 6202	spoiled purple consummate meatloaf	3	crappy	
 6203	moldy massive consummate steak	9	crappy	
-6204	enchanted snack-sized flavorless consummate cuts	2	decent	Effect: "Funky Coal Patina", Effect Duration: 45
-6205	big adequate consummate frankfurter	5	good	
+6204	flavorless snack-sized enchanted consummate cuts	2	decent	Effect: "Funky Coal Patina", Effect Duration: 45
+6205	adequate big consummate frankfurter	5	good	
 6206	rotten consummate french fries	3	crappy	
 6207	adequate upside-down consummate baked potato	4	good	
-6208	triple-distilled drinkable tumbling olive acceptable vodka	8	good	
+6208	drinkable triple-distilled olive tumbling acceptable vodka	8	good	
 6209	yummy consummate ice cream	3	awesome	
 6210	yummy half-sized olive consummate whipped cream	2	awesome	
 6211	adequate small mirror consummate cream	2	good	
-6212	thick tasty consummate strawberries	5	awesome	
+6212	tasty thick consummate strawberries	5	awesome	
 6213	huge bland consummate sorbet	9	decent	
 6214	perfectly mixed adequate rum	3	EPIC	
 6215	watered-down hand-crafted purple mediocre lager	2	EPIC	
 6216	bland immaculate grilled cheese	3	decent	
-6217	flavorless half-sized blurry immaculate ice cream sandwich	2	decent	
-6218	small moldy immaculate hot dog	2	crappy	
-6219	fancy toothsome immaculate egg salad sandwich	3	awesome	Effect: "Heightened Senses", Effect Duration: 50
+6217	half-sized flavorless blurry immaculate ice cream sandwich	2	decent	
+6218	moldy small immaculate hot dog	2	crappy	
+6219	toothsome fancy immaculate egg salad sandwich	3	awesome	Effect: "Heightened Senses", Effect Duration: 50
 6220	normal perfect sandwich	3	good	
 6221	bland perfect chef salad	3	decent	
 6222	flavorless perfect breakfast	4	decent	
@@ -6128,8 +6128,8 @@
 6231	lousy Vodka Dog	4	decent	
 6232	lousy Disappointed Russian	4	decent	
 6233	high-proof lousy Chunky Mary	9	decent	
-6234	enchanted practically non-alcoholic tolerable Nachojito	1	good	Effect: "Strength of Ten Ettins", Effect Duration: 35
-6235	irresponsibly strong bad tumbling fuchsia Le Roi	8	decent	
+6234	tolerable practically non-alcoholic enchanted Nachojito	1	good	Effect: "Strength of Ten Ettins", Effect Duration: 35
+6235	irresponsibly strong bad fuchsia tumbling Le Roi	8	decent	
 6236	bad Over Easy Rider	3	decent	
 6237	cosmic six-pack	0		
 6239	activated colloidal upside-down cube of ectoplasm	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 55
@@ -6182,11 +6182,11 @@
 6286	studded sinister Mark II Steam-Hat of the detective	0		Spell Damage: +10, Damage Absorption: +80, Item Drop: +20, Familiar Effect: "1xLep, cap 37"
 6287	narrow grievous thinker's Mark III Steam-Hat of Calamity Jane of the empath	0		Mysticality: +10, Weapon Damage Percent: +50, Critical Hit Percent: +15, Familiar Weight: +5, Familiar Effect: "1xLep, cap 37"
 6288	skewed sizzling ruddy quilted Mark IV Steam-Hat of the sewer of the cheetah	0		Damage Absorption: +40, Maximum HP Percent: +40, Hot Damage: +10, Stench Damage: +25, Initiative: +60, Familiar Effect: "1xLep, cap 37"
-6289	wobbly up-at-dawn avaricious aromatic fireproof sharpshooter's Mark V Steam-Hat	0		Critical Hit Percent: +10, Hot Resistance: +3, Stench Resistance: +1, Meat Drop: +30, Adventures: +5, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	wobbly up-at-dawn avaricious aromatic fireproof sharpshooter's Mark V Steam-Hat	0		Critical Hit Percent: +10, Hot Resistance: +3, Stench Resistance: +1, Meat Drop: +30, Adventures: +5, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	steam-powered model rocketship	0		
 6291	bouncing greedy double-paned punk rock jacket	0		Cold Resistance: +5, Meat Drop: +20
 6292	curative safety pin of the glutton	0		Food Drop: +100, HP Regen Min: 3, HP Regen Max: 5
-6293	small decent fancy pulsating stolen sushi	2	good	Effect: "Milk Studly", Effect Duration: 50
+6293	fancy small decent pulsating stolen sushi	2	good	Effect: "Milk Studly", Effect Duration: 50
 6294	mirror very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	olive cosmic bucket	0		Free Pull
@@ -6286,7 +6286,7 @@
 6391	alkaline diffused Mer-kin saltsquid	0		Effect: "Piratastic", Effect Duration: 69
 6392	experienced scale-mail underwear of Leguizamo	0		Experience: +2, Monster Level: +20, Familiar Effect: "2xVolley"
 6393	polarized quadruple-alkaline pulsating comb jelly	0		Effect: "Human-Elf Hybrid", Effect Duration: 66
-6394	cyan squat anemone sauce	0		
+6394	squat cyan anemone sauce	0		
 6395	inky squid sauce	0		
 6396	lime green Mer-kin weaksauce	0		
 6397	blurry peanut sauce	0		
@@ -6297,7 +6297,7 @@
 6402	electrified triple-irradiated jagged tooth	0		Effect: "Low on the Hog", Effect Duration: 14
 6403	anodized altered grisly shell fragment	0		Effect: "From Nantucket", Effect Duration: 39
 6404	unsweetened pickled violent pastilles	0		Effect: "Gutterminded", Effect Duration: 60
-6405	concentrated nitrogenated adjusted pulsating blinking worst candy	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 34
+6405	concentrated nitrogenated adjusted blinking pulsating worst candy	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 34
 6406	corrupted bouncing jittery fudge-shaped hole in space-time	0		Effect: "Morninja", Effect Duration: 55
 6407	frosty brawny Pocket Square of Loathing of the detective	0		Muscle Percent: +20, Cold Spell Damage: +10, Item Drop: +20, Single Equip
 6408	narrow corrupted stardust	0		
@@ -6308,10 +6308,10 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	upside-down clutch of dodecapede eggs	0		
 6415	snack-sized moldy blue flavorless gruel	2	crappy	
-6416	yummy tiny bouncing mana curds	1	awesome	
+6416	tiny yummy bouncing mana curds	1	awesome	
 6417	twist of lime	0		
 6418	pencil stub	0		
-6419	quadruple-unsweetened alkaline wobbly tumbling moth dust	0		Effect: "Square to be Hip", Effect Duration: 48
+6419	quadruple-unsweetened alkaline tumbling wobbly moth dust	0		Effect: "Square to be Hip", Effect Duration: 48
 6420	deionized triple-corrupted glob of spoiled mayo	0		Effect: "Poker Faced", Effect Duration: 51
 6421	tonic djinn	0		
 6422	decent squat vampire chowder	3	good	
@@ -6319,7 +6319,7 @@
 6424	upside-down Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
 6426	adequate Dreadsylvanian stew	4	good	
-6427	watered-down lousy Dreadsylvanian	2	decent	
+6427	lousy watered-down Dreadsylvanian	2	decent	
 6428	alkaline anodized bouncing Dreadsylvanian flask	0		Effect: "Creepin' Up on You", Effect Duration: 63
 6429	irradiated deionized upside-down Dreadsylvanian flask	0		Effect: "Bastard!", Effect Duration: 64
 6430	tumbling MacGyver's dreadful fedora of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
@@ -6344,7 +6344,7 @@
 6449	jittery inspector's dance instructor's brainy Great Wolf's right paw	0		Mysticality: +5, Experience Percent (Moxie): +10, Item Drop: +15, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	huge boxer's Great Wolf's rocket launcher of the sweet-tooth	0		Muscle Percent: +10, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	bouncing Temple Grandin's Tesla Great Wolf's beastly trousers of the brazier	0		Familiar Weight: +7, Hot Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xPotato, 1.5xWhelp"
-6452	cyan bouncing blinking Great Wolf's lice	0		
+6452	blinking cyan bouncing Great Wolf's lice	0		
 6453	altered Hunger&trade; Sauce	0		Effect: "Total Protonic Reversal", Effect Duration: 16
 6454	mirror sinister zombie mariachi hat of the brazier of incineration	0		Spell Damage: +10, Hot Spell Damage: 75, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	knitted rosy-cheeked zombie accordion of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Cold Resistance: +3, Class: "Accordion Thief", Single Equip, Song Duration: 20
@@ -6375,9 +6375,9 @@
 6480	skewed skewed smelly chilly Unkillable Skeleton's shield	0		Cold Damage: +5, Stench Spell Damage: +10, Damage Reduction: 23
 6481	frosty Unkillable Skeleton's restless leg of the cougar	0		Moxie: +20, Cold Spell Damage: +10
 6482	pulsating executive rosy-cheeked wizardly Staff of the Roaring Hearth	0		Mysticality: +25, Maximum HP Percent: +30, Meat Drop: +40
-6483	narrow mirror Kool-Aid	1	crappy	
+6483	mirror narrow Kool-Aid	1	crappy	
 6484	dread tarragon	0		
-6485	shaking huge huge bone flour	0		
+6485	huge shaking huge bone flour	0		
 6486	huge dreadful roast	0		
 6487	stinking agaricus	0		
 6488	thick normal Dreadsylvanian shepherd's pie	5	good	
@@ -6450,14 +6450,14 @@
 6556	modified liquefied phial of hotness	0		Effect: "Horrid, Torrid", Effect Duration: 27
 6557	cold-filtered phial of coldness	0		Effect: "Comic Violence", Effect Duration: 65
 6558	ionized phial of spookiness	0		Effect: "Jacked In", Effect Duration: 28
-6559	corrupted ionized blurry spinning tumbling phial of stench	0		Effect: "Berry Statistical", Effect Duration: 26
+6559	corrupted ionized spinning tumbling blurry phial of stench	0		Effect: "Berry Statistical", Effect Duration: 26
 6560	irradiated phial of sleaziness	0		Effect: "Pisces in the Skyces", Effect Duration: 62
 6561	mirror adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	tumbling mini-Mr. Accessory	0		Familiar Weight: +5
 6563	avaricious hand of Mr. Cards	0		Meat Drop: +30, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	adequate Dreadsylvanian hot pocket	4	good	
 6565	spoiled Dreadsylvanian pocket	4	crappy	
-6566	delicious small twirling Dreadsylvanian pocket	2	awesome	
+6566	small delicious twirling Dreadsylvanian pocket	2	awesome	
 6567	moldy Dreadsylvanian stink pocket	3	crappy	
 6568	immense adequate Dreadsylvanian sleaze pocket	6	good	
 6569	bad Dreadsylvanian hot toddy	3	decent	
@@ -6486,12 +6486,12 @@
 6592	green double-paned crafty optimal spreadsheet of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +10, Cold Resistance: +5
 6593	defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
-6595	diluted bouncing teal upside-down epic cluster	1	good	
+6595	diluted teal upside-down bouncing epic cluster	1	good	
 6596	clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	jittery clockwork disc	0		
 6599	clockwork hand	0		
-6600	skewed purple clockwork hand	0		
+6600	purple skewed clockwork hand	0		
 6601	blurry clockwork numeral I	0		
 6602	gray clockwork numeral II	0		
 6603	clockwork numeral III	0		
@@ -6506,8 +6506,8 @@
 6612	fuchsia clockwork numeral XII	0		
 6613	pulsating clockwork cuckoo	0		
 6614	squat cuckoo clock	0		
-6615	lousy extra-dry fancy bouncing Cold One	5	???	Effect: "Loyal Tea", Effect Duration: 35
-6616	immense decent spaghetti breakfast	8	???	
+6615	fancy lousy extra-dry bouncing Cold One	5	???	Effect: "Loyal Tea", Effect Duration: 35
+6616	decent immense spaghetti breakfast	8	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6531,7 +6531,7 @@
 6637	squat folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
 6638	maroon folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	tumbling folder (owl)	0		Last Available: "2013-08"
-6640	blue shaking folder (Stinky Trash Kid)	0		Last Available: "2013-08"
+6640	shaking blue folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	huge folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
 6642	jittery folder (sportsballs)	0		PvP Fights: +5, Last Available: "2013-08"
 6643	folder (heavy metal)	0		Familiar Weight: +5, Last Available: "2013-08"
@@ -6550,7 +6550,7 @@
 6658	pressed moist hair oil	0		Effect: "The Power of Negative Thinking", Effect Duration: 50
 6659	alkaline polymerized energized scrap	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25
 6660	school spirit socket set	0		
-6661	spinning skewed suspension bridge	0		
+6661	skewed spinning suspension bridge	0		
 6662	aromatic therapeutic Staff of the Lunch Lady of mayonnaise of bravery	0		Sleaze Spell Damage: +50, Spooky Resistance: +5, Stench Resistance: +1, HP Regen Min: 5, HP Regen Max: 7
 6663	wobbly universal key	0		
 6664	wobbly world's most dangerous birdhouse	0		
@@ -6569,7 +6569,7 @@
 6677	maroon crude monster sculpture	0		
 6678	flame-retardant Yearbook Club Camera	0		Hot Resistance: +1, Conditional Skill (Equipped): "Blinding Flash"
 6679	teal mirror machete of dire peril	0		Weapon Damage: +20
-6680	lousy watered-down Cursed Punch	2	decent	
+6680	watered-down lousy Cursed Punch	2	decent	
 6681	smooth Bowl of Scorpions	4	awesome	
 6682	lousy pulsating Fog Murderer	3	decent	
 6683	gray book of matches	0		
@@ -6594,7 +6594,7 @@
 6702	narrow bowler	0		
 6703	teal imitation White Russian	1	decent	
 6704	Jack Frost's dangerous short-handled mop	0		Weapon Damage: +10, Cold Spell Damage: +50
-6705	flavorless fuchsia wobbly jungle floor wax	4	decent	
+6705	flavorless wobbly fuchsia jungle floor wax	4	decent	
 6706	smirking shrunken head	0		
 6707	corrupted aerosolized skewed narrow colorful toad	0		Effect: "Cravin' for a Ravin'", Effect Duration: 50
 6708	crude voodoo doll	0		
@@ -6606,7 +6606,7 @@
 6714	ghostly huge short calculator	0		
 6715	wobbly Usain Bolt's sphygmomanometer of the businessman	0		Meat Drop: +50, Initiative: +80
 6716	Vulcanized bag of pygmy blood	0		Effect: "Scrappy, Shadowy", Effect Duration: 30
-6717	twirling spinning tongue depressor	0		
+6717	spinning twirling tongue depressor	0		
 6718	twirling lard-coated thinker's compression stocking	0		Mysticality: +10, Sleaze Spell Damage: +25
 6719	jittery stiffened educational midriff scrubs	0		Experience: +1, Damage Reduction: 1
 6720	warmed olive pill cup	0		Effect: "Thick-Skinned", Effect Duration: 68
@@ -6622,7 +6622,7 @@
 6730	wobbly funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	upside-down claw-foot bathtub	0		
-6733	blue wobbly clothesline pole	0		
+6733	wobbly blue clothesline pole	0		
 6734	cigar sign	0		
 6735	junk junk	0		
 6736	Junk-Bond	0		
@@ -6634,7 +6634,7 @@
 6742	narrow spinning junk band of vim and vigor	0		Maximum HP Percent: +50
 6743	jittery aromatic junk trunks	0		Stench Resistance: +1, Familiar Effect: "cap 15"
 6744	stylish junk-mail shirt	0		Moxie: +25
-6745	bland mirror upside-down junk food	3	decent	
+6745	bland upside-down mirror junk food	3	decent	
 6746	hand-crafted junk yard	4	EPIC	
 6747	miser's Rosewater's swordzall	0		Mysticality Percent: +30, Meat Drop: +10
 6748	lard-coated arm buzzer	0		Sleaze Spell Damage: +25, Damage Reduction: 6
@@ -6647,18 +6647,18 @@
 6755	upside-down pulsating beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	perfectly mixed blurry can of Br&uuml;talbr&auml;u	3	EPIC	Last Available: "2013-09"
-6758	acceptable weak can of Drooling Monk	2	good	Last Available: "2013-09"
+6758	weak acceptable can of Drooling Monk	2	good	Last Available: "2013-09"
 6759	bad blue can of Impetuous Scofflaw	4	decent	Last Available: "2013-09"
 6760	artisanal extra-dry bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
 6761	artisanal bottle of Professor Beer	4	EPIC	Last Available: "2013-09"
-6762	perfectly mixed practically non-alcoholic bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6762	practically non-alcoholic perfectly mixed bottle of Rapier Witbier	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6763	bad bottle of Race Car Red	4	decent	Last Available: "2013-09"
 6764	hand-crafted squat bottle of Greedy Dog	3	EPIC	Last Available: "2013-09"
 6765	aged bottle of Lambada Lambic	3	awesome	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
-6768	skewed blinking liquid bread	1	good	Last Available: "2013-09"
-6769	scandalous therapeutic Socratic tin tam	0		Experience (Mysticality): +1, Sleaze Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6768	blinking skewed liquid bread	1	good	Last Available: "2013-09"
+6769	scandalous therapeutic Socratic tin tam	0		Experience (Mysticality): +1, Sleaze Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	galvanized tin cup	0		Effect: "Sweet and Green", Effect Duration: 56, Last Available: "2013-09"
 6771	Samson's tin foil of the brute of the blizzard	0		Muscle Percent: +30, Experience (Muscle): +5, Cold Spell Damage: +25, Last Available: "2013-09"
 6772	lightning-fast perfumed banded tin drum	0		Damage Absorption: +100, Stench Resistance: +5, Initiative: +40, Last Available: "2013-09"
@@ -6673,7 +6673,7 @@
 6781	double-paned lion tamer's scabrous seal epaulets	0		Experience (familiar): +2, Cold Resistance: +5, Single Equip
 6782	abyssal battle plans	0		
 6783	mansplainer's Tesla MacGyver's seal medal	0		Maximum MP: +100, Monster Level: +15, MP Regen Min: 7, MP Regen Max: 10
-6784	spinning upside-down spinning deanimated reanimator's coffin	0		Free Pull
+6784	upside-down spinning spinning deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
 6788	blank diary	0		
 6789	lime green boot knife	0		
@@ -6682,7 +6682,7 @@
 6792	twirling candy knife	0		
 6793	blinking soap knife	0		
 6795	ionized yellow disco horoscope (Aquarius)	0		Effect: "Reptilian Fortitude", Effect Duration: 18
-6796	altered double-colloidal huge lime green disco horoscope (Pisces)	0		Effect: "Super Accuracy", Effect Duration: 16
+6796	altered double-colloidal lime green huge disco horoscope (Pisces)	0		Effect: "Super Accuracy", Effect Duration: 16
 6797	flattened ghostly upside-down disco horoscope (Aries)	0		Effect: "Cold Throat", Effect Duration: 58
 6798	diffused blinking disco horoscope (Taurus)	0		Effect: "Corruption of Wretched Wally", Effect Duration: 60
 6799	aerosolized double-polarized narrow disco horoscope (Gemini)	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 55
@@ -6717,11 +6717,11 @@
 6828	aged twirling discocktail	3	awesome	
 6829	nasty KoL Con X Bingo Card	0		Stench Damage: +5
 6830	cool Temporal Tempera Tube	0		Moxie: +5
-6831	double-polymerized tumbling gray Tallowcreme Halloween Pumpkin	0		Effect: "Warm Shoulders", Effect Duration: 15
+6831	double-polymerized gray tumbling Tallowcreme Halloween Pumpkin	0		Effect: "Warm Shoulders", Effect Duration: 15
 6832	olive upside-down Way More Tears&trade; pepper spray	0		
 6833	pressed Milk Studs	0		Effect: "Liquidy Smoky", Effect Duration: 46
 6834	nitrogenated Vulcanized box of Dweebs	0		Effect: "Bastard!", Effect Duration: 32
-6835	extra-wet bouncing skewed blurry bag of W&Ws	0		Effect: "Mmmmmelon", Effect Duration: 59
+6835	extra-wet blurry bouncing skewed bag of W&Ws	0		Effect: "Mmmmmelon", Effect Duration: 59
 6836	tarnished double-magnetized double-ionized PEEZ dispenser	0		Effect: "Human-Goblin Hybrid", Effect Duration: 25
 6837	improved flattened concentrated olive Swizzler	0		Effect: "Hare-o-dynamic", Effect Duration: 47
 6838	cold-filtered warmed wobbly Bugbearclaw Donut	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 20
@@ -6746,12 +6746,12 @@
 6857	Cajun accordion of the early riser	0		Adventures: +7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	skewed thinker's quirky accordion	0		Mysticality: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	wobbly jittery auspicious lion tamer's Skipper's accordion	0		Experience (familiar): +2, Item Drop: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	family-friendly perfumed frosty Pantsgiving of the businessman	0		Cold Spell Damage: +10, Stench Resistance: +5, Sleaze Resistance: +1, Meat Drop: +50, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
-6861	special adequate huge ghostly can of sardines	7	good	Effect: "How to Scam Tourists", Effect Duration: 35, Last Available: "2013-11"
+6860	family-friendly perfumed frosty Pantsgiving of the businessman	0		Cold Spell Damage: +10, Stench Resistance: +5, Sleaze Resistance: +1, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6861	huge adequate special ghostly can of sardines	7	good	Effect: "How to Scam Tourists", Effect Duration: 35, Last Available: "2013-11"
 6862	flavorless bite-sized twirling high-calorie sugar substitute	1	decent	Last Available: "2013-11"
-6863	low-calorie spoiled pulsating pat of butter	1	crappy	Last Available: "2013-11"
+6863	spoiled low-calorie pulsating pat of butter	1	crappy	Last Available: "2013-11"
 6864	spoiled dinner roll	3	crappy	Last Available: "2013-11"
-6865	snack-sized flavorless mashed potatoes	2	decent	Last Available: "2013-11"
+6865	flavorless snack-sized mashed potatoes	2	decent	Last Available: "2013-11"
 6866	adequate snack-sized whole turkey leg	2	good	Last Available: "2013-11"
 6867	bland deviled egg	3	decent	Last Available: "2013-11"
 6868	alkaline alkaline finger exerciser	0		Effect: "Hoity Toity", Effect Duration: 47, Last Available: "2013-11"
@@ -6759,7 +6759,7 @@
 6870	flattened triple-polarized wobbly love note	0		Effect: "Infernal Thirst", Effect Duration: 48, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	dry nail file	0		Effect: "The Rich Get Richer", Effect Duration: 41, Last Available: "2013-11"
-6873	warmed extra-boiled skewed olive candy wrapper	0		Effect: "Lemon Enlightenment", Effect Duration: 35, Last Available: "2013-11"
+6873	warmed extra-boiled olive skewed candy wrapper	0		Effect: "Lemon Enlightenment", Effect Duration: 35, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	pressed post-holiday sale coupon	0		Effect: "You Read The Manual", Effect Duration: 15, Last Available: "2013-11"
 6876	spinning dry cleaning receipt	0		Last Available: "2013-11"
@@ -6779,11 +6779,11 @@
 6890	spirit bed	0		
 6891	tumbling electrified beefy spirit bell of mayonnaise	0		Muscle: +10, Sleaze Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Class: "Turtle Tamer"
 6892	concentrated spoonful of Linguine-Os	0		Effect: "Penguinny Flavor", Effect Duration: 27, Last Available: "2013-11"
-6893	pressed extra-warmed tumbling squat red freezer-burned frost-bitten tortellini	0		Effect: "Hoity Toity", Effect Duration: 21, Last Available: "2013-11"
+6893	pressed extra-warmed red squat tumbling freezer-burned frost-bitten tortellini	0		Effect: "Hoity Toity", Effect Duration: 21, Last Available: "2013-11"
 6894	activated altered blob of Alphredo&trade;	0		Effect: "Carrrsmic", Effect Duration: 48, Last Available: "2013-11"
 6895	Vulcanized handful of crafty noodles	0		Effect: "Physicali Tea", Effect Duration: 12, Last Available: "2013-11"
 6896	unsweetened tangled mass of pasta	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 57, Last Available: "2013-11"
-6897	dry purple squat Can of Spaghetto	0		Effect: "Fan-Cooled", Effect Duration: 53, Last Available: "2013-11"
+6897	dry squat purple Can of Spaghetto	0		Effect: "Fan-Cooled", Effect Duration: 53, Last Available: "2013-11"
 6898	Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
 6900	upside-down experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
@@ -6791,9 +6791,9 @@
 6902	wobbly studded flask flops of the cougar	0		Moxie: +20, Damage Absorption: +80, Single Equip
 6903	quadruple-cold-filtered nuts	0		Effect: "Moon'd", Effect Duration: 22, Last Available: "2013-12"
 6904	super-ionized bolts	0		Effect: "Stenchtastic", Effect Duration: 38, Last Available: "2013-12"
-6905	decent ghostly fuchsia tumbling gingerbread robot	3	good	Last Available: "2013-12"
+6905	decent fuchsia tumbling ghostly gingerbread robot	3	good	Last Available: "2013-12"
 6906	adequate petit 4.1	4	good	Last Available: "2013-12"
-6907	fancy spoiled big nut-shaped Crimbo cookie	5	crappy	Effect: "Human-Pirate Hybrid", Effect Duration: 35, Last Available: "2023-06"
+6907	spoiled big fancy nut-shaped Crimbo cookie	5	crappy	Effect: "Human-Pirate Hybrid", Effect Duration: 35, Last Available: "2023-06"
 6908	pulsating plastic GORM-8 of the scaredy-cat	0		Monster Level: -15, Last Available: "2013-12"
 6909	grievous plastic warbear	0		Weapon Damage Percent: +50, Last Available: "2013-12"
 6910	huge nippy plastic Toybot	0		Cold Damage: +10, Last Available: "2013-12"
@@ -6811,28 +6811,28 @@
 6922	flavorless small warbear warrior bread	2	decent	Last Available: "2013-12"
 6923	adequate gigantic warbear thermoregulator bread	6	good	Last Available: "2013-12"
 6924	perfectly mixed warbear feasting mead	3	EPIC	Last Available: "2013-12"
-6925	hand-crafted maroon narrow warbear bearserker mead	3	EPIC	Last Available: "2013-12"
+6925	hand-crafted narrow maroon warbear bearserker mead	3	EPIC	Last Available: "2013-12"
 6926	practically non-alcoholic artisanal blurry warbear blizzard mead	1	super ultra mega turbo EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	foul-smelling sage warbear plain fedora of Gandalf	0		Mysticality Percent: +10, Spell Critical Percent: +20, Stench Damage: +10, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	warbear feathered fedora of courage	0		Spooky Resistance: +3, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	squat mansplainer's hardy rosy-cheeked warbear fedora	0		Maximum HP Percent: +30, Maximum HP: +50, Monster Level: +15, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	up-at-dawn scandalous Newton's warbear plain helm	0		Experience (Mysticality): +3, Sleaze Damage: +5, Adventures: +5, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	Sinatra's warbear spiked helm	0		Experience (Moxie): +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	executive Van der Graaf fortified warbear electro-spiked helm	0		Damage Absorption: +60, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	bouncing greedy warbear plain ushanka of the brute of the sewer	0		Muscle Percent: +30, Stench Damage: +25, Meat Drop: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	warbear lined ushanka of dire peril	0		Weapon Damage: +20, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	lightning-fast ruddy warbear heated ushanka of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +40, Initiative: +40, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	foul-smelling sage warbear plain fedora of Gandalf	0		Mysticality Percent: +10, Spell Critical Percent: +20, Stench Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	warbear feathered fedora of courage	0		Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	squat mansplainer's hardy rosy-cheeked warbear fedora	0		Maximum HP Percent: +30, Maximum HP: +50, Monster Level: +15, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	up-at-dawn scandalous Newton's warbear plain helm	0		Experience (Mysticality): +3, Sleaze Damage: +5, Adventures: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	Sinatra's warbear spiked helm	0		Experience (Moxie): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	executive Van der Graaf fortified warbear electro-spiked helm	0		Damage Absorption: +60, Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	bouncing greedy warbear plain ushanka of the brute of the sewer	0		Muscle Percent: +30, Stench Damage: +25, Meat Drop: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	warbear lined ushanka of dire peril	0		Weapon Damage: +20, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	lightning-fast ruddy warbear heated ushanka of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +40, Initiative: +40, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	wobbly auspicious supercharged warbear party pants of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Item Drop: +10, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	vibrating warbear ceremonial party pants	0		Maximum MP Percent: +10, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	supercharged hardened sinister warbear high festival pants	0		Spell Damage: +10, Damage Reduction: 3, Maximum MP Percent: +30, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	lard-coated groovy warbear battle greaves of the businessman	0		Moxie Percent: +10, Sleaze Spell Damage: +25, Meat Drop: +50, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	bouncing toasty warbear officer greaves	0		Hot Damage: +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	wool ruddy experienced warbear bearserker greaves	0		Experience: +2, Maximum HP Percent: +40, Cold Resistance: +1, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	shaking wholesome warbear johns of the bloodbag of extreme caution	0		Maximum HP Percent: +10, Maximum HP: +100, Monster Level: -25, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	warbear fleece-lined johns of extreme caution	0		Monster Level: -25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	foul-smelling Temple Grandin's medical-grade warbear johns	0		Familiar Weight: +7, Stench Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	wobbly auspicious supercharged warbear party pants of extreme caution	0		Maximum MP Percent: +30, Monster Level: -25, Item Drop: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	vibrating warbear ceremonial party pants	0		Maximum MP Percent: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	supercharged hardened sinister warbear high festival pants	0		Spell Damage: +10, Damage Reduction: 3, Maximum MP Percent: +30, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	lard-coated groovy warbear battle greaves of the businessman	0		Moxie Percent: +10, Sleaze Spell Damage: +25, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	bouncing toasty warbear officer greaves	0		Hot Damage: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	wool ruddy experienced warbear bearserker greaves	0		Experience: +2, Maximum HP Percent: +40, Cold Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	shaking wholesome warbear johns of the bloodbag of extreme caution	0		Maximum HP Percent: +10, Maximum HP: +100, Monster Level: -25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	warbear fleece-lined johns of extreme caution	0		Monster Level: -25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	foul-smelling Temple Grandin's medical-grade warbear johns	0		Familiar Weight: +7, Stench Damage: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	warbear goggles of the brute of horror of Flo-Jo	0		Muscle Percent: +30, Spooky Spell Damage: +25, Initiative: +100, Single Equip, Last Available: "2013-12"
 6949	frightening warbear snowblindness goggles	0		Spooky Damage: +5, Single Equip, Last Available: "2013-12"
@@ -6845,12 +6845,12 @@
 6956	auspicious reassuring greasy warbear warscarf	0		Sleaze Spell Damage: +10, Spooky Resistance: +1, Item Drop: +10, Single Equip, Last Available: "2013-12"
 6957	skewed warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	squat ruddy warbear foil hat	0		Maximum HP Percent: +40, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	squat ruddy warbear foil hat	0		Maximum HP Percent: +40, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	cyan warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	educational stylish warbear oil pan	0		Moxie: +25, Experience: +1, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	educational stylish warbear oil pan	0		Moxie: +25, Experience: +1, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	warbear exhaust manifold of doom	0		Spooky Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
-6964	spinning lime green warbear jackhammer drill press	0		Last Available: "2013-12"
+6964	lime green spinning warbear jackhammer drill press	0		Last Available: "2013-12"
 6965	warbear auto-anvil	0		Last Available: "2013-12"
 6966	warbear induction oven	0		Last Available: "2013-12"
 6967	narrow warbear chemistry lab	0		Last Available: "2013-12"
@@ -6894,9 +6894,9 @@
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered maroon handful of Smithereens	1	decent	Last Available: "2013-12"
 7007	moldy massive Every Day is Like This Sundae	10	crappy	Last Available: "2013-12"
-7008	bland tiny Miserable Pie	1	decent	Last Available: "2013-12"
+7008	tiny bland Miserable Pie	1	decent	Last Available: "2013-12"
 7009	spoiled This Charming Flan	3	crappy	Last Available: "2013-12"
-7010	mediocre weak Irish Coffee, English Heart	2	decent	Last Available: "2013-12"
+7010	weak mediocre Irish Coffee, English Heart	2	decent	Last Available: "2013-12"
 7011	perfectly mixed triple-distilled Strikes Again Bigmouth	6	EPIC	Last Available: "2013-12"
 7012	smooth Paint A Vulgar Pitcher	4	awesome	Last Available: "2013-12"
 7013	bouncing Golden Light	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	maroon perfumed MacGyver's steel-toed Sheila Take a Crossbow of dire peril	0		Weapon Damage: +20, Damage Reduction: 9, Maximum MP: +100, Stench Resistance: +5, Last Available: "2013-12"
 7019	blurry Jack Frost's occult Sinatra's brainy A Light that Never Goes Out	0		Mysticality: +5, Experience (Moxie): +5, Spell Damage Percent: +25, Cold Spell Damage: +50, Last Available: "2013-12"
 7020	Usain Bolt's sizzling chilly Half a Purse of terror	0		Cold Damage: +5, Hot Damage: +10, Spooky Spell Damage: +10, Initiative: +80, Last Available: "2013-12"
-7021	jittery inspector's Oprah's grievous Hairpiece On Fire of the cheetah	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Item Drop: +15, Initiative: +60, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	Jeselnik's dog trainer's Da Vinci's boxer's Vicar's Tutu	0		Muscle Percent: +10, Experience (Mysticality): +5, Experience (familiar): +1, Sleaze Damage: +25, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	jittery inspector's Oprah's grievous Hairpiece On Fire of the cheetah	0		Weapon Damage Percent: +50, Maximum MP Percent: +50, Item Drop: +15, Initiative: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	Jeselnik's dog trainer's Da Vinci's boxer's Vicar's Tutu	0		Muscle Percent: +10, Experience (Mysticality): +5, Experience (familiar): +1, Sleaze Damage: +25, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	fortified personal trainer's Hand in Glove of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Damage Absorption: +60, Single Equip, Last Available: "2013-12"
 7024	crafty quilted groovy Meat Tenderizer is Murder	0		Moxie Percent: +10, Damage Absorption: +40, Maximum MP: +10, Class: "Seal Clubber", Last Available: "2013-12"
 7025	perfumed fireproof friendly Ouija Board, Ouija Board	0		Familiar Weight: +3, Hot Resistance: +3, Stench Resistance: +5, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6939,7 +6939,7 @@
 7050	decent upside-down warbear gyro	3	good	Last Available: "2013-12"
 7051	concentrated jittery teal recording of Rolando's Rondo of Resisto	0		Effect: "Nigh-Invincible", Effect Duration: 20, Last Available: "2013-12"
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
-7053	gray narrow warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
+7053	narrow gray warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	spinning warbear drone codes	0		Last Available: "2013-12"
 7055	decent small breakfast mess	2	good	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
@@ -6951,25 +6951,25 @@
 7062	praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	purple Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	vaporized blurry spinning purple grim fairy tale	1	EPIC	Last Available: "2014-12"
+7065	vaporized purple spinning blurry grim fairy tale	1	EPIC	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	improved denatured single of Inigo's Incantation of Inspiration	0		Effect: "Ginger Snapped", Effect Duration: 11, Last Available: "2010-02"
 7068	anodized vacuum-sealed denatured single of Donho's Bubbly Ballad	0		Effect: "Experimental Effect G-9", Effect Duration: 36
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
 7071	flavorless blinking snow berries	3	decent	Last Available: "2014-01"
-7072	half-sized tasty ice harvest	2	awesome	Last Available: "2014-01"
+7072	tasty half-sized ice harvest	2	awesome	Last Available: "2014-01"
 7073	tarnished narrow frost flower	0		Effect: "Rat-Faced", Effect Duration: 38, Last Available: "2014-01"
 7074	vacuum-sealed bouncing maroon snow cleats	0		Effect: "Extra-Thick Blood", Effect Duration: 40, Last Available: "2014-01"
 7075	energized liquid ice pack	0		Effect: "Disco Nirvana", Effect Duration: 51, Last Available: "2014-01"
 7076	blinking squat cyan snow boards	0		Last Available: "2014-01"
-7077	enchanted delicious huge mirror snow crab	10	awesome	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2014-01"
+7077	huge delicious enchanted mirror snow crab	10	awesome	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2014-01"
 7078	bad Ice Island Long Tea	4	decent	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	shaking snow mobile of Flo-Jo	0		Initiative: +100, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	shaking snow mobile of Flo-Jo	0		Initiative: +100, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	arcane researcher's ice bucket	0		Experience Percent (Mysticality): +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	avaricious banded snow shovel	0		Damage Absorption: +100, Meat Drop: +30, Lasts Until Rollover, Last Available: "2014-01"
 7086	lightning-fast energetic beefcake's bod-ice	0		Muscle: +25, Maximum MP Percent: +20, Initiative: +40, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	delicious En Una Fila Tequila	4	awesome	
 7091	Skully's hot chocolate	1	EPIC	
-7092	yellow family-friendly Samson's warbear dress helmet	0		Experience (Muscle): +5, Sleaze Resistance: +1, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	yellow family-friendly Samson's warbear dress helmet	0		Experience (Muscle): +5, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	rosewater-soaked foul-smelling warbear dress bracers	0		Stench Damage: +10, Stench Resistance: +3, Single Equip, Last Available: "2013-12"
-7094	warbear dress greaves of the cheetah of Flo-Jo	0		Initiative: 160, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	inspector's dangerous sweatband	0		Weapon Damage: +10, Item Drop: +15, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	toasty careful gym shorts	0		Monster Level: -10, Hot Damage: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	warbear dress greaves of the cheetah of Flo-Jo	0		Initiative: 160, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	inspector's dangerous sweatband	0		Weapon Damage: +10, Item Drop: +15, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	toasty careful gym shorts	0		Monster Level: -10, Hot Damage: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	ankleweights of the brute of Leguizamo	0		Muscle Percent: +30, Monster Level: +20, Single Equip, Last Available: "2014-12"
 7098	family-friendly double-paned gravedigger's Annie Oakley's sweat socks	0		Critical Hit Percent: +20, Spooky Damage: +10, Cold Resistance: +5, Sleaze Resistance: +1, Last Available: "2014-12"
 7099	blinking teal pint of sweat	0		Last Available: "2014-12"
@@ -6995,21 +6995,21 @@
 7106	hand-crafted huge yellow snakebite	3	EPIC	Last Available: "2014-12"
 7107	aromatic Annie Oakley's candy stick	0		Critical Hit Percent: +20, Stench Resistance: +1, Last Available: "2014-12"
 7108	bland pecan	3	decent	Last Available: "2014-12"
-7109	gigantic normal squat red pecan pie	10	good	Last Available: "2014-12"
+7109	normal gigantic squat red pecan pie	10	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	gigantic bland candy mountain oyster	7	decent	Last Available: "2014-12"
 7112	perfectly mixed chocotini	3	EPIC	Last Available: "2014-12"
 7113	purple censurious horrifying razor-sharp chocolate rabbit's foot	0		Weapon Damage Percent: +25, Spooky Damage: +25, Sleaze Resistance: +3, Last Available: "2014-12"
-7114	decent half-sized candy carrot	2	good	Last Available: "2014-12"
-7115	jumbo flavorless candy carrot cake	5	decent	Last Available: "2014-12"
+7114	half-sized decent candy carrot	2	good	Last Available: "2014-12"
+7115	flavorless jumbo candy carrot cake	5	decent	Last Available: "2014-12"
 7116	brainy carrot-on-a-stick of the wise owl	0		Mysticality: 25, Last Available: "2014-12"
-7117	Jeselnik's Temple Grandin's weasel stomping pants	0		Familiar Weight: +7, Sleaze Damage: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	Jeselnik's Temple Grandin's weasel stomping pants	0		Familiar Weight: +7, Sleaze Damage: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	moldy pulsating mulberry	4	crappy	Last Available: "2014-12"
 7119	artisanal mulled berry wine	4	EPIC	Last Available: "2014-12"
 7120	purple lemony scales	0		Last Available: "2014-12"
-7121	upside-down blinking maroon lemon party hat of the empath	0		Familiar Weight: +5, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	upside-down blinking maroon lemon party hat of the empath	0		Familiar Weight: +5, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	blurry Oprah's lemon shirt	0		Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2014-12"
-7123	baleful lemon drop trousers	0		Spell Damage: +25, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	baleful lemon drop trousers	0		Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	warmed colloidal liquefied lemonhead caviar	0		Effect: "Memories of Puppy Love", Effect Duration: 48, Last Available: "2014-12"
 7125	shaking spinning greedy Van der Graaf gummi sword	0		Meat Drop: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7126	unsweetened concentrated small gummi fin	0		Effect: "Dancing Prowess", Effect Duration: 32, Last Available: "2014-12"
@@ -7019,9 +7019,9 @@
 7130	strong tolerable magnum of champagne	5	good	Last Available: "2014-12"
 7131	olive Socratic Herculean cow creamer of incineration	0		Experience (Muscle): +1, Experience (Mysticality): +1, Hot Spell Damage: +50, Last Available: "2014-12"
 7132	triple-pickled anodized Outer Wolf&trade; cologne	0		Effect: "Bored Stiff", Effect Duration: 21, Last Available: "2014-12"
-7133	twirling purple lupine appetite hormones	0		Last Available: "2014-12"
-7134	tumbling foul-smelling savvy wolf whistle	0		Mysticality Percent: +20, Stench Damage: +10, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	snack-sized spoiled witch's bread	2	crappy	Last Available: "2014-12"
+7133	purple twirling lupine appetite hormones	0		Last Available: "2014-12"
+7134	tumbling foul-smelling savvy wolf whistle	0		Mysticality Percent: +20, Stench Damage: +10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	spoiled snack-sized witch's bread	2	crappy	Last Available: "2014-12"
 7136	denatured witch's brew	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 15, Last Available: "2014-12"
 7137	banded boxer's witch's bra of the pedagogue	0		Muscle Percent: +10, Experience: +3, Damage Absorption: +100, Last Available: "2014-12"
 7138	bad lime green jittery bouncing mid-level medieval mead	3	decent	Last Available: "2014-12"
@@ -7032,7 +7032,7 @@
 7143	mirror twirling strapping hare pin of doom	0		Muscle: +5, Spooky Spell Damage: +50, Single Equip, Last Available: "2014-12"
 7144	upside-down odd coin	0		Last Available: "2014-12"
 7145	stale immense cinnamon cannoli	9	decent	Last Available: "2014-12"
-7146	artisanal watered-down expensive champagne	2	EPIC	Last Available: "2014-12"
+7146	watered-down artisanal expensive champagne	2	EPIC	Last Available: "2014-12"
 7147	modified teal polo trophy	0		Effect: "Wintergreen Warmongery", Effect Duration: 56, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7043,19 +7043,19 @@
 7154	mirror filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	blue lightning-fast fire hose of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: +50, Initiative: +40, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	blue lightning-fast fire hose of the dark arts of mayonnaise	0		Spell Damage Percent: +100, Sleaze Spell Damage: +50, Initiative: +40, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	enchanted bland fireman's lunch	3	decent	Effect: "Kindly Resolve", Effect Duration: 50, Last Available: "2014-12"
-7159	bouncing ruddy experienced educational plain paper hat	0		Experience: 3, Maximum HP Percent: +40, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7159	bouncing ruddy experienced educational plain paper hat	0		Experience: 3, Maximum HP Percent: +40, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	decent bite-sized ice cream sandwich	1	good	Last Available: "2014-12"
 7161	executive veiny &quot;honey&quot; dipper of the brazier	0		Maximum HP: +10, Hot Spell Damage: +25, Meat Drop: +40, Last Available: "2014-12"
-7162	massive bland blurry plumber's lunch	10	decent	Last Available: "2014-12"
+7162	bland massive blurry plumber's lunch	10	decent	Last Available: "2014-12"
 7163	family-friendly wool skull gearshift knob of the boozehound	0		Cold Resistance: +1, Sleaze Resistance: +1, Booze Drop: +100, Last Available: "2014-12"
 7164	yummy nachos of the night	4	awesome	Last Available: "2014-12"
 7165	stanky slick Sketcherz&trade; of the glutton	0		Moxie: +10, Stench Spell Damage: +25, Food Drop: +100, Last Available: "2014-12"
 7166	decent can of Adultwitch&trade;	3	good	Last Available: "2014-12"
 7167	moist electrified altered fuchsia blurry smudge stick	0		Effect: "Video Game Hot Dog", Effect Duration: 32, Last Available: "2014-12"
 7168	concentrated ghostly wall	0		Effect: "Celestial Sheen", Effect Duration: 40, Last Available: "2014-12"
-7169	drinkable weak tankard of ale	2	good	Last Available: "2014-12"
+7169	weak drinkable tankard of ale	2	good	Last Available: "2014-12"
 7170	quadruple-liquefied flattened modified scroll case	0		Effect: "Omphalotus Omnipresence", Effect Duration: 12, Last Available: "2014-12"
 7171	electrified pickled jug of &quot;wine&quot;	0		Effect: "Berry Experiential", Effect Duration: 47, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
@@ -7088,7 +7088,7 @@
 7199	blowdart	0		
 7200	occult Buddy Bjorn	0		Spell Damage Percent: +25, Softcore Only, Last Available: "2014-02"
 7201	mirror rock-hard educational brainy The Nuge's favorite crossbow	0		Mysticality: +5, Experience: +1, Damage Reduction: 5
-7202	thick adequate sweet roll Alabama	5	good	
+7202	adequate thick sweet roll Alabama	5	good	
 7203	knitted Saturday Night Special	0		Cold Resistance: +3
 7204	lynyrd snare	0		
 7205	mirror Usain Bolt's fleetwood chain	0		Initiative: +80
@@ -7100,18 +7100,18 @@
 7211	energized ionized Vulcanized huge one pill	0		Effect: "Thanksgot", Effect Duration: 37
 7212	Jefferson wings of doom	0		Spooky Spell Damage: +50
 7213	fleetwood macaroni	0		
-7214	ghostly blurry cheesy eagle sauce	0		
-7215	adequate low-calorie lime green fleetwood mac 'n' cheese	1	good	
+7214	blurry ghostly cheesy eagle sauce	0		
+7215	low-calorie adequate lime green fleetwood mac 'n' cheese	1	good	
 7216	ghostly lynyrd skin	0		
 7217	ghostly skewed squat toasty lynyrdskin cap	0		Hot Damage: +5, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	skewed spinning Da Vinci's lynyrdskin tunic	0		Experience (Mysticality): +5
 7219	skewed supercharged lynyrdskin breeches	0		Maximum MP Percent: +30, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	irresponsibly strong mediocre Flamin' Whatshisname	7	decent	
+7222	mediocre irresponsibly strong Flamin' Whatshisname	7	decent	
 7223	tarnished aerosolized oxidized jittery lynyrd musk	0		Effect: "Weather, Man", Effect Duration: 56
 7224	horrifying Oprah's Kashmir sweater	0		Maximum MP Percent: +50, Spooky Damage: +25
-7225	adequate bite-sized green custard pie	1	good	
+7225	bite-sized adequate green custard pie	1	good	
 7226	tea for one	1	EPIC	
 7227	irresponsibly strong aged gray bottle of Evermore	8	awesome	
 7228	spinning box	0		
@@ -7141,11 +7141,11 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	bouncing Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	smooth watered-down blinking mini-martini	2	awesome	
+7255	watered-down smooth blinking mini-martini	2	awesome	
 7256	smoke grenade	0		
 7257	denatured molotov soda	1	EPIC	
 7258	alkaline jittery pile of ashes	0		Effect: "Fustulent", Effect Duration: 11
-7259	blinking bouncing crate of firebombs	0		
+7259	bouncing blinking crate of firebombs	0		
 7260	firebomb	0		
 7261	Temple Grandin's careful Sinatra's Sneaky Pete's basket	0		Experience (Moxie): +5, Monster Level: -10, Familiar Weight: +7
 7262	&quot;I Love Me, Vol. I&quot;	0		
@@ -7210,7 +7210,7 @@
 7321	educational Stephen's lab coat of the glutton	0		Experience: +1, Food Drop: +100
 7322	polarized quadruple-magnetized Stephen's secret formula	0		Effect: "Creepin' Up on You", Effect Duration: 46
 7323	wool Jacob's rung of Gandalf	0		Spell Critical Percent: +20, Cold Resistance: +1
-7324	twisted green blinking battery	1		Effect: "The Real Deal", Effect Duration: 15
+7324	twisted blinking green battery	1		Effect: "The Real Deal", Effect Duration: 15
 7325	tolerable watered-down snakebite	2	good	
 7326	clever dance instructor's rubber ribcage	0		Experience Percent (Moxie): +10, Maximum MP: +20, Damage Reduction: 7
 7327	twisted synthetic marrow	1		Effect: "Super Speed", Effect Duration: 5
@@ -7227,8 +7227,8 @@
 7338	Vulcanized dancer	0		Effect: "Stemonitis Storm", Effect Duration: 26
 7339	music box mechanism	0		
 7340	occult moose antlers	0		Spell Damage Percent: +25, Familiar Effect: "atk, 1xLep, cap 27"
-7341	diffused flattened ghostly narrow moose thought	0		Effect: "Strength of Ten Ettins", Effect Duration: 45
-7342	enchanted big flavorless huge moose chocolate	5	decent	Effect: "Sticks and Stones", Effect Duration: 5
+7341	diffused flattened narrow ghostly moose thought	0		Effect: "Strength of Ten Ettins", Effect Duration: 45
+7342	big flavorless enchanted huge moose chocolate	5	decent	Effect: "Sticks and Stones", Effect Duration: 5
 7343	weak perfectly mixed painting of a glass of wine	2	EPIC	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
@@ -7240,10 +7240,10 @@
 7351	dog trainer's coward's Staff of the Electric Range of the cougar	0		Moxie: +20, Monster Level: -20, Experience (familiar): +1
 7352	stale massive deluxe layer cake	6	decent	
 7353	chunk of hot iron	0		
-7354	bad practically non-alcoholic maroon red-hot boilermaker	1	decent	
+7354	practically non-alcoholic bad maroon red-hot boilermaker	1	decent	
 7355	clever coal shovel	0		Maximum MP: +20, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	magnetized hot coal	0		Effect: "Cold, Dead Hands", Effect Duration: 30
-7357	quantum upside-down squat wobbly coal dust	0		Effect: "Gonna Get You, Sucker", Effect Duration: 67
+7357	quantum wobbly squat upside-down coal dust	0		Effect: "Gonna Get You, Sucker", Effect Duration: 67
 7358	squat sinister Bram's choker of the ox of the dark arts	0		Muscle: +20, Spell Damage: +10, Spell Damage Percent: +100, Single Equip
 7359	bouncing plaid swatch	0		
 7360	plaid bandage	0		
@@ -7254,7 +7254,7 @@
 7365	activated huge fabric hardener	0		Effect: "Icy Composition", Effect Duration: 64
 7366	artisanal blinking bottle of laundry sherry	4	EPIC	
 7367	non-adjusted huge industrial strength starch	0		Effect: "Heavily Breathing", Effect Duration: 36, Wiki Name: "industrial strength starch"
-7368	adequate diet extra-flat panini	1	good	
+7368	diet adequate extra-flat panini	1	good	
 7369	concentrated magnetized fuchsia mangled finger	0		Effect: "Inebriate Pride", Effect Duration: 65
 7370	delicious fuchsia Psychotic Train wine	4	awesome	
 7371	crazy hobo notebook	0		
@@ -7270,8 +7270,8 @@
 7381	Da Vinci's Pendant of Gargalesis	0		Experience (Mysticality): +5
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	DNA extraction syringe	0		Last Available: "2014-04"
-7384	anodized fuchsia squat upside-down Gene Tonic: Dude	0		Effect: "Flambé-a-thon", Effect Duration: 28, Last Available: "2014-04"
-7385	dry yellow narrow Gene Tonic: Beast	0		Effect: "Devil Inside", Effect Duration: 66, Last Available: "2014-04"
+7384	anodized squat upside-down fuchsia Gene Tonic: Dude	0		Effect: "Flambé-a-thon", Effect Duration: 28, Last Available: "2014-04"
+7385	dry narrow yellow Gene Tonic: Beast	0		Effect: "Devil Inside", Effect Duration: 66, Last Available: "2014-04"
 7386	unsweetened concentrated modified lime green Gene Tonic: Construct	0		Effect: "From Nantucket", Effect Duration: 14, Last Available: "2014-04"
 7387	aerosolized alkaline Gene Tonic: Undead	0		Effect: "Jingle Jangle Jingle", Effect Duration: 55, Last Available: "2014-04"
 7388	dry Gene Tonic: Humanoid	0		Effect: "Pisces in the Skyces", Effect Duration: 64, Last Available: "2014-04"
@@ -7288,7 +7288,7 @@
 7399	flattened alkaline Gene Tonic: Elf	0		Effect: "The Power of Positive Thinking", Effect Duration: 55, Last Available: "2014-04"
 7400	extra-moist bouncing Gene Tonic: Mer-kin	0		Effect: "Stemonitis Storm", Effect Duration: 17, Last Available: "2014-04"
 7401	denatured Gene Tonic: Slime	0		Effect: "[800]Chocolate Reign", Effect Duration: 30, Last Available: "2014-04"
-7402	ionized warmed liquefied maroon blinking Gene Tonic: Penguin	0		Effect: "Sepia Tan", Effect Duration: 25, Last Available: "2014-04"
+7402	ionized warmed liquefied blinking maroon Gene Tonic: Penguin	0		Effect: "Sepia Tan", Effect Duration: 25, Last Available: "2014-04"
 7403	nitrogenated Gene Tonic: Elemental	0		Effect: "A View to Some Meat", Effect Duration: 21, Last Available: "2014-04"
 7404	liquefied frozen fuchsia Gene Tonic: Constellation	0		Effect: "Turkey-Agitated", Effect Duration: 30, Last Available: "2014-04"
 7405	magnetized Gene Tonic: Hobo	0		Effect: "Preternatural Greed", Effect Duration: 22, Last Available: "2014-04"
@@ -7307,7 +7307,7 @@
 7418	Steam Card: Jackass Plumber (#1)	0		
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
-7421	blinking red mirror pencil thin mushroom	0		Last Available: "2014-05"
+7421	mirror red blinking pencil thin mushroom	0		Last Available: "2014-05"
 7422	Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
@@ -7327,7 +7327,7 @@
 7438	normal Beefy Crunch Pastaco	4	good	Last Available: "2014-05"
 7439	gigantic decent Brain Food Pastaco	10	good	Last Available: "2014-05"
 7440	rotten Cool Brunch Pastaco	4	crappy	Last Available: "2014-05"
-7441	rotten fancy bouncing Medical Pastaco	3	crappy	Effect: "Ooh, Bitter!", Effect Duration: 20, Last Available: "2014-05"
+7441	fancy rotten bouncing Medical Pastaco	3	crappy	Effect: "Ooh, Bitter!", Effect Duration: 20, Last Available: "2014-05"
 7442	rotten maroon Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
 7443	normal teal Ludovico Pastaco	3	good	Last Available: "2014-05"
 7444	tolerable overpowering mushroom wine	4	good	Last Available: "2014-05"
@@ -7348,13 +7348,13 @@
 7459	shaking Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	electrified Brogre brorts	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	electrified Brogre brorts	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	tumbling lard-coated Brogre brolo shirt	0		Sleaze Spell Damage: +25, Last Available: "2014-05"
-7464	lime green Brogre bucket hat of the early riser	0		Adventures: +7, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	lime green Brogre bucket hat of the early riser	0		Adventures: +7, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	purple Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	pulsating one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	careful Jim Carey's vibrating 8-billed baseball cap	0		Maximum MP Percent: +10, Monster Level: 15, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	careful Jim Carey's vibrating 8-billed baseball cap	0		Maximum MP Percent: +10, Monster Level: 15, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	sharpshooter's studded extremely wet T-shirt of the wise owl	0		Mysticality: +20, Damage Absorption: +80, Critical Hit Percent: +10, Last Available: "2014-05"
 7470	shaking lime green censurious greasy sage shrimp fork	0		Mysticality Percent: +10, Sleaze Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2014-05"
 7471	oxidized adjusted pickled blinking BROS Energy Drink	0		Effect: "Creepypasted", Effect Duration: 16, Last Available: "2014-05"
@@ -7362,15 +7362,15 @@
 7473	super-wet tarnished shrimp cocktail	0		Effect: "Horrid, Torrid", Effect Duration: 39, Last Available: "2014-05"
 7474	concentrated polymerized Yolo&trade; chocolates	0		Effect: "Violent Night", Effect Duration: 52, Last Available: "2020-09"
 7475	upside-down string of moist beads of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2014-05"
-7476	tumbling wobbly Ultimate Mind Destroyer	0		Last Available: "2014-05"
+7476	wobbly tumbling Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	corrupted ionized Meat-inflating powder	0		Effect: "Egg-stra Arm", Effect Duration: 21, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	corrupted sugar fairy	0		Effect: "Spooky Jellied", Effect Duration: 64, Last Available: "2014-05"
 7480	pickled cold-filtered ghostly bouncing sugar bunny	0		Effect: "Memory of Smarts", Effect Duration: 57, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	boozy drinkable Rompedores de Fantasmas	5	good	
-7483	practically non-alcoholic artisanal La Fantasma y La Oscuridad	1	super ultra EPIC	
-7484	strong perfectly mixed Fantasma en la M&aacute;quina	5	EPIC	
+7483	artisanal practically non-alcoholic La Fantasma y La Oscuridad	1	super ultra EPIC	
+7484	perfectly mixed strong Fantasma en la M&aacute;quina	5	EPIC	
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	ghostly drain dissolver	0		
@@ -7405,7 +7405,7 @@
 7516	skewed gray witch's spare house key	0		
 7517	spider leg of James Dean of Gandalf	0		Experience (Moxie): +3, Spell Critical Percent: +20
 7518	mirror wand of pigification	0		
-7519	bad high-proof glass of bourbon	7	decent	
+7519	high-proof bad glass of bourbon	7	decent	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	bland government cheese	3	decent	Last Available: "2014-05"
 7522	narrow Jeselnik's pair of government shades	0		Sleaze Damage: +25, Single Equip, Last Available: "2014-05"
@@ -7418,20 +7418,20 @@
 7529	decent twirling loaf of alien bread	4	good	Last Available: "2014-05"
 7530	stale snack-sized grilled cheese sandwich	2	decent	Last Available: "2014-05"
 7531	twisted alien protein powder	1	decent	Last Available: "2014-05"
-7532	artisanal practically non-alcoholic rocket fuel	1	super ultra EPIC	Last Available: "2014-05"
+7532	practically non-alcoholic artisanal rocket fuel	1	super ultra EPIC	Last Available: "2014-05"
 7533	blurry alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	shaking alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	drinkable pulsating squat stealth bomber	4	good	Last Available: "2014-05"
 7536	pulsating space beast fur	0		Last Available: "2014-05"
 7537	fuchsia twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	knitted space beast fur pants	0		Cold Resistance: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	lard-coated space beast fur hat	0		Sleaze Spell Damage: +25, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	knitted space beast fur pants	0		Cold Resistance: +3, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	tumbling tumbling space beast fur whip of the pedagogue	0		Experience: +3, Last Available: "2014-05"
 7542	red space invader	0		Last Available: "2014-05"
-7543	purple twirling rosy-cheeked sage space heater	0		Mysticality Percent: +10, Maximum HP Percent: +30, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	purple twirling rosy-cheeked sage space heater	0		Mysticality Percent: +10, Maximum HP Percent: +30, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
-7545	drinkable practically non-alcoholic enchanted space port	1	good	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2014-05"
+7545	drinkable enchanted practically non-alcoholic space port	1	good	Effect: "Thaumodynamic", Effect Duration: 10, Last Available: "2014-05"
 7546	olive medical-grade space needle of the detective	0		Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-05"
 7547	improved liquefied fuchsia buffed alien drugs	0		Effect: "Tapped In", Effect Duration: 64, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7460,32 +7460,32 @@
 7571	tumbling rosewater-soaked stylish silent pea shooter	0		Moxie: +25, Stench Resistance: +3
 7572	tasty olive D roll	3	awesome	
 7573	knitted Da Vinci's kiwi beak	0		Experience (Mysticality): +5, Cold Resistance: +3
-7574	practically non-alcoholic hand-crafted New Zealand iced tea	1	super EPIC	
+7574	hand-crafted practically non-alcoholic New Zealand iced tea	1	super EPIC	
 7575	strapping droll monocle of the storm	0		Muscle: +5, Maximum MP Percent: +40, Single Equip
 7576	liquefied magnetized wet huge future drug: Muscularactum	0		Effect: "Chalked Weapon", Effect Duration: 67
 7577	Vulcanized purple future drug: Smartinex	0		Effect: "Joyful Resolve", Effect Duration: 59
 7578	activated huge future drug: Coolscaline	0		Effect: "Hagnk's Gratitude", Effect Duration: 32
 7579	twitching time capsule	0		
-7580	diluted green wobbly liquid shifting time weirdness	1		Effect: "Aquarius Rising", Effect Duration: 5
+7580	diluted wobbly green liquid shifting time weirdness	1		Effect: "Aquarius Rising", Effect Duration: 5
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	normal ghostly rack of dinosaur ribs	4	good	
 7583	irresponsibly strong delicious huge scotch on the rocks	8	awesome	
 7584	narrow arcane researcher's slick yabba dabba doo rag	0		Moxie: +10, Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	wooly loincloth of chilblains of courage	0		Cold Damage: +25, Spooky Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	wobbly helix fossil	0		
-7587	upside-down green pulsating skewed S.S. Ticket	0		Familiar Weight: +5
+7587	upside-down pulsating green skewed S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	artisanal weak upside-down glass of &quot;milk&quot;	2	EPIC	Last Available: "2014-07"
+7589	weak artisanal upside-down glass of &quot;milk&quot;	2	EPIC	Last Available: "2014-07"
 7590	watered-down hand-crafted cup of &quot;tea&quot;	2	EPIC	Last Available: "2014-07"
-7591	tolerable spirit-forward thermos of &quot;whiskey&quot;	5	good	Last Available: "2014-07"
+7591	spirit-forward tolerable thermos of &quot;whiskey&quot;	5	good	Last Available: "2014-07"
 7592	weak hand-crafted tumbling Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
 7593	aged narrow Bee's Knees	4	awesome	Last Available: "2014-07"
 7594	acceptable skewed maroon Sockdollager	3	good	Last Available: "2014-07"
-7595	practically non-alcoholic acceptable Ish Kabibble	1	good	Last Available: "2014-07"
+7595	acceptable practically non-alcoholic Ish Kabibble	1	good	Last Available: "2014-07"
 7596	artisanal Hot Socks	4	EPIC	Last Available: "2014-07"
 7597	smooth Phonus Balonus	3	awesome	Last Available: "2014-07"
 7598	delicious weak Flivver	2	awesome	Last Available: "2014-07"
-7599	weak acceptable blurry Sloppy Jalopy	2	good	Last Available: "2014-07"
+7599	acceptable weak blurry Sloppy Jalopy	2	good	Last Available: "2014-07"
 7600	tarnished aerosolized irradiated flame	0		Effect: "Hot Jellied", Effect Duration: 18
 7601	dry cyan temporary yak tattoo	0		Effect: "Gutterminded", Effect Duration: 49
 7602	magnetized extra-vacuum-sealed Fitspiration&trade; poster	0		Effect: "Piratastic", Effect Duration: 68
@@ -7501,7 +7501,7 @@
 7612	concentrated upside-down tomato soup poster	0		Effect: "BOOsted", Effect Duration: 47
 7613	enhanced adjusted squat bubblin' chemistry solution	0		Effect: "Goldentongue", Effect Duration: 48
 7614	improved blinking voodoo glowskull	0		Effect: "Sweet and Red", Effect Duration: 26
-7615	polarized quadruple-boiled wobbly skewed maroon pygmy adder oil	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 66
+7615	polarized quadruple-boiled maroon skewed wobbly pygmy adder oil	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 66
 7616	liquefied blinking pygmy witchhazel	0		Effect: "Human-Elf Hybrid", Effect Duration: 60
 7617	ionized diffused blue short deposition	0		Effect: "Funky Coal Patina", Effect Duration: 58
 7618	cold-filtered ionized adjusted straw pole	0		Effect: "Trufflin'", Effect Duration: 43
@@ -7519,7 +7519,7 @@
 7630	enhanced magic powder	0		Effect: "Sweet and Red", Effect Duration: 56
 7631	quadruple-aerosolized red friar's tonsure	0		Effect: "Wistfully Nostalgic", Effect Duration: 31
 7632	colloidal government-issue identification badge	0		Effect: "Infernal Thirst", Effect Duration: 35
-7633	pressed colloidal colloidal twirling shaking alien hologram projector	0		Effect: "Pasta Oneness", Effect Duration: 28
+7633	pressed colloidal colloidal shaking twirling alien hologram projector	0		Effect: "Pasta Oneness", Effect Duration: 28
 7634	tarnished boiled frozen squat spinning irradiated turtle	0		Effect: "Aloofah", Effect Duration: 40
 7635	corrupted blinking blinking cigar box turtle	0		Effect: "Seeing Colors", Effect Duration: 58
 7636	supercharged shellacked shell of the ox	0		Muscle: +20, Maximum MP Percent: +30, Class: "Turtle Tamer"
@@ -7534,7 +7534,7 @@
 7645	life preserver	0		
 7646	blinking lightning milk	0		
 7647	aquaconda brain	0		
-7648	ghostly twirling thunder thigh	0		
+7648	twirling ghostly thunder thigh	0		
 7649	pressed gourmet gourami oil	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 54
 7650	aerosolized tarnished catfish whiskers	0		Effect: "Cringle's Curative Carol", Effect Duration: 51
 7651	freshwater fishbone	0		
@@ -7548,7 +7548,7 @@
 7659	neoprene skullcap of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	anodized goblin water	0		Effect: "Superhuman Sarcasm", Effect Duration: 15
 7661	teal dumb mud	0		
-7662	tasty small twirling Sogg-Os	2	awesome	
+7662	small tasty twirling Sogg-Os	2	awesome	
 7663	family-friendly friendly Lord Soggyraven's Slippers of the brute	0		Muscle Percent: +30, Familiar Weight: +3, Sleaze Resistance: +1, Single Equip
 7664	frozen skewed Ancient Protector Soda	0		Effect: "Turkey-Agitated", Effect Duration: 34
 7665	magnetized deionized aerosolized huge liquid ice	0		Effect: "Boschface", Effect Duration: 59
@@ -7561,13 +7561,13 @@
 7672	toasty law-abiding citizen cane	0		Hot Damage: +5, Single Equip
 7673	mediocre legitimate business on the beach	3	decent	
 7674	pulsating occult hep waders	0		Spell Damage Percent: +25, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	bland massive fancy jive turkey leg	7	decent	Effect: "Spooky Blur", Effect Duration: 45
+7675	fancy bland massive jive turkey leg	7	decent	Effect: "Spooky Blur", Effect Duration: 45
 7676	pulsating beefcake's birdbone corset	0		Muscle: +25
 7677	triple-warmed quantum candy cigarette	0		Effect: "Ruby-ous", Effect Duration: 63
 7678	blinking pulsating experienced 4-dimensional fez	0		Experience: +2, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	manspreader's super-absorbent tarp	0		Monster Level: +10
-7681	watered-down mediocre unquiet spirits	2	decent	
+7681	mediocre watered-down unquiet spirits	2	decent	
 7682	banjo kazoo mount of doom	0		Spooky Spell Damage: +50, Single Equip
 7683	unsweetened teal grass	0		Effect: "Abyssal Tears", Effect Duration: 44
 7684	twirling blurry sharpshooter's Time Lord Participation Mug	0		Critical Hit Percent: +10
@@ -7581,7 +7581,7 @@
 7692	pulsating Usain Bolt's wicked hand whip of the sweet-tooth	0		Spell Damage: +5, Candy Drop: +100, Initiative: +80, Last Available: "2014-08"
 7693	electrified glow-in-the-dark necklace of the dark arts of vim and vigor	0		Spell Damage Percent: +100, Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-08"
 7694	skewed Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	twirling personal trainer's wizardly cap gun of the detective	0		Mysticality: +25, Experience Percent (Muscle): +10, Item Drop: +20, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	twirling personal trainer's wizardly cap gun of the detective	0		Mysticality: +25, Experience Percent (Muscle): +10, Item Drop: +20, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	yellow Usain Bolt's clever cassette player	0		Maximum MP: +20, Initiative: +80, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7590,18 +7590,18 @@
 7701	wet confiscated cell phone	0		Effect: "All Branned Up", Effect Duration: 55, Last Available: "2014-08"
 7702	Vulcanized confiscated love note	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 54, Last Available: "2014-08"
 7703	blinking LCD game: Food Eater	0		Last Available: "2014-08"
-7704	gray squat LCD game: Garbage River	0		Last Available: "2014-08"
+7704	squat gray LCD game: Garbage River	0		Last Available: "2014-08"
 7705	blurry LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	chilled polarized rubber nubbin	0		Effect: "Dreadful Sheen", Effect Duration: 15, Last Available: "2014-08"
 7708	huge fireproof Annie Oakley's rubber cape	0		Critical Hit Percent: +20, Hot Resistance: +3, Last Available: "2014-08"
-7709	nasty Newton's beefcake's Thor's Pliers of the detective	0		Muscle: +25, Experience (Mysticality): +3, Stench Damage: +5, Item Drop: +20, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	nasty Newton's beefcake's Thor's Pliers of the detective	0		Muscle: +25, Experience (Mysticality): +3, Stench Damage: +5, Item Drop: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	electrified purple candy UFOs	0		Effect: "Improved Candy Vision", Effect Duration: 13
 7711	baleful water wings for babies of the glutton	0		Spell Damage: +25, Food Drop: +100
 7712	beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
 7713	rotten Strix stix	3	crappy	
 7714	huge coward's razor-sharp vampire pellet of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +25, Monster Level: -20
-7715	acceptable watered-down upside-down squat non-aged vinegar	2	good	
+7715	acceptable watered-down squat upside-down non-aged vinegar	2	good	
 7716	hardened unsanitized scalpel	0		Damage Reduction: 3
 7717	blurry shaking coward's gladiator tunica	0		Monster Level: -20
 7718	dog trainer's Roman sadnals	0		Experience (familiar): +1, Single Equip
@@ -7625,7 +7625,7 @@
 7736	narrow Xiblaxian crystal	0		Last Available: "2014-09"
 7737	blurry Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
 7738	Xiblaxian cache locator simcode	0		Last Available: "2014-09"
-7739	skewed jittery Xiblaxian holo-training simcode	0		Last Available: "2014-09"
+7739	jittery skewed Xiblaxian holo-training simcode	0		Last Available: "2014-09"
 7740	Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	upside-down upside-down Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	spinning Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
@@ -7634,23 +7634,23 @@
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
 7746	Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
 7747	green Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
-7748	twirling bouncing Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
+7748	bouncing twirling Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
 7750	shaking Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	twirling Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	aromatic Xiblaxian xeno-detection goggles	0		Stench Resistance: +1, Single Equip, Last Available: "2014-09"
-7753	ghostly medical-grade Xiblaxian stealth cowl of Calamity Jane	0		Critical Hit Percent: +15, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	ghostly medical-grade Xiblaxian stealth cowl of Calamity Jane	0		Critical Hit Percent: +15, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	wobbly Usain Bolt's strapping Xiblaxian stealth trousers	0		Muscle: +5, Initiative: +80, Last Available: "2014-09"
 7755	asbestos-lined Xiblaxian stealth vest of the detective	0		Hot Resistance: +5, Item Drop: +20, Last Available: "2014-09"
 7756	yummy yellow Xiblaxian ultraburrito	3	awesome	Last Available: "2014-09"
 7757	bad high-proof Xiblaxian space-whiskey	8	decent	Last Available: "2014-09"
 7758	squat Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	chilled unsweetened squat They liver	0		Effect: "Saucegoggles", Effect Duration: 67, Last Available: "2014-09"
-7760	stale super-sized They liver popsicle	5	decent	Last Available: "2014-09"
+7760	super-sized stale They liver popsicle	5	decent	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	upside-down holo-platoon	0		Last Available: "2014-09"
-7764	modified huge squat residual zeal	1		Effect: "Man's Worst Enemy", Effect Duration: 20, Last Available: "2014-09"
+7764	modified squat huge residual zeal	1		Effect: "Man's Worst Enemy", Effect Duration: 20, Last Available: "2014-09"
 7765	red squat wool Xiblaxian holo-wrist-puter	0		Cold Resistance: +1, Last Available: "2014-09"
 7766	prompt hardy defective Golden Mr. Accessory of chilblains	0		Maximum HP: +50, Cold Damage: +25, Adventures: +3
 7767	airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	pulsating toasty wicked Personal Ventilation Unit of courage	0		Spell Damage: +5, Hot Damage: +5, Spooky Resistance: +3, Single Equip, Last Available: "2014-10"
 7771	pickled the most dangerous bait	0		Effect: "Crotchety, Pining", Effect Duration: 18, Last Available: "2014-10"
-7772	bland immense &quot;meat&quot; stick	8	decent	Last Available: "2014-10"
+7772	immense bland &quot;meat&quot; stick	8	decent	Last Available: "2014-10"
 7773	pickled blurry purple transdermal smoke patch	1	good	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	teal stanky pair of plants of vim and vigor of mayonnaise	0		Maximum HP Percent: +50, Stench Spell Damage: +25, Sleaze Spell Damage: +50, Last Available: "2014-10"
@@ -7669,24 +7669,24 @@
 7780	sharpshooter's healthy heavy-duty clipboard of the blizzard	0		Maximum HP Percent: +20, Critical Hit Percent: +10, Cold Spell Damage: +25, Damage Reduction: 8, Last Available: "2014-10"
 7781	wool foul-smelling Herculean beefcake's battery-powered drill	0		Muscle: +25, Experience (Muscle): +1, Stench Damage: +10, Cold Resistance: +1, Last Available: "2014-10"
 7782	moldy narrow limp broccoli	3	crappy	Last Available: "2014-10"
-7783	pulsating scandalous friendly hat of wisdom	0		Mysticality: +15, Familiar Weight: +3, Sleaze Damage: +5, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7783	pulsating scandalous friendly hat of wisdom	0		Mysticality: +15, Familiar Weight: +3, Sleaze Damage: +5, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	nitrogenated denatured huge monkey barf	0		Effect: "Human-Pirate Hybrid", Effect Duration: 33, Last Available: "2014-10"
 7785	boiled nitrogenated candy	0		Effect: "Lobos Fresh", Effect Duration: 55, Last Available: "2014-10"
 7786	Socratic jangly bracelet of the boozehound of the glutton	0		Experience (Mysticality): +1, Booze Drop: +100, Food Drop: +100, Last Available: "2014-10"
-7787	tumbling miser's cuddly teddy bear	0		Meat Drop: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	tumbling miser's cuddly teddy bear	0		Meat Drop: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	mirror jittery ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	stanky nasty first-aid pouch	0		Stench Damage: +5, Stench Spell Damage: +25, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
 7791	pressed non-altered blue airborne mutagen	0		Effect: "Adrenaline Rush", Effect Duration: 16, Last Available: "2014-10"
-7792	ghostly cyan SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
+7792	cyan ghostly SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
 7795	flavorless small initiative shawarma	2	decent	Last Available: "2014-10"
 7796	spoiled warm war shawarma	3	crappy	Last Available: "2014-10"
-7797	snack-sized moldy karma shawarma	2	crappy	Last Available: "2014-10"
-7798	triple-distilled artisanal Jungle Juice	9	EPIC	Last Available: "2014-10"
-7799	artisanal gray bouncing Amnesiac Ale	3	EPIC	Last Available: "2014-10"
-7800	practically non-alcoholic lousy Highest Bitter	1	decent	Last Available: "2014-10"
+7797	moldy snack-sized karma shawarma	2	crappy	Last Available: "2014-10"
+7798	artisanal triple-distilled Jungle Juice	9	EPIC	Last Available: "2014-10"
+7799	artisanal bouncing gray Amnesiac Ale	3	EPIC	Last Available: "2014-10"
+7800	lousy practically non-alcoholic Highest Bitter	1	decent	Last Available: "2014-10"
 7801	huge perfumed smartaleck's mercenary pistol	0		Moxie Percent: +30, Stench Resistance: +5, Last Available: "2014-10"
 7802	twirling deadly educational mercenary rifle	0		Experience: +1, Weapon Damage: +5, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7699,8 +7699,8 @@
 7810	yellow Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	fancy delicious snack-sized seared dino steak	2	awesome	Effect: "Snobby", Effect Duration: 45
-7814	special smooth bottle of drinkin' gas	4	awesome	Effect: "Buttermilk Boogie", Effect Duration: 20
+7813	delicious snack-sized fancy seared dino steak	2	awesome	Effect: "Snobby", Effect Duration: 45
+7814	smooth special bottle of drinkin' gas	4	awesome	Effect: "Buttermilk Boogie", Effect Duration: 20
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7713,8 +7713,8 @@
 7824	mirror greedy shellacked iShield of Calamity Jane	0		Damage Reduction: 13, Critical Hit Percent: +15, Meat Drop: +20
 7825	maroon asbestos-lined arcane researcher's slick earbuds	0		Moxie: +10, Experience Percent (Mysticality): +10, Hot Resistance: +5, Single Equip
 7826	avaricious iFlail of Calamity Jane of temperance	0		Critical Hit Percent: +15, Sleaze Resistance: +5, Meat Drop: +30
-7827	miniature adequate unidentifiable dried fruit	2	good	
-7828	weak perfectly mixed flat cider	2	EPIC	
+7827	adequate miniature unidentifiable dried fruit	2	good	
+7828	perfectly mixed weak flat cider	2	EPIC	
 7829	Oprah's baleful trench lighter of incineration	0		Spell Damage: +25, Maximum MP Percent: +50, Hot Spell Damage: +50, Last Available: "2014-10"
 7830	irradiated experimental serum P-00	0		Effect: "Almost Cool", Effect Duration: 35, Last Available: "2014-10"
 7831	upside-down military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7729,22 +7729,22 @@
 7840	special clip: wailers	0		Last Available: "2014-10"
 7841	purple huge special clip: squelchers	0		Last Available: "2014-10"
 7842	special clip: splatterers	0		Last Available: "2014-10"
-7843	blue squat special clip: boneburners	0		Last Available: "2014-10"
+7843	squat blue special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	non-modified extra-improved jittery perl necklace	0		Effect: "Strange Mental Acuity", Effect Duration: 66, Last Available: "2014-12"
 7846	wet tumbling Fudge Fiber Armor Plating	0		Effect: "Puddingskin", Effect Duration: 67, Last Available: "2014-12"
 7847	deionized ruby on canes	0		Effect: "Healthy Bronze Glow", Effect Duration: 20, Last Available: "2014-12"
-7848	diet adequate twirling petit fortran	1	good	Last Available: "2014-12"
+7848	adequate diet twirling petit fortran	1	good	Last Available: "2014-12"
 7849	decent half-sized java cookie	2	good	Last Available: "2014-12"
-7850	small normal cookie cookie	2	good	Last Available: "2014-12"
+7850	normal small cookie cookie	2	good	Last Available: "2014-12"
 7851	Da Vinci's plastic exo-suited miner	0		Experience (Mysticality): +5, Last Available: "2014-12"
 7852	mirror chaotic plastic semi-autonomous drill unit	0		Spell Critical Percent: +10, Last Available: "2014-12"
 7853	plastic ambulatory robo-minecart of bravery	0		Spooky Resistance: +5, Last Available: "2014-12"
 7854	skewed crafty plastic Crimbot	0		Maximum MP: +10, Last Available: "2014-12"
 7855	blinking hardy plastic Crimbomega	0		Maximum HP: +50, Last Available: "2014-12"
 7856	moist ionized tumbling flask of mining oil	0		Effect: "meat.enh", Effect Duration: 59, Last Available: "2014-12"
-7857	mansplainer's radiation-resistant helmet	0		Monster Level: +15, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	energetic servo-assisted exo-pants	0		Maximum MP Percent: +20, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	mansplainer's radiation-resistant helmet	0		Monster Level: +15, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	energetic servo-assisted exo-pants	0		Maximum MP Percent: +20, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	twirling wicked strapping high-energy mining laser	0		Muscle: +5, Spell Damage: +5, Last Available: "2014-12"
 7860	tumbling peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7762,7 +7762,7 @@
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
 7874	Crimbot schematic: Refrigerator Chassis	0		Last Available: "2014-12"
 7875	Crimbot schematic: Bug Zapper	0		Last Available: "2014-12"
-7876	mirror blinking Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
+7876	blinking mirror Crimbot schematic: Rodent Gun	0		Last Available: "2014-12"
 7877	twirling Crimbot schematic: Rivet Shocker	0		Last Available: "2014-12"
 7878	Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	upside-down Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
@@ -7777,14 +7777,14 @@
 7888	Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
 7890	skewed Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
-7891	maroon huge Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
+7891	huge maroon Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
 7897	huge Crimbot schematic: Rollerfeet	0		Last Available: "2014-12"
-7898	huge skewed Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
+7898	skewed huge Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	twirling Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
@@ -7811,8 +7811,8 @@
 7922	bad jittery Friendly Turkey	4	decent	Last Available: "2014-11"
 7923	drinkable Agitated Turkey	3	good	Last Available: "2014-11"
 7924	bad Ambitious Turkey	3	decent	Last Available: "2014-11"
-7925	toothsome super-sized cyan neutron lollipop	5	awesome	Last Available: "2014-12"
-7926	bad enchanted blinking huge gamma nog	3	decent	Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2014-12"
+7925	super-sized toothsome cyan neutron lollipop	5	awesome	Last Available: "2014-12"
+7926	bad enchanted huge blinking gamma nog	3	decent	Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2014-12"
 7934	cyan sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
@@ -7828,7 +7828,7 @@
 7946	curative outlaw bandana of the cougar of the scaredy-cat	0		Moxie: +20, Monster Level: -15, HP Regen Min: 3, HP Regen Max: 5
 7947	enchanted tolerable pulsating whiskey in a broken glass	3	good	Effect: "It's Soporiffic!", Effect Duration: 10
 7948	perfectly mixed shaking shot of mescal	4	EPIC	
-7949	artisanal high-proof glass of herbal tequila	8	EPIC	
+7949	high-proof artisanal glass of herbal tequila	8	EPIC	
 7950	minin' dynamite	0		
 7951	Oprah's cool plaid cowboy hat	0		Moxie: +5, Maximum MP Percent: +50, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7851,9 +7851,9 @@
 7969	shaking beehive	0		
 7970	boning knife	0		
 7971	ghostly Aggressive Carrot	0		Free Pull
-7972	denatured ghostly upside-down mirror mummified fig	1	good	
+7972	denatured mirror upside-down ghostly mummified fig	1	good	
 7973	mixed yellow mummified loaf of bread	1	decent	Effect: "Bustle Hustlin'", Effect Duration: 25
-7974	powdered twirling bouncing pulsating mummified beef haunch	1	decent	Effect: "Cuts Like a Buttered Knife", Effect Duration: 35
+7974	powdered bouncing twirling pulsating mummified beef haunch	1	decent	Effect: "Cuts Like a Buttered Knife", Effect Duration: 35
 7975	linen bandages	0		
 7976	skewed cotton bandages	0		
 7977	silk bandages	0		
@@ -7876,22 +7876,22 @@
 7994	horrifying experienced pepper mill	0		Experience: +2, Spooky Damage: +25, Last Available: "2015-12"
 7995	experienced pelerine of the early riser	0		Experience: +2, Adventures: +7, Last Available: "2015-12"
 7996	stylish phantom mask of the brute	0		Moxie: +25, Muscle Percent: +30, Single Equip, Last Available: "2015-12"
-7997	mixed jittery shaking polyesterene powder	1		Last Available: "2015-12"
+7997	mixed shaking jittery polyesterene powder	1		Last Available: "2015-12"
 7998	modified blue blinking powder	1		Last Available: "2015-12"
 7999	concentrated ionized denatured choco-Crimbot	0		Effect: "Wallflowering", Effect Duration: 38, Last Available: "2014-12"
 8000	ionized triple-warmed non-corrupted smart watch	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 34, Last Available: "2014-12"
 8001	flattened augmented-reality shades	0		Effect: "Ice Packed", Effect Duration: 30, Last Available: "2014-12"
-8002	toy Crimbot mega face of the detective	0		Item Drop: +20, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	spinning shellacked toy Crimbot power glove	0		Damage Reduction: 7, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	jittery Fonzie's toy Crimbot super fist	0		Experience (Moxie): +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	Rosewater's toy Crimbot rocket legs	0		Mysticality Percent: +30, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	toy Crimbot mega face of the detective	0		Item Drop: +20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	spinning shellacked toy Crimbot power glove	0		Damage Reduction: 7, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	jittery Fonzie's toy Crimbot super fist	0		Experience (Moxie): +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	Rosewater's toy Crimbot rocket legs	0		Mysticality Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	galvanized energized skewed Crimbot battery	0		Effect: "Bat Attitude", Effect Duration: 18, Last Available: "2014-12"
 8007	purple Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	upside-down Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	purple Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	olive smelly Jack Frost's forbidden Crimbomega drive chain	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Stench Spell Damage: +10, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	olive smelly Jack Frost's forbidden Crimbomega drive chain	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Stench Spell Damage: +10, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	squat Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7900,14 +7900,14 @@
 8018	moist ionized and rain stick	0		Effect: "Stenchtastic", Effect Duration: 38
 8019	twirling maroon Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
 8020	stale jittery Choco-Mint patty	3	decent	Last Available: "2015-01"
-8021	bad weak hot mint schnocolate	2	decent	Last Available: "2015-01"
+8021	weak bad hot mint schnocolate	2	decent	Last Available: "2015-01"
 8022	diluted teal homeopathic mint tea	1	good	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	narrow bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
-8027	skewed lime green antler chandelier	0		Last Available: "2015-01"
-8028	narrow pulsating artificial skylight	0		Last Available: "2015-01"
+8027	lime green skewed antler chandelier	0		Last Available: "2015-01"
+8028	pulsating narrow artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	mirror lime green continental juice bar	0		Last Available: "2015-01"
 8031	wobbly stationery set	0		Last Available: "2015-01"
@@ -7944,18 +7944,18 @@
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	mirror monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
-8066	compressed skewed teal	1	good	Last Available: "2015-12"
+8066	compressed teal skewed	1	good	Last Available: "2015-12"
 8067	shaking nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
 8070	warehouse map page	0		
 8071	huge warehouse inventory page	0		
 8072	shaking janitor sponge	0		
-8073	green twirling Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	perfumed healthy Spelunker's fedora of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5, Stench Resistance: +5, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8073	twirling green Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
+8074	perfumed healthy Spelunker's fedora of bravery	0		Maximum HP Percent: +20, Spooky Resistance: +5, Stench Resistance: +5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	olive huge wool friendly Annie Oakley's Spelunker's whip	0		Critical Hit Percent: +20, Familiar Weight: +3, Cold Resistance: +1, Last Available: "2015-12"
-8076	prompt sage Spelunker's khakis of the overflowing toilet	0		Mysticality Percent: +10, Stench Spell Damage: +50, Adventures: +3, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
-8077	cyan bouncing squat Spelunker's Guild prize sack	0		Last Available: "2015-12"
+8076	prompt sage Spelunker's khakis of the overflowing toilet	0		Mysticality Percent: +10, Stench Spell Damage: +50, Adventures: +3, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8077	cyan squat bouncing Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	bouncing mirror LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
@@ -7977,7 +7977,7 @@
 8102	mirror brooch of the dark arts of terror	0		Spell Damage Percent: +100, Spooky Spell Damage: +10, Single Equip, Last Available: "2016-12"
 8103	tumbling padded breeches of incineration	0		Damage Absorption: +20, Hot Spell Damage: +50, Last Available: "2016-12"
 8104	forbidden backpack of incineration	0		Spell Damage Percent: +50, Hot Spell Damage: +50, Last Available: "2016-12"
-8105	modified blurry ghostly bits	1		Effect: "Rave Nirvana", Effect Duration: 35, Last Available: "2016-12"
+8105	modified ghostly blurry bits	1		Effect: "Rave Nirvana", Effect Duration: 35, Last Available: "2016-12"
 8106	lime green aromatic quilted anvil	0		Damage Absorption: +40, Stench Resistance: +1, Single Equip, Last Available: "2017-12"
 8107	Da Vinci's akubra of bravery	0		Experience (Mysticality): +5, Spooky Resistance: +5, Last Available: "2017-12"
 8108	coward's slick apron	0		Moxie: +10, Monster Level: -20, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	frightening frosty garland	0		Cold Spell Damage: +10, Spooky Damage: +5, Single Equip, Last Available: "2018-12"
 8122	narrow curative supercool gunnysack	0		Moxie Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
 8123	scandalous electrified garibaldi	0		Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-12"
-8124	stanky sizzling girdle	0		Hot Damage: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	stanky sizzling girdle	0		Hot Damage: +10, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	miser's groovy gloves	0		Moxie Percent: +10, Meat Drop: +10, Single Equip, Last Available: "2018-12"
 8126	powdered ghostly smithereens	1		Last Available: "2018-12"
 8127	Temple Grandin's razor-sharp fiberglass fetish	0		Weapon Damage Percent: +25, Familiar Weight: +7, Last Available: "2018-12"
@@ -8041,9 +8041,9 @@
 8167	small adequate baguette	2	good	
 8168	blinking glob of icing	0		
 8169	non-oxidized chilled ginger snaps	0		Effect: "Indescribable Flavor", Effect Duration: 51
-8170	dry teal ghostly mostly-broken sunglasses	0		Effect: "The Smeezingtons", Effect Duration: 59
+8170	dry ghostly teal mostly-broken sunglasses	0		Effect: "The Smeezingtons", Effect Duration: 59
 8171	watered-down lousy unflavored wine cooler	2	decent	
-8172	upside-down jittery carton of snake milk	1	crappy	
+8172	jittery upside-down carton of snake milk	1	crappy	
 8173	purple sewer snake of the boozehound	0		Booze Drop: +100
 8174	normal ghostly pigeon egg	3	good	
 8175	hardened Rosewater's jaunty feather	0		Mysticality Percent: +30, Damage Reduction: 3
@@ -8056,22 +8056,22 @@
 8182	purple Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	studded bread basket	0		Damage Absorption: +80
 8184	blinking Ed the Undying exhibit crate	0		
-8185	teal gravedigger's flame-wreathed The Crown of Ed the Undying	0		Spooky Damage: +10, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	teal gravedigger's flame-wreathed The Crown of Ed the Undying	0		Spooky Damage: +10, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	shaking skewed map to a hidden booze cache	0		
 8188	perfectly mixed bouncing Cherrytastrophe wine cooler	4	EPIC	
 8189	hand-crafted red ghostly Radberry Rip wine cooler	3	EPIC	
-8190	lousy practically non-alcoholic Orangemageddon wine cooler	1	decent	
+8190	practically non-alcoholic lousy Orangemageddon wine cooler	1	decent	
 8191	drinkable Breakfast Blast wine cooler	3	good	
 8192	delicious twirling Citrus Crush wine cooler	4	awesome	
 8193	stale miniature plain bagel	2	decent	
-8194	half-sized rotten glob of cream cheese	2	crappy	
+8194	rotten half-sized glob of cream cheese	2	crappy	
 8195	adequate huge loaf of soda bread	4	good	
 8196	flavorless gigantic cyan acceptable bagel	6	decent	
-8197	flavorless gigantic standard-issue cupcake	10	decent	
+8197	gigantic flavorless standard-issue cupcake	10	decent	
 8198	yummy gigantic blurry ultra-deluxe cupcake	10	awesome	
 8199	hypnotic breadcrumbs	0		
-8200	delicious small popular tart	2	awesome	
+8200	small delicious popular tart	2	awesome	
 8201	pulsating no-handed pie	0		
 8202	enhanced Doc Galaktik's Vitality Serum	0		Effect: "Cotton Mouthed", Effect Duration: 12
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8085,14 +8085,14 @@
 8211	bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	Lo Pan's clever rigging rope	0		Maximum MP: +20, Spell Critical Percent: +30, Last Available: "2015-04"
-8214	pickled jittery tumbling lime green nasty snuff	1	awesome	Effect: "Thanksgot", Effect Duration: 35, Last Available: "2015-04"
-8215	arcane researcher's sewage-clogged pistol of the overflowing toilet	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +50, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8214	pickled lime green jittery tumbling nasty snuff	1	awesome	Effect: "Thanksgot", Effect Duration: 35, Last Available: "2015-04"
+8215	arcane researcher's sewage-clogged pistol of the overflowing toilet	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +50, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	deionized narrow beard incense	0		Effect: "Sewer-Drenched", Effect Duration: 15, Last Available: "2015-04"
 8217	lime green perfume-soaked bandana of the scaredy-cat of chilblains	0		Monster Level: -15, Cold Damage: +25, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	delicious toxo	3	awesome	Last Available: "2015-04"
 8220	tolerable Lemonade-235	3	good	Last Available: "2015-04"
-8221	isotophat of chilblains of courage	0		Cold Damage: +25, Spooky Resistance: +3, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	isotophat of chilblains of courage	0		Cold Damage: +25, Spooky Resistance: +3, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Van der Graaf Herculean Three Mile Island shorts	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-04"
 8223	narrow savvy strapping toxic mop	0		Muscle: +5, Mysticality Percent: +20, Last Available: "2015-04"
 8224	narrow inert sludgepuppy	0		Last Available: "2015-04"
@@ -8119,7 +8119,7 @@
 8245	trash net	0		Last Available: "2015-04"
 8246	olive greedy baleful thinker's Dinsey mascot mask	0		Mysticality: +10, Spell Damage: +25, Meat Drop: +20, Last Available: "2015-04"
 8247	flavorless special Dinsey food-cone	3	decent	Effect: "Serendipi Tea", Effect Duration: 5, Last Available: "2015-04"
-8248	fancy bad spirit-forward Dinsey Whinskey	5	decent	Effect: "Smoky Third Eye", Effect Duration: 5, Last Available: "2015-04"
+8248	fancy spirit-forward bad Dinsey Whinskey	5	decent	Effect: "Smoky Third Eye", Effect Duration: 5, Last Available: "2015-04"
 8249	wet pickled Dinsey face paint	0		Effect: "protect.enq", Effect Duration: 11, Last Available: "2015-04"
 8250	family-friendly beefy fannypack	0		Muscle: +10, Sleaze Resistance: +1, Last Available: "2015-04"
 8251	scorching electrified vibrating rosy-cheeked wholesome garbage sticker	0		Maximum HP Percent: 40, Maximum MP Percent: +10, Hot Damage: +25, Item Drop: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-04"
@@ -8152,11 +8152,11 @@
 8278	extra-dry perfectly mixed twirling Afternoon Delight	5	EPIC	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	shaking Golden Kokomo Resort Chip	0		Last Available: "2015-04"
-8281	tarnished corrupted pulsating maroon Kokomo Resort Brand Suntan Oil	0		Effect: "Grumpy and Ornery", Effect Duration: 13, Last Available: "2015-04"
+8281	tarnished corrupted maroon pulsating Kokomo Resort Brand Suntan Oil	0		Effect: "Grumpy and Ornery", Effect Duration: 13, Last Available: "2015-04"
 8282	blinking Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
 8284	vacuum-sealed Kokomo Resort Pass	0		Effect: "Educated (Sorta)", Effect Duration: 35, Last Available: "2023-08"
-8285	blue skewed Mayo Minder&trade;	0		Last Available: "2015-05"
+8285	skewed blue Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	non-energized enhanced wobbly Mayo de Mayo&trade; mayo	0		Effect: "Coldfinger", Effect Duration: 55
 8287	cyan puck	0		Free Pull, Last Available: "2015-06"
 8288	kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
@@ -8173,20 +8173,20 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	non-boiled power pill	0		Effect: "Good Karma", Effect Duration: 26, Last Available: "2015-06"
 8301	unsweetened quadruple-dry pixel star	0		Effect: "Fireproof Lips", Effect Duration: 68, Last Available: "2015-06"
-8302	moldy gigantic pixel banana	7	crappy	Last Available: "2015-06"
-8303	artisanal irresponsibly strong squat pixel beer	9	EPIC	Last Available: "2015-06"
+8302	gigantic moldy pixel banana	7	crappy	Last Available: "2015-06"
+8303	irresponsibly strong artisanal squat pixel beer	9	EPIC	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
 8306	quadruple-denatured red sludgesicle	0		Effect: "Marbles in Your Mouth", Effect Duration: 33
 8307	wet gray &Uuml;berraschthexengebr&auml;u	0		Effect: "Hippy Flavor", Effect Duration: 17
 8308	quadruple-ionized piggy tattoo	0		Effect: "Strange Mental Acuity", Effect Duration: 16
 8309	extra-vacuum-sealed energized baggie of regular-sized tardigrades	0		Effect: "Shawarma Warm War", Effect Duration: 12
-8310	wet adjusted blinking blue .epub file	0		Effect: "Fortunate Resolve", Effect Duration: 40
+8310	wet adjusted blue blinking .epub file	0		Effect: "Fortunate Resolve", Effect Duration: 40
 8311	boiled denatured BUBBLE GUM	0		Effect: "Squatting and Thrusting", Effect Duration: 48
 8312	pickled hustler shades	0		Effect: "Pyromania", Effect Duration: 50
-8313	quadruple-dry teal wobbly jerky stick	0		Effect: "Concentrated Concentration", Effect Duration: 37
+8313	quadruple-dry wobbly teal jerky stick	0		Effect: "Concentrated Concentration", Effect Duration: 37
 8314	corrupted unsweetened costume rental shop	0		Effect: "Muddled", Effect Duration: 41
-8315	boiled extra-nitrogenated upside-down bouncing muscle oil	0		Effect: "Toast Tea", Effect Duration: 15
+8315	boiled extra-nitrogenated bouncing upside-down muscle oil	0		Effect: "Toast Tea", Effect Duration: 15
 8316	colloidal double-adjusted colloidal twirling bottle of Red-Out	0		Effect: "Ruby-ous", Effect Duration: 67
 8317	altered pickpocket protector	0		Effect: "Cold Hands", Effect Duration: 11
 8318	adjusted warmed sinister-looking cat	0		Effect: "Scarysauce", Effect Duration: 62
@@ -8219,12 +8219,12 @@
 8345	frozen enhanced crident	0		Effect: "Resilient Spirit", Effect Duration: 66
 8346	electrified double-improved shaking twirling totally sweet mohawk helmet	0		Effect: "Purity of Spirit", Effect Duration: 44
 8347	Vulcanized nitrogenated blurry spray chrome	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 14
-8348	Vulcanized alkaline extra-oxidized bouncing wobbly filthy monkey head	0		Effect: "Broken Fast", Effect Duration: 12
+8348	Vulcanized alkaline extra-oxidized wobbly bouncing filthy monkey head	0		Effect: "Broken Fast", Effect Duration: 12
 8349	triple-aerosolized yellow hand of cards	0		Effect: "Indescribable Flavor", Effect Duration: 58
 8350	irradiated chilled electrified mirror pulsating damp bar rag	0		Effect: "Boo Tea", Effect Duration: 45
 8351	Vulcanized jittery lump of goofball ore	0		Effect: "Uncaged Power", Effect Duration: 57
 8352	tarnished denatured huge skeleton beans	0		Effect: "Swordholder", Effect Duration: 36
-8353	nitrogenated aerosolized bouncing squat green grimy lab coat	0		Effect: "Crocodile Tear", Effect Duration: 42
+8353	nitrogenated aerosolized squat bouncing green grimy lab coat	0		Effect: "Crocodile Tear", Effect Duration: 42
 8354	triple-energized alkaline non-improved tumbling nursery rhyme	0		Effect: "Sewer-Drenched", Effect Duration: 22
 8355	liquefied iron torso box	0		Effect: "Itchy Trigger Finger", Effect Duration: 53
 8356	super-wet concentrated mercenary headband	0		Effect: "Ancient Protected", Effect Duration: 54
@@ -8235,12 +8235,12 @@
 8361	moist vacuum-sealed purple child-sized dracula cloak	0		Effect: "Fireproof Lips", Effect Duration: 48
 8362	super-enhanced tarnished narrow twirling devil-summoning hat	0		Effect: "Earthen Fist", Effect Duration: 28
 8363	extra-activated shopkeeper beard	0		Effect: "License to Punch", Effect Duration: 61
-8364	triple-Vulcanized alkaline green spinning alien autoautopsy kit	0		Effect: "You're Not Cooking", Effect Duration: 53
+8364	triple-Vulcanized alkaline spinning green alien autoautopsy kit	0		Effect: "You're Not Cooking", Effect Duration: 53
 8365	non-electrified tarnished polymerized blurry novelty fruit hat	0		Effect: "Corona de la Salsa", Effect Duration: 27
 8366	modified blinking invisibility cream	0		Effect: "Dancing Prowess", Effect Duration: 26
 8367	wet wobbly handful of stubble	0		Effect: "Human-Hobo Hybrid", Effect Duration: 34
 8368	warmed lime green garbage juice slurpee	0		Effect: "Sourpuss", Effect Duration: 36
-8369	triple-quantum non-nitrogenated wobbly upside-down plunge-leg	0		Effect: "The Halls of Mysticality", Effect Duration: 28
+8369	triple-quantum non-nitrogenated upside-down wobbly plunge-leg	0		Effect: "The Halls of Mysticality", Effect Duration: 28
 8370	nitrogenated improved narrow funky eyepatch	0		Effect: "Turtle Titters", Effect Duration: 13
 8371	extra-colloidal dry upside-down bucket of fish juice	0		Effect: "init.enh", Effect Duration: 39
 8372	liquefied modified flashy pirate dreadlocks	0		Effect: "Dancing Prowess", Effect Duration: 24
@@ -8248,7 +8248,7 @@
 8374	corrupted chilled gray drinks tray	0		Effect: "Disco State of Mind", Effect Duration: 24
 8375	improved maroon narrow eyebrow lifter	0		Effect: "Natural 20", Effect Duration: 30
 8376	submarine	0		Last Available: "2015-06"
-8377	adequate fancy small skewed pixel lemon	2	good	Effect: "Seriously Mutated", Effect Duration: 45, Last Available: "2015-06"
+8377	fancy small adequate skewed pixel lemon	2	good	Effect: "Seriously Mutated", Effect Duration: 45, Last Available: "2015-06"
 8378	artisanal pixel daiquiri	4	EPIC	Last Available: "2015-06"
 8379	extra-energized tarnished shaking power pill	0		Effect: "Nano-juiced", Effect Duration: 12, Last Available: "2015-06"
 8380	corrupted anodized pixel potion	0		Effect: "Warm Shoulders", Effect Duration: 37, Last Available: "2015-06"
@@ -8283,14 +8283,14 @@
 8409	delicious crudles	3	awesome	
 8410	moldy agnolotti arboli	3	crappy	
 8411	immense moldy spaghetti with ghost balls	6	crappy	
-8412	moldy low-calorie succulent marrow	1	crappy	
-8413	small decent salacious crumbs	2	good	
+8412	low-calorie moldy succulent marrow	1	crappy	
+8413	decent small salacious crumbs	2	good	
 8414	moldy fusilli marrownarrow	4	crappy	
-8415	rotten upside-down red suggestive strozzapreti	3	crappy	
+8415	rotten red upside-down suggestive strozzapreti	3	crappy	
 8416	Mountain Stream gastrique	0		
-8417	snack-sized flavorless Mt. McLargeHuge oyster	2	decent	
+8417	flavorless snack-sized Mt. McLargeHuge oyster	2	decent	
 8418	oyster sauce	0		
-8419	half-sized normal linguini immondizia bianco	2	good	
+8419	normal half-sized linguini immondizia bianco	2	good	
 8420	normal small shells a la shellfish	2	good	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8303,8 +8303,8 @@
 8429	veiny spore pod	0		
 8430	hard spore pod	0		
 8431	spore pod	0		
-8432	bouncing mirror hot spore pod	0		
-8433	spinning shaking red cool spore pod	0		
+8432	mirror bouncing hot spore pod	0		
+8433	shaking red spinning cool spore pod	0		
 8434	wobbly jingling spore pod	0		
 8435	ghostly blue knitted LavaCo Lamp&trade; of the early riser	0		Cold Resistance: +3, Adventures: +7, Last Available: "2015-08"
 8436	rosy-cheeked Samson's LavaCo Lamp&trade;	0		Experience (Muscle): +5, Maximum HP Percent: +30, Last Available: "2015-08"
@@ -8329,30 +8329,30 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	yellow broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	padded high-temperature mining mask of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +20, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	padded high-temperature mining mask of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +20, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	Lo Pan's dance instructor's fireproof megaphone	0		Experience Percent (Moxie): +10, Spell Critical Percent: +30, Last Available: "2015-08"
 8460	spoiled mineapple	3	crappy	Last Available: "2015-08"
 8461	artisanal Gold Velvet&trade; whiskey	3	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	good	Last Available: "2015-08"
 8463	low-calorie adequate smelted roe	1	good	Last Available: "2015-08"
-8464	triple-distilled drinkable lavawater	6	good	Last Available: "2015-08"
+8464	drinkable triple-distilled lavawater	6	good	Last Available: "2015-08"
 8465	double-irradiated oxidized basaltamander tongue	0		Effect: "Turkey-Agitated", Effect Duration: 37, Last Available: "2015-08"
 8466	flame-wreathed nippy manspreader's lavalarva	0		Monster Level: +10, Cold Damage: +10, Hot Spell Damage: +10, Last Available: "2015-08"
 8467	tumbling hale razor-sharp lava balaclava of the brazier	0		Weapon Damage Percent: +25, Maximum HP: +20, Hot Spell Damage: +25, Last Available: "2015-08"
 8468	stanky personal trainer's basaltamander buckler of the ox	0		Muscle: +20, Experience Percent (Muscle): +10, Stench Spell Damage: +25, Damage Reduction: 15, Last Available: "2015-08"
 8469	alkaline alkaline lava globs	0		Effect: "Radiant Personality", Effect Duration: 30, Last Available: "2015-08"
-8470	low-calorie decent huge twirling gooey lava globs	1	good	Last Available: "2015-08"
+8470	low-calorie decent twirling huge gooey lava globs	1	good	Last Available: "2015-08"
 8471	spinning therapeutic lava-proof pants of the detective	0		Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2015-08"
 8472	Annie Oakley's heat-resistant necktie of vim and vigor	0		Maximum HP Percent: +50, Critical Hit Percent: +20, Single Equip, Last Available: "2015-08"
 8473	nasty hardened smartaleck's heat-resistant gloves	0		Moxie Percent: +30, Damage Reduction: 3, Stench Damage: +5, Single Equip, Last Available: "2015-08"
-8474	special super-sized flavorless very hot lunch	5	decent	Effect: "Coming Up Roses", Effect Duration: 10, Last Available: "2015-08"
-8475	perfectly mixed strong asbestos thermos	5	EPIC	Last Available: "2015-08"
+8474	flavorless super-sized special very hot lunch	5	decent	Effect: "Coming Up Roses", Effect Duration: 10, Last Available: "2015-08"
+8475	strong perfectly mixed asbestos thermos	5	EPIC	Last Available: "2015-08"
 8476	tarnished nitrogenated liquid rhinestones	0		Effect: "20/20 Vision", Effect Duration: 24, Last Available: "2015-08"
 8477	rotten disco biscuit	4	crappy	Last Available: "2015-08"
 8478	enchanted tolerable Quaatorade&trade;	3	good	Effect: "Flower Power", Effect Duration: 25, Last Available: "2015-08"
-8479	tumbling aromatic hardened extremely unsafe biker's hat	0		Weapon Damage Percent: +100, Damage Reduction: 3, Stench Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
-8480	Lo Pan's slick feathered headdress of Flo-Jo	0		Moxie: +10, Spell Critical Percent: +30, Initiative: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	gray resourceful educational electrician's hardhat of the bloodbag	0		Experience: +1, Maximum HP: +100, Maximum MP: +50, Familiar Effect: "atk", Last Available: "2015-08"
+8479	tumbling aromatic hardened extremely unsafe biker's hat	0		Weapon Damage Percent: +100, Damage Reduction: 3, Stench Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
+8480	Lo Pan's slick feathered headdress of Flo-Jo	0		Moxie: +10, Spell Critical Percent: +30, Initiative: +100, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	gray resourceful educational electrician's hardhat of the bloodbag	0		Experience: +1, Maximum HP: +100, Maximum MP: +50, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	huge Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	teal airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	bouncing Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	blurry New Age hurting crystal	0		Last Available: "2015-08"
-8490	healthy smooth velvet pants	0		Maximum HP Percent: +20, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	healthy smooth velvet pants	0		Maximum HP Percent: +20, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	squat Samson's smooth velvet shirt	0		Experience (Muscle): +5, Last Available: "2015-08"
 8492	squat prompt smooth velvet hat	0		Adventures: +3, Last Available: "2015-08"
 8493	smooth velvet pocket square of doom	0		Spooky Spell Damage: +50, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	upside-down scandalous hardy SMOOCH bracers	0		Maximum HP: +50, Sleaze Damage: +5, Single Equip, Last Available: "2015-08"
 8518	huge Annie Oakley's SMOOCH kneepads	0		Critical Hit Percent: +20, Single Equip, Last Available: "2015-08"
 8519	spinning fireproof SMOOCH spaulders	0		Hot Resistance: +3, Single Equip, Last Available: "2015-08"
-8520	flame-wreathed SMOOCH codpiece of chilblains	0		Cold Damage: +25, Hot Spell Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	flame-wreathed SMOOCH codpiece of chilblains	0		Cold Damage: +25, Hot Spell Damage: +10, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	narrow SMOOCH breastplate of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8400,9 +8400,9 @@
 8526	low-calorie rotten pink slime	1	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	miniature spoiled devil hair pasta	2	crappy	
-8530	adequate fancy gray spagecialetti	4	good	Effect: "Tapped In", Effect Duration: 50
-8531	tumbling jittery olive Salsa Libre	0		
+8529	spoiled miniature devil hair pasta	2	crappy	
+8530	fancy adequate gray spagecialetti	4	good	Effect: "Tapped In", Effect Duration: 50
+8531	jittery tumbling olive Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	rotten low-calorie libertagliatelle	1	crappy	
@@ -8414,14 +8414,14 @@
 8541	olive drug cocktail sauce	0		
 8542	yummy Fettris	4	awesome	
 8543	flavorless fusillocybin	3	decent	
-8544	fancy flavorless thick prescription noodles	5	decent	Effect: "You Know Who to Call", Effect Duration: 30
+8544	flavorless thick fancy prescription noodles	5	decent	Effect: "You Know Who to Call", Effect Duration: 30
 8545	dehydrated spinning blood-drive sticker	1	EPIC	
 8546	moist galvanized aerosolized bag of grain	0		Effect: "The Real Deal", Effect Duration: 17
 8547	boiled pocket maze	0		Effect: "Mushroom Samba", Effect Duration: 21
 8548	double-enhanced enhanced wobbly shady shades	0		Effect: "One Foot Heavier", Effect Duration: 41
 8549	deionized electrified teal squeaky toy rose	0		Effect: "Sugary World View", Effect Duration: 41
-8550	adequate blue tumbling weird gazelle steak	4	good	
-8551	yummy super-sized sausage without a cause	5	awesome	
+8550	adequate tumbling blue weird gazelle steak	4	good	
+8551	super-sized yummy sausage without a cause	5	awesome	
 8552	dry face paint	0		Effect: "Thunderheart", Effect Duration: 66
 8553	drinkable emergency margarita	4	good	
 8554	lousy triple-distilled pulsating vintage smart drink	8	decent	
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	tumbling lightning-fast zippy chilly barrel lid	0		Cold Damage: +5, Initiative: 60, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	Van der Graaf Newton's barrel hoop earring of horror	0		Experience (Mysticality): +3, Spooky Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2015-09"
-8567	flame-retardant chaotic dance instructor's bankruptcy barrel	0		Experience Percent (Moxie): +10, Spell Critical Percent: +10, Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	flame-retardant chaotic dance instructor's bankruptcy barrel	0		Experience Percent (Moxie): +10, Spell Critical Percent: +10, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	yellow huge firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	pulsating tun	0		Last Available: "2015-09"
@@ -8449,8 +8449,8 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	artisanal distilled red bottle of Amontillado	5	EPIC	Last Available: "2015-09"
-8579	bad practically non-alcoholic special barrel-aged martini	1	decent	Effect: "Booooooze", Effect Duration: 5, Last Available: "2015-09"
-8580	bland diet huge barrel pickle	1	decent	Last Available: "2015-09"
+8579	practically non-alcoholic bad special barrel-aged martini	1	decent	Effect: "Booooooze", Effect Duration: 5, Last Available: "2015-09"
+8580	diet bland huge barrel pickle	1	decent	Last Available: "2015-09"
 8581	delicious barrel cracker	3	awesome	Last Available: "2015-09"
 8582	boiled upside-down vibrating mushroom	1	good	Last Available: "2015-09"
 8583	altered twirling mushroom	1	crappy	Last Available: "2015-09"
@@ -8485,7 +8485,7 @@
 8612	irradiated twirling cuppa Serendipi tea	0		Effect: "Protection from Bad Stuff", Effect Duration: 41, Last Available: "2015-09"
 8613	dry wet skewed cuppa Feroci tea	0		Effect: "Disco Neuropathy", Effect Duration: 49, Last Available: "2015-09"
 8614	wet shaking cuppa Physicali tea	0		Effect: "Human-Hippy Hybrid", Effect Duration: 38, Last Available: "2015-09"
-8615	anodized liquefied jittery skewed cuppa Wit tea	0		Effect: "Ermine Eyes", Effect Duration: 55, Last Available: "2015-09"
+8615	anodized liquefied skewed jittery cuppa Wit tea	0		Effect: "Ermine Eyes", Effect Duration: 55, Last Available: "2015-09"
 8616	moist corrupted bouncing blinking cuppa Neuroplastici tea	0		Effect: "Stuck That Way", Effect Duration: 54, Last Available: "2015-09"
 8617	alkaline tarnished twirling cuppa Dexteri tea	0		Effect: "Ancient Protected", Effect Duration: 35, Last Available: "2015-09"
 8618	electrified adjusted purple cuppa Flexibili tea	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 44, Last Available: "2015-09"
@@ -8512,7 +8512,7 @@
 8639	blurry doghouse	0		Free Pull, Last Available: "2015-10"
 8640	bouncing Ghost Dog Chow	0		Last Available: "2015-10"
 8641	flavorless bowl of eyeballs	4	decent	Last Available: "2015-10"
-8642	moldy diet squat bowl of mummy guts	1	crappy	Last Available: "2015-10"
+8642	diet moldy squat bowl of mummy guts	1	crappy	Last Available: "2015-10"
 8643	small rotten bowl of maggots	2	crappy	Last Available: "2015-10"
 8644	tolerable blood and blood	3	good	Last Available: "2015-10"
 8645	tolerable mirror Jack-O-Lantern beer	4	good	Last Available: "2015-10"
@@ -8546,9 +8546,9 @@
 8673	pulsating Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
-8676	irradiated wet huge squat shoulder-warming lotion	0		Effect: "Become Superficially interested", Effect Duration: 20, Last Available: "2015-11"
+8676	irradiated wet squat huge shoulder-warming lotion	0		Effect: "Become Superficially interested", Effect Duration: 20, Last Available: "2015-11"
 8677	spoiled iceberg lettuce	4	crappy	Last Available: "2015-11"
-8678	drinkable extra-dry ice wine	5	good	Last Available: "2015-11"
+8678	extra-dry drinkable ice wine	5	good	Last Available: "2015-11"
 8679	Oprah's personal trainer's sage Wal-Mart snowglobe	0		Mysticality Percent: +10, Experience Percent (Muscle): +10, Maximum MP Percent: +50, Last Available: "2015-11"
 8680	gray personal trainer's Fonzie's stylish Wal-Mart nametag	0		Moxie: +25, Experience (Moxie): +1, Experience Percent (Muscle): +10, Last Available: "2015-11"
 8681	coward's Wal-Mart overalls of temperance of the sweet-tooth	0		Monster Level: -20, Sleaze Resistance: +5, Candy Drop: +100, Last Available: "2015-11"
@@ -8558,10 +8558,10 @@
 8685	blue Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	spinning dangerous bellhop's hat	0		Weapon Damage: +10, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	practically non-alcoholic mediocre bouncing bouncing ice porter	1	decent	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	spinning dangerous bellhop's hat	0		Weapon Damage: +10, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	mediocre practically non-alcoholic bouncing bouncing ice porter	1	decent	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	deionized boiled bouncing gray exotic travel brochure	0		Effect: "Carrrsmic", Effect Duration: 35, Last Available: "2015-11"
-8691	lime green bouncing mirror bag of foreign bribes	0		Last Available: "2015-11"
+8691	bouncing lime green mirror bag of foreign bribes	0		Last Available: "2015-11"
 8692	anodized aerosolized mirror shampoo-conditioner	0		Effect: "Eye of the Seal", Effect Duration: 14, Last Available: "2015-11"
 8693	blinking hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
@@ -8571,7 +8571,7 @@
 8698	lousy iced plum wine	3	decent	Last Available: "2016-01"
 8699	inspector's family-friendly coward's training belt	0		Monster Level: -20, Sleaze Resistance: +1, Item Drop: +15, Single Equip, Last Available: "2016-01"
 8700	inspector's stanky training legwarmers of Tarzan	0		Experience (Muscle): +3, Stench Spell Damage: +25, Item Drop: +15, Single Equip, Last Available: "2016-01"
-8701	frightening rock-hard training helmet	0		Damage Reduction: 5, Spooky Damage: +5, Item Drop: +5, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	frightening rock-hard training helmet	0		Damage Reduction: 5, Spooky Damage: +5, Item Drop: +5, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	narrow training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	olive training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8579,14 +8579,14 @@
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	fuchsia self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	distilled blue abstraction: action	1		Effect: "Clean-Shaven", Effect Duration: 30, Last Available: "2015-12"
-8709	pickled twirling skewed jittery abstraction: thought	1		Effect: "Sugary World View", Effect Duration: 50, Last Available: "2015-12"
+8709	pickled skewed twirling jittery abstraction: thought	1		Effect: "Sugary World View", Effect Duration: 50, Last Available: "2015-12"
 8710	dried abstraction: sensation	1		Last Available: "2015-12"
 8711	altered squat abstraction: purpose	1		Last Available: "2015-12"
 8712	vaporized abstraction: category	1		Last Available: "2015-12"
 8713	diluted tumbling abstraction: perception	1		Effect: "Sticky Hands", Effect Duration: 10, Last Available: "2015-12"
-8714	denatured jittery yellow pulsating abstraction: motion	1		Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2015-12"
+8714	denatured yellow jittery pulsating abstraction: motion	1		Effect: "Transcendental Wind", Effect Duration: 25, Last Available: "2015-12"
 8715	powdered abstraction: joy	1		Last Available: "2015-12"
-8716	dried blinking huge abstraction: certainty	1		Effect: "Ogred and Oublietted", Effect Duration: 40, Last Available: "2015-12"
+8716	dried huge blinking abstraction: certainty	1		Effect: "Ogred and Oublietted", Effect Duration: 40, Last Available: "2015-12"
 8717	dehydrated abstraction: comprehension	1		Effect: "Rain Dancin'", Effect Duration: 40, Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	half-sized moldy VYKEA meatballs	2	crappy	Last Available: "2015-11"
@@ -8601,21 +8601,21 @@
 8728	blue VYKEA dowel	0		Last Available: "2015-11"
 8729	miser's Oprah's strapping VYKEA hex key	0		Muscle: +5, Maximum MP Percent: +50, Meat Drop: +10, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	moldy tin of submardines	3	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	moldy tin of submardines	3	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	bad huge bottle of norwhiskey	4	decent	Last Available: "2015-11"
 8733	denatured skewed blinking octolus oculus	1	good	Last Available: "2015-11"
 8734	red medical-grade fortified arcane researcher's sardine can key	0		Experience Percent (Mysticality): +10, Damage Absorption: +60, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-11"
-8735	ghostly hardened Herculean norwhal helmet of the boozehound	0		Experience (Muscle): +1, Damage Reduction: 3, Booze Drop: +100, Familiar Effect: "atk", Last Available: "2015-11"
+8735	ghostly hardened Herculean norwhal helmet of the boozehound	0		Experience (Muscle): +1, Damage Reduction: 3, Booze Drop: +100, Last Available: "2015-11", Familiar Effect: "atk"
 8736	jittery greasy baleful thinker's octolus-skin cloak	0		Mysticality: +10, Spell Damage: +25, Sleaze Spell Damage: +10, Last Available: "2015-11"
 8737	tolerable perfect cosmopolitan	3	good	Last Available: "2015-11"
-8738	artisanal watered-down perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
+8738	watered-down artisanal perfect negroni	2	super ultra EPIC	Last Available: "2015-11"
 8739	artisanal perfect dark and stormy	3	EPIC	Last Available: "2015-11"
 8740	artisanal ghostly perfect mimosa	3	EPIC	Last Available: "2015-11"
 8741	lousy perfect old-fashioned	4	decent	Last Available: "2015-11"
 8742	hand-crafted perfect paloma	4	EPIC	Last Available: "2015-11"
-8743	chilled corrupted tumbling green That 70s Cologne	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 39, Last Available: "2015-11"
+8743	chilled corrupted green tumbling That 70s Cologne	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 39, Last Available: "2015-11"
 8744	concentrated wet twirling pulsating Wal-Mart &quot;diamond&quot; ring	0		Effect: "The Dinsey Spirit", Effect Duration: 55, Last Available: "2015-11"
-8745	magnetized cold-filtered twirling blinking Puffstone cigar	0		Effect: "Tightly-Wound Spine", Effect Duration: 23, Last Available: "2015-11"
+8745	magnetized cold-filtered blinking twirling Puffstone cigar	0		Effect: "Tightly-Wound Spine", Effect Duration: 23, Last Available: "2015-11"
 8746	chilled spinning Conspiracy&trade; mascara	0		Effect: "Snobby", Effect Duration: 47, Last Available: "2015-11"
 8747	pickled quantum Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Lit Up", Effect Duration: 17, Last Available: "2015-11"
 8748	airplane tattoo	0		Last Available: "2015-11"
@@ -8636,8 +8636,8 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	blinking box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	ghostly Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	aged watered-down Gratitude chocolate (bourbon-filled)	2	awesome	Last Available: "2016-02"
-8767	skewed olive Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
+8766	watered-down aged Gratitude chocolate (bourbon-filled)	2	awesome	Last Available: "2016-02"
+8767	olive skewed Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	upside-down chocolate bowtie	0		Familiar Weight: +5
 8770	unsweetened pitted sheet	0		Effect: "Adrenaline Rush", Effect Duration: 45, Last Available: "2015-12"
@@ -8662,7 +8662,7 @@
 8790	spinning elven tambourine of the bloodbag	0		Maximum HP: +100, Last Available: "2015-12"
 8791	reindeer sickle of the empath	0		Familiar Weight: +5, Last Available: "2015-12"
 8792	face paint	0		Free Pull, Last Available: "2015-12"
-8793	shaking squat face paint	0		Free Pull, Last Available: "2015-12"
+8793	squat shaking face paint	0		Free Pull, Last Available: "2015-12"
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
 8796	narrow plastic spoiler	0		
@@ -8688,23 +8688,23 @@
 8816	small toothsome Kudzu salad	2	awesome	Last Available: "2016-12"
 8817	dried Mansquito Serum	1		Last Available: "2016-12"
 8818	tolerable blurry Miss Graves' vermouth	4	good	Last Available: "2016-12"
-8819	stale snack-sized The Plumber's mushroom stew	2	decent	Last Available: "2016-12"
-8820	mixed bouncing narrow The Author's ink	1		Last Available: "2016-02"
-8821	watered-down drinkable The Mad Liquor	2	good	Last Available: "2016-12"
+8819	snack-sized stale The Plumber's mushroom stew	2	decent	Last Available: "2016-12"
+8820	mixed narrow bouncing The Author's ink	1		Last Available: "2016-02"
+8821	drinkable watered-down The Mad Liquor	2	good	Last Available: "2016-12"
 8822	lousy Doc Clock's thyme cocktail	3	decent	Last Available: "2016-12"
-8823	snack-sized spoiled Mr. Burnsger	2	crappy	Last Available: "2016-12"
+8823	spoiled snack-sized Mr. Burnsger	2	crappy	Last Available: "2016-12"
 8824	vaporized blinking The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	ghostly Jeselnik's nasty The Jokester's gun of the scaredy-cat	0		Monster Level: -15, Stench Damage: +5, Sleaze Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	teal ghostly flame-retardant greasy The Jokester's wig of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Hot Resistance: +1, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	blinking mansplainer's crafty The Jokester's pants of the scaredy-cat	0		Maximum MP: +10, Monster Level: 0, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	ghostly Jeselnik's nasty The Jokester's gun of the scaredy-cat	0		Monster Level: -15, Stench Damage: +5, Sleaze Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	teal ghostly flame-retardant greasy The Jokester's wig of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Hot Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	blinking mansplainer's crafty The Jokester's pants of the scaredy-cat	0		Maximum MP: +10, Monster Level: 0, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	irradiated Jokester makeup	0		Effect: "Spirit Bubble", Effect Duration: 16, Last Available: "2016-12"
 8829	pulsating replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
-8832	narrow bouncing domino mask	0		Familiar Weight: +5
+8832	bouncing narrow domino mask	0		Familiar Weight: +5
 8833	cold-filtered moist robin's egg	0		Effect: "Slimy Flavor", Effect Duration: 12, Last Available: "2016-12"
 8834	adequate snack-sized robin flan	2	good	Last Available: "2016-12"
-8835	watered-down drinkable robin nog	2	good	Last Available: "2016-12"
+8835	drinkable watered-down robin nog	2	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	upside-down plaintive telegram	0		Last Available: "2016-02"
 8838	upside-down exploding gum	0		
@@ -8719,7 +8719,7 @@
 8847	colloidal vacuum-sealed tumbling narrow red-hot jawbreaker	0		Effect: "Destructive Resolve", Effect Duration: 64
 8848	nitrogenated question juice	0		Effect: "Superhuman Sarcasm", Effect Duration: 26
 8849	energized tube of villain	0		Effect: "Mushroom Moxiousness", Effect Duration: 48
-8850	your cowboy boots of the brute	0		Muscle Percent: +30, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	your cowboy boots of the brute	0		Muscle Percent: +30, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	jittery inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	shaking purple nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,26 +8746,26 @@
 8874	jittery executive lard-coated foul-smelling resourceful Val-U Brand Every Bean Salad of extreme caution	0		Maximum MP: +50, Monster Level: -25, Stench Damage: +10, Sleaze Spell Damage: +25, Meat Drop: +40, Last Available: "2016-02"
 8875	curative supercool Shrub's Premium Baked Beans of vim and vigor	0		Moxie Percent: +20, Maximum HP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-02"
 8876	rotten small plate of Heimz Fortified Kidney Beans	2	crappy	Last Available: "2016-02"
-8877	miniature adequate plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
+8877	adequate miniature plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
 8878	toothsome plate of Mixed Garbanzos and Chickpeas	3	awesome	Last Available: "2016-02"
 8879	tiny decent jittery plate of Hellfire Spicy Beans	1	good	Last Available: "2016-02"
 8880	tasty mirror plate of Frigid Northern Beans	4	awesome	Last Available: "2016-02"
 8881	decent plate of World's Blackest-Eyed Peas	3	good	Last Available: "2016-02"
-8882	spoiled gigantic plate of Trader Olaf's Exotic Stinkbeans	9	crappy	Last Available: "2016-02"
+8882	gigantic spoiled plate of Trader Olaf's Exotic Stinkbeans	9	crappy	Last Available: "2016-02"
 8883	adequate plate of Pork 'n' Pork 'n' Pork 'n' Beans	3	good	Last Available: "2016-02"
 8884	rotten plate of Val-U Brand Every Bean Salad	4	crappy	Last Available: "2016-02"
 8885	spoiled plate of Shrub's Premium Baked Beans	4	crappy	Last Available: "2016-02"
 8886	huge friendly sharpshooter's Fancy Jeff's pocket square	0		Critical Hit Percent: +10, Familiar Weight: +3, Last Available: "2016-02"
-8887	Fonzie's Daisy's unclean bloomers of incineration of courage	0		Experience (Moxie): +1, Hot Spell Damage: +50, Spooky Resistance: +3, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	Fonzie's Daisy's unclean bloomers of incineration of courage	0		Experience (Moxie): +1, Hot Spell Damage: +50, Spooky Resistance: +3, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	blurry supercool Rosewater's Amoon-Ra Cowtep's nemes of the glutton	0		Mysticality Percent: +30, Moxie Percent: +20, Food Drop: +100, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	blurry supercool Rosewater's Amoon-Ra Cowtep's nemes of the glutton	0		Mysticality Percent: +30, Moxie Percent: +20, Food Drop: +100, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	huge foul-smelling steel-toed hardened personal trainer's Samson's Former Sheriff Dan's tin star	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Damage Reduction: 24, Stench Damage: +10, Last Available: "2016-02"
 8892	wobbly El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	experienced Granny Hackleton's Gatling gun of the sewer of mayonnaise	0		Experience: +2, Stench Damage: +25, Sleaze Spell Damage: +50, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
-8896	skewed yellow cow poker	0		Last Available: "2016-02"
+8896	yellow skewed cow poker	0		Last Available: "2016-02"
 8897	frozen warmed poker face paint	0		Effect: "One Foot Heavier", Effect Duration: 26, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	decent	Last Available: "2016-02"
@@ -8775,7 +8775,7 @@
 8903	polymerized red buzzard feather	0		Effect: "Sugary World View", Effect Duration: 62, Last Available: "2016-02"
 8904	energized aerosolized pressed lion musk	0		Effect: "Buggy Flavor", Effect Duration: 53, Last Available: "2016-02"
 8905	decent bear claw	4	good	Last Available: "2016-02"
-8906	anodized super-corrupted blurry narrow rattler gland	0		Effect: "Deadly Lampblade", Effect Duration: 50, Last Available: "2016-02"
+8906	anodized super-corrupted narrow blurry rattler gland	0		Effect: "Deadly Lampblade", Effect Duration: 50, Last Available: "2016-02"
 8907	irradiated jittery half-digested coal	0		Effect: "Liquid Luck", Effect Duration: 67, Last Available: "2016-02"
 8908	galvanized wet tightly-wound spine	0		Effect: "Craft Tea", Effect Duration: 53, Last Available: "2016-02"
 8909	miniature moldy rotting beefsteak	2	crappy	Last Available: "2016-02"
@@ -8827,7 +8827,7 @@
 8955	Tales of the West: Cow Punching	0		
 8956	skewed Tales of the West: Beanslinging	0		
 8957	Tales of the West: Snake Oiling	0		
-8958	shaking green briefcase full of snakes	0		
+8958	green shaking briefcase full of snakes	0		
 8959	flame-wreathed mansplainer's one-gallon hat	0		Monster Level: +15, Hot Spell Damage: +10
 8960	pulsating careful beefcake's two-gallon hat	0		Muscle: +25, Monster Level: -10
 8961	tumbling inspector's perfumed three-gallon hat	0		Stench Resistance: +5, Item Drop: +15
@@ -8852,7 +8852,7 @@
 8980	wet cyan patent avarice tonic	0		Effect: "Coal-Powered", Effect Duration: 32
 8981	magnetized chilled patent alacrity tonic	0		Effect: "Alacri Tea", Effect Duration: 52
 8982	nitrogenated extra-irradiated chilled corrupted marrow	0		Effect: "Itchy Trigger Finger", Effect Duration: 44
-8983	perfectly mixed watered-down spinning rodeo whiskey	2	EPIC	
+8983	watered-down perfectly mixed spinning rodeo whiskey	2	EPIC	
 8984	Thwaitgold scorpion statuette	0		
 8985	twirling slick real cowboy hat	0		Moxie: +10
 8986	ghostly Memories of Cow Punching	0		Free Pull
@@ -8862,23 +8862,23 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	boiled bouncing armored prawn	1		Effect: "familiar.enq", Effect Duration: 25, Last Available: "2016-03"
-8993	moldy half-sized enchanted teal jumping horseradish	2	crappy	Effect: "Feet of Watermelon", Effect Duration: 15, Last Available: "2016-03"
-8994	smooth special extra-dry Sacramento wine	5	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 5, Last Available: "2016-03"
+8993	half-sized moldy enchanted teal jumping horseradish	2	crappy	Effect: "Feet of Watermelon", Effect Duration: 15, Last Available: "2016-03"
+8994	smooth extra-dry special Sacramento wine	5	awesome	Effect: "Also Schmeckt Zarathustra", Effect Duration: 5, Last Available: "2016-03"
 8995	non-activated Greek fire	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 20, Last Available: "2016-03"
 8996	crafty personal trainer's ox-head shield of the cougar of Flo-Jo	0		Moxie: +20, Experience Percent (Muscle): +10, Maximum MP: +10, Item Drop: +5, Initiative: +100, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	blurry censurious medical-grade Sinatra's dented scepter of extreme caution of the early riser	0		Experience (Moxie): +5, Monster Level: -25, Sleaze Resistance: +3, Adventures: +7, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	wool nippy smartaleck's groovy very pointy crown of dire peril	0		Moxie Percent: 40, Weapon Damage: +20, Cold Damage: +10, Cold Resistance: +1, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	wool nippy smartaleck's groovy very pointy crown of dire peril	0		Moxie Percent: 40, Weapon Damage: +20, Cold Damage: +10, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	lion tamer's Samson's smooth battle broom of the bloodbag of the sewer	0		Moxie: +15, Experience (Muscle): +5, Maximum HP: +100, Experience (familiar): +2, Stench Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	family-friendly lion tamer's educational carpe of the brazier	0		Experience: +1, Experience (familiar): +2, Hot Spell Damage: +25, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
 9002	teal spinning wool ribald wholesome educational codpiece	0		Experience: +1, Maximum HP Percent: +10, Sleaze Damage: +10, Cold Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
-9003	bouncing avaricious greasy arcane researcher's troutsers of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Sleaze Spell Damage: +10, Meat Drop: +30, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	bouncing avaricious greasy arcane researcher's troutsers of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Sleaze Spell Damage: +10, Meat Drop: +30, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	red pulsating inspector's mansplainer's dangerous bass clarinet of the empath	0		Weapon Damage: +10, Monster Level: +15, Familiar Weight: +5, Item Drop: +15, Lasts Until Rollover, Last Available: "2016-04"
 9005	ribald scorching Annie Oakley's supercharged fish hatchet	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Hot Damage: +25, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2016-04"
 9006	jittery frosty tunac of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Cold Spell Damage: +10, Item Drop: +5, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	oxidized dry non-modified spinning wriggling worm	0		Effect: "High Blood Chocolate Content", Effect Duration: 11, Last Available: "2016-04"
-9009	tolerable bouncing spinning bottle of Fishhead 900-Day IPA	3	good	Last Available: "2016-04"
+9009	tolerable spinning bouncing bottle of Fishhead 900-Day IPA	3	good	Last Available: "2016-04"
 9010	ionized high-test fishing line	0		Effect: "Electrolit Up", Effect Duration: 69, Last Available: "2016-04"
 9011	brawny fishin' hat	0		Muscle Percent: +20, Last Available: "2016-04"
 9012	tumbling Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8895,17 +8895,17 @@
 9023	shaking screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
 9025	upside-down infinite BACON machine	0		Last Available: "2016-05"
-9026	wobbly maroon First Post shirt package	0		Last Available: "2016-05"
+9026	maroon wobbly First Post shirt package	0		Last Available: "2016-05"
 9027	narrow prompt Lo Pan's beefcake's First Post shirt - Cir Senam	0		Muscle: +25, Spell Critical Percent: +30, Adventures: +3, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
 9030	decent blinking star salad	3	good	
 9031	Thwaitgold moth statuette	0		
 9032	immense toothsome bowl of Tastee-Wheet&trade;	6	awesome	
-9033	yellow wobbly Source terminal	0		Free Pull, Last Available: "2016-06"
+9033	wobbly yellow Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	blurry fuchsia Source essence	0		Last Available: "2016-06"
 9035	spoiled browser cookie	3	crappy	Last Available: "2016-06"
-9036	drinkable triple-distilled hacked gibson	6	good	Last Available: "2016-06"
+9036	triple-distilled drinkable hacked gibson	6	good	Last Available: "2016-06"
 9037	grievous Source shades	0		Weapon Damage Percent: +50, Last Available: "2016-06"
 9038	upside-down software bug	0		Last Available: "2016-06"
 9039	gray missing semicolon	0		Familiar Weight: +11
@@ -8920,7 +8920,7 @@
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	upside-down Source terminal SCRAM chip	0		Last Available: "2016-06"
 9050	ghostly Source terminal TRIGRAM chip	0		Last Available: "2016-06"
-9051	yellow blurry Source terminal file: substats.enh	0		Last Available: "2016-06"
+9051	blurry yellow Source terminal file: substats.enh	0		Last Available: "2016-06"
 9052	lime green Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	blurry Source terminal file: protect.enq	0		Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	extra-frozen blurry blinking shoe gum	0		Effect: "Cringle's Curative Carol", Effect Duration: 61, Last Available: "2016-07"
 9076	pulsating bouncing maroon friendly vibrating hale noir fedora	0		Maximum HP: +20, Maximum MP Percent: +10, Familiar Weight: +3, Last Available: "2016-07"
 9077	Annie Oakley's MacGyver's trench coat of Flo-Jo	0		Maximum MP: +100, Critical Hit Percent: +20, Initiative: +100, Last Available: "2016-07"
-9078	acceptable fancy Falcon&trade; Maltese Liquor	3	good	Effect: "Gummiskin", Effect Duration: 25, Last Available: "2016-07"
+9078	fancy acceptable Falcon&trade; Maltese Liquor	3	good	Effect: "Gummiskin", Effect Duration: 25, Last Available: "2016-07"
 9079	tasty blurry hardboiled egg	3	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	huge DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	up-at-dawn ribald lion tamer's educational cool protonic accelerator pack of the boozehound	0		Moxie: +5, Experience: +1, Experience (familiar): +2, Sleaze Damage: +10, Booze Drop: +100, Adventures: +5, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	up-at-dawn ribald lion tamer's educational cool protonic accelerator pack of the boozehound	0		Moxie: +5, Experience: +1, Experience (familiar): +2, Sleaze Damage: +10, Booze Drop: +100, Adventures: +5, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	steel-toed Adventurer bobblehead	0		Damage Reduction: 9, Last Available: "2016-11"
 9085	fuchsia psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,14 +8963,14 @@
 9091	MacGyver's Mr. Screege's spectacles	0		Maximum MP: +100, Single Equip, Last Available: "2016-08"
 9092	gray wizardly Spookyraven signet of bravery of the sweet-tooth	0		Mysticality: +25, Spooky Resistance: +5, Candy Drop: +100, Single Equip, Last Available: "2016-08"
 9093	blue Socratic tie-dyed fannypack of extreme caution	0		Experience (Mysticality): +1, Monster Level: -25, Single Equip, Last Available: "2016-08"
-9094	pulsating beefcake's burnt snowpants of vim and vigor	0		Muscle: +25, Maximum HP Percent: +50, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	standards and practices guide of terror	0		Spooky Spell Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9094	pulsating beefcake's burnt snowpants of vim and vigor	0		Muscle: +25, Maximum HP Percent: +50, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	standards and practices guide of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	Jeselnik's curative Carpathian longsword of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-08"
 9097	gray jittery foul-smelling Jack Frost's Annie Oakley's Liam's mail	0		Critical Hit Percent: +20, Cold Spell Damage: +50, Stench Damage: +10, Last Available: "2016-08"
 9098	green zippy electrified Unfortunato's foolscap of Flo-Jo	0		Initiative: 120, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2016-08"
 9099	spinning twirling Thwaitgold cockroach statuette	0		
 9100	rad	0		
-9101	narrow tumbling purification tablet	0		
+9101	tumbling narrow purification tablet	0		
 9102	razor-sharp Wrist-Boy	0		Weapon Damage Percent: +25
 9103	spinning Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
 9104	Time-Spinner	0		Last Available: "2016-09"
@@ -9004,27 +9004,27 @@
 9132	blinking nippy pistol of the sweet-tooth	0		Cold Damage: +10, Candy Drop: +100
 9133	wobbly KoL Con 13 snowglobe	0		Last Available: "2016-10"
 9134	rotten ghostly leftover pasty	3	crappy	
-9135	watered-down special perfectly mixed very whiskey	2	super EPIC	Effect: "stats.enq", Effect Duration: 45
+9135	perfectly mixed watered-down special very whiskey	2	super EPIC	Effect: "stats.enq", Effect Duration: 45
 9136	pulsating li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	wobbly li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	cyan li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	purple li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	mirror li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	cyan li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	purple li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	huge li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	mirror li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	ionized hoarded candy wad	0		Effect: "Slimy Hands", Effect Duration: 62, Last Available: "2016-10"
 9147	energized modified pulsating Prunets	0		Effect: "Spirit Bubble", Effect Duration: 46
 9148	Twitching Television Tattoo	0		
 9149	skewed baby scorpion	0		Familiar Weight: +10
 9150	nitrogenated cyan invisible string	0		Lasts Until Rollover, Effect: "The Smile of Mr. A.", Effect Duration: 63, Last Available: "2016-10"
 9151	denatured wobbly invisible seam ripper	0		Lasts Until Rollover, Effect: "Crimbo Epiphany", Effect Duration: 34, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	immense moldy raw sweet potato	6	crappy	Last Available: "2016-11"
+9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9153	moldy immense raw sweet potato	6	crappy	Last Available: "2016-11"
 9154	decent skewed raw beans	3	good	Last Available: "2016-11"
-9155	normal bite-sized raw stuffing	1	good	Last Available: "2016-11"
+9155	bite-sized normal raw stuffing	1	good	Last Available: "2016-11"
 9156	moldy huge fancy wobbly raw cranberry sauce	9	crappy	Effect: "Hot Buttoned", Effect Duration: 50, Last Available: "2016-11"
 9157	adequate raw turkey	3	good	Last Available: "2016-11"
 9158	spoiled raw mincemeat	3	crappy	Last Available: "2016-11"
@@ -9035,22 +9035,22 @@
 9163	fireproof supercool glass casserole dish of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Hot Resistance: +3, Last Available: "2016-11"
 9164	huge stuffing fluffer	0		Last Available: "2016-11"
 9165	greedy grievous can opener	0		Weapon Damage Percent: +50, Meat Drop: +20, Last Available: "2016-11"
-9166	vaporized spinning huge blue turkey blaster	1		Effect: "White Blooded", Effect Duration: 40, Last Available: "2016-11"
+9166	vaporized huge blue spinning turkey blaster	1		Effect: "White Blooded", Effect Duration: 40, Last Available: "2016-11"
 9167	spinning frightening nasty glass pie plate	0		Stench Damage: +5, Spooky Damage: +5, Damage Reduction: 7, Last Available: "2016-11"
 9168	clever deadly potato masher	0		Weapon Damage: +5, Maximum MP: +20, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
-9171	jumbo bland sweet potatoes	5	decent	Last Available: "2016-11"
-9172	decent miniature bean casserole	2	good	Last Available: "2016-11"
-9173	stale shaking pulsating baked stuffing	3	decent	Last Available: "2016-11"
+9171	bland jumbo sweet potatoes	5	decent	Last Available: "2016-11"
+9172	miniature decent bean casserole	2	good	Last Available: "2016-11"
+9173	stale pulsating shaking baked stuffing	3	decent	Last Available: "2016-11"
 9174	normal cranberry cylinder	3	good	Last Available: "2016-11"
-9175	half-sized delicious thanksgiving turkey	2	awesome	Last Available: "2016-11"
-9176	stale super-sized mince pie	5	decent	Last Available: "2016-11"
+9175	delicious half-sized thanksgiving turkey	2	awesome	Last Available: "2016-11"
+9176	super-sized stale mince pie	5	decent	Last Available: "2016-11"
 9177	normal spinning mashed potatoes	3	good	Last Available: "2016-11"
-9178	normal miniature jittery narrow warm gravy	2	good	Last Available: "2016-11"
+9178	miniature normal narrow jittery warm gravy	2	good	Last Available: "2016-11"
 9179	flavorless purple bread roll	3	decent	Last Available: "2016-11"
 9180	rotten maroon jittery leftovers	3	crappy	Last Available: "2016-11"
-9181	low-calorie moldy tumbling leftovers sandwich	1	crappy	Last Available: "2016-11"
+9181	moldy low-calorie tumbling leftovers sandwich	1	crappy	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	pulsating cornucopia	0		Last Available: "2016-11"
 9184	jittery megacopia	0		Last Available: "2016-11"
@@ -9090,10 +9090,10 @@
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	adequate animal part cracker	4	good	Last Available: "2016-12"
 9220	artisanal shaking gingerbread wine	3	EPIC	Last Available: "2016-12"
-9221	stale half-sized gingerbread mug	2	decent	Last Available: "2016-12"
+9221	half-sized stale gingerbread mug	2	decent	Last Available: "2016-12"
 9222	shaking gingerbread mask of dire peril	0		Weapon Damage: +20, Last Available: "2016-12"
 9223	blue coward's gingerservo of Gandalf of Leguizamo	0		Spell Critical Percent: +20, Monster Level: 0, Single Equip, Last Available: "2016-12"
-9224	super-pressed blurry purple tainted icing	0		Effect: "Hair on Your Chest", Effect Duration: 54, Last Available: "2016-12"
+9224	super-pressed purple blurry tainted icing	0		Effect: "Hair on Your Chest", Effect Duration: 54, Last Available: "2016-12"
 9225	tumbling personal trainer's gingerbeard	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2016-12"
 9226	gingerbread smartphone	0		Last Available: "2016-12"
 9227	blurry Rosewater's gingerbread hoodie of the early riser	0		Mysticality Percent: +30, Adventures: +7, Sprinkle Drop: +15, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	clever rock-hard gingerbread gavel	0		Damage Reduction: 5, Maximum MP: +20, Last Available: "2016-12"
 9237	bouncing gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	enchanted spirit-forward perfectly mixed huge ginger beer	5	EPIC	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2016-12"
+9239	spirit-forward enchanted perfectly mixed huge ginger beer	5	EPIC	Effect: "A Few Extra Pounds", Effect Duration: 10, Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	electrified industrial frosting	0		Effect: "Ticking Clock", Effect Duration: 36, Last Available: "2016-12"
 9242	warmed wet fake cocktail	0		Effect: "Fiery Spirit", Effect Duration: 29, Last Available: "2016-12"
@@ -9119,12 +9119,12 @@
 9247	educational plastic Your Brain	0		Experience: +1, Last Available: "2016-12"
 9248	razor-sharp plastic Krampus	0		Weapon Damage Percent: +25, Last Available: "2016-12"
 9249	extra-irradiated ionized Inner Wisdom	0		Effect: "Stands Alone", Effect Duration: 67, Last Available: "2016-12"
-9250	super-dry extra-energized polymerized purple wobbly Inner Strength	0		Effect: "Tiki Temerity", Effect Duration: 26, Last Available: "2016-12"
+9250	super-dry extra-energized polymerized wobbly purple Inner Strength	0		Effect: "Tiki Temerity", Effect Duration: 26, Last Available: "2016-12"
 9251	tarnished triple-modified spinning Inner Truth	0		Effect: "Stone-Faced", Effect Duration: 54, Last Available: "2016-12"
-9252	delicious special spiritual candy cane	3	awesome	Effect: "Hot Hands", Effect Duration: 10, Last Available: "2016-12"
+9252	special delicious spiritual candy cane	3	awesome	Effect: "Hot Hands", Effect Duration: 10, Last Available: "2016-12"
 9253	artisanal fuchsia spiritual eggnog	4	EPIC	Last Available: "2016-12"
 9254	normal spiritual fruitcake	3	good	Last Available: "2016-12"
-9255	miniature flavorless spiritual gingerbread	2	decent	Last Available: "2016-12"
+9255	flavorless miniature spiritual gingerbread	2	decent	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	diffused galvanized rock candy	0		Effect: "Flashing Eyes", Effect Duration: 61, Last Available: "2016-12"
-9267	rotten big upside-down green-iced sweet roll	5	crappy	Last Available: "2016-12"
+9267	big rotten upside-down green-iced sweet roll	5	crappy	Last Available: "2016-12"
 9268	upside-down sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	blinking chocolate sculpture	0		Last Available: "2016-12"
 9270	squat no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	fuchsia twirling negative lump	0		
 9273	Rosewater's Third Eye of the storm	0		Mysticality Percent: +30, Maximum MP Percent: +40, Last Available: "2016-12"
 9274	Socratic Krampus Horn of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +1, Single Equip, Last Available: "2016-12"
-9275	spoiled tiny hambrosier	1	crappy	Last Available: "2016-12"
+9275	tiny spoiled hambrosier	1	crappy	Last Available: "2016-12"
 9276	bad squat chakra-mental wine	3	decent	Last Available: "2016-12"
 9277	denatured Vulcanized chakra malt	0		Effect: "Serenity", Effect Duration: 40, Last Available: "2016-12"
-9278	snack-sized stale tumbling Black Angus blackburger	2	decent	Last Available: "2016-12"
-9279	bad high-proof brandy	8	decent	Last Available: "2016-12"
+9278	stale snack-sized tumbling Black Angus blackburger	2	decent	Last Available: "2016-12"
+9279	high-proof bad brandy	8	decent	Last Available: "2016-12"
 9280	tarnished wet cyan pulsating potion of spiritual gunkifying	0		Effect: "Shortened", Effect Duration: 30, Last Available: "2016-12"
 9281	baleful supercool bad vibroknife	0		Moxie Percent: +20, Spell Damage: +25, Last Available: "2016-12"
 9282	gray flame-retardant crystal belt buckle of the cougar	0		Moxie: +20, Hot Resistance: +1, Last Available: "2016-12"
@@ -9166,9 +9166,9 @@
 9294	dried huge sleaze jelly	1		Last Available: "2017-01"
 9295	twisted wobbly wobbly stench jelly	1		Effect: "Sticky Hands", Effect Duration: 10, Last Available: "2017-01"
 9296	jittery space planula	0		Free Pull, Last Available: "2017-01"
-9297	moldy super-sized enchanted squat toast with hot jelly	5	crappy	Effect: "Anytwo Five Elevenis?", Effect Duration: 50, Last Available: "2017-01"
-9298	stale fancy toast with jelly	4	decent	Effect: "Fangs and Pangs", Effect Duration: 5, Last Available: "2017-01"
-9299	bland enchanted jumbo toast with jelly	5	decent	Effect: "A Contender", Effect Duration: 20, Last Available: "2017-01"
+9297	enchanted super-sized moldy squat toast with hot jelly	5	crappy	Effect: "Anytwo Five Elevenis?", Effect Duration: 50, Last Available: "2017-01"
+9298	fancy stale toast with jelly	4	decent	Effect: "Fangs and Pangs", Effect Duration: 5, Last Available: "2017-01"
+9299	enchanted bland jumbo toast with jelly	5	decent	Effect: "A Contender", Effect Duration: 20, Last Available: "2017-01"
 9300	toothsome toast with sleaze jelly	3	awesome	Last Available: "2017-01"
 9301	normal toast with stench jelly	4	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
@@ -9216,10 +9216,10 @@
 9344	discarded button	0		
 9345	shaking Gummi-Memory	0		
 9346	wobbly Thwaitgold amoeba statuette	0		
-9347	blinking tumbling twirling pickled grasshopper	0		Last Available: "2017-03"
+9347	blinking twirling tumbling pickled grasshopper	0		Last Available: "2017-03"
 9348	jittery tumbling bottle of an&iacute;s	0		Last Available: "2017-03"
 9349	green bottle of novelty hot sauce	0		Last Available: "2017-03"
-9350	upside-down squat red elemental sugarcube	0		Last Available: "2017-03"
+9350	red squat upside-down elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
 9352	bottle of clam juice	0		Last Available: "2017-03"
 9353	cocktail mushroom	0		Last Available: "2017-03"
@@ -9234,44 +9234,44 @@
 9362	pile of dirt	0		Last Available: "2017-03"
 9363	slime shooter	0		Last Available: "2017-03"
 9364	blinking imaginary lemon	0		Last Available: "2017-03"
-9365	tolerable distilled blurry literal grasshopper	5	good	Last Available: "2017-03"
+9365	distilled tolerable blurry literal grasshopper	5	good	Last Available: "2017-03"
 9366	drinkable double entendre	4	good	Last Available: "2017-03"
 9367	drinkable Phlegethon	4	good	Last Available: "2017-03"
-9368	irresponsibly strong perfectly mixed Siberian sunrise	9	EPIC	Last Available: "2017-03"
+9368	perfectly mixed irresponsibly strong Siberian sunrise	9	EPIC	Last Available: "2017-03"
 9369	artisanal mentholated wine	4	EPIC	Last Available: "2017-03"
 9370	artisanal pulsating low tide martini	4	EPIC	Last Available: "2017-03"
-9371	hand-crafted narrow shaking shroomtini	4	EPIC	Last Available: "2017-03"
+9371	hand-crafted shaking narrow shroomtini	4	EPIC	Last Available: "2017-03"
 9372	fortified bad fuchsia morning dew	5	decent	Last Available: "2017-03"
 9373	artisanal whiskey squeeze	3	EPIC	Last Available: "2017-03"
 9374	bad bouncing mirror great fashioned	4	decent	Last Available: "2017-03"
 9375	fancy acceptable Gnomish sagngria	3	good	Effect: "The Halls of Moxiousness", Effect Duration: 45, Last Available: "2017-03"
-9376	special weak perfectly mixed vodka stinger	2	EPIC	Effect: "Omphalotus Omnipresence", Effect Duration: 5, Last Available: "2017-03"
+9376	perfectly mixed weak special vodka stinger	2	EPIC	Effect: "Omphalotus Omnipresence", Effect Duration: 5, Last Available: "2017-03"
 9377	acceptable extremely slippery nipple	3	good	Last Available: "2017-03"
 9378	artisanal blinking piscatini	4	EPIC	Last Available: "2017-03"
-9379	mediocre fortified special Churchill	5	decent	Effect: "Spirit Bubble", Effect Duration: 40, Last Available: "2017-03"
+9379	fortified special mediocre Churchill	5	decent	Effect: "Spirit Bubble", Effect Duration: 40, Last Available: "2017-03"
 9380	perfectly mixed purple soilzerac	4	EPIC	Last Available: "2017-03"
 9381	aged jittery pulsating London frog	4	awesome	Last Available: "2017-03"
-9382	mediocre practically non-alcoholic nothingtini	1	decent	Last Available: "2017-03"
+9382	practically non-alcoholic mediocre nothingtini	1	decent	Last Available: "2017-03"
 9383	lousy practically non-alcoholic eighth plague	1	decent	Last Available: "2017-03"
 9384	acceptable single entendre	3	good	Last Available: "2017-03"
-9385	practically non-alcoholic mediocre maroon reverse Tantalus	1	decent	Last Available: "2017-03"
+9385	mediocre practically non-alcoholic maroon reverse Tantalus	1	decent	Last Available: "2017-03"
 9386	lousy mirror elemental caipiroska	3	decent	Last Available: "2017-03"
-9387	enchanted artisanal red Feliz Navidad	4	EPIC	Effect: "Yet tea", Effect Duration: 20, Last Available: "2017-03"
+9387	artisanal enchanted red Feliz Navidad	4	EPIC	Effect: "Yet tea", Effect Duration: 20, Last Available: "2017-03"
 9388	acceptable Bloody Nora	3	good	Last Available: "2017-03"
 9389	aged moreltini	3	awesome	Last Available: "2017-03"
 9390	lousy hell in a bucket	3	decent	Last Available: "2017-03"
-9391	irresponsibly strong acceptable Newark	7	good	Last Available: "2017-03"
+9391	acceptable irresponsibly strong Newark	7	good	Last Available: "2017-03"
 9392	hand-crafted R'lyeh	3	EPIC	Last Available: "2017-03"
 9393	hand-crafted tumbling Gnollish sangria	4	EPIC	Last Available: "2017-03"
 9394	perfectly mixed jittery vodka barracuda	3	EPIC	Last Available: "2017-03"
 9395	mediocre Mysterious Island iced tea	3	decent	Last Available: "2017-03"
 9396	drinkable drive-by shooting	4	good	Last Available: "2017-03"
-9397	perfectly mixed triple-distilled gunner's daughter	6	EPIC	Last Available: "2017-03"
+9397	triple-distilled perfectly mixed gunner's daughter	6	EPIC	Last Available: "2017-03"
 9398	tolerable blurry dirt julep	3	good	Last Available: "2017-03"
 9399	mediocre Simepore slime	3	decent	Last Available: "2017-03"
-9400	watered-down hand-crafted Phil Collins	2	EPIC	Last Available: "2017-03"
-9401	bouncing tumbling pulsating unpowered Robortender	0		Free Pull, Last Available: "2017-03"
-9402	blue blinking toggle switch (Bartend)	0		Familiar Weight: +5
+9400	hand-crafted watered-down Phil Collins	2	EPIC	Last Available: "2017-03"
+9401	tumbling pulsating bouncing unpowered Robortender	0		Free Pull, Last Available: "2017-03"
+9402	blinking blue toggle switch (Bartend)	0		Familiar Weight: +5
 9403	blurry toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9284,7 +9284,7 @@
 9412	twirling alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	yellow botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	bite-sized spoiled jittery edible alien plant bit	1	crappy	Last Available: "2017-04"
+9415	spoiled bite-sized jittery edible alien plant bit	1	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9292,7 +9292,7 @@
 9420	pickled maroon pulsating alien plant goo	1		Effect: "Greased-Up Familiar", Effect Duration: 35, Last Available: "2017-04"
 9421	shaking alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	jumbo flavorless narrow alien meat	5	decent	Last Available: "2017-04"
+9423	flavorless jumbo narrow alien meat	5	decent	Last Available: "2017-04"
 9424	blinking alien toenails	0		Last Available: "2017-04"
 9425	huge huge alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
@@ -9303,7 +9303,7 @@
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	extra-energized alien medicine	0		Effect: "What's That Smell?", Effect Duration: 32, Last Available: "2017-04"
 9433	delicious fancy alien salad	4	awesome	Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 50, Last Available: "2017-04"
-9434	artisanal enchanted pulsating green alien booze	4	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 25, Last Available: "2017-04"
+9434	enchanted artisanal green pulsating alien booze	4	EPIC	Effect: "Mental A-cue-ity", Effect Duration: 25, Last Available: "2017-04"
 9435	blurry Usain Bolt's executive wholesome alien mask	0		Maximum HP Percent: +10, Meat Drop: +40, Initiative: +80, Last Available: "2017-04"
 9436	steel-toed padded weightlifter's alien spear	0		Muscle: +15, Damage Absorption: +20, Damage Reduction: 9, Last Available: "2017-04"
 9437	Temple Grandin's smartaleck's alien blowgun of bravery	0		Moxie Percent: +30, Familiar Weight: +7, Spooky Resistance: +5, Last Available: "2017-04"
@@ -9318,14 +9318,14 @@
 9446	reassuring curative spant backplate	0		Spooky Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2017-04"
 9447	gravedigger's Socratic spant spear	0		Experience (Mysticality): +1, Spooky Damage: +10, Last Available: "2017-04"
 9448	murderbot power cell	0		Last Available: "2017-04"
-9449	wobbly cyan murderbot component casing	0		Last Available: "2017-04"
+9449	cyan wobbly murderbot component casing	0		Last Available: "2017-04"
 9450	blinking murderbot monofilament	0		Last Available: "2017-04"
 9451	cold-filtered activated murderbot shield unit	0		Effect: "Standard Issue Bravery", Effect Duration: 35, Last Available: "2017-04"
 9452	murderbot live wire	0		Last Available: "2017-04"
 9453	beefy murderbot mask of the empath of temperance	0		Muscle: +10, Familiar Weight: +5, Sleaze Resistance: +5, Avatar: "Murderbot", Last Available: "2017-04"
-9454	quantum teal shaking murderbot spring injector	0		Effect: "Cold Hard Skin", Effect Duration: 58, Last Available: "2017-04"
+9454	quantum shaking teal murderbot spring injector	0		Effect: "Cold Hard Skin", Effect Duration: 58, Last Available: "2017-04"
 9455	narrow avaricious reassuring murderbot whip	0		Spooky Resistance: +1, Meat Drop: +30, Last Available: "2017-04"
-9456	fireproof murderbot plasma rifle of the blizzard	0		Cold Spell Damage: +25, Hot Resistance: +3, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	fireproof murderbot plasma rifle of the blizzard	0		Cold Spell Damage: +25, Hot Resistance: +3, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	bouncing murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	pulsating Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9337,35 +9337,35 @@
 9465	Spacegate	0		Last Available: "2017-04"
 9466	decent Aldebaran sardines	3	good	Last Available: "2017-04"
 9467	high-proof tolerable wobbly Centauri fish wine	8	good	Last Available: "2017-04"
-9468	compressed blinking jittery oxygen	1		Last Available: "2017-04"
+9468	compressed jittery blinking oxygen	1		Last Available: "2017-04"
 9469	upside-down Usain Bolt's veiny Spacegate scientist's insignia	0		Maximum HP: +10, Initiative: +80, Single Equip, Last Available: "2017-04"
 9470	tumbling rosy-cheeked stiffened Spacegate military insignia	0		Damage Reduction: 1, Maximum HP Percent: +30, Single Equip, Last Available: "2017-04"
 9471	chilly hardy Socratic Spacegate diplomat's insignia	0		Experience (Mysticality): +1, Maximum HP: +50, Cold Damage: +5, Single Equip, Last Available: "2017-04"
 9472	skewed Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	massive bland wobbly alien sandwich	10	decent	Last Available: "2017-04"
+9474	bland massive wobbly alien sandwich	10	decent	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
 9476	denatured spinning Spant eggs	0		Effect: "Hypercubed", Effect Duration: 40
 9477	teal Spacegate (open)	0		Lasts Until Rollover
 9478	New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	boiled oxidized denatured Daily Affirmation: Always be Collecting	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 64, Last Available: "2017-05"
-9480	super-denatured quadruple-aerosolized double-frozen lime green skewed Daily Affirmation: Think Win-Lose	0		Effect: "Carrrsmic", Effect Duration: 13, Last Available: "2017-05"
+9480	super-denatured quadruple-aerosolized double-frozen skewed lime green Daily Affirmation: Think Win-Lose	0		Effect: "Carrrsmic", Effect Duration: 13, Last Available: "2017-05"
 9481	boiled Daily Affirmation: Be Superficially interested	0		Effect: "In the Slimelight", Effect Duration: 23, Last Available: "2017-05"
 9482	galvanized Daily Affirmation: Adapt to Change Eventually	0		Effect: "Meatwise", Effect Duration: 48, Last Available: "2017-05"
 9483	quantum Daily Affirmation: Be a Mind Master	0		Effect: "Locks Like the Raven", Effect Duration: 23, Last Available: "2017-05"
 9484	pressed ghostly Daily Affirmation: Work For Hours a Week	0		Effect: "Magically Fingered", Effect Duration: 63, Last Available: "2017-05"
 9485	irradiated Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Executive Greed", Effect Duration: 56, Last Available: "2017-05"
-9486	enchanted gigantic adequate Affirmation Cookie	6	good	Effect: "Video Game Hot Dog", Effect Duration: 40, Last Available: "2017-05"
+9486	gigantic adequate enchanted Affirmation Cookie	6	good	Effect: "Video Game Hot Dog", Effect Duration: 40, Last Available: "2017-05"
 9487	squat License To Kill	0		
 9488	red mirror Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	non-ionized magnetized skewed Threatening Missive	0		Effect: "Chief Executive Optimism", Effect Duration: 17
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	huge vibrating Kremlin's Greatest Briefcase of chilblains of the overflowing toilet	0		Maximum MP Percent: +10, Cold Damage: +25, Stench Spell Damage: +50, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
-9494	watered-down bad lime green wobbly basic martini	2	decent	Last Available: "2017-06"
+9493	huge vibrating Kremlin's Greatest Briefcase of chilblains of the overflowing toilet	0		Maximum MP Percent: +10, Cold Damage: +25, Stench Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9494	bad watered-down wobbly lime green basic martini	2	decent	Last Available: "2017-06"
 9495	mediocre improved martini	3	decent	Last Available: "2017-06"
-9496	acceptable weak splendid martini	2	good	Last Available: "2017-06"
+9496	weak acceptable splendid martini	2	good	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	blinking can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9383,12 +9383,12 @@
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	blurry Meteorite-Ade	0		Last Available: "2017-08"
-9514	immense flavorless meteoreo	10	decent	Last Available: "2017-08"
-9515	tolerable enchanted weak meadeorite	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2017-08"
+9514	flavorless immense meteoreo	10	decent	Last Available: "2017-08"
+9515	enchanted weak tolerable meadeorite	2	good	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2017-08"
 9516	squat meteoroid	0		Last Available: "2017-08"
 9517	ghostly MacGyver's vibrating meteortarboard of Calamity Jane	0		Maximum MP Percent: +10, Maximum MP: +100, Critical Hit Percent: +15, Last Available: "2017-08"
 9518	asbestos-lined stylish meteorite guard of courage	0		Moxie: +25, Hot Resistance: +5, Spooky Resistance: +3, Damage Reduction: 9, Last Available: "2017-08"
-9519	mirror nasty forbidden meteorb	0		Spell Damage Percent: +50, Stench Damage: +5, Lantern Element: "Hot", Last Available: "2017-08"
+9519	mirror nasty forbidden meteorb	0		Spell Damage Percent: +50, Stench Damage: +5, Last Available: "2017-08", Lantern Element: "Hot"
 9520	resourceful sinister asteroid belt	0		Spell Damage: +10, Maximum MP: +50, Single Equip, Last Available: "2017-08"
 9521	maroon Annie Oakley's deadly meteorthopedic shoes of terror	0		Weapon Damage: +5, Critical Hit Percent: +20, Spooky Spell Damage: +10, Single Equip, Last Available: "2017-08"
 9522	twirling greasy shooting morning star of chilblains of the sewer	0		Cold Damage: +25, Stench Damage: +25, Sleaze Spell Damage: +10, Single Equip, Last Available: "2017-08"
@@ -9396,7 +9396,7 @@
 9524	shaking meteor shower cap	0		Familiar Weight: +5
 9525	wobbly Thwaitgold time fly statuette	0		
 9526	red skewed perfectly fair coin	0		Last Available: "2017-11"
-9527	huge blurry Horsery contract	0		Free Pull, Last Available: "2018-08"
+9527	blurry huge Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	jittery corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	genie bottle	0		Last Available: "2017-09"
 9530	Usain Bolt's savvy smooth blessed rustproof +2 gray dragon scale mail	0		Moxie: +15, Mysticality Percent: +20, Initiative: +80, Last Available: "2023-09"
@@ -9419,7 +9419,7 @@
 9547	delicious jittery flask of port	4	awesome	
 9548	razor-sharp contract enforcement stick of the early riser	0		Weapon Damage Percent: +25, Adventures: +7
 9549	tasty blue Hide-rox&trade; cookie	3	awesome	Last Available: "2017-10"
-9550	watered-down tolerable fancy jug of booze	2	good	Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2017-10"
+9550	tolerable watered-down fancy jug of booze	2	good	Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2017-10"
 9551	concentrated electrified pair of candy glasses	0		Effect: "Frostbeard", Effect Duration: 55, Last Available: "2017-10"
 9552	irradiated temporary X tattoos	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 34, Last Available: "2017-10"
 9553	diluted wobbly glyph of athleticism	1		Effect: "Piratastic", Effect Duration: 50, Last Available: "2017-10"
@@ -9448,9 +9448,9 @@
 9576	hardy mafia organizer badge	0		Maximum HP: +50, Single Equip
 9577	gray mafia filofax	0		
 9578	mirror transparent nog	1	awesome	Last Available: "2017-12"
-9579	spoiled small pulsating narrow unfinished fruitcake	2	crappy	Last Available: "2017-12"
+9579	small spoiled pulsating narrow unfinished fruitcake	2	crappy	Last Available: "2017-12"
 9580	liquefied huge shaking and cracker	0		Effect: "substats.enh", Effect Duration: 15, Last Available: "2017-12"
-9581	irresponsibly strong fancy mediocre neg grog	7	decent	Effect: "Wet Jaw", Effect Duration: 15, Last Available: "2017-12"
+9581	fancy irresponsibly strong mediocre neg grog	7	decent	Effect: "Wet Jaw", Effect Duration: 15, Last Available: "2017-12"
 9582	normal half double fruitcake	3	good	Last Available: "2017-12"
 9583	stale small spinning hushed puppy	2	decent	Last Available: "2017-12"
 9584	normal muffled muffuletta	3	good	Last Available: "2017-12"
@@ -9464,10 +9464,10 @@
 9592	green mumming trunk	0		Last Available: "2017-12"
 9593	temperance whiskey	1	super ultra EPIC	Last Available: "2017-11"
 9594	corrupted wishbone	0		Effect: "White Knuckles", Effect Duration: 47, Last Available: "2017-11"
-9595	strong acceptable lime green Racisto Ruidoso	5	good	Last Available: "2017-11"
+9595	acceptable strong lime green Racisto Ruidoso	5	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	yummy super-sized bran muffin	5	awesome	
-9598	gigantic spoiled pulsating gray blueberry muffin	7	crappy	
+9598	spoiled gigantic gray pulsating blueberry muffin	7	crappy	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	silent C	0		Last Available: "2017-12"
@@ -9518,8 +9518,8 @@
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	lime green mime eraser	0		Last Available: "2017-12"
 9648	acceptable irresponsibly strong upside-down executive mime flask	6	good	Last Available: "2017-12"
-9649	super-sized flavorless spinning nega-mushroom	5	decent	Last Available: "2017-12"
-9650	perfectly mixed irresponsibly strong nega-mushroom wine	7	EPIC	Last Available: "2017-12"
+9649	flavorless super-sized spinning nega-mushroom	5	decent	Last Available: "2017-12"
+9650	irresponsibly strong perfectly mixed nega-mushroom wine	7	EPIC	Last Available: "2017-12"
 9651	ionized twirling Cheer-Up soda	0		Effect: "Artificially Sweet", Effect Duration: 15, Last Available: "2017-12"
 9652	normal mime army rations	3	good	Last Available: "2017-12"
 9653	triple-distilled tolerable mime army wine	6	good	Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	huge donated candy	0		
 9665	altered boiled digital honeypot	0		Effect: "Rosewater Mark", Effect Duration: 41, Last Available: "2025-12"
 9666	jittery mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of the blizzard	0		Cold Spell Damage: +25, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	Sinatra's mime army insignia (intelligence)	0		Experience (Moxie): +5, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	scorching mime army insignia (espionage)	0		Hot Damage: +25, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	mime army insignia (infantry) of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	Sinatra's mime army insignia (intelligence)	0		Experience (Moxie): +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	scorching mime army insignia (espionage)	0		Hot Damage: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	cyan mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	wobbly mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9576,7 +9576,7 @@
 9704	mixed excitement pill	1		Effect: "Dance of the Sugar Fairy", Effect Duration: 25
 9705	dried huge vitamin G pill	1		
 9706	twisted ghostly lucky-ish pill	1		
-9707	modified shaking green dieting pill	1		
+9707	modified green shaking dieting pill	1		
 9712	shaking Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
@@ -9593,11 +9593,11 @@
 9725	educational psychic's pslacks of the wise owl	0		Mysticality: +20, Experience: +1, Last Available: "2018-02"
 9726	greedy Oprah's psychic's amulet	0		Maximum MP Percent: +50, Meat Drop: +20, Last Available: "2018-02"
 9727	stale heart-shaped candy whetstone	3	decent	Last Available: "2018-02"
-9728	small rotten red mirror Swedish massage fish	2	crappy	Last Available: "2018-02"
-9729	practically non-alcoholic enchanted hand-crafted Third Base	1	EPIC	Effect: "Innately Wise", Effect Duration: 15, Last Available: "2018-02"
-9730	high-proof hand-crafted Bustle Hustler	7	EPIC	Last Available: "2018-02"
+9728	rotten small red mirror Swedish massage fish	2	crappy	Last Available: "2018-02"
+9729	enchanted hand-crafted practically non-alcoholic Third Base	1	EPIC	Effect: "Innately Wise", Effect Duration: 15, Last Available: "2018-02"
+9730	hand-crafted high-proof Bustle Hustler	7	EPIC	Last Available: "2018-02"
 9731	denatured blurry Fabiotion	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 31, Last Available: "2018-02"
-9732	Vulcanized anodized tumbling cyan Bettie page	0		Effect: "Disco Neuropathy", Effect Duration: 24, Last Available: "2018-02"
+9732	Vulcanized anodized cyan tumbling Bettie page	0		Effect: "Disco Neuropathy", Effect Duration: 24, Last Available: "2018-02"
 9733	magnetized teal tonic o' Banderas	0		Effect: "Crimbo Flavor", Effect Duration: 54, Last Available: "2018-02"
 9734	polymerized heather graham cracker	0		Effect: "Disdain of the War Snapper", Effect Duration: 24, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
@@ -9628,7 +9628,7 @@
 9760	packet of tall grass seeds	0		Last Available: "2018-03"
 9761	Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	shaking Globmule	0		Last Available: "2018-03"
-9763	narrow skewed Bluzzard	0		Last Available: "2018-03"
+9763	skewed narrow Bluzzard	0		Last Available: "2018-03"
 9764	Faux	0		Last Available: "2018-03"
 9765	Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
@@ -9640,7 +9640,7 @@
 9772	fuchsia ghostly Morphan	0		Last Available: "2018-03"
 9773	lime green Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
-9775	huge skewed Turtive	0		Last Available: "2018-03"
+9775	skewed huge Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	Aiolion	0		Last Available: "2018-03"
 9778	Waifuton	0		Last Available: "2018-03"
@@ -9656,7 +9656,7 @@
 9788	Ched	0		Last Available: "2018-03"
 9789	pulsating Gazelleton	0		Last Available: "2018-03"
 9790	Mechamelion	0		Last Available: "2018-03"
-9791	cyan shaking Bicycle	0		Last Available: "2018-03"
+9791	shaking cyan Bicycle	0		Last Available: "2018-03"
 9792	Vamprey	0		Last Available: "2018-03"
 9793	narrow Wullabye	0		Last Available: "2018-03"
 9794	Nursine	0		Last Available: "2018-03"
@@ -9685,12 +9685,12 @@
 9817	blurry twirling Jamocha berry	0		Last Available: "2018-03"
 9818	Tapioc berry	0		Last Available: "2018-03"
 9819	jittery Snarf berry	0		Last Available: "2018-03"
-9820	upside-down squat Keese berry	0		Last Available: "2018-03"
+9820	squat upside-down Keese berry	0		Last Available: "2018-03"
 9821	gray blinking luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	blue shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	teal muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	spinning amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
-9825	mirror cyan razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9825	cyan mirror razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9827	rocket	0		
 9828	pickled magnificent oyster egg	1		
@@ -9722,7 +9722,7 @@
 9854	druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9855	to-go brew	0		Lasts Until Rollover, Last Available: "2018-04"
 9856	flask of holy water	0		Lasts Until Rollover, Last Available: "2018-04"
-9857	activated moist spinning tumbling universal antivenin	0		Lasts Until Rollover, Effect: "Gobliny Flavor", Effect Duration: 31, Last Available: "2018-04"
+9857	activated moist tumbling spinning universal antivenin	0		Lasts Until Rollover, Effect: "Gobliny Flavor", Effect Duration: 31, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	tumbling LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	squat FantasyRealm tattoo kit	0		Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	drinkable two meat muck	3	good	
-9899	flavorless enchanted chocolate Ogre Chieftain	4	decent	Effect: "Transcendental Wind", Effect Duration: 10
+9899	enchanted flavorless chocolate Ogre Chieftain	4	decent	Effect: "Transcendental Wind", Effect Duration: 10
 9900	delicious gigantic chocolate &quot;Phoenix&quot;	8	awesome	
-9901	delicious big chocolate Spider Queen	5	awesome	
-9902	weak drinkable hipster cocktail	2	good	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	gray bouncing God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	narrow God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	ghostly God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9901	big delicious chocolate Spider Queen	5	awesome	
+9902	drinkable weak hipster cocktail	2	good	
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	bouncing gray God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	narrow God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	ghostly God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	wobbly Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	twirling G	0		
 9910	Garland of Greatness	0		
@@ -9784,13 +9784,13 @@
 9916	artisanal gin and ginger	4	EPIC	
 9917	Thwaitgold chigger statuette	0		
 9918	altered skewed blinking gaseous gravy	1		
-9919	blue blurry SongBoom&trade; BoomBox	0		Last Available: "2018-06"
+9919	blurry blue SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	gray A Guide to Safari	0		Skill: "Experience Safari"
 9922	triple-nitrogenated pickled Shielding Potion	0		Effect: "Is This Your Card?", Effect Duration: 68, Last Available: "2018-06"
 9923	activated frozen triple-diffused jittery Punching Potion	0		Effect: "Hopped Up on Goofballs", Effect Duration: 46, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
-9925	boiled blurry wobbly Nightmare Fuel	1		Last Available: "2018-06"
+9925	boiled wobbly blurry Nightmare Fuel	1		Last Available: "2018-06"
 9926	Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	blinking Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	blinking Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
@@ -9800,7 +9800,7 @@
 9932	pressed improved chilled teal sharkfin gumbo	0		Effect: "Marinated", Effect Duration: 14, Last Available: "2018-07"
 9933	super-boiled warmed boiling broth	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 12, Last Available: "2018-07"
 9934	nitrogenated polarized jittery red interrogative elixir	0		Effect: "Flashing Eyes", Effect Duration: 24, Last Available: "2018-07"
-9935	green squat Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
+9935	squat green Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	Bastille Battalion tattoo kit	0		Last Available: "2018-07"
 9937	Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	maroon Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
@@ -9821,7 +9821,7 @@
 9953	adequate snack-sized PB&J with the crusts cut off	2	good	Last Available: "2018-09"
 9954	pulsating Jim Carey's grievous dorky glasses	0		Weapon Damage Percent: +50, Monster Level: +25, Single Equip, Last Available: "2018-09"
 9955	nasty banded ponytail clip	0		Damage Absorption: +100, Stench Damage: +5, Last Available: "2018-09"
-9956	gravedigger's paint palette	0		Spooky Damage: +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	gravedigger's paint palette	0		Spooky Damage: +10, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
 9958	vaporized jittery spinning Purple Beast energy drink	1		Last Available: "2018-09"
 9959	Jack Frost's cosmetic football	0		Cold Spell Damage: +50, Last Available: "2018-09"
@@ -9839,7 +9839,7 @@
 9972	spinning hardy intimidating chainsaw of the blizzard	0		Maximum HP: +50, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-09"
 9973	artisanal party beer bomb	4	EPIC	Last Available: "2018-09"
 9974	moldy bouncing sweet party mix	4	crappy	Last Available: "2018-09"
-9975	boiled yellow spinning party balloon	1		Last Available: "2018-09"
+9975	boiled spinning yellow party balloon	1		Last Available: "2018-09"
 9976	lightning-fast ruddy party pants	0		Maximum HP Percent: +40, Initiative: +40, Last Available: "2018-09"
 9977	quilted Socratic party whip of courage	0		Experience (Mysticality): +1, Damage Absorption: +40, Spooky Resistance: +3, Last Available: "2018-09"
 9978	huge Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	stale blue twirling party platter for one	4	decent	Last Available: "2018-09"
 9981	boiled mirror twirling Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	zippy rosewater-soaked party crasher	0		Stench Resistance: +3, Initiative: +20, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	zippy rosewater-soaked party crasher	0		Stench Resistance: +3, Initiative: +20, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	blinking party mouse hat	0		Familiar Weight: +5
-9987	blue wobbly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	wobbly blue latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	blinking voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	spinning horrifying &quot;I Voted!&quot; sticker	0		Spooky Damage: +25, Lasts Until Rollover, Last Available: "2018-11"
@@ -9882,11 +9882,11 @@
 10016	mediocre twirling eggnog	3	decent	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	low-calorie flavorless Hell ramen	1	decent	Last Available: "2018-11"
-10019	mediocre triple-distilled gimlet	10	decent	Last Available: "2018-11"
+10019	triple-distilled mediocre gimlet	10	decent	Last Available: "2018-11"
 10020	delicious olive twice-haunted screwdriver	3	awesome	Last Available: "2018-11"
 10021	decent candy cane	4	good	Last Available: "2018-12"
-10022	perfectly mixed spirit-forward runny fermented egg	5	EPIC	Last Available: "2018-12"
-10023	miniature spoiled oldcake	2	crappy	Last Available: "2018-12"
+10022	spirit-forward perfectly mixed runny fermented egg	5	EPIC	Last Available: "2018-12"
+10023	spoiled miniature oldcake	2	crappy	Last Available: "2018-12"
 10024	bland enchanted traditional Crimbo cookie	3	decent	Effect: "Crying, Dying", Effect Duration: 35, Last Available: "2023-06"
 10025	extremely unsafe plastic wild beaver	0		Weapon Damage Percent: +100, Last Available: "2018-12"
 10026	plastic reindeer of Gandalf	0		Spell Critical Percent: +20, Last Available: "2018-12"
@@ -9907,9 +9907,9 @@
 10041	balanced antler of Leguizamo	0		Monster Level: +20, Last Available: "2018-12"
 10042	pulsating rosewater-soaked dam	0		Stench Resistance: +3, Damage Reduction: 9, Last Available: "2018-12"
 10043	special aged twirling beavermouth	3	awesome	Effect: "Floundering", Effect Duration: 45, Last Available: "2018-12"
-10044	perfectly mixed enchanted beaver punch (papaya)	3	EPIC	Effect: "Inner Dog", Effect Duration: 25, Last Available: "2018-12"
-10045	fancy acceptable weak beaver punch (peach)	2	good	Effect: "Oxygenated Blood", Effect Duration: 35, Last Available: "2018-12"
-10046	artisanal watered-down beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
+10044	enchanted perfectly mixed beaver punch (papaya)	3	EPIC	Effect: "Inner Dog", Effect Duration: 25, Last Available: "2018-12"
+10045	fancy weak acceptable beaver punch (peach)	2	good	Effect: "Oxygenated Blood", Effect Duration: 35, Last Available: "2018-12"
+10046	watered-down artisanal beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
 10047	toasty sharpshooter's Canadian lantern	0		Critical Hit Percent: +10, Hot Damage: +5, Last Available: "2018-12"
 10048	blinking hardy muskox-skin cap	0		Maximum HP: +50, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
@@ -9919,11 +9919,11 @@
 10053	smartaleck's bauxite beret	0		Moxie Percent: +30, Last Available: "2018-12"
 10054	yellow squat padded bauxite boxers	0		Damage Absorption: +20, Last Available: "2018-12"
 10055	bauxite bow-tie of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2018-12"
-10056	blinking yellow Boxing Day Pass	0		Last Available: "2018-12"
-10057	squat gray Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
+10056	yellow blinking Boxing Day Pass	0		Last Available: "2018-12"
+10057	gray squat Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	twirling clever steel-toed Herculean Rosewater's Kramco Sausage-o-Matic&trade; of the glutton	0		Mysticality Percent: +30, Experience (Muscle): +1, Damage Reduction: 9, Maximum MP: +20, Food Drop: +100, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	huge rotten sausage	7	crappy	Last Available: "2019-01"
+10060	rotten huge sausage	7	crappy	Last Available: "2019-01"
 10061	purple stiffened grievous red-hot sausage fork	0		Weapon Damage Percent: +50, Damage Reduction: 1, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
@@ -9931,7 +9931,7 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	delicious fortified beer	5	awesome	Last Available: "2018-12"
 10067	huge moldy teal yule gruel	9	crappy	Last Available: "2018-12"
-10068	tolerable watered-down hot watered rum	2	good	Last Available: "2018-12"
+10068	watered-down tolerable hot watered rum	2	good	Last Available: "2018-12"
 10069	lousy shaking jittery bottle of Crimbognac	3	decent	Last Available: "2018-12"
 10070	normal Crimboysters Rockefeller	3	good	Last Available: "2018-12"
 10071	altered Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	blue aromatic marble mariachi hat of bravery	0		Spooky Resistance: +5, Stench Resistance: +1, Last Available: "2019-12"
 10096	compressed yellow marble molecules	1		Effect: "Stimulated Body", Effect Duration: 20, Last Available: "2019-12"
 10097	vacuum-sealed narrow Mallomarbles	0		Effect: "Savage Beast Inside", Effect Duration: 61
-10098	skewed rock-hard punching bag of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	bouncing Jack Frost's brainy pith helmet	0		Mysticality: +5, Cold Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	double-paned beefy poncho	0		Muscle: +10, Cold Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	reassuring pendant of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	careful palazzos of the storm	0		Maximum MP Percent: +40, Monster Level: -10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	skewed maroon stylish pseudoaccordion of vim and vigor	0		Moxie: +25, Maximum HP Percent: +50, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	skewed rock-hard punching bag of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	bouncing Jack Frost's brainy pith helmet	0		Mysticality: +5, Cold Spell Damage: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	double-paned beefy poncho	0		Muscle: +10, Cold Resistance: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	reassuring pendant of Tarzan	0		Experience (Muscle): +3, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	careful palazzos of the storm	0		Maximum MP Percent: +40, Monster Level: -10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	skewed maroon stylish pseudoaccordion of vim and vigor	0		Moxie: +25, Maximum HP Percent: +50, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	modified cyan pieces	1		Last Available: "2020-12"
 10105	electrified extra-chilled Para-Pop	0		Effect: "Berry Defensive", Effect Duration: 52
-10106	banded padded terra cotta truss	0		Damage Absorption: 120, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	perfumed terra cotta trousers of bravery	0		Spooky Resistance: +5, Stench Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	blurry hardened smartaleck's terra cotta tongs	0		Moxie Percent: +30, Damage Reduction: 3, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	spinning ghostly nippy shellacked terra cotta train	0		Damage Reduction: 7, Cold Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	up-at-dawn terra cotta tie tack of doom	0		Spooky Spell Damage: +50, Adventures: +5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	scandalous brainy terra cotta tambourine	0		Mysticality: +5, Sleaze Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	banded padded terra cotta truss	0		Damage Absorption: 120, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	perfumed terra cotta trousers of bravery	0		Spooky Resistance: +5, Stench Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	blurry hardened smartaleck's terra cotta tongs	0		Moxie Percent: +30, Damage Reduction: 3, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	spinning ghostly nippy shellacked terra cotta train	0		Damage Reduction: 7, Cold Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	up-at-dawn terra cotta tie tack of doom	0		Spooky Spell Damage: +50, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	scandalous brainy terra cotta tambourine	0		Mysticality: +5, Sleaze Damage: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	vaporized upside-down terra cotta tidbits	1		Last Available: "2020-12"
 10113	aerosolized double-pickled terra panna cotta	0		Effect: "Impregnabili Tea", Effect Duration: 26
 10114	skewed wobbly fireproof Fonzie's velour voulge	0		Experience (Moxie): +1, Hot Resistance: +3, Last Available: "2021-12"
@@ -9991,22 +9991,22 @@
 10125	jittery lime green savvy glass spectacles of chilblains	0		Mysticality Percent: +20, Cold Damage: +25, Single Equip, Last Available: "2021-12"
 10126	beefy glass shiv of bravery	0		Muscle: +10, Spooky Resistance: +5, Last Available: "2021-12"
 10127	Usain Bolt's foul-smelling glass serape	0		Stench Damage: +10, Initiative: +80, Last Available: "2021-12"
-10128	mixed jittery squat glass shards	1		Last Available: "2021-12"
+10128	mixed squat jittery glass shards	1		Last Available: "2021-12"
 10129	warmed pickled green hard candy	0		Effect: "Provocative Perkiness", Effect Duration: 23
-10130	sinister loofah lumberjack's hat of the early riser	0		Spell Damage: +10, Adventures: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	Sinatra's experienced loofah lei	0		Experience: +2, Experience (Moxie): +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	steel-toed Fonzie's loofah lederhosen	0		Experience (Moxie): +1, Damage Reduction: 9, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	blue electrified Rosewater's loofah ladle	0		Mysticality Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	beefcake's loofah legwarmers of the businessman	0		Muscle: +25, Meat Drop: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	stanky loofah lavalier of the ox	0		Muscle: +20, Stench Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	sinister loofah lumberjack's hat of the early riser	0		Spell Damage: +10, Adventures: +7, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	Sinatra's experienced loofah lei	0		Experience: +2, Experience (Moxie): +5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	steel-toed Fonzie's loofah lederhosen	0		Experience (Moxie): +1, Damage Reduction: 9, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	blue electrified Rosewater's loofah ladle	0		Mysticality Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	beefcake's loofah legwarmers of the businessman	0		Muscle: +25, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	stanky loofah lavalier of the ox	0		Muscle: +20, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	vaporized blue loofah lumps	1		Last Available: "2022-12"
 10137	quadruple-concentrated colloidal chocolate-covered loofah	0		Effect: "Bilious Briskness", Effect Duration: 52
-10138	twirling mirror quilted flagstone flag of the pedagogue	0		Experience: +3, Damage Absorption: +40, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	beefcake's flagstone flail of Calamity Jane	0		Muscle: +25, Critical Hit Percent: +15, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	nasty flagstone flip-flops of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	veiny savvy flagstone fez	0		Mysticality Percent: +20, Maximum HP: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	avaricious Sinatra's flagstone fleece	0		Experience (Moxie): +5, Meat Drop: +30, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	foul-smelling sinister flagstone fringe	0		Spell Damage: +10, Stench Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	twirling mirror quilted flagstone flag of the pedagogue	0		Experience: +3, Damage Absorption: +40, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	beefcake's flagstone flail of Calamity Jane	0		Muscle: +25, Critical Hit Percent: +15, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	nasty flagstone flip-flops of vim and vigor	0		Maximum HP Percent: +50, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	veiny savvy flagstone fez	0		Mysticality Percent: +20, Maximum HP: +10, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	avaricious Sinatra's flagstone fleece	0		Experience (Moxie): +5, Meat Drop: +30, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	foul-smelling sinister flagstone fringe	0		Spell Damage: +10, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	twisted flagstone flagments	1		Last Available: "2022-12"
 10145	irradiated ionized narrow Flag by the Foot&trade;	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 33
 10146	maroon elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10016,12 +10016,12 @@
 10150	pickled narrow prototype stimulant	1		Last Available: "2019-12"
 10151	greasy tailored vest	0		Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
-10153	twirling blinking really nice net	0		Last Available: "2019-12"
+10153	blinking twirling really nice net	0		Last Available: "2019-12"
 10154	teal bouncing Herculean elf army poncho	0		Experience (Muscle): +1, Lasts Until Rollover, Last Available: "2019-12"
-10155	rotten big elf army field rations	5	crappy	Last Available: "2019-12"
-10156	ghostly spinning gingernade	0		Last Available: "2019-12"
+10155	big rotten elf army field rations	5	crappy	Last Available: "2019-12"
+10156	spinning ghostly gingernade	0		Last Available: "2019-12"
 10157	lion tamer's rock-hard discarded bowtie	0		Damage Reduction: 5, Experience (familiar): +2, Lasts Until Rollover, Last Available: "2019-12"
-10158	special hand-crafted weak martiny	2	EPIC	Effect: "Wistfully Nostalgic", Effect Duration: 50, Last Available: "2019-12"
+10158	weak hand-crafted special martiny	2	EPIC	Effect: "Wistfully Nostalgic", Effect Duration: 50, Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	vacuum-sealed twirling licorice snake	0		Effect: "Scorpio Rising", Effect Duration: 62
 10161	liquefied virgin jello shot	0		Effect: "Slimily Strong", Effect Duration: 18
@@ -10029,26 +10029,26 @@
 10163	tarnished enhanced tumbling government-issued candy	0		Effect: "La Bamba", Effect Duration: 68
 10164	polarized activated huge Pneumo bar	0		Effect: "Super-Electrified", Effect Duration: 54
 10165	upside-down mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	spinning Tesla thinker's Lil' Doctor&trade; bag	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	spinning Tesla thinker's Lil' Doctor&trade; bag	0		Mysticality: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	ghostly blood bag	0		
 10169	moldy bloodstick	4	crappy	
 10170	lousy jittery bottle of Sanguiovese	4	decent	
 10171	normal snack-sized actual blood sausage	2	good	
-10172	special hand-crafted bouncing mulled blood	3	EPIC	Effect: "Bark of the Dog", Effect Duration: 20
-10173	spoiled bouncing blinking blood snowcone	3	crappy	
+10172	hand-crafted special bouncing mulled blood	3	EPIC	Effect: "Bark of the Dog", Effect Duration: 20
+10173	spoiled blinking bouncing blood snowcone	3	crappy	
 10174	hand-crafted Red Russian	4	EPIC	
 10175	normal blood roll-up	3	good	
-10176	perfectly mixed weak bottle of blood	2	super ultra mega EPIC	
+10176	weak perfectly mixed bottle of blood	2	super ultra mega EPIC	
 10177	flavorless bite-sized blood-soaked sponge cake	1	decent	
 10178	aged vampagne	4	awesome	
 10179	stale fuchsia plain snowcone	3	decent	
 10180	teal Booke of Vampyric Knowledge	0		
-10181	narrow blue upside-down money bag	0		
+10181	upside-down narrow blue money bag	0		
 10182	narrow jittery money bag	0		
 10183	money bag	0		
 10184	Thwaitgold mosquito statuette	0		
 10185	bucket of Vampyre blood	0		
-10186	olive pulsating blood knife	0		Lasts Until Rollover
+10186	pulsating olive blood knife	0		Lasts Until Rollover
 10187	PirateRealm membership packet	0		Free Pull, Last Available: "2019-04"
 10188	PirateRealm guest pass	0		Last Available: "2019-04"
 10189	jittery bouncing family-friendly double-paned sizzling PirateRealm eyepatch	0		Hot Damage: +10, Cold Resistance: +5, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2019-04"
@@ -10063,13 +10063,13 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	moldy crabsicle	4	crappy	Last Available: "2019-04"
 10200	red melty plastic grenade	0		Last Available: "2019-04"
-10201	bad weak bottle of dark rhum	2	decent	Last Available: "2019-04"
+10201	weak bad bottle of dark rhum	2	decent	Last Available: "2019-04"
 10202	delicious high-proof bottle of extra-dark rhum	8	awesome	Last Available: "2019-04"
 10203	acceptable bottle of super-extra-dark rhum	4	good	Last Available: "2019-04"
 10204	Vulcanized frozen pirate shaving cream	0		Effect: "For Your Brain Only", Effect Duration: 41, Last Available: "2019-04"
 10205	spinning jittery Oprah's educational conquistador's breastplate	0		Experience: +1, Maximum MP Percent: +50, Last Available: "2019-04"
 10206	upside-down family-friendly smooth pirate pantaloons	0		Moxie: +15, Sleaze Resistance: +1, Last Available: "2019-04"
-10207	purple narrow [glitch season reward name]	0		
+10207	narrow purple [glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
 10209	windicle	0		Last Available: "2019-04"
 10210	savvy pirate radio ring of mayonnaise	0		Mysticality Percent: +20, Sleaze Spell Damage: +50, Single Equip, Last Available: "2019-04"
@@ -10094,17 +10094,17 @@
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	auspicious piratical blunderbuss of the brazier	0		Hot Spell Damage: +25, Item Drop: +10, Last Available: "2019-04"
 10231	Jeselnik's extremely unsafe PirateRealm party hat of Flo-Jo	0		Weapon Damage Percent: +100, Sleaze Damage: +25, Initiative: +100, Last Available: "2019-04"
-10232	watered-down tolerable Island Landslide	2	good	Last Available: "2019-04"
-10233	watered-down artisanal Island Thunderstorm	2	super EPIC	Last Available: "2019-04"
+10232	tolerable watered-down Island Landslide	2	good	Last Available: "2019-04"
+10233	artisanal watered-down Island Thunderstorm	2	super EPIC	Last Available: "2019-04"
 10234	watered-down tolerable Island Hurricane	2	good	Last Available: "2019-04"
 10235	acceptable olive Skull Punch	4	good	Last Available: "2019-04"
 10236	bad Electric Punch	4	decent	Last Available: "2019-04"
 10237	mediocre Smuggler's Punch	3	decent	Last Available: "2019-04"
-10238	lousy watered-down red pulsating bouncing Scorpion Bowl	2	decent	Last Available: "2019-04"
+10238	watered-down lousy red pulsating bouncing Scorpion Bowl	2	decent	Last Available: "2019-04"
 10239	watered-down acceptable Turtle Bowl	2	good	Last Available: "2019-04"
 10240	practically non-alcoholic aged Cobra Bowl	1	awesome	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	nippy coward's vampyric cloake of the pedagogue of Calamity Jane of the boozehound	0		Experience: +3, Critical Hit Percent: +15, Monster Level: -20, Cold Damage: +10, Booze Drop: +100, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	nippy coward's vampyric cloake of the pedagogue of Calamity Jane of the boozehound	0		Experience: +3, Critical Hit Percent: +15, Monster Level: -20, Cold Damage: +10, Booze Drop: +100, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	blinking plastic pirate hat	0		Familiar Weight: +5
 10244	enhanced nitrogenated one piece of bubble gum	0		Effect: "Crimbo Nostalgia", Effect Duration: 18
 10245	tumbling arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	blown-out speaker cone	0		
 10249	blue overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	skewed careful wholesome rock-hard Fourth of May Cosplay Saber	0		Damage Reduction: 5, Maximum HP Percent: +10, Monster Level: -10, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	skewed careful wholesome rock-hard Fourth of May Cosplay Saber	0		Damage Reduction: 5, Maximum HP Percent: +10, Monster Level: -10, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	huge upside-down Thwaitgold nymph statuette	0		
-10254	blue blinking Sherlock's reassuring lard-coated scorching Tesla hale healthy stiffened hewn moon-rune spoon of Leguizamo of the sweet-tooth of the glutton	0		Damage Reduction: 1, Maximum HP Percent: +20, Maximum HP: +20, Monster Level: +20, Hot Damage: +25, Sleaze Spell Damage: +25, Spooky Resistance: +1, Item Drop: +25, Candy Drop: +100, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
-10255	spinning blurry cartoon harpoon	0		Last Available: "2019-06"
+10254	blue blinking Sherlock's reassuring lard-coated scorching Tesla hale healthy stiffened hewn moon-rune spoon of Leguizamo of the sweet-tooth of the glutton	0		Damage Reduction: 1, Maximum HP Percent: +20, Maximum HP: +20, Monster Level: +20, Hot Damage: +25, Sleaze Spell Damage: +25, Spooky Resistance: +1, Item Drop: +25, Candy Drop: +100, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10255	blurry spinning cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	miser's banded Beach Comb of temperance	0		Damage Absorption: +100, Sleaze Resistance: +5, Meat Drop: +10, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	miser's banded Beach Comb of temperance	0		Damage Absorption: +100, Sleaze Resistance: +5, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	red grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10165,16 +10165,16 @@
 10300	huge therapeutic steel-toed whittled owl figurine of the glutton	0		Damage Reduction: 9, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-08"
 10301	hardy personal trainer's whittled fox figurine of bravery	0		Experience Percent (Muscle): +10, Maximum HP: +50, Spooky Resistance: +5, Single Equip, Last Available: "2019-08"
 10302	scandalous toasty mansplainer's Samson's whittled walking stick	0		Experience (Muscle): +5, Monster Level: +15, Hot Damage: +5, Sleaze Damage: +5, Last Available: "2019-08"
-10303	snack-sized special bland tumbling campfire hot dog	2	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 20, Last Available: "2019-08"
-10304	snack-sized tasty campfire baked potato	2	awesome	Last Available: "2019-08"
+10303	special snack-sized bland tumbling campfire hot dog	2	decent	Effect: "Blessing of Bulbazinalli", Effect Duration: 20, Last Available: "2019-08"
+10304	tasty snack-sized campfire baked potato	2	awesome	Last Available: "2019-08"
 10305	flavorless campfire s'more	3	decent	Last Available: "2019-08"
-10306	flavorless small campfire beans	2	decent	Last Available: "2019-08"
+10306	small flavorless campfire beans	2	decent	Last Available: "2019-08"
 10307	flavorless campfire stew	4	decent	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
 10309	colloidal leftover chocolate bar	0		Effect: "Feet of Grapefruit", Effect Duration: 42
 10310	rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
-10312	blurry cyan squat bundle of firewood	0		Last Available: "2019-08"
+10312	squat blurry cyan bundle of firewood	0		Last Available: "2019-08"
 10313	campfire smoke	0		
 10314	Murgatroyd diode	0		
 10315	signal receiver	0		
@@ -10182,7 +10182,7 @@
 10317	bouncing signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
 10319	twirling Thwaitgold bombardier beetle statuette	0		
-10320	adequate jumbo space chowder	5	good	
+10320	jumbo adequate space chowder	5	good	
 10321	lousy pulsating space wine	3	decent	
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
@@ -10191,11 +10191,11 @@
 10332	Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	narrow mirror electrified hardy rosy-cheeked Eight Days a Week Pill Keeper	0		Maximum HP Percent: +30, Maximum HP: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-10"
 10334	unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
-10335	cyan narrow diabolic pizza cube	0		Last Available: "2019-11"
+10335	narrow cyan diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
-10337	snack-sized bland bu&ntilde;uelos Jaliscos	2	decent	Last Available: "2019-12"
+10337	bland snack-sized bu&ntilde;uelos Jaliscos	2	decent	Last Available: "2019-12"
 10338	snack-sized adequate blurry flan del mar	2	good	Last Available: "2019-12"
-10339	bland small wobbly Baja sopapilla	2	decent	Last Available: "2019-12"
+10339	small bland wobbly Baja sopapilla	2	decent	Last Available: "2019-12"
 10340	twirling plastic Mer-kin baker of the scaredy-cat	0		Monster Level: -15, Last Available: "2019-12"
 10341	manspreader's plastic sea elf	0		Monster Level: +10, Last Available: "2019-12"
 10342	sizzling plastic yuleviathan	0		Hot Damage: +10, Last Available: "2019-12"
@@ -10216,13 +10216,13 @@
 10357	lousy boot flask	3	decent	Last Available: "2019-12"
 10358	ionized maroon infernal snowball	0		Effect: "Stuck That Way", Effect Duration: 58, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	vaporized shaking pulsating twirling fish sauce	1		Last Available: "2019-12"
+10360	vaporized twirling pulsating shaking fish sauce	1		Last Available: "2019-12"
 10361	decent snack-sized guffin	2	good	Last Available: "2019-12"
 10362	vaporized Shantix&trade;	1		Last Available: "2019-12"
 10363	mirror goodberry	0		Last Available: "2019-12"
 10364	denatured cyan non-Euclidean angle	1		Last Available: "2019-12"
 10365	improved denatured warmed upside-down peppermint syrup	0		Effect: "Icy Demeanor", Effect Duration: 59, Last Available: "2019-12"
-10366	diffused pressed bouncing fuchsia Mer-kin eyedrops	0		Effect: "Nuts about Candy", Effect Duration: 53, Last Available: "2019-12"
+10366	diffused pressed fuchsia bouncing Mer-kin eyedrops	0		Effect: "Nuts about Candy", Effect Duration: 53, Last Available: "2019-12"
 10367	quantum super-pickled cold-filtered huge extra-strength goo	0		Effect: "The Power of LOV", Effect Duration: 13, Last Available: "2019-12"
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	pickled gray livid energy	1		Last Available: "2019-12"
@@ -10282,17 +10282,17 @@
 10423	knitted smelly kelp-holly drape	0		Stench Spell Damage: +10, Cold Resistance: +3, Last Available: "2019-12"
 10424	sinister dangerous Staff of the Peppermint Twist of James Dean of the sewer	0		Experience (Moxie): +3, Weapon Damage: +10, Spell Damage: +10, Stench Damage: +25, Last Available: "2019-12"
 10425	moldy huge tempura and bean	6	crappy	Last Available: "2019-12"
-10426	artisanal watered-down bouncing salt plum sake	2	super EPIC	Last Available: "2019-12"
+10426	watered-down artisanal bouncing salt plum sake	2	super EPIC	Last Available: "2019-12"
 10427	triple-improved pressurized potion of possessiveness	0		Effect: "Black Eyes", Effect Duration: 40, Last Available: "2019-12"
 10428	corrupted wobbly almond	0		Effect: "Ponderous Potency", Effect Duration: 44
 10429	cold-filtered handful of mixed nuts	0		Effect: "Polar Express", Effect Duration: 34, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	jittery Temple Grandin's resourceful banded Retrospecs	0		Damage Absorption: +100, Maximum MP: +50, Familiar Weight: +7, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	jittery Temple Grandin's resourceful banded Retrospecs	0		Damage Absorption: +100, Maximum MP: +50, Familiar Weight: +7, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	squat bouncing unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	red Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	huge stanky Lo Pan's sinister wicked Powerful Glove of chilblains	0		Spell Damage: 15, Spell Critical Percent: +30, Cold Damage: +25, Stench Spell Damage: +25, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	huge stanky Lo Pan's sinister wicked Powerful Glove of chilblains	0		Spell Damage: 15, Spell Critical Percent: +30, Cold Damage: +25, Stench Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	blurry Jim Carey's personal trainer's Drip harness of Tarzan	0		Experience (Muscle): +3, Experience Percent (Muscle): +10, Monster Level: +25
@@ -10324,7 +10324,7 @@
 10467	wobbly shaking hale back shell of the detective	0		Maximum HP: +20, Item Drop: +20
 10468	spiky back shell	0		
 10469	power pants	0		Maximum PP: +1
-10470	jittery squat Thwaitgold buzzy beetle statuette	0		
+10470	squat jittery Thwaitgold buzzy beetle statuette	0		
 10471	pulsating Plumber's Union Handbook	0		
 10472	upside-down careful bony back shell	0		Monster Level: -10
 10473	frosty button	0		Single Equip
@@ -10343,9 +10343,9 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	wobbly bouncing immense free-range mushroom	0		Last Available: "2020-03"
 10488	ghostly colossal free-range mushroom	0		Last Available: "2020-03"
-10489	miniature bland shaking mushroom filet	2	decent	Last Available: "2020-03"
+10489	bland miniature shaking mushroom filet	2	decent	Last Available: "2020-03"
 10490	ghostly mushroom slab	0		Last Available: "2020-03"
-10491	vaporized ghostly yellow mushroom tea	1		Last Available: "2020-03"
+10491	vaporized yellow ghostly mushroom tea	1		Last Available: "2020-03"
 10492	mediocre watered-down yellow mushroom whiskey	2	decent	Last Available: "2020-03"
 10493	sharpshooter's rock-hard mushroom cap of vim and vigor	0		Damage Reduction: 5, Maximum HP Percent: +50, Critical Hit Percent: +10, Last Available: "2020-03"
 10494	bouncing wicked Sinatra's mushroom shield of Tarzan of horror	0		Experience (Muscle): +3, Experience (Moxie): +5, Spell Damage: +5, Spooky Spell Damage: +25, Damage Reduction: 6, Last Available: "2020-03"
@@ -10379,7 +10379,7 @@
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
-10525	bad spinning cyan spinning drippy pilsner	3	drippy	
+10525	bad spinning spinning cyan drippy pilsner	3	drippy	
 10526	mirror drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	yellow drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10396,9 +10396,9 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	aged triple-distilled special Ghiaccio Colada	7	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 35, Last Available: "2020-05"
 10542	acceptable practically non-alcoholic Sourfinger	1	good	Last Available: "2020-05"
-10543	delicious watered-down Nog-on-the-Cob	2	awesome	Last Available: "2020-05"
+10543	watered-down delicious Nog-on-the-Cob	2	awesome	Last Available: "2020-05"
 10544	drinkable special weak blinking jittery Steamboat	2	good	Effect: "You Drank Fish Wine", Effect Duration: 15, Last Available: "2020-05"
-10545	drinkable special Buttery Boy	4	good	Effect: "Norwhalloped", Effect Duration: 10, Last Available: "2020-05"
+10545	special drinkable Buttery Boy	4	good	Effect: "Norwhalloped", Effect Duration: 10, Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	miser's dangerous clown car key	0		Weapon Damage: +10, Meat Drop: +10, Last Available: "2020-08"
 10548	blurry careful thinker's batting cage key of the brazier	0		Mysticality: +10, Monster Level: -10, Hot Spell Damage: +25, Last Available: "2020-08"
@@ -10424,7 +10424,7 @@
 10568	lightning-fast deep-fried key of the pedagogue	0		Experience: +3, Item Drop: +5, Initiative: +40, Last Available: "2020-08"
 10569	stanky discarded bike lock key of mayonnaise	0		Stench Spell Damage: +25, Sleaze Spell Damage: +50, Last Available: "2020-08"
 10570	upside-down Thwaitgold keyhole spider statuette	0		
-10571	ghostly twirling Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
+10571	twirling ghostly Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	vacuum-sealed shaking marshroom	0		Effect: "Heart of Orange", Effect Duration: 23
 10573	jittery bag of Iunion stones	0		Free Pull
 10574	tumbling Iunion Crown	0		Last Available: "2020-06"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	teal lightning-fast Jim Carey's birch battery	0		Monster Level: +25, Initiative: +40, Lasts Until Rollover, Last Available: "2020-08"
-10585	groovy ebony epee of the empath of horror	0		Moxie Percent: +10, Familiar Weight: +5, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	pulsating Tesla ruddy razor-sharp weeping willow wand	0		Weapon Damage Percent: +25, Maximum HP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	smelly mansplainer's beechwood blowgun of incineration	0		Monster Level: +15, Hot Spell Damage: +50, Stench Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	groovy ebony epee of the empath of horror	0		Moxie Percent: +10, Familiar Weight: +5, Spooky Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	pulsating Tesla ruddy razor-sharp weeping willow wand	0		Weapon Damage Percent: +25, Maximum HP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	smelly mansplainer's beechwood blowgun of incineration	0		Monster Level: +15, Hot Spell Damage: +50, Stench Spell Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	skewed knitted sharpshooter's maple magnet of the overflowing toilet	0		Critical Hit Percent: +10, Stench Spell Damage: +50, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2020-08"
 10589	twirling Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	blurry scandalous electrified hemlock helm of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2020-08"
@@ -10462,9 +10462,9 @@
 10606	energized Yeg's Motel toothbrush	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 39, Last Available: "2020-09"
 10607	double-unsweetened tumbling Yeg's Motel hand soap	0		Effect: "Superveiny 9000", Effect Duration: 47, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	tasty snack-sized Yeg's Motel pillow mint	2	awesome	Last Available: "2020-09"
+10609	snack-sized tasty Yeg's Motel pillow mint	2	awesome	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	enhanced super-galvanized twirling narrow Yeg's Motel mouthwash	0		Effect: "Fungal Fortification", Effect Duration: 25, Last Available: "2020-09"
+10611	enhanced super-galvanized narrow twirling Yeg's Motel mouthwash	0		Effect: "Fungal Fortification", Effect Duration: 25, Last Available: "2020-09"
 10612	Annie Oakley's vibrating Yeg's Motel shower cap	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Lasts Until Rollover, Last Available: "2020-09"
 10613	Lo Pan's wizardly Yeg's Motel bathrobe	0		Mysticality: +25, Spell Critical Percent: +30, Lasts Until Rollover, Last Available: "2020-09"
 10614	fuchsia lard-coated crafty Yeg's Motel slippers	0		Maximum MP: +10, Sleaze Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	forbidden Samson's Herculean strapping Cargo Cultist Shorts	0		Muscle: +5, Experience (Muscle): 6, Spell Damage Percent: +50, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	high-proof tolerable flask of moonshine	9	good	Last Available: "2020-09"
+10638	tolerable high-proof flask of moonshine	9	good	Last Available: "2020-09"
 10639	Da Vinci's stylish slick sea-worn candlestick	0		Moxie: 35, Experience (Mysticality): +5, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	dry tarnished super-deionized null-day exploit	0		Effect: "Rainbow Bright", Effect Duration: 27, Last Available: "2025-12"
@@ -10525,7 +10525,7 @@
 10669	pulsating plastic Penny of incineration	0		Hot Spell Damage: +50, Last Available: "2020-12"
 10670	blurry overflowing gift basket	0		Last Available: "2020-12"
 10671	red tumbling personalized wassail stein	0		Last Available: "2020-12"
-10672	skewed teal tabletop candy dispenser	0		Last Available: "2020-12"
+10672	teal skewed tabletop candy dispenser	0		Last Available: "2020-12"
 10673	ghostly hale neck wreath	0		Maximum HP: [+20*event(December)], Single Equip, Last Available: "2020-12"
 10674	olive nippy shining star cap	0		Cold Damage: [+10*event(December)], Last Available: "2020-12"
 10675	skewed pulsating Van der Graaf nativity shorts	0		MP Regen Min: [5*event(December)], MP Regen Max: [7*event(December)], Last Available: "2020-12"
@@ -10546,7 +10546,7 @@
 10690	blue Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	blurry food drive button	0		Single Equip, Last Available: "2020-12"
 10692	olive booze drive button	0		Single Equip, Last Available: "2020-12"
-10693	pulsating upside-down candy drive button	0		Single Equip, Last Available: "2020-12"
+10693	upside-down pulsating candy drive button	0		Single Equip, Last Available: "2020-12"
 10694	food mailing list	0		Last Available: "2020-12"
 10695	booze mailing list	0		Last Available: "2020-12"
 10696	candy mailing list	0		Last Available: "2020-12"
@@ -10573,10 +10573,10 @@
 10717	gray blurry fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	blue nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	extra-dry drinkable barrel-aged eggnog	5	good	Last Available: "2020-12"
-10721	enchanted snack-sized spoiled hand-crafted candy cane	2	crappy	Effect: "Gonna Get You, Sucker", Effect Duration: 50, Last Available: "2020-12"
-10722	massive rotten drive-thru burger	7	crappy	Last Available: "2020-12"
-10723	perfectly mixed spirit-forward Boulevardier cocktail	5	EPIC	Last Available: "2020-12"
+10720	drinkable extra-dry barrel-aged eggnog	5	good	Last Available: "2020-12"
+10721	spoiled snack-sized enchanted hand-crafted candy cane	2	crappy	Effect: "Gonna Get You, Sucker", Effect Duration: 50, Last Available: "2020-12"
+10722	rotten massive drive-thru burger	7	crappy	Last Available: "2020-12"
+10723	spirit-forward perfectly mixed Boulevardier cocktail	5	EPIC	Last Available: "2020-12"
 10724	vacuum-sealed ghostly Hotwire&trade; brand candy rope	0		Effect: "Antsy in your Pantsy", Effect Duration: 54, Last Available: "2020-12"
 10725	rotten bowl full of jelly	3	crappy	Last Available: "2020-12"
 10726	mediocre jittery Eye and a Twist	3	decent	Last Available: "2020-12"
@@ -10596,23 +10596,23 @@
 10740	warmed electrified battery (AA)	0		Effect: "Sweet, Nuts", Effect Duration: 43, Last Available: "2021-03"
 10741	improved battery (D)	0		Effect: "Dweeby", Effect Duration: 61, Last Available: "2021-03"
 10742	quantum super-altered boiled battery (9-Volt)	0		Effect: "Initiative and Let Die", Effect Duration: 64, Last Available: "2021-03"
-10743	liquefied narrow huge battery (lantern)	0		Effect: "Cheered Up", Effect Duration: 47, Last Available: "2021-03"
+10743	liquefied huge narrow battery (lantern)	0		Effect: "Cheered Up", Effect Duration: 47, Last Available: "2021-03"
 10744	quadruple-alkaline battery (car)	0		Effect: "Amorphous Cheer", Effect Duration: 63, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	hand-crafted irresponsibly strong blurry marshmallow bomb	6	EPIC	Last Available: "2021-03"
+10747	irresponsibly strong hand-crafted blurry marshmallow bomb	6	EPIC	Last Available: "2021-03"
 10748	mirror packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	corrupted short beer	0		Effect: "Thaumodynamic", Effect Duration: 29, Last Available: "2021-05"
 10753	magnetized ghostly short stack of pancakes	0		Effect: "Super-Electrified", Effect Duration: 50, Last Available: "2021-05"
 10754	liquefied short stick of butter	0		Effect: "Frozen Hands", Effect Duration: 23, Last Available: "2021-05"
 10755	vacuum-sealed short glass of water	0		Effect: "Carrion' On", Effect Duration: 20, Last Available: "2021-05"
-10756	pressed modified narrow jittery short	0		Effect: "Gutterminded", Effect Duration: 43, Last Available: "2021-05"
+10756	pressed modified jittery narrow short	0		Effect: "Gutterminded", Effect Duration: 43, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	ghostly mansplainer's familiar scrapbook of the boozehound	0		Monster Level: +15, Booze Drop: +100, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	ghostly mansplainer's familiar scrapbook of the boozehound	0		Monster Level: +15, Booze Drop: +100, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	cyan clan underground fireworks shop	0		Last Available: "2021-07"
 10762	fuchsia hardy extremely unsafe Socratic fedora-mounted fountain	0		Experience (Mysticality): +1, Weapon Damage Percent: +100, Maximum HP: +50, Lasts Until Rollover, Last Available: "2021-07"
@@ -10630,7 +10630,7 @@
 10774	galvanized upside-down Scent of a Human&trade; candle	0		Effect: "Superioreo", Effect Duration: 67, Last Available: "2021-08"
 10775	Vulcanized quadruple-energized The Beast Within&trade; candle	0		Effect: "Slimily Strong", Effect Duration: 50, Last Available: "2021-08"
 10776	colloidal Salsa Caliente&trade; candle	0		Effect: "Mad at Science", Effect Duration: 58, Last Available: "2021-08"
-10777	warmed ghostly mirror Smoldering Clover&trade; candle	0		Effect: "Lemon Enlightenment", Effect Duration: 30, Last Available: "2021-08"
+10777	warmed mirror ghostly Smoldering Clover&trade; candle	0		Effect: "Lemon Enlightenment", Effect Duration: 30, Last Available: "2021-08"
 10778	irradiated dry Napalm In The Morning&trade; candle	0		Effect: "Bloody-minded", Effect Duration: 17, Last Available: "2021-08"
 10779	mirror lime green sharpshooter's stiffened extra-large utility candle	0		Damage Reduction: 1, Critical Hit Percent: +10, Lasts Until Rollover, Last Available: "2021-08"
 10780	careful runed taper candle of the ox	0		Muscle: +20, Monster Level: -10, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	shaking rainproof barrel caulk	0		
 10795	pulsating pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	squat Oprah's energetic steel-toed experienced groovy Rosewater's industrial fire extinguisher	0		Mysticality Percent: +30, Moxie Percent: +10, Experience: +2, Damage Reduction: 9, Maximum MP Percent: 70, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	squat Oprah's energetic steel-toed experienced groovy Rosewater's industrial fire extinguisher	0		Mysticality Percent: +30, Moxie Percent: +10, Experience: +2, Damage Reduction: 9, Maximum MP Percent: 70, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10659,7 +10659,7 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	Lo Pan's rock-hard Daylight Shavings Helmet of vim and vigor	0		Damage Reduction: 5, Maximum HP Percent: +50, Spell Critical Percent: +30, Last Available: "2021-11"
 10805	mirror eggwater	1	decent	Last Available: "2021-12"
-10806	super-sized adequate purple bread man	5	good	Last Available: "2021-12"
+10806	adequate super-sized purple bread man	5	good	Last Available: "2021-12"
 10807	tasty spinning plain candy cane	4	awesome	Last Available: "2021-12"
 10808	spoiled flour cookie	3	crappy	Last Available: "2021-12"
 10809	quilted plastic food lab	0		Damage Absorption: +40, Single Equip, Last Available: "2021-12"
@@ -10673,17 +10673,17 @@
 10817	teal Van der Graaf baleful jeans of Flo-Jo	0		Spell Damage: +25, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2021-12"
 10818	flame-retardant ice wrap of temperance of the early riser	0		Hot Resistance: +1, Sleaze Resistance: +5, Adventures: +7, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	moldy huge olive tofu pop	7	crappy	Last Available: "2021-12"
-10820	snack-sized moldy bowl of prescription candy	2	crappy	Last Available: "2021-12"
+10820	moldy snack-sized bowl of prescription candy	2	crappy	Last Available: "2021-12"
 10821	flavorless half-sized fishcake	2	decent	Last Available: "2021-12"
 10822	snack-sized spoiled bone broth	2	crappy	Last Available: "2021-12"
 10823	huge adequate star pop	8	good	Last Available: "2021-12"
 10824	lousy weak Doc's Fortifying Wine	2	decent	Last Available: "2021-12"
-10825	perfectly mixed skewed maroon Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
-10826	watered-down lousy jittery Doc's Limbering Wine	2	decent	Last Available: "2021-12"
+10825	perfectly mixed maroon skewed Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
+10826	lousy watered-down jittery Doc's Limbering Wine	2	decent	Last Available: "2021-12"
 10827	triple-distilled smooth twirling Doc's Medical-Grade Wine	10	awesome	Last Available: "2021-12"
 10828	pickled Homebodyl&trade;	1		Effect: "Big Flaming Whip", Effect Duration: 15, Last Available: "2021-12"
 10829	distilled Extrovermectin&trade;	1		Last Available: "2021-12"
-10830	powdered mirror twirling Breathitin&trade;	1		Last Available: "2021-12"
+10830	powdered twirling mirror Breathitin&trade;	1		Last Available: "2021-12"
 10831	twisted twirling Fleshazole&trade;	1		Last Available: "2021-12"
 10832	polymerized enhanced pressed maroon anti-burn cream	0		Effect: "Pumped Stomach", Effect Duration: 12, Last Available: "2021-12"
 10833	colloidal improved maroon anti-freeze cream	0		Effect: "The Wisdom... of the Future", Effect Duration: 24, Last Available: "2021-12"
@@ -10694,10 +10694,10 @@
 10838	tolerable twirling Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
 10839	moldy diet bread pie	1	crappy	Last Available: "2021-12"
 10840	perfectly mixed clear Russian	3	EPIC	Last Available: "2021-12"
-10841	ghostly spinning zero-trust tanktop	0		Last Available: "2025-12"
+10841	spinning ghostly zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
-10844	spinning purple gooified animal matter	0		Last Available: "2021-12"
+10844	purple spinning gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	cyan gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
@@ -10715,7 +10715,7 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	depleted Crimbonium football helmet of chilblains	0		Cold Damage: +25, Last Available: "2021-12"
 10861	squat synthetic rock	0		Last Available: "2021-12"
-10862	low-calorie adequate &quot;caramel&quot;	1	good	Last Available: "2021-12"
+10862	adequate low-calorie &quot;caramel&quot;	1	good	Last Available: "2021-12"
 10863	pulsating huge healthy self-repairing earmuffs	0		Maximum HP Percent: +20, Last Available: "2021-12"
 10864	twirling greasy carnivorous potted plant	0		Sleaze Spell Damage: +10, Last Available: "2021-12"
 10865	cyan universal biscuit	0		Last Available: "2021-12"
@@ -10728,18 +10728,18 @@
 10872	teal squat wholesome pants	0		Maximum HP Percent: +10, Last Available: "2021-12"
 10873	MacGyver's brawny can of mixed everything of the ox	0		Muscle: +20, Muscle Percent: +20, Maximum MP: +100, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
-10875	tumbling blurry the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	delicious big meatball	5	awesome	Last Available: "2021-12"
+10875	blurry tumbling the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
+10876	big delicious meatball	5	awesome	Last Available: "2021-12"
 10877	skewed cloned monster	0		Last Available: "2021-12"
 10878	blinking meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	altered huge fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
-10882	narrow lime green carton of astral energy drinks	0		
+10882	lime green narrow carton of astral energy drinks	0		
 10883	boiled astral energy drink	1		Effect: "Man's Worst Enemy", Effect Duration: 50
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	executive gravedigger's Sinatra's magnifying glass	0		Experience (Moxie): +5, Spooky Damage: +10, Meat Drop: +40, Last Available: "2022-12"
-10886	lousy enchanted void lager	4	decent	Effect: "Orc Chops", Effect Duration: 45, Last Available: "2022-12"
+10886	enchanted lousy void lager	4	decent	Effect: "Orc Chops", Effect Duration: 45, Last Available: "2022-12"
 10887	spoiled spinning void burger	4	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	huge olive greedy wizardly void shard of the bloodbag of the cheetah	0		Mysticality: +25, Maximum HP: +100, Meat Drop: +20, Initiative: +60, Last Available: "2022-12"
@@ -10767,22 +10767,22 @@
 10911	adjusted electrified blurry gaffer's tape	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 62, Last Available: "2022-05"
 10912	yummy huge 20-lb can of rice and beans	3	awesome	Last Available: "2022-05"
 10913	blinking bar of freeze-dried water	1	EPIC	Last Available: "2022-05"
-10914	flavorless jumbo expired MRE	5	decent	Last Available: "2022-05"
+10914	jumbo flavorless expired MRE	5	decent	Last Available: "2022-05"
 10915	tiny stale cool mint precipice bar	1	decent	Last Available: "2022-05"
 10916	yummy carrot cake precipice bar	4	awesome	Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
-10918	ghostly wobbly Thwaitgold harvestman statuette	0		
+10918	wobbly ghostly Thwaitgold harvestman statuette	0		
 10919	gray packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	electrified strapping June cleaver of bravery	0		Muscle: +5, Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5, Attacks Can't Miss, Last Available: "2022-06"
 10921	lousy jittery Dad's brandy	4	decent	Last Available: "2022-06"
 10922	blinking nippy forbidden teacher's pen	0		Spell Damage Percent: +50, Cold Damage: +10, Last Available: "2022-06"
-10923	spoiled half-sized spinning narrow yellow fire-roasted lake trout	2	crappy	Last Available: "2022-06"
-10924	enchanted yummy twirling guilty sprout	4	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 50, Last Available: "2022-06"
+10923	spoiled half-sized spinning yellow narrow fire-roasted lake trout	2	crappy	Last Available: "2022-06"
+10924	yummy enchanted twirling guilty sprout	4	awesome	Effect: "Human-Elf Hybrid", Effect Duration: 50, Last Available: "2022-06"
 10925	blinking knitted energetic mother's necklace	0		Maximum MP Percent: +20, Cold Resistance: +3, Last Available: "2022-06"
 10926	ionized ghostly trampled ticket stub	0		Effect: "Spiky Frozen Hair", Effect Duration: 20, Last Available: "2022-06"
 10927	frozen activated polarized savings bond	0		Effect: "Comic Violence", Effect Duration: 58, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	distilled blurry sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10805,17 +10805,17 @@
 10949	dinosaur of Tarzan	0		Experience (Muscle): +3
 10950	upside-down Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	yellow blinking asbestos-lined Jurassic Parka of James Dean	0		Experience (Moxie): +3, Hot Resistance: +5, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	yellow blinking asbestos-lined Jurassic Parka of James Dean	0		Experience (Moxie): +3, Hot Resistance: +5, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	blurry boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	skewed autumn-aton	0		Last Available: "2022-10"
 10955	ionized polymerized autumn leaf	0		Effect: "Saucefingers", Effect Duration: 59, Last Available: "2022-10"
-10956	weak perfectly mixed AutumnFest ale	2	EPIC	Last Available: "2022-10"
+10956	perfectly mixed weak AutumnFest ale	2	EPIC	Last Available: "2022-10"
 10957	blurry ribald strapping autumn sweater-weather sweater of bravery	0		Muscle: +5, Sleaze Damage: +10, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2022-10"
 10958	blinking red coward's razor-sharp autumn debris shield of dire peril of horror	0		Weapon Damage: +20, Weapon Damage Percent: +25, Monster Level: -20, Spooky Spell Damage: +25, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
 10959	stale bite-sized autumn-spice donut	1	decent	Last Available: "2022-10"
 10960	quadruple-dry ionized cold-filtered autumn dollar	0		Effect: "Inner Warmth", Effect Duration: 30, Last Available: "2022-10"
 10961	resourceful autumn leaf pendant of the bloodbag of the storm	0		Maximum HP: +100, Maximum MP Percent: +40, Maximum MP: +50, Lasts Until Rollover, Last Available: "2022-10"
-10962	modified ghostly green autumn breeze	1		Last Available: "2022-10"
+10962	modified green ghostly autumn breeze	1		Last Available: "2022-10"
 10963	non-adjusted cold-filtered enhanced tumbling autumn years wisdom	0		Effect: "Flexibili Tea", Effect Duration: 68, Last Available: "2022-10"
 10964	yellow familiar-in-the-middle wrapper	0		Last Available: "2025-12"
 10965	bad Oopsie IPA	4	decent	Last Available: "2022-10"
@@ -10823,62 +10823,62 @@
 10967	tumbling Yeast of Boris	0		Last Available: "2022-11"
 10968	shaking St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	blue Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	moldy diet shaking ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
+10970	diet moldy shaking ratatouille de Jarlsberg	1	crappy	Last Available: "2022-11"
 10971	yummy half-sized huge Jarlsberg's vegetable soup	2	awesome	Last Available: "2022-11"
 10972	flavorless roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
 10973	miniature normal yellow St. Pete's sneaky smoothie	2	good	Last Available: "2022-11"
 10974	decent Pete's wiley whey bar	4	good	Last Available: "2022-11"
 10975	tasty Pete's rich ricotta	3	awesome	Last Available: "2022-11"
 10976	enchanted hand-crafted bouncing Boris's beer	3	EPIC	Effect: "Lit Up", Effect Duration: 5, Last Available: "2022-11"
-10977	snack-sized adequate honey bun of Boris	2	good	Last Available: "2022-11"
+10977	adequate snack-sized honey bun of Boris	2	good	Last Available: "2022-11"
 10978	adequate special Boris's bread	4	good	Effect: "Twen Tea", Effect Duration: 35, Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	narrow Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	pulsating Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	shaking Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	narrow Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	pulsating Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	shaking Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	snack-sized normal baked veggie ricotta casserole	2	good	Last Available: "2022-11"
 10989	toothsome immense enchanted plain calzone	7	awesome	Effect: "Concentration", Effect Duration: 45, Last Available: "2022-11"
 10990	stale roasted vegetable focaccia	3	decent	Last Available: "2022-11"
 10991	adequate low-calorie blinking Pizza of Legend	1	good	Last Available: "2022-11"
 10992	toothsome Calzone of Legend	4	awesome	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	cyan Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	spinning Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	shaking fuchsia blinking Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	cyan Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	spinning Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	blinking fuchsia shaking Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	jittery cookbookbat book	0		Familiar Weight: +5
-10999	tumbling Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	tasty enchanted Deep Dish of Legend	3	awesome	Effect: "Gamer Rage", Effect Duration: 35, Last Available: "2022-11"
+10999	tumbling Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	enchanted tasty Deep Dish of Legend	3	awesome	Effect: "Gamer Rage", Effect Duration: 35, Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
 11004	narrow twirling Jim Carey's prohie's hat	0		Monster Level: +25
-11005	extra-ionized flattened blinking ghostly imported taffy	0		Effect: "Blood-Gorged", Effect Duration: 66
+11005	extra-ionized flattened ghostly blinking imported taffy	0		Effect: "Blood-Gorged", Effect Duration: 66
 11006	stanky educational Charleston shoes	0		Experience: +1, Stench Spell Damage: +25, Single Equip
 11007	olive booze bindle	0		
 11008	pulsating extremely unsafe brawny rare oboe	0		Muscle Percent: +20, Weapon Damage Percent: +100
 11009	skewed steel-toed bullet necklace of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 9, Single Equip
-11010	toothsome big yellow swamp haunch	5	awesome	
+11010	big toothsome yellow swamp haunch	5	awesome	
 11011	Temple Grandin's arcane researcher's gator shades	0		Experience Percent (Mysticality): +10, Familiar Weight: +7, Single Equip
 11012	milk cap	0		
 11013	acceptable practically non-alcoholic mirror Charleston Choo-Choo	1	good	
 11014	artisanal Velvet Veil	3	EPIC	
 11015	acceptable Marltini	3	good	
-11016	irresponsibly strong lousy tumbling Strong, Silent Type	8	decent	
+11016	lousy irresponsibly strong tumbling Strong, Silent Type	8	decent	
 11017	perfectly mixed Mysterious Stranger	4	EPIC	
 11018	weak lousy Champagne Shimmy	2	decent	
 11019	upside-down the Sot's parcel	0		
-11020	rosy-cheeked ceramic cestus of vim and vigor	0		Maximum HP Percent: 80, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	family-friendly dog trainer's resourceful ceramic centurion shield	0		Maximum MP: +50, Experience (familiar): +1, Sleaze Resistance: +1, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	ceramic celery grater of Gandalf of the empath	0		Spell Critical Percent: +20, Familiar Weight: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	friendly savvy ceramic celsiturometer of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Familiar Weight: +3, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	upside-down scorching frosty ceramic cerecloth belt of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Hot Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	nippy fortified strapping ceramic cenobite's robe	0		Muscle: +5, Damage Absorption: +60, Cold Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	rosy-cheeked ceramic cestus of vim and vigor	0		Maximum HP Percent: 80, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	family-friendly dog trainer's resourceful ceramic centurion shield	0		Maximum MP: +50, Experience (familiar): +1, Sleaze Resistance: +1, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	ceramic celery grater of Gandalf of the empath	0		Spell Critical Percent: +20, Familiar Weight: +5, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	friendly savvy ceramic celsiturometer of the storm	0		Mysticality Percent: +20, Maximum MP Percent: +40, Familiar Weight: +3, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	upside-down scorching frosty ceramic cerecloth belt of the brute	0		Muscle Percent: +30, Cold Spell Damage: +10, Hot Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	nippy fortified strapping ceramic cenobite's robe	0		Muscle: +5, Damage Absorption: +60, Cold Damage: +10, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	dried maroon jittery ceramic scree	1		Last Available: "2023-12"
 11027	anodized activated extra-hard jawbreaker	0		Effect: "Hair on Your Chest", Effect Duration: 55
 11028	censurious thinker's chiffon chevrons of the early riser	0		Mysticality: +10, Sleaze Resistance: +3, Adventures: +7, Single Equip, Last Available: "2023-12"
@@ -10930,15 +10930,15 @@
 11074	automatic wine thief	0		Single Equip
 11075	gray table-scraper	0		Single Equip
 11076	Trainbot slag	0		
-11077	tumbling blinking industrially-crushed ice	0		Last Available: "2022-12"
+11077	blinking tumbling industrially-crushed ice	0		Last Available: "2022-12"
 11078	rotten spinning steamed oyster	3	crappy	
 11079	really nice lump of coal	0		
 11080	skewed deactivated mini-Trainbot	0		Last Available: "2022-12"
 11081	steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	spinning crystal Crimbo platter	0		
-11084	aged triple-distilled blinking bouncing Crimbosmopolitan	6	awesome	Last Available: "2022-12"
-11085	rotten low-calorie Crimbo dinner	1	crappy	Last Available: "2022-12"
+11084	triple-distilled aged bouncing blinking Crimbosmopolitan	6	awesome	Last Available: "2022-12"
+11085	low-calorie rotten Crimbo dinner	1	crappy	Last Available: "2022-12"
 11086	olive squat overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10964,24 +10964,24 @@
 11108	pulsating hard rock	0		Last Available: "2023-01"
 11109	shaking stalagmite	0		Last Available: "2023-01"
 11110	mirror chocolate covered ping-pong ball	0		
-11112	adequate small pixel bread	2	good	
-11113	lousy strong pixel whiskey	5	decent	
+11112	small adequate pixel bread	2	good	
+11113	strong lousy pixel whiskey	5	decent	
 11114	pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	Vulcanized skewed glob of extra-green chlorophyll	0		Effect: "New Zeal", Effect Duration: 47, Last Available: "2023-02"
 11118	flattened double-vacuum-sealed bouncing mushroom	0		Effect: "Serendipi Tea", Effect Duration: 13, Last Available: "2023-02"
 11119	anodized ghostly fuchsia five-fingered fern resin	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 24, Last Available: "2023-02"
-11120	super-sized moldy super good fruit	5	crappy	Last Available: "2023-02"
+11120	moldy super-sized super good fruit	5	crappy	Last Available: "2023-02"
 11121	vaporized energized spores	1		Last Available: "2023-02"
-11122	zippy dog trainer's hot pepper	0		Experience (familiar): +1, Initiative: +20, Lantern Element: "Hot", Last Available: "2023-02"
+11122	zippy dog trainer's hot pepper	0		Experience (familiar): +1, Initiative: +20, Last Available: "2023-02", Lantern Element: "Hot"
 11123	activated olive bouncing out-of-work circus flea	0		Effect: "Mint-Condition Breath", Effect Duration: 28, Last Available: "2023-02"
 11124	jittery extra-grubby grub	0		Last Available: "2023-02"
 11125	ionized boiled mirror fire ant pheromones	0		Effect: "Marco Polarity", Effect Duration: 60, Last Available: "2023-02"
 11126	pressed activated flapper fly	0		Effect: "Yet tea", Effect Duration: 34, Last Available: "2023-02"
 11127	bad shot of wasp venom	4	decent	Last Available: "2023-02"
 11128	electrified ionized jittery squat filled mosquito	0		Effect: "Berry Statistical", Effect Duration: 19, Last Available: "2023-02"
-11129	adjusted anodized ghostly mirror shim of shame shale	0		Effect: "Ruthlessly Efficient", Effect Duration: 37, Last Available: "2023-02"
+11129	adjusted anodized mirror ghostly shim of shame shale	0		Effect: "Ruthlessly Efficient", Effect Duration: 37, Last Available: "2023-02"
 11130	super-unsweetened pebble of proud pyrite	0		Effect: "Filled with Magic", Effect Duration: 66, Last Available: "2023-02"
 11131	electrified liquefied huge pile of gritty sand	0		Effect: "Human-Undead Hybrid", Effect Duration: 31, Last Available: "2023-02"
 11132	olive hollow rock	0		Last Available: "2023-02"
@@ -10991,8 +10991,8 @@
 11136	twirling shaking Tesla energetic shadow skin	0		Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-03"
 11137	magnetized colloidal shadow flame	0		Effect: "Oh Snap", Effect Duration: 61, Last Available: "2023-03"
 11138	normal narrow shadow bread	4	good	Last Available: "2023-03"
-11139	pulsating upside-down shadow ice	0		Last Available: "2023-03"
-11140	bad practically non-alcoholic jittery shadow fluid	1	decent	Last Available: "2023-03"
+11139	upside-down pulsating shadow ice	0		Last Available: "2023-03"
+11140	practically non-alcoholic bad jittery shadow fluid	1	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11027,7 +11027,7 @@
 11172	ghostly shadow snowflake	0		
 11173	shadow heart	0		
 11174	shadow bucket	0		
-11175	shaking yellow shadow wave	0		
+11175	yellow shaking shadow wave	0		
 11176	Rufus's shadow lodestone	0		
 11177	chaotic groovy weightlifter's shadow chef's hat	0		Muscle: +15, Moxie Percent: +10, Spell Critical Percent: +10
 11178	family-friendly energetic rosy-cheeked shadow trousers	0		Maximum HP Percent: +30, Maximum MP Percent: +20, Sleaze Resistance: +1
@@ -11038,7 +11038,7 @@
 11183	weak hand-crafted shadow martini	2	EPIC	
 11184	mixed upside-down shadow pill	1		Effect: "Blessing of Squirtlcthulli", Effect Duration: 50
 11185	blinking shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	galvanized wobbly spinning shadow candy	0		Effect: "Mistified", Effect Duration: 69
 11189	replica Mr. Accessory	0		
@@ -11074,8 +11074,8 @@
 11219	twirling replica Smith's Tome	0		
 11220	pulsating replica over-the-shoulder Folder Holder	0		
 11221	spinning replica Order of the Green Thumb Order Form	0		
-11222	narrow ghostly shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	jittery MacGyver's hardy occult brawny Cincho de Mayo	0		Muscle Percent: +20, Spell Damage Percent: +25, Maximum HP: +50, Maximum MP: +100, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11222	ghostly narrow shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
+11223	jittery MacGyver's hardy occult brawny Cincho de Mayo	0		Muscle Percent: +20, Spell Damage Percent: +25, Maximum HP: +50, Maximum MP: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	skewed dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	blinking up-at-dawn family-friendly replica Jurassic Parka	0		Sleaze Resistance: +1, Adventures: +5
 11250	tumbling replica grey gosling	0		
-11251	upside-down shaking replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	upside-down shaking replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	blinking replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	cyan huge replica Ten Dollars	0		
 11254	nippy Oprah's brawny replica Cincho de Mayo of Flo-Jo	0		Muscle Percent: +20, Maximum MP Percent: +50, Cold Damage: +10, Initiative: +100, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	up-at-dawn Sherlock's fireproof careful medical-grade Herculean &quot;I survived Y2K&quot; T-Shirt	0		Experience (Muscle): +1, Monster Level: -10, Hot Resistance: +3, Item Drop: +25, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2023-06"
 11259	upside-down Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	scorching brawny pro skateboard	0		Muscle Percent: +20, Hot Damage: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	scorching brawny pro skateboard	0		Muscle Percent: +20, Hot Damage: +25, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	skewed Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	pulsating Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	Sherlock's Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	Sherlock's Flash Liquidizer Ultra Dousing Accessory	0		Item Drop: +25, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	miser's energetic hale Amulet of Perpetual Darkness of Leguizamo	0		Maximum HP: +20, Maximum MP Percent: +20, Monster Level: +20, Meat Drop: +10, Last Available: "2023-06"
 11268	fuchsia Giant monolith	0		Last Available: "2023-06"
 11269	ghostly Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11134,10 +11134,10 @@
 11279	gray Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	hand-crafted triple-distilled cyan Sexy Cosmo	9	EPIC	Last Available: "2023-06"
+11282	triple-distilled hand-crafted cyan Sexy Cosmo	9	EPIC	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	deadly smooth red-soled high heels	0		Moxie: +15, Weapon Damage: +5, Item Drop: +5, Last Available: "2023-06"
-11285	special decent tiny cyburger	1	good	Effect: "Hella Smooth", Effect Duration: 45, Last Available: "2025-12"
+11285	special tiny decent cyburger	1	good	Effect: "Hella Smooth", Effect Duration: 45, Last Available: "2025-12"
 11286	Da Vinci's ncle leg	0		Experience (Mysticality): +5
 11287	Sinatra's educational rutabuga bag	0		Experience: +1, Experience (Moxie): +5
 11288	shaking mesquito proboscis of the early riser	0		Adventures: +7
@@ -11168,11 +11168,11 @@
 11313	mirror mirror blue cat o' nine teeth of the bloodbag of the scaredy-cat	0		Maximum HP: +100, Monster Level: -15
 11314	narrow skewed tooth cap of the cougar of the brazier	0		Moxie: +20, Hot Spell Damage: +25
 11315	padded savvy toothy trousers	0		Mysticality Percent: +20, Damage Absorption: +20
-11316	special moldy banana split	3	crappy	Effect: "Sludgesick", Effect Duration: 20
+11316	moldy special banana split	3	crappy	Effect: "Sludgesick", Effect Duration: 20
 11317	handful of toilet paper	0		
 11318	Mrs. Rush	0		
 11319	tumbling medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	artisanal fortified enchanted shaking mirror bottle of Cabernet Sauvignon	5	EPIC	Effect: "Mayeaugh", Effect Duration: 15
+11320	enchanted fortified artisanal mirror shaking bottle of Cabernet Sauvignon	5	EPIC	Effect: "Mayeaugh", Effect Duration: 15
 11321	wobbly auspicious energetic Newton's baywatch	0		Experience (Mysticality): +3, Maximum MP Percent: +20, Item Drop: +10, Lasts Until Rollover
 11322	upside-down Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
@@ -11180,10 +11180,10 @@
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	pulsating Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	diluted narrow spinning twirling concentrated cooking	1		
+11328	diluted narrow twirling spinning concentrated cooking	1		
 11329	denatured squat meat	1		Effect: "Super-Mega-Charged", Effect Duration: 15
 11330	boiled maroon narrow sparkling orb	1		
-11331	vaporized lime green bouncing hardening cream	1		Effect: "Sweet and Red", Effect Duration: 45
+11331	vaporized bouncing lime green hardening cream	1		Effect: "Sweet and Red", Effect Duration: 45
 11332	dehydrated squat red pool shark hair oil	1		Effect: "Phorcefullness", Effect Duration: 50
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
@@ -11196,7 +11196,7 @@
 11341	inflammable leaf	0		
 11342	upside-down rake	0		Item Drop: +1
 11343	wobbly smooth rake	0		Moxie: +15
-11344	red narrow autumnic bomb	0		
+11344	narrow red autumnic bomb	0		
 11345	forest canopy bed	0		
 11346	day shortener	0		
 11347	olive extra time	0		
@@ -11230,8 +11230,8 @@
 11375	spinning Boltsmann ID badge	0		
 11376	teal housekeeping automa-core	0		
 11377	housekeeping robot	0		
-11378	adequate gigantic pickled bread	7	good	Last Available: "2023-12"
-11379	immense normal pulsating upside-down salted mutton	7	good	Last Available: "2023-12"
+11378	gigantic adequate pickled bread	7	good	Last Available: "2023-12"
+11379	immense normal upside-down pulsating salted mutton	7	good	Last Available: "2023-12"
 11380	moldy corned beet	4	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	huge spoiled enchanted peppermint donut	9	crappy	Effect: "Mushroom Samba", Effect Duration: 10
+11395	enchanted spoiled huge peppermint donut	9	crappy	Effect: "Mushroom Samba", Effect Duration: 10
 11396	twirling auspicious Elf Guard insignia (private)	0		Item Drop: +10, Last Available: "2023-12"
 11397	huge blue Tesla Crimbuccaneer fledges (mint)	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
 11398	huge military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11258,7 +11258,7 @@
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	huge sharpshooter's rosy-cheeked Crimbuccaneer lantern of the cougar	0		Moxie: +20, Maximum HP Percent: +30, Critical Hit Percent: +10, Last Available: "2023-12"
 11405	Crimbuccaneer flotsam	0		Last Available: "2023-12"
-11406	squat narrow purple Crimbuccaneer invasion map	0		Last Available: "2023-12"
+11406	purple narrow squat Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	censurious Crimbuccaneer shirt	0		Sleaze Resistance: [+3*event(December)], Last Available: "2023-12"
 11408	red Elf Guard MPC	0		Last Available: "2023-12"
 11409	huge Crimbuccaneer piece of 12	0		Last Available: "2023-12"
@@ -11268,7 +11268,7 @@
 11413	blinking Elf Guard honor present	0		Last Available: "2023-12"
 11414	Oprah's Elf Guard officer's sidearm of temperance	0		Maximum MP Percent: +50, Sleaze Resistance: +5, Last Available: "2023-12"
 11415	squat experienced Elf Guard insignia (general) of the cougar	0		Moxie: +20, Experience: +2, Single Equip, Last Available: "2023-12"
-11416	drinkable ghostly skewed Crimbow Rainbo	3	good	Last Available: "2023-12"
+11416	drinkable skewed ghostly Crimbow Rainbo	3	good	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	wool Jack Frost's Elf Guard broom	0		Cold Spell Damage: +50, Cold Resistance: +1, Last Available: "2023-12"
@@ -11279,13 +11279,13 @@
 11424	perfumed dance instructor's sawed-off blunderbuss of chilblains	0		Experience Percent (Moxie): +10, Cold Damage: +25, Stench Resistance: +5, Last Available: "2023-12"
 11425	smooth wobbly officer's nog	3	awesome	Last Available: "2023-12"
 11426	pulsating peppermint bomb	0		Last Available: "2023-12"
-11427	flavorless half-sized skewed sundae ration	2	decent	Last Available: "2023-12"
-11428	bland half-sized peppermint tack	2	decent	Last Available: "2023-12"
+11427	half-sized flavorless skewed sundae ration	2	decent	Last Available: "2023-12"
+11428	half-sized bland peppermint tack	2	decent	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	adequate small whalesteak	2	good	Last Available: "2023-12"
 11431	upside-down crafty shellacked experienced whalegun	0		Experience: +2, Damage Reduction: 7, Maximum MP: +10, Last Available: "2023-12"
 11432	Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
-11433	fuchsia tumbling Elf Guard payroll bag	0		Last Available: "2023-12"
+11433	tumbling fuchsia Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	blurry lightning-fast greasy boxer's Elf Guard clipboard	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Initiative: +40, Last Available: "2023-12"
 11435	smooth pegfinger	0		Moxie: +15, Single Equip, Last Available: "2023-12"
 11436	lousy and claret	4	decent	Last Available: "2023-12"
@@ -11307,14 +11307,14 @@
 11452	upside-down aromatic horrifying dog trainer's chaotic stiffened Elf dessert spoon of the early riser	0		Damage Reduction: 1, Spell Critical Percent: +10, Experience (familiar): +1, Spooky Damage: +25, Stench Resistance: +1, Adventures: +7, Last Available: "2023-12"
 11453	censurious toasty Elf Guard SCUBA tank	0		Hot Damage: +5, Sleaze Resistance: +3, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	asbestos-lined hale free boots	0		Maximum HP: +20, Hot Resistance: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	asbestos-lined hale free boots	0		Maximum HP: +20, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	beefcake's strapping Elvish underarmor of Tarzan	0		Muscle: 30, Experience (Muscle): +3, Single Equip, Last Available: "2023-12"
 11458	lion tamer's razor-sharp Crimbuccaneer bombjacket	0		Weapon Damage Percent: +25, Experience (familiar): +2, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	bland small sugarplum ration	2	decent	Last Available: "2023-12"
+11459	small bland sugarplum ration	2	decent	Last Available: "2023-12"
 11460	rotten half-sized gingerbread nylons	2	crappy	Last Available: "2023-12"
 11461	rotten rum-soaked fruitcake	4	crappy	Last Available: "2023-12"
-11462	special spoiled lime	4	crappy	Effect: "The Sweats", Effect Duration: 50, Last Available: "2023-12"
+11462	spoiled special lime	4	crappy	Effect: "The Sweats", Effect Duration: 50, Last Available: "2023-12"
 11463	toothsome tiny upside-down gingerbread pirate	1	awesome	Last Available: "2023-12"
 11464	flavorless fruit-stuffed rumcake	3	decent	Last Available: "2023-12"
 11465	special drinkable squat mulled wine	3	good	Effect: "Cringle's Curative Carol", Effect Duration: 5, Last Available: "2023-12"
@@ -11322,18 +11322,18 @@
 11467	tolerable triple-distilled canteen of eggnog	7	good	Last Available: "2023-12"
 11468	hand-crafted squat hot wine	3	EPIC	Last Available: "2023-12"
 11469	watered-down lousy pulsating Jamaican coffee	2	decent	Last Available: "2023-12"
-11470	practically non-alcoholic hand-crafted flask of egggrog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
+11470	hand-crafted practically non-alcoholic flask of egggrog	1	super ultra mega turbo EPIC	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	upside-down pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	lousy high-proof maroon yule grog	6	decent	Last Available: "2023-12"
 11475	adequate wet tack	4	good	Last Available: "2023-12"
 11476	stale big whalecake	5	decent	Last Available: "2023-12"
-11477	wool stylish gunwale whalegun of the cougar	0		Moxie: 45, Cold Resistance: +1, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	hand-crafted distilled special and claret	5	EPIC	Effect: "Whippin' It Good", Effect Duration: 5, Last Available: "2023-12"
+11477	wool stylish gunwale whalegun of the cougar	0		Moxie: 45, Cold Resistance: +1, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11478	distilled special hand-crafted and claret	5	EPIC	Effect: "Whippin' It Good", Effect Duration: 5, Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	rosewater-soaked energetic Elf Guard squirtgun	0		Maximum MP Percent: +20, Stench Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	rosewater-soaked energetic Elf Guard squirtgun	0		Maximum MP Percent: +20, Stench Resistance: +3, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	upside-down chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	sequin-encrusted sweater of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2023-12"
 11484	avaricious toasty electrified replica Elf Guard medal	0		Hot Damage: +5, Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
@@ -11346,7 +11346,7 @@
 11491	sharpshooter's quilted Crimbuccaneer nose ring of horror	0		Damage Absorption: +40, Critical Hit Percent: +10, Spooky Spell Damage: +25, Last Available: "2023-12"
 11492	pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
-11494	olive twirling Elf Guard safety bear	0		Last Available: "2023-12"
+11494	twirling olive Elf Guard safety bear	0		Last Available: "2023-12"
 11495	lime green kraken	0		Last Available: "2023-12"
 11496	precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11356,14 +11356,14 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	boiled pickled military candy cane	0		Effect: "Dancing Prowess", Effect Duration: 42
 11503	corrupted groggipop	0		Effect: "Pockets of Fire", Effect Duration: 33
-11504	squat Temple Grandin's steel-toed moss mace	0		Damage Reduction: 9, Familiar Weight: +7, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	maroon wobbly jittery wicked moss megaphone of Leguizamo	0		Spell Damage: +5, Monster Level: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	Da Vinci's moss medal	0		Experience (Mysticality): +5, Item Drop: +5, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	reassuring wool moss mitre	0		Cold Resistance: +1, Spooky Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	skewed thinker's moss mantle of the early riser	0		Mysticality: +10, Adventures: +7, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	squat Temple Grandin's steel-toed moss mace	0		Damage Reduction: 9, Familiar Weight: +7, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	maroon wobbly jittery wicked moss megaphone of Leguizamo	0		Spell Damage: +5, Monster Level: +20, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	Da Vinci's moss medal	0		Experience (Mysticality): +5, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	reassuring wool moss mitre	0		Cold Resistance: +1, Spooky Resistance: +1, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	skewed thinker's moss mantle of the early riser	0		Mysticality: +10, Adventures: +7, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	upside-down studded moss marlinspike of the overflowing toilet	0		Damage Absorption: +80, Stench Spell Damage: +50, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	pickled moss mulch	1		Last Available: "2024-12"
-11511	electrified corrupted frozen wobbly bouncing wobbly yellow moss floss	0		Effect: "Radium Radicality", Effect Duration: 17
+11511	electrified corrupted frozen yellow wobbly bouncing wobbly moss floss	0		Effect: "Radium Radicality", Effect Duration: 17
 11512	teal adobe arsecover	0		Last Available: "2024-12"
 11513	upside-down adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	adobe abacus	0		Last Available: "2024-12"
@@ -11372,33 +11372,33 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	altered green adobe assortment	1		Last Available: "2024-12"
 11519	wet quadruple-corrupted nitrogenated twirling adobe brittle	0		Effect: "Hella Smooth", Effect Duration: 32
-11520	tumbling prompt crepe paper phrygian cap of the ox of the glutton	0		Muscle: +20, Food Drop: +100, Adventures: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	tumbling prompt crepe paper phrygian cap of the ox of the glutton	0		Muscle: +20, Food Drop: +100, Adventures: +3, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	rosewater-soaked energetic arcane researcher's crepe paper parachute cape	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, Stench Resistance: +3, Last Available: "2025-12"
-11522	squat Oprah's therapeutic hardened crepe paper pie clip	0		Damage Reduction: 3, Maximum MP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	toasty coward's crepe paper puzzle cube of mayonnaise	0		Monster Level: -20, Hot Damage: +5, Sleaze Spell Damage: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	miser's brawny beefcake's crepe paper plunge camisole	0		Muscle: +25, Muscle Percent: +20, Meat Drop: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	mirror greedy greasy educational crepe paper polka charm	0		Experience: +1, Sleaze Spell Damage: +10, Meat Drop: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	squat Oprah's therapeutic hardened crepe paper pie clip	0		Damage Reduction: 3, Maximum MP Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	toasty coward's crepe paper puzzle cube of mayonnaise	0		Monster Level: -20, Hot Damage: +5, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	miser's brawny beefcake's crepe paper plunge camisole	0		Muscle: +25, Muscle Percent: +20, Meat Drop: +10, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	mirror greedy greasy educational crepe paper polka charm	0		Experience: +1, Sleaze Spell Damage: +10, Meat Drop: +20, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	compressed crepe paper pared cuttings	1		Effect: "Pisces Rising", Effect Duration: 40, Last Available: "2025-12"
 11527	galvanized super-pickled crepe paper peanut candy	0		Effect: "OMG WTF", Effect Duration: 32
 11528	ghostly rosewater-soaked extremely unsafe petrified wood war pike	0		Weapon Damage Percent: +100, Stench Resistance: +3, Last Available: "2025-12"
 11529	petrified wood waist protector of Tarzan of doom	0		Experience (Muscle): +3, Spooky Spell Damage: +50, Single Equip, Last Available: "2025-12"
-11530	auspicious petrified wood wizard's pouch of chilblains	0		Cold Damage: +25, Item Drop: +10, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	smelly experienced petrified wood water purifier	0		Experience: +2, Stench Spell Damage: +10, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	auspicious petrified wood wizard's pouch of chilblains	0		Cold Damage: +25, Item Drop: +10, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	smelly experienced petrified wood water purifier	0		Experience: +2, Stench Spell Damage: +10, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	perfumed toasty petrified wood whoopie panama	0		Hot Damage: +5, Stench Resistance: +5, Last Available: "2025-12"
 11533	asbestos-lined supercharged petrified wood walking pants	0		Maximum MP Percent: +30, Hot Resistance: +5, Last Available: "2025-12"
 11534	compressed petrified wood waste parts	1		Effect: "Crimbo Epiphany", Effect Duration: 40, Last Available: "2025-12"
 11535	altered adjusted petrified wood wafer praline	0		Effect: "Crimbo Epiphany", Effect Duration: 35
 11536	lousy cybeer	4	decent	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	pulsating googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	forbidden Crimbuccaneer war standard of the boozehound	0		Spell Damage Percent: +50, Booze Drop: +100, Last Available: "2023-12"
 11544	asbestos-lined chaotic Elf Guard war standard	0		Spell Critical Percent: +10, Hot Resistance: +5, Last Available: "2023-12"
 11545	shaking in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	stiffened grievous smartaleck's spring shoes	0		Moxie Percent: +30, Weapon Damage Percent: +50, Damage Reduction: 1, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	stiffened grievous smartaleck's spring shoes	0		Moxie Percent: +30, Weapon Damage Percent: +50, Damage Reduction: 1, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	quantum tumbling ultra-soft ferns	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 66, Last Available: "2024-02"
 11548	deionized polymerized anodized maroon crunchy brush	0		Effect: "Slimed Stomach", Effect Duration: 67, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11461,7 +11461,7 @@
 11606	green perfumed mini kiwi icepick	0		Stench Resistance: +5
 11607	dry twirling mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Can Has Cyborger", Effect Duration: 12
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	skewed protogenetic chunklet (muscle)	0		
 11612	spinning protogenetic chunklet (flagellum)	0		
@@ -11470,14 +11470,14 @@
 11615	narrow double-paned sharpshooter's messenger bag RNA of the ox	0		Muscle: +20, Critical Hit Percent: +10, Cold Resistance: +5
 11616	twirling flagellate flagon	0		
 11617	blurry proto-proto-protozoa	0		
-11618	tiny rotten shaking bacteria bisque	1	crappy	
+11618	rotten tiny shaking bacteria bisque	1	crappy	
 11619	fancy big adequate ciliophora chowder	5	good	Effect: "You Can Taste the Darkness", Effect Duration: 5
 11620	flavorless cream of chloroplasts	3	decent	
 11621	synaptic soup	0		
 11622	skewed muscular soup	0		
 11623	ghostly flagellate soup	0		
 11624	elbow soup	0		
-11625	spinning green lip soup	0		
+11625	green spinning lip soup	0		
 11626	unevolved organism	0		Free Pull
 11627	blinking extra ooze	0		
 11628	yellow narrow extra DNA	0		Experience (familiar): +1
@@ -11487,7 +11487,7 @@
 11632	Doll Moll violin case	0		
 11633	narrow Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
-11635	fancy practically non-alcoholic hand-crafted gray Colera Peste Nebbiolo	1	super ultra EPIC	Effect: "Melancholy Burden", Effect Duration: 10
+11635	fancy hand-crafted practically non-alcoholic gray Colera Peste Nebbiolo	1	super ultra EPIC	Effect: "Melancholy Burden", Effect Duration: 10
 11636	longbox of Batfellow comics	0		
 11637	teal Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
@@ -11510,7 +11510,7 @@
 11655	wobbly soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	blurry boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	smartaleck's bat wings of the empath of the glutton	0		Moxie Percent: +30, Familiar Weight: +5, Food Drop: +100, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	smartaleck's bat wings of the empath of the glutton	0		Moxie Percent: +30, Familiar Weight: +5, Food Drop: +100, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	upside-down spinning ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	inspector's crafty monocle on a stick	0		Maximum MP: +10, Item Drop: +15, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	dog trainer's Sheriff badge of wisdom	0		Mysticality: +15, Experience (familiar): +1, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	blinking lard-coated Sinatra's Sheriff pistol	0		Experience (Moxie): +5, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-10"
 11670	Sheriff moustache of wisdom of the blizzard	0		Mysticality: +15, Cold Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	Usain Bolt's personal trainer's photo booth supply list	0		Experience Percent (Muscle): +10, Initiative: +80, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	Usain Bolt's personal trainer's photo booth supply list	0		Experience Percent (Muscle): +10, Initiative: +80, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	spoiled whirled peas	4	crappy	Last Available: "2024-11"
@@ -11535,13 +11535,13 @@
 11680	quantum watch	0		Adventures: +2
 11681	pulsating quantized familiar experience	0		
 11682	quadruple-oxidized magnetized deionized pea brittle	0		Effect: "Spiky Frozen Hair", Effect Duration: 31, Last Available: "2024-11"
-11683	fortified aged skewed peasco	5	awesome	Last Available: "2024-11"
+11683	aged fortified skewed peasco	5	awesome	Last Available: "2024-11"
 11684	miniature moldy piece of cake	2	crappy	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	arcane researcher's deft pirate hook of the brazier	0		Experience Percent (Mysticality): +10, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-12"
-11689	frightening Sinatra's iron tricorn hat	0		Experience (Moxie): +5, Spooky Damage: +5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	frightening Sinatra's iron tricorn hat	0		Experience (Moxie): +5, Spooky Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	jolly roger flag of dire peril	0		Weapon Damage: +20, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	ghostly pirrrate's currrse	0		Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	rosewater-soaked rock-hard Rosewater's potato jacket	0		Mysticality Percent: +30, Damage Reduction: 5, Stench Resistance: +3, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	lard-coated mansplainer's military orb	0		Monster Level: +15, Sleaze Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	lard-coated mansplainer's military orb	0		Monster Level: +15, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	denatured double-modified rum ball	0		Effect: "Three Days Slow", Effect Duration: 18
 11733	gravy skin	0		Last Available: "2024-12"
 11734	scandalous Temple Grandin's gravyskin hat	0		Familiar Weight: +7, Sleaze Damage: +5, Last Available: "2024-12"
@@ -11595,11 +11595,11 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	coward's careful baleful perfect Christmas scarf	0		Spell Damage: [+25*event(December)], Monster Level: [-30*event(December)], Single Equip, Last Available: "2024-12"
-11743	sizzling snowman-enchanting tophat of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	sizzling snowman-enchanting tophat of Calamity Jane	0		Critical Hit Percent: +15, Hot Damage: +10, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	frozen quantum shaking LIDAR candle	0		Effect: "Preemptive Medicine", Effect Duration: 52, Last Available: "2024-12"
 11745	stiffened Congressional Medal of Insanity of dire peril of terror	0		Weapon Damage: +20, Damage Reduction: 1, Spooky Spell Damage: +10, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	watered-down drinkable narrow red Easter grasshopper	2	good	Last Available: "2024-12"
+11747	drinkable watered-down red narrow Easter grasshopper	2	good	Last Available: "2024-12"
 11748	perfectly mixed Irish eggnog	3	EPIC	Last Available: "2024-12"
 11749	perfectly mixed fancy green canteen of jungle juice	3	EPIC	Effect: "Holiday Disappointment", Effect Duration: 35, Last Available: "2024-12"
 11750	artisanal turchucken	4	EPIC	Last Available: "2024-12"
@@ -11609,7 +11609,7 @@
 11754	decent beef and cabbage	4	good	Last Available: "2024-12"
 11755	immense adequate green candy rations	7	good	Last Available: "2024-12"
 11756	yummy double-candied yams	3	awesome	Last Available: "2024-12"
-11757	normal special snack-sized Christmas ham	2	good	Effect: "Shawarma Warm War", Effect Duration: 10, Last Available: "2024-12"
+11757	snack-sized normal special Christmas ham	2	good	Effect: "Shawarma Warm War", Effect Duration: 10, Last Available: "2024-12"
 11758	moldy holiday smorgasbord	3	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	electrified bejazzled eyepatch	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2024-12"
@@ -11624,7 +11624,7 @@
 11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	huge up-at-dawn inspector's ribald savvy egg gun	0		Mysticality Percent: +20, Sleaze Damage: +10, Item Drop: +15, Adventures: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	huge up-at-dawn inspector's ribald savvy egg gun	0		Mysticality Percent: +20, Sleaze Damage: +10, Item Drop: +15, Adventures: +5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	chaotic steel-toed forbidden army helmet of mayonnaise	0		Spell Damage Percent: +50, Damage Reduction: 9, Spell Critical Percent: +10, Sleaze Spell Damage: +50, Last Available: "2024-12"
 11774	jittery candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
@@ -11632,18 +11632,18 @@
 11777	hand-crafted Easter eggnog	4	super EPIC	Last Available: "2024-12"
 11778	altered clovermint	1		Last Available: "2024-12"
 11779	chaotic ruddy Socratic wizardly nylon Christmas stockings	0		Mysticality: +25, Experience (Mysticality): +1, Maximum HP Percent: +40, Spell Critical Percent: +10, Single Equip, Last Available: "2024-12"
-11780	ghostly jittery tattoo of two turkeys	0		Last Available: "2024-12"
-11781	altered flattened teal twirling deviled candy egg	0		Effect: "Cold, Dead Hands", Effect Duration: 58, Last Available: "2024-12"
+11780	jittery ghostly tattoo of two turkeys	0		Last Available: "2024-12"
+11781	altered flattened twirling teal deviled candy egg	0		Effect: "Cold, Dead Hands", Effect Duration: 58, Last Available: "2024-12"
 11782	lime green McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	spinning ghostly toasty supercool McHugeLarge duffel bag	0		Moxie Percent: +20, Hot Damage: +5, Last Available: "2025-01"
-11784	ghostly dangerous McHugeLarge left pole of Calamity Jane of incineration	0		Weapon Damage: +10, Critical Hit Percent: +15, Hot Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	skewed rosy-cheeked weightlifter's McHugeLarge right pole of dire peril	0		Muscle: +15, Weapon Damage: +20, Maximum HP Percent: +30, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	McHugeLarge left ski of the blizzard of the businessman	0		Cold Spell Damage: +25, Meat Drop: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	huge tumbling cyan up-at-dawn wholesome McHugeLarge right ski	0		Maximum HP Percent: +10, Adventures: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	ghostly dangerous McHugeLarge left pole of Calamity Jane of incineration	0		Weapon Damage: +10, Critical Hit Percent: +15, Hot Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	skewed rosy-cheeked weightlifter's McHugeLarge right pole of dire peril	0		Muscle: +15, Weapon Damage: +20, Maximum HP Percent: +30, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	McHugeLarge left ski of the blizzard of the businessman	0		Cold Spell Damage: +25, Meat Drop: +50, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	huge tumbling cyan up-at-dawn wholesome McHugeLarge right ski	0		Maximum HP Percent: +10, Adventures: +5, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	twisted blue eXpand	1		Last Available: "2025-12"
-11791	twirling blinking brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	twirling blinking brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	skewed dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	bouncing retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	gray malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	gray malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11669,7 +11669,7 @@
 11814	skewed dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	maroon dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	lime green dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
-11817	jittery shaking dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
+11817	shaking jittery dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
 11818	purple twirling dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	narrow dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	bouncing insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	gray geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	gray geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	maroon ninja rope	0		
@@ -11692,7 +11692,7 @@
 11837	toy Cupid bow	0		Experience (familiar): +2, Last Available: "2025-02"
 11838	heat arc	0		
 11839	mirror scrape	0		
-11840	tumbling huge gray phantom digit	0		
+11840	tumbling gray huge phantom digit	0		
 11841	foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
@@ -11713,10 +11713,10 @@
 11858	glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
-11861	fuchsia squat Leprecondo	0		Last Available: "2025-03"
+11861	squat fuchsia Leprecondo	0		Last Available: "2025-03"
 11862	modified scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
-11864	acceptable fortified narrow pint of Leprechaun Stout	5	good	Last Available: "2025-03"
+11864	fortified acceptable narrow pint of Leprechaun Stout	5	good	Last Available: "2025-03"
 11865	modified blue phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	upside-down Book of Irony	0		Skill: "Generate Irony"
@@ -11726,12 +11726,12 @@
 11871	diluted leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	normal mirror Heck ramen	3	good	Last Available: "2025-03"
 11873	tiny adequate special burrito	1	good	Effect: "Human-Penguin Hybrid", Effect Duration: 40, Last Available: "2025-03"
-11874	delicious enchanted miniature small beer brat	2	awesome	Effect: "Heart of Pink", Effect Duration: 25, Last Available: "2025-03"
+11874	miniature enchanted delicious small beer brat	2	awesome	Effect: "Heart of Pink", Effect Duration: 25, Last Available: "2025-03"
 11875	rotten jittery peach pie	4	crappy	Last Available: "2025-03"
-11876	rotten miniature incredible mini-pizza	2	crappy	Last Available: "2025-03"
-11877	special acceptable spinning Divine sidecar	3	good	Effect: "Carrion' On", Effect Duration: 30, Last Available: "2025-03"
+11876	miniature rotten incredible mini-pizza	2	crappy	Last Available: "2025-03"
+11877	acceptable special spinning Divine sidecar	3	good	Effect: "Carrion' On", Effect Duration: 30, Last Available: "2025-03"
 11878	watered-down tolerable squat tangarita sidecar	2	good	Last Available: "2025-03"
-11879	perfectly mixed practically non-alcoholic shaking gimlet sidecar	1	EPIC	Last Available: "2025-03"
+11879	practically non-alcoholic perfectly mixed shaking gimlet sidecar	1	EPIC	Last Available: "2025-03"
 11880	practically non-alcoholic delicious vodka stratocaster sidecar	1	awesome	Last Available: "2025-03"
 11881	bad prussian cathouse sidecar	3	decent	Last Available: "2025-03"
 11882	watered-down lousy Mon Tiki sidecar	2	decent	Last Available: "2025-03"
@@ -11740,8 +11740,8 @@
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	twirling spitball	0		Last Available: "2025-04"
 11887	moist wet paper weights	0		Effect: "Transcendental Wind", Effect Duration: 51, Last Available: "2025-04"
-11888	triple-distilled tolerable Three Sheets to the Wind	9	good	Last Available: "2025-04"
-11889	adequate snack-sized green pile of wet dates	2	good	Last Available: "2025-04"
+11888	tolerable triple-distilled Three Sheets to the Wind	9	good	Last Available: "2025-04"
+11889	snack-sized adequate green pile of wet dates	2	good	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	cyan wet shower cap of the cheetah	0		Initiative: +60, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	dog trainer's stylish bycocket	0		Experience (familiar): +1
 11917	wobbly Thwaitgold mad hatterpillar statuette	0		
 11918	lime green pulsating packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	flak shield	0		Damage Reduction: 9
 11921	squat Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11806,7 +11806,7 @@
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	modified mixed berry jelly	1		Last Available: "2025-08"
 11953	normal toast with mixed berry jelly	3	good	Last Available: "2025-08"
-11954	small bland cup of sugar	2	decent	Last Available: "2025-08"
+11954	bland small cup of sugar	2	decent	Last Available: "2025-08"
 11955	normal Susie's cupcake	3	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	lightning-fast friendly the gun of the storm	0		Maximum MP Percent: +40, Familiar Weight: +3, Initiative: +40, Last Available: "2025-08"
@@ -11816,7 +11816,7 @@
 11962	olive careful undersea surveying goggles	0		Monster Level: -10, Lasts Until Rollover
 11963	artisanal Ocean-Touched Rum	4	EPIC	
 11964	dehydrated water-logged pill	1		
-11965	bite-sized rotten kelp puck	1	crappy	
+11965	rotten bite-sized kelp puck	1	crappy	
 11966	squat twirling scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
@@ -11826,24 +11826,24 @@
 11972	jittery durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	ghostly packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	yellow pulsating unblemished pearl	0		
 11977	jittery friendly dentadent	0		Familiar Weight: +3
-11986	bouncing ghostly lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	medical-grade stiffened personal trainer's Rosewater's blood cubic zirconia of the storm of the sweet-tooth	0		Mysticality Percent: +30, Experience Percent (Muscle): +10, Damage Reduction: 1, Maximum MP Percent: +40, Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11986	ghostly bouncing lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
+11987	medical-grade stiffened personal trainer's Rosewater's blood cubic zirconia of the storm of the sweet-tooth	0		Mysticality Percent: +30, Experience Percent (Muscle): +10, Damage Reduction: 1, Maximum MP Percent: +40, Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	vaporized skewed blood thinner	1		Last Available: "2025-10"
 12045	bad twirling pheromone cocktail	4	decent	Last Available: "2025-10"
 12046	toothsome small spinal tapas	2	awesome	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	bouncing shaking crafty experienced shrunken head of the businessman	0		Experience: +2, Maximum MP: +10, Meat Drop: +50, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	bouncing shaking crafty experienced shrunken head of the businessman	0		Experience: +2, Maximum MP: +10, Meat Drop: +50, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	wobbly knucklebone	0		
 12052	extra-dry lousy wobbly Smoking Pope	5	decent	
 12053	stale half-sized prize turkey	2	decent	
 12054	modified medicinal gruel	1		
-12055	spoiled miniature full-sized pumpkin pie	2	crappy	Last Available: "2025-11"
-12056	tolerable irresponsibly strong bouncing vodka cranberry sauce	6	good	Last Available: "2025-11"
+12055	miniature spoiled full-sized pumpkin pie	2	crappy	Last Available: "2025-11"
+12056	irresponsibly strong tolerable bouncing vodka cranberry sauce	6	good	Last Available: "2025-11"
 12057	quantum maroon yammed candy	0		Effect: "The Smeezingtons", Effect Duration: 21, Last Available: "2025-11"
 12058	flavorless miniature treasure chestnut	2	decent	Last Available: "2025-12"
 12059	lousy skewed mulled butter rum	3	decent	Last Available: "2025-12"
@@ -11870,11 +11870,11 @@
 12080	double-paned beefcake's devilbone flute	0		Muscle: +25, Cold Resistance: +5, Last Available: "2026-12"
 12081	deadly devilbone rosary	0		Weapon Damage: +5, Single Equip, Last Available: "2026-12"
 12082	dried skewed jittery devilbone chunks	1		Last Available: "2026-12"
-12083	extra-tarnished lime green narrow Gehenna tattoo	0		Effect: "Deadly Lampblade", Effect Duration: 13
+12083	extra-tarnished narrow lime green Gehenna tattoo	0		Effect: "Deadly Lampblade", Effect Duration: 13
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
 12118	pulsating burnt radius	0		Last Available: "2025-12"
-12119	purple blurry burnt rib	0		Last Available: "2025-12"
+12119	blurry purple burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
 12121	blurry Crymbocurrency	0		Last Available: "2025-12"
 12122	bouncing extra-thick Crimbo sweater of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	quadruple-diffused diffused boiling synovial fluid	0		Effect: "Mushroom Samba", Effect Duration: 55, Last Available: "2025-12"
 12132	blurry Sinatra's smoldering vertebra of courage of the early riser	0		Experience (Moxie): +5, Spooky Resistance: +3, Adventures: +7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +40, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +40, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	crafty supercool hot boning knife of the blizzard	0		Moxie Percent: +20, Maximum MP: +10, Cold Spell Damage: +25, Single Equip, Last Available: "2025-12"
@@ -11897,7 +11897,7 @@
 12139	jittery prompt stanky occult burnt bone belt	0		Spell Damage Percent: +25, Stench Spell Damage: +25, Adventures: +3, Single Equip, Last Available: "2025-12"
 12140	studded scorched skull trophy	0		Damage Absorption: +80, Last Available: "2025-12"
 12141	normal wing bone	4	good	Last Available: "2025-12"
-12142	drinkable fancy squat huge weak skeleton venom	3	good	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2025-12"
+12142	fancy drinkable squat huge weak skeleton venom	3	good	Effect: "Jungle Juiced", Effect Duration: 45, Last Available: "2025-12"
 12143	distilled purple baked bone meal	1		Last Available: "2025-12"
 12144	therapeutic plastic skeleton rib cage	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2025-12"
 12145	grievous plastic skeleton skull	0		Weapon Damage Percent: +50, Last Available: "2025-12"
@@ -11926,19 +11926,19 @@
 12168	greasy vermiculite shield of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Damage Reduction: 9, Last Available: "2025-12"
 12169	ship's lantern of the bloodbag	0		Maximum HP: +100, Last Available: "2025-12"
 12170	narrow fireproof resourceful heat-resistant harpoon pistol	0		Maximum MP: +50, Hot Resistance: +3, Last Available: "2025-12"
-12171	massive rotten traditional gingerloaf	7	crappy	Last Available: "2025-12"
-12172	lousy strong maroon Scotch and eggnog	5	decent	Last Available: "2025-12"
+12171	rotten massive traditional gingerloaf	7	crappy	Last Available: "2025-12"
+12172	strong lousy maroon Scotch and eggnog	5	decent	Last Available: "2025-12"
 12173	polarized blinking counterskeleton elixir	0		Effect: "Purity of Spirit", Effect Duration: 24, Last Available: "2025-12"
 12174	perfectly mixed pulsating &quot;salvaged&quot; wine	3	EPIC	Last Available: "2025-12"
-12175	maroon tumbling The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
+12175	tumbling maroon The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	spoiled wedge of prize-winning cheese	3	crappy	Last Available: "2025-12"
 12178	tarnished super-tarnished triple-ionized gummi fingerbone	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 68
 12179	jittery groovy glimmering crystal of the glutton	0		Moxie Percent: +10, Food Drop: +100, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
-12183	blurry pulsating loose Meats	0		
+12183	pulsating blurry loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
 12185	purple boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	huge dinosaur bone fragment	0		Last Available: "2026-03"
@@ -11950,7 +11950,7 @@
 12192	Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	corrupted pulsating Pork Elf mouthwash	0		Effect: "The Smeezingtons", Effect Duration: 58, Last Available: "2026-03"
 12194	liquefied triple-dry irradiated blinking Pork Elf deodorant	0		Effect: "Uncaged Power", Effect Duration: 54, Last Available: "2026-03"
-12195	dry wobbly upside-down Pork Elf toothpaste	0		Effect: "Full of Vinegar", Effect Duration: 35, Last Available: "2026-03"
+12195	dry upside-down wobbly Pork Elf toothpaste	0		Effect: "Full of Vinegar", Effect Duration: 35, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
 12197	cyan baleful savvy and dress	0		Mysticality Percent: +20, Spell Damage: +25, Last Available: "2026-03"
 12198	scandalous occult and dress	0		Spell Damage Percent: +25, Sleaze Damage: +5, Last Available: "2026-03"
@@ -11969,12 +11969,12 @@
 12211	Annie Oakley's electrified hoverboard of the dark arts	0		Spell Damage Percent: +100, Critical Hit Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2026-03"
 12212	Jim Carey's rosy-cheeked left shark fin of horror	0		Maximum HP Percent: +30, Monster Level: +25, Spooky Spell Damage: +25, Last Available: "2026-03"
 12213	huge fitness tracking bracelet of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2026-03"
-12214	denatured cyan pulsating candy bone	1		
+12214	denatured pulsating cyan candy bone	1		
 12215	ghostly wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	tasty small mirror discarded hot dog	2	awesome	Last Available: "2026-04"
 12218	mediocre pulsating most of a beer	4	decent	Last Available: "2026-04"
-12222	ghostly huge pasta wand loot box	0		Free Pull, Last Available: "2026-05"
+12222	huge ghostly pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	squat legendary noodles	0		Last Available: "2026-05"
 12226	jumbo moldy can of tuna	5	crappy	
@@ -11982,14 +11982,14 @@
 12228	flavorless ratbatatouille	3	decent	
 12229	bland twirling onigiri	4	decent	
 12230	stale crudit&eacute;s	4	decent	
-12231	stale low-calorie olive sauced mutton	1	decent	
-12232	spoiled enchanted hot honey ant	3	crappy	Effect: "Permanent Halloween", Effect Duration: 35
+12231	low-calorie stale olive sauced mutton	1	decent	
+12232	enchanted spoiled hot honey ant	3	crappy	Effect: "Permanent Halloween", Effect Duration: 35
 12233	rotten huge tomb aspic	3	crappy	
 12234	spoiled later tots	4	crappy	
 12235	spoiled half-sized Frutti di Scatoletta	2	crappy	Last Available: "2026-05"
 12236	moldy Pesto alla Marziano	3	crappy	Last Available: "2026-05"
-12237	flavorless mirror ghostly Arrattabbattabiata	3	decent	Last Available: "2026-05"
-12238	big stale Orzo di Riso	5	decent	Last Available: "2026-05"
+12237	flavorless ghostly mirror Arrattabbattabiata	3	decent	Last Available: "2026-05"
+12238	stale big Orzo di Riso	5	decent	Last Available: "2026-05"
 12239	half-sized spoiled tumbling Pasta Grimavera	2	crappy	Last Available: "2026-05"
 12240	moldy narrow Linguini Ubriacapa	3	crappy	Last Available: "2026-05"
 12241	bland snack-sized Formica e Pepe	2	decent	Last Available: "2026-05"
@@ -12001,7 +12001,7 @@
 12248	mega helmet	0		
 12252	rosy-cheeked smartaleck's Space Soldier Helmet	0		Moxie Percent: +30, Maximum HP Percent: +30
 12253	flavorless shaking premium turkey leg	4	decent	
-12254	perfectly mixed watered-down wobbly styrofoam cup of mead	2	EPIC	
+12254	watered-down perfectly mixed wobbly styrofoam cup of mead	2	EPIC	
 12255	wobbly friendly sword	0		Familiar Weight: +3
 12256	bouncing veiny staff	0		Maximum HP: +10
 12257	blurry lime green rock-hard lute	0		Damage Reduction: 5
@@ -12017,17 +12017,17 @@
 12267	Herculean flimsy plastic breastplate	0		Experience (Muscle): +1
 12268	censurious flimsy plastic shield	0		Sleaze Resistance: +3, Damage Reduction: 3
 12269	squat packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	lightning-fast chilly Herculean Portable Laughing Stock	0		Experience (Muscle): +1, Cold Damage: +5, Initiative: +40, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	lightning-fast chilly Herculean Portable Laughing Stock	0		Experience (Muscle): +1, Cold Damage: +5, Initiative: +40, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	personal trainer's wizardly Staff of Anachronistic Churning of the sweet-tooth	0		Mysticality: +25, Experience Percent (Muscle): +10, Candy Drop: +100
 12272	spoiled narrow classic banana	4	crappy	Last Available: "2026-07"
-12273	special moldy watermelon	3	crappy	Effect: "Electrolit Up", Effect Duration: 40, Last Available: "2026-07"
+12273	moldy special watermelon	3	crappy	Effect: "Electrolit Up", Effect Duration: 40, Last Available: "2026-07"
 12274	spoiled quince	4	crappy	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	bland classic banana pie	3	decent	Last Available: "2026-07"
 12278	unsweetened diffused essential banana decoction	0		Effect: "Hobo Flavor", Effect Duration: 17, Last Available: "2026-07"
 12279	extra-enhanced narrow narrow blurry banana quintessence	0		Effect: "Shamboozled", Effect Duration: 57, Last Available: "2026-07"
-12280	hand-crafted irresponsibly strong Aesop Daiquiri	8	EPIC	Last Available: "2026-07"
+12280	irresponsibly strong hand-crafted Aesop Daiquiri	8	EPIC	Last Available: "2026-07"
 12281	tolerable Monkey Congress	4	good	Last Available: "2026-07"
 12282	tasty watermelon pie	3	awesome	Last Available: "2026-07"
 12283	boiled blue concentrated watermelon juice	0		Effect: "Pyramid Power", Effect Duration: 37, Last Available: "2026-07"
@@ -12038,11 +12038,11 @@
 12288	cold-filtered moist pulsating quince quaff	0		Effect: "Bubblin' Rage", Effect Duration: 40, Last Available: "2026-07"
 12289	ionized Quickquince	0		Effect: "Barking Mad", Effect Duration: 39, Last Available: "2026-07"
 12290	extra-dry lousy Quiskey Sour	5	decent	Last Available: "2026-07"
-12291	triple-distilled lousy Quincea&ntilde;era Cooler	6	decent	Last Available: "2026-07"
+12291	lousy triple-distilled Quincea&ntilde;era Cooler	6	decent	Last Available: "2026-07"
 12292	hand-crafted Roth IPA	4	EPIC	Last Available: "2026-08"
 12293	veiny wicked underdraft protection	0		Spell Damage: +5, Maximum HP: +10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	yummy big maroon soybean futures	5	awesome	Last Available: "2026-08"
+12295	big yummy maroon soybean futures	5	awesome	Last Available: "2026-08"
 12296	pickled gray housing bubble	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 30, Last Available: "2026-08"
 12297	warmed wet narrow Pixie-Swordz	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 59
 12298	savvy financial instrument of the brute	0		Muscle Percent: +30, Mysticality Percent: +20, Last Available: "2026-08"
@@ -12054,7 +12054,7 @@
 12304	balance sheet	0		Last Available: "2026-08"
 12305	super-boiled fuchsia invisible hand	0		Effect: "Milk Studly", Effect Duration: 16, Last Available: "2026-08"
 12306	pickled polarized circle of overdraft protection scroll	0		Effect: "Optimist Primal", Effect Duration: 23, Last Available: "2026-08"
-12307	non-chilled ionized spinning shaking mint	0		Effect: "A View to Some Meat", Effect Duration: 28, Last Available: "2026-08"
+12307	non-chilled ionized shaking spinning mint	0		Effect: "A View to Some Meat", Effect Duration: 28, Last Available: "2026-08"
 12308	squat maroon savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	distilled toxic asset	1		Effect: "Wet Jaw", Effect Duration: 15, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Turtle_Tamer_Marmot_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Marmot_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	weak acceptable enchanted Petite Porter	2	good	
--2	distilled lousy Scrawny Stout	5	decent	
--3	lousy watered-down narrow Infinitesimal IPA	2	decent	
--4	fancy acceptable eggnogtini	4	good	
--5	delicious practically non-alcoholic candycaine	1	awesome	
+-2	lousy distilled Scrawny Stout	5	decent	
+-3	watered-down lousy narrow Infinitesimal IPA	2	decent	
+-4	acceptable fancy eggnogtini	4	good	
+-5	practically non-alcoholic delicious candycaine	1	awesome	
 -6	lousy braincracker sweet	4	decent	
 -16	artisanal red fermented honey	4	EPIC	
--17	practically non-alcoholic artisanal moons-shine	1	EPIC	
+-17	artisanal practically non-alcoholic moons-shine	1	EPIC	
 -18	perfectly mixed olive gin	4	EPIC	
 -19	perfectly mixed practically non-alcoholic ecto-nog	1	EPIC	
--20	mediocre practically non-alcoholic hot toady	1	decent	
+-20	practically non-alcoholic mediocre hot toady	1	decent	
 -21	mediocre hot choculate	3	decent	
--49	practically non-alcoholic bad Cyder	1	decent	
--50	weak drinkable spinning Oil Nog	2	good	
--51	drinkable watered-down jittery Hi-Octane Peppermint Jet Fuel	2	good	
+-49	bad practically non-alcoholic Cyder	1	decent	
+-50	drinkable weak spinning Oil Nog	2	good	
+-51	watered-down drinkable jittery Hi-Octane Peppermint Jet Fuel	2	good	
 -58	enchanted bad Grimacider	3	decent	
 -59	mediocre blurry Isotope Nog	3	decent	
 -60	acceptable Mutagin 'n' Tonic	3	good	
--70	fortified drinkable blinking Gin and Herring	5	good	
--71	weak drinkable olive Black and Tan and Red All Over	2	good	
+-70	drinkable fortified blinking Gin and Herring	5	good	
+-71	drinkable weak olive Black and Tan and Red All Over	2	good	
 -72	aged Antarctic Ice Tea	3	awesome	
--76	drinkable fancy weak shaking CRIMBCO Ribbon Candy Schnapps	2	good	
+-76	fancy weak drinkable shaking CRIMBCO Ribbon Candy Schnapps	2	good	
 -77	acceptable blurry CRIMBCO Egg Substitute Nog Substitute	4	good	
 -78	perfectly mixed pulsating CRIMBCO Extreme Braincracker Sour	3	EPIC	
 -82	drinkable Horseradish-infused Vodka	4	good	
 -83	mediocre gray Jerkitini	3	decent	
 -84	watered-down bad shaking Desert Island Iced Tea	2	decent	
--88	hand-crafted boozy Crimbo Saketini	5	EPIC	
+-88	boozy hand-crafted Crimbo Saketini	5	EPIC	
 -89	lousy gray Crimboku Drop	3	decent	
 -90	aged Flaming Crimbo Log	3	awesome	
 -107	smooth shaking spinning Fortified Eggnog Slurry	3	awesome	
--108	extra-dry hand-crafted yellow Hot Buttered Rum	5	EPIC	
+-108	hand-crafted extra-dry yellow Hot Buttered Rum	5	EPIC	
 -109	spirit-forward perfectly mixed Spicy Hot Chocolate	5	EPIC	

--- a/data/TCRS/TCRS_Turtle_Tamer_Marmot_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Marmot_cafe_food.txt
@@ -1,35 +1,35 @@
--1	bland snack-sized Peche a la Frog	2	decent	
--2	super-sized spoiled As Jus Gezund Heit	5	crappy	
--3	spoiled half-sized narrow Bouillabaise Coucher Avec Moi	2	crappy	
+-1	snack-sized bland Peche a la Frog	2	decent	
+-2	spoiled super-sized As Jus Gezund Heit	5	crappy	
+-3	half-sized spoiled narrow Bouillabaise Coucher Avec Moi	2	crappy	
 -7	moldy half-sized purple gumdrop chow mein	2	crappy	
 -8	thick toothsome lime green candy cane pizza	5	awesome	
 -9	normal jumbo gingerbread stir-fry	5	good	
 -10	moldy twigs and gravel	4	crappy	
--11	huge flavorless shoots and leaves	6	decent	
--12	snack-sized moldy mirror bowl of unidentifiable goo	2	crappy	
+-11	flavorless huge shoots and leaves	6	decent	
+-12	moldy snack-sized mirror bowl of unidentifiable goo	2	crappy	
 -13	normal gingerbread massacre	4	good	
 -14	rotten huge It Came From Beyond Dessert	4	crappy	
 -15	rotten skewed vampire cake	3	crappy	
 -52	rotten enchanted mirror Soylent Red and Green	3	crappy	
 -53	moldy Disc-Shaped Nutrition Unit	4	crappy	
--54	stale small Gingerborg Hive	2	decent	
+-54	small stale Gingerborg Hive	2	decent	
 -61	stale Candy Cane Surprise	4	decent	
 -62	adequate fancy tumbling Grimdrop Chow Mein	3	good	
 -63	immense flavorless pulsating Grimgerbread House	7	decent	
--67	stale blue shaking Caviar Carbonara	3	decent	
+-67	stale shaking blue Caviar Carbonara	3	decent	
 -68	rotten Halibut Alfredo	3	crappy	
 -69	normal Red Herring Velvet Cake	3	good	
 -73	normal CRIMBCO Reconstituted Gruel	3	good	
--74	miniature flavorless New and Improved CRIMBCO Reconstituted Gruel	2	decent	
+-74	flavorless miniature New and Improved CRIMBCO Reconstituted Gruel	2	decent	
 -75	spoiled CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	crappy	
--79	stale massive Brussels Sprout Stir-Fry	10	decent	
+-79	massive stale Brussels Sprout Stir-Fry	10	decent	
 -80	flavorless Carrot, Cabbage, and Kale Pizza	3	decent	
--81	decent blue squat Turnip and Rutabaga Pie	4	good	
+-81	decent squat blue Turnip and Rutabaga Pie	4	good	
 -85	delicious squat Rainbow Spider Fun Roll	4	awesome	
 -86	moldy blinking Vegas Volcano Lava Roll	4	crappy	
--87	massive spoiled Crazy Dragon Shogun Buddha Roll	10	crappy	
--92	tiny adequate basic hot dog	1	good	
--93	rotten miniature maroon savage macho dog	2	crappy	
+-87	spoiled massive Crazy Dragon Shogun Buddha Roll	10	crappy	
+-92	adequate tiny basic hot dog	1	good	
+-93	miniature rotten maroon savage macho dog	2	crappy	
 -94	adequate one with everything	3	good	
 -95	yummy sly dog	3	awesome	
 -96	moldy immense devil dog	7	crappy	
@@ -38,8 +38,8 @@
 -99	decent bite-sized junkyard dog	1	good	
 -100	bland wet dog	3	decent	
 -101	normal small sleeping dog	2	good	
--102	toothsome low-calorie optimal dog	1	awesome	
+-102	low-calorie toothsome optimal dog	1	awesome	
 -103	rotten thick video games hot dog	5	crappy	
 -104	stale Peppermint Nutrition Block	4	decent	
--105	huge rotten shaking Gingerbread Nutrition Block	8	crappy	
+-105	rotten huge shaking Gingerbread Nutrition Block	8	crappy	
 -106	decent pulsating narrow Cinnamon Nutrition Block	3	good	

--- a/data/TCRS/TCRS_Turtle_Tamer_Mongoose.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Mongoose.txt
@@ -37,12 +37,12 @@
 38	skewed Knob Goblin pants of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "atk, 5xPotato, cap 6"
 39	shaking pretty flower	0		
 40	shaking casino pass	0		
-41	watered-down bad ice-cold Sir Schlitz	2	decent	
+41	bad watered-down ice-cold Sir Schlitz	2	decent	
 42	blurry hermit permit	0		
 43	worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
-46	olive twirling figurine	0		
+46	twirling olive figurine	0		
 47	rotten half-sized hot buttered roll	2	crappy	
 48	pulsating heart of rock and roll	0		
 49	stale bowl of cottage cheese	3	decent	
@@ -197,10 +197,10 @@
 199	red stylish ring	0		Moxie: +25
 200	stale rat appendix kabob	4	decent	
 201	yummy gigantic bat wing kabob	8	awesome	
-202	flavorless tiny carob chunks	1	decent	
+202	tiny flavorless carob chunks	1	decent	
 203	herbs	0		
 204	flavorless carob chunk cookies	4	decent	
-205	jittery shaking secret blend of herbs and spices	0		
+205	shaking jittery secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	good	
 208	patchouli incense stick	0		
@@ -212,8 +212,8 @@
 214	padded filthy knitted dread sack	0		Damage Absorption: +20, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
 216	adequate carob brownies	3	good	
-217	big toothsome mirror shaking herb brownies	5	awesome	
-218	maroon mirror hemp string	0		
+217	big toothsome shaking mirror herb brownies	5	awesome	
+218	mirror maroon hemp string	0		
 219	necklace chain	0		
 220	gnoll teeth	0		
 221	lard-coated gnoll-tooth necklace	0		Sleaze Spell Damage: +25
@@ -237,17 +237,17 @@
 239	wicked razor-sharp Orcish baseball cap	0		Weapon Damage Percent: +25, Spell Damage: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	spinning zippy Da Vinci's Orcish cargo shorts	0		Experience (Mysticality): +5, Initiative: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	perfumed Orcish frat-paddle	0		Stench Resistance: +5
-242	rotten gigantic	10	crappy	
+242	gigantic rotten	10	crappy	
 243	adequate twirling grapefruit	3	good	
 244	decent green grapes	4	good	
 245	adequate olive	3	good	
 246	spoiled tomato	3	crappy	
-247	twirling shaking huge fermenting powder	0		
+247	shaking huge twirling fermenting powder	0		
 248	weak bad salty dog	2	decent	
 249	lousy shaking bloody mary	4	decent	
-250	acceptable practically non-alcoholic spinning screwdriver	1	good	
+250	practically non-alcoholic acceptable spinning screwdriver	1	good	
 251	hand-crafted martini	4	EPIC	
-252	acceptable fortified yellow bloody beer	5	good	
+252	fortified acceptable yellow bloody beer	5	good	
 253	mediocre olive twirling shot of schnapps	3	decent	
 254	delicious red shot of grapefruit schnapps	3	awesome	
 255	bad practically non-alcoholic green fine wine	1	decent	
@@ -256,18 +256,18 @@
 258	jittery spinning dense meat stack	0		
 259	snake skin	0		
 260	spoiled White Citadel fries	4	crappy	
-261	rotten massive White Citadel burger	10	crappy	
+261	massive rotten White Citadel burger	10	crappy	
 262	toothsome piece of wedding cake	3	awesome	
-263	normal miniature chocolate chips	2	good	
-264	small special moldy blinking chocolate chip cookies	2	crappy	Effect: "Stop and Smell the Fudge", Effect Duration: 20
+263	miniature normal chocolate chips	2	good	
+264	special small moldy blinking chocolate chip cookies	2	crappy	Effect: "Stop and Smell the Fudge", Effect Duration: 20
 265	Jeselnik's satin pants	0		Sleaze Damage: +25, Familiar Effect: "atk, 2xPotato, cap 10"
-266	mediocre special lightning	3	decent	Effect: "Inscrutable exoskeleton", Effect Duration: 10
+266	special mediocre lightning	3	decent	Effect: "Inscrutable exoskeleton", Effect Duration: 10
 267	gray wholesome mullet wig	0		Maximum HP Percent: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	narrow censurious meat cowboy hat	0		Sleaze Resistance: +3, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	squat skewed baleful sword	0		Spell Damage: +25
 270	blue picket fence	0		
 271	boiled bouncing squat barbell	1		Effect: "Flaming Weapon", Effect Duration: 25
-272	powdered yellow ghostly squat concentrated magicalness pill	1		Effect: "Deadly Flashing Blade", Effect Duration: 5
+272	powdered yellow squat ghostly concentrated magicalness pill	1		Effect: "Deadly Flashing Blade", Effect Duration: 5
 273	compressed moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
@@ -298,7 +298,7 @@
 300	unsweetened jaba&ntilde;ero-flavored chewing gum	0		Effect: "Dexteri Tea", Effect Duration: 32
 301	spinning flat dough	0		
 302	flavorless huge Knob sausage	4	decent	
-303	rotten thick skewed Knob mushroom	5	crappy	
+303	thick rotten skewed Knob mushroom	5	crappy	
 304	red dry noodles	0		
 305	shaking ghostly Jeselnik's Knob Goblin harem pants	0		Sleaze Damage: +25, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	sharpshooter's Knob Goblin harem veil	0		Critical Hit Percent: +10, Familiar Effect: "5xLep, cap 2"
@@ -323,22 +323,22 @@
 325	spoiled goat cheese pizza	4	crappy	
 326	flavorless mushroom pizza	3	decent	
 327	goat	0		
-328	lousy skewed spinning bottle of whiskey	3	decent	
+328	lousy spinning skewed bottle of whiskey	3	decent	
 329	jittery skewed Usain Bolt's goat beard	0		Initiative: +80, Familiar Effect: "atk, 1xPotato, cap 15"
-330	shaking huge glass of goat's milk	1	EPIC	
+330	huge shaking glass of goat's milk	1	EPIC	
 331	delicious Canadian	3	awesome	
 332	rotten fancy lemon	3	crappy	Effect: "Polka Face", Effect Duration: 35
 333	tasty bite-sized blurry lime	1	awesome	
 334	sabre teeth of horror	0		Spooky Spell Damage: +25
 335	sabre-toothed lime cub	0		
 336	razor-sharp consolation ribbon	0		Weapon Damage Percent: +25
-337	yellow shaking ol' trophy	0		
+337	shaking yellow ol' trophy	0		
 338	tenderizing hammer	0		
 339	Cobb's Knob lab key	0		
 340	ionized bouncing Knob Goblin steroids	0		Effect: "Red-Shirted Escort", Effect Duration: 24
 341	energized huge pulsating Knob Goblin love potion	0		Effect: "Berry Defensive", Effect Duration: 47
 342	Knob Goblin stink bomb	0		
-343	Vulcanized unsweetened red squat Knob Goblin sharpening spray	0		Effect: "Human-Penguin Hybrid", Effect Duration: 49
+343	Vulcanized unsweetened squat red Knob Goblin sharpening spray	0		Effect: "Human-Penguin Hybrid", Effect Duration: 49
 344	ghostly Knob Goblin seltzer	0		
 345	Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
@@ -353,7 +353,7 @@
 355	huge eXtreme scarf of the businessman	0		Meat Drop: +50, Familiar Effect: "atk, 1xBarrr, cap 25"
 356	wicked snowboarder pants	0		Spell Damage: +5, Familiar Effect: "1xPotato, cap 25"
 357	Mountain Stream soda	0		
-358	enchanted snack-sized adequate spinning gr8ps	2	good	Effect: "Nigh-Invincible", Effect Duration: 10
+358	snack-sized adequate enchanted spinning gr8ps	2	good	Effect: "Nigh-Invincible", Effect Duration: 10
 359	rotten t8r tots	4	crappy	
 360	huge sage miner's helmet	0		Mysticality Percent: +10, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	Jeselnik's miner's pants	0		Sleaze Damage: +25, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
@@ -368,8 +368,8 @@
 370	asbestos stick	0		
 371	asbestos crossbow string	0		
 372	chrome sword hilt	0		
-373	mirror narrow chrome stick	0		
-374	twirling fuchsia chrome crossbow string	0		
+373	narrow mirror chrome stick	0		
+374	fuchsia twirling chrome crossbow string	0		
 375	linoleum meat stack	0		
 376	lime green asbestos meat stack	0		
 377	chrome meat stack	0		
@@ -414,7 +414,7 @@
 416	curative safarrri hat	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xVolley, cap 22"
 417	improved wet henna tattoo	0		Effect: "White-boy Angst", Effect Duration: 56
 418	improved tumbling Ferrigno's Elixir of Power	0		Effect: "Holiday Bliss", Effect Duration: 35
-419	activated liquefied huge green serum of sarcasm	0		Effect: "You Know What's Up", Effect Duration: 24
+419	activated liquefied green huge serum of sarcasm	0		Effect: "You Know What's Up", Effect Duration: 24
 420	Vulcanized dry blurry tomato juice of powerful power	0		Effect: "World's Shortest Giant", Effect Duration: 38
 421	pickled philter of phorce	0		Effect: "Swimming with Sharks", Effect Duration: 46
 422	dry moist skewed potion of potency	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 25
@@ -449,7 +449,7 @@
 451	ghostly pretentious palette	0		
 452	narrow disease	0		
 453	sober pill	0		
-454	maroon narrow screwdriver	0		
+454	narrow maroon screwdriver	0		
 455	adequate fuchsia jumbo olive	3	good	
 456	lousy skewed dry martini	3	decent	
 457	ye olde golde frontes of extreme caution	0		Monster Level: -25, Class: "Disco Bandit", Single Equip
@@ -469,18 +469,18 @@
 471	big spoiled blinking hot wing	5	crappy	
 472	supercharged diamond-studded cane	0		Maximum MP Percent: +30, Class: "Disco Bandit"
 473	Samson's crutch	0		Experience (Muscle): +5
-474	upside-down wobbly cast	0		
+474	wobbly upside-down cast	0		
 475	family-friendly Tesla mask	0		Sleaze Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "sleaze atk, 1xBarrr, cap 15"
 476	ghostly hellion cube	0		
 477	infernal insoles of the cougar of terror	0		Moxie: +20, Spooky Spell Damage: +10
 478	evil arch	0		
 479	dodecagram	0		
 480	box of birthday candles	0		
-481	skewed narrow eldritch butterknife	0		
+481	narrow skewed eldritch butterknife	0		
 482	squat Oprah's Mr. Container	0		Maximum MP Percent: +50, Last Available: "2004-12"
 483	Jack Frost's Newbiesport&trade; backpack	0		Cold Spell Damage: +50, Last Available: "2004-12"
 484	fortified hemp backpack	0		Damage Absorption: +60, Last Available: "2004-12"
-485	jittery tumbling snakehead charrrm	0		
+485	tumbling jittery snakehead charrrm	0		
 486	Talisman o' Namsilat of the early riser	0		Adventures: +7, Single Equip
 487	curative arrrgyle socks	0		HP Regen Min: 3, HP Regen Max: 5
 488	guitar pick	0		
@@ -490,7 +490,7 @@
 492	blue nasty wholesome chaps	0		Maximum HP Percent: +10, Stench Damage: +5, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
 493	cyan ketchup hound	0		
 494	twirling batblade of the detective	0		Item Drop: +20
-495	pulsating bouncing catgut	0		
+495	bouncing pulsating catgut	0		
 496	tumbling cat appendix	0		
 497	jittery gnatwing	0		
 498	stale papaya	4	decent	
@@ -508,7 +508,7 @@
 510	mirror Boris's key lime	0		
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
-513	adequate small Boris's key lime pie	2	good	
+513	small adequate Boris's key lime pie	2	good	
 514	bland olive Jarlsberg's key lime pie	3	decent	
 515	rotten enchanted upside-down Sneaky Pete's key lime pie	3	crappy	Effect: "Badger Underfoot", Effect Duration: 45
 516	Hey Deze map	0		
@@ -519,7 +519,7 @@
 521	blinking Samson's kickback cookbook	0		Experience (Muscle): +5
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	mediocre practically non-alcoholic enchanted papaya sling	1	decent	Effect: "Muscularrr", Effect Duration: 25
+524	practically non-alcoholic enchanted mediocre papaya sling	1	decent	Effect: "Muscularrr", Effect Duration: 25
 525	narrow grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -538,7 +538,7 @@
 540	magnetized pulsating lime green Tasty Fun Good rice candy	0		Effect: "Adrenaline Rush", Effect Duration: 13
 541	executive Temple Grandin's draggin' ball hat	0		Familiar Weight: +7, Meat Drop: +40, Familiar Effect: "atk, 1xVolley, cap 25"
 542	Usain Bolt's miser's 1337 7r0uZ0RZ	0		Meat Drop: +10, Initiative: +80, Familiar Effect: "2xPotato, cap 27"
-543	flavorless super-sized wobbly Trollhouse cookies	5	decent	
+543	super-sized flavorless wobbly Trollhouse cookies	5	decent	
 544	cyan perfumed personal trainer's talons	0		Experience Percent (Muscle): +10, Stench Resistance: +5
 545	toothsome half-sized Spam Witch sammich	2	awesome	
 546	meat vortex	0		
@@ -563,29 +563,29 @@
 565	rock-hard hobo gloves	0		Damage Reduction: 5, Single Equip
 566	cool bum cheek	0		Moxie: +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	enchanted decent Double Bacon Beelzeburger	3	good	Effect: "Ichorous Eyesight", Effect Duration: 40
+568	decent enchanted Double Bacon Beelzeburger	3	good	Effect: "Ichorous Eyesight", Effect Duration: 40
 569	stale mirror Lord of the Flies-sized fries	3	decent	
 570	stale Chicken Sandwich	4	decent	
 571	skewed Jumbo Dr. Lucifer	1	EPIC	
 572	small tasty blurry Children's Meal of the Damned	2	awesome	
-573	adequate bite-sized noodles	1	good	
+573	bite-sized adequate noodles	1	good	
 574	small bland noodles	2	decent	
-575	snack-sized moldy huge fuchsia painful penne pasta	2	crappy	
-576	big rotten ravioli della hippy	5	crappy	
+575	moldy snack-sized fuchsia huge painful penne pasta	2	crappy	
+576	rotten big ravioli della hippy	5	crappy	
 577	rotten ghostly pr0n m4nic0tti	3	crappy	
 578	stale Hell ramen	4	decent	
 579	adequate blue boring spaghetti	3	good	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	blurry Himalayan Hidalgo sauce	0		
-583	tiny adequate fettucini Inconnu	1	good	
-584	bland low-calorie spaghetti with Skullheads	1	decent	
-585	small stale jittery gnocchetti di Nietzsche	2	decent	
+583	adequate tiny fettucini Inconnu	1	good	
+584	low-calorie bland spaghetti with Skullheads	1	decent	
+585	stale small jittery gnocchetti di Nietzsche	2	decent	
 586	stanky studded ridiculously huge sword	0		Damage Absorption: +80, Stench Spell Damage: +25
 587	liquefied triple-diffused skewed tumbling super-spiky hair gel	0		Effect: "Ooh, Umami!", Effect Duration: 27
 588	blinking soft echo eyedrop antidote	0		
 589	decent cocoa eggshell fragment	3	good	
-590	adequate jumbo enchanted olive cocoa eggshell fragment	5	good	Effect: "Springy Fusilli", Effect Duration: 35
+590	jumbo adequate enchanted olive cocoa eggshell fragment	5	good	Effect: "Springy Fusilli", Effect Duration: 35
 591	cocoa egg	0		
 592	house	0		
 593	jittery blinking phonics down	0		
@@ -602,13 +602,13 @@
 604	upside-down Penultimate Fantasy chest	0		
 605	Tissue Paper Immateria	0		
 606	green Tin Foil Immateria	0		
-607	jittery wobbly Gauze Immateria	0		
+607	wobbly jittery Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
 609	squat S.O.C.K.	0		
 610	procrastination potion	0		
 611	D	0		
 612	bouncing original G	0		
-613	tumbling teal plot hole	0		
+613	teal tumbling plot hole	0		
 614	deionized polarized probability potion	0		Effect: "Oh Snap", Effect Duration: 33
 615	chaos butterfly	0		
 616	furry fur	0		
@@ -625,7 +625,7 @@
 627	ND	0		
 628	wobbly metallic A	0		
 629	eye of the businessman	0		Meat Drop: +50
-630	upside-down olive photoprotoneutron torpedo	0		
+630	olive upside-down photoprotoneutron torpedo	0		
 631	skewed reassuring furry pants	0		Spooky Resistance: +1, Familiar Effect: "1xPotato, 1xGhuol, MP regen, cap 37"
 632	reassuring disturbing fanfic	0		Spooky Resistance: +1
 633	censurious scandalous wolf mask	0		Sleaze Damage: +5, Sleaze Resistance: +3, Familiar Effect: "1xBarrr, HP regen, cap 37"
@@ -650,7 +650,7 @@
 652	quantum egg	0		
 653	intragalactic rowboat	0		
 654	star	0		
-655	jittery squat line	0		
+655	squat jittery line	0		
 656	twirling star chart	0		
 657	bouncing blurry wicked star sword	0		Spell Damage: +5
 658	nasty star crossbow	0		Stench Damage: +5
@@ -667,7 +667,7 @@
 669	tasty snack-sized huge ghuol guolash	2	awesome	
 670	chaotic lihc face	0		Spell Critical Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	maroon reassuring chaotic grave robbing shovel	0		Spell Critical Percent: +10, Spooky Resistance: +1
-672	snack-sized bland cranberries	2	decent	
+672	bland snack-sized cranberries	2	decent	
 673	perfectly mixed watered-down vodka and cranberry	2	EPIC	
 674	weak tolerable whiskey	2	good	
 675	skull of the Bonerdagon of terror	0		Spooky Spell Damage: +10
@@ -675,10 +675,10 @@
 677	maroon Fonzie's badass belt	0		Experience (Moxie): +1
 678	squat chest of the Bonerdagon	0		
 679	smooth spirit-forward roll in the hay	5	awesome	
-680	weak bad slap and tickle	2	decent	
+680	bad weak slap and tickle	2	decent	
 681	delicious blurry slip 'n' slide	4	awesome	
 682	practically non-alcoholic smooth jittery a sump'm sump'm	1	awesome	
-683	artisanal weak horizontal tango	2	EPIC	
+683	weak artisanal horizontal tango	2	EPIC	
 684	tolerable pink pony	3	good	
 685	purple inspector's experienced beefy Mr. Shirt	0		Muscle: +10, Experience: +2, Item Drop: +15
 686	blinking strapping knuckles	0		Muscle: +5
@@ -703,7 +703,7 @@
 706	porquoise	0		
 707	shaking pork elf goodies sack	0		
 708	olive ring setting	0		
-709	blurry purple pulsating jewelry-making pliers	0		
+709	blurry pulsating purple jewelry-making pliers	0		
 711	yellow blurry hamethyst earring of temperance of the cheetah	0		Sleaze Resistance: +5, Initiative: +60
 712	narrow miser's stanky hamethyst necklace of the early riser	0		Stench Spell Damage: +25, Meat Drop: +10, Adventures: +7, Single Equip
 713	spinning extremely unsafe hamethyst bracelet of temperance	0		Weapon Damage Percent: +100, Sleaze Resistance: +5, Single Equip
@@ -735,7 +735,7 @@
 739	tambourine bells	0		
 740	crafty tambourine	0		Maximum MP: +10
 741	broken skull	0		
-742	special decent narrow Knoll shroomkabob	3	good	Effect: "Always be Collecting", Effect Duration: 40
+742	decent special narrow Knoll shroomkabob	3	good	Effect: "Always be Collecting", Effect Duration: 40
 743	adequate jittery mushroom	3	good	
 744	liquefied moist aerosolized twirling hair spray	0		Effect: "Taurus Rising", Effect Duration: 29
 746	stat script	0		
@@ -743,11 +743,11 @@
 748	gourd potion	0		
 749	normal blurry warm mushroom	3	good	
 750	stale mushroom quesadilla	4	decent	
-751	toothsome small cool mushroom	2	awesome	
+751	small toothsome cool mushroom	2	awesome	
 752	miniature normal cool mushroom casserole	2	good	
-753	normal half-sized pointy mushroom	2	good	
+753	half-sized normal pointy mushroom	2	good	
 754	bland snack-sized cream of pointy mushroom soup	2	decent	
-755	massive adequate special lime green mushroom	6	good	Effect: "Crying, Dying", Effect Duration: 10
+755	special adequate massive lime green mushroom	6	good	Effect: "Crying, Dying", Effect Duration: 10
 756	special toothsome mushroom	4	awesome	Effect: "Bright!", Effect Duration: 20
 757	spoiled mushroom	4	crappy	
 758	toothsome ghost cucumber	3	awesome	
@@ -779,33 +779,33 @@
 784	artisanal fuchsia Acqua Del Piatto Merlot	3	super EPIC	Last Available: "2004-10"
 785	raffle ticket	0		
 786	spoiled strawberry	3	crappy	
-787	watered-down special artisanal bottle of rum	2	EPIC	Effect: "Bread-Lined", Effect Duration: 15
+787	artisanal special watered-down bottle of rum	2	EPIC	Effect: "Bread-Lined", Effect Duration: 15
 788	mediocre strawberry daiquiri	4	decent	
 789	acceptable rum and cola	3	good	
-790	high-proof aged grog	7	awesome	
+790	aged high-proof grog	7	awesome	
 791	personal trainer's beefcake's Mafia bow tie	0		Muscle: +25, Experience Percent (Muscle): +10, Last Available: "2004-10"
 792	coward's Golden Mr. Accessory	0		Monster Level: -20, Softcore Only
 793	galvanized magnetized liquefied green oil of stability	0		Effect: "Punchy, Murdery", Effect Duration: 57
 794	anodized oil of slipperiness	0		Effect: "Leo Rising", Effect Duration: 44
 795	lousy Acque Luride Grezze Cabernet	3	decent	Last Available: "2004-10"
 796	bouncing ribald beefcake's cement shoes of James Dean	0		Muscle: +25, Experience (Moxie): +3, Sleaze Damage: +10, Last Available: "2004-10"
-797	tolerable fancy huge rockin' wagon	4	good	Effect: "Superhuman Sarcasm", Effect Duration: 50
-798	acceptable weak ocean motion	2	good	
-799	artisanal watered-down fuzzbump	2	EPIC	
+797	fancy tolerable huge rockin' wagon	4	good	Effect: "Superhuman Sarcasm", Effect Duration: 50
+798	weak acceptable ocean motion	2	good	
+799	watered-down artisanal fuzzbump	2	EPIC	
 800	bland poutine	4	decent	
 801	decent Knob stir-fry	3	good	
 804	stale Knoll stir-fry	3	decent	
 805	bite-sized flavorless tumbling stir-fry	1	decent	
-806	miniature moldy squat asparagus stir-fry	2	crappy	
+806	moldy miniature squat asparagus stir-fry	2	crappy	
 807	flavorless diet bouncing olive stir-fry	1	decent	
 808	big tasty Knob sausage stir-fry	5	awesome	
 809	decent bat wing stir-fry	3	good	
-810	big decent lime green rat appendix stir-fry	5	good	
+810	decent big lime green rat appendix stir-fry	5	good	
 811	flavorless tofu stir-fry	4	decent	
 812	yummy teal pr0n stir-fry	4	awesome	
-813	miniature special flavorless Knob shells	2	decent	Effect: "Spooky Weapon", Effect Duration: 50
-814	thick yummy b&auml;tzle	5	awesome	
-815	moldy special bite-sized ghostly mirror ratini	1	crappy	Effect: "Cock of the Walk", Effect Duration: 15
+813	special miniature flavorless Knob shells	2	decent	Effect: "Spooky Weapon", Effect Duration: 50
+814	yummy thick b&auml;tzle	5	awesome	
+815	special bite-sized moldy mirror ghostly ratini	1	crappy	Effect: "Cock of the Walk", Effect Duration: 15
 816	normal Knob stroganoff	3	good	
 817	bland menudo ravioli	4	decent	
 818	blinking plus sign	0		
@@ -815,7 +815,7 @@
 822	smoky potion	0		
 823	cloudy potion	0		
 824	effervescent potion	0		
-825	tumbling jittery fizzy potion	0		
+825	jittery tumbling fizzy potion	0		
 826	dark potion	0		
 827	murky potion	0		
 828	baby killer bee	0		
@@ -826,13 +826,13 @@
 833	vorpal blade of courage	0		Spooky Resistance: +3
 834	Usain Bolt's cornuthaum of incineration	0		Hot Spell Damage: +50, Initiative: +80, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	rock-hard ring of aggravate monster	0		Damage Reduction: 5
-836	tiny adequate special cyan mind flayer corpse	1	good	Effect: "Venomous Weapon", Effect Duration: 20
+836	special tiny adequate cyan mind flayer corpse	1	good	Effect: "Venomous Weapon", Effect Duration: 20
 837	aged Uovo Marcio Shiraz	4	awesome	Last Available: "2004-10"
 838	wobbly boxer's Mafia stogie of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Last Available: "2004-10"
 839	artisanal enchanted Maiali Sifilitici Pinot Noir	4	EPIC	Effect: "Cranberry Cordiality", Effect Duration: 20, Last Available: "2004-10"
 840	ribald Rosewater's Mafia violin case	0		Mysticality Percent: +30, Sleaze Damage: +10, Last Available: "2004-10"
 841	lousy tomato daiquiri	4	decent	
-842	perfectly mixed spirit-forward huge beertini	5	EPIC	
+842	spirit-forward perfectly mixed huge beertini	5	EPIC	
 843	tolerable fancy salty slug	4	good	Effect: "The Magic of Sharing", Effect Duration: 50
 844	hand-crafted papaya slung	4	EPIC	
 845	frosty MAHI fez	0		Cold Spell Damage: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
@@ -878,7 +878,7 @@
 887	fuchsia leaf	0		
 888	blurry maple leaf	0		
 889	foul-smelling balaclava	0		Stench Damage: +10, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	toothsome big balaclava baklava	5	awesome	
+890	big toothsome balaclava baklava	5	awesome	
 891	Warehouse 23 bling of the glutton	0		Food Drop: +100
 892	occult bugbear-smiting sword of James Dean of mayonnaise	0		Experience (Moxie): +3, Spell Damage Percent: +25, Sleaze Spell Damage: +50
 893	drinkable lumbering jack	3	good	
@@ -891,17 +891,17 @@
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	teal 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	extra-dry smooth spinning Spasmi Dolorosi Del Rene Champagne	5	awesome	Last Available: "2004-10"
+903	smooth extra-dry spinning Spasmi Dolorosi Del Rene Champagne	5	awesome	Last Available: "2004-10"
 904	Oprah's extremely unsafe savvy school Mafia knickerbockers	0		Mysticality Percent: +20, Weapon Damage Percent: +100, Maximum MP Percent: +50, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	nitrogenated Yummy Tummy bean	0		Effect: "Berry Critical", Effect Duration: 63
 906	liquefied Rock Pops	0		Effect: "Springy Fusilli", Effect Duration: 68
 907	frozen enhanced huge Mr. Mediocrebar	0		Effect: "Poker Faced", Effect Duration: 38
 908	improved nitrogenated Cold Hots candy	0		Effect: "Patent Alacrity", Effect Duration: 61
 909	super-polymerized extra-oxidized Wint-O-Fresh mint	0		Effect: "How to Scam Tourists", Effect Duration: 57
-910	decent snack-sized tumbling dwarf bread	2	good	
+910	snack-sized decent tumbling dwarf bread	2	good	
 911	corrupted cold-filtered frozen pulsating Senior Mints	0		Effect: "Brother Smothers's Blessing", Effect Duration: 11
 912	double-frozen tumbling pixellated candy heart	0		Effect: "Sugar, Hello", Effect Duration: 67
-913	pressed concentrated galvanized tumbling spinning kobold	0		Effect: "Dancing Prowess", Effect Duration: 21
+913	pressed concentrated galvanized spinning tumbling kobold	0		Effect: "Dancing Prowess", Effect Duration: 21
 914	hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	upside-down yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	fireproof intergalactic pom poms of the detective	0		Hot Resistance: +3, Item Drop: +20
@@ -915,7 +915,7 @@
 924	upside-down crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	boiled super-pickled Hawking's Elixir of Brilliance	0		Effect: "Icy Composition", Effect Duration: 25
-927	mediocre special practically non-alcoholic twirling Ferita Del Petto Zinfandel	1	decent	Effect: "Dreadful Chill", Effect Duration: 50, Last Available: "2006-12"
+927	practically non-alcoholic mediocre special twirling Ferita Del Petto Zinfandel	1	decent	Effect: "Dreadful Chill", Effect Duration: 50, Last Available: "2006-12"
 928	fuzzy bracelets of incineration	0		Hot Spell Damage: +50
 929	arse-shooting crossbow of the ox	0		Muscle: +20
 931	tolerable spiced rum	3	good	
@@ -936,14 +936,14 @@
 946	mirror skewered lime	0		Last Available: "2004-12"
 947	huge skewered cherry	0		Last Available: "2004-12"
 948	perfectly mixed practically non-alcoholic skewed martini	1	super ultra mega turbo EPIC	Last Available: "2004-12"
-949	irresponsibly strong tolerable tumbling grogtini	6	good	Last Available: "2004-12"
+949	tolerable irresponsibly strong tumbling grogtini	6	good	Last Available: "2004-12"
 950	special drinkable pulsating cherry bomb	3	good	Effect: "Liquidy Smoky", Effect Duration: 45, Last Available: "2004-12"
-951	squat narrow extra special Crimbo stocking	0		Last Available: "2004-12"
+951	narrow squat extra special Crimbo stocking	0		Last Available: "2004-12"
 952	dog trainer's Sinatra's hockey mask	0		Experience (Moxie): +5, Experience (familiar): +1, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	shaking orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	double-paned fez of etymology	0		Cold Resistance: +5, Familiar Effect: "1xLep, cap 30"
-956	small bland carob chunk noodles	2	decent	
+956	bland small carob chunk noodles	2	decent	
 957	flavorless chorizo brownies	3	decent	
 958	spoiled upside-down chocolate and tomato pizza	4	crappy	
 959	flange	0		
@@ -990,27 +990,27 @@
 1003	cyan soda water	0		
 1004	delicious bottle of tequila	4	awesome	
 1005	lousy boxed wine	4	decent	
-1006	adequate diet shaking upside-down cherry	1	good	
+1006	diet adequate shaking upside-down cherry	1	good	
 1007	blurry dance instructor's coconut shell	0		Experience Percent (Moxie): +10, Familiar Effect: "1xFairy, cap 7"
 1008	narrow wizardly ice cubes	0		Mysticality: +25
 1009	weak tolerable huge vodka martini	2	good	
 1010	tolerable whiskey and soda	3	good	
-1011	mediocre irresponsibly strong wobbly monkey wrench	6	decent	
-1012	weak delicious bouncing tequila sunrise	2	awesome	
+1011	irresponsibly strong mediocre wobbly monkey wrench	6	decent	
+1012	delicious weak bouncing tequila sunrise	2	awesome	
 1013	weak acceptable margarita	2	good	
 1014	high-proof bad strawberry wine	10	decent	
-1015	special aged wine spritzer	3	awesome	Effect: "Cringle's Curative Carol", Effect Duration: 20
-1016	perfectly mixed high-proof special spinning perpendicular hula	8	EPIC	Effect: "20/20 Vision", Effect Duration: 10
-1017	enchanted acceptable watered-down ducha de oro	2	good	Effect: "New Zeal", Effect Duration: 30
+1015	aged special wine spritzer	3	awesome	Effect: "Cringle's Curative Carol", Effect Duration: 20
+1016	special high-proof perfectly mixed spinning perpendicular hula	8	EPIC	Effect: "20/20 Vision", Effect Duration: 10
+1017	watered-down acceptable enchanted ducha de oro	2	good	Effect: "New Zeal", Effect Duration: 30
 1018	acceptable calle de miel	3	good	
 1019	artisanal irresponsibly strong shaking dry vodka martini	8	EPIC	
 1020	delicious maroon old-fashioned	3	awesome	
-1021	smooth special tequila with training wheels	4	awesome	Effect: "Stands Alone", Effect Duration: 30
+1021	special smooth tequila with training wheels	4	awesome	Effect: "Stands Alone", Effect Duration: 30
 1022	lousy weak sangria	2	decent	
 1023	tolerable vesper	3	good	Last Available: "2004-12"
 1024	smooth upside-down bodyslam	4	awesome	Last Available: "2004-12"
 1025	acceptable sangria del diablo	4	good	Last Available: "2004-12"
-1026	upside-down jittery olive Valentine	0		Free Pull
+1026	olive jittery upside-down Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
 1029	brainy hippo whip	0		Mysticality: +5
@@ -1024,7 +1024,7 @@
 1037	ghostly careful gnauga hide buckler	0		Monster Level: -10, Damage Reduction: 5
 1038	energized colloidal Connery's Elixir of Audacity	0		Effect: "Crotchety, Pining", Effect Duration: 26
 1040	jittery skewed Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	lousy boozy beer	5	decent	
+1041	boozy lousy beer	5	decent	
 1042	veiny string of beads	0		Maximum HP: +10
 1043	Van der Graaf string of beads	0		MP Regen Min: 5, MP Regen Max: 7
 1044	shaking vibrating string of beads	0		Maximum MP Percent: +10
@@ -1048,14 +1048,14 @@
 1062	diluted blurry mauve oyster egg	1		
 1063	squat mauve plastic oyster egg	0		
 1064	denatured skewed oyster egg	1		Effect: "Fruited", Effect Duration: 5
-1065	dried purple jittery spinning oyster egg	1		
+1065	dried spinning jittery purple oyster egg	1		
 1066	modified ghostly oyster egg	1		
 1067	plastic oyster egg	0		
 1068	powdered mirror oyster egg	1		
 1069	compressed oyster egg	1		
 1070	dehydrated jittery oyster egg	1		Effect: "A Contender", Effect Duration: 20
 1071	mirror plastic oyster egg	0		
-1072	modified red blinking off-white oyster egg	1		
+1072	modified blinking red off-white oyster egg	1		
 1073	distilled skewed off-white oyster egg	1		
 1074	vaporized upside-down off-white oyster egg	1		Effect: "Donho's Bubbly Ballad", Effect Duration: 35
 1075	twirling off-white plastic oyster egg	0		
@@ -1070,7 +1070,7 @@
 1084	blue spinning rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	clockwork widget	0		
 1086	clockwork thingamajig	0		
-1087	upside-down ghostly upside-down clockwork doohickey	0		
+1087	ghostly upside-down upside-down clockwork doohickey	0		
 1088	clockwork clockwise dome	0		
 1089	tumbling clockwork spine	0		
 1090	clockwork rings	0		
@@ -1094,7 +1094,7 @@
 1108	spinning clockwork detective skull	0		
 1109	clockwork bartender-head-in-the-box	0		
 1110	red clockwork chef-head-in-the-box	0		
-1111	upside-down skewed clockwork bartender-in-the-box	0		
+1111	skewed upside-down clockwork bartender-in-the-box	0		
 1112	blurry clockwork chef-in-the-box	0		
 1113	clockwork maid	0		
 1114	mirror tisket	0		
@@ -1107,7 +1107,7 @@
 1121	inexplicably rock	0		
 1122	skewed fairy gravy	0		
 1123	blue knitted halfberd	0		Cold Resistance: +3
-1124	bouncing lime green small glove	0		
+1124	lime green bouncing small glove	0		
 1125	stanky rock-hard glove of extreme caution	0		Damage Reduction: 5, Monster Level: -25, Stench Spell Damage: +25
 1126	Annie Oakley's toothpick	0		Critical Hit Percent: +20, Single Equip
 1127	rock-hard ninja sword	0		Damage Reduction: 5
@@ -1123,7 +1123,7 @@
 1137	rosewater-soaked bicycle chain of wisdom	0		Mysticality: +15, Stench Resistance: +3
 1138	mushroom fermenting solution	0		
 1139	acceptable watered-down shaking mushroom wine	2	good	
-1140	tolerable watered-down narrow icy mushroom wine	2	good	
+1140	watered-down tolerable narrow icy mushroom wine	2	good	
 1141	watered-down drinkable mushroom wine	2	good	
 1142	artisanal red pointy mushroom wine	4	EPIC	
 1143	weak acceptable flat mushroom wine	2	good	
@@ -1136,7 +1136,7 @@
 1150	perfectly mixed bottle of single-barrel whiskey	4	EPIC	
 1151	upside-down energetic dangerous discarded plastic fork	0		Weapon Damage: +10, Maximum MP Percent: +20
 1152	blue gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	delicious super-sized Retenez L'Herbe Pat&eacute;	5	awesome	
+1153	super-sized delicious Retenez L'Herbe Pat&eacute;	5	awesome	
 1154	denatured Breathetastic&trade; Premium Canned Air	1	crappy	
 1155	cyan letter from King Ralph XI	0		
 1157	clever wholeberd	0		Maximum MP: +20
@@ -1155,7 +1155,7 @@
 1170	chocolate box	0		
 1171	coffin	0		
 1172	asbestos box	0		
-1173	tumbling skewed linoleum box	0		
+1173	skewed tumbling linoleum box	0		
 1174	chrome box	0		
 1175	cryptic puzzle box	0		
 1176	narrow refrigerated biohazard container	0		
@@ -1179,19 +1179,19 @@
 1194	stab bat	0		
 1195	apathetic lizardman doll	0		
 1196	twirling yeti	0		
-1197	bouncing gray Mob Penguin	0		
+1197	gray bouncing Mob Penguin	0		
 1198	mirror mirror sabre-toothed lime	0		
 1199	bugbear	0		
-1200	normal half-sized special spinning mugcake	2	good	Effect: "Salamander In Your Stomach", Effect Duration: 10
+1200	special normal half-sized spinning mugcake	2	good	Effect: "Salamander In Your Stomach", Effect Duration: 10
 1201	normal urinal cake	3	good	
 1202	adequate Happy Birthday, Claude! cake	3	good	
 1203	rotten personalized birthday cake	4	crappy	
 1204	bland three-tiered wedding cake	3	decent	
-1205	enchanted snack-sized rotten babycakes	2	crappy	Effect: "Sweet Taste", Effect Duration: 10
+1205	rotten enchanted snack-sized babycakes	2	crappy	Effect: "Sweet Taste", Effect Duration: 10
 1206	rotten velvet cake	3	crappy	
 1207	flavorless congratulatory cake	3	decent	
-1208	rotten tiny angel-food cake	1	crappy	
-1209	moldy special yellow devil's-food cake	4	crappy	Effect: "Slimily Strong", Effect Duration: 40
+1208	tiny rotten angel-food cake	1	crappy	
+1209	special moldy yellow devil's-food cake	4	crappy	Effect: "Slimily Strong", Effect Duration: 40
 1210	bland squat birthday party jellybean cheesecake	3	decent	
 1211	tumbling balloon	0		
 1212	bouncing balloon	0		
@@ -1200,7 +1200,7 @@
 1215	upside-down Mylar balloon	0		
 1216	narrow Kevlar balloon	0		
 1217	thought balloon	0		
-1218	jittery teal rat head balloon	0		Familiar Weight: -3
+1218	teal jittery rat head balloon	0		Familiar Weight: -3
 1219	ghostly mini-zeppelin	0		
 1220	veiny Mr. Balloon	0		Maximum HP: +10
 1221	balloon	0		
@@ -1319,7 +1319,7 @@
 1335	jittery Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
 1338	Dyspepsi-Cola d-rations	0		
-1339	upside-down squat green Cloaca-Cola c-rations	0		
+1339	upside-down green squat Cloaca-Cola c-rations	0		
 1340	fuchsia Cloaca-Cola-issue combat knife	0		
 1341	Dyspepsi-Cola-issue canteen of the boozehound	0		Booze Drop: +100, Single Equip
 1342	picture of a dead guy's girlfriend	0		
@@ -1328,16 +1328,16 @@
 1345	liquefied squat Now and Earlier	0		Effect: "The Strength...  of the Future", Effect Duration: 19, Last Available: "2020-09"
 1346	activated Sugar Cog	0		Effect: "Can Has Cyborger", Effect Duration: 52
 1347	loaded serum blowgun	0		Last Available: "2005-11"
-1348	purple narrow wobbly empty blowgun	0		Last Available: "2005-11"
+1348	wobbly narrow purple empty blowgun	0		Last Available: "2005-11"
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	blurry 1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	blurry dangerous pinky ring	0		Weapon Damage: +10, Single Equip
 1352	watered-down mediocre bouncing redrum	2	decent	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	rotten low-calorie blinking narrow bowl of oriole's nest soup	1	crappy	
-1356	wobbly yellow bunny liver	0		
-1357	irresponsibly strong fancy drinkable Mt. Noob Pale Ale	10	good	Effect: "Yes, Can Haz", Effect Duration: 30
+1355	rotten low-calorie narrow blinking bowl of oriole's nest soup	1	crappy	
+1356	yellow wobbly bunny liver	0		
+1357	irresponsibly strong drinkable fancy Mt. Noob Pale Ale	10	good	Effect: "Yes, Can Haz", Effect Duration: 30
 1358	blinking pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	ghostly pirate zombie robot head	0		Last Available: "2005-11"
@@ -1361,9 +1361,9 @@
 1378	plastic sweet nutcracker of bravery	0		Spooky Resistance: +5, Last Available: "2005-12"
 1379	shaking plastic Crimbo reindeer of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2005-12"
 1381	lime green aspirin	0		Last Available: "2005-12"
-1382	quantum polarized ghostly pulsating chocolate	0		Effect: "Paging Betty", Effect Duration: 31, Last Available: "2015-11"
+1382	quantum polarized pulsating ghostly chocolate	0		Effect: "Paging Betty", Effect Duration: 31, Last Available: "2015-11"
 1383	fuchsia length of string	0		
-1384	shaking fuchsia googly eye	0		
+1384	fuchsia shaking googly eye	0		
 1385	stuffing	0		
 1386	felt	0		
 1387	block	0		
@@ -1385,8 +1385,8 @@
 1403	stiffened can of fake snow	0		Damage Reduction: 1, Last Available: "2005-12"
 1404	prompt colored-light &quot;necklace&quot;	0		Adventures: +3, Last Available: "2005-12"
 1405	energetic tree skirt	0		Maximum MP Percent: +20, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
-1406	normal huge wreath-shaped Crimbo cookie	10	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	miniature moldy bell-shaped Crimbo cookie	2	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1406	huge normal wreath-shaped Crimbo cookie	10	good	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1407	moldy miniature bell-shaped Crimbo cookie	2	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	stale tree-shaped Crimbo cookie	3	decent	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	Unionize The Elves sign of the businessman	0		Meat Drop: +50, Last Available: "2005-12"
 1410	sleeping snowy owl	0		Last Available: "2005-12"
@@ -1395,8 +1395,8 @@
 1413	tarnished adjusted snowcone	0		Effect: "Headstrong", Effect Duration: 11, Last Available: "2006-01"
 1414	diffused quantum snowcone	0		Effect: "Devil Inside", Effect Duration: 20, Last Available: "2006-01"
 1415	diffused magnetized narrow snowcone	0		Effect: "Total Protonic Reversal", Effect Duration: 60, Last Available: "2006-01"
-1416	double-denatured lime green tumbling mirror snowcone	0		Effect: "Crimbo Epiphany", Effect Duration: 25, Last Available: "2006-01"
-1417	frozen concentrated gray tumbling snowcone	0		Effect: "Strength of Ten Ettins", Effect Duration: 17, Last Available: "2006-01"
+1416	double-denatured mirror tumbling lime green snowcone	0		Effect: "Crimbo Epiphany", Effect Duration: 25, Last Available: "2006-01"
+1417	frozen concentrated tumbling gray snowcone	0		Effect: "Strength of Ten Ettins", Effect Duration: 17, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
 1420	shaking traffic cone of the sewer of temperance	0		Stench Damage: +25, Sleaze Resistance: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
@@ -1411,7 +1411,7 @@
 1429	roll of drink tickets	0		
 1430	squat pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
-1432	super-sized stale mushroom	5	decent	
+1432	stale super-sized mushroom	5	decent	
 1433	fruit bowl	0		
 1434	cyan fruit basket	0		
 1435	mirror hot pink lipstick	0		Familiar Weight: +5
@@ -1475,7 +1475,7 @@
 1493	dog trainer's slick ridiculously overelaborate ninja weapon	0		Moxie: +10, Experience (familiar): +1
 1494	electrified sugar-coated pine cone	0		Effect: "Highland Sheen", Effect Duration: 40, Last Available: "2020-09"
 1495	toasty healthy traffic cone	0		Maximum HP Percent: +20, Hot Damage: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
-1496	boozy artisanal fancy gloomy mushroom wine	5	EPIC	Effect: "Bonelording", Effect Duration: 10
+1496	fancy artisanal boozy gloomy mushroom wine	5	EPIC	Effect: "Bonelording", Effect Duration: 10
 1497	watered-down hand-crafted mushroom wine	2	super EPIC	
 1498	squat McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
@@ -1487,8 +1487,8 @@
 1505	lime green ice cube with a fly in it	0		Last Available: "2006-04"
 1506	watered-down drinkable calle de miel with a fly in it	2	good	Last Available: "2006-04"
 1507	weak bad rockin' wagon with a fly in it	2	decent	Last Available: "2006-04"
-1508	spirit-forward bad perpendicular hula with a fly in it	5	decent	Last Available: "2006-04"
-1509	distilled hand-crafted narrow slap and tickle with a fly in it	5	EPIC	Last Available: "2006-04"
+1508	bad spirit-forward perpendicular hula with a fly in it	5	decent	Last Available: "2006-04"
+1509	hand-crafted distilled narrow slap and tickle with a fly in it	5	EPIC	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	ruddy fake hand	0		Maximum HP Percent: +40, Last Available: "2006-04"
 1512	mixed red Knob Goblin pet-buffing spray	1		
@@ -1503,7 +1503,7 @@
 1522	censurious cool Radio Free Jersey	0		Moxie: +5, Sleaze Resistance: +3
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	narrow joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1525	narrow joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	shaking corkscrew of the brute of the scaredy-cat	0		Muscle Percent: +30, Monster Level: -15, Last Available: "2006-04"
@@ -1532,8 +1532,8 @@
 1552	acceptable practically non-alcoholic special jittery bottle of Definit	1	good	Effect: "Cheered Up", Effect Duration: 30
 1553	mediocre fuchsia bottle of Calcutta Emerald	3	decent	
 1554	artisanal bottle of Lieutenant Freeman	3	EPIC	
-1555	irresponsibly strong mediocre tumbling bottle of Jorge Sinsonte	7	decent	
-1556	acceptable strong boxed champagne	5	good	
+1555	mediocre irresponsibly strong tumbling bottle of Jorge Sinsonte	7	decent	
+1556	strong acceptable boxed champagne	5	good	
 1557	decent kumquat	3	good	
 1558	adequate tangerine	3	good	
 1559	ghostly tonic water	0		
@@ -1543,43 +1543,43 @@
 1563	acceptable watered-down blue whiskey bittersweet	2	good	
 1564	artisanal blinking mimosette	4	EPIC	
 1565	perfectly mixed lime green tequila sunset	3	EPIC	
-1566	special acceptable blurry zmobie	4	good	Effect: "Here to Kick Ass", Effect Duration: 30, Wiki Name: "Zmobie (drink)"
+1566	acceptable special blurry zmobie	4	good	Effect: "Here to Kick Ass", Effect Duration: 30, Wiki Name: "Zmobie (drink)"
 1567	acceptable fuchsia gin and tonic	3	good	
-1568	practically non-alcoholic lousy vodka and tonic	1	decent	
+1568	lousy practically non-alcoholic vodka and tonic	1	decent	
 1569	high-proof delicious vodka gibson	7	awesome	
 1570	smooth jittery gibson	3	awesome	
 1571	fortified bad parisian cathouse	5	decent	
 1572	artisanal triple-distilled rabbit punch	9	EPIC	
 1573	weak bad green blurry caipifruta	2	decent	
-1574	mediocre watered-down teqiwila	2	decent	
+1574	watered-down mediocre teqiwila	2	decent	
 1575	bad Divine	3	decent	
-1576	drinkable strong Gordon Bennett	5	good	
+1576	strong drinkable Gordon Bennett	5	good	
 1577	artisanal tangarita	3	EPIC	
-1578	tolerable strong mandarina colada	5	good	
-1579	fancy weak lousy spinning gimlet	2	decent	Effect: "Petit Force", Effect Duration: 20
-1580	special tolerable practically non-alcoholic brick road	1	good	Effect: "Marinated", Effect Duration: 50
-1581	watered-down aged vodka stratocaster	2	awesome	
+1578	strong tolerable mandarina colada	5	good	
+1579	weak lousy fancy spinning gimlet	2	decent	Effect: "Petit Force", Effect Duration: 20
+1580	tolerable practically non-alcoholic special brick road	1	good	Effect: "Marinated", Effect Duration: 50
+1581	aged watered-down vodka stratocaster	2	awesome	
 1582	aged Neuromancer	3	awesome	
-1583	practically non-alcoholic perfectly mixed prussian cathouse	1	super ultra mega turbo EPIC	
+1583	perfectly mixed practically non-alcoholic prussian cathouse	1	super ultra mega turbo EPIC	
 1584	aged practically non-alcoholic Mae West	1	awesome	
-1585	irresponsibly strong acceptable Mon Tiki	8	good	
+1585	acceptable irresponsibly strong Mon Tiki	8	good	
 1586	acceptable bouncing teqiwila slammer	3	good	
 1587	stale olive Knob lo mein	4	decent	
-1588	spoiled enchanted snack-sized blinking spinning asparagus lo mein	2	crappy	Effect: "Poker Faced", Effect Duration: 50
-1589	rotten miniature special twirling wobbly Knoll lo mein	2	crappy	Effect: "Egg-headedness", Effect Duration: 5
+1588	enchanted spoiled snack-sized spinning blinking asparagus lo mein	2	crappy	Effect: "Poker Faced", Effect Duration: 50
+1589	special rotten miniature wobbly twirling Knoll lo mein	2	crappy	Effect: "Egg-headedness", Effect Duration: 5
 1590	decent huge lo mein	3	good	
-1591	huge spoiled olive lo mein	10	crappy	
+1591	spoiled huge olive lo mein	10	crappy	
 1592	rotten hot hi mein	3	crappy	
-1593	moldy upside-down red hi mein	3	crappy	
-1594	normal special hi mein	4	good	Effect: "Liquid Luck", Effect Duration: 40
+1593	moldy red upside-down hi mein	3	crappy	
+1594	special normal hi mein	4	good	Effect: "Liquid Luck", Effect Duration: 40
 1595	normal blue hi mein	3	good	
 1596	delicious sleazy hi mein	3	awesome	
 1597	green Junior LAAAAME merit badge of bravery	0		Spooky Resistance: +5, Last Available: "2006-05"
 1598	Herculean Senior LAAAAME merit badge	0		Experience (Muscle): +1, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	hand-crafted weak tangarita with a fly in it	2	EPIC	
+1600	weak hand-crafted tangarita with a fly in it	2	EPIC	
 1601	mediocre blue mandarina colada with a fly in it	3	decent	
-1602	perfectly mixed watered-down prussian cathouse with a fly in it	2	EPIC	
+1602	watered-down perfectly mixed prussian cathouse with a fly in it	2	EPIC	
 1603	artisanal pulsating Mae West with a fly in it	4	EPIC	
 1604	altered gray jittery astronaut ice-cream	1		Effect: "Funky Coal Patina", Effect Duration: 5, Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1613,16 +1613,16 @@
 1633	red Spanish fly	0		
 1634	weak aged around the world	2	awesome	
 1635	scrumdiddlyumptious solution	0		
-1636	narrow tumbling yellow Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
+1636	yellow tumbling narrow Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	boiled blurry lotion of hotness	0		Effect: "Tightly-Wound Spine", Effect Duration: 40
 1638	ionized twirling lotion of coldness	0		Effect: "Frosty the Hitman", Effect Duration: 57
 1639	unsweetened lotion of spookiness	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 66
 1640	triple-galvanized lotion of stench	0		Effect: "Booooooze", Effect Duration: 55
 1641	ionized magnetized tarnished lotion of sleaziness	0		Effect: "Berry Berry Cold", Effect Duration: 50
-1642	mediocre practically non-alcoholic Grimacite Bock	1	decent	Last Available: "2008-11"
+1642	practically non-alcoholic mediocre Grimacite Bock	1	decent	Last Available: "2008-11"
 1643	rotten squat blue wedge of gray cheese	4	crappy	Last Available: "2008-11"
-1644	twirling skewed hot and sauce	0		
-1645	yellow shaking and sauce	0		
+1644	skewed twirling hot and sauce	0		
+1645	shaking yellow and sauce	0		
 1646	and sauce	0		
 1647	stench and sauce	0		
 1648	sleazy and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	milk of magnesium	0		
 1651	spoiled big bouncing foie gras	5	crappy	
 1652	magnetized oxidized candy brain	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 35, Last Available: "2020-09"
-1653	green electrified grievous savvy jewel-eyed wizard hat	0		Mysticality Percent: +20, Weapon Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07"
+1653	green electrified grievous savvy jewel-eyed wizard hat	0		Mysticality Percent: +20, Weapon Damage Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	jittery foul-smelling cool wad of Crovacite	0		Moxie: +5, Stench Damage: +10
 1655	red zippy studded collar	0		Damage Absorption: +80, Initiative: +20
 1656	pulsating White Citadel Satisfaction Satchel	0		
@@ -1673,12 +1673,12 @@
 1693	improved extra-vacuum-sealed eyedrops of newt	0		Effect: "Twinklebritches", Effect Duration: 35
 1694	corrupted non-warmed non-moist Frogade	0		Effect: "Salty Mouth", Effect Duration: 30
 1695	dry warmed Vulcanized pulsating papotion of papower	0		Effect: "Browbeaten", Effect Duration: 15
-1696	adequate super-sized lime green royal jelly taco	5	good	
+1696	super-sized adequate lime green royal jelly taco	5	good	
 1697	normal tofu taco	3	good	
-1698	gigantic normal jittery jumping bean taco	7	good	
+1698	normal gigantic jittery jumping bean taco	7	good	
 1699	toothsome low-calorie catgut taco	1	awesome	
 1700	super-sized normal goat cheese taco	5	good	
-1701	moldy huge pr0n taco	7	crappy	
+1701	huge moldy pr0n taco	7	crappy	
 1702	polarized fuchsia skewed alphabet gum	0		Effect: "Industrial Strength Starch", Effect Duration: 56
 1703	ghostly Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1791,27 +1791,27 @@
 1812	fourth thoracic vertebra	0		
 1813	narrow fifth thoracic vertebra	0		
 1814	wobbly sixth thoracic vertebra	0		
-1815	shaking narrow seventh thoracic vertebra	0		
+1815	narrow shaking seventh thoracic vertebra	0		
 1816	skewed eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
 1818	tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
-1820	mirror huge twelfth thoracic vertebra	0		
+1820	huge mirror twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
 1822	second lumbar vertebra	0		
 1823	upside-down third lumbar vertebra	0		
-1824	bouncing jittery fourth lumbar vertebra	0		
+1824	jittery bouncing fourth lumbar vertebra	0		
 1825	ghostly fifth lumbar vertebra	0		
 1826	sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
 1829	first caudal vertebra	0		
-1830	narrow blue second caudal vertebra	0		
+1830	blue narrow second caudal vertebra	0		
 1831	twirling third caudal vertebra	0		
 1832	upside-down fourth caudal vertebra	0		
 1833	upside-down fifth caudal vertebra	0		
 1834	sixth caudal vertebra	0		
-1835	twirling upside-down purple seventh caudal vertebra	0		
+1835	upside-down purple twirling seventh caudal vertebra	0		
 1836	eighth caudal vertebra	0		
 1837	blinking ninth caudal vertebra	0		
 1838	lime green tenth caudal vertebra	0		
@@ -1821,13 +1821,13 @@
 1842	left fourth rib	0		
 1843	left fifth rib	0		
 1844	shaking olive left sixth rib	0		
-1845	green ghostly left seventh rib	0		
+1845	ghostly green left seventh rib	0		
 1846	narrow left eighth rib	0		
 1847	left ninth rib	0		
 1848	blurry left tenth rib	0		
 1849	left eleventh rib	0		
-1850	pulsating skewed narrow left twelfth rib	0		
-1851	huge upside-down right first rib	0		
+1850	skewed narrow pulsating left twelfth rib	0		
+1851	upside-down huge right first rib	0		
 1852	cyan upside-down right second rib	0		
 1853	right third rib	0		
 1854	right fourth rib	0		
@@ -1841,11 +1841,11 @@
 1862	right twelfth rib	0		
 1863	animal pelvis	0		
 1864	left scapula	0		
-1865	pulsating ghostly right scapula	0		
+1865	ghostly pulsating right scapula	0		
 1866	left clavicle	0		
 1867	squat right clavicle	0		
 1868	left humerus	0		
-1869	blinking wobbly right humerus	0		
+1869	wobbly blinking right humerus	0		
 1870	twirling cyan left radius	0		
 1871	right radius	0		
 1872	left ulna	0		
@@ -1855,7 +1855,7 @@
 1876	left tibia	0		
 1877	right tibia	0		
 1878	left fibula	0		
-1879	blurry huge right fibula	0		
+1879	huge blurry right fibula	0		
 1880	left kneecap	0		
 1881	right kneecap	0		
 1882	left first front claw	0		
@@ -1868,7 +1868,7 @@
 1889	skewed right fourth front claw	0		
 1890	maroon left thumb	0		
 1891	right thumb	0		
-1892	maroon ghostly left first rear claw	0		
+1892	ghostly maroon left first rear claw	0		
 1893	shaking left second rear claw	0		
 1894	left third rear claw	0		
 1895	red left fourth rear claw	0		
@@ -1896,7 +1896,7 @@
 1919	English to A. F. U. E. Dictionary	0		
 1920	teal bizarre illegible sheet music	0		
 1921	friendly wakizashi	0		Familiar Weight: +3
-1922	narrow tumbling gob of wet hair	0		
+1922	tumbling narrow gob of wet hair	0		
 1923	blurry roll of toilet paper	0		Free Pull
 1924	tattered wolf standard	0		
 1925	spinning tattered snake standard	0		
@@ -1930,13 +1930,13 @@
 1953	mediocre practically non-alcoholic flute of flat champagne	1	decent	
 1954	toothsome dehydrated caviar	3	awesome	
 1955	styrofoam peanuts	0		
-1956	fancy lousy skewed snifter of thoroughly aged brandy	3	decent	Effect: "Human-Fish Hybrid", Effect Duration: 20
+1956	lousy fancy skewed snifter of thoroughly aged brandy	3	decent	Effect: "Human-Fish Hybrid", Effect Duration: 20
 1957	quill pen	0		
 1958	bouncing inkwell	0		
 1959	mirror yellow tattered scrap of paper	0		
 1960	scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
-1962	tarnished nitrogenated double-boiled red spinning Bit O' Ectoplasm	0		Effect: "Riboflavin'", Effect Duration: 36
+1962	tarnished nitrogenated double-boiled spinning red Bit O' Ectoplasm	0		Effect: "Riboflavin'", Effect Duration: 36
 1963	dance card	0		
 1964	censurious opera mask	0		Sleaze Resistance: +3, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
 1965	bottle of Monsieur Bubble	0		
@@ -1955,7 +1955,7 @@
 1978	green gravy fairy	0		
 1979	gravy fairy	0		
 1980	sleazy gravy fairy	0		
-1981	maroon narrow astral badger	0		
+1981	narrow maroon astral badger	0		
 1982	upside-down MagiMechTech MicroMechaMech	0		
 1983	bouncing hand turkey	0		
 1984	snowy owl	0		
@@ -1996,12 +1996,12 @@
 2019	cream pie	0		Free Pull
 2020	jumbo spoiled skewed cherry pie	5	crappy	
 2021	stale strawberry pie	4	decent	
-2022	bite-sized bland lemon meringue pie	1	decent	
+2022	bland bite-sized lemon meringue pie	1	decent	
 2023	Genalen&trade; Bottle	1	decent	
 2024	flavorless mixed wildflower greens	3	decent	
 2025	gigantic spoiled handful of walnuts	10	crappy	
-2026	stale low-calorie special nutty organic salad	1	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 25
-2027	decent small super salad	2	good	
+2026	stale special low-calorie nutty organic salad	1	decent	Effect: "Inigo's Incantation of Inspiration", Effect Duration: 25
+2027	small decent super salad	2	good	
 2028	adequate tofu wonton	3	good	
 2029	hippy protest button	0		Single Equip
 2030	huge scandalous groovy Lockenstock&trade; sandals	0		Moxie Percent: +10, Sleaze Damage: +5, Single Equip
@@ -2019,24 +2019,24 @@
 2042	exploding hacky-sack	0		
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	yummy low-calorie brain-meltingly-hot chicken wings	1	awesome	
+2045	low-calorie yummy brain-meltingly-hot chicken wings	1	awesome	
 2046	spoiled frat brats	4	crappy	
-2047	bland tiny knob ka-bobs	1	decent	
+2047	tiny bland knob ka-bobs	1	decent	
 2049	tolerable can of Swiller	3	good	
-2050	shaking wobbly broken wings	0		
+2050	wobbly shaking broken wings	0		
 2051	huge sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
 2055	snake skin	0		
-2056	corrupted shaking ghostly adder bladder	0		Effect: "Electrolit Up", Effect Duration: 30
+2056	corrupted ghostly shaking adder bladder	0		Effect: "Electrolit Up", Effect Duration: 30
 2057	huge narrow pension check	0		
 2058	picnic basket	0		
 2059	extra-altered pickled Black No. 2	0		Effect: "Blubbered Up", Effect Duration: 39
 2060	ghostly Usain Bolt's groovy sword	0		Moxie Percent: +10, Initiative: +80
 2061	sharpshooter's helmet	0		Critical Hit Percent: +10, Familiar Effect: "1xFairy, cap 40"
 2062	savvy shield of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Damage Reduction: 10
-2063	miniature moldy blackberry	2	crappy	
+2063	moldy miniature blackberry	2	crappy	
 2064	forged identification documents	0		
 2065	bouncing PADL Phone	0		
 2066	knitted chaotic kick-ass kicks	0		Spell Critical Percent: +10, Cold Resistance: +3, Single Equip
@@ -2060,20 +2060,20 @@
 2084	can of starch	0		
 2085	pickled bottle of ultravitamins	1		
 2086	vaporized purple narrow bottle of cough syrup	1		
-2087	powdered mirror blinking tube of hair oil	1		
+2087	powdered blinking mirror tube of hair oil	1		
 2088	extra-magnetized triple-improved upside-down upside-down Daffy Taffy	0		Effect: "Spiky Frozen Hair", Effect Duration: 33
 2089	upside-down Crimboween memo	0		Last Available: "2006-10"
 2090	purple medical-grade supercool pilgrim shield of the wise owl of terror of the detective	0		Mysticality: +20, Moxie Percent: +20, Spooky Spell Damage: +10, Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
 2092	mirror hand mirror	0		
 2093	rosewater-soaked hors d'oeuvre tray	0		Stench Resistance: +3, Damage Reduction: 5
-2094	small decent ballroom blintz	2	good	
+2094	decent small ballroom blintz	2	good	
 2095	red towel	0		
 2096	boiled blurry guy made of bee pollen	1		
 2097	twirling dance instructor's 17-ball	0		Experience Percent (Moxie): +10
 2098	filthy lucre	0		
 2099	hobo gristle	0		
-2100	purple mirror narrow shredded can label	0		
+2100	narrow mirror purple shredded can label	0		
 2101	bloodstained briquette	0		
 2102	yellow greasy dreadlock	0		
 2103	narrow vial of pirate sweat	0		
@@ -2082,10 +2082,10 @@
 2106	burned-out arcanodiode	0		
 2107	non-Euclidean hoof	0		
 2108	rock	0		
-2109	skewed red wobbly stringy sinew	0		Last Available: "2011-12"
+2109	red skewed wobbly stringy sinew	0		Last Available: "2011-12"
 2110	stick	0		Last Available: "2011-12"
 2111	bouncing tooth	0		
-2112	lime green ghostly leaf	0		Last Available: "2011-12"
+2112	ghostly lime green leaf	0		Last Available: "2011-12"
 2113	wheel of the storm	0		Maximum MP Percent: +40, Last Available: "2006-12"
 2114	spinning yo	0		Last Available: "2006-12"
 2115	mirror executive prehistoric spear	0		Meat Drop: +40, Last Available: "2006-12"
@@ -2132,7 +2132,7 @@
 2157	spinning high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	tumbling quantum polarity inducer	0		Last Available: "2011-12"
-2160	cyan twirling skewed bi-lateral logic compressor	0		Last Available: "2011-12"
+2160	twirling skewed cyan bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
@@ -2166,9 +2166,9 @@
 2191	shaking book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
 2193	normal tiny skewed candy stake	1	good	Last Available: "2006-12"
-2194	artisanal weak eggnog	2	EPIC	Last Available: "2006-12"
-2195	decent enchanted unspeakable fruitcake	3	good	Effect: "Limber as Mortimer", Effect Duration: 15, Last Available: "2006-12"
-2196	tiny adequate spinning squat pulsating gingerbread horror	1	good	Last Available: "2006-12"
+2194	weak artisanal eggnog	2	EPIC	Last Available: "2006-12"
+2195	enchanted decent unspeakable fruitcake	3	good	Effect: "Limber as Mortimer", Effect Duration: 15, Last Available: "2006-12"
+2196	adequate tiny pulsating spinning squat gingerbread horror	1	good	Last Available: "2006-12"
 2197	unsweetened but probably evil chocolate	0		Effect: "Weather, Man", Effect Duration: 69, Last Available: "2006-12"
 2198	stale bat-shaped Crimboween cookie	4	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	tasty skull-shaped Crimboween cookie	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
@@ -2189,8 +2189,8 @@
 2214	jittery tropical wrapping paper	0		Last Available: "2006-12"
 2215	resourceful Tropical Crimbo Hat	0		Maximum MP: +50, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	olive stylish Tropical Crimbo Shorts	0		Moxie: +25, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	rotten diet super ka-bob	1	crappy	
-2218	stale miniature beer basted brat	2	decent	
+2217	diet rotten super ka-bob	1	crappy	
+2218	miniature stale beer basted brat	2	decent	
 2219	squat Tropical Crimbo Sword of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-12"
 2220	wet modified and Crimboween candy	0		Effect: "Human-Plant Hybrid", Effect Duration: 20, Last Available: "2020-09"
 2221	twirling Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2272,10 +2272,10 @@
 2298	boock of darck magicks	0		
 2299	skewed EZ-Play Harmonica Book	0		
 2300	skewed fingerless hobo gloves	0		
-2301	ghostly maroon Chomsky's comic books	0		
+2301	maroon ghostly Chomsky's comic books	0		
 2302	worm-riding hooks	0		
 2303	narrow Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
-2304	anodized moist ghostly blinking candy heart	0		Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2007-02"
+2304	anodized moist blinking ghostly candy heart	0		Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2007-02"
 2305	denatured ionized twirling pink candy heart	0		Effect: "Amplified Fabulousness", Effect Duration: 11, Last Available: "2007-02"
 2306	frozen candy heart	0		Effect: "Insulated Trousers", Effect Duration: 15, Last Available: "2007-02"
 2307	ionized candy heart	0		Effect: "Carol of the Bones", Effect Duration: 49, Last Available: "2007-02"
@@ -2284,12 +2284,12 @@
 2310	bouncing candygram	0		Last Available: "2007-02"
 2311	pink candygram	0		Last Available: "2007-02"
 2312	jittery candygram	0		Last Available: "2007-02"
-2313	yellow blinking candygram	0		Last Available: "2007-02"
+2313	blinking yellow candygram	0		Last Available: "2007-02"
 2314	candygram	0		Last Available: "2007-02"
-2315	skewed tumbling candygram	0		Last Available: "2007-02"
+2315	tumbling skewed candygram	0		Last Available: "2007-02"
 2316	broken carburetor	0		
 2317	bronze token	0		
-2318	red spinning tumbling bomb	0		
+2318	tumbling spinning red bomb	0		
 2319	carved wheel	0		
 2320	worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
@@ -2310,8 +2310,8 @@
 2336	Socratic pipe of courage	0		Experience (Mysticality): +1, Spooky Resistance: +3
 2337	ghostly wizardly reinforced beaded headband	0		Mysticality: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	miniature spoiled pudding	2	crappy	Wiki Name: "black pudding (food)"
-2339	perfectly mixed practically non-alcoholic pulsating Blackfly Chardonnay	1	EPIC	
-2340	practically non-alcoholic mediocre & tan	1	decent	
+2339	practically non-alcoholic perfectly mixed pulsating Blackfly Chardonnay	1	EPIC	
+2340	mediocre practically non-alcoholic & tan	1	decent	
 2341	pepper	0		
 2342	normal forest cake	3	good	
 2343	big adequate forest ham	5	good	
@@ -2346,10 +2346,10 @@
 2372	shaking bunch of bananas	0		
 2373	normal low-calorie banana	1	good	
 2374	banana peel	0		
-2375	flavorless thick banana cream pie	5	decent	
+2375	thick flavorless banana cream pie	5	decent	
 2376	watered-down lousy banana daiquiri	2	decent	
 2377	artisanal irresponsibly strong bungle in the jungle	10	EPIC	
-2378	blurry yellow banana spritzer	0		
+2378	yellow blurry banana spritzer	0		
 2379	tarnished warmed banana smoothie	0		Effect: "Bone Chilling", Effect Duration: 34
 2380	lime green dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
@@ -2375,7 +2375,7 @@
 2401	olive reassuring fireproof beer bong	0		Hot Resistance: +3, Spooky Resistance: +1
 2402	spinning gauze garter	0		
 2403	barrel of gunpowder	0		
-2404	huge blurry purple jam band flyers	0		
+2404	blurry purple huge jam band flyers	0		
 2405	rock band flyers	0		
 2406	wobbly Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	pink bat eye	0		
@@ -2384,13 +2384,13 @@
 2410	rag	0		
 2411	broken petri dish	0		
 2412	sammich crust	0		
-2413	bouncing shaking triffid bark	0		
+2413	shaking bouncing triffid bark	0		
 2414	lint	0		
 2415	squat discarded pacifier	0		
 2416	brainy bounty-hunting helmet	0		Mysticality: +5, Familiar Effect: "1.5xFairy, cap 25"
 2417	censurious bounty-hunting rifle	0		Sleaze Resistance: +3
 2418	twirling ruddy bounty-hunting pants	0		Maximum HP Percent: +40, Familiar Effect: "1xPotato, 2xFairy, cap 25"
-2419	energized twirling blurry bottle of rhinoceros hormones	0		Effect: "Innately Wise", Effect Duration: 69
+2419	energized blurry twirling bottle of rhinoceros hormones	0		Effect: "Innately Wise", Effect Duration: 69
 2420	galvanized alkaline teeny-tiny magic scroll	0		Effect: "Itchy Trigger Finger", Effect Duration: 45
 2421	tarnished pickled shaking bottle of pirate juice	0		Effect: "Become Intensely interested", Effect Duration: 67
 2422	vacuum-sealed irradiated pet snacks	0		Effect: "Rain Dancin'", Effect Duration: 57
@@ -2398,7 +2398,7 @@
 2424	ionized blurry cyclops eyedrops	0		Effect: "Block-Rockin' Beet", Effect Duration: 28
 2425	Vulcanized teal can of spinach	0		Effect: "So Fresh and So Clean", Effect Duration: 55
 2426	corrupted improved ghostly fire flower	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 14
-2427	electrified narrow fuchsia freezerburned ice cube	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 13
+2427	electrified fuchsia narrow freezerburned ice cube	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 13
 2428	cold-filtered fake blood	0		Effect: "Once Bitten Twice Fried", Effect Duration: 50
 2429	triple-vacuum-sealed quantum Eau de Guaneau	0		Effect: "Seeing Colors", Effect Duration: 15
 2430	tarnished anodized bag of lard	0		Effect: "Greasy Flavor", Effect Duration: 40
@@ -2413,9 +2413,9 @@
 2439	narrow shaking poltergeist-in-the-jar-o	0		
 2440	narrow unnatural gas	0		
 2441	Knob Goblin Encryption Key	0		
-2442	bouncing squat Cobb's Knob map	0		
+2442	squat bouncing Cobb's Knob map	0		
 2443	frightening wholesome pink glowstick	0		Maximum HP Percent: +10, Spooky Damage: +5, Last Available: "2007-03"
-2444	weak tolerable Supernova Champagne	2	good	
+2444	tolerable weak Supernova Champagne	2	good	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	spinning bad penguin egg	0		Free Pull
@@ -2474,7 +2474,7 @@
 2501	molybdenum crescent wrench	0		
 2502	tumbling Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	extra-fancy ring setting	0		
-2504	fuchsia blurry precious piercing post	0		
+2504	blurry fuchsia precious piercing post	0		
 2505	necklace chain	0		
 2506	beach glass bead	0		
 2507	ghostly clay peace-sign bead	0		
@@ -2491,19 +2491,19 @@
 2518	stiffened sawblade shield	0		Damage Reduction: 12
 2519	delicious upside-down McMillicancuddy's Special Lager	4	awesome	
 2520	tolerable melted Jell-o shot	4	good	
-2521	bad weak gray tumbling cruelty-free wine	2	decent	
-2522	triple-distilled smooth huge thistle wine	9	awesome	
+2521	bad weak tumbling gray cruelty-free wine	2	decent	
+2522	smooth triple-distilled huge thistle wine	9	awesome	
 2523	purple megatofu	0		
 2524	displaced fish	0		
 2525	moldy fish	4	crappy	
-2526	decent thick fish casserole	5	good	
+2526	thick decent fish casserole	5	good	
 2527	thick flavorless fish lasagna	5	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	adequate gnatloaf	3	good	
-2530	adequate blurry shaking lime green gnatloaf casserole	3	good	
+2530	adequate lime green blurry shaking gnatloaf casserole	3	good	
 2531	delicious green gnat lasagna	3	awesome	
 2532	jittery pork	0		
-2533	bland huge pork chop sandwiches	9	decent	
+2533	huge bland pork chop sandwiches	9	decent	
 2534	adequate snack-sized shaking pork casserole	2	good	
 2535	bland pork lasagna	3	decent	
 2536	canopic jar	0		
@@ -2549,7 +2549,7 @@
 2576	honey-dipped locust	0		
 2577	horrifying wholesome cactus quill	0		Maximum HP Percent: +10, Spooky Damage: +25
 2578	dog trainer's Staff of the Short Order Cook of the storm of Calamity Jane	0		Maximum MP Percent: +40, Critical Hit Percent: +15, Experience (familiar): +1
-2579	half-sized moldy cactus fruit	2	crappy	
+2579	moldy half-sized cactus fruit	2	crappy	
 2580	curative scorpion whip of mayonnaise	0		Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5
 2581	tumbling ghostly handful of sand	0		
 2582	gray brick of sand	0		
@@ -2559,11 +2559,11 @@
 2586	green skewed medical-grade General Sage's Lonely Diamonds Club Jacket	0		HP Regen Min: 7, HP Regen Max: 10
 2587	Corporal Fennel's Lonely Clubs Club Jacket of the storm	0		Maximum MP Percent: +40
 2588	Private Pepper's Lonely Hearts Club Jacket of the dark arts	0		Spell Damage Percent: +100
-2589	spoiled snack-sized hot date	2	crappy	
+2589	snack-sized spoiled hot date	2	crappy	
 2590	bad enchanted distilled fortified wine	3	decent	Effect: "Optimist Primal", Effect Duration: 25
 2591	flavorless tasty tart	3	decent	
 2592	Knob Goblin lunchbox	0		
-2593	normal gigantic Knob pasty	9	good	
+2593	gigantic normal Knob pasty	9	good	
 2594	practically non-alcoholic hand-crafted thermos full of Knob coffee	1	EPIC	
 2595	quantum Ben-Gal&trade; Balm	0		Effect: "Permafrosty", Effect Duration: 28
 2596	leathery cat skin	0		
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	squat rocky raccoon	0		
 2614	cyan mojo filter	0		
-2615	rotten lime green wobbly savoy truffle	4	crappy	
+2615	rotten wobbly lime green savoy truffle	4	crappy	
 2616	blinking Magi-Wipes	0		
 2617	boom	0		
 2618	Iiti Kitty phone charm of the cheetah	0		Initiative: +60, Single Equip
 2619	squat jar of swamp gas	0		Last Available: "2007-05"
-2620	yummy massive unidentified jerky	10	awesome	
+2620	massive yummy unidentified jerky	10	awesome	
 2621	miser's wool nasty rat mask	0		Cold Resistance: +1, Meat Drop: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	healthy baleful ratskin belt	0		Spell Damage: +25, Maximum HP Percent: +20, Single Equip
 2623	stiffened quilted rattail whip	0		Damage Absorption: +40, Damage Reduction: 1
@@ -2602,7 +2602,7 @@
 2629	fuchsia chilly tail o' nine cats of the detective	0		Cold Damage: +5, Item Drop: +20
 2630	Hugo's Weaving Manual	0		
 2631	polarized narrow gremlin juice	0		Effect: "Human-Fish Hybrid", Effect Duration: 21
-2632	vacuum-sealed altered skewed red mother's helper	0		Effect: "Hiding in Plain Sight", Effect Duration: 16
+2632	vacuum-sealed altered red skewed mother's helper	0		Effect: "Hiding in Plain Sight", Effect Duration: 16
 2633	stanky dance instructor's pat-a-cake pendant	0		Experience Percent (Moxie): +10, Stench Spell Damage: +25
 2634	mummy wrapping	0		
 2635	really thick bandage	0		
@@ -2623,15 +2623,15 @@
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	bland twirling S.T.L.T.	3	decent	Last Available: "2007-06"
-2653	snack-sized rotten jittery honey-dew	2	crappy	Last Available: "2007-06"
+2653	rotten snack-sized jittery honey-dew	2	crappy	Last Available: "2007-06"
 2654	acceptable lime green Xanadian	3	good	Last Available: "2007-06"
 2655	irradiated bottle of absinthe	0		Effect: "Uncaged Power", Effect Duration: 54, Last Available: "2007-06"
 2656	mirror personal trainer's Drowsy Sword of temperance	0		Experience Percent (Muscle): +10, Sleaze Resistance: +5
 2657	tasty blurry escargotsicle	4	awesome	Last Available: "2007-06"
-2658	practically non-alcoholic lousy mirror bottle of realpagne	1	decent	Last Available: "2007-06"
+2658	lousy practically non-alcoholic mirror bottle of realpagne	1	decent	Last Available: "2007-06"
 2659	upside-down albatross necklace of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Last Available: "2007-06"
 2660	modified blinking not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	tolerable strong flask of Amontillado	5	good	Last Available: "2007-06"
+2661	strong tolerable flask of Amontillado	5	good	Last Available: "2007-06"
 2662	baleful ball mask	0		Spell Damage: +25, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	purple vibrating Can-Can skirt	0		Maximum MP Percent: +10, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	flattened sensitive poetry journal	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 25, Last Available: "2007-06"
@@ -2641,7 +2641,7 @@
 2668	diluted huge can-can-in-a-can	1		Last Available: "2007-06"
 2669	denatured patent antipsychotics	1		Effect: "Thunderspell", Effect Duration: 10, Last Available: "2007-06"
 2670	dehydrated tumbling Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	high-proof drinkable shot of nepenthe schnapps	9	good	Last Available: "2007-06"
+2671	drinkable high-proof shot of nepenthe schnapps	9	good	Last Available: "2007-06"
 2672	huge library card	0		Last Available: "2007-06"
 2673	green Bohemian rhapsody	0		Last Available: "2007-06"
 2674	colloidal fuchsia bottle of cat tonic	0		Effect: "Chock Full o' Nanites", Effect Duration: 39, Last Available: "2007-06"
@@ -2661,11 +2661,11 @@
 2688	stiffened fortified educational dreadlock whip	0		Experience: +1, Damage Absorption: +60, Damage Reduction: 1
 2689	hardy beer-a-pult of terror	0		Maximum HP: +50, Spooky Spell Damage: +10
 2690	upside-down blue greedy shellacked cast-iron legacy paddle	0		Damage Reduction: 7, Meat Drop: +20
-2691	special rotten handful of nuts and berries	3	crappy	Effect: "Space Tripping", Effect Duration: 35
+2691	rotten special handful of nuts and berries	3	crappy	Effect: "Space Tripping", Effect Duration: 35
 2692	rosewater-soaked extremely unsafe driftwood sculpture	0		Weapon Damage Percent: +100, Stench Resistance: +3
 2693	bouncing skewed stanky massive sitar	0		Stench Spell Damage: +25, Item Drop: +5
 2694	inspector's supercharged stone baseball cap of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: +30, Item Drop: +15, Familiar Effect: "1xVolley, cap 48"
-2695	extra-dry perfectly mixed cup of beer	5	EPIC	
+2695	perfectly mixed extra-dry cup of beer	5	EPIC	
 2696	ovoid thing	0		
 2697	duct tape	0		
 2698	duct tape wallet	0		
@@ -2696,12 +2696,12 @@
 2723	pulsating arcane researcher's Staff of the Grand Flamb&eacute; of the boozehound	0		Experience Percent (Mysticality): +10, Item Drop: +5, Booze Drop: +100
 2724	toothsome skewed bowl of rye sprouts	4	awesome	
 2725	adequate cob of corn	4	good	
-2726	massive rotten juniper berries	6	crappy	
+2726	rotten massive juniper berries	6	crappy	
 2727	rotten spinning plum	4	crappy	
 2728	adequate skewed pear	3	good	
-2729	small moldy peach	2	crappy	
+2729	moldy small peach	2	crappy	
 2730	drinkable plum wine	3	good	
-2731	weak hand-crafted shot of pear schnapps	2	EPIC	
+2731	hand-crafted weak shot of pear schnapps	2	EPIC	
 2732	drinkable shot of peach schnapps	3	good	
 2733	yummy bunch of square grapes	3	awesome	
 2734	decent narrow brown sugar cane	3	good	
@@ -2711,13 +2711,13 @@
 2738	pile of smoking rags	0		
 2739	quantum pickled panty raider camouflage	0		Effect: "Here's Mud in Your Eye", Effect Duration: 36
 2740	squat banded Staff of the Walk-In Freezer of terror	0		Damage Absorption: +100, Spooky Spell Damage: +10, Item Drop: +5
-2741	practically non-alcoholic lousy tumbling boilermaker	1	decent	
+2741	lousy practically non-alcoholic tumbling boilermaker	1	decent	
 2742	spoiled wobbly steel lasagna	3	quest	
-2743	practically non-alcoholic smooth steel margarita	1	quest	
-2744	powdered upside-down bouncing steel-scented air freshener	1		Effect: "Mad at Science", Effect Duration: 30
+2743	smooth practically non-alcoholic steel margarita	1	quest	
+2744	powdered bouncing upside-down steel-scented air freshener	1		Effect: "Mad at Science", Effect Duration: 30
 2745	enhanced dry gremlin mutagen	0		Effect: "Cheered Up", Effect Duration: 38
 2746	ionized ghostly extra-potent gremlin mutagen	0		Effect: "Woad Warrior", Effect Duration: 49
-2747	narrow twirling chunk of depleted Grimacite	0		Last Available: "2011-12"
+2747	twirling narrow chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of Flo-Jo	0		Initiative: +100, Single Equip
 2749	Jeselnik's rosy-cheeked Da Vinci's Staff of the Grease Trap	0		Experience (Mysticality): +5, Maximum HP Percent: +30, Sleaze Damage: +25
 2750	flame-wreathed stiffened Uranium Omega of Temperance	0		Damage Reduction: 1, Hot Spell Damage: +10, Single Equip
@@ -2804,7 +2804,7 @@
 2831	star key lime	0		
 2832	huge tasty digital key lime pie	9	awesome	
 2833	moldy star key lime pie	4	crappy	
-2834	Lo Pan's MacGyver's bottle-rocket crossbow of incineration	0		Maximum MP: +100, Spell Critical Percent: +30, Hot Spell Damage: +50, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2834	Lo Pan's MacGyver's bottle-rocket crossbow of incineration	0		Maximum MP: +100, Spell Critical Percent: +30, Hot Spell Damage: +50, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	indie comic hipster glasses of Calamity Jane	0		Critical Hit Percent: +15, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
@@ -2812,7 +2812,7 @@
 2839	reassuring Periodical Paintbrush	0		Spooky Resistance: +1, Softcore Only
 2840	mediocre weak upside-down spinning bottle of cooking sherry	2	decent	
 2841	toothsome packet of ketchup	3	awesome	
-2842	distilled artisanal accidental cider	5	EPIC	
+2842	artisanal distilled accidental cider	5	EPIC	
 2843	moldy super-sized ghostly squat dire fudgesicle	5	crappy	
 2844	wobbly Sherlock's arcane researcher's brawny navel ring of navel gazing of extreme caution	0		Muscle Percent: +20, Experience Percent (Mysticality): +10, Monster Level: -25, Item Drop: +25, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	blurry class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2827,7 +2827,7 @@
 2854	bouquet of swamp roses	0		
 2855	executive chaotic huge mosquito proboscis	0		Spell Critical Percent: +10, Meat Drop: +40
 2856	anodized corrupted anodized skewed swamp lolly	0		Effect: "Kindly Resolve", Effect Duration: 24
-2857	triple-flattened frozen diffused blinking ghostly seegar butt	0		Effect: "Fungal Flambé", Effect Duration: 26
+2857	triple-flattened frozen diffused ghostly blinking seegar butt	0		Effect: "Fungal Flambé", Effect Duration: 26
 2858	bottled swamp gas	0		
 2859	twirling rosewater-soaked thinker's witch wart	0		Mysticality: +10, Stench Resistance: +3
 2860	small bland tumbling swamp muck	2	decent	
@@ -2915,9 +2915,9 @@
 2942	super-dry Vulcanized chocolate filthy lucre	0		Effect: "Flame-Retardant Trousers", Effect Duration: 54
 2943	cold-filtered twirling Angry Farmer's Wife Candy	0		Effect: "Stemonitis Storm", Effect Duration: 33
 2945	spinning teal bouncing scorching extremely unsafe party hat	0		Weapon Damage Percent: +100, Hot Damage: +25, Familiar Effect: "4xLep, cap 7"
-2946	ruddy stiffened V for Vivala mask	0		Damage Reduction: 1, Maximum HP Percent: +40, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	ruddy stiffened V for Vivala mask	0		Damage Reduction: 1, Maximum HP Percent: +40, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
-2948	watered-down lousy upside-down shot of rotgut	2	decent	
+2948	lousy watered-down upside-down shot of rotgut	2	decent	
 2949	colloidal electrified jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Carrrsmic", Effect Duration: 68
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2927,7 +2927,7 @@
 2955	adequate yam candy	3	good	
 2956	wobbly cocktail napkin	0		
 2957	rum barrel charrrm	0		
-2958	stale snack-sized tube of cranberry Go-Goo	2	decent	
+2958	snack-sized stale tube of cranberry Go-Goo	2	decent	
 2959	Van der Graaf rum barrel charrrm bracelet	0		MP Regen Min: 5, MP Regen Max: 7
 2960	normal pulsating single-serving herbal stuffing	3	good	
 2961	big normal packet of tofurkey gravy	5	good	
@@ -2938,7 +2938,7 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	frozen blinking Swabbie&trade; swab	0		Effect: "You Know Who to Call", Effect Duration: 38
 2968	liquefied tarnished modified Oil of Parrrlay	0		Effect: "Alpine Mintiness", Effect Duration: 41
-2969	super-sized yummy creamsicle	5	awesome	
+2969	yummy super-sized creamsicle	5	awesome	
 2970	lousy practically non-alcoholic cream stout	1	decent	
 2971	sizzling strapping curmudgel	0		Muscle: +5, Hot Damage: +10
 2972	grumpy man charrrm	0		
@@ -2993,11 +2993,11 @@
 3021	pulsating stone triangle	0		
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
-3024	tumbling shaking stone pyramid	0		
+3024	shaking tumbling stone pyramid	0		
 3025	delicious practically non-alcoholic corpse on the beach	1	awesome	
 3026	drinkable corpsetini	3	good	
-3027	strong perfectly mixed narrow corpsedriver	5	EPIC	
-3028	fancy practically non-alcoholic mediocre wobbly Corpse Island iced tea	1	decent	Effect: "Incredibly Hulking", Effect Duration: 45
+3027	perfectly mixed strong narrow corpsedriver	5	EPIC	
+3028	practically non-alcoholic fancy mediocre wobbly Corpse Island iced tea	1	decent	Effect: "Incredibly Hulking", Effect Duration: 45
 3029	bad red-headed corpse	3	decent	
 3030	drinkable weak kamicorpse-ee	2	good	
 3031	acceptable corpsel	3	good	
@@ -3009,22 +3009,22 @@
 3037	hand-crafted bottle of rum	3	EPIC	
 3038	mediocre watered-down teal bottle of black-label rum	2	decent	
 3039	cannonball	0		
-3040	twirling blue voodoo skull	0		
+3040	blue twirling voodoo skull	0		
 3041	huge joke scroll	0		
 3042	narrow Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	bland nanite-infested gingerbread bugbear	4	decent	Last Available: "2007-12"
-3046	enchanted big decent fuchsia nanite-infested candy cane	5	good	Effect: "Ooh, Bitter!", Effect Duration: 10, Last Available: "2020-09"
+3046	decent enchanted big fuchsia nanite-infested candy cane	5	good	Effect: "Ooh, Bitter!", Effect Duration: 10, Last Available: "2020-09"
 3047	snack-sized adequate nanite-infested fruitcake	2	good	Last Available: "2007-12"
-3048	special drinkable nanite-infested eggnog	4	good	Effect: "Irresistible Resolve", Effect Duration: 10, Last Available: "2007-12"
+3048	drinkable special nanite-infested eggnog	4	good	Effect: "Irresistible Resolve", Effect Duration: 10, Last Available: "2007-12"
 3049	shaking El Vibrato power sphere	0		
 3050	squat eyepatch of the cheetah	0		Initiative: +60, Familiar Effect: "spooky atk, 1xBarrr"
 3051	wobbly foul-smelling cutlass	0		Stench Damage: +10
 3052	shaking medical-grade breeches	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "stench atk, 1xPotato"
 3053	mood ring	0		Last Available: "2007-02"
 3054	vacuum-sealed skewed candy heart	0		Effect: "Mercenary", Effect Duration: 28, Last Available: "2007-02"
-3055	boiled magnetized gray spinning cymbal syrup	0		Free Pull, Effect: "Norwhalloped", Effect Duration: 68, Last Available: "2007-02"
+3055	boiled magnetized spinning gray cymbal syrup	0		Free Pull, Effect: "Norwhalloped", Effect Duration: 68, Last Available: "2007-02"
 3056	gray metallic foil cat ears of the brute	0		Muscle Percent: +30, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	iGoogly	0		Last Available: "2007-12"
@@ -3048,7 +3048,7 @@
 3076	bouncing laser targeting chip	0		Last Available: "2007-12"
 3077	upside-down hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	blinking kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	fortified marionette collective	0		Damage Absorption: +60, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3078,9 +3078,9 @@
 3106	bouncing huge frightening therapeutic weightlifter's cyborg stompin' boot	0		Muscle: +15, Spooky Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2007-12"
 3107	deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
-3109	tumbling olive skewed Miniborg stomper	0		Last Available: "2007-12"
+3109	olive skewed tumbling Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
-3111	cyan twirling Miniborg laser	0		Last Available: "2007-12"
+3111	twirling cyan Miniborg laser	0		Last Available: "2007-12"
 3112	maroon Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
@@ -3095,12 +3095,12 @@
 3123	ghostly divine champagne flute	0		Last Available: "2008-01"
 3124	wet fruitfilm	0		Effect: "Sinuses For Miles", Effect Duration: 17
 3125	colloidal piece of after eight	0		Effect: "Just the Brown Ones", Effect Duration: 41
-3126	red mirror hobo nickel	0		
+3126	mirror red hobo nickel	0		
 3127	sandcastle	0		
 3128	marshmallow	0		
 3129	moldy roasted marshmallow	3	crappy	
 3130	disc	0		Last Available: "2008-01"
-3131	moldy big red tin cup of mulligan stew	5	crappy	
+3131	big moldy red tin cup of mulligan stew	5	crappy	
 3132	squat medical-grade Socratic flamin' bindle	0		Experience (Mysticality): +1, HP Regen Min: 7, HP Regen Max: 10
 3133	foul-smelling freezin' bindle of mayonnaise	0		Stench Damage: +10, Sleaze Spell Damage: +50
 3134	flame-retardant Samson's stinkin' bindle	0		Experience (Muscle): +5, Hot Resistance: +1
@@ -3114,7 +3114,7 @@
 3142	pulsating perfumed cup of infinite pencils	0		Stench Resistance: +5
 3143	cool Hodgman's disgusting technicolor overcoat of Leguizamo	0		Moxie: +5, Monster Level: +20
 3144	shaking a torn paper strip	0		
-3145	jittery gray El Vibrato translator	0		
+3145	gray jittery El Vibrato translator	0		
 3146	huge El Vibrato punchcard (115 holes)	0		
 3147	El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
@@ -3138,9 +3138,9 @@
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	modified extra-nitrogenated seal eyeball	0		Effect: "Magically Delicious", Effect Duration: 21
-3169	adequate special upside-down spinning turtle soup	4	good	Effect: "[598]A Little Bit Evil", Effect Duration: 35
+3169	special adequate spinning upside-down turtle soup	4	good	Effect: "[598]A Little Bit Evil", Effect Duration: 35
 3170	blinking evil noodles	0		
-3171	twirling narrow nauseating reagent	0		
+3171	narrow twirling nauseating reagent	0		
 3172	yellow Newton's evil paper umbrella	0		Experience (Mysticality): +3
 3173	magnetized evil vihuela	0		Effect: "Chow Downed", Effect Duration: 12
 3174	rotten big evil boring spaghetti	5	crappy	
@@ -3148,7 +3148,7 @@
 3176	rotten evil noodles	3	crappy	
 3177	normal evil painful penne pasta	4	good	
 3178	bland olive 3vi1 pr0n m4nic0tti	4	decent	
-3179	yummy snack-sized evil ravioli della hippy	2	awesome	
+3179	snack-sized yummy evil ravioli della hippy	2	awesome	
 3180	small normal evil noodles	2	good	
 3181	enhanced pickled narrow evil potion of potency	0		Effect: "Grumpy and Ornery", Effect Duration: 11
 3182	concentrated concentrated shaking evil libation of liveliness	0		Effect: "Cranberry Cordiality", Effect Duration: 43
@@ -3158,8 +3158,8 @@
 3186	modified cold-filtered evil serum of sarcasm	0		Effect: "Salad Days", Effect Duration: 22
 3187	nitrogenated oxidized wobbly evil philter of phorce	0		Effect: "Ripping, Dripping", Effect Duration: 17
 3188	delicious an evil sump'm sump'm	4	awesome	
-3189	bad watered-down spinning evil ducha de oro	2	decent	
-3190	acceptable practically non-alcoholic evil horizontal tango	1	good	
+3189	watered-down bad spinning evil ducha de oro	2	decent	
+3190	practically non-alcoholic acceptable evil horizontal tango	1	good	
 3191	high-proof hand-crafted evil roll in the hay	6	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	green naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3176,7 +3176,7 @@
 3204	narrow dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
-3207	teal huge dwarvish punchcard	0		
+3207	huge teal dwarvish punchcard	0		
 3208	small laminated card	0		
 3209	laminated card	0		
 3210	notbig laminated card	0		
@@ -3195,13 +3195,13 @@
 3223	wobbly sewer nuggets	0		
 3224	sewer wad	0		
 3225	fancy aged bottle of sewage schnapps	4	awesome	Effect: "Space Tripping", Effect Duration: 25
-3226	fortified aged bottle of Ooze-O	5	awesome	
+3226	aged fortified bottle of Ooze-O	5	awesome	
 3227	decent enchanted C.H.U.M. chum	4	good	Effect: "Brain Freeze", Effect Duration: 40
 3228	enchanted rotten unfortunate dumplings	4	crappy	Effect: "Ginger Snapped", Effect Duration: 5
 3229	decaying goldfish liver	0		
 3230	pressed nitrogenated oil of oiliness	0		Effect: "Healthy Green Glow", Effect Duration: 67
 3231	blue blinking ribald tattered paper crown	0		Sleaze Damage: +10, Familiar Effect: "1xSombrero, cap 15"
-3232	jumbo normal vanilla-frosted king cake	5	good	Last Available: "2008-03"
+3232	normal jumbo vanilla-frosted king cake	5	good	Last Available: "2008-03"
 3233	inflatable duck	0		
 3234	water wings	0		Wiki Name: "water wings"
 3235	noodle	0		
@@ -3243,7 +3243,7 @@
 3271	blurry stiffened crotchety pants	0		Damage Reduction: 1, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	Fonzie's Saccharine Maple pendant	0		Experience (Moxie): +1, Conditional Skill (Equipped): "Spray Sap"
 3273	Herculean willowy bonnet	0		Experience (Muscle): +1, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
-3274	upside-down lime green flavored foot massage oil	0		Last Available: "2008-04"
+3274	lime green upside-down flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	spinning black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	pulsating personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	pulsating stiffened stick-on eyebrow piercing	0		Damage Reduction: 1, Last Available: "2008-04"
-3283	miniature rotten special salad	2	crappy	Effect: "Gingerbread Robust", Effect Duration: 25
+3283	rotten special miniature salad	2	crappy	Effect: "Gingerbread Robust", Effect Duration: 25
 3284	blue Newton's savvy C.H.U.M. lantern	0		Mysticality Percent: +20, Experience (Mysticality): +3
 3285	wicked C.H.U.M. knife	0		Spell Damage: +5
 3286	zippy Frosty's snowball sack	0		Initiative: +20
@@ -3268,7 +3268,7 @@
 3296	unusual disco ball	0		
 3297	stray chihuahua	0		
 3298	cyan pretty pink bow	0		
-3299	spinning mirror smiley-face sticker	0		
+3299	mirror spinning smiley-face sticker	0		
 3300	farfalle bow tie	0		
 3301	jalape&ntilde;o slices	0		
 3302	stick-on mini solar panels	0		
@@ -3291,7 +3291,7 @@
 3319	ghostly electrified Mr. Joe's bangles	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
 3320	green frayed rope belt of bravery	0		Spooky Resistance: +5, Single Equip
 3321	wobbly packet of mayfly bait	0		Last Available: "2008-05"
-3322	occult mayfly bait necklace of the ox	0		Muscle: +20, Spell Damage Percent: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	occult mayfly bait necklace of the ox	0		Muscle: +20, Spell Damage Percent: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	Ol' Scratch's salad fork	0		
 3324	shaking Frosty's frosty mug	0		
 3325	aged ghostly jar of fermented pickle juice	4	awesome	
@@ -3319,7 +3319,7 @@
 3347	comfy coffin	0		
 3348	purple mattress	0		
 3349	mirror dinged-up triangle	0		
-3350	acceptable boozy shaking blurry Ralph IX cognac	5	good	
+3350	boozy acceptable blurry shaking Ralph IX cognac	5	good	
 3351	huge llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	tumbling zen motorcycle	0		Last Available: "2008-06"
 3353	double-concentrated llama lama gong	0		Effect: "Far Out", Effect Duration: 17, Last Available: "2008-06"
@@ -3332,23 +3332,23 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	squat tasty louse	0		Last Available: "2008-06"
-3363	normal narrow lime green mole mol&eacute;	3	good	Last Available: "2008-06"
-3364	fancy mediocre irresponsibly strong Morlock's Mark Bourbon	8	decent	Effect: "Sappy Blood", Effect Duration: 5, Last Available: "2008-06"
+3363	normal lime green narrow mole mol&eacute;	3	good	Last Available: "2008-06"
+3364	mediocre irresponsibly strong fancy Morlock's Mark Bourbon	8	decent	Effect: "Sappy Blood", Effect Duration: 5, Last Available: "2008-06"
 3365	anodized ionized Climate Colada	0		Effect: "Chlorophyll Flavor", Effect Duration: 24, Last Available: "2008-06"
 3366	extra-chilled moist bouncing digital underground potion	0		Effect: "Nutrient-Rich", Effect Duration: 41, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
-3368	modified pulsating purple glimmering roc feather	1	crappy	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2008-06"
-3369	mixed tumbling gray shaking glimmering phoenix feather	1		Effect: "Lemony Goodness", Effect Duration: 45, Last Available: "2008-06"
+3368	modified purple pulsating glimmering roc feather	1	crappy	Effect: "Gummiskin", Effect Duration: 15, Last Available: "2008-06"
+3369	mixed tumbling shaking gray glimmering phoenix feather	1		Effect: "Lemony Goodness", Effect Duration: 45, Last Available: "2008-06"
 3370	altered gray glimmering penguin feather	1		Last Available: "2008-06"
 3371	compressed huge glimmering buzzard feather	1		Effect: "Savage Beast Inside", Effect Duration: 50, Last Available: "2008-06"
 3372	altered narrow glimmering raven feather	1		Effect: "Pride of the Vampire", Effect Duration: 50, Last Available: "2008-06"
-3373	dehydrated shaking mirror blue glimmering great tit feather	1		Last Available: "2008-06"
+3373	dehydrated mirror blue shaking glimmering great tit feather	1		Last Available: "2008-06"
 3374	house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
 3378	narrow Chorale of Companionship	0		Skill: "Chorale of Companionship"
-3379	blinking blurry cyan Prelude of Precision	0		Skill: "Prelude of Precision"
+3379	blinking cyan blurry Prelude of Precision	0		Skill: "Prelude of Precision"
 3380	nasty coward's Ol' Scratch's infernal pitchfork	0		Monster Level: -20, Stench Damage: +5
 3381	Ol' Scratch's stove door of the empath	0		Familiar Weight: +5, Damage Reduction: 15
 3382	olive coward's Tesla Herculean Ol' Scratch's manacles	0		Experience (Muscle): +1, Monster Level: -20, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -3386,7 +3386,7 @@
 3414	green Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	purple Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	teal hobo fortress blueprints	0		
-3421	blurry box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	blurry box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	double-Vulcanized quadruple-pickled concentrated sterno-flavored Hob-O	0		Effect: "Material Witness", Effect Duration: 35
 3423	warmed adjusted triple-modified frostbite-flavored Hob-O	0		Effect: "Limber as Mortimer", Effect Duration: 43
 3424	colloidal fry-oil-flavored Hob-O	0		Effect: "Bat Attitude", Effect Duration: 13
@@ -3424,22 +3424,22 @@
 3457	shellacked Junior Adventurer's merit badge	0		Damage Reduction: 7
 3458	super-warmed STYX deodorant body spray	0		Effect: "Eye of the Lihc", Effect Duration: 69
 3459	mediocre irresponsibly strong twirling white-label gin	9	decent	
-3460	spoiled massive tin rations	9	crappy	
+3460	massive spoiled tin rations	9	crappy	
 3461	tumbling haiku challenge map	0		
 3462	pulsating terrible poem	0		
 3463	lousy cyan bottle of sake	4	decent	
 3464	round pebble of the scaredy-cat	0		Monster Level: -15
 3465	small delicious yellow Bash-&#332;s cereal	2	awesome	Wiki Name: "Bash-Os cereal"
-3466	miser's perfumed haiku katana of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +5, Meat Drop: +10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	miser's perfumed haiku katana of vim and vigor	0		Maximum HP Percent: +50, Stench Resistance: +5, Meat Drop: +10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	skewed bargain flash powder	0		
 3468	pulsating plastic baby of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2008-12"
-3469	toothsome special blueberry-frosted king cake	3	awesome	Effect: "Sausage Festive", Effect Duration: 50, Last Available: "2008-12"
+3469	special toothsome blueberry-frosted king cake	3	awesome	Effect: "Sausage Festive", Effect Duration: 50, Last Available: "2008-12"
 3470	purple bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	tumbling damp boot	0		
 3472	hale shellacked Seasonal Beret of James Dean	0		Experience (Moxie): +3, Damage Reduction: 7, Maximum HP: +20, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
-3474	dry adjusted cyan tumbling cranberry cordial	0		Effect: "Once Bitten Twice Fried", Effect Duration: 31
-3475	concentrated mirror cyan blackberry polite	0		Effect: "Sauce Monocle", Effect Duration: 48
+3474	dry adjusted tumbling cyan cranberry cordial	0		Effect: "Once Bitten Twice Fried", Effect Duration: 31
+3475	concentrated cyan mirror blackberry polite	0		Effect: "Sauce Monocle", Effect Duration: 48
 3476	improved cold-filtered jittery plum lozenge	0		Effect: "Pop-eyed", Effect Duration: 37
 3477	anodized huge pear lozenge	0		Effect: "Earthen Fist", Effect Duration: 52
 3478	quadruple-electrified peach lozenge	0		Effect: "Weapon of Mass Destruction", Effect Duration: 36
@@ -3453,19 +3453,19 @@
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	jittery pristine fish scale	0		
-3489	small flavorless beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
-3490	half-sized bland blue glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3489	flavorless small beefy fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3490	bland half-sized blue glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3491	super-sized stale spinning slick fish meat	5	decent	Effect: "Fishy", Effect Duration: 5
 3492	lightning-fast fish scimitar of the glutton	0		Food Drop: +100, Initiative: +40
 3493	twirling nasty fish stick of the scaredy-cat	0		Monster Level: -15, Stench Damage: +5
 3494	skewed blinking scandalous beefy fish bazooka	0		Muscle: +10, Sleaze Damage: +5
 3495	pickled wet sea salt crystal	0		Effect: "Cinnamouth", Effect Duration: 58
-3496	polarized narrow twirling bazookafish bubble gum	0		Effect: "Bastard!", Effect Duration: 64
+3496	polarized twirling narrow bazookafish bubble gum	0		Effect: "Bastard!", Effect Duration: 64
 3497	perfectly mixed bottle of Pete's Sake	3	EPIC	
 3498	tumbling invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	blinking witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	flavorless enchanted canap&eacute;s	3	decent	Effect: "Berry Experiential", Effect Duration: 10
+3501	enchanted flavorless canap&eacute;s	3	decent	Effect: "Berry Experiential", Effect Duration: 10
 3502	diluted lime green thermos of brew	1	crappy	Last Available: "2011-12"
 3503	lousy upside-down glass of brandy	3	decent	Last Available: "2011-12"
 3504	French slippers	0		
@@ -3476,7 +3476,7 @@
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
-3512	shaking upside-down scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
+3512	upside-down shaking scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
 3513	scratch 'n' sniff dragon sticker	0		Spooky Damage: +3, Stench Damage: +3, Hot Damage: +3, Cold Damage: +3, Sleaze Damage: +3, Last Available: "2008-11"
 3514	blinking scratch 'n' sniff rock band sticker	0		Weapon Damage: +20, Spell Damage: +20, Last Available: "2008-11"
 3515	sizzling veiny ganger bandana	0		Maximum HP: +10, Hot Damage: +10, Familiar Effect: "atk"
@@ -3504,7 +3504,7 @@
 3537	plans for depleted Grimacite weightlifting belt	0		Recipe: "depleted Grimacite weightlifting belt"
 3538	blinking plans for depleted Grimacite grappling hook	0		Recipe: "depleted Grimacite grappling hook"
 3539	plans for depleted Grimacite ninja mask	0		Recipe: "depleted Grimacite ninja mask"
-3540	yellow blurry spinning plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
+3540	blurry yellow spinning plans for depleted Grimacite shinguards	0		Recipe: "depleted Grimacite shinguards"
 3541	ghostly plans for depleted Grimacite astrolabe	0		Recipe: "depleted Grimacite astrolabe"
 3542	cyan depleted Grimacite hammer of the wise owl	0		Mysticality: +20, Last Available: "2011-12"
 3543	manspreader's Sinatra's depleted Grimacite gravy boat	0		Experience (Moxie): +5, Monster Level: +10, Last Available: "2011-12"
@@ -3518,18 +3518,18 @@
 3551	Usain Bolt's horrifying steel-toed straw hat	0		Damage Reduction: 9, Spooky Damage: +25, Initiative: +80, Familiar Effect: "1xFairy"
 3552	lard-coated dog trainer's octopus's spade of Leguizamo	0		Monster Level: +20, Experience (familiar): +1, Sleaze Spell Damage: +25
 3553	wobbly soggy seed packet	0		
-3554	squat cyan glob of slime	0		
-3555	special stale sea carrot	3	decent	Effect: "Glittering Eyelashes", Effect Duration: 10
+3554	cyan squat glob of slime	0		
+3555	stale special sea carrot	3	decent	Effect: "Glittering Eyelashes", Effect Duration: 10
 3556	tasty sea cucumber	3	awesome	
-3557	thick rotten sea avocado	5	crappy	
+3557	rotten thick sea avocado	5	crappy	
 3558	spoiled sea lychee	3	crappy	
-3559	spoiled miniature purple sea tangelo	2	crappy	
+3559	miniature spoiled purple sea tangelo	2	crappy	
 3560	decent sea honeydew	3	good	
 3561	altered diffused pressurized potion of puissance	0		Effect: "Nothing Is Impossible", Effect Duration: 36
 3562	diffused energized ghostly pressurized potion of perspicacity	0		Effect: "Covetous Robbery", Effect Duration: 24
 3563	dry non-boiled blurry pressurized potion of pulchritude	0		Effect: "Dreams and Lights", Effect Duration: 58
 3564	artisanal berry-infused sake	3	EPIC	
-3565	strong artisanal gray tumbling citrus-infused sake	5	EPIC	
+3565	artisanal strong tumbling gray citrus-infused sake	5	EPIC	
 3566	lousy enchanted melon-infused sake	3	decent	Effect: "Thick, Sick", Effect Duration: 40
 3567	slab of sponge	0		
 3568	mirror greedy stanky sponge helmet of the glutton	0		Stench Spell Damage: +25, Meat Drop: +20, Food Drop: +100, Familiar Effect: "atk, 1xFairy"
@@ -3548,7 +3548,7 @@
 3581	mirror sushi-rolling mat	0		
 3582	big bland ghostly rice	5	decent	
 3584	flavorless irradiated candy cane	3	decent	Last Available: "2008-12"
-3585	moldy huge gingerbread mutant bugbear	9	crappy	Last Available: "2008-12"
+3585	huge moldy gingerbread mutant bugbear	9	crappy	Last Available: "2008-12"
 3586	distilled artisanal skewed oozenog	5	EPIC	Last Available: "2008-12"
 3587	vacuum-sealed dry sugar plum	0		Effect: "Inscrutable exoskeleton", Effect Duration: 69, Last Available: "2008-12"
 3588	energized jittery sugar banana	0		Effect: "What's That Smell?", Effect Duration: 37, Last Available: "2008-12"
@@ -3558,7 +3558,7 @@
 3592	Mer-kin takebag	0		Item Drop: +5
 3593	mirror Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
-3595	extra-denatured shaking jittery Mer-kin fastjuice	0		Effect: "[800]Chocolate Reign", Effect Duration: 37
+3595	extra-denatured jittery shaking Mer-kin fastjuice	0		Effect: "[800]Chocolate Reign", Effect Duration: 37
 3596	imitation crab crate	0		
 3597	imitation crab meat	0		
 3598	imitation crab zoea	0		
@@ -3574,14 +3574,14 @@
 3608	blinking live nautical mine	0		
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
-3611	polarized tumbling spinning purple sea grease	0		Effect: "Rainbow Bright", Effect Duration: 40
+3611	polarized purple spinning tumbling sea grease	0		Effect: "Rainbow Bright", Effect Duration: 40
 3612	upside-down maroon sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	pulsating battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	spinning rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	boiled pickled unstable DNA	0		Effect: "Fit To Be Tide", Effect Duration: 61, Last Available: "2008-12"
-3618	green The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	green The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	tumbling wriggling tentacle	0		Last Available: "2008-12"
 3620	upside-down mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
@@ -3608,15 +3608,15 @@
 3642	dragonfish caviar	0		
 3643	blinking pufferfish spine	0		
 3644	huge Jack Frost's depleted Grimacite kneecapping stick	0		Cold Spell Damage: +50, Last Available: "2007-06"
-3645	weak bad twirling canteen of wine	2	decent	Last Available: "2008-12"
+3645	bad weak twirling canteen of wine	2	decent	Last Available: "2008-12"
 3646	decent elven <i>limbos</i> gingerbread	3	good	Last Available: "2008-12"
 3647	bouncing elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	small stale toast with jam	2	decent	Last Available: "2008-12"
-3651	jittery antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	stale small toast with jam	2	decent	Last Available: "2008-12"
+3651	jittery antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	mediocre practically non-alcoholic upside-down elven moonshine	1	decent	Last Available: "2008-12"
-3653	delicious thick lime green knuckle sandwich	5	awesome	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	thick delicious lime green knuckle sandwich	5	awesome	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	greedy Rosewater's psycho sweater	0		Mysticality Percent: +30, Meat Drop: +20, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	spinning savvy plastic Mob Penguin	0		Mysticality Percent: +20, Last Available: "2008-12"
@@ -3636,12 +3636,12 @@
 3670	tumbling bouncing hale glow-in-the-dark burrowgrub	0		Maximum HP: +20, Last Available: "2009-01"
 3671	gray Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	flavorless miniature huge can of franks 'n' beans	2	decent	Last Available: "2010-12"
-3673	weak hand-crafted teal blinking bottle of peppermint schnapps	2	EPIC	Last Available: "2010-12"
+3673	weak hand-crafted blinking teal bottle of peppermint schnapps	2	EPIC	Last Available: "2010-12"
 3674	twirling twirling throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	blurry Mer-kin foodbucket	0		
 3677	diving muff of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
-3678	mediocre fortified salinated mint julep	5	decent	
+3678	fortified mediocre salinated mint julep	5	decent	
 3679	bouncing ink bladder	0		
 3680	esca	0		
 3681	wobbly bubbling tempura batter	0		
@@ -3657,7 +3657,7 @@
 3691	bland low-calorie sea blueberry	1	decent	
 3692	bland tiny sea persimmon	1	decent	
 3693	deionized anodized quantum blurry pressurized potion of perception	0		Effect: "Antarctic Memories", Effect Duration: 16
-3694	colloidal ionized frozen spinning skewed wobbly pressurized potion of proficiency	0		Effect: "Deep-Seated Rage", Effect Duration: 66
+3694	colloidal ionized frozen skewed wobbly spinning pressurized potion of proficiency	0		Effect: "Deep-Seated Rage", Effect Duration: 66
 3695	asbestos-lined Mer-kin digpick	0		Hot Resistance: +5
 3696	anemone nematocyst	0		
 3697	high-pressure seltzer bottle	0		
@@ -3718,7 +3718,7 @@
 3754	quadruple-tarnished shaking love song of vague ambiguity	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 69, Last Available: "2009-02"
 3755	oxidized pickled love song of smoldering passion	0		Effect: "Stuck That Way", Effect Duration: 63, Last Available: "2009-02"
 3756	magnetized quadruple-enhanced blurry ghostly love song of icy revenge	0		Effect: "Clyde's Blessing", Effect Duration: 26, Last Available: "2009-02"
-3757	quadruple-oxidized energized twirling tumbling love song of sugary cuteness	0		Effect: "Rushin' Hands", Effect Duration: 39, Last Available: "2009-02"
+3757	quadruple-oxidized energized tumbling twirling love song of sugary cuteness	0		Effect: "Rushin' Hands", Effect Duration: 39, Last Available: "2009-02"
 3758	non-oxidized love song of disturbing obsession	0		Effect: "Your Eyes are Peeled!", Effect Duration: 40, Last Available: "2009-02"
 3759	flattened double-quantum double-polymerized love song of naughty innuendo	0		Effect: "Conspiratory Eyes", Effect Duration: 28, Last Available: "2009-02"
 3760	dry twirling breath mint	0		Effect: "Vanity Rage", Effect Duration: 26
@@ -3726,9 +3726,9 @@
 3762	pulsating vampire pearl necklace of James Dean	0		Experience (Moxie): +3, Single Equip
 3763	tolerable slug of vodka	4	good	
 3764	tolerable slug of rum	3	good	
-3765	lousy extra-dry slug of shochu	5	decent	
+3765	extra-dry lousy slug of shochu	5	decent	
 3766	triple-distilled tolerable screwdiver	9	good	
-3767	acceptable watered-down twirling red dew yoana lei	2	good	
+3767	watered-down acceptable red twirling dew yoana lei	2	good	
 3768	aged lychee chuhai	3	awesome	
 3769	practically non-alcoholic perfectly mixed gray salacious screwdiver	1	super ultra mega turbo EPIC	
 3770	acceptable bouncing dew yoana salacious lei	4	good	
@@ -3753,18 +3753,18 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	shaking Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	ghostly crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	ghostly crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	baleful cool brainy Mer-kin roundshield	0		Mysticality: +5, Moxie: +5, Spell Damage: +25, Damage Reduction: 14
 3804	reassuring Mer-kin breastplate of dire peril	0		Weapon Damage: +20, Spooky Resistance: +1
 3805	lard-coated Mer-kin sneakmask of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +25, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
-3806	pulsating blue spinning Mer-kin prayerbeads	0		
+3806	spinning blue pulsating Mer-kin prayerbeads	0		
 3807	alkaline electrified unsweetened Mer-kin hidepaint	0		Effect: "Quantum of Moxie", Effect Duration: 32
 3808	huge Mer-kin trailmap	0		
 3809	upside-down Mer-kin healscroll	0		
 3810	blurry Mer-kin lockkey	0		
 3811	cyan Mer-kin stashbox	0		
-3812	tasty bite-sized shaking chocolate-frosted king cake	1	awesome	Last Available: "2009-06"
+3812	bite-sized tasty shaking chocolate-frosted king cake	1	awesome	Last Available: "2009-06"
 3813	pulsating mirror plastic baby of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	wobbly half-height unicycle	0		Familiar Weight: +5
@@ -3780,14 +3780,14 @@
 3826	Grandma's Chartreuse Yarn	0		
 3827	plastic oyster egg	0		
 3828	Grandma's Map	0		
-3829	decent super-sized tempura radish	5	good	
+3829	super-sized decent tempura radish	5	good	
 3830	blinking careful water-polo cap	0		Monster Level: -10, Familiar Effect: "1xVolley, 1xBarrr"
 3831	smooth weak Typical Tavern swill	2	awesome	
 3832	tolerable weak tropical swill	2	good	
 3833	tolerable spirit-forward fruity girl swill	5	good	
 3834	hand-crafted mirror blended swill	4	EPIC	
 3835	costume wardrobe	0		Softcore Only
-3836	fireproof Jim Carey's Oprah's groovy Elvish sunglasses	0		Moxie Percent: +10, Maximum MP Percent: +50, Monster Level: +25, Hot Resistance: +3, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	fireproof Jim Carey's Oprah's groovy Elvish sunglasses	0		Moxie Percent: +10, Maximum MP Percent: +50, Monster Level: +25, Hot Resistance: +3, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	wholesome anniversary safety glass vest	0		Maximum HP Percent: +10
 3838	ghostly aromatic anniversary burlap belt	0		Stench Resistance: +1
 3839	shaking squat anniversary balsa wood socks of the scaredy-cat	0		Monster Level: -15
@@ -3836,7 +3836,7 @@
 3882	spinning encoded cult documents	0		
 3883	jittery cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
-3885	Vulcanized mirror blurry vial of slime	0		Effect: "Influence of Sphere", Effect Duration: 34
+3885	Vulcanized blurry mirror vial of slime	0		Effect: "Influence of Sphere", Effect Duration: 34
 3886	pickled vial of slime	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 33
 3887	adjusted alkaline vial of slime	0		Effect: "Hot Jellied", Effect Duration: 18
 3888	galvanized moist skewed vial of slime	0		Effect: "Dragged Through the Coals", Effect Duration: 24
@@ -3914,7 +3914,7 @@
 3962	blinking designer handbag	0		
 3963	Clan pool table	0		Free Pull, Last Available: "2009-05"
 3964	squat cell phone	0		Familiar Weight: +10
-3965	enhanced dry wobbly cyan cube of billiard chalk	0		Effect: "Spooky Blur", Effect Duration: 68
+3965	enhanced dry cyan wobbly cube of billiard chalk	0		Effect: "Spooky Blur", Effect Duration: 68
 3966	prompt razor-sharp hot-ass club of the boozehound	0		Weapon Damage Percent: +25, Booze Drop: +100, Adventures: +3, Class: "Seal Clubber"
 3967	Sherlock's friendly baleful frigid-ass club	0		Spell Damage: +25, Familiar Weight: +3, Item Drop: +25, Class: "Seal Clubber"
 3968	wobbly maroon deadly educational creepy-ass club of courage	0		Experience: +1, Weapon Damage: +5, Spooky Resistance: +3, Class: "Seal Clubber"
@@ -3987,7 +3987,7 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	mirror caustic slime nodule	0		
 4037	stale wobbly slimy sweetbreads	4	decent	
-4038	mediocre practically non-alcoholic narrow slimy fermented bile bladder	1	decent	
+4038	practically non-alcoholic mediocre narrow slimy fermented bile bladder	1	decent	
 4039	distilled blurry slimy alveolus	1		
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	teal groovy pig-iron helm	0		Moxie Percent: +10, Item Drop: +5, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4003,7 +4003,7 @@
 4051	ghostly green blinking pulsating energetic ring of teleportation	0		Maximum MP Percent: +20, Single Equip
 4052	blurry glass of baboon milk	1	crappy	Last Available: "2009-06"
 4053	banana milkshake	1	good	Last Available: "2009-06"
-4054	watered-down fancy acceptable White Hyborian	2	good	Effect: "Wax On Your Shoes", Effect Duration: 15, Last Available: "2009-06"
+4054	watered-down acceptable fancy White Hyborian	2	good	Effect: "Wax On Your Shoes", Effect Duration: 15, Last Available: "2009-06"
 4055	blinking nippy goblin hunting spear	0		Cold Damage: +10, Last Available: "2009-06"
 4056	razor-sharp goblin autoblowgun of the brazier	0		Weapon Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2009-06"
 4057	strapping tribal beads	0		Muscle: +5, Last Available: "2009-06"
@@ -4012,9 +4012,9 @@
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
 4061	Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
-4063	lime green bouncing Mecha Mayhem Club Card	0		Last Available: "2009-06"
+4063	bouncing lime green Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
-4065	mirror blurry Spacefleet Communicator Badge	0		Last Available: "2009-06"
+4065	blurry mirror Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	essence of kink	0		Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	non-warmed tempura air	0		Effect: "Oriental Mysticism", Effect Duration: 67
 4134	adjusted activated huge pressurized potion of pneumaticity	0		Effect: "Smoky Third Eye", Effect Duration: 59
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	huge greedy grievous dangerous personal trainer's Bag o' Tricks	0		Experience Percent (Muscle): +10, Weapon Damage: +10, Weapon Damage Percent: +50, Meat Drop: +20, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	huge greedy grievous dangerous personal trainer's Bag o' Tricks	0		Experience Percent (Muscle): +10, Weapon Damage: +10, Weapon Damage Percent: +50, Meat Drop: +20, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	slime stack	0		
 4138	shaking a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4165,7 +4165,7 @@
 4213	Temple Grandin's skate blade of terror	0		Familiar Weight: +7, Spooky Spell Damage: +10
 4214	spangly unitard	0		
 4215	scorching dangerous collapsible baton	0		Weapon Damage: +10, Hot Damage: +25
-4216	teal wobbly groupie lipstick	0		
+4216	wobbly teal groupie lipstick	0		
 4217	groupie bra	0		
 4218	deionized tarnished green spinning groupie spangles	0		Effect: "Fishily Speeding", Effect Duration: 30
 4219	yellow ghostly asbestos-lined skate board of the glutton	0		Hot Resistance: +5, Food Drop: +100
@@ -4178,7 +4178,7 @@
 4226	cyan blurry brainy Star of Bravery	0		Mysticality: +5, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	bouncing yellow amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	yellow bouncing amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	yellow ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	wobbly can of sterno	0		
 4237	perfumed cheese-slicer	0		Stench Resistance: +5
-4238	massive stale beef jerky	8	decent	
+4238	stale massive beef jerky	8	decent	
 4239	greasy pipe wrench	0		Sleaze Spell Damage: +10
 4240	modified magnetized gun cleaning kit	0		Effect: "Oxygenated Blood", Effect Duration: 44
 4241	sleep mask of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4244,7 +4244,7 @@
 4292	huge stanky Lo Pan's weightlifter's Mer-kin dodgeball	0		Muscle: +15, Spell Critical Percent: +30, Stench Spell Damage: +25, Conditional Skill (Equipped): "Ball Bust", Conditional Skill (Equipped): "Ball Sweat", Conditional Skill (Equipped): "Ball Sack"
 4293	squat flame-retardant friendly cool Mer-kin dragnet	0		Moxie: +5, Familiar Weight: +3, Hot Resistance: +1, Conditional Skill (Equipped): "Net Gain", Conditional Skill (Equipped): "Net Loss", Conditional Skill (Equipped): "Net Neutrality"
 4294	ghostly lion tamer's resourceful Mer-kin switchblade of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +50, Experience (familiar): +2, Conditional Skill (Equipped): "Blade Sling", Conditional Skill (Equipped): "Blade Roller", Conditional Skill (Equipped): "Blade Runner"
-4295	narrow cyan crystal orb of spirit wrangling	0		
+4295	cyan narrow crystal orb of spirit wrangling	0		
 4296	depleted uranium seal figurine	0		
 4297	blurry Jeselnik's quilted Ass-Stompers of Violence of the cheetah	0		Damage Absorption: +40, Sleaze Damage: +25, Initiative: +60, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	family-friendly supercharged fortified Brand of Violence	0		Damage Absorption: +60, Maximum MP Percent: +30, Sleaze Resistance: +1, Conditional Skill (Equipped): "Brand"
@@ -4310,16 +4310,16 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	jittery A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	normal expired can of franks 'n' beans	3	good	Last Available: "2009-12"
-4361	watered-down perfectly mixed expired bottle of peppermint schnapps	2	EPIC	Last Available: "2009-12"
+4361	perfectly mixed watered-down expired bottle of peppermint schnapps	2	EPIC	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	denatured elven suicide capsule	0		Effect: "Barking Mad", Effect Duration: 36, Last Available: "2009-12"
-4365	snack-sized tasty tumbling penguin focaccia bread	2	awesome	Last Available: "2009-12"
-4366	special lousy weak blinking herringcello	2	decent	Effect: "Mental A-cue-ity", Effect Duration: 20, Last Available: "2009-12"
+4365	tasty snack-sized tumbling penguin focaccia bread	2	awesome	Last Available: "2009-12"
+4366	lousy special weak blinking herringcello	2	decent	Effect: "Mental A-cue-ity", Effect Duration: 20, Last Available: "2009-12"
 4367	hand-crafted elven cellocello	4	EPIC	Last Available: "2009-12"
 4368	gray wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
-4370	pulsating spinning bottle of agitprop ink	0		Last Available: "2009-12"
+4370	spinning pulsating bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
 4372	chunk of cement	0		Last Available: "2009-12"
 4373	olive grappling hook	0		Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	teal baleful peanut brittle shield	0		Spell Damage: +25, Damage Reduction: 3, Last Available: "2009-12"
 4390	huge Oprah's sinister Red Rover BB gun	0		Spell Damage: +10, Maximum MP Percent: +50, Last Available: "2009-12"
-4391	blue red-and-green sweater of the sweet-tooth	0		Candy Drop: +100, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	blue red-and-green sweater of the sweet-tooth	0		Candy Drop: +100, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	energized Crimbo peppermint bark	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 60, Last Available: "2009-12"
 4394	vacuum-sealed Crimbo fudge	0		Effect: "Inner Dog", Effect Duration: 39, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	blinking reassuring cheese sword	0		Spooky Resistance: +1, Softcore Only, Last Available: "2010-01"
 4400	nasty cheese diaper	0		Stench Damage: +5, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	jittery clever cheese wheel	0		Maximum MP: +20, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	shaking jittery thinker's cheese eye	0		Mysticality: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	shaking jittery thinker's cheese eye	0		Mysticality: +10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	mirror mansplainer's therapeutic Fonzie's Staff of Queso Escusado	0		Experience (Moxie): +1, Monster Level: +15, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4372,15 +4372,15 @@
 4421	crafty sealhide gloves	0		Maximum MP: +10
 4422	gray groovy sealhide belt	0		Moxie Percent: +10
 4423	twirling sealhide snare	0		
-4424	pulsating teal puzzling trophy	0		
+4424	teal pulsating puzzling trophy	0		
 4425	improved activated ionized blurry sealhide seal doll	0		Effect: "Weird Flavor", Effect Duration: 46
 4426	hymnal	0		Skill: "Canticle of Carboloading"
 4428	upside-down nasty glowstick on a string	0		Stench Damage: +5
 4429	ghostly spinning yellow dance instructor's candy necklace	0		Experience Percent (Moxie): +10, Single Equip
 4430	mirror teddybear backpack of bravery	0		Spooky Resistance: +5
 4431	NPZR chemistry set	0		Last Available: "2011-08"
-4432	quadruple-cold-filtered ghostly bouncing invisibility potion	0		Effect: "Healthy Blue Glow", Effect Duration: 60, Last Available: "2011-08"
-4433	unsweetened magnetized oxidized ghostly teal spinning irresistibility potion	0		Effect: "Woad Warrior", Effect Duration: 58, Last Available: "2011-08"
+4432	quadruple-cold-filtered bouncing ghostly invisibility potion	0		Effect: "Healthy Blue Glow", Effect Duration: 60, Last Available: "2011-08"
+4433	unsweetened magnetized oxidized spinning ghostly teal irresistibility potion	0		Effect: "Woad Warrior", Effect Duration: 58, Last Available: "2011-08"
 4434	non-altered super-liquefied irritability potion	0		Effect: "Optimist Primal", Effect Duration: 59, Last Available: "2011-08"
 4436	cube	0		Last Available: "2011-02"
 4438	hellseal whisker	0		
@@ -4423,8 +4423,8 @@
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	cyan BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
-4478	blurry gray BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4478	gray blurry BRICKO elephant	0		Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	pulsating BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	squat BRICKO airship	0		Last Available: "2010-02"
@@ -4447,7 +4447,7 @@
 4499	modified double-ionized recording of Elron's Explosive Etude	0		Effect: "Quiet 'n' Good", Effect Duration: 41
 4500	pressed skewed recording of Chorale of Companionship	0		Effect: "Stimulated Brain", Effect Duration: 47
 4501	oxidized oxidized recording of Prelude of Precision	0		Effect: "Horrid, Torrid", Effect Duration: 59
-4502	diffused wet cyan twirling recording of Donho's Bubbly Ballad	0		Effect: "Memory of Smarts", Effect Duration: 24
+4502	diffused wet twirling cyan recording of Donho's Bubbly Ballad	0		Effect: "Memory of Smarts", Effect Duration: 24
 4503	warmed dry recording of Inigo's Incantation of Inspiration	0		Effect: "Flambé-a-thon", Effect Duration: 18, Last Available: "2010-02"
 4504	boxer's heart of the volcano of Calamity Jane	0		Muscle Percent: +10, Critical Hit Percent: +15
 4505	vacuum-sealed galvanized spinning Northern pemmican	0		Effect: "Stands Alone", Effect Duration: 37
@@ -4455,11 +4455,11 @@
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	altered dry green &quot;DRINK ME&quot; potion	0		Effect: "Lifted Spirits", Effect Duration: 30, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
-4510	stale diet shaking cyan walrus ice cream	1	decent	Last Available: "2010-03"
+4510	diet stale cyan shaking walrus ice cream	1	decent	Last Available: "2010-03"
 4511	spoiled immense shaking purple beautiful soup	9	crappy	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	teal Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	toothsome bouncing yellow Humpty Dumplings	4	awesome	Last Available: "2010-03"
+4514	toothsome yellow bouncing Humpty Dumplings	4	awesome	Last Available: "2010-03"
 4515	low-calorie spoiled Lobster <i>qua</i> Grill	1	crappy	Last Available: "2010-03"
 4516	mediocre olive missing wine	3	decent	Last Available: "2010-03"
 4517	half-sized normal skewed matter custard	2	good	Last Available: "2010-03"
@@ -4470,16 +4470,16 @@
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	ghostly greedy friendly eye of the Tiger-lily	0		Familiar Weight: +3, Meat Drop: +20, Last Available: "2010-03"
 4524	Sherlock's hardened wig	0		Damage Reduction: 3, Item Drop: +25, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	stale small jittery donut	2	decent	Last Available: "2010-03"
-4526	huge adequate bucket of honey	10	good	Last Available: "2010-03"
+4525	small stale jittery donut	2	decent	Last Available: "2010-03"
+4526	adequate huge bucket of honey	10	good	Last Available: "2010-03"
 4527	spinning squat clever brawny elephant stinger	0		Muscle Percent: +20, Maximum MP: +20, Last Available: "2010-03"
 4528	tasty dragon snaps	3	awesome	Last Available: "2010-03"
 4529	fuchsia snapdragon pistil of Leguizamo of the scaredy-cat	0		Monster Level: 5, Last Available: "2010-03"
 4530	mirror puff of smoke	0		Last Available: "2010-03"
-4531	bite-sized yummy rook cookie	1	awesome	Last Available: "2010-03"
+4531	yummy bite-sized rook cookie	1	awesome	Last Available: "2010-03"
 4532	spoiled narrow bishop cookie	3	crappy	Last Available: "2010-03"
 4533	toothsome big knight cookie	5	awesome	Last Available: "2010-03"
-4534	normal tiny fancy king cookie	1	good	Effect: "A View to Some Meat", Effect Duration: 50, Last Available: "2010-03"
+4534	tiny fancy normal king cookie	1	good	Effect: "A View to Some Meat", Effect Duration: 50, Last Available: "2010-03"
 4535	delicious queen cookie	4	awesome	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	wicked insane tophat	0		Spell Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
@@ -4495,7 +4495,7 @@
 4547	caterpillar	0		Last Available: "2010-03"
 4548	spinning walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
-4550	fuchsia jittery dodo	0		Last Available: "2010-03"
+4550	jittery fuchsia dodo	0		Last Available: "2010-03"
 4551	beefy detour shield	0		Muscle: +10, Damage Reduction: 6, Last Available: "2010-03"
 4552	ghostly left parenthesis	0		
 4553	mirror lowercase a	0		
@@ -4510,7 +4510,7 @@
 4562	narrow hair of the calf	0		Last Available: "2010-04"
 4563	drinkable world's most unappetizing beverage	3	good	Last Available: "2010-04"
 4564	shellacked slippery when wet shield	0		Damage Reduction: 13, Last Available: "2010-04"
-4565	miniature adequate narrow raisin	2	good	Last Available: "2010-04"
+4565	adequate miniature narrow raisin	2	good	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	padded flyest of shirts of bravery	0		Damage Absorption: +20, Spooky Resistance: +5, Last Available: "2010-04"
 4568	stale a dance upon the palate	4	decent	Last Available: "2010-04"
@@ -4526,10 +4526,10 @@
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	Vulcanized nitrogenated Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Berry Statistical", Effect Duration: 40, Last Available: "2010-04"
 4580	squat MacGyver's school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Maximum MP: +100, Last Available: "2010-04"
-4581	greasy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the businessman	0		Sleaze Spell Damage: +10, Meat Drop: +50, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	greasy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the businessman	0		Sleaze Spell Damage: +10, Meat Drop: +50, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
-4584	big rotten six wedges of goat cheese	5	crappy	
+4584	rotten big six wedges of goat cheese	5	crappy	
 4585	collection of objects	0		
 4586	boulder	0		
 4587	twirling goth	0		
@@ -4543,18 +4543,18 @@
 4595	purple pixel holy water	0		Last Available: "2010-07"
 4596	wobbly map to Vanya's Castle	0		Last Available: "2010-07"
 4597	fuchsia 8-Bit Power magazine	0		Last Available: "2010-07"
-4598	spinning fuchsia pixel stopwatch	0		Last Available: "2010-07"
+4598	fuchsia spinning pixel stopwatch	0		Last Available: "2010-07"
 4599	jittery bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	practically non-alcoholic tolerable plastic cup of beer	1	good	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	green keg	0		Last Available: "2010-06"
-4605	scandalous bottle of Goldschn&ouml;ckered of the detective	0		Sleaze Damage: +5, Item Drop: +20, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	scandalous bottle of Goldschn&ouml;ckered of the detective	0		Sleaze Damage: +5, Item Drop: +20, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	delicious half-sized sun-dried tofu	2	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	delicious soyburger juice	3	awesome	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
-4609	huge narrow essential tofu	0		Last Available: "2010-08"
+4609	narrow huge essential tofu	0		Last Available: "2010-08"
 4610	warmed unsweetened essential soy	0		Effect: "Elemental Mastery", Effect Duration: 47, Last Available: "2010-08"
 4611	energized super-frozen essential cameraderie	0		Effect: "Thicker, Sicker", Effect Duration: 27, Last Available: "2010-08"
 4612	tumbling souvenir drawing	0		Last Available: "2010-08"
@@ -4574,7 +4574,7 @@
 4626	superduperball	0		Last Available: "2010-06"
 4627	lime green finger cuffs	0		Last Available: "2010-06"
 4628	wobbly jittery parachute guy	0		Last Available: "2010-06"
-4629	brainy plastic spider ring	0		Mysticality: +5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	brainy plastic spider ring	0		Mysticality: +5, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	banded plastic kazoo	0		Damage Absorption: +100, Last Available: "2010-06"
 4631	hardened inflatable baseball bat	0		Damage Reduction: 3, Last Available: "2010-06"
 4632	ghostly Lo Pan's thinker's googly-star hat	0		Mysticality: +10, Spell Critical Percent: +30, Familiar Effect: "atk", Last Available: "2010-06"
@@ -4594,8 +4594,8 @@
 4646	nippy ruddy Meteoid ice beam of Flo-Jo	0		Maximum HP Percent: +40, Cold Damage: +10, Initiative: +100, Last Available: "2011-12"
 4647	banded Dungeon Fist gauntlet of the pedagogue of the storm	0		Experience: +3, Damage Absorption: +100, Maximum MP Percent: +40, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	purple fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	purple fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	greedy arcane researcher's ironic knit cap	0		Experience Percent (Mysticality): +10, Meat Drop: +20, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4617,9 +4617,9 @@
 4669	blurry Socratic hilarious comedy prop	0		Experience (Mysticality): +1
 4670	beer-scented teddy bear	0		
 4671	enchanted perfectly mixed upside-down booze-soaked cherry	3	EPIC	Effect: "Booze Goozles", Effect Duration: 40
-4672	purple shaking comfy pillow	0		
-4673	yummy half-sized shaking marshmallow	2	awesome	
-4674	spoiled snack-sized skewed sponge cake	2	crappy	
+4672	shaking purple comfy pillow	0		
+4673	half-sized yummy shaking marshmallow	2	awesome	
+4674	snack-sized spoiled skewed sponge cake	2	crappy	
 4675	watered-down hand-crafted gin-soaked blotter paper	2	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4659,19 +4659,19 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	special miniature toothsome squat lemon popsicle	2	awesome	Effect: "Knightlife", Effect Duration: 5
+4714	miniature toothsome special squat lemon popsicle	2	awesome	Effect: "Knightlife", Effect Duration: 5
 4715	decent popsicle	4	good	
-4716	adequate snack-sized strawberry popsicle	2	good	
+4716	snack-sized adequate strawberry popsicle	2	good	
 4717	tasty snack-sized blue liver popsicle	2	awesome	
 4718	ghostly mariachi hat of the detective	0		Item Drop: +20, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of temperance	0		Sleaze Resistance: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	squat microwave stogie	0		Last Available: "2011-12"
-4722	normal special liver and let pie	3	good	Effect: "Permanent Halloween", Effect Duration: 10, Last Available: "2010-10"
-4723	normal small badass pie	2	good	Last Available: "2010-10"
+4722	special normal liver and let pie	3	good	Effect: "Permanent Halloween", Effect Duration: 10, Last Available: "2010-10"
+4723	small normal badass pie	2	good	Last Available: "2010-10"
 4724	normal purple shoo-fish pie	4	good	Last Available: "2010-10"
 4725	tasty huge piping organ pie	3	awesome	Last Available: "2010-10"
-4726	diet stale igloo pie	1	decent	Last Available: "2010-10"
+4726	stale diet igloo pie	1	decent	Last Available: "2010-10"
 4727	delicious stomach turnover	4	awesome	Last Available: "2010-10"
 4728	spoiled dead lights pie	3	crappy	Last Available: "2010-10"
 4729	moldy pulsating throbbing organ pie	4	crappy	Last Available: "2010-10"
@@ -4683,9 +4683,9 @@
 4735	narrow prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	beer-soaked mop of mayonnaise	0		Sleaze Spell Damage: +50
-4738	weak mediocre day-old beer	2	decent	
-4739	smooth watered-down plain beer	2	awesome	
-4740	acceptable practically non-alcoholic overpriced &quot;imported&quot; beer	1	good	
+4738	mediocre weak day-old beer	2	decent	
+4739	watered-down smooth plain beer	2	awesome	
+4740	practically non-alcoholic acceptable overpriced &quot;imported&quot; beer	1	good	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	gray bone chips	0		Last Available: "2011-12"
@@ -4693,7 +4693,7 @@
 4745	polarized Wax Flask	0		Effect: "Prideful Strut", Effect Duration: 31
 4746	concentrated Pain Dip	0		Effect: "Spiky Hair", Effect Duration: 68
 4747	spoiled thick special bone meal	5	crappy	Effect: "Berry Berry Cold", Effect Duration: 10, Last Available: "2010-10"
-4748	watered-down lousy bone aperitif	2	decent	Last Available: "2010-10"
+4748	lousy watered-down bone aperitif	2	decent	Last Available: "2010-10"
 4749	spinning reassuring bonerang	0		Spooky Resistance: +1, Last Available: "2010-10"
 4750	Sinatra's bone and arrows	0		Experience (Moxie): +5, Last Available: "2010-10"
 4751	spinning boxer's boning knife	0		Muscle Percent: +10, Last Available: "2010-10"
@@ -4710,7 +4710,7 @@
 4762	skewed huge pumpkin	0		Last Available: "2010-11"
 4763	bland pumpkin pie	4	decent	Last Available: "2010-11"
 4764	weak tolerable pumpkin beer	2	good	Last Available: "2010-11"
-4765	ionized squat blurry pumpkin juice	0		Effect: "The Halls of Muscularity", Effect Duration: 49, Last Available: "2010-11"
+4765	ionized blurry squat pumpkin juice	0		Effect: "The Halls of Muscularity", Effect Duration: 49, Last Available: "2010-11"
 4766	twirling pumpkin bomb	0		Last Available: "2010-11"
 4767	strapping shin gourds of James Dean	0		Muscle: +5, Experience (Moxie): +3, Single Equip, Last Available: "2010-11"
 4768	ribald educational Staff of the November Jack-O-Lantern of the dark arts	0		Experience: +1, Spell Damage Percent: +100, Sleaze Damage: +10, Last Available: "2010-11"
@@ -4790,9 +4790,9 @@
 4881	aged CRIMBCO wine	4	awesome	Last Available: "2011-01"
 4882	Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	squat toe jam	0		Last Available: "2011-01"
-4884	bland special shaking toe jam toast	4	decent	Effect: "Broken Bone Nubs", Effect Duration: 50, Last Available: "2011-01"
+4884	special bland shaking toe jam toast	4	decent	Effect: "Broken Bone Nubs", Effect Duration: 50, Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	miniature adequate traffic jam toast	2	good	Last Available: "2011-01"
+4886	adequate miniature traffic jam toast	2	good	Last Available: "2011-01"
 4887	teal space jam	0		Last Available: "2011-01"
 4888	thick bland narrow space jam toast	5	decent	Last Available: "2011-01"
 4889	super-tarnished extra-chilled pulsating motivational poster	0		Effect: "Ten out of Ten", Effect Duration: 46, Last Available: "2011-01"
@@ -4855,7 +4855,7 @@
 4952	flattened green baggie of sugar	0		Effect: "Egg-headedness", Effect Duration: 39
 4953	lime green ribald nippy whalebone corset	0		Cold Damage: +10, Sleaze Damage: +10, Single Equip
 4954	therapeutic oven mitts	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip
-4955	bite-sized toothsome overcookie	1	awesome	
+4955	toothsome bite-sized overcookie	1	awesome	
 4956	moldy philosopher's scone	3	crappy	
 4957	boiled anodized half-baked potion	0		Effect: "Quadrilled", Effect Duration: 56
 4958	teal shaking boxer's Knob Goblin deluxe scimitar	0		Muscle Percent: +10
@@ -4874,7 +4874,7 @@
 4971	pulsating maroon Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
 4973	Alice's Army Alchemist	0		Last Available: "2011-03"
-4974	jittery mirror ghostly Alice's Army Page	0		Last Available: "2011-03"
+4974	mirror ghostly jittery Alice's Army Page	0		Last Available: "2011-03"
 4975	red Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	skewed Alice's Army Nurse	0		Last Available: "2011-03"
@@ -4924,9 +4924,9 @@
 5021	wet boiled natto marble soda	0		Effect: "Feet of Watermelon", Effect Duration: 49, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	ionized oxidized elderly jawbreaker	0		Effect: "Barbecue Saucy", Effect Duration: 17, Last Available: "2020-09"
-5024	mediocre distilled maroon upside-down marshmallow flamb&eacute;	5	decent	Last Available: "2011-03"
+5024	distilled mediocre upside-down maroon marshmallow flamb&eacute;	5	decent	Last Available: "2011-03"
 5025	delicious cranberry schnapps	4	awesome	Last Available: "2011-03"
-5026	fortified bad breaded beer	5	decent	Last Available: "2011-03"
+5026	bad fortified breaded beer	5	decent	Last Available: "2011-03"
 5027	mediocre twirling soy cordial	4	decent	Last Available: "2011-03"
 5028	shaking rosy-cheeked beefcake's astral bludgeon of the early riser	0		Muscle: +25, Maximum HP Percent: +30, Adventures: +7
 5029	rock-hard astral shield of the overflowing toilet	0		Damage Reduction: 20, Stench Spell Damage: +50
@@ -4953,8 +4953,8 @@
 5050	personal trainer's double-ice box of terror	0		Experience Percent (Muscle): +10, Spooky Spell Damage: +10, Item Drop: +5, Last Available: "2011-04"
 5051	mirror squat Herculean slick strapping double-ice britches	0		Muscle: +5, Moxie: +10, Experience (Muscle): +1, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	handful of numbers	0		Last Available: "2020-09"
-5053	twirling upside-down Lars the Cyberian	0		Last Available: "2011-04"
-5054	shaking squat intriguing puzzle box	0		Last Available: "2011-04"
+5053	upside-down twirling Lars the Cyberian	0		Last Available: "2011-04"
+5054	squat shaking intriguing puzzle box	0		Last Available: "2011-04"
 5055	shaking obnoxious riddle	0		Last Available: "2011-04"
 5056	best joke ever	0		Last Available: "2011-04"
 5057	irradiated Atomic Comic	0		Effect: "Milk Studly", Effect Duration: 15, Last Available: "2011-04"
@@ -4968,7 +4968,7 @@
 5065	bland spaghetti con calaveras	3	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	normal popcorn	3	good	Last Available: "2011-04"
-5068	moldy small chaos popcorn	2	crappy	Last Available: "2011-04"
+5068	small moldy chaos popcorn	2	crappy	Last Available: "2011-04"
 5069	flame-retardant flame-wreathed hale hole	0		Maximum HP: +20, Hot Spell Damage: +10, Hot Resistance: +1, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	fancy bland s'more	0	decent	Effect: "Preternatural Greed", Effect Duration: 15, Last Available: "2011-04"
@@ -5007,10 +5007,10 @@
 5104	concentrated fish juice box	0		Effect: "Macho Profundo", Effect Duration: 44, Last Available: "2011-05"
 5105	cyan paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	practically non-alcoholic hand-crafted Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
+5107	hand-crafted practically non-alcoholic Jeppson's Malort	1	super ultra mega turbo EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	fuchsia brainy stress ball	0		Mysticality: +5, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
-5110	jittery mirror Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
+5109	fuchsia brainy stress ball	0		Mysticality: +5, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5110	mirror jittery Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	Ultracolor&trade; shirt of the pedagogue	0		Experience: +3, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	packet of orchid seeds	0		
@@ -5029,17 +5029,17 @@
 5126	Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
 5128	Notes from the Elfpocalypse, Chapter IV	0		Last Available: "2011-06"
-5129	blurry ghostly Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
+5129	ghostly blurry Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	ionized Ultrasoldier Serum	0		Effect: "All Fired Up", Effect Duration: 22, Last Available: "2011-06"
-5132	rotten snack-sized red narrow elven hardtack	2	crappy	Last Available: "2011-06"
-5133	perfectly mixed weak cyan shaking elven squeeze	2	EPIC	Last Available: "2011-06"
+5132	rotten snack-sized narrow red elven hardtack	2	crappy	Last Available: "2011-06"
+5133	perfectly mixed weak shaking cyan elven squeeze	2	EPIC	Last Available: "2011-06"
 5134	blurry lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	upside-down E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
-5139	tumbling upside-down carton of astral energy drinks	0		
+5139	upside-down tumbling carton of astral energy drinks	0		
 5140	compressed astral energy drink	1		Effect: "Twinklebritches", Effect Duration: 40
 5141	pulsating Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
@@ -5075,14 +5075,14 @@
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	bad Saison du Lune	3	decent	Last Available: "2011-06"
-5175	watered-down bad huge Moonthril Schnapps	2	decent	Last Available: "2011-06"
-5176	drinkable high-proof Wrecked Generator	10	good	Last Available: "2011-06"
+5175	bad watered-down huge Moonthril Schnapps	2	decent	Last Available: "2011-06"
+5176	high-proof drinkable Wrecked Generator	10	good	Last Available: "2011-06"
 5177	delicious tumbling Spaghetti with Moonballs	4	awesome	Last Available: "2011-06"
-5178	bland diet Crepes a la Lune	1	decent	Last Available: "2011-06"
+5178	diet bland Crepes a la Lune	1	decent	Last Available: "2011-06"
 5179	spoiled Moon Pie	3	crappy	Last Available: "2011-06"
 5180	dry irradiated teal Comet Pop	0		Effect: "Employee of the Month", Effect Duration: 19, Last Available: "2011-06"
 5181	nitrogenated Flan in the Moon	0		Effect: "Tingly Wrists", Effect Duration: 44, Last Available: "2011-06"
-5182	electrified gray spinning spinning 1/6th Pound Cake	0		Effect: "Clean-Shaven", Effect Duration: 46, Last Available: "2011-06"
+5182	electrified spinning spinning gray 1/6th Pound Cake	0		Effect: "Clean-Shaven", Effect Duration: 46, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
 5184	Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	blurry Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	moist aerosolized ionized skewed tumbling honey stick	0		Effect: "Stimulated Brain", Effect Duration: 38
 5189	boiled skewed double-ice gum	0		Effect: "Ichorous Eyesight", Effect Duration: 42, Last Available: "2011-04"
-5190	nasty Samson's wizardly Operation Patriot Shield	0		Mysticality: +25, Experience (Muscle): +5, Stench Damage: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	nasty Samson's wizardly Operation Patriot Shield	0		Mysticality: +25, Experience (Muscle): +5, Stench Damage: +5, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	triple-adjusted corrupted data	0		Effect: "Tingly Elbows", Effect Duration: 66, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5108,8 +5108,8 @@
 5205	dehydrated orc paste	1	good	Last Available: "2011-08"
 5206	compressed demonic paste	1	EPIC	Last Available: "2011-08"
 5207	boiled blinking indescribably horrible paste	1	crappy	Last Available: "2011-08"
-5208	pickled ghostly shaking teal paste	1	good	Last Available: "2011-08"
-5209	powdered pulsating mirror goblin paste	1	EPIC	Last Available: "2011-08"
+5208	pickled ghostly teal shaking paste	1	good	Last Available: "2011-08"
+5209	powdered mirror pulsating goblin paste	1	EPIC	Last Available: "2011-08"
 5210	altered pirate paste	1	crappy	Last Available: "2011-08"
 5211	altered wobbly chlorophyll paste	1	awesome	Effect: "Dreadful Sheen", Effect Duration: 30, Last Available: "2011-08"
 5212	powdered twirling paste	1	decent	Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	squat fat loot token	0		No Pull
 5222	spinning Thwaitgold grasshopper statuette	0		
 5223	shaking Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	adequate diet tumbling Ur-Donut	1	good	Last Available: "2011-09"
+5224	diet adequate tumbling Ur-Donut	1	good	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
 5227	perfectly mixed weak squat bucket of wine	2	super ultra EPIC	Last Available: "2011-09"
@@ -5140,13 +5140,13 @@
 5237	hardy time halo	0		Maximum HP: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	enchanted weak delicious Lumineux Limnio	2	awesome	Effect: "Shamboozled", Effect Duration: 50, Last Available: "2011-09"
 5239	delicious Morto Moreto	3	awesome	Last Available: "2011-09"
-5240	enchanted mediocre spinning Temps Tempranillo	4	decent	Last Available: "2011-09"
+5240	mediocre enchanted spinning Temps Tempranillo	4	decent	Last Available: "2011-09"
 5241	artisanal Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
 5242	hand-crafted Fromage Pinotage	4	EPIC	Last Available: "2011-09"
 5243	acceptable Beignet Milgranet	4	good	Last Available: "2011-09"
 5244	perfectly mixed Muschat	3	EPIC	Last Available: "2011-09"
-5245	fancy spoiled huge spinning cool jelly donut	10	crappy	Effect: "Peppermint Bite", Effect Duration: 30, Last Available: "2011-09"
-5246	bite-sized moldy blinking shrapnel jelly donut	1	crappy	Last Available: "2011-09"
+5245	huge spoiled fancy spinning cool jelly donut	10	crappy	Effect: "Peppermint Bite", Effect Duration: 30, Last Available: "2011-09"
+5246	moldy bite-sized blinking shrapnel jelly donut	1	crappy	Last Available: "2011-09"
 5247	stale jumbo pulsating occult jelly donut	5	decent	Last Available: "2011-09"
 5248	rotten cyan thyme jelly donut	4	crappy	Last Available: "2011-09"
 5249	toothsome danish	3	awesome	Last Available: "2011-09"
@@ -5154,12 +5154,12 @@
 5251	yummy forbidden danish	3	awesome	Last Available: "2011-09"
 5252	stale cool cat claw	4	decent	Last Available: "2011-09"
 5253	moldy blunt cat claw	3	crappy	Last Available: "2011-09"
-5254	stale miniature mirror shadowy cat claw	2	decent	Last Available: "2011-09"
+5254	miniature stale mirror shadowy cat claw	2	decent	Last Available: "2011-09"
 5255	stale huge cheezburger	3	decent	Last Available: "2011-09"
-5256	tiny spoiled ghostly toasted brie	1	crappy	Last Available: "2011-09"
+5256	spoiled tiny ghostly toasted brie	1	crappy	Last Available: "2011-09"
 5257	Vulcanized super-electrified potion of the field gar	0		Effect: "Space Tripping", Effect Duration: 57, Last Available: "2011-09"
 5258	adjusted pressed too legit potion	0		Effect: "Buggy Flavor", Effect Duration: 52, Last Available: "2011-09"
-5259	galvanized colloidal squat blue Bright Water	0		Effect: "Rain Dancin'", Effect Duration: 11, Last Available: "2011-09"
+5259	galvanized colloidal blue squat Bright Water	0		Effect: "Rain Dancin'", Effect Duration: 11, Last Available: "2011-09"
 5260	adjusted activated lime green cold-filtered water	0		Effect: "Triangle, Man", Effect Duration: 32, Last Available: "2011-09"
 5261	unsweetened graveyard snowglobe	0		Effect: "Icy Composition", Effect Duration: 18, Last Available: "2011-09"
 5262	oxidized cool cat elixir	0		Effect: "Quaaaaaaa", Effect Duration: 22, Last Available: "2011-09"
@@ -5172,7 +5172,7 @@
 5269	bobcat grenade	0		Last Available: "2011-09"
 5270	twirling chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
-5272	green blinking huge noxious gas grenade	0		Last Available: "2011-09"
+5272	blinking huge green noxious gas grenade	0		Last Available: "2011-09"
 5273	skull with a fuse in it	0		Last Available: "2011-09"
 5274	boozebomb	0		Last Available: "2011-09"
 5275	Usain Bolt's hammerus	0		Initiative: +80, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	executive broken clock	0		Meat Drop: +40, Last Available: "2011-09"
 5282	jittery family-friendly dethklok	0		Sleaze Resistance: +1, Last Available: "2011-09"
 5283	ruddy glacial clock	0		Maximum HP Percent: +40, Last Available: "2011-09"
-5284	blurry lime green blurry Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	lime green blurry blurry Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	blinking d4	0		Last Available: "2011-09"
 5286	mirror d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	narrow slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	mirror dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy big phish stick	5	crappy	Last Available: "2011-09"
-5299	huge dance instructor's plastic vampire fangs of the brute	0		Muscle Percent: +30, Experience Percent (Moxie): +10, Item Drop: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	huge dance instructor's plastic vampire fangs of the brute	0		Muscle Percent: +30, Experience Percent (Moxie): +10, Item Drop: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	blinking Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	gray your own heart	0		Last Available: "2011-10"
@@ -5222,8 +5222,8 @@
 5319	alkaline shaking Blood 'n' Plenty	0		Effect: "Antsy in your Pantsy", Effect Duration: 66, Last Available: "2011-10"
 5320	concentrated aerosolized yellow Lobos Mints	0		Effect: "Experimental Effect G-9", Effect Duration: 26, Last Available: "2011-10"
 5321	dry moist huge Sweet Sword	0		Effect: "Slippery Tongue", Effect Duration: 22, Last Available: "2011-10"
-5322	mediocre distilled Ecto-Cooler	5	decent	Last Available: "2011-10"
-5323	perfectly mixed extra-dry Bartles and BRAAAINS wine cooler	5	EPIC	Last Available: "2011-10"
+5322	distilled mediocre Ecto-Cooler	5	decent	Last Available: "2011-10"
+5323	extra-dry perfectly mixed Bartles and BRAAAINS wine cooler	5	EPIC	Last Available: "2011-10"
 5324	hand-crafted watered-down spinning Blood Light	2	EPIC	Last Available: "2011-10"
 5325	acceptable Silver Bullet beer	3	good	Last Available: "2011-10"
 5326	tolerable ghostly Bone's Farm &quot;wine&quot;	4	good	Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	frightening fortified The Necbromancer's Shorts of vim and vigor	0		Damage Absorption: +60, Maximum HP Percent: +50, Spooky Damage: +5, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	Jim Carey's healthy stylish The Necbromancer's Wizard Staff	0		Moxie: +25, Maximum HP Percent: +20, Monster Level: +25, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	watered-down mediocre spinning The Cooler Out of Space	2	decent	Last Available: "2011-10"
+5342	mediocre watered-down spinning The Cooler Out of Space	2	decent	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
 5345	diffused alkaline electrified Necbro wafers	0		Effect: "Jawin'", Effect Duration: 56, Last Available: "2020-09"
@@ -5292,8 +5292,8 @@
 5389	diet flavorless ridiculous sandwich	1	decent	Last Available: "2011-11"
 5390	tolerable ridiculous cocktail	3	good	Last Available: "2011-11"
 5391	crafty zombie monkey necklace of the cheetah	0		Maximum MP: +10, Initiative: +60
-5392	pulsating squat Thwaitgold butterfly statuette	0		
-5393	yellow bouncing scrap of paper	0		
+5392	squat pulsating Thwaitgold butterfly statuette	0		
+5393	bouncing yellow scrap of paper	0		
 5394	tumbling sandpaper	0		
 5395	peppermint sprout	0		Last Available: "2011-11"
 5396	pickled galvanized peppermint twist	0		Effect: "Human-Hobo Hybrid", Effect Duration: 19, Last Available: "2011-11"
@@ -5358,7 +5358,7 @@
 5455	bouncing purple gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	diffused activated Fudgie Roll	0		Effect: "Butt-Rock Hair", Effect Duration: 15, Last Available: "2011-11"
-5458	normal miniature blinking yellow fudge bunny	2	good	Last Available: "2011-11"
+5458	normal miniature yellow blinking fudge bunny	2	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	Usain Bolt's knitted toasty fudgecycle	0		Hot Damage: +5, Cold Resistance: +3, Initiative: +80, Single Equip, Last Available: "2011-11"
 5461	shaking fudge cube	0		Last Available: "2011-11"
@@ -5368,7 +5368,7 @@
 5465	unsweetened quadruple-improved denatured tumbling resolution: be happier	0		Effect: "Elemental Flavor", Effect Duration: 45, Last Available: "2012-01"
 5466	ionized resolution: be stronger	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 48, Last Available: "2012-01"
 5467	electrified huge resolution: be smarter	0		Effect: "Mortarfied", Effect Duration: 15, Last Available: "2012-01"
-5468	boiled electrified anodized jittery shaking resolution: be sexier	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 21, Last Available: "2012-01"
+5468	boiled electrified anodized shaking jittery resolution: be sexier	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 21, Last Available: "2012-01"
 5469	quantum altered squat resolution: be feistier	0		Effect: "Nutrient-Rich", Effect Duration: 27, Last Available: "2012-01"
 5470	deionized wobbly resolution: be kinder	0		Effect: "Permafrosty", Effect Duration: 49, Last Available: "2012-01"
 5471	wet nitrogenated blinking resolution: be more adventurous	0		Effect: "Stinky Hands", Effect Duration: 65, Last Available: "2012-01"
@@ -5379,11 +5379,11 @@
 5476	polymerized gummi salamander	0		Effect: "Hobonic", Effect Duration: 12, Last Available: "2011-11"
 5477	improved adjusted activated gummi snake	0		Effect: "[1609]Dancin' Fool", Effect Duration: 19, Last Available: "2011-11"
 5478	unsweetened denatured blurry gummi canary	0		Effect: "Wallflowering", Effect Duration: 19, Last Available: "2011-11"
-5479	rotten massive gummi bear	7	crappy	Last Available: "2011-11"
+5479	massive rotten gummi bear	7	crappy	Last Available: "2011-11"
 5480	moldy gummi bear	3	crappy	Last Available: "2011-11"
-5481	stale half-sized narrow gummi bear	2	decent	Last Available: "2011-11"
-5482	normal miniature drunki-bear	2	good	Last Available: "2011-11"
-5483	thick flavorless huge drunki-bear	5	decent	Last Available: "2011-11"
+5481	half-sized stale narrow gummi bear	2	decent	Last Available: "2011-11"
+5482	miniature normal drunki-bear	2	good	Last Available: "2011-11"
+5483	flavorless thick huge drunki-bear	5	decent	Last Available: "2011-11"
 5484	delicious drunki-bear	4	awesome	Last Available: "2011-11"
 5485	upside-down mirror steel-toed gummi bowtie	0		Damage Reduction: 9, Last Available: "2011-11"
 5486	ghostly huge bouncing fudge pocket square of doom	0		Spooky Spell Damage: +50, Last Available: "2011-11"
@@ -5440,14 +5440,14 @@
 5537	jittery prose pen	0		Last Available: "2012-12"
 5538	green half-empty carton of milk	0		Last Available: "2012-12"
 5539	blurry glass of warm water	0		Free Pull
-5540	quadruple-dry blurry ghostly desktop zen garden	0		Effect: "Heart of Orange", Effect Duration: 65, Last Available: "2012-12"
+5540	quadruple-dry ghostly blurry desktop zen garden	0		Effect: "Heart of Orange", Effect Duration: 65, Last Available: "2012-12"
 5541	skewed Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	pulsating Herculean wizardly Leapin' Trousers	0		Mysticality: +25, Experience (Muscle): +1
 5544	acceptable eggnog	4	good	Last Available: "2012-12"
 5545	delicious bouncing hamhock	3	awesome	Last Available: "2012-12"
 5546	mirror The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
-5547	teal spinning Clancy's sackbut	0		Last Available: "2012-12"
+5547	spinning teal Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
 5549	green Clancy's crumhorn	0		Last Available: "2012-12"
 5550	The Snitch's Manifesto	0		Skill: "Tattle", Last Available: "2012-12"
@@ -5465,9 +5465,9 @@
 5562	wobbly cyan friendly Rosewater's Rain-Doh violet bo	0		Mysticality Percent: +30, Familiar Weight: +3, Softcore Only, Last Available: "2012-02"
 5563	Rain-Doh box	0		Last Available: "2012-02"
 5564	fuchsia Rain-Doh box full of monster	0		Last Available: "2012-02"
-5565	bland special PB&BP	4	decent	Effect: "Whole Latte Love", Effect Duration: 10
+5565	special bland PB&BP	4	decent	Effect: "Whole Latte Love", Effect Duration: 10
 5566	miniature rotten club sandwich	2	crappy	
-5567	yummy super-sized narrow corned-beef Reuben	5	awesome	
+5567	super-sized yummy narrow corned-beef Reuben	5	awesome	
 5568	frayed ninja rope	0		
 5569	shaking red dull ninja crampons	0		
 5570	loose ninja carabiner	0		
@@ -5481,32 +5481,32 @@
 5578	hand-crafted lime green Flaming Knob	3	EPIC	Last Available: "2012-03"
 5579	weak hand-crafted Grasshopper	2	EPIC	Last Available: "2012-03"
 5580	perfectly mixed Locust	4	EPIC	Last Available: "2012-03"
-5581	lousy watered-down Plague of Locusts	2	decent	Last Available: "2012-03"
-5582	watered-down hand-crafted Red Dwarf	2	EPIC	Last Available: "2012-03"
+5581	watered-down lousy Plague of Locusts	2	decent	Last Available: "2012-03"
+5582	hand-crafted watered-down Red Dwarf	2	EPIC	Last Available: "2012-03"
 5583	perfectly mixed Golden Mean	3	EPIC	Last Available: "2012-03"
-5584	hand-crafted triple-distilled twirling Green Giant	7	EPIC	Last Available: "2012-03"
+5584	triple-distilled hand-crafted twirling Green Giant	7	EPIC	Last Available: "2012-03"
 5585	acceptable Aye Aye	3	good	Last Available: "2012-03"
 5586	hand-crafted Aye Aye, Captain	3	EPIC	Last Available: "2012-03"
-5587	boozy tolerable Aye Aye, Tooth Tooth	5	good	Last Available: "2012-03"
-5588	irresponsibly strong acceptable Humanitini	6	good	Last Available: "2012-03"
+5587	tolerable boozy Aye Aye, Tooth Tooth	5	good	Last Available: "2012-03"
+5588	acceptable irresponsibly strong Humanitini	6	good	Last Available: "2012-03"
 5589	artisanal extra-dry More Humanitini than Humanitini	5	EPIC	Last Available: "2012-03"
-5590	weak tolerable Oh, the Humanitini	2	good	Last Available: "2012-03"
+5590	tolerable weak Oh, the Humanitini	2	good	Last Available: "2012-03"
 5591	drinkable special mirror Great Older Fashioned	3	good	Effect: "Held Closer", Effect Duration: 15, Last Available: "2012-03"
 5592	delicious upside-down spinning Fuzzy Tentacle	4	awesome	Last Available: "2012-03"
-5593	perfectly mixed watered-down wobbly Crazymaker	2	EPIC	Last Available: "2012-03"
+5593	watered-down perfectly mixed wobbly Crazymaker	2	EPIC	Last Available: "2012-03"
 5594	drinkable mirror Zoodriver	3	good	Last Available: "2012-03"
 5595	watered-down bad Sloe Comfortable Zoo	2	decent	Last Available: "2012-03"
 5596	perfectly mixed Sloe Comfortable Zoo on Fire	3	EPIC	Last Available: "2012-03"
 5597	perfectly mixed Suffering Sinner	3	EPIC	Last Available: "2012-03"
 5598	mediocre wobbly Suppurating Sinner	3	decent	Last Available: "2012-03"
-5599	bad practically non-alcoholic ghostly upside-down Sizzling Sinner	1	decent	Last Available: "2012-03"
-5600	practically non-alcoholic artisanal Firewater	1	EPIC	Last Available: "2012-03"
-5601	weak mediocre special Earth and Firewater	2	decent	Effect: "Hairless and Airless", Effect Duration: 20, Last Available: "2012-03"
-5602	bad watered-down Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
-5603	weak tolerable Slimosa	2	good	Last Available: "2012-03"
-5604	artisanal practically non-alcoholic Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
+5599	practically non-alcoholic bad ghostly upside-down Sizzling Sinner	1	decent	Last Available: "2012-03"
+5600	artisanal practically non-alcoholic Firewater	1	EPIC	Last Available: "2012-03"
+5601	special mediocre weak Earth and Firewater	2	decent	Effect: "Hairless and Airless", Effect Duration: 20, Last Available: "2012-03"
+5602	watered-down bad Earth, Wind and Firewater	2	decent	Last Available: "2012-03"
+5603	tolerable weak Slimosa	2	good	Last Available: "2012-03"
+5604	practically non-alcoholic artisanal Extra-slimy Slimosa	1	EPIC	Last Available: "2012-03"
 5605	hand-crafted Slimebite	4	EPIC	Last Available: "2012-03"
-5606	acceptable high-proof Cement Mixer	6	good	Last Available: "2012-03"
+5606	high-proof acceptable Cement Mixer	6	good	Last Available: "2012-03"
 5607	tolerable Jackhammer	3	good	Last Available: "2012-03"
 5608	bad blinking Dump Truck	4	decent	Last Available: "2012-03"
 5609	tolerable Fauna Libre	4	good	Last Available: "2012-03"
@@ -5514,28 +5514,28 @@
 5611	watered-down tolerable tumbling Aura Libre	2	good	Last Available: "2012-03"
 5612	lousy watered-down shaking Sazerorc	2	decent	Last Available: "2012-03"
 5613	bad Sazuruk-hai	4	decent	Last Available: "2012-03"
-5614	irresponsibly strong delicious Flaming Sazerorc	9	awesome	Last Available: "2012-03"
+5614	delicious irresponsibly strong Flaming Sazerorc	9	awesome	Last Available: "2012-03"
 5615	mediocre Green Velvet	3	decent	Last Available: "2012-03"
 5616	acceptable blurry Green Muslin	4	good	Last Available: "2012-03"
-5617	high-proof delicious Green Burlap	6	awesome	Last Available: "2012-03"
+5617	delicious high-proof Green Burlap	6	awesome	Last Available: "2012-03"
 5618	artisanal irresponsibly strong twirling Mohobo	6	EPIC	Last Available: "2012-03"
 5619	tolerable Moonshine Mohobo	3	good	Last Available: "2012-03"
 5620	aged spinning Flaming Mohobo	4	awesome	Last Available: "2012-03"
 5621	aged Drunken Philosopher	4	awesome	Last Available: "2012-03"
-5622	perfectly mixed distilled Drunken Neurologist	5	EPIC	Last Available: "2012-03"
+5622	distilled perfectly mixed Drunken Neurologist	5	EPIC	Last Available: "2012-03"
 5623	distilled artisanal shaking Drunken Astrophysicist	5	EPIC	Last Available: "2012-03"
 5624	artisanal practically non-alcoholic Dark & Starry	1	EPIC	Last Available: "2012-03"
-5625	practically non-alcoholic lousy fancy bouncing Black Hole	1	decent	Effect: "Amorous", Effect Duration: 10, Last Available: "2012-03"
+5625	fancy lousy practically non-alcoholic bouncing Black Hole	1	decent	Effect: "Amorous", Effect Duration: 10, Last Available: "2012-03"
 5626	drinkable Event Horizon	3	good	Last Available: "2012-03"
 5627	weak bad Herring Daiquiri	2	decent	Last Available: "2012-03"
-5628	fancy acceptable tumbling Herring Wallbanger	4	good	Effect: "Bolts about Candy", Effect Duration: 15, Last Available: "2012-03"
+5628	acceptable fancy tumbling Herring Wallbanger	4	good	Effect: "Bolts about Candy", Effect Duration: 15, Last Available: "2012-03"
 5629	acceptable Herringtini	3	good	Last Available: "2012-03"
 5630	bad Lollipop Drop	3	decent	Last Available: "2012-03"
 5631	artisanal huge Candy Alexander	3	EPIC	Last Available: "2012-03"
-5632	hand-crafted special Candicaine	4	EPIC	Effect: "Weasels Underfoot", Effect Duration: 45, Last Available: "2012-03"
-5633	high-proof delicious twirling Caipiranha	7	awesome	Last Available: "2012-03"
-5634	artisanal watered-down spinning Flying Caipiranha	2	EPIC	Last Available: "2012-03"
-5635	extra-dry acceptable tumbling Flaming Caipiranha	5	good	Last Available: "2012-03"
+5632	special hand-crafted Candicaine	4	EPIC	Effect: "Weasels Underfoot", Effect Duration: 45, Last Available: "2012-03"
+5633	delicious high-proof twirling Caipiranha	7	awesome	Last Available: "2012-03"
+5634	watered-down artisanal spinning Flying Caipiranha	2	EPIC	Last Available: "2012-03"
+5635	acceptable extra-dry tumbling Flaming Caipiranha	5	good	Last Available: "2012-03"
 5636	drinkable Punchplanter	4	good	Last Available: "2012-03"
 5637	bad Doublepunchplanter	3	decent	Last Available: "2012-03"
 5638	artisanal watered-down jittery Haymaker	2	EPIC	Last Available: "2012-03"
@@ -5571,11 +5571,11 @@
 5668	green bagged &quot;L&quot;	0		
 5669	club	0		
 5670	yummy low-calorie tumbling fettucini &eacute;pines Inconnu	1	awesome	
-5671	smooth shaking mirror slap and slap again	3	awesome	
+5671	smooth mirror shaking slap and slap again	3	awesome	
 5672	tumbling gunpowder burrito	2	good	
 5673	huge beery blood	2	good	
 5674	&quot;L&quot;	0		
-5675	diluted purple mirror bouncing watered-down Red Minotaur	1		
+5675	diluted mirror purple bouncing watered-down Red Minotaur	1		
 5676	skewed pool torpedo	0		Last Available: "2012-05"
 5677	steel-toed Ze&trade; goggles	0		Damage Reduction: 9, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
@@ -5629,19 +5629,19 @@
 5728	scandalous arcane researcher's foot-long hot daub	0		Experience Percent (Mysticality): +10, Sleaze Damage: +5, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	moldy angst burger	3	crappy	
-5731	enchanted bad 5-hour acrimony	4	decent	Effect: "The Strength...  of the Future", Effect Duration: 25
+5731	bad enchanted 5-hour acrimony	4	decent	Effect: "The Strength...  of the Future", Effect Duration: 25
 5732	pulsating blank note	0		
 5733	ghostly eerily silent box	0		
 5734	flavorless blurry forbidden sausage	3	decent	
-5735	pulsating fuchsia Lord Flameface's cloak of extreme caution	0		Monster Level: -25, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
-5736	enhanced skewed bouncing Drizzlers&trade; Black Licorice	0		Effect: "Bananas!", Effect Duration: 42
+5735	pulsating fuchsia Lord Flameface's cloak of extreme caution	0		Monster Level: -25, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5736	enhanced bouncing skewed Drizzlers&trade; Black Licorice	0		Effect: "Bananas!", Effect Duration: 42
 5737	adjusted modified huge daub-breaker	0		Effect: "Tomato Power", Effect Duration: 47, Last Available: "2020-09"
 5738	ghostly banded Camp Scout backpack	0		Damage Absorption: +100, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	rotten huge bag of GORP	3	crappy	Last Available: "2012-07"
-5741	mediocre high-proof water purification pills	10	decent	Last Available: "2012-07"
+5741	high-proof mediocre water purification pills	10	decent	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	artisanal weak CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
+5743	weak artisanal CSA scoutmaster's &quot;water&quot;	2	EPIC	Last Available: "2012-07"
 5744	super-sized rotten pulsating bag of GORF	5	crappy	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	delicious bag of QWOP	4	awesome	Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	flavorless big decent brain	5	decent	
 5754	tasty twirling good brain	4	awesome	
 5755	adequate fancy boss brain	3	good	Effect: "Stop the Presses!", Effect Duration: 5
-5756	yummy special hunter brain	3	awesome	Effect: "Ham-Fisted", Effect Duration: 35
+5756	special yummy hunter brain	3	awesome	Effect: "Ham-Fisted", Effect Duration: 35
 5758	upside-down upside-down rosewater-soaked frightening supercool Staff of Holiday Sensations	0		Moxie Percent: +20, Spooky Damage: +5, Stench Resistance: +3, Last Available: "2011-11"
 5759	Usain Bolt's mansplainer's staff	0		Monster Level: +15, Initiative: +80
 5760	squat gravedigger's flame-wreathed lion tamer's staff	0		Experience (familiar): +2, Hot Spell Damage: +10, Spooky Damage: +10
@@ -5665,14 +5665,14 @@
 5765	greasy boxer's fuzzy earmuffs	0		Muscle Percent: +10, Sleaze Spell Damage: +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	wobbly blurry horrifying smelly lion tamer's fuzzy montera	0		Experience (familiar): +2, Stench Spell Damage: +10, Spooky Damage: +25, Familiar Effect: "1.5xVolley, cap 32"
 5767	pulsating Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	bouncing gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Familiar Effect: "underwater", Last Available: "2012-08"
-5769	bouncing gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Familiar Effect: "block", Last Available: "2012-08"
-5770	narrow spinning gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Familiar Effect: "damage", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Familiar Effect: "delevel", Last Available: "2012-08"
+5768	bouncing gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	bouncing gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	narrow spinning gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
-5775	bouncing lime green fronts	0		Familiar Weight: +5
+5775	lime green bouncing fronts	0		Familiar Weight: +5
 5776	Barney's rake of chilblains of the overflowing toilet	0		Cold Damage: +25, Stench Spell Damage: +50
 5778	adequate gigantic blue idiot brain	10	good	
 5779	keel-haulin' knife of the overflowing toilet	0		Stench Spell Damage: +50
@@ -5687,8 +5687,8 @@
 5788	gray smut orc keepsake box	0		
 5789	mirror bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	experienced right bear arm of the businessman	0		Experience: +2, Meat Drop: +50, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	MacGyver's baleful brainy left bear arm	0		Mysticality: +5, Spell Damage: +25, Maximum MP: +100, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	experienced right bear arm of the businessman	0		Experience: +2, Meat Drop: +50, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	MacGyver's baleful brainy left bear arm	0		Mysticality: +5, Spell Damage: +25, Maximum MP: +100, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	Hat O' Nine Tails of extreme caution	0		Monster Level: -25
 5794	enhanced Enchanted Plunger	0		Effect: "Violent Night", Effect Duration: 46
 5795	pickled polymerized quantum yellow Enchanted Flyswatter	0		Effect: "Super Speed", Effect Duration: 52
@@ -5706,9 +5706,9 @@
 5807	aerosolized concentrated upside-down glass of warm milk	0		Effect: "Purpose", Effect Duration: 35
 5808	modified glass of gnat milk	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 49
 5809	polymerized pulsating Knob Goblin Mutagen	0		Effect: "Carrrsmic", Effect Duration: 15
-5810	unsweetened flattened colloidal bouncing cyan narrow Tears of the Quiet Healer	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 53
+5810	unsweetened flattened colloidal narrow cyan bouncing Tears of the Quiet Healer	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 53
 5811	galvanized frozen pulsating tube of lipstick	0		Effect: "Adapt to Change Eventually", Effect Duration: 25
-5812	wet lime green pulsating mirror skelelton spine	0		Effect: "Can't Smell Nothin'", Effect Duration: 52
+5812	wet lime green mirror pulsating skelelton spine	0		Effect: "Can't Smell Nothin'", Effect Duration: 52
 5813	alkaline non-vacuum-sealed blue skewed squat smut orc sunglasses	0		Effect: "Icy Demeanor", Effect Duration: 38
 5814	magnetized purple blob of acid	0		Effect: "Sugary Tongue", Effect Duration: 40
 5815	polymerized diffused flayed mind	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 18
@@ -5718,7 +5718,7 @@
 5819	dry anodized gravy fairy warlock hat	0		Effect: "Mmmmmelon", Effect Duration: 18
 5820	colloidal nitrogenated wobbly bull blubber	0		Effect: "Overstimulated", Effect Duration: 11
 5821	magnetized frog lip-print	0		Effect: "Pride of the Vampire", Effect Duration: 15
-5822	warmed alkaline narrow spinning gazely stare	0		Effect: "Pasty", Effect Duration: 13
+5822	warmed alkaline spinning narrow gazely stare	0		Effect: "Pasty", Effect Duration: 13
 5823	polarized cold-filtered super-activated canopic jar	0		Effect: "Clean-Shaven", Effect Duration: 11
 5824	extra-alkaline corrupted bouncing clove-flavored lip balm	0		Effect: "Sticks and Stones", Effect Duration: 62
 5825	polarized Skullery Maid's Knee	0		Effect: "Employee of the Month", Effect Duration: 61
@@ -5732,7 +5732,7 @@
 5833	modified galvanized brigand brittle	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 20
 5834	extra-denatured aerosolized blinking holistic headache remedy	0		Effect: "Buggy Flavor", Effect Duration: 45
 5835	quadruple-corrupted vacuum-sealed scrunchie tourniquet	0		Effect: "Horrid, Torrid", Effect Duration: 65
-5836	chilled jittery spinning embezzler's oil	0		Effect: "Angry like the Wolf", Effect Duration: 55
+5836	chilled spinning jittery embezzler's oil	0		Effect: "Angry like the Wolf", Effect Duration: 55
 5837	anodized quantum skewed Fu Manchu Wax	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 53
 5838	frozen Iiti Kitty Gumdrop	0		Effect: "Wreathed in Merriment", Effect Duration: 53
 5839	warmed aerosolized nitrogenated blurry ravenous eye	0		Effect: "Thanksgot", Effect Duration: 27
@@ -5744,8 +5744,8 @@
 5845	Vulcanized dry compressed air canister	0		Effect: "Pie in the Sky", Effect Duration: 35
 5846	vacuum-sealed purple salt water taffy	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 54
 5847	tarnished polymerized unholy water	0		Effect: "Piratey Flavor", Effect Duration: 46
-5848	unsweetened red skewed Bangyomaman battle juice	0		Effect: "Celestial Body", Effect Duration: 17
-5849	extra-quantum narrow gray handyman &quot;hand soap&quot;	0		Effect: "Patent Avarice", Effect Duration: 26
+5848	unsweetened skewed red Bangyomaman battle juice	0		Effect: "Celestial Body", Effect Duration: 17
+5849	extra-quantum gray narrow handyman &quot;hand soap&quot;	0		Effect: "Patent Avarice", Effect Duration: 26
 5850	galvanized dry moist space marine flash grenade	0		Effect: "Bustle Hustlin'", Effect Duration: 46
 5851	deionized skewed temporary tribal tattoo	0		Effect: "Amorous Avarice", Effect Duration: 55
 5852	unsweetened triple-modified oil-filled donut	0		Effect: "Scrappy, Shadowy", Effect Duration: 50
@@ -5763,7 +5763,7 @@
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	non-colloidal pickled papier-mochi	0		Effect: "Fizzier Than Light", Effect Duration: 15, Last Available: "2012-09"
 5866	vacuum-sealed papier-m&acirc;chaeranthera	0		Effect: "Cosmic Flavor", Effect Duration: 28, Last Available: "2012-09"
-5867	non-energized energized narrow skewed jittery papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Enraged", Effect Duration: 55, Last Available: "2012-09"
+5867	non-energized energized jittery skewed narrow papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Enraged", Effect Duration: 55, Last Available: "2012-09"
 5868	inspector's asbestos-lined papier-m&acirc;ch&eacute;te	0		Hot Resistance: +5, Item Drop: +15, Last Available: "2012-09"
 5869	jittery fuchsia supercool papier-m&acirc;chine gun of the overflowing toilet	0		Moxie Percent: +20, Stench Spell Damage: +50, Last Available: "2012-09"
 5870	tumbling resourceful stylish papier-masque	0		Moxie: +25, Maximum MP: +50, Single Equip, Last Available: "2012-09"
@@ -5791,7 +5791,7 @@
 5892	irradiated huge that gum you like	0		Effect: "Adventurer's Best Friendship", Effect Duration: 11
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	bouncing Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
-5895	wobbly olive avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
+5895	olive wobbly avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
 5896	blurry canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	distilled bouncing Unconscious Collective Dream Jar	1	decent	Last Available: "2013-12"
 5898	cyan jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	green pulsating BittyCar MeatCar	0		Last Available: "2012-12"
 5927	bouncing BittyCar HotCar	0		Last Available: "2012-12"
-5928	MacGyver's brainwave-controlled unicorn horn	0		Maximum MP: +100, Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12"
+5928	MacGyver's brainwave-controlled unicorn horn	0		Maximum MP: +100, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	Jack Frost's Temple Grandin's plastic four-shadowed mime of the dark arts	0		Spell Damage Percent: +100, Familiar Weight: +7, Cold Spell Damage: +50, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	huge wicked plastic Father McGruber	0		Spell Damage: +5, Last Available: "2012-12"
 5961	blue veiny plastic Hank North, Photojournalist	0		Maximum HP: +10, Last Available: "2012-12"
 5962	upside-down crafty plastic blazing bat	0		Maximum MP: +10, Last Available: "2012-12"
-5963	tumbling forbidden Fonzie's electronic dulcimer pants	0		Experience (Moxie): +1, Spell Damage Percent: +50, Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12"
+5963	tumbling forbidden Fonzie's electronic dulcimer pants	0		Experience (Moxie): +1, Spell Damage Percent: +50, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	pulsating A-Boo clue	0		
 5965	beefy Frown Exerciser of James Dean	0		Muscle: +10, Experience (Moxie): +3, Single Equip, Last Available: "2012-12"
 5966	huge yellow soul monocle	0		Single Equip
@@ -5873,26 +5873,26 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	teal record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	spinning coward's Jim Carey's veiny silent beret	0		Maximum HP: +10, Monster Level: 5, Familiar Effect: "1xVolley, cap 3"
-5978	spoiled gigantic slice of pizza	9	crappy	Last Available: "2013-02"
+5978	gigantic spoiled slice of pizza	9	crappy	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	wobbly star	0		Last Available: "2013-02"
-5982	watered-down hand-crafted tankard of ale	2	EPIC	Last Available: "2013-02"
+5982	hand-crafted watered-down tankard of ale	2	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	asbestos-lined smartaleck's cloth cap of the cheetah	0		Moxie Percent: +30, Hot Resistance: +5, Initiative: +60, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	tumbling ruddy occult sinister iron dagger	0		Spell Damage: +10, Spell Damage Percent: +25, Maximum HP Percent: +40, Last Available: "2013-02"
 5986	bland hamburger	4	decent	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
-5988	fuchsia tumbling potion	0		Last Available: "2013-02"
+5988	tumbling fuchsia potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
 5990	spirit-forward bad bottle of wine	5	decent	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
 5992	Usain Bolt's friendly occult iron helmet	0		Spell Damage Percent: +25, Familiar Weight: +3, Initiative: +80, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	rosewater-soaked stylish steel sword of Tarzan	0		Moxie: +25, Experience (Muscle): +3, Stench Resistance: +3, Last Available: "2013-02"
-5994	decent half-sized whole roasted chicken	2	good	Last Available: "2013-02"
+5994	half-sized decent whole roasted chicken	2	good	Last Available: "2013-02"
 5995	wobbly massive gemstone	0		Last Available: "2013-02"
 5996	yellow extra-strength potion	0		Last Available: "2013-02"
-5997	mirror spinning potion	0		Last Available: "2013-02"
+5997	spinning mirror potion	0		Last Available: "2013-02"
 5998	mediocre yellow narrow shining goblet	4	decent	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
 6000	shaking shaking crafty dance instructor's crown of James Dean	0		Experience (Moxie): +3, Experience Percent (Moxie): +10, Maximum MP: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
@@ -5911,7 +5911,7 @@
 6013	purple coward's orcish stud-finder of Gandalf	0		Spell Critical Percent: +20, Monster Level: -20
 6014	screwing pooch of the businessman	0		Meat Drop: +50
 6015	vacuum-sealed vacuum-sealed orcish hand lotion	0		Effect: "Boletus Swoletus", Effect Duration: 64
-6016	Vulcanized shaking fuchsia orcish rubber	0		Effect: "Oily Flavor", Effect Duration: 49
+6016	Vulcanized fuchsia shaking orcish rubber	0		Effect: "Oily Flavor", Effect Duration: 49
 6017	ionized diffused spinning orcish nailing lube	0		Effect: "Super Vision", Effect Duration: 40
 6018	triple-distilled artisanal mirror backwoods screwdriver	6	EPIC	
 6019	vibrating loadstone	0		Maximum MP Percent: +10
@@ -5922,7 +5922,7 @@
 6024	Whatsian Ionic Pliers of horror	0		Spooky Spell Damage: +25
 6025	denatured quantum Polysniff Perfume	0		Effect: "Pecan Pied Piper", Effect Duration: 28
 6026	Duskwalker syringe	0		
-6027	blinking gray Space Tours Tripple	0		
+6027	gray blinking Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	mirror cyan arcane researcher's dress pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "2xFairy, cap 28"
@@ -5930,8 +5930,8 @@
 6032	auspicious brawny motorcycle boots	0		Muscle Percent: +20, Item Drop: +10, Single Equip
 6033	blurry wobbly nippy Van der Graaf stolen necklace	0		Cold Damage: +10, MP Regen Min: 5, MP Regen Max: 7
 6034	Jim Carey's arcane researcher's troll britches	0		Experience Percent (Mysticality): +10, Monster Level: +25, Familiar Effect: "1.5xPotato, cap 28"
-6035	extra-aerosolized wobbly blinking bouncing vial of The Glistening	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 42
-6036	hand-crafted irresponsibly strong olive artisanal limoncello	8	EPIC	
+6035	extra-aerosolized bouncing blinking wobbly vial of The Glistening	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 42
+6036	irresponsibly strong hand-crafted olive artisanal limoncello	8	EPIC	
 6037	spinning ginger ale	0		
 6038	half-sized yummy incredible pizza	2	awesome	
 6039	Socratic oil cap of wisdom	0		Mysticality: +15, Experience (Mysticality): +1, Familiar Effect: "cap 28"
@@ -5951,7 +5951,7 @@
 6053	lousy high-proof Taco Dan's Taco Stand Chimichangarita	6	decent	Last Available: "2012-12"
 6054	energized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "stats.enq", Effect Duration: 66, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	skewed The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	skewed The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	executive Meatcleaver of Gandalf	0		Spell Critical Percent: +20, Meat Drop: +40, Last Available: "2013-12"
 6058	auspicious Crimbo Elf bobble-head	0		Item Drop: +10, Last Available: "2012-12"
 6059	narrow upside-down teal ribald Crimbo stogie-scented room odorizer	0		Sleaze Damage: +10, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	rotten blinking tumbling haggis-wrapped haggis-stuffed haggis	3	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	shaking haggis socks of the detective	0		Item Drop: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	shaking haggis socks of the detective	0		Item Drop: +20, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	lime green mirror Mr. Haggis	0		Last Available: "2012-12"
@@ -6023,7 +6023,7 @@
 6125	unsweetened frozen corrupted bottle of limeade	0		Effect: "Become Superficially interested", Effect Duration: 24, Last Available: "2013-12"
 6126	Fonzie's Newton's novelty tattoo sleeves	0		Experience (Mysticality): +3, Experience (Moxie): +1, Single Equip, Last Available: "2013-12"
 6127	pair of rhinoceros horns	0		Last Available: "2013-12"
-6128	blurry shaking furry brown pillow	0		Last Available: "2013-12"
+6128	shaking blurry furry brown pillow	0		Last Available: "2013-12"
 6129	mirror razor-sharp makeshift yakuza mask	0		Weapon Damage Percent: +25, Last Available: "2013-12"
 6130	blue piece	0		Last Available: "2013-12"
 6131	toy taijijian	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	perfumed rubber gloves	0		Stench Resistance: +5, Last Available: "2013-12"
 6140	blurry Chinese curse words	0		Last Available: "2013-12"
 6141	upside-down triad summoning scroll	0		Last Available: "2013-12"
-6142	special moldy half-sized roasted duck	2	crappy	Effect: "Robocamo", Effect Duration: 15, Last Available: "2013-12"
+6142	half-sized special moldy roasted duck	2	crappy	Effect: "Robocamo", Effect Duration: 15, Last Available: "2013-12"
 6143	bland dead meat bun	3	decent	Last Available: "2013-12"
 6144	brawny cat collar	0		Muscle Percent: +20, Single Equip, Last Available: "2013-12"
 6145	blurry personal trainer's suspicious-looking fedora of the overflowing toilet	0		Experience Percent (Muscle): +10, Stench Spell Damage: +50, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
@@ -6052,10 +6052,10 @@
 6155	twirling pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	Byte of vim and vigor of horror	0		Maximum HP Percent: +50, Spooky Spell Damage: +25, Last Available: "2013-12"
-6158	squat anger blaster of terror	0		Spooky Spell Damage: +10, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	squat doubt cannon of extreme caution	0		Monster Level: -25, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	sharpshooter's fear condenser	0		Critical Hit Percent: +10, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	asbestos-lined regret hose	0		Hot Resistance: +5, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	squat anger blaster of terror	0		Spooky Spell Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	squat doubt cannon of extreme caution	0		Monster Level: -25, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	sharpshooter's fear condenser	0		Critical Hit Percent: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	asbestos-lined regret hose	0		Hot Resistance: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	horrifying energetic commodore's hat	0		Maximum MP Percent: +20, Spooky Damage: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
@@ -6063,7 +6063,7 @@
 6166	greedy sizzling deck cannon	0		Hot Damage: +10, Meat Drop: +20, Last Available: "2013-12"
 6167	ornamental sextant of Leguizamo	0		Monster Level: +20, Last Available: "2013-12"
 6168	wool strapping Bloodbath	0		Muscle: +5, Cold Resistance: +1, Last Available: "2013-12"
-6169	tolerable weak Hundred Headed IPA	2	good	Last Available: "2013-12"
+6169	weak tolerable Hundred Headed IPA	2	good	Last Available: "2013-12"
 6170	stale chum	4	decent	Last Available: "2013-12"
 6171	galvanized purple crude crudit&eacute;s	0		Effect: "Retrograde Relaxation", Effect Duration: 27
 6172	warmed chilled candy crayons	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 49, Last Available: "2020-09"
@@ -6079,63 +6079,63 @@
 6182	cosmic cream	0		
 6183	green cosmic fruit	0		
 6184	shaking stylish Jarlsberg's hat of the brute of the brazier	0		Moxie: +25, Muscle Percent: +30, Hot Spell Damage: +25
-6185	normal big narrow consummate hard-boiled egg	5	good	
+6185	big normal narrow consummate hard-boiled egg	5	good	
 6186	snack-sized tasty consummate fried egg	2	awesome	
 6187	normal consummate egg salad	3	good	
 6188	moldy consummate bagel	4	crappy	
-6189	flavorless massive consummate sliced bread	9	decent	
+6189	massive flavorless consummate sliced bread	9	decent	
 6190	adequate consummate hot dog bun	4	good	
-6191	adequate special consummate brownie	3	good	Effect: "Robocamo", Effect Duration: 45
+6191	special adequate consummate brownie	3	good	Effect: "Robocamo", Effect Duration: 45
 6192	spoiled gigantic bouncing consummate toast	8	crappy	
 6193	tolerable tumbling passable stout	3	good	
 6194	fancy moldy consummate soup	3	crappy	Effect: "Eye of the Lihc", Effect Duration: 20
 6195	moldy teal consummate corn chips	4	crappy	
 6196	flavorless consummate salad	3	decent	
 6197	normal consummate salsa	3	good	
-6198	stale massive consummate sauerkraut	6	decent	
+6198	massive stale consummate sauerkraut	6	decent	
 6199	tasty pulsating consummate cheese slice	3	awesome	
 6200	spoiled consummate melted cheese	4	crappy	
-6201	tasty thick consummate bacon	5	awesome	
+6201	thick tasty consummate bacon	5	awesome	
 6202	toothsome consummate meatloaf	3	awesome	
 6203	rotten ghostly consummate steak	3	crappy	
 6204	toothsome consummate cuts	4	awesome	
 6205	moldy consummate frankfurter	3	crappy	
 6206	normal yellow consummate french fries	3	good	
-6207	normal gigantic consummate baked potato	9	good	
+6207	gigantic normal consummate baked potato	9	good	
 6208	bad acceptable vodka	4	decent	
 6209	bland miniature lime green consummate ice cream	2	decent	
-6210	thick tasty consummate whipped cream	5	awesome	
+6210	tasty thick consummate whipped cream	5	awesome	
 6211	bland immense consummate cream	8	decent	
 6212	jumbo normal consummate strawberries	5	good	
-6213	low-calorie stale consummate sorbet	1	decent	
+6213	stale low-calorie consummate sorbet	1	decent	
 6214	smooth adequate rum	4	awesome	
 6215	hand-crafted mediocre lager	3	EPIC	
 6216	small stale shaking immaculate grilled cheese	2	decent	
-6217	stale snack-sized squat immaculate ice cream sandwich	2	decent	
-6218	immense normal enchanted immaculate hot dog	6	good	Effect: "Devil Inside", Effect Duration: 50
+6217	snack-sized stale squat immaculate ice cream sandwich	2	decent	
+6218	normal immense enchanted immaculate hot dog	6	good	Effect: "Devil Inside", Effect Duration: 50
 6219	bland low-calorie pulsating immaculate egg salad sandwich	1	decent	
 6220	thick rotten perfect sandwich	5	crappy	
-6221	stale low-calorie skewed perfect chef salad	1	decent	
-6222	adequate skewed red perfect breakfast	4	good	
+6221	low-calorie stale skewed perfect chef salad	1	decent	
+6222	adequate red skewed perfect breakfast	4	good	
 6223	adequate sublime deluxe hot dog	4	good	
 6224	adequate blue sublime stew	4	good	
 6225	stale sublime nachos	3	decent	
 6226	tiny moldy Ultimate Breakfast Sandwich	1	crappy	
 6227	spoiled blinking Loaded Baked Potato	3	crappy	
 6228	spoiled Omega Sundae	3	crappy	
-6229	drinkable watered-down twirling fuchsia Das Sauerlager	2	good	
+6229	watered-down drinkable fuchsia twirling Das Sauerlager	2	good	
 6230	hand-crafted Bologna Lambic	3	EPIC	
 6231	mediocre triple-distilled Vodka Dog	10	decent	
 6232	artisanal practically non-alcoholic Disappointed Russian	1	super ultra EPIC	
 6233	spirit-forward tolerable Chunky Mary	5	good	
 6234	lousy blue Nachojito	3	decent	
 6235	acceptable watered-down Le Roi	2	good	
-6236	spirit-forward smooth Over Easy Rider	5	awesome	
+6236	smooth spirit-forward Over Easy Rider	5	awesome	
 6237	yellow cosmic six-pack	0		
 6239	deionized quantum cube of ectoplasm	0		Effect: "Pumped Up", Effect Duration: 40
-6240	flattened magnetized upside-down tumbling Illuminati earpiece	0		Effect: "Shot in the Arse", Effect Duration: 32
+6240	flattened magnetized tumbling upside-down Illuminati earpiece	0		Effect: "Shot in the Arse", Effect Duration: 32
 6241	quadruple-galvanized tarnished narrow censored can label	0		Effect: "Memories of Puppy Love", Effect Duration: 51
-6242	dry pressed fuchsia twirling ectoplasm <i>au jus</i>	0		Effect: "Action", Effect Duration: 36
+6242	dry pressed twirling fuchsia ectoplasm <i>au jus</i>	0		Effect: "Action", Effect Duration: 36
 6243	unsweetened the kindest cut	0		Effect: "Patent Prevention", Effect Duration: 62
 6244	quantum ionized cat's paw	0		Effect: "Clyde's Blessing", Effect Duration: 32
 6245	double-corrupted warmed ASCII fu manchu	0		Effect: "Gingerbread Robust", Effect Duration: 21
@@ -6144,7 +6144,7 @@
 6248	improved gamer slurry	0		Effect: "Punch Another Day", Effect Duration: 22
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	Jack Frost's dog trainer's vibrating hale numberwang of wisdom of the empath	0		Mysticality: +15, Maximum HP: +20, Maximum MP Percent: +10, Familiar Weight: +5, Experience (familiar): +1, Cold Spell Damage: +50, Single Equip
-6251	diffused quantum double-tarnished jittery maroon scroll of Protection from Bad Stuff	0		Effect: "Chilblains of the Corn", Effect Duration: 13, Last Available: "2013-02"
+6251	diffused quantum double-tarnished maroon jittery scroll of Protection from Bad Stuff	0		Effect: "Chilblains of the Corn", Effect Duration: 13, Last Available: "2013-02"
 6252	enhanced super-magnetized scroll of Puddingskin	0		Effect: "Flaming Weapon", Effect Duration: 12, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
@@ -6170,7 +6170,7 @@
 6274	perfectly mixed open sauce	3	EPIC	
 6275	spinning wobbly savvy turkey leg of courage	0		Mysticality Percent: +20, Spooky Resistance: +3
 6276	smooth jittery Ye Olde Meade	4	awesome	
-6277	adjusted polarized olive tumbling tumbling Ye Olde Bawdy Limerick	0		Effect: "Strength of Ten Ettins", Effect Duration: 19
+6277	adjusted polarized tumbling olive tumbling Ye Olde Bawdy Limerick	0		Effect: "Strength of Ten Ettins", Effect Duration: 19
 6278	wobbly Ye Olde Medieval Insult	0		
 6279	forbidden pewter claymore	0		Spell Damage Percent: +50
 6280	frosty artisanal rice peeler	0		Cold Spell Damage: +10
@@ -6186,7 +6186,7 @@
 6290	red steam-powered model rocketship	0		
 6291	auspicious careful punk rock jacket	0		Monster Level: -10, Item Drop: +10
 6292	red chaotic experienced safety pin	0		Experience: +2, Spell Critical Percent: +10
-6293	miniature bland stolen sushi	2	decent	
+6293	bland miniature stolen sushi	2	decent	
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6203,7 +6203,7 @@
 6307	modified wet skewed celestial olive oil	0		Effect: "Leash of Linguini", Effect Duration: 14, Last Available: "2013-03"
 6308	nitrogenated adjusted celestial carrot juice	0		Effect: "Stinky Weapon", Effect Duration: 63, Last Available: "2013-03"
 6309	electrified frozen celestial au jus	0		Effect: "Stench Jellied", Effect Duration: 19, Last Available: "2013-03"
-6310	improved vacuum-sealed blinking pulsating celestial squid ink	0		Effect: "The Real Deal", Effect Duration: 68, Last Available: "2013-03"
+6310	improved vacuum-sealed pulsating blinking celestial squid ink	0		Effect: "The Real Deal", Effect Duration: 68, Last Available: "2013-03"
 6311	ghostly lime green wholesome Uncle Buck	0		Maximum HP Percent: +10, Softcore Only
 6312	crate of fish meat	0		
 6313	shaking damp wallet	0		
@@ -6237,7 +6237,7 @@
 6341	pulsating beefcake's spectral axe of the dark arts	0		Muscle: +25, Spell Damage Percent: +100
 6342	maroon reassuring manspreader's super-strong air freshener	0		Monster Level: +10, Spooky Resistance: +1
 6343	super-polarized Mer-kin lipstick	0		Effect: "Superioreo", Effect Duration: 15
-6344	green squat tumbling Mer-kin mouthsoap	0		
+6344	green tumbling squat Mer-kin mouthsoap	0		
 6345	cold-filtered mirror Mer-kin strongjuice	0		Effect: "Boilermade", Effect Duration: 27
 6346	spinning Mer-kin fitbrine	0		
 6347	aerosolized Mer-kin ragejuice	0		Effect: "Unusual Perspective", Effect Duration: 60
@@ -6258,7 +6258,7 @@
 6362	boiled tumbling pulled indigo taffy	0		Effect: "Antsy in your Pantsy", Effect Duration: 33, Last Available: "2013-04"
 6363	super-activated galvanized blurry pulled taffy	0		Effect: "Leo Rising", Effect Duration: 59, Last Available: "2013-04"
 6364	extra-moist bouncing blinking pulled taffy	0		Effect: "Tenacity of the Snapper", Effect Duration: 39, Last Available: "2013-04"
-6365	vacuum-sealed mirror wobbly pulled taffy	0		Effect: "Unrunnable Face", Effect Duration: 26, Last Available: "2013-04"
+6365	vacuum-sealed wobbly mirror pulled taffy	0		Effect: "Unrunnable Face", Effect Duration: 26, Last Available: "2013-04"
 6366	activated frozen blurry pulled violet taffy	0		Effect: "Sparkling Consciousness", Effect Duration: 59, Last Available: "2013-04"
 6367	warmed bouncing pulled taffy	0		Effect: "Electrolit Up", Effect Duration: 45, Last Available: "2013-04"
 6368	Mer-kin hallpass	0		
@@ -6283,7 +6283,7 @@
 6388	envyfish egg	0		Last Available: "2013-04"
 6389	energized nitrogenated bouncing Mer-kin rocksalt	0		Effect: "Ancestral Disapproval", Effect Duration: 50
 6390	chilled irradiated Mer-kin saltmint	0		Effect: "Dreadful Sheen", Effect Duration: 15
-6391	enhanced blinking squat Mer-kin saltsquid	0		Effect: "Fever From the Flavor", Effect Duration: 61
+6391	enhanced squat blinking Mer-kin saltsquid	0		Effect: "Fever From the Flavor", Effect Duration: 61
 6392	cyan pulsating gravedigger's flame-wreathed scale-mail underwear	0		Hot Spell Damage: +10, Spooky Damage: +10, Familiar Effect: "2xVolley"
 6393	denatured ionized maroon comb jelly	0		Effect: "Hoity Toity", Effect Duration: 33
 6394	anemone sauce	0		
@@ -6293,7 +6293,7 @@
 6398	teal glass	0		
 6399	super-flattened modified shaking Boss Drops	0		Effect: "Al Dente Inferno", Effect Duration: 43
 6400	Mer-kin lunchbox	0		
-6401	warmed upside-down shaking tear	0		Effect: "Sagittarius Rising", Effect Duration: 16
+6401	warmed shaking upside-down tear	0		Effect: "Sagittarius Rising", Effect Duration: 16
 6402	non-altered pressed jagged tooth	0		Effect: "meat.enh", Effect Duration: 50
 6403	electrified denatured skewed grisly shell fragment	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 13
 6404	alkaline warmed blurry violent pastilles	0		Effect: "Spooky Flavor", Effect Duration: 14
@@ -6314,10 +6314,10 @@
 6419	quadruple-ionized improved maroon moth dust	0		Effect: "Well-Swabbed Ear", Effect Duration: 15
 6420	altered enhanced glob of spoiled mayo	0		Effect: "Bored Stiff", Effect Duration: 45
 6421	tonic djinn	0		
-6422	miniature flavorless twirling vampire chowder	2	decent	
+6422	flavorless miniature twirling vampire chowder	2	decent	
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
-6425	red upside-down Official Seal of Dreadsylvania	0		
+6425	upside-down red Official Seal of Dreadsylvania	0		
 6426	rotten fancy Dreadsylvanian stew	3	crappy	Effect: "Twinklebritches", Effect Duration: 25
 6427	acceptable Dreadsylvanian	3	good	
 6428	denatured wet olive skewed Dreadsylvanian flask	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 17
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	skewed dreadful roast	0		
 6487	stinking agaricus	0		
-6488	adequate half-sized Dreadsylvanian shepherd's pie	2	good	
+6488	half-sized adequate Dreadsylvanian shepherd's pie	2	good	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
@@ -6417,7 +6417,7 @@
 6522	twirling lard-coated groping claw of the wise owl	0		Mysticality: +20, Sleaze Spell Damage: +25
 6523	vengeful spirit of the early riser	0		Adventures: +7
 6524	squat Herculean BOOtonniere	0		Experience (Muscle): +1, Single Equip
-6525	moist red shaking ghost thread	0		Effect: "Sauce Monocle", Effect Duration: 24
+6525	moist shaking red ghost thread	0		Effect: "Sauce Monocle", Effect Duration: 24
 6526	wool strapping bag of unfinished business	0		Muscle: +5, Cold Resistance: +1
 6527	lime green perfumed Jim Carey's transparent pants	0		Monster Level: +25, Stench Resistance: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	narrow hothammer of Gandalf	0		Spell Critical Percent: +20
@@ -6429,7 +6429,7 @@
 6534	dance instructor's remorseless knife	0		Experience Percent (Moxie): +10
 6535	tumbling MacGyver's intimidating coiffure	0		Maximum MP: +100, Familiar Effect: "hot afk, 1xPotato"
 6536	avaricious Jim Carey's cod cape	0		Monster Level: +25, Meat Drop: +30
-6537	decent big upside-down blood sausage	5	good	
+6537	big decent upside-down blood sausage	5	good	
 6538	lightning-fast asbestos-lined frying brainpan	0		Hot Resistance: +5, Initiative: +40
 6539	olive lightning-fast ball and chain of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Single Equip
 6540	Temple Grandin's dry bone	0		Familiar Weight: +7
@@ -6438,10 +6438,10 @@
 6543	knitted quilted pogo stick	0		Damage Absorption: +40, Cold Resistance: +3, Single Equip
 6545	tumbling family-friendly reassuring weedy skirt of mayonnaise	0		Sleaze Spell Damage: +50, Spooky Resistance: +1, Sleaze Resistance: +1, Familiar Effect: "atk, 1xFairy"
 6546	Sinatra's pants of James Dean	0		Experience (Moxie): 8, Familiar Effect: "atk"
-6547	purple shaking Thwaitgold Goliath beetle statuette	0		
+6547	shaking purple Thwaitgold Goliath beetle statuette	0		
 6548	yellow cooling iron helmet	0		
 6549	upside-down cooling iron breastplate	0		
-6550	pulsating twirling cooling iron greaves	0		
+6550	twirling pulsating cooling iron greaves	0		
 6551	blurry hot cluster	0		
 6552	cluster	0		
 6553	skewed blurry cluster	0		
@@ -6455,16 +6455,16 @@
 6561	olive adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	jittery mini-Mr. Accessory	0		Familiar Weight: +5
 6563	energetic hand of Mr. Cards	0		Maximum MP Percent: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	big stale Dreadsylvanian hot pocket	5	decent	
+6564	stale big Dreadsylvanian hot pocket	5	decent	
 6565	half-sized spoiled Dreadsylvanian pocket	2	crappy	
 6566	moldy small Dreadsylvanian pocket	2	crappy	
-6567	stale diet Dreadsylvanian stink pocket	1	decent	
+6567	diet stale Dreadsylvanian stink pocket	1	decent	
 6568	toothsome miniature cyan Dreadsylvanian sleaze pocket	2	awesome	
-6569	tolerable distilled Dreadsylvanian hot toddy	5	good	
-6570	weak perfectly mixed blurry Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
+6569	distilled tolerable Dreadsylvanian hot toddy	5	good	
+6570	perfectly mixed weak blurry Dreadsylvanian cold-fashioned	2	super ultra mega turbo EPIC	
 6571	acceptable Dreadsylvanian grimlet	3	good	
-6572	lousy special Dreadsylvanian dank and stormy	3	decent	Effect: "Flaming Weapon", Effect Duration: 20
-6573	drinkable watered-down green Dreadsylvanian slithery nipple	2	good	
+6572	special lousy Dreadsylvanian dank and stormy	3	decent	Effect: "Flaming Weapon", Effect Duration: 20
+6573	watered-down drinkable green Dreadsylvanian slithery nipple	2	good	
 6574	hot clusterbomb	0		
 6575	tumbling clusterbomb	0		
 6576	tumbling clusterbomb	0		
@@ -6482,7 +6482,7 @@
 6588	stanky weightlifter's gnawed-up dog bone	0		Muscle: +15, Stench Spell Damage: +25
 6589	strapping Grey Guanon	0		Muscle: +5
 6590	upside-down ribald resourceful Engorged Sausages and You of James Dean	0		Experience (Moxie): +3, Maximum MP: +50, Sleaze Damage: +10
-6591	watered-down tolerable dream of a dog	2	good	
+6591	tolerable watered-down dream of a dog	2	good	
 6592	double-paned padded experienced optimal spreadsheet	0		Experience: +2, Damage Absorption: +20, Cold Resistance: +5
 6593	bouncing defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
@@ -6505,12 +6505,12 @@
 6611	clockwork numeral XI	0		
 6612	gray clockwork numeral XII	0		
 6613	clockwork cuckoo	0		
-6614	maroon upside-down cuckoo clock	0		
+6614	upside-down maroon cuckoo clock	0		
 6615	perfectly mixed pulsating Cold One	3	???	
-6616	flavorless small spaghetti breakfast	2	???	
+6616	small flavorless spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
-6619	olive skewed folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
+6619	skewed olive folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	upside-down folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
@@ -6519,7 +6519,7 @@
 6625	folder (wizard)	0		Experience (Mysticality): +2, Last Available: "2013-08"
 6626	narrow folder (space skeleton)	0		Experience (Moxie): +2, Last Available: "2013-08"
 6627	shaking folder (D-Team)	0		Last Available: "2013-08"
-6628	maroon wobbly spinning squat folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
+6628	maroon squat spinning wobbly folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	blurry folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	lime green folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
@@ -6569,7 +6569,7 @@
 6677	jittery crude monster sculpture	0		
 6678	twirling flame-retardant Yearbook Club Camera	0		Hot Resistance: +1, Conditional Skill (Equipped): "Blinding Flash"
 6679	machete of the pedagogue	0		Experience: +3
-6680	weak artisanal Cursed Punch	2	EPIC	
+6680	artisanal weak Cursed Punch	2	EPIC	
 6681	mediocre Bowl of Scorpions	4	decent	
 6682	lousy Fog Murderer	4	decent	
 6683	book of matches	0		
@@ -6594,13 +6594,13 @@
 6702	wobbly bowler	0		
 6703	imitation White Russian	1	decent	
 6704	fuchsia short-handled mop of incineration of the overflowing toilet	0		Hot Spell Damage: +50, Stench Spell Damage: +50
-6705	bland huge jungle floor wax	10	decent	
+6705	huge bland jungle floor wax	10	decent	
 6706	smirking shrunken head	0		
 6707	polymerized quantum colorful toad	0		Effect: "Disco Nirvana", Effect Duration: 11
 6708	crude voodoo doll	0		
 6709	wobbly attorney's badge	0		Single Equip
 6710	Jack Frost's padded pygmy briefs	0		Damage Absorption: +20, Cold Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 41"
-6711	gray shaking short writ of habeas corpus	0		
+6711	shaking gray short writ of habeas corpus	0		
 6712	jittery bone abacus	0		
 6713	adder	0		
 6714	teal short calculator	0		
@@ -6613,7 +6613,7 @@
 6721	vibrating medical-grade Fonzie's water bottle	0		Experience (Moxie): +1, Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	vacuum-sealed shaking teal pygmy phone number	0		Effect: "Pretending to Pretend", Effect Duration: 30
 6723	narrow Boozehounds Anonymous token	0		
-6724	stale upside-down olive exotic jungle fruit	3	decent	
+6724	stale olive upside-down exotic jungle fruit	3	decent	
 6725	huge Shore Inc. Ship Trip Scrip	0		
 6726	mirror jittery dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
@@ -6634,7 +6634,7 @@
 6742	rock-hard junk band	0		Damage Reduction: 5
 6743	brawny junk trunks	0		Muscle Percent: +20, Familiar Effect: "cap 15"
 6744	family-friendly junk-mail shirt	0		Sleaze Resistance: +1
-6745	miniature adequate fuchsia junk food	2	good	
+6745	adequate miniature fuchsia junk food	2	good	
 6746	aged junk yard	3	awesome	
 6747	olive tumbling Socratic swordzall of the cheetah	0		Experience (Mysticality): +1, Initiative: +60
 6748	skewed arm buzzer of the brazier	0		Hot Spell Damage: +25, Damage Reduction: 6
@@ -6649,12 +6649,12 @@
 6757	lousy can of Br&uuml;talbr&auml;u	3	decent	Last Available: "2013-09"
 6758	perfectly mixed bouncing can of Drooling Monk	4	EPIC	Last Available: "2013-09"
 6759	hand-crafted can of Impetuous Scofflaw	4	EPIC	Last Available: "2013-09"
-6760	strong perfectly mixed bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
+6760	perfectly mixed strong bottle of Old Pugilist	5	EPIC	Last Available: "2013-09"
 6761	bad enchanted bottle of Professor Beer	3	decent	Effect: "Prince of Seaside Town", Effect Duration: 50, Last Available: "2013-09"
-6762	mediocre squat blue narrow bottle of Rapier Witbier	4	decent	Last Available: "2013-09"
+6762	mediocre blue narrow squat bottle of Rapier Witbier	4	decent	Last Available: "2013-09"
 6763	drinkable lime green bottle of Race Car Red	4	good	Last Available: "2013-09"
 6764	bad bottle of Greedy Dog	3	decent	Last Available: "2013-09"
-6765	practically non-alcoholic drinkable teal bottle of Lambada Lambic	1	good	Last Available: "2013-09"
+6765	drinkable practically non-alcoholic teal bottle of Lambada Lambic	1	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	fancy liquid bread	1	good	Effect: "Flame-Retardant Trousers", Effect Duration: 50, Last Available: "2013-09"
@@ -6673,7 +6673,7 @@
 6781	manspreader's sharpshooter's scabrous seal epaulets	0		Critical Hit Percent: +10, Monster Level: +10, Single Equip
 6782	purple abyssal battle plans	0		
 6783	chilly manspreader's seal medal of the businessman	0		Monster Level: +10, Cold Damage: +5, Meat Drop: +50
-6784	spinning squat deanimated reanimator's coffin	0		Free Pull
+6784	squat spinning deanimated reanimator's coffin	0		Free Pull
 6785	upside-down flask of embalming fluid	0		
 6788	blank diary	0		
 6789	boot knife	0		
@@ -6683,13 +6683,13 @@
 6793	soap knife	0		
 6795	triple-enhanced concentrated narrow disco horoscope (Aquarius)	0		Effect: "Cool Spirit", Effect Duration: 40
 6796	activated lime green disco horoscope (Pisces)	0		Effect: "All Fired Up", Effect Duration: 11
-6797	quadruple-electrified bouncing pulsating twirling disco horoscope (Aries)	0		Effect: "Healthy Blue Glow", Effect Duration: 26
+6797	quadruple-electrified twirling bouncing pulsating disco horoscope (Aries)	0		Effect: "Healthy Blue Glow", Effect Duration: 26
 6798	modified ghostly disco horoscope (Taurus)	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 12
 6799	super-nitrogenated irradiated adjusted blurry disco horoscope (Gemini)	0		Effect: "Here's Mud in Your Eye", Effect Duration: 53
 6800	alkaline double-pickled disco horoscope (Cancer)	0		Effect: "Your Interest is Peaked", Effect Duration: 47
 6801	deionized alkaline non-ionized disco horoscope (Leo)	0		Effect: "Dwarven Hardiness", Effect Duration: 49
 6802	boiled corrupted disco horoscope (Virgo)	0		Effect: "Toothy Grin", Effect Duration: 34
-6803	activated jittery blurry disco horoscope (Libra)	0		Effect: "Highland Sheen", Effect Duration: 51
+6803	activated blurry jittery disco horoscope (Libra)	0		Effect: "Highland Sheen", Effect Duration: 51
 6804	tarnished corrupted spinning disco horoscope (Scorpio)	0		Effect: "Perfect Hair", Effect Duration: 61
 6805	quantum disco horoscope (Sagittarius)	0		Effect: "Using Protection", Effect Duration: 21
 6806	polarized disco horoscope (Capricorn)	0		Effect: "Sugary World View", Effect Duration: 66
@@ -6717,7 +6717,7 @@
 6828	tolerable tumbling discocktail	4	good	
 6829	ribald KoL Con X Bingo Card	0		Sleaze Damage: +10
 6830	weightlifter's Temporal Tempera Tube	0		Muscle: +15
-6831	tarnished anodized green huge Tallowcreme Halloween Pumpkin	0		Effect: "Ode to Booze", Effect Duration: 61
+6831	tarnished anodized huge green Tallowcreme Halloween Pumpkin	0		Effect: "Ode to Booze", Effect Duration: 61
 6832	Way More Tears&trade; pepper spray	0		
 6833	improved Milk Studs	0		Effect: "Eye of the Seal", Effect Duration: 48
 6834	boiled quadruple-alkaline narrow box of Dweebs	0		Effect: "Balls of Ectoplasm", Effect Duration: 56
@@ -6732,7 +6732,7 @@
 6843	diffused blinking bone bons	0		Effect: "Is This Your Card?", Effect Duration: 42
 6844	super-diffused ironic mint	0		Effect: "Marco Polarity", Effect Duration: 24
 6845	purple unused walkie-talkie	0		Free Pull
-6846	bouncing cyan walkie-talkie	0		Free Pull
+6846	cyan bouncing walkie-talkie	0		Free Pull
 6847	cyan mirror killing jar	0		
 6848	security flashlight of the scaredy-cat	0		Monster Level: -15
 6849	diffused Effermint&trade; tablets	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 41
@@ -6746,13 +6746,13 @@
 6857	ghostly Jack Frost's Cajun accordion	0		Cold Spell Damage: +50, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	skewed wool quirky accordion	0		Cold Resistance: +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	jittery extremely unsafe Skipper's accordion of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	inspector's frosty banded weightlifter's Pantsgiving	0		Muscle: +15, Damage Absorption: +100, Cold Spell Damage: +10, Item Drop: +15, Softcore Only, Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11"
+6860	inspector's frosty banded weightlifter's Pantsgiving	0		Muscle: +15, Damage Absorption: +100, Cold Spell Damage: +10, Item Drop: +15, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	normal can of sardines	4	good	Last Available: "2013-11"
 6862	yummy high-calorie sugar substitute	3	awesome	Last Available: "2013-11"
 6863	stale pat of butter	3	decent	Last Available: "2013-11"
-6864	huge flavorless dinner roll	6	decent	Last Available: "2013-11"
+6864	flavorless huge dinner roll	6	decent	Last Available: "2013-11"
 6865	stale mashed potatoes	3	decent	Last Available: "2013-11"
-6866	decent big lime green whole turkey leg	5	good	Last Available: "2013-11"
+6866	big decent lime green whole turkey leg	5	good	Last Available: "2013-11"
 6867	spoiled deviled egg	4	crappy	Last Available: "2013-11"
 6868	altered vacuum-sealed green finger exerciser	0		Effect: "Ichorous Intensity", Effect Duration: 34, Last Available: "2013-11"
 6869	extra-electrified altered tarnished dented spoon	0		Effect: "Ponderous Potency", Effect Duration: 66, Last Available: "2013-11"
@@ -6807,9 +6807,9 @@
 6918	nitrogenated extra-irradiated flattened maroon warbear wardance potion	0		Effect: "Nutrient-Rich", Effect Duration: 54, Last Available: "2013-12"
 6919	extra-alkaline alkaline extra-tarnished red squat warbear bearserker potion	0		Effect: "Appeteyes", Effect Duration: 45, Last Available: "2013-12"
 6920	ionized ionized warbear liquid overcoat	0		Effect: "Sepia Tan", Effect Duration: 48, Last Available: "2013-12"
-6921	small bland warbear feasting bread	2	decent	Last Available: "2013-12"
+6921	bland small warbear feasting bread	2	decent	Last Available: "2013-12"
 6922	moldy warbear warrior bread	3	crappy	Last Available: "2013-12"
-6923	super-sized toothsome teal spinning narrow warbear thermoregulator bread	5	awesome	Last Available: "2013-12"
+6923	toothsome super-sized teal narrow spinning warbear thermoregulator bread	5	awesome	Last Available: "2013-12"
 6924	artisanal blurry warbear feasting mead	3	EPIC	Last Available: "2013-12"
 6925	hand-crafted warbear bearserker mead	4	EPIC	Last Available: "2013-12"
 6926	mediocre purple warbear blizzard mead	3	decent	Last Available: "2013-12"
@@ -6847,7 +6847,7 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	red Temple Grandin's warbear foil hat	0		Familiar Weight: +7, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	arcane researcher's warbear oil pan of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	arcane researcher's warbear oil pan of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	twirling warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	narrow warbear exhaust manifold of the cheetah	0		Initiative: +60, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	squat warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6894,11 +6894,11 @@
 7005	cyan lump of Brituminous coal	0		Last Available: "2013-12"
 7006	altered handful of Smithereens	1	crappy	Last Available: "2013-12"
 7007	yummy massive Every Day is Like This Sundae	8	awesome	Last Available: "2013-12"
-7008	yummy snack-sized Miserable Pie	2	awesome	Last Available: "2013-12"
-7009	normal thick This Charming Flan	5	good	Last Available: "2013-12"
+7008	snack-sized yummy Miserable Pie	2	awesome	Last Available: "2013-12"
+7009	thick normal This Charming Flan	5	good	Last Available: "2013-12"
 7010	lousy Irish Coffee, English Heart	4	decent	Last Available: "2013-12"
 7011	bad Strikes Again Bigmouth	4	decent	Last Available: "2013-12"
-7012	hand-crafted triple-distilled red Paint A Vulgar Pitcher	6	EPIC	Last Available: "2013-12"
+7012	triple-distilled hand-crafted red Paint A Vulgar Pitcher	6	EPIC	Last Available: "2013-12"
 7013	green blurry Golden Light	0		Last Available: "2013-12"
 7014	wobbly Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6918,7 +6918,7 @@
 7029	reassuring brainy Shakespeare's Sister's Accordion of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25, Spooky Resistance: +1, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	pulsating nasty third-hand lantern	0		Stench Damage: +5
 7031	loose purse strings	0		
-7032	enchanted adequate super-sized pickled egg	5	good	Effect: "Frozen Shoulders", Effect Duration: 10
+7032	adequate enchanted super-sized pickled egg	5	good	Effect: "Frozen Shoulders", Effect Duration: 10
 7033	cup of lukewarm tea	1	decent	
 7034	mirror warbear soda machine assembler	0		Last Available: "2013-12"
 7035	warbear box	0		Last Available: "2013-12"
@@ -6929,11 +6929,11 @@
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	shaking huge warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
-7043	upside-down jittery warbear sequential gaiety distribution system	0		Last Available: "2013-12"
+7043	jittery upside-down warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	altered glass slipper	0		Effect: "Nightlit", Effect Duration: 54, Last Available: "2014-12"
 7045	pickled blinking antimatter wad	1	good	Last Available: "2013-12"
 7046	diffused shaking warbear superpotion	0		Effect: "World's Shortest Giant", Effect Duration: 15, Last Available: "2013-12"
-7047	pressed non-nitrogenated skewed green warbear liquid lasers	0		Effect: "Cold Hands", Effect Duration: 37, Last Available: "2013-12"
+7047	pressed non-nitrogenated green skewed warbear liquid lasers	0		Effect: "Cold Hands", Effect Duration: 37, Last Available: "2013-12"
 7048	dry anodized fuchsia warbear rejuvenation potion	0		Effect: "Boletus Swoletus", Effect Duration: 16, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	yummy twirling warbear gyro	4	awesome	Last Available: "2013-12"
@@ -6951,13 +6951,13 @@
 7062	jittery praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
 7064	hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
-7065	pickled ghostly tumbling grim fairy tale	1	good	Last Available: "2014-12"
+7065	pickled tumbling ghostly grim fairy tale	1	good	Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	galvanized colloidal upside-down single of Inigo's Incantation of Inspiration	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 39, Last Available: "2010-02"
-7068	ionized warmed mirror olive single of Donho's Bubbly Ballad	0		Effect: "La Bamba", Effect Duration: 47
+7068	ionized warmed olive mirror single of Donho's Bubbly Ballad	0		Effect: "La Bamba", Effect Duration: 47
 7069	wobbly Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	spinning packet of winter seeds	0		Last Available: "2014-01"
-7071	moldy red tumbling snow berries	3	crappy	Last Available: "2014-01"
+7071	moldy tumbling red snow berries	3	crappy	Last Available: "2014-01"
 7072	tasty ice harvest	3	awesome	Last Available: "2014-01"
 7073	colloidal ionized super-irradiated frost flower	0		Effect: "Broken Fast", Effect Duration: 22, Last Available: "2014-01"
 7074	alkaline tumbling snow cleats	0		Effect: "Enraged", Effect Duration: 49, Last Available: "2014-01"
@@ -6997,10 +6997,10 @@
 7108	spoiled pecan	4	crappy	Last Available: "2014-12"
 7109	jumbo normal pecan pie	5	good	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
-7111	fancy super-sized rotten candy mountain oyster	5	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 50, Last Available: "2014-12"
-7112	aged watered-down chocotini	2	awesome	Last Available: "2014-12"
+7111	rotten fancy super-sized candy mountain oyster	5	crappy	Effect: "You're High as a Crow, Marty", Effect Duration: 50, Last Available: "2014-12"
+7112	watered-down aged chocotini	2	awesome	Last Available: "2014-12"
 7113	knitted fortified chocolate rabbit's foot of the pedagogue	0		Experience: +3, Damage Absorption: +60, Cold Resistance: +3, Last Available: "2014-12"
-7114	tiny moldy candy carrot	1	crappy	Last Available: "2014-12"
+7114	moldy tiny candy carrot	1	crappy	Last Available: "2014-12"
 7115	bland candy carrot cake	3	decent	Last Available: "2014-12"
 7116	hardened carrot-on-a-stick	0		Damage Reduction: 3, Item Drop: +5, Last Available: "2014-12"
 7117	careful forbidden weasel stomping pants	0		Spell Damage Percent: +50, Monster Level: -10, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
@@ -7016,12 +7016,12 @@
 7127	squat chocolate cow bone of the boozehound	0		Booze Drop: +100, Last Available: "2014-12"
 7128	diffused gummi fang	0		Effect: "Virgo Rising", Effect Duration: 21, Last Available: "2014-12"
 7129	bite-sized decent mirror leftover canap&eacute;s	1	good	Last Available: "2014-12"
-7130	tolerable watered-down narrow magnum of champagne	2	good	Last Available: "2014-12"
+7130	watered-down tolerable narrow magnum of champagne	2	good	Last Available: "2014-12"
 7131	Usain Bolt's cow creamer of the scaredy-cat of bravery	0		Monster Level: -15, Spooky Resistance: +5, Initiative: +80, Last Available: "2014-12"
 7132	adjusted nitrogenated twirling Outer Wolf&trade; cologne	0		Effect: "Weepy, Creepy", Effect Duration: 36, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	maroon electrified wolf whistle of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	yummy special witch's bread	4	awesome	Effect: "Supafly", Effect Duration: 35, Last Available: "2014-12"
+7134	maroon electrified wolf whistle of Tarzan	0		Experience (Muscle): +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7135	special yummy witch's bread	4	awesome	Effect: "Supafly", Effect Duration: 35, Last Available: "2014-12"
 7136	improved polymerized huge witch's brew	0		Effect: "Dweeby", Effect Duration: 61, Last Available: "2014-12"
 7137	witch's bra of the wise owl of Calamity Jane	0		Mysticality: +20, Critical Hit Percent: +15, Item Drop: +5, Last Available: "2014-12"
 7138	mediocre mid-level medieval mead	3	decent	Last Available: "2014-12"
@@ -7052,7 +7052,7 @@
 7163	manspreader's hardened skull gearshift knob of Calamity Jane	0		Damage Reduction: 3, Critical Hit Percent: +15, Monster Level: +10, Last Available: "2014-12"
 7164	bland massive nachos of the night	7	decent	Last Available: "2014-12"
 7165	fortified Socratic sage Sketcherz&trade;	0		Mysticality Percent: +10, Experience (Mysticality): +1, Damage Absorption: +60, Last Available: "2014-12"
-7166	normal bite-sized spinning skewed blinking can of Adultwitch&trade;	1	good	Last Available: "2014-12"
+7166	normal bite-sized blinking spinning skewed can of Adultwitch&trade;	1	good	Last Available: "2014-12"
 7167	quadruple-boiled non-dry polymerized tumbling smudge stick	0		Effect: "Infernal Thirst", Effect Duration: 44, Last Available: "2014-12"
 7168	extra-electrified electrified wall	0		Effect: "Bestial Sympathy", Effect Duration: 29, Last Available: "2014-12"
 7169	delicious tankard of ale	4	awesome	Last Available: "2014-12"
@@ -7064,7 +7064,7 @@
 7175	jittery maroon small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	energized spinning crappy waiter disguise	0		Effect: "Haunted Liver", Effect Duration: 16
-7178	maroon twirling Copperhead Charm	0		
+7178	twirling maroon Copperhead Charm	0		
 7179	The First Pizza	0		
 7180	yellow The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
@@ -7073,7 +7073,7 @@
 7184	ghostly jittery The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	fortified artisanal unnamed cocktail	5	EPIC	
+7187	artisanal fortified unnamed cocktail	5	EPIC	
 7188	blurry handful of tips	0		
 7189	green unrequired jacket of the scaredy-cat	0		Monster Level: -15
 7190	twirling prompt tommy gun	0		Adventures: +3, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7101,7 +7101,7 @@
 7212	stylish Jefferson wings	0		Moxie: +25
 7213	shaking fleetwood macaroni	0		
 7214	wobbly cheesy eagle sauce	0		
-7215	thick moldy fancy fuchsia fleetwood mac 'n' cheese	5	crappy	Effect: "You Drank Fish Wine", Effect Duration: 35
+7215	moldy fancy thick fuchsia fleetwood mac 'n' cheese	5	crappy	Effect: "You Drank Fish Wine", Effect Duration: 35
 7216	blinking lynyrd skin	0		
 7217	yellow lynyrdskin cap of terror	0		Spooky Spell Damage: +10, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	upside-down inspector's lynyrdskin tunic	0		Item Drop: +15
@@ -7111,14 +7111,14 @@
 7222	hand-crafted Flamin' Whatshisname	4	EPIC	
 7223	cold-filtered pressed galvanized jittery lynyrd musk	0		Effect: "Eagle Eyes", Effect Duration: 12
 7224	gray stanky razor-sharp Kashmir sweater	0		Weapon Damage Percent: +25, Stench Spell Damage: +25
-7225	rotten immense custard pie	7	crappy	
+7225	immense rotten custard pie	7	crappy	
 7226	skewed tea for one	1	decent	
 7227	weak bad bottle of Evermore	2	decent	
 7228	fuchsia box	0		
 7229	acceptable skewed wine	4	good	
 7230	hand-crafted rum	3	EPIC	
 7231	perfectly mixed Murderer's Punch	3	EPIC	
-7232	decent half-sized velvet cake	2	good	
+7232	half-sized decent velvet cake	2	good	
 7233	nitrogenated letter	0		Effect: "Phairly Pheromonal", Effect Duration: 28
 7234	sinister book of temperance	0		Spell Damage: +10, Sleaze Resistance: +5
 7235	narrow hardy sage masque	0		Mysticality Percent: +10, Maximum HP: +50, Single Equip
@@ -7150,9 +7150,9 @@
 7261	jittery avaricious Sneaky Pete's basket of incineration of the early riser	0		Hot Spell Damage: +50, Meat Drop: +30, Adventures: +7
 7262	&quot;I Love Me, Vol. I&quot;	0		
 7263	photograph of a dog	0		
-7264	gray blurry photograph of a nugget	0		
+7264	blurry gray photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
-7266	maroon blurry disposable instant camera	0		
+7266	blurry maroon disposable instant camera	0		
 7267	chaotic smartaleck's thinker's Sneaky Pete's jacket (collar popped) of vim and vigor	0		Mysticality: +10, Moxie Percent: +30, Maximum HP Percent: +50, Spell Critical Percent: +10, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
@@ -7163,12 +7163,12 @@
 7274	hardened plastic Duke Starkiller	0		Damage Reduction: 3
 7275	educational plastic Gary Claybender	0		Experience: +1
 7276	plastic Captain Kerkard of Calamity Jane	0		Critical Hit Percent: +15
-7277	aerosolized wet nitrogenated jittery blue robot grease	0		Effect: "Mmmmmelon", Effect Duration: 16
+7277	aerosolized wet nitrogenated blue jittery robot grease	0		Effect: "Mmmmmelon", Effect Duration: 16
 7278	returned Thinknerd package	0		
 7279	denatured wind-up Whatsian robot	0		Effect: "Tenacity of the Snapper", Effect Duration: 22
 7280	polymerized dry wind-up vampire teeth	0		Effect: "Blackberry Politeness", Effect Duration: 55
 7281	warmed ionized wind-up navigation droid	0		Effect: "Slime Time", Effect Duration: 65
-7282	magnetized green jittery wind-up owl	0		Effect: "Overstimulated", Effect Duration: 39
+7282	magnetized jittery green wind-up owl	0		Effect: "Overstimulated", Effect Duration: 39
 7283	tarnished electrified twirling wind-up ensign	0		Effect: "Stinky Hands", Effect Duration: 68
 7284	studded dance instructor's crying statue earrings	0		Experience Percent (Moxie): +10, Damage Absorption: +80, Single Equip, Lasts Until Rollover
 7285	wobbly dog trainer's strapping plastic Duskwalker necklace	0		Muscle: +5, Experience (familiar): +1, Single Equip, Lasts Until Rollover
@@ -7217,7 +7217,7 @@
 7328	double-pickled funny bone	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 41
 7329	squat occult half-melted spoon of the sewer	0		Spell Damage Percent: +25, Stench Damage: +25
 7330	altered huge the funk	1		
-7331	low-calorie spoiled gunky chicken	1	crappy	
+7331	spoiled low-calorie gunky chicken	1	crappy	
 7332	shaking lime green rock-hard doll head	0		Damage Reduction: 5
 7333	mirror droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7234,13 +7234,13 @@
 7345	ornate picture frame	0		
 7346	squat doll-eye amulet	0		Single Equip
 7347	supercharged hardened ghost toga	0		Damage Reduction: 3, Maximum MP Percent: +30
-7348	half-sized stale purple sheet cake	2	decent	
+7348	stale half-sized purple sheet cake	2	decent	
 7349	ghost key	0		
 7350	picture of you	0		
 7351	Sherlock's veiny Staff of the Electric Range of the scaredy-cat	0		Maximum HP: +10, Monster Level: -15, Item Drop: +25
-7352	jumbo stale jittery deluxe layer cake	5	decent	
+7352	stale jumbo jittery deluxe layer cake	5	decent	
 7353	chunk of hot iron	0		
-7354	artisanal watered-down twirling red-hot boilermaker	2	EPIC	
+7354	watered-down artisanal twirling red-hot boilermaker	2	EPIC	
 7355	stiffened coal shovel	0		Damage Reduction: 1, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	electrified hot coal	0		Effect: "Carrion' On", Effect Duration: 55
 7357	enhanced chilled coal dust	0		Effect: "Unusual Perspective", Effect Duration: 42
@@ -7253,12 +7253,12 @@
 7364	fabric softener	0		
 7365	galvanized squat fabric hardener	0		Effect: "Bat Attitude", Effect Duration: 39
 7366	practically non-alcoholic drinkable bottle of laundry sherry	1	good	
-7367	oxidized quantum mirror wobbly industrial strength starch	0		Effect: "Nuts about Candy", Effect Duration: 43, Wiki Name: "industrial strength starch"
+7367	oxidized quantum wobbly mirror industrial strength starch	0		Effect: "Nuts about Candy", Effect Duration: 43, Wiki Name: "industrial strength starch"
 7368	normal narrow extra-flat panini	3	good	
 7369	vacuum-sealed enhanced huge mangled finger	0		Effect: "Oleaginous Soles", Effect Duration: 61
 7370	boozy artisanal Psychotic Train wine	5	EPIC	
 7371	huge crazy hobo notebook	0		
-7372	miniature fancy bland huge pie man was not meant to eat	2	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 10
+7372	fancy miniature bland huge pie man was not meant to eat	2	decent	Effect: "Hopped Up on Goofballs", Effect Duration: 10
 7373	chilly sommelier's towel	0		Cold Damage: +5
 7374	healthy tarnished tastevin	0		Maximum HP Percent: +20, Single Equip
 7375	fancy bland spinning actual tapas	4	decent	Effect: "stats.enq", Effect Duration: 10
@@ -7270,13 +7270,13 @@
 7381	curative Pendant of Gargalesis	0		HP Regen Min: 3, HP Regen Max: 5
 7382	green Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
 7383	cyan DNA extraction syringe	0		Last Available: "2014-04"
-7384	extra-unsweetened adjusted upside-down tumbling Gene Tonic: Dude	0		Effect: "Stone-Faced", Effect Duration: 11, Last Available: "2014-04"
+7384	extra-unsweetened adjusted tumbling upside-down Gene Tonic: Dude	0		Effect: "Stone-Faced", Effect Duration: 11, Last Available: "2014-04"
 7385	vacuum-sealed vacuum-sealed Gene Tonic: Beast	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 42, Last Available: "2014-04"
 7386	activated deionized huge Gene Tonic: Construct	0		Effect: "Gummi Badass", Effect Duration: 58, Last Available: "2014-04"
 7387	energized warmed Gene Tonic: Undead	0		Effect: "The Smeezingtons", Effect Duration: 14, Last Available: "2014-04"
 7388	quantum quadruple-oxidized Gene Tonic: Humanoid	0		Effect: "Natural 20", Effect Duration: 67, Last Available: "2014-04"
 7389	Vulcanized magnetized Gene Tonic: Insect	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 51, Last Available: "2014-04"
-7390	electrified red twirling Gene Tonic: Hippy	0		Effect: "Briny Blood", Effect Duration: 27, Last Available: "2014-04"
+7390	electrified twirling red Gene Tonic: Hippy	0		Effect: "Briny Blood", Effect Duration: 27, Last Available: "2014-04"
 7391	diffused squat Gene Tonic: Orc	0		Effect: "Very Clean Teeth", Effect Duration: 54, Last Available: "2014-04"
 7392	cold-filtered Gene Tonic: Demon	0		Effect: "Taurus Rising", Effect Duration: 57, Last Available: "2014-04"
 7393	deionized maroon Gene Tonic: Horror	0		Effect: "Egg-stra Arm", Effect Duration: 27, Last Available: "2014-04"
@@ -7316,7 +7316,7 @@
 7427	colloidal non-adjusted sleight-of-hand mushroom	0		Effect: "Cautious Prowl", Effect Duration: 16, Last Available: "2014-05"
 7428	spinning Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	huge Beach Buck	0		Last Available: "2014-05"
-7430	diffused huge blinking lime green Fun-Guy spore	0		Effect: "Aided and Abetted", Effect Duration: 51, Last Available: "2014-05"
+7430	diffused blinking huge lime green Fun-Guy spore	0		Effect: "Aided and Abetted", Effect Duration: 51, Last Available: "2014-05"
 7431	diffused tarnished upside-down Boletus Broletus mushroom	0		Effect: "Balls of Ectoplasm", Effect Duration: 45, Last Available: "2014-05"
 7432	unsweetened Omphalotus Omphaloskepsis mushroom	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 48, Last Available: "2014-05"
 7433	double-activated tumbling Gyromitra Dynomita mushroom	0		Effect: "Drunk With Power", Effect Duration: 11, Last Available: "2014-05"
@@ -7324,26 +7324,26 @@
 7435	adjusted flattened Stemonitis Staticus mushroom	0		Effect: "Discomfited", Effect Duration: 18, Last Available: "2014-05"
 7436	flattened ionized ionized Tremella Tarantella mushroom	0		Effect: "Kissed By Fire", Effect Duration: 19, Last Available: "2014-05"
 7437	twirling Pastaco shell	0		Last Available: "2014-05"
-7438	normal thick Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
+7438	thick normal Beefy Crunch Pastaco	5	good	Last Available: "2014-05"
 7439	normal Brain Food Pastaco	3	good	Last Available: "2014-05"
 7440	yummy gigantic Cool Brunch Pastaco	10	awesome	Last Available: "2014-05"
 7441	moldy Medical Pastaco	3	crappy	Last Available: "2014-05"
-7442	flavorless yellow pulsating Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
+7442	flavorless pulsating yellow Energy Buzz Pastaco	3	decent	Last Available: "2014-05"
 7443	bland Ludovico Pastaco	3	decent	Last Available: "2014-05"
 7444	perfectly mixed ghostly overpowering mushroom wine	3	super EPIC	Last Available: "2014-05"
 7445	watered-down artisanal complex mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7446	boozy lousy smooth mushroom wine	5	decent	Last Available: "2014-05"
-7447	perfectly mixed weak blood-red mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
+7447	weak perfectly mixed blood-red mushroom wine	2	super ultra mega turbo EPIC	Last Available: "2014-05"
 7448	drinkable buzzing mushroom wine	4	good	Last Available: "2014-05"
 7449	lousy swirling mushroom wine	3	decent	Last Available: "2014-05"
 7450	stale Taco Dan's Basic Taco Dan Taco	3	decent	Last Available: "2014-05"
-7451	half-sized moldy Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
-7452	tumbling red narrow Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	aged practically non-alcoholic regular-size brogurt	1	awesome	Last Available: "2014-05"
-7454	watered-down artisanal super-size brogurt	2	EPIC	Last Available: "2014-05"
-7455	artisanal practically non-alcoholic mirror broberry brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
-7456	perfectly mixed watered-down brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
-7457	smooth skewed upside-down French bronilla brogurt	4	awesome	Last Available: "2014-05"
+7451	moldy half-sized Taco Dan's Taco Fish Fish Taco	2	crappy	Last Available: "2014-05"
+7452	tumbling narrow red Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
+7453	practically non-alcoholic aged regular-size brogurt	1	awesome	Last Available: "2014-05"
+7454	artisanal watered-down super-size brogurt	2	EPIC	Last Available: "2014-05"
+7455	practically non-alcoholic artisanal mirror broberry brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7456	watered-down perfectly mixed brocolate brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7457	smooth upside-down skewed French bronilla brogurt	4	awesome	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	skewed Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	red Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
@@ -7362,12 +7362,12 @@
 7473	frozen maroon shrimp cocktail	0		Effect: "Nuts about Candy", Effect Duration: 67, Last Available: "2014-05"
 7474	vacuum-sealed twirling Yolo&trade; chocolates	0		Effect: "Cybernetic Muscles", Effect Duration: 26, Last Available: "2020-09"
 7475	groovy string of moist beads	0		Moxie Percent: +10, Last Available: "2014-05"
-7476	cyan spinning Ultimate Mind Destroyer	0		Last Available: "2014-05"
+7476	spinning cyan Ultimate Mind Destroyer	0		Last Available: "2014-05"
 7477	quadruple-nitrogenated Meat-inflating powder	0		Effect: "Ocelot Eyes", Effect Duration: 23, Last Available: "2014-05"
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	unsweetened skewed sugar fairy	0		Effect: "Feelin' Philosophical", Effect Duration: 30, Last Available: "2014-05"
 7480	deionized sugar bunny	0		Effect: "Izchak's Blessing", Effect Duration: 29, Last Available: "2014-05"
-7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	artisanal lime green Rompedores de Fantasmas	4	EPIC	
 7483	bad La Fantasma y La Oscuridad	3	decent	
 7484	bad twirling Fantasma en la M&aacute;quina	4	decent	
@@ -7405,7 +7405,7 @@
 7516	ghostly wobbly witch's spare house key	0		
 7517	sharpshooter's weightlifter's spider leg	0		Muscle: +15, Critical Hit Percent: +10
 7518	wand of pigification	0		
-7519	artisanal strong tumbling bouncing glass of bourbon	5	EPIC	
+7519	strong artisanal bouncing tumbling glass of bourbon	5	EPIC	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	tasty government cheese	4	awesome	Last Available: "2014-05"
 7522	avaricious pair of government shades	0		Meat Drop: +30, Single Equip, Last Available: "2014-05"
@@ -7415,7 +7415,7 @@
 7526	wobbly weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	blue censurious government-issued night-vision goggles of the brute	0		Muscle Percent: +30, Sleaze Resistance: +3, Single Equip, Last Available: "2014-05"
-7529	bland big blue loaf of alien bread	5	decent	Last Available: "2014-05"
+7529	big bland blue loaf of alien bread	5	decent	Last Available: "2014-05"
 7530	flavorless teal grilled cheese sandwich	3	decent	Last Available: "2014-05"
 7531	twisted mirror alien protein powder	1	EPIC	Effect: "Shoesauce", Effect Duration: 10, Last Available: "2014-05"
 7532	mediocre olive rocket fuel	4	decent	Last Available: "2014-05"
@@ -7429,11 +7429,11 @@
 7540	rosewater-soaked space beast fur pants	0		Stench Resistance: +3, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	up-at-dawn space beast fur whip	0		Adventures: +5, Last Available: "2014-05"
 7542	fuchsia squat space invader	0		Last Available: "2014-05"
-7543	space heater of Leguizamo of terror	0		Monster Level: +20, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	space heater of Leguizamo of terror	0		Monster Level: +20, Spooky Spell Damage: +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
 7545	lousy space port	3	decent	Last Available: "2014-05"
 7546	upside-down aromatic Da Vinci's space needle	0		Experience (Mysticality): +5, Stench Resistance: +1, Last Available: "2014-05"
-7547	tarnished spinning lime green buffed alien drugs	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 39, Last Available: "2014-05"
+7547	tarnished lime green spinning buffed alien drugs	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 39, Last Available: "2014-05"
 7548	mirror hot ashes	0		Last Available: "2014-06"
 7549	aerosolized ash soda	0		Effect: "Busy Bein' Delicious", Effect Duration: 18, Last Available: "2014-06"
 7550	electrified activated liquid smoke	0		Effect: "Super-Charged", Effect Duration: 52, Last Available: "2014-06"
@@ -7451,16 +7451,16 @@
 7562	non-ionized frozen musk turtle	0		Effect: "Night Vision", Effect Duration: 59
 7563	polymerized ionized programmable turtle	0		Effect: "Yes, Can Haz", Effect Duration: 16
 7564	magnetized ghostly mocking turtle	0		Effect: "Rave Nirvana", Effect Duration: 68
-7565	low-calorie rotten special teal ham steak	1	crappy	Effect: "Hot Jellied", Effect Duration: 20
+7565	special rotten low-calorie teal ham steak	1	crappy	Effect: "Hot Jellied", Effect Duration: 20
 7566	time-twitching toolbelt of the glutton	0		Food Drop: +100, Single Equip, Free Pull
 7567	Chroner	0		
 7568	wholesome Fonzie's Time Lord Badge of Honor of the cheetah	0		Experience (Moxie): +1, Maximum HP Percent: +10, Initiative: +60
 7569	tumbling veiny occult strapping Time Bandit Badge of Courage	0		Muscle: +5, Spell Damage Percent: +25, Maximum HP: +10
 7570	vacuum-sealed wobbly Friendliness Beverage	0		Effect: "Truly Gritty", Effect Duration: 22
 7571	Usain Bolt's forbidden silent pea shooter	0		Spell Damage Percent: +50, Initiative: +80
-7572	bland miniature mirror D roll	2	decent	
+7572	miniature bland mirror D roll	2	decent	
 7573	family-friendly baleful kiwi beak	0		Spell Damage: +25, Sleaze Resistance: +1
-7574	enchanted perfectly mixed New Zealand iced tea	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50
+7574	perfectly mixed enchanted New Zealand iced tea	3	EPIC	Effect: "Cold Hard Skin", Effect Duration: 50
 7575	Jack Frost's Jim Carey's droll monocle	0		Monster Level: +25, Cold Spell Damage: +50, Single Equip
 7576	moist enhanced future drug: Muscularactum	0		Effect: "Slimed Stomach", Effect Duration: 66
 7577	activated unsweetened extra-boiled future drug: Smartinex	0		Effect: "Granolarrrgh", Effect Duration: 63
@@ -7469,25 +7469,25 @@
 7580	dehydrated liquid shifting time weirdness	1		Effect: "Neutered Nostrils", Effect Duration: 35
 7581	shaking shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	flavorless half-sized rack of dinosaur ribs	2	decent	
-7583	practically non-alcoholic hand-crafted scotch on the rocks	1	super ultra mega turbo EPIC	
+7583	hand-crafted practically non-alcoholic scotch on the rocks	1	super ultra mega turbo EPIC	
 7584	lion tamer's careful yabba dabba doo rag	0		Monster Level: -10, Experience (familiar): +2, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	olive weightlifter's wooly loincloth of the brazier	0		Muscle: +15, Hot Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	wobbly S.S. Ticket	0		Familiar Weight: +5
 7588	twirling Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	practically non-alcoholic drinkable glass of &quot;milk&quot;	1	good	Last Available: "2014-07"
-7590	weak bad cup of &quot;tea&quot;	2	decent	Last Available: "2014-07"
-7591	watered-down mediocre thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
-7592	artisanal practically non-alcoholic Lucky Lindy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
-7593	mediocre boozy Bee's Knees	5	decent	Last Available: "2014-07"
+7589	drinkable practically non-alcoholic glass of &quot;milk&quot;	1	good	Last Available: "2014-07"
+7590	bad weak cup of &quot;tea&quot;	2	decent	Last Available: "2014-07"
+7591	mediocre watered-down thermos of &quot;whiskey&quot;	2	decent	Last Available: "2014-07"
+7592	practically non-alcoholic artisanal Lucky Lindy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
+7593	boozy mediocre Bee's Knees	5	decent	Last Available: "2014-07"
 7594	perfectly mixed Sockdollager	3	EPIC	Last Available: "2014-07"
-7595	mediocre special Ish Kabibble	3	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2014-07"
-7596	fortified artisanal Hot Socks	5	EPIC	Last Available: "2014-07"
-7597	watered-down lousy jittery yellow Phonus Balonus	2	decent	Last Available: "2014-07"
+7595	special mediocre Ish Kabibble	3	decent	Effect: "Swimming Head", Effect Duration: 20, Last Available: "2014-07"
+7596	artisanal fortified Hot Socks	5	EPIC	Last Available: "2014-07"
+7597	watered-down lousy yellow jittery Phonus Balonus	2	decent	Last Available: "2014-07"
 7598	artisanal Flivver	3	EPIC	Last Available: "2014-07"
-7599	weak mediocre Sloppy Jalopy	2	decent	Last Available: "2014-07"
+7599	mediocre weak Sloppy Jalopy	2	decent	Last Available: "2014-07"
 7600	flattened fuchsia flame	0		Effect: "Make Meat FA$T!", Effect Duration: 69
-7601	dry pickled quadruple-cold-filtered teal bouncing temporary yak tattoo	0		Effect: "Coal-Powered", Effect Duration: 44
+7601	dry pickled quadruple-cold-filtered bouncing teal temporary yak tattoo	0		Effect: "Coal-Powered", Effect Duration: 44
 7602	adjusted Fitspiration&trade; poster	0		Effect: "Unusual Fashion Sense", Effect Duration: 55
 7603	moist nitrogenated neckbeard	0		Effect: "Flambé-a-thon", Effect Duration: 22
 7604	boiled concentrated enhanced artisanal hand-squeezed wheatgrass juice	0		Effect: "Okee-Dokee Go!", Effect Duration: 58
@@ -7538,7 +7538,7 @@
 7649	electrified boiled ghostly gourmet gourami oil	0		Effect: "Cool, Catlike", Effect Duration: 16
 7650	pickled catfish whiskers	0		Effect: "Gummi-Grin", Effect Duration: 44
 7651	mirror freshwater fishbone	0		
-7652	narrow yellow fishbone catcher's mitt	0		
+7652	yellow narrow fishbone catcher's mitt	0		
 7653	fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
 7655	fishbone fins	0		Single Equip
@@ -7548,7 +7548,7 @@
 7659	shaking savvy neoprene skullcap	0		Mysticality Percent: +20, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	corrupted narrow goblin water	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 31
 7661	dumb mud	0		
-7662	big decent Sogg-Os	5	good	
+7662	decent big Sogg-Os	5	good	
 7663	cyan miser's lion tamer's Lord Soggyraven's Slippers of extreme caution	0		Monster Level: -25, Experience (familiar): +2, Meat Drop: +10, Single Equip
 7664	double-chilled ghostly jittery Ancient Protector Soda	0		Effect: "Rampage!", Effect Duration: 17
 7665	cold-filtered liquid ice	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 20
@@ -7567,7 +7567,7 @@
 7678	scandalous 4-dimensional fez	0		Sleaze Damage: +5, Familiar Effect: "atk, 1xLep, cap 12"
 7679	throwing candy	0		
 7680	manspreader's super-absorbent tarp	0		Monster Level: +10
-7681	bad triple-distilled unquiet spirits	6	decent	
+7681	triple-distilled bad unquiet spirits	6	decent	
 7682	banjo kazoo mount of the detective	0		Item Drop: +20, Single Equip
 7683	pickled activated grass	0		Effect: "Initiative and Let Die", Effect Duration: 37
 7684	bouncing electrified Time Lord Participation Mug	0		MP Regen Min: 3, MP Regen Max: 5
@@ -7581,7 +7581,7 @@
 7692	yellow Oprah's ruddy Socratic hand whip	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Maximum MP Percent: +50, Last Available: "2014-08"
 7693	horrifying experienced glow-in-the-dark necklace of the businessman	0		Experience: +2, Spooky Damage: +25, Meat Drop: +50, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	Van der Graaf Fonzie's cap gun of wisdom	0		Mysticality: +15, Experience (Moxie): +1, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	Van der Graaf Fonzie's cap gun of wisdom	0		Mysticality: +15, Experience (Moxie): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	personal trainer's cassette player of the businessman	0		Experience Percent (Muscle): +10, Meat Drop: +50, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7595,13 +7595,13 @@
 7706	wobbly The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	dry adjusted rubber nubbin	0		Effect: "Gleaming White Teeth", Effect Duration: 60, Last Available: "2014-08"
 7708	red shaking wizardly rubber cape of Tarzan	0		Mysticality: +25, Experience (Muscle): +3, Last Available: "2014-08"
-7709	blue miser's wool Thor's Pliers of James Dean of doom	0		Experience (Moxie): +3, Spooky Spell Damage: +50, Cold Resistance: +1, Meat Drop: +10, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	blue miser's wool Thor's Pliers of James Dean of doom	0		Experience (Moxie): +3, Spooky Spell Damage: +50, Cold Resistance: +1, Meat Drop: +10, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	warmed candy UFOs	0		Effect: "Powdered", Effect Duration: 53
 7711	squat Samson's strapping water wings for babies	0		Muscle: +5, Experience (Muscle): +5
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	adequate Strix stix	4	good	
 7714	up-at-dawn manspreader's vampire pellet of the overflowing toilet	0		Monster Level: +10, Stench Spell Damage: +50, Adventures: +5
-7715	fortified smooth olive non-aged vinegar	5	awesome	
+7715	smooth fortified olive non-aged vinegar	5	awesome	
 7716	unsanitized scalpel of courage	0		Spooky Resistance: +3
 7717	rosewater-soaked gladiator tunica	0		Stench Resistance: +3
 7718	squat energetic Roman sadnals	0		Maximum MP Percent: +20, Single Equip
@@ -7633,7 +7633,7 @@
 7744	Xiblaxian holo-schematic: stealth trousers	0		Last Available: "2014-09"
 7745	Xiblaxian holo-schematic: stealth vest	0		Last Available: "2014-09"
 7746	jittery Xiblaxian holo-schematic: ultraburrito	0		Last Available: "2014-09"
-7747	blinking huge Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
+7747	huge blinking Xiblaxian holo-schematic: space whiskey	0		Last Available: "2014-09"
 7748	Xiblaxian holo-schematic: residence cube	0		Last Available: "2014-09"
 7749	Xiblaxian holo-schematic: xeno-goggles	0		Last Available: "2014-09"
 7750	jittery Xiblaxian 5D printer	0		Last Available: "2014-09"
@@ -7642,11 +7642,11 @@
 7753	mansplainer's banded Xiblaxian stealth cowl	0		Damage Absorption: +100, Monster Level: +15, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	red groovy Rosewater's Xiblaxian stealth trousers	0		Mysticality Percent: +30, Moxie Percent: +10, Last Available: "2014-09"
 7755	deadly Xiblaxian stealth vest of the pedagogue	0		Experience: +3, Weapon Damage: +5, Last Available: "2014-09"
-7756	decent diet Xiblaxian ultraburrito	1	good	Last Available: "2014-09"
-7757	triple-distilled tolerable Xiblaxian space-whiskey	9	good	Last Available: "2014-09"
+7756	diet decent Xiblaxian ultraburrito	1	good	Last Available: "2014-09"
+7757	tolerable triple-distilled Xiblaxian space-whiskey	9	good	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	oxidized irradiated They liver	0		Effect: "Irresistible Resolve", Effect Duration: 17, Last Available: "2014-09"
-7760	flavorless thick blurry They liver popsicle	5	decent	Last Available: "2014-09"
+7760	thick flavorless blurry They liver popsicle	5	decent	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	green holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7665,15 +7665,15 @@
 7776	experienced beefy Sasq&trade; watch of Tarzan	0		Muscle: +10, Experience: +2, Experience (Muscle): +3, Single Equip, Last Available: "2014-10"
 7777	healthy rock-hard smoker's cloak of dire peril	0		Weapon Damage: +20, Damage Reduction: 5, Maximum HP Percent: +20, Last Available: "2014-10"
 7778	Lo Pan's Tesla Samson's camouflage T-shirt of Flo-Jo	0		Experience (Muscle): +5, Spell Critical Percent: +30, Initiative: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
-7779	flattened energized electrified squat teal experimental serum G-9	0		Effect: "Sugar, Hello", Effect Duration: 26, Last Available: "2014-10"
+7779	flattened energized electrified teal squat experimental serum G-9	0		Effect: "Sugar, Hello", Effect Duration: 26, Last Available: "2014-10"
 7780	jittery asbestos-lined chilly resourceful heavy-duty clipboard	0		Maximum MP: +50, Cold Damage: +5, Hot Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	Newton's slick cool battery-powered drill of the detective	0		Moxie: 15, Experience (Mysticality): +3, Item Drop: +20, Last Available: "2014-10"
-7782	tasty half-sized purple tumbling limp broccoli	2	awesome	Last Available: "2014-10"
+7782	half-sized tasty purple tumbling limp broccoli	2	awesome	Last Available: "2014-10"
 7783	stiffened Samson's smartaleck's hat	0		Moxie Percent: +30, Experience (Muscle): +5, Damage Reduction: 1, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	energized monkey barf	0		Effect: "Grrrrrrreat!", Effect Duration: 51, Last Available: "2014-10"
 7785	diffused polymerized candy	0		Effect: "Seeing Colors", Effect Duration: 69, Last Available: "2014-10"
 7786	healthy stylish thinker's jangly bracelet	0		Mysticality: +10, Moxie: +25, Maximum HP Percent: +20, Last Available: "2014-10"
-7787	frosty cuddly teddy bear	0		Cold Spell Damage: +10, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	frosty cuddly teddy bear	0		Cold Spell Damage: +10, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	blinking brawny beefy first-aid pouch	0		Muscle: +10, Muscle Percent: +20, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7681,11 +7681,11 @@
 7792	pulsating SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	ghostly bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	stale diet tumbling shaking initiative shawarma	1	decent	Last Available: "2014-10"
+7795	stale diet shaking tumbling initiative shawarma	1	decent	Last Available: "2014-10"
 7796	adequate warm war shawarma	4	good	Last Available: "2014-10"
-7797	super-sized decent karma shawarma	5	good	Last Available: "2014-10"
-7798	weak bad Jungle Juice	2	decent	Last Available: "2014-10"
-7799	special smooth Amnesiac Ale	3	awesome	Effect: "Insatiable Hunger", Effect Duration: 15, Last Available: "2014-10"
+7797	decent super-sized karma shawarma	5	good	Last Available: "2014-10"
+7798	bad weak Jungle Juice	2	decent	Last Available: "2014-10"
+7799	smooth special Amnesiac Ale	3	awesome	Effect: "Insatiable Hunger", Effect Duration: 15, Last Available: "2014-10"
 7800	smooth Highest Bitter	4	awesome	Last Available: "2014-10"
 7801	extremely unsafe mercenary pistol of Leguizamo	0		Weapon Damage Percent: +100, Monster Level: +20, Last Available: "2014-10"
 7802	wholesome slick mercenary rifle	0		Moxie: +10, Maximum HP Percent: +10, Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	improved wet blurry perl necklace	0		Effect: "Concentration", Effect Duration: 47, Last Available: "2014-12"
 7846	super-anodized ghostly Fudge Fiber Armor Plating	0		Effect: "Radiated and Grodiated", Effect Duration: 13, Last Available: "2014-12"
 7847	dry mirror ruby on canes	0		Effect: "Chilblains of the Corn", Effect Duration: 37, Last Available: "2014-12"
-7848	toothsome snack-sized petit fortran	2	awesome	Last Available: "2014-12"
+7848	snack-sized toothsome petit fortran	2	awesome	Last Available: "2014-12"
 7849	stale super-sized java cookie	5	decent	Last Available: "2014-12"
 7850	stale cookie cookie	4	decent	Last Available: "2014-12"
 7851	jittery skewed resourceful plastic exo-suited miner	0		Maximum MP: +50, Last Available: "2014-12"
@@ -7787,20 +7787,20 @@
 7898	Crimbot schematic: Sim-Simian Feet	0		Last Available: "2014-12"
 7899	Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
-7901	wobbly green Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
+7901	green wobbly Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
 7902	Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	tumbling Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
-7907	huge narrow recovered elf sleeping pills	0		Last Available: "2014-12"
+7907	narrow huge recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	skewed recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	recovered elf photo album	0		Last Available: "2014-12"
 7912	mirror recovered elf smartphone	0		Last Available: "2014-12"
 7913	stanky Herculean cool Size XI Wizard's Robe	0		Moxie: +5, Experience (Muscle): +1, Stench Spell Damage: +25, Last Available: "2014-09"
-7914	boiled extra-alkaline wobbly lime green Bit O' Quail Spleen	0		Effect: "Gemini Rising", Effect Duration: 45
+7914	boiled extra-alkaline lime green wobbly Bit O' Quail Spleen	0		Effect: "Gemini Rising", Effect Duration: 45
 7915	quadruple-pressed concentrated Take Eleven Bar	0		Effect: "Army of One", Effect Duration: 45
 7916	cyan mimeplasm	0		
 7917	altered altered BOOterfinger	0		Effect: "Spookyravin'", Effect Duration: 58
@@ -7809,7 +7809,7 @@
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	perfectly mixed distilled Friendly Turkey	5	EPIC	Last Available: "2014-11"
-7923	practically non-alcoholic tolerable Agitated Turkey	1	good	Last Available: "2014-11"
+7923	tolerable practically non-alcoholic Agitated Turkey	1	good	Last Available: "2014-11"
 7924	acceptable shaking Ambitious Turkey	4	good	Last Available: "2014-11"
 7925	normal blue neutron lollipop	3	good	Last Available: "2014-12"
 7926	hand-crafted gamma nog	3	EPIC	Last Available: "2014-12"
@@ -7827,8 +7827,8 @@
 7945	table	0		
 7946	aromatic Rosewater's outlaw bandana of the ox	0		Muscle: +20, Mysticality Percent: +30, Stench Resistance: +1
 7947	extra-dry bad maroon whiskey in a broken glass	5	decent	
-7948	perfectly mixed enchanted shot of mescal	4	EPIC	Effect: "Cybernetic Muscles", Effect Duration: 35
-7949	strong bad ghostly glass of herbal tequila	5	decent	
+7948	enchanted perfectly mixed shot of mescal	4	EPIC	Effect: "Cybernetic Muscles", Effect Duration: 35
+7949	bad strong ghostly glass of herbal tequila	5	decent	
 7950	lime green minin' dynamite	0		
 7951	ghostly therapeutic hardy plaid cowboy hat	0		Maximum HP: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lasso	0		
@@ -7836,7 +7836,7 @@
 7954	rattler rattle	0		
 7955	bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
-7957	teal blurry blinking even more tinsel	0		Familiar Weight: +5
+7957	blurry blinking teal even more tinsel	0		Familiar Weight: +5
 7958	box of Crimbo decorations	0		
 7959	mirror letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
@@ -7848,7 +7848,7 @@
 7966	squat Ka coin	0		
 7967	dog trainer's World's Best Adventurer sash	0		Experience (familiar): +1
 7968	mirror topiary nugglet	0		
-7969	mirror skewed ghostly beehive	0		
+7969	skewed mirror ghostly beehive	0		
 7970	boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
 7972	modified olive mummified fig	1	good	
@@ -7876,22 +7876,22 @@
 7994	experienced pepper mill of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Last Available: "2015-12"
 7995	smelly rock-hard pelerine	0		Damage Reduction: 5, Stench Spell Damage: +10, Last Available: "2015-12"
 7996	arcane researcher's phantom mask of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP: +100, Single Equip, Last Available: "2015-12"
-7997	compressed bouncing squat spinning polyesterene powder	1		Last Available: "2015-12"
+7997	compressed bouncing spinning squat polyesterene powder	1		Last Available: "2015-12"
 7998	compressed olive powder	1		Effect: "Rad-ish", Effect Duration: 10, Last Available: "2015-12"
 7999	unsweetened wet choco-Crimbot	0		Effect: "Rotten Memories", Effect Duration: 52, Last Available: "2014-12"
 8000	oxidized diffused smart watch	0		Effect: "Pasty", Effect Duration: 65, Last Available: "2014-12"
 8001	polymerized wobbly augmented-reality shades	0		Effect: "Hyperoffended", Effect Duration: 62, Last Available: "2014-12"
-8002	toy Crimbot mega face of terror	0		Spooky Spell Damage: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12"
-8003	purple weightlifter's toy Crimbot power glove	0		Muscle: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	Van der Graaf toy Crimbot super fist	0		MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	shaking Herculean toy Crimbot rocket legs	0		Experience (Muscle): +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	toy Crimbot mega face of terror	0		Spooky Spell Damage: +10, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	purple weightlifter's toy Crimbot power glove	0		Muscle: +15, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	Van der Graaf toy Crimbot super fist	0		MP Regen Min: 5, MP Regen Max: 7, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	shaking Herculean toy Crimbot rocket legs	0		Experience (Muscle): +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	modified energized deionized Crimbot battery	0		Effect: "Artificially Sweet", Effect Duration: 67, Last Available: "2014-12"
 8007	pulsating Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	wobbly Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	blurry Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	fuchsia heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	mirror Sherlock's personal trainer's Crimbomega drive chain of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Item Drop: +25, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	mirror Sherlock's personal trainer's Crimbomega drive chain of the brazier	0		Experience Percent (Muscle): +10, Hot Spell Damage: +25, Item Drop: +25, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	mirror Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,15 +7899,15 @@
 8017	wet jittery flask of tainted mining oil	0		Effect: "In the Slimelight", Effect Duration: 23, Last Available: "2014-12"
 8018	enhanced moist anodized twirling and rain stick	0		Effect: "Ogred and Oublietted", Effect Duration: 26
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	tasty thick Choco-Mint patty	5	awesome	Last Available: "2015-01"
-8021	artisanal watered-down hot mint schnocolate	2	EPIC	Last Available: "2015-01"
+8020	thick tasty Choco-Mint patty	5	awesome	Last Available: "2015-01"
+8021	watered-down artisanal hot mint schnocolate	2	EPIC	Last Available: "2015-01"
 8022	denatured homeopathic mint tea	1	EPIC	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	bouncing foreign language tapes	0		Last Available: "2015-01"
 8025	tumbling bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
 8027	antler chandelier	0		Last Available: "2015-01"
-8028	pulsating green artificial skylight	0		Last Available: "2015-01"
+8028	green pulsating artificial skylight	0		Last Available: "2015-01"
 8029	Swiss piggy bank	0		Last Available: "2015-01"
 8030	continental juice bar	0		Last Available: "2015-01"
 8031	stationery set	0		Last Available: "2015-01"
@@ -7996,7 +7996,7 @@
 8121	greasy electrified garland	0		Sleaze Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2018-12"
 8122	aromatic curative gunnysack	0		Stench Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
 8123	skewed wizardly garibaldi of dire peril	0		Mysticality: +25, Weapon Damage: +20, Last Available: "2018-12"
-8124	lightning-fast Jim Carey's girdle	0		Monster Level: +25, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	lightning-fast Jim Carey's girdle	0		Monster Level: +25, Initiative: +40, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	hardy gloves of the storm	0		Maximum HP: +50, Maximum MP Percent: +40, Single Equip, Last Available: "2018-12"
 8126	dehydrated blinking tumbling smithereens	1		Last Available: "2018-12"
 8127	mirror electrified fiberglass fetish of terror	0		Spooky Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2018-12"
@@ -8025,20 +8025,20 @@
 8151	super-liquefied Shrubble Bubble	0		Effect: "Cold Blooded", Effect Duration: 53
 8152	electrified polyeaster egg	0		Effect: "Mayeaugh", Effect Duration: 56
 8153	dry gray candy dish	0		Effect: "Floundering", Effect Duration: 59
-8154	improved extra-corrupted skewed mirror Spechunky bar	0		Effect: "Gyromitra Gymnastics", Effect Duration: 21
+8154	improved extra-corrupted mirror skewed Spechunky bar	0		Effect: "Gyromitra Gymnastics", Effect Duration: 21
 8155	electrified wet blurry talisman of Horus	0		Effect: "Capricorn Rising", Effect Duration: 29
 8156	check to the Meatsmith	0		
 8157	red Skeleton Store office key	0		
 8158	bone with a price tag on it	0		
 8159	half of a tooth	0		
 8160	magnetized colloidal oxidized olive mouse skull	0		Effect: "Cockroach Scurry", Effect Duration: 28
-8161	flattened magnetized pulsating blinking really thick spine	0		Effect: "Omphalotus Omnipresence", Effect Duration: 23
+8161	flattened magnetized blinking pulsating really thick spine	0		Effect: "Omphalotus Omnipresence", Effect Duration: 23
 8162	tumbling nasty studded skullcap	0		Damage Absorption: +80, Stench Damage: +5, Familiar Effect: "1xVolley,cap 5"
 8163	fireproof arcane researcher's three-legged pants	0		Experience Percent (Mysticality): +10, Hot Resistance: +3, Familiar Effect: "hot atk, cap 25"
 8164	padded groovy remaindered axe	0		Moxie Percent: +10, Damage Absorption: +20
-8165	tumbling gray low-budget shield	0		Damage Reduction: 3
+8165	gray tumbling low-budget shield	0		Damage Reduction: 3
 8166	frightening padded cr&ecirc;epy mask	0		Damage Absorption: +20, Spooky Damage: +5, Familiar Effect: "spooky atk, cap 5"
-8167	yummy huge pulsating baguette	4	awesome	
+8167	yummy pulsating huge baguette	4	awesome	
 8168	glob of icing	0		
 8169	concentrated ginger snaps	0		Effect: "Halloweeny", Effect Duration: 51
 8170	deionized frozen green mostly-broken sunglasses	0		Effect: "All Branned Up", Effect Duration: 59
@@ -8064,14 +8064,14 @@
 8190	practically non-alcoholic drinkable tumbling Orangemageddon wine cooler	1	good	
 8191	hand-crafted practically non-alcoholic Breakfast Blast wine cooler	1	EPIC	
 8192	drinkable Citrus Crush wine cooler	3	good	
-8193	small adequate wobbly plain bagel	2	good	
+8193	adequate small wobbly plain bagel	2	good	
 8194	rotten glob of cream cheese	4	crappy	
 8195	decent loaf of soda bread	3	good	
-8196	stale enchanted acceptable bagel	4	decent	Effect: "Flambé-a-thon", Effect Duration: 40
+8196	enchanted stale acceptable bagel	4	decent	Effect: "Flambé-a-thon", Effect Duration: 40
 8197	decent standard-issue cupcake	3	good	
 8198	spoiled ultra-deluxe cupcake	3	crappy	
 8199	ghostly hypnotic breadcrumbs	0		
-8200	jumbo bland popular tart	5	decent	
+8200	bland jumbo popular tart	5	decent	
 8201	no-handed pie	0		
 8202	denatured Doc Galaktik's Vitality Serum	0		Effect: "Superveiny 9000", Effect Duration: 44
 8203	huge airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8086,11 +8086,11 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	chilly rigging rope of extreme caution	0		Monster Level: -25, Cold Damage: +5, Last Available: "2015-04"
 8214	boiled twirling blue nasty snuff	1	decent	Effect: "Night of the Nachos", Effect Duration: 20, Last Available: "2015-04"
-8215	blurry sharpshooter's stiffened sewage-clogged pistol	0		Damage Reduction: 1, Critical Hit Percent: +10, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8215	blurry sharpshooter's stiffened sewage-clogged pistol	0		Damage Reduction: 1, Critical Hit Percent: +10, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	nitrogenated frozen oxidized beard incense	0		Effect: "Lemony Goodness", Effect Duration: 66, Last Available: "2015-04"
 8217	electrified brainy perfume-soaked bandana	0		Mysticality: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2015-04"
 8218	spinning toxic globule	0		Last Available: "2015-04"
-8219	miniature decent toxo	2	good	Last Available: "2015-04"
+8219	decent miniature toxo	2	good	Last Available: "2015-04"
 8220	mediocre Lemonade-235	3	decent	Last Available: "2015-04"
 8221	foul-smelling crafty isotophat	0		Maximum MP: +10, Stench Damage: +10, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	narrow Three Mile Island shorts of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Initiative: +100, Last Available: "2015-04"
@@ -8101,7 +8101,7 @@
 8227	smelly Fonzie's thinker's backwoods banjo	0		Mysticality: +10, Experience (Moxie): +1, Stench Spell Damage: +10, Last Available: "2015-04"
 8228	grody jug	0		Last Available: "2015-04"
 8229	Lo Pan's studded Newton's ratskin pajama pants	0		Experience (Mysticality): +3, Damage Absorption: +80, Spell Critical Percent: +30, Last Available: "2015-04"
-8230	anodized jittery blue turtle voicebox	0		Effect: "Pasty", Effect Duration: 11, Last Available: "2015-04"
+8230	anodized blue jittery turtle voicebox	0		Effect: "Pasty", Effect Duration: 11, Last Available: "2015-04"
 8231	foul-smelling Temple Grandin's fake washboard of the bloodbag	0		Maximum HP: +100, Familiar Weight: +7, Stench Damage: +10, Damage Reduction: 13, Last Available: "2015-04"
 8232	reassuring manspreader's Dinsey's oculus	0		Monster Level: +10, Spooky Resistance: +1, Single Equip, Last Available: "2015-04"
 8233	wobbly mirror nasty Dinsey's radar dish	0		Stench Damage: +5, Damage Reduction: 15, Last Available: "2015-04"
@@ -8120,7 +8120,7 @@
 8246	asbestos-lined hardened Dinsey mascot mask of the cougar	0		Moxie: +20, Damage Reduction: 3, Hot Resistance: +5, Last Available: "2015-04"
 8247	yummy mirror Dinsey food-cone	3	awesome	Last Available: "2015-04"
 8248	watered-down mediocre pulsating Dinsey Whinskey	2	decent	Last Available: "2015-04"
-8249	electrified wet lime green mirror wobbly Dinsey face paint	0		Effect: "Shot in the Arse", Effect Duration: 55, Last Available: "2015-04"
+8249	electrified wet lime green wobbly mirror Dinsey face paint	0		Effect: "Shot in the Arse", Effect Duration: 55, Last Available: "2015-04"
 8250	studded fannypack of the brute	0		Muscle Percent: +30, Damage Absorption: +80, Last Available: "2015-04"
 8251	squat up-at-dawn smelly arcane researcher's Samson's garbage sticker of the detective of the sweet-tooth	0		Experience (Muscle): +5, Experience Percent (Mysticality): +10, Stench Spell Damage: +10, Item Drop: +20, Candy Drop: +100, Adventures: +5, Last Available: "2015-04"
 8252	shaking inspector's wool scorching supercharged hazmat helmet of horror	0		Maximum MP Percent: +30, Hot Damage: +25, Spooky Spell Damage: +25, Cold Resistance: +1, Item Drop: +15, Last Available: "2015-04"
@@ -8134,7 +8134,7 @@
 8260	Mayo Clinic	0		Last Available: "2015-05"
 8261	skewed Mayonex	0		Last Available: "2015-05"
 8262	olive Mayodiol	0		Last Available: "2015-05"
-8263	maroon tumbling Mayostat	0		Last Available: "2015-05"
+8263	tumbling maroon Mayostat	0		Last Available: "2015-05"
 8264	purple wobbly Mayozapine	0		Last Available: "2015-05"
 8265	tumbling Mayoflex	0		Last Available: "2015-05"
 8266	mirror extremely unsafe thinker's miracle whip of the bloodbag of the businessman	0		Mysticality: +10, Weapon Damage Percent: +100, Maximum HP: +100, Meat Drop: +50, Lasts Until Rollover, Last Available: "2015-05"
@@ -8145,7 +8145,7 @@
 8271	moldy gigantic spinning uninteresting mayolus	10	crappy	Last Available: "2015-05"
 8272	enchanted decent blurry acceptable mayolus	4	good	Effect: "Mariachi Mood", Effect Duration: 45, Last Available: "2015-05"
 8273	decent enticing mayolus	3	good	Last Available: "2015-05"
-8274	half-sized rotten mouth-watering mayolus	2	crappy	Last Available: "2015-05"
+8274	rotten half-sized mouth-watering mayolus	2	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	huge mayo pump	0		Familiar Weight: +5
 8277	mirror Essence of Bear	0		Skill: "Bear Essence"
@@ -8173,8 +8173,8 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	dry quadruple-deionized skewed power pill	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 13, Last Available: "2015-06"
 8301	chilled activated narrow pixel star	0		Effect: "Berry Critical", Effect Duration: 29, Last Available: "2015-06"
-8302	miniature spoiled pixel banana	2	crappy	Last Available: "2015-06"
-8303	watered-down acceptable pixel beer	2	good	Last Available: "2015-06"
+8302	spoiled miniature pixel banana	2	crappy	Last Available: "2015-06"
+8303	acceptable watered-down pixel beer	2	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	upside-down pumps	0		Last Available: "2015-06"
 8306	diffused extra-aerosolized sludgesicle	0		Effect: "Really Deep Breath", Effect Duration: 13
@@ -8198,7 +8198,7 @@
 8324	dry cold-filtered disposable lighter	0		Effect: "Headstrong", Effect Duration: 35
 8325	frozen Vulcanized ghostly coal contact lenses	0		Effect: "Hangdog", Effect Duration: 49
 8326	extra-alkaline conjured ice cream	0		Effect: "New and Improved", Effect Duration: 59
-8327	extra-chilled irradiated shaking green Iceberglar scarf	0		Effect: "Shawarma Warm War", Effect Duration: 53
+8327	extra-chilled irradiated green shaking Iceberglar scarf	0		Effect: "Shawarma Warm War", Effect Duration: 53
 8328	chilled mirror icy hairspray	0		Effect: "The Magic of LOV", Effect Duration: 12
 8329	extra-unsweetened smellbook	0		Effect: "Scorpio Rising", Effect Duration: 23
 8330	ionized teal assassin's cheese knife	0		Effect: "Neuromancy", Effect Duration: 54
@@ -8227,16 +8227,16 @@
 8353	triple-flattened blue grimy lab coat	0		Effect: "What's That Smell?", Effect Duration: 28
 8354	moist alkaline bouncing maroon nursery rhyme	0		Effect: "Strawberry Alarm", Effect Duration: 49
 8355	oxidized improved iron torso box	0		Effect: "Ruthlessly Efficient", Effect Duration: 65
-8356	oxidized non-wet squat cyan mercenary headband	0		Effect: "On the Shoulders of Giants", Effect Duration: 47
+8356	oxidized non-wet cyan squat mercenary headband	0		Effect: "On the Shoulders of Giants", Effect Duration: 47
 8357	Vulcanized radioactive spider venom	0		Effect: "Provocative Perkiness", Effect Duration: 68
 8358	quadruple-pressed x-ray mirror	0		Effect: "Is This Your Card?", Effect Duration: 66
-8359	super-vacuum-sealed irradiated tumbling fuchsia wrestling mask	0		Effect: "Very Clean Guns", Effect Duration: 54
+8359	super-vacuum-sealed irradiated fuchsia tumbling wrestling mask	0		Effect: "Very Clean Guns", Effect Duration: 54
 8360	irradiated improved alkaline hawkface potion	0		Effect: "Chalky Hand", Effect Duration: 65
 8361	ionized child-sized dracula cloak	0		Effect: "Frostbeard", Effect Duration: 28
 8362	dry devil-summoning hat	0		Effect: "Outer Wolf&trade;", Effect Duration: 24
 8363	warmed shopkeeper beard	0		Effect: "Frigid Weapon", Effect Duration: 63
 8364	modified improved alien autoautopsy kit	0		Effect: "Painted-On Bikini", Effect Duration: 12
-8365	diffused irradiated spinning lime green novelty fruit hat	0		Effect: "Sweet and Green", Effect Duration: 55
+8365	diffused irradiated lime green spinning novelty fruit hat	0		Effect: "Sweet and Green", Effect Duration: 55
 8366	ionized adjusted invisibility cream	0		Effect: "Full-Body Tan", Effect Duration: 25
 8367	wet anodized handful of stubble	0		Effect: "Mo' Hobo", Effect Duration: 48
 8368	polymerized jittery wobbly garbage juice slurpee	0		Effect: "Chari Tea", Effect Duration: 35
@@ -8248,7 +8248,7 @@
 8374	moist tumbling drinks tray	0		Effect: "No Vertigo", Effect Duration: 44
 8375	colloidal eyebrow lifter	0		Effect: "Fitter, Happier", Effect Duration: 23
 8376	narrow twirling submarine	0		Last Available: "2015-06"
-8377	low-calorie adequate pulsating pixel lemon	1	good	Last Available: "2015-06"
+8377	adequate low-calorie pulsating pixel lemon	1	good	Last Available: "2015-06"
 8378	aged blinking pixel daiquiri	3	awesome	Last Available: "2015-06"
 8379	frozen power pill	0		Effect: "Mistified", Effect Duration: 40, Last Available: "2015-06"
 8380	alkaline blinking pixel potion	0		Effect: "Badger Underfoot", Effect Duration: 11, Last Available: "2015-06"
@@ -8262,7 +8262,7 @@
 8388	mana	0		Last Available: "2015-07"
 8389	purple mana	0		Last Available: "2015-07"
 8390	shaking mana	0		Last Available: "2015-07"
-8391	upside-down wobbly mana	0		Last Available: "2015-07"
+8391	wobbly upside-down mana	0		Last Available: "2015-07"
 8392	gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
 8394	purple The Emperor's dry cleaning	0		Last Available: "2015-07"
@@ -8284,7 +8284,7 @@
 8410	stale huge blurry agnolotti arboli	6	decent	
 8411	decent spaghetti with ghost balls	3	good	
 8412	half-sized decent succulent marrow	2	good	
-8413	tasty diet salacious crumbs	1	awesome	
+8413	diet tasty salacious crumbs	1	awesome	
 8414	decent lime green fusilli marrownarrow	3	good	
 8415	flavorless suggestive strozzapreti	3	decent	
 8416	narrow pulsating Mountain Stream gastrique	0		
@@ -8303,7 +8303,7 @@
 8429	veiny spore pod	0		
 8430	hard spore pod	0		
 8431	spore pod	0		
-8432	mirror skewed shaking hot spore pod	0		
+8432	shaking skewed mirror hot spore pod	0		
 8433	squat cool spore pod	0		
 8434	upside-down jingling spore pod	0		
 8435	chilly LavaCo Lamp&trade; of the glutton	0		Cold Damage: +5, Food Drop: +100, Last Available: "2015-08"
@@ -8326,7 +8326,7 @@
 8452	green capped lava bottle	0		Last Available: "2015-08"
 8453	heat-resistant sheet	0		Last Available: "2015-08"
 8454	squat LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
-8455	upside-down jittery New Age crystal	0		Last Available: "2015-08"
+8455	jittery upside-down New Age crystal	0		Last Available: "2015-08"
 8456	blurry crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	wobbly flame-retardant boxer's high-temperature mining mask	0		Muscle Percent: +10, Hot Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
@@ -8376,7 +8376,7 @@
 8502	cyan Pener's crisps	0		Last Available: "2015-08"
 8503	maroon signed deuce	0		Last Available: "2015-08"
 8504	bouncing narrow Lavalos core	0		Last Available: "2015-08"
-8505	gray pulsating half-melted hula girl	0		Last Available: "2015-08"
+8505	pulsating gray half-melted hula girl	0		Last Available: "2015-08"
 8506	glass ceiling fragments	0		Last Available: "2015-08"
 8507	diluted SMOOCH coffee cup	1	decent	Last Available: "2015-08"
 8508	concentrated non-anodized deionized skewed purple labrador cookie	0		Effect: "Strong Grip", Effect Duration: 25, Last Available: "2015-08"
@@ -8401,26 +8401,26 @@
 8527	blinking wobbly Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
 8529	thick tasty devil hair pasta	5	awesome	
-8530	adequate gigantic teal spagecialetti	9	good	
+8530	gigantic adequate teal spagecialetti	9	good	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	narrow illicit fish sauce	0		
 8534	flavorless libertagliatelle	3	decent	
-8535	half-sized flavorless turkish mostaccioli	2	decent	
+8535	flavorless half-sized turkish mostaccioli	2	decent	
 8536	spoiled linguini of the sea	3	crappy	
 8537	vacuum-sealed yellow Hersey&trade; SMOOCH	0		Effect: "Sappy Blood", Effect Duration: 62
 8539	Alexy sauce	0		
 8540	red rainbow sauce	0		
 8541	wobbly wobbly drug cocktail sauce	0		
-8542	immense adequate Fettris	6	good	
+8542	adequate immense Fettris	6	good	
 8543	bland fusillocybin	4	decent	
-8544	flavorless big fuchsia prescription noodles	5	decent	
+8544	big flavorless fuchsia prescription noodles	5	decent	
 8545	mixed blood-drive sticker	1	crappy	
 8546	super-activated bag of grain	0		Effect: "Glittering Eyelashes", Effect Duration: 21
 8547	energized pocket maze	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 28
 8548	double-polymerized shady shades	0		Effect: "Sparkly!", Effect Duration: 39
 8549	energized anodized dry twirling squeaky toy rose	0		Effect: "Holiday Bliss", Effect Duration: 11
-8550	flavorless immense weird gazelle steak	9	decent	
+8550	immense flavorless weird gazelle steak	9	decent	
 8551	rotten ghostly sausage without a cause	3	crappy	
 8552	tarnished irradiated corrupted mirror lime green face paint	0		Effect: "Video Game Hot Dog", Effect Duration: 33
 8553	strong hand-crafted wobbly emergency margarita	5	super ultra EPIC	
@@ -8433,7 +8433,7 @@
 8560	pickled pressed shaking Aerheads	0		Effect: "Whitened Teeth", Effect Duration: 55
 8561	diffused altered blinking Wrotz	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 15
 8562	pickled Gabarbar	0		Effect: "Turkey-Agitated", Effect Duration: 42
-8563	ionized lime green huge fiberglass insulation	0		Effect: "Faboooo", Effect Duration: 27
+8563	ionized huge lime green fiberglass insulation	0		Effect: "Faboooo", Effect Duration: 27
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	medical-grade ruddy beefcake's barrel lid	0		Muscle: +25, Maximum HP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	crafty stiffened beefy barrel hoop earring	0		Muscle: +10, Damage Reduction: 1, Maximum MP: +10, Lasts Until Rollover, Last Available: "2015-09"
@@ -8446,20 +8446,20 @@
 8573	green barrel	0		Last Available: "2015-09"
 8574	moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
-8576	narrow teal upside-down mouldering barrel	0		Last Available: "2015-09"
+8576	upside-down narrow teal mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	artisanal bottle of Amontillado	3	EPIC	Last Available: "2015-09"
 8579	artisanal strong barrel-aged martini	5	EPIC	Last Available: "2015-09"
-8580	flavorless half-sized barrel pickle	2	decent	Last Available: "2015-09"
+8580	half-sized flavorless barrel pickle	2	decent	Last Available: "2015-09"
 8581	special stale barrel cracker	4	decent	Effect: "Very Clean Guns", Effect Duration: 15, Last Available: "2015-09"
-8582	dried olive skewed vibrating mushroom	1	decent	Last Available: "2015-09"
+8582	dried skewed olive vibrating mushroom	1	decent	Last Available: "2015-09"
 8583	compressed skewed mushroom	1	crappy	Effect: "Sappy Blood", Effect Duration: 5, Last Available: "2015-09"
 8584	extremely unsafe KoL Con 12-gauge	0		Weapon Damage Percent: +100, Last Available: "2015-09"
 8585	aromatic Golden Mr. Eh?	0		Stench Resistance: +1, Last Available: "2015-09"
 8586	auspicious barrel gun	0		Item Drop: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	olive barrel beryl	0		Last Available: "2015-09"
-8589	tiny bland ghostly water log	1	decent	Last Available: "2015-09"
+8589	bland tiny ghostly water log	1	decent	Last Available: "2015-09"
 8590	chaotic barrelhead of terror	0		Spell Critical Percent: +10, Spooky Spell Damage: +10, Last Available: "2015-09"
 8591	ribald crafty bottoms of the barrel	0		Maximum MP: +10, Sleaze Damage: +10, Last Available: "2015-09"
 8592	stanky beefy chest barrel	0		Muscle: +10, Stench Spell Damage: +25, Last Available: "2015-09"
@@ -8480,13 +8480,13 @@
 8607	oxidized cuppa Toast tea	0		Effect: "Wise Spirit", Effect Duration: 68, Last Available: "2015-09"
 8608	quadruple-pressed gray squat cuppa Net tea	0		Effect: "Ticking Clock", Effect Duration: 11, Last Available: "2015-09"
 8609	oxidized mirror cuppa Proprie tea	0		Effect: "Horrid, Torrid", Effect Duration: 25, Last Available: "2015-09"
-8610	improved nitrogenated skewed narrow cuppa Morbidi tea	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 12, Last Available: "2015-09"
+8610	improved nitrogenated narrow skewed cuppa Morbidi tea	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 12, Last Available: "2015-09"
 8611	unsweetened denatured squat cuppa Chari tea	0		Effect: "Itchy Trigger Finger", Effect Duration: 59, Last Available: "2015-09"
 8612	wet colloidal cuppa Serendipi tea	0		Effect: "Chow Downed", Effect Duration: 43, Last Available: "2015-09"
 8613	irradiated warmed alkaline tumbling cuppa Feroci tea	0		Effect: "Weird Vibrations", Effect Duration: 27, Last Available: "2015-09"
 8614	chilled cyan cuppa Physicali tea	0		Effect: "Heart of Pink", Effect Duration: 26, Last Available: "2015-09"
 8615	polarized diffused nitrogenated green narrow pulsating cuppa Wit tea	0		Effect: "Army of One", Effect Duration: 25, Last Available: "2015-09"
-8616	triple-galvanized double-flattened maroon twirling cuppa Neuroplastici tea	0		Effect: "Red-Shirted Escort", Effect Duration: 53, Last Available: "2015-09"
+8616	triple-galvanized double-flattened twirling maroon cuppa Neuroplastici tea	0		Effect: "Red-Shirted Escort", Effect Duration: 53, Last Available: "2015-09"
 8617	extra-activated cuppa Dexteri tea	0		Effect: "Bark of the Dog", Effect Duration: 68, Last Available: "2015-09"
 8618	oxidized energized cuppa Flexibili tea	0		Effect: "Mayeaugh", Effect Duration: 30, Last Available: "2015-09"
 8619	polarized ionized bouncing cuppa Impregnabili tea	0		Effect: "Spooky Demeanor", Effect Duration: 44, Last Available: "2015-09"
@@ -8494,11 +8494,11 @@
 8621	dry frozen polymerized cuppa Irritabili tea	0		Effect: "Musky", Effect Duration: 62, Last Available: "2015-09"
 8622	concentrated corrupted colloidal cuppa Mediocri tea	0		Effect: "Night Vision", Effect Duration: 55, Last Available: "2015-09"
 8623	liquefied cuppa Loyal tea	0		Effect: "Buff as a Baobab", Effect Duration: 28, Last Available: "2015-09"
-8624	twisted yellow tumbling cuppa Activi tea	1	good	Effect: "Elbow Sauce", Effect Duration: 50, Last Available: "2015-09"
+8624	twisted tumbling yellow cuppa Activi tea	1	good	Effect: "Elbow Sauce", Effect Duration: 50, Last Available: "2015-09"
 8625	powdered cyan cuppa Cruel tea	1		Last Available: "2015-09"
 8626	unsweetened deionized jittery cuppa Alacri tea	0		Effect: "Wings of the Grasshopper", Effect Duration: 39, Last Available: "2015-09"
 8627	dry anodized bouncing cuppa Vitali tea	0		Effect: "Aquarius Rising", Effect Duration: 69, Last Available: "2015-09"
-8628	denatured non-tarnished twirling blurry cyan cuppa Mana tea	0		Effect: "Booooooze", Effect Duration: 66, Last Available: "2015-09"
+8628	denatured non-tarnished blurry twirling cyan cuppa Mana tea	0		Effect: "Booooooze", Effect Duration: 66, Last Available: "2015-09"
 8629	pressed cuppa Monstrosi tea	0		Effect: "Bricked-In", Effect Duration: 52, Last Available: "2015-09"
 8630	quantum oxidized cuppa Twen tea	0		Effect: "Squatting and Thrusting", Effect Duration: 50, Last Available: "2015-09"
 8631	pressed ghostly cuppa Gill tea	0		Effect: "Provocative Perkiness", Effect Duration: 14, Last Available: "2015-09"
@@ -8511,7 +8511,7 @@
 8638	greedy wholesome Royal scepter of incineration	0		Maximum HP Percent: +10, Hot Spell Damage: +50, Meat Drop: +20, Last Available: "2015-09"
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
-8641	delicious small bowl of eyeballs	2	awesome	Last Available: "2015-10"
+8641	small delicious bowl of eyeballs	2	awesome	Last Available: "2015-10"
 8642	adequate bowl of mummy guts	4	good	Last Available: "2015-10"
 8643	moldy blurry bowl of maggots	3	crappy	Last Available: "2015-10"
 8644	perfectly mixed blood and blood	3	EPIC	Last Available: "2015-10"
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	squat How to Play Othello	0		
 8662	skewed Sherlock's Jeselnik's ghostly dagger of courage	0		Sleaze Damage: +25, Spooky Resistance: +3, Item Drop: +25
-8663	acceptable triple-distilled ghost beer	6	good	
+8663	triple-distilled acceptable ghost beer	6	good	
 8664	Jim Carey's Othello set	0		Monster Level: +25
 8665	rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8559,14 +8559,14 @@
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	huge blinking weightlifter's bellhop's hat	0		Muscle: +15, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	boozy acceptable blurry ice porter	5	good	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8689	acceptable boozy blurry ice porter	5	good	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	Vulcanized blinking exotic travel brochure	0		Effect: "Human-Slime Hybrid", Effect Duration: 43, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	denatured shampoo-conditioner	0		Effect: "Feet of Grapefruit", Effect Duration: 44, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
-8696	altered huge twirling blinking medicinal herbs	1		Effect: "Flamibili Tea", Effect Duration: 15, Last Available: "2016-01"
+8696	altered blinking twirling huge medicinal herbs	1		Effect: "Flamibili Tea", Effect Duration: 15, Last Available: "2016-01"
 8697	normal olive ice rice	3	good	Last Available: "2016-01"
 8698	artisanal green iced plum wine	4	EPIC	Last Available: "2016-01"
 8699	narrow blurry grievous dangerous training belt of the overflowing toilet	0		Weapon Damage: +10, Weapon Damage Percent: +50, Stench Spell Damage: +50, Single Equip, Last Available: "2016-01"
@@ -8579,7 +8579,7 @@
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	diluted abstraction: action	1		Effect: "The Moxie of LOV", Effect Duration: 10, Last Available: "2015-12"
-8709	altered blinking cyan abstraction: thought	1		Last Available: "2015-12"
+8709	altered cyan blinking abstraction: thought	1		Last Available: "2015-12"
 8710	pickled upside-down abstraction: sensation	1		Last Available: "2015-12"
 8711	powdered abstraction: purpose	1		Effect: "Yuletide Sappiness", Effect Duration: 15, Last Available: "2015-12"
 8712	denatured skewed abstraction: category	1		Effect: "Dexteri Tea", Effect Duration: 35, Last Available: "2015-12"
@@ -8589,8 +8589,8 @@
 8716	dehydrated spinning abstraction: certainty	1		Last Available: "2015-12"
 8717	dehydrated abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	spoiled gigantic red VYKEA meatballs	7	crappy	Last Available: "2015-11"
-8720	irresponsibly strong fancy lousy VYKEA mead	8	decent	Effect: "Pumped Up", Effect Duration: 30, Last Available: "2015-11"
+8719	gigantic spoiled red VYKEA meatballs	7	crappy	Last Available: "2015-11"
+8720	irresponsibly strong lousy fancy VYKEA mead	8	decent	Effect: "Pumped Up", Effect Duration: 30, Last Available: "2015-11"
 8721	improved quantum spinning VYKEA woadpaint	0		Effect: "Ticking Clock", Effect Duration: 26, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	purple VYKEA blood rune	0		Last Available: "2015-11"
@@ -8600,30 +8600,30 @@
 8727	upside-down skewed VYKEA bracket	0		Last Available: "2015-11"
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	red prompt auspicious VYKEA hex key of Flo-Jo	0		Item Drop: +10, Initiative: +100, Adventures: +3, Last Available: "2015-11"
-8730	wobbly tumbling VYKEA instructions	0		Last Available: "2015-11"
-8731	diet flavorless tin of submardines	1	decent	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8730	tumbling wobbly VYKEA instructions	0		Last Available: "2015-11"
+8731	flavorless diet tin of submardines	1	decent	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	lousy squat bottle of norwhiskey	4	decent	Last Available: "2015-11"
-8733	mixed twirling gray octolus oculus	1	awesome	Last Available: "2015-11"
+8733	mixed gray twirling octolus oculus	1	awesome	Last Available: "2015-11"
 8734	squat skewed hardy rock-hard hardened sardine can key	0		Damage Reduction: 16, Maximum HP: +50, Last Available: "2015-11"
 8735	pulsating mirror upside-down double-paned MacGyver's brawny norwhal helmet	0		Muscle Percent: +20, Maximum MP: +100, Cold Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	horrifying stiffened educational octolus-skin cloak	0		Experience: +1, Damage Reduction: 1, Spooky Damage: +25, Last Available: "2015-11"
-8737	perfectly mixed fancy practically non-alcoholic blurry olive perfect cosmopolitan	1	super ultra mega turbo EPIC	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2015-11"
-8738	lousy irresponsibly strong perfect negroni	7	decent	Last Available: "2015-11"
+8737	fancy practically non-alcoholic perfectly mixed blurry olive perfect cosmopolitan	1	super ultra mega turbo EPIC	Effect: "The Q Is Talking To You", Effect Duration: 15, Last Available: "2015-11"
+8738	irresponsibly strong lousy perfect negroni	7	decent	Last Available: "2015-11"
 8739	acceptable practically non-alcoholic perfect dark and stormy	1	good	Last Available: "2015-11"
 8740	smooth fortified perfect mimosa	5	awesome	Last Available: "2015-11"
 8741	perfectly mixed perfect old-fashioned	4	EPIC	Last Available: "2015-11"
 8742	tolerable perfect paloma	4	good	Last Available: "2015-11"
-8743	galvanized quadruple-tarnished alkaline blue wobbly That 70s Cologne	0		Effect: "Cock of the Walk", Effect Duration: 35, Last Available: "2015-11"
+8743	galvanized quadruple-tarnished alkaline wobbly blue That 70s Cologne	0		Effect: "Cock of the Walk", Effect Duration: 35, Last Available: "2015-11"
 8744	cold-filtered Wal-Mart &quot;diamond&quot; ring	0		Effect: "Object Detection", Effect Duration: 38, Last Available: "2015-11"
 8745	quadruple-moist Puffstone cigar	0		Effect: "Pronounced Potency", Effect Duration: 11, Last Available: "2015-11"
 8746	energized altered wobbly skewed Conspiracy&trade; mascara	0		Effect: "Crimbo Nostalgia", Effect Duration: 48, Last Available: "2015-11"
 8747	unsweetened cold-filtered Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Wreathed in Smoke", Effect Duration: 63, Last Available: "2015-11"
 8748	bouncing airplane tattoo	0		Last Available: "2015-11"
 8749	deionized teal Deep Machine Tunnels snowglobe	0		Effect: "Horrid, Torrid", Effect Duration: 23, Last Available: "2015-12"
-8750	quadruple-galvanized twirling lime green hemp candy necklace	0		Effect: "Glo-Face", Effect Duration: 30, Last Available: "2015-12"
+8750	quadruple-galvanized lime green twirling hemp candy necklace	0		Effect: "Glo-Face", Effect Duration: 30, Last Available: "2015-12"
 8751	energized vacuum-sealed communal gobstopper	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 42, Last Available: "2015-12"
 8752	delicious gigantic Crimbo salad	6	awesome	Last Available: "2015-12"
-8753	spoiled diet bread line	1	crappy	Last Available: "2015-12"
+8753	diet spoiled bread line	1	crappy	Last Available: "2015-12"
 8754	acceptable bark rootbeer	3	good	Last Available: "2015-12"
 8755	strong mediocre ale	5	decent	Last Available: "2015-12"
 8756	Jack Frost's plastic Tammy the Tambourine Elf	0		Cold Spell Damage: +50, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	BACON	0		Last Available: "2016-05"
 8764	ghostly box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	blurry Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	practically non-alcoholic perfectly mixed Gratitude chocolate (bourbon-filled)	1	EPIC	Last Available: "2016-02"
+8766	perfectly mixed practically non-alcoholic Gratitude chocolate (bourbon-filled)	1	EPIC	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	narrow chocolate bowtie	0		Familiar Weight: +5
@@ -8649,7 +8649,7 @@
 8777	bundle of &quot;fragrant&quot; herbs	0		Last Available: "2015-12"
 8778	nuclear stockpile	0		Last Available: "2015-12"
 8779	pine cone	0		Last Available: "2015-12"
-8780	spinning jittery iron chain	0		Last Available: "2015-12"
+8780	jittery spinning iron chain	0		Last Available: "2015-12"
 8781	supercool pine cone necklace	0		Moxie Percent: +20, Last Available: "2015-12"
 8782	strapping reindeer hammer	0		Muscle: +5, Last Available: "2015-12"
 8783	asbestos-lined elf ploughshare	0		Hot Resistance: +5, Last Available: "2015-12"
@@ -8685,18 +8685,18 @@
 8813	glob of Bat-Glue	0		Last Available: "2017-01"
 8814	wobbly Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bouncing wobbly bat-bearing	0		Last Available: "2017-01"
-8816	rotten small Kudzu salad	2	crappy	Last Available: "2016-12"
+8816	small rotten Kudzu salad	2	crappy	Last Available: "2016-12"
 8817	altered upside-down Mansquito Serum	1		Last Available: "2016-12"
-8818	special high-proof acceptable Miss Graves' vermouth	6	good	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2016-12"
+8818	high-proof acceptable special Miss Graves' vermouth	6	good	Effect: "Flashing Eyes", Effect Duration: 35, Last Available: "2016-12"
 8819	yummy The Plumber's mushroom stew	3	awesome	Last Available: "2016-12"
 8820	diluted ghostly The Author's ink	1		Effect: "Rushtacean'", Effect Duration: 50, Last Available: "2016-02"
 8821	hand-crafted extra-dry The Mad Liquor	5	EPIC	Last Available: "2016-12"
 8822	weak artisanal teal Doc Clock's thyme cocktail	2	super ultra mega turbo EPIC	Last Available: "2016-12"
 8823	decent bouncing Mr. Burnsger	4	good	Last Available: "2016-12"
 8824	mixed blinking maroon The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	frightening fortified The Jokester's gun of the boozehound	0		Damage Absorption: +60, Spooky Damage: +5, Booze Drop: +100, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	squat forbidden Sinatra's The Jokester's wig of horror	0		Experience (Moxie): +5, Spell Damage Percent: +50, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12"
-8827	zippy forbidden The Jokester's pants of Leguizamo	0		Spell Damage Percent: +50, Monster Level: +20, Initiative: +20, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	frightening fortified The Jokester's gun of the boozehound	0		Damage Absorption: +60, Spooky Damage: +5, Booze Drop: +100, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	squat forbidden Sinatra's The Jokester's wig of horror	0		Experience (Moxie): +5, Spell Damage Percent: +50, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	zippy forbidden The Jokester's pants of Leguizamo	0		Spell Damage Percent: +50, Monster Level: +20, Initiative: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	pickled jittery skewed Jokester makeup	0		Effect: "Baconstoned", Effect Duration: 48, Last Available: "2016-12"
 8829	blurry replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	domino mask	0		Familiar Weight: +5
 8833	magnetized robin's egg	0		Effect: "Concentrated Concentration", Effect Duration: 32, Last Available: "2016-12"
 8834	miniature delicious upside-down robin flan	2	awesome	Last Available: "2016-12"
-8835	triple-distilled drinkable yellow robin nog	6	good	Last Available: "2016-12"
+8835	drinkable triple-distilled yellow robin nog	6	good	Last Available: "2016-12"
 8836	narrow LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	blue exploding gum	0		
@@ -8717,9 +8717,9 @@
 8845	electrified diffused bag of random words	0		Effect: "Emotion Sickness", Effect Duration: 17
 8846	super-irradiated ionized tumbling yellow tube of pendulum lube	0		Effect: "Dance Interpreter", Effect Duration: 16
 8847	diffused red-hot jawbreaker	0		Effect: "Pasta Oneness", Effect Duration: 68
-8848	triple-moist extra-electrified lime green upside-down question juice	0		Effect: "Resilient Spirit", Effect Duration: 55
+8848	triple-moist extra-electrified upside-down lime green question juice	0		Effect: "Resilient Spirit", Effect Duration: 55
 8849	magnetized tube of villain	0		Effect: "Swordholder", Effect Duration: 23
-8850	MacGyver's your cowboy boots	0		Maximum MP: +100, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	MacGyver's your cowboy boots	0		Maximum MP: +100, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	purple nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,12 +8746,12 @@
 8874	nippy curative Socratic Val-U Brand Every Bean Salad of the ox of mayonnaise	0		Muscle: +20, Experience (Mysticality): +1, Cold Damage: +10, Sleaze Spell Damage: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-02"
 8875	family-friendly gravedigger's Shrub's Premium Baked Beans of the early riser	0		Spooky Damage: +10, Sleaze Resistance: +1, Adventures: +7, Last Available: "2016-02"
 8876	normal plate of Heimz Fortified Kidney Beans	3	good	Last Available: "2016-02"
-8877	stale special plate of Tesla's Electroplated Beans	3	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2016-02"
+8877	special stale plate of Tesla's Electroplated Beans	3	decent	Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2016-02"
 8878	adequate plate of Mixed Garbanzos and Chickpeas	4	good	Last Available: "2016-02"
 8879	half-sized rotten plate of Hellfire Spicy Beans	2	crappy	Last Available: "2016-02"
 8880	stale plate of Frigid Northern Beans	4	decent	Last Available: "2016-02"
-8881	diet adequate plate of World's Blackest-Eyed Peas	1	good	Last Available: "2016-02"
-8882	flavorless gigantic special plate of Trader Olaf's Exotic Stinkbeans	6	decent	Effect: "Lifted Spirits", Effect Duration: 15, Last Available: "2016-02"
+8881	adequate diet plate of World's Blackest-Eyed Peas	1	good	Last Available: "2016-02"
+8882	gigantic special flavorless plate of Trader Olaf's Exotic Stinkbeans	6	decent	Effect: "Lifted Spirits", Effect Duration: 15, Last Available: "2016-02"
 8883	decent thick plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	good	Last Available: "2016-02"
 8884	super-sized normal plate of Val-U Brand Every Bean Salad	5	good	Last Available: "2016-02"
 8885	normal plate of Shrub's Premium Baked Beans	4	good	Last Available: "2016-02"
@@ -8766,7 +8766,7 @@
 8894	stanky personal trainer's Granny Hackleton's Gatling gun of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Stench Spell Damage: +25, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
-8897	diffused squat pulsating poker face paint	0		Effect: "Adrenaline Rush", Effect Duration: 55, Last Available: "2016-02"
+8897	diffused pulsating squat poker face paint	0		Effect: "Adrenaline Rush", Effect Duration: 55, Last Available: "2016-02"
 8898	realistic cap gun	0		Last Available: "2016-02"
 8899	fancy tainted milk	1	decent	Effect: "Conspiratory Eyes", Effect Duration: 30, Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
@@ -8778,7 +8778,7 @@
 8906	dry electrified rattler gland	0		Effect: "Disdain of the War Snapper", Effect Duration: 58, Last Available: "2016-02"
 8907	adjusted half-digested coal	0		Effect: "Fizzier Than Light", Effect Duration: 19, Last Available: "2016-02"
 8908	oxidized tightly-wound spine	0		Effect: "Sleazy Jellied", Effect Duration: 16, Last Available: "2016-02"
-8909	enchanted rotten green rotting beefsteak	3	crappy	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2016-02"
+8909	rotten enchanted green rotting beefsteak	3	crappy	Effect: "Slippery Tongue", Effect Duration: 35, Last Available: "2016-02"
 8910	acceptable cyan firemilk	3	good	Last Available: "2016-02"
 8911	dry ionized liquefied skewed spidercow eye-cluster	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 52, Last Available: "2016-02"
 8912	mixed teal moomy dust	1		Effect: "Deadly Flashing Blade", Effect Duration: 30, Last Available: "2016-02"
@@ -8802,7 +8802,7 @@
 8930	activated unsweetened moist demonic cow's blood	0		Effect: "Piratey Flavor", Effect Duration: 39, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
 8932	narrow makeshift sixgun	0		Last Available: "2016-02"
-8933	ghostly gray custom sixgun	0		Last Available: "2016-02"
+8933	gray ghostly custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
@@ -8851,8 +8851,8 @@
 8979	pickled red narrow patent sallowness tonic	0		Effect: "Grumpy and Ornery", Effect Duration: 42
 8980	ionized patent avarice tonic	0		Effect: "Drenched With Filth", Effect Duration: 58
 8981	concentrated wet nitrogenated patent alacrity tonic	0		Effect: "You're Rubber", Effect Duration: 69
-8982	double-pickled jittery twirling corrupted marrow	0		Effect: "Innately Strong", Effect Duration: 68
-8983	delicious fancy practically non-alcoholic rodeo whiskey	1	awesome	Effect: "Unrunnable Face", Effect Duration: 15
+8982	double-pickled twirling jittery corrupted marrow	0		Effect: "Innately Strong", Effect Duration: 68
+8983	fancy practically non-alcoholic delicious rodeo whiskey	1	awesome	Effect: "Unrunnable Face", Effect Duration: 15
 8984	blurry Thwaitgold scorpion statuette	0		
 8985	red sinister real cowboy hat	0		Spell Damage: +10
 8986	jittery Memories of Cow Punching	0		Free Pull
@@ -8860,7 +8860,7 @@
 8988	Memories of Snake Oiling	0		Free Pull
 8989	upside-down bouncing Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	purple electronic Brain Trainer game	0		Skill: "Brain Games"
-8991	skewed squat do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
+8991	squat skewed do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	powdered armored prawn	1		Last Available: "2016-03"
 8993	stale jumping horseradish	4	decent	Last Available: "2016-03"
 8994	hand-crafted practically non-alcoholic wobbly Sacramento wine	1	EPIC	Last Available: "2016-03"
@@ -8878,7 +8878,7 @@
 9006	Lo Pan's supercool savvy cool tunac	0		Moxie: +5, Mysticality Percent: +20, Moxie Percent: +20, Spell Critical Percent: +30, Lasts Until Rollover, Last Available: "2016-04"
 9007	jittery fishin' pole	0		Last Available: "2016-04"
 9008	ionized extra-nitrogenated narrow wriggling worm	0		Effect: "Hombre Muerto Caminando", Effect Duration: 48, Last Available: "2016-04"
-9009	hand-crafted spirit-forward upside-down bottle of Fishhead 900-Day IPA	5	EPIC	Last Available: "2016-04"
+9009	spirit-forward hand-crafted upside-down bottle of Fishhead 900-Day IPA	5	EPIC	Last Available: "2016-04"
 9010	activated non-denatured high-test fishing line	0		Effect: "Helping Comes Second", Effect Duration: 39, Last Available: "2016-04"
 9011	blue Fonzie's fishin' hat	0		Experience (Moxie): +1, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8886,7 +8886,7 @@
 9014	luxury fly-tying workbench	0		Fishing Skill: +10, Last Available: "2016-04"
 9015	tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
-9017	lime green bouncing viral video	0		Last Available: "2016-05"
+9017	bouncing lime green viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
@@ -8901,15 +8901,15 @@
 9029	blinking no spoon	0		
 9030	toothsome star salad	4	awesome	
 9031	teal Thwaitgold moth statuette	0		
-9032	immense normal bowl of Tastee-Wheet&trade;	10	good	
+9032	normal immense bowl of Tastee-Wheet&trade;	10	good	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	blue Source essence	0		Last Available: "2016-06"
-9035	tasty low-calorie browser cookie	1	awesome	Last Available: "2016-06"
+9035	low-calorie tasty browser cookie	1	awesome	Last Available: "2016-06"
 9036	lousy special maroon hacked gibson	4	decent	Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 20, Last Available: "2016-06"
 9037	Source shades of the storm	0		Maximum MP Percent: +40, Last Available: "2016-06"
 9038	gray software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
-9040	squat twirling Source terminal PRAM chip	0		Last Available: "2016-06"
+9040	twirling squat Source terminal PRAM chip	0		Last Available: "2016-06"
 9041	Source terminal GRAM chip	0		Last Available: "2016-06"
 9042	ghostly Source terminal SPAM chip	0		Last Available: "2016-06"
 9043	Source terminal CRAM chip	0		Last Available: "2016-06"
@@ -8944,14 +8944,14 @@
 9072	cop dollar	0		Last Available: "2016-07"
 9073	detective school application	0		Free Pull, Last Available: "2016-07"
 9074	energetic detective roscoe of dire peril of incineration	0		Weapon Damage: +20, Maximum MP Percent: +20, Hot Spell Damage: +50, Last Available: "2016-07"
-9075	quantum skewed narrow shoe gum	0		Effect: "Radium Radicality", Effect Duration: 61, Last Available: "2016-07"
+9075	quantum narrow skewed shoe gum	0		Effect: "Radium Radicality", Effect Duration: 61, Last Available: "2016-07"
 9076	flame-wreathed Lo Pan's clever noir fedora	0		Maximum MP: +20, Spell Critical Percent: +30, Hot Spell Damage: +10, Last Available: "2016-07"
 9077	clever supercharged trench coat of terror	0		Maximum MP Percent: +30, Maximum MP: +20, Spooky Spell Damage: +10, Last Available: "2016-07"
-9078	tolerable weak Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
+9078	weak tolerable Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
 9079	decent big hardboiled egg	5	good	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	Usain Bolt's Sherlock's scandalous rock-hard grievous protonic accelerator pack of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Damage Reduction: 5, Sleaze Damage: +5, Item Drop: +25, Initiative: +80, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	Usain Bolt's Sherlock's scandalous rock-hard grievous protonic accelerator pack of James Dean	0		Experience (Moxie): +3, Weapon Damage Percent: +50, Damage Reduction: 5, Sleaze Damage: +5, Item Drop: +25, Initiative: +80, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	blue narrow Adventurer bobblehead of the storm	0		Maximum MP Percent: +40, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	yellow ghostly supercharged stylish Spookyraven signet of the cheetah	0		Moxie: +25, Maximum MP Percent: +30, Initiative: +60, Single Equip, Last Available: "2016-08"
 9093	tumbling Lo Pan's wicked tie-dyed fannypack	0		Spell Damage: +5, Spell Critical Percent: +30, Single Equip, Last Available: "2016-08"
 9094	squat burnt snowpants of Tarzan of the sweet-tooth	0		Experience (Muscle): +3, Candy Drop: +100, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	narrow blinking standards and practices guide of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9095	narrow blinking standards and practices guide of the boozehound	0		Booze Drop: +100, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	wool smelly educational Carpathian longsword	0		Experience: +1, Stench Spell Damage: +10, Cold Resistance: +1, Last Available: "2016-08"
 9097	twirling flame-retardant veiny occult Liam's mail	0		Spell Damage Percent: +25, Maximum HP: +10, Hot Resistance: +1, Last Available: "2016-08"
 9098	wool grievous Unfortunato's foolscap of Calamity Jane	0		Weapon Damage Percent: +50, Critical Hit Percent: +15, Cold Resistance: +1, Last Available: "2016-08"
@@ -8979,18 +8979,18 @@
 9107	alkaline colloidal Rad-Pro (1 oz.)	0		Effect: "Conspiratory Eyes", Effect Duration: 66
 9108	lead umbrella	0		
 9109	moist wet Shrieking Weasel holo-record	0		Effect: "Vital", Effect Duration: 35
-9110	vacuum-sealed quantum magnetized squat tumbling Power-Guy 2000 holo-record	0		Effect: "Elron's Explosive Etude", Effect Duration: 45
+9110	vacuum-sealed quantum magnetized tumbling squat Power-Guy 2000 holo-record	0		Effect: "Elron's Explosive Etude", Effect Duration: 45
 9111	magnetized energized Lucky Strikes holo-record	0		Effect: "Shredding, Sweating", Effect Duration: 39
 9112	chilled flattened twirling EMD holo-record	0		Effect: "Metal Speed", Effect Duration: 36
 9113	liquefied aerosolized Superdrifter holo-record	0		Effect: "Concentration", Effect Duration: 24
-9114	adjusted improved green ghostly skewed The Pigs holo-record	0		Effect: "Enraged", Effect Duration: 18
+9114	adjusted improved skewed green ghostly The Pigs holo-record	0		Effect: "Enraged", Effect Duration: 18
 9115	galvanized Drunk Uncles holo-record	0		Effect: "Punchy, Murdery", Effect Duration: 31
 9116	time residue	0		Last Available: "2016-09"
 9117	hale repaid diaper	0		Maximum HP: +20
 9118	yellow Riker's Search History	0		Last Available: "2016-09"
 9119	practically non-alcoholic artisanal Shot of Kardashian Gin	1	EPIC	Last Available: "2016-09"
 9120	scorching Unstable Pointy Ears	0		Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-09"
-9121	red shaking Memory Disk, Alpha	0		Last Available: "2016-09"
+9121	shaking red Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	narrow Tea, Earl Grey, Hot	1	decent	Last Available: "2016-09"
 9123	pulsating fuchsia School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
@@ -9017,19 +9017,19 @@
 9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	chilled dry boiled bouncing squat hoarded candy wad	0		Effect: "Weasels Underfoot", Effect Duration: 12, Last Available: "2016-10"
 9147	moist triple-aerosolized Prunets	0		Effect: "Puddingface", Effect Duration: 42
-9148	fuchsia jittery Twitching Television Tattoo	0		
+9148	jittery fuchsia Twitching Television Tattoo	0		
 9149	bouncing baby scorpion	0		Familiar Weight: +10
 9150	corrupted activated invisible string	0		Lasts Until Rollover, Effect: "Hairless and Airless", Effect Duration: 36, Last Available: "2016-10"
 9151	extra-deionized pickled olive invisible seam ripper	0		Lasts Until Rollover, Effect: "Purity of Spirit", Effect Duration: 61, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	massive spoiled raw sweet potato	6	crappy	Last Available: "2016-11"
+9153	spoiled massive raw sweet potato	6	crappy	Last Available: "2016-11"
 9154	spoiled fuchsia raw beans	3	crappy	Last Available: "2016-11"
 9155	stale immense raw stuffing	7	decent	Last Available: "2016-11"
-9156	bland huge raw cranberry sauce	10	decent	Last Available: "2016-11"
+9156	huge bland raw cranberry sauce	10	decent	Last Available: "2016-11"
 9157	stale raw turkey	4	decent	Last Available: "2016-11"
 9158	moldy raw mincemeat	3	crappy	Last Available: "2016-11"
 9159	bite-sized flavorless raw potato	1	decent	Last Available: "2016-11"
-9160	miniature enchanted bland twirling raw gravy	2	decent	Effect: "Meadulla Oblongota", Effect Duration: 40, Last Available: "2016-11"
+9160	bland miniature enchanted twirling raw gravy	2	decent	Effect: "Meadulla Oblongota", Effect Duration: 40, Last Available: "2016-11"
 9161	stale raw bread	3	decent	Last Available: "2016-11"
 9162	experienced mini-marshmallow dispenser of the sewer	0		Experience: +2, Stench Damage: +25, Last Available: "2016-11"
 9163	gray dangerous deadly glass casserole dish of dire peril	0		Weapon Damage: 35, Last Available: "2016-11"
@@ -9039,15 +9039,15 @@
 9167	sharpshooter's glass pie plate of the empath	0		Critical Hit Percent: +10, Familiar Weight: +5, Damage Reduction: 7, Last Available: "2016-11"
 9168	double-paned potato masher of terror	0		Spooky Spell Damage: +10, Cold Resistance: +5, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
-9170	maroon twirling bread mold	0		Last Available: "2016-11"
+9170	twirling maroon bread mold	0		Last Available: "2016-11"
 9171	half-sized moldy sweet potatoes	2	crappy	Last Available: "2016-11"
 9172	spoiled tiny bean casserole	1	crappy	Last Available: "2016-11"
 9173	moldy baked stuffing	4	crappy	Last Available: "2016-11"
-9174	flavorless bite-sized cranberry cylinder	1	decent	Last Available: "2016-11"
+9174	bite-sized flavorless cranberry cylinder	1	decent	Last Available: "2016-11"
 9175	adequate snack-sized thanksgiving turkey	2	good	Last Available: "2016-11"
 9176	special bland diet mince pie	1	decent	Effect: "Bright!", Effect Duration: 50, Last Available: "2016-11"
 9177	rotten mashed potatoes	4	crappy	Last Available: "2016-11"
-9178	stale low-calorie special purple warm gravy	1	decent	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2016-11"
+9178	low-calorie stale special purple warm gravy	1	decent	Effect: "Resilient Spirit", Effect Duration: 10, Last Available: "2016-11"
 9179	spoiled half-sized bouncing gray twirling bread roll	2	crappy	Last Available: "2016-11"
 9180	low-calorie decent twirling leftovers	1	good	Last Available: "2016-11"
 9181	moldy small leftovers sandwich	2	crappy	Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	mirror Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	double-quantum galvanized olive eldritch concentrate	0		Effect: "Human-Humanoid Hybrid", Effect Duration: 25, Last Available: "2016-11"
-9192	lousy fancy eldritch extract	3	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2016-11"
+9192	fancy lousy eldritch extract	3	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2016-11"
 9193	knitted Official Council Aide Pin of the dark arts	0		Spell Damage Percent: +100, Cold Resistance: +3, Last Available: "2016-11"
-9194	lousy enchanted tumbling eldritch distillate	3	decent	Effect: "Analog Drunk", Effect Duration: 10, Last Available: "2016-11"
+9194	enchanted lousy tumbling eldritch distillate	3	decent	Effect: "Analog Drunk", Effect Duration: 10, Last Available: "2016-11"
 9195	compressed fuchsia wobbly eldritch essence	1		Last Available: "2016-11"
 9196	Samson's Science Notebook	0		Experience (Muscle): +5
 9197	ghostly reassuring clever wicked eldritch hat	0		Spell Damage: +5, Maximum MP: +20, Spooky Resistance: +1, Last Available: "2016-11"
@@ -9090,7 +9090,7 @@
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	stale diet animal part cracker	1	decent	Last Available: "2016-12"
 9220	artisanal upside-down gingerbread wine	3	EPIC	Last Available: "2016-12"
-9221	jumbo rotten gingerbread mug	5	crappy	Last Available: "2016-12"
+9221	rotten jumbo gingerbread mug	5	crappy	Last Available: "2016-12"
 9222	gingerbread mask of Leguizamo	0		Monster Level: +20, Last Available: "2016-12"
 9223	skewed olive careful MacGyver's Oprah's gingerservo	0		Maximum MP Percent: +50, Maximum MP: +100, Monster Level: -10, Single Equip, Last Available: "2016-12"
 9224	polymerized tainted icing	0		Effect: "Booze Goozles", Effect Duration: 56, Last Available: "2016-12"
@@ -9109,9 +9109,9 @@
 9237	tumbling gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	drinkable ginger beer	3	good	Last Available: "2016-12"
-9240	huge squat spare chocolate parts	0		Last Available: "2016-12"
+9240	squat huge spare chocolate parts	0		Last Available: "2016-12"
 9241	quantum ionized industrial frosting	0		Effect: "damage.enh", Effect Duration: 34, Last Available: "2016-12"
-9242	alkaline wobbly wobbly teal fake cocktail	0		Effect: "Strawberry Alarm", Effect Duration: 63, Last Available: "2016-12"
+9242	alkaline wobbly teal wobbly fake cocktail	0		Effect: "Strawberry Alarm", Effect Duration: 63, Last Available: "2016-12"
 9243	delicious high-end ginger wine	4	awesome	Last Available: "2016-12"
 9244	spinning maroon rock-hard plastic bad vibe	0		Damage Reduction: 5, Last Available: "2016-12"
 9245	baleful plastic angry vikings	0		Spell Damage: +25, Last Available: "2016-12"
@@ -9121,11 +9121,11 @@
 9249	activated Inner Wisdom	0		Effect: "Mitre Cut", Effect Duration: 62, Last Available: "2016-12"
 9250	nitrogenated quantum Inner Strength	0		Effect: "Aloofah", Effect Duration: 22, Last Available: "2016-12"
 9251	aerosolized ionized quadruple-boiled gray Inner Truth	0		Effect: "Ack!  Barred!", Effect Duration: 54, Last Available: "2016-12"
-9252	spoiled snack-sized spiritual candy cane	2	crappy	Last Available: "2016-12"
+9252	snack-sized spoiled spiritual candy cane	2	crappy	Last Available: "2016-12"
 9253	drinkable spiritual eggnog	3	good	Last Available: "2016-12"
-9254	adequate special blinking spiritual fruitcake	4	good	Effect: "Burning Ears", Effect Duration: 20, Last Available: "2016-12"
-9255	half-sized bland spiritual gingerbread	2	decent	Last Available: "2016-12"
-9256	olive narrow chocolate puppy	0		Last Available: "2016-12"
+9254	special adequate blinking spiritual fruitcake	4	good	Effect: "Burning Ears", Effect Duration: 20, Last Available: "2016-12"
+9255	bland half-sized spiritual gingerbread	2	decent	Last Available: "2016-12"
+9256	narrow olive chocolate puppy	0		Last Available: "2016-12"
 9257	chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	bouncing My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
 9259	shaking Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
@@ -9148,14 +9148,14 @@
 9276	hand-crafted chakra-mental wine	3	EPIC	Last Available: "2016-12"
 9277	unsweetened cold-filtered bouncing chakra malt	0		Effect: "You Know When to Walk Away", Effect Duration: 57, Last Available: "2016-12"
 9278	bite-sized stale Black Angus blackburger	1	decent	Last Available: "2016-12"
-9279	practically non-alcoholic delicious yellow brandy	1	awesome	Last Available: "2016-12"
-9280	extra-altered moist ionized pulsating fuchsia potion of spiritual gunkifying	0		Effect: "Gummi-Grin", Effect Duration: 14, Last Available: "2016-12"
+9279	delicious practically non-alcoholic yellow brandy	1	awesome	Last Available: "2016-12"
+9280	extra-altered moist ionized fuchsia pulsating potion of spiritual gunkifying	0		Effect: "Gummi-Grin", Effect Duration: 14, Last Available: "2016-12"
 9281	resourceful smartaleck's bad vibroknife	0		Moxie Percent: +30, Maximum MP: +50, Last Available: "2016-12"
 9282	shellacked Rosewater's crystal belt buckle	0		Mysticality Percent: +30, Damage Reduction: 7, Last Available: "2016-12"
 9283	stylish saffron antaravasaka of terror	0		Moxie: +25, Spooky Spell Damage: +10, Last Available: "2016-12"
 9284	tumbling brainy saffron uttarasanga of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25, Last Available: "2016-12"
 9285	jittery Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
-9286	jittery wobbly eternal knot tattoo	0		Last Available: "2016-12"
+9286	wobbly jittery eternal knot tattoo	0		Last Available: "2016-12"
 9287	narrow pet bad vibe	0		Last Available: "2016-12"
 9288	tumbling gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	lime green Newton's boxer's cool Uncle Crimbo's hat	0		Moxie: +5, Muscle Percent: +10, Experience (Mysticality): +3, Last Available: "2016-12"
@@ -9167,9 +9167,9 @@
 9295	dehydrated stench jelly	1		Last Available: "2017-01"
 9296	jittery space planula	0		Free Pull, Last Available: "2017-01"
 9297	decent toast with hot jelly	3	good	Last Available: "2017-01"
-9298	massive delicious special toast with jelly	7	awesome	Effect: "Mutated", Effect Duration: 40, Last Available: "2017-01"
-9299	tiny spoiled toast with jelly	1	crappy	Last Available: "2017-01"
-9300	delicious gigantic toast with sleaze jelly	6	awesome	Last Available: "2017-01"
+9298	special massive delicious toast with jelly	7	awesome	Effect: "Mutated", Effect Duration: 40, Last Available: "2017-01"
+9299	spoiled tiny toast with jelly	1	crappy	Last Available: "2017-01"
+9300	gigantic delicious toast with sleaze jelly	6	awesome	Last Available: "2017-01"
 9301	flavorless toast with stench jelly	3	decent	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	spinning blurry hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9180,7 +9180,7 @@
 9308	supercool wax face of vim and vigor	0		Moxie Percent: +20, Maximum HP Percent: +50, Last Available: "2017-01"
 9309	extra-dry bad wax booze	5	decent	Last Available: "2017-01"
 9310	gray glob of melted wax	0		Last Available: "2017-01"
-9311	diluted huge maroon sea jelly	1		Effect: "Larger", Effect Duration: 20, Last Available: "2017-01"
+9311	diluted maroon huge sea jelly	1		Effect: "Larger", Effect Duration: 20, Last Available: "2017-01"
 9312	tasty fancy skewed sea truffle	3	awesome	Effect: "Mariachi Mood", Effect Duration: 20, Last Available: "2017-01"
 9313	huge tarnished luggage key	0		Last Available: "2017-01"
 9314	blue crushed steamer trunk	0		Last Available: "2017-01"
@@ -9199,9 +9199,9 @@
 9327	sinister LOV Elephant	0		Spell Damage: +10, Damage Reduction: 6, Last Available: "2017-02"
 9328	greedy eldritch scanner	0		Meat Drop: +20, Last Available: "2017-02"
 9329	quantum shaking eldritch alignment spray	0		Effect: "Cockroach Scurry", Effect Duration: 47, Last Available: "2017-02"
-9330	narrow blurry LOV Entrance Pass	0		Last Available: "2017-02"
+9330	blurry narrow LOV Entrance Pass	0		Last Available: "2017-02"
 9331	manspreader's eldritch hammer of wisdom of Leguizamo	0		Mysticality: +15, Monster Level: 30, Last Available: "2017-01"
-9332	miniature bland eldritch mushroom	2	decent	Last Available: "2017-03"
+9332	bland miniature eldritch mushroom	2	decent	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	decent huge shaking eldritch mushroom pizza	9	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9226,7 +9226,7 @@
 9354	shot of granola liqueur	0		Last Available: "2017-03"
 9355	can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	lump of ichor	0		Last Available: "2017-03"
-9357	ghostly wobbly bottle of gregnadigne	0		Last Available: "2017-03"
+9357	wobbly ghostly bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	spinning fuchsia baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
@@ -9236,40 +9236,40 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	practically non-alcoholic perfectly mixed literal grasshopper	1	EPIC	Last Available: "2017-03"
 9366	practically non-alcoholic aged double entendre	1	awesome	Last Available: "2017-03"
-9367	weak tolerable Phlegethon	2	good	Last Available: "2017-03"
+9367	tolerable weak Phlegethon	2	good	Last Available: "2017-03"
 9368	delicious tumbling Siberian sunrise	4	awesome	Last Available: "2017-03"
 9369	acceptable mirror mentholated wine	3	good	Last Available: "2017-03"
 9370	acceptable low tide martini	4	good	Last Available: "2017-03"
 9371	lousy shroomtini	3	decent	Last Available: "2017-03"
 9372	mediocre watered-down twirling morning dew	2	decent	Last Available: "2017-03"
 9373	hand-crafted wobbly whiskey squeeze	3	EPIC	Last Available: "2017-03"
-9374	tolerable practically non-alcoholic great fashioned	1	good	Last Available: "2017-03"
-9375	watered-down acceptable Gnomish sagngria	2	good	Last Available: "2017-03"
+9374	practically non-alcoholic tolerable great fashioned	1	good	Last Available: "2017-03"
+9375	acceptable watered-down Gnomish sagngria	2	good	Last Available: "2017-03"
 9376	drinkable vodka stinger	4	good	Last Available: "2017-03"
 9377	artisanal extremely slippery nipple	3	EPIC	Last Available: "2017-03"
 9378	acceptable watered-down piscatini	2	good	Last Available: "2017-03"
 9379	tolerable Churchill	4	good	Last Available: "2017-03"
 9380	delicious weak blurry soilzerac	2	awesome	Last Available: "2017-03"
-9381	hand-crafted weak gray London frog	2	EPIC	Last Available: "2017-03"
-9382	watered-down perfectly mixed skewed nothingtini	2	EPIC	Last Available: "2017-03"
+9381	weak hand-crafted gray London frog	2	EPIC	Last Available: "2017-03"
+9382	perfectly mixed watered-down skewed nothingtini	2	EPIC	Last Available: "2017-03"
 9383	lousy spinning eighth plague	4	decent	Last Available: "2017-03"
 9384	practically non-alcoholic hand-crafted single entendre	1	EPIC	Last Available: "2017-03"
 9385	hand-crafted high-proof narrow reverse Tantalus	7	EPIC	Last Available: "2017-03"
 9386	mediocre huge elemental caipiroska	3	decent	Last Available: "2017-03"
-9387	extra-dry smooth Feliz Navidad	5	awesome	Last Available: "2017-03"
+9387	smooth extra-dry Feliz Navidad	5	awesome	Last Available: "2017-03"
 9388	weak delicious blurry Bloody Nora	2	awesome	Last Available: "2017-03"
 9389	lousy moreltini	4	decent	Last Available: "2017-03"
 9390	artisanal special hell in a bucket	4	EPIC	Effect: "Yes, Can Haz", Effect Duration: 35, Last Available: "2017-03"
 9391	artisanal extra-dry Newark	5	EPIC	Last Available: "2017-03"
-9392	lousy irresponsibly strong skewed R'lyeh	8	decent	Last Available: "2017-03"
+9392	irresponsibly strong lousy skewed R'lyeh	8	decent	Last Available: "2017-03"
 9393	tolerable blurry Gnollish sangria	3	good	Last Available: "2017-03"
-9394	bad practically non-alcoholic squat tumbling vodka barracuda	1	decent	Last Available: "2017-03"
-9395	perfectly mixed watered-down jittery Mysterious Island iced tea	2	EPIC	Last Available: "2017-03"
+9394	bad practically non-alcoholic tumbling squat vodka barracuda	1	decent	Last Available: "2017-03"
+9395	watered-down perfectly mixed jittery Mysterious Island iced tea	2	EPIC	Last Available: "2017-03"
 9396	delicious drive-by shooting	3	awesome	Last Available: "2017-03"
-9397	perfectly mixed weak gunner's daughter	2	EPIC	Last Available: "2017-03"
-9398	practically non-alcoholic perfectly mixed dirt julep	1	EPIC	Last Available: "2017-03"
-9399	artisanal weak fuchsia Simepore slime	2	EPIC	Last Available: "2017-03"
-9400	lousy high-proof blinking Phil Collins	8	decent	Last Available: "2017-03"
+9397	weak perfectly mixed gunner's daughter	2	EPIC	Last Available: "2017-03"
+9398	perfectly mixed practically non-alcoholic dirt julep	1	EPIC	Last Available: "2017-03"
+9399	weak artisanal fuchsia Simepore slime	2	EPIC	Last Available: "2017-03"
+9400	high-proof lousy blinking Phil Collins	8	decent	Last Available: "2017-03"
 9401	upside-down unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9284,11 +9284,11 @@
 9412	blinking alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	shaking botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	adequate half-sized edible alien plant bit	2	good	Last Available: "2017-04"
+9415	half-sized adequate edible alien plant bit	2	good	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	fuchsia alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
-9419	ghostly spinning fascinating alien plant sample	0		Last Available: "2017-04"
+9419	spinning ghostly fascinating alien plant sample	0		Last Available: "2017-04"
 9420	boiled maroon alien plant goo	1		Last Available: "2017-04"
 9421	mirror alien plant pod	0		Last Available: "2017-04"
 9422	tumbling zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9297,12 +9297,12 @@
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	denatured tumbling tumbling cyan alien animal goo	1		Last Available: "2017-04"
-9429	blinking spinning alien animal milk	0		Last Available: "2017-04"
+9428	denatured tumbling cyan tumbling alien animal goo	1		Last Available: "2017-04"
+9429	spinning blinking alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	huge murderbot data core	0		Last Available: "2017-04"
-9432	galvanized huge purple alien medicine	0		Effect: "Sepia Tan", Effect Duration: 65, Last Available: "2017-04"
-9433	delicious enchanted alien salad	4	awesome	Effect: "Gemini Rising", Effect Duration: 20, Last Available: "2017-04"
+9432	galvanized purple huge alien medicine	0		Effect: "Sepia Tan", Effect Duration: 65, Last Available: "2017-04"
+9433	enchanted delicious alien salad	4	awesome	Effect: "Gemini Rising", Effect Duration: 20, Last Available: "2017-04"
 9434	bad weak alien booze	2	decent	Last Available: "2017-04"
 9435	narrow lightning-fast baleful alien mask of doom	0		Spell Damage: +25, Spooky Spell Damage: +50, Initiative: +40, Last Available: "2017-04"
 9436	friendly alien spear of the storm of the overflowing toilet	0		Maximum MP Percent: +40, Familiar Weight: +3, Stench Spell Damage: +50, Last Available: "2017-04"
@@ -9325,9 +9325,9 @@
 9453	zippy frightening murderbot mask of temperance	0		Spooky Damage: +5, Sleaze Resistance: +5, Initiative: +20, Avatar: "Murderbot", Last Available: "2017-04"
 9454	flattened Vulcanized murderbot spring injector	0		Effect: "Biologically Shocked", Effect Duration: 37, Last Available: "2017-04"
 9455	Newton's murderbot whip of the boozehound	0		Experience (Mysticality): +3, Booze Drop: +100, Last Available: "2017-04"
-9456	nasty personal trainer's murderbot plasma rifle	0		Experience Percent (Muscle): +10, Stench Damage: +5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	nasty personal trainer's murderbot plasma rifle	0		Experience Percent (Muscle): +10, Stench Damage: +5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	pulsating murderbot memory chip	0		Last Available: "2017-04"
-9458	squat wobbly space pirate treasure map	0		Last Available: "2017-04"
+9458	wobbly squat space pirate treasure map	0		Last Available: "2017-04"
 9459	huge Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
@@ -9355,20 +9355,20 @@
 9483	triple-boiled blue Daily Affirmation: Be a Mind Master	0		Effect: "All Is Forgiven", Effect Duration: 33, Last Available: "2017-05"
 9484	adjusted Daily Affirmation: Work For Hours a Week	0		Effect: "Some Cheese with Your Wine", Effect Duration: 51, Last Available: "2017-05"
 9485	electrified twirling Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Glo-Face", Effect Duration: 55, Last Available: "2017-05"
-9486	fancy moldy gray skewed Affirmation Cookie	3	crappy	Effect: "Pecan Pied Piper", Effect Duration: 15, Last Available: "2017-05"
+9486	fancy moldy skewed gray Affirmation Cookie	3	crappy	Effect: "Pecan Pied Piper", Effect Duration: 15, Last Available: "2017-05"
 9487	pulsating License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
-9490	enhanced diffused upside-down bouncing Threatening Missive	0		Effect: "Beastly Flavor", Effect Duration: 61
+9490	enhanced diffused bouncing upside-down Threatening Missive	0		Effect: "Beastly Flavor", Effect Duration: 61
 9491	mirror Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	foul-smelling Kremlin's Greatest Briefcase of chilblains of the glutton	0		Cold Damage: +25, Stench Damage: +10, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	drinkable blinking upside-down basic martini	3	good	Last Available: "2017-06"
+9493	foul-smelling Kremlin's Greatest Briefcase of chilblains of the glutton	0		Cold Damage: +25, Stench Damage: +10, Food Drop: +100, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9494	drinkable upside-down blinking basic martini	3	good	Last Available: "2017-06"
 9495	strong smooth huge improved martini	5	awesome	Last Available: "2017-06"
-9496	lousy extra-dry special blue splendid martini	5	decent	Effect: "Tapped In", Effect Duration: 30, Last Available: "2017-06"
+9496	special extra-dry lousy blue splendid martini	5	decent	Effect: "Tapped In", Effect Duration: 30, Last Available: "2017-06"
 9497	lime green exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
-9499	teal mirror tattoo gun	0		Last Available: "2017-06"
+9499	mirror teal tattoo gun	0		Last Available: "2017-06"
 9500	gun	0		Free Pull, Last Available: "2017-06"
 9501	gum	0		Free Pull, Last Available: "2017-06"
 9502	aromatic veiny plastic gundam of dire peril	0		Weapon Damage: +20, Maximum HP: +10, Stench Resistance: +1, Last Available: "2017-06"
@@ -9385,7 +9385,7 @@
 9513	huge Meteorite-Ade	0		Last Available: "2017-08"
 9514	normal skewed meteoreo	4	good	Last Available: "2017-08"
 9515	mediocre meadeorite	4	decent	Last Available: "2017-08"
-9516	narrow teal meteoroid	0		Last Available: "2017-08"
+9516	teal narrow meteoroid	0		Last Available: "2017-08"
 9517	blurry Temple Grandin's meteortarboard of the ox of the brute	0		Muscle: +20, Muscle Percent: +30, Familiar Weight: +7, Last Available: "2017-08"
 9518	zippy meteorite guard of the ox of the boozehound	0		Muscle: +20, Booze Drop: +100, Initiative: +20, Damage Reduction: 9, Last Available: "2017-08"
 9519	veiny meteorb of extreme caution	0		Maximum HP: +10, Monster Level: -25, Lantern Element: "Hot", Last Available: "2017-08"
@@ -9402,7 +9402,7 @@
 9530	wobbly shaking hardy rosy-cheeked supercool blessed rustproof +2 gray dragon scale mail	0		Moxie Percent: +20, Maximum HP Percent: +30, Maximum HP: +50, Last Available: "2023-09"
 9531	blurry pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	bouncing pony: Shutterfly	0		Last Available: "2017-09"
-9533	twirling blue pony: Pearjack	0		Last Available: "2017-09"
+9533	blue twirling pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
 9535	blinking pony: Rosey Cake	0		Last Available: "2017-09"
 9536	blinking pony: Spectrum Dash	0		Last Available: "2017-09"
@@ -9414,7 +9414,7 @@
 9542	narrow exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	smooth extra-dry DUFRESNE Suds	5	awesome	Last Available: "2017-09"
+9545	extra-dry smooth DUFRESNE Suds	5	awesome	Last Available: "2017-09"
 9546	jittery groovy mafia pinky ring of Flo-Jo	0		Moxie Percent: +10, Initiative: +100, Single Equip
 9547	bad olive flask of port	3	decent	
 9548	censurious chilly contract enforcement stick	0		Cold Damage: +5, Sleaze Resistance: +3
@@ -9422,7 +9422,7 @@
 9550	lousy watered-down squat jug of booze	2	decent	Last Available: "2017-10"
 9551	colloidal squat pair of candy glasses	0		Effect: "No Worries", Effect Duration: 13, Last Available: "2017-10"
 9552	concentrated irradiated temporary X tattoos	0		Effect: "Rotten Memories", Effect Duration: 46, Last Available: "2017-10"
-9553	boiled spinning wobbly glyph of athleticism	1		Last Available: "2017-10"
+9553	boiled wobbly spinning glyph of athleticism	1		Last Available: "2017-10"
 9554	pair of scissors	0		Last Available: "2017-10"
 9555	deionized moist tumbling new habit	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 31, Last Available: "2017-10"
 9556	tumbling purple bridge truss	0		Last Available: "2017-10"
@@ -9448,11 +9448,11 @@
 9576	purple upside-down up-at-dawn mafia organizer badge	0		Adventures: +5, Single Equip
 9577	mafia filofax	0		
 9578	transparent nog	1	decent	Last Available: "2017-12"
-9579	decent snack-sized yellow unfinished fruitcake	2	good	Last Available: "2017-12"
+9579	snack-sized decent yellow unfinished fruitcake	2	good	Last Available: "2017-12"
 9580	aerosolized unsweetened and cracker	0		Effect: "The Power of Positive Thinking", Effect Duration: 66, Last Available: "2017-12"
-9581	watered-down lousy upside-down neg grog	2	decent	Last Available: "2017-12"
+9581	lousy watered-down upside-down neg grog	2	decent	Last Available: "2017-12"
 9582	spoiled half double fruitcake	3	crappy	Last Available: "2017-12"
-9583	enchanted small adequate hushed puppy	2	good	Effect: "Took Eleven", Effect Duration: 30, Last Available: "2017-12"
+9583	enchanted adequate small hushed puppy	2	good	Effect: "Took Eleven", Effect Duration: 30, Last Available: "2017-12"
 9584	tasty tiny muffled muffuletta	1	awesome	Last Available: "2017-12"
 9585	stale fuchsia shushed potatoes	3	decent	Last Available: "2017-12"
 9586	deadly plastic mime functionary	0		Weapon Damage: +5, Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	vacuum-sealed corrupted wishbone	0		Effect: "Disdain of She-Who-Was", Effect Duration: 67, Last Available: "2017-11"
 9595	mediocre jittery Racisto Ruidoso	4	decent	Last Available: "2017-11"
 9596	olive earthenware muffin tin	0		
-9597	decent small bran muffin	2	good	
+9597	small decent bran muffin	2	good	
 9598	spoiled blueberry muffin	3	crappy	
 9599	huge silent A	0		Last Available: "2017-12"
 9600	bouncing silent B	0		Last Available: "2017-12"
@@ -9475,7 +9475,7 @@
 9603	gray silent E	0		Last Available: "2017-12"
 9604	jittery silent F	0		Last Available: "2017-12"
 9605	silent G	0		Last Available: "2017-12"
-9606	shaking green silent H	0		Last Available: "2017-12"
+9606	green shaking silent H	0		Last Available: "2017-12"
 9607	ghostly silent I	0		Last Available: "2017-12"
 9608	silent J	0		Last Available: "2017-12"
 9609	gray silent K	0		Last Available: "2017-12"
@@ -9489,7 +9489,7 @@
 9617	silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
-9620	narrow bouncing silent V	0		Last Available: "2017-12"
+9620	bouncing narrow silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
 9622	silent X	0		Last Available: "2017-12"
 9623	silent Y	0		Last Available: "2017-12"
@@ -9517,13 +9517,13 @@
 9645	blurry The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	shaking mime eraser	0		Last Available: "2017-12"
-9648	triple-distilled smooth executive mime flask	8	awesome	Last Available: "2017-12"
+9648	smooth triple-distilled executive mime flask	8	awesome	Last Available: "2017-12"
 9649	yummy nega-mushroom	4	awesome	Last Available: "2017-12"
 9650	artisanal nega-mushroom wine	4	EPIC	Last Available: "2017-12"
 9651	dry upside-down Cheer-Up soda	0		Effect: "Knightlife", Effect Duration: 15, Last Available: "2017-12"
-9652	spoiled tiny red mime army rations	1	crappy	Last Available: "2017-12"
+9652	tiny spoiled red mime army rations	1	crappy	Last Available: "2017-12"
 9653	bad boozy tumbling mime army wine	5	decent	Last Available: "2017-12"
-9654	dried skewed tumbling mime army superserum	1		Effect: "Flashing Eyes", Effect Duration: 25, Last Available: "2017-12"
+9654	dried tumbling skewed mime army superserum	1		Effect: "Flashing Eyes", Effect Duration: 25, Last Available: "2017-12"
 9655	warmed irradiated yellow mime army camouflage kit	0		Effect: "Pie in the Sky", Effect Duration: 28, Last Available: "2017-12"
 9656	dog trainer's smooth miming beret	0		Moxie: +15, Experience (familiar): +1, Last Available: "2017-12"
 9657	veiny thinker's miming shirt	0		Mysticality: +10, Maximum HP: +10, Last Available: "2017-12"
@@ -9534,7 +9534,7 @@
 9662	wobbly donated booze	0		
 9663	mirror donated food	0		
 9664	donated candy	0		
-9665	tarnished wet upside-down narrow digital honeypot	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 62, Last Available: "2025-12"
+9665	tarnished wet narrow upside-down digital honeypot	0		Effect: "You Can Really Taste the Dormouse", Effect Duration: 62, Last Available: "2025-12"
 9666	pulsating mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
 9667	shaking mime army insignia (infantry) of bravery	0		Spooky Resistance: +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
 9668	slick mime army insignia (intelligence)	0		Moxie: +10, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
@@ -9565,7 +9565,7 @@
 9693	razor-sharp arcane researcher's tinsel tights	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +25, Last Available: "2018-01"
 9694	executive censurious wad of used tape of the businessman	0		Sleaze Resistance: +3, Meat Drop: 90, Last Available: "2018-01"
 9695	maroon avaricious vibrating silent nightlight of the detective of the early riser	0		Maximum MP Percent: +10, Item Drop: +20, Meat Drop: +30, Adventures: +7
-9696	extra-polymerized blurry narrow sweetened reindeer fat	0		Effect: "Always be Collecting", Effect Duration: 34
+9696	extra-polymerized narrow blurry sweetened reindeer fat	0		Effect: "Always be Collecting", Effect Duration: 34
 9697	flattened energized narrow Good 'n' Quiet	0		Effect: "Broken Fast", Effect Duration: 26
 9698	Vulcanized moist blurry hot button candy	0		Effect: "Superioreo", Effect Duration: 21
 9699	huge red gravedigger's baleful makeshift garbage shirt of the sewer	0		Spell Damage: +25, Stench Damage: +25, Spooky Damage: +10, Last Available: "2018-01"
@@ -9608,7 +9608,7 @@
 9740	Mysterious Green Box	0		Last Available: "2018-02"
 9741	Mysterious Blue Box	0		Last Available: "2018-02"
 9742	lime green Mysterious Black Box	0		Last Available: "2018-02"
-9743	Vulcanized altered gray blinking rainbow jellybean	0		Effect: "Smoky Third Eye", Effect Duration: 20
+9743	Vulcanized altered blinking gray rainbow jellybean	0		Effect: "Smoky Third Eye", Effect Duration: 20
 9744	corrupted jittery mystery lollipop	0		Effect: "Sticky Hands", Effect Duration: 51
 9745	Love Potion #0	0		Effect: "Tainted Love Potion", Effect Duration: 20
 9746	ionized moist triple-dry blinking rhinestone	0		Effect: "Stop and Smell the Fudge", Effect Duration: 51
@@ -9650,7 +9650,7 @@
 9782	Ruffalo	0		Last Available: "2018-03"
 9783	Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
-9785	upside-down blue Straypler	0		Last Available: "2018-03"
+9785	blue upside-down Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	upside-down Ched	0		Last Available: "2018-03"
@@ -9696,7 +9696,7 @@
 9828	denatured lime green skewed magnificent oyster egg	1		Effect: "Billiards Belligerence", Effect Duration: 5
 9829	dried narrow ghostly brilliant oyster egg	1		
 9830	dehydrated lime green glistening oyster egg	1		
-9831	pickled twirling purple narrow scintillating oyster egg	1		Effect: "Chorale of Companionship", Effect Duration: 25
+9831	pickled purple twirling narrow scintillating oyster egg	1		Effect: "Chorale of Companionship", Effect Duration: 25
 9832	vaporized ghostly pearlescent oyster egg	1		
 9833	altered lustrous oyster egg	1		
 9834	altered wobbly gleaming oyster egg	1		Effect: "License to Punch", Effect Duration: 30
@@ -9743,7 +9743,7 @@
 9875	map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	upside-down map to the Sprawling Cemetery	0		Last Available: "2018-04"
-9878	delicious small denastified haunch	2	awesome	Last Available: "2018-04"
+9878	small delicious denastified haunch	2	awesome	Last Available: "2018-04"
 9879	hand-crafted extra-dry bad rum and good cola	5	EPIC	Last Available: "2018-04"
 9880	pressed wet skewed Potion of Heroism	0		Effect: "Kindly Resolve", Effect Duration: 59, Last Available: "2018-04"
 9881	huge family-friendly flame-wreathed leggings of the Spider Queen of terror	0		Hot Spell Damage: +10, Spooky Spell Damage: +10, Sleaze Resistance: +1, Last Available: "2018-04"
@@ -9762,17 +9762,17 @@
 9894	horrifying foul-smelling Van der Graaf hale Staff of Kitchen Royalty of incineration	0		Maximum HP: +20, Hot Spell Damage: +50, Stench Damage: +10, Spooky Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-04"
 9895	charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
-9897	skewed spinning notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
+9897	spinning skewed notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	high-proof artisanal two meat muck	10	EPIC	
-9899	miniature yummy huge fuchsia chocolate Ogre Chieftain	2	awesome	
+9899	yummy miniature fuchsia huge chocolate Ogre Chieftain	2	awesome	
 9900	bland twirling chocolate &quot;Phoenix&quot;	4	decent	
 9901	small stale chocolate Spider Queen	2	decent	
-9902	triple-distilled special mediocre spinning hipster cocktail	6	decent	Effect: "Dreadful Smell", Effect Duration: 40
-9903	lime green God Lobster's Scepter	0		Equips On: "God Lobster", Familiar Effect: "small fairy/lep", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Equips On: "God Lobster", Familiar Effect: "sombrero", Last Available: "2018-05"
-9905	mirror God Lobster's Rod	0		Equips On: "God Lobster", Familiar Effect: "whelp", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Equips On: "God Lobster", Familiar Effect: "block", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Equips On: "God Lobster", Familiar Effect: "fairy", Last Available: "2018-05"
+9902	mediocre special triple-distilled spinning hipster cocktail	6	decent	Effect: "Dreadful Smell", Effect Duration: 40
+9903	lime green God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	mirror God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
@@ -9813,7 +9813,7 @@
 9945	lime green Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	purple gas can	0		Last Available: "2018-09"
-9948	drinkable weak Middle of the Road&trade; brand whiskey	2	good	Last Available: "2018-09"
+9948	weak drinkable Middle of the Road&trade; brand whiskey	2	good	Last Available: "2018-09"
 9949	olive neverending wallet chain	0		Last Available: "2018-09"
 9950	studded pentagram bandana of the blizzard	0		Damage Absorption: +80, Cold Spell Damage: +25, Last Available: "2018-09"
 9951	huge personal trainer's skull ring	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2018-09"
@@ -9821,9 +9821,9 @@
 9953	flavorless spinning PB&J with the crusts cut off	3	decent	Last Available: "2018-09"
 9954	energetic hardy dorky glasses	0		Maximum HP: +50, Maximum MP Percent: +20, Single Equip, Last Available: "2018-09"
 9955	spinning resourceful ponytail clip of chilblains	0		Maximum MP: +50, Cold Damage: +25, Last Available: "2018-09"
-9956	paint palette	0		Item Drop: +5, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	paint palette	0		Item Drop: +5, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
-9958	pickled olive upside-down Purple Beast energy drink	1		Last Available: "2018-09"
+9958	pickled upside-down olive Purple Beast energy drink	1		Last Available: "2018-09"
 9959	yellow prompt cosmetic football	0		Adventures: +3, Last Available: "2018-09"
 9960	shoe ad T-shirt of the empath of temperance	0		Familiar Weight: +5, Sleaze Resistance: +5, Last Available: "2018-09"
 9961	hardened pump-up high-tops	0		Damage Reduction: 3, Single Equip, Last Available: "2018-09"
@@ -9839,7 +9839,7 @@
 9972	supercharged intimidating chainsaw of doom	0		Maximum MP Percent: +30, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-09"
 9973	tolerable party beer bomb	3	good	Last Available: "2018-09"
 9974	rotten fuchsia sweet party mix	3	crappy	Last Available: "2018-09"
-9975	distilled upside-down wobbly pulsating party balloon	1		Effect: "All Fired Up", Effect Duration: 25, Last Available: "2018-09"
+9975	distilled pulsating wobbly upside-down party balloon	1		Effect: "All Fired Up", Effect Duration: 25, Last Available: "2018-09"
 9976	squat stanky strapping party pants	0		Muscle: +5, Stench Spell Damage: +25, Last Available: "2018-09"
 9977	ghostly Usain Bolt's scorching party whip of temperance	0		Hot Damage: +25, Sleaze Resistance: +5, Initiative: +80, Last Available: "2018-09"
 9978	Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	moldy wobbly party platter for one	3	crappy	Last Available: "2018-09"
 9981	distilled yellow Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	Jack Frost's party crasher of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9983	Jack Frost's party crasher of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	purple party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	red latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	Temple Grandin's &quot;I Voted!&quot; sticker	0		Familiar Weight: +7, Lasts Until Rollover, Last Available: "2018-11"
@@ -9873,21 +9873,21 @@
 10007	huge bouncing Jeselnik's foul-smelling ruddy mutant arm	0		Maximum HP Percent: +40, Stench Damage: +10, Sleaze Damage: +25, Last Available: "2018-11"
 10008	clever dance instructor's slick mutant legs	0		Moxie: +10, Experience Percent (Moxie): +10, Maximum MP: +20, Last Available: "2018-11"
 10009	manspreader's wicked groovy mutant crown	0		Moxie Percent: +10, Spell Damage: +5, Monster Level: +10, Last Available: "2018-11"
-10010	bland diet ghostly ectoplasm	1	decent	Last Available: "2018-11"
+10010	diet bland ghostly ectoplasm	1	decent	Last Available: "2018-11"
 10011	bland small	2	decent	Last Available: "2018-11"
-10012	triple-distilled smooth cyan blinking bottle of vodka	9	awesome	Last Available: "2018-11"
+10012	smooth triple-distilled cyan blinking bottle of vodka	9	awesome	Last Available: "2018-11"
 10013	stale pizza	4	decent	Last Available: "2018-11"
 10014	drinkable martini	4	good	Last Available: "2018-11"
-10015	massive bland cherry pie	10	decent	Last Available: "2018-11"
-10016	acceptable irresponsibly strong eggnog	6	good	Last Available: "2018-11"
+10015	bland massive cherry pie	10	decent	Last Available: "2018-11"
+10016	irresponsibly strong acceptable eggnog	6	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	rotten Hell ramen	3	crappy	Last Available: "2018-11"
 10019	hand-crafted gimlet	3	EPIC	Last Available: "2018-11"
-10020	watered-down perfectly mixed twice-haunted screwdriver	2	EPIC	Last Available: "2018-11"
-10021	normal miniature blurry ghostly candy cane	2	good	Last Available: "2018-12"
-10022	tolerable twirling upside-down runny fermented egg	3	good	Last Available: "2018-12"
-10023	toothsome miniature special upside-down tumbling oldcake	2	awesome	Effect: "Sappy Blood", Effect Duration: 30, Last Available: "2018-12"
-10024	miniature rotten blurry red traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
+10020	perfectly mixed watered-down twice-haunted screwdriver	2	EPIC	Last Available: "2018-11"
+10021	normal miniature ghostly blurry candy cane	2	good	Last Available: "2018-12"
+10022	tolerable upside-down twirling runny fermented egg	3	good	Last Available: "2018-12"
+10023	special toothsome miniature upside-down tumbling oldcake	2	awesome	Effect: "Sappy Blood", Effect Duration: 30, Last Available: "2018-12"
+10024	miniature rotten red blurry traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
 10025	Sinatra's plastic wild beaver	0		Experience (Moxie): +5, Last Available: "2018-12"
 10026	Newton's plastic reindeer	0		Experience (Mysticality): +3, Last Available: "2018-12"
 10027	yellow plastic Caf&eacute; Elf of the cougar	0		Moxie: +20, Last Available: "2018-12"
@@ -9900,20 +9900,20 @@
 10034	thick walrus blubber	0		Last Available: "2018-12"
 10035	censurious Annie Oakley's Staff of Frozen Lard of chilblains of the detective	0		Critical Hit Percent: +20, Cold Damage: +25, Sleaze Resistance: +3, Item Drop: +20, Last Available: "2018-12"
 10036	blue bomb	0		Last Available: "2018-12"
-10037	spinning upside-down plastic bazooka	0		Last Available: "2018-12"
+10037	upside-down spinning plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	miniature normal grilled mooseflank	2	good	Last Available: "2018-12"
-10040	moldy thick moosemeat pie	5	crappy	Last Available: "2018-12"
+10039	normal miniature grilled mooseflank	2	good	Last Available: "2018-12"
+10040	thick moldy moosemeat pie	5	crappy	Last Available: "2018-12"
 10041	greasy balanced antler	0		Sleaze Spell Damage: +10, Last Available: "2018-12"
 10042	avaricious dam	0		Meat Drop: +30, Damage Reduction: 9, Last Available: "2018-12"
-10043	special perfectly mixed beavermouth	3	EPIC	Effect: "Mo' Hobo", Effect Duration: 10, Last Available: "2018-12"
+10043	perfectly mixed special beavermouth	3	EPIC	Effect: "Mo' Hobo", Effect Duration: 10, Last Available: "2018-12"
 10044	weak tolerable twirling beaver punch (papaya)	2	good	Last Available: "2018-12"
-10045	perfectly mixed weak beaver punch (peach)	2	EPIC	Last Available: "2018-12"
+10045	weak perfectly mixed beaver punch (peach)	2	EPIC	Last Available: "2018-12"
 10046	practically non-alcoholic lousy mirror beaver punch (cherry)	1	decent	Last Available: "2018-12"
 10047	Annie Oakley's extremely unsafe Canadian lantern	0		Weapon Damage Percent: +100, Critical Hit Percent: +20, Last Available: "2018-12"
 10048	Oprah's muskox-skin cap	0		Maximum MP Percent: +50, Last Available: "2018-12"
 10049	tumbling Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	decent huge glass of raw eggs	6	good	Last Available: "2018-12"
+10050	huge decent glass of raw eggs	6	good	Last Available: "2018-12"
 10051	aged punch-drunk punch	3	awesome	Last Available: "2018-12"
 10052	diluted lime green body spradium	1		Effect: "Pretending to Pretend", Effect Duration: 50, Last Available: "2018-12"
 10053	foul-smelling bauxite beret	0		Stench Damage: +10, Last Available: "2018-12"
@@ -9926,7 +9926,7 @@
 10060	bland sausage	3	decent	Last Available: "2019-01"
 10061	executive red-hot sausage fork of the businessman	0		Meat Drop: 90, Last Available: "2019-01"
 10062	bag of sausage links	0		Last Available: "2019-01"
-10063	wobbly upside-down sausage golem	0		Last Available: "2019-01"
+10063	upside-down wobbly sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	aged beer	3	awesome	Last Available: "2018-12"
@@ -9959,22 +9959,22 @@
 10093	fireproof marble mignonette bowl of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +3, Last Available: "2019-12"
 10094	occult marble medallion of Leguizamo	0		Spell Damage Percent: +25, Monster Level: +20, Single Equip, Last Available: "2019-12"
 10095	dog trainer's hale marble mariachi hat	0		Maximum HP: +20, Experience (familiar): +1, Last Available: "2019-12"
-10096	denatured wobbly red marble molecules	1		Last Available: "2019-12"
+10096	denatured red wobbly marble molecules	1		Last Available: "2019-12"
 10097	enhanced Mallomarbles	0		Effect: "Witch's Brood", Effect Duration: 11
-10098	upside-down shaking miser's frosty punching bag	0		Cold Spell Damage: +10, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	fuchsia double-paned dog trainer's pith helmet	0		Experience (familiar): +1, Cold Resistance: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	poncho of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	arcane researcher's pendant of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	twirling sharpshooter's palazzos of chilblains	0		Critical Hit Percent: +10, Cold Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	wobbly avaricious pseudoaccordion of extreme caution	0		Monster Level: -25, Meat Drop: +30, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	upside-down shaking miser's frosty punching bag	0		Cold Spell Damage: +10, Meat Drop: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	fuchsia double-paned dog trainer's pith helmet	0		Experience (familiar): +1, Cold Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	poncho of vim and vigor of Calamity Jane	0		Maximum HP Percent: +50, Critical Hit Percent: +15, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	arcane researcher's pendant of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	twirling sharpshooter's palazzos of chilblains	0		Critical Hit Percent: +10, Cold Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	wobbly avaricious pseudoaccordion of extreme caution	0		Monster Level: -25, Meat Drop: +30, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	distilled pieces	1		Last Available: "2020-12"
 10105	tarnished Para-Pop	0		Effect: "Patience of the Tortoise", Effect Duration: 49
-10106	reassuring supercool terra cotta truss	0		Moxie Percent: +20, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	baleful terra cotta trousers of temperance	0		Spell Damage: +25, Sleaze Resistance: +5, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	flame-wreathed terra cotta tongs of horror	0		Hot Spell Damage: +10, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	auspicious terra cotta train of vim and vigor	0		Maximum HP Percent: +50, Item Drop: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	spinning rock-hard terra cotta tie tack of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	Jack Frost's Annie Oakley's terra cotta tambourine	0		Critical Hit Percent: +20, Cold Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	reassuring supercool terra cotta truss	0		Moxie Percent: +20, Spooky Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	baleful terra cotta trousers of temperance	0		Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	flame-wreathed terra cotta tongs of horror	0		Hot Spell Damage: +10, Spooky Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	auspicious terra cotta train of vim and vigor	0		Maximum HP Percent: +50, Item Drop: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	spinning rock-hard terra cotta tie tack of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	Jack Frost's Annie Oakley's terra cotta tambourine	0		Critical Hit Percent: +20, Cold Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	dried narrow terra cotta tidbits	1		Last Available: "2020-12"
 10113	ionized terra panna cotta	0		Effect: "Disdain of She-Who-Was", Effect Duration: 69
 10114	chaotic velour voulge of the cheetah	0		Spell Critical Percent: +10, Initiative: +60, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	MacGyver's energetic glass serape	0		Maximum MP Percent: +20, Maximum MP: +100, Last Available: "2021-12"
 10128	diluted glass shards	1		Effect: "Fangs and Pangs", Effect Duration: 40, Last Available: "2021-12"
 10129	extra-vacuum-sealed hard candy	0		Effect: "Abominably Slippery", Effect Duration: 67
-10130	wobbly censurious loofah lumberjack's hat of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +3, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	ghostly chilly Sinatra's loofah lei	0		Experience (Moxie): +5, Cold Damage: +5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	Annie Oakley's wholesome loofah lederhosen	0		Maximum HP Percent: +10, Critical Hit Percent: +20, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	smartaleck's brainy loofah ladle	0		Mysticality: +5, Moxie Percent: +30, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	tumbling razor-sharp wizardly loofah legwarmers	0		Mysticality: +25, Weapon Damage Percent: +25, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	lightning-fast therapeutic loofah lavalier	0		Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
-10136	altered maroon narrow shaking loofah lumps	1		Last Available: "2022-12"
+10130	wobbly censurious loofah lumberjack's hat of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	ghostly chilly Sinatra's loofah lei	0		Experience (Moxie): +5, Cold Damage: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	Annie Oakley's wholesome loofah lederhosen	0		Maximum HP Percent: +10, Critical Hit Percent: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	smartaleck's brainy loofah ladle	0		Mysticality: +5, Moxie Percent: +30, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	tumbling razor-sharp wizardly loofah legwarmers	0		Mysticality: +25, Weapon Damage Percent: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	lightning-fast therapeutic loofah lavalier	0		Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10136	altered shaking maroon narrow loofah lumps	1		Last Available: "2022-12"
 10137	improved upside-down chocolate-covered loofah	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 59
-10138	green greasy weightlifter's flagstone flag	0		Muscle: +15, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	auspicious flagstone flail of the wise owl	0		Mysticality: +20, Item Drop: +10, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	auspicious knitted flagstone flip-flops	0		Cold Resistance: +3, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	aromatic clever flagstone fez	0		Maximum MP: +20, Stench Resistance: +1, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	auspicious flagstone fleece of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	blue flagstone fringe of wisdom of horror	0		Mysticality: +15, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	green greasy weightlifter's flagstone flag	0		Muscle: +15, Sleaze Spell Damage: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	auspicious flagstone flail of the wise owl	0		Mysticality: +20, Item Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	auspicious knitted flagstone flip-flops	0		Cold Resistance: +3, Item Drop: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	aromatic clever flagstone fez	0		Maximum MP: +20, Stench Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	auspicious flagstone fleece of incineration	0		Hot Spell Damage: +50, Item Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	blue flagstone fringe of wisdom of horror	0		Mysticality: +15, Spooky Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	mixed fuchsia flagstone flagments	1		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 30, Last Available: "2022-12"
 10145	super-adjusted liquefied jittery Flag by the Foot&trade;	0		Effect: "Can Has Cyborger", Effect Duration: 61
 10146	olive elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10023,25 +10023,25 @@
 10157	therapeutic discarded bowtie of courage	0		Spooky Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2019-12"
 10158	aged martiny	3	awesome	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
-10160	non-frozen magnetized mirror narrow licorice snake	0		Effect: "Extra-Thick Blood", Effect Duration: 34
+10160	non-frozen magnetized narrow mirror licorice snake	0		Effect: "Extra-Thick Blood", Effect Duration: 34
 10161	dry galvanized virgin jello shot	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 43
 10162	energized adjusted mutated candy lump	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 30
 10163	polarized frozen magnetized government-issued candy	0		Effect: "Horrid, Torrid", Effect Duration: 16
 10164	ionized Pneumo bar	0		Effect: "Fudgehound", Effect Duration: 50
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	rock-hard wizardly Lil' Doctor&trade; bag	0		Mysticality: +25, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	rock-hard wizardly Lil' Doctor&trade; bag	0		Mysticality: +25, Damage Reduction: 5, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	wobbly blood bag	0		
-10169	decent fancy squat bloodstick	4	good	Effect: "Memory of Smarts", Effect Duration: 30
-10170	special drinkable bottle of Sanguiovese	3	good	Effect: "Black Lung", Effect Duration: 40
+10169	fancy decent squat bloodstick	4	good	Effect: "Memory of Smarts", Effect Duration: 30
+10170	drinkable special bottle of Sanguiovese	3	good	Effect: "Black Lung", Effect Duration: 40
 10171	moldy actual blood sausage	4	crappy	
 10172	smooth practically non-alcoholic mulled blood	1	awesome	
 10173	flavorless blood snowcone	4	decent	
 10174	weak tolerable Red Russian	2	good	
-10175	small adequate blood roll-up	2	good	
-10176	irresponsibly strong hand-crafted upside-down bottle of blood	7	EPIC	
+10175	adequate small blood roll-up	2	good	
+10176	hand-crafted irresponsibly strong upside-down bottle of blood	7	EPIC	
 10177	super-sized flavorless blood-soaked sponge cake	5	decent	
 10178	artisanal squat vampagne	3	super EPIC	
-10179	diet spoiled blue plain snowcone	1	crappy	
+10179	spoiled diet blue plain snowcone	1	crappy	
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	squat money bag	0		
@@ -10063,7 +10063,7 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	half-sized normal narrow crabsicle	2	good	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	hand-crafted watered-down wobbly bottle of dark rhum	2	EPIC	Last Available: "2019-04"
+10201	watered-down hand-crafted wobbly bottle of dark rhum	2	EPIC	Last Available: "2019-04"
 10202	bad irresponsibly strong bottle of extra-dark rhum	10	decent	Last Available: "2019-04"
 10203	practically non-alcoholic lousy bottle of super-extra-dark rhum	1	decent	Last Available: "2019-04"
 10204	chilled shaking pirate shaving cream	0		Effect: "Flambé-a-thon", Effect Duration: 63, Last Available: "2019-04"
@@ -10074,14 +10074,14 @@
 10209	lime green windicle	0		Last Available: "2019-04"
 10210	jittery Temple Grandin's pirate radio ring of the storm	0		Maximum MP Percent: +40, Familiar Weight: +7, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
-10212	stale tiny pineapple slab	1	decent	Last Available: "2019-04"
+10212	tiny stale pineapple slab	1	decent	Last Available: "2019-04"
 10213	spoiled hibiscus petal	4	crappy	Last Available: "2019-04"
 10214	improved squat jittery huge mint leaf	0		Effect: "Human-Constellation Hybrid", Effect Duration: 23, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	dehydrated ice molecule	1		Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	Red Roger's right hand	0		Last Available: "2019-04"
-10219	squat twirling olive Red Roger's left hand	0		Last Available: "2019-04"
+10219	squat olive twirling Red Roger's left hand	0		Last Available: "2019-04"
 10220	red Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
@@ -10099,12 +10099,12 @@
 10234	practically non-alcoholic perfectly mixed Island Hurricane	1	super ultra mega turbo EPIC	Last Available: "2019-04"
 10235	delicious spirit-forward Skull Punch	5	awesome	Last Available: "2019-04"
 10236	hand-crafted Electric Punch	4	EPIC	Last Available: "2019-04"
-10237	fancy tolerable watered-down Smuggler's Punch	2	good	Effect: "Stimulated Body", Effect Duration: 20, Last Available: "2019-04"
+10237	fancy watered-down tolerable Smuggler's Punch	2	good	Effect: "Stimulated Body", Effect Duration: 20, Last Available: "2019-04"
 10238	smooth Scorpion Bowl	3	awesome	Last Available: "2019-04"
-10239	strong drinkable Turtle Bowl	5	good	Last Available: "2019-04"
+10239	drinkable strong Turtle Bowl	5	good	Last Available: "2019-04"
 10240	artisanal Cobra Bowl	4	EPIC	Last Available: "2019-04"
 10241	shaking vampyric cloake pattern	0		Free Pull
-10242	purple lard-coated Annie Oakley's rosy-cheeked stiffened baleful vampyric cloake	0		Spell Damage: +25, Damage Reduction: 1, Maximum HP Percent: +30, Critical Hit Percent: +20, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	purple lard-coated Annie Oakley's rosy-cheeked stiffened baleful vampyric cloake	0		Spell Damage: +25, Damage Reduction: 1, Maximum HP Percent: +30, Critical Hit Percent: +20, Sleaze Spell Damage: +25, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	moist triple-frozen mirror gray one piece of bubble gum	0		Effect: "Chilblains of the Corn", Effect Duration: 56
 10245	arcanoferric housing	0		
@@ -10113,22 +10113,22 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	pulsating Fourth of May Cosplay Saber kit	0		Free Pull
-10251	cyan greedy hale Fourth of May Cosplay Saber of extreme caution	0		Maximum HP: +20, Monster Level: -25, Meat Drop: +20, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	cyan greedy hale Fourth of May Cosplay Saber of extreme caution	0		Maximum HP: +20, Monster Level: -25, Meat Drop: +20, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	yellow prompt aromatic Jeselnik's Van der Graaf vibrating wholesome shellacked banded educational wizardly hewn moon-rune spoon of courage	0		Mysticality: +25, Experience: +1, Damage Absorption: +100, Damage Reduction: 7, Maximum HP Percent: +10, Maximum MP Percent: +10, Sleaze Damage: +25, Spooky Resistance: +3, Stench Resistance: +1, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	yellow prompt aromatic Jeselnik's Van der Graaf vibrating wholesome shellacked banded educational wizardly hewn moon-rune spoon of courage	0		Mysticality: +25, Experience: +1, Damage Absorption: +100, Damage Reduction: 7, Maximum HP Percent: +10, Maximum MP Percent: +10, Sleaze Damage: +25, Spooky Resistance: +3, Stench Resistance: +1, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	mirror cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	ruddy educational Beach Comb of Leguizamo	0		Experience: +1, Maximum HP Percent: +40, Monster Level: +20, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	ruddy educational Beach Comb of Leguizamo	0		Experience: +1, Maximum HP Percent: +40, Monster Level: +20, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	blurry ghostly grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	ghostly pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
 10263	squat empty hourglass	0		Last Available: "2019-07"
-10264	skewed mirror hourglass	0		Last Available: "2019-07"
+10264	mirror skewed hourglass	0		Last Available: "2019-07"
 10265	red etched hourglass	0		Last Available: "2019-07"
-10266	enhanced moist mirror jittery magenta seashell	0		Effect: "Heart of Yellow", Effect Duration: 13, Last Available: "2019-07"
+10266	enhanced moist jittery mirror magenta seashell	0		Effect: "Heart of Yellow", Effect Duration: 13, Last Available: "2019-07"
 10267	aerosolized cyan seashell	0		Effect: "Nightlit", Effect Duration: 33, Last Available: "2019-07"
 10268	warmed electrified green gray seashell	0		Effect: "Saucefingers", Effect Duration: 42, Last Available: "2019-07"
 10269	double-unsweetened quantum seashell	0		Effect: "Can't Be a Chooser", Effect Duration: 49, Last Available: "2019-07"
@@ -10166,14 +10166,14 @@
 10301	narrow flame-wreathed ruddy Socratic whittled fox figurine	0		Experience (Mysticality): +1, Maximum HP Percent: +40, Hot Spell Damage: +10, Single Equip, Last Available: "2019-08"
 10302	flame-wreathed Fonzie's Newton's whittled walking stick	0		Experience (Mysticality): +3, Experience (Moxie): +1, Hot Spell Damage: +10, Item Drop: +5, Last Available: "2019-08"
 10303	tasty campfire hot dog	3	awesome	Last Available: "2019-08"
-10304	yummy tiny enchanted campfire baked potato	1	awesome	Effect: "Worth Your Salt", Effect Duration: 45, Last Available: "2019-08"
+10304	enchanted tiny yummy campfire baked potato	1	awesome	Effect: "Worth Your Salt", Effect Duration: 45, Last Available: "2019-08"
 10305	yummy campfire s'more	4	awesome	Last Available: "2019-08"
 10306	normal blue campfire beans	4	good	Last Available: "2019-08"
 10307	bland snack-sized campfire stew	2	decent	Last Available: "2019-08"
 10308	campfire coffee	1	crappy	Last Available: "2019-08"
 10309	altered diffused irradiated leftover chocolate bar	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 28
 10310	rare Meat isotope	0		
-10311	cyan bouncing burnt stick	0		Last Available: "2019-08"
+10311	bouncing cyan burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
 10313	gray campfire smoke	0		
 10314	Murgatroyd diode	0		
@@ -10182,7 +10182,7 @@
 10317	signal jammer	0		Single Equip
 10318	ghostly low-pressure oxygen tank	0		Single Equip
 10319	Thwaitgold bombardier beetle statuette	0		
-10320	tiny toothsome space chowder	1	awesome	
+10320	toothsome tiny space chowder	1	awesome	
 10321	practically non-alcoholic tolerable gray space wine	1	good	
 10322	upside-down The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
@@ -10194,7 +10194,7 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	decent bu&ntilde;uelos Jaliscos	4	good	Last Available: "2019-12"
-10338	massive flavorless huge blurry flan del mar	7	decent	Last Available: "2019-12"
+10338	flavorless massive huge blurry flan del mar	7	decent	Last Available: "2019-12"
 10339	low-calorie adequate Baja sopapilla	1	good	Last Available: "2019-12"
 10340	gravedigger's plastic Mer-kin baker	0		Spooky Damage: +10, Last Available: "2019-12"
 10341	lard-coated plastic sea elf	0		Sleaze Spell Damage: +25, Last Available: "2019-12"
@@ -10202,10 +10202,10 @@
 10343	twirling huge Rosewater's plastic dolphin &quot;orphan&quot;	0		Mysticality Percent: +30, Single Equip, Last Available: "2019-12"
 10344	mirror boxer's plastic Dolph Bossin	0		Muscle Percent: +10, Last Available: "2019-12"
 10345	gray red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
-10346	enchanted normal low-calorie spinning mana-coated yams	1	good	Effect: "Squatting and Thrusting", Effect Duration: 15, Last Available: "2019-11"
-10347	special delicious miniature mana-basted tofurkey leg	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 15, Last Available: "2019-11"
-10348	tiny enchanted rotten mana-fortified cranberry sauce	1	crappy	Effect: "Abyssal Blood", Effect Duration: 35, Last Available: "2019-11"
-10349	fancy decent miniature mana-stuffed herbal stuffing	2	good	Effect: "La Bamba", Effect Duration: 30, Last Available: "2019-11"
+10346	enchanted low-calorie normal spinning mana-coated yams	1	good	Effect: "Squatting and Thrusting", Effect Duration: 15, Last Available: "2019-11"
+10347	delicious special miniature mana-basted tofurkey leg	2	awesome	Effect: "Bells in the Batfry", Effect Duration: 15, Last Available: "2019-11"
+10348	enchanted rotten tiny mana-fortified cranberry sauce	1	crappy	Effect: "Abyssal Blood", Effect Duration: 35, Last Available: "2019-11"
+10349	fancy miniature decent mana-stuffed herbal stuffing	2	good	Effect: "La Bamba", Effect Duration: 30, Last Available: "2019-11"
 10350	twirling human musk	0		Last Available: "2019-12"
 10351	energized patch of extra-warm fur	0		Effect: "Burning Hands", Effect Duration: 19, Last Available: "2019-12"
 10352	dehydrated upside-down industrial lubricant	1		Last Available: "2019-12"
@@ -10242,8 +10242,8 @@
 10383	soggy gingerbread chunk	0		Last Available: "2019-12"
 10384	non-polarized tumbling salty gumdrop	0		Effect: "Can't Smell Nothin'", Effect Duration: 50, Last Available: "2019-12"
 10385	knitted smooth ribbon candy ascot	0		Moxie: +15, Cold Resistance: +3, Single Equip, Last Available: "2019-12"
-10386	olive mirror moist Crimbo spices	0		Last Available: "2019-12"
-10387	pulsating jittery tumbling intact anemone spike	0		Last Available: "2019-12"
+10386	mirror olive moist Crimbo spices	0		Last Available: "2019-12"
+10387	jittery pulsating tumbling intact anemone spike	0		Last Available: "2019-12"
 10388	executive anemoney clip	0		Meat Drop: +40, Single Equip, Last Available: "2019-12"
 10389	runny icing	0		Last Available: "2019-12"
 10390	altered jittery super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
@@ -10254,7 +10254,7 @@
 10395	red personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	adequate bowl of mernudo	3	good	Last Available: "2019-12"
-10398	irresponsibly strong tolerable special red squat shaking fishelada	6	good	Effect: "Well-preserved", Effect Duration: 50, Last Available: "2019-12"
+10398	special irresponsibly strong tolerable squat red shaking fishelada	6	good	Effect: "Well-preserved", Effect Duration: 50, Last Available: "2019-12"
 10399	yummy ojo de pez burrito	3	awesome	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	ghostly waterlogged cloth	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	fireproof brainy nutcracker cape	0		Mysticality: +5, Hot Resistance: +3, Last Available: "2019-12"
 10413	twirling rosewater-soaked foul-smelling nutcracker epaulets	0		Stench Damage: +10, Stench Resistance: +3, Single Equip, Last Available: "2019-12"
 10414	ghostly nutcracker figurine	0		Last Available: "2019-12"
-10415	diet flavorless salt plum	1	decent	Last Available: "2019-12"
+10415	flavorless diet salt plum	1	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	decent and bean	3	good	Last Available: "2019-12"
 10418	educational kelp-holly gun of the overflowing toilet	0		Experience: +1, Stench Spell Damage: +50, Item Drop: +5, Last Available: "2019-12"
@@ -10281,27 +10281,27 @@
 10422	therapeutic Crimbylow-rise jeans of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-12"
 10423	huge careful smooth kelp-holly drape	0		Moxie: +15, Monster Level: -10, Last Available: "2019-12"
 10424	purple careful forbidden brainy Staff of the Peppermint Twist of the scaredy-cat	0		Mysticality: +5, Spell Damage Percent: +50, Monster Level: -25, Last Available: "2019-12"
-10425	spoiled diet tempura and bean	1	crappy	Last Available: "2019-12"
+10425	diet spoiled tempura and bean	1	crappy	Last Available: "2019-12"
 10426	artisanal blinking salt plum sake	3	EPIC	Last Available: "2019-12"
 10427	concentrated energized wobbly pressurized potion of possessiveness	0		Effect: "All Branned Up", Effect Duration: 17, Last Available: "2019-12"
 10428	dry gray almond	0		Effect: "Seriously Mutated", Effect Duration: 57
 10429	non-pressed olive handful of mixed nuts	0		Effect: "Spirit of Alph", Effect Duration: 18, Last Available: "2019-12"
 10430	nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	rosewater-soaked energetic grievous Retrospecs	0		Weapon Damage Percent: +50, Maximum MP Percent: +20, Stench Resistance: +3, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	rosewater-soaked energetic grievous Retrospecs	0		Weapon Damage Percent: +50, Maximum MP Percent: +20, Stench Resistance: +3, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	ghostly unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	Usain Bolt's Jim Carey's Annie Oakley's Powerful Glove of the bloodbag of the sweet-tooth	0		Maximum HP: +100, Critical Hit Percent: +20, Monster Level: +25, Candy Drop: +100, Initiative: +80, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	Usain Bolt's Jim Carey's Annie Oakley's Powerful Glove of the bloodbag of the sweet-tooth	0		Maximum HP: +100, Critical Hit Percent: +20, Monster Level: +25, Candy Drop: +100, Initiative: +80, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	jittery enhanced signal receiver	0		
 10440	yellow status cymbal	0		Last Available: "2020-02"
 10441	Jack Frost's sinister personal trainer's Drip harness	0		Experience Percent (Muscle): +10, Spell Damage: +10, Cold Spell Damage: +50
 10442	blurry blinking thinker's drippy truncheon	0		Mysticality: +10, Single Equip
 10443	ghostly Driplet	0		
-10444	mirror squat drippy snail shell	0		
-10445	immense enchanted adequate drippy nugget	7	drippy	Effect: "Demonic Flavor", Effect Duration: 35
+10444	squat mirror drippy snail shell	0		
+10445	adequate enchanted immense drippy nugget	7	drippy	Effect: "Demonic Flavor", Effect Duration: 35
 10446	artisanal mirror glass of drippy wine	4	drippy	
-10447	enchanted adequate skewed fuchsia drippy caviar	3	drippy	Effect: "Fangs and Pangs", Effect Duration: 20
+10447	adequate enchanted skewed fuchsia drippy caviar	3	drippy	Effect: "Fangs and Pangs", Effect Duration: 20
 10448	huge decent drippy plum(?)	9	drippy	
 10449	pulsating Annie Oakley's drippy stake	0		Critical Hit Percent: +20, Single Equip
 10450	huge The Eye of the Thing in the Basement	0		
@@ -10346,7 +10346,7 @@
 10489	moldy mushroom filet	4	crappy	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	mixed spinning mushroom tea	1		Last Available: "2020-03"
-10492	acceptable watered-down mushroom whiskey	2	good	Last Available: "2020-03"
+10492	watered-down acceptable mushroom whiskey	2	good	Last Available: "2020-03"
 10493	Lo Pan's fortified weightlifter's mushroom cap	0		Muscle: +15, Damage Absorption: +60, Spell Critical Percent: +30, Last Available: "2020-03"
 10494	tumbling flame-wreathed wicked beefy mushroom shield of the businessman	0		Muscle: +10, Spell Damage: +5, Hot Spell Damage: +10, Meat Drop: +50, Damage Reduction: 6, Last Available: "2020-03"
 10495	purple stanky dance instructor's smartaleck's mushroom pants of bravery	0		Moxie Percent: +30, Experience Percent (Moxie): +10, Stench Spell Damage: +25, Spooky Resistance: +5, Last Available: "2020-03"
@@ -10356,7 +10356,7 @@
 10499	blurry plastic piranha pot	0		Familiar Weight: +5
 10500	ionized dry skewed blinking piranha pollen	0		Effect: "Material Witness", Effect Duration: 38, Last Available: "2020-03"
 10501	tumbling plumber's boots	0		Single Equip, Conditional Skill (Equipped): "Plumber Jump"
-10502	purple blurry sinistral homunculus	0		Free Pull, Last Available: "2020-04"
+10502	blurry purple sinistral homunculus	0		Free Pull, Last Available: "2020-04"
 10503	huge crafty kettle bell	0		Maximum MP: +10, Last Available: "2020-04"
 10504	pulsating experienced glued-together crystal ball	0		Experience: +2, Last Available: "2020-04"
 10505	martini dregs of the brazier	0		Hot Spell Damage: +25, Last Available: "2020-04"
@@ -10372,9 +10372,9 @@
 10515	upside-down drippy grub	0		
 10516	ghostly drippy bezoar	0		
 10517	tumbling Drip Institute petri dish	0		
-10518	spinning teal drippy ichor	0		
+10518	teal spinning drippy ichor	0		
 10519	mirror drippy enzyme	0		
-10520	teal jittery drippy salt	0		
+10520	jittery teal drippy salt	0		
 10521	drippy pigment	0		
 10522	huge drippy bromide	0		
 10523	drippy flux	0		
@@ -10388,13 +10388,13 @@
 10532	Guzzlr application	0		Free Pull
 10533	brainy Guzzlr tablet of Tarzan	0		Mysticality: +5, Experience (Muscle): +3, Last Available: "2020-05"
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
-10535	lime green bouncing Guzzlrbuck	0		Last Available: "2020-05"
+10535	bouncing lime green Guzzlrbuck	0		Last Available: "2020-05"
 10536	ghostly Guzzlr hat	0		Last Available: "2020-05"
 10537	pulsating Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	bouncing Guzzlr pants	0		Last Available: "2020-05"
 10539	ghostly Guzzlr souvenir stein of the boozehound	0		Booze Drop: +100, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	distilled artisanal Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
+10541	artisanal distilled Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
 10542	artisanal cyan Sourfinger	3	EPIC	Last Available: "2020-05"
 10543	aged Nog-on-the-Cob	4	awesome	Last Available: "2020-05"
 10544	delicious Steamboat	4	awesome	Last Available: "2020-05"
@@ -10425,22 +10425,22 @@
 10569	shaking huge inspector's arcane researcher's discarded bike lock key	0		Experience Percent (Mysticality): +10, Item Drop: +15, Last Available: "2020-08"
 10570	Thwaitgold keyhole spider statuette	0		
 10571	maroon Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
-10572	quantum deionized blinking pulsating marshroom	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 25
+10572	quantum deionized pulsating blinking marshroom	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 25
 10573	yellow bag of Iunion stones	0		Free Pull
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	bouncing drippy candy bar	0		
 10576	deionized adjusted salty drippy candy bar	0		Effect: "items.enh", Effect Duration: 48
 10577	deionized denatured squat writhing drippy candy bar	0		Effect: "Dancing Prowess", Effect Duration: 36
-10578	polarized Vulcanized narrow cyan gooey drippy candy bar	0		Effect: "Mushroom Melody", Effect Duration: 61
+10578	polarized Vulcanized cyan narrow gooey drippy candy bar	0		Effect: "Mushroom Melody", Effect Duration: 61
 10579	upside-down baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	jittery SpinMaster&trade; lathe	0		Last Available: "2020-08"
-10583	blinking pulsating flimsy hardwood scraps	0		Last Available: "2020-08"
+10583	pulsating blinking flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	olive scorching brawny birch battery	0		Muscle Percent: +20, Hot Damage: +25, Lasts Until Rollover, Last Available: "2020-08"
-10585	lion tamer's ebony epee of vim and vigor of the blizzard	0		Maximum HP Percent: +50, Experience (familiar): +2, Cold Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	flame-retardant Da Vinci's weeping willow wand of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +5, Hot Resistance: +1, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	scorching strapping beechwood blowgun of the sweet-tooth	0		Muscle: +5, Hot Damage: +25, Candy Drop: +100, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	lion tamer's ebony epee of vim and vigor of the blizzard	0		Maximum HP Percent: +50, Experience (familiar): +2, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	flame-retardant Da Vinci's weeping willow wand of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +5, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	scorching strapping beechwood blowgun of the sweet-tooth	0		Muscle: +5, Hot Damage: +25, Candy Drop: +100, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	huge foul-smelling hale maple magnet of James Dean	0		Experience (Moxie): +3, Maximum HP: +20, Stench Damage: +10, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	knitted wool energetic hemlock helm	0		Maximum MP Percent: +20, Cold Resistance: 4, Last Available: "2020-08"
@@ -10459,10 +10459,10 @@
 10603	fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
-10606	enhanced blurry spinning Yeg's Motel toothbrush	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40, Last Available: "2020-09"
+10606	enhanced spinning blurry Yeg's Motel toothbrush	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 40, Last Available: "2020-09"
 10607	concentrated moist moist gray mirror Yeg's Motel hand soap	0		Effect: "Creepin' Up on You", Effect Duration: 13, Last Available: "2020-09"
 10608	cyan Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	special spoiled miniature squat Yeg's Motel pillow mint	2	crappy	Effect: "Bricked-In", Effect Duration: 25, Last Available: "2020-09"
+10609	spoiled special miniature squat Yeg's Motel pillow mint	2	crappy	Effect: "Bricked-In", Effect Duration: 25, Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	enhanced teal Yeg's Motel mouthwash	0		Effect: "Squid Squint", Effect Duration: 30, Last Available: "2020-09"
 10612	hardened Yeg's Motel shower cap of horror	0		Damage Reduction: 3, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-09"
@@ -10494,9 +10494,9 @@
 10638	special lousy practically non-alcoholic flask of moonshine	1	decent	Effect: "Big Meat Big Prizes", Effect Duration: 20, Last Available: "2020-09"
 10639	ghostly jittery greasy Jim Carey's sea-worn candlestick of temperance	0		Monster Level: +25, Sleaze Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2020-09"
 10640	Universal Seasoning	0		
-10641	adjusted pulsating maroon null-day exploit	0		Effect: "Phairly Balanced", Effect Duration: 45, Last Available: "2025-12"
+10641	adjusted maroon pulsating null-day exploit	0		Effect: "Phairly Balanced", Effect Duration: 45, Last Available: "2025-12"
 10642	flame orb	0		Last Available: "2020-09"
-10643	fancy flavorless ghostly shaking chocolate chip muffin	3	decent	Effect: "Thanksgot", Effect Duration: 45
+10643	flavorless fancy shaking ghostly chocolate chip muffin	3	decent	Effect: "Thanksgot", Effect Duration: 45
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
 10646	packaged knock-off retro superhero cape	0		Free Pull, Last Available: "2020-11"
@@ -10510,12 +10510,12 @@
 10654	denatured magnetized blinking boiling hot cocoa	0		Effect: "Mistified", Effect Duration: 68, Last Available: "2020-12"
 10655	enhanced cool hot cocoa	0		Effect: "5 Pounds Lighter", Effect Duration: 54, Last Available: "2020-12"
 10656	Vulcanized triple-boiled blinking overly-fancy hot cocoa	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 18, Last Available: "2020-12"
-10657	flattened purple ghostly hot cocoa au beurre	0		Effect: "Slimily Speedy", Effect Duration: 65, Last Available: "2020-12"
+10657	flattened ghostly purple hot cocoa au beurre	0		Effect: "Slimily Speedy", Effect Duration: 65, Last Available: "2020-12"
 10658	non-quantum spinning hot cocoa with rainbow marshmallows	0		Effect: "Dwarven Hardiness", Effect Duration: 50, Last Available: "2020-12"
 10659	padded Book of Old-Timey Carols	0		Damage Absorption: [+20*event(December)], Last Available: "2020-12"
 10660	curative Crimbo smile	0		HP Regen Min: [3*event(December)], HP Regen Max: [5*event(December)], Last Available: "2020-12"
 10661	studded SalesCo sample kit	0		Damage Absorption: [+80*event(December)], Last Available: "2020-12"
-10662	boiled skewed cyan candy harmonica	0		Effect: "Slimy Flavor", Effect Duration: 31, Last Available: "2020-12"
+10662	boiled cyan skewed candy harmonica	0		Effect: "Slimy Flavor", Effect Duration: 31, Last Available: "2020-12"
 10663	diffused extra-moist sugar	0		Effect: "Soles of Glass", Effect Duration: 13, Last Available: "2020-12"
 10664	vacuum-sealed multi-level marzipan	0		Effect: "You Drank Fish Wine", Effect Duration: 40, Last Available: "2020-12"
 10665	dog trainer's plastic Crimbo caroler	0		Experience (familiar): +1, Last Available: "2020-12"
@@ -10523,7 +10523,7 @@
 10667	pulsating frosty plastic Crimbo cheer	0		Cold Spell Damage: +10, Last Available: "2020-12"
 10668	tumbling yellow Van der Graaf plastic Mirth	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-12"
 10669	plastic Penny of incineration	0		Hot Spell Damage: +50, Last Available: "2020-12"
-10670	wobbly blinking olive overflowing gift basket	0		Last Available: "2020-12"
+10670	olive blinking wobbly overflowing gift basket	0		Last Available: "2020-12"
 10671	personalized wassail stein	0		Last Available: "2020-12"
 10672	tabletop candy dispenser	0		Last Available: "2020-12"
 10673	Usain Bolt's neck wreath	0		Initiative: [+80*event(December)], Single Equip, Last Available: "2020-12"
@@ -10568,8 +10568,8 @@
 10712	The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	jittery The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	snack-sized normal and pepper (stale)	2	good	Last Available: "2020-12"
-10716	weak drinkable cranberry margarita (brackish)	2	good	Last Available: "2020-12"
+10715	normal snack-sized and pepper (stale)	2	good	Last Available: "2020-12"
+10716	drinkable weak cranberry margarita (brackish)	2	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
@@ -10593,7 +10593,7 @@
 10737	power seed	0		Free Pull, Last Available: "2021-03"
 10738	fuchsia wobbly potted power plant	0		Last Available: "2021-03"
 10739	boiled pressed galvanized battery (AAA)	0		Effect: "Think Win-Lose", Effect Duration: 63, Last Available: "2021-03"
-10740	nitrogenated enhanced skewed squat ghostly battery (AA)	0		Effect: "Sugar Smacks", Effect Duration: 31, Last Available: "2021-03"
+10740	nitrogenated enhanced ghostly squat skewed battery (AA)	0		Effect: "Sugar Smacks", Effect Duration: 31, Last Available: "2021-03"
 10741	magnetized narrow battery (D)	0		Effect: "Shawarma Warm War", Effect Duration: 67, Last Available: "2021-03"
 10742	modified blurry battery (9-Volt)	0		Effect: "Phoenix, Right?", Effect Duration: 14, Last Available: "2021-03"
 10743	electrified diffused battery (lantern)	0		Effect: "Feroci Tea", Effect Duration: 55, Last Available: "2021-03"
@@ -10602,7 +10602,7 @@
 10746	marshmallow	0		
 10747	mediocre marshmallow bomb	4	decent	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	maroon shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	teal plate	0		Familiar Weight: +5
 10752	cold-filtered pressed short beer	0		Effect: "Stogied", Effect Duration: 28, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	altered vacuum-sealed short	0		Effect: "Sweet Taste", Effect Duration: 38, Last Available: "2021-05"
 10757	wobbly Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	blinking vibrating medical-grade familiar scrapbook	0		Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	blinking vibrating medical-grade familiar scrapbook	0		Maximum MP Percent: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	tumbling clan underground fireworks shop	0		Last Available: "2021-07"
 10762	auspicious toasty fedora-mounted fountain of wisdom	0		Mysticality: +15, Hot Damage: +5, Item Drop: +10, Lasts Until Rollover, Last Available: "2021-07"
@@ -10631,7 +10631,7 @@
 10775	pickled maroon The Beast Within&trade; candle	0		Effect: "Pisces in the Skyces", Effect Duration: 48, Last Available: "2021-08"
 10776	dry twirling Salsa Caliente&trade; candle	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 43, Last Available: "2021-08"
 10777	non-galvanized quadruple-improved spinning Smoldering Clover&trade; candle	0		Effect: "Grape Expectations", Effect Duration: 22, Last Available: "2021-08"
-10778	non-tarnished jittery bouncing Napalm In The Morning&trade; candle	0		Effect: "Twinkly Weapon", Effect Duration: 36, Last Available: "2021-08"
+10778	non-tarnished bouncing jittery Napalm In The Morning&trade; candle	0		Effect: "Twinkly Weapon", Effect Duration: 36, Last Available: "2021-08"
 10779	healthy beefcake's extra-large utility candle	0		Muscle: +25, Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2021-08"
 10780	baleful wizardly runed taper candle	0		Mysticality: +25, Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
 10781	zippy novelty sparkling candle of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Initiative: +20, Lasts Until Rollover, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	bouncing packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	asbestos-lined MacGyver's personal trainer's Da Vinci's experienced industrial fire extinguisher of Calamity Jane	0		Experience: +2, Experience (Mysticality): +5, Experience Percent (Muscle): +10, Maximum MP: +100, Critical Hit Percent: +15, Hot Resistance: +5, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	asbestos-lined MacGyver's personal trainer's Da Vinci's experienced industrial fire extinguisher of Calamity Jane	0		Experience: +2, Experience (Mysticality): +5, Experience Percent (Muscle): +10, Maximum MP: +100, Critical Hit Percent: +15, Hot Resistance: +5, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	bouncing The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10659,8 +10659,8 @@
 10803	packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	blinking forbidden grievous Daylight Shavings Helmet of the early riser	0		Weapon Damage Percent: +50, Spell Damage Percent: +50, Adventures: +7, Last Available: "2021-11"
 10805	eggwater	1	good	Last Available: "2021-12"
-10806	diet rotten ghostly bread man	1	crappy	Last Available: "2021-12"
-10807	half-sized stale lime green plain candy cane	2	decent	Last Available: "2021-12"
+10806	rotten diet ghostly bread man	1	crappy	Last Available: "2021-12"
+10807	stale half-sized lime green plain candy cane	2	decent	Last Available: "2021-12"
 10808	decent flour cookie	4	good	Last Available: "2021-12"
 10809	blurry wool plastic food lab	0		Cold Resistance: +1, Single Equip, Last Available: "2021-12"
 10810	cyan huge hardened plastic nog lab	0		Damage Reduction: 3, Single Equip, Last Available: "2021-12"
@@ -10677,9 +10677,9 @@
 10821	rotten fishcake	3	crappy	Last Available: "2021-12"
 10822	flavorless bone broth	4	decent	Last Available: "2021-12"
 10823	decent jittery star pop	3	good	Last Available: "2021-12"
-10824	delicious spirit-forward upside-down Doc's Fortifying Wine	5	awesome	Last Available: "2021-12"
+10824	spirit-forward delicious upside-down Doc's Fortifying Wine	5	awesome	Last Available: "2021-12"
 10825	smooth Doc's Smartifying Wine	4	awesome	Last Available: "2021-12"
-10826	irresponsibly strong delicious narrow Doc's Limbering Wine	8	awesome	Last Available: "2021-12"
+10826	delicious irresponsibly strong narrow Doc's Limbering Wine	8	awesome	Last Available: "2021-12"
 10827	bad Doc's Medical-Grade Wine	4	decent	Last Available: "2021-12"
 10828	dehydrated narrow Homebodyl&trade;	1		Last Available: "2021-12"
 10829	vaporized squat Extrovermectin&trade;	1		Effect: "Human-Weird Thing Hybrid", Effect Duration: 15, Last Available: "2021-12"
@@ -10715,7 +10715,7 @@
 10859	projectile chemistry set	0		Last Available: "2021-12"
 10860	spinning scorching depleted Crimbonium football helmet	0		Hot Damage: +25, Last Available: "2021-12"
 10861	maroon blurry synthetic rock	0		Last Available: "2021-12"
-10862	miniature delicious tumbling &quot;caramel&quot;	2	awesome	Last Available: "2021-12"
+10862	delicious miniature tumbling &quot;caramel&quot;	2	awesome	Last Available: "2021-12"
 10863	jittery coward's self-repairing earmuffs	0		Monster Level: -20, Last Available: "2021-12"
 10864	carnivorous potted plant of the glutton	0		Food Drop: +100, Last Available: "2021-12"
 10865	fuchsia universal biscuit	0		Last Available: "2021-12"
@@ -10724,7 +10724,7 @@
 10868	adequate lab-grown meat	4	good	Last Available: "2021-12"
 10869	Lo Pan's fleece	0		Spell Critical Percent: +30, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
-10871	bouncing skewed cloning kit	0		Last Available: "2021-12"
+10871	skewed bouncing cloning kit	0		Last Available: "2021-12"
 10872	therapeutic pants	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2021-12"
 10873	supercool can of mixed everything of the cougar of Tarzan	0		Moxie: +20, Moxie Percent: +20, Experience (Muscle): +3, Last Available: "2021-12"
 10874	shaking mirror Site Alpha ID badge	0		Familiar Weight: +5
@@ -10739,16 +10739,16 @@
 10883	denatured astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	vibrating brainy magnifying glass of extreme caution	0		Mysticality: +5, Maximum MP Percent: +10, Monster Level: -25, Last Available: "2022-12"
-10886	triple-distilled smooth void lager	9	awesome	Last Available: "2022-12"
-10887	miniature spoiled void burger	2	crappy	Last Available: "2022-12"
+10886	smooth triple-distilled void lager	9	awesome	Last Available: "2022-12"
+10887	spoiled miniature void burger	2	crappy	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	bouncing lightning-fast sharpshooter's hardy groovy void shard	0		Moxie Percent: +10, Maximum HP: +50, Critical Hit Percent: +10, Initiative: +40, Last Available: "2022-12"
-10890	green bouncing blinking undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
+10890	blinking green bouncing undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	pulsating cosmic bowling ball	0		Last Available: "2022-01"
 10892	twirling mirror combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	toasty combat lover's locket	0		Hot Damage: +5, Single Equip, Last Available: "2022-02"
 10894	Thwaitgold protozoa statuette	0		
-10895	bouncing red grey gosling	0		Free Pull, Last Available: "2022-03"
+10895	red bouncing grey gosling	0		Free Pull, Last Available: "2022-03"
 10896	grey down vest	0		Experience (familiar): +2
 10897	trojan horseshoe	0		Last Available: "2025-12"
 10898	squat undamaged Unbreakable Umbrella	0		Free Pull, Last Available: "2022-04"
@@ -10767,9 +10767,9 @@
 10911	polymerized red gaffer's tape	0		Effect: "Izchak's Blessing", Effect Duration: 62, Last Available: "2022-05"
 10912	rotten blue 20-lb can of rice and beans	4	crappy	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	good	Last Available: "2022-05"
-10914	diet tasty upside-down expired MRE	1	awesome	Last Available: "2022-05"
-10915	normal miniature cool mint precipice bar	2	good	Last Available: "2022-05"
-10916	normal half-sized enchanted carrot cake precipice bar	2	good	Effect: "Tapped In", Effect Duration: 10, Last Available: "2022-05"
+10914	tasty diet upside-down expired MRE	1	awesome	Last Available: "2022-05"
+10915	miniature normal cool mint precipice bar	2	good	Last Available: "2022-05"
+10916	enchanted half-sized normal carrot cake precipice bar	2	good	Effect: "Tapped In", Effect Duration: 10, Last Available: "2022-05"
 10917	maroon The Big Book of Every Skill	0		
 10918	ghostly Thwaitgold harvestman statuette	0		
 10919	gray packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	dry diffused blinking trampled ticket stub	0		Effect: "Human-Constellation Hybrid", Effect Duration: 41, Last Available: "2022-06"
 10927	quadruple-unsweetened flattened diffused green savings bond	0		Effect: "Springy Fusilli", Effect Duration: 48, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	mixed sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	wobbly stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10804,8 +10804,8 @@
 10948	shellacked reflective vest	0		Damage Reduction: 7
 10949	forbidden dinosaur	0		Spell Damage Percent: +50
 10950	Thwaitgold mosquito-in-amber statuette	0		
-10951	squat teal packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	upside-down sharpshooter's Rosewater's Jurassic Parka	0		Mysticality Percent: +30, Critical Hit Percent: +10, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10951	teal squat packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
+10952	upside-down sharpshooter's Rosewater's Jurassic Parka	0		Mysticality Percent: +30, Critical Hit Percent: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	flattened quantum bouncing autumn leaf	0		Effect: "Slightly Mutated", Effect Duration: 37, Last Available: "2022-10"
@@ -10824,28 +10824,28 @@
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	maroon Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	rotten ratatouille de Jarlsberg	4	crappy	Last Available: "2022-11"
-10971	bland bite-sized Jarlsberg's vegetable soup	1	decent	Last Available: "2022-11"
+10971	bite-sized bland Jarlsberg's vegetable soup	1	decent	Last Available: "2022-11"
 10972	stale mirror roasted vegetable of Jarlsberg	4	decent	Last Available: "2022-11"
 10973	spoiled St. Pete's sneaky smoothie	3	crappy	Last Available: "2022-11"
-10974	tiny enchanted moldy wobbly Pete's wiley whey bar	1	crappy	Effect: "Virgo Rising", Effect Duration: 20, Last Available: "2022-11"
+10974	moldy tiny enchanted wobbly Pete's wiley whey bar	1	crappy	Effect: "Virgo Rising", Effect Duration: 20, Last Available: "2022-11"
 10975	half-sized stale Pete's rich ricotta	2	decent	Last Available: "2022-11"
 10976	lousy irresponsibly strong Boris's beer	7	decent	Last Available: "2022-11"
 10977	bland honey bun of Boris	3	decent	Last Available: "2022-11"
 10978	flavorless ghostly Boris's bread	3	decent	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	mirror jittery Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10980	jittery mirror Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
 10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
 10983	blinking Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
 10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
 10986	tumbling Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	skewed yellow Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10987	yellow skewed Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	adequate jittery baked veggie ricotta casserole	4	good	Last Available: "2022-11"
 10989	low-calorie moldy plain calzone	1	crappy	Last Available: "2022-11"
-10990	bland tiny roasted vegetable focaccia	1	decent	Last Available: "2022-11"
+10990	tiny bland roasted vegetable focaccia	1	decent	Last Available: "2022-11"
 10991	yummy Pizza of Legend	4	awesome	Last Available: "2022-11"
-10992	bland gigantic Calzone of Legend	8	decent	Last Available: "2022-11"
+10992	gigantic bland Calzone of Legend	8	decent	Last Available: "2022-11"
 10993	jittery Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
 10994	upside-down Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
 10995	fuchsia Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
@@ -10863,22 +10863,22 @@
 11007	booze bindle	0		
 11008	mansplainer's rare oboe of the bloodbag	0		Maximum HP: +100, Monster Level: +15
 11009	asbestos-lined bullet necklace of Tarzan	0		Experience (Muscle): +3, Hot Resistance: +5, Single Equip
-11010	decent miniature narrow swamp haunch	2	good	
+11010	miniature decent narrow swamp haunch	2	good	
 11011	executive groovy gator shades	0		Moxie Percent: +10, Meat Drop: +40, Single Equip
 11012	milk cap	0		
 11013	drinkable huge Charleston Choo-Choo	3	good	
 11014	drinkable narrow Velvet Veil	3	good	
 11015	practically non-alcoholic acceptable jittery Marltini	1	good	
-11016	bad watered-down Strong, Silent Type	2	decent	
+11016	watered-down bad Strong, Silent Type	2	decent	
 11017	smooth Mysterious Stranger	3	awesome	
 11018	tolerable Champagne Shimmy	4	good	
 11019	shaking the Sot's parcel	0		
-11020	ghostly ceramic cestus of the brazier of the glutton	0		Hot Spell Damage: +25, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	padded Da Vinci's ceramic centurion shield of courage	0		Experience (Mysticality): +5, Damage Absorption: +20, Spooky Resistance: +3, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	blue scandalous ceramic celery grater of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	occult razor-sharp cool ceramic celsiturometer	0		Moxie: +5, Weapon Damage Percent: +25, Spell Damage Percent: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	coward's beefy ceramic cerecloth belt of Tarzan	0		Muscle: +10, Experience (Muscle): +3, Monster Level: -20, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	ribald Socratic ceramic cenobite's robe of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Sleaze Damage: +10, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	ghostly ceramic cestus of the brazier of the glutton	0		Hot Spell Damage: +25, Food Drop: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	padded Da Vinci's ceramic centurion shield of courage	0		Experience (Mysticality): +5, Damage Absorption: +20, Spooky Resistance: +3, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	blue scandalous ceramic celery grater of the blizzard	0		Cold Spell Damage: +25, Sleaze Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	occult razor-sharp cool ceramic celsiturometer	0		Moxie: +5, Weapon Damage Percent: +25, Spell Damage Percent: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	coward's beefy ceramic cerecloth belt of Tarzan	0		Muscle: +10, Experience (Muscle): +3, Monster Level: -20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	ribald Socratic ceramic cenobite's robe of the wise owl	0		Mysticality: +20, Experience (Mysticality): +1, Sleaze Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	distilled ceramic scree	1		Last Available: "2023-12"
 11027	frozen frozen wobbly extra-hard jawbreaker	0		Effect: "Human-Orc Hybrid", Effect Duration: 54
 11028	wobbly knitted scandalous chiffon chevrons of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5, Cold Resistance: +3, Single Equip, Last Available: "2023-12"
@@ -10890,7 +10890,7 @@
 11034	pickled blue chiffon carbage	1		Last Available: "2023-12"
 11035	unsweetened tumbling chiffon lemon	0		Effect: "Nutrient-Rich", Effect Duration: 13
 11036	stale snack-sized chocomotive	2	decent	Last Available: "2022-12"
-11037	fancy decent thick upside-down tumbling freightcake	5	good	Effect: "Gr8ness", Effect Duration: 45, Last Available: "2022-12"
+11037	decent fancy thick upside-down tumbling freightcake	5	good	Effect: "Gr8ness", Effect Duration: 45, Last Available: "2022-12"
 11038	practically non-alcoholic lousy tumbling cabooze	1	decent	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	knitted plastic passenger car	0		Cold Resistance: +3, Last Available: "2022-12"
@@ -10914,7 +10914,7 @@
 11058	weightlifter's Trainbot harness	0		Muscle: +15
 11059	ping-pong table	0		
 11060	Crimbo train emergency brake	0		
-11061	squat shaking Trainbot autoassembly module	0		
+11061	shaking squat Trainbot autoassembly module	0		
 11062	shaking shaking careful electrified savvy head-mounted Trainbot	0		Mysticality Percent: +20, Monster Level: -10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12"
 11063	zippy lion tamer's leg-mounted Trainbots of the detective	0		Experience (familiar): +2, Item Drop: +20, Initiative: +20, Last Available: "2022-12"
 11064	Jack Frost's shoulder-mounted Trainbot of the cougar of doom	0		Moxie: +20, Cold Spell Damage: +50, Spooky Spell Damage: +50, Single Equip, Last Available: "2022-12"
@@ -10965,12 +10965,12 @@
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
 11112	tasty pixel bread	3	awesome	
-11113	perfectly mixed fancy extra-dry gray pixel whiskey	5	EPIC	Effect: "20-20 Second Sight", Effect Duration: 20
+11113	fancy extra-dry perfectly mixed gray pixel whiskey	5	EPIC	Effect: "20-20 Second Sight", Effect Duration: 20
 11114	pixel rock	0		
 11115	red ghostly S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
 11117	moist blurry glob of extra-green chlorophyll	0		Effect: "Sinuses For Miles", Effect Duration: 59, Last Available: "2023-02"
-11118	enhanced ionized mirror yellow mushroom	0		Effect: "The Style... of the Future", Effect Duration: 40, Last Available: "2023-02"
+11118	enhanced ionized yellow mirror mushroom	0		Effect: "The Style... of the Future", Effect Duration: 40, Last Available: "2023-02"
 11119	vacuum-sealed alkaline double-irradiated skewed five-fingered fern resin	0		Effect: "Burning Ears", Effect Duration: 22, Last Available: "2023-02"
 11120	stale super good fruit	4	decent	Last Available: "2023-02"
 11121	modified narrow energized spores	1		Last Available: "2023-02"
@@ -10979,13 +10979,13 @@
 11124	green extra-grubby grub	0		Last Available: "2023-02"
 11125	deionized modified fire ant pheromones	0		Effect: "Empathy", Effect Duration: 22, Last Available: "2023-02"
 11126	concentrated flapper fly	0		Effect: "Spookyravin'", Effect Duration: 54, Last Available: "2023-02"
-11127	practically non-alcoholic hand-crafted fancy shot of wasp venom	1	EPIC	Effect: "Action", Effect Duration: 10, Last Available: "2023-02"
+11127	fancy practically non-alcoholic hand-crafted shot of wasp venom	1	EPIC	Effect: "Action", Effect Duration: 10, Last Available: "2023-02"
 11128	frozen warmed filled mosquito	0		Effect: "Angry like the Wolf", Effect Duration: 40, Last Available: "2023-02"
 11129	quadruple-enhanced polarized green shim of shame shale	0		Effect: "Corruption of Wretched Wally", Effect Duration: 42, Last Available: "2023-02"
 11130	boiled aerosolized twirling pebble of proud pyrite	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 22, Last Available: "2023-02"
 11131	ionized colloidal squat pile of gritty sand	0		Effect: "Old School Pompadour", Effect Duration: 35, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
-11133	double-dry upside-down jittery angry agate	0		Effect: "Salty Mouth", Effect Duration: 49, Last Available: "2023-02"
+11133	double-dry jittery upside-down angry agate	0		Effect: "Salty Mouth", Effect Duration: 49, Last Available: "2023-02"
 11134	modified pressed lump of loyal latite	0		Effect: "Ooh, Umami!", Effect Duration: 39, Last Available: "2023-02"
 11135	immense normal shadow sausage	9	good	Last Available: "2023-03"
 11136	twirling rock-hard thinker's shadow skin	0		Mysticality: +10, Damage Reduction: 5, Last Available: "2023-03"
@@ -10996,7 +10996,7 @@
 11141	shadow glass	0		Last Available: "2023-03"
 11142	twirling shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	drinkable practically non-alcoholic shadow venom	1	good	Last Available: "2023-03"
+11144	practically non-alcoholic drinkable shadow venom	1	good	Last Available: "2023-03"
 11145	pickled shadow nectar	1		Effect: "Become Intensely interested", Effect Duration: 20, Last Available: "2023-03"
 11146	mirror asbestos-lined smelly dance instructor's shadow stick	0		Experience Percent (Moxie): +10, Stench Spell Damage: +10, Hot Resistance: +5, Last Available: "2023-03"
 11147	knitted Van der Graaf bat paw	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7
@@ -11018,7 +11018,7 @@
 11163	wobbly Advanced Pig Skinning	0		
 11164	The Cheese Wizard's Companion	0		
 11165	yellow Jazz Agent sheet music	0		
-11166	olive upside-down Thwaitgold anti-moth statuette	0		
+11166	upside-down olive Thwaitgold anti-moth statuette	0		
 11167	pulsating shadowy cheat sheet	0		Free Pull
 11168	closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
@@ -11036,14 +11036,14 @@
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	normal jittery shadow hot dog	4	good	
 11183	high-proof delicious shadow martini	6	awesome	
-11184	distilled pulsating shaking shadow pill	1		
+11184	distilled shaking pulsating shadow pill	1		
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	quantum extra-colloidal quantum blinking shadow candy	0		Effect: "All Blued Up", Effect Duration: 34
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
-11191	twirling mirror replica hand turkey outline	0		
+11191	mirror twirling replica hand turkey outline	0		
 11192	replica crimbo elfling	0		
 11193	replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
@@ -11075,7 +11075,7 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	yellow shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	smelly frosty Fonzie's Herculean Cincho de Mayo	0		Experience (Muscle): +1, Experience (Moxie): +1, Cold Spell Damage: +10, Stench Spell Damage: +10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	smelly frosty Fonzie's Herculean Cincho de Mayo	0		Experience (Muscle): +1, Experience (Moxie): +1, Cold Spell Damage: +10, Stench Spell Damage: +10, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	olive dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	mirror replica Little Geneticist DNA-Splicing Lab	0		
 11226	cyan replica still grill	0		
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	chaotic educational smooth &quot;I survived Y2K&quot; T-Shirt of vim and vigor of Leguizamo of the scaredy-cat	0		Moxie: +15, Experience: +1, Maximum HP Percent: +50, Spell Critical Percent: +10, Monster Level: 5, Single Equip, Last Available: "2023-06"
 11259	squat Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	fortified educational pro skateboard	0		Experience: +1, Damage Absorption: +60, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	fortified educational pro skateboard	0		Experience: +1, Damage Absorption: +60, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	pulsating Meat Butler	0		Last Available: "2023-06"
 11263	tumbling Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	Annie Oakley's Flash Liquidizer Ultra Dousing Accessory	0		Critical Hit Percent: +20, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	Annie Oakley's Flash Liquidizer Ultra Dousing Accessory	0		Critical Hit Percent: +20, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	gravedigger's banded Amulet of Perpetual Darkness of the storm of the businessman	0		Damage Absorption: +100, Maximum MP Percent: +40, Spooky Damage: +10, Meat Drop: +50, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	narrow Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11159,7 +11159,7 @@
 11304	replica sleeping patriotic eagle	0		
 11305	boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
-11307	low-calorie bland fuchsia watermelon	1	decent	
+11307	bland low-calorie fuchsia watermelon	1	decent	
 11308	watermelon seed	0		
 11309	water balloon	0		
 11310	thriftshop coupon	0		
@@ -11180,7 +11180,7 @@
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	pickled upside-down blue concentrated cooking	1		Effect: "No Vertigo", Effect Duration: 10
+11328	pickled blue upside-down concentrated cooking	1		Effect: "No Vertigo", Effect Duration: 10
 11329	denatured meat	1		
 11330	dehydrated fuchsia sparkling orb	1		
 11331	twisted jittery hardening cream	1		
@@ -11197,7 +11197,7 @@
 11342	olive rake	0		Item Drop: +1
 11343	blurry clever rake	0		Maximum MP: +20
 11344	autumnic bomb	0		
-11345	blurry mirror forest canopy bed	0		
+11345	mirror blurry forest canopy bed	0		
 11346	day shortener	0		
 11347	tumbling extra time	0		
 11348	narrow experienced autumnal aegis of terror	0		Experience: +2, Spooky Spell Damage: +10, Damage Reduction: 9
@@ -11268,16 +11268,16 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	sinister strapping Elf Guard officer's sidearm	0		Muscle: +5, Spell Damage: +10, Last Available: "2023-12"
 11415	chaotic Tesla Elf Guard insignia (general)	0		Spell Critical Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12"
-11416	watered-down drinkable Crimbow Rainbo	2	good	Last Available: "2023-12"
+11416	drinkable watered-down Crimbow Rainbo	2	good	Last Available: "2023-12"
 11417	red Elf Guard strategic map	0		Last Available: "2023-12"
 11418	blurry Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	electrified hale Elf Guard broom	0		Maximum HP: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
 11420	red double-paned educational thinker's Crimbuccaneer tavern swab	0		Mysticality: +10, Experience: +1, Cold Resistance: +5, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	artisanal old-school pirate grog	3	EPIC	Last Available: "2023-12"
-11423	snack-sized normal blinking shaking grog nuts	2	good	Last Available: "2023-12"
+11423	normal snack-sized shaking blinking grog nuts	2	good	Last Available: "2023-12"
 11424	spinning scandalous toasty sawed-off blunderbuss of James Dean	0		Experience (Moxie): +3, Hot Damage: +5, Sleaze Damage: +5, Last Available: "2023-12"
-11425	hand-crafted strong officer's nog	5	EPIC	Last Available: "2023-12"
+11425	strong hand-crafted officer's nog	5	EPIC	Last Available: "2023-12"
 11426	green peppermint bomb	0		Last Available: "2023-12"
 11427	tasty diet sundae ration	1	awesome	Last Available: "2023-12"
 11428	jumbo normal purple peppermint tack	5	good	Last Available: "2023-12"
@@ -11301,39 +11301,39 @@
 11446	Elf Guard fuel tank of the blizzard	0		Cold Spell Damage: +25, Last Available: "2023-12"
 11447	crafty massive wrench of Calamity Jane of horror	0		Maximum MP: +10, Critical Hit Percent: +15, Spooky Spell Damage: +25, Last Available: "2023-12"
 11448	shellacked Fonzie's brown pirate pants	0		Experience (Moxie): +1, Damage Reduction: 7, Last Available: "2023-12"
-11449	ghostly twirling Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
+11449	twirling ghostly Elf Guard Field Manual: Extortion	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
 11450	The Encyclopedia of Fruit	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11451	punching mirror	0		Last Available: "2023-12"
 11452	prompt manspreader's sharpshooter's baleful Elf dessert spoon of the pedagogue of the sewer	0		Experience: +3, Spell Damage: +25, Critical Hit Percent: +10, Monster Level: +10, Stench Damage: +25, Adventures: +3, Last Available: "2023-12"
 11453	wobbly prompt shellacked Elf Guard SCUBA tank	0		Damage Reduction: 7, Adventures: +3, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	auspicious free boots of the cheetah	0		Item Drop: +10, Initiative: +60, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	auspicious free boots of the cheetah	0		Item Drop: +10, Initiative: +60, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	huge lime green Sinatra's Fonzie's Elvish underarmor of terror	0		Experience (Moxie): 6, Spooky Spell Damage: +10, Single Equip, Last Available: "2023-12"
 11458	lightning-fast extremely unsafe Crimbuccaneer bombjacket	0		Weapon Damage Percent: +100, Initiative: +40, Combat Item Damage Percent: 100, Last Available: "2023-12"
-11459	stale tumbling spinning sugarplum ration	4	decent	Last Available: "2023-12"
+11459	stale spinning tumbling sugarplum ration	4	decent	Last Available: "2023-12"
 11460	normal gingerbread nylons	3	good	Last Available: "2023-12"
 11461	flavorless massive tumbling rum-soaked fruitcake	9	decent	Last Available: "2023-12"
 11462	stale lime	4	decent	Last Available: "2023-12"
 11463	spoiled gingerbread pirate	3	crappy	Last Available: "2023-12"
-11464	thick rotten tumbling olive jittery fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
+11464	rotten thick jittery tumbling olive fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
 11465	acceptable yellow mulled wine	4	good	Last Available: "2023-12"
 11466	tolerable watered-down Swedish coffee	2	good	Last Available: "2023-12"
 11467	practically non-alcoholic drinkable upside-down canteen of eggnog	1	good	Last Available: "2023-12"
 11468	practically non-alcoholic acceptable hot wine	1	good	Last Available: "2023-12"
-11469	delicious skewed narrow Jamaican coffee	3	awesome	Last Available: "2023-12"
+11469	delicious narrow skewed Jamaican coffee	3	awesome	Last Available: "2023-12"
 11470	tolerable flask of egggrog	4	good	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	upside-down pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	fancy hand-crafted yule grog	3	EPIC	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 45, Last Available: "2023-12"
-11475	tasty small wet tack	2	awesome	Last Available: "2023-12"
+11474	hand-crafted fancy yule grog	3	EPIC	Effect: "Brother Flying Burrito's Blessing", Effect Duration: 45, Last Available: "2023-12"
+11475	small tasty wet tack	2	awesome	Last Available: "2023-12"
 11476	decent whalecake	3	good	Last Available: "2023-12"
-11477	Sinatra's gunwale whalegun of the scaredy-cat of horror	0		Experience (Moxie): +5, Monster Level: -15, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11477	Sinatra's gunwale whalegun of the scaredy-cat of horror	0		Experience (Moxie): +5, Monster Level: -15, Spooky Spell Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	weak delicious upside-down and claret	2	awesome	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	mirror trick coin	0		Last Available: "2023-12"
-11481	experienced brawny Elf Guard squirtgun	0		Muscle Percent: +20, Experience: +2, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	experienced brawny Elf Guard squirtgun	0		Muscle Percent: +20, Experience: +2, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	fuchsia chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	perfumed sequin-encrusted sweater	0		Stench Resistance: +5, Last Available: "2023-12"
 11484	clever hale replica Elf Guard medal of the detective	0		Maximum HP: +20, Maximum MP: +20, Item Drop: +20, Last Available: "2023-12"
@@ -11344,7 +11344,7 @@
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	ribald foul-smelling weightlifter's barnacle-encrusted sweater	0		Muscle: +15, Stench Damage: +10, Sleaze Damage: +10, Last Available: "2023-12"
 11491	foul-smelling chaotic brainy Crimbuccaneer nose ring	0		Mysticality: +5, Spell Critical Percent: +10, Stench Damage: +10, Last Available: "2023-12"
-11492	shaking blue tumbling mirror pet anchor	0		Last Available: "2023-12"
+11492	mirror tumbling blue shaking pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	narrow Elf Guard safety bear	0		Last Available: "2023-12"
 11495	huge kraken	0		Last Available: "2023-12"
@@ -11356,28 +11356,28 @@
 11501	twirling Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	corrupted polarized pickled blurry military candy cane	0		Effect: "You're Rubber", Effect Duration: 63
 11503	oxidized super-polarized groggipop	0		Effect: "Shawarma Warm War", Effect Duration: 28
-11504	squat frightening Van der Graaf moss mace	0		Spooky Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	shaking manspreader's weightlifter's moss megaphone	0		Muscle: +15, Monster Level: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	Da Vinci's moss medal of doom	0		Experience (Mysticality): +5, Spooky Spell Damage: +50, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	friendly moss mitre of the pedagogue	0		Experience: +3, Familiar Weight: +3, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	moss mantle of courage of the boozehound	0		Spooky Resistance: +3, Booze Drop: +100, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	squat frightening Van der Graaf moss mace	0		Spooky Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	shaking manspreader's weightlifter's moss megaphone	0		Muscle: +15, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	Da Vinci's moss medal of doom	0		Experience (Mysticality): +5, Spooky Spell Damage: +50, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	friendly moss mitre of the pedagogue	0		Experience: +3, Familiar Weight: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	moss mantle of courage of the boozehound	0		Spooky Resistance: +3, Booze Drop: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	Sherlock's wool moss marlinspike	0		Cold Resistance: +1, Item Drop: +25, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	distilled spinning moss mulch	1		Last Available: "2024-12"
 11511	ionized moss floss	0		Effect: "Mana Tea", Effect Duration: 67
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	adobe adze	0		Single Equip, Last Available: "2024-12"
 11514	wobbly adobe abacus	0		Last Available: "2024-12"
-11515	twirling spinning adobe ayam	0		Last Available: "2024-12"
+11515	spinning twirling adobe ayam	0		Last Available: "2024-12"
 11516	red adobe ascot	0		Single Equip, Last Available: "2024-12"
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	dried adobe assortment	1		Effect: "Grumpy and Ornery", Effect Duration: 50, Last Available: "2024-12"
 11519	pressed adobe brittle	0		Effect: "Peppermint Bite", Effect Duration: 57
-11520	twirling rock-hard Herculean sage crepe paper phrygian cap	0		Mysticality Percent: +10, Experience (Muscle): +1, Damage Reduction: 5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	twirling rock-hard Herculean sage crepe paper phrygian cap	0		Mysticality Percent: +10, Experience (Muscle): +1, Damage Reduction: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	dog trainer's Tesla crepe paper parachute cape of James Dean	0		Experience (Moxie): +3, Experience (familiar): +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
-11522	executive hardy crepe paper pie clip of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Meat Drop: +40, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	squat perfumed chaotic boxer's crepe paper puzzle cube	0		Muscle Percent: +10, Spell Critical Percent: +10, Stench Resistance: +5, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	twirling inspector's Rosewater's crepe paper plunge camisole of the empath	0		Mysticality Percent: +30, Familiar Weight: +5, Item Drop: +15, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	jittery prompt ribald strapping crepe paper polka charm	0		Muscle: +5, Sleaze Damage: +10, Adventures: +3, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	executive hardy crepe paper pie clip of the scaredy-cat	0		Maximum HP: +50, Monster Level: -15, Meat Drop: +40, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	squat perfumed chaotic boxer's crepe paper puzzle cube	0		Muscle Percent: +10, Spell Critical Percent: +10, Stench Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	twirling inspector's Rosewater's crepe paper plunge camisole of the empath	0		Mysticality Percent: +30, Familiar Weight: +5, Item Drop: +15, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	jittery prompt ribald strapping crepe paper polka charm	0		Muscle: +5, Sleaze Damage: +10, Adventures: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	mixed crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	magnetized activated crepe paper peanut candy	0		Effect: "Mushroom Magicalness", Effect Duration: 60
 11528	lion tamer's wholesome petrified wood war pike	0		Maximum HP Percent: +10, Experience (familiar): +2, Last Available: "2025-12"
@@ -11390,15 +11390,15 @@
 11535	denatured flattened super-altered petrified wood wafer praline	0		Effect: "Turkey-Agitated", Effect Duration: 20
 11536	perfectly mixed spirit-forward cybeer	5	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	upside-down wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	huge encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	upside-down wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	huge encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
 11541	purple googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	greedy forbidden Crimbuccaneer war standard	0		Spell Damage Percent: +50, Meat Drop: +20, Last Available: "2023-12"
 11544	asbestos-lined grievous Elf Guard war standard	0		Weapon Damage Percent: +50, Hot Resistance: +5, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	narrow teal MacGyver's steel-toed beefcake's spring shoes	0		Muscle: +25, Damage Reduction: 9, Maximum MP: +100, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	narrow teal MacGyver's steel-toed beefcake's spring shoes	0		Muscle: +25, Damage Reduction: 9, Maximum MP: +100, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	energized ultra-soft ferns	0		Effect: "Seeing Colors", Effect Duration: 66, Last Available: "2024-02"
 11548	frozen colloidal olive crunchy brush	0		Effect: "Marinated", Effect Duration: 38, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11425,13 +11425,13 @@
 11570	spinning Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	lime green boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	stale low-calorie yam	1	decent	Last Available: "2024-05"
+11573	low-calorie stale yam	1	decent	Last Available: "2024-05"
 11574	hand-crafted practically non-alcoholic ghostly yam martini	1	EPIC	Last Available: "2024-05"
 11575	fortified drinkable sweet potato o' mine	5	good	Last Available: "2024-05"
 11576	hand-crafted weak Southern yam	2	EPIC	Last Available: "2024-05"
 11577	perfectly mixed sweet potato punch	3	EPIC	Last Available: "2024-05"
-11578	adequate super-sized lime green Mayam spinach	5	good	Last Available: "2024-05"
-11579	toothsome snack-sized huge yam and swiss	2	awesome	Last Available: "2024-05"
+11578	super-sized adequate lime green Mayam spinach	5	good	Last Available: "2024-05"
+11579	snack-sized toothsome huge yam and swiss	2	awesome	Last Available: "2024-05"
 11580	blue chaotic educational beefy yam cannon	0		Muscle: +10, Experience: +1, Spell Critical Percent: +10, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11440,7 +11440,7 @@
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	upside-down blinking Sherlock's careful yamtility belt of bravery	0		Monster Level: -10, Spooky Resistance: +5, Item Drop: +25, Lasts Until Rollover, Last Available: "2024-05"
 11587	half-sized yummy blurry yam slider	2	awesome	Last Available: "2024-05"
-11588	rotten enchanted jumbo yam mayo	5	crappy	Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2024-05"
+11588	jumbo rotten enchanted yam mayo	5	crappy	Effect: "Woad Warrior", Effect Duration: 20, Last Available: "2024-05"
 11589	adequate small yam burrito	2	good	Last Available: "2024-05"
 11590	visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11453,15 +11453,15 @@
 11598	upside-down mini kiwi aioli	0		
 11599	greedy stanky mini kiwi silicon tiepin of bravery	0		Stench Spell Damage: +25, Spooky Resistance: +5, Meat Drop: +20
 11600	olive mini kiwi tipi	0		
-11601	adequate miniature mini kiwi digitized cookies	2	good	
-11602	irresponsibly strong smooth mini kiwi intoxicating spirits	8	awesome	
+11601	miniature adequate mini kiwi digitized cookies	2	good	
+11602	smooth irresponsibly strong mini kiwi intoxicating spirits	8	awesome	
 11603	non-oxidized cold-filtered mini kiwi antimilitaristic hippy petition	0		Effect: "Starry-Eyed", Effect Duration: 11
 11604	extra-warmed mini kiwi illicit antibiotic	0		Effect: "It's Electric!", Effect Duration: 57
 11605	scorching careful mini kiwi whipping stick	0		Monster Level: -10, Hot Damage: +25
 11606	ghostly mini kiwi icepick of courage	0		Spooky Resistance: +3
 11607	ionized polymerized mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "The Magic of Sharing", Effect Duration: 18
 11608	upside-down packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	protogenetic chunklet (synapse)	0		
 11611	tumbling protogenetic chunklet (muscle)	0		
 11612	upside-down protogenetic chunklet (flagellum)	0		
@@ -11488,7 +11488,7 @@
 11633	spinning red Tina gun	0		Familiar Weight: +5
 11634	tattoo gun	0		
 11635	perfectly mixed lime green Colera Peste Nebbiolo	3	EPIC	
-11636	huge shaking longbox of Batfellow comics	0		
+11636	shaking huge longbox of Batfellow comics	0		
 11637	Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
@@ -11510,7 +11510,7 @@
 11655	soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	jittery boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	occult beefy bat wings of Calamity Jane	0		Muscle: +10, Spell Damage Percent: +25, Critical Hit Percent: +15, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	occult beefy bat wings of Calamity Jane	0		Muscle: +10, Spell Damage Percent: +25, Critical Hit Percent: +15, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	aromatic friendly monocle on a stick	0		Familiar Weight: +3, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	avaricious Sheriff badge of courage	0		Spooky Resistance: +3, Meat Drop: +30, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	ghostly Sheriff pistol of the storm of bravery	0		Maximum MP Percent: +40, Spooky Resistance: +5, Lasts Until Rollover, Last Available: "2024-10"
 11670	Sheriff moustache of the pedagogue of the brazier	0		Experience: +3, Hot Spell Damage: +25, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	Temple Grandin's photo booth supply list of the pedagogue	0		Experience: +3, Familiar Weight: +7, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	Temple Grandin's photo booth supply list of the pedagogue	0		Experience: +3, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	flavorless whirled peas	3	decent	Last Available: "2024-11"
@@ -11536,12 +11536,12 @@
 11681	quantized familiar experience	0		
 11682	quadruple-concentrated pea brittle	0		Effect: "Chalked Weapon", Effect Duration: 49, Last Available: "2024-11"
 11683	tolerable peasco	4	good	Last Available: "2024-11"
-11684	jumbo spoiled squat piece of cake	5	crappy	Last Available: "2024-11"
+11684	spoiled jumbo squat piece of cake	5	crappy	Last Available: "2024-11"
 11685	ghostly handful of split pea soup	0		Last Available: "2024-11"
 11686	shaking Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	skewed TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	censurious studded deft pirate hook	0		Damage Absorption: +80, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-12"
-11689	nasty savvy iron tricorn hat	0		Mysticality Percent: +20, Stench Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	nasty savvy iron tricorn hat	0		Mysticality Percent: +20, Stench Damage: +5, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	Fonzie's jolly roger flag	0		Experience (Moxie): +1, Lasts Until Rollover, Last Available: "2024-12"
 11691	spinning sleeping profane parrot	0		Last Available: "2024-12"
 11692	upside-down pirrrate's currrse	0		Last Available: "2024-12"
@@ -11583,7 +11583,7 @@
 11728	frightening friendly Sinatra's potato jacket	0		Experience (Moxie): +5, Familiar Weight: +3, Spooky Damage: +5, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	therapeutic military orb of the scaredy-cat	0		Monster Level: -15, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	therapeutic military orb of the scaredy-cat	0		Monster Level: -15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	liquefied chilled rum ball	0		Effect: "Human-Undead Hybrid", Effect Duration: 62
 11733	gravy skin	0		Last Available: "2024-12"
 11734	tumbling lightning-fast healthy gravyskin hat	0		Maximum HP Percent: +20, Initiative: +40, Last Available: "2024-12"
@@ -11595,21 +11595,21 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	Oprah's curative savvy perfect Christmas scarf	0		Mysticality Percent: [+20*event(December)], Maximum MP Percent: [+50*event(December)], HP Regen Min: [3*event(December)], HP Regen Max: [5*event(December)], Single Equip, Last Available: "2024-12"
-11743	smartaleck's snowman-enchanting tophat of the cougar	0		Moxie: +20, Moxie Percent: +30, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	smartaleck's snowman-enchanting tophat of the cougar	0		Moxie: +20, Moxie Percent: +30, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	denatured lime green wobbly LIDAR candle	0		Effect: "Good Motivator", Effect Duration: 12, Last Available: "2024-12"
 11745	hardy personal trainer's brawny Congressional Medal of Insanity	0		Muscle Percent: +20, Experience Percent (Muscle): +10, Maximum HP: +50, Last Available: "2024-12"
 11746	blurry maroon pumpkin spice whorl	0		Last Available: "2024-12"
-11747	acceptable boozy Easter grasshopper	5	good	Last Available: "2024-12"
+11747	boozy acceptable Easter grasshopper	5	good	Last Available: "2024-12"
 11748	bad Irish eggnog	4	decent	Last Available: "2024-12"
-11749	bad watered-down canteen of jungle juice	2	decent	Last Available: "2024-12"
+11749	watered-down bad canteen of jungle juice	2	decent	Last Available: "2024-12"
 11750	tolerable turchucken	4	good	Last Available: "2024-12"
-11751	boozy mediocre blinking mechanically-mulled cider	5	decent	Last Available: "2024-12"
+11751	mediocre boozy blinking mechanically-mulled cider	5	decent	Last Available: "2024-12"
 11752	artisanal holiday trip around the world	3	super ultra EPIC	Last Available: "2024-12"
 11753	snack-sized toothsome chocolate ostrich egg	2	awesome	Last Available: "2024-12"
-11754	stale half-sized beef and cabbage	2	decent	Last Available: "2024-12"
+11754	half-sized stale beef and cabbage	2	decent	Last Available: "2024-12"
 11755	rotten candy rations	3	crappy	Last Available: "2024-12"
 11756	jumbo spoiled bouncing double-candied yams	5	crappy	Last Available: "2024-12"
-11757	enchanted stale twirling Christmas ham	3	decent	Effect: "Eau de Tortue", Effect Duration: 30, Last Available: "2024-12"
+11757	stale enchanted twirling Christmas ham	3	decent	Effect: "Eau de Tortue", Effect Duration: 30, Last Available: "2024-12"
 11758	spoiled small holiday smorgasbord	2	crappy	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	stylish bejazzled eyepatch	0		Moxie: +25, Last Available: "2024-12"
@@ -11624,27 +11624,27 @@
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	blurry moai statuette	0		Last Available: "2024-12"
-11772	flame-wreathed crafty stylish egg gun of the early riser	0		Moxie: +25, Maximum MP: +10, Hot Spell Damage: +10, Adventures: +7, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	flame-wreathed crafty stylish egg gun of the early riser	0		Moxie: +25, Maximum MP: +10, Hot Spell Damage: +10, Adventures: +7, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	careful fortified Da Vinci's thinker's army helmet	0		Mysticality: +10, Experience (Mysticality): +5, Damage Absorption: +60, Monster Level: -10, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	huge napkin	0		Last Available: "2024-12"
-11776	rotten tiny Thanksgiving ration	1	crappy	Last Available: "2024-12"
-11777	acceptable fancy Easter eggnog	3	good	Effect: "Chock Full o' Nanites", Effect Duration: 45, Last Available: "2024-12"
-11778	dried narrow squat clovermint	1		Last Available: "2024-12"
+11776	tiny rotten Thanksgiving ration	1	crappy	Last Available: "2024-12"
+11777	fancy acceptable Easter eggnog	3	good	Effect: "Chock Full o' Nanites", Effect Duration: 45, Last Available: "2024-12"
+11778	dried squat narrow clovermint	1		Last Available: "2024-12"
 11779	Tesla baleful nylon Christmas stockings of wisdom of extreme caution	0		Mysticality: +15, Spell Damage: +25, Monster Level: -25, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	cold-filtered quadruple-oxidized deviled candy egg	0		Effect: "Knightlife", Effect Duration: 12, Last Available: "2024-12"
 11782	skewed McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	miser's Sherlock's McHugeLarge duffel bag	0		Item Drop: +25, Meat Drop: +10, Last Available: "2025-01"
-11784	horrifying Temple Grandin's McHugeLarge left pole of chilblains	0		Familiar Weight: +7, Cold Damage: +25, Spooky Damage: +25, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	nasty dangerous sage McHugeLarge right pole	0		Mysticality Percent: +10, Weapon Damage: +10, Stench Damage: +5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	smartaleck's McHugeLarge left ski of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	purple Jeselnik's rosy-cheeked McHugeLarge right ski	0		Maximum HP Percent: +30, Sleaze Damage: +25, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	horrifying Temple Grandin's McHugeLarge left pole of chilblains	0		Familiar Weight: +7, Cold Damage: +25, Spooky Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	nasty dangerous sage McHugeLarge right pole	0		Mysticality Percent: +10, Weapon Damage: +10, Stench Damage: +5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	smartaleck's McHugeLarge left ski of temperance	0		Moxie Percent: +30, Sleaze Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	purple Jeselnik's rosy-cheeked McHugeLarge right ski	0		Maximum HP Percent: +30, Sleaze Damage: +25, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	ghostly 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	compressed red eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
-11792	blurry skewed datastick	0		Last Available: "2025-12"
+11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11792	skewed blurry datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	spinning dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	purple cybervisor	0		Last Available: "2025-12"
 11804	olive retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	huge CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	skewed 3d printed server room key	0		Last Available: "2025-12"
@@ -11668,18 +11668,18 @@
 11813	dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	gray shaking dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
-11816	blurry gray skewed dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
+11816	skewed blurry gray dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
-11818	skewed olive dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
-11819	cyan narrow dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
-11820	ghostly olive dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
+11818	olive skewed dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
+11819	narrow cyan dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
+11820	olive ghostly dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	tumbling SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	blurry OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	tumbling STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
-11825	pulsating purple parity bit	0		Familiar Weight: +5
+11825	purple pulsating parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	lime green geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	lime green geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	tumbling ninja rope	0		
@@ -11706,7 +11706,7 @@
 11851	mirror stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	twirling foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
-11854	purple blurry grim cellophane	0		Combat Rate: -5
+11854	blurry purple grim cellophane	0		Combat Rate: -5
 11855	pulsating rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
@@ -11716,7 +11716,7 @@
 11861	bouncing Leprecondo	0		Last Available: "2025-03"
 11862	pickled scoop of pre-workout powder	1		Effect: "Ocelot Eyes", Effect Duration: 25, Last Available: "2025-03"
 11863	shaking table tennis ball	0		Last Available: "2025-03"
-11864	tolerable weak pint of Leprechaun Stout	2	good	Last Available: "2025-03"
+11864	weak tolerable pint of Leprechaun Stout	2	good	Last Available: "2025-03"
 11865	compressed phosphor traces	1		Effect: "Superveiny 9000", Effect Duration: 5, Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	Book of Irony	0		Skill: "Generate Irony"
@@ -11726,24 +11726,24 @@
 11871	distilled tumbling leprechaun antidepressant pill	1		Effect: "OMG WTF", Effect Duration: 15, Last Available: "2025-03"
 11872	yummy Heck ramen	4	awesome	Last Available: "2025-03"
 11873	delicious super-sized bouncing burrito	5	awesome	Last Available: "2025-03"
-11874	jumbo special spoiled small beer brat	5	crappy	Effect: "Make Meat FA$T!", Effect Duration: 5, Last Available: "2025-03"
+11874	jumbo spoiled special small beer brat	5	crappy	Effect: "Make Meat FA$T!", Effect Duration: 5, Last Available: "2025-03"
 11875	spoiled peach pie	3	crappy	Last Available: "2025-03"
 11876	half-sized adequate incredible mini-pizza	2	good	Last Available: "2025-03"
-11877	triple-distilled delicious Divine sidecar	7	awesome	Last Available: "2025-03"
+11877	delicious triple-distilled Divine sidecar	7	awesome	Last Available: "2025-03"
 11878	drinkable tangarita sidecar	3	good	Last Available: "2025-03"
 11879	artisanal gimlet sidecar	4	EPIC	Last Available: "2025-03"
 11880	delicious red vodka stratocaster sidecar	3	awesome	Last Available: "2025-03"
-11881	hand-crafted weak prussian cathouse sidecar	2	EPIC	Last Available: "2025-03"
-11882	high-proof acceptable Mon Tiki sidecar	8	good	Last Available: "2025-03"
+11881	weak hand-crafted prussian cathouse sidecar	2	EPIC	Last Available: "2025-03"
+11882	acceptable high-proof Mon Tiki sidecar	8	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	pulsating family-friendly groovy April Shower Thoughts shield	0		Moxie Percent: +10, Sleaze Resistance: +1, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	spitball	0		Last Available: "2025-04"
 11887	activated wet paper weights	0		Effect: "Seriously Mutated", Effect Duration: 13, Last Available: "2025-04"
 11888	mediocre twirling Three Sheets to the Wind	3	decent	Last Available: "2025-04"
-11889	miniature tasty enchanted pile of wet dates	2	awesome	Effect: "Patent Alacrity", Effect Duration: 15, Last Available: "2025-04"
+11889	enchanted miniature tasty pile of wet dates	2	awesome	Effect: "Patent Alacrity", Effect Duration: 15, Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
-11891	blinking gray wet blanket	0		Last Available: "2025-04"
+11891	gray blinking wet blanket	0		Last Available: "2025-04"
 11892	wholesome wet shower cap	0		Maximum HP Percent: +10, Last Available: "2025-04"
 11893	green gravedigger's wet shower shoes	0		Spooky Damage: +10, Last Available: "2025-04"
 11894	squat Socratic wet shower shorts	0		Experience (Mysticality): +1, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	sage stylish bycocket	0		Mysticality Percent: +10
 11917	gray Thwaitgold mad hatterpillar statuette	0		
 11918	upside-down spinning packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	blurry skewed flak shield	0		Damage Reduction: 9
 11921	upside-down Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11780,18 +11780,18 @@
 11925	scandalous Van der Graaf Axis fatigues	0		Sleaze Damage: +5, MP Regen Min: 5, MP Regen Max: 7
 11926	mirror spinning studded Fonzie's Axis suspenders	0		Experience (Moxie): +1, Damage Absorption: +80, Single Equip
 11927	stolen artifact	0		
-11928	blinking huge really expensive stolen artifact	0		
+11928	huge blinking really expensive stolen artifact	0		
 11929	narrow priceless stolen artifact	0		
 11930	chocolate rations	0		
-11931	huge jittery nice nylon stockings	0		
+11931	jittery huge nice nylon stockings	0		
 11932	yellow Allied Radio Backpack Pack	0		Free Pull
 11933	cyan Usain Bolt's avaricious ribald Allied Radio Backpack	0		Sleaze Damage: +10, Meat Drop: +30, Initiative: +80, Conditional Skill (Equipped): "Call in an Airstrike"
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	shaking confetti grenade	0		
-11937	normal huge ghostly narrow Skeleton Wars rations	9	good	
+11937	normal huge narrow ghostly Skeleton Wars rations	9	good	
 11938	drinkable skeleton war fuel can	4	good	
-11939	pulsating jittery skeleton war grenade	0		
+11939	jittery pulsating skeleton war grenade	0		
 11940	squat chocolate and nylons detector	0		
 11941	M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
 11942	M&ouml;bius ring	0		Last Available: "2025-08"
@@ -11803,14 +11803,14 @@
 11948	super-electrified nitrogenated tumbling yellow Life Goals Pamphlet	0		Effect: "Spiky Frozen Hair", Effect Duration: 26, Last Available: "2025-08"
 11949	hardened bully badge	0		Damage Reduction: 3, Lasts Until Rollover, Last Available: "2025-08"
 11950	green nippy time cop top hat	0		Cold Damage: +10, Last Available: "2025-08"
-11951	ghostly blinking yellow Stock Certificate	0		Last Available: "2025-08"
+11951	blinking ghostly yellow Stock Certificate	0		Last Available: "2025-08"
 11952	twisted mixed berry jelly	1		Effect: "Fishy Fortification", Effect Duration: 10, Last Available: "2025-08"
 11953	flavorless bite-sized toast with mixed berry jelly	1	decent	Last Available: "2025-08"
-11954	jumbo spoiled cup of sugar	5	crappy	Last Available: "2025-08"
+11954	spoiled jumbo cup of sugar	5	crappy	Last Available: "2025-08"
 11955	moldy Susie's cupcake	4	crappy	Last Available: "2025-08"
 11956	ghostly clock	0		Last Available: "2025-08"
 11957	careful the gun of the storm of the cheetah	0		Maximum MP Percent: +40, Monster Level: -10, Initiative: +60, Last Available: "2025-08"
-11958	acceptable fancy wine	3	good	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2025-08"
+11958	fancy acceptable wine	3	good	Effect: "Elemental Mastery", Effect Duration: 10, Last Available: "2025-08"
 11960	fuchsia really, really nice swimming trunks	0		
 11961	sand penny	0		
 11962	green undersea surveying goggles of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover
@@ -11826,22 +11826,22 @@
 11972	durable dolphin whistle	0		
 11973	lime green huge Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	dentadent of the overflowing toilet	0		Stench Spell Damage: +50
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	wobbly huge fuchsia foul-smelling Jim Carey's Da Vinci's supercool blood cubic zirconia of the pedagogue of Flo-Jo	0		Moxie Percent: +20, Experience: +3, Experience (Mysticality): +5, Monster Level: +25, Stench Damage: +10, Initiative: +100, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	wobbly huge fuchsia foul-smelling Jim Carey's Da Vinci's supercool blood cubic zirconia of the pedagogue of Flo-Jo	0		Moxie Percent: +20, Experience: +3, Experience (Mysticality): +5, Monster Level: +25, Stench Damage: +10, Initiative: +100, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	dried blood thinner	1		Last Available: "2025-10"
-12045	enchanted drinkable pheromone cocktail	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2025-10"
+12045	drinkable enchanted pheromone cocktail	3	good	Effect: "Superhuman Sarcasm", Effect Duration: 50, Last Available: "2025-10"
 12046	stale pulsating spinal tapas	3	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	blinking Usain Bolt's dance instructor's shrunken head of the dark arts	0		Experience Percent (Moxie): +10, Spell Damage Percent: +100, Initiative: +80, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	blinking Usain Bolt's dance instructor's shrunken head of the dark arts	0		Experience Percent (Moxie): +10, Spell Damage Percent: +100, Initiative: +80, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	pulsating knucklebone	0		
-12052	extra-dry drinkable tumbling Smoking Pope	5	good	
+12052	drinkable extra-dry tumbling Smoking Pope	5	good	
 12053	stale snack-sized prize turkey	2	decent	
-12054	boiled bouncing yellow wobbly medicinal gruel	1		
+12054	boiled yellow wobbly bouncing medicinal gruel	1		
 12055	normal full-sized pumpkin pie	3	good	Last Available: "2025-11"
 12056	hand-crafted vodka cranberry sauce	3	EPIC	Last Available: "2025-11"
 12057	flattened energized quadruple-altered huge yammed candy	0		Effect: "The Halls of Mysticality", Effect Duration: 37, Last Available: "2025-11"
@@ -11880,8 +11880,8 @@
 12122	up-at-dawn extra-thick Crimbo sweater	0		Adventures: +5, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	tolerable Steve Abrams' Holiday Sampler Beer	3	good	Last Available: "2025-12"
-12125	twirling gray crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	artisanal fancy triple-distilled bottle of prize-winning rum	8	EPIC	Effect: "Hagg-ard", Effect Duration: 5, Last Available: "2025-12"
+12125	gray twirling crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
+12126	triple-distilled artisanal fancy bottle of prize-winning rum	8	EPIC	Effect: "Hagg-ard", Effect Duration: 5, Last Available: "2025-12"
 12127	frosty sharpshooter's Socratic Santa-Slayer medal	0		Experience (Mysticality): +1, Critical Hit Percent: +10, Cold Spell Damage: +10, Single Equip, Last Available: "2025-12"
 12128	twirling Skull of Claus	0		Last Available: "2025-12"
 12129	pickled ionized boiling bone marrow	0		Effect: "Mer-kinny Flavor", Effect Duration: 44, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	polymerized boiled nitrogenated narrow boiling synovial fluid	0		Effect: "Taurus Rising", Effect Duration: 28, Last Available: "2025-12"
 12132	mirror clever arcane researcher's Newton's smoldering vertebra	0		Experience (Mysticality): +3, Experience Percent (Mysticality): +10, Maximum MP: +20, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	knitted sizzling hot boning knife of the businessman	0		Hot Damage: +10, Cold Resistance: +3, Meat Drop: +50, Single Equip, Last Available: "2025-12"
 12138	scandalous shellacked fistbone of dire peril	0		Weapon Damage: +20, Damage Reduction: 7, Sleaze Damage: +5, Last Available: "2025-12"
 12139	Usain Bolt's Sherlock's lard-coated burnt bone belt	0		Sleaze Spell Damage: +25, Item Drop: +25, Initiative: +80, Single Equip, Last Available: "2025-12"
 12140	scorched skull trophy of the storm	0		Maximum MP Percent: +40, Last Available: "2025-12"
-12141	yummy jumbo squat shaking wobbly maroon wing bone	5	awesome	Last Available: "2025-12"
+12141	yummy jumbo squat maroon wobbly shaking wing bone	5	awesome	Last Available: "2025-12"
 12142	acceptable weak skeleton venom	4	good	Last Available: "2025-12"
 12143	dried baked bone meal	1		Last Available: "2025-12"
 12144	lime green narrow smartaleck's plastic skeleton rib cage	0		Moxie Percent: +30, Last Available: "2025-12"
@@ -11926,17 +11926,17 @@
 12168	gravedigger's vermiculite shield of mayonnaise	0		Spooky Damage: +10, Sleaze Spell Damage: +50, Damage Reduction: 9, Last Available: "2025-12"
 12169	Jim Carey's ship's lantern	0		Monster Level: +25, Last Available: "2025-12"
 12170	crafty heat-resistant harpoon pistol of the storm	0		Maximum MP Percent: +40, Maximum MP: +10, Last Available: "2025-12"
-12171	adequate diet green traditional gingerloaf	1	good	Last Available: "2025-12"
+12171	diet adequate green traditional gingerloaf	1	good	Last Available: "2025-12"
 12172	mediocre triple-distilled Scotch and eggnog	7	decent	Last Available: "2025-12"
 12173	moist alkaline counterskeleton elixir	0		Effect: "Your Interest is Peaked", Effect Duration: 65, Last Available: "2025-12"
-12174	perfectly mixed special squat &quot;salvaged&quot; wine	3	EPIC	Effect: "Ginger Snapped", Effect Duration: 25, Last Available: "2025-12"
+12174	special perfectly mixed squat &quot;salvaged&quot; wine	3	EPIC	Effect: "Ginger Snapped", Effect Duration: 25, Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	decent half-sized green wedge of prize-winning cheese	2	good	Last Available: "2025-12"
 12178	galvanized activated gummi fingerbone	0		Effect: "Sweet, Nuts", Effect Duration: 38
 12179	glimmering crystal of Calamity Jane	0		Critical Hit Percent: +15, Item Drop: +5, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11977,23 +11977,23 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	spoiled half-sized can of tuna	2	crappy	
-12227	jumbo yummy special cyan alien salad	5	awesome	Effect: "Cold Throat", Effect Duration: 5
-12228	rotten gigantic twirling ratbatatouille	9	crappy	
+12226	half-sized spoiled can of tuna	2	crappy	
+12227	yummy jumbo special cyan alien salad	5	awesome	Effect: "Cold Throat", Effect Duration: 5
+12228	gigantic rotten twirling ratbatatouille	9	crappy	
 12229	stale onigiri	4	decent	
 12230	normal huge crudit&eacute;s	3	good	
-12231	delicious huge sauced mutton	9	awesome	
+12231	huge delicious sauced mutton	9	awesome	
 12232	bland mirror hot honey ant	4	decent	
 12233	small decent tomb aspic	2	good	
 12234	toothsome later tots	3	awesome	
 12235	bland teal Frutti di Scatoletta	4	decent	Last Available: "2026-05"
 12236	flavorless fancy bouncing pulsating Pesto alla Marziano	4	decent	Effect: "Bricked-In", Effect Duration: 35, Last Available: "2026-05"
-12237	enchanted rotten blurry Arrattabbattabiata	3	crappy	Effect: "It Tickles!  It Tickles!", Effect Duration: 30, Last Available: "2026-05"
-12238	jumbo decent bouncing Orzo di Riso	5	good	Last Available: "2026-05"
+12237	rotten enchanted blurry Arrattabbattabiata	3	crappy	Effect: "It Tickles!  It Tickles!", Effect Duration: 30, Last Available: "2026-05"
+12238	decent jumbo bouncing Orzo di Riso	5	good	Last Available: "2026-05"
 12239	moldy jumbo shaking Pasta Grimavera	5	crappy	Last Available: "2026-05"
 12240	flavorless snack-sized maroon Linguini Ubriacapa	2	decent	Last Available: "2026-05"
-12241	jumbo adequate Formica e Pepe	5	good	Last Available: "2026-05"
-12242	snack-sized normal Tubetto Gelatto	2	good	Last Available: "2026-05"
+12241	adequate jumbo Formica e Pepe	5	good	Last Available: "2026-05"
+12242	normal snack-sized Tubetto Gelatto	2	good	Last Available: "2026-05"
 12243	bland Gnocci Domani	3	decent	Last Available: "2026-05"
 12244	blurry Thwaitgold wallet moth statuette	0		
 12245	scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
@@ -12017,28 +12017,28 @@
 12267	miser's flimsy plastic breastplate	0		Meat Drop: +10
 12268	weightlifter's flimsy plastic shield	0		Muscle: +15, Damage Reduction: 3
 12269	pulsating packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	squat zippy censurious Portable Laughing Stock of James Dean	0		Experience (Moxie): +3, Sleaze Resistance: +3, Initiative: +20, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	squat zippy censurious Portable Laughing Stock of James Dean	0		Experience (Moxie): +3, Sleaze Resistance: +3, Initiative: +20, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	wobbly ruddy stiffened groovy Staff of Anachronistic Churning	0		Moxie Percent: +10, Damage Reduction: 1, Maximum HP Percent: +40
 12272	miniature bland classic banana	2	decent	Last Available: "2026-07"
-12273	immense stale ghostly watermelon	7	decent	Last Available: "2026-07"
+12273	stale immense ghostly watermelon	7	decent	Last Available: "2026-07"
 12274	stale huge quince	9	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	gray Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
-12277	massive decent classic banana pie	8	good	Last Available: "2026-07"
+12277	decent massive classic banana pie	8	good	Last Available: "2026-07"
 12278	diffused blinking essential banana decoction	0		Effect: "It's Electric!", Effect Duration: 25, Last Available: "2026-07"
 12279	moist unsweetened jittery banana quintessence	0		Effect: "Powdered", Effect Duration: 39, Last Available: "2026-07"
 12280	high-proof drinkable Aesop Daiquiri	8	good	Last Available: "2026-07"
 12281	mediocre Monkey Congress	3	decent	Last Available: "2026-07"
 12282	adequate snack-sized fuchsia watermelon pie	2	good	Last Available: "2026-07"
-12283	super-alkaline concentrated jittery blinking concentrated watermelon juice	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 63, Last Available: "2026-07"
+12283	super-alkaline concentrated blinking jittery concentrated watermelon juice	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 63, Last Available: "2026-07"
 12284	extra-electrified Aqua Citrulanatae	0		Effect: "Think Win-Lose", Effect Duration: 45, Last Available: "2026-07"
 12285	practically non-alcoholic aged Melonegroni	1	awesome	Last Available: "2026-07"
 12286	acceptable gray Melonade Spritz	3	good	Last Available: "2026-07"
 12287	half-sized decent ghostly quince pie	2	good	Last Available: "2026-07"
-12288	nitrogenated irradiated quadruple-galvanized upside-down ghostly quince quaff	0		Effect: "Puzzle Fury", Effect Duration: 53, Last Available: "2026-07"
+12288	nitrogenated irradiated quadruple-galvanized ghostly upside-down quince quaff	0		Effect: "Puzzle Fury", Effect Duration: 53, Last Available: "2026-07"
 12289	extra-deionized jittery Quickquince	0		Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2026-07"
 12290	fancy smooth triple-distilled teal Quiskey Sour	8	awesome	Effect: "Enraged", Effect Duration: 45, Last Available: "2026-07"
-12291	fancy hand-crafted practically non-alcoholic yellow Quincea&ntilde;era Cooler	1	super ultra mega turbo EPIC	Effect: "Trash-Wrapped", Effect Duration: 25, Last Available: "2026-07"
+12291	hand-crafted practically non-alcoholic fancy yellow Quincea&ntilde;era Cooler	1	super ultra mega turbo EPIC	Effect: "Trash-Wrapped", Effect Duration: 25, Last Available: "2026-07"
 12292	hand-crafted Roth IPA	3	EPIC	Last Available: "2026-08"
 12293	underdraft protection of the ox of Tarzan	0		Muscle: +20, Experience (Muscle): +3, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
@@ -12060,5 +12060,5 @@
 12310	dried skewed toxic asset	1		Last Available: "2026-08"
 12311	modified mirror intangible asset	1		Effect: "Extra-Sharp Weapon", Effect Duration: 35, Last Available: "2026-08"
 12312	dehydrated liquid asset	1		Last Available: "2026-08"
-12313	blurry olive mirror gross prophet chrysalis	0		Last Available: "2026-08"
+12313	blurry mirror olive gross prophet chrysalis	0		Last Available: "2026-08"
 12314	squat twirling cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Turtle_Tamer_Mongoose_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Mongoose_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	tolerable Petite Porter	3	good	
 -2	aged Scrawny Stout	3	awesome	
 -3	drinkable Infinitesimal IPA	4	good	
--4	enchanted acceptable extra-dry eggnogtini	5	good	
+-4	acceptable enchanted extra-dry eggnogtini	5	good	
 -5	practically non-alcoholic acceptable candycaine	1	good	
--6	distilled perfectly mixed braincracker sweet	5	EPIC	
+-6	perfectly mixed distilled braincracker sweet	5	EPIC	
 -16	bad high-proof fermented honey	6	decent	
 -17	acceptable skewed moons-shine	4	good	
 -18	bad skewed gin	4	decent	
--19	tolerable fancy upside-down skewed ecto-nog	3	good	
+-19	fancy tolerable upside-down skewed ecto-nog	3	good	
 -20	tolerable fortified hot toady	5	good	
--21	watered-down tolerable hot choculate	2	good	
--49	artisanal practically non-alcoholic Cyder	1	EPIC	
+-21	tolerable watered-down hot choculate	2	good	
+-49	practically non-alcoholic artisanal Cyder	1	EPIC	
 -50	weak lousy Oil Nog	2	decent	
 -51	hand-crafted Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	hand-crafted twirling Grimacider	3	EPIC	
--59	artisanal weak Isotope Nog	2	EPIC	
+-59	weak artisanal Isotope Nog	2	EPIC	
 -60	hand-crafted weak wobbly spinning Mutagin 'n' Tonic	2	EPIC	
--70	fancy delicious Gin and Herring	4	awesome	
+-70	delicious fancy Gin and Herring	4	awesome	
 -71	tolerable Black and Tan and Red All Over	4	good	
 -72	acceptable Antarctic Ice Tea	3	good	
 -76	weak hand-crafted lime green CRIMBCO Ribbon Candy Schnapps	2	EPIC	
 -77	acceptable CRIMBCO Egg Substitute Nog Substitute	3	good	
--78	high-proof lousy CRIMBCO Extreme Braincracker Sour	6	decent	
--82	drinkable boozy Horseradish-infused Vodka	5	good	
--83	lousy practically non-alcoholic Jerkitini	1	decent	
+-78	lousy high-proof CRIMBCO Extreme Braincracker Sour	6	decent	
+-82	boozy drinkable Horseradish-infused Vodka	5	good	
+-83	practically non-alcoholic lousy Jerkitini	1	decent	
 -84	bad Desert Island Iced Tea	3	decent	
 -88	acceptable Crimbo Saketini	4	good	
 -89	hand-crafted spirit-forward Crimboku Drop	5	EPIC	
--90	watered-down tolerable Flaming Crimbo Log	2	good	
--107	practically non-alcoholic smooth lime green Fortified Eggnog Slurry	1	awesome	
--108	extra-dry special lousy Hot Buttered Rum	5	decent	
+-90	tolerable watered-down Flaming Crimbo Log	2	good	
+-107	smooth practically non-alcoholic lime green Fortified Eggnog Slurry	1	awesome	
+-108	lousy special extra-dry Hot Buttered Rum	5	decent	
 -109	weak perfectly mixed blinking Spicy Hot Chocolate	2	EPIC	

--- a/data/TCRS/TCRS_Turtle_Tamer_Mongoose_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Mongoose_cafe_food.txt
@@ -2,7 +2,7 @@
 -2	normal As Jus Gezund Heit	3	good	
 -3	stale Bouillabaise Coucher Avec Moi	4	decent	
 -7	adequate gumdrop chow mein	4	good	
--8	bland tiny candy cane pizza	1	decent	
+-8	tiny bland candy cane pizza	1	decent	
 -9	rotten gingerbread stir-fry	4	crappy	
 -10	bland huge twigs and gravel	10	decent	
 -11	moldy shoots and leaves	4	crappy	
@@ -16,30 +16,30 @@
 -61	rotten tumbling Candy Cane Surprise	3	crappy	
 -62	decent Grimdrop Chow Mein	3	good	
 -63	normal Grimgerbread House	3	good	
--67	rotten huge mirror Caviar Carbonara	8	crappy	
+-67	huge rotten mirror Caviar Carbonara	8	crappy	
 -68	normal fancy squat Halibut Alfredo	4	good	
--69	half-sized bland olive Red Herring Velvet Cake	2	decent	
+-69	bland half-sized olive Red Herring Velvet Cake	2	decent	
 -73	half-sized flavorless CRIMBCO Reconstituted Gruel	2	decent	
 -74	spoiled tiny New and Improved CRIMBCO Reconstituted Gruel	1	crappy	
--75	decent special CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	good	
+-75	special decent CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	4	good	
 -79	spoiled Brussels Sprout Stir-Fry	3	crappy	
 -80	spoiled Carrot, Cabbage, and Kale Pizza	3	crappy	
 -81	spoiled jumbo Turnip and Rutabaga Pie	5	crappy	
 -85	adequate green Rainbow Spider Fun Roll	4	good	
--86	immense normal Vegas Volcano Lava Roll	10	good	
+-86	normal immense Vegas Volcano Lava Roll	10	good	
 -87	stale Crazy Dragon Shogun Buddha Roll	4	decent	
--92	stale gigantic wobbly basic hot dog	9	decent	
--93	normal low-calorie savage macho dog	1	good	
+-92	gigantic stale wobbly basic hot dog	9	decent	
+-93	low-calorie normal savage macho dog	1	good	
 -94	decent one with everything	4	good	
 -95	stale sly dog	4	decent	
 -96	super-sized flavorless devil dog	5	decent	
 -97	delicious chilly dog	4	awesome	
--98	snack-sized moldy cyan ghost dog	2	crappy	
--99	fancy miniature adequate junkyard dog	2	good	
--100	gigantic toothsome wet dog	6	awesome	
+-98	moldy snack-sized cyan ghost dog	2	crappy	
+-99	miniature adequate fancy junkyard dog	2	good	
+-100	toothsome gigantic wet dog	6	awesome	
 -101	half-sized bland sleeping dog	2	decent	
 -102	snack-sized flavorless pulsating optimal dog	2	decent	
--103	diet stale video games hot dog	1	decent	
--104	flavorless shaking yellow Peppermint Nutrition Block	3	decent	
--105	immense flavorless Gingerbread Nutrition Block	7	decent	
+-103	stale diet video games hot dog	1	decent	
+-104	flavorless yellow shaking Peppermint Nutrition Block	3	decent	
+-105	flavorless immense Gingerbread Nutrition Block	7	decent	
 -106	stale olive Cinnamon Nutrition Block	4	decent	

--- a/data/TCRS/TCRS_Turtle_Tamer_Opossum.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Opossum.txt
@@ -37,15 +37,15 @@
 38	friendly Knob Goblin pants	0		Familiar Weight: +3, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	casino pass	0		
-41	mediocre twirling wobbly ice-cold Sir Schlitz	3	decent	
+41	mediocre wobbly twirling ice-cold Sir Schlitz	3	decent	
 42	hermit permit	0		
 43	worthless trinket	0		
 44	skewed worthless gewgaw	0		
 45	worthless knick-knack	0		
 46	shaking figurine	0		
-47	diet normal hot buttered roll	1	good	
+47	normal diet hot buttered roll	1	good	
 48	heart of rock and roll	0		
-49	low-calorie adequate jittery maroon bowl of cottage cheese	1	good	
+49	low-calorie adequate maroon jittery bowl of cottage cheese	1	good	
 50	Rock and Roll Legend of the sweet-tooth	0		Candy Drop: +100, Class: "Accordion Thief", Song Duration: 10
 51	shaking bouncing stanky Knob Goblin Uberpants	0		Stench Spell Damage: +25, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	shaking banjo strings	0		
@@ -57,7 +57,7 @@
 58	olive stone turtle	0		
 59	ghostly slingshot	0		
 60	teal shaking Mace of the Tortoise of incineration	0		Hot Spell Damage: +50, Class: "Turtle Tamer"
-61	miniature rotten fortune cookie	2	crappy	
+61	rotten miniature fortune cookie	2	crappy	
 62	ghostly Da Vinci's oriole-feather headdress	0		Experience (Mysticality): +5, Familiar Effect: "atk, 3xVolley, cap 3"
 63	action figure body	0		
 64	action figure head	0		
@@ -127,7 +127,7 @@
 128	hardy meat pants	0		Maximum HP: +50, Familiar Effect: "2xPotato, cap 11"
 129	toasty third-hand nunchaku	0		Hot Damage: +5
 130	personal trainer's eyepatch	0		Experience Percent (Muscle): +10, Familiar Effect: "4xBarrr, cap 8"
-131	blinking shaking frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
+131	shaking blinking frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	Meat maid body	0		
 133	Certificate of Participation	0		
 134	yellow bitchin' meatcar	0		
@@ -157,8 +157,8 @@
 158	Gnollish pie tin	0		
 159	wad of dough	0		
 160	jittery pie crust	0		
-161	flavorless low-calorie enchanted ghuol egg	1	decent	Effect: "Elbow Sauce", Effect Duration: 35
-162	normal thick ghuol egg quiche	5	good	
+161	enchanted low-calorie flavorless ghuol egg	1	decent	Effect: "Elbow Sauce", Effect Duration: 35
+162	thick normal ghuol egg quiche	5	good	
 163	Lo Pan's skeleton bone	0		Spell Critical Percent: +30
 164	smart skull	0		
 165	skewer	0		
@@ -167,15 +167,15 @@
 168	lightning-fast bone rattle	0		Initiative: +40
 169	bouncing bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	yellow lihc eye	0		
-171	bland low-calorie lihc eye pie	1	decent	
+171	low-calorie bland lihc eye pie	1	decent	
 172	spinning gnoll lips	0		
-173	ghostly squat taco shell	0		
+173	squat ghostly taco shell	0		
 174	Gnollish casserole dish	0		
 175	enchanted normal uncooked chorizo	4	good	Effect: "Icy Demeanor", Effect Duration: 50
 176	pulsating disembodied brain	0		
 177	red brainy skull	0		
 178	detective skull	0		
-179	bite-sized stale chorizo taco	1	decent	
+179	stale bite-sized chorizo taco	1	decent	
 180	aged twirling mirror ice-cold fotie	3	awesome	
 181	baseball	0		
 182	ghostly batgut	0		
@@ -195,11 +195,11 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	lightning-fast ring	0		Initiative: +40
-200	adequate lime green ghostly rat appendix kabob	3	good	
+200	adequate ghostly lime green rat appendix kabob	3	good	
 201	normal bat wing kabob	4	good	
-202	tasty big carob chunks	5	awesome	
+202	big tasty carob chunks	5	awesome	
 203	herbs	0		
-204	rotten snack-sized carob chunk cookies	2	crappy	
+204	snack-sized rotten carob chunk cookies	2	crappy	
 205	secret blend of herbs and spices	0		
 206	blinking piercing post	0		
 207	hippy herbal tea	1	awesome	
@@ -233,13 +233,13 @@
 235	scorching sharpshooter's Bigger Bugfinder Blade	0		Critical Hit Percent: +10, Hot Damage: +25
 236	spinning red Queue Du Coq cocktailcrafting kit	0		
 237	mediocre bottle of gin	4	decent	
-238	watered-down drinkable bottle of vodka	2	good	
+238	drinkable watered-down bottle of vodka	2	good	
 239	personal trainer's boxer's Orcish baseball cap	0		Muscle Percent: +10, Experience Percent (Muscle): +10, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	sinister boxer's Orcish cargo shorts	0		Muscle Percent: +10, Spell Damage: +10, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	Socratic Orcish frat-paddle	0		Experience (Mysticality): +1
 242	jumbo flavorless bouncing	5	decent	
-243	jumbo tasty skewed grapefruit	5	awesome	
-244	moldy massive grapes	10	crappy	
+243	tasty jumbo skewed grapefruit	5	awesome	
+244	massive moldy grapes	10	crappy	
 245	rotten olive	4	crappy	
 246	adequate tomato	3	good	
 247	fermenting powder	0		
@@ -249,16 +249,16 @@
 251	smooth practically non-alcoholic enchanted blinking martini	1	awesome	Effect: "Appeteyes", Effect Duration: 20
 252	artisanal bouncing bloody beer	3	EPIC	
 253	drinkable enchanted watered-down shot of schnapps	2	good	Effect: "Well Owl Be!", Effect Duration: 35
-254	boozy drinkable shot of grapefruit schnapps	5	good	
-255	special drinkable irresponsibly strong fine wine	8	good	Effect: "Alpine Mintiness", Effect Duration: 15
+254	drinkable boozy shot of grapefruit schnapps	5	good	
+255	irresponsibly strong special drinkable fine wine	8	good	Effect: "Alpine Mintiness", Effect Duration: 15
 256	artisanal distilled shot of tomato schnapps	5	EPIC	
 257	watered-down acceptable huge extra-spicy bloody mary	2	good	
 258	huge dense meat stack	0		
 259	upside-down shaking snake skin	0		
 260	normal White Citadel fries	3	good	
-261	bland low-calorie wobbly White Citadel burger	1	decent	
+261	low-calorie bland wobbly White Citadel burger	1	decent	
 262	rotten piece of wedding cake	3	crappy	
-263	flavorless special chocolate chips	3	decent	Effect: "Bubblin' Rage", Effect Duration: 20
+263	special flavorless chocolate chips	3	decent	Effect: "Bubblin' Rage", Effect Duration: 20
 264	decent skewed chocolate chip cookies	3	good	
 265	squat lime green wool satin pants	0		Cold Resistance: +1, Familiar Effect: "atk, 2xPotato, cap 10"
 266	triple-distilled acceptable lightning	9	good	
@@ -267,14 +267,14 @@
 269	lion tamer's sword	0		Experience (familiar): +2
 270	picket fence	0		
 271	compressed barbell	1		
-272	modified skewed green concentrated magicalness pill	1		
+272	modified green skewed concentrated magicalness pill	1		
 273	altered moxie weed	1		Effect: "Stinkybeard", Effect Duration: 35
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	pulsating leprechaun hatchling	0		
-277	dehydrated lime green jittery extra-strength strongness elixir	1		Effect: "Human-Human Hybrid", Effect Duration: 35
+277	dehydrated jittery lime green extra-strength strongness elixir	1		Effect: "Human-Human Hybrid", Effect Duration: 35
 278	dehydrated blue squat jug-o-magicalness	1		Effect: "Mitre Cut", Effect Duration: 5
-279	boiled upside-down spinning purple suntan lotion of moxiousness	1		Effect: "Cockroach Scurry", Effect Duration: 35
+279	boiled purple spinning upside-down suntan lotion of moxiousness	1		Effect: "Cockroach Scurry", Effect Duration: 35
 280	Pick-O-Matic lockpicks	0		
 281	blue mirror hardy gasmask	0		Maximum HP: +50, Familiar Effect: "1xBarrr, cap 12"
 282	bouncing Boris's key	0		
@@ -309,25 +309,25 @@
 311	squat hill of beans	0		
 312	Knob Goblin visor of extreme caution	0		Monster Level: -25, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	flame-retardant Crown of the Goblin King	0		Hot Resistance: +1, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	snack-sized fancy rotten bean burrito	2	crappy	Effect: "Winning Smile", Effect Duration: 45
+314	rotten snack-sized fancy bean burrito	2	crappy	Effect: "Winning Smile", Effect Duration: 45
 315	delicious bean burrito	4	awesome	
 316	decent insanely bean burrito	3	good	
 317	bland bean burrito	4	decent	
 318	yummy bite-sized bean burrito	1	awesome	
 319	toothsome insanely bean burrito	4	awesome	
-320	bland massive bat haggis	9	decent	
-321	fancy half-sized adequate menudo	2	good	Effect: "Protection from Bad Stuff", Effect Duration: 35
-322	massive tasty goat cheese	7	awesome	
-323	enchanted gigantic spoiled plain pizza	9	crappy	Effect: "Compensatory Cruelness", Effect Duration: 45
+320	massive bland bat haggis	9	decent	
+321	fancy adequate half-sized menudo	2	good	Effect: "Protection from Bad Stuff", Effect Duration: 35
+322	tasty massive goat cheese	7	awesome	
+323	gigantic enchanted spoiled plain pizza	9	crappy	Effect: "Compensatory Cruelness", Effect Duration: 45
 324	thick normal blinking sausage pizza	5	good	
-325	half-sized enchanted bland goat cheese pizza	2	decent	Effect: "Gummiskin", Effect Duration: 35
+325	bland half-sized enchanted goat cheese pizza	2	decent	Effect: "Gummiskin", Effect Duration: 35
 326	low-calorie bland mushroom pizza	1	decent	
 327	goat	0		
-328	enchanted acceptable bottle of whiskey	4	good	Effect: "Full Bottle in front of Me", Effect Duration: 40
+328	acceptable enchanted bottle of whiskey	4	good	Effect: "Full Bottle in front of Me", Effect Duration: 40
 329	foul-smelling goat beard	0		Stench Damage: +10, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	EPIC	
 331	lousy Canadian	3	decent	
-332	spoiled enchanted blinking lemon	4	crappy	Effect: "Twinkly Weapon", Effect Duration: 45
+332	enchanted spoiled blinking lemon	4	crappy	Effect: "Twinkly Weapon", Effect Duration: 45
 333	toothsome bite-sized lime	1	awesome	
 334	Usain Bolt's sabre teeth	0		Initiative: +80
 335	upside-down upside-down sabre-toothed lime cub	0		
@@ -354,7 +354,7 @@
 356	pulsating censurious snowboarder pants	0		Sleaze Resistance: +3, Familiar Effect: "1xPotato, cap 25"
 357	lime green Mountain Stream soda	0		
 358	spoiled narrow gr8ps	3	crappy	
-359	massive bland t8r tots	8	decent	
+359	bland massive t8r tots	8	decent	
 360	miner's helmet of the cheetah	0		Initiative: +60, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	MacGyver's miner's pants	0		Maximum MP: +100, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	teal deadly 7-Foot Dwarven mattock	0		Weapon Damage: +5
@@ -390,7 +390,7 @@
 392	wicked chrome helmet turtle	0		Spell Damage: +5, Familiar Effect: "cold atk, 1xFairy, cap 30"
 393	penguin skin	0		
 394	yak skin	0		
-395	upside-down blurry hippopotamus skin	0		
+395	blurry upside-down hippopotamus skin	0		
 396	resourceful penguin shorts	0		Maximum MP: +50, Familiar Effect: "cold atk, 1xGhuol, cap 30"
 397	hardy yakskin pants	0		Maximum HP: +50, Familiar Effect: "stench atk, 1xPotato, cap 35"
 398	hippopotamus pants of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xPotato, 2xGhuol, cap 32"
@@ -457,16 +457,16 @@
 459	pixel	0		
 460	wobbly pixel	0		
 461	pixel	0		
-462	ghostly maroon spinning pixel	0		
-463	jittery spinning pixel	0		
+462	spinning ghostly maroon pixel	0		
+463	spinning jittery pixel	0		
 464	pixel potion	0		
-465	upside-down wobbly pixel potion	0		
-466	upside-down ghostly pixel potion	0		
+465	wobbly upside-down pixel potion	0		
+466	ghostly upside-down pixel potion	0		
 467	moldy pixel pie	4	crappy	
 468	ruby W	0		
 469	spinning wussiness potion	0		
-470	bad extra-dry Imp Ale	5	decent	
-471	decent olive twirling hot wing	3	good	
+470	extra-dry bad Imp Ale	5	decent	
+471	decent twirling olive hot wing	3	good	
 472	skewed jittery smelly diamond-studded cane	0		Stench Spell Damage: +10, Class: "Disco Bandit"
 473	padded crutch	0		Damage Absorption: +20
 474	cast	0		
@@ -498,10 +498,10 @@
 500	Elf Farm Raffle ticket	0		
 501	flavorless blurry Elfin shortbread	3	decent	
 502	twirling pagoda plans	0		
-503	jumbo spoiled skewered cat appendix	5	crappy	
+503	spoiled jumbo skewered cat appendix	5	crappy	
 504	evil arches	0		
 505	friendly dangerous gnatwing earring	0		Weapon Damage: +10, Familiar Weight: +3
-506	rotten enchanted jumbo lime green Hell broth	5	crappy	Effect: "Expert Vacationer", Effect Duration: 30
+506	rotten jumbo enchanted lime green Hell broth	5	crappy	Effect: "Expert Vacationer", Effect Duration: 30
 507	nippy thunderrr guitarrr	0		Cold Damage: +10
 508	sonata	0		
 509	blinking Hey Deze nuts	0		
@@ -510,7 +510,7 @@
 512	Sneaky Pete's key lime	0		
 513	spoiled tumbling Boris's key lime pie	4	crappy	
 514	huge yummy Jarlsberg's key lime pie	6	awesome	
-515	tiny adequate blinking Sneaky Pete's key lime pie	1	good	
+515	adequate tiny blinking Sneaky Pete's key lime pie	1	good	
 516	Hey Deze map	0		
 517	electrified bejeweled accordion strap	0		MP Regen Min: 3, MP Regen Max: 5, Class: "Accordion Thief"
 518	huge mystery juice	0		
@@ -519,7 +519,7 @@
 521	weightlifter's kickback cookbook	0		Muscle: +15
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	enchanted delicious papaya sling	4	awesome	Effect: "Brother Smothers's Blessing", Effect Duration: 15
+524	delicious enchanted papaya sling	4	awesome	Effect: "Brother Smothers's Blessing", Effect Duration: 15
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	volleyball	0		
@@ -559,7 +559,7 @@
 561	blurry pregnant mushroom	0		
 562	ratgut	0		
 563	teal sonar-in-a-biscuit	0		
-564	delicious practically non-alcoholic blue Mad Train wine	1	awesome	
+564	practically non-alcoholic delicious blue Mad Train wine	1	awesome	
 565	Sinatra's hobo gloves	0		Experience (Moxie): +5, Single Equip
 566	red chaotic bum cheek	0		Spell Critical Percent: +10, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
@@ -567,9 +567,9 @@
 569	tiny rotten Lord of the Flies-sized fries	1	crappy	
 570	miniature moldy olive Chicken Sandwich	2	crappy	
 571	Jumbo Dr. Lucifer	1	decent	
-572	decent super-sized upside-down Children's Meal of the Damned	5	good	
+572	super-sized decent upside-down Children's Meal of the Damned	5	good	
 573	normal noodles	4	good	
-574	enchanted stale gigantic noodles	10	decent	Effect: "Moon'd", Effect Duration: 40
+574	enchanted gigantic stale noodles	10	decent	Effect: "Moon'd", Effect Duration: 40
 575	gigantic bland jittery painful penne pasta	10	decent	
 576	massive decent maroon ravioli della hippy	6	good	
 577	big bland pr0n m4nic0tti	5	decent	
@@ -618,7 +618,7 @@
 620	altered blinking thin candle	0		Effect: "Innately Wise", Effect Duration: 49
 621	mirror Warm Subject gift certificate	0		
 622	twirling awful poetry journal	0		
-623	green wobbly WA	0		
+623	wobbly green WA	0		
 624	NG	0		
 625	wang	0		
 626	Wand of Nagamar	0		
@@ -634,7 +634,7 @@
 636	meat globe	0		
 637	toaster	0		
 638	pulsating Oprah's weightlifter's asshat	0		Muscle: +15, Maximum MP Percent: +50, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	small adequate abominable snowcone	2	good	
+639	adequate small abominable snowcone	2	good	
 640	Ent cider	1	crappy	
 641	yummy toast	4	awesome	
 642	spinning skeleton key	0		
@@ -642,7 +642,7 @@
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	blurry bouncing wrapping paper	0		Last Available: "2003-12"
 646	stale upside-down fruitcake	3	decent	
-647	blurry shaking present	0		Last Available: "2004-11"
+647	shaking blurry present	0		Last Available: "2004-11"
 648	pulsating Newton's Crimbo sword	0		Experience (Mysticality): +3, Last Available: "2004-10"
 649	sharpshooter's Crimbo hat	0		Critical Hit Percent: +10, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
 650	asbestos-lined Crimbo pants	0		Hot Resistance: +5, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
@@ -664,11 +664,11 @@
 666	steel-toed steaming evil of dire peril of terror	0		Weapon Damage: +20, Damage Reduction: 9, Spooky Spell Damage: +10
 667	castle map	0		
 668	upside-down spiked femur of the blizzard	0		Cold Spell Damage: +25
-669	jumbo decent ghuol guolash	5	good	
+669	decent jumbo ghuol guolash	5	good	
 670	lihc face of the boozehound	0		Booze Drop: +100, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	Annie Oakley's Newton's grave robbing shovel	0		Experience (Mysticality): +3, Critical Hit Percent: +20
-672	decent snack-sized cranberries	2	good	
-673	delicious enchanted spinning vodka and cranberry	4	awesome	Effect: "Sweet and Yellow", Effect Duration: 40
+672	snack-sized decent cranberries	2	good	
+673	enchanted delicious spinning vodka and cranberry	4	awesome	Effect: "Sweet and Yellow", Effect Duration: 40
 674	weak acceptable skewed whiskey	2	good	
 675	friendly skull of the Bonerdagon	0		Familiar Weight: +3
 676	shaking bouncing dragonbone belt buckle	0		
@@ -678,8 +678,8 @@
 680	tolerable slap and tickle	3	good	
 681	drinkable slip 'n' slide	3	good	
 682	perfectly mixed a sump'm sump'm	3	EPIC	
-683	watered-down bad ghostly horizontal tango	2	decent	
-684	drinkable blurry ghostly pink pony	3	good	
+683	bad watered-down ghostly horizontal tango	2	decent	
+684	drinkable ghostly blurry pink pony	3	good	
 685	double-paned gravedigger's Mr. Shirt of the cougar	0		Moxie: +20, Spooky Damage: +10, Cold Resistance: +5
 686	squat brawny knuckles	0		Muscle Percent: +20
 687	alkaline triple-anodized blood of the Wereseal	0		Effect: "Eldritch Concentration", Effect Duration: 42
@@ -698,7 +698,7 @@
 701	teal floral print shirt of Gandalf	0		Spell Critical Percent: +20
 702	bouncing coconut bikini top	0		Item Drop: +5
 703	ghostly personal trainer's goth kid t-shirt	0		Experience Percent (Muscle): +10
-704	lime green blinking hamethyst	0		
+704	blinking lime green hamethyst	0		
 705	jittery baconstone	0		
 706	porquoise	0		
 707	squat pork elf goodies sack	0		
@@ -725,13 +725,13 @@
 729	skewed fishbowl	0		
 730	fishtank	0		
 731	fish hose	0		
-732	pulsating upside-down hosed tank	0		
+732	upside-down pulsating hosed tank	0		
 733	upside-down hosed fishbowl	0		
 734	toasty Van der Graaf cool makeshift SCUBA gear	0		Moxie: +5, Hot Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Adventure Underwater
 735	easter egg balloon of the empath	0		Familiar Weight: +5
 736	stone tablet (Sinister Strumming)	0		
 737	stone tablet (Squeezings of Woe)	0		
-738	pulsating fuchsia stone tablet (Really Evil Rhythm)	0		
+738	fuchsia pulsating stone tablet (Really Evil Rhythm)	0		
 739	shaking tambourine bells	0		
 740	horrifying tambourine	0		Spooky Damage: +25
 741	mirror broken skull	0		
@@ -743,13 +743,13 @@
 748	gourd potion	0		
 749	adequate warm mushroom	4	good	
 750	delicious half-sized mirror mushroom quesadilla	2	awesome	
-751	special yummy cool mushroom	3	awesome	Effect: "Browbeaten", Effect Duration: 15
+751	yummy special cool mushroom	3	awesome	Effect: "Browbeaten", Effect Duration: 15
 752	adequate cool mushroom casserole	4	good	
-753	toothsome enchanted ghostly pointy mushroom	3	awesome	Effect: "Haunted Liver", Effect Duration: 15
+753	enchanted toothsome ghostly pointy mushroom	3	awesome	Effect: "Haunted Liver", Effect Duration: 15
 754	big moldy cream of pointy mushroom soup	5	crappy	
 755	rotten mushroom	3	crappy	
 756	flavorless half-sized mushroom	2	decent	
-757	rotten tumbling mirror mushroom	4	crappy	
+757	rotten mirror tumbling mushroom	4	crappy	
 758	decent ghost cucumber	3	good	
 759	narrow dill	0		
 760	vinegar	0		
@@ -775,13 +775,13 @@
 780	scroll of pasta summoning	0		
 781	ionized galvanized spinning mafia aria	0		Effect: "Fizzier Than Light", Effect Duration: 54
 782	green Mr. Exploiter	0		Last Available: "2009-12"
-783	bouncing tumbling skewed 'Villa' document	0		
+783	bouncing skewed tumbling 'Villa' document	0		
 784	practically non-alcoholic bad Acqua Del Piatto Merlot	1	decent	Last Available: "2004-10"
 785	raffle ticket	0		
 786	flavorless strawberry	4	decent	
 787	tolerable weak bottle of rum	2	good	
 788	watered-down acceptable strawberry daiquiri	2	good	
-789	fancy hand-crafted rum and cola	3	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 10
+789	hand-crafted fancy rum and cola	3	EPIC	Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 10
 790	acceptable grog	3	good	
 791	skewed friendly Mafia bow tie of the early riser	0		Familiar Weight: +3, Adventures: +7, Last Available: "2004-10"
 792	beefcake's Golden Mr. Accessory	0		Muscle: +25, Softcore Only
@@ -789,14 +789,14 @@
 794	alkaline extra-dry teal oil of slipperiness	0		Effect: "Standard Issue Bravery", Effect Duration: 60
 795	tolerable fuchsia Acque Luride Grezze Cabernet	3	good	Last Available: "2004-10"
 796	yellow grievous experienced strapping cement shoes	0		Muscle: +5, Experience: +2, Weapon Damage Percent: +50, Last Available: "2004-10"
-797	mediocre watered-down rockin' wagon	2	decent	
+797	watered-down mediocre rockin' wagon	2	decent	
 798	drinkable distilled ocean motion	5	good	
 799	acceptable practically non-alcoholic fuzzbump	1	good	
 800	bland big bouncing poutine	5	decent	
 801	flavorless mirror Knob stir-fry	4	decent	
-804	diet moldy shaking Knoll stir-fry	1	crappy	
+804	moldy diet shaking Knoll stir-fry	1	crappy	
 805	adequate thick blurry stir-fry	5	good	
-806	special half-sized flavorless purple asparagus stir-fry	2	decent	Effect: "Thick, Sick", Effect Duration: 45
+806	flavorless half-sized special purple asparagus stir-fry	2	decent	Effect: "Thick, Sick", Effect Duration: 45
 807	bland ghostly olive stir-fry	4	decent	
 808	normal huge Knob sausage stir-fry	8	good	
 809	bite-sized moldy bat wing stir-fry	1	crappy	
@@ -804,10 +804,10 @@
 811	flavorless tofu stir-fry	4	decent	
 812	yummy fancy pr0n stir-fry	3	awesome	Effect: "Pumped Stomach", Effect Duration: 30
 813	spoiled Knob shells	3	crappy	
-814	flavorless lime green pulsating b&auml;tzle	4	decent	
+814	flavorless pulsating lime green b&auml;tzle	4	decent	
 815	tasty jittery ratini	3	awesome	
 816	moldy Knob stroganoff	3	crappy	
-817	thick decent menudo ravioli	5	good	
+817	decent thick menudo ravioli	5	good	
 818	plus sign	0		
 819	milky potion	0		
 820	blurry swirly potion	0		
@@ -831,7 +831,7 @@
 838	ghostly Oprah's Mafia stogie of the sweet-tooth	0		Maximum MP Percent: +50, Candy Drop: +100, Last Available: "2004-10"
 839	bad Maiali Sifilitici Pinot Noir	3	decent	Last Available: "2004-10"
 840	Lo Pan's personal trainer's Mafia violin case	0		Experience Percent (Muscle): +10, Spell Critical Percent: +30, Last Available: "2004-10"
-841	mediocre special tomato daiquiri	3	decent	Effect: "Block-Rockin' Beet", Effect Duration: 25
+841	special mediocre tomato daiquiri	3	decent	Effect: "Block-Rockin' Beet", Effect Duration: 25
 842	smooth squat beertini	3	awesome	
 843	mediocre green salty slug	3	decent	
 844	perfectly mixed papaya slung	3	EPIC	
@@ -885,13 +885,13 @@
 894	teal Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	olive blinking curative Ms. Accessory	0		HP Regen Min: 3, HP Regen Max: 5, Softcore Only
 896	savvy Mr. Accessory Jr. of the boozehound	0		Mysticality Percent: +20, Booze Drop: +100, Softcore Only
-897	olive jittery coffee sprite	0		Free Pull, Last Available: "2005-10"
+897	jittery olive coffee sprite	0		Free Pull, Last Available: "2005-10"
 898	squat Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	upside-down espresso maker	0		Familiar Weight: +5
 902	jittery 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	smooth weak Spasmi Dolorosi Del Rene Champagne	2	awesome	Last Available: "2004-10"
+903	weak smooth Spasmi Dolorosi Del Rene Champagne	2	awesome	Last Available: "2004-10"
 904	ruddy studded cool school Mafia knickerbockers	0		Moxie: +5, Damage Absorption: +80, Maximum HP Percent: +40, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	activated vacuum-sealed twirling Yummy Tummy bean	0		Effect: "Gummi-Grin", Effect Duration: 14
 906	boiled Vulcanized irradiated wobbly Rock Pops	0		Effect: "Celestial Body", Effect Duration: 35
@@ -915,13 +915,13 @@
 924	twirling crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	jittery dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	aerosolized alkaline Hawking's Elixir of Brilliance	0		Effect: "Superhuman Sarcasm", Effect Duration: 12
-927	tolerable fortified Ferita Del Petto Zinfandel	5	good	Last Available: "2006-12"
+927	fortified tolerable Ferita Del Petto Zinfandel	5	good	Last Available: "2006-12"
 928	up-at-dawn fuzzy bracelets	0		Adventures: +5
 929	lime green blurry chilly arse-shooting crossbow	0		Cold Damage: +5
 931	artisanal watered-down spiced rum	2	EPIC	
-932	weak delicious eggnog	2	awesome	
+932	delicious weak eggnog	2	awesome	
 933	super-sized normal candy cane	5	good	
-934	special decent gigantic gingerbread bugbear	10	good	Effect: "Block-Rockin' Beet", Effect Duration: 35
+934	special gigantic decent gingerbread bugbear	10	good	Effect: "Block-Rockin' Beet", Effect Duration: 35
 935	spinning imitation nice watch of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	upside-down menorette	0		Familiar Weight: +5, Last Available: "2004-12"
@@ -945,7 +945,7 @@
 955	family-friendly fez of etymology	0		Sleaze Resistance: +1, Familiar Effect: "1xLep, cap 30"
 956	toothsome bouncing carob chunk noodles	3	awesome	
 957	bland chorizo brownies	3	decent	
-958	half-sized flavorless spinning chocolate and tomato pizza	2	decent	
+958	flavorless half-sized spinning chocolate and tomato pizza	2	decent	
 959	flange	0		
 960	clockwork key	0		
 961	blurry silk garter snake	0		Free Pull, Last Available: "2011-12"
@@ -1003,13 +1003,13 @@
 1016	bad weak perpendicular hula	2	decent	
 1017	enchanted mediocre ducha de oro	4	decent	Effect: "Extra-Thick Blood", Effect Duration: 20
 1018	lousy wobbly narrow calle de miel	3	decent	
-1019	weak bad spinning dry vodka martini	2	decent	
+1019	bad weak spinning dry vodka martini	2	decent	
 1020	artisanal old-fashioned	4	EPIC	
 1021	drinkable tequila with training wheels	3	good	
 1022	distilled artisanal sangria	5	EPIC	
-1023	bad strong vesper	5	decent	Last Available: "2004-12"
+1023	strong bad vesper	5	decent	Last Available: "2004-12"
 1024	hand-crafted bodyslam	3	super ultra EPIC	Last Available: "2004-12"
-1025	special bad weak sangria del diablo	2	decent	Effect: "Minerva's Zen", Effect Duration: 15, Last Available: "2004-12"
+1025	bad weak special sangria del diablo	2	decent	Effect: "Minerva's Zen", Effect Duration: 15, Last Available: "2004-12"
 1026	upside-down Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1024,7 +1024,7 @@
 1037	brainy gnauga hide buckler	0		Mysticality: +5, Damage Reduction: 5
 1038	triple-electrified double-enhanced wobbly Connery's Elixir of Audacity	0		Effect: "Memento Moir&eacute;", Effect Duration: 42
 1040	Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1041	fancy lousy beer	3	decent	Effect: "Hyphemariffic", Effect Duration: 45
+1041	lousy fancy beer	3	decent	Effect: "Hyphemariffic", Effect Duration: 45
 1042	zippy string of beads	0		Initiative: +20
 1043	string of beads	0		Item Drop: +5
 1044	miser's string of beads	0		Meat Drop: +10
@@ -1035,11 +1035,11 @@
 1049	modified jittery oyster egg	1		
 1050	powdered oyster egg	1		
 1051	blinking plastic oyster egg	0		
-1052	mixed blue blinking oyster egg	1		
+1052	mixed blinking blue oyster egg	1		
 1053	distilled tumbling oyster egg	1		
 1054	mixed gray oyster egg	1		Effect: "Hairless and Airless", Effect Duration: 40
 1055	skewed plastic oyster egg	0		
-1056	dehydrated mirror upside-down puce oyster egg	1		Effect: "Uncucumbered", Effect Duration: 20
+1056	dehydrated upside-down mirror puce oyster egg	1		Effect: "Uncucumbered", Effect Duration: 20
 1057	powdered tumbling puce oyster egg	1		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 25
 1058	twisted blue puce oyster egg	1		Effect: "Deeply Ironic", Effect Duration: 25
 1059	puce plastic oyster egg	0		
@@ -1059,7 +1059,7 @@
 1073	powdered blue off-white oyster egg	1		
 1074	vaporized bouncing ghostly off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
-1076	powdered ghostly fuchsia oyster egg	1		
+1076	powdered fuchsia ghostly oyster egg	1		
 1077	diluted oyster egg	1		
 1078	denatured cyan oyster egg	1		
 1079	huge plastic oyster egg	0		
@@ -1067,7 +1067,7 @@
 1081	emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	personal raindrop	0		Free Pull, Last Available: "2005-04"
-1084	cyan mirror rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
+1084	mirror cyan rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	gray clockwork widget	0		
 1086	skewed clockwork thingamajig	0		
 1087	squat clockwork doohickey	0		
@@ -1088,7 +1088,7 @@
 1102	fuchsia targeting chip	0		
 1103	unwound clockwork grapefruit	0		
 1104	Mountie hat	0		Familiar Weight: +5
-1105	shaking spinning clockwork bartender head	0		
+1105	spinning shaking clockwork bartender head	0		
 1106	clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	jittery clockwork detective skull	0		
@@ -1115,10 +1115,10 @@
 1129	red studded sequined fez	0		Damage Absorption: +80, Familiar Effect: "1.75xLep, cap 20"
 1130	blank card	0		
 1131	squat beet	0		Last Available: "2005-12"
-1132	lime green skewed Totally Gay Claymore	0		
+1132	skewed lime green Totally Gay Claymore	0		
 1133	pulsating narrow energetic star shirt	0		Maximum MP Percent: +20
 1134	cosmetics bag	0		
-1135	dry improved pickled lime green twirling eyeliner	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 56
+1135	dry improved pickled twirling lime green eyeliner	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 56
 1136	Vulcanized blinking lipstick	0		Effect: "Kernel Panic!", Effect Duration: 28
 1137	crafty bicycle chain of the early riser	0		Maximum MP: +10, Adventures: +7
 1138	mushroom fermenting solution	0		
@@ -1130,10 +1130,10 @@
 1144	distilled drinkable mirror cool mushroom wine	5	good	
 1145	lousy practically non-alcoholic knob mushroom wine	1	decent	
 1146	perfectly mixed knoll mushroom wine	3	EPIC	
-1147	fancy irresponsibly strong mediocre skewed mushroom wine	7	decent	Effect: "Healthy, Elfy, and Wise", Effect Duration: 15
+1147	fancy mediocre irresponsibly strong skewed mushroom wine	7	decent	Effect: "Healthy, Elfy, and Wise", Effect Duration: 15
 1148	drinkable shot of flower schnapps	4	good	
 1149	stale flower petal pie	3	decent	
-1150	irresponsibly strong acceptable bottle of single-barrel whiskey	7	good	
+1150	acceptable irresponsibly strong bottle of single-barrel whiskey	7	good	
 1151	skewed up-at-dawn aromatic discarded plastic fork	0		Stench Resistance: +1, Adventures: +5
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
 1153	stale Retenez L'Herbe Pat&eacute;	3	decent	
@@ -1157,10 +1157,10 @@
 1172	asbestos box	0		
 1173	olive linoleum box	0		
 1174	spinning chrome box	0		
-1175	bouncing skewed cryptic puzzle box	0		
+1175	skewed bouncing cryptic puzzle box	0		
 1176	pulsating maroon refrigerated biohazard container	0		
 1177	magnetic field	0		
-1178	twirling bouncing potted cactus	0		
+1178	bouncing twirling potted cactus	0		
 1179	pulsating daisy	0		
 1180	blinking potted fern	0		
 1181	tulip	0		
@@ -1185,11 +1185,11 @@
 1200	immense decent mugcake	10	good	
 1201	bland urinal cake	4	decent	
 1202	small delicious Happy Birthday, Claude! cake	2	awesome	
-1203	snack-sized special rotten spinning jittery personalized birthday cake	2	crappy	Effect: "Always be Collecting", Effect Duration: 20
+1203	special snack-sized rotten spinning jittery personalized birthday cake	2	crappy	Effect: "Always be Collecting", Effect Duration: 20
 1204	yummy diet three-tiered wedding cake	1	awesome	
-1205	toothsome low-calorie babycakes	1	awesome	
+1205	low-calorie toothsome babycakes	1	awesome	
 1206	spoiled velvet cake	4	crappy	
-1207	miniature decent tumbling congratulatory cake	2	good	
+1207	decent miniature tumbling congratulatory cake	2	good	
 1208	flavorless angel-food cake	3	decent	
 1209	normal small fancy pulsating devil's-food cake	2	good	Effect: "Dilated Pupils", Effect Duration: 5
 1210	tasty snack-sized birthday party jellybean cheesecake	2	awesome	
@@ -1257,7 +1257,7 @@
 1273	fuchsia magic lamp of Tarzan	0		Experience (Muscle): +3
 1274	mixed spinning Medicinal Herb's medicinal herbs	1		Effect: "Human-Hippy Hybrid", Effect Duration: 50
 1275	purple avaricious basic meat skirt	0		Meat Drop: +30, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	bad irresponsibly strong Otorian Battle Scar	8	decent	
+1276	irresponsibly strong bad Otorian Battle Scar	8	decent	
 1277	dangerous basic meat kilt	0		Weapon Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	mirror sinister meat skirt	0		Spell Damage: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	purple crafty meat kilt	0		Maximum MP: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1301,7 +1301,7 @@
 1317	blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	small decent bouncing questionable taco	2	good	
+1320	decent small bouncing questionable taco	2	good	
 1321	teal Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	lightning-fast time helmet	0		Initiative: +40, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
@@ -1325,7 +1325,7 @@
 1342	picture of a dead guy's girlfriend	0		
 1343	blurry zombie pineal gland	0		Last Available: "2005-11"
 1344	irradiated blinking Gummi-Gnauga	0		Effect: "Brother Smothers's Blessing", Effect Duration: 53
-1345	polymerized spinning fuchsia wobbly Now and Earlier	0		Effect: "Your Eyes are Peeled!", Effect Duration: 56, Last Available: "2020-09"
+1345	polymerized wobbly fuchsia spinning Now and Earlier	0		Effect: "Your Eyes are Peeled!", Effect Duration: 56, Last Available: "2020-09"
 1346	cold-filtered gray upside-down Sugar Cog	0		Effect: "You're High as a Crow, Marty", Effect Duration: 16
 1347	loaded serum blowgun	0		Last Available: "2005-11"
 1348	empty blowgun	0		Last Available: "2005-11"
@@ -1337,7 +1337,7 @@
 1354	pile of pebbles	0		
 1355	bland bowl of oriole's nest soup	3	decent	
 1356	jittery bunny liver	0		
-1357	mediocre watered-down Mt. Noob Pale Ale	2	decent	
+1357	watered-down mediocre Mt. Noob Pale Ale	2	decent	
 1358	bouncing pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
 1360	pirate zombie robot head	0		Last Available: "2005-11"
@@ -1347,9 +1347,9 @@
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	decent small green tofurkey leg	2	good	
 1366	flavorless wobbly tofurkey gravy	3	decent	
-1367	big rotten herbal stuffing	5	crappy	
-1368	thick stale can-shaped gelatinous cranberry sauce	5	decent	
-1369	special bland half-sized squat yams	2	decent	Effect: "Hot Hands", Effect Duration: 5
+1367	rotten big herbal stuffing	5	crappy	
+1368	stale thick can-shaped gelatinous cranberry sauce	5	decent	
+1369	special half-sized bland squat yams	2	decent	Effect: "Hot Hands", Effect Duration: 5
 1370	ghostly rock-hard rhinestone cowboy shirt	0		Damage Reduction: 5
 1371	gingham blouse of incineration	0		Hot Spell Damage: +50
 1372	spinning souvenir ski t-shirt of the scaredy-cat	0		Monster Level: -15
@@ -1377,7 +1377,7 @@
 1395	teddy bear	0		Last Available: "2005-12"
 1396	experienced duck-on-a-string of the sweet-tooth	0		Experience: +2, Candy Drop: +100, Last Available: "2005-12"
 1397	huge toy soldier	0		Last Available: "2005-12"
-1398	narrow pulsating doll house	0		Last Available: "2005-12"
+1398	pulsating narrow doll house	0		Last Available: "2005-12"
 1399	Tesla toy train	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2005-12"
 1400	greasy marionette	0		Sleaze Spell Damage: +10, Last Available: "2005-12"
 1401	red sock monkey of extreme caution	0		Monster Level: -25, Last Available: "2005-12"
@@ -1387,7 +1387,7 @@
 1405	family-friendly tree skirt	0		Sleaze Resistance: +1, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	moldy small wreath-shaped Crimbo cookie	2	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	tiny rotten bell-shaped Crimbo cookie	1	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
-1408	adequate special miniature blue squat tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
+1408	miniature adequate special blue squat tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	strapping Unionize The Elves sign	0		Muscle: +5, Last Available: "2005-12"
 1410	blinking sleeping snowy owl	0		Last Available: "2005-12"
 1411	squat Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
@@ -1407,7 +1407,7 @@
 1425	skewed ice baby of courage	0		Spooky Resistance: +3, Softcore Only, Last Available: "2006-02"
 1426	tumbling blinking sinister ice pick	0		Spell Damage: +10, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	foul-smelling ice skates of the sewer	0		Stench Damage: 35, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	small bland mirror grue egg omelette	2	decent	
+1428	bland small mirror grue egg omelette	2	decent	
 1429	ghostly shaking roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1416,11 +1416,11 @@
 1434	fruit basket	0		
 1435	narrow hot pink lipstick	0		Familiar Weight: +5
 1436	hot stuffing	0		
-1437	narrow gray useless powder	0		
+1437	gray narrow useless powder	0		
 1438	super-corrupted twinkly powder	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 36
 1439	extra-ionized ionized hot powder	0		Effect: "El Vibrations", Effect Duration: 37
 1440	anodized non-vacuum-sealed non-irradiated powder	0		Effect: "Hagg-ard", Effect Duration: 32
-1441	boiled galvanized huge cyan powder	0		Effect: "A Few Extra Pounds", Effect Duration: 23
+1441	boiled galvanized cyan huge powder	0		Effect: "A Few Extra Pounds", Effect Duration: 23
 1442	double-flattened quadruple-galvanized pressed spinning stench powder	0		Effect: "Thick, Sick", Effect Duration: 48
 1443	Vulcanized wet warmed sleaze powder	0		Effect: "Pop-eyed", Effect Duration: 46
 1444	wet blinking twinkly nuggets	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 37
@@ -1432,9 +1432,9 @@
 1450	denatured tumbling twinkly wad	1		Effect: "Fever From the Flavor", Effect Duration: 15
 1451	denatured narrow hot wad	1		
 1452	compressed wad	1		
-1453	diluted yellow blurry narrow jittery wad	1		
+1453	diluted yellow blurry jittery narrow wad	1		
 1454	mixed spinning stench wad	1		
-1455	distilled narrow huge sleaze wad	1		Effect: "Good with the Ladies", Effect Duration: 45
+1455	distilled huge narrow sleaze wad	1		Effect: "Good with the Ladies", Effect Duration: 45
 1456	huge double daisy	0		
 1457	Goth Giant	0		
 1458	decent skewed Valentine's Day cake	3	good	
@@ -1452,7 +1452,7 @@
 1470	lead yo-yo	0		
 1471	mirror slightly peevedbow	0		
 1472	squat sack of doorknobs	0		
-1473	upside-down cyan ball-and-chain	0		
+1473	cyan upside-down ball-and-chain	0		
 1474	upside-down automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
 1476	olive goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
@@ -1475,12 +1475,12 @@
 1493	wobbly hale ridiculously overelaborate ninja weapon of the overflowing toilet	0		Maximum HP: +20, Stench Spell Damage: +50
 1494	ionized moist pulsating twirling sugar-coated pine cone	0		Effect: "Become Intensely interested", Effect Duration: 61, Last Available: "2020-09"
 1495	fuchsia Usain Bolt's curative traffic cone	0		Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
-1496	drinkable watered-down gloomy mushroom wine	2	good	
+1496	watered-down drinkable gloomy mushroom wine	2	good	
 1497	lousy mushroom wine	4	decent	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	lime green skewed whoopie cushion	0		Last Available: "2006-04"
 1500	maroon fake fake vomit	0		Last Available: "2006-04"
-1501	enhanced corrupted wobbly bouncing purple explosion-flavored chewing gum	0		Effect: "Ancestral Disapproval", Effect Duration: 43, Last Available: "2006-04"
+1501	enhanced corrupted bouncing wobbly purple explosion-flavored chewing gum	0		Effect: "Ancestral Disapproval", Effect Duration: 43, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	huge rubber emo roe	0		Last Available: "2006-04"
 1504	liquefied snowcone	0		Effect: "Astral Shell", Effect Duration: 14, Last Available: "2006-04"
@@ -1488,12 +1488,12 @@
 1506	weak mediocre calle de miel with a fly in it	2	decent	Last Available: "2006-04"
 1507	hand-crafted rockin' wagon with a fly in it	4	EPIC	Last Available: "2006-04"
 1508	aged weak perpendicular hula with a fly in it	2	awesome	Last Available: "2006-04"
-1509	practically non-alcoholic aged slap and tickle with a fly in it	1	awesome	Last Available: "2006-04"
+1509	aged practically non-alcoholic slap and tickle with a fly in it	1	awesome	Last Available: "2006-04"
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	fake hand of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-04"
 1512	twisted upside-down Knob Goblin pet-buffing spray	1		Effect: "Improprie Tea", Effect Duration: 10
 1513	powdered squat Knob Goblin learning pill	1		
-1514	vaporized blurry jittery Knob Goblin eyedrops	1		
+1514	vaporized jittery blurry Knob Goblin eyedrops	1		
 1515	vaporized shaking pulsating Knob Goblin nasal spray	1		Effect: "Savage Beast Inside", Effect Duration: 50
 1516	KWE-brand transistor radio	0		
 1518	vampire heart	0		
@@ -1534,25 +1534,25 @@
 1554	watered-down bad bottle of Lieutenant Freeman	2	decent	
 1555	acceptable weak red squat bottle of Jorge Sinsonte	2	good	
 1556	tolerable irresponsibly strong boxed champagne	10	good	
-1557	stale miniature red tumbling kumquat	2	decent	
+1557	miniature stale red tumbling kumquat	2	decent	
 1558	stale tangerine	4	decent	
 1559	tonic water	0		
 1560	bland shaking cocktail onion	4	decent	
 1561	delicious raspberry	3	awesome	
-1562	flavorless low-calorie fancy kiwi	1	decent	Effect: "Pharmaceutically Cool", Effect Duration: 40
+1562	fancy low-calorie flavorless kiwi	1	decent	Effect: "Pharmaceutically Cool", Effect Duration: 40
 1563	bad whiskey bittersweet	3	decent	
 1564	tolerable red mimosette	4	good	
-1565	weak delicious yellow tequila sunset	2	awesome	
+1565	delicious weak yellow tequila sunset	2	awesome	
 1566	watered-down mediocre zmobie	2	decent	Wiki Name: "Zmobie (drink)"
 1567	practically non-alcoholic bad gin and tonic	1	decent	
 1568	perfectly mixed narrow vodka and tonic	3	EPIC	
 1569	drinkable vodka gibson	4	good	
 1570	artisanal ghostly pulsating gibson	4	EPIC	
 1571	hand-crafted lime green parisian cathouse	4	EPIC	
-1572	weak tolerable rabbit punch	2	good	
+1572	tolerable weak rabbit punch	2	good	
 1573	mediocre caipifruta	4	decent	
 1574	tolerable teqiwila	4	good	
-1575	hand-crafted fortified jittery Divine	5	EPIC	
+1575	fortified hand-crafted jittery Divine	5	EPIC	
 1576	perfectly mixed enchanted Gordon Bennett	3	EPIC	Effect: "Woad Warrior", Effect Duration: 20
 1577	bad tangarita	4	decent	
 1578	aged mandarina colada	3	awesome	
@@ -1560,17 +1560,17 @@
 1580	bad brick road	3	decent	
 1581	drinkable shaking vodka stratocaster	4	good	
 1582	hand-crafted Neuromancer	4	EPIC	
-1583	weak lousy twirling prussian cathouse	2	decent	
+1583	lousy weak twirling prussian cathouse	2	decent	
 1584	smooth Mae West	3	awesome	
-1585	irresponsibly strong bad narrow tumbling Mon Tiki	10	decent	
+1585	irresponsibly strong bad tumbling narrow Mon Tiki	10	decent	
 1586	bad teqiwila slammer	4	decent	
 1587	super-sized adequate tumbling Knob lo mein	5	good	
-1588	bite-sized bland asparagus lo mein	1	decent	
+1588	bland bite-sized asparagus lo mein	1	decent	
 1589	stale Knoll lo mein	4	decent	
 1590	yummy gigantic lo mein	9	awesome	
-1591	adequate enchanted small wobbly olive lo mein	2	good	Effect: "Initiative and Let Die", Effect Duration: 35
-1592	rotten special snack-sized hot hi mein	2	crappy	Effect: "Meadulla Oblongota", Effect Duration: 5
-1593	special flavorless hi mein	4	decent	Effect: "Amorphous Cheer", Effect Duration: 45
+1591	adequate small enchanted wobbly olive lo mein	2	good	Effect: "Initiative and Let Die", Effect Duration: 35
+1592	rotten snack-sized special hot hi mein	2	crappy	Effect: "Meadulla Oblongota", Effect Duration: 5
+1593	flavorless special hi mein	4	decent	Effect: "Amorphous Cheer", Effect Duration: 45
 1594	thick moldy hi mein	5	crappy	
 1595	snack-sized rotten upside-down hi mein	2	crappy	
 1596	moldy sleazy hi mein	4	crappy	
@@ -1580,13 +1580,13 @@
 1600	bad tangarita with a fly in it	3	decent	
 1601	mediocre cyan mandarina colada with a fly in it	3	decent	
 1602	perfectly mixed wobbly prussian cathouse with a fly in it	3	EPIC	
-1603	tolerable extra-dry Mae West with a fly in it	5	good	
-1604	diluted bouncing upside-down astronaut ice-cream	1		Last Available: "2006-05"
+1603	extra-dry tolerable Mae West with a fly in it	5	good	
+1604	diluted upside-down bouncing astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	compressed ultimate wad	1		
 1607	diffused libation of liveliness	0		Effect: "Prince of Seaside Town", Effect Duration: 49
 1608	alkaline eyedrops of the ermine	0		Effect: "critical.enh", Effect Duration: 21
-1609	liquefied enhanced twirling red perfume of prejudice	0		Effect: "Dreadful Smell", Effect Duration: 11
+1609	liquefied enhanced red twirling perfume of prejudice	0		Effect: "Dreadful Smell", Effect Duration: 11
 1610	wet pickled deionized jittery eyedrops of the ocelot	0		Effect: "Super-Electrified", Effect Duration: 63
 1611	warmed quadruple-adjusted wobbly potent potion of potency	0		Effect: "Feroci Tea", Effect Duration: 54
 1612	polymerized magnetized upside-down concentrated cordial of concentration	0		Effect: "Phairly Balanced", Effect Duration: 38
@@ -1611,16 +1611,16 @@
 1631	jittery beer cartilage	0		
 1632	upside-down twirling Spanish fly trap	0		
 1633	squat squat Spanish fly	0		
-1634	watered-down tolerable around the world	2	good	
+1634	tolerable watered-down around the world	2	good	
 1635	scrumdiddlyumptious solution	0		
 1636	blue Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	aerosolized triple-altered extra-aerosolized lotion of hotness	0		Effect: "Abyssal Sweat", Effect Duration: 68
 1638	non-dry huge lotion of coldness	0		Effect: "Sludgesick", Effect Duration: 12
 1639	ionized lotion of spookiness	0		Effect: "Haunted Stomach", Effect Duration: 17
-1640	Vulcanized anodized shaking maroon lotion of stench	0		Effect: "Cat Class, Cat Style", Effect Duration: 42
+1640	Vulcanized anodized maroon shaking lotion of stench	0		Effect: "Cat Class, Cat Style", Effect Duration: 42
 1641	Vulcanized narrow lotion of sleaziness	0		Effect: "Seeing Colors", Effect Duration: 59
 1642	irresponsibly strong smooth blurry Grimacite Bock	10	awesome	Last Available: "2008-11"
-1643	flavorless massive wedge of gray cheese	6	decent	Last Available: "2008-11"
+1643	massive flavorless wedge of gray cheese	6	decent	Last Available: "2008-11"
 1644	fuchsia hot and sauce	0		
 1645	shaking and sauce	0		
 1646	shaking and sauce	0		
@@ -1629,11 +1629,11 @@
 1649	brick	0		Free Pull
 1650	squat milk of magnesium	0		
 1651	yummy squat foie gras	3	awesome	
-1652	corrupted olive upside-down candy brain	0		Effect: "On the Shoulders of Giants", Effect Duration: 34, Last Available: "2020-09"
+1652	corrupted upside-down olive candy brain	0		Effect: "On the Shoulders of Giants", Effect Duration: 34, Last Available: "2020-09"
 1653	fireproof scorching educational jewel-eyed wizard hat	0		Experience: +1, Hot Damage: +25, Hot Resistance: +3, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
 1654	hardy shellacked wad of Crovacite	0		Damage Reduction: 7, Maximum HP: +50
 1655	dog trainer's manspreader's collar	0		Monster Level: +10, Experience (familiar): +1
-1656	green blurry White Citadel Satisfaction Satchel	0		
+1656	blurry green White Citadel Satisfaction Satchel	0		
 1657	onion shurikens	0		
 1658	huge Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
@@ -1673,11 +1673,11 @@
 1693	ionized dry eyedrops of newt	0		Effect: "Very Clean Guns", Effect Duration: 24
 1694	nitrogenated Frogade	0		Effect: "[1701]Hip to the Jive", Effect Duration: 17
 1695	extra-nitrogenated diffused upside-down papotion of papower	0		Effect: "Aided and Abetted", Effect Duration: 37
-1696	half-sized flavorless royal jelly taco	2	decent	
+1696	flavorless half-sized royal jelly taco	2	decent	
 1697	decent tofu taco	3	good	
 1698	bland jittery jumping bean taco	3	decent	
 1699	bland catgut taco	3	decent	
-1700	bland miniature narrow goat cheese taco	2	decent	
+1700	miniature bland narrow goat cheese taco	2	decent	
 1701	rotten pr0n taco	4	crappy	
 1702	aerosolized concentrated quadruple-alkaline alphabet gum	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 24
 1703	Comma Chameleon egg	0		Free Pull
@@ -1754,7 +1754,7 @@
 1775	dishrag of the early riser	0		Adventures: +7
 1776	yummy jumbo teal stale baguette	5	awesome	
 1777	leftovers of indeterminate origin	0		
-1778	bite-sized normal wobbly dinner	1	good	
+1778	normal bite-sized wobbly dinner	1	good	
 1779	katana of courage	0		Spooky Resistance: +3
 1780	green auspicious ram stick	0		Item Drop: +10
 1781	arcane researcher's enchantlers	0		Experience Percent (Mysticality): +10, Familiar Effect: "hot atk, 1xLep, cap 28"
@@ -1766,7 +1766,7 @@
 1787	dry spinning bag of Cheat-Os	0		Effect: "Frostbeard", Effect Duration: 15
 1788	skewed unrefined Mountain Stream syrup	0		
 1789	Mob Penguin	0		
-1790	fortified smooth Ram's Face Lager	5	awesome	
+1790	smooth fortified Ram's Face Lager	5	awesome	
 1791	ram horns	0		
 1792	wobbly green sizzling Annie Oakley's Travoltan trousers of the empath	0		Critical Hit Percent: +20, Familiar Weight: +5, Hot Damage: +10, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	bouncing zippy sinister pool cue	0		Spell Damage: +10, Initiative: +20
@@ -1775,11 +1775,11 @@
 1796	skewed bone collar	0		Familiar Weight: +5
 1797	wobbly misshapen animal skeleton	0		
 1798	maroon pile of animal bones	0		
-1799	squat teal animal skull	0		
+1799	teal squat animal skull	0		
 1800	animal cranium	0		
 1801	upside-down animal jawbone	0		
 1802	maroon tumbling first cervical vertebra	0		
-1803	narrow ghostly huge second cervical vertebra	0		
+1803	huge ghostly narrow second cervical vertebra	0		
 1804	third cervical vertebra	0		
 1805	shaking fourth cervical vertebra	0		
 1806	teal fifth cervical vertebra	0		
@@ -1790,7 +1790,7 @@
 1811	third thoracic vertebra	0		
 1812	blinking fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
-1814	blinking purple sixth thoracic vertebra	0		
+1814	purple blinking sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
@@ -1832,7 +1832,7 @@
 1853	tumbling right third rib	0		
 1854	right fourth rib	0		
 1855	right fifth rib	0		
-1856	tumbling purple mirror right sixth rib	0		
+1856	mirror tumbling purple right sixth rib	0		
 1857	pulsating right seventh rib	0		
 1858	twirling ghostly right eighth rib	0		
 1859	right ninth rib	0		
@@ -1855,7 +1855,7 @@
 1876	left tibia	0		
 1877	right tibia	0		
 1878	left fibula	0		
-1879	narrow ghostly right fibula	0		
+1879	ghostly narrow right fibula	0		
 1880	left kneecap	0		
 1881	upside-down right kneecap	0		
 1882	huge left first front claw	0		
@@ -1883,7 +1883,7 @@
 1904	green supercool 5-ball of the sweet-tooth	0		Moxie Percent: +20, Candy Drop: +100
 1905	smelly 6-ball of Leguizamo	0		Monster Level: +20, Stench Spell Damage: +10
 1906	upside-down 7-ball of the brazier	0		Hot Spell Damage: +25
-1907	upside-down blue 8-ball	0		
+1907	blue upside-down 8-ball	0		
 1910	squat Usain Bolt's Jeselnik's Temple Grandin's clockwork sword	0		Familiar Weight: +7, Sleaze Damage: +25, Initiative: +80
 1911	upside-down stanky sinister clockwork staff of Tarzan	0		Experience (Muscle): +3, Spell Damage: +10, Stench Spell Damage: +25
 1912	gravedigger's Annie Oakley's clockwork crossbow of the cheetah	0		Critical Hit Percent: +20, Spooky Damage: +10, Initiative: +60
@@ -1927,7 +1927,7 @@
 1950	bottle of Vangoghbitussin	0		
 1951	fortified hand-crafted bottle of Pinot Renoir	5	EPIC	
 1952	yummy maroon desiccated apricot	3	awesome	
-1953	strong aged bouncing flute of flat champagne	5	awesome	
+1953	aged strong bouncing flute of flat champagne	5	awesome	
 1954	decent dehydrated caviar	4	good	
 1955	styrofoam peanuts	0		
 1956	weak acceptable snifter of thoroughly aged brandy	2	good	
@@ -1959,10 +1959,10 @@
 1982	MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	shaking snowy owl	0		
-1985	shaking blue scary death orb	0		
+1985	blue shaking scary death orb	0		
 1986	mind flayer	0		
 1987	undead elbow macaroni	0		
-1988	twirling shaking angry cow	0		
+1988	shaking twirling angry cow	0		
 1989	gray Cheshire bitten	0		
 1990	yo-yo	0		
 1991	rubber WWJD? bracelet	0		
@@ -1995,13 +1995,13 @@
 2018	blinking club necklace	0		
 2019	blurry cream pie	0		Free Pull
 2020	stale cherry pie	4	decent	
-2021	miniature decent strawberry pie	2	good	
+2021	decent miniature strawberry pie	2	good	
 2022	spoiled lemon meringue pie	3	crappy	
-2023	spinning green blurry Genalen&trade; Bottle	1	decent	
-2024	low-calorie special rotten mixed wildflower greens	1	crappy	Effect: "Marco Polarity", Effect Duration: 30
-2025	tiny normal handful of walnuts	1	good	
+2023	blurry green spinning Genalen&trade; Bottle	1	decent	
+2024	special low-calorie rotten mixed wildflower greens	1	crappy	Effect: "Marco Polarity", Effect Duration: 30
+2025	normal tiny handful of walnuts	1	good	
 2026	decent nutty organic salad	3	good	
-2027	massive normal red jittery super salad	7	good	
+2027	massive normal jittery red super salad	7	good	
 2028	spoiled tofu wonton	3	crappy	
 2029	hippy protest button	0		Single Equip
 2030	teal twirling hale experienced Lockenstock&trade; sandals	0		Experience: +2, Maximum HP: +20, Single Equip
@@ -2020,7 +2020,7 @@
 2043	lime green hemp net	0		
 2044	huge your father's MacGuffin diary	0		
 2045	rotten thick wobbly brain-meltingly-hot chicken wings	5	crappy	
-2046	big bland frat brats	5	decent	
+2046	bland big frat brats	5	decent	
 2047	normal upside-down knob ka-bobs	3	good	
 2049	hand-crafted can of Swiller	3	EPIC	
 2050	broken wings	0		
@@ -2029,7 +2029,7 @@
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
 2055	snake skin	0		
-2056	concentrated bouncing twirling adder bladder	0		Effect: "Greedy Resolve", Effect Duration: 15
+2056	concentrated twirling bouncing adder bladder	0		Effect: "Greedy Resolve", Effect Duration: 15
 2057	pension check	0		
 2058	skewed picnic basket	0		
 2059	chilled Black No. 2	0		Effect: "Loyal Tea", Effect Duration: 48
@@ -2087,7 +2087,7 @@
 2111	spinning tooth	0		
 2112	leaf	0		Last Available: "2011-12"
 2113	frosty wheel	0		Cold Spell Damage: +10, Last Available: "2006-12"
-2114	bouncing squat yo	0		Last Available: "2006-12"
+2114	squat bouncing yo	0		Last Available: "2006-12"
 2115	tumbling nasty prehistoric spear	0		Stench Damage: +5, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
 2117	twirling zippy stiffened fire	0		Damage Reduction: 1, Initiative: +20, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
@@ -2112,7 +2112,7 @@
 2137	jittery toy crazy train of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2006-12"
 2138	pulsating razor-tipped yo-yo	0		Last Available: "2010-12"
 2139	toy mercenary	0		Last Available: "2006-12"
-2140	bouncing ghostly length of string	0		Last Available: "2011-12"
+2140	ghostly bouncing length of string	0		Last Available: "2011-12"
 2141	toy wheel	0		Last Available: "2011-12"
 2142	block	0		Last Available: "2011-12"
 2143	felt	0		Last Available: "2011-12"
@@ -2149,14 +2149,14 @@
 2174	mossy stone sphere	0		
 2175	smooth stone sphere	0		
 2176	blurry cracked stone sphere	0		
-2177	pulsating blinking rough stone sphere	0		
+2177	blinking pulsating rough stone sphere	0		
 2178	lime green mirror obsidian dagger of bravery	0		Spooky Resistance: +5
 2179	archaeologist's notebook	0		
 2180	amulet	0		
 2181	chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
-2183	lime green squat Harold's hammer handle	0		
-2184	red spinning Harold's hammer	0		
+2183	squat lime green Harold's hammer handle	0		
+2184	spinning red Harold's hammer	0		
 2185	fuchsia Kiss the Knob apron of Tarzan	0		Experience (Muscle): +3
 2186	wobbly unlit birthday cake	0		
 2187	lit birthday cake	0		
@@ -2165,11 +2165,11 @@
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	moldy fancy blue bouncing candy stake	3	crappy	Effect: "Burning Hands", Effect Duration: 35, Last Available: "2006-12"
-2194	artisanal strong eggnog	5	EPIC	Last Available: "2006-12"
+2193	fancy moldy blue bouncing candy stake	3	crappy	Effect: "Burning Hands", Effect Duration: 35, Last Available: "2006-12"
+2194	strong artisanal eggnog	5	EPIC	Last Available: "2006-12"
 2195	special spoiled unspeakable fruitcake	3	crappy	Effect: "Prelude of Precision", Effect Duration: 15, Last Available: "2006-12"
-2196	decent low-calorie gingerbread horror	1	good	Last Available: "2006-12"
-2197	unsweetened red huge but probably evil chocolate	0		Effect: "Slimed Stomach", Effect Duration: 14, Last Available: "2006-12"
+2196	low-calorie decent gingerbread horror	1	good	Last Available: "2006-12"
+2197	unsweetened huge red but probably evil chocolate	0		Effect: "Slimed Stomach", Effect Duration: 14, Last Available: "2006-12"
 2198	stale red bat-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	tasty gray skull-shaped Crimboween cookie	3	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	rotten blinking tombstone-shaped Crimboween cookie	4	crappy	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
@@ -2192,7 +2192,7 @@
 2217	flavorless super ka-bob	3	decent	
 2218	delicious beer basted brat	3	awesome	
 2219	quilted Tropical Crimbo Sword	0		Damage Absorption: +40, Last Available: "2006-12"
-2220	pressed wobbly pulsating skewed and Crimboween candy	0		Effect: "Crocodile Tear", Effect Duration: 66, Last Available: "2020-09"
+2220	pressed wobbly skewed pulsating and Crimboween candy	0		Effect: "Crocodile Tear", Effect Duration: 66, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
 2222	green shaking liar's pants of Leguizamo of the overflowing toilet	0		Monster Level: +20, Stench Spell Damage: +50, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	reassuring sizzling juggler's balls	0		Hot Damage: +10, Spooky Resistance: +1, Softcore Only, Last Available: "2007-01"
@@ -2201,7 +2201,7 @@
 2226	Usain Bolt's flame-retardant evil eyeball pendant	0		Hot Resistance: +1, Initiative: +80, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	nitrogenated huge arse-a'fire elixir	0		Effect: "Magically Fingered", Effect Duration: 50, Last Available: "2007-01"
 2228	quantum shaking cosmic lemonade	0		Effect: "Feet of Watermelon", Effect Duration: 37, Last Available: "2007-01"
-2229	nitrogenated electrified maroon bouncing toad horn	0		Effect: "Insulated Trousers", Effect Duration: 41, Last Available: "2007-01"
+2229	nitrogenated electrified bouncing maroon toad horn	0		Effect: "Insulated Trousers", Effect Duration: 41, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	spinning mote	0		
 2232	shaking smudged alchemical recipe	0		
@@ -2214,7 +2214,7 @@
 2239	avaricious nasty bad voodoo mask	0		Stench Damage: +5, Meat Drop: +30, Familiar Effect: "1xBarrr, 1xGhuol, cap 40"
 2240	bottle of alcohol	0		
 2241	pygmy spear of Leguizamo	0		Monster Level: +20
-2242	triple-electrified warmed fuchsia upside-down pygmy pygment	0		Effect: "The Smeezingtons", Effect Duration: 48
+2242	triple-electrified warmed upside-down fuchsia pygmy pygment	0		Effect: "The Smeezingtons", Effect Duration: 48
 2243	olive baleful headhunter necktie of terror	0		Spell Damage: +25, Spooky Spell Damage: +10, Single Equip
 2244	Annie Oakley's hardy pointed stick	0		Maximum HP: +50, Critical Hit Percent: +20
 2245	fortified knobby helmet turtle	0		Damage Absorption: +60, Familiar Effect: "atk, 2xFairy, cap 5"
@@ -2240,12 +2240,12 @@
 2266	wet stunt nut stew	0		
 2267	purple Mega Gem	0		
 2268	bouncing Staff of Fats of the brazier	0		Hot Spell Damage: +25
-2269	rotten small sausage wonton	2	crappy	
+2269	small rotten sausage wonton	2	crappy	
 2270	belt of Calamity Jane of Flo-Jo	0		Critical Hit Percent: +15, Initiative: +100, Single Equip
 2271	mediocre bottle of Merlot	4	decent	
 2272	acceptable bottle of Port	4	good	
 2273	bad bottle of Pinot Noir	3	decent	
-2274	mediocre watered-down bottle of Zinfandel	2	decent	
+2274	watered-down mediocre bottle of Zinfandel	2	decent	
 2275	mediocre bottle of Marsala	3	decent	
 2276	bad upside-down bottle of Muscat	4	decent	
 2277	Fernswarthy's key	0		
@@ -2267,7 +2267,7 @@
 2293	cup of strong herbal tea	0		
 2294	cyan shaking Curiously Shiny Ancient Evil-Bashing Axe	0		
 2295	marinated stakes	0		
-2296	huge blinking knob butter	0		
+2296	blinking huge knob butter	0		
 2297	vial of ectoplasm	0		
 2298	boock of darck magicks	0		
 2299	tumbling EZ-Play Harmonica Book	0		
@@ -2309,12 +2309,12 @@
 2335	maroon rubber WWBBDD? bracelet	0		
 2336	wobbly extremely unsafe smooth pipe	0		Moxie: +15, Weapon Damage Percent: +100
 2337	pulsating reinforced beaded headband of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	rotten huge pudding	10	crappy	Wiki Name: "black pudding (food)"
-2339	drinkable high-proof Blackfly Chardonnay	7	good	
+2338	huge rotten pudding	10	crappy	Wiki Name: "black pudding (food)"
+2339	high-proof drinkable Blackfly Chardonnay	7	good	
 2340	watered-down delicious & tan	2	awesome	
 2341	yellow pepper	0		
 2342	normal spinning forest cake	3	good	
-2343	gigantic normal forest ham	10	good	
+2343	normal gigantic forest ham	10	good	
 2344	corrupted boiled irradiated filthworm hatchling scent gland	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 17
 2345	denatured filthworm drone scent gland	0		Effect: "Frosty the Hitman", Effect Duration: 64
 2346	liquefied vacuum-sealed denatured narrow filthworm royal guard scent gland	0		Effect: "Smoking like a Bandit", Effect Duration: 43
@@ -2327,7 +2327,7 @@
 2353	bejeweled pledge pin of the scaredy-cat	0		Monster Level: -15, Single Equip
 2354	squat communications windchimes	0		
 2355	double-corrupted maroon henna face paint	0		Effect: "Action", Effect Duration: 55
-2356	diffused shaking red tube of dread wax	0		Effect: "Surreally Buff", Effect Duration: 33
+2356	diffused red shaking tube of dread wax	0		Effect: "Surreally Buff", Effect Duration: 33
 2357	Tesla medical-grade Gaia beads	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 7, HP Regen Max: 10
 2358	blinking pink clay bead	0		
 2359	clay bead	0		
@@ -2347,13 +2347,13 @@
 2373	bland squat banana	4	decent	
 2374	banana peel	0		
 2375	decent banana cream pie	3	good	
-2376	artisanal strong banana daiquiri	5	EPIC	
-2377	artisanal spirit-forward bungle in the jungle	5	EPIC	
+2376	strong artisanal banana daiquiri	5	EPIC	
+2377	spirit-forward artisanal bungle in the jungle	5	EPIC	
 2378	jittery banana spritzer	0		
 2379	quadruple-denatured banana smoothie	0		Effect: "Heart of Pink", Effect Duration: 64
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	ghostly woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
-2382	bouncing gray class ring	0		
+2382	gray bouncing class ring	0		
 2383	class ring	0		
 2384	class ring	0		
 2385	narrow bottle opener belt buckle	0		Single Equip
@@ -2391,7 +2391,7 @@
 2417	supercool bounty-hunting rifle	0		Moxie Percent: +20
 2418	stanky bounty-hunting pants	0		Stench Spell Damage: +25, Familiar Effect: "1xPotato, 2xFairy, cap 25"
 2419	corrupted altered bottle of rhinoceros hormones	0		Effect: "Mistified", Effect Duration: 11
-2420	anodized fuchsia jittery teeny-tiny magic scroll	0		Effect: "Greasy Flavor", Effect Duration: 66
+2420	anodized jittery fuchsia teeny-tiny magic scroll	0		Effect: "Greasy Flavor", Effect Duration: 66
 2421	deionized wet bottle of pirate juice	0		Effect: "Cancer Rising", Effect Duration: 45
 2422	warmed irradiated pet snacks	0		Effect: "Material Witness", Effect Duration: 60
 2423	wet huge Mick's IcyVapoHotness Inhaler	0		Effect: "Speed of the Internet", Effect Duration: 14
@@ -2404,7 +2404,7 @@
 2430	wet quadruple-irradiated bag of lard	0		Effect: "Horrid, Torrid", Effect Duration: 12
 2431	alkaline bottle of Mystic Shell	0		Effect: "Devil Inside", Effect Duration: 18
 2432	deionized SPF 451 lip balm	0		Effect: "Become Intensely interested", Effect Duration: 68
-2433	alkaline teal huge bottle of antifreeze	0		Effect: "Weasels Underfoot", Effect Duration: 13
+2433	alkaline huge teal bottle of antifreeze	0		Effect: "Weasels Underfoot", Effect Duration: 13
 2434	moist wet eyedrops	0		Effect: "Adrenaline Rush", Effect Duration: 37
 2435	tarnished Dogsgotnonoz pills	0		Effect: "Your Interest is Peaked", Effect Duration: 31
 2436	dry aerosolized donkey flipbook	0		Effect: "Pronounced Potency", Effect Duration: 44
@@ -2434,8 +2434,8 @@
 2460	healthy yak toupee	0		Maximum HP Percent: +20, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	tumbling odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	miniature flavorless bowl of Bounty-Os	2	decent	
-2465	high-proof perfectly mixed Oreille Divis&eacute;e brandy	9	EPIC	
+2464	flavorless miniature bowl of Bounty-Os	2	decent	
+2465	perfectly mixed high-proof Oreille Divis&eacute;e brandy	9	EPIC	
 2466	tumbling pompadour'd puppy	0		
 2467	blinking suede shoes	0		Familiar Weight: +5
 2468	pulsating callused fingerbone	0		
@@ -2473,7 +2473,7 @@
 2500	jittery tumbling molybdenum pliers	0		
 2501	wobbly molybdenum crescent wrench	0		
 2502	pulsating Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
-2503	twirling ghostly extra-fancy ring setting	0		
+2503	ghostly twirling extra-fancy ring setting	0		
 2504	precious piercing post	0		
 2505	necklace chain	0		
 2506	blue beach glass bead	0		
@@ -2482,7 +2482,7 @@
 2509	peace-sign necklace of chilblains	0		Cold Damage: +25
 2510	perfumed crafty round sunglasses	0		Maximum MP: +10, Stench Resistance: +5, Single Equip
 2511	Frat Army FGF	0		
-2512	lime green bouncing tumbling Hippy Army MPE	0		
+2512	bouncing lime green tumbling Hippy Army MPE	0		
 2513	blurry twirling greasy spark plug earring of the pedagogue	0		Experience: +3, Sleaze Spell Damage: +10
 2514	inspector's coward's woven baling wire bracelets	0		Monster Level: -20, Item Drop: +15
 2515	inspector's gearbox necklace of wisdom	0		Mysticality: +15, Item Drop: +15
@@ -2497,18 +2497,18 @@
 2524	displaced fish	0		
 2525	moldy red fish	4	crappy	
 2526	stale fish casserole	4	decent	
-2527	enchanted flavorless super-sized fish lasagna	5	decent	Effect: "Snobby", Effect Duration: 20
+2527	enchanted super-sized flavorless fish lasagna	5	decent	Effect: "Snobby", Effect Duration: 20
 2528	twirling filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	adequate skewed gnatloaf	4	good	
 2530	big toothsome tumbling gnatloaf casserole	5	awesome	
-2531	diet moldy skewed tumbling gnat lasagna	1	crappy	
+2531	diet moldy tumbling skewed gnat lasagna	1	crappy	
 2532	lime green pork	0		
 2533	adequate tumbling pork chop sandwiches	4	good	
 2534	normal twirling pork casserole	3	good	
 2535	immense spoiled pork lasagna	9	crappy	
 2536	pulsating canopic jar	0		
 2537	teal spice	0		
-2538	yellow mirror organs	0		
+2538	mirror yellow organs	0		
 2539	teal narrow personal trainer's Ankh of Badahnkadh	0		Experience Percent (Muscle): +10, Single Equip
 2540	blurry tomb ratchet	0		
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
@@ -2545,7 +2545,7 @@
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	twirling ant sickle	0		Familiar Effect: "spooky damage, meat"
 2574	maroon ant pick	0		Familiar Effect: "cold damage, meat"
-2575	bouncing gray bronzed locust	0		
+2575	gray bouncing bronzed locust	0		
 2576	honey-dipped locust	0		
 2577	gravedigger's foul-smelling cactus quill	0		Stench Damage: +10, Spooky Damage: +10
 2578	foul-smelling sizzling Staff of the Short Order Cook of the sewer	0		Hot Damage: +10, Stench Damage: 35
@@ -2560,7 +2560,7 @@
 2587	Socratic Corporal Fennel's Lonely Clubs Club Jacket	0		Experience (Mysticality): +1
 2588	narrow auspicious Private Pepper's Lonely Hearts Club Jacket	0		Item Drop: +10
 2589	stale spinning hot date	3	decent	
-2590	weak artisanal distilled fortified wine	2	EPIC	
+2590	artisanal weak distilled fortified wine	2	EPIC	
 2591	normal tasty tart	3	good	
 2592	ghostly Knob Goblin lunchbox	0		
 2593	tasty tumbling Knob pasty	3	awesome	
@@ -2590,7 +2590,7 @@
 2617	spinning boom	0		
 2618	spinning lion tamer's Iiti Kitty phone charm	0		Experience (familiar): +2, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	thick spoiled unidentified jerky	5	crappy	
+2620	spoiled thick unidentified jerky	5	crappy	
 2621	manspreader's nasty rat mask of Tarzan	0		Experience (Muscle): +3, Monster Level: +10, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	huge occult arcane researcher's ratskin belt	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +25, Single Equip
 2623	friendly stiffened rattail whip	0		Damage Reduction: 1, Familiar Weight: +3
@@ -2608,7 +2608,7 @@
 2635	really thick bandage	0		
 2636	Da Vinci's mummy mask	0		Experience (Mysticality): +5, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	cyan banded personal trainer's gauze shorts	0		Experience Percent (Muscle): +10, Damage Absorption: +100, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
-2638	spinning bouncing red gauze hammock	0		
+2638	spinning red bouncing gauze hammock	0		
 2639	narrow cherry soda	0		
 2640	wholesome greaves of doom	0		Maximum HP Percent: +10, Spooky Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 40"
 2641	zippy beefy cowboy hat	0		Muscle: +10, Initiative: +20, Familiar Effect: "1xBarrr, 1xLep, cap 41"
@@ -2620,31 +2620,31 @@
 2647	blurry fetid feather	0		
 2648	flirtatious feather	0		
 2649	Lord Spookyraven's ear trumpet of extreme caution	0		Monster Level: -25, Single Equip
-2650	wobbly mirror bottled pixie	0		Free Pull
+2650	mirror wobbly bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	moldy snack-sized special S.T.L.T.	2	crappy	Effect: "Stimulated Body", Effect Duration: 10, Last Available: "2007-06"
 2653	tiny rotten honey-dew	1	crappy	Last Available: "2007-06"
-2654	watered-down acceptable fuchsia Xanadian	2	good	Last Available: "2007-06"
+2654	acceptable watered-down fuchsia Xanadian	2	good	Last Available: "2007-06"
 2655	super-enhanced nitrogenated bottle of absinthe	0		Effect: "Black Eyes", Effect Duration: 54, Last Available: "2007-06"
 2656	gray Jack Frost's clever Drowsy Sword	0		Maximum MP: +20, Cold Spell Damage: +50
 2657	moldy half-sized escargotsicle	2	crappy	Last Available: "2007-06"
 2658	weak artisanal bottle of realpagne	2	EPIC	Last Available: "2007-06"
 2659	reassuring albatross necklace	0		Spooky Resistance: +1, Single Equip, Last Available: "2007-06"
 2660	dried not-a-pipe	1	decent	Last Available: "2007-06"
-2661	perfectly mixed practically non-alcoholic flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
+2661	practically non-alcoholic perfectly mixed flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
 2662	jittery ball mask of the storm	0		Maximum MP Percent: +40, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
 2663	upside-down gray gravedigger's Can-Can skirt	0		Spooky Damage: +10, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	enhanced sensitive poetry journal	0		Effect: "Cold Blooded", Effect Duration: 60, Last Available: "2007-06"
-2665	oxidized liquefied ghostly pulsating bottled inspiration	0		Effect: "Can't Smell Nothin'", Effect Duration: 30, Last Available: "2007-06"
+2665	oxidized liquefied pulsating ghostly bottled inspiration	0		Effect: "Can't Smell Nothin'", Effect Duration: 30, Last Available: "2007-06"
 2666	wet upside-down bellhop bell	0		Effect: "Incensed", Effect Duration: 43, Last Available: "2007-06"
 2667	enhanced anodized upside-down spiky collar	0		Effect: "Pronounced Potency", Effect Duration: 57, Last Available: "2007-06"
-2668	pickled blinking fuchsia can-can-in-a-can	1		Effect: "Macho Profundo", Effect Duration: 25, Last Available: "2007-06"
+2668	pickled fuchsia blinking can-can-in-a-can	1		Effect: "Macho Profundo", Effect Duration: 25, Last Available: "2007-06"
 2669	dehydrated patent antipsychotics	1		Last Available: "2007-06"
-2670	dried wobbly lime green tumbling Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	tolerable fancy blinking shot of nepenthe schnapps	3	good	Effect: "Spell Transfer Complete", Effect Duration: 40, Last Available: "2007-06"
+2670	dried lime green tumbling wobbly Mariner's Friend cough drops	1		Last Available: "2007-06"
+2671	fancy tolerable blinking shot of nepenthe schnapps	3	good	Effect: "Spell Transfer Complete", Effect Duration: 40, Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	wobbly Bohemian rhapsody	0		Last Available: "2007-06"
-2674	extra-boiled electrified pressed pulsating mirror shaking bottle of cat tonic	0		Effect: "Turtle Power", Effect Duration: 65, Last Available: "2007-06"
+2674	extra-boiled electrified pressed mirror shaking pulsating bottle of cat tonic	0		Effect: "Turtle Power", Effect Duration: 65, Last Available: "2007-06"
 2675	twisted shaking handful of moss	1		Effect: "Mental A-cue-ity", Effect Duration: 40
 2676	denatured bit-o-cactus	1		
 2677	powdered protein powder	1		Effect: "Disco State of Mind", Effect Duration: 35
@@ -2665,7 +2665,7 @@
 2692	sharpshooter's driftwood sculpture of Leguizamo	0		Critical Hit Percent: +10, Monster Level: +20
 2693	lard-coated educational massive sitar	0		Experience: +1, Sleaze Spell Damage: +25
 2694	censurious healthy groovy stone baseball cap	0		Moxie Percent: +10, Maximum HP Percent: +20, Sleaze Resistance: +3, Familiar Effect: "1xVolley, cap 48"
-2695	perfectly mixed special weak cup of beer	2	EPIC	Effect: "Purpose", Effect Duration: 15
+2695	weak special perfectly mixed cup of beer	2	EPIC	Effect: "Purpose", Effect Duration: 15
 2696	red mirror ovoid thing	0		
 2697	blue duct tape	0		
 2698	duct tape wallet	0		
@@ -2695,28 +2695,28 @@
 2722	up-at-dawn family-friendly studded Staff of the Greasefire of courage	0		Damage Absorption: +80, Spooky Resistance: +3, Sleaze Resistance: +1, Adventures: +5
 2723	wicked Staff of the Grand Flamb&eacute; of vim and vigor of the scaredy-cat	0		Spell Damage: +5, Maximum HP Percent: +50, Monster Level: -15
 2724	delicious bowl of rye sprouts	3	awesome	
-2725	immense flavorless enchanted cob of corn	10	decent	Effect: "Hot Blooded", Effect Duration: 50
+2725	immense enchanted flavorless cob of corn	10	decent	Effect: "Hot Blooded", Effect Duration: 50
 2726	half-sized moldy juniper berries	2	crappy	
 2727	spoiled plum	3	crappy	
 2728	flavorless pear	3	decent	
 2729	yummy snack-sized peach	2	awesome	
 2730	tolerable blinking plum wine	3	good	
 2731	acceptable shot of pear schnapps	3	good	
-2732	tolerable high-proof blue shot of peach schnapps	9	good	
+2732	high-proof tolerable blue shot of peach schnapps	9	good	
 2733	yummy bunch of square grapes	4	awesome	
-2734	huge bland blinking brown sugar cane	8	decent	
+2734	bland huge blinking brown sugar cane	8	decent	
 2735	normal shaking sandwich of the gods	3	good	
 2736	mediocre purple Pan-Dimensional Gargle Blaster	4	decent	
 2737	twisted shaking leopard-print barbell	1	good	Effect: "Bestial Sympathy", Effect Duration: 20
 2738	pile of smoking rags	0		
 2739	alkaline panty raider camouflage	0		Effect: "Permanent Halloween", Effect Duration: 55
 2740	groovy Staff of the Walk-In Freezer of Calamity Jane of the brazier	0		Moxie Percent: +10, Critical Hit Percent: +15, Hot Spell Damage: +25
-2741	fancy weak mediocre boilermaker	2	decent	Effect: "Putting the Pro in Proletariat", Effect Duration: 20
+2741	fancy mediocre weak boilermaker	2	decent	Effect: "Putting the Pro in Proletariat", Effect Duration: 20
 2742	adequate steel lasagna	3	quest	
 2743	artisanal steel margarita	3	quest	
 2744	powdered squat steel-scented air freshener	1		
 2745	enhanced tumbling gremlin mutagen	0		Effect: "Fire Inside", Effect Duration: 31
-2746	triple-anodized green squat mirror extra-potent gremlin mutagen	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 48
+2746	triple-anodized mirror green squat extra-potent gremlin mutagen	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 48
 2747	chunk of depleted Grimacite	0		Last Available: "2011-12"
 2748	furniture dolly of horror	0		Spooky Spell Damage: +25, Single Equip
 2749	twirling lightning-fast fireproof Temple Grandin's Staff of the Grease Trap	0		Familiar Weight: +7, Hot Resistance: +3, Initiative: +40
@@ -2737,9 +2737,9 @@
 2764	jittery pulsating smelly hardy Order of the Silver Wossname of chilblains	0		Maximum HP: +50, Cold Damage: +25, Stench Spell Damage: +10, Single Equip
 2765	pulsating Harold's bell	0		
 2766	bowling ball	0		
-2767	adequate small Crimbo pie	2	good	
+2767	small adequate Crimbo pie	2	good	
 2768	rotten pear tart	3	crappy	
-2769	immense spoiled peach pie	9	crappy	
+2769	spoiled immense peach pie	9	crappy	
 2770	anodized non-anodized twirling chunk of rock salt	0		Effect: "Mushroom Magicalness", Effect Duration: 36
 2771	tarnished nitrogenated alkaline gray handful of pine needles	0		Effect: "Bilious Brawn", Effect Duration: 17
 2772	blinking steamy ruby	0		
@@ -2779,7 +2779,7 @@
 2806	dry vial of porquoise juice	0		Effect: "Patent Avarice", Effect Duration: 63
 2807	vacuum-sealed non-improved deionized mirror flask of hamethyst juice	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 57
 2808	galvanized spinning flask of baconstone juice	0		Effect: "Cold, Dead Hands", Effect Duration: 61
-2809	dry modified tumbling blurry flask of porquoise juice	0		Effect: "License to Punch", Effect Duration: 14
+2809	dry modified blurry tumbling flask of porquoise juice	0		Effect: "License to Punch", Effect Duration: 14
 2810	diffused shaking jug of hamethyst juice	0		Effect: "Sweet and Yellow", Effect Duration: 20
 2811	galvanized deionized double-nitrogenated jug of baconstone juice	0		Effect: "Fit To Be Tide", Effect Duration: 31
 2812	improved cold-filtered pulsating jug of porquoise juice	0		Effect: "Fit To Be Tide", Effect Duration: 30
@@ -2803,7 +2803,7 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	moldy digital key lime pie	3	crappy	
-2833	tiny flavorless jittery star key lime pie	1	decent	
+2833	flavorless tiny jittery star key lime pie	1	decent	
 2834	olive zippy knitted rosy-cheeked bottle-rocket crossbow	0		Maximum HP Percent: +30, Cold Resistance: +3, Initiative: +20, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	indie comic hipster glasses of dire peril	0		Weapon Damage: +20, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
@@ -2812,7 +2812,7 @@
 2839	Periodical Paintbrush of the ox	0		Muscle: +20, Softcore Only
 2840	practically non-alcoholic artisanal bottle of cooking sherry	1	EPIC	
 2841	decent thick packet of ketchup	5	good	
-2842	perfectly mixed fortified teal accidental cider	5	EPIC	
+2842	fortified perfectly mixed teal accidental cider	5	EPIC	
 2843	normal immense dire fudgesicle	9	good	
 2844	foul-smelling electrified Samson's navel ring of navel gazing of Calamity Jane	0		Experience (Muscle): +5, Critical Hit Percent: +15, Stench Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	red class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2830,7 +2830,7 @@
 2857	modified mirror seegar butt	0		Effect: "Muscularrr", Effect Duration: 24
 2858	bottled swamp gas	0		
 2859	blinking auspicious witch wart of incineration	0		Hot Spell Damage: +50, Item Drop: +10
-2860	adequate big yellow swamp muck	5	good	
+2860	big adequate yellow swamp muck	5	good	
 2861	baleful Herculean leechknife of dire peril	0		Experience (Muscle): +1, Weapon Damage: +20, Spell Damage: +25
 2862	tumbling decomposed boot	0		
 2863	double-alkaline pickled deionized pulsating dribbly candle	0		Effect: "Helvella Health", Effect Duration: 60
@@ -2910,14 +2910,14 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	small delicious Surprise Egg	2	awesome	
+2940	delicious small Surprise Egg	2	awesome	
 2941	ionized deionized wobbly Steal This Candy	0		Effect: "Fortunate Resolve", Effect Duration: 52
 2942	alkaline chilled frozen skewed chocolate filthy lucre	0		Effect: "Guts Feeling", Effect Duration: 44
 2943	super-enhanced tarnished Angry Farmer's Wife Candy	0		Effect: "Chow Downed", Effect Duration: 62
 2945	cyan coward's groovy party hat	0		Moxie Percent: +10, Monster Level: -20, Familiar Effect: "4xLep, cap 7"
 2946	crafty V for Vivala mask of the storm	0		Maximum MP Percent: +40, Maximum MP: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
-2948	perfectly mixed weak pulsating shot of rotgut	2	EPIC	
+2948	weak perfectly mixed pulsating shot of rotgut	2	EPIC	
 2949	triple-vacuum-sealed nitrogenated blue jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Warm Belly", Effect Duration: 47
 2950	jittery Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2938,21 +2938,21 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	oxidized boiled Swabbie&trade; swab	0		Effect: "Cravin' for a Ravin'", Effect Duration: 17
 2968	electrified jittery Oil of Parrrlay	0		Effect: "You Drank Fish Wine", Effect Duration: 66
-2969	enchanted adequate immense creamsicle	10	good	Effect: "Stimulated Body", Effect Duration: 25
+2969	adequate enchanted immense creamsicle	10	good	Effect: "Stimulated Body", Effect Duration: 25
 2970	aged cream stout	3	awesome	
 2971	skewed Jeselnik's curmudgel of the cheetah	0		Sleaze Damage: +25, Initiative: +60
 2972	cyan grumpy man charrrm	0		
 2973	supercool grumpy man charrrm bracelet	0		Moxie Percent: +20, Single Equip
 2974	tarrrnish charrrm	0		
 2975	squat up-at-dawn coward's tarrrnished charrrm bracelet	0		Monster Level: -20, Adventures: +5, Single Equip
-2976	lousy fortified bilge wine	5	decent	
+2976	fortified lousy bilge wine	5	decent	
 2977	blinking sage witty rapier	0		Mysticality Percent: +10
 2978	jittery up-at-dawn Newton's yohohoyo	0		Experience (Mysticality): +3, Adventures: +5
 2979	polymerized fish-liver oil	0		Effect: "In a Lather", Effect Duration: 12
 2980	booty chest charrrm	0		
 2981	blinking brainy booty chest charrrm bracelet	0		Mysticality: +5, Single Equip
 2982	skewed cannonball charrrm	0		
-2983	narrow blurry cannonball charrrm bracelet	0		Single Equip
+2983	blurry narrow cannonball charrrm bracelet	0		Single Equip
 2984	copper ha'penny charrrm	0		
 2985	copper ha'penny charrrm bracelet of the bloodbag	0		Maximum HP: +100
 2986	tongue charrrm	0		
@@ -2984,14 +2984,14 @@
 3012	shimmering rainbow sand	0		
 3013	bouncing simple key	0		
 3014	ornate key	0		
-3015	huge twirling squat gilded key	0		
+3015	squat huge twirling gilded key	0		
 3016	foot locker	0		
 3017	upside-down ornate chest	0		
-3018	spinning pulsating gilded chest	0		
+3018	pulsating spinning gilded chest	0		
 3019	all-purpose cleaner	0		
 3020	handful of sawdust	0		
 3021	teal stone triangle	0		
-3022	bouncing upside-down medium stone triangle	0		
+3022	upside-down bouncing medium stone triangle	0		
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	enchanted artisanal corpse on the beach	3	super EPIC	Effect: "Optimist Primal", Effect Duration: 40
@@ -2999,13 +2999,13 @@
 3027	mediocre skewed corpsedriver	4	decent	
 3028	hand-crafted Corpse Island iced tea	3	super EPIC	
 3029	artisanal red-headed corpse	3	EPIC	
-3030	acceptable high-proof kamicorpse-ee	8	good	
-3031	extra-dry mediocre ghostly corpsel	5	decent	
-3032	fortified hand-crafted corpsebite	5	EPIC	
+3030	high-proof acceptable kamicorpse-ee	8	good	
+3031	mediocre extra-dry ghostly corpsel	5	decent	
+3032	hand-crafted fortified corpsebite	5	EPIC	
 3033	twirling careful pirate fledges	0		Monster Level: -10
 3034	piece of thirteen	0		
 3035	super-sized flavorless pearl onion	5	decent	
-3036	normal big sea biscuit	5	good	
+3036	big normal sea biscuit	5	good	
 3037	acceptable mirror narrow bottle of rum	3	good	
 3038	artisanal bottle of black-label rum	3	EPIC	
 3039	cannonball	0		
@@ -3017,7 +3017,7 @@
 3045	delicious nanite-infested gingerbread bugbear	3	awesome	Last Available: "2007-12"
 3046	big delicious huge nanite-infested candy cane	5	awesome	Last Available: "2020-09"
 3047	normal ghostly nanite-infested fruitcake	4	good	Last Available: "2007-12"
-3048	hand-crafted weak nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
+3048	weak hand-crafted nanite-infested eggnog	2	EPIC	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	eyepatch of the cheetah	0		Initiative: +60, Familiar Effect: "spooky atk, 1xBarrr"
 3051	cutlass of wisdom	0		Mysticality: +15
@@ -3064,11 +3064,11 @@
 3092	ghostly strapping handmade hobby horse	0		Muscle: +5, Last Available: "2007-12"
 3093	grievous ball-in-a-cup	0		Weapon Damage Percent: +50, Last Available: "2007-12"
 3094	mirror hardy set of jacks	0		Maximum HP: +50, Last Available: "2007-12"
-3095	spoiled big wobbly blue laser-broiled pear	5	crappy	Last Available: "2007-12"
+3095	spoiled big blue wobbly laser-broiled pear	5	crappy	Last Available: "2007-12"
 3096	tumbling fortified polyalloy shield of the sewer	0		Damage Absorption: +60, Stench Damage: +25, Damage Reduction: 9, Last Available: "2007-12"
 3097	fish scaler	0		Last Available: "2007-12"
 3098	twirling killing feather	0		Last Available: "2007-12"
-3099	red huge ring	0		Last Available: "2007-12"
+3099	huge red ring	0		Last Available: "2007-12"
 3100	robotronic egg	0		Last Available: "2007-12"
 3101	ghostly rogue swarmer	0		Last Available: "2007-12"
 3102	sawblade fragment	0		Last Available: "2007-12"
@@ -3100,7 +3100,7 @@
 3128	marshmallow	0		
 3129	half-sized spoiled roasted marshmallow	2	crappy	
 3130	disc	0		Last Available: "2008-01"
-3131	big spoiled skewed tin cup of mulligan stew	5	crappy	
+3131	spoiled big skewed tin cup of mulligan stew	5	crappy	
 3132	Sinatra's experienced flamin' bindle	0		Experience: +2, Experience (Moxie): +5
 3133	educational freezin' bindle of the blizzard	0		Experience: +1, Cold Spell Damage: +25
 3134	stinkin' bindle of the glutton of Flo-Jo	0		Food Drop: +100, Initiative: +100
@@ -3119,7 +3119,7 @@
 3147	ghostly El Vibrato punchcard (97 holes)	0		
 3148	El Vibrato punchcard (129 holes)	0		
 3149	spinning El Vibrato punchcard (213 holes)	0		
-3150	gray shaking El Vibrato punchcard (165 holes)	0		
+3150	shaking gray El Vibrato punchcard (165 holes)	0		
 3151	El Vibrato punchcard (142 holes)	0		
 3152	El Vibrato punchcard (216 holes)	0		
 3153	El Vibrato punchcard (88 holes)	0		
@@ -3129,26 +3129,26 @@
 3157	skewed El Vibrato drone	0		
 3158	huge sparking El Vibrato drone	0		
 3159	adjusted fuchsia warm El Vibrato drone	0		Effect: "Kernel Panic!", Effect Duration: 68
-3160	frozen pulsating squat blue ghostly humming El Vibrato drone	0		Effect: "Powdered", Effect Duration: 41
+3160	frozen squat blue ghostly pulsating humming El Vibrato drone	0		Effect: "Powdered", Effect Duration: 41
 3161	alkaline El Vibrato drone	0		Effect: "Winning Smile", Effect Duration: 47
 3162	bouncing cyan El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	tumbling El Vibrato energy spear	0		
-3164	mirror red El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
+3164	red mirror El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	mirror broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
 3167	augmented El Vibrato drone	0		
 3168	boiled tumbling seal eyeball	0		Effect: "Brother Corsican's Blessing", Effect Duration: 44
-3169	super-sized decent turtle soup	5	good	Effect: "[598]A Little Bit Evil"
+3169	decent super-sized turtle soup	5	good	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	gravedigger's evil paper umbrella	0		Spooky Damage: +10
 3173	diffused twirling evil vihuela	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 30
 3174	bland evil boring spaghetti	4	decent	
 3175	adequate evil noodles	3	good	
-3176	normal miniature evil noodles	2	good	
+3176	miniature normal evil noodles	2	good	
 3177	delicious evil painful penne pasta	4	awesome	
 3178	moldy 3vi1 pr0n m4nic0tti	4	crappy	
-3179	miniature decent spinning evil ravioli della hippy	2	good	
+3179	decent miniature spinning evil ravioli della hippy	2	good	
 3180	moldy evil noodles	3	crappy	
 3181	galvanized evil potion of potency	0		Effect: "Transcendental Wind", Effect Duration: 64
 3182	warmed evil libation of liveliness	0		Effect: "Inner Warmth", Effect Duration: 23
@@ -3157,7 +3157,7 @@
 3185	extra-irradiated pressed anodized spinning blinking evil ointment of the occult	0		Effect: "Hangdog", Effect Duration: 58
 3186	moist extra-moist evil serum of sarcasm	0		Effect: "Neuromancy", Effect Duration: 54
 3187	oxidized evil philter of phorce	0		Effect: "Joy", Effect Duration: 58
-3188	fortified tolerable an evil sump'm sump'm	5	good	
+3188	tolerable fortified an evil sump'm sump'm	5	good	
 3189	smooth evil ducha de oro	3	awesome	
 3190	acceptable huge evil horizontal tango	3	good	
 3191	lousy evil roll in the hay	3	decent	
@@ -3196,8 +3196,8 @@
 3224	upside-down sewer wad	0		
 3225	acceptable teal tumbling bottle of sewage schnapps	3	good	
 3226	boozy enchanted tolerable blurry bottle of Ooze-O	5	good	Effect: "Curse of the Black Pearl Onion", Effect Duration: 10
-3227	bite-sized rotten squat C.H.U.M. chum	1	crappy	
-3228	adequate immense ghostly unfortunate dumplings	9	good	
+3227	rotten bite-sized squat C.H.U.M. chum	1	crappy	
+3228	immense adequate ghostly unfortunate dumplings	9	good	
 3229	decaying goldfish liver	0		
 3230	magnetized boiled green oil of oiliness	0		Effect: "Sewer-Drenched", Effect Duration: 69
 3231	jittery greedy tattered paper crown	0		Meat Drop: +20, Familiar Effect: "1xSombrero, cap 15"
@@ -3263,7 +3263,7 @@
 3291	secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
 3293	upside-down untamable turtle	0		
-3294	ghostly green macaroni duck	0		
+3294	green ghostly macaroni duck	0		
 3295	friendly cheez blob	0		
 3296	lime green unusual disco ball	0		
 3297	stray chihuahua	0		
@@ -3285,7 +3285,7 @@
 3313	steel-toed marinara jug	0		Damage Reduction: 9, Class: "Sauceror"
 3314	stanky makeshift castanets	0		Stench Spell Damage: +25, Class: "Disco Bandit"
 3315	tumbling MacGyver's left-handed melodica	0		Maximum MP: +100, Class: "Accordion Thief"
-3316	mixed upside-down wobbly epic wad	1	good	Effect: "Seeing Colors", Effect Duration: 15
+3316	mixed wobbly upside-down epic wad	1	good	Effect: "Seeing Colors", Effect Duration: 15
 3317	stanky bottlecap	0		Stench Spell Damage: +25, Single Equip
 3318	lion tamer's corncob pipe	0		Experience (familiar): +2, Single Equip
 3319	ghostly cyan Mr. Joe's bangles	0		Item Drop: +5, Single Equip
@@ -3296,7 +3296,7 @@
 3324	shaking Frosty's frosty mug	0		
 3325	perfectly mixed jar of fermented pickle juice	3	super ultra mega EPIC	
 3326	modified voodoo snuff	1	EPIC	
-3327	gigantic bland pulsating skewed extra-greasy slider	6	decent	
+3327	gigantic bland skewed pulsating extra-greasy slider	6	decent	
 3328	lard-coated Newton's crumpled felt fedora	0		Experience (Mysticality): +3, Sleaze Spell Damage: +25, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	twirling forbidden battered top-hat of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	shaking steel-toed Herculean shapeless wide-brimmed hat	0		Experience (Muscle): +1, Damage Reduction: 9, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3313,7 +3313,7 @@
 3341	The Six-Pack of Pain	0		
 3342	hobo monkey	0		
 3343	bindle	0		Familiar Weight: +5
-3344	cyan jittery bed of coals	0		
+3344	jittery cyan bed of coals	0		
 3345	air mattress	0		
 3346	filth-encrusted futon	0		
 3347	teal comfy coffin	0		
@@ -3323,7 +3323,7 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	energized dry llama lama gong	0		Effect: "Litterboxing", Effect Duration: 45, Last Available: "2008-06"
-3354	tasty bite-sized banana-frosted king cake	1	awesome	Last Available: "2008-08"
+3354	bite-sized tasty banana-frosted king cake	1	awesome	Last Available: "2008-08"
 3355	toasty brown plastic baby	0		Hot Damage: +5, Single Equip, Last Available: "2008-08"
 3356	green plump juicy grub	0		Last Available: "2008-06"
 3357	red shimmering moth	0		Last Available: "2008-06"
@@ -3332,13 +3332,13 @@
 3360	stinkbug	0		Last Available: "2008-06"
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	tasty tiny lime green mole mol&eacute;	1	awesome	Last Available: "2008-06"
-3364	enchanted hand-crafted Morlock's Mark Bourbon	3	EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2008-06"
+3363	tiny tasty lime green mole mol&eacute;	1	awesome	Last Available: "2008-06"
+3364	hand-crafted enchanted Morlock's Mark Bourbon	3	EPIC	Effect: "Educated (Sorta)", Effect Duration: 15, Last Available: "2008-06"
 3365	irradiated dry spinning Climate Colada	0		Effect: "Strong Spirit", Effect Duration: 16, Last Available: "2008-06"
 3366	extra-boiled chilled squat digital underground potion	0		Effect: "Jacked In", Effect Duration: 19, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
 3368	diluted blue glimmering roc feather	1	decent	Effect: "Seriously Mutated", Effect Duration: 20, Last Available: "2008-06"
-3369	pickled mirror bouncing glimmering phoenix feather	1		Effect: "Punch Another Day", Effect Duration: 15, Last Available: "2008-06"
+3369	pickled bouncing mirror glimmering phoenix feather	1		Effect: "Punch Another Day", Effect Duration: 15, Last Available: "2008-06"
 3370	boiled twirling glimmering penguin feather	1		Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2008-06"
 3371	distilled glimmering buzzard feather	1		Last Available: "2008-06"
 3372	vaporized glimmering raven feather	1		Last Available: "2008-06"
@@ -3369,7 +3369,7 @@
 3397	baleful razor-sharp Hodgman's bow tie	0		Weapon Damage Percent: +25, Spell Damage: +25, Single Equip
 3398	perfectly mixed Hodgman's blanket	3	EPIC	
 3399	delicious jar of squeeze	4	awesome	
-3400	small adequate bowl of fishysoisse	2	good	
+3400	adequate small bowl of fishysoisse	2	good	
 3401	quantum alkaline ghostly deadly lampshade	0		Effect: "Mystically Oiled", Effect Duration: 23
 3402	ionized galvanized concentrated garbage juice	0		Effect: "5 Pounds Lighter", Effect Duration: 56
 3403	lewd playing card	0		
@@ -3382,7 +3382,7 @@
 3410	red huge Annie Oakley's Hodgman's detector	0		Critical Hit Percent: +20
 3411	squat Hodgman's cane of the glutton	0		Food Drop: +100
 3412	squat Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
-3413	narrow blurry Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
+3413	blurry narrow Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
@@ -3393,7 +3393,7 @@
 3425	altered ionized vacuum-sealed ghostly garbage-juice-flavored Hob-O	0		Effect: "Berry Thorny", Effect Duration: 40
 3426	tarnished olive huge strawberry-flavored Hob-O	0		Effect: "Nightlit", Effect Duration: 66
 3427	roll of Hob-Os	0		
-3428	polarized tumbling blue Everlasting Deckswabber	0		Effect: "Macho, Macho Dog", Effect Duration: 29
+3428	polarized blue tumbling Everlasting Deckswabber	0		Effect: "Macho, Macho Dog", Effect Duration: 29
 3430	blurry bindle of joy	0		
 3431	cotton candy cocoon	0		Free Pull, Last Available: "2008-08"
 3432	cotton candy cordial	0		Familiar Weight: +5, Last Available: "2008-08"
@@ -3419,11 +3419,11 @@
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	fuchsia cotton candy plug	0		Last Available: "2008-08"
 3454	cotton candy pillow	0		Last Available: "2008-08"
-3455	lime green shaking cotton candy bale	0		Last Available: "2008-08"
+3455	shaking lime green cotton candy bale	0		Last Available: "2008-08"
 3456	maroon clever trusty torch	0		Maximum MP: +20, Last Available: "2011-12"
 3457	teal prompt Junior Adventurer's merit badge	0		Adventures: +3
 3458	oxidized denatured STYX deodorant body spray	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 29
-3459	smooth spirit-forward white-label gin	5	awesome	
+3459	spirit-forward smooth white-label gin	5	awesome	
 3460	half-sized bland blinking tin rations	2	decent	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
@@ -3437,7 +3437,7 @@
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	damp boot	0		
 3472	ghostly wicked thinker's Seasonal Beret	0		Mysticality: +10, Spell Damage: +5, Item Drop: +5, Familiar Effect: "1xPotato, 1xFairy, cap 25"
-3473	jittery purple Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
+3473	purple jittery Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
 3474	magnetized enhanced cyan cranberry cordial	0		Effect: "Slimy Flavor", Effect Duration: 46
 3475	altered improved blackberry polite	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 47
 3476	aerosolized dry denatured blurry plum lozenge	0		Effect: "Ancestral Disapproval", Effect Duration: 41
@@ -3454,7 +3454,7 @@
 3487	shaking rough fish scale	0		
 3488	pristine fish scale	0		
 3489	flavorless beefy fish meat	3	decent	Effect: "Fishy", Effect Duration: 5
-3490	normal snack-sized glistening fish meat	2	good	Effect: "Fishy", Effect Duration: 5
+3490	snack-sized normal glistening fish meat	2	good	Effect: "Fishy", Effect Duration: 5
 3491	low-calorie yummy slick fish meat	1	awesome	Effect: "Fishy", Effect Duration: 5
 3492	greedy rosewater-soaked fish scimitar	0		Stench Resistance: +3, Meat Drop: +20
 3493	maroon dangerous strapping fish stick	0		Muscle: +5, Weapon Damage: +10
@@ -3466,7 +3466,7 @@
 3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	decent canap&eacute;s	4	good	
-3502	dehydrated huge fuchsia thermos of brew	1	EPIC	Last Available: "2011-12"
+3502	dehydrated fuchsia huge thermos of brew	1	EPIC	Last Available: "2011-12"
 3503	irresponsibly strong lousy olive huge glass of brandy	7	decent	Last Available: "2011-12"
 3504	wobbly French slippers	0		
 3505	LWA ring of horror	0		Spooky Spell Damage: +25
@@ -3523,14 +3523,14 @@
 3556	moldy squat sea cucumber	3	crappy	
 3557	tasty miniature sea avocado	2	awesome	
 3558	bland massive sea lychee	9	decent	
-3559	bland jumbo sea tangelo	5	decent	
+3559	jumbo bland sea tangelo	5	decent	
 3560	small stale sea honeydew	2	decent	
 3561	Vulcanized quantum green pressurized potion of puissance	0		Effect: "Shoesauce", Effect Duration: 56
 3562	electrified diffused pressurized potion of perspicacity	0		Effect: "El Vibrations", Effect Duration: 39
 3563	magnetized nitrogenated pressurized potion of pulchritude	0		Effect: "Beastly Flavor", Effect Duration: 24
 3564	tolerable blinking berry-infused sake	3	good	
 3565	lousy shaking citrus-infused sake	3	decent	
-3566	perfectly mixed irresponsibly strong pulsating melon-infused sake	8	EPIC	
+3566	irresponsibly strong perfectly mixed pulsating melon-infused sake	8	EPIC	
 3567	squat slab of sponge	0		
 3568	scorching curative sponge helmet of terror	0		Hot Damage: +25, Spooky Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy"
 3569	gray tumbling rosewater-soaked Temple Grandin's Herculean spongy shield	0		Experience (Muscle): +1, Familiar Weight: +7, Stench Resistance: +3, Damage Reduction: 14
@@ -3547,8 +3547,8 @@
 3580	wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	half-sized bland teal rice	2	decent	
-3584	gigantic stale irradiated candy cane	7	decent	Last Available: "2008-12"
-3585	moldy jumbo gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
+3584	stale gigantic irradiated candy cane	7	decent	Last Available: "2008-12"
+3585	jumbo moldy gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
 3586	acceptable high-proof oozenog	9	good	Last Available: "2008-12"
 3587	activated Vulcanized super-wet sugar plum	0		Effect: "Salamanderenity", Effect Duration: 34, Last Available: "2008-12"
 3588	dry ionized blue spinning sugar banana	0		Effect: "Oleaginous Soles", Effect Duration: 46, Last Available: "2008-12"
@@ -3575,7 +3575,7 @@
 3609	das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
 3610	imitation whetstone	0		
 3611	denatured huge sea grease	0		Effect: "Sweet Incentive", Effect Duration: 59
-3612	tumbling blue sturdy Crimbo crate	0		Last Available: "2008-12"
+3612	blue tumbling sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	wobbly battered Crimbo Crate	0		Last Available: "2008-12"
 3614	twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
@@ -3602,21 +3602,21 @@
 3636	Jack Frost's patent shoes of the pedagogue	0		Experience: +3, Cold Spell Damage: +50, Last Available: "2008-12"
 3637	rosewater-soaked knitted gray bow tie	0		Cold Resistance: +3, Stench Resistance: +3, Last Available: "2008-12"
 3638	Sherlock's vibrating penguin thesaurus	0		Maximum MP Percent: +10, Item Drop: +25, Last Available: "2008-12"
-3639	moldy half-sized blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
-3640	shaking mirror seaweed	0		
+3639	half-sized moldy blob-shaped Crimbo cookie	2	crappy	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3640	mirror shaking seaweed	0		
 3641	red jamfish jam	0		
 3642	dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	shellacked depleted Grimacite kneecapping stick	0		Damage Reduction: 7, Last Available: "2007-06"
-3645	weak drinkable canteen of wine	2	good	Last Available: "2008-12"
+3645	drinkable weak canteen of wine	2	good	Last Available: "2008-12"
 3646	moldy elven <i>limbos</i> gingerbread	3	crappy	Last Available: "2008-12"
 3647	wobbly elven whittling knife	0		Last Available: "2008-12"
 3648	green magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	flavorless toast with jam	4	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	acceptable high-proof elven moonshine	10	good	Last Available: "2008-12"
-3653	toothsome special knuckle sandwich	3	awesome	Effect: "Whitened Teeth", Effect Duration: 20, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	special toothsome knuckle sandwich	3	awesome	Effect: "Whitened Teeth", Effect Duration: 20, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	Tesla psycho sweater of James Dean	0		Experience (Moxie): +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	twirling fortified plastic Mob Penguin	0		Damage Absorption: +60, Last Available: "2008-12"
@@ -3636,22 +3636,22 @@
 3670	reassuring glow-in-the-dark burrowgrub	0		Spooky Resistance: +1, Last Available: "2009-01"
 3671	pulsating Uncle Crimbo's Rations	0		Last Available: "2010-12"
 3672	adequate can of franks 'n' beans	4	good	Last Available: "2010-12"
-3673	drinkable enchanted bottle of peppermint schnapps	3	good	Effect: "Nuts about Candy", Effect Duration: 5, Last Available: "2010-12"
+3673	enchanted drinkable bottle of peppermint schnapps	3	good	Effect: "Nuts about Candy", Effect Duration: 5, Last Available: "2010-12"
 3674	throbbing rage gland	0		Skill: "Vent Rage Gland"
 3675	Mer-kin pressureglobe	0		
 3676	tumbling Mer-kin foodbucket	0		
 3677	double-paned diving muff	0		Cold Resistance: +5, Single Equip
-3678	perfectly mixed practically non-alcoholic salinated mint julep	1	EPIC	
+3678	practically non-alcoholic perfectly mixed salinated mint julep	1	EPIC	
 3679	ink bladder	0		
 3680	esca	0		
 3681	huge bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
 3684	stale small tempura carrot	2	decent	
-3685	tiny rotten tempura cucumber	1	crappy	
-3686	massive adequate tempura avocado	9	good	
+3685	rotten tiny tempura cucumber	1	crappy	
+3686	adequate massive tempura avocado	9	good	
 3687	gigantic enchanted flavorless sea broccoli	10	decent	Effect: "Truly Gritty", Effect Duration: 40
-3688	flavorless big sea cauliflower	5	decent	
+3688	big flavorless sea cauliflower	5	decent	
 3689	gigantic flavorless fuchsia tempura broccoli	6	decent	
 3690	spoiled tempura cauliflower	4	crappy	
 3691	rotten super-sized bouncing sea blueberry	5	crappy	
@@ -3701,7 +3701,7 @@
 3735	fat wallet	0		
 3736	wholesome handwarmer of temperance	0		Maximum HP Percent: +10, Sleaze Resistance: +5, Single Equip
 3737	lighter of the bloodbag of courage	0		Maximum HP: +100, Spooky Resistance: +3
-3738	spoiled snack-sized packet of beer nuts	2	crappy	
+3738	snack-sized spoiled packet of beer nuts	2	crappy	
 3739	Boozehounds Anonymous token	0		
 3740	blinking handful of bees	0		
 3741	spectral jelly	0		
@@ -3713,12 +3713,12 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	pickled concoction of clumsiness	0		Effect: "Oxygenated Blood", Effect Duration: 51
 3750	vampire pearl earring of temperance	0		Sleaze Resistance: +5, Single Equip
-3751	decent half-sized maroon chocolate chip brownies	2	good	
+3751	half-sized decent maroon chocolate chip brownies	2	good	
 3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	extra-quantum double-corrupted narrow love song of vague ambiguity	0		Effect: "Scavengers Scavenging", Effect Duration: 36, Last Available: "2009-02"
 3755	electrified love song of smoldering passion	0		Effect: "Gemini Rising", Effect Duration: 11, Last Available: "2009-02"
 3756	improved yellow love song of icy revenge	0		Effect: "Wax On Your Shoes", Effect Duration: 14, Last Available: "2009-02"
-3757	frozen ghostly narrow love song of sugary cuteness	0		Effect: "Coal-Powered", Effect Duration: 19, Last Available: "2009-02"
+3757	frozen narrow ghostly love song of sugary cuteness	0		Effect: "Coal-Powered", Effect Duration: 19, Last Available: "2009-02"
 3758	triple-warmed spinning twirling love song of disturbing obsession	0		Effect: "A Few Extra Pounds", Effect Duration: 63, Last Available: "2009-02"
 3759	extra-unsweetened activated blue love song of naughty innuendo	0		Effect: "Morninja", Effect Duration: 20, Last Available: "2009-02"
 3760	irradiated breath mint	0		Effect: "Bloody-minded", Effect Duration: 26
@@ -3727,11 +3727,11 @@
 3763	aged slug of vodka	3	awesome	
 3764	artisanal slug of rum	3	EPIC	
 3765	lousy squat slug of shochu	4	decent	
-3766	watered-down acceptable screwdiver	2	good	
+3766	acceptable watered-down screwdiver	2	good	
 3767	extra-dry acceptable dew yoana lei	5	good	
 3768	perfectly mixed squat lychee chuhai	3	EPIC	
-3769	drinkable irresponsibly strong salacious screwdiver	8	good	
-3770	drinkable twirling huge dew yoana salacious lei	4	good	
+3769	irresponsibly strong drinkable salacious screwdiver	8	good	
+3770	drinkable huge twirling dew yoana salacious lei	4	good	
 3771	mediocre salacious lychee chuhai	4	decent	
 3772	lousy practically non-alcoholic Alewife&trade; Ale	1	decent	
 3773	maroon seaode	0		
@@ -3760,7 +3760,7 @@
 3805	maroon greasy thinker's Mer-kin sneakmask	0		Mysticality: +10, Sleaze Spell Damage: +10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	pulsating Mer-kin prayerbeads	0		
 3807	anodized ghostly Mer-kin hidepaint	0		Effect: "Sparkly!", Effect Duration: 66
-3808	ghostly lime green Mer-kin trailmap	0		
+3808	lime green ghostly Mer-kin trailmap	0		
 3809	Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
@@ -3768,7 +3768,7 @@
 3813	blinking Jack Frost's plastic baby	0		Cold Spell Damage: +50, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	fancy flavorless sea radish	3	decent	Effect: "Gummi Badass", Effect Duration: 40
+3817	flavorless fancy sea radish	3	decent	Effect: "Gummi Badass", Effect Duration: 40
 3818	zippy groovy Rosewater's halibut	0		Mysticality Percent: +30, Moxie Percent: +10, Initiative: +20
 3819	upside-down eel sauce	0		
 3820	smooth water-polo mitt	0		Moxie: +15, Single Equip
@@ -3782,7 +3782,7 @@
 3828	Grandma's Map	0		
 3829	half-sized flavorless tempura radish	2	decent	
 3830	water-polo cap of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xBarrr"
-3831	practically non-alcoholic perfectly mixed lime green Typical Tavern swill	1	EPIC	
+3831	perfectly mixed practically non-alcoholic lime green Typical Tavern swill	1	EPIC	
 3832	watered-down acceptable tropical swill	2	good	
 3833	perfectly mixed fruity girl swill	4	EPIC	
 3834	bad watered-down blended swill	2	decent	
@@ -3837,7 +3837,7 @@
 3883	cult memo	0		
 3884	decoded cult documents	0		Skill: "Bind Spaghetti Elemental"
 3885	ionized vial of slime	0		Effect: "Human-Hippy Hybrid", Effect Duration: 23
-3886	boiled modified purple blinking tumbling vial of slime	0		Effect: "Cold Blooded", Effect Duration: 63
+3886	boiled modified purple tumbling blinking vial of slime	0		Effect: "Cold Blooded", Effect Duration: 63
 3887	non-pressed vial of slime	0		Effect: "Slimily Sagacious", Effect Duration: 63
 3888	triple-boiled vial of slime	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 38
 3889	tarnished vial of slime	0		Effect: "Spiro Gyro", Effect Duration: 34
@@ -3860,7 +3860,7 @@
 3908	bouncing figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	figurine of a charred seal	0		Class: "Seal Clubber"
 3910	olive figurine of a seal	0		Class: "Seal Clubber"
-3911	cyan blurry figurine of a slippery seal	0		Class: "Seal Clubber"
+3911	blurry cyan figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
 3913	drinkable skewed blended swill with a fly in it	3	good	
 3914	turtle wax	0		
@@ -3878,7 +3878,7 @@
 3926	chilly occult spiky turtle shield	0		Spell Damage Percent: +25, Cold Damage: +5, Damage Reduction: 8
 3927	shaking cyan turtling rod	0		Class: "Turtle Tamer"
 3928	syncopated turtle	0		
-3929	mirror purple grinning turtle	0		
+3929	purple mirror grinning turtle	0		
 3930	aerosolized triple-deionized lime green tainted seal's blood	0		Effect: "Weird Vibrations", Effect Duration: 47
 3931	asbestos-lined therapeutic severed flipper	0		Hot Resistance: +5, HP Regen Min: 5, HP Regen Max: 7, Class: "Seal Clubber"
 3932	ingot of seal-iron	0		
@@ -3913,7 +3913,7 @@
 3961	electrified smooth opera glasses	0		Moxie: +15, MP Regen Min: 3, MP Regen Max: 5
 3962	designer handbag	0		
 3963	narrow Clan pool table	0		Free Pull, Last Available: "2009-05"
-3964	yellow wobbly cell phone	0		Familiar Weight: +10
+3964	wobbly yellow cell phone	0		Familiar Weight: +10
 3965	tarnished dry twirling mirror cube of billiard chalk	0		Effect: "Bored Stiff", Effect Duration: 15
 3966	Sinatra's slick hot-ass club of the sewer	0		Moxie: +10, Experience (Moxie): +5, Stench Damage: +25, Class: "Seal Clubber"
 3967	energetic frigid-ass club of terror of temperance	0		Maximum MP Percent: +20, Spooky Spell Damage: +10, Sleaze Resistance: +5, Class: "Seal Clubber"
@@ -3987,7 +3987,7 @@
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	cyan caustic slime nodule	0		
 4037	stale slimy sweetbreads	3	decent	
-4038	weak smooth slimy fermented bile bladder	2	awesome	
+4038	smooth weak slimy fermented bile bladder	2	awesome	
 4039	boiled wobbly wobbly slimy alveolus	1		Effect: "Cold Jellied", Effect Duration: 10
 4040	pulsating memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	quilted pig-iron helm of Flo-Jo	0		Damage Absorption: +40, Initiative: +100, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
@@ -4010,7 +4010,7 @@
 4058	flame-wreathed studded stone fist	0		Damage Absorption: +80, Hot Spell Damage: +10, Last Available: "2009-06"
 4059	supercool stone head	0		Moxie Percent: +20, Damage Reduction: 5, Last Available: "2009-06"
 4060	Indigo Party Invitation	0		Last Available: "2009-06"
-4061	skewed wobbly Violet Hunt Invitation	0		Last Available: "2009-06"
+4061	wobbly skewed Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
@@ -4081,7 +4081,7 @@
 4129	frightening nasty arcane researcher's hardened slime belt	0		Experience Percent (Mysticality): +10, Stench Damage: +5, Spooky Damage: +5, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	distilled pulsating boot plant	1	good	Last Available: "2009-06"
-4132	mediocre triple-distilled special mirror sham champagne	7	decent	Effect: "Here to Kick Ass", Effect Duration: 40, Last Available: "2009-06"
+4132	triple-distilled special mediocre mirror sham champagne	7	decent	Effect: "Here to Kick Ass", Effect Duration: 40, Last Available: "2009-06"
 4133	quadruple-polarized nitrogenated skewed tempura air	0		Effect: "Nothing Is Impossible", Effect Duration: 22
 4134	diffused cyan pressurized potion of pneumaticity	0		Effect: "Mucilaginous Muscle", Effect Duration: 49
 4135	wobbly moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
@@ -4105,15 +4105,15 @@
 4153	rockfish stomach	0		Last Available: "2009-09"
 4154	live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
-4156	teal bouncing pebbles	0		Last Available: "2009-09"
+4156	bouncing teal pebbles	0		Last Available: "2009-09"
 4157	gravel	0		Last Available: "2009-09"
 4158	jittery rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	drinkable pebblebr&auml;u	4	good	Last Available: "2009-09"
-4161	jumbo spoiled narrow rocky road ice cream	5	crappy	Last Available: "2009-09"
+4161	spoiled jumbo narrow rocky road ice cream	5	crappy	Last Available: "2009-09"
 4162	blurry extra-strength rubber bands	0		Familiar Weight: +5
 4163	warmed nitrogenated olive children of the candy corn	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 42
-4164	aerosolized blue spinning Good 'n' Slimy	0		Effect: "Boilermade", Effect Duration: 52
+4164	aerosolized spinning blue Good 'n' Slimy	0		Effect: "Boilermade", Effect Duration: 52
 4165	lion tamer's beefcake's Staff of the Soupbone of James Dean	0		Muscle: +25, Experience (Moxie): +3, Experience (familiar): +2
 4166	deadly Voluminous Radio Pants	0		Weapon Damage: +5, Familiar Effect: "2xGhoul, cap 37"
 4167	hardened Voluminous Radio Hat	0		Damage Reduction: 3, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4124,7 +4124,7 @@
 4172	fuchsia ruddy rock helmet	0		Maximum HP Percent: +40, Familiar Effect: "1xGhuol, cap 25"
 4173	rock pants of extreme caution	0		Monster Level: -25, Familiar Effect: "1.5xBarrr, 1xGhuol, cap 25"
 4174	studded rock necklace	0		Damage Absorption: +80, Single Equip
-4175	upside-down jittery lime green spaghetti cult robe	0		
+4175	jittery lime green upside-down spaghetti cult robe	0		
 4176	sugar sheet	0		Last Available: "2009-09"
 4177	Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	sugar shotgun of the wise owl	0		Mysticality: +20, Last Available: "2009-09"
@@ -4132,7 +4132,7 @@
 4180	rock-hard sugar shank	0		Damage Reduction: 5, Last Available: "2009-09"
 4181	jittery censurious hardened dangerous sugar chapeau	0		Weapon Damage: +10, Damage Reduction: 3, Sleaze Resistance: +3, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
 4182	manspreader's sugar shorts	0		Monster Level: +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
-4183	bouncing squat sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
+4183	squat bouncing sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	twirling slime convention swag bag	0		
 4185	slime convention flyers	0		
 4186	slime convention coupons	0		
@@ -4147,11 +4147,11 @@
 4195	mirror stanky pacifier necklace	0		Stench Spell Damage: +25, Single Equip
 4196	sea cowbell	0		
 4197	sea	0		
-4198	tumbling shaking sea lasso	0		
+4198	shaking tumbling sea lasso	0		
 4199	bouncing Jim Carey's sea cowboy hat of the wise owl of bravery	0		Mysticality: +20, Monster Level: +25, Spooky Resistance: +5, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
 4201	blinking gill rings	0		Familiar Weight: +5
-4202	upside-down blurry urchin roe	0		
+4202	blurry upside-down urchin roe	0		
 4203	upside-down pet anemone	0		Familiar Weight: +5
 4204	Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
@@ -4187,7 +4187,7 @@
 4235	gray salt-shaker	0		
 4236	can of sterno	0		
 4237	cheese-slicer of bravery	0		Spooky Resistance: +5
-4238	decent fancy beef jerky	3	good	Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
+4238	fancy decent beef jerky	3	good	Effect: "Human-Weird Thing Hybrid", Effect Duration: 25
 4239	scorching pipe wrench	0		Hot Damage: +25
 4240	quadruple-wet gun cleaning kit	0		Effect: "Red Around the Gills", Effect Duration: 28
 4241	up-at-dawn sleep mask	0		Adventures: +5, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4203,12 +4203,12 @@
 4251	fish-oil smoke bomb	0		
 4252	nitrogenated mirror vial of squid ink	0		Effect: "Sweet Taste", Effect Duration: 65
 4253	dry wobbly potion of speed	0		Effect: "Dweeby", Effect Duration: 23
-4254	spinning narrow teal bark	0		Last Available: "2009-10"
+4254	narrow spinning teal bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	pressed squat sap	0		Effect: "Improprie Tea", Effect Duration: 33, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	adequate gigantic chocolate-covered scarab beetle	9	good	Last Available: "2009-10"
-4259	acceptable maroon upside-down squat mulled cider	4	good	Last Available: "2009-10"
+4259	acceptable squat maroon upside-down mulled cider	4	good	Last Available: "2009-10"
 4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
 4261	narrow pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4262	gray mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -4279,11 +4279,11 @@
 4327	Usain Bolt's grievous Sinatra's La Hebilla del Cintur&oacute;n de Lopez	0		Experience (Moxie): +5, Weapon Damage Percent: +50, Initiative: +80, Class: "Accordion Thief", Single Equip
 4328	skewed suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	blinking spinning bag of many confections	0		Last Available: "2009-12"
-4330	tiny moldy pulsating candy kneecapping stick	1	crappy	Last Available: "2009-12"
+4330	moldy tiny pulsating candy kneecapping stick	1	crappy	Last Available: "2009-12"
 4331	miniature decent licorice garrote	2	good	Last Available: "2009-12"
 4332	candy knuckles of the storm	0		Maximum MP Percent: +40, Last Available: "2009-12"
 4333	special flavorless jawbruiser	3	decent	Effect: "Your Favorite Flavor", Effect Duration: 35, Last Available: "2010-12"
-4334	liquefied electrified tumbling upside-down chocolate car	0		Effect: "Fitter, Happier", Effect Duration: 54, Last Available: "2009-12"
+4334	liquefied electrified upside-down tumbling chocolate car	0		Effect: "Fitter, Happier", Effect Duration: 54, Last Available: "2009-12"
 4335	veiny plastic 11 Dealer	0		Maximum HP: +10, Last Available: "2009-12"
 4336	plastic Crimbo Casino of horror	0		Spooky Spell Damage: +25, Last Available: "2009-12"
 4337	purple plastic stocking mimic of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2009-12"
@@ -4310,12 +4310,12 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	big bland ghostly expired can of franks 'n' beans	5	decent	Last Available: "2009-12"
-4361	drinkable strong fancy expired bottle of peppermint schnapps	5	good	Effect: "Sizzling with Fury", Effect Duration: 40, Last Available: "2009-12"
+4361	strong drinkable fancy expired bottle of peppermint schnapps	5	good	Effect: "Sizzling with Fury", Effect Duration: 40, Last Available: "2009-12"
 4362	teal snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	polarized quadruple-anodized squat elven suicide capsule	0		Effect: "Whitened Teeth", Effect Duration: 36, Last Available: "2009-12"
-4365	yummy huge penguin focaccia bread	10	awesome	Last Available: "2009-12"
-4366	delicious fancy distilled herringcello	5	awesome	Effect: "Biologically Shocked", Effect Duration: 10, Last Available: "2009-12"
+4365	huge yummy penguin focaccia bread	10	awesome	Last Available: "2009-12"
+4366	fancy delicious distilled herringcello	5	awesome	Effect: "Biologically Shocked", Effect Duration: 10, Last Available: "2009-12"
 4367	bad practically non-alcoholic elven cellocello	1	decent	Last Available: "2009-12"
 4368	wobbly wrench handle	0		Last Available: "2009-12"
 4369	upside-down handful of headless bolts	0		Last Available: "2009-12"
@@ -4360,8 +4360,8 @@
 4409	jittery Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	bouncing The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	stale miniature quantum taco	0		Last Available: "2010-10"
-4413	artisanal triple-distilled shaking Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4412	miniature stale quantum taco	0		Last Available: "2010-10"
+4413	triple-distilled artisanal shaking Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	twirling Jack Frost's sealhide hood	0		Cold Spell Damage: +50, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	tumbling dog trainer's sealhide leggings	0		Experience (familiar): +1, Familiar Effect: "1xVolley, cap 40"
@@ -4411,7 +4411,7 @@
 4463	frozen cold-filtered chocolate turtle totem	0		Effect: "Nigh-Invincible", Effect Duration: 34
 4464	cold-filtered jittery chocolate pasta spoon	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 28
 4465	energized chocolate saucepan	0		Effect: "Rushin' Hands", Effect Duration: 67
-4466	extra-energized dry skewed green chocolate disco ball	0		Effect: "Polka of Plenty", Effect Duration: 40
+4466	extra-energized dry green skewed chocolate disco ball	0		Effect: "Polka of Plenty", Effect Duration: 40
 4467	extra-chilled galvanized maroon wobbly chocolate stolen accordion	0		Effect: "Magically Delicious", Effect Duration: 58
 4468	yellow wobbly Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	fuchsia spinning BRICKO brick	0		Last Available: "2010-02"
@@ -4462,8 +4462,8 @@
 4514	bland Humpty Dumplings	3	decent	Last Available: "2010-03"
 4515	moldy Lobster <i>qua</i> Grill	4	crappy	Last Available: "2010-03"
 4516	delicious blurry missing wine	4	awesome	Last Available: "2010-03"
-4517	spoiled snack-sized fancy bouncing ghostly matter custard	2	crappy	Effect: "Flaming Weapon", Effect Duration: 25, Last Available: "2010-03"
-4518	deionized anodized olive jittery comfit?	0		Effect: "Very Clean Guns", Effect Duration: 68, Last Available: "2010-03"
+4517	fancy spoiled snack-sized bouncing ghostly matter custard	2	crappy	Effect: "Flaming Weapon", Effect Duration: 25, Last Available: "2010-03"
+4518	deionized anodized jittery olive comfit?	0		Effect: "Very Clean Guns", Effect Duration: 68, Last Available: "2010-03"
 4519	fuchsia ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	gravedigger's flamingo mallet of the glutton	0		Spooky Damage: +10, Food Drop: +100, Last Available: "2010-03"
 4521	lime green croquet hedgehog	0		Last Available: "2010-03"
@@ -4471,14 +4471,14 @@
 4523	tumbling purple rosewater-soaked baleful eye of the Tiger-lily	0		Spell Damage: +25, Stench Resistance: +3, Last Available: "2010-03"
 4524	spinning Usain Bolt's wig of the overflowing toilet	0		Stench Spell Damage: +50, Initiative: +80, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	spoiled donut	3	crappy	Last Available: "2010-03"
-4526	flavorless small yellow bucket of honey	2	decent	Last Available: "2010-03"
+4526	small flavorless yellow bucket of honey	2	decent	Last Available: "2010-03"
 4527	studded elephant stinger of incineration	0		Damage Absorption: +80, Hot Spell Damage: +50, Last Available: "2010-03"
 4528	half-sized moldy purple dragon snaps	2	crappy	Last Available: "2010-03"
 4529	red frosty snapdragon pistil of the sewer	0		Cold Spell Damage: +10, Stench Damage: +25, Last Available: "2010-03"
 4530	jittery olive puff of smoke	0		Last Available: "2010-03"
-4531	miniature special rotten rook cookie	2	crappy	Effect: "In the Slimelight", Effect Duration: 50, Last Available: "2010-03"
-4532	miniature flavorless pulsating bishop cookie	2	decent	Last Available: "2010-03"
-4533	miniature toothsome purple knight cookie	2	awesome	Last Available: "2010-03"
+4531	special miniature rotten rook cookie	2	crappy	Effect: "In the Slimelight", Effect Duration: 50, Last Available: "2010-03"
+4532	flavorless miniature pulsating bishop cookie	2	decent	Last Available: "2010-03"
+4533	toothsome miniature purple knight cookie	2	awesome	Last Available: "2010-03"
 4534	delicious king cookie	4	awesome	Last Available: "2010-03"
 4535	big tasty queen cookie	5	awesome	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
@@ -4493,7 +4493,7 @@
 4545	pocketwatch	0		Last Available: "2010-03"
 4546	purple bandersnatch	0		Last Available: "2010-03"
 4547	caterpillar	0		Last Available: "2010-03"
-4548	teal squat squat walrus	0		Last Available: "2010-03"
+4548	squat teal squat walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
 4550	dodo	0		Last Available: "2010-03"
 4551	healthy detour shield	0		Maximum HP Percent: +20, Damage Reduction: 6, Last Available: "2010-03"
@@ -4503,7 +4503,7 @@
 4555	mirror jittery left bracket	0		
 4556	right parenthesis	0		
 4557	squat dollar sign	0		
-4558	maroon pulsating equal sign	0		
+4558	pulsating maroon equal sign	0		
 4559	record album	0		Last Available: "2010-04"
 4560	narrow map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	can of depilatory cream	0		Last Available: "2010-04"
@@ -4513,7 +4513,7 @@
 4565	fancy flavorless twirling raisin	4	decent	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40, Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	ghostly Tesla resourceful flyest of shirts	0		Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-04"
-4568	huge rotten a dance upon the palate	6	crappy	Last Available: "2010-04"
+4568	rotten huge a dance upon the palate	6	crappy	Last Available: "2010-04"
 4569	special spoiled green pulsating prehistoric meteorite jawbreaker	3	crappy	Effect: "Pyramid Power", Effect Duration: 15, Last Available: "2010-04"
 4570	teal Crazyleg's razor	0		Last Available: "2010-04"
 4571	moldy squirmy violent party snack	3	crappy	Last Available: "2010-04"
@@ -4556,7 +4556,7 @@
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	essential tofu	0		Last Available: "2010-08"
 4610	tarnished double-ionized essential soy	0		Effect: "Eye of the Lihc", Effect Duration: 52, Last Available: "2010-08"
-4611	alkaline wobbly narrow essential cameraderie	0		Effect: "Bone Chilling", Effect Duration: 13, Last Available: "2010-08"
+4611	alkaline narrow wobbly essential cameraderie	0		Effect: "Bone Chilling", Effect Duration: 13, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	upside-down nippy Crown of Thrones	0		Cold Damage: +10, Softcore Only, Last Available: "2010-05"
@@ -4570,7 +4570,7 @@
 4622	blue Game Grid ticket	0		Last Available: "2010-06"
 4623	quadruple-anodized pressed wet upside-down chocolate-covered caviar	0		Effect: "Outer Wolf&trade;", Effect Duration: 52, Last Available: "2020-09"
 4624	adequate pawn cookie	4	good	Last Available: "2010-06"
-4625	powdered spinning jittery coffee pixie stick	1	EPIC	Effect: "PERL of Great Price", Effect Duration: 25, Last Available: "2010-06"
+4625	powdered jittery spinning coffee pixie stick	1	EPIC	Effect: "PERL of Great Price", Effect Duration: 25, Last Available: "2010-06"
 4626	lime green superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
@@ -4581,7 +4581,7 @@
 4633	stanky crafty googly-ball hat	0		Maximum MP: +10, Stench Spell Damage: +25, Last Available: "2010-06"
 4634	brawny beefy googly-heart hat	0		Muscle: +10, Muscle Percent: +20, Last Available: "2010-06"
 4635	Jim Carey's arcane researcher's super-sweet boom box	0		Experience Percent (Mysticality): +10, Monster Level: +25, Four Songs, Last Available: "2010-06"
-4636	ghostly narrow Game Grid valued membership card	0		Last Available: "2010-06"
+4636	narrow ghostly Game Grid valued membership card	0		Last Available: "2010-06"
 4637	narrow Jeselnik's nippy razor-sharp sinister demon mask	0		Weapon Damage Percent: +25, Cold Damage: +10, Sleaze Damage: +25, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	bouncing foul-smelling streetfighting champion's belt of the sewer of mayonnaise	0		Stench Damage: 35, Sleaze Spell Damage: +50, Single Equip, Last Available: "2010-06"
 4639	spinning asbestos-lined Temple Grandin's Space Trip safety headphones of courage	0		Familiar Weight: +7, Hot Resistance: +5, Spooky Resistance: +3, Single Equip, Last Available: "2010-06"
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	jittery toasty blackberry galoshes	0		Hot Damage: +5, Single Equip
 4660	auspicious weightlifter's trout fang	0		Muscle: +15, Item Drop: +10, Last Available: "2010-09"
-4661	adequate enchanted poisonous caviar	3	good	Effect: "Weepy, Creepy", Effect Duration: 15, Last Available: "2010-09"
+4661	enchanted adequate poisonous caviar	3	good	Effect: "Weepy, Creepy", Effect Duration: 15, Last Available: "2010-09"
 4662	nitrogenated fuchsia pulsating wet venom duct	0		Effect: "damage.enh", Effect Duration: 62, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	squat Ellsbury's skull of the sewer of mayonnaise	0		Stench Damage: +25, Sleaze Spell Damage: +50, Last Available: "2010-09"
@@ -4616,10 +4616,10 @@
 4668	personal trainer's observational glasses	0		Experience Percent (Muscle): +10
 4669	studded hilarious comedy prop	0		Damage Absorption: +80
 4670	beer-scented teddy bear	0		
-4671	mediocre teal bouncing twirling booze-soaked cherry	3	decent	
+4671	mediocre twirling bouncing teal booze-soaked cherry	3	decent	
 4672	comfy pillow	0		
-4673	moldy massive marshmallow	6	crappy	
-4674	tasty thick sponge cake	5	awesome	
+4673	massive moldy marshmallow	6	crappy	
+4674	thick tasty sponge cake	5	awesome	
 4675	mediocre gin-soaked blotter paper	4	decent	
 4676	cyan tree-holed coin	0		
 4677	wobbly unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4639,7 +4639,7 @@
 4691	fossilized wing	0		Last Available: "2010-09"
 4692	fossilized limb	0		Last Available: "2010-09"
 4693	gray fossilized torso	0		Last Available: "2010-09"
-4694	shaking pulsating fossilized spine	0		Last Available: "2010-09"
+4694	pulsating shaking fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
 4696	ribald supercharged baleful Greatest American Pants	0		Spell Damage: +25, Maximum MP Percent: +30, Sleaze Damage: +10, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	blue sage fossilized necklace	0		Mysticality Percent: +10, Last Available: "2010-09"
@@ -4653,7 +4653,7 @@
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	sinister tablet	0		
 4707	E-Z Cook&trade; oven	0		
-4708	fuchsia mirror My First Shaker&trade;	0		
+4708	mirror fuchsia My First Shaker&trade;	0		
 4709	hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
@@ -4668,10 +4668,10 @@
 4720	wobbly organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	stale jumbo liver and let pie	5	decent	Last Available: "2010-10"
-4723	massive adequate badass pie	9	good	Last Available: "2010-10"
+4723	adequate massive badass pie	9	good	Last Available: "2010-10"
 4724	low-calorie decent shoo-fish pie	1	good	Last Available: "2010-10"
 4725	normal low-calorie piping organ pie	1	good	Last Available: "2010-10"
-4726	small bland igloo pie	2	decent	Last Available: "2010-10"
+4726	bland small igloo pie	2	decent	Last Available: "2010-10"
 4727	fancy decent squat stomach turnover	4	good	Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 25, Last Available: "2010-10"
 4728	moldy dead lights pie	3	crappy	Last Available: "2010-10"
 4729	adequate massive throbbing organ pie	7	good	Last Available: "2010-10"
@@ -4683,17 +4683,17 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	forbidden beer-soaked mop	0		Spell Damage Percent: +50
-4738	weak tolerable narrow day-old beer	2	good	
+4738	tolerable weak narrow day-old beer	2	good	
 4739	artisanal plain beer	4	EPIC	
 4740	tolerable gray overpriced &quot;imported&quot; beer	4	good	
 4741	smiling rat	0		
 4742	olive pulsating rat tooth polish	0		Familiar Weight: +5
 4743	ghostly bone chips	0		Last Available: "2011-12"
 4744	moist PlexiPips	0		Effect: "Goldentongue", Effect Duration: 40
-4745	warmed deionized flattened upside-down red Wax Flask	0		Effect: "Dexteri Tea", Effect Duration: 38
+4745	warmed deionized flattened red upside-down Wax Flask	0		Effect: "Dexteri Tea", Effect Duration: 38
 4746	magnetized Pain Dip	0		Effect: "Sweet, Nuts", Effect Duration: 63
-4747	low-calorie tasty bone meal	1	awesome	Last Available: "2010-10"
-4748	triple-distilled mediocre bone aperitif	7	decent	Last Available: "2010-10"
+4747	tasty low-calorie bone meal	1	awesome	Last Available: "2010-10"
+4748	mediocre triple-distilled bone aperitif	7	decent	Last Available: "2010-10"
 4749	bonerang of the brazier	0		Hot Spell Damage: +25, Last Available: "2010-10"
 4750	cyan blinking bone and arrows of temperance	0		Sleaze Resistance: +5, Last Available: "2010-10"
 4751	boning knife of horror	0		Spooky Spell Damage: +25, Last Available: "2010-10"
@@ -4705,7 +4705,7 @@
 4757	mirror narrow Stabonic scroll	0		Last Available: "2010-10"
 4758	polymerized shaking candy skeleton	0		Effect: "Rad-ish", Effect Duration: 28, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
-4760	shaking narrow packet of pumpkin seeds	0		Last Available: "2010-11"
+4760	narrow shaking packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	bouncing pulsating pumpkin	0		Last Available: "2010-11"
 4762	red huge pumpkin	0		Last Available: "2010-11"
 4763	bland fancy pumpkin pie	4	decent	Effect: "Badger Underfoot", Effect Duration: 15, Last Available: "2010-11"
@@ -4727,7 +4727,7 @@
 4818	spoiled jittery CRIMBCOIDS mints	4	crappy	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	jumbo bland bouncing CRIMBCOLOAF	5	decent	Last Available: "2011-01"
-4821	bland diet circular CRIMBCOOKIE	1	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4821	diet bland circular CRIMBCOOKIE	1	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	shaking tumbling arcane researcher's plastic CRIMBCO HQ	0		Experience Percent (Mysticality): +10, Last Available: "2010-12"
 4823	wobbly plastic fax machine of the blizzard	0		Cold Spell Damage: +25, Last Available: "2010-12"
 4824	plastic hobo elf of the empath	0		Familiar Weight: +5, Last Available: "2010-12"
@@ -4741,7 +4741,7 @@
 4832	robot reindeer protocol V.I.X.E.N.	0		Last Available: "2010-12"
 4833	purple robot reindeer protocol C.U.P.I.D.	0		Last Available: "2010-12"
 4834	robot reindeer protocol D.A.N.C.E.R.	0		Last Available: "2010-12"
-4835	wobbly teal narrow robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
+4835	wobbly narrow teal robot reindeer protocol C.O.M.E.T.	0		Last Available: "2010-12"
 4836	robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	tumbling robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
@@ -4780,7 +4780,7 @@
 4871	skewed huge supercharged paperclip cape	0		Maximum MP Percent: +30, Last Available: "2011-01"
 4872	fuchsia glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
-4874	shaking blinking gaudy key	0		
+4874	blinking shaking gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
 4876	dry quadruple-ionized tumbling chocolate bath ball	0		Effect: "Muscularrr", Effect Duration: 15, Last Available: "2011-01"
 4877	energized ghostly bacon bath ball	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 46, Last Available: "2011-01"
@@ -4791,11 +4791,11 @@
 4882	wobbly Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	decent toe jam toast	3	good	Last Available: "2011-01"
-4885	narrow tumbling traffic jam	0		Last Available: "2011-01"
+4885	tumbling narrow traffic jam	0		Last Available: "2011-01"
 4886	half-sized spoiled traffic jam toast	2	crappy	Last Available: "2011-01"
 4887	blinking space jam	0		Last Available: "2011-01"
 4888	rotten space jam toast	4	crappy	Last Available: "2011-01"
-4889	quadruple-nitrogenated lime green upside-down pulsating motivational poster	0		Effect: "Bloodstain-Resistant", Effect Duration: 46, Last Available: "2011-01"
+4889	quadruple-nitrogenated upside-down lime green pulsating motivational poster	0		Effect: "Bloodstain-Resistant", Effect Duration: 46, Last Available: "2011-01"
 4890	skewed sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
@@ -4811,7 +4811,7 @@
 4902	blurry Fonzie's stapler bear	0		Experience (Moxie): +1, Last Available: "2010-12"
 4903	tumbling pulsating blurry rosewater-soaked adhesive tape dolly	0		Stench Resistance: +3, Last Available: "2010-12"
 4904	red banded scissor duck	0		Damage Absorption: +100, Last Available: "2010-12"
-4905	maroon shaking coal paperweight	0		Last Available: "2010-12"
+4905	shaking maroon coal paperweight	0		Last Available: "2010-12"
 4906	green jingle bell	0		Last Available: "2010-12"
 4907	censurious asbestos-lined Seven Loco	0		Hot Resistance: +5, Sleaze Resistance: +3, Last Available: "2010-09"
 4908	Loathing Legion knife	0		Last Available: "2011-01"
@@ -4859,15 +4859,15 @@
 4956	decent cyan philosopher's scone	3	good	
 4957	enhanced aerosolized upside-down half-baked potion	0		Effect: "Comprehensively Nourished", Effect Duration: 49
 4958	nippy Knob Goblin deluxe scimitar	0		Cold Damage: +10
-4959	flavorless small Knob nuts	2	decent	
-4960	drinkable watered-down Cobb's Knob Wurstbrau	2	good	
+4959	small flavorless Knob nuts	2	decent	
+4960	watered-down drinkable Cobb's Knob Wurstbrau	2	good	
 4961	Subject 37 file	0		
 4962	greasy mysterious lapel pin of the brazier	0		Hot Spell Damage: +25, Sleaze Spell Damage: +10, Single Equip
 4963	state loom	0		Familiar Weight: +10
 4964	lime green Evilometer	0		
 4965	Sorcerers of the Shore Grimoire	0		Free Pull, Skill: "Summon Alice's Army Cards"
 4966	purple Pack of Alice's Army Cards	0		Last Available: "2011-03"
-4967	blinking blue Alice's Army Swordsman	0		Last Available: "2011-03"
+4967	blue blinking Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	upside-down Alice's Army Spearsman	0		Last Available: "2011-03"
 4969	Alice's Army Halberder	0		Last Available: "2011-03"
 4970	Alice's Army Guard	0		Last Available: "2011-03"
@@ -4880,11 +4880,11 @@
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
-4980	olive spinning Alice's Army Lanceman	0		Last Available: "2011-03"
+4980	spinning olive Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
 4983	Alice's Army Cleric	0		Last Available: "2011-03"
-4984	gray huge Alice's Army Sniper	0		Last Available: "2011-03"
+4984	huge gray Alice's Army Sniper	0		Last Available: "2011-03"
 4985	mirror Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
@@ -4895,14 +4895,14 @@
 4992	Alice's Army Foil Wallman	0		Last Available: "2011-03"
 4993	Alice's Army Foil Ninja	0		Last Available: "2011-03"
 4994	Alice's Army Foil Alchemist	0		Last Available: "2011-03"
-4995	bouncing squat Alice's Army Foil Page	0		Last Available: "2011-03"
+4995	squat bouncing Alice's Army Foil Page	0		Last Available: "2011-03"
 4996	ghostly Alice's Army Foil Shieldmaiden	0		Last Available: "2011-03"
 4997	yellow Alice's Army Foil Mad Bomber	0		Last Available: "2011-03"
 4998	Alice's Army Foil Nurse	0		Last Available: "2011-03"
 4999	Alice's Army Foil Hammerman	0		Last Available: "2011-03"
 5000	skewed Alice's Army Foil Bowman	0		Last Available: "2011-03"
 5001	huge Alice's Army Foil Lanceman	0		Last Available: "2011-03"
-5002	narrow shaking Alice's Army Foil Horseman	0		Last Available: "2011-03"
+5002	shaking narrow Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	pulsating Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	Alice's Army Foil Cleric	0		Last Available: "2011-03"
 5005	Alice's Army Foil Sniper	0		Last Available: "2011-03"
@@ -4913,10 +4913,10 @@
 5010	evil eye	0		
 5011	shaking Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
-5013	enchanted bland snack-sized wasabi pocky	2	decent	Effect: "La Bamba", Effect Duration: 15, Last Available: "2011-03"
+5013	enchanted snack-sized bland wasabi pocky	2	decent	Effect: "La Bamba", Effect Duration: 15, Last Available: "2011-03"
 5014	normal gigantic cyan tobiko pocky	8	good	Last Available: "2011-03"
-5015	miniature stale natto pocky	2	decent	Last Available: "2011-03"
-5016	irresponsibly strong lousy wasabi-infused sake	7	decent	Last Available: "2011-03"
+5015	stale miniature natto pocky	2	decent	Last Available: "2011-03"
+5016	lousy irresponsibly strong wasabi-infused sake	7	decent	Last Available: "2011-03"
 5017	mediocre tobiko-infused sake	3	decent	Last Available: "2011-03"
 5018	acceptable weak narrow natto-infused sake	2	good	Last Available: "2011-03"
 5019	altered irradiated wasabi marble soda	0		Effect: "Punch Another Day", Effect Duration: 14, Last Available: "2011-03"
@@ -4925,7 +4925,7 @@
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	cold-filtered double-flattened upside-down elderly jawbreaker	0		Effect: "Grumpy and Ornery", Effect Duration: 54, Last Available: "2020-09"
 5024	aged practically non-alcoholic marshmallow flamb&eacute;	1	awesome	Last Available: "2011-03"
-5025	irresponsibly strong hand-crafted maroon wobbly cranberry schnapps	7	EPIC	Last Available: "2011-03"
+5025	irresponsibly strong hand-crafted wobbly maroon cranberry schnapps	7	EPIC	Last Available: "2011-03"
 5026	perfectly mixed breaded beer	3	super ultra EPIC	Last Available: "2011-03"
 5027	tolerable soy cordial	3	good	Last Available: "2011-03"
 5028	ghostly green Jeselnik's sage astral bludgeon of vim and vigor	0		Mysticality Percent: +10, Maximum HP Percent: +50, Sleaze Damage: +25
@@ -4968,7 +4968,7 @@
 5065	rotten spaghetti con calaveras	3	crappy	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	rotten huge popcorn	8	crappy	Last Available: "2011-04"
-5068	gigantic bland chaos popcorn	10	decent	Last Available: "2011-04"
+5068	bland gigantic chaos popcorn	10	decent	Last Available: "2011-04"
 5069	avaricious lard-coated hole of the bloodbag	0		Maximum HP: +100, Sleaze Spell Damage: +25, Meat Drop: +30, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	flavorless s'more	0	decent	Last Available: "2011-04"
@@ -5032,7 +5032,7 @@
 5129	narrow teal Notes from the Elfpocalypse, Chapter V	0		Last Available: "2011-06"
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	extra-liquefied colloidal spinning Ultrasoldier Serum	0		Effect: "Category", Effect Duration: 37, Last Available: "2011-06"
-5132	fancy huge flavorless elven hardtack	6	decent	Effect: "Takin' It Greasy", Effect Duration: 5, Last Available: "2011-06"
+5132	flavorless fancy huge elven hardtack	6	decent	Effect: "Takin' It Greasy", Effect Duration: 5, Last Available: "2011-06"
 5133	practically non-alcoholic drinkable upside-down elven squeeze	1	good	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
@@ -5041,11 +5041,11 @@
 5138	E.M.U. harness	0		Last Available: "2011-06"
 5139	squat carton of astral energy drinks	0		
 5140	vaporized bouncing astral energy drink	1		Effect: "Sweet Incentive", Effect Duration: 45
-5141	twirling blue Thwaitgold bee statuette	0		
+5141	blue twirling Thwaitgold bee statuette	0		
 5142	moon unit	0		Last Available: "2011-06"
 5143	ghostly E.M.U. Unit	0		Last Available: "2011-06"
 5144	spinning handful of honey	0		
-5145	super-adjusted maroon shaking honeypot	0		Effect: "Patent Prevention", Effect Duration: 22
+5145	super-adjusted shaking maroon honeypot	0		Effect: "Patent Prevention", Effect Duration: 22
 5146	enchanted normal wild honey pie	4	good	Effect: "Disco State of Mind", Effect Duration: 5
 5147	drinkable purple honey mead	3	good	
 5148	Jeselnik's therapeutic Newton's honey dipper	0		Experience (Mysticality): +3, Sleaze Damage: +25, HP Regen Min: 5, HP Regen Max: 7
@@ -5066,7 +5066,7 @@
 5163	hardy plush mutated alielephant of Calamity Jane	0		Maximum HP: +50, Critical Hit Percent: +15, Last Available: "2011-06"
 5164	jittery mysterious chest	0		Free Pull, Last Available: "2011-06"
 5165	girl of courage	0		Spooky Resistance: +3, Last Available: "2011-06"
-5166	blurry fuchsia top hat and cane	0		Last Available: "2011-06"
+5166	fuchsia blurry top hat and cane	0		Last Available: "2011-06"
 5167	synthetic dog hair pill	0		Last Available: "2011-06"
 5168	ghostly distention pill	0		Last Available: "2011-06"
 5169	elven medi-pack	0		Last Available: "2011-06"
@@ -5074,9 +5074,9 @@
 5171	narrow Map to Safety Shelter Ronald Prime	0		Last Available: "2011-06"
 5172	spinning yellow Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
-5174	drinkable fancy Saison du Lune	4	good	Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2011-06"
-5175	special lousy squat ghostly Moonthril Schnapps	4	decent	Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2011-06"
-5176	weak perfectly mixed special Wrecked Generator	2	super ultra mega turbo EPIC	Effect: "Sugar Smacks", Effect Duration: 40, Last Available: "2011-06"
+5174	fancy drinkable Saison du Lune	4	good	Effect: "The Rich Get Richer", Effect Duration: 25, Last Available: "2011-06"
+5175	lousy special ghostly squat Moonthril Schnapps	4	decent	Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2011-06"
+5176	perfectly mixed special weak Wrecked Generator	2	super ultra mega turbo EPIC	Effect: "Sugar Smacks", Effect Duration: 40, Last Available: "2011-06"
 5177	tasty Spaghetti with Moonballs	4	awesome	Last Available: "2011-06"
 5178	stale Crepes a la Lune	3	decent	Last Available: "2011-06"
 5179	small decent huge Moon Pie	2	good	Last Available: "2011-06"
@@ -5106,10 +5106,10 @@
 5203	mixed mirror bug paste	1	EPIC	Effect: "Super-Electrified", Effect Duration: 10, Last Available: "2011-08"
 5204	dehydrated hippy paste	1	good	Effect: "Thick, Sick", Effect Duration: 20, Last Available: "2011-08"
 5205	distilled orc paste	1	decent	Last Available: "2011-08"
-5206	pickled pulsating upside-down demonic paste	1	decent	Last Available: "2011-08"
-5207	twisted cyan pulsating indescribably horrible paste	1	decent	Last Available: "2011-08"
-5208	altered spinning pulsating narrow blue paste	1	decent	Last Available: "2011-08"
-5209	dried maroon blinking pulsating shaking goblin paste	1	crappy	Effect: "You Can Taste the Darkness", Effect Duration: 20, Last Available: "2011-08"
+5206	pickled upside-down pulsating demonic paste	1	decent	Last Available: "2011-08"
+5207	twisted pulsating cyan indescribably horrible paste	1	decent	Last Available: "2011-08"
+5208	altered pulsating narrow spinning blue paste	1	decent	Last Available: "2011-08"
+5209	dried shaking pulsating maroon blinking goblin paste	1	crappy	Effect: "You Can Taste the Darkness", Effect Duration: 20, Last Available: "2011-08"
 5210	pickled gray pirate paste	1	decent	Last Available: "2011-08"
 5211	dried bouncing huge chlorophyll paste	1	decent	Effect: "Greasy Flavor", Effect Duration: 45, Last Available: "2011-08"
 5212	powdered paste	1	awesome	Last Available: "2011-08"
@@ -5124,7 +5124,7 @@
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
 5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
-5224	super-sized tasty cyan Ur-Donut	5	awesome	Last Available: "2011-09"
+5224	tasty super-sized cyan Ur-Donut	5	awesome	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	pulsating box of Familiar Jacks	0		Last Available: "2011-09"
 5227	perfectly mixed blue bucket of wine	3	EPIC	Last Available: "2011-09"
@@ -5144,17 +5144,17 @@
 5241	perfectly mixed blinking Bordeaux Marteaux	3	EPIC	Last Available: "2011-09"
 5242	tolerable Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	acceptable Beignet Milgranet	3	good	Last Available: "2011-09"
-5244	weak acceptable huge Muschat	2	good	Last Available: "2011-09"
+5244	acceptable weak huge Muschat	2	good	Last Available: "2011-09"
 5245	moldy pulsating cool jelly donut	3	crappy	Last Available: "2011-09"
-5246	stale massive shrapnel jelly donut	9	decent	Last Available: "2011-09"
+5246	massive stale shrapnel jelly donut	9	decent	Last Available: "2011-09"
 5247	bland occult jelly donut	3	decent	Last Available: "2011-09"
-5248	super-sized rotten special thyme jelly donut	5	crappy	Last Available: "2011-09"
-5249	flavorless diet danish	1	decent	Last Available: "2011-09"
+5248	special rotten super-sized thyme jelly donut	5	crappy	Last Available: "2011-09"
+5249	diet flavorless danish	1	decent	Last Available: "2011-09"
 5250	decent twirling smashed danish	3	good	Last Available: "2011-09"
 5251	stale forbidden danish	4	decent	Last Available: "2011-09"
 5252	moldy upside-down cool cat claw	3	crappy	Last Available: "2011-09"
 5253	special stale blunt cat claw	3	decent	Effect: "You're Not Cooking", Effect Duration: 20, Last Available: "2011-09"
-5254	yummy enchanted snack-sized jittery shadowy cat claw	2	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 35, Last Available: "2011-09"
+5254	snack-sized yummy enchanted jittery shadowy cat claw	2	awesome	Effect: "Blessing of the Hot Linguine", Effect Duration: 35, Last Available: "2011-09"
 5255	bland cheezburger	4	decent	Last Available: "2011-09"
 5256	jumbo bland toasted brie	5	decent	Last Available: "2011-09"
 5257	unsweetened pulsating maroon skewed potion of the field gar	0		Effect: "Crocodile Tear", Effect Duration: 48, Last Available: "2011-09"
@@ -5170,7 +5170,7 @@
 5267	energized adjusted potion of punctual companionship	0		Effect: "This Is Where You're a Viking", Effect Duration: 26, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	bobcat grenade	0		Last Available: "2011-09"
-5270	spinning red chocolate frosted sugar bomb	0		Last Available: "2011-09"
+5270	red spinning chocolate frosted sugar bomb	0		Last Available: "2011-09"
 5271	broken glass grenade	0		Last Available: "2011-09"
 5272	ghostly noxious gas grenade	0		Last Available: "2011-09"
 5273	blinking skull with a fuse in it	0		Last Available: "2011-09"
@@ -5188,7 +5188,7 @@
 5285	d4	0		Last Available: "2011-09"
 5286	wobbly d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
-5288	jittery blue d10	0		Last Available: "2011-09"
+5288	blue jittery d10	0		Last Available: "2011-09"
 5289	ghostly d12	0		Last Available: "2011-09"
 5290	d20	0		Last Available: "2011-09"
 5291	generic healing potion	0		Last Available: "2011-09"
@@ -5198,7 +5198,7 @@
 5295	upside-down newborn kobold	0		Last Available: "2011-09"
 5296	pulsating spinning slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	skewed dungeon dragon chest	0		Last Available: "2011-09"
-5298	fancy miniature delicious phish stick	2	awesome	Effect: "Greedy Resolve", Effect Duration: 25, Last Available: "2011-09"
+5298	miniature fancy delicious phish stick	2	awesome	Effect: "Greedy Resolve", Effect Duration: 25, Last Available: "2011-09"
 5299	huge tumbling aromatic mansplainer's hardened plastic vampire fangs	0		Damage Reduction: 3, Monster Level: +15, Stench Resistance: +1, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	wobbly Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	mirror Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
@@ -5223,7 +5223,7 @@
 5320	improved Lobos Mints	0		Effect: "Wreathed in Merriment", Effect Duration: 26, Last Available: "2011-10"
 5321	denatured double-flattened Sweet Sword	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 46, Last Available: "2011-10"
 5322	bad yellow Ecto-Cooler	4	decent	Last Available: "2011-10"
-5323	drinkable watered-down Bartles and BRAAAINS wine cooler	2	good	Last Available: "2011-10"
+5323	watered-down drinkable Bartles and BRAAAINS wine cooler	2	good	Last Available: "2011-10"
 5324	artisanal tumbling Blood Light	3	EPIC	Last Available: "2011-10"
 5325	drinkable Silver Bullet beer	4	good	Last Available: "2011-10"
 5326	extra-dry hand-crafted squat Bone's Farm &quot;wine&quot;	5	EPIC	Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	mansplainer's banded smartaleck's The Necbromancer's Shorts	0		Moxie Percent: +30, Damage Absorption: +100, Monster Level: +15, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	Sherlock's scorching Tesla The Necbromancer's Wizard Staff	0		Hot Damage: +25, Item Drop: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-10"
 5341	upside-down The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	drinkable weak pulsating The Cooler Out of Space	2	good	Last Available: "2011-10"
+5342	weak drinkable pulsating The Cooler Out of Space	2	good	Last Available: "2011-10"
 5343	bouncing The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	squat sorority girl's box	0		Last Available: "2011-10"
 5345	warmed Necbro wafers	0		Effect: "OMG WTF", Effect Duration: 40, Last Available: "2020-09"
@@ -5255,7 +5255,7 @@
 5352	A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	lime green jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
-5355	squat ghostly Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
+5355	ghostly squat Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
 5356	A Beginner's Guide to Charming Snakes (used)	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 5357	Zu Mannk&auml;se Dienen (used)	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 5358	Autobiography Of Dynamite Superman Jones (used)	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
@@ -5289,7 +5289,7 @@
 5386	bouncing ridiculous belt of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-11"
 5387	lard-coated ridiculous earring	0		Sleaze Spell Damage: +25, Last Available: "2011-11"
 5388	ridiculous sunglasses of dire peril	0		Weapon Damage: +20, Last Available: "2011-11"
-5389	flavorless tiny ridiculous sandwich	1	decent	Last Available: "2011-11"
+5389	tiny flavorless ridiculous sandwich	1	decent	Last Available: "2011-11"
 5390	irresponsibly strong bad ridiculous cocktail	6	decent	Last Available: "2011-11"
 5391	pulsating cool zombie monkey necklace of wisdom	0		Mysticality: +15, Moxie: +5
 5392	maroon Thwaitgold butterfly statuette	0		
@@ -5300,7 +5300,7 @@
 5397	yummy peppermint patty	3	awesome	Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	peppermint rhino baby	0		Last Available: "2011-11"
-5400	skewed narrow candy cane candygram	0		Last Available: "2011-12"
+5400	narrow skewed candy cane candygram	0		Last Available: "2011-12"
 5401	mirror peppermint parasol	0		Last Available: "2011-11"
 5402	blurry maroon chaotic candy cane	0		Spell Critical Percent: +10, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
@@ -5313,7 +5313,7 @@
 5410	tolerable boozy Mint Yulep	5	good	Last Available: "2011-12"
 5411	smooth special Crimbojito	3	awesome	Effect: "Yuletide Industry", Effect Duration: 50, Last Available: "2011-12"
 5412	tolerable Sangria de Menthe	4	good	Last Available: "2011-12"
-5413	mirror maroon candycaine powder	0		Last Available: "2011-12"
+5413	maroon mirror candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	polarized colloidal dry licorice root	0		Effect: "Ticking Clock", Effect Duration: 43, Last Available: "2011-12"
 5416	modified modified olive banana supersucker	0		Effect: "Pretending to Pretend", Effect Duration: 58, Last Available: "2011-11"
@@ -5345,8 +5345,8 @@
 5442	fuchsia The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
 5444	pickled colloidal devilish folio	0		Effect: "A Few Extra Pounds", Effect Duration: 51, Last Available: "2012-12"
-5445	green pulsating clumsiness bark	0		Last Available: "2012-12"
-5446	purple wobbly jar full of wind	0		Last Available: "2012-12"
+5445	pulsating green clumsiness bark	0		Last Available: "2012-12"
+5446	wobbly purple jar full of wind	0		Last Available: "2012-12"
 5447	dangerous jerkcicle	0		Last Available: "2012-12"
 5448	furious stone	0		Last Available: "2012-12"
 5449	narrow vanity stone	0		Last Available: "2012-12"
@@ -5358,7 +5358,7 @@
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
 5457	flattened concentrated cold-filtered Fudgie Roll	0		Effect: "Macho Profundo", Effect Duration: 62, Last Available: "2011-11"
-5458	normal immense fudge bunny	9	good	Last Available: "2011-11"
+5458	immense normal fudge bunny	9	good	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	Tesla fudgecycle of the ox of the cheetah	0		Muscle: +20, Initiative: +60, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-11"
 5461	fuchsia fudge cube	0		Last Available: "2011-11"
@@ -5377,7 +5377,7 @@
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	squat cyan blurry gummi ingot	0		Last Available: "2011-11"
 5476	moist liquefied tumbling gummi salamander	0		Effect: "Your Favorite Flavor", Effect Duration: 57, Last Available: "2011-11"
-5477	pressed jittery tumbling olive gummi snake	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25, Last Available: "2011-11"
+5477	pressed tumbling olive jittery gummi snake	0		Effect: "Medieval Mage Mayhem", Effect Duration: 25, Last Available: "2011-11"
 5478	alkaline energized gummi canary	0		Effect: "Far Out", Effect Duration: 64, Last Available: "2011-11"
 5479	immense adequate purple gummi bear	8	good	Last Available: "2011-11"
 5480	stale gummi bear	3	decent	Last Available: "2011-11"
@@ -5394,7 +5394,7 @@
 5491	olive trilobite candy mold	0		Last Available: "2011-11"
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
-5494	cold-filtered ionized bouncing shaking gummi trilobite	0		Effect: "Smoky Third Eye", Effect Duration: 44, Last Available: "2011-11"
+5494	cold-filtered ionized shaking bouncing gummi trilobite	0		Effect: "Smoky Third Eye", Effect Duration: 44, Last Available: "2011-11"
 5495	concentrated huge upside-down gummi ammonite	0		Effect: "Red-Shirted Escort", Effect Duration: 23, Last Available: "2011-11"
 5496	deionized colloidal jittery gummi belemnite	0		Effect: "Cool Spirit", Effect Duration: 45, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
@@ -5429,7 +5429,7 @@
 5526	double-energized upside-down Atomic Pop	0		Effect: "A Taste of Rainbow", Effect Duration: 20, Last Available: "2020-09"
 5527	do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	decent gigantic enchanted spinning bouncing berries of suffering	7	good	Effect: "Hoity Toity", Effect Duration: 30, Last Available: "2012-12"
+5529	gigantic enchanted decent bouncing spinning berries of suffering	7	good	Effect: "Hoity Toity", Effect Duration: 30, Last Available: "2012-12"
 5530	chilled teal baobab sap	0		Effect: "Ichorous Intensity", Effect Duration: 28, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
@@ -5445,7 +5445,7 @@
 5542	pulsating pink-belly slapper	0		Last Available: "2012-12"
 5543	prompt Leapin' Trousers of horror	0		Spooky Spell Damage: +25, Adventures: +3
 5544	perfectly mixed eggnog	4	EPIC	Last Available: "2012-12"
-5545	thick stale ghostly hamhock	5	decent	Last Available: "2012-12"
+5545	stale thick ghostly hamhock	5	decent	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	spinning Clancy's sackbut	0		Last Available: "2012-12"
 5548	Ghost Pinching Quarterly	0		Skill: "Pinch Ghost", Last Available: "2012-12"
@@ -5474,39 +5474,39 @@
 5571	huge Groar's fur	0		
 5572	huge Thwaitgold stag beetle statuette	0		
 5573	practically non-alcoholic mediocre Drac & Tan	1	decent	Last Available: "2012-03"
-5574	perfectly mixed triple-distilled Transylvania Sling	8	EPIC	Last Available: "2012-03"
+5574	triple-distilled perfectly mixed Transylvania Sling	8	EPIC	Last Available: "2012-03"
 5575	lousy Shot of the Living Dead	4	decent	Last Available: "2012-03"
 5576	bad squat Buttery Knob	3	decent	Last Available: "2012-03"
 5577	mediocre distilled Slippery Knob	5	decent	Last Available: "2012-03"
 5578	perfectly mixed practically non-alcoholic huge Flaming Knob	1	super ultra EPIC	Last Available: "2012-03"
-5579	strong tolerable Grasshopper	5	good	Last Available: "2012-03"
+5579	tolerable strong Grasshopper	5	good	Last Available: "2012-03"
 5580	bad maroon Locust	3	decent	Last Available: "2012-03"
-5581	enchanted smooth Plague of Locusts	4	awesome	Effect: "Ghostly Shell", Effect Duration: 35, Last Available: "2012-03"
-5582	hand-crafted enchanted green Red Dwarf	4	EPIC	Effect: "Frosty the Hitman", Effect Duration: 30, Last Available: "2012-03"
+5581	smooth enchanted Plague of Locusts	4	awesome	Effect: "Ghostly Shell", Effect Duration: 35, Last Available: "2012-03"
+5582	enchanted hand-crafted green Red Dwarf	4	EPIC	Effect: "Frosty the Hitman", Effect Duration: 30, Last Available: "2012-03"
 5583	drinkable blinking Golden Mean	4	good	Last Available: "2012-03"
 5584	tolerable Green Giant	4	good	Last Available: "2012-03"
 5585	tolerable Aye Aye	4	good	Last Available: "2012-03"
 5586	drinkable gray Aye Aye, Captain	3	good	Last Available: "2012-03"
-5587	drinkable watered-down Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
-5588	extra-dry tolerable squat Humanitini	5	good	Last Available: "2012-03"
+5587	watered-down drinkable Aye Aye, Tooth Tooth	2	good	Last Available: "2012-03"
+5588	tolerable extra-dry squat Humanitini	5	good	Last Available: "2012-03"
 5589	acceptable red More Humanitini than Humanitini	4	good	Last Available: "2012-03"
 5590	hand-crafted Oh, the Humanitini	4	EPIC	Last Available: "2012-03"
-5591	weak drinkable Great Older Fashioned	2	good	Last Available: "2012-03"
+5591	drinkable weak Great Older Fashioned	2	good	Last Available: "2012-03"
 5592	drinkable Fuzzy Tentacle	4	good	Last Available: "2012-03"
 5593	hand-crafted extra-dry red Crazymaker	5	EPIC	Last Available: "2012-03"
 5594	aged practically non-alcoholic Zoodriver	1	awesome	Last Available: "2012-03"
 5595	aged purple mirror Sloe Comfortable Zoo	3	awesome	Last Available: "2012-03"
-5596	hand-crafted practically non-alcoholic cyan Sloe Comfortable Zoo on Fire	1	super ultra EPIC	Last Available: "2012-03"
+5596	practically non-alcoholic hand-crafted cyan Sloe Comfortable Zoo on Fire	1	super ultra EPIC	Last Available: "2012-03"
 5597	aged triple-distilled Suffering Sinner	10	awesome	Last Available: "2012-03"
-5598	mediocre practically non-alcoholic Suppurating Sinner	1	decent	Last Available: "2012-03"
+5598	practically non-alcoholic mediocre Suppurating Sinner	1	decent	Last Available: "2012-03"
 5599	weak lousy bouncing teal Sizzling Sinner	2	decent	Last Available: "2012-03"
 5600	hand-crafted Firewater	3	EPIC	Last Available: "2012-03"
-5601	practically non-alcoholic mediocre Earth and Firewater	1	decent	Last Available: "2012-03"
+5601	mediocre practically non-alcoholic Earth and Firewater	1	decent	Last Available: "2012-03"
 5602	drinkable mirror Earth, Wind and Firewater	4	good	Last Available: "2012-03"
-5603	irresponsibly strong lousy Slimosa	9	decent	Last Available: "2012-03"
+5603	lousy irresponsibly strong Slimosa	9	decent	Last Available: "2012-03"
 5604	perfectly mixed Extra-slimy Slimosa	4	EPIC	Last Available: "2012-03"
 5605	mediocre Slimebite	3	decent	Last Available: "2012-03"
-5606	weak delicious tumbling Cement Mixer	2	awesome	Last Available: "2012-03"
+5606	delicious weak tumbling Cement Mixer	2	awesome	Last Available: "2012-03"
 5607	mediocre Jackhammer	3	decent	Last Available: "2012-03"
 5608	drinkable maroon Dump Truck	3	good	Last Available: "2012-03"
 5609	fortified drinkable red skewed Fauna Libre	5	good	Last Available: "2012-03"
@@ -5515,33 +5515,33 @@
 5612	lousy Sazerorc	4	decent	Last Available: "2012-03"
 5613	tolerable pulsating Sazuruk-hai	3	good	Last Available: "2012-03"
 5614	fancy bad Flaming Sazerorc	4	decent	Effect: "Tiki Toughness", Effect Duration: 15, Last Available: "2012-03"
-5615	special lousy Green Velvet	4	decent	Effect: "Hot Blooded", Effect Duration: 15, Last Available: "2012-03"
+5615	lousy special Green Velvet	4	decent	Effect: "Hot Blooded", Effect Duration: 15, Last Available: "2012-03"
 5616	triple-distilled hand-crafted Green Muslin	6	EPIC	Last Available: "2012-03"
 5617	acceptable green Green Burlap	3	good	Last Available: "2012-03"
 5618	delicious Mohobo	4	awesome	Last Available: "2012-03"
-5619	drinkable extra-dry Moonshine Mohobo	5	good	Last Available: "2012-03"
+5619	extra-dry drinkable Moonshine Mohobo	5	good	Last Available: "2012-03"
 5620	lousy special Flaming Mohobo	3	decent	Effect: "Human-Human Hybrid", Effect Duration: 40, Last Available: "2012-03"
 5621	acceptable Drunken Philosopher	3	good	Last Available: "2012-03"
 5622	bad Drunken Neurologist	4	decent	Last Available: "2012-03"
 5623	perfectly mixed Drunken Astrophysicist	3	EPIC	Last Available: "2012-03"
 5624	drinkable Dark & Starry	4	good	Last Available: "2012-03"
 5625	hand-crafted shaking Black Hole	3	EPIC	Last Available: "2012-03"
-5626	tolerable strong Event Horizon	5	good	Last Available: "2012-03"
-5627	smooth watered-down Herring Daiquiri	2	awesome	Last Available: "2012-03"
+5626	strong tolerable Event Horizon	5	good	Last Available: "2012-03"
+5627	watered-down smooth Herring Daiquiri	2	awesome	Last Available: "2012-03"
 5628	tolerable maroon Herring Wallbanger	3	good	Last Available: "2012-03"
 5629	hand-crafted Herringtini	3	EPIC	Last Available: "2012-03"
 5630	artisanal practically non-alcoholic Lollipop Drop	1	EPIC	Last Available: "2012-03"
 5631	mediocre Candy Alexander	4	decent	Last Available: "2012-03"
-5632	special aged weak Candicaine	2	awesome	Effect: "Polka of Plenty", Effect Duration: 5, Last Available: "2012-03"
+5632	weak aged special Candicaine	2	awesome	Effect: "Polka of Plenty", Effect Duration: 5, Last Available: "2012-03"
 5633	acceptable Caipiranha	3	good	Last Available: "2012-03"
 5634	drinkable bouncing Flying Caipiranha	3	good	Last Available: "2012-03"
 5635	hand-crafted practically non-alcoholic Flaming Caipiranha	1	super ultra EPIC	Last Available: "2012-03"
-5636	weak bad mirror blinking Punchplanter	2	decent	Last Available: "2012-03"
-5637	perfectly mixed boozy fancy Doublepunchplanter	5	EPIC	Effect: "A View to Some Meat", Effect Duration: 5, Last Available: "2012-03"
+5636	weak bad blinking mirror Punchplanter	2	decent	Last Available: "2012-03"
+5637	fancy boozy perfectly mixed Doublepunchplanter	5	EPIC	Effect: "A View to Some Meat", Effect Duration: 5, Last Available: "2012-03"
 5638	acceptable ghostly Haymaker	4	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	huge crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	adequate miniature ghostly fungus	2	good	
+5641	miniature adequate ghostly fungus	2	good	
 5642	poisoned dart	0		
 5643	colloidal denatured bouncing stone wool	0		Effect: "Alchemical, Brother", Effect Duration: 22
 5644	upside-down stones	0		
@@ -5555,9 +5555,9 @@
 5652	Monster Manuel	0		Free Pull
 5653	wobbly wobbly key-o-tron	0		
 5654	spoiled special nailswurst	3	crappy	Effect: "Newt Gets In Your Eyes", Effect Duration: 20
-5655	bad boozy used beer	5	decent	
+5655	boozy bad used beer	5	decent	
 5656	Huggler Radio	0		Free Pull
-5657	tumbling pulsating fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
+5657	pulsating tumbling fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
 5659	yellow wobbly insulting hat of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "cap 2"
 5660	spinning tumbling knitted offensive moustache	0		Cold Resistance: +3, Single Equip
@@ -5570,12 +5570,12 @@
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	wobbly club	0		
-5670	super-sized normal fettucini &eacute;pines Inconnu	5	good	
+5670	normal super-sized fettucini &eacute;pines Inconnu	5	good	
 5671	artisanal slap and slap again	3	EPIC	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
-5675	pickled twirling wobbly watered-down Red Minotaur	1		Effect: "Blood-Gorged", Effect Duration: 50
+5675	pickled wobbly twirling watered-down Red Minotaur	1		Effect: "Blood-Gorged", Effect Duration: 50
 5676	pulsating pool torpedo	0		Last Available: "2012-05"
 5677	Sherlock's Ze&trade; goggles	0		Item Drop: +25, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	soggy used band-aid	0		Last Available: "2012-05"
@@ -5613,7 +5613,7 @@
 5712	upside-down experienced fire axe	0		Experience: +2, Last Available: "2012-07"
 5713	red aromatic dog trainer's baleful fire extinguisher	0		Spell Damage: +25, Experience (familiar): +1, Stench Resistance: +1, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
-5715	tumbling pulsating Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
+5715	pulsating tumbling Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	delicious tiny FDKOL hotcakes	1	awesome	Last Available: "2012-07"
 5718	gray hot egg	0		Last Available: "2012-07"
@@ -5629,10 +5629,10 @@
 5728	friendly foot-long hot daub of the pedagogue	0		Experience: +3, Familiar Weight: +3, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	decent angst burger	3	good	
-5731	lousy weak jittery gray 5-hour acrimony	2	decent	
+5731	weak lousy gray jittery 5-hour acrimony	2	decent	
 5732	purple blank note	0		
 5733	eerily silent box	0		
-5734	enchanted rotten miniature forbidden sausage	2	crappy	Effect: "Insatiable Hunger", Effect Duration: 5
+5734	rotten enchanted miniature forbidden sausage	2	crappy	Effect: "Insatiable Hunger", Effect Duration: 5
 5735	greedy Lord Flameface's cloak	0		Meat Drop: +20, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	liquefied deionized Drizzlers&trade; Black Licorice	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 56
 5737	cold-filtered flattened daub-breaker	0		Effect: "Stimulated Brain", Effect Duration: 57, Last Available: "2020-09"
@@ -5640,7 +5640,7 @@
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
 5740	moldy bag of GORP	3	crappy	Last Available: "2012-07"
 5741	mediocre water purification pills	4	decent	Last Available: "2012-07"
-5742	squat olive Camp Scout pup tent	0		Last Available: "2012-07"
+5742	olive squat Camp Scout pup tent	0		Last Available: "2012-07"
 5743	aged squat CSA scoutmaster's &quot;water&quot;	3	awesome	Last Available: "2012-07"
 5744	bland enchanted blue bag of GORF	3	decent	Effect: "Highland Sheen", Effect Duration: 10, Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
@@ -5652,8 +5652,8 @@
 5751	Tales of the Word Realms	0		
 5752	tiny normal upside-down crappy brain	1	good	
 5753	delicious decent brain	3	awesome	
-5754	half-sized special moldy good brain	2	crappy	Effect: "Badger Underfoot", Effect Duration: 45
-5755	small normal shaking upside-down boss brain	2	good	
+5754	half-sized moldy special good brain	2	crappy	Effect: "Badger Underfoot", Effect Duration: 45
+5755	small normal upside-down shaking boss brain	2	good	
 5756	normal thick hunter brain	5	good	
 5758	slick strapping Staff of Holiday Sensations of terror	0		Muscle: +5, Moxie: +10, Spooky Spell Damage: +10, Last Available: "2011-11"
 5759	weightlifter's beefy staff	0		Muscle: 25
@@ -5677,7 +5677,7 @@
 5778	spoiled low-calorie bouncing idiot brain	1	crappy	
 5779	keel-haulin' knife	0		Item Drop: +5
 5780	ice cream scoop of mayonnaise	0		Sleaze Spell Damage: +50
-5781	practically non-alcoholic perfectly mixed soft echo eyedrop antidote martini	1	super ultra mega turbo EPIC	
+5781	perfectly mixed practically non-alcoholic soft echo eyedrop antidote martini	1	super ultra mega turbo EPIC	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	cyan pulsating weirdwood plank	0		
@@ -5726,7 +5726,7 @@
 5827	altered flattened skeletal banana	0		Effect: "Moose Wisdom", Effect Duration: 30
 5828	extra-tarnished bouncing gilt perfume bottle	0		Effect: "Fireproof Lips", Effect Duration: 57
 5829	concentrated janglin' bones	0		Effect: "Rushtacean'", Effect Duration: 36
-5830	quadruple-enhanced lime green squat pygmy papers	0		Effect: "Badger Underfoot", Effect Duration: 48
+5830	quadruple-enhanced squat lime green pygmy papers	0		Effect: "Badger Underfoot", Effect Duration: 48
 5831	liquefied pygmy dart	0		Effect: "Hot Jellied", Effect Duration: 62
 5832	adjusted pressed triple-activated spinning blurry secret mummy herbs and spices	0		Effect: "Reedy Pipes", Effect Duration: 58
 5833	cold-filtered diffused huge brigand brittle	0		Effect: "Extra-Wet", Effect Duration: 31
@@ -5747,7 +5747,7 @@
 5848	ionized corrupted huge Bangyomaman battle juice	0		Effect: "Sugar Smacks", Effect Duration: 50
 5849	liquefied colloidal squat bouncing handyman &quot;hand soap&quot;	0		Effect: "Extra Terrestrial", Effect Duration: 26
 5850	aerosolized space marine flash grenade	0		Effect: "Super Skill", Effect Duration: 36
-5851	polarized squat blurry temporary tribal tattoo	0		Effect: "Cold Blooded", Effect Duration: 11
+5851	polarized blurry squat temporary tribal tattoo	0		Effect: "Cold Blooded", Effect Duration: 11
 5852	super-denatured magnetized spinning oil-filled donut	0		Effect: "What's That Smell?", Effect Duration: 48
 5853	altered purple stick-on gnome beard	0		Effect: "Towering Strength", Effect Duration: 55
 5854	extra-moist moist fuchsia BRICKO stud	0		Effect: "Mana Tea", Effect Duration: 59
@@ -5783,12 +5783,12 @@
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	huge skeletal skiff	0		Last Available: "2012-10"
 5886	miser's lion tamer's steel-toed Bonestabber of the overflowing toilet	0		Damage Reduction: 9, Experience (familiar): +2, Stench Spell Damage: +50, Meat Drop: +10, Last Available: "2012-10"
-5887	perfectly mixed practically non-alcoholic crystal skeleton vodka	1	super ultra mega turbo EPIC	Last Available: "2012-10"
+5887	practically non-alcoholic perfectly mixed crystal skeleton vodka	1	super ultra mega turbo EPIC	Last Available: "2012-10"
 5888	upside-down Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	groovy auxiliary backbone	0		Moxie Percent: +10, Last Available: "2012-10"
 5890	skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
-5892	wet bouncing spinning that gum you like	0		Effect: "Night Vision", Effect Duration: 41
+5892	wet spinning bouncing that gum you like	0		Effect: "Night Vision", Effect Duration: 41
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	twirling avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
@@ -5821,7 +5821,7 @@
 5923	plastic ingot	0		Last Available: "2012-12"
 5924	twirling electrical thingamabob	0		Last Available: "2012-12"
 5925	wobbly ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
-5926	twirling blue BittyCar MeatCar	0		Last Available: "2012-12"
+5926	blue twirling BittyCar MeatCar	0		Last Available: "2012-12"
 5927	blurry BittyCar HotCar	0		Last Available: "2012-12"
 5928	Sherlock's brainwave-controlled unicorn horn	0		Item Drop: +25, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
@@ -5873,11 +5873,11 @@
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	avaricious scorching silent beret of the brazier	0		Hot Damage: +25, Hot Spell Damage: +25, Meat Drop: +30, Familiar Effect: "1xVolley, cap 3"
-5978	stale miniature jittery slice of pizza	2	decent	Last Available: "2013-02"
+5978	miniature stale jittery slice of pizza	2	decent	Last Available: "2013-02"
 5979	twirling huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	ghostly star	0		Last Available: "2013-02"
-5982	drinkable fortified tankard of ale	5	good	Last Available: "2013-02"
+5982	fortified drinkable tankard of ale	5	good	Last Available: "2013-02"
 5983	twirling vial of holy water	0		Last Available: "2013-02"
 5984	horrifying gravedigger's deadly cloth cap	0		Weapon Damage: +5, Spooky Damage: 35, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	Sinatra's supercool iron dagger of horror	0		Moxie Percent: +20, Experience (Moxie): +5, Spooky Spell Damage: +25, Last Available: "2013-02"
@@ -5889,7 +5889,7 @@
 5991	round bomb	0		Last Available: "2013-02"
 5992	studded supercool iron helmet of the brazier	0		Moxie Percent: +20, Damage Absorption: +80, Hot Spell Damage: +25, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	spinning ruddy hardened smartaleck's steel sword	0		Moxie Percent: +30, Damage Reduction: 3, Maximum HP Percent: +40, Last Available: "2013-02"
-5994	spoiled narrow gray whole roasted chicken	3	crappy	Last Available: "2013-02"
+5994	spoiled gray narrow whole roasted chicken	3	crappy	Last Available: "2013-02"
 5995	skewed massive gemstone	0		Last Available: "2013-02"
 5996	extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
@@ -5930,10 +5930,10 @@
 6032	Lo Pan's padded motorcycle boots	0		Damage Absorption: +20, Spell Critical Percent: +30, Single Equip
 6033	mirror horrifying sage stolen necklace	0		Mysticality Percent: +10, Spooky Damage: +25
 6034	Tesla beefcake's troll britches	0		Muscle: +25, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xPotato, cap 28"
-6035	wet lime green pulsating vial of The Glistening	0		Effect: "Pasta Oneness", Effect Duration: 43
+6035	wet pulsating lime green vial of The Glistening	0		Effect: "Pasta Oneness", Effect Duration: 43
 6036	tolerable artisanal limoncello	4	good	
 6037	mirror ginger ale	0		
-6038	decent red narrow incredible pizza	4	good	
+6038	decent narrow red incredible pizza	4	good	
 6039	Temple Grandin's oil cap of the sewer	0		Familiar Weight: +7, Stench Damage: +25, Familiar Effect: "cap 28"
 6040	Jim Carey's wholesome oil lamp	0		Maximum HP Percent: +10, Monster Level: +25
 6041	groovy oil slacks	0		Moxie Percent: +10, Familiar Effect: "1xPotato, cap 30"
@@ -5948,7 +5948,7 @@
 6050	woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	bite-sized bland Taco Dan's Taco Stand Taco	1	decent	Last Available: "2012-12"
-6053	perfectly mixed fortified Taco Dan's Taco Stand Chimichangarita	5	EPIC	Last Available: "2012-12"
+6053	fortified perfectly mixed Taco Dan's Taco Stand Chimichangarita	5	EPIC	Last Available: "2012-12"
 6054	concentrated Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Trivia Master", Effect Duration: 16, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
@@ -5959,7 +5959,7 @@
 6061	shellacked Crimbo tree flocker	0		Damage Reduction: 7, Last Available: "2012-12"
 6062	ruddy Crimbo light-up Rudolph doll	0		Maximum HP Percent: +40, Last Available: "2012-12"
 6063	yellow blinking pulsating Super Crimboman Ultra Mega Hypersword of the sewer	0		Stench Damage: +25, Last Available: "2012-12"
-6064	teal bouncing sharp tin strip	0		
+6064	bouncing teal sharp tin strip	0		
 6065	wad of spider silk	0		
 6066	goblin collarbone	0		
 6067	quilted Truthsayer of James Dean	0		Experience (Moxie): +3, Damage Absorption: +40, Last Available: "2013-12"
@@ -5969,10 +5969,10 @@
 6071	mirror blue Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	dry non-galvanized haggis-infused soap	0		Effect: "Worth Your Salt", Effect Duration: 64, Last Available: "2012-12"
-6074	extra-magnetized blinking jittery magicberry tablets	0		Effect: "Egg-stortionary Tactics", Effect Duration: 29, Last Available: "2012-12"
+6074	extra-magnetized jittery blinking magicberry tablets	0		Effect: "Egg-stortionary Tactics", Effect Duration: 29, Last Available: "2012-12"
 6075	moist purple 37x37x37 puzzle cube	0		Effect: "Vitali Tea", Effect Duration: 68, Last Available: "2012-12"
 6076	mediocre special ghostly McLeod's Hard Haggis-Ade	3	decent	Effect: "Stuck That Way", Effect Duration: 25, Last Available: "2012-12"
-6077	immense spoiled olive haggis-wrapped haggis-stuffed haggis	10	crappy	Last Available: "2012-12"
+6077	spoiled immense olive haggis-wrapped haggis-stuffed haggis	10	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
 6080	experienced haggis socks	0		Experience: +2, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
@@ -6000,7 +6000,7 @@
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	Artist's Whisk of Misery	0		Last Available: "2013-12"
 6104	ghostly Artist's Butterknife of Regret	0		Last Available: "2013-12"
-6105	jittery blurry Artist's Spatula of Despair	0		Last Available: "2013-12"
+6105	blurry jittery Artist's Spatula of Despair	0		Last Available: "2013-12"
 6106	Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	skewed Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	Tesla quilted Ginsu&trade;	0		Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
@@ -6026,7 +6026,7 @@
 6128	upside-down furry brown pillow	0		Last Available: "2013-12"
 6129	makeshift yakuza mask	0		Item Drop: +5, Last Available: "2013-12"
 6130	maroon piece	0		Last Available: "2013-12"
-6131	squat jittery toy taijijian	0		Last Available: "2013-12"
+6131	jittery squat toy taijijian	0		Last Available: "2013-12"
 6132	battery	0		Last Available: "2013-12"
 6133	family-friendly brawny White Dragon Fang of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Sleaze Resistance: +1, Last Available: "2013-12"
 6134	resourceful butterfly knife	0		Maximum MP: +50, Last Available: "2013-12"
@@ -6038,7 +6038,7 @@
 6140	upside-down yellow Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	yummy roasted duck	3	awesome	Last Available: "2013-12"
-6143	spoiled snack-sized dead meat bun	2	crappy	Last Available: "2013-12"
+6143	snack-sized spoiled dead meat bun	2	crappy	Last Available: "2013-12"
 6144	Da Vinci's cat collar	0		Experience (Mysticality): +5, Single Equip, Last Available: "2013-12"
 6145	forbidden cool suspicious-looking fedora	0		Moxie: +5, Spell Damage Percent: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	tumbling Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6063,7 +6063,7 @@
 6166	spinning Jeselnik's deck cannon of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +25, Last Available: "2013-12"
 6167	smelly ornamental sextant	0		Stench Spell Damage: +10, Last Available: "2013-12"
 6168	fireproof beefcake's Bloodbath	0		Muscle: +25, Hot Resistance: +3, Last Available: "2013-12"
-6169	watered-down artisanal teal spinning Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
+6169	artisanal watered-down spinning teal Hundred Headed IPA	2	EPIC	Last Available: "2013-12"
 6170	moldy chum	4	crappy	Last Available: "2013-12"
 6171	moist quadruple-warmed crude crudit&eacute;s	0		Effect: "Stogied", Effect Duration: 62
 6172	tarnished spinning candy crayons	0		Effect: "Innately Truthy", Effect Duration: 24, Last Available: "2020-09"
@@ -6082,47 +6082,47 @@
 6185	spoiled fancy consummate hard-boiled egg	3	crappy	Effect: "Innately Wise", Effect Duration: 15
 6186	bland consummate fried egg	4	decent	
 6187	adequate consummate egg salad	4	good	
-6188	normal gigantic pulsating skewed consummate bagel	10	good	
+6188	normal gigantic skewed pulsating consummate bagel	10	good	
 6189	normal shaking consummate sliced bread	4	good	
-6190	normal diet fancy yellow consummate hot dog bun	1	good	Effect: "Thought", Effect Duration: 50
+6190	fancy diet normal yellow consummate hot dog bun	1	good	Effect: "Thought", Effect Duration: 50
 6191	adequate consummate brownie	3	good	
-6192	miniature tasty consummate toast	2	awesome	
-6193	bad special weak passable stout	2	decent	Effect: "Abyssal Sweat", Effect Duration: 30
+6192	tasty miniature consummate toast	2	awesome	
+6193	weak special bad passable stout	2	decent	Effect: "Abyssal Sweat", Effect Duration: 30
 6194	adequate consummate soup	3	good	
 6195	flavorless jumbo consummate corn chips	5	decent	
 6196	normal consummate salad	3	good	
 6197	huge stale consummate salsa	6	decent	
 6198	stale consummate sauerkraut	3	decent	
-6199	jumbo stale enchanted shaking narrow consummate cheese slice	5	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25
+6199	jumbo enchanted stale narrow shaking consummate cheese slice	5	decent	Effect: "The Wisdom... of the Future", Effect Duration: 25
 6200	small rotten consummate melted cheese	2	crappy	
 6201	decent mirror consummate bacon	4	good	
-6202	moldy snack-sized blue consummate meatloaf	2	crappy	
+6202	snack-sized moldy blue consummate meatloaf	2	crappy	
 6203	rotten consummate steak	3	crappy	
-6204	adequate miniature consummate cuts	2	good	
+6204	miniature adequate consummate cuts	2	good	
 6205	flavorless consummate frankfurter	3	decent	
-6206	rotten miniature consummate french fries	2	crappy	
+6206	miniature rotten consummate french fries	2	crappy	
 6207	toothsome super-sized consummate baked potato	5	awesome	
 6208	delicious jittery acceptable vodka	3	awesome	
 6209	delicious consummate ice cream	3	awesome	
 6210	normal consummate whipped cream	3	good	
-6211	special thick stale consummate cream	5	decent	Effect: "Toothy Grin", Effect Duration: 50
+6211	thick stale special consummate cream	5	decent	Effect: "Toothy Grin", Effect Duration: 50
 6212	rotten ghostly consummate strawberries	4	crappy	
 6213	bland half-sized consummate sorbet	2	decent	
-6214	enchanted triple-distilled bad adequate rum	7	decent	Effect: "All Fired Up", Effect Duration: 25
-6215	weak perfectly mixed fancy mediocre lager	2	EPIC	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30
-6216	adequate half-sized immaculate grilled cheese	2	good	
+6214	bad triple-distilled enchanted adequate rum	7	decent	Effect: "All Fired Up", Effect Duration: 25
+6215	fancy perfectly mixed weak mediocre lager	2	EPIC	Effect: "Brawnee's Anthem of Absorption", Effect Duration: 30
+6216	half-sized adequate immaculate grilled cheese	2	good	
 6217	flavorless immaculate ice cream sandwich	3	decent	
-6218	stale fancy mirror blinking immaculate hot dog	3	decent	Effect: "Full of Vinegar", Effect Duration: 50
+6218	fancy stale blinking mirror immaculate hot dog	3	decent	Effect: "Full of Vinegar", Effect Duration: 50
 6219	bland immaculate egg salad sandwich	3	decent	
 6220	diet decent perfect sandwich	1	good	
-6221	small decent upside-down perfect chef salad	2	good	
+6221	decent small upside-down perfect chef salad	2	good	
 6222	thick toothsome twirling perfect breakfast	5	awesome	
 6223	stale bite-sized sublime deluxe hot dog	1	decent	
 6224	flavorless sublime stew	3	decent	
-6225	rotten low-calorie sublime nachos	1	crappy	
+6225	low-calorie rotten sublime nachos	1	crappy	
 6226	stale bite-sized Ultimate Breakfast Sandwich	1	decent	
 6227	special bland olive Loaded Baked Potato	4	decent	Effect: "Sugary World View", Effect Duration: 35
-6228	stale immense pulsating Omega Sundae	10	decent	
+6228	immense stale pulsating Omega Sundae	10	decent	
 6229	tolerable wobbly Das Sauerlager	3	good	
 6230	spirit-forward perfectly mixed Bologna Lambic	5	EPIC	
 6231	drinkable Vodka Dog	4	good	
@@ -6202,7 +6202,7 @@
 6306	Cosmic Calorie	0		Last Available: "2013-03"
 6307	triple-deionized super-warmed celestial olive oil	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 12, Last Available: "2013-03"
 6308	Vulcanized frozen celestial carrot juice	0		Effect: "Just the Brown Ones", Effect Duration: 55, Last Available: "2013-03"
-6309	pickled teal wobbly celestial au jus	0		Effect: "Slimily Strong", Effect Duration: 26, Last Available: "2013-03"
+6309	pickled wobbly teal celestial au jus	0		Effect: "Slimily Strong", Effect Duration: 26, Last Available: "2013-03"
 6310	quadruple-improved non-dry shaking celestial squid ink	0		Effect: "Hyperoffended", Effect Duration: 58, Last Available: "2013-03"
 6311	squat cyan stylish Uncle Buck	0		Moxie: +25, Softcore Only
 6312	crate of fish meat	0		
@@ -6270,10 +6270,10 @@
 6374	gray angry inch	0		
 6375	frosty testy toolbox	0		Cold Spell Damage: +10
 6376	Jick-o-User	0		
-6378	mirror wobbly eraser nubbin	0		
+6378	wobbly mirror eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	denatured super-quantum ph balancer	0		Effect: "Memory of Speed", Effect Duration: 69
-6381	energized alkaline lime green twirling mysterious chemical residue	0		Effect: "Cat Class, Cat Style", Effect Duration: 22
+6381	energized alkaline twirling lime green mysterious chemical residue	0		Effect: "Cat Class, Cat Style", Effect Duration: 22
 6382	blinking nugget of sodium	0		
 6383	root beer	1	good	
 6384	jigsaw blade	0		
@@ -6285,7 +6285,7 @@
 6390	anodized skewed Mer-kin saltmint	0		Effect: "Rushin' Hands", Effect Duration: 66
 6391	polymerized Mer-kin saltsquid	0		Effect: "Tiki Temerity", Effect Duration: 35
 6392	family-friendly quilted scale-mail underwear	0		Damage Absorption: +40, Sleaze Resistance: +1, Familiar Effect: "2xVolley"
-6393	anodized dry huge squat comb jelly	0		Effect: "In Tuna", Effect Duration: 55
+6393	anodized dry squat huge comb jelly	0		Effect: "In Tuna", Effect Duration: 55
 6394	anemone sauce	0		
 6395	inky squid sauce	0		
 6396	upside-down Mer-kin weaksauce	0		
@@ -6295,7 +6295,7 @@
 6400	Mer-kin lunchbox	0		
 6401	unsweetened magnetized tumbling tear	0		Effect: "Soles of Glass", Effect Duration: 47
 6402	Vulcanized vacuum-sealed jagged tooth	0		Effect: "Executive Greed", Effect Duration: 58
-6403	oxidized shaking purple grisly shell fragment	0		Effect: "Crimbo Epiphany", Effect Duration: 16
+6403	oxidized purple shaking grisly shell fragment	0		Effect: "Crimbo Epiphany", Effect Duration: 16
 6404	tarnished denatured violent pastilles	0		Effect: "Trufflin'", Effect Duration: 18
 6405	concentrated worst candy	0		Effect: "You're Rubber", Effect Duration: 16
 6406	oxidized polarized fudge-shaped hole in space-time	0		Effect: "Pwnd", Effect Duration: 54
@@ -6307,7 +6307,7 @@
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	blue clutch of dodecapede eggs	0		
-6415	enchanted flavorless flavorless gruel	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 15
+6415	flavorless enchanted flavorless gruel	3	decent	Effect: "Belch the Rainbow&trade;", Effect Duration: 15
 6416	decent mana curds	3	good	
 6417	twist of lime	0		
 6418	purple spinning pencil stub	0		
@@ -6338,7 +6338,7 @@
 6443	blinking sizzling healthy Helps-You-Sleep	0		Maximum HP Percent: +20, Hot Damage: +10, Single Equip
 6444	frosty rosy-cheeked Socratic Quiets-Your-Steps	0		Experience (Mysticality): +1, Maximum HP Percent: +30, Cold Spell Damage: +10, Single Equip
 6445	pulsating frosty beefy Protects-Your-Junk	0		Muscle: +10, Cold Spell Damage: +10, Single Equip
-6446	weak tolerable pulsating Gets-You-Drunk	2	good	
+6446	tolerable weak pulsating Gets-You-Drunk	2	good	
 6447	inspector's wizardly Great Wolf's headband	0		Mysticality: +25, Item Drop: 20, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	executive Great Wolf's left paw of chilblains of the brazier	0		Cold Damage: +25, Hot Spell Damage: +25, Meat Drop: +40, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	scandalous fortified baleful Great Wolf's right paw	0		Spell Damage: +25, Damage Absorption: +60, Sleaze Damage: +5, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6379,7 +6379,7 @@
 6484	cyan dread tarragon	0		
 6485	bone flour	0		
 6486	dreadful roast	0		
-6487	ghostly squat stinking agaricus	0		
+6487	squat ghostly stinking agaricus	0		
 6488	enchanted stale Dreadsylvanian shepherd's pie	3	decent	Effect: "Human-Machine Hybrid", Effect Duration: 15
 6489	music box parts	0		
 6490	mirror cyan unwound mechanical songbird	0		
@@ -6398,7 +6398,7 @@
 6503	purple ghost pencil	0		
 6504	pulsating chaotic supercharged hardy hangman's hood	0		Maximum HP: +50, Maximum MP Percent: +30, Spell Critical Percent: +10
 6505	Jeselnik's ruddy ring finger ring of mayonnaise	0		Maximum HP Percent: +40, Sleaze Damage: +25, Sleaze Spell Damage: +50, Single Equip
-6506	cyan squat Dreadsylvanian clockwork key	0		
+6506	squat cyan Dreadsylvanian clockwork key	0		
 6507	cool iron ingot	0		
 6508	miser's cool iron helmet of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Familiar Effect: "atk, 1xFairy"
 6509	skewed avaricious MacGyver's cool iron breastplate	0		Maximum MP: +100, Meat Drop: +30
@@ -6408,7 +6408,7 @@
 6513	twirling slick warm fur	0		Moxie: +10
 6514	rosewater-soaked snowstick	0		Stench Resistance: +3
 6515	jittery blinking pulsating perfumed eerie fetish	0		Stench Resistance: +5, Single Equip
-6516	practically non-alcoholic delicious skewed tumbling stinkwater	1	awesome	
+6516	delicious practically non-alcoholic tumbling skewed stinkwater	1	awesome	
 6517	ghostly dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	super-sized delicious accidental mutton	5	awesome	
 6519	spinning double-paned veiny drafty drawers	0		Maximum HP: +10, Cold Resistance: +5, Familiar Effect: "1.5xVolley"
@@ -6455,8 +6455,8 @@
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	razor-sharp hand of Mr. Cards	0		Weapon Damage Percent: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	bland fancy miniature Dreadsylvanian hot pocket	2	decent	Effect: "Deadly Flashing Blade", Effect Duration: 50
-6565	snack-sized normal bouncing Dreadsylvanian pocket	2	good	
+6564	miniature fancy bland Dreadsylvanian hot pocket	2	decent	Effect: "Deadly Flashing Blade", Effect Duration: 50
+6565	normal snack-sized bouncing Dreadsylvanian pocket	2	good	
 6566	toothsome Dreadsylvanian pocket	3	awesome	
 6567	normal Dreadsylvanian stink pocket	3	good	
 6568	yummy Dreadsylvanian sleaze pocket	4	awesome	
@@ -6471,7 +6471,7 @@
 6577	fuchsia stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
 6579	Dreadsylvanian Almanac page	0		
-6580	mirror huge shaking length of fuse	0		
+6580	shaking huge mirror length of fuse	0		
 6581	dreadful box	0		
 6582	Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
 6583	vicious spiked collar	0		Familiar Damage: +20
@@ -6488,7 +6488,7 @@
 6594	hot Dreadsylvanian cocoa	0		
 6595	denatured epic cluster	1	good	
 6596	clockwork egg	0		
-6597	blinking lime green clockwork birdhouse	0		
+6597	lime green blinking clockwork birdhouse	0		
 6598	clockwork disc	0		
 6599	shaking clockwork hand	0		
 6600	mirror clockwork hand	0		
@@ -6506,7 +6506,7 @@
 6612	blurry clockwork numeral XII	0		
 6613	mirror clockwork cuckoo	0		
 6614	jittery cuckoo clock	0		
-6615	watered-down delicious Cold One	2	???	
+6615	delicious watered-down Cold One	2	???	
 6616	normal twirling spaghetti breakfast	3	???	
 6617	blurry over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6529,7 +6529,7 @@
 6635	fuchsia folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
 6637	folder (catfish)	0		Familiar Weight: +15, Last Available: "2013-08"
-6638	spinning purple folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
+6638	purple spinning folder (tranquil landscape)	0		Damage Reduction: 15, HP Regen Min: 10, HP Regen Max: 20, MP Regen Min: 10, MP Regen Max: 20, Last Available: "2013-08"
 6639	fuchsia folder (owl)	0		Last Available: "2013-08"
 6640	twirling folder (Stinky Trash Kid)	0		Last Available: "2013-08"
 6641	folder (sports car)	0		Adventures: +5, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	moist energized Ogres and Oubliettes&trade; module	0		Effect: "Okee-Dokee Go!", Effect Duration: 69
 6650	narrow Mountain Stream Code Black Alert	0		
 6651	tumbling twisted-up wet towel	0		
-6652	extra-dry artisanal stepmom's booze	5	EPIC	
+6652	artisanal extra-dry stepmom's booze	5	EPIC	
 6653	twirling surgical tape	0		
 6654	shaking toasty band T-shirt	0		Hot Damage: +5
 6655	artisanal fountain 'soda'	3	EPIC	
@@ -6550,13 +6550,13 @@
 6658	corrupted wobbly hair oil	0		Effect: "Frisky Spirit", Effect Duration: 56
 6659	enhanced scrap	0		Effect: "Wasabi With You", Effect Duration: 20
 6660	school spirit socket set	0		
-6661	teal blinking suspension bridge	0		
+6661	blinking teal suspension bridge	0		
 6662	toasty careful Staff of the Lunch Lady of Tarzan of incineration	0		Experience (Muscle): +3, Monster Level: -10, Hot Damage: +5, Hot Spell Damage: +50
 6663	universal key	0		
 6664	world's most dangerous birdhouse	0		
 6665	deathchucks of extreme caution of the overflowing toilet	0		Monster Level: -25, Stench Spell Damage: +50
-6666	pulsating maroon eraser	0		
-6667	teal blinking quasireligious sculpture	0		
+6666	maroon pulsating eraser	0		
+6667	blinking teal quasireligious sculpture	0		
 6668	pulsating Faraday cage	0		
 6669	modeling claymore	0		
 6670	huge clay homunculus	0		
@@ -6570,7 +6570,7 @@
 6678	cyan slick Yearbook Club Camera	0		Moxie: +10, Conditional Skill (Equipped): "Blinding Flash"
 6679	mirror squat ribald machete	0		Sleaze Damage: +10
 6680	perfectly mixed pulsating Cursed Punch	3	EPIC	
-6681	watered-down artisanal Bowl of Scorpions	2	EPIC	
+6681	artisanal watered-down Bowl of Scorpions	2	EPIC	
 6682	bad practically non-alcoholic Fog Murderer	1	decent	
 6683	book of matches	0		
 6684	smooth surgical mask	0		Moxie: +15, Surgeonosity: +1
@@ -6598,7 +6598,7 @@
 6706	blue smirking shrunken head	0		
 6707	altered polarized pulsating colorful toad	0		Effect: "Afternoon Insight", Effect Duration: 28
 6708	crude voodoo doll	0		
-6709	narrow mirror attorney's badge	0		Single Equip
+6709	mirror narrow attorney's badge	0		Single Equip
 6710	upside-down chilly cool pygmy briefs	0		Moxie: +5, Cold Damage: +5, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	short writ of habeas corpus	0		
 6712	bone abacus	0		
@@ -6617,7 +6617,7 @@
 6725	blinking Shore Inc. Ship Trip Scrip	0		
 6726	narrow dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
-6728	spinning huge bouncing ski resort souvenir crate	0		
+6728	bouncing spinning huge ski resort souvenir crate	0		
 6729	blue UV-resistant compass	0		
 6730	funky junk key	0		
 6731	mirror Worse Homes and Gardens	0		
@@ -6628,14 +6628,14 @@
 6736	gray Junk-Bond	0		
 6737	tangle of copper wire	0		
 6738	olive jagged scrap	0		
-6739	enhanced dry squat upside-down bent scrap	0		Effect: "Purpose", Effect Duration: 47
+6739	enhanced dry upside-down squat bent scrap	0		Effect: "Purpose", Effect Duration: 47
 6740	molten scrap	0		
 6741	eternal car battery	0		
 6742	slick junk band	0		Moxie: +10
 6743	gravedigger's junk trunks	0		Spooky Damage: +10, Familiar Effect: "cap 15"
 6744	bouncing groovy junk-mail shirt	0		Moxie Percent: +10
-6745	normal massive special junk food	7	good	Effect: "Cheered Up", Effect Duration: 45
-6746	distilled smooth junk yard	5	awesome	
+6745	normal special massive junk food	7	good	Effect: "Cheered Up", Effect Duration: 45
+6746	smooth distilled junk yard	5	awesome	
 6747	hardened swordzall of courage	0		Damage Reduction: 3, Spooky Resistance: +3
 6748	blue skewed up-at-dawn arm buzzer	0		Adventures: +5, Damage Reduction: 6
 6749	olive Tesla veiny boilgun	0		Maximum HP: +10, MP Regen Min: 7, MP Regen Max: 10
@@ -6643,17 +6643,17 @@
 6751	packet of beer seeds	0		Last Available: "2013-09"
 6752	handful of barley	0		
 6753	cluster of hops	0		
-6754	olive jittery blinking beer bottle	0		
+6754	jittery blinking olive beer bottle	0		
 6755	twirling beer label	0		
 6756	blue shaking artisanal homebrew sampler	0		
 6757	drinkable squat can of Br&uuml;talbr&auml;u	4	good	Last Available: "2013-09"
-6758	acceptable practically non-alcoholic tumbling can of Drooling Monk	1	good	Last Available: "2013-09"
+6758	practically non-alcoholic acceptable tumbling can of Drooling Monk	1	good	Last Available: "2013-09"
 6759	drinkable can of Impetuous Scofflaw	3	good	Last Available: "2013-09"
-6760	watered-down artisanal bottle of Old Pugilist	2	EPIC	Last Available: "2013-09"
-6761	tolerable irresponsibly strong bottle of Professor Beer	9	good	Last Available: "2013-09"
-6762	tolerable watered-down bottle of Rapier Witbier	2	good	Last Available: "2013-09"
+6760	artisanal watered-down bottle of Old Pugilist	2	EPIC	Last Available: "2013-09"
+6761	irresponsibly strong tolerable bottle of Professor Beer	9	good	Last Available: "2013-09"
+6762	watered-down tolerable bottle of Rapier Witbier	2	good	Last Available: "2013-09"
 6763	perfectly mixed green bottle of Race Car Red	4	EPIC	Last Available: "2013-09"
-6764	practically non-alcoholic perfectly mixed bottle of Greedy Dog	1	super ultra mega turbo EPIC	Last Available: "2013-09"
+6764	perfectly mixed practically non-alcoholic bottle of Greedy Dog	1	super ultra mega turbo EPIC	Last Available: "2013-09"
 6765	mediocre bottle of Lambada Lambic	3	decent	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
@@ -6668,10 +6668,10 @@
 6776	modified energized gray foetid seal tear	0		Effect: "Mortarfied", Effect Duration: 48
 6777	chilled alkaline wobbly seal sweat	0		Effect: "Chari Tea", Effect Duration: 62
 6778	wet non-activated blinking boiling seal blood	0		Effect: "Starry-Eyed", Effect Duration: 50
-6779	squat huge crystalline seal eye	0		Single Equip
+6779	huge squat crystalline seal eye	0		Single Equip
 6780	energetic razor-sharp studded sealhide shield	0		Weapon Damage Percent: +25, Maximum MP Percent: +20, Damage Reduction: 7
 6781	lion tamer's scabrous seal epaulets of James Dean	0		Experience (Moxie): +3, Experience (familiar): +2, Single Equip
-6782	blue wobbly blinking abyssal battle plans	0		
+6782	blinking blue wobbly abyssal battle plans	0		
 6783	flame-wreathed wicked thinker's seal medal	0		Mysticality: +10, Spell Damage: +5, Hot Spell Damage: +10
 6784	deanimated reanimator's coffin	0		Free Pull
 6785	flask of embalming fluid	0		
@@ -6738,7 +6738,7 @@
 6849	warmed chilled Effermint&trade; tablets	0		Effect: "Sealed Brain", Effect Duration: 11
 6850	up-at-dawn dog trainer's sharpshooter's sturdy cane	0		Critical Hit Percent: +10, Experience (familiar): +1, Adventures: +5
 6851	gray huge bowl of candy	0		
-6852	mirror yellow Ultra Mega Sour Ball	0		
+6852	yellow mirror Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	desert sightseeing pamphlet	0		
 6855	a suspicious address	0		
@@ -6751,17 +6751,17 @@
 6862	rotten diet teal high-calorie sugar substitute	1	crappy	Last Available: "2013-11"
 6863	delicious purple pat of butter	3	awesome	Last Available: "2013-11"
 6864	snack-sized decent purple dinner roll	2	good	Last Available: "2013-11"
-6865	normal special low-calorie mashed potatoes	1	good	Effect: "Blackberry Politeness", Effect Duration: 10, Last Available: "2013-11"
+6865	special low-calorie normal mashed potatoes	1	good	Effect: "Blackberry Politeness", Effect Duration: 10, Last Available: "2013-11"
 6866	decent whole turkey leg	3	good	Last Available: "2013-11"
 6867	rotten tumbling deviled egg	4	crappy	Last Available: "2013-11"
-6868	enhanced mirror ghostly finger exerciser	0		Effect: "Down With Chow", Effect Duration: 31, Last Available: "2013-11"
+6868	enhanced ghostly mirror finger exerciser	0		Effect: "Down With Chow", Effect Duration: 31, Last Available: "2013-11"
 6869	frozen aerosolized dented spoon	0		Effect: "Hiding in Plain Sight", Effect Duration: 44, Last Available: "2013-11"
 6870	tarnished blurry love note	0		Effect: "Trivia Master", Effect Duration: 41, Last Available: "2013-11"
 6871	blurry school beer pull tab	0		Last Available: "2013-11"
 6872	pickled liquefied ghostly nail file	0		Effect: "Toast Tea", Effect Duration: 35, Last Available: "2013-11"
 6873	non-quantum mirror candy wrapper	0		Effect: "Mucilaginous Mentalism", Effect Duration: 66, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
-6875	electrified concentrated skewed red post-holiday sale coupon	0		Effect: "The Real Deal", Effect Duration: 50, Last Available: "2013-11"
+6875	electrified concentrated red skewed post-holiday sale coupon	0		Effect: "The Real Deal", Effect Duration: 50, Last Available: "2013-11"
 6876	twirling dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
@@ -6778,7 +6778,7 @@
 6889	spirit blanket	0		
 6890	spirit bed	0		
 6891	olive Temple Grandin's spirit bell of chilblains of temperance	0		Familiar Weight: +7, Cold Damage: +25, Sleaze Resistance: +5, Class: "Turtle Tamer"
-6892	chilled electrified tumbling ghostly spoonful of Linguine-Os	0		Effect: "Egg-headedness", Effect Duration: 63, Last Available: "2013-11"
+6892	chilled electrified ghostly tumbling spoonful of Linguine-Os	0		Effect: "Egg-headedness", Effect Duration: 63, Last Available: "2013-11"
 6893	boiled blurry freezer-burned frost-bitten tortellini	0		Effect: "Fustulent", Effect Duration: 51, Last Available: "2013-11"
 6894	deionized vacuum-sealed blob of Alphredo&trade;	0		Effect: "Ooh, Umami!", Effect Duration: 17, Last Available: "2013-11"
 6895	pressed maroon handful of crafty noodles	0		Effect: "Wet and Greedy", Effect Duration: 42, Last Available: "2013-11"
@@ -6807,12 +6807,12 @@
 6918	magnetized warbear wardance potion	0		Effect: "Executive Greed", Effect Duration: 50, Last Available: "2013-12"
 6919	ionized denatured warbear bearserker potion	0		Effect: "Antsy in your Pantsy", Effect Duration: 65, Last Available: "2013-12"
 6920	electrified super-alkaline improved wobbly warbear liquid overcoat	0		Effect: "Holiday Disappointment", Effect Duration: 46, Last Available: "2013-12"
-6921	moldy jumbo warbear feasting bread	5	crappy	Last Available: "2013-12"
-6922	tiny spoiled huge spinning warbear warrior bread	1	crappy	Last Available: "2013-12"
-6923	super-sized adequate pulsating warbear thermoregulator bread	5	good	Last Available: "2013-12"
+6921	jumbo moldy warbear feasting bread	5	crappy	Last Available: "2013-12"
+6922	spoiled tiny spinning huge warbear warrior bread	1	crappy	Last Available: "2013-12"
+6923	adequate super-sized pulsating warbear thermoregulator bread	5	good	Last Available: "2013-12"
 6924	acceptable warbear feasting mead	3	good	Last Available: "2013-12"
 6925	smooth warbear bearserker mead	4	awesome	Last Available: "2013-12"
-6926	hand-crafted irresponsibly strong warbear blizzard mead	7	EPIC	Last Available: "2013-12"
+6926	irresponsibly strong hand-crafted warbear blizzard mead	7	EPIC	Last Available: "2013-12"
 6927	maroon warbear helm fragment	0		Last Available: "2013-12"
 6928	Temple Grandin's rock-hard warbear plain fedora of the empath	0		Damage Reduction: 5, Familiar Weight: 12, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
 6929	warbear feathered fedora of dire peril	0		Weapon Damage: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
@@ -6893,7 +6893,7 @@
 7004	oxidized polymerized Flaskfull of Hollow	0		Effect: "Three Days Slow", Effect Duration: 14, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	compressed handful of Smithereens	1	good	Last Available: "2013-12"
-7007	spoiled huge ghostly Every Day is Like This Sundae	10	crappy	Last Available: "2013-12"
+7007	huge spoiled ghostly Every Day is Like This Sundae	10	crappy	Last Available: "2013-12"
 7008	spoiled Miserable Pie	3	crappy	Last Available: "2013-12"
 7009	adequate This Charming Flan	4	good	Last Available: "2013-12"
 7010	triple-distilled hand-crafted Irish Coffee, English Heart	10	EPIC	Last Available: "2013-12"
@@ -6941,22 +6941,22 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	narrow warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	spoiled thick breakfast mess	5	crappy	Last Available: "2013-12"
+7055	thick spoiled breakfast mess	5	crappy	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	flavorless breakfast miracle	3	decent	Last Available: "2013-12"
-7058	irradiated wobbly bouncing Cloaca Cola Polar	0		Effect: "Punch Another Day", Effect Duration: 43, Last Available: "2013-12"
+7058	irradiated bouncing wobbly Cloaca Cola Polar	0		Effect: "Punch Another Day", Effect Duration: 43, Last Available: "2013-12"
 7059	bouncing warbear soda machine	0		Last Available: "2013-12"
 7060	spinning festive warbear bank	0		Last Available: "2013-12"
 7061	mirror grimstone mask	0		Last Available: "2014-12"
 7062	pulsating praying Grim Brother	0		Free Pull, Last Available: "2014-12"
 7063	Grim Brothers' story book	0		Familiar Weight: +5
-7064	purple skewed hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
+7064	skewed purple hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	boiled huge grim fairy tale	1	decent	Effect: "Wet Willied", Effect Duration: 5, Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
 7067	super-deionized skewed single of Inigo's Incantation of Inspiration	0		Effect: "Waxing", Effect Duration: 43, Last Available: "2010-02"
 7068	extra-chilled irradiated pulsating single of Donho's Bubbly Ballad	0		Effect: "White Blooded", Effect Duration: 61
 7069	pulsating Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
-7070	upside-down red packet of winter seeds	0		Last Available: "2014-01"
+7070	red upside-down packet of winter seeds	0		Last Available: "2014-01"
 7071	snack-sized flavorless snow berries	2	decent	Last Available: "2014-01"
 7072	yummy ice harvest	3	awesome	Last Available: "2014-01"
 7073	triple-pickled denatured frost flower	0		Effect: "Orchid Blood", Effect Duration: 56, Last Available: "2014-01"
@@ -6964,7 +6964,7 @@
 7075	extra-alkaline liquid ice pack	0		Effect: "Superheroic", Effect Duration: 33, Last Available: "2014-01"
 7076	snow boards	0		Last Available: "2014-01"
 7077	spoiled skewed snow crab	3	crappy	Last Available: "2014-01"
-7078	hand-crafted distilled pulsating Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
+7078	distilled hand-crafted pulsating Ice Island Long Tea	5	EPIC	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	twirling ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -7000,11 +7000,11 @@
 7111	moldy tumbling candy mountain oyster	3	crappy	Last Available: "2014-12"
 7112	weak bad chocotini	2	decent	Last Available: "2014-12"
 7113	tumbling sizzling Jim Carey's chocolate rabbit's foot of the sewer	0		Monster Level: +25, Hot Damage: +10, Stench Damage: +25, Last Available: "2014-12"
-7114	spoiled diet candy carrot	1	crappy	Last Available: "2014-12"
+7114	diet spoiled candy carrot	1	crappy	Last Available: "2014-12"
 7115	yummy candy carrot cake	3	awesome	Last Available: "2014-12"
 7116	ribald horrifying carrot-on-a-stick	0		Spooky Damage: +25, Sleaze Damage: +10, Last Available: "2014-12"
 7117	tumbling manspreader's dance instructor's weasel stomping pants	0		Experience Percent (Moxie): +10, Monster Level: +10, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	normal low-calorie mulberry	1	good	Last Available: "2014-12"
+7118	low-calorie normal mulberry	1	good	Last Available: "2014-12"
 7119	mediocre watered-down blurry mulled berry wine	2	decent	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	boxer's lemon party hat	0		Muscle Percent: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
@@ -7012,7 +7012,7 @@
 7123	lemon drop trousers of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	super-chilled cyan lemonhead caviar	0		Effect: "Memory of Speed", Effect Duration: 35, Last Available: "2014-12"
 7125	fuchsia upside-down flame-wreathed Herculean gummi sword	0		Experience (Muscle): +1, Hot Spell Damage: +10, Last Available: "2014-12"
-7126	energized nitrogenated ghostly huge small gummi fin	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 19, Last Available: "2014-12"
+7126	energized nitrogenated huge ghostly small gummi fin	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 19, Last Available: "2014-12"
 7127	spinning Samson's chocolate cow bone	0		Experience (Muscle): +5, Last Available: "2014-12"
 7128	denatured quadruple-wet gummi fang	0		Effect: "Turkey-Friendly", Effect Duration: 61, Last Available: "2014-12"
 7129	delicious twirling leftover canap&eacute;s	4	awesome	Last Available: "2014-12"
@@ -7024,7 +7024,7 @@
 7135	toothsome witch's bread	4	awesome	Last Available: "2014-12"
 7136	chilled triple-activated shaking witch's brew	0		Effect: "Nightlit", Effect Duration: 34, Last Available: "2014-12"
 7137	foul-smelling toasty hardened witch's bra	0		Damage Reduction: 3, Hot Damage: +5, Stench Damage: +10, Last Available: "2014-12"
-7138	smooth triple-distilled mid-level medieval mead	9	awesome	Last Available: "2014-12"
+7138	triple-distilled smooth mid-level medieval mead	9	awesome	Last Available: "2014-12"
 7139	modified quadruple-denatured skewed R&uuml;mpelstiltz	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 61, Last Available: "2014-12"
 7140	bouncing spinning wheel	0		Last Available: "2014-12"
 7141	altered extra-dry purple hi-octane carrot juice	0		Effect: "Tingly Elbows", Effect Duration: 62, Last Available: "2014-12"
@@ -7032,9 +7032,9 @@
 7143	personal trainer's hare pin of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
 7145	normal gray cinnamon cannoli	3	good	Last Available: "2014-12"
-7146	practically non-alcoholic lousy expensive champagne	1	decent	Last Available: "2014-12"
+7146	lousy practically non-alcoholic expensive champagne	1	decent	Last Available: "2014-12"
 7147	Vulcanized colloidal polo trophy	0		Effect: "Powdered", Effect Duration: 49, Last Available: "2014-12"
-7148	yellow spinning oil painting	0		Last Available: "2014-12"
+7148	spinning yellow oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
 7151	straw	0		Last Available: "2014-12"
@@ -7044,23 +7044,23 @@
 7155	blurry parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	fire hose of Tarzan of extreme caution of the early riser	0		Experience (Muscle): +3, Monster Level: -25, Adventures: +7, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	adequate half-sized fireman's lunch	2	good	Last Available: "2014-12"
+7158	half-sized adequate fireman's lunch	2	good	Last Available: "2014-12"
 7159	family-friendly frightening strapping plain paper hat	0		Muscle: +5, Spooky Damage: +5, Sleaze Resistance: +1, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	super-sized delicious blurry ice cream sandwich	5	awesome	Last Available: "2014-12"
+7160	delicious super-sized blurry ice cream sandwich	5	awesome	Last Available: "2014-12"
 7161	avaricious frightening grievous &quot;honey&quot; dipper	0		Weapon Damage Percent: +50, Spooky Damage: +5, Meat Drop: +30, Last Available: "2014-12"
 7162	special huge toothsome plumber's lunch	6	awesome	Effect: "Thick, Sick", Effect Duration: 15, Last Available: "2014-12"
 7163	sizzling frosty clever skull gearshift knob	0		Maximum MP: +20, Cold Spell Damage: +10, Hot Damage: +10, Last Available: "2014-12"
 7164	stale nachos of the night	4	decent	Last Available: "2014-12"
 7165	blinking wicked Sketcherz&trade; of the storm of the glutton	0		Spell Damage: +5, Maximum MP Percent: +40, Food Drop: +100, Last Available: "2014-12"
-7166	small decent can of Adultwitch&trade;	2	good	Last Available: "2014-12"
+7166	decent small can of Adultwitch&trade;	2	good	Last Available: "2014-12"
 7167	altered dry smudge stick	0		Effect: "Sticky Hands", Effect Duration: 24, Last Available: "2014-12"
 7168	extra-flattened red wall	0		Effect: "Sleazy Hands", Effect Duration: 47, Last Available: "2014-12"
-7169	irresponsibly strong acceptable blurry tankard of ale	8	good	Last Available: "2014-12"
+7169	acceptable irresponsibly strong blurry tankard of ale	8	good	Last Available: "2014-12"
 7170	electrified scroll case	0		Effect: "Supafly", Effect Duration: 59, Last Available: "2014-12"
 7171	galvanized jug of &quot;wine&quot;	0		Effect: "Steroid Boost", Effect Duration: 22, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	crappy camera	0		Last Available: "2014-12"
-7174	diet moldy humble pie	1	crappy	Last Available: "2014-12"
+7174	moldy diet humble pie	1	crappy	Last Available: "2014-12"
 7175	twirling small golem	0		Last Available: "2014-12"
 7176	spinning shaking crappy camera	0		Last Available: "2014-12"
 7177	electrified magnetized crappy waiter disguise	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 54
@@ -7069,11 +7069,11 @@
 7180	skewed The Lacrosse Stick of Lacoronado	0		
 7181	The Eye of the Stars	0		
 7182	wobbly The Stankara Stone	0		
-7183	huge shaking Murphy's Rancid Black Flag	0		
+7183	shaking huge Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	smooth jittery gray unnamed cocktail	3	awesome	
+7187	smooth gray jittery unnamed cocktail	3	awesome	
 7188	wobbly handful of tips	0		
 7189	coward's unrequired jacket	0		Monster Level: -20
 7190	tommy gun of horror	0		Spooky Spell Damage: +25, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7082,7 +7082,7 @@
 7193	throwing spoon	0		
 7194	throwing fork	0		
 7195	breadchucks of extreme caution of bravery	0		Monster Level: -25, Spooky Resistance: +5
-7196	ghostly olive shuriken salad	0		
+7196	olive ghostly shuriken salad	0		
 7197	strapping combat fan	0		Muscle: +5
 7198	blinking yellow horrifying silk skirt of courage	0		Spooky Damage: +25, Spooky Resistance: +3, Familiar Effect: "atk, 1xFairy, cap 38"
 7199	ghostly blowdart	0		
@@ -7092,7 +7092,7 @@
 7203	brawny Saturday Night Special	0		Muscle Percent: +20
 7204	lynyrd snare	0		
 7205	beefy fleetwood chain	0		Muscle: +10
-7206	boozy hand-crafted yellow Green Manalishi	5	EPIC	
+7206	hand-crafted boozy yellow Green Manalishi	5	EPIC	
 7207	Temple Grandin's blade	0		Familiar Weight: +7
 7208	blinking fire of unknown origin	0		
 7209	fuchsia eagle's milk	1	awesome	
@@ -7101,24 +7101,24 @@
 7212	Oprah's Jefferson wings	0		Maximum MP Percent: +50
 7213	skewed fleetwood macaroni	0		
 7214	cheesy eagle sauce	0		
-7215	small tasty fleetwood mac 'n' cheese	2	awesome	
+7215	tasty small fleetwood mac 'n' cheese	2	awesome	
 7216	lynyrd skin	0		
 7217	lime green Van der Graaf lynyrdskin cap	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	squat lynyrdskin tunic of the cheetah	0		Initiative: +60
 7219	lynyrdskin breeches of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	aged practically non-alcoholic bouncing Flamin' Whatshisname	1	awesome	
+7222	practically non-alcoholic aged bouncing Flamin' Whatshisname	1	awesome	
 7223	vacuum-sealed lynyrd musk	0		Effect: "Orc Chops", Effect Duration: 22
 7224	prompt curative Kashmir sweater	0		Adventures: +3, HP Regen Min: 3, HP Regen Max: 5
 7225	stale pulsating custard pie	3	decent	
 7226	enchanted tea for one	1	awesome	Effect: "Mighty Shout", Effect Duration: 25
 7227	artisanal skewed bottle of Evermore	3	EPIC	
 7228	box	0		
-7229	tolerable distilled wine	5	good	
-7230	weak drinkable teal rum	2	good	
+7229	distilled tolerable wine	5	good	
+7230	drinkable weak teal rum	2	good	
 7231	hand-crafted Murderer's Punch	3	EPIC	
-7232	small stale velvet cake	2	decent	
+7232	stale small velvet cake	2	decent	
 7233	activated polarized letter	0		Effect: "Dilated Pupils", Effect Duration: 36
 7234	olive avaricious book of wisdom	0		Mysticality: +15, Meat Drop: +30
 7235	shaking dance instructor's masque of the sweet-tooth	0		Experience Percent (Moxie): +10, Candy Drop: +100, Single Equip
@@ -7141,7 +7141,7 @@
 7252	shot of Sneaky Pete's Mojo	0		Free Pull
 7253	mirror Anniversary Miniature Sword & Martini Guy	0		
 7254	red really cocktail shaker	0		Familiar Weight: +5
-7255	hand-crafted triple-distilled mini-martini	8	EPIC	
+7255	triple-distilled hand-crafted mini-martini	8	EPIC	
 7256	smoke grenade	0		
 7257	mixed molotov soda	1	decent	
 7258	quadruple-polymerized polarized blue pile of ashes	0		Effect: "Powder Power", Effect Duration: 48
@@ -7168,7 +7168,7 @@
 7279	aerosolized unsweetened cold-filtered wind-up Whatsian robot	0		Effect: "Rave Nirvana", Effect Duration: 18
 7280	tarnished cold-filtered flattened wind-up vampire teeth	0		Effect: "Well-preserved", Effect Duration: 55
 7281	polarized extra-flattened wind-up navigation droid	0		Effect: "Stimulated Brain", Effect Duration: 21
-7282	liquefied vacuum-sealed fuchsia pulsating wind-up owl	0		Effect: "Eldritch Concentration", Effect Duration: 35
+7282	liquefied vacuum-sealed pulsating fuchsia wind-up owl	0		Effect: "Eldritch Concentration", Effect Duration: 35
 7283	super-wet concentrated wind-up ensign	0		Effect: "Amorphous Cheer", Effect Duration: 17
 7284	Jack Frost's occult crying statue earrings	0		Spell Damage Percent: +25, Cold Spell Damage: +50, Single Equip, Lasts Until Rollover
 7285	narrow Tesla personal trainer's plastic Duskwalker necklace	0		Experience Percent (Muscle): +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover
@@ -7184,9 +7184,9 @@
 7295	elevent	0		Last Available: "2014-03"
 7296	wool elevenderizing hammer of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1, Last Available: "2014-03"
 7297	pulsating inspector's Professor What T-Shirt	0		Item Drop: +15
-7298	huge skewed heavy-duty bendy straw	0		
+7298	skewed huge heavy-duty bendy straw	0		
 7299	pellet of plant food	0		
-7300	pulsating purple sewing kit	0		
+7300	purple pulsating sewing kit	0		
 7301	tumbling Spookyraven billiards room key	0		
 7302	jittery Spookyraven library key	0		
 7303	Lady Spookyraven's necklace	0		
@@ -7211,13 +7211,13 @@
 7322	cold-filtered dry corrupted huge Stephen's secret formula	0		Effect: "Pumped Stomach", Effect Duration: 14
 7323	maroon flame-retardant extremely unsafe Jacob's rung	0		Weapon Damage Percent: +100, Hot Resistance: +1
 7324	vaporized battery	1		
-7325	mediocre practically non-alcoholic snakebite	1	decent	
+7325	practically non-alcoholic mediocre snakebite	1	decent	
 7326	curative steel-toed rubber ribcage	0		Damage Reduction: 16, HP Regen Min: 3, HP Regen Max: 5
 7327	denatured narrow synthetic marrow	1		
 7328	cold-filtered yellow funny bone	0		Effect: "Frigid Weapon", Effect Duration: 19
 7329	gravedigger's veiny half-melted spoon	0		Maximum HP: +10, Spooky Damage: +10
 7330	pickled green the funk	1		Effect: "Turtle Titters", Effect Duration: 30
-7331	small toothsome gunky chicken	2	awesome	
+7331	toothsome small gunky chicken	2	awesome	
 7332	doll head of Flo-Jo	0		Initiative: +100
 7333	droopy doll eye	0		
 7334	voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
@@ -7225,7 +7225,7 @@
 7336	moist denatured sound effects record	0		Effect: "Grape Expectations", Effect Duration: 42
 7337	twirling alphabet block	0		
 7338	dry pickled shaking maroon dancer	0		Effect: "Fiery Spirit", Effect Duration: 68
-7339	purple shaking music box mechanism	0		
+7339	shaking purple music box mechanism	0		
 7340	executive moose antlers	0		Meat Drop: +40, Familiar Effect: "atk, 1xLep, cap 27"
 7341	super-quantum ghostly moose thought	0		Effect: "Wet and Greedy", Effect Duration: 22
 7342	tiny stale moose chocolate	1	decent	
@@ -7234,13 +7234,13 @@
 7345	jittery ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
 7347	olive rock-hard ghost toga of the sewer	0		Damage Reduction: 5, Stench Damage: +25
-7348	enchanted miniature adequate sheet cake	2	good	Effect: "Certainty", Effect Duration: 45
+7348	adequate enchanted miniature sheet cake	2	good	Effect: "Certainty", Effect Duration: 45
 7349	ghost key	0		
 7350	maroon picture of you	0		
 7351	rosewater-soaked slick Staff of the Electric Range of the boozehound	0		Moxie: +10, Stench Resistance: +3, Booze Drop: +100
-7352	rotten miniature deluxe layer cake	2	crappy	
+7352	miniature rotten deluxe layer cake	2	crappy	
 7353	jittery chunk of hot iron	0		
-7354	artisanal weak red-hot boilermaker	2	EPIC	
+7354	weak artisanal red-hot boilermaker	2	EPIC	
 7355	narrow censurious coal shovel	0		Sleaze Resistance: +3, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	triple-warmed hot coal	0		Effect: "Hagg-ard", Effect Duration: 37
 7357	irradiated diffused coal dust	0		Effect: "Pasty", Effect Duration: 55
@@ -7256,7 +7256,7 @@
 7367	super-cold-filtered diffused industrial strength starch	0		Effect: "The Dinsey Way", Effect Duration: 26, Wiki Name: "industrial strength starch"
 7368	delicious extra-flat panini	4	awesome	
 7369	adjusted modified mangled finger	0		Effect: "Warm Belly", Effect Duration: 61
-7370	perfectly mixed practically non-alcoholic Psychotic Train wine	1	super ultra mega turbo EPIC	
+7370	practically non-alcoholic perfectly mixed Psychotic Train wine	1	super ultra mega turbo EPIC	
 7371	yellow crazy hobo notebook	0		
 7372	low-calorie delicious pie man was not meant to eat	1	awesome	
 7373	sommelier's towel of Flo-Jo	0		Initiative: +100
@@ -7287,15 +7287,15 @@
 7398	quadruple-colloidal energized Gene Tonic: Weird	0		Effect: "Nasty, Nasty Breath", Effect Duration: 40, Last Available: "2014-04"
 7399	concentrated blurry Gene Tonic: Elf	0		Effect: "La Bamba", Effect Duration: 68, Last Available: "2014-04"
 7400	adjusted Gene Tonic: Mer-kin	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 51, Last Available: "2014-04"
-7401	nitrogenated dry skewed purple Gene Tonic: Slime	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14, Last Available: "2014-04"
+7401	nitrogenated dry purple skewed Gene Tonic: Slime	0		Effect: "Gyromitra Gymnastics", Effect Duration: 14, Last Available: "2014-04"
 7402	anodized magnetized green jittery Gene Tonic: Penguin	0		Effect: "Squirming Like a Toad", Effect Duration: 23, Last Available: "2014-04"
 7403	tarnished extra-nitrogenated tumbling blinking bouncing Gene Tonic: Elemental	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 43, Last Available: "2014-04"
-7404	galvanized shaking narrow Gene Tonic: Constellation	0		Effect: "Boo Tea", Effect Duration: 19, Last Available: "2014-04"
-7405	pickled upside-down skewed Gene Tonic: Hobo	0		Effect: "Vitali Tea", Effect Duration: 58, Last Available: "2014-04"
+7404	galvanized narrow shaking Gene Tonic: Constellation	0		Effect: "Boo Tea", Effect Duration: 19, Last Available: "2014-04"
+7405	pickled skewed upside-down Gene Tonic: Hobo	0		Effect: "Vitali Tea", Effect Duration: 58, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	Steam Card: Dungeon Fist (#2)	0		
 7408	Steam Card: Dungeon Fist (#3)	0		
-7409	blinking mirror Steam Card: Space Trip (#1)	0		
+7409	mirror blinking Steam Card: Space Trip (#1)	0		
 7410	fuchsia Steam Card: Space Trip (#2)	0		
 7411	purple blinking Steam Card: Space Trip (#3)	0		
 7412	green Steam Card: Meteoid (#1)	0		
@@ -7305,7 +7305,7 @@
 7416	Steam Card: DemonStar (#2)	0		
 7417	Steam Card: DemonStar (#3)	0		
 7418	skewed Steam Card: Jackass Plumber (#1)	0		
-7419	shaking purple Steam Card: Jackass Plumber (#2)	0		
+7419	purple shaking Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
 7421	pencil thin mushroom	0		Last Available: "2014-05"
 7422	fuchsia Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
@@ -7323,12 +7323,12 @@
 7434	adjusted polarized dry pulsating Helvella Haemophilia mushroom	0		Effect: "Eyes Wide Propped", Effect Duration: 15, Last Available: "2014-05"
 7435	non-deionized double-adjusted galvanized Stemonitis Staticus mushroom	0		Effect: "One For Tea", Effect Duration: 31, Last Available: "2014-05"
 7436	triple-diffused irradiated Tremella Tarantella mushroom	0		Effect: "Man's Worst Enemy", Effect Duration: 67, Last Available: "2014-05"
-7437	blinking teal Pastaco shell	0		Last Available: "2014-05"
+7437	teal blinking Pastaco shell	0		Last Available: "2014-05"
 7438	half-sized flavorless Beefy Crunch Pastaco	2	decent	Last Available: "2014-05"
 7439	moldy maroon Brain Food Pastaco	3	crappy	Last Available: "2014-05"
 7440	yummy Cool Brunch Pastaco	4	awesome	Last Available: "2014-05"
-7441	small stale twirling Medical Pastaco	2	decent	Last Available: "2014-05"
-7442	half-sized flavorless Energy Buzz Pastaco	2	decent	Last Available: "2014-05"
+7441	stale small twirling Medical Pastaco	2	decent	Last Available: "2014-05"
+7442	flavorless half-sized Energy Buzz Pastaco	2	decent	Last Available: "2014-05"
 7443	spoiled Ludovico Pastaco	4	crappy	Last Available: "2014-05"
 7444	artisanal overpowering mushroom wine	3	super EPIC	Last Available: "2014-05"
 7445	mediocre enchanted complex mushroom wine	3	decent	Effect: "Big Ol' Glass of Rum", Effect Duration: 20, Last Available: "2014-05"
@@ -7336,8 +7336,8 @@
 7447	lousy blood-red mushroom wine	4	decent	Last Available: "2014-05"
 7448	mediocre mirror buzzing mushroom wine	3	decent	Last Available: "2014-05"
 7449	bad practically non-alcoholic swirling mushroom wine	1	decent	Last Available: "2014-05"
-7450	delicious big Taco Dan's Basic Taco Dan Taco	5	awesome	Last Available: "2014-05"
-7451	delicious enchanted super-sized bouncing Taco Dan's Taco Fish Fish Taco	5	awesome	Effect: "Hardened Fabric", Effect Duration: 20, Last Available: "2014-05"
+7450	big delicious Taco Dan's Basic Taco Dan Taco	5	awesome	Last Available: "2014-05"
+7451	super-sized enchanted delicious bouncing Taco Dan's Taco Fish Fish Taco	5	awesome	Effect: "Hardened Fabric", Effect Duration: 20, Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	watered-down bad regular-size brogurt	2	decent	Last Available: "2014-05"
 7454	irresponsibly strong lousy super-size brogurt	10	decent	Last Available: "2014-05"
@@ -7369,11 +7369,11 @@
 7480	irradiated unsweetened pulsating spinning sugar bunny	0		Effect: "Sealed Brain", Effect Duration: 63, Last Available: "2014-05"
 7481	jittery sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	acceptable ghostly Rompedores de Fantasmas	3	good	
-7483	fancy lousy practically non-alcoholic La Fantasma y La Oscuridad	1	decent	Effect: "Gamer Rage", Effect Duration: 50
-7484	special acceptable Fantasma en la M&aacute;quina	3	good	Effect: "Tasting the Rainbow", Effect Duration: 15
+7483	fancy practically non-alcoholic lousy La Fantasma y La Oscuridad	1	decent	Effect: "Gamer Rage", Effect Duration: 50
+7484	acceptable special Fantasma en la M&aacute;quina	3	good	Effect: "Tasting the Rainbow", Effect Duration: 15
 7485	loosening powder	0		
 7486	castoreum	0		
-7487	wobbly blue drain dissolver	0		
+7487	blue wobbly drain dissolver	0		
 7488	triple-distilled turpentine	0		
 7489	jittery detartrated anhydrous sublicalc	0		
 7490	maroon triatomaceous dust	0		
@@ -7381,11 +7381,11 @@
 7492	twirling blasting soda	0		
 7493	unstable fulminate	0		
 7494	huge wine bomb	0		
-7495	tumbling blinking recipe: mortar-dissolving solution	0		
+7495	blinking tumbling recipe: mortar-dissolving solution	0		
 7496	bottled day	0		
 7497	ghost formula	0		
 7498	Thwaitgold wheel bug statuette	0		
-7499	colloidal diffused spinning bouncing Hot 'n' Scarys	0		Effect: "Walberg's Dim Bulb", Effect Duration: 41
+7499	colloidal diffused bouncing spinning Hot 'n' Scarys	0		Effect: "Walberg's Dim Bulb", Effect Duration: 41
 7500	map	0		
 7501		0		
 7502	alkaline concentrated Texas tea	0		Effect: "Techno Bliss", Effect Duration: 23
@@ -7394,8 +7394,8 @@
 7505	dark porquoise ring of Gandalf	0		Spell Critical Percent: +20
 7506	nippy healthy book	0		Maximum HP Percent: +20, Cold Damage: +10
 7507	blurry hardy cloak	0		Maximum HP: +50
-7508	squat fuchsia label	0		
-7509	adequate narrow tumbling Mornington crescent roll	4	good	
+7508	fuchsia squat label	0		
+7509	adequate tumbling narrow Mornington crescent roll	4	good	
 7510	electrified maroon eye shadow	0		Effect: "Flower Power", Effect Duration: 35
 7511	crumbling wheel	0		
 7512	magnetized quantum vacuum-sealed poppy	0		Effect: "Gr8ness", Effect Duration: 22
@@ -7416,12 +7416,12 @@
 7527	twirling alien force field disruptor bean	0		Last Available: "2014-05"
 7528	green lion tamer's government-issued night-vision goggles of dire peril	0		Weapon Damage: +20, Experience (familiar): +2, Single Equip, Last Available: "2014-05"
 7529	yummy miniature loaf of alien bread	2	awesome	Last Available: "2014-05"
-7530	bland super-sized grilled cheese sandwich	5	decent	Last Available: "2014-05"
+7530	super-sized bland grilled cheese sandwich	5	decent	Last Available: "2014-05"
 7531	mixed upside-down alien protein powder	1	decent	Effect: "Shawarma Initiative", Effect Duration: 50, Last Available: "2014-05"
-7532	fortified aged upside-down narrow gray rocket fuel	5	awesome	Last Available: "2014-05"
+7532	aged fortified upside-down gray narrow rocket fuel	5	awesome	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	weak acceptable stealth bomber	2	good	Last Available: "2014-05"
+7535	acceptable weak stealth bomber	2	good	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	narrow twitching space egg	0		Last Available: "2014-05"
 7538	bouncing ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7431,7 +7431,7 @@
 7542	space invader	0		Last Available: "2014-05"
 7543	bouncing double-paned space heater of horror	0		Spooky Spell Damage: +25, Cold Resistance: +5, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	space bar	0		Last Available: "2014-05"
-7545	high-proof mediocre space port	9	decent	Last Available: "2014-05"
+7545	mediocre high-proof space port	9	decent	Last Available: "2014-05"
 7546	space needle of dire peril of terror	0		Weapon Damage: +20, Spooky Spell Damage: +10, Last Available: "2014-05"
 7547	altered enhanced buffed alien drugs	0		Effect: "Wreathed in Merriment", Effect Duration: 51, Last Available: "2014-05"
 7548	hot ashes	0		Last Available: "2014-06"
@@ -7441,7 +7441,7 @@
 7552	ionized bowl of marinade	0		Effect: "French Bronilla Brogueishness", Effect Duration: 69, Last Available: "2014-06"
 7553	red shaker of dry rub	0		Last Available: "2014-06"
 7554	activated olive bottle of lighter fluid	0		Effect: "Kernel Panic!", Effect Duration: 48, Last Available: "2014-06"
-7555	mirror jittery page	0		
+7555	jittery mirror page	0		
 7556	fuchsia elephant gift	0		
 7557	deionized wet blood cells	0		Effect: "Bottle in front of Me", Effect Duration: 46
 7558	aged fortified fuchsia wine	5	awesome	
@@ -7453,7 +7453,7 @@
 7564	non-moist pulsating mocking turtle	0		Effect: "Crotchety, Pining", Effect Duration: 55
 7565	big moldy ham steak	5	crappy	
 7566	Rosewater's time-twitching toolbelt	0		Mysticality Percent: +30, Single Equip, Free Pull
-7567	spinning blinking gray Chroner	0		
+7567	spinning gray blinking Chroner	0		
 7568	shellacked wizardly Time Lord Badge of Honor of horror	0		Mysticality: +25, Damage Reduction: 7, Spooky Spell Damage: +25
 7569	hardened personal trainer's Time Bandit Badge of Courage of the brazier	0		Experience Percent (Muscle): +10, Damage Reduction: 3, Hot Spell Damage: +25
 7570	denatured irradiated Friendliness Beverage	0		Effect: "Prideful Strut", Effect Duration: 60
@@ -7476,19 +7476,19 @@
 7587	bouncing S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	acceptable green glass of &quot;milk&quot;	3	good	Last Available: "2014-07"
-7590	lousy enchanted watered-down cup of &quot;tea&quot;	2	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2014-07"
+7590	watered-down enchanted lousy cup of &quot;tea&quot;	2	decent	Effect: "Texas Elegance", Effect Duration: 30, Last Available: "2014-07"
 7591	lousy thermos of &quot;whiskey&quot;	4	decent	Last Available: "2014-07"
-7592	mediocre tumbling olive Lucky Lindy	3	decent	Last Available: "2014-07"
-7593	irresponsibly strong bad blue Bee's Knees	8	decent	Last Available: "2014-07"
-7594	artisanal high-proof yellow Sockdollager	9	EPIC	Last Available: "2014-07"
-7595	delicious practically non-alcoholic special Ish Kabibble	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2014-07"
+7592	mediocre olive tumbling Lucky Lindy	3	decent	Last Available: "2014-07"
+7593	bad irresponsibly strong blue Bee's Knees	8	decent	Last Available: "2014-07"
+7594	high-proof artisanal yellow Sockdollager	9	EPIC	Last Available: "2014-07"
+7595	practically non-alcoholic special delicious Ish Kabibble	1	awesome	Effect: "Big Meat Big Prizes", Effect Duration: 25, Last Available: "2014-07"
 7596	smooth Hot Socks	4	awesome	Last Available: "2014-07"
 7597	distilled acceptable ghostly Phonus Balonus	5	good	Last Available: "2014-07"
 7598	smooth boozy Flivver	5	awesome	Last Available: "2014-07"
 7599	drinkable Sloppy Jalopy	3	good	Last Available: "2014-07"
 7600	Vulcanized dry twirling flame	0		Effect: "Swimming Head", Effect Duration: 26
 7601	dry narrow temporary yak tattoo	0		Effect: "Towering Strength", Effect Duration: 62
-7602	electrified tumbling red Fitspiration&trade; poster	0		Effect: "Chow Downed", Effect Duration: 24
+7602	electrified red tumbling Fitspiration&trade; poster	0		Effect: "Chow Downed", Effect Duration: 24
 7603	electrified neckbeard	0		Effect: "Net Tea", Effect Duration: 69
 7604	polarized Vulcanized maroon artisanal hand-squeezed wheatgrass juice	0		Effect: "Warm Shoulders", Effect Duration: 24
 7605	cold-filtered punk patch	0		Effect: "Booze Goozles", Effect Duration: 50
@@ -7497,9 +7497,9 @@
 7608	dry turtle mud	0		Effect: "Category", Effect Duration: 64
 7609	deionized nitrogenated pulsating Redeye&trade; Eyedrops	0		Effect: "Hagnk's Gratitude", Effect Duration: 22
 7610	concentrated bouncing squat squat Dweebisol&trade; inhaler	0		Effect: "Human-Slime Hybrid", Effect Duration: 32
-7611	improved improved squat fuchsia Lewd Lemmy Hair Oil	0		Effect: "Chain Chain Chains", Effect Duration: 61
+7611	improved improved fuchsia squat Lewd Lemmy Hair Oil	0		Effect: "Chain Chain Chains", Effect Duration: 61
 7612	dry pulsating tomato soup poster	0		Effect: "Executive Greed", Effect Duration: 60
-7613	alkaline ionized jittery red bubblin' chemistry solution	0		Effect: "Neutered Nostrils", Effect Duration: 42
+7613	alkaline ionized red jittery bubblin' chemistry solution	0		Effect: "Neutered Nostrils", Effect Duration: 42
 7614	electrified unsweetened voodoo glowskull	0		Effect: "Boon of She-Who-Was", Effect Duration: 45
 7615	enhanced extra-pressed anodized blinking pygmy adder oil	0		Effect: "Texas Elegance", Effect Duration: 36
 7616	nitrogenated pygmy witchhazel	0		Effect: "Fizzier Than Light", Effect Duration: 48
@@ -7516,11 +7516,11 @@
 7627	electrified plastic Jefferson wings	0		Effect: "familiar.enq", Effect Duration: 27
 7628	super-altered maroon dancing fan	0		Effect: "Buff as a Baobab", Effect Duration: 27
 7629	quantum fuchsia page of the Necrohobocon	0		Effect: "The Halls of Muscularity", Effect Duration: 16
-7630	vacuum-sealed super-ionized chilled blurry shaking magic powder	0		Effect: "Net Tea", Effect Duration: 34
+7630	vacuum-sealed super-ionized chilled shaking blurry magic powder	0		Effect: "Net Tea", Effect Duration: 34
 7631	extra-pickled friar's tonsure	0		Effect: "Painted-On Bikini", Effect Duration: 27
 7632	quantum shaking government-issue identification badge	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 18
 7633	adjusted denatured alien hologram projector	0		Effect: "Heightened Senses", Effect Duration: 65
-7634	dry gray huge irradiated turtle	0		Effect: "There Is A Spoon", Effect Duration: 16
+7634	dry huge gray irradiated turtle	0		Effect: "There Is A Spoon", Effect Duration: 16
 7635	chilled aerosolized cigar box turtle	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 54
 7636	perfumed quilted shellacked shell	0		Damage Absorption: +40, Stench Resistance: +5, Class: "Turtle Tamer"
 7637	Oprah's pillow shell	0		Maximum MP Percent: +50, Class: "Turtle Tamer"
@@ -7552,7 +7552,7 @@
 7663	censurious Lord Soggyraven's Slippers of Tarzan of the overflowing toilet	0		Experience (Muscle): +3, Stench Spell Damage: +50, Sleaze Resistance: +3, Single Equip
 7664	anodized tumbling Ancient Protector Soda	0		Effect: "Goldentongue", Effect Duration: 63
 7665	oxidized pickled green liquid ice	0		Effect: "Here to Kick Ass", Effect Duration: 41
-7666	practically non-alcoholic perfectly mixed Wet Russian	1	super ultra mega turbo EPIC	
+7666	perfectly mixed practically non-alcoholic Wet Russian	1	super ultra mega turbo EPIC	
 7667	bland filet of The Fish	3	decent	
 7668	Thwaitgold spider statuette	0		
 7669	wobbly huge scandalous friendly fortified thunder down underwear	0		Damage Absorption: +60, Familiar Weight: +3, Sleaze Damage: +5, Lasts Until Rollover
@@ -7561,7 +7561,7 @@
 7672	blinking law-abiding citizen cane of James Dean	0		Experience (Moxie): +3, Single Equip
 7673	weak smooth legitimate business on the beach	2	awesome	
 7674	maroon manspreader's hep waders	0		Monster Level: +10, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	flavorless bite-sized jive turkey leg	1	decent	
+7675	bite-sized flavorless jive turkey leg	1	decent	
 7676	greedy birdbone corset	0		Meat Drop: +20
 7677	concentrated candy cigarette	0		Effect: "Fizzier Than Light", Effect Duration: 67
 7678	4-dimensional fez of the pedagogue	0		Experience: +3, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7615,7 +7615,7 @@
 7726	corrupted gray Dennis's blessing of Minerva	0		Effect: "Antibiotic Saucesphere", Effect Duration: 14
 7727	polarized Burt's blessing of Bacchus	0		Effect: "Slippery Tongue", Effect Duration: 37
 7728	quadruple-magnetized tarnished adjusted Freddie's blessing of Mercury	0		Effect: "Penguinny Flavor", Effect Duration: 34
-7729	twirling olive Chroner trigger	0		
+7729	olive twirling Chroner trigger	0		
 7730	Xi Receiver Unit	0		Last Available: "2014-09"
 7731	transmission from planet Xi	0		Last Available: "2014-09"
 7732	maroon Black Bart's Booty	0		Skill: "Pirate Bellow"
@@ -7626,7 +7626,7 @@
 7737	Xiblaxian holo-wrist-puter simcode	0		Last Available: "2014-09"
 7738	jittery Xiblaxian cache locator simcode	0		Last Available: "2014-09"
 7739	teal Xiblaxian holo-training simcode	0		Last Available: "2014-09"
-7740	green twirling Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
+7740	twirling green Xiblaxian direct marketing simcode	0		Last Available: "2014-09"
 7741	Xiblaxian holo-buddy simcode	0		Last Available: "2014-09"
 7742	Xiblaxian encrypted political prisoner	0		Last Available: "2014-09"
 7743	Xiblaxian holo-schematic: stealth cowl	0		Last Available: "2014-09"
@@ -7642,8 +7642,8 @@
 7753	hale weightlifter's Xiblaxian stealth cowl	0		Muscle: +15, Maximum HP: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	pulsating flame-retardant Herculean Xiblaxian stealth trousers	0		Experience (Muscle): +1, Hot Resistance: +1, Last Available: "2014-09"
 7755	upside-down wicked Samson's Xiblaxian stealth vest	0		Experience (Muscle): +5, Spell Damage: +5, Last Available: "2014-09"
-7756	fancy half-sized decent Xiblaxian ultraburrito	2	good	Effect: "Pumped Stomach", Effect Duration: 30, Last Available: "2014-09"
-7757	irresponsibly strong smooth upside-down Xiblaxian space-whiskey	10	awesome	Last Available: "2014-09"
+7756	decent half-sized fancy Xiblaxian ultraburrito	2	good	Effect: "Pumped Stomach", Effect Duration: 30, Last Available: "2014-09"
+7757	smooth irresponsibly strong upside-down Xiblaxian space-whiskey	10	awesome	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	modified They liver	0		Effect: "Slightly Larger Than Usual", Effect Duration: 26, Last Available: "2014-09"
 7760	bland They liver popsicle	3	decent	Last Available: "2014-09"
@@ -7659,7 +7659,7 @@
 7770	upside-down stiffened strapping Personal Ventilation Unit of doom	0		Muscle: +5, Damage Reduction: 1, Spooky Spell Damage: +50, Single Equip, Last Available: "2014-10"
 7771	colloidal extra-alkaline the most dangerous bait	0		Effect: "Dreadful Smell", Effect Duration: 56, Last Available: "2014-10"
 7772	rotten miniature &quot;meat&quot; stick	2	crappy	Last Available: "2014-10"
-7773	diluted skewed tumbling transdermal smoke patch	1	good	Last Available: "2014-10"
+7773	diluted tumbling skewed transdermal smoke patch	1	good	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
 7775	executive aromatic smartaleck's pair of plants	0		Moxie Percent: +30, Stench Resistance: +1, Meat Drop: +40, Last Available: "2014-10"
 7776	pulsating lightning-fast therapeutic savvy Sasq&trade; watch	0		Mysticality Percent: +20, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2014-10"
@@ -7668,7 +7668,7 @@
 7779	chilled maroon experimental serum G-9	0		Effect: "Egged On", Effect Duration: 12, Last Available: "2014-10"
 7780	smooth heavy-duty clipboard of Tarzan of horror	0		Moxie: +15, Experience (Muscle): +3, Spooky Spell Damage: +25, Damage Reduction: 8, Last Available: "2014-10"
 7781	vibrating therapeutic battery-powered drill of chilblains of the glutton	0		Maximum MP Percent: +10, Cold Damage: +25, Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-10"
-7782	fancy stale limp broccoli	3	decent	Effect: "Boilermade", Effect Duration: 5, Last Available: "2014-10"
+7782	stale fancy limp broccoli	3	decent	Effect: "Boilermade", Effect Duration: 5, Last Available: "2014-10"
 7783	executive chaotic Fonzie's hat	0		Experience (Moxie): +1, Spell Critical Percent: +10, Meat Drop: +40, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	electrified modified monkey barf	0		Effect: "Wallflowering", Effect Duration: 67, Last Available: "2014-10"
 7785	enhanced Vulcanized candy	0		Effect: "Quantum of Moxie", Effect Duration: 59, Last Available: "2014-10"
@@ -7681,12 +7681,12 @@
 7792	ghostly SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	mirror bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
-7795	normal half-sized initiative shawarma	2	good	Last Available: "2014-10"
+7795	half-sized normal initiative shawarma	2	good	Last Available: "2014-10"
 7796	moldy warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	flavorless karma shawarma	4	decent	Last Available: "2014-10"
-7798	practically non-alcoholic bad Jungle Juice	1	decent	Last Available: "2014-10"
-7799	smooth watered-down wobbly narrow Amnesiac Ale	2	awesome	Last Available: "2014-10"
-7800	irresponsibly strong tolerable Highest Bitter	6	good	Last Available: "2014-10"
+7798	bad practically non-alcoholic Jungle Juice	1	decent	Last Available: "2014-10"
+7799	smooth watered-down narrow wobbly Amnesiac Ale	2	awesome	Last Available: "2014-10"
+7800	tolerable irresponsibly strong Highest Bitter	6	good	Last Available: "2014-10"
 7801	twirling Tesla strapping mercenary pistol	0		Muscle: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
 7802	Sinatra's mercenary rifle of James Dean	0		Experience (Moxie): 8, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7713,10 +7713,10 @@
 7824	inspector's Da Vinci's iShield	0		Experience (Mysticality): +5, Item Drop: 20, Damage Reduction: 6
 7825	family-friendly dog trainer's earbuds of the brazier	0		Experience (familiar): +1, Hot Spell Damage: +25, Sleaze Resistance: +1, Single Equip
 7826	huge gravedigger's Herculean iFlail of the empath	0		Experience (Muscle): +1, Familiar Weight: +5, Spooky Damage: +10
-7827	bland shaking olive unidentifiable dried fruit	4	decent	
+7827	bland olive shaking unidentifiable dried fruit	4	decent	
 7828	drinkable watered-down red flat cider	2	good	
 7829	mirror family-friendly horrifying razor-sharp trench lighter	0		Weapon Damage Percent: +25, Spooky Damage: +25, Sleaze Resistance: +1, Last Available: "2014-10"
-7830	activated Vulcanized purple tumbling experimental serum P-00	0		Effect: "Mushroom Melody", Effect Duration: 14, Last Available: "2014-10"
+7830	activated Vulcanized tumbling purple experimental serum P-00	0		Effect: "Mushroom Melody", Effect Duration: 14, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
@@ -7728,7 +7728,7 @@
 7839	special clip: tracers	0		Last Available: "2014-10"
 7840	special clip: wailers	0		Last Available: "2014-10"
 7841	upside-down special clip: squelchers	0		Last Available: "2014-10"
-7842	blinking twirling special clip: splatterers	0		Last Available: "2014-10"
+7842	twirling blinking special clip: splatterers	0		Last Available: "2014-10"
 7843	tumbling special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	anodized wet perl necklace	0		Effect: "Full Bottle in front of Me", Effect Duration: 20, Last Available: "2014-12"
@@ -7746,7 +7746,7 @@
 7857	fireproof radiation-resistant helmet	0		Hot Resistance: +3, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
 7858	Lo Pan's servo-assisted exo-pants	0		Spell Critical Percent: +30, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	jittery asbestos-lined friendly high-energy mining laser	0		Familiar Weight: +3, Hot Resistance: +5, Last Available: "2014-12"
-7860	pulsating ghostly peppermint tailings	0		Last Available: "2014-12"
+7860	ghostly pulsating peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
 7862	cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
@@ -7811,7 +7811,7 @@
 7922	lousy Friendly Turkey	4	decent	Last Available: "2014-11"
 7923	drinkable Agitated Turkey	3	good	Last Available: "2014-11"
 7924	artisanal Ambitious Turkey	4	EPIC	Last Available: "2014-11"
-7925	spoiled super-sized neutron lollipop	5	crappy	Last Available: "2014-12"
+7925	super-sized spoiled neutron lollipop	5	crappy	Last Available: "2014-12"
 7926	artisanal gamma nog	3	EPIC	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7827,7 +7827,7 @@
 7945	table	0		
 7946	bouncing censurious Fonzie's savvy outlaw bandana	0		Mysticality Percent: +20, Experience (Moxie): +1, Sleaze Resistance: +3
 7947	lousy blue pulsating whiskey in a broken glass	3	decent	
-7948	perfectly mixed strong shot of mescal	5	EPIC	
+7948	strong perfectly mixed shot of mescal	5	EPIC	
 7949	practically non-alcoholic drinkable glass of herbal tequila	1	good	
 7950	minin' dynamite	0		
 7951	skewed prompt plaid cowboy hat of the scaredy-cat	0		Monster Level: -15, Adventures: +3, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7841,7 +7841,7 @@
 7959	squat letter to Ed the Undying	0		
 7960	squat copy of a jerk adventurer's father's diary	0		
 7961	therapeutic hardened extremely unsafe Staff of Ed of temperance	0		Weapon Damage Percent: +100, Damage Reduction: 3, Sleaze Resistance: +5, HP Regen Min: 5, HP Regen Max: 7
-7962	skewed blue wobbly pulsating Eye of Ed	0		
+7962	pulsating skewed blue wobbly Eye of Ed	0		
 7963	amulet	0		
 7964	bouncing double-paned Staff of Fats	0		Cold Resistance: +5
 7965	Holy MacGuffin	0		
@@ -7850,12 +7850,12 @@
 7968	huge topiary nugglet	0		
 7969	olive beehive	0		
 7970	boning knife	0		
-7971	mirror upside-down Aggressive Carrot	0		Free Pull
+7971	upside-down mirror Aggressive Carrot	0		Free Pull
 7972	altered fuchsia mummified fig	1	decent	
 7973	dried mummified loaf of bread	1	good	Effect: "Berry Elemental", Effect Duration: 25
 7974	powdered twirling skewed cyan mummified beef haunch	1	good	Effect: "Icy Composition", Effect Duration: 25
 7975	spinning linen bandages	0		
-7976	teal upside-down cotton bandages	0		
+7976	upside-down teal cotton bandages	0		
 7977	spinning silk bandages	0		
 7978	holy spring water	0		
 7979	spirit beer	0		
@@ -7863,7 +7863,7 @@
 7981	talisman of Thoth	0		
 7982	blinking cure-all	0		
 7983	ruddy wizardly Sister Accessory	0		Mysticality: +25, Maximum HP Percent: +40, Softcore Only
-7984	extra-deionized non-denatured lime green ghostly squat Boosty Juice	0		Effect: "Three Days Slow", Effect Duration: 57
+7984	extra-deionized non-denatured lime green squat ghostly Boosty Juice	0		Effect: "Three Days Slow", Effect Duration: 57
 7985	spinning maroon greedy slick parachute	0		Moxie: +10, Meat Drop: +20, Last Available: "2015-12"
 7986	lard-coated pad of the empath	0		Familiar Weight: +5, Sleaze Spell Damage: +25, Damage Reduction: 3, Last Available: "2015-12"
 7987	skewed olive knitted peeler of James Dean	0		Experience (Moxie): +3, Cold Resistance: +3, Last Available: "2015-12"
@@ -7899,9 +7899,9 @@
 8017	enhanced non-anodized colloidal huge flask of tainted mining oil	0		Effect: "Ginger Snapped", Effect Duration: 25, Last Available: "2014-12"
 8018	warmed and rain stick	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 11
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	normal enchanted miniature Choco-Mint patty	2	good	Effect: "Pharmaceutically Cool", Effect Duration: 40, Last Available: "2015-01"
+8020	miniature normal enchanted Choco-Mint patty	2	good	Effect: "Pharmaceutically Cool", Effect Duration: 40, Last Available: "2015-01"
 8021	tolerable hot mint schnocolate	3	good	Last Available: "2015-01"
-8022	boiled maroon twirling homeopathic mint tea	1	decent	Last Available: "2015-01"
+8022	boiled twirling maroon homeopathic mint tea	1	decent	Last Available: "2015-01"
 8023	muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	jittery supercharged dangerous tope&eacute;	0		Weapon Damage: +10, Maximum MP Percent: +30, Familiar Effect: "3xBarrr, cap 12"
 8035	twirling red inspector's topiary tights of the glutton	0		Item Drop: +15, Food Drop: +100
 8036	electrified topiary necktie	0		MP Regen Min: 3, MP Regen Max: 5
-8037	bland massive bowl of topioca	8	decent	
+8037	massive bland bowl of topioca	8	decent	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	red trusty whip	0		
@@ -7944,13 +7944,13 @@
 8063	Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
-8066	distilled bouncing blinking	1	decent	Last Available: "2015-12"
+8066	distilled blinking bouncing	1	decent	Last Available: "2015-12"
 8067	nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
 8069	Stembridge sidearm	0		Familiar Weight: +5
 8070	warehouse map page	0		
 8071	skewed twirling warehouse inventory page	0		
-8072	tumbling shaking spinning janitor sponge	0		
+8072	tumbling spinning shaking janitor sponge	0		
 8073	Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
 8074	spinning lightning-fast grievous Spelunker's fedora of the cheetah	0		Weapon Damage Percent: +50, Initiative: 100, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	shaking Lo Pan's deadly Spelunker's whip of bravery	0		Weapon Damage: +5, Spell Critical Percent: +30, Spooky Resistance: +5, Last Available: "2015-12"
@@ -7960,7 +7960,7 @@
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	twirling still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
-8088	shaking wobbly jewel	0		
+8088	wobbly shaking jewel	0		
 8089	headless sparrow	0		
 8090	mangled squirrel	0		
 8091	rat carcass	0		
@@ -7998,7 +7998,7 @@
 8123	garibaldi of doom	0		Spooky Spell Damage: +50, Item Drop: +5, Last Available: "2018-12"
 8124	Lo Pan's girdle of horror	0		Spell Critical Percent: +30, Spooky Spell Damage: +25, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	supercharged gloves of courage	0		Maximum MP Percent: +30, Spooky Resistance: +3, Single Equip, Last Available: "2018-12"
-8126	dried fuchsia bouncing smithereens	1		Last Available: "2018-12"
+8126	dried bouncing fuchsia smithereens	1		Last Available: "2018-12"
 8127	scorching coward's fiberglass fetish	0		Monster Level: -20, Hot Damage: +25, Last Available: "2018-12"
 8128	Oprah's razor-sharp fiberglass foil	0		Weapon Damage Percent: +25, Maximum MP Percent: +50, Last Available: "2018-12"
 8129	rosewater-soaked fiberglass fannypack of doom	0		Spooky Spell Damage: +50, Stench Resistance: +3, Single Equip, Last Available: "2018-12"
@@ -8008,7 +8008,7 @@
 8133	denatured fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
-8136	mirror spinning talisman of Renenutet	0		
+8136	spinning mirror talisman of Renenutet	0		
 8138	Fonzie's rubber spatula	0		Experience (Moxie): +1
 8139	jittery supercool spoon	0		Moxie Percent: +20
 8140	olive miser's crystalline reamer	0		Meat Drop: +10
@@ -8026,7 +8026,7 @@
 8152	colloidal pressed adjusted olive polyeaster egg	0		Effect: "Become Superficially interested", Effect Duration: 64
 8153	quantum spinning candy dish	0		Effect: "Pecan Pied Piper", Effect Duration: 15
 8154	improved unsweetened Spechunky bar	0		Effect: "Comprehensively Nourished", Effect Duration: 45
-8155	oxidized maroon tumbling talisman of Horus	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 13
+8155	oxidized tumbling maroon talisman of Horus	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 13
 8156	check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
 8158	bone with a price tag on it	0		
@@ -8042,7 +8042,7 @@
 8168	glob of icing	0		
 8169	corrupted tumbling ginger snaps	0		Effect: "Berry Critical", Effect Duration: 15
 8170	warmed liquefied mostly-broken sunglasses	0		Effect: "You Drank Fish Wine", Effect Duration: 51
-8171	watered-down artisanal unflavored wine cooler	2	EPIC	
+8171	artisanal watered-down unflavored wine cooler	2	EPIC	
 8172	carton of snake milk	1	decent	
 8173	skewed extremely unsafe sewer snake	0		Weapon Damage Percent: +100
 8174	super-sized spoiled upside-down pigeon egg	5	crappy	
@@ -8080,10 +8080,10 @@
 8206	miser's Rosewater's expensive camera	0		Mysticality Percent: +30, Meat Drop: +10, Single Equip, Last Available: "2015-04"
 8207	sunglasses	0		Single Equip, Last Available: "2015-04"
 8208	frozen activated purple How to Avoid Scams	0		Effect: "Bone Chilling", Effect Duration: 41, Last Available: "2015-04"
-8209	teal spinning filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
-8210	bouncing narrow bag of gross foreign snacks	0		Last Available: "2015-04"
+8209	spinning teal filthy child leash	0		Familiar Weight: +5, Last Available: "2015-04"
+8210	narrow bouncing bag of gross foreign snacks	0		Last Available: "2015-04"
 8211	bag of park garbage	0		Last Available: "2015-04"
-8212	narrow twirling grogpagne	0		Last Available: "2021-07"
+8212	twirling narrow grogpagne	0		Last Available: "2021-07"
 8213	Lo Pan's thinker's rigging rope	0		Mysticality: +10, Spell Critical Percent: +30, Last Available: "2015-04"
 8214	denatured nasty snuff	1	crappy	Last Available: "2015-04"
 8215	sewage-clogged pistol of the blizzard of the early riser	0		Cold Spell Damage: +25, Adventures: +7, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
@@ -8091,7 +8091,7 @@
 8217	healthy savvy perfume-soaked bandana	0		Mysticality Percent: +20, Maximum HP Percent: +20, Single Equip, Last Available: "2015-04"
 8218	squat toxic globule	0		Last Available: "2015-04"
 8219	delicious toxo	3	awesome	Last Available: "2015-04"
-8220	weak perfectly mixed Lemonade-235	2	EPIC	Last Available: "2015-04"
+8220	perfectly mixed weak Lemonade-235	2	EPIC	Last Available: "2015-04"
 8221	medical-grade isotophat of the businessman	0		Meat Drop: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	Three Mile Island shorts of Tarzan of incineration	0		Experience (Muscle): +3, Hot Spell Damage: +50, Last Available: "2015-04"
 8223	greedy auspicious toxic mop	0		Item Drop: +10, Meat Drop: +20, Last Available: "2015-04"
@@ -8151,7 +8151,7 @@
 8277	Essence of Bear	0		Skill: "Bear Essence"
 8278	smooth wobbly Afternoon Delight	4	awesome	Last Available: "2015-04"
 8279	jittery Kokomo Resort Chip	0		Last Available: "2015-04"
-8280	skewed pulsating Golden Kokomo Resort Chip	0		Last Available: "2015-04"
+8280	pulsating skewed Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	dry Kokomo Resort Brand Suntan Oil	0		Effect: "Inner Warmth", Effect Duration: 38, Last Available: "2015-04"
 8282	Kokomo Resort Order Pad	0		Last Available: "2015-04"
 8283	The Cocktail Shaker	0		Last Available: "2015-04"
@@ -8168,7 +8168,7 @@
 8294	blurry savvy dice-print do-rag	0		Mysticality Percent: +20
 8295	blinking Usain Bolt's dice sunglasses	0		Initiative: +80, Single Equip
 8296	Thwaitgold caterpillar statuette	0		
-8297	moist green mirror dice	0		Effect: "Omphalotus Omnipresence", Effect Duration: 62
+8297	moist mirror green dice	0		Effect: "Omphalotus Omnipresence", Effect Duration: 62
 8298	green pixel	0		Last Available: "2015-06"
 8299	maroon pixel coin	0		Last Available: "2015-06"
 8300	tarnished electrified power pill	0		Effect: "Amorphous Cheer", Effect Duration: 55, Last Available: "2015-06"
@@ -8180,7 +8180,7 @@
 8306	quadruple-enhanced sludgesicle	0		Effect: "Wasabi With You", Effect Duration: 69
 8307	pressed mirror &Uuml;berraschthexengebr&auml;u	0		Effect: "Supafly", Effect Duration: 39
 8308	magnetized wobbly piggy tattoo	0		Effect: "Fire Inside", Effect Duration: 56
-8309	deionized olive ghostly baggie of regular-sized tardigrades	0		Effect: "Whitened Teeth", Effect Duration: 66
+8309	deionized ghostly olive baggie of regular-sized tardigrades	0		Effect: "Whitened Teeth", Effect Duration: 66
 8310	wet ionized electrified .epub file	0		Effect: "Amorous Avarice", Effect Duration: 11
 8311	dry denatured BUBBLE GUM	0		Effect: "Rave Concentration", Effect Duration: 64
 8312	double-cold-filtered pickled spinning hustler shades	0		Effect: "Loco Motives", Effect Duration: 14
@@ -8225,13 +8225,13 @@
 8351	corrupted lump of goofball ore	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 37
 8352	concentrated extra-quantum skeleton beans	0		Effect: "Bread Burps", Effect Duration: 27
 8353	anodized alkaline grimy lab coat	0		Effect: "Human-Undead Hybrid", Effect Duration: 42
-8354	concentrated super-alkaline narrow blue huge nursery rhyme	0		Effect: "Inebriate Pride", Effect Duration: 68
+8354	concentrated super-alkaline blue huge narrow nursery rhyme	0		Effect: "Inebriate Pride", Effect Duration: 68
 8355	unsweetened iron torso box	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 68
 8356	dry skewed mercenary headband	0		Effect: "Mana Tea", Effect Duration: 49
 8357	alkaline wet radioactive spider venom	0		Effect: "Cold Hands", Effect Duration: 57
 8358	anodized irradiated mirror x-ray mirror	0		Effect: "Smoking like a Bandit", Effect Duration: 67
 8359	vacuum-sealed double-denatured upside-down wrestling mask	0		Effect: "Corona de la Salsa", Effect Duration: 67
-8360	modified blurry narrow blue hawkface potion	0		Effect: "Poker Faced", Effect Duration: 50
+8360	modified narrow blurry blue hawkface potion	0		Effect: "Poker Faced", Effect Duration: 50
 8361	alkaline corrupted child-sized dracula cloak	0		Effect: "What's That Smell?", Effect Duration: 48
 8362	denatured devil-summoning hat	0		Effect: "Slimed Stomach", Effect Duration: 29
 8363	irradiated warmed teal shopkeeper beard	0		Effect: "Human-Beast Hybrid", Effect Duration: 16
@@ -8246,10 +8246,10 @@
 8372	galvanized vacuum-sealed ghostly flashy pirate dreadlocks	0		Effect: "Rushtacean'", Effect Duration: 49
 8373	triple-galvanized oxidized huge captured boozles	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 62
 8374	diffused drinks tray	0		Effect: "From Nantucket", Effect Duration: 36
-8375	flattened double-chilled adjusted olive shaking ghostly eyebrow lifter	0		Effect: "Insatiable Hunger", Effect Duration: 16
-8376	tumbling blurry submarine	0		Last Available: "2015-06"
+8375	flattened double-chilled adjusted ghostly olive shaking eyebrow lifter	0		Effect: "Insatiable Hunger", Effect Duration: 16
+8376	blurry tumbling submarine	0		Last Available: "2015-06"
 8377	rotten twirling blurry pixel lemon	3	crappy	Last Available: "2015-06"
-8378	acceptable practically non-alcoholic pixel daiquiri	1	good	Last Available: "2015-06"
+8378	practically non-alcoholic acceptable pixel daiquiri	1	good	Last Available: "2015-06"
 8379	diffused extra-energized power pill	0		Effect: "Become Intensely interested", Effect Duration: 56, Last Available: "2015-06"
 8380	magnetized cold-filtered pixel potion	0		Effect: "Wreathed in Smoke", Effect Duration: 44, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8285,13 +8285,13 @@
 8411	stale bouncing spaghetti with ghost balls	3	decent	
 8412	decent succulent marrow	4	good	
 8413	yummy skewed salacious crumbs	4	awesome	
-8414	thick stale huge fusilli marrownarrow	5	decent	
+8414	stale thick huge fusilli marrownarrow	5	decent	
 8415	immense rotten suggestive strozzapreti	6	crappy	
 8416	Mountain Stream gastrique	0		
-8417	moldy small Mt. McLargeHuge oyster	2	crappy	
+8417	small moldy Mt. McLargeHuge oyster	2	crappy	
 8418	oyster sauce	0		
-8419	tiny adequate maroon linguini immondizia bianco	1	good	
-8420	thick flavorless shells a la shellfish	5	decent	
+8419	adequate tiny maroon linguini immondizia bianco	1	good	
+8420	flavorless thick shells a la shellfish	5	decent	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
 8423	unsmoothed velvet	0		Last Available: "2015-08"
@@ -8332,7 +8332,7 @@
 8458	veiny high-temperature mining mask of the scaredy-cat	0		Maximum HP: +10, Monster Level: -15, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	fireproof megaphone of Calamity Jane of incineration	0		Critical Hit Percent: +15, Hot Spell Damage: +50, Last Available: "2015-08"
 8460	tasty mineapple	3	awesome	Last Available: "2015-08"
-8461	perfectly mixed strong Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
+8461	strong perfectly mixed Gold Velvet&trade; whiskey	5	EPIC	Last Available: "2015-08"
 8462	yellow SMOOCH soda	1	good	Last Available: "2015-08"
 8463	rotten smelted roe	4	crappy	Last Available: "2015-08"
 8464	artisanal lavawater	4	EPIC	Last Available: "2015-08"
@@ -8345,11 +8345,11 @@
 8471	teal lightning-fast smooth lava-proof pants	0		Moxie: +15, Initiative: +40, Last Available: "2015-08"
 8472	scorching Samson's heat-resistant necktie	0		Experience (Muscle): +5, Hot Damage: +25, Single Equip, Last Available: "2015-08"
 8473	shaking zippy supercool heat-resistant gloves of the blizzard	0		Moxie Percent: +20, Cold Spell Damage: +25, Initiative: +20, Single Equip, Last Available: "2015-08"
-8474	special rotten massive very hot lunch	6	crappy	Effect: "Ocelot Eyes", Effect Duration: 40, Last Available: "2015-08"
+8474	rotten special massive very hot lunch	6	crappy	Effect: "Ocelot Eyes", Effect Duration: 40, Last Available: "2015-08"
 8475	lousy blurry asbestos thermos	3	decent	Last Available: "2015-08"
 8476	electrified shaking liquid rhinestones	0		Effect: "Reptilian Fortitude", Effect Duration: 30, Last Available: "2015-08"
 8477	snack-sized adequate blurry disco biscuit	2	good	Last Available: "2015-08"
-8478	weak artisanal Quaatorade&trade;	2	EPIC	Last Available: "2015-08"
+8478	artisanal weak Quaatorade&trade;	2	EPIC	Last Available: "2015-08"
 8479	bouncing perfumed biker's hat of doom of mayonnaise	0		Spooky Spell Damage: +50, Sleaze Spell Damage: +50, Stench Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk"
 8480	blinking studded feathered headdress of the wise owl of James Dean	0		Mysticality: +20, Experience (Moxie): +3, Damage Absorption: +80, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
 8481	huge censurious Temple Grandin's smartaleck's electrician's hardhat	0		Moxie Percent: +30, Familiar Weight: +7, Sleaze Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
@@ -8358,7 +8358,7 @@
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
 8485	&quot;DEBBIE&quot; tattoo kit	0		Last Available: "2015-08"
 8486	squat one-day ticket to That 70s Volcano	0		Last Available: "2015-08"
-8487	huge pulsating airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
+8487	pulsating huge airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	fuchsia Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
 8490	cool smooth velvet pants	0		Moxie: +5, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
@@ -8370,7 +8370,7 @@
 8496	twirling wicked The One Mood Ring of Gandalf	0		Spell Damage: +5, Spell Critical Percent: +20, Single Equip, Last Available: "2015-08"
 8497	Mr. Choch's bone	0		Last Available: "2015-08"
 8498	Mr. Cheeng's 'stache	0		Last Available: "2015-08"
-8499	spinning blinking Saturday Night thermometer	0		Last Available: "2015-08"
+8499	blinking spinning Saturday Night thermometer	0		Last Available: "2015-08"
 8500	the tongue of Smimmons	0		Last Available: "2015-08"
 8501	Raul's guitar pick	0		Last Available: "2015-08"
 8502	tumbling Pener's crisps	0		Last Available: "2015-08"
@@ -8400,12 +8400,12 @@
 8526	spoiled super-sized pink slime	5	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	upside-down Special&trade; Sauce	0		
-8529	normal enchanted miniature devil hair pasta	2	good	Effect: "Sealed Brain", Effect Duration: 15
+8529	enchanted normal miniature devil hair pasta	2	good	Effect: "Sealed Brain", Effect Duration: 15
 8530	stale spagecialetti	4	decent	
-8531	shaking wobbly Salsa Libre	0		
+8531	wobbly shaking Salsa Libre	0		
 8532	huge good gravy	0		
 8533	skewed illicit fish sauce	0		
-8534	jumbo adequate libertagliatelle	5	good	
+8534	adequate jumbo libertagliatelle	5	good	
 8535	moldy turkish mostaccioli	3	crappy	
 8536	decent linguini of the sea	3	good	
 8537	alkaline upside-down Hersey&trade; SMOOCH	0		Effect: "Powder Power", Effect Duration: 55
@@ -8413,18 +8413,18 @@
 8540	lime green rainbow sauce	0		
 8541	shaking drug cocktail sauce	0		
 8542	adequate Fettris	4	good	
-8543	normal small maroon upside-down fusillocybin	2	good	
+8543	normal small upside-down maroon fusillocybin	2	good	
 8544	bland prescription noodles	3	decent	
-8545	compressed mirror blurry blood-drive sticker	1	good	Effect: "Patent Alacrity", Effect Duration: 35
+8545	compressed blurry mirror blood-drive sticker	1	good	Effect: "Patent Alacrity", Effect Duration: 35
 8546	irradiated liquefied shaking bag of grain	0		Effect: "Here's Mud in Your Eye", Effect Duration: 30
 8547	non-boiled corrupted lime green pocket maze	0		Effect: "Sweet and Green", Effect Duration: 27
 8548	ionized olive huge shady shades	0		Effect: "Here to Kick Ass", Effect Duration: 54
 8549	concentrated warmed squeaky toy rose	0		Effect: "No Vertigo", Effect Duration: 19
 8550	spoiled weird gazelle steak	4	crappy	
-8551	stale lime green wobbly sausage without a cause	3	decent	
+8551	stale wobbly lime green sausage without a cause	3	decent	
 8552	diffused face paint	0		Effect: "Cringle's Curative Carol", Effect Duration: 44
 8553	lousy jittery emergency margarita	4	decent	
-8554	practically non-alcoholic perfectly mixed vintage smart drink	1	super ultra mega turbo EPIC	
+8554	perfectly mixed practically non-alcoholic vintage smart drink	1	super ultra mega turbo EPIC	
 8555	a ten-percent bonus	0		
 8556	Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
@@ -8447,10 +8447,10 @@
 8574	moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
-8577	fuchsia ghostly barnacled barrel	0		Last Available: "2015-09"
-8578	aged weak bottle of Amontillado	2	awesome	Last Available: "2015-09"
+8577	ghostly fuchsia barnacled barrel	0		Last Available: "2015-09"
+8578	weak aged bottle of Amontillado	2	awesome	Last Available: "2015-09"
 8579	acceptable barrel-aged martini	4	good	Last Available: "2015-09"
-8580	big rotten barrel pickle	5	crappy	Last Available: "2015-09"
+8580	rotten big barrel pickle	5	crappy	Last Available: "2015-09"
 8581	normal barrel cracker	4	good	Last Available: "2015-09"
 8582	compressed vibrating mushroom	1	good	Last Available: "2015-09"
 8583	modified mushroom	1	crappy	Last Available: "2015-09"
@@ -8475,22 +8475,22 @@
 8602	concentrated diffused cuppa Yet tea	0		Effect: "Sugary Tongue", Effect Duration: 24, Last Available: "2015-09"
 8603	deionized cuppa Boo tea	0		Effect: "Flagrantly Fragrant", Effect Duration: 14, Last Available: "2015-09"
 8604	vacuum-sealed super-diffused cuppa Nas tea	0		Effect: "Trufflin'", Effect Duration: 39, Last Available: "2015-09"
-8605	enhanced colloidal wobbly huge cuppa Improprie tea	0		Effect: "Going Ape", Effect Duration: 13, Last Available: "2015-09"
+8605	enhanced colloidal huge wobbly cuppa Improprie tea	0		Effect: "Going Ape", Effect Duration: 13, Last Available: "2015-09"
 8606	triple-unsweetened wet narrow cuppa Frost tea	0		Effect: "Hoity Toity", Effect Duration: 11, Last Available: "2015-09"
 8607	aerosolized oxidized pickled cuppa Toast tea	0		Effect: "Polka of Plenty", Effect Duration: 32, Last Available: "2015-09"
 8608	magnetized anodized cuppa Net tea	0		Effect: "Wet Jaw", Effect Duration: 16, Last Available: "2015-09"
 8609	deionized unsweetened cuppa Proprie tea	0		Effect: "BOOsted", Effect Duration: 34, Last Available: "2015-09"
 8610	chilled cuppa Morbidi tea	0		Effect: "Taurus Rising", Effect Duration: 38, Last Available: "2015-09"
-8611	quantum bouncing squat cuppa Chari tea	0		Effect: "Musky", Effect Duration: 19, Last Available: "2015-09"
+8611	quantum squat bouncing cuppa Chari tea	0		Effect: "Musky", Effect Duration: 19, Last Available: "2015-09"
 8612	pressed galvanized colloidal narrow cuppa Serendipi tea	0		Effect: "Cravin' for a Ravin'", Effect Duration: 68, Last Available: "2015-09"
 8613	extra-modified moist cuppa Feroci tea	0		Effect: "The Power of Positive Thinking", Effect Duration: 15, Last Available: "2015-09"
 8614	boiled double-Vulcanized cuppa Physicali tea	0		Effect: "Inner Dog", Effect Duration: 15, Last Available: "2015-09"
 8615	alkaline improved cuppa Wit tea	0		Effect: "Bone Chilling", Effect Duration: 39, Last Available: "2015-09"
 8616	nitrogenated galvanized jittery cuppa Neuroplastici tea	0		Effect: "Category", Effect Duration: 30, Last Available: "2015-09"
 8617	tarnished cuppa Dexteri tea	0		Effect: "Spooky Demeanor", Effect Duration: 18, Last Available: "2015-09"
-8618	altered corrupted double-liquefied maroon huge cuppa Flexibili tea	0		Effect: "Crud&eacute;", Effect Duration: 41, Last Available: "2015-09"
-8619	liquefied blue pulsating cuppa Impregnabili tea	0		Effect: "Slightly Mutated", Effect Duration: 22, Last Available: "2015-09"
-8620	anodized purple pulsating cuppa Obscuri tea	0		Effect: "Comprehensively Nourished", Effect Duration: 17, Last Available: "2015-09"
+8618	altered corrupted double-liquefied huge maroon cuppa Flexibili tea	0		Effect: "Crud&eacute;", Effect Duration: 41, Last Available: "2015-09"
+8619	liquefied pulsating blue cuppa Impregnabili tea	0		Effect: "Slightly Mutated", Effect Duration: 22, Last Available: "2015-09"
+8620	anodized pulsating purple cuppa Obscuri tea	0		Effect: "Comprehensively Nourished", Effect Duration: 17, Last Available: "2015-09"
 8621	magnetized huge wobbly cuppa Irritabili tea	0		Effect: "Gr8ness", Effect Duration: 55, Last Available: "2015-09"
 8622	super-warmed cuppa Mediocri tea	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 41, Last Available: "2015-09"
 8623	flattened cuppa Loyal tea	0		Effect: "Corona de la Salsa", Effect Duration: 33, Last Available: "2015-09"
@@ -8501,7 +8501,7 @@
 8628	non-frozen unsweetened cuppa Mana tea	0		Effect: "Vented Spleen", Effect Duration: 19, Last Available: "2015-09"
 8629	warmed double-pressed cuppa Monstrosi tea	0		Effect: "Piratastic", Effect Duration: 57, Last Available: "2015-09"
 8630	Vulcanized cuppa Twen tea	0		Effect: "It's Electric!", Effect Duration: 22, Last Available: "2015-09"
-8631	diffused non-altered upside-down ghostly cuppa Gill tea	0		Effect: "Celestial Sheen", Effect Duration: 58, Last Available: "2015-09"
+8631	diffused non-altered ghostly upside-down cuppa Gill tea	0		Effect: "Celestial Sheen", Effect Duration: 58, Last Available: "2015-09"
 8632	aerosolized cuppa Uncertain tea	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 44, Last Available: "2015-09"
 8633	cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
@@ -8512,10 +8512,10 @@
 8639	maroon doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	decent bowl of eyeballs	4	good	Last Available: "2015-10"
-8642	diet spoiled bowl of mummy guts	1	crappy	Last Available: "2015-10"
+8642	spoiled diet bowl of mummy guts	1	crappy	Last Available: "2015-10"
 8643	yummy bowl of maggots	3	awesome	Last Available: "2015-10"
 8644	perfectly mixed shaking blood and blood	4	EPIC	Last Available: "2015-10"
-8645	lousy watered-down Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
+8645	watered-down lousy Jack-O-Lantern beer	2	decent	Last Available: "2015-10"
 8646	enchanted mediocre green zombie	4	decent	Effect: "A Contender", Effect Duration: 10, Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
@@ -8548,7 +8548,7 @@
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	wet deionized shoulder-warming lotion	0		Effect: "Carrrsmic", Effect Duration: 20, Last Available: "2015-11"
 8677	stale huge iceberg lettuce	3	decent	Last Available: "2015-11"
-8678	artisanal high-proof pulsating ice wine	9	EPIC	Last Available: "2015-11"
+8678	high-proof artisanal pulsating ice wine	9	EPIC	Last Available: "2015-11"
 8679	bouncing prompt dog trainer's grievous Wal-Mart snowglobe	0		Weapon Damage Percent: +50, Experience (familiar): +1, Adventures: +3, Last Available: "2015-11"
 8680	wool curative Wal-Mart nametag of terror	0		Spooky Spell Damage: +10, Cold Resistance: +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-11"
 8681	Van der Graaf stylish Wal-Mart overalls of dire peril	0		Moxie: +25, Weapon Damage: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-11"
@@ -8559,13 +8559,13 @@
 8686	twirling perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	blurry teal brawny bellhop's hat	0		Muscle Percent: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	weak smooth ice porter	2	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	smooth weak ice porter	2	awesome	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	altered exotic travel brochure	0		Effect: "Pockets of Fire", Effect Duration: 42, Last Available: "2015-11"
 8691	red bag of foreign bribes	0		Last Available: "2015-11"
 8692	liquefied shampoo-conditioner	0		Effect: "Preternatural Greed", Effect Duration: 50, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
-8695	tumbling blue Martialest Arts trophy	0		Last Available: "2016-01"
+8695	blue tumbling Martialest Arts trophy	0		Last Available: "2016-01"
 8696	modified shaking medicinal herbs	1		Last Available: "2016-01"
 8697	flavorless massive ice rice	10	decent	Last Available: "2016-01"
 8698	aged iced plum wine	3	awesome	Last Available: "2016-01"
@@ -8590,9 +8590,9 @@
 8717	denatured twirling abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	adequate snack-sized pulsating VYKEA meatballs	2	good	Last Available: "2015-11"
-8720	fancy watered-down tolerable VYKEA mead	2	good	Effect: "Human-Slime Hybrid", Effect Duration: 25, Last Available: "2015-11"
+8720	fancy tolerable watered-down VYKEA mead	2	good	Effect: "Human-Slime Hybrid", Effect Duration: 25, Last Available: "2015-11"
 8721	anodized adjusted twirling VYKEA woadpaint	0		Effect: "Dirge of Dreadfulness", Effect Duration: 58, Last Available: "2015-11"
-8722	blue ghostly VYKEA frenzy rune	0		Last Available: "2015-11"
+8722	ghostly blue VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
 8724	huge VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
@@ -8602,19 +8602,19 @@
 8729	Oprah's slick VYKEA hex key of the pedagogue	0		Moxie: +10, Experience: +3, Maximum MP Percent: +50, Last Available: "2015-11"
 8730	bouncing VYKEA instructions	0		Last Available: "2015-11"
 8731	small spoiled tin of submardines	2	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
-8732	practically non-alcoholic bad red ghostly bottle of norwhiskey	1	decent	Last Available: "2015-11"
+8732	bad practically non-alcoholic red ghostly bottle of norwhiskey	1	decent	Last Available: "2015-11"
 8733	pickled upside-down teal octolus oculus	1	decent	Last Available: "2015-11"
 8734	chaotic padded sardine can key of Gandalf	0		Damage Absorption: +20, Spell Critical Percent: 30, Last Available: "2015-11"
 8735	scorching energetic dance instructor's norwhal helmet	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20, Hot Damage: +25, Last Available: "2015-11", Familiar Effect: "atk"
 8736	shaking stanky mansplainer's vibrating octolus-skin cloak	0		Maximum MP Percent: +10, Monster Level: +15, Stench Spell Damage: +25, Last Available: "2015-11"
-8737	fancy acceptable shaking perfect cosmopolitan	3	good	Effect: "Coy to the Hurled", Effect Duration: 30, Last Available: "2015-11"
+8737	acceptable fancy shaking perfect cosmopolitan	3	good	Effect: "Coy to the Hurled", Effect Duration: 30, Last Available: "2015-11"
 8738	mediocre special perfect negroni	3	decent	Effect: "Shoesauce", Effect Duration: 15, Last Available: "2015-11"
 8739	bad skewed perfect dark and stormy	4	decent	Last Available: "2015-11"
 8740	perfectly mixed weak perfect mimosa	2	super ultra EPIC	Last Available: "2015-11"
 8741	bad twirling perfect old-fashioned	4	decent	Last Available: "2015-11"
-8742	mediocre triple-distilled perfect paloma	8	decent	Last Available: "2015-11"
+8742	triple-distilled mediocre perfect paloma	8	decent	Last Available: "2015-11"
 8743	tarnished quadruple-enhanced That 70s Cologne	0		Effect: "Ginger Snapped", Effect Duration: 16, Last Available: "2015-11"
-8744	tarnished wobbly teal Wal-Mart &quot;diamond&quot; ring	0		Effect: "Spring Training", Effect Duration: 32, Last Available: "2015-11"
+8744	tarnished teal wobbly Wal-Mart &quot;diamond&quot; ring	0		Effect: "Spring Training", Effect Duration: 32, Last Available: "2015-11"
 8745	oxidized quadruple-moist moist shaking Puffstone cigar	0		Effect: "Vital", Effect Duration: 27, Last Available: "2015-11"
 8746	pressed electrified aerosolized pulsating Conspiracy&trade; mascara	0		Effect: "Wise Spirit", Effect Duration: 54, Last Available: "2015-11"
 8747	super-moist liquefied fuchsia Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Tingly Wrists", Effect Duration: 16, Last Available: "2015-11"
@@ -8624,8 +8624,8 @@
 8751	non-pickled communal gobstopper	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 60, Last Available: "2015-12"
 8752	half-sized flavorless Crimbo salad	2	decent	Last Available: "2015-12"
 8753	decent bread line	3	good	Last Available: "2015-12"
-8754	hand-crafted weak bark rootbeer	2	EPIC	Last Available: "2015-12"
-8755	weak mediocre ale	2	decent	Last Available: "2015-12"
+8754	weak hand-crafted bark rootbeer	2	EPIC	Last Available: "2015-12"
+8755	mediocre weak ale	2	decent	Last Available: "2015-12"
 8756	squat curative plastic Tammy the Tambourine Elf	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12"
 8757	wobbly medical-grade plastic Rudolph the Red	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-12"
 8758	plastic Gaia'ajh-dsli Ak'lwej of wisdom	0		Mysticality: +15, Last Available: "2015-12"
@@ -8636,7 +8636,7 @@
 8763	maroon BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	purple Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	perfectly mixed weak tumbling Gratitude chocolate (bourbon-filled)	2	EPIC	Last Available: "2016-02"
+8766	weak perfectly mixed tumbling Gratitude chocolate (bourbon-filled)	2	EPIC	Last Available: "2016-02"
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	huge chocolate bowtie	0		Familiar Weight: +5
@@ -8665,15 +8665,15 @@
 8793	shaking face paint	0		Free Pull, Last Available: "2015-12"
 8794	The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
-8796	ghostly narrow plastic spoiler	0		
+8796	narrow ghostly plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	bat-jute	0		Last Available: "2017-01"
 8799	mirror bat-o-mite	0		Last Available: "2017-01"
 8800	upside-down ROM of Optimality	0		Skill: "Toggle Optimality"
-8801	gray ghostly incriminating evidence	0		Last Available: "2017-01"
+8801	ghostly gray incriminating evidence	0		Last Available: "2017-01"
 8802	dangerous chemicals	0		Last Available: "2017-01"
 8803	kidnapped orphan	0		Last Available: "2017-01"
-8804	twirling tumbling high-grade	0		Last Available: "2017-01"
+8804	tumbling twirling high-grade	0		Last Available: "2017-01"
 8805	shaking high-tensile-strength fibers	0		Last Available: "2017-01"
 8806	high-grade explosives	0		Last Available: "2017-01"
 8807	experimental gene therapy	0		Last Available: "2017-01"
@@ -8685,13 +8685,13 @@
 8813	huge pulsating glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	tumbling red bat-bearing	0		Last Available: "2017-01"
-8816	special tiny decent Kudzu salad	1	good	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2016-12"
+8816	special decent tiny Kudzu salad	1	good	Effect: "French Bronilla Brogueishness", Effect Duration: 40, Last Available: "2016-12"
 8817	modified Mansquito Serum	1		Last Available: "2016-12"
-8818	acceptable fancy Miss Graves' vermouth	4	good	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2016-12"
-8819	small fancy normal ghostly The Plumber's mushroom stew	2	good	Effect: "From Nantucket", Effect Duration: 35, Last Available: "2016-12"
+8818	fancy acceptable Miss Graves' vermouth	4	good	Effect: "Improprie Tea", Effect Duration: 30, Last Available: "2016-12"
+8819	normal small fancy ghostly The Plumber's mushroom stew	2	good	Effect: "From Nantucket", Effect Duration: 35, Last Available: "2016-12"
 8820	diluted The Author's ink	1		Last Available: "2016-02"
 8821	weak lousy The Mad Liquor	2	decent	Last Available: "2016-12"
-8822	practically non-alcoholic bad Doc Clock's thyme cocktail	1	decent	Last Available: "2016-12"
+8822	bad practically non-alcoholic Doc Clock's thyme cocktail	1	decent	Last Available: "2016-12"
 8823	spoiled blurry Mr. Burnsger	3	crappy	Last Available: "2016-12"
 8824	vaporized blurry The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	prompt nippy The Jokester's gun of the dark arts	0		Spell Damage Percent: +100, Cold Damage: +10, Adventures: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
@@ -8750,10 +8750,10 @@
 8878	special flavorless plate of Mixed Garbanzos and Chickpeas	3	decent	Effect: "Deadly Flashing Blade", Effect Duration: 10, Last Available: "2016-02"
 8879	gigantic flavorless plate of Hellfire Spicy Beans	7	decent	Last Available: "2016-02"
 8880	flavorless plate of Frigid Northern Beans	3	decent	Last Available: "2016-02"
-8881	half-sized toothsome upside-down plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
-8882	spoiled immense upside-down skewed plate of Trader Olaf's Exotic Stinkbeans	8	crappy	Last Available: "2016-02"
+8881	toothsome half-sized upside-down plate of World's Blackest-Eyed Peas	2	awesome	Last Available: "2016-02"
+8882	immense spoiled upside-down skewed plate of Trader Olaf's Exotic Stinkbeans	8	crappy	Last Available: "2016-02"
 8883	big bland ghostly plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	decent	Last Available: "2016-02"
-8884	half-sized decent huge narrow plate of Val-U Brand Every Bean Salad	2	good	Last Available: "2016-02"
+8884	decent half-sized huge narrow plate of Val-U Brand Every Bean Salad	2	good	Last Available: "2016-02"
 8885	bland plate of Shrub's Premium Baked Beans	4	decent	Last Available: "2016-02"
 8886	skewed sharpshooter's weightlifter's Fancy Jeff's pocket square	0		Muscle: +15, Critical Hit Percent: +10, Last Available: "2016-02"
 8887	lightning-fast gravedigger's arcane researcher's Daisy's unclean bloomers	0		Experience Percent (Mysticality): +10, Spooky Damage: +10, Initiative: +40, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
@@ -8761,7 +8761,7 @@
 8889	mirror vibrating healthy Da Vinci's Amoon-Ra Cowtep's nemes	0		Experience (Mysticality): +5, Maximum HP Percent: +20, Maximum MP Percent: +10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	scorching friendly Samson's beefcake's Former Sheriff Dan's tin star of the overflowing toilet	0		Muscle: +25, Experience (Muscle): +5, Familiar Weight: +3, Hot Damage: +25, Stench Spell Damage: +50, Last Available: "2016-02"
-8892	blinking bouncing El Vibrato restraints	0		Last Available: "2016-02"
+8892	bouncing blinking El Vibrato restraints	0		Last Available: "2016-02"
 8893	Clara's bell	0		Last Available: "2016-02"
 8894	teal gravedigger's Granny Hackleton's Gatling gun of mayonnaise of the early riser	0		Spooky Damage: +10, Sleaze Spell Damage: +50, Adventures: +7, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
@@ -8778,10 +8778,10 @@
 8906	enhanced upside-down rattler gland	0		Effect: "Mayeaugh", Effect Duration: 66, Last Available: "2016-02"
 8907	dry half-digested coal	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 38, Last Available: "2016-02"
 8908	non-altered tightly-wound spine	0		Effect: "Spooky Blur", Effect Duration: 34, Last Available: "2016-02"
-8909	normal special rotting beefsteak	3	good	Effect: "Trivia Master", Effect Duration: 45, Last Available: "2016-02"
+8909	special normal rotting beefsteak	3	good	Effect: "Trivia Master", Effect Duration: 45, Last Available: "2016-02"
 8910	mediocre firemilk	3	decent	Last Available: "2016-02"
 8911	magnetized spidercow eye-cluster	0		Effect: "Broken Fast", Effect Duration: 37, Last Available: "2016-02"
-8912	denatured mirror spinning moomy dust	1		Effect: "Very Clean Teeth", Effect Duration: 50, Last Available: "2016-02"
+8912	denatured spinning mirror moomy dust	1		Effect: "Very Clean Teeth", Effect Duration: 50, Last Available: "2016-02"
 8913	blinking reassuring western-style skinning knife	0		Spooky Resistance: +1, Item Drop: +5, Last Available: "2016-02"
 8914	teal bouncing reliable sixgun	0		Last Available: "2016-02"
 8915	hale steel knuckles	0		Maximum HP: +20, Last Available: "2016-02"
@@ -8814,7 +8814,7 @@
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	shuddering cow skull	0		Last Available: "2016-02"
 8944	huge rhinestone cowhorn	0		Familiar Weight: +5
-8945	jittery twirling cow skull	0		Last Available: "2016-02"
+8945	twirling jittery cow skull	0		Last Available: "2016-02"
 8946	jangly spurs	0		Last Available: "2016-02"
 8947	quicksilver spurs	0		Initiative: +30, Last Available: "2016-02"
 8948	ghostly thicksilver spurs	0		Spooky Resistance: , Stench Resistance: , Hot Resistance: , Cold Resistance: , Sleaze Resistance: , Last Available: "2016-02"
@@ -8862,7 +8862,7 @@
 8990	electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	squat do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	dried armored prawn	1		Last Available: "2016-03"
-8993	half-sized adequate jumping horseradish	2	good	Last Available: "2016-03"
+8993	adequate half-sized jumping horseradish	2	good	Last Available: "2016-03"
 8994	mediocre Sacramento wine	4	decent	Last Available: "2016-03"
 8995	double-energized Greek fire	0		Effect: "Yuletide Industry", Effect Duration: 53, Last Available: "2016-03"
 8996	rosewater-soaked razor-sharp dangerous brawny ox-head shield of the pedagogue	0		Muscle Percent: +20, Experience: +3, Weapon Damage: +10, Weapon Damage Percent: +25, Stench Resistance: +3, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
@@ -8878,7 +8878,7 @@
 9006	prompt frightening chaotic hale tunac	0		Maximum HP: +20, Spell Critical Percent: +10, Spooky Damage: +5, Adventures: +3, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	pressed wriggling worm	0		Effect: "Metal Speed", Effect Duration: 27, Last Available: "2016-04"
-9009	drinkable practically non-alcoholic skewed bottle of Fishhead 900-Day IPA	1	good	Last Available: "2016-04"
+9009	practically non-alcoholic drinkable skewed bottle of Fishhead 900-Day IPA	1	good	Last Available: "2016-04"
 9010	energized high-test fishing line	0		Effect: "Pwnd", Effect Duration: 61, Last Available: "2016-04"
 9011	stylish fishin' hat	0		Moxie: +25, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8892,20 +8892,20 @@
 9020	plus one	0		Last Available: "2016-05"
 9021	decent gallon of milk	3	good	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
-9023	narrow huge screencapped monster	0		Last Available: "2016-05"
+9023	huge narrow screencapped monster	0		Last Available: "2016-05"
 9024	daily dungeon malware	0		Last Available: "2016-05"
 9025	upside-down infinite BACON machine	0		Last Available: "2016-05"
 9026	First Post shirt package	0		Last Available: "2016-05"
 9027	lightning-fast nasty hale First Post shirt - Cir Senam	0		Maximum HP: +20, Stench Damage: +5, Initiative: +40, Last Available: "2016-05"
 9028	upside-down high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	enchanted bland bite-sized jittery star salad	1	decent	Effect: "Fireproof Lips", Effect Duration: 15
+9030	bland enchanted bite-sized jittery star salad	1	decent	Effect: "Fireproof Lips", Effect Duration: 15
 9031	Thwaitgold moth statuette	0		
-9032	flavorless thick huge bowl of Tastee-Wheet&trade;	5	decent	
+9032	thick flavorless huge bowl of Tastee-Wheet&trade;	5	decent	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	normal browser cookie	4	good	Last Available: "2016-06"
-9036	lousy fortified hacked gibson	5	decent	Last Available: "2016-06"
+9036	fortified lousy hacked gibson	5	decent	Last Available: "2016-06"
 9037	purple vibrating Source shades	0		Maximum MP Percent: +10, Last Available: "2016-06"
 9038	skewed software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8948,7 +8948,7 @@
 9076	wool Samson's noir fedora of Flo-Jo	0		Experience (Muscle): +5, Cold Resistance: +1, Initiative: +100, Last Available: "2016-07"
 9077	perfumed medical-grade arcane researcher's trench coat	0		Experience Percent (Mysticality): +10, Stench Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-07"
 9078	watered-down tolerable Falcon&trade; Maltese Liquor	2	good	Last Available: "2016-07"
-9079	tiny spoiled blue hardboiled egg	1	crappy	Last Available: "2016-07"
+9079	spoiled tiny blue hardboiled egg	1	crappy	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	gray DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	gray fireproof Jeselnik's gravedigger's Fonzie's beefcake's protonic accelerator pack of the dark arts	0		Muscle: +25, Experience (Moxie): +1, Spell Damage Percent: +100, Spooky Damage: +10, Sleaze Damage: +25, Hot Resistance: +3, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
@@ -8983,7 +8983,7 @@
 9111	colloidal quantum squat Lucky Strikes holo-record	0		Effect: "Here's Mud in Your Eye", Effect Duration: 62
 9112	aerosolized EMD holo-record	0		Effect: "Neuroplastici Tea", Effect Duration: 63
 9113	nitrogenated dry jittery Superdrifter holo-record	0		Effect: "Make Meat FA$T!", Effect Duration: 51
-9114	tarnished energized narrow upside-down The Pigs holo-record	0		Effect: "Powder Power", Effect Duration: 60
+9114	tarnished energized upside-down narrow The Pigs holo-record	0		Effect: "Powder Power", Effect Duration: 60
 9115	Vulcanized blurry Drunk Uncles holo-record	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 25
 9116	tumbling time residue	0		Last Available: "2016-09"
 9117	curative repaid diaper	0		HP Regen Min: 3, HP Regen Max: 5
@@ -8993,7 +8993,7 @@
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	enchanted jittery Tea, Earl Grey, Hot	1	awesome	Effect: "Oxygenated Blood", Effect Duration: 50, Last Available: "2016-09"
 9123	huge School of Hard Knocks Diploma	0		
-9124	huge blue baby bark scorpion	0		
+9124	blue huge baby bark scorpion	0		
 9125	droppable microphone	0		
 9126	lousy enchanted unidentified drink	3	decent	Effect: "Slimy Flavor", Effect Duration: 15
 9127	inspector's fireproof KoL Con 13 T-shirt	0		Hot Resistance: +3, Item Drop: +15
@@ -9003,7 +9003,7 @@
 9131	extremely confusing manual	0		
 9132	ghostly groovy pistol of James Dean	0		Moxie Percent: +10, Experience (Moxie): +3
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	thick normal leftover pasty	5	good	
+9134	normal thick leftover pasty	5	good	
 9135	lousy fortified very whiskey	5	decent	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9028,7 +9028,7 @@
 9156	super-sized rotten gray raw cranberry sauce	5	crappy	Last Available: "2016-11"
 9157	normal raw turkey	3	good	Last Available: "2016-11"
 9158	half-sized adequate bouncing raw mincemeat	2	good	Last Available: "2016-11"
-9159	adequate miniature pulsating raw potato	2	good	Last Available: "2016-11"
+9159	miniature adequate pulsating raw potato	2	good	Last Available: "2016-11"
 9160	spoiled miniature narrow raw gravy	2	crappy	Last Available: "2016-11"
 9161	adequate raw bread	3	good	Last Available: "2016-11"
 9162	flame-retardant mini-marshmallow dispenser of the businessman	0		Hot Resistance: +1, Meat Drop: +50, Last Available: "2016-11"
@@ -9047,10 +9047,10 @@
 9175	flavorless squat blurry thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	yummy mince pie	3	awesome	Last Available: "2016-11"
 9177	tiny rotten yellow mashed potatoes	1	crappy	Last Available: "2016-11"
-9178	rotten huge warm gravy	7	crappy	Last Available: "2016-11"
-9179	bite-sized decent fuchsia bread roll	1	good	Last Available: "2016-11"
+9178	huge rotten warm gravy	7	crappy	Last Available: "2016-11"
+9179	decent bite-sized fuchsia bread roll	1	good	Last Available: "2016-11"
 9180	yummy snack-sized leftovers	2	awesome	Last Available: "2016-11"
-9181	gigantic flavorless leftovers sandwich	8	decent	Last Available: "2016-11"
+9181	flavorless gigantic leftovers sandwich	8	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
@@ -9061,9 +9061,9 @@
 9189	upside-down Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	cyan eldritch effluvium	0		
 9191	nitrogenated olive eldritch concentrate	0		Effect: "Polka of Plenty", Effect Duration: 54, Last Available: "2016-11"
-9192	mediocre high-proof eldritch extract	7	decent	Last Available: "2016-11"
+9192	high-proof mediocre eldritch extract	7	decent	Last Available: "2016-11"
 9193	spinning wool shellacked Official Council Aide Pin	0		Damage Reduction: 7, Cold Resistance: +1, Last Available: "2016-11"
-9194	smooth practically non-alcoholic eldritch distillate	1	awesome	Last Available: "2016-11"
+9194	practically non-alcoholic smooth eldritch distillate	1	awesome	Last Available: "2016-11"
 9195	modified eldritch essence	1		Effect: "Meat the Flintstones", Effect Duration: 5, Last Available: "2016-11"
 9196	spinning flame-retardant Science Notebook	0		Hot Resistance: +1
 9197	tumbling up-at-dawn scandalous MacGyver's eldritch hat	0		Maximum MP: +100, Sleaze Damage: +5, Adventures: +5, Last Available: "2016-11"
@@ -9088,7 +9088,7 @@
 9216	blue interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	bite-sized enchanted rotten narrow animal part cracker	1	crappy	Effect: "Sticky Fingers", Effect Duration: 15, Last Available: "2016-12"
+9219	rotten enchanted bite-sized narrow animal part cracker	1	crappy	Effect: "Sticky Fingers", Effect Duration: 15, Last Available: "2016-12"
 9220	watered-down drinkable gingerbread wine	2	good	Last Available: "2016-12"
 9221	adequate huge gingerbread mug	3	good	Last Available: "2016-12"
 9222	purple gingerbread mask of the scaredy-cat	0		Monster Level: -15, Last Available: "2016-12"
@@ -9108,11 +9108,11 @@
 9236	wobbly smelly wholesome gingerbread gavel	0		Maximum HP Percent: +10, Stench Spell Damage: +10, Last Available: "2016-12"
 9237	pulsating wobbly gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	hand-crafted practically non-alcoholic huge ginger beer	1	super ultra mega turbo EPIC	Last Available: "2016-12"
+9239	practically non-alcoholic hand-crafted huge ginger beer	1	super ultra mega turbo EPIC	Last Available: "2016-12"
 9240	tumbling spare chocolate parts	0		Last Available: "2016-12"
 9241	non-ionized frozen pulsating blurry industrial frosting	0		Effect: "Burning Ears", Effect Duration: 26, Last Available: "2016-12"
 9242	triple-modified ionized improved fake cocktail	0		Effect: "Phairly Balanced", Effect Duration: 31, Last Available: "2016-12"
-9243	practically non-alcoholic acceptable red high-end ginger wine	1	good	Last Available: "2016-12"
+9243	acceptable practically non-alcoholic red high-end ginger wine	1	good	Last Available: "2016-12"
 9244	blurry Tesla plastic bad vibe	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-12"
 9245	Socratic plastic angry vikings	0		Experience (Mysticality): +1, Last Available: "2016-12"
 9246	skewed toasty plastic Knows About Chakras	0		Hot Damage: +5, Last Available: "2016-12"
@@ -9124,7 +9124,7 @@
 9252	adequate gigantic spiritual candy cane	10	good	Last Available: "2016-12"
 9253	tolerable spiritual eggnog	3	good	Last Available: "2016-12"
 9254	stale spiritual fruitcake	4	decent	Last Available: "2016-12"
-9255	decent tiny upside-down spiritual gingerbread	1	good	Last Available: "2016-12"
+9255	tiny decent upside-down spiritual gingerbread	1	good	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	tumbling chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	spinning My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	frozen double-improved mirror green rock candy	0		Effect: "Medieval Mage Mayhem", Effect Duration: 53, Last Available: "2016-12"
-9267	flavorless half-sized green-iced sweet roll	2	decent	Last Available: "2016-12"
+9267	half-sized flavorless green-iced sweet roll	2	decent	Last Available: "2016-12"
 9268	sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	pulsating no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9155,22 +9155,22 @@
 9283	frosty saffron antaravasaka of the empath	0		Familiar Weight: +5, Cold Spell Damage: +10, Last Available: "2016-12"
 9284	dog trainer's wicked saffron uttarasanga	0		Spell Damage: +5, Experience (familiar): +1, Last Available: "2016-12"
 9285	Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
-9286	jittery twirling eternal knot tattoo	0		Last Available: "2016-12"
+9286	twirling jittery eternal knot tattoo	0		Last Available: "2016-12"
 9287	cyan pet bad vibe	0		Last Available: "2016-12"
 9288	jittery yellow gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	resourceful sinister Uncle Crimbo's hat of chilblains	0		Spell Damage: +10, Maximum MP: +50, Cold Damage: +25, Last Available: "2016-12"
-9290	spoiled super-sized Eldritch snap	5	crappy	Last Available: "2017-01"
+9290	super-sized spoiled Eldritch snap	5	crappy	Last Available: "2017-01"
 9291	diluted twirling purple hot jelly	1		Effect: "Here to Kick Ass", Effect Duration: 20, Last Available: "2017-01"
 9292	powdered huge jelly	1		Effect: "Arcane in the Brain", Effect Duration: 40, Last Available: "2017-01"
-9293	altered bouncing cyan jelly	1		Last Available: "2017-01"
+9293	altered cyan bouncing jelly	1		Last Available: "2017-01"
 9294	dried jittery sleaze jelly	1		Last Available: "2017-01"
 9295	mixed wobbly stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	rotten shaking toast with hot jelly	3	crappy	Last Available: "2017-01"
-9298	special tiny flavorless toast with jelly	1	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2017-01"
-9299	normal bite-sized blurry toast with jelly	1	good	Last Available: "2017-01"
-9300	normal special snack-sized toast with sleaze jelly	2	good	Effect: "Bloody-minded", Effect Duration: 10, Last Available: "2017-01"
-9301	moldy gigantic toast with stench jelly	7	crappy	Last Available: "2017-01"
+9298	flavorless tiny special toast with jelly	1	decent	Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 45, Last Available: "2017-01"
+9299	bite-sized normal blurry toast with jelly	1	good	Last Available: "2017-01"
+9300	special snack-sized normal toast with sleaze jelly	2	good	Effect: "Bloody-minded", Effect Duration: 10, Last Available: "2017-01"
+9301	gigantic moldy toast with stench jelly	7	crappy	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
 9303	shaking hopeful candle	0		Free Pull, Last Available: "2017-01"
 9304	pewter candlestick	0		Familiar Weight: +10
@@ -9181,11 +9181,11 @@
 9309	delicious enchanted wax booze	3	awesome	Effect: "Marco Polarity", Effect Duration: 50, Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	diluted spinning sea jelly	1		Effect: "Inappropriate Spirit", Effect Duration: 15, Last Available: "2017-01"
-9312	spoiled diet sea truffle	1	crappy	Last Available: "2017-01"
+9312	diet spoiled sea truffle	1	crappy	Last Available: "2017-01"
 9313	wobbly tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	skewed reassuring recovered cufflinks	0		Spooky Resistance: +1, Single Equip, Last Available: "2017-01"
-9316	cyan wobbly heart-shaped crate	0		Free Pull, Last Available: "2017-02"
+9316	wobbly cyan heart-shaped crate	0		Free Pull, Last Available: "2017-02"
 9317	double-oxidized LOV Elixir #3	0		Effect: "Sepia Tan", Effect Duration: 47, Last Available: "2017-02"
 9318	irradiated moist mirror mirror LOV Elixir #6	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 30, Last Available: "2017-02"
 9319	enhanced Vulcanized purple LOV Elixir #9	0		Effect: "There Is A Spoon", Effect Duration: 48, Last Available: "2017-02"
@@ -9195,7 +9195,7 @@
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	huge LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	distilled huge yellow jittery LOV Echinacea Bouquet	1		Last Available: "2017-02"
+9326	distilled huge jittery yellow LOV Echinacea Bouquet	1		Last Available: "2017-02"
 9327	blue double-paned LOV Elephant	0		Cold Resistance: +5, Damage Reduction: 6, Last Available: "2017-02"
 9328	experienced eldritch scanner	0		Experience: +2, Last Available: "2017-02"
 9329	frozen eldritch alignment spray	0		Effect: "Scrappy, Shadowy", Effect Duration: 49, Last Available: "2017-02"
@@ -9203,7 +9203,7 @@
 9331	double-paned wicked cool eldritch hammer	0		Moxie: +5, Spell Damage: +5, Cold Resistance: +5, Last Available: "2017-01"
 9332	stale eldritch mushroom	4	decent	Last Available: "2017-03"
 9333	eldritch ichor	0		
-9334	delicious bite-sized ghostly eldritch mushroom pizza	1	awesome	Last Available: "2017-03"
+9334	bite-sized delicious ghostly eldritch mushroom pizza	1	awesome	Last Available: "2017-03"
 9335	pulsating eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	red eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	unsweetened liquefied eldritch rub	0		Effect: "[1609]Dancin' Fool", Effect Duration: 69, Last Available: "2017-02"
@@ -9212,7 +9212,7 @@
 9340	bouncing Golden HP-35 Calculator	0		
 9341	Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
-9343	squat wobbly bottlecap	0		
+9343	wobbly squat bottlecap	0		
 9344	discarded button	0		
 9345	Gummi-Memory	0		
 9346	Thwaitgold amoeba statuette	0		
@@ -9227,7 +9227,7 @@
 9355	gray can of cherry-flavored sterno	0		Last Available: "2017-03"
 9356	lump of ichor	0		Last Available: "2017-03"
 9357	bouncing bottle of gregnadigne	0		Last Available: "2017-03"
-9358	green narrow shaking bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
+9358	narrow green shaking bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
 9359	jittery baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
 9361	limepatch	0		Last Available: "2017-03"
@@ -9236,13 +9236,13 @@
 9364	imaginary lemon	0		Last Available: "2017-03"
 9365	mediocre literal grasshopper	4	decent	Last Available: "2017-03"
 9366	smooth double entendre	4	awesome	Last Available: "2017-03"
-9367	special artisanal Phlegethon	4	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 15, Last Available: "2017-03"
+9367	artisanal special Phlegethon	4	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 15, Last Available: "2017-03"
 9368	lousy Siberian sunrise	3	decent	Last Available: "2017-03"
-9369	artisanal olive narrow shaking mentholated wine	4	EPIC	Last Available: "2017-03"
-9370	watered-down bad green low tide martini	2	decent	Last Available: "2017-03"
+9369	artisanal shaking narrow olive mentholated wine	4	EPIC	Last Available: "2017-03"
+9370	bad watered-down green low tide martini	2	decent	Last Available: "2017-03"
 9371	delicious shroomtini	4	awesome	Last Available: "2017-03"
 9372	perfectly mixed weak morning dew	2	EPIC	Last Available: "2017-03"
-9373	acceptable irresponsibly strong shaking whiskey squeeze	7	good	Last Available: "2017-03"
+9373	irresponsibly strong acceptable shaking whiskey squeeze	7	good	Last Available: "2017-03"
 9374	artisanal weak great fashioned	2	EPIC	Last Available: "2017-03"
 9375	lousy Gnomish sagngria	3	decent	Last Available: "2017-03"
 9376	hand-crafted watered-down vodka stinger	2	EPIC	Last Available: "2017-03"
@@ -9253,23 +9253,23 @@
 9381	drinkable London frog	3	good	Last Available: "2017-03"
 9382	tolerable nothingtini	3	good	Last Available: "2017-03"
 9383	practically non-alcoholic hand-crafted eighth plague	1	EPIC	Last Available: "2017-03"
-9384	watered-down mediocre maroon single entendre	2	decent	Last Available: "2017-03"
+9384	mediocre watered-down maroon single entendre	2	decent	Last Available: "2017-03"
 9385	lousy red mirror reverse Tantalus	4	decent	Last Available: "2017-03"
-9386	special practically non-alcoholic mediocre elemental caipiroska	1	decent	Effect: "You Liver", Effect Duration: 45, Last Available: "2017-03"
-9387	drinkable spirit-forward Feliz Navidad	5	good	Last Available: "2017-03"
+9386	practically non-alcoholic mediocre special elemental caipiroska	1	decent	Effect: "You Liver", Effect Duration: 45, Last Available: "2017-03"
+9387	spirit-forward drinkable Feliz Navidad	5	good	Last Available: "2017-03"
 9388	hand-crafted extra-dry Bloody Nora	5	EPIC	Last Available: "2017-03"
-9389	drinkable weak moreltini	2	good	Last Available: "2017-03"
-9390	drinkable extra-dry squat hell in a bucket	5	good	Last Available: "2017-03"
+9389	weak drinkable moreltini	2	good	Last Available: "2017-03"
+9390	extra-dry drinkable squat hell in a bucket	5	good	Last Available: "2017-03"
 9391	acceptable Newark	3	good	Last Available: "2017-03"
 9392	artisanal R'lyeh	4	EPIC	Last Available: "2017-03"
-9393	lousy boozy Gnollish sangria	5	decent	Last Available: "2017-03"
-9394	bad fancy wobbly vodka barracuda	3	decent	Effect: "Itchy Trigger Finger", Effect Duration: 25, Last Available: "2017-03"
+9393	boozy lousy Gnollish sangria	5	decent	Last Available: "2017-03"
+9394	fancy bad wobbly vodka barracuda	3	decent	Effect: "Itchy Trigger Finger", Effect Duration: 25, Last Available: "2017-03"
 9395	artisanal triple-distilled pulsating Mysterious Island iced tea	6	EPIC	Last Available: "2017-03"
 9396	acceptable skewed drive-by shooting	3	good	Last Available: "2017-03"
 9397	bad gunner's daughter	3	decent	Last Available: "2017-03"
 9398	artisanal skewed dirt julep	4	EPIC	Last Available: "2017-03"
-9399	watered-down mediocre Simepore slime	2	decent	Last Available: "2017-03"
-9400	irresponsibly strong hand-crafted Phil Collins	9	EPIC	Last Available: "2017-03"
+9399	mediocre watered-down Simepore slime	2	decent	Last Available: "2017-03"
+9400	hand-crafted irresponsibly strong Phil Collins	9	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9297,13 +9297,13 @@
 9425	alien zoological sample	0		Last Available: "2017-04"
 9426	bouncing complex alien zoological sample	0		Last Available: "2017-04"
 9427	teal fascinating alien zoological sample	0		Last Available: "2017-04"
-9428	boiled pulsating fuchsia alien animal goo	1		Last Available: "2017-04"
+9428	boiled fuchsia pulsating alien animal goo	1		Last Available: "2017-04"
 9429	alien animal milk	0		Last Available: "2017-04"
 9430	olive spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	ionized alien medicine	0		Effect: "Craft Tea", Effect Duration: 41, Last Available: "2017-04"
 9433	moldy alien salad	3	crappy	Last Available: "2017-04"
-9434	bad fancy narrow alien booze	3	decent	Effect: "Holiday Disappointment", Effect Duration: 30, Last Available: "2017-04"
+9434	fancy bad narrow alien booze	3	decent	Effect: "Holiday Disappointment", Effect Duration: 30, Last Available: "2017-04"
 9435	boxer's alien mask of the scaredy-cat of courage	0		Muscle Percent: +10, Monster Level: -15, Spooky Resistance: +3, Last Available: "2017-04"
 9436	huge blue up-at-dawn nippy rosy-cheeked alien spear	0		Maximum HP Percent: +30, Cold Damage: +10, Adventures: +5, Last Available: "2017-04"
 9437	spinning knitted alien blowgun of the ox of the wise owl	0		Muscle: +20, Mysticality: +20, Cold Resistance: +3, Last Available: "2017-04"
@@ -9321,16 +9321,16 @@
 9449	murderbot component casing	0		Last Available: "2017-04"
 9450	murderbot monofilament	0		Last Available: "2017-04"
 9451	extra-diffused polymerized murderbot shield unit	0		Effect: "Healthy Bronze Glow", Effect Duration: 13, Last Available: "2017-04"
-9452	olive bouncing murderbot live wire	0		Last Available: "2017-04"
+9452	bouncing olive murderbot live wire	0		Last Available: "2017-04"
 9453	forbidden sinister murderbot mask of the sewer	0		Spell Damage: +10, Spell Damage Percent: +50, Stench Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
 9454	dry teal spinning murderbot spring injector	0		Effect: "Hobo Flavor", Effect Duration: 33, Last Available: "2017-04"
 9455	stiffened savvy murderbot whip	0		Mysticality Percent: +20, Damage Reduction: 1, Last Available: "2017-04"
 9456	green clever crafty murderbot plasma rifle	0		Maximum MP: 30, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
-9458	blinking twirling space pirate treasure map	0		Last Available: "2017-04"
+9458	twirling blinking space pirate treasure map	0		Last Available: "2017-04"
 9459	purple Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
-9461	gray upside-down mirror Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
+9461	upside-down mirror gray Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	upside-down Space Baby children's book	0		Last Available: "2017-04"
 9464	skewed Space Baby bawbaw	0		Last Available: "2017-04"
@@ -9355,7 +9355,7 @@
 9483	pickled diffused skewed upside-down Daily Affirmation: Be a Mind Master	0		Effect: "Quantum of Moxie", Effect Duration: 47, Last Available: "2017-05"
 9484	quantum improved Daily Affirmation: Work For Hours a Week	0		Effect: "Carrrsmic", Effect Duration: 55, Last Available: "2017-05"
 9485	unsweetened polymerized Daily Affirmation: Keep Free Hate in your Heart	0		Effect: "Human-Goblin Hybrid", Effect Duration: 66, Last Available: "2017-05"
-9486	tasty jumbo tumbling Affirmation Cookie	5	awesome	Last Available: "2017-05"
+9486	jumbo tasty tumbling Affirmation Cookie	5	awesome	Last Available: "2017-05"
 9487	License To Kill	0		
 9488	Thwaitgold bug statuette	0		
 9489	wobbly Victor's Spoils	0		
@@ -9370,7 +9370,7 @@
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
 9500	shaking gun	0		Free Pull, Last Available: "2017-06"
-9501	pulsating ghostly tumbling gum	0		Free Pull, Last Available: "2017-06"
+9501	ghostly pulsating tumbling gum	0		Free Pull, Last Available: "2017-06"
 9502	maroon tumbling rosewater-soaked dog trainer's educational plastic gundam	0		Experience: +1, Experience (familiar): +1, Stench Resistance: +3, Last Available: "2017-06"
 9503	jittery License to Chill	0		Last Available: "2017-07"
 9504	blue Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
@@ -9413,7 +9413,7 @@
 9541	xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	lime green X	0		Last Available: "2017-10"
-9544	ghostly upside-down O	0		Last Available: "2017-10"
+9544	upside-down ghostly O	0		Last Available: "2017-10"
 9545	watered-down bad DUFRESNE Suds	2	decent	Last Available: "2017-09"
 9546	Usain Bolt's supercharged mafia pinky ring	0		Maximum MP Percent: +30, Initiative: +80, Single Equip
 9547	tolerable flask of port	3	good	
@@ -9434,7 +9434,7 @@
 9562	tumbling nippy curative stylish weightlifter's protection stick	0		Muscle: +15, Moxie: +25, Cold Damage: +10, HP Regen Min: 3, HP Regen Max: 5
 9563	colloidal bouncing roll of meat	0		Effect: "Frozen Hands", Effect Duration: 58
 9564	censurious flame-retardant mafia thumb ring	0		Hot Resistance: +1, Sleaze Resistance: +3, Single Equip
-9565	colloidal ionized warmed spinning cyan cocoa chondrule	0		Effect: "Phairly Balanced", Effect Duration: 44, Last Available: "2020-09"
+9565	colloidal ionized warmed cyan spinning cocoa chondrule	0		Effect: "Phairly Balanced", Effect Duration: 44, Last Available: "2020-09"
 9566	extremely unsafe strapping mafia middle finger ring	0		Muscle: +5, Weapon Damage Percent: +100, Single Equip, Conditional Skill (Equipped): "Show them your ring"
 9567	reassuring frightening Herculean Rosewater's steel drivin' hammer	0		Mysticality Percent: +30, Experience (Muscle): +1, Spooky Damage: +5, Spooky Resistance: +1
 9568	upside-down fuchsia piece of steel	0		
@@ -9467,7 +9467,7 @@
 9595	bad tumbling Racisto Ruidoso	4	decent	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
 9597	massive special bland skewed squat bran muffin	6	decent	Effect: "Blessing of the Creepy Pasta", Effect Duration: 45
-9598	small normal ghostly blueberry muffin	2	good	
+9598	normal small ghostly blueberry muffin	2	good	
 9599	silent A	0		Last Available: "2017-12"
 9600	silent B	0		Last Available: "2017-12"
 9601	twirling silent C	0		Last Available: "2017-12"
@@ -9520,9 +9520,9 @@
 9648	artisanal extra-dry skewed executive mime flask	5	EPIC	Last Available: "2017-12"
 9649	rotten bouncing nega-mushroom	3	crappy	Last Available: "2017-12"
 9650	drinkable weak pulsating nega-mushroom wine	2	good	Last Available: "2017-12"
-9651	pickled non-dry spinning upside-down Cheer-Up soda	0		Effect: "Metal Speed", Effect Duration: 59, Last Available: "2017-12"
+9651	pickled non-dry upside-down spinning Cheer-Up soda	0		Effect: "Metal Speed", Effect Duration: 59, Last Available: "2017-12"
 9652	delicious shaking mime army rations	3	awesome	Last Available: "2017-12"
-9653	watered-down drinkable twirling mime army wine	2	good	Last Available: "2017-12"
+9653	drinkable watered-down twirling mime army wine	2	good	Last Available: "2017-12"
 9654	altered squat mime army superserum	1		Last Available: "2017-12"
 9655	quantum ghostly mime army camouflage kit	0		Effect: "Unrunnable Face", Effect Duration: 28, Last Available: "2017-12"
 9656	nippy miming beret of the bloodbag	0		Maximum HP: +100, Cold Damage: +10, Last Available: "2017-12"
@@ -9550,8 +9550,8 @@
 9678	shaking cheer extractor	0		Last Available: "2017-12"
 9679	kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	bouncing fireproof skip lid	0		Familiar Weight: +5
-9681	spoiled super-sized squat extra-toasted half sandwich	5	crappy	Last Available: "2018-12"
-9682	triple-distilled acceptable mulled hobo wine	10	good	Last Available: "2018-12"
+9681	super-sized spoiled squat extra-toasted half sandwich	5	crappy	Last Available: "2018-12"
+9682	acceptable triple-distilled mulled hobo wine	10	good	Last Available: "2018-12"
 9683	narrow burning newspaper	0		Last Available: "2018-12"
 9684	executive chaotic crafty burning paper hat	0		Maximum MP: +10, Spell Critical Percent: +10, Meat Drop: +40, Lasts Until Rollover, Last Available: "2018-12"
 9685	Oprah's vibrating burning cape of the dark arts	0		Spell Damage Percent: +100, Maximum MP Percent: 60, Lasts Until Rollover, Last Available: "2018-12"
@@ -9571,8 +9571,8 @@
 9699	foul-smelling clever makeshift garbage shirt of dire peril	0		Weapon Damage: +20, Maximum MP: +20, Stench Damage: +10, Last Available: "2018-01"
 9700	novelty monorail ticket of chilblains of terror	0		Cold Damage: +25, Spooky Spell Damage: +10
 9701	modified upside-down pills	1		Effect: "Got Your Boots On", Effect Duration: 40
-9702	altered maroon tumbling tumbling blurry furry pill	1		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 50
-9703	denatured jittery green ghostly beefy pill	1		Effect: "Icy Demeanor", Effect Duration: 30
+9702	altered blurry tumbling maroon tumbling furry pill	1		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 50
+9703	denatured green ghostly jittery beefy pill	1		Effect: "Icy Demeanor", Effect Duration: 30
 9704	twisted jittery excitement pill	1		Effect: "Patent Alacrity", Effect Duration: 20
 9705	twisted maroon vitamin G pill	1		Effect: "Wise Spirit", Effect Duration: 5
 9706	modified jittery ghostly lucky-ish pill	1		
@@ -9594,8 +9594,8 @@
 9726	teal chilly psychic's amulet of temperance	0		Cold Damage: +5, Sleaze Resistance: +5, Last Available: "2018-02"
 9727	delicious heart-shaped candy whetstone	3	awesome	Last Available: "2018-02"
 9728	yummy Swedish massage fish	3	awesome	Last Available: "2018-02"
-9729	smooth spirit-forward Third Base	5	awesome	Last Available: "2018-02"
-9730	special perfectly mixed fortified Bustle Hustler	5	EPIC	Effect: "Moose Wisdom", Effect Duration: 15, Last Available: "2018-02"
+9729	spirit-forward smooth Third Base	5	awesome	Last Available: "2018-02"
+9730	fortified perfectly mixed special Bustle Hustler	5	EPIC	Effect: "Moose Wisdom", Effect Duration: 15, Last Available: "2018-02"
 9731	moist Fabiotion	0		Effect: "Perception", Effect Duration: 22, Last Available: "2018-02"
 9732	magnetized dry shaking ghostly Bettie page	0		Effect: "Super Speed", Effect Duration: 64, Last Available: "2018-02"
 9733	ionized boiled improved huge tonic o' Banderas	0		Effect: "Beastly Flavor", Effect Duration: 46, Last Available: "2018-02"
@@ -9615,7 +9615,7 @@
 9747	bouncing 1,960 pok&eacute;dollar bill	0		
 9748	metandienone	0		
 9749	blue riboflavin	0		
-9750	blurry blinking olive bronze	0		
+9750	blinking blurry olive bronze	0		
 9751	piracetam	0		
 9752	ultracalcium	0		
 9753	gray ginseng	0		
@@ -9632,7 +9632,7 @@
 9764	jittery Faux	0		Last Available: "2018-03"
 9765	ghostly Sledgehamster	0		Last Available: "2018-03"
 9766	Pimpsqueak	0		Last Available: "2018-03"
-9767	purple mirror Pillowbug	0		Last Available: "2018-03"
+9767	mirror purple Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	Sequestrian	0		Last Available: "2018-03"
 9770	Carpricorn	0		Last Available: "2018-03"
@@ -9677,7 +9677,7 @@
 9809	fuchsia Disgeist	0		Last Available: "2018-03"
 9810	red Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
-9812	shaking blurry Mu	0		Last Available: "2018-03"
+9812	blurry shaking Mu	0		Last Available: "2018-03"
 9813	pulsating Glum berry	0		Last Available: "2018-03"
 9814	Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
@@ -9687,7 +9687,7 @@
 9819	narrow Snarf berry	0		Last Available: "2018-03"
 9820	Keese berry	0		Last Available: "2018-03"
 9821	pulsating luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
-9822	tumbling blue shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9822	blue tumbling shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9823	muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	squat razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9697,8 +9697,8 @@
 9829	boiled brilliant oyster egg	1		Effect: "Human-Machine Hybrid", Effect Duration: 40
 9830	pickled shaking glistening oyster egg	1		
 9831	mixed scintillating oyster egg	1		
-9832	pickled ghostly blue pearlescent oyster egg	1		Effect: "Pop-eyed", Effect Duration: 50
-9833	altered bouncing blue twirling lustrous oyster egg	1		Effect: "Eyes of the Dragon", Effect Duration: 50
+9832	pickled blue ghostly pearlescent oyster egg	1		Effect: "Pop-eyed", Effect Duration: 50
+9833	altered twirling blue bouncing lustrous oyster egg	1		Effect: "Eyes of the Dragon", Effect Duration: 50
 9834	dehydrated spinning gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9712,7 +9712,7 @@
 9844	FantasyRealm key	0		Last Available: "2018-04"
 9845	plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	spinning shaking tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
-9847	bouncing blinking maroon Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
+9847	maroon blinking bouncing Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	maroon LyleCo premium pickaxe	0		Last Available: "2018-04"
 9849	purple LyleCo premium rope	0		Last Available: "2018-04"
 9850	huge My First Art of War	0		Skill: "Army of Toddlers", Last Available: "2018-12"
@@ -9727,15 +9727,15 @@
 9859	LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	tiny moldy FantasyRealm turkey leg	1	crappy	Last Available: "2018-04"
-9863	high-proof hand-crafted fuchsia FantasyRealm mead	10	EPIC	Last Available: "2018-04"
+9862	moldy tiny FantasyRealm turkey leg	1	crappy	Last Available: "2018-04"
+9863	hand-crafted high-proof fuchsia FantasyRealm mead	10	EPIC	Last Available: "2018-04"
 9864	teal nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	jittery hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	flavorless diet ghostly druidic s'more	1	decent	Last Available: "2018-04"
-9870	modified teal tumbling sachet of powder	1		Last Available: "2018-04"
+9869	diet flavorless ghostly druidic s'more	1	decent	Last Available: "2018-04"
+9870	modified tumbling teal sachet of powder	1		Last Available: "2018-04"
 9871	mediocre enchanted mourning wine	4	decent	Effect: "Cold Throat", Effect Duration: 20, Last Available: "2018-04"
 9872	bouncing lime green sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	lime green map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless wobbly denastified haunch	3	decent	Last Available: "2018-04"
-9879	weak drinkable bad rum and good cola	2	good	Last Available: "2018-04"
+9879	drinkable weak bad rum and good cola	2	good	Last Available: "2018-04"
 9880	quadruple-enhanced Potion of Heroism	0		Effect: "Fruited", Effect Duration: 46, Last Available: "2018-04"
 9881	ribald coward's leggings of the Spider Queen of bravery	0		Monster Level: -20, Sleaze Damage: +10, Spooky Resistance: +5, Last Available: "2018-04"
 9882	wholesome slick Master Thief's utility belt of the overflowing toilet	0		Moxie: +10, Maximum HP Percent: +10, Stench Spell Damage: +50, Single Equip, Last Available: "2018-04"
@@ -9765,10 +9765,10 @@
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	bad two meat muck	4	decent	
 9899	stale chocolate Ogre Chieftain	3	decent	
-9900	rotten small ghostly chocolate &quot;Phoenix&quot;	2	crappy	
+9900	small rotten ghostly chocolate &quot;Phoenix&quot;	2	crappy	
 9901	rotten cyan chocolate Spider Queen	4	crappy	
 9902	fortified hand-crafted hipster cocktail	5	EPIC	
-9903	green skewed God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9903	skewed green God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	narrow God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
 9906	skewed God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
@@ -9783,7 +9783,7 @@
 9915	decent good guava	3	good	
 9916	mediocre gin and ginger	4	decent	
 9917	bouncing teal Thwaitgold chigger statuette	0		
-9918	pickled upside-down huge gaseous gravy	1		
+9918	pickled huge upside-down gaseous gravy	1		
 9919	huge SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	jittery A Guide to Safari	0		Skill: "Experience Safari"
@@ -9802,7 +9802,7 @@
 9934	activated interrogative elixir	0		Effect: "Staying Frosty", Effect Duration: 21, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	green Bastille Battalion tattoo kit	0		Last Available: "2018-07"
-9937	olive jittery Bastille Battalion cheese wheel	0		Last Available: "2018-07"
+9937	jittery olive Bastille Battalion cheese wheel	0		Last Available: "2018-07"
 9938	Bastille Battalion control rig loaner voucher	0		Last Available: "2018-07"
 9939	blurry kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	burglar/sleep mask	0		Last Available: "2018-07"
@@ -9818,7 +9818,7 @@
 9950	Socratic pentagram bandana of courage	0		Experience (Mysticality): +1, Spooky Resistance: +3, Last Available: "2018-09"
 9951	sage skull ring	0		Mysticality Percent: +10, Single Equip, Last Available: "2018-09"
 9952	twirling electronics kit	0		Last Available: "2018-09"
-9953	special normal gigantic huge PB&J with the crusts cut off	8	good	Effect: "Ermine Eyes", Effect Duration: 35, Last Available: "2018-09"
+9953	gigantic normal special huge PB&J with the crusts cut off	8	good	Effect: "Ermine Eyes", Effect Duration: 35, Last Available: "2018-09"
 9954	veiny brawny dorky glasses	0		Muscle Percent: +20, Maximum HP: +10, Single Equip, Last Available: "2018-09"
 9955	upside-down yellow Jeselnik's sizzling ponytail clip	0		Hot Damage: +10, Sleaze Damage: +25, Last Available: "2018-09"
 9956	crafty paint palette	0		Maximum MP: +10, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
@@ -9833,12 +9833,12 @@
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
 9966	triple-distilled acceptable blurry everfull glass	8		Last Available: "2018-09"
 9967	cyan van key	0		Last Available: "2018-09"
-9968	mirror wobbly jam band bootleg	0		Last Available: "2018-09"
+9968	wobbly mirror jam band bootleg	0		Last Available: "2018-09"
 9969	green lightning-fast medical-grade denim jacket	0		Initiative: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-09"
 9970	up-at-dawn Da Vinci's ratty knitted cap	0		Experience (Mysticality): +5, Adventures: +5, Last Available: "2018-09"
 9972	teal Rosewater's cool intimidating chainsaw	0		Moxie: +5, Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2018-09"
 9973	irresponsibly strong lousy party beer bomb	7	decent	Last Available: "2018-09"
-9974	huge spoiled fancy sweet party mix	10	crappy	Effect: "protect.enq", Effect Duration: 40, Last Available: "2018-09"
+9974	spoiled huge fancy sweet party mix	10	crappy	Effect: "protect.enq", Effect Duration: 40, Last Available: "2018-09"
 9975	twisted party balloon	1		Last Available: "2018-09"
 9976	teal executive ribald party pants	0		Sleaze Damage: +10, Meat Drop: +40, Last Available: "2018-09"
 9977	blinking Da Vinci's party whip of James Dean of horror	0		Experience (Mysticality): +5, Experience (Moxie): +3, Spooky Spell Damage: +25, Last Available: "2018-09"
@@ -9881,13 +9881,13 @@
 10015	snack-sized flavorless twirling cherry pie	2	decent	Last Available: "2018-11"
 10016	bad olive eggnog	3	decent	Last Available: "2018-11"
 10017	narrow glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	half-sized adequate Hell ramen	2	good	Last Available: "2018-11"
+10018	adequate half-sized Hell ramen	2	good	Last Available: "2018-11"
 10019	mediocre squat gimlet	3	decent	Last Available: "2018-11"
-10020	irresponsibly strong tolerable jittery twice-haunted screwdriver	7	good	Last Available: "2018-11"
+10020	tolerable irresponsibly strong jittery twice-haunted screwdriver	7	good	Last Available: "2018-11"
 10021	rotten half-sized squat candy cane	2	crappy	Last Available: "2018-12"
 10022	mediocre squat runny fermented egg	4	decent	Last Available: "2018-12"
 10023	stale oldcake	3	decent	Last Available: "2018-12"
-10024	flavorless big traditional Crimbo cookie	5	decent	Last Available: "2023-06"
+10024	big flavorless traditional Crimbo cookie	5	decent	Last Available: "2023-06"
 10025	clever plastic wild beaver	0		Maximum MP: +20, Last Available: "2018-12"
 10026	plastic reindeer of the businessman	0		Meat Drop: +50, Last Available: "2018-12"
 10027	ghostly toasty plastic Caf&eacute; Elf	0		Hot Damage: +5, Last Available: "2018-12"
@@ -9902,7 +9902,7 @@
 10036	shaking bomb	0		Last Available: "2018-12"
 10037	shaking plastic bazooka	0		Last Available: "2018-12"
 10038	bouncing mooseflank	0		Last Available: "2018-12"
-10039	rotten half-sized grilled mooseflank	2	crappy	Last Available: "2018-12"
+10039	half-sized rotten grilled mooseflank	2	crappy	Last Available: "2018-12"
 10040	snack-sized yummy shaking moosemeat pie	2	awesome	Last Available: "2018-12"
 10041	balanced antler of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2018-12"
 10042	dam of the overflowing toilet	0		Stench Spell Damage: +50, Damage Reduction: 9, Last Available: "2018-12"
@@ -9914,8 +9914,8 @@
 10048	careful muskox-skin cap	0		Monster Level: -10, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	tasty glass of raw eggs	4	awesome	Last Available: "2018-12"
-10051	drinkable weak punch-drunk punch	2	good	Last Available: "2018-12"
-10052	pickled mirror cyan body spradium	1		Last Available: "2018-12"
+10051	weak drinkable punch-drunk punch	2	good	Last Available: "2018-12"
+10052	pickled cyan mirror body spradium	1		Last Available: "2018-12"
 10053	veiny bauxite beret	0		Maximum HP: +10, Last Available: "2018-12"
 10054	bauxite boxers of the brazier	0		Hot Spell Damage: +25, Last Available: "2018-12"
 10055	bauxite bow-tie of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2018-12"
@@ -9929,7 +9929,7 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	cyan Toyleporter	0		Last Available: "2018-12"
-10066	boozy drinkable skewed beer	5	good	Last Available: "2018-12"
+10066	drinkable boozy skewed beer	5	good	Last Available: "2018-12"
 10067	normal thick yule gruel	5	good	Last Available: "2018-12"
 10068	fortified bad hot watered rum	5	decent	Last Available: "2018-12"
 10069	acceptable bottle of Crimbognac	3	good	Last Available: "2018-12"
@@ -10032,16 +10032,16 @@
 10166	Lil' Doctor&trade; bag of the cougar of chilblains	0		Moxie: +20, Cold Damage: +25, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
 10169	low-calorie yummy bloodstick	1	awesome	
-10170	mediocre extra-dry bottle of Sanguiovese	5	decent	
+10170	extra-dry mediocre bottle of Sanguiovese	5	decent	
 10171	delicious small actual blood sausage	2	awesome	
-10172	bad special narrow mulled blood	3	decent	Effect: "Super-Charged", Effect Duration: 45
+10172	special bad narrow mulled blood	3	decent	Effect: "Super-Charged", Effect Duration: 45
 10173	normal blood snowcone	4	good	
 10174	perfectly mixed squat Red Russian	3	EPIC	
 10175	adequate blood roll-up	3	good	
 10176	acceptable bottle of blood	3	good	
 10177	delicious blood-soaked sponge cake	4	awesome	
 10178	fancy lousy vampagne	3	decent	Effect: "On the Shoulders of Giants", Effect Duration: 20
-10179	bite-sized moldy plain snowcone	1	crappy	
+10179	moldy bite-sized plain snowcone	1	crappy	
 10180	bouncing Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	money bag	0		
@@ -10061,9 +10061,9 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	squat Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	adequate immense crabsicle	8	good	Last Available: "2019-04"
+10199	immense adequate crabsicle	8	good	Last Available: "2019-04"
 10200	squat melty plastic grenade	0		Last Available: "2019-04"
-10201	spirit-forward acceptable bottle of dark rhum	5	good	Last Available: "2019-04"
+10201	acceptable spirit-forward bottle of dark rhum	5	good	Last Available: "2019-04"
 10202	perfectly mixed bottle of extra-dark rhum	3	EPIC	Last Available: "2019-04"
 10203	lousy jittery bottle of super-extra-dark rhum	3	decent	Last Available: "2019-04"
 10204	dry pirate shaving cream	0		Effect: "Meat the Flintstones", Effect Duration: 36, Last Available: "2019-04"
@@ -10071,15 +10071,15 @@
 10206	huge jittery Jeselnik's nippy pirate pantaloons	0		Cold Damage: +10, Sleaze Damage: +25, Last Available: "2019-04"
 10207	mirror [glitch season reward name]	0		
 10208	signal fragment	0		Last Available: "2019-04"
-10209	twirling narrow skewed windicle	0		Last Available: "2019-04"
+10209	narrow twirling skewed windicle	0		Last Available: "2019-04"
 10210	groovy Rosewater's pirate radio ring	0		Mysticality Percent: +30, Moxie Percent: +10, Single Equip, Last Available: "2019-04"
-10211	mirror blurry Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
+10211	blurry mirror Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	normal pineapple slab	3	good	Last Available: "2019-04"
-10213	fancy adequate green hibiscus petal	3	good	Effect: "Swimming with Sharks", Effect Duration: 5, Last Available: "2019-04"
+10213	adequate fancy green hibiscus petal	3	good	Effect: "Swimming with Sharks", Effect Duration: 5, Last Available: "2019-04"
 10214	polymerized ionized tumbling mirror huge mint leaf	0		Effect: "[1609]Dancin' Fool", Effect Duration: 54, Last Available: "2019-04"
-10215	mirror twirling cocoa of youth	0		Last Available: "2019-04"
+10215	twirling mirror cocoa of youth	0		Last Available: "2019-04"
 10216	boiled ice molecule	1		Last Available: "2019-04"
-10217	olive skewed Red Roger's reliquary	0		Last Available: "2019-04"
+10217	skewed olive Red Roger's reliquary	0		Last Available: "2019-04"
 10218	shaking Red Roger's right hand	0		Last Available: "2019-04"
 10219	shaking Red Roger's left hand	0		Last Available: "2019-04"
 10220	olive Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
@@ -10087,7 +10087,7 @@
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	diluted blinking pewter shavings	1		Effect: "Strength of Ten Ettins", Effect Duration: 10, Last Available: "2019-04"
 10224	upside-down Red Roger tattoo kit	0		Last Available: "2019-04"
-10225	skewed red PirateRealm fun-a-log	0		Last Available: "2019-04"
+10225	red skewed PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	yellow Usain Bolt's plush sea serpent	0		Initiative: +80, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	decent pulsating pirate fork	4		Last Available: "2019-04"
 10228	Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
@@ -10097,16 +10097,16 @@
 10232	perfectly mixed strong Island Landslide	5	EPIC	Last Available: "2019-04"
 10233	bad distilled twirling Island Thunderstorm	5	decent	Last Available: "2019-04"
 10234	perfectly mixed ghostly Island Hurricane	4	EPIC	Last Available: "2019-04"
-10235	mediocre irresponsibly strong yellow Skull Punch	8	decent	Last Available: "2019-04"
+10235	irresponsibly strong mediocre yellow Skull Punch	8	decent	Last Available: "2019-04"
 10236	lousy Electric Punch	4	decent	Last Available: "2019-04"
 10237	artisanal mirror Smuggler's Punch	4	EPIC	Last Available: "2019-04"
 10238	drinkable mirror Scorpion Bowl	3	good	Last Available: "2019-04"
 10239	lousy Turtle Bowl	4	decent	Last Available: "2019-04"
-10240	tolerable wobbly tumbling Cobra Bowl	3	good	Last Available: "2019-04"
+10240	tolerable tumbling wobbly Cobra Bowl	3	good	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
 10242	family-friendly rock-hard vampyric cloake of dire peril of the empath of the cheetah	0		Weapon Damage: +20, Damage Reduction: 5, Familiar Weight: +5, Sleaze Resistance: +1, Initiative: +60, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	plastic pirate hat	0		Familiar Weight: +5
-10244	concentrated energized blurry wobbly one piece of bubble gum	0		Effect: "Boon of the War Snapper", Effect Duration: 56
+10244	concentrated energized wobbly blurry one piece of bubble gum	0		Effect: "Boon of the War Snapper", Effect Duration: 56
 10245	jittery arcanoferric housing	0		
 10246	blinking intact medium-wave antenna	0		
 10247	bouncing wobbly 18-picohertz resonator crystal	0		
@@ -10123,10 +10123,10 @@
 10258	spinning fireproof wool padded Beach Comb	0		Damage Absorption: +20, Cold Resistance: +1, Hot Resistance: +3, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	blinking grain of sand	0		Last Available: "2019-07"
 10260	narrow small pile of sand	0		Last Available: "2019-07"
-10261	shaking squat pile of sand	0		Last Available: "2019-07"
+10261	squat shaking pile of sand	0		Last Available: "2019-07"
 10262	upside-down pile of sand	0		Last Available: "2019-07"
 10263	empty hourglass	0		Last Available: "2019-07"
-10264	lime green blurry hourglass	0		Last Available: "2019-07"
+10264	blurry lime green hourglass	0		Last Available: "2019-07"
 10265	narrow etched hourglass	0		Last Available: "2019-07"
 10266	liquefied modified polarized upside-down magenta seashell	0		Effect: "Work For Hours a Week", Effect Duration: 16, Last Available: "2019-07"
 10267	triple-liquefied pressed cyan seashell	0		Effect: "Ooh, Bitter!", Effect Duration: 18, Last Available: "2019-07"
@@ -10154,7 +10154,7 @@
 10289	energized modified Finnish Fish	0		Effect: "Toothy Grin", Effect Duration: 11
 10290	ionized skewed chocolate doubloon	0		Effect: "Penguinny Flavor", Effect Duration: 54
 10291	narrow upside-down up-at-dawn avaricious curative driftwood beach comb	0		Meat Drop: +30, Adventures: +5, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
-10292	blue blurry Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
+10292	blurry blue Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	stick of firewood	0		Last Available: "2019-08"
 10294	mansplainer's whittled tiara of James Dean of the boozehound	0		Experience (Moxie): +3, Monster Level: +15, Booze Drop: +100, Last Available: "2019-08"
 10295	fireproof stylish brainy whittled shorts	0		Mysticality: +5, Moxie: +25, Hot Resistance: +3, Last Available: "2019-08"
@@ -10165,16 +10165,16 @@
 10300	manspreader's Fonzie's Da Vinci's whittled owl figurine	0		Experience (Mysticality): +5, Experience (Moxie): +1, Monster Level: +10, Single Equip, Last Available: "2019-08"
 10301	lion tamer's Jim Carey's slick whittled fox figurine	0		Moxie: +10, Monster Level: +25, Experience (familiar): +2, Single Equip, Last Available: "2019-08"
 10302	squat Sherlock's supercharged wizardly whittled walking stick of terror	0		Mysticality: +25, Maximum MP Percent: +30, Spooky Spell Damage: +10, Item Drop: +25, Last Available: "2019-08"
-10303	big rotten narrow campfire hot dog	5	crappy	Last Available: "2019-08"
-10304	huge bland jittery campfire baked potato	7	decent	Last Available: "2019-08"
+10303	rotten big narrow campfire hot dog	5	crappy	Last Available: "2019-08"
+10304	bland huge jittery campfire baked potato	7	decent	Last Available: "2019-08"
 10305	tasty campfire s'more	3	awesome	Last Available: "2019-08"
-10306	immense flavorless campfire beans	6	decent	Last Available: "2019-08"
+10306	flavorless immense campfire beans	6	decent	Last Available: "2019-08"
 10307	normal mirror campfire stew	4	good	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
 10309	wet leftover chocolate bar	0		Effect: "Neuroplastici Tea", Effect Duration: 18
 10310	rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
-10312	blinking gray bundle of firewood	0		Last Available: "2019-08"
+10312	gray blinking bundle of firewood	0		Last Available: "2019-08"
 10313	spinning campfire smoke	0		
 10314	maroon Murgatroyd diode	0		
 10315	signal receiver	0		
@@ -10195,7 +10195,7 @@
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	delicious bu&ntilde;uelos Jaliscos	3	awesome	Last Available: "2019-12"
 10338	moldy ghostly flan del mar	4	crappy	Last Available: "2019-12"
-10339	jumbo spoiled Baja sopapilla	5	crappy	Last Available: "2019-12"
+10339	spoiled jumbo Baja sopapilla	5	crappy	Last Available: "2019-12"
 10340	scandalous plastic Mer-kin baker	0		Sleaze Damage: +5, Last Available: "2019-12"
 10341	experienced plastic sea elf	0		Experience: +2, Last Available: "2019-12"
 10342	squat skewed avaricious plastic yuleviathan	0		Meat Drop: +30, Last Available: "2019-12"
@@ -10204,7 +10204,7 @@
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	spoiled enchanted mana-coated yams	3	crappy	Effect: "Newt Gets In Your Eyes", Effect Duration: 35, Last Available: "2019-11"
 10347	rotten mana-basted tofurkey leg	4	crappy	Last Available: "2019-11"
-10348	diet stale mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
+10348	stale diet mana-fortified cranberry sauce	1	decent	Last Available: "2019-11"
 10349	bland mana-stuffed herbal stuffing	4	decent	Last Available: "2019-11"
 10350	bouncing human musk	0		Last Available: "2019-12"
 10351	irradiated chilled vacuum-sealed patch of extra-warm fur	0		Effect: "Partially Ghosted", Effect Duration: 56, Last Available: "2019-12"
@@ -10213,11 +10213,11 @@
 10354	distilled vial of humanoid growth hormone	1		Effect: "Gemini Rising", Effect Duration: 20, Last Available: "2019-12"
 10355	diluted a bug's lymph	1		Last Available: "2019-12"
 10356	dry ionized corrupted skewed organic potpourri	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 62, Last Available: "2019-12"
-10357	perfectly mixed triple-distilled boot flask	8	EPIC	Last Available: "2019-12"
+10357	triple-distilled perfectly mixed boot flask	8	EPIC	Last Available: "2019-12"
 10358	super-pickled galvanized infernal snowball	0		Effect: "Category", Effect Duration: 53, Last Available: "2019-12"
 10359	upside-down madness	0		Last Available: "2019-12"
 10360	boiled fish sauce	1		Effect: "Squirming Like a Toad", Effect Duration: 10, Last Available: "2019-12"
-10361	bland fancy low-calorie guffin	1	decent	Effect: "Burning Tongue", Effect Duration: 15, Last Available: "2019-12"
+10361	bland low-calorie fancy guffin	1	decent	Effect: "Burning Tongue", Effect Duration: 15, Last Available: "2019-12"
 10362	denatured shaking Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	dried red non-Euclidean angle	1		Last Available: "2019-12"
@@ -10240,13 +10240,13 @@
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	wobbly Crimbo Factory surprise box	0		Last Available: "2019-12"
 10383	blinking soggy gingerbread chunk	0		Last Available: "2019-12"
-10384	enhanced bouncing gray salty gumdrop	0		Effect: "Takin' It Greasy", Effect Duration: 42, Last Available: "2019-12"
+10384	enhanced gray bouncing salty gumdrop	0		Effect: "Takin' It Greasy", Effect Duration: 42, Last Available: "2019-12"
 10385	maroon shellacked grievous ribbon candy ascot	0		Weapon Damage Percent: +50, Damage Reduction: 7, Single Equip, Last Available: "2019-12"
 10386	wobbly moist Crimbo spices	0		Last Available: "2019-12"
 10387	intact anemone spike	0		Last Available: "2019-12"
 10388	beefy anemoney clip	0		Muscle: +10, Single Equip, Last Available: "2019-12"
 10389	runny icing	0		Last Available: "2019-12"
-10390	vaporized wobbly spinning super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	vaporized spinning wobbly super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	sage icing poncho of James Dean of the empath	0		Mysticality Percent: +10, Experience (Moxie): +3, Familiar Weight: +5, Last Available: "2019-12"
 10392	blue Mer-kin cookiestove	0		Last Available: "2019-12"
 10393	double-galvanized colloidal glob of salty molasses	0		Effect: "Tea-hee", Effect Duration: 64, Last Available: "2019-12"
@@ -10271,9 +10271,9 @@
 10412	lion tamer's hale nutcracker cape	0		Maximum HP: +20, Experience (familiar): +2, Last Available: "2019-12"
 10413	narrow cyan nippy nutcracker epaulets of the cougar	0		Moxie: +20, Cold Damage: +10, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	super-sized bland salt plum	5	decent	Last Available: "2019-12"
+10415	bland super-sized salt plum	5	decent	Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
-10417	miniature bland and bean	2	decent	Last Available: "2019-12"
+10417	bland miniature and bean	2	decent	Last Available: "2019-12"
 10418	Lo Pan's studded kelp-holly gun of doom	0		Damage Absorption: +80, Spell Critical Percent: +30, Spooky Spell Damage: +50, Last Available: "2019-12"
 10419	Yuleviathan necklace of Calamity Jane of the cheetah	0		Critical Hit Percent: +15, Initiative: +60, Single Equip, Last Available: "2019-12"
 10420	squat pulsating peppermint spine of Tarzan of the blizzard	0		Experience (Muscle): +3, Cold Spell Damage: +25, Last Available: "2019-12"
@@ -10283,7 +10283,7 @@
 10424	squat zippy sharpshooter's Staff of the Peppermint Twist of Tarzan of horror	0		Experience (Muscle): +3, Critical Hit Percent: +10, Spooky Spell Damage: +25, Initiative: +20, Last Available: "2019-12"
 10425	rotten tempura and bean	3	crappy	Last Available: "2019-12"
 10426	artisanal weak green huge salt plum sake	2	super EPIC	Last Available: "2019-12"
-10427	super-unsweetened blurry huge pressurized potion of possessiveness	0		Effect: "Sleazy Hands", Effect Duration: 55, Last Available: "2019-12"
+10427	super-unsweetened huge blurry pressurized potion of possessiveness	0		Effect: "Sleazy Hands", Effect Duration: 55, Last Available: "2019-12"
 10428	galvanized oxidized teal almond	0		Effect: "Bandersnatched", Effect Duration: 34
 10429	vacuum-sealed unsweetened handful of mixed nuts	0		Effect: "Cock of the Walk", Effect Duration: 25, Last Available: "2019-12"
 10430	narrow nutcracking pliers	0		
@@ -10299,9 +10299,9 @@
 10442	lard-coated drippy truncheon	0		Sleaze Spell Damage: +25, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
-10445	decent enchanted drippy nugget	4	drippy	Effect: "Destructive Resolve", Effect Duration: 15
+10445	enchanted decent drippy nugget	4	drippy	Effect: "Destructive Resolve", Effect Duration: 15
 10446	mediocre glass of drippy wine	3	drippy	
-10447	normal upside-down skewed drippy caviar	3	drippy	
+10447	normal skewed upside-down drippy caviar	3	drippy	
 10448	miniature rotten drippy plum(?)	2	drippy	
 10449	spinning drippy stake of Gandalf	0		Spell Critical Percent: +20, Single Equip
 10450	The Eye of the Thing in the Basement	0		
@@ -10345,7 +10345,7 @@
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
 10489	rotten mushroom filet	3	crappy	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
-10491	mixed upside-down narrow jittery mushroom tea	1		Last Available: "2020-03"
+10491	mixed jittery narrow upside-down mushroom tea	1		Last Available: "2020-03"
 10492	drinkable pulsating mushroom whiskey	3	good	Last Available: "2020-03"
 10493	scandalous clever grievous mushroom cap	0		Weapon Damage Percent: +50, Maximum MP: +20, Sleaze Damage: +5, Last Available: "2020-03"
 10494	skewed dance instructor's Sinatra's Rosewater's mushroom shield of incineration	0		Mysticality Percent: +30, Experience (Moxie): +5, Experience Percent (Moxie): +10, Hot Spell Damage: +50, Damage Reduction: 6, Last Available: "2020-03"
@@ -10379,23 +10379,23 @@
 10522	mirror drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
-10525	smooth boozy drippy pilsner	5	drippy	
+10525	boozy smooth drippy pilsner	5	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	squat lustrous drippy orb	0		
 10530	fireproof gory drippy orb	0		Hot Resistance: +3
-10531	huge maroon annealed drippy orb	0		
+10531	maroon huge annealed drippy orb	0		
 10532	Guzzlr application	0		Free Pull
 10533	gray asbestos-lined Guzzlr tablet of the bloodbag	0		Maximum HP: +100, Hot Resistance: +5, Last Available: "2020-05"
-10534	wobbly blurry Guzzlr cocktail set	0		Last Available: "2020-05"
+10534	blurry wobbly Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
 10536	Guzzlr hat	0		Last Available: "2020-05"
 10537	Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	purple Guzzlr pants	0		Last Available: "2020-05"
 10539	toasty Guzzlr souvenir stein	0		Hot Damage: +5, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	hand-crafted irresponsibly strong Ghiaccio Colada	8	EPIC	Last Available: "2020-05"
-10542	special strong delicious skewed Sourfinger	5	awesome	Effect: "Larger", Effect Duration: 5, Last Available: "2020-05"
+10541	irresponsibly strong hand-crafted Ghiaccio Colada	8	EPIC	Last Available: "2020-05"
+10542	delicious special strong skewed Sourfinger	5	awesome	Effect: "Larger", Effect Duration: 5, Last Available: "2020-05"
 10543	bad practically non-alcoholic Nog-on-the-Cob	1	decent	Last Available: "2020-05"
 10544	special acceptable Steamboat	3	good	Effect: "Amplified Fabulousness", Effect Duration: 50, Last Available: "2020-05"
 10545	practically non-alcoholic artisanal narrow Buttery Boy	1	super ultra mega turbo EPIC	Last Available: "2020-05"
@@ -10430,7 +10430,7 @@
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	drippy candy bar	0		
 10576	dry salty drippy candy bar	0		Effect: "Oth-Jeal-O", Effect Duration: 13
-10577	dry pulsating teal writhing drippy candy bar	0		Effect: "Bilious Brains", Effect Duration: 29
+10577	dry teal pulsating writhing drippy candy bar	0		Effect: "Bilious Brains", Effect Duration: 29
 10578	anodized ionized gooey drippy candy bar	0		Effect: "Ooh, Sweet!", Effect Duration: 45
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	tumbling dromedary drinking helmet	0		
@@ -10469,7 +10469,7 @@
 10613	Sherlock's Yeg's Motel bathrobe of the storm	0		Maximum MP Percent: +40, Item Drop: +25, Lasts Until Rollover, Last Available: "2020-09"
 10614	gray twirling Sherlock's supercool Yeg's Motel slippers	0		Moxie Percent: +20, Item Drop: +25, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
-10616	spinning squat Yeg's Motel minibar key	0		Last Available: "2020-09"
+10616	squat spinning Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	green uncanny desk bell	0		Last Available: "2020-09"
@@ -10491,7 +10491,7 @@
 10635	blinking lime green bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	miser's family-friendly extremely unsafe beefy Cargo Cultist Shorts	0		Muscle: +10, Weapon Damage Percent: +100, Sleaze Resistance: +1, Meat Drop: +10, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	delicious watered-down flask of moonshine	2	awesome	Last Available: "2020-09"
+10638	watered-down delicious flask of moonshine	2	awesome	Last Available: "2020-09"
 10639	narrow resourceful steel-toed sea-worn candlestick of the ox	0		Muscle: +20, Damage Reduction: 9, Maximum MP: +50, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	boiled null-day exploit	0		Effect: "Ten out of Ten", Effect Duration: 46, Last Available: "2025-12"
@@ -10517,7 +10517,7 @@
 10661	pulsating SalesCo sample kit of temperance	0		Sleaze Resistance: [+5*event(December)], Last Available: "2020-12"
 10662	double-irradiated twirling candy harmonica	0		Effect: "Thick-Skinned", Effect Duration: 57, Last Available: "2020-12"
 10663	quadruple-denatured non-ionized colloidal sugar	0		Effect: "Protection from Bad Stuff", Effect Duration: 24, Last Available: "2020-12"
-10664	unsweetened narrow blue multi-level marzipan	0		Effect: "Outer Wolf&trade;", Effect Duration: 15, Last Available: "2020-12"
+10664	unsweetened blue narrow multi-level marzipan	0		Effect: "Outer Wolf&trade;", Effect Duration: 15, Last Available: "2020-12"
 10665	careful plastic Crimbo caroler	0		Monster Level: -10, Last Available: "2020-12"
 10666	studded plastic multi-level marketer	0		Damage Absorption: +80, Last Available: "2020-12"
 10667	pulsating plastic Crimbo cheer of the brute	0		Muscle Percent: +30, Last Available: "2020-12"
@@ -10571,14 +10571,14 @@
 10715	bland and pepper (stale)	4	decent	Last Available: "2020-12"
 10716	acceptable cranberry margarita (brackish)	4	good	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
-10718	upside-down red nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
+10718	red upside-down nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	delicious mirror barrel-aged eggnog	3	awesome	Last Available: "2020-12"
 10721	flavorless huge hand-crafted candy cane	4	decent	Last Available: "2020-12"
-10722	snack-sized spoiled drive-thru burger	2	crappy	Last Available: "2020-12"
+10722	spoiled snack-sized drive-thru burger	2	crappy	Last Available: "2020-12"
 10723	acceptable boozy Boulevardier cocktail	5	good	Last Available: "2020-12"
-10724	super-vacuum-sealed activated spinning upside-down bouncing Hotwire&trade; brand candy rope	0		Effect: "Goldentongue", Effect Duration: 34, Last Available: "2020-12"
-10725	rotten low-calorie bowl full of jelly	1	crappy	Last Available: "2020-12"
+10724	super-vacuum-sealed activated bouncing spinning upside-down Hotwire&trade; brand candy rope	0		Effect: "Goldentongue", Effect Duration: 34, Last Available: "2020-12"
+10725	low-calorie rotten bowl full of jelly	1	crappy	Last Available: "2020-12"
 10726	mediocre Eye and a Twist	3	decent	Last Available: "2020-12"
 10727	quadruple-flattened tumbling Chubby and Plump bar	0		Effect: "Eau de Tortue", Effect Duration: 30, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
@@ -10594,7 +10594,7 @@
 10738	potted power plant	0		Last Available: "2021-03"
 10739	quantum chilled yellow battery (AAA)	0		Effect: "Big Flaming Whip", Effect Duration: 49, Last Available: "2021-03"
 10740	improved battery (AA)	0		Effect: "Paging Betty", Effect Duration: 41, Last Available: "2021-03"
-10741	pressed super-colloidal jittery blurry cyan battery (D)	0		Effect: "Stands Alone", Effect Duration: 16, Last Available: "2021-03"
+10741	pressed super-colloidal blurry jittery cyan battery (D)	0		Effect: "Stands Alone", Effect Duration: 16, Last Available: "2021-03"
 10742	wet ghostly battery (9-Volt)	0		Effect: "How to Scam Tourists", Effect Duration: 20, Last Available: "2021-03"
 10743	modified modified battery (lantern)	0		Effect: "Analog Drunk", Effect Duration: 49, Last Available: "2021-03"
 10744	warmed anodized squat battery (car)	0		Effect: "Really Deep Breath", Effect Duration: 24, Last Available: "2021-03"
@@ -10611,7 +10611,7 @@
 10755	energized short glass of water	0		Effect: "Joyful Resolve", Effect Duration: 67, Last Available: "2021-05"
 10756	tarnished spinning short	0		Effect: "Dragged Through the Coals", Effect Duration: 47, Last Available: "2021-05"
 10757	red Thwaitgold quantum bug statuette	0		
-10758	skewed cyan quantum of familiar	0		
+10758	cyan skewed quantum of familiar	0		
 10759	Jeselnik's energetic familiar scrapbook	0		Maximum MP Percent: +20, Sleaze Damage: +25, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
@@ -10621,7 +10621,7 @@
 10765	rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	bouncing rocket	0		Last Available: "2021-07"
-10768	thick stale wobbly fire crackers	5	decent	Last Available: "2021-07"
+10768	stale thick wobbly fire crackers	5	decent	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	up-at-dawn Oprah's Catherine Wheel	0		Maximum MP Percent: +50, Adventures: +5, Lasts Until Rollover, Last Available: "2021-07"
 10771	red personal trainer's smartaleck's rocket boots	0		Moxie Percent: +30, Experience Percent (Muscle): +10, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10639,9 +10639,9 @@
 10783	slick extra-wide head candle of dire peril	0		Moxie: +10, Weapon Damage: +20, Lasts Until Rollover, Last Available: "2021-08"
 10784	nitrogenated natural magick candle	0		Effect: "Wintry Breath", Effect Duration: 47, Last Available: "2021-08"
 10785	improved double-oxidized spinning rainbow glitter candle	0		Effect: "Faboooo", Effect Duration: 43, Last Available: "2021-08"
-10786	modified upside-down twirling banana candle	0		Effect: "Thicker, Sicker", Effect Duration: 38, Last Available: "2021-08"
+10786	modified twirling upside-down banana candle	0		Effect: "Thicker, Sicker", Effect Duration: 38, Last Available: "2021-08"
 10787	adjusted diffused maroon ear candle	0		Effect: "Nightstalkin'", Effect Duration: 60, Last Available: "2021-08"
-10788	dry twirling maroon votive of confidence	0		Effect: "Pyromania", Effect Duration: 39, Last Available: "2021-08"
+10788	dry maroon twirling votive of confidence	0		Effect: "Pyromania", Effect Duration: 39, Last Available: "2021-08"
 10789	rosy-cheeked water candle	0		Maximum HP Percent: +30, Water: 3, Lasts Until Rollover
 10790	Herculean B. L. A. R. T.	0		Experience (Muscle): +1, Conditional Skill (Equipped): "B. L. A. R. T. Spray (narrow)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (medium)", Conditional Skill (Equipped): "B. L. A. R. T. Spray (wide)"
 10791	Thwaitgold fire beetle statuette	0		
@@ -10672,28 +10672,28 @@
 10816	pulsating skewed fireproof healthy ice crown of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +20, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2021-12"
 10817	red inspector's Temple Grandin's studded jeans	0		Damage Absorption: +80, Familiar Weight: +7, Item Drop: +15, Lasts Until Rollover, Last Available: "2021-12"
 10818	wobbly rosewater-soaked supercharged ice wrap of Gandalf	0		Maximum MP Percent: +30, Spell Critical Percent: +20, Stench Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	tasty super-sized tofu pop	5	awesome	Last Available: "2021-12"
+10819	super-sized tasty tofu pop	5	awesome	Last Available: "2021-12"
 10820	moldy blinking bowl of prescription candy	4	crappy	Last Available: "2021-12"
-10821	moldy massive shaking fishcake	9	crappy	Last Available: "2021-12"
-10822	snack-sized tasty bone broth	2	awesome	Last Available: "2021-12"
+10821	massive moldy shaking fishcake	9	crappy	Last Available: "2021-12"
+10822	tasty snack-sized bone broth	2	awesome	Last Available: "2021-12"
 10823	decent star pop	3	good	Last Available: "2021-12"
 10824	aged irresponsibly strong Doc's Fortifying Wine	10	awesome	Last Available: "2021-12"
 10825	hand-crafted Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
 10826	tolerable boozy Doc's Limbering Wine	5	good	Last Available: "2021-12"
 10827	watered-down hand-crafted Doc's Medical-Grade Wine	2	EPIC	Last Available: "2021-12"
 10828	vaporized pulsating pulsating Homebodyl&trade;	1		Last Available: "2021-12"
-10829	modified tumbling huge Extrovermectin&trade;	1		Effect: "Hustlin'", Effect Duration: 15, Last Available: "2021-12"
-10830	denatured gray mirror tumbling Breathitin&trade;	1		Last Available: "2021-12"
+10829	modified huge tumbling Extrovermectin&trade;	1		Effect: "Hustlin'", Effect Duration: 15, Last Available: "2021-12"
+10830	denatured mirror gray tumbling Breathitin&trade;	1		Last Available: "2021-12"
 10831	vaporized Fleshazole&trade;	1		Last Available: "2021-12"
 10832	boiled diffused anti-burn cream	0		Effect: "Pisces in the Skyces", Effect Duration: 35, Last Available: "2021-12"
 10833	quadruple-boiled anti-freeze cream	0		Effect: "Sauce Monocle", Effect Duration: 16, Last Available: "2021-12"
-10834	modified gray jittery anti-goosebump cream	0		Effect: "Charrrming", Effect Duration: 32, Last Available: "2021-12"
+10834	modified jittery gray anti-goosebump cream	0		Effect: "Charrrming", Effect Duration: 32, Last Available: "2021-12"
 10835	cold-filtered twirling anti-odor cream	0		Effect: "Stenchtastic", Effect Duration: 67, Last Available: "2021-12"
 10836	energized pressed olive anti-creep cream	0		Effect: "Slimily Sagacious", Effect Duration: 47, Last Available: "2021-12"
 10837	pressed pressed upside-down anti-pain cream	0		Effect: "Sweet Incentive", Effect Duration: 15, Last Available: "2021-12"
 10838	drinkable Doc's Special Reserve Wine	3	good	Last Available: "2021-12"
 10839	enchanted flavorless bread pie	4	decent	Effect: "Rosewater Mark", Effect Duration: 15, Last Available: "2021-12"
-10840	artisanal mirror blurry clear Russian	3	EPIC	Last Available: "2021-12"
+10840	artisanal blurry mirror clear Russian	3	EPIC	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	shaking Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10705,7 +10705,7 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	gray goo magnet	0		Last Available: "2021-12"
 10851	slick cozy scarf	0		Moxie: +10, Last Available: "2021-12"
-10852	adequate half-sized fuchsia huge Crimbo cookie	2	good	Last Available: "2023-06"
+10852	half-sized adequate fuchsia huge Crimbo cookie	2	good	Last Available: "2023-06"
 10853	super-wet aerosolized narrow fleshy putty	0		Effect: "Gamer Rage", Effect Duration: 64, Last Available: "2021-12"
 10854	third ear of bravery	0		Spooky Resistance: +5, Single Equip, Last Available: "2021-12"
 10855	squat festive egg sac	0		Last Available: "2021-12"
@@ -10730,9 +10730,9 @@
 10874	wobbly Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
 10876	rotten meatball	3	crappy	Last Available: "2021-12"
-10877	upside-down mirror cloned monster	0		Last Available: "2021-12"
+10877	mirror upside-down cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
-10879	green mirror pulsating refurbished air fryer	0		Last Available: "2021-12"
+10879	green pulsating mirror refurbished air fryer	0		Last Available: "2021-12"
 10880	dried fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
@@ -10765,11 +10765,11 @@
 10909	space blanket	0		Last Available: "2022-05"
 10910	ionized ghostly single-use dust mask	0		Effect: "Warm Belly", Effect Duration: 33, Last Available: "2022-05"
 10911	triple-dry gaffer's tape	0		Effect: "Stands Alone", Effect Duration: 50, Last Available: "2022-05"
-10912	delicious special small spinning 20-lb can of rice and beans	2	awesome	Effect: "Egg-stra Arm", Effect Duration: 40, Last Available: "2022-05"
+10912	delicious small special spinning 20-lb can of rice and beans	2	awesome	Effect: "Egg-stra Arm", Effect Duration: 40, Last Available: "2022-05"
 10913	mirror bar of freeze-dried water	1	EPIC	Last Available: "2022-05"
 10914	decent diet expired MRE	1	good	Last Available: "2022-05"
 10915	gigantic stale yellow cool mint precipice bar	8	decent	Last Available: "2022-05"
-10916	normal gigantic carrot cake precipice bar	6	good	Last Available: "2022-05"
+10916	gigantic normal carrot cake precipice bar	6	good	Last Available: "2022-05"
 10917	huge The Big Book of Every Skill	0		
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
@@ -10780,10 +10780,10 @@
 10924	tasty blinking guilty sprout	4	awesome	Last Available: "2022-06"
 10925	rosewater-soaked boxer's mother's necklace	0		Muscle Percent: +10, Stench Resistance: +3, Last Available: "2022-06"
 10926	diffused altered skewed trampled ticket stub	0		Effect: "Wax On Your Shoes", Effect Duration: 64, Last Available: "2022-06"
-10927	chilled narrow purple savings bond	0		Effect: "Gemini Rising", Effect Duration: 67, Last Available: "2022-06"
+10927	chilled purple narrow savings bond	0		Effect: "Gemini Rising", Effect Duration: 67, Last Available: "2022-06"
 10928	cyan designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
 10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
-10930	powdered narrow ghostly sweat-ade	1		Last Available: "2022-07"
+10930	powdered ghostly narrow sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	tumbling stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	cyan thick dinosaur	0		
@@ -10807,12 +10807,12 @@
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
 10952	red vibrating Jurassic Parka of the cougar	0		Moxie: +20, Maximum MP Percent: +10, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
-10954	fuchsia blurry autumn-aton	0		Last Available: "2022-10"
+10954	blurry fuchsia autumn-aton	0		Last Available: "2022-10"
 10955	diffused colloidal autumn leaf	0		Effect: "Sweet, Nuts", Effect Duration: 26, Last Available: "2022-10"
 10956	lousy AutumnFest ale	3	decent	Last Available: "2022-10"
 10957	mirror greedy resourceful therapeutic autumn sweater-weather sweater	0		Maximum MP: +50, Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Lasts Until Rollover, Last Available: "2022-10"
 10958	clever curative rock-hard studded autumn debris shield	0		Damage Absorption: +80, Damage Reduction: 14, Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
-10959	half-sized spoiled autumn-spice donut	2	crappy	Last Available: "2022-10"
+10959	spoiled half-sized autumn-spice donut	2	crappy	Last Available: "2022-10"
 10960	dry altered skewed autumn dollar	0		Effect: "Cold Hard Skin", Effect Duration: 49, Last Available: "2022-10"
 10961	lime green narrow beefy autumn leaf pendant of Leguizamo of the blizzard	0		Muscle: +10, Monster Level: +20, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2022-10"
 10962	dehydrated blinking autumn breeze	1		Last Available: "2022-10"
@@ -10823,13 +10823,13 @@
 10967	mirror Yeast of Boris	0		Last Available: "2022-11"
 10968	St. Sneaky Pete's Whey	0		Last Available: "2022-11"
 10969	green Vegetable of Jarlsberg	0		Last Available: "2022-11"
-10970	decent enchanted ratatouille de Jarlsberg	3	good	Effect: "Flagrantly Fragrant", Effect Duration: 5, Last Available: "2022-11"
-10971	small moldy Jarlsberg's vegetable soup	2	crappy	Last Available: "2022-11"
+10970	enchanted decent ratatouille de Jarlsberg	3	good	Effect: "Flagrantly Fragrant", Effect Duration: 5, Last Available: "2022-11"
+10971	moldy small Jarlsberg's vegetable soup	2	crappy	Last Available: "2022-11"
 10972	bland shaking roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
 10973	moldy ghostly St. Pete's sneaky smoothie	3	crappy	Last Available: "2022-11"
 10974	decent Pete's wiley whey bar	3	good	Last Available: "2022-11"
-10975	decent half-sized Pete's rich ricotta	2	good	Last Available: "2022-11"
-10976	watered-down tolerable Boris's beer	2	good	Last Available: "2022-11"
+10975	half-sized decent Pete's rich ricotta	2	good	Last Available: "2022-11"
+10976	tolerable watered-down Boris's beer	2	good	Last Available: "2022-11"
 10977	yummy lime green honey bun of Boris	3	awesome	Last Available: "2022-11"
 10978	tasty Boris's bread	3	awesome	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
@@ -10842,9 +10842,9 @@
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	rotten shaking baked veggie ricotta casserole	3	crappy	Last Available: "2022-11"
-10989	bland jumbo plain calzone	5	decent	Last Available: "2022-11"
+10989	jumbo bland plain calzone	5	decent	Last Available: "2022-11"
 10990	thick delicious narrow roasted vegetable focaccia	5	awesome	Last Available: "2022-11"
-10991	miniature yummy wobbly Pizza of Legend	2	awesome	Last Available: "2022-11"
+10991	yummy miniature wobbly Pizza of Legend	2	awesome	Last Available: "2022-11"
 10992	moldy Calzone of Legend	3	crappy	Last Available: "2022-11"
 10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
 10994	yellow Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
@@ -10853,7 +10853,7 @@
 10997	huge lime green Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	blinking shaking cookbookbat book	0		Familiar Weight: +5
 10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	half-sized decent Deep Dish of Legend	2	good	Last Available: "2022-11"
+11000	decent half-sized Deep Dish of Legend	2	good	Last Available: "2022-11"
 11001	huge deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
@@ -10865,9 +10865,9 @@
 11009	dog trainer's ruddy bullet necklace	0		Maximum HP Percent: +40, Experience (familiar): +1, Single Equip
 11010	massive stale swamp haunch	8	decent	
 11011	boxer's gator shades of Gandalf	0		Muscle Percent: +10, Spell Critical Percent: +20, Single Equip
-11012	cyan upside-down milk cap	0		
-11013	mediocre extra-dry Charleston Choo-Choo	5	decent	
-11014	lousy watered-down Velvet Veil	2	decent	
+11012	upside-down cyan milk cap	0		
+11013	extra-dry mediocre Charleston Choo-Choo	5	decent	
+11014	watered-down lousy Velvet Veil	2	decent	
 11015	aged Marltini	4	awesome	
 11016	drinkable Strong, Silent Type	3	good	
 11017	hand-crafted spinning Mysterious Stranger	4	EPIC	
@@ -10879,7 +10879,7 @@
 11023	aromatic ceramic celsiturometer of the sewer of the sweet-tooth	0		Stench Damage: +25, Stench Resistance: +1, Candy Drop: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
 11024	inspector's occult Samson's ceramic cerecloth belt	0		Experience (Muscle): +5, Spell Damage Percent: +25, Item Drop: +15, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
 11025	hardy dangerous ceramic cenobite's robe of the cougar	0		Moxie: +20, Weapon Damage: +10, Maximum HP: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
-11026	vaporized spinning maroon skewed ceramic scree	1		Last Available: "2023-12"
+11026	vaporized skewed maroon spinning ceramic scree	1		Last Available: "2023-12"
 11027	ionized bouncing extra-hard jawbreaker	0		Effect: "Cat-Alyzed", Effect Duration: 54
 11028	ghostly Oprah's curative hardened chiffon chevrons	0		Damage Reduction: 3, Maximum MP Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2023-12"
 11029	smartaleck's brawny chiffon chapeau of the wise owl	0		Mysticality: +20, Muscle Percent: +20, Moxie Percent: +30, Last Available: "2023-12"
@@ -10920,7 +10920,7 @@
 11064	upside-down auspicious sharpshooter's Herculean shoulder-mounted Trainbot	0		Experience (Muscle): +1, Critical Hit Percent: +10, Item Drop: +10, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	gray Crimbo crystal shards	0		
-11067	practically non-alcoholic bad dregs of a Crimbo cocktail	1	decent	
+11067	bad practically non-alcoholic dregs of a Crimbo cocktail	1	decent	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	rotten honey-drenched ham slice	4	crappy	
@@ -10934,11 +10934,11 @@
 11078	spoiled lime green steamed oyster	4	crappy	
 11079	really nice lump of coal	0		
 11080	blurry deactivated mini-Trainbot	0		Last Available: "2022-12"
-11081	bouncing lime green steam unit	0		Last Available: "2022-12"
+11081	lime green bouncing steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	mediocre weak spinning Crimbosmopolitan	2	decent	Last Available: "2022-12"
-11085	toothsome snack-sized Crimbo dinner	2	awesome	Last Available: "2022-12"
+11084	weak mediocre spinning Crimbosmopolitan	2	decent	Last Available: "2022-12"
+11085	snack-sized toothsome Crimbo dinner	2	awesome	Last Available: "2022-12"
 11086	green overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	train whistle	0		Last Available: "2022-12"
 11088	The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
@@ -10965,7 +10965,7 @@
 11109	stalagmite	0		Last Available: "2023-01"
 11110	wobbly chocolate covered ping-pong ball	0		
 11112	moldy pixel bread	3	crappy	
-11113	tolerable practically non-alcoholic pixel whiskey	1	good	
+11113	practically non-alcoholic tolerable pixel whiskey	1	good	
 11114	pixel rock	0		
 11115	yellow S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	blinking S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10978,12 +10978,12 @@
 11123	warmed green out-of-work circus flea	0		Effect: "Berry Elemental", Effect Duration: 23, Last Available: "2023-02"
 11124	bouncing extra-grubby grub	0		Last Available: "2023-02"
 11125	double-unsweetened gray fire ant pheromones	0		Effect: "Overstimulated", Effect Duration: 60, Last Available: "2023-02"
-11126	galvanized anodized narrow upside-down flapper fly	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 60, Last Available: "2023-02"
+11126	galvanized anodized upside-down narrow flapper fly	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 60, Last Available: "2023-02"
 11127	artisanal shot of wasp venom	4	EPIC	Last Available: "2023-02"
 11128	pickled blinking filled mosquito	0		Effect: "Saucegoggles", Effect Duration: 36, Last Available: "2023-02"
 11129	double-pickled dry shim of shame shale	0		Effect: "Patience of the Tortoise", Effect Duration: 35, Last Available: "2023-02"
 11130	dry extra-corrupted fuchsia pebble of proud pyrite	0		Effect: "Sausage Festive", Effect Duration: 42, Last Available: "2023-02"
-11131	extra-moist huge spinning pile of gritty sand	0		Effect: "Ticking Clock", Effect Duration: 65, Last Available: "2023-02"
+11131	extra-moist spinning huge pile of gritty sand	0		Effect: "Ticking Clock", Effect Duration: 65, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	diffused polymerized diffused fuchsia angry agate	0		Effect: "Whippin' It Good", Effect Duration: 36, Last Available: "2023-02"
 11134	liquefied twirling lump of loyal latite	0		Effect: "Hyperoxygenated Blood", Effect Duration: 60, Last Available: "2023-02"
@@ -10992,7 +10992,7 @@
 11137	activated corrupted aerosolized shadow flame	0		Effect: "Ancestral Disapproval", Effect Duration: 61, Last Available: "2023-03"
 11138	super-sized adequate shadow bread	5	good	Last Available: "2023-03"
 11139	blinking shadow ice	0		Last Available: "2023-03"
-11140	weak bad shadow fluid	2	decent	Last Available: "2023-03"
+11140	bad weak shadow fluid	2	decent	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	narrow shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11020,9 +11020,9 @@
 11165	blue upside-down Jazz Agent sheet music	0		
 11166	narrow Thwaitgold anti-moth statuette	0		
 11167	narrow shadowy cheat sheet	0		Free Pull
-11168	skewed bouncing closed-circuit phone system	0		Free Pull
+11168	bouncing skewed closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
-11170	bouncing skewed shadow lighter	0		
+11170	skewed bouncing shadow lighter	0		
 11171	shadow heptahedron	0		
 11172	spinning shadow snowflake	0		
 11173	shadow heart	0		
@@ -11062,7 +11062,7 @@
 11207	jittery replica squamous polyp	0		
 11208	replica stone sphere	0		
 11209	wobbly flame-retardant chaotic baleful replica Greatest American Pants	0		Spell Damage: +25, Spell Critical Percent: +10, Hot Resistance: +1
-11210	green huge replica organ grinder	0		
+11210	huge green replica organ grinder	0		
 11211	mirror wicked boxer's replica Juju Mojo Mask of the detective	0		Muscle Percent: +10, Spell Damage: +5, Item Drop: +20, Single Equip
 11212	lard-coated boxer's smooth replica Operation Patriot Shield	0		Moxie: +15, Muscle Percent: +10, Sleaze Spell Damage: +25, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	twirling replica Libram of Resolutions	0		
@@ -11086,7 +11086,7 @@
 11231	replica Source terminal	0		
 11232	skewed replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
-11234	teal blinking replica genie bottle	0		
+11234	blinking teal replica genie bottle	0		
 11235	replica space planula	0		
 11236	blurry replica unpowered Robortender	0		
 11237	wobbly replica Neverending Party invitation envelope	0		
@@ -11116,7 +11116,7 @@
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
-11264	lime green huge Charter: Nellyville	0		Last Available: "2023-06"
+11264	huge lime green Charter: Nellyville	0		Last Available: "2023-06"
 11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	blinking weightlifter's Flash Liquidizer Ultra Dousing Accessory	0		Muscle: +15, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	Temple Grandin's careful manspreader's padded Amulet of Perpetual Darkness	0		Damage Absorption: +20, Monster Level: 0, Familiar Weight: +7, Last Available: "2023-06"
@@ -11157,13 +11157,13 @@
 11302	souvenir flag	0		
 11303	name change form	0		
 11304	red replica sleeping patriotic eagle	0		
-11305	blue shaking boxed august scepter	0		Free Pull
+11305	shaking blue boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	bland watermelon	4	decent	
 11308	watermelon seed	0		
 11309	spinning water balloon	0		
 11310	thriftshop coupon	0		
-11311	half-sized special spoiled upside-down waffle	2	crappy	Effect: "Adrenaline Rush", Effect Duration: 15
+11311	half-sized spoiled special upside-down waffle	2	crappy	Effect: "Adrenaline Rush", Effect Duration: 15
 11312	fixodent	0		
 11313	scandalous cat o' nine teeth of bravery	0		Sleaze Damage: +5, Spooky Resistance: +5
 11314	clever Oprah's tooth cap	0		Maximum MP Percent: +50, Maximum MP: +20
@@ -11181,7 +11181,7 @@
 11326	shaking Thwaitgold fairyfly statue	0		
 11327	upside-down residual chitin paste	0		Skill: "Chitinous Soul"
 11328	mixed bouncing concentrated cooking	1		
-11329	pickled olive skewed huge meat	1		Effect: "Ginger Snapped", Effect Duration: 20
+11329	pickled skewed olive huge meat	1		Effect: "Ginger Snapped", Effect Duration: 20
 11330	modified huge sparkling orb	1		
 11331	pickled hardening cream	1		
 11332	compressed pool shark hair oil	1		Effect: "Joy", Effect Duration: 45
@@ -11192,7 +11192,7 @@
 11337	bouncing map to a candy-rich block	0		Last Available: "2023-10"
 11338	frozen dry sampler size toothpaste	0		Effect: "Yuletide Industry", Effect Duration: 16
 11339	Franken Stein	0		Conditional Skill (Equipped): "Toast your enemy"
-11340	ghostly maroon shaking A Guide to Burning Leaves	0		Free Pull
+11340	maroon ghostly shaking A Guide to Burning Leaves	0		Free Pull
 11341	inflammable leaf	0		
 11342	twirling rake	0		Item Drop: +1
 11343	gray energetic rake	0		Maximum MP Percent: +20
@@ -11203,7 +11203,7 @@
 11348	scorching Sinatra's autumnal aegis	0		Experience (Moxie): +5, Hot Damage: +25, Damage Reduction: 9
 11349	polymerized non-galvanized squat distilled resin	0		Effect: "Jacked In", Effect Duration: 34
 11350	super-heated leaf	0		
-11351	tumbling tumbling twirling teal lit leaf lasso	0		
+11351	tumbling tumbling teal twirling lit leaf lasso	0		
 11352	tied-up leaflet	0		
 11353	tied-up monstera	0		
 11354	tied-up leaviathan	0		
@@ -11212,7 +11212,7 @@
 11357	cyan greedy Temple Grandin's smoldering drape	0		Familiar Weight: +7, Meat Drop: +20, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	inspector's scandalous horrifying leaf crown of extreme caution of the empath of the boozehound	0		Monster Level: -25, Familiar Weight: +5, Spooky Damage: +25, Sleaze Damage: +5, Item Drop: +15, Booze Drop: +100
-11360	toothsome super-sized shaking leafy browns	5	awesome	
+11360	super-sized toothsome shaking leafy browns	5	awesome	
 11361	colloidal extra-polarized autumnic balm	0		Effect: "Turtle Power", Effect Duration: 37
 11362	improved quantum red coping juice	0		Effect: "Bright!", Effect Duration: 27
 11363	squat greedy mansplainer's Lo Pan's wholesome candy cane sword cane of Gandalf	0		Maximum HP Percent: +10, Spell Critical Percent: 50, Monster Level: +15, Meat Drop: +20, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
@@ -11231,7 +11231,7 @@
 11376	housekeeping automa-core	0		
 11377	housekeeping robot	0		
 11378	delicious enchanted miniature pickled bread	2	awesome	Effect: "damage.enh", Effect Duration: 40, Last Available: "2023-12"
-11379	bite-sized moldy salted mutton	1	crappy	Last Available: "2023-12"
+11379	moldy bite-sized salted mutton	1	crappy	Last Available: "2023-12"
 11380	bland diet corned beet	1	decent	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11275,11 +11275,11 @@
 11420	Oprah's supercharged extremely unsafe Crimbuccaneer tavern swab	0		Weapon Damage Percent: +100, Maximum MP Percent: 80, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	watered-down mediocre jittery old-school pirate grog	2	decent	Last Available: "2023-12"
-11423	bland miniature skewed squat grog nuts	2	decent	Last Available: "2023-12"
+11423	bland miniature squat skewed grog nuts	2	decent	Last Available: "2023-12"
 11424	reassuring chaotic sawed-off blunderbuss of Calamity Jane	0		Critical Hit Percent: +15, Spell Critical Percent: +10, Spooky Resistance: +1, Last Available: "2023-12"
-11425	lousy distilled blinking shaking olive officer's nog	5	decent	Last Available: "2023-12"
+11425	lousy distilled olive shaking blinking officer's nog	5	decent	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	decent special sundae ration	4	good	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2023-12"
+11427	special decent sundae ration	4	good	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2023-12"
 11428	super-sized stale narrow peppermint tack	5	decent	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	snack-sized bland whalesteak	2	decent	Last Available: "2023-12"
@@ -11293,7 +11293,7 @@
 11438	skewed upside-down reassuring crafty rosy-cheeked shipwright's hammer	0		Maximum HP Percent: +30, Maximum MP: +10, Spooky Resistance: +1, Last Available: "2023-12"
 11439	reassuring gravedigger's stiffened gunwale	0		Damage Reduction: 10, Spooky Damage: +10, Spooky Resistance: +1, Last Available: "2023-12"
 11440	avaricious personal trainer's supercool Kelflar vest	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Meat Drop: +30, Last Available: "2023-12"
-11441	dry maroon blurry whale cerebrospinal fluid	0		Effect: "Feet of Watermelon", Effect Duration: 40, Last Available: "2023-12"
+11441	dry blurry maroon whale cerebrospinal fluid	0		Effect: "Feet of Watermelon", Effect Duration: 40, Last Available: "2023-12"
 11442	deadly Crimbuccaneer runebone of the wise owl	0		Mysticality: +20, Weapon Damage: +5, Single Equip, Last Available: "2023-12"
 11443	cannonbomb	0		Last Available: "2023-12"
 11444	lightning-fast wool Elf Guard mouthknife	0		Cold Resistance: +1, Initiative: +40, Last Available: "2023-12"
@@ -11330,7 +11330,7 @@
 11475	spoiled special wet tack	3	crappy	Effect: "Physicali Tea", Effect Duration: 35, Last Available: "2023-12"
 11476	adequate whalecake	4	good	Last Available: "2023-12"
 11477	scandalous Lo Pan's gunwale whalegun of the empath	0		Spell Critical Percent: +30, Familiar Weight: +5, Sleaze Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
-11478	tolerable weak special and claret	2	good	Effect: "Stop the Presses!", Effect Duration: 50, Last Available: "2023-12"
+11478	tolerable special weak and claret	2	good	Effect: "Stop the Presses!", Effect Duration: 50, Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
 11481	Temple Grandin's Elf Guard squirtgun of chilblains	0		Familiar Weight: +7, Cold Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
@@ -11344,7 +11344,7 @@
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	fireproof chaotic deadly barnacle-encrusted sweater	0		Weapon Damage: +5, Spell Critical Percent: +10, Hot Resistance: +3, Last Available: "2023-12"
 11491	blurry curative padded Fonzie's Crimbuccaneer nose ring	0		Experience (Moxie): +1, Damage Absorption: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2023-12"
-11492	skewed olive pet anchor	0		Last Available: "2023-12"
+11492	olive skewed pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	jittery Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
@@ -11352,7 +11352,7 @@
 11497	bouncing Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	spinning Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
-11500	shaking upside-down The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
+11500	upside-down shaking The Encyclopedia of Fruit (used)	0		Skill: "Fruit Recognition", Last Available: "2023-12"
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	irradiated mirror military candy cane	0		Effect: "Bestial Sympathy", Effect Duration: 24
 11503	anodized vacuum-sealed groggipop	0		Effect: "Wet Rub", Effect Duration: 33
@@ -11378,7 +11378,7 @@
 11523	Sherlock's extremely unsafe crepe paper puzzle cube of Tarzan	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Item Drop: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
 11524	blue perfumed Tesla sage crepe paper plunge camisole	0		Mysticality Percent: +10, Stench Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
 11525	frightening frosty baleful crepe paper polka charm	0		Spell Damage: +25, Cold Spell Damage: +10, Spooky Damage: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
-11526	altered squat cyan crepe paper pared cuttings	1		Last Available: "2025-12"
+11526	altered cyan squat crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	denatured crepe paper peanut candy	0		Effect: "Stinky Hands", Effect Duration: 66
 11528	skewed scorching petrified wood war pike of the brute	0		Muscle Percent: +30, Hot Damage: +25, Last Available: "2025-12"
 11529	upside-down dog trainer's petrified wood waist protector of wisdom	0		Mysticality: +15, Experience (familiar): +1, Single Equip, Last Available: "2025-12"
@@ -11388,7 +11388,7 @@
 11533	gravedigger's petrified wood walking pants of vim and vigor	0		Maximum HP Percent: +50, Spooky Damage: +10, Last Available: "2025-12"
 11534	dehydrated blinking petrified wood waste parts	1		Effect: "Video Game Hot Dog", Effect Duration: 30, Last Available: "2025-12"
 11535	tarnished petrified wood wafer praline	0		Effect: "Simulation Stimulation", Effect Duration: 35
-11536	acceptable fancy blue cybeer	3	good	Effect: "Surreally Buff", Effect Duration: 40, Last Available: "2025-12"
+11536	fancy acceptable blue cybeer	3	good	Effect: "Surreally Buff", Effect Duration: 40, Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
 11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
 11539	gray encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
@@ -11400,7 +11400,7 @@
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
 11546	huge baleful educational smooth spring shoes	0		Moxie: +15, Experience: +1, Spell Damage: +25, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	altered tumbling ultra-soft ferns	0		Effect: "Superheroic", Effect Duration: 23, Last Available: "2024-02"
-11548	extra-anodized energized twirling upside-down crunchy brush	0		Effect: "Tasting the Rainbow", Effect Duration: 55, Last Available: "2024-02"
+11548	extra-anodized energized upside-down twirling crunchy brush	0		Effect: "Tasting the Rainbow", Effect Duration: 55, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
 11550	pulsating biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
@@ -11412,7 +11412,7 @@
 11557	teal quick-release utility belt	0		Single Equip
 11558	supercool motion sensor	0		Moxie Percent: +20, Single Equip
 11559	focused magnetron pistol	0		Single Equip
-11560	huge lime green packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
+11560	lime green huge packaged Everfull Dart Holster	0		Free Pull, Last Available: "2024-03"
 11561	squat scandalous Lo Pan's Everfull Dart Holster	0		Spell Critical Percent: +30, Sleaze Damage: +5, Single Equip, Last Available: "2024-03"
 11562	research fragment	0		
 11563	pulsating Thwaitgold wolf spider statuette	0		
@@ -11428,9 +11428,9 @@
 11573	special adequate yam	4	good	Effect: "Always In Motion", Effect Duration: 10, Last Available: "2024-05"
 11574	artisanal yam martini	3	EPIC	Last Available: "2024-05"
 11575	mediocre sweet potato o' mine	3	decent	Last Available: "2024-05"
-11576	watered-down bad Southern yam	2	decent	Last Available: "2024-05"
-11577	tolerable watered-down sweet potato punch	2	good	Last Available: "2024-05"
-11578	immense delicious Mayam spinach	6	awesome	Last Available: "2024-05"
+11576	bad watered-down Southern yam	2	decent	Last Available: "2024-05"
+11577	watered-down tolerable sweet potato punch	2	good	Last Available: "2024-05"
+11578	delicious immense Mayam spinach	6	awesome	Last Available: "2024-05"
 11579	delicious yam and swiss	3	awesome	Last Available: "2024-05"
 11580	frosty smartaleck's savvy yam cannon	0		Mysticality Percent: +20, Moxie Percent: +30, Cold Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
@@ -11527,7 +11527,7 @@
 11672	jittery peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	ghostly tie-dye headband	0		
 11674	rotten fancy spinning whirled peas	3	crappy	Effect: "Saucegoggles", Effect Duration: 15, Last Available: "2024-11"
-11675	massive tasty twirling peaza	6	awesome	Last Available: "2024-11"
+11675	tasty massive twirling peaza	6	awesome	Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	compressed ghostly drenchrome 2.0	1		Last Available: "2025-12"
 11678	powdered teal Synapse Blaster	1		Last Available: "2025-12"
@@ -11535,7 +11535,7 @@
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	chilled ionized pea brittle	0		Effect: "Sealed Brain", Effect Duration: 38, Last Available: "2024-11"
-11683	fortified artisanal lime green peasco	5	EPIC	Last Available: "2024-11"
+11683	artisanal fortified lime green peasco	5	EPIC	Last Available: "2024-11"
 11684	flavorless snack-sized piece of cake	2	decent	Last Available: "2024-11"
 11685	teal handful of split pea soup	0		Last Available: "2024-11"
 11686	pulsating fuchsia Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
@@ -11553,7 +11553,7 @@
 11698	shaking nasty governor's daughter's pearl hairpin	0		Stench Damage: +5, Last Available: "2024-12"
 11699	purple harpoon	0		Last Available: "2024-12"
 11700	medical-grade chili powder cutlass	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2024-12"
-11701	moldy massive Aztec tamale	8	crappy	Last Available: "2024-12"
+11701	massive moldy Aztec tamale	8	crappy	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	groggles of wisdom	0		Mysticality: +15, Last Available: "2024-12"
@@ -11563,7 +11563,7 @@
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	nitrogenated peppermint pegleg	0		Effect: "Slightly Larger Than Usual", Effect Duration: 41, Last Available: "2024-12"
 11710	smooth extra-dry hard cocoa	5	awesome	Last Available: "2024-12"
-11711	bite-sized flavorless salmagumdi	1	decent	Last Available: "2024-12"
+11711	flavorless bite-sized salmagumdi	1	decent	Last Available: "2024-12"
 11712	twirling Newton's plastic Easter Island Bunny	0		Experience (Mysticality): +3, Last Available: "2024-12"
 11713	lime green plastic St. Patrick of the detective	0		Item Drop: +20, Last Available: "2024-12"
 11714	fireproof Temple Grandin's plastic Colonel Brando	0		Familiar Weight: +7, Hot Resistance: +3, Last Available: "2024-12"
@@ -11579,9 +11579,9 @@
 11724	weak tolerable ghostly moai toai	2	good	
 11725	hardened sage cool moaiball	0		Moxie: +5, Mysticality Percent: +10, Damage Reduction: 3, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
-11727	galvanized activated yellow skewed four-leaf potato sprout	0		Effect: "Icy Composition", Effect Duration: 38, Last Available: "2024-12"
+11727	galvanized activated skewed yellow four-leaf potato sprout	0		Effect: "Icy Composition", Effect Duration: 38, Last Available: "2024-12"
 11728	supercool groovy potato jacket of Leguizamo	0		Moxie Percent: 30, Monster Level: +20, Last Available: "2024-12"
-11729	lime green pulsating traumatic holiday memory	0		Last Available: "2024-12"
+11729	pulsating lime green traumatic holiday memory	0		Last Available: "2024-12"
 11730	skewed Brandonian footlocker key	0		Last Available: "2024-12"
 11731	huge lard-coated military orb of the pedagogue	0		Experience: +3, Sleaze Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	irradiated rum ball	0		Effect: "Well Owl Be!", Effect Duration: 43
@@ -11601,21 +11601,21 @@
 11746	shaking pumpkin spice whorl	0		Last Available: "2024-12"
 11747	practically non-alcoholic acceptable twirling Easter grasshopper	1	good	Last Available: "2024-12"
 11748	tolerable shaking Irish eggnog	4	good	Last Available: "2024-12"
-11749	lousy irresponsibly strong wobbly canteen of jungle juice	9	decent	Last Available: "2024-12"
+11749	irresponsibly strong lousy wobbly canteen of jungle juice	9	decent	Last Available: "2024-12"
 11750	practically non-alcoholic tolerable ghostly turchucken	1	good	Last Available: "2024-12"
-11751	extra-dry drinkable mechanically-mulled cider	5	good	Last Available: "2024-12"
-11752	perfectly mixed watered-down holiday trip around the world	2	super ultra mega turbo EPIC	Last Available: "2024-12"
+11751	drinkable extra-dry mechanically-mulled cider	5	good	Last Available: "2024-12"
+11752	watered-down perfectly mixed holiday trip around the world	2	super ultra mega turbo EPIC	Last Available: "2024-12"
 11753	delicious yellow chocolate ostrich egg	3	awesome	Last Available: "2024-12"
 11754	delicious beef and cabbage	4	awesome	Last Available: "2024-12"
 11755	tiny enchanted bland candy rations	1	decent	Effect: "Vinegavotte", Effect Duration: 50, Last Available: "2024-12"
 11756	flavorless skewed double-candied yams	3	decent	Last Available: "2024-12"
 11757	stale Christmas ham	3	decent	Last Available: "2024-12"
-11758	bland massive holiday smorgasbord	10	decent	Last Available: "2024-12"
+11758	massive bland holiday smorgasbord	10	decent	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	upside-down double-paned bejazzled eyepatch	0		Cold Resistance: +5, Last Available: "2024-12"
 11761	skewed Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
 11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	fuchsia upside-down How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11763	upside-down fuchsia How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
 11765	mirror Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
 11766	spinning Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
@@ -11630,7 +11630,7 @@
 11775	napkin	0		Last Available: "2024-12"
 11776	yummy squat Thanksgiving ration	4	awesome	Last Available: "2024-12"
 11777	tolerable Easter eggnog	4	good	Last Available: "2024-12"
-11778	denatured upside-down spinning clovermint	1		Last Available: "2024-12"
+11778	denatured spinning upside-down clovermint	1		Last Available: "2024-12"
 11779	family-friendly energetic hale Herculean nylon Christmas stockings	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP Percent: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	colloidal ionized aerosolized deviled candy egg	0		Effect: "Cake Caked", Effect Duration: 19, Last Available: "2024-12"
@@ -11660,9 +11660,9 @@
 11805	cyan pocket GPU	0		Single Equip, Last Available: "2025-12"
 11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
-11808	green narrow server room key	0		Last Available: "2025-12"
+11808	narrow green server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
-11810	pulsating blurry gray dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
+11810	gray blurry pulsating dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
 11812	vaporized psilocyber mushroom	1		Last Available: "2025-12"
 11813	spinning dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
@@ -11673,7 +11673,7 @@
 11818	teal dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
-11821	upside-down huge SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
+11821	huge upside-down SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
 11822	OVERCLOCK(10) rom chip	0		Skill: "OVERCLOCK(10)", Last Available: "2025-12"
 11823	blurry STATS+++ rom chip	0		Skill: "STATS+++", Last Available: "2025-12"
 11824	insignificant bit	0		Last Available: "2025-12"
@@ -11701,7 +11701,7 @@
 11846	plover's egg	0		
 11847	blue flyswatter	0		
 11848	wobbly Thwaitgold cordyceps ant statuette	0		
-11849	shaking teal upside-down heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
+11849	upside-down shaking teal heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
@@ -11726,21 +11726,21 @@
 11871	twisted leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	stale pulsating Heck ramen	4	decent	Last Available: "2025-03"
 11873	delicious red burrito	3	awesome	Last Available: "2025-03"
-11874	thick moldy olive small beer brat	5	crappy	Last Available: "2025-03"
-11875	rotten half-sized peach pie	2	crappy	Last Available: "2025-03"
+11874	moldy thick olive small beer brat	5	crappy	Last Available: "2025-03"
+11875	half-sized rotten peach pie	2	crappy	Last Available: "2025-03"
 11876	normal incredible mini-pizza	3	good	Last Available: "2025-03"
-11877	tolerable practically non-alcoholic bouncing Divine sidecar	1	good	Last Available: "2025-03"
+11877	practically non-alcoholic tolerable bouncing Divine sidecar	1	good	Last Available: "2025-03"
 11878	aged practically non-alcoholic tangarita sidecar	1	awesome	Last Available: "2025-03"
-11879	extra-dry mediocre gimlet sidecar	5	decent	Last Available: "2025-03"
+11879	mediocre extra-dry gimlet sidecar	5	decent	Last Available: "2025-03"
 11880	bad vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
 11881	tolerable prussian cathouse sidecar	3	good	Last Available: "2025-03"
-11882	bad irresponsibly strong Mon Tiki sidecar	9	decent	Last Available: "2025-03"
+11882	irresponsibly strong bad Mon Tiki sidecar	9	decent	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	chilly coward's April Shower Thoughts shield	0		Monster Level: -20, Cold Damage: +5, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	cyan spitball	0		Last Available: "2025-04"
 11887	pickled magnetized wet paper weights	0		Effect: "Aloofah", Effect Duration: 24, Last Available: "2025-04"
-11888	enchanted triple-distilled artisanal Three Sheets to the Wind	10	EPIC	Effect: "Livin' Large", Effect Duration: 40, Last Available: "2025-04"
+11888	triple-distilled enchanted artisanal Three Sheets to the Wind	10	EPIC	Effect: "Livin' Large", Effect Duration: 40, Last Available: "2025-04"
 11889	half-sized bland tumbling pile of wet dates	2	decent	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
@@ -11806,7 +11806,7 @@
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	mixed mixed berry jelly	1		Last Available: "2025-08"
 11953	adequate shaking toast with mixed berry jelly	3	good	Last Available: "2025-08"
-11954	stale massive purple cup of sugar	8	decent	Last Available: "2025-08"
+11954	massive stale purple cup of sugar	8	decent	Last Available: "2025-08"
 11955	spoiled Susie's cupcake	3	crappy	Last Available: "2025-08"
 11956	olive clock	0		Last Available: "2025-08"
 11957	knitted the gun of wisdom of the bloodbag	0		Mysticality: +15, Maximum HP: +100, Cold Resistance: +3, Last Available: "2025-08"
@@ -11815,7 +11815,7 @@
 11961	sand penny	0		
 11962	pulsating twirling weightlifter's undersea surveying goggles	0		Muscle: +15, Lasts Until Rollover
 11963	artisanal practically non-alcoholic Ocean-Touched Rum	1	EPIC	
-11964	pickled gray spinning pulsating tumbling water-logged pill	1		
+11964	pickled tumbling gray spinning pulsating water-logged pill	1		
 11965	normal enchanted kelp puck	4	good	Effect: "You're Not Cooking", Effect Duration: 35
 11966	scroll of sea strength	0		
 11967	scroll of sea smarts	0		
@@ -11842,11 +11842,11 @@
 12052	lousy Smoking Pope	4	decent	
 12053	moldy prize turkey	4	crappy	
 12054	dehydrated shaking medicinal gruel	1		Effect: "Healthy Green Glow", Effect Duration: 30
-12055	huge moldy full-sized pumpkin pie	8	crappy	Last Available: "2025-11"
+12055	moldy huge full-sized pumpkin pie	8	crappy	Last Available: "2025-11"
 12056	watered-down mediocre skewed vodka cranberry sauce	2	decent	Last Available: "2025-11"
 12057	anodized yammed candy	0		Effect: "Protection from Bad Stuff", Effect Duration: 16, Last Available: "2025-11"
 12058	yummy treasure chestnut	4	awesome	Last Available: "2025-12"
-12059	delicious weak mulled butter rum	2	awesome	Last Available: "2025-12"
+12059	weak delicious mulled butter rum	2	awesome	Last Available: "2025-12"
 12060	triple-polymerized anodized cinnamon doubloon	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 14, Last Available: "2025-12"
 12061	prompt plastic left skeleton arm	0		Adventures: +3, Last Available: "2025-12"
 12062	Van der Graaf plastic left skeleton leg	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2025-12"
@@ -11871,9 +11871,9 @@
 12081	blinking veiny devilbone rosary	0		Maximum HP: +10, Single Equip, Last Available: "2026-12"
 12082	mixed ghostly spinning devilbone chunks	1		Effect: "Kernel Panic!", Effect Duration: 35, Last Available: "2026-12"
 12083	unsweetened magnetized shaking Gehenna tattoo	0		Effect: "Proprie Tea", Effect Duration: 13
-12116	teal blinking burnt incisor	0		Last Available: "2025-12"
+12116	blinking teal burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
-12118	narrow upside-down burnt radius	0		Last Available: "2025-12"
+12118	upside-down narrow burnt radius	0		Last Available: "2025-12"
 12119	burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
 12121	Crymbocurrency	0		Last Available: "2025-12"
@@ -11881,7 +11881,7 @@
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	acceptable Steve Abrams' Holiday Sampler Beer	4	good	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	tolerable weak bottle of prize-winning rum	2	good	Last Available: "2025-12"
+12126	weak tolerable bottle of prize-winning rum	2	good	Last Available: "2025-12"
 12127	wobbly spinning sage Santa-Slayer medal of chilblains of the detective	0		Mysticality Percent: +10, Cold Damage: +25, Item Drop: +20, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	boiled squat boiling bone marrow	0		Effect: "Educated (Sorta)", Effect Duration: 13, Last Available: "2025-12"
@@ -11897,7 +11897,7 @@
 12139	friendly Rosewater's burnt bone belt of terror	0		Mysticality Percent: +30, Familiar Weight: +3, Spooky Spell Damage: +10, Single Equip, Last Available: "2025-12"
 12140	flame-wreathed scorched skull trophy	0		Hot Spell Damage: +10, Last Available: "2025-12"
 12141	bland wing bone	3	decent	Last Available: "2025-12"
-12142	weak tolerable bouncing weak skeleton venom	2	good	Last Available: "2025-12"
+12142	tolerable weak bouncing weak skeleton venom	2	good	Last Available: "2025-12"
 12143	mixed upside-down baked bone meal	1		Last Available: "2025-12"
 12144	censurious plastic skeleton rib cage	0		Sleaze Resistance: +3, Last Available: "2025-12"
 12145	toasty plastic skeleton skull	0		Hot Damage: +5, Last Available: "2025-12"
@@ -11926,10 +11926,10 @@
 12168	scandalous stylish vermiculite shield	0		Moxie: +25, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2025-12"
 12169	ghostly ship's lantern of courage	0		Spooky Resistance: +3, Last Available: "2025-12"
 12170	nasty chilly heat-resistant harpoon pistol	0		Cold Damage: +5, Stench Damage: +5, Last Available: "2025-12"
-12171	bite-sized normal narrow traditional gingerloaf	1	good	Last Available: "2025-12"
+12171	normal bite-sized narrow traditional gingerloaf	1	good	Last Available: "2025-12"
 12172	artisanal Scotch and eggnog	3	EPIC	Last Available: "2025-12"
 12173	ionized triple-irradiated shaking counterskeleton elixir	0		Effect: "Weasels Underfoot", Effect Duration: 21, Last Available: "2025-12"
-12174	aged fancy lime green &quot;salvaged&quot; wine	3	awesome	Effect: "Boletus Swoletus", Effect Duration: 30, Last Available: "2025-12"
+12174	fancy aged lime green &quot;salvaged&quot; wine	3	awesome	Effect: "Boletus Swoletus", Effect Duration: 30, Last Available: "2025-12"
 12175	The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12176	upside-down maroon crate of prize-winning cheese	0		No Pull, Last Available: "2025-12"
 12177	spoiled snack-sized wedge of prize-winning cheese	2	crappy	Last Available: "2025-12"
@@ -11969,7 +11969,7 @@
 12211	tumbling medical-grade hoverboard of the ox of extreme caution	0		Muscle: +20, Monster Level: -25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2026-03"
 12212	scorching Jim Carey's beefcake's left shark fin	0		Muscle: +25, Monster Level: +25, Hot Damage: +25, Last Available: "2026-03"
 12213	fitness tracking bracelet of the sewer	0		Stench Damage: +25, Single Equip, Last Available: "2026-03"
-12214	dried upside-down purple candy bone	1		Effect: "Magically Fingered", Effect Duration: 35
+12214	dried purple upside-down candy bone	1		Effect: "Magically Fingered", Effect Duration: 35
 12215	jittery wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	bland discarded hot dog	3	decent	Last Available: "2026-04"
@@ -11977,22 +11977,22 @@
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	low-calorie flavorless upside-down can of tuna	1	decent	
+12226	flavorless low-calorie upside-down can of tuna	1	decent	
 12227	adequate alien salad	3	good	
 12228	miniature decent bouncing ratbatatouille	2	good	
-12229	decent small onigiri	2	good	
+12229	small decent onigiri	2	good	
 12230	spoiled upside-down crudit&eacute;s	4	crappy	
 12231	stale snack-sized sauced mutton	2	decent	
-12232	tasty half-sized hot honey ant	2	awesome	
+12232	half-sized tasty hot honey ant	2	awesome	
 12233	adequate tomb aspic	4	good	
-12234	delicious immense later tots	7	awesome	
+12234	immense delicious later tots	7	awesome	
 12235	stale blinking skewed Frutti di Scatoletta	3	decent	Last Available: "2026-05"
 12236	moldy Pesto alla Marziano	3	crappy	Last Available: "2026-05"
-12237	moldy immense Arrattabbattabiata	6	crappy	Last Available: "2026-05"
+12237	immense moldy Arrattabbattabiata	6	crappy	Last Available: "2026-05"
 12238	normal Orzo di Riso	4	good	Last Available: "2026-05"
 12239	rotten low-calorie Pasta Grimavera	1	crappy	Last Available: "2026-05"
 12240	spoiled Linguini Ubriacapa	4	crappy	Last Available: "2026-05"
-12241	rotten enchanted jumbo twirling Formica e Pepe	5	crappy	Effect: "Larger", Effect Duration: 20, Last Available: "2026-05"
+12241	jumbo enchanted rotten twirling Formica e Pepe	5	crappy	Effect: "Larger", Effect Duration: 20, Last Available: "2026-05"
 12242	stale immense Tubetto Gelatto	10	decent	Last Available: "2026-05"
 12243	moldy upside-down Gnocci Domani	3	crappy	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
@@ -12019,7 +12019,7 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	brawny Portable Laughing Stock of terror	0		Muscle Percent: +20, Spooky Spell Damage: +10, Item Drop: +5, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	shellacked forbidden Staff of Anachronistic Churning of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Damage Reduction: 7
-12272	moldy special classic banana	3	crappy	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2026-07"
+12272	special moldy classic banana	3	crappy	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2026-07"
 12273	small delicious jittery watermelon	2	awesome	Last Available: "2026-07"
 12274	bland skewed skewed quince	4	decent	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
@@ -12027,8 +12027,8 @@
 12277	toothsome huge olive classic banana pie	4	awesome	Last Available: "2026-07"
 12278	triple-liquefied irradiated blinking essential banana decoction	0		Effect: "How to Scam Tourists", Effect Duration: 16, Last Available: "2026-07"
 12279	irradiated tumbling gray banana quintessence	0		Effect: "Stick Emporium Membership", Effect Duration: 45, Last Available: "2026-07"
-12280	hand-crafted practically non-alcoholic cyan Aesop Daiquiri	1	super EPIC	Last Available: "2026-07"
-12281	fortified artisanal Monkey Congress	5	EPIC	Last Available: "2026-07"
+12280	practically non-alcoholic hand-crafted cyan Aesop Daiquiri	1	super EPIC	Last Available: "2026-07"
+12281	artisanal fortified Monkey Congress	5	EPIC	Last Available: "2026-07"
 12282	bite-sized normal blurry watermelon pie	1	good	Last Available: "2026-07"
 12283	double-energized energized concentrated watermelon juice	0		Effect: "Twinkly Weapon", Effect Duration: 34, Last Available: "2026-07"
 12284	dry oxidized green Aqua Citrulanatae	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 34, Last Available: "2026-07"
@@ -12058,7 +12058,7 @@
 12308	jittery savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	pickled wobbly upside-down toxic asset	1		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 45, Last Available: "2026-08"
-12311	compressed pulsating olive jittery intangible asset	1		Last Available: "2026-08"
+12311	compressed jittery olive pulsating intangible asset	1		Last Available: "2026-08"
 12312	altered liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	narrow cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Turtle_Tamer_Opossum_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Opossum_cafe_booze.txt
@@ -2,32 +2,32 @@
 -2	perfectly mixed Scrawny Stout	3	EPIC	
 -3	lousy wobbly Infinitesimal IPA	4	decent	
 -4	hand-crafted eggnogtini	3	EPIC	
--5	enchanted mediocre candycaine	4	decent	
+-5	mediocre enchanted candycaine	4	decent	
 -6	practically non-alcoholic hand-crafted braincracker sweet	1	super ultra mega turbo EPIC	
--16	weak smooth fermented honey	2	awesome	
--17	irresponsibly strong bad moons-shine	9	decent	
--18	practically non-alcoholic artisanal gin	1	EPIC	
+-16	smooth weak fermented honey	2	awesome	
+-17	bad irresponsibly strong moons-shine	9	decent	
+-18	artisanal practically non-alcoholic gin	1	EPIC	
 -19	mediocre ecto-nog	3	decent	
 -20	acceptable weak maroon hot toady	2	good	
 -21	smooth hot choculate	3	awesome	
 -49	practically non-alcoholic mediocre Cyder	1	decent	
--50	practically non-alcoholic tolerable tumbling Oil Nog	1	good	
--51	spirit-forward enchanted smooth wobbly Hi-Octane Peppermint Jet Fuel	5	awesome	
+-50	tolerable practically non-alcoholic tumbling Oil Nog	1	good	
+-51	smooth enchanted spirit-forward wobbly Hi-Octane Peppermint Jet Fuel	5	awesome	
 -58	lousy Grimacider	3	decent	
 -59	weak perfectly mixed teal Isotope Nog	2	EPIC	
 -60	drinkable Mutagin 'n' Tonic	4	good	
 -70	perfectly mixed watered-down mirror Gin and Herring	2	EPIC	
 -71	aged Black and Tan and Red All Over	4	awesome	
 -72	acceptable Antarctic Ice Tea	4	good	
--76	mediocre practically non-alcoholic cyan CRIMBCO Ribbon Candy Schnapps	1	decent	
--77	fortified bad blue CRIMBCO Egg Substitute Nog Substitute	5	decent	
+-76	practically non-alcoholic mediocre cyan CRIMBCO Ribbon Candy Schnapps	1	decent	
+-77	bad fortified blue CRIMBCO Egg Substitute Nog Substitute	5	decent	
 -78	smooth CRIMBCO Extreme Braincracker Sour	3	awesome	
 -82	weak lousy Horseradish-infused Vodka	2	decent	
 -83	smooth Jerkitini	3	awesome	
 -84	acceptable special Desert Island Iced Tea	3	good	
--88	delicious practically non-alcoholic Crimbo Saketini	1	awesome	
--89	perfectly mixed practically non-alcoholic Crimboku Drop	1	EPIC	
--90	artisanal triple-distilled Flaming Crimbo Log	6	EPIC	
--107	weak acceptable fancy Fortified Eggnog Slurry	2	good	
--108	boozy artisanal blurry Hot Buttered Rum	5	EPIC	
+-88	practically non-alcoholic delicious Crimbo Saketini	1	awesome	
+-89	practically non-alcoholic perfectly mixed Crimboku Drop	1	EPIC	
+-90	triple-distilled artisanal Flaming Crimbo Log	6	EPIC	
+-107	acceptable fancy weak Fortified Eggnog Slurry	2	good	
+-108	artisanal boozy blurry Hot Buttered Rum	5	EPIC	
 -109	delicious Spicy Hot Chocolate	4	awesome	

--- a/data/TCRS/TCRS_Turtle_Tamer_Opossum_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Opossum_cafe_food.txt
@@ -5,41 +5,41 @@
 -8	decent olive candy cane pizza	4	good	
 -9	spoiled skewed gingerbread stir-fry	3	crappy	
 -10	adequate twigs and gravel	3	good	
--11	spoiled enchanted low-calorie shoots and leaves	1	crappy	
+-11	enchanted spoiled low-calorie shoots and leaves	1	crappy	
 -12	decent bowl of unidentifiable goo	3	good	
--13	bland low-calorie gingerbread massacre	1	decent	
--14	normal low-calorie shaking It Came From Beyond Dessert	1	good	
--15	small yummy blurry vampire cake	2	awesome	
--52	adequate huge Soylent Red and Green	6	good	
--53	immense moldy Disc-Shaped Nutrition Unit	8	crappy	
+-13	low-calorie bland gingerbread massacre	1	decent	
+-14	low-calorie normal shaking It Came From Beyond Dessert	1	good	
+-15	yummy small blurry vampire cake	2	awesome	
+-52	huge adequate Soylent Red and Green	6	good	
+-53	moldy immense Disc-Shaped Nutrition Unit	8	crappy	
 -54	decent Gingerborg Hive	3	good	
 -61	spoiled Candy Cane Surprise	4	crappy	
 -62	adequate tumbling Grimdrop Chow Mein	3	good	
 -63	diet tasty olive Grimgerbread House	1	awesome	
--67	bite-sized rotten Caviar Carbonara	1	crappy	
--68	tiny normal bouncing Halibut Alfredo	1	good	
+-67	rotten bite-sized Caviar Carbonara	1	crappy	
+-68	normal tiny bouncing Halibut Alfredo	1	good	
 -69	spoiled pulsating Red Herring Velvet Cake	3	crappy	
--73	moldy small gray CRIMBCO Reconstituted Gruel	2	crappy	
--74	snack-sized bland tumbling jittery skewed New and Improved CRIMBCO Reconstituted Gruel	2	decent	
--75	low-calorie special delicious CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	awesome	
+-73	small moldy gray CRIMBCO Reconstituted Gruel	2	crappy	
+-74	snack-sized bland skewed jittery tumbling New and Improved CRIMBCO Reconstituted Gruel	2	decent	
+-75	delicious low-calorie special CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	awesome	
 -79	yummy blurry Brussels Sprout Stir-Fry	3	awesome	
--80	jumbo delicious narrow Carrot, Cabbage, and Kale Pizza	5	awesome	
--81	flavorless huge upside-down teal Turnip and Rutabaga Pie	7	decent	
--85	special big stale Rainbow Spider Fun Roll	5	decent	
--86	adequate snack-sized teal bouncing Vegas Volcano Lava Roll	2	good	
+-80	delicious jumbo narrow Carrot, Cabbage, and Kale Pizza	5	awesome	
+-81	flavorless huge teal upside-down Turnip and Rutabaga Pie	7	decent	
+-85	special stale big Rainbow Spider Fun Roll	5	decent	
+-86	adequate snack-sized bouncing teal Vegas Volcano Lava Roll	2	good	
 -87	spoiled Crazy Dragon Shogun Buddha Roll	3	crappy	
 -92	decent basic hot dog	4	good	
--93	adequate fuchsia bouncing savage macho dog	3	good	
--94	tiny rotten one with everything	1	crappy	
+-93	adequate bouncing fuchsia savage macho dog	3	good	
+-94	rotten tiny one with everything	1	crappy	
 -95	flavorless sly dog	4	decent	
--96	jumbo decent devil dog	5	good	
+-96	decent jumbo devil dog	5	good	
 -97	decent chilly dog	4	good	
 -98	moldy tumbling ghost dog	3	crappy	
--99	toothsome thick twirling junkyard dog	5	awesome	
+-99	thick toothsome twirling junkyard dog	5	awesome	
 -100	bland small wet dog	2	decent	
 -101	normal sleeping dog	3	good	
--102	fancy normal spinning olive optimal dog	4	good	
--103	delicious super-sized video games hot dog	5	awesome	
--104	rotten blinking blurry Peppermint Nutrition Block	3	crappy	
+-102	normal fancy spinning olive optimal dog	4	good	
+-103	super-sized delicious video games hot dog	5	awesome	
+-104	rotten blurry blinking Peppermint Nutrition Block	3	crappy	
 -105	snack-sized rotten Gingerbread Nutrition Block	2	crappy	
 -106	spoiled bouncing Cinnamon Nutrition Block	3	crappy	

--- a/data/TCRS/TCRS_Turtle_Tamer_Packrat.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Packrat.txt
@@ -4,7 +4,7 @@
 4	turtle totem	0		
 5	pasta spoon	0		
 6	fuchsia brawny ravioli hat	0		Muscle Percent: +20, Familiar Effect: "atk, cap 2"
-7	jittery narrow purple saucepan	0		
+7	purple jittery narrow saucepan	0		
 8	spinning spices	0		
 9	huge lightning-fast disco mask	0		Initiative: +40, Familiar Effect: "atk, cap 2"
 10	disco ball	0		
@@ -41,9 +41,9 @@
 42	teal hermit permit	0		
 43	shaking worthless trinket	0		
 44	worthless gewgaw	0		
-45	purple mirror worthless knick-knack	0		
+45	mirror purple worthless knick-knack	0		
 46	figurine	0		
-47	immense decent hot buttered roll	8	good	
+47	decent immense hot buttered roll	8	good	
 48	heart of rock and roll	0		
 49	toothsome bowl of cottage cheese	3	awesome	
 50	spinning beefy Rock and Roll Legend	0		Muscle: +10, Class: "Accordion Thief", Song Duration: 10
@@ -63,7 +63,7 @@
 64	jittery action figure head	0		
 65	Mighty Bjorn action figure	0		
 66	twig	0		
-67	skewed bouncing spaghetti with rock-balls	0		
+67	bouncing skewed spaghetti with rock-balls	0		
 68	olive mirror Fonzie's Pasta Spoon of Peril of the cougar	0		Moxie: +20, Experience (Moxie): +1, Class: "Pastamancer"
 69	Newbiesport&trade; tent	0		
 70	bar skin	0		
@@ -78,7 +78,7 @@
 79	bugbear bungguard	0		Familiar Effect: "5xBarrr, cap 7"
 80	ghostly fairy gravy boat	0		
 81	acceptable ice-cold Willer	3	good	
-82	cyan shaking ring	0		
+82	shaking cyan ring	0		
 83	gray shaft	0		
 84	blinking Orcish meat locker	0		
 85	unlocked meat locker	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	energetic wicked staff	0		Spell Damage: +5, Maximum MP Percent: +20
 104	skewed scarecrow	0		
-105	thick spoiled bowl of charms	5	crappy	
+105	spoiled thick bowl of charms	5	crappy	
 106	ketchup	1	decent	
 107	catsup	1	EPIC	
 108	stick	0		
@@ -113,16 +113,16 @@
 114	studded dripping meat staff	0		Damage Absorption: +80
 115	mansplainer's dripping meat crossbow	0		Monster Level: +15
 116	flame-wreathed cool Bugfinder Blade	0		Moxie: +5, Hot Spell Damage: +10
-117	shaking huge Gnollish plunger	0		
+117	huge shaking Gnollish plunger	0		
 118	spring	0		
 119	spinning sprocket	0		
 120	ghostly cog	0		
 121	sprocket assembly	0		
 122	cog and sprocket assembly	0		
-123	twirling narrow squat Gnollish flyswatter	0		
+123	squat twirling narrow Gnollish flyswatter	0		
 124	empty meat tank	0		
 125	full meat tank	0		
-126	jittery spinning meat engine	0		
+126	spinning jittery meat engine	0		
 127	bouncing crafty Gnollish autoplunger	0		Maximum MP: +10
 128	razor-sharp meat pants	0		Weapon Damage Percent: +25, Familiar Effect: "2xPotato, cap 11"
 129	huge wobbly third-hand nunchaku of the wise owl	0		Mysticality: +20
@@ -162,7 +162,7 @@
 163	upside-down sharpshooter's skeleton bone	0		Critical Hit Percent: +10
 164	smart skull	0		
 165	skewed skewer	0		
-166	wobbly huge ghuol ears	0		
+166	huge wobbly ghuol ears	0		
 167	decent ghuol-ear kabob	3	good	
 168	blurry bone rattle of incineration	0		Hot Spell Damage: +50
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
@@ -175,19 +175,19 @@
 176	disembodied brain	0		
 177	blurry brainy skull	0		
 178	detective skull	0		
-179	half-sized flavorless wobbly chorizo taco	2	decent	
-180	practically non-alcoholic aged huge ice-cold fotie	1	awesome	
+179	flavorless half-sized wobbly chorizo taco	2	decent	
+180	aged practically non-alcoholic huge ice-cold fotie	1	awesome	
 181	baseball	0		
 182	batgut	0		
 183	bat wing	0		
 184	briefcase	0		
 185	skewed fat stacks of cash	0		
 186	bean	0		
-187	squat teal loose teeth	0		
+187	teal squat loose teeth	0		
 188	bat guano	0		
 189	guano coffee cup	0		
 191	nasty batskin belt	0		Stench Damage: +5
-192	blinking narrow maroon batskin belt	0		
+192	maroon blinking narrow batskin belt	0		
 193	birthday candle	0		
 194	Mr. Accessory of wisdom	0		Mysticality: +15, Softcore Only
 195	medical-grade eXtreme nose ring	0		HP Regen Min: 7, HP Regen Max: 10
@@ -220,7 +220,7 @@
 222	bouncing phat turquoise bead	0		
 223	red phat turquoise bracelet of the bloodbag	0		Maximum HP: +100
 224	lion tamer's eyepatch	0		Experience (familiar): +2, Familiar Effect: "3xBarrr, cap 6"
-225	snack-sized tasty tofu casserole	2	awesome	
+225	tasty snack-sized tofu casserole	2	awesome	
 226	altered twirling can of Red Minotaur	1	awesome	Effect: "Super-Mega-Charged", Effect Duration: 30
 227	resourceful Kentucky-fried meat sword	0		Maximum MP: +50
 228	squat groovy Kentucky-fried meat staff	0		Moxie Percent: +10
@@ -232,8 +232,8 @@
 234	skewed Doc Galaktik's Homeopathic Elixir	0		
 235	perfumed Bigger Bugfinder Blade of the empath	0		Familiar Weight: +5, Stench Resistance: +5
 236	Queue Du Coq cocktailcrafting kit	0		
-237	weak smooth bottle of gin	2	awesome	
-238	practically non-alcoholic tolerable bottle of vodka	1	good	
+237	smooth weak bottle of gin	2	awesome	
+238	tolerable practically non-alcoholic bottle of vodka	1	good	
 239	blinking spinning perfumed Orcish baseball cap of the sweet-tooth	0		Stench Resistance: +5, Candy Drop: +100, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	greedy ruddy Orcish cargo shorts	0		Maximum HP Percent: +40, Meat Drop: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	green Orcish frat-paddle of the storm	0		Maximum MP Percent: +40
@@ -246,19 +246,19 @@
 248	perfectly mixed salty dog	3	EPIC	
 249	bad bloody mary	3	decent	
 250	mediocre practically non-alcoholic screwdriver	1	decent	
-251	weak artisanal martini	2	EPIC	
+251	artisanal weak martini	2	EPIC	
 252	delicious shaking bloody beer	4	awesome	
 253	hand-crafted shot of schnapps	3	EPIC	
 254	mediocre spirit-forward blinking shot of grapefruit schnapps	5	decent	
 255	tolerable weak blue fine wine	2	good	
 256	bad green pulsating shot of tomato schnapps	4	decent	
 257	practically non-alcoholic smooth extra-spicy bloody mary	1	awesome	
-258	spinning olive dense meat stack	0		
+258	olive spinning dense meat stack	0		
 259	snake skin	0		
 260	decent massive White Citadel fries	9	good	
 261	small adequate White Citadel burger	2	good	
 262	flavorless blinking piece of wedding cake	4	decent	
-263	special massive stale chocolate chips	7	decent	Effect: "Hot Buttoned", Effect Duration: 5
+263	stale massive special chocolate chips	7	decent	Effect: "Hot Buttoned", Effect Duration: 5
 264	rotten chocolate chip cookies	4	crappy	
 265	ribald satin pants	0		Sleaze Damage: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	acceptable high-proof lightning	9	good	
@@ -267,7 +267,7 @@
 269	friendly sword	0		Familiar Weight: +3
 270	picket fence	0		
 271	powdered barbell	1		
-272	powdered pulsating narrow concentrated magicalness pill	1		
+272	powdered narrow pulsating concentrated magicalness pill	1		
 273	mixed shaking moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	olive mosquito larva	0		
@@ -306,20 +306,20 @@
 308	chaotic Knob Goblin elite helm	0		Spell Critical Percent: +10, Familiar Effect: "2xFairy, cap 15"
 309	Knob Goblin elite pants of the businessman	0		Meat Drop: +50, Familiar Effect: "2xBarrr, cap 15"
 310	Knob Goblin elite polearm of James Dean	0		Experience (Moxie): +3
-311	twirling wobbly jittery hill of beans	0		
+311	wobbly jittery twirling hill of beans	0		
 312	lard-coated Knob Goblin visor	0		Sleaze Spell Damage: +25, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	frightening Crown of the Goblin King	0		Spooky Damage: +5, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	adequate bean burrito	3	good	
 315	super-sized flavorless bean burrito	5	decent	
-316	tiny normal spinning insanely bean burrito	1	good	
-317	adequate massive bean burrito	10	good	
+316	normal tiny spinning insanely bean burrito	1	good	
+317	massive adequate bean burrito	10	good	
 318	stale bean burrito	3	decent	
 319	special adequate insanely bean burrito	4	good	Effect: "The Q Is Talking To You", Effect Duration: 35
 320	big bland olive bat haggis	5	decent	
 321	stale bite-sized upside-down menudo	1	decent	
 322	rotten special goat cheese	3	crappy	Effect: "Buff as a Baobab", Effect Duration: 10
 323	bite-sized flavorless blinking plain pizza	1	decent	
-324	decent half-sized wobbly yellow sausage pizza	2	good	
+324	half-sized decent yellow wobbly sausage pizza	2	good	
 325	toothsome narrow goat cheese pizza	4	awesome	
 326	half-sized decent mushroom pizza	2	good	
 327	goat	0		
@@ -354,7 +354,7 @@
 356	squat snowboarder pants of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, cap 25"
 357	jittery Mountain Stream soda	0		
 358	stale gr8ps	3	decent	
-359	miniature stale t8r tots	2	decent	
+359	stale miniature t8r tots	2	decent	
 360	ghostly stiffened miner's helmet	0		Damage Reduction: 1, Familiar Effect: "1xBarrr, 1xFairy, cap 20"
 361	wobbly personal trainer's miner's pants	0		Experience Percent (Muscle): +10, Familiar Effect: "stench atk, 1.5xPotato, cap 20"
 362	green energetic 7-Foot Dwarven mattock	0		Maximum MP Percent: +20
@@ -417,7 +417,7 @@
 419	boiled irradiated serum of sarcasm	0		Effect: "Angry like the Wolf", Effect Duration: 24
 420	improved squat tomato juice of powerful power	0		Effect: "Goldentongue", Effect Duration: 62
 421	magnetized philter of phorce	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 62
-422	improved anodized skewed blue potion of potency	0		Effect: "Compensatory Cruelness", Effect Duration: 55
+422	improved anodized blue skewed potion of potency	0		Effect: "Compensatory Cruelness", Effect Duration: 55
 423	non-improved tarnished unsweetened bouncing cordial of concentration	0		Effect: "Rave Concentration", Effect Duration: 13
 424	unsweetened pressed cold-filtered jittery lime green ointment of the occult	0		Effect: "Crimbo Flavor", Effect Duration: 16
 425	anodized alkaline blinking oil of expertise	0		Effect: "Stick Emporium Membership", Effect Duration: 58
@@ -450,8 +450,8 @@
 452	disease	0		
 453	sober pill	0		
 454	screwdriver	0		
-455	super-sized normal jumbo olive	5	good	
-456	practically non-alcoholic lousy narrow dry martini	1	decent	
+455	normal super-sized jumbo olive	5	good	
+456	lousy practically non-alcoholic narrow dry martini	1	decent	
 457	family-friendly ye olde golde frontes	0		Sleaze Resistance: +1, Class: "Disco Bandit", Single Equip
 458	blinking continuum transfunctioner	0		
 459	narrow pixel	0		
@@ -462,7 +462,7 @@
 464	bouncing purple pixel potion	0		
 465	pixel potion	0		
 466	blue pixel potion	0		
-467	decent low-calorie pixel pie	1	good	
+467	low-calorie decent pixel pie	1	good	
 468	ghostly ruby W	0		
 469	wussiness potion	0		
 470	hand-crafted Imp Ale	3	EPIC	
@@ -493,7 +493,7 @@
 495	mirror catgut	0		
 496	narrow blinking cat appendix	0		
 497	gnatwing	0		
-498	miniature enchanted delicious pulsating papaya	2	awesome	Effect: "Smoking like a Bandit", Effect Duration: 30
+498	delicious miniature enchanted pulsating papaya	2	awesome	Effect: "Smoking like a Bandit", Effect Duration: 30
 499	auspicious perfumed denim axe	0		Stench Resistance: +5, Item Drop: +10
 500	Elf Farm Raffle ticket	0		
 501	spoiled Elfin shortbread	4	crappy	
@@ -501,7 +501,7 @@
 503	snack-sized adequate blue skewered cat appendix	2	good	
 504	upside-down evil arches	0		
 505	lime green ghostly nasty dance instructor's gnatwing earring	0		Experience Percent (Moxie): +10, Stench Damage: +5
-506	big stale shaking lime green Hell broth	5	decent	
+506	stale big lime green shaking Hell broth	5	decent	
 507	vibrating thunderrr guitarrr	0		Maximum MP Percent: +10
 508	blurry sonata	0		
 509	twirling red Hey Deze nuts	0		
@@ -510,7 +510,7 @@
 512	upside-down Sneaky Pete's key lime	0		
 513	rotten upside-down Boris's key lime pie	4	crappy	
 514	bland massive Jarlsberg's key lime pie	8	decent	
-515	massive rotten Sneaky Pete's key lime pie	7	crappy	
+515	rotten massive Sneaky Pete's key lime pie	7	crappy	
 516	Hey Deze map	0		
 517	bejeweled accordion strap of the wise owl	0		Mysticality: +20, Class: "Accordion Thief"
 518	huge mystery juice	0		
@@ -522,20 +522,20 @@
 524	mediocre papaya sling	3	decent	
 525	grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
-527	mirror teal volleyball	0		
+527	teal mirror volleyball	0		
 528	blood-faced volleyball	0		
 529	squat fertilized ghuol egg	0		
 530	adjusted improved red jittery wobbly spray paint	0		Effect: "Cold, Dead Hands", Effect Duration: 15
 531	smelly special sauce glove	0		Stench Spell Damage: +10, Class: "Sauceror", Single Equip
 532	groovy ladle of mystery	0		Moxie Percent: +10, Class: "Sauceror"
 533	Gnollish toolbox	0		
-534	huge wobbly abridged dictionary	0		
+534	wobbly huge abridged dictionary	0		
 535	bridge	0		
 536	dictionary	0		
 537	pr0n legs	0		
 538	f3d0r4 of the wise owl	0		Mysticality: +20, Familiar Effect: "atk, 1xLep, cap 27"
 539	lowercase N	0		
-540	concentrated lime green blurry Tasty Fun Good rice candy	0		Effect: "Broberry Brotality", Effect Duration: 36
+540	concentrated blurry lime green Tasty Fun Good rice candy	0		Effect: "Broberry Brotality", Effect Duration: 36
 541	knitted draggin' ball hat of the businessman	0		Cold Resistance: +3, Meat Drop: +50, Familiar Effect: "atk, 1xVolley, cap 25"
 542	pulsating veiny padded 1337 7r0uZ0RZ	0		Damage Absorption: +20, Maximum HP: +10, Familiar Effect: "2xPotato, cap 27"
 543	adequate bite-sized blurry Trollhouse cookies	1	good	
@@ -549,38 +549,38 @@
 551	gray 64067 scroll	0		
 552	upside-down 64735 scroll	0		
 553	31337 scroll	0		
-554	yummy small pr0n cocktail	2	awesome	
+554	small yummy pr0n cocktail	2	awesome	
 555	forbidden drywall axe of the blizzard	0		Spell Damage Percent: +50, Cold Spell Damage: +25
 556	Da Vinci's Pine-Fresh air freshener	0		Experience (Mysticality): +5
 557	lousy whiskey and cola	4	decent	
-558	super-sized normal wobbly papaya taco	5	good	
+558	normal super-sized wobbly papaya taco	5	good	
 559	razor-sharp can lid	0		
 560	adequate stalk of asparagus	3	good	
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	green sonar-in-a-biscuit	0		
-564	practically non-alcoholic enchanted bad Mad Train wine	1	decent	Effect: "Crusty Head", Effect Duration: 30
+564	bad enchanted practically non-alcoholic Mad Train wine	1	decent	Effect: "Crusty Head", Effect Duration: 30
 565	jittery chilly hobo gloves	0		Cold Damage: +5, Single Equip
 566	deadly bum cheek	0		Weapon Damage: +5, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	adequate big Double Bacon Beelzeburger	5	good	
-569	low-calorie decent Lord of the Flies-sized fries	1	good	
+568	big adequate Double Bacon Beelzeburger	5	good	
+569	decent low-calorie Lord of the Flies-sized fries	1	good	
 570	bland upside-down Chicken Sandwich	4	decent	
 571	Jumbo Dr. Lucifer	1	good	
-572	snack-sized yummy Children's Meal of the Damned	2	awesome	
-573	yummy small noodles	2	awesome	
+572	yummy snack-sized Children's Meal of the Damned	2	awesome	
+573	small yummy noodles	2	awesome	
 574	special normal blinking noodles	4	good	Effect: "Frostbeard", Effect Duration: 45
-575	moldy tiny painful penne pasta	1	crappy	
+575	tiny moldy painful penne pasta	1	crappy	
 576	flavorless ravioli della hippy	3	decent	
 577	decent pr0n m4nic0tti	3	good	
-578	adequate small Hell ramen	2	good	
-579	yummy low-calorie boring spaghetti	1	awesome	
+578	small adequate Hell ramen	2	good	
+579	low-calorie yummy boring spaghetti	1	awesome	
 580	mirror sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	half-sized moldy fettucini Inconnu	2	crappy	
 584	rotten upside-down spaghetti with Skullheads	4	crappy	
-585	gigantic tasty gnocchetti di Nietzsche	8	awesome	
+585	tasty gigantic gnocchetti di Nietzsche	8	awesome	
 586	green electrified ridiculously huge sword of courage	0		Spooky Resistance: +3, MP Regen Min: 3, MP Regen Max: 5
 587	vacuum-sealed non-chilled super-spiky hair gel	0		Effect: "Radiated and Grodiated", Effect Duration: 47
 588	upside-down soft echo eyedrop antidote	0		
@@ -615,7 +615,7 @@
 617	moist olive Angry Farmer candy	0		Effect: "Squid Squint", Effect Duration: 38
 618	concentrated colloidal Mick's IcyVapoHotness Rub	0		Effect: "Video Game Hot Dog", Effect Duration: 20
 619	needle of the businessman	0		Meat Drop: +50
-620	nitrogenated ghostly yellow thin candle	0		Effect: "Improved Candy Vision", Effect Duration: 57
+620	nitrogenated yellow ghostly thin candle	0		Effect: "Improved Candy Vision", Effect Duration: 57
 621	upside-down Warm Subject gift certificate	0		
 622	awful poetry journal	0		
 623	blue WA	0		
@@ -636,7 +636,7 @@
 638	bouncing chaotic quilted asshat	0		Damage Absorption: +40, Spell Critical Percent: +10, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	big toothsome abominable snowcone	5	awesome	
 640	Ent cider	1	good	
-641	gigantic rotten toast	6	crappy	
+641	rotten gigantic toast	6	crappy	
 642	skeleton key	0		
 643	wobbly skeleton key ring	0		
 644	twirling Crimbo pressie	0		Last Available: "2003-12"
@@ -667,8 +667,8 @@
 669	special huge flavorless ghuol guolash	9	decent	Effect: "World's Shortest Giant", Effect Duration: 20
 670	experienced lihc face	0		Experience: +2, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	maroon bouncing ghostly rosy-cheeked sage grave robbing shovel	0		Mysticality Percent: +10, Maximum HP Percent: +30
-672	normal mirror blinking cranberries	3	good	
-673	watered-down delicious teal vodka and cranberry	2	awesome	
+672	normal blinking mirror cranberries	3	good	
+673	delicious watered-down teal vodka and cranberry	2	awesome	
 674	artisanal whiskey	3	EPIC	
 675	smooth skull of the Bonerdagon	0		Moxie: +15
 676	dragonbone belt buckle	0		
@@ -679,7 +679,7 @@
 681	triple-distilled acceptable slip 'n' slide	9	good	
 682	delicious tumbling a sump'm sump'm	4	awesome	
 683	perfectly mixed horizontal tango	3	EPIC	
-684	tolerable spirit-forward pink pony	5	good	
+684	spirit-forward tolerable pink pony	5	good	
 685	shaking up-at-dawn smelly Mr. Shirt of bravery	0		Stench Spell Damage: +10, Spooky Resistance: +5, Adventures: +5
 686	green wool knuckles	0		Cold Resistance: +1
 687	concentrated tarnished jittery blood of the Wereseal	0		Effect: "Feet of Grapefruit", Effect Duration: 49
@@ -716,8 +716,8 @@
 720	ghostly crafty dangerous porquoise necklace	0		Weapon Damage: +10, Maximum MP: +10, Single Equip
 721	Lo Pan's Rosewater's porquoise bracelet	0		Mysticality Percent: +30, Spell Critical Percent: +30
 722	greedy horrifying flame-wreathed porquoise ring	0		Hot Spell Damage: +10, Spooky Damage: +25, Meat Drop: +20, Single Equip
-723	immense bland skewed Knoll mushroom	8	decent	
-724	bland fancy jittery mushroom	3	decent	Effect: "Elemental Saucesphere", Effect Duration: 10
+723	bland immense skewed Knoll mushroom	8	decent	
+724	fancy bland jittery mushroom	3	decent	Effect: "Elemental Saucesphere", Effect Duration: 10
 725	one million meat pancakes	0		
 726	nasty huge mirror shard	0		Stench Damage: +5
 727	blinking hedge maze puzzle	0		
@@ -735,7 +735,7 @@
 739	tambourine bells	0		
 740	tambourine of the glutton	0		Food Drop: +100
 741	broken skull	0		
-742	diet decent bouncing Knoll shroomkabob	1	good	
+742	decent diet bouncing Knoll shroomkabob	1	good	
 743	adequate mushroom	4	good	
 744	nitrogenated ionized hair spray	0		Effect: "Smoking like a Bandit", Effect Duration: 36
 746	stat script	0		
@@ -752,7 +752,7 @@
 757	rotten mushroom	3	crappy	
 758	stale ghost cucumber	3	decent	
 759	dill	0		
-760	huge tumbling vinegar	0		
+760	tumbling huge vinegar	0		
 761	brine	0		
 762	tolerable especially salty dog	3	good	
 763	spinning spinning blurry ghostly pickling solution	0		
@@ -773,7 +773,7 @@
 778	mirror support cummerbund of the empath	0		Familiar Weight: +5
 779	Mob Penguin cellular phone	0		
 780	scroll of pasta summoning	0		
-781	tarnished extra-electrified quadruple-electrified mirror huge mafia aria	0		Effect: "Liquid Courage", Effect Duration: 20
+781	tarnished extra-electrified quadruple-electrified huge mirror mafia aria	0		Effect: "Liquid Courage", Effect Duration: 20
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	squat 'Villa' document	0		
 784	boozy hand-crafted Acqua Del Piatto Merlot	5	EPIC	Last Available: "2004-10"
@@ -789,9 +789,9 @@
 794	anodized oil of slipperiness	0		Effect: "Stickler for Promptness", Effect Duration: 68
 795	watered-down acceptable spinning Acque Luride Grezze Cabernet	2	good	Last Available: "2004-10"
 796	avaricious manspreader's deadly cement shoes	0		Weapon Damage: +5, Monster Level: +10, Meat Drop: +30, Last Available: "2004-10"
-797	weak perfectly mixed rockin' wagon	2	EPIC	
+797	perfectly mixed weak rockin' wagon	2	EPIC	
 798	mediocre weak mirror bouncing ocean motion	2	decent	
-799	smooth practically non-alcoholic tumbling fuzzbump	1	awesome	
+799	practically non-alcoholic smooth tumbling fuzzbump	1	awesome	
 800	spoiled poutine	4	crappy	
 801	moldy Knob stir-fry	3	crappy	
 804	adequate Knoll stir-fry	4	good	
@@ -799,17 +799,17 @@
 806	flavorless pulsating green asparagus stir-fry	3	decent	
 807	flavorless olive stir-fry	4	decent	
 808	stale Knob sausage stir-fry	3	decent	
-809	low-calorie stale blue bat wing stir-fry	1	decent	
+809	stale low-calorie blue bat wing stir-fry	1	decent	
 810	bite-sized flavorless rat appendix stir-fry	1	decent	
 811	decent mirror tofu stir-fry	4	good	
 812	toothsome snack-sized pr0n stir-fry	2	awesome	
-813	flavorless miniature Knob shells	2	decent	
+813	miniature flavorless Knob shells	2	decent	
 814	decent miniature b&auml;tzle	2	good	
 815	bland low-calorie ratini	1	decent	
 816	decent gigantic Knob stroganoff	10	good	
 817	rotten jittery menudo ravioli	3	crappy	
 818	huge plus sign	0		
-819	mirror maroon milky potion	0		
+819	maroon mirror milky potion	0		
 820	twirling swirly potion	0		
 821	bubbly potion	0		
 822	smoky potion	0		
@@ -827,7 +827,7 @@
 834	therapeutic cornuthaum of dire peril	0		Weapon Damage: +20, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	brainy ring of aggravate monster	0		Mysticality: +5
 836	rotten purple mind flayer corpse	3	crappy	
-837	watered-down mediocre enchanted Uovo Marcio Shiraz	2	decent	Effect: "Emotion Sickness", Effect Duration: 35, Last Available: "2004-10"
+837	mediocre enchanted watered-down Uovo Marcio Shiraz	2	decent	Effect: "Emotion Sickness", Effect Duration: 35, Last Available: "2004-10"
 838	nippy Mafia stogie of wisdom	0		Mysticality: +15, Cold Damage: +10, Last Available: "2004-10"
 839	fortified artisanal Maiali Sifilitici Pinot Noir	5	EPIC	Last Available: "2004-10"
 840	blurry supercool Mafia violin case of wisdom	0		Mysticality: +15, Moxie Percent: +20, Last Available: "2004-10"
@@ -847,7 +847,7 @@
 855	balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
 857	moonglasses	0		
-858	narrow mirror palm-frond toupee	0		Familiar Weight: +5
+858	mirror narrow palm-frond toupee	0		Familiar Weight: +5
 859	jittery knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
@@ -878,7 +878,7 @@
 887	bouncing leaf	0		
 888	maple leaf	0		
 889	shaking pulsating nasty balaclava	0		Stench Damage: +5, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	small normal balaclava baklava	2	good	
+890	normal small balaclava baklava	2	good	
 891	blinking forbidden Warehouse 23 bling	0		Spell Damage Percent: +50
 892	miser's Tesla dance instructor's bugbear-smiting sword	0		Experience Percent (Moxie): +10, Meat Drop: +10, MP Regen Min: 7, MP Regen Max: 10
 893	smooth twirling lumbering jack	4	awesome	
@@ -891,14 +891,14 @@
 900	wobbly smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	blinking 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	mediocre fortified tumbling Spasmi Dolorosi Del Rene Champagne	5	decent	Last Available: "2004-10"
+903	fortified mediocre tumbling Spasmi Dolorosi Del Rene Champagne	5	decent	Last Available: "2004-10"
 904	squat executive greasy school Mafia knickerbockers of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Meat Drop: +40, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
-905	altered frozen warmed ghostly huge Yummy Tummy bean	0		Effect: "Stogied", Effect Duration: 24
-906	polymerized blinking ghostly wobbly Rock Pops	0		Effect: "You Liver", Effect Duration: 48
-907	electrified chilled squat gray Mr. Mediocrebar	0		Effect: "Flame-Retardant Trousers", Effect Duration: 29
+905	altered frozen warmed huge ghostly Yummy Tummy bean	0		Effect: "Stogied", Effect Duration: 24
+906	polymerized wobbly ghostly blinking Rock Pops	0		Effect: "You Liver", Effect Duration: 48
+907	electrified chilled gray squat Mr. Mediocrebar	0		Effect: "Flame-Retardant Trousers", Effect Duration: 29
 908	flattened Cold Hots candy	0		Effect: "Egged On", Effect Duration: 43
 909	quadruple-activated irradiated blue Wint-O-Fresh mint	0		Effect: "Squirming Like a Toad", Effect Duration: 21
-910	fancy decent dwarf bread	3	good	Effect: "Vitamin-Maxed", Effect Duration: 40
+910	decent fancy dwarf bread	3	good	Effect: "Vitamin-Maxed", Effect Duration: 40
 911	quantum Senior Mints	0		Effect: "Night of the Nachos", Effect Duration: 59
 912	diffused anodized upside-down pixellated candy heart	0		Effect: "Haunted Liver", Effect Duration: 28
 913	alkaline extra-flattened kobold	0		Effect: "Abyssal Tears", Effect Duration: 14
@@ -909,17 +909,17 @@
 918	coward's Radio Free Baseball Cap	0		Monster Level: -20, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
 919	skewed up-at-dawn Radio Free Pants	0		Adventures: +5, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	frightening Radio Free Foil	0		Spooky Damage: +5, Last Available: "2006-07"
-921	bland half-sized radio button candy	2	decent	
+921	half-sized bland radio button candy	2	decent	
 922	maroon wicked severed rocking horse head	0		Spell Damage: +5
 923	broken cellular phone	0		Last Available: "2004-01"
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
-925	red huge dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
+925	huge red dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	tarnished tumbling Hawking's Elixir of Brilliance	0		Effect: "Fustulent", Effect Duration: 69
 927	perfectly mixed Ferita Del Petto Zinfandel	4	EPIC	Last Available: "2006-12"
 928	Tesla fuzzy bracelets	0		MP Regen Min: 7, MP Regen Max: 10
 929	quilted arse-shooting crossbow	0		Damage Absorption: +40
 931	fancy hand-crafted twirling spiced rum	4	EPIC	Effect: "Sweet Tooth", Effect Duration: 40
-932	acceptable boozy maroon eggnog	5	good	
+932	boozy acceptable maroon eggnog	5	good	
 933	delicious candy cane	3	awesome	
 934	normal enchanted mirror gingerbread bugbear	4	good	Effect: "init.enh", Effect Duration: 15
 935	extremely unsafe imitation nice watch	0		Weapon Damage Percent: +100, Single Equip, Last Available: "2004-12"
@@ -947,7 +947,7 @@
 957	yummy chorizo brownies	4	awesome	
 958	decent tiny ghostly chocolate and tomato pizza	1	good	
 959	bouncing flange	0		
-960	wobbly tumbling clockwork key	0		
+960	tumbling wobbly clockwork key	0		
 961	silk garter snake	0		Free Pull, Last Available: "2011-12"
 962	velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
 963	auspicious wholesome plastic seal clubber	0		Maximum HP Percent: +10, Item Drop: +10
@@ -982,14 +982,14 @@
 992	hale plastic Jarlsberg of extreme caution of the brazier	0		Maximum HP: +20, Monster Level: -25, Hot Spell Damage: +25
 993	lime green narrow careful manspreader's personal trainer's plastic Sneaky Pete	0		Experience Percent (Muscle): +10, Monster Level: 0
 994	up-at-dawn plastic Susie	0		Adventures: +5
-995	super-sized delicious Lucky Surprise Egg	5	awesome	
+995	delicious super-sized Lucky Surprise Egg	5	awesome	
 998	maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	blinking maid head	0		
 1000	Meat maid	0		
 1002	spinning Xlyinia's notebook of horror	0		Spooky Spell Damage: +25
 1003	soda water	0		
-1004	tolerable weak bottle of tequila	2	good	
-1005	weak enchanted perfectly mixed boxed wine	2	EPIC	Effect: "Bread-Lined", Effect Duration: 50
+1004	weak tolerable bottle of tequila	2	good	
+1005	enchanted weak perfectly mixed boxed wine	2	EPIC	Effect: "Bread-Lined", Effect Duration: 50
 1006	adequate pulsating mirror cherry	4	good	
 1007	twirling coconut shell of the sewer	0		Stench Damage: +25, Familiar Effect: "1xFairy, cap 7"
 1008	rock-hard ice cubes	0		Damage Reduction: 5
@@ -1001,16 +1001,16 @@
 1014	bad strawberry wine	3	decent	
 1015	mediocre wine spritzer	3	decent	
 1016	lousy perpendicular hula	3	decent	
-1017	weak mediocre enchanted ducha de oro	2	decent	Effect: "In Vino Vires", Effect Duration: 15
+1017	enchanted mediocre weak ducha de oro	2	decent	Effect: "In Vino Vires", Effect Duration: 15
 1018	bad calle de miel	4	decent	
-1019	hand-crafted distilled dry vodka martini	5	EPIC	
-1020	acceptable high-proof tumbling old-fashioned	6	good	
+1019	distilled hand-crafted dry vodka martini	5	EPIC	
+1020	high-proof acceptable tumbling old-fashioned	6	good	
 1021	drinkable extra-dry tequila with training wheels	5	good	
 1022	bad sangria	3	decent	
 1023	aged watered-down vesper	2	awesome	Last Available: "2004-12"
 1024	mediocre upside-down bodyslam	4	decent	Last Available: "2004-12"
 1025	drinkable sangria del diablo	3	good	Last Available: "2004-12"
-1026	mirror bouncing Valentine	0		Free Pull
+1026	bouncing mirror Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
 1029	jittery hippo whip of incineration	0		Hot Spell Damage: +50
@@ -1032,7 +1032,7 @@
 1046	flame-wreathed wholesome traffic cone	0		Maximum HP Percent: +10, Hot Spell Damage: +10, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	watered-down mediocre N. O. Beer	2	decent	
 1048	modified mirror oyster egg	1		
-1049	diluted wobbly teal oyster egg	1		
+1049	diluted teal wobbly oyster egg	1		
 1050	boiled oyster egg	1		
 1051	upside-down narrow plastic oyster egg	0		
 1052	modified ghostly bouncing lime green oyster egg	1		Effect: "Human-Constellation Hybrid", Effect Duration: 30
@@ -1040,16 +1040,16 @@
 1054	twisted huge purple upside-down oyster egg	1		Effect: "Rotten Memories", Effect Duration: 25
 1055	plastic oyster egg	0		
 1056	distilled puce oyster egg	1		
-1057	vaporized bouncing upside-down puce oyster egg	1		
+1057	vaporized upside-down bouncing puce oyster egg	1		
 1058	distilled squat puce oyster egg	1		
 1059	puce plastic oyster egg	0		
 1060	modified squat mauve oyster egg	1		
 1061	denatured mauve oyster egg	1		Effect: "Witch's Brood", Effect Duration: 35
-1062	altered squat jittery maroon mauve oyster egg	1		
+1062	altered maroon squat jittery mauve oyster egg	1		
 1063	mauve plastic oyster egg	0		
 1064	vaporized oyster egg	1		Effect: "Notably Lovely", Effect Duration: 50
 1065	dried squat green oyster egg	1		
-1066	distilled spinning bouncing spinning oyster egg	1		
+1066	distilled bouncing spinning spinning oyster egg	1		
 1067	tumbling plastic oyster egg	0		
 1068	mixed squat oyster egg	1		Effect: "Patience of the Tortoise", Effect Duration: 30
 1069	boiled green oyster egg	1		
@@ -1075,7 +1075,7 @@
 1089	clockwork spine	0		
 1090	clockwork rings	0		
 1091	clockwork claws	0		
-1092	blinking ghostly clockwork sheet	0		
+1092	ghostly blinking clockwork sheet	0		
 1093	clockwork counterclockwise dome	0		
 1094	clockwork sphere	0		
 1095	deactivated MicroMechaMech	0		
@@ -1125,18 +1125,18 @@
 1139	weak tolerable mushroom wine	2	good	
 1140	hand-crafted icy mushroom wine	3	EPIC	
 1141	enchanted extra-dry artisanal mushroom wine	5	EPIC	Effect: "Hella Smart", Effect Duration: 30
-1142	smooth practically non-alcoholic pointy mushroom wine	1	awesome	
+1142	practically non-alcoholic smooth pointy mushroom wine	1	awesome	
 1143	hand-crafted flat mushroom wine	4	EPIC	
-1144	bad irresponsibly strong cool mushroom wine	9	decent	
-1145	artisanal enchanted knob mushroom wine	3	EPIC	Effect: "Sparkly!", Effect Duration: 30
+1144	irresponsibly strong bad cool mushroom wine	9	decent	
+1145	enchanted artisanal knob mushroom wine	3	EPIC	Effect: "Sparkly!", Effect Duration: 30
 1146	bad knoll mushroom wine	3	decent	
 1147	perfectly mixed mushroom wine	3	EPIC	
-1148	aged upside-down shaking shot of flower schnapps	3	awesome	
+1148	aged shaking upside-down shot of flower schnapps	3	awesome	
 1149	stale tiny huge red flower petal pie	1	decent	
 1150	distilled acceptable bottle of single-barrel whiskey	5	good	
 1151	mirror smooth discarded plastic fork of Leguizamo	0		Moxie: +15, Monster Level: +20
 1152	gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
-1153	super-sized decent fancy yellow Retenez L'Herbe Pat&eacute;	5	good	Effect: "Human-Horror Hybrid", Effect Duration: 15
+1153	fancy super-sized decent yellow Retenez L'Herbe Pat&eacute;	5	good	Effect: "Human-Horror Hybrid", Effect Duration: 15
 1154	compressed teal bouncing Breathetastic&trade; Premium Canned Air	1	decent	
 1155	letter from King Ralph XI	0		
 1157	Samson's wholeberd	0		Experience (Muscle): +5
@@ -1150,13 +1150,13 @@
 1165	hovering sombrero	0		
 1166	maroon maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
-1168	narrow jittery less-than-three-shaped box	0		
+1168	jittery narrow less-than-three-shaped box	0		
 1169	spinning exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	skewed coffin	0		
 1172	red asbestos box	0		
 1173	linoleum box	0		
-1174	blurry fuchsia chrome box	0		
+1174	fuchsia blurry chrome box	0		
 1175	cryptic puzzle box	0		
 1176	refrigerated biohazard container	0		
 1177	spinning magnetic field	0		
@@ -1185,14 +1185,14 @@
 1200	delicious mugcake	3	awesome	
 1201	rotten yellow urinal cake	4	crappy	
 1202	stale Happy Birthday, Claude! cake	3	decent	
-1203	special adequate personalized birthday cake	4	good	Effect: "EVISCERATE!", Effect Duration: 45
+1203	adequate special personalized birthday cake	4	good	Effect: "EVISCERATE!", Effect Duration: 45
 1204	adequate three-tiered wedding cake	3	good	
 1205	bland babycakes	4	decent	
 1206	bland velvet cake	3	decent	
-1207	normal enchanted congratulatory cake	3	good	Effect: "All Branned Up", Effect Duration: 15
+1207	enchanted normal congratulatory cake	3	good	Effect: "All Branned Up", Effect Duration: 15
 1208	delicious angel-food cake	4	awesome	
 1209	enchanted moldy devil's-food cake	3	crappy	Effect: "Cancer Rising", Effect Duration: 5
-1210	flavorless big birthday party jellybean cheesecake	5	decent	
+1210	big flavorless birthday party jellybean cheesecake	5	decent	
 1211	balloon	0		
 1212	balloon	0		
 1213	heart-shaped balloon	0		
@@ -1301,7 +1301,7 @@
 1317	blood flower	0		
 1318	skewed lovecat tail	0		
 1319	tumbling plastic passion fruit	0		
-1320	small spoiled fuchsia questionable taco	2	crappy	
+1320	spoiled small fuchsia questionable taco	2	crappy	
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	pulsating mirror dangerous time helmet	0		Weapon Damage: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
@@ -1333,9 +1333,9 @@
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	jittery fuchsia Lo Pan's pinky ring	0		Spell Critical Percent: +30, Single Equip
 1352	mediocre redrum	3	decent	
-1353	spinning pulsating ninja pirate zombie robot	0		
+1353	pulsating spinning ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	rotten gigantic bowl of oriole's nest soup	10	crappy	
+1355	gigantic rotten bowl of oriole's nest soup	10	crappy	
 1356	bunny liver	0		
 1357	bad triple-distilled green Mt. Noob Pale Ale	7	decent	
 1358	twirling pirate zombie head	0		Last Available: "2005-11"
@@ -1343,17 +1343,17 @@
 1360	yellow pirate zombie robot head	0		Last Available: "2005-11"
 1361	shaking rosewater-soaked disembodied smile	0		Stench Resistance: +3, Single Equip
 1362	narrow jittery sausage	0		
-1363	tumbling narrow clockwork pirate skull	0		
+1363	narrow tumbling clockwork pirate skull	0		
 1364	blurry rhesus monkey	0		Familiar Weight: +5
 1365	normal jittery tofurkey leg	4	good	
-1366	gigantic bland tofurkey gravy	8	decent	
+1366	bland gigantic tofurkey gravy	8	decent	
 1367	bland herbal stuffing	3	decent	
 1368	yummy can-shaped gelatinous cranberry sauce	3	awesome	
 1369	rotten yams	4	crappy	
 1370	censurious rhinestone cowboy shirt	0		Sleaze Resistance: +3
 1371	Newton's gingham blouse	0		Experience (Mysticality): +3
 1372	gravedigger's souvenir ski t-shirt	0		Spooky Damage: +10
-1373	pulsating squat sweet nutcracker	0		Free Pull, Last Available: "2005-12"
+1373	squat pulsating sweet nutcracker	0		Free Pull, Last Available: "2005-12"
 1374	mandible	0		Familiar Weight: +5, Last Available: "2005-12"
 1375	upside-down yellow Temple Grandin's plastic Crimbo wreath	0		Familiar Weight: +7, Single Equip, Last Available: "2005-12"
 1376	flame-retardant plastic Uncle Crimbo	0		Hot Resistance: +1, Last Available: "2005-12"
@@ -1396,7 +1396,7 @@
 1414	tarnished ionized snowcone	0		Effect: "Musky", Effect Duration: 36, Last Available: "2006-01"
 1415	deionized nitrogenated snowcone	0		Effect: "Browbeaten", Effect Duration: 28, Last Available: "2006-01"
 1416	non-oxidized olive snowcone	0		Effect: "Feroci Tea", Effect Duration: 44, Last Available: "2006-01"
-1417	dry narrow bouncing snowcone	0		Effect: "Paging Betty", Effect Duration: 69, Last Available: "2006-01"
+1417	dry bouncing narrow snowcone	0		Effect: "Paging Betty", Effect Duration: 69, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
 1420	asbestos-lined gravedigger's traffic cone	0		Spooky Damage: +10, Hot Resistance: +5, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
@@ -1439,7 +1439,7 @@
 1457	narrow Goth Giant	0		
 1458	adequate Valentine's Day cake	4	good	
 1459	upside-down arrow'd heart balloon	0		
-1460	squat skewed velvet box	0		
+1460	skewed squat velvet box	0		
 1461	squashed frog	0		
 1462	eye of newt	0		
 1463	salamander spleen	0		
@@ -1476,7 +1476,7 @@
 1494	galvanized chilled pulsating red sugar-coated pine cone	0		Effect: "Extra-Sharp Weapon", Effect Duration: 44, Last Available: "2020-09"
 1495	traffic cone of the ox of the businessman	0		Muscle: +20, Meat Drop: +50, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	lousy gloomy mushroom wine	3	decent	
-1497	tolerable blinking tumbling mushroom wine	4	good	
+1497	tolerable tumbling blinking mushroom wine	4	good	
 1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	tumbling whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
@@ -1501,9 +1501,9 @@
 1520	foul-smelling steel-toed Radio KoL Coffee Mug	0		Damage Reduction: 9, Stench Damage: +10
 1521	Frank Gorshin trophy	0		
 1522	Tesla Radio Free Jersey of temperance	0		Sleaze Resistance: +5, MP Regen Min: 7, MP Regen Max: 10
-1523	mirror teal bottle of used blood	0		
+1523	teal mirror bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	twirling joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	twirling joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	blinking huge pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	ghostly purple diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	prompt Jeselnik's corkscrew	0		Sleaze Damage: +25, Adventures: +3, Last Available: "2006-04"
@@ -1512,7 +1512,7 @@
 1531	jittery nasty grass skirt	0		Stench Damage: +5, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
 1532	rosewater-soaked grass hat	0		Stench Resistance: +3, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	fireproof grass blade	0		Hot Resistance: +3, Last Available: "2011-01"
-1534	upside-down wobbly squat raffle prize box	0		
+1534	upside-down squat wobbly raffle prize box	0		
 1536	pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	olive asbestos-lined sparkly engagement ring	0		Hot Resistance: +5, Single Equip
@@ -1528,24 +1528,24 @@
 1548	twirling dance instructor's thinker's Gazpacho's Glacial Grimoire	0		Mysticality: +10, Experience Percent (Moxie): +10
 1549	MSG	0		
 1550	jittery maroon stiffened second-hand knockoff engagement ring	0		Damage Reduction: 1, Single Equip
-1551	perfectly mixed purple ghostly bottle of Domesticated Turkey	3	EPIC	
+1551	perfectly mixed ghostly purple bottle of Domesticated Turkey	3	EPIC	
 1552	perfectly mixed practically non-alcoholic bottle of Definit	1	EPIC	
 1553	lousy bottle of Calcutta Emerald	3	decent	
-1554	triple-distilled drinkable bottle of Lieutenant Freeman	8	good	
-1555	watered-down artisanal bottle of Jorge Sinsonte	2	EPIC	
+1554	drinkable triple-distilled bottle of Lieutenant Freeman	8	good	
+1555	artisanal watered-down bottle of Jorge Sinsonte	2	EPIC	
 1556	weak mediocre boxed champagne	2	decent	
-1557	immense bland kumquat	10	decent	
+1557	bland immense kumquat	10	decent	
 1558	flavorless special tangerine	3	decent	Effect: "Armor-Plated", Effect Duration: 40
 1559	squat tonic water	0		
 1560	decent cocktail onion	4	good	
 1561	normal raspberry	3	good	
 1562	adequate miniature kiwi	2	good	
-1563	triple-distilled lousy ghostly whiskey bittersweet	7	decent	
+1563	lousy triple-distilled ghostly whiskey bittersweet	7	decent	
 1564	perfectly mixed extra-dry mimosette	5	EPIC	
 1565	aged weak tequila sunset	2	awesome	
 1566	bad zmobie	3	decent	Wiki Name: "Zmobie (drink)"
 1567	delicious watered-down lime green gin and tonic	2	awesome	
-1568	mediocre watered-down bouncing vodka and tonic	2	decent	
+1568	watered-down mediocre bouncing vodka and tonic	2	decent	
 1569	lousy weak vodka gibson	2	decent	
 1570	delicious watered-down gibson	2	awesome	
 1571	hand-crafted parisian cathouse	4	EPIC	
@@ -1559,28 +1559,28 @@
 1579	acceptable gimlet	4	good	
 1580	perfectly mixed brick road	4	EPIC	
 1581	mediocre vodka stratocaster	3	decent	
-1582	distilled acceptable Neuromancer	5	good	
+1582	acceptable distilled Neuromancer	5	good	
 1583	drinkable prussian cathouse	3	good	
 1584	aged Mae West	4	awesome	
 1585	artisanal Mon Tiki	3	EPIC	
-1586	perfectly mixed fancy teqiwila slammer	3	EPIC	Effect: "Powdered", Effect Duration: 15
+1586	fancy perfectly mixed teqiwila slammer	3	EPIC	Effect: "Powdered", Effect Duration: 15
 1587	moldy Knob lo mein	4	crappy	
 1588	yummy miniature enchanted asparagus lo mein	2	awesome	Effect: "Work For Hours a Week", Effect Duration: 20
 1589	rotten Knoll lo mein	4	crappy	
 1590	special normal lo mein	3	good	Effect: "Stogied", Effect Duration: 45
-1591	moldy jumbo olive lo mein	5	crappy	
-1592	enchanted normal hot hi mein	4	good	Effect: "Oth-Jeal-O", Effect Duration: 10
+1591	jumbo moldy olive lo mein	5	crappy	
+1592	normal enchanted hot hi mein	4	good	Effect: "Oth-Jeal-O", Effect Duration: 10
 1593	small decent squat hi mein	2	good	
-1594	moldy snack-sized blinking hi mein	2	crappy	
+1594	snack-sized moldy blinking hi mein	2	crappy	
 1595	bland hi mein	4	decent	
-1596	moldy fancy mirror sleazy hi mein	3	crappy	Effect: "Alpine Mintiness", Effect Duration: 50
+1596	fancy moldy mirror sleazy hi mein	3	crappy	Effect: "Alpine Mintiness", Effect Duration: 50
 1597	Junior LAAAAME merit badge of the glutton	0		Food Drop: +100, Last Available: "2006-05"
 1598	zippy Senior LAAAAME merit badge	0		Initiative: +20, Last Available: "2006-05"
 1599	pulsating olive jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	drinkable high-proof tangarita with a fly in it	8	good	
-1601	distilled enchanted artisanal mandarina colada with a fly in it	5	EPIC	Effect: "Truly Gritty", Effect Duration: 5
+1600	high-proof drinkable tangarita with a fly in it	8	good	
+1601	artisanal distilled enchanted mandarina colada with a fly in it	5	EPIC	Effect: "Truly Gritty", Effect Duration: 5
 1602	perfectly mixed prussian cathouse with a fly in it	3	EPIC	
-1603	practically non-alcoholic smooth Mae West with a fly in it	1	awesome	
+1603	smooth practically non-alcoholic Mae West with a fly in it	1	awesome	
 1604	mixed tumbling astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
 1606	powdered ghostly ultimate wad	1		
@@ -1614,12 +1614,12 @@
 1634	acceptable around the world	4	good	
 1635	scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
-1637	super-warmed quadruple-ionized squat cyan lotion of hotness	0		Effect: "Eyes All Black", Effect Duration: 46
+1637	super-warmed quadruple-ionized cyan squat lotion of hotness	0		Effect: "Eyes All Black", Effect Duration: 46
 1638	magnetized polarized pulsating lotion of coldness	0		Effect: "Chlorophyll Flavor", Effect Duration: 21
 1639	colloidal oxidized lotion of spookiness	0		Effect: "Cravin' for a Ravin'", Effect Duration: 52
 1640	ionized double-wet jittery lotion of stench	0		Effect: "Halloweeny", Effect Duration: 14
 1641	deionized narrow lotion of sleaziness	0		Effect: "Gemini Rising", Effect Duration: 29
-1642	watered-down artisanal spinning Grimacite Bock	2	EPIC	Last Available: "2008-11"
+1642	artisanal watered-down spinning Grimacite Bock	2	EPIC	Last Available: "2008-11"
 1643	adequate wedge of gray cheese	4	good	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	purple and sauce	0		
@@ -1630,7 +1630,7 @@
 1650	mirror milk of magnesium	0		
 1651	huge normal foie gras	7	good	
 1652	super-irradiated candy brain	0		Effect: "Salsa Satanica", Effect Duration: 22, Last Available: "2020-09"
-1653	Da Vinci's Socratic jewel-eyed wizard hat of Calamity Jane	0		Experience (Mysticality): 6, Critical Hit Percent: +15, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
+1653	Da Vinci's Socratic jewel-eyed wizard hat of Calamity Jane	0		Experience (Mysticality): 6, Critical Hit Percent: +15, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
 1654	squat arcane researcher's wad of Crovacite of bravery	0		Experience Percent (Mysticality): +10, Spooky Resistance: +5
 1655	inspector's Jim Carey's collar	0		Monster Level: +25, Item Drop: +15
 1656	White Citadel Satisfaction Satchel	0		
@@ -1675,7 +1675,7 @@
 1695	frozen ghostly papotion of papower	0		Effect: "You Liver", Effect Duration: 13
 1696	spoiled royal jelly taco	3	crappy	
 1697	moldy bite-sized ghostly tofu taco	1	crappy	
-1698	miniature moldy jumping bean taco	2	crappy	
+1698	moldy miniature jumping bean taco	2	crappy	
 1699	moldy immense catgut taco	8	crappy	
 1700	low-calorie flavorless goat cheese taco	1	decent	
 1701	adequate tumbling pr0n taco	3	good	
@@ -1759,7 +1759,7 @@
 1780	stiffened ram stick	0		Damage Reduction: 1
 1781	grievous enchantlers	0		Weapon Damage Percent: +50, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	pulsating knitted ram-battering staff of incineration	0		Hot Spell Damage: +50, Cold Resistance: +3
-1783	decent huge crazy Turkish delight	9	good	
+1783	huge decent crazy Turkish delight	9	good	
 1784	lightning-fast horrifying Snow Queen Crown	0		Spooky Damage: +25, Initiative: +40, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	toasty rosy-cheeked healthy ga-ga radio	0		Maximum HP Percent: 50, Hot Damage: +5
 1786	six pack of Mountain Stream	0		
@@ -1822,10 +1822,10 @@
 1843	left fifth rib	0		
 1844	left sixth rib	0		
 1845	tumbling left seventh rib	0		
-1846	huge cyan left eighth rib	0		
+1846	cyan huge left eighth rib	0		
 1847	squat left ninth rib	0		
 1848	maroon left tenth rib	0		
-1849	ghostly green left eleventh rib	0		
+1849	green ghostly left eleventh rib	0		
 1850	left twelfth rib	0		
 1851	right first rib	0		
 1852	right second rib	0		
@@ -1874,7 +1874,7 @@
 1895	left fourth rear claw	0		
 1896	right first rear claw	0		
 1897	jittery right second rear claw	0		
-1898	purple bouncing shaking right third rear claw	0		
+1898	shaking purple bouncing right third rear claw	0		
 1899	narrow right fourth rear claw	0		
 1900	1-ball of the detective	0		Item Drop: +20
 1901	Van der Graaf Oprah's 2-ball	0		Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7
@@ -1883,7 +1883,7 @@
 1904	squat inspector's toasty 5-ball	0		Hot Damage: +5, Item Drop: +15
 1905	stiffened smartaleck's 6-ball	0		Moxie Percent: +30, Damage Reduction: 1
 1906	frosty 7-ball	0		Cold Spell Damage: +10
-1907	ghostly jittery 8-ball	0		
+1907	jittery ghostly 8-ball	0		
 1910	stiffened clockwork sword of the overflowing toilet of the glutton	0		Damage Reduction: 1, Stench Spell Damage: +50, Food Drop: +100
 1911	Usain Bolt's chilly wholesome clockwork staff	0		Maximum HP Percent: +10, Cold Damage: +5, Initiative: +80
 1912	zippy flame-wreathed Lo Pan's clockwork crossbow	0		Spell Critical Percent: +30, Hot Spell Damage: +10, Initiative: +20
@@ -1924,7 +1924,7 @@
 1947	baleful worn tophat of the scaredy-cat	0		Spell Damage: +25, Monster Level: -15, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	wool ribald tap shoes	0		Sleaze Damage: +10, Cold Resistance: +1, Single Equip
 1949	massive decent Manetwich	7	good	
-1950	huge bouncing purple bottle of Vangoghbitussin	0		
+1950	purple huge bouncing bottle of Vangoghbitussin	0		
 1951	artisanal bottle of Pinot Renoir	4	EPIC	
 1952	moldy low-calorie pulsating desiccated apricot	1	crappy	
 1953	delicious flute of flat champagne	3	awesome	
@@ -1959,7 +1959,7 @@
 1982	MagiMechTech MicroMechaMech	0		
 1983	upside-down lime green hand turkey	0		
 1984	snowy owl	0		
-1985	tumbling ghostly scary death orb	0		
+1985	ghostly tumbling scary death orb	0		
 1986	mind flayer	0		
 1987	squat teal undead elbow macaroni	0		
 1988	angry cow	0		
@@ -1994,15 +1994,15 @@
 2017	spade necklace	0		
 2018	huge club necklace	0		
 2019	wobbly cream pie	0		Free Pull
-2020	decent jumbo cherry pie	5	good	
-2021	low-calorie rotten green strawberry pie	1	crappy	
+2020	jumbo decent cherry pie	5	good	
+2021	rotten low-calorie green strawberry pie	1	crappy	
 2022	fancy adequate massive upside-down lemon meringue pie	6	good	Effect: "Spell Transfer Complete", Effect Duration: 10
 2023	Genalen&trade; Bottle	1	EPIC	
-2024	flavorless diet blurry bouncing mixed wildflower greens	1	decent	
+2024	diet flavorless blurry bouncing mixed wildflower greens	1	decent	
 2025	stale handful of walnuts	4	decent	
 2026	yummy huge nutty organic salad	8	awesome	
 2027	moldy small upside-down super salad	2	crappy	
-2028	big rotten tofu wonton	5	crappy	
+2028	rotten big tofu wonton	5	crappy	
 2029	mirror hippy protest button	0		Single Equip
 2030	family-friendly gravedigger's Lockenstock&trade; sandals	0		Spooky Damage: +10, Sleaze Resistance: +1, Single Equip
 2031	Jack Frost's didgeridooka	0		Cold Spell Damage: +50
@@ -2020,8 +2020,8 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	adequate jittery brain-meltingly-hot chicken wings	3	good	
-2046	normal miniature skewed frat brats	2	good	
-2047	bite-sized adequate blurry knob ka-bobs	1	good	
+2046	miniature normal skewed frat brats	2	good	
+2047	adequate bite-sized blurry knob ka-bobs	1	good	
 2049	drinkable huge can of Swiller	3	good	
 2050	broken wings	0		
 2051	sunken eyes	0		
@@ -2055,19 +2055,19 @@
 2079	crafty Socratic makeshift turban	0		Experience (Mysticality): +1, Maximum MP: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 25"
 2080	pulsating thinker's makeshift cape	0		Mysticality: +10
 2081	makeshift skirt of the ox	0		Muscle: +20, Familiar Effect: "2xBarrr, 1xFairy, cap 25"
-2082	narrow blue toothbrush	0		
+2082	blue narrow toothbrush	0		
 2083	makeshift crane	0		
 2084	can of starch	0		
-2085	altered shaking twirling bottle of ultravitamins	1		Effect: "Waxing", Effect Duration: 10
+2085	altered twirling shaking bottle of ultravitamins	1		Effect: "Waxing", Effect Duration: 10
 2086	compressed shaking bottle of cough syrup	1		
-2087	diluted yellow blinking huge tube of hair oil	1		Effect: "Pretending to Pretend", Effect Duration: 5
+2087	diluted huge yellow blinking tube of hair oil	1		Effect: "Pretending to Pretend", Effect Duration: 5
 2088	concentrated Daffy Taffy	0		Effect: "Tasting the Rainbow", Effect Duration: 12
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	chilly coward's therapeutic arcane researcher's brainy pilgrim shield	0		Mysticality: +5, Experience Percent (Mysticality): +10, Monster Level: -20, Cold Damage: +5, HP Regen Min: 5, HP Regen Max: 7, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
 2092	hand mirror	0		
 2093	twirling olive razor-sharp hors d'oeuvre tray	0		Weapon Damage Percent: +25, Damage Reduction: 5
-2094	moldy half-sized enchanted blue ballroom blintz	2	crappy	Effect: "Arresistible", Effect Duration: 35
+2094	half-sized moldy enchanted blue ballroom blintz	2	crappy	Effect: "Arresistible", Effect Duration: 35
 2095	towel	0		
 2096	dried guy made of bee pollen	1		
 2097	17-ball of the detective	0		Item Drop: +20
@@ -2121,16 +2121,16 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	blurry toothsome rock	0		
-2149	low-calorie tasty frank	1	awesome	Last Available: "2011-12"
+2149	tasty low-calorie frank	1	awesome	Last Available: "2011-12"
 2150	decent snack-sized teal plate of franks and beans	2	good	Last Available: "2011-12"
-2151	special bad purple shot of blackberry schnapps	3	decent	Effect: "Tremella Tremens", Effect Duration: 10
+2151	bad special purple shot of blackberry schnapps	3	decent	Effect: "Tremella Tremens", Effect Duration: 10
 2152	narrow capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
-2154	bouncing narrow ion grid	0		Last Available: "2011-12"
+2154	narrow bouncing ion grid	0		Last Available: "2011-12"
 2155	twirling wobbly Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
 2157	spinning high-resistance ultrapolymer plating	0		Last Available: "2011-12"
-2158	blurry jittery servomechanical torsion facilitator	0		Last Available: "2011-12"
+2158	jittery blurry servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	computronic processing unit	0		Last Available: "2011-12"
@@ -2139,7 +2139,7 @@
 2164	recursive spline reticulator	0		Last Available: "2011-12"
 2165	jittery atomic vector plotter	0		Last Available: "2011-12"
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
-2167	blinking skewed hyperbolic plasma focuser	0		Last Available: "2011-12"
+2167	skewed blinking hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	crafty toy ray gun of the empath	0		Maximum MP: +10, Familiar Weight: +5, Last Available: "2006-12"
 2169	Fonzie's toy space helmet of chilblains	0		Experience (Moxie): +1, Cold Damage: +25, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	bouncing MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
@@ -2166,7 +2166,7 @@
 2191	book of carols	0		Last Available: "2006-12"
 2192	mirror sheet music	0		Last Available: "2006-12"
 2193	decent candy stake	4	good	Last Available: "2006-12"
-2194	mediocre practically non-alcoholic eggnog	1	decent	Last Available: "2006-12"
+2194	practically non-alcoholic mediocre eggnog	1	decent	Last Available: "2006-12"
 2195	delicious unspeakable fruitcake	3	awesome	Last Available: "2006-12"
 2196	bland gingerbread horror	3	decent	Last Available: "2006-12"
 2197	chilled cold-filtered pulsating but probably evil chocolate	0		Effect: "Barbecue Saucy", Effect Duration: 48, Last Available: "2006-12"
@@ -2189,8 +2189,8 @@
 2214	narrow tropical wrapping paper	0		Last Available: "2006-12"
 2215	huge Tropical Crimbo Hat of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
 2216	manspreader's Tropical Crimbo Shorts	0		Monster Level: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
-2217	enchanted bland huge blurry super ka-bob	8	decent	Effect: "Butt-Rock Hair", Effect Duration: 25
-2218	low-calorie normal ghostly blurry beer basted brat	1	good	
+2217	bland huge enchanted blurry super ka-bob	8	decent	Effect: "Butt-Rock Hair", Effect Duration: 25
+2218	low-calorie normal blurry ghostly beer basted brat	1	good	
 2219	mirror forbidden Tropical Crimbo Sword	0		Spell Damage Percent: +50, Last Available: "2006-12"
 2220	extra-enhanced and Crimboween candy	0		Effect: "X-Ray Vision", Effect Duration: 41, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
@@ -2229,30 +2229,30 @@
 2255	blurry lion tamer's furry turtle	0		Experience (familiar): +2, Familiar Effect: "2xPotato, 2xFairy, cap 11"
 2256	mansplainer's furry earmuffs	0		Monster Level: +15
 2257	blue scandalous clever reinforced furry underpants	0		Maximum MP: +20, Sleaze Damage: +5
-2258	shaking ghostly maroon &quot;I Love Me, Vol. I&quot;	0		
+2258	maroon shaking ghostly &quot;I Love Me, Vol. I&quot;	0		
 2259	photograph of God	0		
 2260	hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
-2263	ghostly yellow lion oil	0		
+2263	yellow ghostly lion oil	0		
 2264	yummy stunt nuts	4	awesome	
 2265	miniature moldy wet stew	2	crappy	
 2266	narrow wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	vibrating Staff of Fats	0		Maximum MP Percent: +10
-2269	yummy diet sausage wonton	1	awesome	
+2269	diet yummy sausage wonton	1	awesome	
 2270	mirror curative ruddy belt	0		Maximum HP Percent: +40, HP Regen Min: 3, HP Regen Max: 5, Single Equip
-2271	watered-down perfectly mixed bottle of Merlot	2	EPIC	
-2272	tolerable watered-down bottle of Port	2	good	
+2271	perfectly mixed watered-down bottle of Merlot	2	EPIC	
+2272	watered-down tolerable bottle of Port	2	good	
 2273	tolerable bottle of Pinot Noir	4	good	
-2274	hand-crafted weak enchanted bottle of Zinfandel	2	EPIC	Effect: "Crud&eacute;", Effect Duration: 25
+2274	hand-crafted enchanted weak bottle of Zinfandel	2	EPIC	Effect: "Crud&eacute;", Effect Duration: 25
 2275	delicious bottle of Marsala	3	awesome	
-2276	acceptable fortified special bottle of Muscat	5	good	Effect: "Berry Defensive", Effect Duration: 25
+2276	fortified acceptable special bottle of Muscat	5	good	Effect: "Berry Defensive", Effect Duration: 25
 2277	Fernswarthy's key	0		
 2278	huge spinning Fernswarthy's letter	0		
 2279	book	0		
 2280	mirror Manual of Labor	0		
-2281	twirling tumbling Manual of Transmission	0		
+2281	tumbling twirling Manual of Transmission	0		
 2282	Manual of Dexterity	0		
 2283	Newton's seal-skull helmet	0		Experience (Mysticality): +3, Familiar Effect: "atk, cap 2"
 2284	upside-down petrified noodles	0		
@@ -2260,7 +2260,7 @@
 2286	maroon Eye of Ed	0		
 2287	blinking sharpshooter's glowstick of the sewer	0		Critical Hit Percent: +10, Stench Damage: +25, Last Available: "2007-01"
 2288	encoder ring	0		Single Equip
-2289	olive huge paperclip	0		
+2289	huge olive paperclip	0		
 2290	wobbly really house	0		
 2291	Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
@@ -2314,9 +2314,9 @@
 2340	tolerable bouncing bouncing & tan	3	good	
 2341	pepper	0		
 2342	rotten forest cake	4	crappy	
-2343	jumbo stale forest ham	5	decent	
-2344	double-cold-filtered tumbling squat filthworm hatchling scent gland	0		Effect: "Emotion Sickness", Effect Duration: 37
-2345	triple-irradiated twirling pulsating filthworm drone scent gland	0		Effect: "Heart of Green", Effect Duration: 36
+2343	stale jumbo forest ham	5	decent	
+2344	double-cold-filtered squat tumbling filthworm hatchling scent gland	0		Effect: "Emotion Sickness", Effect Duration: 37
+2345	triple-irradiated pulsating twirling filthworm drone scent gland	0		Effect: "Heart of Green", Effect Duration: 36
 2346	quadruple-liquefied wet shaking filthworm royal guard scent gland	0		Effect: "Neuroplastici Tea", Effect Duration: 60
 2347	heart of the filthworm queen	0		
 2348	pulsating water pipe bomb	0		
@@ -2347,7 +2347,7 @@
 2373	rotten twirling banana	4	crappy	
 2374	banana peel	0		
 2375	rotten banana cream pie	4	crappy	
-2376	acceptable watered-down shaking banana daiquiri	2	good	
+2376	watered-down acceptable shaking banana daiquiri	2	good	
 2377	lousy bungle in the jungle	4	decent	
 2378	banana spritzer	0		
 2379	super-pressed banana smoothie	0		Effect: "Human-Machine Hybrid", Effect Duration: 44
@@ -2360,7 +2360,7 @@
 2386	twirling forbidden keg shield of horror	0		Spell Damage Percent: +50, Spooky Spell Damage: +25, Damage Reduction: 11
 2387	ghostly finger of the cheetah	0		Initiative: +60
 2388	wobbly wicked war tongs of the boozehound	0		Spell Damage: +5, Booze Drop: +100
-2389	blinking gray Monstar energy beverage	0		
+2389	gray blinking Monstar energy beverage	0		
 2390	auspicious asbestos apron	0		Item Drop: +10
 2391	beaten-up Chucks of the wise owl	0		Mysticality: +20
 2392	aromatic natty ascot	0		Stench Resistance: +1
@@ -2381,7 +2381,7 @@
 2407	pink bat eye	0		
 2408	maroon worthless piece of glass	0		
 2409	tumbling billy idol	0		
-2410	twirling wobbly rag	0		
+2410	wobbly twirling rag	0		
 2411	jittery broken petri dish	0		
 2412	tumbling sammich crust	0		
 2413	triffid bark	0		
@@ -2393,21 +2393,21 @@
 2419	corrupted bottle of rhinoceros hormones	0		Effect: "Feline Ferocity", Effect Duration: 11
 2420	electrified anodized skewed teeny-tiny magic scroll	0		Effect: "Spooky Blur", Effect Duration: 55
 2421	alkaline gray bottle of pirate juice	0		Effect: "Toothy Grin", Effect Duration: 50
-2422	improved magnetized bouncing narrow irradiated pet snacks	0		Effect: "Gunky Dory", Effect Duration: 64
+2422	improved magnetized narrow bouncing irradiated pet snacks	0		Effect: "Gunky Dory", Effect Duration: 64
 2423	polarized wobbly Mick's IcyVapoHotness Inhaler	0		Effect: "Squid Squint", Effect Duration: 27
 2424	oxidized blinking cyclops eyedrops	0		Effect: "Always In Motion", Effect Duration: 23
 2425	modified polarized mirror can of spinach	0		Effect: "Stemonitis Storm", Effect Duration: 53
 2426	dry ionized fire flower	0		Effect: "Very Clean Guns", Effect Duration: 63
-2427	ionized twirling teal freezerburned ice cube	0		Effect: "Boschface", Effect Duration: 37
+2427	ionized teal twirling freezerburned ice cube	0		Effect: "Boschface", Effect Duration: 37
 2428	unsweetened skewed ghostly pulsating fake blood	0		Effect: "Broken Bone Nubs", Effect Duration: 69
 2429	ionized fuchsia narrow Eau de Guaneau	0		Effect: "Vitamin-Maxed", Effect Duration: 27
-2430	dry energized shaking purple bag of lard	0		Effect: "Mo' Hobo", Effect Duration: 47
+2430	dry energized purple shaking bag of lard	0		Effect: "Mo' Hobo", Effect Duration: 47
 2431	non-modified bottle of Mystic Shell	0		Effect: "Fiery Spirit", Effect Duration: 24
 2432	magnetized SPF 451 lip balm	0		Effect: "Educated (Sorta)", Effect Duration: 30
 2433	aerosolized Vulcanized bottle of antifreeze	0		Effect: "Human-Insect Hybrid", Effect Duration: 63
-2434	corrupted ionized Vulcanized ghostly teal eyedrops	0		Effect: "Billiards Belligerence", Effect Duration: 13
+2434	corrupted ionized Vulcanized teal ghostly eyedrops	0		Effect: "Billiards Belligerence", Effect Duration: 13
 2435	activated blinking Dogsgotnonoz pills	0		Effect: "Steroid Boost", Effect Duration: 51
-2436	modified spinning red donkey flipbook	0		Effect: "Broken Fast", Effect Duration: 64
+2436	modified red spinning donkey flipbook	0		Effect: "Broken Fast", Effect Duration: 64
 2437	New Cloaca-Cola	0		
 2438	blue scented massage oil	0		
 2439	poltergeist-in-the-jar-o	0		
@@ -2434,12 +2434,12 @@
 2460	bouncing rosewater-soaked yak toupee	0		Stench Resistance: +3, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	enchanted spoiled bowl of Bounty-Os	3	crappy	Effect: "Mighty Shout", Effect Duration: 10
+2464	spoiled enchanted bowl of Bounty-Os	3	crappy	Effect: "Mighty Shout", Effect Duration: 10
 2465	lousy Oreille Divis&eacute;e brandy	4	decent	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
-2469	gray blurry bundle of receipts	0		
+2469	blurry gray bundle of receipts	0		
 2470	twirling cork	0		
 2471	stardust	0		
 2472	wilted lettuce	0		
@@ -2491,17 +2491,17 @@
 2518	purple Jim Carey's sawblade shield	0		Monster Level: +25, Damage Reduction: 11
 2519	perfectly mixed pulsating McMillicancuddy's Special Lager	4	EPIC	
 2520	aged practically non-alcoholic melted Jell-o shot	1	awesome	
-2521	distilled aged cruelty-free wine	5	awesome	
+2521	aged distilled cruelty-free wine	5	awesome	
 2522	lousy thistle wine	4	decent	
 2523	squat megatofu	0		
 2524	displaced fish	0		
-2525	decent miniature fish	2	good	
+2525	miniature decent fish	2	good	
 2526	flavorless fancy big fish casserole	5	decent	Effect: "New Zeal", Effect Duration: 5
-2527	normal diet fish lasagna	1	good	
+2527	diet normal fish lasagna	1	good	
 2528	bouncing filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	moldy squat gnatloaf	3	crappy	
-2530	spoiled fancy yellow gnatloaf casserole	3	crappy	Effect: "Chalky White Pallor", Effect Duration: 10
-2531	half-sized tasty gnat lasagna	2	awesome	
+2530	fancy spoiled yellow gnatloaf casserole	3	crappy	Effect: "Chalky White Pallor", Effect Duration: 10
+2531	tasty half-sized gnat lasagna	2	awesome	
 2532	huge pork	0		
 2533	flavorless pork chop sandwiches	3	decent	
 2534	bland pork casserole	3	decent	
@@ -2540,7 +2540,7 @@
 2567	Azazel's lollipop	0		
 2568	olive Azazel's tutu	0		
 2569	adjusted ant agonist	0		Effect: "Muscle Unbound", Effect Duration: 24
-2570	cyan squat ant hoe	0		Familiar Effect: "sleaze damage, meat"
+2570	squat cyan ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	blurry ant sickle	0		Familiar Effect: "spooky damage, meat"
@@ -2549,7 +2549,7 @@
 2576	purple honey-dipped locust	0		
 2577	curative strapping cactus quill	0		Muscle: +5, HP Regen Min: 3, HP Regen Max: 5
 2578	clever educational Staff of the Short Order Cook of the brute	0		Muscle Percent: +30, Experience: +1, Maximum MP: +20
-2579	special thick spoiled cactus fruit	5	crappy	Effect: "Fishy Fortification", Effect Duration: 40
+2579	thick spoiled special cactus fruit	5	crappy	Effect: "Fishy Fortification", Effect Duration: 40
 2580	olive scorching scorpion whip of the sweet-tooth	0		Hot Damage: +25, Candy Drop: +100
 2581	blurry handful of sand	0		
 2582	brick of sand	0		
@@ -2560,15 +2560,15 @@
 2587	Corporal Fennel's Lonely Clubs Club Jacket of doom	0		Spooky Spell Damage: +50
 2588	blurry toasty Private Pepper's Lonely Hearts Club Jacket	0		Hot Damage: +5
 2589	adequate pulsating hot date	3	good	
-2590	drinkable weak distilled fortified wine	2	good	
-2591	bland big tasty tart	5	decent	
+2590	weak drinkable distilled fortified wine	2	good	
+2591	big bland tasty tart	5	decent	
 2592	Knob Goblin lunchbox	0		
 2593	spoiled shaking Knob pasty	4	crappy	
 2594	delicious mirror thermos full of Knob coffee	3	awesome	
 2595	oxidized double-corrupted vacuum-sealed Ben-Gal&trade; Balm	0		Effect: "Moon-Eyed", Effect Duration: 36
 2596	leathery cat skin	0		
 2597	leathery bat skin	0		
-2598	wobbly lime green leathery rat skin	0		
+2598	lime green wobbly leathery rat skin	0		
 2599	Discount Telescope Warehouse gift certificate	0		
 2600	maroon carbonated water lily	0		
 2601	zippy miser's Staff of the Midnight Snack of chilblains	0		Cold Damage: +25, Meat Drop: +10, Initiative: +20
@@ -2589,7 +2589,7 @@
 2616	wobbly Magi-Wipes	0		
 2617	boom	0		
 2618	Fonzie's Iiti Kitty phone charm	0		Experience (Moxie): +1, Single Equip
-2619	narrow fuchsia jar of swamp gas	0		Last Available: "2007-05"
+2619	fuchsia narrow jar of swamp gas	0		Last Available: "2007-05"
 2620	adequate blurry unidentified jerky	3	good	
 2621	Fonzie's boxer's nasty rat mask	0		Muscle Percent: +10, Experience (Moxie): +1, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	rosewater-soaked ratskin belt of the cougar	0		Moxie: +20, Stench Resistance: +3, Single Equip
@@ -2622,16 +2622,16 @@
 2649	Lord Spookyraven's ear trumpet of the wise owl	0		Mysticality: +20, Single Equip
 2650	ghostly bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	low-calorie yummy S.T.L.T.	1	awesome	Last Available: "2007-06"
-2653	normal tiny honey-dew	1	good	Last Available: "2007-06"
+2652	yummy low-calorie S.T.L.T.	1	awesome	Last Available: "2007-06"
+2653	tiny normal honey-dew	1	good	Last Available: "2007-06"
 2654	high-proof hand-crafted lime green Xanadian	7	EPIC	Last Available: "2007-06"
 2655	triple-deionized boiled dry bottle of absinthe	0		Effect: "Fire Inside", Effect Duration: 30, Last Available: "2007-06"
 2656	Drowsy Sword of the businessman of the cheetah	0		Meat Drop: +50, Initiative: +60
 2657	normal escargotsicle	3	good	Last Available: "2007-06"
 2658	hand-crafted bottle of realpagne	3	EPIC	Last Available: "2007-06"
 2659	yellow studded albatross necklace	0		Damage Absorption: +80, Single Equip, Last Available: "2007-06"
-2660	mixed squat narrow not-a-pipe	1	good	Last Available: "2007-06"
-2661	practically non-alcoholic perfectly mixed flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
+2660	mixed narrow squat not-a-pipe	1	good	Last Available: "2007-06"
+2661	perfectly mixed practically non-alcoholic flask of Amontillado	1	super ultra mega turbo EPIC	Last Available: "2007-06"
 2662	twirling educational ball mask	0		Experience: +1, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
 2663	blue Sherlock's Can-Can skirt	0		Item Drop: +25, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	boiled extra-polymerized flattened huge sensitive poetry journal	0		Effect: "Adventurer's Best Friendship", Effect Duration: 65, Last Available: "2007-06"
@@ -2639,9 +2639,9 @@
 2666	quadruple-altered narrow bellhop bell	0		Effect: "Celestial Body", Effect Duration: 48, Last Available: "2007-06"
 2667	ionized liquefied triple-frozen huge spiky collar	0		Effect: "Texas Elegance", Effect Duration: 26, Last Available: "2007-06"
 2668	modified can-can-in-a-can	1		Last Available: "2007-06"
-2669	pickled blue squat patent antipsychotics	1		Last Available: "2007-06"
+2669	pickled squat blue patent antipsychotics	1		Last Available: "2007-06"
 2670	modified red Mariner's Friend cough drops	1		Last Available: "2007-06"
-2671	weak lousy shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
+2671	lousy weak shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
 2672	yellow library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	polarized bottle of cat tonic	0		Effect: "Mathematically Precise", Effect Duration: 29, Last Available: "2007-06"
@@ -2674,7 +2674,7 @@
 2701	clever Newton's duct tape sword	0		Experience (Mysticality): +3, Maximum MP: +20
 2702	dog trainer's Fonzie's duct tape dockers	0		Experience (Moxie): +1, Experience (familiar): +1, Familiar Effect: "1xPotato, 1xGhuol, cap 48"
 2703	olive wholesome duct tape buckler	0		Maximum HP Percent: +10, Damage Reduction: 12
-2704	green narrow shrinking powder	0		
+2704	narrow green shrinking powder	0		
 2705	blue Tesla resourceful blackberry slippers of the detective	0		Maximum MP: +50, Item Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 2706	green Van der Graaf groovy blackberry moccasins of chilblains	0		Moxie Percent: +10, Cold Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip
 2707	curative boxer's stylish blackberry combat boots	0		Moxie: +25, Muscle Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip
@@ -2696,25 +2696,25 @@
 2723	huge olive bouncing hale Staff of the Grand Flamb&eacute; of chilblains of the detective	0		Maximum HP: +20, Cold Damage: +25, Item Drop: +20
 2724	rotten bowl of rye sprouts	4	crappy	
 2725	bland squat upside-down cob of corn	4	decent	
-2726	bland snack-sized juniper berries	2	decent	
+2726	snack-sized bland juniper berries	2	decent	
 2727	huge adequate huge plum	9	good	
 2728	flavorless tumbling pear	3	decent	
-2729	spoiled super-sized fancy green peach	5	crappy	Effect: "Educated (Kinda)", Effect Duration: 20
+2729	super-sized spoiled fancy green peach	5	crappy	Effect: "Educated (Kinda)", Effect Duration: 20
 2730	delicious pulsating plum wine	3	awesome	
-2731	drinkable distilled enchanted upside-down jittery shot of pear schnapps	5	good	Effect: "Muddled", Effect Duration: 35
-2732	lousy triple-distilled shot of peach schnapps	10	decent	
+2731	drinkable enchanted distilled jittery upside-down shot of pear schnapps	5	good	Effect: "Muddled", Effect Duration: 35
+2732	triple-distilled lousy shot of peach schnapps	10	decent	
 2733	delicious massive bunch of square grapes	9	awesome	
-2734	decent miniature brown sugar cane	2	good	
+2734	miniature decent brown sugar cane	2	good	
 2735	bland skewed sandwich of the gods	4	decent	
 2736	practically non-alcoholic bad Pan-Dimensional Gargle Blaster	1	decent	
 2737	denatured blinking leopard-print barbell	1	decent	
 2738	shaking pile of smoking rags	0		
 2739	liquefied squat panty raider camouflage	0		Effect: "Spooky Demeanor", Effect Duration: 31
 2740	upside-down fireproof stiffened Staff of the Walk-In Freezer of Flo-Jo	0		Damage Reduction: 1, Hot Resistance: +3, Initiative: +100
-2741	acceptable irresponsibly strong boilermaker	6	good	
+2741	irresponsibly strong acceptable boilermaker	6	good	
 2742	flavorless steel lasagna	4	quest	
 2743	mediocre blinking steel margarita	4	quest	
-2744	distilled pulsating tumbling steel-scented air freshener	1		
+2744	distilled tumbling pulsating steel-scented air freshener	1		
 2745	modified colloidal gremlin mutagen	0		Effect: "Faboooo", Effect Duration: 59
 2746	ionized polarized extra-potent gremlin mutagen	0		Effect: "Holiday Bliss", Effect Duration: 46
 2747	squat chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2738,8 +2738,8 @@
 2765	blue Harold's bell	0		
 2766	bowling ball	0		
 2767	moldy Crimbo pie	3	crappy	
-2768	half-sized decent pear tart	2	good	
-2769	delicious small peach pie	2	awesome	
+2768	decent half-sized pear tart	2	good	
+2769	small delicious peach pie	2	awesome	
 2770	cold-filtered irradiated wobbly chunk of rock salt	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 16
 2771	vacuum-sealed deionized handful of pine needles	0		Effect: "Held Closer", Effect Duration: 64
 2772	steamy ruby	0		
@@ -2776,7 +2776,7 @@
 2803	jug of Gnomochloric acid	0		
 2804	improved oxidized vial of hamethyst juice	0		Effect: "Big Punkin'", Effect Duration: 49
 2805	oxidized vial of baconstone juice	0		Effect: "Funky Coal Patina", Effect Duration: 51
-2806	extra-alkaline narrow mirror pulsating vial of porquoise juice	0		Effect: "Nutrient-Rich", Effect Duration: 27
+2806	extra-alkaline mirror narrow pulsating vial of porquoise juice	0		Effect: "Nutrient-Rich", Effect Duration: 27
 2807	liquefied blurry flask of hamethyst juice	0		Effect: "Psalm of Pointiness", Effect Duration: 60
 2808	quantum irradiated flask of baconstone juice	0		Effect: "Kindly Resolve", Effect Duration: 57
 2809	ionized flask of porquoise juice	0		Effect: "French Bronilla Brogueishness", Effect Duration: 65
@@ -2802,17 +2802,17 @@
 2829	squat really dense meat stack	0		
 2830	digital key lime	0		
 2831	star key lime	0		
-2832	fancy stale narrow digital key lime pie	3	decent	Effect: "Bootyliciousness", Effect Duration: 35
-2833	miniature delicious star key lime pie	2	awesome	
-2834	huge lard-coated studded Samson's bottle-rocket crossbow	0		Experience (Muscle): +5, Damage Absorption: +80, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2832	stale fancy narrow digital key lime pie	3	decent	Effect: "Bootyliciousness", Effect Duration: 35
+2833	delicious miniature star key lime pie	2	awesome	
+2834	huge lard-coated studded Samson's bottle-rocket crossbow	0		Experience (Muscle): +5, Damage Absorption: +80, Sleaze Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	tumbling wobbly MacGyver's indie comic hipster glasses	0		Maximum MP: +100, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	bouncing mint-condition magic wand	0		Last Available: "2011-12"
 2838	bouncing sharpshooter's glowstick of doom	0		Critical Hit Percent: +10, Spooky Spell Damage: +50, Last Available: "2007-08"
 2839	Periodical Paintbrush of Leguizamo	0		Monster Level: +20, Softcore Only
-2840	practically non-alcoholic acceptable bottle of cooking sherry	1	good	
+2840	acceptable practically non-alcoholic bottle of cooking sherry	1	good	
 2841	rotten packet of ketchup	3	crappy	
-2842	tolerable watered-down accidental cider	2	good	
+2842	watered-down tolerable accidental cider	2	good	
 2843	rotten dire fudgesicle	4	crappy	
 2844	twirling energetic shellacked smooth navel ring of navel gazing of Tarzan	0		Moxie: +15, Experience (Muscle): +3, Damage Reduction: 7, Maximum MP Percent: +20, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
@@ -2911,13 +2911,13 @@
 2938	upside-down Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	adequate Surprise Egg	4	good	
-2941	extra-pressed wobbly bouncing Steal This Candy	0		Effect: "Brother Smothers's Blessing", Effect Duration: 32
+2941	extra-pressed bouncing wobbly Steal This Candy	0		Effect: "Brother Smothers's Blessing", Effect Duration: 32
 2942	altered diffused lime green chocolate filthy lucre	0		Effect: "Happy Trails", Effect Duration: 12
 2943	Vulcanized Angry Farmer's Wife Candy	0		Effect: "Natural 20", Effect Duration: 16
 2945	greasy party hat of the businessman	0		Sleaze Spell Damage: +10, Meat Drop: +50, Familiar Effect: "4xLep, cap 7"
-2946	healthy V for Vivala mask of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	healthy V for Vivala mask of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
-2948	practically non-alcoholic aged shot of rotgut	1	awesome	
+2948	aged practically non-alcoholic shot of rotgut	1	awesome	
 2949	chilled concentrated jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Extra-Wet", Effect Duration: 42
 2950	Cap'm Caronch's Map	0		
 2951	Orcish Frat House blueprints	0		
@@ -2925,21 +2925,21 @@
 2953	huge charrrm bracelet	0		
 2954	tip jar of doom	0		Spooky Spell Damage: +50
 2955	normal gray yam candy	4	good	
-2956	huge olive ghostly cocktail napkin	0		
+2956	huge ghostly olive cocktail napkin	0		
 2957	wobbly rum barrel charrrm	0		
 2958	tasty big tube of cranberry Go-Goo	5	awesome	
 2959	curative rum barrel charrrm bracelet	0		HP Regen Min: 3, HP Regen Max: 5
-2960	bland massive single-serving herbal stuffing	10	decent	
+2960	massive bland single-serving herbal stuffing	10	decent	
 2961	half-sized decent packet of tofurkey gravy	2	good	
-2962	special adequate tofurkey nugget	3	good	Effect: "Hopped Up on Goofballs", Effect Duration: 45
+2962	adequate special tofurkey nugget	3	good	Effect: "Hopped Up on Goofballs", Effect Duration: 45
 2963	rigging shampoo	0		
 2964	mirror ball polish	0		
 2965	mirror mizzenmast mop	0		
 2966	pulsating Tom's of the Spanish Main Toothpaste	0		
 2967	diffused vacuum-sealed huge Swabbie&trade; swab	0		Effect: "Rotten Memories", Effect Duration: 69
 2968	triple-moist extra-pressed Oil of Parrrlay	0		Effect: "Jammin'", Effect Duration: 38
-2969	snack-sized toothsome creamsicle	2	awesome	
-2970	lousy distilled teal cream stout	5	decent	
+2969	toothsome snack-sized creamsicle	2	awesome	
+2970	distilled lousy teal cream stout	5	decent	
 2971	maroon medical-grade groovy curmudgel	0		Moxie Percent: +10, HP Regen Min: 7, HP Regen Max: 10
 2972	grumpy man charrrm	0		
 2973	grumpy man charrrm bracelet of the glutton	0		Food Drop: +100, Single Equip
@@ -2962,7 +2962,7 @@
 2990	frosty sinister clingfilm cap	0		Spell Damage: +10, Cold Spell Damage: +10, Familiar Effect: "1xVolley, cap 37"
 2991	ghostly wool clingfilm slippers	0		Cold Resistance: +1, Single Equip
 2992	clingfilm tangle	0		
-2993	flavorless enchanted jumbo vinegar-soaked lemon slice	5	decent	Effect: "The Magic of LOV", Effect Duration: 30
+2993	jumbo flavorless enchanted vinegar-soaked lemon slice	5	decent	Effect: "The Magic of LOV", Effect Duration: 30
 2994	super-adjusted polarized true grit	0		Effect: "Lemon Enlightenment", Effect Duration: 30
 2995	knitted buoybottoms of Calamity Jane of Flo-Jo	0		Critical Hit Percent: +15, Cold Resistance: +3, Initiative: +100, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	upside-down mansplainer's grungy flannel shirt	0		Monster Level: +15
@@ -2974,7 +2974,7 @@
 3002	upside-down extremely unsafe lam&eacute; pants	0		Weapon Damage Percent: +100, Familiar Effect: "2xPotato, 1xLep, cap 25"
 3003	olive brainy enormous hoop earring	0		Mysticality: +5
 3004	narrow blue beefy costume sword of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15
-3005	squat huge rainbow pearl	0		Last Available: "2007-12"
+3005	huge squat rainbow pearl	0		Last Available: "2007-12"
 3006	knitted Samson's rainbow pearl earring	0		Experience (Muscle): +5, Cold Resistance: +3, Single Equip, Last Available: "2007-12"
 3007	shaking upside-down hardy rainbow pearl necklace of the storm	0		Maximum HP: +50, Maximum MP Percent: +40, Single Equip, Last Available: "2007-12"
 3008	avaricious savvy rainbow pearl ring	0		Mysticality Percent: +20, Meat Drop: +30, Single Equip, Last Available: "2007-12"
@@ -2995,16 +2995,16 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	tolerable corpse on the beach	3	good	
-3026	fancy lousy corpsetini	4	decent	Effect: "Staying Frosty", Effect Duration: 10
+3026	lousy fancy corpsetini	4	decent	Effect: "Staying Frosty", Effect Duration: 10
 3027	drinkable corpsedriver	3	good	
 3028	drinkable Corpse Island iced tea	3	good	
-3029	hand-crafted practically non-alcoholic bouncing olive red-headed corpse	1	super EPIC	
-3030	special mediocre practically non-alcoholic squat kamicorpse-ee	1	decent	Effect: "Fruited", Effect Duration: 20
+3029	practically non-alcoholic hand-crafted olive bouncing red-headed corpse	1	super EPIC	
+3030	special practically non-alcoholic mediocre squat kamicorpse-ee	1	decent	Effect: "Fruited", Effect Duration: 20
 3031	artisanal corpsel	3	EPIC	
 3032	fortified hand-crafted corpsebite	5	EPIC	
 3033	MacGyver's pirate fledges	0		Maximum MP: +100
 3034	piece of thirteen	0		
-3035	stale bite-sized pearl onion	1	decent	
+3035	bite-sized stale pearl onion	1	decent	
 3036	delicious sea biscuit	3	awesome	
 3037	perfectly mixed teal bottle of rum	3	EPIC	
 3038	practically non-alcoholic aged fuchsia bottle of black-label rum	1	awesome	
@@ -3016,9 +3016,9 @@
 3044	skewed metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
 3045	rotten nanite-infested gingerbread bugbear	4	crappy	Last Available: "2007-12"
 3046	adequate nanite-infested candy cane	3	good	Last Available: "2020-09"
-3047	stale low-calorie squat nanite-infested fruitcake	1	decent	Last Available: "2007-12"
-3048	tolerable high-proof nanite-infested eggnog	9	good	Last Available: "2007-12"
-3049	fuchsia pulsating El Vibrato power sphere	0		
+3047	low-calorie stale squat nanite-infested fruitcake	1	decent	Last Available: "2007-12"
+3048	high-proof tolerable nanite-infested eggnog	9	good	Last Available: "2007-12"
+3049	pulsating fuchsia El Vibrato power sphere	0		
 3050	eyepatch of temperance	0		Sleaze Resistance: +5, Familiar Effect: "spooky atk, 1xBarrr"
 3051	MacGyver's cutlass	0		Maximum MP: +100
 3052	breeches of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "stench atk, 1xPotato"
@@ -3048,7 +3048,7 @@
 3076	jittery laser targeting chip	0		Last Available: "2007-12"
 3077	blurry upside-down hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	narrow Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	narrow Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	ghostly teddy borg	0		Last Available: "2007-12"
 3081	sage marionette collective	0		Mysticality Percent: +10, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3130,7 +3130,7 @@
 3158	sparking El Vibrato drone	0		
 3159	energized ionized warm El Vibrato drone	0		Effect: "Simulation Stimulation", Effect Duration: 52
 3160	enhanced super-improved teal humming El Vibrato drone	0		Effect: "Memories of Puppy Love", Effect Duration: 36
-3161	unsweetened oxidized double-nitrogenated upside-down lime green El Vibrato drone	0		Effect: "Chow Downed", Effect Duration: 20
+3161	unsweetened oxidized double-nitrogenated lime green upside-down El Vibrato drone	0		Effect: "Chow Downed", Effect Duration: 20
 3162	El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
 3163	green El Vibrato energy spear	0		
 3164	blinking El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
@@ -3138,18 +3138,18 @@
 3166	skewed repaired El Vibrato drone	0		
 3167	skewed augmented El Vibrato drone	0		
 3168	super-adjusted tarnished seal eyeball	0		Effect: "Permanent Halloween", Effect Duration: 45
-3169	moldy special narrow turtle soup	3	crappy	Effect: "[598]A Little Bit Evil", Effect Duration: 25
+3169	special moldy narrow turtle soup	3	crappy	Effect: "[598]A Little Bit Evil", Effect Duration: 25
 3170	evil noodles	0		
 3171	gray nauseating reagent	0		
 3172	spinning asbestos-lined evil paper umbrella	0		Hot Resistance: +5
 3173	denatured pickled evil vihuela	0		Effect: "The Solution", Effect Duration: 22
-3174	rotten tiny tumbling evil boring spaghetti	1	crappy	
+3174	tiny rotten tumbling evil boring spaghetti	1	crappy	
 3175	spoiled ghostly evil noodles	4	crappy	
-3176	flavorless half-sized skewed evil noodles	2	decent	
-3177	spoiled small evil painful penne pasta	2	crappy	
-3178	special flavorless 3vi1 pr0n m4nic0tti	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15
-3179	yummy special snack-sized skewed evil ravioli della hippy	2	awesome	Effect: "Yet tea", Effect Duration: 30
-3180	yummy diet evil noodles	1	awesome	
+3176	half-sized flavorless skewed evil noodles	2	decent	
+3177	small spoiled evil painful penne pasta	2	crappy	
+3178	flavorless special 3vi1 pr0n m4nic0tti	3	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 15
+3179	snack-sized yummy special skewed evil ravioli della hippy	2	awesome	Effect: "Yet tea", Effect Duration: 30
+3180	diet yummy evil noodles	1	awesome	
 3181	concentrated deionized anodized huge evil potion of potency	0		Effect: "Hoity Toity", Effect Duration: 67
 3182	non-dry spinning evil libation of liveliness	0		Effect: "Feeling No Pain", Effect Duration: 24
 3183	colloidal evil tomato juice of powerful power	0		Effect: "Super Speed", Effect Duration: 39
@@ -3159,9 +3159,9 @@
 3187	unsweetened evil philter of phorce	0		Effect: "Scavengers Scavenging", Effect Duration: 40
 3188	artisanal cyan an evil sump'm sump'm	3	EPIC	
 3189	acceptable evil ducha de oro	4	good	
-3190	fancy smooth evil horizontal tango	3	awesome	Effect: "Mana Tea", Effect Duration: 30
-3191	tolerable weak evil roll in the hay	2	good	
-3192	pulsating teal naughty origami kit	0		Last Available: "2008-02"
+3190	smooth fancy evil horizontal tango	3	awesome	Effect: "Mana Tea", Effect Duration: 30
+3191	weak tolerable evil roll in the hay	2	good	
+3192	teal pulsating naughty origami kit	0		Last Available: "2008-02"
 3193	skewed tumbling naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	twirling cyan origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	maroon naughty paper shuriken	0		Last Available: "2008-02"
@@ -3197,7 +3197,7 @@
 3225	lousy bottle of sewage schnapps	4	decent	
 3226	weak mediocre bottle of Ooze-O	2	decent	
 3227	normal super-sized skewed C.H.U.M. chum	5	good	
-3228	immense spoiled pulsating cyan unfortunate dumplings	9	crappy	
+3228	spoiled immense pulsating cyan unfortunate dumplings	9	crappy	
 3229	decaying goldfish liver	0		
 3230	quadruple-magnetized oil of oiliness	0		Effect: "You Know Where to Go", Effect Duration: 68
 3231	stiffened tattered paper crown	0		Damage Reduction: 1, Familiar Effect: "1xSombrero, cap 15"
@@ -3240,9 +3240,9 @@
 3268	non-electrified flattened handful of Crotchety Pine needles	0		Effect: "New and Improved", Effect Duration: 27
 3269	magnetized mirror lump of Saccharine Maple sap	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 60
 3270	triple-boiled handful of Laughing Willow bark	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 66
-3271	green resourceful crotchety pants	0		Maximum MP: +50, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	green resourceful crotchety pants	0		Maximum MP: +50, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	smelly Saccharine Maple pendant	0		Stench Spell Damage: +10, Conditional Skill (Equipped): "Spray Sap"
-3273	green hardened willowy bonnet	0		Damage Reduction: 3, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	green hardened willowy bonnet	0		Damage Reduction: 3, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	black-and-blue light	0		Last Available: "2008-04"
@@ -3252,7 +3252,7 @@
 3280	personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	jittery beefy stick-on eyebrow piercing	0		Muscle: +10, Last Available: "2008-04"
-3283	super-sized special tasty salad	5	awesome	Effect: "Nano-juiced", Effect Duration: 50
+3283	special super-sized tasty salad	5	awesome	Effect: "Nano-juiced", Effect Duration: 50
 3284	nasty C.H.U.M. lantern of Leguizamo	0		Monster Level: +20, Stench Damage: +5
 3285	manspreader's C.H.U.M. knife	0		Monster Level: +10
 3286	Newton's Frosty's snowball sack	0		Experience (Mysticality): +3
@@ -3291,7 +3291,7 @@
 3319	stylish Mr. Joe's bangles	0		Moxie: +25, Single Equip
 3320	clever frayed rope belt	0		Maximum MP: +20, Single Equip
 3321	gray packet of mayfly bait	0		Last Available: "2008-05"
-3322	pulsating inspector's medical-grade mayfly bait necklace	0		Item Drop: +15, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	pulsating inspector's medical-grade mayfly bait necklace	0		Item Drop: +15, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	squat Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	tolerable jar of fermented pickle juice	3	good	
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	pulsating supercharged dead guy's memento of Flo-Jo	0		Maximum MP Percent: +30, Initiative: +100, Single Equip
-3338	gigantic rotten banquet	9	crappy	
+3338	rotten gigantic banquet	9	crappy	
 3339	wobbly sharpened hubcap	0		
 3340	very caltrop	0		
 3341	The Six-Pack of Pain	0		
@@ -3333,7 +3333,7 @@
 3361	yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	diet bland mole mol&eacute;	1	decent	Last Available: "2008-06"
-3364	mediocre triple-distilled Morlock's Mark Bourbon	6	decent	Last Available: "2008-06"
+3364	triple-distilled mediocre Morlock's Mark Bourbon	6	decent	Last Available: "2008-06"
 3365	altered dry skewed Climate Colada	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 32, Last Available: "2008-06"
 3366	ionized digital underground potion	0		Effect: "Salsa Satanica", Effect Duration: 49, Last Available: "2008-06"
 3367	interesting-looking twig	0		Last Available: "2008-06"
@@ -3368,8 +3368,8 @@
 3396	blue rosy-cheeked brawny Hodgman's lobsterskin pants	0		Muscle Percent: +20, Maximum HP Percent: +30, Familiar Effect: "atk, 1xPotato"
 3397	occult Hodgman's bow tie of doom	0		Spell Damage Percent: +25, Spooky Spell Damage: +50, Single Equip
 3398	acceptable Hodgman's blanket	3	good	
-3399	lousy watered-down jar of squeeze	2	decent	
-3400	flavorless thick bowl of fishysoisse	5	decent	
+3399	watered-down lousy jar of squeeze	2	decent	
+3400	thick flavorless bowl of fishysoisse	5	decent	
 3401	triple-Vulcanized squat deadly lampshade	0		Effect: "Hood Ridin'", Effect Duration: 16
 3402	boiled unsweetened olive concentrated garbage juice	0		Effect: "Healthy Blue Glow", Effect Duration: 26
 3403	lewd playing card	0		
@@ -3386,10 +3386,10 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	corrupted liquefied maroon sterno-flavored Hob-O	0		Effect: "Chlorophyll Flavor", Effect Duration: 55
 3423	frozen corrupted frostbite-flavored Hob-O	0		Effect: "Soles of Glass", Effect Duration: 28
-3424	deionized pressed twirling squat fry-oil-flavored Hob-O	0		Effect: "Pla-see-bo", Effect Duration: 64
+3424	deionized pressed squat twirling fry-oil-flavored Hob-O	0		Effect: "Pla-see-bo", Effect Duration: 64
 3425	flattened ionized garbage-juice-flavored Hob-O	0		Effect: "Truly Gritty", Effect Duration: 16
 3426	nitrogenated vacuum-sealed twirling cyan strawberry-flavored Hob-O	0		Effect: "Sizzling with Fury", Effect Duration: 28
 3427	roll of Hob-Os	0		
@@ -3423,14 +3423,14 @@
 3456	bouncing quilted trusty torch	0		Damage Absorption: +40, Last Available: "2011-12"
 3457	cyan skewed baleful Junior Adventurer's merit badge	0		Spell Damage: +25
 3458	alkaline STYX deodorant body spray	0		Effect: "Melancholy Burden", Effect Duration: 53
-3459	irresponsibly strong drinkable white-label gin	10	good	
-3460	small spoiled tin rations	2	crappy	
+3459	drinkable irresponsibly strong white-label gin	10	good	
+3460	spoiled small tin rations	2	crappy	
 3461	olive haiku challenge map	0		
 3462	terrible poem	0		
-3463	drinkable irresponsibly strong bottle of sake	9	good	
+3463	irresponsibly strong drinkable bottle of sake	9	good	
 3464	maroon Samson's round pebble	0		Experience (Muscle): +5
-3465	flavorless gigantic Bash-&#332;s cereal	10	decent	Wiki Name: "Bash-Os cereal"
-3466	jittery Tesla healthy studded haiku katana	0		Damage Absorption: +80, Maximum HP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3465	gigantic flavorless Bash-&#332;s cereal	10	decent	Wiki Name: "Bash-Os cereal"
+3466	jittery Tesla healthy studded haiku katana	0		Damage Absorption: +80, Maximum HP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	avaricious plastic baby	0		Meat Drop: +30, Single Equip, Last Available: "2008-12"
 3469	half-sized moldy narrow blueberry-frosted king cake	2	crappy	Last Available: "2008-12"
@@ -3454,18 +3454,18 @@
 3487	rough fish scale	0		
 3488	skewed narrow pristine fish scale	0		
 3489	bland gigantic beefy fish meat	10	decent	Effect: "Fishy", Effect Duration: 5
-3490	bland snack-sized huge glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
+3490	snack-sized bland huge glistening fish meat	2	decent	Effect: "Fishy", Effect Duration: 5
 3491	stale bite-sized bouncing slick fish meat	1	decent	Effect: "Fishy", Effect Duration: 5
 3492	Jack Frost's manspreader's fish scimitar	0		Monster Level: +10, Cold Spell Damage: +50
 3493	wobbly hardy fish stick of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100
 3494	Van der Graaf personal trainer's fish bazooka	0		Experience Percent (Muscle): +10, MP Regen Min: 5, MP Regen Max: 7
 3495	deionized olive sea salt crystal	0		Effect: "Triangle, Man", Effect Duration: 13
-3496	super-warmed quantum wobbly gray bazookafish bubble gum	0		Effect: "Papowerful", Effect Duration: 31
+3496	super-warmed quantum gray wobbly bazookafish bubble gum	0		Effect: "Papowerful", Effect Duration: 31
 3497	aged bottle of Pete's Sake	3	awesome	
 3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	jumbo normal canap&eacute;s	5	good	
+3501	normal jumbo canap&eacute;s	5	good	
 3502	boiled narrow thermos of brew	1	decent	Last Available: "2011-12"
 3503	weak bad glass of brandy	2	decent	Last Available: "2011-12"
 3504	French slippers	0		
@@ -3493,7 +3493,7 @@
 3526	fireproof scratch 'n' sniff crossbow	0		Hot Resistance: +3, Last Available: "2008-11"
 3527	mutant rattlesnake egg	0		
 3528	mutant fire ant egg	0		
-3529	purple squat mutant cactus bud	0		
+3529	squat purple mutant cactus bud	0		
 3530	mutant gila monster egg	0		
 3531	cyan rattlesnake enrager	0		Familiar Weight: +5
 3532	narrow ant antidepressant	0		Familiar Weight: +5
@@ -3524,13 +3524,13 @@
 3557	yummy spinning narrow sea avocado	3	awesome	
 3558	gigantic decent sea lychee	10	good	
 3559	bland snack-sized sea tangelo	2	decent	
-3560	flavorless half-sized sea honeydew	2	decent	
+3560	half-sized flavorless sea honeydew	2	decent	
 3561	non-polarized bouncing tumbling pressurized potion of puissance	0		Effect: "Ready to Snap", Effect Duration: 47
 3562	unsweetened super-activated pressurized potion of perspicacity	0		Effect: "Bustle Hustlin'", Effect Duration: 55
 3563	cold-filtered huge pressurized potion of pulchritude	0		Effect: "Frigid Weapon", Effect Duration: 27
 3564	perfectly mixed pulsating berry-infused sake	4	EPIC	
 3565	acceptable bouncing citrus-infused sake	4	good	
-3566	strong delicious upside-down melon-infused sake	5	awesome	
+3566	delicious strong upside-down melon-infused sake	5	awesome	
 3567	slab of sponge	0		
 3568	toasty Fonzie's sponge helmet of the wise owl	0		Mysticality: +20, Experience (Moxie): +1, Hot Damage: +5, Familiar Effect: "atk, 1xFairy"
 3569	aromatic scandalous spongy shield of the early riser	0		Sleaze Damage: +5, Stench Resistance: +1, Adventures: +7, Damage Reduction: 14
@@ -3548,11 +3548,11 @@
 3581	sushi-rolling mat	0		
 3582	rotten rice	3	crappy	
 3584	flavorless twirling irradiated candy cane	3	decent	Last Available: "2008-12"
-3585	thick moldy blue ghostly huge gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
+3585	moldy thick huge ghostly blue gingerbread mutant bugbear	5	crappy	Last Available: "2008-12"
 3586	perfectly mixed oozenog	3	EPIC	Last Available: "2008-12"
 3587	improved boiled twirling sugar plum	0		Effect: "Enraged", Effect Duration: 53, Last Available: "2008-12"
 3588	polymerized sugar banana	0		Effect: "Carrrsmic", Effect Duration: 12, Last Available: "2008-12"
-3589	colloidal huge skewed sugar lime	0		Effect: "Broken Fast", Effect Duration: 17, Last Available: "2008-12"
+3589	colloidal skewed huge sugar lime	0		Effect: "Broken Fast", Effect Duration: 17, Last Available: "2008-12"
 3590	tarnished colloidal sugar cherry	0		Effect: "Human-Goblin Hybrid", Effect Duration: 46, Last Available: "2008-12"
 3591	twirling Socratic Mer-kin hookspear of extreme caution	0		Experience (Mysticality): +1, Monster Level: -25
 3592	Mer-kin takebag	0		Item Drop: +5
@@ -3573,20 +3573,20 @@
 3607	Jim Carey's aerated diving helmet of the bloodbag of mayonnaise	0		Maximum HP: +100, Monster Level: +25, Sleaze Spell Damage: +50, Adventure Underwater, Familiar Effect: "0.5xPotato"
 3608	live nautical mine	0		
 3609	bouncing das boot	0		Familiar Weight: -10, Underwater Familiar, Familiar Effect: "adventure underwater"
-3610	upside-down spinning imitation whetstone	0		
-3611	aerosolized tumbling mirror sea grease	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 50
+3610	spinning upside-down imitation whetstone	0		
+3611	aerosolized mirror tumbling sea grease	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 50
 3612	blue sturdy Crimbo crate	0		Last Available: "2008-12"
 3613	battered Crimbo Crate	0		Last Available: "2008-12"
 3614	skewed twitching claw	0		Last Available: "2008-12"
 3615	blurry rigid carapace	0		Last Available: "2008-12"
 3616	shaking pulsing flesh	0		Last Available: "2008-12"
 3617	oxidized unstable DNA	0		Effect: "Rotten Memories", Effect Duration: 22, Last Available: "2008-12"
-3618	mirror The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	mirror The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	pulsating wriggling tentacle	0		Last Available: "2008-12"
 3620	narrow mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	mirror pair of twitching claws	0		Last Available: "2008-12"
 3622	gnashing teeth	0		Last Available: "2008-12"
-3623	olive skewed chitinous pod	0		Last Available: "2008-12"
+3623	skewed olive chitinous pod	0		Last Available: "2008-12"
 3624	blinking narrow smooth parasitic claw	0		Moxie: +15, Last Available: "2008-12"
 3625	blue executive parasitic tentacles	0		Meat Drop: +40, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
 3626	auspicious parasitic headgnawer	0		Item Drop: +10, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
@@ -3602,21 +3602,21 @@
 3636	executive shellacked patent shoes	0		Damage Reduction: 7, Meat Drop: +40, Last Available: "2008-12"
 3637	MacGyver's wholesome gray bow tie	0		Maximum HP Percent: +10, Maximum MP: +100, Last Available: "2008-12"
 3638	family-friendly penguin thesaurus of the cougar	0		Moxie: +20, Sleaze Resistance: +1, Last Available: "2008-12"
-3639	half-sized normal special blob-shaped Crimbo cookie	2	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	normal special half-sized blob-shaped Crimbo cookie	2	good	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	ghostly dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	occult depleted Grimacite kneecapping stick	0		Spell Damage Percent: +25, Last Available: "2007-06"
 3645	drinkable weak tumbling canteen of wine	2	good	Last Available: "2008-12"
-3646	enchanted tiny flavorless elven <i>limbos</i> gingerbread	1	decent	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2008-12"
+3646	tiny flavorless enchanted elven <i>limbos</i> gingerbread	1	decent	Effect: "Feet of Watermelon", Effect Duration: 20, Last Available: "2008-12"
 3647	spinning jittery elven whittling knife	0		Last Available: "2008-12"
 3648	lime green magic dragonfish fry	0		
 3649	map to Madness Reef	0		
-3650	big rotten toast with jam	5	crappy	Last Available: "2008-12"
-3651	olive jittery antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3650	rotten big toast with jam	5	crappy	Last Available: "2008-12"
+3651	olive jittery antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	practically non-alcoholic delicious elven moonshine	1	awesome	Last Available: "2008-12"
-3653	gigantic spoiled knuckle sandwich	6	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	gigantic spoiled knuckle sandwich	6	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	narrow twirling brainy psycho sweater of the brute	0		Mysticality: +5, Muscle Percent: +30, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	teal hardy plastic Mob Penguin	0		Maximum HP: +50, Last Available: "2008-12"
@@ -3647,7 +3647,7 @@
 3681	bubbling tempura batter	0		
 3682	squat globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	gigantic spoiled wobbly tempura carrot	9	crappy	
+3684	spoiled gigantic wobbly tempura carrot	9	crappy	
 3685	immense stale tempura cucumber	10	decent	
 3686	adequate tempura avocado	3	good	
 3687	stale red sea broccoli	3	decent	
@@ -3666,7 +3666,7 @@
 3700	green vinyl ore	0		
 3701	map to Anemone Mine	0		
 3702	shaking marine aquamarine	0		
-3703	blurry bouncing valve wheel	0		
+3703	bouncing blurry valve wheel	0		
 3704	shaking upside-down waterlogged bootstraps	0		
 3705	censurious curative Sinatra's velcro broadsword	0		Experience (Moxie): +5, Sleaze Resistance: +3, HP Regen Min: 3, HP Regen Max: 5
 3706	Van der Graaf Oprah's velcro paddle ball of wisdom	0		Mysticality: +15, Maximum MP Percent: +50, MP Regen Min: 5, MP Regen Max: 7
@@ -3680,7 +3680,7 @@
 3714	razor-sharp deadly PVC staff of extreme caution	0		Weapon Damage: +5, Weapon Damage Percent: +25, Monster Level: -25
 3715	fuchsia scorching medical-grade brainy vinyl shield	0		Mysticality: +5, Hot Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 14
 3716	electrified rosy-cheeked beefy vinyl boots	0		Muscle: +10, Maximum HP Percent: +30, MP Regen Min: 3, MP Regen Max: 5, Single Equip
-3717	shaking blue decaying oar	0		
+3717	blue shaking decaying oar	0		
 3718	fishhook	0		
 3719	lantern	0		
 3720	decaying pole	0		
@@ -3701,8 +3701,8 @@
 3735	gray upside-down fat wallet	0		
 3736	ruddy padded handwarmer	0		Damage Absorption: +20, Maximum HP Percent: +40, Single Equip
 3737	blinking Jack Frost's quilted lighter	0		Damage Absorption: +40, Cold Spell Damage: +50
-3738	decent immense tumbling packet of beer nuts	10	good	
-3739	bouncing wobbly Boozehounds Anonymous token	0		
+3738	immense decent tumbling packet of beer nuts	10	good	
+3739	wobbly bouncing Boozehounds Anonymous token	0		
 3740	cyan handful of bees	0		
 3741	spectral jelly	0		
 3742	aerosolized wet jellyfish gel	0		Effect: "Is This Your Card?", Effect Duration: 35
@@ -3729,11 +3729,11 @@
 3765	special acceptable slug of shochu	4	good	Effect: "Speed of the Internet", Effect Duration: 45
 3766	mediocre weak bouncing bouncing screwdiver	2	decent	
 3767	lousy dew yoana lei	4	decent	
-3768	drinkable watered-down lychee chuhai	2	good	
+3768	watered-down drinkable lychee chuhai	2	good	
 3769	hand-crafted extra-dry salacious screwdiver	5	EPIC	
 3770	perfectly mixed squat dew yoana salacious lei	3	EPIC	
-3771	watered-down acceptable salacious lychee chuhai	2	good	
-3772	practically non-alcoholic delicious Alewife&trade; Ale	1	awesome	
+3771	acceptable watered-down salacious lychee chuhai	2	good	
+3772	delicious practically non-alcoholic Alewife&trade; Ale	1	awesome	
 3773	gray seaode	0		
 3774	map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
@@ -3743,7 +3743,7 @@
 3779	concentrated modified hair of the fish	0		Effect: "Hood Ridin'", Effect Duration: 29
 3780	blue wobbly ghostly shellacked nurse's hat of temperance of Flo-Jo	0		Damage Reduction: 7, Sleaze Resistance: +5, Initiative: +100, Familiar Effect: "atk"
 3781	shaking blank prescription sheet	0		
-3782	twisted skewed maroon bottle of melodramamine	1		
+3782	twisted maroon skewed bottle of melodramamine	1		
 3783	denatured upside-down bottle of extra-strength melodramamine	1		Effect: "Mer-kinny Flavor", Effect Duration: 15
 3784	blinking maroon paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
@@ -3752,7 +3752,7 @@
 3788	crumbling rat skull	0		Class: "Pastamancer"
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	jittery Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
-3800	teal pulsating aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
+3800	pulsating teal aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
 3801	crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
 3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	MacGyver's hardened fortified Mer-kin roundshield	0		Damage Absorption: +60, Damage Reduction: 17, Maximum MP: +100
@@ -3764,11 +3764,11 @@
 3809	squat Mer-kin healscroll	0		
 3810	twirling Mer-kin lockkey	0		
 3811	wobbly Mer-kin stashbox	0		
-3812	half-sized stale shaking chocolate-frosted king cake	2	decent	Last Available: "2009-06"
+3812	stale half-sized shaking chocolate-frosted king cake	2	decent	Last Available: "2009-06"
 3813	wobbly Jeselnik's plastic baby	0		Sleaze Damage: +25, Single Equip, Last Available: "2009-06"
 3815	spinning midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	enchanted stale mirror sea radish	3	decent	Effect: "Sugar, Hello", Effect Duration: 35
+3817	stale enchanted mirror sea radish	3	decent	Effect: "Sugar, Hello", Effect Duration: 35
 3818	lard-coated resourceful halibut of Flo-Jo	0		Maximum MP: +50, Sleaze Spell Damage: +25, Initiative: +100
 3819	eel sauce	0		
 3820	electrified water-polo mitt	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
@@ -3782,12 +3782,12 @@
 3828	bouncing ghostly Grandma's Map	0		
 3829	flavorless half-sized tempura radish	2	decent	
 3830	therapeutic water-polo cap	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 1xBarrr"
-3831	mediocre practically non-alcoholic Typical Tavern swill	1	decent	
-3832	practically non-alcoholic acceptable tropical swill	1	good	
-3833	weak acceptable fruity girl swill	2	good	
-3834	weak enchanted hand-crafted blended swill	2	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5
+3831	practically non-alcoholic mediocre Typical Tavern swill	1	decent	
+3832	acceptable practically non-alcoholic tropical swill	1	good	
+3833	acceptable weak fruity girl swill	2	good	
+3834	hand-crafted enchanted weak blended swill	2	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 5
 3835	shaking skewed costume wardrobe	0		Softcore Only
-3836	lard-coated Lo Pan's Sinatra's brainy Elvish sunglasses	0		Mysticality: +5, Experience (Moxie): +5, Spell Critical Percent: +30, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	lard-coated Lo Pan's Sinatra's brainy Elvish sunglasses	0		Mysticality: +5, Experience (Moxie): +5, Spell Critical Percent: +30, Sleaze Spell Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	strapping anniversary safety glass vest	0		Muscle: +5
 3838	foul-smelling anniversary burlap belt	0		Stench Damage: +10
 3839	pulsating MacGyver's anniversary balsa wood socks	0		Maximum MP: +100
@@ -3863,12 +3863,12 @@
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	imbued seal-blubber candle	0		Class: "Seal Clubber"
 3913	drinkable tumbling blended swill with a fly in it	3	good	
-3914	gray mirror turtle wax	0		
+3914	mirror gray turtle wax	0		
 3915	turtle wax shield of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 2
 3916	narrow stiffened turtle wax helmet	0		Damage Reduction: 1, Familiar Effect: "0.5xPotato, 0.5xFairy, cap 10"
 3917	cyan brainy turtle wax greaves	0		Mysticality: +5, Familiar Effect: "atk, 3xBarrr, cap 10"
 3918	reassuring meat shield	0		Spooky Resistance: +1, Damage Reduction: 3
-3919	twirling wobbly turtlemail bits	0		
+3919	wobbly twirling turtlemail bits	0		
 3920	coward's groovy turtlemail coif	0		Moxie Percent: +10, Monster Level: -20, Familiar Effect: "1xPotato, cap 20"
 3921	huge friendly Socratic turtlemail breeches	0		Experience (Mysticality): +1, Familiar Weight: +3, Familiar Effect: "3xBarrr, 1.5xFairy, cap 20"
 3922	cyan clever curative turtlemail hauberk	0		Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5
@@ -3885,7 +3885,7 @@
 3933	stylish bad-ass club of mayonnaise	0		Moxie: +25, Sleaze Spell Damage: +50, Class: "Seal Clubber"
 3934	pulsating sealbone	0		
 3935	non-frozen polymerized spinning tumbling hyperinflated seal lung	0		Effect: "Eyes of the Dragon", Effect Duration: 69
-3936	moist super-oxidized purple bouncing scrap of shadow	0		Effect: "Castaway Physique", Effect Duration: 37
+3936	moist super-oxidized bouncing purple scrap of shadow	0		Effect: "Castaway Physique", Effect Duration: 37
 3937	corrupted fustulent seal grulch	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 22
 3938	arcane researcher's club of corruption	0		Experience Percent (Mysticality): +10, Class: "Seal Clubber"
 3939	wobbly quilted corrupt club of corruption	0		Damage Absorption: +40, Class: "Seal Clubber"
@@ -3898,7 +3898,7 @@
 3946	Clan VIP Lounge invitation	0		Free Pull
 3947	Clan VIP Lounge key	0		Free Pull
 3948	Meat	0		
-3949	cyan skewed treasure chest	0		
+3949	skewed cyan treasure chest	0		
 3950	key	0		
 3951	Baron von Ratsworth	0		
 3952	twirling monocle	0		
@@ -3960,7 +3960,7 @@
 4008	twirling memory of an A	0		Last Available: "2009-06"
 4009	narrow memory of a G	0		Last Available: "2009-06"
 4010	blurry blurry memory of a T	0		Last Available: "2009-06"
-4011	skewed narrow memory of a CA base pair	0		Last Available: "2009-06"
+4011	narrow skewed memory of a CA base pair	0		Last Available: "2009-06"
 4012	ghostly memory of a CG base pair	0		Last Available: "2009-06"
 4013	memory of a CT base pair	0		Last Available: "2009-06"
 4014	squat memory of an AG base pair	0		Last Available: "2009-06"
@@ -3987,7 +3987,7 @@
 4035	maroon memory of a crystal	0		Last Available: "2009-06"
 4036	upside-down caustic slime nodule	0		
 4037	rotten massive yellow slimy sweetbreads	6	crappy	
-4038	weak bad slimy fermented bile bladder	2	decent	
+4038	bad weak slimy fermented bile bladder	2	decent	
 4039	pickled skewed slimy alveolus	1		Effect: "Big", Effect Duration: 5
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	tumbling Tesla hale pig-iron helm	0		Maximum HP: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
@@ -4022,7 +4022,7 @@
 4070	lime green essence of stench	0		Last Available: "2009-06"
 4071	upside-down essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
-4073	maroon spinning Supreme Being Glossary	0		Last Available: "2009-06"
+4073	spinning maroon Supreme Being Glossary	0		Last Available: "2009-06"
 4074	multi-pass	0		Last Available: "2009-06"
 4075	vibrating villainous scythe of the pedagogue	0		Experience: +3, Maximum MP Percent: +10, Slime Hates It: +2
 4076	squat pulsating MacGyver's baneful bandolier of the cougar	0		Moxie: +20, Maximum MP: +100, Slime Hates It: +1
@@ -4034,7 +4034,7 @@
 4082	Tesla supercharged pernicious cudgel	0		Maximum MP Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Slime Hates It: +1
 4083	moldy blurry cupcake-in-a-cup	4	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	tiny yummy skewed protein paste	1	awesome	Last Available: "2009-06"
+4085	yummy tiny skewed protein paste	1	awesome	Last Available: "2009-06"
 4086	MacGyver's supercharged cyber-mattock	0		Maximum MP Percent: +30, Maximum MP: +100, Last Available: "2009-06"
 4087	tumbling facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4080,12 +4080,12 @@
 4128	tumbling toasty clever hardened slime pants of the sewer	0		Maximum MP: +20, Hot Damage: +5, Stench Damage: +25, Familiar Effect: "atk, 1xPotato"
 4129	steel-toed beefy hardened slime belt of the pedagogue	0		Muscle: +10, Experience: +3, Damage Reduction: 9, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
-4131	boiled blinking squat boot plant	1	crappy	Last Available: "2009-06"
-4132	practically non-alcoholic perfectly mixed sham champagne	1	EPIC	Last Available: "2009-06"
+4131	boiled squat blinking boot plant	1	crappy	Last Available: "2009-06"
+4132	perfectly mixed practically non-alcoholic sham champagne	1	EPIC	Last Available: "2009-06"
 4133	denatured non-activated tempura air	0		Effect: "Pill Power", Effect Duration: 60
 4134	triple-modified bouncing pressurized potion of pneumaticity	0		Effect: "Ooh, Umami!", Effect Duration: 22
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	bouncing dog trainer's Van der Graaf energetic Bag o' Tricks of the businessman	0		Maximum MP Percent: +20, Experience (familiar): +1, Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	bouncing dog trainer's Van der Graaf energetic Bag o' Tricks of the businessman	0		Maximum MP Percent: +20, Experience (familiar): +1, Meat Drop: +50, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	tumbling slime stack	0		
 4138	a rumpled paper strip	0		
 4139	skewed a creased paper strip	0		
@@ -4110,7 +4110,7 @@
 4158	shaking rock	0		Last Available: "2009-09"
 4159	rock lobster	0		Last Available: "2009-09"
 4160	lousy pebblebr&auml;u	3	decent	Last Available: "2009-09"
-4161	diet adequate rocky road ice cream	1	good	Last Available: "2009-09"
+4161	adequate diet rocky road ice cream	1	good	Last Available: "2009-09"
 4162	fuchsia extra-strength rubber bands	0		Familiar Weight: +5
 4163	quadruple-energized anodized children of the candy corn	0		Effect: "Toothy Grin", Effect Duration: 43
 4164	non-dry corrupted bouncing Good 'n' Slimy	0		Effect: "Inappropriate Spirit", Effect Duration: 20
@@ -4151,7 +4151,7 @@
 4199	therapeutic banded baleful sea cowboy hat	0		Spell Damage: +25, Damage Absorption: +100, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
 4201	gill rings	0		Familiar Weight: +5
-4202	shaking blinking urchin roe	0		
+4202	blinking shaking urchin roe	0		
 4203	mirror pet anemone	0		Familiar Weight: +5
 4204	squat Mer-kin cheatsheet	0		
 4205	Mer-kin wordquiz	0		
@@ -4174,7 +4174,7 @@
 4222	map to the Skate Park	0		
 4223	blinking purple squamous polyp	0		Free Pull, Last Available: "2011-12"
 4224	unspeakable lozenges	0		Familiar Weight: +5, Last Available: "2009-10"
-4225	bouncing blinking roller skate doll	0		
+4225	blinking bouncing roller skate doll	0		
 4226	clever Star of Bravery	0		Maximum MP: +20, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	fuchsia perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
@@ -4185,7 +4185,7 @@
 4233	lime green hacienda key	0		
 4234	ruddy pat&eacute; knife	0		Maximum HP Percent: +40
 4235	spinning salt-shaker	0		
-4236	wobbly tumbling green can of sterno	0		
+4236	tumbling wobbly green can of sterno	0		
 4237	rosewater-soaked cheese-slicer	0		Stench Resistance: +3
 4238	normal beef jerky	3	good	
 4239	foul-smelling pipe wrench	0		Stench Damage: +10
@@ -4196,7 +4196,7 @@
 4244	Jeselnik's leather-bound tome	0		Sleaze Damage: +25
 4245	blurry bookmark	0		
 4246	scorching ivory cue ball	0		Hot Damage: +25
-4247	delicious special decanter of fine Scotch	4	awesome	Effect: "Mushroom Melody", Effect Duration: 45
+4247	special delicious decanter of fine Scotch	4	awesome	Effect: "Mushroom Melody", Effect Duration: 45
 4248	altered expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	tumbling fisherman's sack	0		
@@ -4208,8 +4208,8 @@
 4256	galvanized sap	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 35, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	special adequate chocolate-covered scarab beetle	4	good	Effect: "Oh Snap", Effect Duration: 5, Last Available: "2009-10"
-4259	tolerable watered-down green mulled cider	2	good	Last Available: "2009-10"
-4260	mirror ghostly wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4259	watered-down tolerable green mulled cider	2	good	Last Available: "2009-10"
+4260	ghostly mirror wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4261	blue narrow pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4262	mirror mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	reassuring chaotic Ass-Stompers of Violence of the sweet-tooth	0		Spell Critical Percent: +10, Spooky Resistance: +1, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	tumbling Jeselnik's manspreader's beefy Brand of Violence	0		Muscle: +10, Monster Level: +10, Sleaze Damage: +25, Conditional Skill (Equipped): "Brand"
 4299	baleful strapping Novelty Belt Buckle of Violence of bravery	0		Muscle: +5, Spell Damage: +25, Spooky Resistance: +5, Single Equip
-4300	greedy manspreader's groovy Lens of Violence	0		Moxie Percent: +10, Monster Level: +10, Meat Drop: +20, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	greedy manspreader's groovy Lens of Violence	0		Moxie Percent: +10, Monster Level: +10, Meat Drop: +20, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	knitted slick cool Pigsticker of Violence	0		Moxie: 15, Cold Resistance: +3
-4302	pulsating zippy healthy Jodhpurs of Violence of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Initiative: +20, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	pulsating zippy healthy Jodhpurs of Violence of the bloodbag	0		Maximum HP Percent: +20, Maximum HP: +100, Initiative: +20, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	miser's toasty rock-hard Cold Stone of Hatred	0		Damage Reduction: 5, Hot Damage: +5, Meat Drop: +10, Conditional Skill (Equipped): "Chilling Grip"
 4304	greedy inspector's stiffened Girdle of Hatred	0		Damage Reduction: 1, Item Drop: +15, Meat Drop: +20, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	scorching manspreader's personal trainer's Staff of Simmering Hatred	0		Experience Percent (Muscle): +10, Monster Level: +10, Hot Damage: +25
-4306	up-at-dawn friendly electrified Pantaloons of Hatred	0		Familiar Weight: +3, Adventures: +5, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	up-at-dawn friendly electrified Pantaloons of Hatred	0		Familiar Weight: +3, Adventures: +5, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	gravedigger's stanky mansplainer's Fuzzy Slippers of Hatred	0		Monster Level: +15, Stench Spell Damage: +25, Spooky Damage: +10, Single Equip
-4308	manspreader's Sinatra's Lens of Hatred of bravery	0		Experience (Moxie): +5, Monster Level: +10, Spooky Resistance: +5, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	manspreader's Sinatra's Lens of Hatred of bravery	0		Experience (Moxie): +5, Monster Level: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	brainy Treads of Loathing of wisdom of incineration	0		Mysticality: 20, Hot Spell Damage: +50, Single Equip
 4310	lard-coated Scepter of Loathing of the dark arts of horror	0		Spell Damage Percent: +100, Spooky Spell Damage: +25, Sleaze Spell Damage: +25
 4311	wizardly beefy Belt of Loathing of horror	0		Muscle: +10, Mysticality: +25, Spooky Spell Damage: +25, Single Equip
@@ -4279,8 +4279,8 @@
 4327	upside-down inspector's double-paned Samson's La Hebilla del Cintur&oacute;n de Lopez	0		Experience (Muscle): +5, Cold Resistance: +5, Item Drop: +15, Class: "Accordion Thief", Single Equip
 4328	suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	decent miniature blinking lime green candy kneecapping stick	2	good	Last Available: "2009-12"
-4331	enchanted spoiled licorice garrote	4	crappy	Effect: "Spore-Wreathed", Effect Duration: 10, Last Available: "2009-12"
+4330	miniature decent blinking lime green candy kneecapping stick	2	good	Last Available: "2009-12"
+4331	spoiled enchanted licorice garrote	4	crappy	Effect: "Spore-Wreathed", Effect Duration: 10, Last Available: "2009-12"
 4332	teal wobbly beefy candy knuckles	0		Muscle: +10, Last Available: "2009-12"
 4333	bite-sized adequate jawbruiser	1	good	Last Available: "2010-12"
 4334	double-modified chocolate car	0		Effect: "Ginger Snapped", Effect Duration: 51, Last Available: "2009-12"
@@ -4315,7 +4315,7 @@
 4363	narrow elf resistance button	0		Last Available: "2009-12"
 4364	oxidized elven suicide capsule	0		Effect: "Bootyliciousness", Effect Duration: 47, Last Available: "2009-12"
 4365	low-calorie toothsome penguin focaccia bread	1	awesome	Last Available: "2009-12"
-4366	drinkable watered-down herringcello	2	good	Last Available: "2009-12"
+4366	watered-down drinkable herringcello	2	good	Last Available: "2009-12"
 4367	mediocre spirit-forward elven cellocello	5	decent	Last Available: "2009-12"
 4368	huge wrench handle	0		Last Available: "2009-12"
 4369	squat handful of headless bolts	0		Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	savvy peanut brittle shield	0		Mysticality Percent: +20, Damage Reduction: 3, Last Available: "2009-12"
 4390	jittery forbidden supercool Red Rover BB gun	0		Moxie Percent: +20, Spell Damage Percent: +50, Last Available: "2009-12"
-4391	wool red-and-green sweater	0		Cold Resistance: +1, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	wool red-and-green sweater	0		Cold Resistance: +1, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	blurry Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	liquefied Crimbo peppermint bark	0		Effect: "Tiki Thoughtfulness", Effect Duration: 13, Last Available: "2009-12"
 4394	modified galvanized Crimbo fudge	0		Effect: "Jelly Combed", Effect Duration: 37, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	fortified cheese sword	0		Damage Absorption: +60, Softcore Only, Last Available: "2010-01"
 4400	cheese diaper of the dark arts	0		Spell Damage Percent: +100, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	gray cheese wheel of the scaredy-cat	0		Monster Level: -15, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	Annie Oakley's cheese eye	0		Critical Hit Percent: +20, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	Annie Oakley's cheese eye	0		Critical Hit Percent: +20, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	Van der Graaf Staff of Queso Escusado of the brazier of incineration	0		Hot Spell Damage: 75, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-01"
 4405	foreign box	0		
 4406	teal The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4373,7 +4373,7 @@
 4422	inspector's sealhide belt	0		Item Drop: +15
 4423	sealhide snare	0		
 4424	jittery puzzling trophy	0		
-4425	vacuum-sealed extra-modified lime green jittery sealhide seal doll	0		Effect: "Scorpio Rising", Effect Duration: 24
+4425	vacuum-sealed extra-modified jittery lime green sealhide seal doll	0		Effect: "Scorpio Rising", Effect Duration: 24
 4426	fuchsia hymnal	0		Skill: "Canticle of Carboloading"
 4428	blinking studded glowstick on a string	0		Damage Absorption: +80
 4429	huge electrified candy necklace	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip
@@ -4406,7 +4406,7 @@
 4458	Usain Bolt's quilted snailmail coif	0		Damage Absorption: +40, Initiative: +80, Familiar Effect: "1xPotato, 1xFairy, cap 41"
 4459	aromatic greasy snailmail breeches	0		Sleaze Spell Damage: +10, Stench Resistance: +1, Familiar Effect: "1xBarrr, 0.5xFairy, cap 41"
 4460	horrifying dance instructor's snailmail hauberk	0		Experience Percent (Moxie): +10, Spooky Damage: +25
-4461	concentrated blurry teal seal-brain elixir	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 29
+4461	concentrated teal blurry seal-brain elixir	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 29
 4462	nitrogenated galvanized chocolate seal-clubbing club	0		Effect: "Wreathed in Smoke", Effect Duration: 41
 4463	diffused deionized wobbly chocolate turtle totem	0		Effect: "Sleazy Weapon", Effect Duration: 28
 4464	frozen quantum pulsating chocolate pasta spoon	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 46
@@ -4424,12 +4424,12 @@
 4476	red BRICKO oyster	0		Last Available: "2010-02"
 4477	bouncing BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	jittery BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	jittery BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	pulsating BRICKO python	0		Last Available: "2010-02"
 4481	gray BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
 4483	huge BRICKO cathedral	0		Last Available: "2010-02"
-4484	tumbling mirror BRICKO gargantuchicken	0		Last Available: "2010-02"
+4484	mirror tumbling BRICKO gargantuchicken	0		Last Available: "2010-02"
 4485	BRICKO pyramid	0		Last Available: "2010-02"
 4486	BRICKO pearl	0		Last Available: "2010-02"
 4487	foul-smelling BRICKO bulwark	0		Stench Damage: +10, Damage Reduction: 3, Last Available: "2010-02"
@@ -4437,7 +4437,7 @@
 4489	skewed gilded BRICKO brick	0		Last Available: "2010-02"
 4490	gilded BRICKO chalice	0		Last Available: "2010-02"
 4491	gray bouncing BRICKO brick	0		Last Available: "2010-02"
-4492	jittery lime green BRICKO brick	0		Last Available: "2010-02"
+4492	lime green jittery BRICKO brick	0		Last Available: "2010-02"
 4493	mirror broken BRICKO brick	0		Last Available: "2010-02"
 4494	spinning BRICKO reactor	0		Last Available: "2010-02"
 4495	mirror BRICKO egg	0		Last Available: "2010-02"
@@ -4455,8 +4455,8 @@
 4507	spinning Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	ionized irradiated &quot;DRINK ME&quot; potion	0		Effect: "Quadrilled", Effect Duration: 23, Last Available: "2010-03"
 4509	bouncing reflection of a map	0		Last Available: "2010-03"
-4510	immense decent walrus ice cream	6	good	Last Available: "2010-03"
-4511	stale massive blurry beautiful soup	8	decent	Last Available: "2010-03"
+4510	decent immense walrus ice cream	6	good	Last Available: "2010-03"
+4511	massive stale blurry beautiful soup	8	decent	Last Available: "2010-03"
 4512	eggman noodles	0		Last Available: "2010-03"
 4513	Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	delicious miniature Humpty Dumplings	2	awesome	Last Available: "2010-03"
@@ -4480,7 +4480,7 @@
 4532	decent bishop cookie	4	good	Last Available: "2010-03"
 4533	spoiled knight cookie	4	crappy	Last Available: "2010-03"
 4534	decent spinning king cookie	3	good	Last Available: "2010-03"
-4535	moldy big queen cookie	5	crappy	Effect: "Towering Strength", Last Available: "2010-03"
+4535	big moldy queen cookie	5	crappy	Effect: "Towering Strength", Last Available: "2010-03"
 4536	blurry fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	wobbly prompt insane tophat	0		Adventures: +3, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
 4538	huge gravedigger's steel-toed helm of the knight	0		Damage Reduction: 9, Spooky Damage: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
@@ -4514,9 +4514,9 @@
 4566	twirling fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	squat rosy-cheeked supercool flyest of shirts	0		Moxie Percent: +20, Maximum HP Percent: +30, Last Available: "2010-04"
 4568	super-sized stale a dance upon the palate	5	decent	Last Available: "2010-04"
-4569	yummy huge prehistoric meteorite jawbreaker	10	awesome	Last Available: "2010-04"
+4569	huge yummy prehistoric meteorite jawbreaker	10	awesome	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
-4571	snack-sized bland squirmy violent party snack	2	decent	Last Available: "2010-04"
+4571	bland snack-sized squirmy violent party snack	2	decent	Last Available: "2010-04"
 4572	chilly can-you-dig-it?	0		Cold Damage: +5, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4526,10 +4526,10 @@
 4578	olive bouncing meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	pickled enhanced unsweetened Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "The Smile of Mr. A.", Effect Duration: 61, Last Available: "2010-04"
 4580	lard-coated school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Sleaze Spell Damage: +25, Last Available: "2010-04"
-4581	deadly T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the sewer	0		Weapon Damage: +5, Stench Damage: +25, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	deadly T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger; of the sewer	0		Weapon Damage: +5, Stench Damage: +25, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	huge blinking glob of skin	0		
-4584	moldy shaking skewed six wedges of goat cheese	4	crappy	
+4584	moldy skewed shaking six wedges of goat cheese	4	crappy	
 4585	upside-down collection of objects	0		
 4586	boulder	0		
 4587	goth	0		
@@ -4538,7 +4538,7 @@
 4590	Sinatra's pixel chain whip	0		Experience (Moxie): +5, Last Available: "2010-07"
 4591	Tesla pixel morning star	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-07"
 4592	gray pixel orb	0		Last Available: "2010-07"
-4593	bouncing huge pixellated moneybag	0		Last Available: "2010-07"
+4593	huge bouncing pixellated moneybag	0		Last Available: "2010-07"
 4594	pixel cross	0		
 4595	pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
@@ -4548,9 +4548,9 @@
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
 4601	bad plastic cup of beer	4	decent	Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
-4603	mirror olive bronze handcuffs	0		Last Available: "2010-06"
+4603	olive mirror bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	family-friendly bottle of Goldschn&ouml;ckered of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +1, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	family-friendly bottle of Goldschn&ouml;ckered of the dark arts	0		Spell Damage Percent: +100, Sleaze Resistance: +1, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	normal blinking sun-dried tofu	3	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	lousy teal jittery soyburger juice	4	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4561,7 +4561,7 @@
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	yellow educational Crown of Thrones	0		Experience: +1, Softcore Only, Last Available: "2010-05"
 4615	lousy Cinco Mayo Lager	3	decent	Last Available: "2010-05"
-4616	narrow upside-down Underworld sapling	0		Last Available: "2009-10"
+4616	upside-down narrow Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
@@ -4569,12 +4569,12 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	lime green Game Grid ticket	0		Last Available: "2010-06"
 4623	polarized chocolate-covered caviar	0		Effect: "Dilated Pupils", Effect Duration: 66, Last Available: "2020-09"
-4624	delicious bite-sized pawn cookie	1	awesome	Last Available: "2010-06"
+4624	bite-sized delicious pawn cookie	1	awesome	Last Available: "2010-06"
 4625	modified coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	skewed parachute guy	0		Last Available: "2010-06"
-4629	clever plastic spider ring	0		Maximum MP: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4629	clever plastic spider ring	0		Maximum MP: +20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	Oprah's plastic kazoo	0		Maximum MP Percent: +50, Last Available: "2010-06"
 4631	huge hardy inflatable baseball bat	0		Maximum HP: +50, Last Available: "2010-06"
 4632	hardy googly-star hat of the sweet-tooth	0		Maximum HP: +50, Candy Drop: +100, Familiar Effect: "atk", Last Available: "2010-06"
@@ -4603,7 +4603,7 @@
 4655	coward's personal trainer's boxer's ironic jogging shorts	0		Muscle Percent: +10, Experience Percent (Muscle): +10, Monster Level: -20, Familiar Effect: "1xBarrr, 6xGhuol, cap 10"
 4656	skewed mole skin notebook of incineration	0		Hot Spell Damage: +50
 4657	pair of jeans	0		Last Available: "2010-09"
-4658	maroon blinking map to Ellsbury's Claim	0		Last Available: "2010-09"
+4658	blinking maroon map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	blackberry galoshes of vim and vigor	0		Maximum HP Percent: +50, Single Equip
 4660	tumbling Tesla resourceful trout fang	0		Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2010-09"
 4661	big tasty poisonous caviar	5	awesome	Last Available: "2010-09"
@@ -4619,7 +4619,7 @@
 4671	enchanted lousy booze-soaked cherry	3	decent	Effect: "Muddled", Effect Duration: 50
 4672	comfy pillow	0		
 4673	moldy gigantic marshmallow	10	crappy	
-4674	rotten miniature green sponge cake	2	crappy	
+4674	miniature rotten green sponge cake	2	crappy	
 4675	artisanal boozy yellow gin-soaked blotter paper	5	EPIC	
 4676	tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4631,7 +4631,7 @@
 4683	twirling pottery training pants of dire peril of the glutton	0		Weapon Damage: +20, Food Drop: +100, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	tumbling skewed padded pottery club	0		Damage Absorption: +20, Last Available: "2010-09"
 4685	pottery yo-yo of the sweet-tooth	0		Candy Drop: +100, Last Available: "2010-09"
-4686	blurry maroon pottery barn owl figurine	0		Last Available: "2010-09"
+4686	maroon blurry pottery barn owl figurine	0		Last Available: "2010-09"
 4687	fossilized bat skull	0		Last Available: "2010-09"
 4688	jittery shaking fossilized serpent skull	0		Last Available: "2010-09"
 4689	fossilized baboon skull	0		Last Available: "2010-09"
@@ -4643,7 +4643,7 @@
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
 4696	blurry horrifying studded Herculean Greatest American Pants	0		Experience (Muscle): +1, Damage Absorption: +80, Spooky Damage: +25, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	fuchsia fossilized necklace of temperance	0		Sleaze Resistance: +5, Last Available: "2010-09"
-4698	jittery upside-down imp air	0		
+4698	upside-down jittery imp air	0		
 4699	bus pass	0		
 4700	fossilized spike	0		Last Available: "2010-09"
 4701	squat waterlogged crate	0		Last Available: "2011-12"
@@ -4659,10 +4659,10 @@
 4711	sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	upside-down popsicle stick	0		
-4714	bite-sized rotten squat lemon popsicle	1	crappy	
+4714	rotten bite-sized squat lemon popsicle	1	crappy	
 4715	spoiled popsicle	3	crappy	
-4716	special rotten small upside-down strawberry popsicle	2	crappy	Effect: "Net Tea", Effect Duration: 25
-4717	bland snack-sized huge liver popsicle	2	decent	
+4716	small special rotten upside-down strawberry popsicle	2	crappy	Effect: "Net Tea", Effect Duration: 25
+4717	snack-sized bland huge liver popsicle	2	decent	
 4718	wobbly ruddy mariachi hat	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 2"
 4719	ghostly Hollandaise helmet of doom	0		Spooky Spell Damage: +50, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
@@ -4670,7 +4670,7 @@
 4722	flavorless huge liver and let pie	4	decent	Last Available: "2010-10"
 4723	bland badass pie	3	decent	Last Available: "2010-10"
 4724	flavorless shoo-fish pie	4	decent	Last Available: "2010-10"
-4725	adequate tiny piping organ pie	1	good	Last Available: "2010-10"
+4725	tiny adequate piping organ pie	1	good	Last Available: "2010-10"
 4726	normal shaking igloo pie	3	good	Last Available: "2010-10"
 4727	adequate stomach turnover	3	good	Last Available: "2010-10"
 4728	tasty dead lights pie	4	awesome	Last Available: "2010-10"
@@ -4684,7 +4684,7 @@
 4736	tangle of rat tails	0		
 4737	beer-soaked mop of incineration	0		Hot Spell Damage: +50
 4738	mediocre watered-down narrow day-old beer	2	decent	
-4739	practically non-alcoholic aged ghostly huge plain beer	1	awesome	
+4739	aged practically non-alcoholic ghostly huge plain beer	1	awesome	
 4740	aged practically non-alcoholic overpriced &quot;imported&quot; beer	1	awesome	
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
@@ -4692,7 +4692,7 @@
 4744	corrupted PlexiPips	0		Effect: "Floundering", Effect Duration: 59
 4745	pickled alkaline extra-frozen fuchsia Wax Flask	0		Effect: "Concentrated Concentration", Effect Duration: 69
 4746	concentrated improved bouncing Pain Dip	0		Effect: "Brain Freeze", Effect Duration: 11
-4747	tiny flavorless narrow bone meal	1	decent	Last Available: "2010-10"
+4747	flavorless tiny narrow bone meal	1	decent	Last Available: "2010-10"
 4748	bad watered-down bone aperitif	2	decent	Last Available: "2010-10"
 4749	inspector's bonerang	0		Item Drop: +15, Last Available: "2010-10"
 4750	bone and arrows of James Dean	0		Experience (Moxie): +3, Last Available: "2010-10"
@@ -4724,7 +4724,7 @@
 4810	blue Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	skewed Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	jittery Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	small flavorless blurry CRIMBCOIDS mints	2	decent	Last Available: "2011-01"
+4818	flavorless small blurry CRIMBCOIDS mints	2	decent	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	miniature adequate huge CRIMBCOLOAF	2	good	Last Available: "2011-01"
 4821	tasty half-sized circular CRIMBCOOKIE	2	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
@@ -4782,20 +4782,20 @@
 4873	wobbly photocopied monster	0		Last Available: "2011-01"
 4874	pulsating gaudy key	0		
 4875	BGE merchandise order form	0		Last Available: "2010-12"
-4876	tarnished altered mirror mirror blue chocolate bath ball	0		Effect: "Feet of Grapefruit", Effect Duration: 55, Last Available: "2011-01"
+4876	tarnished altered blue mirror mirror chocolate bath ball	0		Effect: "Feet of Grapefruit", Effect Duration: 55, Last Available: "2011-01"
 4877	concentrated skewed bacon bath ball	0		Effect: "Elemental Flavor", Effect Duration: 28, Last Available: "2011-01"
 4878	nitrogenated polymerized tarnished tumbling incense bath ball	0		Effect: "Hopped Up on Goofballs", Effect Duration: 42, Last Available: "2011-01"
 4879	irradiated red myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Here's Mud in Your Eye", Effect Duration: 43, Last Available: "2011-01"
 4880	CRIMBCO mug	0		Last Available: "2011-01"
-4881	extra-dry fancy perfectly mixed CRIMBCO wine	5	EPIC	Effect: "You Read The Manual", Effect Duration: 5, Last Available: "2011-01"
+4881	extra-dry perfectly mixed fancy CRIMBCO wine	5	EPIC	Effect: "You Read The Manual", Effect Duration: 5, Last Available: "2011-01"
 4882	shaking Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
-4884	decent small green toe jam toast	2	good	Last Available: "2011-01"
+4884	small decent green toe jam toast	2	good	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
 4886	flavorless traffic jam toast	4	decent	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	delicious small space jam toast	2	awesome	Last Available: "2011-01"
-4889	vacuum-sealed magnetized jittery purple motivational poster	0		Effect: "Spore-Wreathed", Effect Duration: 63, Last Available: "2011-01"
+4888	small delicious space jam toast	2	awesome	Last Available: "2011-01"
+4889	vacuum-sealed magnetized purple jittery motivational poster	0		Effect: "Spore-Wreathed", Effect Duration: 63, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	tumbling bath ball gift set	0		Last Available: "2011-01"
 4892	blinking slow jam collection	0		Last Available: "2011-01"
@@ -4812,7 +4812,7 @@
 4903	adhesive tape dolly of the empath	0		Familiar Weight: +5, Last Available: "2010-12"
 4904	bouncing zippy scissor duck	0		Initiative: +20, Last Available: "2010-12"
 4905	coal paperweight	0		Last Available: "2010-12"
-4906	mirror ghostly jingle bell	0		Last Available: "2010-12"
+4906	ghostly mirror jingle bell	0		Last Available: "2010-12"
 4907	pulsating smelly brawny Seven Loco	0		Muscle Percent: +20, Stench Spell Damage: +10, Last Available: "2010-09"
 4908	huge Loathing Legion knife	0		Last Available: "2011-01"
 4909	shellacked Loathing Legion many-purpose hook	0		Damage Reduction: 7, Softcore Only, Last Available: "2011-01"
@@ -4856,7 +4856,7 @@
 4953	flame-wreathed Da Vinci's whalebone corset	0		Experience (Mysticality): +5, Hot Spell Damage: +10, Single Equip
 4954	Lo Pan's oven mitts	0		Spell Critical Percent: +30, Single Equip
 4955	rotten small teal overcookie	2	crappy	
-4956	snack-sized delicious philosopher's scone	2	awesome	
+4956	delicious snack-sized philosopher's scone	2	awesome	
 4957	diffused half-baked potion	0		Effect: "Crotchety, Pining", Effect Duration: 66
 4958	squat Knob Goblin deluxe scimitar of dire peril	0		Weapon Damage: +20
 4959	bland Knob nuts	3	decent	
@@ -4923,9 +4923,9 @@
 5020	triple-ionized tobiko marble soda	0		Effect: "In Vino Vires", Effect Duration: 62, Last Available: "2011-03"
 5021	modified cyan natto marble soda	0		Effect: "Omphalotus Omnipresence", Effect Duration: 50, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
-5023	dry lime green jittery elderly jawbreaker	0		Effect: "Happy Trails", Effect Duration: 38, Last Available: "2020-09"
+5023	dry jittery lime green elderly jawbreaker	0		Effect: "Happy Trails", Effect Duration: 38, Last Available: "2020-09"
 5024	tolerable marshmallow flamb&eacute;	3	good	Last Available: "2011-03"
-5025	practically non-alcoholic lousy cranberry schnapps	1	decent	Last Available: "2011-03"
+5025	lousy practically non-alcoholic cranberry schnapps	1	decent	Last Available: "2011-03"
 5026	artisanal distilled mirror breaded beer	5	EPIC	Last Available: "2011-03"
 5027	bad soy cordial	4	decent	Last Available: "2011-03"
 5028	blinking Jeselnik's manspreader's extremely unsafe astral bludgeon	0		Weapon Damage Percent: +100, Monster Level: +10, Sleaze Damage: +25
@@ -4944,15 +4944,15 @@
 5041	squat chilly rock-hard astral shirt of the scaredy-cat	0		Damage Reduction: 5, Monster Level: -15, Cold Damage: +5
 5042	narrow brawny astral belt	0		Muscle Percent: +20, Item Drop: +5
 5043	big decent astral hot dog	5		
-5044	lousy fancy weak astral pilsner	2		Effect: "Patent Prevention", Effect Duration: 45
+5044	weak fancy lousy astral pilsner	2		Effect: "Patent Prevention", Effect Duration: 45
 5045	shaking astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
-5048	blinking teal shard of double-ice	0		Last Available: "2011-04"
+5048	teal blinking shard of double-ice	0		Last Available: "2011-04"
 5049	MacGyver's shellacked double-ice cap of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40, Maximum MP: +100, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	extremely unsafe double-ice box of Tarzan of the sweet-tooth	0		Experience (Muscle): +3, Weapon Damage Percent: +100, Candy Drop: +100, Last Available: "2011-04"
 5051	olive lard-coated manspreader's double-ice britches of the brazier	0		Monster Level: +10, Hot Spell Damage: +25, Sleaze Spell Damage: +25, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
-5052	red spinning handful of numbers	0		Last Available: "2020-09"
+5052	spinning red handful of numbers	0		Last Available: "2020-09"
 5053	narrow Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	obnoxious riddle	0		Last Available: "2011-04"
@@ -4968,7 +4968,7 @@
 5065	delicious huge blue spaghetti con calaveras	6	awesome	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	bland popcorn	4	decent	Last Available: "2011-04"
-5068	special snack-sized yummy chaos popcorn	2	awesome	Last Available: "2011-04"
+5068	snack-sized special yummy chaos popcorn	2	awesome	Last Available: "2011-04"
 5069	executive lion tamer's hole of terror	0		Experience (familiar): +2, Spooky Spell Damage: +10, Meat Drop: +40, Last Available: "2011-04"
 5070	innuendo	0		Last Available: "2011-04"
 5071	decent snack-sized blinking s'more	0	good	Last Available: "2011-04"
@@ -5002,14 +5002,14 @@
 5099	Pok&euml;mann figurine: Shoggoth of extreme caution	0		Monster Level: -25, Single Equip, Last Available: "2011-05"
 5100	chilly Pok&euml;mann figurine: Frank	0		Cold Damage: +5, Single Equip, Last Available: "2011-05"
 5101	twirling tumbling banded Pok&euml;mann figurine: Moog	0		Damage Absorption: +100, Single Equip, Last Available: "2011-05"
-5102	ionized lime green skewed willyweed	0		Effect: "Phorcefullness", Effect Duration: 66, Last Available: "2011-05"
+5102	ionized skewed lime green willyweed	0		Effect: "Phorcefullness", Effect Duration: 66, Last Available: "2011-05"
 5103	quantum energized tumbling Nuclear Blastball	0		Effect: "Insulated Trousers", Effect Duration: 22, Last Available: "2011-05"
 5104	warmed liquefied lime green fish juice box	0		Effect: "Morninja", Effect Duration: 43, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	hideous egg	0		Last Available: "2011-05"
-5107	fancy tolerable Jeppson's Malort	3	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 40, Last Available: "2011-06"
+5107	tolerable fancy Jeppson's Malort	3	good	Effect: "Stopping to Smell the Flowers", Effect Duration: 40, Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	energetic stress ball	0		Maximum MP Percent: +20, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	energetic stress ball	0		Maximum MP Percent: +20, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	veiny Ultracolor&trade; shirt	0		Maximum HP: +10, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5033,21 +5033,21 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	alkaline dry Ultrasoldier Serum	0		Effect: "Tomato Power", Effect Duration: 61, Last Available: "2011-06"
 5132	moldy elven hardtack	4	crappy	Last Available: "2011-06"
-5133	bad cyan blinking elven squeeze	4	decent	Last Available: "2011-06"
+5133	bad blinking cyan elven squeeze	4	decent	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	E.M.U. joystick	0		Last Available: "2011-06"
 5136	E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	blurry E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
-5140	dried squat blurry astral energy drink	1		
+5140	dried blurry squat astral energy drink	1		
 5141	Thwaitgold bee statuette	0		
 5142	wobbly blinking moon unit	0		Last Available: "2011-06"
 5143	E.M.U. Unit	0		Last Available: "2011-06"
 5144	maroon handful of honey	0		
 5145	quadruple-improved honeypot	0		Effect: "El Vibrations", Effect Duration: 45
-5146	delicious super-sized wild honey pie	5	awesome	
-5147	fancy smooth honey mead	3	awesome	Effect: "Afternoon Insight", Effect Duration: 40
+5146	super-sized delicious wild honey pie	5	awesome	
+5147	smooth fancy honey mead	3	awesome	Effect: "Afternoon Insight", Effect Duration: 40
 5148	smelly nippy banded honey dipper	0		Damage Absorption: +100, Cold Damage: +10, Stench Spell Damage: +10
 5149	Tesla honeybritches of wisdom of the glutton	0		Mysticality: +15, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	friendly smartaleck's cool honeycap	0		Moxie: +5, Moxie Percent: +30, Familiar Weight: +3, Familiar Effect: "1xPotato, cap 43"
@@ -5057,7 +5057,7 @@
 5154	Moonthril Longbow of doom	0		Spooky Spell Damage: +50, Last Available: "2011-06"
 5155	Moonthril Cuirass of doom	0		Spooky Spell Damage: +50, Softcore Only, Last Available: "2011-06"
 5156	plush alielf of dire peril	0		Weapon Damage: +20, Last Available: "2011-06"
-5157	aerosolized dry shaking mirror Comet Drop	0		Effect: "Twen Tea", Effect Duration: 51, Last Available: "2020-09"
+5157	aerosolized dry mirror shaking Comet Drop	0		Effect: "Twen Tea", Effect Duration: 51, Last Available: "2020-09"
 5158	rosy-cheeked plush dogcat	0		Maximum HP Percent: +30, Last Available: "2011-06"
 5159	upside-down strapping plush hamsterpus	0		Muscle: +5, Last Available: "2011-06"
 5160	experienced plush ferrelf	0		Experience: +2, Last Available: "2011-06"
@@ -5075,12 +5075,12 @@
 5172	Map to Safety Shelter Grimace Prime	0		Last Available: "2011-06"
 5173	elven magi-pack	0		Last Available: "2011-06"
 5174	perfectly mixed twirling Saison du Lune	4	EPIC	Last Available: "2011-06"
-5175	triple-distilled bad Moonthril Schnapps	8	decent	Last Available: "2011-06"
+5175	bad triple-distilled Moonthril Schnapps	8	decent	Last Available: "2011-06"
 5176	lousy Wrecked Generator	3	decent	Last Available: "2011-06"
 5177	bland Spaghetti with Moonballs	3	decent	Last Available: "2011-06"
 5178	massive stale blue Crepes a la Lune	6	decent	Last Available: "2011-06"
 5179	rotten Moon Pie	3	crappy	Last Available: "2011-06"
-5180	oxidized deionized teal jittery Comet Pop	0		Effect: "It Didn't Kill You", Effect Duration: 29, Last Available: "2011-06"
+5180	oxidized deionized jittery teal Comet Pop	0		Effect: "It Didn't Kill You", Effect Duration: 29, Last Available: "2011-06"
 5181	diffused green Flan in the Moon	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 64, Last Available: "2011-06"
 5182	improved unsweetened maroon 1/6th Pound Cake	0		Effect: "Hobo Flavor", Effect Duration: 42, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5090,10 +5090,10 @@
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	polymerized wet honey stick	0		Effect: "Spiritually Awake", Effect Duration: 31
 5189	triple-moist ionized diffused double-ice gum	0		Effect: "Chalk Outline", Effect Duration: 40, Last Available: "2011-04"
-5190	clever razor-sharp Operation Patriot Shield of the sweet-tooth	0		Weapon Damage Percent: +25, Maximum MP: +20, Candy Drop: +100, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	clever razor-sharp Operation Patriot Shield of the sweet-tooth	0		Weapon Damage Percent: +25, Maximum MP: +20, Candy Drop: +100, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	shaking teal squirming egg sac	0		Last Available: "2011-06"
 5192	wet pressed quadruple-denatured corrupted data	0		Effect: "Phorcefullness", Effect Duration: 34, Last Available: "2011-06"
-5193	huge yellow 11-inch knob sausage	0		
+5193	yellow huge 11-inch knob sausage	0		
 5194	bouncing exorcised sandwich	0		
 5195	Banfoy's Boutique Order Form	0		Last Available: "2011-07"
 5196	coward's Great S-Cape	0		Monster Level: -20, Softcore Only, Last Available: "2011-07"
@@ -5107,12 +5107,12 @@
 5204	pickled hippy paste	1	decent	Last Available: "2011-08"
 5205	pickled orc paste	1	good	Last Available: "2011-08"
 5206	vaporized demonic paste	1	EPIC	Effect: "Swimming with Sharks", Effect Duration: 25, Last Available: "2011-08"
-5207	boiled mirror huge indescribably horrible paste	1	good	Last Available: "2011-08"
+5207	boiled huge mirror indescribably horrible paste	1	good	Last Available: "2011-08"
 5208	altered paste	1	awesome	Last Available: "2011-08"
 5209	pickled shaking goblin paste	1	decent	Effect: "Bureaucratized", Effect Duration: 20, Last Available: "2011-08"
 5210	modified mirror skewed pirate paste	1	crappy	Last Available: "2011-08"
 5211	boiled huge chlorophyll paste	1	awesome	Last Available: "2011-08"
-5212	compressed twirling fuchsia paste	1	decent	Last Available: "2011-08"
+5212	compressed fuchsia twirling paste	1	decent	Last Available: "2011-08"
 5213	dehydrated jittery Mer-kin paste	1	crappy	Last Available: "2011-08"
 5214	pickled huge slimy paste	1	awesome	Effect: "Bubblin' Rage", Effect Duration: 40, Last Available: "2011-08"
 5215	twisted penguin paste	1	decent	Last Available: "2011-08"
@@ -5138,29 +5138,29 @@
 5235	quilted furry halo	0		Damage Absorption: +40, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	teal wool frosty halo	0		Cold Resistance: +1, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	olive time halo of incineration	0		Hot Spell Damage: +50, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	tolerable practically non-alcoholic wobbly huge Lumineux Limnio	1	good	Last Available: "2011-09"
+5238	practically non-alcoholic tolerable huge wobbly Lumineux Limnio	1	good	Last Available: "2011-09"
 5239	bad practically non-alcoholic gray blinking Morto Moreto	1	decent	Last Available: "2011-09"
 5240	lousy twirling Temps Tempranillo	3	decent	Last Available: "2011-09"
-5241	weak tolerable Bordeaux Marteaux	2	good	Last Available: "2011-09"
+5241	tolerable weak Bordeaux Marteaux	2	good	Last Available: "2011-09"
 5242	drinkable Fromage Pinotage	3	good	Last Available: "2011-09"
-5243	artisanal jittery pulsating Beignet Milgranet	4	EPIC	Last Available: "2011-09"
+5243	artisanal pulsating jittery Beignet Milgranet	4	EPIC	Last Available: "2011-09"
 5244	hand-crafted squat Muschat	3	EPIC	Last Available: "2011-09"
 5245	toothsome cool jelly donut	4	awesome	Last Available: "2011-09"
-5246	stale massive narrow shrapnel jelly donut	8	decent	Last Available: "2011-09"
-5247	jumbo stale occult jelly donut	5	decent	Last Available: "2011-09"
-5248	fancy moldy blinking thyme jelly donut	4	crappy	Last Available: "2011-09"
-5249	normal enchanted danish	4	good	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2011-09"
+5246	massive stale narrow shrapnel jelly donut	8	decent	Last Available: "2011-09"
+5247	stale jumbo occult jelly donut	5	decent	Last Available: "2011-09"
+5248	moldy fancy blinking thyme jelly donut	4	crappy	Last Available: "2011-09"
+5249	enchanted normal danish	4	good	Effect: "Resilient Spirit", Effect Duration: 40, Last Available: "2011-09"
 5250	stale smashed danish	3	decent	Last Available: "2011-09"
 5251	normal small jittery forbidden danish	2	good	Last Available: "2011-09"
 5252	spoiled cool cat claw	3	crappy	Last Available: "2011-09"
-5253	normal half-sized blunt cat claw	2	good	Last Available: "2011-09"
+5253	half-sized normal blunt cat claw	2	good	Last Available: "2011-09"
 5254	moldy low-calorie shadowy cat claw	1	crappy	Last Available: "2011-09"
 5255	moldy cheezburger	4	crappy	Last Available: "2011-09"
 5256	spoiled jittery toasted brie	3	crappy	Last Available: "2011-09"
 5257	tarnished potion of the field gar	0		Effect: "Yes, Can Haz", Effect Duration: 54, Last Available: "2011-09"
 5258	warmed super-modified too legit potion	0		Effect: "Full-Body Tan", Effect Duration: 23, Last Available: "2011-09"
 5259	concentrated modified blurry Bright Water	0		Effect: "Hot Buttoned", Effect Duration: 19, Last Available: "2011-09"
-5260	triple-nitrogenated yellow blinking cold-filtered water	0		Effect: "Outer Wolf&trade;", Effect Duration: 42, Last Available: "2011-09"
+5260	triple-nitrogenated blinking yellow cold-filtered water	0		Effect: "Outer Wolf&trade;", Effect Duration: 42, Last Available: "2011-09"
 5261	denatured moist narrow graveyard snowglobe	0		Effect: "Towering Strength", Effect Duration: 52, Last Available: "2011-09"
 5262	extra-ionized liquefied shaking cool cat elixir	0		Effect: "Brother Smothers's Blessing", Effect Duration: 44, Last Available: "2011-09"
 5263	corrupted irradiated potion of the captain's hammer	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 48, Last Available: "2011-09"
@@ -5199,7 +5199,7 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	snack-sized flavorless phish stick	2	decent	Last Available: "2011-09"
-5299	narrow prompt Temple Grandin's arcane researcher's plastic vampire fangs	0		Experience Percent (Mysticality): +10, Familiar Weight: +7, Adventures: +3, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	narrow prompt Temple Grandin's arcane researcher's plastic vampire fangs	0		Experience Percent (Mysticality): +10, Familiar Weight: +7, Adventures: +3, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	upside-down Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
@@ -5225,8 +5225,8 @@
 5322	perfectly mixed Ecto-Cooler	4	EPIC	Last Available: "2011-10"
 5323	bad Bartles and BRAAAINS wine cooler	3	decent	Last Available: "2011-10"
 5324	drinkable weak Blood Light	2	good	Last Available: "2011-10"
-5325	irresponsibly strong perfectly mixed Silver Bullet beer	7	EPIC	Last Available: "2011-10"
-5326	high-proof hand-crafted squat Bone's Farm &quot;wine&quot;	9	EPIC	Last Available: "2011-10"
+5325	perfectly mixed irresponsibly strong Silver Bullet beer	7	EPIC	Last Available: "2011-10"
+5326	hand-crafted high-proof squat Bone's Farm &quot;wine&quot;	9	EPIC	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	cold-filtered blinking sorority brain	0		Effect: "Heart of Yellow", Effect Duration: 68, Last Available: "2011-10"
 5329	alkaline skewed Nightstalker perfume	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 48, Last Available: "2011-10"
@@ -5242,10 +5242,10 @@
 5339	blinking rosy-cheeked thinker's The Necbromancer's Shorts of the cougar	0		Mysticality: +10, Moxie: +20, Maximum HP Percent: +30, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	blinking lightning-fast frightening energetic The Necbromancer's Wizard Staff	0		Maximum MP Percent: +20, Spooky Damage: +5, Initiative: +40, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	practically non-alcoholic perfectly mixed yellow ghostly The Cooler Out of Space	1	super ultra EPIC	Last Available: "2011-10"
+5342	practically non-alcoholic perfectly mixed ghostly yellow The Cooler Out of Space	1	super ultra EPIC	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	sorority girl's box	0		Last Available: "2011-10"
-5345	quantum concentrated blinking huge Necbro wafers	0		Effect: "Oiled Skin", Effect Duration: 42, Last Available: "2020-09"
+5345	quantum concentrated huge blinking Necbro wafers	0		Effect: "Oiled Skin", Effect Duration: 42, Last Available: "2020-09"
 5346	green death blossom	0		
 5347	A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -5340,11 +5340,11 @@
 5437	superheated fudge	0		Last Available: "2011-11"
 5438	anodized galvanized fluid of fudge-finding	0		Effect: "Ripping, Dripping", Effect Duration: 46, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	rotten miniature fudgesicle	2	crappy	Last Available: "2011-11"
+5440	miniature rotten fudgesicle	2	crappy	Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	huge miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
-5444	dry tarnished ionized fuchsia jittery devilish folio	0		Effect: "Glittering Eyelashes", Effect Duration: 11, Last Available: "2012-12"
+5444	dry tarnished ionized jittery fuchsia devilish folio	0		Effect: "Glittering Eyelashes", Effect Duration: 11, Last Available: "2012-12"
 5445	clumsiness bark	0		Last Available: "2012-12"
 5446	yellow jar full of wind	0		Last Available: "2012-12"
 5447	shaking dangerous jerkcicle	0		Last Available: "2012-12"
@@ -5358,10 +5358,10 @@
 5455	gummi ingot	0		Last Available: "2011-11"
 5456	twirling gummi ingot	0		Last Available: "2011-11"
 5457	chilled Fudgie Roll	0		Effect: "Arresistible", Effect Duration: 20, Last Available: "2011-11"
-5458	fancy adequate tumbling fudge bunny	3	good	Effect: "Bottle in front of Me", Effect Duration: 30, Last Available: "2011-11"
+5458	adequate fancy tumbling fudge bunny	3	good	Effect: "Bottle in front of Me", Effect Duration: 30, Last Available: "2011-11"
 5459	red fudge spork	0		Last Available: "2011-11"
 5460	frosty Van der Graaf brawny fudgecycle	0		Muscle Percent: +20, Cold Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-11"
-5461	shaking narrow fudge cube	0		Last Available: "2011-11"
+5461	narrow shaking fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	bouncing Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	diffused magnetized resolution: be wealthier	0		Effect: "Wax On Your Shoes", Effect Duration: 63, Last Available: "2012-01"
@@ -5376,15 +5376,15 @@
 5473	gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
-5476	extra-dry denatured wobbly narrow mirror gummi salamander	0		Effect: "Twen Tea", Effect Duration: 61, Last Available: "2011-11"
+5476	extra-dry denatured narrow wobbly mirror gummi salamander	0		Effect: "Twen Tea", Effect Duration: 61, Last Available: "2011-11"
 5477	corrupted super-Vulcanized huge gummi snake	0		Effect: "Cold Jellied", Effect Duration: 16, Last Available: "2011-11"
 5478	oxidized huge gummi canary	0		Effect: "Flaming Weapon", Effect Duration: 31, Last Available: "2011-11"
 5479	yummy olive gummi bear	4	awesome	Last Available: "2011-11"
-5480	normal purple skewed tumbling gummi bear	3	good	Last Available: "2011-11"
+5480	normal tumbling purple skewed gummi bear	3	good	Last Available: "2011-11"
 5481	bland gummi bear	4	decent	Last Available: "2011-11"
 5482	toothsome drunki-bear	4	awesome	Last Available: "2011-11"
 5483	yummy miniature drunki-bear	2	awesome	Last Available: "2011-11"
-5484	toothsome miniature drunki-bear	2	awesome	Last Available: "2011-11"
+5484	miniature toothsome drunki-bear	2	awesome	Last Available: "2011-11"
 5485	horrifying gummi bowtie	0		Spooky Damage: +25, Last Available: "2011-11"
 5486	pulsating smooth fudge pocket square	0		Moxie: +15, Last Available: "2011-11"
 5487	wobbly spinning electrified lollipop cufflinks	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
@@ -5395,7 +5395,7 @@
 5492	ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	improved pickled liquefied gummi trilobite	0		Effect: "Antibiotic Saucesphere", Effect Duration: 27, Last Available: "2011-11"
-5495	super-Vulcanized boiled blinking shaking blue gummi ammonite	0		Effect: "Jacked In", Effect Duration: 14, Last Available: "2011-11"
+5495	super-Vulcanized boiled blue blinking shaking gummi ammonite	0		Effect: "Jacked In", Effect Duration: 14, Last Available: "2011-11"
 5496	extra-pressed gummi belemnite	0		Effect: "Boon of She-Who-Was", Effect Duration: 47, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
@@ -5429,22 +5429,22 @@
 5526	unsweetened red Atomic Pop	0		Effect: "Shot in the Arse", Effect Duration: 43, Last Available: "2020-09"
 5527	narrow do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	miniature stale berries of suffering	2	decent	Last Available: "2012-12"
-5530	extra-galvanized quantum squat jittery baobab sap	0		Effect: "Sensation", Effect Duration: 27, Last Available: "2012-12"
+5529	stale miniature berries of suffering	2	decent	Last Available: "2012-12"
+5530	extra-galvanized quantum jittery squat baobab sap	0		Effect: "Sensation", Effect Duration: 27, Last Available: "2012-12"
 5531	cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	quadruple-dry fuchsia Mortimer's nostrum	0		Effect: "Flamingly Floral", Effect Duration: 36, Last Available: "2012-12"
-5534	perfectly mixed triple-distilled Barulio's bottle	10	EPIC	Last Available: "2012-12"
+5534	triple-distilled perfectly mixed Barulio's bottle	10	EPIC	Last Available: "2012-12"
 5535	aerosolized magnetized fuchsia upside-down Marvin's marvelous pill	0		Effect: "Hammered", Effect Duration: 43, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	mirror half-empty carton of milk	0		Last Available: "2012-12"
 5539	squat glass of warm water	0		Free Pull
 5540	double-improved spinning skewed desktop zen garden	0		Effect: "Mortarfied", Effect Duration: 54, Last Available: "2012-12"
-5541	upside-down green blurry Vivian's Vitamin	0		Last Available: "2012-12"
+5541	green upside-down blurry Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	dance instructor's Leapin' Trousers of doom	0		Experience Percent (Moxie): +10, Spooky Spell Damage: +50
-5544	enchanted lousy watered-down wobbly eggnog	2	decent	Effect: "Leo Rising", Effect Duration: 30, Last Available: "2012-12"
+5544	watered-down enchanted lousy wobbly eggnog	2	decent	Effect: "Leo Rising", Effect Duration: 30, Last Available: "2012-12"
 5545	small yummy hamhock	2	awesome	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
@@ -5466,58 +5466,58 @@
 5563	green Rain-Doh box	0		Last Available: "2012-02"
 5564	pulsating Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	rotten PB&BP	3	crappy	
-5566	spoiled gigantic club sandwich	9	crappy	
+5566	gigantic spoiled club sandwich	9	crappy	
 5567	big decent olive corned-beef Reuben	5	good	
 5568	narrow frayed ninja rope	0		
 5569	ghostly dull ninja crampons	0		
-5570	wobbly bouncing loose ninja carabiner	0		
+5570	bouncing wobbly loose ninja carabiner	0		
 5571	purple Groar's fur	0		
 5572	purple Thwaitgold stag beetle statuette	0		
 5573	delicious Drac & Tan	3	awesome	Last Available: "2012-03"
 5574	tolerable Transylvania Sling	3	good	Last Available: "2012-03"
 5575	acceptable Shot of the Living Dead	3	good	Last Available: "2012-03"
-5576	mediocre practically non-alcoholic jittery Buttery Knob	1	decent	Last Available: "2012-03"
+5576	practically non-alcoholic mediocre jittery Buttery Knob	1	decent	Last Available: "2012-03"
 5577	boozy aged Slippery Knob	5	awesome	Last Available: "2012-03"
-5578	extra-dry delicious Flaming Knob	5	awesome	Last Available: "2012-03"
+5578	delicious extra-dry Flaming Knob	5	awesome	Last Available: "2012-03"
 5579	bad Grasshopper	3	decent	Last Available: "2012-03"
 5580	smooth Locust	3	awesome	Last Available: "2012-03"
 5581	tolerable weak Plague of Locusts	2	good	Last Available: "2012-03"
 5582	weak mediocre red Red Dwarf	2	decent	Last Available: "2012-03"
-5583	tolerable high-proof upside-down Golden Mean	7	good	Last Available: "2012-03"
+5583	high-proof tolerable upside-down Golden Mean	7	good	Last Available: "2012-03"
 5584	aged Green Giant	3	awesome	Last Available: "2012-03"
 5585	bad Aye Aye	3	decent	Last Available: "2012-03"
 5586	triple-distilled acceptable Aye Aye, Captain	8	good	Last Available: "2012-03"
 5587	artisanal Aye Aye, Tooth Tooth	4	EPIC	Last Available: "2012-03"
 5588	perfectly mixed bouncing Humanitini	3	EPIC	Last Available: "2012-03"
 5589	artisanal More Humanitini than Humanitini	3	EPIC	Last Available: "2012-03"
-5590	practically non-alcoholic drinkable wobbly Oh, the Humanitini	1	good	Last Available: "2012-03"
+5590	drinkable practically non-alcoholic wobbly Oh, the Humanitini	1	good	Last Available: "2012-03"
 5591	high-proof hand-crafted blurry Great Older Fashioned	10	EPIC	Last Available: "2012-03"
-5592	artisanal watered-down Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5592	watered-down artisanal Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
 5593	drinkable tumbling Crazymaker	3	good	Last Available: "2012-03"
 5594	tolerable Zoodriver	3	good	Last Available: "2012-03"
 5595	practically non-alcoholic tolerable squat Sloe Comfortable Zoo	1	good	Last Available: "2012-03"
 5596	smooth spinning Sloe Comfortable Zoo on Fire	3	awesome	Last Available: "2012-03"
 5597	high-proof lousy jittery Suffering Sinner	8	decent	Last Available: "2012-03"
 5598	acceptable practically non-alcoholic Suppurating Sinner	1	good	Last Available: "2012-03"
-5599	special irresponsibly strong tolerable Sizzling Sinner	9	good	Effect: "Emotion Sickness", Effect Duration: 20, Last Available: "2012-03"
+5599	irresponsibly strong special tolerable Sizzling Sinner	9	good	Effect: "Emotion Sickness", Effect Duration: 20, Last Available: "2012-03"
 5600	bad blurry Firewater	3	decent	Last Available: "2012-03"
 5601	perfectly mixed narrow Earth and Firewater	3	EPIC	Last Available: "2012-03"
-5602	smooth weak Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
-5603	drinkable special maroon bouncing Slimosa	3	good	Effect: "Bilious Brawn", Effect Duration: 25, Last Available: "2012-03"
+5602	weak smooth Earth, Wind and Firewater	2	awesome	Last Available: "2012-03"
+5603	special drinkable bouncing maroon Slimosa	3	good	Effect: "Bilious Brawn", Effect Duration: 25, Last Available: "2012-03"
 5604	distilled artisanal Extra-slimy Slimosa	5	EPIC	Last Available: "2012-03"
 5605	fancy perfectly mixed Slimebite	3	EPIC	Effect: "The Power of Negative Thinking", Effect Duration: 20, Last Available: "2012-03"
-5606	high-proof drinkable tumbling Cement Mixer	7	good	Last Available: "2012-03"
+5606	drinkable high-proof tumbling Cement Mixer	7	good	Last Available: "2012-03"
 5607	bad yellow Jackhammer	4	decent	Last Available: "2012-03"
-5608	bad watered-down Dump Truck	2	decent	Last Available: "2012-03"
+5608	watered-down bad Dump Truck	2	decent	Last Available: "2012-03"
 5609	tolerable ghostly blue Fauna Libre	3	good	Last Available: "2012-03"
-5610	acceptable enchanted pulsating Chakra Libre	3	good	Effect: "Vital", Effect Duration: 50, Last Available: "2012-03"
-5611	perfectly mixed weak Aura Libre	2	EPIC	Last Available: "2012-03"
-5612	lousy high-proof Sazerorc	7	decent	Last Available: "2012-03"
-5613	fancy drinkable bouncing cyan mirror Sazuruk-hai	4	good	Effect: "In the Limelight", Effect Duration: 40, Last Available: "2012-03"
+5610	enchanted acceptable pulsating Chakra Libre	3	good	Effect: "Vital", Effect Duration: 50, Last Available: "2012-03"
+5611	weak perfectly mixed Aura Libre	2	EPIC	Last Available: "2012-03"
+5612	high-proof lousy Sazerorc	7	decent	Last Available: "2012-03"
+5613	fancy drinkable mirror cyan bouncing Sazuruk-hai	4	good	Effect: "In the Limelight", Effect Duration: 40, Last Available: "2012-03"
 5614	bad Flaming Sazerorc	4	decent	Last Available: "2012-03"
 5615	artisanal Green Velvet	4	EPIC	Last Available: "2012-03"
-5616	weak mediocre Green Muslin	2	decent	Last Available: "2012-03"
-5617	practically non-alcoholic hand-crafted Green Burlap	1	super ultra EPIC	Last Available: "2012-03"
+5616	mediocre weak Green Muslin	2	decent	Last Available: "2012-03"
+5617	hand-crafted practically non-alcoholic Green Burlap	1	super ultra EPIC	Last Available: "2012-03"
 5618	mediocre huge Mohobo	4	decent	Last Available: "2012-03"
 5619	bad practically non-alcoholic Moonshine Mohobo	1	decent	Last Available: "2012-03"
 5620	mediocre Flaming Mohobo	4	decent	Last Available: "2012-03"
@@ -5526,23 +5526,23 @@
 5623	hand-crafted fancy Drunken Astrophysicist	4	EPIC	Effect: "Perception", Effect Duration: 50, Last Available: "2012-03"
 5624	hand-crafted skewed Dark & Starry	3	EPIC	Last Available: "2012-03"
 5625	high-proof tolerable ghostly Black Hole	6	good	Last Available: "2012-03"
-5626	mediocre weak ghostly Event Horizon	2	decent	Last Available: "2012-03"
-5627	bad fortified squat blinking Herring Daiquiri	5	decent	Last Available: "2012-03"
+5626	weak mediocre ghostly Event Horizon	2	decent	Last Available: "2012-03"
+5627	fortified bad squat blinking Herring Daiquiri	5	decent	Last Available: "2012-03"
 5628	watered-down artisanal Herring Wallbanger	2	EPIC	Last Available: "2012-03"
 5629	perfectly mixed watered-down Herringtini	2	EPIC	Last Available: "2012-03"
 5630	practically non-alcoholic hand-crafted squat Lollipop Drop	1	EPIC	Last Available: "2012-03"
 5631	bad Candy Alexander	4	decent	Last Available: "2012-03"
-5632	acceptable weak Candicaine	2	good	Last Available: "2012-03"
+5632	weak acceptable Candicaine	2	good	Last Available: "2012-03"
 5633	hand-crafted mirror Caipiranha	4	EPIC	Last Available: "2012-03"
-5634	practically non-alcoholic drinkable skewed Flying Caipiranha	1	good	Last Available: "2012-03"
-5635	tolerable practically non-alcoholic Flaming Caipiranha	1	good	Last Available: "2012-03"
+5634	drinkable practically non-alcoholic skewed Flying Caipiranha	1	good	Last Available: "2012-03"
+5635	practically non-alcoholic tolerable Flaming Caipiranha	1	good	Last Available: "2012-03"
 5636	lousy squat Punchplanter	4	decent	Last Available: "2012-03"
 5637	tolerable Doublepunchplanter	3	good	Last Available: "2012-03"
-5638	high-proof fancy drinkable Haymaker	9	good	Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2012-03"
+5638	fancy drinkable high-proof Haymaker	9	good	Effect: "Here to Kick Ass", Effect Duration: 5, Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	tasty miniature fungus	2	awesome	
-5642	narrow spinning poisoned dart	0		
+5641	miniature tasty fungus	2	awesome	
+5642	spinning narrow poisoned dart	0		
 5643	nitrogenated adjusted gray stone wool	0		Effect: "Guts Feeling", Effect Duration: 21
 5644	huge stones	0		
 5645	the Nostril of the Serpent	0		
@@ -5555,14 +5555,14 @@
 5652	skewed Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	decent nailswurst	3	good	
-5655	fortified acceptable used beer	5	good	
+5655	acceptable fortified used beer	5	good	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
 5659	dangerous insulting hat	0		Weapon Damage: +10, Familiar Effect: "cap 2"
 5660	twirling baleful offensive moustache	0		Spell Damage: +25, Single Equip
 5661	fuchsia smelly hairshirt	0		Stench Spell Damage: +10
-5662	skewed spinning Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
+5662	spinning skewed Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
 5663	microwave	0		Free Pull
 5664	shaking pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
@@ -5570,7 +5570,7 @@
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	bouncing skewed club	0		
-5670	half-sized bland special twirling fettucini &eacute;pines Inconnu	2	decent	Effect: "Executive Greed", Effect Duration: 20
+5670	special half-sized bland twirling fettucini &eacute;pines Inconnu	2	decent	Effect: "Executive Greed", Effect Duration: 20
 5671	drinkable slap and slap again	4	good	
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
@@ -5580,12 +5580,12 @@
 5677	blurry Van der Graaf Ze&trade; goggles	0		MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	fuchsia soggy used band-aid	0		Last Available: "2012-05"
 5679	spinning Newton's slick stylish swimsuit	0		Moxie: +10, Experience (Mysticality): +3, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
-5680	spinning blue lost key	0		Last Available: "2012-05"
+5680	blue spinning lost key	0		Last Available: "2012-05"
 5681	flavorless snack-sized P.B.L.T.	2	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
 5684	cyan handful of juicy garbage	0		
-5685	tumbling shaking bugbear communicator badge	0		
+5685	shaking tumbling bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
 5687	jittery bugbear autopsy tweezers	0		
 5688	Van der Graaf UV monocular	0		MP Regen Min: 5, MP Regen Max: 7, Single Equip
@@ -5602,7 +5602,7 @@
 5699	upside-down The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
 5701	Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
-5702	squat maroon mannequin	0		Familiar Weight: +5
+5702	maroon squat mannequin	0		Familiar Weight: +5
 5703	bouncing crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
 5705	hardy wax hat of temperance	0		Maximum HP: +50, Sleaze Resistance: +5, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
@@ -5615,9 +5615,9 @@
 5714	ghostly FDKOL tattoo	0		
 5715	gray Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5717	low-calorie delicious FDKOL hotcakes	1	awesome	Last Available: "2012-07"
+5717	delicious low-calorie FDKOL hotcakes	1	awesome	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
-5719	cyan pulsating smoking grass	0		Last Available: "2012-07"
+5719	pulsating cyan smoking grass	0		Last Available: "2012-07"
 5720	spoiled fiery wing	3	crappy	Last Available: "2012-07"
 5721	teal wings of fire of Leguizamo of the brazier	0		Monster Level: +20, Hot Spell Damage: +25, Last Available: "2012-07"
 5722	Lo Pan's FDKOL fire hose	0		Spell Critical Percent: +30, Last Available: "2012-07"
@@ -5629,11 +5629,11 @@
 5728	sizzling foot-long hot daub of the blizzard	0		Cold Spell Damage: +25, Hot Damage: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	spoiled cyan wobbly angst burger	3	crappy	
-5731	smooth watered-down 5-hour acrimony	2	awesome	
+5731	watered-down smooth 5-hour acrimony	2	awesome	
 5732	jittery blank note	0		
 5733	eerily silent box	0		
 5734	gigantic moldy forbidden sausage	6	crappy	
-5735	yellow Lord Flameface's cloak of James Dean	0		Experience (Moxie): +3, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	yellow Lord Flameface's cloak of James Dean	0		Experience (Moxie): +3, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	adjusted Vulcanized tumbling Drizzlers&trade; Black Licorice	0		Effect: "Deep-Seated Rage", Effect Duration: 37
 5737	improved blurry daub-breaker	0		Effect: "Highland Sheen", Effect Duration: 49, Last Available: "2020-09"
 5738	bouncing boxer's Camp Scout backpack	0		Muscle Percent: +10, Softcore Only, Last Available: "2012-07"
@@ -5641,7 +5641,7 @@
 5740	diet bland bouncing bag of GORP	1	decent	Last Available: "2012-07"
 5741	acceptable narrow water purification pills	3	good	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
-5743	strong mediocre CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
+5743	mediocre strong CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
 5744	delicious squat bag of GORF	3	awesome	Last Available: "2012-07"
 5745	CSA discount card	0		Last Available: "2020-09"
 5746	yummy bag of QWOP	3	awesome	Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	bland low-calorie decent brain	1	decent	
 5754	thick bland good brain	5	decent	
 5755	delicious boss brain	4	awesome	
-5756	immense decent hunter brain	10	good	
+5756	decent immense hunter brain	10	good	
 5758	olive blurry scandalous sharpshooter's Staff of Holiday Sensations of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +10, Sleaze Damage: +5, Last Available: "2011-11"
 5759	electrified staff of extreme caution	0		Monster Level: -25, MP Regen Min: 3, MP Regen Max: 5
 5760	scandalous Fonzie's thinker's staff	0		Mysticality: +10, Experience (Moxie): +1, Sleaze Damage: +5
@@ -5668,7 +5668,7 @@
 5768	pulsating gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5769	wobbly gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5770	purple jittery gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	blurry cyan gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	cyan blurry gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5772	shaking gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
@@ -5677,7 +5677,7 @@
 5778	snack-sized stale huge idiot brain	2	decent	
 5779	twirling Sherlock's keel-haulin' knife	0		Item Drop: +25
 5780	bouncing baleful ice cream scoop	0		Spell Damage: +25
-5781	hand-crafted spirit-forward soft echo eyedrop antidote martini	5	EPIC	
+5781	spirit-forward hand-crafted soft echo eyedrop antidote martini	5	EPIC	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	bouncing teal box of bear arms	0		Last Available: "2012-09"
-5791	banded right bear arm of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	gray squat executive supercharged left bear arm of the pedagogue	0		Experience: +3, Maximum MP Percent: +30, Meat Drop: +40, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	banded right bear arm of James Dean	0		Experience (Moxie): +3, Damage Absorption: +100, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	gray squat executive supercharged left bear arm of the pedagogue	0		Experience: +3, Maximum MP Percent: +30, Meat Drop: +40, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	blue sizzling Hat O' Nine Tails	0		Hot Damage: +10
 5794	flattened ionized wobbly squat Enchanted Plunger	0		Effect: "Adrenaline Rush", Effect Duration: 13
 5795	flattened Enchanted Flyswatter	0		Effect: "Healthy Red Glow", Effect Duration: 18
@@ -5743,7 +5743,7 @@
 5844	adjusted una poca de gracia	0		Effect: "Dances with Tweedles", Effect Duration: 63
 5845	denatured quadruple-energized compressed air canister	0		Effect: "Man's Worst Enemy", Effect Duration: 34
 5846	colloidal shaking salt water taffy	0		Effect: "Jerky, Boy", Effect Duration: 56
-5847	tarnished adjusted shaking wobbly skewed unholy water	0		Effect: "Bone Chilling", Effect Duration: 49
+5847	tarnished adjusted wobbly shaking skewed unholy water	0		Effect: "Bone Chilling", Effect Duration: 49
 5848	polarized deionized modified Bangyomaman battle juice	0		Effect: "Thanksgot", Effect Duration: 21
 5849	double-ionized improved handyman &quot;hand soap&quot;	0		Effect: "You Know Who to Call", Effect Duration: 33
 5850	colloidal space marine flash grenade	0		Effect: "Minerva's Zen", Effect Duration: 15
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	squat skeleton	0		Last Available: "2012-10"
 5882	skeleton skis of the storm of the blizzard of the sewer	0		Maximum MP Percent: +40, Cold Spell Damage: +25, Stench Damage: +25, Single Equip, Last Available: "2012-10"
-5883	spoiled huge skeleton quiche	10	crappy	Last Available: "2012-10"
+5883	huge spoiled skeleton quiche	10	crappy	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	scorching chilly Da Vinci's boxer's Bonestabber	0		Muscle Percent: +10, Experience (Mysticality): +5, Cold Damage: +5, Hot Damage: +25, Last Available: "2012-10"
@@ -5809,7 +5809,7 @@
 5911	nanorhino credit card	0		Last Available: "2012-11"
 5912	blurry Jeselnik's Solstice Shield of the dark arts	0		Spell Damage Percent: +100, Sleaze Damage: +25
 5913	quadruple-energized candy sushi set	0		Effect: "Musky", Effect Duration: 69, Last Available: "2012-12"
-5914	ionized shaking wobbly sweet mochi ball	0		Effect: "Healthy Bronze Glow", Effect Duration: 24, Last Available: "2012-12"
+5914	ionized wobbly shaking sweet mochi ball	0		Effect: "Healthy Bronze Glow", Effect Duration: 24, Last Available: "2012-12"
 5915	polarized twirling beet-flavored Mr. Mediocrebar	0		Effect: "Pork Power", Effect Duration: 32, Last Available: "2012-12"
 5916	denatured aerosolized cyan sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Adorable Lookout", Effect Duration: 67, Last Available: "2012-12"
 5917	non-colloidal anodized wet squat cabbage-flavored Mr. Mediocrebar	0		Effect: "Spiro Gyro", Effect Duration: 49, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	studded brainwave-controlled unicorn horn	0		Damage Absorption: +80, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
+5928	studded brainwave-controlled unicorn horn	0		Damage Absorption: +80, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	miser's toasty plastic four-shadowed mime of the sewer	0		Hot Damage: +5, Stench Damage: +25, Meat Drop: +10, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	plastic Father McGruber of the blizzard	0		Cold Spell Damage: +25, Last Available: "2012-12"
 5961	squat wobbly plastic Hank North, Photojournalist of Flo-Jo	0		Initiative: +100, Last Available: "2012-12"
 5962	padded plastic blazing bat	0		Damage Absorption: +20, Last Available: "2012-12"
-5963	teal wobbly inspector's electronic dulcimer pants of wisdom	0		Mysticality: +15, Item Drop: +15, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	teal wobbly inspector's electronic dulcimer pants of wisdom	0		Mysticality: +15, Item Drop: +15, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
 5964	red A-Boo clue	0		
 5965	blurry Jack Frost's banded Frown Exerciser	0		Damage Absorption: +100, Cold Spell Damage: +50, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5870,7 +5870,7 @@
 5972	tumbling record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
 5973	yellow wobbly record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
-5975	fuchsia huge record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
+5975	huge fuchsia record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	wobbly record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	squat hale extremely unsafe smartaleck's silent beret	0		Moxie Percent: +30, Weapon Damage Percent: +100, Maximum HP: +20, Familiar Effect: "1xVolley, cap 3"
 5978	toothsome purple slice of pizza	3	awesome	Last Available: "2013-02"
@@ -5881,7 +5881,7 @@
 5983	skewed vial of holy water	0		Last Available: "2013-02"
 5984	narrow Van der Graaf MacGyver's educational cloth cap	0		Experience: +1, Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	studded padded smartaleck's iron dagger	0		Moxie Percent: +30, Damage Absorption: 100, Last Available: "2013-02"
-5986	decent miniature ghostly maroon hamburger	2	good	Last Available: "2013-02"
+5986	miniature decent ghostly maroon hamburger	2	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	upside-down potion	0		Last Available: "2013-02"
@@ -5923,15 +5923,15 @@
 6025	adjusted polymerized twirling Polysniff Perfume	0		Effect: "Brother Corsican's Blessing", Effect Duration: 52
 6026	Duskwalker syringe	0		
 6027	Space Tours Tripple	0		
-6028	spinning gray Battlie Light Saver	0		
+6028	gray spinning Battlie Light Saver	0		
 6029	skewed T.U.R.D.S. Key	0		
 6030	blinking manspreader's dress pants	0		Monster Level: +10, Familiar Effect: "2xFairy, cap 28"
 6031	beefcake's badge of authority	0		Muscle: +25, Single Equip
 6032	Socratic motorcycle boots of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +1, Single Equip
 6033	knitted rock-hard stolen necklace	0		Damage Reduction: 5, Cold Resistance: +3
 6034	blurry scorching healthy troll britches	0		Maximum HP Percent: +20, Hot Damage: +25, Familiar Effect: "1.5xPotato, cap 28"
-6035	activated super-corrupted squat jittery vial of The Glistening	0		Effect: "critical.enh", Effect Duration: 21
-6036	bad irresponsibly strong artisanal limoncello	8	decent	
+6035	activated super-corrupted jittery squat vial of The Glistening	0		Effect: "critical.enh", Effect Duration: 21
+6036	irresponsibly strong bad artisanal limoncello	8	decent	
 6037	purple ginger ale	0		
 6038	flavorless twirling incredible pizza	4	decent	
 6039	stanky supercharged oil cap	0		Maximum MP Percent: +30, Stench Spell Damage: +25, Familiar Effect: "cap 28"
@@ -5948,10 +5948,10 @@
 6050	tumbling woimbook	0		Familiar Weight: +5
 6051	Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	normal ghostly Taco Dan's Taco Stand Taco	3	good	Last Available: "2012-12"
-6053	watered-down mediocre Taco Dan's Taco Stand Chimichangarita	2	decent	Last Available: "2012-12"
+6053	mediocre watered-down Taco Dan's Taco Stand Chimichangarita	2	decent	Last Available: "2012-12"
 6054	polymerized anodized nitrogenated narrow Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Cinnamouth", Effect Duration: 60, Last Available: "2012-12"
 6055	twirling psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	Jeselnik's vibrating Meatcleaver	0		Maximum MP Percent: +10, Sleaze Damage: +25, Last Available: "2013-12"
 6058	pulsating Tesla Crimbo Elf bobble-head	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2012-12"
 6059	Crimbo stogie-scented room odorizer of the dark arts	0		Spell Damage Percent: +100, Last Available: "2012-12"
@@ -5972,11 +5972,11 @@
 6074	boiled electrified magicberry tablets	0		Effect: "Riboflavin'", Effect Duration: 36, Last Available: "2012-12"
 6075	unsweetened quadruple-dry quadruple-cold-filtered 37x37x37 puzzle cube	0		Effect: "Scorpio Rising", Effect Duration: 33, Last Available: "2012-12"
 6076	weak perfectly mixed McLeod's Hard Haggis-Ade	2	EPIC	Last Available: "2012-12"
-6077	tiny moldy fuchsia haggis-wrapped haggis-stuffed haggis	1	crappy	Last Available: "2012-12"
+6077	moldy tiny fuchsia haggis-wrapped haggis-stuffed haggis	1	crappy	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	huge school calculator watch	0		Last Available: "2012-12"
-6080	haggis socks of the ox	0		Muscle: +20, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	haggis socks of the ox	0		Muscle: +20, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	ghostly olive actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -5995,7 +5995,7 @@
 6097	classy monkey	0		Last Available: "2012-12"
 6098	cyan gourd potion	0		Last Available: "2013-12"
 6099	fuchsia beefy Thinknerd T-Shirt	0		Muscle: +10, Last Available: "2012-12"
-6100	blurry upside-down pile of useless robot parts	0		Last Available: "2012-12"
+6100	upside-down blurry pile of useless robot parts	0		Last Available: "2012-12"
 6101	homemade robot	0		Last Available: "2012-12"
 6102	homemade robot gear	0		Last Available: "2012-12"
 6103	bouncing Artist's Whisk of Misery	0		Last Available: "2013-12"
@@ -6037,7 +6037,7 @@
 6139	rubber gloves of the bloodbag	0		Maximum HP: +100, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	spinning triad summoning scroll	0		Last Available: "2013-12"
-6142	toothsome snack-sized teal roasted duck	2	awesome	Last Available: "2013-12"
+6142	snack-sized toothsome teal roasted duck	2	awesome	Last Available: "2013-12"
 6143	flavorless shaking shaking dead meat bun	3	decent	Last Available: "2013-12"
 6144	stylish cat collar	0		Moxie: +25, Single Equip, Last Available: "2013-12"
 6145	maroon experienced suspicious-looking fedora of the glutton	0		Experience: +2, Food Drop: +100, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
@@ -6046,16 +6046,16 @@
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	toothsome snack-sized carrot cake	2	awesome	Last Available: "2013-01"
+6152	snack-sized toothsome carrot cake	2	awesome	Last Available: "2013-01"
 6153	hand-crafted boozy purple carrot claret	5	EPIC	Last Available: "2013-01"
 6154	modified blinking carrot juice	1	good	Last Available: "2013-01"
 6155	shaking pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	spinning Rosewater's Byte of the wise owl	0		Mysticality: +20, Mysticality Percent: +30, Last Available: "2013-12"
-6158	mirror Sherlock's anger blaster	0		Item Drop: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	wicked doubt cannon	0		Spell Damage: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	dog trainer's fear condenser	0		Experience (familiar): +1, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	wizardly regret hose	0		Mysticality: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	mirror Sherlock's anger blaster	0		Item Drop: +25, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	wicked doubt cannon	0		Spell Damage: +5, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	dog trainer's fear condenser	0		Experience (familiar): +1, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	wizardly regret hose	0		Mysticality: +25, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	upside-down Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	Jim Carey's extremely unsafe commodore's hat	0		Weapon Damage Percent: +100, Monster Level: +25, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
@@ -6064,7 +6064,7 @@
 6167	ornamental sextant of the glutton	0		Food Drop: +100, Last Available: "2013-12"
 6168	blue Annie Oakley's energetic Bloodbath	0		Maximum MP Percent: +20, Critical Hit Percent: +20, Last Available: "2013-12"
 6169	mediocre Hundred Headed IPA	3	decent	Last Available: "2013-12"
-6170	small rotten blinking chum	2	crappy	Last Available: "2013-12"
+6170	rotten small blinking chum	2	crappy	Last Available: "2013-12"
 6171	boiled shaking crude crudit&eacute;s	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 36
 6172	tarnished oxidized green tumbling candy crayons	0		Effect: "Boschface", Effect Duration: 12, Last Available: "2020-09"
 6173	shellacked padded pixel grappling hook	0		Damage Absorption: +20, Damage Reduction: 7
@@ -6079,7 +6079,7 @@
 6182	cosmic cream	0		
 6183	cosmic fruit	0		
 6184	auspicious studded Jarlsberg's hat	0		Damage Absorption: +80, Item Drop: 15
-6185	moldy enchanted consummate hard-boiled egg	4	crappy	Effect: "Frigid Weapon", Effect Duration: 40
+6185	enchanted moldy consummate hard-boiled egg	4	crappy	Effect: "Frigid Weapon", Effect Duration: 40
 6186	stale snack-sized consummate fried egg	2	decent	
 6187	decent teal consummate egg salad	4	good	
 6188	yummy consummate bagel	3	awesome	
@@ -6087,8 +6087,8 @@
 6190	normal half-sized upside-down consummate hot dog bun	2	good	
 6191	snack-sized decent consummate brownie	2	good	
 6192	tasty mirror consummate toast	3	awesome	
-6193	acceptable weak fancy jittery passable stout	2	good	Effect: "Holiday Disappointment", Effect Duration: 45
-6194	special decent snack-sized wobbly upside-down consummate soup	2	good	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45
+6193	acceptable fancy weak jittery passable stout	2	good	Effect: "Holiday Disappointment", Effect Duration: 45
+6194	decent special snack-sized wobbly upside-down consummate soup	2	good	Effect: "Yeah, It's Just Gasoline", Effect Duration: 45
 6195	stale jumbo consummate corn chips	5	decent	
 6196	snack-sized spoiled consummate salad	2	crappy	
 6197	spoiled fancy upside-down consummate salsa	3	crappy	Effect: "Tennis Elbow-wow", Effect Duration: 45
@@ -6104,7 +6104,7 @@
 6207	spoiled consummate baked potato	3	crappy	
 6208	mediocre cyan acceptable vodka	3	decent	
 6209	flavorless bouncing consummate ice cream	3	decent	
-6210	jumbo bland consummate whipped cream	5	decent	
+6210	bland jumbo consummate whipped cream	5	decent	
 6211	rotten consummate cream	3	crappy	
 6212	bland huge consummate strawberries	6	decent	
 6213	normal consummate sorbet	4	good	
@@ -6112,26 +6112,26 @@
 6215	drinkable boozy mediocre lager	5	good	
 6216	small stale immaculate grilled cheese	2	decent	
 6217	tasty immaculate ice cream sandwich	3	awesome	
-6218	fancy rotten small immaculate hot dog	2	crappy	Effect: "Bear Clawed", Effect Duration: 25
-6219	flavorless small lime green tumbling squat immaculate egg salad sandwich	2	decent	
+6218	rotten fancy small immaculate hot dog	2	crappy	Effect: "Bear Clawed", Effect Duration: 25
+6219	flavorless small tumbling squat lime green immaculate egg salad sandwich	2	decent	
 6220	moldy perfect sandwich	3	crappy	
 6221	small spoiled mirror perfect chef salad	2	crappy	
-6222	toothsome low-calorie perfect breakfast	1	awesome	
-6223	massive moldy yellow sublime deluxe hot dog	9	crappy	
-6224	half-sized rotten sublime stew	2	crappy	
-6225	special spoiled sublime nachos	4	crappy	Effect: "Incredibly Hulking", Effect Duration: 30
+6222	low-calorie toothsome perfect breakfast	1	awesome	
+6223	moldy massive yellow sublime deluxe hot dog	9	crappy	
+6224	rotten half-sized sublime stew	2	crappy	
+6225	spoiled special sublime nachos	4	crappy	Effect: "Incredibly Hulking", Effect Duration: 30
 6226	diet decent Ultimate Breakfast Sandwich	1	good	
 6227	spoiled Loaded Baked Potato	4	crappy	
 6228	bland Omega Sundae	3	decent	
 6229	bad spinning Das Sauerlager	3	decent	
 6230	artisanal strong Bologna Lambic	5	EPIC	
-6231	watered-down tolerable Vodka Dog	2	good	
+6231	tolerable watered-down Vodka Dog	2	good	
 6232	weak perfectly mixed Disappointed Russian	2	EPIC	
 6233	aged Chunky Mary	4	awesome	
 6234	tolerable spirit-forward Nachojito	5	good	
 6235	aged practically non-alcoholic Le Roi	1	awesome	
 6236	watered-down acceptable Over Easy Rider	2	good	
-6237	twirling teal cosmic six-pack	0		
+6237	teal twirling cosmic six-pack	0		
 6239	magnetized purple cube of ectoplasm	0		Effect: "Briny Blood", Effect Duration: 41
 6240	oxidized double-warmed Illuminati earpiece	0		Effect: "Gummiheart", Effect Duration: 37
 6241	altered jittery censored can label	0		Effect: "Human-Elemental Hybrid", Effect Duration: 64
@@ -6182,7 +6182,7 @@
 6286	Oprah's dangerous Mark II Steam-Hat of the businessman	0		Weapon Damage: +10, Maximum MP Percent: +50, Meat Drop: +50, Familiar Effect: "1xLep, cap 37"
 6287	pulsating mansplainer's crafty studded boxer's Mark III Steam-Hat	0		Muscle Percent: +10, Damage Absorption: +80, Maximum MP: +10, Monster Level: +15, Familiar Effect: "1xLep, cap 37"
 6288	twirling asbestos-lined Van der Graaf boxer's beefcake's Mark IV Steam-Hat of incineration	0		Muscle: +25, Muscle Percent: +10, Hot Spell Damage: +50, Hot Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xLep, cap 37"
-6289	blinking rosewater-soaked knitted wool scandalous healthy Mark V Steam-Hat	0		Maximum HP Percent: +20, Sleaze Damage: +5, Cold Resistance: 4, Stench Resistance: +3, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	blinking rosewater-soaked knitted wool scandalous healthy Mark V Steam-Hat	0		Maximum HP Percent: +20, Sleaze Damage: +5, Cold Resistance: 4, Stench Resistance: +3, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	spinning steam-powered model rocketship	0		
 6291	inspector's quilted punk rock jacket	0		Damage Absorption: +40, Item Drop: +15
 6292	blurry MacGyver's hardened safety pin	0		Damage Reduction: 3, Maximum MP: +100
@@ -6246,7 +6246,7 @@
 6350	clever Mer-kin gutgirdle	0		Maximum MP: +20, Experience (Moxie): +20, Single Equip
 6351	lion tamer's Mer-kin finpaddle	0		Experience (familiar): +2
 6352	Mer-kin stopwatch of the sewer	0		Stench Damage: +25, Initiative: +50
-6353	green narrow Mer-kin dreadscroll	0		
+6353	narrow green Mer-kin dreadscroll	0		
 6354	super-pressed dry Mer-kin smartjuice	0		Effect: "Nature's Bounty", Effect Duration: 20
 6355	dry ghostly Mer-kin cooljuice	0		Effect: "Boon of She-Who-Was", Effect Duration: 37
 6356	skewed blinking Mer-kin worktea	0		
@@ -6264,9 +6264,9 @@
 6368	shaking Mer-kin hallpass	0		
 6369	shaking shaking lump of clay	0		
 6370	twisted piece of wire	0		
-6371	weak drinkable squat can of the cheapest beer	2	good	
+6371	drinkable weak squat can of the cheapest beer	2	good	
 6372	mediocre jittery bottle of fruity &quot;wine&quot;	3	decent	
-6373	triple-distilled lousy pulsating mirror single swig of vodka	8	decent	
+6373	lousy triple-distilled pulsating mirror single swig of vodka	8	decent	
 6374	huge angry inch	0		
 6375	huge shellacked testy toolbox	0		Damage Reduction: 7
 6376	Jick-o-User	0		
@@ -6275,7 +6275,7 @@
 6380	triple-adjusted spinning ph balancer	0		Effect: "Impregnably Delicious", Effect Duration: 44
 6381	colloidal blinking mysterious chemical residue	0		Effect: "Fratty Flavor", Effect Duration: 38
 6382	nugget of sodium	0		
-6383	skewed blurry root beer	1	good	
+6383	blurry skewed root beer	1	good	
 6384	upside-down jigsaw blade	0		
 6385	wood screw	0		
 6386	blurry balsa plank	0		
@@ -6308,7 +6308,7 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	tumbling clutch of dodecapede eggs	0		
 6415	normal diet shaking flavorless gruel	1	good	
-6416	flavorless half-sized mana curds	2	decent	
+6416	half-sized flavorless mana curds	2	decent	
 6417	twist of lime	0		
 6418	blurry pencil stub	0		
 6419	unsweetened moth dust	0		Effect: "Salamander In Your Stomach", Effect Duration: 37
@@ -6318,7 +6318,7 @@
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	bouncing lime green Official Seal of Dreadsylvania	0		
-6426	bland snack-sized blurry Dreadsylvanian stew	2	decent	
+6426	snack-sized bland blurry Dreadsylvanian stew	2	decent	
 6427	hand-crafted upside-down Dreadsylvanian	4	EPIC	
 6428	irradiated Vulcanized ghostly Dreadsylvanian flask	0		Effect: "Penguinny Flavor", Effect Duration: 11
 6429	anodized magnetized huge Dreadsylvanian flask	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 30
@@ -6331,14 +6331,14 @@
 6436	shaking Mark of the Zombie	0		
 6437	Mark of the Ghost	0		
 6438	huge Mark of the Vampire	0		
-6439	ghostly olive Mark of the Skeleton	0		
+6439	olive ghostly Mark of the Skeleton	0		
 6440	vibrating savvy Covers-Your-Head of bravery	0		Mysticality Percent: +20, Maximum MP Percent: +10, Spooky Resistance: +5, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
 6441	cyan flame-retardant Drapes-You-Regally of the bloodbag of the sweet-tooth	0		Maximum HP: +100, Hot Resistance: +1, Candy Drop: +100, Class: "Disco Bandit"
 6442	maroon family-friendly greasy Warms-Your-Tush of the brute	0		Muscle Percent: +30, Sleaze Spell Damage: +10, Sleaze Resistance: +1, Class: "Disco Bandit", Familiar Effect: "1xVolley, 1xPotato"
 6443	green zippy brainy Helps-You-Sleep	0		Mysticality: +5, Initiative: +20, Single Equip
 6444	therapeutic shellacked Quiets-Your-Steps of doom	0		Damage Reduction: 7, Spooky Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 6445	mirror knitted nasty Protects-Your-Junk	0		Stench Damage: +5, Cold Resistance: +3, Single Equip
-6446	special tolerable tumbling Gets-You-Drunk	4	good	Effect: "Sweet and Red", Effect Duration: 25
+6446	tolerable special tumbling Gets-You-Drunk	4	good	Effect: "Sweet and Red", Effect Duration: 25
 6447	Sherlock's asbestos-lined horrifying Great Wolf's headband	0		Spooky Damage: +25, Hot Resistance: +5, Item Drop: +25, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	purple reassuring resourceful Great Wolf's left paw of Leguizamo	0		Maximum MP: +50, Monster Level: +20, Spooky Resistance: +1, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	teal lightning-fast frosty personal trainer's Great Wolf's right paw	0		Experience Percent (Muscle): +10, Cold Spell Damage: +10, Initiative: +40, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6359,7 +6359,7 @@
 6464	horrifying banded educational Mayor Ghost's khakis	0		Experience: +1, Damage Absorption: +100, Spooky Damage: +25, Class: "Pastamancer", Familiar Effect: "1xPotato, HP regen"
 6465	scandalous stiffened Mayor Ghost's gavel of the blizzard	0		Damage Reduction: 1, Cold Spell Damage: +25, Sleaze Damage: +5, Conditional Skill (Equipped): "Hammer Ghost"
 6466	blue spinning foul-smelling stiffened Mayor Ghost's sash of doom	0		Damage Reduction: 1, Stench Damage: +10, Spooky Spell Damage: +50, Single Equip
-6467	upside-down jittery huge Mayor Ghost's scissors	0		
+6467	huge upside-down jittery Mayor Ghost's scissors	0		
 6468	bland ghost pepper	3	decent	
 6469	blinking yellow lightning-fast dangerous cool Thunkula's drinking cap	0		Moxie: +5, Weapon Damage: +10, Initiative: +40, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	horrifying Drunkula's cape of dire peril of vim and vigor	0		Weapon Damage: +20, Maximum HP Percent: +50, Spooky Damage: +25, Class: "Sauceror"
@@ -6408,8 +6408,8 @@
 6513	twirling cool warm fur	0		Moxie: +5
 6514	hale snowstick	0		Maximum HP: +20
 6515	eerie fetish of Calamity Jane	0		Critical Hit Percent: +15, Single Equip
-6516	drinkable weak stinkwater	2	good	
-6517	jittery blue bouncing skewed dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
+6516	weak drinkable stinkwater	2	good	
+6517	blue skewed jittery bouncing dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	bland accidental mutton	3	decent	
 6519	deadly drafty drawers of vim and vigor	0		Weapon Damage: +5, Maximum HP Percent: +50, Familiar Effect: "1.5xVolley"
 6520	careful dance instructor's wolfskull mask	0		Experience Percent (Moxie): +10, Monster Level: -10, Familiar Effect: "spooky atk, 1xBarrr"
@@ -6421,7 +6421,7 @@
 6526	miser's Fonzie's bag of unfinished business	0		Experience (Moxie): +1, Meat Drop: +10
 6527	Sherlock's transparent pants of the blizzard	0		Cold Spell Damage: +25, Item Drop: +25, Familiar Effect: "sleaze atk, 1xPotato"
 6528	green knitted hothammer	0		Cold Resistance: +3
-6529	irresponsibly strong aged squat Thriller Ice	8	awesome	
+6529	aged irresponsibly strong squat Thriller Ice	8	awesome	
 6530	skewed Newton's grandfather watch	0		Experience (Mysticality): +3, Single Equip
 6531	blue muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	mirror greedy spyglass of vim and vigor	0		Maximum HP Percent: +50, Meat Drop: +20
@@ -6439,7 +6439,7 @@
 6545	twirling Oprah's banded stylish weedy skirt	0		Moxie: +25, Damage Absorption: +100, Maximum MP Percent: +50, Familiar Effect: "atk, 1xFairy"
 6546	rosewater-soaked pants of Leguizamo	0		Monster Level: +20, Stench Resistance: +3, Familiar Effect: "atk"
 6547	twirling Thwaitgold Goliath beetle statuette	0		
-6548	blinking jittery cooling iron helmet	0		
+6548	jittery blinking cooling iron helmet	0		
 6549	cooling iron breastplate	0		
 6550	cooling iron greaves	0		
 6551	spinning hot cluster	0		
@@ -6456,14 +6456,14 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	beefcake's hand of Mr. Cards	0		Muscle: +25, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	special normal tumbling Dreadsylvanian hot pocket	4	good	Effect: "Slightly Larger Than Usual", Effect Duration: 40
-6565	stale big upside-down Dreadsylvanian pocket	5	decent	
+6565	big stale upside-down Dreadsylvanian pocket	5	decent	
 6566	small normal shaking Dreadsylvanian pocket	2	good	
 6567	rotten snack-sized wobbly Dreadsylvanian stink pocket	2	crappy	
 6568	decent Dreadsylvanian sleaze pocket	4	good	
 6569	practically non-alcoholic drinkable Dreadsylvanian hot toddy	1	good	
-6570	acceptable weak Dreadsylvanian cold-fashioned	2	good	
+6570	weak acceptable Dreadsylvanian cold-fashioned	2	good	
 6571	fancy mediocre Dreadsylvanian grimlet	4	decent	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25
-6572	weak drinkable Dreadsylvanian dank and stormy	2	good	
+6572	drinkable weak Dreadsylvanian dank and stormy	2	good	
 6573	artisanal gray Dreadsylvanian slithery nipple	3	super ultra mega turbo EPIC	
 6574	hot clusterbomb	0		
 6575	clusterbomb	0		
@@ -6492,7 +6492,7 @@
 6598	cyan clockwork disc	0		
 6599	clockwork hand	0		
 6600	clockwork hand	0		
-6601	huge jittery clockwork numeral I	0		
+6601	jittery huge clockwork numeral I	0		
 6602	clockwork numeral II	0		
 6603	olive clockwork numeral III	0		
 6604	clockwork numeral IV	0		
@@ -6522,7 +6522,7 @@
 6628	folder (Ex-Files)	0		Combat Rate: +5, Last Available: "2013-08"
 6629	folder (skull and crossbones)	0		Combat Rate: -5, Last Available: "2013-08"
 6630	folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
-6631	purple tumbling folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
+6631	tumbling purple folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
 6633	folder (barbarian)	0		Last Available: "2013-08"
 6634	jittery folder (rainbow unicorn)	0		Last Available: "2013-08"
@@ -6571,7 +6571,7 @@
 6679	red skewed healthy machete	0		Maximum HP Percent: +20
 6680	artisanal Cursed Punch	3	EPIC	
 6681	tolerable special Bowl of Scorpions	4	good	Effect: "Cool, Catlike", Effect Duration: 30
-6682	weak hand-crafted Fog Murderer	2	super EPIC	
+6682	hand-crafted weak Fog Murderer	2	super EPIC	
 6683	book of matches	0		
 6684	deadly surgical mask	0		Weapon Damage: +5, Surgeonosity: +1
 6685	shaking boxer's head mirror	0		Muscle Percent: +10, Surgeonosity: +1
@@ -6594,7 +6594,7 @@
 6702	spinning huge bowler	0		
 6703	imitation White Russian	1	decent	
 6704	tumbling tumbling rosewater-soaked short-handled mop of terror	0		Spooky Spell Damage: +10, Stench Resistance: +3
-6705	gigantic rotten jungle floor wax	10	crappy	
+6705	rotten gigantic jungle floor wax	10	crappy	
 6706	skewed smirking shrunken head	0		
 6707	warmed colorful toad	0		Effect: "Minerva's Zen", Effect Duration: 27
 6708	crude voodoo doll	0		
@@ -6647,11 +6647,11 @@
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
 6757	irresponsibly strong lousy can of Br&uuml;talbr&auml;u	6	decent	Last Available: "2013-09"
-6758	delicious watered-down fancy can of Drooling Monk	2	awesome	Effect: "Frostbeard", Effect Duration: 50, Last Available: "2013-09"
-6759	weak aged can of Impetuous Scofflaw	2	awesome	Last Available: "2013-09"
+6758	fancy delicious watered-down can of Drooling Monk	2	awesome	Effect: "Frostbeard", Effect Duration: 50, Last Available: "2013-09"
+6759	aged weak can of Impetuous Scofflaw	2	awesome	Last Available: "2013-09"
 6760	tolerable blinking ghostly bottle of Old Pugilist	4	good	Last Available: "2013-09"
 6761	smooth bottle of Professor Beer	3	awesome	Last Available: "2013-09"
-6762	artisanal strong bottle of Rapier Witbier	5	EPIC	Last Available: "2013-09"
+6762	strong artisanal bottle of Rapier Witbier	5	EPIC	Last Available: "2013-09"
 6763	practically non-alcoholic tolerable bouncing bottle of Race Car Red	1	good	Last Available: "2013-09"
 6764	hand-crafted boozy blurry bottle of Greedy Dog	5	EPIC	Last Available: "2013-09"
 6765	enchanted hand-crafted skewed bottle of Lambada Lambic	4	EPIC	Effect: "Oth-Jeal-O", Effect Duration: 20, Last Available: "2013-09"
@@ -6666,7 +6666,7 @@
 6774	skewed teal tin snips	0		Last Available: "2013-09"
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	alkaline alkaline electrified foetid seal tear	0		Effect: "Liquid Luck", Effect Duration: 18
-6777	cold-filtered triple-irradiated cyan blurry seal sweat	0		Effect: "items.enh", Effect Duration: 13
+6777	cold-filtered triple-irradiated blurry cyan seal sweat	0		Effect: "items.enh", Effect Duration: 13
 6778	super-tarnished boiling seal blood	0		Effect: "Disco Neuropathy", Effect Duration: 27
 6779	mirror crystalline seal eye	0		Single Equip
 6780	flame-wreathed extremely unsafe studded sealhide shield	0		Weapon Damage Percent: +100, Hot Spell Damage: +10, Damage Reduction: 7
@@ -6746,22 +6746,22 @@
 6857	wizardly Cajun accordion	0		Mysticality: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	narrow careful quirky accordion	0		Monster Level: -10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	huge Skipper's accordion of the ox of the early riser	0		Muscle: +20, Adventures: +7, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	jittery gravedigger's stiffened boxer's beefy Pantsgiving	0		Muscle: +10, Muscle Percent: +10, Damage Reduction: 1, Spooky Damage: +10, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	jittery gravedigger's stiffened boxer's beefy Pantsgiving	0		Muscle: +10, Muscle Percent: +10, Damage Reduction: 1, Spooky Damage: +10, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
 6861	spoiled can of sardines	3	crappy	Last Available: "2013-11"
-6862	spoiled tiny mirror high-calorie sugar substitute	1	crappy	Last Available: "2013-11"
+6862	tiny spoiled mirror high-calorie sugar substitute	1	crappy	Last Available: "2013-11"
 6863	normal pat of butter	3	good	Last Available: "2013-11"
-6864	diet decent wobbly dinner roll	1	good	Last Available: "2013-11"
-6865	spoiled miniature mashed potatoes	2	crappy	Last Available: "2013-11"
+6864	decent diet wobbly dinner roll	1	good	Last Available: "2013-11"
+6865	miniature spoiled mashed potatoes	2	crappy	Last Available: "2013-11"
 6866	delicious green whole turkey leg	4	awesome	Last Available: "2013-11"
-6867	stale snack-sized mirror skewed deviled egg	2	decent	Last Available: "2013-11"
+6867	snack-sized stale skewed mirror deviled egg	2	decent	Last Available: "2013-11"
 6868	double-boiled frozen finger exerciser	0		Effect: "Amorous", Effect Duration: 50, Last Available: "2013-11"
-6869	pressed warmed pulsating teal dented spoon	0		Effect: "White-boy Angst", Effect Duration: 20, Last Available: "2013-11"
+6869	pressed warmed teal pulsating dented spoon	0		Effect: "White-boy Angst", Effect Duration: 20, Last Available: "2013-11"
 6870	tarnished diffused huge love note	0		Effect: "Flamibili Tea", Effect Duration: 56, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	corrupted upside-down nail file	0		Effect: "Grrrrrrreat!", Effect Duration: 17, Last Available: "2013-11"
 6873	Vulcanized cold-filtered ghostly candy wrapper	0		Effect: "Celestial Vision", Effect Duration: 34, Last Available: "2013-11"
 6874	mirror gym membership card	0		Last Available: "2013-11"
-6875	pressed twirling wobbly post-holiday sale coupon	0		Effect: "Very Clean Guns", Effect Duration: 62, Last Available: "2013-11"
+6875	pressed wobbly twirling post-holiday sale coupon	0		Effect: "Very Clean Guns", Effect Duration: 62, Last Available: "2013-11"
 6876	pulsating dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
@@ -6847,7 +6847,7 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	tumbling nasty warbear foil hat	0		Stench Damage: +5, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	huge warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	rosewater-soaked steel-toed warbear oil pan	0		Damage Reduction: 9, Stench Resistance: +3, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	rosewater-soaked steel-toed warbear oil pan	0		Damage Reduction: 9, Stench Resistance: +3, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	shaking warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	veiny warbear exhaust manifold	0		Maximum HP: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	jittery warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6856,7 +6856,7 @@
 6967	warbear chemistry lab	0		Last Available: "2013-12"
 6968	warbear officer requisition box	0		Last Available: "2013-12"
 6969	warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
-6970	yellow shaking warbear drone assembler	0		Last Available: "2013-12"
+6970	shaking yellow warbear drone assembler	0		Last Available: "2013-12"
 6971	warbear breakfast machine assembler	0		Last Available: "2013-12"
 6972	blind-packed die-cast toy	0		Last Available: "2013-12"
 6973	blinking die-cast Bashful the Reindeer of the ox	0		Muscle: +20, Last Available: "2013-12"
@@ -6893,7 +6893,7 @@
 7004	improved Flaskfull of Hollow	0		Effect: "Uncucumbered", Effect Duration: 22, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	dried handful of Smithereens	1	decent	Last Available: "2013-12"
-7007	enchanted immense spoiled spinning ghostly huge Every Day is Like This Sundae	6	crappy	Effect: "Dwarven Hardiness", Effect Duration: 50, Last Available: "2013-12"
+7007	spoiled immense enchanted spinning ghostly huge Every Day is Like This Sundae	6	crappy	Effect: "Dwarven Hardiness", Effect Duration: 50, Last Available: "2013-12"
 7008	normal small Miserable Pie	2	good	Last Available: "2013-12"
 7009	spoiled gigantic red This Charming Flan	9	crappy	Last Available: "2013-12"
 7010	acceptable Irish Coffee, English Heart	3	good	Last Available: "2013-12"
@@ -6924,7 +6924,7 @@
 7035	warbear box	0		Last Available: "2013-12"
 7036	jittery warbear high-efficiency still	0		Last Available: "2013-12"
 7037	skewed warbear LP-ROM burner	0		Last Available: "2013-12"
-7038	narrow skewed warbear gyrocopter	0		Last Available: "2013-12"
+7038	skewed narrow warbear gyrocopter	0		Last Available: "2013-12"
 7039	oxidized Vulcanized mirror warbear robo-camouflage unit	0		Effect: "Tiki Thoughtfulness", Effect Duration: 57, Last Available: "2013-12"
 7040	warbear beeping telegram	0		Last Available: "2013-12"
 7041	warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
@@ -6938,10 +6938,10 @@
 7049	jittery broken warbear gyrocopter	0		Last Available: "2013-12"
 7050	delicious snack-sized warbear gyro	2	awesome	Last Available: "2013-12"
 7051	activated recording of Rolando's Rondo of Resisto	0		Effect: "Trivia Master", Effect Duration: 28, Last Available: "2013-12"
-7052	narrow shaking warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
+7052	shaking narrow warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	fuchsia warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	stale immense breakfast mess	9	decent	Last Available: "2013-12"
+7055	immense stale breakfast mess	9	decent	Last Available: "2013-12"
 7056	warbear breakfast machine	0		Last Available: "2013-12"
 7057	flavorless breakfast miracle	3	decent	Last Available: "2013-12"
 7058	extra-polymerized Cloaca Cola Polar	0		Effect: "Spookyravin'", Effect Duration: 46, Last Available: "2013-12"
@@ -6964,7 +6964,7 @@
 7075	alkaline quadruple-warmed blurry liquid ice pack	0		Effect: "You're Rubber", Effect Duration: 44, Last Available: "2014-01"
 7076	bouncing snow boards	0		Last Available: "2014-01"
 7077	stale cyan snow crab	4	decent	Last Available: "2014-01"
-7078	smooth watered-down Ice Island Long Tea	2	awesome	Last Available: "2014-01"
+7078	watered-down smooth Ice Island Long Tea	2	awesome	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	squat ice sculpture	0		Last Available: "2014-01"
 7081	spinning ice house	0		Last Available: "2014-01"
@@ -6976,7 +6976,7 @@
 7087	bouncing censurious snow belt of the storm of the brazier of the businessman	0		Maximum MP Percent: +40, Hot Spell Damage: +25, Sleaze Resistance: +3, Meat Drop: +50, Single Equip, Lasts Until Rollover, Last Available: "2014-01"
 7088	bouncing executive Sherlock's greasy brawny ice nine	0		Muscle Percent: +20, Sleaze Spell Damage: +10, Item Drop: +25, Meat Drop: +40, Lasts Until Rollover, Last Available: "2014-01"
 7089	wobbly snow fort	0		Last Available: "2014-01"
-7090	tolerable triple-distilled En Una Fila Tequila	6	good	
+7090	triple-distilled tolerable En Una Fila Tequila	6	good	
 7091	blinking Skully's hot chocolate	1	awesome	
 7092	studded warbear dress helmet of the sweet-tooth	0		Damage Absorption: +80, Candy Drop: +100, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	huge knitted sizzling warbear dress bracers	0		Hot Damage: +10, Cold Resistance: +3, Single Equip, Last Available: "2013-12"
@@ -6992,35 +6992,35 @@
 7103	polymerized huge powder	0		Effect: "Nightstalkin'", Effect Duration: 28, Last Available: "2014-12"
 7104	blinking censurious licorice whip	0		Sleaze Resistance: +3, Last Available: "2014-12"
 7105	red anise-flavored venom	0		Last Available: "2014-12"
-7106	lousy special fortified ghostly snakebite	5	decent	Effect: "Buttermilk Boogie", Effect Duration: 20, Last Available: "2014-12"
+7106	lousy fortified special ghostly snakebite	5	decent	Effect: "Buttermilk Boogie", Effect Duration: 20, Last Available: "2014-12"
 7107	lard-coated candy stick of the cougar	0		Moxie: +20, Sleaze Spell Damage: +25, Last Available: "2014-12"
-7108	rotten half-sized pecan	2	crappy	Last Available: "2014-12"
+7108	half-sized rotten pecan	2	crappy	Last Available: "2014-12"
 7109	small tasty pecan pie	2	awesome	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	yummy huge candy mountain oyster	3	awesome	Last Available: "2014-12"
 7112	practically non-alcoholic delicious chocotini	1	awesome	Last Available: "2014-12"
 7113	Jeselnik's Fonzie's chocolate rabbit's foot of Gandalf	0		Experience (Moxie): +1, Spell Critical Percent: +20, Sleaze Damage: +25, Last Available: "2014-12"
 7114	spoiled snack-sized blinking candy carrot	2	crappy	Last Available: "2014-12"
-7115	fancy bland candy carrot cake	3	decent	Effect: "Full of Wist", Effect Duration: 35, Last Available: "2014-12"
+7115	bland fancy candy carrot cake	3	decent	Effect: "Full of Wist", Effect Duration: 35, Last Available: "2014-12"
 7116	yellow inspector's carrot-on-a-stick of Gandalf	0		Spell Critical Percent: +20, Item Drop: +15, Last Available: "2014-12"
 7117	gravedigger's groovy weasel stomping pants	0		Moxie Percent: +10, Spooky Damage: +10, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	decent mulberry	3	good	Last Available: "2014-12"
-7119	drinkable practically non-alcoholic spinning mulled berry wine	1	good	Last Available: "2014-12"
+7119	practically non-alcoholic drinkable spinning mulled berry wine	1	good	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	pulsating twirling Annie Oakley's lemon party hat	0		Critical Hit Percent: +20, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	Da Vinci's lemon shirt	0		Experience (Mysticality): +5, Lasts Until Rollover, Last Available: "2014-12"
 7123	tumbling auspicious lemon drop trousers	0		Item Drop: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	galvanized twirling lemonhead caviar	0		Effect: "Flashing Eyes", Effect Duration: 67, Last Available: "2014-12"
 7125	smelly deadly gummi sword	0		Weapon Damage: +5, Stench Spell Damage: +10, Last Available: "2014-12"
-7126	corrupted mirror skewed small gummi fin	0		Effect: "Super Skill", Effect Duration: 52, Last Available: "2014-12"
+7126	corrupted skewed mirror small gummi fin	0		Effect: "Super Skill", Effect Duration: 52, Last Available: "2014-12"
 7127	huge Fonzie's chocolate cow bone	0		Experience (Moxie): +1, Last Available: "2014-12"
 7128	dry jittery gummi fang	0		Effect: "Dexteri Tea", Effect Duration: 38, Last Available: "2014-12"
-7129	rotten special bite-sized leftover canap&eacute;s	1	crappy	Effect: "Radiated and Grodiated", Effect Duration: 30, Last Available: "2014-12"
-7130	boozy hand-crafted magnum of champagne	5	EPIC	Last Available: "2014-12"
+7129	rotten bite-sized special leftover canap&eacute;s	1	crappy	Effect: "Radiated and Grodiated", Effect Duration: 30, Last Available: "2014-12"
+7130	hand-crafted boozy magnum of champagne	5	EPIC	Last Available: "2014-12"
 7131	careful cow creamer of the pedagogue of dire peril	0		Experience: +3, Weapon Damage: +20, Monster Level: -10, Last Available: "2014-12"
 7132	deionized Outer Wolf&trade; cologne	0		Effect: "Pisces Rising", Effect Duration: 38, Last Available: "2014-12"
 7133	narrow lupine appetite hormones	0		Last Available: "2014-12"
-7134	jittery aromatic wolf whistle of temperance	0		Stench Resistance: +1, Sleaze Resistance: +5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7134	jittery aromatic wolf whistle of temperance	0		Stench Resistance: +1, Sleaze Resistance: +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
 7135	rotten witch's bread	4	crappy	Last Available: "2014-12"
 7136	liquefied denatured witch's brew	0		Effect: "Jungle Juiced", Effect Duration: 24, Last Available: "2014-12"
 7137	stiffened wizardly witch's bra of the ox	0		Muscle: +20, Mysticality: +25, Damage Reduction: 1, Last Available: "2014-12"
@@ -7031,13 +7031,13 @@
 7142	colloidal jittery hare brush	0		Effect: "Comprehensively Nourished", Effect Duration: 30, Last Available: "2014-12"
 7143	baleful hare pin of extreme caution	0		Spell Damage: +25, Monster Level: -25, Single Equip, Last Available: "2014-12"
 7144	blue odd coin	0		Last Available: "2014-12"
-7145	special moldy thick cinnamon cannoli	5	crappy	Effect: "Moon-Eyed", Effect Duration: 35, Last Available: "2014-12"
+7145	moldy special thick cinnamon cannoli	5	crappy	Effect: "Moon-Eyed", Effect Duration: 35, Last Available: "2014-12"
 7146	delicious expensive champagne	3	awesome	Last Available: "2014-12"
 7147	liquefied moist extra-magnetized cyan polo trophy	0		Effect: "The Best a Pirate Can Get", Effect Duration: 48, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
 7150	ornate dowsing rod	0		Last Available: "2014-12"
-7151	bouncing narrow cyan straw	0		Last Available: "2014-12"
+7151	narrow cyan bouncing straw	0		Last Available: "2014-12"
 7152		0		Last Available: "2014-12"
 7153	jittery clay	0		Last Available: "2014-12"
 7154	filling	0		Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	activated jug of &quot;wine&quot;	0		Effect: "Chunky", Effect Duration: 32, Last Available: "2014-12"
 7172	squat juggling ball	0		Last Available: "2014-12"
 7173	shaking crappy camera	0		Last Available: "2014-12"
-7174	decent immense humble pie	7	good	Last Available: "2014-12"
+7174	immense decent humble pie	7	good	Last Available: "2014-12"
 7175	squat small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	warmed ghostly crappy waiter disguise	0		Effect: "Mmmmmelon", Effect Duration: 61
@@ -7069,11 +7069,11 @@
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	bouncing The Eye of the Stars	0		
 7182	The Stankara Stone	0		
-7183	bouncing spinning purple Murphy's Rancid Black Flag	0		
+7183	purple spinning bouncing Murphy's Rancid Black Flag	0		
 7184	The Shield of Brook	0		
 7185	teal wobbly Red Zeppelin ticket	0		
 7186	Copperhead Charm (rampant)	0		
-7187	watered-down drinkable narrow unnamed cocktail	2	good	
+7187	drinkable watered-down narrow unnamed cocktail	2	good	
 7188	handful of tips	0		
 7189	inspector's unrequired jacket	0		Item Drop: +15
 7190	pulsating studded tommy gun	0		Damage Absorption: +80, Conditional Skill (Equipped): "Unload Tommy Gun"
@@ -7096,7 +7096,7 @@
 7207	twirling huge zippy blade	0		Initiative: +20
 7208	fire of unknown origin	0		
 7209	eagle's milk	1	crappy	
-7210	chilled bouncing blurry eagle feather	0		Effect: "Fancy Feasted", Effect Duration: 40
+7210	chilled blurry bouncing eagle feather	0		Effect: "Fancy Feasted", Effect Duration: 40
 7211	anodized one pill	0		Effect: "Sludgesick", Effect Duration: 16
 7212	Jefferson wings of the brute	0		Muscle Percent: +30
 7213	narrow fleetwood macaroni	0		
@@ -7108,10 +7108,10 @@
 7219	gray miser's lynyrdskin breeches	0		Meat Drop: +10, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	fuchsia cigarette lighter	0		
 7221	twirling priceless diamond	0		
-7222	bad high-proof yellow squat Flamin' Whatshisname	7	decent	
+7222	bad high-proof squat yellow Flamin' Whatshisname	7	decent	
 7223	modified lynyrd musk	0		Effect: "Blood-Gorged", Effect Duration: 51
 7224	spinning Lo Pan's baleful Kashmir sweater	0		Spell Damage: +25, Spell Critical Percent: +30
-7225	adequate twirling upside-down custard pie	3	good	
+7225	adequate upside-down twirling custard pie	3	good	
 7226	tea for one	1	decent	
 7227	smooth bottle of Evermore	3	awesome	
 7228	shaking box	0		
@@ -7152,12 +7152,12 @@
 7263	skewed photograph of a dog	0		
 7264	photograph of a nugget	0		
 7265	photograph of an ostrich egg	0		
-7266	twirling mirror disposable instant camera	0		
+7266	mirror twirling disposable instant camera	0		
 7267	lightning-fast scorching fortified Samson's Sneaky Pete's jacket (collar popped)	0		Experience (Muscle): +5, Damage Absorption: +60, Hot Damage: +25, Initiative: +40, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	jittery Letter for Melvign the Gnome	0		
 7269	Professor What garment	0		
 7270	squat &quot;2 Love Me, Vol. 2&quot;	0		
-7271	twirling spinning Thinknerd Blind-Packed Toy	0		
+7271	spinning twirling Thinknerd Blind-Packed Toy	0		
 7272	mirror deadly plastic Professor What	0		Weapon Damage: +5
 7273	beefy plastic Jared the Duskwalker	0		Muscle: +10
 7274	plastic Duke Starkiller of the early riser	0		Adventures: +7
@@ -7196,7 +7196,7 @@
 7307	Lady Spookyraven's dancing shoes	0		
 7308	double-boiled deionized eyebrow pencil	0		Effect: "Ancient Protected", Effect Duration: 63
 7309	warmed aerosolized fuchsia rosewater cream	0		Effect: "Mo' Hobo", Effect Duration: 49
-7310	electrified lime green pulsating bronzer	0		Effect: "Ass Over Teakettle", Effect Duration: 36
+7310	electrified pulsating lime green bronzer	0		Effect: "Ass Over Teakettle", Effect Duration: 36
 7311	ghostly yellow shellacked elegant nightstick of the sewer	0		Damage Reduction: 7, Stench Damage: +25
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	cyan squat box of hickory chips	0		Familiar Weight: +5
@@ -7225,11 +7225,11 @@
 7336	improved alkaline sound effects record	0		Effect: "Beastly Flavor", Effect Duration: 20
 7337	spinning alphabet block	0		
 7338	galvanized quantum mirror dancer	0		Effect: "Thick, Sick", Effect Duration: 43
-7339	red ghostly music box mechanism	0		
+7339	ghostly red music box mechanism	0		
 7340	nippy moose antlers	0		Cold Damage: +10, Familiar Effect: "atk, 1xLep, cap 27"
 7341	unsweetened tarnished moose thought	0		Effect: "Deeply Ironic", Effect Duration: 30
 7342	stale moose chocolate	3	decent	
-7343	boozy bad painting of a glass of wine	5	decent	
+7343	bad boozy painting of a glass of wine	5	decent	
 7344	oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	doll-eye amulet	0		Single Equip
@@ -7240,7 +7240,7 @@
 7351	double-paned ruddy beefy Staff of the Electric Range	0		Muscle: +10, Maximum HP Percent: +40, Cold Resistance: +5
 7352	rotten mirror deluxe layer cake	3	crappy	
 7353	chunk of hot iron	0		
-7354	perfectly mixed boozy enchanted red-hot boilermaker	5	EPIC	Effect: "Chilblains of the Corn", Effect Duration: 35
+7354	enchanted perfectly mixed boozy red-hot boilermaker	5	EPIC	Effect: "Chilblains of the Corn", Effect Duration: 35
 7355	maroon manspreader's coal shovel	0		Monster Level: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	wet moist olive hot coal	0		Effect: "Red Misty-Eyed", Effect Duration: 69
 7357	non-tarnished anodized coal dust	0		Effect: "Mighty Shout", Effect Duration: 48
@@ -7249,10 +7249,10 @@
 7360	cyan blinking plaid bandage	0		
 7361	skewed shaking wobbly brawny plaid pocket square	0		Muscle Percent: +20
 7362	studded Samson's plaid skirt	0		Experience (Muscle): +5, Damage Absorption: +80, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-7363	pickled ghostly pulsating bloodstain stick	0		Effect: "Locks Like the Raven", Effect Duration: 47
+7363	pickled pulsating ghostly bloodstain stick	0		Effect: "Locks Like the Raven", Effect Duration: 47
 7364	fuchsia fabric softener	0		
 7365	dry aerosolized fabric hardener	0		Effect: "Celestial Sheen", Effect Duration: 35
-7366	hand-crafted watered-down upside-down bottle of laundry sherry	2	EPIC	
+7366	watered-down hand-crafted upside-down bottle of laundry sherry	2	EPIC	
 7367	wet alkaline upside-down industrial strength starch	0		Effect: "You're Not Cooking", Effect Duration: 12, Wiki Name: "industrial strength starch"
 7368	normal extra-flat panini	4	good	
 7369	unsweetened mangled finger	0		Effect: "Arse-a'fire", Effect Duration: 66
@@ -7272,13 +7272,13 @@
 7383	DNA extraction syringe	0		Last Available: "2014-04"
 7384	galvanized irradiated spinning Gene Tonic: Dude	0		Effect: "Chow Downed", Effect Duration: 14, Last Available: "2014-04"
 7385	activated polymerized ghostly tumbling Gene Tonic: Beast	0		Effect: "Super-Mega-Ultra-Charged", Effect Duration: 46, Last Available: "2014-04"
-7386	oxidized moist shaking olive Gene Tonic: Construct	0		Effect: "Shot in the Arse", Effect Duration: 16, Last Available: "2014-04"
+7386	oxidized moist olive shaking Gene Tonic: Construct	0		Effect: "Shot in the Arse", Effect Duration: 16, Last Available: "2014-04"
 7387	dry Gene Tonic: Undead	0		Effect: "Bottle in front of Me", Effect Duration: 34, Last Available: "2014-04"
 7388	energized concentrated blue Gene Tonic: Humanoid	0		Effect: "Lubed", Effect Duration: 28, Last Available: "2014-04"
 7389	super-pickled modified blinking Gene Tonic: Insect	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 34, Last Available: "2014-04"
 7390	aerosolized Gene Tonic: Hippy	0		Effect: "Fangs and Pangs", Effect Duration: 44, Last Available: "2014-04"
-7391	boiled green narrow narrow Gene Tonic: Orc	0		Effect: "Hombre Muerto Caminando", Effect Duration: 47, Last Available: "2014-04"
-7392	quantum warmed quadruple-pressed jittery gray Gene Tonic: Demon	0		Effect: "Going Ape", Effect Duration: 43, Last Available: "2014-04"
+7391	boiled narrow green narrow Gene Tonic: Orc	0		Effect: "Hombre Muerto Caminando", Effect Duration: 47, Last Available: "2014-04"
+7392	quantum warmed quadruple-pressed gray jittery Gene Tonic: Demon	0		Effect: "Going Ape", Effect Duration: 43, Last Available: "2014-04"
 7393	nitrogenated Gene Tonic: Horror	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 63, Last Available: "2014-04"
 7394	extra-alkaline upside-down Gene Tonic: Fish	0		Effect: "Disco Neuropathy", Effect Duration: 60, Last Available: "2014-04"
 7395	nitrogenated skewed Gene Tonic: Goblin	0		Effect: "Alpine Mintiness", Effect Duration: 50, Last Available: "2014-04"
@@ -7294,7 +7294,7 @@
 7405	dry Gene Tonic: Hobo	0		Effect: "Fungal Flambé", Effect Duration: 17, Last Available: "2014-04"
 7406	Steam Card: Dungeon Fist (#1)	0		
 7407	fuchsia Steam Card: Dungeon Fist (#2)	0		
-7408	cyan twirling Steam Card: Dungeon Fist (#3)	0		
+7408	twirling cyan Steam Card: Dungeon Fist (#3)	0		
 7409	wobbly Steam Card: Space Trip (#1)	0		
 7410	narrow Steam Card: Space Trip (#2)	0		
 7411	Steam Card: Space Trip (#3)	0		
@@ -7318,20 +7318,20 @@
 7429	bouncing blue Beach Buck	0		Last Available: "2014-05"
 7430	extra-polymerized double-unsweetened Fun-Guy spore	0		Effect: "Sagittarius Rising", Effect Duration: 14, Last Available: "2014-05"
 7431	electrified nitrogenated maroon Boletus Broletus mushroom	0		Effect: "Happy Trails", Effect Duration: 34, Last Available: "2014-05"
-7432	enhanced moist upside-down twirling maroon Omphalotus Omphaloskepsis mushroom	0		Effect: "On Pins and Needles", Effect Duration: 39, Last Available: "2014-05"
+7432	enhanced moist upside-down maroon twirling Omphalotus Omphaloskepsis mushroom	0		Effect: "On Pins and Needles", Effect Duration: 39, Last Available: "2014-05"
 7433	galvanized Vulcanized frozen Gyromitra Dynomita mushroom	0		Effect: "Filled with Magic", Effect Duration: 38, Last Available: "2014-05"
-7434	quantum flattened pulsating squat Helvella Haemophilia mushroom	0		Effect: "There Wolf", Effect Duration: 53, Last Available: "2014-05"
+7434	quantum flattened squat pulsating Helvella Haemophilia mushroom	0		Effect: "There Wolf", Effect Duration: 53, Last Available: "2014-05"
 7435	electrified Stemonitis Staticus mushroom	0		Effect: "Sharp Weapon", Effect Duration: 18, Last Available: "2014-05"
 7436	vacuum-sealed ionized wobbly Tremella Tarantella mushroom	0		Effect: "Improved Candy Vision", Effect Duration: 29, Last Available: "2014-05"
 7437	upside-down Pastaco shell	0		Last Available: "2014-05"
 7438	spoiled miniature Beefy Crunch Pastaco	2	crappy	Last Available: "2014-05"
 7439	rotten pulsating Brain Food Pastaco	3	crappy	Last Available: "2014-05"
-7440	spoiled miniature Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
+7440	miniature spoiled Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
 7441	flavorless tiny narrow Medical Pastaco	1	decent	Last Available: "2014-05"
-7442	small yummy purple Energy Buzz Pastaco	2	awesome	Last Available: "2014-05"
+7442	yummy small purple Energy Buzz Pastaco	2	awesome	Last Available: "2014-05"
 7443	gigantic bland Ludovico Pastaco	8	decent	Last Available: "2014-05"
 7444	bad overpowering mushroom wine	3	decent	Last Available: "2014-05"
-7445	watered-down mediocre blinking green complex mushroom wine	2	decent	Last Available: "2014-05"
+7445	mediocre watered-down green blinking complex mushroom wine	2	decent	Last Available: "2014-05"
 7446	lousy smooth mushroom wine	3	decent	Last Available: "2014-05"
 7447	drinkable blood-red mushroom wine	4	good	Last Available: "2014-05"
 7448	drinkable buzzing mushroom wine	3	good	Last Available: "2014-05"
@@ -7343,9 +7343,9 @@
 7454	artisanal weak super-size brogurt	2	EPIC	Last Available: "2014-05"
 7455	spirit-forward mediocre broberry brogurt	5	decent	Last Available: "2014-05"
 7456	delicious brocolate brogurt	4	awesome	Last Available: "2014-05"
-7457	lousy triple-distilled fancy French bronilla brogurt	10	decent	Effect: "Poker Faced", Effect Duration: 40, Last Available: "2014-05"
+7457	triple-distilled fancy lousy French bronilla brogurt	10	decent	Effect: "Poker Faced", Effect Duration: 40, Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
-7459	bouncing twirling Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
+7459	twirling bouncing Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	purple industrial strength anti-fungal spray	0		Last Available: "2014-05"
 7462	shaking gray smelly Brogre brorts	0		Stench Spell Damage: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
@@ -7367,8 +7367,8 @@
 7478	yellow possessed sugar cube	0		Last Available: "2014-05"
 7479	moist dry super-modified sugar fairy	0		Effect: "Sauce Monocle", Effect Duration: 54, Last Available: "2014-05"
 7480	non-ionized ghostly sugar bunny	0		Effect: "Nature's Bounty", Effect Duration: 30, Last Available: "2014-05"
-7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	fancy lousy practically non-alcoholic Rompedores de Fantasmas	1	decent	Effect: "Moon-Eyed", Effect Duration: 20
+7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	practically non-alcoholic fancy lousy Rompedores de Fantasmas	1	decent	Effect: "Moon-Eyed", Effect Duration: 20
 7483	bad watered-down jittery La Fantasma y La Oscuridad	2	decent	
 7484	tolerable boozy lime green Fantasma en la M&aacute;quina	5	good	
 7485	loosening powder	0		
@@ -7377,7 +7377,7 @@
 7488	olive triple-distilled turpentine	0		
 7489	detartrated anhydrous sublicalc	0		
 7490	fuchsia triatomaceous dust	0		
-7491	artisanal strong bottle of Chateau de Vinegar	5	EPIC	
+7491	strong artisanal bottle of Chateau de Vinegar	5	EPIC	
 7492	blasting soda	0		
 7493	unstable fulminate	0		
 7494	squat pulsating wine bomb	0		
@@ -7395,7 +7395,7 @@
 7506	sinister educational book	0		Experience: +1, Spell Damage: +10
 7507	perfumed cloak	0		Stench Resistance: +5
 7508	label	0		
-7509	half-sized tasty Mornington crescent roll	2	awesome	
+7509	tasty half-sized Mornington crescent roll	2	awesome	
 7510	cold-filtered adjusted eye shadow	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 26
 7511	crumbling wheel	0		
 7512	pickled concentrated poppy	0		Effect: "Disco Neuropathy", Effect Duration: 12
@@ -7405,7 +7405,7 @@
 7516	witch's spare house key	0		
 7517	Annie Oakley's spider leg of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +20
 7518	maroon wand of pigification	0		
-7519	delicious fortified jittery glass of bourbon	5	awesome	
+7519	fortified delicious jittery glass of bourbon	5	awesome	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	stale jumbo government cheese	5	decent	Last Available: "2014-05"
 7522	energetic pair of government shades	0		Maximum MP Percent: +20, Single Equip, Last Available: "2014-05"
@@ -7416,12 +7416,12 @@
 7527	teal alien force field disruptor bean	0		Last Available: "2014-05"
 7528	bouncing Da Vinci's government-issued night-vision goggles of the sewer	0		Experience (Mysticality): +5, Stench Damage: +25, Single Equip, Last Available: "2014-05"
 7529	bland loaf of alien bread	3	decent	Last Available: "2014-05"
-7530	flavorless bite-sized grilled cheese sandwich	1	decent	Last Available: "2014-05"
+7530	bite-sized flavorless grilled cheese sandwich	1	decent	Last Available: "2014-05"
 7531	diluted wobbly alien protein powder	1	crappy	Effect: "Fan-Cooled", Effect Duration: 30, Last Available: "2014-05"
-7532	fancy bad spirit-forward rocket fuel	5	decent	Effect: "Night Vision", Effect Duration: 40, Last Available: "2014-05"
+7532	bad fancy spirit-forward rocket fuel	5	decent	Effect: "Night Vision", Effect Duration: 40, Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	jittery alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
-7535	perfectly mixed special weak stealth bomber	2	EPIC	Effect: "Dexteri Tea", Effect Duration: 15, Last Available: "2014-05"
+7535	special perfectly mixed weak stealth bomber	2	EPIC	Effect: "Dexteri Tea", Effect Duration: 15, Last Available: "2014-05"
 7536	upside-down space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
@@ -7429,7 +7429,7 @@
 7540	huge weightlifter's space beast fur pants	0		Muscle: +15, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	Sherlock's space beast fur whip	0		Item Drop: +25, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	pulsating dance instructor's personal trainer's space heater	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	pulsating dance instructor's personal trainer's space heater	0		Experience Percent (Muscle): +10, Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
 7545	artisanal space port	4	EPIC	Last Available: "2014-05"
 7546	Jim Carey's rock-hard space needle	0		Damage Reduction: 5, Monster Level: +25, Last Available: "2014-05"
@@ -7437,21 +7437,21 @@
 7548	hot ashes	0		Last Available: "2014-06"
 7549	energized electrified ash soda	0		Effect: "Updated", Effect Duration: 48, Last Available: "2014-06"
 7550	double-dry cold-filtered oxidized liquid smoke	0		Effect: "Super-Mega-Charged", Effect Duration: 24, Last Available: "2014-06"
-7551	pressed activated olive blinking ghostly dollop of barbecue sauce	0		Effect: "Aided and Abetted", Effect Duration: 33, Last Available: "2014-06"
+7551	pressed activated blinking ghostly olive dollop of barbecue sauce	0		Effect: "Aided and Abetted", Effect Duration: 33, Last Available: "2014-06"
 7552	enhanced pickled jittery bowl of marinade	0		Effect: "Lubed", Effect Duration: 31, Last Available: "2014-06"
-7553	narrow bouncing shaker of dry rub	0		Last Available: "2014-06"
+7553	bouncing narrow shaker of dry rub	0		Last Available: "2014-06"
 7554	electrified jittery bottle of lighter fluid	0		Effect: "Marco Polarity", Effect Duration: 12, Last Available: "2014-06"
 7555	lime green shaking page	0		
 7556	elephant gift	0		
-7557	magnetized pulsating yellow blood cells	0		Effect: "Spooky Hands", Effect Duration: 54
+7557	magnetized yellow pulsating blood cells	0		Effect: "Spooky Hands", Effect Duration: 54
 7558	artisanal wine	4	EPIC	
 7559	quadruple-quantum alkaline modified gummi turtle	0		Effect: "Cravin' for a Ravin'", Effect Duration: 67
 7560	turtle-shaped rock	0		
-7561	electrified modified wobbly blinking giraffe-necked turtle	0		Effect: "Hoity Toity", Effect Duration: 23
-7562	super-vacuum-sealed fuchsia mirror musk turtle	0		Effect: "Items Are Forever", Effect Duration: 57
+7561	electrified modified blinking wobbly giraffe-necked turtle	0		Effect: "Hoity Toity", Effect Duration: 23
+7562	super-vacuum-sealed mirror fuchsia musk turtle	0		Effect: "Items Are Forever", Effect Duration: 57
 7563	wet improved programmable turtle	0		Effect: "Boon of the War Snapper", Effect Duration: 24
 7564	improved cold-filtered mocking turtle	0		Effect: "Glo-Face", Effect Duration: 43
-7565	normal tumbling green ham steak	3	good	
+7565	normal green tumbling ham steak	3	good	
 7566	time-twitching toolbelt of the overflowing toilet	0		Stench Spell Damage: +50, Single Equip, Free Pull
 7567	bouncing Chroner	0		
 7568	Time Lord Badge of Honor of Calamity Jane of bravery of temperance	0		Critical Hit Percent: +15, Spooky Resistance: +5, Sleaze Resistance: +5
@@ -7462,28 +7462,28 @@
 7573	steel-toed kiwi beak of the cougar	0		Moxie: +20, Damage Reduction: 9
 7574	delicious New Zealand iced tea	3	awesome	
 7575	mirror reassuring sage droll monocle	0		Mysticality Percent: +10, Spooky Resistance: +1, Single Equip
-7576	polymerized concentrated cyan narrow shaking future drug: Muscularactum	0		Effect: "Sharp Weapon", Effect Duration: 31
-7577	pressed extra-diffused fuchsia wobbly future drug: Smartinex	0		Effect: "Sleazy Hands", Effect Duration: 62
+7576	polymerized concentrated shaking narrow cyan future drug: Muscularactum	0		Effect: "Sharp Weapon", Effect Duration: 31
+7577	pressed extra-diffused wobbly fuchsia future drug: Smartinex	0		Effect: "Sleazy Hands", Effect Duration: 62
 7578	magnetized future drug: Coolscaline	0		Effect: "Cake Caked", Effect Duration: 11
 7579	twitching time capsule	0		
-7580	modified twirling gray liquid shifting time weirdness	1		
+7580	modified gray twirling liquid shifting time weirdness	1		
 7581	shifting time weirdness	0		Adventures: +4, PvP Fights: +4
 7582	flavorless pulsating rack of dinosaur ribs	3	decent	
-7583	drinkable weak scotch on the rocks	2	good	
+7583	weak drinkable scotch on the rocks	2	good	
 7584	blurry Socratic yabba dabba doo rag of mayonnaise	0		Experience (Mysticality): +1, Sleaze Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 27"
 7585	avaricious clever wooly loincloth	0		Maximum MP: +20, Meat Drop: +30, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
-7588	blurry mirror Clan speakeasy	0		Free Pull, Last Available: "2014-07"
+7588	mirror blurry Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	acceptable triple-distilled glass of &quot;milk&quot;	10	good	Last Available: "2014-07"
 7590	watered-down fancy bad cup of &quot;tea&quot;	2	decent	Effect: "Ripping, Dripping", Effect Duration: 40, Last Available: "2014-07"
-7591	extra-dry bad thermos of &quot;whiskey&quot;	5	decent	Last Available: "2014-07"
+7591	bad extra-dry thermos of &quot;whiskey&quot;	5	decent	Last Available: "2014-07"
 7592	perfectly mixed practically non-alcoholic gray Lucky Lindy	1	super ultra mega turbo EPIC	Last Available: "2014-07"
 7593	perfectly mixed Bee's Knees	3	EPIC	Last Available: "2014-07"
-7594	tolerable triple-distilled Sockdollager	7	good	Last Available: "2014-07"
-7595	weak drinkable Ish Kabibble	2	good	Last Available: "2014-07"
+7594	triple-distilled tolerable Sockdollager	7	good	Last Available: "2014-07"
+7595	drinkable weak Ish Kabibble	2	good	Last Available: "2014-07"
 7596	tolerable Hot Socks	3	good	Last Available: "2014-07"
-7597	distilled artisanal shaking Phonus Balonus	5	EPIC	Last Available: "2014-07"
+7597	artisanal distilled shaking Phonus Balonus	5	EPIC	Last Available: "2014-07"
 7598	artisanal pulsating Flivver	4	EPIC	Last Available: "2014-07"
 7599	bad special Sloppy Jalopy	3	decent	Effect: "L'instinct F&eacute;lin", Effect Duration: 25, Last Available: "2014-07"
 7600	pickled polarized skewed flame	0		Effect: "Sepia Tan", Effect Duration: 63
@@ -7502,8 +7502,8 @@
 7613	anodized upside-down bubblin' chemistry solution	0		Effect: "Donho's Bubbly Ballad", Effect Duration: 17
 7614	pressed adjusted bouncing voodoo glowskull	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 51
 7615	unsweetened pulsating pygmy adder oil	0		Effect: "Crotchety, Pining", Effect Duration: 36
-7616	anodized jittery purple pygmy witchhazel	0		Effect: "Extra-Sharp Weapon", Effect Duration: 16
-7617	extra-pickled deionized bouncing narrow short deposition	0		Effect: "Blessing of Charcoatl", Effect Duration: 53
+7616	anodized purple jittery pygmy witchhazel	0		Effect: "Extra-Sharp Weapon", Effect Duration: 16
+7617	extra-pickled deionized narrow bouncing short deposition	0		Effect: "Blessing of Charcoatl", Effect Duration: 53
 7618	denatured shaking straw pole	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 64
 7619	warmed shaking copperhead potion	0		Effect: "Hobo Flavor", Effect Duration: 26
 7620	wet ionized tumbling twirling ninja fear powder	0		Effect: "Berry Elemental", Effect Duration: 62
@@ -7552,9 +7552,9 @@
 7663	up-at-dawn stanky Lord Soggyraven's Slippers of the dark arts	0		Spell Damage Percent: +100, Stench Spell Damage: +25, Adventures: +5, Single Equip
 7664	flattened electrified mirror Ancient Protector Soda	0		Effect: "The Dinsey Way", Effect Duration: 21
 7665	quadruple-enhanced liquid ice	0		Effect: "Radiant Personality", Effect Duration: 16
-7666	artisanal watered-down skewed Wet Russian	2	super EPIC	
-7667	diet decent filet of The Fish	1	good	
-7668	jittery teal Thwaitgold spider statuette	0		
+7666	watered-down artisanal skewed Wet Russian	2	super EPIC	
+7667	decent diet filet of The Fish	1	good	
+7668	teal jittery Thwaitgold spider statuette	0		
 7669	medical-grade healthy baleful thunder down underwear	0		Spell Damage: +25, Maximum HP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover
 7670	Lo Pan's occult Da Vinci's famous raincoat	0		Experience (Mysticality): +5, Spell Damage Percent: +25, Spell Critical Percent: +30, Lasts Until Rollover
 7671	censurious flame-wreathed lightning rod of the boozehound	0		Hot Spell Damage: +10, Sleaze Resistance: +3, Booze Drop: +100, Lasts Until Rollover
@@ -7581,27 +7581,27 @@
 7692	quilted hand whip of extreme caution of the overflowing toilet	0		Damage Absorption: +40, Monster Level: -25, Stench Spell Damage: +50, Last Available: "2014-08"
 7693	cyan electrified groovy glow-in-the-dark necklace of Flo-Jo	0		Moxie Percent: +10, Initiative: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	cyan tumbling auspicious cap gun of the bloodbag of Gandalf	0		Maximum HP: +100, Spell Critical Percent: +20, Item Drop: +10, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	cyan tumbling auspicious cap gun of the bloodbag of Gandalf	0		Maximum HP: +100, Spell Critical Percent: +20, Item Drop: +10, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	smooth cassette player of Calamity Jane	0		Moxie: +15, Critical Hit Percent: +15, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	nitrogenated concentrated confiscated comic book	0		Effect: "Superveiny 9000", Effect Duration: 18, Last Available: "2014-08"
 7701	magnetized huge tumbling confiscated cell phone	0		Effect: "Thicker, Sicker", Effect Duration: 34, Last Available: "2014-08"
-7702	extra-dry activated cyan narrow confiscated love note	0		Effect: "Macho Profundo", Effect Duration: 43, Last Available: "2014-08"
+7702	extra-dry activated narrow cyan confiscated love note	0		Effect: "Macho Profundo", Effect Duration: 43, Last Available: "2014-08"
 7703	purple LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	huge LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	green The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	super-irradiated double-quantum upside-down rubber nubbin	0		Effect: "Pork Power", Effect Duration: 11, Last Available: "2014-08"
 7708	sharpshooter's studded rubber cape	0		Damage Absorption: +80, Critical Hit Percent: +10, Last Available: "2014-08"
-7709	greedy flame-wreathed groovy sage Thor's Pliers	0		Mysticality Percent: +10, Moxie Percent: +10, Hot Spell Damage: +10, Meat Drop: +20, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	greedy flame-wreathed groovy sage Thor's Pliers	0		Mysticality Percent: +10, Moxie Percent: +10, Hot Spell Damage: +10, Meat Drop: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	ionized polymerized pickled candy UFOs	0		Effect: "Castaway Physique", Effect Duration: 55
 7711	Jim Carey's water wings for babies of James Dean	0		Experience (Moxie): +3, Monster Level: +25
 7712	blinking beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	toothsome Strix stix	3	awesome	
 7714	Samson's cool vampire pellet of extreme caution	0		Moxie: +5, Experience (Muscle): +5, Monster Level: -25
-7715	watered-down lousy non-aged vinegar	2	decent	
+7715	lousy watered-down non-aged vinegar	2	decent	
 7716	upside-down sharpshooter's unsanitized scalpel	0		Critical Hit Percent: +10
 7717	steel-toed gladiator tunica	0		Damage Reduction: 9
 7718	wholesome Roman sadnals	0		Maximum HP Percent: +10, Single Equip
@@ -7657,10 +7657,10 @@
 7768	one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	Lo Pan's weightlifter's Personal Ventilation Unit of extreme caution	0		Muscle: +15, Spell Critical Percent: +30, Monster Level: -25, Single Equip, Last Available: "2014-10"
-7771	tarnished non-diffused huge squat the most dangerous bait	0		Effect: "Wistfully Nostalgic", Effect Duration: 50, Last Available: "2014-10"
+7771	tarnished non-diffused squat huge the most dangerous bait	0		Effect: "Wistfully Nostalgic", Effect Duration: 50, Last Available: "2014-10"
 7772	small delicious &quot;meat&quot; stick	2	awesome	Last Available: "2014-10"
 7773	modified transdermal smoke patch	1	crappy	Effect: "The Power of LOV", Effect Duration: 15, Last Available: "2014-10"
-7774	narrow skewed specialty ammo bandolier	0		Last Available: "2014-10"
+7774	skewed narrow specialty ammo bandolier	0		Last Available: "2014-10"
 7775	reassuring slick pair of plants of the detective	0		Moxie: +10, Spooky Resistance: +1, Item Drop: +20, Last Available: "2014-10"
 7776	Usain Bolt's lion tamer's Sasq&trade; watch of the detective	0		Experience (familiar): +2, Item Drop: +20, Initiative: +80, Single Equip, Last Available: "2014-10"
 7777	nasty brainy smoker's cloak of the scaredy-cat	0		Mysticality: +5, Monster Level: -15, Stench Damage: +5, Last Available: "2014-10"
@@ -7668,12 +7668,12 @@
 7779	polarized experimental serum G-9	0		Effect: "Mmmmmelon", Effect Duration: 66, Last Available: "2014-10"
 7780	energetic heavy-duty clipboard of courage of temperance	0		Maximum MP Percent: +20, Spooky Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 8, Last Available: "2014-10"
 7781	cyan family-friendly wool stanky Oprah's battery-powered drill	0		Maximum MP Percent: +50, Stench Spell Damage: +25, Cold Resistance: +1, Sleaze Resistance: +1, Last Available: "2014-10"
-7782	decent massive limp broccoli	6	good	Last Available: "2014-10"
+7782	massive decent limp broccoli	6	good	Last Available: "2014-10"
 7783	double-paned gravedigger's Sinatra's hat	0		Experience (Moxie): +5, Spooky Damage: +10, Cold Resistance: +5, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	anodized ghostly monkey barf	0		Effect: "items.enh", Effect Duration: 43, Last Available: "2014-10"
 7785	wet candy	0		Effect: "Elvish", Effect Duration: 41, Last Available: "2014-10"
 7786	Tesla educational jangly bracelet of the bloodbag	0		Experience: +1, Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
-7787	spinning cuddly teddy bear of the empath	0		Familiar Weight: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	spinning cuddly teddy bear of the empath	0		Familiar Weight: +5, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	padded forbidden first-aid pouch	0		Spell Damage Percent: +50, Damage Absorption: +20, Last Available: "2014-10"
 7790	red khaki duffel bag	0		Last Available: "2014-10"
@@ -7683,10 +7683,10 @@
 7794	tumbling Armory keycard	0		Last Available: "2014-10"
 7795	rotten initiative shawarma	4	crappy	Last Available: "2014-10"
 7796	rotten diet upside-down warm war shawarma	1	crappy	Last Available: "2014-10"
-7797	huge adequate olive karma shawarma	8	good	Last Available: "2014-10"
+7797	adequate huge olive karma shawarma	8	good	Last Available: "2014-10"
 7798	lousy Jungle Juice	3	decent	Last Available: "2014-10"
-7799	tolerable high-proof jittery Amnesiac Ale	7	good	Last Available: "2014-10"
-7800	hand-crafted weak Highest Bitter	2	super EPIC	Last Available: "2014-10"
+7799	high-proof tolerable jittery Amnesiac Ale	7	good	Last Available: "2014-10"
+7800	weak hand-crafted Highest Bitter	2	super EPIC	Last Available: "2014-10"
 7801	mirror lightning-fast mercenary pistol of the businessman	0		Meat Drop: +50, Initiative: +40, Last Available: "2014-10"
 7802	Temple Grandin's Oprah's mercenary rifle	0		Maximum MP Percent: +50, Familiar Weight: +7, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
@@ -7700,7 +7700,7 @@
 7811	shaking viral DNA	0		
 7812	green tarnished bottlecap	0		
 7813	spoiled twirling seared dino steak	3	crappy	
-7814	practically non-alcoholic drinkable bottle of drinkin' gas	1	good	
+7814	drinkable practically non-alcoholic bottle of drinkin' gas	1	good	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	narrow gelatinous meat mass	0		
@@ -7734,8 +7734,8 @@
 7845	dry perl necklace	0		Effect: "Christmessy", Effect Duration: 41, Last Available: "2014-12"
 7846	pickled Fudge Fiber Armor Plating	0		Effect: "Blood-Gorged", Effect Duration: 48, Last Available: "2014-12"
 7847	dry denatured lime green ruby on canes	0		Effect: "Shrimpin' Ain't Easy", Effect Duration: 42, Last Available: "2014-12"
-7848	bland immense maroon petit fortran	7	decent	Last Available: "2014-12"
-7849	special adequate java cookie	3	good	Effect: "Memories of Puppy Love", Effect Duration: 30, Last Available: "2014-12"
+7848	immense bland maroon petit fortran	7	decent	Last Available: "2014-12"
+7849	adequate special java cookie	3	good	Effect: "Memories of Puppy Love", Effect Duration: 30, Last Available: "2014-12"
 7850	toothsome cookie cookie	3	awesome	Last Available: "2014-12"
 7851	pulsating Jeselnik's plastic exo-suited miner	0		Sleaze Damage: +25, Last Available: "2014-12"
 7852	bouncing tumbling smartaleck's plastic semi-autonomous drill unit	0		Moxie Percent: +30, Last Available: "2014-12"
@@ -7751,12 +7751,12 @@
 7862	cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	spinning Petite Paintbrush	0		Adventures: +1
-7865	squat blurry Crimbot schematic: Gun Face	0		Last Available: "2014-12"
+7865	blurry squat Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	blinking Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	jittery Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	Crimbot schematic: Crab Core	0		Last Available: "2014-12"
-7870	lime green shaking Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
+7870	shaking lime green Crimbot schematic: Dynamo Head	0		Last Available: "2014-12"
 7871	olive tumbling Crimbot schematic: Cyclopean Torso	0		Last Available: "2014-12"
 7872	maroon Crimbot schematic: Really Big Head	0		Last Available: "2014-12"
 7873	Crimbot schematic: Nerding Module	0		Last Available: "2014-12"
@@ -7779,7 +7779,7 @@
 7890	Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
-7893	yellow bouncing Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
+7893	bouncing yellow Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
 7894	Crimbot schematic: Lamp Filler	0		Last Available: "2014-12"
 7895	Crimbot schematic: Heavy-Duty Legs	0		Last Available: "2014-12"
 7896	Crimbot schematic: Tripod Legs	0		Last Available: "2014-12"
@@ -7810,14 +7810,14 @@
 7921	upside-down blue turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
 7922	bad triple-distilled Friendly Turkey	9	decent	Last Available: "2014-11"
 7923	weak hand-crafted Agitated Turkey	2	EPIC	Last Available: "2014-11"
-7924	tolerable boozy narrow Ambitious Turkey	5	good	Last Available: "2014-11"
+7924	boozy tolerable narrow Ambitious Turkey	5	good	Last Available: "2014-11"
 7925	stale ghostly neutron lollipop	3	decent	Last Available: "2014-12"
-7926	watered-down hand-crafted gamma nog	2	EPIC	Last Available: "2014-12"
+7926	hand-crafted watered-down gamma nog	2	EPIC	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	upside-down picky tweezers	0		Last Available: "2015-02"
 7937	ghostly Crimbo Credit	0		
-7938	compressed skewed mirror fuchsia single atom	1	decent	Last Available: "2015-02"
+7938	compressed fuchsia mirror skewed single atom	1	decent	Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	green Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
@@ -7827,7 +7827,7 @@
 7945	table	0		
 7946	wool educational outlaw bandana of doom	0		Experience: +1, Spooky Spell Damage: +50, Cold Resistance: +1
 7947	aged whiskey in a broken glass	3	awesome	
-7948	practically non-alcoholic lousy shot of mescal	1	decent	
+7948	lousy practically non-alcoholic shot of mescal	1	decent	
 7949	tolerable glass of herbal tequila	4	good	
 7950	minin' dynamite	0		
 7951	foul-smelling baleful plaid cowboy hat	0		Spell Damage: +25, Stench Damage: +10, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7851,7 +7851,7 @@
 7969	squat beehive	0		
 7970	mirror boning knife	0		
 7971	maroon Aggressive Carrot	0		Free Pull
-7972	denatured squat ghostly olive mummified fig	1	good	Effect: "Stimulated Body", Effect Duration: 20
+7972	denatured ghostly squat olive mummified fig	1	good	Effect: "Stimulated Body", Effect Duration: 20
 7973	diluted skewed wobbly teal mummified loaf of bread	1	crappy	
 7974	altered narrow mummified beef haunch	1	awesome	Effect: "Biologically Shocked", Effect Duration: 10
 7975	linen bandages	0		
@@ -7861,7 +7861,7 @@
 7979	spirit beer	0		
 7980	sacramental wine	0		
 7981	bouncing talisman of Thoth	0		
-7982	mirror jittery cure-all	0		
+7982	jittery mirror cure-all	0		
 7983	Sherlock's Da Vinci's Sister Accessory	0		Experience (Mysticality): +5, Item Drop: +25, Softcore Only
 7984	vacuum-sealed anodized shaking Boosty Juice	0		Effect: "Ready to Snap", Effect Duration: 43
 7985	purple shaking quilted parachute of temperance	0		Damage Absorption: +40, Sleaze Resistance: +5, Last Available: "2015-12"
@@ -7880,18 +7880,18 @@
 7998	distilled skewed powder	1		Effect: "Blood-Rich", Effect Duration: 40, Last Available: "2015-12"
 7999	boiled chilled squat choco-Crimbot	0		Effect: "Papowerful", Effect Duration: 22, Last Available: "2014-12"
 8000	nitrogenated ionized smart watch	0		Effect: "Tingling Feeling", Effect Duration: 39, Last Available: "2014-12"
-8001	non-modified energized mirror cyan augmented-reality shades	0		Effect: "Tiki Temerity", Effect Duration: 61, Last Available: "2014-12"
-8002	coward's toy Crimbot mega face	0		Monster Level: -20, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
-8003	cyan toy Crimbot power glove of the brute	0		Muscle Percent: +30, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	toy Crimbot super fist of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8001	non-modified energized cyan mirror augmented-reality shades	0		Effect: "Tiki Temerity", Effect Duration: 61, Last Available: "2014-12"
+8002	coward's toy Crimbot mega face	0		Monster Level: -20, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8003	cyan toy Crimbot power glove of the brute	0		Muscle Percent: +30, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	toy Crimbot super fist of incineration	0		Hot Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of the businessman	0		Meat Drop: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	electrified warmed Crimbot battery	0		Effect: "Filled with Magic", Effect Duration: 40, Last Available: "2014-12"
 8007	shaking Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	prompt Sherlock's wizardly Crimbomega drive chain	0		Mysticality: +25, Item Drop: +25, Adventures: +3, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	prompt Sherlock's wizardly Crimbomega drive chain	0		Mysticality: +25, Item Drop: +25, Adventures: +3, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7899,7 +7899,7 @@
 8017	denatured corrupted flask of tainted mining oil	0		Effect: "Armored Innards", Effect Duration: 54, Last Available: "2014-12"
 8018	denatured irradiated spinning and rain stick	0		Effect: "Outer Wolf&trade;", Effect Duration: 52
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
-8020	diet toothsome enchanted Choco-Mint patty	1	awesome	Effect: "Yuletide Industry", Effect Duration: 40, Last Available: "2015-01"
+8020	toothsome diet enchanted Choco-Mint patty	1	awesome	Effect: "Yuletide Industry", Effect Duration: 40, Last Available: "2015-01"
 8021	perfectly mixed watered-down hot mint schnocolate	2	EPIC	Last Available: "2015-01"
 8022	vaporized ghostly homeopathic mint tea	1	decent	Effect: "The Grass...  Is Blue...", Effect Duration: 20, Last Available: "2015-01"
 8023	bouncing muscle stimulator	0		Last Available: "2015-01"
@@ -7996,7 +7996,7 @@
 8121	squat sharpshooter's extremely unsafe garland	0		Weapon Damage Percent: +100, Critical Hit Percent: +10, Single Equip, Last Available: "2018-12"
 8122	gunnysack of temperance of the detective	0		Sleaze Resistance: +5, Item Drop: +20, Last Available: "2018-12"
 8123	inspector's rock-hard garibaldi	0		Damage Reduction: 5, Item Drop: +15, Last Available: "2018-12"
-8124	girdle of terror of the glutton	0		Spooky Spell Damage: +10, Food Drop: +100, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	girdle of terror of the glutton	0		Spooky Spell Damage: +10, Food Drop: +100, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	huge narrow hale weightlifter's gloves	0		Muscle: +15, Maximum HP: +20, Single Equip, Last Available: "2018-12"
 8126	denatured huge fuchsia smithereens	1		Last Available: "2018-12"
 8127	mirror avaricious reassuring fiberglass fetish	0		Spooky Resistance: +1, Meat Drop: +30, Last Available: "2018-12"
@@ -8030,7 +8030,7 @@
 8156	check to the Meatsmith	0		
 8157	Skeleton Store office key	0		
 8158	gray bone with a price tag on it	0		
-8159	maroon mirror half of a tooth	0		
+8159	mirror maroon half of a tooth	0		
 8160	corrupted mouse skull	0		Effect: "Fungal Fortification", Effect Duration: 56
 8161	vacuum-sealed cold-filtered really thick spine	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 45
 8162	ghostly crafty stiffened skullcap	0		Damage Reduction: 1, Maximum MP: +10, Familiar Effect: "1xVolley,cap 5"
@@ -8042,7 +8042,7 @@
 8168	glob of icing	0		
 8169	super-deionized unsweetened ginger snaps	0		Effect: "Chalked-Up Teeth", Effect Duration: 69
 8170	chilled double-dry denatured spinning mostly-broken sunglasses	0		Effect: "Sweet Nostalgia", Effect Duration: 42
-8171	high-proof smooth unflavored wine cooler	8	awesome	
+8171	smooth high-proof unflavored wine cooler	8	awesome	
 8172	enchanted carton of snake milk	1	decent	Effect: "Material Witness", Effect Duration: 20
 8173	dog trainer's sewer snake	0		Experience (familiar): +1
 8174	huge adequate pigeon egg	8	good	
@@ -8061,13 +8061,13 @@
 8187	wobbly map to a hidden booze cache	0		
 8188	watered-down artisanal Cherrytastrophe wine cooler	2	EPIC	
 8189	lousy Radberry Rip wine cooler	4	decent	
-8190	lousy practically non-alcoholic Orangemageddon wine cooler	1	decent	
-8191	watered-down lousy blue Breakfast Blast wine cooler	2	decent	
+8190	practically non-alcoholic lousy Orangemageddon wine cooler	1	decent	
+8191	lousy watered-down blue Breakfast Blast wine cooler	2	decent	
 8192	hand-crafted Citrus Crush wine cooler	3	EPIC	
-8193	stale miniature plain bagel	2	decent	
+8193	miniature stale plain bagel	2	decent	
 8194	spoiled glob of cream cheese	3	crappy	
 8195	huge normal loaf of soda bread	9	good	
-8196	normal low-calorie jittery acceptable bagel	1	good	
+8196	low-calorie normal jittery acceptable bagel	1	good	
 8197	snack-sized rotten standard-issue cupcake	2	crappy	
 8198	decent ultra-deluxe cupcake	3	good	
 8199	skewed blurry hypnotic breadcrumbs	0		
@@ -8086,7 +8086,7 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	miser's rigging rope of the detective	0		Item Drop: +20, Meat Drop: +10, Last Available: "2015-04"
 8214	mixed ghostly nasty snuff	1	decent	Last Available: "2015-04"
-8215	knitted sewage-clogged pistol of extreme caution	0		Monster Level: -25, Cold Resistance: +3, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	knitted sewage-clogged pistol of extreme caution	0		Monster Level: -25, Cold Resistance: +3, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	enhanced ionized tumbling shaking beard incense	0		Effect: "Eyes All Black", Effect Duration: 20, Last Available: "2015-04"
 8217	red rock-hard perfume-soaked bandana of temperance	0		Damage Reduction: 5, Sleaze Resistance: +5, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	lard-coated lube-shoes	0		Sleaze Spell Damage: +25, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	up-at-dawn perfumed Dinsey mascot mask of the ox	0		Muscle: +20, Stench Resistance: +5, Adventures: +5, Last Available: "2015-04"
-8247	super-sized rotten yellow Dinsey food-cone	5	crappy	Last Available: "2015-04"
+8247	rotten super-sized yellow Dinsey food-cone	5	crappy	Last Available: "2015-04"
 8248	delicious Dinsey Whinskey	3	awesome	Last Available: "2015-04"
 8249	extra-chilled Dinsey face paint	0		Effect: "French Bronilla Brogueishness", Effect Duration: 24, Last Available: "2015-04"
 8250	squat hale fannypack of incineration	0		Maximum HP: +20, Hot Spell Damage: +50, Last Available: "2015-04"
@@ -8128,7 +8128,7 @@
 8254	tumbling blurry Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	ghostly pulsating Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	blurry Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	unsweetened energized super-moist maroon skewed nasty gum	0		Effect: "substats.enh", Effect Duration: 48
+8257	unsweetened energized super-moist skewed maroon nasty gum	0		Effect: "substats.enh", Effect Duration: 48
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	Socratic The Lot's engagement ring	0		Experience (Mysticality): +1, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	Mayo Clinic	0		Last Available: "2015-05"
@@ -8143,13 +8143,13 @@
 8269	purple mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	bland blue unappetizing mayolus	4	decent	Last Available: "2015-05"
 8271	decent uninteresting mayolus	3	good	Last Available: "2015-05"
-8272	decent snack-sized acceptable mayolus	2	good	Last Available: "2015-05"
+8272	snack-sized decent acceptable mayolus	2	good	Last Available: "2015-05"
 8273	rotten enticing mayolus	4	crappy	Last Available: "2015-05"
 8274	rotten mouth-watering mayolus	4	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	red mayo pump	0		Familiar Weight: +5
 8277	olive Essence of Bear	0		Skill: "Bear Essence"
-8278	irresponsibly strong tolerable pulsating Afternoon Delight	7	good	Last Available: "2015-04"
+8278	tolerable irresponsibly strong pulsating Afternoon Delight	7	good	Last Available: "2015-04"
 8279	Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	blurry Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	non-polymerized altered Kokomo Resort Brand Suntan Oil	0		Effect: "Celestial Body", Effect Duration: 35, Last Available: "2015-04"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	colloidal extra-dry green power pill	0		Effect: "All Blued Up", Effect Duration: 49, Last Available: "2015-06"
 8301	dry pixel star	0		Effect: "Hairless and Airless", Effect Duration: 13, Last Available: "2015-06"
-8302	small delicious pixel banana	2	awesome	Last Available: "2015-06"
+8302	delicious small pixel banana	2	awesome	Last Available: "2015-06"
 8303	tolerable pixel beer	3	good	Last Available: "2015-06"
 8304	squat puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8181,11 +8181,11 @@
 8307	deionized teal narrow &Uuml;berraschthexengebr&auml;u	0		Effect: "Boschface", Effect Duration: 55
 8308	moist cold-filtered piggy tattoo	0		Effect: "Hot Buttoned", Effect Duration: 50
 8309	denatured liquefied baggie of regular-sized tardigrades	0		Effect: "Initiative and Let Die", Effect Duration: 65
-8310	non-liquefied polarized twirling skewed .epub file	0		Effect: "Drenched With Filth", Effect Duration: 14
+8310	non-liquefied polarized skewed twirling .epub file	0		Effect: "Drenched With Filth", Effect Duration: 14
 8311	triple-oxidized improved BUBBLE GUM	0		Effect: "Blessing of Charcoatl", Effect Duration: 17
 8312	warmed electrified twirling hustler shades	0		Effect: "Smugness", Effect Duration: 32
 8313	denatured jerky stick	0		Effect: "Here to Kick Ass", Effect Duration: 19
-8314	liquefied oxidized extra-polymerized olive pulsating costume rental shop	0		Effect: "Phoenix, Right?", Effect Duration: 44
+8314	liquefied oxidized extra-polymerized pulsating olive costume rental shop	0		Effect: "Phoenix, Right?", Effect Duration: 44
 8315	pressed muscle oil	0		Effect: "Brain Freeze", Effect Duration: 50
 8316	dry blinking bottle of Red-Out	0		Effect: "Full of Vinegar", Effect Duration: 34
 8317	pressed mirror pickpocket protector	0		Effect: "Flexibili Tea", Effect Duration: 39
@@ -8194,7 +8194,7 @@
 8320	extra-vacuum-sealed wobbly one glove	0		Effect: "Dance Interpreter", Effect Duration: 18
 8321	ionized glove	0		Effect: "Mucilaginous Muscle", Effect Duration: 27
 8322	deionized Vulcanized liquefied handful of fire	0		Effect: "Tightly-Wound Spine", Effect Duration: 43
-8323	frozen shaking teal Cracklin' Oat Bran	0		Effect: "Berry Berry Cold", Effect Duration: 24
+8323	frozen teal shaking Cracklin' Oat Bran	0		Effect: "Berry Berry Cold", Effect Duration: 24
 8324	irradiated alkaline polymerized disposable lighter	0		Effect: "Corona de la Salsa", Effect Duration: 27
 8325	frozen diffused coal contact lenses	0		Effect: "Spiky Hair", Effect Duration: 42
 8326	altered conjured ice cream	0		Effect: "Can Has Cyborger", Effect Duration: 49
@@ -8225,15 +8225,15 @@
 8351	dry modified narrow lump of goofball ore	0		Effect: "Corruption of Wretched Wally", Effect Duration: 52
 8352	corrupted ionized skeleton beans	0		Effect: "Covetous Robbery", Effect Duration: 40
 8353	anodized dry red grimy lab coat	0		Effect: "Influence of Sphere", Effect Duration: 11
-8354	alkaline cyan skewed nursery rhyme	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 28
-8355	triple-irradiated nitrogenated ghostly lime green iron torso box	0		Effect: "Scorpio Rising", Effect Duration: 48
+8354	alkaline skewed cyan nursery rhyme	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 28
+8355	triple-irradiated nitrogenated lime green ghostly iron torso box	0		Effect: "Scorpio Rising", Effect Duration: 48
 8356	adjusted non-diffused concentrated mercenary headband	0		Effect: "Stinking Cloud", Effect Duration: 65
 8357	galvanized energized narrow radioactive spider venom	0		Effect: "Tingly Wrists", Effect Duration: 52
 8358	anodized alkaline flattened wobbly x-ray mirror	0		Effect: "Sauce Monocle", Effect Duration: 34
 8359	oxidized jittery wrestling mask	0		Effect: "Grape Expectations", Effect Duration: 51
 8360	modified double-diffused irradiated hawkface potion	0		Effect: "Heart of Green", Effect Duration: 42
 8361	super-flattened altered narrow child-sized dracula cloak	0		Effect: "Sugar Smacks", Effect Duration: 59
-8362	irradiated olive blurry devil-summoning hat	0		Effect: "critical.enh", Effect Duration: 64
+8362	irradiated blurry olive devil-summoning hat	0		Effect: "critical.enh", Effect Duration: 64
 8363	ionized ghostly shopkeeper beard	0		Effect: "Crud&eacute;", Effect Duration: 22
 8364	energized triple-deionized upside-down alien autoautopsy kit	0		Effect: "Patched In", Effect Duration: 68
 8365	warmed Vulcanized blurry novelty fruit hat	0		Effect: "Super Speed", Effect Duration: 12
@@ -8248,8 +8248,8 @@
 8374	nitrogenated liquefied red drinks tray	0		Effect: "Gyromitra Gymnastics", Effect Duration: 28
 8375	irradiated non-denatured eyebrow lifter	0		Effect: "Cold Jellied", Effect Duration: 14
 8376	submarine	0		Last Available: "2015-06"
-8377	gigantic adequate blurry pixel lemon	6	good	Last Available: "2015-06"
-8378	weak bad maroon pixel daiquiri	2	decent	Last Available: "2015-06"
+8377	adequate gigantic blurry pixel lemon	6	good	Last Available: "2015-06"
+8378	bad weak maroon pixel daiquiri	2	decent	Last Available: "2015-06"
 8379	chilled ghostly power pill	0		Effect: "Toothy Grin", Effect Duration: 55, Last Available: "2015-06"
 8380	ionized quantum liquefied pixel potion	0		Effect: "Cranberry Cordiality", Effect Duration: 64, Last Available: "2015-06"
 8381	Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8278,23 +8278,23 @@
 8404	blue 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	ghostly talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	half-sized bland fancy pestopiary	2	decent	Effect: "Celestial Body", Effect Duration: 5
+8407	bland half-sized fancy pestopiary	2	decent	Effect: "Celestial Body", Effect Duration: 5
 8408	boiled ionized fuchsia ectoplasmic orbs	0		Effect: "Weapon of Mass Destruction", Effect Duration: 49
-8409	small flavorless crudles	2	decent	
+8409	flavorless small crudles	2	decent	
 8410	moldy agnolotti arboli	4	crappy	
 8411	decent cyan spaghetti with ghost balls	3	good	
 8412	stale enchanted succulent marrow	3	decent	Effect: "Saucemastery", Effect Duration: 20
 8413	moldy salacious crumbs	3	crappy	
-8414	fancy bland half-sized fusilli marrownarrow	2	decent	Effect: "Booooooze", Effect Duration: 20
+8414	half-sized bland fancy fusilli marrownarrow	2	decent	Effect: "Booooooze", Effect Duration: 20
 8415	tasty suggestive strozzapreti	4	awesome	
 8416	Mountain Stream gastrique	0		
 8417	gigantic spoiled gray Mt. McLargeHuge oyster	7	crappy	
 8418	tumbling oyster sauce	0		
 8419	normal linguini immondizia bianco	3	good	
-8420	tasty tiny shells a la shellfish	1	awesome	
+8420	tiny tasty shells a la shellfish	1	awesome	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
-8423	skewed green unsmoothed velvet	0		Last Available: "2015-08"
+8423	green skewed unsmoothed velvet	0		Last Available: "2015-08"
 8424	1,970 carat	0		Last Available: "2015-08"
 8425	lime green ghostly New Age healing crystal	0		Last Available: "2015-08"
 8426	narrow Volcoino	0		Last Available: "2015-08"
@@ -8332,7 +8332,7 @@
 8458	shellacked high-temperature mining mask of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	skewed Van der Graaf stiffened fireproof megaphone	0		Damage Reduction: 1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-08"
 8460	normal mineapple	4	good	Last Available: "2015-08"
-8461	watered-down artisanal Gold Velvet&trade; whiskey	2	EPIC	Last Available: "2015-08"
+8461	artisanal watered-down Gold Velvet&trade; whiskey	2	EPIC	Last Available: "2015-08"
 8462	huge SMOOCH soda	1	awesome	Last Available: "2015-08"
 8463	yummy smelted roe	3	awesome	Last Available: "2015-08"
 8464	perfectly mixed lavawater	3	EPIC	Last Available: "2015-08"
@@ -8341,14 +8341,14 @@
 8467	olive mirror double-paned groovy lava balaclava of temperance	0		Moxie Percent: +10, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2015-08"
 8468	blurry censurious rosewater-soaked Jack Frost's basaltamander buckler	0		Cold Spell Damage: +50, Stench Resistance: +3, Sleaze Resistance: +3, Damage Reduction: 15, Last Available: "2015-08"
 8469	electrified tarnished lava globs	0		Effect: "Tingly Wrists", Effect Duration: 61, Last Available: "2015-08"
-8470	adequate jumbo gooey lava globs	5	good	Last Available: "2015-08"
+8470	jumbo adequate gooey lava globs	5	good	Last Available: "2015-08"
 8471	medical-grade lava-proof pants	0		Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-08"
 8472	heat-resistant necktie of the dark arts of the blizzard	0		Spell Damage Percent: +100, Cold Spell Damage: +25, Single Equip, Last Available: "2015-08"
 8473	Usain Bolt's smartaleck's heat-resistant gloves of the brute	0		Muscle Percent: +30, Moxie Percent: +30, Initiative: +80, Single Equip, Last Available: "2015-08"
-8474	snack-sized normal very hot lunch	2	good	Last Available: "2015-08"
+8474	normal snack-sized very hot lunch	2	good	Last Available: "2015-08"
 8475	hand-crafted asbestos thermos	4	EPIC	Last Available: "2015-08"
 8476	diffused magnetized liquid rhinestones	0		Effect: "Sealed Brain", Effect Duration: 60, Last Available: "2015-08"
-8477	immense rotten wobbly disco biscuit	10	crappy	Last Available: "2015-08"
+8477	rotten immense wobbly disco biscuit	10	crappy	Last Available: "2015-08"
 8478	bad lime green Quaatorade&trade;	3	decent	Last Available: "2015-08"
 8479	green knitted lard-coated biker's hat of the scaredy-cat	0		Monster Level: -15, Sleaze Spell Damage: +25, Cold Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
 8480	extremely unsafe grievous feathered headdress of the storm	0		Weapon Damage Percent: 150, Maximum MP Percent: +40, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
@@ -8378,7 +8378,7 @@
 8504	Lavalos core	0		Last Available: "2015-08"
 8505	blurry half-melted hula girl	0		Last Available: "2015-08"
 8506	shaking glass ceiling fragments	0		Last Available: "2015-08"
-8507	modified wobbly squat SMOOCH coffee cup	1	decent	Effect: "Disco Neuropathy", Effect Duration: 45, Last Available: "2015-08"
+8507	modified squat wobbly SMOOCH coffee cup	1	decent	Effect: "Disco Neuropathy", Effect Duration: 45, Last Available: "2015-08"
 8508	corrupted labrador cookie	0		Effect: "Educated (Kinda)", Effect Duration: 67, Last Available: "2015-08"
 8509	wobbly up-at-dawn careful quilted Mr. Cheeng's spectacles	0		Damage Absorption: +40, Monster Level: -10, Adventures: +5, Single Equip, Last Available: "2015-08"
 8510	vibrating sage grease cannon	0		Mysticality Percent: +10, Maximum MP Percent: +10, Last Available: "2015-08"
@@ -8396,7 +8396,7 @@
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	gigantic moldy lava cake	10	crappy	Last Available: "2015-08"
+8525	moldy gigantic lava cake	10	crappy	Last Available: "2015-08"
 8526	yummy massive twirling green pink slime	10	awesome	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
@@ -8405,7 +8405,7 @@
 8531	spinning Salsa Libre	0		
 8532	good gravy	0		
 8533	tumbling illicit fish sauce	0		
-8534	small spoiled blinking libertagliatelle	2	crappy	
+8534	spoiled small blinking libertagliatelle	2	crappy	
 8535	rotten fancy turkish mostaccioli	4	crappy	Effect: "Bustle Hustlin'", Effect Duration: 10
 8536	delicious twirling linguini of the sea	4	awesome	
 8537	aerosolized squat Hersey&trade; SMOOCH	0		Effect: "Object Detection", Effect Duration: 20
@@ -8413,15 +8413,15 @@
 8540	maroon rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	spoiled Fettris	3	crappy	
-8543	decent fancy fuchsia fusillocybin	3	good	Effect: "Greasy Flavor", Effect Duration: 5
+8543	fancy decent fuchsia fusillocybin	3	good	Effect: "Greasy Flavor", Effect Duration: 5
 8544	bland twirling prescription noodles	4	decent	
-8545	twisted blinking skewed blood-drive sticker	1	good	
+8545	twisted skewed blinking blood-drive sticker	1	good	
 8546	pressed adjusted bag of grain	0		Effect: "Sealed Brain", Effect Duration: 49
 8547	galvanized pocket maze	0		Effect: "init.enh", Effect Duration: 39
 8548	chilled improved shady shades	0		Effect: "Patience of the Tortoise", Effect Duration: 13
 8549	oxidized huge lime green squeaky toy rose	0		Effect: "It Tickles!  It Tickles!", Effect Duration: 56
-8550	delicious diet weird gazelle steak	1	awesome	
-8551	small delicious sausage without a cause	2	awesome	
+8550	diet delicious weird gazelle steak	1	awesome	
+8551	delicious small sausage without a cause	2	awesome	
 8552	polarized face paint	0		Effect: "Fury of the Bells", Effect Duration: 16
 8553	bad emergency margarita	3	decent	
 8554	watered-down smooth vintage smart drink	2	awesome	
@@ -8429,7 +8429,7 @@
 8556	bouncing Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
 8558	oxidized skewed Wickers bar	0		Effect: "Radiated and Grodiated", Effect Duration: 55
-8559	pressed wet oxidized bouncing twirling bakelite-covered bacon	0		Effect: "Bolts about Candy", Effect Duration: 56
+8559	pressed wet oxidized twirling bouncing bakelite-covered bacon	0		Effect: "Bolts about Candy", Effect Duration: 56
 8560	altered boiled spinning Aerheads	0		Effect: "Serenity", Effect Duration: 57
 8561	alkaline altered Wrotz	0		Effect: "Demonic Flavor", Effect Duration: 67
 8562	tarnished improved squat Gabarbar	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 16
@@ -8449,7 +8449,7 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	practically non-alcoholic bad bottle of Amontillado	1	decent	Last Available: "2015-09"
-8579	bad weak barrel-aged martini	2	decent	Last Available: "2015-09"
+8579	weak bad barrel-aged martini	2	decent	Last Available: "2015-09"
 8580	miniature tasty barrel pickle	2	awesome	Last Available: "2015-09"
 8581	adequate special barrel cracker	3	good	Effect: "How to Scam Tourists", Effect Duration: 30, Last Available: "2015-09"
 8582	diluted tumbling vibrating mushroom	1	good	Effect: "Marinated", Effect Duration: 20, Last Available: "2015-09"
@@ -8470,7 +8470,7 @@
 8597	bouncing hale barrel beryl nose ring of extreme caution	0		Maximum HP: +20, Monster Level: -25, Last Available: "2015-09"
 8598	barrel beryl ring of the scaredy-cat of bravery	0		Monster Level: -15, Spooky Resistance: +5, Last Available: "2015-09"
 8599	blinking map to the Biggest Barrel	0		Last Available: "2015-09"
-8600	twirling blinking potted tea tree	0		Last Available: "2015-09"
+8600	blinking twirling potted tea tree	0		Last Available: "2015-09"
 8601	colloidal tumbling bouncing cuppa Flamibili tea	0		Effect: "Artificially Sweet", Effect Duration: 52, Last Available: "2015-09"
 8602	tarnished cuppa Yet tea	0		Effect: "The Smile of Mr. A.", Effect Duration: 27, Last Available: "2015-09"
 8603	enhanced irradiated cuppa Boo tea	0		Effect: "Brain Freeze", Effect Duration: 45, Last Available: "2015-09"
@@ -8494,14 +8494,14 @@
 8621	anodized concentrated galvanized cuppa Irritabili tea	0		Effect: "Woad Warrior", Effect Duration: 69, Last Available: "2015-09"
 8622	deionized spinning cuppa Mediocri tea	0		Effect: "Pasty", Effect Duration: 60, Last Available: "2015-09"
 8623	galvanized galvanized wobbly cuppa Loyal tea	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 37, Last Available: "2015-09"
-8624	dried jittery jittery blue cuppa Activi tea	1	decent	Last Available: "2015-09"
+8624	dried blue jittery jittery cuppa Activi tea	1	decent	Last Available: "2015-09"
 8625	twisted pulsating cuppa Cruel tea	1		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 40, Last Available: "2015-09"
 8626	adjusted galvanized pressed cuppa Alacri tea	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 46, Last Available: "2015-09"
 8627	liquefied cuppa Vitali tea	0		Effect: "Hyphemariffic", Effect Duration: 44, Last Available: "2015-09"
 8628	pickled galvanized cuppa Mana tea	0		Effect: "New Zeal", Effect Duration: 21, Last Available: "2015-09"
 8629	quadruple-flattened ghostly cuppa Monstrosi tea	0		Effect: "Outer Wolf&trade;", Effect Duration: 41, Last Available: "2015-09"
 8630	pressed colloidal skewed cuppa Twen tea	0		Effect: "Horrid, Torrid", Effect Duration: 67, Last Available: "2015-09"
-8631	aerosolized narrow blurry red cuppa Gill tea	0		Effect: "On a Roll", Effect Duration: 48, Last Available: "2015-09"
+8631	aerosolized narrow red blurry cuppa Gill tea	0		Effect: "On a Roll", Effect Duration: 48, Last Available: "2015-09"
 8632	galvanized pressed cuppa Uncertain tea	0		Effect: "Pronounced Potency", Effect Duration: 27, Last Available: "2015-09"
 8633	tumbling cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
@@ -8513,7 +8513,7 @@
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
 8641	adequate jittery bowl of eyeballs	3	good	Last Available: "2015-10"
 8642	moldy bowl of mummy guts	4	crappy	Last Available: "2015-10"
-8643	flavorless fancy green bowl of maggots	3	decent	Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2015-10"
+8643	fancy flavorless green bowl of maggots	3	decent	Effect: "Arcane in the Brain", Effect Duration: 25, Last Available: "2015-10"
 8644	delicious blood and blood	3	awesome	Last Available: "2015-10"
 8645	boozy artisanal Jack-O-Lantern beer	5	EPIC	Last Available: "2015-10"
 8646	bad high-proof zombie	6	decent	Last Available: "2015-10"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	shaking stink-penny	0		
 8654	jittery smartaleck's hawk of James Dean of the sweet-tooth	0		Moxie Percent: +30, Experience (Moxie): +3, Candy Drop: +100
-8655	small decent hamlet sandwich	2	good	
+8655	decent small hamlet sandwich	2	good	
 8656	cyan Jack Frost's Othello's military jacket	0		Cold Spell Damage: +50
 8657	shaking maroon Newton's Othello's dagger	0		Experience (Mysticality): +3, Single Equip
 8658	skewed beefy Othello's handkerchief	0		Muscle: +10, Single Equip
@@ -8545,7 +8545,7 @@
 8672	Walford's bucket	0		Last Available: "2015-11"
 8673	Wal-Mart gift certificate	0		Last Available: "2015-11"
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
-8675	olive narrow one-day ticket to The Glaciest	0		Last Available: "2015-11"
+8675	narrow olive one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	anodized alkaline anodized shoulder-warming lotion	0		Effect: "Tiki Thoughtfulness", Effect Duration: 25, Last Available: "2015-11"
 8677	delicious squat blinking iceberg lettuce	4	awesome	Last Available: "2015-11"
 8678	mediocre ice wine	4	decent	Last Available: "2015-11"
@@ -8553,20 +8553,20 @@
 8680	sizzling hardened smartaleck's Wal-Mart nametag	0		Moxie Percent: +30, Damage Reduction: 3, Hot Damage: +10, Last Available: "2015-11"
 8681	tumbling yellow scandalous Temple Grandin's hale Wal-Mart overalls	0		Maximum HP: +20, Familiar Weight: +7, Sleaze Damage: +5, Last Available: "2015-11"
 8682	To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
-8683	skewed green The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
+8683	green skewed The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
 8684	Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
-8686	skewed spinning perfect ice cube	0		Last Available: "2015-11"
+8686	spinning skewed perfect ice cube	0		Last Available: "2015-11"
 8687	The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
 8688	Jim Carey's bellhop's hat	0		Monster Level: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	perfectly mixed boozy ice porter	5	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8689	perfectly mixed boozy ice porter	5	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	non-alkaline oxidized exotic travel brochure	0		Effect: "Strawberry Alarm", Effect Duration: 27, Last Available: "2015-11"
 8691	teal bag of foreign bribes	0		Last Available: "2015-11"
 8692	flattened dry triple-galvanized shampoo-conditioner	0		Effect: "Heart of White", Effect Duration: 46, Last Available: "2015-11"
 8693	bouncing bouncing hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
-8696	diluted green mirror medicinal herbs	1		Effect: "Sleazy Weapon", Effect Duration: 20, Last Available: "2016-01"
+8696	diluted mirror green medicinal herbs	1		Effect: "Sleazy Weapon", Effect Duration: 20, Last Available: "2016-01"
 8697	yummy ice rice	3	awesome	Last Available: "2016-01"
 8698	acceptable skewed iced plum wine	3	good	Last Available: "2016-01"
 8699	nippy weightlifter's training belt of temperance	0		Muscle: +15, Cold Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2016-01"
@@ -8590,7 +8590,7 @@
 8717	mixed abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
 8719	normal VYKEA meatballs	4	good	Last Available: "2015-11"
-8720	bad practically non-alcoholic VYKEA mead	1	decent	Last Available: "2015-11"
+8720	practically non-alcoholic bad VYKEA mead	1	decent	Last Available: "2015-11"
 8721	deionized huge VYKEA woadpaint	0		Effect: "There Is A Spoon", Effect Duration: 12, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
@@ -8601,7 +8601,7 @@
 8728	VYKEA dowel	0		Last Available: "2015-11"
 8729	greasy Jim Carey's clever VYKEA hex key	0		Maximum MP: +20, Monster Level: +25, Sleaze Spell Damage: +10, Last Available: "2015-11"
 8730	blinking VYKEA instructions	0		Last Available: "2015-11"
-8731	snack-sized toothsome tin of submardines	2	awesome	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	toothsome snack-sized tin of submardines	2	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	acceptable fuchsia bottle of norwhiskey	3	good	Last Available: "2015-11"
 8733	mixed octolus oculus	1	decent	Last Available: "2015-11"
 8734	zippy executive knitted sardine can key	0		Cold Resistance: +3, Meat Drop: +40, Initiative: +20, Last Available: "2015-11"
@@ -8612,7 +8612,7 @@
 8739	drinkable perfect dark and stormy	3	good	Last Available: "2015-11"
 8740	watered-down smooth perfect mimosa	2	awesome	Last Available: "2015-11"
 8741	fancy acceptable wobbly perfect old-fashioned	3	good	Effect: "Nuts about Candy", Effect Duration: 5, Last Available: "2015-11"
-8742	hand-crafted spirit-forward perfect paloma	5	EPIC	Last Available: "2015-11"
+8742	spirit-forward hand-crafted perfect paloma	5	EPIC	Last Available: "2015-11"
 8743	vacuum-sealed alkaline jittery That 70s Cologne	0		Effect: "Drenched With Filth", Effect Duration: 13, Last Available: "2015-11"
 8744	double-anodized anodized Wal-Mart &quot;diamond&quot; ring	0		Effect: "Shredding, Sweating", Effect Duration: 53, Last Available: "2015-11"
 8745	flattened non-irradiated Puffstone cigar	0		Effect: "Fishily Speeding", Effect Duration: 51, Last Available: "2015-11"
@@ -8620,10 +8620,10 @@
 8747	ionized Spring Break Beach &quot;swimsuit&quot;	0		Effect: "There Is A Spoon", Effect Duration: 25, Last Available: "2015-11"
 8748	twirling airplane tattoo	0		Last Available: "2015-11"
 8749	double-concentrated irradiated ghostly Deep Machine Tunnels snowglobe	0		Effect: "Gyromitra Gymnastics", Effect Duration: 57, Last Available: "2015-12"
-8750	warmed bouncing tumbling hemp candy necklace	0		Effect: "Extra-Sharp Weapon", Effect Duration: 38, Last Available: "2015-12"
+8750	warmed tumbling bouncing hemp candy necklace	0		Effect: "Extra-Sharp Weapon", Effect Duration: 38, Last Available: "2015-12"
 8751	pickled pickled communal gobstopper	0		Effect: "Knightlife", Effect Duration: 43, Last Available: "2015-12"
 8752	decent Crimbo salad	4	good	Last Available: "2015-12"
-8753	massive bland huge bread line	8	decent	Last Available: "2015-12"
+8753	bland massive huge bread line	8	decent	Last Available: "2015-12"
 8754	weak artisanal bark rootbeer	2	EPIC	Last Available: "2015-12"
 8755	practically non-alcoholic bad skewed ale	1	decent	Last Available: "2015-12"
 8756	stanky plastic Tammy the Tambourine Elf	0		Stench Spell Damage: +25, Last Available: "2015-12"
@@ -8640,7 +8640,7 @@
 8767	Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	chocolate bowtie	0		Familiar Weight: +5
-8770	dry cyan shaking pitted sheet	0		Effect: "Human-Penguin Hybrid", Effect Duration: 26, Last Available: "2015-12"
+8770	dry shaking cyan pitted sheet	0		Effect: "Human-Penguin Hybrid", Effect Duration: 26, Last Available: "2015-12"
 8771	sparking robo-battery	0		Last Available: "2015-12"
 8772	skewed overloaded micro-reactor	0		Last Available: "2015-12"
 8773	squat Van der Graaf Samson's reusable shopping bag of courage	0		Experience (Muscle): +5, Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-12"
@@ -8685,18 +8685,18 @@
 8813	jittery glob of Bat-Glue	0		Last Available: "2017-01"
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
-8816	gigantic bland Kudzu salad	6	decent	Last Available: "2016-12"
+8816	bland gigantic Kudzu salad	6	decent	Last Available: "2016-12"
 8817	diluted ghostly yellow ghostly Mansquito Serum	1		Effect: "Rat-Faced", Effect Duration: 15, Last Available: "2016-12"
 8818	bad Miss Graves' vermouth	3	decent	Last Available: "2016-12"
 8819	delicious mirror The Plumber's mushroom stew	3	awesome	Last Available: "2016-12"
 8820	pickled The Author's ink	1		Last Available: "2016-02"
-8821	practically non-alcoholic mediocre The Mad Liquor	1	decent	Last Available: "2016-12"
+8821	mediocre practically non-alcoholic The Mad Liquor	1	decent	Last Available: "2016-12"
 8822	smooth Doc Clock's thyme cocktail	3	awesome	Last Available: "2016-12"
 8823	adequate jittery Mr. Burnsger	3	good	Last Available: "2016-12"
 8824	modified The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	Rosewater's The Jokester's gun of wisdom of Gandalf	0		Mysticality: +15, Mysticality Percent: +30, Spell Critical Percent: +20, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	Jeselnik's occult thinker's The Jokester's wig	0		Mysticality: +10, Spell Damage Percent: +25, Sleaze Damage: +25, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	The Jokester's pants of wisdom of the bloodbag of temperance	0		Mysticality: +15, Maximum HP: +100, Sleaze Resistance: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	Rosewater's The Jokester's gun of wisdom of Gandalf	0		Mysticality: +15, Mysticality Percent: +30, Spell Critical Percent: +20, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	Jeselnik's occult thinker's The Jokester's wig	0		Mysticality: +10, Spell Damage Percent: +25, Sleaze Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8827	The Jokester's pants of wisdom of the bloodbag of temperance	0		Mysticality: +15, Maximum HP: +100, Sleaze Resistance: +5, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	denatured blinking blue bouncing Jokester makeup	0		Effect: "Eagle Eyes", Effect Duration: 21, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8719,7 +8719,7 @@
 8847	pickled wet red-hot jawbreaker	0		Effect: "Celestial Sheen", Effect Duration: 44
 8848	super-irradiated shaking question juice	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 65
 8849	moist spinning tube of villain	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 40
-8850	fireproof your cowboy boots	0		Hot Resistance: +3, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	fireproof your cowboy boots	0		Hot Resistance: +3, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	skewed inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	jittery nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,15 +8746,15 @@
 8874	bouncing tumbling fireproof careful grievous Herculean Val-U Brand Every Bean Salad of doom	0		Experience (Muscle): +1, Weapon Damage Percent: +50, Monster Level: -10, Spooky Spell Damage: +50, Hot Resistance: +3, Last Available: "2016-02"
 8875	lard-coated occult Rosewater's Shrub's Premium Baked Beans	0		Mysticality Percent: +30, Spell Damage Percent: +25, Sleaze Spell Damage: +25, Last Available: "2016-02"
 8876	diet adequate plate of Heimz Fortified Kidney Beans	1	good	Last Available: "2016-02"
-8877	adequate thick plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
+8877	thick adequate plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
 8878	spoiled jittery plate of Mixed Garbanzos and Chickpeas	4	crappy	Last Available: "2016-02"
 8879	rotten tiny ghostly plate of Hellfire Spicy Beans	1	crappy	Last Available: "2016-02"
 8880	low-calorie normal fuchsia plate of Frigid Northern Beans	1	good	Last Available: "2016-02"
 8881	flavorless fancy plate of World's Blackest-Eyed Peas	3	decent	Effect: "Hot Blooded", Effect Duration: 40, Last Available: "2016-02"
 8882	normal plate of Trader Olaf's Exotic Stinkbeans	4	good	Last Available: "2016-02"
-8883	special bite-sized stale plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Celestial Body", Effect Duration: 25, Last Available: "2016-02"
-8884	snack-sized flavorless mirror plate of Val-U Brand Every Bean Salad	2	decent	Last Available: "2016-02"
-8885	tiny flavorless ghostly plate of Shrub's Premium Baked Beans	1	decent	Last Available: "2016-02"
+8883	bite-sized stale special plate of Pork 'n' Pork 'n' Pork 'n' Beans	1	decent	Effect: "Celestial Body", Effect Duration: 25, Last Available: "2016-02"
+8884	flavorless snack-sized mirror plate of Val-U Brand Every Bean Salad	2	decent	Last Available: "2016-02"
+8885	flavorless tiny ghostly plate of Shrub's Premium Baked Beans	1	decent	Last Available: "2016-02"
 8886	friendly wholesome Fancy Jeff's pocket square	0		Maximum HP Percent: +10, Familiar Weight: +3, Last Available: "2016-02"
 8887	therapeutic sinister extremely unsafe Daisy's unclean bloomers	0		Weapon Damage Percent: +100, Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
@@ -8802,14 +8802,14 @@
 8930	denatured spinning demonic cow's blood	0		Effect: "Corona de la Salsa", Effect Duration: 62, Last Available: "2016-02"
 8931	rinky-dink sixgun	0		Last Available: "2016-02"
 8932	makeshift sixgun	0		Last Available: "2016-02"
-8933	pulsating jittery custom sixgun	0		Last Available: "2016-02"
+8933	jittery pulsating custom sixgun	0		Last Available: "2016-02"
 8934	blinking narrow baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	cyan porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	bouncing grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
-8940	skewed huge coal snakeskin	0		Last Available: "2016-02"
+8940	huge skewed coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
 8942	rotting cowskin	0		Last Available: "2016-02"
 8943	jittery shuddering cow skull	0		Last Available: "2016-02"
@@ -8849,10 +8849,10 @@
 8977	liquefied patent invisibility tonic	0		Effect: "Boo Tea", Effect Duration: 44
 8978	dry moist patent aggression tonic	0		Effect: "Crimbo Nostalgia", Effect Duration: 48
 8979	concentrated deionized triple-wet pulsating patent sallowness tonic	0		Effect: "Spooky Hands", Effect Duration: 17
-8980	moist green pulsating patent avarice tonic	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 56
+8980	moist pulsating green patent avarice tonic	0		Effect: "Egg-cellent Vocabulary", Effect Duration: 56
 8981	colloidal mirror patent alacrity tonic	0		Effect: "Human-Orc Hybrid", Effect Duration: 52
 8982	Vulcanized super-corrupted corrupted marrow	0		Effect: "You Know When to Walk Away", Effect Duration: 20
-8983	boozy bad squat huge rodeo whiskey	5	decent	
+8983	bad boozy squat huge rodeo whiskey	5	decent	
 8984	Thwaitgold scorpion statuette	0		
 8985	Newton's real cowboy hat	0		Experience (Mysticality): +3
 8986	Memories of Cow Punching	0		Free Pull
@@ -8861,9 +8861,9 @@
 8989	narrow red Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	bouncing electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	vaporized shaking olive armored prawn	1		Last Available: "2016-03"
+8992	vaporized olive shaking armored prawn	1		Last Available: "2016-03"
 8993	spoiled jumping horseradish	3	crappy	Last Available: "2016-03"
-8994	drinkable weak Sacramento wine	2	good	Last Available: "2016-03"
+8994	weak drinkable Sacramento wine	2	good	Last Available: "2016-03"
 8995	colloidal lime green Greek fire	0		Effect: "Shoesauce", Effect Duration: 18, Last Available: "2016-03"
 8996	censurious ribald rosy-cheeked beefcake's ox-head shield of Calamity Jane	0		Muscle: +25, Maximum HP Percent: +30, Critical Hit Percent: +15, Sleaze Damage: +10, Sleaze Resistance: +3, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	pulsating double-paned resourceful wicked stylish dented scepter of the cheetah	0		Moxie: +25, Spell Damage: +5, Maximum MP: +50, Cold Resistance: +5, Initiative: +60, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
@@ -8899,13 +8899,13 @@
 9027	yellow electrified therapeutic First Post shirt - Cir Senam of the overflowing toilet	0		Stench Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	thick bland wobbly star salad	5	decent	
-9031	blue spinning Thwaitgold moth statuette	0		
-9032	delicious gigantic bowl of Tastee-Wheet&trade;	9	awesome	
+9030	bland thick wobbly star salad	5	decent	
+9031	spinning blue Thwaitgold moth statuette	0		
+9032	gigantic delicious bowl of Tastee-Wheet&trade;	9	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	upside-down Source essence	0		Last Available: "2016-06"
 9035	decent super-sized browser cookie	5	good	Last Available: "2016-06"
-9036	acceptable high-proof hacked gibson	7	good	Last Available: "2016-06"
+9036	high-proof acceptable hacked gibson	7	good	Last Available: "2016-06"
 9037	green brainy Source shades	0		Mysticality: +5, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	missing semicolon	0		Familiar Weight: +11
@@ -8929,7 +8929,7 @@
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	spinning Source terminal file: portscan.edu	0		Last Available: "2016-06"
 9059	olive narrow Source terminal file: turbo.edu	0		Last Available: "2016-06"
-9060	cyan upside-down Source terminal file: familiar.ext	0		Last Available: "2016-06"
+9060	upside-down cyan Source terminal file: familiar.ext	0		Last Available: "2016-06"
 9061	narrow Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	wobbly Source terminal file: spam.ext	0		Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	electrified quadruple-electrified maroon shoe gum	0		Effect: "Jittery", Effect Duration: 36, Last Available: "2016-07"
 9076	lion tamer's Newton's noir fedora of Tarzan	0		Experience (Muscle): +3, Experience (Mysticality): +3, Experience (familiar): +2, Last Available: "2016-07"
 9077	chilly ruddy trench coat of doom	0		Maximum HP Percent: +40, Cold Damage: +5, Spooky Spell Damage: +50, Last Available: "2016-07"
-9078	perfectly mixed watered-down special Falcon&trade; Maltese Liquor	2	EPIC	Effect: "Preemptive Medicine", Effect Duration: 35, Last Available: "2016-07"
-9079	normal low-calorie hardboiled egg	1	good	Last Available: "2016-07"
+9078	watered-down perfectly mixed special Falcon&trade; Maltese Liquor	2	EPIC	Effect: "Preemptive Medicine", Effect Duration: 35, Last Available: "2016-07"
+9079	low-calorie normal hardboiled egg	1	good	Last Available: "2016-07"
 9080	mirror detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	blue lightning-fast rosewater-soaked smelly groovy strapping protonic accelerator pack of the ox	0		Muscle: 25, Moxie Percent: +10, Stench Spell Damage: +10, Stench Resistance: +3, Initiative: +40, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	blue lightning-fast rosewater-soaked smelly groovy strapping protonic accelerator pack of the ox	0		Muscle: 25, Moxie Percent: +10, Stench Spell Damage: +10, Stench Resistance: +3, Initiative: +40, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	gray upside-down almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	groovy Adventurer bobblehead	0		Moxie Percent: +10, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	ghostly ribald resourceful vibrating Spookyraven signet	0		Maximum MP Percent: +10, Maximum MP: +50, Sleaze Damage: +10, Single Equip, Last Available: "2016-08"
 9093	skewed curative smooth tie-dyed fannypack	0		Moxie: +15, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2016-08"
 9094	razor-sharp Da Vinci's burnt snowpants	0		Experience (Mysticality): +5, Weapon Damage Percent: +25, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	foul-smelling standards and practices guide	0		Stench Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	foul-smelling standards and practices guide	0		Stench Damage: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	tumbling scandalous fortified sinister Carpathian longsword	0		Spell Damage: +10, Damage Absorption: +60, Sleaze Damage: +5, Last Available: "2016-08"
 9097	hale Liam's mail of the bloodbag of the cheetah	0		Maximum HP: 120, Initiative: +60, Last Available: "2016-08"
 9098	stanky rosy-cheeked Unfortunato's foolscap of vim and vigor	0		Maximum HP Percent: 80, Stench Spell Damage: +25, Last Available: "2016-08"
@@ -9019,15 +9019,15 @@
 9147	activated warmed dry Prunets	0		Effect: "Petit Force", Effect Duration: 63
 9148	blinking tumbling Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
-9150	alkaline diffused double-modified huge skewed invisible string	0		Lasts Until Rollover, Effect: "Boon of She-Who-Was", Effect Duration: 16, Last Available: "2016-10"
+9150	alkaline diffused double-modified skewed huge invisible string	0		Lasts Until Rollover, Effect: "Boon of She-Who-Was", Effect Duration: 16, Last Available: "2016-10"
 9151	dry invisible seam ripper	0		Lasts Until Rollover, Effect: "Sharp Weapon", Effect Duration: 25, Last Available: "2016-10"
 9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9153	small normal mirror ghostly raw sweet potato	2	good	Last Available: "2016-11"
-9154	stale special raw beans	4	decent	Effect: "Patent Avarice", Effect Duration: 5, Last Available: "2016-11"
+9153	normal small mirror ghostly raw sweet potato	2	good	Last Available: "2016-11"
+9154	special stale raw beans	4	decent	Effect: "Patent Avarice", Effect Duration: 5, Last Available: "2016-11"
 9155	enchanted decent raw stuffing	3	good	Effect: "Petit Force", Effect Duration: 15, Last Available: "2016-11"
 9156	toothsome raw cranberry sauce	3	awesome	Last Available: "2016-11"
 9157	rotten small cyan raw turkey	2	crappy	Last Available: "2016-11"
-9158	gigantic yummy purple raw mincemeat	10	awesome	Last Available: "2016-11"
+9158	yummy gigantic purple raw mincemeat	10	awesome	Last Available: "2016-11"
 9159	snack-sized decent raw potato	2	good	Last Available: "2016-11"
 9160	stale half-sized raw gravy	2	decent	Last Available: "2016-11"
 9161	stale miniature raw bread	2	decent	Last Available: "2016-11"
@@ -9041,30 +9041,30 @@
 9169	blurry gravy boat	0		Last Available: "2016-11"
 9170	mirror bread mold	0		Last Available: "2016-11"
 9171	rotten shaking sweet potatoes	3	crappy	Last Available: "2016-11"
-9172	stale special bean casserole	4	decent	Effect: "Dreadful Chill", Effect Duration: 5, Last Available: "2016-11"
-9173	gigantic normal baked stuffing	9	good	Last Available: "2016-11"
+9172	special stale bean casserole	4	decent	Effect: "Dreadful Chill", Effect Duration: 5, Last Available: "2016-11"
+9173	normal gigantic baked stuffing	9	good	Last Available: "2016-11"
 9174	huge adequate upside-down cranberry cylinder	8	good	Last Available: "2016-11"
 9175	diet bland thanksgiving turkey	1	decent	Last Available: "2016-11"
 9176	rotten mince pie	3	crappy	Last Available: "2016-11"
 9177	yummy fuchsia mashed potatoes	4	awesome	Last Available: "2016-11"
 9178	adequate warm gravy	3	good	Last Available: "2016-11"
 9179	flavorless diet green bread roll	1	decent	Last Available: "2016-11"
-9180	tasty half-sized jittery leftovers	2	awesome	Last Available: "2016-11"
+9180	half-sized tasty jittery leftovers	2	awesome	Last Available: "2016-11"
 9181	decent leftovers sandwich	3	good	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	megacopia	0		Last Available: "2016-11"
 9185	pilgrim hat	0		Last Available: "2016-11"
 9186	packet of thanksgarden seeds	0		Last Available: "2016-11"
-9187	skewed gray cashew	0		Last Available: "2016-11"
+9187	gray skewed cashew	0		Last Available: "2016-11"
 9188	bouncing bomb of unknown origin	0		Last Available: "2016-11"
 9189	green Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	eldritch effluvium	0		
 9191	frozen eldritch concentrate	0		Effect: "Aquarius Rising", Effect Duration: 30, Last Available: "2016-11"
 9192	bad eldritch extract	3	decent	Last Available: "2016-11"
 9193	executive Official Council Aide Pin of Tarzan	0		Experience (Muscle): +3, Meat Drop: +40, Last Available: "2016-11"
-9194	enchanted perfectly mixed eldritch distillate	3	EPIC	Effect: "Frozen Hands", Effect Duration: 15, Last Available: "2016-11"
-9195	distilled purple blurry twirling eldritch essence	1		Effect: "Ghost Finger", Effect Duration: 40, Last Available: "2016-11"
+9194	perfectly mixed enchanted eldritch distillate	3	EPIC	Effect: "Frozen Hands", Effect Duration: 15, Last Available: "2016-11"
+9195	distilled purple twirling blurry eldritch essence	1		Effect: "Ghost Finger", Effect Duration: 40, Last Available: "2016-11"
 9196	Lo Pan's Science Notebook	0		Spell Critical Percent: +30
 9197	blinking deadly Samson's beefcake's eldritch hat	0		Muscle: +25, Experience (Muscle): +5, Weapon Damage: +5, Last Available: "2016-11"
 9198	flame-wreathed hardened thinker's eldritch pants	0		Mysticality: +10, Damage Reduction: 3, Hot Spell Damage: +10, Last Available: "2016-11"
@@ -9072,7 +9072,7 @@
 9200	red rock-hard Quartet of Flare Masters Jacket of the blizzard	0		Damage Reduction: 5, Cold Spell Damage: +25, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	bouncing twirling upside-down Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	twirling bouncing upside-down Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
 9205	upside-down sprinkles	0		Last Available: "2016-12"
 9206	The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
@@ -9087,10 +9087,10 @@
 9215	broken chocolate pocketwatch	0		Last Available: "2016-12"
 9216	gray interesting clod of dirt	0		
 9217	gingerbread restraining order	0		Last Available: "2016-12"
-9218	skewed jittery sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	enchanted thick toothsome animal part cracker	5	awesome	Effect: "Muscularrr", Effect Duration: 5, Last Available: "2016-12"
+9218	jittery skewed sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
+9219	thick enchanted toothsome animal part cracker	5	awesome	Effect: "Muscularrr", Effect Duration: 5, Last Available: "2016-12"
 9220	lousy gingerbread wine	4	decent	Last Available: "2016-12"
-9221	delicious super-sized green twirling upside-down gingerbread mug	5	awesome	Last Available: "2016-12"
+9221	super-sized delicious twirling upside-down green gingerbread mug	5	awesome	Last Available: "2016-12"
 9222	supercool gingerbread mask	0		Moxie Percent: +20, Last Available: "2016-12"
 9223	energetic padded gingerservo of the sweet-tooth	0		Damage Absorption: +20, Maximum MP Percent: +20, Candy Drop: +100, Single Equip, Last Available: "2016-12"
 9224	Vulcanized denatured tainted icing	0		Effect: "Shamboozled", Effect Duration: 39, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	bouncing knitted gingerbread gavel of the overflowing toilet	0		Stench Spell Damage: +50, Cold Resistance: +3, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	spirit-forward tolerable skewed ginger beer	5	good	Last Available: "2016-12"
+9239	tolerable spirit-forward skewed ginger beer	5	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	modified pickled magnetized industrial frosting	0		Effect: "The Smeezingtons", Effect Duration: 34, Last Available: "2016-12"
 9242	chilled denatured fake cocktail	0		Effect: "Ten out of Ten", Effect Duration: 61, Last Available: "2016-12"
@@ -9118,7 +9118,7 @@
 9246	plastic Knows About Chakras of chilblains	0		Cold Damage: +25, Last Available: "2016-12"
 9247	wobbly lard-coated plastic Your Brain	0		Sleaze Spell Damage: +25, Last Available: "2016-12"
 9248	ribald plastic Krampus	0		Sleaze Damage: +10, Last Available: "2016-12"
-9249	modified ionized blue pulsating Inner Wisdom	0		Effect: "Sausage Festive", Effect Duration: 14, Last Available: "2016-12"
+9249	modified ionized pulsating blue Inner Wisdom	0		Effect: "Sausage Festive", Effect Duration: 14, Last Available: "2016-12"
 9250	tarnished quantum squat Inner Strength	0		Effect: "Uncaged Power", Effect Duration: 16, Last Available: "2016-12"
 9251	deionized unsweetened fuchsia Inner Truth	0		Effect: "Thick, Sick", Effect Duration: 35, Last Available: "2016-12"
 9252	half-sized stale spiritual candy cane	2	decent	Last Available: "2016-12"
@@ -9128,9 +9128,9 @@
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	ghostly chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
-9259	huge twirling Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
+9259	twirling huge Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	blue No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
-9261	shaking blinking Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
+9261	blinking shaking Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	shaking fruit-leather negatives	0		Last Available: "2016-12"
 9263	upside-down gingerbread blackmail photos	0		Last Available: "2016-12"
 9264	gray jittery briefcase full of sprinkles	0		Last Available: "2016-12"
@@ -9145,10 +9145,10 @@
 9273	greedy therapeutic Third Eye	0		Meat Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-12"
 9274	careful Krampus Horn of the empath	0		Monster Level: -10, Familiar Weight: +5, Single Equip, Last Available: "2016-12"
 9275	adequate enchanted hambrosier	3	good	Effect: "Blubbered Up", Effect Duration: 25, Last Available: "2016-12"
-9276	watered-down lousy chakra-mental wine	2	decent	Last Available: "2016-12"
+9276	lousy watered-down chakra-mental wine	2	decent	Last Available: "2016-12"
 9277	quadruple-Vulcanized wobbly chakra malt	0		Effect: "Stinking Cloud", Effect Duration: 31, Last Available: "2016-12"
 9278	adequate Black Angus blackburger	3	good	Last Available: "2016-12"
-9279	bad watered-down brandy	2	decent	Last Available: "2016-12"
+9279	watered-down bad brandy	2	decent	Last Available: "2016-12"
 9280	improved warmed upside-down potion of spiritual gunkifying	0		Effect: "Magically Fingered", Effect Duration: 11, Last Available: "2016-12"
 9281	blinking dangerous bad vibroknife of doom	0		Weapon Damage: +10, Spooky Spell Damage: +50, Last Available: "2016-12"
 9282	Usain Bolt's nasty crystal belt buckle	0		Stench Damage: +5, Initiative: +80, Last Available: "2016-12"
@@ -9157,18 +9157,18 @@
 9285	Lump-Stacking for Beginners	0		Skill: "Stack Lumps", Last Available: "2016-12"
 9286	eternal knot tattoo	0		Last Available: "2016-12"
 9287	pet bad vibe	0		Last Available: "2016-12"
-9288	huge squat gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
+9288	squat huge gallstone	0		Familiar Weight: +5, Last Available: "2016-12"
 9289	up-at-dawn sharpshooter's veiny Uncle Crimbo's hat	0		Maximum HP: +10, Critical Hit Percent: +10, Adventures: +5, Last Available: "2016-12"
 9290	diet normal gray Eldritch snap	1	good	Last Available: "2017-01"
 9291	compressed tumbling pulsating hot jelly	1		Last Available: "2017-01"
 9292	distilled jelly	1		Last Available: "2017-01"
-9293	modified gray blurry skewed jelly	1		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 50, Last Available: "2017-01"
+9293	modified skewed gray blurry jelly	1		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 50, Last Available: "2017-01"
 9294	compressed mirror pulsating sleaze jelly	1		Last Available: "2017-01"
 9295	diluted pulsating stench jelly	1		Last Available: "2017-01"
 9296	twirling space planula	0		Free Pull, Last Available: "2017-01"
-9297	super-sized special bland toast with hot jelly	5	decent	Effect: "Human-Elf Hybrid", Effect Duration: 35, Last Available: "2017-01"
-9298	half-sized moldy toast with jelly	2	crappy	Last Available: "2017-01"
-9299	super-sized flavorless jittery toast with jelly	5	decent	Last Available: "2017-01"
+9297	super-sized bland special toast with hot jelly	5	decent	Effect: "Human-Elf Hybrid", Effect Duration: 35, Last Available: "2017-01"
+9298	moldy half-sized toast with jelly	2	crappy	Last Available: "2017-01"
+9299	flavorless super-sized jittery toast with jelly	5	decent	Last Available: "2017-01"
 9300	normal spinning toast with sleaze jelly	3	good	Last Available: "2017-01"
 9301	adequate tumbling toast with stench jelly	3	good	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
@@ -9195,7 +9195,7 @@
 9323	LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
 9325	squat LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	vaporized tumbling twirling red LOV Echinacea Bouquet	1		Effect: "The Halls of Mysticality", Effect Duration: 30, Last Available: "2017-02"
+9326	vaporized tumbling red twirling LOV Echinacea Bouquet	1		Effect: "The Halls of Mysticality", Effect Duration: 30, Last Available: "2017-02"
 9327	tumbling LOV Elephant of the bloodbag	0		Maximum HP: +100, Damage Reduction: 6, Last Available: "2017-02"
 9328	mirror asbestos-lined eldritch scanner	0		Hot Resistance: +5, Last Available: "2017-02"
 9329	non-Vulcanized eldritch alignment spray	0		Effect: "Gr8ness", Effect Duration: 15, Last Available: "2017-02"
@@ -9207,7 +9207,7 @@
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	tarnished alkaline modified ghostly eldritch rub	0		Effect: "Pla-see-bo", Effect Duration: 41, Last Available: "2017-02"
-9338	yellow blurry mirror HP-35 Calculator	0		
+9338	yellow mirror blurry HP-35 Calculator	0		
 9339	Silver HP-35 Calculator	0		
 9340	Golden HP-35 Calculator	0		
 9341	jittery Platinum HP-35 Calculator	0		
@@ -9241,33 +9241,33 @@
 9369	weak tolerable mentholated wine	2	good	Last Available: "2017-03"
 9370	mediocre low tide martini	4	decent	Last Available: "2017-03"
 9371	hand-crafted weak shroomtini	2	EPIC	Last Available: "2017-03"
-9372	distilled lousy morning dew	5	decent	Last Available: "2017-03"
-9373	watered-down drinkable red whiskey squeeze	2	good	Last Available: "2017-03"
-9374	extra-dry tolerable great fashioned	5	good	Last Available: "2017-03"
+9372	lousy distilled morning dew	5	decent	Last Available: "2017-03"
+9373	drinkable watered-down red whiskey squeeze	2	good	Last Available: "2017-03"
+9374	tolerable extra-dry great fashioned	5	good	Last Available: "2017-03"
 9375	extra-dry artisanal Gnomish sagngria	5	EPIC	Last Available: "2017-03"
-9376	distilled tolerable vodka stinger	5	good	Last Available: "2017-03"
-9377	hand-crafted practically non-alcoholic extremely slippery nipple	1	EPIC	Last Available: "2017-03"
+9376	tolerable distilled vodka stinger	5	good	Last Available: "2017-03"
+9377	practically non-alcoholic hand-crafted extremely slippery nipple	1	EPIC	Last Available: "2017-03"
 9378	watered-down drinkable cyan piscatini	2	good	Last Available: "2017-03"
-9379	high-proof tolerable jittery Churchill	10	good	Last Available: "2017-03"
-9380	special drinkable lime green soilzerac	4	good	Effect: "Dirge of Dreadfulness", Effect Duration: 25, Last Available: "2017-03"
+9379	tolerable high-proof jittery Churchill	10	good	Last Available: "2017-03"
+9380	drinkable special lime green soilzerac	4	good	Effect: "Dirge of Dreadfulness", Effect Duration: 25, Last Available: "2017-03"
 9381	hand-crafted spinning London frog	4	EPIC	Last Available: "2017-03"
-9382	smooth distilled nothingtini	5	awesome	Last Available: "2017-03"
-9383	practically non-alcoholic perfectly mixed special eighth plague	1	EPIC	Effect: "Permafrosty", Effect Duration: 30, Last Available: "2017-03"
-9384	watered-down mediocre single entendre	2	decent	Last Available: "2017-03"
+9382	distilled smooth nothingtini	5	awesome	Last Available: "2017-03"
+9383	practically non-alcoholic special perfectly mixed eighth plague	1	EPIC	Effect: "Permafrosty", Effect Duration: 30, Last Available: "2017-03"
+9384	mediocre watered-down single entendre	2	decent	Last Available: "2017-03"
 9385	lousy practically non-alcoholic tumbling reverse Tantalus	1	decent	Last Available: "2017-03"
 9386	tolerable fancy elemental caipiroska	4	good	Effect: "White Knuckles", Effect Duration: 40, Last Available: "2017-03"
 9387	delicious Feliz Navidad	3	awesome	Last Available: "2017-03"
-9388	lousy spirit-forward pulsating Bloody Nora	5	decent	Last Available: "2017-03"
-9389	hand-crafted enchanted blue moreltini	3	EPIC	Effect: "Ode to Booze", Effect Duration: 35, Last Available: "2017-03"
+9388	spirit-forward lousy pulsating Bloody Nora	5	decent	Last Available: "2017-03"
+9389	enchanted hand-crafted blue moreltini	3	EPIC	Effect: "Ode to Booze", Effect Duration: 35, Last Available: "2017-03"
 9390	lousy hell in a bucket	3	decent	Last Available: "2017-03"
 9391	aged Newark	3	awesome	Last Available: "2017-03"
-9392	weak lousy special yellow R'lyeh	2	decent	Effect: "Black Eyes", Effect Duration: 50, Last Available: "2017-03"
-9393	distilled hand-crafted Gnollish sangria	5	EPIC	Last Available: "2017-03"
-9394	delicious enchanted weak vodka barracuda	2	awesome	Effect: "Become Intensely interested", Effect Duration: 35, Last Available: "2017-03"
-9395	fancy irresponsibly strong artisanal Mysterious Island iced tea	8	EPIC	Effect: "Fastbreaker", Effect Duration: 25, Last Available: "2017-03"
+9392	weak special lousy yellow R'lyeh	2	decent	Effect: "Black Eyes", Effect Duration: 50, Last Available: "2017-03"
+9393	hand-crafted distilled Gnollish sangria	5	EPIC	Last Available: "2017-03"
+9394	weak enchanted delicious vodka barracuda	2	awesome	Effect: "Become Intensely interested", Effect Duration: 35, Last Available: "2017-03"
+9395	irresponsibly strong fancy artisanal Mysterious Island iced tea	8	EPIC	Effect: "Fastbreaker", Effect Duration: 25, Last Available: "2017-03"
 9396	spirit-forward bad drive-by shooting	5	decent	Last Available: "2017-03"
 9397	mediocre gunner's daughter	3	decent	Last Available: "2017-03"
-9398	hand-crafted triple-distilled dirt julep	8	EPIC	Last Available: "2017-03"
+9398	triple-distilled hand-crafted dirt julep	8	EPIC	Last Available: "2017-03"
 9399	artisanal practically non-alcoholic bouncing lime green Simepore slime	1	EPIC	Last Available: "2017-03"
 9400	artisanal weak Phil Collins	2	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9276,7 +9276,7 @@
 9404	Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
-9407	narrow huge rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
+9407	huge narrow rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	narrow gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9409	high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
@@ -9293,7 +9293,7 @@
 9421	skewed alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9423	normal alien meat	4	good	Last Available: "2017-04"
-9424	wobbly squat alien toenails	0		Last Available: "2017-04"
+9424	squat wobbly alien toenails	0		Last Available: "2017-04"
 9425	mirror alien zoological sample	0		Last Available: "2017-04"
 9426	complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
@@ -9325,14 +9325,14 @@
 9453	mansplainer's forbidden thinker's murderbot mask	0		Mysticality: +10, Spell Damage Percent: +50, Monster Level: +15, Avatar: "Murderbot", Last Available: "2017-04"
 9454	dry dry narrow murderbot spring injector	0		Effect: "Disco Neuropathy", Effect Duration: 25, Last Available: "2017-04"
 9455	perfumed extremely unsafe murderbot whip	0		Weapon Damage Percent: +100, Stench Resistance: +5, Last Available: "2017-04"
-9456	squat wizardly murderbot plasma rifle of terror	0		Mysticality: +25, Spooky Spell Damage: +10, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	squat wizardly murderbot plasma rifle of terror	0		Mysticality: +25, Spooky Spell Damage: +10, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	murderbot memory chip	0		Last Available: "2017-04"
 9458	space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	mirror Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
-9463	mirror maroon Space Baby children's book	0		Last Available: "2017-04"
+9463	maroon mirror Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
 9466	yummy Aldebaran sardines	4	awesome	Last Available: "2017-04"
@@ -9345,10 +9345,10 @@
 9473	narrow tumbling Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	normal alien sandwich	3	good	Last Available: "2017-04"
 9475	glitched malware	0		Last Available: "2025-12"
-9476	aerosolized bouncing jittery Spant eggs	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
+9476	aerosolized jittery bouncing Spant eggs	0		Effect: "Some Cheese with Your Wine", Effect Duration: 43
 9477	Spacegate (open)	0		Lasts Until Rollover
-9478	bouncing blue New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	cold-filtered shaking blurry green Daily Affirmation: Always be Collecting	0		Effect: "Flame-Retardant Trousers", Effect Duration: 59, Last Available: "2017-05"
+9478	blue bouncing New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
+9479	cold-filtered green shaking blurry Daily Affirmation: Always be Collecting	0		Effect: "Flame-Retardant Trousers", Effect Duration: 59, Last Available: "2017-05"
 9480	super-energized triple-tarnished Daily Affirmation: Think Win-Lose	0		Effect: "Meadulla Oblongota", Effect Duration: 69, Last Available: "2017-05"
 9481	frozen quantum Daily Affirmation: Be Superficially interested	0		Effect: "Pecan Pied Piper", Effect Duration: 42, Last Available: "2017-05"
 9482	tarnished nitrogenated Daily Affirmation: Adapt to Change Eventually	0		Effect: "Angry like the Wolf", Effect Duration: 37, Last Available: "2017-05"
@@ -9362,7 +9362,7 @@
 9490	cold-filtered irradiated huge Threatening Missive	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 43
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	tumbling teal executive scorching Rosewater's Kremlin's Greatest Briefcase	0		Mysticality Percent: +30, Hot Damage: +25, Meat Drop: +40, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	tumbling teal executive scorching Rosewater's Kremlin's Greatest Briefcase	0		Mysticality Percent: +30, Hot Damage: +25, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	lousy squat basic martini	4	decent	Last Available: "2017-06"
 9495	perfectly mixed improved martini	3	EPIC	Last Available: "2017-06"
 9496	artisanal splendid martini	4	EPIC	Last Available: "2017-06"
@@ -9376,7 +9376,7 @@
 9504	Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	Lazenby's Life Lesson	0		Free Pull
-9507	maroon pulsating LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
+9507	pulsating maroon LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	upside-down L.I.M.P. Stock Certificate	0		
 9510	cyan Dust bunny	0		
@@ -9403,7 +9403,7 @@
 9531	pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	cyan pony: Shutterfly	0		Last Available: "2017-09"
 9533	pony: Pearjack	0		Last Available: "2017-09"
-9534	jittery blue pony: Uniquity	0		Last Available: "2017-09"
+9534	blue jittery pony: Uniquity	0		Last Available: "2017-09"
 9535	squat pony: Rosey Cake	0		Last Available: "2017-09"
 9536	squat pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	wobbly pocket wish	0		Last Available: "2023-09"
@@ -9416,7 +9416,7 @@
 9544	skewed O	0		Last Available: "2017-10"
 9545	perfectly mixed bouncing DUFRESNE Suds	3	EPIC	Last Available: "2017-09"
 9546	upside-down stiffened slick mafia pinky ring	0		Moxie: +10, Damage Reduction: 1, Single Equip
-9547	extra-dry hand-crafted special olive flask of port	5	EPIC	Effect: "Mitre Cut", Effect Duration: 30
+9547	extra-dry special hand-crafted olive flask of port	5	EPIC	Effect: "Mitre Cut", Effect Duration: 30
 9548	knitted crafty contract enforcement stick	0		Maximum MP: +10, Cold Resistance: +3
 9549	stale purple Hide-rox&trade; cookie	3	decent	Last Available: "2017-10"
 9550	practically non-alcoholic hand-crafted twirling jug of booze	1	EPIC	Last Available: "2017-10"
@@ -9428,7 +9428,7 @@
 9556	jittery bridge truss	0		Last Available: "2017-10"
 9557	double-paned chaotic hale pearl necklace	0		Maximum HP: +20, Spell Critical Percent: +10, Cold Resistance: +5, Single Equip, Last Available: "2017-10"
 9558	huge amorphous blob	0		Last Available: "2017-11"
-9559	blinking tumbling X	0		Last Available: "2017-11"
+9559	tumbling blinking X	0		Last Available: "2017-11"
 9560	O	0		Last Available: "2017-11"
 9561	amorphous blob	0		Last Available: "2017-11"
 9562	narrow Sherlock's wicked Socratic protection stick of extreme caution	0		Experience (Mysticality): +1, Spell Damage: +5, Monster Level: -25, Item Drop: +25
@@ -9453,8 +9453,8 @@
 9581	smooth neg grog	4	awesome	Last Available: "2017-12"
 9582	moldy twirling half double fruitcake	3	crappy	Last Available: "2017-12"
 9583	decent hushed puppy	3	good	Last Available: "2017-12"
-9584	diet flavorless jittery muffled muffuletta	1	decent	Last Available: "2017-12"
-9585	tasty special jumbo shushed potatoes	5	awesome	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2017-12"
+9584	flavorless diet jittery muffled muffuletta	1	decent	Last Available: "2017-12"
+9585	jumbo special tasty shushed potatoes	5	awesome	Effect: "Stuck-Up Hair", Effect Duration: 50, Last Available: "2017-12"
 9586	Newton's plastic mime functionary	0		Experience (Mysticality): +3, Last Available: "2017-12"
 9587	smartaleck's plastic mime scientist	0		Moxie Percent: +30, Last Available: "2017-12"
 9588	upside-down nippy plastic mime soldier	0		Cold Damage: +10, Last Available: "2017-12"
@@ -9465,8 +9465,8 @@
 9593	enchanted temperance whiskey	1	super ultra EPIC	Effect: "items.enh", Effect Duration: 45, Last Available: "2017-11"
 9594	aerosolized fuchsia ghostly wishbone	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 60, Last Available: "2017-11"
 9595	artisanal Racisto Ruidoso	4	super ultra EPIC	Last Available: "2017-11"
-9596	blinking yellow earthenware muffin tin	0		
-9597	stale huge spinning bran muffin	10	decent	
+9596	yellow blinking earthenware muffin tin	0		
+9597	huge stale spinning bran muffin	10	decent	
 9598	stale lime green blueberry muffin	3	decent	
 9599	silent A	0		Last Available: "2017-12"
 9600	maroon twirling silent B	0		Last Available: "2017-12"
@@ -9499,7 +9499,7 @@
 9627	jittery warehouse key	0		Last Available: "2017-12"
 9628	pulsating mime pocket probe	0		Last Available: "2017-12"
 9629	enchanted bad stale cheer wine	3	decent	Effect: "Spell Transfer Complete", Effect Duration: 50, Last Available: "2017-12"
-9630	miniature flavorless bouncing stale Cheer-E-Os	2	decent	Last Available: "2017-12"
+9630	flavorless miniature bouncing stale Cheer-E-Os	2	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	blurry cyan hardened cheerful antler hat of the ox	0		Muscle: +20, Damage Reduction: 3, Last Available: "2017-12"
 9633	blinking hardened cheerful Crimbo sweater of the cougar	0		Moxie: +20, Damage Reduction: 3, Last Available: "2017-12"
@@ -9517,7 +9517,7 @@
 9645	wobbly The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	huge The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	mime eraser	0		Last Available: "2017-12"
-9648	acceptable spirit-forward executive mime flask	5	good	Last Available: "2017-12"
+9648	spirit-forward acceptable executive mime flask	5	good	Last Available: "2017-12"
 9649	flavorless nega-mushroom	3	decent	Last Available: "2017-12"
 9650	perfectly mixed nega-mushroom wine	4	EPIC	Last Available: "2017-12"
 9651	quantum Cheer-Up soda	0		Effect: "Thanksgot", Effect Duration: 63, Last Available: "2017-12"
@@ -9539,7 +9539,7 @@
 9667	upside-down mime army insignia (infantry) of the ox	0		Muscle: +20, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
 9668	executive mime army insignia (intelligence)	0		Meat Drop: +40, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
 9669	wizardly mime army insignia (espionage)	0		Mysticality: +25, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
-9670	red ghostly bouncing mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
+9670	ghostly bouncing red mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	squat squat mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
 9673	mime army insignia (sanitation)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	narrow kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	wobbly fireproof skip lid	0		Familiar Weight: +5
 9681	snack-sized bland spinning extra-toasted half sandwich	2	decent	Last Available: "2018-12"
-9682	fortified artisanal mulled hobo wine	5	EPIC	Last Available: "2018-12"
+9682	artisanal fortified mulled hobo wine	5	EPIC	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	flame-retardant Jeselnik's lion tamer's burning paper hat	0		Experience (familiar): +2, Sleaze Damage: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2018-12"
 9685	up-at-dawn Rosewater's burning cape of dire peril	0		Mysticality Percent: +30, Weapon Damage: +20, Adventures: +5, Lasts Until Rollover, Last Available: "2018-12"
@@ -9573,16 +9573,16 @@
 9701	twisted pills	1		Effect: "Rampage!", Effect Duration: 50
 9702	twisted furry pill	1		Effect: "The Sweats", Effect Duration: 50
 9703	dried ghostly beefy pill	1		
-9704	twisted tumbling red upside-down excitement pill	1		
+9704	twisted upside-down tumbling red excitement pill	1		
 9705	dehydrated blurry vitamin G pill	1		
 9706	boiled narrow lucky-ish pill	1		Effect: "You're Rubber", Effect Duration: 15
 9707	modified shaking dieting pill	1		
-9712	blurry mirror Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
+9712	mirror blurry Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	blurry Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
-9717	mirror gray They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
+9717	gray mirror They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	ghostly Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	lion tamer's sage genie's turbane	0		Mysticality Percent: +10, Experience (familiar): +2, Last Available: "2018-02"
 9720	greedy Temple Grandin's genie's scimitar	0		Familiar Weight: +7, Meat Drop: +20, Last Available: "2018-02"
@@ -9595,9 +9595,9 @@
 9727	delicious super-sized heart-shaped candy whetstone	5	awesome	Last Available: "2018-02"
 9728	bland Swedish massage fish	3	decent	Last Available: "2018-02"
 9729	perfectly mixed Third Base	3	EPIC	Last Available: "2018-02"
-9730	special tolerable Bustle Hustler	3	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 25, Last Available: "2018-02"
+9730	tolerable special Bustle Hustler	3	good	Effect: "Knob Goblin Lust Frenzy", Effect Duration: 25, Last Available: "2018-02"
 9731	deionized olive Fabiotion	0		Effect: "Outer Wolf&trade;", Effect Duration: 42, Last Available: "2018-02"
-9732	polymerized twirling jittery Bettie page	0		Effect: "Eyes for Miles", Effect Duration: 61, Last Available: "2018-02"
+9732	polymerized jittery twirling Bettie page	0		Effect: "Eyes for Miles", Effect Duration: 61, Last Available: "2018-02"
 9733	anodized double-deionized tonic o' Banderas	0		Effect: "Human-Horror Hybrid", Effect Duration: 28, Last Available: "2018-02"
 9734	diffused heather graham cracker	0		Effect: "The Strength...  of the Future", Effect Duration: 18, Last Available: "2018-02"
 9735	Lolsipop	0		Last Available: "2018-02"
@@ -9667,7 +9667,7 @@
 9799	squat Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
 9801	Vulgure	0		Last Available: "2018-03"
-9802	huge shaking Squib	0		Last Available: "2018-03"
+9802	shaking huge Squib	0		Last Available: "2018-03"
 9803	Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
 9805	Shudder	0		Last Available: "2018-03"
@@ -9692,13 +9692,13 @@
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	shaking smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9827	blinking tumbling rocket	0		
+9827	tumbling blinking rocket	0		
 9828	dried teal magnificent oyster egg	1		Effect: "Full Bottle in front of Me", Effect Duration: 15
 9829	vaporized ghostly brilliant oyster egg	1		
 9830	modified ghostly squat glistening oyster egg	1		
 9831	boiled scintillating oyster egg	1		
 9832	altered twirling pearlescent oyster egg	1		Effect: "Dancing Prowess", Effect Duration: 45
-9833	compressed lime green upside-down lustrous oyster egg	1		Effect: "L'instinct F&eacute;lin", Effect Duration: 50
+9833	compressed upside-down lime green lustrous oyster egg	1		Effect: "L'instinct F&eacute;lin", Effect Duration: 50
 9834	pickled spinning gleaming oyster egg	1		
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
@@ -9734,7 +9734,7 @@
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
-9869	normal snack-sized druidic s'more	2	good	Last Available: "2018-04"
+9869	snack-sized normal druidic s'more	2	good	Last Available: "2018-04"
 9870	mixed shaking sachet of powder	1		Last Available: "2018-04"
 9871	perfectly mixed special mirror mourning wine	3	EPIC	Effect: "Cruisin' for a Bruisin'", Effect Duration: 15, Last Available: "2018-04"
 9872	twirling squat ghostly sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	ghostly map to the Cursed Village	0		Last Available: "2018-04"
 9877	bouncing map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless denastified haunch	4	decent	Last Available: "2018-04"
-9879	high-proof perfectly mixed bad rum and good cola	6	EPIC	Last Available: "2018-04"
+9879	perfectly mixed high-proof bad rum and good cola	6	EPIC	Last Available: "2018-04"
 9880	concentrated aerosolized unsweetened huge Potion of Heroism	0		Effect: "Horrid, Torrid", Effect Duration: 28, Last Available: "2018-04"
 9881	olive chilly dog trainer's leggings of the Spider Queen of the overflowing toilet	0		Experience (familiar): +1, Cold Damage: +5, Stench Spell Damage: +50, Last Available: "2018-04"
 9882	up-at-dawn veiny Sinatra's Master Thief's utility belt	0		Experience (Moxie): +5, Maximum HP: +10, Adventures: +5, Single Equip, Last Available: "2018-04"
@@ -9766,7 +9766,7 @@
 9898	tolerable two meat muck	3	good	
 9899	yummy chocolate Ogre Chieftain	3	awesome	
 9900	stale blurry chocolate &quot;Phoenix&quot;	3	decent	
-9901	half-sized decent chocolate Spider Queen	2	good	
+9901	decent half-sized chocolate Spider Queen	2	good	
 9902	fortified drinkable hipster cocktail	5	good	
 9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
 9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
@@ -9781,7 +9781,7 @@
 9913	bouncing glued A-Boo clue	0		
 9914	teal crude oil congealer	0		
 9915	delicious jumbo good guava	5	awesome	
-9916	weak perfectly mixed bouncing gin and ginger	2	EPIC	
+9916	perfectly mixed weak bouncing gin and ginger	2	EPIC	
 9917	Thwaitgold chigger statuette	0		
 9918	modified mirror gaseous gravy	1		Effect: "Libra Rising", Effect Duration: 10
 9919	tumbling SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9797,7 +9797,7 @@
 9929	huge miser's Jack Frost's Brutal brogues of terror of the sweet-tooth	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Meat Drop: +10, Candy Drop: +100, Lasts Until Rollover, Last Available: "2018-07"
 9930	ribald padded Draftsman's driving gloves of mayonnaise of courage	0		Damage Absorption: +20, Sleaze Damage: +10, Sleaze Spell Damage: +50, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2018-07"
 9931	rosewater-soaked razor-sharp wizardly Nouveau nosering of dire peril	0		Mysticality: +25, Weapon Damage: +20, Weapon Damage Percent: +25, Stench Resistance: +3, Lasts Until Rollover, Last Available: "2018-07"
-9932	enhanced pressed triple-improved huge upside-down sharkfin gumbo	0		Effect: "Wet Jaw", Effect Duration: 63, Last Available: "2018-07"
+9932	enhanced pressed triple-improved upside-down huge sharkfin gumbo	0		Effect: "Wet Jaw", Effect Duration: 63, Last Available: "2018-07"
 9933	alkaline electrified boiling broth	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 54, Last Available: "2018-07"
 9934	quadruple-altered corrupted spinning interrogative elixir	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 57, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
@@ -9813,17 +9813,17 @@
 9945	huge ghostly Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	fuchsia gas can	0		Last Available: "2018-09"
-9948	irresponsibly strong hand-crafted blinking olive Middle of the Road&trade; brand whiskey	8	EPIC	Last Available: "2018-09"
+9948	hand-crafted irresponsibly strong blinking olive Middle of the Road&trade; brand whiskey	8	EPIC	Last Available: "2018-09"
 9949	olive neverending wallet chain	0		Last Available: "2018-09"
 9950	narrow censurious lard-coated pentagram bandana	0		Sleaze Spell Damage: +25, Sleaze Resistance: +3, Last Available: "2018-09"
 9951	pulsating jittery skull ring of the dark arts	0		Spell Damage Percent: +100, Single Equip, Last Available: "2018-09"
 9952	electronics kit	0		Last Available: "2018-09"
-9953	diet normal narrow PB&J with the crusts cut off	1	good	Last Available: "2018-09"
+9953	normal diet narrow PB&J with the crusts cut off	1	good	Last Available: "2018-09"
 9954	flame-retardant dorky glasses of the bloodbag	0		Maximum HP: +100, Hot Resistance: +1, Single Equip, Last Available: "2018-09"
 9955	pulsating sharpshooter's boxer's ponytail clip	0		Muscle Percent: +10, Critical Hit Percent: +10, Last Available: "2018-09"
-9956	paint palette of the sweet-tooth	0		Candy Drop: +100, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	paint palette of the sweet-tooth	0		Candy Drop: +100, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	lime green unremarkable duffel bag	0		Last Available: "2018-09"
-9958	modified skewed ghostly Purple Beast energy drink	1		Last Available: "2018-09"
+9958	modified ghostly skewed Purple Beast energy drink	1		Last Available: "2018-09"
 9959	lime green medical-grade cosmetic football	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-09"
 9960	mansplainer's shellacked shoe ad T-shirt	0		Damage Reduction: 7, Monster Level: +15, Last Available: "2018-09"
 9961	pump-up high-tops of temperance	0		Sleaze Resistance: +5, Single Equip, Last Available: "2018-09"
@@ -9831,27 +9831,27 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	shaking arcane researcher's noticeable pumps of the scaredy-cat	0		Experience Percent (Mysticality): +10, Monster Level: -15, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	tolerable weak narrow everfull glass	2		Last Available: "2018-09"
+9966	weak tolerable narrow everfull glass	2		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
 9968	teal jam band bootleg	0		Last Available: "2018-09"
 9969	purple bouncing executive crafty denim jacket	0		Maximum MP: +10, Meat Drop: +40, Last Available: "2018-09"
 9970	squat smelly deadly ratty knitted cap	0		Weapon Damage: +5, Stench Spell Damage: +10, Last Available: "2018-09"
 9972	wholesome brainy intimidating chainsaw	0		Mysticality: +5, Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2018-09"
-9973	irresponsibly strong drinkable party beer bomb	8	good	Last Available: "2018-09"
-9974	small stale sweet party mix	2	decent	Last Available: "2018-09"
-9975	vaporized mirror bouncing shaking party balloon	1		Effect: "Gummiheart", Effect Duration: 25, Last Available: "2018-09"
+9973	drinkable irresponsibly strong party beer bomb	8	good	Last Available: "2018-09"
+9974	stale small sweet party mix	2	decent	Last Available: "2018-09"
+9975	vaporized shaking mirror bouncing party balloon	1		Effect: "Gummiheart", Effect Duration: 25, Last Available: "2018-09"
 9976	twirling steel-toed stiffened party pants	0		Damage Reduction: 20, Last Available: "2018-09"
 9977	executive strapping party whip of chilblains	0		Muscle: +5, Cold Damage: +25, Meat Drop: +40, Last Available: "2018-09"
 9978	shaking Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	artisanal TRIO cup of beer	4	EPIC	Last Available: "2018-09"
 9980	spoiled party platter for one	3	crappy	Last Available: "2018-09"
-9981	denatured jittery teal shaking Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9981	denatured teal shaking jittery Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	chaotic crafty party crasher	0		Maximum MP: +10, Spell Critical Percent: +10, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9983	chaotic crafty party crasher	0		Maximum MP: +10, Spell Critical Percent: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
 9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	shaking purple Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
-9986	pulsating mirror party mouse hat	0		Familiar Weight: +5
-9987	wobbly ghostly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9986	mirror pulsating party mouse hat	0		Familiar Weight: +5
+9987	ghostly wobbly latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	steel-toed &quot;I Voted!&quot; sticker	0		Damage Reduction: 9, Lasts Until Rollover, Last Available: "2018-11"
@@ -9876,18 +9876,18 @@
 10010	miniature moldy ghostly ectoplasm	2	crappy	Last Available: "2018-11"
 10011	stale	3	decent	Last Available: "2018-11"
 10012	perfectly mixed bottle of vodka	4	EPIC	Last Available: "2018-11"
-10013	special immense flavorless tumbling pizza	7	decent	Effect: "So Fresh and So Clean", Effect Duration: 25, Last Available: "2018-11"
+10013	flavorless special immense tumbling pizza	7	decent	Effect: "So Fresh and So Clean", Effect Duration: 25, Last Available: "2018-11"
 10014	hand-crafted martini	3	EPIC	Last Available: "2018-11"
 10015	bland cherry pie	4	decent	Last Available: "2018-11"
-10016	tolerable weak eggnog	2	good	Last Available: "2018-11"
+10016	weak tolerable eggnog	2	good	Last Available: "2018-11"
 10017	bouncing glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	spoiled olive Hell ramen	3	crappy	Last Available: "2018-11"
-10019	smooth strong fancy wobbly gimlet	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 20, Last Available: "2018-11"
+10019	strong fancy smooth wobbly gimlet	5	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 20, Last Available: "2018-11"
 10020	delicious irresponsibly strong mirror twice-haunted screwdriver	9	awesome	Last Available: "2018-11"
 10021	spoiled gray candy cane	3	crappy	Last Available: "2018-12"
 10022	perfectly mixed runny fermented egg	4	EPIC	Last Available: "2018-12"
 10023	spoiled fuchsia oldcake	3	crappy	Last Available: "2018-12"
-10024	rotten miniature spinning traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
+10024	miniature rotten spinning traditional Crimbo cookie	2	crappy	Last Available: "2023-06"
 10025	curative plastic wild beaver	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2018-12"
 10026	skewed quilted plastic reindeer	0		Damage Absorption: +40, Last Available: "2018-12"
 10027	gravedigger's plastic Caf&eacute; Elf	0		Spooky Damage: +10, Last Available: "2018-12"
@@ -9907,7 +9907,7 @@
 10041	balanced antler of the brazier	0		Hot Spell Damage: +25, Last Available: "2018-12"
 10042	occult dam	0		Spell Damage Percent: +25, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable beavermouth	4	good	Last Available: "2018-12"
-10044	triple-distilled artisanal beaver punch (papaya)	6	EPIC	Last Available: "2018-12"
+10044	artisanal triple-distilled beaver punch (papaya)	6	EPIC	Last Available: "2018-12"
 10045	bad beaver punch (peach)	3	decent	Last Available: "2018-12"
 10046	weak hand-crafted twirling beaver punch (cherry)	2	EPIC	Last Available: "2018-12"
 10047	banded groovy Canadian lantern	0		Moxie Percent: +10, Damage Absorption: +100, Last Available: "2018-12"
@@ -9925,13 +9925,13 @@
 10059	sausage casing	0		Last Available: "2019-01"
 10060	huge bland sausage	8	decent	Last Available: "2019-01"
 10061	squat censurious perfumed red-hot sausage fork	0		Stench Resistance: +5, Sleaze Resistance: +3, Last Available: "2019-01"
-10062	shaking narrow bag of sausage links	0		Last Available: "2019-01"
+10062	narrow shaking bag of sausage links	0		Last Available: "2019-01"
 10063	upside-down sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	Toyleporter	0		Last Available: "2018-12"
-10066	watered-down lousy red wobbly beer	2	decent	Last Available: "2018-12"
+10066	lousy watered-down red wobbly beer	2	decent	Last Available: "2018-12"
 10067	spoiled yule gruel	4	crappy	Last Available: "2018-12"
-10068	practically non-alcoholic drinkable hot watered rum	1	good	Last Available: "2018-12"
+10068	drinkable practically non-alcoholic hot watered rum	1	good	Last Available: "2018-12"
 10069	drinkable bottle of Crimbognac	4	good	Last Available: "2018-12"
 10070	spoiled Crimboysters Rockefeller	4	crappy	Last Available: "2018-12"
 10071	dehydrated huge Crimbeau de toilette	1		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	lime green Van der Graaf Herculean marble mariachi hat	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
 10096	diluted pulsating marble molecules	1		Last Available: "2019-12"
 10097	quantum warmed ghostly Mallomarbles	0		Effect: "Patent Alacrity", Effect Duration: 16
-10098	nippy Newton's punching bag	0		Experience (Mysticality): +3, Cold Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	smelly thinker's pith helmet	0		Mysticality: +10, Stench Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	prompt mansplainer's poncho	0		Monster Level: +15, Adventures: +3, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	bouncing rock-hard razor-sharp pendant	0		Weapon Damage Percent: +25, Damage Reduction: 5, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	Herculean palazzos of the storm	0		Experience (Muscle): +1, Maximum MP Percent: +40, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	arcane researcher's pseudoaccordion of Calamity Jane	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +15, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	nippy Newton's punching bag	0		Experience (Mysticality): +3, Cold Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	smelly thinker's pith helmet	0		Mysticality: +10, Stench Spell Damage: +10, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	prompt mansplainer's poncho	0		Monster Level: +15, Adventures: +3, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	bouncing rock-hard razor-sharp pendant	0		Weapon Damage Percent: +25, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	Herculean palazzos of the storm	0		Experience (Muscle): +1, Maximum MP Percent: +40, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	arcane researcher's pseudoaccordion of Calamity Jane	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +15, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	mixed maroon pieces	1		Effect: "Cruisin' for a Bruisin'", Effect Duration: 50, Last Available: "2020-12"
 10105	moist skewed Para-Pop	0		Effect: "Blessing of Pikachutlotal", Effect Duration: 57
-10106	terra cotta truss of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	terra cotta trousers of Tarzan of Gandalf	0		Experience (Muscle): +3, Spell Critical Percent: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	blinking Fonzie's cool terra cotta tongs	0		Moxie: +5, Experience (Moxie): +1, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	Van der Graaf educational terra cotta train	0		Experience: +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	tumbling terra cotta tie tack of the blizzard of horror	0		Cold Spell Damage: +25, Spooky Spell Damage: +25, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	wholesome dance instructor's terra cotta tambourine	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	terra cotta truss of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	terra cotta trousers of Tarzan of Gandalf	0		Experience (Muscle): +3, Spell Critical Percent: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	blinking Fonzie's cool terra cotta tongs	0		Moxie: +5, Experience (Moxie): +1, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	Van der Graaf educational terra cotta train	0		Experience: +1, MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	tumbling terra cotta tie tack of the blizzard of horror	0		Cold Spell Damage: +25, Spooky Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	wholesome dance instructor's terra cotta tambourine	0		Experience Percent (Moxie): +10, Maximum HP Percent: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	vaporized terra cotta tidbits	1		Effect: "Florid Cheeks", Effect Duration: 10, Last Available: "2020-12"
 10113	boiled warmed terra panna cotta	0		Effect: "Yuletide Mutations", Effect Duration: 29
 10114	inspector's censurious velour voulge	0		Sleaze Resistance: +3, Item Drop: +15, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	cyan glass serape of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15, Last Available: "2021-12"
 10128	pickled mirror glass shards	1		Last Available: "2021-12"
 10129	vacuum-sealed chilled ionized narrow hard candy	0		Effect: "You Read The Manual", Effect Duration: 13
-10130	gray twirling chilly loofah lumberjack's hat of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	cyan rock-hard baleful loofah lei	0		Spell Damage: +25, Damage Reduction: 5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	jittery wobbly toasty loofah lederhosen of Leguizamo	0		Monster Level: +20, Hot Damage: +5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	Temple Grandin's slick loofah ladle	0		Moxie: +10, Familiar Weight: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	pulsating gravedigger's stiffened loofah legwarmers	0		Damage Reduction: 1, Spooky Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	yellow Lo Pan's Samson's loofah lavalier	0		Experience (Muscle): +5, Spell Critical Percent: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	gray twirling chilly loofah lumberjack's hat of Calamity Jane	0		Critical Hit Percent: +15, Cold Damage: +5, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	cyan rock-hard baleful loofah lei	0		Spell Damage: +25, Damage Reduction: 5, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	jittery wobbly toasty loofah lederhosen of Leguizamo	0		Monster Level: +20, Hot Damage: +5, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	Temple Grandin's slick loofah ladle	0		Moxie: +10, Familiar Weight: +7, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	pulsating gravedigger's stiffened loofah legwarmers	0		Damage Reduction: 1, Spooky Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	yellow Lo Pan's Samson's loofah lavalier	0		Experience (Muscle): +5, Spell Critical Percent: +30, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	vaporized loofah lumps	1		Effect: "Cletus's Canticle of Celerity", Effect Duration: 25, Last Available: "2022-12"
 10137	energized squat chocolate-covered loofah	0		Effect: "Locks Like the Raven", Effect Duration: 34
-10138	therapeutic flagstone flag of incineration	0		Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	squat miser's Jeselnik's flagstone flail	0		Sleaze Damage: +25, Meat Drop: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	ghostly Lo Pan's arcane researcher's flagstone flip-flops	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	lion tamer's Jim Carey's flagstone fez	0		Monster Level: +25, Experience (familiar): +2, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	fireproof quilted flagstone fleece	0		Damage Absorption: +40, Hot Resistance: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	Sinatra's flagstone fringe of the blizzard	0		Experience (Moxie): +5, Cold Spell Damage: +25, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
+10138	therapeutic flagstone flag of incineration	0		Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	squat miser's Jeselnik's flagstone flail	0		Sleaze Damage: +25, Meat Drop: +10, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	ghostly Lo Pan's arcane researcher's flagstone flip-flops	0		Experience Percent (Mysticality): +10, Spell Critical Percent: +30, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	lion tamer's Jim Carey's flagstone fez	0		Monster Level: +25, Experience (familiar): +2, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	fireproof quilted flagstone fleece	0		Damage Absorption: +40, Hot Resistance: +3, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	Sinatra's flagstone fringe of the blizzard	0		Experience (Moxie): +5, Cold Spell Damage: +25, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
 10144	altered lime green spinning flagstone flagments	1		Last Available: "2022-12"
 10145	colloidal super-colloidal Flag by the Foot&trade;	0		Effect: "Serenity", Effect Duration: 64
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10021,24 +10021,24 @@
 10155	decent immense elf army field rations	8	good	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	toasty Newton's discarded bowtie	0		Experience (Mysticality): +3, Hot Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
-10158	bad fortified martiny	5	decent	Last Available: "2019-12"
+10158	fortified bad martiny	5	decent	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	extra-corrupted licorice snake	0		Effect: "Kissed By Fire", Effect Duration: 23
 10161	non-corrupted virgin jello shot	0		Effect: "Piratastic", Effect Duration: 46
 10162	magnetized wet unsweetened huge mutated candy lump	0		Effect: "Uncanny Shot", Effect Duration: 24
 10163	nitrogenated quantum government-issued candy	0		Effect: "Wintergreen Warmongery", Effect Duration: 69
-10164	irradiated electrified ghostly blurry Pneumo bar	0		Effect: "Fishy", Effect Duration: 63
+10164	irradiated electrified blurry ghostly Pneumo bar	0		Effect: "Fishy", Effect Duration: 63
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	huge quilted extremely unsafe Lil' Doctor&trade; bag	0		Weapon Damage Percent: +100, Damage Absorption: +40, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	huge quilted extremely unsafe Lil' Doctor&trade; bag	0		Weapon Damage Percent: +100, Damage Absorption: +40, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blue blood bag	0		
 10169	toothsome bloodstick	3	awesome	
-10170	aged fancy bottle of Sanguiovese	3	awesome	Effect: "meat.enh", Effect Duration: 50
+10170	fancy aged bottle of Sanguiovese	3	awesome	Effect: "meat.enh", Effect Duration: 50
 10171	bland huge actual blood sausage	7	decent	
 10172	high-proof lousy mulled blood	6	decent	
 10173	adequate lime green blood snowcone	3	good	
 10174	watered-down drinkable Red Russian	2	good	
 10175	normal blood roll-up	3	good	
-10176	irresponsibly strong lousy bottle of blood	8	decent	
+10176	lousy irresponsibly strong bottle of blood	8	decent	
 10177	gigantic delicious blood-soaked sponge cake	6	awesome	
 10178	lousy jittery vampagne	4	decent	
 10179	normal big plain snowcone	5	good	
@@ -10064,8 +10064,8 @@
 10199	stale shaking crabsicle	3	decent	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	drinkable spirit-forward bottle of dark rhum	5	good	Last Available: "2019-04"
-10202	practically non-alcoholic hand-crafted bottle of extra-dark rhum	1	EPIC	Last Available: "2019-04"
-10203	enchanted perfectly mixed watered-down bottle of super-extra-dark rhum	2	EPIC	Effect: "Petit Forbearance", Effect Duration: 35, Last Available: "2019-04"
+10202	hand-crafted practically non-alcoholic bottle of extra-dark rhum	1	EPIC	Last Available: "2019-04"
+10203	watered-down enchanted perfectly mixed bottle of super-extra-dark rhum	2	EPIC	Effect: "Petit Forbearance", Effect Duration: 35, Last Available: "2019-04"
 10204	pickled dry pirate shaving cream	0		Effect: "Artificially Sweet", Effect Duration: 36, Last Available: "2019-04"
 10205	Annie Oakley's conquistador's breastplate of bravery	0		Critical Hit Percent: +20, Spooky Resistance: +5, Last Available: "2019-04"
 10206	foul-smelling pirate pantaloons of the sewer	0		Stench Damage: 35, Last Available: "2019-04"
@@ -10076,7 +10076,7 @@
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	stale pineapple slab	4	decent	Last Available: "2019-04"
 10213	bland hibiscus petal	3	decent	Last Available: "2019-04"
-10214	polarized super-galvanized ionized blue blinking huge mint leaf	0		Effect: "Uncaged Power", Effect Duration: 36, Last Available: "2019-04"
+10214	polarized super-galvanized ionized blinking blue huge mint leaf	0		Effect: "Uncaged Power", Effect Duration: 36, Last Available: "2019-04"
 10215	blurry cocoa of youth	0		Last Available: "2019-04"
 10216	dried ice molecule	1		Last Available: "2019-04"
 10217	blurry Red Roger's reliquary	0		Last Available: "2019-04"
@@ -10089,7 +10089,7 @@
 10224	twirling Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	blinking scandalous plush sea serpent	0		Sleaze Damage: +5, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	miniature rotten skewed bouncing pirate fork	2		Last Available: "2019-04"
+10227	rotten miniature bouncing skewed pirate fork	2		Last Available: "2019-04"
 10228	narrow Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	tumbling ring	0		Single Equip, Last Available: "2019-04"
 10230	squat educational strapping piratical blunderbuss	0		Muscle: +5, Experience: +1, Last Available: "2019-04"
@@ -10104,7 +10104,7 @@
 10239	drinkable Turtle Bowl	3	good	Last Available: "2019-04"
 10240	weak perfectly mixed Cobra Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	frightening stanky chaotic occult beefcake's vampyric cloake	0		Muscle: +25, Spell Damage Percent: +25, Spell Critical Percent: +10, Stench Spell Damage: +25, Spooky Damage: +5, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	frightening stanky chaotic occult beefcake's vampyric cloake	0		Muscle: +25, Spell Damage Percent: +25, Spell Critical Percent: +10, Stench Spell Damage: +25, Spooky Damage: +5, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	improved flattened one piece of bubble gum	0		Effect: "Favored by Lyle", Effect Duration: 30
 10245	maroon arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	tumbling blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	ruddy occult experienced Fourth of May Cosplay Saber	0		Experience: +2, Spell Damage Percent: +25, Maximum HP Percent: +40, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	ruddy occult experienced Fourth of May Cosplay Saber	0		Experience: +2, Spell Damage Percent: +25, Maximum HP Percent: +40, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	prompt double-paned Lo Pan's MacGyver's clever slick strapping hewn moon-rune spoon of the dark arts of the overflowing toilet of terror of mayonnaise	0		Muscle: +5, Moxie: +10, Spell Damage Percent: +100, Maximum MP: 120, Spell Critical Percent: +30, Stench Spell Damage: +50, Spooky Spell Damage: +10, Sleaze Spell Damage: +50, Cold Resistance: +5, Adventures: +3, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	prompt double-paned Lo Pan's MacGyver's clever slick strapping hewn moon-rune spoon of the dark arts of the overflowing toilet of terror of mayonnaise	0		Muscle: +5, Moxie: +10, Spell Damage Percent: +100, Maximum MP: 120, Spell Critical Percent: +30, Stench Spell Damage: +50, Spooky Spell Damage: +10, Sleaze Spell Damage: +50, Cold Resistance: +5, Adventures: +3, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	wobbly Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	supercool sage Beach Comb of chilblains	0		Mysticality Percent: +10, Moxie Percent: +20, Cold Damage: +25, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	supercool sage Beach Comb of chilblains	0		Mysticality Percent: +10, Moxie Percent: +20, Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	blue grain of sand	0		Last Available: "2019-07"
 10260	blurry small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10167,9 +10167,9 @@
 10302	skewed yellow executive Socratic whittled walking stick of the dark arts	0		Experience (Mysticality): +1, Spell Damage Percent: +100, Item Drop: +5, Meat Drop: +40, Last Available: "2019-08"
 10303	normal campfire hot dog	4	good	Last Available: "2019-08"
 10304	rotten campfire baked potato	3	crappy	Last Available: "2019-08"
-10305	low-calorie normal campfire s'more	1	good	Last Available: "2019-08"
+10305	normal low-calorie campfire s'more	1	good	Last Available: "2019-08"
 10306	spoiled gigantic skewed campfire beans	7	crappy	Last Available: "2019-08"
-10307	toothsome big campfire stew	5	awesome	Last Available: "2019-08"
+10307	big toothsome campfire stew	5	awesome	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
 10309	warmed twirling leftover chocolate bar	0		Effect: "So You Can Work More...", Effect Duration: 20
 10310	rare Meat isotope	0		
@@ -10181,7 +10181,7 @@
 10316	maroon space shield	0		Damage Reduction: 9
 10317	upside-down signal jammer	0		Single Equip
 10318	low-pressure oxygen tank	0		Single Equip
-10319	blurry mirror Thwaitgold bombardier beetle statuette	0		
+10319	mirror blurry Thwaitgold bombardier beetle statuette	0		
 10320	adequate space chowder	3	good	
 10321	weak tolerable space wine	2	good	
 10322	spinning The Imploded World	0		Skill: "Implode Universe"
@@ -10194,8 +10194,8 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	snack-sized rotten bu&ntilde;uelos Jaliscos	2	crappy	Last Available: "2019-12"
-10338	moldy diet flan del mar	1	crappy	Last Available: "2019-12"
-10339	rotten massive Baja sopapilla	8	crappy	Last Available: "2019-12"
+10338	diet moldy flan del mar	1	crappy	Last Available: "2019-12"
+10339	massive rotten Baja sopapilla	8	crappy	Last Available: "2019-12"
 10340	bouncing sizzling plastic Mer-kin baker	0		Hot Damage: +10, Last Available: "2019-12"
 10341	squat forbidden plastic sea elf	0		Spell Damage Percent: +50, Last Available: "2019-12"
 10342	pulsating Jim Carey's plastic yuleviathan	0		Monster Level: +25, Last Available: "2019-12"
@@ -10210,7 +10210,7 @@
 10351	quantum colloidal altered narrow patch of extra-warm fur	0		Effect: "Items Are Forever", Effect Duration: 19, Last Available: "2019-12"
 10352	vaporized jittery industrial lubricant	1		Last Available: "2019-12"
 10353	Vulcanized lime green unfinished pleasure	0		Effect: "Carol of the Bones", Effect Duration: 58, Last Available: "2019-12"
-10354	pickled squat twirling vial of humanoid growth hormone	1		Effect: "Sugary World View", Effect Duration: 20, Last Available: "2019-12"
+10354	pickled twirling squat vial of humanoid growth hormone	1		Effect: "Sugary World View", Effect Duration: 20, Last Available: "2019-12"
 10355	pickled squat mirror a bug's lymph	1		Last Available: "2019-12"
 10356	pressed polarized spinning organic potpourri	0		Effect: "Object Detection", Effect Duration: 61, Last Available: "2019-12"
 10357	perfectly mixed boot flask	3	EPIC	Last Available: "2019-12"
@@ -10243,7 +10243,7 @@
 10384	super-warmed flattened salty gumdrop	0		Effect: "Pockets of Fire", Effect Duration: 14, Last Available: "2019-12"
 10385	fuchsia dance instructor's ribbon candy ascot of the brazier	0		Experience Percent (Moxie): +10, Hot Spell Damage: +25, Single Equip, Last Available: "2019-12"
 10386	ghostly moist Crimbo spices	0		Last Available: "2019-12"
-10387	twirling blurry intact anemone spike	0		Last Available: "2019-12"
+10387	blurry twirling intact anemone spike	0		Last Available: "2019-12"
 10388	anemoney clip of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2019-12"
 10389	fuchsia runny icing	0		Last Available: "2019-12"
 10390	altered super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
@@ -10254,7 +10254,7 @@
 10395	olive personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	adequate squat bowl of mernudo	3	good	Last Available: "2019-12"
-10398	bad weak fishelada	2	decent	Last Available: "2019-12"
+10398	weak bad fishelada	2	decent	Last Available: "2019-12"
 10399	flavorless ojo de pez burrito	3	decent	Last Available: "2019-12"
 10400	waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10273,7 +10273,7 @@
 10414	nutcracker figurine	0		Last Available: "2019-12"
 10415	tasty salt plum	3	awesome	Last Available: "2019-12"
 10416	upside-down peppermint eel sauce	0		Last Available: "2019-12"
-10417	gigantic flavorless and bean	8	decent	Last Available: "2019-12"
+10417	flavorless gigantic and bean	8	decent	Last Available: "2019-12"
 10418	maroon aromatic kelp-holly gun of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50, Stench Resistance: +1, Last Available: "2019-12"
 10419	blinking quilted Socratic Yuleviathan necklace	0		Experience (Mysticality): +1, Damage Absorption: +40, Single Equip, Last Available: "2019-12"
 10420	miser's baleful peppermint spine	0		Spell Damage: +25, Meat Drop: +10, Last Available: "2019-12"
@@ -10281,18 +10281,18 @@
 10422	lightning-fast Crimbylow-rise jeans of doom	0		Spooky Spell Damage: +50, Initiative: +40, Last Available: "2019-12"
 10423	stanky frosty kelp-holly drape	0		Cold Spell Damage: +10, Stench Spell Damage: +25, Last Available: "2019-12"
 10424	twirling toasty curative Rosewater's Staff of the Peppermint Twist of bravery	0		Mysticality Percent: +30, Hot Damage: +5, Spooky Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2019-12"
-10425	rotten small tempura and bean	2	crappy	Last Available: "2019-12"
+10425	small rotten tempura and bean	2	crappy	Last Available: "2019-12"
 10426	smooth salt plum sake	3	awesome	Last Available: "2019-12"
 10427	frozen frozen pressurized potion of possessiveness	0		Effect: "Smelly Pants", Effect Duration: 58, Last Available: "2019-12"
 10428	denatured shaking almond	0		Effect: "Bat Attitude", Effect Duration: 12
 10429	pickled energized handful of mixed nuts	0		Effect: "Brocolate Brostidigitation", Effect Duration: 14, Last Available: "2019-12"
 10430	squat nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	tumbling electrified medical-grade Fonzie's Retrospecs	0		Experience (Moxie): +1, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	tumbling electrified medical-grade Fonzie's Retrospecs	0		Experience (Moxie): +1, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	narrow Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	fuchsia mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	wobbly avaricious careful Oprah's wizardly Powerful Glove of the scaredy-cat	0		Mysticality: +25, Maximum MP Percent: +50, Monster Level: -25, Meat Drop: +30, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	wobbly avaricious careful Oprah's wizardly Powerful Glove of the scaredy-cat	0		Mysticality: +25, Maximum MP Percent: +50, Monster Level: -25, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	quilted boxer's Drip harness of dire peril	0		Muscle Percent: +10, Weapon Damage: +20, Damage Absorption: +40
@@ -10300,7 +10300,7 @@
 10443	red Driplet	0		
 10444	drippy snail shell	0		
 10445	flavorless upside-down drippy nugget	3	drippy	
-10446	lousy watered-down glass of drippy wine	2	drippy	
+10446	watered-down lousy glass of drippy wine	2	drippy	
 10447	bland drippy caviar	3	drippy	
 10448	small tasty upside-down drippy plum(?)	2	drippy	
 10449	asbestos-lined drippy stake	0		Hot Resistance: +5, Single Equip
@@ -10310,7 +10310,7 @@
 10453	The Fingernail of the Thing in the Basement	0		
 10454	shaking coin	0		
 10455	mushroom	0		
-10456	mirror pulsating deluxe mushroom	0		
+10456	pulsating mirror deluxe mushroom	0		
 10457	super deluxe mushroom	0		
 10458	boiled ionized upside-down fizzy soda	0		Effect: "Human-Beast Hybrid", Effect Duration: 46
 10459	diffused anodized healthy juice	0		Effect: "Leisurely Amblin'", Effect Duration: 51
@@ -10329,7 +10329,7 @@
 10472	upside-down bony back shell of bravery	0		Spooky Resistance: +5
 10473	frosty button	0		Single Equip
 10474	activated quadruple-galvanized dry blooper ink	0		Effect: "Feet of Grapefruit", Effect Duration: 59
-10475	bouncing jittery coin	0		
+10475	jittery bouncing coin	0		
 10476	rubber doll head	0		
 10477	rubber doll body	0		
 10478	squat plastic doll arms	0		
@@ -10343,10 +10343,10 @@
 10486	pulsating free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	teal colossal free-range mushroom	0		Last Available: "2020-03"
-10489	diet stale bouncing mushroom filet	1	decent	Last Available: "2020-03"
+10489	stale diet bouncing mushroom filet	1	decent	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	denatured gray spinning mushroom tea	1		Last Available: "2020-03"
-10492	spirit-forward bad fuchsia mushroom whiskey	5	decent	Last Available: "2020-03"
+10492	bad spirit-forward fuchsia mushroom whiskey	5	decent	Last Available: "2020-03"
 10493	greedy mushroom cap of the dark arts of incineration	0		Spell Damage Percent: +100, Hot Spell Damage: +50, Meat Drop: +20, Last Available: "2020-03"
 10494	stylish mushroom shield of the dark arts of the bloodbag of horror	0		Moxie: +25, Spell Damage Percent: +100, Maximum HP: +100, Spooky Spell Damage: +25, Damage Reduction: 6, Last Available: "2020-03"
 10495	huge electrified therapeutic hardened beefy mushroom pants	0		Muscle: +10, Damage Reduction: 3, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2020-03"
@@ -10394,9 +10394,9 @@
 10538	blinking Guzzlr pants	0		Last Available: "2020-05"
 10539	Guzzlr souvenir stein of the boozehound	0		Booze Drop: +100, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	distilled hand-crafted Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
-10542	weak bad fancy Sourfinger	2	decent	Effect: "Twenty-three Squid, Ew", Effect Duration: 45, Last Available: "2020-05"
-10543	practically non-alcoholic artisanal Nog-on-the-Cob	1	super ultra mega turbo EPIC	Last Available: "2020-05"
+10541	hand-crafted distilled Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
+10542	bad weak fancy Sourfinger	2	decent	Effect: "Twenty-three Squid, Ew", Effect Duration: 45, Last Available: "2020-05"
+10543	artisanal practically non-alcoholic Nog-on-the-Cob	1	super ultra mega turbo EPIC	Last Available: "2020-05"
 10544	smooth red Steamboat	3	awesome	Last Available: "2020-05"
 10545	tolerable Buttery Boy	4	good	Last Available: "2020-05"
 10546	wobbly Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
@@ -10423,7 +10423,7 @@
 10567	smelly experienced actual skeleton key	0		Experience: +2, Stench Spell Damage: +10, Last Available: "2020-08"
 10568	twirling maroon Jim Carey's stylish slick deep-fried key	0		Moxie: 35, Monster Level: +25, Last Available: "2020-08"
 10569	aromatic Annie Oakley's discarded bike lock key	0		Critical Hit Percent: +20, Stench Resistance: +1, Last Available: "2020-08"
-10570	tumbling skewed Thwaitgold keyhole spider statuette	0		
+10570	skewed tumbling Thwaitgold keyhole spider statuette	0		
 10571	Manual of Lock Picking	0		Skill: "Lock Picking", Last Available: "2020-08"
 10572	galvanized marshroom	0		Effect: "Memory of Strength", Effect Duration: 53
 10573	blinking bag of Iunion stones	0		Free Pull
@@ -10433,14 +10433,14 @@
 10577	tarnished pickled ghostly writhing drippy candy bar	0		Effect: "Impregnably Delicious", Effect Duration: 46
 10578	triple-flattened magnetized gooey drippy candy bar	0		Effect: "Crimbo Flavor", Effect Duration: 51
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
-10580	huge mirror dromedary drinking helmet	0		
+10580	mirror huge dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	purple flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	fuchsia bouncing asbestos-lined MacGyver's birch battery	0		Maximum MP: +100, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2020-08"
-10585	upside-down ribald chilly ebony epee of mayonnaise	0		Cold Damage: +5, Sleaze Damage: +10, Sleaze Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	huge gravedigger's grievous beefy weeping willow wand	0		Muscle: +10, Weapon Damage Percent: +50, Spooky Damage: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	zippy stiffened beefcake's beechwood blowgun	0		Muscle: +25, Damage Reduction: 1, Initiative: +20, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	upside-down ribald chilly ebony epee of mayonnaise	0		Cold Damage: +5, Sleaze Damage: +10, Sleaze Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	huge gravedigger's grievous beefy weeping willow wand	0		Muscle: +10, Weapon Damage Percent: +50, Spooky Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	zippy stiffened beefcake's beechwood blowgun	0		Muscle: +25, Damage Reduction: 1, Initiative: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	miser's maple magnet of the brute of courage	0		Muscle Percent: +30, Spooky Resistance: +3, Meat Drop: +10, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	huge Annie Oakley's MacGyver's steel-toed hemlock helm	0		Damage Reduction: 9, Maximum MP: +100, Critical Hit Percent: +20, Last Available: "2020-08"
@@ -10547,7 +10547,7 @@
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
 10692	red booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	narrow candy drive button	0		Single Equip, Last Available: "2020-12"
-10694	skewed blue mirror food mailing list	0		Last Available: "2020-12"
+10694	blue mirror skewed food mailing list	0		Last Available: "2020-12"
 10695	mirror booze mailing list	0		Last Available: "2020-12"
 10696	huge candy mailing list	0		Last Available: "2020-12"
 10697	narrow veiny fruit bat of James Dean	0		Experience (Moxie): +3, Maximum HP: +10, Class: "Seal Clubber", Single Equip, Last Available: "2020-12"
@@ -10576,7 +10576,7 @@
 10720	smooth barrel-aged eggnog	4	awesome	Last Available: "2020-12"
 10721	spoiled hand-crafted candy cane	3	crappy	Last Available: "2020-12"
 10722	flavorless wobbly drive-thru burger	4	decent	Last Available: "2020-12"
-10723	delicious special Boulevardier cocktail	4	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 15, Last Available: "2020-12"
+10723	special delicious Boulevardier cocktail	4	awesome	Effect: "Once Bitten Twice Fried", Effect Duration: 15, Last Available: "2020-12"
 10724	polarized triple-altered narrow Hotwire&trade; brand candy rope	0		Effect: "World's Shortest Giant", Effect Duration: 63, Last Available: "2020-12"
 10725	normal bowl full of jelly	4	good	Last Available: "2020-12"
 10726	lousy Eye and a Twist	4	decent	Last Available: "2020-12"
@@ -10600,9 +10600,9 @@
 10744	anodized polymerized battery (car)	0		Effect: "Bilious Briskness", Effect Duration: 35, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	high-proof tolerable marshmallow bomb	8	good	Last Available: "2021-03"
+10747	tolerable high-proof marshmallow bomb	8	good	Last Available: "2021-03"
 10748	ghostly packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	blinking plate	0		Familiar Weight: +5
 10752	nitrogenated short beer	0		Effect: "Frost Tea", Effect Duration: 53, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	diffused aerosolized short	0		Effect: "Yuletide Mutations", Effect Duration: 25, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	olive rosewater-soaked familiar scrapbook of courage	0		Spooky Resistance: +3, Stench Resistance: +3, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10759	olive rosewater-soaked familiar scrapbook of courage	0		Spooky Resistance: +3, Stench Resistance: +3, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	executive double-paned fedora-mounted fountain of Flo-Jo	0		Cold Resistance: +5, Meat Drop: +40, Initiative: +100, Lasts Until Rollover, Last Available: "2021-07"
@@ -10628,18 +10628,18 @@
 10772	mirror family-friendly banded sparkler	0		Damage Absorption: +100, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2021-07"
 10773	tumbling wobbly Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	chilled bouncing Scent of a Human&trade; candle	0		Effect: "Stogied", Effect Duration: 35, Last Available: "2021-08"
-10775	ionized cold-filtered upside-down wobbly The Beast Within&trade; candle	0		Effect: "Lobos Fresh", Effect Duration: 12, Last Available: "2021-08"
+10775	ionized cold-filtered wobbly upside-down The Beast Within&trade; candle	0		Effect: "Lobos Fresh", Effect Duration: 12, Last Available: "2021-08"
 10776	aerosolized Vulcanized polarized olive Salsa Caliente&trade; candle	0		Effect: "Vented Spleen", Effect Duration: 37, Last Available: "2021-08"
-10777	activated upside-down maroon Smoldering Clover&trade; candle	0		Effect: "Partially Ghosted", Effect Duration: 54, Last Available: "2021-08"
+10777	activated maroon upside-down Smoldering Clover&trade; candle	0		Effect: "Partially Ghosted", Effect Duration: 54, Last Available: "2021-08"
 10778	polymerized chilled Napalm In The Morning&trade; candle	0		Effect: "Castaway Physique", Effect Duration: 39, Last Available: "2021-08"
 10779	greasy smelly extra-large utility candle	0		Stench Spell Damage: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2021-08"
 10780	ghostly skewed Oprah's dangerous runed taper candle	0		Weapon Damage: +10, Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2021-08"
 10781	purple dog trainer's Lo Pan's clever novelty sparkling candle	0		Maximum MP: +20, Spell Critical Percent: +30, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2021-08"
 10782	greedy studded Abracandalabra	0		Damage Absorption: +80, Meat Drop: +20, Lasts Until Rollover, Last Available: "2021-08"
 10783	chaotic extra-wide head candle of chilblains	0		Spell Critical Percent: +10, Cold Damage: +25, Lasts Until Rollover, Last Available: "2021-08"
-10784	triple-concentrated narrow mirror natural magick candle	0		Effect: "The Power of Positive Thinking", Effect Duration: 36, Last Available: "2021-08"
+10784	triple-concentrated mirror narrow natural magick candle	0		Effect: "The Power of Positive Thinking", Effect Duration: 36, Last Available: "2021-08"
 10785	energized rainbow glitter candle	0		Effect: "Patent Avarice", Effect Duration: 65, Last Available: "2021-08"
-10786	polymerized cyan mirror banana candle	0		Effect: "Chalked Weapon", Effect Duration: 14, Last Available: "2021-08"
+10786	polymerized mirror cyan banana candle	0		Effect: "Chalked Weapon", Effect Duration: 14, Last Available: "2021-08"
 10787	polymerized diffused anodized ear candle	0		Effect: "Buggy Flavor", Effect Duration: 46, Last Available: "2021-08"
 10788	adjusted activated votive of confidence	0		Effect: "Slightly Larger Than Usual", Effect Duration: 48, Last Available: "2021-08"
 10789	water candle of the overflowing toilet	0		Stench Spell Damage: +50, Water: 3, Lasts Until Rollover
@@ -10650,7 +10650,7 @@
 10794	mirror rainproof barrel caulk	0		
 10795	pump grease	0		
 10796	huge packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	horrifying frosty supercharged fortified padded industrial fire extinguisher of the blizzard	0		Damage Absorption: 80, Maximum MP Percent: +30, Cold Spell Damage: 35, Spooky Damage: +25, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10797	horrifying frosty supercharged fortified padded industrial fire extinguisher of the blizzard	0		Damage Absorption: 80, Maximum MP Percent: +30, Cold Spell Damage: 35, Spooky Damage: +25, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	red blurry The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,7 +10660,7 @@
 10804	Oprah's sinister Daylight Shavings Helmet of Calamity Jane	0		Spell Damage: +10, Maximum MP Percent: +50, Critical Hit Percent: +15, Last Available: "2021-11"
 10805	enchanted pulsating eggwater	1	EPIC	Effect: "Burning Hands", Effect Duration: 45, Last Available: "2021-12"
 10806	moldy purple bread man	4	crappy	Last Available: "2021-12"
-10807	flavorless miniature plain candy cane	2	decent	Last Available: "2021-12"
+10807	miniature flavorless plain candy cane	2	decent	Last Available: "2021-12"
 10808	stale flour cookie	4	decent	Last Available: "2021-12"
 10809	plastic food lab of Flo-Jo	0		Initiative: +100, Single Equip, Last Available: "2021-12"
 10810	squat plastic nog lab of dire peril	0		Weapon Damage: +20, Single Equip, Last Available: "2021-12"
@@ -10682,7 +10682,7 @@
 10826	mediocre Doc's Limbering Wine	4	decent	Last Available: "2021-12"
 10827	smooth Doc's Medical-Grade Wine	4	awesome	Last Available: "2021-12"
 10828	pickled Homebodyl&trade;	1		Last Available: "2021-12"
-10829	denatured huge huge cyan Extrovermectin&trade;	1		Effect: "Balls of Ectoplasm", Effect Duration: 45, Last Available: "2021-12"
+10829	denatured huge cyan huge Extrovermectin&trade;	1		Effect: "Balls of Ectoplasm", Effect Duration: 45, Last Available: "2021-12"
 10830	dehydrated cyan mirror Breathitin&trade;	1		Last Available: "2021-12"
 10831	boiled gray Fleshazole&trade;	1		Last Available: "2021-12"
 10832	frozen quadruple-cold-filtered boiled skewed anti-burn cream	0		Effect: "Colorful Gratitude", Effect Duration: 27, Last Available: "2021-12"
@@ -10695,10 +10695,10 @@
 10839	rotten small bread pie	2	crappy	Last Available: "2021-12"
 10840	special perfectly mixed clear Russian	3	EPIC	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
-10842	skewed twirling lime green Crimbo ball	0		Last Available: "2021-12"
+10842	skewed lime green twirling Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
 10844	huge gooified animal matter	0		Last Available: "2021-12"
-10845	ghostly blue gooified vegetable matter	0		Last Available: "2021-12"
+10845	blue ghostly gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
 10847	apple brown pudding pie	3	EPIC	Effect: "Hoity Toity", Effect Duration: 13
 10848	extra-sweet chocolate and pear nog	3	good	Effect: "Hoity Toity", Effect Duration: 33
@@ -10729,21 +10729,21 @@
 10873	purple reassuring thinker's can of mixed everything of the early riser	0		Mysticality: +10, Spooky Resistance: +1, Adventures: +7, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	enchanted normal big meatball	5	good	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2021-12"
+10876	big normal enchanted meatball	5	good	Effect: "Mushroom Samba", Effect Duration: 40, Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	meatball machine	0		Last Available: "2021-12"
 10879	gray refurbished air fryer	0		Last Available: "2021-12"
 10880	modified blurry fried air	1		Last Available: "2021-12"
 10881	tumbling 11-leaf clover	0		
 10882	ghostly carton of astral energy drinks	0		
-10883	dehydrated narrow skewed purple astral energy drink	1		
-10884	pulsating bouncing mint condition magnifying glass	0		Last Available: "2022-12"
+10883	dehydrated narrow purple skewed astral energy drink	1		
+10884	bouncing pulsating mint condition magnifying glass	0		Last Available: "2022-12"
 10885	narrow chilly Oprah's magnifying glass of extreme caution	0		Maximum MP Percent: +50, Monster Level: -25, Cold Damage: +5, Last Available: "2022-12"
 10886	practically non-alcoholic tolerable void lager	1	good	Last Available: "2022-12"
 10887	spoiled void burger	3	crappy	Last Available: "2022-12"
 10888	skewed void stone	0		Last Available: "2022-12"
 10889	void shard of wisdom of Tarzan of the bloodbag of mayonnaise	0		Mysticality: +15, Experience (Muscle): +3, Maximum HP: +100, Sleaze Spell Damage: +50, Last Available: "2022-12"
-10890	blinking skewed undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
+10890	skewed blinking undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	teal cosmic bowling ball	0		Last Available: "2022-01"
 10892	combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	ghostly horrifying combat lover's locket	0		Spooky Damage: +25, Single Equip, Last Available: "2022-02"
@@ -10774,21 +10774,21 @@
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	rosewater-soaked steel-toed dance instructor's June cleaver	0		Experience Percent (Moxie): +10, Damage Reduction: 9, Stench Resistance: +3, Attacks Can't Miss, Last Available: "2022-06"
-10921	bad practically non-alcoholic yellow Dad's brandy	1	decent	Last Available: "2022-06"
+10921	practically non-alcoholic bad yellow Dad's brandy	1	decent	Last Available: "2022-06"
 10922	cyan horrifying Jim Carey's teacher's pen	0		Monster Level: +25, Spooky Damage: +25, Last Available: "2022-06"
 10923	adequate miniature maroon fire-roasted lake trout	2	good	Last Available: "2022-06"
-10924	low-calorie yummy guilty sprout	1	awesome	Last Available: "2022-06"
+10924	yummy low-calorie guilty sprout	1	awesome	Last Available: "2022-06"
 10925	veiny mother's necklace of chilblains	0		Maximum HP: +10, Cold Damage: +25, Last Available: "2022-06"
 10926	chilled bouncing blue trampled ticket stub	0		Effect: "Danish Cunning", Effect Duration: 54, Last Available: "2022-06"
 10927	flattened modified savings bond	0		Effect: "Highland Sheen", Effect Duration: 62, Last Available: "2022-06"
 10928	ghostly designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	shaking designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	shaking designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
 10930	pickled ghostly sweat-ade	1		Last Available: "2022-07"
-10931	mirror bouncing unopened stillsuit	0		Free Pull, Last Available: "2022-08"
+10931	bouncing mirror unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	skewed stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	wobbly thick dinosaur	0		
-10934	jittery ghostly huge dinosaur scale	0		
-10935	green bouncing pristine dinosaur feather	0		
+10934	jittery huge ghostly dinosaur scale	0		
+10935	bouncing green pristine dinosaur feather	0		
 10936	nasty dinosaur spike	0		
 10937	reassuring pterodactyl rifle	0		Spooky Resistance: +1, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
@@ -10798,15 +10798,15 @@
 10942	dinosaur repellent	0		
 10943	hardy camouflage vest	0		Maximum HP: +50
 10944	jittery Dinodollar	0		
-10945	lime green shaking valuable dinosaur droppings	0		
+10945	shaking lime green valuable dinosaur droppings	0		
 10946	dinosaur pheromone kit	0		
 10947	Usain Bolt's fortified Da Vinci's awkward dinosaur research harness	0		Experience (Mysticality): +5, Damage Absorption: +60, Initiative: +80
 10948	bouncing upside-down fuchsia scandalous reflective vest	0		Sleaze Damage: +5
 10949	Da Vinci's dinosaur	0		Experience (Mysticality): +5
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	censurious Jurassic Parka of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
-10953	huge narrow boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
+10952	censurious Jurassic Parka of extreme caution	0		Monster Level: -25, Sleaze Resistance: +3, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10953	narrow huge boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	skewed autumn-aton	0		Last Available: "2022-10"
 10955	frozen moist autumn leaf	0		Effect: "Crying, Dying", Effect Duration: 65, Last Available: "2022-10"
 10956	acceptable AutumnFest ale	3	good	Last Available: "2022-10"
@@ -10815,10 +10815,10 @@
 10959	bland tumbling autumn-spice donut	3	decent	Last Available: "2022-10"
 10960	corrupted chilled liquefied autumn dollar	0		Effect: "Penguinny Flavor", Effect Duration: 41, Last Available: "2022-10"
 10961	purple pulsating smooth autumn leaf pendant of chilblains of the cheetah	0		Moxie: +15, Cold Damage: +25, Initiative: +60, Lasts Until Rollover, Last Available: "2022-10"
-10962	mixed pulsating jittery autumn breeze	1		Effect: "Stuck That Way", Effect Duration: 35, Last Available: "2022-10"
+10962	mixed jittery pulsating autumn breeze	1		Effect: "Stuck That Way", Effect Duration: 35, Last Available: "2022-10"
 10963	enhanced autumn years wisdom	0		Effect: "Dancing Prowess", Effect Duration: 61, Last Available: "2022-10"
-10964	huge upside-down familiar-in-the-middle wrapper	0		Last Available: "2025-12"
-10965	weak mediocre twirling Oopsie IPA	2	decent	Last Available: "2022-10"
+10964	upside-down huge familiar-in-the-middle wrapper	0		Last Available: "2025-12"
+10965	mediocre weak twirling Oopsie IPA	2	decent	Last Available: "2022-10"
 10966	purple mummified entombed cookbookbat	0		Free Pull, Last Available: "2022-11"
 10967	twirling Yeast of Boris	0		Last Available: "2022-11"
 10968	narrow St. Sneaky Pete's Whey	0		Last Available: "2022-11"
@@ -10827,10 +10827,10 @@
 10971	special adequate gray Jarlsberg's vegetable soup	4	good	Effect: "Nuts about Candy", Effect Duration: 40, Last Available: "2022-11"
 10972	flavorless blue roasted vegetable of Jarlsberg	3	decent	Last Available: "2022-11"
 10973	bland thick St. Pete's sneaky smoothie	5	decent	Last Available: "2022-11"
-10974	spoiled fancy Pete's wiley whey bar	4	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 20, Last Available: "2022-11"
+10974	fancy spoiled Pete's wiley whey bar	4	crappy	Effect: "Heal Thy Nanoself", Effect Duration: 20, Last Available: "2022-11"
 10975	immense normal Pete's rich ricotta	8	good	Last Available: "2022-11"
 10976	drinkable Boris's beer	3	good	Last Available: "2022-11"
-10977	thick rotten honey bun of Boris	5	crappy	Last Available: "2022-11"
+10977	rotten thick honey bun of Boris	5	crappy	Last Available: "2022-11"
 10978	yummy Boris's bread	4	awesome	Last Available: "2022-11"
 10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
 10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
@@ -10843,8 +10843,8 @@
 10987	shaking Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	flavorless snack-sized blue baked veggie ricotta casserole	2	decent	Last Available: "2022-11"
 10989	stale enchanted plain calzone	3	decent	Effect: "Dexteri Tea", Effect Duration: 40, Last Available: "2022-11"
-10990	miniature moldy blinking roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
-10991	stale small Pizza of Legend	2	decent	Last Available: "2022-11"
+10990	moldy miniature blinking roasted vegetable focaccia	2	crappy	Last Available: "2022-11"
+10991	small stale Pizza of Legend	2	decent	Last Available: "2022-11"
 10992	small adequate green Calzone of Legend	2	good	Last Available: "2022-11"
 10993	huge Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
 10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
@@ -10853,7 +10853,7 @@
 10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	green Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	half-sized flavorless yellow Deep Dish of Legend	2	decent	Last Available: "2022-11"
+11000	flavorless half-sized yellow Deep Dish of Legend	2	decent	Last Available: "2022-11"
 11001	jittery deed to Oliver's Place	0		Free Pull
 11002	squat drink chit	0		
 11003	government per-diem	0		
@@ -10869,16 +10869,16 @@
 11013	mediocre Charleston Choo-Choo	3	decent	
 11014	perfectly mixed Velvet Veil	3	EPIC	
 11015	perfectly mixed Marltini	4	EPIC	
-11016	practically non-alcoholic lousy Strong, Silent Type	1	decent	
+11016	lousy practically non-alcoholic Strong, Silent Type	1	decent	
 11017	perfectly mixed Mysterious Stranger	3	EPIC	
-11018	fortified artisanal Champagne Shimmy	5	EPIC	
+11018	artisanal fortified Champagne Shimmy	5	EPIC	
 11019	skewed the Sot's parcel	0		
-11020	thinker's strapping ceramic cestus	0		Muscle: +5, Mysticality: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	baleful smartaleck's ceramic centurion shield of the ox	0		Muscle: +20, Moxie Percent: +30, Spell Damage: +25, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	shaking wizardly ceramic celery grater of terror	0		Mysticality: +25, Spooky Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	double-paned lard-coated extremely unsafe ceramic celsiturometer	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Cold Resistance: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	narrow wholesome ceramic cerecloth belt of the storm of chilblains	0		Maximum HP Percent: +10, Maximum MP Percent: +40, Cold Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	rock-hard beefy ceramic cenobite's robe	0		Muscle: +10, Damage Reduction: 5, Item Drop: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	thinker's strapping ceramic cestus	0		Muscle: +5, Mysticality: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	baleful smartaleck's ceramic centurion shield of the ox	0		Muscle: +20, Moxie Percent: +30, Spell Damage: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	shaking wizardly ceramic celery grater of terror	0		Mysticality: +25, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	double-paned lard-coated extremely unsafe ceramic celsiturometer	0		Weapon Damage Percent: +100, Sleaze Spell Damage: +25, Cold Resistance: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	narrow wholesome ceramic cerecloth belt of the storm of chilblains	0		Maximum HP Percent: +10, Maximum MP Percent: +40, Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	rock-hard beefy ceramic cenobite's robe	0		Muscle: +10, Damage Reduction: 5, Item Drop: +5, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	twisted pulsating ceramic scree	1		Effect: "Mutated", Effect Duration: 45, Last Available: "2023-12"
 11027	Vulcanized moist extra-hard jawbreaker	0		Effect: "Human-Plant Hybrid", Effect Duration: 31
 11028	twirling scandalous chiffon chevrons of the overflowing toilet of the businessman	0		Stench Spell Damage: +50, Sleaze Damage: +5, Meat Drop: +50, Single Equip, Last Available: "2023-12"
@@ -10890,8 +10890,8 @@
 11034	mixed twirling chiffon carbage	1		Last Available: "2023-12"
 11035	adjusted chiffon lemon	0		Effect: "Transcendental Wind", Effect Duration: 25
 11036	stale chocomotive	3	decent	Last Available: "2022-12"
-11037	flavorless half-sized shaking freightcake	2	decent	Last Available: "2022-12"
-11038	smooth practically non-alcoholic cabooze	1	awesome	Last Available: "2022-12"
+11037	half-sized flavorless shaking freightcake	2	decent	Last Available: "2022-12"
+11038	practically non-alcoholic smooth cabooze	1	awesome	Last Available: "2022-12"
 11039	tumbling plastic caboose	0		Last Available: "2022-12"
 11040	padded plastic passenger car	0		Damage Absorption: +20, Last Available: "2022-12"
 11041	upside-down Rosewater's plastic dining car	0		Mysticality Percent: +30, Last Available: "2022-12"
@@ -10910,7 +10910,7 @@
 11054	flattened quantum blinking Trainbot servomotors	0		Effect: "Boletus Swoletus", Effect Duration: 53
 11055	super-ionized enhanced Trainbot linkages	0		Effect: "Norwhalloped", Effect Duration: 36
 11056	mirror ping-pong paddle	0		Single Equip
-11057	spinning blinking ping-pong ball	0		
+11057	blinking spinning ping-pong ball	0		
 11058	flame-wreathed Trainbot harness	0		Hot Spell Damage: +10
 11059	ping-pong table	0		
 11060	Crimbo train emergency brake	0		
@@ -10920,11 +10920,11 @@
 11064	pulsating prompt Fonzie's shoulder-mounted Trainbot of dire peril	0		Experience (Moxie): +1, Weapon Damage: +20, Adventures: +3, Single Equip, Last Available: "2022-12"
 11065	wobbly cinnamon machine oil	0		
 11066	ghostly Crimbo crystal shards	0		
-11067	strong bad dregs of a Crimbo cocktail	5	decent	
+11067	bad strong dregs of a Crimbo cocktail	5	decent	
 11068	blinking lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	decent honey-drenched ham slice	3	good	
-11071	triple-distilled artisanal fancy olive mostly-empty bottle of cookie wine	7	EPIC	Effect: "Gummiskin", Effect Duration: 15
+11071	fancy triple-distilled artisanal olive mostly-empty bottle of cookie wine	7	EPIC	Effect: "Gummiskin", Effect Duration: 15
 11072	adequate fancy spinning Crimbo food scraps	3	good	Effect: "Riboflavin'", Effect Duration: 15
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
@@ -10937,7 +10937,7 @@
 11081	pulsating steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
-11084	acceptable irresponsibly strong shaking Crimbosmopolitan	6	good	Last Available: "2022-12"
+11084	irresponsibly strong acceptable shaking Crimbosmopolitan	6	good	Last Available: "2022-12"
 11085	normal Crimbo dinner	3	good	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
 11087	shaking train whistle	0		Last Available: "2022-12"
@@ -10952,7 +10952,7 @@
 11096	grubby wool beerwarmer	0		
 11097	mediocre nice warm beer	3	decent	
 11098	grubby woolball	0		
-11099	huge olive Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
+11099	olive huge Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	groveling gravel	0		Last Available: "2023-01"
 11102	powdered lime green spinning fruity pebble	1		Effect: "Grrrrrrreat!", Effect Duration: 35, Last Available: "2023-01"
@@ -10983,10 +10983,10 @@
 11128	enhanced Vulcanized filled mosquito	0		Effect: "All Branned Up", Effect Duration: 63, Last Available: "2023-02"
 11129	frozen pulsating shim of shame shale	0		Effect: "Infernal Thirst", Effect Duration: 60, Last Available: "2023-02"
 11130	vacuum-sealed pebble of proud pyrite	0		Effect: "Armored Innards", Effect Duration: 45, Last Available: "2023-02"
-11131	ionized pickled twirling blue pile of gritty sand	0		Effect: "Nano-juiced", Effect Duration: 17, Last Available: "2023-02"
+11131	ionized pickled blue twirling pile of gritty sand	0		Effect: "Nano-juiced", Effect Duration: 17, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	aerosolized ionized bouncing angry agate	0		Effect: "Elemental Flavor", Effect Duration: 47, Last Available: "2023-02"
-11134	altered dry bouncing jittery lump of loyal latite	0		Effect: "Meatwise", Effect Duration: 58, Last Available: "2023-02"
+11134	altered dry jittery bouncing lump of loyal latite	0		Effect: "Meatwise", Effect Duration: 58, Last Available: "2023-02"
 11135	spoiled twirling shadow sausage	4	crappy	Last Available: "2023-03"
 11136	auspicious brainy shadow skin	0		Mysticality: +5, Item Drop: +10, Last Available: "2023-03"
 11137	cold-filtered ionized blue shadow flame	0		Effect: "Ocelot Eyes", Effect Duration: 51, Last Available: "2023-03"
@@ -10994,7 +10994,7 @@
 11139	shadow ice	0		Last Available: "2023-03"
 11140	lousy shadow fluid	3	decent	Last Available: "2023-03"
 11141	jittery shadow glass	0		Last Available: "2023-03"
-11142	teal squat shadow brick	0		Last Available: "2023-03"
+11142	squat teal shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
 11144	drinkable weak shadow venom	2	good	Last Available: "2023-03"
 11145	dehydrated shadow nectar	1		Last Available: "2023-03"
@@ -11034,23 +11034,23 @@
 11179	lime green sizzling shellacked shadow hammer	0		Damage Reduction: 7, Hot Damage: +10
 11180	fireproof coward's occult shadow monocle	0		Spell Damage Percent: +25, Monster Level: -20, Hot Resistance: +3, Single Equip
 11181	mirror shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	half-sized bland shadow hot dog	2	decent	
+11182	bland half-sized shadow hot dog	2	decent	
 11183	watered-down mediocre shadow martini	2	decent	
 11184	pickled shadow pill	1		
 11185	ghostly shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	shaking monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	concentrated cyan shadow candy	0		Effect: "Witch's Brood", Effect Duration: 56
 11189	replica Mr. Accessory	0		
 11190	replica Dark Jill-O-Lantern	0		
 11191	replica hand turkey outline	0		
 11192	replica crimbo elfling	0		
-11193	huge gray replica pygmy bugbear shaman	0		
+11193	gray huge replica pygmy bugbear shaman	0		
 11194	dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	blurry replica wax lips	0		Experience: +3
-11197	jittery fuchsia replica Tome of Snowcone Summoning	0		
-11198	fuchsia twirling dedigitizer schematic: cybeer	0		Last Available: "2025-12"
+11197	fuchsia jittery replica Tome of Snowcone Summoning	0		
+11198	twirling fuchsia dedigitizer schematic: cybeer	0		Last Available: "2025-12"
 11199	blurry hardened replica jewel-eyed wizard hat of dire peril of Leguizamo	0		Weapon Damage: +20, Damage Reduction: 3, Monster Level: +20, Conditional Skill (Equipped): "Magic Missile"
 11200	careful sinister savvy replica bottle-rocket crossbow	0		Mysticality Percent: +20, Spell Damage: +10, Monster Level: -10, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 11201	red huge asbestos-lined knitted grievous replica navel ring of navel gazing of the scaredy-cat	0		Weapon Damage Percent: +50, Monster Level: -15, Cold Resistance: +3, Hot Resistance: +5, Single Equip
@@ -11059,10 +11059,10 @@
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
 11205	replica cotton candy cocoon	0		
 11206	foul-smelling thinker's replica Elvish sunglasses of the ox of the pedagogue	0		Muscle: +20, Mysticality: +10, Experience: +3, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
-11207	yellow bouncing squat replica squamous polyp	0		
+11207	bouncing squat yellow replica squamous polyp	0		
 11208	blinking mirror mirror replica stone sphere	0		
 11209	ghostly blinking sharpshooter's brainy replica Greatest American Pants of Gandalf	0		Mysticality: +5, Critical Hit Percent: +10, Spell Critical Percent: +20
-11210	blinking spinning replica organ grinder	0		
+11210	spinning blinking replica organ grinder	0		
 11211	mirror Lo Pan's supercharged arcane researcher's replica Juju Mojo Mask	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, Spell Critical Percent: +30, Single Equip
 11212	pulsating greasy ribald replica Operation Patriot Shield of vim and vigor	0		Maximum HP Percent: +50, Sleaze Damage: +10, Sleaze Spell Damage: +10, Damage Reduction: 15, Conditional Skill (Equipped): "Throw Shield"
 11213	tumbling replica Libram of Resolutions	0		
@@ -11075,7 +11075,7 @@
 11220	ghostly replica over-the-shoulder Folder Holder	0		
 11221	narrow replica Order of the Green Thumb Order Form	0		
 11222	skewed shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	huge prompt Socratic Herculean Cincho de Mayo of the sweet-tooth	0		Experience (Muscle): +1, Experience (Mysticality): +1, Candy Drop: +100, Adventures: +3, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11223	huge prompt Socratic Herculean Cincho de Mayo of the sweet-tooth	0		Experience (Muscle): +1, Experience (Mysticality): +1, Candy Drop: +100, Adventures: +3, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
 11224	dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	gray replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11087,7 +11087,7 @@
 11232	replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
 11234	replica genie bottle	0		
-11235	squat maroon replica space planula	0		
+11235	maroon squat replica space planula	0		
 11236	pulsating replica unpowered Robortender	0		
 11237	mirror replica Neverending Party invitation envelope	0		
 11238	replica January's Garbage Tote	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	horrifying hardened replica Jurassic Parka	0		Damage Reduction: 3, Spooky Damage: +25
 11250	twirling blinking replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	red replica Ten Dollars	0		
 11254	lard-coated gravedigger's rock-hard extremely unsafe replica Cincho de Mayo	0		Weapon Damage Percent: +100, Damage Reduction: 5, Spooky Damage: +10, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	lard-coated stylish brainy &quot;I survived Y2K&quot; T-Shirt of the bloodbag of Calamity Jane	0		Mysticality: +5, Moxie: +25, Maximum HP: +100, Critical Hit Percent: +15, Sleaze Spell Damage: +25, Item Drop: +5, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	stiffened pro skateboard of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	stiffened pro skateboard of the brazier	0		Damage Reduction: 1, Hot Spell Damage: +25, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	green Charter: Nellyville	0		Last Available: "2023-06"
 11265	blurry Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	strapping Flash Liquidizer Ultra Dousing Accessory	0		Muscle: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11266	strapping Flash Liquidizer Ultra Dousing Accessory	0		Muscle: +5, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	scandalous lion tamer's dog trainer's deadly Amulet of Perpetual Darkness	0		Weapon Damage: +5, Experience (familiar): 3, Sleaze Damage: +5, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	wobbly Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11152,7 +11152,7 @@
 11297	shaking kilopede skull of the ox of temperance	0		Muscle: +20, Sleaze Resistance: +5
 11298	liquefied alkaline haemolymphnode	0		Effect: "Red-Shirted Escort", Effect Duration: 18
 11299	double-nitrogenated blinking chitin powder paste	0		Effect: "Executive Greed", Effect Duration: 36
-11300	fuchsia upside-down sleeping patriotic eagle	0		Free Pull
+11300	upside-down fuchsia sleeping patriotic eagle	0		Free Pull
 11301	pulsating claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
 11303	name change form	0		
@@ -11168,11 +11168,11 @@
 11313	extremely unsafe cat o' nine teeth of horror	0		Weapon Damage Percent: +100, Spooky Spell Damage: +25
 11314	lightning-fast manspreader's tooth cap	0		Monster Level: +10, Initiative: +40
 11315	Newton's toothy trousers of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3
-11316	decent small mirror banana split	2	good	
+11316	small decent mirror banana split	2	good	
 11317	olive handful of toilet paper	0		
 11318	tumbling Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	fancy tolerable bottle of Cabernet Sauvignon	4	good	Effect: "Mercenary", Effect Duration: 45
+11320	tolerable fancy bottle of Cabernet Sauvignon	4	good	Effect: "Mercenary", Effect Duration: 45
 11321	greasy energetic wicked baywatch	0		Spell Damage: +5, Maximum MP Percent: +20, Sleaze Spell Damage: +10, Lasts Until Rollover
 11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
@@ -11212,15 +11212,15 @@
 11357	ghostly lion tamer's dance instructor's smoldering drape	0		Experience Percent (Moxie): +10, Experience (familiar): +2, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	razor-sharp deadly boxer's slick beefcake's leaf crown of dire peril	0		Muscle: +25, Moxie: +10, Muscle Percent: +10, Weapon Damage: 25, Weapon Damage Percent: +25
-11360	stale miniature leafy browns	2	decent	
+11360	miniature stale leafy browns	2	decent	
 11361	cold-filtered autumnic balm	0		Effect: "Okee-Dokee Computer", Effect Duration: 21
-11362	irradiated concentrated jittery yellow shaking twirling coping juice	0		Effect: "Ham-Fisted", Effect Duration: 23
+11362	irradiated concentrated yellow jittery twirling shaking coping juice	0		Effect: "Ham-Fisted", Effect Duration: 23
 11363	bouncing up-at-dawn Jim Carey's healthy steel-toed thinker's candy cane sword cane	0		Mysticality: +10, Damage Reduction: 9, Maximum HP Percent: +20, Monster Level: +25, Adventures: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	squat wrapped candy cane sword cane	0		Free Pull
 11365	lime green twirling Elf Guard patrol cap	0		Last Available: "2023-12"
 11366	yellow Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
-11368	blurry lime green Crimbuccaneer breeches	0		Last Available: "2023-12"
+11368	lime green blurry Crimbuccaneer breeches	0		Last Available: "2023-12"
 11369	blinking automa-bot parts	0		
 11370	security automa-core	0		
 11371	upside-down clerical automa-core	0		
@@ -11231,8 +11231,8 @@
 11376	housekeeping automa-core	0		
 11377	mirror housekeeping robot	0		
 11378	bland pickled bread	4	decent	Last Available: "2023-12"
-11379	diet normal salted mutton	1	good	Last Available: "2023-12"
-11380	immense normal corned beet	8	good	Last Available: "2023-12"
+11379	normal diet salted mutton	1	good	Last Available: "2023-12"
+11380	normal immense corned beet	8	good	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
 11383	tiny plastic Elf Guard Mess Hall	0		Food Drop: +3
@@ -11240,20 +11240,20 @@
 11385	tiny plastic Abuela's Cottage (Pirate Control)	0		Muscle: +3, Mysticality: +3, Moxie: +3
 11386	pirate encryption key alpha	0		Last Available: "2023-12"
 11387	pirate encryption key bravo	0		Last Available: "2023-12"
-11388	blinking bouncing olive pirate encryption key charlie	0		Last Available: "2023-12"
+11388	olive bouncing blinking pirate encryption key charlie	0		Last Available: "2023-12"
 11389	mirror pirate encryption key delta	0		Last Available: "2023-12"
 11390	bouncing wardrobe-o-matic	0		
 11391	futuristic shirt	0		Lasts Until Rollover
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	rotten ghostly maroon peppermint donut	3	crappy	
+11395	rotten maroon ghostly peppermint donut	3	crappy	
 11396	Newton's Elf Guard insignia (private)	0		Experience (Mysticality): +3, Last Available: "2023-12"
 11397	shellacked Crimbuccaneer fledges (mint)	0		Damage Reduction: 7, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	lousy weak blinking Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
+11401	weak lousy blinking Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	spinning sinister razor-sharp Crimbuccaneer lantern of bravery	0		Weapon Damage Percent: +25, Spell Damage: +10, Spooky Resistance: +5, Last Available: "2023-12"
@@ -11277,10 +11277,10 @@
 11422	lousy watered-down old-school pirate grog	2	decent	Last Available: "2023-12"
 11423	adequate grog nuts	3	good	Last Available: "2023-12"
 11424	pulsating sizzling clever hale sawed-off blunderbuss	0		Maximum HP: +20, Maximum MP: +20, Hot Damage: +10, Last Available: "2023-12"
-11425	artisanal fortified officer's nog	5	EPIC	Last Available: "2023-12"
+11425	fortified artisanal officer's nog	5	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
 11427	normal sundae ration	3	good	Last Available: "2023-12"
-11428	stale huge peppermint tack	7	decent	Last Available: "2023-12"
+11428	huge stale peppermint tack	7	decent	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	moldy whalesteak	4	crappy	Last Available: "2023-12"
 11431	pulsating pulsating studded supercool brawny whalegun	0		Muscle Percent: +20, Moxie Percent: +20, Damage Absorption: +80, Last Available: "2023-12"
@@ -11307,7 +11307,7 @@
 11452	foul-smelling extremely unsafe personal trainer's Elf dessert spoon of the empath of horror of the detective	0		Experience Percent (Muscle): +10, Weapon Damage Percent: +100, Familiar Weight: +5, Stench Damage: +10, Spooky Spell Damage: +25, Item Drop: +20, Last Available: "2023-12"
 11453	mirror scorching clever Elf Guard SCUBA tank	0		Maximum MP: +20, Hot Damage: +25, Last Available: "2023-12"
 11454	purple Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	studded stylish free boots	0		Moxie: +25, Damage Absorption: +80, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	studded stylish free boots	0		Moxie: +25, Damage Absorption: +80, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	mirror wool flame-wreathed occult Elvish underarmor	0		Spell Damage Percent: +25, Hot Spell Damage: +10, Cold Resistance: +1, Single Equip, Last Available: "2023-12"
 11458	censurious banded Crimbuccaneer bombjacket	0		Damage Absorption: +100, Sleaze Resistance: +3, Combat Item Damage Percent: 100, Last Available: "2023-12"
@@ -11315,25 +11315,25 @@
 11460	stale fuchsia gingerbread nylons	3	decent	Last Available: "2023-12"
 11461	moldy rum-soaked fruitcake	3	crappy	Last Available: "2023-12"
 11462	snack-sized adequate red lime	2	good	Last Available: "2023-12"
-11463	immense normal gingerbread pirate	6	good	Last Available: "2023-12"
-11464	half-sized moldy fruit-stuffed rumcake	2	crappy	Last Available: "2023-12"
-11465	watered-down mediocre mulled wine	2	decent	Last Available: "2023-12"
+11463	normal immense gingerbread pirate	6	good	Last Available: "2023-12"
+11464	moldy half-sized fruit-stuffed rumcake	2	crappy	Last Available: "2023-12"
+11465	mediocre watered-down mulled wine	2	decent	Last Available: "2023-12"
 11466	lousy olive Swedish coffee	4	decent	Last Available: "2023-12"
-11467	drinkable watered-down jittery canteen of eggnog	2	good	Last Available: "2023-12"
+11467	watered-down drinkable jittery canteen of eggnog	2	good	Last Available: "2023-12"
 11468	practically non-alcoholic acceptable hot wine	1	good	Last Available: "2023-12"
 11469	hand-crafted Jamaican coffee	4	EPIC	Last Available: "2023-12"
 11470	tolerable huge flask of egggrog	3	good	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	spinning Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
-11474	watered-down acceptable skewed ghostly yule grog	2	good	Last Available: "2023-12"
+11474	acceptable watered-down ghostly skewed yule grog	2	good	Last Available: "2023-12"
 11475	normal bouncing wet tack	4	good	Last Available: "2023-12"
 11476	adequate whalecake	3	good	Last Available: "2023-12"
-11477	sharpshooter's dangerous gunwale whalegun of the glutton	0		Weapon Damage: +10, Critical Hit Percent: +10, Food Drop: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	sharpshooter's dangerous gunwale whalegun of the glutton	0		Weapon Damage: +10, Critical Hit Percent: +10, Food Drop: +100, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	hand-crafted and claret	3	super EPIC	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	rock-hard stiffened Elf Guard squirtgun	0		Damage Reduction: 12, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	rock-hard stiffened Elf Guard squirtgun	0		Damage Reduction: 12, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	olive smelly sequin-encrusted sweater	0		Stench Spell Damage: +10, Last Available: "2023-12"
 11484	lightning-fast cool replica Elf Guard medal of mayonnaise	0		Moxie: +5, Sleaze Spell Damage: +50, Initiative: +40, Last Available: "2023-12"
@@ -11356,13 +11356,13 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	enhanced diffused ghostly military candy cane	0		Effect: "Hood Ridin'", Effect Duration: 58
 11503	unsweetened oxidized dry groggipop	0		Effect: "Hopped Up on Goofballs", Effect Duration: 18
-11504	prompt wicked moss mace	0		Spell Damage: +5, Adventures: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	upside-down deadly moss megaphone of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	pulsating narrow Tesla moss medal of the wise owl	0		Mysticality: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	nippy moss mitre of the sewer	0		Cold Damage: +10, Stench Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	twirling manspreader's hardy moss mantle	0		Maximum HP: +50, Monster Level: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	prompt wicked moss mace	0		Spell Damage: +5, Adventures: +3, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	upside-down deadly moss megaphone of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	pulsating narrow Tesla moss medal of the wise owl	0		Mysticality: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	nippy moss mitre of the sewer	0		Cold Damage: +10, Stench Damage: +25, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	twirling manspreader's hardy moss mantle	0		Maximum HP: +50, Monster Level: +10, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	lime green spinning huge ribald Sinatra's moss marlinspike	0		Experience (Moxie): +5, Sleaze Damage: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	boiled green jittery moss mulch	1		Last Available: "2024-12"
+11510	boiled jittery green moss mulch	1		Last Available: "2024-12"
 11511	quadruple-wet jittery moss floss	0		Effect: "Flashing Eyes", Effect Duration: 34
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	gray adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11372,12 +11372,12 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	diluted adobe assortment	1		Last Available: "2024-12"
 11519	electrified ionized adobe brittle	0		Effect: "Heart of Orange", Effect Duration: 24
-11520	greedy grievous crepe paper phrygian cap of the early riser	0		Weapon Damage Percent: +50, Meat Drop: +20, Adventures: +7, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	greedy grievous crepe paper phrygian cap of the early riser	0		Weapon Damage Percent: +50, Meat Drop: +20, Adventures: +7, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	bouncing pulsating perfumed nippy crepe paper parachute cape of the glutton	0		Cold Damage: +10, Stench Resistance: +5, Food Drop: +100, Last Available: "2025-12"
-11522	rosewater-soaked sage crepe paper pie clip of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Stench Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	maroon sharpshooter's forbidden crepe paper puzzle cube of the pedagogue	0		Experience: +3, Spell Damage Percent: +50, Critical Hit Percent: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	flame-wreathed curative crepe paper plunge camisole of the scaredy-cat	0		Monster Level: -15, Hot Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	blurry blinking grievous sage crepe paper polka charm of dire peril	0		Mysticality Percent: +10, Weapon Damage: +20, Weapon Damage Percent: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	rosewater-soaked sage crepe paper pie clip of the brute	0		Muscle Percent: +30, Mysticality Percent: +10, Stench Resistance: +3, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	maroon sharpshooter's forbidden crepe paper puzzle cube of the pedagogue	0		Experience: +3, Spell Damage Percent: +50, Critical Hit Percent: +10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	flame-wreathed curative crepe paper plunge camisole of the scaredy-cat	0		Monster Level: -15, Hot Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	blurry blinking grievous sage crepe paper polka charm of dire peril	0		Mysticality Percent: +10, Weapon Damage: +20, Weapon Damage Percent: +50, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	distilled blinking crepe paper pared cuttings	1		Effect: "I See Everything Thrice!", Effect Duration: 35, Last Available: "2025-12"
 11527	alkaline enhanced crepe paper peanut candy	0		Effect: "Metal Speed", Effect Duration: 57
 11528	energetic stiffened petrified wood war pike	0		Damage Reduction: 1, Maximum MP Percent: +20, Last Available: "2025-12"
@@ -11388,17 +11388,17 @@
 11533	blinking shellacked rock-hard petrified wood walking pants	0		Damage Reduction: 24, Last Available: "2025-12"
 11534	altered petrified wood waste parts	1		Effect: "Space Cowboy", Effect Duration: 20, Last Available: "2025-12"
 11535	energized electrified petrified wood wafer praline	0		Effect: "Artificially Sweet", Effect Duration: 40
-11536	perfectly mixed triple-distilled cybeer	9	EPIC	Last Available: "2025-12"
+11536	triple-distilled perfectly mixed cybeer	9	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	mirror upside-down encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	mirror upside-down encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	twirling googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	ribald energetic Crimbuccaneer war standard	0		Maximum MP Percent: +20, Sleaze Damage: +10, Last Available: "2023-12"
 11544	rosewater-soaked Jack Frost's Elf Guard war standard	0		Cold Spell Damage: +50, Stench Resistance: +3, Last Available: "2023-12"
 11545	in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	avaricious ruddy spring shoes of the wise owl	0		Mysticality: +20, Maximum HP Percent: +40, Meat Drop: +30, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	avaricious ruddy spring shoes of the wise owl	0		Mysticality: +20, Maximum HP Percent: +40, Meat Drop: +30, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	alkaline ultra-soft ferns	0		Effect: "Fishy Fortification", Effect Duration: 45, Last Available: "2024-02"
 11548	frozen super-oxidized diffused pulsating crunchy brush	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 15, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11406,7 +11406,7 @@
 11551	narrow triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
 11553	ultra-high-tension exoskeleton	0		
-11554	jittery mirror blue irresponsible-tension exoskeleton	0		
+11554	mirror blue jittery irresponsible-tension exoskeleton	0		
 11555	quick-release belt pouch	0		Single Equip
 11556	quick-release fannypack	0		Single Equip
 11557	bouncing quick-release utility belt	0		Single Equip
@@ -11430,10 +11430,10 @@
 11575	delicious watered-down sweet potato o' mine	2	awesome	Last Available: "2024-05"
 11576	perfectly mixed irresponsibly strong Southern yam	10	EPIC	Last Available: "2024-05"
 11577	lousy sweet potato punch	3	decent	Last Available: "2024-05"
-11578	bite-sized stale pulsating Mayam spinach	1	decent	Last Available: "2024-05"
-11579	bland snack-sized yam and swiss	2	decent	Last Available: "2024-05"
+11578	stale bite-sized pulsating Mayam spinach	1	decent	Last Available: "2024-05"
+11579	snack-sized bland yam and swiss	2	decent	Last Available: "2024-05"
 11580	ribald careful yam cannon of Tarzan	0		Experience (Muscle): +3, Monster Level: -10, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2024-05"
-11581	upside-down pulsating gray yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
+11581	upside-down gray pulsating yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
 11583	yam stinkbomb	0		Last Available: "2024-05"
 11584	wool furry yam buckler of Leguizamo of mayonnaise	0		Monster Level: +20, Sleaze Spell Damage: +50, Cold Resistance: +1, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
@@ -11446,22 +11446,22 @@
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	diet yummy skewed mini kiwi	1	awesome	Last Available: "2024-06"
+11594	yummy diet skewed mini kiwi	1	awesome	Last Available: "2024-06"
 11595	razor-sharp sage mini kiwi bikini of courage	0		Mysticality Percent: +10, Weapon Damage Percent: +25, Spooky Resistance: +3, Last Available: "2024-06"
-11596	practically non-alcoholic aged mini kiwitini	1	awesome	Last Available: "2024-06"
+11596	aged practically non-alcoholic mini kiwitini	1	awesome	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	Jim Carey's energetic deadly mini kiwi silicon tiepin	0		Weapon Damage: +5, Maximum MP Percent: +20, Monster Level: +25
 11600	mini kiwi tipi	0		
 11601	spoiled mini kiwi digitized cookies	4	crappy	
-11602	lousy enchanted watered-down spinning mini kiwi intoxicating spirits	2	decent	Effect: "Hypercubed", Effect Duration: 25
+11602	watered-down enchanted lousy spinning mini kiwi intoxicating spirits	2	decent	Effect: "Hypercubed", Effect Duration: 25
 11603	quadruple-polarized mini kiwi antimilitaristic hippy petition	0		Effect: "Cinnamouth", Effect Duration: 60
 11604	wet mini kiwi illicit antibiotic	0		Effect: "Gutterminded", Effect Duration: 15
 11605	twirling miser's Samson's mini kiwi whipping stick	0		Experience (Muscle): +5, Meat Drop: +10
 11606	jittery ghostly clever mini kiwi icepick	0		Maximum MP: +20
-11607	improved olive jittery huge mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Dilated Pupils", Effect Duration: 19
+11607	improved jittery olive huge mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Dilated Pupils", Effect Duration: 19
 11608	blue packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11471,7 +11471,7 @@
 11616	green flagellate flagon	0		
 11617	proto-proto-protozoa	0		
 11618	flavorless bacteria bisque	3	decent	
-11619	spoiled small ciliophora chowder	2	crappy	
+11619	small spoiled ciliophora chowder	2	crappy	
 11620	low-calorie flavorless cream of chloroplasts	1	decent	
 11621	synaptic soup	0		
 11622	muscular soup	0		
@@ -11489,7 +11489,7 @@
 11634	tattoo gun	0		
 11635	lousy Colera Peste Nebbiolo	3	decent	
 11636	longbox of Batfellow comics	0		
-11637	twirling blinking Thwaitgold shield bug statuette	0		
+11637	blinking twirling Thwaitgold shield bug statuette	0		
 11638	bodyguard badge	0		
 11639	gray Too Cold to Hold: How to Be Cool - A Memoir	0		Skill: "Too Cool"
 11640	green Too Cold to Hold: How to Be Cool - A Memoir (read)	0		Skill: "Too Cool"
@@ -11497,7 +11497,7 @@
 11642	Sept-Ember Censer	0		Last Available: "2024-09"
 11643	shaking stylish blade of dismemberment	0		Moxie: +25, Lasts Until Rollover, Last Available: "2024-09"
 11644	Embering Hulk	0		Last Available: "2024-09"
-11645	yellow blurry bouncing Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
+11645	yellow bouncing blurry Mmm-brr! brand mouthwash	0		Last Available: "2024-09"
 11646	Septapus summoning charm	0		Last Available: "2024-09"
 11647	spinning structural ember	0		Last Available: "2024-09"
 11648	pulsating huge censurious resourceful embers-only jacket of James Dean	0		Experience (Moxie): +3, Maximum MP: +50, Sleaze Resistance: +3, Lasts Until Rollover, Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	blurry soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	lime green boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	double-paned quilted bat wings of dire peril	0		Weapon Damage: +20, Damage Absorption: +40, Cold Resistance: +5, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	double-paned quilted bat wings of dire peril	0		Weapon Damage: +20, Damage Absorption: +40, Cold Resistance: +5, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	ember egg	0		Last Available: "2024-09"
 11660	huge ember	0		Cold Resistance: +1
 11661	auspicious resourceful monocle on a stick	0		Maximum MP: +50, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	upside-down strapping Sheriff badge of the scaredy-cat	0		Muscle: +5, Monster Level: -15, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	narrow Sinatra's experienced Sheriff pistol	0		Experience: +2, Experience (Moxie): +5, Lasts Until Rollover, Last Available: "2024-10"
 11670	knitted Van der Graaf Sheriff moustache	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	padded photo booth supply list of the scaredy-cat	0		Damage Absorption: +20, Monster Level: -15, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	padded photo booth supply list of the scaredy-cat	0		Damage Absorption: +20, Monster Level: -15, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	decent low-calorie squat whirled peas	1	good	Last Available: "2024-11"
@@ -11531,7 +11531,7 @@
 11676	tumbling peace shooter	0		Last Available: "2024-11"
 11677	denatured squat blinking drenchrome 2.0	1		Last Available: "2025-12"
 11678	dried huge Synapse Blaster	1		Effect: "Squatting and Thrusting", Effect Duration: 50, Last Available: "2025-12"
-11679	upside-down squat quantized familiar	0		
+11679	squat upside-down quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	mirror quantized familiar experience	0		
 11682	Vulcanized cold-filtered pea brittle	0		Effect: "Brother Corsican's Blessing", Effect Duration: 62, Last Available: "2024-11"
@@ -11541,7 +11541,7 @@
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	wobbly squat TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	deft pirate hook of the pedagogue of terror	0		Experience: +3, Spooky Spell Damage: +10, Lasts Until Rollover, Last Available: "2024-12"
-11689	shaking dance instructor's Socratic iron tricorn hat	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	shaking dance instructor's Socratic iron tricorn hat	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	squat strapping jolly roger flag	0		Muscle: +5, Lasts Until Rollover, Last Available: "2024-12"
 11691	wobbly sleeping profane parrot	0		Last Available: "2024-12"
 11692	upside-down pirrrate's currrse	0		Last Available: "2024-12"
@@ -11570,32 +11570,32 @@
 11715	twirling sinister plastic Jedediah and Boiling Cloud	0		Spell Damage: +10, Last Available: "2024-12"
 11716	baleful plastic &quot;Santa Claus&quot;	0		Spell Damage: +25, Last Available: "2024-12"
 11717	wobbly Spirit of Easter	0		Last Available: "2024-12"
-11718	twirling purple ghostly Spirit of St. Patrick's Day	0		Last Available: "2024-12"
+11718	ghostly twirling purple Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	cyan Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	wobbly Spirit of Thanksgiving	0		Last Available: "2024-12"
 11721	tumbling cyan Spirit of Christmas	0		Last Available: "2024-12"
-11722	normal big narrow spinning coney haunch	5	good	Last Available: "2024-12"
+11722	big normal narrow spinning coney haunch	5	good	Last Available: "2024-12"
 11723	ionized cyan dark chocolate egg	0		Effect: "Spooky Hands", Effect Duration: 16, Last Available: "2024-12"
-11724	weak bad moai toai	2	decent	
+11724	bad weak moai toai	2	decent	
 11725	squat twirling inspector's fortified moaiball of mayonnaise	0		Damage Absorption: +60, Sleaze Spell Damage: +50, Item Drop: +15, Last Available: "2024-12"
-11726	lime green ghostly squat half-digested rat	0		Last Available: "2024-12"
+11726	squat lime green ghostly half-digested rat	0		Last Available: "2024-12"
 11727	concentrated four-leaf potato sprout	0		Effect: "Rave Concentration", Effect Duration: 17, Last Available: "2024-12"
 11728	narrow Usain Bolt's greasy Annie Oakley's potato jacket	0		Critical Hit Percent: +20, Sleaze Spell Damage: +10, Initiative: +80, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	olive Brandonian footlocker key	0		Last Available: "2024-12"
-11731	sinister boxer's military orb	0		Muscle Percent: +10, Spell Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	sinister boxer's military orb	0		Muscle Percent: +10, Spell Damage: +10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	tarnished green rum ball	0		Effect: "Healthy Red Glow", Effect Duration: 33
 11733	gravy skin	0		Last Available: "2024-12"
 11734	dance instructor's gravyskin hat of chilblains	0		Experience Percent (Moxie): +10, Cold Damage: +25, Last Available: "2024-12"
 11735	thinker's gravyskin buckler of mayonnaise	0		Mysticality: +10, Sleaze Spell Damage: +50, Damage Reduction: 7, Last Available: "2024-12"
 11736	ribald Herculean gravyskin skirt	0		Experience (Muscle): +1, Sleaze Damage: +10, Last Available: "2024-12"
 11737	family-friendly gravyskin pants of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +1, Last Available: "2024-12"
-11738	non-wet tumbling yellow bouncing crystallized pumpkin spice	0		Effect: "Human-Hippy Hybrid", Effect Duration: 53, Last Available: "2024-12"
+11738	non-wet yellow bouncing tumbling crystallized pumpkin spice	0		Effect: "Human-Hippy Hybrid", Effect Duration: 53, Last Available: "2024-12"
 11739	stale room scale bean casserole	3	decent	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	wobbly ragged wool yarn	0		Last Available: "2024-12"
 11742	asbestos-lined brainy perfect Christmas scarf of the cheetah	0		Mysticality: [+5*event(December)], Hot Resistance: [+5*event(December)], Initiative: [+60*event(December)], Single Equip, Last Available: "2024-12"
-11743	skewed MacGyver's forbidden snowman-enchanting tophat	0		Spell Damage Percent: +50, Maximum MP: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	skewed MacGyver's forbidden snowman-enchanting tophat	0		Spell Damage Percent: +50, Maximum MP: +100, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	wet ghostly LIDAR candle	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 14, Last Available: "2024-12"
 11745	shaking miser's stiffened Da Vinci's Congressional Medal of Insanity	0		Experience (Mysticality): +5, Damage Reduction: 1, Meat Drop: +10, Last Available: "2024-12"
 11746	huge pumpkin spice whorl	0		Last Available: "2024-12"
@@ -11603,13 +11603,13 @@
 11748	mediocre high-proof Irish eggnog	9	decent	Last Available: "2024-12"
 11749	high-proof perfectly mixed wobbly canteen of jungle juice	7	EPIC	Last Available: "2024-12"
 11750	acceptable turchucken	3	good	Last Available: "2024-12"
-11751	practically non-alcoholic hand-crafted mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
+11751	hand-crafted practically non-alcoholic mechanically-mulled cider	1	super ultra mega turbo EPIC	Last Available: "2024-12"
 11752	smooth holiday trip around the world	4	awesome	Last Available: "2024-12"
-11753	delicious jumbo chocolate ostrich egg	5	awesome	Last Available: "2024-12"
+11753	jumbo delicious chocolate ostrich egg	5	awesome	Last Available: "2024-12"
 11754	toothsome blurry beef and cabbage	3	awesome	Last Available: "2024-12"
 11755	bland candy rations	3	decent	Last Available: "2024-12"
 11756	normal double-candied yams	3	good	Last Available: "2024-12"
-11757	super-sized bland Christmas ham	5	decent	Last Available: "2024-12"
+11757	bland super-sized Christmas ham	5	decent	Last Available: "2024-12"
 11758	adequate huge holiday smorgasbord	8	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	squat bejazzled eyepatch of James Dean	0		Experience (Moxie): +3, Last Available: "2024-12"
@@ -11624,11 +11624,11 @@
 11769	wobbly Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	squat wool rock-hard stiffened studded egg gun	0		Damage Absorption: +80, Damage Reduction: 12, Cold Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	squat wool rock-hard stiffened studded egg gun	0		Damage Absorption: +80, Damage Reduction: 12, Cold Resistance: +1, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	hale rosy-cheeked strapping army helmet of the boozehound	0		Muscle: +5, Maximum HP Percent: +30, Maximum HP: +20, Booze Drop: +100, Last Available: "2024-12"
 11774	narrow candy egg deviler	0		Last Available: "2024-12"
 11775	jittery red napkin	0		Last Available: "2024-12"
-11776	half-sized flavorless gray Thanksgiving ration	2	decent	Last Available: "2024-12"
+11776	flavorless half-sized gray Thanksgiving ration	2	decent	Last Available: "2024-12"
 11777	acceptable Easter eggnog	3	good	Last Available: "2024-12"
 11778	boiled ghostly clovermint	1		Last Available: "2024-12"
 11779	skewed lightning-fast chaotic occult razor-sharp nylon Christmas stockings	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Spell Critical Percent: +10, Initiative: +40, Single Equip, Last Available: "2024-12"
@@ -11636,17 +11636,17 @@
 11781	oxidized deviled candy egg	0		Effect: "Baconstoned", Effect Duration: 68, Last Available: "2024-12"
 11782	McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	blurry executive supercharged McHugeLarge duffel bag	0		Maximum MP Percent: +30, Meat Drop: +40, Last Available: "2025-01"
-11784	twirling thinker's McHugeLarge left pole of the overflowing toilet of terror	0		Mysticality: +10, Stench Spell Damage: +50, Spooky Spell Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	ribald electrified Rosewater's McHugeLarge right pole	0		Mysticality Percent: +30, Sleaze Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	hardy McHugeLarge left ski of the detective	0		Maximum HP: +50, Item Drop: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	squat ribald brawny McHugeLarge right ski	0		Muscle Percent: +20, Sleaze Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	twirling thinker's McHugeLarge left pole of the overflowing toilet of terror	0		Mysticality: +10, Stench Spell Damage: +50, Spooky Spell Damage: +10, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	ribald electrified Rosewater's McHugeLarge right pole	0		Mysticality Percent: +30, Sleaze Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	hardy McHugeLarge left ski of the detective	0		Maximum HP: +50, Item Drop: +20, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	squat ribald brawny McHugeLarge right ski	0		Muscle Percent: +20, Sleaze Damage: +10, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	1	0		Last Available: "2025-12"
 11789	purple 0	0		Last Available: "2025-12"
 11790	mixed blurry eXpand	1		Last Available: "2025-12"
-11791	tumbling brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11791	tumbling brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
 11793	mirror dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
-11794	mirror lime green dedigitizer schematic: malware injector	0		Last Available: "2025-12"
+11794	lime green mirror dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	upside-down dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
 11797	dedigitizer schematic: cryptocloak	0		Last Available: "2025-12"
@@ -11656,9 +11656,9 @@
 11801	dedigitizer schematic: trojan horseshoe	0		Last Available: "2025-12"
 11802	dedigitizer schematic: familiar-in-the-middle	0		Last Available: "2025-12"
 11803	cybervisor	0		Last Available: "2025-12"
-11804	huge teal retro floppy disk	0		Last Available: "2025-12"
+11804	teal huge retro floppy disk	0		Last Available: "2025-12"
 11805	lime green pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	ghostly 3d printed server room key	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	blinking hashing vise	0		Last Available: "2025-12"
-11827	ghostly geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	ghostly geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	yellow virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11698,7 +11698,7 @@
 11843	Observer source code	0		
 11844	upside-down chill gherkin	0		
 11845	tumbling childrens' stapler	0		
-11846	green twirling plover's egg	0		
+11846	twirling green plover's egg	0		
 11847	flyswatter	0		
 11848	Thwaitgold cordyceps ant statuette	0		
 11849	mirror jittery heat particle	0		Hot Damage: +10, Hot Spell Damage: +10
@@ -11714,7 +11714,7 @@
 11859	mosquito speakers	0		Monster Level: +5
 11860	yellow assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
-11862	altered blinking lime green shaking scoop of pre-workout powder	1		Effect: "Stone-Faced", Effect Duration: 10, Last Available: "2025-03"
+11862	altered blinking shaking lime green scoop of pre-workout powder	1		Effect: "Stone-Faced", Effect Duration: 10, Last Available: "2025-03"
 11863	table tennis ball	0		Last Available: "2025-03"
 11864	practically non-alcoholic mediocre pint of Leprechaun Stout	1	decent	Last Available: "2025-03"
 11865	diluted squat phosphor traces	1		Last Available: "2025-03"
@@ -11726,14 +11726,14 @@
 11871	dehydrated tumbling leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	bland snack-sized pulsating Heck ramen	2	decent	Last Available: "2025-03"
 11873	normal burrito	3	good	Last Available: "2025-03"
-11874	tiny tasty small beer brat	1	awesome	Last Available: "2025-03"
+11874	tasty tiny small beer brat	1	awesome	Last Available: "2025-03"
 11875	flavorless blurry peach pie	3	decent	Last Available: "2025-03"
 11876	spoiled incredible mini-pizza	4	crappy	Last Available: "2025-03"
 11877	practically non-alcoholic perfectly mixed Divine sidecar	1	super ultra EPIC	Last Available: "2025-03"
 11878	artisanal jittery tangarita sidecar	3	EPIC	Last Available: "2025-03"
 11879	weak mediocre squat gimlet sidecar	2	decent	Last Available: "2025-03"
 11880	lousy vodka stratocaster sidecar	3	decent	Last Available: "2025-03"
-11881	fortified acceptable prussian cathouse sidecar	5	good	Last Available: "2025-03"
+11881	acceptable fortified prussian cathouse sidecar	5	good	Last Available: "2025-03"
 11882	practically non-alcoholic delicious Mon Tiki sidecar	1	awesome	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	shaking skewed strapping April Shower Thoughts shield of temperance	0		Muscle: +5, Sleaze Resistance: +5, Damage Reduction: 6, Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	narrow razor-sharp stylish bycocket	0		Weapon Damage Percent: +25
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	narrow flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	blurry yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11803,11 +11803,11 @@
 11948	diffused Life Goals Pamphlet	0		Effect: "Stick Emporium Membership", Effect Duration: 47, Last Available: "2025-08"
 11949	up-at-dawn bully badge	0		Adventures: +5, Lasts Until Rollover, Last Available: "2025-08"
 11950	huge Sherlock's time cop top hat	0		Item Drop: +25, Last Available: "2025-08"
-11951	bouncing wobbly Stock Certificate	0		Last Available: "2025-08"
-11952	twisted ghostly bouncing maroon mixed berry jelly	1		Last Available: "2025-08"
-11953	half-sized decent toast with mixed berry jelly	2	good	Last Available: "2025-08"
-11954	toothsome tiny cup of sugar	1	awesome	Last Available: "2025-08"
-11955	spoiled snack-sized enchanted ghostly Susie's cupcake	2	crappy	Effect: "The Wisdom... of the Future", Effect Duration: 35, Last Available: "2025-08"
+11951	wobbly bouncing Stock Certificate	0		Last Available: "2025-08"
+11952	twisted bouncing maroon ghostly mixed berry jelly	1		Last Available: "2025-08"
+11953	decent half-sized toast with mixed berry jelly	2	good	Last Available: "2025-08"
+11954	tiny toothsome cup of sugar	1	awesome	Last Available: "2025-08"
+11955	enchanted snack-sized spoiled ghostly Susie's cupcake	2	crappy	Effect: "The Wisdom... of the Future", Effect Duration: 35, Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	skewed maroon aromatic horrifying Fonzie's the gun	0		Experience (Moxie): +1, Spooky Damage: +25, Stench Resistance: +1, Last Available: "2025-08"
 11958	tolerable wine	4	good	Last Available: "2025-08"
@@ -11816,26 +11816,26 @@
 11962	teal mirror hardy undersea surveying goggles	0		Maximum HP: +50, Lasts Until Rollover
 11963	delicious Ocean-Touched Rum	4	awesome	
 11964	twisted water-logged pill	1		
-11965	stale small kelp puck	2	decent	
+11965	small stale kelp puck	2	decent	
 11966	scroll of sea strength	0		
 11967	jittery scroll of sea smarts	0		
 11968	scroll of sea smarm	0		
 11969	teal waterlogged scroll of healing	0		
 11970	sea gel	0		
 11971	dry octopus ink bladder	0		Effect: "Phairly Balanced", Effect Duration: 29
-11972	wobbly blinking durable dolphin whistle	0		
+11972	blinking wobbly durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	spinning packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	blue unblemished pearl	0		
 11977	reassuring dentadent	0		Spooky Resistance: +1
 11986	spinning lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	asbestos-lined sharpshooter's hale beefcake's blood cubic zirconia of the glutton	0		Muscle: +25, Maximum HP: +20, Critical Hit Percent: +10, Hot Resistance: +5, Item Drop: +5, Food Drop: +100, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	asbestos-lined sharpshooter's hale beefcake's blood cubic zirconia of the glutton	0		Muscle: +25, Maximum HP: +20, Critical Hit Percent: +10, Hot Resistance: +5, Item Drop: +5, Food Drop: +100, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	altered shaking red blood thinner	1		Last Available: "2025-10"
-12045	boozy hand-crafted pheromone cocktail	5	EPIC	Last Available: "2025-10"
+12045	hand-crafted boozy pheromone cocktail	5	EPIC	Last Available: "2025-10"
 12046	flavorless spinal tapas	3	decent	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	dangerous shrunken head of the scaredy-cat of extreme caution	0		Weapon Damage: +10, Monster Level: -40, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	dangerous shrunken head of the scaredy-cat of extreme caution	0		Weapon Damage: +10, Monster Level: -40, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	cyan stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	squat knucklebone	0		
@@ -11846,7 +11846,7 @@
 12056	lousy blinking vodka cranberry sauce	4	decent	Last Available: "2025-11"
 12057	vacuum-sealed yammed candy	0		Effect: "Chorale of Companionship", Effect Duration: 60, Last Available: "2025-11"
 12058	tasty huge treasure chestnut	3	awesome	Last Available: "2025-12"
-12059	practically non-alcoholic bad mulled butter rum	1	decent	Last Available: "2025-12"
+12059	bad practically non-alcoholic mulled butter rum	1	decent	Last Available: "2025-12"
 12060	liquefied dry chilled mirror cinnamon doubloon	0		Effect: "Mmmmmelon", Effect Duration: 42, Last Available: "2025-12"
 12061	mirror lion tamer's plastic left skeleton arm	0		Experience (familiar): +2, Last Available: "2025-12"
 12062	ruddy plastic left skeleton leg	0		Maximum HP Percent: +40, Last Available: "2025-12"
@@ -11869,7 +11869,7 @@
 12079	cool devilbone corset	0		Moxie: +5, Last Available: "2026-12"
 12080	zippy resourceful devilbone flute	0		Maximum MP: +50, Initiative: +20, Last Available: "2026-12"
 12081	ghostly devilbone rosary of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2026-12"
-12082	mixed wobbly jittery blurry devilbone chunks	1		Last Available: "2026-12"
+12082	mixed jittery blurry wobbly devilbone chunks	1		Last Available: "2026-12"
 12083	dry dry Gehenna tattoo	0		Effect: "Shortened", Effect Duration: 11
 12116	pulsating burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	energized activated upside-down boiling synovial fluid	0		Effect: "Cosmic Flavor", Effect Duration: 48, Last Available: "2025-12"
 12132	squat smoldering vertebra of the scaredy-cat of extreme caution	0		Monster Level: -40, Item Drop: +5, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	wobbly smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	healthy strapping hot boning knife of incineration	0		Muscle: +5, Maximum HP Percent: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2025-12"
@@ -11909,7 +11909,7 @@
 12151	ruddy Sinatra's scorched skeleton mask	0		Experience (Moxie): +5, Maximum HP Percent: +40, Last Available: "2025-12"
 12152	lightning-fast educational scorched skeleton shirt	0		Experience: +1, Initiative: +40, Last Available: "2025-12"
 12153	bouncing ribald sinister scorched skeleton pants	0		Spell Damage: +10, Sleaze Damage: +10, Last Available: "2025-12"
-12154	pulsating huge messenger parrot egg	0		Last Available: "2025-12"
+12154	huge pulsating messenger parrot egg	0		Last Available: "2025-12"
 12155	buryable chest	0		Last Available: "2025-12"
 12156	Shanty: Let's Beat Up This Drunken Sailor	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
 12157	upside-down Shanty: Let's Beat Up This Drunken Sailor (used)	0		Skill: "Let's Beat Up This Drunken Sailor", Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	manspreader's strapping vermiculite shield	0		Muscle: +5, Monster Level: +10, Damage Reduction: 9, Last Available: "2025-12"
 12169	fuchsia ship's lantern of the pedagogue	0		Experience: +3, Last Available: "2025-12"
 12170	quilted supercool heat-resistant harpoon pistol	0		Moxie Percent: +20, Damage Absorption: +40, Last Available: "2025-12"
-12171	spoiled super-sized traditional gingerloaf	5	crappy	Last Available: "2025-12"
+12171	super-sized spoiled traditional gingerloaf	5	crappy	Last Available: "2025-12"
 12172	mediocre Scotch and eggnog	3	decent	Last Available: "2025-12"
 12173	alkaline counterskeleton elixir	0		Effect: "Block-Rockin' Beet", Effect Duration: 35, Last Available: "2025-12"
 12174	acceptable &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
@@ -11936,10 +11936,10 @@
 12178	colloidal gummi fingerbone	0		Effect: "Amplified Fabulousness", Effect Duration: 15
 12179	pulsating bouncing grievous glimmering crystal of horror	0		Weapon Damage Percent: +50, Spooky Spell Damage: +25, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
-12184	bouncing lime green bouncing Archaeologist's Spade	0		Last Available: "2026-03"
+12184	lime green bouncing bouncing Archaeologist's Spade	0		Last Available: "2026-03"
 12185	pulsating boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
 12186	dinosaur bone fragment	0		Last Available: "2026-03"
 12187	Pork Elf pottery shard	0		Last Available: "2026-03"
@@ -11959,12 +11959,12 @@
 12201	shaking Samson's dinosaur bone club	0		Experience (Muscle): +5, Last Available: "2026-03"
 12202	spinning baleful dinosaur skull helmet of James Dean	0		Experience (Moxie): +3, Spell Damage: +25, Last Available: "2026-03"
 12203	tumbling smelly dangerous experienced dinosaur bone corset	0		Experience: +2, Weapon Damage: +10, Stench Spell Damage: +10, Last Available: "2026-03"
-12204	artisanal weak Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
+12204	weak artisanal Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
 12205	narrow Pork Elf neti pot	0		Last Available: "2026-03"
 12206	Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
 12208	Pork Elf toilet	0		Last Available: "2026-03"
-12209	decent bite-sized enchanted wobbly rat pizza	1	good	Effect: "Blessing of Charcoatl", Effect Duration: 30, Last Available: "2026-03"
+12209	bite-sized enchanted decent wobbly rat pizza	1	good	Effect: "Blessing of Charcoatl", Effect Duration: 30, Last Available: "2026-03"
 12210	Fleek&trade; mascara	0		Last Available: "2026-03"
 12211	zippy strapping hoverboard of Gandalf	0		Muscle: +5, Spell Critical Percent: +20, Initiative: +20, Single Equip, Last Available: "2026-03"
 12212	aromatic left shark fin of horror of the early riser	0		Spooky Spell Damage: +25, Stench Resistance: +1, Adventures: +7, Last Available: "2026-03"
@@ -11978,21 +11978,21 @@
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	stale can of tuna	3	decent	
-12227	tiny spoiled alien salad	1	crappy	
+12227	spoiled tiny alien salad	1	crappy	
 12228	stale massive ratbatatouille	6	decent	
 12229	bland gray onigiri	4	decent	
 12230	miniature spoiled bouncing crudit&eacute;s	2	crappy	
 12231	moldy sauced mutton	3	crappy	
 12232	yummy diet hot honey ant	1	awesome	
-12233	gigantic flavorless tomb aspic	7	decent	
-12234	diet decent later tots	1	good	
+12233	flavorless gigantic tomb aspic	7	decent	
+12234	decent diet later tots	1	good	
 12235	huge decent Frutti di Scatoletta	9	good	Last Available: "2026-05"
 12236	normal gray squat Pesto alla Marziano	4	good	Last Available: "2026-05"
 12237	stale Arrattabbattabiata	3	decent	Last Available: "2026-05"
-12238	snack-sized adequate Orzo di Riso	2	good	Last Available: "2026-05"
-12239	adequate snack-sized Pasta Grimavera	2	good	Last Available: "2026-05"
-12240	miniature stale Linguini Ubriacapa	2	decent	Last Available: "2026-05"
-12241	decent massive Formica e Pepe	8	good	Last Available: "2026-05"
+12238	adequate snack-sized Orzo di Riso	2	good	Last Available: "2026-05"
+12239	snack-sized adequate Pasta Grimavera	2	good	Last Available: "2026-05"
+12240	stale miniature Linguini Ubriacapa	2	decent	Last Available: "2026-05"
+12241	massive decent Formica e Pepe	8	good	Last Available: "2026-05"
 12242	yummy red upside-down Tubetto Gelatto	3	awesome	Last Available: "2026-05"
 12243	toothsome Gnocci Domani	4	awesome	Last Available: "2026-05"
 12244	spinning Thwaitgold wallet moth statuette	0		
@@ -12017,11 +12017,11 @@
 12267	flimsy plastic breastplate of bravery	0		Spooky Resistance: +5
 12268	tumbling scorching flimsy plastic shield	0		Hot Damage: +25, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	Sherlock's careful Portable Laughing Stock of Gandalf	0		Spell Critical Percent: +20, Monster Level: -10, Item Drop: +25, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	Sherlock's careful Portable Laughing Stock of Gandalf	0		Spell Critical Percent: +20, Monster Level: -10, Item Drop: +25, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	skewed horrifying frosty Staff of Anachronistic Churning of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +10, Spooky Damage: +25
-12272	stale tiny classic banana	1	decent	Last Available: "2026-07"
-12273	thick bland mirror watermelon	5	decent	Last Available: "2026-07"
-12274	decent immense quince	9	good	Last Available: "2026-07"
+12272	tiny stale classic banana	1	decent	Last Available: "2026-07"
+12273	bland thick mirror watermelon	5	decent	Last Available: "2026-07"
+12274	immense decent quince	9	good	Last Available: "2026-07"
 12275	Interesting Coin	0		Last Available: "2026-08"
 12276	gray Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	delicious purple classic banana pie	4	awesome	Last Available: "2026-07"
@@ -12029,7 +12029,7 @@
 12279	pressed ionized banana quintessence	0		Effect: "Horrid, Torrid", Effect Duration: 64, Last Available: "2026-07"
 12280	bad blue shaking Aesop Daiquiri	3	decent	Last Available: "2026-07"
 12281	lousy Monkey Congress	4	decent	Last Available: "2026-07"
-12282	normal enchanted jumbo watermelon pie	5	good	Effect: "Pemmican't", Effect Duration: 15, Last Available: "2026-07"
+12282	enchanted normal jumbo watermelon pie	5	good	Effect: "Pemmican't", Effect Duration: 15, Last Available: "2026-07"
 12283	corrupted concentrated watermelon juice	0		Effect: "Greasy Flavor", Effect Duration: 61, Last Available: "2026-07"
 12284	frozen modified jittery Aqua Citrulanatae	0		Effect: "Bananas!", Effect Duration: 24, Last Available: "2026-07"
 12285	tolerable Melonegroni	3	good	Last Available: "2026-07"
@@ -12037,9 +12037,9 @@
 12287	normal quince pie	3	good	Last Available: "2026-07"
 12288	electrified ghostly quince quaff	0		Effect: "Ginger Snapped", Effect Duration: 29, Last Available: "2026-07"
 12289	galvanized oxidized dry narrow Quickquince	0		Effect: "Block-Rockin' Beet", Effect Duration: 23, Last Available: "2026-07"
-12290	boozy drinkable Quiskey Sour	5	good	Last Available: "2026-07"
+12290	drinkable boozy Quiskey Sour	5	good	Last Available: "2026-07"
 12291	aged Quincea&ntilde;era Cooler	3	awesome	Last Available: "2026-07"
-12292	triple-distilled bad Roth IPA	10	decent	Last Available: "2026-08"
+12292	bad triple-distilled Roth IPA	10	decent	Last Available: "2026-08"
 12293	Herculean underdraft protection of terror	0		Experience (Muscle): +1, Spooky Spell Damage: +10, Last Available: "2026-08"
 12294	blurry solvent	0		Last Available: "2026-08"
 12295	spoiled soybean futures	4	crappy	Last Available: "2026-08"
@@ -12052,10 +12052,10 @@
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	shellacked studded 401k ring	0		Damage Absorption: +80, Damage Reduction: 7, Last Available: "2026-08"
 12304	yellow balance sheet	0		Last Available: "2026-08"
-12305	alkaline blue huge invisible hand	0		Effect: "Strong Grip", Effect Duration: 53, Last Available: "2026-08"
+12305	alkaline huge blue invisible hand	0		Effect: "Strong Grip", Effect Duration: 53, Last Available: "2026-08"
 12306	dry extra-irradiated circle of overdraft protection scroll	0		Effect: "Riboflavin'", Effect Duration: 39, Last Available: "2026-08"
 12307	unsweetened mint	0		Effect: "Heart of Yellow", Effect Duration: 11, Last Available: "2026-08"
-12308	fuchsia twirling savings bondo	0		Last Available: "2026-08"
+12308	twirling fuchsia savings bondo	0		Last Available: "2026-08"
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	compressed toxic asset	1		Last Available: "2026-08"
 12311	denatured fuchsia narrow intangible asset	1		Effect: "X-Ray Vision", Effect Duration: 20, Last Available: "2026-08"

--- a/data/TCRS/TCRS_Turtle_Tamer_Packrat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Packrat_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	practically non-alcoholic artisanal shaking Petite Porter	1	EPIC	
+-1	artisanal practically non-alcoholic shaking Petite Porter	1	EPIC	
 -2	drinkable Scrawny Stout	3	good	
--3	tolerable practically non-alcoholic Infinitesimal IPA	1	good	
+-3	practically non-alcoholic tolerable Infinitesimal IPA	1	good	
 -4	tolerable practically non-alcoholic eggnogtini	1	good	
--5	aged watered-down candycaine	2	awesome	
+-5	watered-down aged candycaine	2	awesome	
 -6	artisanal weak braincracker sweet	2	EPIC	
 -16	artisanal weak shaking fermented honey	2	EPIC	
--17	perfectly mixed triple-distilled moons-shine	6	EPIC	
+-17	triple-distilled perfectly mixed moons-shine	6	EPIC	
 -18	artisanal purple gin	3	EPIC	
--19	special bad mirror ecto-nog	4	decent	
+-19	bad special mirror ecto-nog	4	decent	
 -20	lousy practically non-alcoholic hot toady	1	decent	
 -21	perfectly mixed hot choculate	3	EPIC	
 -49	perfectly mixed Cyder	4	EPIC	
 -50	drinkable upside-down Oil Nog	3	good	
--51	high-proof artisanal Hi-Octane Peppermint Jet Fuel	10	EPIC	
--58	watered-down mediocre Grimacider	2	decent	
+-51	artisanal high-proof Hi-Octane Peppermint Jet Fuel	10	EPIC	
+-58	mediocre watered-down Grimacider	2	decent	
 -59	aged Isotope Nog	4	awesome	
 -60	smooth skewed Mutagin 'n' Tonic	4	awesome	
 -70	watered-down smooth Gin and Herring	2	awesome	
 -71	bad practically non-alcoholic Black and Tan and Red All Over	1	decent	
 -72	acceptable boozy upside-down Antarctic Ice Tea	5	good	
--76	watered-down artisanal CRIMBCO Ribbon Candy Schnapps	2	EPIC	
+-76	artisanal watered-down CRIMBCO Ribbon Candy Schnapps	2	EPIC	
 -77	tolerable practically non-alcoholic CRIMBCO Egg Substitute Nog Substitute	1	good	
 -78	bad CRIMBCO Extreme Braincracker Sour	3	decent	
 -82	weak acceptable ghostly Horseradish-infused Vodka	2	good	
 -83	acceptable red twirling Jerkitini	3	good	
 -84	hand-crafted olive Desert Island Iced Tea	4	EPIC	
--88	distilled tolerable shaking Crimbo Saketini	5	good	
+-88	tolerable distilled shaking Crimbo Saketini	5	good	
 -89	mediocre Crimboku Drop	3	decent	
--90	practically non-alcoholic hand-crafted bouncing Flaming Crimbo Log	1	EPIC	
+-90	hand-crafted practically non-alcoholic bouncing Flaming Crimbo Log	1	EPIC	
 -107	perfectly mixed Fortified Eggnog Slurry	4	EPIC	
 -108	drinkable weak Hot Buttered Rum	2	good	
 -109	irresponsibly strong mediocre Spicy Hot Chocolate	6	decent	

--- a/data/TCRS/TCRS_Turtle_Tamer_Packrat_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Packrat_cafe_food.txt
@@ -1,15 +1,15 @@
--1	tiny tasty shaking Peche a la Frog	1	awesome	
+-1	tasty tiny shaking Peche a la Frog	1	awesome	
 -2	stale As Jus Gezund Heit	3	decent	
 -3	bite-sized flavorless Bouillabaise Coucher Avec Moi	1	decent	
 -7	rotten snack-sized wobbly gumdrop chow mein	2	crappy	
--8	normal miniature candy cane pizza	2	good	
+-8	miniature normal candy cane pizza	2	good	
 -9	massive bland huge spinning gingerbread stir-fry	7	decent	
 -10	bland wobbly twigs and gravel	4	decent	
--11	enchanted adequate shoots and leaves	4	good	
--12	half-sized adequate fuchsia wobbly bowl of unidentifiable goo	2	good	
+-11	adequate enchanted shoots and leaves	4	good	
+-12	adequate half-sized fuchsia wobbly bowl of unidentifiable goo	2	good	
 -13	stale gingerbread massacre	3	decent	
 -14	adequate massive It Came From Beyond Dessert	7	good	
--15	decent jumbo wobbly vampire cake	5	good	
+-15	jumbo decent wobbly vampire cake	5	good	
 -52	miniature moldy Soylent Red and Green	2	crappy	
 -53	delicious Disc-Shaped Nutrition Unit	4	awesome	
 -54	rotten miniature pulsating Gingerborg Hive	2	crappy	
@@ -19,27 +19,27 @@
 -67	bland tumbling Caviar Carbonara	3	decent	
 -68	rotten Halibut Alfredo	3	crappy	
 -69	toothsome Red Herring Velvet Cake	4	awesome	
--73	miniature bland CRIMBCO Reconstituted Gruel	2	decent	
--74	rotten big huge New and Improved CRIMBCO Reconstituted Gruel	5	crappy	
+-73	bland miniature CRIMBCO Reconstituted Gruel	2	decent	
+-74	big rotten huge New and Improved CRIMBCO Reconstituted Gruel	5	crappy	
 -75	moldy huge CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	6	crappy	
 -79	tasty mirror Brussels Sprout Stir-Fry	4	awesome	
--80	jumbo rotten Carrot, Cabbage, and Kale Pizza	5	crappy	
--81	rotten jumbo Turnip and Rutabaga Pie	5	crappy	
--85	diet rotten red Rainbow Spider Fun Roll	1	crappy	
+-80	rotten jumbo Carrot, Cabbage, and Kale Pizza	5	crappy	
+-81	jumbo rotten Turnip and Rutabaga Pie	5	crappy	
+-85	rotten diet red Rainbow Spider Fun Roll	1	crappy	
 -86	yummy Vegas Volcano Lava Roll	4	awesome	
--87	big tasty Crazy Dragon Shogun Buddha Roll	5	awesome	
+-87	tasty big Crazy Dragon Shogun Buddha Roll	5	awesome	
 -92	stale basic hot dog	4	decent	
 -93	bland savage macho dog	3	decent	
 -94	bland thick one with everything	5	decent	
--95	moldy fancy huge jittery sly dog	3	crappy	
+-95	fancy moldy huge jittery sly dog	3	crappy	
 -96	bland shaking devil dog	3	decent	
--97	decent enchanted chilly dog	3	good	
+-97	enchanted decent chilly dog	3	good	
 -98	bland small ghost dog	2	decent	
 -99	spoiled junkyard dog	3	crappy	
 -100	adequate wet dog	4	good	
--101	flavorless low-calorie shaking sleeping dog	1	decent	
+-101	low-calorie flavorless shaking sleeping dog	1	decent	
 -102	jumbo rotten blurry optimal dog	5	crappy	
 -103	adequate video games hot dog	3	good	
--104	small bland maroon Peppermint Nutrition Block	2	decent	
+-104	bland small maroon Peppermint Nutrition Block	2	decent	
 -105	normal tiny ghostly Gingerbread Nutrition Block	1	good	
--106	adequate special Cinnamon Nutrition Block	3	good	
+-106	special adequate Cinnamon Nutrition Block	3	good	

--- a/data/TCRS/TCRS_Turtle_Tamer_Platypus.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Platypus.txt
@@ -20,7 +20,7 @@
 21	yellow sweet ninja sword	0		
 22	pulsating studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
-24	huge jittery ten-leaf clover	0		
+24	jittery huge ten-leaf clover	0		
 25	meat paste	0		
 26	Dolphin King's map	0		
 27	spider web	0		
@@ -101,7 +101,7 @@
 102	spinning shrunken head	0		
 103	yellow energetic staff of the wise owl	0		Mysticality: +20, Maximum MP Percent: +20
 104	fuchsia scarecrow	0		
-105	massive decent bowl of charms	7	good	
+105	decent massive bowl of charms	7	good	
 106	green ketchup	1	good	
 107	catsup	1	EPIC	
 108	bouncing stick	0		
@@ -131,7 +131,7 @@
 132	upside-down Meat maid body	0		
 133	Certificate of Participation	0		
 134	pulsating bitchin' meatcar	0		
-135	spinning maroon sweet rims	0		
+135	maroon spinning sweet rims	0		
 136	tires	0		
 137	dope wheels	0		
 138	ice-cold six-pack	0		
@@ -170,8 +170,8 @@
 171	rotten bouncing lihc eye pie	3	crappy	
 172	ghostly gnoll lips	0		
 173	taco shell	0		
-174	spinning upside-down Gnollish casserole dish	0		
-175	bland thick cyan jittery uncooked chorizo	5	decent	
+174	upside-down spinning Gnollish casserole dish	0		
+175	thick bland jittery cyan uncooked chorizo	5	decent	
 176	disembodied brain	0		
 177	mirror brainy skull	0		
 178	twirling detective skull	0		
@@ -181,7 +181,7 @@
 182	batgut	0		
 183	maroon bouncing bat wing	0		
 184	briefcase	0		
-185	wobbly squat fat stacks of cash	0		
+185	squat wobbly fat stacks of cash	0		
 186	bean	0		
 187	loose teeth	0		
 188	bat guano	0		
@@ -193,16 +193,16 @@
 195	inspector's eXtreme nose ring	0		Item Drop: +15
 196	green disassembled clover	0		
 197	rat whisker	0		
-198	jittery spinning rat appendix	0		
+198	spinning jittery rat appendix	0		
 199	huge ring of the scaredy-cat	0		Monster Level: -15
 200	half-sized normal rat appendix kabob	2	good	
 201	stale bat wing kabob	3	decent	
 202	fancy moldy carob chunks	4	crappy	Effect: "Pasta Oneness", Effect Duration: 10
 203	twirling herbs	0		
-204	delicious gigantic carob chunk cookies	7	awesome	
+204	gigantic delicious carob chunk cookies	7	awesome	
 205	secret blend of herbs and spices	0		
 206	piercing post	0		
-207	ghostly narrow hippy herbal tea	1	crappy	
+207	narrow ghostly hippy herbal tea	1	crappy	
 208	patchouli incense stick	0		
 209	wad of tofu	0		
 210	shaking huge Feng Shui for Big Dumb Idiots	0		
@@ -239,7 +239,7 @@
 241	Orcish frat-paddle of extreme caution	0		Monster Level: -25
 242	decent	3	good	
 243	rotten blinking grapefruit	4	crappy	
-244	small flavorless shaking bouncing grapes	2	decent	
+244	flavorless small shaking bouncing grapes	2	decent	
 245	normal small olive	2	good	
 246	rotten huge tomato	3	crappy	
 247	blinking fermenting powder	0		
@@ -248,17 +248,17 @@
 250	tolerable yellow screwdriver	3	good	
 251	drinkable strong martini	5	good	
 252	hand-crafted bloody beer	3	EPIC	
-253	practically non-alcoholic bad shot of schnapps	1	decent	
+253	bad practically non-alcoholic shot of schnapps	1	decent	
 254	bad skewed tumbling shot of grapefruit schnapps	3	decent	
 255	delicious fine wine	4	awesome	
-256	mediocre fancy practically non-alcoholic shot of tomato schnapps	1	decent	Effect: "Abyssal Tears", Effect Duration: 10
+256	fancy mediocre practically non-alcoholic shot of tomato schnapps	1	decent	Effect: "Abyssal Tears", Effect Duration: 10
 257	drinkable extra-spicy bloody mary	4	good	
 258	dense meat stack	0		
 259	skewed snake skin	0		
-260	normal enchanted White Citadel fries	3	good	Effect: "Vanity Rage", Effect Duration: 15
+260	enchanted normal White Citadel fries	3	good	Effect: "Vanity Rage", Effect Duration: 15
 261	stale White Citadel burger	4	decent	
 262	stale piece of wedding cake	3	decent	
-263	special bland huge chocolate chips	7	decent	Effect: "Wit Tea", Effect Duration: 50
+263	special huge bland chocolate chips	7	decent	Effect: "Wit Tea", Effect Duration: 50
 264	adequate huge chocolate chip cookies	6	good	
 265	wicked satin pants	0		Spell Damage: +5, Familiar Effect: "atk, 2xPotato, cap 10"
 266	hand-crafted practically non-alcoholic lightning	1	super EPIC	
@@ -268,11 +268,11 @@
 270	picket fence	0		
 271	pickled blinking barbell	1		Effect: "You're Rubber", Effect Duration: 20
 272	boiled cyan concentrated magicalness pill	1		
-273	dried skewed tumbling moxie weed	1		
+273	dried tumbling skewed moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	leprechaun hatchling	0		
-277	vaporized blurry squat extra-strength strongness elixir	1		
+277	vaporized squat blurry extra-strength strongness elixir	1		
 278	dehydrated purple shaking jug-o-magicalness	1		Effect: "In Tuna", Effect Duration: 10
 279	dried spinning suntan lotion of moxiousness	1		
 280	Pick-O-Matic lockpicks	0		
@@ -295,7 +295,7 @@
 297	ionized adjusted tamarind-flavored chewing gum	0		Effect: "items.enh", Effect Duration: 61
 298	pickled adjusted lime-and-chile-flavored chewing gum	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 40
 299	frozen pickle-flavored chewing gum	0		Effect: "On a Roll", Effect Duration: 65
-300	polymerized moist lime green mirror jaba&ntilde;ero-flavored chewing gum	0		Effect: "Phairly Pheromonal", Effect Duration: 43
+300	polymerized moist mirror lime green jaba&ntilde;ero-flavored chewing gum	0		Effect: "Phairly Pheromonal", Effect Duration: 43
 301	flat dough	0		
 302	decent spinning Knob sausage	3	good	
 303	adequate Knob mushroom	3	good	
@@ -309,25 +309,25 @@
 311	twirling hill of beans	0		
 312	upside-down clever Knob Goblin visor	0		Maximum MP: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	Crown of the Goblin King of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	moldy half-sized upside-down bean burrito	2	crappy	
-315	normal enchanted bean burrito	3	good	Effect: "Dragged Through the Coals", Effect Duration: 30
-316	thick bland insanely bean burrito	5	decent	
+314	half-sized moldy upside-down bean burrito	2	crappy	
+315	enchanted normal bean burrito	3	good	Effect: "Dragged Through the Coals", Effect Duration: 30
+316	bland thick insanely bean burrito	5	decent	
 317	thick moldy bean burrito	5	crappy	
 318	bland bean burrito	3	decent	
 319	adequate fancy insanely bean burrito	3	good	Effect: "Bilious Brawn", Effect Duration: 15
-320	decent special skewed bat haggis	3	good	Effect: "It Didn't Kill You", Effect Duration: 45
+320	special decent skewed bat haggis	3	good	Effect: "It Didn't Kill You", Effect Duration: 45
 321	normal wobbly menudo	4	good	
 322	spoiled goat cheese	3	crappy	
 323	normal plain pizza	3	good	
 324	toothsome small sausage pizza	2	awesome	
-325	miniature decent mirror goat cheese pizza	2	good	
+325	decent miniature mirror goat cheese pizza	2	good	
 326	flavorless bite-sized mushroom pizza	1	decent	
 327	shaking goat	0		
 328	drinkable bottle of whiskey	3	good	
 329	coward's goat beard	0		Monster Level: -20, Familiar Effect: "atk, 1xPotato, cap 15"
 330	glass of goat's milk	1	crappy	
-331	aged irresponsibly strong fancy green Canadian	10	awesome	Effect: "Innately Truthy", Effect Duration: 20
-332	moldy massive shaking lemon	10	crappy	
+331	fancy irresponsibly strong aged green Canadian	10	awesome	Effect: "Innately Truthy", Effect Duration: 20
+332	massive moldy shaking lemon	10	crappy	
 333	rotten maroon lime	3	crappy	
 334	jittery sabre teeth of the cougar	0		Moxie: +20
 335	sabre-toothed lime cub	0		
@@ -340,7 +340,7 @@
 342	ghostly Knob Goblin stink bomb	0		
 343	altered quantum Knob Goblin sharpening spray	0		Effect: "Bureaucratized", Effect Duration: 18
 344	Knob Goblin seltzer	0		
-345	bouncing gray Knob Goblin superseltzer	0		
+345	gray bouncing Knob Goblin superseltzer	0		
 346	upside-down scrumptious reagent	0		
 347	blinking Dyspepsi-Cola	0		
 348	ninja mask of the early riser	0		Adventures: +7, Familiar Effect: "cold atk, 1xBarrr, cap 20"
@@ -367,7 +367,7 @@
 369	asbestos sword hilt	0		
 370	asbestos stick	0		
 371	asbestos crossbow string	0		
-372	twirling upside-down chrome sword hilt	0		
+372	upside-down twirling chrome sword hilt	0		
 373	chrome stick	0		
 374	teal chrome crossbow string	0		
 375	ghostly linoleum meat stack	0		
@@ -414,11 +414,11 @@
 416	Temple Grandin's safarrri hat	0		Familiar Weight: +7, Familiar Effect: "2xVolley, cap 22"
 417	frozen alkaline non-enhanced henna tattoo	0		Effect: "Wax On Your Shoes", Effect Duration: 54
 418	quantum pulsating Ferrigno's Elixir of Power	0		Effect: "Spookyravin'", Effect Duration: 31
-419	quadruple-galvanized adjusted huge ghostly serum of sarcasm	0		Effect: "Thunderheart", Effect Duration: 54
+419	quadruple-galvanized adjusted ghostly huge serum of sarcasm	0		Effect: "Thunderheart", Effect Duration: 54
 420	corrupted jittery tomato juice of powerful power	0		Effect: "Serendipi Tea", Effect Duration: 57
 421	double-ionized modified philter of phorce	0		Effect: "Bootyliciousness", Effect Duration: 55
 422	electrified altered potion of potency	0		Effect: "New Zeal", Effect Duration: 46
-423	quadruple-flattened activated squat tumbling cordial of concentration	0		Effect: "Mint-Condition Breath", Effect Duration: 28
+423	quadruple-flattened activated tumbling squat cordial of concentration	0		Effect: "Mint-Condition Breath", Effect Duration: 28
 424	irradiated modified ointment of the occult	0		Effect: "Super-Mega-Charged", Effect Duration: 31
 425	triple-pickled wobbly oil of expertise	0		Effect: "Insatiable Hunger", Effect Duration: 22
 426	quantum electrified non-irradiated potion of temporary gr8ness	0		Effect: "Phorcefullness", Effect Duration: 18
@@ -450,10 +450,10 @@
 452	pulsating disease	0		
 453	sober pill	0		
 454	screwdriver	0		
-455	tasty half-sized jumbo olive	2	awesome	
-456	weak bad enchanted skewed dry martini	2	decent	Effect: "Omphalotus Omnipresence", Effect Duration: 25
+455	half-sized tasty jumbo olive	2	awesome	
+456	enchanted weak bad skewed dry martini	2	decent	Effect: "Omphalotus Omnipresence", Effect Duration: 25
 457	ye olde golde frontes of the bloodbag	0		Maximum HP: +100, Class: "Disco Bandit", Single Equip
-458	upside-down wobbly continuum transfunctioner	0		
+458	wobbly upside-down continuum transfunctioner	0		
 459	pixel	0		
 460	pixel	0		
 461	twirling pixel	0		
@@ -493,10 +493,10 @@
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	special spoiled half-sized skewed papaya	2	crappy	Effect: "Bored Stiff", Effect Duration: 15
+498	spoiled half-sized special skewed papaya	2	crappy	Effect: "Bored Stiff", Effect Duration: 15
 499	ghostly Sherlock's denim axe of the early riser	0		Item Drop: +25, Adventures: +7
 500	bouncing Elf Farm Raffle ticket	0		
-501	snack-sized flavorless Elfin shortbread	2	decent	
+501	flavorless snack-sized Elfin shortbread	2	decent	
 502	shaking pagoda plans	0		
 503	normal super-sized upside-down skewered cat appendix	5	good	
 504	purple evil arches	0		
@@ -509,8 +509,8 @@
 511	twirling Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	yummy gigantic twirling Boris's key lime pie	10	awesome	
-514	gigantic stale skewed Jarlsberg's key lime pie	9	decent	
-515	spoiled small fancy squat bouncing Sneaky Pete's key lime pie	2	crappy	Effect: "Third Based", Effect Duration: 10
+514	stale gigantic skewed Jarlsberg's key lime pie	9	decent	
+515	small fancy spoiled squat bouncing Sneaky Pete's key lime pie	2	crappy	Effect: "Third Based", Effect Duration: 10
 516	blinking Hey Deze map	0		
 517	shaking bejeweled accordion strap of the brute	0		Muscle Percent: +30, Class: "Accordion Thief"
 518	pulsating mystery juice	0		
@@ -540,7 +540,7 @@
 542	teal therapeutic 1337 7r0uZ0RZ of horror	0		Spooky Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "2xPotato, cap 27"
 543	immense normal Trollhouse cookies	8	good	
 544	twirling squat Van der Graaf talons of extreme caution	0		Monster Level: -25, MP Regen Min: 5, MP Regen Max: 7
-545	moldy jumbo Spam Witch sammich	5	crappy	
+545	jumbo moldy Spam Witch sammich	5	crappy	
 546	meat vortex	0		
 547	334 scroll	0		
 548	green 668 scroll	0		
@@ -553,7 +553,7 @@
 555	frightening drywall axe of mayonnaise	0		Spooky Damage: +5, Sleaze Spell Damage: +50
 556	Oprah's Pine-Fresh air freshener	0		Maximum MP Percent: +50
 557	tolerable whiskey and cola	3	good	
-558	toothsome super-sized purple papaya taco	5	awesome	
+558	super-sized toothsome purple papaya taco	5	awesome	
 559	razor-sharp can lid	0		
 560	normal miniature red stalk of asparagus	2	good	
 561	twirling pregnant mushroom	0		
@@ -567,14 +567,14 @@
 569	small stale Lord of the Flies-sized fries	2	decent	
 570	stale Chicken Sandwich	4	decent	
 571	Jumbo Dr. Lucifer	1	EPIC	
-572	fancy adequate Children's Meal of the Damned	3	good	Effect: "Super Skill", Effect Duration: 5
+572	adequate fancy Children's Meal of the Damned	3	good	Effect: "Super Skill", Effect Duration: 5
 573	bland bouncing noodles	4	decent	
-574	spoiled jumbo special noodles	5	crappy	Effect: "The Style... of the Future", Effect Duration: 10
+574	special jumbo spoiled noodles	5	crappy	Effect: "The Style... of the Future", Effect Duration: 10
 575	stale painful penne pasta	3	decent	
 576	super-sized moldy ravioli della hippy	5	crappy	
-577	small stale huge pr0n m4nic0tti	2	decent	
+577	stale small huge pr0n m4nic0tti	2	decent	
 578	spoiled Hell ramen	4	crappy	
-579	low-calorie decent narrow boring spaghetti	1	good	
+579	decent low-calorie narrow boring spaghetti	1	good	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
@@ -584,8 +584,8 @@
 586	pulsating supercharged smooth ridiculously huge sword	0		Moxie: +15, Maximum MP Percent: +30
 587	tarnished vacuum-sealed ghostly super-spiky hair gel	0		Effect: "Stimulated Body", Effect Duration: 45
 588	soft echo eyedrop antidote	0		
-589	stale miniature cocoa eggshell fragment	2	decent	
-590	rotten small cocoa eggshell fragment	2	crappy	
+589	miniature stale cocoa eggshell fragment	2	decent	
+590	small rotten cocoa eggshell fragment	2	crappy	
 591	cocoa egg	0		
 592	house	0		
 593	phonics down	0		
@@ -611,7 +611,7 @@
 613	plot hole	0		
 614	denatured dry ionized green probability potion	0		Effect: "Sugary Tongue", Effect Duration: 15
 615	pulsating chaos butterfly	0		
-616	yellow spinning furry fur	0		
+616	spinning yellow furry fur	0		
 617	ionized irradiated pulsating Angry Farmer candy	0		Effect: "Sweetened and Fattened", Effect Duration: 54
 618	altered Mick's IcyVapoHotness Rub	0		Effect: "Pill Power", Effect Duration: 68
 619	Oprah's needle	0		Maximum MP Percent: +50
@@ -638,14 +638,14 @@
 640	Ent cider	1	good	
 641	bland super-sized toast	5	decent	
 642	skeleton key	0		
-643	narrow skewed skeleton key ring	0		
+643	skewed narrow skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	small spoiled fruitcake	2	crappy	
+646	spoiled small fruitcake	2	crappy	
 647	present	0		Last Available: "2004-11"
 648	ghostly dangerous Crimbo sword	0		Weapon Damage: +10, Last Available: "2004-10"
-649	brainy Crimbo hat	0		Mysticality: +5, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	Crimbo pants of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	brainy Crimbo hat	0		Mysticality: +5, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	Crimbo pants of dire peril	0		Weapon Damage: +20, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	yellow thinker's exclusive ultra-rare item	0		Mysticality: +10
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,20 +664,20 @@
 666	horrifying hale wholesome steaming evil	0		Maximum HP Percent: +10, Maximum HP: +20, Spooky Damage: +25
 667	pulsating castle map	0		
 668	crafty spiked femur	0		Maximum MP: +10
-669	moldy enchanted skewed spinning ghuol guolash	3	crappy	Effect: "Cockroach Scurry", Effect Duration: 15
+669	enchanted moldy spinning skewed ghuol guolash	3	crappy	Effect: "Cockroach Scurry", Effect Duration: 15
 670	quilted lihc face	0		Damage Absorption: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	banded Fonzie's grave robbing shovel	0		Experience (Moxie): +1, Damage Absorption: +100
 672	spoiled cranberries	3	crappy	
 673	acceptable vodka and cranberry	4	good	
 674	lousy weak tumbling whiskey	2	decent	
 675	manspreader's skull of the Bonerdagon	0		Monster Level: +10
-676	wobbly spinning dragonbone belt buckle	0		
+676	spinning wobbly dragonbone belt buckle	0		
 677	purple cool badass belt	0		Moxie: +5
 678	chest of the Bonerdagon	0		
 679	bad roll in the hay	3	decent	
 680	bad pulsating slap and tickle	4	decent	
 681	artisanal slip 'n' slide	4	EPIC	
-682	mediocre weak ghostly a sump'm sump'm	2	decent	
+682	weak mediocre ghostly a sump'm sump'm	2	decent	
 683	perfectly mixed horizontal tango	3	EPIC	
 684	acceptable jittery pink pony	3	good	
 685	lime green foul-smelling Samson's wizardly Mr. Shirt	0		Mysticality: +25, Experience (Muscle): +5, Stench Damage: +10
@@ -686,8 +686,8 @@
 688	wobbly wicked pixel hat	0		Spell Damage: +5, Familiar Effect: "atk, 2xVolley, cap 12"
 689	Temple Grandin's pixel pants	0		Familiar Weight: +7, Familiar Effect: "atk, 4xPotato, cap 12"
 690	pixel sword of extreme caution	0		Monster Level: -25
-691	olive pulsating digital key	0		
-692	ghostly maroon Ascension Souvenir T-Shirt	0		
+691	pulsating olive digital key	0		
+692	maroon ghostly Ascension Souvenir T-Shirt	0		
 693	stanky harem girl t-shirt	0		Stench Spell Damage: +25
 694	inspector's Knob Goblin elite shirt	0		Item Drop: +15
 696	mirror nippy frilly shirt	0		Cold Damage: +10
@@ -700,7 +700,7 @@
 703	Samson's goth kid t-shirt	0		Experience (Muscle): +5
 704	hamethyst	0		
 705	blurry baconstone	0		
-706	bouncing tumbling porquoise	0		
+706	tumbling bouncing porquoise	0		
 707	twirling pork elf goodies sack	0		
 708	ring setting	0		
 709	jewelry-making pliers	0		
@@ -717,7 +717,7 @@
 721	blurry mansplainer's Samson's porquoise bracelet	0		Experience (Muscle): +5, Monster Level: +15
 722	sinister dance instructor's experienced porquoise ring	0		Experience: +2, Experience Percent (Moxie): +10, Spell Damage: +10, Single Equip
 723	massive yummy Knoll mushroom	6	awesome	
-724	adequate gigantic mushroom	6	good	
+724	gigantic adequate mushroom	6	good	
 725	one million meat pancakes	0		
 726	chaotic huge mirror shard	0		Spell Critical Percent: +10
 727	narrow hedge maze puzzle	0		
@@ -739,16 +739,16 @@
 743	toothsome tumbling mushroom	3	awesome	
 744	alkaline non-vacuum-sealed energized mirror hair spray	0		Effect: "Mana Tea", Effect Duration: 13
 746	shaking stat script	0		
-747	blinking wobbly maroon Knob Goblin firecracker	0		
+747	maroon blinking wobbly Knob Goblin firecracker	0		
 748	shaking gourd potion	0		
 749	spoiled olive warm mushroom	3	crappy	
-750	spoiled super-sized mushroom quesadilla	5	crappy	
+750	super-sized spoiled mushroom quesadilla	5	crappy	
 751	moldy cool mushroom	4	crappy	
 752	normal enchanted cool mushroom casserole	3	good	Effect: "Vinegavotte", Effect Duration: 50
 753	rotten jumbo skewed pointy mushroom	5	crappy	
 754	rotten ghostly cream of pointy mushroom soup	3	crappy	
 755	tasty mushroom	4	awesome	
-756	massive bland mushroom	6	decent	
+756	bland massive mushroom	6	decent	
 757	yummy mushroom	3	awesome	
 758	stale huge ghost cucumber	3	decent	
 759	blurry dill	0		
@@ -782,33 +782,33 @@
 787	artisanal bottle of rum	3	EPIC	
 788	tolerable strawberry daiquiri	3	good	
 789	bad rum and cola	3	decent	
-790	hand-crafted watered-down grog	2	EPIC	
+790	watered-down hand-crafted grog	2	EPIC	
 791	blinking up-at-dawn aromatic Mafia bow tie	0		Stench Resistance: +1, Adventures: +5, Last Available: "2004-10"
 792	blurry veiny Golden Mr. Accessory	0		Maximum HP: +10, Softcore Only
 793	boiled aerosolized gray pulsating oil of stability	0		Effect: "Texas Elegance", Effect Duration: 34
 794	ionized dry oil of slipperiness	0		Effect: "Clyde's Blessing", Effect Duration: 30
-795	weak hand-crafted Acque Luride Grezze Cabernet	2	super ultra mega EPIC	Last Available: "2004-10"
+795	hand-crafted weak Acque Luride Grezze Cabernet	2	super ultra mega EPIC	Last Available: "2004-10"
 796	red miser's scorching cement shoes of James Dean	0		Experience (Moxie): +3, Hot Damage: +25, Meat Drop: +10, Last Available: "2004-10"
-797	spirit-forward mediocre rockin' wagon	5	decent	
+797	mediocre spirit-forward rockin' wagon	5	decent	
 798	hand-crafted high-proof ocean motion	9	EPIC	
 799	distilled drinkable fuzzbump	5	good	
-800	bite-sized bland blinking lime green poutine	1	decent	
+800	bland bite-sized lime green blinking poutine	1	decent	
 801	rotten tiny squat Knob stir-fry	1	crappy	
 804	decent massive Knoll stir-fry	8	good	
 805	yummy stir-fry	3	awesome	
 806	stale asparagus stir-fry	3	decent	
 807	decent fuchsia olive stir-fry	4	good	
 808	adequate Knob sausage stir-fry	3	good	
-809	huge spoiled bat wing stir-fry	7	crappy	
+809	spoiled huge bat wing stir-fry	7	crappy	
 810	half-sized adequate rat appendix stir-fry	2	good	
 811	rotten pulsating tofu stir-fry	4	crappy	
 812	stale skewed pr0n stir-fry	3	decent	
-813	toothsome gigantic olive blurry Knob shells	10	awesome	
+813	toothsome gigantic blurry olive Knob shells	10	awesome	
 814	normal fuchsia b&auml;tzle	3	good	
 815	rotten massive cyan ratini	9	crappy	
 816	normal big wobbly Knob stroganoff	5	good	
 817	low-calorie decent menudo ravioli	1	good	
-818	squat huge plus sign	0		
+818	huge squat plus sign	0		
 819	milky potion	0		
 820	swirly potion	0		
 821	bubbly potion	0		
@@ -827,9 +827,9 @@
 834	twirling smelly cornuthaum of the pedagogue	0		Experience: +3, Stench Spell Damage: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	bouncing mirror studded ring of aggravate monster	0		Damage Absorption: +80
 836	rotten red mind flayer corpse	4	crappy	
-837	irresponsibly strong mediocre Uovo Marcio Shiraz	6	decent	Last Available: "2004-10"
+837	mediocre irresponsibly strong Uovo Marcio Shiraz	6	decent	Last Available: "2004-10"
 838	blurry nippy stiffened Mafia stogie	0		Damage Reduction: 1, Cold Damage: +10, Last Available: "2004-10"
-839	triple-distilled artisanal special ghostly blurry Maiali Sifilitici Pinot Noir	7	EPIC	Effect: "Hopped Up on Goofballs", Effect Duration: 10, Last Available: "2004-10"
+839	triple-distilled special artisanal ghostly blurry Maiali Sifilitici Pinot Noir	7	EPIC	Effect: "Hopped Up on Goofballs", Effect Duration: 10, Last Available: "2004-10"
 840	blinking spinning scorching Tesla Mafia violin case	0		Hot Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2004-10"
 841	bad practically non-alcoholic tomato daiquiri	1	decent	
 842	bad beertini	3	decent	
@@ -837,7 +837,7 @@
 844	bad practically non-alcoholic spinning papaya slung	1	decent	
 845	MAHI fez of the sweet-tooth	0		Candy Drop: +100, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	skewed heteroerotic frat-paddle	0		
-848	mirror upside-down hypodermic needle	0		Familiar Weight: +5
+848	upside-down mirror hypodermic needle	0		Familiar Weight: +5
 849	Meat detector	0		Familiar Weight: +5
 850	many-eyed glasses	0		Familiar Weight: +5
 851	prosthetic forehead	0		Familiar Weight: +5
@@ -851,12 +851,12 @@
 859	knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
 861	chocolate spurs	0		Familiar Weight: +5
-862	shaking mirror maroon magnifying glass	0		Familiar Weight: +5
+862	mirror shaking maroon magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
 865	lead necklace	0		Familiar Weight: +3
 866	squat shaving cream	0		
-867	unsweetened enhanced blinking cyan pine tar	0		Effect: "Salt Rockin'", Effect Duration: 54
+867	unsweetened enhanced cyan blinking pine tar	0		Effect: "Salt Rockin'", Effect Duration: 54
 869	skewed forest tears	0		
 870	huge narrow savvy fetus-smashing club	0		Mysticality Percent: +20
 871	meatcar model	0		Familiar Weight: +5
@@ -891,8 +891,8 @@
 900	fuchsia smile-sharpening stone	0		Familiar Weight: +5
 901	twirling espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
-903	special perfectly mixed practically non-alcoholic blurry Spasmi Dolorosi Del Rene Champagne	1	super ultra mega turbo EPIC	Effect: "Demonic Taint", Effect Duration: 40, Last Available: "2004-10"
-904	tumbling teal Jack Frost's MacGyver's Da Vinci's school Mafia knickerbockers	0		Experience (Mysticality): +5, Maximum MP: +100, Cold Spell Damage: +50, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+903	practically non-alcoholic special perfectly mixed blurry Spasmi Dolorosi Del Rene Champagne	1	super ultra mega turbo EPIC	Effect: "Demonic Taint", Effect Duration: 40, Last Available: "2004-10"
+904	tumbling teal Jack Frost's MacGyver's Da Vinci's school Mafia knickerbockers	0		Experience (Mysticality): +5, Maximum MP: +100, Cold Spell Damage: +50, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	liquefied irradiated enhanced Yummy Tummy bean	0		Effect: "Outer Wolf&trade;", Effect Duration: 66
 906	galvanized Rock Pops	0		Effect: "Partially Ghosted", Effect Duration: 28
 907	triple-nitrogenated Mr. Mediocrebar	0		Effect: "Ham-Fisted", Effect Duration: 33
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	clever curative intergalactic pom poms	0		Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5
 917	Mob Penguin protection contract	0		
-918	Radio Free Baseball Cap	0		Item Drop: +5, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	jittery Radio Free Pants of dire peril	0		Weapon Damage: +20, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	Radio Free Baseball Cap	0		Item Drop: +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	jittery Radio Free Pants of dire peril	0		Weapon Damage: +20, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	toasty Radio Free Foil	0		Hot Damage: +5, Last Available: "2006-07"
 921	bland radio button candy	3	decent	
 922	savvy severed rocking horse head	0		Mysticality Percent: +20
@@ -915,12 +915,12 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	super-adjusted deionized modified Hawking's Elixir of Brilliance	0		Effect: "Always be Collecting", Effect Duration: 36
-927	artisanal practically non-alcoholic narrow Ferita Del Petto Zinfandel	1	super ultra mega turbo EPIC	Last Available: "2006-12"
+927	practically non-alcoholic artisanal narrow Ferita Del Petto Zinfandel	1	super ultra mega turbo EPIC	Last Available: "2006-12"
 928	mirror experienced fuzzy bracelets	0		Experience: +2
 929	wobbly wizardly arse-shooting crossbow	0		Mysticality: +25
-931	boozy drinkable spiced rum	5	good	
+931	drinkable boozy spiced rum	5	good	
 932	irresponsibly strong tolerable jittery eggnog	6	good	
-933	special normal half-sized candy cane	2	good	Effect: "The Sweats", Effect Duration: 20
+933	normal half-sized special candy cane	2	good	Effect: "The Sweats", Effect Duration: 20
 934	spoiled massive gingerbread bugbear	10	crappy	
 935	personal trainer's imitation nice watch	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
@@ -929,24 +929,24 @@
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	Samson's bowler	0		Experience (Muscle): +5, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	Samson's bowler	0		Experience (Muscle): +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	Rosewater's savvy bow staff	0		Mysticality Percent: 50, Last Available: "2004-12"
-944	Fonzie's bowlegged pants	0		Experience (Moxie): +1, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	Fonzie's bowlegged pants	0		Experience (Moxie): +1, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	jittery skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
 948	perfectly mixed martini	3	super ultra EPIC	Last Available: "2004-12"
 949	acceptable grogtini	3	good	Last Available: "2004-12"
-950	weak bad cherry bomb	2	decent	Last Available: "2004-12"
+950	bad weak cherry bomb	2	decent	Last Available: "2004-12"
 951	extra special Crimbo stocking	0		Last Available: "2004-12"
 952	lion tamer's hockey mask of horror	0		Experience (familiar): +2, Spooky Spell Damage: +25, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	wobbly fireproof fez of etymology	0		Hot Resistance: +3, Familiar Effect: "1xLep, cap 30"
 956	moldy carob chunk noodles	3	crappy	
-957	moldy special thick chorizo brownies	5	crappy	Effect: "Bat Attitude", Effect Duration: 35
-958	tasty small chocolate and tomato pizza	2	awesome	
-959	cyan wobbly flange	0		
+957	thick special moldy chorizo brownies	5	crappy	Effect: "Bat Attitude", Effect Duration: 35
+958	small tasty chocolate and tomato pizza	2	awesome	
+959	wobbly cyan flange	0		
 960	narrow blinking clockwork key	0		
 961	fuchsia silk garter snake	0		Free Pull, Last Available: "2011-12"
 962	velvet choker	0		Familiar Weight: +5, Last Available: "2011-12"
@@ -993,15 +993,15 @@
 1006	low-calorie flavorless cherry	1	decent	
 1007	olive Da Vinci's coconut shell	0		Experience (Mysticality): +5, Familiar Effect: "1xFairy, cap 7"
 1008	bouncing Jeselnik's ice cubes	0		Sleaze Damage: +25
-1009	special mediocre vodka martini	4	decent	Effect: "Knightlife", Effect Duration: 30
+1009	mediocre special vodka martini	4	decent	Effect: "Knightlife", Effect Duration: 30
 1010	acceptable fuchsia wobbly whiskey and soda	3	good	
 1011	bad bouncing monkey wrench	3	decent	
 1012	enchanted mediocre boozy tequila sunrise	5	decent	Effect: "Pasta Oneness", Effect Duration: 30
-1013	enchanted lousy margarita	4	decent	Effect: "Helvella Health", Effect Duration: 50
-1014	weak artisanal yellow strawberry wine	2	EPIC	
-1015	bad watered-down spinning wine spritzer	2	decent	
+1013	lousy enchanted margarita	4	decent	Effect: "Helvella Health", Effect Duration: 50
+1014	artisanal weak yellow strawberry wine	2	EPIC	
+1015	watered-down bad spinning wine spritzer	2	decent	
 1016	acceptable practically non-alcoholic perpendicular hula	1	good	
-1017	aged twirling upside-down ducha de oro	4	awesome	
+1017	aged upside-down twirling ducha de oro	4	awesome	
 1018	artisanal squat calle de miel	4	EPIC	
 1019	lousy dry vodka martini	3	decent	
 1020	artisanal bouncing wobbly old-fashioned	3	EPIC	
@@ -1009,7 +1009,7 @@
 1022	acceptable sangria	4	good	
 1023	watered-down lousy wobbly vesper	2	decent	Last Available: "2004-12"
 1024	acceptable bodyslam	4	good	Last Available: "2004-12"
-1025	acceptable high-proof sangria del diablo	10	good	Last Available: "2004-12"
+1025	high-proof acceptable sangria del diablo	10	good	Last Available: "2004-12"
 1026	narrow Valentine	0		Free Pull
 1027	whip kit	0		
 1028	buckler buckle	0		
@@ -1022,19 +1022,19 @@
 1035	occult penguin skin buckler	0		Spell Damage Percent: +25, Damage Reduction: 5
 1036	twirling yakskin buckler of the sewer	0		Stench Damage: +25, Damage Reduction: 5
 1037	curative gnauga hide buckler	0		HP Regen Min: 3, HP Regen Max: 5, Damage Reduction: 5
-1038	wet flattened blinking purple Connery's Elixir of Audacity	0		Effect: "Sweet and Red", Effect Duration: 57
+1038	wet flattened purple blinking Connery's Elixir of Audacity	0		Effect: "Sweet and Red", Effect Duration: 57
 1040	huge Tam O'Shanter	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
 1041	smooth skewed beer	4	awesome	
 1042	mirror Jim Carey's string of beads	0		Monster Level: +25
 1043	asbestos-lined string of beads	0		Hot Resistance: +5
 1044	bouncing string of beads of the storm	0		Maximum MP Percent: +40
 1045	upside-down arcane researcher's plastic bottle opener	0		Experience Percent (Mysticality): +10
-1046	squat censurious MacGyver's traffic cone	0		Maximum MP: +100, Sleaze Resistance: +3, Familiar Effect: "cap 15", Last Available: "2005-03"
-1047	practically non-alcoholic bad N. O. Beer	1	decent	
+1046	squat censurious MacGyver's traffic cone	0		Maximum MP: +100, Sleaze Resistance: +3, Last Available: "2005-03", Familiar Effect: "cap 15"
+1047	bad practically non-alcoholic N. O. Beer	1	decent	
 1048	compressed oyster egg	1		
 1049	twisted spinning oyster egg	1		
 1050	diluted oyster egg	1		Effect: "Egg on your Face", Effect Duration: 45
-1051	blue narrow plastic oyster egg	0		
+1051	narrow blue plastic oyster egg	0		
 1052	dehydrated green oyster egg	1		
 1053	compressed yellow oyster egg	1		Effect: "Berry Statistical", Effect Duration: 40
 1054	dried cyan oyster egg	1		
@@ -1047,7 +1047,7 @@
 1061	twisted pulsating mauve oyster egg	1		
 1062	powdered mauve oyster egg	1		
 1063	mirror mauve plastic oyster egg	0		
-1064	modified upside-down blurry oyster egg	1		Effect: "Human-Human Hybrid", Effect Duration: 50
+1064	modified blurry upside-down oyster egg	1		Effect: "Human-Human Hybrid", Effect Duration: 50
 1065	powdered wobbly oyster egg	1		Effect: "Colorful Gratitude", Effect Duration: 25
 1066	denatured lime green oyster egg	1		
 1067	plastic oyster egg	0		
@@ -1067,7 +1067,7 @@
 1081	teal emo roe	0		Free Pull, Last Available: "2005-04"
 1082	gazing shoes	0		Familiar Weight: +5, Last Available: "2011-12"
 1083	twirling personal raindrop	0		Free Pull, Last Available: "2005-04"
-1084	blurry cyan rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
+1084	cyan blurry rainbow tie	0		Familiar Weight: +5, Last Available: "2011-12"
 1085	tumbling clockwork widget	0		
 1086	clockwork thingamajig	0		
 1087	squat clockwork doohickey	0		
@@ -1126,8 +1126,8 @@
 1140	acceptable icy mushroom wine	3	good	
 1141	artisanal narrow mushroom wine	4	EPIC	
 1142	acceptable pointy mushroom wine	3	good	
-1143	watered-down drinkable jittery flat mushroom wine	2	good	
-1144	practically non-alcoholic hand-crafted cool mushroom wine	1	super ultra mega turbo EPIC	
+1143	drinkable watered-down jittery flat mushroom wine	2	good	
+1144	hand-crafted practically non-alcoholic cool mushroom wine	1	super ultra mega turbo EPIC	
 1145	lousy knob mushroom wine	4	decent	
 1146	hand-crafted knoll mushroom wine	3	EPIC	
 1147	smooth mushroom wine	4	awesome	
@@ -1140,8 +1140,8 @@
 1154	pickled cyan Breathetastic&trade; Premium Canned Air	1	awesome	
 1155	letter from King Ralph XI	0		
 1157	wholeberd of dire peril	0		Weapon Damage: +20
-1158	altered modified spinning wobbly Meleegra&trade; pills	0		Effect: "Wreathed in Merriment", Effect Duration: 46
-1159	green spinning mariachi G-string	0		
+1158	altered modified wobbly spinning Meleegra&trade; pills	0		Effect: "Wreathed in Merriment", Effect Duration: 46
+1159	spinning green mariachi G-string	0		
 1160	clever irate sombrero	0		Maximum MP: +20, Familiar Effect: "1xPotato, 3xLep, cap 11"
 1161	squat pile of candy	0		
 1162	oxidized diffused handsomeness potion	0		Effect: "Powder Power", Effect Duration: 26
@@ -1182,15 +1182,15 @@
 1197	fuchsia Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	upside-down bugbear	0		
-1200	immense flavorless mugcake	7	decent	
-1201	flavorless gigantic urinal cake	9	decent	
-1202	delicious thick Happy Birthday, Claude! cake	5	awesome	
-1203	massive stale personalized birthday cake	9	decent	
-1204	moldy big three-tiered wedding cake	5	crappy	
-1205	yummy huge babycakes	7	awesome	
-1206	decent fancy jumbo spinning blinking velvet cake	5	good	Effect: "Feline Ferocity", Effect Duration: 20
-1207	stale miniature congratulatory cake	2	decent	
-1208	toothsome gigantic jittery angel-food cake	6	awesome	
+1200	flavorless immense mugcake	7	decent	
+1201	gigantic flavorless urinal cake	9	decent	
+1202	thick delicious Happy Birthday, Claude! cake	5	awesome	
+1203	stale massive personalized birthday cake	9	decent	
+1204	big moldy three-tiered wedding cake	5	crappy	
+1205	huge yummy babycakes	7	awesome	
+1206	fancy decent jumbo blinking spinning velvet cake	5	good	Effect: "Feline Ferocity", Effect Duration: 20
+1207	miniature stale congratulatory cake	2	decent	
+1208	gigantic toothsome jittery angel-food cake	6	awesome	
 1209	snack-sized decent devil's-food cake	2	good	
 1210	rotten birthday party jellybean cheesecake	3	crappy	
 1211	upside-down balloon	0		
@@ -1235,12 +1235,12 @@
 1251	adequate Knob shroomkabob	3	good	
 1252	adequate tumbling shroomkabob	3	good	
 1253	spinning pile of jumping beans	0		
-1254	toothsome low-calorie jumping bean burrito	1	awesome	
+1254	low-calorie toothsome jumping bean burrito	1	awesome	
 1255	adequate jumping bean burrito	4	good	
-1256	massive delicious insanely jumping bean burrito	8	awesome	
+1256	delicious massive insanely jumping bean burrito	8	awesome	
 1257	delicious miniature rat scrapple	2	awesome	
 1258	jittery pail of pretentious paint	0		
-1259	Jack Frost's ruddy traffic cone	0		Maximum HP Percent: +40, Cold Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1259	Jack Frost's ruddy traffic cone	0		Maximum HP Percent: +40, Cold Spell Damage: +50, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	boiled Hatorade	1		
 1262	olive censurious razor-sharp off-hand balloon of the overflowing toilet	0		Weapon Damage Percent: +25, Stench Spell Damage: +50, Sleaze Resistance: +3
@@ -1253,7 +1253,7 @@
 1269	ebony wand	0		
 1270	maroon hexagonal wand	0		
 1271	purple aluminum wand	0		
-1272	pulsating gray marble wand	0		
+1272	gray pulsating marble wand	0		
 1273	wool magic lamp	0		Cold Resistance: +1
 1274	diluted jittery Medicinal Herb's medicinal herbs	1		Effect: "Sauce Monocle", Effect Duration: 25
 1275	baleful basic meat skirt	0		Spell Damage: +25, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
@@ -1287,7 +1287,7 @@
 1303	yellow Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	curative beefcake's traffic cone	0		Muscle: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	curative beefcake's traffic cone	0		Muscle: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	narrow unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	squat attention spanner	0		Familiar Weight: +5
@@ -1304,8 +1304,8 @@
 1320	enchanted moldy questionable taco	3	crappy	Effect: "Puddingskin", Effect Duration: 35
 1321	ghostly Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	hardy time helmet	0		Maximum HP: +50, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	time trousers of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	hardy time helmet	0		Maximum HP: +50, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	time trousers of doom	0		Spooky Spell Damage: +50, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	jittery slick time sword	0		Moxie: +10, Last Available: "2005-10"
 1326	purple ghostly reassuring Dyspepsi-Cola helmet	0		Spooky Resistance: +1, Familiar Effect: "3xFairy, cap 7"
 1327	squat auspicious Cloaca-Cola shield	0		Item Drop: +10, Damage Reduction: 4
@@ -1332,11 +1332,11 @@
 1349	miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	wholesome pinky ring	0		Maximum HP Percent: +10, Single Equip
-1352	lousy weak special skewed redrum	2	decent	Effect: "Can't Smell Nothin'", Effect Duration: 30
+1352	weak special lousy skewed redrum	2	decent	Effect: "Can't Smell Nothin'", Effect Duration: 30
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
 1355	decent bowl of oriole's nest soup	3	good	
-1356	shaking jittery bunny liver	0		
+1356	jittery shaking bunny liver	0		
 1357	artisanal high-proof red Mt. Noob Pale Ale	8	EPIC	
 1358	pirate zombie head	0		Last Available: "2005-11"
 1359	ninja pirate zombie robot head	0		Last Available: "2005-11"
@@ -1346,9 +1346,9 @@
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
 1365	snack-sized stale skewed tofurkey leg	2	decent	
-1366	decent small tofurkey gravy	2	good	
-1367	special decent purple herbal stuffing	3	good	Effect: "Notably Lovely", Effect Duration: 50
-1368	half-sized normal can-shaped gelatinous cranberry sauce	2	good	
+1366	small decent tofurkey gravy	2	good	
+1367	decent special purple herbal stuffing	3	good	Effect: "Notably Lovely", Effect Duration: 50
+1368	normal half-sized can-shaped gelatinous cranberry sauce	2	good	
 1369	adequate skewed yams	3	good	
 1370	tumbling rhinestone cowboy shirt of the empath	0		Familiar Weight: +5
 1371	olive perfumed gingham blouse	0		Stench Resistance: +5
@@ -1384,13 +1384,13 @@
 1402	educational rag doll	0		Experience: +1, Last Available: "2005-12"
 1403	can of fake snow of the brazier	0		Hot Spell Damage: +25, Last Available: "2005-12"
 1404	skewed yellow Rosewater's colored-light &quot;necklace&quot;	0		Mysticality Percent: +30, Last Available: "2005-12"
-1405	squat ruddy tree skirt	0		Maximum HP Percent: +40, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	squat ruddy tree skirt	0		Maximum HP Percent: +40, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	flavorless wreath-shaped Crimbo cookie	4	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	bland super-sized bell-shaped Crimbo cookie	5	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	super-sized bland bell-shaped Crimbo cookie	5	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	tasty tree-shaped Crimbo cookie	4	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	blue dangerous Unionize The Elves sign	0		Weapon Damage: +10, Last Available: "2005-12"
 1410	huge sleeping snowy owl	0		Last Available: "2005-12"
-1411	pulsating Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	pulsating Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	chilled snowcone	0		Effect: "Rad-ish", Effect Duration: 57, Last Available: "2006-01"
 1413	alkaline warmed spinning snowcone	0		Effect: "Disco Inferno", Effect Duration: 65, Last Available: "2006-01"
 1414	liquefied snowcone	0		Effect: "Petit Force", Effect Duration: 47, Last Available: "2006-01"
@@ -1399,15 +1399,15 @@
 1417	moist snowcone	0		Effect: "Faboooo", Effect Duration: 62, Last Available: "2006-01"
 1418	shaking Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	purple teddy bear sewing kit	0		Last Available: "2006-01"
-1420	reassuring boxer's traffic cone	0		Muscle Percent: +10, Spooky Resistance: +1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	reassuring boxer's traffic cone	0		Muscle Percent: +10, Spooky Resistance: +1, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	spinning Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	fuchsia Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	Tesla ice sickle of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2006-02"
 1425	ice baby of the cougar	0		Moxie: +20, Softcore Only, Last Available: "2006-02"
-1426	wobbly slick ice pick	0		Moxie: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	wobbly slick ice pick	0		Moxie: +10, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	hardened ice skates of bravery	0		Damage Reduction: 3, Spooky Resistance: +5, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	miniature spoiled grue egg omelette	2	crappy	
+1428	spoiled miniature grue egg omelette	2	crappy	
 1429	mirror roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1421,7 +1421,7 @@
 1439	corrupted hot powder	0		Effect: "Frosty the Hitman", Effect Duration: 11
 1440	super-anodized powder	0		Effect: "Fratty Flavor", Effect Duration: 53
 1441	chilled powder	0		Effect: "Sparkly!", Effect Duration: 47
-1442	modified fuchsia narrow stench powder	0		Effect: "Sausage Festive", Effect Duration: 44
+1442	modified narrow fuchsia stench powder	0		Effect: "Sausage Festive", Effect Duration: 44
 1443	denatured activated sleaze powder	0		Effect: "Mer-kinny Flavor", Effect Duration: 65
 1444	non-energized polarized twinkly nuggets	0		Effect: "Tingly Elbows", Effect Duration: 62
 1445	tarnished nitrogenated hot nuggets	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 30
@@ -1434,7 +1434,7 @@
 1452	dehydrated wad	1		
 1453	distilled wad	1		Effect: "On the Shoulders of Giants", Effect Duration: 45
 1454	powdered bouncing twirling stench wad	1		
-1455	boiled fuchsia ghostly blinking sleaze wad	1		
+1455	boiled blinking ghostly fuchsia sleaze wad	1		
 1456	blurry double daisy	0		
 1457	gray Goth Giant	0		
 1458	stale blinking Valentine's Day cake	4	decent	
@@ -1455,7 +1455,7 @@
 1473	ball-and-chain	0		
 1474	skewed automatic catapult	0		
 1475	pentacorn hat	0		Familiar Effect: "atk, cap 10"
-1476	cyan squat goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
+1476	squat cyan goofily-plumed helmet	0		Familiar Effect: "atk, cap 17"
 1477	squat plastic hard hat	0		Familiar Effect: "atk, cap 22"
 1478	shaking salad bowl	0		Familiar Effect: "atk, cap 30"
 1479	football helmet	0		Familiar Effect: "atk, cap 37"
@@ -1474,10 +1474,10 @@
 1492	upside-down ninja mop of the cheetah	0		Initiative: +60
 1493	lightning-fast careful ridiculously overelaborate ninja weapon	0		Monster Level: -10, Initiative: +40
 1494	extra-vacuum-sealed liquefied blue sugar-coated pine cone	0		Effect: "Polka Face", Effect Duration: 44, Last Available: "2020-09"
-1495	blurry Van der Graaf MacGyver's traffic cone	0		Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	blurry Van der Graaf MacGyver's traffic cone	0		Maximum MP: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	drinkable weak gloomy mushroom wine	2	good	
 1497	drinkable ghostly mushroom wine	3	good	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	fake fake vomit	0		Last Available: "2006-04"
 1501	double-polarized quantum spinning squat explosion-flavored chewing gum	0		Effect: "Total Protonic Reversal", Effect Duration: 66, Last Available: "2006-04"
@@ -1485,13 +1485,13 @@
 1503	rubber emo roe	0		Last Available: "2006-04"
 1504	quantum adjusted pulsating snowcone	0		Effect: "Crocodile Tear", Effect Duration: 49, Last Available: "2006-04"
 1505	mirror ice cube with a fly in it	0		Last Available: "2006-04"
-1506	watered-down smooth blurry calle de miel with a fly in it	2	awesome	Last Available: "2006-04"
-1507	perfectly mixed high-proof rockin' wagon with a fly in it	6	EPIC	Last Available: "2006-04"
+1506	smooth watered-down blurry calle de miel with a fly in it	2	awesome	Last Available: "2006-04"
+1507	high-proof perfectly mixed rockin' wagon with a fly in it	6	EPIC	Last Available: "2006-04"
 1508	delicious perpendicular hula with a fly in it	3	awesome	Last Available: "2006-04"
 1509	special lousy slap and tickle with a fly in it	3	decent	Effect: "[1701]Hip to the Jive", Effect Duration: 15, Last Available: "2006-04"
-1510	blinking fuchsia bag of airline peanuts	0		Last Available: "2006-04"
+1510	fuchsia blinking bag of airline peanuts	0		Last Available: "2006-04"
 1511	blinking beefcake's fake hand	0		Muscle: +25, Last Available: "2006-04"
-1512	vaporized mirror olive Knob Goblin pet-buffing spray	1		
+1512	vaporized olive mirror Knob Goblin pet-buffing spray	1		
 1513	vaporized spinning upside-down Knob Goblin learning pill	1		
 1514	modified Knob Goblin eyedrops	1		Effect: "Thicker, Sicker", Effect Duration: 35
 1515	mixed Knob Goblin nasal spray	1		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 30
@@ -1503,23 +1503,23 @@
 1522	blurry blue deadly brawny Radio Free Jersey	0		Muscle Percent: +20, Weapon Damage: +5
 1523	cyan bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	tumbling joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
+1525	tumbling joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
 1526	huge pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	manspreader's strapping corkscrew	0		Muscle: +5, Monster Level: +10, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	huge fake plastic grass	0		Last Available: "2011-01"
-1531	upside-down coward's grass skirt	0		Monster Level: -20, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	maroon grass hat of the sewer	0		Stench Damage: +25, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	upside-down coward's grass skirt	0		Monster Level: -20, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	maroon grass hat of the sewer	0		Stench Damage: +25, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	zippy grass blade	0		Initiative: +20, Last Available: "2011-01"
 1534	raffle prize box	0		
 1536	pulsating homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	weegee sqouija	0		Last Available: "2011-12"
 1538	upside-down sparkly engagement ring of the wise owl	0		Mysticality: +20, Single Equip
 1539	bouncing Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	spinning reassuring Grimacite goggles of the sewer	0		Stench Damage: +25, Spooky Resistance: +1, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	spinning reassuring Grimacite goggles of the sewer	0		Stench Damage: +25, Spooky Resistance: +1, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	Grimacite glaive of the cougar of Calamity Jane	0		Moxie: +20, Critical Hit Percent: +15, Last Available: "2008-10"
-1542	sharpshooter's Grimacite greaves of the dark arts	0		Spell Damage Percent: +100, Critical Hit Percent: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	sharpshooter's Grimacite greaves of the dark arts	0		Spell Damage Percent: +100, Critical Hit Percent: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	cyan fortified Grimacite garter of terror	0		Damage Absorption: +60, Spooky Spell Damage: +10, Last Available: "2008-10"
 1544	blinking coward's wicked Grimacite galoshes	0		Spell Damage: +5, Monster Level: -20, Last Available: "2008-10"
 1545	huge wizardly Grimacite gorget of temperance	0		Mysticality: +25, Sleaze Resistance: +5, Last Available: "2008-10"
@@ -1528,7 +1528,7 @@
 1548	mirror stylish Gazpacho's Glacial Grimoire of the boozehound	0		Moxie: +25, Booze Drop: +100
 1549	MSG	0		
 1550	bouncing lion tamer's second-hand knockoff engagement ring	0		Experience (familiar): +2, Single Equip
-1551	artisanal practically non-alcoholic bottle of Domesticated Turkey	1	EPIC	
+1551	practically non-alcoholic artisanal bottle of Domesticated Turkey	1	EPIC	
 1552	tolerable extra-dry bottle of Definit	5	good	
 1553	delicious weak bottle of Calcutta Emerald	2	awesome	
 1554	fortified artisanal bottle of Lieutenant Freeman	5	EPIC	
@@ -1539,47 +1539,47 @@
 1559	tonic water	0		
 1560	flavorless ghostly cocktail onion	3	decent	
 1561	spoiled olive raspberry	3	crappy	
-1562	decent snack-sized kiwi	2	good	
-1563	mediocre weak cyan wobbly whiskey bittersweet	2	decent	
-1564	fancy hand-crafted irresponsibly strong squat mimosette	9	EPIC	Effect: "Disdain of She-Who-Was", Effect Duration: 45
+1562	snack-sized decent kiwi	2	good	
+1563	mediocre weak wobbly cyan whiskey bittersweet	2	decent	
+1564	irresponsibly strong hand-crafted fancy squat mimosette	9	EPIC	Effect: "Disdain of She-Who-Was", Effect Duration: 45
 1565	perfectly mixed practically non-alcoholic tequila sunset	1	super EPIC	
 1566	drinkable zmobie	4	good	Wiki Name: "Zmobie (drink)"
-1567	weak lousy spinning gin and tonic	2	decent	
+1567	lousy weak spinning gin and tonic	2	decent	
 1568	perfectly mixed vodka and tonic	3	EPIC	
-1569	acceptable practically non-alcoholic maroon vodka gibson	1	good	
+1569	practically non-alcoholic acceptable maroon vodka gibson	1	good	
 1570	acceptable gibson	4	good	
 1571	delicious parisian cathouse	3	awesome	
 1572	lousy rabbit punch	3	decent	
 1573	hand-crafted caipifruta	4	EPIC	
 1574	acceptable teqiwila	3	good	
-1575	aged enchanted narrow Divine	3	awesome	Effect: "Good with the Ladies", Effect Duration: 10
+1575	enchanted aged narrow Divine	3	awesome	Effect: "Good with the Ladies", Effect Duration: 10
 1576	mediocre distilled Gordon Bennett	5	decent	
 1577	delicious tangarita	3	awesome	
 1578	tolerable ghostly mandarina colada	3	good	
 1579	aged gimlet	3	awesome	
-1580	watered-down perfectly mixed blurry brick road	2	super ultra EPIC	
-1581	smooth enchanted tumbling vodka stratocaster	3	awesome	Effect: "Ready to Snap", Effect Duration: 10
+1580	perfectly mixed watered-down blurry brick road	2	super ultra EPIC	
+1581	enchanted smooth tumbling vodka stratocaster	3	awesome	Effect: "Ready to Snap", Effect Duration: 10
 1582	hand-crafted twirling Neuromancer	3	EPIC	
 1583	hand-crafted blinking prussian cathouse	4	EPIC	
 1584	smooth Mae West	4	awesome	
-1585	high-proof aged Mon Tiki	9	awesome	
+1585	aged high-proof Mon Tiki	9	awesome	
 1586	drinkable teqiwila slammer	3	good	
 1587	toothsome Knob lo mein	4	awesome	
 1588	moldy miniature asparagus lo mein	2	crappy	
-1589	small bland Knoll lo mein	2	decent	
+1589	bland small Knoll lo mein	2	decent	
 1590	stale enchanted big lo mein	5	decent	Effect: "Elvish", Effect Duration: 20
 1591	spoiled miniature mirror olive lo mein	2	crappy	
 1592	moldy diet cyan hot hi mein	1	crappy	
-1593	super-sized decent hi mein	5	good	
-1594	super-sized moldy hi mein	5	crappy	
-1595	small toothsome hi mein	2	awesome	
+1593	decent super-sized hi mein	5	good	
+1594	moldy super-sized hi mein	5	crappy	
+1595	toothsome small hi mein	2	awesome	
 1596	bland blurry sleazy hi mein	3	decent	
 1597	experienced Junior LAAAAME merit badge	0		Experience: +2, Last Available: "2006-05"
 1598	blinking maroon grievous Senior LAAAAME merit badge	0		Weapon Damage Percent: +50, Last Available: "2006-05"
 1599	jittery jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	acceptable tangarita with a fly in it	3	good	
-1601	watered-down delicious mandarina colada with a fly in it	2	awesome	
-1602	practically non-alcoholic tolerable squat prussian cathouse with a fly in it	1	good	
+1601	delicious watered-down mandarina colada with a fly in it	2	awesome	
+1602	tolerable practically non-alcoholic squat prussian cathouse with a fly in it	1	good	
 1603	hand-crafted high-proof Mae West with a fly in it	10	EPIC	
 1604	mixed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
@@ -1592,8 +1592,8 @@
 1612	dry ionized concentrated cordial of concentration	0		Effect: "Twinklebritches", Effect Duration: 69
 1613	extremely unsafe coffin lid	0		Weapon Damage Percent: +100, Damage Reduction: 3
 1614	satin shield of the ox	0		Muscle: +20, Damage Reduction: 5
-1615	Cerebral Cloche of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	Jeselnik's Cerebral Culottes	0		Sleaze Damage: +25, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	Cerebral Cloche of horror	0		Spooky Spell Damage: +25, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	Jeselnik's Cerebral Culottes	0		Sleaze Damage: +25, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	double-paned Van der Graaf Cerebral Crossbow of the sewer	0		Stench Damage: +25, Cold Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	jittery munchies pill	0		Last Available: "2006-06"
@@ -1611,7 +1611,7 @@
 1631	beer cartilage	0		
 1632	Spanish fly trap	0		
 1633	Spanish fly	0		
-1634	enchanted acceptable watered-down around the world	2	good	Effect: "Whitened Teeth", Effect Duration: 10
+1634	enchanted watered-down acceptable around the world	2	good	Effect: "Whitened Teeth", Effect Duration: 10
 1635	tumbling scrumdiddlyumptious solution	0		
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	ionized alkaline lotion of hotness	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 45
@@ -1619,8 +1619,8 @@
 1639	nitrogenated blurry lotion of spookiness	0		Effect: "Larger", Effect Duration: 34
 1640	ionized lotion of stench	0		Effect: "Mercenary", Effect Duration: 14
 1641	non-adjusted Vulcanized jittery lotion of sleaziness	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 28
-1642	high-proof acceptable Grimacite Bock	8	good	Last Available: "2008-11"
-1643	tasty small skewed wedge of gray cheese	2	awesome	Last Available: "2008-11"
+1642	acceptable high-proof Grimacite Bock	8	good	Last Available: "2008-11"
+1643	small tasty skewed wedge of gray cheese	2	awesome	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	pulsating and sauce	0		
 1646	and sauce	0		
@@ -1630,14 +1630,14 @@
 1650	milk of magnesium	0		
 1651	spoiled bouncing foie gras	3	crappy	
 1652	corrupted tarnished candy brain	0		Effect: "Curse of the Black Pearl Onion", Effect Duration: 19, Last Available: "2020-09"
-1653	wobbly flame-retardant ribald wholesome jewel-eyed wizard hat	0		Maximum HP Percent: +10, Sleaze Damage: +10, Hot Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	wobbly flame-retardant ribald wholesome jewel-eyed wizard hat	0		Maximum HP Percent: +10, Sleaze Damage: +10, Hot Resistance: +1, Softcore Only, Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	wad of Crovacite of the storm of the businessman	0		Maximum MP Percent: +40, Meat Drop: +50
 1655	red gravedigger's fortified collar	0		Damage Absorption: +60, Spooky Damage: +10
 1656	White Citadel Satisfaction Satchel	0		
-1657	twirling narrow shaking onion shurikens	0		
+1657	narrow twirling shaking onion shurikens	0		
 1658	Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
-1660	shaking maroon Regular Cloaca Cola	0		
+1660	maroon shaking Regular Cloaca Cola	0		
 1661	Radio KoL Keychain of the ox	0		Muscle: +20
 1662	upside-down Radio KoL Antenna Ball of the wise owl	0		Mysticality: +20
 1663	smooth Radio KoL Flashlight	0		Moxie: +15
@@ -1649,12 +1649,12 @@
 1669	inspector's star stiletto	0		Item Drop: +15
 1670	fraudwort	0		
 1671	shysterweed	0		
-1672	bouncing skewed swindleblossom	0		
+1672	skewed bouncing swindleblossom	0		
 1673	dog trainer's experienced grave robbing shovel	0		Experience: +2, Experience (familiar): +1
 1674	twirling Samson's superhero mask	0		Experience (Muscle): +5, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
 1675	purple ore	0		
 1676	bouncing styrofoam ore	0		
-1677	narrow pulsating bubblewrap ore	0		
+1677	pulsating narrow bubblewrap ore	0		
 1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	supercharged supercool sword	0		Moxie Percent: +20, Maximum MP Percent: +30
 1680	wool chilly staff	0		Cold Damage: +5, Cold Resistance: +1
@@ -1674,8 +1674,8 @@
 1694	deionized dry Frogade	0		Effect: "Pharmaceutically Cool", Effect Duration: 49
 1695	adjusted jittery papotion of papower	0		Effect: "Thunderspell", Effect Duration: 33
 1696	gigantic adequate royal jelly taco	8	good	
-1697	delicious half-sized tofu taco	2	awesome	
-1698	snack-sized adequate jumping bean taco	2	good	
+1697	half-sized delicious tofu taco	2	awesome	
+1698	adequate snack-sized jumping bean taco	2	good	
 1699	decent fancy fuchsia catgut taco	3	good	Effect: "Chunky", Effect Duration: 15
 1700	moldy snack-sized goat cheese taco	2	crappy	
 1701	big normal green pr0n taco	5	good	
@@ -1746,7 +1746,7 @@
 1767	pack of chewing gum	0		
 1768	skewed Gnomish toolbox	0		
 1769	adequate wobbly fricasseed brains	3	good	
-1770	decent super-sized brains casserole	5	good	
+1770	super-sized decent brains casserole	5	good	
 1771	chaotic butcherknife	0		Spell Critical Percent: +10
 1772	jittery chaotic corn holder	0		Spell Critical Percent: +10
 1773	zippy eggbeater	0		Initiative: +20
@@ -1768,14 +1768,14 @@
 1789	Mob Penguin	0		
 1790	hand-crafted Ram's Face Lager	4	EPIC	
 1791	ram horns	0		
-1792	shaking crafty boxer's Travoltan trousers of Tarzan	0		Muscle Percent: +10, Experience (Muscle): +3, Maximum MP: +10, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	shaking crafty boxer's Travoltan trousers of Tarzan	0		Muscle Percent: +10, Experience (Muscle): +3, Maximum MP: +10, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	mirror rosewater-soaked pool cue of the scaredy-cat	0		Monster Level: -15, Stench Resistance: +3
 1794	tarnished triple-cold-filtered handful of hand chalk	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 44
 1795	deadly Counterclockwise Watch	0		Weapon Damage: +5, Single Equip
 1796	bone collar	0		Familiar Weight: +5
 1797	squat misshapen animal skeleton	0		
 1798	pile of animal bones	0		
-1799	narrow blue animal skull	0		
+1799	blue narrow animal skull	0		
 1800	animal cranium	0		
 1801	animal jawbone	0		
 1802	first cervical vertebra	0		
@@ -1790,7 +1790,7 @@
 1811	third thoracic vertebra	0		
 1812	shaking fourth thoracic vertebra	0		
 1813	fifth thoracic vertebra	0		
-1814	lime green shaking sixth thoracic vertebra	0		
+1814	shaking lime green sixth thoracic vertebra	0		
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
@@ -1827,8 +1827,8 @@
 1848	squat mirror left tenth rib	0		
 1849	left eleventh rib	0		
 1850	blurry left twelfth rib	0		
-1851	spinning bouncing right first rib	0		
-1852	huge blinking green right second rib	0		
+1851	bouncing spinning right first rib	0		
+1852	green blinking huge right second rib	0		
 1853	right third rib	0		
 1854	jittery right fourth rib	0		
 1855	right fifth rib	0		
@@ -1842,8 +1842,8 @@
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
-1866	blurry blue left clavicle	0		
-1867	tumbling squat right clavicle	0		
+1866	blue blurry left clavicle	0		
+1867	squat tumbling right clavicle	0		
 1868	blue left humerus	0		
 1869	tumbling right humerus	0		
 1870	left radius	0		
@@ -1871,7 +1871,7 @@
 1892	left first rear claw	0		
 1893	left second rear claw	0		
 1894	left third rear claw	0		
-1895	bouncing narrow left fourth rear claw	0		
+1895	narrow bouncing left fourth rear claw	0		
 1896	right first rear claw	0		
 1897	right second rear claw	0		
 1898	right third rear claw	0		
@@ -1900,7 +1900,7 @@
 1923	roll of toilet paper	0		Free Pull
 1924	shaking upside-down tattered wolf standard	0		
 1925	skewed tattered snake standard	0		
-1926	shaking cyan KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
+1926	cyan shaking KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
 1927	scary death orb	0		
 1928	lime green tuning fork	0		
 1929	greaves of doom	0		Spooky Spell Damage: +50, Familiar Effect: "1xBarrr"
@@ -1925,12 +1925,12 @@
 1948	beefy tap shoes of chilblains	0		Muscle: +10, Cold Damage: +25, Single Equip
 1949	stale Manetwich	4	decent	
 1950	bottle of Vangoghbitussin	0		
-1951	enchanted artisanal bottle of Pinot Renoir	3	EPIC	Effect: "Educated (Kinda)", Effect Duration: 40
-1952	bland miniature squat desiccated apricot	2	decent	
-1953	triple-distilled mediocre flute of flat champagne	10	decent	
-1954	miniature delicious dehydrated caviar	2	awesome	
+1951	artisanal enchanted bottle of Pinot Renoir	3	EPIC	Effect: "Educated (Kinda)", Effect Duration: 40
+1952	miniature bland squat desiccated apricot	2	decent	
+1953	mediocre triple-distilled flute of flat champagne	10	decent	
+1954	delicious miniature dehydrated caviar	2	awesome	
 1955	cyan styrofoam peanuts	0		
-1956	distilled hand-crafted snifter of thoroughly aged brandy	5	EPIC	
+1956	hand-crafted distilled snifter of thoroughly aged brandy	5	EPIC	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	tattered scrap of paper	0		
@@ -1939,11 +1939,11 @@
 1962	unsweetened polymerized triple-frozen Bit O' Ectoplasm	0		Effect: "Towering Strength", Effect Duration: 22
 1963	upside-down dance card	0		
 1964	chaotic opera mask	0		Spell Critical Percent: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
-1965	mirror bouncing spinning bottle of Monsieur Bubble	0		
+1965	mirror spinning bouncing bottle of Monsieur Bubble	0		
 1966	perfumed Amulet of Yendor of wisdom	0		Mysticality: +15, Stench Resistance: +5, Single Equip, Last Available: "2011-12"
 1967	jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	bottle of perfume	0		Familiar Weight: +5
-1969	narrow maroon spoon!	0		Familiar Weight: +5
+1969	maroon narrow spoon!	0		Familiar Weight: +5
 1970	blurry nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	cyan prompt frosty shrimp fork	0		Cold Spell Damage: +10, Adventures: +3
@@ -1978,7 +1978,7 @@
 2001	Vaso De Agua trading card	0		
 2002	The Grand Poo-Bah trading card	0		
 2003	narrow Thorny Toad trading card	0		
-2004	teal tumbling Chori Zo trading card	0		
+2004	tumbling teal Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	Poison Oak trading card	0		
 2007	skewed Princess Rutabaga trading card	0		
@@ -1995,8 +1995,8 @@
 2018	club necklace	0		
 2019	cream pie	0		Free Pull
 2020	decent miniature twirling cherry pie	2	good	
-2021	decent tumbling ghostly strawberry pie	4	good	
-2022	adequate super-sized lemon meringue pie	5	good	
+2021	decent ghostly tumbling strawberry pie	4	good	
+2022	super-sized adequate lemon meringue pie	5	good	
 2023	shaking Genalen&trade; Bottle	1	good	
 2024	low-calorie moldy mixed wildflower greens	1	crappy	
 2025	spoiled snack-sized handful of walnuts	2	crappy	
@@ -2012,16 +2012,16 @@
 2035	Marquis de Poivre soda	0		
 2036	corrupted unsweetened cyan radium-flavored potato chips	0		Effect: "Aloofah", Effect Duration: 60
 2037	altered wintergreen-flavored potato chips	0		Effect: "You're High as a Crow, Marty", Effect Duration: 18
-2038	double-chilled ionized huge pulsating ennui-flavored potato chips	0		Effect: "Tremella Tremens", Effect Duration: 54
+2038	double-chilled ionized pulsating huge ennui-flavored potato chips	0		Effect: "Tremella Tremens", Effect Duration: 54
 2039	x-ray specs	0		Last Available: "2011-12"
 2040	twirling patchouli oil bomb	0		
 2041	ferret bait	0		
 2042	exploding hacky-sack	0		
 2043	teal hemp net	0		
 2044	skewed your father's MacGuffin diary	0		
-2045	thick tasty brain-meltingly-hot chicken wings	5	awesome	
+2045	tasty thick brain-meltingly-hot chicken wings	5	awesome	
 2046	flavorless twirling frat brats	3	decent	
-2047	toothsome snack-sized knob ka-bobs	2	awesome	
+2047	snack-sized toothsome knob ka-bobs	2	awesome	
 2049	acceptable pulsating can of Swiller	3	good	
 2050	broken wings	0		
 2051	jittery sunken eyes	0		
@@ -2031,17 +2031,17 @@
 2055	snake skin	0		
 2056	ionized colloidal adder bladder	0		Effect: "Oh Snap", Effect Duration: 39
 2057	pension check	0		
-2058	twirling green picnic basket	0		
+2058	green twirling picnic basket	0		
 2059	extra-boiled green Black No. 2	0		Effect: "Crimbo Flavor", Effect Duration: 41
 2060	mansplainer's MacGyver's sword	0		Maximum MP: +100, Monster Level: +15
 2061	miser's helmet	0		Meat Drop: +10, Familiar Effect: "1xFairy, cap 40"
 2062	wicked shield of Gandalf	0		Spell Damage: +5, Spell Critical Percent: +20, Damage Reduction: 10
-2063	thick rotten blackberry	5	crappy	
+2063	rotten thick blackberry	5	crappy	
 2064	forged identification documents	0		
-2065	blurry yellow PADL Phone	0		
+2065	yellow blurry PADL Phone	0		
 2066	asbestos-lined Annie Oakley's kick-ass kicks	0		Critical Hit Percent: +20, Hot Resistance: +5, Single Equip
 2067	upside-down sake bomb	0		
-2068	olive jittery tequila grenade	0		
+2068	jittery olive tequila grenade	0		
 2069	Rosewater's beer helmet	0		Mysticality Percent: +30, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2070	chaotic educational distressed denim pants	0		Experience: +1, Spell Critical Percent: +10, Familiar Effect: "sleaze atk, 1xPotato, cap 42"
 2071	rock-hard perforated battle paddle	0		Damage Reduction: 5
@@ -2059,15 +2059,15 @@
 2083	makeshift crane	0		
 2084	can of starch	0		
 2085	dehydrated purple ghostly bottle of ultravitamins	1		Effect: "Adorable Lookout", Effect Duration: 40
-2086	twisted lime green blurry bottle of cough syrup	1		Effect: "Seriously Mutated", Effect Duration: 50
-2087	twisted maroon wobbly upside-down tube of hair oil	1		Effect: "Puddingface", Effect Duration: 20
+2086	twisted blurry lime green bottle of cough syrup	1		Effect: "Seriously Mutated", Effect Duration: 50
+2087	twisted maroon upside-down wobbly tube of hair oil	1		Effect: "Puddingface", Effect Duration: 20
 2088	extra-dry non-energized Daffy Taffy	0		Effect: "Disco State of Mind", Effect Duration: 30
 2089	mirror Crimboween memo	0		Last Available: "2006-10"
 2090	ribald frightening baleful deadly pilgrim shield of the early riser	0		Weapon Damage: +5, Spell Damage: +25, Spooky Damage: +5, Sleaze Damage: +10, Adventures: +7, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
 2091	bath salts	0		
 2092	green spinning hand mirror	0		
 2093	vibrating hors d'oeuvre tray	0		Maximum MP Percent: +10, Damage Reduction: 5
-2094	adequate snack-sized ballroom blintz	2	good	
+2094	snack-sized adequate ballroom blintz	2	good	
 2095	towel	0		
 2096	compressed guy made of bee pollen	1		
 2097	medical-grade 17-ball	0		HP Regen Min: 7, HP Regen Max: 10
@@ -2087,10 +2087,10 @@
 2111	tooth	0		
 2112	pulsating leaf	0		Last Available: "2011-12"
 2113	spinning wheel of the scaredy-cat	0		Monster Level: -15, Last Available: "2006-12"
-2114	purple shaking upside-down yo	0		Last Available: "2006-12"
+2114	shaking purple upside-down yo	0		Last Available: "2006-12"
 2115	baleful prehistoric spear	0		Spell Damage: +25, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	sage beefy fire	0		Muscle: +10, Mysticality Percent: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	sage beefy fire	0		Muscle: +10, Mysticality Percent: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	mirror jittery Grateful Undead T-shirt of courage	0		Spooky Resistance: +3
@@ -2123,13 +2123,13 @@
 2148	toothsome rock	0		
 2149	normal thick frank	5	good	Last Available: "2011-12"
 2150	stale ghostly plate of franks and beans	3	decent	Last Available: "2011-12"
-2151	watered-down smooth shot of blackberry schnapps	2	awesome	
+2151	smooth watered-down shot of blackberry schnapps	2	awesome	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
 2154	pulsating ion grid	0		Last Available: "2011-12"
 2155	Feynman gate	0		Last Available: "2011-12"
 2156	logic synthesizer	0		Last Available: "2011-12"
-2157	cyan twirling high-resistance ultrapolymer plating	0		Last Available: "2011-12"
+2157	twirling cyan high-resistance ultrapolymer plating	0		Last Available: "2011-12"
 2158	servomechanical torsion facilitator	0		Last Available: "2011-12"
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	red bi-lateral logic compressor	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	skewed hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	blue spinning Sinatra's toy ray gun of the wise owl	0		Mysticality: +20, Experience (Moxie): +5, Last Available: "2006-12"
-2169	narrow narrow curative Newton's toy space helmet	0		Experience (Mysticality): +3, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	narrow narrow curative Newton's toy space helmet	0		Experience (Mysticality): +3, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	Annie Oakley's smartaleck's astronaut pants	0		Moxie Percent: +30, Critical Hit Percent: +20, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	Annie Oakley's smartaleck's astronaut pants	0		Moxie Percent: +30, Critical Hit Percent: +20, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	tumbling toy jet pack of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-12"
 2173	huge pulsating triangular stone	0		
 2174	wobbly mossy stone sphere	0		
@@ -2153,7 +2153,7 @@
 2178	obsidian dagger of James Dean	0		Experience (Moxie): +3
 2179	archaeologist's notebook	0		
 2180	amulet	0		
-2181	gray blinking chocolate lump	0		Last Available: "2011-12"
+2181	blinking gray chocolate lump	0		Last Available: "2011-12"
 2182	Harold's hammer head	0		
 2183	spinning Harold's hammer handle	0		
 2184	Harold's hammer	0		
@@ -2161,7 +2161,7 @@
 2186	blue upside-down unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	flask of peppermint oil	1	EPIC	Last Available: "2006-12"
-2189	tolerable fancy watered-down flask of peppermint schnapps	2	good	Effect: "Eggs-tra Sensory Perception", Effect Duration: 25, Last Available: "2006-12"
+2189	tolerable watered-down fancy flask of peppermint schnapps	2	good	Effect: "Eggs-tra Sensory Perception", Effect Duration: 25, Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
@@ -2171,8 +2171,8 @@
 2196	spoiled gingerbread horror	3	crappy	Last Available: "2006-12"
 2197	triple-liquefied oxidized shaking but probably evil chocolate	0		Effect: "Milk Studly", Effect Duration: 22, Last Available: "2006-12"
 2198	normal bat-shaped Crimboween cookie	3	good	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
-2199	spoiled big skull-shaped Crimboween cookie	5	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	decent massive blurry tombstone-shaped Crimboween cookie	9	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2199	big spoiled skull-shaped Crimboween cookie	5	crappy	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
+2200	massive decent blurry tombstone-shaped Crimboween cookie	9	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	pulsating plastic gift-wrapping vampire of incineration	0		Hot Spell Damage: +50, Last Available: "2006-12"
 2202	jittery plastic yuletide troll of incineration	0		Hot Spell Damage: +50, Last Available: "2006-12"
 2203	plastic skeletal reindeer of the storm	0		Maximum MP Percent: +40, Single Equip, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	resourceful Crimbo tiki necklace	0		Maximum MP: +50, Last Available: "2006-12"
 2208	Oprah's bobble-hip hula elf doll of the storm	0		Maximum MP Percent: 90, Last Available: "2006-12"
 2209	huge greasy Crimbo ukulele	0		Sleaze Spell Damage: +10, Last Available: "2006-12"
-2210	upside-down prompt dangerous Tiki lighter	0		Weapon Damage: +10, Adventures: +3, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	ghostly rosewater-soaked deck of tropical cards of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	knitted energetic tropical paperweight	0		Maximum MP Percent: +20, Cold Resistance: +3, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	upside-down prompt dangerous Tiki lighter	0		Weapon Damage: +10, Adventures: +3, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	ghostly rosewater-soaked deck of tropical cards of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	knitted energetic tropical paperweight	0		Maximum MP Percent: +20, Cold Resistance: +3, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	personal trainer's Tropical Crimbo Hat	0		Experience Percent (Muscle): +10, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	squat Tropical Crimbo Shorts of mayonnaise	0		Sleaze Spell Damage: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	personal trainer's Tropical Crimbo Hat	0		Experience Percent (Muscle): +10, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	squat Tropical Crimbo Shorts of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	delicious super ka-bob	3	awesome	
 2218	moldy huge beer basted brat	3	crappy	
 2219	Tropical Crimbo Sword of Tarzan	0		Experience (Muscle): +3, Last Available: "2006-12"
 2220	adjusted adjusted shaking and Crimboween candy	0		Effect: "Berry Experiential", Effect Duration: 52, Last Available: "2020-09"
 2221	narrow Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	spinning dance instructor's liar's pants of James Dean	0		Experience (Moxie): +3, Experience Percent (Moxie): +10, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	spinning dance instructor's liar's pants of James Dean	0		Experience (Moxie): +3, Experience Percent (Moxie): +10, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	careful curative juggler's balls	0		Monster Level: -10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2007-01"
 2224	strapping pink shirt	0		Muscle: +5, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2236,32 +2236,32 @@
 2262	bird rib	0		
 2263	blue blurry lion oil	0		
 2264	normal huge spinning stunt nuts	3	good	
-2265	flavorless bite-sized blurry wet stew	1	decent	
+2265	bite-sized flavorless blurry wet stew	1	decent	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	ruddy Staff of Fats	0		Maximum HP Percent: +40
 2269	delicious sausage wonton	4	awesome	
 2270	upside-down studded belt of mayonnaise	0		Damage Absorption: +80, Sleaze Spell Damage: +50, Single Equip
 2271	tolerable bottle of Merlot	3	good	
-2272	high-proof lousy fancy skewed blinking bottle of Port	9	decent	Effect: "Bestial Sympathy", Effect Duration: 20
-2273	drinkable practically non-alcoholic bottle of Pinot Noir	1	good	
-2274	hand-crafted enchanted practically non-alcoholic huge bottle of Zinfandel	1	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 30
+2272	fancy high-proof lousy skewed blinking bottle of Port	9	decent	Effect: "Bestial Sympathy", Effect Duration: 20
+2273	practically non-alcoholic drinkable bottle of Pinot Noir	1	good	
+2274	hand-crafted practically non-alcoholic enchanted huge bottle of Zinfandel	1	EPIC	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 30
 2275	mediocre extra-dry bottle of Marsala	5	decent	
-2276	hand-crafted fancy blinking bottle of Muscat	3	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 50
+2276	fancy hand-crafted blinking bottle of Muscat	3	EPIC	Effect: "Memories of Puppy Love", Effect Duration: 50
 2277	jittery Fernswarthy's key	0		
 2278	squat Fernswarthy's letter	0		
-2279	ghostly green ghostly book	0		
+2279	ghostly ghostly green book	0		
 2280	Manual of Labor	0		
 2281	Manual of Transmission	0		
 2282	Manual of Dexterity	0		
 2283	rosy-cheeked seal-skull helmet	0		Maximum HP Percent: +30, Familiar Effect: "atk, cap 2"
 2284	petrified noodles	0		
 2285	chisel	0		
-2286	teal twirling Eye of Ed	0		
+2286	twirling teal Eye of Ed	0		
 2287	smelly electrified glowstick	0		Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-01"
 2288	shaking encoder ring	0		Single Equip
 2289	squat paperclip	0		
-2290	upside-down wobbly really house	0		
+2290	wobbly upside-down really house	0		
 2291	Non-Essential Amulet	0		
 2292	wine vinaigrette	0		
 2293	cup of strong herbal tea	0		
@@ -2274,10 +2274,10 @@
 2300	fingerless hobo gloves	0		
 2301	wobbly Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	deionized candy heart	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 54, Last Available: "2007-02"
 2305	pressed extra-activated pink candy heart	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 61, Last Available: "2007-02"
-2306	activated upside-down huge candy heart	0		Effect: "Human-Hippy Hybrid", Effect Duration: 22, Last Available: "2007-02"
+2306	activated huge upside-down candy heart	0		Effect: "Human-Hippy Hybrid", Effect Duration: 22, Last Available: "2007-02"
 2307	altered adjusted pickled bouncing candy heart	0		Effect: "Slimily Sagacious", Effect Duration: 20, Last Available: "2007-02"
 2308	quantum pulsating candy heart	0		Effect: "Coated Arms", Effect Duration: 50, Last Available: "2007-02"
 2309	chilled mirror candy heart	0		Effect: "Comprehensively Nourished", Effect Duration: 52, Last Available: "2007-02"
@@ -2304,7 +2304,7 @@
 2330	chocolate-covered diamond-studded roses	0		
 2331	maroon bouquet of circular saw blades	0		
 2332	spoiled yellow Better Than Cuddling Cake	3	crappy	
-2333	huge tumbling maroon ninja snowman	0		
+2333	maroon tumbling huge ninja snowman	0		
 2334	skewed Holy MacGuffin	0		
 2335	cyan rubber WWBBDD? bracelet	0		
 2336	squat ribald rock-hard pipe	0		Damage Reduction: 5, Sleaze Damage: +10
@@ -2348,7 +2348,7 @@
 2374	twirling banana peel	0		
 2375	adequate banana cream pie	3	good	
 2376	bad spirit-forward banana daiquiri	5	decent	
-2377	spirit-forward mediocre bungle in the jungle	5	decent	
+2377	mediocre spirit-forward bungle in the jungle	5	decent	
 2378	banana spritzer	0		
 2379	corrupted banana smoothie	0		Effect: "Joy", Effect Duration: 51
 2380	dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2401,7 +2401,7 @@
 2427	Vulcanized huge freezerburned ice cube	0		Effect: "Peppermint Bite", Effect Duration: 46
 2428	electrified pickled fake blood	0		Effect: "There Wolf", Effect Duration: 14
 2429	activated irradiated squat tumbling Eau de Guaneau	0		Effect: "Cold Hands", Effect Duration: 34
-2430	ionized spinning mirror bag of lard	0		Effect: "Frozen Shoulders", Effect Duration: 12
+2430	ionized mirror spinning bag of lard	0		Effect: "Frozen Shoulders", Effect Duration: 12
 2431	irradiated super-galvanized boiled bottle of Mystic Shell	0		Effect: "Tearful, Fearful", Effect Duration: 45
 2432	tarnished aerosolized quadruple-denatured narrow SPF 451 lip balm	0		Effect: "Initiative and Let Die", Effect Duration: 64
 2433	colloidal anodized bottle of antifreeze	0		Effect: "Neutered Nostrils", Effect Duration: 41
@@ -2424,7 +2424,7 @@
 2450	empty Cloaca-Cola bottle	0		
 2451	blurry flame-wreathed goatskin umbrella	0		Hot Spell Damage: +10
 2452	horrifying wool hat of the ox	0		Muscle: +20, Spooky Damage: +25, Familiar Effect: "1xLep, cap 43"
-2453	ghostly squat Goodfella contract	0		Last Available: "2011-12"
+2453	squat ghostly Goodfella contract	0		Last Available: "2011-12"
 2454	blurry frosty belt of courage	0		Cold Spell Damage: +10, Spooky Resistance: +3, Single Equip
 2455	bar whip of the businessman	0		Meat Drop: +50
 2456	tumbling barskin buckler of the empath	0		Familiar Weight: +5, Damage Reduction: 1
@@ -2435,7 +2435,7 @@
 2462	odor extractor	0		Last Available: "2019-12"
 2463	narrow Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
 2464	decent bowl of Bounty-Os	4	good	
-2465	weak delicious fuchsia ghostly squat Oreille Divis&eacute;e brandy	2	awesome	
+2465	delicious weak ghostly squat fuchsia Oreille Divis&eacute;e brandy	2	awesome	
 2466	pompadour'd puppy	0		
 2467	suede shoes	0		Familiar Weight: +5
 2468	callused fingerbone	0		
@@ -2482,7 +2482,7 @@
 2509	shaking Jack Frost's peace-sign necklace	0		Cold Spell Damage: +50
 2510	Da Vinci's cool round sunglasses	0		Moxie: +5, Experience (Mysticality): +5, Single Equip
 2511	Frat Army FGF	0		
-2512	huge spinning Hippy Army MPE	0		
+2512	spinning huge Hippy Army MPE	0		
 2513	skewed yellow Lo Pan's sage spark plug earring	0		Mysticality Percent: +10, Spell Critical Percent: +30
 2514	twirling scorching deadly woven baling wire bracelets	0		Weapon Damage: +5, Hot Damage: +25
 2515	yellow Tesla gearbox necklace of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
@@ -2491,21 +2491,21 @@
 2518	sawblade shield of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 11
 2519	lousy jittery McMillicancuddy's Special Lager	3	decent	
 2520	lousy melted Jell-o shot	3	decent	
-2521	drinkable fancy cruelty-free wine	3	good	Effect: "Magically Delicious", Effect Duration: 10
+2521	fancy drinkable cruelty-free wine	3	good	Effect: "Magically Delicious", Effect Duration: 10
 2522	acceptable weak thistle wine	2	good	
 2523	megatofu	0		
 2524	displaced fish	0		
 2525	normal mirror fish	4	good	
-2526	diet rotten enchanted skewed fish casserole	1	crappy	Effect: "Bloody-minded", Effect Duration: 20
+2526	rotten diet enchanted skewed fish casserole	1	crappy	Effect: "Bloody-minded", Effect Duration: 20
 2527	adequate fish lasagna	4	good	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	moldy upside-down gnatloaf	3	crappy	
 2530	decent gnatloaf casserole	3	good	
-2531	bland tiny gnat lasagna	1	decent	
+2531	tiny bland gnat lasagna	1	decent	
 2532	pork	0		
 2533	half-sized adequate pork chop sandwiches	2	good	
 2534	rotten pork casserole	3	crappy	
-2535	flavorless half-sized pork lasagna	2	decent	
+2535	half-sized flavorless pork lasagna	2	decent	
 2536	spinning canopic jar	0		
 2537	spice	0		
 2538	organs	0		
@@ -2518,7 +2518,7 @@
 2545	vacuum-sealed super-chilled lime green spinning upsy daisy	0		Effect: "Tomato Power", Effect Duration: 24, Last Available: "2007-05"
 2546	galvanized narrow half-orchid	0		Effect: "Charrrming", Effect Duration: 55, Last Available: "2007-05"
 2547	nasty tin star of the bloodbag	0		Maximum HP: +100, Stench Damage: +5, Last Available: "2007-05"
-2548	careful outrageous sombrero of the businessman	0		Monster Level: -10, Meat Drop: +50, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	careful outrageous sombrero of the businessman	0		Monster Level: -10, Meat Drop: +50, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	tumbling blue &quot;Humorous&quot; T-shirt of horror of the cheetah	0		Spooky Spell Damage: +25, Initiative: +60, Last Available: "2007-05"
 2550	purple Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2540,7 +2540,7 @@
 2567	Azazel's lollipop	0		
 2568	Azazel's tutu	0		
 2569	super-ionized adjusted huge ant agonist	0		Effect: "Expert Vacationer", Effect Duration: 53
-2570	olive huge spinning ant hoe	0		Familiar Effect: "sleaze damage, meat"
+2570	huge spinning olive ant hoe	0		Familiar Effect: "sleaze damage, meat"
 2571	ant rake	0		Familiar Effect: "hot damage, meat"
 2572	lime green huge ant pitchfork	0		Familiar Effect: "stench damage, meat"
 2573	ant sickle	0		Familiar Effect: "spooky damage, meat"
@@ -2553,7 +2553,7 @@
 2580	wobbly electrified scorpion whip of chilblains	0		Cold Damage: +25, MP Regen Min: 3, MP Regen Max: 5
 2581	squat handful of sand	0		
 2582	blurry brick of sand	0		
-2583	snack-sized flavorless enchanted centipede eggs	2	decent	Effect: "Innately Strong", Effect Duration: 40
+2583	flavorless enchanted snack-sized centipede eggs	2	decent	Effect: "Innately Strong", Effect Duration: 40
 2584	squat razor-sharp wonderwall shield	0		Weapon Damage Percent: +25, Damage Reduction: 12
 2585	flame-retardant Colonel Mustard's Lonely Spades Club Jacket	0		Hot Resistance: +1
 2586	green skewed aromatic General Sage's Lonely Diamonds Club Jacket	0		Stench Resistance: +1
@@ -2561,10 +2561,10 @@
 2588	squat Herculean Private Pepper's Lonely Hearts Club Jacket	0		Experience (Muscle): +1
 2589	spoiled hot date	4	crappy	
 2590	weak perfectly mixed squat distilled fortified wine	2	EPIC	
-2591	huge moldy wobbly tasty tart	10	crappy	
+2591	moldy huge wobbly tasty tart	10	crappy	
 2592	Knob Goblin lunchbox	0		
 2593	rotten huge spinning Knob pasty	4	crappy	
-2594	special watered-down perfectly mixed huge thermos full of Knob coffee	2	EPIC	Effect: "Bottle in front of Me", Effect Duration: 25
+2594	watered-down special perfectly mixed huge thermos full of Knob coffee	2	EPIC	Effect: "Bottle in front of Me", Effect Duration: 25
 2595	polymerized enhanced Ben-Gal&trade; Balm	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 25
 2596	tumbling leathery cat skin	0		
 2597	skewed leathery bat skin	0		
@@ -2622,18 +2622,18 @@
 2649	inspector's Lord Spookyraven's ear trumpet	0		Item Drop: +15, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	super-sized stale blue spinning S.T.L.T.	5	decent	Last Available: "2007-06"
+2652	stale super-sized blue spinning S.T.L.T.	5	decent	Last Available: "2007-06"
 2653	spoiled huge purple honey-dew	9	crappy	Last Available: "2007-06"
 2654	artisanal Xanadian	3	EPIC	Last Available: "2007-06"
-2655	alkaline colloidal twirling teal bottle of absinthe	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 43, Last Available: "2007-06"
+2655	alkaline colloidal teal twirling bottle of absinthe	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 43, Last Available: "2007-06"
 2656	upside-down Temple Grandin's Drowsy Sword of the businessman	0		Familiar Weight: +7, Meat Drop: +50
-2657	spoiled shaking lime green escargotsicle	3	crappy	Last Available: "2007-06"
-2658	mediocre triple-distilled bottle of realpagne	10	decent	Last Available: "2007-06"
+2657	spoiled lime green shaking escargotsicle	3	crappy	Last Available: "2007-06"
+2658	triple-distilled mediocre bottle of realpagne	10	decent	Last Available: "2007-06"
 2659	wobbly careful albatross necklace	0		Monster Level: -10, Single Equip, Last Available: "2007-06"
 2660	modified skewed not-a-pipe	1	awesome	Last Available: "2007-06"
 2661	perfectly mixed flask of Amontillado	3	EPIC	Last Available: "2007-06"
-2662	chilly ball mask	0		Cold Damage: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	Can-Can skirt of the detective	0		Item Drop: +20, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	chilly ball mask	0		Cold Damage: +5, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	Can-Can skirt of the detective	0		Item Drop: +20, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	triple-frozen ionized sensitive poetry journal	0		Effect: "Wasabi With You", Effect Duration: 34, Last Available: "2007-06"
 2665	activated ghostly bottled inspiration	0		Effect: "Truly Gritty", Effect Duration: 38, Last Available: "2007-06"
 2666	altered bellhop bell	0		Effect: "Human-Pirate Hybrid", Effect Duration: 15, Last Available: "2007-06"
@@ -2694,27 +2694,27 @@
 2721	inspector's Temple Grandin's Lo Pan's hand-carved staff	0		Spell Critical Percent: +30, Familiar Weight: +7, Item Drop: +15
 2722	reassuring smartaleck's Staff of the Greasefire of chilblains of temperance	0		Moxie Percent: +30, Cold Damage: +25, Spooky Resistance: +1, Sleaze Resistance: +5
 2723	twirling horrifying grievous Staff of the Grand Flamb&eacute; of temperance	0		Weapon Damage Percent: +50, Spooky Damage: +25, Sleaze Resistance: +5
-2724	decent jumbo wobbly bowl of rye sprouts	5	good	
-2725	half-sized adequate cob of corn	2	good	
+2724	jumbo decent wobbly bowl of rye sprouts	5	good	
+2725	adequate half-sized cob of corn	2	good	
 2726	bland juniper berries	3	decent	
 2727	bland plum	3	decent	
-2728	miniature rotten enchanted pear	2	crappy	Effect: "Carol of the Bones", Effect Duration: 25
+2728	enchanted rotten miniature pear	2	crappy	Effect: "Carol of the Bones", Effect Duration: 25
 2729	normal miniature peach	2	good	
-2730	spirit-forward perfectly mixed plum wine	5	EPIC	
+2730	perfectly mixed spirit-forward plum wine	5	EPIC	
 2731	artisanal shot of pear schnapps	3	EPIC	
 2732	mediocre spirit-forward red shot of peach schnapps	5	decent	
-2733	jumbo moldy yellow bunch of square grapes	5	crappy	
+2733	moldy jumbo yellow bunch of square grapes	5	crappy	
 2734	rotten jittery squat brown sugar cane	4	crappy	
 2735	big spoiled sandwich of the gods	5	crappy	
-2736	special acceptable Pan-Dimensional Gargle Blaster	3	good	Effect: "Ichorous Eyesight", Effect Duration: 30
+2736	acceptable special Pan-Dimensional Gargle Blaster	3	good	Effect: "Ichorous Eyesight", Effect Duration: 30
 2737	powdered leopard-print barbell	1	decent	
 2738	jittery pile of smoking rags	0		
 2739	anodized anodized panty raider camouflage	0		Effect: "Human-Beast Hybrid", Effect Duration: 54
 2740	Jim Carey's Staff of the Walk-In Freezer of Gandalf of terror	0		Spell Critical Percent: +20, Monster Level: +25, Spooky Spell Damage: +10
-2741	lousy fancy boilermaker	3	decent	Effect: "Your Favorite Flavor", Effect Duration: 25
+2741	fancy lousy boilermaker	3	decent	Effect: "Your Favorite Flavor", Effect Duration: 25
 2742	massive delicious steel lasagna	7	quest	
 2743	acceptable irresponsibly strong steel margarita	10	quest	
-2744	powdered ghostly maroon steel-scented air freshener	1		
+2744	powdered maroon ghostly steel-scented air freshener	1		
 2745	chilled anodized adjusted gremlin mutagen	0		Effect: "Libra Rising", Effect Duration: 52
 2746	diffused activated blurry extra-potent gremlin mutagen	0		Effect: "Tea-hee", Effect Duration: 38
 2747	squat chunk of depleted Grimacite	0		Last Available: "2011-12"
@@ -2737,7 +2737,7 @@
 2764	squat nippy Oprah's banded Order of the Silver Wossname	0		Damage Absorption: +100, Maximum MP Percent: +50, Cold Damage: +10, Single Equip
 2765	twirling Harold's bell	0		
 2766	bowling ball	0		
-2767	normal immense skewed Crimbo pie	9	good	
+2767	immense normal skewed Crimbo pie	9	good	
 2768	normal pear tart	4	good	
 2769	bland peach pie	3	decent	
 2770	enhanced blinking chunk of rock salt	0		Effect: "Just the Brown Ones", Effect Duration: 33
@@ -2772,7 +2772,7 @@
 2799	blinking censurious Mudflap-Girl Necklace of the glutton	0		Sleaze Resistance: +3, Food Drop: +100, Single Equip
 2800	dance instructor's Fonzie's Mudflap-Girl Ring	0		Experience (Moxie): +1, Experience Percent (Moxie): +10, Single Equip
 2801	bouncing vial of Gnomochloric acid	0		
-2802	blurry red flask of Gnomochloric acid	0		
+2802	red blurry flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	moist vial of hamethyst juice	0		Effect: "Texas Elegance", Effect Duration: 48
 2805	pressed activated twirling vial of baconstone juice	0		Effect: "Liquid Luck", Effect Duration: 47
@@ -2789,9 +2789,9 @@
 2816	shellacked padded Boxers of the cheetah	0		Damage Absorption: +20, Damage Reduction: 7, Initiative: +60, Familiar Effect: "1xVolley, 1xLep"
 2817	bouncing tumbling quilted stylish Brooch of dire peril	0		Moxie: +25, Weapon Damage: +20, Damage Absorption: +40, Single Equip
 2818	purple strapping Bracelet of the pedagogue of the early riser	0		Muscle: +5, Experience: +3, Adventures: +7, Single Equip
-2819	ribald Grimacite gasmask of the boozehound	0		Sleaze Damage: +10, Booze Drop: +100, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	ribald Grimacite gasmask of the boozehound	0		Sleaze Damage: +10, Booze Drop: +100, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	forbidden Grimacite gat of temperance	0		Spell Damage Percent: +50, Sleaze Resistance: +5, Last Available: "2008-11"
-2821	horrifying Grimacite gaiters of the ox	0		Muscle: +20, Spooky Damage: +25, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	horrifying Grimacite gaiters of the ox	0		Muscle: +20, Spooky Damage: +25, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	pulsating frightening extremely unsafe Grimacite gauntlets	0		Weapon Damage Percent: +100, Spooky Damage: +5, Single Equip, Last Available: "2008-11"
 2823	blurry up-at-dawn Grimacite go-go boots of the detective	0		Item Drop: +20, Adventures: +5, Single Equip, Last Available: "2008-11"
 2824	boxer's Grimacite girdle of Gandalf	0		Muscle Percent: +10, Spell Critical Percent: +20, Single Equip, Last Available: "2008-11"
@@ -2804,16 +2804,16 @@
 2831	blurry star key lime	0		
 2832	spoiled diet digital key lime pie	1	crappy	
 2833	bland half-sized star key lime pie	2	decent	
-2834	flame-wreathed occult bottle-rocket crossbow of the empath	0		Spell Damage Percent: +25, Familiar Weight: +5, Hot Spell Damage: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2834	flame-wreathed occult bottle-rocket crossbow of the empath	0		Spell Damage Percent: +25, Familiar Weight: +5, Hot Spell Damage: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	inspector's indie comic hipster glasses	0		Item Drop: +15, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	blurry mint-condition magic wand	0		Last Available: "2011-12"
 2838	bouncing fireproof wholesome glowstick	0		Maximum HP Percent: +10, Hot Resistance: +3, Last Available: "2007-08"
 2839	spinning vibrating Periodical Paintbrush	0		Maximum MP Percent: +10, Softcore Only
 2840	hand-crafted bottle of cooking sherry	3	EPIC	
-2841	diet fancy tasty packet of ketchup	1	awesome	Effect: "Tapped In", Effect Duration: 30
+2841	tasty diet fancy packet of ketchup	1	awesome	Effect: "Tapped In", Effect Duration: 30
 2842	special bad accidental cider	4	decent	Effect: "The Q Is Talking To You", Effect Duration: 5
-2843	moldy massive twirling dire fudgesicle	9	crappy	
+2843	massive moldy twirling dire fudgesicle	9	crappy	
 2844	Jeselnik's nippy lion tamer's navel ring of navel gazing of the dark arts	0		Spell Damage Percent: +100, Experience (familiar): +2, Cold Damage: +10, Sleaze Damage: +25, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	skewed class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2821,7 +2821,7 @@
 2848	Gnomitronic Hyperspatial Demodulizer	0		
 2849	shrunken navigator head	0		
 2850	perfectly mixed moonberry wine cooler	3	EPIC	
-2851	bland miniature fine aged cheddarwurst	2	decent	
+2851	miniature bland fine aged cheddarwurst	2	decent	
 2852	branch from the Great Tree	0		
 2853	shaking Phil Bunion's axe	0		
 2854	ghostly bouquet of swamp roses	0		
@@ -2910,12 +2910,12 @@
 2937	siesta-ing Casagnova gnome	0		Free Pull, Last Available: "2008-10"
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	olive unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
-2940	tiny decent Surprise Egg	1	good	
+2940	decent tiny Surprise Egg	1	good	
 2941	ionized ghostly ghostly Steal This Candy	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 40
 2942	warmed chocolate filthy lucre	0		Effect: "Hombre Muerto Caminando", Effect Duration: 51
 2943	energized colloidal Angry Farmer's Wife Candy	0		Effect: "Greasy Peasy", Effect Duration: 57
 2945	tumbling censurious aromatic party hat	0		Stench Resistance: +1, Sleaze Resistance: +3, Familiar Effect: "4xLep, cap 7"
-2946	skewed energetic occult V for Vivala mask	0		Spell Damage Percent: +25, Maximum MP Percent: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	skewed energetic occult V for Vivala mask	0		Spell Damage Percent: +25, Maximum MP Percent: +20, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	The Big Book of Pirate Insults	0		
 2948	tolerable shot of rotgut	4	good	
 2949	ionized aerosolized jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Cringle's Curative Carol", Effect Duration: 69
@@ -2938,7 +2938,7 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	denatured super-boiled Swabbie&trade; swab	0		Effect: "Cancer Rising", Effect Duration: 17
 2968	liquefied diffused enhanced Oil of Parrrlay	0		Effect: "Unusual Perspective", Effect Duration: 14
-2969	enchanted delicious creamsicle	3	awesome	Effect: "Rave Nirvana", Effect Duration: 20
+2969	delicious enchanted creamsicle	3	awesome	Effect: "Rave Nirvana", Effect Duration: 20
 2970	artisanal weak tumbling cream stout	2	EPIC	
 2971	Herculean curmudgel of the brazier	0		Experience (Muscle): +1, Hot Spell Damage: +25
 2972	mirror purple grumpy man charrrm	0		
@@ -2951,7 +2951,7 @@
 2979	super-anodized dry shaking fish-liver oil	0		Effect: "The Q Is Talking To You", Effect Duration: 42
 2980	upside-down booty chest charrrm	0		
 2981	narrow rock-hard booty chest charrrm bracelet	0		Damage Reduction: 5, Single Equip
-2982	teal narrow squat cannonball charrrm	0		
+2982	narrow teal squat cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
 2984	shaking copper ha'penny charrrm	0		
 2985	bouncing deadly copper ha'penny charrrm bracelet	0		Weapon Damage: +5
@@ -2962,7 +2962,7 @@
 2990	clingfilm cap of the storm of the overflowing toilet	0		Maximum MP Percent: +40, Stench Spell Damage: +50, Familiar Effect: "1xVolley, cap 37"
 2991	pulsating skewed smartaleck's clingfilm slippers	0		Moxie Percent: +30, Single Equip
 2992	clingfilm tangle	0		
-2993	miniature spoiled vinegar-soaked lemon slice	2	crappy	
+2993	spoiled miniature vinegar-soaked lemon slice	2	crappy	
 2994	pickled ionized wobbly true grit	0		Effect: "Flaming Weapon", Effect Duration: 49
 2995	avaricious greasy buoybottoms of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +10, Meat Drop: +30, Familiar Effect: "1xPotato, 1xLep, cap 37"
 2996	Sherlock's grungy flannel shirt	0		Item Drop: +25
@@ -2994,20 +2994,20 @@
 3022	medium stone triangle	0		
 3023	small stone triangle	0		
 3024	huge stone pyramid	0		
-3025	bad extra-dry skewed corpse on the beach	5	decent	
+3025	extra-dry bad skewed corpse on the beach	5	decent	
 3026	artisanal fancy corpsetini	4	EPIC	Effect: "Frostbeard", Effect Duration: 30
-3027	high-proof smooth jittery corpsedriver	7	awesome	
+3027	smooth high-proof jittery corpsedriver	7	awesome	
 3028	irresponsibly strong lousy Corpse Island iced tea	10	decent	
 3029	hand-crafted jittery red-headed corpse	3	EPIC	
-3030	weak delicious kamicorpse-ee	2	awesome	
-3031	acceptable enchanted corpsel	4	good	Effect: "Healthy Bronze Glow", Effect Duration: 40
+3030	delicious weak kamicorpse-ee	2	awesome	
+3031	enchanted acceptable corpsel	4	good	Effect: "Healthy Bronze Glow", Effect Duration: 40
 3032	lousy corpsebite	3	decent	
 3033	Da Vinci's pirate fledges	0		Experience (Mysticality): +5
 3034	piece of thirteen	0		
 3035	immense yummy pearl onion	9	awesome	
-3036	rotten special sea biscuit	3	crappy	Effect: "Belch the Rainbow&trade;", Effect Duration: 5
+3036	special rotten sea biscuit	3	crappy	Effect: "Belch the Rainbow&trade;", Effect Duration: 5
 3037	aged bottle of rum	3	awesome	
-3038	perfectly mixed watered-down purple bottle of black-label rum	2	EPIC	
+3038	watered-down perfectly mixed purple bottle of black-label rum	2	EPIC	
 3039	cannonball	0		
 3040	voodoo skull	0		
 3041	joke scroll	0		
@@ -3025,7 +3025,7 @@
 3053	bouncing mood ring	0		Last Available: "2007-02"
 3054	denatured pressed energized twirling candy heart	0		Effect: "Material Witness", Effect Duration: 19, Last Available: "2007-02"
 3055	quadruple-altered tumbling cymbal syrup	0		Free Pull, Effect: "Weird Vibrations", Effect Duration: 44, Last Available: "2007-02"
-3056	veiny metallic foil cat ears	0		Maximum HP: +10, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	veiny metallic foil cat ears	0		Maximum HP: +10, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	jittery nanofiber cloth	0		Last Available: "2007-12"
 3058	mirror iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3057,9 +3057,9 @@
 3085	roboduck-on-a-string of the wise owl of the pedagogue	0		Mysticality: +20, Experience: +3, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	purple forbidden Samson's biomechanical crimborg helmet	0		Experience (Muscle): +5, Spell Damage Percent: +50, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	purple forbidden Samson's biomechanical crimborg helmet	0		Experience (Muscle): +5, Spell Damage Percent: +50, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	lime green Tesla curative C.B.F.G.	0		MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2007-12"
-3090	upside-down Oprah's arcane researcher's biomechanical crimborg leg armor	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +50, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	upside-down Oprah's arcane researcher's biomechanical crimborg leg armor	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +50, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	improved pulsating vitachoconutriment capsule	0		Effect: "Chain Chain Chains", Effect Duration: 46, Last Available: "2007-12"
 3092	blue tumbling executive handmade hobby horse	0		Meat Drop: +40, Last Available: "2007-12"
 3093	ball-in-a-cup of the cheetah	0		Initiative: +60, Last Available: "2007-12"
@@ -3083,10 +3083,10 @@
 3111	ghostly Miniborg laser	0		Last Available: "2007-12"
 3112	Miniborg beeper	0		Last Available: "2007-12"
 3113	Miniborg hiveminder	0		Last Available: "2007-12"
-3114	pulsating tumbling Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
+3114	tumbling pulsating Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	squat old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	gray Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	gray Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3125,10 +3125,10 @@
 3153	El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
 3155	blue El Vibrato punchcard (176 holes)	0		
-3156	bouncing blinking El Vibrato punchcard (104 holes)	0		
+3156	blinking bouncing El Vibrato punchcard (104 holes)	0		
 3157	El Vibrato drone	0		
 3158	pulsating sparking El Vibrato drone	0		
-3159	diffused tarnished moist skewed green warm El Vibrato drone	0		Effect: "Crocodile Tear", Effect Duration: 51
+3159	diffused tarnished moist green skewed warm El Vibrato drone	0		Effect: "Crocodile Tear", Effect Duration: 51
 3160	denatured humming El Vibrato drone	0		Effect: "Ham-Fisted", Effect Duration: 21
 3161	tarnished nitrogenated activated twirling El Vibrato drone	0		Effect: "Spooky Demeanor", Effect Duration: 31
 3162	bouncing El Vibrato helmet	0		Familiar Effect: "0.5xPotato, 1xFairy"
@@ -3143,11 +3143,11 @@
 3171	nauseating reagent	0		
 3172	ghostly weightlifter's evil paper umbrella	0		Muscle: +15
 3173	denatured quadruple-diffused blinking evil vihuela	0		Effect: "Scarysauce", Effect Duration: 51
-3174	moldy jumbo evil boring spaghetti	5	crappy	
+3174	jumbo moldy evil boring spaghetti	5	crappy	
 3175	rotten shaking evil noodles	4	crappy	
 3176	decent pulsating evil noodles	4	good	
 3177	delicious small spinning evil painful penne pasta	2	awesome	
-3178	miniature adequate 3vi1 pr0n m4nic0tti	2	good	
+3178	adequate miniature 3vi1 pr0n m4nic0tti	2	good	
 3179	flavorless evil ravioli della hippy	4	decent	
 3180	decent evil noodles	3	good	
 3181	unsweetened chilled evil potion of potency	0		Effect: "Gonna Get You, Sucker", Effect Duration: 22
@@ -3158,11 +3158,11 @@
 3186	galvanized warmed evil serum of sarcasm	0		Effect: "Orchid Blood", Effect Duration: 28
 3187	quadruple-unsweetened quantum evil philter of phorce	0		Effect: "Phairly Balanced", Effect Duration: 62
 3188	practically non-alcoholic aged an evil sump'm sump'm	1	awesome	
-3189	lousy practically non-alcoholic olive evil ducha de oro	1	decent	
+3189	practically non-alcoholic lousy olive evil ducha de oro	1	decent	
 3190	weak tolerable bouncing evil horizontal tango	2	good	
 3191	hand-crafted yellow evil roll in the hay	3	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
-3193	shaking purple skewed naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
+3193	skewed purple shaking naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	up-at-dawn origami pasties	0		Adventures: +5, Softcore Only, Last Available: "2008-02"
@@ -3178,12 +3178,12 @@
 3206	shaking dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	twirling blurry dwarvish punchcard	0		
 3208	small laminated card	0		
-3209	tumbling cyan laminated card	0		
+3209	cyan tumbling laminated card	0		
 3210	notbig laminated card	0		
 3211	blinking unlarge laminated card	0		
 3212	dwarvish document	0		
 3213	dwarvish paper	0		
-3214	squat blue dwarvish parchment	0		
+3214	blue squat dwarvish parchment	0		
 3215	purple overcharged El Vibrato power sphere	0		
 3216	Fly-By-Knight Heraldry form	0		Free Pull
 3217	mirror El Vibrato Megadrone	0		
@@ -3194,7 +3194,7 @@
 3222	careful vibrating gatorskin umbrella	0		Maximum MP Percent: +10, Monster Level: -10
 3223	spinning sewer nuggets	0		
 3224	sewer wad	0		
-3225	mediocre irresponsibly strong bottle of sewage schnapps	10	decent	
+3225	irresponsibly strong mediocre bottle of sewage schnapps	10	decent	
 3226	perfectly mixed bottle of Ooze-O	3	EPIC	
 3227	stale C.H.U.M. chum	3	decent	
 3228	moldy jittery unfortunate dumplings	4	crappy	
@@ -3205,7 +3205,7 @@
 3233	yellow inflatable duck	0		
 3234	ghostly water wings	0		Wiki Name: "water wings"
 3235	ghostly noodle	0		
-3236	twirling maroon blurry Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
+3236	twirling blurry maroon Kissin' Cousins	0		Skill: "Awesome Balls of Fire"
 3237	jittery Tales from the Fireside	0		Skill: "Conjure Relaxing Campfire"
 3238	blinking Blizzards I Have Died In	0		Skill: "Snowclone"
 3239	Maxing, Relaxing	0		Skill: "Maximum Chill"
@@ -3232,7 +3232,7 @@
 3260	chilly Annie Oakley's Fonzie's Chester's moustache	0		Experience (Moxie): +1, Critical Hit Percent: +20, Cold Damage: +5, Class: "Disco Bandit", Single Equip
 3261	flame-wreathed frosty Chester's bag of candy	0		Cold Spell Damage: +10, Hot Spell Damage: +10, Class: "Disco Bandit"
 3262	skewed lightning-fast resourceful Chester's cutoffs	0		Maximum MP: +50, Initiative: +40, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	bag of Crotchety Pine saplings	0		
 3266	blue bag of Saccharine Maple saplings	0		
@@ -3248,11 +3248,11 @@
 3276	black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	frosty studded belt	0		Cold Spell Damage: +10, Last Available: "2008-04"
-3279	shaking jittery personal massager	0		Last Available: "2008-04"
+3279	jittery shaking personal massager	0		Last Available: "2008-04"
 3280	huge personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	maroon plasma ball	0		Last Available: "2008-04"
 3282	Fonzie's stick-on eyebrow piercing	0		Experience (Moxie): +1, Last Available: "2008-04"
-3283	bland narrow squat salad	3	decent	
+3283	bland squat narrow salad	3	decent	
 3284	blurry purple horrifying C.H.U.M. lantern of the ox	0		Muscle: +20, Spooky Damage: +25
 3285	C.H.U.M. knife of courage	0		Spooky Resistance: +3
 3286	steel-toed Frosty's snowball sack	0		Damage Reduction: 9
@@ -3261,11 +3261,11 @@
 3289	jittery scintillating powder	0		Class: "Pastamancer"
 3290	abandoned candy	0		
 3291	red secret tropical island volcano lair map	0		
-3292	blurry green adorable seal larva	0		
+3292	green blurry adorable seal larva	0		
 3293	huge untamable turtle	0		
 3294	narrow macaroni duck	0		
 3295	huge friendly cheez blob	0		
-3296	narrow cyan unusual disco ball	0		
+3296	cyan narrow unusual disco ball	0		
 3297	stray chihuahua	0		
 3298	twirling pretty pink bow	0		
 3299	smiley-face sticker	0		
@@ -3291,12 +3291,12 @@
 3319	brainy Mr. Joe's bangles	0		Mysticality: +5, Single Equip
 3320	skewed frosty frayed rope belt	0		Cold Spell Damage: +10, Single Equip
 3321	twirling packet of mayfly bait	0		Last Available: "2008-05"
-3322	grievous mayfly bait necklace of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	grievous mayfly bait necklace of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	wobbly Ol' Scratch's salad fork	0		
 3324	gray Frosty's frosty mug	0		
-3325	artisanal watered-down jar of fermented pickle juice	2	super ultra mega turbo EPIC	
+3325	watered-down artisanal jar of fermented pickle juice	2	super ultra mega turbo EPIC	
 3326	boiled bouncing voodoo snuff	1	decent	
-3327	half-sized flavorless extra-greasy slider	2	decent	
+3327	flavorless half-sized extra-greasy slider	2	decent	
 3328	steel-toed baleful crumpled felt fedora	0		Spell Damage: +25, Damage Reduction: 9, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	blurry battered top-hat of terror of temperance	0		Spooky Spell Damage: +10, Sleaze Resistance: +5, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	shaking shellacked shapeless wide-brimmed hat of incineration	0		Damage Reduction: 7, Hot Spell Damage: +50, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	MacGyver's hardened dead guy's memento	0		Damage Reduction: 3, Maximum MP: +100, Single Equip
-3338	stale huge fancy purple banquet	10	decent	Effect: "Meat the Flintstones", Effect Duration: 50
+3338	huge fancy stale purple banquet	10	decent	Effect: "Meat the Flintstones", Effect Duration: 50
 3339	shaking sharpened hubcap	0		
 3340	teal very caltrop	0		
 3341	blinking The Six-Pack of Pain	0		
@@ -3323,7 +3323,7 @@
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	twirling zen motorcycle	0		Last Available: "2008-06"
 3353	cold-filtered shaking llama lama gong	0		Effect: "Black Lung", Effect Duration: 37, Last Available: "2008-06"
-3354	bland small banana-frosted king cake	2	decent	Last Available: "2008-08"
+3354	small bland banana-frosted king cake	2	decent	Last Available: "2008-08"
 3355	brown plastic baby of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2008-08"
 3356	blinking plump juicy grub	0		Last Available: "2008-06"
 3357	tumbling shimmering moth	0		Last Available: "2008-06"
@@ -3343,7 +3343,7 @@
 3371	boiled blinking glimmering buzzard feather	1		Last Available: "2008-06"
 3372	boiled ghostly glimmering raven feather	1		Last Available: "2008-06"
 3373	vaporized tumbling blurry glimmering great tit feather	1		Last Available: "2008-06"
-3374	twirling green house of twigs and spit	0		Last Available: "2008-06"
+3374	green twirling house of twigs and spit	0		Last Available: "2008-06"
 3375	twirling The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
 3376	Benetton's Medley of Diversity	0		Skill: "Benetton's Medley of Diversity"
 3377	shaking Elron's Explosive Etude	0		Skill: "Elron's Explosive Etude"
@@ -3357,7 +3357,7 @@
 3385	blue shellacked brainy Chester's Aquarius medallion	0		Mysticality: +5, Damage Reduction: 7, Single Equip
 3386	beefcake's Zombo's shoulder blade of the glutton	0		Muscle: +25, Food Drop: +100
 3387	gray Zombo's skull ring of the wise owl of doom	0		Mysticality: +20, Spooky Spell Damage: +50, Single Equip
-3388	wobbly narrow Zombo's empty eye	0		
+3388	narrow wobbly Zombo's empty eye	0		
 3389	spinning greasy Frosty's arm of dire peril	0		Weapon Damage: +20, Sleaze Spell Damage: +10
 3390	auspicious Staff of the Deepest Freeze of chilblains of the boozehound	0		Cold Damage: +25, Item Drop: +10, Booze Drop: +100
 3391	Frosty's iceball	0		
@@ -3368,7 +3368,7 @@
 3396	upside-down gravedigger's ruddy Hodgman's lobsterskin pants	0		Maximum HP Percent: +40, Spooky Damage: +10, Familiar Effect: "atk, 1xPotato"
 3397	boxer's brainy Hodgman's bow tie	0		Mysticality: +5, Muscle Percent: +10, Single Equip
 3398	hand-crafted narrow Hodgman's blanket	4	EPIC	
-3399	smooth triple-distilled wobbly jar of squeeze	10	awesome	
+3399	triple-distilled smooth wobbly jar of squeeze	10	awesome	
 3400	snack-sized normal bowl of fishysoisse	2	good	
 3401	modified deadly lampshade	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 45
 3402	polarized concentrated garbage juice	0		Effect: "Coated Arms", Effect Duration: 39
@@ -3381,17 +3381,17 @@
 3409	maroon slick Hodgman's garbage sticker	0		Moxie: +10
 3410	stiffened Hodgman's detector	0		Damage Reduction: 1
 3411	cool Hodgman's cane	0		Moxie: +5
-3412	blinking upside-down Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
+3412	upside-down blinking Hodgman's journal #1: The Lean Times	0		Skill: "Natural Born Scrabbler"
 3413	Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	skewed Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	twirling hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	electrified blurry sterno-flavored Hob-O	0		Effect: "New and Improved", Effect Duration: 20
 3423	non-warmed frostbite-flavored Hob-O	0		Effect: "Chorale of Companionship", Effect Duration: 69
 3424	pickled polarized corrupted fry-oil-flavored Hob-O	0		Effect: "Saucegoggles", Effect Duration: 19
 3425	diffused jittery garbage-juice-flavored Hob-O	0		Effect: "Top Dog", Effect Duration: 25
-3426	enhanced non-chilled quantum jittery teal strawberry-flavored Hob-O	0		Effect: "Resilient Spirit", Effect Duration: 33
+3426	enhanced non-chilled quantum teal jittery strawberry-flavored Hob-O	0		Effect: "Resilient Spirit", Effect Duration: 33
 3427	roll of Hob-Os	0		
 3428	adjusted altered Everlasting Deckswabber	0		Effect: "Smokin'", Effect Duration: 20
 3430	bindle of joy	0		
@@ -3430,15 +3430,15 @@
 3463	mediocre bottle of sake	4	decent	
 3464	upside-down baleful round pebble	0		Spell Damage: +25
 3465	low-calorie normal Bash-&#332;s cereal	1	good	Wiki Name: "Bash-Os cereal"
-3466	up-at-dawn MacGyver's arcane researcher's haiku katana	0		Experience Percent (Mysticality): +10, Maximum MP: +100, Adventures: +5, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	up-at-dawn MacGyver's arcane researcher's haiku katana	0		Experience Percent (Mysticality): +10, Maximum MP: +100, Adventures: +5, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	Jim Carey's plastic baby	0		Monster Level: +25, Single Equip, Last Available: "2008-12"
 3469	normal small blueberry-frosted king cake	2	good	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
-3471	shaking squat damp boot	0		
+3471	squat shaking damp boot	0		
 3472	lard-coated hardy educational Seasonal Beret	0		Experience: +1, Maximum HP: +50, Sleaze Spell Damage: +25, Familiar Effect: "1xPotato, 1xFairy, cap 25"
 3473	Bash-&#332;s boxtop	0		Wiki Name: "Bash-Os boxtop"
-3474	liquefied maroon blurry cranberry cordial	0		Effect: "Funky Coal Patina", Effect Duration: 39
+3474	liquefied blurry maroon cranberry cordial	0		Effect: "Funky Coal Patina", Effect Duration: 39
 3475	flattened denatured blackberry polite	0		Effect: "Spiky Hair", Effect Duration: 53
 3476	galvanized wet narrow plum lozenge	0		Effect: "damage.enh", Effect Duration: 44
 3477	super-alkaline activated huge pear lozenge	0		Effect: "Spiky Hair", Effect Duration: 62
@@ -3461,19 +3461,19 @@
 3494	shaking brawny fish bazooka of Flo-Jo	0		Muscle Percent: +20, Initiative: +100
 3495	frozen sea salt crystal	0		Effect: "Ack!  Barred!", Effect Duration: 39
 3496	wet bazookafish bubble gum	0		Effect: "Dance Interpreter", Effect Duration: 18
-3497	watered-down hand-crafted bottle of Pete's Sake	2	EPIC	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3501	stale low-calorie squat canap&eacute;s	1	decent	
+3497	hand-crafted watered-down bottle of Pete's Sake	2	EPIC	
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3501	low-calorie stale squat canap&eacute;s	1	decent	
 3502	altered pulsating olive thermos of brew	1	decent	Effect: "Berry Statistical", Effect Duration: 20, Last Available: "2011-12"
 3503	tolerable glass of brandy	4	good	Last Available: "2011-12"
 3504	French slippers	0		
 3505	upside-down LWA ring of the sweet-tooth	0		Candy Drop: +100
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	pulsating Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	pulsating Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	maroon scratch 'n' sniff sword of the early riser	0		Adventures: +7, Last Available: "2008-11"
-3509	ghostly jittery tumbling red scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
+3509	jittery ghostly red tumbling scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	jittery scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
 3511	scratch 'n' sniff UPC sticker	0		Meat Drop: +25, Last Available: "2008-11"
 3512	scratch 'n' sniff wrestler sticker	0		Muscle Percent: +10, Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2008-11"
@@ -3497,7 +3497,7 @@
 3530	tumbling mutant gila monster egg	0		
 3531	rattlesnake enrager	0		Familiar Weight: +5
 3532	ant antidepressant	0		Familiar Weight: +5
-3533	green tumbling cactus monocle	0		Familiar Weight: +5
+3533	tumbling green cactus monocle	0		Familiar Weight: +5
 3534	red Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
 3536	teal plans for depleted Grimacite gravy boat	0		Recipe: "depleted Grimacite gravy boat"
@@ -3510,28 +3510,28 @@
 3543	Sherlock's flame-retardant depleted Grimacite gravy boat	0		Hot Resistance: +1, Item Drop: +25, Last Available: "2011-12"
 3544	Sinatra's depleted Grimacite weightlifting belt of temperance	0		Experience (Moxie): +5, Sleaze Resistance: +5, Single Equip, Last Available: "2011-12"
 3545	Socratic depleted Grimacite grappling hook of the cougar	0		Moxie: +20, Experience (Mysticality): +1, Single Equip, Last Available: "2011-12"
-3546	hardy depleted Grimacite ninja mask of temperance	0		Maximum HP: +50, Sleaze Resistance: +5, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	fuchsia frightening depleted Grimacite shinguards of Gandalf	0		Spell Critical Percent: +20, Spooky Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	hardy depleted Grimacite ninja mask of temperance	0		Maximum HP: +50, Sleaze Resistance: +5, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	fuchsia frightening depleted Grimacite shinguards of Gandalf	0		Spell Critical Percent: +20, Spooky Damage: +5, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	scorching Fonzie's depleted Grimacite astrolabe	0		Experience (Moxie): +1, Hot Damage: +25, Single Equip, Last Available: "2011-12"
 3549	olive up-at-dawn rock-hard KoL Con Cinco Pi&ntilde;ata Bat	0		Damage Reduction: 5, Adventures: +5, Softcore Only, Last Available: "2008-09"
 3550	lard-coated propeller beanie	0		Sleaze Spell Damage: +25, Familiar Effect: "atk, cap 7"
 3551	double-paned foul-smelling healthy straw hat	0		Maximum HP Percent: +20, Stench Damage: +10, Cold Resistance: +5, Familiar Effect: "1xFairy"
 3552	Annie Oakley's supercharged octopus's spade of incineration	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Hot Spell Damage: +50
-3553	maroon twirling soggy seed packet	0		
+3553	twirling maroon soggy seed packet	0		
 3554	skewed glob of slime	0		
 3555	rotten sea carrot	3	crappy	
 3556	low-calorie normal sea cucumber	1	good	
-3557	spoiled big ghostly sea avocado	5	crappy	
+3557	big spoiled ghostly sea avocado	5	crappy	
 3558	moldy half-sized huge sea lychee	2	crappy	
-3559	big rotten blurry shaking sea tangelo	5	crappy	
-3560	bite-sized special normal sea honeydew	1	good	Effect: "Gamer Rage", Effect Duration: 5
+3559	rotten big blurry shaking sea tangelo	5	crappy	
+3560	special normal bite-sized sea honeydew	1	good	Effect: "Gamer Rage", Effect Duration: 5
 3561	electrified tumbling pressurized potion of puissance	0		Effect: "Human-Goblin Hybrid", Effect Duration: 60
 3562	chilled pressurized potion of perspicacity	0		Effect: "Joy", Effect Duration: 62
 3563	unsweetened deionized maroon pressurized potion of pulchritude	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 46
-3564	mediocre practically non-alcoholic green berry-infused sake	1	decent	
+3564	practically non-alcoholic mediocre green berry-infused sake	1	decent	
 3565	mediocre citrus-infused sake	4	decent	
 3566	artisanal bouncing melon-infused sake	4	EPIC	
-3567	shaking cyan slab of sponge	0		
+3567	cyan shaking slab of sponge	0		
 3568	skewed razor-sharp sponge helmet of the pedagogue of the overflowing toilet	0		Experience: +3, Weapon Damage Percent: +25, Stench Spell Damage: +50, Familiar Effect: "atk, 1xFairy"
 3569	personal trainer's boxer's spongy shield of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Experience Percent (Muscle): +10, Damage Reduction: 14
 3570	wobbly avaricious censurious dangerous square sponge pants	0		Weapon Damage: +10, Sleaze Resistance: +3, Meat Drop: +30, Familiar Effect: "hot atk, 1xPotato"
@@ -3545,17 +3545,17 @@
 3578	skewed candy cornucopia	0		Free Pull, Last Available: "2011-12"
 3579	yellow ballet slippers	0		Familiar Weight: +5, Last Available: "2008-12"
 3580	wriggling flytrap pellet	0		
-3581	narrow ghostly blue sushi-rolling mat	0		
+3581	narrow blue ghostly sushi-rolling mat	0		
 3582	spoiled rice	3	crappy	
-3584	miniature adequate irradiated candy cane	2	good	Last Available: "2008-12"
-3585	bland miniature gingerbread mutant bugbear	2	decent	Last Available: "2008-12"
+3584	adequate miniature irradiated candy cane	2	good	Last Available: "2008-12"
+3585	miniature bland gingerbread mutant bugbear	2	decent	Last Available: "2008-12"
 3586	perfectly mixed oozenog	4	EPIC	Last Available: "2008-12"
 3587	alkaline double-chilled sugar plum	0		Effect: "Salt Rockin'", Effect Duration: 12, Last Available: "2008-12"
 3588	double-aerosolized sugar banana	0		Effect: "Aquarius Rising", Effect Duration: 30, Last Available: "2008-12"
 3589	irradiated wobbly sugar lime	0		Effect: "Mercenary", Effect Duration: 36, Last Available: "2008-12"
 3590	frozen concentrated blurry sugar cherry	0		Effect: "On a Roll", Effect Duration: 12, Last Available: "2008-12"
 3591	ghostly sage brainy Mer-kin hookspear	0		Mysticality: +5, Mysticality Percent: +10
-3592	skewed green Mer-kin takebag	0		Item Drop: +5
+3592	green skewed Mer-kin takebag	0		Item Drop: +5
 3593	yellow Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	quadruple-flattened ionized huge Mer-kin fastjuice	0		Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 13
@@ -3581,15 +3581,15 @@
 3615	wobbly rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	chilled unstable DNA	0		Effect: "Amorous Avarice", Effect Duration: 22, Last Available: "2008-12"
-3618	teal The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	teal The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	mirror wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	cyan pair of twitching claws	0		Last Available: "2008-12"
 3622	squat gnashing teeth	0		Last Available: "2008-12"
 3623	squat chitinous pod	0		Last Available: "2008-12"
 3624	squat Newton's parasitic claw	0		Experience (Mysticality): +3, Last Available: "2008-12"
-3625	sage parasitic tentacles	0		Mysticality Percent: +10, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	maroon parasitic headgnawer of the cheetah	0		Initiative: +60, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	sage parasitic tentacles	0		Mysticality Percent: +10, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	maroon parasitic headgnawer of the cheetah	0		Initiative: +60, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	parasitic strangleworm of Leguizamo	0		Monster Level: +20, Last Available: "2008-12"
 3628	skewed pair of ragged claws	0		Last Available: "2008-12"
 3629	blurry burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,23 +3598,23 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	perfumed elven socks of terror	0		Spooky Spell Damage: +10, Stench Resistance: +5, Last Available: "2008-12"
 3634	personal trainer's elven gloves of the early riser	0		Experience Percent (Muscle): +10, Adventures: +7, Last Available: "2008-12"
-3635	festive holiday hat of the empath of the detective	0		Familiar Weight: +5, Item Drop: +20, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	festive holiday hat of the empath of the detective	0		Familiar Weight: +5, Item Drop: +20, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	personal trainer's patent shoes of extreme caution	0		Experience Percent (Muscle): +10, Monster Level: -25, Last Available: "2008-12"
 3637	pulsating spinning zippy coward's gray bow tie	0		Monster Level: -20, Initiative: +20, Last Available: "2008-12"
 3638	ruddy penguin thesaurus of the dark arts	0		Spell Damage Percent: +100, Maximum HP Percent: +40, Last Available: "2008-12"
-3639	jumbo delicious blob-shaped Crimbo cookie	5	awesome	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
+3639	delicious jumbo blob-shaped Crimbo cookie	5	awesome	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
 3640	seaweed	0		
 3641	jamfish jam	0		
 3642	olive dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	teal rock-hard depleted Grimacite kneecapping stick	0		Damage Reduction: 5, Last Available: "2007-06"
 3645	drinkable practically non-alcoholic canteen of wine	1	good	Last Available: "2008-12"
-3646	low-calorie spoiled elven <i>limbos</i> gingerbread	1	crappy	Last Available: "2008-12"
+3646	spoiled low-calorie elven <i>limbos</i> gingerbread	1	crappy	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	pulsating map to Madness Reef	0		
 3650	normal bite-sized skewed toast with jam	1	good	Last Available: "2008-12"
-3651	tumbling antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	tumbling antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	acceptable elven moonshine	3	good	Last Available: "2008-12"
 3653	big adequate knuckle sandwich	5	good	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	Annie Oakley's hardy psycho sweater	0		Maximum HP: +50, Critical Hit Percent: +20, Last Available: "2008-12"
@@ -3625,10 +3625,10 @@
 3659	wobbly rock-hard plastic strand of DNA	0		Damage Reduction: 5, Last Available: "2008-12"
 3660	boxer's plastic chunk of depleted Grimacite	0		Muscle Percent: +10, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	bouncing Putty mitre of doom	0		Spooky Spell Damage: +50, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	frosty curative Putty leotard	0		Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	bouncing Putty mitre of doom	0		Spooky Spell Damage: +50, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	frosty curative Putty leotard	0		Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	pulsating lightning-fast Putty ball	0		Initiative: +40, Softcore Only, Last Available: "2009-01"
-3665	ghostly blue Putty sheet	0		Last Available: "2009-01"
+3665	blue ghostly Putty sheet	0		Last Available: "2009-01"
 3666	pulsating toasty chaotic brawny Putty snake	0		Muscle Percent: +20, Spell Critical Percent: +10, Hot Damage: +5, Softcore Only, Last Available: "2009-01"
 3667	huge Putty monster	0		Last Available: "2009-01"
 3668	toasty dangerous glow-in-the-dark wristwatch	0		Weapon Damage: +10, Hot Damage: +5, Single Equip, Last Available: "2009-01"
@@ -3647,15 +3647,15 @@
 3681	bubbling tempura batter	0		
 3682	globe of Deep Sauce	0		
 3683	map to the Marinara Trench	0		
-3684	bland enchanted spinning tempura carrot	3	decent	Effect: "Squid Squint", Effect Duration: 5
+3684	enchanted bland spinning tempura carrot	3	decent	Effect: "Squid Squint", Effect Duration: 5
 3685	adequate tempura cucumber	3	good	
-3686	adequate half-sized pulsating gray tempura avocado	2	good	
+3686	half-sized adequate gray pulsating tempura avocado	2	good	
 3687	decent sea broccoli	3	good	
 3688	adequate sea cauliflower	3	good	
 3689	spoiled tempura broccoli	3	crappy	
 3690	miniature normal tempura cauliflower	2	good	
 3691	decent blurry sea blueberry	3	good	
-3692	immense fancy delicious narrow ghostly sea persimmon	9	awesome	Effect: "Banono", Effect Duration: 40
+3692	delicious fancy immense narrow ghostly sea persimmon	9	awesome	Effect: "Banono", Effect Duration: 40
 3693	quadruple-pickled pressurized potion of perception	0		Effect: "Abyssal Blood", Effect Duration: 33
 3694	deionized ionized pressurized potion of proficiency	0		Effect: "Brother Smothers's Blessing", Effect Duration: 22
 3695	huge hardened Mer-kin digpick	0		Damage Reduction: 3
@@ -3714,11 +3714,11 @@
 3749	warmed concoction of clumsiness	0		Effect: "Cold as Ice", Effect Duration: 13
 3750	chaotic vampire pearl earring	0		Spell Critical Percent: +10, Single Equip
 3751	bland fuchsia chocolate chip brownies	4	decent	
-3753	upside-down Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
-3754	pickled alkaline wobbly tumbling olive love song of vague ambiguity	0		Effect: "Sugar High", Effect Duration: 44, Last Available: "2009-02"
+3753	upside-down Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3754	pickled alkaline wobbly olive tumbling love song of vague ambiguity	0		Effect: "Sugar High", Effect Duration: 44, Last Available: "2009-02"
 3755	activated super-pickled olive love song of smoldering passion	0		Effect: "Can Has Cyborger", Effect Duration: 43, Last Available: "2009-02"
 3756	adjusted diffused love song of icy revenge	0		Effect: "Gummiskin", Effect Duration: 19, Last Available: "2009-02"
-3757	adjusted huge squat love song of sugary cuteness	0		Effect: "Sugary Tongue", Effect Duration: 14, Last Available: "2009-02"
+3757	adjusted squat huge love song of sugary cuteness	0		Effect: "Sugary Tongue", Effect Duration: 14, Last Available: "2009-02"
 3758	polymerized wet squat love song of disturbing obsession	0		Effect: "Cancer Rising", Effect Duration: 30, Last Available: "2009-02"
 3759	unsweetened love song of naughty innuendo	0		Effect: "Flexibili Tea", Effect Duration: 25, Last Available: "2009-02"
 3760	dry ghostly breath mint	0		Effect: "Ruby-ous", Effect Duration: 59
@@ -3726,16 +3726,16 @@
 3762	shaking lime green Sinatra's vampire pearl necklace	0		Experience (Moxie): +5, Single Equip
 3763	mediocre squat slug of vodka	3	decent	
 3764	hand-crafted purple slug of rum	3	EPIC	
-3765	drinkable irresponsibly strong slug of shochu	10	good	
-3766	delicious watered-down screwdiver	2	awesome	
+3765	irresponsibly strong drinkable slug of shochu	10	good	
+3766	watered-down delicious screwdiver	2	awesome	
 3767	mediocre ghostly dew yoana lei	4	decent	
 3768	hand-crafted squat lychee chuhai	3	EPIC	
-3769	irresponsibly strong tolerable salacious screwdiver	8	good	
+3769	tolerable irresponsibly strong salacious screwdiver	8	good	
 3770	artisanal dew yoana salacious lei	4	EPIC	
 3771	hand-crafted salacious lychee chuhai	3	EPIC	
-3772	drinkable practically non-alcoholic teal mirror Alewife&trade; Ale	1	good	
+3772	practically non-alcoholic drinkable mirror teal Alewife&trade; Ale	1	good	
 3773	maroon seaode	0		
-3774	bouncing mirror map to the Dive Bar	0		
+3774	mirror bouncing map to the Dive Bar	0		
 3775	Mer-kin pinkslip	0		
 3776	frosty occult pink pinkslip slip	0		Spell Damage Percent: +25, Cold Spell Damage: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3777	horrifying lion tamer's sea salt scrubs	0		Experience (familiar): +2, Spooky Damage: +25
@@ -3753,17 +3753,17 @@
 3789	pulsating twitching trigger finger	0		Class: "Pastamancer"
 3799	Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	squat blinking crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	blinking squat crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	upside-down blue miser's asbestos-lined toasty Mer-kin roundshield	0		Hot Damage: +5, Hot Resistance: +5, Meat Drop: +10, Damage Reduction: 14
 3804	flame-retardant steel-toed Mer-kin breastplate	0		Damage Reduction: 9, Hot Resistance: +1
 3805	pulsating ruddy Mer-kin sneakmask of the storm	0		Maximum HP Percent: +40, Maximum MP Percent: +40, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
 3807	galvanized twirling Mer-kin hidepaint	0		Effect: "Magically Fingered", Effect Duration: 55
 3808	upside-down Mer-kin trailmap	0		
-3809	fuchsia skewed Mer-kin healscroll	0		
+3809	skewed fuchsia Mer-kin healscroll	0		
 3810	twirling Mer-kin lockkey	0		
-3811	bouncing tumbling Mer-kin stashbox	0		
+3811	tumbling bouncing Mer-kin stashbox	0		
 3812	rotten chocolate-frosted king cake	3	crappy	Last Available: "2009-06"
 3813	ghostly sharpshooter's plastic baby	0		Critical Hit Percent: +10, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
@@ -3785,9 +3785,9 @@
 3831	hand-crafted gray bouncing Typical Tavern swill	3	EPIC	
 3832	tolerable mirror tropical swill	3	good	
 3833	mediocre fruity girl swill	3	decent	
-3834	mediocre triple-distilled maroon blended swill	8	decent	
+3834	triple-distilled mediocre maroon blended swill	8	decent	
 3835	costume wardrobe	0		Softcore Only
-3836	upside-down lard-coated smooth Elvish sunglasses of the sweet-tooth	0		Moxie: +15, Sleaze Spell Damage: +25, Item Drop: +5, Candy Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	upside-down lard-coated smooth Elvish sunglasses of the sweet-tooth	0		Moxie: +15, Sleaze Spell Damage: +25, Item Drop: +5, Candy Drop: +100, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	electrified anniversary safety glass vest	0		MP Regen Min: 3, MP Regen Max: 5
 3838	fortified anniversary burlap belt	0		Damage Absorption: +60
 3839	hardy anniversary balsa wood socks	0		Maximum HP: +50
@@ -3821,7 +3821,7 @@
 3867	lard-coated strapping magilaser blastercannon	0		Muscle: +5, Sleaze Spell Damage: +25
 3868	ghostly zippy hanky&#363; of doom	0		Spooky Spell Damage: +50, Initiative: +20, Wiki Name: "frigid hankyu"
 3869	medical-grade ultimate ultimate frisbee of Tarzan	0		Experience (Muscle): +3, HP Regen Min: 7, HP Regen Max: 10
-3870	huge narrow stolen office supplies	0		
+3870	narrow huge stolen office supplies	0		
 3871	up-at-dawn office-supply crossbow of the bloodbag	0		Maximum HP: +100, Adventures: +5
 3872	spinning vibrating pocket theremin	0		Maximum MP Percent: +10
 3873	supercharged rave whistle of the brute	0		Muscle Percent: +30, Maximum MP Percent: +30
@@ -3847,10 +3847,10 @@
 3893	dry teal vial of chartreuse slime	0		Effect: "Hot Hands", Effect Duration: 57
 3894	adjusted triple-energized upside-down huge vial of teal slime	0		Effect: "Meadulla Oblongota", Effect Duration: 13
 3895	irradiated vial of indigo slime	0		Effect: "Worth Your Salt", Effect Duration: 38
-3896	quadruple-improved activated skewed maroon vial of slime	0		Effect: "Norwhalloped", Effect Duration: 62
+3896	quadruple-improved activated maroon skewed vial of slime	0		Effect: "Norwhalloped", Effect Duration: 62
 3897	flattened vial of brown slime	0		Effect: "Industrial Strength Starch", Effect Duration: 38
 3898	fuchsia bottle of G&uuml;-Gone	0		
-3901	bouncing squat seal-blubber candle	0		Class: "Seal Clubber"
+3901	squat bouncing seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
 3903	pulsating figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
@@ -3948,7 +3948,7 @@
 3996	shaking boxcar turtle	0		
 3997	dolphin whistle	0		
 3998	metrognome	0		Familiar Weight: +5
-3999	shaking pulsating infant sandworm	0		Free Pull, Last Available: "2011-12"
+3999	pulsating shaking infant sandworm	0		Free Pull, Last Available: "2011-12"
 4000	string of dingle balls	0		Familiar Weight: +5, Last Available: "2011-12"
 4001	distilled wobbly agua de vida	1	EPIC	Last Available: "2009-06"
 4002	Annie Oakley's tortoboggan shield of the wise owl	0		Mysticality: +20, Critical Hit Percent: +20, Damage Reduction: 6
@@ -3982,40 +3982,40 @@
 4030	skewed memory of a small stone block	0		Last Available: "2009-06"
 4031	memory of a stone block	0		Last Available: "2009-06"
 4032	yellow blinking memory of half a stone circle	0		Last Available: "2009-06"
-4033	mirror upside-down memory of a stone half-circle	0		Last Available: "2009-06"
+4033	upside-down mirror memory of a stone half-circle	0		Last Available: "2009-06"
 4034	bouncing mirror memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	upside-down caustic slime nodule	0		
-4037	small adequate bouncing slimy sweetbreads	2	good	
-4038	strong acceptable slimy fermented bile bladder	5	good	
+4037	adequate small bouncing slimy sweetbreads	2	good	
+4038	acceptable strong slimy fermented bile bladder	5	good	
 4039	mixed skewed slimy alveolus	1		Effect: "Rampage!", Effect Duration: 25
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	Rosewater's pig-iron helm of the blizzard	0		Mysticality Percent: +30, Cold Spell Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	electrified pig-iron shinguards of the wise owl	0		Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	Rosewater's pig-iron helm of the blizzard	0		Mysticality Percent: +30, Cold Spell Damage: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	electrified pig-iron shinguards of the wise owl	0		Mysticality: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	avaricious pig-iron bracers of the boozehound	0		Meat Drop: +30, Booze Drop: +100, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	narrow wumpus-hair bolo	0		Last Available: "2009-06"
 4046	purple wumpus-hair net	0		Last Available: "2009-06"
 4047	Rosewater's wumpus-hair whip	0		Mysticality Percent: +30, Last Available: "2009-06"
-4048	narrow wizardly wumpus-hair wig of the pedagogue of the sewer	0		Mysticality: +25, Experience: +3, Stench Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	knitted supercool wumpus-hair loincloth of courage	0		Moxie Percent: +20, Cold Resistance: +3, Spooky Resistance: +3, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	narrow wizardly wumpus-hair wig of the pedagogue of the sewer	0		Mysticality: +25, Experience: +3, Stench Damage: +25, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	knitted supercool wumpus-hair loincloth of courage	0		Moxie Percent: +20, Cold Resistance: +3, Spooky Resistance: +3, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	smelly wumpus-hair sweater of the glutton	0		Stench Spell Damage: +10, Food Drop: +100, Last Available: "2009-06"
 4051	lightning-fast ring of teleportation	0		Initiative: +40, Single Equip
 4052	wobbly glass of baboon milk	1	awesome	Last Available: "2009-06"
 4053	fancy wobbly banana milkshake	1	decent	Effect: "Big", Effect Duration: 30, Last Available: "2009-06"
-4054	perfectly mixed spinning narrow White Hyborian	4	EPIC	Last Available: "2009-06"
+4054	perfectly mixed narrow spinning White Hyborian	4	EPIC	Last Available: "2009-06"
 4055	greedy goblin hunting spear	0		Meat Drop: +20, Last Available: "2009-06"
 4056	clever goblin autoblowgun of vim and vigor	0		Maximum HP Percent: +50, Maximum MP: +20, Last Available: "2009-06"
 4057	blurry spinning mirror tribal beads of the brute	0		Muscle Percent: +30, Last Available: "2009-06"
 4058	executive forbidden stone fist	0		Spell Damage Percent: +50, Meat Drop: +40, Last Available: "2009-06"
 4059	olive stone head of courage	0		Spooky Resistance: +3, Damage Reduction: 5, Last Available: "2009-06"
-4060	skewed ghostly Indigo Party Invitation	0		Last Available: "2009-06"
+4060	ghostly skewed Indigo Party Invitation	0		Last Available: "2009-06"
 4061	blue Violet Hunt Invitation	0		Last Available: "2009-06"
 4062	Blue Milk Club Card	0		Last Available: "2009-06"
 4063	Mecha Mayhem Club Card	0		Last Available: "2009-06"
 4064	'Smuggler Shot First' Button	0		Last Available: "2009-06"
 4065	Spacefleet Communicator Badge	0		Last Available: "2009-06"
-4066	yellow blurry Ruby Rod	0		Last Available: "2009-06"
+4066	blurry yellow Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
 4068	shaking essence of kink	0		Last Available: "2009-06"
 4069	mirror essence of	0		Last Available: "2009-06"
@@ -4032,14 +4032,14 @@
 4080	therapeutic Socratic grisly shield	0		Experience (Mysticality): +1, HP Regen Min: 5, HP Regen Max: 7, Slime Hates It: +1, Damage Reduction: 13
 4081	smelly frosty corroded breeches	0		Cold Spell Damage: +10, Stench Spell Damage: +10, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	jittery Jack Frost's pernicious cudgel of the wise owl	0		Mysticality: +20, Cold Spell Damage: +50, Slime Hates It: +1
-4083	adequate massive cupcake-in-a-cup	7	good	Last Available: "2009-06"
+4083	massive adequate cupcake-in-a-cup	7	good	Last Available: "2009-06"
 4084	squat pool of liquid	0		Last Available: "2009-06"
 4085	rotten wobbly protein paste	3	crappy	Last Available: "2009-06"
 4086	lightning-fast flame-retardant cyber-mattock	0		Hot Resistance: +1, Initiative: +40, Last Available: "2009-06"
 4087	skewed facehugging alien	0		Last Available: "2009-06"
 4088	pulsating X-37 gun	0		Last Available: "2009-06"
 4089	galvanized non-colloidal huge wobbly neurostim pill	0		Effect: "Hairy Palms", Effect Duration: 49, Last Available: "2009-06"
-4090	anodized chilled teal tumbling physiostim pill	0		Effect: "Boilermade", Effect Duration: 23, Last Available: "2009-06"
+4090	anodized chilled tumbling teal physiostim pill	0		Effect: "Boilermade", Effect Duration: 23, Last Available: "2009-06"
 4091	skewed mirror slimy cyst	0		
 4092	small slimy cyst	0		
 4093	twirling medium slimy cyst	0		
@@ -4081,11 +4081,11 @@
 4129	cyan mansplainer's wholesome hardened slime belt of the bloodbag	0		Maximum HP Percent: +10, Maximum HP: +100, Monster Level: +15, Single Equip
 4130	empty agua de vida bottle	0		Last Available: "2009-06"
 4131	mixed boot plant	1	good	Effect: "Alpine Mintiness", Effect Duration: 30, Last Available: "2009-06"
-4132	perfectly mixed triple-distilled sham champagne	8	EPIC	Last Available: "2009-06"
+4132	triple-distilled perfectly mixed sham champagne	8	EPIC	Last Available: "2009-06"
 4133	energized vacuum-sealed jittery cyan tempura air	0		Effect: "Strange Mental Acuity", Effect Duration: 32
 4134	improved pressurized potion of pneumaticity	0		Effect: "Feline Ferocity", Effect Duration: 36
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	family-friendly frightening Bag o' Tricks of extreme caution of terror	0		Monster Level: -25, Spooky Damage: +5, Spooky Spell Damage: +10, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	family-friendly frightening Bag o' Tricks of extreme caution of terror	0		Monster Level: -25, Spooky Damage: +5, Spooky Spell Damage: +10, Sleaze Resistance: +1, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	purple slime stack	0		
 4138	a rumpled paper strip	0		
 4139	a creased paper strip	0		
@@ -4104,7 +4104,7 @@
 4152	enhanced pickled twirling Elvish delight	0		Effect: "Wit Tea", Effect Duration: 18
 4153	squat rockfish stomach	0		Last Available: "2009-09"
 4154	live lobster	0		Last Available: "2011-12"
-4155	ghostly blurry wok lobster	0		Last Available: "2011-12"
+4155	blurry ghostly wok lobster	0		Last Available: "2011-12"
 4156	pulsating pebbles	0		Last Available: "2009-09"
 4157	gravel	0		Last Available: "2009-09"
 4158	upside-down rock	0		Last Available: "2009-09"
@@ -4126,12 +4126,12 @@
 4174	prompt rock necklace	0		Adventures: +3, Single Equip
 4175	huge spaghetti cult robe	0		
 4176	fuchsia sugar sheet	0		Last Available: "2009-09"
-4177	mirror squat Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
+4177	squat mirror Tome of Sugar Shummoning	0		Free Pull, Skill: "Summon Sugar Sheets"
 4178	ghostly sugar shotgun of the businessman	0		Meat Drop: +50, Last Available: "2009-09"
 4179	shellacked sugar shillelagh	0		Damage Reduction: 7, Last Available: "2009-09"
 4180	narrow chilly sugar shank	0		Cold Damage: +5, Last Available: "2009-09"
-4181	fuchsia Oprah's extremely unsafe supercool sugar chapeau	0		Moxie Percent: +20, Weapon Damage Percent: +100, Maximum MP Percent: +50, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	cool sugar shorts	0		Moxie: +5, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	fuchsia Oprah's extremely unsafe supercool sugar chapeau	0		Moxie Percent: +20, Weapon Damage Percent: +100, Maximum MP Percent: +50, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	cool sugar shorts	0		Moxie: +5, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	tumbling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4150,11 +4150,11 @@
 4198	ghostly sea lasso	0		
 4199	blinking yellow Lo Pan's boxer's sea cowboy hat of the storm	0		Muscle Percent: +10, Maximum MP Percent: +40, Spell Critical Percent: +30, Familiar Effect: "1xLep"
 4200	grouper fangirl	0		
-4201	bouncing wobbly wobbly gill rings	0		Familiar Weight: +5
+4201	wobbly wobbly bouncing gill rings	0		Familiar Weight: +5
 4202	urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
 4204	bouncing Mer-kin cheatsheet	0		
-4205	mirror upside-down Mer-kin wordquiz	0		
+4205	upside-down mirror Mer-kin wordquiz	0		
 4206	lime green double-paned lion tamer's brand new key	0		Experience (familiar): +2, Cold Resistance: +5
 4207	electrified dorsal fin	0		MP Regen Min: 3, MP Regen Max: 5, Damage Reduction: 13
 4208	gray skate skates	0		
@@ -4178,7 +4178,7 @@
 4226	tumbling dance instructor's Star of Bravery	0		Experience Percent (Moxie): +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	cyan ice skate doll	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	huge can of sterno	0		
 4237	cheese-slicer of temperance	0		Sleaze Resistance: +5
-4238	enchanted bite-sized rotten beef jerky	1	crappy	Effect: "Phairly Pheromonal", Effect Duration: 20
+4238	rotten enchanted bite-sized beef jerky	1	crappy	Effect: "Phairly Pheromonal", Effect Duration: 20
 4239	pipe wrench of wisdom	0		Mysticality: +15
 4240	liquefied pickled bouncing gun cleaning kit	0		Effect: "Serenity", Effect Duration: 37
 4241	pulsating sage sleep mask	0		Mysticality Percent: +10, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4196,7 +4196,7 @@
 4244	double-paned leather-bound tome	0		Cold Resistance: +5
 4245	blurry bookmark	0		
 4246	censurious ivory cue ball	0		Sleaze Resistance: +3
-4247	enchanted perfectly mixed blurry decanter of fine Scotch	3	super EPIC	Effect: "Billiards Belligerence", Effect Duration: 30
+4247	perfectly mixed enchanted blurry decanter of fine Scotch	3	super EPIC	Effect: "Billiards Belligerence", Effect Duration: 30
 4248	diluted twirling expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	mirror fisherman's sack	0		
@@ -4204,17 +4204,17 @@
 4252	Vulcanized galvanized twirling vial of squid ink	0		Effect: "This Is Where You're a Viking", Effect Duration: 34
 4253	activated skewed potion of speed	0		Effect: "Polka Face", Effect Duration: 28
 4254	bark	0		Last Available: "2009-10"
-4255	narrow maroon Wolfman Nardz	0		Last Available: "2009-10"
+4255	maroon narrow Wolfman Nardz	0		Last Available: "2009-10"
 4256	cold-filtered energized sap	0		Effect: "Capricorn Rising", Effect Duration: 12, Last Available: "2009-10"
 4257	wobbly petrified wood	0		Last Available: "2009-10"
 4258	normal squat twirling chocolate-covered scarab beetle	4	good	Last Available: "2009-10"
-4259	bad practically non-alcoholic mulled cider	1	decent	Last Available: "2009-10"
-4260	blurry gray wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	jittery mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4259	practically non-alcoholic bad mulled cider	1	decent	Last Available: "2009-10"
+4260	blurry gray wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	jittery mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	upside-down squat Ax of L'rose	0		Last Available: "2009-10"
-4264	steel-toed bark boxers	0		Damage Reduction: 9, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	bark beret of the detective	0		Item Drop: +20, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	steel-toed bark boxers	0		Damage Reduction: 9, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	bark beret of the detective	0		Item Drop: +20, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	clever bark bracelet	0		Maximum MP: +20, Single Equip
 4267	Lo Pan's personal trainer's Krakrox's Loincloth	0		Experience Percent (Muscle): +10, Spell Critical Percent: +30, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	flame-wreathed Galapagosian Cuisses of the early riser	0		Hot Spell Damage: +10, Adventures: +7, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4298,8 +4298,8 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	wobbly leftover Crimbo rations	0		Last Available: "2009-12"
-4349	hale snow hat	0		Maximum HP: +20, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	sizzling snow pants	0		Hot Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	hale snow hat	0		Maximum HP: +20, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	sizzling snow pants	0		Hot Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	greedy snow belly	0		Meat Drop: +20, Single Equip, Last Available: "2009-12"
 4352	blinking pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4309,19 +4309,19 @@
 4357	blue A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	pulsating ghostly A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	stale bouncing cyan expired can of franks 'n' beans	3	decent	Last Available: "2009-12"
+4360	stale cyan bouncing expired can of franks 'n' beans	3	decent	Last Available: "2009-12"
 4361	practically non-alcoholic aged skewed expired bottle of peppermint schnapps	1	awesome	Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	super-polymerized aerosolized elven suicide capsule	0		Effect: "Super-Mega-Charged", Effect Duration: 51, Last Available: "2009-12"
-4365	toothsome small blue penguin focaccia bread	2	awesome	Last Available: "2009-12"
+4365	small toothsome blue penguin focaccia bread	2	awesome	Last Available: "2009-12"
 4366	bad practically non-alcoholic herringcello	1	decent	Last Available: "2009-12"
-4367	perfectly mixed weak narrow elven cellocello	2	EPIC	Last Available: "2009-12"
+4367	weak perfectly mixed narrow elven cellocello	2	EPIC	Last Available: "2009-12"
 4368	upside-down wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
-4372	blinking upside-down red chunk of cement	0		Last Available: "2009-12"
+4372	red upside-down blinking chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	wobbly elf ear	0		Last Available: "2009-12"
 4375	spiraling shape	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	blurry occult pocketwatch on a chain of the brazier	0		Spell Damage Percent: +25, Hot Spell Damage: +25, Last Available: "2009-12"
 4386	cyan Oprah's stiffened cement sandals	0		Damage Reduction: 1, Maximum MP Percent: +50, Single Equip, Last Available: "2009-12"
 4387	scandalous wicked night-vision goggles	0		Spell Damage: +5, Sleaze Damage: +5, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	Sinatra's peanut brittle shield	0		Experience (Moxie): +5, Damage Reduction: 3, Last Available: "2009-12"
 4390	Red Rover BB gun of doom of temperance	0		Spooky Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2009-12"
-4391	spinning auspicious red-and-green sweater	0		Item Drop: +10, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	spinning auspicious red-and-green sweater	0		Item Drop: +10, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	tumbling Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	diffused nitrogenated Crimbo peppermint bark	0		Effect: "So Fresh and So Clean", Effect Duration: 35, Last Available: "2009-12"
 4394	modified shaking Crimbo fudge	0		Effect: "Dancing Prowess", Effect Duration: 40, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	medical-grade cheese sword	0		HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2010-01"
-4400	cheese diaper of courage	0		Spooky Resistance: +3, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	cheese diaper of courage	0		Spooky Resistance: +3, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	blinking Sinatra's cheese wheel	0		Experience (Moxie): +5, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	sharpshooter's cheese eye	0		Critical Hit Percent: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	sharpshooter's cheese eye	0		Critical Hit Percent: +10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	Van der Graaf supercool Staff of Queso Escusado of the scaredy-cat	0		Moxie Percent: +20, Monster Level: -15, MP Regen Min: 5, MP Regen Max: 7, Softcore Only, Last Available: "2010-01"
 4405	upside-down foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	squat Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	adequate twirling quantum taco	0		Last Available: "2010-10"
-4413	bad fancy triple-distilled Schr&ouml;dinger's thermos	0		Effect: "Sweet and Red", Effect Duration: 30, Last Available: "2010-04"
+4413	fancy bad triple-distilled Schr&ouml;dinger's thermos	0		Effect: "Sweet and Red", Effect Duration: 30, Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	narrow personal trainer's sealhide hood	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	fuchsia Jim Carey's sealhide leggings	0		Monster Level: +25, Familiar Effect: "1xVolley, cap 40"
@@ -4393,10 +4393,10 @@
 4445	spangly mariachi pants of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	green blurry fireproof spangly mariachi vest of the brute	0		Muscle Percent: +30, Hot Resistance: +3
 4447	groovy spangly sombrero	0		Moxie Percent: +10, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	dried blue narrow Instant Karma	1	EPIC	
-4449	squat pulsating painting of a landscape	0		Last Available: "2010-04"
+4448	dried narrow blue Instant Karma	1	EPIC	
+4449	pulsating squat painting of a landscape	0		Last Available: "2010-04"
 4450	mirror map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	scandalous pointy hat	0		Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4451	scandalous pointy hat	0		Sleaze Damage: +5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	cool machetito	0		Moxie: +5, Last Available: "2010-04"
 4453	lawnmower blade of the cheetah	0		Initiative: +60, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4413,11 +4413,11 @@
 4465	flattened super-dry nitrogenated spinning chocolate saucepan	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 12
 4466	adjusted blurry chocolate disco ball	0		Effect: "Limber as Mortimer", Effect Duration: 31
 4467	boiled chocolate stolen accordion	0		Effect: "Coated Arms", Effect Duration: 29
-4468	huge Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	huge Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	BRICKO brick	0		Last Available: "2010-02"
 4470	BRICKO eye brick	0		Last Available: "2010-02"
-4471	thinker's BRICKO hat	0		Mysticality: +10, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	upside-down perfumed BRICKO pants	0		Stench Resistance: +5, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	thinker's BRICKO hat	0		Mysticality: +10, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	upside-down perfumed BRICKO pants	0		Stench Resistance: +5, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	squat nippy BRICKO sword	0		Cold Damage: +10, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
@@ -4451,7 +4451,7 @@
 4503	denatured skewed recording of Inigo's Incantation of Inspiration	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 69, Last Available: "2010-02"
 4504	banded grievous heart of the volcano	0		Weapon Damage Percent: +50, Damage Absorption: +100
 4505	flattened cold-filtered Northern pemmican	0		Effect: "Warm Shoulders", Effect Duration: 54
-4506	spinning yellow puzzling ribbon	0		
+4506	yellow spinning puzzling ribbon	0		
 4507	Clan looking glass	0		Free Pull, Last Available: "2010-03"
 4508	concentrated dry deionized olive &quot;DRINK ME&quot; potion	0		Effect: "Boo Tea", Effect Duration: 53, Last Available: "2010-03"
 4509	reflection of a map	0		Last Available: "2010-03"
@@ -4462,30 +4462,30 @@
 4514	moldy upside-down Humpty Dumplings	3	crappy	Last Available: "2010-03"
 4515	normal Lobster <i>qua</i> Grill	3	good	Last Available: "2010-03"
 4516	lousy missing wine	4	decent	Last Available: "2010-03"
-4517	decent bite-sized huge mirror matter custard	1	good	Last Available: "2010-03"
+4517	bite-sized decent huge mirror matter custard	1	good	Last Available: "2010-03"
 4518	pickled tumbling comfit?	0		Effect: "Heart of Orange", Effect Duration: 58, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	cyan Temple Grandin's forbidden flamingo mallet	0		Spell Damage Percent: +50, Familiar Weight: +7, Last Available: "2010-03"
 4521	blinking teal ghostly croquet hedgehog	0		Last Available: "2010-03"
 4522	Tiger-lily's milk	1	good	Last Available: "2010-03"
 4523	gray mirror sage eye of the Tiger-lily of temperance	0		Mysticality Percent: +10, Sleaze Resistance: +5, Last Available: "2010-03"
-4524	Jim Carey's wig of the brazier	0		Monster Level: +25, Hot Spell Damage: +25, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
-4525	huge flavorless donut	9	decent	Last Available: "2010-03"
+4524	Jim Carey's wig of the brazier	0		Monster Level: +25, Hot Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
+4525	flavorless huge donut	9	decent	Last Available: "2010-03"
 4526	bland bucket of honey	4	decent	Last Available: "2010-03"
 4527	upside-down teal scandalous Jack Frost's elephant stinger	0		Cold Spell Damage: +50, Sleaze Damage: +5, Last Available: "2010-03"
 4528	stale dragon snaps	4	decent	Last Available: "2010-03"
 4529	narrow foul-smelling banded snapdragon pistil	0		Damage Absorption: +100, Stench Damage: +10, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
 4531	flavorless rook cookie	3	decent	Last Available: "2010-03"
-4532	adequate super-sized blinking bishop cookie	5	good	Last Available: "2010-03"
-4533	huge rotten knight cookie	6	crappy	Last Available: "2010-03"
-4534	moldy gigantic king cookie	9	crappy	Last Available: "2010-03"
-4535	thick stale queen cookie	5	decent	Effect: "Towering Strength", Last Available: "2010-03"
+4532	super-sized adequate blinking bishop cookie	5	good	Last Available: "2010-03"
+4533	rotten huge knight cookie	6	crappy	Last Available: "2010-03"
+4534	gigantic moldy king cookie	9	crappy	Last Available: "2010-03"
+4535	stale thick queen cookie	5	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	knitted insane tophat	0		Cold Resistance: +3, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	blurry sinister Socratic helm of the knight	0		Experience (Mysticality): +1, Spell Damage: +10, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	knitted insane tophat	0		Cold Resistance: +3, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	blurry sinister Socratic helm of the knight	0		Experience (Mysticality): +1, Spell Damage: +10, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	red upside-down occult wristwatch of the knight of doom	0		Spell Damage Percent: +25, Spooky Spell Damage: +50, Single Equip, Last Available: "2010-03"
-4540	blurry Herculean savvy trousers of the knight	0		Mysticality Percent: +20, Experience (Muscle): +1, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	blurry Herculean savvy trousers of the knight	0		Mysticality Percent: +20, Experience (Muscle): +1, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	wobbly skewed tophat of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xBarrr, cap 25"
 4542	jittery green Sinatra's tie	0		Experience (Moxie): +5, Single Equip
 4543	fuchsia supercharged tuxedo pants	0		Maximum MP Percent: +30, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4508,15 +4508,15 @@
 4560	map to Professor Jacking's laboratory	0		Last Available: "2010-04"
 4561	olive can of depilatory cream	0		Last Available: "2010-04"
 4562	hair of the calf	0		Last Available: "2010-04"
-4563	enchanted tolerable weak world's most unappetizing beverage	2	good	Effect: "Chorale of Companionship", Effect Duration: 25, Last Available: "2010-04"
+4563	weak tolerable enchanted world's most unappetizing beverage	2	good	Effect: "Chorale of Companionship", Effect Duration: 25, Last Available: "2010-04"
 4564	slippery when wet shield of Flo-Jo	0		Initiative: +100, Damage Reduction: 6, Last Available: "2010-04"
 4565	rotten upside-down raisin	4	crappy	Last Available: "2010-04"
 4566	teal fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	greasy flyest of shirts of the glutton	0		Sleaze Spell Damage: +10, Food Drop: +100, Last Available: "2010-04"
 4568	flavorless half-sized a dance upon the palate	2	decent	Last Available: "2010-04"
-4569	immense moldy prehistoric meteorite jawbreaker	10	crappy	Last Available: "2010-04"
+4569	moldy immense prehistoric meteorite jawbreaker	10	crappy	Last Available: "2010-04"
 4570	narrow Crazyleg's razor	0		Last Available: "2010-04"
-4571	bland immense squirmy violent party snack	6	decent	Last Available: "2010-04"
+4571	immense bland squirmy violent party snack	6	decent	Last Available: "2010-04"
 4572	yellow bouncing can-you-dig-it? of the brazier	0		Hot Spell Damage: +25, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	huge panicked kernel	0		Free Pull, Last Available: "2010-04"
@@ -4539,7 +4539,7 @@
 4591	blurry horrifying pixel morning star	0		Spooky Damage: +25, Last Available: "2010-07"
 4592	pixel orb	0		Last Available: "2010-07"
 4593	twirling pixellated moneybag	0		Last Available: "2010-07"
-4594	twirling teal pixel cross	0		
+4594	teal twirling pixel cross	0		
 4595	cyan pixel holy water	0		Last Available: "2010-07"
 4596	map to Vanya's Castle	0		Last Available: "2010-07"
 4597	wobbly 8-Bit Power magazine	0		Last Available: "2010-07"
@@ -4550,17 +4550,17 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	supercharged Herculean bottle of Goldschn&ouml;ckered	0		Experience (Muscle): +1, Maximum MP Percent: +30, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
-4606	normal thick sun-dried tofu	5	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
-4607	watered-down mediocre cyan soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4605	supercharged Herculean bottle of Goldschn&ouml;ckered	0		Experience (Muscle): +1, Maximum MP Percent: +30, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4606	thick normal sun-dried tofu	5	good	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
+4607	mediocre watered-down cyan soyburger juice	2	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
 4609	twirling essential tofu	0		Last Available: "2010-08"
 4610	dry electrified mirror essential soy	0		Effect: "Swimming with Sharks", Effect Duration: 28, Last Available: "2010-08"
-4611	aerosolized non-alkaline cyan twirling essential cameraderie	0		Effect: "Gr8ness", Effect Duration: 21, Last Available: "2010-08"
+4611	aerosolized non-alkaline twirling cyan essential cameraderie	0		Effect: "Gr8ness", Effect Duration: 21, Last Available: "2010-08"
 4612	souvenir drawing	0		Last Available: "2010-08"
 4613	map to the Magic Commune	0		Last Available: "2010-08"
 4614	Jack Frost's Crown of Thrones	0		Cold Spell Damage: +50, Softcore Only, Last Available: "2010-05"
-4615	tolerable triple-distilled Cinco Mayo Lager	8	good	Last Available: "2010-05"
+4615	triple-distilled tolerable Cinco Mayo Lager	8	good	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	jittery pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4574,15 +4574,15 @@
 4626	superduperball	0		Last Available: "2010-06"
 4627	twirling finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
-4629	Fonzie's plastic spider ring	0		Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	Fonzie's plastic spider ring	0		Experience (Moxie): +1, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	skewed energetic plastic kazoo	0		Maximum MP Percent: +20, Last Available: "2010-06"
 4631	yellow deadly inflatable baseball bat	0		Weapon Damage: +5, Last Available: "2010-06"
-4632	Van der Graaf googly-star hat of the bloodbag	0		Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk", Last Available: "2010-06"
+4632	Van der Graaf googly-star hat of the bloodbag	0		Maximum HP: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-06", Familiar Effect: "atk"
 4633	banded fortified googly-ball hat	0		Damage Absorption: 160, Last Available: "2010-06"
 4634	fuchsia wholesome brainy googly-heart hat	0		Mysticality: +5, Maximum HP Percent: +10, Last Available: "2010-06"
 4635	sizzling super-sweet boom box of mayonnaise	0		Hot Damage: +10, Sleaze Spell Damage: +50, Four Songs, Last Available: "2010-06"
 4636	Game Grid valued membership card	0		Last Available: "2010-06"
-4637	wool rosy-cheeked sinister demon mask of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Cold Resistance: +1, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	wool rosy-cheeked sinister demon mask of wisdom	0		Mysticality: +15, Maximum HP Percent: +30, Cold Resistance: +1, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	spinning lion tamer's stiffened streetfighting champion's belt of the empath	0		Damage Reduction: 1, Familiar Weight: +5, Experience (familiar): +2, Single Equip, Last Available: "2010-06"
 4639	maroon rosewater-soaked arcane researcher's supercool Space Trip safety headphones	0		Moxie Percent: +20, Experience Percent (Mysticality): +10, Stench Resistance: +3, Single Equip, Last Available: "2010-06"
 4640	Usain Bolt's LARP carp	0		Initiative: +80
@@ -4594,8 +4594,8 @@
 4646	shaking Temple Grandin's rock-hard Meteoid ice beam of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Familiar Weight: +7, Last Available: "2011-12"
 4647	wizardly Dungeon Fist gauntlet of Tarzan of horror	0		Mysticality: +25, Experience (Muscle): +3, Spooky Spell Damage: +25, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	spinning chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	shaking fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	spinning chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	shaking fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	wool therapeutic ironic knit cap	0		Cold Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	jittery ironic sunglasses	0		Single Equip
@@ -4606,7 +4606,7 @@
 4658	map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	fuchsia tumbling blackberry galoshes of Tarzan	0		Experience (Muscle): +3, Single Equip
 4660	stanky trout fang of temperance	0		Stench Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2010-09"
-4661	decent low-calorie huge poisonous caviar	1	good	Last Available: "2010-09"
+4661	low-calorie decent huge poisonous caviar	1	good	Last Available: "2010-09"
 4662	super-magnetized colloidal wet venom duct	0		Effect: "Purpose", Effect Duration: 19, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	spinning healthy Ellsbury's skull of the storm	0		Maximum HP Percent: +20, Maximum MP Percent: +40, Last Available: "2010-09"
@@ -4616,9 +4616,9 @@
 4668	huge Jeselnik's observational glasses	0		Sleaze Damage: +25
 4669	arcane researcher's hilarious comedy prop	0		Experience Percent (Mysticality): +10
 4670	beer-scented teddy bear	0		
-4671	weak mediocre pulsating blurry booze-soaked cherry	2	decent	
+4671	weak mediocre blurry pulsating booze-soaked cherry	2	decent	
 4672	yellow comfy pillow	0		
-4673	normal small marshmallow	2	good	
+4673	small normal marshmallow	2	good	
 4674	bland skewed mirror sponge cake	3	decent	
 4675	hand-crafted gin-soaked blotter paper	4	EPIC	
 4676	maroon tree-holed coin	0		
@@ -4627,8 +4627,8 @@
 4679	shaking volcanic ash	0		
 4680	smoked potsherd	0		
 4681	executive pottery shield	0		Meat Drop: +40, Damage Reduction: 3, Last Available: "2010-09"
-4682	aromatic wholesome pottery hat	0		Maximum HP Percent: +10, Stench Resistance: +1, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	gray toasty studded pottery training pants	0		Damage Absorption: +80, Hot Damage: +5, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	aromatic wholesome pottery hat	0		Maximum HP Percent: +10, Stench Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	gray toasty studded pottery training pants	0		Damage Absorption: +80, Hot Damage: +5, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	inspector's pottery club	0		Item Drop: +15, Last Available: "2010-09"
 4685	twirling groovy pottery yo-yo	0		Moxie Percent: +10, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	squat fossilized spine	0		Last Available: "2010-09"
 4695	shaking affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	nasty toasty chilly Greatest American Pants	0		Cold Damage: +5, Hot Damage: +5, Stench Damage: +5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	nasty toasty chilly Greatest American Pants	0		Cold Damage: +5, Hot Damage: +5, Stench Damage: +5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	huge greasy fossilized necklace	0		Sleaze Spell Damage: +10, Last Available: "2010-09"
 4698	imp air	0		
 4699	bus pass	0		
@@ -4659,20 +4659,20 @@
 4711	ghostly sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	skewed GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	popsicle stick	0		
-4714	small tasty upside-down lemon popsicle	2	awesome	
+4714	tasty small upside-down lemon popsicle	2	awesome	
 4715	flavorless immense popsicle	10	decent	
-4716	rotten snack-sized blurry strawberry popsicle	2	crappy	
-4717	big rotten liver popsicle	5	crappy	
+4716	snack-sized rotten blurry strawberry popsicle	2	crappy	
+4717	rotten big liver popsicle	5	crappy	
 4718	ghostly hale mariachi hat	0		Maximum HP: +20, Familiar Effect: "atk, cap 2"
 4719	mirror frightening Hollandaise helmet	0		Spooky Damage: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
 4722	moldy thick liver and let pie	5	crappy	Last Available: "2010-10"
 4723	adequate badass pie	3	good	Last Available: "2010-10"
-4724	moldy small shoo-fish pie	2	crappy	Last Available: "2010-10"
+4724	small moldy shoo-fish pie	2	crappy	Last Available: "2010-10"
 4725	rotten piping organ pie	4	crappy	Last Available: "2010-10"
 4726	toothsome igloo pie	4	awesome	Last Available: "2010-10"
-4727	enchanted thick flavorless stomach turnover	5	decent	Effect: "Trufflin'", Effect Duration: 25, Last Available: "2010-10"
+4727	thick enchanted flavorless stomach turnover	5	decent	Effect: "Trufflin'", Effect Duration: 25, Last Available: "2010-10"
 4728	small bland dead lights pie	2	decent	Last Available: "2010-10"
 4729	flavorless throbbing organ pie	3	decent	Last Available: "2010-10"
 4730	Temple Grandin's stop shield	0		Familiar Weight: +7, Damage Reduction: 6, Last Available: "2009-12"
@@ -4683,7 +4683,7 @@
 4735	tumbling prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	nippy beer-soaked mop	0		Cold Damage: +10
-4738	mediocre enchanted skewed day-old beer	4	decent	Effect: "Nightlit", Effect Duration: 15
+4738	enchanted mediocre skewed day-old beer	4	decent	Effect: "Nightlit", Effect Duration: 15
 4739	artisanal strong plain beer	5	EPIC	
 4740	drinkable overpriced &quot;imported&quot; beer	3	good	
 4741	jittery smiling rat	0		
@@ -4692,15 +4692,15 @@
 4744	non-dry green PlexiPips	0		Effect: "Chock Full o' Nanites", Effect Duration: 62
 4745	chilled Wax Flask	0		Effect: "The Rich Get Richer", Effect Duration: 34
 4746	altered quantum Pain Dip	0		Effect: "Stimulated Brain", Effect Duration: 42
-4747	low-calorie flavorless bone meal	1	decent	Last Available: "2010-10"
-4748	watered-down fancy tolerable bone aperitif	2	good	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 10, Last Available: "2010-10"
+4747	flavorless low-calorie bone meal	1	decent	Last Available: "2010-10"
+4748	tolerable watered-down fancy bone aperitif	2	good	Effect: "Power Ballad of the Arrowsmith", Effect Duration: 10, Last Available: "2010-10"
 4749	boxer's bonerang	0		Muscle Percent: +10, Last Available: "2010-10"
 4750	twirling inspector's bone and arrows	0		Item Drop: +15, Last Available: "2010-10"
 4751	steel-toed boning knife	0		Damage Reduction: 9, Last Available: "2010-10"
 4752	supercool bone crusher	0		Moxie Percent: +20, Last Available: "2010-10"
 4753	maroon hardy bone spurs	0		Maximum HP: +50, Single Equip, Last Available: "2010-10"
-4754	jittery flame-retardant wizardly bonedanna	0		Mysticality: +25, Hot Resistance: +1, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	blurry Lo Pan's brainy boneana hammock	0		Mysticality: +5, Spell Critical Percent: +30, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	jittery flame-retardant wizardly bonedanna	0		Mysticality: +25, Hot Resistance: +1, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	blurry Lo Pan's brainy boneana hammock	0		Mysticality: +5, Spell Critical Percent: +30, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	fuchsia Stabonic scroll	0		Last Available: "2010-10"
 4758	activated ghostly candy skeleton	0		Effect: "Standard Cheer", Effect Duration: 47, Last Available: "2020-09"
@@ -4708,8 +4708,8 @@
 4760	upside-down packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	shaking pulsating huge pumpkin	0		Last Available: "2010-11"
-4763	tiny rotten pumpkin pie	1	crappy	Last Available: "2010-11"
-4764	weak hand-crafted pumpkin beer	2	EPIC	Last Available: "2010-11"
+4763	rotten tiny pumpkin pie	1	crappy	Last Available: "2010-11"
+4764	hand-crafted weak pumpkin beer	2	EPIC	Last Available: "2010-11"
 4765	activated activated double-oxidized pumpkin juice	0		Effect: "Ham-Fisted", Effect Duration: 61, Last Available: "2010-11"
 4766	spinning pumpkin bomb	0		Last Available: "2010-11"
 4767	spinning dog trainer's Newton's shin gourds	0		Experience (Mysticality): +3, Experience (familiar): +1, Single Equip, Last Available: "2010-11"
@@ -4726,7 +4726,7 @@
 4812	pulsating Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	spoiled CRIMBCOIDS mints	4	crappy	Last Available: "2011-01"
 4819	huge can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	fancy adequate CRIMBCOLOAF	4	good	Effect: "Braaaains Over Braaaawwn", Effect Duration: 45, Last Available: "2011-01"
+4820	adequate fancy CRIMBCOLOAF	4	good	Effect: "Braaaains Over Braaaawwn", Effect Duration: 45, Last Available: "2011-01"
 4821	stale circular CRIMBCOOKIE	4	decent	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	frightening plastic CRIMBCO HQ	0		Spooky Damage: +5, Last Available: "2010-12"
 4823	ghostly chaotic plastic fax machine	0		Spell Critical Percent: +10, Last Available: "2010-12"
@@ -4745,15 +4745,15 @@
 4836	olive skewed robot reindeer protocol B.L.I.T.Z.E.N.	0		Last Available: "2010-12"
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
-4839	super-sized normal special triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
+4839	special normal super-sized triangular CRIMBCOOKIE	5	good	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	spoiled square CRIMBCOOKIE	4	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	Annie Oakley's resourceful bindlestocking of Flo-Jo	0		Maximum MP: +50, Critical Hit Percent: +20, Initiative: +100, Last Available: "2010-12"
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	ghostly Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	twirling The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	blurry cyan Jeselnik's veiny Uncle Hobo's stocking cap	0		Maximum HP: +10, Sleaze Damage: +25, Familiar Effect: "atk", Last Available: "2010-12"
+4845	blurry cyan Jeselnik's veiny Uncle Hobo's stocking cap	0		Maximum HP: +10, Sleaze Damage: +25, Last Available: "2010-12", Familiar Effect: "atk"
 4846	green sharpshooter's curative Uncle Hobo's epic beard	0		Critical Hit Percent: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2010-12"
-4847	Uncle Hobo's gift baggy pants of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	Uncle Hobo's gift baggy pants of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	medical-grade beefcake's Uncle Hobo's fingerless tinsel gloves	0		Muscle: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2010-12"
 4849	Usain Bolt's Uncle Hobo's highest bough of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +80, Last Available: "2010-12"
 4850	wobbly flame-retardant Sinatra's Uncle Hobo's belt	0		Experience (Moxie): +5, Hot Resistance: +1, Single Equip, Last Available: "2010-12"
@@ -4766,7 +4766,7 @@
 4857	bottle of Blank-Out	0		Last Available: "2011-01"
 4858	CRIMBCO lanyard of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2011-01"
 4859	lime green CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
-4860	ghostly gray CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
+4860	gray ghostly CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	spinning CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	squat pulsating Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	upside-down bouncing gray prompt reassuring paperclip-on tie of the wise owl	0		Mysticality: +20, Spooky Resistance: +1, Adventures: +3, Single Equip, Last Available: "2011-01"
-4869	perfumed studded paperclip pants	0		Damage Absorption: +80, Stench Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	dangerous deadly paperclip turban of extreme caution	0		Weapon Damage: 15, Monster Level: -25, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	perfumed studded paperclip pants	0		Damage Absorption: +80, Stench Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	dangerous deadly paperclip turban of extreme caution	0		Weapon Damage: 15, Monster Level: -25, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	therapeutic paperclip cape	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2011-01"
 4872	wobbly glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4786,22 +4786,22 @@
 4877	concentrated non-quantum bacon bath ball	0		Effect: "Slimed Stomach", Effect Duration: 22, Last Available: "2011-01"
 4878	moist corrupted incense bath ball	0		Effect: "Make Meat FA$T!", Effect Duration: 44, Last Available: "2011-01"
 4879	polarized myrrh-soaked, chocolate-covered bacon bath ball	0		Effect: "Blackberry Politeness", Effect Duration: 36, Last Available: "2011-01"
-4880	narrow blurry CRIMBCO mug	0		Last Available: "2011-01"
+4880	blurry narrow CRIMBCO mug	0		Last Available: "2011-01"
 4881	acceptable CRIMBCO wine	3	good	Last Available: "2011-01"
 4882	shaking Dickory Farms Gift Basket	0		Last Available: "2011-01"
 4883	toe jam	0		Last Available: "2011-01"
 4884	moldy toe jam toast	3	crappy	Last Available: "2011-01"
 4885	traffic jam	0		Last Available: "2011-01"
-4886	low-calorie bland traffic jam toast	1	decent	Last Available: "2011-01"
+4886	bland low-calorie traffic jam toast	1	decent	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	stale half-sized space jam toast	2	decent	Last Available: "2011-01"
-4889	alkaline galvanized upside-down bouncing blurry motivational poster	0		Effect: "White Blooded", Effect Duration: 66, Last Available: "2011-01"
+4888	half-sized stale space jam toast	2	decent	Last Available: "2011-01"
+4889	alkaline galvanized blurry bouncing upside-down motivational poster	0		Effect: "White Blooded", Effect Duration: 66, Last Available: "2011-01"
 4890	blinking sack lunch	0		Last Available: "2011-01"
 4891	bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	BGE shotglass	0		Last Available: "2010-12"
-4894	normal half-sized blinking festive sausage	2	good	Last Available: "2011-01"
-4895	normal spinning pulsating holiday cheese log	3	good	Last Available: "2011-01"
+4894	half-sized normal blinking festive sausage	2	good	Last Available: "2011-01"
+4895	normal pulsating spinning holiday cheese log	3	good	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	lard-coated scorching BGE 'ferocious fruit' shirt	0		Hot Damage: +25, Sleaze Spell Damage: +25, Last Available: "2010-12"
 4898	inspector's dance instructor's BGE 'cuddly critter' shirt	0		Experience Percent (Moxie): +10, Item Drop: +15, Last Available: "2010-12"
@@ -4842,7 +4842,7 @@
 4939	mirror time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	jittery arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	decent purple Knob jelly donut	3	good	
-4942	blinking maroon Knob cake	0		
+4942	maroon blinking Knob cake	0		
 4943	Knob cake pan	0		
 4944	pulsating Knob batter	0		
 4945	Knob frosting	0		
@@ -4885,7 +4885,7 @@
 4982	pulsating Alice's Army Coward	0		Last Available: "2011-03"
 4983	Alice's Army Cleric	0		Last Available: "2011-03"
 4984	wobbly Alice's Army Sniper	0		Last Available: "2011-03"
-4985	wobbly upside-down Alice's Army Dervish	0		Last Available: "2011-03"
+4985	upside-down wobbly Alice's Army Dervish	0		Last Available: "2011-03"
 4986	Alice's Army Martyr	0		Last Available: "2011-03"
 4987	tumbling Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
 4988	Alice's Army Foil Swordsman	0		Last Available: "2011-03"
@@ -4914,19 +4914,19 @@
 5011	green Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	small rotten shaking wasabi pocky	2	crappy	Last Available: "2011-03"
-5014	moldy miniature red tobiko pocky	2	crappy	Last Available: "2011-03"
+5014	miniature moldy red tobiko pocky	2	crappy	Last Available: "2011-03"
 5015	adequate natto pocky	3	good	Last Available: "2011-03"
-5016	weak tolerable wasabi-infused sake	2	good	Last Available: "2011-03"
+5016	tolerable weak wasabi-infused sake	2	good	Last Available: "2011-03"
 5017	perfectly mixed tobiko-infused sake	3	EPIC	Last Available: "2011-03"
-5018	lousy weak natto-infused sake	2	decent	Last Available: "2011-03"
+5018	weak lousy natto-infused sake	2	decent	Last Available: "2011-03"
 5019	triple-boiled ionized wasabi marble soda	0		Effect: "Rootin' Around", Effect Duration: 58, Last Available: "2011-03"
 5020	pressed pulsating tobiko marble soda	0		Effect: "Hyperoxygenated Blood", Effect Duration: 28, Last Available: "2011-03"
 5021	super-denatured deionized natto marble soda	0		Effect: "World's Shortest Giant", Effect Duration: 31, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	nitrogenated diffused elderly jawbreaker	0		Effect: "Mortarfied", Effect Duration: 31, Last Available: "2020-09"
-5024	watered-down tolerable pulsating marshmallow flamb&eacute;	2	good	Last Available: "2011-03"
+5024	tolerable watered-down pulsating marshmallow flamb&eacute;	2	good	Last Available: "2011-03"
 5025	lousy cranberry schnapps	3	decent	Last Available: "2011-03"
-5026	weak lousy breaded beer	2	decent	Last Available: "2011-03"
+5026	lousy weak breaded beer	2	decent	Last Available: "2011-03"
 5027	tolerable weak upside-down soy cordial	2	good	Last Available: "2011-03"
 5028	greedy nasty smooth astral bludgeon	0		Moxie: +15, Stench Damage: +5, Meat Drop: +20
 5029	flame-retardant astral shield of courage	0		Hot Resistance: +1, Spooky Resistance: +3, Damage Reduction: 15
@@ -4949,14 +4949,14 @@
 5046	shaking astral six-pack	0		
 5047	maroon Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	upside-down shard of double-ice	0		Last Available: "2011-04"
-5049	toasty healthy extremely unsafe double-ice cap	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Hot Damage: +5, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5049	toasty healthy extremely unsafe double-ice cap	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Hot Damage: +5, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	shellacked savvy double-ice box of the bloodbag	0		Mysticality Percent: +20, Damage Reduction: 7, Maximum HP: +100, Last Available: "2011-04"
-5051	shaking executive scorching razor-sharp double-ice britches	0		Weapon Damage Percent: +25, Hot Damage: +25, Meat Drop: +40, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	shaking executive scorching razor-sharp double-ice britches	0		Weapon Damage Percent: +25, Hot Damage: +25, Meat Drop: +40, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	red handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	gray intriguing puzzle box	0		Last Available: "2011-04"
 5055	obnoxious riddle	0		Last Available: "2011-04"
-5056	purple wobbly upside-down best joke ever	0		Last Available: "2011-04"
+5056	upside-down purple wobbly best joke ever	0		Last Available: "2011-04"
 5057	oxidized teal Atomic Comic	0		Effect: "Boletus Swoletus", Effect Duration: 52, Last Available: "2011-04"
 5058	activated dry spinning Red Pill	0		Effect: "Abominably Slippery", Effect Duration: 53, Last Available: "2011-04"
 5059	shaking Skullhead's Screw	0		Last Available: "2011-04"
@@ -4967,7 +4967,7 @@
 5064	twirling Salsa de las Epocas	0		Last Available: "2011-04"
 5065	immense flavorless spaghetti con calaveras	7	decent	Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
-5067	adequate snack-sized popcorn	2	good	Last Available: "2011-04"
+5067	snack-sized adequate popcorn	2	good	Last Available: "2011-04"
 5068	stale chaos popcorn	3	decent	Last Available: "2011-04"
 5069	squat wobbly yellow foul-smelling clever hole of the cheetah	0		Maximum MP: +20, Stench Damage: +10, Initiative: +60, Last Available: "2011-04"
 5070	upside-down innuendo	0		Last Available: "2011-04"
@@ -4976,17 +4976,17 @@
 5073	drinkable Russian Ice	3	good	Last Available: "2011-04"
 5074	clay ashtray of the sewer	0		Stench Damage: +25, Damage Reduction: 3, Last Available: "2011-05"
 5075	yellow pulsating slick lanyard	0		Moxie: +10, Single Equip, Last Available: "2011-05"
-5076	sharpshooter's monster pants	0		Critical Hit Percent: +10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	sharpshooter's monster pants	0		Critical Hit Percent: +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	moist tarnished blurry Pok&euml;mann band-aid	0		Effect: "Surreally Buff", Effect Duration: 23, Last Available: "2011-05"
-5079	extremely unsafe Newton's Van der Graaf helmet	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	extremely unsafe Newton's Van der Graaf helmet	0		Experience (Mysticality): +3, Weapon Damage Percent: +100, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	mirror crutch of the dark arts	0		Spell Damage Percent: +100, Last Available: "2011-05"
 5081	shock belt of the early riser	0		Adventures: +7, Single Equip, Last Available: "2011-05"
 5082	denatured adjusted twirling Okee-Dokee soda	0		Effect: "Lifted Spirits", Effect Duration: 11, Last Available: "2011-05"
 5083	friendly rubber band gun	0		Familiar Weight: +3, Last Available: "2011-05"
-5084	pin-stripe slacks of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	pin-stripe slacks of the blizzard	0		Cold Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	electrified gloves	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-05"
-5086	pressed altered narrow bouncing correction fluid	0		Effect: "Aquarius Rising", Effect Duration: 43, Last Available: "2011-05"
+5086	pressed altered bouncing narrow correction fluid	0		Effect: "Aquarius Rising", Effect Duration: 43, Last Available: "2011-05"
 5087	upside-down supercharged Pok&euml;mann figurine: Porkachu	0		Maximum MP Percent: +30, Single Equip, Last Available: "2011-05"
 5088	narrow up-at-dawn Pok&euml;mann figurine: Magikrap	0		Adventures: +5, Single Equip, Last Available: "2011-05"
 5089	Pok&euml;mann figurine: Vegemite of the boozehound	0		Booze Drop: +100, Single Equip, Last Available: "2011-05"
@@ -5002,14 +5002,14 @@
 5099	Pok&euml;mann figurine: Shoggoth of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2011-05"
 5100	Pok&euml;mann figurine: Frank of chilblains	0		Cold Damage: +25, Single Equip, Last Available: "2011-05"
 5101	cool Pok&euml;mann figurine: Moog	0		Moxie: +5, Single Equip, Last Available: "2011-05"
-5102	non-altered dry pulsating narrow willyweed	0		Effect: "All Branned Up", Effect Duration: 24, Last Available: "2011-05"
+5102	non-altered dry narrow pulsating willyweed	0		Effect: "All Branned Up", Effect Duration: 24, Last Available: "2011-05"
 5103	vacuum-sealed cold-filtered Nuclear Blastball	0		Effect: "Stregngth of the Gnome", Effect Duration: 29, Last Available: "2011-05"
 5104	aerosolized anodized narrow pulsating fish juice box	0		Effect: "Sleazy Weapon", Effect Duration: 19, Last Available: "2011-05"
 5105	upside-down paint bomb	0		Last Available: "2011-05"
 5106	narrow hideous egg	0		Last Available: "2011-05"
 5107	artisanal mirror Jeppson's Malort	4	EPIC	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	perfumed stress ball	0		Stench Resistance: +5, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
+5109	perfumed stress ball	0		Stench Resistance: +5, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
 5110	squat Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	friendly Ultracolor&trade; shirt	0		Familiar Weight: +3, Last Available: "2011-05"
 5112	red My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
@@ -5021,8 +5021,8 @@
 5118	bird brain	0		
 5119	busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	purple hardened beefcake's Admiral's hat of the pedagogue	0		Muscle: +25, Experience: +3, Damage Reduction: 3, Familiar Effect: "atk", Last Available: "2011-05"
-5122	resourceful hale shellacked aviator's cap	0		Damage Reduction: 7, Maximum HP: +20, Maximum MP: +50, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	purple hardened beefcake's Admiral's hat of the pedagogue	0		Muscle: +25, Experience: +3, Damage Reduction: 3, Last Available: "2011-05", Familiar Effect: "atk"
+5122	resourceful hale shellacked aviator's cap	0		Damage Reduction: 7, Maximum HP: +20, Maximum MP: +50, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	Van der Graaf baleful mirrored aviator shades	0		Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2011-05"
 5124	twirling Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
@@ -5047,12 +5047,12 @@
 5144	teal handful of honey	0		
 5145	non-dry denatured bouncing honeypot	0		Effect: "Bored Stiff", Effect Duration: 57
 5146	tasty wild honey pie	3	awesome	
-5147	watered-down drinkable honey mead	2	good	
+5147	drinkable watered-down honey mead	2	good	
 5148	wobbly chaotic shellacked deadly honey dipper	0		Weapon Damage: +5, Damage Reduction: 7, Spell Critical Percent: +10
 5149	careful arcane researcher's cool honeybritches	0		Moxie: +5, Experience Percent (Mysticality): +10, Monster Level: -10, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	skewed dog trainer's steel-toed honeycap of the wise owl	0		Mysticality: +20, Damage Reduction: 9, Experience (familiar): +1, Familiar Effect: "1xPotato, cap 43"
-5151	tumbling Moonthril Circlet of the cheetah	0		Initiative: +60, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	blinking Annie Oakley's Moonthril Greaves	0		Critical Hit Percent: +20, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	tumbling Moonthril Circlet of the cheetah	0		Initiative: +60, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	blinking Annie Oakley's Moonthril Greaves	0		Critical Hit Percent: +20, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	flame-retardant Moonthril Flamberge	0		Hot Resistance: +1, Last Available: "2011-06"
 5154	Newton's Moonthril Longbow	0		Experience (Mysticality): +3, Last Available: "2011-06"
 5155	squat Samson's Moonthril Cuirass	0		Experience (Muscle): +5, Softcore Only, Last Available: "2011-06"
@@ -5084,13 +5084,13 @@
 5181	magnetized denatured Flan in the Moon	0		Effect: "Frozen Shoulders", Effect Duration: 58, Last Available: "2011-06"
 5182	improved liquefied jittery 1/6th Pound Cake	0		Effect: "Impregnabili Tea", Effect Duration: 36, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
-5184	mirror lime green Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
+5184	lime green mirror Mint-in-box Moonthril Greaves	0		Last Available: "2011-06"
 5185	Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	narrow Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	moist warmed mirror honey stick	0		Effect: "Ghost Finger", Effect Duration: 45
 5189	unsweetened mirror double-ice gum	0		Effect: "The Dinsey Spirit", Effect Duration: 41, Last Available: "2011-04"
-5190	mirror green wholesome Fonzie's sage Operation Patriot Shield	0		Mysticality Percent: +10, Experience (Moxie): +1, Maximum HP Percent: +10, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
+5190	mirror green wholesome Fonzie's sage Operation Patriot Shield	0		Mysticality Percent: +10, Experience (Moxie): +1, Maximum HP Percent: +10, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	irradiated unsweetened skewed corrupted data	0		Effect: "Conspiratory Eyes", Effect Duration: 29, Last Available: "2011-06"
 5193	11-inch knob sausage	0		
@@ -5100,7 +5100,7 @@
 5197	Newton's Marvelous Unitard	0		Experience (Mysticality): +3, Softcore Only, Last Available: "2011-07"
 5198	boiled pulsating blue gooey paste	1	good	Last Available: "2011-08"
 5199	pickled maroon beastly paste	1	good	Last Available: "2011-08"
-5200	twisted twirling squat blinking paste	1	decent	Last Available: "2011-08"
+5200	twisted twirling blinking squat paste	1	decent	Last Available: "2011-08"
 5201	mixed pulsating ectoplasmic paste	1	awesome	Last Available: "2011-08"
 5202	distilled greasy paste	1	awesome	Last Available: "2011-08"
 5203	twisted bug paste	1	decent	Last Available: "2011-08"
@@ -5108,7 +5108,7 @@
 5205	dehydrated yellow orc paste	1	decent	Effect: "Slimy Flavor", Effect Duration: 35, Last Available: "2011-08"
 5206	distilled ghostly demonic paste	1	good	Last Available: "2011-08"
 5207	dried bouncing indescribably horrible paste	1	good	Last Available: "2011-08"
-5208	distilled bouncing narrow paste	1	good	Effect: "Void Between the Stars", Effect Duration: 35, Last Available: "2011-08"
+5208	distilled narrow bouncing paste	1	good	Effect: "Void Between the Stars", Effect Duration: 35, Last Available: "2011-08"
 5209	dehydrated goblin paste	1	decent	Last Available: "2011-08"
 5210	powdered wobbly pirate paste	1	EPIC	Effect: "Elemental Flavor", Effect Duration: 5, Last Available: "2011-08"
 5211	altered ghostly chlorophyll paste	1	decent	Last Available: "2011-08"
@@ -5122,9 +5122,9 @@
 5219	dried ghostly Crimbo paste	1	good	Last Available: "2011-08"
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
-5222	spinning purple Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
-5224	stale gigantic Ur-Donut	10	decent	Last Available: "2011-09"
+5222	purple spinning Thwaitgold grasshopper statuette	0		
+5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5224	gigantic stale Ur-Donut	10	decent	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	fuchsia box of Familiar Jacks	0		Last Available: "2011-09"
 5227	tolerable tumbling bucket of wine	3	good	Last Available: "2011-09"
@@ -5138,7 +5138,7 @@
 5235	shaking gray stanky furry halo	0		Stench Spell Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	twirling frosty halo of courage	0		Spooky Resistance: +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	blinking olive Jim Carey's time halo	0		Monster Level: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
-5238	distilled hand-crafted squat Lumineux Limnio	5	EPIC	Last Available: "2011-09"
+5238	hand-crafted distilled squat Lumineux Limnio	5	EPIC	Last Available: "2011-09"
 5239	aged Morto Moreto	3	awesome	Last Available: "2011-09"
 5240	hand-crafted Temps Tempranillo	4	EPIC	Last Available: "2011-09"
 5241	drinkable Bordeaux Marteaux	3	good	Last Available: "2011-09"
@@ -5152,12 +5152,12 @@
 5249	spoiled bouncing danish	4	crappy	Last Available: "2011-09"
 5250	bland huge smashed danish	4	decent	Last Available: "2011-09"
 5251	normal forbidden danish	4	good	Last Available: "2011-09"
-5252	half-sized delicious cool cat claw	2	awesome	Last Available: "2011-09"
+5252	delicious half-sized cool cat claw	2	awesome	Last Available: "2011-09"
 5253	rotten blunt cat claw	3	crappy	Last Available: "2011-09"
-5254	toothsome fancy super-sized tumbling jittery shadowy cat claw	5	awesome	Effect: "Hella Smooth", Effect Duration: 25, Last Available: "2011-09"
+5254	super-sized fancy toothsome jittery tumbling shadowy cat claw	5	awesome	Effect: "Hella Smooth", Effect Duration: 25, Last Available: "2011-09"
 5255	massive adequate cheezburger	8	good	Last Available: "2011-09"
-5256	decent super-sized blurry toasted brie	5	good	Last Available: "2011-09"
-5257	dry quadruple-enhanced jittery olive potion of the field gar	0		Effect: "Prelude of Precision", Effect Duration: 65, Last Available: "2011-09"
+5256	super-sized decent blurry toasted brie	5	good	Last Available: "2011-09"
+5257	dry quadruple-enhanced olive jittery potion of the field gar	0		Effect: "Prelude of Precision", Effect Duration: 65, Last Available: "2011-09"
 5258	pickled chilled tumbling too legit potion	0		Effect: "Briny Blood", Effect Duration: 13, Last Available: "2011-09"
 5259	super-polarized Bright Water	0		Effect: "Took Eleven", Effect Duration: 37, Last Available: "2011-09"
 5260	quadruple-corrupted purple cold-filtered water	0		Effect: "Spring Training", Effect Duration: 46, Last Available: "2011-09"
@@ -5165,13 +5165,13 @@
 5262	pickled cool cat elixir	0		Effect: "Slimily Speedy", Effect Duration: 50, Last Available: "2011-09"
 5263	quantum potion of the captain's hammer	0		Effect: "Incredibly Hulking", Effect Duration: 29, Last Available: "2011-09"
 5264	extra-dry super-enhanced tarnished potion of X-ray vision	0		Effect: "Mo' Hobo", Effect Duration: 61, Last Available: "2011-09"
-5265	dry triple-anodized ghostly skewed tumbling potion of the litterbox	0		Effect: "Good Motivator", Effect Duration: 29, Last Available: "2011-09"
+5265	dry triple-anodized ghostly tumbling skewed potion of the litterbox	0		Effect: "Good Motivator", Effect Duration: 29, Last Available: "2011-09"
 5266	vacuum-sealed purple potion of animal rage	0		Effect: "Extra-Sharp Weapon", Effect Duration: 18, Last Available: "2011-09"
 5267	enhanced chilled potion of punctual companionship	0		Effect: "The Living Hitpoints", Effect Duration: 12, Last Available: "2011-09"
 5268	holy bomb, batman	0		Last Available: "2011-09"
 5269	purple bobcat grenade	0		Last Available: "2011-09"
 5270	yellow chocolate frosted sugar bomb	0		Last Available: "2011-09"
-5271	skewed skewed yellow broken glass grenade	0		Last Available: "2011-09"
+5271	yellow skewed skewed broken glass grenade	0		Last Available: "2011-09"
 5272	noxious gas grenade	0		Last Available: "2011-09"
 5273	upside-down skull with a fuse in it	0		Last Available: "2011-09"
 5274	blue boozebomb	0		Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	flame-retardant broken clock	0		Hot Resistance: +1, Last Available: "2011-09"
 5282	skewed nasty dethklok	0		Stench Damage: +5, Last Available: "2011-09"
 5283	family-friendly glacial clock	0		Sleaze Resistance: +1, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	maroon d8	0		Last Available: "2011-09"
@@ -5196,10 +5196,10 @@
 5293	huge generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
 5295	newborn kobold	0		Last Available: "2011-09"
-5296	lime green shaking slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
+5296	shaking lime green slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	delicious tiny phish stick	1	awesome	Last Available: "2011-09"
-5299	scandalous fortified strapping plastic vampire fangs	0		Muscle: +5, Damage Absorption: +60, Sleaze Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	scandalous fortified strapping plastic vampire fangs	0		Muscle: +5, Damage Absorption: +60, Sleaze Damage: +5, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	blurry your own heart	0		Last Available: "2011-10"
@@ -5211,9 +5211,9 @@
 5308	ghost trap	0		Last Available: "2011-10"
 5309	chainsaw chain	0		Last Available: "2011-10"
 5310	shotgun shell	0		Last Available: "2011-10"
-5311	huge gray funhouse mirror	0		Last Available: "2011-10"
+5311	gray huge funhouse mirror	0		Last Available: "2011-10"
 5312	diffused oxidized dry bouncing ghostly body paint	0		Effect: "Petit Forbearance", Effect Duration: 42, Last Available: "2011-10"
-5313	irradiated altered twirling fuchsia narrow bouncing necrotizing body spray	0		Effect: "Beastly Flavor", Effect Duration: 30, Last Available: "2011-10"
+5313	irradiated altered bouncing twirling narrow fuchsia necrotizing body spray	0		Effect: "Beastly Flavor", Effect Duration: 30, Last Available: "2011-10"
 5314	deionized aerosolized bite-me-red lipstick	0		Effect: "Fancy Feasted", Effect Duration: 56, Last Available: "2011-10"
 5315	boiled deionized narrow whisker pencil	0		Effect: "Superhuman Sarcasm", Effect Duration: 46, Last Available: "2011-10"
 5316	anodized denatured non-denatured blue press-on ribs	0		Effect: "Marbles in Your Mouth", Effect Duration: 45, Last Available: "2011-10"
@@ -5224,7 +5224,7 @@
 5321	super-deionized oxidized Sweet Sword	0		Effect: "Warm Shoulders", Effect Duration: 47, Last Available: "2011-10"
 5322	mediocre Ecto-Cooler	3	decent	Last Available: "2011-10"
 5323	delicious skewed Bartles and BRAAAINS wine cooler	3	awesome	Last Available: "2011-10"
-5324	practically non-alcoholic mediocre mirror Blood Light	1	decent	Last Available: "2011-10"
+5324	mediocre practically non-alcoholic mirror Blood Light	1	decent	Last Available: "2011-10"
 5325	perfectly mixed Silver Bullet beer	3	EPIC	Last Available: "2011-10"
 5326	mediocre Bone's Farm &quot;wine&quot;	4	decent	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
@@ -5233,13 +5233,13 @@
 5330	nitrogenated drum of pomade	0		Effect: "Mad at Science", Effect Duration: 34, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	mansplainer's extra-see-thru nightie	0		Monster Level: +15, Last Available: "2011-10"
-5333	supercharged supercool BRAINS shorts	0		Moxie Percent: +20, Maximum MP Percent: +30, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	supercharged supercool BRAINS shorts	0		Moxie Percent: +20, Maximum MP Percent: +30, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	Mesmereyes&trade; contact lenses of the scaredy-cat	0		Monster Level: -15, Single Equip, Last Available: "2011-10"
 5335	huge smelly scrunchie	0		Stench Spell Damage: +10, Single Equip, Last Available: "2011-10"
-5336	fireproof foul-smelling extremely skinny jeans	0		Stench Damage: +10, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	scandalous The Necbromancer's Hat of the pedagogue	0		Experience: +3, Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	fireproof foul-smelling extremely skinny jeans	0		Stench Damage: +10, Hot Resistance: +3, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	scandalous The Necbromancer's Hat of the pedagogue	0		Experience: +3, Sleaze Damage: +5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	executive coward's cool The Necbromancer's Stein	0		Moxie: +5, Monster Level: -20, Meat Drop: +40, Last Available: "2011-10"
-5339	ruddy thinker's beefy The Necbromancer's Shorts	0		Muscle: +10, Mysticality: +10, Maximum HP Percent: +40, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	ruddy thinker's beefy The Necbromancer's Shorts	0		Muscle: +10, Mysticality: +10, Maximum HP Percent: +40, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	ghostly foul-smelling vibrating fortified The Necbromancer's Wizard Staff	0		Damage Absorption: +60, Maximum MP Percent: +10, Stench Damage: +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	smooth pulsating The Cooler Out of Space	3	awesome	Last Available: "2011-10"
@@ -5306,7 +5306,7 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	skewed greasy deadly cane-mail shirt of chilblains	0		Weapon Damage: +5, Cold Damage: +25, Sleaze Spell Damage: +10, Last Available: "2011-12"
-5406	savvy cane-mail pants of the dark arts of the scaredy-cat	0		Mysticality Percent: +20, Spell Damage Percent: +100, Monster Level: -15, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	savvy cane-mail pants of the dark arts of the scaredy-cat	0		Mysticality Percent: +20, Spell Damage Percent: +100, Monster Level: -15, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	hand-crafted fuchsia Vodka Matryoshka	4	EPIC	Last Available: "2011-12"
 5408	smooth Gin Mint	3	awesome	Last Available: "2011-12"
 5409	drinkable Tequiz Navidad	4	good	Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	mirror censurious kumquartz ring	0		Sleaze Resistance: +3, Single Equip, Last Available: "2011-11"
 5425	healthy strawberyl necklace	0		Maximum HP Percent: +20, Single Equip, Last Available: "2011-11"
 5426	olive dog trainer's padded sucker bucket	0		Damage Absorption: +20, Experience (familiar): +1, Last Available: "2011-11"
-5427	upside-down energetic sucker hakama	0		Maximum MP Percent: +20, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	ruddy sucker kabuto	0		Maximum HP Percent: +40, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	upside-down energetic sucker hakama	0		Maximum MP Percent: +20, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	ruddy sucker kabuto	0		Maximum HP Percent: +40, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	squat toasty sucker tachi	0		Hot Damage: +5, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5357,13 +5357,13 @@
 5454	blurry gummi ingot	0		Last Available: "2011-11"
 5455	wobbly gummi ingot	0		Last Available: "2011-11"
 5456	gummi ingot	0		Last Available: "2011-11"
-5457	extra-Vulcanized shaking gray bouncing Fudgie Roll	0		Effect: "Arse-a'fire", Effect Duration: 29, Last Available: "2011-11"
-5458	miniature rotten fudge bunny	2	crappy	Last Available: "2011-11"
+5457	extra-Vulcanized shaking bouncing gray Fudgie Roll	0		Effect: "Arse-a'fire", Effect Duration: 29, Last Available: "2011-11"
+5458	rotten miniature fudge bunny	2	crappy	Last Available: "2011-11"
 5459	fudge spork	0		Last Available: "2011-11"
 5460	boxer's stylish fudgecycle of the early riser	0		Moxie: +25, Muscle Percent: +10, Adventures: +7, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	mirror Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	mirror Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	galvanized enhanced resolution: be wealthier	0		Effect: "Radiated and Grodiated", Effect Duration: 66, Last Available: "2012-01"
 5465	adjusted moist yellow resolution: be happier	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 63, Last Available: "2012-01"
 5466	pickled resolution: be stronger	0		Effect: "Feet of Watermelon", Effect Duration: 33, Last Available: "2012-01"
@@ -5372,7 +5372,7 @@
 5469	ionized colloidal resolution: be feistier	0		Effect: "Piratastic", Effect Duration: 54, Last Available: "2012-01"
 5470	extra-altered anodized Vulcanized resolution: be kinder	0		Effect: "Beastly Flavor", Effect Duration: 16, Last Available: "2012-01"
 5471	dry aerosolized Vulcanized resolution: be more adventurous	0		Effect: "Yuletide Industry", Effect Duration: 51, Last Available: "2012-01"
-5472	modified skewed narrow resolution: be luckier	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 24, Last Available: "2012-01"
+5472	modified narrow skewed resolution: be luckier	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 24, Last Available: "2012-01"
 5473	bouncing gummi ingot	0		Last Available: "2011-11"
 5474	gummi ingot	0		Last Available: "2011-11"
 5475	gummi ingot	0		Last Available: "2011-11"
@@ -5380,7 +5380,7 @@
 5477	warmed ionized gummi snake	0		Effect: "Psalm of Pointiness", Effect Duration: 17, Last Available: "2011-11"
 5478	tarnished quadruple-improved gummi canary	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 14, Last Available: "2011-11"
 5479	flavorless snack-sized gummi bear	2	decent	Last Available: "2011-11"
-5480	rotten immense gummi bear	6	crappy	Last Available: "2011-11"
+5480	immense rotten gummi bear	6	crappy	Last Available: "2011-11"
 5481	decent pulsating gummi bear	3	good	Last Available: "2011-11"
 5482	normal olive drunki-bear	4	good	Last Available: "2011-11"
 5483	normal miniature jittery drunki-bear	2	good	Last Available: "2011-11"
@@ -5392,14 +5392,14 @@
 5489	ammonite fossil	0		Last Available: "2011-11"
 5490	maroon belemnite fossil	0		Last Available: "2011-11"
 5491	trilobite candy mold	0		Last Available: "2011-11"
-5492	spinning narrow ammonite candy mold	0		Last Available: "2011-11"
+5492	narrow spinning ammonite candy mold	0		Last Available: "2011-11"
 5493	belemnite candy mold	0		Last Available: "2011-11"
 5494	polymerized concentrated narrow gummi trilobite	0		Effect: "Inebriate Pride", Effect Duration: 62, Last Available: "2011-11"
 5495	magnetized extra-oxidized yellow gummi ammonite	0		Effect: "Think Win-Lose", Effect Duration: 22, Last Available: "2011-11"
 5496	vacuum-sealed activated wobbly gummi belemnite	0		Effect: "In Vino Vires", Effect Duration: 27, Last Available: "2011-11"
 5497	shaking all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	blurry Big Candy's tophat of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	blurry Big Candy's tophat of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	green Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	teal Jackass Plumber home game	0		Last Available: "2011-11"
 5502	narrow Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5459,9 +5459,9 @@
 5556	censurious Rain-Doh wings of the storm	0		Maximum MP Percent: +40, Sleaze Resistance: +3, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	sharpshooter's brawny Rain-Doh laser gun	0		Muscle Percent: +20, Critical Hit Percent: +10, Softcore Only, Last Available: "2012-02"
-5559	banded extremely unsafe Rain-Doh lantern	0		Weapon Damage Percent: +100, Damage Absorption: +100, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	banded extremely unsafe Rain-Doh lantern	0		Weapon Damage Percent: +100, Damage Absorption: +100, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
-5561	jittery tumbling blue Rain-Doh indigo cup	0		Last Available: "2012-02"
+5561	jittery blue tumbling Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	huge manspreader's supercool Rain-Doh violet bo	0		Moxie Percent: +20, Monster Level: +10, Softcore Only, Last Available: "2012-02"
 5563	yellow Rain-Doh box	0		Last Available: "2012-02"
 5564	Rain-Doh box full of monster	0		Last Available: "2012-02"
@@ -5475,36 +5475,36 @@
 5572	Thwaitgold stag beetle statuette	0		
 5573	aged Drac & Tan	4	awesome	Last Available: "2012-03"
 5574	tolerable pulsating Transylvania Sling	4	good	Last Available: "2012-03"
-5575	irresponsibly strong enchanted acceptable Shot of the Living Dead	10	good	Effect: "Flagrantly Fragrant", Effect Duration: 45, Last Available: "2012-03"
-5576	practically non-alcoholic aged Buttery Knob	1	awesome	Last Available: "2012-03"
+5575	acceptable irresponsibly strong enchanted Shot of the Living Dead	10	good	Effect: "Flagrantly Fragrant", Effect Duration: 45, Last Available: "2012-03"
+5576	aged practically non-alcoholic Buttery Knob	1	awesome	Last Available: "2012-03"
 5577	drinkable upside-down shaking Slippery Knob	4	good	Last Available: "2012-03"
 5578	perfectly mixed pulsating Flaming Knob	3	EPIC	Last Available: "2012-03"
 5579	acceptable Grasshopper	3	good	Last Available: "2012-03"
-5580	drinkable enchanted mirror Locust	4	good	Effect: "The Dinsey Way", Effect Duration: 25, Last Available: "2012-03"
+5580	enchanted drinkable mirror Locust	4	good	Effect: "The Dinsey Way", Effect Duration: 25, Last Available: "2012-03"
 5581	hand-crafted blinking Plague of Locusts	4	EPIC	Last Available: "2012-03"
-5582	bad watered-down Red Dwarf	2	decent	Last Available: "2012-03"
-5583	weak perfectly mixed jittery Golden Mean	2	EPIC	Last Available: "2012-03"
+5582	watered-down bad Red Dwarf	2	decent	Last Available: "2012-03"
+5583	perfectly mixed weak jittery Golden Mean	2	EPIC	Last Available: "2012-03"
 5584	mediocre cyan Green Giant	3	decent	Last Available: "2012-03"
-5585	bad high-proof Aye Aye	9	decent	Last Available: "2012-03"
+5585	high-proof bad Aye Aye	9	decent	Last Available: "2012-03"
 5586	bad Aye Aye, Captain	4	decent	Last Available: "2012-03"
-5587	boozy fancy artisanal Aye Aye, Tooth Tooth	5	EPIC	Effect: "Mmmmmelon", Effect Duration: 35, Last Available: "2012-03"
+5587	artisanal fancy boozy Aye Aye, Tooth Tooth	5	EPIC	Effect: "Mmmmmelon", Effect Duration: 35, Last Available: "2012-03"
 5588	lousy jittery Humanitini	4	decent	Last Available: "2012-03"
 5589	smooth More Humanitini than Humanitini	4	awesome	Last Available: "2012-03"
 5590	aged Oh, the Humanitini	3	awesome	Last Available: "2012-03"
 5591	practically non-alcoholic bad blue Great Older Fashioned	1	decent	Last Available: "2012-03"
-5592	watered-down hand-crafted Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
-5593	acceptable fancy Crazymaker	4	good	Effect: "Dirty Pear", Effect Duration: 15, Last Available: "2012-03"
+5592	hand-crafted watered-down Fuzzy Tentacle	2	EPIC	Last Available: "2012-03"
+5593	fancy acceptable Crazymaker	4	good	Effect: "Dirty Pear", Effect Duration: 15, Last Available: "2012-03"
 5594	acceptable Zoodriver	4	good	Last Available: "2012-03"
 5595	mediocre Sloe Comfortable Zoo	3	decent	Last Available: "2012-03"
 5596	bad extra-dry spinning Sloe Comfortable Zoo on Fire	5	decent	Last Available: "2012-03"
 5597	tolerable Suffering Sinner	3	good	Last Available: "2012-03"
-5598	hand-crafted fancy practically non-alcoholic blurry Suppurating Sinner	1	EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2012-03"
+5598	fancy practically non-alcoholic hand-crafted blurry Suppurating Sinner	1	EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 25, Last Available: "2012-03"
 5599	aged high-proof Sizzling Sinner	7	awesome	Last Available: "2012-03"
 5600	practically non-alcoholic lousy Firewater	1	decent	Last Available: "2012-03"
 5601	practically non-alcoholic tolerable Earth and Firewater	1	good	Last Available: "2012-03"
 5602	lousy Earth, Wind and Firewater	3	decent	Last Available: "2012-03"
 5603	weak perfectly mixed Slimosa	2	EPIC	Last Available: "2012-03"
-5604	mediocre high-proof twirling Extra-slimy Slimosa	6	decent	Last Available: "2012-03"
+5604	high-proof mediocre twirling Extra-slimy Slimosa	6	decent	Last Available: "2012-03"
 5605	watered-down acceptable upside-down Slimebite	2	good	Last Available: "2012-03"
 5606	acceptable jittery Cement Mixer	3	good	Last Available: "2012-03"
 5607	drinkable irresponsibly strong twirling Jackhammer	10	good	Last Available: "2012-03"
@@ -5512,35 +5512,35 @@
 5609	fortified artisanal jittery Fauna Libre	5	EPIC	Last Available: "2012-03"
 5610	perfectly mixed Chakra Libre	3	EPIC	Last Available: "2012-03"
 5611	lousy upside-down Aura Libre	4	decent	Last Available: "2012-03"
-5612	irresponsibly strong perfectly mixed Sazerorc	8	EPIC	Last Available: "2012-03"
+5612	perfectly mixed irresponsibly strong Sazerorc	8	EPIC	Last Available: "2012-03"
 5613	acceptable Sazuruk-hai	4	good	Last Available: "2012-03"
 5614	hand-crafted Flaming Sazerorc	3	EPIC	Last Available: "2012-03"
 5615	distilled drinkable tumbling Green Velvet	5	good	Last Available: "2012-03"
 5616	fancy mediocre Green Muslin	3	decent	Effect: "Remaining Alive", Effect Duration: 10, Last Available: "2012-03"
 5617	triple-distilled artisanal Green Burlap	8	EPIC	Last Available: "2012-03"
 5618	perfectly mixed practically non-alcoholic Mohobo	1	EPIC	Last Available: "2012-03"
-5619	practically non-alcoholic lousy Moonshine Mohobo	1	decent	Last Available: "2012-03"
-5620	acceptable practically non-alcoholic Flaming Mohobo	1	good	Last Available: "2012-03"
+5619	lousy practically non-alcoholic Moonshine Mohobo	1	decent	Last Available: "2012-03"
+5620	practically non-alcoholic acceptable Flaming Mohobo	1	good	Last Available: "2012-03"
 5621	high-proof drinkable Drunken Philosopher	6	good	Last Available: "2012-03"
 5622	bad ghostly Drunken Neurologist	3	decent	Last Available: "2012-03"
-5623	artisanal practically non-alcoholic Drunken Astrophysicist	1	super ultra EPIC	Last Available: "2012-03"
-5624	acceptable watered-down Dark & Starry	2	good	Last Available: "2012-03"
-5625	weak perfectly mixed special Black Hole	2	EPIC	Effect: "Tea-hee", Effect Duration: 25, Last Available: "2012-03"
-5626	watered-down aged Event Horizon	2	awesome	Last Available: "2012-03"
+5623	practically non-alcoholic artisanal Drunken Astrophysicist	1	super ultra EPIC	Last Available: "2012-03"
+5624	watered-down acceptable Dark & Starry	2	good	Last Available: "2012-03"
+5625	perfectly mixed special weak Black Hole	2	EPIC	Effect: "Tea-hee", Effect Duration: 25, Last Available: "2012-03"
+5626	aged watered-down Event Horizon	2	awesome	Last Available: "2012-03"
 5627	smooth Herring Daiquiri	3	awesome	Last Available: "2012-03"
 5628	drinkable Herring Wallbanger	3	good	Last Available: "2012-03"
 5629	acceptable weak shaking Herringtini	2	good	Last Available: "2012-03"
-5630	enchanted acceptable triple-distilled huge Lollipop Drop	7	good	Effect: "Bonelording", Effect Duration: 50, Last Available: "2012-03"
-5631	acceptable enchanted Candy Alexander	3	good	Effect: "Patience of the Tortoise", Effect Duration: 45, Last Available: "2012-03"
+5630	acceptable triple-distilled enchanted huge Lollipop Drop	7	good	Effect: "Bonelording", Effect Duration: 50, Last Available: "2012-03"
+5631	enchanted acceptable Candy Alexander	3	good	Effect: "Patience of the Tortoise", Effect Duration: 45, Last Available: "2012-03"
 5632	weak bad Candicaine	2	decent	Last Available: "2012-03"
 5633	drinkable weak Caipiranha	2	good	Last Available: "2012-03"
 5634	mediocre shaking Flying Caipiranha	4	decent	Last Available: "2012-03"
 5635	delicious Flaming Caipiranha	3	awesome	Last Available: "2012-03"
-5636	bad weak Punchplanter	2	decent	Last Available: "2012-03"
-5637	drinkable boozy Doublepunchplanter	5	good	Last Available: "2012-03"
-5638	aged spirit-forward Haymaker	5	awesome	Last Available: "2012-03"
+5636	weak bad Punchplanter	2	decent	Last Available: "2012-03"
+5637	boozy drinkable Doublepunchplanter	5	good	Last Available: "2012-03"
+5638	spirit-forward aged Haymaker	5	awesome	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
-5640	gray blinking squat crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
+5640	blinking squat gray crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	normal fungus	4	good	
 5642	twirling jittery poisoned dart	0		
 5643	quantum activated wobbly skewed stone wool	0		Effect: "Dreadful Heat", Effect Duration: 50
@@ -5548,14 +5548,14 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	twirling Sherlock's calendar	0		Item Drop: +25, Damage Reduction: 4
-5648	yellow Boris's Helm of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	yellow Boris's Helm of wisdom of the storm	0		Mysticality: +15, Maximum MP Percent: +40, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	twirling Usain Bolt's staph of homophones of Calamity Jane	0		Critical Hit Percent: +15, Initiative: +80
-5650	horrifying ruddy wholesome Boris's Helm (askew)	0		Maximum HP Percent: 50, Spooky Damage: +25, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	horrifying ruddy wholesome Boris's Helm (askew)	0		Maximum HP Percent: 50, Spooky Damage: +25, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	moldy nailswurst	3	crappy	
-5655	practically non-alcoholic bad fuchsia jittery squat used beer	1	decent	
+5655	practically non-alcoholic bad fuchsia squat jittery used beer	1	decent	
 5656	Huggler Radio	0		Free Pull
 5657	fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5563,34 +5563,34 @@
 5660	razor-sharp offensive moustache	0		Weapon Damage Percent: +25, Single Equip
 5661	mirror beefcake's hairshirt	0		Muscle: +25
 5662	gray Olympic-sized Clan crate	0		Free Pull, Last Available: "2012-05"
-5663	bouncing cyan microwave	0		Free Pull
+5663	cyan bouncing microwave	0		Free Pull
 5664	pony keg	0		Free Pull
 5665	How to Tolerate Jerks	0		Skill: "Thick-Skinned"
-5666	skewed purple How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
+5666	purple skewed How to Hold a Grudge	0		Skill: "Chip on your Shoulder"
 5667	puppet strings	0		Free Pull
 5668	bagged &quot;L&quot;	0		
 5669	blinking club	0		
 5670	adequate fettucini &eacute;pines Inconnu	3	good	
-5671	triple-distilled smooth slap and slap again	7	awesome	
+5671	smooth triple-distilled slap and slap again	7	awesome	
 5672	jittery gunpowder burrito	2	good	
 5673	tumbling beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	modified watered-down Red Minotaur	1		
 5676	narrow pool torpedo	0		Last Available: "2012-05"
-5677	jittery slick Ze&trade; goggles	0		Moxie: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	jittery slick Ze&trade; goggles	0		Moxie: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	tumbling soggy used band-aid	0		Last Available: "2012-05"
-5679	personal trainer's stylish swimsuit of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	personal trainer's stylish swimsuit of Gandalf	0		Experience Percent (Muscle): +10, Spell Critical Percent: +20, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
 5681	small spoiled jittery P.B.L.T.	2	crappy	
-5682	blinking spinning bouncing note from Clancy	0		Skill: "Request Sandwich"
-5683	pulsating mirror red BURT	0		
+5682	bouncing blinking spinning note from Clancy	0		Skill: "Request Sandwich"
+5683	red pulsating mirror BURT	0		
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
 5687	bugbear autopsy tweezers	0		
 5688	yellow upside-down Jeselnik's UV monocular	0		Sleaze Damage: +25, Single Equip
 5689	drone self-destruct chip	0		
-5690	jittery yellow Jeff Goldblum larva	0		
+5690	yellow jittery Jeff Goldblum larva	0		
 5691	pacification grenade	0		
 5692	thinker's quantum disintegrator pistol	0		Mysticality: +10
 5693	tumbling steel-toed phase-tuned shield generator belt	0		Damage Reduction: 9, Single Equip
@@ -5605,14 +5605,14 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	wax hat of Leguizamo of the businessman	0		Monster Level: +20, Meat Drop: +50, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	lime green aromatic padded wax pants	0		Damage Absorption: +20, Stench Resistance: +1, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	wax hat of Leguizamo of the businessman	0		Monster Level: +20, Meat Drop: +50, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	lime green aromatic padded wax pants	0		Damage Absorption: +20, Stench Resistance: +1, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	blinking FDKOL commendation	0		Last Available: "2012-07"
 5708	alkaline narrow jittery drop of water-37	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 49, Last Available: "2012-07"
-5709	wobbly mirror Van der Graaf fireman's helmet of James Dean	0		Experience (Moxie): +3, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	wobbly mirror Van der Graaf fireman's helmet of James Dean	0		Experience (Moxie): +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	wobbly rosewater-soaked fire axe	0		Stench Resistance: +3, Last Available: "2012-07"
 5713	flame-wreathed Temple Grandin's Oprah's fire extinguisher	0		Maximum MP Percent: +50, Familiar Weight: +7, Hot Spell Damage: +10, Last Available: "2012-07"
-5714	jittery twirling FDKOL tattoo	0		
+5714	twirling jittery FDKOL tattoo	0		
 5715	shaking Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5716	skewed Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	spoiled spinning FDKOL hotcakes	4	crappy	Last Available: "2012-07"
@@ -5624,22 +5624,22 @@
 5723	cold-filtered magnetized pulsating bottle of fire	0		Effect: "Outer Wolf&trade;", Effect Duration: 45, Last Available: "2012-07"
 5724	tumbling molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	tumbling jittery smelly hot daub bun of the early riser	0		Stench Spell Damage: +10, Adventures: +7, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	huge shaking blue family-friendly hot daub stand of mayonnaise	0		Sleaze Spell Damage: +50, Sleaze Resistance: +1, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	tumbling jittery smelly hot daub bun of the early riser	0		Stench Spell Damage: +10, Adventures: +7, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	huge shaking blue family-friendly hot daub stand of mayonnaise	0		Sleaze Spell Damage: +50, Sleaze Resistance: +1, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	hale veiny foot-long hot daub	0		Maximum HP: 30, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
-5730	special decent twirling angst burger	3	good	Effect: "Fancy Feasted", Effect Duration: 15
+5730	decent special twirling angst burger	3	good	Effect: "Fancy Feasted", Effect Duration: 15
 5731	drinkable 5-hour acrimony	3	good	
 5732	cyan blank note	0		
 5733	shaking eerily silent box	0		
-5734	miniature stale upside-down forbidden sausage	2	decent	
-5735	miser's Lord Flameface's cloak	0		Meat Drop: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
+5734	stale miniature upside-down forbidden sausage	2	decent	
+5735	miser's Lord Flameface's cloak	0		Meat Drop: +10, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
 5736	dry squat Drizzlers&trade; Black Licorice	0		Effect: "Spiro Gyro", Effect Duration: 56
-5737	dry twirling skewed daub-breaker	0		Effect: "Kissed By Fire", Effect Duration: 11, Last Available: "2020-09"
+5737	dry skewed twirling daub-breaker	0		Effect: "Kissed By Fire", Effect Duration: 11, Last Available: "2020-09"
 5738	wobbly flame-retardant Camp Scout backpack	0		Hot Resistance: +1, Softcore Only, Last Available: "2012-07"
 5739	tumbling CSA fire-starting kit	0		Last Available: "2012-07"
 5740	tasty enchanted skewed bag of GORP	3	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 40, Last Available: "2012-07"
-5741	perfectly mixed blinking lime green tumbling water purification pills	4	EPIC	Last Available: "2012-07"
+5741	perfectly mixed tumbling lime green blinking water purification pills	4	EPIC	Last Available: "2012-07"
 5742	Camp Scout pup tent	0		Last Available: "2012-07"
 5743	aged CSA scoutmaster's &quot;water&quot;	3	awesome	Last Available: "2012-07"
 5744	decent bag of GORF	3	good	Last Available: "2012-07"
@@ -5652,8 +5652,8 @@
 5751	Tales of the Word Realms	0		
 5752	rotten crappy brain	4	crappy	
 5753	spoiled squat decent brain	4	crappy	
-5754	spoiled enchanted good brain	3	crappy	Effect: "Fancy Feasted", Effect Duration: 45
-5755	stale super-sized fancy boss brain	5	decent	Effect: "protect.enq", Effect Duration: 45
+5754	enchanted spoiled good brain	3	crappy	Effect: "Fancy Feasted", Effect Duration: 45
+5755	fancy stale super-sized boss brain	5	decent	Effect: "protect.enq", Effect Duration: 45
 5756	toothsome olive hunter brain	4	awesome	
 5758	Usain Bolt's coward's supercharged Staff of Holiday Sensations	0		Maximum MP Percent: +30, Monster Level: -20, Initiative: +80, Last Available: "2011-11"
 5759	ghostly hardened padded staff	0		Damage Absorption: +20, Damage Reduction: 3
@@ -5665,14 +5665,14 @@
 5765	vibrating fuzzy earmuffs of the pedagogue	0		Experience: +3, Maximum MP Percent: +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	scandalous rock-hard fortified fuzzy montera	0		Damage Absorption: +60, Damage Reduction: 5, Sleaze Damage: +5, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	spinning gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	yellow gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	spinning gnomish swimmer's ears	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "underwater"
+5769	yellow gnomish coal miner's lung	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "block"
+5770	gnomish tennis elbow	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "gain advs"
+5772	gnomish athlete's foot	0		Equips On: "Reagnimated Gnome", Last Available: "2012-08", Familiar Effect: "delevel"
 5773	Thwaitgold maggot statuette	0		
 5774	cyan talkative skull	0		
-5775	spinning blurry fronts	0		Familiar Weight: +5
+5775	blurry spinning fronts	0		Familiar Weight: +5
 5776	purple wool Barney's rake of the storm	0		Maximum MP Percent: +40, Cold Resistance: +1
 5778	stale purple idiot brain	4	decent	
 5779	brawny keel-haulin' knife	0		Muscle Percent: +20
@@ -5687,8 +5687,8 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	fireproof beefy right bear arm	0		Muscle: +10, Hot Resistance: +3, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	pulsating Jeselnik's smelly curative left bear arm	0		Stench Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	fireproof beefy right bear arm	0		Muscle: +10, Hot Resistance: +3, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	pulsating Jeselnik's smelly curative left bear arm	0		Stench Spell Damage: +10, Sleaze Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	frosty Hat O' Nine Tails	0		Cold Spell Damage: +10
 5794	irradiated corrupted wobbly Enchanted Plunger	0		Effect: "Whitened Teeth", Effect Duration: 47
 5795	diffused Vulcanized extra-magnetized wobbly jittery Enchanted Flyswatter	0		Effect: "Tea-hee", Effect Duration: 45
@@ -5707,7 +5707,7 @@
 5808	triple-polarized nitrogenated glass of gnat milk	0		Effect: "Pork Power", Effect Duration: 59
 5809	moist Knob Goblin Mutagen	0		Effect: "Macho, Macho Dog", Effect Duration: 52
 5810	quantum Tears of the Quiet Healer	0		Effect: "Petit Forbearance", Effect Duration: 58
-5811	colloidal galvanized ghostly red tumbling tube of lipstick	0		Effect: "Cat-Alyzed", Effect Duration: 53
+5811	colloidal galvanized tumbling red ghostly tube of lipstick	0		Effect: "Cat-Alyzed", Effect Duration: 53
 5812	triple-altered triple-galvanized squat skelelton spine	0		Effect: "Patent Prevention", Effect Duration: 60
 5813	chilled blinking smut orc sunglasses	0		Effect: "Eye of the Lihc", Effect Duration: 40
 5814	nitrogenated improved concentrated blob of acid	0		Effect: "Afternoon Insight", Effect Duration: 38
@@ -5723,7 +5723,7 @@
 5824	extra-quantum wet clove-flavored lip balm	0		Effect: "Saucegoggles", Effect Duration: 25
 5825	quadruple-dry galvanized liquefied Skullery Maid's Knee	0		Effect: "Prince of Seaside Town", Effect Duration: 62
 5826	Vulcanized improved skewed twirling zombie hollandaise	0		Effect: "Wax On Your Shoes", Effect Duration: 48
-5827	corrupted lime green upside-down skeletal banana	0		Effect: "Sauce Monocle", Effect Duration: 44
+5827	corrupted upside-down lime green skeletal banana	0		Effect: "Sauce Monocle", Effect Duration: 44
 5828	activated galvanized jittery gilt perfume bottle	0		Effect: "Dexteri Tea", Effect Duration: 29
 5829	colloidal enhanced janglin' bones	0		Effect: "Jingle Jangle Jingle", Effect Duration: 13
 5830	chilled aerosolized spinning pygmy papers	0		Effect: "Swordholder", Effect Duration: 19
@@ -5758,7 +5758,7 @@
 5859	dry nitrogenated olive booby trap	0		Effect: "Healthy Green Glow", Effect Duration: 31
 5860	tarnished energized huge Agent Corrigan's cigarette	0		Effect: "Slime Time", Effect Duration: 13
 5861	frozen pickled oxidized twirling good ash	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 30
-5862	shaking Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	shaking Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	twirling papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	warmed papier-mochi	0		Effect: "Cake Caked", Effect Duration: 40, Last Available: "2012-09"
@@ -5767,8 +5767,8 @@
 5868	resourceful thinker's papier-m&acirc;ch&eacute;te	0		Mysticality: +10, Maximum MP: +50, Last Available: "2012-09"
 5869	knitted beefy papier-m&acirc;chine gun	0		Muscle: +10, Cold Resistance: +3, Last Available: "2012-09"
 5870	huge reassuring medical-grade papier-masque	0		Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2012-09"
-5871	scandalous papier-mitre of the brazier	0		Hot Spell Damage: +25, Sleaze Damage: +5, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	fireproof papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Hot Resistance: +3, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	scandalous papier-mitre of the brazier	0		Hot Spell Damage: +25, Sleaze Damage: +5, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	fireproof papier-m&acirc;churidars of dire peril	0		Weapon Damage: +20, Hot Resistance: +3, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	tumbling papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5776,7 +5776,7 @@
 5877	papier-m&acirc;ch&eacute; trophy pi&ntilde;ata	0		Last Available: "2012-09"
 5878	blinking Rainbow Jello Mould of Gandalf	0		Spell Critical Percent: +20
 5879	Pete & Jackie's Dragon Tooth Emporium Catalog	0		Last Available: "2012-10"
-5880	blue twirling packet of dragon's teeth	0		Last Available: "2012-10"
+5880	twirling blue packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	Usain Bolt's rosy-cheeked skeleton skis of mayonnaise	0		Maximum HP Percent: +30, Sleaze Spell Damage: +50, Initiative: +80, Single Equip, Last Available: "2012-10"
 5883	toothsome skeleton quiche	3	awesome	Last Available: "2012-10"
@@ -5786,13 +5786,13 @@
 5887	lousy crystal skeleton vodka	3	decent	Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	huge huge curative auxiliary backbone	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2012-10"
-5890	squat narrow mirror skulldozer egg	0		Last Available: "2012-10"
+5890	narrow mirror squat skulldozer egg	0		Last Available: "2012-10"
 5891	ribcage rollcage	0		Familiar Weight: +5, Last Available: "2012-10"
 5892	aerosolized cold-filtered that gum you like	0		Effect: "Hot Jellied", Effect Duration: 35
 5893	dreaming Jung man	0		Free Pull, Last Available: "2013-12"
 5894	skewed Little Crimson Book	0		Familiar Weight: +5, Last Available: "2013-12"
 5895	teal avatar of the Unconscious Collective	0		Free Pull, Last Available: "2013-12"
-5896	maroon twirling canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
+5896	twirling maroon canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	distilled wobbly Unconscious Collective Dream Jar	1	good	Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
 5899	jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
@@ -5808,7 +5808,7 @@
 5910	deactivated nanobots	0		Free Pull, Last Available: "2012-11"
 5911	spinning nanorhino credit card	0		Last Available: "2012-11"
 5912	blurry smelly Solstice Shield of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100
-5913	alkaline concentrated boiled ghostly teal candy sushi set	0		Effect: "Boo Tea", Effect Duration: 69, Last Available: "2012-12"
+5913	alkaline concentrated boiled teal ghostly candy sushi set	0		Effect: "Boo Tea", Effect Duration: 69, Last Available: "2012-12"
 5914	diffused sweet mochi ball	0		Effect: "Coy to the Hurled", Effect Duration: 50, Last Available: "2012-12"
 5915	polymerized nitrogenated non-alkaline pulsating shaking beet-flavored Mr. Mediocrebar	0		Effect: "Salamander In Your Stomach", Effect Duration: 33, Last Available: "2012-12"
 5916	wet energized concentrated wobbly sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Shamboozled", Effect Duration: 54, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	twirling ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	skewed BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	nippy brainwave-controlled unicorn horn	0		Cold Damage: +10, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	nippy brainwave-controlled unicorn horn	0		Cold Damage: +10, Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	squat bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	frosty coward's curative plastic four-shadowed mime	0		Monster Level: -20, Cold Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2012-12"
@@ -5858,8 +5858,8 @@
 5960	plastic Father McGruber of the bloodbag	0		Maximum HP: +100, Last Available: "2012-12"
 5961	sharpshooter's plastic Hank North, Photojournalist	0		Critical Hit Percent: +10, Last Available: "2012-12"
 5962	maroon stylish plastic blazing bat	0		Moxie: +25, Last Available: "2012-12"
-5963	rosewater-soaked electronic dulcimer pants of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
-5964	shaking teal A-Boo clue	0		
+5963	rosewater-soaked electronic dulcimer pants of the blizzard	0		Cold Spell Damage: +25, Stench Resistance: +3, Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2"
+5964	teal shaking A-Boo clue	0		
 5965	slick Frown Exerciser of extreme caution	0		Moxie: +10, Monster Level: -25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	soul doorbell	0		
@@ -5868,7 +5868,7 @@
 5970	narrow supercharged soul mask	0		Maximum MP Percent: +30, Single Equip
 5971	record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
 5972	skewed record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
-5973	mirror yellow record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
+5973	yellow mirror record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	narrow record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
 5976	bouncing record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
@@ -5877,17 +5877,17 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
-5982	irresponsibly strong smooth purple tankard of ale	9	awesome	Last Available: "2013-02"
+5982	smooth irresponsibly strong purple tankard of ale	9	awesome	Last Available: "2013-02"
 5983	olive vial of holy water	0		Last Available: "2013-02"
-5984	Newton's strapping cloth cap of the detective	0		Muscle: +5, Experience (Mysticality): +3, Item Drop: +20, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	Newton's strapping cloth cap of the detective	0		Muscle: +5, Experience (Mysticality): +3, Item Drop: +20, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	wool scorching iron dagger of Flo-Jo	0		Hot Damage: +25, Cold Resistance: +1, Initiative: +100, Last Available: "2013-02"
-5986	spoiled snack-sized blurry hamburger	2	crappy	Last Available: "2013-02"
+5986	snack-sized spoiled blurry hamburger	2	crappy	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	delicious high-proof squat bottle of wine	7	awesome	Last Available: "2013-02"
+5990	high-proof delicious squat bottle of wine	7	awesome	Last Available: "2013-02"
 5991	upside-down round bomb	0		Last Available: "2013-02"
-5992	medical-grade hardened razor-sharp iron helmet	0		Weapon Damage Percent: +25, Damage Reduction: 3, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	medical-grade hardened razor-sharp iron helmet	0		Weapon Damage Percent: +25, Damage Reduction: 3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	wool ribald flame-wreathed steel sword	0		Hot Spell Damage: +10, Sleaze Damage: +10, Cold Resistance: +1, Last Available: "2013-02"
 5994	low-calorie moldy whole roasted chicken	1	crappy	Last Available: "2013-02"
 5995	massive gemstone	0		Last Available: "2013-02"
@@ -5895,13 +5895,13 @@
 5997	potion	0		Last Available: "2013-02"
 5998	lousy watered-down shining goblet	2	decent	Last Available: "2013-02"
 5999	teal fireball	0		Last Available: "2013-02"
-6000	jittery crafty hale Herculean crown	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP: +10, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	jittery crafty hale Herculean crown	0		Experience (Muscle): +1, Maximum HP: +20, Maximum MP: +10, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	Usain Bolt's savvy sword of temperance	0		Mysticality Percent: +20, Sleaze Resistance: +5, Initiative: +80, Last Available: "2013-02"
-6002	chilly Tesla Helm of the Scream Emperor of bravery	0		Cold Damage: +5, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	chilly Tesla Helm of the Scream Emperor of bravery	0		Cold Damage: +5, Spooky Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	olive chaotic Cloak of Dire Shadows of Tarzan of mayonnaise	0		Experience (Muscle): +3, Spell Critical Percent: +10, Sleaze Spell Damage: +50, Last Available: "2013-02"
 6004	teal vibrating Newton's Sword of Dark Omens of the glutton	0		Experience (Mysticality): +3, Maximum MP Percent: +10, Food Drop: +100, Last Available: "2013-02"
 6005	up-at-dawn mansplainer's Shield of Icy Fate of courage	0		Monster Level: +15, Spooky Resistance: +3, Adventures: +5, Damage Reduction: 7, Last Available: "2013-02"
-6006	lime green MacGyver's dance instructor's Greaves of the Murk Lord of bravery	0		Experience Percent (Moxie): +10, Maximum MP: +100, Spooky Resistance: +5, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	lime green MacGyver's dance instructor's Greaves of the Murk Lord of bravery	0		Experience Percent (Moxie): +10, Maximum MP: +100, Spooky Resistance: +5, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	wholesome arcane researcher's Gauntlets of the Blood Moon of bravery	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +10, Spooky Resistance: +5, Single Equip, Last Available: "2013-02"
 6008	horrifying friendly Boots of Twilight Whispers of extreme caution	0		Monster Level: -25, Familiar Weight: +3, Spooky Damage: +25, Single Equip, Last Available: "2013-02"
 6009	manspreader's Tesla groovy Belt of Howling Anger	0		Moxie Percent: +10, Monster Level: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2013-02"
@@ -5922,7 +5922,7 @@
 6024	auspicious Whatsian Ionic Pliers	0		Item Drop: +10
 6025	adjusted super-altered bouncing Polysniff Perfume	0		Effect: "Grrrrrrreat!", Effect Duration: 30
 6026	Duskwalker syringe	0		
-6027	upside-down blurry Space Tours Tripple	0		
+6027	blurry upside-down Space Tours Tripple	0		
 6028	Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	dress pants of courage	0		Spooky Resistance: +3, Familiar Effect: "2xFairy, cap 28"
@@ -5933,7 +5933,7 @@
 6035	magnetized vial of The Glistening	0		Effect: "Bolts about Candy", Effect Duration: 23
 6036	enchanted mediocre artisanal limoncello	4	decent	Effect: "Robocamo", Effect Duration: 25
 6037	squat ginger ale	0		
-6038	big normal blurry incredible pizza	5	good	
+6038	normal big blurry incredible pizza	5	good	
 6039	nippy oil cap of Flo-Jo	0		Cold Damage: +10, Initiative: +100, Familiar Effect: "cap 28"
 6040	fuchsia censurious toasty oil lamp	0		Hot Damage: +5, Sleaze Resistance: +3
 6041	skewed blue ruddy oil slacks	0		Maximum HP Percent: +40, Familiar Effect: "1xPotato, cap 30"
@@ -5966,7 +5966,7 @@
 6068	cyan loose blade	0		
 6069	goblin bone hilt	0		
 6070	shaking sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	irradiated pulsating narrow haggis-infused soap	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 55, Last Available: "2012-12"
 6074	moist spinning magicberry tablets	0		Effect: "Moon'd", Effect Duration: 69, Last Available: "2012-12"
@@ -5975,8 +5975,8 @@
 6077	decent haggis-wrapped haggis-stuffed haggis	3	good	Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	jittery school calculator watch	0		Last Available: "2012-12"
-6080	quilted haggis socks	0		Damage Absorption: +40, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	quilted haggis socks	0		Damage Absorption: +40, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	wobbly Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -6008,7 +6008,7 @@
 6110	blinking bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	blurry blurry bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	huge zaibatsu lobby card	0		Last Available: "2013-12"
-6113	spinning narrow zaibatsu level 1 card	0		Last Available: "2013-12"
+6113	narrow spinning zaibatsu level 1 card	0		Last Available: "2013-12"
 6114	pulsating zaibatsu level 2 card	0		Last Available: "2013-12"
 6115	zaibatsu level 3 card	0		Last Available: "2013-12"
 6116	blue CEO office card	0		Last Available: "2013-12"
@@ -6037,10 +6037,10 @@
 6139	mirror sharpshooter's rubber gloves	0		Critical Hit Percent: +10, Last Available: "2013-12"
 6140	blurry Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	rotten massive roasted duck	6	crappy	Last Available: "2013-12"
+6142	massive rotten roasted duck	6	crappy	Last Available: "2013-12"
 6143	special adequate lime green dead meat bun	3	good	Effect: "Crotchety, Pining", Effect Duration: 5, Last Available: "2013-12"
 6144	horrifying cat collar	0		Spooky Damage: +25, Single Equip, Last Available: "2013-12"
-6145	Temple Grandin's suspicious-looking fedora of the cheetah	0		Familiar Weight: +7, Initiative: +60, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	Temple Grandin's suspicious-looking fedora of the cheetah	0		Familiar Weight: +7, Initiative: +60, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6052,27 +6052,27 @@
 6155	pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	teal greasy weightlifter's Byte	0		Muscle: +15, Sleaze Spell Damage: +10, Last Available: "2013-12"
-6158	anger blaster of the blizzard	0		Cold Spell Damage: +25, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	blinking greasy doubt cannon	0		Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	mansplainer's fear condenser	0		Monster Level: +15, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	gravedigger's regret hose	0		Spooky Damage: +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	anger blaster of the blizzard	0		Cold Spell Damage: +25, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	blinking greasy doubt cannon	0		Sleaze Spell Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	mansplainer's fear condenser	0		Monster Level: +15, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	gravedigger's regret hose	0		Spooky Damage: +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	sharpshooter's commodore's hat	0		Critical Hit Percent: +10, Item Drop: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	blue skewed quilted naval trousers	0		Damage Absorption: +40, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	sharpshooter's commodore's hat	0		Critical Hit Percent: +10, Item Drop: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	blue skewed quilted naval trousers	0		Damage Absorption: +40, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	spinning therapeutic brawny deck cannon	0		Muscle Percent: +20, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2013-12"
 6167	smooth ornamental sextant	0		Moxie: +15, Last Available: "2013-12"
 6168	stanky grievous Bloodbath	0		Weapon Damage Percent: +50, Stench Spell Damage: +25, Last Available: "2013-12"
 6169	acceptable Hundred Headed IPA	3	good	Last Available: "2013-12"
-6170	moldy low-calorie bouncing chum	1	crappy	Last Available: "2013-12"
-6171	activated deionized dry blurry twirling crude crudit&eacute;s	0		Effect: "The Dinsey Way", Effect Duration: 50
+6170	low-calorie moldy bouncing chum	1	crappy	Last Available: "2013-12"
+6171	activated deionized dry twirling blurry crude crudit&eacute;s	0		Effect: "The Dinsey Way", Effect Duration: 50
 6172	irradiated anodized blinking candy crayons	0		Effect: "Stimulated Brain", Effect Duration: 25, Last Available: "2020-09"
 6173	spinning fortified pixel grappling hook of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +60
 6174	GameInformPowerDailyPro magazine	0		Last Available: "2013-02"
 6175	GameInformPowerDailyPro walkthru	0		Last Available: "2013-02"
 6176	cosmic egg	0		
 6177	cosmic dough	0		
-6178	pulsating teal cosmic vegetable	0		
+6178	teal pulsating cosmic vegetable	0		
 6179	lime green cosmic cheese	0		
 6180	cosmic potted meat product	0		
 6181	cosmic potato	0		
@@ -6080,39 +6080,39 @@
 6183	cosmic fruit	0		
 6184	supercharged groovy Jarlsberg's hat of courage	0		Moxie Percent: +10, Maximum MP Percent: +30, Spooky Resistance: +3
 6185	delicious consummate hard-boiled egg	4	awesome	
-6186	enchanted half-sized tasty consummate fried egg	2	awesome	Effect: "Raging Animal", Effect Duration: 30
+6186	half-sized enchanted tasty consummate fried egg	2	awesome	Effect: "Raging Animal", Effect Duration: 30
 6187	yummy half-sized consummate egg salad	2	awesome	
 6188	spoiled consummate bagel	3	crappy	
-6189	stale bite-sized consummate sliced bread	1	decent	
+6189	bite-sized stale consummate sliced bread	1	decent	
 6190	delicious consummate hot dog bun	4	awesome	
-6191	snack-sized fancy normal skewed consummate brownie	2	good	Effect: "Salty Dogs", Effect Duration: 30
+6191	normal snack-sized fancy skewed consummate brownie	2	good	Effect: "Salty Dogs", Effect Duration: 30
 6192	bland half-sized consummate toast	2	decent	
-6193	irresponsibly strong acceptable passable stout	7	good	
+6193	acceptable irresponsibly strong passable stout	7	good	
 6194	rotten shaking consummate soup	3	crappy	
 6195	big moldy huge consummate corn chips	5	crappy	
 6196	small yummy consummate salad	2	awesome	
 6197	rotten half-sized consummate salsa	2	crappy	
 6198	delicious consummate sauerkraut	3	awesome	
-6199	moldy thick tumbling consummate cheese slice	5	crappy	
-6200	stale pulsating skewed consummate melted cheese	3	decent	
+6199	thick moldy tumbling consummate cheese slice	5	crappy	
+6200	stale skewed pulsating consummate melted cheese	3	decent	
 6201	yummy consummate bacon	4	awesome	
 6202	stale half-sized bouncing consummate meatloaf	2	decent	
 6203	bland jumbo consummate steak	5	decent	
 6204	stale consummate cuts	4	decent	
-6205	yummy huge consummate frankfurter	10	awesome	
-6206	bland half-sized cyan consummate french fries	2	decent	
+6205	huge yummy consummate frankfurter	10	awesome	
+6206	half-sized bland cyan consummate french fries	2	decent	
 6207	moldy consummate baked potato	3	crappy	
-6208	hand-crafted practically non-alcoholic acceptable vodka	1	EPIC	
+6208	practically non-alcoholic hand-crafted acceptable vodka	1	EPIC	
 6209	flavorless low-calorie spinning consummate ice cream	1	decent	
 6210	rotten consummate whipped cream	3	crappy	
 6211	adequate consummate cream	4	good	
-6212	moldy bite-sized consummate strawberries	1	crappy	
+6212	bite-sized moldy consummate strawberries	1	crappy	
 6213	moldy consummate sorbet	3	crappy	
-6214	tolerable triple-distilled enchanted adequate rum	6	good	Effect: "Thick, Sick", Effect Duration: 40
+6214	triple-distilled tolerable enchanted adequate rum	6	good	Effect: "Thick, Sick", Effect Duration: 40
 6215	weak hand-crafted mediocre lager	2	EPIC	
 6216	flavorless immaculate grilled cheese	3	decent	
-6217	low-calorie bland immaculate ice cream sandwich	1	decent	
-6218	diet fancy bland squat immaculate hot dog	1	decent	Effect: "Disco Neuropathy", Effect Duration: 15
+6217	bland low-calorie immaculate ice cream sandwich	1	decent	
+6218	fancy diet bland squat immaculate hot dog	1	decent	Effect: "Disco Neuropathy", Effect Duration: 15
 6219	adequate huge immaculate egg salad sandwich	6	good	
 6220	spoiled perfect sandwich	4	crappy	
 6221	bland perfect chef salad	3	decent	
@@ -6121,14 +6121,14 @@
 6224	bland sublime stew	4	decent	
 6225	flavorless sublime nachos	3	decent	
 6226	spoiled Ultimate Breakfast Sandwich	3	crappy	
-6227	flavorless huge Loaded Baked Potato	6	decent	
+6227	huge flavorless Loaded Baked Potato	6	decent	
 6228	moldy green Omega Sundae	3	crappy	
 6229	tolerable irresponsibly strong Das Sauerlager	10	good	
 6230	spirit-forward drinkable Bologna Lambic	5	good	
-6231	bad weak Vodka Dog	2	decent	
+6231	weak bad Vodka Dog	2	decent	
 6232	perfectly mixed practically non-alcoholic skewed Disappointed Russian	1	super ultra EPIC	
-6233	drinkable practically non-alcoholic Chunky Mary	1	good	
-6234	acceptable watered-down Nachojito	2	good	
+6233	practically non-alcoholic drinkable Chunky Mary	1	good	
+6234	watered-down acceptable Nachojito	2	good	
 6235	drinkable Le Roi	4	good	
 6236	hand-crafted weak Over Easy Rider	2	EPIC	
 6237	olive cosmic six-pack	0		
@@ -6138,13 +6138,13 @@
 6242	galvanized ectoplasm <i>au jus</i>	0		Effect: "One Foot Heavier", Effect Duration: 37
 6243	warmed dry cyan the kindest cut	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 59
 6244	adjusted colloidal twirling cat's paw	0		Effect: "Chief Executive Optimism", Effect Duration: 13
-6245	triple-polarized skewed purple ASCII fu manchu	0		Effect: "Capricorn Rising", Effect Duration: 55
+6245	triple-polarized purple skewed ASCII fu manchu	0		Effect: "Capricorn Rising", Effect Duration: 55
 6246	chilled demonic surgical gloves	0		Effect: "Uncucumbered", Effect Duration: 35
 6247	super-pressed concentrated mirror clip-on ninja tie	0		Effect: "Flamibili Tea", Effect Duration: 36
 6248	boiled gamer slurry	0		Effect: "Preternatural Greed", Effect Duration: 48
 6249	dungeoneering kit	0		Last Available: "2013-02"
 6250	cyan Usain Bolt's manspreader's sharpshooter's curative thinker's numberwang of the brazier	0		Mysticality: +10, Critical Hit Percent: +10, Monster Level: +10, Hot Spell Damage: +25, Initiative: +80, HP Regen Min: 3, HP Regen Max: 5, Single Equip
-6251	deionized red blinking scroll of Protection from Bad Stuff	0		Effect: "Demonic Flavor", Effect Duration: 61, Last Available: "2013-02"
+6251	deionized blinking red scroll of Protection from Bad Stuff	0		Effect: "Demonic Flavor", Effect Duration: 61, Last Available: "2013-02"
 6252	concentrated squat scroll of Puddingskin	0		Effect: "Flagrantly Fragrant", Effect Duration: 18, Last Available: "2013-02"
 6253	Spellbook: Walberg's Dim Bulb	0		Skill: "Walberg's Dim Bulb"
 6254	Spellbook: Singer's Faithful Ocelot	0		Skill: "Singer's Faithful Ocelot"
@@ -6164,7 +6164,7 @@
 6268	modified aerosolized pec oil	0		Effect: "Okee-Dokee, Smokee", Effect Duration: 39
 6269	dangerous gym membership card	0		Weapon Damage: +10
 6270	polymerized vacuum-sealed Squat-Thrust Magazine	0		Effect: "Brawnee's Anthem of Absorption", Effect Duration: 40
-6271	tumbling upside-down jittery massive dumbbell	0		
+6271	upside-down jittery tumbling massive dumbbell	0		
 6272	clever penguin keychain of the early riser	0		Maximum MP: +20, Adventures: +7, Damage Reduction: 10
 6273	diffused O'RLY manual	0		Effect: "Elvish", Effect Duration: 61
 6274	hand-crafted upside-down jittery open sauce	4	EPIC	
@@ -6186,14 +6186,14 @@
 6290	steam-powered model rocketship	0		
 6291	flame-wreathed Fonzie's punk rock jacket	0		Experience (Moxie): +1, Hot Spell Damage: +10
 6292	wool medical-grade safety pin	0		Cold Resistance: +1, HP Regen Min: 7, HP Regen Max: 10
-6293	yummy small stolen sushi	2	awesome	
+6293	small yummy stolen sushi	2	awesome	
 6294	upside-down very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
 6297	fragment of Jarlsberg's soul	0		Free Pull, Last Available: "2013-06"
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
-6300	ionized vacuum-sealed yellow mirror Super Weight-Gain 9000	0		Effect: "Heavily Breathing", Effect Duration: 55
+6300	ionized vacuum-sealed mirror yellow Super Weight-Gain 9000	0		Effect: "Heavily Breathing", Effect Duration: 55
 6301	quantum alkaline cyan blurry possibility potion	0		Effect: "A Few Extra Pounds", Effect Duration: 16
 6302	pulsating eleven-foot pole	0		
 6303	wobbly ring of Detect Boring Doors	0		
@@ -6231,7 +6231,7 @@
 6335	teal stylish sea mantle of the boozehound	0		Moxie: +25, Booze Drop: +100
 6336	mirror Jeselnik's flame-wreathed sea shawl	0		Hot Spell Damage: +10, Sleaze Damage: +25, Spell Damage Percent: +150
 6337	horrifying sea cape of extreme caution	0		Monster Level: -25, Spooky Damage: +25, Initiative: +50, Critical Hit Percent: +15
-6338	red bouncing saltwaterbed	0		
+6338	bouncing red saltwaterbed	0		
 6339	muddy pirate hat of the storm of doom	0		Maximum MP Percent: +40, Spooky Spell Damage: +50, Familiar Effect: "1xFairy, cap 31"
 6340	curative forbidden floral-print skirt	0		Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	tumbling supercharged spectral axe of courage	0		Maximum MP Percent: +30, Spooky Resistance: +3
@@ -6253,8 +6253,8 @@
 6357	jittery Mer-kin knucklebone	0		
 6358	squat Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	jittery stanky Mer-kin begsign	0		Stench Spell Damage: +25, Meat Drop: +40
-6360	shaking Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
-6361	activated super-chilled huge green pulled taffy	0		Effect: "Big Flaming Whip", Effect Duration: 17, Last Available: "2013-04"
+6360	shaking Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6361	activated super-chilled green huge pulled taffy	0		Effect: "Big Flaming Whip", Effect Duration: 17, Last Available: "2013-04"
 6362	irradiated double-unsweetened narrow pulled indigo taffy	0		Effect: "Yuletide Sappiness", Effect Duration: 22, Last Available: "2013-04"
 6363	enhanced blue pulled taffy	0		Effect: "Scarysauce", Effect Duration: 65, Last Available: "2013-04"
 6364	non-flattened purple pulled taffy	0		Effect: "Pharmaceutically Cool", Effect Duration: 14, Last Available: "2013-04"
@@ -6308,7 +6308,7 @@
 6413	fuchsia Order of the Green Thumb Order Form	0		Free Pull
 6414	blurry clutch of dodecapede eggs	0		
 6415	decent thick olive flavorless gruel	5	good	
-6416	flavorless twirling wobbly mana curds	3	decent	
+6416	flavorless wobbly twirling mana curds	3	decent	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	galvanized flattened moth dust	0		Effect: "Al Dente Inferno", Effect Duration: 69
@@ -6318,7 +6318,7 @@
 6423	narrow Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	snack-sized spoiled purple Dreadsylvanian stew	2	crappy	
+6426	spoiled snack-sized purple Dreadsylvanian stew	2	crappy	
 6427	mediocre fortified Dreadsylvanian	5	decent	
 6428	ionized narrow squat Dreadsylvanian flask	0		Effect: "Shortened", Effect Duration: 11
 6429	moist Dreadsylvanian flask	0		Effect: "Mitre Cut", Effect Duration: 29
@@ -6360,14 +6360,14 @@
 6465	blurry Tesla hardy Samson's Mayor Ghost's gavel	0		Experience (Muscle): +5, Maximum HP: +50, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Hammer Ghost"
 6466	upside-down perfumed Mayor Ghost's sash of the overflowing toilet of the businessman	0		Stench Spell Damage: +50, Stench Resistance: +5, Meat Drop: +50, Single Equip
 6467	Mayor Ghost's scissors	0		
-6468	miniature moldy ghost pepper	2	crappy	
+6468	moldy miniature ghost pepper	2	crappy	
 6469	blurry greasy friendly Herculean Thunkula's drinking cap	0		Experience (Muscle): +1, Familiar Weight: +3, Sleaze Spell Damage: +10, Class: "Sauceror", Familiar Effect: "atk, 1xVolley"
 6470	dog trainer's supercharged Samson's Drunkula's cape	0		Experience (Muscle): +5, Maximum MP Percent: +30, Experience (familiar): +1, Class: "Sauceror"
 6471	zippy inspector's Drunkula's silky pants of the cheetah	0		Item Drop: +15, Initiative: 80, Class: "Sauceror", Familiar Effect: "1xPotato, 1xGhoul"
 6472	narrow Drunkula's bell	0		
 6473	spinning greedy resourceful clever Drunkula's ring of haze	0		Maximum MP: 70, Meat Drop: +20, Avoid Attack: 1, Single Equip
 6474	Socratic Drunkula's wineglass	0		Experience (Mysticality): +1
-6475	watered-down artisanal pulsating bottle of Bloodweiser	2	EPIC	
+6475	artisanal watered-down pulsating bottle of Bloodweiser	2	EPIC	
 6476	blurry mirror dance instructor's Unkillable Skeleton's skullcap of wisdom of the detective	0		Mysticality: +15, Experience Percent (Moxie): +10, Item Drop: +20, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	sizzling educational beefy Unkillable Skeleton's breastplate	0		Muscle: +10, Experience: +1, Hot Damage: +10, Class: "Turtle Tamer"
 6478	skewed wool wholesome weightlifter's Unkillable Skeleton's shinguards	0		Muscle: +15, Maximum HP Percent: +10, Cold Resistance: +1, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6384,7 +6384,7 @@
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	tailfeathers	0		Familiar Weight: +5
-6492	red twirling wax banana	0		
+6492	twirling red wax banana	0		
 6493	complicated lock impression	0		
 6494	bouncing replica key	0		
 6495	shaking razor-sharp Dreadsylvania Auditor's badge	0		Weapon Damage Percent: +25, Kruegerand Drop: 5, Single Equip
@@ -6410,7 +6410,7 @@
 6515	educational eerie fetish	0		Experience: +1, Single Equip
 6516	delicious stinkwater	4	awesome	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
-6518	tiny delicious ghostly accidental mutton	1	awesome	
+6518	delicious tiny ghostly accidental mutton	1	awesome	
 6519	chaotic drafty drawers of the dark arts	0		Spell Damage Percent: +100, Spell Critical Percent: +10, Familiar Effect: "1.5xVolley"
 6520	auspicious wolfskull mask of the wise owl	0		Mysticality: +20, Item Drop: +10, Familiar Effect: "spooky atk, 1xBarrr"
 6521	jittery MacGyver's guts necklace	0		Maximum MP: +100, Single Equip
@@ -6421,7 +6421,7 @@
 6526	spinning steel-toed stylish bag of unfinished business	0		Moxie: +25, Damage Reduction: 9
 6527	yellow shaking toasty Herculean transparent pants	0		Experience (Muscle): +1, Hot Damage: +5, Familiar Effect: "sleaze atk, 1xPotato"
 6528	squat banded hothammer	0		Damage Absorption: +100
-6529	high-proof lousy huge Thriller Ice	10	decent	
+6529	lousy high-proof huge Thriller Ice	10	decent	
 6530	maroon grandfather watch of Gandalf	0		Spell Critical Percent: +20, Single Equip
 6531	muddy skirt	0		Familiar Effect: "sleaze atk, 1xFairy"
 6532	censurious spyglass of the blizzard	0		Cold Spell Damage: +25, Sleaze Resistance: +3
@@ -6429,7 +6429,7 @@
 6534	occult remorseless knife	0		Spell Damage Percent: +25
 6535	bouncing clever intimidating coiffure	0		Maximum MP: +20, Familiar Effect: "hot afk, 1xPotato"
 6536	sage cod cape of Leguizamo	0		Mysticality Percent: +10, Monster Level: +20
-6537	half-sized enchanted flavorless pulsating blood sausage	2	decent	Effect: "Turtle Power", Effect Duration: 35
+6537	half-sized flavorless enchanted pulsating blood sausage	2	decent	Effect: "Turtle Power", Effect Duration: 35
 6538	wool padded frying brainpan	0		Damage Absorption: +20, Cold Resistance: +1
 6539	deadly ball and chain of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Single Equip
 6540	spinning bouncing hardened dry bone	0		Damage Reduction: 3
@@ -6443,28 +6443,28 @@
 6549	cooling iron breastplate	0		
 6550	tumbling cooling iron greaves	0		
 6551	jittery hot cluster	0		
-6552	teal squat cluster	0		
+6552	squat teal cluster	0		
 6553	cluster	0		
 6554	pulsating shaking stench cluster	0		
 6555	sleaze cluster	0		
 6556	super-cold-filtered bouncing phial of hotness	0		Effect: "Liquid Luck", Effect Duration: 57
 6557	cold-filtered moist diffused phial of coldness	0		Effect: "Frog In Your Throat", Effect Duration: 22
-6558	activated dry magnetized tumbling ghostly phial of spookiness	0		Effect: "Full-Body Tan", Effect Duration: 16
+6558	activated dry magnetized ghostly tumbling phial of spookiness	0		Effect: "Full-Body Tan", Effect Duration: 16
 6559	adjusted anodized phial of stench	0		Effect: "Extra-Sharp Weapon", Effect Duration: 51
 6560	non-galvanized flattened ionized blinking teal phial of sleaziness	0		Effect: "Bilious Brawn", Effect Duration: 33
 6561	purple adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	spinning mini-Mr. Accessory	0		Familiar Weight: +5
 6563	upside-down ghostly energetic hand of Mr. Cards	0		Maximum MP Percent: +20, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	rotten spinning yellow Dreadsylvanian hot pocket	3	crappy	
+6564	rotten yellow spinning Dreadsylvanian hot pocket	3	crappy	
 6565	adequate Dreadsylvanian pocket	4	good	
 6566	tasty skewed Dreadsylvanian pocket	4	awesome	
-6567	small flavorless green huge Dreadsylvanian stink pocket	2	decent	
-6568	huge adequate narrow wobbly olive Dreadsylvanian sleaze pocket	6	good	
+6567	flavorless small huge green Dreadsylvanian stink pocket	2	decent	
+6568	huge adequate olive narrow wobbly Dreadsylvanian sleaze pocket	6	good	
 6569	artisanal Dreadsylvanian hot toddy	3	super ultra mega turbo EPIC	
 6570	perfectly mixed Dreadsylvanian cold-fashioned	3	super ultra mega turbo EPIC	
 6571	lousy weak Dreadsylvanian grimlet	2	decent	
 6572	fancy hand-crafted Dreadsylvanian dank and stormy	4	super ultra mega EPIC	Effect: "Human-Pirate Hybrid", Effect Duration: 40
-6573	special delicious mirror Dreadsylvanian slithery nipple	3	awesome	Effect: "Heart of White", Effect Duration: 25
+6573	delicious special mirror Dreadsylvanian slithery nipple	3	awesome	Effect: "Heart of White", Effect Duration: 25
 6574	blinking hot clusterbomb	0		
 6575	tumbling clusterbomb	0		
 6576	twirling clusterbomb	0		
@@ -6498,7 +6498,7 @@
 6604	skewed clockwork numeral IV	0		
 6605	clockwork numeral V	0		
 6606	mirror clockwork numeral VI	0		
-6607	shaking shaking blinking clockwork numeral VII	0		
+6607	shaking blinking shaking clockwork numeral VII	0		
 6608	clockwork numeral VIII	0		
 6609	maroon clockwork numeral IX	0		
 6610	clockwork numeral X	0		
@@ -6506,8 +6506,8 @@
 6612	clockwork numeral XII	0		
 6613	tumbling clockwork cuckoo	0		
 6614	blurry wobbly cuckoo clock	0		
-6615	bad weak Cold One	2	???	
-6616	stale miniature huge spaghetti breakfast	2	???	
+6615	weak bad Cold One	2	???	
+6616	miniature stale huge spaghetti breakfast	2	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	narrow folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	concentrated pulsating tumbling Ogres and Oubliettes&trade; module	0		Effect: "Nasty, Nasty Breath", Effect Duration: 40
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	extra-dry mediocre stepmom's booze	5	decent	
+6652	mediocre extra-dry stepmom's booze	5	decent	
 6653	surgical tape	0		
 6654	padded band T-shirt	0		Damage Absorption: +20
 6655	weak mediocre fountain 'soda'	2	decent	
@@ -6553,10 +6553,10 @@
 6661	wobbly suspension bridge	0		
 6662	upside-down supercool boxer's Staff of the Lunch Lady of the scaredy-cat of mayonnaise	0		Muscle Percent: +10, Moxie Percent: +20, Monster Level: -15, Sleaze Spell Damage: +50
 6663	universal key	0		
-6664	upside-down tumbling world's most dangerous birdhouse	0		
+6664	tumbling upside-down world's most dangerous birdhouse	0		
 6665	lion tamer's savvy deathchucks	0		Mysticality Percent: +20, Experience (familiar): +2
 6666	purple eraser	0		
-6667	gray shaking quasireligious sculpture	0		
+6667	shaking gray quasireligious sculpture	0		
 6668	Faraday cage	0		
 6669	red bouncing modeling claymore	0		
 6670	clay homunculus	0		
@@ -6565,12 +6565,12 @@
 6673	purple yellowcake bomb	0		
 6674	stinkbomb	0		
 6675	boiled superwater	0		Effect: "Raging Animal", Effect Duration: 36
-6676	fuchsia skewed shaking Thwaitgold bookworm statuette	0		
+6676	shaking skewed fuchsia Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	upside-down Yearbook Club Camera of wisdom	0		Mysticality: +15, Conditional Skill (Equipped): "Blinding Flash"
 6679	censurious machete	0		Sleaze Resistance: +3
 6680	drinkable ghostly Cursed Punch	3	good	
-6681	smooth practically non-alcoholic twirling Bowl of Scorpions	1	awesome	
+6681	practically non-alcoholic smooth twirling Bowl of Scorpions	1	awesome	
 6682	aged Fog Murderer	3	awesome	
 6683	book of matches	0		
 6684	greasy surgical mask	0		Sleaze Spell Damage: +10, Surgeonosity: +1
@@ -6580,7 +6580,7 @@
 6688	brainy bloodied surgical dungarees	0		Mysticality: +5, Surgeonosity: +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 6689	McClusky file (page 1)	0		
 6690	mirror skewed McClusky file (page 2)	0		
-6691	mirror wobbly McClusky file (page 3)	0		
+6691	wobbly mirror McClusky file (page 3)	0		
 6692	McClusky file (page 4)	0		
 6693	McClusky file (page 5)	0		
 6694	boring binder clip	0		
@@ -6627,14 +6627,14 @@
 6735	junk junk	0		
 6736	Junk-Bond	0		
 6737	tangle of copper wire	0		
-6738	tumbling wobbly jagged scrap	0		
+6738	wobbly tumbling jagged scrap	0		
 6739	improved cyan bent scrap	0		Effect: "Christmessy", Effect Duration: 59
-6740	cyan skewed molten scrap	0		
+6740	skewed cyan molten scrap	0		
 6741	eternal car battery	0		
 6742	steel-toed junk band	0		Damage Reduction: 9
 6743	up-at-dawn junk trunks	0		Adventures: +5, Familiar Effect: "cap 15"
 6744	weightlifter's junk-mail shirt	0		Muscle: +15
-6745	normal big skewed junk food	5	good	
+6745	big normal skewed junk food	5	good	
 6746	aged huge junk yard	4	awesome	
 6747	pulsating chilly swordzall of Flo-Jo	0		Cold Damage: +5, Initiative: +100
 6748	wobbly Sinatra's arm buzzer	0		Experience (Moxie): +5, Damage Reduction: 6
@@ -6658,7 +6658,7 @@
 6766	tin beer can	0		
 6767	skewed bouncing artisanal homebrew gift package	0		
 6768	skewed liquid bread	1	good	Last Available: "2013-09"
-6769	auspicious toasty healthy tin tam	0		Maximum HP Percent: +20, Hot Damage: +5, Item Drop: +10, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	auspicious toasty healthy tin tam	0		Maximum HP Percent: +20, Hot Damage: +5, Item Drop: +10, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	aerosolized diffused maroon tin cup	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 21, Last Available: "2013-09"
 6771	lard-coated clever personal trainer's tin foil	0		Experience Percent (Muscle): +10, Maximum MP: +20, Sleaze Spell Damage: +25, Last Available: "2013-09"
 6772	huge knitted greasy tin drum of temperance	0		Sleaze Spell Damage: +10, Cold Resistance: +3, Sleaze Resistance: +5, Last Available: "2013-09"
@@ -6692,7 +6692,7 @@
 6803	concentrated disco horoscope (Libra)	0		Effect: "Stemonitis Storm", Effect Duration: 24
 6804	wet adjusted maroon disco horoscope (Scorpio)	0		Effect: "Witch's Brood", Effect Duration: 24
 6805	electrified double-dry mirror disco horoscope (Sagittarius)	0		Effect: "High Blood Chocolate Content", Effect Duration: 41
-6806	unsweetened super-irradiated bouncing fuchsia disco horoscope (Capricorn)	0		Effect: "Slimily Strong", Effect Duration: 11
+6806	unsweetened super-irradiated fuchsia bouncing disco horoscope (Capricorn)	0		Effect: "Slimily Strong", Effect Duration: 11
 6807	blinking green aromatic personal trainer's The Sagittarian's leisure pants	0		Experience Percent (Muscle): +10, Stench Resistance: +1, Familiar Effect: "atk, cap 18"
 6808	toy accordion	0		Song Duration: 5
 6809	accordion	0		Song Duration: 10
@@ -6725,11 +6725,11 @@
 6836	dry tumbling PEEZ dispenser	0		Effect: "Meatwise", Effect Duration: 54
 6837	ionized pickled magnetized tumbling Swizzler	0		Effect: "Rootin' Around", Effect Duration: 63
 6838	cold-filtered mirror Bugbearclaw Donut	0		Effect: "Ooh, Sweet!", Effect Duration: 23
-6839	vacuum-sealed skewed twirling jam	0		Effect: "Wasabi With You", Effect Duration: 34
+6839	vacuum-sealed twirling skewed jam	0		Effect: "Wasabi With You", Effect Duration: 34
 6840	colloidal corrupted wobbly Whenchamacallit bar	0		Effect: "Frost Tea", Effect Duration: 23
 6841	triple-concentrated non-ionized huge 8-bit banana	0		Effect: "Hyperoffended", Effect Duration: 15
 6842	tarnished blurry vial of blood simple syrup	0		Effect: "Human-Elf Hybrid", Effect Duration: 60
-6843	vacuum-sealed non-dry squat skewed blurry purple bone bons	0		Effect: "Salsa Satanica", Effect Duration: 68
+6843	vacuum-sealed non-dry blurry squat skewed purple bone bons	0		Effect: "Salsa Satanica", Effect Duration: 68
 6844	aerosolized ghostly ironic mint	0		Effect: "Protection from Bad Stuff", Effect Duration: 20
 6845	unused walkie-talkie	0		Free Pull
 6846	tumbling wobbly walkie-talkie	0		Free Pull
@@ -6746,23 +6746,23 @@
 6857	stiffened Cajun accordion	0		Damage Reduction: 1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	stanky quirky accordion	0		Stench Spell Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	lard-coated wizardly Skipper's accordion	0		Mysticality: +25, Sleaze Spell Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	friendly Jim Carey's Newton's Pantsgiving of the bloodbag	0		Experience (Mysticality): +3, Maximum HP: +100, Monster Level: +25, Familiar Weight: +3, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6860	friendly Jim Carey's Newton's Pantsgiving of the bloodbag	0		Experience (Mysticality): +3, Maximum HP: +100, Monster Level: +25, Familiar Weight: +3, Softcore Only, Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25"
 6861	adequate can of sardines	3	good	Last Available: "2013-11"
 6862	decent high-calorie sugar substitute	3	good	Last Available: "2013-11"
 6863	decent pulsating pat of butter	3	good	Last Available: "2013-11"
 6864	stale miniature dinner roll	2	decent	Last Available: "2013-11"
 6865	normal thick mashed potatoes	5	good	Last Available: "2013-11"
-6866	bland snack-sized whole turkey leg	2	decent	Last Available: "2013-11"
-6867	toothsome jumbo deviled egg	5	awesome	Last Available: "2013-11"
+6866	snack-sized bland whole turkey leg	2	decent	Last Available: "2013-11"
+6867	jumbo toothsome deviled egg	5	awesome	Last Available: "2013-11"
 6868	irradiated dry pickled finger exerciser	0		Effect: "Liquidy Smoky", Effect Duration: 28, Last Available: "2013-11"
-6869	electrified quantum twirling pulsating dented spoon	0		Effect: "Resilient Spirit", Effect Duration: 20, Last Available: "2013-11"
+6869	electrified quantum pulsating twirling dented spoon	0		Effect: "Resilient Spirit", Effect Duration: 20, Last Available: "2013-11"
 6870	modified altered love note	0		Effect: "Egg Burps", Effect Duration: 47, Last Available: "2013-11"
 6871	school beer pull tab	0		Last Available: "2013-11"
 6872	oxidized unsweetened quadruple-improved squat nail file	0		Effect: "Can't Smell Nothin'", Effect Duration: 27, Last Available: "2013-11"
 6873	triple-flattened concentrated lime green candy wrapper	0		Effect: "Lemony Goodness", Effect Duration: 50, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
 6875	warmed dry mirror post-holiday sale coupon	0		Effect: "Your Favorite Flavor", Effect Duration: 31, Last Available: "2013-11"
-6876	teal twirling blurry huge dry cleaning receipt	0		Last Available: "2013-11"
+6876	teal huge twirling blurry dry cleaning receipt	0		Last Available: "2013-11"
 6877	teal pocket lint (blue)	0		Last Available: "2013-11"
 6878	fuchsia pocket lint (green)	0		Last Available: "2013-11"
 6879	twirling pocket lint (white)	0		Last Available: "2013-11"
@@ -6773,7 +6773,7 @@
 6884	avaricious double-paned rosy-cheeked padded moustache sock	0		Damage Absorption: +20, Maximum HP Percent: +30, Cold Resistance: +5, Meat Drop: +30, Single Equip, Last Available: "2013-11"
 6885	activated wet spirit gum	0		Effect: "Flower Power", Effect Duration: 40
 6886	spirit pillow	0		
-6887	jittery gray spirit sheet	0		
+6887	gray jittery spirit sheet	0		
 6888	spirit mattress	0		
 6889	wobbly spirit blanket	0		
 6890	skewed spirit bed	0		
@@ -6807,32 +6807,32 @@
 6918	wet enhanced liquefied warbear wardance potion	0		Effect: "Feet of Grapefruit", Effect Duration: 16, Last Available: "2013-12"
 6919	cold-filtered anodized wobbly warbear bearserker potion	0		Effect: "Fastbreaker", Effect Duration: 12, Last Available: "2013-12"
 6920	flattened Vulcanized cold-filtered warbear liquid overcoat	0		Effect: "Beastly Flavor", Effect Duration: 54, Last Available: "2013-12"
-6921	adequate enchanted skewed warbear feasting bread	3	good	Effect: "Third Based", Effect Duration: 5, Last Available: "2013-12"
-6922	thick spoiled mirror warbear warrior bread	5	crappy	Last Available: "2013-12"
+6921	enchanted adequate skewed warbear feasting bread	3	good	Effect: "Third Based", Effect Duration: 5, Last Available: "2013-12"
+6922	spoiled thick mirror warbear warrior bread	5	crappy	Last Available: "2013-12"
 6923	spoiled thick blinking warbear thermoregulator bread	5	crappy	Last Available: "2013-12"
 6924	hand-crafted warbear feasting mead	3	EPIC	Last Available: "2013-12"
 6925	perfectly mixed fortified warbear bearserker mead	5	EPIC	Last Available: "2013-12"
-6926	perfectly mixed high-proof ghostly warbear blizzard mead	9	EPIC	Last Available: "2013-12"
+6926	high-proof perfectly mixed ghostly warbear blizzard mead	9	EPIC	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	tumbling Jack Frost's beefcake's warbear plain fedora of Flo-Jo	0		Muscle: +25, Cold Spell Damage: +50, Initiative: +100, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	warbear feathered fedora of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	lion tamer's studded warbear fedora of courage	0		Damage Absorption: +80, Experience (familiar): +2, Spooky Resistance: +3, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	huge fireproof savvy warbear plain helm of the boozehound	0		Mysticality Percent: +20, Hot Resistance: +3, Booze Drop: +100, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	warbear spiked helm of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	huge blurry horrifying careful dance instructor's warbear electro-spiked helm	0		Experience Percent (Moxie): +10, Monster Level: -10, Spooky Damage: +25, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	resourceful warbear plain ushanka of dire peril of courage	0		Weapon Damage: +20, Maximum MP: +50, Spooky Resistance: +3, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	groovy warbear lined ushanka	0		Moxie Percent: +10, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	savvy warbear heated ushanka of the blizzard of the businessman	0		Mysticality Percent: +20, Cold Spell Damage: +25, Meat Drop: +50, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	tumbling Jack Frost's beefcake's warbear plain fedora of Flo-Jo	0		Muscle: +25, Cold Spell Damage: +50, Initiative: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	warbear feathered fedora of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	lion tamer's studded warbear fedora of courage	0		Damage Absorption: +80, Experience (familiar): +2, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	huge fireproof savvy warbear plain helm of the boozehound	0		Mysticality Percent: +20, Hot Resistance: +3, Booze Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	warbear spiked helm of the sewer	0		Stench Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	huge blurry horrifying careful dance instructor's warbear electro-spiked helm	0		Experience Percent (Moxie): +10, Monster Level: -10, Spooky Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	resourceful warbear plain ushanka of dire peril of courage	0		Weapon Damage: +20, Maximum MP: +50, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	groovy warbear lined ushanka	0		Moxie Percent: +10, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	savvy warbear heated ushanka of the blizzard of the businessman	0		Mysticality Percent: +20, Cold Spell Damage: +25, Meat Drop: +50, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	warbear trouser fragment	0		Last Available: "2013-12"
-6938	avaricious careful warbear party pants of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: -10, Meat Drop: +30, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	huge careful warbear ceremonial party pants	0		Monster Level: -10, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	ghostly nippy fortified cool warbear high festival pants	0		Moxie: +5, Damage Absorption: +60, Cold Damage: +10, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	blurry nippy crafty warbear battle greaves of the cougar	0		Moxie: +20, Maximum MP: +10, Cold Damage: +10, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	lightning-fast warbear officer greaves	0		Initiative: +40, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	rosewater-soaked banded warbear bearserker greaves of the pedagogue	0		Experience: +3, Damage Absorption: +100, Stench Resistance: +3, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	nippy Tesla warbear johns of the pedagogue	0		Experience: +3, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	extremely unsafe warbear fleece-lined johns	0		Weapon Damage Percent: +100, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	clever warbear johns of Gandalf of chilblains	0		Maximum MP: +20, Spell Critical Percent: +20, Cold Damage: +25, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	avaricious careful warbear party pants of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: -10, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	huge careful warbear ceremonial party pants	0		Monster Level: -10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	ghostly nippy fortified cool warbear high festival pants	0		Moxie: +5, Damage Absorption: +60, Cold Damage: +10, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	blurry nippy crafty warbear battle greaves of the cougar	0		Moxie: +20, Maximum MP: +10, Cold Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	lightning-fast warbear officer greaves	0		Initiative: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	rosewater-soaked banded warbear bearserker greaves of the pedagogue	0		Experience: +3, Damage Absorption: +100, Stench Resistance: +3, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	nippy Tesla warbear johns of the pedagogue	0		Experience: +3, Cold Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	extremely unsafe warbear fleece-lined johns	0		Weapon Damage Percent: +100, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	clever warbear johns of Gandalf of chilblains	0		Maximum MP: +20, Spell Critical Percent: +20, Cold Damage: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	smelly healthy Newton's warbear goggles	0		Experience (Mysticality): +3, Maximum HP Percent: +20, Stench Spell Damage: +10, Single Equip, Last Available: "2013-12"
 6949	cool warbear snowblindness goggles	0		Moxie: +5, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	lime green therapeutic grievous warbear warscarf of the sweet-tooth	0		Weapon Damage Percent: +50, Candy Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	mirror warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	pulsating olive friendly warbear foil hat	0		Familiar Weight: +3, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
-6960	huge wobbly warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	auspicious warbear oil pan of the cheetah	0		Item Drop: +10, Initiative: +60, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6959	pulsating olive friendly warbear foil hat	0		Familiar Weight: +3, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6960	wobbly huge warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
+6961	auspicious warbear oil pan of the cheetah	0		Item Drop: +10, Initiative: +60, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	fuchsia stiffened warbear exhaust manifold	0		Damage Reduction: 1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	ghostly warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,14 +6889,14 @@
 7000	supercharged die-cast Don Crimbo of Gandalf	0		Maximum MP Percent: +30, Spell Critical Percent: +20, Last Available: "2013-12"
 7001	Temple Grandin's dance instructor's die-cast Uncle Hobo	0		Experience Percent (Moxie): +10, Familiar Weight: +7, Last Available: "2013-12"
 7002	maroon die-cast Father Crimbo of mayonnaise of courage	0		Sleaze Spell Damage: +50, Spooky Resistance: +3, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	adjusted Flaskfull of Hollow	0		Effect: "Stinkybeard", Effect Duration: 68, Last Available: "2013-12"
 7005	upside-down mirror lump of Brituminous coal	0		Last Available: "2013-12"
 7006	vaporized huge handful of Smithereens	1	decent	Last Available: "2013-12"
 7007	flavorless miniature yellow Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
 7008	miniature rotten spinning Miserable Pie	2	crappy	Last Available: "2013-12"
-7009	snack-sized bland enchanted This Charming Flan	2	decent	Effect: "Notably Lovely", Effect Duration: 25, Last Available: "2013-12"
-7010	acceptable special Irish Coffee, English Heart	3	good	Effect: "Extra-Wet", Effect Duration: 5, Last Available: "2013-12"
+7009	enchanted bland snack-sized This Charming Flan	2	decent	Effect: "Notably Lovely", Effect Duration: 25, Last Available: "2013-12"
+7010	special acceptable Irish Coffee, English Heart	3	good	Effect: "Extra-Wet", Effect Duration: 5, Last Available: "2013-12"
 7011	perfectly mixed Strikes Again Bigmouth	3	EPIC	Last Available: "2013-12"
 7012	artisanal Paint A Vulgar Pitcher	4	EPIC	Last Available: "2013-12"
 7013	twirling Golden Light	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	spinning stanky coward's Rosewater's Sheila Take a Crossbow of the dark arts	0		Mysticality Percent: +30, Spell Damage Percent: +100, Monster Level: -20, Stench Spell Damage: +25, Last Available: "2013-12"
 7019	medical-grade healthy A Light that Never Goes Out of Tarzan of the storm	0		Experience (Muscle): +3, Maximum HP Percent: +20, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2013-12"
 7020	Lo Pan's chaotic beefy Half a Purse	0		Muscle: +10, Spell Critical Percent: 40, Item Drop: +5, Last Available: "2013-12"
-7021	double-paned dance instructor's Fonzie's savvy Hairpiece On Fire	0		Mysticality Percent: +20, Experience (Moxie): +1, Experience Percent (Moxie): +10, Cold Resistance: +5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	toasty Tesla Rosewater's Vicar's Tutu of the sweet-tooth	0		Mysticality Percent: +30, Hot Damage: +5, Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	double-paned dance instructor's Fonzie's savvy Hairpiece On Fire	0		Mysticality Percent: +20, Experience (Moxie): +1, Experience Percent (Moxie): +10, Cold Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	toasty Tesla Rosewater's Vicar's Tutu of the sweet-tooth	0		Mysticality Percent: +30, Hot Damage: +5, Candy Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	blurry asbestos-lined sinister Hand in Glove of courage	0		Spell Damage: +10, Hot Resistance: +5, Spooky Resistance: +3, Single Equip, Last Available: "2013-12"
 7024	gravedigger's clever thinker's Meat Tenderizer is Murder	0		Mysticality: +10, Maximum MP: +20, Spooky Damage: +10, Class: "Seal Clubber", Last Available: "2013-12"
 7025	veiny stylish smooth Ouija Board, Ouija Board	0		Moxie: 40, Maximum HP: +10, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6927,7 +6927,7 @@
 7038	warbear gyrocopter	0		Last Available: "2013-12"
 7039	enhanced huge warbear robo-camouflage unit	0		Effect: "Remaining Alive", Effect Duration: 14, Last Available: "2013-12"
 7040	twirling warbear beeping telegram	0		Last Available: "2013-12"
-7041	huge wobbly warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
+7041	wobbly huge warbear procedural hilarity drone	0		Free Pull, Last Available: "2013-12"
 7042	warbear metalworking primer	0		Skill: "Shrap", Last Available: "2013-12"
 7043	warbear sequential gaiety distribution system	0		Last Available: "2013-12"
 7044	polymerized adjusted spinning glass slipper	0		Effect: "Cool Spirit", Effect Duration: 17, Last Available: "2014-12"
@@ -6941,9 +6941,9 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	yellow warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	massive rotten tumbling breakfast mess	8	crappy	Last Available: "2013-12"
+7055	rotten massive tumbling breakfast mess	8	crappy	Last Available: "2013-12"
 7056	tumbling warbear breakfast machine	0		Last Available: "2013-12"
-7057	thick stale breakfast miracle	5	decent	Last Available: "2013-12"
+7057	stale thick breakfast miracle	5	decent	Last Available: "2013-12"
 7058	dry green Cloaca Cola Polar	0		Effect: "Eye of the Seal", Effect Duration: 49, Last Available: "2013-12"
 7059	purple warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6957,8 +6957,8 @@
 7068	moist single of Donho's Bubbly Ballad	0		Effect: "Turtle Power", Effect Duration: 33
 7069	yellow Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	skewed packet of winter seeds	0		Last Available: "2014-01"
-7071	super-sized rotten wobbly snow berries	5	crappy	Last Available: "2014-01"
-7072	thick adequate shaking ice harvest	5	good	Last Available: "2014-01"
+7071	rotten super-sized wobbly snow berries	5	crappy	Last Available: "2014-01"
+7072	adequate thick shaking ice harvest	5	good	Last Available: "2014-01"
 7073	frozen improved squat frost flower	0		Effect: "Whippin' It Good", Effect Duration: 53, Last Available: "2014-01"
 7074	vacuum-sealed Vulcanized bouncing snow cleats	0		Effect: "Artificially Sweet", Effect Duration: 29, Last Available: "2014-01"
 7075	non-aerosolized denatured shaking liquid ice pack	0		Effect: "Standard Cheer", Effect Duration: 47, Last Available: "2014-01"
@@ -6969,7 +6969,7 @@
 7080	blurry ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	dance instructor's snow mobile	0		Experience Percent (Moxie): +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	dance instructor's snow mobile	0		Experience Percent (Moxie): +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	cyan gravedigger's ice bucket	0		Spooky Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	cyan inspector's ribald snow shovel	0		Sleaze Damage: +10, Item Drop: +15, Lasts Until Rollover, Last Available: "2014-01"
 7086	executive crafty steel-toed bod-ice	0		Damage Reduction: 9, Maximum MP: +10, Meat Drop: +40, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	hand-crafted En Una Fila Tequila	4	EPIC	
 7091	pulsating Skully's hot chocolate	1	crappy	
-7092	dog trainer's dangerous warbear dress helmet	0		Weapon Damage: +10, Experience (familiar): +1, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	dog trainer's dangerous warbear dress helmet	0		Weapon Damage: +10, Experience (familiar): +1, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	Rosewater's warbear dress bracers of Calamity Jane	0		Mysticality Percent: +30, Critical Hit Percent: +15, Single Equip, Last Available: "2013-12"
-7094	Newton's warbear dress greaves of courage	0		Experience (Mysticality): +3, Spooky Resistance: +3, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	olive foul-smelling sweatband of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +10, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	grievous experienced gym shorts	0		Experience: +2, Weapon Damage Percent: +50, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	Newton's warbear dress greaves of courage	0		Experience (Mysticality): +3, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	olive foul-smelling sweatband of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	grievous experienced gym shorts	0		Experience: +2, Weapon Damage Percent: +50, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	slick ankleweights of vim and vigor	0		Moxie: +10, Maximum HP Percent: +50, Single Equip, Last Available: "2014-12"
 7098	Temple Grandin's curative steel-toed beefy sweat socks	0		Muscle: +10, Damage Reduction: 9, Familiar Weight: +7, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6998,37 +6998,37 @@
 7109	jumbo delicious gray ghostly pecan pie	5	awesome	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	yummy candy mountain oyster	4	awesome	Last Available: "2014-12"
-7112	strong mediocre chocotini	5	decent	Last Available: "2014-12"
+7112	mediocre strong chocotini	5	decent	Last Available: "2014-12"
 7113	cyan censurious vibrating chocolate rabbit's foot of terror	0		Maximum MP Percent: +10, Spooky Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2014-12"
 7114	spoiled tumbling candy carrot	3	crappy	Last Available: "2014-12"
 7115	bland candy carrot cake	4	decent	Last Available: "2014-12"
 7116	smooth carrot-on-a-stick of the sweet-tooth	0		Moxie: +15, Candy Drop: +100, Last Available: "2014-12"
-7117	spinning Van der Graaf weasel stomping pants of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
-7118	low-calorie rotten mulberry	1	crappy	Last Available: "2014-12"
+7117	spinning Van der Graaf weasel stomping pants of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7118	rotten low-calorie mulberry	1	crappy	Last Available: "2014-12"
 7119	practically non-alcoholic perfectly mixed mulled berry wine	1	super ultra mega turbo EPIC	Last Available: "2014-12"
 7120	narrow lemony scales	0		Last Available: "2014-12"
-7121	spinning skewed prompt lemon party hat	0		Adventures: +3, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	spinning skewed prompt lemon party hat	0		Adventures: +3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	lemon shirt of the brazier	0		Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2014-12"
-7123	rosy-cheeked lemon drop trousers	0		Maximum HP Percent: +30, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	rosy-cheeked lemon drop trousers	0		Maximum HP Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	flattened red lemonhead caviar	0		Effect: "Astral Shell", Effect Duration: 61, Last Available: "2014-12"
 7125	wobbly frosty gummi sword of chilblains	0		Cold Damage: +25, Cold Spell Damage: +10, Last Available: "2014-12"
 7126	boiled small gummi fin	0		Effect: "Greedy Resolve", Effect Duration: 30, Last Available: "2014-12"
 7127	twirling padded chocolate cow bone	0		Damage Absorption: +20, Last Available: "2014-12"
 7128	corrupted triple-moist wet green gummi fang	0		Effect: "Eldritch Concentration", Effect Duration: 42, Last Available: "2014-12"
-7129	bland jumbo enchanted upside-down leftover canap&eacute;s	5	decent	Effect: "Goldentongue", Effect Duration: 35, Last Available: "2014-12"
+7129	jumbo bland enchanted upside-down leftover canap&eacute;s	5	decent	Effect: "Goldentongue", Effect Duration: 35, Last Available: "2014-12"
 7130	tolerable ghostly magnum of champagne	3	good	Last Available: "2014-12"
 7131	upside-down smelly veiny smooth cow creamer	0		Moxie: +15, Maximum HP: +10, Stench Spell Damage: +10, Last Available: "2014-12"
 7132	moist unsweetened wobbly tumbling Outer Wolf&trade; cologne	0		Effect: "Orchid Blood", Effect Duration: 39, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	bouncing upside-down blurry arcane researcher's beefcake's wolf whistle	0		Muscle: +25, Experience Percent (Mysticality): +10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7134	bouncing upside-down blurry arcane researcher's beefcake's wolf whistle	0		Muscle: +25, Experience Percent (Mysticality): +10, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
 7135	bland jumbo witch's bread	5	decent	Last Available: "2014-12"
 7136	vacuum-sealed super-flattened mirror witch's brew	0		Effect: "Spookypants", Effect Duration: 46, Last Available: "2014-12"
 7137	jittery rosewater-soaked Oprah's witch's bra of Gandalf	0		Maximum MP Percent: +50, Spell Critical Percent: +20, Stench Resistance: +3, Last Available: "2014-12"
-7138	practically non-alcoholic aged enchanted mid-level medieval mead	1	awesome	Effect: "Bloodstain-Resistant", Effect Duration: 20, Last Available: "2014-12"
+7138	aged enchanted practically non-alcoholic mid-level medieval mead	1	awesome	Effect: "Bloodstain-Resistant", Effect Duration: 20, Last Available: "2014-12"
 7139	vacuum-sealed wobbly R&uuml;mpelstiltz	0		Effect: "Icy Composition", Effect Duration: 25, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	extra-dry pulsating hi-octane carrot juice	0		Effect: "Sealed Brain", Effect Duration: 44, Last Available: "2014-12"
-7142	ionized blurry upside-down hare brush	0		Effect: "Spooky Flavor", Effect Duration: 12, Last Available: "2014-12"
+7142	ionized upside-down blurry hare brush	0		Effect: "Spooky Flavor", Effect Duration: 12, Last Available: "2014-12"
 7143	curative brawny hare pin	0		Muscle Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2014-12"
 7144	spinning odd coin	0		Last Available: "2014-12"
 7145	flavorless blinking cinnamon cannoli	3	decent	Last Available: "2014-12"
@@ -7043,16 +7043,16 @@
 7154	filling	0		Last Available: "2014-12"
 7155	fuchsia parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	coward's personal trainer's educational fire hose	0		Experience: +1, Experience Percent (Muscle): +10, Monster Level: -20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
-7158	thick flavorless blinking jittery fireman's lunch	5	decent	Last Available: "2014-12"
-7159	wholesome plain paper hat of the dark arts of terror	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Spooky Spell Damage: +10, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7157	coward's personal trainer's educational fire hose	0		Experience: +1, Experience Percent (Muscle): +10, Monster Level: -20, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7158	flavorless thick jittery blinking fireman's lunch	5	decent	Last Available: "2014-12"
+7159	wholesome plain paper hat of the dark arts of terror	0		Spell Damage Percent: +100, Maximum HP Percent: +10, Spooky Spell Damage: +10, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
 7160	rotten snack-sized ice cream sandwich	2	crappy	Last Available: "2014-12"
 7161	careful dangerous &quot;honey&quot; dipper of bravery	0		Weapon Damage: +10, Monster Level: -10, Spooky Resistance: +5, Last Available: "2014-12"
 7162	snack-sized decent plumber's lunch	2	good	Last Available: "2014-12"
 7163	experienced beefy skull gearshift knob of the blizzard	0		Muscle: +10, Experience: +2, Cold Spell Damage: +25, Last Available: "2014-12"
 7164	bland shaking nachos of the night	4	decent	Last Available: "2014-12"
 7165	spinning maroon Lo Pan's Sketcherz&trade; of the sewer of horror	0		Spell Critical Percent: +30, Stench Damage: +25, Spooky Spell Damage: +25, Last Available: "2014-12"
-7166	half-sized adequate spinning tumbling can of Adultwitch&trade;	2	good	Last Available: "2014-12"
+7166	adequate half-sized tumbling spinning can of Adultwitch&trade;	2	good	Last Available: "2014-12"
 7167	super-activated quadruple-moist smudge stick	0		Effect: "Flamibili Tea", Effect Duration: 41, Last Available: "2014-12"
 7168	non-energized fuchsia wall	0		Effect: "Dancing Prowess", Effect Duration: 52, Last Available: "2014-12"
 7169	drinkable tankard of ale	3	good	Last Available: "2014-12"
@@ -7060,7 +7060,7 @@
 7171	ionized enhanced tumbling jug of &quot;wine&quot;	0		Effect: "Snobby", Effect Duration: 33, Last Available: "2014-12"
 7172	juggling ball	0		Last Available: "2014-12"
 7173	bouncing crappy camera	0		Last Available: "2014-12"
-7174	small moldy enchanted humble pie	2	crappy	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2014-12"
+7174	moldy enchanted small humble pie	2	crappy	Effect: "Full of Wist", Effect Duration: 10, Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
 7176	shaking crappy camera	0		Last Available: "2014-12"
 7177	cold-filtered wobbly crappy waiter disguise	0		Effect: "The Style... of the Future", Effect Duration: 50
@@ -7073,12 +7073,12 @@
 7184	blue The Shield of Brook	0		
 7185	Red Zeppelin ticket	0		
 7186	huge Copperhead Charm (rampant)	0		
-7187	aged watered-down narrow unnamed cocktail	2	awesome	
+7187	watered-down aged narrow unnamed cocktail	2	awesome	
 7188	skewed handful of tips	0		
 7189	fuchsia crafty unrequired jacket	0		Maximum MP: +10
 7190	medical-grade tommy gun	0		HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	drum of tommy ammo	0		
-7192	squat maroon throwing knife	0		
+7192	maroon squat throwing knife	0		
 7193	throwing spoon	0		
 7194	throwing fork	0		
 7195	shaking lion tamer's breadchucks of the storm	0		Maximum MP Percent: +40, Experience (familiar): +2
@@ -7092,7 +7092,7 @@
 7203	red shaking forbidden Saturday Night Special	0		Spell Damage Percent: +50
 7204	pulsating lynyrd snare	0		
 7205	wobbly nippy fleetwood chain	0		Cold Damage: +10
-7206	bad enchanted Green Manalishi	3	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 15
+7206	enchanted bad Green Manalishi	3	decent	Effect: "It Tickles!  It Tickles!", Effect Duration: 15
 7207	huge wobbly blade of vim and vigor	0		Maximum HP Percent: +50
 7208	fire of unknown origin	0		
 7209	eagle's milk	1	good	
@@ -7113,7 +7113,7 @@
 7224	ghostly Jim Carey's studded Kashmir sweater	0		Damage Absorption: +80, Monster Level: +25
 7225	flavorless custard pie	3	decent	
 7226	tea for one	1	decent	
-7227	practically non-alcoholic bad fancy bottle of Evermore	1	decent	Effect: "Muscle Unbound", Effect Duration: 25
+7227	fancy bad practically non-alcoholic bottle of Evermore	1	decent	Effect: "Muscle Unbound", Effect Duration: 25
 7228	squat box	0		
 7229	enchanted hand-crafted wine	3	EPIC	Effect: "Sweet Nostalgia", Effect Duration: 35
 7230	mediocre rum	4	decent	
@@ -7138,7 +7138,7 @@
 7249	Thwaitgold dragonfly statuette	0		
 7250	family-friendly perfumed veiny sinister Sneaky Pete's jacket	0		Spell Damage: +10, Maximum HP: +10, Stench Resistance: +5, Sleaze Resistance: +1, Softcore Only, Free Pull, Last Available: "2014-03"
 7251	jug of Sneaky Pete's Mojo	0		Free Pull
-7252	cyan pulsating blurry shot of Sneaky Pete's Mojo	0		Free Pull
+7252	cyan blurry pulsating shot of Sneaky Pete's Mojo	0		Free Pull
 7253	spinning Anniversary Miniature Sword & Martini Guy	0		
 7254	blinking really cocktail shaker	0		Familiar Weight: +5
 7255	tolerable mini-martini	4	good	
@@ -7206,17 +7206,17 @@
 7317	skewed jar of baby ghosts	0		
 7318	Jim Carey's ghost of a necklace of the pedagogue of horror	0		Experience: +3, Monster Level: +25, Spooky Spell Damage: +25
 7319	lime green razor-sharp wizardly Elizabeth's Dollie	0		Mysticality: +25, Weapon Damage Percent: +25
-7320	polymerized bouncing upside-down Elizabeth's paintbrush	0		Effect: "Bright!", Effect Duration: 24
+7320	polymerized upside-down bouncing Elizabeth's paintbrush	0		Effect: "Bright!", Effect Duration: 24
 7321	Lo Pan's Stephen's lab coat of James Dean	0		Experience (Moxie): +3, Spell Critical Percent: +30
 7322	liquefied polymerized corrupted Stephen's secret formula	0		Effect: "substats.enh", Effect Duration: 18
 7323	huge Lo Pan's vibrating Jacob's rung	0		Maximum MP Percent: +10, Spell Critical Percent: +30
-7324	powdered cyan shaking battery	1		
-7325	fancy acceptable snakebite	4	good	Effect: "Hagg-ard", Effect Duration: 15
+7324	powdered shaking cyan battery	1		
+7325	acceptable fancy snakebite	4	good	Effect: "Hagg-ard", Effect Duration: 15
 7326	green shellacked rubber ribcage of incineration	0		Damage Reduction: 14, Hot Spell Damage: +50
 7327	powdered maroon twirling synthetic marrow	1		Effect: "Your Favorite Flavor", Effect Duration: 5
 7328	liquefied dry blurry funny bone	0		Effect: "Amorphous Cheer", Effect Duration: 33
 7329	red electrified half-melted spoon of bravery	0		Spooky Resistance: +5, MP Regen Min: 3, MP Regen Max: 5
-7330	dehydrated gray twirling spinning the funk	1		
+7330	dehydrated spinning twirling gray the funk	1		
 7331	moldy gunky chicken	3	crappy	
 7332	tumbling asbestos-lined doll head	0		Hot Resistance: +5
 7333	upside-down droopy doll eye	0		
@@ -7224,11 +7224,11 @@
 7335	padded paddle-ball of incineration	0		Damage Absorption: +20, Hot Spell Damage: +50
 7336	adjusted twirling sound effects record	0		Effect: "Well-Lubed", Effect Duration: 47
 7337	gray alphabet block	0		
-7338	chilled spinning jittery dancer	0		Effect: "Stinky Hands", Effect Duration: 69
+7338	chilled jittery spinning dancer	0		Effect: "Stinky Hands", Effect Duration: 69
 7339	music box mechanism	0		
 7340	asbestos-lined moose antlers	0		Hot Resistance: +5, Familiar Effect: "atk, 1xLep, cap 27"
 7341	adjusted huge jittery moose thought	0		Effect: "Sugar, Hello", Effect Duration: 11
-7342	bland thick narrow moose chocolate	5	decent	
+7342	thick bland narrow moose chocolate	5	decent	
 7343	fancy bad painting of a glass of wine	4	decent	Effect: "Human-Goblin Hybrid", Effect Duration: 25
 7344	oil painting of yourself	0		
 7345	spinning ornate picture frame	0		
@@ -7236,7 +7236,7 @@
 7347	thinker's ghost toga of horror	0		Mysticality: +10, Spooky Spell Damage: +25
 7348	small normal sheet cake	2	good	
 7349	ghost key	0		
-7350	jittery lime green picture of you	0		
+7350	lime green jittery picture of you	0		
 7351	rock-hard Staff of the Electric Range of Calamity Jane of the early riser	0		Damage Reduction: 5, Critical Hit Percent: +15, Adventures: +7
 7352	low-calorie rotten gray deluxe layer cake	1	crappy	
 7353	chunk of hot iron	0		
@@ -7251,7 +7251,7 @@
 7362	blinking purple extremely unsafe plaid skirt of dire peril	0		Weapon Damage: +20, Weapon Damage Percent: +100, Familiar Effect: "1xPotato, 1xFairy, cap 38"
 7363	frozen diffused bloodstain stick	0		Effect: "Ponderous Potency", Effect Duration: 39
 7364	fabric softener	0		
-7365	concentrated upside-down tumbling fabric hardener	0		Effect: "Red Misty-Eyed", Effect Duration: 38
+7365	concentrated tumbling upside-down fabric hardener	0		Effect: "Red Misty-Eyed", Effect Duration: 38
 7366	practically non-alcoholic bad huge bottle of laundry sherry	1	decent	
 7367	adjusted improved triple-aerosolized industrial strength starch	0		Effect: "You're Not Cooking", Effect Duration: 46, Wiki Name: "industrial strength starch"
 7368	moldy extra-flat panini	3	crappy	
@@ -7276,7 +7276,7 @@
 7387	vacuum-sealed Gene Tonic: Undead	0		Effect: "Yes, Can Haz", Effect Duration: 68, Last Available: "2014-04"
 7388	boiled improved spinning Gene Tonic: Humanoid	0		Effect: "Sweet Nostalgia", Effect Duration: 59, Last Available: "2014-04"
 7389	quantum diffused Gene Tonic: Insect	0		Effect: "Whole Latte Love", Effect Duration: 41, Last Available: "2014-04"
-7390	cold-filtered narrow bouncing Gene Tonic: Hippy	0		Effect: "One Foot Heavier", Effect Duration: 15, Last Available: "2014-04"
+7390	cold-filtered bouncing narrow Gene Tonic: Hippy	0		Effect: "One Foot Heavier", Effect Duration: 15, Last Available: "2014-04"
 7391	dry magnetized enhanced Gene Tonic: Orc	0		Effect: "Memory of Strength", Effect Duration: 37, Last Available: "2014-04"
 7392	triple-energized Gene Tonic: Demon	0		Effect: "Perfect Hair", Effect Duration: 46, Last Available: "2014-04"
 7393	quadruple-dry jittery Gene Tonic: Horror	0		Effect: "You Liver", Effect Duration: 63, Last Available: "2014-04"
@@ -7287,7 +7287,7 @@
 7398	improved moist twirling Gene Tonic: Weird	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 38, Last Available: "2014-04"
 7399	polarized non-energized Gene Tonic: Elf	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 68, Last Available: "2014-04"
 7400	pickled Gene Tonic: Mer-kin	0		Effect: "Nut-Rition", Effect Duration: 35, Last Available: "2014-04"
-7401	double-flattened modified ghostly cyan wobbly Gene Tonic: Slime	0		Effect: "White Knuckles", Effect Duration: 62, Last Available: "2014-04"
+7401	double-flattened modified cyan ghostly wobbly Gene Tonic: Slime	0		Effect: "White Knuckles", Effect Duration: 62, Last Available: "2014-04"
 7402	polymerized Gene Tonic: Penguin	0		Effect: "Rain Dancin'", Effect Duration: 30, Last Available: "2014-04"
 7403	nitrogenated Gene Tonic: Elemental	0		Effect: "Techno Bliss", Effect Duration: 14, Last Available: "2014-04"
 7404	moist unsweetened shaking Gene Tonic: Constellation	0		Effect: "Experimental Effect G-9", Effect Duration: 27, Last Available: "2014-04"
@@ -7317,44 +7317,44 @@
 7428	Taco Dan's Taco Stand's Taco Receipt	0		Last Available: "2014-05"
 7429	Beach Buck	0		Last Available: "2014-05"
 7430	energized anodized narrow Fun-Guy spore	0		Effect: "Egg-stra Arm", Effect Duration: 60, Last Available: "2014-05"
-7431	liquefied mirror twirling Boletus Broletus mushroom	0		Effect: "Hood Ridin'", Effect Duration: 24, Last Available: "2014-05"
+7431	liquefied twirling mirror Boletus Broletus mushroom	0		Effect: "Hood Ridin'", Effect Duration: 24, Last Available: "2014-05"
 7432	oxidized Omphalotus Omphaloskepsis mushroom	0		Effect: "Goldentongue", Effect Duration: 55, Last Available: "2014-05"
 7433	double-cold-filtered enhanced Gyromitra Dynomita mushroom	0		Effect: "Rotten Memories", Effect Duration: 25, Last Available: "2014-05"
-7434	ionized energized pulsating squat Helvella Haemophilia mushroom	0		Effect: "Uncaged Power", Effect Duration: 39, Last Available: "2014-05"
+7434	ionized energized squat pulsating Helvella Haemophilia mushroom	0		Effect: "Uncaged Power", Effect Duration: 39, Last Available: "2014-05"
 7435	flattened Stemonitis Staticus mushroom	0		Effect: "Bear Clawed", Effect Duration: 14, Last Available: "2014-05"
 7436	denatured Tremella Tarantella mushroom	0		Effect: "In Vino Vires", Effect Duration: 60, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	normal half-sized Beefy Crunch Pastaco	2	good	Last Available: "2014-05"
+7438	half-sized normal Beefy Crunch Pastaco	2	good	Last Available: "2014-05"
 7439	adequate Brain Food Pastaco	4	good	Last Available: "2014-05"
 7440	jumbo adequate Cool Brunch Pastaco	5	good	Last Available: "2014-05"
 7441	decent Medical Pastaco	3	good	Last Available: "2014-05"
 7442	normal Energy Buzz Pastaco	3	good	Last Available: "2014-05"
-7443	snack-sized bland shaking narrow Ludovico Pastaco	2	decent	Last Available: "2014-05"
-7444	tolerable triple-distilled overpowering mushroom wine	7	good	Last Available: "2014-05"
+7443	snack-sized bland narrow shaking Ludovico Pastaco	2	decent	Last Available: "2014-05"
+7444	triple-distilled tolerable overpowering mushroom wine	7	good	Last Available: "2014-05"
 7445	mediocre special purple complex mushroom wine	4	decent	Effect: "Vinegavotte", Effect Duration: 30, Last Available: "2014-05"
 7446	perfectly mixed smooth mushroom wine	4	EPIC	Last Available: "2014-05"
-7447	aged weak blood-red mushroom wine	2	awesome	Last Available: "2014-05"
-7448	triple-distilled special tolerable buzzing mushroom wine	6	good	Effect: "Big Flaming Whip", Effect Duration: 5, Last Available: "2014-05"
-7449	mediocre high-proof blurry swirling mushroom wine	10	decent	Last Available: "2014-05"
+7447	weak aged blood-red mushroom wine	2	awesome	Last Available: "2014-05"
+7448	special triple-distilled tolerable buzzing mushroom wine	6	good	Effect: "Big Flaming Whip", Effect Duration: 5, Last Available: "2014-05"
+7449	high-proof mediocre blurry swirling mushroom wine	10	decent	Last Available: "2014-05"
 7450	adequate blinking Taco Dan's Basic Taco Dan Taco	4	good	Last Available: "2014-05"
 7451	moldy Taco Dan's Taco Fish Fish Taco	3	crappy	Last Available: "2014-05"
 7452	Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	irresponsibly strong enchanted acceptable regular-size brogurt	8	good	Effect: "Ode to Booze", Effect Duration: 35, Last Available: "2014-05"
+7453	acceptable enchanted irresponsibly strong regular-size brogurt	8	good	Effect: "Ode to Booze", Effect Duration: 35, Last Available: "2014-05"
 7454	tolerable super-size brogurt	3	good	Last Available: "2014-05"
-7455	watered-down acceptable huge broberry brogurt	2	good	Last Available: "2014-05"
-7456	hand-crafted fortified brocolate brogurt	5	EPIC	Last Available: "2014-05"
+7455	acceptable watered-down huge broberry brogurt	2	good	Last Available: "2014-05"
+7456	fortified hand-crafted brocolate brogurt	5	EPIC	Last Available: "2014-05"
 7457	smooth skewed French bronilla brogurt	3	awesome	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	blinking industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	up-at-dawn Brogre brorts	0		Adventures: +5, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	up-at-dawn Brogre brorts	0		Adventures: +5, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	Oprah's Brogre brolo shirt	0		Maximum MP Percent: +50, Last Available: "2014-05"
-7464	twirling savvy Brogre bucket hat	0		Mysticality Percent: +20, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	twirling savvy Brogre bucket hat	0		Mysticality Percent: +20, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	mirror one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	squat avaricious horrifying cool 8-billed baseball cap	0		Moxie: +5, Spooky Damage: +25, Meat Drop: +30, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	squat avaricious horrifying cool 8-billed baseball cap	0		Moxie: +5, Spooky Damage: +25, Meat Drop: +30, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	jittery avaricious wool slick extremely wet T-shirt	0		Moxie: +10, Cold Resistance: +1, Meat Drop: +30, Last Available: "2014-05"
 7470	smelly dangerous shrimp fork of doom	0		Weapon Damage: +10, Stench Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2014-05"
 7471	non-improved Vulcanized huge BROS Energy Drink	0		Effect: "Mystically Oiled", Effect Duration: 41, Last Available: "2014-05"
@@ -7412,24 +7412,24 @@
 7523	space junk	0		Last Available: "2014-05"
 7524	super-enhanced triple-magnetized government	0		Effect: "Ocelot Eyes", Effect Duration: 28, Last Available: "2014-05"
 7525	nitrogenated Vulcanized alien drugs	0		Effect: "Here's Mud in Your Eye", Effect Duration: 59, Last Available: "2023-09"
-7526	purple shaking weird space book	0		Last Available: "2014-05"
+7526	shaking purple weird space book	0		Last Available: "2014-05"
 7527	narrow alien force field disruptor bean	0		Last Available: "2014-05"
 7528	cyan flame-wreathed energetic government-issued night-vision goggles	0		Maximum MP Percent: +20, Hot Spell Damage: +10, Single Equip, Last Available: "2014-05"
 7529	diet yummy loaf of alien bread	1	awesome	Last Available: "2014-05"
 7530	normal grilled cheese sandwich	3	good	Last Available: "2014-05"
 7531	vaporized alien protein powder	1	decent	Last Available: "2014-05"
-7532	special watered-down bad rocket fuel	2	decent	Effect: "Void Between the Stars", Effect Duration: 15, Last Available: "2014-05"
+7532	watered-down bad special rocket fuel	2	decent	Effect: "Void Between the Stars", Effect Duration: 15, Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	lousy watered-down gray stealth bomber	2	decent	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	shaking ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	flame-wreathed space beast fur hat	0		Hot Spell Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	pulsating skewed hardy space beast fur pants	0		Maximum HP: +50, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	flame-wreathed space beast fur hat	0		Hot Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	pulsating skewed hardy space beast fur pants	0		Maximum HP: +50, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	censurious space beast fur whip	0		Sleaze Resistance: +3, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	quilted thinker's space heater	0		Mysticality: +10, Damage Absorption: +40, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	quilted thinker's space heater	0		Mysticality: +10, Damage Absorption: +40, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	spinning space bar	0		Last Available: "2014-05"
 7545	perfectly mixed weak jittery space port	2	EPIC	Last Available: "2014-05"
 7546	cyan studded Socratic space needle	0		Experience (Mysticality): +1, Damage Absorption: +80, Last Available: "2014-05"
@@ -7458,7 +7458,7 @@
 7569	mirror asbestos-lined razor-sharp Rosewater's Time Bandit Badge of Courage	0		Mysticality Percent: +30, Weapon Damage Percent: +25, Hot Resistance: +5
 7570	chilled polymerized fuchsia Friendliness Beverage	0		Effect: "Burning Hands", Effect Duration: 55
 7571	blue nippy silent pea shooter of courage	0		Cold Damage: +10, Spooky Resistance: +3
-7572	small moldy D roll	2	crappy	
+7572	moldy small D roll	2	crappy	
 7573	banded kiwi beak	0		Damage Absorption: +100, Item Drop: +5
 7574	extra-dry lousy twirling New Zealand iced tea	5	decent	
 7575	family-friendly Annie Oakley's droll monocle	0		Critical Hit Percent: +20, Sleaze Resistance: +1, Single Equip
@@ -7475,14 +7475,14 @@
 7586	helix fossil	0		
 7587	olive S.S. Ticket	0		Familiar Weight: +5
 7588	Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	hand-crafted weak glass of &quot;milk&quot;	2	EPIC	Last Available: "2014-07"
+7589	weak hand-crafted glass of &quot;milk&quot;	2	EPIC	Last Available: "2014-07"
 7590	perfectly mixed practically non-alcoholic cup of &quot;tea&quot;	1	EPIC	Last Available: "2014-07"
-7591	practically non-alcoholic hand-crafted yellow thermos of &quot;whiskey&quot;	1	EPIC	Last Available: "2014-07"
+7591	hand-crafted practically non-alcoholic yellow thermos of &quot;whiskey&quot;	1	EPIC	Last Available: "2014-07"
 7592	hand-crafted Lucky Lindy	3	EPIC	Last Available: "2014-07"
 7593	bad watered-down Bee's Knees	2	decent	Last Available: "2014-07"
 7594	smooth high-proof Sockdollager	7	awesome	Last Available: "2014-07"
 7595	tolerable shaking Ish Kabibble	4	good	Last Available: "2014-07"
-7596	special perfectly mixed red Hot Socks	3	EPIC	Effect: "Speed of the Internet", Effect Duration: 45, Last Available: "2014-07"
+7596	perfectly mixed special red Hot Socks	3	EPIC	Effect: "Speed of the Internet", Effect Duration: 45, Last Available: "2014-07"
 7597	triple-distilled tolerable jittery Phonus Balonus	9	good	Last Available: "2014-07"
 7598	acceptable Flivver	3	good	Last Available: "2014-07"
 7599	boozy bad skewed Sloppy Jalopy	5	decent	Last Available: "2014-07"
@@ -7490,7 +7490,7 @@
 7601	aerosolized enhanced temporary yak tattoo	0		Effect: "All Branned Up", Effect Duration: 34
 7602	chilled Fitspiration&trade; poster	0		Effect: "Stone-Faced", Effect Duration: 30
 7603	tarnished gray neckbeard	0		Effect: "Shawarma Warm War", Effect Duration: 54
-7604	denatured shaking blurry artisanal hand-squeezed wheatgrass juice	0		Effect: "Chalky Hand", Effect Duration: 31
+7604	denatured blurry shaking artisanal hand-squeezed wheatgrass juice	0		Effect: "Chalky Hand", Effect Duration: 31
 7605	deionized adjusted punk patch	0		Effect: "Butt-Rock Hair", Effect Duration: 50
 7606	double-pressed oxidized steampunk potion	0		Effect: "Sleazy Jellied", Effect Duration: 34
 7607	wet colloidal twirling vial of swamp vapors	0		Effect: "Stench Jellied", Effect Duration: 21
@@ -7510,7 +7510,7 @@
 7621	dry ninja eyeblack	0		Effect: "Concentration", Effect Duration: 52
 7622	nitrogenated button rouge	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 57
 7623	triple-enhanced pulsating Red Army camouflage kit	0		Effect: "Hobonic", Effect Duration: 44
-7624	nitrogenated irradiated squat blurry lynyrd skinner toothblack	0		Effect: "Stinky Hands", Effect Duration: 47
+7624	nitrogenated irradiated blurry squat lynyrd skinner toothblack	0		Effect: "Stinky Hands", Effect Duration: 47
 7625	triple-enhanced flask of rainwater	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 15
 7626	improved adjusted jittery oyster badge	0		Effect: "Glo-Face", Effect Duration: 40
 7627	tarnished blurry plastic Jefferson wings	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 36
@@ -7534,7 +7534,7 @@
 7645	life preserver	0		
 7646	lightning milk	0		
 7647	aquaconda brain	0		
-7648	mirror skewed thunder thigh	0		
+7648	skewed mirror thunder thigh	0		
 7649	unsweetened improved maroon gourmet gourami oil	0		Effect: "Frisky Spirit", Effect Duration: 40
 7650	concentrated tarnished catfish whiskers	0		Effect: "Boon of the Storm Tortoise", Effect Duration: 19
 7651	red freshwater fishbone	0		
@@ -7553,13 +7553,13 @@
 7664	nitrogenated Ancient Protector Soda	0		Effect: "Less Pervious", Effect Duration: 49
 7665	triple-enhanced energized pickled jittery cyan liquid ice	0		Effect: "Grape Expectations", Effect Duration: 23
 7666	watered-down acceptable pulsating bouncing Wet Russian	2	good	
-7667	miniature tasty filet of The Fish	2	awesome	
+7667	tasty miniature filet of The Fish	2	awesome	
 7668	Thwaitgold spider statuette	0		
 7669	tumbling Oprah's Herculean thunder down underwear of the sewer	0		Experience (Muscle): +1, Maximum MP Percent: +50, Stench Damage: +25, Lasts Until Rollover
 7670	nippy quilted famous raincoat of horror	0		Damage Absorption: +40, Cold Damage: +10, Spooky Spell Damage: +25, Lasts Until Rollover
 7671	green hardy rosy-cheeked Fonzie's lightning rod	0		Experience (Moxie): +1, Maximum HP Percent: +30, Maximum HP: +50, Lasts Until Rollover
 7672	auspicious law-abiding citizen cane	0		Item Drop: +10, Single Equip
-7673	bad boozy legitimate business on the beach	5	decent	
+7673	boozy bad legitimate business on the beach	5	decent	
 7674	coward's hep waders	0		Monster Level: -20, Familiar Effect: "1xPotato, 1xVolley, cap 12"
 7675	normal jive turkey leg	3	good	
 7676	Jim Carey's birdbone corset	0		Monster Level: +25
@@ -7581,10 +7581,10 @@
 7692	deadly Sinatra's hand whip	0		Experience (Moxie): +5, Weapon Damage: +5, Item Drop: +5, Last Available: "2014-08"
 7693	spinning perfumed beefy glow-in-the-dark necklace of the storm	0		Muscle: +10, Maximum MP Percent: +40, Stench Resistance: +5, Last Available: "2014-08"
 7694	squat Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	pulsating fireproof Jim Carey's cap gun of the pedagogue	0		Experience: +3, Monster Level: +25, Hot Resistance: +3, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	pulsating fireproof Jim Carey's cap gun of the pedagogue	0		Experience: +3, Monster Level: +25, Hot Resistance: +3, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	bouncing flame-retardant horrifying cassette player	0		Spooky Damage: +25, Hot Resistance: +1, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
-7698	olive pulsating mirror rubber spider	0		Last Available: "2014-08"
+7698	olive mirror pulsating rubber spider	0		Last Available: "2014-08"
 7699	&quot;KICK ME&quot; sign	0		Last Available: "2014-08"
 7700	cold-filtered cold-filtered confiscated comic book	0		Effect: "Hobo Flavor", Effect Duration: 39, Last Available: "2014-08"
 7701	triple-liquefied bouncing confiscated cell phone	0		Effect: "Phorcefullness", Effect Duration: 62, Last Available: "2014-08"
@@ -7592,16 +7592,16 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	denatured tumbling rubber nubbin	0		Effect: "Moose Wisdom", Effect Duration: 55, Last Available: "2014-08"
 7708	executive rubber cape of wisdom	0		Mysticality: +15, Meat Drop: +40, Last Available: "2014-08"
-7709	huge frosty arcane researcher's stylish Thor's Pliers of extreme caution	0		Moxie: +25, Experience Percent (Mysticality): +10, Monster Level: -25, Cold Spell Damage: +10, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	huge frosty arcane researcher's stylish Thor's Pliers of extreme caution	0		Moxie: +25, Experience Percent (Mysticality): +10, Monster Level: -25, Cold Spell Damage: +10, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	double-nitrogenated tarnished candy UFOs	0		Effect: "Okee-Dokee Go!", Effect Duration: 69
 7711	water wings for babies of terror of the early riser	0		Spooky Spell Damage: +10, Adventures: +7
-7712	blinking beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	delicious special Strix stix	3	awesome	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 5
+7712	blinking beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7713	special delicious Strix stix	3	awesome	Effect: "Stevedave's Shanty of Superiority", Effect Duration: 5
 7714	asbestos-lined curative brainy vampire pellet	0		Mysticality: +5, Hot Resistance: +5, HP Regen Min: 3, HP Regen Max: 5
-7715	high-proof hand-crafted non-aged vinegar	7	EPIC	
+7715	hand-crafted high-proof non-aged vinegar	7	EPIC	
 7716	skewed fireproof unsanitized scalpel	0		Hot Resistance: +3
 7717	upside-down double-paned gladiator tunica	0		Cold Resistance: +5
 7718	Roman sadnals of the detective	0		Item Drop: +20, Single Equip
@@ -7639,14 +7639,14 @@
 7750	cyan Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	wobbly Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	energetic Xiblaxian xeno-detection goggles	0		Maximum MP Percent: +20, Single Equip, Last Available: "2014-09"
-7753	blinking up-at-dawn sizzling Xiblaxian stealth cowl	0		Hot Damage: +10, Adventures: +5, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	blinking up-at-dawn sizzling Xiblaxian stealth cowl	0		Hot Damage: +10, Adventures: +5, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	blinking hardened Xiblaxian stealth trousers of horror	0		Damage Reduction: 3, Spooky Spell Damage: +25, Last Available: "2014-09"
 7755	flame-wreathed Xiblaxian stealth vest of the cougar	0		Moxie: +20, Hot Spell Damage: +10, Last Available: "2014-09"
 7756	moldy Xiblaxian ultraburrito	3	crappy	Last Available: "2014-09"
 7757	mediocre weak Xiblaxian space-whiskey	2	decent	Last Available: "2014-09"
 7758	red Xiblaxian residence-cube	0		Last Available: "2014-09"
-7759	energized skewed narrow They liver	0		Effect: "Covetous Robbery", Effect Duration: 69, Last Available: "2014-09"
-7760	decent small mirror They liver popsicle	2	good	Last Available: "2014-09"
+7759	energized narrow skewed They liver	0		Effect: "Covetous Robbery", Effect Duration: 69, Last Available: "2014-09"
+7760	small decent mirror They liver popsicle	2	good	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	holo-platoon	0		Last Available: "2014-09"
@@ -7658,7 +7658,7 @@
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	scorching coward's Personal Ventilation Unit of dire peril	0		Weapon Damage: +20, Monster Level: -20, Hot Damage: +25, Single Equip, Last Available: "2014-10"
 7771	diffused galvanized red the most dangerous bait	0		Effect: "Sleazy Jellied", Effect Duration: 65, Last Available: "2014-10"
-7772	adequate big &quot;meat&quot; stick	5	good	Last Available: "2014-10"
+7772	big adequate &quot;meat&quot; stick	5	good	Last Available: "2014-10"
 7773	pickled blurry transdermal smoke patch	1	crappy	Last Available: "2014-10"
 7774	twirling specialty ammo bandolier	0		Last Available: "2014-10"
 7775	squat pair of plants of the dark arts of the blizzard of terror	0		Spell Damage Percent: +100, Cold Spell Damage: +25, Spooky Spell Damage: +10, Last Available: "2014-10"
@@ -7668,12 +7668,12 @@
 7779	vacuum-sealed quantum ghostly red experimental serum G-9	0		Effect: "Steroid Boost", Effect Duration: 16, Last Available: "2014-10"
 7780	experienced boxer's heavy-duty clipboard of horror	0		Muscle Percent: +10, Experience: +2, Spooky Spell Damage: +25, Damage Reduction: 8, Last Available: "2014-10"
 7781	reassuring electrified wholesome battery-powered drill of the early riser	0		Maximum HP Percent: +10, Spooky Resistance: +1, Adventures: +7, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-10"
-7782	bite-sized normal limp broccoli	1	good	Last Available: "2014-10"
-7783	Jack Frost's crafty supercool hat	0		Moxie Percent: +20, Maximum MP: +10, Cold Spell Damage: +50, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
+7782	normal bite-sized limp broccoli	1	good	Last Available: "2014-10"
+7783	Jack Frost's crafty supercool hat	0		Moxie Percent: +20, Maximum MP: +10, Cold Spell Damage: +50, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
 7784	tarnished skewed monkey barf	0		Effect: "Okee-Dokee Computer", Effect Duration: 33, Last Available: "2014-10"
 7785	wet lime green candy	0		Effect: "Scorpio Rising", Effect Duration: 57, Last Available: "2014-10"
 7786	upside-down quilted baleful jangly bracelet of the brute	0		Muscle Percent: +30, Spell Damage: +25, Damage Absorption: +40, Last Available: "2014-10"
-7787	deadly cuddly teddy bear	0		Weapon Damage: +5, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	deadly cuddly teddy bear	0		Weapon Damage: +5, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	spinning ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	maroon ghostly fireproof MacGyver's first-aid pouch	0		Maximum MP: +100, Hot Resistance: +3, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7681,17 +7681,17 @@
 7792	mirror SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	teal bottle-opener keycard	0		Last Available: "2014-10"
 7794	upside-down Armory keycard	0		Last Available: "2014-10"
-7795	snack-sized delicious initiative shawarma	2	awesome	Last Available: "2014-10"
+7795	delicious snack-sized initiative shawarma	2	awesome	Last Available: "2014-10"
 7796	flavorless green warm war shawarma	3	decent	Last Available: "2014-10"
 7797	bland massive karma shawarma	9	decent	Last Available: "2014-10"
 7798	mediocre Jungle Juice	3	decent	Last Available: "2014-10"
 7799	bad Amnesiac Ale	3	decent	Last Available: "2014-10"
-7800	watered-down perfectly mixed Highest Bitter	2	super EPIC	Last Available: "2014-10"
+7800	perfectly mixed watered-down Highest Bitter	2	super EPIC	Last Available: "2014-10"
 7801	red groovy stylish mercenary pistol	0		Moxie: +25, Moxie Percent: +10, Last Available: "2014-10"
 7802	foul-smelling healthy mercenary rifle	0		Maximum HP Percent: +20, Stench Damage: +10, Last Available: "2014-10"
 7803	Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
 7804	Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
-7805	pulsating blurry Merc Core challenge coin	0		Last Available: "2014-10"
+7805	blurry pulsating Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
 7807	TI-9000 calculator	0		
 7808	unused soap	0		
@@ -7700,7 +7700,7 @@
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	rotten seared dino steak	3	crappy	
-7814	mediocre weak cyan bottle of drinkin' gas	2	decent	
+7814	weak mediocre cyan bottle of drinkin' gas	2	decent	
 7815	handful of napalm	0		
 7816	mirror dove DNA	0		
 7817	ghostly gelatinous meat mass	0		
@@ -7713,11 +7713,11 @@
 7824	flame-retardant beefcake's iShield of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Hot Resistance: +1, Damage Reduction: 6
 7825	executive miser's grievous earbuds	0		Weapon Damage Percent: +50, Meat Drop: 50, Single Equip
 7826	teal clever personal trainer's iFlail of the early riser	0		Experience Percent (Muscle): +10, Maximum MP: +20, Adventures: +7
-7827	miniature stale unidentifiable dried fruit	2	decent	
+7827	stale miniature unidentifiable dried fruit	2	decent	
 7828	perfectly mixed weak flat cider	2	EPIC	
 7829	green Jim Carey's manspreader's Van der Graaf trench lighter	0		Monster Level: 35, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-10"
-7830	dry alkaline spinning pulsating experimental serum P-00	0		Effect: "Wise Spirit", Effect Duration: 16, Last Available: "2014-10"
-7831	red tumbling military-grade fingernail clippers	0		Last Available: "2014-10"
+7830	dry alkaline pulsating spinning experimental serum P-00	0		Effect: "Wise Spirit", Effect Duration: 16, Last Available: "2014-10"
+7831	tumbling red military-grade fingernail clippers	0		Last Available: "2014-10"
 7832	encrypted micro-cassette recorder	0		Last Available: "2014-10"
 7833	gore bucket	0		Last Available: "2014-10"
 7834	pack of smokes	0		Last Available: "2014-10"
@@ -7734,8 +7734,8 @@
 7845	modified perl necklace	0		Effect: "Alchemical, Brother", Effect Duration: 45, Last Available: "2014-12"
 7846	cold-filtered Fudge Fiber Armor Plating	0		Effect: "Salty Mouth", Effect Duration: 42, Last Available: "2014-12"
 7847	deionized skewed ruby on canes	0		Effect: "Healthy, Elfy, and Wise", Effect Duration: 57, Last Available: "2014-12"
-7848	half-sized spoiled petit fortran	2	crappy	Last Available: "2014-12"
-7849	rotten miniature java cookie	2	crappy	Last Available: "2014-12"
+7848	spoiled half-sized petit fortran	2	crappy	Last Available: "2014-12"
+7849	miniature rotten java cookie	2	crappy	Last Available: "2014-12"
 7850	adequate cookie cookie	4	good	Last Available: "2014-12"
 7851	Jeselnik's plastic exo-suited miner	0		Sleaze Damage: +25, Last Available: "2014-12"
 7852	plastic semi-autonomous drill unit of the wise owl	0		Mysticality: +20, Last Available: "2014-12"
@@ -7743,12 +7743,12 @@
 7854	maroon stylish plastic Crimbot	0		Moxie: +25, Last Available: "2014-12"
 7855	toasty plastic Crimbomega	0		Hot Damage: +5, Last Available: "2014-12"
 7856	aerosolized irradiated flask of mining oil	0		Effect: "Macho Profundo", Effect Duration: 57, Last Available: "2014-12"
-7857	Rosewater's radiation-resistant helmet	0		Mysticality Percent: +30, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	ghostly wobbly Newton's servo-assisted exo-pants	0		Experience (Mysticality): +3, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	Rosewater's radiation-resistant helmet	0		Mysticality Percent: +30, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	ghostly wobbly Newton's servo-assisted exo-pants	0		Experience (Mysticality): +3, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	shaking jittery Van der Graaf banded high-energy mining laser	0		Damage Absorption: +100, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
-7862	huge jittery cylindrical mold	0		Last Available: "2014-12"
+7862	jittery huge cylindrical mold	0		Last Available: "2014-12"
 7863	red Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	squat Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
@@ -7767,7 +7767,7 @@
 7878	wobbly Crimbot schematic: Mega Vise	0		Last Available: "2014-12"
 7879	pulsating jittery Crimbot schematic: Mobile Girder	0		Last Available: "2014-12"
 7880	Crimbot schematic: Swiss Arm	0		Last Available: "2014-12"
-7881	blinking skewed Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
+7881	skewed blinking Crimbot schematic: Data Analyzer	0		Last Available: "2014-12"
 7882	Crimbot schematic: Maxi-Mag Lite	0		Last Available: "2014-12"
 7883	upside-down Crimbot schematic: Bit Masher	0		Last Available: "2014-12"
 7884	Crimbot schematic: Camera Claw	0		Last Available: "2014-12"
@@ -7776,7 +7776,7 @@
 7887	squat Crimbot schematic: Ribbon Manipulator	0		Last Available: "2014-12"
 7888	Crimbot schematic: Power Stapler	0		Last Available: "2014-12"
 7889	Crimbot schematic: Grease Gun	0		Last Available: "2014-12"
-7890	green upside-down Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
+7890	upside-down green Crimbot schematic: Grease / Regular Gun	0		Last Available: "2014-12"
 7891	tumbling Crimbot schematic: Snow Blower	0		Last Available: "2014-12"
 7892	Crimbot schematic: Cold Shoulder	0		Last Available: "2014-12"
 7893	blurry spinning Crimbot schematic: Candle Lighter	0		Last Available: "2014-12"
@@ -7788,12 +7788,12 @@
 7899	maroon Crimbot schematic: High-Speed Fan	0		Last Available: "2014-12"
 7900	blinking Crimbot schematic: Big Wheel	0		Last Available: "2014-12"
 7901	squat cyan Crimbot schematic: Hoverjack	0		Last Available: "2014-12"
-7902	jittery tumbling Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
+7902	tumbling jittery Crimbot schematic: Gun Legs	0		Last Available: "2014-12"
 7903	Crimbot schematic: Heavy Treads	0		Last Available: "2014-12"
 7904	Crimbot schematic: Rocket Skirt	0		Last Available: "2014-12"
 7905	twirling green recovered elf magazine	0		Last Available: "2014-12"
 7906	recovered elf toothbrush	0		Last Available: "2014-12"
-7907	upside-down green squat recovered elf sleeping pills	0		Last Available: "2014-12"
+7907	green upside-down squat recovered elf sleeping pills	0		Last Available: "2014-12"
 7908	recovered elf underpants	0		Last Available: "2014-12"
 7909	skewed recovered elf wallet	0		Last Available: "2014-12"
 7910	pulsating recovered elf pocketwatch	0		Last Available: "2014-12"
@@ -7808,7 +7808,7 @@
 7919	unsweetened Big Punk	0		Effect: "Nigh-Invincible", Effect Duration: 13
 7920	cyan fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	practically non-alcoholic lousy enchanted Friendly Turkey	1	decent	Effect: "Puddingface", Effect Duration: 35, Last Available: "2014-11"
+7922	lousy enchanted practically non-alcoholic Friendly Turkey	1	decent	Effect: "Puddingface", Effect Duration: 35, Last Available: "2014-11"
 7923	irresponsibly strong hand-crafted Agitated Turkey	8	EPIC	Last Available: "2014-11"
 7924	smooth Ambitious Turkey	4	awesome	Last Available: "2014-11"
 7925	jumbo tasty neutron lollipop	5	awesome	Last Available: "2014-12"
@@ -7827,7 +7827,7 @@
 7945	table	0		
 7946	bouncing supercharged dance instructor's outlaw bandana of the scaredy-cat	0		Experience Percent (Moxie): +10, Maximum MP Percent: +30, Monster Level: -15
 7947	weak artisanal whiskey in a broken glass	2	EPIC	
-7948	weak delicious shot of mescal	2	awesome	
+7948	delicious weak shot of mescal	2	awesome	
 7949	mediocre weak lime green glass of herbal tequila	2	decent	
 7950	minin' dynamite	0		
 7951	olive MacGyver's plaid cowboy hat of the glutton	0		Maximum MP: +100, Food Drop: +100, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7842,7 +7842,7 @@
 7960	copy of a jerk adventurer's father's diary	0		
 7961	scorching Jim Carey's Oprah's Staff of Ed of doom	0		Maximum MP Percent: +50, Monster Level: +25, Hot Damage: +25, Spooky Spell Damage: +50
 7962	Eye of Ed	0		
-7963	blurry bouncing amulet	0		
+7963	bouncing blurry amulet	0		
 7964	tumbling teal Staff of Fats of courage	0		Spooky Resistance: +3
 7965	Holy MacGuffin	0		
 7966	huge Ka coin	0		
@@ -7850,13 +7850,13 @@
 7968	topiary nugglet	0		
 7969	beehive	0		
 7970	boning knife	0		
-7971	green upside-down Aggressive Carrot	0		Free Pull
+7971	upside-down green Aggressive Carrot	0		Free Pull
 7972	dried mummified fig	1	decent	
 7973	distilled jittery mummified loaf of bread	1	decent	
-7974	diluted huge maroon mummified beef haunch	1	good	Effect: "Superhuman Sarcasm", Effect Duration: 20
+7974	diluted maroon huge mummified beef haunch	1	good	Effect: "Superhuman Sarcasm", Effect Duration: 20
 7975	linen bandages	0		
 7976	cotton bandages	0		
-7977	maroon skewed silk bandages	0		
+7977	skewed maroon silk bandages	0		
 7978	holy spring water	0		
 7979	spirit beer	0		
 7980	sacramental wine	0		
@@ -7876,26 +7876,26 @@
 7994	Tesla energetic pepper mill	0		Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
 7995	foul-smelling Tesla pelerine	0		Stench Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
 7996	squat baleful strapping phantom mask	0		Muscle: +5, Spell Damage: +25, Single Equip, Last Available: "2015-12"
-7997	boiled spinning squat polyesterene powder	1		Last Available: "2015-12"
-7998	diluted blinking fuchsia squat powder	1		Last Available: "2015-12"
+7997	boiled squat spinning polyesterene powder	1		Last Available: "2015-12"
+7998	diluted squat blinking fuchsia powder	1		Last Available: "2015-12"
 7999	frozen enhanced spinning choco-Crimbot	0		Effect: "Booing Radly", Effect Duration: 14, Last Available: "2014-12"
 8000	double-moist flattened smart watch	0		Effect: "Biologically Shocked", Effect Duration: 30, Last Available: "2014-12"
 8001	wet skewed augmented-reality shades	0		Effect: "Extra-Thick Blood", Effect Duration: 33, Last Available: "2014-12"
-8002	twirling curative toy Crimbot mega face	0		HP Regen Min: 3, HP Regen Max: 5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
-8003	skewed mirror frosty toy Crimbot power glove	0		Cold Spell Damage: +10, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	lard-coated toy Crimbot super fist	0		Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	lion tamer's toy Crimbot rocket legs	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	twirling curative toy Crimbot mega face	0		HP Regen Min: 3, HP Regen Max: 5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12"
+8003	skewed mirror frosty toy Crimbot power glove	0		Cold Spell Damage: +10, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	lard-coated toy Crimbot super fist	0		Sleaze Spell Damage: +25, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	lion tamer's toy Crimbot rocket legs	0		Experience (familiar): +2, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	super-improved spinning Crimbot battery	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 58, Last Available: "2014-12"
 8007	huge Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	mirror blue Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	spinning rosewater-soaked Crimbomega drive chain of extreme caution of mayonnaise	0		Monster Level: -25, Sleaze Spell Damage: +50, Stench Resistance: +3, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	spinning rosewater-soaked Crimbomega drive chain of extreme caution of mayonnaise	0		Monster Level: -25, Sleaze Spell Damage: +50, Stench Resistance: +3, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
-8016	liquefied liquefied jittery huge fitness wristband	0		Effect: "Alpine Mintiness", Effect Duration: 28, Last Available: "2014-12"
+8016	liquefied liquefied huge jittery fitness wristband	0		Effect: "Alpine Mintiness", Effect Duration: 28, Last Available: "2014-12"
 8017	dry flask of tainted mining oil	0		Effect: "Pork Power", Effect Duration: 64, Last Available: "2014-12"
 8018	nitrogenated blinking blinking and rain stick	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 56
 8019	Chateau Mantegna room key	0		Free Pull, Last Available: "2015-01"
@@ -7941,7 +7941,7 @@
 8060	stanky hale The Joke Book of the Dead	0		Maximum HP: +20, Stench Spell Damage: +25, Luck: -6
 8061	The Clown Crown	0		Luck: -6
 8062	coffee cup	0		Luck: -2
-8063	gray blinking Tales of Spelunking	0		Last Available: "2015-12"
+8063	blinking gray Tales of Spelunking	0		Last Available: "2015-12"
 8064	monkey statuette	0		Free Pull, Last Available: "2015-12"
 8065	banana	0		Familiar Weight: +5
 8066	mixed jittery	1	decent	Last Available: "2015-12"
@@ -7952,15 +7952,15 @@
 8071	blurry red warehouse inventory page	0		
 8072	shaking janitor sponge	0		
 8073	upside-down Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	curative personal trainer's sage Spelunker's fedora	0		Mysticality Percent: +10, Experience Percent (Muscle): +10, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	curative personal trainer's sage Spelunker's fedora	0		Mysticality Percent: +10, Experience Percent (Muscle): +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	prompt fireproof Spelunker's whip of the cougar	0		Moxie: +20, Hot Resistance: +3, Adventures: +3, Last Available: "2015-12"
-8076	rosewater-soaked frosty Spelunker's khakis of bravery	0		Cold Spell Damage: +10, Spooky Resistance: +5, Stench Resistance: +3, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	rosewater-soaked frosty Spelunker's khakis of bravery	0		Cold Spell Damage: +10, Spooky Resistance: +5, Stench Resistance: +3, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	pulsating Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	blinking blue Spelunker of Fortune (used)	0		Skill: "Speluck"
 8086	still-beating spleen	0		
 8087	Thwaitgold scarab beetle statuette	0		
-8088	narrow blurry jewel	0		
+8088	blurry narrow jewel	0		
 8089	red headless sparrow	0		
 8090	mangled squirrel	0		
 8091	blue rat carcass	0		
@@ -7996,7 +7996,7 @@
 8121	ruddy garland of the bloodbag	0		Maximum HP Percent: +40, Maximum HP: +100, Single Equip, Last Available: "2018-12"
 8122	teal rosewater-soaked sizzling gunnysack	0		Hot Damage: +10, Stench Resistance: +3, Last Available: "2018-12"
 8123	miser's forbidden garibaldi	0		Spell Damage Percent: +50, Meat Drop: +10, Last Available: "2018-12"
-8124	boxer's slick girdle	0		Moxie: +10, Muscle Percent: +10, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	boxer's slick girdle	0		Moxie: +10, Muscle Percent: +10, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	wool gloves of the pedagogue	0		Experience: +3, Cold Resistance: +1, Single Equip, Last Available: "2018-12"
 8126	twisted huge smithereens	1		Effect: "Sharp Weapon", Effect Duration: 10, Last Available: "2018-12"
 8127	narrow chilly fiberglass fetish of Leguizamo	0		Monster Level: +20, Cold Damage: +5, Last Available: "2018-12"
@@ -8005,7 +8005,7 @@
 8130	huge Van der Graaf hale fiberglass frock	0		Maximum HP: +20, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-12"
 8131	huge mansplainer's rosy-cheeked fiberglass fingerguard	0		Maximum HP Percent: +30, Monster Level: +15, Single Equip, Last Available: "2018-12"
 8132	Jack Frost's fiberglass fedora of the wise owl	0		Mysticality: +20, Cold Spell Damage: +50, Last Available: "2018-12"
-8133	dehydrated pulsating purple fiberglass fibers	1		Last Available: "2018-12"
+8133	dehydrated purple pulsating fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	talisman of Renenutet	0		
@@ -8038,7 +8038,7 @@
 8164	occult wizardly remaindered axe	0		Mysticality: +25, Spell Damage Percent: +25
 8165	mirror green low-budget shield	0		Damage Reduction: 3
 8166	huge blinking curative rock-hard cr&ecirc;epy mask	0		Damage Reduction: 5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "spooky atk, cap 5"
-8167	miniature enchanted delicious narrow baguette	2	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
+8167	delicious miniature enchanted narrow baguette	2	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
 8168	glob of icing	0		
 8169	alkaline ginger snaps	0		Effect: "The Halls of Muscularity", Effect Duration: 31
 8170	diffused huge teal mostly-broken sunglasses	0		Effect: "Analog Drunk", Effect Duration: 64
@@ -8047,7 +8047,7 @@
 8173	olive resourceful sewer snake	0		Maximum MP: +50
 8174	flavorless pigeon egg	3	decent	
 8175	supercool strapping jaunty feather	0		Muscle: +5, Moxie Percent: +20
-8176	acceptable practically non-alcoholic premium malt liquor	1	good	
+8176	practically non-alcoholic acceptable premium malt liquor	1	good	
 8177	pulsating Usain Bolt's dangerous brown paper pants	0		Weapon Damage: +10, Initiative: +80
 8178	brown paper bag mask of the pedagogue of dire peril	0		Experience: +3, Weapon Damage: +20
 8179	grievous ring of telling skeletons what to do	0		Weapon Damage Percent: +50, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,19 +8056,19 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	olive Tesla bread basket	0		MP Regen Min: 7, MP Regen Max: 10
 8184	yellow Ed the Undying exhibit crate	0		
-8185	weightlifter's The Crown of Ed the Undying of the ox	0		Muscle: 35, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	weightlifter's The Crown of Ed the Undying of the ox	0		Muscle: 35, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	wobbly Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
 8188	smooth Cherrytastrophe wine cooler	3	awesome	
 8189	boozy bad Radberry Rip wine cooler	5	decent	
 8190	delicious cyan spinning Orangemageddon wine cooler	3	awesome	
-8191	watered-down bad Breakfast Blast wine cooler	2	decent	
-8192	lousy weak skewed cyan Citrus Crush wine cooler	2	decent	
+8191	bad watered-down Breakfast Blast wine cooler	2	decent	
+8192	weak lousy cyan skewed Citrus Crush wine cooler	2	decent	
 8193	spoiled half-sized plain bagel	2	crappy	
 8194	flavorless glob of cream cheese	4	decent	
-8195	miniature flavorless loaf of soda bread	2	decent	
-8196	thick normal acceptable bagel	5	good	
-8197	spoiled gigantic standard-issue cupcake	6	crappy	
+8195	flavorless miniature loaf of soda bread	2	decent	
+8196	normal thick acceptable bagel	5	good	
+8197	gigantic spoiled standard-issue cupcake	6	crappy	
 8198	spoiled snack-sized ultra-deluxe cupcake	2	crappy	
 8199	huge hypnotic breadcrumbs	0		
 8200	enchanted stale diet twirling popular tart	1	decent	Effect: "Wit Tea", Effect Duration: 5
@@ -8085,14 +8085,14 @@
 8211	huge bag of park garbage	0		Last Available: "2015-04"
 8212	grogpagne	0		Last Available: "2021-07"
 8213	shaking purple zippy slick rigging rope	0		Moxie: +10, Initiative: +20, Last Available: "2015-04"
-8214	diluted green upside-down nasty snuff	1	awesome	Last Available: "2015-04"
-8215	medical-grade sewage-clogged pistol of the boozehound	0		Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
+8214	diluted upside-down green nasty snuff	1	awesome	Last Available: "2015-04"
+8215	medical-grade sewage-clogged pistol of the boozehound	0		Booze Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
 8216	frozen beard incense	0		Effect: "Medieval Mage Mayhem", Effect Duration: 58, Last Available: "2015-04"
 8217	perfumed perfume-soaked bandana of the boozehound	0		Stench Resistance: +5, Booze Drop: +100, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
 8219	big normal skewed toxo	5	good	Last Available: "2015-04"
-8220	tolerable triple-distilled teal Lemonade-235	8	good	Last Available: "2015-04"
-8221	teal bouncing Fonzie's isotophat of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8220	triple-distilled tolerable teal Lemonade-235	8	good	Last Available: "2015-04"
+8221	teal bouncing Fonzie's isotophat of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	shaking blue Sherlock's studded Three Mile Island shorts	0		Damage Absorption: +80, Item Drop: +25, Last Available: "2015-04"
 8223	frosty Temple Grandin's toxic mop	0		Familiar Weight: +7, Cold Spell Damage: +10, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8126,7 +8126,7 @@
 8252	veiny healthy Newton's hazmat helmet of horror of temperance	0		Experience (Mysticality): +3, Maximum HP Percent: +20, Maximum HP: +10, Spooky Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2015-04"
 8253	Scratch-and-Sniff Guide to Dinseylandfill	0		Skill: "Olfactory Burnout", Last Available: "2015-04"
 8254	teal Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
-8255	skewed red Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
+8255	red skewed Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	tumbling Dinsey tattoo kit	0		Last Available: "2015-04"
 8257	dry non-polarized narrow nasty gum	0		Effect: "Holiday Bliss", Effect Duration: 12
 8258	Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	extra-pressed power pill	0		Effect: "Salty Mouth", Effect Duration: 19, Last Available: "2015-06"
 8301	colloidal pixel star	0		Effect: "Aloofah", Effect Duration: 53, Last Available: "2015-06"
-8302	big toothsome squat teal pixel banana	5	awesome	Last Available: "2015-06"
+8302	toothsome big teal squat pixel banana	5	awesome	Last Available: "2015-06"
 8303	hand-crafted blinking pixel beer	3	EPIC	Last Available: "2015-06"
 8304	gray puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	pumps	0		Last Available: "2015-06"
@@ -8187,7 +8187,7 @@
 8313	quantum jerky stick	0		Effect: "Bloody Bloody Bloody!", Effect Duration: 25
 8314	extra-unsweetened quadruple-Vulcanized shaking costume rental shop	0		Effect: "The Spy Who Loved XP", Effect Duration: 25
 8315	deionized flattened muscle oil	0		Effect: "Witch Breaded", Effect Duration: 48
-8316	super-polymerized super-ionized skewed tumbling bottle of Red-Out	0		Effect: "Cold Hard Skin", Effect Duration: 38
+8316	super-polymerized super-ionized tumbling skewed bottle of Red-Out	0		Effect: "Cold Hard Skin", Effect Duration: 38
 8317	tarnished double-frozen olive pickpocket protector	0		Effect: "Earthen Fist", Effect Duration: 19
 8318	Vulcanized ionized sinister-looking cat	0		Effect: "Elemental Saucesphere", Effect Duration: 34
 8319	energized alkaline cyan blinking jazzy cigarette holder	0		Effect: "Flashing Eyes", Effect Duration: 68
@@ -8210,9 +8210,9 @@
 8336	triple-quantum polarized gray shamanic ham	0		Effect: "Hardened Fabric", Effect Duration: 42
 8337	moist teal porkpocket	0		Effect: "Night Vision", Effect Duration: 32
 8338	electrified polarized Leonard's glasses	0		Effect: "Cotton Mouthed", Effect Duration: 26
-8339	tarnished magnetized blurry tumbling jittery olive warehouse walkie-talkie	0		Effect: "Fishy", Effect Duration: 60
+8339	tarnished magnetized olive blurry tumbling jittery warehouse walkie-talkie	0		Effect: "Fishy", Effect Duration: 60
 8340	colloidal non-pickled janitor's mop	0		Effect: "Retrograde Relaxation", Effect Duration: 46
-8341	anodized mirror skewed warehouse clerk's glasses	0		Effect: "Fan-Cooled", Effect Duration: 45
+8341	anodized skewed mirror warehouse clerk's glasses	0		Effect: "Fan-Cooled", Effect Duration: 45
 8342	triple-modified aerosolized tumbling shaking baloney rotgut	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 51
 8343	liquefied carton of gaspers	0		Effect: "Sealed Brain", Effect Duration: 42
 8344	galvanized narrow bronze polish	0		Effect: "Bright!", Effect Duration: 68
@@ -8244,7 +8244,7 @@
 8370	chilled polymerized diffused funky eyepatch	0		Effect: "I See Everything Thrice!", Effect Duration: 34
 8371	aerosolized galvanized squat bucket of fish juice	0		Effect: "Your Interest is Peaked", Effect Duration: 22
 8372	quadruple-diffused tarnished shaking flashy pirate dreadlocks	0		Effect: "Retrograde Relaxation", Effect Duration: 11
-8373	Vulcanized anodized lime green mirror captured boozles	0		Effect: "Twinkly Weapon", Effect Duration: 63
+8373	Vulcanized anodized mirror lime green captured boozles	0		Effect: "Twinkly Weapon", Effect Duration: 63
 8374	double-oxidized maroon drinks tray	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 57
 8375	extra-magnetized blue eyebrow lifter	0		Effect: "Fudge Headache", Effect Duration: 65
 8376	submarine	0		Last Available: "2015-06"
@@ -8278,17 +8278,17 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	upside-down savory dry noodles	0		
-8407	tasty gigantic huge pestopiary	10	awesome	
-8408	alkaline spinning red ectoplasmic orbs	0		Effect: "Wet Jaw", Effect Duration: 66
-8409	huge bland blurry crudles	10	decent	
+8407	gigantic tasty huge pestopiary	10	awesome	
+8408	alkaline red spinning ectoplasmic orbs	0		Effect: "Wet Jaw", Effect Duration: 66
+8409	bland huge blurry crudles	10	decent	
 8410	normal agnolotti arboli	4	good	
 8411	decent spaghetti with ghost balls	4	good	
-8412	snack-sized yummy succulent marrow	2	awesome	
+8412	yummy snack-sized succulent marrow	2	awesome	
 8413	small special flavorless salacious crumbs	2	decent	Effect: "Barking Mad", Effect Duration: 20
-8414	spoiled fancy fusilli marrownarrow	3	crappy	Effect: "Bone Chilling", Effect Duration: 5
+8414	fancy spoiled fusilli marrownarrow	3	crappy	Effect: "Bone Chilling", Effect Duration: 5
 8415	normal suggestive strozzapreti	3	good	
 8416	Mountain Stream gastrique	0		
-8417	rotten thick Mt. McLargeHuge oyster	5	crappy	
+8417	thick rotten Mt. McLargeHuge oyster	5	crappy	
 8418	oyster sauce	0		
 8419	huge decent squat linguini immondizia bianco	9	good	
 8420	flavorless shells a la shellfish	4	decent	
@@ -8329,9 +8329,9 @@
 8455	narrow New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	upside-down miser's vibrating high-temperature mining mask	0		Maximum MP Percent: +10, Meat Drop: +10, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	upside-down miser's vibrating high-temperature mining mask	0		Maximum MP Percent: +10, Meat Drop: +10, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	executive Temple Grandin's fireproof megaphone	0		Familiar Weight: +7, Meat Drop: +40, Last Available: "2015-08"
-8460	adequate gigantic cyan mineapple	8	good	Last Available: "2015-08"
+8460	gigantic adequate cyan mineapple	8	good	Last Available: "2015-08"
 8461	distilled tolerable Gold Velvet&trade; whiskey	5	good	Last Available: "2015-08"
 8462	SMOOCH soda	1	decent	Last Available: "2015-08"
 8463	spoiled gigantic red smelted roe	10	crappy	Last Available: "2015-08"
@@ -8346,13 +8346,13 @@
 8472	weightlifter's heat-resistant necktie of the storm	0		Muscle: +15, Maximum MP Percent: +40, Single Equip, Last Available: "2015-08"
 8473	gray flame-wreathed chilly stiffened heat-resistant gloves	0		Damage Reduction: 1, Cold Damage: +5, Hot Spell Damage: +10, Single Equip, Last Available: "2015-08"
 8474	normal very hot lunch	4	good	Last Available: "2015-08"
-8475	high-proof lousy blurry asbestos thermos	10	decent	Last Available: "2015-08"
+8475	lousy high-proof blurry asbestos thermos	10	decent	Last Available: "2015-08"
 8476	altered electrified liquid rhinestones	0		Effect: "Pisces in the Skyces", Effect Duration: 56, Last Available: "2015-08"
 8477	spoiled disco biscuit	4	crappy	Last Available: "2015-08"
 8478	smooth Quaatorade&trade;	4	awesome	Last Available: "2015-08"
-8479	blinking supercharged rock-hard educational biker's hat	0		Experience: +1, Damage Reduction: 5, Maximum MP Percent: +30, Familiar Effect: "atk", Last Available: "2015-08"
-8480	Sherlock's family-friendly feathered headdress of the detective	0		Sleaze Resistance: +1, Item Drop: 45, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	asbestos-lined Jeselnik's electrician's hardhat of the cheetah	0		Sleaze Damage: +25, Hot Resistance: +5, Initiative: +60, Familiar Effect: "atk", Last Available: "2015-08"
+8479	blinking supercharged rock-hard educational biker's hat	0		Experience: +1, Damage Reduction: 5, Maximum MP Percent: +30, Last Available: "2015-08", Familiar Effect: "atk"
+8480	Sherlock's family-friendly feathered headdress of the detective	0		Sleaze Resistance: +1, Item Drop: 45, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	asbestos-lined Jeselnik's electrician's hardhat of the cheetah	0		Sleaze Damage: +25, Hot Resistance: +5, Initiative: +60, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	upside-down The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	upside-down Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	studded smooth velvet pants	0		Damage Absorption: +80, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	studded smooth velvet pants	0		Damage Absorption: +80, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	smooth velvet shirt of the businessman	0		Meat Drop: +50, Last Available: "2015-08"
 8492	upside-down ribald smooth velvet hat	0		Sleaze Damage: +10, Last Available: "2015-08"
 8493	ghostly smooth velvet pocket square of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	ghostly manspreader's wizardly SMOOCH bracers	0		Mysticality: +25, Monster Level: +10, Single Equip, Last Available: "2015-08"
 8518	blurry rosewater-soaked SMOOCH kneepads	0		Stench Resistance: +3, Single Equip, Last Available: "2015-08"
 8519	Usain Bolt's SMOOCH spaulders	0		Initiative: +80, Single Equip, Last Available: "2015-08"
-8520	extremely unsafe SMOOCH codpiece of courage	0		Weapon Damage Percent: +100, Spooky Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	extremely unsafe SMOOCH codpiece of courage	0		Weapon Damage Percent: +100, Spooky Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	gray SMOOCH breastplate of the cougar	0		Moxie: +20, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	twirling fused fuse	0		Last Available: "2015-08"
@@ -8400,44 +8400,44 @@
 8526	rotten jumbo pink slime	5	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	blurry Special&trade; Sauce	0		
-8529	immense tasty devil hair pasta	7	awesome	
+8529	tasty immense devil hair pasta	7	awesome	
 8530	bland spagecialetti	3	decent	
 8531	upside-down Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	adequate jittery skewed libertagliatelle	4	good	
-8535	stale fancy turkish mostaccioli	4	decent	Effect: "Slimily Strong", Effect Duration: 30
-8536	small rotten linguini of the sea	2	crappy	
+8535	fancy stale turkish mostaccioli	4	decent	Effect: "Slimily Strong", Effect Duration: 30
+8536	rotten small linguini of the sea	2	crappy	
 8537	chilled anodized olive Hersey&trade; SMOOCH	0		Effect: "Sewer-Drenched", Effect Duration: 35
 8539	Alexy sauce	0		
 8540	rainbow sauce	0		
 8541	drug cocktail sauce	0		
 8542	delicious blurry Fettris	3	awesome	
-8543	normal jumbo special fusillocybin	5	good	Effect: "You Can Taste the Darkness", Effect Duration: 5
-8544	rotten diet prescription noodles	1	crappy	
+8543	jumbo special normal fusillocybin	5	good	Effect: "You Can Taste the Darkness", Effect Duration: 5
+8544	diet rotten prescription noodles	1	crappy	
 8545	altered blood-drive sticker	1	good	Effect: "Extra Terrestrial", Effect Duration: 50
 8546	anodized quantum super-nitrogenated mirror bag of grain	0		Effect: "Cold Hands", Effect Duration: 53
 8547	triple-galvanized pocket maze	0		Effect: "Whole Latte Love", Effect Duration: 55
 8548	nitrogenated blue shady shades	0		Effect: "Bone Chilling", Effect Duration: 63
 8549	deionized skewed squeaky toy rose	0		Effect: "Tenacity of the Snapper", Effect Duration: 61
-8550	immense adequate weird gazelle steak	6	good	
-8551	toothsome gigantic sausage without a cause	7	awesome	
-8552	quantum squat mirror face paint	0		Effect: "The Smeezingtons", Effect Duration: 28
+8550	adequate immense weird gazelle steak	6	good	
+8551	gigantic toothsome sausage without a cause	7	awesome	
+8552	quantum mirror squat face paint	0		Effect: "The Smeezingtons", Effect Duration: 28
 8553	fortified aged emergency margarita	5	awesome	
 8554	artisanal vintage smart drink	4	super ultra mega EPIC	
 8555	a ten-percent bonus	0		
 8556	skewed cyan Thwaitgold termite statuette	0		
 8557	The Emperor's new cookie	0		
-8558	galvanized wobbly blinking Wickers bar	0		Effect: "Dances with Tweedles", Effect Duration: 22
+8558	galvanized blinking wobbly Wickers bar	0		Effect: "Dances with Tweedles", Effect Duration: 22
 8559	triple-ionized vacuum-sealed wobbly bakelite-covered bacon	0		Effect: "Dweeby", Effect Duration: 44
 8560	super-warmed colloidal Aerheads	0		Effect: "Eagle Eyes", Effect Duration: 52
-8561	colloidal tumbling blinking Wrotz	0		Effect: "Square to be Hip", Effect Duration: 55
+8561	colloidal blinking tumbling Wrotz	0		Effect: "Square to be Hip", Effect Duration: 55
 8562	liquefied double-altered Gabarbar	0		Effect: "Bootyliciousness", Effect Duration: 36
 8563	improved fiberglass insulation	0		Effect: "Flagrantly Fragrant", Effect Duration: 64
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	fireproof grievous barrel lid of the boozehound	0		Weapon Damage Percent: +50, Hot Resistance: +3, Booze Drop: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	lightning-fast razor-sharp smooth barrel hoop earring	0		Moxie: +15, Weapon Damage Percent: +25, Initiative: +40, Lasts Until Rollover, Last Available: "2015-09"
-8567	Van der Graaf curative smartaleck's bankruptcy barrel	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	Van der Graaf curative smartaleck's bankruptcy barrel	0		Moxie Percent: +30, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 3, HP Regen Max: 5, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	huge firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	huge mirror tun	0		Last Available: "2015-09"
@@ -8449,17 +8449,17 @@
 8576	mouldering barrel	0		Last Available: "2015-09"
 8577	barnacled barrel	0		Last Available: "2015-09"
 8578	acceptable bottle of Amontillado	4	good	Last Available: "2015-09"
-8579	bad practically non-alcoholic barrel-aged martini	1	decent	Last Available: "2015-09"
-8580	massive moldy barrel pickle	8	crappy	Last Available: "2015-09"
-8581	rotten ghostly wobbly barrel cracker	3	crappy	Last Available: "2015-09"
+8579	practically non-alcoholic bad barrel-aged martini	1	decent	Last Available: "2015-09"
+8580	moldy massive barrel pickle	8	crappy	Last Available: "2015-09"
+8581	rotten wobbly ghostly barrel cracker	3	crappy	Last Available: "2015-09"
 8582	dried mirror vibrating mushroom	1	decent	Last Available: "2015-09"
-8583	pickled tumbling olive mirror mushroom	1	awesome	Last Available: "2015-09"
+8583	pickled mirror olive tumbling mushroom	1	awesome	Last Available: "2015-09"
 8584	lard-coated KoL Con 12-gauge	0		Sleaze Spell Damage: +25, Last Available: "2015-09"
 8585	squat Golden Mr. Eh? of Flo-Jo	0		Initiative: +100, Last Available: "2015-09"
 8586	stanky barrel gun	0		Stench Spell Damage: +25, Last Available: "2015-09"
 8587	squat barrel	0		Last Available: "2015-09"
 8588	maroon barrel beryl	0		Last Available: "2015-09"
-8589	miniature decent water log	2	good	Last Available: "2015-09"
+8589	decent miniature water log	2	good	Last Available: "2015-09"
 8590	blurry purple stiffened barrelhead of Tarzan	0		Experience (Muscle): +3, Damage Reduction: 1, Last Available: "2015-09"
 8591	thinker's bottoms of the barrel of mayonnaise	0		Mysticality: +10, Sleaze Spell Damage: +50, Last Available: "2015-09"
 8592	blurry manspreader's chest barrel of courage	0		Monster Level: +10, Spooky Resistance: +3, Last Available: "2015-09"
@@ -8481,10 +8481,10 @@
 8608	energized Vulcanized blue cuppa Net tea	0		Effect: "Gunky Dory", Effect Duration: 25, Last Available: "2015-09"
 8609	nitrogenated cuppa Proprie tea	0		Effect: "Salamander In Your Stomach", Effect Duration: 33, Last Available: "2015-09"
 8610	moist denatured cuppa Morbidi tea	0		Effect: "Weather, Man", Effect Duration: 64, Last Available: "2015-09"
-8611	non-oxidized tarnished huge cyan cuppa Chari tea	0		Effect: "Stimulated Brain", Effect Duration: 61, Last Available: "2015-09"
+8611	non-oxidized tarnished cyan huge cuppa Chari tea	0		Effect: "Stimulated Brain", Effect Duration: 61, Last Available: "2015-09"
 8612	chilled oxidized cuppa Serendipi tea	0		Effect: "Flamingly Floral", Effect Duration: 25, Last Available: "2015-09"
 8613	polymerized concentrated cuppa Feroci tea	0		Effect: "Tiki Toughness", Effect Duration: 22, Last Available: "2015-09"
-8614	cold-filtered upside-down maroon cuppa Physicali tea	0		Effect: "Gyromitra Gymnastics", Effect Duration: 18, Last Available: "2015-09"
+8614	cold-filtered maroon upside-down cuppa Physicali tea	0		Effect: "Gyromitra Gymnastics", Effect Duration: 18, Last Available: "2015-09"
 8615	quantum irradiated enhanced blurry cuppa Wit tea	0		Effect: "Takin' It Greasy", Effect Duration: 43, Last Available: "2015-09"
 8616	ionized non-anodized shaking cuppa Neuroplastici tea	0		Effect: "Dwarven Hardiness", Effect Duration: 49, Last Available: "2015-09"
 8617	quadruple-concentrated cuppa Dexteri tea	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 54, Last Available: "2015-09"
@@ -8533,7 +8533,7 @@
 8660	blurry upside-down grip key	0		
 8661	blinking How to Play Othello	0		
 8662	upside-down rosewater-soaked wool mansplainer's ghostly dagger	0		Monster Level: +15, Cold Resistance: +1, Stench Resistance: +3
-8663	acceptable distilled ghost beer	5	good	
+8663	distilled acceptable ghost beer	5	good	
 8664	Othello set of the cheetah	0		Initiative: +60
 8665	rotten tomato	0		
 8666	squat blinking Twelve Night Energy	0		
@@ -8548,7 +8548,7 @@
 8675	pulsating one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	pressed shoulder-warming lotion	0		Effect: "Quaaaaaaa", Effect Duration: 63, Last Available: "2015-11"
 8677	stale iceberg lettuce	3	decent	Last Available: "2015-11"
-8678	aged watered-down ice wine	2	awesome	Last Available: "2015-11"
+8678	watered-down aged ice wine	2	awesome	Last Available: "2015-11"
 8679	flame-wreathed dangerous Wal-Mart snowglobe of vim and vigor	0		Weapon Damage: +10, Maximum HP Percent: +50, Hot Spell Damage: +10, Last Available: "2015-11"
 8680	electrified Socratic smooth Wal-Mart nametag	0		Moxie: +15, Experience (Mysticality): +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-11"
 8681	blurry up-at-dawn experienced Wal-Mart overalls of horror	0		Experience: +2, Spooky Spell Damage: +25, Adventures: +5, Last Available: "2015-11"
@@ -8558,20 +8558,20 @@
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	jittery The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	bellhop's hat of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8688	bellhop's hat of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
 8689	watered-down artisanal jittery ice porter	2	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
-8690	flattened pressed skewed huge exotic travel brochure	0		Effect: "Walberg's Dim Bulb", Effect Duration: 21, Last Available: "2015-11"
+8690	flattened pressed huge skewed exotic travel brochure	0		Effect: "Walberg's Dim Bulb", Effect Duration: 21, Last Available: "2015-11"
 8691	shaking bag of foreign bribes	0		Last Available: "2015-11"
 8692	pressed huge shampoo-conditioner	0		Effect: "Squid Squint", Effect Duration: 35, Last Available: "2015-11"
 8693	hotel minibar key	0		Last Available: "2015-11"
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	purple Martialest Arts trophy	0		Last Available: "2016-01"
 8696	diluted wobbly medicinal herbs	1		Last Available: "2016-01"
-8697	bland low-calorie huge ice rice	1	decent	Last Available: "2016-01"
+8697	low-calorie bland huge ice rice	1	decent	Last Available: "2016-01"
 8698	artisanal watered-down pulsating iced plum wine	2	EPIC	Last Available: "2016-01"
 8699	greasy training belt of extreme caution of the sweet-tooth	0		Monster Level: -25, Sleaze Spell Damage: +10, Candy Drop: +100, Single Equip, Last Available: "2016-01"
 8700	lime green electrified Newton's savvy training legwarmers	0		Mysticality Percent: +20, Experience (Mysticality): +3, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-01"
-8701	jittery crafty training helmet of the cheetah of the early riser	0		Maximum MP: +10, Initiative: +60, Adventures: +7, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	jittery crafty training helmet of the cheetah of the early riser	0		Maximum MP: +10, Initiative: +60, Adventures: +7, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	yellow training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	blinking training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	tumbling training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8583,15 +8583,15 @@
 8710	powdered huge abstraction: sensation	1		Last Available: "2015-12"
 8711	pickled abstraction: purpose	1		Last Available: "2015-12"
 8712	modified bouncing cyan abstraction: category	1		Last Available: "2015-12"
-8713	distilled gray shaking abstraction: perception	1		Last Available: "2015-12"
+8713	distilled shaking gray abstraction: perception	1		Last Available: "2015-12"
 8714	vaporized gray abstraction: motion	1		Last Available: "2015-12"
 8715	denatured twirling red abstraction: joy	1		Last Available: "2015-12"
 8716	boiled abstraction: certainty	1		Last Available: "2015-12"
 8717	denatured abstraction: comprehension	1		Last Available: "2015-12"
 8718	modern picture frame	0		Last Available: "2015-12"
-8719	jumbo decent VYKEA meatballs	5	good	Last Available: "2015-11"
+8719	decent jumbo VYKEA meatballs	5	good	Last Available: "2015-11"
 8720	acceptable watered-down VYKEA mead	2	good	Last Available: "2015-11"
-8721	diffused warmed pulsating huge shaking VYKEA woadpaint	0		Effect: "Stregngth of the Gnome", Effect Duration: 23, Last Available: "2015-11"
+8721	diffused warmed huge pulsating shaking VYKEA woadpaint	0		Effect: "Stregngth of the Gnome", Effect Duration: 23, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	squat shaking VYKEA blood rune	0		Last Available: "2015-11"
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
@@ -8605,13 +8605,13 @@
 8732	artisanal irresponsibly strong twirling bottle of norwhiskey	6	EPIC	Last Available: "2015-11"
 8733	vaporized blurry octolus oculus	1	decent	Last Available: "2015-11"
 8734	twirling pulsating clever wicked brawny sardine can key	0		Muscle Percent: +20, Spell Damage: +5, Maximum MP: +20, Last Available: "2015-11"
-8735	bouncing Van der Graaf wicked norwhal helmet of the overflowing toilet	0		Spell Damage: +5, Stench Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk", Last Available: "2015-11"
+8735	bouncing Van der Graaf wicked norwhal helmet of the overflowing toilet	0		Spell Damage: +5, Stench Spell Damage: +50, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-11", Familiar Effect: "atk"
 8736	flame-retardant razor-sharp octolus-skin cloak of the cheetah	0		Weapon Damage Percent: +25, Hot Resistance: +1, Initiative: +60, Last Available: "2015-11"
 8737	artisanal wobbly perfect cosmopolitan	4	EPIC	Last Available: "2015-11"
 8738	tolerable perfect negroni	3	good	Last Available: "2015-11"
 8739	acceptable strong purple perfect dark and stormy	5	good	Last Available: "2015-11"
-8740	tolerable special watered-down perfect mimosa	2	good	Effect: "Egg-stra Arm", Effect Duration: 45, Last Available: "2015-11"
-8741	practically non-alcoholic acceptable narrow perfect old-fashioned	1	good	Last Available: "2015-11"
+8740	watered-down special tolerable perfect mimosa	2	good	Effect: "Egg-stra Arm", Effect Duration: 45, Last Available: "2015-11"
+8741	acceptable practically non-alcoholic narrow perfect old-fashioned	1	good	Last Available: "2015-11"
 8742	mediocre perfect paloma	3	decent	Last Available: "2015-11"
 8743	boiled flattened That 70s Cologne	0		Effect: "Starry-Eyed", Effect Duration: 16, Last Available: "2015-11"
 8744	improved Wal-Mart &quot;diamond&quot; ring	0		Effect: "Salad Days", Effect Duration: 42, Last Available: "2015-11"
@@ -8632,7 +8632,7 @@
 8759	shaking plastic Crimborgatron of the bloodbag	0		Maximum HP: +100, Last Available: "2015-12"
 8760	twirling squat beefcake's plastic Crimbodhisattva	0		Muscle: +25, Last Available: "2015-12"
 8761	bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
-8762	wobbly mirror stack of communist leaflets	0		Last Available: "2015-12"
+8762	mirror wobbly stack of communist leaflets	0		Last Available: "2015-12"
 8763	BACON	0		Last Available: "2016-05"
 8764	jittery blinking box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
@@ -8654,7 +8654,7 @@
 8782	reindeer hammer of the sweet-tooth	0		Candy Drop: +100, Last Available: "2015-12"
 8783	double-paned elf ploughshare	0		Cold Resistance: +5, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	purple faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8688,38 +8688,38 @@
 8816	tasty special blurry Kudzu salad	4	awesome	Effect: "Frostbeard", Effect Duration: 5, Last Available: "2016-12"
 8817	modified Mansquito Serum	1		Last Available: "2016-12"
 8818	hand-crafted Miss Graves' vermouth	4	EPIC	Last Available: "2016-12"
-8819	bite-sized spoiled narrow lime green The Plumber's mushroom stew	1	crappy	Last Available: "2016-12"
-8820	altered maroon jittery The Author's ink	1		Effect: "In the Limelight", Effect Duration: 50, Last Available: "2016-02"
+8819	spoiled bite-sized lime green narrow The Plumber's mushroom stew	1	crappy	Last Available: "2016-12"
+8820	altered jittery maroon The Author's ink	1		Effect: "In the Limelight", Effect Duration: 50, Last Available: "2016-02"
 8821	tolerable The Mad Liquor	3	good	Last Available: "2016-12"
 8822	hand-crafted Doc Clock's thyme cocktail	3	super ultra EPIC	Last Available: "2016-12"
-8823	massive toothsome Mr. Burnsger	9	awesome	Last Available: "2016-12"
+8823	toothsome massive Mr. Burnsger	9	awesome	Last Available: "2016-12"
 8824	modified shaking The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	double-paned Jeselnik's The Jokester's gun of mayonnaise	0		Sleaze Damage: +25, Sleaze Spell Damage: +50, Cold Resistance: +5, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	slick cool The Jokester's wig of horror	0		Moxie: 15, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
-8827	greasy rock-hard The Jokester's pants of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Sleaze Spell Damage: +10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	double-paned Jeselnik's The Jokester's gun of mayonnaise	0		Sleaze Damage: +25, Sleaze Spell Damage: +50, Cold Resistance: +5, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	slick cool The Jokester's wig of horror	0		Moxie: 15, Spooky Spell Damage: +25, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol"
+8827	greasy rock-hard The Jokester's pants of the wise owl	0		Mysticality: +20, Damage Reduction: 5, Sleaze Spell Damage: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	unsweetened aerosolized altered Jokester makeup	0		Effect: "Turkey-Agitated", Effect Duration: 44, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	mirror battoo kit	0		Last Available: "2016-12"
 8831	basking robin	0		Free Pull, Last Available: "2016-12"
 8832	teal domino mask	0		Familiar Weight: +5
 8833	tarnished pickled diffused narrow robin's egg	0		Effect: "Jacked In", Effect Duration: 15, Last Available: "2016-12"
-8834	bland diet robin flan	1	decent	Last Available: "2016-12"
+8834	diet bland robin flan	1	decent	Last Available: "2016-12"
 8835	acceptable wobbly robin nog	3	good	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
-8837	olive mirror plaintive telegram	0		Last Available: "2016-02"
+8837	mirror olive plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
 8839	blurry root beer barrel	0		
 8840	concentrated denatured pulsating Kudzu slaw	0		Effect: "Rave Concentration", Effect Duration: 34
 8841	triple-enhanced Mansquito's blood	0		Effect: "Riboflavin'", Effect Duration: 37
 8842	quadruple-aerosolized ionized boiled tumbling infrablack lipstick	0		Effect: "Aquarius Rising", Effect Duration: 33
 8843	oxidized pressed squat can of drain cleaner	0		Effect: "Jittery", Effect Duration: 25
-8844	aerosolized cyan shaking The Author's inkwell	0		Effect: "Moon-Eyed", Effect Duration: 31
+8844	aerosolized shaking cyan The Author's inkwell	0		Effect: "Moon-Eyed", Effect Duration: 31
 8845	quantum bag of random words	0		Effect: "Ginger Snapped", Effect Duration: 14
 8846	energized pulsating tube of pendulum lube	0		Effect: "Painted-On Bikini", Effect Duration: 51
 8847	liquefied red-hot jawbreaker	0		Effect: "Mistified", Effect Duration: 39
 8848	pickled super-electrified modified question juice	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 39
 8849	non-dry quadruple-dry moist tube of villain	0		Effect: "Disco Neuropathy", Effect Duration: 21
-8850	bouncing groovy your cowboy boots	0		Moxie Percent: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	bouncing groovy your cowboy boots	0		Moxie Percent: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	purple inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	tumbling nugget of thicksilver	0		Last Available: "2016-02"
@@ -8749,16 +8749,16 @@
 8877	adequate narrow plate of Tesla's Electroplated Beans	4	good	Last Available: "2016-02"
 8878	rotten purple plate of Mixed Garbanzos and Chickpeas	3	crappy	Last Available: "2016-02"
 8879	adequate plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
-8880	rotten gigantic plate of Frigid Northern Beans	7	crappy	Last Available: "2016-02"
-8881	jumbo normal blue plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
+8880	gigantic rotten plate of Frigid Northern Beans	7	crappy	Last Available: "2016-02"
+8881	normal jumbo blue plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
 8882	moldy plate of Trader Olaf's Exotic Stinkbeans	4	crappy	Last Available: "2016-02"
-8883	small moldy plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
+8883	moldy small plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	crappy	Last Available: "2016-02"
 8884	adequate plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
-8885	small spoiled fuchsia spinning plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
+8885	small spoiled spinning fuchsia plate of Shrub's Premium Baked Beans	2	crappy	Last Available: "2016-02"
 8886	green Sherlock's Fancy Jeff's pocket square of chilblains	0		Cold Damage: +25, Item Drop: +25, Last Available: "2016-02"
-8887	horrifying Annie Oakley's arcane researcher's Daisy's unclean bloomers	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Spooky Damage: +25, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	horrifying Annie Oakley's arcane researcher's Daisy's unclean bloomers	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Spooky Damage: +25, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	ghostly olive Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	huge wobbly Tesla hardy Amoon-Ra Cowtep's nemes of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	huge wobbly Tesla hardy Amoon-Ra Cowtep's nemes of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	skewed toasty lion tamer's mansplainer's savvy Former Sheriff Dan's tin star of the sweet-tooth	0		Mysticality Percent: +20, Monster Level: +15, Experience (familiar): +2, Hot Damage: +5, Candy Drop: +100, Last Available: "2016-02"
 8892	ghostly El Vibrato restraints	0		Last Available: "2016-02"
@@ -8766,14 +8766,14 @@
 8894	inspector's double-paned smartaleck's Granny Hackleton's Gatling gun	0		Moxie Percent: +30, Cold Resistance: +5, Item Drop: +15, Last Available: "2016-02"
 8895	buffalo dime	0		Last Available: "2016-02"
 8896	cow poker	0		Last Available: "2016-02"
-8897	anodized ionized blurry shaking spinning poker face paint	0		Effect: "Raging Animal", Effect Duration: 24, Last Available: "2016-02"
+8897	anodized ionized spinning shaking blurry poker face paint	0		Effect: "Raging Animal", Effect Duration: 24, Last Available: "2016-02"
 8898	shaking realistic cap gun	0		Last Available: "2016-02"
 8899	tainted milk	1	crappy	Last Available: "2016-02"
 8900	gun parts	0		Last Available: "2016-02"
 8901	enhanced energized triggerfingerbone	0		Effect: "The Real Deal", Effect Duration: 43, Last Available: "2016-02"
 8902	cold-filtered vacuum-sealed ghost bit	0		Effect: "Abominably Slippery", Effect Duration: 26, Last Available: "2016-02"
 8903	double-irradiated fuchsia buzzard feather	0		Effect: "Elemental Saucesphere", Effect Duration: 67, Last Available: "2016-02"
-8904	ionized liquefied concentrated yellow wobbly lion musk	0		Effect: "Pecan Pied Piper", Effect Duration: 60, Last Available: "2016-02"
+8904	ionized liquefied concentrated wobbly yellow lion musk	0		Effect: "Pecan Pied Piper", Effect Duration: 60, Last Available: "2016-02"
 8905	bland bear claw	4	decent	Last Available: "2016-02"
 8906	pickled rattler gland	0		Effect: "Nano-juiced", Effect Duration: 52, Last Available: "2016-02"
 8907	modified pressed lime green half-digested coal	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 54, Last Available: "2016-02"
@@ -8845,14 +8845,14 @@
 8973	nitrogenated moist moist unusual oil	0		Effect: "Ten out of Ten", Effect Duration: 69
 8974	deionized polarized olive eldritch oil	0		Effect: "Broken Fast", Effect Duration: 49
 8975	upside-down exclusive club	0		
-8976	anodized green twirling patent preventative tonic	0		Effect: "Dirty Pear", Effect Duration: 61
+8976	anodized twirling green patent preventative tonic	0		Effect: "Dirty Pear", Effect Duration: 61
 8977	ionized alkaline corrupted red patent invisibility tonic	0		Effect: "Sugary World View", Effect Duration: 23
 8978	enhanced patent aggression tonic	0		Effect: "Smelly Pants", Effect Duration: 48
 8979	galvanized vacuum-sealed yellow patent sallowness tonic	0		Effect: "Okee-Dokee Go!", Effect Duration: 41
 8980	ionized anodized blurry patent avarice tonic	0		Effect: "Fudgehound", Effect Duration: 21
 8981	deionized patent alacrity tonic	0		Effect: "Superioreo", Effect Duration: 22
 8982	deionized corrupted marrow	0		Effect: "Sappy Blood", Effect Duration: 12
-8983	artisanal watered-down rodeo whiskey	2	EPIC	
+8983	watered-down artisanal rodeo whiskey	2	EPIC	
 8984	Thwaitgold scorpion statuette	0		
 8985	Annie Oakley's real cowboy hat	0		Critical Hit Percent: +20
 8986	bouncing Memories of Cow Punching	0		Free Pull
@@ -8863,16 +8863,16 @@
 8991	jittery purple do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	compressed narrow armored prawn	1		Last Available: "2016-03"
 8993	delicious blinking jumping horseradish	4	awesome	Last Available: "2016-03"
-8994	high-proof perfectly mixed Sacramento wine	7	EPIC	Last Available: "2016-03"
+8994	perfectly mixed high-proof Sacramento wine	7	EPIC	Last Available: "2016-03"
 8995	liquefied polymerized narrow Greek fire	0		Effect: "Vitali Tea", Effect Duration: 14, Last Available: "2016-03"
 8996	mirror zippy lard-coated friendly sharpshooter's dance instructor's ox-head shield	0		Experience Percent (Moxie): +10, Critical Hit Percent: +10, Familiar Weight: +3, Sleaze Spell Damage: +25, Initiative: +20, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	aromatic coward's occult Fonzie's weightlifter's dented scepter	0		Muscle: +15, Experience (Moxie): +1, Spell Damage Percent: +25, Monster Level: -20, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	stiffened brawny very pointy crown of the wise owl of Tarzan of Calamity Jane	0		Mysticality: +20, Muscle Percent: +20, Experience (Muscle): +3, Damage Reduction: 1, Critical Hit Percent: +15, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	stiffened brawny very pointy crown of the wise owl of Tarzan of Calamity Jane	0		Mysticality: +20, Muscle Percent: +20, Experience (Muscle): +3, Damage Reduction: 1, Critical Hit Percent: +15, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	blurry aromatic hardened Herculean educational slick battle broom	0		Moxie: +10, Experience: +1, Experience (Muscle): +1, Damage Reduction: 3, Stench Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	jittery Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	auspicious stanky nippy carpe of the overflowing toilet	0		Cold Damage: +10, Stench Spell Damage: 75, Item Drop: +10, Lasts Until Rollover, Last Available: "2016-04"
 9002	jittery scandalous hardened grievous codpiece of incineration	0		Weapon Damage Percent: +50, Damage Reduction: 3, Hot Spell Damage: +50, Sleaze Damage: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	reassuring smelly beefcake's troutsers of the sweet-tooth	0		Muscle: +25, Stench Spell Damage: +10, Spooky Resistance: +1, Candy Drop: +100, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	reassuring smelly beefcake's troutsers of the sweet-tooth	0		Muscle: +25, Stench Spell Damage: +10, Spooky Resistance: +1, Candy Drop: +100, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	blue bouncing rosewater-soaked scorching occult bass clarinet of the boozehound	0		Spell Damage Percent: +25, Hot Damage: +25, Stench Resistance: +3, Booze Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9005	asbestos-lined gravedigger's steel-toed fish hatchet of the boozehound	0		Damage Reduction: 9, Spooky Damage: +10, Hot Resistance: +5, Booze Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9006	nippy friendly tunac of Gandalf of the overflowing toilet	0		Spell Critical Percent: +20, Familiar Weight: +3, Cold Damage: +10, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2016-04"
@@ -8887,7 +8887,7 @@
 9015	pulsating tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	viral video	0		Last Available: "2016-05"
-9018	twirling tumbling internet point	0		Last Available: "2016-05"
+9018	tumbling twirling internet point	0		Last Available: "2016-05"
 9019	lime green meme generator	0		Last Available: "2016-05"
 9020	narrow plus one	0		Last Available: "2016-05"
 9021	stale gallon of milk	3	decent	Last Available: "2016-05"
@@ -8901,7 +8901,7 @@
 9029	tumbling no spoon	0		
 9030	fancy decent star salad	4	good	Effect: "Dreadful Sheen", Effect Duration: 45
 9031	Thwaitgold moth statuette	0		
-9032	enchanted bland super-sized blurry bowl of Tastee-Wheet&trade;	5	decent	Effect: "Bells in the Batfry", Effect Duration: 25
+9032	enchanted super-sized bland blurry bowl of Tastee-Wheet&trade;	5	decent	Effect: "Bells in the Batfry", Effect Duration: 25
 9033	blinking bouncing Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	bland blurry browser cookie	4	decent	Last Available: "2016-06"
@@ -8916,7 +8916,7 @@
 9044	Source terminal DRAM chip	0		Last Available: "2016-06"
 9045	Source terminal TRAM chip	0		Last Available: "2016-06"
 9046	green Source terminal INGRAM chip	0		Last Available: "2016-06"
-9047	mirror fuchsia pulsating Source terminal DIAGRAM chip	0		Last Available: "2016-06"
+9047	pulsating mirror fuchsia Source terminal DIAGRAM chip	0		Last Available: "2016-06"
 9048	Source terminal ASHRAM chip	0		Last Available: "2016-06"
 9049	Source terminal SCRAM chip	0		Last Available: "2016-06"
 9050	Source terminal TRIGRAM chip	0		Last Available: "2016-06"
@@ -8951,7 +8951,7 @@
 9079	big yummy hardboiled egg	5	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	Sherlock's auspicious frightening resourceful Socratic strapping protonic accelerator pack	0		Muscle: +5, Experience (Mysticality): +1, Maximum MP: +50, Spooky Damage: +5, Item Drop: 35, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	Sherlock's auspicious frightening resourceful Socratic strapping protonic accelerator pack	0		Muscle: +5, Experience (Mysticality): +1, Maximum MP: +50, Spooky Damage: +5, Item Drop: 35, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	jittery scandalous Adventurer bobblehead	0		Sleaze Damage: +5, Last Available: "2016-11"
 9085	mirror psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,22 +8963,22 @@
 9091	friendly Mr. Screege's spectacles	0		Familiar Weight: +3, Single Equip, Last Available: "2016-08"
 9092	Spookyraven signet of the blizzard of the sewer of temperance	0		Cold Spell Damage: +25, Stench Damage: +25, Sleaze Resistance: +5, Single Equip, Last Available: "2016-08"
 9093	ribald forbidden tie-dyed fannypack	0		Spell Damage Percent: +50, Sleaze Damage: +10, Single Equip, Last Available: "2016-08"
-9094	supercharged Samson's burnt snowpants	0		Experience (Muscle): +5, Maximum MP Percent: +30, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
-9095	tumbling experienced standards and practices guide	0		Experience: +2, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9094	supercharged Samson's burnt snowpants	0		Experience (Muscle): +5, Maximum MP Percent: +30, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
+9095	tumbling experienced standards and practices guide	0		Experience: +2, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	huge inspector's Carpathian longsword of horror of the sweet-tooth	0		Spooky Spell Damage: +25, Item Drop: +15, Candy Drop: +100, Last Available: "2016-08"
 9097	skewed skewed Jack Frost's lion tamer's Liam's mail of the boozehound	0		Experience (familiar): +2, Cold Spell Damage: +50, Booze Drop: +100, Last Available: "2016-08"
 9098	scorching careful hardy Unfortunato's foolscap	0		Maximum HP: +50, Monster Level: -10, Hot Damage: +25, Last Available: "2016-08"
-9099	ghostly narrow Thwaitgold cockroach statuette	0		
+9099	narrow ghostly Thwaitgold cockroach statuette	0		
 9100	rad	0		
 9101	blue purification tablet	0		
 9102	ribald Wrist-Boy	0		Sleaze Damage: +10
 9103	Dear Past Self Package	0		Free Pull, Last Available: "2016-09"
-9104	blurry ghostly Time-Spinner	0		Last Available: "2016-09"
+9104	ghostly blurry Time-Spinner	0		Last Available: "2016-09"
 9105	shaking compounded experience	0		Last Available: "2016-09"
 9106	Rad-B-Gone (1 lb.)	0		
 9107	enhanced spinning Rad-Pro (1 oz.)	0		Effect: "Square to be Hip", Effect Duration: 58
 9108	lead umbrella	0		
-9109	warmed pickled magnetized bouncing cyan blurry Shrieking Weasel holo-record	0		Effect: "Fastbreaker", Effect Duration: 43
+9109	warmed pickled magnetized bouncing blurry cyan Shrieking Weasel holo-record	0		Effect: "Fastbreaker", Effect Duration: 43
 9110	triple-energized pickled skewed Power-Guy 2000 holo-record	0		Effect: "Ruby-ous", Effect Duration: 57
 9111	anodized quadruple-diffused green Lucky Strikes holo-record	0		Effect: "Work For Hours a Week", Effect Duration: 55
 9112	polymerized ionized cyan EMD holo-record	0		Effect: "Mushroom Moxiousness", Effect Duration: 35
@@ -8992,18 +8992,18 @@
 9120	maroon lard-coated Unstable Pointy Ears	0		Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	awesome	Last Available: "2016-09"
-9123	upside-down narrow School of Hard Knocks Diploma	0		
+9123	narrow upside-down School of Hard Knocks Diploma	0		
 9124	ghostly baby bark scorpion	0		
 9125	blue droppable microphone	0		
 9126	drinkable unidentified drink	4	good	
 9127	friendly cool KoL Con 13 T-shirt	0		Moxie: +5, Familiar Weight: +3
 9128	stanky arcane researcher's discarded swimming trunks of the boozehound	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +25, Booze Drop: +100
-9129	activated flattened blinking tumbling diluted makeup	0		Effect: "Petit Force", Effect Duration: 38
+9129	activated flattened tumbling blinking diluted makeup	0		Effect: "Petit Force", Effect Duration: 38
 9130	nitrogenated charisma potion	0		Effect: "Very Clean Guns", Effect Duration: 51
 9131	extremely confusing manual	0		
 9132	cyan nippy wicked pistol	0		Spell Damage: +5, Cold Damage: +10
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	flavorless miniature narrow leftover pasty	2	decent	
+9134	miniature flavorless narrow leftover pasty	2	decent	
 9135	hand-crafted very whiskey	3	EPIC	
 9136	li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9020,16 +9020,16 @@
 9148	Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	energized ghostly invisible string	0		Lasts Until Rollover, Effect: "Painted-On Bikini", Effect Duration: 56, Last Available: "2016-10"
-9151	dry teal jittery shaking invisible seam ripper	0		Lasts Until Rollover, Effect: "Boon of the War Snapper", Effect Duration: 32, Last Available: "2016-10"
+9151	dry jittery shaking teal invisible seam ripper	0		Lasts Until Rollover, Effect: "Boon of the War Snapper", Effect Duration: 32, Last Available: "2016-10"
 9152	teal li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	fancy stale ghostly raw sweet potato	3	decent	Effect: "Boletus Swoletus", Effect Duration: 25, Last Available: "2016-11"
 9154	decent huge raw beans	3	good	Last Available: "2016-11"
 9155	flavorless snack-sized raw stuffing	2	decent	Last Available: "2016-11"
-9156	rotten special jumbo raw cranberry sauce	5	crappy	Effect: "Yet tea", Effect Duration: 15, Last Available: "2016-11"
+9156	rotten jumbo special raw cranberry sauce	5	crappy	Effect: "Yet tea", Effect Duration: 15, Last Available: "2016-11"
 9157	adequate raw turkey	4	good	Last Available: "2016-11"
 9158	rotten blinking raw mincemeat	3	crappy	Last Available: "2016-11"
 9159	moldy raw potato	4	crappy	Last Available: "2016-11"
-9160	toothsome half-sized raw gravy	2	awesome	Last Available: "2016-11"
+9160	half-sized toothsome raw gravy	2	awesome	Last Available: "2016-11"
 9161	bland raw bread	3	decent	Last Available: "2016-11"
 9162	ribald careful mini-marshmallow dispenser	0		Monster Level: -10, Sleaze Damage: +10, Last Available: "2016-11"
 9163	dog trainer's glass casserole dish of the scaredy-cat of the brazier	0		Monster Level: -15, Experience (familiar): +1, Hot Spell Damage: +25, Last Available: "2016-11"
@@ -9043,14 +9043,14 @@
 9171	spoiled sweet potatoes	3	crappy	Last Available: "2016-11"
 9172	bland bean casserole	3	decent	Last Available: "2016-11"
 9173	delicious baked stuffing	4	awesome	Last Available: "2016-11"
-9174	moldy miniature cranberry cylinder	2	crappy	Last Available: "2016-11"
-9175	small spoiled shaking thanksgiving turkey	2	crappy	Last Available: "2016-11"
+9174	miniature moldy cranberry cylinder	2	crappy	Last Available: "2016-11"
+9175	spoiled small shaking thanksgiving turkey	2	crappy	Last Available: "2016-11"
 9176	small stale green mince pie	2	decent	Last Available: "2016-11"
-9177	small spoiled pulsating mashed potatoes	2	crappy	Last Available: "2016-11"
+9177	spoiled small pulsating mashed potatoes	2	crappy	Last Available: "2016-11"
 9178	normal warm gravy	3	good	Last Available: "2016-11"
 9179	flavorless tumbling bread roll	3	decent	Last Available: "2016-11"
 9180	delicious leftovers	4	awesome	Last Available: "2016-11"
-9181	snack-sized decent leftovers sandwich	2	good	Last Available: "2016-11"
+9181	decent snack-sized leftovers sandwich	2	good	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	cornucopia	0		Last Available: "2016-11"
 9184	bouncing megacopia	0		Last Available: "2016-11"
@@ -9063,7 +9063,7 @@
 9191	altered eldritch concentrate	0		Effect: "Tingly Biceps", Effect Duration: 45, Last Available: "2016-11"
 9192	aged weak upside-down eldritch extract	2	awesome	Last Available: "2016-11"
 9193	nippy wizardly Official Council Aide Pin	0		Mysticality: +25, Cold Damage: +10, Last Available: "2016-11"
-9194	fancy artisanal extra-dry lime green ghostly eldritch distillate	5	EPIC	Effect: "Nasty, Nasty Breath", Effect Duration: 50, Last Available: "2016-11"
+9194	extra-dry fancy artisanal ghostly lime green eldritch distillate	5	EPIC	Effect: "Nasty, Nasty Breath", Effect Duration: 50, Last Available: "2016-11"
 9195	dehydrated squat eldritch essence	1		Last Available: "2016-11"
 9196	jittery nippy Science Notebook	0		Cold Damage: +10
 9197	greedy ribald groovy eldritch hat	0		Moxie Percent: +10, Sleaze Damage: +10, Meat Drop: +20, Last Available: "2016-11"
@@ -9111,8 +9111,8 @@
 9239	bad jittery ginger beer	3	decent	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	nitrogenated triple-polymerized huge industrial frosting	0		Effect: "Savage Beast Inside", Effect Duration: 57, Last Available: "2016-12"
-9242	frozen double-ionized jittery ghostly fake cocktail	0		Effect: "Disdain of the War Snapper", Effect Duration: 33, Last Available: "2016-12"
-9243	mediocre fancy blue high-end ginger wine	3	decent	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2016-12"
+9242	frozen double-ionized ghostly jittery fake cocktail	0		Effect: "Disdain of the War Snapper", Effect Duration: 33, Last Available: "2016-12"
+9243	fancy mediocre blue high-end ginger wine	3	decent	Effect: "Ninja, Please", Effect Duration: 20, Last Available: "2016-12"
 9244	plastic bad vibe of the boozehound	0		Booze Drop: +100, Last Available: "2016-12"
 9245	blue Sinatra's plastic angry vikings	0		Experience (Moxie): +5, Last Available: "2016-12"
 9246	tumbling plastic Knows About Chakras of temperance	0		Sleaze Resistance: +5, Last Available: "2016-12"
@@ -9128,7 +9128,7 @@
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	skewed chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	tumbling purple My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
-9259	bouncing cyan Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
+9259	cyan bouncing Pop Art: a Guide	0		Skill: "Fifteen Minutes of Flame", Last Available: "2016-12"
 9260	No Hats as Art	0		Skill: "Ceci N'Est Pas Un Chapeau", Last Available: "2016-12"
 9261	wobbly wobbly Rethinking Candy	0		Skill: "Sweet Synthesis", Last Available: "2016-12"
 9262	squat fruit-leather negatives	0		Last Available: "2016-12"
@@ -9141,14 +9141,14 @@
 9269	chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
 9271	yellow chakra sludge	0		
-9272	blinking yellow negative lump	0		
+9272	yellow blinking negative lump	0		
 9273	Sherlock's groovy Third Eye	0		Moxie Percent: +10, Item Drop: +25, Last Available: "2016-12"
 9274	coward's Newton's Krampus Horn	0		Experience (Mysticality): +3, Monster Level: -20, Single Equip, Last Available: "2016-12"
 9275	decent hambrosier	3	good	Last Available: "2016-12"
 9276	aged chakra-mental wine	4	awesome	Last Available: "2016-12"
 9277	quadruple-pressed squat chakra malt	0		Effect: "No Vertigo", Effect Duration: 13, Last Available: "2016-12"
-9278	normal enchanted Black Angus blackburger	3	good	Effect: "Vitali Tea", Effect Duration: 45, Last Available: "2016-12"
-9279	smooth blue bouncing pulsating brandy	3	awesome	Last Available: "2016-12"
+9278	enchanted normal Black Angus blackburger	3	good	Effect: "Vitali Tea", Effect Duration: 45, Last Available: "2016-12"
+9279	smooth pulsating bouncing blue brandy	3	awesome	Last Available: "2016-12"
 9280	ionized potion of spiritual gunkifying	0		Effect: "Wet and Greedy", Effect Duration: 46, Last Available: "2016-12"
 9281	beefcake's bad vibroknife of the blizzard	0		Muscle: +25, Cold Spell Damage: +25, Last Available: "2016-12"
 9282	supercool slick crystal belt buckle	0		Moxie: +10, Moxie Percent: +20, Last Available: "2016-12"
@@ -9167,7 +9167,7 @@
 9295	diluted stench jelly	1		Effect: "Hot Blooded", Effect Duration: 10, Last Available: "2017-01"
 9296	tumbling space planula	0		Free Pull, Last Available: "2017-01"
 9297	stale toast with hot jelly	3	decent	Last Available: "2017-01"
-9298	flavorless enchanted toast with jelly	4	decent	Effect: "Net Tea", Effect Duration: 40, Last Available: "2017-01"
+9298	enchanted flavorless toast with jelly	4	decent	Effect: "Net Tea", Effect Duration: 40, Last Available: "2017-01"
 9299	rotten toast with jelly	3	crappy	Last Available: "2017-01"
 9300	toothsome diet blurry toast with sleaze jelly	1	awesome	Last Available: "2017-01"
 9301	half-sized rotten bouncing toast with stench jelly	2	crappy	Last Available: "2017-01"
@@ -9176,12 +9176,12 @@
 9304	pulsating pewter candlestick	0		Familiar Weight: +10
 9305	wobbly rosewater-soaked banded wax hand	0		Damage Absorption: +100, Stench Resistance: +3, Last Available: "2017-01"
 9306	resourceful candle of the businessman	0		Maximum MP: +50, Meat Drop: +50, Lasts Until Rollover, Last Available: "2017-01"
-9307	miniature bland wax pancake	2	decent	Last Available: "2017-01"
+9307	bland miniature wax pancake	2	decent	Last Available: "2017-01"
 9308	mirror sinister wax face of the bloodbag	0		Spell Damage: +10, Maximum HP: +100, Last Available: "2017-01"
 9309	hand-crafted wax booze	3	EPIC	Last Available: "2017-01"
 9310	blue blurry glob of melted wax	0		Last Available: "2017-01"
 9311	twisted sea jelly	1		Last Available: "2017-01"
-9312	stale jumbo special jittery sea truffle	5	decent	Effect: "Chunky", Effect Duration: 40, Last Available: "2017-01"
+9312	jumbo special stale jittery sea truffle	5	decent	Effect: "Chunky", Effect Duration: 40, Last Available: "2017-01"
 9313	spinning narrow tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	brawny recovered cufflinks	0		Muscle Percent: +20, Single Equip, Last Available: "2017-01"
@@ -9192,7 +9192,7 @@
 9320	zippy banded educational LOV Eardigan	0		Experience: +1, Damage Absorption: +100, Initiative: +20, Lasts Until Rollover, Last Available: "2017-02"
 9321	fortified LOV Epaulettes of Gandalf of the businessman	0		Damage Absorption: +60, Spell Critical Percent: +20, Meat Drop: +50, Lasts Until Rollover, Last Available: "2017-02"
 9322	huge lightning-fast greedy quilted LOV Earrings	0		Damage Absorption: +40, Meat Drop: +20, Initiative: +40, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
-9323	tumbling teal LOV Enamorang	0		Last Available: "2017-02"
+9323	teal tumbling LOV Enamorang	0		Last Available: "2017-02"
 9324	LOV Emotionizer	0		Last Available: "2017-02"
 9325	mirror LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
 9326	pickled gray squat LOV Echinacea Bouquet	1		Last Available: "2017-02"
@@ -9202,7 +9202,7 @@
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	quilted Herculean eldritch hammer of incineration	0		Experience (Muscle): +1, Damage Absorption: +40, Hot Spell Damage: +50, Last Available: "2017-01"
 9332	rotten eldritch mushroom	4	crappy	Last Available: "2017-03"
-9333	ghostly pulsating eldritch ichor	0		
+9333	pulsating ghostly eldritch ichor	0		
 9334	half-sized decent narrow eldritch mushroom pizza	2	good	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9336	huge eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9228,7 +9228,7 @@
 9356	lump of ichor	0		Last Available: "2017-03"
 9357	blurry bottle of gregnadigne	0		Last Available: "2017-03"
 9358	bottle of Cr&egrave;me de Fugu	0		Last Available: "2017-03"
-9359	bouncing cyan baby oil shooter	0		Last Available: "2017-03"
+9359	cyan bouncing baby oil shooter	0		Last Available: "2017-03"
 9360	fish head	0		Last Available: "2017-03"
 9361	twirling limepatch	0		Last Available: "2017-03"
 9362	fuchsia pile of dirt	0		Last Available: "2017-03"
@@ -9237,42 +9237,42 @@
 9365	smooth high-proof literal grasshopper	7	awesome	Last Available: "2017-03"
 9366	drinkable distilled maroon double entendre	5	good	Last Available: "2017-03"
 9367	watered-down drinkable Phlegethon	2	good	Last Available: "2017-03"
-9368	artisanal watered-down Siberian sunrise	2	EPIC	Last Available: "2017-03"
-9369	hand-crafted special mentholated wine	3	EPIC	Effect: "Transcendental Wind", Effect Duration: 30, Last Available: "2017-03"
+9368	watered-down artisanal Siberian sunrise	2	EPIC	Last Available: "2017-03"
+9369	special hand-crafted mentholated wine	3	EPIC	Effect: "Transcendental Wind", Effect Duration: 30, Last Available: "2017-03"
 9370	artisanal extra-dry bouncing low tide martini	5	EPIC	Last Available: "2017-03"
-9371	fortified bad enchanted teal shroomtini	5	decent	Effect: "Eldritch Concentration", Effect Duration: 5, Last Available: "2017-03"
+9371	bad enchanted fortified teal shroomtini	5	decent	Effect: "Eldritch Concentration", Effect Duration: 5, Last Available: "2017-03"
 9372	acceptable morning dew	4	good	Last Available: "2017-03"
 9373	special artisanal twirling whiskey squeeze	3	EPIC	Effect: "Dreams and Lights", Effect Duration: 15, Last Available: "2017-03"
-9374	perfectly mixed practically non-alcoholic great fashioned	1	EPIC	Last Available: "2017-03"
+9374	practically non-alcoholic perfectly mixed great fashioned	1	EPIC	Last Available: "2017-03"
 9375	lousy Gnomish sagngria	3	decent	Last Available: "2017-03"
 9376	hand-crafted ghostly vodka stinger	3	EPIC	Last Available: "2017-03"
-9377	special drinkable boozy jittery extremely slippery nipple	5	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 50, Last Available: "2017-03"
-9378	watered-down drinkable piscatini	2	good	Last Available: "2017-03"
+9377	boozy drinkable special jittery extremely slippery nipple	5	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 50, Last Available: "2017-03"
+9378	drinkable watered-down piscatini	2	good	Last Available: "2017-03"
 9379	drinkable jittery Churchill	4	good	Last Available: "2017-03"
 9380	tolerable fortified soilzerac	5	good	Last Available: "2017-03"
 9381	tolerable London frog	4	good	Last Available: "2017-03"
 9382	smooth nothingtini	3	awesome	Last Available: "2017-03"
 9383	fancy artisanal eighth plague	4	EPIC	Effect: "Human-Insect Hybrid", Effect Duration: 30, Last Available: "2017-03"
-9384	irresponsibly strong artisanal single entendre	9	EPIC	Last Available: "2017-03"
-9385	aged watered-down reverse Tantalus	2	awesome	Last Available: "2017-03"
+9384	artisanal irresponsibly strong single entendre	9	EPIC	Last Available: "2017-03"
+9385	watered-down aged reverse Tantalus	2	awesome	Last Available: "2017-03"
 9386	enchanted artisanal jittery elemental caipiroska	3	EPIC	Effect: "Little Mouse Skull Buddy", Effect Duration: 10, Last Available: "2017-03"
 9387	hand-crafted Feliz Navidad	4	EPIC	Last Available: "2017-03"
 9388	smooth Bloody Nora	4	awesome	Last Available: "2017-03"
-9389	special practically non-alcoholic perfectly mixed moreltini	1	EPIC	Effect: "Braaaains Over Braaaawwn", Effect Duration: 10, Last Available: "2017-03"
+9389	practically non-alcoholic special perfectly mixed moreltini	1	EPIC	Effect: "Braaaains Over Braaaawwn", Effect Duration: 10, Last Available: "2017-03"
 9390	perfectly mixed hell in a bucket	4	EPIC	Last Available: "2017-03"
-9391	drinkable practically non-alcoholic Newark	1	good	Last Available: "2017-03"
+9391	practically non-alcoholic drinkable Newark	1	good	Last Available: "2017-03"
 9392	irresponsibly strong smooth skewed R'lyeh	8	awesome	Last Available: "2017-03"
 9393	artisanal Gnollish sangria	3	EPIC	Last Available: "2017-03"
 9394	lousy bouncing vodka barracuda	3	decent	Last Available: "2017-03"
-9395	distilled aged teal Mysterious Island iced tea	5	awesome	Last Available: "2017-03"
+9395	aged distilled teal Mysterious Island iced tea	5	awesome	Last Available: "2017-03"
 9396	lousy skewed drive-by shooting	4	decent	Last Available: "2017-03"
-9397	drinkable irresponsibly strong gunner's daughter	10	good	Last Available: "2017-03"
+9397	irresponsibly strong drinkable gunner's daughter	10	good	Last Available: "2017-03"
 9398	bad spirit-forward dirt julep	5	decent	Last Available: "2017-03"
-9399	weak artisanal Simepore slime	2	EPIC	Last Available: "2017-03"
-9400	drinkable special Phil Collins	4	good	Effect: "Leo Rising", Effect Duration: 40, Last Available: "2017-03"
+9399	artisanal weak Simepore slime	2	EPIC	Last Available: "2017-03"
+9400	special drinkable Phil Collins	4	good	Effect: "Leo Rising", Effect Duration: 40, Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	blinking toggle switch (Bartend)	0		Familiar Weight: +5
-9403	bouncing wobbly toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
+9403	wobbly bouncing toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
 9404	spinning Spacegate access badge	0		Free Pull, Last Available: "2017-04"
 9405	filter helmet	0		Lasts Until Rollover, Last Available: "2017-04"
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
@@ -9284,25 +9284,25 @@
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	small moldy special blurry edible alien plant bit	2	crappy	Effect: "Goldentongue", Effect Duration: 25, Last Available: "2017-04"
+9415	special small moldy blurry edible alien plant bit	2	crappy	Effect: "Goldentongue", Effect Duration: 25, Last Available: "2017-04"
 9416	fuchsia alien plant fibers	0		Last Available: "2017-04"
-9417	upside-down tumbling alien plant sample	0		Last Available: "2017-04"
+9417	tumbling upside-down alien plant sample	0		Last Available: "2017-04"
 9418	blurry complex alien plant sample	0		Last Available: "2017-04"
 9419	fascinating alien plant sample	0		Last Available: "2017-04"
-9420	mixed squat huge alien plant goo	1		Effect: "Icy Composition", Effect Duration: 20, Last Available: "2017-04"
+9420	mixed huge squat alien plant goo	1		Effect: "Icy Composition", Effect Duration: 20, Last Available: "2017-04"
 9421	alien plant pod	0		Last Available: "2017-04"
 9422	zoological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9423	miniature stale spinning alien meat	2	decent	Last Available: "2017-04"
+9423	stale miniature spinning alien meat	2	decent	Last Available: "2017-04"
 9424	bouncing bouncing alien toenails	0		Last Available: "2017-04"
 9425	teal alien zoological sample	0		Last Available: "2017-04"
 9426	narrow complex alien zoological sample	0		Last Available: "2017-04"
 9427	fascinating alien zoological sample	0		Last Available: "2017-04"
 9428	mixed alien animal goo	1		Effect: "Voracious Gorging", Effect Duration: 35, Last Available: "2017-04"
-9429	mirror lime green alien animal milk	0		Last Available: "2017-04"
+9429	lime green mirror alien animal milk	0		Last Available: "2017-04"
 9430	twirling spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
 9432	quadruple-warmed bouncing alien medicine	0		Effect: "Spookyravin'", Effect Duration: 47, Last Available: "2017-04"
-9433	decent thick ghostly alien salad	5	good	Last Available: "2017-04"
+9433	thick decent ghostly alien salad	5	good	Last Available: "2017-04"
 9434	acceptable triple-distilled alien booze	7	good	Last Available: "2017-04"
 9435	spinning perfumed veiny sinister alien mask	0		Spell Damage: +10, Maximum HP: +10, Stench Resistance: +5, Last Available: "2017-04"
 9436	Jeselnik's shellacked stiffened alien spear	0		Damage Reduction: 16, Sleaze Damage: +25, Last Available: "2017-04"
@@ -9310,7 +9310,7 @@
 9438	foul-smelling resourceful baleful alien loincloth	0		Spell Damage: +25, Maximum MP: +50, Stench Damage: +10, Last Available: "2017-04"
 9439	fireproof wizardly alien totem of the empath	0		Mysticality: +25, Familiar Weight: +5, Hot Resistance: +3, Last Available: "2017-04"
 9440	skewed green toasty Herculean stylish alien necklace	0		Moxie: +25, Experience (Muscle): +1, Hot Damage: +5, Last Available: "2017-04"
-9441	tumbling ghostly spant chitin	0		Last Available: "2017-04"
+9441	ghostly tumbling spant chitin	0		Last Available: "2017-04"
 9442	spant tendon	0		Last Available: "2017-04"
 9443	twirling shellacked spants of bravery	0		Damage Reduction: 7, Spooky Resistance: +5, Last Available: "2017-04"
 9444	rosy-cheeked spant shield of the glutton	0		Maximum HP Percent: +30, Food Drop: +100, Damage Reduction: 6, Last Available: "2017-04"
@@ -9325,30 +9325,30 @@
 9453	lard-coated Oprah's thinker's murderbot mask	0		Mysticality: +10, Maximum MP Percent: +50, Sleaze Spell Damage: +25, Avatar: "Murderbot", Last Available: "2017-04"
 9454	improved murderbot spring injector	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 62, Last Available: "2017-04"
 9455	squat frightening murderbot whip of Tarzan	0		Experience (Muscle): +3, Spooky Damage: +5, Last Available: "2017-04"
-9456	up-at-dawn Rosewater's murderbot plasma rifle	0		Mysticality Percent: +30, Adventures: +5, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
+9456	up-at-dawn Rosewater's murderbot plasma rifle	0		Mysticality Percent: +30, Adventures: +5, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
 9457	murderbot memory chip	0		Last Available: "2017-04"
-9458	squat ghostly space pirate treasure map	0		Last Available: "2017-04"
+9458	ghostly squat space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
 9461	Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	Procrastinator locker key	0		Last Available: "2017-04"
 9463	Space Baby children's book	0		Last Available: "2017-04"
 9464	blinking Space Baby bawbaw	0		Last Available: "2017-04"
-9465	green spinning Spacegate	0		Last Available: "2017-04"
-9466	stale immense blinking Aldebaran sardines	9	decent	Last Available: "2017-04"
-9467	strong smooth Centauri fish wine	5	awesome	Last Available: "2017-04"
+9465	spinning green Spacegate	0		Last Available: "2017-04"
+9466	immense stale blinking Aldebaran sardines	9	decent	Last Available: "2017-04"
+9467	smooth strong Centauri fish wine	5	awesome	Last Available: "2017-04"
 9468	boiled olive oxygen	1		Effect: "Carol of the Bones", Effect Duration: 35, Last Available: "2017-04"
 9469	up-at-dawn energetic Spacegate scientist's insignia	0		Maximum MP Percent: +20, Adventures: +5, Single Equip, Last Available: "2017-04"
 9470	boxer's Spacegate military insignia of the glutton	0		Muscle Percent: +10, Food Drop: +100, Single Equip, Last Available: "2017-04"
 9471	clever healthy Spacegate diplomat's insignia of extreme caution	0		Maximum HP Percent: +20, Maximum MP: +20, Monster Level: -25, Single Equip, Last Available: "2017-04"
 9472	Spacegate emergency disintegrator	0		Skill: "Disintegrate", Last Available: "2017-04"
 9473	Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
-9474	flavorless jumbo alien sandwich	5	decent	Last Available: "2017-04"
+9474	jumbo flavorless alien sandwich	5	decent	Last Available: "2017-04"
 9475	red glitched malware	0		Last Available: "2025-12"
 9476	dry Spant eggs	0		Effect: "Bananas!", Effect Duration: 51
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	upside-down New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
-9479	colloidal electrified olive bouncing Daily Affirmation: Always be Collecting	0		Effect: "Tingly Elbows", Effect Duration: 38, Last Available: "2017-05"
+9479	colloidal electrified bouncing olive Daily Affirmation: Always be Collecting	0		Effect: "Tingly Elbows", Effect Duration: 38, Last Available: "2017-05"
 9480	tarnished enhanced Daily Affirmation: Think Win-Lose	0		Effect: "Holiday Bliss", Effect Duration: 27, Last Available: "2017-05"
 9481	flattened cyan twirling Daily Affirmation: Be Superficially interested	0		Effect: "Salty Dogs", Effect Duration: 38, Last Available: "2017-05"
 9482	wet lime green Daily Affirmation: Adapt to Change Eventually	0		Effect: "Dweeby", Effect Duration: 59, Last Available: "2017-05"
@@ -9362,33 +9362,33 @@
 9490	unsweetened double-galvanized gray Threatening Missive	0		Effect: "Winning Smile", Effect Duration: 44
 9491	Targeted Plague Vector	0		
 9492	blinking suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	purple shaking auspicious clever steel-toed Kremlin's Greatest Briefcase	0		Damage Reduction: 9, Maximum MP: +20, Item Drop: +10, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	purple shaking auspicious clever steel-toed Kremlin's Greatest Briefcase	0		Damage Reduction: 9, Maximum MP: +20, Item Drop: +10, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	bad mirror basic martini	4	decent	Last Available: "2017-06"
 9495	enchanted watered-down acceptable improved martini	2	good	Effect: "Magically Fingered", Effect Duration: 15, Last Available: "2017-06"
-9496	extra-dry bad cyan splendid martini	5	decent	Last Available: "2017-06"
+9496	bad extra-dry cyan splendid martini	5	decent	Last Available: "2017-06"
 9497	exploding cigar	0		Last Available: "2017-06"
 9498	can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	spinning tattoo gun	0		Last Available: "2017-06"
 9500	gun	0		Free Pull, Last Available: "2017-06"
-9501	lime green twirling gum	0		Free Pull, Last Available: "2017-06"
+9501	twirling lime green gum	0		Free Pull, Last Available: "2017-06"
 9502	avaricious thinker's beefcake's plastic gundam	0		Muscle: +25, Mysticality: +10, Meat Drop: +30, Last Available: "2017-06"
 9503	fuchsia License to Chill	0		Last Available: "2017-07"
 9504	jittery Celsius 233	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9505	gray Celsius 233 (singed)	0		Skill: "Eternal Flame", Last Available: "2017-06"
 9506	upside-down Lazenby's Life Lesson	0		Free Pull
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
-9508	skewed gray Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
+9508	gray skewed Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	ghostly L.I.M.P. Stock Certificate	0		
 9510	ghostly Dust bunny	0		
 9511	tumbling Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
-9514	small decent blinking meteoreo	2	good	Last Available: "2017-08"
+9514	decent small blinking meteoreo	2	good	Last Available: "2017-08"
 9515	acceptable meadeorite	3	good	Last Available: "2017-08"
 9516	shaking meteoroid	0		Last Available: "2017-08"
 9517	horrifying beefy meteortarboard of the businessman	0		Muscle: +10, Spooky Damage: +25, Meat Drop: +50, Last Available: "2017-08"
 9518	coward's dangerous meteorite guard of the overflowing toilet	0		Weapon Damage: +10, Monster Level: -20, Stench Spell Damage: +50, Damage Reduction: 9, Last Available: "2017-08"
-9519	coward's hardened meteorb	0		Damage Reduction: 3, Monster Level: -20, Lantern Element: "Hot", Last Available: "2017-08"
+9519	coward's hardened meteorb	0		Damage Reduction: 3, Monster Level: -20, Last Available: "2017-08", Lantern Element: "Hot"
 9520	Usain Bolt's stylish asteroid belt	0		Moxie: +25, Initiative: +80, Single Equip, Last Available: "2017-08"
 9521	up-at-dawn MacGyver's banded meteorthopedic shoes	0		Damage Absorption: +100, Maximum MP: +100, Adventures: +5, Single Equip, Last Available: "2017-08"
 9522	clever wholesome arcane researcher's shooting morning star	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +10, Maximum MP: +20, Single Equip, Last Available: "2017-08"
@@ -9416,7 +9416,7 @@
 9544	O	0		Last Available: "2017-10"
 9545	mediocre DUFRESNE Suds	4	decent	Last Available: "2017-09"
 9546	twirling extremely unsafe wizardly mafia pinky ring	0		Mysticality: +25, Weapon Damage Percent: +100, Single Equip
-9547	high-proof tolerable spinning flask of port	9	good	
+9547	tolerable high-proof spinning flask of port	9	good	
 9548	Van der Graaf Rosewater's contract enforcement stick	0		Mysticality Percent: +30, MP Regen Min: 5, MP Regen Max: 7
 9549	moldy Hide-rox&trade; cookie	4	crappy	Last Available: "2017-10"
 9550	lousy jug of booze	3	decent	Last Available: "2017-10"
@@ -9452,9 +9452,9 @@
 9580	concentrated anodized and cracker	0		Effect: "Unusual Perspective", Effect Duration: 26, Last Available: "2017-12"
 9581	lousy enchanted neg grog	3	decent	Effect: "Black Lung", Effect Duration: 20, Last Available: "2017-12"
 9582	stale half double fruitcake	4	decent	Last Available: "2017-12"
-9583	bland miniature hushed puppy	2	decent	Last Available: "2017-12"
+9583	miniature bland hushed puppy	2	decent	Last Available: "2017-12"
 9584	jumbo adequate muffled muffuletta	5	good	Last Available: "2017-12"
-9585	small bland shushed potatoes	2	decent	Last Available: "2017-12"
+9585	bland small shushed potatoes	2	decent	Last Available: "2017-12"
 9586	fortified plastic mime functionary	0		Damage Absorption: +60, Last Available: "2017-12"
 9587	foul-smelling plastic mime scientist	0		Stench Damage: +10, Last Available: "2017-12"
 9588	twirling plastic mime soldier of terror	0		Spooky Spell Damage: +10, Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	dry wishbone	0		Effect: "Your Eyes are Peeled!", Effect Duration: 60, Last Available: "2017-11"
 9595	tolerable huge Racisto Ruidoso	4	good	Last Available: "2017-11"
 9596	earthenware muffin tin	0		
-9597	gigantic toothsome bran muffin	10	awesome	
+9597	toothsome gigantic bran muffin	10	awesome	
 9598	spoiled huge blueberry muffin	4	crappy	
 9599	wobbly silent A	0		Last Available: "2017-12"
 9600	huge silent B	0		Last Available: "2017-12"
@@ -9522,8 +9522,8 @@
 9650	strong lousy nega-mushroom wine	5	decent	Last Available: "2017-12"
 9651	flattened gray Cheer-Up soda	0		Effect: "Mer-kinny Flavor", Effect Duration: 14, Last Available: "2017-12"
 9652	spoiled mime army rations	4	crappy	Last Available: "2017-12"
-9653	weak drinkable tumbling mime army wine	2	good	Last Available: "2017-12"
-9654	dried jittery cyan mime army superserum	1		Effect: "Super Accuracy", Effect Duration: 45, Last Available: "2017-12"
+9653	drinkable weak tumbling mime army wine	2	good	Last Available: "2017-12"
+9654	dried cyan jittery mime army superserum	1		Effect: "Super Accuracy", Effect Duration: 45, Last Available: "2017-12"
 9655	modified maroon mime army camouflage kit	0		Effect: "Old School Pompadour", Effect Duration: 41, Last Available: "2017-12"
 9656	up-at-dawn knitted miming beret	0		Cold Resistance: +3, Adventures: +5, Last Available: "2017-12"
 9657	executive crafty miming shirt	0		Maximum MP: +10, Meat Drop: +40, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	quadruple-energized digital honeypot	0		Effect: "Rampage!", Effect Duration: 30, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	mime army insignia (infantry) of the detective	0		Item Drop: +20, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	wobbly mime army insignia (intelligence)	0		Item Drop: +5, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	perfumed mime army insignia (espionage)	0		Stench Resistance: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	mime army insignia (infantry) of the detective	0		Item Drop: +20, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	wobbly mime army insignia (intelligence)	0		Item Drop: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	perfumed mime army insignia (espionage)	0		Stench Resistance: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	yellow mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	bouncing wobbly kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	yellow fireproof skip lid	0		Familiar Weight: +5
 9681	massive adequate extra-toasted half sandwich	8	good	Last Available: "2018-12"
-9682	mediocre watered-down mulled hobo wine	2	decent	Last Available: "2018-12"
+9682	watered-down mediocre mulled hobo wine	2	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	shaking Da Vinci's burning paper hat of vim and vigor of Flo-Jo	0		Experience (Mysticality): +5, Maximum HP Percent: +50, Initiative: +100, Lasts Until Rollover, Last Available: "2018-12"
 9685	tumbling careful sage wizardly burning cape	0		Mysticality: +25, Mysticality Percent: +10, Monster Level: -10, Lasts Until Rollover, Last Available: "2018-12"
@@ -9581,7 +9581,7 @@
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	lime green Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
-9716	bouncing spinning Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
+9716	spinning bouncing Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	ghostly Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	clever hale genie's turbane	0		Maximum HP: +20, Maximum MP: +20, Last Available: "2018-02"
@@ -9592,7 +9592,7 @@
 9724	narrow blurry strapping psychic's crystal ball of mayonnaise	0		Muscle: +5, Sleaze Spell Damage: +50, Last Available: "2018-02"
 9725	beefy psychic's pslacks of horror	0		Muscle: +10, Spooky Spell Damage: +25, Last Available: "2018-02"
 9726	manspreader's chaotic psychic's amulet	0		Spell Critical Percent: +10, Monster Level: +10, Last Available: "2018-02"
-9727	stale super-sized heart-shaped candy whetstone	5	decent	Last Available: "2018-02"
+9727	super-sized stale heart-shaped candy whetstone	5	decent	Last Available: "2018-02"
 9728	normal Swedish massage fish	3	good	Last Available: "2018-02"
 9729	lousy special Third Base	3	decent	Effect: "Highland Sheen", Effect Duration: 35, Last Available: "2018-02"
 9730	bad practically non-alcoholic Bustle Hustler	1	decent	Last Available: "2018-02"
@@ -9648,7 +9648,7 @@
 9780	Wendtigo	0		Last Available: "2018-03"
 9781	blinking Snoutlet	0		Last Available: "2018-03"
 9782	Ruffalo	0		Last Available: "2018-03"
-9783	skewed blue Vaporpoise	0		Last Available: "2018-03"
+9783	blue skewed Vaporpoise	0		Last Available: "2018-03"
 9784	Ghosprey	0		Last Available: "2018-03"
 9785	Straypler	0		Last Available: "2018-03"
 9786	Flan	0		Last Available: "2018-03"
@@ -9661,12 +9661,12 @@
 9793	ghostly ghostly Wullabye	0		Last Available: "2018-03"
 9794	Nursine	0		Last Available: "2018-03"
 9795	narrow Cantelope	0		Last Available: "2018-03"
-9796	purple jittery Ungulant	0		Last Available: "2018-03"
+9796	jittery purple Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
-9801	shaking wobbly Vulgure	0		Last Available: "2018-03"
+9801	wobbly shaking Vulgure	0		Last Available: "2018-03"
 9802	Squib	0		Last Available: "2018-03"
 9803	wobbly Trafikoan	0		Last Available: "2018-03"
 9804	Slotter	0		Last Available: "2018-03"
@@ -9679,7 +9679,7 @@
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
 9813	Glum berry	0		Last Available: "2018-03"
-9814	bouncing twirling Egnaro berry	0		Last Available: "2018-03"
+9814	twirling bouncing Egnaro berry	0		Last Available: "2018-03"
 9815	Sitrep berry	0		Last Available: "2018-03"
 9816	Nadsat berry	0		Last Available: "2018-03"
 9817	Jamocha berry	0		Last Available: "2018-03"
@@ -9728,7 +9728,7 @@
 9860	yellow FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	ghostly wobbly LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
 9862	flavorless FantasyRealm turkey leg	4	decent	Last Available: "2018-04"
-9863	smooth fancy FantasyRealm mead	3	awesome	Effect: "Shrimpin' Ain't Easy", Effect Duration: 35, Last Available: "2018-04"
+9863	fancy smooth FantasyRealm mead	3	awesome	Effect: "Shrimpin' Ain't Easy", Effect Duration: 35, Last Available: "2018-04"
 9864	squat nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	spinning Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9736,7 +9736,7 @@
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	flavorless druidic s'more	4	decent	Last Available: "2018-04"
 9870	distilled yellow sachet of powder	1		Effect: "Fungal Flambé", Effect Duration: 20, Last Available: "2018-04"
-9871	boozy tolerable skewed mourning wine	5	good	Last Available: "2018-04"
+9871	tolerable boozy skewed mourning wine	5	good	Last Available: "2018-04"
 9872	sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
@@ -9768,16 +9768,16 @@
 9900	stale chocolate &quot;Phoenix&quot;	3	decent	
 9901	decent half-sized gray chocolate Spider Queen	2	good	
 9902	acceptable hipster cocktail	3	good	
-9903	huge upside-down God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	upside-down huge God Lobster's Scepter	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "sombrero"
+9905	God Lobster's Rod	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "whelp"
+9906	God Lobster's Robe	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "block"
+9907	God Lobster's Crown	0		Equips On: "God Lobster", Last Available: "2018-05", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
 9910	Garland of Greatness	0		
 9911	gattoo	0		
-9912	blurry cyan A-Boo glue	0		
+9912	cyan blurry A-Boo glue	0		
 9913	glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	rotten immense good guava	9	crappy	
@@ -9791,7 +9791,7 @@
 9923	electrified shaking blurry Punching Potion	0		Effect: "Sugar Smacks", Effect Duration: 30, Last Available: "2018-06"
 9924	Special Seasoning	0		Last Available: "2018-06"
 9925	boiled narrow Nightmare Fuel	1		Last Available: "2018-06"
-9926	blinking tumbling Gathered Meat-Clip	0		Last Available: "2020-09"
+9926	tumbling blinking Gathered Meat-Clip	0		Last Available: "2020-09"
 9927	blinking jittery Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	yellow tumbling ruddy wicked boxer's Brutal brogues of the boozehound	0		Muscle Percent: +10, Spell Damage: +5, Maximum HP Percent: +40, Booze Drop: +100, Lasts Until Rollover, Last Available: "2018-07"
@@ -9817,11 +9817,11 @@
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	twirling ghostly pentagram bandana of the storm of the early riser	0		Maximum MP Percent: +40, Adventures: +7, Last Available: "2018-09"
 9951	shaking perfumed skull ring	0		Stench Resistance: +5, Single Equip, Last Available: "2018-09"
-9952	red ghostly electronics kit	0		Last Available: "2018-09"
+9952	ghostly red electronics kit	0		Last Available: "2018-09"
 9953	stale PB&J with the crusts cut off	3	decent	Last Available: "2018-09"
 9954	scandalous lion tamer's dorky glasses	0		Experience (familiar): +2, Sleaze Damage: +5, Single Equip, Last Available: "2018-09"
 9955	ponytail clip of the wise owl of the bloodbag	0		Mysticality: +20, Maximum HP: +100, Last Available: "2018-09"
-9956	tumbling huge fuchsia paint palette of the cheetah	0		Initiative: +60, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	tumbling huge fuchsia paint palette of the cheetah	0		Initiative: +60, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	pulsating unremarkable duffel bag	0		Last Available: "2018-09"
 9958	diluted narrow Purple Beast energy drink	1		Effect: "Old Time Hydration", Effect Duration: 20, Last Available: "2018-09"
 9959	blinking cosmetic football of bravery	0		Spooky Resistance: +5, Last Available: "2018-09"
@@ -9847,11 +9847,11 @@
 9980	half-sized flavorless party platter for one	2	decent	Last Available: "2018-09"
 9981	compressed Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	purple party pup	0		Last Available: "2018-09"
-9983	auspicious party crasher	0		Item Drop: 15, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	skewed Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
+9983	auspicious party crasher	0		Item Drop: 15, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
+9984	skewed Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	ghostly party mouse hat	0		Familiar Weight: +5
-9987	wobbly latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	wobbly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	huge latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of the dark arts	0		Spell Damage Percent: +100, Lasts Until Rollover, Last Available: "2018-11"
@@ -9873,18 +9873,18 @@
 10007	miser's Fonzie's mutant arm of doom	0		Experience (Moxie): +1, Spooky Spell Damage: +50, Meat Drop: +10, Last Available: "2018-11"
 10008	MacGyver's strapping mutant legs of chilblains	0		Muscle: +5, Maximum MP: +100, Cold Damage: +25, Last Available: "2018-11"
 10009	knitted Van der Graaf clever mutant crown	0		Maximum MP: +20, Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2018-11"
-10010	yummy fancy ghostly ectoplasm	4	awesome	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2018-11"
-10011	half-sized moldy	2	crappy	Last Available: "2018-11"
-10012	watered-down tolerable bottle of vodka	2	good	Last Available: "2018-11"
+10010	fancy yummy ghostly ectoplasm	4	awesome	Effect: "Improved Candy Vision", Effect Duration: 5, Last Available: "2018-11"
+10011	moldy half-sized	2	crappy	Last Available: "2018-11"
+10012	tolerable watered-down bottle of vodka	2	good	Last Available: "2018-11"
 10013	adequate green pizza	3	good	Last Available: "2018-11"
 10014	weak artisanal bouncing martini	2	EPIC	Last Available: "2018-11"
 10015	spoiled bouncing cherry pie	3	crappy	Last Available: "2018-11"
-10016	perfectly mixed triple-distilled eggnog	10	EPIC	Last Available: "2018-11"
+10016	triple-distilled perfectly mixed eggnog	10	EPIC	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
 10018	big stale Hell ramen	5	decent	Last Available: "2018-11"
-10019	tolerable boozy gimlet	5	good	Last Available: "2018-11"
-10020	perfectly mixed fortified blurry blurry twice-haunted screwdriver	5	EPIC	Last Available: "2018-11"
-10021	rotten thick spinning candy cane	5	crappy	Last Available: "2018-12"
+10019	boozy tolerable gimlet	5	good	Last Available: "2018-11"
+10020	fortified perfectly mixed blurry blurry twice-haunted screwdriver	5	EPIC	Last Available: "2018-11"
+10021	thick rotten spinning candy cane	5	crappy	Last Available: "2018-12"
 10022	lousy watered-down runny fermented egg	2	decent	Last Available: "2018-12"
 10023	flavorless oldcake	3	decent	Last Available: "2018-12"
 10024	yummy traditional Crimbo cookie	3	awesome	Last Available: "2023-06"
@@ -9908,14 +9908,14 @@
 10042	weightlifter's dam	0		Muscle: +15, Damage Reduction: 9, Last Available: "2018-12"
 10043	hand-crafted beavermouth	4	EPIC	Last Available: "2018-12"
 10044	bad high-proof beaver punch (papaya)	9	decent	Last Available: "2018-12"
-10045	tolerable triple-distilled beaver punch (peach)	6	good	Last Available: "2018-12"
+10045	triple-distilled tolerable beaver punch (peach)	6	good	Last Available: "2018-12"
 10046	lousy skewed beaver punch (cherry)	3	decent	Last Available: "2018-12"
 10047	Jeselnik's Canadian lantern of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +25, Last Available: "2018-12"
 10048	Newton's muskox-skin cap	0		Experience (Mysticality): +3, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
-10050	big bland glass of raw eggs	5	decent	Last Available: "2018-12"
-10051	watered-down hand-crafted punch-drunk punch	2	EPIC	Last Available: "2018-12"
-10052	compressed blue skewed huge body spradium	1		Last Available: "2018-12"
+10050	bland big glass of raw eggs	5	decent	Last Available: "2018-12"
+10051	hand-crafted watered-down punch-drunk punch	2	EPIC	Last Available: "2018-12"
+10052	compressed huge blue skewed body spradium	1		Last Available: "2018-12"
 10053	spinning arcane researcher's bauxite beret	0		Experience Percent (Mysticality): +10, Last Available: "2018-12"
 10054	lion tamer's bauxite boxers	0		Experience (familiar): +2, Last Available: "2018-12"
 10055	wobbly bauxite bow-tie of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2018-12"
@@ -9923,16 +9923,16 @@
 10057	olive Kramco Industries packing carton	0		Free Pull, Last Available: "2019-01"
 10058	pulsating auspicious censurious reassuring beefcake's Kramco Sausage-o-Matic&trade; of Gandalf	0		Muscle: +25, Spell Critical Percent: +20, Spooky Resistance: +1, Sleaze Resistance: +3, Item Drop: +10, Last Available: "2019-01"
 10059	sausage casing	0		Last Available: "2019-01"
-10060	flavorless big sausage	5	decent	Last Available: "2019-01"
+10060	big flavorless sausage	5	decent	Last Available: "2019-01"
 10061	therapeutic ruddy red-hot sausage fork	0		Maximum HP Percent: +40, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2019-01"
 10062	squat bag of sausage links	0		Last Available: "2019-01"
 10063	skewed sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	red Toyleporter	0		Last Available: "2018-12"
 10066	aged beer	3	awesome	Last Available: "2018-12"
-10067	small adequate skewed yule gruel	2	good	Last Available: "2018-12"
-10068	triple-distilled drinkable enchanted hot watered rum	8	good	Effect: "Chilblains of the Corn", Effect Duration: 45, Last Available: "2018-12"
-10069	delicious practically non-alcoholic bottle of Crimbognac	1	awesome	Last Available: "2018-12"
+10067	adequate small skewed yule gruel	2	good	Last Available: "2018-12"
+10068	triple-distilled enchanted drinkable hot watered rum	8	good	Effect: "Chilblains of the Corn", Effect Duration: 45, Last Available: "2018-12"
+10069	practically non-alcoholic delicious bottle of Crimbognac	1	awesome	Last Available: "2018-12"
 10070	decent Crimboysters Rockefeller	4	good	Last Available: "2018-12"
 10071	vaporized cyan Crimbeau de toilette	1		Effect: "Violent Night", Effect Duration: 20, Last Available: "2018-12"
 10072	upside-down mirror Crimbo candle	0		Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	marble mariachi hat of vim and vigor of the storm	0		Maximum HP Percent: +50, Maximum MP Percent: +40, Last Available: "2019-12"
 10096	mixed marble molecules	1		Last Available: "2019-12"
 10097	double-magnetized magnetized skewed Mallomarbles	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 16
-10098	resourceful punching bag of the early riser	0		Maximum MP: +50, Adventures: +7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	spinning aromatic vibrating pith helmet	0		Maximum MP Percent: +10, Stench Resistance: +1, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	red curative smooth poncho	0		Moxie: +15, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	mirror Usain Bolt's pendant of Leguizamo	0		Monster Level: +20, Initiative: +80, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	frightening nasty palazzos	0		Stench Damage: +5, Spooky Damage: +5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	aromatic ribald pseudoaccordion	0		Sleaze Damage: +10, Stench Resistance: +1, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	resourceful punching bag of the early riser	0		Maximum MP: +50, Adventures: +7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	spinning aromatic vibrating pith helmet	0		Maximum MP Percent: +10, Stench Resistance: +1, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	red curative smooth poncho	0		Moxie: +15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	mirror Usain Bolt's pendant of Leguizamo	0		Monster Level: +20, Initiative: +80, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	frightening nasty palazzos	0		Stench Damage: +5, Spooky Damage: +5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	aromatic ribald pseudoaccordion	0		Sleaze Damage: +10, Stench Resistance: +1, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	twisted pieces	1		Effect: "Mutated", Effect Duration: 50, Last Available: "2020-12"
 10105	cold-filtered dry squat Para-Pop	0		Effect: "Hobo Flavor", Effect Duration: 55
-10106	wool terra cotta truss of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	lime green energetic fortified terra cotta trousers	0		Damage Absorption: +60, Maximum MP Percent: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	coward's terra cotta tongs of the blizzard	0		Monster Level: -20, Cold Spell Damage: +25, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	ghostly Jack Frost's grievous terra cotta train	0		Weapon Damage Percent: +50, Cold Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	narrow brawny terra cotta tie tack of terror	0		Muscle Percent: +20, Spooky Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	avaricious terra cotta tambourine of horror	0		Spooky Spell Damage: +25, Meat Drop: +30, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	wool terra cotta truss of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	lime green energetic fortified terra cotta trousers	0		Damage Absorption: +60, Maximum MP Percent: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	coward's terra cotta tongs of the blizzard	0		Monster Level: -20, Cold Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	ghostly Jack Frost's grievous terra cotta train	0		Weapon Damage Percent: +50, Cold Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	narrow brawny terra cotta tie tack of terror	0		Muscle Percent: +20, Spooky Spell Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	avaricious terra cotta tambourine of horror	0		Spooky Spell Damage: +25, Meat Drop: +30, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	powdered upside-down terra cotta tidbits	1		Last Available: "2020-12"
 10113	electrified colloidal galvanized purple mirror terra panna cotta	0		Effect: "Booooooze", Effect Duration: 50
 10114	bouncing extremely unsafe velour voulge of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Last Available: "2021-12"
@@ -9983,7 +9983,7 @@
 10117	avaricious deadly velour viscometer	0		Weapon Damage: +5, Meat Drop: +30, Single Equip, Last Available: "2021-12"
 10118	blue hardened padded velour valise	0		Damage Absorption: +20, Damage Reduction: 3, Last Available: "2021-12"
 10119	velour vaqueros of the empath of the sewer	0		Familiar Weight: +5, Stench Damage: +25, Last Available: "2021-12"
-10120	diluted squat gray velour veneer	1		Last Available: "2021-12"
+10120	diluted gray squat velour veneer	1		Last Available: "2021-12"
 10121	magnetized Velougats&trade;	0		Effect: "Slightly Larger Than Usual", Effect Duration: 53
 10122	narrow narrow auspicious flame-retardant glass suspenders	0		Hot Resistance: +1, Item Drop: +10, Single Equip, Last Available: "2021-12"
 10123	tumbling foul-smelling occult glass shield	0		Spell Damage Percent: +25, Stench Damage: +10, Damage Reduction: 7, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	bouncing resourceful glass serape of incineration	0		Maximum MP: +50, Hot Spell Damage: +50, Last Available: "2021-12"
 10128	pickled blurry glass shards	1		Effect: "Human-Human Hybrid", Effect Duration: 25, Last Available: "2021-12"
 10129	pressed extra-Vulcanized hard candy	0		Effect: "Triangle, Man", Effect Duration: 23
-10130	spinning smooth wizardly loofah lumberjack's hat	0		Mysticality: +25, Moxie: +15, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	mirror veiny Newton's loofah lei	0		Experience (Mysticality): +3, Maximum HP: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	friendly loofah lederhosen of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	Temple Grandin's Fonzie's loofah ladle	0		Experience (Moxie): +1, Familiar Weight: +7, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	pulsating miser's dance instructor's loofah legwarmers	0		Experience Percent (Moxie): +10, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	loofah lavalier of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	spinning smooth wizardly loofah lumberjack's hat	0		Mysticality: +25, Moxie: +15, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	mirror veiny Newton's loofah lei	0		Experience (Mysticality): +3, Maximum HP: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	friendly loofah lederhosen of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	Temple Grandin's Fonzie's loofah ladle	0		Experience (Moxie): +1, Familiar Weight: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	pulsating miser's dance instructor's loofah legwarmers	0		Experience Percent (Moxie): +10, Meat Drop: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	loofah lavalier of Tarzan of vim and vigor	0		Experience (Muscle): +3, Maximum HP Percent: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	dehydrated blinking loofah lumps	1		Last Available: "2022-12"
 10137	Vulcanized pulsating chocolate-covered loofah	0		Effect: "Coming Up Roses", Effect Duration: 11
-10138	fuchsia squat Jeselnik's flagstone flag of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	zippy Annie Oakley's flagstone flail	0		Critical Hit Percent: +20, Initiative: +20, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	asbestos-lined deadly flagstone flip-flops	0		Weapon Damage: +5, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	chaotic vibrating flagstone fez	0		Maximum MP Percent: +10, Spell Critical Percent: +10, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	Sherlock's coward's flagstone fleece	0		Monster Level: -20, Item Drop: +25, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	ghostly avaricious rosy-cheeked flagstone fringe	0		Maximum HP Percent: +30, Meat Drop: +30, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	fuchsia squat Jeselnik's flagstone flag of chilblains	0		Cold Damage: +25, Sleaze Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	zippy Annie Oakley's flagstone flail	0		Critical Hit Percent: +20, Initiative: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	asbestos-lined deadly flagstone flip-flops	0		Weapon Damage: +5, Hot Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	chaotic vibrating flagstone fez	0		Maximum MP Percent: +10, Spell Critical Percent: +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	Sherlock's coward's flagstone fleece	0		Monster Level: -20, Item Drop: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	ghostly avaricious rosy-cheeked flagstone fringe	0		Maximum HP Percent: +30, Meat Drop: +30, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	altered cyan flagstone flagments	1		Last Available: "2022-12"
 10145	triple-corrupted chilled skewed Flag by the Foot&trade;	0		Effect: "Heart of Pink", Effect Duration: 64
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	squat really nice net	0		Last Available: "2019-12"
 10154	hardened elf army poncho	0		Damage Reduction: 3, Lasts Until Rollover, Last Available: "2019-12"
-10155	decent tiny elf army field rations	1	good	Last Available: "2019-12"
+10155	tiny decent elf army field rations	1	good	Last Available: "2019-12"
 10156	ghostly jittery gingernade	0		Last Available: "2019-12"
 10157	spinning hardened slick discarded bowtie	0		Moxie: +10, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2019-12"
 10158	smooth watered-down ghostly martiny	2	awesome	Last Available: "2019-12"
@@ -10029,16 +10029,16 @@
 10163	adjusted jittery government-issued candy	0		Effect: "Wax On Your Shoes", Effect Duration: 67
 10164	adjusted Pneumo bar	0		Effect: "Intimidating Mien", Effect Duration: 57
 10165	spinning gray mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	reassuring Lil' Doctor&trade; bag of wisdom	0		Mysticality: +15, Spooky Resistance: +1, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	reassuring Lil' Doctor&trade; bag of wisdom	0		Mysticality: +15, Spooky Resistance: +1, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	blood bag	0		
-10169	flavorless fancy bloodstick	3	decent	Effect: "Shoesauce", Effect Duration: 35
+10169	fancy flavorless bloodstick	3	decent	Effect: "Shoesauce", Effect Duration: 35
 10170	smooth skewed bottle of Sanguiovese	3	awesome	
 10171	normal miniature actual blood sausage	2	good	
-10172	irresponsibly strong perfectly mixed mulled blood	8	EPIC	
+10172	perfectly mixed irresponsibly strong mulled blood	8	EPIC	
 10173	flavorless blood snowcone	3	decent	
-10174	tolerable watered-down narrow Red Russian	2	good	
+10174	watered-down tolerable narrow Red Russian	2	good	
 10175	tiny flavorless blood roll-up	1	decent	
-10176	practically non-alcoholic bad bottle of blood	1	decent	
+10176	bad practically non-alcoholic bottle of blood	1	decent	
 10177	rotten blood-soaked sponge cake	4	crappy	
 10178	drinkable olive vampagne	3	good	
 10179	decent plain snowcone	4	good	
@@ -10061,9 +10061,9 @@
 10196	recursed compass	0		Lasts Until Rollover, Last Available: "2019-04"
 10197	tomb-opener	0		Lasts Until Rollover, Last Available: "2019-04"
 10198	pulsating Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
-10199	miniature normal crabsicle	2	good	Last Available: "2019-04"
+10199	normal miniature crabsicle	2	good	Last Available: "2019-04"
 10200	blinking melty plastic grenade	0		Last Available: "2019-04"
-10201	lousy practically non-alcoholic bottle of dark rhum	1	decent	Last Available: "2019-04"
+10201	practically non-alcoholic lousy bottle of dark rhum	1	decent	Last Available: "2019-04"
 10202	practically non-alcoholic artisanal pulsating bottle of extra-dark rhum	1	EPIC	Last Available: "2019-04"
 10203	drinkable bottle of super-extra-dark rhum	3	good	Last Available: "2019-04"
 10204	corrupted wet mirror pirate shaving cream	0		Effect: "Pronounced Potency", Effect Duration: 48, Last Available: "2019-04"
@@ -10082,29 +10082,29 @@
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
 10218	gray Red Roger's right hand	0		Last Available: "2019-04"
 10219	shaking Red Roger's left hand	0		Last Available: "2019-04"
-10220	pulsating skewed green Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
+10220	skewed green pulsating Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	red Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
-10223	dehydrated ghostly spinning pewter shavings	1		Effect: "Bone Homie", Effect Duration: 5, Last Available: "2019-04"
+10223	dehydrated spinning ghostly pewter shavings	1		Effect: "Bone Homie", Effect Duration: 5, Last Available: "2019-04"
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	plush sea serpent of chilblains	0		Cold Damage: +25, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	small rotten green pirate fork	2		Last Available: "2019-04"
+10227	rotten small green pirate fork	2		Last Available: "2019-04"
 10228	bouncing Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	resourceful savvy piratical blunderbuss	0		Mysticality Percent: +20, Maximum MP: +50, Last Available: "2019-04"
 10231	Jeselnik's hale rosy-cheeked PirateRealm party hat	0		Maximum HP Percent: +30, Maximum HP: +20, Sleaze Damage: +25, Last Available: "2019-04"
 10232	weak bad wobbly Island Landslide	2	decent	Last Available: "2019-04"
-10233	practically non-alcoholic drinkable blinking Island Thunderstorm	1	good	Last Available: "2019-04"
+10233	drinkable practically non-alcoholic blinking Island Thunderstorm	1	good	Last Available: "2019-04"
 10234	tolerable spinning skewed Island Hurricane	3	good	Last Available: "2019-04"
 10235	acceptable Skull Punch	4	good	Last Available: "2019-04"
 10236	lousy high-proof Electric Punch	10	decent	Last Available: "2019-04"
-10237	lousy high-proof mirror Smuggler's Punch	7	decent	Last Available: "2019-04"
+10237	high-proof lousy mirror Smuggler's Punch	7	decent	Last Available: "2019-04"
 10238	drinkable Scorpion Bowl	3	good	Last Available: "2019-04"
 10239	lousy ghostly Turtle Bowl	4	decent	Last Available: "2019-04"
 10240	hand-crafted Cobra Bowl	3	super EPIC	Last Available: "2019-04"
 10241	fuchsia vampyric cloake pattern	0		Free Pull
-10242	aromatic knitted careful steel-toed extremely unsafe vampyric cloake	0		Weapon Damage Percent: +100, Damage Reduction: 9, Monster Level: -10, Cold Resistance: +3, Stench Resistance: +1, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	aromatic knitted careful steel-toed extremely unsafe vampyric cloake	0		Weapon Damage Percent: +100, Damage Reduction: 9, Monster Level: -10, Cold Resistance: +3, Stench Resistance: +1, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	olive plastic pirate hat	0		Familiar Weight: +5
 10244	flattened polarized one piece of bubble gum	0		Effect: "Kindly Resolve", Effect Duration: 24
 10245	arcanoferric housing	0		
@@ -10113,14 +10113,14 @@
 10248	upside-down blown-out speaker cone	0		
 10249	upside-down overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	skewed auspicious ribald resourceful Fourth of May Cosplay Saber	0		Maximum MP: +50, Sleaze Damage: +10, Item Drop: +10, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	skewed auspicious ribald resourceful Fourth of May Cosplay Saber	0		Maximum MP: +50, Sleaze Damage: +10, Item Drop: +10, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	twirling prompt gravedigger's stanky mansplainer's sharpshooter's fortified supercool Rosewater's hewn moon-rune spoon of James Dean of bravery of the early riser	0		Mysticality Percent: +30, Moxie Percent: +20, Experience (Moxie): +3, Damage Absorption: +60, Critical Hit Percent: +10, Monster Level: +15, Stench Spell Damage: +25, Spooky Damage: +10, Spooky Resistance: +5, Adventures: 10, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	twirling prompt gravedigger's stanky mansplainer's sharpshooter's fortified supercool Rosewater's hewn moon-rune spoon of James Dean of bravery of the early riser	0		Mysticality Percent: +30, Moxie Percent: +20, Experience (Moxie): +3, Damage Absorption: +60, Critical Hit Percent: +10, Monster Level: +15, Stench Spell Damage: +25, Spooky Damage: +10, Spooky Resistance: +5, Adventures: 10, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	ghostly Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	up-at-dawn greasy Beach Comb of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Adventures: +5, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
+10258	up-at-dawn greasy Beach Comb of the storm	0		Maximum MP Percent: +40, Sleaze Spell Damage: +10, Adventures: +5, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
 10259	narrow grain of sand	0		Last Available: "2019-07"
 10260	squat small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
@@ -10154,7 +10154,7 @@
 10289	adjusted colloidal blue Finnish Fish	0		Effect: "Chock Full o' Nanites", Effect Duration: 61
 10290	improved chocolate doubloon	0		Effect: "Standard Issue Bravery", Effect Duration: 15
 10291	executive auspicious reassuring driftwood beach comb	0		Spooky Resistance: +1, Item Drop: +10, Meat Drop: +40, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
-10292	pulsating blue shaking Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
+10292	pulsating shaking blue Distant Woods Getaway Brochure	0		Free Pull, Last Available: "2019-08"
 10293	stick of firewood	0		Last Available: "2019-08"
 10294	foul-smelling Da Vinci's beefy whittled tiara	0		Muscle: +10, Experience (Mysticality): +5, Stench Damage: +10, Last Available: "2019-08"
 10295	stanky rock-hard whittled shorts of extreme caution	0		Damage Reduction: 5, Monster Level: -25, Stench Spell Damage: +25, Last Available: "2019-08"
@@ -10165,13 +10165,13 @@
 10300	scandalous scorching experienced whittled owl figurine	0		Experience: +2, Hot Damage: +25, Sleaze Damage: +5, Single Equip, Last Available: "2019-08"
 10301	foul-smelling boxer's whittled fox figurine of doom	0		Muscle Percent: +10, Stench Damage: +10, Spooky Spell Damage: +50, Single Equip, Last Available: "2019-08"
 10302	perfumed toasty whittled walking stick of dire peril of the bloodbag	0		Weapon Damage: +20, Maximum HP: +100, Hot Damage: +5, Stench Resistance: +5, Last Available: "2019-08"
-10303	yummy bite-sized campfire hot dog	1	awesome	Last Available: "2019-08"
-10304	half-sized flavorless special campfire baked potato	2	decent	Effect: "Je Ne Sais Porquoise", Effect Duration: 35, Last Available: "2019-08"
-10305	decent gigantic campfire s'more	7	good	Last Available: "2019-08"
+10303	bite-sized yummy campfire hot dog	1	awesome	Last Available: "2019-08"
+10304	flavorless special half-sized campfire baked potato	2	decent	Effect: "Je Ne Sais Porquoise", Effect Duration: 35, Last Available: "2019-08"
+10305	gigantic decent campfire s'more	7	good	Last Available: "2019-08"
 10306	toothsome campfire beans	4	awesome	Last Available: "2019-08"
-10307	massive decent bouncing ghostly campfire stew	6	good	Last Available: "2019-08"
+10307	decent massive bouncing ghostly campfire stew	6	good	Last Available: "2019-08"
 10308	campfire coffee	1	good	Last Available: "2019-08"
-10309	boiled teal shaking leftover chocolate bar	0		Effect: "Mana Tea", Effect Duration: 39
+10309	boiled shaking teal leftover chocolate bar	0		Effect: "Mana Tea", Effect Duration: 39
 10310	rare Meat isotope	0		
 10311	burnt stick	0		Last Available: "2019-08"
 10312	bundle of firewood	0		Last Available: "2019-08"
@@ -10190,12 +10190,12 @@
 10325	Law of Averages	0		
 10332	huge Unopened Eight Days a Week Pill Keeper	0		Free Pull, Last Available: "2019-10"
 10333	experienced beefy Eight Days a Week Pill Keeper of incineration	0		Muscle: +10, Experience: +2, Hot Spell Damage: +50, Last Available: "2019-10"
-10334	blurry huge unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
+10334	huge blurry unopened diabolic pizza cube box	0		Free Pull, Last Available: "2019-11"
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	tasty twirling bu&ntilde;uelos Jaliscos	3	awesome	Last Available: "2019-12"
-10338	stale jumbo skewed flan del mar	5	decent	Last Available: "2019-12"
-10339	super-sized bland lime green Baja sopapilla	5	decent	Last Available: "2019-12"
+10338	jumbo stale skewed flan del mar	5	decent	Last Available: "2019-12"
+10339	bland super-sized lime green Baja sopapilla	5	decent	Last Available: "2019-12"
 10340	lightning-fast plastic Mer-kin baker	0		Initiative: +40, Last Available: "2019-12"
 10341	plastic sea elf of the storm	0		Maximum MP Percent: +40, Last Available: "2019-12"
 10342	Sherlock's plastic yuleviathan	0		Item Drop: +25, Last Available: "2019-12"
@@ -10204,8 +10204,8 @@
 10345	red-spotted snapper roe	0		Free Pull, Last Available: "2019-12"
 10346	flavorless mana-coated yams	3	decent	Last Available: "2019-11"
 10347	adequate mana-basted tofurkey leg	4	good	Last Available: "2019-11"
-10348	adequate enchanted mana-fortified cranberry sauce	3	good	Effect: "Toothy Grin", Effect Duration: 15, Last Available: "2019-11"
-10349	stale tiny maroon bouncing mana-stuffed herbal stuffing	1	decent	Last Available: "2019-11"
+10348	enchanted adequate mana-fortified cranberry sauce	3	good	Effect: "Toothy Grin", Effect Duration: 15, Last Available: "2019-11"
+10349	tiny stale maroon bouncing mana-stuffed herbal stuffing	1	decent	Last Available: "2019-11"
 10350	squat human musk	0		Last Available: "2019-12"
 10351	energized activated shaking patch of extra-warm fur	0		Effect: "Greased-Up Familiar", Effect Duration: 22, Last Available: "2019-12"
 10352	vaporized twirling industrial lubricant	1		Effect: "Crotchety, Pining", Effect Duration: 45, Last Available: "2019-12"
@@ -10214,11 +10214,11 @@
 10355	modified narrow a bug's lymph	1		Last Available: "2019-12"
 10356	adjusted huge organic potpourri	0		Effect: "Blessing of Charcoatl", Effect Duration: 36, Last Available: "2019-12"
 10357	artisanal cyan boot flask	4	EPIC	Last Available: "2019-12"
-10358	vacuum-sealed quadruple-pressed blurry shaking gray infernal snowball	0		Effect: "Sugar Smacks", Effect Duration: 51, Last Available: "2019-12"
-10359	purple blurry madness	0		Last Available: "2019-12"
+10358	vacuum-sealed quadruple-pressed shaking gray blurry infernal snowball	0		Effect: "Sugar Smacks", Effect Duration: 51, Last Available: "2019-12"
+10359	blurry purple madness	0		Last Available: "2019-12"
 10360	powdered fish sauce	1		Last Available: "2019-12"
 10361	special stale guffin	3	decent	Effect: "Riboflavin'", Effect Duration: 10, Last Available: "2019-12"
-10362	pickled purple tumbling Shantix&trade;	1		Last Available: "2019-12"
+10362	pickled tumbling purple Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	modified non-Euclidean angle	1		Last Available: "2019-12"
 10365	ionized warmed peppermint syrup	0		Effect: "Be a Mind Master", Effect Duration: 63, Last Available: "2019-12"
@@ -10227,7 +10227,7 @@
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	altered maroon livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	dried wobbly tumbling beggin' cologne	1		Last Available: "2019-12"
+10371	dried tumbling wobbly beggin' cologne	1		Last Available: "2019-12"
 10372	sharpshooter's beefy oxygenated eggnog helmet	0		Muscle: +10, Critical Hit Percent: +10, Adventure Underwater, Last Available: "2019-12"
 10373	blinking hand-knitted diving booties	0		Last Available: "2019-12"
 10374	teal peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10254,7 +10254,7 @@
 10395	pulsating personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
 10397	spoiled squat bowl of mernudo	4	crappy	Last Available: "2019-12"
-10398	irresponsibly strong acceptable spinning fishelada	7	good	Last Available: "2019-12"
+10398	acceptable irresponsibly strong spinning fishelada	7	good	Last Available: "2019-12"
 10399	toothsome ojo de pez burrito	3	awesome	Last Available: "2019-12"
 10400	blinking waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	friendly arcane researcher's nutcracker cape	0		Experience Percent (Mysticality): +10, Familiar Weight: +3, Last Available: "2019-12"
 10413	auspicious thinker's nutcracker epaulets	0		Mysticality: +10, Item Drop: +10, Single Equip, Last Available: "2019-12"
 10414	squat nutcracker figurine	0		Last Available: "2019-12"
-10415	special spoiled gigantic salt plum	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35, Last Available: "2019-12"
+10415	spoiled special gigantic salt plum	9	crappy	Effect: "Arcane in the Brain", Effect Duration: 35, Last Available: "2019-12"
 10416	peppermint eel sauce	0		Last Available: "2019-12"
 10417	decent miniature and bean	2	good	Last Available: "2019-12"
 10418	censurious stiffened brainy kelp-holly gun	0		Mysticality: +5, Damage Reduction: 1, Sleaze Resistance: +3, Last Available: "2019-12"
@@ -10282,27 +10282,27 @@
 10423	fuchsia Jeselnik's brawny kelp-holly drape	0		Muscle Percent: +20, Sleaze Damage: +25, Last Available: "2019-12"
 10424	upside-down beefy Staff of the Peppermint Twist of dire peril of Gandalf of the glutton	0		Muscle: +10, Weapon Damage: +20, Spell Critical Percent: +20, Food Drop: +100, Last Available: "2019-12"
 10425	decent upside-down tempura and bean	3	good	Last Available: "2019-12"
-10426	lousy practically non-alcoholic salt plum sake	1	decent	Last Available: "2019-12"
+10426	practically non-alcoholic lousy salt plum sake	1	decent	Last Available: "2019-12"
 10427	pickled cyan pressurized potion of possessiveness	0		Effect: "Thought", Effect Duration: 51, Last Available: "2019-12"
 10428	super-galvanized almond	0		Effect: "Goldentongue", Effect Duration: 62
 10429	activated spinning handful of mixed nuts	0		Effect: "Greasy Flavor", Effect Duration: 53, Last Available: "2019-12"
 10430	tumbling nutcracking pliers	0		
 10431	narrow Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	friendly weightlifter's Retrospecs of incineration	0		Muscle: +15, Familiar Weight: +3, Hot Spell Damage: +50, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	friendly weightlifter's Retrospecs of incineration	0		Muscle: +15, Familiar Weight: +3, Hot Spell Damage: +50, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	maroon unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	wobbly mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	mirror greedy greasy Tesla stylish Powerful Glove of James Dean	0		Moxie: +25, Experience (Moxie): +3, Sleaze Spell Damage: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
-10439	mirror olive enhanced signal receiver	0		
+10438	mirror greedy greasy Tesla stylish Powerful Glove of James Dean	0		Moxie: +25, Experience (Moxie): +3, Sleaze Spell Damage: +10, Meat Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10439	olive mirror enhanced signal receiver	0		
 10440	status cymbal	0		Last Available: "2020-02"
 10441	upside-down maroon quilted supercool Drip harness of doom	0		Moxie Percent: +20, Damage Absorption: +40, Spooky Spell Damage: +50
 10442	Fonzie's drippy truncheon	0		Experience (Moxie): +1, Single Equip
 10443	blue Driplet	0		
 10444	drippy snail shell	0		
 10445	spoiled drippy nugget	3	drippy	
-10446	bad practically non-alcoholic blurry glass of drippy wine	1	drippy	
+10446	practically non-alcoholic bad blurry glass of drippy wine	1	drippy	
 10447	moldy drippy caviar	3	drippy	
-10448	spoiled small blinking drippy plum(?)	2	drippy	
+10448	small spoiled blinking drippy plum(?)	2	drippy	
 10449	chaotic drippy stake	0		Spell Critical Percent: +10, Single Equip
 10450	The Eye of the Thing in the Basement	0		
 10451	drippy khakis	0		
@@ -10318,11 +10318,11 @@
 10461	green hammer	0		
 10462	bouncing fire flower	0		
 10463	bonfire flower	0		
-10464	huge spinning work boots	0		Single Equip
+10464	spinning huge work boots	0		Single Equip
 10465	boots	0		Single Equip
 10466	ghostly energetic cape	0		Maximum MP Percent: +20
 10467	scorching stiffened back shell	0		Damage Reduction: 1, Hot Damage: +25
-10468	fuchsia bouncing spiky back shell	0		
+10468	bouncing fuchsia spiky back shell	0		
 10469	blinking power pants	0		Maximum PP: +1
 10470	Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
@@ -10373,13 +10373,13 @@
 10516	drippy bezoar	0		
 10517	Drip Institute petri dish	0		
 10518	drippy ichor	0		
-10519	wobbly jittery drippy enzyme	0		
+10519	jittery wobbly drippy enzyme	0		
 10520	drippy salt	0		
 10521	wobbly drippy pigment	0		
 10522	drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
-10525	weak aged jittery drippy pilsner	2	drippy	
+10525	aged weak jittery drippy pilsner	2	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
 10528	drippy orb	0		
 10529	lustrous drippy orb	0		
@@ -10396,9 +10396,9 @@
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
 10541	practically non-alcoholic mediocre Ghiaccio Colada	1	decent	Last Available: "2020-05"
 10542	mediocre practically non-alcoholic Sourfinger	1	decent	Last Available: "2020-05"
-10543	watered-down mediocre Nog-on-the-Cob	2	decent	Last Available: "2020-05"
+10543	mediocre watered-down Nog-on-the-Cob	2	decent	Last Available: "2020-05"
 10544	aged red Steamboat	4	awesome	Last Available: "2020-05"
-10545	delicious fancy Buttery Boy	3	awesome	Effect: "Bear Clawed", Effect Duration: 10, Last Available: "2020-05"
+10545	fancy delicious Buttery Boy	3	awesome	Effect: "Bear Clawed", Effect Duration: 10, Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	ghostly pulsating asbestos-lined MacGyver's clown car key	0		Maximum MP: +100, Hot Resistance: +5, Last Available: "2020-08"
 10548	hardy veiny Da Vinci's batting cage key	0		Experience (Mysticality): +5, Maximum HP: 60, Last Available: "2020-08"
@@ -10430,17 +10430,17 @@
 10574	Iunion Crown	0		Last Available: "2020-06"
 10575	twirling drippy candy bar	0		
 10576	warmed salty drippy candy bar	0		Effect: "Memory of Attractiveness", Effect Duration: 54
-10577	concentrated double-enhanced olive squat writhing drippy candy bar	0		Effect: "Updated", Effect Duration: 63
+10577	concentrated double-enhanced squat olive writhing drippy candy bar	0		Effect: "Updated", Effect Duration: 63
 10578	liquefied alkaline gooey drippy candy bar	0		Effect: "Starry-Eyed", Effect Duration: 43
 10579	purple ghostly baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
-10581	upside-down jittery upside-down packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
+10581	upside-down upside-down jittery packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	fuchsia jittery dog trainer's birch battery of the cougar	0		Moxie: +20, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2020-08"
-10585	Oprah's ebony epee of Leguizamo of the early riser	0		Maximum MP Percent: +50, Monster Level: +20, Adventures: +7, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	Tesla baleful weeping willow wand of the detective	0		Spell Damage: +25, Item Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	auspicious nasty beechwood blowgun of extreme caution	0		Monster Level: -25, Stench Damage: +5, Item Drop: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	Oprah's ebony epee of Leguizamo of the early riser	0		Maximum MP Percent: +50, Monster Level: +20, Adventures: +7, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	Tesla baleful weeping willow wand of the detective	0		Spell Damage: +25, Item Drop: +20, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	auspicious nasty beechwood blowgun of extreme caution	0		Monster Level: -25, Stench Damage: +5, Item Drop: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	squat dog trainer's brainy maple magnet of Gandalf	0		Mysticality: +5, Spell Critical Percent: +20, Experience (familiar): +1, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	Jack Frost's wicked wizardly hemlock helm	0		Mysticality: +25, Spell Damage: +5, Cold Spell Damage: +50, Last Available: "2020-08"
@@ -10456,7 +10456,7 @@
 10600	drippy diadem	0		Last Available: "2020-08"
 10601	Thwaitgold slug statuette	0		
 10602	therapeutic ert grey goo ring	0		HP Regen Min: 5, HP Regen Max: 7
-10603	twirling mirror fistful of wood shavings	0		
+10603	mirror twirling fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	deionized non-dry narrow Yeg's Motel toothbrush	0		Effect: "Omphalotus Omnipresence", Effect Duration: 46, Last Available: "2020-09"
@@ -10464,7 +10464,7 @@
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	moldy massive gray Yeg's Motel pillow mint	7	crappy	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
-10611	nitrogenated shaking maroon Yeg's Motel mouthwash	0		Effect: "Cheered Up", Effect Duration: 22, Last Available: "2020-09"
+10611	nitrogenated maroon shaking Yeg's Motel mouthwash	0		Effect: "Cheered Up", Effect Duration: 22, Last Available: "2020-09"
 10612	purple Yeg's Motel shower cap of extreme caution of incineration	0		Monster Level: -25, Hot Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-09"
 10613	Van der Graaf Yeg's Motel bathrobe of chilblains	0		Cold Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2020-09"
 10614	avaricious Tesla Yeg's Motel slippers	0		Meat Drop: +30, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
@@ -10479,7 +10479,7 @@
 10623	blinking onyx king	0		Last Available: "2020-09"
 10624	twirling onyx queen	0		Last Available: "2020-09"
 10625	onyx rook	0		Last Available: "2020-09"
-10626	wobbly upside-down blurry onyx bishop	0		Last Available: "2020-09"
+10626	upside-down wobbly blurry onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
 10628	jittery onyx pawn	0		Last Available: "2020-09"
 10629	narrow alabaster king	0		Last Available: "2020-09"
@@ -10506,7 +10506,7 @@
 10650	blinking grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
 10652	teal subscription cocoa dispenser	0		Last Available: "2020-12"
-10653	ionized anodized pulsating pulsating gray fortifying hot cocoa	0		Effect: "Insatiable Hunger", Effect Duration: 34, Last Available: "2020-12"
+10653	ionized anodized pulsating gray pulsating fortifying hot cocoa	0		Effect: "Insatiable Hunger", Effect Duration: 34, Last Available: "2020-12"
 10654	ionized boiling hot cocoa	0		Effect: "Jawin'", Effect Duration: 22, Last Available: "2020-12"
 10655	aerosolized energized pickled cool hot cocoa	0		Effect: "Serendipi Tea", Effect Duration: 49, Last Available: "2020-12"
 10656	quantum overly-fancy hot cocoa	0		Effect: "Blessing of Charcoatl", Effect Duration: 39, Last Available: "2020-12"
@@ -10542,7 +10542,7 @@
 10686	government booze shipment	0		Last Available: "2020-12"
 10687	twirling government candy shipment	0		Last Available: "2020-12"
 10688	shaking jittery Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
-10689	mirror teal Crimbo Carol tattoo kit	0		Last Available: "2020-12"
+10689	teal mirror Crimbo Carol tattoo kit	0		Last Available: "2020-12"
 10690	Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	food drive button	0		Single Equip, Last Available: "2020-12"
 10692	yellow booze drive button	0		Single Equip, Last Available: "2020-12"
@@ -10573,10 +10573,10 @@
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	fuchsia goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	irresponsibly strong delicious barrel-aged eggnog	10	awesome	Last Available: "2020-12"
-10721	massive stale squat hand-crafted candy cane	10	decent	Last Available: "2020-12"
+10720	delicious irresponsibly strong barrel-aged eggnog	10	awesome	Last Available: "2020-12"
+10721	stale massive squat hand-crafted candy cane	10	decent	Last Available: "2020-12"
 10722	rotten fancy drive-thru burger	4	crappy	Effect: "Healthy Bronze Glow", Effect Duration: 5, Last Available: "2020-12"
-10723	practically non-alcoholic bad Boulevardier cocktail	1	decent	Last Available: "2020-12"
+10723	bad practically non-alcoholic Boulevardier cocktail	1	decent	Last Available: "2020-12"
 10724	boiled Hotwire&trade; brand candy rope	0		Effect: "Rad-ish", Effect Duration: 28, Last Available: "2020-12"
 10725	bland bowl full of jelly	3	decent	Last Available: "2020-12"
 10726	bad blinking narrow Eye and a Twist	3	decent	Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	shaking bouncing spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	bouncing shaking spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	robo-battery	0		
 10736	pulsating Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10602,17 +10602,17 @@
 10746	cyan marshmallow	0		
 10747	bad marshmallow bomb	3	decent	Last Available: "2021-03"
 10748	upside-down packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	lime green tumbling shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	ghostly plate	0		Familiar Weight: +5
-10752	quantum colloidal cyan bouncing short beer	0		Effect: "Always be Collecting", Effect Duration: 14, Last Available: "2021-05"
+10752	quantum colloidal bouncing cyan short beer	0		Effect: "Always be Collecting", Effect Duration: 14, Last Available: "2021-05"
 10753	oxidized huge short stack of pancakes	0		Effect: "Izchak's Blessing", Effect Duration: 61, Last Available: "2021-05"
 10754	polymerized red shaking short stick of butter	0		Effect: "Sweet and Green", Effect Duration: 13, Last Available: "2021-05"
 10755	frozen electrified spinning wobbly short glass of water	0		Effect: "Bone Homie", Effect Duration: 55, Last Available: "2021-05"
 10756	quadruple-polarized squat short	0		Effect: "Phairly Pheromonal", Effect Duration: 65, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	fireproof Da Vinci's familiar scrapbook	0		Experience (Mysticality): +5, Hot Resistance: +3, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	fireproof Da Vinci's familiar scrapbook	0		Experience (Mysticality): +5, Hot Resistance: +3, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	mirror packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	sizzling Van der Graaf padded fedora-mounted fountain	0		Damage Absorption: +20, Hot Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,14 +10621,14 @@
 10765	squat rocket	0		Last Available: "2021-07"
 10766	rocket	0		Last Available: "2021-07"
 10767	rocket	0		Last Available: "2021-07"
-10768	miniature moldy wobbly wobbly lime green fire crackers	2	crappy	Last Available: "2021-07"
+10768	moldy miniature wobbly wobbly lime green fire crackers	2	crappy	Last Available: "2021-07"
 10769	gray Arr, M80	0		Last Available: "2021-07"
 10770	wobbly pulsating wholesome brainy Catherine Wheel	0		Mysticality: +5, Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2021-07"
 10771	rock-hard rocket boots of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 5, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
 10772	clever Samson's sparkler	0		Experience (Muscle): +5, Maximum MP: +20, Lasts Until Rollover, Last Available: "2021-07"
 10773	squat Our Daily Candles&trade; order form	0		Free Pull, Last Available: "2021-08"
 10774	improved Scent of a Human&trade; candle	0		Effect: "Superhuman Sarcasm", Effect Duration: 52, Last Available: "2021-08"
-10775	enhanced upside-down blue The Beast Within&trade; candle	0		Effect: "Full of Wist", Effect Duration: 45, Last Available: "2021-08"
+10775	enhanced blue upside-down The Beast Within&trade; candle	0		Effect: "Full of Wist", Effect Duration: 45, Last Available: "2021-08"
 10776	non-corrupted green Salsa Caliente&trade; candle	0		Effect: "Speed of the Internet", Effect Duration: 39, Last Available: "2021-08"
 10777	liquefied moist aerosolized Smoldering Clover&trade; candle	0		Effect: "High Blood Chocolate Content", Effect Duration: 49, Last Available: "2021-08"
 10778	aerosolized Napalm In The Morning&trade; candle	0		Effect: "Super Accuracy", Effect Duration: 54, Last Available: "2021-08"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	upside-down pump grease	0		
 10796	packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	Usain Bolt's nasty studded arcane researcher's industrial fire extinguisher of wisdom of the bloodbag	0		Mysticality: +15, Experience Percent (Mysticality): +10, Damage Absorption: +80, Maximum HP: +100, Stench Damage: +5, Initiative: +80, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	Usain Bolt's nasty studded arcane researcher's industrial fire extinguisher of wisdom of the bloodbag	0		Mysticality: +15, Experience Percent (Mysticality): +10, Damage Absorption: +80, Maximum HP: +100, Stench Damage: +5, Initiative: +80, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	blurry The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10672,18 +10672,18 @@
 10816	toasty boxer's ice crown of the businessman	0		Muscle Percent: +10, Hot Damage: +5, Meat Drop: +50, Lasts Until Rollover, Last Available: "2021-12"
 10817	double-paned quilted boxer's jeans	0		Muscle Percent: +10, Damage Absorption: +40, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2021-12"
 10818	jittery miser's sharpshooter's MacGyver's ice wrap	0		Maximum MP: +100, Critical Hit Percent: +10, Meat Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	toothsome special small tofu pop	2	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2021-12"
+10819	special toothsome small tofu pop	2	awesome	Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2021-12"
 10820	adequate special skewed bowl of prescription candy	4	good	Effect: "Mariachi Mood", Effect Duration: 40, Last Available: "2021-12"
 10821	spoiled bouncing fishcake	4	crappy	Last Available: "2021-12"
 10822	rotten huge bone broth	3	crappy	Last Available: "2021-12"
-10823	flavorless fancy star pop	3	decent	Effect: "Cotton Mouthed", Effect Duration: 35, Last Available: "2021-12"
-10824	drinkable enchanted narrow Doc's Fortifying Wine	4	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 45, Last Available: "2021-12"
+10823	fancy flavorless star pop	3	decent	Effect: "Cotton Mouthed", Effect Duration: 35, Last Available: "2021-12"
+10824	enchanted drinkable narrow Doc's Fortifying Wine	4	good	Effect: "Healthy, Elfy, and Wise", Effect Duration: 45, Last Available: "2021-12"
 10825	irresponsibly strong hand-crafted Doc's Smartifying Wine	6	EPIC	Last Available: "2021-12"
 10826	perfectly mixed Doc's Limbering Wine	3	EPIC	Last Available: "2021-12"
-10827	irresponsibly strong drinkable Doc's Medical-Grade Wine	9	good	Last Available: "2021-12"
-10828	vaporized jittery huge Homebodyl&trade;	1		Last Available: "2021-12"
+10827	drinkable irresponsibly strong Doc's Medical-Grade Wine	9	good	Last Available: "2021-12"
+10828	vaporized huge jittery Homebodyl&trade;	1		Last Available: "2021-12"
 10829	mixed Extrovermectin&trade;	1		Last Available: "2021-12"
-10830	altered twirling maroon Breathitin&trade;	1		Last Available: "2021-12"
+10830	altered maroon twirling Breathitin&trade;	1		Last Available: "2021-12"
 10831	modified pulsating Fleshazole&trade;	1		Last Available: "2021-12"
 10832	vacuum-sealed oxidized anti-burn cream	0		Effect: "Rainbow Bright", Effect Duration: 48, Last Available: "2021-12"
 10833	magnetized concentrated anti-freeze cream	0		Effect: "Buggy Flavor", Effect Duration: 13, Last Available: "2021-12"
@@ -10692,7 +10692,7 @@
 10836	ionized vacuum-sealed anti-creep cream	0		Effect: "Healthy Bronze Glow", Effect Duration: 51, Last Available: "2021-12"
 10837	quadruple-modified anti-pain cream	0		Effect: "Hood Ridin'", Effect Duration: 36, Last Available: "2021-12"
 10838	bad Doc's Special Reserve Wine	4	decent	Last Available: "2021-12"
-10839	flavorless miniature bread pie	2	decent	Last Available: "2021-12"
+10839	miniature flavorless bread pie	2	decent	Last Available: "2021-12"
 10840	acceptable clear Russian	4	good	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	jittery Crimbo ball	0		Last Available: "2021-12"
@@ -10705,8 +10705,8 @@
 10849	coagulated plum pudding isomers	2		Effect: "Festively Experimented-Upon", Effect Duration: 50
 10850	blinking goo magnet	0		Last Available: "2021-12"
 10851	cozy scarf of the glutton	0		Food Drop: +100, Last Available: "2021-12"
-10852	immense normal huge Crimbo cookie	9	good	Last Available: "2023-06"
-10853	wet concentrated mirror wobbly jittery fleshy putty	0		Effect: "Earthen Fist", Effect Duration: 44, Last Available: "2021-12"
+10852	normal immense huge Crimbo cookie	9	good	Last Available: "2023-06"
+10853	wet concentrated jittery mirror wobbly fleshy putty	0		Effect: "Earthen Fist", Effect Duration: 44, Last Available: "2021-12"
 10854	inspector's third ear	0		Item Drop: +15, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	green poisonsettia	0		Last Available: "2021-12"
@@ -10739,7 +10739,7 @@
 10883	compressed blinking tumbling astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	Jack Frost's Tesla magnifying glass of incineration	0		Cold Spell Damage: +50, Hot Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2022-12"
-10886	acceptable watered-down special spinning void lager	2	good	Effect: "Ass Over Teakettle", Effect Duration: 35, Last Available: "2022-12"
+10886	watered-down special acceptable spinning void lager	2	good	Effect: "Ass Over Teakettle", Effect Duration: 35, Last Available: "2022-12"
 10887	flavorless bite-sized narrow void burger	1	decent	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	MacGyver's weightlifter's beefy void shard of incineration	0		Muscle: 25, Maximum MP: +100, Hot Spell Damage: +50, Last Available: "2022-12"
@@ -10765,7 +10765,7 @@
 10909	shaking pulsating space blanket	0		Last Available: "2022-05"
 10910	Vulcanized non-unsweetened single-use dust mask	0		Effect: "Warm Shoulders", Effect Duration: 17, Last Available: "2022-05"
 10911	energized bouncing gaffer's tape	0		Effect: "Elvish", Effect Duration: 45, Last Available: "2022-05"
-10912	immense normal 20-lb can of rice and beans	7	good	Last Available: "2022-05"
+10912	normal immense 20-lb can of rice and beans	7	good	Last Available: "2022-05"
 10913	special bar of freeze-dried water	1	EPIC	Effect: "Beastly Flavor", Effect Duration: 45, Last Available: "2022-05"
 10914	super-sized moldy expired MRE	5	crappy	Last Available: "2022-05"
 10915	stale cool mint precipice bar	3	decent	Last Available: "2022-05"
@@ -10782,7 +10782,7 @@
 10926	concentrated skewed trampled ticket stub	0		Effect: "You Know What's Up", Effect Duration: 35, Last Available: "2022-06"
 10927	warmed savings bond	0		Effect: "Chow Downed", Effect Duration: 48, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	dried skewed sweat-ade	1		Last Available: "2022-07"
 10931	blue unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10794,7 +10794,7 @@
 10938	upside-down birdseed hat	0		
 10939	shaking flatusaur gasmask	0		
 10940	olive dinosaur dart	0		
-10941	boiled ionized olive shaking Dino DNAde&trade;	0		Effect: "Sausage Festive", Effect Duration: 24
+10941	boiled ionized shaking olive Dino DNAde&trade;	0		Effect: "Sausage Festive", Effect Duration: 24
 10942	spinning dinosaur repellent	0		
 10943	greasy camouflage vest	0		Sleaze Spell Damage: +10
 10944	teal Dinodollar	0		
@@ -10805,7 +10805,7 @@
 10949	blurry double-paned dinosaur	0		Cold Resistance: +5
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	wobbly packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	purple Jurassic Parka of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	purple Jurassic Parka of the wise owl of mayonnaise	0		Mysticality: +20, Sleaze Spell Damage: +50, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	fuchsia boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	ionized polarized autumn leaf	0		Effect: "Mercenary", Effect Duration: 35, Last Available: "2022-10"
@@ -10825,38 +10825,38 @@
 10969	Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	spoiled olive ratatouille de Jarlsberg	3	crappy	Last Available: "2022-11"
 10971	decent jumbo Jarlsberg's vegetable soup	5	good	Last Available: "2022-11"
-10972	adequate super-sized roasted vegetable of Jarlsberg	5	good	Last Available: "2022-11"
+10972	super-sized adequate roasted vegetable of Jarlsberg	5	good	Last Available: "2022-11"
 10973	miniature delicious twirling St. Pete's sneaky smoothie	2	awesome	Last Available: "2022-11"
 10974	flavorless Pete's wiley whey bar	4	decent	Last Available: "2022-11"
 10975	decent lime green Pete's rich ricotta	3	good	Last Available: "2022-11"
 10976	lousy strong Boris's beer	5	decent	Last Available: "2022-11"
 10977	bite-sized decent honey bun of Boris	1	good	Last Available: "2022-11"
 10978	half-sized normal Boris's bread	2	good	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	skewed Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	narrow Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	skewed Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	skewed Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	narrow Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	skewed Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	enchanted toothsome bouncing baked veggie ricotta casserole	3	awesome	Effect: "Sticky Fingers", Effect Duration: 35, Last Available: "2022-11"
 10989	flavorless enchanted plain calzone	4	decent	Effect: "Benetton's Medley of Diversity", Effect Duration: 50, Last Available: "2022-11"
 10990	flavorless bouncing roasted vegetable focaccia	3	decent	Last Available: "2022-11"
 10991	decent Pizza of Legend	3	good	Last Available: "2022-11"
 10992	massive spoiled Calzone of Legend	6	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	gray Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	gray Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	pulsating cookbookbat book	0		Familiar Weight: +5
-10999	upside-down Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
+10999	upside-down Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
 11000	miniature decent skewed Deep Dish of Legend	2	good	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
-11003	shaking yellow government per-diem	0		
+11003	yellow shaking government per-diem	0		
 11004	miser's prohie's hat	0		Meat Drop: +10
 11005	electrified extra-diffused imported taffy	0		Effect: "Holiday Disappointment", Effect Duration: 46
 11006	flame-retardant Charleston shoes of the storm	0		Maximum MP Percent: +40, Hot Resistance: +1, Single Equip
@@ -10868,17 +10868,17 @@
 11012	milk cap	0		
 11013	artisanal gray Charleston Choo-Choo	3	EPIC	
 11014	drinkable skewed blurry Velvet Veil	3	good	
-11015	artisanal strong Marltini	5	EPIC	
+11015	strong artisanal Marltini	5	EPIC	
 11016	tolerable Strong, Silent Type	3	good	
 11017	artisanal Mysterious Stranger	3	EPIC	
 11018	tolerable Champagne Shimmy	3	good	
 11019	spinning the Sot's parcel	0		
-11020	wholesome wizardly ceramic cestus	0		Mysticality: +25, Maximum HP Percent: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	scandalous ceramic centurion shield of courage of temperance	0		Sleaze Damage: +5, Spooky Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	blurry gravedigger's ceramic celery grater of the cougar	0		Moxie: +20, Spooky Damage: +10, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	ribald hardened ceramic celsiturometer of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Sleaze Damage: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	supercharged veiny ceramic cerecloth belt of Gandalf	0		Maximum HP: +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	horrifying energetic weightlifter's ceramic cenobite's robe	0		Muscle: +15, Maximum MP Percent: +20, Spooky Damage: +25, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	wholesome wizardly ceramic cestus	0		Mysticality: +25, Maximum HP Percent: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	scandalous ceramic centurion shield of courage of temperance	0		Sleaze Damage: +5, Spooky Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	blurry gravedigger's ceramic celery grater of the cougar	0		Moxie: +20, Spooky Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	ribald hardened ceramic celsiturometer of the wise owl	0		Mysticality: +20, Damage Reduction: 3, Sleaze Damage: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	supercharged veiny ceramic cerecloth belt of Gandalf	0		Maximum HP: +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	horrifying energetic weightlifter's ceramic cenobite's robe	0		Muscle: +15, Maximum MP Percent: +20, Spooky Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	compressed shaking green ceramic scree	1		Effect: "Bustle Hustlin'", Effect Duration: 45, Last Available: "2023-12"
 11027	denatured ionized oxidized extra-hard jawbreaker	0		Effect: "Weird Vibrations", Effect Duration: 11
 11028	lightning-fast Jim Carey's chiffon chevrons of the businessman	0		Monster Level: +25, Meat Drop: +50, Initiative: +40, Single Equip, Last Available: "2023-12"
@@ -10890,8 +10890,8 @@
 11034	powdered lime green chiffon carbage	1		Last Available: "2023-12"
 11035	colloidal jittery chiffon lemon	0		Effect: "Pla-see-bo", Effect Duration: 17
 11036	adequate chocomotive	3	good	Last Available: "2022-12"
-11037	decent miniature shaking freightcake	2	good	Last Available: "2022-12"
-11038	hand-crafted weak blurry wobbly blue cabooze	2	super EPIC	Last Available: "2022-12"
+11037	miniature decent shaking freightcake	2	good	Last Available: "2022-12"
+11038	hand-crafted weak wobbly blue blurry cabooze	2	super EPIC	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	mirror plastic passenger car of the cougar	0		Moxie: +20, Last Available: "2022-12"
 11041	Temple Grandin's plastic dining car	0		Familiar Weight: +7, Last Available: "2022-12"
@@ -10902,8 +10902,8 @@
 11046	blurry purple Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
 11048	Trainbot radar monocle	0		Single Equip
-11049	upside-down huge pile of Trainbot parts	0		
-11050	pressed adjusted blinking green Trainbot circuitry	0		Effect: "Superhuman Sarcasm", Effect Duration: 38
+11049	huge upside-down pile of Trainbot parts	0		
+11050	pressed adjusted green blinking Trainbot circuitry	0		Effect: "Superhuman Sarcasm", Effect Duration: 38
 11051	energized Trainbot tubing	0		Effect: "On the Shoulders of Giants", Effect Duration: 56
 11052	non-electrified moist fuchsia Trainbot plating	0		Effect: "Sensation", Effect Duration: 38
 11053	pressed Trainbot optics	0		Effect: "Baconstoned", Effect Duration: 60
@@ -10920,12 +10920,12 @@
 11064	twirling resourceful savvy smooth shoulder-mounted Trainbot	0		Moxie: +15, Mysticality Percent: +20, Maximum MP: +50, Single Equip, Last Available: "2022-12"
 11065	cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	special mediocre practically non-alcoholic skewed dregs of a Crimbo cocktail	1	decent	Effect: "Happy Salamander", Effect Duration: 10
+11067	mediocre special practically non-alcoholic skewed dregs of a Crimbo cocktail	1	decent	Effect: "Happy Salamander", Effect Duration: 10
 11068	lost elf luggage	0		
 11069	twirling Trainbot luggage hook	0		Single Equip
-11070	special moldy bite-sized blurry honey-drenched ham slice	1	crappy	Effect: "Old School Pompadour", Effect Duration: 5
+11070	moldy bite-sized special blurry honey-drenched ham slice	1	crappy	Effect: "Old School Pompadour", Effect Duration: 5
 11071	hand-crafted mostly-empty bottle of cookie wine	4	EPIC	
-11072	flavorless small huge Crimbo food scraps	2	decent	
+11072	small flavorless huge Crimbo food scraps	2	decent	
 11073	arm towel	0		Last Available: "2022-12"
 11074	automatic wine thief	0		Single Equip
 11075	table-scraper	0		Single Equip
@@ -10960,11 +10960,11 @@
 11104	milestone	0		Last Available: "2023-01"
 11105	bolder boulder	0		Last Available: "2023-01"
 11106	molehill mountain	0		Last Available: "2023-01"
-11107	gray wobbly whet stone	0		Last Available: "2023-01"
+11107	wobbly gray whet stone	0		Last Available: "2023-01"
 11108	hard rock	0		Last Available: "2023-01"
 11109	twirling stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	delicious special miniature pixel bread	2	awesome	Effect: "Rad-ish", Effect Duration: 10
+11112	special miniature delicious pixel bread	2	awesome	Effect: "Rad-ish", Effect Duration: 10
 11113	perfectly mixed pixel whiskey	3	EPIC	
 11114	cyan pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10972,14 +10972,14 @@
 11117	non-boiled electrified glob of extra-green chlorophyll	0		Effect: "Sweet Incentive", Effect Duration: 52, Last Available: "2023-02"
 11118	cold-filtered chilled yellow mushroom	0		Effect: "Larger", Effect Duration: 59, Last Available: "2023-02"
 11119	ionized twirling five-fingered fern resin	0		Effect: "Nightstalkin'", Effect Duration: 65, Last Available: "2023-02"
-11120	bland enchanted tiny blinking super good fruit	1	decent	Effect: "Okee-Dokee Computer", Effect Duration: 5, Last Available: "2023-02"
+11120	enchanted tiny bland blinking super good fruit	1	decent	Effect: "Okee-Dokee Computer", Effect Duration: 5, Last Available: "2023-02"
 11121	dehydrated ghostly energized spores	1		Last Available: "2023-02"
-11122	huge resourceful Rosewater's hot pepper	0		Mysticality Percent: +30, Maximum MP: +50, Lantern Element: "Hot", Last Available: "2023-02"
+11122	huge resourceful Rosewater's hot pepper	0		Mysticality Percent: +30, Maximum MP: +50, Last Available: "2023-02", Lantern Element: "Hot"
 11123	non-tarnished vacuum-sealed out-of-work circus flea	0		Effect: "Notably Lovely", Effect Duration: 25, Last Available: "2023-02"
 11124	pulsating extra-grubby grub	0		Last Available: "2023-02"
 11125	pressed non-adjusted maroon fire ant pheromones	0		Effect: "Wasabi With You", Effect Duration: 25, Last Available: "2023-02"
 11126	polarized energized teal flapper fly	0		Effect: "Cold Jellied", Effect Duration: 16, Last Available: "2023-02"
-11127	boozy tolerable skewed shot of wasp venom	5	good	Last Available: "2023-02"
+11127	tolerable boozy skewed shot of wasp venom	5	good	Last Available: "2023-02"
 11128	activated filled mosquito	0		Effect: "All Is Forgiven", Effect Duration: 60, Last Available: "2023-02"
 11129	tarnished warmed shim of shame shale	0		Effect: "Transcendental Wind", Effect Duration: 17, Last Available: "2023-02"
 11130	double-Vulcanized chilled pebble of proud pyrite	0		Effect: "Sweet Incentive", Effect Duration: 35, Last Available: "2023-02"
@@ -10989,14 +10989,14 @@
 11134	electrified frozen triple-cold-filtered lump of loyal latite	0		Effect: "Scorpio Rising", Effect Duration: 48, Last Available: "2023-02"
 11135	decent shadow sausage	3	good	Last Available: "2023-03"
 11136	zippy dog trainer's shadow skin	0		Experience (familiar): +1, Initiative: +20, Last Available: "2023-03"
-11137	cold-filtered bouncing cyan shadow flame	0		Effect: "Pyramid Power", Effect Duration: 57, Last Available: "2023-03"
-11138	jumbo decent green shadow bread	5	good	Last Available: "2023-03"
+11137	cold-filtered cyan bouncing shadow flame	0		Effect: "Pyramid Power", Effect Duration: 57, Last Available: "2023-03"
+11138	decent jumbo green shadow bread	5	good	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
 11140	perfectly mixed shadow fluid	3	EPIC	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
-11144	weak special hand-crafted shaking shadow venom	2	EPIC	Effect: "Thunderspell", Effect Duration: 20, Last Available: "2023-03"
+11144	hand-crafted special weak shaking shadow venom	2	EPIC	Effect: "Thunderspell", Effect Duration: 20, Last Available: "2023-03"
 11145	modified shadow nectar	1		Last Available: "2023-03"
 11146	rosy-cheeked shadow stick of the ox of Gandalf	0		Muscle: +20, Maximum HP Percent: +30, Spell Critical Percent: +20, Last Available: "2023-03"
 11147	dance instructor's Rosewater's bat paw	0		Mysticality Percent: +30, Experience Percent (Moxie): +10
@@ -11020,7 +11020,7 @@
 11165	tumbling Jazz Agent sheet music	0		
 11166	Thwaitgold anti-moth statuette	0		
 11167	shadowy cheat sheet	0		Free Pull
-11168	twirling mirror closed-circuit phone system	0		Free Pull
+11168	mirror twirling closed-circuit phone system	0		Free Pull
 11169	closed-circuit pay phone	0		
 11170	shadow lighter	0		
 11171	shadow heptahedron	0		
@@ -11033,12 +11033,12 @@
 11178	double-paned shellacked shadow trousers of the pedagogue	0		Experience: +3, Damage Reduction: 7, Cold Resistance: +5
 11179	wobbly shadow hammer of wisdom of chilblains	0		Mysticality: +15, Cold Damage: +25
 11180	supercharged sinister shadow monocle of dire peril	0		Weapon Damage: +20, Spell Damage: +10, Maximum MP Percent: +30, Single Equip
-11181	purple blinking shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	low-calorie yummy shadow hot dog	1	awesome	
+11181	blinking purple shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
+11182	yummy low-calorie shadow hot dog	1	awesome	
 11183	acceptable extra-dry shadow martini	5	good	
 11184	mixed blinking shadow pill	1		Effect: "Clean-Shaven", Effect Duration: 35
 11185	blurry shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	altered altered tumbling shadow candy	0		Effect: "A Taste of Rainbow", Effect Duration: 13
 11189	ghostly replica Mr. Accessory	0		
@@ -11075,8 +11075,8 @@
 11220	red ghostly replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	mirror shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	stanky manspreader's razor-sharp Cincho de Mayo of the overflowing toilet	0		Weapon Damage Percent: +25, Monster Level: +10, Stench Spell Damage: 75, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
-11224	skewed blurry dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
+11223	stanky manspreader's razor-sharp Cincho de Mayo of the overflowing toilet	0		Weapon Damage Percent: +25, Monster Level: +10, Stench Spell Damage: 75, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
+11224	blurry skewed dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	green replica Little Geneticist DNA-Splicing Lab	0		
 11226	lime green replica still grill	0		
 11227	replica Crimbo sapling	0		
@@ -11112,13 +11112,13 @@
 11257	pulsating 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	lightning-fast MacGyver's veiny &quot;I survived Y2K&quot; T-Shirt of the cougar of James Dean of Gandalf	0		Moxie: +20, Experience (Moxie): +3, Maximum HP: +10, Maximum MP: +100, Spell Critical Percent: +20, Initiative: +40, Single Equip, Last Available: "2023-06"
 11259	maroon Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	Da Vinci's supercool pro skateboard	0		Moxie Percent: +20, Experience (Mysticality): +5, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	Da Vinci's supercool pro skateboard	0		Moxie Percent: +20, Experience (Mysticality): +5, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	upside-down Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	upside-down Charter: Nellyville	0		Last Available: "2023-06"
-11265	wobbly Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	red mirror ribald Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Damage: +10, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11265	wobbly Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
+11266	red mirror ribald Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	purple rosy-cheeked studded wicked supercool Amulet of Perpetual Darkness	0		Moxie Percent: +20, Spell Damage: +5, Damage Absorption: +80, Maximum HP Percent: +30, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
 11269	Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11163,7 +11163,7 @@
 11308	watermelon seed	0		
 11309	shaking water balloon	0		
 11310	gray thriftshop coupon	0		
-11311	huge decent waffle	9	good	
+11311	decent huge waffle	9	good	
 11312	fixodent	0		
 11313	twirling cat o' nine teeth of dire peril of incineration	0		Weapon Damage: +20, Hot Spell Damage: +50
 11314	mirror lard-coated studded tooth cap	0		Damage Absorption: +80, Sleaze Spell Damage: +25
@@ -11174,19 +11174,19 @@
 11319	blurry medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	high-proof acceptable bottle of Cabernet Sauvignon	9	good	
 11321	lime green friendly baywatch of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Item Drop: +5, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
-11328	vaporized skewed blurry twirling concentrated cooking	1		Effect: "Thicker, Sicker", Effect Duration: 50
-11329	mixed blurry yellow huge meat	1		
+11328	vaporized blurry skewed twirling concentrated cooking	1		Effect: "Thicker, Sicker", Effect Duration: 50
+11329	mixed huge blurry yellow meat	1		
 11330	distilled yellow sparkling orb	1		Effect: "Greasy Visage", Effect Duration: 15
 11331	twisted blinking hardening cream	1		
 11332	diluted bouncing pool shark hair oil	1		Effect: "Heart of White", Effect Duration: 10
 11333	narrow book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
-11334	lime green upside-down book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
+11334	upside-down lime green book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	shaking Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	blurry LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
 11337	jittery map to a candy-rich block	0		Last Available: "2023-10"
@@ -11205,16 +11205,16 @@
 11350	mirror super-heated leaf	0		
 11351	lit leaf lasso	0		
 11352	bouncing tied-up leaflet	0		
-11353	green wobbly tied-up monstera	0		
+11353	wobbly green tied-up monstera	0		
 11354	tied-up leaviathan	0		
 11355	Van der Graaf Herculean impromptu torch	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Lasts Until Rollover
 11356	horrifying forbidden fig leaf	0		Spell Damage Percent: +50, Spooky Damage: +25, Lasts Until Rollover
 11357	Sinatra's slick smoldering drape	0		Moxie: +10, Experience (Moxie): +5, Lasts Until Rollover
 11358	smoldering leafcutter ant egg	0		
 11359	Usain Bolt's greasy gravedigger's medical-grade veiny quilted leaf crown	0		Damage Absorption: +40, Maximum HP: +10, Spooky Damage: +10, Sleaze Spell Damage: +10, Initiative: +80, HP Regen Min: 7, HP Regen Max: 10
-11360	normal enchanted leafy browns	4	good	Effect: "Resilient Spirit", Effect Duration: 45
+11360	enchanted normal leafy browns	4	good	Effect: "Resilient Spirit", Effect Duration: 45
 11361	double-boiled autumnic balm	0		Effect: "Okee-Dokee Computer", Effect Duration: 38
-11362	triple-liquefied olive skewed spinning coping juice	0		Effect: "Briny Blood", Effect Duration: 33
+11362	triple-liquefied spinning skewed olive coping juice	0		Effect: "Briny Blood", Effect Duration: 33
 11363	mansplainer's manspreader's quilted dance instructor's candy cane sword cane of Leguizamo	0		Experience Percent (Moxie): +10, Damage Absorption: +40, Monster Level: 45, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
 11365	teal Elf Guard patrol cap	0		Last Available: "2023-12"
@@ -11231,7 +11231,7 @@
 11376	housekeeping automa-core	0		
 11377	mirror housekeeping robot	0		
 11378	small yummy pickled bread	2	awesome	Last Available: "2023-12"
-11379	rotten special skewed salted mutton	3	crappy	Effect: "Yuletide Sappiness", Effect Duration: 45, Last Available: "2023-12"
+11379	special rotten skewed salted mutton	3	crappy	Effect: "Yuletide Sappiness", Effect Duration: 45, Last Available: "2023-12"
 11380	rotten half-sized corned beet	2	crappy	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
 11382	tiny plastic Crimbuccaneer Grog Hall	0		Booze Drop: +3
@@ -11247,7 +11247,7 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	rotten mirror narrow peppermint donut	4	crappy	
+11395	rotten narrow mirror peppermint donut	4	crappy	
 11396	twirling shaking Elf Guard insignia (private) of the sweet-tooth	0		Candy Drop: +100, Last Available: "2023-12"
 11397	sizzling Crimbuccaneer fledges (mint)	0		Hot Damage: +10, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
@@ -11268,24 +11268,24 @@
 11413	Elf Guard honor present	0		Last Available: "2023-12"
 11414	smelly shellacked Elf Guard officer's sidearm	0		Damage Reduction: 7, Stench Spell Damage: +10, Last Available: "2023-12"
 11415	ghostly Elf Guard insignia (general) of Tarzan of Calamity Jane	0		Experience (Muscle): +3, Critical Hit Percent: +15, Single Equip, Last Available: "2023-12"
-11416	irresponsibly strong delicious maroon Crimbow Rainbo	9	awesome	Last Available: "2023-12"
+11416	delicious irresponsibly strong maroon Crimbow Rainbo	9	awesome	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	skewed ghostly Jeselnik's Elf Guard broom of the brazier	0		Hot Spell Damage: +25, Sleaze Damage: +25, Last Available: "2023-12"
 11420	auspicious sizzling wholesome Crimbuccaneer tavern swab	0		Maximum HP Percent: +10, Hot Damage: +10, Item Drop: +10, Last Available: "2023-12"
 11421	ghostly Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	weak artisanal yellow old-school pirate grog	2	EPIC	Last Available: "2023-12"
+11422	artisanal weak yellow old-school pirate grog	2	EPIC	Last Available: "2023-12"
 11423	stale wobbly grog nuts	3	decent	Last Available: "2023-12"
 11424	electrified dangerous sawed-off blunderbuss of the bloodbag	0		Weapon Damage: +10, Maximum HP: +100, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2023-12"
 11425	hand-crafted officer's nog	3	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	immense spoiled sundae ration	6	crappy	Last Available: "2023-12"
-11428	decent enchanted immense peppermint tack	9	good	Effect: "El Vibrations", Effect Duration: 15, Last Available: "2023-12"
+11427	spoiled immense sundae ration	6	crappy	Last Available: "2023-12"
+11428	decent immense enchanted peppermint tack	9	good	Effect: "El Vibrations", Effect Duration: 15, Last Available: "2023-12"
 11429	jittery Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten half-sized whalesteak	2	crappy	Last Available: "2023-12"
 11431	inspector's friendly whalegun of chilblains	0		Familiar Weight: +3, Cold Damage: +25, Item Drop: +15, Last Available: "2023-12"
 11432	pulsating Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
-11433	olive blurry Elf Guard payroll bag	0		Last Available: "2023-12"
+11433	blurry olive Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	Usain Bolt's healthy Elf Guard clipboard of the glutton	0		Maximum HP Percent: +20, Food Drop: +100, Initiative: +80, Last Available: "2023-12"
 11435	Samson's pegfinger	0		Experience (Muscle): +5, Single Equip, Last Available: "2023-12"
 11436	acceptable practically non-alcoholic bouncing and claret	1	good	Last Available: "2023-12"
@@ -11293,7 +11293,7 @@
 11438	shaking narrow coward's hale Sinatra's shipwright's hammer	0		Experience (Moxie): +5, Maximum HP: +20, Monster Level: -20, Last Available: "2023-12"
 11439	auspicious gunwale of horror of doom	0		Spooky Spell Damage: 75, Item Drop: +10, Damage Reduction: 9, Last Available: "2023-12"
 11440	mirror avaricious frightening Kelflar vest of the early riser	0		Spooky Damage: +5, Meat Drop: +30, Adventures: +7, Last Available: "2023-12"
-11441	moist gray upside-down whale cerebrospinal fluid	0		Effect: "Sweet Nostalgia", Effect Duration: 20, Last Available: "2023-12"
+11441	moist upside-down gray whale cerebrospinal fluid	0		Effect: "Sweet Nostalgia", Effect Duration: 20, Last Available: "2023-12"
 11442	miser's arcane researcher's Crimbuccaneer runebone	0		Experience Percent (Mysticality): +10, Meat Drop: +10, Single Equip, Last Available: "2023-12"
 11443	cannonbomb	0		Last Available: "2023-12"
 11444	inspector's dog trainer's Elf Guard mouthknife	0		Experience (familiar): +1, Item Drop: +15, Last Available: "2023-12"
@@ -11306,34 +11306,34 @@
 11451	punching mirror	0		Last Available: "2023-12"
 11452	pulsating avaricious flame-retardant nippy groovy strapping Elf dessert spoon of the businessman	0		Muscle: +5, Moxie Percent: +10, Cold Damage: +10, Hot Resistance: +1, Meat Drop: 80, Last Available: "2023-12"
 11453	narrow crafty Elf Guard SCUBA tank of the cheetah	0		Maximum MP: +10, Initiative: +60, Last Available: "2023-12"
-11454	squat purple Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	personal trainer's free boots of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11454	purple squat Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
+11455	personal trainer's free boots of Calamity Jane	0		Experience Percent (Muscle): +10, Critical Hit Percent: +15, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	fuchsia baby rigging snake	0		Last Available: "2023-12"
 11457	blue Herculean Elvish underarmor of Tarzan of mayonnaise	0		Experience (Muscle): 4, Sleaze Spell Damage: +50, Single Equip, Last Available: "2023-12"
 11458	Crimbuccaneer bombjacket of the empath of temperance	0		Familiar Weight: +5, Sleaze Resistance: +5, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	adequate sugarplum ration	4	good	Last Available: "2023-12"
-11460	normal miniature jittery pulsating gingerbread nylons	2	good	Last Available: "2023-12"
+11460	normal miniature pulsating jittery gingerbread nylons	2	good	Last Available: "2023-12"
 11461	normal tiny bouncing rum-soaked fruitcake	1	good	Last Available: "2023-12"
 11462	adequate lime	3	good	Last Available: "2023-12"
 11463	bland gingerbread pirate	3	decent	Last Available: "2023-12"
 11464	moldy fruit-stuffed rumcake	3	crappy	Last Available: "2023-12"
 11465	acceptable triple-distilled huge mulled wine	6	good	Last Available: "2023-12"
 11466	watered-down drinkable Swedish coffee	2	good	Last Available: "2023-12"
-11467	distilled tolerable canteen of eggnog	5	good	Last Available: "2023-12"
+11467	tolerable distilled canteen of eggnog	5	good	Last Available: "2023-12"
 11468	acceptable hot wine	4	good	Last Available: "2023-12"
-11469	triple-distilled delicious wobbly huge Jamaican coffee	6	awesome	Last Available: "2023-12"
+11469	delicious triple-distilled huge wobbly Jamaican coffee	6	awesome	Last Available: "2023-12"
 11470	artisanal flask of egggrog	3	super EPIC	Last Available: "2023-12"
 11471	tumbling Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
 11473	gray pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	irresponsibly strong smooth yule grog	8	awesome	Last Available: "2023-12"
 11475	yummy wet tack	3	awesome	Last Available: "2023-12"
-11476	half-sized rotten whalecake	2	crappy	Last Available: "2023-12"
-11477	deadly gunwale whalegun of James Dean of terror	0		Experience (Moxie): +3, Weapon Damage: +5, Spooky Spell Damage: +10, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11476	rotten half-sized whalecake	2	crappy	Last Available: "2023-12"
+11477	deadly gunwale whalegun of James Dean of terror	0		Experience (Moxie): +3, Weapon Damage: +5, Spooky Spell Damage: +10, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	strong acceptable and claret	5	good	Last Available: "2023-12"
 11479	rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	dog trainer's Elf Guard squirtgun of Flo-Jo	0		Experience (familiar): +1, Initiative: +100, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	dog trainer's Elf Guard squirtgun of Flo-Jo	0		Experience (familiar): +1, Initiative: +100, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	bouncing chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	Rosewater's sequin-encrusted sweater	0		Mysticality Percent: +30, Last Available: "2023-12"
 11484	dangerous educational replica Elf Guard medal of temperance	0		Experience: +1, Weapon Damage: +10, Sleaze Resistance: +5, Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	diffused galvanized upside-down military candy cane	0		Effect: "Stands Alone", Effect Duration: 54
 11503	galvanized galvanized pressed blinking groggipop	0		Effect: "Turtle Power", Effect Duration: 47
-11504	blinking deadly moss mace of the empath	0		Weapon Damage: +5, Familiar Weight: +5, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	yellow scorching moss megaphone of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	Jeselnik's careful moss medal	0		Monster Level: -10, Sleaze Damage: +25, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	spinning steel-toed moss mitre of the brazier	0		Damage Reduction: 9, Hot Spell Damage: +25, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	blurry healthy moss mantle of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	blinking deadly moss mace of the empath	0		Weapon Damage: +5, Familiar Weight: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	yellow scorching moss megaphone of bravery	0		Hot Damage: +25, Spooky Resistance: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	Jeselnik's careful moss medal	0		Monster Level: -10, Sleaze Damage: +25, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	spinning steel-toed moss mitre of the brazier	0		Damage Reduction: 9, Hot Spell Damage: +25, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	blurry healthy moss mantle of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	Jack Frost's moss marlinspike of Flo-Jo	0		Cold Spell Damage: +50, Initiative: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	mixed moss mulch	1		Last Available: "2024-12"
 11511	concentrated moss floss	0		Effect: "Abominably Slippery", Effect Duration: 27
@@ -11372,41 +11372,41 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	boiled adobe assortment	1		Last Available: "2024-12"
 11519	polymerized skewed adobe brittle	0		Effect: "Strong Spirit", Effect Duration: 41
-11520	squat gravedigger's electrified crepe paper phrygian cap of the storm	0		Maximum MP Percent: +40, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	squat gravedigger's electrified crepe paper phrygian cap of the storm	0		Maximum MP Percent: +40, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	maroon Van der Graaf medical-grade hardened crepe paper parachute cape	0		Damage Reduction: 3, MP Regen Min: 5, MP Regen Max: 7, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-12"
-11522	perfumed hardened Newton's crepe paper pie clip	0		Experience (Mysticality): +3, Damage Reduction: 3, Stench Resistance: +5, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	blinking prompt Annie Oakley's beefy crepe paper puzzle cube	0		Muscle: +10, Critical Hit Percent: +20, Adventures: +3, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	wobbly greasy educational crepe paper plunge camisole of the businessman	0		Experience: +1, Sleaze Spell Damage: +10, Meat Drop: +50, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	teal forbidden crepe paper polka charm of Tarzan of Leguizamo	0		Experience (Muscle): +3, Spell Damage Percent: +50, Monster Level: +20, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	perfumed hardened Newton's crepe paper pie clip	0		Experience (Mysticality): +3, Damage Reduction: 3, Stench Resistance: +5, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	blinking prompt Annie Oakley's beefy crepe paper puzzle cube	0		Muscle: +10, Critical Hit Percent: +20, Adventures: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	wobbly greasy educational crepe paper plunge camisole of the businessman	0		Experience: +1, Sleaze Spell Damage: +10, Meat Drop: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	teal forbidden crepe paper polka charm of Tarzan of Leguizamo	0		Experience (Muscle): +3, Spell Damage Percent: +50, Monster Level: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	vaporized bouncing crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	flattened altered upside-down crepe paper peanut candy	0		Effect: "Moose Wisdom", Effect Duration: 25
 11528	huge petrified wood war pike of the empath of the glutton	0		Familiar Weight: +5, Food Drop: +100, Last Available: "2025-12"
 11529	wholesome brawny petrified wood waist protector	0		Muscle Percent: +20, Maximum HP Percent: +10, Single Equip, Last Available: "2025-12"
-11530	spinning greedy petrified wood wizard's pouch of Leguizamo	0		Monster Level: +20, Meat Drop: +20, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	greasy resourceful petrified wood water purifier	0		Maximum MP: +50, Sleaze Spell Damage: +10, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	spinning greedy petrified wood wizard's pouch of Leguizamo	0		Monster Level: +20, Meat Drop: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	greasy resourceful petrified wood water purifier	0		Maximum MP: +50, Sleaze Spell Damage: +10, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	resourceful Fonzie's petrified wood whoopie panama	0		Experience (Moxie): +1, Maximum MP: +50, Last Available: "2025-12"
 11533	twirling veiny petrified wood walking pants	0		Maximum HP: +10, Item Drop: +5, Last Available: "2025-12"
-11534	powdered spinning purple petrified wood waste parts	1		Effect: "Puddingface", Effect Duration: 15, Last Available: "2025-12"
+11534	powdered purple spinning petrified wood waste parts	1		Effect: "Puddingface", Effect Duration: 15, Last Available: "2025-12"
 11535	galvanized nitrogenated petrified wood wafer praline	0		Effect: "Wreathed in Merriment", Effect Duration: 67
-11536	spirit-forward mediocre cybeer	5	decent	Last Available: "2025-12"
+11536	mediocre spirit-forward cybeer	5	decent	Last Available: "2025-12"
 11537	blinking ICEbox	0		Last Available: "2025-12"
-11538	jittery wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	skewed encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	jittery wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	skewed encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	pulsating baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	smelly Crimbuccaneer war standard of chilblains	0		Cold Damage: +25, Stench Spell Damage: +10, Last Available: "2023-12"
 11544	Sherlock's medical-grade Elf Guard war standard	0		Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2023-12"
 11545	purple in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	hardy wholesome brainy spring shoes	0		Mysticality: +5, Maximum HP Percent: +10, Maximum HP: +50, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	hardy wholesome brainy spring shoes	0		Mysticality: +5, Maximum HP Percent: +10, Maximum HP: +50, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	nitrogenated nitrogenated squat ultra-soft ferns	0		Effect: "Bloody-minded", Effect Duration: 68, Last Available: "2024-02"
 11548	adjusted triple-vacuum-sealed pulsating crunchy brush	0		Effect: "Minerva's Zen", Effect Duration: 25, Last Available: "2024-02"
-11549	narrow green huge smashed scientific equipment	0		
+11549	green narrow huge smashed scientific equipment	0		
 11550	lime green biphasic molecular oculus	0		No Pull
 11551	triphasic molecular oculus	0		
 11552	high-tension exoskeleton	0		
 11553	upside-down ultra-high-tension exoskeleton	0		
-11554	tumbling bouncing mirror irresponsible-tension exoskeleton	0		
+11554	mirror bouncing tumbling irresponsible-tension exoskeleton	0		
 11555	lime green quick-release belt pouch	0		Single Equip
 11556	blurry quick-release fannypack	0		Single Equip
 11557	tumbling quick-release utility belt	0		Single Equip
@@ -11428,7 +11428,7 @@
 11573	flavorless yam	3	decent	Last Available: "2024-05"
 11574	delicious practically non-alcoholic yam martini	1	awesome	Last Available: "2024-05"
 11575	drinkable sweet potato o' mine	3	good	Last Available: "2024-05"
-11576	drinkable fancy watered-down Southern yam	2	good	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2024-05"
+11576	drinkable watered-down fancy Southern yam	2	good	Effect: "Sticky Fingers", Effect Duration: 30, Last Available: "2024-05"
 11577	weak aged sweet potato punch	2	awesome	Last Available: "2024-05"
 11578	moldy upside-down Mayam spinach	3	crappy	Last Available: "2024-05"
 11579	gigantic moldy yam and swiss	8	crappy	Last Available: "2024-05"
@@ -11441,27 +11441,27 @@
 11586	avaricious Fonzie's yamtility belt of the early riser	0		Experience (Moxie): +1, Meat Drop: +30, Adventures: +7, Lasts Until Rollover, Last Available: "2024-05"
 11587	adequate small yam slider	2	good	Last Available: "2024-05"
 11588	half-sized flavorless yam mayo	2	decent	Last Available: "2024-05"
-11589	jumbo spoiled yam burrito	5	crappy	Last Available: "2024-05"
+11589	spoiled jumbo yam burrito	5	crappy	Last Available: "2024-05"
 11590	huge visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	skewed aviator goggles	0		
 11593	Thwaitgold Illinigina illinoiensis model	0		
-11594	stale miniature mini kiwi	2	decent	Last Available: "2024-06"
+11594	miniature stale mini kiwi	2	decent	Last Available: "2024-06"
 11595	greasy Oprah's Socratic mini kiwi bikini	0		Experience (Mysticality): +1, Maximum MP Percent: +50, Sleaze Spell Damage: +10, Last Available: "2024-06"
-11596	tolerable special shaking mini kiwitini	3	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2024-06"
+11596	special tolerable shaking mini kiwitini	3	good	Effect: "Sludgesick", Effect Duration: 10, Last Available: "2024-06"
 11597	tumbling mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	green mini kiwi aioli	0		
 11599	reassuring dog trainer's mini kiwi silicon tiepin of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +1, Spooky Resistance: +1
 11600	mini kiwi tipi	0		
 11601	flavorless half-sized mini kiwi digitized cookies	2	decent	
-11602	weak artisanal mini kiwi intoxicating spirits	2	EPIC	
-11603	quantum squat twirling mini kiwi antimilitaristic hippy petition	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 18
+11602	artisanal weak mini kiwi intoxicating spirits	2	EPIC	
+11603	quantum twirling squat mini kiwi antimilitaristic hippy petition	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 18
 11604	anodized alkaline twirling mini kiwi illicit antibiotic	0		Effect: "Seriously Mutated", Effect Duration: 43
 11605	grievous mini kiwi whipping stick of the brazier	0		Weapon Damage Percent: +50, Hot Spell Damage: +25
 11606	smooth mini kiwi icepick	0		Moxie: +15
 11607	wet mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Protection from Bad Stuff", Effect Duration: 24
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	tumbling protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	shaking protogenetic chunklet (flagellum)	0		
@@ -11470,8 +11470,8 @@
 11615	Jack Frost's veiny grievous messenger bag RNA	0		Weapon Damage Percent: +50, Maximum HP: +10, Cold Spell Damage: +50
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	immense spoiled tumbling bacteria bisque	6	crappy	
-11619	moldy snack-sized ciliophora chowder	2	crappy	
+11618	spoiled immense tumbling bacteria bisque	6	crappy	
+11619	snack-sized moldy ciliophora chowder	2	crappy	
 11620	stale wobbly cream of chloroplasts	4	decent	
 11621	huge synaptic soup	0		
 11622	muscular soup	0		
@@ -11510,7 +11510,7 @@
 11655	squat soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	tumbling boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	flame-retardant Fonzie's brawny bat wings	0		Muscle Percent: +20, Experience (Moxie): +1, Hot Resistance: +1, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	flame-retardant Fonzie's brawny bat wings	0		Muscle Percent: +20, Experience (Moxie): +1, Hot Resistance: +1, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	ember egg	0		Last Available: "2024-09"
 11660	ember	0		Cold Resistance: +1
 11661	Lo Pan's monocle on a stick of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +30, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,7 +11523,7 @@
 11668	bouncing dog trainer's Newton's Sheriff badge	0		Experience (Mysticality): +3, Experience (familiar): +1, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	reassuring Samson's Sheriff pistol	0		Experience (Muscle): +5, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2024-10"
 11670	wool stylish Sheriff moustache	0		Moxie: +25, Cold Resistance: +1, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	stanky sinister photo booth supply list	0		Spell Damage: +10, Stench Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	stanky sinister photo booth supply list	0		Spell Damage: +10, Stench Spell Damage: +25, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tie-dye headband	0		
 11674	small bland blurry whirled peas	2	decent	Last Available: "2024-11"
@@ -11534,19 +11534,19 @@
 11679	quantized familiar	0		
 11680	fuchsia quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
-11682	frozen pressed bouncing teal pea brittle	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 60, Last Available: "2024-11"
-11683	spirit-forward smooth peasco	5	awesome	Last Available: "2024-11"
+11682	frozen pressed teal bouncing pea brittle	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 60, Last Available: "2024-11"
+11683	smooth spirit-forward peasco	5	awesome	Last Available: "2024-11"
 11684	flavorless piece of cake	4	decent	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	lime green jittery TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	bouncing MacGyver's deft pirate hook of Leguizamo	0		Maximum MP: +100, Monster Level: +20, Lasts Until Rollover, Last Available: "2024-12"
-11689	mirror nippy sage iron tricorn hat	0		Mysticality Percent: +10, Cold Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	mirror nippy sage iron tricorn hat	0		Mysticality Percent: +10, Cold Damage: +10, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	jittery avaricious jolly roger flag	0		Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
-11693	watered-down perfectly mixed teal bouncing tankard of spiced rum	2	EPIC	Last Available: "2024-12"
-11694	artisanal weak tankard of spiced Goldschlepper	2	EPIC	Last Available: "2024-12"
+11693	perfectly mixed watered-down teal bouncing tankard of spiced rum	2	EPIC	Last Available: "2024-12"
+11694	weak artisanal tankard of spiced Goldschlepper	2	EPIC	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	maroon dance instructor's governor's daughter's lace collar	0		Experience Percent (Moxie): +10, Last Available: "2024-12"
 11697	wool governor's daughter's petticoats	0		Cold Resistance: +1, Last Available: "2024-12"
@@ -11561,8 +11561,8 @@
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	shaking olive hardened occult silky pirate drawers	0		Spell Damage Percent: +25, Damage Reduction: 3, Last Available: "2024-12"
 11708	yellow profane eye patch	0		Sleaze Damage: +3
-11709	triple-electrified oxidized diffused huge blinking peppermint pegleg	0		Effect: "Cat Class, Cat Style", Effect Duration: 48, Last Available: "2024-12"
-11710	enchanted practically non-alcoholic tolerable hard cocoa	1	good	Effect: "Sweet and Green", Effect Duration: 50, Last Available: "2024-12"
+11709	triple-electrified oxidized diffused blinking huge peppermint pegleg	0		Effect: "Cat Class, Cat Style", Effect Duration: 48, Last Available: "2024-12"
+11710	tolerable enchanted practically non-alcoholic hard cocoa	1	good	Effect: "Sweet and Green", Effect Duration: 50, Last Available: "2024-12"
 11711	moldy salmagumdi	3	crappy	Last Available: "2024-12"
 11712	plastic Easter Island Bunny of Tarzan	0		Experience (Muscle): +3, Last Available: "2024-12"
 11713	huge knitted plastic St. Patrick	0		Cold Resistance: +3, Last Available: "2024-12"
@@ -11578,13 +11578,13 @@
 11723	colloidal enhanced pickled dark chocolate egg	0		Effect: "All Glory To the Toad", Effect Duration: 22, Last Available: "2024-12"
 11724	smooth fortified moai toai	5	awesome	
 11725	flame-retardant moaiball of mayonnaise of Flo-Jo	0		Sleaze Spell Damage: +50, Hot Resistance: +1, Initiative: +100, Last Available: "2024-12"
-11726	bouncing spinning maroon half-digested rat	0		Last Available: "2024-12"
+11726	maroon spinning bouncing half-digested rat	0		Last Available: "2024-12"
 11727	electrified double-cold-filtered polarized spinning four-leaf potato sprout	0		Effect: "Fit To Be Tide", Effect Duration: 26, Last Available: "2024-12"
 11728	yellow baleful Samson's potato jacket of the dark arts	0		Experience (Muscle): +5, Spell Damage: +25, Spell Damage Percent: +100, Last Available: "2024-12"
-11729	twirling jittery traumatic holiday memory	0		Last Available: "2024-12"
+11729	jittery twirling traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	gravedigger's supercharged military orb	0		Maximum MP Percent: +30, Spooky Damage: +10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
-11732	cold-filtered nitrogenated triple-aerosolized huge squat mirror rum ball	0		Effect: "Broberry Brotality", Effect Duration: 52
+11731	gravedigger's supercharged military orb	0		Maximum MP Percent: +30, Spooky Damage: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11732	cold-filtered nitrogenated triple-aerosolized mirror huge squat rum ball	0		Effect: "Broberry Brotality", Effect Duration: 52
 11733	purple gravy skin	0		Last Available: "2024-12"
 11734	teal huge Tesla gravyskin hat of the bloodbag	0		Maximum HP: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12"
 11735	huge gravyskin buckler of the cougar of the empath	0		Moxie: +20, Familiar Weight: +5, Damage Reduction: 7, Last Available: "2024-12"
@@ -11595,55 +11595,55 @@
 11740	teal fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	squat friendly perfect Christmas scarf of Calamity Jane of courage	0		Critical Hit Percent: [+15*event(December)], Familiar Weight: [+3*event(December)], Spooky Resistance: [+3*event(December)], Single Equip, Last Available: "2024-12"
-11743	skewed snowman-enchanting tophat of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Initiative: +100, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	skewed snowman-enchanting tophat of the brazier of Flo-Jo	0		Hot Spell Damage: +25, Initiative: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	vacuum-sealed lime green LIDAR candle	0		Effect: "Alpine Mintiness", Effect Duration: 63, Last Available: "2024-12"
 11745	flame-retardant toasty thinker's Congressional Medal of Insanity	0		Mysticality: +10, Hot Damage: +5, Hot Resistance: +1, Last Available: "2024-12"
 11746	wobbly pumpkin spice whorl	0		Last Available: "2024-12"
-11747	delicious enchanted practically non-alcoholic narrow mirror Easter grasshopper	1	awesome	Effect: "Ichorous Eyesight", Effect Duration: 5, Last Available: "2024-12"
-11748	bad practically non-alcoholic Irish eggnog	1	decent	Last Available: "2024-12"
+11747	practically non-alcoholic delicious enchanted mirror narrow Easter grasshopper	1	awesome	Effect: "Ichorous Eyesight", Effect Duration: 5, Last Available: "2024-12"
+11748	practically non-alcoholic bad Irish eggnog	1	decent	Last Available: "2024-12"
 11749	smooth canteen of jungle juice	4	awesome	Last Available: "2024-12"
 11750	lousy ghostly turchucken	3	decent	Last Available: "2024-12"
 11751	bad squat mechanically-mulled cider	4	decent	Last Available: "2024-12"
 11752	perfectly mixed teal holiday trip around the world	3	super ultra EPIC	Last Available: "2024-12"
 11753	stale wobbly chocolate ostrich egg	3	decent	Last Available: "2024-12"
-11754	rotten half-sized spinning wobbly beef and cabbage	2	crappy	Last Available: "2024-12"
+11754	rotten half-sized wobbly spinning beef and cabbage	2	crappy	Last Available: "2024-12"
 11755	spoiled candy rations	4	crappy	Last Available: "2024-12"
-11756	half-sized decent double-candied yams	2	good	Last Available: "2024-12"
-11757	special normal half-sized twirling Christmas ham	2	good	Effect: "Human-Constellation Hybrid", Effect Duration: 30, Last Available: "2024-12"
-11758	decent bite-sized holiday smorgasbord	1	good	Last Available: "2024-12"
+11756	decent half-sized double-candied yams	2	good	Last Available: "2024-12"
+11757	half-sized special normal twirling Christmas ham	2	good	Effect: "Human-Constellation Hybrid", Effect Duration: 30, Last Available: "2024-12"
+11758	bite-sized decent holiday smorgasbord	1	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	Sherlock's bejazzled eyepatch	0		Item Drop: +25, Last Available: "2024-12"
-11761	mirror Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	green Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	yellow How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	purple Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	narrow Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	mirror Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	green Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	yellow How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	purple Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	narrow Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	red family-friendly greasy Jack Frost's egg gun of Flo-Jo	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Sleaze Resistance: +1, Initiative: +100, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	red family-friendly greasy Jack Frost's egg gun of Flo-Jo	0		Cold Spell Damage: +50, Sleaze Spell Damage: +10, Sleaze Resistance: +1, Initiative: +100, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	wobbly frightening steel-toed personal trainer's army helmet of the detective	0		Experience Percent (Muscle): +10, Damage Reduction: 9, Spooky Damage: +5, Item Drop: +20, Last Available: "2024-12"
 11774	tumbling candy egg deviler	0		Last Available: "2024-12"
 11775	napkin	0		Last Available: "2024-12"
-11776	flavorless thick huge Thanksgiving ration	5	decent	Last Available: "2024-12"
-11777	watered-down lousy Easter eggnog	2	decent	Last Available: "2024-12"
+11776	thick flavorless huge Thanksgiving ration	5	decent	Last Available: "2024-12"
+11777	lousy watered-down Easter eggnog	2	decent	Last Available: "2024-12"
 11778	dried huge clovermint	1		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 10, Last Available: "2024-12"
 11779	knitted dog trainer's MacGyver's groovy nylon Christmas stockings	0		Moxie Percent: +10, Maximum MP: +100, Experience (familiar): +1, Cold Resistance: +3, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
 11781	anodized corrupted green deviled candy egg	0		Effect: "Holiday Bliss", Effect Duration: 11, Last Available: "2024-12"
 11782	pulsating McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	yellow McHugeLarge duffel bag of dire peril of the bloodbag	0		Weapon Damage: +20, Maximum HP: +100, Last Available: "2025-01"
-11784	narrow ribald baleful weightlifter's McHugeLarge left pole	0		Muscle: +15, Spell Damage: +25, Sleaze Damage: +10, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	extremely unsafe McHugeLarge right pole of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Item Drop: +5, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	teal asbestos-lined vibrating McHugeLarge left ski	0		Maximum MP Percent: +10, Hot Resistance: +5, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	supercharged McHugeLarge right ski of Leguizamo	0		Maximum MP Percent: +30, Monster Level: +20, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
-11788	shaking huge jittery 1	0		Last Available: "2025-12"
+11784	narrow ribald baleful weightlifter's McHugeLarge left pole	0		Muscle: +15, Spell Damage: +25, Sleaze Damage: +10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	extremely unsafe McHugeLarge right pole of bravery	0		Weapon Damage Percent: +100, Spooky Resistance: +5, Item Drop: +5, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	teal asbestos-lined vibrating McHugeLarge left ski	0		Maximum MP Percent: +10, Hot Resistance: +5, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	supercharged McHugeLarge right ski of Leguizamo	0		Maximum MP Percent: +30, Monster Level: +20, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11788	huge jittery shaking 1	0		Last Available: "2025-12"
 11789	twirling 0	0		Last Available: "2025-12"
 11790	twisted gray eXpand	1		Last Available: "2025-12"
-11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	gray datastick	0		Last Available: "2025-12"
 11793	dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	bouncing dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,13 +11658,13 @@
 11803	red cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	jittery malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	jittery malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	skewed server room key	0		Last Available: "2025-12"
 11809	squat 3d printed server room key	0		Last Available: "2025-12"
 11810	squat yellow upside-down dedigitizer schematic: 3d printed server room key	0		Last Available: "2025-12"
 11811	logic grenade	0		Last Available: "2025-12"
-11812	twisted tumbling upside-down psilocyber mushroom	1		Effect: "Billiards Belligerence", Effect Duration: 15, Last Available: "2025-12"
+11812	twisted upside-down tumbling psilocyber mushroom	1		Effect: "Billiards Belligerence", Effect Duration: 15, Last Available: "2025-12"
 11813	huge dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	spinning dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
 11815	red dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	blurry geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	blurry geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	lime green virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11725,11 +11725,11 @@
 11870	blurry bar dart	0		Last Available: "2025-03"
 11871	modified pulsating purple leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	toothsome skewed Heck ramen	3	awesome	Last Available: "2025-03"
-11873	half-sized stale burrito	2	decent	Last Available: "2025-03"
+11873	stale half-sized burrito	2	decent	Last Available: "2025-03"
 11874	stale small beer brat	3	decent	Last Available: "2025-03"
-11875	massive bland peach pie	7	decent	Last Available: "2025-03"
+11875	bland massive peach pie	7	decent	Last Available: "2025-03"
 11876	adequate incredible mini-pizza	4	good	Last Available: "2025-03"
-11877	irresponsibly strong lousy Divine sidecar	8	decent	Last Available: "2025-03"
+11877	lousy irresponsibly strong Divine sidecar	8	decent	Last Available: "2025-03"
 11878	acceptable tangarita sidecar	3	good	Last Available: "2025-03"
 11879	perfectly mixed pulsating gimlet sidecar	4	EPIC	Last Available: "2025-03"
 11880	drinkable tumbling vodka stratocaster sidecar	3	good	Last Available: "2025-03"
@@ -11755,7 +11755,7 @@
 11900	wet shower radio of doom	0		Spooky Spell Damage: +50, Single Equip, Lasts Until Rollover, Last Available: "2025-04"
 11901	wet shower stamp	0		Last Available: "2025-04"
 11902	blinking grievous birthday bloon	0		Weapon Damage Percent: +50
-11903	extra-flattened squat green jawwetter	0		Effect: "Salad Days", Effect Duration: 49
+11903	extra-flattened green squat jawwetter	0		Effect: "Salad Days", Effect Duration: 49
 11904	olive Unpeeled Peridot of Peril	0		Free Pull, Last Available: "2025-06"
 11905	blinking quilted boxer's Peridot of Peril of horror	0		Muscle Percent: +10, Damage Absorption: +40, Spooky Spell Damage: +25, Single Equip, Last Available: "2025-06"
 11906	dog trainer's terrycloth turban	0		Experience (familiar): +1
@@ -11771,11 +11771,11 @@
 11916	stylish bycocket of the early riser	0		Adventures: +7
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	tumbling yellow packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	blurry Axis HQ Code	0		
 11922	huge upside-down yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
-11923	yellow ghostly blurry exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
+11923	blurry ghostly yellow exchanger	0		Cold Damage: +10, Cold Spell Damage: +10, Familiar Weight: +3, Last Available: "2025-07"
 11924	bouncing Tesla Axis helmet of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 7, MP Regen Max: 10
 11925	executive sharpshooter's Axis fatigues	0		Critical Hit Percent: +10, Meat Drop: +40
 11926	shaking teal foul-smelling Tesla Axis suspenders	0		Stench Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -11790,7 +11790,7 @@
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
 11937	miniature toothsome Skeleton Wars rations	2	awesome	
-11938	perfectly mixed practically non-alcoholic skeleton war fuel can	1	EPIC	
+11938	practically non-alcoholic perfectly mixed skeleton war fuel can	1	EPIC	
 11939	blurry skeleton war grenade	0		
 11940	chocolate and nylons detector	0		
 11941	ghostly M&ouml;bius ring box	0		Free Pull, Last Available: "2025-08"
@@ -11799,15 +11799,15 @@
 11944	scorching toasty Allied Forces insignia of the empath	0		Familiar Weight: +5, Hot Damage: 30, Single Equip
 11945	Allied Tattoo Kit	0		
 11946	handheld Allied radio	0		
-11947	wobbly jittery Axis codebook	0		
+11947	jittery wobbly Axis codebook	0		
 11948	ionized Life Goals Pamphlet	0		Effect: "Super Speed", Effect Duration: 43, Last Available: "2025-08"
 11949	shaking grievous bully badge	0		Weapon Damage Percent: +50, Lasts Until Rollover, Last Available: "2025-08"
 11950	nippy time cop top hat	0		Cold Damage: +10, Last Available: "2025-08"
 11951	skewed Stock Certificate	0		Last Available: "2025-08"
 11952	modified mixed berry jelly	1		Last Available: "2025-08"
-11953	jumbo spoiled enchanted mirror toast with mixed berry jelly	5	crappy	Effect: "Squirming Like a Toad", Effect Duration: 40, Last Available: "2025-08"
-11954	bite-sized spoiled cup of sugar	1	crappy	Last Available: "2025-08"
-11955	small normal Susie's cupcake	2	good	Last Available: "2025-08"
+11953	enchanted jumbo spoiled mirror toast with mixed berry jelly	5	crappy	Effect: "Squirming Like a Toad", Effect Duration: 40, Last Available: "2025-08"
+11954	spoiled bite-sized cup of sugar	1	crappy	Last Available: "2025-08"
+11955	normal small Susie's cupcake	2	good	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	lard-coated the gun of Calamity Jane of the blizzard	0		Critical Hit Percent: +15, Cold Spell Damage: +25, Sleaze Spell Damage: +25, Last Available: "2025-08"
 11958	artisanal wine	4	EPIC	Last Available: "2025-08"
@@ -11815,8 +11815,8 @@
 11961	sand penny	0		
 11962	skewed squat undersea surveying goggles of the sewer	0		Stench Damage: +25, Lasts Until Rollover
 11963	hand-crafted Ocean-Touched Rum	3	EPIC	
-11964	mixed jittery lime green wobbly water-logged pill	1		Effect: "Gobliny Flavor", Effect Duration: 50
-11965	rotten small jittery kelp puck	2	crappy	
+11964	mixed wobbly jittery lime green water-logged pill	1		Effect: "Gobliny Flavor", Effect Duration: 50
+11965	small rotten jittery kelp puck	2	crappy	
 11966	blinking scroll of sea strength	0		
 11967	scroll of sea smarts	0		
 11968	mirror scroll of sea smarm	0		
@@ -11826,21 +11826,21 @@
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
 11976	unblemished pearl	0		
 11977	narrow Jeselnik's dentadent	0		Sleaze Damage: +25
 11986	blue lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	fuchsia auspicious censurious horrifying scorching Jack Frost's blood cubic zirconia of the cheetah	0		Cold Spell Damage: +50, Hot Damage: +25, Spooky Damage: +25, Sleaze Resistance: +3, Item Drop: +10, Initiative: +60, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	fuchsia auspicious censurious horrifying scorching Jack Frost's blood cubic zirconia of the cheetah	0		Cold Spell Damage: +50, Hot Damage: +25, Spooky Damage: +25, Sleaze Resistance: +3, Item Drop: +10, Initiative: +60, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	diluted twirling blood thinner	1		Effect: "Cool Spirit", Effect Duration: 35, Last Available: "2025-10"
 12045	tolerable tumbling pheromone cocktail	4	good	Last Available: "2025-10"
 12046	normal pulsating spinal tapas	3	good	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	narrow gravedigger's frosty sinister shrunken head	0		Spell Damage: +10, Cold Spell Damage: +10, Spooky Damage: +10, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	narrow gravedigger's frosty sinister shrunken head	0		Spell Damage: +10, Cold Spell Damage: +10, Spooky Damage: +10, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	jittery small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	artisanal extra-dry Smoking Pope	5	EPIC	
-12053	decent enchanted diet prize turkey	1	good	Effect: "Ruby-ous", Effect Duration: 20
+12053	enchanted decent diet prize turkey	1	good	Effect: "Ruby-ous", Effect Duration: 20
 12054	diluted ghostly medicinal gruel	1		Effect: "Funky Coal Patina", Effect Duration: 45
 12055	miniature adequate full-sized pumpkin pie	2	good	Last Available: "2025-11"
 12056	lousy skewed vodka cranberry sauce	4	decent	Last Available: "2025-11"
@@ -11881,7 +11881,7 @@
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
 12124	hand-crafted Steve Abrams' Holiday Sampler Beer	3	EPIC	Last Available: "2025-12"
 12125	crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
-12126	artisanal practically non-alcoholic blurry bottle of prize-winning rum	1	super ultra mega turbo EPIC	Last Available: "2025-12"
+12126	practically non-alcoholic artisanal blurry bottle of prize-winning rum	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12127	pulsating wicked dance instructor's Santa-Slayer medal of the cheetah	0		Experience Percent (Moxie): +10, Spell Damage: +5, Initiative: +60, Single Equip, Last Available: "2025-12"
 12128	Skull of Claus	0		Last Available: "2025-12"
 12129	unsweetened Vulcanized energized boiling bone marrow	0		Effect: "Crusty Head", Effect Duration: 11, Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	aerosolized green mirror boiling synovial fluid	0		Effect: "Blood-Gorged", Effect Duration: 29, Last Available: "2025-12"
 12132	narrow inspector's flame-wreathed smoldering vertebra of incineration	0		Hot Spell Damage: 60, Item Drop: +15, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	volatile bone bomb	0		Last Available: "2025-12"
 12137	executive ribald Annie Oakley's hot boning knife	0		Critical Hit Percent: +20, Sleaze Damage: +10, Meat Drop: +40, Single Equip, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	shaking wobbly ship's lantern of Leguizamo	0		Monster Level: +20, Last Available: "2025-12"
 12170	ghostly frightening Da Vinci's heat-resistant harpoon pistol	0		Experience (Mysticality): +5, Spooky Damage: +5, Last Available: "2025-12"
 12171	adequate traditional gingerloaf	3	good	Last Available: "2025-12"
-12172	mediocre watered-down fancy Scotch and eggnog	2	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5, Last Available: "2025-12"
+12172	mediocre fancy watered-down Scotch and eggnog	2	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5, Last Available: "2025-12"
 12173	denatured polymerized counterskeleton elixir	0		Effect: "Broken Bone Nubs", Effect Duration: 43, Last Available: "2025-12"
 12174	bad &quot;salvaged&quot; wine	3	decent	Last Available: "2025-12"
 12175	upside-down The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11936,8 +11936,8 @@
 12178	adjusted adjusted colloidal narrow gummi fingerbone	0		Effect: "Prelude of Precision", Effect Duration: 43
 12179	fireproof Herculean glimmering crystal	0		Experience (Muscle): +1, Hot Resistance: +3, Last Available: "2025-12"
 12180	fuchsia boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
-12182	maroon skewed Thwaitgold meat bee statuette	0		
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12182	skewed maroon Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	shaking Archaeologist's Spade	0		Last Available: "2026-03"
 12185	boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
@@ -11973,28 +11973,28 @@
 12215	gray wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
 12217	normal discarded hot dog	3	good	Last Available: "2026-04"
-12218	bad weak enchanted most of a beer	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2026-04"
+12218	enchanted bad weak most of a beer	2	decent	Effect: "Grumpy and Ornery", Effect Duration: 15, Last Available: "2026-04"
 12222	blurry pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	small adequate can of tuna	2	good	
 12227	moldy miniature alien salad	2	crappy	
-12228	yummy miniature ratbatatouille	2	awesome	
+12228	miniature yummy ratbatatouille	2	awesome	
 12229	spoiled onigiri	3	crappy	
 12230	low-calorie decent crudit&eacute;s	1	good	
 12231	spoiled lime green sauced mutton	3	crappy	
 12232	stale pulsating hot honey ant	3	decent	
 12233	immense stale tomb aspic	7	decent	
 12234	adequate later tots	3	good	
-12235	rotten big Frutti di Scatoletta	5	crappy	Last Available: "2026-05"
+12235	big rotten Frutti di Scatoletta	5	crappy	Last Available: "2026-05"
 12236	miniature stale Pesto alla Marziano	2	decent	Last Available: "2026-05"
 12237	delicious jittery Arrattabbattabiata	3	awesome	Last Available: "2026-05"
 12238	moldy Orzo di Riso	3	crappy	Last Available: "2026-05"
 12239	moldy lime green Pasta Grimavera	3	crappy	Last Available: "2026-05"
 12240	normal bite-sized Linguini Ubriacapa	1	good	Last Available: "2026-05"
-12241	super-sized bland Formica e Pepe	5	decent	Last Available: "2026-05"
+12241	bland super-sized Formica e Pepe	5	decent	Last Available: "2026-05"
 12242	flavorless Tubetto Gelatto	4	decent	Last Available: "2026-05"
-12243	half-sized stale blurry Gnocci Domani	2	decent	Last Available: "2026-05"
+12243	stale half-sized blurry Gnocci Domani	2	decent	Last Available: "2026-05"
 12244	Thwaitgold wallet moth statuette	0		
 12245	pulsating scabbarded Sword of S Words	0		Free Pull, Last Available: "2026-06"
 12246	second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
@@ -12017,7 +12017,7 @@
 12267	censurious flimsy plastic breastplate	0		Sleaze Resistance: +3
 12268	flimsy plastic shield of Leguizamo	0		Monster Level: +20, Damage Reduction: 3
 12269	jittery green packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	miser's family-friendly hardened Portable Laughing Stock	0		Damage Reduction: 3, Sleaze Resistance: +1, Meat Drop: +10, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	miser's family-friendly hardened Portable Laughing Stock	0		Damage Reduction: 3, Sleaze Resistance: +1, Meat Drop: +10, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	inspector's coward's forbidden Staff of Anachronistic Churning	0		Spell Damage Percent: +50, Monster Level: -20, Item Drop: +15
 12272	fancy bland tumbling classic banana	4	decent	Effect: "Mucilaginous Moxiousness", Effect Duration: 20, Last Available: "2026-07"
 12273	normal squat watermelon	3	good	Last Available: "2026-07"
@@ -12032,14 +12032,14 @@
 12282	spoiled watermelon pie	4	crappy	Last Available: "2026-07"
 12283	colloidal concentrated watermelon juice	0		Effect: "Flame-Retardant Trousers", Effect Duration: 17, Last Available: "2026-07"
 12284	liquefied quadruple-dry wobbly Aqua Citrulanatae	0		Effect: "Can Has Cyborger", Effect Duration: 63, Last Available: "2026-07"
-12285	weak smooth pulsating Melonegroni	2	awesome	Last Available: "2026-07"
+12285	smooth weak pulsating Melonegroni	2	awesome	Last Available: "2026-07"
 12286	lousy weak Melonade Spritz	2	decent	Last Available: "2026-07"
 12287	decent quince pie	4	good	Last Available: "2026-07"
 12288	activated quince quaff	0		Effect: "Educated (Sorta)", Effect Duration: 36, Last Available: "2026-07"
 12289	magnetized electrified moist Quickquince	0		Effect: "Salamanderenity", Effect Duration: 16, Last Available: "2026-07"
 12290	high-proof smooth Quiskey Sour	9	awesome	Last Available: "2026-07"
 12291	fortified perfectly mixed twirling Quincea&ntilde;era Cooler	5	EPIC	Last Available: "2026-07"
-12292	extra-dry enchanted bad Roth IPA	5	decent	Effect: "Full of Vinegar", Effect Duration: 35, Last Available: "2026-08"
+12292	bad extra-dry enchanted Roth IPA	5	decent	Effect: "Full of Vinegar", Effect Duration: 35, Last Available: "2026-08"
 12293	energetic fortified underdraft protection	0		Damage Absorption: +60, Maximum MP Percent: +20, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	delicious pulsating soybean futures	3	awesome	Last Available: "2026-08"
@@ -12057,8 +12057,8 @@
 12307	modified blurry mint	0		Effect: "You're Not Cooking", Effect Duration: 15, Last Available: "2026-08"
 12308	savings bondo	0		Last Available: "2026-08"
 12309	bouncing homeowner's loam	0		Last Available: "2026-08"
-12310	boiled blue huge shaking toxic asset	1		Last Available: "2026-08"
-12311	mixed twirling lime green mirror intangible asset	1		Effect: "Stickler for Promptness", Effect Duration: 40, Last Available: "2026-08"
+12310	boiled huge shaking blue toxic asset	1		Last Available: "2026-08"
+12311	mixed mirror lime green twirling intangible asset	1		Effect: "Stickler for Promptness", Effect Duration: 40, Last Available: "2026-08"
 12312	mixed liquid asset	1		Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Turtle_Tamer_Platypus_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Platypus_cafe_booze.txt
@@ -1,33 +1,33 @@
 -1	perfectly mixed Petite Porter	3	EPIC	
--2	special artisanal shaking Scrawny Stout	3	EPIC	
+-2	artisanal special shaking Scrawny Stout	3	EPIC	
 -3	hand-crafted weak Infinitesimal IPA	2	EPIC	
 -4	bad boozy yellow eggnogtini	5	decent	
--5	weak delicious candycaine	2	awesome	
--6	fancy triple-distilled hand-crafted braincracker sweet	7	EPIC	
--16	practically non-alcoholic bad spinning fermented honey	1	decent	
--17	spirit-forward mediocre moons-shine	5	decent	
+-5	delicious weak candycaine	2	awesome	
+-6	fancy hand-crafted triple-distilled braincracker sweet	7	EPIC	
+-16	bad practically non-alcoholic spinning fermented honey	1	decent	
+-17	mediocre spirit-forward moons-shine	5	decent	
 -18	drinkable gin	3	good	
--19	bad high-proof ecto-nog	7	decent	
--20	watered-down perfectly mixed hot toady	2	EPIC	
--21	triple-distilled enchanted aged hot choculate	6	awesome	
--49	acceptable practically non-alcoholic skewed mirror Cyder	1	good	
+-19	high-proof bad ecto-nog	7	decent	
+-20	perfectly mixed watered-down hot toady	2	EPIC	
+-21	aged enchanted triple-distilled hot choculate	6	awesome	
+-49	practically non-alcoholic acceptable mirror skewed Cyder	1	good	
 -50	hand-crafted weak gray Oil Nog	2	EPIC	
 -51	artisanal Hi-Octane Peppermint Jet Fuel	3	EPIC	
 -58	acceptable Grimacider	3	good	
--59	watered-down mediocre Isotope Nog	2	decent	
+-59	mediocre watered-down Isotope Nog	2	decent	
 -60	perfectly mixed irresponsibly strong Mutagin 'n' Tonic	6	EPIC	
 -70	tolerable Gin and Herring	4	good	
--71	watered-down acceptable Black and Tan and Red All Over	2	good	
+-71	acceptable watered-down Black and Tan and Red All Over	2	good	
 -72	delicious skewed Antarctic Ice Tea	3	awesome	
 -76	delicious practically non-alcoholic CRIMBCO Ribbon Candy Schnapps	1	awesome	
--77	practically non-alcoholic bad gray mirror CRIMBCO Egg Substitute Nog Substitute	1	decent	
--78	watered-down lousy CRIMBCO Extreme Braincracker Sour	2	decent	
+-77	practically non-alcoholic bad mirror gray CRIMBCO Egg Substitute Nog Substitute	1	decent	
+-78	lousy watered-down CRIMBCO Extreme Braincracker Sour	2	decent	
 -82	fancy hand-crafted Horseradish-infused Vodka	4	EPIC	
 -83	practically non-alcoholic perfectly mixed Jerkitini	1	EPIC	
 -84	drinkable jittery Desert Island Iced Tea	3	good	
--88	watered-down mediocre Crimbo Saketini	2	decent	
+-88	mediocre watered-down Crimbo Saketini	2	decent	
 -89	bad skewed Crimboku Drop	4	decent	
 -90	tolerable mirror Flaming Crimbo Log	4	good	
 -107	lousy Fortified Eggnog Slurry	3	decent	
 -108	hand-crafted Hot Buttered Rum	3	EPIC	
--109	bad watered-down blinking huge Spicy Hot Chocolate	2	decent	
+-109	watered-down bad blinking huge Spicy Hot Chocolate	2	decent	

--- a/data/TCRS/TCRS_Turtle_Tamer_Platypus_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Platypus_cafe_food.txt
@@ -1,45 +1,45 @@
 -1	decent Peche a la Frog	3	good	
--2	special toothsome shaking As Jus Gezund Heit	3	awesome	
+-2	toothsome special shaking As Jus Gezund Heit	3	awesome	
 -3	normal snack-sized Bouillabaise Coucher Avec Moi	2	good	
--7	miniature spoiled gumdrop chow mein	2	crappy	
+-7	spoiled miniature gumdrop chow mein	2	crappy	
 -8	bland red candy cane pizza	3	decent	
 -9	super-sized delicious gingerbread stir-fry	5	awesome	
--10	stale fancy twigs and gravel	3	decent	
+-10	fancy stale twigs and gravel	3	decent	
 -11	diet moldy narrow shoots and leaves	1	crappy	
 -12	super-sized normal bowl of unidentifiable goo	5	good	
 -13	fancy rotten half-sized gingerbread massacre	2	crappy	
 -14	thick decent It Came From Beyond Dessert	5	good	
 -15	flavorless vampire cake	4	decent	
--52	adequate fancy big lime green Soylent Red and Green	5	good	
+-52	fancy big adequate lime green Soylent Red and Green	5	good	
 -53	adequate Disc-Shaped Nutrition Unit	4	good	
--54	normal fancy snack-sized Gingerborg Hive	2	good	
--61	stale fancy Candy Cane Surprise	4	decent	
+-54	snack-sized normal fancy Gingerborg Hive	2	good	
+-61	fancy stale Candy Cane Surprise	4	decent	
 -62	moldy Grimdrop Chow Mein	4	crappy	
 -63	toothsome Grimgerbread House	3	awesome	
 -67	spoiled Caviar Carbonara	3	crappy	
 -68	spoiled olive Halibut Alfredo	4	crappy	
 -69	small decent Red Herring Velvet Cake	2	good	
 -73	spoiled yellow CRIMBCO Reconstituted Gruel	4	crappy	
--74	big decent New and Improved CRIMBCO Reconstituted Gruel	5	good	
+-74	decent big New and Improved CRIMBCO Reconstituted Gruel	5	good	
 -75	moldy upside-down CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	3	crappy	
 -79	half-sized adequate pulsating jittery Brussels Sprout Stir-Fry	2	good	
--80	decent low-calorie Carrot, Cabbage, and Kale Pizza	1	good	
--81	half-sized toothsome special Turnip and Rutabaga Pie	2	awesome	
+-80	low-calorie decent Carrot, Cabbage, and Kale Pizza	1	good	
+-81	special toothsome half-sized Turnip and Rutabaga Pie	2	awesome	
 -85	adequate miniature Rainbow Spider Fun Roll	2	good	
--86	adequate miniature Vegas Volcano Lava Roll	2	good	
+-86	miniature adequate Vegas Volcano Lava Roll	2	good	
 -87	tiny yummy Crazy Dragon Shogun Buddha Roll	1	awesome	
--92	tasty huge basic hot dog	7	awesome	
+-92	huge tasty basic hot dog	7	awesome	
 -93	spoiled savage macho dog	3	crappy	
 -94	stale one with everything	3	decent	
 -95	bland miniature sly dog	2	decent	
 -96	flavorless devil dog	4	decent	
 -97	half-sized spoiled upside-down chilly dog	2	crappy	
 -98	decent ghost dog	4	good	
--99	jumbo decent narrow junkyard dog	5	good	
+-99	decent jumbo narrow junkyard dog	5	good	
 -100	decent wet dog	4	good	
 -101	big rotten sleeping dog	5	crappy	
 -102	normal upside-down optimal dog	4	good	
 -103	flavorless massive video games hot dog	8	decent	
--104	spoiled bite-sized mirror Peppermint Nutrition Block	1	crappy	
+-104	bite-sized spoiled mirror Peppermint Nutrition Block	1	crappy	
 -105	flavorless Gingerbread Nutrition Block	4	decent	
 -106	delicious huge Cinnamon Nutrition Block	3	awesome	

--- a/data/TCRS/TCRS_Turtle_Tamer_Vole.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Vole.txt
@@ -5,16 +5,16 @@
 5	red pasta spoon	0		
 6	twirling grievous ravioli hat	0		Weapon Damage Percent: +50, Familiar Effect: "atk, cap 2"
 7	saucepan	0		
-8	blurry bouncing spices	0		
+8	bouncing blurry spices	0		
 9	frightening disco mask	0		Spooky Damage: +5, Familiar Effect: "atk, cap 2"
 10	maroon disco ball	0		
 11	squat stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	diluted bouncing tumbling upside-down moxie weed	1		
+14	diluted upside-down bouncing tumbling moxie weed	1		
 15	diluted strongness elixir	1		
 16	distilled blurry magicalness-in-a-can	1		
 17	spoiled gigantic noodles	6	crappy	
-18	twirling pulsating tortoise's blessing	0		
+18	pulsating twirling tortoise's blessing	0		
 19	deadly asparagus knife	0		Weapon Damage: +5
 20	lime green Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
 21	sweet ninja sword	0		
@@ -81,7 +81,7 @@
 82	ring	0		
 83	shaft	0		
 84	Orcish meat locker	0		
-85	blinking blue skewed unlocked meat locker	0		
+85	blue blinking skewed unlocked meat locker	0		
 86	yellow key	0		
 87	tumbling meat from yesterday	0		
 88	ghostly meat stack	0		
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	gravedigger's nasty staff	0		Stench Damage: +5, Spooky Damage: +10
 104	scarecrow	0		
-105	snack-sized rotten bowl of charms	2	crappy	
+105	rotten snack-sized bowl of charms	2	crappy	
 106	ketchup	1	awesome	
 107	fancy wobbly catsup	1	good	Effect: "Weather, Man", Effect Duration: 15
 108	red stick	0		
@@ -116,7 +116,7 @@
 117	upside-down Gnollish plunger	0		
 118	spring	0		
 119	mirror sprocket	0		
-120	huge red cog	0		
+120	red huge cog	0		
 121	sprocket assembly	0		
 122	cog and sprocket assembly	0		
 123	narrow narrow Gnollish flyswatter	0		
@@ -176,7 +176,7 @@
 177	brainy skull	0		
 178	narrow detective skull	0		
 179	spoiled snack-sized narrow chorizo taco	2	crappy	
-180	tolerable practically non-alcoholic ice-cold fotie	1	good	
+180	practically non-alcoholic tolerable ice-cold fotie	1	good	
 181	ghostly baseball	0		
 182	blinking batgut	0		
 183	bat wing	0		
@@ -195,7 +195,7 @@
 197	rat whisker	0		
 198	rat appendix	0		
 199	ring of chilblains	0		Cold Damage: +25
-200	snack-sized toothsome jittery narrow rat appendix kabob	2	awesome	
+200	toothsome snack-sized narrow jittery rat appendix kabob	2	awesome	
 201	adequate spinning bat wing kabob	3	good	
 202	bland small huge carob chunks	2	decent	
 203	shaking herbs	0		
@@ -229,11 +229,11 @@
 231	Doc Galaktik's Pungent Unguent	0		
 232	Doc Galaktik's Ailment Ointment	0		
 233	tumbling Doc Galaktik's Restorative Balm	0		
-234	skewed wobbly Doc Galaktik's Homeopathic Elixir	0		
+234	wobbly skewed Doc Galaktik's Homeopathic Elixir	0		
 235	Tesla quilted Bigger Bugfinder Blade	0		Damage Absorption: +40, MP Regen Min: 7, MP Regen Max: 10
 236	Queue Du Coq cocktailcrafting kit	0		
 237	smooth squat bottle of gin	3	awesome	
-238	mediocre high-proof ghostly bottle of vodka	9	decent	
+238	high-proof mediocre ghostly bottle of vodka	9	decent	
 239	dance instructor's Orcish baseball cap of mayonnaise	0		Experience Percent (Moxie): +10, Sleaze Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	Sinatra's Orcish cargo shorts of the overflowing toilet	0		Experience (Moxie): +5, Stench Spell Damage: +50, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	rock-hard Orcish frat-paddle	0		Damage Reduction: 5
@@ -243,36 +243,36 @@
 245	tiny adequate shaking olive	1	good	
 246	tasty blurry tomato	3	awesome	
 247	fermenting powder	0		
-248	tolerable triple-distilled salty dog	6	good	
+248	triple-distilled tolerable salty dog	6	good	
 249	bad bloody mary	3	decent	
 250	lousy distilled blurry screwdriver	5	decent	
-251	drinkable strong blinking martini	5	good	
-252	mediocre practically non-alcoholic bloody beer	1	decent	
+251	strong drinkable blinking martini	5	good	
+252	practically non-alcoholic mediocre bloody beer	1	decent	
 253	tolerable shot of schnapps	3	good	
-254	perfectly mixed practically non-alcoholic twirling shot of grapefruit schnapps	1	EPIC	
+254	practically non-alcoholic perfectly mixed twirling shot of grapefruit schnapps	1	EPIC	
 255	weak lousy narrow fine wine	2	decent	
 256	bad shot of tomato schnapps	4	decent	
 257	hand-crafted watered-down extra-spicy bloody mary	2	EPIC	
 258	dense meat stack	0		
 259	olive snake skin	0		
 260	adequate White Citadel fries	3	good	
-261	low-calorie stale White Citadel burger	1	decent	
-262	bland half-sized piece of wedding cake	2	decent	
+261	stale low-calorie White Citadel burger	1	decent	
+262	half-sized bland piece of wedding cake	2	decent	
 263	bland jumbo chocolate chips	5	decent	
 264	flavorless ghostly chocolate chip cookies	3	decent	
 265	ghostly crafty satin pants	0		Maximum MP: +10, Familiar Effect: "atk, 2xPotato, cap 10"
-266	strong lousy fancy lightning	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 5
+266	lousy fancy strong lightning	5	decent	Effect: "Chauve-Souris Merde Fou", Effect Duration: 5
 267	curative mullet wig	0		HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "3xPotato, 2xGhuol, cap 10"
 268	upside-down dog trainer's meat cowboy hat	0		Experience (familiar): +1, Familiar Effect: "1xBarrr, 3xLep, cap 10"
 269	ghostly stylish sword	0		Moxie: +25
 270	bouncing picket fence	0		
 271	twisted skewed barbell	1		
-272	dried pulsating yellow blurry concentrated magicalness pill	1		
+272	dried blurry pulsating yellow concentrated magicalness pill	1		
 273	diluted yellow moxie weed	1		Effect: "Very Clean Guns", Effect Duration: 45
 274	Familiar-Gro&trade; Terrarium	0		
-275	huge purple mosquito larva	0		
+275	purple huge mosquito larva	0		
 276	blinking leprechaun hatchling	0		
-277	boiled bouncing squat extra-strength strongness elixir	1		
+277	boiled squat bouncing extra-strength strongness elixir	1		
 278	boiled bouncing bouncing jug-o-magicalness	1		Effect: "A View to Some Meat", Effect Duration: 50
 279	mixed narrow wobbly suntan lotion of moxiousness	1		
 280	tumbling Pick-O-Matic lockpicks	0		
@@ -298,7 +298,7 @@
 300	tarnished tumbling jaba&ntilde;ero-flavored chewing gum	0		Effect: "Cold, Dead Hands", Effect Duration: 40
 301	flat dough	0		
 302	rotten Knob sausage	4	crappy	
-303	fancy big decent Knob mushroom	5	good	Effect: "White Blooded", Effect Duration: 10
+303	decent big fancy Knob mushroom	5	good	Effect: "White Blooded", Effect Duration: 10
 304	dry noodles	0		
 305	blinking therapeutic Knob Goblin harem pants	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	red Knob Goblin harem veil of the cheetah	0		Initiative: +60, Familiar Effect: "5xLep, cap 2"
@@ -309,13 +309,13 @@
 311	hill of beans	0		
 312	hale Knob Goblin visor	0		Maximum HP: +20, Familiar Effect: "2xVolley, 1xPotato, cap 12"
 313	blinking Crown of the Goblin King of chilblains	0		Cold Damage: +25, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
-314	super-sized toothsome bean burrito	5	awesome	
-315	thick flavorless blue bean burrito	5	decent	
+314	toothsome super-sized bean burrito	5	awesome	
+315	flavorless thick blue bean burrito	5	decent	
 316	half-sized delicious insanely bean burrito	2	awesome	
-317	moldy small bean burrito	2	crappy	
-318	enchanted snack-sized spoiled blurry bean burrito	2	crappy	Effect: "Cybernetic Muscles", Effect Duration: 20
-319	special immense stale narrow insanely bean burrito	10	decent	Effect: "Superhuman Sarcasm", Effect Duration: 45
-320	big decent bat haggis	5	good	
+317	small moldy bean burrito	2	crappy	
+318	snack-sized enchanted spoiled blurry bean burrito	2	crappy	Effect: "Cybernetic Muscles", Effect Duration: 20
+319	immense stale special narrow insanely bean burrito	10	decent	Effect: "Superhuman Sarcasm", Effect Duration: 45
+320	decent big bat haggis	5	good	
 321	bite-sized normal menudo	1	good	
 322	low-calorie stale goat cheese	1	decent	
 323	flavorless plain pizza	3	decent	
@@ -328,7 +328,7 @@
 330	tumbling glass of goat's milk	1	crappy	
 331	spirit-forward artisanal upside-down Canadian	5	EPIC	
 332	stale lemon	3	decent	
-333	decent jumbo lime	5	good	
+333	jumbo decent lime	5	good	
 334	shellacked sabre teeth	0		Damage Reduction: 7
 335	sabre-toothed lime cub	0		
 336	olive dance instructor's consolation ribbon	0		Experience Percent (Moxie): +10
@@ -366,7 +366,7 @@
 368	shaking linoleum crossbow string	0		
 369	asbestos sword hilt	0		
 370	asbestos stick	0		
-371	blurry spinning spinning asbestos crossbow string	0		
+371	spinning blurry spinning asbestos crossbow string	0		
 372	huge gray chrome sword hilt	0		
 373	chrome stick	0		
 374	huge chrome crossbow string	0		
@@ -417,7 +417,7 @@
 419	magnetized moist non-altered serum of sarcasm	0		Effect: "The Dinsey Way", Effect Duration: 14
 420	oxidized teal tomato juice of powerful power	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 43
 421	polarized wobbly philter of phorce	0		Effect: "Red-Shirted Escort", Effect Duration: 31
-422	denatured super-electrified mirror olive spinning potion of potency	0		Effect: "Chalky Hand", Effect Duration: 48
+422	denatured super-electrified olive mirror spinning potion of potency	0		Effect: "Chalky Hand", Effect Duration: 48
 423	dry cordial of concentration	0		Effect: "Sweet and Red", Effect Duration: 47
 424	flattened ointment of the occult	0		Effect: "Ruby-ous", Effect Duration: 44
 425	oxidized oil of expertise	0		Effect: "The Solution", Effect Duration: 51
@@ -445,16 +445,16 @@
 447	purple avaricious box-in-the-box-in-the-box	0		Meat Drop: +30
 448	gravedigger's educational foolscap fool's cap	0		Experience: +1, Spooky Damage: +10, Clowniness: 25, Familiar Effect: "3xVolley, cap 10"
 449	clown nose of James Dean	0		Experience (Moxie): +3, Clowniness: 25
-450	pulsating fuchsia pretentious paintbrush	0		
+450	fuchsia pulsating pretentious paintbrush	0		
 451	pretentious palette	0		
 452	disease	0		
-453	blinking skewed sober pill	0		
+453	skewed blinking sober pill	0		
 454	pulsating screwdriver	0		
-455	snack-sized bland narrow jumbo olive	2	decent	
-456	drinkable watered-down special dry martini	2	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 15
+455	bland snack-sized narrow jumbo olive	2	decent	
+456	watered-down drinkable special dry martini	2	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 15
 457	ye olde golde frontes of the pedagogue	0		Experience: +3, Class: "Disco Bandit", Single Equip
 458	bouncing continuum transfunctioner	0		
-459	lime green twirling pixel	0		
+459	twirling lime green pixel	0		
 460	skewed pixel	0		
 461	shaking pulsating pixel	0		
 462	pixel	0		
@@ -462,7 +462,7 @@
 464	pixel potion	0		
 465	pixel potion	0		
 466	cyan pixel potion	0		
-467	decent low-calorie red pixel pie	1	good	
+467	low-calorie decent red pixel pie	1	good	
 468	ruby W	0		
 469	tumbling wussiness potion	0		
 470	strong acceptable squat Imp Ale	5	good	
@@ -496,7 +496,7 @@
 498	normal huge papaya	4	good	
 499	bouncing veiny denim axe of the brute	0		Muscle Percent: +30, Maximum HP: +10
 500	jittery Elf Farm Raffle ticket	0		
-501	miniature spoiled lime green wobbly Elfin shortbread	2	crappy	
+501	spoiled miniature lime green wobbly Elfin shortbread	2	crappy	
 502	pagoda plans	0		
 503	normal skewered cat appendix	3	good	
 504	jittery evil arches	0		
@@ -538,9 +538,9 @@
 540	dry warmed pulsating Tasty Fun Good rice candy	0		Effect: "Spirit of Alph", Effect Duration: 21
 541	banded sinister draggin' ball hat	0		Spell Damage: +10, Damage Absorption: +100, Familiar Effect: "atk, 1xVolley, cap 25"
 542	vibrating hardened 1337 7r0uZ0RZ	0		Damage Reduction: 3, Maximum MP Percent: +10, Familiar Effect: "2xPotato, cap 27"
-543	spoiled miniature skewed Trollhouse cookies	2	crappy	
+543	miniature spoiled skewed Trollhouse cookies	2	crappy	
 544	Tesla talons	0		Item Drop: +5, MP Regen Min: 7, MP Regen Max: 10
-545	adequate small Spam Witch sammich	2	good	
+545	small adequate Spam Witch sammich	2	good	
 546	blue meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -555,7 +555,7 @@
 557	delicious whiskey and cola	3	awesome	
 558	normal papaya taco	3	good	
 559	blue razor-sharp can lid	0		
-560	miniature moldy ghostly stalk of asparagus	2	crappy	
+560	moldy miniature ghostly stalk of asparagus	2	crappy	
 561	wobbly pregnant mushroom	0		
 562	mirror ratgut	0		
 563	sonar-in-a-biscuit	0		
@@ -563,8 +563,8 @@
 565	blurry hobo gloves of courage	0		Spooky Resistance: +3, Single Equip
 566	healthy bum cheek	0		Maximum HP Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	hermit script	0		
-568	massive decent Double Bacon Beelzeburger	6	good	
-569	miniature adequate skewed Lord of the Flies-sized fries	2	good	
+568	decent massive Double Bacon Beelzeburger	6	good	
+569	adequate miniature skewed Lord of the Flies-sized fries	2	good	
 570	moldy Chicken Sandwich	4	crappy	
 571	wobbly Jumbo Dr. Lucifer	1	EPIC	
 572	adequate Children's Meal of the Damned	3	good	
@@ -573,14 +573,14 @@
 575	bland painful penne pasta	3	decent	
 576	delicious ravioli della hippy	3	awesome	
 577	stale pr0n m4nic0tti	4	decent	
-578	normal thick Hell ramen	5	good	
-579	huge tasty boring spaghetti	8	awesome	
+578	thick normal Hell ramen	5	good	
+579	tasty huge boring spaghetti	8	awesome	
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	adequate half-sized fettucini Inconnu	2	good	
+583	half-sized adequate fettucini Inconnu	2	good	
 584	adequate spaghetti with Skullheads	3	good	
-585	normal half-sized gnocchetti di Nietzsche	2	good	
+585	half-sized normal gnocchetti di Nietzsche	2	good	
 586	dance instructor's ridiculously huge sword of the sweet-tooth	0		Experience Percent (Moxie): +10, Candy Drop: +100
 587	quadruple-concentrated anodized energized ghostly super-spiky hair gel	0		Effect: "Tingling Feeling", Effect Duration: 17
 588	soft echo eyedrop antidote	0		
@@ -593,7 +593,7 @@
 595	tumbling scroll of drastic healing	0		
 596	bouncing squat crafty titanium assault umbrella	0		Maximum MP: +10
 597	Mohawk wig of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 35"
-598	jittery twirling the Slug Lord's map	0		
+598	twirling jittery the Slug Lord's map	0		
 599	pants of the Slug Lord of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "stench atk, 3xPotato, cap 8"
 600	sinister Dr. Hobo's scalpel of Tarzan	0		Experience (Muscle): +3, Spell Damage: +10
 601	Dr. Hobo's map	0		
@@ -605,10 +605,10 @@
 607	huge Gauze Immateria	0		
 608	Plastic Wrap Immateria	0		
 609	S.O.C.K.	0		
-610	wobbly blue procrastination potion	0		
+610	blue wobbly procrastination potion	0		
 611	D	0		
 612	original G	0		
-613	squat squat cyan plot hole	0		
+613	squat cyan squat plot hole	0		
 614	denatured unsweetened pulsating probability potion	0		Effect: "Prelude of Precision", Effect Duration: 47
 615	chaos butterfly	0		
 616	huge furry fur	0		
@@ -636,7 +636,7 @@
 638	smelly rosy-cheeked asshat	0		Maximum HP Percent: +30, Stench Spell Damage: +10, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	flavorless bouncing abominable snowcone	3	decent	
 640	upside-down Ent cider	1	awesome	
-641	half-sized decent toast	2	good	
+641	decent half-sized toast	2	good	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	Crimbo pressie	0		Last Available: "2003-12"
@@ -644,8 +644,8 @@
 646	miniature decent fruitcake	2	good	
 647	present	0		Last Available: "2004-11"
 648	cool Crimbo sword	0		Moxie: +5, Last Available: "2004-10"
-649	Crimbo hat of the dark arts	0		Spell Damage Percent: +100, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
-650	tumbling stiffened Crimbo pants	0		Damage Reduction: 1, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
+649	Crimbo hat of the dark arts	0		Spell Damage Percent: +100, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
+650	tumbling stiffened Crimbo pants	0		Damage Reduction: 1, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
 651	miser's exclusive ultra-rare item	0		Meat Drop: +10
 652	squat quantum egg	0		
 653	intragalactic rowboat	0		
@@ -667,19 +667,19 @@
 669	stale ghuol guolash	3	decent	
 670	blurry scandalous lihc face	0		Sleaze Damage: +5, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	frightening weightlifter's grave robbing shovel	0		Muscle: +15, Spooky Damage: +5
-672	tiny enchanted rotten cranberries	1	crappy	Effect: "Fan-Cooled", Effect Duration: 50
-673	high-proof smooth twirling vodka and cranberry	9	awesome	
+672	rotten tiny enchanted cranberries	1	crappy	Effect: "Fan-Cooled", Effect Duration: 50
+673	smooth high-proof twirling vodka and cranberry	9	awesome	
 674	perfectly mixed lime green whiskey	4	EPIC	
 675	green skull of the Bonerdagon of the empath	0		Familiar Weight: +5
 676	dragonbone belt buckle	0		
 677	clever badass belt	0		Maximum MP: +20
 678	chest of the Bonerdagon	0		
 679	distilled delicious roll in the hay	5	awesome	
-680	hand-crafted squat red slap and tickle	3	EPIC	
+680	hand-crafted red squat slap and tickle	3	EPIC	
 681	drinkable tumbling slip 'n' slide	3	good	
 682	artisanal a sump'm sump'm	3	EPIC	
 683	watered-down artisanal horizontal tango	2	EPIC	
-684	triple-distilled artisanal pink pony	8	EPIC	
+684	artisanal triple-distilled pink pony	8	EPIC	
 685	miser's greasy Jim Carey's Mr. Shirt	0		Monster Level: +25, Sleaze Spell Damage: +10, Meat Drop: +10
 686	clever knuckles	0		Maximum MP: +20
 687	dry blood of the Wereseal	0		Effect: "Cute Vision", Effect Duration: 36
@@ -729,7 +729,7 @@
 733	hosed fishbowl	0		
 734	blue dance instructor's makeshift SCUBA gear of Calamity Jane of the sweet-tooth	0		Experience Percent (Moxie): +10, Critical Hit Percent: +15, Candy Drop: +100, Adventure Underwater
 735	twirling ribald easter egg balloon	0		Sleaze Damage: +10
-736	bouncing maroon stone tablet (Sinister Strumming)	0		
+736	maroon bouncing stone tablet (Sinister Strumming)	0		
 737	upside-down stone tablet (Squeezings of Woe)	0		
 738	stone tablet (Really Evil Rhythm)	0		
 739	tambourine bells	0		
@@ -743,13 +743,13 @@
 748	gourd potion	0		
 749	bland warm mushroom	3	decent	
 750	rotten mushroom quesadilla	3	crappy	
-751	spoiled skewed huge cool mushroom	4	crappy	
+751	spoiled huge skewed cool mushroom	4	crappy	
 752	normal red cool mushroom casserole	4	good	
 753	toothsome pointy mushroom	3	awesome	
 754	bland miniature cream of pointy mushroom soup	2	decent	
-755	snack-sized stale mushroom	2	decent	
+755	stale snack-sized mushroom	2	decent	
 756	decent blinking mushroom	3	good	
-757	miniature adequate bouncing mushroom	2	good	
+757	adequate miniature bouncing mushroom	2	good	
 758	decent thick ghost cucumber	5	good	
 759	dill	0		
 760	vinegar	0		
@@ -757,7 +757,7 @@
 762	perfectly mixed especially salty dog	4	EPIC	
 763	ghostly pickling solution	0		
 764	flavorless shaking spectral pickle	3	decent	
-765	huge pulsating bouncing briny vinegar	0		
+765	pulsating huge bouncing briny vinegar	0		
 766	ghost pickle on a stick	0		
 767	aerosolized liquefied blinking cologne of contempt	0		Effect: "EVISCERATE!", Effect Duration: 49
 768	mirror upside-down rosy-cheeked spork	0		Maximum HP Percent: +30
@@ -779,7 +779,7 @@
 784	perfectly mixed Acqua Del Piatto Merlot	3	super EPIC	Last Available: "2004-10"
 785	squat raffle ticket	0		
 786	normal enchanted huge strawberry	3	good	Effect: "There Is A Spoon", Effect Duration: 35
-787	weak perfectly mixed huge teal bottle of rum	2	EPIC	
+787	perfectly mixed weak teal huge bottle of rum	2	EPIC	
 788	lousy strawberry daiquiri	4	decent	
 789	aged rum and cola	3	awesome	
 790	tolerable narrow grog	4	good	
@@ -787,7 +787,7 @@
 792	yellow healthy Golden Mr. Accessory	0		Maximum HP Percent: +20, Softcore Only
 793	ionized improved wobbly oil of stability	0		Effect: "Flaming Weapon", Effect Duration: 61
 794	super-anodized maroon oil of slipperiness	0		Effect: "Sludgesick", Effect Duration: 30
-795	watered-down lousy Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
+795	lousy watered-down Acque Luride Grezze Cabernet	2	decent	Last Available: "2004-10"
 796	pulsating avaricious Oprah's boxer's cement shoes	0		Muscle Percent: +10, Maximum MP Percent: +50, Meat Drop: +30, Last Available: "2004-10"
 797	perfectly mixed rockin' wagon	4	EPIC	
 798	lousy maroon mirror ocean motion	3	decent	
@@ -806,7 +806,7 @@
 813	half-sized adequate Knob shells	2	good	
 814	flavorless small b&auml;tzle	2	decent	
 815	normal fancy ratini	3	good	Effect: "Pwnd", Effect Duration: 50
-816	normal snack-sized Knob stroganoff	2	good	
+816	snack-sized normal Knob stroganoff	2	good	
 817	adequate menudo ravioli	3	good	
 818	plus sign	0		
 819	twirling milky potion	0		
@@ -820,7 +820,7 @@
 827	murky potion	0		
 828	baby killer bee	0		
 829	anti-anti-antidote	0		
-830	spoiled half-sized jittery royal jelly	2	crappy	
+830	half-sized spoiled jittery royal jelly	2	crappy	
 831	small box	0		
 832	tumbling box	0		
 833	vorpal blade of the empath	0		Familiar Weight: +5
@@ -831,10 +831,10 @@
 838	Fonzie's slick Mafia stogie	0		Moxie: +10, Experience (Moxie): +1, Last Available: "2004-10"
 839	acceptable Maiali Sifilitici Pinot Noir	3	good	Last Available: "2004-10"
 840	executive Mafia violin case of doom	0		Spooky Spell Damage: +50, Meat Drop: +40, Last Available: "2004-10"
-841	perfectly mixed watered-down enchanted spinning tomato daiquiri	2	EPIC	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
+841	enchanted watered-down perfectly mixed spinning tomato daiquiri	2	EPIC	Effect: "Boon of the Storm Tortoise", Effect Duration: 35
 842	fancy acceptable beertini	4	good	Effect: "Tennis Elbow-wow", Effect Duration: 15
 843	delicious bouncing salty slug	4	awesome	
-844	aged spirit-forward papaya slung	5	awesome	
+844	spirit-forward aged papaya slung	5	awesome	
 845	ghostly strapping MAHI fez	0		Muscle: +5, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	hypodermic needle	0		Familiar Weight: +5
@@ -878,7 +878,7 @@
 887	leaf	0		
 888	maple leaf	0		
 889	blue smooth balaclava	0		Moxie: +15, Familiar Effect: "cold atk, 1.5xLep, cap 12"
-890	huge rotten blurry huge squat balaclava baklava	10	crappy	
+890	rotten huge squat huge blurry balaclava baklava	10	crappy	
 891	Jim Carey's Warehouse 23 bling	0		Monster Level: +25
 892	knitted greasy grievous bugbear-smiting sword	0		Weapon Damage Percent: +50, Sleaze Spell Damage: +10, Cold Resistance: +3
 893	acceptable pulsating lumbering jack	4	good	
@@ -886,19 +886,19 @@
 895	family-friendly Ms. Accessory	0		Sleaze Resistance: +1, Softcore Only
 896	lightning-fast strapping Mr. Accessory Jr.	0		Muscle: +5, Initiative: +40, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
-898	blue ghostly Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
+898	ghostly blue Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	jittery custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	watered-down lousy squat Spasmi Dolorosi Del Rene Champagne	2	decent	Last Available: "2004-10"
-904	personal trainer's brawny school Mafia knickerbockers of James Dean	0		Muscle Percent: +20, Experience (Moxie): +3, Experience Percent (Muscle): +10, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
+904	personal trainer's brawny school Mafia knickerbockers of James Dean	0		Muscle Percent: +20, Experience (Moxie): +3, Experience Percent (Muscle): +10, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
 905	pressed quantum Yummy Tummy bean	0		Effect: "Burning Tongue", Effect Duration: 29
 906	liquefied anodized huge Rock Pops	0		Effect: "Covetous Robbery", Effect Duration: 25
-907	vacuum-sealed upside-down shaking Mr. Mediocrebar	0		Effect: "Raging Animal", Effect Duration: 35
+907	vacuum-sealed shaking upside-down Mr. Mediocrebar	0		Effect: "Raging Animal", Effect Duration: 35
 908	ionized Cold Hots candy	0		Effect: "A Taste of Rainbow", Effect Duration: 39
 909	polarized pickled Wint-O-Fresh mint	0		Effect: "Can't Be a Chooser", Effect Duration: 14
-910	miniature stale dwarf bread	2	decent	
+910	stale miniature dwarf bread	2	decent	
 911	improved triple-electrified upside-down Senior Mints	0		Effect: "Space Cadet", Effect Duration: 31
 912	improved alkaline blurry pixellated candy heart	0		Effect: "Knightlife", Effect Duration: 49
 913	quantum unsweetened super-moist kobold	0		Effect: "Antsy in your Pantsy", Effect Duration: 59
@@ -906,8 +906,8 @@
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	Annie Oakley's intergalactic pom poms of Flo-Jo	0		Critical Hit Percent: +20, Initiative: +100
 917	bouncing Mob Penguin protection contract	0		
-918	Radio Free Baseball Cap of the cheetah	0		Initiative: +60, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
-919	skewed Radio Free Pants of the scaredy-cat	0		Monster Level: -15, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
+918	Radio Free Baseball Cap of the cheetah	0		Initiative: +60, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
+919	skewed Radio Free Pants of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
 920	Radio Free Foil of temperance	0		Sleaze Resistance: +5, Last Available: "2006-07"
 921	adequate blinking radio button candy	4	good	
 922	strapping severed rocking horse head	0		Muscle: +5
@@ -915,23 +915,23 @@
 924	crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	squat dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	non-corrupted enhanced shaking Hawking's Elixir of Brilliance	0		Effect: "Larger", Effect Duration: 16
-927	watered-down tolerable Ferita Del Petto Zinfandel	2	good	Last Available: "2006-12"
+927	tolerable watered-down Ferita Del Petto Zinfandel	2	good	Last Available: "2006-12"
 928	smooth fuzzy bracelets	0		Moxie: +15
 929	spinning family-friendly arse-shooting crossbow	0		Sleaze Resistance: +1
-931	enchanted mediocre weak spiced rum	2	decent	Effect: "The Strength...  of the Future", Effect Duration: 45
+931	weak mediocre enchanted spiced rum	2	decent	Effect: "The Strength...  of the Future", Effect Duration: 45
 932	lousy eggnog	3	decent	
 933	rotten huge candy cane	6	crappy	
-934	fancy moldy half-sized gingerbread bugbear	2	crappy	Effect: "Super Skill", Effect Duration: 5
+934	moldy half-sized fancy gingerbread bugbear	2	crappy	Effect: "Super Skill", Effect Duration: 5
 935	chaotic imitation nice watch	0		Spell Critical Percent: +10, Single Equip, Last Available: "2004-12"
 936	Hanukkimbo dreidl	0		Last Available: "2004-12"
 937	pulsating menorette	0		Familiar Weight: +5, Last Available: "2004-12"
 938	foul-smelling plastic sword	0		Stench Damage: +10, Last Available: "2004-12"
 939	small Crimbo Pressie	0		Last Available: "2004-12"
 940	red bow	0		Last Available: "2004-12"
-941	skewed gray mirror Crimbo stocking	0		Last Available: "2004-12"
-942	shaking toasty bowler	0		Hot Damage: +5, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
+941	skewed mirror gray Crimbo stocking	0		Last Available: "2004-12"
+942	shaking toasty bowler	0		Hot Damage: +5, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
 943	ghostly greedy weightlifter's bow staff	0		Muscle: +15, Meat Drop: +20, Last Available: "2004-12"
-944	dance instructor's bowlegged pants	0		Experience Percent (Moxie): +10, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
+944	dance instructor's bowlegged pants	0		Experience Percent (Moxie): +10, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	pulsating skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -984,32 +984,32 @@
 994	ghostly banded plastic Susie	0		Damage Absorption: +100
 995	thick yummy Lucky Surprise Egg	5	awesome	
 998	fuchsia maiden wig	0		Familiar Effect: "2xPotato, cap 8"
-999	bouncing fuchsia maid head	0		
+999	fuchsia bouncing maid head	0		
 1000	Meat maid	0		
 1002	tumbling veiny Xlyinia's notebook	0		Maximum HP: +10
 1003	skewed soda water	0		
-1004	lousy gray blurry bottle of tequila	3	decent	
+1004	lousy blurry gray bottle of tequila	3	decent	
 1005	aged practically non-alcoholic boxed wine	1	awesome	
 1006	spoiled cherry	3	crappy	
 1007	Newton's coconut shell	0		Experience (Mysticality): +3, Familiar Effect: "1xFairy, cap 7"
 1008	quilted ice cubes	0		Damage Absorption: +40
 1009	fancy smooth blinking vodka martini	3	awesome	Effect: "The Two-Prong Crown", Effect Duration: 30
 1010	mediocre whiskey and soda	4	decent	
-1011	practically non-alcoholic enchanted bad monkey wrench	1	decent	Effect: "Standard Issue Bravery", Effect Duration: 5
+1011	bad enchanted practically non-alcoholic monkey wrench	1	decent	Effect: "Standard Issue Bravery", Effect Duration: 5
 1012	irresponsibly strong mediocre tequila sunrise	8	decent	
 1013	perfectly mixed cyan margarita	3	EPIC	
-1014	aged practically non-alcoholic strawberry wine	1	awesome	
-1015	smooth fortified maroon wine spritzer	5	awesome	
+1014	practically non-alcoholic aged strawberry wine	1	awesome	
+1015	fortified smooth maroon wine spritzer	5	awesome	
 1016	perfectly mixed perpendicular hula	4	EPIC	
-1017	strong mediocre ducha de oro	5	decent	
+1017	mediocre strong ducha de oro	5	decent	
 1018	drinkable calle de miel	3	good	
-1019	weak smooth dry vodka martini	2	awesome	
-1020	weak delicious wobbly old-fashioned	2	awesome	
+1019	smooth weak dry vodka martini	2	awesome	
+1020	delicious weak wobbly old-fashioned	2	awesome	
 1021	artisanal boozy tequila with training wheels	5	EPIC	
 1022	drinkable mirror sangria	4	good	
 1023	watered-down artisanal vesper	2	super ultra mega turbo EPIC	Last Available: "2004-12"
 1024	extra-dry artisanal bodyslam	5	EPIC	Last Available: "2004-12"
-1025	practically non-alcoholic bad purple blurry sangria del diablo	1	decent	Last Available: "2004-12"
+1025	bad practically non-alcoholic blurry purple sangria del diablo	1	decent	Last Available: "2004-12"
 1026	Valentine	0		Free Pull
 1027	tumbling whip kit	0		
 1028	buckler buckle	0		
@@ -1029,25 +1029,25 @@
 1043	experienced string of beads	0		Experience: +2
 1044	huge forbidden string of beads	0		Spell Damage Percent: +50
 1045	twirling Oprah's plastic bottle opener	0		Maximum MP Percent: +50
-1046	Fonzie's traffic cone of courage	0		Experience (Moxie): +1, Spooky Resistance: +3, Last Available: "2005-03", Familiar Effect: "cap 15"
+1046	Fonzie's traffic cone of courage	0		Experience (Moxie): +1, Spooky Resistance: +3, Familiar Effect: "cap 15", Last Available: "2005-03"
 1047	hand-crafted blue N. O. Beer	4	EPIC	
 1048	powdered spinning spinning oyster egg	1		Effect: "Ginger Snapped", Effect Duration: 50
 1049	powdered oyster egg	1		
 1050	dehydrated oyster egg	1		
 1051	plastic oyster egg	0		
-1052	twisted olive twirling tumbling oyster egg	1		Effect: "Larger", Effect Duration: 50
+1052	twisted twirling tumbling olive oyster egg	1		Effect: "Larger", Effect Duration: 50
 1053	diluted upside-down narrow oyster egg	1		Effect: "Souper Vengeful", Effect Duration: 50
 1054	compressed blurry oyster egg	1		
 1055	plastic oyster egg	0		
 1056	denatured narrow ghostly puce oyster egg	1		
 1057	boiled jittery mirror puce oyster egg	1		Effect: "Cancer Rising", Effect Duration: 30
-1058	powdered shaking fuchsia blinking puce oyster egg	1		
+1058	powdered fuchsia blinking shaking puce oyster egg	1		
 1059	mirror puce plastic oyster egg	0		
 1060	denatured mauve oyster egg	1		
 1061	powdered mauve oyster egg	1		
 1062	diluted mauve oyster egg	1		
 1063	maroon mauve plastic oyster egg	0		
-1064	pickled twirling pulsating oyster egg	1		Effect: "Bugbear in Tooth and Claw", Effect Duration: 45
+1064	pickled pulsating twirling oyster egg	1		Effect: "Bugbear in Tooth and Claw", Effect Duration: 45
 1065	compressed oyster egg	1		Effect: "Minerva's Zen", Effect Duration: 20
 1066	boiled jittery ghostly oyster egg	1		
 1067	skewed plastic oyster egg	0		
@@ -1073,7 +1073,7 @@
 1087	clockwork doohickey	0		
 1088	blue clockwork clockwise dome	0		
 1089	jittery clockwork spine	0		
-1090	skewed blinking clockwork rings	0		
+1090	blinking skewed clockwork rings	0		
 1091	bouncing clockwork claws	0		
 1092	shaking ghostly clockwork sheet	0		
 1093	maroon clockwork counterclockwise dome	0		
@@ -1092,7 +1092,7 @@
 1106	blinking clockwork chef head	0		
 1107	clockwork maid head	0		
 1108	upside-down clockwork detective skull	0		
-1109	jittery shaking clockwork bartender-head-in-the-box	0		
+1109	shaking jittery clockwork bartender-head-in-the-box	0		
 1110	purple clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
 1112	clockwork chef-in-the-box	0		
@@ -1107,7 +1107,7 @@
 1121	inexplicably rock	0		
 1122	teal fairy gravy	0		
 1123	slick halfberd	0		Moxie: +10
-1124	squat skewed small glove	0		
+1124	skewed squat small glove	0		
 1125	flame-retardant nasty glove of extreme caution	0		Monster Level: -25, Stench Damage: +5, Hot Resistance: +1
 1126	toothpick of the glutton	0		Food Drop: +100, Single Equip
 1127	rosy-cheeked ninja sword	0		Maximum HP Percent: +30
@@ -1127,12 +1127,12 @@
 1141	drinkable mushroom wine	3	good	
 1142	perfectly mixed pointy mushroom wine	3	EPIC	
 1143	bad bouncing flat mushroom wine	4	decent	
-1144	enchanted hand-crafted cool mushroom wine	4	EPIC	Effect: "Afternoon Insight", Effect Duration: 10
-1145	enchanted mediocre blurry fuchsia knob mushroom wine	4	decent	Effect: "Flagrantly Fragrant", Effect Duration: 10
+1144	hand-crafted enchanted cool mushroom wine	4	EPIC	Effect: "Afternoon Insight", Effect Duration: 10
+1145	mediocre enchanted blurry fuchsia knob mushroom wine	4	decent	Effect: "Flagrantly Fragrant", Effect Duration: 10
 1146	perfectly mixed ghostly knoll mushroom wine	4	EPIC	
-1147	delicious practically non-alcoholic mushroom wine	1	awesome	
-1148	delicious enchanted shot of flower schnapps	3	awesome	Effect: "Happy Salamander", Effect Duration: 15
-1149	fancy spoiled mirror flower petal pie	3	crappy	Effect: "Bottle in front of Me", Effect Duration: 30
+1147	practically non-alcoholic delicious mushroom wine	1	awesome	
+1148	enchanted delicious shot of flower schnapps	3	awesome	Effect: "Happy Salamander", Effect Duration: 15
+1149	spoiled fancy mirror flower petal pie	3	crappy	Effect: "Bottle in front of Me", Effect Duration: 30
 1150	perfectly mixed blinking bottle of single-barrel whiskey	4	EPIC	
 1151	pulsating scorching discarded plastic fork of the bloodbag	0		Maximum HP: +100, Hot Damage: +25
 1152	ghostly gravy-covered maypole	0		Item Drop: +25, Softcore Only, Last Available: "2005-05"
@@ -1158,7 +1158,7 @@
 1173	linoleum box	0		
 1174	chrome box	0		
 1175	bouncing cryptic puzzle box	0		
-1176	ghostly wobbly refrigerated biohazard container	0		
+1176	wobbly ghostly refrigerated biohazard container	0		
 1177	magnetic field	0		
 1178	potted cactus	0		
 1179	purple daisy	0		
@@ -1183,14 +1183,14 @@
 1198	shaking sabre-toothed lime	0		
 1199	bugbear	0		
 1200	spoiled upside-down mugcake	3	crappy	
-1201	rotten miniature urinal cake	2	crappy	
-1202	bland huge Happy Birthday, Claude! cake	8	decent	
-1203	special flavorless thick personalized birthday cake	5	decent	Effect: "Whippin' It Good", Effect Duration: 10
+1201	miniature rotten urinal cake	2	crappy	
+1202	huge bland Happy Birthday, Claude! cake	8	decent	
+1203	flavorless special thick personalized birthday cake	5	decent	Effect: "Whippin' It Good", Effect Duration: 10
 1204	miniature decent fuchsia three-tiered wedding cake	2	good	
 1205	small bland babycakes	2	decent	
 1206	normal velvet cake	4	good	
 1207	normal congratulatory cake	3	good	
-1208	bland cyan skewed angel-food cake	3	decent	
+1208	bland skewed cyan angel-food cake	3	decent	
 1209	stale devil's-food cake	4	decent	
 1210	moldy huge birthday party jellybean cheesecake	4	crappy	
 1211	ghostly balloon	0		
@@ -1236,11 +1236,11 @@
 1252	bland miniature shroomkabob	2	decent	
 1253	twirling blue pile of jumping beans	0		
 1254	moldy jumping bean burrito	4	crappy	
-1255	rotten super-sized spinning jumping bean burrito	5	crappy	
+1255	super-sized rotten spinning jumping bean burrito	5	crappy	
 1256	spoiled blurry insanely jumping bean burrito	4	crappy	
 1257	decent wobbly rat scrapple	3	good	
 1258	pail of pretentious paint	0		
-1259	forbidden extremely unsafe traffic cone	0		Weapon Damage Percent: +100, Spell Damage Percent: +50, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
+1259	forbidden extremely unsafe traffic cone	0		Weapon Damage Percent: +100, Spell Damage Percent: +50, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	pickled Hatorade	1		
 1262	Lo Pan's medical-grade Newton's off-hand balloon	0		Experience (Mysticality): +3, Spell Critical Percent: +30, HP Regen Min: 7, HP Regen Max: 10
@@ -1257,7 +1257,7 @@
 1273	wobbly sage magic lamp	0		Mysticality Percent: +10
 1274	modified Medicinal Herb's medicinal herbs	1		Effect: "Oily Flavor", Effect Duration: 50
 1275	olive sharpshooter's basic meat skirt	0		Critical Hit Percent: +10, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	enchanted acceptable watered-down jittery Otorian Battle Scar	2	good	Effect: "Ooh, Sweet!", Effect Duration: 20
+1276	watered-down acceptable enchanted jittery Otorian Battle Scar	2	good	Effect: "Ooh, Sweet!", Effect Duration: 20
 1277	ghostly basic meat kilt of the cougar	0		Moxie: +20, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	nasty meat skirt	0		Stench Damage: +5, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	olive miser's meat kilt	0		Meat Drop: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1287,7 +1287,7 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	upside-down makeup kit	0		Familiar Weight: +15
-1306	forbidden traffic cone of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
+1306	forbidden traffic cone of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
@@ -1301,11 +1301,11 @@
 1317	blood flower	0		
 1318	spinning lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	rotten half-sized special upside-down questionable taco	2	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 45
+1320	half-sized special rotten upside-down questionable taco	2	crappy	Effect: "Dirge of Dreadfulness", Effect Duration: 45
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	reassuring time helmet	0		Spooky Resistance: +1, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
-1324	green scandalous time trousers	0		Sleaze Damage: +5, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
+1323	reassuring time helmet	0		Spooky Resistance: +1, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
+1324	green scandalous time trousers	0		Sleaze Damage: +5, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
 1325	blurry yellow wool time sword	0		Cold Resistance: +1, Last Available: "2005-10"
 1326	tumbling Dyspepsi-Cola helmet of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "3xFairy, cap 7"
 1327	Socratic Cloaca-Cola shield	0		Experience (Mysticality): +1, Damage Reduction: 4
@@ -1316,7 +1316,7 @@
 1332	shaking Cloaca-Cola knapsack	0		
 1333	Dyspepsi-Cola knapsack	0		
 1334	Cloaca-Cola	0		
-1335	blinking olive Dyspepsi grenade	0		
+1335	olive blinking Dyspepsi grenade	0		
 1336	Cloaca grenade	0		
 1338	Dyspepsi-Cola d-rations	0		
 1339	blue Cloaca-Cola c-rations	0		
@@ -1335,7 +1335,7 @@
 1352	tolerable weak redrum	2	good	
 1353	ninja pirate zombie robot	0		
 1354	pile of pebbles	0		
-1355	snack-sized moldy bowl of oriole's nest soup	2	crappy	
+1355	moldy snack-sized bowl of oriole's nest soup	2	crappy	
 1356	bunny liver	0		
 1357	lousy Mt. Noob Pale Ale	4	decent	
 1358	cyan pirate zombie head	0		Last Available: "2005-11"
@@ -1345,7 +1345,7 @@
 1362	sausage	0		
 1363	clockwork pirate skull	0		
 1364	rhesus monkey	0		Familiar Weight: +5
-1365	gigantic normal tofurkey leg	10	good	
+1365	normal gigantic tofurkey leg	10	good	
 1366	normal upside-down tofurkey gravy	3	good	
 1367	normal massive olive herbal stuffing	6	good	
 1368	decent shaking can-shaped gelatinous cranberry sauce	3	good	
@@ -1384,7 +1384,7 @@
 1402	gray rag doll of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2005-12"
 1403	twirling can of fake snow of the cougar	0		Moxie: +20, Last Available: "2005-12"
 1404	lime green greasy colored-light &quot;necklace&quot;	0		Sleaze Spell Damage: +10, Last Available: "2005-12"
-1405	olive prompt tree skirt	0		Adventures: +3, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
+1405	olive prompt tree skirt	0		Adventures: +3, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
 1406	rotten wreath-shaped Crimbo cookie	3	crappy	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	small rotten bell-shaped Crimbo cookie	2	crappy	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	tasty tree-shaped Crimbo cookie	3	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
@@ -1399,13 +1399,13 @@
 1417	warmed double-alkaline cyan snowcone	0		Effect: "Ermine Eyes", Effect Duration: 52, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	wobbly teddy bear sewing kit	0		Last Available: "2006-01"
-1420	dance instructor's cool traffic cone	0		Moxie: +5, Experience Percent (Moxie): +10, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1420	dance instructor's cool traffic cone	0		Moxie: +5, Experience Percent (Moxie): +10, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
 1421	blurry Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	squat Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	pulsating iceberglet	0		Last Available: "2006-02"
 1424	asbestos-lined beefy ice sickle	0		Muscle: +10, Hot Resistance: +5, Softcore Only, Last Available: "2006-02"
 1425	frightening ice baby	0		Spooky Damage: +5, Softcore Only, Last Available: "2006-02"
-1426	skewed ice pick of the wise owl	0		Mysticality: +20, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+1426	skewed ice pick of the wise owl	0		Mysticality: +20, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
 1427	lightning-fast thinker's ice skates	0		Mysticality: +10, Initiative: +40, Single Equip, Softcore Only, Last Available: "2006-02"
 1428	toothsome bouncing grue egg omelette	3	awesome	
 1429	squat roll of drink tickets	0		
@@ -1448,7 +1448,7 @@
 1466	bamboo bokuto	0		
 1467	blurry 25-meat staff	0		
 1468	gray two-handed depthsword	0		
-1469	olive blinking bill bec-de-bardiche glaive-guisarme	0		
+1469	blinking olive bill bec-de-bardiche glaive-guisarme	0		
 1470	lead yo-yo	0		
 1471	slightly peevedbow	0		
 1472	shaking huge sack of doorknobs	0		
@@ -1474,7 +1474,7 @@
 1492	beefy ninja mop	0		Muscle: +10
 1493	Temple Grandin's ridiculously overelaborate ninja weapon of vim and vigor	0		Maximum HP Percent: +50, Familiar Weight: +7
 1494	alkaline bouncing sugar-coated pine cone	0		Effect: "The Solution", Effect Duration: 65, Last Available: "2020-09"
-1495	stiffened Sinatra's traffic cone	0		Experience (Moxie): +5, Damage Reduction: 1, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
+1495	stiffened Sinatra's traffic cone	0		Experience (Moxie): +5, Damage Reduction: 1, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
 1496	practically non-alcoholic special hand-crafted gloomy mushroom wine	1	super ultra mega turbo EPIC	Effect: "Superhuman Sarcasm", Effect Duration: 25
 1497	aged blinking mushroom wine	3	awesome	
 1498	jittery McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
@@ -1485,7 +1485,7 @@
 1503	huge rubber emo roe	0		Last Available: "2006-04"
 1504	extra-denatured twirling snowcone	0		Effect: "Going Ape", Effect Duration: 47, Last Available: "2006-04"
 1505	tumbling ice cube with a fly in it	0		Last Available: "2006-04"
-1506	artisanal distilled calle de miel with a fly in it	5	EPIC	Last Available: "2006-04"
+1506	distilled artisanal calle de miel with a fly in it	5	EPIC	Last Available: "2006-04"
 1507	perfectly mixed triple-distilled rockin' wagon with a fly in it	6	EPIC	Last Available: "2006-04"
 1508	artisanal perpendicular hula with a fly in it	4	EPIC	Last Available: "2006-04"
 1509	hand-crafted slap and tickle with a fly in it	3	EPIC	Last Available: "2006-04"
@@ -1494,7 +1494,7 @@
 1512	dried huge Knob Goblin pet-buffing spray	1		Effect: "Fit To Be Tide", Effect Duration: 10
 1513	powdered narrow Knob Goblin learning pill	1		Effect: "Coldfinger", Effect Duration: 30
 1514	vaporized skewed Knob Goblin eyedrops	1		
-1515	distilled huge blinking Knob Goblin nasal spray	1		Effect: "Almost Cool", Effect Duration: 20
+1515	distilled blinking huge Knob Goblin nasal spray	1		Effect: "Almost Cool", Effect Duration: 20
 1516	KWE-brand transistor radio	0		
 1518	vampire heart	0		
 1519	Talisman of Bakula	0		Single Equip, Conditional Skill (Equipped): "Give In To Your Vampiric Urges"
@@ -1503,23 +1503,23 @@
 1522	skewed supercharged sinister Radio Free Jersey	0		Spell Damage: +10, Maximum MP Percent: +30
 1523	blurry bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	ghostly joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	yellow pulsating pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1525	ghostly joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1526	yellow pulsating pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
 1527	diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	reassuring Lo Pan's corkscrew	0		Spell Critical Percent: +30, Spooky Resistance: +1, Last Available: "2006-04"
 1529	St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	purple Sherlock's grass skirt	0		Item Drop: +25, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
-1532	grass hat of courage	0		Spooky Resistance: +3, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
+1531	purple Sherlock's grass skirt	0		Item Drop: +25, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
+1532	grass hat of courage	0		Spooky Resistance: +3, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
 1533	lightning-fast grass blade	0		Initiative: +40, Last Available: "2011-01"
 1534	tumbling raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	huge weegee sqouija	0		Last Available: "2011-12"
 1538	sparkly engagement ring of James Dean	0		Experience (Moxie): +3, Single Equip
 1539	Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	veiny Grimacite goggles of chilblains	0		Maximum HP: +10, Cold Damage: +25, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
+1540	veiny Grimacite goggles of chilblains	0		Maximum HP: +10, Cold Damage: +25, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
 1541	nippy boxer's Grimacite glaive	0		Muscle Percent: +10, Cold Damage: +10, Last Available: "2008-10"
-1542	Rosewater's Grimacite greaves of vim and vigor	0		Mysticality Percent: +30, Maximum HP Percent: +50, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
+1542	Rosewater's Grimacite greaves of vim and vigor	0		Mysticality Percent: +30, Maximum HP Percent: +50, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
 1543	Oprah's stylish Grimacite garter	0		Moxie: +25, Maximum MP Percent: +50, Last Available: "2008-10"
 1544	Van der Graaf Grimacite galoshes of the empath	0		Familiar Weight: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2008-10"
 1545	auspicious Grimacite gorget of bravery	0		Spooky Resistance: +5, Item Drop: +10, Last Available: "2008-10"
@@ -1528,21 +1528,21 @@
 1548	mirror twirling lard-coated studded Gazpacho's Glacial Grimoire	0		Damage Absorption: +80, Sleaze Spell Damage: +25
 1549	blinking red MSG	0		
 1550	nasty second-hand knockoff engagement ring	0		Stench Damage: +5, Single Equip
-1551	drinkable extra-dry bottle of Domesticated Turkey	5	good	
+1551	extra-dry drinkable bottle of Domesticated Turkey	5	good	
 1552	bad pulsating bottle of Definit	4	decent	
 1553	artisanal bottle of Calcutta Emerald	3	EPIC	
-1554	strong lousy bottle of Lieutenant Freeman	5	decent	
+1554	lousy strong bottle of Lieutenant Freeman	5	decent	
 1555	artisanal weak bottle of Jorge Sinsonte	2	EPIC	
-1556	tolerable high-proof boxed champagne	6	good	
+1556	high-proof tolerable boxed champagne	6	good	
 1557	spoiled kumquat	4	crappy	
 1558	decent tangerine	4	good	
 1559	tonic water	0		
-1560	normal low-calorie cocktail onion	1	good	
+1560	low-calorie normal cocktail onion	1	good	
 1561	rotten raspberry	4	crappy	
 1562	low-calorie flavorless jittery kiwi	1	decent	
 1563	bad huge whiskey bittersweet	4	decent	
 1564	weak acceptable mimosette	2	good	
-1565	mediocre red upside-down tequila sunset	4	decent	
+1565	mediocre upside-down red tequila sunset	4	decent	
 1566	mediocre zmobie	3	decent	Wiki Name: "Zmobie (drink)"
 1567	drinkable gin and tonic	3	good	
 1568	watered-down aged vodka and tonic	2	awesome	
@@ -1553,37 +1553,37 @@
 1573	bad caipifruta	3	decent	
 1574	tolerable teqiwila	3	good	
 1575	hand-crafted narrow Divine	3	EPIC	
-1576	drinkable practically non-alcoholic Gordon Bennett	1	good	
-1577	mediocre weak special tangarita	2	decent	Effect: "Stemonitis Storm", Effect Duration: 35
-1578	artisanal distilled mandarina colada	5	EPIC	
-1579	tolerable irresponsibly strong gimlet	6	good	
-1580	drinkable watered-down twirling brick road	2	good	
-1581	smooth distilled fancy vodka stratocaster	5	awesome	Effect: "Helping Comes Second", Effect Duration: 15
-1582	practically non-alcoholic artisanal mirror blurry Neuromancer	1	super ultra mega turbo EPIC	
+1576	practically non-alcoholic drinkable Gordon Bennett	1	good	
+1577	weak special mediocre tangarita	2	decent	Effect: "Stemonitis Storm", Effect Duration: 35
+1578	distilled artisanal mandarina colada	5	EPIC	
+1579	irresponsibly strong tolerable gimlet	6	good	
+1580	watered-down drinkable twirling brick road	2	good	
+1581	smooth fancy distilled vodka stratocaster	5	awesome	Effect: "Helping Comes Second", Effect Duration: 15
+1582	artisanal practically non-alcoholic blurry mirror Neuromancer	1	super ultra mega turbo EPIC	
 1583	drinkable tumbling prussian cathouse	3	good	
-1584	perfectly mixed fortified Mae West	5	EPIC	
+1584	fortified perfectly mixed Mae West	5	EPIC	
 1585	artisanal special Mon Tiki	3	EPIC	Effect: "Human-Elemental Hybrid", Effect Duration: 10
-1586	enchanted artisanal teqiwila slammer	3	EPIC	Effect: "Vital", Effect Duration: 40
-1587	normal fancy big twirling Knob lo mein	5	good	Effect: "Top Dog", Effect Duration: 40
+1586	artisanal enchanted teqiwila slammer	3	EPIC	Effect: "Vital", Effect Duration: 40
+1587	normal big fancy twirling Knob lo mein	5	good	Effect: "Top Dog", Effect Duration: 40
 1588	decent upside-down asparagus lo mein	4	good	
 1589	spoiled Knoll lo mein	3	crappy	
 1590	adequate lo mein	3	good	
 1591	flavorless olive lo mein	4	decent	
 1592	huge moldy hot hi mein	6	crappy	
-1593	bland bite-sized hi mein	1	decent	
-1594	spoiled snack-sized hi mein	2	crappy	
-1595	jumbo adequate hi mein	5	good	
-1596	enchanted adequate skewed red sleazy hi mein	4	good	Effect: "So Fresh and So Clean", Effect Duration: 50
+1593	bite-sized bland hi mein	1	decent	
+1594	snack-sized spoiled hi mein	2	crappy	
+1595	adequate jumbo hi mein	5	good	
+1596	adequate enchanted skewed red sleazy hi mein	4	good	Effect: "So Fresh and So Clean", Effect Duration: 50
 1597	resourceful Junior LAAAAME merit badge	0		Maximum MP: +50, Last Available: "2006-05"
 1598	double-paned Senior LAAAAME merit badge	0		Cold Resistance: +5, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
 1600	bad tangarita with a fly in it	3	decent	
-1601	perfectly mixed upside-down red mandarina colada with a fly in it	3	EPIC	
-1602	acceptable watered-down prussian cathouse with a fly in it	2	good	
+1601	perfectly mixed red upside-down mandarina colada with a fly in it	3	EPIC	
+1602	watered-down acceptable prussian cathouse with a fly in it	2	good	
 1603	fancy perfectly mixed Mae West with a fly in it	4	EPIC	Effect: "Black Lung", Effect Duration: 15
 1604	altered purple astronaut ice-cream	1		Effect: "Stregngth of the Gnome", Effect Duration: 5, Last Available: "2006-05"
 1605	blinking delectable catalyst	0		
-1606	dehydrated blurry mirror ultimate wad	1		
+1606	dehydrated mirror blurry ultimate wad	1		
 1607	non-energized wobbly libation of liveliness	0		Effect: "Hypercubed", Effect Duration: 28
 1608	double-alkaline irradiated eyedrops of the ermine	0		Effect: "Macho, Macho Dog", Effect Duration: 55
 1609	super-modified twirling perfume of prejudice	0		Effect: "Frosty the Hitman", Effect Duration: 34
@@ -1592,8 +1592,8 @@
 1612	modified alkaline skewed concentrated cordial of concentration	0		Effect: "Turkey-Friendly", Effect Duration: 14
 1613	shaking supercool coffin lid	0		Moxie Percent: +20, Damage Reduction: 3
 1614	greedy satin shield	0		Meat Drop: +20, Damage Reduction: 5
-1615	Cerebral Cloche of the ox	0		Muscle: +20, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
-1616	medical-grade Cerebral Culottes	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
+1615	Cerebral Cloche of the ox	0		Muscle: +20, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
+1616	medical-grade Cerebral Culottes	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
 1617	blue razor-sharp savvy Cerebral Crossbow of the brute	0		Muscle Percent: +30, Mysticality Percent: +20, Weapon Damage Percent: +25, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	munchies pill	0		Last Available: "2006-06"
@@ -1628,12 +1628,12 @@
 1648	sleazy and sauce	0		
 1649	brick	0		Free Pull
 1650	milk of magnesium	0		
-1651	bland gigantic foie gras	10	decent	
+1651	gigantic bland foie gras	10	decent	
 1652	diffused jittery candy brain	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 60, Last Available: "2020-09"
-1653	cyan dog trainer's smooth brainy jewel-eyed wizard hat	0		Mysticality: +5, Moxie: +15, Experience (familiar): +1, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
+1653	cyan dog trainer's smooth brainy jewel-eyed wizard hat	0		Mysticality: +5, Moxie: +15, Experience (familiar): +1, Softcore Only, Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07", Conditional Skill (Equipped): "Magic Missile"
 1654	purple MacGyver's smartaleck's wad of Crovacite	0		Moxie Percent: +30, Maximum MP: +100
 1655	deadly collar of the empath	0		Weapon Damage: +5, Familiar Weight: +5
-1656	squat fuchsia White Citadel Satisfaction Satchel	0		
+1656	fuchsia squat White Citadel Satisfaction Satchel	0		
 1657	onion shurikens	0		
 1658	jittery Cherry Cloaca Cola	0		
 1659	Diet Cloaca Cola	0		
@@ -1648,14 +1648,14 @@
 1668	star boomerang of mayonnaise	0		Sleaze Spell Damage: +50
 1669	pulsating flame-retardant star stiletto	0		Hot Resistance: +1
 1670	blue fraudwort	0		
-1671	skewed huge blue shysterweed	0		
+1671	blue skewed huge shysterweed	0		
 1672	swindleblossom	0		
 1673	knitted rock-hard grave robbing shovel	0		Damage Reduction: 5, Cold Resistance: +3
 1674	yellow friendly superhero mask	0		Familiar Weight: +3, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
 1675	ore	0		
 1676	styrofoam ore	0		
 1677	green bubblewrap ore	0		
-1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
+1678	pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
 1679	frightening MacGyver's sword	0		Maximum MP: +100, Spooky Damage: +5
 1680	horrifying staff of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Damage: +25
 1681	jittery bubblewrap sword of the sweet-tooth of the cheetah	0		Candy Drop: +100, Initiative: +60
@@ -1669,16 +1669,16 @@
 1689	miser's ribbon	0		Meat Drop: +10, Last Available: "2006-07"
 1690	tumbling inspector's discarded bottlecap of the dark arts	0		Spell Damage Percent: +100, Item Drop: +15, Familiar Effect: "atk, 1xFairy, cap 38"
 1691	gravedigger's Van der Graaf discarded torn-up glove	0		Spooky Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "stench atk, 0.5xPotato, cap 38"
-1692	wet pulsating twirling bouncing salamander slurry	0		Effect: "Pisces Rising", Effect Duration: 56
+1692	wet bouncing pulsating twirling salamander slurry	0		Effect: "Pisces Rising", Effect Duration: 56
 1693	concentrated lime green eyedrops of newt	0		Effect: "Square to be Hip", Effect Duration: 11
 1694	concentrated concentrated upside-down huge Frogade	0		Effect: "Sugar, Hello", Effect Duration: 56
 1695	ionized quadruple-irradiated spinning papotion of papower	0		Effect: "Jammin'", Effect Duration: 46
-1696	fancy bite-sized decent skewed royal jelly taco	1	good	Effect: "Blessing of Bulbazinalli", Effect Duration: 50
-1697	half-sized adequate tofu taco	2	good	
+1696	bite-sized decent fancy skewed royal jelly taco	1	good	Effect: "Blessing of Bulbazinalli", Effect Duration: 50
+1697	adequate half-sized tofu taco	2	good	
 1698	spoiled maroon jumping bean taco	3	crappy	
 1699	stale immense bouncing catgut taco	7	decent	
-1700	diet rotten upside-down goat cheese taco	1	crappy	
-1701	delicious fancy pr0n taco	3	awesome	Effect: "Papowerful", Effect Duration: 20
+1700	rotten diet upside-down goat cheese taco	1	crappy	
+1701	fancy delicious pr0n taco	3	awesome	Effect: "Papowerful", Effect Duration: 20
 1702	enhanced blurry alphabet gum	0		Effect: "Springy Fusilli", Effect Duration: 66
 1703	Comma Chameleon egg	0		Free Pull
 1704	upside-down shingle	0		
@@ -1744,13 +1744,13 @@
 1765	Spookyraven gallery key	0		
 1766	blinking Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
-1768	mirror shaking Gnomish toolbox	0		
-1769	flavorless special huge fricasseed brains	8	decent	Effect: "Feelin' Philosophical", Effect Duration: 5
+1768	shaking mirror Gnomish toolbox	0		
+1769	huge flavorless special fricasseed brains	8	decent	Effect: "Feelin' Philosophical", Effect Duration: 5
 1770	stale brains casserole	3	decent	
 1771	greasy butcherknife	0		Sleaze Spell Damage: +10
 1772	corn holder of James Dean	0		Experience (Moxie): +3
 1773	eggbeater of the storm	0		Maximum MP Percent: +40
-1774	irresponsibly strong hand-crafted bottle of popskull	9	EPIC	
+1774	hand-crafted irresponsibly strong bottle of popskull	9	EPIC	
 1775	Newton's dishrag	0		Experience (Mysticality): +3
 1776	normal low-calorie stale baguette	1	good	
 1777	mirror leftovers of indeterminate origin	0		
@@ -1768,7 +1768,7 @@
 1789	blinking Mob Penguin	0		
 1790	tolerable Ram's Face Lager	4	good	
 1791	olive ram horns	0		
-1792	shaking olive prompt supercharged groovy Travoltan trousers	0		Moxie Percent: +10, Maximum MP Percent: +30, Adventures: +3, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
+1792	shaking olive prompt supercharged groovy Travoltan trousers	0		Moxie Percent: +10, Maximum MP Percent: +30, Adventures: +3, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
 1793	spinning olive shellacked pool cue of the empath	0		Damage Reduction: 7, Familiar Weight: +5
 1794	nitrogenated ghostly handful of hand chalk	0		Effect: "Pisces Rising", Effect Duration: 69
 1795	squat pulsating Tesla Counterclockwise Watch	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
@@ -1794,7 +1794,7 @@
 1815	seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
-1818	ghostly blue tenth thoracic vertebra	0		
+1818	blue ghostly tenth thoracic vertebra	0		
 1819	eleventh thoracic vertebra	0		
 1820	spinning twelfth thoracic vertebra	0		
 1821	skewed first lumbar vertebra	0		
@@ -1846,7 +1846,7 @@
 1867	tumbling right clavicle	0		
 1868	left humerus	0		
 1869	right humerus	0		
-1870	skewed jittery left radius	0		
+1870	jittery skewed left radius	0		
 1871	squat right radius	0		
 1872	left ulna	0		
 1873	jittery right ulna	0		
@@ -1883,7 +1883,7 @@
 1904	tumbling coward's sinister 5-ball	0		Spell Damage: +10, Monster Level: -20
 1905	narrow olive greedy supercool 6-ball	0		Moxie Percent: +20, Meat Drop: +20
 1906	7-ball of temperance	0		Sleaze Resistance: +5
-1907	huge pulsating 8-ball	0		
+1907	pulsating huge 8-ball	0		
 1910	pulsating lion tamer's ruddy cool clockwork sword	0		Moxie: +5, Maximum HP Percent: +40, Experience (familiar): +2
 1911	ribald toasty electrified clockwork staff	0		Hot Damage: +5, Sleaze Damage: +10, MP Regen Min: 3, MP Regen Max: 5
 1912	arcane researcher's Fonzie's clockwork crossbow of incineration	0		Experience (Moxie): +1, Experience Percent (Mysticality): +10, Hot Spell Damage: +50
@@ -1901,7 +1901,7 @@
 1924	tattered wolf standard	0		
 1925	tattered snake standard	0		
 1926	purple KoL Con 3-D Glasses	0		Familiar Effect: "8xLep, 1xFairy, cap 2"
-1927	pulsating olive scary death orb	0		
+1927	olive pulsating scary death orb	0		
 1928	tuning fork	0		
 1929	skewed fuchsia quilted greaves	0		Damage Absorption: +40, Familiar Effect: "1xBarrr"
 1930	Van der Graaf brawny helmet	0		Muscle Percent: +20, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "0.5xPotato, 0.5xFairy"
@@ -1924,13 +1924,13 @@
 1947	reassuring smartaleck's worn tophat	0		Moxie Percent: +30, Spooky Resistance: +1, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	upside-down zippy Fonzie's tap shoes	0		Experience (Moxie): +1, Initiative: +20, Single Equip
 1949	normal Manetwich	3	good	
-1950	mirror wobbly red bottle of Vangoghbitussin	0		
+1950	wobbly red mirror bottle of Vangoghbitussin	0		
 1951	weak lousy bottle of Pinot Renoir	2	decent	
 1952	flavorless spinning desiccated apricot	3	decent	
 1953	hand-crafted flute of flat champagne	4	EPIC	
 1954	moldy small dehydrated caviar	2	crappy	
 1955	styrofoam peanuts	0		
-1956	artisanal high-proof snifter of thoroughly aged brandy	9	EPIC	
+1956	high-proof artisanal snifter of thoroughly aged brandy	9	EPIC	
 1957	huge quill pen	0		
 1958	inkwell	0		
 1959	skewed tattered scrap of paper	0		
@@ -1997,7 +1997,7 @@
 2020	moldy cherry pie	3	crappy	
 2021	normal tumbling strawberry pie	4	good	
 2022	flavorless lemon meringue pie	3	decent	
-2023	mirror spinning Genalen&trade; Bottle	1	crappy	
+2023	spinning mirror Genalen&trade; Bottle	1	crappy	
 2024	immense normal mixed wildflower greens	8	good	
 2025	spoiled handful of walnuts	3	crappy	
 2026	massive delicious bouncing nutty organic salad	10	awesome	
@@ -2020,15 +2020,15 @@
 2043	hemp net	0		
 2044	your father's MacGuffin diary	0		
 2045	adequate brain-meltingly-hot chicken wings	4	good	
-2046	snack-sized yummy frat brats	2	awesome	
-2047	miniature adequate knob ka-bobs	2	good	
+2046	yummy snack-sized frat brats	2	awesome	
+2047	adequate miniature knob ka-bobs	2	good	
 2049	watered-down artisanal tumbling can of Swiller	2	EPIC	
 2050	narrow broken wings	0		
 2051	sunken eyes	0		
 2052	blurry reassembled blackbird	0		
 2053	bust of Pallas	0		Familiar Weight: +5
 2054	market map	0		
-2055	jittery blue snake skin	0		
+2055	blue jittery snake skin	0		
 2056	concentrated maroon adder bladder	0		Effect: "You're High as a Crow, Marty", Effect Duration: 45
 2057	pension check	0		
 2058	olive picnic basket	0		
@@ -2036,7 +2036,7 @@
 2060	purple bouncing deadly sword of the storm	0		Weapon Damage: +5, Maximum MP Percent: +40
 2061	studded helmet	0		Damage Absorption: +80, Familiar Effect: "1xFairy, cap 40"
 2062	huge smelly studded shield	0		Damage Absorption: +80, Stench Spell Damage: +10, Damage Reduction: 10
-2063	half-sized flavorless blackberry	2	decent	
+2063	flavorless half-sized blackberry	2	decent	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	blinking greasy groovy kick-ass kicks	0		Moxie Percent: +10, Sleaze Spell Damage: +10, Single Equip
@@ -2090,7 +2090,7 @@
 2114	yo	0		Last Available: "2006-12"
 2115	strapping prehistoric spear	0		Muscle: +5, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	pulsating crafty quilted fire	0		Damage Absorption: +40, Maximum MP: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
+2117	pulsating crafty quilted fire	0		Damage Absorption: +40, Maximum MP: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
 2118	leaf tube	0		Last Available: "2006-12"
 2119	lit cigar	0		Last Available: "2011-12"
 2120	stylish Grateful Undead T-shirt	0		Moxie: +25
@@ -2137,13 +2137,13 @@
 2162	reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	olive sub-molecular interocitor	0		Last Available: "2011-12"
 2164	recursive spline reticulator	0		Last Available: "2011-12"
-2165	gray upside-down atomic vector plotter	0		Last Available: "2011-12"
+2165	upside-down gray atomic vector plotter	0		Last Available: "2011-12"
 2166	blinking ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	clever toy ray gun of Gandalf	0		Maximum MP: +20, Spell Critical Percent: +20, Last Available: "2006-12"
-2169	rock-hard educational toy space helmet	0		Experience: +1, Damage Reduction: 5, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
+2169	rock-hard educational toy space helmet	0		Experience: +1, Damage Reduction: 5, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
 2170	pulsating MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	greasy astronaut pants of the cheetah	0		Sleaze Spell Damage: +10, Initiative: +60, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
+2171	greasy astronaut pants of the cheetah	0		Sleaze Spell Damage: +10, Initiative: +60, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
 2172	red toy jet pack of the blizzard	0		Cold Spell Damage: +25, Last Available: "2006-12"
 2173	squat triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2161,47 +2161,47 @@
 2186	unlit birthday cake	0		
 2187	lit birthday cake	0		
 2188	spinning flask of peppermint oil	1	good	Last Available: "2006-12"
-2189	watered-down tolerable tumbling flask of peppermint schnapps	2	good	Last Available: "2006-12"
+2189	tolerable watered-down tumbling flask of peppermint schnapps	2	good	Last Available: "2006-12"
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	massive normal bouncing candy stake	8	good	Last Available: "2006-12"
-2194	hand-crafted weak eggnog	2	EPIC	Last Available: "2006-12"
-2195	jumbo fancy bland unspeakable fruitcake	5	decent	Effect: "Ogred and Oublietted", Effect Duration: 30, Last Available: "2006-12"
+2193	normal massive bouncing candy stake	8	good	Last Available: "2006-12"
+2194	weak hand-crafted eggnog	2	EPIC	Last Available: "2006-12"
+2195	jumbo bland fancy unspeakable fruitcake	5	decent	Effect: "Ogred and Oublietted", Effect Duration: 30, Last Available: "2006-12"
 2196	spoiled teal gingerbread horror	4	crappy	Last Available: "2006-12"
 2197	cold-filtered but probably evil chocolate	0		Effect: "Night of the Nachos", Effect Duration: 27, Last Available: "2006-12"
 2198	flavorless spinning bat-shaped Crimboween cookie	3	decent	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	yummy skull-shaped Crimboween cookie	4	awesome	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
-2200	small adequate tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
+2200	adequate small tombstone-shaped Crimboween cookie	2	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	studded plastic gift-wrapping vampire	0		Damage Absorption: +80, Last Available: "2006-12"
 2202	censurious plastic yuletide troll	0		Sleaze Resistance: +3, Last Available: "2006-12"
 2203	narrow rosewater-soaked plastic skeletal reindeer	0		Stench Resistance: +3, Single Equip, Last Available: "2006-12"
 2204	lard-coated plastic Crimboween pentagram	0		Sleaze Spell Damage: +25, Single Equip, Last Available: "2006-12"
 2205	plastic Scream Queen of the early riser	0		Adventures: +7, Last Available: "2006-12"
-2206	ghostly jittery time sleigh	0		Free Pull, Last Available: "2006-12"
+2206	jittery ghostly time sleigh	0		Free Pull, Last Available: "2006-12"
 2207	scorching Crimbo tiki necklace	0		Hot Damage: +25, Last Available: "2006-12"
 2208	blurry knitted flame-wreathed bobble-hip hula elf doll	0		Hot Spell Damage: +10, Cold Resistance: +3, Last Available: "2006-12"
 2209	dangerous Crimbo ukulele	0		Weapon Damage: +10, Last Available: "2006-12"
-2210	double-paned educational Tiki lighter	0		Experience: +1, Cold Resistance: +5, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	banded deck of tropical cards of the pedagogue	0		Experience: +3, Damage Absorption: +100, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	pulsating green cool weightlifter's tropical paperweight	0		Muscle: +15, Moxie: +5, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	double-paned educational Tiki lighter	0		Experience: +1, Cold Resistance: +5, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	banded deck of tropical cards of the pedagogue	0		Experience: +3, Damage Absorption: +100, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	pulsating green cool weightlifter's tropical paperweight	0		Muscle: +15, Moxie: +5, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	electrified Tropical Crimbo Hat	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
-2216	wobbly Tropical Crimbo Shorts of Gandalf	0		Spell Critical Percent: +20, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
+2215	electrified Tropical Crimbo Hat	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
+2216	wobbly Tropical Crimbo Shorts of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
 2217	rotten mirror super ka-bob	3	crappy	
 2218	moldy upside-down beer basted brat	3	crappy	
 2219	supercharged Tropical Crimbo Sword	0		Maximum MP Percent: +30, Last Available: "2006-12"
 2220	polymerized tumbling bouncing and Crimboween candy	0		Effect: "Tiki Thoughtfulness", Effect Duration: 37, Last Available: "2020-09"
 2221	tumbling Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	wicked liar's pants of the cheetah	0		Spell Damage: +5, Initiative: +60, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
+2222	wicked liar's pants of the cheetah	0		Spell Damage: +5, Initiative: +60, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
 2223	twirling family-friendly brainy juggler's balls	0		Mysticality: +5, Sleaze Resistance: +1, Softcore Only, Last Available: "2007-01"
 2224	jittery Herculean pink shirt	0		Experience (Muscle): +1, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
 2226	blinking flame-retardant evil eyeball pendant of the scaredy-cat	0		Monster Level: -15, Hot Resistance: +1, Single Equip, Softcore Only, Last Available: "2007-01"
 2227	pressed modified arse-a'fire elixir	0		Effect: "Gyromitra Gymnastics", Effect Duration: 31, Last Available: "2007-01"
 2228	dry maroon cosmic lemonade	0		Effect: "Red Misty-Eyed", Effect Duration: 36, Last Available: "2007-01"
-2229	galvanized pickled cyan bouncing toad horn	0		Effect: "Gutterminded", Effect Duration: 57, Last Available: "2007-01"
+2229	galvanized pickled bouncing cyan toad horn	0		Effect: "Gutterminded", Effect Duration: 57, Last Available: "2007-01"
 2230	icicle katana	0		Familiar Weight: +5
 2231	mote	0		
 2232	smudged alchemical recipe	0		
@@ -2236,17 +2236,17 @@
 2262	bird rib	0		
 2263	lion oil	0		
 2264	adequate low-calorie stunt nuts	1	good	
-2265	decent small wet stew	2	good	
+2265	small decent wet stew	2	good	
 2266	wobbly wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	wobbly personal trainer's Staff of Fats	0		Experience Percent (Muscle): +10
 2269	rotten sausage wonton	4	crappy	
 2270	lightning-fast foul-smelling belt	0		Stench Damage: +10, Initiative: +40, Single Equip
-2271	strong drinkable ghostly gray bottle of Merlot	5	good	
-2272	enchanted watered-down drinkable bottle of Port	2	good	Effect: "Warm Belly", Effect Duration: 15
+2271	drinkable strong gray ghostly bottle of Merlot	5	good	
+2272	drinkable watered-down enchanted bottle of Port	2	good	Effect: "Warm Belly", Effect Duration: 15
 2273	hand-crafted bottle of Pinot Noir	3	EPIC	
 2274	mediocre boozy blinking bottle of Zinfandel	5	decent	
-2275	triple-distilled special mediocre ghostly bottle of Marsala	9	decent	Effect: "Mer-kinny Flavor", Effect Duration: 25
+2275	special mediocre triple-distilled ghostly bottle of Marsala	9	decent	Effect: "Mer-kinny Flavor", Effect Duration: 25
 2276	drinkable maroon bottle of Muscat	4	good	
 2277	Fernswarthy's key	0		
 2278	spinning Fernswarthy's letter	0		
@@ -2275,7 +2275,7 @@
 2301	Chomsky's comic books	0		
 2302	pulsating worm-riding hooks	0		
 2303	Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
-2304	ionized improved purple tumbling candy heart	0		Effect: "Bandersnatched", Effect Duration: 43, Last Available: "2007-02"
+2304	ionized improved tumbling purple candy heart	0		Effect: "Bandersnatched", Effect Duration: 43, Last Available: "2007-02"
 2305	unsweetened pressed pink candy heart	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 36, Last Available: "2007-02"
 2306	activated candy heart	0		Effect: "Human-Horror Hybrid", Effect Duration: 17, Last Available: "2007-02"
 2307	adjusted red candy heart	0		Effect: "Salad Days", Effect Duration: 52, Last Available: "2007-02"
@@ -2303,18 +2303,18 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	pulsating bouquet of circular saw blades	0		
-2332	rotten super-sized twirling Better Than Cuddling Cake	5	crappy	
+2332	super-sized rotten twirling Better Than Cuddling Cake	5	crappy	
 2333	ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	rubber WWBBDD? bracelet	0		
 2336	squat friendly crafty pipe	0		Maximum MP: +10, Familiar Weight: +3
 2337	lime green rosy-cheeked reinforced beaded headband	0		Maximum HP Percent: +30, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	special adequate pudding	3	good	Effect: "Souper Vengeful", Effect Duration: 5, Wiki Name: "black pudding (food)"
+2338	adequate special pudding	3	good	Effect: "Souper Vengeful", Effect Duration: 5, Wiki Name: "black pudding (food)"
 2339	watered-down perfectly mixed Blackfly Chardonnay	2	EPIC	
 2340	delicious & tan	3	awesome	
 2341	pepper	0		
 2342	delicious forest cake	4	awesome	
-2343	moldy snack-sized forest ham	2	crappy	
+2343	snack-sized moldy forest ham	2	crappy	
 2344	warmed filthworm hatchling scent gland	0		Effect: "Spooky Blur", Effect Duration: 45
 2345	vacuum-sealed filthworm drone scent gland	0		Effect: "Truly Gritty", Effect Duration: 42
 2346	super-denatured deionized non-deionized filthworm royal guard scent gland	0		Effect: "Meatwise", Effect Duration: 55
@@ -2325,7 +2325,7 @@
 2351	superamplified boom box	0		
 2352	cyan Sherlock's wholesome fire poi	0		Maximum HP Percent: +10, Item Drop: +25
 2353	red chilly bejeweled pledge pin	0		Cold Damage: +5, Single Equip
-2354	skewed bouncing communications windchimes	0		
+2354	bouncing skewed communications windchimes	0		
 2355	irradiated cold-filtered blurry henna face paint	0		Effect: "Triangle, Man", Effect Duration: 43
 2356	triple-ionized flattened tube of dread wax	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 57
 2357	upside-down teal lard-coated Oprah's Gaia beads	0		Maximum MP Percent: +50, Sleaze Spell Damage: +25
@@ -2347,9 +2347,9 @@
 2373	spoiled half-sized banana	2	crappy	
 2374	banana peel	0		
 2375	flavorless massive banana cream pie	9	decent	
-2376	practically non-alcoholic lousy banana daiquiri	1	decent	
+2376	lousy practically non-alcoholic banana daiquiri	1	decent	
 2377	smooth bungle in the jungle	3	awesome	
-2378	wobbly pulsating banana spritzer	0		
+2378	pulsating wobbly banana spritzer	0		
 2379	frozen squat jittery banana smoothie	0		Effect: "Thick-Skinned", Effect Duration: 55
 2380	upside-down dandy lion cub	0		Free Pull, Last Available: "2007-03"
 2381	blurry woolen cravat	0		Familiar Weight: +5, Last Available: "2007-03"
@@ -2383,7 +2383,7 @@
 2409	billy idol	0		
 2410	rag	0		
 2411	broken petri dish	0		
-2412	pulsating jittery sammich crust	0		
+2412	jittery pulsating sammich crust	0		
 2413	triffid bark	0		
 2414	lint	0		
 2415	mirror discarded pacifier	0		
@@ -2397,16 +2397,16 @@
 2423	unsweetened pulsating Mick's IcyVapoHotness Inhaler	0		Effect: "Buff as a Baobab", Effect Duration: 18
 2424	concentrated energized cyclops eyedrops	0		Effect: "Healthy Green Glow", Effect Duration: 39
 2425	enhanced denatured can of spinach	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 46
-2426	electrified quadruple-unsweetened jittery olive fire flower	0		Effect: "Nightlit", Effect Duration: 21
+2426	electrified quadruple-unsweetened olive jittery fire flower	0		Effect: "Nightlit", Effect Duration: 21
 2427	electrified vacuum-sealed corrupted narrow huge freezerburned ice cube	0		Effect: "Slime Time", Effect Duration: 42
-2428	cold-filtered cold-filtered moist tumbling blue blurry fake blood	0		Effect: "Superioreo", Effect Duration: 29
+2428	cold-filtered cold-filtered moist blue tumbling blurry fake blood	0		Effect: "Superioreo", Effect Duration: 29
 2429	nitrogenated upside-down Eau de Guaneau	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 65
 2430	warmed upside-down bag of lard	0		Effect: "Jelly Combed", Effect Duration: 53
 2431	unsweetened dry bottle of Mystic Shell	0		Effect: "Heart of White", Effect Duration: 20
 2432	alkaline ionized SPF 451 lip balm	0		Effect: "Squid Squint", Effect Duration: 52
 2433	flattened wet blurry bottle of antifreeze	0		Effect: "Flaming Weapon", Effect Duration: 45
 2434	adjusted galvanized eyedrops	0		Effect: "Pisces in the Skyces", Effect Duration: 54
-2435	triple-frozen mirror pulsating spinning Dogsgotnonoz pills	0		Effect: "Space Cowboy", Effect Duration: 21
+2435	triple-frozen pulsating mirror spinning Dogsgotnonoz pills	0		Effect: "Space Cowboy", Effect Duration: 21
 2436	adjusted quantum upside-down mirror donkey flipbook	0		Effect: "Concentrated Concentration", Effect Duration: 19
 2437	New Cloaca-Cola	0		
 2438	tumbling scented massage oil	0		
@@ -2421,7 +2421,7 @@
 2447	bad penguin egg	0		Free Pull
 2448	tasteful bow tie	0		Familiar Weight: +5
 2449	six-pack of New Cloaca-Cola	0		
-2450	tumbling squat empty Cloaca-Cola bottle	0		
+2450	squat tumbling empty Cloaca-Cola bottle	0		
 2451	Rosewater's goatskin umbrella	0		Mysticality Percent: +30
 2452	wicked personal trainer's wool hat	0		Experience Percent (Muscle): +10, Spell Damage: +5, Familiar Effect: "1xLep, cap 43"
 2453	Goodfella contract	0		Last Available: "2011-12"
@@ -2491,19 +2491,19 @@
 2518	pulsating sawblade shield of vim and vigor	0		Maximum HP Percent: +50, Damage Reduction: 11
 2519	acceptable wobbly McMillicancuddy's Special Lager	3	good	
 2520	drinkable weak melted Jell-o shot	2	good	
-2521	smooth boozy cruelty-free wine	5	awesome	
+2521	boozy smooth cruelty-free wine	5	awesome	
 2522	hand-crafted spinning thistle wine	3	EPIC	
 2523	megatofu	0		
-2524	shaking ghostly displaced fish	0		
-2525	small rotten fish	2	crappy	
+2524	ghostly shaking displaced fish	0		
+2525	rotten small fish	2	crappy	
 2526	spoiled fish casserole	3	crappy	
 2527	spoiled fish lasagna	3	crappy	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	decent super-sized gnatloaf	5	good	
 2530	decent upside-down gnatloaf casserole	3	good	
-2531	huge delicious lime green gnat lasagna	6	awesome	
+2531	delicious huge lime green gnat lasagna	6	awesome	
 2532	pork	0		
-2533	moldy huge tumbling pork chop sandwiches	9	crappy	
+2533	huge moldy tumbling pork chop sandwiches	9	crappy	
 2534	bite-sized delicious pork casserole	1	awesome	
 2535	normal pork lasagna	3	good	
 2536	canopic jar	0		
@@ -2518,7 +2518,7 @@
 2545	wet aerosolized upsy daisy	0		Effect: "Human-Elemental Hybrid", Effect Duration: 61, Last Available: "2007-05"
 2546	improved tumbling half-orchid	0		Effect: "Frog In Your Throat", Effect Duration: 52, Last Available: "2007-05"
 2547	pulsating jittery stiffened razor-sharp tin star	0		Weapon Damage Percent: +25, Damage Reduction: 1, Last Available: "2007-05"
-2548	huge flame-wreathed Oprah's outrageous sombrero	0		Maximum MP Percent: +50, Hot Spell Damage: +10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+2548	huge flame-wreathed Oprah's outrageous sombrero	0		Maximum MP Percent: +50, Hot Spell Damage: +10, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
 2549	smooth beefy &quot;Humorous&quot; T-shirt	0		Muscle: +10, Moxie: +15, Last Available: "2007-05"
 2550	fuchsia narrow Peppercorns of Power	0		
 2551	squat vial of mojo	0		
@@ -2553,13 +2553,13 @@
 2580	shaking aromatic arcane researcher's scorpion whip	0		Experience Percent (Mysticality): +10, Stench Resistance: +1
 2581	handful of sand	0		
 2582	brick of sand	0		
-2583	bland special tumbling cyan blinking centipede eggs	3	decent	Effect: "Chow Downed", Effect Duration: 5
+2583	bland special cyan tumbling blinking centipede eggs	3	decent	Effect: "Chow Downed", Effect Duration: 5
 2584	ghostly red dance instructor's wonderwall shield	0		Experience Percent (Moxie): +10, Damage Reduction: 12
 2585	huge mirror energetic Colonel Mustard's Lonely Spades Club Jacket	0		Maximum MP Percent: +20
 2586	tumbling purple educational General Sage's Lonely Diamonds Club Jacket	0		Experience: +1
 2587	yellow sizzling Corporal Fennel's Lonely Clubs Club Jacket	0		Hot Damage: +10
 2588	maroon miser's Private Pepper's Lonely Hearts Club Jacket	0		Meat Drop: +10
-2589	massive moldy hot date	7	crappy	
+2589	moldy massive hot date	7	crappy	
 2590	hand-crafted distilled fortified wine	4	EPIC	
 2591	normal fancy tasty tart	3	good	Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 40
 2592	blinking Knob Goblin lunchbox	0		
@@ -2576,7 +2576,7 @@
 2603	smoldering box	0		
 2604	pulsating spinning therapeutic Tuesday's ruby	0		HP Regen Min: 5, HP Regen Max: 7
 2605	tumbling palm frond	0		
-2606	ghostly squat palm-frond fan	0		
+2606	squat ghostly palm-frond fan	0		
 2607	friendly palm-frond whip	0		Familiar Weight: +3
 2608	upside-down palm-frond net	0		
 2609	Lo Pan's palm-frond capris of the detective	0		Spell Critical Percent: +30, Item Drop: +20, Familiar Effect: "1.5xGhuol, cap 35"
@@ -2605,7 +2605,7 @@
 2632	nitrogenated blinking pulsating mother's helper	0		Effect: "Woad Warrior", Effect Duration: 18
 2633	shellacked Herculean pat-a-cake pendant	0		Experience (Muscle): +1, Damage Reduction: 7
 2634	mummy wrapping	0		
-2635	mirror upside-down really thick bandage	0		
+2635	upside-down mirror really thick bandage	0		
 2636	red mummy mask of the scaredy-cat	0		Monster Level: -15, Familiar Effect: "1xBarrr, 1xFairy, cap 42"
 2637	smelly shellacked gauze shorts	0		Damage Reduction: 7, Stench Spell Damage: +10, Familiar Effect: "1xBarrr, 1xGhuol, cap 42"
 2638	shaking gauze hammock	0		
@@ -2624,16 +2624,16 @@
 2651	shaking pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
 2652	stale jumbo blurry S.T.L.T.	5	decent	Last Available: "2007-06"
 2653	flavorless honey-dew	4	decent	Last Available: "2007-06"
-2654	fortified perfectly mixed Xanadian	5	EPIC	Last Available: "2007-06"
+2654	perfectly mixed fortified Xanadian	5	EPIC	Last Available: "2007-06"
 2655	pickled upside-down bottle of absinthe	0		Effect: "Egg Burps", Effect Duration: 61, Last Available: "2007-06"
 2656	zippy friendly Drowsy Sword	0		Familiar Weight: +3, Initiative: +20
 2657	normal escargotsicle	3	good	Last Available: "2007-06"
-2658	weak artisanal bottle of realpagne	2	EPIC	Last Available: "2007-06"
+2658	artisanal weak bottle of realpagne	2	EPIC	Last Available: "2007-06"
 2659	albatross necklace of the businessman	0		Meat Drop: +50, Single Equip, Last Available: "2007-06"
 2660	compressed blinking not-a-pipe	1	EPIC	Last Available: "2007-06"
-2661	triple-distilled hand-crafted ghostly flask of Amontillado	9	EPIC	Last Available: "2007-06"
-2662	dog trainer's ball mask	0		Experience (familiar): +1, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
-2663	upside-down dog trainer's Can-Can skirt	0		Experience (familiar): +1, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
+2661	hand-crafted triple-distilled ghostly flask of Amontillado	9	EPIC	Last Available: "2007-06"
+2662	dog trainer's ball mask	0		Experience (familiar): +1, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
+2663	upside-down dog trainer's Can-Can skirt	0		Experience (familiar): +1, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
 2664	polarized polarized gray sensitive poetry journal	0		Effect: "Okee-Dokee Go!", Effect Duration: 11, Last Available: "2007-06"
 2665	alkaline diffused bottled inspiration	0		Effect: "Gummiheart", Effect Duration: 59, Last Available: "2007-06"
 2666	extra-corrupted cold-filtered nitrogenated bellhop bell	0		Effect: "Coldfinger", Effect Duration: 54, Last Available: "2007-06"
@@ -2644,9 +2644,9 @@
 2671	artisanal shot of nepenthe schnapps	3	EPIC	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	blue squat Bohemian rhapsody	0		Last Available: "2007-06"
-2674	vacuum-sealed narrow olive bottle of cat tonic	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 34, Last Available: "2007-06"
-2675	vaporized shaking ghostly handful of moss	1		
-2676	compressed narrow skewed upside-down bit-o-cactus	1		Effect: "Morninja", Effect Duration: 30
+2674	vacuum-sealed olive narrow bottle of cat tonic	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 34, Last Available: "2007-06"
+2675	vaporized ghostly shaking handful of moss	1		
+2676	compressed upside-down skewed narrow bit-o-cactus	1		Effect: "Morninja", Effect Duration: 30
 2677	altered protein powder	1		
 2678	tumbling spectre scepter	0		
 2679	dry deionized fuchsia twirling sparkler	0		Effect: "Egg-headedness", Effect Duration: 39
@@ -2674,7 +2674,7 @@
 2701	teal gravedigger's savvy duct tape sword	0		Mysticality Percent: +20, Spooky Damage: +10
 2702	ghostly Van der Graaf banded duct tape dockers	0		Damage Absorption: +100, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, 1xGhuol, cap 48"
 2703	cyan Socratic duct tape buckler	0		Experience (Mysticality): +1, Damage Reduction: 12
-2704	mirror lime green shrinking powder	0		
+2704	lime green mirror shrinking powder	0		
 2705	avaricious beefy blackberry slippers of Calamity Jane	0		Muscle: +10, Critical Hit Percent: +15, Meat Drop: +30, Single Equip
 2706	Tesla stiffened blackberry moccasins of the storm	0		Damage Reduction: 1, Maximum MP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 2707	jittery Jim Carey's padded dangerous blackberry combat boots	0		Weapon Damage: +10, Damage Absorption: +20, Monster Level: +25, Single Equip
@@ -2694,15 +2694,15 @@
 2721	reassuring chilly hand-carved staff of the brute	0		Muscle Percent: +30, Cold Damage: +5, Spooky Resistance: +1
 2722	blinking squat reassuring veiny wicked smartaleck's Staff of the Greasefire	0		Moxie Percent: +30, Spell Damage: +5, Maximum HP: +10, Spooky Resistance: +1
 2723	olive gravedigger's Jack Frost's Staff of the Grand Flamb&eacute; of mayonnaise	0		Cold Spell Damage: +50, Spooky Damage: +10, Sleaze Spell Damage: +50
-2724	spoiled big bowl of rye sprouts	5	crappy	
+2724	big spoiled bowl of rye sprouts	5	crappy	
 2725	tasty cob of corn	3	awesome	
 2726	big rotten maroon juniper berries	5	crappy	
 2727	normal plum	4	good	
-2728	super-sized flavorless pear	5	decent	
+2728	flavorless super-sized pear	5	decent	
 2729	spoiled peach	4	crappy	
-2730	perfectly mixed practically non-alcoholic plum wine	1	EPIC	
-2731	bad irresponsibly strong shot of pear schnapps	10	decent	
-2732	weak mediocre shot of peach schnapps	2	decent	
+2730	practically non-alcoholic perfectly mixed plum wine	1	EPIC	
+2731	irresponsibly strong bad shot of pear schnapps	10	decent	
+2732	mediocre weak shot of peach schnapps	2	decent	
 2733	flavorless bunch of square grapes	4	decent	
 2734	spoiled jumbo bouncing brown sugar cane	5	crappy	
 2735	small moldy sandwich of the gods	2	crappy	
@@ -2711,7 +2711,7 @@
 2738	mirror tumbling pile of smoking rags	0		
 2739	enhanced ionized skewed panty raider camouflage	0		Effect: "Abyssal Blood", Effect Duration: 64
 2740	slick cool wizardly Staff of the Walk-In Freezer	0		Mysticality: +25, Moxie: 15
-2741	watered-down artisanal squat boilermaker	2	EPIC	
+2741	artisanal watered-down squat boilermaker	2	EPIC	
 2742	rotten steel lasagna	4	quest	
 2743	acceptable steel margarita	4	quest	
 2744	boiled steel-scented air freshener	1		Effect: "Pie in the Sky", Effect Duration: 40
@@ -2738,7 +2738,7 @@
 2765	Harold's bell	0		
 2766	bowling ball	0		
 2767	snack-sized normal Crimbo pie	2	good	
-2768	tasty low-calorie fancy pear tart	1	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 45
+2768	low-calorie tasty fancy pear tart	1	awesome	Effect: "Curse of the Black Pearl Onion", Effect Duration: 45
 2769	tasty peach pie	3	awesome	
 2770	frozen magnetized yellow chunk of rock salt	0		Effect: "Supafly", Effect Duration: 45
 2771	corrupted chilled ghostly handful of pine needles	0		Effect: "Colorful Gratitude", Effect Duration: 24
@@ -2771,15 +2771,15 @@
 2798	toasty arcane researcher's Mudflap-Girl Earring	0		Experience Percent (Mysticality): +10, Hot Damage: +5, Single Equip
 2799	studded padded Mudflap-Girl Necklace	0		Damage Absorption: 100, Single Equip
 2800	medical-grade healthy Mudflap-Girl Ring	0		Maximum HP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip
-2801	blinking bouncing vial of Gnomochloric acid	0		
+2801	bouncing blinking vial of Gnomochloric acid	0		
 2802	spinning flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	deionized unsweetened super-anodized vial of hamethyst juice	0		Effect: "Wet and Greedy", Effect Duration: 45
-2805	Vulcanized energized bouncing blurry vial of baconstone juice	0		Effect: "Cookie Backup", Effect Duration: 56
+2805	Vulcanized energized blurry bouncing vial of baconstone juice	0		Effect: "Cookie Backup", Effect Duration: 56
 2806	activated electrified vial of porquoise juice	0		Effect: "Ass Over Teakettle", Effect Duration: 13
 2807	triple-Vulcanized flask of hamethyst juice	0		Effect: "You Read The Manual", Effect Duration: 26
 2808	vacuum-sealed electrified flask of baconstone juice	0		Effect: "Nightstalkin'", Effect Duration: 39
-2809	non-nitrogenated non-quantum bouncing olive blurry flask of porquoise juice	0		Effect: "Perception", Effect Duration: 57
+2809	non-nitrogenated non-quantum blurry bouncing olive flask of porquoise juice	0		Effect: "Perception", Effect Duration: 57
 2810	cold-filtered dry shaking jug of hamethyst juice	0		Effect: "Inner Warmth", Effect Duration: 45
 2811	alkaline blurry wobbly jug of baconstone juice	0		Effect: "Chalk Outline", Effect Duration: 18
 2812	irradiated tarnished green jug of porquoise juice	0		Effect: "Executive Greed", Effect Duration: 36
@@ -2789,9 +2789,9 @@
 2816	dog trainer's extremely unsafe Boxers of the sewer	0		Weapon Damage Percent: +100, Experience (familiar): +1, Stench Damage: +25, Familiar Effect: "1xVolley, 1xLep"
 2817	experienced groovy Brooch of the overflowing toilet	0		Moxie Percent: +10, Experience: +2, Stench Spell Damage: +50, Single Equip
 2818	squat tumbling toasty banded thinker's Bracelet	0		Mysticality: +10, Damage Absorption: +100, Hot Damage: +5, Single Equip
-2819	curative Grimacite gasmask of the sewer	0		Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
+2819	curative Grimacite gasmask of the sewer	0		Stench Damage: +25, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
 2820	weightlifter's Grimacite gat of the overflowing toilet	0		Muscle: +15, Stench Spell Damage: +50, Last Available: "2008-11"
-2821	sinister Sinatra's Grimacite gaiters	0		Experience (Moxie): +5, Spell Damage: +10, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
+2821	sinister Sinatra's Grimacite gaiters	0		Experience (Moxie): +5, Spell Damage: +10, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
 2822	mirror MacGyver's razor-sharp Grimacite gauntlets	0		Weapon Damage Percent: +25, Maximum MP: +100, Single Equip, Last Available: "2008-11"
 2823	fuchsia beefcake's Grimacite go-go boots of Flo-Jo	0		Muscle: +25, Initiative: +100, Single Equip, Last Available: "2008-11"
 2824	ghostly narrow manspreader's curative Grimacite girdle	0		Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2008-11"
@@ -2804,13 +2804,13 @@
 2831	star key lime	0		
 2832	toothsome bite-sized digital key lime pie	1	awesome	
 2833	moldy spinning star key lime pie	3	crappy	
-2834	manspreader's cool strapping bottle-rocket crossbow	0		Muscle: +5, Moxie: +5, Monster Level: +10, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
+2834	manspreader's cool strapping bottle-rocket crossbow	0		Muscle: +5, Moxie: +5, Monster Level: +10, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
 2835	beefcake's indie comic hipster glasses	0		Muscle: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
 2837	mint-condition magic wand	0		Last Available: "2011-12"
 2838	blue shaking twirling up-at-dawn ruddy glowstick	0		Maximum HP Percent: +40, Adventures: +5, Last Available: "2007-08"
 2839	skewed sharpshooter's Periodical Paintbrush	0		Critical Hit Percent: +10, Softcore Only
-2840	mediocre fortified bottle of cooking sherry	5	decent	
+2840	fortified mediocre bottle of cooking sherry	5	decent	
 2841	normal packet of ketchup	3	good	
 2842	delicious watered-down accidental cider	2	awesome	
 2843	decent purple dire fudgesicle	3	good	
@@ -2915,7 +2915,7 @@
 2942	pressed flattened chocolate filthy lucre	0		Effect: "Pyromania", Effect Duration: 66
 2943	non-flattened wobbly Angry Farmer's Wife Candy	0		Effect: "Hare-o-dynamic", Effect Duration: 60
 2945	toasty party hat of terror	0		Hot Damage: +5, Spooky Spell Damage: +10, Familiar Effect: "4xLep, cap 7"
-2946	stanky friendly V for Vivala mask	0		Familiar Weight: +3, Stench Spell Damage: +25, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
+2946	stanky friendly V for Vivala mask	0		Familiar Weight: +3, Stench Spell Damage: +25, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
 2947	skewed The Big Book of Pirate Insults	0		
 2948	lousy shot of rotgut	4	decent	
 2949	double-frozen energized adjusted spinning jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Reptilian Fortitude", Effect Duration: 50
@@ -2929,7 +2929,7 @@
 2957	rum barrel charrrm	0		
 2958	spoiled squat tube of cranberry Go-Goo	4	crappy	
 2959	censurious rum barrel charrrm bracelet	0		Sleaze Resistance: +3
-2960	normal massive single-serving herbal stuffing	6	good	
+2960	massive normal single-serving herbal stuffing	6	good	
 2961	decent packet of tofurkey gravy	3	good	
 2962	delicious upside-down tofurkey nugget	4	awesome	
 2963	rigging shampoo	0		
@@ -2941,7 +2941,7 @@
 2969	flavorless fancy creamsicle	3	decent	Effect: "Polka Face", Effect Duration: 30
 2970	delicious cream stout	4	awesome	
 2971	steel-toed Sinatra's curmudgel	0		Experience (Moxie): +5, Damage Reduction: 9
-2972	wobbly green grumpy man charrrm	0		
+2972	green wobbly grumpy man charrrm	0		
 2973	shaking mirror rosy-cheeked grumpy man charrrm bracelet	0		Maximum HP Percent: +30, Single Equip
 2974	tarrrnish charrrm	0		
 2975	censurious careful tarrrnished charrrm bracelet	0		Monster Level: -10, Sleaze Resistance: +3, Single Equip
@@ -2995,13 +2995,13 @@
 3023	small stone triangle	0		
 3024	stone pyramid	0		
 3025	tolerable olive corpse on the beach	4	good	
-3026	artisanal high-proof corpsetini	8	EPIC	
+3026	high-proof artisanal corpsetini	8	EPIC	
 3027	delicious corpsedriver	4	awesome	
 3028	fancy boozy drinkable Corpse Island iced tea	5	good	Effect: "Empathy", Effect Duration: 35
 3029	practically non-alcoholic hand-crafted blinking red-headed corpse	1	super EPIC	
 3030	acceptable kamicorpse-ee	3	good	
 3031	bad practically non-alcoholic narrow corpsel	1	decent	
-3032	mediocre weak corpsebite	2	decent	
+3032	weak mediocre corpsebite	2	decent	
 3033	squat brainy pirate fledges	0		Mysticality: +5
 3034	skewed piece of thirteen	0		
 3035	decent big shaking pearl onion	5	good	
@@ -3013,9 +3013,9 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	upside-down metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	shaking metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
-3045	small bland spinning nanite-infested gingerbread bugbear	2	decent	Last Available: "2007-12"
-3046	adequate snack-sized nanite-infested candy cane	2	good	Last Available: "2020-09"
+3044	shaking metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
+3045	bland small spinning nanite-infested gingerbread bugbear	2	decent	Last Available: "2007-12"
+3046	snack-sized adequate nanite-infested candy cane	2	good	Last Available: "2020-09"
 3047	rotten big nanite-infested fruitcake	5	crappy	Last Available: "2007-12"
 3048	drinkable bouncing nanite-infested eggnog	3	good	Last Available: "2007-12"
 3049	mirror El Vibrato power sphere	0		
@@ -3025,7 +3025,7 @@
 3053	huge mood ring	0		Last Available: "2007-02"
 3054	tarnished non-modified spinning candy heart	0		Effect: "Physicali Tea", Effect Duration: 63, Last Available: "2007-02"
 3055	boiled cymbal syrup	0		Free Pull, Effect: "Sharp Weapon", Effect Duration: 15, Last Available: "2007-02"
-3056	spinning occult metallic foil cat ears	0		Spell Damage Percent: +25, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
+3056	spinning occult metallic foil cat ears	0		Spell Damage Percent: +25, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
 3057	jittery nanofiber cloth	0		Last Available: "2007-12"
 3058	gray iGoogly	0		Last Available: "2007-12"
 3059	squat theoretical string	0		Last Available: "2007-12"
@@ -3044,11 +3044,11 @@
 3072	tumbling carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
 3074	polymorphic fastening apparatus	0		Last Available: "2007-12"
-3075	bouncing purple wobbly General Assembly Module	0		Last Available: "2007-12"
+3075	bouncing wobbly purple General Assembly Module	0		Last Available: "2007-12"
 3076	mirror laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
+3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
 3080	blurry teddy borg	0		Last Available: "2007-12"
 3081	extremely unsafe marionette collective	0		Weapon Damage Percent: +100, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
@@ -3057,9 +3057,9 @@
 3085	tumbling blurry aromatic electrified roboduck-on-a-string	0		Stench Resistance: +1, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2007-12"
 3086	wobbly mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	tumbling personal trainer's smooth biomechanical crimborg helmet	0		Moxie: +15, Experience Percent (Muscle): +10, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
+3088	tumbling personal trainer's smooth biomechanical crimborg helmet	0		Moxie: +15, Experience Percent (Muscle): +10, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
 3089	blurry rosewater-soaked C.B.F.G. of Tarzan	0		Experience (Muscle): +3, Stench Resistance: +3, Last Available: "2007-12"
-3090	wicked grievous biomechanical crimborg leg armor	0		Weapon Damage Percent: +50, Spell Damage: +5, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
+3090	wicked grievous biomechanical crimborg leg armor	0		Weapon Damage Percent: +50, Spell Damage: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
 3091	unsweetened altered olive vitachoconutriment capsule	0		Effect: "Oriental Mysticism", Effect Duration: 35, Last Available: "2007-12"
 3092	red handmade hobby horse of extreme caution	0		Monster Level: -25, Last Available: "2007-12"
 3093	twirling ball-in-a-cup of the sweet-tooth	0		Candy Drop: +100, Last Available: "2007-12"
@@ -3143,7 +3143,7 @@
 3171	nauseating reagent	0		
 3172	coward's evil paper umbrella	0		Monster Level: -20
 3173	double-pressed non-tarnished evil vihuela	0		Effect: "The Dinsey Spirit", Effect Duration: 41
-3174	decent tiny wobbly evil boring spaghetti	1	good	
+3174	tiny decent wobbly evil boring spaghetti	1	good	
 3175	stale diet maroon evil noodles	1	decent	
 3176	adequate evil noodles	4	good	
 3177	bland spinning evil painful penne pasta	4	decent	
@@ -3152,14 +3152,14 @@
 3180	flavorless evil noodles	3	decent	
 3181	triple-boiled evil potion of potency	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 57
 3182	improved flattened chilled tumbling evil libation of liveliness	0		Effect: "One Very Clear Eye", Effect Duration: 63
-3183	irradiated olive huge evil tomato juice of powerful power	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 41
+3183	irradiated huge olive evil tomato juice of powerful power	0		Effect: "Twenty-three Squid, Ew", Effect Duration: 41
 3184	activated green evil eyedrops of the ermine	0		Effect: "Hippy Flavor", Effect Duration: 55
 3185	corrupted quantum green evil ointment of the occult	0		Effect: "Can't Be a Chooser", Effect Duration: 24
 3186	altered magnetized deionized evil serum of sarcasm	0		Effect: "Nano-juiced", Effect Duration: 66
 3187	flattened quadruple-concentrated polymerized twirling evil philter of phorce	0		Effect: "Sewer-Drenched", Effect Duration: 38
 3188	hand-crafted high-proof an evil sump'm sump'm	6	EPIC	
 3189	high-proof artisanal evil ducha de oro	10	EPIC	
-3190	artisanal practically non-alcoholic blurry evil horizontal tango	1	super ultra mega turbo EPIC	
+3190	practically non-alcoholic artisanal blurry evil horizontal tango	1	super ultra mega turbo EPIC	
 3191	bad shaking evil roll in the hay	4	decent	
 3192	skewed naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
@@ -3173,7 +3173,7 @@
 3201	thick padded envelope	0		
 3202	ghostly reassuring double-paned smooth KoL Con IV Pole	0		Moxie: +15, Cold Resistance: +5, Spooky Resistance: +1, Last Available: "2007-09"
 3203	yellow dwarvish magazine	0		
-3204	jittery green shaking dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
+3204	shaking jittery green dwarvish war helmet	0		Familiar Effect: "atk, 1xFairy, cap 41"
 3205	dwarvish war mattock	0		
 3206	dwarvish war kilt	0		Familiar Effect: "1xBarrr, 1xFairy, cap 41"
 3207	yellow dwarvish punchcard	0		
@@ -3197,8 +3197,8 @@
 3225	drinkable spinning bottle of sewage schnapps	3	good	
 3226	hand-crafted bottle of Ooze-O	3	EPIC	
 3227	flavorless C.H.U.M. chum	3	decent	
-3228	jumbo adequate unfortunate dumplings	5	good	
-3229	jittery wobbly decaying goldfish liver	0		
+3228	adequate jumbo unfortunate dumplings	5	good	
+3229	wobbly jittery decaying goldfish liver	0		
 3230	altered adjusted oil of oiliness	0		Effect: "Frigid Weapon", Effect Duration: 52
 3231	extremely unsafe tattered paper crown	0		Weapon Damage Percent: +100, Familiar Effect: "1xSombrero, cap 15"
 3232	tasty gigantic vanilla-frosted king cake	9	awesome	Last Available: "2008-03"
@@ -3234,22 +3234,22 @@
 3262	dance instructor's Chester's cutoffs of incineration	0		Experience Percent (Moxie): +10, Hot Spell Damage: +50, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
 3263	tumbling Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	candygram	0		Last Available: "2008-04"
-3265	twirling lime green bag of Crotchety Pine saplings	0		
+3265	lime green twirling bag of Crotchety Pine saplings	0		
 3266	pulsating cyan bag of Saccharine Maple saplings	0		
 3267	yellow blurry bag of Laughing Willow saplings	0		
 3268	irradiated pressed huge handful of Crotchety Pine needles	0		Effect: "Super Vision", Effect Duration: 13
 3269	quantum electrified lump of Saccharine Maple sap	0		Effect: "Sagittarius Rising", Effect Duration: 56
 3270	vacuum-sealed handful of Laughing Willow bark	0		Effect: "Educated (Sorta)", Effect Duration: 36
-3271	dangerous crotchety pants	0		Weapon Damage: +10, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
+3271	dangerous crotchety pants	0		Weapon Damage: +10, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
 3272	skewed asbestos-lined Saccharine Maple pendant	0		Hot Resistance: +5, Conditional Skill (Equipped): "Spray Sap"
-3273	cool willowy bonnet	0		Moxie: +5, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
+3273	cool willowy bonnet	0		Moxie: +5, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	yellow black-and-blue light	0		Last Available: "2008-04"
 3277	Loudmouth Larry Lamprey	0		Last Available: "2008-04"
 3278	avaricious studded belt	0		Meat Drop: +30, Last Available: "2008-04"
 3279	personal massager	0		Last Available: "2008-04"
-3280	wobbly squat personalized coffee mug	0		Free Pull, Last Available: "2008-04"
+3280	squat wobbly personalized coffee mug	0		Free Pull, Last Available: "2008-04"
 3281	plasma ball	0		Last Available: "2008-04"
 3282	stick-on eyebrow piercing of the cougar	0		Moxie: +20, Last Available: "2008-04"
 3283	stale narrow salad	4	decent	
@@ -3259,7 +3259,7 @@
 3287	quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
 3288	shimmering tendrils	0		Class: "Pastamancer"
 3289	ghostly scintillating powder	0		Class: "Pastamancer"
-3290	squat twirling abandoned candy	0		
+3290	twirling squat abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	adorable seal larva	0		
 3293	huge untamable turtle	0		
@@ -3269,7 +3269,7 @@
 3297	shaking stray chihuahua	0		
 3298	pretty pink bow	0		
 3299	smiley-face sticker	0		
-3300	wobbly red farfalle bow tie	0		
+3300	red wobbly farfalle bow tie	0		
 3301	green ghostly jalape&ntilde;o slices	0		
 3302	upside-down stick-on mini solar panels	0		
 3303	tumbling sombrero	0		Sombrero Bonus: +10
@@ -3291,11 +3291,11 @@
 3319	Mr. Joe's bangles of the dark arts	0		Spell Damage Percent: +100, Single Equip
 3320	Sinatra's frayed rope belt	0		Experience (Moxie): +5, Single Equip
 3321	spinning packet of mayfly bait	0		Last Available: "2008-05"
-3322	shaking frightening mayfly bait necklace of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
+3322	shaking frightening mayfly bait necklace of the brute	0		Muscle Percent: +30, Spooky Damage: +5, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
 3323	mirror Ol' Scratch's salad fork	0		
 3324	Frosty's frosty mug	0		
 3325	acceptable jar of fermented pickle juice	3	good	
-3326	dehydrated fuchsia skewed narrow voodoo snuff	1	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 40
+3326	dehydrated skewed fuchsia narrow voodoo snuff	1	good	Effect: "Blessing of the Pervy Noodles", Effect Duration: 40
 3327	rotten blurry extra-greasy slider	4	crappy	
 3328	wobbly crumpled felt fedora of the ox of courage	0		Muscle: +20, Spooky Resistance: +3, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	forbidden battered top-hat of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Familiar Effect: "0.5xVolley, 0.75xFairy"
@@ -3307,7 +3307,7 @@
 3335	ghostly rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	tumbling up-at-dawn extremely unsafe dead guy's memento	0		Weapon Damage Percent: +100, Adventures: +5, Single Equip
-3338	bite-sized rotten banquet	1	crappy	
+3338	rotten bite-sized banquet	1	crappy	
 3339	sharpened hubcap	0		
 3340	very caltrop	0		
 3341	teal The Six-Pack of Pain	0		
@@ -3319,11 +3319,11 @@
 3347	green comfy coffin	0		
 3348	mattress	0		
 3349	dinged-up triangle	0		
-3350	distilled hand-crafted maroon Ralph IX cognac	5	super ultra mega turbo EPIC	
+3350	hand-crafted distilled maroon Ralph IX cognac	5	super ultra mega turbo EPIC	
 3351	llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	wet moist llama lama gong	0		Effect: "Litterboxing", Effect Duration: 20, Last Available: "2008-06"
-3354	diet stale upside-down twirling banana-frosted king cake	1	decent	Last Available: "2008-08"
+3354	diet stale twirling upside-down banana-frosted king cake	1	decent	Last Available: "2008-08"
 3355	dance instructor's brown plastic baby	0		Experience Percent (Moxie): +10, Single Equip, Last Available: "2008-08"
 3356	pulsating plump juicy grub	0		Last Available: "2008-06"
 3357	skewed shimmering moth	0		Last Available: "2008-06"
@@ -3333,15 +3333,15 @@
 3361	bouncing yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	moldy mole mol&eacute;	4	crappy	Last Available: "2008-06"
-3364	mediocre irresponsibly strong Morlock's Mark Bourbon	9	decent	Last Available: "2008-06"
+3364	irresponsibly strong mediocre Morlock's Mark Bourbon	9	decent	Last Available: "2008-06"
 3365	super-unsweetened squat squat Climate Colada	0		Effect: "Using Protection", Effect Duration: 23, Last Available: "2008-06"
 3366	warmed chilled digital underground potion	0		Effect: "Filled with Magic", Effect Duration: 64, Last Available: "2008-06"
 3367	huge interesting-looking twig	0		Last Available: "2008-06"
 3368	diluted tumbling shaking glimmering roc feather	1	EPIC	Effect: "High Blood Chocolate Content", Effect Duration: 5, Last Available: "2008-06"
 3369	compressed squat glimmering phoenix feather	1		Last Available: "2008-06"
 3370	denatured glimmering penguin feather	1		Last Available: "2008-06"
-3371	twisted jittery ghostly glimmering buzzard feather	1		Last Available: "2008-06"
-3372	mixed gray shaking tumbling glimmering raven feather	1		Effect: "Berry Elemental", Effect Duration: 45, Last Available: "2008-06"
+3371	twisted ghostly jittery glimmering buzzard feather	1		Last Available: "2008-06"
+3372	mixed tumbling shaking gray glimmering raven feather	1		Effect: "Berry Elemental", Effect Duration: 45, Last Available: "2008-06"
 3373	modified glimmering great tit feather	1		Last Available: "2008-06"
 3374	gray house of twigs and spit	0		Last Available: "2008-06"
 3375	The Ballad of Richie Thingfinder	0		Skill: "The Ballad of Richie Thingfinder"
@@ -3368,7 +3368,7 @@
 3396	fortified arcane researcher's Hodgman's lobsterskin pants	0		Experience Percent (Mysticality): +10, Damage Absorption: +60, Familiar Effect: "atk, 1xPotato"
 3397	reassuring Hodgman's bow tie of the scaredy-cat	0		Monster Level: -15, Spooky Resistance: +1, Single Equip
 3398	fancy acceptable Hodgman's blanket	4	good	Effect: "Mayeaugh", Effect Duration: 50
-3399	smooth watered-down jar of squeeze	2	awesome	
+3399	watered-down smooth jar of squeeze	2	awesome	
 3400	decent bowl of fishysoisse	3	good	
 3401	irradiated pressed skewed deadly lampshade	0		Effect: "Adventurer's Best Friendship", Effect Duration: 46
 3402	tarnished super-liquefied concentrated garbage juice	0		Effect: "Salamander In Your Stomach", Effect Duration: 54
@@ -3386,7 +3386,7 @@
 3414	gray Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
 3422	quantum sterno-flavored Hob-O	0		Effect: "Flamingly Floral", Effect Duration: 41
 3423	adjusted energized tarnished frostbite-flavored Hob-O	0		Effect: "Well-Swabbed Ear", Effect Duration: 36
 3424	altered fry-oil-flavored Hob-O	0		Effect: "Ghost Finger", Effect Duration: 68
@@ -3410,27 +3410,27 @@
 3443	jittery kitten	0		
 3444	twirling webbed comic mask of doom	0		Spooky Spell Damage: +50, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 3445	Junior Adventurer's kit	0		
-3446	red huge shaking groovy prism necklace	0		Single Equip
+3446	shaking red huge groovy prism necklace	0		Single Equip
 3447	knitted horrifying six-rainbow shield	0		Spooky Damage: +25, Cold Resistance: +3, Damage Reduction: 12, Last Available: "2008-07"
 3448	rainbow bomb	0		Last Available: "2008-07"
-3449	twirling maroon cotton candy cone	0		Last Available: "2008-08"
+3449	maroon twirling cotton candy cone	0		Last Available: "2008-08"
 3450	cotton candy pinch	0		Last Available: "2008-08"
 3451	cotton candy smidgen	0		Last Available: "2008-08"
 3452	cotton candy skoshe	0		Last Available: "2008-08"
 3453	cotton candy plug	0		Last Available: "2008-08"
 3454	cotton candy pillow	0		Last Available: "2008-08"
-3455	yellow narrow cotton candy bale	0		Last Available: "2008-08"
+3455	narrow yellow cotton candy bale	0		Last Available: "2008-08"
 3456	scandalous trusty torch	0		Sleaze Damage: +5, Last Available: "2011-12"
 3457	jittery Junior Adventurer's merit badge of the brazier	0		Hot Spell Damage: +25
 3458	alkaline spinning STYX deodorant body spray	0		Effect: "Mucilaginous Moxiousness", Effect Duration: 19
-3459	artisanal blurry green white-label gin	3	EPIC	
+3459	artisanal green blurry white-label gin	3	EPIC	
 3460	tiny normal purple tin rations	1	good	
 3461	haiku challenge map	0		
 3462	terrible poem	0		
 3463	strong tolerable bottle of sake	5	good	
 3464	huge perfumed round pebble	0		Stench Resistance: +5
 3465	spoiled Bash-&#332;s cereal	4	crappy	Wiki Name: "Bash-Os cereal"
-3466	twirling fuchsia flame-wreathed lion tamer's therapeutic haiku katana	0		Experience (familiar): +2, Hot Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
+3466	twirling fuchsia flame-wreathed lion tamer's therapeutic haiku katana	0		Experience (familiar): +2, Hot Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 3467	bargain flash powder	0		
 3468	spinning cool plastic baby	0		Moxie: +5, Single Equip, Last Available: "2008-12"
 3469	adequate half-sized blurry blueberry-frosted king cake	2	good	Last Available: "2008-12"
@@ -3442,35 +3442,35 @@
 3475	galvanized maroon blackberry polite	0		Effect: "Buzzard Breath", Effect Duration: 46
 3476	galvanized dry plum lozenge	0		Effect: "Spring Training", Effect Duration: 26
 3477	ionized pear lozenge	0		Effect: "Pride of the Vampire", Effect Duration: 38
-3478	deionized skewed wobbly peach lozenge	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 58
+3478	deionized wobbly skewed peach lozenge	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 58
 3479	balloon shield	0		Damage Reduction: 3
 3480	spot	0		
 3481	uniclops egg	0		Free Pull, Last Available: "2009-10"
 3482	passed-out psychedelic bear	0		Free Pull, Last Available: "2009-10"
 3483	psychedelic bubble wand	0		Familiar Weight: +5
-3484	spinning teal jittery eye 'n' horn shampoo	0		Familiar Weight: +5
+3484	teal jittery spinning eye 'n' horn shampoo	0		Familiar Weight: +5
 3485	improved altered dry glittery mascara	0		Effect: "Stenchtastic", Effect Duration: 21
 3486	dull fish scale	0		
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
-3489	spoiled huge blurry narrow beefy fish meat	10	crappy	Effect: "Fishy", Effect Duration: 5
-3490	bite-sized toothsome narrow glistening fish meat	1	awesome	Effect: "Fishy", Effect Duration: 5
+3489	spoiled huge narrow blurry beefy fish meat	10	crappy	Effect: "Fishy", Effect Duration: 5
+3490	toothsome bite-sized narrow glistening fish meat	1	awesome	Effect: "Fishy", Effect Duration: 5
 3491	spoiled blurry slick fish meat	3	crappy	Effect: "Fishy", Effect Duration: 5
 3492	huge hale fish scimitar of the wise owl	0		Mysticality: +20, Maximum HP: +20
 3493	mirror friendly dance instructor's fish stick	0		Experience Percent (Moxie): +10, Familiar Weight: +3
 3494	inspector's supercharged fish bazooka	0		Maximum MP Percent: +30, Item Drop: +15
 3495	extra-activated Vulcanized tumbling sea salt crystal	0		Effect: "White-boy Angst", Effect Duration: 45
 3496	cold-filtered bazookafish bubble gum	0		Effect: "Bilious Brawn", Effect Duration: 24
-3497	fortified hand-crafted bottle of Pete's Sake	5	EPIC	
-3498	wobbly invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3500	narrow beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3497	hand-crafted fortified bottle of Pete's Sake	5	EPIC	
+3498	wobbly invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3500	narrow beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
 3501	snack-sized rotten twirling canap&eacute;s	2	crappy	
 3502	compressed thermos of brew	1	good	Last Available: "2011-12"
 3503	lousy blurry glass of brandy	4	decent	Last Available: "2011-12"
 3504	French slippers	0		
 3505	LWA ring of the scaredy-cat	0		Monster Level: -15
-3506	ghostly blurry LARP membership card	0		Last Available: "2008-10"
+3506	blurry ghostly LARP membership card	0		Last Available: "2008-10"
 3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	scratch 'n' sniff sword of James Dean	0		Experience (Moxie): +3, Last Available: "2008-11"
 3509	scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
@@ -3496,7 +3496,7 @@
 3529	mutant cactus bud	0		
 3530	pulsating mutant gila monster egg	0		
 3531	rattlesnake enrager	0		Familiar Weight: +5
-3532	pulsating cyan ant antidepressant	0		Familiar Weight: +5
+3532	cyan pulsating ant antidepressant	0		Familiar Weight: +5
 3533	skewed cactus monocle	0		Familiar Weight: +5
 3534	Jawmaster 2000&trade;	0		Familiar Weight: +5
 3535	plans for depleted Grimacite hammer	0		Recipe: "depleted Grimacite hammer"
@@ -3510,8 +3510,8 @@
 3543	flame-retardant rock-hard depleted Grimacite gravy boat	0		Damage Reduction: 5, Hot Resistance: +1, Last Available: "2011-12"
 3544	upside-down resourceful Sinatra's depleted Grimacite weightlifting belt	0		Experience (Moxie): +5, Maximum MP: +50, Single Equip, Last Available: "2011-12"
 3545	lime green personal trainer's depleted Grimacite grappling hook of mayonnaise	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +50, Single Equip, Last Available: "2011-12"
-3546	hardened dance instructor's depleted Grimacite ninja mask	0		Experience Percent (Moxie): +10, Damage Reduction: 3, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
-3547	lime green gravedigger's toasty depleted Grimacite shinguards	0		Hot Damage: +5, Spooky Damage: +10, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
+3546	hardened dance instructor's depleted Grimacite ninja mask	0		Experience Percent (Moxie): +10, Damage Reduction: 3, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
+3547	lime green gravedigger's toasty depleted Grimacite shinguards	0		Hot Damage: +5, Spooky Damage: +10, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
 3548	rosewater-soaked chilly depleted Grimacite astrolabe	0		Cold Damage: +5, Stench Resistance: +3, Single Equip, Last Available: "2011-12"
 3549	blinking double-paned KoL Con Cinco Pi&ntilde;ata Bat of extreme caution	0		Monster Level: -25, Cold Resistance: +5, Softcore Only, Last Available: "2008-09"
 3550	olive propeller beanie of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, cap 7"
@@ -3520,17 +3520,17 @@
 3553	soggy seed packet	0		
 3554	glob of slime	0		
 3555	adequate sea carrot	3	good	
-3556	miniature spoiled huge sea cucumber	2	crappy	
+3556	spoiled miniature huge sea cucumber	2	crappy	
 3557	stale teal sea avocado	3	decent	
-3558	bland enchanted sea lychee	3	decent	Effect: "Orchid Blood", Effect Duration: 50
+3558	enchanted bland sea lychee	3	decent	Effect: "Orchid Blood", Effect Duration: 50
 3559	spoiled sea tangelo	4	crappy	
-3560	huge moldy sea honeydew	7	crappy	
+3560	moldy huge sea honeydew	7	crappy	
 3561	alkaline pressurized potion of puissance	0		Effect: "Libra Rising", Effect Duration: 24
 3562	extra-electrified pressurized potion of perspicacity	0		Effect: "Chunky", Effect Duration: 42
 3563	frozen pressurized potion of pulchritude	0		Effect: "New and Improved", Effect Duration: 23
-3564	watered-down acceptable wobbly purple berry-infused sake	2	good	
+3564	watered-down acceptable purple wobbly berry-infused sake	2	good	
 3565	acceptable wobbly citrus-infused sake	4	good	
-3566	bad extra-dry melon-infused sake	5	decent	
+3566	extra-dry bad melon-infused sake	5	decent	
 3567	slab of sponge	0		
 3568	gray MacGyver's quilted slick sponge helmet	0		Moxie: +10, Damage Absorption: +40, Maximum MP: +100, Familiar Effect: "atk, 1xFairy"
 3569	experienced brainy spongy shield of Gandalf	0		Mysticality: +5, Experience: +2, Spell Critical Percent: +20, Damage Reduction: 14
@@ -3548,7 +3548,7 @@
 3581	sushi-rolling mat	0		
 3582	bland wobbly rice	3	decent	
 3584	half-sized flavorless green irradiated candy cane	2	decent	Last Available: "2008-12"
-3585	immense stale gingerbread mutant bugbear	9	decent	Last Available: "2008-12"
+3585	stale immense gingerbread mutant bugbear	9	decent	Last Available: "2008-12"
 3586	artisanal watered-down green oozenog	2	EPIC	Last Available: "2008-12"
 3587	irradiated polarized sugar plum	0		Effect: "Meadulla Oblongota", Effect Duration: 23, Last Available: "2008-12"
 3588	quantum liquefied sugar banana	0		Effect: "The Smeezingtons", Effect Duration: 44, Last Available: "2008-12"
@@ -3581,15 +3581,15 @@
 3615	twirling mirror rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	diffused galvanized energized blinking unstable DNA	0		Effect: "Egg-headedness", Effect Duration: 14, Last Available: "2008-12"
-3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
+3618	The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
 3619	wriggling tentacle	0		Last Available: "2008-12"
-3620	narrow wobbly mass of wriggling tentacles	0		Last Available: "2008-12"
+3620	wobbly narrow mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
 3622	green gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	parasitic claw of dire peril	0		Weapon Damage: +20, Last Available: "2008-12"
-3625	parasitic tentacles of the businessman	0		Meat Drop: +50, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
-3626	ruddy parasitic headgnawer	0		Maximum HP Percent: +40, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
+3625	parasitic tentacles of the businessman	0		Meat Drop: +50, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
+3626	ruddy parasitic headgnawer	0		Maximum HP Percent: +40, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
 3627	executive parasitic strangleworm	0		Meat Drop: +40, Last Available: "2008-12"
 3628	pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,25 +3598,25 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	ghostly vibrating elven socks of the bloodbag	0		Maximum HP: +100, Maximum MP Percent: +10, Last Available: "2008-12"
 3634	nasty forbidden elven gloves	0		Spell Damage Percent: +50, Stench Damage: +5, Last Available: "2008-12"
-3635	ghostly chilly Fonzie's festive holiday hat	0		Experience (Moxie): +1, Cold Damage: +5, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
+3635	ghostly chilly Fonzie's festive holiday hat	0		Experience (Moxie): +1, Cold Damage: +5, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
 3636	mansplainer's baleful patent shoes	0		Spell Damage: +25, Monster Level: +15, Last Available: "2008-12"
 3637	jittery upside-down Newton's gray bow tie of bravery	0		Experience (Mysticality): +3, Spooky Resistance: +5, Last Available: "2008-12"
 3638	tumbling rosewater-soaked dangerous penguin thesaurus	0		Weapon Damage: +10, Stench Resistance: +3, Last Available: "2008-12"
 3639	yummy blob-shaped Crimbo cookie	4	awesome	Effect: "Amorphous Cheer", Effect Duration: 10, Last Available: "2023-06"
-3640	skewed spinning seaweed	0		
+3640	spinning skewed seaweed	0		
 3641	jamfish jam	0		
 3642	cyan dragonfish caviar	0		
 3643	pufferfish spine	0		
 3644	depleted Grimacite kneecapping stick of courage	0		Spooky Resistance: +3, Last Available: "2007-06"
 3645	distilled drinkable canteen of wine	5	good	Last Available: "2008-12"
-3646	decent immense elven <i>limbos</i> gingerbread	10	good	Last Available: "2008-12"
+3646	immense decent elven <i>limbos</i> gingerbread	10	good	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	normal toast with jam	3	good	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	aged gray elven moonshine	4	awesome	Last Available: "2008-12"
-3653	enchanted normal half-sized knuckle sandwich	2	good	Effect: "Sugary Tongue", Effect Duration: 15, Wiki Name: "knuckle sandwich", Last Available: "2008-12"
+3653	half-sized normal enchanted knuckle sandwich	2	good	Effect: "Sugary Tongue", Effect Duration: 15, Last Available: "2008-12", Wiki Name: "knuckle sandwich"
 3654	personal trainer's psycho sweater	0		Experience Percent (Muscle): +10, Item Drop: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	plastic Mob Penguin of doom	0		Spooky Spell Damage: +50, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	nippy plastic strand of DNA	0		Cold Damage: +10, Last Available: "2008-12"
 3660	plastic chunk of depleted Grimacite of the glutton	0		Food Drop: +100, Last Available: "2008-12"
 3661	container of Putty	0		Last Available: "2009-01"
-3662	mirror Samson's Putty mitre	0		Experience (Muscle): +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
-3663	blinking spinning gravedigger's rosy-cheeked Putty leotard	0		Maximum HP Percent: +30, Spooky Damage: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
+3662	mirror Samson's Putty mitre	0		Experience (Muscle): +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
+3663	blinking spinning gravedigger's rosy-cheeked Putty leotard	0		Maximum HP Percent: +30, Spooky Damage: +10, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
 3664	experienced Putty ball	0		Experience: +2, Softcore Only, Last Available: "2009-01"
 3665	Putty sheet	0		Last Available: "2009-01"
 3666	resourceful brainy Putty snake of the cheetah	0		Mysticality: +5, Maximum MP: +50, Initiative: +60, Softcore Only, Last Available: "2009-01"
@@ -3645,12 +3645,12 @@
 3679	blinking ink bladder	0		
 3680	esca	0		
 3681	bubbling tempura batter	0		
-3682	twirling narrow globe of Deep Sauce	0		
+3682	narrow twirling globe of Deep Sauce	0		
 3683	purple skewed map to the Marinara Trench	0		
 3684	yummy mirror tempura carrot	3	awesome	
-3685	tasty diet tempura cucumber	1	awesome	
-3686	bland miniature olive tempura avocado	2	decent	
-3687	bland snack-sized sea broccoli	2	decent	
+3685	diet tasty tempura cucumber	1	awesome	
+3686	miniature bland olive tempura avocado	2	decent	
+3687	snack-sized bland sea broccoli	2	decent	
 3688	normal cyan sea cauliflower	3	good	
 3689	bland tempura broccoli	4	decent	
 3690	bland tempura cauliflower	3	decent	
@@ -3667,7 +3667,7 @@
 3701	map to Anemone Mine	0		
 3702	narrow marine aquamarine	0		
 3703	upside-down valve wheel	0		
-3704	mirror upside-down waterlogged bootstraps	0		
+3704	upside-down mirror waterlogged bootstraps	0		
 3705	greedy friendly velcro broadsword of the sewer	0		Familiar Weight: +3, Stench Damage: +25, Meat Drop: +20
 3706	manspreader's curative groovy velcro paddle ball	0		Moxie Percent: +10, Monster Level: +10, HP Regen Min: 3, HP Regen Max: 5
 3707	jittery fuchsia blurry sinister velcro shield of the bloodbag of mayonnaise	0		Spell Damage: +10, Maximum HP: +100, Sleaze Spell Damage: +50, Damage Reduction: 14
@@ -3705,10 +3705,10 @@
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
-3742	nitrogenated tumbling twirling jellyfish gel	0		Effect: "Yuletide Sappiness", Effect Duration: 49
+3742	nitrogenated twirling tumbling jellyfish gel	0		Effect: "Yuletide Sappiness", Effect Duration: 49
 3743	unstable quark	0		
 3744	software glitch	0		
-3745	skewed shaking fumble formula	0		Recipe: "concoction of clumsiness"
+3745	shaking skewed fumble formula	0		Recipe: "concoction of clumsiness"
 3746	vampire pearl	0		
 3747	spinning mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	galvanized super-ionized blinking concoction of clumsiness	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 25
@@ -3736,11 +3736,11 @@
 3772	acceptable Alewife&trade; Ale	3	good	
 3773	wobbly seaode	0		
 3774	map to the Dive Bar	0		
-3775	ghostly jittery Mer-kin pinkslip	0		
+3775	jittery ghostly Mer-kin pinkslip	0		
 3776	blurry veiny hardened pink pinkslip slip	0		Damage Reduction: 3, Maximum HP: +10, Familiar Effect: "1xVolley, 1xBarrr"
 3777	MacGyver's steel-toed sea salt scrubs	0		Damage Reduction: 9, Maximum MP: +100
 3778	gray auspicious toasty beefy amber aviator shades	0		Muscle: +10, Hot Damage: +5, Item Drop: +10, Single Equip
-3779	polymerized Vulcanized improved upside-down huge hair of the fish	0		Effect: "Booze Goozles", Effect Duration: 26
+3779	polymerized Vulcanized improved huge upside-down hair of the fish	0		Effect: "Booze Goozles", Effect Duration: 26
 3780	mirror Jim Carey's chaotic nurse's hat of the sewer	0		Spell Critical Percent: +10, Monster Level: +25, Stench Damage: +25, Familiar Effect: "atk"
 3781	pulsating blank prescription sheet	0		
 3782	mixed bottle of melodramamine	1		
@@ -3753,8 +3753,8 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	spinning Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	blurry crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
-3802	cyan charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
+3801	blurry crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
+3802	cyan charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
 3803	huge toasty medical-grade occult Mer-kin roundshield	0		Spell Damage Percent: +25, Hot Damage: +5, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 14
 3804	upside-down rosewater-soaked stylish Mer-kin breastplate	0		Moxie: +25, Stench Resistance: +3
 3805	spinning wholesome Samson's Mer-kin sneakmask	0		Experience (Muscle): +5, Maximum HP Percent: +10, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
@@ -3768,7 +3768,7 @@
 3813	plastic baby of Leguizamo	0		Monster Level: +20, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	ghostly skewed half-height unicycle	0		Familiar Weight: +5
-3817	small bland sea radish	2	decent	
+3817	bland small sea radish	2	decent	
 3818	squat halibut of the pedagogue of Tarzan of the overflowing toilet	0		Experience: +3, Experience (Muscle): +3, Stench Spell Damage: +50
 3819	eel sauce	0		
 3820	dog trainer's water-polo mitt	0		Experience (familiar): +1, Single Equip
@@ -3784,10 +3784,10 @@
 3830	lard-coated water-polo cap	0		Sleaze Spell Damage: +25, Familiar Effect: "1xVolley, 1xBarrr"
 3831	practically non-alcoholic delicious Typical Tavern swill	1	awesome	
 3832	artisanal weak tropical swill	2	EPIC	
-3833	mediocre watered-down fancy blurry fruity girl swill	2	decent	Effect: "Sugary Tongue", Effect Duration: 40
+3833	mediocre fancy watered-down blurry fruity girl swill	2	decent	Effect: "Sugary Tongue", Effect Duration: 40
 3834	weak artisanal blended swill	2	EPIC	
 3835	gray costume wardrobe	0		Softcore Only
-3836	shaking wool wholesome brainy Elvish sunglasses	0		Mysticality: +5, Maximum HP Percent: +10, Cold Resistance: +1, Item Drop: +5, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
+3836	shaking wool wholesome brainy Elvish sunglasses	0		Mysticality: +5, Maximum HP Percent: +10, Cold Resistance: +1, Item Drop: +5, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 3837	jittery wobbly energetic anniversary safety glass vest	0		Maximum MP Percent: +20
 3838	green pulsating arcane researcher's anniversary burlap belt	0		Experience Percent (Mysticality): +10
 3839	clever anniversary balsa wood socks	0		Maximum MP: +20
@@ -3842,12 +3842,12 @@
 3888	unsweetened vial of slime	0		Effect: "Blubbered Up", Effect Duration: 57
 3889	ionized improved blinking lime green vial of slime	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 19
 3890	aerosolized vial of violet slime	0		Effect: "Stimulated Body", Effect Duration: 15
-3891	warmed tumbling spinning vial of vermilion slime	0		Effect: "Purpose", Effect Duration: 68
+3891	warmed spinning tumbling vial of vermilion slime	0		Effect: "Purpose", Effect Duration: 68
 3892	super-adjusted anodized blurry green vial of amber slime	0		Effect: "Wintry Breath", Effect Duration: 25
 3893	corrupted concentrated jittery vial of chartreuse slime	0		Effect: "Dirge of Dreadfulness", Effect Duration: 14
 3894	flattened vial of teal slime	0		Effect: "Sticky Fingers", Effect Duration: 39
 3895	vacuum-sealed upside-down vial of indigo slime	0		Effect: "Healthy Red Glow", Effect Duration: 48
-3896	Vulcanized enhanced blinking narrow vial of slime	0		Effect: "Ichorous Eyesight", Effect Duration: 49
+3896	Vulcanized enhanced narrow blinking vial of slime	0		Effect: "Ichorous Eyesight", Effect Duration: 49
 3897	galvanized vial of brown slime	0		Effect: "Yuletide Mutations", Effect Duration: 15
 3898	bottle of G&uuml;-Gone	0		
 3901	seal-blubber candle	0		Class: "Seal Clubber"
@@ -3857,8 +3857,8 @@
 3905	figurine of an seal	0		Class: "Seal Clubber"
 3906	upside-down figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
-3908	jittery shaking figurine of a stinking seal	0		Class: "Seal Clubber"
-3909	huge cyan figurine of a charred seal	0		Class: "Seal Clubber"
+3908	shaking jittery figurine of a stinking seal	0		Class: "Seal Clubber"
+3909	cyan huge figurine of a charred seal	0		Class: "Seal Clubber"
 3910	twirling figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	mirror imbued seal-blubber candle	0		Class: "Seal Clubber"
@@ -3961,7 +3961,7 @@
 4009	memory of a G	0		Last Available: "2009-06"
 4010	memory of a T	0		Last Available: "2009-06"
 4011	memory of a CA base pair	0		Last Available: "2009-06"
-4012	blue skewed memory of a CG base pair	0		Last Available: "2009-06"
+4012	skewed blue memory of a CG base pair	0		Last Available: "2009-06"
 4013	memory of a CT base pair	0		Last Available: "2009-06"
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
@@ -3990,15 +3990,15 @@
 4038	mediocre slimy fermented bile bladder	3	decent	
 4039	mixed blurry slimy alveolus	1		Effect: "Healthy Blue Glow", Effect Duration: 40
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	Jeselnik's clever pig-iron helm	0		Maximum MP: +20, Sleaze Damage: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
-4042	toasty dangerous pig-iron shinguards	0		Weapon Damage: +10, Hot Damage: +5, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
+4041	Jeselnik's clever pig-iron helm	0		Maximum MP: +20, Sleaze Damage: +25, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
+4042	toasty dangerous pig-iron shinguards	0		Weapon Damage: +10, Hot Damage: +5, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
 4043	crafty pig-iron bracers of Leguizamo	0		Maximum MP: +10, Monster Level: +20, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
-4046	blinking shaking twirling wumpus-hair net	0		Last Available: "2009-06"
+4046	shaking blinking twirling wumpus-hair net	0		Last Available: "2009-06"
 4047	skewed Usain Bolt's wumpus-hair whip	0		Initiative: +80, Last Available: "2009-06"
-4048	Usain Bolt's fireproof wumpus-hair wig of temperance	0		Hot Resistance: +3, Sleaze Resistance: +5, Initiative: +80, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
-4049	vibrating banded forbidden wumpus-hair loincloth	0		Spell Damage Percent: +50, Damage Absorption: +100, Maximum MP Percent: +10, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
+4048	Usain Bolt's fireproof wumpus-hair wig of temperance	0		Hot Resistance: +3, Sleaze Resistance: +5, Initiative: +80, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
+4049	vibrating banded forbidden wumpus-hair loincloth	0		Spell Damage Percent: +50, Damage Absorption: +100, Maximum MP Percent: +10, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
 4050	up-at-dawn flame-wreathed wumpus-hair sweater	0		Hot Spell Damage: +10, Adventures: +5, Last Available: "2009-06"
 4051	Tesla ring of teleportation	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip
 4052	glass of baboon milk	1	awesome	Last Available: "2009-06"
@@ -4017,7 +4017,7 @@
 4065	spinning Spacefleet Communicator Badge	0		Last Available: "2009-06"
 4066	mirror Ruby Rod	0		Last Available: "2009-06"
 4067	essence of heat	0		Last Available: "2009-06"
-4068	skewed blinking essence of kink	0		Last Available: "2009-06"
+4068	blinking skewed essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
 4070	essence of stench	0		Last Available: "2009-06"
 4071	shaking blinking essence of fright	0		Last Available: "2009-06"
@@ -4085,7 +4085,7 @@
 4133	ionized mirror tempura air	0		Effect: "Twen Tea", Effect Duration: 41
 4134	modified narrow pressurized potion of pneumaticity	0		Effect: "Stuck That Way", Effect Duration: 20
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	frightening stiffened occult strapping Bag o' Tricks	0		Muscle: +5, Spell Damage Percent: +25, Damage Reduction: 1, Spooky Damage: +5, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
+4136	frightening stiffened occult strapping Bag o' Tricks	0		Muscle: +5, Spell Damage Percent: +25, Damage Reduction: 1, Spooky Damage: +5, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
 4137	slime stack	0		
 4138	a rumpled paper strip	0		
 4139	twirling a creased paper strip	0		
@@ -4106,10 +4106,10 @@
 4154	live lobster	0		Last Available: "2011-12"
 4155	wok lobster	0		Last Available: "2011-12"
 4156	pebbles	0		Last Available: "2009-09"
-4157	red huge gravel	0		Last Available: "2009-09"
+4157	huge red gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
 4159	olive rock lobster	0		Last Available: "2009-09"
-4160	hand-crafted weak wobbly pebblebr&auml;u	2	EPIC	Last Available: "2009-09"
+4160	weak hand-crafted wobbly pebblebr&auml;u	2	EPIC	Last Available: "2009-09"
 4161	yummy snack-sized rocky road ice cream	2	awesome	Last Available: "2009-09"
 4162	skewed extra-strength rubber bands	0		Familiar Weight: +5
 4163	vacuum-sealed children of the candy corn	0		Effect: "Nature's Bounty", Effect Duration: 26
@@ -4130,8 +4130,8 @@
 4178	Rosewater's sugar shotgun	0		Mysticality Percent: +30, Last Available: "2009-09"
 4179	horrifying sugar shillelagh	0		Spooky Damage: +25, Last Available: "2009-09"
 4180	blurry manspreader's sugar shank	0		Monster Level: +10, Last Available: "2009-09"
-4181	mirror vibrating therapeutic slick sugar chapeau	0		Moxie: +10, Maximum MP Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
-4182	narrow rosy-cheeked sugar shorts	0		Maximum HP Percent: +30, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
+4181	mirror vibrating therapeutic slick sugar chapeau	0		Moxie: +10, Maximum MP Percent: +10, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
+4182	narrow rosy-cheeked sugar shorts	0		Maximum HP Percent: +30, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
 4183	lime green spinning twirling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	blinking slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4141,12 +4141,12 @@
 4189	inverse geode	0		
 4190	maroon control crystal	0		Free Pull, Last Available: "2011-12"
 4191	yellow rosy-cheeked sugar shirt	0		Maximum HP Percent: +30, Last Available: "2009-09"
-4192	tumbling blinking blurry sugar shard	0		Last Available: "2009-09"
+4192	blinking tumbling blurry sugar shard	0		Last Available: "2009-09"
 4193	narrow rave visor	0		Item Drop: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 37"
 4194	blurry smartaleck's baggy rave pants	0		Moxie Percent: +30, Familiar Effect: "1xVolley, 1xPotato, cap 37"
 4195	ghostly red pacifier necklace of chilblains	0		Cold Damage: +25, Single Equip
 4196	sea cowbell	0		
-4197	yellow huge ghostly sea	0		
+4197	huge ghostly yellow sea	0		
 4198	sea lasso	0		
 4199	huge Sherlock's groovy sea cowboy hat of the glutton	0		Moxie Percent: +10, Item Drop: +25, Food Drop: +100, Familiar Effect: "1xLep"
 4200	skewed grouper fangirl	0		
@@ -4165,7 +4165,7 @@
 4213	aromatic beefcake's skate blade	0		Muscle: +25, Stench Resistance: +1
 4214	spangly unitard	0		
 4215	collapsible baton of James Dean of the brazier	0		Experience (Moxie): +3, Hot Spell Damage: +25
-4216	wobbly maroon groupie lipstick	0		
+4216	maroon wobbly groupie lipstick	0		
 4217	groupie bra	0		
 4218	electrified quadruple-galvanized anodized groupie spangles	0		Effect: "Florid Cheeks", Effect Duration: 53
 4219	inspector's sage skate board	0		Mysticality Percent: +10, Item Drop: +15
@@ -4178,7 +4178,7 @@
 4226	skewed spinning greasy Star of Bravery	0		Sleaze Spell Damage: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
+4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	blinking upside-down ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4196,25 +4196,25 @@
 4244	inspector's leather-bound tome	0		Item Drop: +15
 4245	bookmark	0		
 4246	narrow dog trainer's ivory cue ball	0		Experience (familiar): +1
-4247	practically non-alcoholic delicious special decanter of fine Scotch	1	awesome	Effect: "Thaumodynamic", Effect Duration: 50
+4247	delicious practically non-alcoholic special decanter of fine Scotch	1	awesome	Effect: "Thaumodynamic", Effect Duration: 50
 4248	pickled skewed expensive cigar	1		
 4249	tumbling tophat	0		Familiar Weight: +5
 4250	bouncing fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	electrified skewed vial of squid ink	0		Effect: "Sticky Fingers", Effect Duration: 11
 4253	cold-filtered colloidal purple upside-down potion of speed	0		Effect: "Patience of the Tortoise", Effect Duration: 65
-4254	skewed blinking bark	0		Last Available: "2009-10"
+4254	blinking skewed bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	tarnished sap	0		Effect: "Buff as a Baobab", Effect Duration: 33, Last Available: "2009-10"
 4257	petrified wood	0		Last Available: "2009-10"
 4258	delicious chocolate-covered scarab beetle	3	awesome	Last Available: "2009-10"
 4259	acceptable mulled cider	3	good	Last Available: "2009-10"
-4260	wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
-4261	spinning pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
-4262	maroon mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4260	wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4261	spinning pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4262	maroon mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	therapeutic bark boxers	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
-4265	Samson's bark beret	0		Experience (Muscle): +5, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
+4264	therapeutic bark boxers	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
+4265	Samson's bark beret	0		Experience (Muscle): +5, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
 4266	bark bracelet of the glutton	0		Food Drop: +100, Single Equip
 4267	shaking Sinatra's Herculean Krakrox's Loincloth	0		Experience (Muscle): +1, Experience (Moxie): +5, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	wobbly yellow lion tamer's deadly Galapagosian Cuisses	0		Weapon Damage: +5, Experience (familiar): +2, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4249,15 +4249,15 @@
 4297	blinking censurious Sinatra's smartaleck's Ass-Stompers of Violence	0		Moxie Percent: +30, Experience (Moxie): +5, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	avaricious family-friendly Brand of Violence of the wise owl	0		Mysticality: +20, Sleaze Resistance: +1, Meat Drop: +30, Conditional Skill (Equipped): "Brand"
 4299	blurry frosty forbidden Newton's Novelty Belt Buckle of Violence	0		Experience (Mysticality): +3, Spell Damage Percent: +50, Cold Spell Damage: +10, Single Equip
-4300	yellow mirror veiny Lens of Violence of the cougar of chilblains	0		Moxie: +20, Maximum HP: +10, Cold Damage: +25, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
+4300	yellow mirror veiny Lens of Violence of the cougar of chilblains	0		Moxie: +20, Maximum HP: +10, Cold Damage: +25, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
 4301	medical-grade Samson's Pigsticker of Violence of the dark arts	0		Experience (Muscle): +5, Spell Damage Percent: +100, HP Regen Min: 7, HP Regen Max: 10
-4302	jittery skewed prompt supercharged stiffened Jodhpurs of Violence	0		Damage Reduction: 1, Maximum MP Percent: +30, Adventures: +3, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
+4302	jittery skewed prompt supercharged stiffened Jodhpurs of Violence	0		Damage Reduction: 1, Maximum MP Percent: +30, Adventures: +3, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
 4303	blurry reassuring therapeutic stylish Cold Stone of Hatred	0		Moxie: +25, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Chilling Grip"
 4304	lime green wool medical-grade Da Vinci's Girdle of Hatred	0		Experience (Mysticality): +5, Cold Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	ribald Staff of Simmering Hatred of mayonnaise of the boozehound	0		Sleaze Damage: +10, Sleaze Spell Damage: +50, Booze Drop: +100
-4306	twirling tumbling censurious forbidden Pantaloons of Hatred of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50, Sleaze Resistance: +3, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
+4306	twirling tumbling censurious forbidden Pantaloons of Hatred of vim and vigor	0		Spell Damage Percent: +50, Maximum HP Percent: +50, Sleaze Resistance: +3, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
 4307	avaricious sizzling brawny Fuzzy Slippers of Hatred	0		Muscle Percent: +20, Hot Damage: +10, Meat Drop: +30, Single Equip
-4308	spinning up-at-dawn studded weightlifter's Lens of Hatred	0		Muscle: +15, Damage Absorption: +80, Adventures: +5, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
+4308	spinning up-at-dawn studded weightlifter's Lens of Hatred	0		Muscle: +15, Damage Absorption: +80, Adventures: +5, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
 4309	green bouncing manspreader's forbidden Treads of Loathing of chilblains	0		Spell Damage Percent: +50, Monster Level: +10, Cold Damage: +25, Single Equip
 4310	aromatic frightening foul-smelling Scepter of Loathing	0		Stench Damage: +10, Spooky Damage: +5, Stench Resistance: +1
 4311	blinking gray family-friendly chilly careful Belt of Loathing	0		Monster Level: -10, Cold Damage: +5, Sleaze Resistance: +1, Single Equip
@@ -4298,30 +4298,30 @@
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	purple gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	brainy snow hat	0		Mysticality: +5, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
-4350	snow pants of James Dean	0		Experience (Moxie): +3, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+4349	brainy snow hat	0		Mysticality: +5, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
+4350	snow pants of James Dean	0		Experience (Moxie): +3, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
 4351	shaking blurry stylish snow belly	0		Moxie: +25, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
-4353	bouncing narrow Crimbough	0		Last Available: "2009-12"
+4353	narrow bouncing Crimbough	0		Last Available: "2009-12"
 4354	A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
 4356	jittery A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	jittery purple A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
-4360	gigantic adequate expired can of franks 'n' beans	9	good	Last Available: "2009-12"
-4361	mediocre weak enchanted lime green expired bottle of peppermint schnapps	2	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 30, Last Available: "2009-12"
+4360	adequate gigantic expired can of franks 'n' beans	9	good	Last Available: "2009-12"
+4361	enchanted mediocre weak lime green expired bottle of peppermint schnapps	2	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 30, Last Available: "2009-12"
 4362	huge snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	shaking elf resistance button	0		Last Available: "2009-12"
 4364	activated moist jittery elven suicide capsule	0		Effect: "Berry Experiential", Effect Duration: 18, Last Available: "2009-12"
 4365	snack-sized moldy penguin focaccia bread	2	crappy	Last Available: "2009-12"
 4366	tolerable ghostly herringcello	4	good	Last Available: "2009-12"
-4367	weak hand-crafted elven cellocello	2	EPIC	Last Available: "2009-12"
+4367	hand-crafted weak elven cellocello	2	EPIC	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	pulsating teal handful of headless bolts	0		Last Available: "2009-12"
 4370	bottle of agitprop ink	0		Last Available: "2009-12"
 4371	handful of wires	0		Last Available: "2009-12"
-4372	squat ghostly chunk of cement	0		Last Available: "2009-12"
+4372	ghostly squat chunk of cement	0		Last Available: "2009-12"
 4373	grappling hook	0		Last Available: "2009-12"
 4374	elf ear	0		Last Available: "2009-12"
 4375	purple spiraling shape	0		Last Available: "2009-12"
@@ -4337,10 +4337,10 @@
 4385	crafty deadly pocketwatch on a chain	0		Weapon Damage: +5, Maximum MP: +10, Last Available: "2009-12"
 4386	bouncing lime green Van der Graaf experienced cement sandals	0		Experience: +2, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2009-12"
 4387	scorching fortified night-vision goggles	0		Damage Absorption: +60, Hot Damage: +25, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
+4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
 4389	mirror peanut brittle shield of incineration	0		Hot Spell Damage: +50, Damage Reduction: 3, Last Available: "2009-12"
 4390	tumbling greasy Herculean Red Rover BB gun	0		Experience (Muscle): +1, Sleaze Spell Damage: +10, Last Available: "2009-12"
-4391	scorching red-and-green sweater	0		Hot Damage: +25, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
+4391	scorching red-and-green sweater	0		Hot Damage: +25, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
 4392	blue Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	dry unsweetened Crimbo peppermint bark	0		Effect: "You Liver", Effect Duration: 56, Last Available: "2009-12"
 4394	improved red Crimbo fudge	0		Effect: "Carrion' On", Effect Duration: 25, Last Available: "2009-12"
@@ -4349,9 +4349,9 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	groovy cheese sword	0		Moxie Percent: +10, Softcore Only, Last Available: "2010-01"
-4400	supercool cheese diaper	0		Moxie Percent: +20, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
+4400	supercool cheese diaper	0		Moxie Percent: +20, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
 4401	skewed cheese wheel of extreme caution	0		Monster Level: -25, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	ghostly Tesla cheese eye	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
+4402	ghostly Tesla cheese eye	0		MP Regen Min: 7, MP Regen Max: 10, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
 4403	gray Jim Carey's experienced Staff of Queso Escusado of the dark arts	0		Experience: +2, Spell Damage Percent: +100, Monster Level: +25, Softcore Only, Last Available: "2010-01"
 4405	huge foreign box	0		
 4406	The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4359,8 +4359,8 @@
 4408	A Beginner's Guide to Charming Snakes	0		Class: "Pastamancer", Skill: "Stringozzi Serpent", Last Available: "2010-04"
 4409	Zu Mannk&auml;se Dienen	0		Class: "Sauceror", Skill: "K&auml;seso&szlig;esturm", Last Available: "2010-01"
 4410	The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
-4411	narrow twirling Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
-4412	normal snack-sized quantum taco	0		Last Available: "2010-10"
+4411	twirling narrow Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
+4412	snack-sized normal quantum taco	0		Last Available: "2010-10"
 4413	weak acceptable jittery Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	manspreader's sealhide hood	0		Monster Level: +10, Familiar Effect: "atk, 1xBarrr, cap 40"
@@ -4382,7 +4382,7 @@
 4432	tarnished double-chilled invisibility potion	0		Effect: "Concentration", Effect Duration: 62, Last Available: "2011-08"
 4433	triple-energized bouncing irresistibility potion	0		Effect: "Joyful Resolve", Effect Duration: 66, Last Available: "2011-08"
 4434	nitrogenated irradiated irritability potion	0		Effect: "Al Dente Inferno", Effect Duration: 22, Last Available: "2011-08"
-4436	blue narrow cube	0		Last Available: "2011-02"
+4436	narrow blue cube	0		Last Available: "2011-02"
 4438	blinking hellseal whisker	0		
 4439	hellseal claw	0		
 4440	huge dangerous guard turtle shell	0		Weapon Damage: +10, Familiar Effect: "atk, 1xFairy, cap 40"
@@ -4396,7 +4396,7 @@
 4448	pickled Instant Karma	1	good	
 4449	painting of a landscape	0		Last Available: "2010-04"
 4450	mirror map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	fuchsia Sinatra's pointy hat	0		Experience (Moxie): +5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
+4451	fuchsia Sinatra's pointy hat	0		Experience (Moxie): +5, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
 4452	yellow machetito of the glutton	0		Food Drop: +100, Last Available: "2010-04"
 4453	blurry lawnmower blade of the cheetah	0		Initiative: +60, Last Available: "2010-04"
 4454	grass clippings	0		Last Available: "2023-12"
@@ -4416,15 +4416,15 @@
 4468	upside-down Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	mirror BRICKO brick	0		Last Available: "2010-02"
 4470	narrow BRICKO eye brick	0		Last Available: "2010-02"
-4471	maroon ribald BRICKO hat	0		Sleaze Damage: +10, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
-4472	wobbly reassuring BRICKO pants	0		Spooky Resistance: +1, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
+4471	maroon ribald BRICKO hat	0		Sleaze Damage: +10, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
+4472	wobbly reassuring BRICKO pants	0		Spooky Resistance: +1, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
 4473	shellacked BRICKO sword	0		Damage Reduction: 7, Last Available: "2010-02"
 4474	cyan BRICKO ooze	0		Last Available: "2010-02"
 4475	BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	wobbly BRICKO elephant	0		Last Available: "2010-02"
-4479	BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
+4479	BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4461,7 +4461,7 @@
 4513	wobbly Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	rotten Humpty Dumplings	4	crappy	Last Available: "2010-03"
 4515	stale gigantic Lobster <i>qua</i> Grill	7	decent	Last Available: "2010-03"
-4516	watered-down smooth skewed maroon missing wine	2	awesome	Last Available: "2010-03"
+4516	smooth watered-down maroon skewed missing wine	2	awesome	Last Available: "2010-03"
 4517	rotten snack-sized matter custard	2	crappy	Last Available: "2010-03"
 4518	flattened boiled comfit?	0		Effect: "Simulation Stimulation", Effect Duration: 13, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
@@ -4469,29 +4469,29 @@
 4521	narrow croquet hedgehog	0		Last Available: "2010-03"
 4522	lime green Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	Newton's eye of the Tiger-lily of Flo-Jo	0		Experience (Mysticality): +3, Initiative: +100, Last Available: "2010-03"
-4524	narrow MacGyver's wig of the early riser	0		Maximum MP: +100, Adventures: +7, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
-4525	moldy fancy lime green donut	4	crappy	Effect: "Make Meat FA$T!", Effect Duration: 45, Last Available: "2010-03"
-4526	adequate fancy bucket of honey	3	good	Effect: "Comprehensively Nourished", Effect Duration: 5, Last Available: "2010-03"
+4524	narrow MacGyver's wig of the early riser	0		Maximum MP: +100, Adventures: +7, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4525	fancy moldy lime green donut	4	crappy	Effect: "Make Meat FA$T!", Effect Duration: 45, Last Available: "2010-03"
+4526	fancy adequate bucket of honey	3	good	Effect: "Comprehensively Nourished", Effect Duration: 5, Last Available: "2010-03"
 4527	shaking toasty weightlifter's elephant stinger	0		Muscle: +15, Hot Damage: +5, Last Available: "2010-03"
-4528	decent miniature fancy dragon snaps	2	good	Effect: "Wet and Greedy", Effect Duration: 15, Last Available: "2010-03"
+4528	fancy miniature decent dragon snaps	2	good	Effect: "Wet and Greedy", Effect Duration: 15, Last Available: "2010-03"
 4529	squat snapdragon pistil of the ox of the detective	0		Muscle: +20, Item Drop: +20, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	small moldy rook cookie	2	crappy	Last Available: "2010-03"
+4531	moldy small rook cookie	2	crappy	Last Available: "2010-03"
 4532	normal bishop cookie	3	good	Last Available: "2010-03"
 4533	rotten knight cookie	4	crappy	Last Available: "2010-03"
-4534	gigantic spoiled ghostly king cookie	6	crappy	Last Available: "2010-03"
-4535	low-calorie flavorless enchanted ghostly queen cookie	1	decent	Effect: "Towering Strength", Effect Duration: 25, Last Available: "2010-03"
+4534	spoiled gigantic ghostly king cookie	6	crappy	Last Available: "2010-03"
+4535	flavorless low-calorie enchanted ghostly queen cookie	1	decent	Effect: "Towering Strength", Effect Duration: 25, Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	insane tophat of incineration	0		Hot Spell Damage: +50, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
-4538	lard-coated Sinatra's helm of the knight	0		Experience (Moxie): +5, Sleaze Spell Damage: +25, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
+4537	insane tophat of incineration	0		Hot Spell Damage: +50, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
+4538	lard-coated Sinatra's helm of the knight	0		Experience (Moxie): +5, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
 4539	brainy wristwatch of the knight of the storm	0		Mysticality: +5, Maximum MP Percent: +40, Single Equip, Last Available: "2010-03"
-4540	greedy trousers of the knight of the boozehound	0		Meat Drop: +20, Booze Drop: +100, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
+4540	greedy trousers of the knight of the boozehound	0		Meat Drop: +20, Booze Drop: +100, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
 4541	wobbly tophat	0		Item Drop: +5, Familiar Effect: "1xBarrr, cap 25"
 4542	Samson's tie	0		Experience (Muscle): +5, Single Equip
 4543	flame-retardant tuxedo pants	0		Hot Resistance: +1, Familiar Effect: "2xVolley, 1xPotato, cap 25"
 4544	porpoise	0		Last Available: "2010-03"
 4545	pocketwatch	0		Last Available: "2010-03"
-4546	jittery bouncing bandersnatch	0		Last Available: "2010-03"
+4546	bouncing jittery bandersnatch	0		Last Available: "2010-03"
 4547	wobbly caterpillar	0		Last Available: "2010-03"
 4548	walrus	0		Last Available: "2010-03"
 4549	carpenter	0		Last Available: "2010-03"
@@ -4514,19 +4514,19 @@
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	knitted personal trainer's flyest of shirts	0		Experience Percent (Muscle): +10, Cold Resistance: +3, Last Available: "2010-04"
 4568	normal gigantic a dance upon the palate	9	good	Last Available: "2010-04"
-4569	miniature toothsome prehistoric meteorite jawbreaker	2	awesome	Last Available: "2010-04"
+4569	toothsome miniature prehistoric meteorite jawbreaker	2	awesome	Last Available: "2010-04"
 4570	Crazyleg's razor	0		Last Available: "2010-04"
 4571	toothsome squirmy violent party snack	3	awesome	Last Available: "2010-04"
 4572	arcane researcher's can-you-dig-it?	0		Experience Percent (Mysticality): +10, Last Available: "2010-04"
 4573	The Legendary Beat	0		Last Available: "2010-04"
 4574	panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	upside-down bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	spinning bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
-4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4576	spinning bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4577	bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	triple-tarnished upside-down Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Paging Betty", Effect Duration: 23, Last Available: "2010-04"
 4580	red huge school Mafi<i>a kni</i>cke&frac12;&aelig; of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2010-04"
-4581	cyan Samson's beefy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Muscle: +10, Experience (Muscle): +5, Wiki Name: "Bugged baio", Last Available: "2010-04"
+4581	cyan Samson's beefy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Muscle: +10, Experience (Muscle): +5, Last Available: "2010-04", Wiki Name: "Bugged baio"
 4582	huge shaking fat bottom quark	0		Last Available: "2010-05"
 4583	pulsating upside-down glob of skin	0		
 4584	tasty six wedges of goat cheese	4	awesome	
@@ -4550,7 +4550,7 @@
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	olive bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
-4605	ribald hale bottle of Goldschn&ouml;ckered	0		Maximum HP: +20, Sleaze Damage: +10, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
+4605	ribald hale bottle of Goldschn&ouml;ckered	0		Maximum HP: +20, Sleaze Damage: +10, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
 4606	spoiled gigantic sun-dried tofu	9	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	lousy ghostly soyburger juice	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	respected companion biscuit	0		Last Available: "2010-08"
@@ -4562,7 +4562,7 @@
 4614	steel-toed Crown of Thrones	0		Damage Reduction: 9, Softcore Only, Last Available: "2010-05"
 4615	perfectly mixed Cinco Mayo Lager	3	EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
-4617	teal shaking skewed pruning shears	0		Familiar Weight: +5
+4617	skewed teal shaking pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
 4619	frisbee	0		Free Pull, Last Available: "2011-12"
 4620	motorcycle	0		Familiar Weight: +5, Last Available: "2010-06"
@@ -4574,15 +4574,15 @@
 4626	superduperball	0		Last Available: "2010-06"
 4627	tumbling finger cuffs	0		Last Available: "2010-06"
 4628	upside-down parachute guy	0		Last Available: "2010-06"
-4629	plastic spider ring of Gandalf	0		Spell Critical Percent: +20, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
+4629	plastic spider ring of Gandalf	0		Spell Critical Percent: +20, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
 4630	Jeselnik's plastic kazoo	0		Sleaze Damage: +25, Last Available: "2010-06"
 4631	foul-smelling inflatable baseball bat	0		Stench Damage: +10, Last Available: "2010-06"
-4632	fuchsia wool googly-star hat of the businessman	0		Cold Resistance: +1, Meat Drop: +50, Last Available: "2010-06", Familiar Effect: "atk"
+4632	fuchsia wool googly-star hat of the businessman	0		Cold Resistance: +1, Meat Drop: +50, Familiar Effect: "atk", Last Available: "2010-06"
 4633	rosewater-soaked scorching googly-ball hat	0		Hot Damage: +25, Stench Resistance: +3, Last Available: "2010-06"
 4634	stanky googly-heart hat of chilblains	0		Cold Damage: +25, Stench Spell Damage: +25, Last Available: "2010-06"
 4635	foul-smelling dog trainer's super-sweet boom box	0		Experience (familiar): +1, Stench Damage: +10, Four Songs, Last Available: "2010-06"
 4636	mirror Game Grid valued membership card	0		Last Available: "2010-06"
-4637	inspector's smooth sinister demon mask of horror	0		Moxie: +15, Spooky Spell Damage: +25, Item Drop: +15, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
+4637	inspector's smooth sinister demon mask of horror	0		Moxie: +15, Spooky Spell Damage: +25, Item Drop: +15, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
 4638	reassuring streetfighting champion's belt of the brute of James Dean	0		Muscle Percent: +30, Experience (Moxie): +3, Spooky Resistance: +1, Single Equip, Last Available: "2010-06"
 4639	cyan dog trainer's brawny Space Trip safety headphones of incineration	0		Muscle Percent: +20, Experience (familiar): +1, Hot Spell Damage: +50, Single Equip, Last Available: "2010-06"
 4640	prompt LARP carp	0		Adventures: +3
@@ -4594,8 +4594,8 @@
 4646	yellow perfumed reassuring ruddy Meteoid ice beam	0		Maximum HP Percent: +40, Spooky Resistance: +1, Stench Resistance: +5, Last Available: "2011-12"
 4647	scandalous coward's Dungeon Fist gauntlet of terror	0		Monster Level: -20, Spooky Spell Damage: +10, Sleaze Damage: +5, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
-4650	fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
+4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
+4650	fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
 4651	ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	smooth ironic knit cap of temperance	0		Moxie: +15, Sleaze Resistance: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	purple ironic sunglasses	0		Single Equip
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	asbestos-lined pottery shield	0		Hot Resistance: +5, Damage Reduction: 3, Last Available: "2010-09"
-4682	shaking Usain Bolt's brawny pottery hat	0		Muscle Percent: +20, Initiative: +80, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
-4683	wool steel-toed pottery training pants	0		Damage Reduction: 9, Cold Resistance: +1, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
+4682	shaking Usain Bolt's brawny pottery hat	0		Muscle Percent: +20, Initiative: +80, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
+4683	wool steel-toed pottery training pants	0		Damage Reduction: 9, Cold Resistance: +1, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
 4684	pottery club of terror	0		Spooky Spell Damage: +10, Last Available: "2010-09"
 4685	resourceful pottery yo-yo	0		Maximum MP: +50, Last Available: "2010-09"
 4686	blue pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	knitted curative Greatest American Pants of the empath	0		Familiar Weight: +5, Cold Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
+4696	knitted curative Greatest American Pants of the empath	0		Familiar Weight: +5, Cold Resistance: +3, HP Regen Min: 3, HP Regen Max: 5, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
 4697	Sherlock's fossilized necklace	0		Item Drop: +25, Last Available: "2010-09"
 4698	imp air	0		
 4699	blue bus pass	0		
@@ -4660,18 +4660,18 @@
 4712	teal GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	bouncing bouncing popsicle stick	0		
 4714	small flavorless lemon popsicle	2	decent	
-4715	rotten snack-sized popsicle	2	crappy	
-4716	gigantic moldy strawberry popsicle	10	crappy	
+4715	snack-sized rotten popsicle	2	crappy	
+4716	moldy gigantic strawberry popsicle	10	crappy	
 4717	snack-sized spoiled liver popsicle	2	crappy	
 4718	olive steel-toed mariachi hat	0		Damage Reduction: 9, Familiar Effect: "atk, cap 2"
 4719	Hollandaise helmet of the empath	0		Familiar Weight: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	huge microwave stogie	0		Last Available: "2011-12"
 4722	normal squat liver and let pie	3	good	Last Available: "2010-10"
-4723	gigantic adequate badass pie	7	good	Last Available: "2010-10"
+4723	adequate gigantic badass pie	7	good	Last Available: "2010-10"
 4724	half-sized toothsome shoo-fish pie	2	awesome	Last Available: "2010-10"
 4725	moldy lime green piping organ pie	4	crappy	Last Available: "2010-10"
-4726	moldy big igloo pie	5	crappy	Last Available: "2010-10"
+4726	big moldy igloo pie	5	crappy	Last Available: "2010-10"
 4727	flavorless massive stomach turnover	7	decent	Last Available: "2010-10"
 4728	moldy olive dead lights pie	4	crappy	Last Available: "2010-10"
 4729	flavorless throbbing organ pie	3	decent	Last Available: "2010-10"
@@ -4681,7 +4681,7 @@
 4733	blinking kitty sheet music	0		Familiar Weight: +5
 4734	upside-down rehearsing dramatic hedgehog	0		Free Pull, Last Available: "2011-12"
 4735	prop sword	0		Familiar Weight: +5
-4736	skewed upside-down tangle of rat tails	0		
+4736	upside-down skewed tangle of rat tails	0		
 4737	teal curative beer-soaked mop	0		HP Regen Min: 3, HP Regen Max: 5
 4738	drinkable skewed day-old beer	4	good	
 4739	artisanal huge plain beer	3	EPIC	
@@ -4689,26 +4689,26 @@
 4741	smiling rat	0		
 4742	rat tooth polish	0		Familiar Weight: +5
 4743	olive bone chips	0		Last Available: "2011-12"
-4744	concentrated modified pulsating tumbling PlexiPips	0		Effect: "Haunted Stomach", Effect Duration: 48
+4744	concentrated modified tumbling pulsating PlexiPips	0		Effect: "Haunted Stomach", Effect Duration: 48
 4745	colloidal aerosolized irradiated maroon ghostly Wax Flask	0		Effect: "French Bronilla Brogueishness", Effect Duration: 62
 4746	modified alkaline Pain Dip	0		Effect: "Sweetened and Fattened", Effect Duration: 25
 4747	stale bone meal	3	decent	Last Available: "2010-10"
-4748	spirit-forward acceptable bone aperitif	5	good	Last Available: "2010-10"
+4748	acceptable spirit-forward bone aperitif	5	good	Last Available: "2010-10"
 4749	bonerang of the boozehound	0		Booze Drop: +100, Last Available: "2010-10"
 4750	bone and arrows of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2010-10"
 4751	boning knife of the pedagogue	0		Experience: +3, Last Available: "2010-10"
 4752	studded bone crusher	0		Damage Absorption: +80, Last Available: "2010-10"
 4753	blinking blue smelly bone spurs	0		Stench Spell Damage: +10, Single Equip, Last Available: "2010-10"
-4754	bonedanna of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
-4755	boneana hammock of mayonnaise of the boozehound	0		Sleaze Spell Damage: +50, Booze Drop: +100, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
+4754	bonedanna of Calamity Jane of courage	0		Critical Hit Percent: +15, Spooky Resistance: +3, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
+4755	boneana hammock of mayonnaise of the boozehound	0		Sleaze Spell Damage: +50, Booze Drop: +100, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
 4756	bag of bones	0		Last Available: "2010-10"
 4757	Stabonic scroll	0		Last Available: "2010-10"
-4758	enhanced tumbling olive huge candy skeleton	0		Effect: "Haunted Liver", Effect Duration: 56, Last Available: "2020-09"
+4758	enhanced olive huge tumbling candy skeleton	0		Effect: "Haunted Liver", Effect Duration: 56, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	red packet of pumpkin seeds	0		Last Available: "2010-11"
 4761	pumpkin	0		Last Available: "2010-11"
 4762	upside-down jittery huge pumpkin	0		Last Available: "2010-11"
-4763	bland shaking narrow pumpkin pie	3	decent	Last Available: "2010-11"
+4763	bland narrow shaking pumpkin pie	3	decent	Last Available: "2010-11"
 4764	hand-crafted pumpkin beer	3	EPIC	Last Available: "2010-11"
 4765	flattened pumpkin juice	0		Effect: "Big", Effect Duration: 63, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
@@ -4719,21 +4719,21 @@
 4771	ginormous pumpkin	0		Last Available: "2010-11"
 4804	pulsating Essence of Annoyance	0		Skill: "Summon Annoyance"
 4805	Unmotivator: Crashed Orca	0		Free Pull
-4806	jittery narrow Unmotivator: Success Warrior	0		Free Pull
+4806	narrow jittery Unmotivator: Success Warrior	0		Free Pull
 4807	Unmotivator: Crashed Meat Car	0		Free Pull
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	jittery Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
 4818	rotten super-sized CRIMBCOIDS mints	5	crappy	Last Available: "2011-01"
 4819	skewed can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	huge normal CRIMBCOLOAF	9	good	Last Available: "2011-01"
-4821	delicious half-sized circular CRIMBCOOKIE	2	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
+4820	normal huge CRIMBCOLOAF	9	good	Last Available: "2011-01"
+4821	half-sized delicious circular CRIMBCOOKIE	2	awesome	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	Oprah's plastic CRIMBCO HQ	0		Maximum MP Percent: +50, Last Available: "2010-12"
 4823	plastic fax machine of Leguizamo	0		Monster Level: +20, Last Available: "2010-12"
 4824	spinning plastic hobo elf of the pedagogue	0		Experience: +3, Last Available: "2010-12"
 4825	pulsating red Jack Frost's plastic Mr. Mination	0		Cold Spell Damage: +50, Last Available: "2010-12"
 4826	brawny plastic Best Game Ever	0		Muscle Percent: +20, Last Available: "2010-12"
-4827	yellow mirror hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
+4827	mirror yellow hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
 4828	narrow S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
@@ -4748,12 +4748,12 @@
 4839	bland triangular CRIMBCOOKIE	3	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
 4840	toothsome square CRIMBCOOKIE	4	awesome	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	jittery Jim Carey's beefcake's bindlestocking of mayonnaise	0		Muscle: +25, Monster Level: +25, Sleaze Spell Damage: +50, Last Available: "2010-12"
-4842	maroon blinking sleeping stocking	0		Last Available: "2010-12"
+4842	blinking maroon sleeping stocking	0		Last Available: "2010-12"
 4843	blue Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	asbestos-lined nasty Uncle Hobo's stocking cap	0		Stench Damage: +5, Hot Resistance: +5, Last Available: "2010-12", Familiar Effect: "atk"
+4845	asbestos-lined nasty Uncle Hobo's stocking cap	0		Stench Damage: +5, Hot Resistance: +5, Familiar Effect: "atk", Last Available: "2010-12"
 4846	red padded strapping Uncle Hobo's epic beard	0		Muscle: +5, Damage Absorption: +20, Single Equip, Last Available: "2010-12"
-4847	Uncle Hobo's gift baggy pants of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
+4847	Uncle Hobo's gift baggy pants of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
 4848	jittery Uncle Hobo's fingerless tinsel gloves of dire peril of the overflowing toilet	0		Weapon Damage: +20, Stench Spell Damage: +50, Single Equip, Last Available: "2010-12"
 4849	Temple Grandin's rock-hard Uncle Hobo's highest bough	0		Damage Reduction: 5, Familiar Weight: +7, Last Available: "2010-12"
 4850	bouncing dance instructor's Uncle Hobo's belt of courage	0		Experience Percent (Moxie): +10, Spooky Resistance: +3, Single Equip, Last Available: "2010-12"
@@ -4768,15 +4768,15 @@
 4859	CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
 4860	green CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	yellow CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
-4862	narrow huge CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
+4862	huge narrow CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	mirror CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
 4864	photocopier	0		Last Available: "2011-01"
 4865	deluxe fax machine	0		Last Available: "2011-01"
 4866	green Workytime Tea	0		Last Available: "2011-01"
 4867	squat paperclip sproinger	0		Last Available: "2011-01"
 4868	electrified medical-grade quilted paperclip-on tie	0		Damage Absorption: +40, MP Regen Min: 3, MP Regen Max: 5, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2011-01"
-4869	twirling pulsating frightening paperclip pants of bravery	0		Spooky Damage: +5, Spooky Resistance: +5, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
-4870	experienced paperclip turban of Leguizamo of the sweet-tooth	0		Experience: +2, Monster Level: +20, Candy Drop: +100, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
+4869	twirling pulsating frightening paperclip pants of bravery	0		Spooky Damage: +5, Spooky Resistance: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
+4870	experienced paperclip turban of Leguizamo of the sweet-tooth	0		Experience: +2, Monster Level: +20, Candy Drop: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
 4871	pulsating bouncing educational paperclip cape	0		Experience: +1, Last Available: "2011-01"
 4872	cyan glob of Blank-Out	0		Last Available: "2011-01"
 4873	maroon photocopied monster	0		Last Available: "2011-01"
@@ -4792,15 +4792,15 @@
 4883	toe jam	0		Last Available: "2011-01"
 4884	bland narrow toe jam toast	4	decent	Last Available: "2011-01"
 4885	wobbly traffic jam	0		Last Available: "2011-01"
-4886	low-calorie moldy twirling tumbling traffic jam toast	1	crappy	Last Available: "2011-01"
+4886	moldy low-calorie tumbling twirling traffic jam toast	1	crappy	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	diet decent space jam toast	1	good	Last Available: "2011-01"
+4888	decent diet space jam toast	1	good	Last Available: "2011-01"
 4889	adjusted activated motivational poster	0		Effect: "Human-Orc Hybrid", Effect Duration: 67, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	pulsating bath ball gift set	0		Last Available: "2011-01"
 4892	slow jam collection	0		Last Available: "2011-01"
 4893	tumbling BGE shotglass	0		Last Available: "2010-12"
-4894	small moldy festive sausage	2	crappy	Last Available: "2011-01"
+4894	moldy small festive sausage	2	crappy	Last Available: "2011-01"
 4895	moldy ghostly holiday cheese log	4	crappy	Last Available: "2011-01"
 4896	holiday log	0		Last Available: "2011-01"
 4897	smelly curative BGE 'ferocious fruit' shirt	0		Stench Spell Damage: +10, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2010-12"
@@ -4811,7 +4811,7 @@
 4902	chilly stapler bear	0		Cold Damage: +5, Last Available: "2010-12"
 4903	squat upside-down extremely unsafe adhesive tape dolly	0		Weapon Damage Percent: +100, Last Available: "2010-12"
 4904	wobbly zippy scissor duck	0		Initiative: +20, Last Available: "2010-12"
-4905	cyan upside-down skewed coal paperweight	0		Last Available: "2010-12"
+4905	skewed cyan upside-down coal paperweight	0		Last Available: "2010-12"
 4906	jingle bell	0		Last Available: "2010-12"
 4907	green knitted Van der Graaf Seven Loco	0		Cold Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-09"
 4908	Loathing Legion knife	0		Last Available: "2011-01"
@@ -4839,7 +4839,7 @@
 4930	shaking Folder Holder	0		Last Available: "2013-08"
 4937	a angel	0		Free Pull, Last Available: "2011-12"
 4938	jittery quake of arrows	0		Last Available: "2011-12"
-4939	red twirling time's arrow	0		Free Pull, Last Available: "2011-12"
+4939	twirling red time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	stale Knob jelly donut	3	decent	
 4942	Knob cake	0		
@@ -4855,7 +4855,7 @@
 4952	irradiated altered baggie of sugar	0		Effect: "New and Improved", Effect Duration: 56
 4953	bouncing flame-retardant personal trainer's whalebone corset	0		Experience Percent (Muscle): +10, Hot Resistance: +1, Single Equip
 4954	wholesome oven mitts	0		Maximum HP Percent: +10, Single Equip
-4955	tiny stale overcookie	1	decent	
+4955	stale tiny overcookie	1	decent	
 4956	tiny yummy philosopher's scone	1	awesome	
 4957	moist boiled half-baked potion	0		Effect: "Voracious Gorging", Effect Duration: 59
 4958	Da Vinci's Knob Goblin deluxe scimitar	0		Experience (Mysticality): +5
@@ -4905,7 +4905,7 @@
 5002	Alice's Army Foil Horseman	0		Last Available: "2011-03"
 5003	shaking Alice's Army Foil Coward	0		Last Available: "2011-03"
 5004	huge Alice's Army Foil Cleric	0		Last Available: "2011-03"
-5005	ghostly narrow Alice's Army Foil Sniper	0		Last Available: "2011-03"
+5005	narrow ghostly Alice's Army Foil Sniper	0		Last Available: "2011-03"
 5006	Alice's Army Foil Dervish	0		Last Available: "2011-03"
 5007	pulsating Alice's Army Foil Martyr	0		Last Available: "2011-03"
 5008	Single Alice's Army Foil	0		Last Available: "2011-03"
@@ -4916,18 +4916,18 @@
 5013	normal super-sized narrow wasabi pocky	5	good	Last Available: "2011-03"
 5014	rotten tobiko pocky	3	crappy	Last Available: "2011-03"
 5015	bland fuchsia natto pocky	3	decent	Last Available: "2011-03"
-5016	tolerable bouncing blurry wasabi-infused sake	4	good	Last Available: "2011-03"
-5017	tolerable practically non-alcoholic tobiko-infused sake	1	good	Last Available: "2011-03"
+5016	tolerable blurry bouncing wasabi-infused sake	4	good	Last Available: "2011-03"
+5017	practically non-alcoholic tolerable tobiko-infused sake	1	good	Last Available: "2011-03"
 5018	acceptable natto-infused sake	3	good	Last Available: "2011-03"
 5019	galvanized polymerized wobbly teal wasabi marble soda	0		Effect: "Bored Stiff", Effect Duration: 12, Last Available: "2011-03"
 5020	flattened oxidized tobiko marble soda	0		Effect: "Flagrantly Fragrant", Effect Duration: 49, Last Available: "2011-03"
 5021	adjusted natto marble soda	0		Effect: "Heart of White", Effect Duration: 59, Last Available: "2011-03"
 5022	pulsating Alice's Army booster box	0		Last Available: "2011-03"
 5023	boiled bouncing elderly jawbreaker	0		Effect: "Wings of the Grasshopper", Effect Duration: 30, Last Available: "2020-09"
-5024	mediocre weak marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
-5025	lousy practically non-alcoholic cranberry schnapps	1	decent	Last Available: "2011-03"
+5024	weak mediocre marshmallow flamb&eacute;	2	decent	Last Available: "2011-03"
+5025	practically non-alcoholic lousy cranberry schnapps	1	decent	Last Available: "2011-03"
 5026	mediocre breaded beer	3	decent	Last Available: "2011-03"
-5027	mediocre boozy soy cordial	5	decent	Last Available: "2011-03"
+5027	boozy mediocre soy cordial	5	decent	Last Available: "2011-03"
 5028	Sherlock's manspreader's medical-grade astral bludgeon	0		Monster Level: +10, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10
 5029	sage astral shield of the glutton	0		Mysticality Percent: +10, Food Drop: +100, Damage Reduction: 15
 5030	healthy stylish slick astral chapeau	0		Moxie: 35, Maximum HP Percent: +20, Familiar Effect: "1xVolley, 1xLep, cap 12"
@@ -4949,9 +4949,9 @@
 5046	upside-down astral six-pack	0		
 5047	shaking Clan shower	0		Free Pull, Last Available: "2011-04"
 5048	shard of double-ice	0		Last Available: "2011-04"
-5049	manspreader's Socratic Rosewater's double-ice cap	0		Mysticality Percent: +30, Experience (Mysticality): +1, Monster Level: +10, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
+5049	manspreader's Socratic Rosewater's double-ice cap	0		Mysticality Percent: +30, Experience (Mysticality): +1, Monster Level: +10, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
 5050	scorching double-ice box of the empath of the glutton	0		Familiar Weight: +5, Hot Damage: +25, Food Drop: +100, Last Available: "2011-04"
-5051	jittery horrifying supercharged Fonzie's double-ice britches	0		Experience (Moxie): +1, Maximum MP Percent: +30, Spooky Damage: +25, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
+5051	jittery horrifying supercharged Fonzie's double-ice britches	0		Experience (Moxie): +1, Maximum MP Percent: +30, Spooky Damage: +25, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
 5052	pulsating handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	ghostly intriguing puzzle box	0		Last Available: "2011-04"
@@ -4967,24 +4967,24 @@
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
 5065	adequate upside-down spaghetti con calaveras	4	good	Last Available: "2011-04"
 5066	jittery blurry s'more gun	0		Last Available: "2011-04"
-5067	gigantic toothsome popcorn	8	awesome	Last Available: "2011-04"
-5068	yummy enchanted half-sized chaos popcorn	2	awesome	Last Available: "2011-04"
+5067	toothsome gigantic popcorn	8	awesome	Last Available: "2011-04"
+5068	enchanted half-sized yummy chaos popcorn	2	awesome	Last Available: "2011-04"
 5069	frosty hole of Gandalf of the boozehound	0		Spell Critical Percent: +20, Cold Spell Damage: +10, Booze Drop: +100, Last Available: "2011-04"
 5070	narrow innuendo	0		Last Available: "2011-04"
-5071	big bland s'more	0	decent	Last Available: "2011-04"
+5071	bland big s'more	0	decent	Last Available: "2011-04"
 5072	diamond ring	0		Last Available: "2011-04"
 5073	perfectly mixed mirror Russian Ice	4	EPIC	Last Available: "2011-04"
 5074	yellow wicked clay ashtray	0		Spell Damage: +5, Damage Reduction: 3, Last Available: "2011-05"
 5075	tumbling thinker's lanyard	0		Mysticality: +10, Single Equip, Last Available: "2011-05"
-5076	arcane researcher's monster pants	0		Experience Percent (Mysticality): +10, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
+5076	arcane researcher's monster pants	0		Experience Percent (Mysticality): +10, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
 5077	box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	pickled corrupted Pok&euml;mann band-aid	0		Effect: "Chalk Outline", Effect Duration: 65, Last Available: "2011-05"
-5079	jittery medical-grade Van der Graaf helmet	0		Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
+5079	jittery medical-grade Van der Graaf helmet	0		Item Drop: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
 5080	green blurry crutch of Leguizamo	0		Monster Level: +20, Last Available: "2011-05"
 5081	shock belt of the pedagogue	0		Experience: +3, Single Equip, Last Available: "2011-05"
 5082	colloidal Okee-Dokee soda	0		Effect: "Smelly Pants", Effect Duration: 52, Last Available: "2011-05"
 5083	rubber band gun of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2011-05"
-5084	strapping pin-stripe slacks	0		Muscle: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
+5084	strapping pin-stripe slacks	0		Muscle: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
 5085	blurry curative gloves	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-05"
 5086	aerosolized polarized correction fluid	0		Effect: "Spooky Jellied", Effect Duration: 16, Last Available: "2011-05"
 5087	pulsating Pok&euml;mann figurine: Porkachu of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2011-05"
@@ -5009,22 +5009,22 @@
 5106	blinking hideous egg	0		Last Available: "2011-05"
 5107	delicious special squat Jeppson's Malort	3	awesome	Effect: "Bone Chilling", Effect Duration: 45, Last Available: "2011-06"
 5108	blinking fistful of ashes	0		
-5109	yellow friendly stress ball	0		Familiar Weight: +3, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
-5110	squat maroon Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
+5109	yellow friendly stress ball	0		Familiar Weight: +3, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5110	maroon squat Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	upside-down fuchsia clever Ultracolor&trade; shirt	0		Maximum MP: +20, Last Available: "2011-05"
 5112	huge My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
 5113	tumbling packet of orchid seeds	0		
-5114	skewed ghostly stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
+5114	ghostly skewed stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
 5117	cyan reconstituted crow	0		Last Available: "2011-05"
-5118	huge shaking bird brain	0		
+5118	shaking huge bird brain	0		
 5119	twirling busted wings	0		
 5120	Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	maroon spinning Admiral's hat of Tarzan of vim and vigor of doom	0		Experience (Muscle): +3, Maximum HP Percent: +50, Spooky Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "atk"
-5122	healthy aviator's cap of vim and vigor of horror	0		Maximum HP Percent: 70, Spooky Spell Damage: +25, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
+5121	maroon spinning Admiral's hat of Tarzan of vim and vigor of doom	0		Experience (Muscle): +3, Maximum HP Percent: +50, Spooky Spell Damage: +50, Familiar Effect: "atk", Last Available: "2011-05"
+5122	healthy aviator's cap of vim and vigor of horror	0		Maximum HP Percent: 70, Spooky Spell Damage: +25, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
 5123	blue smooth mirrored aviator shades of the glutton	0		Moxie: +15, Food Drop: +100, Single Equip, Last Available: "2011-05"
-5124	yellow narrow Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
+5124	narrow yellow Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
@@ -5033,7 +5033,7 @@
 5130	Notes from the Elfpocalypse, Chapter VI	0		Last Available: "2011-06"
 5131	concentrated irradiated Ultrasoldier Serum	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 65, Last Available: "2011-06"
 5132	decent elven hardtack	3	good	Last Available: "2011-06"
-5133	watered-down perfectly mixed elven squeeze	2	EPIC	Last Available: "2011-06"
+5133	perfectly mixed watered-down elven squeeze	2	EPIC	Last Available: "2011-06"
 5134	lunar isotope	0		Last Available: "2011-06"
 5135	ghostly E.M.U. joystick	0		Last Available: "2011-06"
 5136	blurry E.M.U. rocket thrusters	0		Last Available: "2011-06"
@@ -5051,8 +5051,8 @@
 5148	Van der Graaf crafty honey dipper of the brute	0		Muscle Percent: +30, Maximum MP: +10, MP Regen Min: 5, MP Regen Max: 7
 5149	inspector's resourceful Samson's honeybritches	0		Experience (Muscle): +5, Maximum MP: +50, Item Drop: +15, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	coward's electrified steel-toed honeycap	0		Damage Reduction: 9, Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xPotato, cap 43"
-5151	Tesla Moonthril Circlet	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
-5152	aromatic Moonthril Greaves	0		Stench Resistance: +1, Last Available: "2011-06", Familiar Effect: "cap 25"
+5151	Tesla Moonthril Circlet	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
+5152	aromatic Moonthril Greaves	0		Stench Resistance: +1, Familiar Effect: "cap 25", Last Available: "2011-06"
 5153	inspector's Moonthril Flamberge	0		Item Drop: +15, Last Available: "2011-06"
 5154	avaricious Moonthril Longbow	0		Meat Drop: +30, Last Available: "2011-06"
 5155	Jim Carey's Moonthril Cuirass	0		Monster Level: +25, Softcore Only, Last Available: "2011-06"
@@ -5077,10 +5077,10 @@
 5174	artisanal Saison du Lune	3	EPIC	Last Available: "2011-06"
 5175	aged Moonthril Schnapps	4	awesome	Last Available: "2011-06"
 5176	lousy Wrecked Generator	4	decent	Last Available: "2011-06"
-5177	bland diet Spaghetti with Moonballs	1	decent	Last Available: "2011-06"
+5177	diet bland Spaghetti with Moonballs	1	decent	Last Available: "2011-06"
 5178	thick toothsome Crepes a la Lune	5	awesome	Last Available: "2011-06"
-5179	snack-sized decent cyan Moon Pie	2	good	Last Available: "2011-06"
-5180	polymerized pulsating bouncing Comet Pop	0		Effect: "Hammered", Effect Duration: 65, Last Available: "2011-06"
+5179	decent snack-sized cyan Moon Pie	2	good	Last Available: "2011-06"
+5180	polymerized bouncing pulsating Comet Pop	0		Effect: "Hammered", Effect Duration: 65, Last Available: "2011-06"
 5181	quantum Flan in the Moon	0		Effect: "Cookie Backup", Effect Duration: 63, Last Available: "2011-06"
 5182	dry ionized Vulcanized shaking 1/6th Pound Cake	0		Effect: "Mer-kindliness", Effect Duration: 48, Last Available: "2011-06"
 5183	Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5088,10 +5088,10 @@
 5185	huge Mint-in-box Moonthril Cuirass	0		Last Available: "2011-06"
 5186	blinking pulsating Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
-5188	irradiated maroon skewed honey stick	0		Effect: "Beastly Flavor", Effect Duration: 64
+5188	irradiated skewed maroon honey stick	0		Effect: "Beastly Flavor", Effect Duration: 64
 5189	pickled double-ice gum	0		Effect: "Tingly Wrists", Effect Duration: 49, Last Available: "2011-04"
-5190	family-friendly aromatic Operation Patriot Shield of the brute	0		Muscle Percent: +30, Stench Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
-5191	upside-down cyan squirming egg sac	0		Last Available: "2011-06"
+5190	family-friendly aromatic Operation Patriot Shield of the brute	0		Muscle Percent: +30, Stench Resistance: +1, Sleaze Resistance: +1, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5191	cyan upside-down squirming egg sac	0		Last Available: "2011-06"
 5192	triple-tarnished pulsating corrupted data	0		Effect: "Coldfinger", Effect Duration: 36, Last Available: "2011-06"
 5193	teal 11-inch knob sausage	0		
 5194	exorcised sandwich	0		
@@ -5123,7 +5123,7 @@
 5220	Teachings of the Fist	0		
 5221	fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	blurry gray Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	gray blurry Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	normal Ur-Donut	3	good	Last Available: "2011-09"
 5225	wobbly The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5139,23 +5139,23 @@
 5236	frosty halo of the brute	0		Muscle Percent: +30, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	lion tamer's time halo	0		Experience (familiar): +2, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	bad Lumineux Limnio	3	decent	Last Available: "2011-09"
-5239	practically non-alcoholic bad Morto Moreto	1	decent	Last Available: "2011-09"
+5239	bad practically non-alcoholic Morto Moreto	1	decent	Last Available: "2011-09"
 5240	perfectly mixed Temps Tempranillo	3	EPIC	Last Available: "2011-09"
 5241	perfectly mixed irresponsibly strong Bordeaux Marteaux	7	EPIC	Last Available: "2011-09"
 5242	acceptable Fromage Pinotage	3	good	Last Available: "2011-09"
 5243	practically non-alcoholic lousy twirling Beignet Milgranet	1	decent	Last Available: "2011-09"
 5244	hand-crafted squat Muschat	3	EPIC	Last Available: "2011-09"
-5245	big enchanted stale cool jelly donut	5	decent	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2011-09"
+5245	big stale enchanted cool jelly donut	5	decent	Effect: "Wallflowering", Effect Duration: 35, Last Available: "2011-09"
 5246	adequate pulsating shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	delicious red occult jelly donut	3	awesome	Last Available: "2011-09"
 5248	normal thyme jelly donut	3	good	Last Available: "2011-09"
 5249	stale danish	3	decent	Last Available: "2011-09"
-5250	small flavorless smashed danish	2	decent	Last Available: "2011-09"
-5251	jumbo normal forbidden danish	5	good	Last Available: "2011-09"
+5250	flavorless small smashed danish	2	decent	Last Available: "2011-09"
+5251	normal jumbo forbidden danish	5	good	Last Available: "2011-09"
 5252	yummy cool cat claw	4	awesome	Last Available: "2011-09"
 5253	gigantic toothsome blunt cat claw	9	awesome	Last Available: "2011-09"
-5254	thick decent shadowy cat claw	5	good	Last Available: "2011-09"
-5255	moldy enchanted big tumbling cheezburger	5	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2011-09"
+5254	decent thick shadowy cat claw	5	good	Last Available: "2011-09"
+5255	big moldy enchanted tumbling cheezburger	5	crappy	Effect: "Grumpy and Ornery", Effect Duration: 25, Last Available: "2011-09"
 5256	decent red toasted brie	3	good	Last Available: "2011-09"
 5257	triple-concentrated potion of the field gar	0		Effect: "Purpose", Effect Duration: 53, Last Available: "2011-09"
 5258	quantum lime green huge too legit potion	0		Effect: "Once Bitten Twice Fried", Effect Duration: 52, Last Available: "2011-09"
@@ -5164,7 +5164,7 @@
 5261	frozen energized graveyard snowglobe	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 60, Last Available: "2011-09"
 5262	ionized cool cat elixir	0		Effect: "Soles of Glass", Effect Duration: 42, Last Available: "2011-09"
 5263	Vulcanized double-enhanced wobbly potion of the captain's hammer	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 37, Last Available: "2011-09"
-5264	modified dry yellow pulsating potion of X-ray vision	0		Effect: "Memory of Speed", Effect Duration: 65, Last Available: "2011-09"
+5264	modified dry pulsating yellow potion of X-ray vision	0		Effect: "Memory of Speed", Effect Duration: 65, Last Available: "2011-09"
 5265	colloidal pulsating potion of the litterbox	0		Effect: "Gobliny Flavor", Effect Duration: 37, Last Available: "2011-09"
 5266	tarnished oxidized shaking potion of animal rage	0		Effect: "Fruited", Effect Duration: 53, Last Available: "2011-09"
 5267	vacuum-sealed non-dry jittery potion of punctual companionship	0		Effect: "Oth-Jeal-O", Effect Duration: 54, Last Available: "2011-09"
@@ -5195,11 +5195,11 @@
 5292	red generic mana potion	0		Last Available: "2011-09"
 5293	generic restorative potion	0		Last Available: "2011-09"
 5294	kobold treasure hoard	0		Last Available: "2011-09"
-5295	tumbling blinking newborn kobold	0		Last Available: "2011-09"
+5295	blinking tumbling newborn kobold	0		Last Available: "2011-09"
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	red dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy phish stick	3	crappy	Last Available: "2011-09"
-5299	quilted plastic vampire fangs of terror of the sweet-tooth	0		Damage Absorption: +40, Spooky Spell Damage: +10, Candy Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
+5299	quilted plastic vampire fangs of terror of the sweet-tooth	0		Damage Absorption: +40, Spooky Spell Damage: +10, Candy Drop: +100, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
 5301	mirror Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	twirling ghostly your own heart	0		Last Available: "2011-10"
@@ -5223,9 +5223,9 @@
 5320	double-tarnished lime green Lobos Mints	0		Effect: "Category", Effect Duration: 26, Last Available: "2011-10"
 5321	dry Sweet Sword	0		Effect: "Salty Dogs", Effect Duration: 49, Last Available: "2011-10"
 5322	drinkable boozy Ecto-Cooler	5	good	Last Available: "2011-10"
-5323	perfectly mixed triple-distilled Bartles and BRAAAINS wine cooler	7	EPIC	Last Available: "2011-10"
+5323	triple-distilled perfectly mixed Bartles and BRAAAINS wine cooler	7	EPIC	Last Available: "2011-10"
 5324	tolerable Blood Light	3	good	Last Available: "2011-10"
-5325	acceptable triple-distilled Silver Bullet beer	9	good	Last Available: "2011-10"
+5325	triple-distilled acceptable Silver Bullet beer	9	good	Last Available: "2011-10"
 5326	aged Bone's Farm &quot;wine&quot;	4	awesome	Last Available: "2011-10"
 5327	ghost protocol	0		Last Available: "2011-10"
 5328	electrified frozen sorority brain	0		Effect: "Guts Feeling", Effect Duration: 31, Last Available: "2011-10"
@@ -5233,19 +5233,19 @@
 5330	quadruple-Vulcanized altered drum of pomade	0		Effect: "Oily Flavor", Effect Duration: 17, Last Available: "2011-10"
 5331	red throwing bone	0		Last Available: "2011-10"
 5332	energetic extra-see-thru nightie	0		Maximum MP Percent: +20, Last Available: "2011-10"
-5333	tumbling narrow olive Sherlock's scorching BRAINS shorts	0		Hot Damage: +25, Item Drop: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
+5333	tumbling narrow olive Sherlock's scorching BRAINS shorts	0		Hot Damage: +25, Item Drop: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
 5334	jittery wobbly narrow ruddy Mesmereyes&trade; contact lenses	0		Maximum HP Percent: +40, Single Equip, Last Available: "2011-10"
 5335	fuchsia curative scrunchie	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Last Available: "2011-10"
-5336	wool nippy extremely skinny jeans	0		Cold Damage: +10, Cold Resistance: +1, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
-5337	The Necbromancer's Hat of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
+5336	wool nippy extremely skinny jeans	0		Cold Damage: +10, Cold Resistance: +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
+5337	The Necbromancer's Hat of the dark arts of temperance	0		Spell Damage Percent: +100, Sleaze Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
 5338	narrow sizzling sharpshooter's stylish The Necbromancer's Stein	0		Moxie: +25, Critical Hit Percent: +10, Hot Damage: +10, Last Available: "2011-10"
-5339	padded The Necbromancer's Shorts of the brute of the boozehound	0		Muscle Percent: +30, Damage Absorption: +20, Booze Drop: +100, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
+5339	padded The Necbromancer's Shorts of the brute of the boozehound	0		Muscle Percent: +30, Damage Absorption: +20, Booze Drop: +100, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
 5340	skewed foul-smelling nippy quilted The Necbromancer's Wizard Staff	0		Damage Absorption: +40, Cold Damage: +10, Stench Damage: +10, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	acceptable The Cooler Out of Space	4	good	Last Available: "2011-10"
 5343	The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	tumbling wobbly sorority girl's box	0		Last Available: "2011-10"
-5345	aerosolized blurry spinning Necbro wafers	0		Effect: "Bricked-In", Effect Duration: 33, Last Available: "2020-09"
+5345	aerosolized spinning blurry Necbro wafers	0		Effect: "Bricked-In", Effect Duration: 33, Last Available: "2020-09"
 5346	fuchsia death blossom	0		
 5347	shaking A Crimbo Carol, Ch. 1 (used)	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 5348	A Crimbo Carol, Ch. 2 (used)	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -5289,7 +5289,7 @@
 5386	pulsating savvy ridiculous belt	0		Mysticality Percent: +20, Last Available: "2011-11"
 5387	pulsating rosewater-soaked ridiculous earring	0		Stench Resistance: +3, Last Available: "2011-11"
 5388	ridiculous sunglasses of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-11"
-5389	rotten tumbling maroon ridiculous sandwich	3	crappy	Last Available: "2011-11"
+5389	rotten maroon tumbling ridiculous sandwich	3	crappy	Last Available: "2011-11"
 5390	practically non-alcoholic lousy ridiculous cocktail	1	decent	Last Available: "2011-11"
 5391	sharpshooter's supercharged zombie monkey necklace	0		Maximum MP Percent: +30, Critical Hit Percent: +10
 5392	Thwaitgold butterfly statuette	0		
@@ -5297,18 +5297,18 @@
 5394	sandpaper	0		
 5395	lime green peppermint sprout	0		Last Available: "2011-11"
 5396	polymerized boiled narrow blinking peppermint twist	0		Effect: "Creepypasted", Effect Duration: 53, Last Available: "2011-11"
-5397	fancy delicious small peppermint patty	2	awesome	Effect: "Quaaaaaaa", Effect Duration: 30, Last Available: "2011-11"
+5397	small delicious fancy peppermint patty	2	awesome	Effect: "Quaaaaaaa", Effect Duration: 30, Last Available: "2011-11"
 5398	peppermint crook	0		Last Available: "2011-11"
 5399	shaking peppermint rhino baby	0		Last Available: "2011-11"
-5400	spinning purple candy cane candygram	0		Last Available: "2011-12"
+5400	purple spinning candy cane candygram	0		Last Available: "2011-12"
 5401	peppermint parasol	0		Last Available: "2011-11"
 5402	teal aromatic candy cane	0		Stench Resistance: +1, Last Available: "2011-12"
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	teal zippy smelly vibrating cane-mail shirt	0		Maximum MP Percent: +10, Stench Spell Damage: +10, Initiative: +20, Last Available: "2011-12"
-5406	aromatic chaotic cane-mail pants of the wise owl	0		Mysticality: +20, Spell Critical Percent: +10, Stench Resistance: +1, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
-5407	fortified artisanal olive Vodka Matryoshka	5	EPIC	Last Available: "2011-12"
-5408	irresponsibly strong acceptable Gin Mint	6	good	Last Available: "2011-12"
+5406	aromatic chaotic cane-mail pants of the wise owl	0		Mysticality: +20, Spell Critical Percent: +10, Stench Resistance: +1, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5407	artisanal fortified olive Vodka Matryoshka	5	EPIC	Last Available: "2011-12"
+5408	acceptable irresponsibly strong Gin Mint	6	good	Last Available: "2011-12"
 5409	hand-crafted Tequiz Navidad	3	EPIC	Last Available: "2011-12"
 5410	acceptable Mint Yulep	4	good	Last Available: "2011-12"
 5411	artisanal Crimbojito	3	EPIC	Last Available: "2011-12"
@@ -5320,19 +5320,19 @@
 5417	deionized pear supersucker	0		Effect: "High Blood Chocolate Content", Effect Duration: 37, Last Available: "2011-11"
 5418	super-enhanced concentrated blue pulsating lime supersucker	0		Effect: "Old School Pompadour", Effect Duration: 39, Last Available: "2011-11"
 5419	ionized dry kumquat supersucker	0		Effect: "Blessing of Charcoatl", Effect Duration: 37, Last Available: "2011-11"
-5420	vacuum-sealed teal mirror strawberry supersucker	0		Effect: "Hippy Flavor", Effect Duration: 40, Last Available: "2011-11"
+5420	vacuum-sealed mirror teal strawberry supersucker	0		Effect: "Hippy Flavor", Effect Duration: 40, Last Available: "2011-11"
 5421	bananarama bangle of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2011-11"
 5422	thinker's pair of pearidot earrings	0		Mysticality: +10, Single Equip, Last Available: "2011-11"
 5423	gray experienced tourmalime tourniquet	0		Experience: +2, Single Equip, Last Available: "2011-11"
 5424	wholesome kumquartz ring	0		Maximum HP Percent: +10, Single Equip, Last Available: "2011-11"
 5425	olive avaricious strawberyl necklace	0		Meat Drop: +30, Single Equip, Last Available: "2011-11"
 5426	frightening sucker bucket of the pedagogue	0		Experience: +3, Spooky Damage: +5, Last Available: "2011-11"
-5427	asbestos-lined sucker hakama	0		Hot Resistance: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
-5428	toasty sucker kabuto	0		Hot Damage: +5, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
+5427	asbestos-lined sucker hakama	0		Hot Resistance: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
+5428	toasty sucker kabuto	0		Hot Damage: +5, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
 5429	greedy sucker tachi	0		Meat Drop: +20, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
-5432	tumbling purple grape troll doll	0		Last Available: "2011-11"
+5432	purple tumbling grape troll doll	0		Last Available: "2011-11"
 5433	raspberry troll doll	0		Last Available: "2011-11"
 5434	wobbly DNOTC Box	0		Last Available: "2017-12"
 5435	shaking fudgecule	0		Last Available: "2011-11"
@@ -5364,7 +5364,7 @@
 5461	fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
 5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
-5464	electrified huge lime green resolution: be wealthier	0		Effect: "Bricked-In", Effect Duration: 19, Last Available: "2012-01"
+5464	electrified lime green huge resolution: be wealthier	0		Effect: "Bricked-In", Effect Duration: 19, Last Available: "2012-01"
 5465	unsweetened resolution: be happier	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 57, Last Available: "2012-01"
 5466	unsweetened oxidized resolution: be stronger	0		Effect: "Just Aged Enough", Effect Duration: 39, Last Available: "2012-01"
 5467	alkaline adjusted resolution: be smarter	0		Effect: "Coal-Powered", Effect Duration: 42, Last Available: "2012-01"
@@ -5381,10 +5381,10 @@
 5478	double-modified galvanized twirling gummi canary	0		Effect: "Space Cowboy", Effect Duration: 48, Last Available: "2011-11"
 5479	yummy miniature gummi bear	2	awesome	Last Available: "2011-11"
 5480	adequate gummi bear	3	good	Last Available: "2011-11"
-5481	decent fancy half-sized gummi bear	2	good	Effect: "It's Soporiffic!", Effect Duration: 5, Last Available: "2011-11"
+5481	fancy decent half-sized gummi bear	2	good	Effect: "It's Soporiffic!", Effect Duration: 5, Last Available: "2011-11"
 5482	moldy special green drunki-bear	4	crappy	Effect: "Leash of Linguini", Effect Duration: 30, Last Available: "2011-11"
 5483	snack-sized decent enchanted upside-down drunki-bear	2	good	Effect: "Wet and Greedy", Effect Duration: 35, Last Available: "2011-11"
-5484	low-calorie stale drunki-bear	1	decent	Last Available: "2011-11"
+5484	stale low-calorie drunki-bear	1	decent	Last Available: "2011-11"
 5485	tumbling dangerous gummi bowtie	0		Weapon Damage: +10, Last Available: "2011-11"
 5486	tumbling blinking chaotic fudge pocket square	0		Spell Critical Percent: +10, Last Available: "2011-11"
 5487	narrow energetic lollipop cufflinks	0		Maximum MP Percent: +20, Last Available: "2011-11"
@@ -5399,7 +5399,7 @@
 5496	liquefied ionized twirling gummi belemnite	0		Effect: "Smoky Third Eye", Effect Duration: 49, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	heart of dark chocolate	0		Last Available: "2011-11"
-5499	Tesla Socratic Big Candy's tophat	0		Experience (Mysticality): +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
+5499	Tesla Socratic Big Candy's tophat	0		Experience (Mysticality): +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	green Jackass Plumber home game	0		Last Available: "2011-11"
 5502	Trivial Avocations board game	0		Last Available: "2011-11"
@@ -5417,7 +5417,7 @@
 5514	Trivial Avocations Card: Where?	0		Last Available: "2011-11"
 5515	mirror pog #01 (spider)	0		Last Available: "2011-11"
 5516	pog #02 (Knob goblin)	0		Last Available: "2011-11"
-5517	purple tumbling pog #03 (warwelf)	0		Last Available: "2011-11"
+5517	tumbling purple pog #03 (warwelf)	0		Last Available: "2011-11"
 5518	pog #04 (skleleton)	0		Last Available: "2011-11"
 5519	pog #05 (ninja snowman)	0		Last Available: "2011-11"
 5520	blue pog #06 (filthy hippy)	0		Last Available: "2011-11"
@@ -5438,13 +5438,13 @@
 5535	wet double-cold-filtered green Marvin's marvelous pill	0		Effect: "Headstrong", Effect Duration: 26, Last Available: "2012-12"
 5536	Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
-5538	cyan squat half-empty carton of milk	0		Last Available: "2012-12"
+5538	squat cyan half-empty carton of milk	0		Last Available: "2012-12"
 5539	glass of warm water	0		Free Pull
 5540	boiled upside-down desktop zen garden	0		Effect: "Standard Issue Bravery", Effect Duration: 15, Last Available: "2012-12"
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	tumbling clever therapeutic Leapin' Trousers	0		Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7
-5544	fancy lousy weak upside-down red eggnog	2	decent	Effect: "Tiki Temerity", Effect Duration: 35, Last Available: "2012-12"
+5544	fancy lousy weak red upside-down eggnog	2	decent	Effect: "Tiki Temerity", Effect Duration: 35, Last Available: "2012-12"
 5545	gigantic yummy hamhock	7	awesome	Last Available: "2012-12"
 5546	cyan The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	tumbling Clancy's sackbut	0		Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	tumbling zippy dance instructor's Rain-Doh wings	0		Experience Percent (Moxie): +10, Initiative: +20, Softcore Only, Last Available: "2012-02"
 5557	Rain-Doh agent	0		Last Available: "2012-02"
 5558	sizzling Rain-Doh laser gun of bravery	0		Hot Damage: +10, Spooky Resistance: +5, Softcore Only, Last Available: "2012-02"
-5559	gravedigger's sage Rain-Doh lantern	0		Mysticality Percent: +10, Spooky Damage: +10, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
+5559	gravedigger's sage Rain-Doh lantern	0		Mysticality Percent: +10, Spooky Damage: +10, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
 5560	wobbly Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	wobbly zippy Sinatra's Rain-Doh violet bo	0		Experience (Moxie): +5, Initiative: +20, Softcore Only, Last Available: "2012-02"
@@ -5471,16 +5471,16 @@
 5568	frayed ninja rope	0		
 5569	lime green dull ninja crampons	0		
 5570	loose ninja carabiner	0		
-5571	yellow mirror Groar's fur	0		
+5571	mirror yellow Groar's fur	0		
 5572	Thwaitgold stag beetle statuette	0		
 5573	bad Drac & Tan	4	decent	Last Available: "2012-03"
-5574	hand-crafted distilled upside-down Transylvania Sling	5	EPIC	Last Available: "2012-03"
+5574	distilled hand-crafted upside-down Transylvania Sling	5	EPIC	Last Available: "2012-03"
 5575	delicious Shot of the Living Dead	4	awesome	Last Available: "2012-03"
 5576	hand-crafted Buttery Knob	4	EPIC	Last Available: "2012-03"
-5577	fancy tolerable Slippery Knob	4	good	Effect: "Savage Beast Inside", Effect Duration: 20, Last Available: "2012-03"
+5577	tolerable fancy Slippery Knob	4	good	Effect: "Savage Beast Inside", Effect Duration: 20, Last Available: "2012-03"
 5578	spirit-forward artisanal tumbling Flaming Knob	5	EPIC	Last Available: "2012-03"
 5579	perfectly mixed Grasshopper	3	EPIC	Last Available: "2012-03"
-5580	delicious special watered-down jittery Locust	2	awesome	Effect: "Cool Spirit", Effect Duration: 45, Last Available: "2012-03"
+5580	delicious watered-down special jittery Locust	2	awesome	Effect: "Cool Spirit", Effect Duration: 45, Last Available: "2012-03"
 5581	smooth Plague of Locusts	4	awesome	Last Available: "2012-03"
 5582	aged Red Dwarf	3	awesome	Last Available: "2012-03"
 5583	smooth pulsating lime green Golden Mean	3	awesome	Last Available: "2012-03"
@@ -5488,14 +5488,14 @@
 5585	hand-crafted Aye Aye	4	EPIC	Last Available: "2012-03"
 5586	acceptable narrow Aye Aye, Captain	4	good	Last Available: "2012-03"
 5587	delicious Aye Aye, Tooth Tooth	3	awesome	Last Available: "2012-03"
-5588	bad spirit-forward Humanitini	5	decent	Last Available: "2012-03"
+5588	spirit-forward bad Humanitini	5	decent	Last Available: "2012-03"
 5589	mediocre More Humanitini than Humanitini	3	decent	Last Available: "2012-03"
 5590	lousy Oh, the Humanitini	3	decent	Last Available: "2012-03"
 5591	aged Great Older Fashioned	3	awesome	Last Available: "2012-03"
 5592	tolerable Fuzzy Tentacle	3	good	Last Available: "2012-03"
 5593	fortified aged Crazymaker	5	awesome	Last Available: "2012-03"
 5594	hand-crafted Zoodriver	3	EPIC	Last Available: "2012-03"
-5595	triple-distilled aged Sloe Comfortable Zoo	6	awesome	Last Available: "2012-03"
+5595	aged triple-distilled Sloe Comfortable Zoo	6	awesome	Last Available: "2012-03"
 5596	bad weak shaking Sloe Comfortable Zoo on Fire	2	decent	Last Available: "2012-03"
 5597	lousy Suffering Sinner	3	decent	Last Available: "2012-03"
 5598	special lousy pulsating Suppurating Sinner	3	decent	Effect: "Sparkling Consciousness", Effect Duration: 25, Last Available: "2012-03"
@@ -5503,35 +5503,35 @@
 5600	practically non-alcoholic lousy Firewater	1	decent	Last Available: "2012-03"
 5601	weak artisanal Earth and Firewater	2	EPIC	Last Available: "2012-03"
 5602	practically non-alcoholic bad Earth, Wind and Firewater	1	decent	Last Available: "2012-03"
-5603	boozy hand-crafted Slimosa	5	EPIC	Last Available: "2012-03"
-5604	tolerable practically non-alcoholic ghostly blurry Extra-slimy Slimosa	1	good	Last Available: "2012-03"
-5605	watered-down smooth Slimebite	2	awesome	Last Available: "2012-03"
+5603	hand-crafted boozy Slimosa	5	EPIC	Last Available: "2012-03"
+5604	practically non-alcoholic tolerable blurry ghostly Extra-slimy Slimosa	1	good	Last Available: "2012-03"
+5605	smooth watered-down Slimebite	2	awesome	Last Available: "2012-03"
 5606	bad Cement Mixer	3	decent	Last Available: "2012-03"
-5607	lousy watered-down Jackhammer	2	decent	Last Available: "2012-03"
-5608	acceptable high-proof Dump Truck	7	good	Last Available: "2012-03"
+5607	watered-down lousy Jackhammer	2	decent	Last Available: "2012-03"
+5608	high-proof acceptable Dump Truck	7	good	Last Available: "2012-03"
 5609	mediocre huge Fauna Libre	4	decent	Last Available: "2012-03"
 5610	acceptable Chakra Libre	4	good	Last Available: "2012-03"
 5611	strong hand-crafted Aura Libre	5	EPIC	Last Available: "2012-03"
-5612	extra-dry drinkable Sazerorc	5	good	Last Available: "2012-03"
+5612	drinkable extra-dry Sazerorc	5	good	Last Available: "2012-03"
 5613	artisanal Sazuruk-hai	4	EPIC	Last Available: "2012-03"
 5614	bad watered-down Flaming Sazerorc	2	decent	Last Available: "2012-03"
-5615	practically non-alcoholic hand-crafted Green Velvet	1	EPIC	Last Available: "2012-03"
+5615	hand-crafted practically non-alcoholic Green Velvet	1	EPIC	Last Available: "2012-03"
 5616	perfectly mixed narrow Green Muslin	4	EPIC	Last Available: "2012-03"
 5617	perfectly mixed Green Burlap	4	EPIC	Last Available: "2012-03"
 5618	fortified tolerable Mohobo	5	good	Last Available: "2012-03"
-5619	artisanal high-proof Moonshine Mohobo	10	EPIC	Last Available: "2012-03"
+5619	high-proof artisanal Moonshine Mohobo	10	EPIC	Last Available: "2012-03"
 5620	aged Flaming Mohobo	3	awesome	Last Available: "2012-03"
 5621	hand-crafted blurry Drunken Philosopher	3	EPIC	Last Available: "2012-03"
 5622	hand-crafted Drunken Neurologist	4	EPIC	Last Available: "2012-03"
-5623	watered-down tolerable Drunken Astrophysicist	2	good	Last Available: "2012-03"
+5623	tolerable watered-down Drunken Astrophysicist	2	good	Last Available: "2012-03"
 5624	acceptable enchanted Dark & Starry	3	good	Effect: "Feelin' Philosophical", Effect Duration: 25, Last Available: "2012-03"
-5625	fortified perfectly mixed Black Hole	5	EPIC	Last Available: "2012-03"
-5626	lousy watered-down Event Horizon	2	decent	Last Available: "2012-03"
+5625	perfectly mixed fortified Black Hole	5	EPIC	Last Available: "2012-03"
+5626	watered-down lousy Event Horizon	2	decent	Last Available: "2012-03"
 5627	drinkable spirit-forward Herring Daiquiri	5	good	Last Available: "2012-03"
 5628	artisanal bouncing Herring Wallbanger	3	EPIC	Last Available: "2012-03"
-5629	hand-crafted high-proof Herringtini	8	EPIC	Last Available: "2012-03"
+5629	high-proof hand-crafted Herringtini	8	EPIC	Last Available: "2012-03"
 5630	perfectly mixed irresponsibly strong skewed narrow Lollipop Drop	9	EPIC	Last Available: "2012-03"
-5631	weak hand-crafted Candy Alexander	2	EPIC	Last Available: "2012-03"
+5631	hand-crafted weak Candy Alexander	2	EPIC	Last Available: "2012-03"
 5632	hand-crafted Candicaine	4	EPIC	Last Available: "2012-03"
 5633	artisanal Caipiranha	3	EPIC	Last Available: "2012-03"
 5634	acceptable Flying Caipiranha	3	good	Last Available: "2012-03"
@@ -5541,16 +5541,16 @@
 5638	tolerable practically non-alcoholic Haymaker	1	good	Last Available: "2012-03"
 5639	Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	ghostly crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
-5641	normal low-calorie narrow fungus	1	good	
+5641	low-calorie normal narrow fungus	1	good	
 5642	poisoned dart	0		
 5643	pressed triple-dry upside-down blinking stone wool	0		Effect: "Brocolate Brostidigitation", Effect Duration: 69
 5644	stones	0		
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	spinning supercool calendar	0		Moxie Percent: +20, Damage Reduction: 4
-5648	bouncing Socratic Boris's Helm of chilblains	0		Experience (Mysticality): +1, Cold Damage: +25, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5648	bouncing Socratic Boris's Helm of chilblains	0		Experience (Mysticality): +1, Cold Damage: +25, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5649	prompt veiny staph of homophones	0		Maximum HP: +10, Adventures: +3
-5650	squat aromatic clever Boris's Helm (askew) of doom	0		Maximum MP: +20, Spooky Spell Damage: +50, Stench Resistance: +1, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
+5650	squat aromatic clever Boris's Helm (askew) of doom	0		Maximum MP: +20, Spooky Spell Damage: +50, Stench Resistance: +1, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
 5651	mime soul fragment	0		Last Available: "2012-04"
 5652	wobbly Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
@@ -5577,16 +5577,16 @@
 5674	&quot;L&quot;	0		
 5675	compressed watered-down Red Minotaur	1		
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	beefy Ze&trade; goggles	0		Muscle: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
+5677	beefy Ze&trade; goggles	0		Muscle: +10, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
 5678	soggy used band-aid	0		Last Available: "2012-05"
-5679	mirror nasty Da Vinci's stylish swimsuit	0		Experience (Mysticality): +5, Stench Damage: +5, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
+5679	mirror nasty Da Vinci's stylish swimsuit	0		Experience (Mysticality): +5, Stench Damage: +5, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
 5680	twirling lost key	0		Last Available: "2012-05"
 5681	fancy adequate P.B.L.T.	3	good	Effect: "Libra Rising", Effect Duration: 25
 5682	blue note from Clancy	0		Skill: "Request Sandwich"
 5683	red BURT	0		
 5684	blinking handful of juicy garbage	0		
-5685	tumbling ghostly bugbear communicator badge	0		
-5686	fuchsia upside-down quantum nanopolymer spider web	0		
+5685	ghostly tumbling bugbear communicator badge	0		
+5686	upside-down fuchsia quantum nanopolymer spider web	0		
 5687	bugbear autopsy tweezers	0		
 5688	purple greedy UV monocular	0		Meat Drop: +20, Single Equip
 5689	drone self-destruct chip	0		
@@ -5605,11 +5605,11 @@
 5702	mannequin	0		Familiar Weight: +5
 5703	crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	upside-down skewed crafty wax hat of horror	0		Maximum MP: +10, Spooky Spell Damage: +25, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
-5706	jittery bouncing toasty wax pants of wisdom	0		Mysticality: +15, Hot Damage: +5, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
+5705	upside-down skewed crafty wax hat of horror	0		Maximum MP: +10, Spooky Spell Damage: +25, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
+5706	jittery bouncing toasty wax pants of wisdom	0		Mysticality: +15, Hot Damage: +5, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	irradiated energized drop of water-37	0		Effect: "The Power of Positive Thinking", Effect Duration: 61, Last Available: "2012-07"
-5709	ruddy banded fireman's helmet	0		Damage Absorption: +100, Maximum HP Percent: +40, Last Available: "2012-07", Familiar Effect: "cold atk"
+5709	ruddy banded fireman's helmet	0		Damage Absorption: +100, Maximum HP Percent: +40, Familiar Effect: "cold atk", Last Available: "2012-07"
 5712	spinning fuchsia brainy fire axe	0		Mysticality: +5, Last Available: "2012-07"
 5713	prompt toasty fire extinguisher of the brazier	0		Hot Damage: +5, Hot Spell Damage: +25, Adventures: +3, Last Available: "2012-07"
 5714	blurry FDKOL tattoo	0		
@@ -5624,8 +5624,8 @@
 5723	galvanized bottle of fire	0		Effect: "No Vertigo", Effect Duration: 36, Last Available: "2012-07"
 5724	shaking molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	knitted stylish hot daub bun	0		Moxie: +25, Cold Resistance: +3, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
-5727	dangerous thinker's hot daub stand	0		Mysticality: +10, Weapon Damage: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5726	knitted stylish hot daub bun	0		Moxie: +25, Cold Resistance: +3, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5727	dangerous thinker's hot daub stand	0		Mysticality: +10, Weapon Damage: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
 5728	crafty foot-long hot daub of the wise owl	0		Mysticality: +20, Maximum MP: +10, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	jumbo adequate angst burger	5	good	
@@ -5633,8 +5633,8 @@
 5732	blank note	0		
 5733	jittery eerily silent box	0		
 5734	rotten forbidden sausage	3	crappy	
-5735	bouncing slick Lord Flameface's cloak	0		Moxie: +10, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
-5736	alkaline non-denatured galvanized tumbling gray Drizzlers&trade; Black Licorice	0		Effect: "Prideful Strut", Effect Duration: 41
+5735	bouncing slick Lord Flameface's cloak	0		Moxie: +10, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5736	alkaline non-denatured galvanized gray tumbling Drizzlers&trade; Black Licorice	0		Effect: "Prideful Strut", Effect Duration: 41
 5737	nitrogenated polarized daub-breaker	0		Effect: "Tapped In", Effect Duration: 34, Last Available: "2020-09"
 5738	shaking toasty Camp Scout backpack	0		Hot Damage: +5, Softcore Only, Last Available: "2012-07"
 5739	CSA fire-starting kit	0		Last Available: "2012-07"
@@ -5647,7 +5647,7 @@
 5746	rotten bag of QWOP	3	crappy	Last Available: "2012-07"
 5747	polarized denatured CSA bravery badge	0		Effect: "Stop and Smell the Fudge", Effect Duration: 43, Last Available: "2012-07"
 5748	CSA all-purpose soap	0		Last Available: "2012-07"
-5749	smooth irresponsibly strong CSA cheerfulness ration	8	awesome	Last Available: "2012-07"
+5749	irresponsibly strong smooth CSA cheerfulness ration	8	awesome	Last Available: "2012-07"
 5750	CSA obedience grenade	0		Last Available: "2012-07"
 5751	upside-down Tales of the Word Realms	0		
 5752	flavorless crappy brain	4	decent	
@@ -5665,11 +5665,11 @@
 5765	personal trainer's fuzzy earmuffs of the cougar	0		Moxie: +20, Experience Percent (Muscle): +10, Familiar Effect: "1.5xVolley, cap 32"
 5766	twirling prompt censurious Tesla fuzzy montera	0		Sleaze Resistance: +3, Adventures: +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5767	Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
-5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
-5770	gray gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
-5771	teal gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
-5772	narrow narrow gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
+5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5770	gray gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5771	teal gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5772	narrow narrow gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
 5773	teal Thwaitgold maggot statuette	0		
 5774	ghostly talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5680,17 +5680,17 @@
 5781	lousy soft echo eyedrop antidote martini	4	decent	
 5782	morningwood plank	0		
 5783	raging hardwood plank	0		
-5784	bouncing blue weirdwood plank	0		
+5784	blue bouncing weirdwood plank	0		
 5785	thick caulk	0		
 5786	spinning hard screw	0		
-5787	gray shaking messy butt joint	0		
-5788	skewed huge smut orc keepsake box	0		
+5787	shaking gray messy butt joint	0		
+5788	huge skewed smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	box of bear arms	0		Last Available: "2012-09"
-5791	mirror chaotic smooth right bear arm	0		Moxie: +15, Spell Critical Percent: +10, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
-5792	foul-smelling Oprah's left bear arm of the glutton	0		Maximum MP Percent: +50, Stench Damage: +10, Food Drop: +100, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
+5791	mirror chaotic smooth right bear arm	0		Moxie: +15, Spell Critical Percent: +10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
+5792	foul-smelling Oprah's left bear arm of the glutton	0		Maximum MP Percent: +50, Stench Damage: +10, Food Drop: +100, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
 5793	medical-grade Hat O' Nine Tails	0		HP Regen Min: 7, HP Regen Max: 10
-5794	vacuum-sealed diffused bouncing tumbling Enchanted Plunger	0		Effect: "Resilient Spirit", Effect Duration: 20
+5794	vacuum-sealed diffused tumbling bouncing Enchanted Plunger	0		Effect: "Resilient Spirit", Effect Duration: 20
 5795	deionized non-diffused twirling tumbling Enchanted Flyswatter	0		Effect: "Warm Belly", Effect Duration: 53
 5796	altered deionized tumbling Gearhead Goo	0		Effect: "Taurus Rising", Effect Duration: 42
 5797	diffused tarnished Missing Eye Simulation Device	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 60
@@ -5698,10 +5698,10 @@
 5799	chilled upside-down eldritch dough	0		Effect: "Slightly Larger Than Usual", Effect Duration: 43
 5800	aerosolized cold-filtered Charity's choker	0		Effect: "Salamanderenity", Effect Duration: 21
 5801	double-liquefied spinning Smart Bone Dust	0		Effect: "Cake Caked", Effect Duration: 15
-5802	deionized polymerized bouncing shaking perpendicular guano	0		Effect: "Mistified", Effect Duration: 30
+5802	deionized polymerized shaking bouncing perpendicular guano	0		Effect: "Mistified", Effect Duration: 30
 5803	adjusted enhanced tumbling White Chocolate Golem Seeds	0		Effect: "Overstimulated", Effect Duration: 13
-5804	improved polymerized pulsating shaking Shivering Ch&egrave;vre	0		Effect: "Tomato Power", Effect Duration: 32
-5805	nitrogenated pulsating jittery breath mint	0		Effect: "Superhuman Sarcasm", Effect Duration: 46
+5804	improved polymerized shaking pulsating Shivering Ch&egrave;vre	0		Effect: "Tomato Power", Effect Duration: 32
+5805	nitrogenated jittery pulsating breath mint	0		Effect: "Superhuman Sarcasm", Effect Duration: 46
 5806	double-denatured diffused wobbly muesli	0		Effect: "Ocelot Eyes", Effect Duration: 28
 5807	nitrogenated maroon glass of warm milk	0		Effect: "Feet of Grapefruit", Effect Duration: 69
 5808	frozen glass of gnat milk	0		Effect: "New and Improved", Effect Duration: 61
@@ -5710,12 +5710,12 @@
 5811	chilled alkaline maroon blurry tube of lipstick	0		Effect: "How to Scam Tourists", Effect Duration: 53
 5812	denatured dry skelelton spine	0		Effect: "Pwnd", Effect Duration: 54
 5813	liquefied smut orc sunglasses	0		Effect: "Sweet, Nuts", Effect Duration: 37
-5814	extra-dry improved quadruple-colloidal twirling wobbly blob of acid	0		Effect: "Surreally Buff", Effect Duration: 30
+5814	extra-dry improved quadruple-colloidal wobbly twirling blob of acid	0		Effect: "Surreally Buff", Effect Duration: 30
 5815	non-adjusted flayed mind	0		Effect: "New and Improved", Effect Duration: 47
 5816	nitrogenated quadruple-dry kobold kibble	0		Effect: "Hopped Up on Goofballs", Effect Duration: 27
-5817	modified polarized adjusted teal twirling narrow forest spirit rattle	0		Effect: "Coated Arms", Effect Duration: 26
+5817	modified polarized adjusted twirling teal narrow forest spirit rattle	0		Effect: "Coated Arms", Effect Duration: 26
 5818	irradiated spinning Stone Golem pebbles	0		Effect: "Quaaaaaaa", Effect Duration: 12
-5819	ionized nitrogenated shaking spinning gravy fairy warlock hat	0		Effect: "Spooky Weapon", Effect Duration: 12
+5819	ionized nitrogenated spinning shaking gravy fairy warlock hat	0		Effect: "Spooky Weapon", Effect Duration: 12
 5820	anodized deionized purple bull blubber	0		Effect: "Cravin' for a Ravin'", Effect Duration: 12
 5821	adjusted tarnished olive squat frog lip-print	0		Effect: "Springy Fusilli", Effect Duration: 34
 5822	tarnished pickled pulsating gazely stare	0		Effect: "Bandersnatched", Effect Duration: 19
@@ -5724,7 +5724,7 @@
 5825	corrupted extra-quantum mirror Skullery Maid's Knee	0		Effect: "Halloweeny", Effect Duration: 11
 5826	diffused adjusted zombie hollandaise	0		Effect: "Sugar Smacks", Effect Duration: 28
 5827	electrified skeletal banana	0		Effect: "Hiding in Plain Sight", Effect Duration: 42
-5828	boiled skewed squat gilt perfume bottle	0		Effect: "Rat-Faced", Effect Duration: 58
+5828	boiled squat skewed gilt perfume bottle	0		Effect: "Rat-Faced", Effect Duration: 58
 5829	electrified jittery janglin' bones	0		Effect: "Destructive Resolve", Effect Duration: 19
 5830	quantum pygmy papers	0		Effect: "substats.enh", Effect Duration: 17
 5831	concentrated ionized tumbling pygmy dart	0		Effect: "License to Punch", Effect Duration: 50
@@ -5742,18 +5742,18 @@
 5843	frozen aerosolized pirate cream pie	0		Effect: "Ancient Protected", Effect Duration: 49
 5844	pickled cyan una poca de gracia	0		Effect: "Smoking like a Bandit", Effect Duration: 35
 5845	improved corrupted electrified twirling compressed air canister	0		Effect: "Faboooo", Effect Duration: 27
-5846	improved irradiated jittery bouncing green salt water taffy	0		Effect: "Quadrilled", Effect Duration: 25
+5846	improved irradiated bouncing jittery green salt water taffy	0		Effect: "Quadrilled", Effect Duration: 25
 5847	vacuum-sealed blurry unholy water	0		Effect: "Inner Dog", Effect Duration: 67
 5848	liquefied frozen Bangyomaman battle juice	0		Effect: "You Know When to Walk Away", Effect Duration: 43
 5849	irradiated nitrogenated ghostly handyman &quot;hand soap&quot;	0		Effect: "Nutrient-Rich", Effect Duration: 37
-5850	activated improved narrow blurry space marine flash grenade	0		Effect: "Hagg-ard", Effect Duration: 17
+5850	activated improved blurry narrow space marine flash grenade	0		Effect: "Hagg-ard", Effect Duration: 17
 5851	improved temporary tribal tattoo	0		Effect: "Conspiratory Eyes", Effect Duration: 34
 5852	concentrated adjusted frozen oil-filled donut	0		Effect: "Cold Throat", Effect Duration: 37
 5853	ionized fuchsia stick-on gnome beard	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 47
 5854	Vulcanized huge BRICKO stud	0		Effect: "Healthy Blue Glow", Effect Duration: 13
-5855	corrupted twirling twirling gray Osk'r Chow	0		Effect: "Bored Stiff", Effect Duration: 32
+5855	corrupted twirling gray twirling Osk'r Chow	0		Effect: "Bored Stiff", Effect Duration: 32
 5856	galvanized mirror Scuba Snack	0		Effect: "Dances with Tweedles", Effect Duration: 63
-5857	super-nitrogenated modified dry bouncing mirror grey cube	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 60
+5857	super-nitrogenated modified dry mirror bouncing grey cube	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 60
 5858	diffused ionized quadruple-polymerized votive candle	0		Effect: "Winklered", Effect Duration: 31
 5859	concentrated booby trap	0		Effect: "Human-Machine Hybrid", Effect Duration: 21
 5860	oxidized Agent Corrigan's cigarette	0		Effect: "Chalky White Pallor", Effect Duration: 67
@@ -5763,12 +5763,12 @@
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	concentrated papier-mochi	0		Effect: "One Very Clear Eye", Effect Duration: 25, Last Available: "2012-09"
 5866	double-wet blurry papier-m&acirc;chaeranthera	0		Effect: "Macho Profundo", Effect Duration: 67, Last Available: "2012-09"
-5867	dry ghostly maroon papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2012-09"
+5867	dry maroon ghostly papier-m&acirc;ch&eacute; toothpicks	0		Effect: "Creepin' Up on You", Effect Duration: 20, Last Available: "2012-09"
 5868	spinning wicked deadly papier-m&acirc;ch&eacute;te	0		Weapon Damage: +5, Spell Damage: +5, Last Available: "2012-09"
 5869	Jack Frost's personal trainer's papier-m&acirc;chine gun	0		Experience Percent (Muscle): +10, Cold Spell Damage: +50, Last Available: "2012-09"
 5870	inspector's grievous papier-masque	0		Weapon Damage Percent: +50, Item Drop: +15, Single Equip, Last Available: "2012-09"
-5871	pulsating reassuring Herculean papier-mitre	0		Experience (Muscle): +1, Spooky Resistance: +1, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
-5872	frightening arcane researcher's papier-m&acirc;churidars	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
+5871	pulsating reassuring Herculean papier-mitre	0		Experience (Muscle): +1, Spooky Resistance: +1, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
+5872	frightening arcane researcher's papier-m&acirc;churidars	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
 5873	blinking papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	squat skeleton	0		Last Available: "2012-10"
 5882	double-paned stanky skeleton skis of the businessman	0		Stench Spell Damage: +25, Cold Resistance: +5, Meat Drop: +50, Single Equip, Last Available: "2012-10"
-5883	yummy half-sized skeleton quiche	2	awesome	Last Available: "2012-10"
+5883	half-sized yummy skeleton quiche	2	awesome	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	green supercharged rosy-cheeked grievous Bonestabber of the cheetah	0		Weapon Damage Percent: +50, Maximum HP Percent: +30, Maximum MP Percent: +30, Initiative: +60, Last Available: "2012-10"
@@ -5795,7 +5795,7 @@
 5896	blinking canary nightlight	0		Familiar Weight: +5, Last Available: "2013-12"
 5897	vaporized Unconscious Collective Dream Jar	1	EPIC	Effect: "Human-Human Hybrid", Effect Duration: 50, Last Available: "2013-12"
 5898	jar of psychoses (The Suspicious-Looking Guy)	0		Last Available: "2013-12"
-5899	pulsating narrow jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
+5899	narrow pulsating jar of psychoses (The Captain of the Gourd)	0		Last Available: "2013-12"
 5900	jar of psychoses (The Crackpot Mystic)	0		Last Available: "2013-12"
 5901	jar of psychoses (The Old Man)	0		Last Available: "2013-12"
 5902	shaking jar of psychoses (The Pretentious Artist)	0		Last Available: "2013-12"
@@ -5811,7 +5811,7 @@
 5913	tarnished maroon candy sushi set	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 26, Last Available: "2012-12"
 5914	double-aerosolized polymerized sweet mochi ball	0		Effect: "Bats in the Belfry", Effect Duration: 67, Last Available: "2012-12"
 5915	diffused narrow beet-flavored Mr. Mediocrebar	0		Effect: "Macho, Macho Dog", Effect Duration: 41, Last Available: "2012-12"
-5916	boiled pickled wobbly pulsating cyan sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Pemmican't", Effect Duration: 22, Last Available: "2012-12"
+5916	boiled pickled cyan wobbly pulsating sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Pemmican't", Effect Duration: 22, Last Available: "2012-12"
 5917	vacuum-sealed green cabbage-flavored Mr. Mediocrebar	0		Effect: "Sweet Incentive", Effect Duration: 21, Last Available: "2012-12"
 5918	twirling ribald plastic animelf	0		Sleaze Damage: +10, Last Available: "2012-12"
 5919	shellacked plastic ChibiBuddy&trade;	0		Damage Reduction: 7, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	spinning jittery ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	jittery BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of the sewer	0		Stench Damage: +25, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
+5928	brainwave-controlled unicorn horn of the sewer	0		Stench Damage: +25, Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Uni-Gore"
 5929	blurry bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	fireproof careful Tesla plastic four-shadowed mime	0		Monster Level: -10, Hot Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2012-12"
@@ -5858,13 +5858,13 @@
 5960	zippy plastic Father McGruber	0		Initiative: +20, Last Available: "2012-12"
 5961	frightening plastic Hank North, Photojournalist	0		Spooky Damage: +5, Last Available: "2012-12"
 5962	supercharged plastic blazing bat	0		Maximum MP Percent: +30, Last Available: "2012-12"
-5963	prompt gravedigger's electronic dulcimer pants	0		Spooky Damage: +10, Adventures: +3, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
+5963	prompt gravedigger's electronic dulcimer pants	0		Spooky Damage: +10, Adventures: +3, Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12", Conditional Skill (Equipped): "Play Hog Fiddle"
 5964	A-Boo clue	0		
 5965	Frown Exerciser of courage of the early riser	0		Spooky Resistance: +3, Adventures: +7, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
 5967	soul doorbell	0		
 5968	cyan soul coin	0		
-5969	pulsating wobbly soul knife	0		
+5969	wobbly pulsating soul knife	0		
 5970	pulsating Temple Grandin's soul mask	0		Familiar Weight: +7, Single Equip
 5971	yellow record of infuriating silence	0		Skill: "Silent Slam", Last Available: "2012-10"
 5972	record of infuriating silence (used)	0		Skill: "Silent Slam", Last Available: "2012-10"
@@ -5877,9 +5877,9 @@
 5979	huge coin	0		Last Available: "2013-02"
 5980	spinning cartoon heart	0		Last Available: "2013-02"
 5981	twirling star	0		Last Available: "2013-02"
-5982	triple-distilled acceptable blurry green tankard of ale	9	good	Last Available: "2013-02"
+5982	acceptable triple-distilled green blurry tankard of ale	9	good	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	nasty sizzling cloth cap of the sewer	0		Hot Damage: +10, Stench Damage: 30, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
+5984	nasty sizzling cloth cap of the sewer	0		Hot Damage: +10, Stench Damage: 30, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
 5985	wobbly crafty padded iron dagger of horror	0		Damage Absorption: +20, Maximum MP: +10, Spooky Spell Damage: +25, Last Available: "2013-02"
 5986	tiny yummy hamburger	1	awesome	Last Available: "2013-02"
 5987	tumbling dollar-sign bag	0		Last Available: "2013-02"
@@ -5887,21 +5887,21 @@
 5989	potion	0		Last Available: "2013-02"
 5990	high-proof lousy bouncing bottle of wine	7	decent	Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	frosty dangerous beefy iron helmet	0		Muscle: +10, Weapon Damage: +10, Cold Spell Damage: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
+5992	frosty dangerous beefy iron helmet	0		Muscle: +10, Weapon Damage: +10, Cold Spell Damage: +10, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
 5993	jittery lard-coated toasty smartaleck's steel sword	0		Moxie Percent: +30, Hot Damage: +5, Sleaze Spell Damage: +25, Last Available: "2013-02"
 5994	normal whole roasted chicken	4	good	Last Available: "2013-02"
-5995	gray bouncing massive gemstone	0		Last Available: "2013-02"
+5995	bouncing gray massive gemstone	0		Last Available: "2013-02"
 5996	blurry extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
-5998	watered-down drinkable huge shining goblet	2	good	Last Available: "2013-02"
+5998	drinkable watered-down huge shining goblet	2	good	Last Available: "2013-02"
 5999	lime green fireball	0		Last Available: "2013-02"
-6000	huge strapping crown of Leguizamo of courage	0		Muscle: +5, Monster Level: +20, Spooky Resistance: +3, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
+6000	huge strapping crown of Leguizamo of courage	0		Muscle: +5, Monster Level: +20, Spooky Resistance: +3, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
 6001	pulsating bouncing teal MacGyver's sword of the wise owl of temperance	0		Mysticality: +20, Maximum MP: +100, Sleaze Resistance: +5, Last Available: "2013-02"
-6002	jittery manspreader's Helm of the Scream Emperor of Flo-Jo of the early riser	0		Monster Level: +10, Initiative: +100, Adventures: +7, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
+6002	jittery manspreader's Helm of the Scream Emperor of Flo-Jo of the early riser	0		Monster Level: +10, Initiative: +100, Adventures: +7, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
 6003	huge Cloak of Dire Shadows of the dark arts of the businessman of the early riser	0		Spell Damage Percent: +100, Meat Drop: +50, Adventures: +7, Last Available: "2013-02"
 6004	squat wool Tesla Sword of Dark Omens of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-02"
 6005	mirror fuchsia zippy dog trainer's Shield of Icy Fate of the bloodbag	0		Maximum HP: +100, Experience (familiar): +1, Initiative: +20, Damage Reduction: 7, Last Available: "2013-02"
-6006	coward's manspreader's brainy Greaves of the Murk Lord	0		Mysticality: +5, Monster Level: -10, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
+6006	coward's manspreader's brainy Greaves of the Murk Lord	0		Mysticality: +5, Monster Level: -10, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
 6007	medical-grade Fonzie's Gauntlets of the Blood Moon of chilblains	0		Experience (Moxie): +1, Cold Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2013-02"
 6008	perfumed manspreader's Boots of Twilight Whispers of vim and vigor	0		Maximum HP Percent: +50, Monster Level: +10, Stench Resistance: +5, Single Equip, Last Available: "2013-02"
 6009	red stanky hardened Belt of Howling Anger of the ox	0		Muscle: +20, Damage Reduction: 3, Stench Spell Damage: +25, Single Equip, Last Available: "2013-02"
@@ -5913,7 +5913,7 @@
 6015	enhanced nitrogenated orcish hand lotion	0		Effect: "Scavengers Scavenging", Effect Duration: 19
 6016	aerosolized orcish rubber	0		Effect: "Gobliny Flavor", Effect Duration: 64
 6017	flattened twirling orcish nailing lube	0		Effect: "Is This Your Card?", Effect Duration: 40
-6018	watered-down mediocre backwoods screwdriver	2	decent	
+6018	mediocre watered-down backwoods screwdriver	2	decent	
 6019	maroon beefy loadstone	0		Muscle: +10
 6020	pulsating therapeutic Claybender glasses of horror	0		Spooky Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip
 6021	blurry inspector's Duskwalker fangs	0		Item Drop: 20
@@ -5931,7 +5931,7 @@
 6033	yellow vibrating deadly stolen necklace	0		Weapon Damage: +5, Maximum MP Percent: +10
 6034	Jeselnik's smooth troll britches	0		Moxie: +15, Sleaze Damage: +25, Familiar Effect: "1.5xPotato, cap 28"
 6035	warmed enhanced vial of The Glistening	0		Effect: "The Magic of Sharing", Effect Duration: 29
-6036	special hand-crafted pulsating artisanal limoncello	3	EPIC	Effect: "Stick Emporium Membership", Effect Duration: 40
+6036	hand-crafted special pulsating artisanal limoncello	3	EPIC	Effect: "Stick Emporium Membership", Effect Duration: 40
 6037	ginger ale	0		
 6038	small normal upside-down incredible pizza	2	good	
 6039	cool oil cap of Flo-Jo	0		Moxie: +5, Initiative: +100, Familiar Effect: "cap 28"
@@ -5948,10 +5948,10 @@
 6050	jittery twirling woimbook	0		Familiar Weight: +5
 6051	mirror Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
 6052	low-calorie adequate bouncing Taco Dan's Taco Stand Taco	1	good	Last Available: "2012-12"
-6053	lousy watered-down Taco Dan's Taco Stand Chimichangarita	2	decent	Last Available: "2012-12"
+6053	watered-down lousy Taco Dan's Taco Stand Chimichangarita	2	decent	Last Available: "2012-12"
 6054	polarized blinking Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Chain Chain Chains", Effect Duration: 11, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
+6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
 6057	shaking Sherlock's Meatcleaver of the glutton	0		Item Drop: +25, Food Drop: +100, Last Available: "2013-12"
 6058	greedy Crimbo Elf bobble-head	0		Meat Drop: +20, Last Available: "2012-12"
 6059	Crimbo stogie-scented room odorizer of chilblains	0		Cold Damage: +25, Last Available: "2012-12"
@@ -5975,10 +5975,10 @@
 6077	massive normal haggis-wrapped haggis-stuffed haggis	7	good	Last Available: "2012-12"
 6078	upside-down home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	ghostly ribald haggis socks	0		Sleaze Damage: +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
-6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
+6080	ghostly ribald haggis socks	0		Sleaze Damage: +10, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
+6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
-6083	skewed green actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
+6083	green skewed actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
 6085	huge magnetic sculpture kit	0		Last Available: "2012-12"
 6086	friendly Microplushie: Otakulone	0		Familiar Weight: +3, Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	blinking wobbly abacus	0		Last Available: "2013-12"
 6120	bonsai tree	0		Last Available: "2013-12"
-6121	acceptable irresponsibly strong spinning Chinese beer	8	good	Last Available: "2013-12"
+6121	irresponsibly strong acceptable spinning Chinese beer	8	good	Last Available: "2013-12"
 6122	blue cat statue	0		Last Available: "2013-12"
 6123	bouncing rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6037,34 +6037,34 @@
 6139	tumbling inspector's rubber gloves	0		Item Drop: +15, Last Available: "2013-12"
 6140	Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
-6142	rotten huge squat roasted duck	6	crappy	Last Available: "2013-12"
+6142	huge rotten squat roasted duck	6	crappy	Last Available: "2013-12"
 6143	bland dead meat bun	4	decent	Last Available: "2013-12"
 6144	cat collar of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2013-12"
-6145	lard-coated stylish suspicious-looking fedora	0		Moxie: +25, Sleaze Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
+6145	lard-coated stylish suspicious-looking fedora	0		Moxie: +25, Sleaze Spell Damage: +25, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
 6147	wobbly Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
 6150	blinking Snow Suit	0		Familiar Weight: +20, Softcore Only, Last Available: "2013-01"
 6151	carrot nose	0		Last Available: "2013-01"
-6152	special normal half-sized carrot cake	2	good	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2013-01"
+6152	half-sized normal special carrot cake	2	good	Effect: "Fishy Fortification", Effect Duration: 40, Last Available: "2013-01"
 6153	weak tolerable spinning carrot claret	2	good	Last Available: "2013-01"
 6154	denatured pulsating carrot juice	1	crappy	Effect: "Thunderheart", Effect Duration: 5, Last Available: "2013-01"
 6155	spinning twirling pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	occult Da Vinci's Byte	0		Experience (Mysticality): +5, Spell Damage Percent: +25, Last Available: "2013-12"
-6158	avaricious anger blaster	0		Meat Drop: +30, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
-6159	lime green personal trainer's doubt cannon	0		Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
-6160	squat fear condenser of vim and vigor	0		Maximum HP Percent: +50, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
-6161	olive regret hose of the empath	0		Familiar Weight: +5, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
+6158	avaricious anger blaster	0		Meat Drop: +30, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
+6159	lime green personal trainer's doubt cannon	0		Experience Percent (Muscle): +10, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
+6160	squat fear condenser of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
+6161	olive regret hose of the empath	0		Familiar Weight: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	purple supercharged dance instructor's commodore's hat	0		Experience Percent (Moxie): +10, Maximum MP Percent: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
-6165	scandalous naval trousers	0		Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
+6164	purple supercharged dance instructor's commodore's hat	0		Experience Percent (Moxie): +10, Maximum MP Percent: +30, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
+6165	scandalous naval trousers	0		Sleaze Damage: +5, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
 6166	deck cannon of vim and vigor of incineration	0		Maximum HP Percent: +50, Hot Spell Damage: +50, Last Available: "2013-12"
 6167	huge Jack Frost's ornamental sextant	0		Cold Spell Damage: +50, Last Available: "2013-12"
 6168	blue hardened sage Bloodbath	0		Mysticality Percent: +10, Damage Reduction: 3, Last Available: "2013-12"
-6169	spirit-forward aged Hundred Headed IPA	5	awesome	Last Available: "2013-12"
-6170	thick decent chum	5	good	Last Available: "2013-12"
+6169	aged spirit-forward Hundred Headed IPA	5	awesome	Last Available: "2013-12"
+6170	decent thick chum	5	good	Last Available: "2013-12"
 6171	Vulcanized liquefied pulsating crude crudit&eacute;s	0		Effect: "Hot Blooded", Effect Duration: 35
 6172	flattened candy crayons	0		Effect: "Ooh, Bitter!", Effect Duration: 44, Last Available: "2020-09"
 6173	jittery knitted pixel grappling hook of Calamity Jane	0		Critical Hit Percent: +15, Cold Resistance: +3
@@ -6080,58 +6080,58 @@
 6183	cosmic fruit	0		
 6184	padded razor-sharp Jarlsberg's hat of doom	0		Weapon Damage Percent: +25, Damage Absorption: +20, Spooky Spell Damage: +50
 6185	moldy consummate hard-boiled egg	3	crappy	
-6186	spoiled jumbo consummate fried egg	5	crappy	
+6186	jumbo spoiled consummate fried egg	5	crappy	
 6187	tasty spinning consummate egg salad	3	awesome	
 6188	normal consummate bagel	3	good	
-6189	decent snack-sized consummate sliced bread	2	good	
-6190	bland super-sized consummate hot dog bun	5	decent	
-6191	huge bland bouncing consummate brownie	9	decent	
-6192	stale yellow pulsating consummate toast	3	decent	
+6189	snack-sized decent consummate sliced bread	2	good	
+6190	super-sized bland consummate hot dog bun	5	decent	
+6191	bland huge bouncing consummate brownie	9	decent	
+6192	stale pulsating yellow consummate toast	3	decent	
 6193	mediocre passable stout	4	decent	
 6194	stale consummate soup	4	decent	
 6195	bland olive consummate corn chips	3	decent	
-6196	miniature adequate consummate salad	2	good	
-6197	enchanted tasty jumbo consummate salsa	5	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
+6196	adequate miniature consummate salad	2	good	
+6197	enchanted jumbo tasty consummate salsa	5	awesome	Effect: "Abyssal Sweat", Effect Duration: 35
 6198	tasty bite-sized consummate sauerkraut	1	awesome	
-6199	massive normal consummate cheese slice	8	good	
+6199	normal massive consummate cheese slice	8	good	
 6200	miniature decent consummate melted cheese	2	good	
-6201	spoiled fancy green consummate bacon	3	crappy	Effect: "Oily Flavor", Effect Duration: 30
-6202	bite-sized moldy consummate meatloaf	1	crappy	
-6203	fancy diet flavorless spinning consummate steak	1	decent	Effect: "Boschface", Effect Duration: 5
+6201	fancy spoiled green consummate bacon	3	crappy	Effect: "Oily Flavor", Effect Duration: 30
+6202	moldy bite-sized consummate meatloaf	1	crappy	
+6203	flavorless diet fancy spinning consummate steak	1	decent	Effect: "Boschface", Effect Duration: 5
 6204	flavorless consummate cuts	4	decent	
-6205	huge decent teal consummate frankfurter	9	good	
+6205	decent huge teal consummate frankfurter	9	good	
 6206	decent consummate french fries	3	good	
-6207	super-sized bland blurry blue consummate baked potato	5	decent	
+6207	bland super-sized blurry blue consummate baked potato	5	decent	
 6208	fortified tolerable bouncing acceptable vodka	5	good	
 6209	adequate consummate ice cream	3	good	
 6210	spoiled consummate whipped cream	3	crappy	
 6211	normal consummate cream	3	good	
 6212	adequate consummate strawberries	4	good	
-6213	miniature delicious blurry consummate sorbet	2	awesome	
+6213	delicious miniature blurry consummate sorbet	2	awesome	
 6214	delicious adequate rum	3	awesome	
-6215	tolerable watered-down mediocre lager	2	good	
-6216	miniature rotten mirror immaculate grilled cheese	2	crappy	
-6217	miniature delicious skewed tumbling immaculate ice cream sandwich	2	awesome	
+6215	watered-down tolerable mediocre lager	2	good	
+6216	rotten miniature mirror immaculate grilled cheese	2	crappy	
+6217	delicious miniature skewed tumbling immaculate ice cream sandwich	2	awesome	
 6218	normal immense huge immaculate hot dog	9	good	
-6219	bland enchanted miniature immaculate egg salad sandwich	2	decent	Effect: "Eye of the Lihc", Effect Duration: 50
-6220	immense spoiled perfect sandwich	8	crappy	
-6221	special stale perfect chef salad	3	decent	Effect: "Celestial Vision", Effect Duration: 10
+6219	miniature enchanted bland immaculate egg salad sandwich	2	decent	Effect: "Eye of the Lihc", Effect Duration: 50
+6220	spoiled immense perfect sandwich	8	crappy	
+6221	stale special perfect chef salad	3	decent	Effect: "Celestial Vision", Effect Duration: 10
 6222	normal huge perfect breakfast	3	good	
 6223	spoiled sublime deluxe hot dog	3	crappy	
 6224	normal diet mirror sublime stew	1	good	
 6225	miniature spoiled blurry sublime nachos	2	crappy	
 6226	snack-sized bland tumbling upside-down Ultimate Breakfast Sandwich	2	decent	
-6227	moldy special snack-sized Loaded Baked Potato	2	crappy	Effect: "Faboooo", Effect Duration: 30
+6227	moldy snack-sized special Loaded Baked Potato	2	crappy	Effect: "Faboooo", Effect Duration: 30
 6228	huge flavorless blurry Omega Sundae	6	decent	
-6229	irresponsibly strong lousy Das Sauerlager	9	decent	
-6230	strong lousy blurry shaking Bologna Lambic	5	decent	
+6229	lousy irresponsibly strong Das Sauerlager	9	decent	
+6230	lousy strong shaking blurry Bologna Lambic	5	decent	
 6231	perfectly mixed practically non-alcoholic Vodka Dog	1	super ultra EPIC	
 6232	acceptable fuchsia Disappointed Russian	4	good	
 6233	delicious Chunky Mary	3	awesome	
 6234	lousy Nachojito	4	decent	
 6235	perfectly mixed Le Roi	3	EPIC	
 6236	tolerable Over Easy Rider	4	good	
-6237	blue mirror cosmic six-pack	0		
+6237	mirror blue cosmic six-pack	0		
 6239	irradiated alkaline cube of ectoplasm	0		Effect: "Disco Neuropathy", Effect Duration: 25
 6240	polarized galvanized gray Illuminati earpiece	0		Effect: "Vanity Rage", Effect Duration: 63
 6241	anodized squat teal censored can label	0		Effect: "Thought", Effect Duration: 46
@@ -6174,7 +6174,7 @@
 6278	Ye Olde Medieval Insult	0		
 6279	pewter claymore of the cheetah	0		Initiative: +60
 6280	bouncing wobbly Tesla artisanal rice peeler	0		MP Regen Min: 7, MP Regen Max: 10
-6281	spoiled spinning yellow heirloom grape tomato	3	crappy	
+6281	spoiled yellow spinning heirloom grape tomato	3	crappy	
 6282	wobbly chipotle wasabi cilantro aioli	0		
 6283	brown felt tophat of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "1xLep, cap 37"
 6284	gear	0		
@@ -6182,11 +6182,11 @@
 6286	double-paned crafty curative Mark II Steam-Hat	0		Maximum MP: +10, Cold Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6287	sizzling savvy wizardly Mark III Steam-Hat of the cougar	0		Mysticality: +25, Moxie: +20, Mysticality Percent: +20, Hot Damage: +10, Familiar Effect: "1xLep, cap 37"
 6288	wobbly yellow Jim Carey's MacGyver's baleful supercool beefy Mark IV Steam-Hat	0		Muscle: +10, Moxie Percent: +20, Spell Damage: +25, Maximum MP: +100, Monster Level: +25, Familiar Effect: "1xLep, cap 37"
-6289	teal family-friendly rosy-cheeked baleful Mark V Steam-Hat of the ox of dire peril	0		Muscle: +20, Weapon Damage: +20, Spell Damage: +25, Maximum HP Percent: +30, Sleaze Resistance: +1, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
-6290	gray tumbling steam-powered model rocketship	0		
+6289	teal family-friendly rosy-cheeked baleful Mark V Steam-Hat of the ox of dire peril	0		Muscle: +20, Weapon Damage: +20, Spell Damage: +25, Maximum HP Percent: +30, Sleaze Resistance: +1, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6290	tumbling gray steam-powered model rocketship	0		
 6291	frosty veiny punk rock jacket	0		Maximum HP: +10, Cold Spell Damage: +10
 6292	bouncing teal Jack Frost's safety pin of the boozehound	0		Cold Spell Damage: +50, Booze Drop: +100
-6293	rotten snack-sized stolen sushi	2	crappy	
+6293	snack-sized rotten stolen sushi	2	crappy	
 6294	very overdue library book	0		
 6295	drum 'n' bass 'n' drum 'n' bass record	0		
 6296	mirror cosmic bucket	0		Free Pull
@@ -6194,7 +6194,7 @@
 6298	Thwaitgold firefly statuette	0		
 6299	model airship	0		
 6300	oxidized oxidized huge Super Weight-Gain 9000	0		Effect: "Savage Beast Inside", Effect Duration: 66
-6301	concentrated bouncing twirling possibility potion	0		Effect: "Hagg-ard", Effect Duration: 56
+6301	concentrated twirling bouncing possibility potion	0		Effect: "Hagg-ard", Effect Duration: 56
 6302	squat eleven-foot pole	0		
 6303	spinning ring of Detect Boring Doors	0		
 6304	flame-retardant dog trainer's healthy banded Jarlsberg's pan (Cosmic portal mode) of incineration	0		Damage Absorption: +100, Maximum HP Percent: +20, Experience (familiar): +1, Hot Spell Damage: +50, Hot Resistance: +1, Softcore Only, Free Pull, Last Available: "2013-03"
@@ -6221,7 +6221,7 @@
 6325	family-friendly Da Vinci's aquamariner's necklace of courage	0		Experience (Mysticality): +5, Spooky Resistance: +3, Sleaze Resistance: +1, Single Equip
 6326	executive supercool pearl diver's ring	0		Moxie Percent: +20, Meat Drop: +40, Single Equip
 6327	pearl diver's necklace of wisdom of Calamity Jane	0		Mysticality: +15, Critical Hit Percent: +15, Single Equip
-6328	ghostly twirling sushi doily	0		
+6328	twirling ghostly sushi doily	0		
 6329	scimitar cozy	0		
 6330	fish stick cozy	0		
 6331	bazooka cozy	0		
@@ -6250,14 +6250,14 @@
 6354	dry gray squat Mer-kin smartjuice	0		Effect: "Gunky Dory", Effect Duration: 69
 6355	extra-concentrated activated jittery Mer-kin cooljuice	0		Effect: "Polka of Plenty", Effect Duration: 66
 6356	squat Mer-kin worktea	0		
-6357	jittery upside-down Mer-kin knucklebone	0		
+6357	upside-down jittery Mer-kin knucklebone	0		
 6358	mirror Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	auspicious Mer-kin begsign	0		Item Drop: +10, Meat Drop: +40
 6360	Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	corrupted pulled taffy	0		Effect: "Educated (Sorta)", Effect Duration: 37, Last Available: "2013-04"
 6362	diffused pulled indigo taffy	0		Effect: "Booing Radly", Effect Duration: 52, Last Available: "2013-04"
 6363	altered frozen deionized pulled taffy	0		Effect: "Preternatural Greed", Effect Duration: 46, Last Available: "2013-04"
-6364	deionized twirling skewed pulled taffy	0		Effect: "Mer-kindliness", Effect Duration: 62, Last Available: "2013-04"
+6364	deionized skewed twirling pulled taffy	0		Effect: "Mer-kindliness", Effect Duration: 62, Last Available: "2013-04"
 6365	flattened pulled taffy	0		Effect: "Stimulated Body", Effect Duration: 51, Last Available: "2013-04"
 6366	irradiated alkaline pulled violet taffy	0		Effect: "White Knuckles", Effect Duration: 61, Last Available: "2013-04"
 6367	denatured activated pulled taffy	0		Effect: "Comic Violence", Effect Duration: 64, Last Available: "2013-04"
@@ -6273,7 +6273,7 @@
 6378	bouncing eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	dry dry ph balancer	0		Effect: "Adorable Lookout", Effect Duration: 12
-6381	dry boiled twirling blinking mysterious chemical residue	0		Effect: "Unusual Fashion Sense", Effect Duration: 25
+6381	dry boiled blinking twirling mysterious chemical residue	0		Effect: "Unusual Fashion Sense", Effect Duration: 25
 6382	nugget of sodium	0		
 6383	root beer	1	decent	
 6384	jigsaw blade	0		
@@ -6301,20 +6301,20 @@
 6406	quadruple-corrupted altered fudge-shaped hole in space-time	0		Effect: "This Is Where You're a Viking", Effect Duration: 59
 6407	gravedigger's flame-wreathed baleful Pocket Square of Loathing	0		Spell Damage: +25, Hot Spell Damage: +10, Spooky Damage: +10, Single Equip
 6408	shaking corrupted stardust	0		
-6409	spinning skewed Star Spawn	0		
+6409	skewed spinning Star Spawn	0		
 6410	teal bow from beyond the stars	0		Familiar Weight: +5
 6411	KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	upside-down shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	huge upside-down clutch of dodecapede eggs	0		
-6415	decent bite-sized flavorless gruel	1	good	
+6415	bite-sized decent flavorless gruel	1	good	
 6416	adequate twirling mana curds	3	good	
 6417	twist of lime	0		
 6418	pencil stub	0		
 6419	double-nitrogenated blurry moth dust	0		Effect: "Carrrsmic", Effect Duration: 58
 6420	pickled triple-boiled glob of spoiled mayo	0		Effect: "You Liver", Effect Duration: 32
 6421	tonic djinn	0		
-6422	rotten snack-sized vampire chowder	2	crappy	
+6422	snack-sized rotten vampire chowder	2	crappy	
 6423	Tales of Dread	0		Free Pull
 6424	red Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
@@ -6338,7 +6338,7 @@
 6443	mirror baleful dangerous Helps-You-Sleep	0		Weapon Damage: +10, Spell Damage: +25, Single Equip
 6444	twirling rosewater-soaked greasy Lo Pan's Quiets-Your-Steps	0		Spell Critical Percent: +30, Sleaze Spell Damage: +10, Stench Resistance: +3, Single Equip
 6445	coward's brawny Protects-Your-Junk	0		Muscle Percent: +20, Monster Level: -20, Single Equip
-6446	aged watered-down Gets-You-Drunk	2	awesome	
+6446	watered-down aged Gets-You-Drunk	2	awesome	
 6447	flame-retardant Annie Oakley's occult Great Wolf's headband	0		Spell Damage Percent: +25, Critical Hit Percent: +20, Hot Resistance: +1, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	olive MacGyver's Great Wolf's left paw of extreme caution of the blizzard	0		Maximum MP: +100, Monster Level: -25, Cold Spell Damage: +25, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	lightning-fast mansplainer's Great Wolf's right paw of extreme caution	0		Monster Level: -10, Initiative: +40, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6351,7 +6351,7 @@
 6456	energetic Sinatra's wizardly zombie mariachi pants	0		Mysticality: +25, Experience (Moxie): +5, Maximum MP Percent: +20, Class: "Accordion Thief", Familiar Effect: "1xPotato, 1xFairy"
 6457	manspreader's stiffened HOA regulation book of vim and vigor	0		Damage Reduction: 24, Maximum HP Percent: +50, Monster Level: +10
 6458	huge hardy smartaleck's supercool HOA zombie eyes	0		Moxie Percent: 50, Maximum HP: +50, Single Equip
-6459	shaking wobbly HOA citation pad	0		
+6459	wobbly shaking HOA citation pad	0		
 6460	wriggling severed nose	0		
 6461	nosy nose ringy ring	0		Familiar Weight: +15
 6462	flame-retardant sizzling dog trainer's Mayor Ghost's toupee	0		Experience (familiar): +1, Hot Damage: +10, Hot Resistance: +1, Class: "Pastamancer", Familiar Effect: "spooky atk, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	huge bland Dreadsylvanian shepherd's pie	7	decent	
+6488	bland huge Dreadsylvanian shepherd's pie	7	decent	
 6489	twirling pulsating music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	lime green tailfeathers	0		Familiar Weight: +5
@@ -6389,7 +6389,7 @@
 6494	replica key	0		
 6495	Dreadsylvania Auditor's badge of doom	0		Spooky Spell Damage: +50, Kruegerand Drop: 5, Single Equip
 6496	narrow blood kiwi	0		
-6497	spinning tumbling yellow eau de mort	0		
+6497	yellow spinning tumbling eau de mort	0		
 6498	delicious high-proof bloody kiwitini	6	awesome	
 6499	mirror moon-amber	0		
 6500	polished moon-amber	0		
@@ -6456,8 +6456,8 @@
 6562	mini-Mr. Accessory	0		Familiar Weight: +5
 6563	hand of Mr. Cards of the empath	0		Familiar Weight: +5, Conditional Skill (Equipped): "Throw a Mr. Card"
 6564	special adequate Dreadsylvanian hot pocket	3	good	Effect: "Flimsy Shield of the Pastalord", Effect Duration: 50
-6565	flavorless teal mirror Dreadsylvanian pocket	3	decent	
-6566	stale gigantic blurry shaking Dreadsylvanian pocket	9	decent	
+6565	flavorless mirror teal Dreadsylvanian pocket	3	decent	
+6566	gigantic stale shaking blurry Dreadsylvanian pocket	9	decent	
 6567	snack-sized decent Dreadsylvanian stink pocket	2	good	
 6568	snack-sized moldy Dreadsylvanian sleaze pocket	2	crappy	
 6569	lousy practically non-alcoholic Dreadsylvanian hot toddy	1	decent	
@@ -6486,7 +6486,7 @@
 6592	zippy steel-toed occult optimal spreadsheet	0		Spell Damage Percent: +25, Damage Reduction: 9, Initiative: +20
 6593	spinning defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
-6595	pickled twirling jittery epic cluster	1	decent	
+6595	pickled jittery twirling epic cluster	1	decent	
 6596	clockwork egg	0		
 6597	clockwork birdhouse	0		
 6598	clockwork disc	0		
@@ -6506,11 +6506,11 @@
 6612	clockwork numeral XII	0		
 6613	upside-down clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	weak artisanal Cold One	2	???	
+6615	artisanal weak Cold One	2	???	
 6616	spoiled spaghetti breakfast	4	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
-6619	narrow olive folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
+6619	olive narrow folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
 6622	folder (cyan)	0		Mysticality: +15, Moxie: +15, Last Available: "2013-08"
@@ -6540,8 +6540,8 @@
 6648	grievous slide rule of the scaredy-cat	0		Weapon Damage Percent: +50, Monster Level: -15
 6649	denatured twirling blurry green Ogres and Oubliettes&trade; module	0		Effect: "Be a Mind Master", Effect Duration: 19
 6650	Mountain Stream Code Black Alert	0		
-6651	twirling wobbly twisted-up wet towel	0		
-6652	hand-crafted irresponsibly strong stepmom's booze	9	EPIC	
+6651	wobbly twirling twisted-up wet towel	0		
+6652	irresponsibly strong hand-crafted stepmom's booze	9	EPIC	
 6653	twirling surgical tape	0		
 6654	bouncing yellow dog trainer's band T-shirt	0		Experience (familiar): +1
 6655	delicious irresponsibly strong fountain 'soda'	6	awesome	
@@ -6583,11 +6583,11 @@
 6691	McClusky file (page 3)	0		
 6692	shaking McClusky file (page 4)	0		
 6693	McClusky file (page 5)	0		
-6694	blinking red boring binder clip	0		
+6694	red blinking boring binder clip	0		
 6695	upside-down McClusky file (complete)	0		
 6696	bowling ball	0		
 6697	moss-covered stone sphere	0		
-6698	jittery blurry dripping stone sphere	0		
+6698	blurry jittery dripping stone sphere	0		
 6699	crackling stone sphere	0		
 6700	scorched stone sphere	0		
 6701	stone triangle	0		
@@ -6613,13 +6613,13 @@
 6721	ghostly asbestos-lined horrifying lion tamer's water bottle	0		Experience (familiar): +2, Spooky Damage: +25, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	quadruple-moist pygmy phone number	0		Effect: "Sugar High", Effect Duration: 28
 6723	Boozehounds Anonymous token	0		
-6724	small flavorless exotic jungle fruit	2	decent	
+6724	flavorless small exotic jungle fruit	2	decent	
 6725	mirror Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	tumbling ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
-6730	jittery blue funky junk key	0		
+6730	blue jittery funky junk key	0		
 6731	Worse Homes and Gardens	0		
 6732	claw-foot bathtub	0		
 6733	maroon clothesline pole	0		
@@ -6634,7 +6634,7 @@
 6742	blue junk band of the early riser	0		Adventures: +7
 6743	huge huge double-paned junk trunks	0		Cold Resistance: +5, Familiar Effect: "cap 15"
 6744	curative junk-mail shirt	0		HP Regen Min: 3, HP Regen Max: 5
-6745	tiny moldy blinking junk food	1	crappy	
+6745	moldy tiny blinking junk food	1	crappy	
 6746	hand-crafted watered-down junk yard	2	EPIC	
 6747	Van der Graaf banded swordzall	0		Damage Absorption: +100, MP Regen Min: 5, MP Regen Max: 7
 6748	energetic arm buzzer	0		Maximum MP Percent: +20, Damage Reduction: 6
@@ -6644,12 +6644,12 @@
 6752	ghostly upside-down handful of barley	0		
 6753	pulsating cluster of hops	0		
 6754	beer bottle	0		
-6755	skewed shaking beer label	0		
+6755	shaking skewed beer label	0		
 6756	teal artisanal homebrew sampler	0		
 6757	acceptable squat can of Br&uuml;talbr&auml;u	3	good	Last Available: "2013-09"
 6758	irresponsibly strong hand-crafted pulsating can of Drooling Monk	8	EPIC	Last Available: "2013-09"
 6759	artisanal can of Impetuous Scofflaw	3	EPIC	Last Available: "2013-09"
-6760	watered-down mediocre bottle of Old Pugilist	2	decent	Last Available: "2013-09"
+6760	mediocre watered-down bottle of Old Pugilist	2	decent	Last Available: "2013-09"
 6761	lousy squat bottle of Professor Beer	3	decent	Last Available: "2013-09"
 6762	artisanal bottle of Rapier Witbier	3	EPIC	Last Available: "2013-09"
 6763	bad bottle of Race Car Red	3	decent	Last Available: "2013-09"
@@ -6658,11 +6658,11 @@
 6766	wobbly tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	tumbling liquid bread	1	decent	Last Available: "2013-09"
-6769	gray zippy MacGyver's sinister tin tam	0		Spell Damage: +10, Maximum MP: +100, Initiative: +20, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
+6769	gray zippy MacGyver's sinister tin tam	0		Spell Damage: +10, Maximum MP: +100, Initiative: +20, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
 6770	colloidal pressed blurry tin cup	0		Effect: "Cruisin' for a Bruisin'", Effect Duration: 13, Last Available: "2013-09"
 6771	huge miser's sizzling tin foil of the bloodbag	0		Maximum HP: +100, Hot Damage: +10, Meat Drop: +10, Last Available: "2013-09"
 6772	studded beefcake's tin drum of the overflowing toilet	0		Muscle: +25, Damage Absorption: +80, Stench Spell Damage: +50, Last Available: "2013-09"
-6773	narrow blurry twirling tin roof (rusted)	0		Last Available: "2013-09"
+6773	twirling blurry narrow tin roof (rusted)	0		Last Available: "2013-09"
 6774	tin snips	0		Last Available: "2013-09"
 6775	tin lizzie	0		Last Available: "2013-09"
 6776	liquefied upside-down foetid seal tear	0		Effect: "Smugness", Effect Duration: 28
@@ -6684,7 +6684,7 @@
 6795	Vulcanized skewed disco horoscope (Aquarius)	0		Effect: "All Blued Up", Effect Duration: 29
 6796	electrified disco horoscope (Pisces)	0		Effect: "Just the Brown Ones", Effect Duration: 28
 6797	pickled disco horoscope (Aries)	0		Effect: "Dance Interpreter", Effect Duration: 12
-6798	irradiated lime green spinning disco horoscope (Taurus)	0		Effect: "Swimming Head", Effect Duration: 20
+6798	irradiated spinning lime green disco horoscope (Taurus)	0		Effect: "Swimming Head", Effect Duration: 20
 6799	quadruple-cold-filtered wet mirror disco horoscope (Gemini)	0		Effect: "Tremella Tremens", Effect Duration: 27
 6800	polarized dry tumbling disco horoscope (Cancer)	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 65
 6801	polymerized triple-moist wobbly disco horoscope (Leo)	0		Effect: "Top Dog", Effect Duration: 32
@@ -6732,10 +6732,10 @@
 6843	super-frozen diffused mirror bone bons	0		Effect: "Shawarma Warm War", Effect Duration: 29
 6844	pressed improved teal ironic mint	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 50
 6845	unused walkie-talkie	0		Free Pull
-6846	blurry yellow walkie-talkie	0		Free Pull
+6846	yellow blurry walkie-talkie	0		Free Pull
 6847	wobbly killing jar	0		
 6848	wobbly educational security flashlight	0		Experience: +1
-6849	electrified tumbling pulsating Effermint&trade; tablets	0		Effect: "Slimily Strong", Effect Duration: 32
+6849	electrified pulsating tumbling Effermint&trade; tablets	0		Effect: "Slimily Strong", Effect Duration: 32
 6850	upside-down teal dance instructor's supercool sturdy cane of terror	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Spooky Spell Damage: +10
 6851	huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
@@ -6746,12 +6746,12 @@
 6857	wobbly upside-down reassuring Cajun accordion	0		Spooky Resistance: +1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	Jeselnik's quirky accordion	0		Sleaze Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	scorching Skipper's accordion of the brazier	0		Hot Damage: +25, Hot Spell Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	resourceful Pantsgiving of the brute of chilblains of bravery	0		Muscle Percent: +30, Maximum MP: +50, Cold Damage: +25, Spooky Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
+6860	resourceful Pantsgiving of the brute of chilblains of bravery	0		Muscle Percent: +30, Maximum MP: +50, Cold Damage: +25, Spooky Resistance: +5, Softcore Only, Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
 6861	tasty special can of sardines	3	awesome	Effect: "Patent Prevention", Effect Duration: 30, Last Available: "2013-11"
 6862	spoiled high-calorie sugar substitute	4	crappy	Last Available: "2013-11"
 6863	immense delicious pat of butter	8	awesome	Last Available: "2013-11"
-6864	decent fancy upside-down yellow ghostly dinner roll	4	good	Effect: "Prelude of Precision", Effect Duration: 25, Last Available: "2013-11"
-6865	adequate gigantic red mashed potatoes	9	good	Last Available: "2013-11"
+6864	fancy decent upside-down yellow ghostly dinner roll	4	good	Effect: "Prelude of Precision", Effect Duration: 25, Last Available: "2013-11"
+6865	gigantic adequate red mashed potatoes	9	good	Last Available: "2013-11"
 6866	low-calorie moldy whole turkey leg	1	crappy	Last Available: "2013-11"
 6867	stale deviled egg	3	decent	Last Available: "2013-11"
 6868	polarized fuchsia finger exerciser	0		Effect: "Gummibrain", Effect Duration: 21, Last Available: "2013-11"
@@ -6786,12 +6786,12 @@
 6897	diffused Can of Spaghetto	0		Effect: "Celestial Body", Effect Duration: 53, Last Available: "2013-11"
 6898	twirling Chef Boy, R&D's business card	0		Last Available: "2013-11"
 6899	Thwaitgold ant statuette	0		
-6900	mirror shaking experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
+6900	shaking mirror experimental carbon fiber pasta additive	0		Class: "Pastamancer", Last Available: "2013-11"
 6901	wobbly hazardous sauce dosimeter	0		Class: "Sauceror", Last Available: "2013-11"
 6902	perfumed fortified flask flops	0		Damage Absorption: +60, Stench Resistance: +5, Single Equip
 6903	modified blurry nuts	0		Effect: "Slippery Tongue", Effect Duration: 66, Last Available: "2013-12"
 6904	non-polymerized yellow bolts	0		Effect: "Hagnk's Gratitude", Effect Duration: 60, Last Available: "2013-12"
-6905	stale gigantic gingerbread robot	9	decent	Last Available: "2013-12"
+6905	gigantic stale gingerbread robot	9	decent	Last Available: "2013-12"
 6906	half-sized moldy special petit 4.1	2	crappy	Effect: "Always be Collecting", Effect Duration: 30, Last Available: "2013-12"
 6907	miniature flavorless nut-shaped Crimbo cookie	2	decent	Last Available: "2023-06"
 6908	blurry stiffened plastic GORM-8	0		Damage Reduction: 1, Last Available: "2013-12"
@@ -6809,30 +6809,30 @@
 6920	activated shaking warbear liquid overcoat	0		Effect: "Sleazy Jellied", Effect Duration: 52, Last Available: "2013-12"
 6921	special toothsome teal warbear feasting bread	3	awesome	Effect: "Items Are Forever", Effect Duration: 15, Last Available: "2013-12"
 6922	tiny spoiled maroon warbear warrior bread	1	crappy	Last Available: "2013-12"
-6923	toothsome tiny pulsating warbear thermoregulator bread	1	awesome	Last Available: "2013-12"
-6924	enchanted irresponsibly strong drinkable huge warbear feasting mead	6	good	Effect: "Jammin'", Effect Duration: 20, Last Available: "2013-12"
+6923	tiny toothsome pulsating warbear thermoregulator bread	1	awesome	Last Available: "2013-12"
+6924	irresponsibly strong drinkable enchanted huge warbear feasting mead	6	good	Effect: "Jammin'", Effect Duration: 20, Last Available: "2013-12"
 6925	acceptable blurry warbear bearserker mead	3	good	Last Available: "2013-12"
 6926	bad jittery warbear blizzard mead	4	decent	Last Available: "2013-12"
 6927	warbear helm fragment	0		Last Available: "2013-12"
-6928	brainy warbear plain fedora of vim and vigor of incineration	0		Mysticality: +5, Maximum HP Percent: +50, Hot Spell Damage: +50, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
-6929	sizzling warbear feathered fedora	0		Hot Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
-6930	aromatic toasty savvy warbear fedora	0		Mysticality Percent: +20, Hot Damage: +5, Stench Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
-6931	huge Jim Carey's healthy warbear plain helm of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Monster Level: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
-6932	yellow studded warbear spiked helm	0		Damage Absorption: +80, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
-6933	squat curative quilted baleful warbear electro-spiked helm	0		Spell Damage: +25, Damage Absorption: +40, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
-6934	clever supercharged Herculean warbear plain ushanka	0		Experience (Muscle): +1, Maximum MP Percent: +30, Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
-6935	cyan warbear lined ushanka of the storm	0		Maximum MP Percent: +40, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
-6936	squat squat asbestos-lined ribald warbear heated ushanka of the ox	0		Muscle: +20, Sleaze Damage: +10, Hot Resistance: +5, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
+6928	brainy warbear plain fedora of vim and vigor of incineration	0		Mysticality: +5, Maximum HP Percent: +50, Hot Spell Damage: +50, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
+6929	sizzling warbear feathered fedora	0		Hot Damage: +10, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
+6930	aromatic toasty savvy warbear fedora	0		Mysticality Percent: +20, Hot Damage: +5, Stench Resistance: +1, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
+6931	huge Jim Carey's healthy warbear plain helm of Calamity Jane	0		Maximum HP Percent: +20, Critical Hit Percent: +15, Monster Level: +25, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
+6932	yellow studded warbear spiked helm	0		Damage Absorption: +80, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
+6933	squat curative quilted baleful warbear electro-spiked helm	0		Spell Damage: +25, Damage Absorption: +40, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
+6934	clever supercharged Herculean warbear plain ushanka	0		Experience (Muscle): +1, Maximum MP Percent: +30, Maximum MP: +20, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
+6935	cyan warbear lined ushanka of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
+6936	squat squat asbestos-lined ribald warbear heated ushanka of the ox	0		Muscle: +20, Sleaze Damage: +10, Hot Resistance: +5, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
 6937	teal warbear trouser fragment	0		Last Available: "2013-12"
-6938	mirror Sherlock's rosewater-soaked warbear party pants of the detective	0		Stench Resistance: +3, Item Drop: 45, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
-6939	baleful warbear ceremonial party pants	0		Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
-6940	scandalous Temple Grandin's groovy warbear high festival pants	0		Moxie Percent: +10, Familiar Weight: +7, Sleaze Damage: +5, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
-6941	ruddy occult razor-sharp warbear battle greaves	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
-6942	arcane researcher's warbear officer greaves	0		Experience Percent (Mysticality): +10, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
-6943	clever stiffened warbear bearserker greaves of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Maximum MP: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
-6944	red frightening toasty warbear johns of wisdom	0		Mysticality: +15, Hot Damage: +5, Spooky Damage: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
-6945	wobbly fuchsia coward's warbear fleece-lined johns	0		Monster Level: -20, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-6946	family-friendly banded warbear johns of wisdom	0		Mysticality: +15, Damage Absorption: +100, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
+6938	mirror Sherlock's rosewater-soaked warbear party pants of the detective	0		Stench Resistance: +3, Item Drop: 45, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
+6939	baleful warbear ceremonial party pants	0		Spell Damage: +25, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
+6940	scandalous Temple Grandin's groovy warbear high festival pants	0		Moxie Percent: +10, Familiar Weight: +7, Sleaze Damage: +5, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
+6941	ruddy occult razor-sharp warbear battle greaves	0		Weapon Damage Percent: +25, Spell Damage Percent: +25, Maximum HP Percent: +40, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
+6942	arcane researcher's warbear officer greaves	0		Experience Percent (Mysticality): +10, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
+6943	clever stiffened warbear bearserker greaves of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Maximum MP: +20, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
+6944	red frightening toasty warbear johns of wisdom	0		Mysticality: +15, Hot Damage: +5, Spooky Damage: +5, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
+6945	wobbly fuchsia coward's warbear fleece-lined johns	0		Monster Level: -20, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
+6946	family-friendly banded warbear johns of wisdom	0		Mysticality: +15, Damage Absorption: +100, Sleaze Resistance: +1, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	knitted Da Vinci's warbear goggles of temperance	0		Experience (Mysticality): +5, Cold Resistance: +3, Sleaze Resistance: +5, Single Equip, Last Available: "2013-12"
 6949	blinking clever warbear snowblindness goggles	0		Maximum MP: +20, Single Equip, Last Available: "2013-12"
@@ -6845,9 +6845,9 @@
 6956	spinning knitted experienced boxer's warbear warscarf	0		Muscle Percent: +10, Experience: +2, Cold Resistance: +3, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	Jim Carey's warbear foil hat	0		Monster Level: +25, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
+6959	Jim Carey's warbear foil hat	0		Monster Level: +25, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	mirror scorching warbear oil pan of the glutton	0		Hot Damage: +25, Food Drop: +100, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
+6961	mirror scorching warbear oil pan of the glutton	0		Hot Damage: +25, Food Drop: +100, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	toasty warbear exhaust manifold	0		Hot Damage: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6895,7 +6895,7 @@
 7006	mixed handful of Smithereens	1	good	Last Available: "2013-12"
 7007	tasty fuchsia Every Day is Like This Sundae	3	awesome	Last Available: "2013-12"
 7008	massive normal Miserable Pie	8	good	Last Available: "2013-12"
-7009	half-sized toothsome wobbly This Charming Flan	2	awesome	Last Available: "2013-12"
+7009	toothsome half-sized wobbly This Charming Flan	2	awesome	Last Available: "2013-12"
 7010	enchanted artisanal Irish Coffee, English Heart	4	EPIC	Effect: "Marco Polarity", Effect Duration: 5, Last Available: "2013-12"
 7011	aged jittery Strikes Again Bigmouth	4	awesome	Last Available: "2013-12"
 7012	fancy perfectly mixed practically non-alcoholic twirling Paint A Vulgar Pitcher	1	super ultra mega turbo EPIC	Effect: "What's That Smell?", Effect Duration: 5, Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	red gravedigger's lion tamer's mansplainer's Sheila Take a Crossbow of the overflowing toilet	0		Monster Level: +15, Experience (familiar): +2, Stench Spell Damage: +50, Spooky Damage: +10, Last Available: "2013-12"
 7019	avaricious miser's greasy fortified A Light that Never Goes Out	0		Damage Absorption: +60, Sleaze Spell Damage: +10, Meat Drop: 40, Last Available: "2013-12"
 7020	fuchsia healthy grievous supercool stylish Half a Purse	0		Moxie: +25, Moxie Percent: +20, Weapon Damage Percent: +50, Maximum HP Percent: +20, Last Available: "2013-12"
-7021	ghostly avaricious Jeselnik's curative Hairpiece On Fire of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +25, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
-7022	reassuring fireproof wholesome wicked Vicar's Tutu	0		Spell Damage: +5, Maximum HP Percent: +10, Hot Resistance: +3, Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
+7021	ghostly avaricious Jeselnik's curative Hairpiece On Fire of Tarzan	0		Experience (Muscle): +3, Sleaze Damage: +25, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
+7022	reassuring fireproof wholesome wicked Vicar's Tutu	0		Spell Damage: +5, Maximum HP Percent: +10, Hot Resistance: +3, Spooky Resistance: +1, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
 7023	blinking careful wicked Hand in Glove of dire peril	0		Weapon Damage: +20, Spell Damage: +5, Monster Level: -10, Single Equip, Last Available: "2013-12"
 7024	yellow clever therapeutic Da Vinci's Meat Tenderizer is Murder	0		Experience (Mysticality): +5, Maximum MP: +20, HP Regen Min: 5, HP Regen Max: 7, Class: "Seal Clubber", Last Available: "2013-12"
 7025	sizzling Samson's Ouija Board, Ouija Board of Flo-Jo	0		Experience (Muscle): +5, Hot Damage: +10, Initiative: +100, Class: "Turtle Tamer", Damage Reduction: 7, Last Available: "2013-12"
@@ -6917,7 +6917,7 @@
 7028	sharpshooter's Frankly Mr. Shank of the ox of the cougar	0		Muscle: +20, Moxie: +20, Critical Hit Percent: +10, Class: "Disco Bandit", Last Available: "2013-12"
 7029	supercharged padded Shakespeare's Sister's Accordion of the ox	0		Muscle: +20, Damage Absorption: +20, Maximum MP Percent: +30, Class: "Accordion Thief", Song Duration: 15, Last Available: "2013-12"
 7030	frightening third-hand lantern	0		Spooky Damage: +5
-7031	gray spinning loose purse strings	0		
+7031	spinning gray loose purse strings	0		
 7032	toothsome pickled egg	3	awesome	
 7033	cup of lukewarm tea	1	decent	
 7034	warbear soda machine assembler	0		Last Available: "2013-12"
@@ -6965,11 +6965,11 @@
 7076	snow boards	0		Last Available: "2014-01"
 7077	spoiled snow crab	4	crappy	Last Available: "2014-01"
 7078	artisanal Ice Island Long Tea	3	super EPIC	Last Available: "2014-01"
-7079	pulsating spinning unfinished ice sculpture	0		Last Available: "2014-01"
+7079	spinning pulsating unfinished ice sculpture	0		Last Available: "2014-01"
 7080	upside-down ice sculpture	0		Last Available: "2014-01"
 7081	wobbly ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	Jeselnik's snow mobile	0		Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
+7083	Jeselnik's snow mobile	0		Sleaze Damage: +25, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
 7084	ribald ice bucket	0		Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	flame-retardant wholesome snow shovel	0		Maximum HP Percent: +10, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2014-01"
 7086	upside-down rock-hard supercool bod-ice of James Dean	0		Moxie Percent: +20, Experience (Moxie): +3, Damage Reduction: 5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	hand-crafted skewed En Una Fila Tequila	3	EPIC	
 7091	enchanted Skully's hot chocolate	1	awesome	Effect: "Itchy Trigger Finger", Effect Duration: 5
-7092	gray Newton's groovy warbear dress helmet	0		Moxie Percent: +10, Experience (Mysticality): +3, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
+7092	gray Newton's groovy warbear dress helmet	0		Moxie Percent: +10, Experience (Mysticality): +3, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
 7093	teal huge frightening Van der Graaf warbear dress bracers	0		Spooky Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2013-12"
-7094	ghostly greasy steel-toed warbear dress greaves	0		Damage Reduction: 9, Sleaze Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
-7095	upside-down weightlifter's sweatband of bravery	0		Muscle: +15, Spooky Resistance: +5, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
-7096	gray crafty Socratic gym shorts	0		Experience (Mysticality): +1, Maximum MP: +10, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7094	ghostly greasy steel-toed warbear dress greaves	0		Damage Reduction: 9, Sleaze Spell Damage: +10, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
+7095	upside-down weightlifter's sweatband of bravery	0		Muscle: +15, Spooky Resistance: +5, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
+7096	gray crafty Socratic gym shorts	0		Experience (Mysticality): +1, Maximum MP: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
 7097	twirling smooth ankleweights of terror	0		Moxie: +15, Spooky Spell Damage: +10, Single Equip, Last Available: "2014-12"
 7098	supercharged hale boxer's brainy sweat socks	0		Mysticality: +5, Muscle Percent: +10, Maximum HP: +20, Maximum MP Percent: +30, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6992,7 +6992,7 @@
 7103	chilled mirror powder	0		Effect: "Salamander In Your Stomach", Effect Duration: 66, Last Available: "2014-12"
 7104	toasty licorice whip	0		Hot Damage: +5, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	practically non-alcoholic acceptable snakebite	1	good	Last Available: "2014-12"
+7106	acceptable practically non-alcoholic snakebite	1	good	Last Available: "2014-12"
 7107	upside-down blurry sizzling dog trainer's candy stick	0		Experience (familiar): +1, Hot Damage: +10, Last Available: "2014-12"
 7108	normal pecan	3	good	Last Available: "2014-12"
 7109	bland pecan pie	3	decent	Last Available: "2014-12"
@@ -7000,16 +7000,16 @@
 7111	tasty candy mountain oyster	4	awesome	Last Available: "2014-12"
 7112	artisanal high-proof chocotini	9	EPIC	Last Available: "2014-12"
 7113	chaotic MacGyver's chocolate rabbit's foot of Flo-Jo	0		Maximum MP: +100, Spell Critical Percent: +10, Initiative: +100, Last Available: "2014-12"
-7114	diet decent candy carrot	1	good	Last Available: "2014-12"
+7114	decent diet candy carrot	1	good	Last Available: "2014-12"
 7115	special yummy candy carrot cake	4	awesome	Effect: "You Know When to Walk Away", Effect Duration: 35, Last Available: "2014-12"
 7116	blinking inspector's carrot-on-a-stick of the dark arts	0		Spell Damage Percent: +100, Item Drop: +15, Last Available: "2014-12"
-7117	fuchsia wizardly beefcake's weasel stomping pants	0		Muscle: +25, Mysticality: +25, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
+7117	fuchsia wizardly beefcake's weasel stomping pants	0		Muscle: +25, Mysticality: +25, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
 7118	adequate yellow mulberry	3	good	Last Available: "2014-12"
 7119	perfectly mixed mulled berry wine	3	super EPIC	Last Available: "2014-12"
 7120	shaking lemony scales	0		Last Available: "2014-12"
-7121	nippy lemon party hat	0		Cold Damage: +10, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
+7121	nippy lemon party hat	0		Cold Damage: +10, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
 7122	red lemon shirt of the empath	0		Familiar Weight: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	Rosewater's lemon drop trousers	0		Mysticality Percent: +30, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
+7123	Rosewater's lemon drop trousers	0		Mysticality Percent: +30, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
 7124	Vulcanized dry lemonhead caviar	0		Effect: "Scarysauce", Effect Duration: 45, Last Available: "2014-12"
 7125	frosty steel-toed gummi sword	0		Damage Reduction: 9, Cold Spell Damage: +10, Last Available: "2014-12"
 7126	altered colloidal small gummi fin	0		Effect: "Starry-Eyed", Effect Duration: 47, Last Available: "2014-12"
@@ -7020,12 +7020,12 @@
 7131	flame-wreathed toasty cow creamer of the early riser	0		Hot Damage: +5, Hot Spell Damage: +10, Adventures: +7, Last Available: "2014-12"
 7132	anodized magnetized shaking Outer Wolf&trade; cologne	0		Effect: "Chunky", Effect Duration: 53, Last Available: "2014-12"
 7133	wobbly maroon lupine appetite hormones	0		Last Available: "2014-12"
-7134	spinning steel-toed wolf whistle of the blizzard	0		Damage Reduction: 9, Cold Spell Damage: +25, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	half-sized moldy witch's bread	2	crappy	Last Available: "2014-12"
+7134	spinning steel-toed wolf whistle of the blizzard	0		Damage Reduction: 9, Cold Spell Damage: +25, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
+7135	moldy half-sized witch's bread	2	crappy	Last Available: "2014-12"
 7136	Vulcanized witch's brew	0		Effect: "Proprie Tea", Effect Duration: 68, Last Available: "2014-12"
 7137	avaricious curative stylish witch's bra	0		Moxie: +25, Meat Drop: +30, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12"
-7138	bad distilled mid-level medieval mead	5	decent	Last Available: "2014-12"
-7139	wet lime green shaking R&uuml;mpelstiltz	0		Effect: "Yet tea", Effect Duration: 57, Last Available: "2014-12"
+7138	distilled bad mid-level medieval mead	5	decent	Last Available: "2014-12"
+7139	wet shaking lime green R&uuml;mpelstiltz	0		Effect: "Yet tea", Effect Duration: 57, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	tarnished triple-anodized hi-octane carrot juice	0		Effect: "Elemental Saucesphere", Effect Duration: 20, Last Available: "2014-12"
 7142	irradiated spinning hare brush	0		Effect: "Armor-Plated", Effect Duration: 42, Last Available: "2014-12"
@@ -7043,22 +7043,22 @@
 7154	blinking filling	0		Last Available: "2014-12"
 7155	tumbling olive parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	twirling shaking stanky fire hose of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Stench Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+7157	twirling shaking stanky fire hose of wisdom of the cougar	0		Mysticality: +15, Moxie: +20, Stench Spell Damage: +25, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
 7158	moldy fireman's lunch	3	crappy	Last Available: "2014-12"
-7159	scandalous dance instructor's plain paper hat of wisdom	0		Mysticality: +15, Experience Percent (Moxie): +10, Sleaze Damage: +5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	flavorless jumbo ice cream sandwich	5	decent	Last Available: "2014-12"
+7159	scandalous dance instructor's plain paper hat of wisdom	0		Mysticality: +15, Experience Percent (Moxie): +10, Sleaze Damage: +5, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
+7160	jumbo flavorless ice cream sandwich	5	decent	Last Available: "2014-12"
 7161	skewed Temple Grandin's wholesome baleful &quot;honey&quot; dipper	0		Spell Damage: +25, Maximum HP Percent: +10, Familiar Weight: +7, Last Available: "2014-12"
 7162	flavorless plumber's lunch	4	decent	Last Available: "2014-12"
 7163	avaricious inspector's skull gearshift knob of the empath	0		Familiar Weight: +5, Item Drop: +15, Meat Drop: +30, Last Available: "2014-12"
-7164	flavorless jumbo gray nachos of the night	5	decent	Last Available: "2014-12"
+7164	jumbo flavorless gray nachos of the night	5	decent	Last Available: "2014-12"
 7165	upside-down studded occult Sketcherz&trade; of Flo-Jo	0		Spell Damage Percent: +25, Damage Absorption: +80, Initiative: +100, Last Available: "2014-12"
 7166	decent snack-sized ghostly can of Adultwitch&trade;	2	good	Last Available: "2014-12"
-7167	adjusted triple-ionized blue squat smudge stick	0		Effect: "Extra Backbone", Effect Duration: 35, Last Available: "2014-12"
+7167	adjusted triple-ionized squat blue smudge stick	0		Effect: "Extra Backbone", Effect Duration: 35, Last Available: "2014-12"
 7168	modified altered wall	0		Effect: "Flame-Retardant Trousers", Effect Duration: 44, Last Available: "2014-12"
 7169	smooth tankard of ale	3	awesome	Last Available: "2014-12"
 7170	colloidal concentrated scroll case	0		Effect: "Nothing Is Impossible", Effect Duration: 22, Last Available: "2014-12"
 7171	chilled ghostly teal jug of &quot;wine&quot;	0		Effect: "Quantum of Moxie", Effect Duration: 45, Last Available: "2014-12"
-7172	gray squat jittery juggling ball	0		Last Available: "2014-12"
+7172	jittery squat gray juggling ball	0		Last Available: "2014-12"
 7173	jittery crappy camera	0		Last Available: "2014-12"
 7174	normal bouncing humble pie	4	good	Last Available: "2014-12"
 7175	small golem	0		Last Available: "2014-12"
@@ -7068,7 +7068,7 @@
 7179	pulsating The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
 7181	skewed The Eye of the Stars	0		
-7182	squat skewed The Stankara Stone	0		
+7182	skewed squat The Stankara Stone	0		
 7183	Murphy's Rancid Black Flag	0		
 7184	jittery The Shield of Brook	0		
 7185	green Red Zeppelin ticket	0		
@@ -7108,7 +7108,7 @@
 7219	lynyrdskin breeches of the detective	0		Item Drop: +20, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
 7220	cigarette lighter	0		
 7221	priceless diamond	0		
-7222	acceptable high-proof Flamin' Whatshisname	9	good	
+7222	high-proof acceptable Flamin' Whatshisname	9	good	
 7223	double-wet energized huge lynyrd musk	0		Effect: "Big Ol' Glass of Rum", Effect Duration: 54
 7224	mirror rock-hard Kashmir sweater of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40
 7225	adequate custard pie	4	good	
@@ -7117,8 +7117,8 @@
 7228	box	0		
 7229	acceptable teal wine	3	good	
 7230	drinkable purple rum	3	good	
-7231	delicious practically non-alcoholic Murderer's Punch	1	awesome	
-7232	gigantic stale upside-down velvet cake	7	decent	
+7231	practically non-alcoholic delicious Murderer's Punch	1	awesome	
+7232	stale gigantic upside-down velvet cake	7	decent	
 7233	ionized chilled letter	0		Effect: "Hustlin'", Effect Duration: 61
 7234	horrifying nippy book	0		Cold Damage: +10, Spooky Damage: +25
 7235	Da Vinci's masque of the detective	0		Experience (Mysticality): +5, Item Drop: +20, Single Equip
@@ -7131,7 +7131,7 @@
 7242	huge button	0		
 7243	spinning button	0		
 7244	quadruple-diffused spinning blood cells	0		Effect: "Egg on your Face", Effect Duration: 30
-7245	vacuum-sealed skewed bouncing eye	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 40
+7245	vacuum-sealed bouncing skewed eye	0		Effect: "Disdain of the Storm Tortoise", Effect Duration: 40
 7246	spinning glark cable	0		
 7247	huge manspreader's resourceful Red Fox glove	0		Maximum MP: +50, Monster Level: +10, Attacks Can't Miss, Single Equip
 7248	double-vacuum-sealed wobbly foxglove	0		Effect: "The Halls of Moxiousness", Effect Duration: 37
@@ -7155,7 +7155,7 @@
 7266	disposable instant camera	0		
 7267	fireproof gravedigger's Sneaky Pete's jacket (collar popped) of chilblains of the businessman	0		Cold Damage: +25, Spooky Damage: +10, Hot Resistance: +3, Meat Drop: +50, Softcore Only, Free Pull, Last Available: "2014-03"
 7268	Letter for Melvign the Gnome	0		
-7269	wobbly ghostly Professor What garment	0		
+7269	ghostly wobbly Professor What garment	0		
 7270	&quot;2 Love Me, Vol. 2&quot;	0		
 7271	spinning Thinknerd Blind-Packed Toy	0		
 7272	veiny plastic Professor What	0		Maximum HP: +10
@@ -7192,7 +7192,7 @@
 7303	Lady Spookyraven's necklace	0		
 7304	telegram from Lady Spookyraven	0		
 7305	Lady Spookyraven's powder puff	0		
-7306	twirling bouncing Lady Spookyraven's finest gown	0		
+7306	bouncing twirling Lady Spookyraven's finest gown	0		
 7307	bouncing Lady Spookyraven's dancing shoes	0		
 7308	quadruple-ionized magnetized pressed eyebrow pencil	0		Effect: "Dance of the Sugar Fairy", Effect Duration: 41
 7309	triple-oxidized modified shaking rosewater cream	0		Effect: "The Grass...  Is Blue...", Effect Duration: 67
@@ -7201,16 +7201,16 @@
 7312	still grill	0		Free Pull, Last Available: "2014-06"
 7313	box of hickory chips	0		Familiar Weight: +5
 7314	poppet	0		
-7315	green huge rickety rocking horse	0		
+7315	huge green rickety rocking horse	0		
 7316	jack-in-the-box	0		
-7317	spinning bouncing jar of baby ghosts	0		
+7317	bouncing spinning jar of baby ghosts	0		
 7318	scandalous wholesome shellacked ghost of a necklace	0		Damage Reduction: 7, Maximum HP Percent: +10, Sleaze Damage: +5
 7319	green MacGyver's therapeutic Elizabeth's Dollie	0		Maximum MP: +100, HP Regen Min: 5, HP Regen Max: 7
 7320	Vulcanized oxidized tumbling Elizabeth's paintbrush	0		Effect: "Frosty the Hitman", Effect Duration: 12
 7321	careful hale Stephen's lab coat	0		Maximum HP: +20, Monster Level: -10
 7322	oxidized blurry Stephen's secret formula	0		Effect: "Category", Effect Duration: 29
 7323	gravedigger's razor-sharp Jacob's rung	0		Weapon Damage Percent: +25, Spooky Damage: +10
-7324	diluted blue huge battery	1		Effect: "Oriental Mysticism", Effect Duration: 50
+7324	diluted huge blue battery	1		Effect: "Oriental Mysticism", Effect Duration: 50
 7325	aged spinning snakebite	3	awesome	
 7326	twirling jittery inspector's Lo Pan's rubber ribcage	0		Spell Critical Percent: +30, Item Drop: +15, Damage Reduction: 7
 7327	boiled upside-down synthetic marrow	1		Effect: "Vitamin-Maxed", Effect Duration: 10
@@ -7228,13 +7228,13 @@
 7339	music box mechanism	0		
 7340	narrow beefcake's moose antlers	0		Muscle: +25, Familiar Effect: "atk, 1xLep, cap 27"
 7341	polymerized denatured moose thought	0		Effect: "Saucemastery", Effect Duration: 13
-7342	half-sized rotten moose chocolate	2	crappy	
-7343	perfectly mixed weak painting of a glass of wine	2	EPIC	
+7342	rotten half-sized moose chocolate	2	crappy	
+7343	weak perfectly mixed painting of a glass of wine	2	EPIC	
 7344	tumbling oil painting of yourself	0		
 7345	ornate picture frame	0		
 7346	shaking doll-eye amulet	0		Single Equip
 7347	arcane researcher's Da Vinci's ghost toga	0		Experience (Mysticality): +5, Experience Percent (Mysticality): +10
-7348	diet rotten jittery yellow sheet cake	1	crappy	
+7348	rotten diet yellow jittery sheet cake	1	crappy	
 7349	ghost key	0		
 7350	ghostly picture of you	0		
 7351	avaricious rock-hard personal trainer's Staff of the Electric Range	0		Experience Percent (Muscle): +10, Damage Reduction: 5, Meat Drop: +30
@@ -7254,14 +7254,14 @@
 7365	alkaline shaking fabric hardener	0		Effect: "Big Punkin'", Effect Duration: 60
 7366	hand-crafted bottle of laundry sherry	3	EPIC	
 7367	alkaline industrial strength starch	0		Effect: "Cold Blooded", Effect Duration: 54, Wiki Name: "industrial strength starch"
-7368	bite-sized bland extra-flat panini	1	decent	
+7368	bland bite-sized extra-flat panini	1	decent	
 7369	diffused pickled mangled finger	0		Effect: "5 Pounds Lighter", Effect Duration: 32
-7370	delicious practically non-alcoholic Psychotic Train wine	1	awesome	
+7370	practically non-alcoholic delicious Psychotic Train wine	1	awesome	
 7371	crazy hobo notebook	0		
 7372	yummy squat pie man was not meant to eat	3	awesome	
 7373	fuchsia sommelier's towel of doom	0		Spooky Spell Damage: +50
 7374	smelly tarnished tastevin	0		Stench Spell Damage: +10, Single Equip
-7375	flavorless upside-down mirror actual tapas	3	decent	
+7375	flavorless mirror upside-down actual tapas	3	decent	
 7376	ghast iron ingot	0		
 7377	quilted educational ghast iron cleaver	0		Experience: +1, Damage Absorption: +40
 7378	blinking baleful ghast iron Garibaldi of extreme caution	0		Spell Damage: +25, Monster Level: -25, Familiar Effect: "atk, 1xFairy, cap 14"
@@ -7326,35 +7326,35 @@
 7437	pulsating Pastaco shell	0		Last Available: "2014-05"
 7438	decent Beefy Crunch Pastaco	3	good	Last Available: "2014-05"
 7439	yummy tiny shaking Brain Food Pastaco	1	awesome	Last Available: "2014-05"
-7440	normal miniature Cool Brunch Pastaco	2	good	Last Available: "2014-05"
+7440	miniature normal Cool Brunch Pastaco	2	good	Last Available: "2014-05"
 7441	toothsome Medical Pastaco	3	awesome	Last Available: "2014-05"
-7442	spoiled small Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
+7442	small spoiled Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
 7443	flavorless Ludovico Pastaco	3	decent	Last Available: "2014-05"
 7444	tolerable jittery overpowering mushroom wine	3	good	Last Available: "2014-05"
 7445	mediocre triple-distilled complex mushroom wine	8	decent	Last Available: "2014-05"
-7446	mediocre practically non-alcoholic smooth mushroom wine	1	decent	Last Available: "2014-05"
+7446	practically non-alcoholic mediocre smooth mushroom wine	1	decent	Last Available: "2014-05"
 7447	acceptable blood-red mushroom wine	3	good	Last Available: "2014-05"
 7448	smooth yellow blurry buzzing mushroom wine	3	awesome	Last Available: "2014-05"
 7449	weak bad blurry swirling mushroom wine	2	decent	Last Available: "2014-05"
 7450	flavorless snack-sized mirror Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
 7451	adequate Taco Dan's Taco Fish Fish Taco	3	good	Last Available: "2014-05"
 7452	twirling Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
-7453	mediocre wobbly blue regular-size brogurt	3	decent	Last Available: "2014-05"
+7453	mediocre blue wobbly regular-size brogurt	3	decent	Last Available: "2014-05"
 7454	hand-crafted super-size brogurt	3	EPIC	Last Available: "2014-05"
 7455	bad broberry brogurt	4	decent	Last Available: "2014-05"
 7456	artisanal practically non-alcoholic brocolate brogurt	1	super ultra mega turbo EPIC	Last Available: "2014-05"
-7457	bad high-proof wobbly spinning French bronilla brogurt	10	decent	Last Available: "2014-05"
+7457	bad high-proof spinning wobbly French bronilla brogurt	10	decent	Last Available: "2014-05"
 7458	History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	pulsating industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	groovy Brogre brorts	0		Moxie Percent: +10, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
+7462	groovy Brogre brorts	0		Moxie Percent: +10, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
 7463	smooth Brogre brolo shirt	0		Moxie: +15, Last Available: "2014-05"
-7464	tumbling Brogre bucket hat of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
+7464	tumbling Brogre bucket hat of the overflowing toilet	0		Stench Spell Damage: +50, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
 7465	ghostly Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	red perfumed gravedigger's dance instructor's 8-billed baseball cap	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Stench Resistance: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
+7468	red perfumed gravedigger's dance instructor's 8-billed baseball cap	0		Experience Percent (Moxie): +10, Spooky Damage: +10, Stench Resistance: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
 7469	grievous strapping extremely wet T-shirt of incineration	0		Muscle: +5, Weapon Damage Percent: +50, Hot Spell Damage: +50, Last Available: "2014-05"
 7470	ghostly wobbly scandalous banded shrimp fork of temperance	0		Damage Absorption: +100, Sleaze Damage: +5, Sleaze Resistance: +5, Last Available: "2014-05"
 7471	non-dry super-colloidal BROS Energy Drink	0		Effect: "Jittery", Effect Duration: 46, Last Available: "2014-05"
@@ -7367,10 +7367,10 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	concentrated oxidized sugar fairy	0		Effect: "Go-Gone", Effect Duration: 39, Last Available: "2014-05"
 7480	tarnished red sugar bunny	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 57, Last Available: "2014-05"
-7481	sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7481	sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
 7482	lousy skewed Rompedores de Fantasmas	4	decent	
 7483	distilled hand-crafted spinning fuchsia La Fantasma y La Oscuridad	5	EPIC	
-7484	hand-crafted weak Fantasma en la M&aacute;quina	2	EPIC	
+7484	weak hand-crafted Fantasma en la M&aacute;quina	2	EPIC	
 7485	loosening powder	0		
 7486	castoreum	0		
 7487	drain dissolver	0		
@@ -7378,7 +7378,7 @@
 7489	detartrated anhydrous sublicalc	0		
 7490	bouncing triatomaceous dust	0		
 7491	tolerable bouncing bottle of Chateau de Vinegar	4	good	
-7492	shaking maroon blasting soda	0		
+7492	maroon shaking blasting soda	0		
 7493	unstable fulminate	0		
 7494	wine bomb	0		
 7495	recipe: mortar-dissolving solution	0		
@@ -7407,15 +7407,15 @@
 7518	wand of pigification	0		
 7519	aged glass of bourbon	4	awesome	
 7520	burned government manual fragment	0		Last Available: "2014-05"
-7521	thick spoiled government cheese	5	crappy	Last Available: "2014-05"
+7521	spoiled thick government cheese	5	crappy	Last Available: "2014-05"
 7522	teal veiny pair of government shades	0		Maximum HP: +10, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
 7524	super-Vulcanized fuchsia government	0		Effect: "Frozen Shoulders", Effect Duration: 40, Last Available: "2014-05"
 7525	wet non-flattened alien drugs	0		Effect: "Corruption of Wretched Wally", Effect Duration: 28, Last Available: "2023-09"
-7526	mirror green spinning weird space book	0		Last Available: "2014-05"
+7526	spinning green mirror weird space book	0		Last Available: "2014-05"
 7527	upside-down alien force field disruptor bean	0		Last Available: "2014-05"
 7528	avaricious inspector's government-issued night-vision goggles	0		Item Drop: +15, Meat Drop: +30, Single Equip, Last Available: "2014-05"
-7529	miniature rotten gray skewed loaf of alien bread	2	crappy	Last Available: "2014-05"
+7529	rotten miniature gray skewed loaf of alien bread	2	crappy	Last Available: "2014-05"
 7530	flavorless grilled cheese sandwich	3	decent	Last Available: "2014-05"
 7531	vaporized bouncing alien protein powder	1	decent	Last Available: "2014-05"
 7532	weak mediocre rocket fuel	2	decent	Last Available: "2014-05"
@@ -7425,13 +7425,13 @@
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	upside-down ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	jittery up-at-dawn space beast fur hat	0		Adventures: +5, Last Available: "2014-05", Familiar Effect: "1xVolley"
-7540	shaking space beast fur pants of the bloodbag	0		Maximum HP: +100, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7539	jittery up-at-dawn space beast fur hat	0		Adventures: +5, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7540	shaking space beast fur pants of the bloodbag	0		Maximum HP: +100, Familiar Effect: "1xVolley", Last Available: "2014-05"
 7541	crafty space beast fur whip	0		Maximum MP: +10, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
-7543	blurry executive strapping space heater	0		Muscle: +5, Meat Drop: +40, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
+7543	blurry executive strapping space heater	0		Muscle: +5, Meat Drop: +40, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
 7544	squat space bar	0		Last Available: "2014-05"
-7545	drinkable triple-distilled space port	10	good	Last Available: "2014-05"
+7545	triple-distilled drinkable space port	10	good	Last Available: "2014-05"
 7546	mirror lightning-fast space needle of the blizzard	0		Cold Spell Damage: +25, Initiative: +40, Last Available: "2014-05"
 7547	concentrated magnetized squat buffed alien drugs	0		Effect: "Hagnk's Gratitude", Effect Duration: 45, Last Available: "2014-05"
 7548	ghostly hot ashes	0		Last Available: "2014-06"
@@ -7449,7 +7449,7 @@
 7560	turtle-shaped rock	0		
 7561	aerosolized adjusted spinning giraffe-necked turtle	0		Effect: "Gummi-Grin", Effect Duration: 56
 7562	chilled musk turtle	0		Effect: "Mighty Shout", Effect Duration: 51
-7563	moist red narrow programmable turtle	0		Effect: "Incensed", Effect Duration: 69
+7563	moist narrow red programmable turtle	0		Effect: "Incensed", Effect Duration: 69
 7564	double-nitrogenated anodized irradiated mocking turtle	0		Effect: "Glo-Face", Effect Duration: 31
 7565	stale ham steak	3	decent	
 7566	skewed deadly time-twitching toolbelt	0		Weapon Damage: +5, Single Equip, Free Pull
@@ -7474,13 +7474,13 @@
 7585	gray jittery wooly loincloth of the sewer of courage	0		Stench Damage: +25, Spooky Resistance: +3, Familiar Effect: "atk, 1xVolley, cap 27"
 7586	wobbly helix fossil	0		
 7587	mirror S.S. Ticket	0		Familiar Weight: +5
-7588	wobbly mirror Clan speakeasy	0		Free Pull, Last Available: "2014-07"
+7588	mirror wobbly Clan speakeasy	0		Free Pull, Last Available: "2014-07"
 7589	drinkable high-proof cyan glass of &quot;milk&quot;	9	good	Last Available: "2014-07"
-7590	weak aged blurry cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
+7590	aged weak blurry cup of &quot;tea&quot;	2	awesome	Last Available: "2014-07"
 7591	practically non-alcoholic drinkable thermos of &quot;whiskey&quot;	1	good	Last Available: "2014-07"
 7592	tolerable purple Lucky Lindy	4	good	Last Available: "2014-07"
-7593	perfectly mixed triple-distilled Bee's Knees	7	EPIC	Last Available: "2014-07"
-7594	artisanal enchanted Sockdollager	4	EPIC	Effect: "Very Clean Teeth", Effect Duration: 45, Last Available: "2014-07"
+7593	triple-distilled perfectly mixed Bee's Knees	7	EPIC	Last Available: "2014-07"
+7594	enchanted artisanal Sockdollager	4	EPIC	Effect: "Very Clean Teeth", Effect Duration: 45, Last Available: "2014-07"
 7595	tolerable Ish Kabibble	4	good	Last Available: "2014-07"
 7596	artisanal squat teal Hot Socks	3	EPIC	Last Available: "2014-07"
 7597	perfectly mixed Phonus Balonus	3	EPIC	Last Available: "2014-07"
@@ -7496,7 +7496,7 @@
 7607	non-ionized polymerized galvanized ghostly vial of swamp vapors	0		Effect: "Petit Force", Effect Duration: 51
 7608	dry olive turtle mud	0		Effect: "Lemony Goodness", Effect Duration: 43
 7609	magnetized gray Redeye&trade; Eyedrops	0		Effect: "Took Eleven", Effect Duration: 28
-7610	electrified spinning purple Dweebisol&trade; inhaler	0		Effect: "Enraged", Effect Duration: 46
+7610	electrified purple spinning Dweebisol&trade; inhaler	0		Effect: "Enraged", Effect Duration: 46
 7611	modified Lewd Lemmy Hair Oil	0		Effect: "Speed of the Internet", Effect Duration: 61
 7612	boiled polarized blinking tomato soup poster	0		Effect: "Frozen Shoulders", Effect Duration: 25
 7613	irradiated spinning bubblin' chemistry solution	0		Effect: "Chlorophyll Flavor", Effect Duration: 57
@@ -7516,7 +7516,7 @@
 7627	vacuum-sealed bouncing plastic Jefferson wings	0		Effect: "Squid Squint", Effect Duration: 43
 7628	ionized corrupted wobbly skewed dancing fan	0		Effect: "Greasy Visage", Effect Duration: 47
 7629	vacuum-sealed page of the Necrohobocon	0		Effect: "Cold Hard Skin", Effect Duration: 44
-7630	irradiated gray blinking magic powder	0		Effect: "Shot in the Arse", Effect Duration: 26
+7630	irradiated blinking gray magic powder	0		Effect: "Shot in the Arse", Effect Duration: 26
 7631	polarized boiled extra-polarized huge bouncing friar's tonsure	0		Effect: "Preternatural Greed", Effect Duration: 66
 7632	polarized boiled galvanized upside-down government-issue identification badge	0		Effect: "Extra-Sharp Weapon", Effect Duration: 61
 7633	activated non-deionized alien hologram projector	0		Effect: "Memento Moir&eacute;", Effect Duration: 65
@@ -7544,11 +7544,11 @@
 7655	fishbone fins	0		Single Equip
 7656	tumbling fishbone facemask	0		Monster Level: -30
 7657	blinking fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
-7658	mirror jittery fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
+7658	jittery mirror fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	cyan neoprene skullcap of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, 1xFairy, cap 16"
 7660	irradiated goblin water	0		Effect: "Nas Tea", Effect Duration: 21
 7661	narrow dumb mud	0		
-7662	super-sized stale Sogg-Os	5	decent	
+7662	stale super-sized Sogg-Os	5	decent	
 7663	pulsating electrified Lord Soggyraven's Slippers of the bloodbag of mayonnaise	0		Maximum HP: +100, Sleaze Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Single Equip
 7664	nitrogenated nitrogenated Ancient Protector Soda	0		Effect: "Bastard!", Effect Duration: 56
 7665	energized liquid ice	0		Effect: "Boilermade", Effect Duration: 66
@@ -7561,7 +7561,7 @@
 7672	rosy-cheeked law-abiding citizen cane	0		Maximum HP Percent: +30, Single Equip
 7673	tolerable legitimate business on the beach	4	good	
 7674	up-at-dawn hep waders	0		Adventures: +5, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	super-sized rotten jive turkey leg	5	crappy	
+7675	rotten super-sized jive turkey leg	5	crappy	
 7676	ghostly yellow thinker's birdbone corset	0		Mysticality: +10
 7677	triple-moist improved candy cigarette	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 15
 7678	4-dimensional fez of Flo-Jo	0		Initiative: +100, Familiar Effect: "atk, 1xLep, cap 12"
@@ -7581,7 +7581,7 @@
 7692	miser's brawny hand whip of the dark arts	0		Muscle Percent: +20, Spell Damage Percent: +100, Meat Drop: +10, Last Available: "2014-08"
 7693	ghostly knitted electrified glow-in-the-dark necklace of the wise owl	0		Mysticality: +20, Cold Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	olive squat scorching vibrating savvy cap gun	0		Mysticality Percent: +20, Maximum MP Percent: +10, Hot Damage: +25, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
+7695	olive squat scorching vibrating savvy cap gun	0		Mysticality Percent: +20, Maximum MP Percent: +10, Hot Damage: +25, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
 7696	jittery yellow hardened cassette player of the cheetah	0		Damage Reduction: 3, Initiative: +60, Single Equip, Last Available: "2014-08"
 7697	gray chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	rubber spider	0		Last Available: "2014-08"
@@ -7589,19 +7589,19 @@
 7700	galvanized ionized nitrogenated confiscated comic book	0		Effect: "Heart of Lavender", Effect Duration: 46, Last Available: "2014-08"
 7701	triple-nitrogenated modified confiscated cell phone	0		Effect: "Third Based", Effect Duration: 21, Last Available: "2014-08"
 7702	ionized confiscated love note	0		Effect: "Blessing of the Pervy Noodles", Effect Duration: 56, Last Available: "2014-08"
-7703	gray ghostly LCD game: Food Eater	0		Last Available: "2014-08"
+7703	ghostly gray LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	spinning LCD game: Burger Belt	0		Last Available: "2014-08"
 7706	upside-down The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	liquefied triple-ionized rubber nubbin	0		Effect: "Arabian Knighthood", Effect Duration: 16, Last Available: "2014-08"
 7708	greasy rubber cape of the detective	0		Sleaze Spell Damage: +10, Item Drop: +20, Last Available: "2014-08"
-7709	Tesla energetic curative arcane researcher's Thor's Pliers	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
+7709	Tesla energetic curative arcane researcher's Thor's Pliers	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, HP Regen Min: 3, HP Regen Max: 5, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
 7710	dry activated teal candy UFOs	0		Effect: "Dreadful Chill", Effect Duration: 49
 7711	bouncing rosy-cheeked water wings for babies of bravery	0		Maximum HP Percent: +30, Spooky Resistance: +5
 7712	beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	rotten snack-sized Strix stix	2	crappy	
+7713	snack-sized rotten Strix stix	2	crappy	
 7714	Sherlock's aromatic supercool vampire pellet	0		Moxie Percent: +20, Stench Resistance: +1, Item Drop: +25
-7715	weak hand-crafted non-aged vinegar	2	EPIC	
+7715	hand-crafted weak non-aged vinegar	2	EPIC	
 7716	rock-hard unsanitized scalpel	0		Damage Reduction: 5
 7717	gladiator tunica of Tarzan	0		Experience (Muscle): +3
 7718	shaking blue veiny Roman sadnals	0		Maximum HP: +10, Single Equip
@@ -7639,7 +7639,7 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	teal wool Xiblaxian xeno-detection goggles	0		Cold Resistance: +1, Single Equip, Last Available: "2014-09"
-7753	chaotic Xiblaxian stealth cowl of the wise owl	0		Mysticality: +20, Spell Critical Percent: +10, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
+7753	chaotic Xiblaxian stealth cowl of the wise owl	0		Mysticality: +20, Spell Critical Percent: +10, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
 7754	tumbling Temple Grandin's Jim Carey's Xiblaxian stealth trousers	0		Monster Level: +25, Familiar Weight: +7, Last Available: "2014-09"
 7755	tumbling cyan flame-retardant cool Xiblaxian stealth vest	0		Moxie: +5, Hot Resistance: +1, Last Available: "2014-09"
 7756	adequate Xiblaxian ultraburrito	4	good	Last Available: "2014-09"
@@ -7653,7 +7653,7 @@
 7764	mixed fuchsia residual zeal	1		Effect: "Mushroom Might", Effect Duration: 20, Last Available: "2014-09"
 7765	studded Xiblaxian holo-wrist-puter	0		Damage Absorption: +80, Last Available: "2014-09"
 7766	crafty defective Golden Mr. Accessory of wisdom of temperance	0		Mysticality: +15, Maximum MP: +10, Sleaze Resistance: +5
-7767	lime green skewed airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
+7767	skewed lime green airplane charter: Conspiracy Island	0		Free Pull, Last Available: "2014-10"
 7768	one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	foul-smelling sage Personal Ventilation Unit of wisdom	0		Mysticality: +15, Mysticality Percent: +10, Stench Damage: +10, Single Equip, Last Available: "2014-10"
@@ -7668,12 +7668,12 @@
 7779	dry polarized experimental serum G-9	0		Effect: "Jingle Jangle Jingle", Effect Duration: 26, Last Available: "2014-10"
 7780	wobbly shaking cyan zippy supercool heavy-duty clipboard of the brute	0		Muscle Percent: +30, Moxie Percent: +20, Initiative: +20, Damage Reduction: 8, Last Available: "2014-10"
 7781	friendly slick battery-powered drill of the brazier of incineration	0		Moxie: +10, Familiar Weight: +3, Hot Spell Damage: 75, Last Available: "2014-10"
-7782	bite-sized normal limp broccoli	1	good	Last Available: "2014-10"
-7783	fireproof ribald Newton's hat	0		Experience (Mysticality): +3, Sleaze Damage: +10, Hot Resistance: +3, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7782	normal bite-sized limp broccoli	1	good	Last Available: "2014-10"
+7783	fireproof ribald Newton's hat	0		Experience (Mysticality): +3, Sleaze Damage: +10, Hot Resistance: +3, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
 7784	magnetized monkey barf	0		Effect: "Stick Emporium Membership", Effect Duration: 20, Last Available: "2014-10"
 7785	concentrated moist candy	0		Effect: "Bastard!", Effect Duration: 64, Last Available: "2014-10"
 7786	therapeutic slick jangly bracelet of Flo-Jo	0		Moxie: +10, Initiative: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-10"
-7787	twirling cuddly teddy bear of courage	0		Spooky Resistance: +3, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
+7787	twirling cuddly teddy bear of courage	0		Spooky Resistance: +3, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
 7788	ghostly ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	squat nasty extremely unsafe first-aid pouch	0		Weapon Damage Percent: +100, Stench Damage: +5, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
@@ -7685,11 +7685,11 @@
 7796	spoiled warm war shawarma	3	crappy	Last Available: "2014-10"
 7797	rotten bouncing karma shawarma	4	crappy	Last Available: "2014-10"
 7798	practically non-alcoholic tolerable Jungle Juice	1	good	Last Available: "2014-10"
-7799	enchanted tolerable narrow Amnesiac Ale	3	good	Effect: "What's That Smell?", Effect Duration: 50, Last Available: "2014-10"
-7800	irresponsibly strong aged Highest Bitter	10	awesome	Last Available: "2014-10"
+7799	tolerable enchanted narrow Amnesiac Ale	3	good	Effect: "What's That Smell?", Effect Duration: 50, Last Available: "2014-10"
+7800	aged irresponsibly strong Highest Bitter	10	awesome	Last Available: "2014-10"
 7801	Tesla energetic mercenary pistol	0		Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-10"
 7802	medical-grade healthy mercenary rifle	0		Maximum HP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-10"
-7803	narrow blue twirling Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
+7803	twirling blue narrow Merc Core Field Manual: Sanity Maintenance	0		Skill: "Hypersane", Last Available: "2014-10"
 7804	Merc Core Field Manual: Intimidation Techniques	0		Skill: "Intimidating Mien", Last Available: "2014-10"
 7805	twirling twirling Merc Core challenge coin	0		Last Available: "2014-10"
 7806	Merc Core deployment orders	0		Last Available: "2014-10"
@@ -7698,7 +7698,7 @@
 7809	impure gasoline	0		
 7810	upside-down Z-Bone steak	0		
 7811	blinking viral DNA	0		
-7812	yellow ghostly tarnished bottlecap	0		
+7812	ghostly yellow tarnished bottlecap	0		
 7813	flavorless seared dino steak	3	decent	
 7814	acceptable practically non-alcoholic bottle of drinkin' gas	1	good	
 7815	mirror handful of napalm	0		
@@ -7714,7 +7714,7 @@
 7825	MacGyver's deadly Da Vinci's earbuds	0		Experience (Mysticality): +5, Weapon Damage: +5, Maximum MP: +100, Single Equip
 7826	Usain Bolt's scandalous iFlail of James Dean	0		Experience (Moxie): +3, Sleaze Damage: +5, Initiative: +80
 7827	spoiled unidentifiable dried fruit	4	crappy	
-7828	aged fancy irresponsibly strong flat cider	10	awesome	Effect: "Ready to Snap", Effect Duration: 35
+7828	irresponsibly strong fancy aged flat cider	10	awesome	Effect: "Ready to Snap", Effect Duration: 35
 7829	shaking fuchsia crafty trench lighter of Tarzan of the sewer	0		Experience (Muscle): +3, Maximum MP: +10, Stench Damage: +25, Last Available: "2014-10"
 7830	modified teal experimental serum P-00	0		Effect: "Raging Animal", Effect Duration: 24, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7732,7 +7732,7 @@
 7843	special clip: boneburners	0		Last Available: "2014-10"
 7844	special clip: graveburpers	0		Last Available: "2014-10"
 7845	irradiated altered perl necklace	0		Effect: "Creepypasted", Effect Duration: 16, Last Available: "2014-12"
-7846	quadruple-dry upside-down narrow Fudge Fiber Armor Plating	0		Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2014-12"
+7846	quadruple-dry narrow upside-down Fudge Fiber Armor Plating	0		Effect: "Cotton Mouthed", Effect Duration: 25, Last Available: "2014-12"
 7847	colloidal blurry olive ruby on canes	0		Effect: "On a Roll", Effect Duration: 33, Last Available: "2014-12"
 7848	moldy petit fortran	4	crappy	Last Available: "2014-12"
 7849	moldy big java cookie	5	crappy	Last Available: "2014-12"
@@ -7743,14 +7743,14 @@
 7854	executive plastic Crimbot	0		Meat Drop: +40, Last Available: "2014-12"
 7855	pulsating wholesome plastic Crimbomega	0		Maximum HP Percent: +10, Last Available: "2014-12"
 7856	denatured wobbly flask of mining oil	0		Effect: "Nasty, Nasty Breath", Effect Duration: 66, Last Available: "2014-12"
-7857	gravedigger's radiation-resistant helmet	0		Spooky Damage: +10, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
-7858	cyan quilted servo-assisted exo-pants	0		Damage Absorption: +40, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
+7857	gravedigger's radiation-resistant helmet	0		Spooky Damage: +10, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
+7858	cyan quilted servo-assisted exo-pants	0		Damage Absorption: +40, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
 7859	cyan high-energy mining laser of the ox of the dark arts	0		Muscle: +20, Spell Damage Percent: +100, Last Available: "2014-12"
 7860	peppermint tailings	0		Last Available: "2014-12"
 7861	huge nugget of Crimbonium	0		Last Available: "2014-12"
 7862	cylindrical mold	0		Last Available: "2014-12"
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
-7864	spinning shaking Petite Paintbrush	0		Adventures: +1
+7864	shaking spinning Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
 7866	Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
@@ -7812,12 +7812,12 @@
 7923	tolerable gray Agitated Turkey	4	good	Last Available: "2014-11"
 7924	bad wobbly jittery Ambitious Turkey	4	decent	Last Available: "2014-11"
 7925	stale neutron lollipop	3	decent	Last Available: "2014-12"
-7926	perfectly mixed strong enchanted lime green gamma nog	5	EPIC	Effect: "Sealed Brain", Effect Duration: 10, Last Available: "2014-12"
+7926	enchanted perfectly mixed strong lime green gamma nog	5	EPIC	Effect: "Sealed Brain", Effect Duration: 10, Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	Crimbo Credit	0		
-7938	mixed cyan huge upside-down single atom	1	EPIC	Effect: "Shot in the Arse", Effect Duration: 30, Last Available: "2015-02"
+7938	mixed huge upside-down cyan single atom	1	EPIC	Effect: "Shot in the Arse", Effect Duration: 30, Last Available: "2015-02"
 7939	Time Cape	0		Last Available: "2014-11"
 7940	Time Cloak	0		Last Available: "2014-11"
 7941	sleeve deuce	0		
@@ -7828,7 +7828,7 @@
 7946	blurry frightening outlaw bandana of the pedagogue of the businessman	0		Experience: +3, Spooky Damage: +5, Meat Drop: +50
 7947	high-proof aged whiskey in a broken glass	10	awesome	
 7948	bad irresponsibly strong shot of mescal	6	decent	
-7949	extra-dry drinkable glass of herbal tequila	5	good	
+7949	drinkable extra-dry glass of herbal tequila	5	good	
 7950	twirling minin' dynamite	0		
 7951	rosy-cheeked plaid cowboy hat of the ox	0		Muscle: +20, Maximum HP Percent: +30, Familiar Effect: "2xLep, 1xBarrr, cap 25"
 7952	lime green lasso	0		
@@ -7836,13 +7836,13 @@
 7954	rattler rattle	0		
 7955	bag of money	0		
 7956	blinking olive Crimbo sapling	0		Free Pull, Last Available: "2014-12"
-7957	huge narrow even more tinsel	0		Familiar Weight: +5
+7957	narrow huge even more tinsel	0		Familiar Weight: +5
 7958	jittery box of Crimbo decorations	0		
 7959	letter to Ed the Undying	0		
 7960	yellow copy of a jerk adventurer's father's diary	0		
 7961	squat prompt dog trainer's savvy Staff of Ed of the empath	0		Mysticality Percent: +20, Familiar Weight: +5, Experience (familiar): +1, Adventures: +3
 7962	Eye of Ed	0		
-7963	wobbly tumbling amulet	0		
+7963	tumbling wobbly amulet	0		
 7964	friendly Staff of Fats	0		Familiar Weight: +3
 7965	Holy MacGuffin	0		
 7966	maroon Ka coin	0		
@@ -7881,17 +7881,17 @@
 7999	improved alkaline tumbling tumbling choco-Crimbot	0		Effect: "Sweet Incentive", Effect Duration: 58, Last Available: "2014-12"
 8000	pickled smart watch	0		Effect: "Flower Power", Effect Duration: 48, Last Available: "2014-12"
 8001	frozen magnetized augmented-reality shades	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 68, Last Available: "2014-12"
-8002	toy Crimbot mega face of Flo-Jo	0		Initiative: +100, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
-8003	tumbling spinning wool toy Crimbot power glove	0		Cold Resistance: +1, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
-8004	toy Crimbot super fist of the storm	0		Maximum MP Percent: +40, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
-8005	toy Crimbot rocket legs of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
+8002	toy Crimbot mega face of Flo-Jo	0		Initiative: +100, Crimbot Outfit Power: +1, Familiar Effect: "hot atk, cap 12", Last Available: "2014-12", Conditional Skill (Equipped): "LIGHT"
+8003	tumbling spinning wool toy Crimbot power glove	0		Cold Resistance: +1, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
+8004	toy Crimbot super fist of the storm	0		Maximum MP Percent: +40, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
+8005	toy Crimbot rocket legs of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
 8006	double-dry green Crimbot battery	0		Effect: "Sugary World View", Effect Duration: 33, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	spinning Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	squat heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	Lo Pan's MacGyver's strapping Crimbomega drive chain	0		Muscle: +5, Maximum MP: +100, Spell Critical Percent: +30, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
+8012	Lo Pan's MacGyver's strapping Crimbomega drive chain	0		Muscle: +5, Maximum MP: +100, Spell Critical Percent: +30, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
 8013	squat Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	tumbling Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7902,7 +7902,7 @@
 8020	bland Choco-Mint patty	4	decent	Last Available: "2015-01"
 8021	perfectly mixed hot mint schnocolate	3	EPIC	Last Available: "2015-01"
 8022	modified huge homeopathic mint tea	1	good	Effect: "Hombre Muerto Caminando", Effect Duration: 45, Last Available: "2015-01"
-8023	jittery purple muscle stimulator	0		Last Available: "2015-01"
+8023	purple jittery muscle stimulator	0		Last Available: "2015-01"
 8024	foreign language tapes	0		Last Available: "2015-01"
 8025	bowl of potpourri	0		Last Available: "2015-01"
 8026	ceiling fan	0		Last Available: "2015-01"
@@ -7916,7 +7916,7 @@
 8034	chaotic banded tope&eacute;	0		Damage Absorption: +100, Spell Critical Percent: +10, Familiar Effect: "3xBarrr, cap 12"
 8035	narrow family-friendly topiary tights of the empath	0		Familiar Weight: +5, Sleaze Resistance: +1
 8036	lime green shaking brainy topiary necktie	0		Mysticality: +5
-8037	small adequate bouncing bowl of topioca	2	good	
+8037	adequate small bouncing bowl of topioca	2	good	
 8038	wobbly topiary skunk	0		
 8039	jittery topiary noseplugs	0		Familiar Weight: +5
 8040	cyan trusty whip	0		
@@ -7947,14 +7947,14 @@
 8066	twisted	1	good	Last Available: "2015-12"
 8067	nuggets	0		
 8068	Professor of Spelunkology	0		Free Pull, Last Available: "2015-12"
-8069	gray squat Stembridge sidearm	0		Familiar Weight: +5
+8069	squat gray Stembridge sidearm	0		Familiar Weight: +5
 8070	narrow warehouse map page	0		
 8071	warehouse inventory page	0		
 8072	ghostly janitor sponge	0		
 8073	upside-down Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	shaking greedy Sherlock's rosy-cheeked Spelunker's fedora	0		Maximum HP Percent: +30, Item Drop: +25, Meat Drop: +20, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
+8074	shaking greedy Sherlock's rosy-cheeked Spelunker's fedora	0		Maximum HP Percent: +30, Item Drop: +25, Meat Drop: +20, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
 8075	gray skewed Jeselnik's healthy extremely unsafe Spelunker's whip	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Sleaze Damage: +25, Last Available: "2015-12"
-8076	smartaleck's Rosewater's Spelunker's khakis of the sweet-tooth	0		Mysticality Percent: +30, Moxie Percent: +30, Candy Drop: +100, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
+8076	smartaleck's Rosewater's Spelunker's khakis of the sweet-tooth	0		Mysticality Percent: +30, Moxie Percent: +30, Candy Drop: +100, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
 8077	skewed Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7984,7 +7984,7 @@
 8109	resourceful ascot of the pedagogue	0		Experience: +3, Maximum MP: +50, Single Equip, Last Available: "2017-12"
 8110	huge censurious veiny attache case	0		Maximum HP: +10, Sleaze Resistance: +3, Last Available: "2017-12"
 8111	lightning-fast sage accordion	0		Mysticality Percent: +10, Initiative: +40, Song Duration: 10, Last Available: "2017-12"
-8112	diluted twirling blinking huge aerosolized	1		Effect: "Butt-Rock Hair", Effect Duration: 40, Last Available: "2017-12"
+8112	diluted twirling huge blinking aerosolized	1		Effect: "Butt-Rock Hair", Effect Duration: 40, Last Available: "2017-12"
 8113	ghostly stanky wig of the empath	0		Familiar Weight: +5, Stench Spell Damage: +25, Last Available: "2017-12"
 8114	squat studded Newton's winch crank	0		Experience (Mysticality): +3, Damage Absorption: +80, Single Equip, Last Available: "2017-12"
 8115	stanky shellacked widget	0		Damage Reduction: 7, Stench Spell Damage: +25, Single Equip, Last Available: "2017-12"
@@ -7996,7 +7996,7 @@
 8121	huge nasty chilly garland	0		Cold Damage: +5, Stench Damage: +5, Single Equip, Last Available: "2018-12"
 8122	dangerous smooth gunnysack	0		Moxie: +15, Weapon Damage: +10, Last Available: "2018-12"
 8123	mirror garibaldi of the bloodbag of the boozehound	0		Maximum HP: +100, Booze Drop: +100, Last Available: "2018-12"
-8124	red wool girdle of the scaredy-cat	0		Monster Level: -15, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
+8124	red wool girdle of the scaredy-cat	0		Monster Level: -15, Cold Resistance: +1, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
 8125	personal trainer's gloves of James Dean	0		Experience (Moxie): +3, Experience Percent (Muscle): +10, Single Equip, Last Available: "2018-12"
 8126	pickled skewed smithereens	1		Last Available: "2018-12"
 8127	gray twirling healthy fiberglass fetish of the brute	0		Muscle Percent: +30, Maximum HP Percent: +20, Last Available: "2018-12"
@@ -8020,7 +8020,7 @@
 8146	chilled invisible potion	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 52
 8147	olive time shuriken	0		
 8148	friendly ninjammies of Leguizamo of the brazier	0		Monster Level: +20, Familiar Weight: +3, Hot Spell Damage: +25, Familiar Effect: "atk, 0.5xPotato, cap 25"
-8149	unsweetened cold-filtered ghostly bouncing Glo-Pop	0		Effect: "Go-Gone", Effect Duration: 68
+8149	unsweetened cold-filtered bouncing ghostly Glo-Pop	0		Effect: "Go-Gone", Effect Duration: 68
 8150	ionized moist sugar sphere	0		Effect: "Mighty Shout", Effect Duration: 19
 8151	denatured dry shaking Shrubble Bubble	0		Effect: "Flame-Retardant Trousers", Effect Duration: 58
 8152	irradiated altered green polyeaster egg	0		Effect: "Melancholy Burden", Effect Duration: 61
@@ -8036,9 +8036,9 @@
 8162	beefcake's skullcap of the brazier	0		Muscle: +25, Hot Spell Damage: +25, Familiar Effect: "1xVolley,cap 5"
 8163	jittery greedy rosewater-soaked three-legged pants	0		Stench Resistance: +3, Meat Drop: +20, Familiar Effect: "hot atk, cap 25"
 8164	jittery aromatic remaindered axe of Calamity Jane	0		Critical Hit Percent: +15, Stench Resistance: +1
-8165	narrow maroon low-budget shield	0		Damage Reduction: 3
+8165	maroon narrow low-budget shield	0		Damage Reduction: 3
 8166	wobbly thinker's cr&ecirc;epy mask of wisdom	0		Mysticality: 25, Familiar Effect: "spooky atk, cap 5"
-8167	thick toothsome baguette	5	awesome	
+8167	toothsome thick baguette	5	awesome	
 8168	huge glob of icing	0		
 8169	activated tumbling ginger snaps	0		Effect: "Smoky Third Eye", Effect Duration: 56
 8170	frozen cold-filtered mostly-broken sunglasses	0		Effect: "Dilated Pupils", Effect Duration: 39
@@ -8047,7 +8047,7 @@
 8173	Newton's sewer snake	0		Experience (Mysticality): +3
 8174	rotten pigeon egg	3	crappy	
 8175	horrifying jaunty feather of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +25
-8176	weak delicious premium malt liquor	2	awesome	
+8176	delicious weak premium malt liquor	2	awesome	
 8177	toasty brown paper pants of the boozehound	0		Hot Damage: +5, Booze Drop: +100
 8178	cyan sage brown paper bag mask of the detective	0		Mysticality Percent: +10, Item Drop: +20
 8179	scandalous ring of telling skeletons what to do	0		Sleaze Damage: +5, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8056,10 +8056,10 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	yellow twirling narrow forbidden bread basket	0		Spell Damage Percent: +50
 8184	Ed the Undying exhibit crate	0		
-8185	pulsating Jim Carey's The Crown of Ed the Undying of Flo-Jo	0		Monster Level: +25, Initiative: +100, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
+8185	pulsating Jim Carey's The Crown of Ed the Undying of Flo-Jo	0		Monster Level: +25, Initiative: +100, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	map to a hidden booze cache	0		
-8188	weak bad narrow blinking Cherrytastrophe wine cooler	2	decent	
+8188	bad weak blinking narrow Cherrytastrophe wine cooler	2	decent	
 8189	tolerable wobbly squat Radberry Rip wine cooler	4	good	
 8190	lousy Orangemageddon wine cooler	3	decent	
 8191	artisanal Breakfast Blast wine cooler	4	EPIC	
@@ -8068,11 +8068,11 @@
 8194	jumbo moldy glob of cream cheese	5	crappy	
 8195	tasty loaf of soda bread	3	awesome	
 8196	bland acceptable bagel	3	decent	
-8197	half-sized adequate upside-down standard-issue cupcake	2	good	
+8197	adequate half-sized upside-down standard-issue cupcake	2	good	
 8198	enchanted normal ultra-deluxe cupcake	4	good	Effect: "A Few Extra Pounds", Effect Duration: 20
 8199	hypnotic breadcrumbs	0		
 8200	flavorless popular tart	3	decent	
-8201	narrow teal upside-down no-handed pie	0		
+8201	teal upside-down narrow no-handed pie	0		
 8202	tarnished nitrogenated Doc Galaktik's Vitality Serum	0		Effect: "Gummiheart", Effect Duration: 22
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
 8204	tumbling lime green one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
@@ -8086,13 +8086,13 @@
 8212	grogpagne	0		Last Available: "2021-07"
 8213	spinning smelly smooth rigging rope	0		Moxie: +15, Stench Spell Damage: +10, Last Available: "2015-04"
 8214	compressed mirror nasty snuff	1	decent	Last Available: "2015-04"
-8215	rosewater-soaked forbidden sewage-clogged pistol	0		Spell Damage Percent: +50, Stench Resistance: +3, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
-8216	flattened quadruple-warmed gray narrow beard incense	0		Effect: "Sinuses For Miles", Effect Duration: 62, Last Available: "2015-04"
+8215	rosewater-soaked forbidden sewage-clogged pistol	0		Spell Damage Percent: +50, Stench Resistance: +3, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8216	flattened quadruple-warmed narrow gray beard incense	0		Effect: "Sinuses For Miles", Effect Duration: 62, Last Available: "2015-04"
 8217	medical-grade perfume-soaked bandana of the pedagogue	0		Experience: +3, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2015-04"
 8218	toxic globule	0		Last Available: "2015-04"
-8219	delicious massive toxo	9	awesome	Last Available: "2015-04"
-8220	aged weak Lemonade-235	2	awesome	Last Available: "2015-04"
-8221	purple avaricious savvy isotophat	0		Mysticality Percent: +20, Meat Drop: +30, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
+8219	massive delicious toxo	9	awesome	Last Available: "2015-04"
+8220	weak aged Lemonade-235	2	awesome	Last Available: "2015-04"
+8221	purple avaricious savvy isotophat	0		Mysticality Percent: +20, Meat Drop: +30, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
 8222	blinking nippy Three Mile Island shorts of the brazier	0		Cold Damage: +10, Hot Spell Damage: +25, Last Available: "2015-04"
 8223	resourceful Sinatra's toxic mop	0		Experience (Moxie): +5, Maximum MP: +50, Last Available: "2015-04"
 8224	inert sludgepuppy	0		Last Available: "2015-04"
@@ -8111,7 +8111,7 @@
 8237	green savvy Dinsey's pants of the sewer	0		Mysticality Percent: +20, Stench Damage: +25, Last Available: "2015-04"
 8238	brain preservation fluid	0		Last Available: "2015-04"
 8239	keycard &alpha;	0		Last Available: "2015-04"
-8240	huge olive keycard &beta;	0		Last Available: "2015-04"
+8240	olive huge keycard &beta;	0		Last Available: "2015-04"
 8241	tumbling keycard &gamma;	0		Last Available: "2015-04"
 8242	keycard &delta;	0		Last Available: "2015-04"
 8243	blinking complimentary Dinsey refreshments	0		Last Available: "2015-04"
@@ -8139,12 +8139,12 @@
 8265	Mayoflex	0		Last Available: "2015-05"
 8266	yellow lard-coated Annie Oakley's hardy miracle whip of Leguizamo	0		Maximum HP: +50, Critical Hit Percent: +20, Monster Level: +20, Sleaze Spell Damage: +25, Lasts Until Rollover, Last Available: "2015-05"
 8267	family-friendly sphygmayomanometer	0		Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2015-05"
-8268	gray skewed tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
+8268	skewed gray tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	thick toothsome unappetizing mayolus	5	awesome	Last Available: "2015-05"
 8271	huge rotten uninteresting mayolus	6	crappy	Last Available: "2015-05"
-8272	snack-sized delicious twirling acceptable mayolus	2	awesome	Last Available: "2015-05"
-8273	special normal enticing mayolus	3	good	Effect: "Ogred and Oublietted", Effect Duration: 50, Last Available: "2015-05"
+8272	delicious snack-sized twirling acceptable mayolus	2	awesome	Last Available: "2015-05"
+8273	normal special enticing mayolus	3	good	Effect: "Ogred and Oublietted", Effect Duration: 50, Last Available: "2015-05"
 8274	normal skewed mouth-watering mayolus	4	good	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
@@ -8184,17 +8184,17 @@
 8310	dry double-frozen .epub file	0		Effect: "Wet Rub", Effect Duration: 17
 8311	pickled mirror BUBBLE GUM	0		Effect: "Twinkly Weapon", Effect Duration: 59
 8312	tarnished ghostly hustler shades	0		Effect: "Chunky", Effect Duration: 68
-8313	moist bouncing shaking jerky stick	0		Effect: "Polka Face", Effect Duration: 35
+8313	moist shaking bouncing jerky stick	0		Effect: "Polka Face", Effect Duration: 35
 8314	concentrated yellow costume rental shop	0		Effect: "Spooky Flavor", Effect Duration: 18
 8315	improved muscle oil	0		Effect: "Hypercubed", Effect Duration: 18
 8316	double-quantum deionized blinking squat bottle of Red-Out	0		Effect: "It Didn't Kill You", Effect Duration: 60
-8317	ionized dry teal shaking pickpocket protector	0		Effect: "Liquid Luck", Effect Duration: 37
+8317	ionized dry shaking teal pickpocket protector	0		Effect: "Liquid Luck", Effect Duration: 37
 8318	modified aerosolized sinister-looking cat	0		Effect: "Larger", Effect Duration: 42
 8319	polymerized chilled jazzy cigarette holder	0		Effect: "Hagg-ard", Effect Duration: 30
 8320	alkaline quantum one glove	0		Effect: "Icy Demeanor", Effect Duration: 53
 8321	vacuum-sealed glove	0		Effect: "Spirit of Alph", Effect Duration: 11
 8322	diffused wet teal handful of fire	0		Effect: "Sticks and Stones", Effect Duration: 38
-8323	alkaline yellow skewed Cracklin' Oat Bran	0		Effect: "Crimbo Epiphany", Effect Duration: 68
+8323	alkaline skewed yellow Cracklin' Oat Bran	0		Effect: "Crimbo Epiphany", Effect Duration: 68
 8324	non-aerosolized shaking disposable lighter	0		Effect: "Tingly Biceps", Effect Duration: 58
 8325	super-vacuum-sealed unsweetened twirling coal contact lenses	0		Effect: "Super-Mega-Ultra-Hyper-Charged", Effect Duration: 28
 8326	dry narrow spinning conjured ice cream	0		Effect: "Good Karma", Effect Duration: 63
@@ -8216,7 +8216,7 @@
 8342	chilled liquefied baloney rotgut	0		Effect: "In the Limelight", Effect Duration: 39
 8343	alkaline aerosolized blurry carton of gaspers	0		Effect: "Flower Power", Effect Duration: 25
 8344	adjusted mirror bronze polish	0		Effect: "Techno Bliss", Effect Duration: 25
-8345	warmed chilled shaking jittery narrow crident	0		Effect: "Covetous Robbery", Effect Duration: 20
+8345	warmed chilled narrow jittery shaking crident	0		Effect: "Covetous Robbery", Effect Duration: 20
 8346	enhanced maroon blurry totally sweet mohawk helmet	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 16
 8347	ionized purple spray chrome	0		Effect: "Fortunate Resolve", Effect Duration: 46
 8348	frozen tarnished filthy monkey head	0		Effect: "On the Shoulders of Giants", Effect Duration: 36
@@ -8227,7 +8227,7 @@
 8353	pressed concentrated altered shaking grimy lab coat	0		Effect: "Litterboxing", Effect Duration: 14
 8354	colloidal improved jittery nursery rhyme	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 38
 8355	oxidized iron torso box	0		Effect: "Incensed", Effect Duration: 44
-8356	ionized jittery red narrow mercenary headband	0		Effect: "Meadulla Oblongota", Effect Duration: 64
+8356	ionized red narrow jittery mercenary headband	0		Effect: "Meadulla Oblongota", Effect Duration: 64
 8357	enhanced radioactive spider venom	0		Effect: "Cold, Dead Hands", Effect Duration: 27
 8358	oxidized x-ray mirror	0		Effect: "Stop and Smell the Fudge", Effect Duration: 66
 8359	triple-Vulcanized jittery wrestling mask	0		Effect: "Mushroom Moxiousness", Effect Duration: 58
@@ -8265,7 +8265,7 @@
 8391	mana	0		Last Available: "2015-07"
 8392	pulsating gift card	0		Last Available: "2015-07"
 8393	hermit factoid	0		Last Available: "2015-07"
-8394	bouncing tumbling The Emperor's dry cleaning	0		Last Available: "2015-07"
+8394	tumbling bouncing The Emperor's dry cleaning	0		Last Available: "2015-07"
 8395	blinking The Emperor's new hat of the glutton	0		Food Drop: +100, Last Available: "2015-07"
 8396	Rosewater's The Emperor's new shirt	0		Mysticality Percent: +30, Last Available: "2015-07"
 8397	greasy The Emperor's new pants	0		Sleaze Spell Damage: +10, Last Available: "2015-07"
@@ -8285,12 +8285,12 @@
 8411	thick bland spaghetti with ghost balls	5	decent	
 8412	decent miniature succulent marrow	2	good	
 8413	rotten salacious crumbs	3	crappy	
-8414	toothsome snack-sized blue fusilli marrownarrow	2	awesome	
+8414	snack-sized toothsome blue fusilli marrownarrow	2	awesome	
 8415	moldy spinning suggestive strozzapreti	4	crappy	
 8416	Mountain Stream gastrique	0		
-8417	snack-sized delicious jittery Mt. McLargeHuge oyster	2	awesome	
+8417	delicious snack-sized jittery Mt. McLargeHuge oyster	2	awesome	
 8418	fuchsia oyster sauce	0		
-8419	flavorless tiny linguini immondizia bianco	1	decent	
+8419	tiny flavorless linguini immondizia bianco	1	decent	
 8420	adequate mirror shells a la shellfish	4	good	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8329,19 +8329,19 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	green crystalline light bulb	0		Last Available: "2015-08"
 8457	skewed broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	educational groovy high-temperature mining mask	0		Moxie Percent: +10, Experience: +1, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
+8458	educational groovy high-temperature mining mask	0		Moxie Percent: +10, Experience: +1, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
 8459	blue aromatic fireproof megaphone of the sewer	0		Stench Damage: +25, Stench Resistance: +1, Last Available: "2015-08"
-8460	fancy moldy lime green mineapple	3	crappy	Effect: "Make Meat FA$T!", Effect Duration: 35, Last Available: "2015-08"
+8460	moldy fancy lime green mineapple	3	crappy	Effect: "Make Meat FA$T!", Effect Duration: 35, Last Available: "2015-08"
 8461	tolerable Gold Velvet&trade; whiskey	3	good	Last Available: "2015-08"
 8462	twirling lime green SMOOCH soda	1	good	Last Available: "2015-08"
-8463	bite-sized spoiled special bouncing smelted roe	1	crappy	Effect: "Category", Effect Duration: 25, Last Available: "2015-08"
+8463	special spoiled bite-sized bouncing smelted roe	1	crappy	Effect: "Category", Effect Duration: 25, Last Available: "2015-08"
 8464	high-proof mediocre lavawater	8	decent	Last Available: "2015-08"
 8465	wet modified fuchsia basaltamander tongue	0		Effect: "Strength of Ten Ettins", Effect Duration: 20, Last Available: "2015-08"
 8466	MacGyver's brawny lavalarva of the scaredy-cat	0		Muscle Percent: +20, Maximum MP: +100, Monster Level: -15, Last Available: "2015-08"
 8467	Lo Pan's Oprah's wizardly lava balaclava	0		Mysticality: +25, Maximum MP Percent: +50, Spell Critical Percent: +30, Last Available: "2015-08"
 8468	jittery Jim Carey's MacGyver's basaltamander buckler of the cheetah	0		Maximum MP: +100, Monster Level: +25, Initiative: +60, Damage Reduction: 15, Last Available: "2015-08"
 8469	polarized Vulcanized lava globs	0		Effect: "No Worries", Effect Duration: 40, Last Available: "2015-08"
-8470	moldy bite-sized fuchsia gooey lava globs	1	crappy	Last Available: "2015-08"
+8470	bite-sized moldy fuchsia gooey lava globs	1	crappy	Last Available: "2015-08"
 8471	extremely unsafe cool lava-proof pants	0		Moxie: +5, Weapon Damage Percent: +100, Last Available: "2015-08"
 8472	Annie Oakley's heat-resistant necktie of the bloodbag	0		Maximum HP: +100, Critical Hit Percent: +20, Single Equip, Last Available: "2015-08"
 8473	bouncing Usain Bolt's miser's rosewater-soaked heat-resistant gloves	0		Stench Resistance: +3, Meat Drop: +10, Initiative: +80, Single Equip, Last Available: "2015-08"
@@ -8350,9 +8350,9 @@
 8476	dry tumbling liquid rhinestones	0		Effect: "[1609]Dancin' Fool", Effect Duration: 26, Last Available: "2015-08"
 8477	moldy disco biscuit	4	crappy	Last Available: "2015-08"
 8478	perfectly mixed Quaatorade&trade;	4	EPIC	Last Available: "2015-08"
-8479	family-friendly horrifying vibrating biker's hat	0		Maximum MP Percent: +10, Spooky Damage: +25, Sleaze Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk"
-8480	Herculean brainy feathered headdress of the businessman	0		Mysticality: +5, Experience (Muscle): +1, Meat Drop: +50, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
-8481	nippy weightlifter's electrician's hardhat of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50, Cold Damage: +10, Last Available: "2015-08", Familiar Effect: "atk"
+8479	family-friendly horrifying vibrating biker's hat	0		Maximum MP Percent: +10, Spooky Damage: +25, Sleaze Resistance: +1, Familiar Effect: "atk", Last Available: "2015-08"
+8480	Herculean brainy feathered headdress of the businessman	0		Mysticality: +5, Experience (Muscle): +1, Meat Drop: +50, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
+8481	nippy weightlifter's electrician's hardhat of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50, Cold Damage: +10, Familiar Effect: "atk", Last Available: "2015-08"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	New Age hurting crystal	0		Last Available: "2015-08"
-8490	careful smooth velvet pants	0		Monster Level: -10, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
+8490	careful smooth velvet pants	0		Monster Level: -10, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
 8491	tumbling olive shaking beefy smooth velvet shirt	0		Muscle: +10, Last Available: "2015-08"
 8492	blinking supercharged smooth velvet hat	0		Maximum MP Percent: +30, Last Available: "2015-08"
 8493	smooth velvet pocket square of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2015-08"
@@ -8373,11 +8373,11 @@
 8499	Saturday Night thermometer	0		Last Available: "2015-08"
 8500	olive the tongue of Smimmons	0		Last Available: "2015-08"
 8501	spinning Raul's guitar pick	0		Last Available: "2015-08"
-8502	jittery huge Pener's crisps	0		Last Available: "2015-08"
+8502	huge jittery Pener's crisps	0		Last Available: "2015-08"
 8503	signed deuce	0		Last Available: "2015-08"
 8504	Lavalos core	0		Last Available: "2015-08"
 8505	blue half-melted hula girl	0		Last Available: "2015-08"
-8506	blurry skewed glass ceiling fragments	0		Last Available: "2015-08"
+8506	skewed blurry glass ceiling fragments	0		Last Available: "2015-08"
 8507	diluted SMOOCH coffee cup	1	good	Last Available: "2015-08"
 8508	electrified dry labrador cookie	0		Effect: "Mad at Science", Effect Duration: 46, Last Available: "2015-08"
 8509	brawny cool Mr. Cheeng's spectacles of the businessman	0		Moxie: +5, Muscle Percent: +20, Meat Drop: +50, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	knitted smooth SMOOCH bracers	0		Moxie: +15, Cold Resistance: +3, Single Equip, Last Available: "2015-08"
 8518	Lo Pan's SMOOCH kneepads	0		Spell Critical Percent: +30, Single Equip, Last Available: "2015-08"
 8519	flame-wreathed SMOOCH spaulders	0		Hot Spell Damage: +10, Single Equip, Last Available: "2015-08"
-8520	censurious electrified SMOOCH codpiece	0		Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
+8520	censurious electrified SMOOCH codpiece	0		Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
 8521	frightening SMOOCH breastplate	0		Spooky Damage: +5, Last Available: "2015-08"
 8522	narrow superduperheated	0		Last Available: "2015-08"
 8523	skewed fused fuse	0		Last Available: "2015-08"
@@ -8400,19 +8400,19 @@
 8526	moldy pink slime	4	crappy	
 8527	Devil's Elbow Hot Sauce	0		
 8528	spinning Special&trade; Sauce	0		
-8529	special rotten devil hair pasta	3	crappy	Effect: "Alacri Tea", Effect Duration: 40
+8529	rotten special devil hair pasta	3	crappy	Effect: "Alacri Tea", Effect Duration: 40
 8530	stale spagecialetti	3	decent	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
 8534	stale super-sized upside-down libertagliatelle	5	decent	
-8535	miniature decent gray skewed turkish mostaccioli	2	good	
+8535	miniature decent skewed gray turkish mostaccioli	2	good	
 8536	delicious bite-sized linguini of the sea	1	awesome	
 8537	anodized dry adjusted spinning Hersey&trade; SMOOCH	0		Effect: "Wax On Your Shoes", Effect Duration: 28
 8539	narrow Alexy sauce	0		
 8540	wobbly rainbow sauce	0		
-8541	shaking mirror drug cocktail sauce	0		
-8542	stale half-sized enchanted Fettris	2	decent	Effect: "Jerky, Boy", Effect Duration: 30
+8541	mirror shaking drug cocktail sauce	0		
+8542	enchanted stale half-sized Fettris	2	decent	Effect: "Jerky, Boy", Effect Duration: 30
 8543	big flavorless fusillocybin	5	decent	
 8544	tasty prescription noodles	3	awesome	
 8545	powdered blood-drive sticker	1	good	
@@ -8421,7 +8421,7 @@
 8548	double-pressed blurry shady shades	0		Effect: "Haunted Stomach", Effect Duration: 31
 8549	enhanced squeaky toy rose	0		Effect: "Initiative and Let Die", Effect Duration: 19
 8550	flavorless narrow weird gazelle steak	3	decent	
-8551	adequate half-sized sausage without a cause	2	good	
+8551	half-sized adequate sausage without a cause	2	good	
 8552	super-moist face paint	0		Effect: "Thick, Sick", Effect Duration: 26
 8553	bad practically non-alcoholic emergency margarita	1	decent	
 8554	drinkable vintage smart drink	4	good	
@@ -8437,7 +8437,7 @@
 8564	yellow shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	Lo Pan's medical-grade barrel lid of the cheetah	0		Spell Critical Percent: +30, Initiative: +60, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	flame-wreathed stylish barrel hoop earring of the cougar	0		Moxie: 45, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2015-09"
-8567	executive Temple Grandin's beefy bankruptcy barrel	0		Muscle: +10, Familiar Weight: +7, Meat Drop: +40, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
+8567	executive Temple Grandin's beefy bankruptcy barrel	0		Muscle: +10, Familiar Weight: +7, Meat Drop: +40, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
 8568	firkin	0		Last Available: "2015-09"
 8569	normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	cyan chaotic barrel gun	0		Spell Critical Percent: +10, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	snack-sized moldy water log	2	crappy	Last Available: "2015-09"
+8589	moldy snack-sized water log	2	crappy	Last Available: "2015-09"
 8590	curative barrelhead of wisdom	0		Mysticality: +15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2015-09"
 8591	gravedigger's experienced bottoms of the barrel	0		Experience: +2, Spooky Damage: +10, Last Available: "2015-09"
 8592	medical-grade supercool chest barrel	0		Moxie Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-09"
@@ -8501,13 +8501,13 @@
 8628	activated cuppa Mana tea	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 19, Last Available: "2015-09"
 8629	corrupted anodized wobbly cuppa Monstrosi tea	0		Effect: "Analog Drunk", Effect Duration: 21, Last Available: "2015-09"
 8630	energized jittery cuppa Twen tea	0		Effect: "Sizzling with Fury", Effect Duration: 65, Last Available: "2015-09"
-8631	quadruple-concentrated jittery red cuppa Gill tea	0		Effect: "Surreally Buff", Effect Duration: 37, Last Available: "2015-09"
+8631	quadruple-concentrated red jittery cuppa Gill tea	0		Effect: "Surreally Buff", Effect Duration: 37, Last Available: "2015-09"
 8632	frozen cuppa Uncertain tea	0		Effect: "Burning Hands", Effect Duration: 56, Last Available: "2015-09"
 8633	jittery cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
 8635	cuppa Royal tea	0		Last Available: "2015-09"
-8636	pickled tumbling pulsating pulsating cuppa Craft tea	0		Effect: "Carrion' On", Effect Duration: 26, Last Available: "2015-09"
-8637	concentrated ionized narrow red cuppa Insani tea	0		Effect: "Takin' It Greasy", Effect Duration: 33, Last Available: "2015-09"
+8636	pickled pulsating pulsating tumbling cuppa Craft tea	0		Effect: "Carrion' On", Effect Duration: 26, Last Available: "2015-09"
+8637	concentrated ionized red narrow cuppa Insani tea	0		Effect: "Takin' It Greasy", Effect Duration: 33, Last Available: "2015-09"
 8638	brawny Royal scepter of the businessman of the glutton	0		Muscle Percent: +20, Meat Drop: +50, Food Drop: +100, Last Available: "2015-09"
 8639	jittery doghouse	0		Free Pull, Last Available: "2015-10"
 8640	Ghost Dog Chow	0		Last Available: "2015-10"
@@ -8516,7 +8516,7 @@
 8643	snack-sized stale bowl of maggots	2	decent	Last Available: "2015-10"
 8644	drinkable blood and blood	3	good	Last Available: "2015-10"
 8645	watered-down delicious purple Jack-O-Lantern beer	2	awesome	Last Available: "2015-10"
-8646	weak perfectly mixed zombie	2	EPIC	Last Available: "2015-10"
+8646	perfectly mixed weak zombie	2	EPIC	Last Available: "2015-10"
 8647	red Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	skewed wind-up spider	0		Last Available: "2015-10"
 8649	plastic nightmare troll	0		Last Available: "2015-10"
@@ -8533,7 +8533,7 @@
 8660	grip key	0		
 8661	How to Play Othello	0		
 8662	grievous brainy ghostly dagger of James Dean	0		Mysticality: +5, Experience (Moxie): +3, Weapon Damage Percent: +50
-8663	practically non-alcoholic lousy yellow ghost beer	1	decent	
+8663	lousy practically non-alcoholic yellow ghost beer	1	decent	
 8664	huge medical-grade Othello set	0		HP Regen Min: 7, HP Regen Max: 10
 8665	narrow rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8547,8 +8547,8 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	electrified twirling shoulder-warming lotion	0		Effect: "Amplified Fabulousness", Effect Duration: 61, Last Available: "2015-11"
-8677	diet moldy blurry iceberg lettuce	1	crappy	Last Available: "2015-11"
-8678	mediocre practically non-alcoholic ice wine	1	decent	Last Available: "2015-11"
+8677	moldy diet blurry iceberg lettuce	1	crappy	Last Available: "2015-11"
+8678	practically non-alcoholic mediocre ice wine	1	decent	Last Available: "2015-11"
 8679	supercharged Newton's smartaleck's Wal-Mart snowglobe	0		Moxie Percent: +30, Experience (Mysticality): +3, Maximum MP Percent: +30, Last Available: "2015-11"
 8680	blurry family-friendly manspreader's Socratic Wal-Mart nametag	0		Experience (Mysticality): +1, Monster Level: +10, Sleaze Resistance: +1, Last Available: "2015-11"
 8681	squat friendly Lo Pan's Wal-Mart overalls of the early riser	0		Spell Critical Percent: +30, Familiar Weight: +3, Adventures: +7, Last Available: "2015-11"
@@ -8558,8 +8558,8 @@
 8685	tumbling Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	lime green The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	occult bellhop's hat	0		Spell Damage Percent: +25, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
-8689	special artisanal blinking ice porter	4	EPIC	Effect: "Heavily Breathing", Effect Duration: 50, Wiki Name: "ice porter (drink)", Last Available: "2015-11"
+8688	occult bellhop's hat	0		Spell Damage Percent: +25, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
+8689	artisanal special blinking ice porter	4	EPIC	Effect: "Heavily Breathing", Effect Duration: 50, Last Available: "2015-11", Wiki Name: "ice porter (drink)"
 8690	quadruple-polarized dry exotic travel brochure	0		Effect: "Egged On", Effect Duration: 31, Last Available: "2015-11"
 8691	tumbling bag of foreign bribes	0		Last Available: "2015-11"
 8692	pressed triple-aerosolized super-liquefied shampoo-conditioner	0		Effect: "Weird Flavor", Effect Duration: 66, Last Available: "2015-11"
@@ -8567,11 +8567,11 @@
 8694	narrow ice hotel bell	0		Last Available: "2015-11"
 8695	fuchsia Martialest Arts trophy	0		Last Available: "2016-01"
 8696	distilled medicinal herbs	1		Last Available: "2016-01"
-8697	low-calorie tasty ice rice	1	awesome	Last Available: "2016-01"
-8698	bad weak iced plum wine	2	decent	Last Available: "2016-01"
+8697	tasty low-calorie ice rice	1	awesome	Last Available: "2016-01"
+8698	weak bad iced plum wine	2	decent	Last Available: "2016-01"
 8699	jittery friendly Newton's sage training belt	0		Mysticality Percent: +10, Experience (Mysticality): +3, Familiar Weight: +3, Single Equip, Last Available: "2016-01"
 8700	mirror wool lard-coated training legwarmers of the businessman	0		Sleaze Spell Damage: +25, Cold Resistance: +1, Meat Drop: +50, Single Equip, Last Available: "2016-01"
-8701	Usain Bolt's veiny training helmet of the empath	0		Maximum HP: +10, Familiar Weight: +5, Initiative: +80, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
+8701	Usain Bolt's veiny training helmet of the empath	0		Maximum HP: +10, Familiar Weight: +5, Initiative: +80, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	blinking blinking training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
@@ -8597,35 +8597,35 @@
 8724	VYKEA lightning rune	0		Last Available: "2015-11"
 8725	bouncing VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
-8727	squat spinning teal VYKEA bracket	0		Last Available: "2015-11"
+8727	spinning squat teal VYKEA bracket	0		Last Available: "2015-11"
 8728	blue VYKEA dowel	0		Last Available: "2015-11"
 8729	inspector's perfumed VYKEA hex key of the dark arts	0		Spell Damage Percent: +100, Stench Resistance: +5, Item Drop: +15, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	moldy narrow tin of submardines	3	crappy	Wiki Name: "tin of submardines", Last Available: "2015-11"
+8731	moldy narrow tin of submardines	3	crappy	Last Available: "2015-11", Wiki Name: "tin of submardines"
 8732	smooth weak bottle of norwhiskey	2	awesome	Last Available: "2015-11"
 8733	compressed spinning octolus oculus	1	crappy	Effect: "Lubed", Effect Duration: 40, Last Available: "2015-11"
 8734	teal ghostly ruddy hardened weightlifter's sardine can key	0		Muscle: +15, Damage Reduction: 3, Maximum HP Percent: +40, Last Available: "2015-11"
-8735	stanky cool norwhal helmet of temperance	0		Moxie: +5, Stench Spell Damage: +25, Sleaze Resistance: +5, Last Available: "2015-11", Familiar Effect: "atk"
+8735	stanky cool norwhal helmet of temperance	0		Moxie: +5, Stench Spell Damage: +25, Sleaze Resistance: +5, Familiar Effect: "atk", Last Available: "2015-11"
 8736	energetic quilted Sinatra's octolus-skin cloak	0		Experience (Moxie): +5, Damage Absorption: +40, Maximum MP Percent: +20, Last Available: "2015-11"
 8737	spirit-forward bad perfect cosmopolitan	5	decent	Last Available: "2015-11"
 8738	artisanal shaking perfect negroni	4	EPIC	Last Available: "2015-11"
-8739	watered-down drinkable perfect dark and stormy	2	good	Last Available: "2015-11"
+8739	drinkable watered-down perfect dark and stormy	2	good	Last Available: "2015-11"
 8740	special aged perfect mimosa	4	awesome	Effect: "Square to be Hip", Effect Duration: 50, Last Available: "2015-11"
 8741	drinkable perfect old-fashioned	3	good	Last Available: "2015-11"
-8742	extra-dry artisanal perfect paloma	5	EPIC	Last Available: "2015-11"
+8742	artisanal extra-dry perfect paloma	5	EPIC	Last Available: "2015-11"
 8743	altered That 70s Cologne	0		Effect: "Really Deep Breath", Effect Duration: 23, Last Available: "2015-11"
 8744	irradiated super-flattened huge tumbling Wal-Mart &quot;diamond&quot; ring	0		Effect: "Weepy, Creepy", Effect Duration: 29, Last Available: "2015-11"
 8745	unsweetened narrow Puffstone cigar	0		Effect: "Cold Throat", Effect Duration: 53, Last Available: "2015-11"
 8746	pressed mirror Conspiracy&trade; mascara	0		Effect: "Human-Human Hybrid", Effect Duration: 15, Last Available: "2015-11"
 8747	deionized enhanced double-colloidal pulsating Spring Break Beach &quot;swimsuit&quot;	0		Effect: "Healthy Red Glow", Effect Duration: 46, Last Available: "2015-11"
 8748	purple airplane tattoo	0		Last Available: "2015-11"
-8749	modified frozen blinking blinking blue Deep Machine Tunnels snowglobe	0		Effect: "Fitter, Happier", Effect Duration: 51, Last Available: "2015-12"
+8749	modified frozen blinking blue blinking Deep Machine Tunnels snowglobe	0		Effect: "Fitter, Happier", Effect Duration: 51, Last Available: "2015-12"
 8750	magnetized hemp candy necklace	0		Effect: "Favored by Lyle", Effect Duration: 48, Last Available: "2015-12"
 8751	frozen communal gobstopper	0		Effect: "Hella Smart", Effect Duration: 12, Last Available: "2015-12"
-8752	rotten small Crimbo salad	2	crappy	Last Available: "2015-12"
+8752	small rotten Crimbo salad	2	crappy	Last Available: "2015-12"
 8753	decent bread line	3	good	Last Available: "2015-12"
-8754	weak perfectly mixed tumbling bark rootbeer	2	EPIC	Last Available: "2015-12"
-8755	drinkable fancy ale	3	good	Effect: "I See Everything Thrice!", Effect Duration: 15, Last Available: "2015-12"
+8754	perfectly mixed weak tumbling bark rootbeer	2	EPIC	Last Available: "2015-12"
+8755	fancy drinkable ale	3	good	Effect: "I See Everything Thrice!", Effect Duration: 15, Last Available: "2015-12"
 8756	horrifying plastic Tammy the Tambourine Elf	0		Spooky Damage: +25, Last Available: "2015-12"
 8757	bouncing slick plastic Rudolph the Red	0		Moxie: +10, Last Available: "2015-12"
 8758	extremely unsafe plastic Gaia'ajh-dsli Ak'lwej	0		Weapon Damage Percent: +100, Last Available: "2015-12"
@@ -8665,7 +8665,7 @@
 8793	face paint	0		Free Pull, Last Available: "2015-12"
 8794	squat The Big Book of Communism (used)	0		Skill: "Communism!", Last Available: "2015-12"
 8795	Batfellow comic	0		Free Pull, Last Available: "2016-12"
-8796	yellow narrow plastic spoiler	0		
+8796	narrow yellow plastic spoiler	0		
 8797	bat-oomerang	0		Last Available: "2017-01"
 8798	jittery wobbly bat-jute	0		Last Available: "2017-01"
 8799	bat-o-mite	0		Last Available: "2017-01"
@@ -8686,17 +8686,17 @@
 8814	Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	bat-bearing	0		Last Available: "2017-01"
 8816	toothsome huge Kudzu salad	9	awesome	Last Available: "2016-12"
-8817	altered squat blinking cyan Mansquito Serum	1		Effect: "Beastly Flavor", Effect Duration: 45, Last Available: "2016-12"
-8818	irresponsibly strong mediocre Miss Graves' vermouth	7	decent	Last Available: "2016-12"
-8819	low-calorie flavorless blurry The Plumber's mushroom stew	1	decent	Last Available: "2016-12"
+8817	altered cyan squat blinking Mansquito Serum	1		Effect: "Beastly Flavor", Effect Duration: 45, Last Available: "2016-12"
+8818	mediocre irresponsibly strong Miss Graves' vermouth	7	decent	Last Available: "2016-12"
+8819	flavorless low-calorie blurry The Plumber's mushroom stew	1	decent	Last Available: "2016-12"
 8820	mixed huge jittery The Author's ink	1		Last Available: "2016-02"
 8821	bad The Mad Liquor	3	decent	Last Available: "2016-12"
-8822	aged weak Doc Clock's thyme cocktail	2	awesome	Last Available: "2016-12"
+8822	weak aged Doc Clock's thyme cocktail	2	awesome	Last Available: "2016-12"
 8823	delicious Mr. Burnsger	3	awesome	Last Available: "2016-12"
 8824	powdered The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	rosewater-soaked dance instructor's The Jokester's gun of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Stench Resistance: +3, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	therapeutic The Jokester's wig of Tarzan of incineration	0		Experience (Muscle): +3, Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
-8827	asbestos-lined medical-grade forbidden The Jokester's pants	0		Spell Damage Percent: +50, Hot Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
+8825	rosewater-soaked dance instructor's The Jokester's gun of vim and vigor	0		Experience Percent (Moxie): +10, Maximum HP Percent: +50, Stench Resistance: +3, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
+8826	therapeutic The Jokester's wig of Tarzan of incineration	0		Experience (Muscle): +3, Hot Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
+8827	asbestos-lined medical-grade forbidden The Jokester's pants	0		Spell Damage Percent: +50, Hot Resistance: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
 8828	double-vacuum-sealed oxidized wobbly Jokester makeup	0		Effect: "Full of Vinegar", Effect Duration: 23, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
 8830	battoo kit	0		Last Available: "2016-12"
@@ -8716,10 +8716,10 @@
 8844	frozen The Author's inkwell	0		Effect: "Snobby", Effect Duration: 61
 8845	pickled cold-filtered bag of random words	0		Effect: "Heart of Lavender", Effect Duration: 69
 8846	enhanced liquefied tube of pendulum lube	0		Effect: "Nut-Rition", Effect Duration: 39
-8847	ionized double-ionized wobbly upside-down red-hot jawbreaker	0		Effect: "On the Trolley", Effect Duration: 50
+8847	ionized double-ionized upside-down wobbly red-hot jawbreaker	0		Effect: "On the Trolley", Effect Duration: 50
 8848	corrupted boiled question juice	0		Effect: "Turtle Power", Effect Duration: 38
 8849	polarized ionized tube of villain	0		Effect: "Deadly Lampblade", Effect Duration: 24
-8850	upside-down upside-down wholesome your cowboy boots	0		Maximum HP Percent: +10, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
+8850	upside-down upside-down wholesome your cowboy boots	0		Maximum HP Percent: +10, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	huge nugget of quicksilver	0		Last Available: "2016-02"
 8853	fuchsia nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,19 +8746,19 @@
 8874	asbestos-lined boxer's smooth Val-U Brand Every Bean Salad of James Dean of the scaredy-cat	0		Moxie: +15, Muscle Percent: +10, Experience (Moxie): +3, Monster Level: -15, Hot Resistance: +5, Last Available: "2016-02"
 8875	mansplainer's medical-grade boxer's Shrub's Premium Baked Beans	0		Muscle Percent: +10, Monster Level: +15, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-02"
 8876	spoiled plate of Heimz Fortified Kidney Beans	4	crappy	Last Available: "2016-02"
-8877	jumbo normal plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
+8877	normal jumbo plate of Tesla's Electroplated Beans	5	good	Last Available: "2016-02"
 8878	flavorless plate of Mixed Garbanzos and Chickpeas	4	decent	Last Available: "2016-02"
 8879	adequate plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
 8880	adequate diet pulsating plate of Frigid Northern Beans	1	good	Last Available: "2016-02"
-8881	rotten enchanted plate of World's Blackest-Eyed Peas	4	crappy	Effect: "Aided and Abetted", Effect Duration: 40, Last Available: "2016-02"
+8881	enchanted rotten plate of World's Blackest-Eyed Peas	4	crappy	Effect: "Aided and Abetted", Effect Duration: 40, Last Available: "2016-02"
 8882	immense adequate plate of Trader Olaf's Exotic Stinkbeans	7	good	Last Available: "2016-02"
-8883	stale shaking mirror plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	decent	Last Available: "2016-02"
+8883	stale mirror shaking plate of Pork 'n' Pork 'n' Pork 'n' Beans	4	decent	Last Available: "2016-02"
 8884	yummy plate of Val-U Brand Every Bean Salad	4	awesome	Last Available: "2016-02"
 8885	spoiled plate of Shrub's Premium Baked Beans	4	crappy	Last Available: "2016-02"
 8886	studded Fancy Jeff's pocket square of the cougar	0		Moxie: +20, Damage Absorption: +80, Last Available: "2016-02"
-8887	pulsating family-friendly Sinatra's Daisy's unclean bloomers of Flo-Jo	0		Experience (Moxie): +5, Sleaze Resistance: +1, Initiative: +100, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
+8887	pulsating family-friendly Sinatra's Daisy's unclean bloomers of Flo-Jo	0		Experience (Moxie): +5, Sleaze Resistance: +1, Initiative: +100, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	family-friendly chaotic fortified Amoon-Ra Cowtep's nemes	0		Damage Absorption: +60, Spell Critical Percent: +10, Sleaze Resistance: +1, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
+8889	family-friendly chaotic fortified Amoon-Ra Cowtep's nemes	0		Damage Absorption: +60, Spell Critical Percent: +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
 8890	green Glenn's dice	0		Last Available: "2016-02"
 8891	reassuring horrifying fortified groovy Former Sheriff Dan's tin star of the boozehound	0		Moxie Percent: +10, Damage Absorption: +60, Spooky Damage: +25, Spooky Resistance: +1, Booze Drop: +100, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8774,14 +8774,14 @@
 8902	wet denatured frozen ghost bit	0		Effect: "Down With Chow", Effect Duration: 54, Last Available: "2016-02"
 8903	extra-corrupted buzzard feather	0		Effect: "Incredibly Hulking", Effect Duration: 38, Last Available: "2016-02"
 8904	oxidized extra-warmed maroon lion musk	0		Effect: "Jammin'", Effect Duration: 41, Last Available: "2016-02"
-8905	immense rotten bear claw	6	crappy	Last Available: "2016-02"
+8905	rotten immense bear claw	6	crappy	Last Available: "2016-02"
 8906	oxidized rattler gland	0		Effect: "Steroid Boost", Effect Duration: 57, Last Available: "2016-02"
 8907	pressed deionized half-digested coal	0		Effect: "Really Deep Breath", Effect Duration: 34, Last Available: "2016-02"
 8908	denatured nitrogenated tightly-wound spine	0		Effect: "Abyssal Sweat", Effect Duration: 28, Last Available: "2016-02"
 8909	stale tumbling rotting beefsteak	3	decent	Last Available: "2016-02"
 8910	delicious watered-down firemilk	2	awesome	Last Available: "2016-02"
 8911	liquefied spidercow eye-cluster	0		Effect: "Hot Hands", Effect Duration: 12, Last Available: "2016-02"
-8912	compressed tumbling twirling moomy dust	1		Effect: "Smokin'", Effect Duration: 25, Last Available: "2016-02"
+8912	compressed twirling tumbling moomy dust	1		Effect: "Smokin'", Effect Duration: 25, Last Available: "2016-02"
 8913	ghostly Annie Oakley's western-style skinning knife of Flo-Jo	0		Critical Hit Percent: +20, Initiative: +100, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	supercharged steel knuckles	0		Maximum MP Percent: +30, Last Available: "2016-02"
@@ -8793,7 +8793,7 @@
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	blinking Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
 8923	disc (white)	0		
-8924	tumbling cyan disc (black)	0		
+8924	cyan tumbling disc (black)	0		
 8925	disc (red)	0		
 8926	mirror skewed disc (green)	0		
 8927	green huge disc (blue)	0		
@@ -8805,7 +8805,7 @@
 8933	custom sixgun	0		Last Available: "2016-02"
 8934	baconstone-handled sixgun	0		Last Available: "2016-02"
 8935	narrow porquoise-handled sixgun	0		Last Available: "2016-02"
-8936	skewed ghostly hamethyst-handled sixgun	0		Last Available: "2016-02"
+8936	ghostly skewed hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
 8938	grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
@@ -8861,24 +8861,24 @@
 8989	Witchess Set	0		Free Pull, Last Available: "2016-03"
 8990	shaking shaking electronic Brain Trainer game	0		Skill: "Brain Games"
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
-8992	powdered bouncing blurry armored prawn	1		Effect: "Oleaginous Soles", Effect Duration: 45, Last Available: "2016-03"
+8992	powdered blurry bouncing armored prawn	1		Effect: "Oleaginous Soles", Effect Duration: 45, Last Available: "2016-03"
 8993	stale fuchsia jumping horseradish	3	decent	Last Available: "2016-03"
-8994	fancy smooth triple-distilled Sacramento wine	8	awesome	Effect: "Prelude of Precision", Effect Duration: 30, Last Available: "2016-03"
+8994	fancy triple-distilled smooth Sacramento wine	8	awesome	Effect: "Prelude of Precision", Effect Duration: 30, Last Available: "2016-03"
 8995	adjusted wobbly Greek fire	0		Effect: "Material Witness", Effect Duration: 35, Last Available: "2016-03"
 8996	Jack Frost's medical-grade steel-toed ox-head shield of wisdom of Tarzan	0		Mysticality: +15, Experience (Muscle): +3, Damage Reduction: 25, Cold Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2016-03"
 8997	skewed coward's banded razor-sharp groovy dented scepter	0		Moxie Percent: +10, Weapon Damage Percent: +25, Damage Absorption: +100, Monster Level: -20, Item Drop: +5, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	mirror flame-retardant scorching very pointy crown of wisdom of the dark arts of the scaredy-cat	0		Mysticality: +15, Spell Damage Percent: +100, Monster Level: -15, Hot Damage: +25, Hot Resistance: +1, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
+8998	mirror flame-retardant scorching very pointy crown of wisdom of the dark arts of the scaredy-cat	0		Mysticality: +15, Spell Damage Percent: +100, Monster Level: -15, Hot Damage: +25, Hot Resistance: +1, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
 8999	coward's hardened Da Vinci's cool thinker's battle broom	0		Mysticality: +10, Moxie: +5, Experience (Mysticality): +5, Damage Reduction: 3, Monster Level: -20, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	spinning Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	cyan Usain Bolt's greedy shellacked beefcake's carpe	0		Muscle: +25, Damage Reduction: 7, Meat Drop: +20, Initiative: +80, Lasts Until Rollover, Last Available: "2016-04"
 9002	tumbling red reassuring Temple Grandin's savvy codpiece of wisdom	0		Mysticality: +15, Mysticality Percent: +20, Familiar Weight: +7, Spooky Resistance: +1, Lasts Until Rollover, Last Available: "2016-04"
-9003	nippy rosy-cheeked rock-hard troutsers of Gandalf	0		Damage Reduction: 5, Maximum HP Percent: +30, Spell Critical Percent: +20, Cold Damage: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
+9003	nippy rosy-cheeked rock-hard troutsers of Gandalf	0		Damage Reduction: 5, Maximum HP Percent: +30, Spell Critical Percent: +20, Cold Damage: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
 9004	resourceful personal trainer's bass clarinet of the cougar of horror	0		Moxie: +20, Experience Percent (Muscle): +10, Maximum MP: +50, Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9005	tumbling wool personal trainer's fish hatchet of the sweet-tooth of the glutton	0		Experience Percent (Muscle): +10, Cold Resistance: +1, Candy Drop: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9006	scorching mansplainer's beefy tunac of wisdom	0		Muscle: +10, Mysticality: +15, Monster Level: +15, Hot Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9007	tumbling fishin' pole	0		Last Available: "2016-04"
 9008	enhanced bouncing wriggling worm	0		Effect: "Corruption of Wretched Wally", Effect Duration: 21, Last Available: "2016-04"
-9009	spirit-forward mediocre upside-down bottle of Fishhead 900-Day IPA	5	decent	Last Available: "2016-04"
+9009	mediocre spirit-forward upside-down bottle of Fishhead 900-Day IPA	5	decent	Last Available: "2016-04"
 9010	denatured super-energized green high-test fishing line	0		Effect: "Mystic Circle", Effect Duration: 33, Last Available: "2016-04"
 9011	hardened fishin' hat	0		Damage Reduction: 3, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8890,7 +8890,7 @@
 9018	internet point	0		Last Available: "2016-05"
 9019	yellow meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
-9021	thick bland gallon of milk	5	decent	Last Available: "2016-05"
+9021	bland thick gallon of milk	5	decent	Last Available: "2016-05"
 9022	print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	twirling daily dungeon malware	0		Last Available: "2016-05"
@@ -8899,9 +8899,9 @@
 9027	huge horrifying Jack Frost's First Post shirt - Cir Senam of incineration	0		Cold Spell Damage: +50, Hot Spell Damage: +50, Spooky Damage: +25, Last Available: "2016-05"
 9028	mirror high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	diet bland star salad	1	decent	
+9030	bland diet star salad	1	decent	
 9031	Thwaitgold moth statuette	0		
-9032	flavorless snack-sized bowl of Tastee-Wheet&trade;	2	decent	
+9032	snack-sized flavorless bowl of Tastee-Wheet&trade;	2	decent	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	Source essence	0		Last Available: "2016-06"
 9035	stale browser cookie	3	decent	Last Available: "2016-06"
@@ -8947,11 +8947,11 @@
 9075	double-electrified shoe gum	0		Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 50, Last Available: "2016-07"
 9076	skewed Annie Oakley's noir fedora of James Dean of the blizzard	0		Experience (Moxie): +3, Critical Hit Percent: +20, Cold Spell Damage: +25, Last Available: "2016-07"
 9077	twirling wobbly Tesla thinker's trench coat of the cougar	0		Mysticality: +10, Moxie: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-07"
-9078	acceptable practically non-alcoholic Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
+9078	practically non-alcoholic acceptable Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
 9079	moldy tumbling hardboiled egg	3	crappy	Last Available: "2016-07"
 9080	ghostly jittery detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	huge lard-coated scorching sizzling Jim Carey's banded protonic accelerator pack of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Monster Level: +25, Hot Damage: 35, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
+9082	huge lard-coated scorching sizzling Jim Carey's banded protonic accelerator pack of the brute	0		Muscle Percent: +30, Damage Absorption: +100, Monster Level: +25, Hot Damage: 35, Sleaze Spell Damage: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
 9083	gray almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	Adventurer bobblehead of the sweet-tooth	0		Candy Drop: +100, Last Available: "2016-11"
 9085	blurry psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8963,8 +8963,8 @@
 9091	Mr. Screege's spectacles of the cougar	0		Moxie: +20, Single Equip, Last Available: "2016-08"
 9092	lard-coated experienced Spookyraven signet of the sweet-tooth	0		Experience: +2, Sleaze Spell Damage: +25, Candy Drop: +100, Single Equip, Last Available: "2016-08"
 9093	energetic tie-dyed fannypack of Calamity Jane	0		Maximum MP Percent: +20, Critical Hit Percent: +15, Single Equip, Last Available: "2016-08"
-9094	curative forbidden burnt snowpants	0		Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	standards and practices guide of the sewer	0		Stench Damage: +25, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
+9094	curative forbidden burnt snowpants	0		Spell Damage Percent: +50, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9095	standards and practices guide of the sewer	0		Stench Damage: +25, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
 9096	blinking Tesla energetic stylish Carpathian longsword	0		Moxie: +25, Maximum MP Percent: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-08"
 9097	mirror executive medical-grade beefy Liam's mail	0		Muscle: +10, Meat Drop: +40, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-08"
 9098	Unfortunato's foolscap of Tarzan of Leguizamo of the brazier	0		Experience (Muscle): +3, Monster Level: +20, Hot Spell Damage: +25, Last Available: "2016-08"
@@ -8978,24 +8978,24 @@
 9106	fuchsia Rad-B-Gone (1 lb.)	0		
 9107	colloidal pulsating bouncing Rad-Pro (1 oz.)	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 32
 9108	lead umbrella	0		
-9109	polymerized quadruple-corrupted blinking purple ghostly Shrieking Weasel holo-record	0		Effect: "Wistfully Nostalgic", Effect Duration: 55
-9110	pressed cold-filtered twirling lime green Power-Guy 2000 holo-record	0		Effect: "Fizzier Than Light", Effect Duration: 46
+9109	polymerized quadruple-corrupted purple blinking ghostly Shrieking Weasel holo-record	0		Effect: "Wistfully Nostalgic", Effect Duration: 55
+9110	pressed cold-filtered lime green twirling Power-Guy 2000 holo-record	0		Effect: "Fizzier Than Light", Effect Duration: 46
 9111	ionized corrupted Lucky Strikes holo-record	0		Effect: "Amorous Avarice", Effect Duration: 50
 9112	nitrogenated fuchsia EMD holo-record	0		Effect: "Egg-headedness", Effect Duration: 13
 9113	liquefied magnetized Superdrifter holo-record	0		Effect: "Pasta Oneness", Effect Duration: 25
 9114	polarized wobbly blinking pulsating The Pigs holo-record	0		Effect: "stats.enq", Effect Duration: 48
-9115	energized aerosolized red wobbly Drunk Uncles holo-record	0		Effect: "Human-Hobo Hybrid", Effect Duration: 43
+9115	energized aerosolized wobbly red Drunk Uncles holo-record	0		Effect: "Human-Hobo Hybrid", Effect Duration: 43
 9116	time residue	0		Last Available: "2016-09"
 9117	pulsating nippy repaid diaper	0		Cold Damage: +10
 9118	Riker's Search History	0		Last Available: "2016-09"
-9119	artisanal fortified Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
+9119	fortified artisanal Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
 9120	family-friendly Unstable Pointy Ears	0		Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2016-09"
 9121	Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
 9123	School of Hard Knocks Diploma	0		
 9124	baby bark scorpion	0		
 9125	twirling droppable microphone	0		
-9126	artisanal high-proof skewed unidentified drink	10	EPIC	
+9126	high-proof artisanal skewed unidentified drink	10	EPIC	
 9127	red asbestos-lined KoL Con 13 T-shirt of dire peril	0		Weapon Damage: +20, Hot Resistance: +5
 9128	family-friendly lard-coated Fonzie's discarded swimming trunks	0		Experience (Moxie): +1, Sleaze Spell Damage: +25, Sleaze Resistance: +1
 9129	improved irradiated diluted makeup	0		Effect: "Berry Berry Cold", Effect Duration: 55
@@ -9003,28 +9003,28 @@
 9131	extremely confusing manual	0		
 9132	smooth pistol of Tarzan	0		Moxie: +15, Experience (Muscle): +3
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	special super-sized rotten leftover pasty	5	crappy	Effect: "Hennaliciousness", Effect Duration: 10
+9134	rotten special super-sized leftover pasty	5	crappy	Effect: "Hennaliciousness", Effect Duration: 10
 9135	delicious fortified blue very whiskey	5	awesome	
 9136	upside-down li'l orphan tot	0		Free Pull, Last Available: "2016-10"
-9137	narrow blinking li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9141	olive li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9144	bouncing blue li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9137	blinking narrow li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
+9138	li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9141	olive li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9142	blurry li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9144	bouncing blue li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9146	activated extra-enhanced bouncing hoarded candy wad	0		Effect: "Celestial Vision", Effect Duration: 37, Last Available: "2016-10"
 9147	double-chilled Vulcanized triple-oxidized Prunets	0		Effect: "Joyful Resolve", Effect Duration: 17
 9148	bouncing Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	deionized triple-flattened invisible string	0		Lasts Until Rollover, Effect: "Toast Tea", Effect Duration: 13, Last Available: "2016-10"
 9151	galvanized pulsating invisible seam ripper	0		Lasts Until Rollover, Effect: "Bark of the Dog", Effect Duration: 30, Last Available: "2016-10"
-9152	li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9152	li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
 9153	decent upside-down raw sweet potato	3	good	Last Available: "2016-11"
-9154	decent huge fuchsia raw beans	9	good	Last Available: "2016-11"
-9155	flavorless fancy raw stuffing	4	decent	Effect: "El Vibrations", Effect Duration: 35, Last Available: "2016-11"
+9154	huge decent fuchsia raw beans	9	good	Last Available: "2016-11"
+9155	fancy flavorless raw stuffing	4	decent	Effect: "El Vibrations", Effect Duration: 35, Last Available: "2016-11"
 9156	super-sized rotten twirling raw cranberry sauce	5	crappy	Last Available: "2016-11"
 9157	adequate raw turkey	4	good	Last Available: "2016-11"
 9158	tasty raw mincemeat	3	awesome	Last Available: "2016-11"
@@ -9040,15 +9040,15 @@
 9168	smelly baleful potato masher	0		Spell Damage: +25, Stench Spell Damage: +10, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	blurry bread mold	0		Last Available: "2016-11"
-9171	tiny stale sweet potatoes	1	decent	Last Available: "2016-11"
+9171	stale tiny sweet potatoes	1	decent	Last Available: "2016-11"
 9172	moldy half-sized fuchsia huge bean casserole	2	crappy	Last Available: "2016-11"
 9173	stale small baked stuffing	2	decent	Last Available: "2016-11"
-9174	enchanted bland narrow cranberry cylinder	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45, Last Available: "2016-11"
+9174	bland enchanted narrow cranberry cylinder	4	decent	Effect: "Sharpened Sweet Tooth", Effect Duration: 45, Last Available: "2016-11"
 9175	moldy squat mirror thanksgiving turkey	4	crappy	Last Available: "2016-11"
 9176	flavorless miniature tumbling blurry mince pie	2	decent	Last Available: "2016-11"
 9177	spoiled bouncing mashed potatoes	4	crappy	Last Available: "2016-11"
 9178	moldy big warm gravy	5	crappy	Last Available: "2016-11"
-9179	half-sized normal twirling bread roll	2	good	Last Available: "2016-11"
+9179	normal half-sized twirling bread roll	2	good	Last Available: "2016-11"
 9180	moldy lime green leftovers	4	crappy	Last Available: "2016-11"
 9181	bland snack-sized pulsating leftovers sandwich	2	decent	Last Available: "2016-11"
 9182	upside-down gray Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
@@ -9056,7 +9056,7 @@
 9184	upside-down megacopia	0		Last Available: "2016-11"
 9185	squat pilgrim hat	0		Last Available: "2016-11"
 9186	skewed packet of thanksgarden seeds	0		Last Available: "2016-11"
-9187	blue squat cashew	0		Last Available: "2016-11"
+9187	squat blue cashew	0		Last Available: "2016-11"
 9188	bomb of unknown origin	0		Last Available: "2016-11"
 9189	Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	jittery eldritch effluvium	0		
@@ -9064,18 +9064,18 @@
 9192	mediocre eldritch extract	4	decent	Last Available: "2016-11"
 9193	fuchsia Official Council Aide Pin of incineration of mayonnaise	0		Hot Spell Damage: +50, Sleaze Spell Damage: +50, Last Available: "2016-11"
 9194	weak drinkable special eldritch distillate	2	good	Effect: "Superveiny 9000", Effect Duration: 40, Last Available: "2016-11"
-9195	twisted upside-down skewed eldritch essence	1		Effect: "Pretending to Pretend", Effect Duration: 35, Last Available: "2016-11"
+9195	twisted skewed upside-down eldritch essence	1		Effect: "Pretending to Pretend", Effect Duration: 35, Last Available: "2016-11"
 9196	narrow experienced Science Notebook	0		Experience: +2
 9197	cyan miser's strapping eldritch hat of wisdom	0		Muscle: +5, Mysticality: +15, Meat Drop: +10, Last Available: "2016-11"
 9198	pulsating frightening toasty Jim Carey's eldritch pants	0		Monster Level: +25, Hot Damage: +5, Spooky Damage: +5, Last Available: "2016-11"
-9199	aged weak eldritch elixir	2	awesome	Last Available: "2016-11"
+9199	weak aged eldritch elixir	2	awesome	Last Available: "2016-11"
 9200	tumbling rock-hard Quartet of Flare Masters Jacket of the detective	0		Damage Reduction: 5, Item Drop: +20, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
-9203	olive huge Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
+9203	huge olive Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	huge counterfeit city	0		Last Available: "2016-12"
 9205	sprinkles	0		Last Available: "2016-12"
-9206	spinning green The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
+9206	green spinning The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	tumbling Van der Graaf ball and chain	0		MP Regen Min: 5, MP Regen Max: 7, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	olive candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9209	huge gingerbread tophat of the empath	0		Familiar Weight: +5, Last Available: "2016-12"
@@ -9088,7 +9088,7 @@
 9216	blinking interesting clod of dirt	0		
 9217	upside-down gingerbread restraining order	0		Last Available: "2016-12"
 9218	sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
-9219	miniature fancy normal animal part cracker	2	good	Effect: "Disco Neuropathy", Effect Duration: 5, Last Available: "2016-12"
+9219	normal fancy miniature animal part cracker	2	good	Effect: "Disco Neuropathy", Effect Duration: 5, Last Available: "2016-12"
 9220	triple-distilled tolerable wobbly gingerbread wine	8	good	Last Available: "2016-12"
 9221	stale gingerbread mug	3	decent	Last Available: "2016-12"
 9222	slick gingerbread mask	0		Moxie: +10, Last Available: "2016-12"
@@ -9123,8 +9123,8 @@
 9251	frozen Inner Truth	0		Effect: "Tiki Temerity", Effect Duration: 36, Last Available: "2016-12"
 9252	decent squat gray spiritual candy cane	4	good	Last Available: "2016-12"
 9253	bad blinking spiritual eggnog	3	decent	Last Available: "2016-12"
-9254	small moldy spiritual fruitcake	2	crappy	Last Available: "2016-12"
-9255	tasty super-sized olive bouncing spiritual gingerbread	5	awesome	Last Available: "2016-12"
+9254	moldy small spiritual fruitcake	2	crappy	Last Available: "2016-12"
+9255	super-sized tasty bouncing olive spiritual gingerbread	5	awesome	Last Available: "2016-12"
 9256	chocolate puppy	0		Last Available: "2016-12"
 9257	teal chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
 9258	My Life of Crime, a Memoir	0		Skill: "Gingerbread Mob Hit", Last Available: "2016-12"
@@ -9144,11 +9144,11 @@
 9272	negative lump	0		
 9273	huge smelly thinker's Third Eye	0		Mysticality: +10, Stench Spell Damage: +10, Last Available: "2016-12"
 9274	censurious beefcake's Krampus Horn	0		Muscle: +25, Sleaze Resistance: +3, Single Equip, Last Available: "2016-12"
-9275	enchanted stale tiny hambrosier	1	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2016-12"
+9275	tiny stale enchanted hambrosier	1	decent	Effect: "All Fired Up", Effect Duration: 10, Last Available: "2016-12"
 9276	artisanal watered-down teal jittery chakra-mental wine	2	EPIC	Last Available: "2016-12"
 9277	denatured chakra malt	0		Effect: "Fizzier Than Light", Effect Duration: 54, Last Available: "2016-12"
 9278	moldy huge Black Angus blackburger	3	crappy	Last Available: "2016-12"
-9279	mediocre tumbling olive brandy	3	decent	Last Available: "2016-12"
+9279	mediocre olive tumbling brandy	3	decent	Last Available: "2016-12"
 9280	corrupted altered upside-down potion of spiritual gunkifying	0		Effect: "Irresistible Resolve", Effect Duration: 13, Last Available: "2016-12"
 9281	shellacked smartaleck's bad vibroknife	0		Moxie Percent: +30, Damage Reduction: 7, Last Available: "2016-12"
 9282	stanky cool crystal belt buckle	0		Moxie: +5, Stench Spell Damage: +25, Last Available: "2016-12"
@@ -9166,7 +9166,7 @@
 9294	diluted squat gray sleaze jelly	1		Effect: "Buggy Flavor", Effect Duration: 5, Last Available: "2017-01"
 9295	twisted stench jelly	1		Last Available: "2017-01"
 9296	shaking space planula	0		Free Pull, Last Available: "2017-01"
-9297	flavorless super-sized toast with hot jelly	5	decent	Last Available: "2017-01"
+9297	super-sized flavorless toast with hot jelly	5	decent	Last Available: "2017-01"
 9298	normal toast with jelly	4	good	Last Available: "2017-01"
 9299	bland bite-sized fancy toast with jelly	1	decent	Effect: "Melancholy Burden", Effect Duration: 45, Last Available: "2017-01"
 9300	normal lime green toast with sleaze jelly	3	good	Last Available: "2017-01"
@@ -9176,12 +9176,12 @@
 9304	pewter candlestick	0		Familiar Weight: +10
 9305	red nippy occult wax hand	0		Spell Damage Percent: +25, Cold Damage: +10, Last Available: "2017-01"
 9306	nippy candle of doom	0		Cold Damage: +10, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2017-01"
-9307	decent massive squat wax pancake	8	good	Last Available: "2017-01"
+9307	massive decent squat wax pancake	8	good	Last Available: "2017-01"
 9308	bouncing squat jittery executive Van der Graaf wax face	0		Meat Drop: +40, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2017-01"
 9309	hand-crafted wax booze	3	EPIC	Last Available: "2017-01"
 9310	glob of melted wax	0		Last Available: "2017-01"
 9311	powdered skewed sea jelly	1		Last Available: "2017-01"
-9312	decent diet skewed sea truffle	1	good	Last Available: "2017-01"
+9312	diet decent skewed sea truffle	1	good	Last Available: "2017-01"
 9313	twirling wobbly tarnished luggage key	0		Last Available: "2017-01"
 9314	crushed steamer trunk	0		Last Available: "2017-01"
 9315	huge lightning-fast recovered cufflinks	0		Initiative: +40, Single Equip, Last Available: "2017-01"
@@ -9208,7 +9208,7 @@
 9336	jittery eldritch tincture (depleted)	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
 9337	dry eldritch rub	0		Effect: "Salt Rockin'", Effect Duration: 25, Last Available: "2017-02"
 9338	narrow HP-35 Calculator	0		
-9339	bouncing red twirling Silver HP-35 Calculator	0		
+9339	twirling red bouncing Silver HP-35 Calculator	0		
 9340	blue Golden HP-35 Calculator	0		
 9341	maroon Platinum HP-35 Calculator	0		
 9342	Diamond HP-35 Calculator	0		
@@ -9238,30 +9238,30 @@
 9366	acceptable double entendre	4	good	Last Available: "2017-03"
 9367	perfectly mixed narrow Phlegethon	4	EPIC	Last Available: "2017-03"
 9368	aged Siberian sunrise	4	awesome	Last Available: "2017-03"
-9369	perfectly mixed strong mentholated wine	5	EPIC	Last Available: "2017-03"
-9370	watered-down aged low tide martini	2	awesome	Last Available: "2017-03"
+9369	strong perfectly mixed mentholated wine	5	EPIC	Last Available: "2017-03"
+9370	aged watered-down low tide martini	2	awesome	Last Available: "2017-03"
 9371	acceptable spirit-forward shroomtini	5	good	Last Available: "2017-03"
 9372	irresponsibly strong artisanal morning dew	8	EPIC	Last Available: "2017-03"
 9373	artisanal whiskey squeeze	3	EPIC	Last Available: "2017-03"
 9374	bad high-proof great fashioned	6	decent	Last Available: "2017-03"
 9375	aged distilled teal Gnomish sagngria	5	awesome	Last Available: "2017-03"
 9376	special lousy vodka stinger	3	decent	Effect: "Ooh, Umami!", Effect Duration: 40, Last Available: "2017-03"
-9377	weak lousy extremely slippery nipple	2	decent	Last Available: "2017-03"
-9378	watered-down delicious piscatini	2	awesome	Last Available: "2017-03"
+9377	lousy weak extremely slippery nipple	2	decent	Last Available: "2017-03"
+9378	delicious watered-down piscatini	2	awesome	Last Available: "2017-03"
 9379	acceptable Churchill	3	good	Last Available: "2017-03"
 9380	tolerable soilzerac	3	good	Last Available: "2017-03"
 9381	tolerable London frog	3	good	Last Available: "2017-03"
-9382	lousy strong nothingtini	5	decent	Last Available: "2017-03"
+9382	strong lousy nothingtini	5	decent	Last Available: "2017-03"
 9383	watered-down drinkable eighth plague	2	good	Last Available: "2017-03"
-9384	triple-distilled acceptable single entendre	7	good	Last Available: "2017-03"
-9385	lousy triple-distilled cyan reverse Tantalus	9	decent	Last Available: "2017-03"
+9384	acceptable triple-distilled single entendre	7	good	Last Available: "2017-03"
+9385	triple-distilled lousy cyan reverse Tantalus	9	decent	Last Available: "2017-03"
 9386	drinkable elemental caipiroska	4	good	Last Available: "2017-03"
 9387	drinkable Feliz Navidad	4	good	Last Available: "2017-03"
-9388	weak drinkable purple Bloody Nora	2	good	Last Available: "2017-03"
+9388	drinkable weak purple Bloody Nora	2	good	Last Available: "2017-03"
 9389	drinkable blue moreltini	3	good	Last Available: "2017-03"
-9390	drinkable weak spinning hell in a bucket	2	good	Last Available: "2017-03"
-9391	special perfectly mixed Newark	3	EPIC	Effect: "Banono", Effect Duration: 45, Last Available: "2017-03"
-9392	bad fortified R'lyeh	5	decent	Last Available: "2017-03"
+9390	weak drinkable spinning hell in a bucket	2	good	Last Available: "2017-03"
+9391	perfectly mixed special Newark	3	EPIC	Effect: "Banono", Effect Duration: 45, Last Available: "2017-03"
+9392	fortified bad R'lyeh	5	decent	Last Available: "2017-03"
 9393	practically non-alcoholic bad upside-down Gnollish sangria	1	decent	Last Available: "2017-03"
 9394	mediocre weak vodka barracuda	2	decent	Last Available: "2017-03"
 9395	irresponsibly strong perfectly mixed twirling Mysterious Island iced tea	10	EPIC	Last Available: "2017-03"
@@ -9269,7 +9269,7 @@
 9397	lousy gunner's daughter	4	decent	Last Available: "2017-03"
 9398	fancy bad upside-down dirt julep	4	decent	Effect: "White-boy Angst", Effect Duration: 50, Last Available: "2017-03"
 9399	tolerable Simepore slime	3	good	Last Available: "2017-03"
-9400	watered-down perfectly mixed blinking Phil Collins	2	EPIC	Last Available: "2017-03"
+9400	perfectly mixed watered-down blinking Phil Collins	2	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
 9402	toggle switch (Bartend)	0		Familiar Weight: +5
 9403	toggle switch (Bounce)	0		Familiar Weight: +5, Equips On: "Robortender"
@@ -9278,13 +9278,13 @@
 9406	exo-servo leg braces	0		Lasts Until Rollover, Last Available: "2017-04"
 9407	teal blurry rad cloak	0		Lasts Until Rollover, Last Available: "2017-04"
 9408	gate transceiver	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
-9409	jittery ghostly high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
+9409	ghostly jittery high-friction boots	0		Single Equip, Lasts Until Rollover, Last Available: "2017-04"
 9410	Spacegate Research	0		Last Available: "2017-04"
 9411	alien rock sample	0		Last Available: "2017-04"
 9412	alien gemstone	0		Last Available: "2017-04"
 9413	jittery geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9414	botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9415	moldy half-sized edible alien plant bit	2	crappy	Last Available: "2017-04"
+9415	half-sized moldy edible alien plant bit	2	crappy	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	tumbling alien plant sample	0		Last Available: "2017-04"
 9418	complex alien plant sample	0		Last Available: "2017-04"
@@ -9317,16 +9317,16 @@
 9445	lion tamer's banded spant shoulderpads	0		Damage Absorption: +100, Experience (familiar): +2, Single Equip, Last Available: "2017-04"
 9446	pulsating Sherlock's spant backplate of temperance	0		Sleaze Resistance: +5, Item Drop: +25, Last Available: "2017-04"
 9447	medical-grade slick spant spear	0		Moxie: +10, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2017-04"
-9448	twirling spinning purple murderbot power cell	0		Last Available: "2017-04"
+9448	twirling purple spinning murderbot power cell	0		Last Available: "2017-04"
 9449	murderbot component casing	0		Last Available: "2017-04"
-9450	blinking teal murderbot monofilament	0		Last Available: "2017-04"
+9450	teal blinking murderbot monofilament	0		Last Available: "2017-04"
 9451	enhanced triple-electrified wobbly murderbot shield unit	0		Effect: "Witch's Brood", Effect Duration: 19, Last Available: "2017-04"
 9452	shaking murderbot live wire	0		Last Available: "2017-04"
 9453	groovy murderbot mask of Tarzan of incineration	0		Moxie Percent: +10, Experience (Muscle): +3, Hot Spell Damage: +50, Avatar: "Murderbot", Last Available: "2017-04"
 9454	modified murderbot spring injector	0		Effect: "Make Meat FA$T!", Effect Duration: 52, Last Available: "2017-04"
 9455	pulsating flame-retardant mansplainer's murderbot whip	0		Monster Level: +15, Hot Resistance: +1, Last Available: "2017-04"
-9456	clever murderbot plasma rifle of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
-9457	mirror bouncing murderbot memory chip	0		Last Available: "2017-04"
+9456	clever murderbot plasma rifle of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9457	bouncing mirror murderbot memory chip	0		Last Available: "2017-04"
 9458	upside-down space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
@@ -9335,7 +9335,7 @@
 9463	spinning Space Baby children's book	0		Last Available: "2017-04"
 9464	Space Baby bawbaw	0		Last Available: "2017-04"
 9465	teal Spacegate	0		Last Available: "2017-04"
-9466	stale enchanted jumbo Aldebaran sardines	5	decent	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2017-04"
+9466	jumbo enchanted stale Aldebaran sardines	5	decent	Effect: "Meadulla Oblongota", Effect Duration: 50, Last Available: "2017-04"
 9467	extra-dry aged Centauri fish wine	5	awesome	Last Available: "2017-04"
 9468	dried jittery oxygen	1		Effect: "Fratty Flavor", Effect Duration: 45, Last Available: "2017-04"
 9469	thinker's Spacegate scientist's insignia of the cheetah	0		Mysticality: +10, Initiative: +60, Single Equip, Last Available: "2017-04"
@@ -9345,7 +9345,7 @@
 9473	jittery Spacegate Initiative tattoo unit	0		Last Available: "2017-04"
 9474	tasty small alien sandwich	2	awesome	Last Available: "2017-04"
 9475	squat glitched malware	0		Last Available: "2025-12"
-9476	double-frozen triple-Vulcanized enhanced tumbling squat Spant eggs	0		Effect: "Ass Over Teakettle", Effect Duration: 15
+9476	double-frozen triple-Vulcanized enhanced squat tumbling Spant eggs	0		Effect: "Ass Over Teakettle", Effect Duration: 15
 9477	Spacegate (open)	0		Lasts Until Rollover
 9478	huge New-You Club Membership Form	0		Free Pull, Last Available: "2017-05"
 9479	enhanced Daily Affirmation: Always be Collecting	0		Effect: "Mo' Hobo", Effect Duration: 49, Last Available: "2017-05"
@@ -9360,12 +9360,12 @@
 9488	twirling Thwaitgold bug statuette	0		
 9489	Victor's Spoils	0		
 9490	alkaline activated Threatening Missive	0		Effect: "Tiki Thoughtfulness", Effect Duration: 45
-9491	twirling bouncing Targeted Plague Vector	0		
+9491	bouncing twirling Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	squat rosewater-soaked energetic therapeutic Kremlin's Greatest Briefcase	0		Maximum MP Percent: +20, Stench Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
+9493	squat rosewater-soaked energetic therapeutic Kremlin's Greatest Briefcase	0		Maximum MP Percent: +20, Stench Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
 9494	perfectly mixed watered-down tumbling basic martini	2	EPIC	Last Available: "2017-06"
 9495	acceptable spinning improved martini	4	good	Last Available: "2017-06"
-9496	irresponsibly strong delicious splendid martini	7	awesome	Last Available: "2017-06"
+9496	delicious irresponsibly strong splendid martini	7	awesome	Last Available: "2017-06"
 9497	jittery exploding cigar	0		Last Available: "2017-06"
 9498	blinking blurry can of Minions-Be-Gone	0		Last Available: "2017-06"
 9499	tattoo gun	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	blinking Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	blue Meteorite-Ade	0		Last Available: "2017-08"
 9514	fancy decent meteoreo	3	good	Effect: "A Contender", Effect Duration: 20, Last Available: "2017-08"
-9515	watered-down artisanal teal meadeorite	2	EPIC	Last Available: "2017-08"
+9515	artisanal watered-down teal meadeorite	2	EPIC	Last Available: "2017-08"
 9516	meteoroid	0		Last Available: "2017-08"
 9517	smelly Van der Graaf meteortarboard of the sewer	0		Stench Damage: +25, Stench Spell Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2017-08"
 9518	spinning frightening strapping meteorite guard of the blizzard	0		Muscle: +5, Cold Spell Damage: +25, Spooky Damage: +5, Damage Reduction: 9, Last Available: "2017-08"
-9519	yellow Annie Oakley's meteorb of chilblains	0		Critical Hit Percent: +20, Cold Damage: +25, Last Available: "2017-08", Lantern Element: "Hot"
+9519	yellow Annie Oakley's meteorb of chilblains	0		Critical Hit Percent: +20, Cold Damage: +25, Lantern Element: "Hot", Last Available: "2017-08"
 9520	energetic asteroid belt of the cheetah	0		Maximum MP Percent: +20, Initiative: +60, Single Equip, Last Available: "2017-08"
 9521	dance instructor's stylish meteorthopedic shoes of chilblains	0		Moxie: +25, Experience Percent (Moxie): +10, Cold Damage: +25, Single Equip, Last Available: "2017-08"
 9522	wool occult baleful shooting morning star	0		Spell Damage: +25, Spell Damage Percent: +25, Cold Resistance: +1, Single Equip, Last Available: "2017-08"
@@ -9404,7 +9404,7 @@
 9532	pulsating pony: Shutterfly	0		Last Available: "2017-09"
 9533	shaking green pony: Pearjack	0		Last Available: "2017-09"
 9534	pony: Uniquity	0		Last Available: "2017-09"
-9535	bouncing huge pony: Rosey Cake	0		Last Available: "2017-09"
+9535	huge bouncing pony: Rosey Cake	0		Last Available: "2017-09"
 9536	mirror pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
 9538	dropped scrap of paper	0		
@@ -9414,9 +9414,9 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
-9545	tolerable special DUFRESNE Suds	4	good	Effect: "Limber as Mortimer", Effect Duration: 35, Last Available: "2017-09"
+9545	special tolerable DUFRESNE Suds	4	good	Effect: "Limber as Mortimer", Effect Duration: 35, Last Available: "2017-09"
 9546	avaricious mafia pinky ring of dire peril	0		Weapon Damage: +20, Meat Drop: +30, Single Equip
-9547	practically non-alcoholic drinkable flask of port	1	good	
+9547	drinkable practically non-alcoholic flask of port	1	good	
 9548	reassuring Lo Pan's contract enforcement stick	0		Spell Critical Percent: +30, Spooky Resistance: +1
 9549	normal snack-sized jittery fuchsia Hide-rox&trade; cookie	2	good	Last Available: "2017-10"
 9550	lousy triple-distilled jug of booze	8	decent	Last Available: "2017-10"
@@ -9451,7 +9451,7 @@
 9579	thick toothsome unfinished fruitcake	5	awesome	Last Available: "2017-12"
 9580	polarized liquefied and cracker	0		Effect: "Spooky Flavor", Effect Duration: 65, Last Available: "2017-12"
 9581	tolerable cyan neg grog	4	good	Last Available: "2017-12"
-9582	delicious fancy skewed half double fruitcake	3	awesome	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25, Last Available: "2017-12"
+9582	fancy delicious skewed half double fruitcake	3	awesome	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 25, Last Available: "2017-12"
 9583	delicious tiny hushed puppy	1	awesome	Last Available: "2017-12"
 9584	stale muffled muffuletta	3	decent	Last Available: "2017-12"
 9585	flavorless thick spinning shushed potatoes	5	decent	Last Available: "2017-12"
@@ -9479,14 +9479,14 @@
 9607	silent I	0		Last Available: "2017-12"
 9608	silent J	0		Last Available: "2017-12"
 9609	silent K	0		Last Available: "2017-12"
-9610	squat jittery olive silent L	0		Last Available: "2017-12"
+9610	jittery squat olive silent L	0		Last Available: "2017-12"
 9611	silent M	0		Last Available: "2017-12"
 9612	silent N	0		Last Available: "2017-12"
 9613	narrow silent O	0		Last Available: "2017-12"
 9614	upside-down silent P	0		Last Available: "2017-12"
 9615	silent Q	0		Last Available: "2017-12"
 9616	silent R	0		Last Available: "2017-12"
-9617	spinning tumbling silent S	0		Last Available: "2017-12"
+9617	tumbling spinning silent S	0		Last Available: "2017-12"
 9618	silent T	0		Last Available: "2017-12"
 9619	lime green silent U	0		Last Available: "2017-12"
 9620	silent V	0		Last Available: "2017-12"
@@ -9521,9 +9521,9 @@
 9649	tasty huge nega-mushroom	4	awesome	Last Available: "2017-12"
 9650	delicious nega-mushroom wine	4	awesome	Last Available: "2017-12"
 9651	super-frozen tarnished cold-filtered Cheer-Up soda	0		Effect: "Quadrilled", Effect Duration: 43, Last Available: "2017-12"
-9652	massive spoiled mime army rations	7	crappy	Last Available: "2017-12"
+9652	spoiled massive mime army rations	7	crappy	Last Available: "2017-12"
 9653	tolerable mime army wine	3	good	Last Available: "2017-12"
-9654	dehydrated blinking upside-down mime army superserum	1		Last Available: "2017-12"
+9654	dehydrated upside-down blinking mime army superserum	1		Last Available: "2017-12"
 9655	quantum pickled mime army camouflage kit	0		Effect: "Techno Bliss", Effect Duration: 47, Last Available: "2017-12"
 9656	spinning spinning mansplainer's brainy miming beret	0		Mysticality: +5, Monster Level: +15, Last Available: "2017-12"
 9657	squat purple greedy horrifying miming shirt	0		Spooky Damage: +25, Meat Drop: +20, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	denatured warmed digital honeypot	0		Effect: "You Know When to Walk Away", Effect Duration: 24, Last Available: "2025-12"
 9666	jittery mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	purple squat careful mime army insignia (infantry)	0		Monster Level: -10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	spinning mime army insignia (intelligence) of the cheetah	0		Initiative: +60, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	tumbling hardy mime army insignia (espionage)	0		Maximum HP: +50, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	purple squat careful mime army insignia (infantry)	0		Monster Level: -10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	spinning mime army insignia (intelligence) of the cheetah	0		Initiative: +60, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	tumbling hardy mime army insignia (espionage)	0		Maximum HP: +50, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9552,7 +9552,7 @@
 9680	fireproof skip lid	0		Familiar Weight: +5
 9681	stale teal extra-toasted half sandwich	4	decent	Last Available: "2018-12"
 9682	mediocre mulled hobo wine	3	decent	Last Available: "2018-12"
-9683	tumbling narrow burning newspaper	0		Last Available: "2018-12"
+9683	narrow tumbling burning newspaper	0		Last Available: "2018-12"
 9684	scorching deadly dance instructor's burning paper hat	0		Experience Percent (Moxie): +10, Weapon Damage: +5, Hot Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
 9685	upside-down knitted ruddy burning cape	0		Maximum HP Percent: +40, Cold Resistance: +3, Item Drop: +5, Lasts Until Rollover, Last Available: "2018-12"
 9686	Lo Pan's occult smooth burning paper slippers	0		Moxie: +15, Spell Damage Percent: +25, Spell Critical Percent: +30, Single Equip, Lasts Until Rollover, Last Available: "2018-12"
@@ -9576,7 +9576,7 @@
 9704	dehydrated jittery teal spinning excitement pill	1		
 9705	dehydrated vitamin G pill	1		
 9706	boiled lucky-ish pill	1		Effect: "Piratey Flavor", Effect Duration: 30
-9707	distilled upside-down huge fuchsia dieting pill	1		Effect: "Crusty Head", Effect Duration: 20
+9707	distilled huge fuchsia upside-down dieting pill	1		Effect: "Crusty Head", Effect Duration: 20
 9712	spinning Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
@@ -9592,11 +9592,11 @@
 9724	mansplainer's extremely unsafe psychic's crystal ball	0		Weapon Damage Percent: +100, Monster Level: +15, Last Available: "2018-02"
 9725	reassuring medical-grade psychic's pslacks	0		Spooky Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-02"
 9726	deadly psychic's amulet of Leguizamo	0		Weapon Damage: +5, Monster Level: +20, Last Available: "2018-02"
-9727	thick bland ghostly heart-shaped candy whetstone	5	decent	Last Available: "2018-02"
-9728	bland immense blurry Swedish massage fish	9	decent	Last Available: "2018-02"
+9727	bland thick ghostly heart-shaped candy whetstone	5	decent	Last Available: "2018-02"
+9728	immense bland blurry Swedish massage fish	9	decent	Last Available: "2018-02"
 9729	hand-crafted blurry tumbling Third Base	3	EPIC	Last Available: "2018-02"
-9730	aged boozy Bustle Hustler	5	awesome	Last Available: "2018-02"
-9731	Vulcanized wobbly narrow Fabiotion	0		Effect: "Serenity", Effect Duration: 23, Last Available: "2018-02"
+9730	boozy aged Bustle Hustler	5	awesome	Last Available: "2018-02"
+9731	Vulcanized narrow wobbly Fabiotion	0		Effect: "Serenity", Effect Duration: 23, Last Available: "2018-02"
 9732	dry Bettie page	0		Effect: "Down With Chow", Effect Duration: 68, Last Available: "2018-02"
 9733	polarized blurry tonic o' Banderas	0		Effect: "Sweet, Nuts", Effect Duration: 30, Last Available: "2018-02"
 9734	frozen wobbly heather graham cracker	0		Effect: "Memory of Attractiveness", Effect Duration: 67, Last Available: "2018-02"
@@ -9631,7 +9631,7 @@
 9763	Bluzzard	0		Last Available: "2018-03"
 9764	jittery Faux	0		Last Available: "2018-03"
 9765	twirling fuchsia Sledgehamster	0		Last Available: "2018-03"
-9766	wobbly jittery Pimpsqueak	0		Last Available: "2018-03"
+9766	jittery wobbly Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
 9768	Dressage	0		Last Available: "2018-03"
 9769	squat Sequestrian	0		Last Available: "2018-03"
@@ -9695,11 +9695,11 @@
 9827	bouncing rocket	0		
 9828	altered magnificent oyster egg	1		
 9829	pickled wobbly brilliant oyster egg	1		
-9830	diluted lime green tumbling glistening oyster egg	1		
+9830	diluted tumbling lime green glistening oyster egg	1		
 9831	boiled ghostly scintillating oyster egg	1		Effect: "Dreadful Sheen", Effect Duration: 40
 9832	distilled mirror pearlescent oyster egg	1		
 9833	pickled squat lustrous oyster egg	1		
-9834	vaporized mirror teal upside-down gleaming oyster egg	1		Effect: "Fiery Spirit", Effect Duration: 35
+9834	vaporized teal mirror upside-down gleaming oyster egg	1		Effect: "Fiery Spirit", Effect Duration: 35
 9835	FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
 9836	FantasyRealm guest pass	0		Last Available: "2018-04"
 9837	asbestos-lined frosty Tesla FantasyRealm G. E. M.	0		Cold Spell Damage: +10, Hot Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2018-04"
@@ -9727,8 +9727,8 @@
 9859	upside-down LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	snack-sized moldy FantasyRealm turkey leg	2	crappy	Last Available: "2018-04"
-9863	weak perfectly mixed FantasyRealm mead	2	EPIC	Last Available: "2018-04"
+9862	moldy snack-sized FantasyRealm turkey leg	2	crappy	Last Available: "2018-04"
+9863	perfectly mixed weak FantasyRealm mead	2	EPIC	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	narrow arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9736,16 +9736,16 @@
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	decent blurry druidic s'more	3	good	Last Available: "2018-04"
 9870	twisted sachet of powder	1		Last Available: "2018-04"
-9871	aged irresponsibly strong spinning mourning wine	6	awesome	Last Available: "2018-04"
+9871	irresponsibly strong aged spinning mourning wine	6	awesome	Last Available: "2018-04"
 9872	green sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	upside-down map to the Towering Mountains	0		Last Available: "2018-04"
 9874	map to the Mystic Wood	0		Last Available: "2018-04"
-9875	green bouncing jittery map to the Putrid Swamp	0		Last Available: "2018-04"
+9875	jittery bouncing green map to the Putrid Swamp	0		Last Available: "2018-04"
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	flavorless denastified haunch	3	decent	Last Available: "2018-04"
 9879	tolerable bad rum and good cola	3	good	Last Available: "2018-04"
-9880	triple-chilled quadruple-moist narrow mirror Potion of Heroism	0		Effect: "Wintry Breath", Effect Duration: 47, Last Available: "2018-04"
+9880	triple-chilled quadruple-moist mirror narrow Potion of Heroism	0		Effect: "Wintry Breath", Effect Duration: 47, Last Available: "2018-04"
 9881	flame-retardant foul-smelling Temple Grandin's leggings of the Spider Queen	0		Familiar Weight: +7, Stench Damage: +10, Hot Resistance: +1, Last Available: "2018-04"
 9882	grievous slick Master Thief's utility belt of the cheetah	0		Moxie: +10, Weapon Damage Percent: +50, Initiative: +60, Single Equip, Last Available: "2018-04"
 9883	tumbling Socratic Duke Vampire's regal cloak of the storm of terror	0		Experience (Mysticality): +1, Maximum MP Percent: +40, Spooky Spell Damage: +10, Last Available: "2018-04"
@@ -9764,15 +9764,15 @@
 9896	dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	olive notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	mediocre cyan two meat muck	4	decent	
-9899	half-sized yummy chocolate Ogre Chieftain	2	awesome	
+9899	yummy half-sized chocolate Ogre Chieftain	2	awesome	
 9900	decent chocolate &quot;Phoenix&quot;	3	good	
-9901	snack-sized bland huge chocolate Spider Queen	2	decent	
+9901	bland snack-sized huge chocolate Spider Queen	2	decent	
 9902	drinkable ghostly hipster cocktail	4	good	
-9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
-9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
-9905	God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	twirling God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
-9907	blue upside-down God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
+9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
+9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
+9905	God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
+9906	twirling God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
+9907	upside-down blue God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
 9908	gray Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	pulsating G	0		
 9910	Garland of Greatness	0		
@@ -9821,7 +9821,7 @@
 9953	moldy PB&J with the crusts cut off	3	crappy	Last Available: "2018-09"
 9954	purple padded forbidden dorky glasses	0		Spell Damage Percent: +50, Damage Absorption: +20, Single Equip, Last Available: "2018-09"
 9955	maroon shellacked banded ponytail clip	0		Damage Absorption: +100, Damage Reduction: 7, Last Available: "2018-09"
-9956	maroon spinning banded paint palette	0		Damage Absorption: +100, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
+9956	maroon spinning banded paint palette	0		Damage Absorption: +100, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
 9957	ghostly unremarkable duffel bag	0		Last Available: "2018-09"
 9958	diluted blurry purple blinking skewed Purple Beast energy drink	1		Effect: "Thaumodynamic", Effect Duration: 35, Last Available: "2018-09"
 9959	Oprah's cosmetic football	0		Maximum MP Percent: +50, Last Available: "2018-09"
@@ -9833,7 +9833,7 @@
 9965	twirling surprisingly capacious handbag	0		Last Available: "2018-09"
 9966	triple-distilled lousy lime green everfull glass	9		Last Available: "2018-09"
 9967	van key	0		Last Available: "2018-09"
-9968	huge fuchsia jam band bootleg	0		Last Available: "2018-09"
+9968	fuchsia huge jam band bootleg	0		Last Available: "2018-09"
 9969	blue beefcake's weightlifter's denim jacket	0		Muscle: 40, Last Available: "2018-09"
 9970	olive chaotic energetic ratty knitted cap	0		Maximum MP Percent: +20, Spell Critical Percent: +10, Last Available: "2018-09"
 9972	MacGyver's intimidating chainsaw of the brazier	0		Maximum MP: +100, Hot Spell Damage: +25, Lasts Until Rollover, Last Available: "2018-09"
@@ -9845,13 +9845,13 @@
 9978	blue Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	acceptable yellow TRIO cup of beer	3	good	Last Available: "2018-09"
 9980	snack-sized moldy mirror shaking party platter for one	2	crappy	Last Available: "2018-09"
-9981	denatured narrow bouncing Party-in-a-Can&trade;	1		Last Available: "2018-09"
+9981	denatured bouncing narrow Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	scorching Jack Frost's party crasher	0		Cold Spell Damage: +50, Hot Damage: +25, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9983	scorching Jack Frost's party crasher	0		Cold Spell Damage: +50, Hot Damage: +25, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
 9984	pulsating Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	cyan Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	party mouse hat	0		Familiar Weight: +5
-9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
+9987	latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
 9988	narrow latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	green voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	dog trainer's &quot;I Voted!&quot; sticker	0		Experience (familiar): +1, Lasts Until Rollover, Last Available: "2018-11"
@@ -9873,18 +9873,18 @@
 10007	foul-smelling sharpshooter's mutant arm of the blizzard	0		Critical Hit Percent: +10, Cold Spell Damage: +25, Stench Damage: +10, Last Available: "2018-11"
 10008	Tesla brainy mutant legs of the blizzard	0		Mysticality: +5, Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2018-11"
 10009	padded occult Rosewater's mutant crown	0		Mysticality Percent: +30, Spell Damage Percent: +25, Damage Absorption: +20, Last Available: "2018-11"
-10010	diet bland ghostly ectoplasm	1	decent	Last Available: "2018-11"
-10011	huge adequate green	9	good	Last Available: "2018-11"
+10010	bland diet ghostly ectoplasm	1	decent	Last Available: "2018-11"
+10011	adequate huge green	9	good	Last Available: "2018-11"
 10012	smooth bottle of vodka	3	awesome	Last Available: "2018-11"
 10013	stale special pizza	4	decent	Effect: "Thick, Sick", Effect Duration: 45, Last Available: "2018-11"
 10014	acceptable red martini	4	good	Last Available: "2018-11"
 10015	snack-sized flavorless cherry pie	2	decent	Last Available: "2018-11"
 10016	drinkable eggnog	4	good	Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	normal small blurry Hell ramen	2	good	Last Available: "2018-11"
+10018	small normal blurry Hell ramen	2	good	Last Available: "2018-11"
 10019	artisanal gimlet	3	EPIC	Last Available: "2018-11"
 10020	artisanal maroon twice-haunted screwdriver	3	EPIC	Last Available: "2018-11"
-10021	rotten thick candy cane	5	crappy	Last Available: "2018-12"
+10021	thick rotten candy cane	5	crappy	Last Available: "2018-12"
 10022	artisanal blurry runny fermented egg	3	EPIC	Last Available: "2018-12"
 10023	huge normal oldcake	7	good	Last Available: "2018-12"
 10024	normal traditional Crimbo cookie	3	good	Last Available: "2023-06"
@@ -9908,7 +9908,7 @@
 10042	dam of the pedagogue	0		Experience: +3, Damage Reduction: 9, Last Available: "2018-12"
 10043	perfectly mixed shaking beavermouth	3	EPIC	Last Available: "2018-12"
 10044	bad beaver punch (papaya)	4	decent	Last Available: "2018-12"
-10045	tolerable spirit-forward beaver punch (peach)	5	good	Last Available: "2018-12"
+10045	spirit-forward tolerable beaver punch (peach)	5	good	Last Available: "2018-12"
 10046	acceptable beaver punch (cherry)	3	good	Last Available: "2018-12"
 10047	scorching ruddy Canadian lantern	0		Maximum HP Percent: +40, Hot Damage: +25, Last Available: "2018-12"
 10048	muskox-skin cap of the ox	0		Muscle: +20, Last Available: "2018-12"
@@ -9929,11 +9929,11 @@
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	spinning Toyleporter	0		Last Available: "2018-12"
-10066	drinkable watered-down purple beer	2	good	Last Available: "2018-12"
-10067	normal immense yule gruel	10	good	Last Available: "2018-12"
+10066	watered-down drinkable purple beer	2	good	Last Available: "2018-12"
+10067	immense normal yule gruel	10	good	Last Available: "2018-12"
 10068	artisanal distilled hot watered rum	5	EPIC	Last Available: "2018-12"
 10069	watered-down aged purple wobbly bottle of Crimbognac	2	awesome	Last Available: "2018-12"
-10070	normal bouncing pulsating Crimboysters Rockefeller	3	good	Last Available: "2018-12"
+10070	normal pulsating bouncing Crimboysters Rockefeller	3	good	Last Available: "2018-12"
 10071	compressed Crimbeau de toilette	1		Last Available: "2018-12"
 10072	tumbling Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9961,20 +9961,20 @@
 10095	squat wool sizzling marble mariachi hat	0		Hot Damage: +10, Cold Resistance: +1, Last Available: "2019-12"
 10096	modified skewed marble molecules	1		Last Available: "2019-12"
 10097	concentrated warmed fuchsia ghostly Mallomarbles	0		Effect: "Remaining Alive", Effect Duration: 59
-10098	bouncing studded punching bag of vim and vigor	0		Damage Absorption: +80, Maximum HP Percent: +50, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10099	gray mansplainer's veiny pith helmet	0		Maximum HP: +10, Monster Level: +15, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10100	greedy rock-hard poncho	0		Damage Reduction: 5, Meat Drop: +20, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10101	blurry knitted Rosewater's pendant	0		Mysticality Percent: +30, Cold Resistance: +3, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10102	red family-friendly palazzos of the glutton	0		Sleaze Resistance: +1, Food Drop: +100, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
-10103	scorching grievous pseudoaccordion	0		Weapon Damage Percent: +50, Hot Damage: +25, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10098	bouncing studded punching bag of vim and vigor	0		Damage Absorption: +80, Maximum HP Percent: +50, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10099	gray mansplainer's veiny pith helmet	0		Maximum HP: +10, Monster Level: +15, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10100	greedy rock-hard poncho	0		Damage Reduction: 5, Meat Drop: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10101	blurry knitted Rosewater's pendant	0		Mysticality Percent: +30, Cold Resistance: +3, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10102	red family-friendly palazzos of the glutton	0		Sleaze Resistance: +1, Food Drop: +100, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10103	scorching grievous pseudoaccordion	0		Weapon Damage Percent: +50, Hot Damage: +25, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
 10104	powdered gray twirling pieces	1		Last Available: "2020-12"
 10105	warmed electrified huge Para-Pop	0		Effect: "Disdain of the War Snapper", Effect Duration: 58
-10106	stiffened deadly terra cotta truss	0		Weapon Damage: +5, Damage Reduction: 1, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10107	Tesla clever terra cotta trousers	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10108	smelly beefcake's terra cotta tongs	0		Muscle: +25, Stench Spell Damage: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10109	shaking grievous terra cotta train of incineration	0		Weapon Damage Percent: +50, Hot Spell Damage: +50, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10110	foul-smelling Da Vinci's terra cotta tie tack	0		Experience (Mysticality): +5, Stench Damage: +10, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
-10111	shaking hale terra cotta tambourine of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +20, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10106	stiffened deadly terra cotta truss	0		Weapon Damage: +5, Damage Reduction: 1, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10107	Tesla clever terra cotta trousers	0		Maximum MP: +20, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10108	smelly beefcake's terra cotta tongs	0		Muscle: +25, Stench Spell Damage: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10109	shaking grievous terra cotta train of incineration	0		Weapon Damage Percent: +50, Hot Spell Damage: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10110	foul-smelling Da Vinci's terra cotta tie tack	0		Experience (Mysticality): +5, Stench Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10111	shaking hale terra cotta tambourine of the dark arts	0		Spell Damage Percent: +100, Maximum HP: +20, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
 10112	modified blurry terra cotta tidbits	1		Last Available: "2020-12"
 10113	anodized super-corrupted bouncing bouncing terra panna cotta	0		Effect: "Mathematically Precise", Effect Duration: 48
 10114	yellow MacGyver's occult velour voulge	0		Spell Damage Percent: +25, Maximum MP: +100, Last Available: "2021-12"
@@ -9993,20 +9993,20 @@
 10127	deadly glass serape of courage	0		Weapon Damage: +5, Spooky Resistance: +3, Last Available: "2021-12"
 10128	pickled pulsating glass shards	1		Last Available: "2021-12"
 10129	adjusted ghostly hard candy	0		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 69
-10130	Jeselnik's loofah lumberjack's hat of the brute	0		Muscle Percent: +30, Sleaze Damage: +25, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
-10131	spinning wobbly greasy stylish loofah lei	0		Moxie: +25, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
-10132	Jeselnik's rosy-cheeked loofah lederhosen	0		Maximum HP Percent: +30, Sleaze Damage: +25, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
-10133	lime green lard-coated greasy loofah ladle	0		Sleaze Spell Damage: 35, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
-10134	stanky loofah legwarmers of Flo-Jo	0		Stench Spell Damage: +25, Initiative: +100, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
-10135	tumbling ghostly vibrating loofah lavalier of the scaredy-cat	0		Maximum MP Percent: +10, Monster Level: -15, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
+10130	Jeselnik's loofah lumberjack's hat of the brute	0		Muscle Percent: +30, Sleaze Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
+10131	spinning wobbly greasy stylish loofah lei	0		Moxie: +25, Sleaze Spell Damage: +10, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
+10132	Jeselnik's rosy-cheeked loofah lederhosen	0		Maximum HP Percent: +30, Sleaze Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
+10133	lime green lard-coated greasy loofah ladle	0		Sleaze Spell Damage: 35, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
+10134	stanky loofah legwarmers of Flo-Jo	0		Stench Spell Damage: +25, Initiative: +100, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
+10135	tumbling ghostly vibrating loofah lavalier of the scaredy-cat	0		Maximum MP Percent: +10, Monster Level: -15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
 10136	vaporized tumbling loofah lumps	1		Last Available: "2022-12"
 10137	flattened altered chocolate-covered loofah	0		Effect: "Natural 20", Effect Duration: 27
-10138	flagstone flag of dire peril of Leguizamo	0		Weapon Damage: +20, Monster Level: +20, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
-10139	upside-down dance instructor's savvy flagstone flail	0		Mysticality Percent: +20, Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
-10140	shaking teal wool flagstone flip-flops of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
-10141	energetic educational flagstone fez	0		Experience: +1, Maximum MP Percent: +20, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
-10142	Herculean educational flagstone fleece	0		Experience: +1, Experience (Muscle): +1, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
-10143	blinking therapeutic experienced flagstone fringe	0		Experience: +2, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10138	flagstone flag of dire peril of Leguizamo	0		Weapon Damage: +20, Monster Level: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
+10139	upside-down dance instructor's savvy flagstone flail	0		Mysticality Percent: +20, Experience Percent (Moxie): +10, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
+10140	shaking teal wool flagstone flip-flops of incineration	0		Hot Spell Damage: +50, Cold Resistance: +1, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
+10141	energetic educational flagstone fez	0		Experience: +1, Maximum MP Percent: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
+10142	Herculean educational flagstone fleece	0		Experience: +1, Experience (Muscle): +1, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
+10143	blinking therapeutic experienced flagstone fringe	0		Experience: +2, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
 10144	dried gray spinning flagstone flagments	1		Last Available: "2022-12"
 10145	deionized Flag by the Foot&trade;	0		Effect: "Elemental Mastery", Effect Duration: 62
 10146	tumbling elf sleeper agent	0		Free Pull, Last Available: "2019-12"
@@ -10018,7 +10018,7 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	yellow pulsating elf army poncho of horror	0		Spooky Spell Damage: +25, Lasts Until Rollover, Last Available: "2019-12"
-10155	snack-sized special bland elf army field rations	2	decent	Effect: "Slimed Stomach", Effect Duration: 40, Last Available: "2019-12"
+10155	special bland snack-sized elf army field rations	2	decent	Effect: "Slimed Stomach", Effect Duration: 40, Last Available: "2019-12"
 10156	pulsating gingernade	0		Last Available: "2019-12"
 10157	blue toasty wizardly discarded bowtie	0		Mysticality: +25, Hot Damage: +5, Lasts Until Rollover, Last Available: "2019-12"
 10158	hand-crafted blinking purple martiny	3	EPIC	Last Available: "2019-12"
@@ -10029,7 +10029,7 @@
 10163	nitrogenated deionized narrow government-issued candy	0		Effect: "Riboflavin'", Effect Duration: 14
 10164	dry ionized Pneumo bar	0		Effect: "Bread-Lined", Effect Duration: 37
 10165	twirling mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	Fonzie's strapping Lil' Doctor&trade; bag	0		Muscle: +5, Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
+10166	Fonzie's strapping Lil' Doctor&trade; bag	0		Muscle: +5, Experience (Moxie): +1, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
 10168	narrow blood bag	0		
 10169	normal miniature bloodstick	2	good	
 10170	boozy acceptable squat bottle of Sanguiovese	5	good	
@@ -10037,9 +10037,9 @@
 10172	aged narrow mulled blood	4	awesome	
 10173	moldy blood snowcone	3	crappy	
 10174	weak acceptable Red Russian	2	good	
-10175	rotten bite-sized blood roll-up	1	crappy	
-10176	irresponsibly strong bad bottle of blood	10	decent	
-10177	decent squat lime green squat blood-soaked sponge cake	3	good	
+10175	bite-sized rotten blood roll-up	1	crappy	
+10176	bad irresponsibly strong bottle of blood	10	decent	
+10177	decent squat squat lime green blood-soaked sponge cake	3	good	
 10178	mediocre vampagne	3	decent	
 10179	spoiled small tumbling plain snowcone	2	crappy	
 10180	Booke of Vampyric Knowledge	0		
@@ -10065,7 +10065,7 @@
 10200	melty plastic grenade	0		Last Available: "2019-04"
 10201	drinkable bottle of dark rhum	3	good	Last Available: "2019-04"
 10202	enchanted acceptable bottle of extra-dark rhum	3	good	Effect: "Ogred and Oublietted", Effect Duration: 35, Last Available: "2019-04"
-10203	fancy boozy smooth bottle of super-extra-dark rhum	5	awesome	Effect: "Certainty", Effect Duration: 30, Last Available: "2019-04"
+10203	smooth fancy boozy bottle of super-extra-dark rhum	5	awesome	Effect: "Certainty", Effect Duration: 30, Last Available: "2019-04"
 10204	vacuum-sealed pickled squat pirate shaving cream	0		Effect: "The Power of Negative Thinking", Effect Duration: 55, Last Available: "2019-04"
 10205	family-friendly rosewater-soaked conquistador's breastplate	0		Stench Resistance: +3, Sleaze Resistance: +1, Last Available: "2019-04"
 10206	blue scandalous pirate pantaloons of the storm	0		Maximum MP Percent: +40, Sleaze Damage: +5, Last Available: "2019-04"
@@ -10075,12 +10075,12 @@
 10210	family-friendly frosty pirate radio ring	0		Cold Spell Damage: +10, Sleaze Resistance: +1, Single Equip, Last Available: "2019-04"
 10211	purple Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	bland twirling pineapple slab	4	decent	Last Available: "2019-04"
-10213	tasty half-sized hibiscus petal	2	awesome	Last Available: "2019-04"
+10213	half-sized tasty hibiscus petal	2	awesome	Last Available: "2019-04"
 10214	activated lime green huge mint leaf	0		Effect: "items.enh", Effect Duration: 52, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	twisted pulsating twirling ice molecule	1		Last Available: "2019-04"
 10217	Red Roger's reliquary	0		Last Available: "2019-04"
-10218	cyan upside-down Red Roger's right hand	0		Last Available: "2019-04"
+10218	upside-down cyan Red Roger's right hand	0		Last Available: "2019-04"
 10219	jittery Red Roger's left hand	0		Last Available: "2019-04"
 10220	Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
 10221	squat Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
@@ -10089,22 +10089,22 @@
 10224	Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	twirling PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	blue padded plush sea serpent	0		Damage Absorption: +20, Monster Level: -100, Single Equip, Last Available: "2019-04"
-10227	fancy spoiled snack-sized pirate fork	2		Effect: "Violent Night", Effect Duration: 10, Last Available: "2019-04"
+10227	spoiled fancy snack-sized pirate fork	2		Effect: "Violent Night", Effect Duration: 10, Last Available: "2019-04"
 10228	narrow Scurvy and Sobriety Prevention	0		Skill: "Prevent Scurvy and Sobriety", Last Available: "2019-04"
 10229	ring	0		Single Equip, Last Available: "2019-04"
 10230	tumbling electrified supercool piratical blunderbuss	0		Moxie Percent: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-04"
 10231	greasy forbidden PirateRealm party hat of Gandalf	0		Spell Damage Percent: +50, Spell Critical Percent: +20, Sleaze Spell Damage: +10, Last Available: "2019-04"
-10232	watered-down lousy Island Landslide	2	decent	Last Available: "2019-04"
-10233	watered-down lousy huge Island Thunderstorm	2	decent	Last Available: "2019-04"
-10234	lousy special mirror Island Hurricane	3	decent	Effect: "Grrrrrrreat!", Effect Duration: 45, Last Available: "2019-04"
+10232	lousy watered-down Island Landslide	2	decent	Last Available: "2019-04"
+10233	lousy watered-down huge Island Thunderstorm	2	decent	Last Available: "2019-04"
+10234	special lousy mirror Island Hurricane	3	decent	Effect: "Grrrrrrreat!", Effect Duration: 45, Last Available: "2019-04"
 10235	mediocre Skull Punch	4	decent	Last Available: "2019-04"
 10236	mediocre Electric Punch	4	decent	Last Available: "2019-04"
 10237	bad purple Smuggler's Punch	3	decent	Last Available: "2019-04"
-10238	watered-down hand-crafted teal twirling Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
+10238	hand-crafted watered-down twirling teal Scorpion Bowl	2	super ultra mega EPIC	Last Available: "2019-04"
 10239	high-proof aged Turtle Bowl	9	awesome	Last Available: "2019-04"
 10240	special practically non-alcoholic tolerable Cobra Bowl	1	good	Effect: "Mistified", Effect Duration: 35, Last Available: "2019-04"
 10241	red vampyric cloake pattern	0		Free Pull
-10242	lard-coated resourceful stylish vampyric cloake of the overflowing toilet of the businessman	0		Moxie: +25, Maximum MP: +50, Stench Spell Damage: +50, Sleaze Spell Damage: +25, Meat Drop: +50, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
+10242	lard-coated resourceful stylish vampyric cloake of the overflowing toilet of the businessman	0		Moxie: +25, Maximum MP: +50, Stench Spell Damage: +50, Sleaze Spell Damage: +25, Meat Drop: +50, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
 10243	skewed plastic pirate hat	0		Familiar Weight: +5
 10244	flattened ionized bouncing one piece of bubble gum	0		Effect: "A Taste of Rainbow", Effect Duration: 48
 10245	cyan arcanoferric housing	0		
@@ -10113,15 +10113,15 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	shaking Fourth of May Cosplay Saber kit	0		Free Pull
-10251	olive sharpshooter's Fourth of May Cosplay Saber of dire peril of the storm	0		Weapon Damage: +20, Maximum MP Percent: +40, Critical Hit Percent: +10, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
+10251	olive sharpshooter's Fourth of May Cosplay Saber of dire peril of the storm	0		Weapon Damage: +20, Maximum MP Percent: +40, Critical Hit Percent: +10, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	lightning-fast executive Sherlock's hardy hardened fortified grievous smartaleck's brawny hewn moon-rune spoon of wisdom of the boozehound	0		Mysticality: +15, Muscle Percent: +20, Moxie Percent: +30, Weapon Damage Percent: +50, Damage Absorption: +60, Damage Reduction: 3, Maximum HP: +50, Item Drop: +25, Meat Drop: +40, Booze Drop: +100, Initiative: +40, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
+10254	lightning-fast executive Sherlock's hardy hardened fortified grievous smartaleck's brawny hewn moon-rune spoon of wisdom of the boozehound	0		Mysticality: +15, Muscle Percent: +20, Moxie Percent: +30, Weapon Damage Percent: +50, Damage Absorption: +60, Damage Reduction: 3, Maximum HP: +50, Item Drop: +25, Meat Drop: +40, Booze Drop: +100, Initiative: +40, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
 10255	blurry cartoon harpoon	0		Last Available: "2019-06"
 10256	blinking skewed rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	green greasy scorching wholesome Beach Comb	0		Maximum HP Percent: +10, Hot Damage: +25, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
-10259	twirling jittery grain of sand	0		Last Available: "2019-07"
+10258	green greasy scorching wholesome Beach Comb	0		Maximum HP Percent: +10, Hot Damage: +25, Sleaze Spell Damage: +10, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10259	jittery twirling grain of sand	0		Last Available: "2019-07"
 10260	small pile of sand	0		Last Available: "2019-07"
 10261	pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
@@ -10129,8 +10129,8 @@
 10264	spinning hourglass	0		Last Available: "2019-07"
 10265	etched hourglass	0		Last Available: "2019-07"
 10266	concentrated super-ionized ionized magenta seashell	0		Effect: "Healthy Green Glow", Effect Duration: 26, Last Available: "2019-07"
-10267	super-pressed energized concentrated fuchsia blinking cyan seashell	0		Effect: "Chalk Outline", Effect Duration: 38, Last Available: "2019-07"
-10268	chilled quadruple-Vulcanized jittery red twirling gray seashell	0		Effect: "Mushroom Moxiousness", Effect Duration: 53, Last Available: "2019-07"
+10267	super-pressed energized concentrated blinking fuchsia cyan seashell	0		Effect: "Chalk Outline", Effect Duration: 38, Last Available: "2019-07"
+10268	chilled quadruple-Vulcanized red twirling jittery gray seashell	0		Effect: "Mushroom Moxiousness", Effect Duration: 53, Last Available: "2019-07"
 10269	denatured aerosolized seashell	0		Effect: "Bonelording", Effect Duration: 59, Last Available: "2019-07"
 10270	triple-aerosolized yellow seashell	0		Effect: "Fancy Feasted", Effect Duration: 45, Last Available: "2019-07"
 10271	bunch of sea grapes	0		Last Available: "2019-07"
@@ -10167,7 +10167,7 @@
 10302	prompt ruddy Herculean whittled walking stick of chilblains	0		Experience (Muscle): +1, Maximum HP Percent: +40, Cold Damage: +25, Adventures: +3, Last Available: "2019-08"
 10303	flavorless maroon campfire hot dog	4	decent	Last Available: "2019-08"
 10304	rotten campfire baked potato	3	crappy	Last Available: "2019-08"
-10305	flavorless massive blinking campfire s'more	6	decent	Last Available: "2019-08"
+10305	massive flavorless blinking campfire s'more	6	decent	Last Available: "2019-08"
 10306	decent campfire beans	4	good	Last Available: "2019-08"
 10307	thick moldy campfire stew	5	crappy	Last Available: "2019-08"
 10308	mirror campfire coffee	1	decent	Last Available: "2019-08"
@@ -10194,7 +10194,7 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bu&ntilde;uelos Jaliscos	3	decent	Last Available: "2019-12"
-10338	tiny adequate fancy cyan flan del mar	1	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40, Last Available: "2019-12"
+10338	fancy adequate tiny cyan flan del mar	1	good	Effect: "Go Get 'Em, Tiger!", Effect Duration: 40, Last Available: "2019-12"
 10339	spoiled Baja sopapilla	3	crappy	Last Available: "2019-12"
 10340	toasty plastic Mer-kin baker	0		Hot Damage: +5, Last Available: "2019-12"
 10341	avaricious plastic sea elf	0		Meat Drop: +30, Last Available: "2019-12"
@@ -10213,7 +10213,7 @@
 10354	altered vial of humanoid growth hormone	1		Last Available: "2019-12"
 10355	diluted twirling a bug's lymph	1		Last Available: "2019-12"
 10356	moist nitrogenated twirling organic potpourri	0		Effect: "Salty Mouth", Effect Duration: 15, Last Available: "2019-12"
-10357	special boozy acceptable boot flask	5	good	Effect: "Human-Hobo Hybrid", Effect Duration: 10, Last Available: "2019-12"
+10357	special acceptable boozy boot flask	5	good	Effect: "Human-Hobo Hybrid", Effect Duration: 10, Last Available: "2019-12"
 10358	chilled infernal snowball	0		Effect: "Deeply Ironic", Effect Duration: 51, Last Available: "2019-12"
 10359	upside-down madness	0		Last Available: "2019-12"
 10360	compressed fish sauce	1		Last Available: "2019-12"
@@ -10246,10 +10246,10 @@
 10387	intact anemone spike	0		Last Available: "2019-12"
 10388	pulsating lion tamer's anemoney clip	0		Experience (familiar): +2, Single Equip, Last Available: "2019-12"
 10389	mirror runny icing	0		Last Available: "2019-12"
-10390	mixed gray mirror super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
+10390	mixed mirror gray super-sweet fish goo (spoiled)	1		Last Available: "2019-12"
 10391	perfumed ribald beefy icing poncho	0		Muscle: +10, Sleaze Damage: +10, Stench Resistance: +5, Last Available: "2019-12"
 10392	Mer-kin cookiestove	0		Last Available: "2019-12"
-10393	enhanced double-enhanced green upside-down glob of salty molasses	0		Effect: "Cold Hands", Effect Duration: 14, Last Available: "2019-12"
+10393	enhanced double-enhanced upside-down green glob of salty molasses	0		Effect: "Cold Hands", Effect Duration: 14, Last Available: "2019-12"
 10394	energetic Mer-kin rollpin of doom	0		Maximum MP Percent: +20, Spooky Spell Damage: +50, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	blue tinsel fin	0		Familiar Weight: +5
@@ -10282,17 +10282,17 @@
 10423	narrow shellacked kelp-holly drape of Leguizamo	0		Damage Reduction: 7, Monster Level: +20, Last Available: "2019-12"
 10424	stanky sizzling Staff of the Peppermint Twist of James Dean of dire peril	0		Experience (Moxie): +3, Weapon Damage: +20, Hot Damage: +10, Stench Spell Damage: +25, Last Available: "2019-12"
 10425	toothsome blinking tempura and bean	3	awesome	Last Available: "2019-12"
-10426	drinkable high-proof salt plum sake	10	good	Last Available: "2019-12"
+10426	high-proof drinkable salt plum sake	10	good	Last Available: "2019-12"
 10427	frozen pickled pressurized potion of possessiveness	0		Effect: "Itchy Trigger Finger", Effect Duration: 58, Last Available: "2019-12"
 10428	boiled magnetized almond	0		Effect: "Arse-a'fire", Effect Duration: 28
 10429	double-pickled handful of mixed nuts	0		Effect: "Spooky Hands", Effect Duration: 28, Last Available: "2019-12"
 10430	blinking nutcracking pliers	0		
 10431	shaking Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	Temple Grandin's Jim Carey's veiny Retrospecs	0		Maximum HP: +10, Monster Level: +25, Familiar Weight: +7, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
+10432	Temple Grandin's Jim Carey's veiny Retrospecs	0		Maximum HP: +10, Monster Level: +25, Familiar Weight: +7, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	blurry mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	shaking prompt therapeutic healthy smooth Powerful Glove of the overflowing toilet	0		Moxie: +15, Maximum HP Percent: +20, Stench Spell Damage: +50, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
+10438	shaking prompt therapeutic healthy smooth Powerful Glove of the overflowing toilet	0		Moxie: +15, Maximum HP Percent: +20, Stench Spell Damage: +50, Adventures: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
 10439	enhanced signal receiver	0		
 10440	upside-down status cymbal	0		Last Available: "2020-02"
 10441	aromatic weightlifter's Drip harness of the cougar	0		Muscle: +15, Moxie: +20, Stench Resistance: +1
@@ -10300,7 +10300,7 @@
 10443	Driplet	0		
 10444	drippy snail shell	0		
 10445	stale low-calorie drippy nugget	1	drippy	
-10446	artisanal distilled jittery mirror glass of drippy wine	5	drippy	
+10446	distilled artisanal mirror jittery glass of drippy wine	5	drippy	
 10447	spoiled miniature pulsating drippy caviar	2	drippy	
 10448	half-sized normal bouncing drippy plum(?)	2	drippy	
 10449	sharpshooter's drippy stake	0		Critical Hit Percent: +10, Single Equip
@@ -10316,7 +10316,7 @@
 10459	cold-filtered lime green healthy juice	0		Effect: "Heavily Breathing", Effect Duration: 51
 10460	hammer	0		
 10461	upside-down hammer	0		
-10462	mirror maroon fire flower	0		
+10462	maroon mirror fire flower	0		
 10463	ghostly bonfire flower	0		
 10464	work boots	0		Single Equip
 10465	boots	0		Single Equip
@@ -10341,12 +10341,12 @@
 10484	plump free-range mushroom	0		Last Available: "2020-03"
 10485	teal bulky free-range mushroom	0		Last Available: "2020-03"
 10486	huge free-range mushroom	0		Last Available: "2020-03"
-10487	skewed blurry immense free-range mushroom	0		Last Available: "2020-03"
+10487	blurry skewed immense free-range mushroom	0		Last Available: "2020-03"
 10488	teal colossal free-range mushroom	0		Last Available: "2020-03"
-10489	adequate half-sized mushroom filet	2	good	Last Available: "2020-03"
+10489	half-sized adequate mushroom filet	2	good	Last Available: "2020-03"
 10490	mushroom slab	0		Last Available: "2020-03"
 10491	mixed mirror twirling mushroom tea	1		Last Available: "2020-03"
-10492	practically non-alcoholic aged mushroom whiskey	1	awesome	Last Available: "2020-03"
+10492	aged practically non-alcoholic mushroom whiskey	1	awesome	Last Available: "2020-03"
 10493	hale experienced strapping mushroom cap	0		Muscle: +5, Experience: +2, Maximum HP: +20, Last Available: "2020-03"
 10494	jittery healthy wicked Sinatra's mushroom shield of vim and vigor	0		Experience (Moxie): +5, Spell Damage: +5, Maximum HP Percent: 70, Damage Reduction: 6, Last Available: "2020-03"
 10495	blue zippy nippy savvy mushroom pants of temperance	0		Mysticality Percent: +20, Cold Damage: +10, Sleaze Resistance: +5, Initiative: +20, Last Available: "2020-03"
@@ -10387,18 +10387,18 @@
 10531	annealed drippy orb	0		
 10532	wobbly Guzzlr application	0		Free Pull
 10533	bouncing Samson's Guzzlr tablet of the brute	0		Muscle Percent: +30, Experience (Muscle): +5, Last Available: "2020-05"
-10534	blinking blurry Guzzlr cocktail set	0		Last Available: "2020-05"
+10534	blurry blinking Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	Guzzlrbuck	0		Last Available: "2020-05"
 10536	Guzzlr hat	0		Last Available: "2020-05"
 10537	huge Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	fuchsia Guzzlr pants	0		Last Available: "2020-05"
 10539	ruddy Guzzlr souvenir stein	0		Maximum HP Percent: +40, Last Available: "2020-05"
-10540	blurry twirling Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	artisanal boozy Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
-10542	practically non-alcoholic drinkable Sourfinger	1	good	Last Available: "2020-05"
+10540	twirling blurry Guzzlr tattoo kit	0		Last Available: "2020-05"
+10541	boozy artisanal Ghiaccio Colada	5	EPIC	Last Available: "2020-05"
+10542	drinkable practically non-alcoholic Sourfinger	1	good	Last Available: "2020-05"
 10543	acceptable Nog-on-the-Cob	3	good	Last Available: "2020-05"
 10544	bad weak Steamboat	2	decent	Last Available: "2020-05"
-10545	delicious extra-dry Buttery Boy	5	awesome	Last Available: "2020-05"
+10545	extra-dry delicious Buttery Boy	5	awesome	Last Available: "2020-05"
 10546	Never Don't Stop Not Striving	0		Skill: "Always Never Not Guzzling", Last Available: "2020-05"
 10547	huge shaking family-friendly smartaleck's clown car key	0		Moxie Percent: +30, Sleaze Resistance: +1, Last Available: "2020-08"
 10548	bouncing veiny studded batting cage key of horror	0		Damage Absorption: +80, Maximum HP: +10, Spooky Spell Damage: +25, Last Available: "2020-08"
@@ -10438,9 +10438,9 @@
 10582	lime green SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	huge cyan birch battery of the wise owl of extreme caution	0		Mysticality: +20, Monster Level: -25, Lasts Until Rollover, Last Available: "2020-08"
-10585	zippy Temple Grandin's Oprah's ebony epee	0		Maximum MP Percent: +50, Familiar Weight: +7, Initiative: +20, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
-10586	baleful weeping willow wand of Tarzan of dire peril	0		Experience (Muscle): +3, Weapon Damage: +20, Spell Damage: +25, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
-10587	blue veiny Samson's stylish beechwood blowgun	0		Moxie: +25, Experience (Muscle): +5, Maximum HP: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
+10585	zippy Temple Grandin's Oprah's ebony epee	0		Maximum MP Percent: +50, Familiar Weight: +7, Initiative: +20, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
+10586	baleful weeping willow wand of Tarzan of dire peril	0		Experience (Muscle): +3, Weapon Damage: +20, Spell Damage: +25, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
+10587	blue veiny Samson's stylish beechwood blowgun	0		Moxie: +25, Experience (Muscle): +5, Maximum HP: +10, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
 10588	mirror ribald smelly arcane researcher's maple magnet	0		Experience Percent (Mysticality): +10, Stench Spell Damage: +10, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2020-08"
 10589	tumbling Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	shaking flame-retardant Fonzie's hemlock helm of Gandalf	0		Experience (Moxie): +1, Spell Critical Percent: +20, Hot Resistance: +1, Last Available: "2020-08"
@@ -10462,14 +10462,14 @@
 10606	Vulcanized tumbling Yeg's Motel toothbrush	0		Effect: "Conspiratory Eyes", Effect Duration: 52, Last Available: "2020-09"
 10607	Vulcanized mirror Yeg's Motel hand soap	0		Effect: "Tingly Elbows", Effect Duration: 17, Last Available: "2020-09"
 10608	Yeg's Motel sewing kit	0		Last Available: "2020-09"
-10609	yummy big wobbly Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
+10609	big yummy wobbly Yeg's Motel pillow mint	5	awesome	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
 10611	polymerized super-chilled electrified pulsating Yeg's Motel mouthwash	0		Effect: "Bandersnatched", Effect Duration: 64, Last Available: "2020-09"
 10612	greedy Yeg's Motel shower cap of the storm	0		Maximum MP Percent: +40, Meat Drop: +20, Lasts Until Rollover, Last Available: "2020-09"
 10613	shaking flame-wreathed Temple Grandin's Yeg's Motel bathrobe	0		Familiar Weight: +7, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2020-09"
 10614	up-at-dawn dog trainer's Yeg's Motel slippers	0		Experience (familiar): +1, Adventures: +5, Single Equip, Lasts Until Rollover, Last Available: "2020-09"
 10615	Yeg's Motel stationery	0		Last Available: "2020-09"
-10616	spinning blinking Yeg's Motel minibar key	0		Last Available: "2020-09"
+10616	blinking spinning Yeg's Motel minibar key	0		Last Available: "2020-09"
 10617	bouncing sizzling desk bell	0		Last Available: "2020-09"
 10618	frost-rimed desk bell	0		Last Available: "2020-09"
 10619	uncanny desk bell	0		Last Available: "2020-09"
@@ -10491,11 +10491,11 @@
 10635	skewed bagged Cargo Cultist Shorts	0		Free Pull, Last Available: "2020-09"
 10636	spinning Sherlock's toasty Jim Carey's fortified Cargo Cultist Shorts	0		Damage Absorption: +60, Monster Level: +25, Hot Damage: +5, Item Drop: +25, Last Available: "2020-09"
 10637	complicated device	0		Last Available: "2020-09"
-10638	irresponsibly strong drinkable jittery spinning flask of moonshine	8	good	Last Available: "2020-09"
+10638	drinkable irresponsibly strong spinning jittery flask of moonshine	8	good	Last Available: "2020-09"
 10639	family-friendly sea-worn candlestick of Tarzan of Calamity Jane	0		Experience (Muscle): +3, Critical Hit Percent: +15, Sleaze Resistance: +1, Last Available: "2020-09"
 10640	Universal Seasoning	0		
 10641	flattened wobbly null-day exploit	0		Effect: "Seeing Colors", Effect Duration: 40, Last Available: "2025-12"
-10642	cyan skewed flame orb	0		Last Available: "2020-09"
+10642	skewed cyan flame orb	0		Last Available: "2020-09"
 10643	spoiled chocolate chip muffin	3	crappy	
 10644	Comprehensive Cartographic Compendium	0		Free Pull, Last Available: "2020-10"
 10645	Comprehensive Cartographic Compendium (well-read)	0		Last Available: "2020-10"
@@ -10517,7 +10517,7 @@
 10661	SalesCo sample kit of the sweet-tooth	0		Candy Drop: [+100*event(December)], Last Available: "2020-12"
 10662	improved nitrogenated jittery olive candy harmonica	0		Effect: "Ooh, Salty!", Effect Duration: 66, Last Available: "2020-12"
 10663	chilled oxidized bouncing sugar	0		Effect: "Purpose", Effect Duration: 41, Last Available: "2020-12"
-10664	quantum ionized blinking blurry multi-level marzipan	0		Effect: "Berry Thorny", Effect Duration: 38, Last Available: "2020-12"
+10664	quantum ionized blurry blinking multi-level marzipan	0		Effect: "Berry Thorny", Effect Duration: 38, Last Available: "2020-12"
 10665	rock-hard plastic Crimbo caroler	0		Damage Reduction: 5, Last Available: "2020-12"
 10666	hardy plastic multi-level marketer	0		Maximum HP: +50, Last Available: "2020-12"
 10667	shaking smartaleck's plastic Crimbo cheer	0		Moxie Percent: +30, Last Available: "2020-12"
@@ -10569,10 +10569,10 @@
 10713	upside-down The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	shaking The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10715	decent and pepper (stale)	4	good	Last Available: "2020-12"
-10716	hand-crafted irresponsibly strong twirling cranberry margarita (brackish)	10	EPIC	Last Available: "2020-12"
+10716	irresponsibly strong hand-crafted twirling cranberry margarita (brackish)	10	EPIC	Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	maroon nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
-10719	tumbling maroon goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
+10719	maroon tumbling goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
 10720	mediocre enchanted spinning barrel-aged eggnog	3	decent	Effect: "Surreally Buff", Effect Duration: 5, Last Available: "2020-12"
 10721	flavorless hand-crafted candy cane	4	decent	Last Available: "2020-12"
 10722	decent tiny drive-thru burger	1	good	Last Available: "2020-12"
@@ -10602,7 +10602,7 @@
 10746	twirling marshmallow	0		
 10747	watered-down bad marshmallow bomb	2	decent	Last Available: "2021-03"
 10748	packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	plate	0		Familiar Weight: +5
 10752	liquefied vacuum-sealed wobbly short beer	0		Effect: "Abominably Slippery", Effect Duration: 47, Last Available: "2021-05"
@@ -10612,7 +10612,7 @@
 10756	magnetized Vulcanized short	0		Effect: "Ticking Clock", Effect Duration: 51, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
 10758	quantum of familiar	0		
-10759	groovy familiar scrapbook of courage	0		Moxie Percent: +10, Spooky Resistance: +3, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
+10759	groovy familiar scrapbook of courage	0		Moxie Percent: +10, Spooky Resistance: +3, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	mirror clan underground fireworks shop	0		Last Available: "2021-07"
 10762	blinking zippy hardy weightlifter's fedora-mounted fountain	0		Muscle: +15, Maximum HP: +50, Initiative: +20, Lasts Until Rollover, Last Available: "2021-07"
@@ -10650,7 +10650,7 @@
 10794	rainproof barrel caulk	0		
 10795	lime green pump grease	0		
 10796	upside-down packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	horrifying dog trainer's Lo Pan's padded smartaleck's industrial fire extinguisher of the brazier	0		Moxie Percent: +30, Damage Absorption: +20, Spell Critical Percent: +30, Experience (familiar): +1, Hot Spell Damage: +25, Spooky Damage: +25, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
+10797	horrifying dog trainer's Lo Pan's padded smartaleck's industrial fire extinguisher of the brazier	0		Moxie Percent: +30, Damage Absorption: +20, Spell Critical Percent: +30, Experience (familiar): +1, Hot Spell Damage: +25, Spooky Damage: +25, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10660,7 +10660,7 @@
 10804	manspreader's crafty Daylight Shavings Helmet of mayonnaise	0		Maximum MP: +10, Monster Level: +10, Sleaze Spell Damage: +50, Last Available: "2021-11"
 10805	eggwater	1	EPIC	Last Available: "2021-12"
 10806	adequate bread man	4	good	Last Available: "2021-12"
-10807	toothsome tiny plain candy cane	1	awesome	Last Available: "2021-12"
+10807	tiny toothsome plain candy cane	1	awesome	Last Available: "2021-12"
 10808	rotten blinking flour cookie	3	crappy	Last Available: "2021-12"
 10809	asbestos-lined plastic food lab	0		Hot Resistance: +5, Single Equip, Last Available: "2021-12"
 10810	bouncing Jim Carey's plastic nog lab	0		Monster Level: +25, Single Equip, Last Available: "2021-12"
@@ -10672,19 +10672,19 @@
 10816	fuchsia ice crown of Leguizamo of courage of Flo-Jo	0		Monster Level: +20, Spooky Resistance: +3, Initiative: +100, Lasts Until Rollover, Last Available: "2021-12"
 10817	medical-grade beefy jeans of the detective	0		Muscle: +10, Item Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2021-12"
 10818	ghostly gravedigger's frosty wizardly ice wrap	0		Mysticality: +25, Cold Spell Damage: +10, Spooky Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
-10819	super-sized flavorless tofu pop	5	decent	Last Available: "2021-12"
+10819	flavorless super-sized tofu pop	5	decent	Last Available: "2021-12"
 10820	rotten half-sized bowl of prescription candy	2	crappy	Last Available: "2021-12"
 10821	decent jittery fishcake	3	good	Last Available: "2021-12"
 10822	huge normal blue bone broth	10	good	Last Available: "2021-12"
-10823	diet adequate star pop	1	good	Last Available: "2021-12"
+10823	adequate diet star pop	1	good	Last Available: "2021-12"
 10824	lousy Doc's Fortifying Wine	3	decent	Last Available: "2021-12"
-10825	spirit-forward delicious Doc's Smartifying Wine	5	awesome	Last Available: "2021-12"
+10825	delicious spirit-forward Doc's Smartifying Wine	5	awesome	Last Available: "2021-12"
 10826	tolerable spinning Doc's Limbering Wine	4	good	Last Available: "2021-12"
 10827	drinkable mirror Doc's Medical-Grade Wine	3	good	Last Available: "2021-12"
 10828	distilled red ghostly Homebodyl&trade;	1		Effect: "Virgo Rising", Effect Duration: 5, Last Available: "2021-12"
 10829	powdered wobbly Extrovermectin&trade;	1		Effect: "So You Can Work More...", Effect Duration: 40, Last Available: "2021-12"
-10830	denatured red bouncing twirling Breathitin&trade;	1		Last Available: "2021-12"
-10831	modified bouncing fuchsia Fleshazole&trade;	1		Effect: "Fizzier Than Light", Effect Duration: 25, Last Available: "2021-12"
+10830	denatured bouncing twirling red Breathitin&trade;	1		Last Available: "2021-12"
+10831	modified fuchsia bouncing Fleshazole&trade;	1		Effect: "Fizzier Than Light", Effect Duration: 25, Last Available: "2021-12"
 10832	aerosolized vacuum-sealed anodized anti-burn cream	0		Effect: "Bats in the Belfry", Effect Duration: 29, Last Available: "2021-12"
 10833	magnetized anti-freeze cream	0		Effect: "Work For Hours a Week", Effect Duration: 15, Last Available: "2021-12"
 10834	pickled denatured anti-goosebump cream	0		Effect: "Worth Your Salt", Effect Duration: 50, Last Available: "2021-12"
@@ -10694,7 +10694,7 @@
 10838	special bad Doc's Special Reserve Wine	3	decent	Effect: "Fan-Cooled", Effect Duration: 35, Last Available: "2021-12"
 10839	spoiled bread pie	3	crappy	Last Available: "2021-12"
 10840	bad triple-distilled blue clear Russian	7	decent	Last Available: "2021-12"
-10841	purple jittery zero-trust tanktop	0		Last Available: "2025-12"
+10841	jittery purple zero-trust tanktop	0		Last Available: "2025-12"
 10842	shaking Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
 10844	pulsating gooified animal matter	0		Last Available: "2021-12"
@@ -10724,7 +10724,7 @@
 10868	flavorless lab-grown meat	4	decent	Last Available: "2021-12"
 10869	fleece of the brazier	0		Hot Spell Damage: +25, Last Available: "2021-12"
 10870	blinking boxed gumball machine	0		Last Available: "2021-12"
-10871	spinning skewed cloning kit	0		Last Available: "2021-12"
+10871	skewed spinning cloning kit	0		Last Available: "2021-12"
 10872	rosy-cheeked pants	0		Maximum HP Percent: +30, Last Available: "2021-12"
 10873	bouncing fireproof razor-sharp can of mixed everything of incineration	0		Weapon Damage Percent: +25, Hot Spell Damage: +50, Hot Resistance: +3, Last Available: "2021-12"
 10874	Site Alpha ID badge	0		Familiar Weight: +5
@@ -10735,7 +10735,7 @@
 10879	refurbished air fryer	0		Last Available: "2021-12"
 10880	twisted jittery gray fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
-10882	blinking teal carton of astral energy drinks	0		
+10882	teal blinking carton of astral energy drinks	0		
 10883	boiled astral energy drink	1		Effect: "Goldentongue", Effect Duration: 25
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	twirling shellacked banded baleful magnifying glass	0		Spell Damage: +25, Damage Absorption: +100, Damage Reduction: 7, Last Available: "2022-12"
@@ -10779,12 +10779,12 @@
 10923	rotten small fire-roasted lake trout	2	crappy	Last Available: "2022-06"
 10924	adequate fancy guilty sprout	4	good	Effect: "One For Tea", Effect Duration: 20, Last Available: "2022-06"
 10925	Lo Pan's mother's necklace of the sewer	0		Spell Critical Percent: +30, Stench Damage: +25, Last Available: "2022-06"
-10926	vacuum-sealed purple ghostly twirling trampled ticket stub	0		Effect: "Heart of Yellow", Effect Duration: 57, Last Available: "2022-06"
+10926	vacuum-sealed twirling ghostly purple trampled ticket stub	0		Effect: "Heart of Yellow", Effect Duration: 57, Last Available: "2022-06"
 10927	chilled narrow savings bond	0		Effect: "Browbeaten", Effect Duration: 34, Last Available: "2022-06"
 10928	pulsating pulsating designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
+10929	designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 10930	twisted sweat-ade	1		Last Available: "2022-07"
-10931	bouncing lime green unopened stillsuit	0		Free Pull, Last Available: "2022-08"
+10931	lime green bouncing unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	dinosaur scale	0		
@@ -10805,14 +10805,14 @@
 10949	wobbly dinosaur of wisdom	0		Mysticality: +15
 10950	wobbly Thwaitgold mosquito-in-amber statuette	0		
 10951	packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	ribald Jurassic Parka	0		Sleaze Damage: +10, Item Drop: +5, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
+10952	ribald Jurassic Parka	0		Sleaze Damage: +10, Item Drop: +5, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
 10953	cyan boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	oxidized triple-enhanced maroon autumn leaf	0		Effect: "Nas Tea", Effect Duration: 23, Last Available: "2022-10"
 10956	delicious wobbly AutumnFest ale	4	awesome	Last Available: "2022-10"
 10957	vibrating Samson's savvy autumn sweater-weather sweater	0		Mysticality Percent: +20, Experience (Muscle): +5, Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2022-10"
 10958	auspicious baleful autumn debris shield of Leguizamo of the cheetah	0		Spell Damage: +25, Monster Level: +20, Item Drop: +10, Initiative: +60, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2022-10"
-10959	thick moldy tumbling autumn-spice donut	5	crappy	Last Available: "2022-10"
+10959	moldy thick tumbling autumn-spice donut	5	crappy	Last Available: "2022-10"
 10960	triple-diffused ghostly autumn dollar	0		Effect: "Hopped Up on Goofballs", Effect Duration: 36, Last Available: "2022-10"
 10961	up-at-dawn hardy veiny autumn leaf pendant	0		Maximum HP: 60, Adventures: +5, Lasts Until Rollover, Last Available: "2022-10"
 10962	denatured narrow autumn breeze	1		Last Available: "2022-10"
@@ -10825,40 +10825,40 @@
 10969	purple Vegetable of Jarlsberg	0		Last Available: "2022-11"
 10970	rotten huge ratatouille de Jarlsberg	10	crappy	Last Available: "2022-11"
 10971	adequate Jarlsberg's vegetable soup	4	good	Last Available: "2022-11"
-10972	fancy low-calorie flavorless roasted vegetable of Jarlsberg	1	decent	Effect: "Flower Power", Effect Duration: 10, Last Available: "2022-11"
-10973	small stale St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
+10972	low-calorie fancy flavorless roasted vegetable of Jarlsberg	1	decent	Effect: "Flower Power", Effect Duration: 10, Last Available: "2022-11"
+10973	stale small St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
 10974	flavorless Pete's wiley whey bar	4	decent	Last Available: "2022-11"
 10975	spoiled Pete's rich ricotta	4	crappy	Last Available: "2022-11"
 10976	weak artisanal pulsating Boris's beer	2	EPIC	Last Available: "2022-11"
 10977	rotten honey bun of Boris	3	crappy	Last Available: "2022-11"
 10978	moldy Boris's bread	3	crappy	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	narrow purple Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
-10982	upside-down fuchsia Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
-10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
-10985	shaking Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
-10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
-10987	Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
+10981	purple narrow Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
+10982	upside-down fuchsia Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
+10984	Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
+10985	shaking Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
+10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
+10987	Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
 10988	small rotten baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
 10989	adequate miniature plain calzone	2	good	Last Available: "2022-11"
 10990	huge moldy roasted vegetable focaccia	9	crappy	Last Available: "2022-11"
 10991	small spoiled Pizza of Legend	2	crappy	Last Available: "2022-11"
 10992	moldy Calzone of Legend	4	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
-10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
-10995	ghostly Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
-10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
+10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
+10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
+10995	ghostly Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
+10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
 10998	red cookbookbat book	0		Familiar Weight: +5
-10999	narrow Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+10999	narrow Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
 11000	normal huge Deep Dish of Legend	4	good	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	government per-diem	0		
 11004	upside-down tumbling lard-coated prohie's hat	0		Sleaze Spell Damage: +25
-11005	extra-ionized gray pulsating imported taffy	0		Effect: "You Know Who to Call", Effect Duration: 67
+11005	extra-ionized pulsating gray imported taffy	0		Effect: "You Know Who to Call", Effect Duration: 67
 11006	jittery coward's forbidden Charleston shoes	0		Spell Damage Percent: +50, Monster Level: -20, Single Equip
 11007	booze bindle	0		
 11008	rare oboe of the dark arts	0		Spell Damage Percent: +100, Item Drop: +5
@@ -10866,19 +10866,19 @@
 11010	rotten red swamp haunch	4	crappy	
 11011	Tesla experienced gator shades	0		Experience: +2, MP Regen Min: 7, MP Regen Max: 10, Single Equip
 11012	mirror milk cap	0		
-11013	hand-crafted spirit-forward blurry Charleston Choo-Choo	5	EPIC	
+11013	spirit-forward hand-crafted blurry Charleston Choo-Choo	5	EPIC	
 11014	acceptable Velvet Veil	4	good	
-11015	delicious watered-down tumbling Marltini	2	awesome	
+11015	watered-down delicious tumbling Marltini	2	awesome	
 11016	watered-down delicious squat Strong, Silent Type	2	awesome	
-11017	fancy strong bad Mysterious Stranger	5	decent	Effect: "Al Dente Inferno", Effect Duration: 40
+11017	fancy bad strong Mysterious Stranger	5	decent	Effect: "Al Dente Inferno", Effect Duration: 40
 11018	acceptable Champagne Shimmy	4	good	
 11019	the Sot's parcel	0		
-11020	fuchsia chilly Tesla ceramic cestus	0		Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
-11021	scandalous friendly dance instructor's ceramic centurion shield	0		Experience Percent (Moxie): +10, Familiar Weight: +3, Sleaze Damage: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
-11022	blue frightening ceramic celery grater of the empath	0		Familiar Weight: +5, Spooky Damage: +5, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
-11023	narrow zippy Fonzie's ceramic celsiturometer of the empath	0		Experience (Moxie): +1, Familiar Weight: +5, Initiative: +20, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
-11024	shaking spinning studded boxer's ceramic cerecloth belt of chilblains	0		Muscle Percent: +10, Damage Absorption: +80, Cold Damage: +25, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
-11025	blurry Oprah's healthy extremely unsafe ceramic cenobite's robe	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Maximum MP Percent: +50, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
+11020	fuchsia chilly Tesla ceramic cestus	0		Cold Damage: +5, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
+11021	scandalous friendly dance instructor's ceramic centurion shield	0		Experience Percent (Moxie): +10, Familiar Weight: +3, Sleaze Damage: +5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
+11022	blue frightening ceramic celery grater of the empath	0		Familiar Weight: +5, Spooky Damage: +5, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
+11023	narrow zippy Fonzie's ceramic celsiturometer of the empath	0		Experience (Moxie): +1, Familiar Weight: +5, Initiative: +20, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
+11024	shaking spinning studded boxer's ceramic cerecloth belt of chilblains	0		Muscle Percent: +10, Damage Absorption: +80, Cold Damage: +25, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
+11025	blurry Oprah's healthy extremely unsafe ceramic cenobite's robe	0		Weapon Damage Percent: +100, Maximum HP Percent: +20, Maximum MP Percent: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
 11026	modified ceramic scree	1		Last Available: "2023-12"
 11027	denatured extra-hard jawbreaker	0		Effect: "Improved Candy Vision", Effect Duration: 24
 11028	fuchsia narrow fireproof therapeutic experienced chiffon chevrons	0		Experience: +2, Hot Resistance: +3, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2023-12"
@@ -10891,7 +10891,7 @@
 11035	dry dry gray chiffon lemon	0		Effect: "Powdered", Effect Duration: 63
 11036	yummy chocomotive	3	awesome	Last Available: "2022-12"
 11037	moldy bouncing freightcake	4	crappy	Last Available: "2022-12"
-11038	hand-crafted practically non-alcoholic cabooze	1	super ultra mega turbo EPIC	Last Available: "2022-12"
+11038	practically non-alcoholic hand-crafted cabooze	1	super ultra mega turbo EPIC	Last Available: "2022-12"
 11039	plastic caboose	0		Last Available: "2022-12"
 11040	purple scorching plastic passenger car	0		Hot Damage: +25, Last Available: "2022-12"
 11041	pulsating lime green reassuring plastic dining car	0		Spooky Resistance: +1, Last Available: "2022-12"
@@ -10906,7 +10906,7 @@
 11050	vacuum-sealed Trainbot circuitry	0		Effect: "Polar Express", Effect Duration: 14
 11051	triple-irradiated deionized mirror Trainbot tubing	0		Effect: "Warm Shoulders", Effect Duration: 53
 11052	denatured tarnished Trainbot plating	0		Effect: "Knob Goblin Lust Frenzy", Effect Duration: 38
-11053	unsweetened pulsating teal Trainbot optics	0		Effect: "Triangle, Man", Effect Duration: 40
+11053	unsweetened teal pulsating Trainbot optics	0		Effect: "Triangle, Man", Effect Duration: 40
 11054	corrupted tarnished Trainbot servomotors	0		Effect: "Leash of Linguini", Effect Duration: 27
 11055	energized energized olive Trainbot linkages	0		Effect: "Bottle in front of Me", Effect Duration: 18
 11056	ping-pong paddle	0		Single Equip
@@ -10940,8 +10940,8 @@
 11084	smooth Crimbosmopolitan	3	awesome	Last Available: "2022-12"
 11085	moldy jumbo Crimbo dinner	5	crappy	Last Available: "2022-12"
 11086	overloaded Yule battery	0		Familiar Weight: +25, Last Available: "2022-12"
-11087	jittery blurry train whistle	0		Last Available: "2022-12"
-11088	yellow upside-down The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
+11087	blurry jittery train whistle	0		Last Available: "2022-12"
+11088	upside-down yellow The Superconductor's CPU	0		Single Equip, Last Available: "2022-12"
 11089	gray twirling unoccupied sheep suit	0		Free Pull, Last Available: "2023-12"
 11090	gray half-height cigar	0		Familiar Weight: +5
 11091	grubby wool	0		
@@ -10950,7 +10950,7 @@
 11094	auspicious supercool grubby wool trousers of chilblains	0		Moxie Percent: +20, Cold Damage: +25, Item Drop: +10
 11095	jittery lion tamer's resourceful thinker's grubby wool gloves of the early riser	0		Mysticality: +10, Maximum MP: +50, Experience (familiar): +2, Adventures: +7, Single Equip
 11096	grubby wool beerwarmer	0		
-11097	triple-distilled fancy artisanal nice warm beer	9	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 15
+11097	artisanal fancy triple-distilled nice warm beer	9	EPIC	Effect: "Tenacity of the Snapper", Effect Duration: 15
 11098	grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
@@ -10974,7 +10974,7 @@
 11119	quantum ionized upside-down five-fingered fern resin	0		Effect: "Hot Jellied", Effect Duration: 49, Last Available: "2023-02"
 11120	half-sized flavorless super good fruit	2	decent	Last Available: "2023-02"
 11121	vaporized blue energized spores	1		Effect: "Patent Prevention", Effect Duration: 45, Last Available: "2023-02"
-11122	zippy Fonzie's hot pepper	0		Experience (Moxie): +1, Initiative: +20, Last Available: "2023-02", Lantern Element: "Hot"
+11122	zippy Fonzie's hot pepper	0		Experience (Moxie): +1, Initiative: +20, Lantern Element: "Hot", Last Available: "2023-02"
 11123	dry quadruple-irradiated out-of-work circus flea	0		Effect: "Stevedave's Shanty of Superiority", Effect Duration: 55, Last Available: "2023-02"
 11124	mirror extra-grubby grub	0		Last Available: "2023-02"
 11125	vacuum-sealed Vulcanized fire ant pheromones	0		Effect: "Vanity Rage", Effect Duration: 47, Last Available: "2023-02"
@@ -10983,16 +10983,16 @@
 11128	liquefied oxidized mirror filled mosquito	0		Effect: "Sensation", Effect Duration: 57, Last Available: "2023-02"
 11129	vacuum-sealed non-chilled lime green shim of shame shale	0		Effect: "Jawin'", Effect Duration: 61, Last Available: "2023-02"
 11130	non-pressed denatured bouncing pebble of proud pyrite	0		Effect: "Here to Kick Ass", Effect Duration: 20, Last Available: "2023-02"
-11131	non-warmed pulsating bouncing pile of gritty sand	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2023-02"
+11131	non-warmed bouncing pulsating pile of gritty sand	0		Effect: "The Halls of Mysticality", Effect Duration: 12, Last Available: "2023-02"
 11132	hollow rock	0		Last Available: "2023-02"
 11133	polymerized nitrogenated angry agate	0		Effect: "Christmessy", Effect Duration: 55, Last Available: "2023-02"
 11134	irradiated lump of loyal latite	0		Effect: "The Magic of Sharing", Effect Duration: 13, Last Available: "2023-02"
-11135	stale super-sized shadow sausage	5	decent	Last Available: "2023-03"
+11135	super-sized stale shadow sausage	5	decent	Last Available: "2023-03"
 11136	chilly MacGyver's shadow skin	0		Maximum MP: +100, Cold Damage: +5, Last Available: "2023-03"
 11137	anodized shadow flame	0		Effect: "Hare-o-dynamic", Effect Duration: 51, Last Available: "2023-03"
 11138	tasty ghostly shadow bread	4	awesome	Last Available: "2023-03"
 11139	shadow ice	0		Last Available: "2023-03"
-11140	weak special hand-crafted jittery shadow fluid	2	EPIC	Effect: "Pla-see-bo", Effect Duration: 30, Last Available: "2023-03"
+11140	hand-crafted weak special jittery shadow fluid	2	EPIC	Effect: "Pla-see-bo", Effect Duration: 30, Last Available: "2023-03"
 11141	jittery shadow glass	0		Last Available: "2023-03"
 11142	shadow brick	0		Last Available: "2023-03"
 11143	shadow sinew	0		Last Available: "2023-03"
@@ -11035,10 +11035,10 @@
 11180	Sherlock's stiffened educational shadow monocle	0		Experience: +1, Damage Reduction: 1, Item Drop: +25, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	moldy maroon shadow hot dog	3	crappy	
-11183	fancy watered-down delicious shadow martini	2	awesome	Effect: "Always In Motion", Effect Duration: 10
+11183	delicious fancy watered-down shadow martini	2	awesome	Effect: "Always In Motion", Effect Duration: 10
 11184	denatured shadow pill	1		Effect: "Bananas!", Effect Duration: 50
 11185	shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
 11187	squat monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	anodized improved blue shadow candy	0		Effect: "Memory of Strength", Effect Duration: 39
 11189	mirror wobbly replica Mr. Accessory	0		
@@ -11075,7 +11075,7 @@
 11220	twirling replica over-the-shoulder Folder Holder	0		
 11221	tumbling blue replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	double-paned Lo Pan's wholesome Cincho de Mayo of terror	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Spooky Spell Damage: +10, Cold Resistance: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11223	double-paned Lo Pan's wholesome Cincho de Mayo of terror	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Spooky Spell Damage: +10, Cold Resistance: +5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11224	skewed dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	Herculean replica Jurassic Parka of bravery	0		Experience (Muscle): +1, Spooky Resistance: +5
 11250	shaking replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
+11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	replica Ten Dollars	0		
 11254	occult Socratic replica Cincho de Mayo of the bloodbag of horror	0		Experience (Mysticality): +1, Spell Damage Percent: +25, Maximum HP: +100, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	mirror 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	stanky nippy studded dangerous smooth &quot;I survived Y2K&quot; T-Shirt of terror	0		Moxie: +15, Weapon Damage: +10, Damage Absorption: +80, Cold Damage: +10, Stench Spell Damage: +25, Spooky Spell Damage: +10, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	manspreader's banded pro skateboard	0		Damage Absorption: +100, Monster Level: +10, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
+11260	manspreader's banded pro skateboard	0		Damage Absorption: +100, Monster Level: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
 11261	Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	jittery Charter: Nellyville	0		Last Available: "2023-06"
 11265	narrow Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
-11266	squat Flash Liquidizer Ultra Dousing Accessory of the businessman	0		Meat Drop: +50, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
+11266	squat Flash Liquidizer Ultra Dousing Accessory of the businessman	0		Meat Drop: +50, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
 11267	rock-hard baleful extremely unsafe Amulet of Perpetual Darkness of the detective	0		Weapon Damage Percent: +100, Spell Damage: +25, Damage Reduction: 5, Item Drop: +20, Last Available: "2023-06"
 11268	jittery Giant monolith	0		Last Available: "2023-06"
 11269	spinning Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11151,19 +11151,19 @@
 11296	prompt auspicious birdybug antenna	0		Item Drop: +10, Adventures: +3
 11297	red veiny savvy kilopede skull	0		Mysticality Percent: +20, Maximum HP: +10
 11298	ionized altered haemolymphnode	0		Effect: "Strong Grip", Effect Duration: 60
-11299	wet deionized maroon narrow mirror chitin powder paste	0		Effect: "Liquid Courage", Effect Duration: 47
+11299	wet deionized narrow mirror maroon chitin powder paste	0		Effect: "Liquid Courage", Effect Duration: 47
 11300	sleeping patriotic eagle	0		Free Pull
 11301	claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
 11303	lime green name change form	0		
-11304	olive twirling replica sleeping patriotic eagle	0		
+11304	twirling olive replica sleeping patriotic eagle	0		
 11305	ghostly boxed august scepter	0		Free Pull
 11306	august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11307	flavorless watermelon	3	decent	
 11308	watermelon seed	0		
 11309	spinning water balloon	0		
 11310	thriftshop coupon	0		
-11311	stale snack-sized waffle	2	decent	
+11311	snack-sized stale waffle	2	decent	
 11312	fixodent	0		
 11313	hale fortified cat o' nine teeth	0		Damage Absorption: +60, Maximum HP: +20
 11314	lime green zippy inspector's tooth cap	0		Item Drop: +15, Initiative: +20
@@ -11184,12 +11184,12 @@
 11329	pickled meat	1		Effect: "Memory of Speed", Effect Duration: 20
 11330	altered sparkling orb	1		Effect: "Prideful Strut", Effect Duration: 30
 11331	diluted shaking hardening cream	1		
-11332	mixed tumbling spinning huge pool shark hair oil	1		Effect: "Carrion' On", Effect Duration: 20
+11332	mixed huge spinning tumbling pool shark hair oil	1		Effect: "Carrion' On", Effect Duration: 20
 11333	book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
 11334	book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
-11337	twirling upside-down map to a candy-rich block	0		Last Available: "2023-10"
+11337	upside-down twirling map to a candy-rich block	0		Last Available: "2023-10"
 11338	magnetized polymerized ghostly sampler size toothpaste	0		Effect: "Hangdog", Effect Duration: 69
 11339	Franken Stein	0		Conditional Skill (Equipped): "Toast your enemy"
 11340	A Guide to Burning Leaves	0		Free Pull
@@ -11247,13 +11247,13 @@
 11392	futuristic hat	0		Lasts Until Rollover
 11393	futuristic collar	0		Lasts Until Rollover
 11394	crated wardrobe-o-matic	0		
-11395	normal jumbo peppermint donut	5	good	
+11395	jumbo normal peppermint donut	5	good	
 11396	scandalous Elf Guard insignia (private)	0		Sleaze Damage: +5, Last Available: "2023-12"
 11397	savvy Crimbuccaneer fledges (mint)	0		Mysticality Percent: +20, Last Available: "2023-12"
 11398	military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	spinning Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	weak bad shaking Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
+11401	bad weak shaking Crimbuccaneer mologrog cocktail	2	decent	Last Available: "2023-12"
 11402	blurry Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	blinking Crimbuccaneer lantern of the bloodbag of the storm of the glutton	0		Maximum HP: +100, Maximum MP Percent: +40, Food Drop: +100, Last Available: "2023-12"
@@ -11275,14 +11275,14 @@
 11420	healthy Crimbuccaneer tavern swab of the overflowing toilet of the cheetah	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Initiative: +60, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
 11422	drinkable blue old-school pirate grog	3	good	Last Available: "2023-12"
-11423	gigantic decent grog nuts	10	good	Last Available: "2023-12"
+11423	decent gigantic grog nuts	10	good	Last Available: "2023-12"
 11424	prompt Newton's boxer's sawed-off blunderbuss	0		Muscle Percent: +10, Experience (Mysticality): +3, Adventures: +3, Last Available: "2023-12"
 11425	perfectly mixed upside-down officer's nog	3	EPIC	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	toothsome bite-sized blurry purple sundae ration	1	awesome	Last Available: "2023-12"
+11427	bite-sized toothsome blurry purple sundae ration	1	awesome	Last Available: "2023-12"
 11428	bite-sized spoiled peppermint tack	1	crappy	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
-11430	delicious small bouncing whalesteak	2	awesome	Last Available: "2023-12"
+11430	small delicious bouncing whalesteak	2	awesome	Last Available: "2023-12"
 11431	stiffened cool beefcake's whalegun	0		Muscle: +25, Moxie: +5, Damage Reduction: 1, Last Available: "2023-12"
 11432	Cocktails of the Age of Sail	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11433	Elf Guard payroll bag	0		Last Available: "2023-12"
@@ -11307,15 +11307,15 @@
 11452	lard-coated toasty Tesla quilted sage Elf dessert spoon of the storm	0		Mysticality Percent: +10, Damage Absorption: +40, Maximum MP Percent: +40, Hot Damage: +5, Sleaze Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
 11453	ghostly dance instructor's boxer's Elf Guard SCUBA tank	0		Muscle Percent: +10, Experience Percent (Moxie): +10, Last Available: "2023-12"
 11454	Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	banded sage free boots	0		Mysticality Percent: +10, Damage Absorption: +100, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
+11455	banded sage free boots	0		Mysticality Percent: +10, Damage Absorption: +100, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
 11456	pulsating baby rigging snake	0		Last Available: "2023-12"
 11457	friendly Elvish underarmor of temperance of the glutton	0		Familiar Weight: +3, Sleaze Resistance: +5, Food Drop: +100, Single Equip, Last Available: "2023-12"
 11458	bouncing sizzling Herculean Crimbuccaneer bombjacket	0		Experience (Muscle): +1, Hot Damage: +10, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	diet adequate huge sugarplum ration	1	good	Last Available: "2023-12"
-11460	moldy miniature gingerbread nylons	2	crappy	Last Available: "2023-12"
+11460	miniature moldy gingerbread nylons	2	crappy	Last Available: "2023-12"
 11461	normal rum-soaked fruitcake	3	good	Last Available: "2023-12"
-11462	bite-sized yummy lime	1	awesome	Last Available: "2023-12"
-11463	thick adequate gingerbread pirate	5	good	Last Available: "2023-12"
+11462	yummy bite-sized lime	1	awesome	Last Available: "2023-12"
+11463	adequate thick gingerbread pirate	5	good	Last Available: "2023-12"
 11464	delicious fruit-stuffed rumcake	3	awesome	Last Available: "2023-12"
 11465	practically non-alcoholic drinkable skewed mulled wine	1	good	Last Available: "2023-12"
 11466	smooth extra-dry blurry Swedish coffee	5	awesome	Last Available: "2023-12"
@@ -11328,12 +11328,12 @@
 11473	pirate encryption key (complete)	0		Last Available: "2023-12"
 11474	bad yule grog	3	decent	Last Available: "2023-12"
 11475	stale wet tack	4	decent	Last Available: "2023-12"
-11476	gigantic flavorless whalecake	7	decent	Last Available: "2023-12"
-11477	scorching nippy wizardly gunwale whalegun	0		Mysticality: +25, Cold Damage: +10, Hot Damage: +25, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
+11476	flavorless gigantic whalecake	7	decent	Last Available: "2023-12"
+11477	scorching nippy wizardly gunwale whalegun	0		Mysticality: +25, Cold Damage: +10, Hot Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
 11478	smooth huge and claret	3	awesome	Last Available: "2023-12"
 11479	narrow gray rigging knot	0		Familiar Weight: +5
 11480	trick coin	0		Last Available: "2023-12"
-11481	boxer's Elf Guard squirtgun of the brute	0		Muscle Percent: 40, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
+11481	boxer's Elf Guard squirtgun of the brute	0		Muscle Percent: 40, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
 11482	skewed chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	sequin-encrusted sweater of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2023-12"
 11484	narrow blue occult replica Elf Guard medal of the pedagogue of the cheetah	0		Experience: +3, Spell Damage Percent: +25, Initiative: +60, Last Available: "2023-12"
@@ -11356,13 +11356,13 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	ionized super-improved tumbling military candy cane	0		Effect: "Enraged", Effect Duration: 44
 11503	extra-dry blue groggipop	0		Effect: "Aloofah", Effect Duration: 51
-11504	upside-down therapeutic moss mace of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
-11505	rosy-cheeked moss megaphone of the empath	0		Maximum HP Percent: +30, Familiar Weight: +5, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
-11506	wicked thinker's moss medal	0		Mysticality: +10, Spell Damage: +5, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
-11507	spinning ruddy moss mitre of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +40, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
-11508	zippy frightening moss mantle	0		Spooky Damage: +5, Initiative: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
+11504	upside-down therapeutic moss mace of the glutton	0		Food Drop: +100, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
+11505	rosy-cheeked moss megaphone of the empath	0		Maximum HP Percent: +30, Familiar Weight: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
+11506	wicked thinker's moss medal	0		Mysticality: +10, Spell Damage: +5, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
+11507	spinning ruddy moss mitre of James Dean	0		Experience (Moxie): +3, Maximum HP Percent: +40, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
+11508	zippy frightening moss mantle	0		Spooky Damage: +5, Initiative: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
 11509	Herculean moss marlinspike of the glutton	0		Experience (Muscle): +1, Food Drop: +100, Extra Pickpocket, Single Equip, Last Available: "2024-12"
-11510	dehydrated shaking lime green moss mulch	1		Last Available: "2024-12"
+11510	dehydrated lime green shaking moss mulch	1		Last Available: "2024-12"
 11511	ionized moss floss	0		Effect: "Fastbreaker", Effect Duration: 68
 11512	adobe arsecover	0		Last Available: "2024-12"
 11513	narrow adobe adze	0		Single Equip, Last Available: "2024-12"
@@ -11372,33 +11372,33 @@
 11517	adobe abaya	0		Last Available: "2024-12"
 11518	twisted adobe assortment	1		Last Available: "2024-12"
 11519	ionized deionized upside-down adobe brittle	0		Effect: "The Chains Down In The Belly-O", Effect Duration: 58
-11520	veiny crepe paper phrygian cap of terror of the businessman	0		Maximum HP: +10, Spooky Spell Damage: +10, Meat Drop: +50, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
+11520	veiny crepe paper phrygian cap of terror of the businessman	0		Maximum HP: +10, Spooky Spell Damage: +10, Meat Drop: +50, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
 11521	twirling baleful Newton's crepe paper parachute cape of the wise owl	0		Mysticality: +20, Experience (Mysticality): +3, Spell Damage: +25, Last Available: "2025-12"
-11522	fireproof crepe paper pie clip of chilblains of the cheetah	0		Cold Damage: +25, Hot Resistance: +3, Initiative: +60, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
-11523	sizzling shellacked crepe paper puzzle cube of Gandalf	0		Damage Reduction: 7, Spell Critical Percent: +20, Hot Damage: +10, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
-11524	purple curative crepe paper plunge camisole of the brazier of temperance	0		Hot Spell Damage: +25, Sleaze Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
-11525	Sherlock's Oprah's sage crepe paper polka charm	0		Mysticality Percent: +10, Maximum MP Percent: +50, Item Drop: +25, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
+11522	fireproof crepe paper pie clip of chilblains of the cheetah	0		Cold Damage: +25, Hot Resistance: +3, Initiative: +60, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
+11523	sizzling shellacked crepe paper puzzle cube of Gandalf	0		Damage Reduction: 7, Spell Critical Percent: +20, Hot Damage: +10, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
+11524	purple curative crepe paper plunge camisole of the brazier of temperance	0		Hot Spell Damage: +25, Sleaze Resistance: +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
+11525	Sherlock's Oprah's sage crepe paper polka charm	0		Mysticality Percent: +10, Maximum MP Percent: +50, Item Drop: +25, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
 11526	distilled olive crepe paper pared cuttings	1		Effect: "substats.enh", Effect Duration: 45, Last Available: "2025-12"
 11527	altered crepe paper peanut candy	0		Effect: "Lemon Enlightenment", Effect Duration: 36
 11528	tumbling experienced petrified wood war pike of the empath	0		Experience: +2, Familiar Weight: +5, Last Available: "2025-12"
 11529	avaricious Jeselnik's petrified wood waist protector	0		Sleaze Damage: +25, Meat Drop: +30, Single Equip, Last Available: "2025-12"
-11530	healthy petrified wood wizard's pouch of temperance	0		Maximum HP Percent: +20, Sleaze Resistance: +5, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
-11531	lard-coated petrified wood water purifier of the detective	0		Sleaze Spell Damage: +25, Item Drop: +20, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
+11530	healthy petrified wood wizard's pouch of temperance	0		Maximum HP Percent: +20, Sleaze Resistance: +5, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
+11531	lard-coated petrified wood water purifier of the detective	0		Sleaze Spell Damage: +25, Item Drop: +20, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
 11532	spinning fireproof forbidden petrified wood whoopie panama	0		Spell Damage Percent: +50, Hot Resistance: +3, Last Available: "2025-12"
 11533	huge pulsating Jim Carey's Rosewater's petrified wood walking pants	0		Mysticality Percent: +30, Monster Level: +25, Last Available: "2025-12"
 11534	dried petrified wood waste parts	1		Effect: "Gr8ness", Effect Duration: 35, Last Available: "2025-12"
 11535	Vulcanized cyan petrified wood wafer praline	0		Effect: "Oleaginous Soles", Effect Duration: 15
 11536	perfectly mixed blurry cybeer	4	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
-11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
+11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
+11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
 11540	baby chest mimic	0		Free Pull
-11541	upside-down shaking googly chest eyes	0		Familiar Weight: +5
+11541	shaking upside-down googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	huge educational slick Crimbuccaneer war standard	0		Moxie: +10, Experience: +1, Last Available: "2023-12"
 11544	aromatic sinister Elf Guard war standard	0		Spell Damage: +10, Stench Resistance: +1, Last Available: "2023-12"
 11545	ghostly in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	zippy Fonzie's spring shoes of dire peril	0		Experience (Moxie): +1, Weapon Damage: +20, Initiative: +20, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
+11546	zippy Fonzie's spring shoes of dire peril	0		Experience (Moxie): +1, Weapon Damage: +20, Initiative: +20, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
 11547	pickled irradiated upside-down ultra-soft ferns	0		Effect: "Hella Smooth", Effect Duration: 24, Last Available: "2024-02"
 11548	enhanced non-flattened lime green crunchy brush	0		Effect: "Woad Warrior", Effect Duration: 43, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11426,12 +11426,12 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	normal yam	3	good	Last Available: "2024-05"
-11574	fancy tolerable yam martini	4	good	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2024-05"
+11574	tolerable fancy yam martini	4	good	Effect: "Tingling Feeling", Effect Duration: 20, Last Available: "2024-05"
 11575	lousy distilled sweet potato o' mine	5	decent	Last Available: "2024-05"
 11576	tolerable Southern yam	3	good	Last Available: "2024-05"
-11577	weak tolerable sweet potato punch	2	good	Last Available: "2024-05"
-11578	snack-sized moldy Mayam spinach	2	crappy	Last Available: "2024-05"
-11579	normal small yam and swiss	2	good	Last Available: "2024-05"
+11577	tolerable weak sweet potato punch	2	good	Last Available: "2024-05"
+11578	moldy snack-sized Mayam spinach	2	crappy	Last Available: "2024-05"
+11579	small normal yam and swiss	2	good	Last Available: "2024-05"
 11580	wholesome hardened yam cannon of the storm	0		Damage Reduction: 3, Maximum HP Percent: +10, Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2024-05"
 11581	yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
@@ -11442,35 +11442,35 @@
 11587	normal yam slider	4	good	Last Available: "2024-05"
 11588	spoiled shaking yam mayo	3	crappy	Last Available: "2024-05"
 11589	bland yam burrito	4	decent	Last Available: "2024-05"
-11590	upside-down tumbling visual packet sniffer	0		Last Available: "2025-12"
+11590	tumbling upside-down visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
-11593	shaking squat Thwaitgold Illinigina illinoiensis model	0		
+11593	squat shaking Thwaitgold Illinigina illinoiensis model	0		
 11594	tasty mini kiwi	4	awesome	Last Available: "2024-06"
 11595	lime green horrifying frosty mini kiwi bikini of the boozehound	0		Cold Spell Damage: +10, Spooky Damage: +25, Booze Drop: +100, Last Available: "2024-06"
-11596	boozy acceptable mini kiwitini	5	good	Last Available: "2024-06"
+11596	acceptable boozy mini kiwitini	5	good	Last Available: "2024-06"
 11597	mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	rosy-cheeked mini kiwi silicon tiepin of dire peril of Calamity Jane	0		Weapon Damage: +20, Maximum HP Percent: +30, Critical Hit Percent: +15
 11600	skewed mini kiwi tipi	0		
-11601	spoiled snack-sized mini kiwi digitized cookies	2	crappy	
-11602	bad strong mini kiwi intoxicating spirits	5	decent	
+11601	snack-sized spoiled mini kiwi digitized cookies	2	crappy	
+11602	strong bad mini kiwi intoxicating spirits	5	decent	
 11603	aerosolized diffused skewed mini kiwi antimilitaristic hippy petition	0		Effect: "Granolarrrgh", Effect Duration: 64
 11604	anodized aerosolized mini kiwi illicit antibiotic	0		Effect: "Trash-Wrapped", Effect Duration: 13
 11605	medical-grade hale mini kiwi whipping stick	0		Maximum HP: +20, HP Regen Min: 7, HP Regen Max: 10
 11606	dog trainer's mini kiwi icepick	0		Experience (familiar): +1
 11607	Vulcanized modified mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Flagrantly Fragrant", Effect Duration: 34
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
+11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
 11610	tumbling protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
-11613	squat mirror protogenetic chunklet (elbow)	0		
+11613	mirror squat protogenetic chunklet (elbow)	0		
 11614	blurry protogenetic chunklet (lips)	0		
 11615	scorching vibrating messenger bag RNA of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +10, Hot Damage: +25
 11616	blue flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	diet decent bacteria bisque	1	good	
+11618	decent diet bacteria bisque	1	good	
 11619	toothsome ciliophora chowder	4	awesome	
 11620	adequate cream of chloroplasts	4	good	
 11621	synaptic soup	0		
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	upside-down Sinatra's brawny embers-only jacket of dire peril	0		Muscle Percent: +20, Experience (Moxie): +5, Weapon Damage: +20, Lasts Until Rollover, Last Available: "2024-09"
 11649	ghostly bembershoot of the storm	0		Maximum MP Percent: +40, Lasts Until Rollover, Last Available: "2024-09"
-11650	normal shaking bouncing fuchsia wheel of camembert	3	good	Last Available: "2024-09"
+11650	normal bouncing shaking fuchsia wheel of camembert	3	good	Last Available: "2024-09"
 11651	up-at-dawn stanky hat of remembering of the brute	0		Muscle Percent: +30, Stench Spell Damage: +25, Adventures: +5, Lasts Until Rollover, Last Available: "2024-09"
 11652	green throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	ghostly soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	purple boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	prompt healthy bat wings	0		Maximum HP Percent: +20, Item Drop: +5, Adventures: +3, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
+11658	prompt healthy bat wings	0		Maximum HP Percent: +20, Item Drop: +5, Adventures: +3, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
 11659	maroon ember egg	0		Last Available: "2024-09"
 11660	ghostly ember	0		Cold Resistance: +1
 11661	blinking knitted monocle on a stick of wisdom	0		Mysticality: +15, Cold Resistance: +3, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,29 +11523,29 @@
 11668	Sheriff badge of the bloodbag of courage	0		Maximum HP: +100, Spooky Resistance: +3, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	savvy brainy Sheriff pistol	0		Mysticality: +5, Mysticality Percent: +20, Lasts Until Rollover, Last Available: "2024-10"
 11670	veiny Sheriff moustache of Tarzan	0		Experience (Muscle): +3, Maximum HP: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	jittery careful forbidden photo booth supply list	0		Spell Damage Percent: +50, Monster Level: -10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
+11671	jittery careful forbidden photo booth supply list	0		Spell Damage Percent: +50, Monster Level: -10, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	blinking blurry tie-dye headband	0		
-11674	yummy enchanted tumbling whirled peas	4	awesome	Effect: "Sauce Monocle", Effect Duration: 30, Last Available: "2024-11"
-11675	special rotten jumbo narrow peaza	5	crappy	Effect: "Smoky Third Eye", Effect Duration: 5, Last Available: "2024-11"
+11674	enchanted yummy tumbling whirled peas	4	awesome	Effect: "Sauce Monocle", Effect Duration: 30, Last Available: "2024-11"
+11675	jumbo special rotten narrow peaza	5	crappy	Effect: "Smoky Third Eye", Effect Duration: 5, Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	distilled lime green drenchrome 2.0	1		Last Available: "2025-12"
-11678	compressed lime green squat Synapse Blaster	1		Last Available: "2025-12"
+11678	compressed squat lime green Synapse Blaster	1		Last Available: "2025-12"
 11679	tumbling quantized familiar	0		
 11680	quantum watch	0		Adventures: +2
 11681	quantized familiar experience	0		
 11682	deionized nitrogenated warmed tumbling pea brittle	0		Effect: "Pharmaceutically Cool", Effect Duration: 59, Last Available: "2024-11"
-11683	drinkable strong special purple peasco	5	good	Effect: "Well Owl Be!", Effect Duration: 5, Last Available: "2024-11"
+11683	drinkable special strong purple peasco	5	good	Effect: "Well Owl Be!", Effect Duration: 5, Last Available: "2024-11"
 11684	rotten massive huge piece of cake	9	crappy	Last Available: "2024-11"
 11685	blinking handful of split pea soup	0		Last Available: "2024-11"
 11686	blurry Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
 11687	TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	executive sharpshooter's deft pirate hook	0		Critical Hit Percent: +10, Meat Drop: +40, Lasts Until Rollover, Last Available: "2024-12"
-11689	Da Vinci's iron tricorn hat of the overflowing toilet	0		Experience (Mysticality): +5, Stench Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
+11689	Da Vinci's iron tricorn hat of the overflowing toilet	0		Experience (Mysticality): +5, Stench Spell Damage: +50, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
 11690	razor-sharp jolly roger flag	0		Weapon Damage Percent: +25, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	blurry pirrrate's currrse	0		Last Available: "2024-12"
-11693	fortified acceptable tankard of spiced rum	5	good	Last Available: "2024-12"
+11693	acceptable fortified tankard of spiced rum	5	good	Last Available: "2024-12"
 11694	strong lousy blinking tankard of spiced Goldschlepper	5	decent	Last Available: "2024-12"
 11695	narrow packaged luxury garment	0		Last Available: "2024-12"
 11696	teal ghostly Fonzie's governor's daughter's lace collar	0		Experience (Moxie): +1, Last Available: "2024-12"
@@ -11561,9 +11561,9 @@
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	scorching Tesla silky pirate drawers	0		Hot Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
-11709	cold-filtered Vulcanized narrow yellow ghostly peppermint pegleg	0		Effect: "Initiative and Let Die", Effect Duration: 45, Last Available: "2024-12"
-11710	drinkable extra-dry hard cocoa	5	good	Last Available: "2024-12"
-11711	moldy bite-sized salmagumdi	1	crappy	Last Available: "2024-12"
+11709	cold-filtered Vulcanized ghostly narrow yellow peppermint pegleg	0		Effect: "Initiative and Let Die", Effect Duration: 45, Last Available: "2024-12"
+11710	extra-dry drinkable hard cocoa	5	good	Last Available: "2024-12"
+11711	bite-sized moldy salmagumdi	1	crappy	Last Available: "2024-12"
 11712	plastic Easter Island Bunny of extreme caution	0		Monster Level: -25, Last Available: "2024-12"
 11713	tumbling sizzling plastic St. Patrick	0		Hot Damage: +10, Last Available: "2024-12"
 11714	nippy cool plastic Colonel Brando	0		Moxie: +5, Cold Damage: +10, Last Available: "2024-12"
@@ -11576,14 +11576,14 @@
 11721	skewed Spirit of Christmas	0		Last Available: "2024-12"
 11722	flavorless coney haunch	3	decent	Last Available: "2024-12"
 11723	pickled fuchsia tumbling dark chocolate egg	0		Effect: "Electrolit Up", Effect Duration: 67, Last Available: "2024-12"
-11724	hand-crafted practically non-alcoholic moai toai	1	EPIC	
+11724	practically non-alcoholic hand-crafted moai toai	1	EPIC	
 11725	lime green Rosewater's weightlifter's moaiball of terror	0		Muscle: +15, Mysticality Percent: +30, Spooky Spell Damage: +10, Last Available: "2024-12"
-11726	huge squat half-digested rat	0		Last Available: "2024-12"
+11726	squat huge half-digested rat	0		Last Available: "2024-12"
 11727	ionized huge bouncing four-leaf potato sprout	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 23, Last Available: "2024-12"
 11728	fortified experienced brawny potato jacket	0		Muscle Percent: +20, Experience: +2, Damage Absorption: +60, Last Available: "2024-12"
 11729	traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	Usain Bolt's military orb of the empath	0		Familiar Weight: +5, Initiative: +80, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
+11731	Usain Bolt's military orb of the empath	0		Familiar Weight: +5, Initiative: +80, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
 11732	wet rum ball	0		Effect: "Castaway Physique", Effect Duration: 23
 11733	gravy skin	0		Last Available: "2024-12"
 11734	padded razor-sharp gravyskin hat	0		Weapon Damage Percent: +25, Damage Absorption: +20, Last Available: "2024-12"
@@ -11595,7 +11595,7 @@
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
 11742	wobbly sharpshooter's Da Vinci's perfect Christmas scarf of vim and vigor	0		Experience (Mysticality): [+5*event(December)], Maximum HP Percent: [+50*event(December)], Critical Hit Percent: [+10*event(December)], Single Equip, Last Available: "2024-12"
-11743	wobbly flame-retardant snowman-enchanting tophat of the ox	0		Muscle: +20, Hot Resistance: +1, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
+11743	wobbly flame-retardant snowman-enchanting tophat of the ox	0		Muscle: +20, Hot Resistance: +1, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
 11744	modified magnetized LIDAR candle	0		Effect: "Unusual Perspective", Effect Duration: 44, Last Available: "2024-12"
 11745	Newton's Congressional Medal of Insanity of the ox of the storm	0		Muscle: +20, Experience (Mysticality): +3, Maximum MP Percent: +40, Last Available: "2024-12"
 11746	shaking pumpkin spice whorl	0		Last Available: "2024-12"
@@ -11603,14 +11603,14 @@
 11748	acceptable Irish eggnog	3	good	Last Available: "2024-12"
 11749	lousy fortified canteen of jungle juice	5	decent	Last Available: "2024-12"
 11750	perfectly mixed turchucken	4	EPIC	Last Available: "2024-12"
-11751	practically non-alcoholic delicious mechanically-mulled cider	1	awesome	Last Available: "2024-12"
+11751	delicious practically non-alcoholic mechanically-mulled cider	1	awesome	Last Available: "2024-12"
 11752	high-proof smooth holiday trip around the world	7	awesome	Last Available: "2024-12"
 11753	bland olive chocolate ostrich egg	4	decent	Last Available: "2024-12"
-11754	diet flavorless beef and cabbage	1	decent	Last Available: "2024-12"
+11754	flavorless diet beef and cabbage	1	decent	Last Available: "2024-12"
 11755	miniature normal candy rations	2	good	Last Available: "2024-12"
 11756	low-calorie spoiled ghostly double-candied yams	1	crappy	Last Available: "2024-12"
-11757	spoiled miniature cyan Christmas ham	2	crappy	Last Available: "2024-12"
-11758	rotten small huge jittery holiday smorgasbord	2	crappy	Last Available: "2024-12"
+11757	miniature spoiled cyan Christmas ham	2	crappy	Last Available: "2024-12"
+11758	rotten small jittery huge holiday smorgasbord	2	crappy	Last Available: "2024-12"
 11759	shaking Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	blue careful bejazzled eyepatch	0		Monster Level: -10, Last Available: "2024-12"
 11761	ghostly Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
@@ -11620,11 +11620,11 @@
 11765	tumbling Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
 11767	olive Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	huge red Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	red huge Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
 11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11770	shaking Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	chilly banded egg gun of Tarzan of Leguizamo	0		Experience (Muscle): +3, Damage Absorption: +100, Monster Level: +20, Cold Damage: +5, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
+11772	chilly banded egg gun of Tarzan of Leguizamo	0		Experience (Muscle): +3, Damage Absorption: +100, Monster Level: +20, Cold Damage: +5, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
 11773	upside-down foul-smelling Lo Pan's stiffened deadly army helmet	0		Weapon Damage: +5, Damage Reduction: 1, Spell Critical Percent: +30, Stench Damage: +10, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	blinking napkin	0		Last Available: "2024-12"
@@ -11636,14 +11636,14 @@
 11781	galvanized deviled candy egg	0		Effect: "License to Punch", Effect Duration: 42, Last Available: "2024-12"
 11782	upside-down McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	scorching supercharged McHugeLarge duffel bag	0		Maximum MP Percent: +30, Hot Damage: +25, Last Available: "2025-01"
-11784	narrow Socratic educational McHugeLarge left pole of the overflowing toilet	0		Experience: +1, Experience (Mysticality): +1, Stench Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
-11785	upside-down family-friendly fireproof McHugeLarge right pole of extreme caution	0		Monster Level: -25, Hot Resistance: +3, Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
-11786	medical-grade rosy-cheeked McHugeLarge left ski	0		Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
-11787	shaking quilted McHugeLarge right ski of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +40, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
+11784	narrow Socratic educational McHugeLarge left pole of the overflowing toilet	0		Experience: +1, Experience (Mysticality): +1, Stench Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
+11785	upside-down family-friendly fireproof McHugeLarge right pole of extreme caution	0		Monster Level: -25, Hot Resistance: +3, Sleaze Resistance: +1, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
+11786	medical-grade rosy-cheeked McHugeLarge left ski	0		Maximum HP Percent: +30, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
+11787	shaking quilted McHugeLarge right ski of Tarzan	0		Experience (Muscle): +3, Damage Absorption: +40, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
 11788	squat 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
 11790	boiled blue twirling eXpand	1		Effect: "Motion", Effect Duration: 40, Last Available: "2025-12"
-11791	lime green brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
+11791	lime green brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
 11792	datastick	0		Last Available: "2025-12"
 11793	maroon dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	green dedigitizer schematic: malware injector	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	blurry cybervisor	0		Last Available: "2025-12"
 11804	purple retro floppy disk	0		Last Available: "2025-12"
 11805	maroon pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	olive server room key	0		Last Available: "2025-12"
 11809	jittery 3d printed server room key	0		Last Available: "2025-12"
@@ -11667,10 +11667,10 @@
 11812	modified narrow fuchsia psilocyber mushroom	1		Last Available: "2025-12"
 11813	bouncing dedigitizer schematic: SLEEP(5) rom chip	0		Last Available: "2025-12"
 11814	dedigitizer schematic: OVERCLOCK(10) rom chip	0		Last Available: "2025-12"
-11815	squat shaking blue dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
+11815	shaking squat blue dedigitizer schematic: STATS+++ rom chip	0		Last Available: "2025-12"
 11816	dedigitizer schematic: insignificant bit	0		Last Available: "2025-12"
 11817	skewed dedigitizer schematic: hashing vise	0		Last Available: "2025-12"
-11818	spinning spinning squat dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
+11818	spinning squat spinning dedigitizer schematic: geofencing rapier	0		Last Available: "2025-12"
 11819	dedigitizer schematic: geofencing shield	0		Last Available: "2025-12"
 11820	dedigitizer schematic: virtual cybertattoo	0		Last Available: "2025-12"
 11821	huge SLEEP(5) rom chip	0		Skill: "SLEEP(5)", Last Available: "2025-12"
@@ -11679,7 +11679,7 @@
 11824	mirror insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
+11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
 11828	green geofencing shield	0		Last Available: "2025-12"
 11829	blurry virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
@@ -11705,7 +11705,7 @@
 11850	sore	0		Cold Damage: +10, Cold Spell Damage: +10
 11851	stomach churner	0		Sleaze Damage: +10, Sleaze Spell Damage: +10
 11852	wobbly phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
-11853	upside-down pulsating foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
+11853	pulsating upside-down foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
 11855	rift oculus	0		Combat Rate: +5
 11856	sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
@@ -11714,27 +11714,27 @@
 11859	mosquito speakers	0		Monster Level: +5
 11860	assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
 11861	Leprecondo	0		Last Available: "2025-03"
-11862	dried huge bouncing scoop of pre-workout powder	1		Last Available: "2025-03"
+11862	dried bouncing huge scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	bouncing table tennis ball	0		Last Available: "2025-03"
 11864	drinkable watered-down blurry pint of Leprechaun Stout	2	good	Last Available: "2025-03"
 11865	diluted jittery phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
-11867	shaking blinking Book of Irony	0		Skill: "Generate Irony"
-11868	lime green bouncing spoon	0		
+11867	blinking shaking Book of Irony	0		Skill: "Generate Irony"
+11868	bouncing lime green spoon	0		
 11869	unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	boiled twirling leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	normal Heck ramen	3	good	Last Available: "2025-03"
 11873	moldy massive burrito	6	crappy	Last Available: "2025-03"
-11874	decent massive fancy tumbling small beer brat	8	good	Effect: "Scrappy, Shadowy", Effect Duration: 25, Last Available: "2025-03"
+11874	decent fancy massive tumbling small beer brat	8	good	Effect: "Scrappy, Shadowy", Effect Duration: 25, Last Available: "2025-03"
 11875	flavorless peach pie	3	decent	Last Available: "2025-03"
-11876	enchanted jumbo flavorless incredible mini-pizza	5	decent	Effect: "How to Scam Tourists", Effect Duration: 40, Last Available: "2025-03"
-11877	enchanted watered-down hand-crafted pulsating Divine sidecar	2	EPIC	Effect: "Hot Buttoned", Effect Duration: 45, Last Available: "2025-03"
+11876	enchanted flavorless jumbo incredible mini-pizza	5	decent	Effect: "How to Scam Tourists", Effect Duration: 40, Last Available: "2025-03"
+11877	watered-down enchanted hand-crafted pulsating Divine sidecar	2	EPIC	Effect: "Hot Buttoned", Effect Duration: 45, Last Available: "2025-03"
 11878	smooth narrow tangarita sidecar	3	awesome	Last Available: "2025-03"
 11879	smooth gimlet sidecar	4	awesome	Last Available: "2025-03"
 11880	high-proof drinkable bouncing vodka stratocaster sidecar	10	good	Last Available: "2025-03"
 11881	watered-down tolerable prussian cathouse sidecar	2	good	Last Available: "2025-03"
-11882	practically non-alcoholic delicious Mon Tiki sidecar	1	awesome	Last Available: "2025-03"
+11882	delicious practically non-alcoholic Mon Tiki sidecar	1	awesome	Last Available: "2025-03"
 11883	cyan squat Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	asbestos-lined forbidden April Shower Thoughts shield	0		Spell Damage Percent: +50, Hot Resistance: +5, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	upside-down stylish bycocket of Leguizamo	0		Monster Level: +20
 11917	Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
+11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
 11920	flak shield	0		Damage Reduction: 9
 11921	Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11789,7 +11789,7 @@
 11934	orphaned baby skeleton	0		
 11935	ordnance magnet	0		Single Equip
 11936	confetti grenade	0		
-11937	toothsome miniature Skeleton Wars rations	2	awesome	
+11937	miniature toothsome Skeleton Wars rations	2	awesome	
 11938	perfectly mixed skeleton war fuel can	3	EPIC	
 11939	skeleton war grenade	0		
 11940	wobbly chocolate and nylons detector	0		
@@ -11804,7 +11804,7 @@
 11949	careful bully badge	0		Monster Level: -10, Lasts Until Rollover, Last Available: "2025-08"
 11950	mirror brawny time cop top hat	0		Muscle Percent: +20, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
-11952	diluted pulsating green mixed berry jelly	1		Last Available: "2025-08"
+11952	diluted green pulsating mixed berry jelly	1		Last Available: "2025-08"
 11953	decent toast with mixed berry jelly	3	good	Last Available: "2025-08"
 11954	snack-sized moldy cup of sugar	2	crappy	Last Available: "2025-08"
 11955	delicious narrow Susie's cupcake	3	awesome	Last Available: "2025-08"
@@ -11826,24 +11826,24 @@
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	twirling packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
-11976	jittery skewed unblemished pearl	0		
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11976	skewed jittery unblemished pearl	0		
 11977	dance instructor's dentadent	0		Experience Percent (Moxie): +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	inspector's scorching mansplainer's curative blood cubic zirconia of dire peril of doom	0		Weapon Damage: +20, Monster Level: +15, Hot Damage: +25, Spooky Spell Damage: +50, Item Drop: +15, HP Regen Min: 3, HP Regen Max: 5, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
+11987	inspector's scorching mansplainer's curative blood cubic zirconia of dire peril of doom	0		Weapon Damage: +20, Monster Level: +15, Hot Damage: +25, Spooky Spell Damage: +50, Item Drop: +15, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
 12044	denatured pulsating blood thinner	1		Effect: "Disco State of Mind", Effect Duration: 15, Last Available: "2025-10"
 12045	delicious pheromone cocktail	3	awesome	Last Available: "2025-10"
-12046	rotten fuchsia tumbling spinal tapas	3	crappy	Last Available: "2025-10"
+12046	rotten tumbling fuchsia spinal tapas	3	crappy	Last Available: "2025-10"
 12047	shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	twirling yellow gravedigger's scorching electrified shrunken head	0		Hot Damage: +25, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
+12048	twirling yellow gravedigger's scorching electrified shrunken head	0		Hot Damage: +25, Spooky Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	small peppermint-flavored sugar walking crook	0		
 12051	knucklebone	0		
 12052	bad Smoking Pope	4	decent	
 12053	rotten prize turkey	3	crappy	
-12054	altered blue narrow medicinal gruel	1		Effect: "Shrimpin' Ain't Easy", Effect Duration: 10
-12055	special moldy full-sized pumpkin pie	4	crappy	Effect: "5 Pounds Lighter", Effect Duration: 45, Last Available: "2025-11"
-12056	perfectly mixed watered-down huge skewed vodka cranberry sauce	2	super ultra EPIC	Last Available: "2025-11"
+12054	altered narrow blue medicinal gruel	1		Effect: "Shrimpin' Ain't Easy", Effect Duration: 10
+12055	moldy special full-sized pumpkin pie	4	crappy	Effect: "5 Pounds Lighter", Effect Duration: 45, Last Available: "2025-11"
+12056	watered-down perfectly mixed skewed huge vodka cranberry sauce	2	super ultra EPIC	Last Available: "2025-11"
 12057	denatured narrow yammed candy	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 19, Last Available: "2025-11"
 12058	thick adequate treasure chestnut	5	good	Last Available: "2025-12"
 12059	artisanal mulled butter rum	3	EPIC	Last Available: "2025-12"
@@ -11870,11 +11870,11 @@
 12080	devilbone flute of the cougar of the cheetah	0		Moxie: +20, Initiative: +60, Last Available: "2026-12"
 12081	devilbone rosary of extreme caution	0		Monster Level: -25, Single Equip, Last Available: "2026-12"
 12082	boiled devilbone chunks	1		Last Available: "2026-12"
-12083	Vulcanized fuchsia tumbling Gehenna tattoo	0		Effect: "Greedy Resolve", Effect Duration: 41
+12083	Vulcanized tumbling fuchsia Gehenna tattoo	0		Effect: "Greedy Resolve", Effect Duration: 41
 12116	mirror burnt incisor	0		Last Available: "2025-12"
 12117	upside-down burnt phalange	0		Last Available: "2025-12"
 12118	squat burnt radius	0		Last Available: "2025-12"
-12119	upside-down blurry burnt rib	0		Last Available: "2025-12"
+12119	blurry upside-down burnt rib	0		Last Available: "2025-12"
 12120	burnt skull	0		Last Available: "2025-12"
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	energetic extra-thick Crimbo sweater	0		Maximum MP Percent: +20, Last Available: "2025-12"
@@ -11889,14 +11889,14 @@
 12131	alkaline purple boiling synovial fluid	0		Effect: "Ichorous Intensity", Effect Duration: 11, Last Available: "2025-12"
 12132	dangerous deadly groovy smoldering vertebra	0		Moxie Percent: +10, Weapon Damage: 15, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
 12135	smoldering bone dust	0		Last Available: "2025-12"
 12136	yellow volatile bone bomb	0		Last Available: "2025-12"
 12137	lion tamer's Van der Graaf beefy hot boning knife	0		Muscle: +10, Experience (familiar): +2, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12138	auspicious foul-smelling Socratic fistbone	0		Experience (Mysticality): +1, Stench Damage: +10, Item Drop: +10, Last Available: "2025-12"
 12139	censurious friendly extremely unsafe burnt bone belt	0		Weapon Damage Percent: +100, Familiar Weight: +3, Sleaze Resistance: +3, Single Equip, Last Available: "2025-12"
 12140	scorched skull trophy of the cheetah	0		Initiative: +60, Last Available: "2025-12"
-12141	tiny moldy wing bone	1	crappy	Last Available: "2025-12"
+12141	moldy tiny wing bone	1	crappy	Last Available: "2025-12"
 12142	watered-down artisanal blue weak skeleton venom	2	EPIC	Last Available: "2025-12"
 12143	twisted twirling baked bone meal	1		Last Available: "2025-12"
 12144	resourceful plastic skeleton rib cage	0		Maximum MP: +50, Last Available: "2025-12"
@@ -11927,7 +11927,7 @@
 12169	ship's lantern of wisdom	0		Mysticality: +15, Last Available: "2025-12"
 12170	Socratic stylish heat-resistant harpoon pistol	0		Moxie: +25, Experience (Mysticality): +1, Last Available: "2025-12"
 12171	low-calorie yummy spinning traditional gingerloaf	1	awesome	Last Available: "2025-12"
-12172	weak tolerable Scotch and eggnog	2	good	Last Available: "2025-12"
+12172	tolerable weak Scotch and eggnog	2	good	Last Available: "2025-12"
 12173	quadruple-pickled jittery counterskeleton elixir	0		Effect: "Serendipi Tea", Effect Duration: 62, Last Available: "2025-12"
 12174	perfectly mixed irresponsibly strong &quot;salvaged&quot; wine	8	EPIC	Last Available: "2025-12"
 12175	wobbly The Encyclopedia of Holiday Funerary Rites (used)	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	nitrogenated ghostly gummi fingerbone	0		Effect: "Strange Mental Acuity", Effect Duration: 65
 12179	forbidden savvy glimmering crystal	0		Mysticality Percent: +20, Spell Damage Percent: +50, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
 12182	shaking Thwaitgold meat bee statuette	0		
 12183	blurry loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11979,19 +11979,19 @@
 12225	legendary noodles	0		Last Available: "2026-05"
 12226	stale can of tuna	3	decent	
 12227	decent alien salad	3	good	
-12228	thick moldy ratbatatouille	5	crappy	
+12228	moldy thick ratbatatouille	5	crappy	
 12229	decent shaking onigiri	3	good	
-12230	adequate bite-sized crudit&eacute;s	1	good	
+12230	bite-sized adequate crudit&eacute;s	1	good	
 12231	spoiled half-sized sauced mutton	2	crappy	
-12232	stale low-calorie purple hot honey ant	1	decent	
-12233	bland blinking fuchsia tomb aspic	4	decent	
+12232	low-calorie stale purple hot honey ant	1	decent	
+12233	bland fuchsia blinking tomb aspic	4	decent	
 12234	yummy jittery later tots	3	awesome	
 12235	moldy pulsating Frutti di Scatoletta	3	crappy	Last Available: "2026-05"
 12236	thick moldy Pesto alla Marziano	5	crappy	Last Available: "2026-05"
-12237	flavorless fancy upside-down Arrattabbattabiata	4	decent	Effect: "Raging Animal", Effect Duration: 35, Last Available: "2026-05"
+12237	fancy flavorless upside-down Arrattabbattabiata	4	decent	Effect: "Raging Animal", Effect Duration: 35, Last Available: "2026-05"
 12238	massive normal teal Orzo di Riso	8	good	Last Available: "2026-05"
 12239	bland Pasta Grimavera	3	decent	Last Available: "2026-05"
-12240	moldy half-sized mirror Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
+12240	half-sized moldy mirror Linguini Ubriacapa	2	crappy	Last Available: "2026-05"
 12241	fancy bland miniature Formica e Pepe	2	decent	Effect: "Natural 20", Effect Duration: 5, Last Available: "2026-05"
 12242	decent Tubetto Gelatto	3	good	Last Available: "2026-05"
 12243	spoiled Gnocci Domani	3	crappy	Last Available: "2026-05"
@@ -12000,7 +12000,7 @@
 12246	yellow shaking second-hand synthetic sloth skin scabbard	0		Familiar Weight: +5
 12248	mega helmet	0		
 12252	razor-sharp Space Soldier Helmet of the cheetah	0		Weapon Damage Percent: +25, Initiative: +60
-12253	half-sized decent premium turkey leg	2	good	
+12253	decent half-sized premium turkey leg	2	good	
 12254	tolerable styrofoam cup of mead	3	good	
 12255	Samson's sword	0		Experience (Muscle): +5
 12256	hale staff	0		Maximum HP: +20
@@ -12017,18 +12017,18 @@
 12267	nippy flimsy plastic breastplate	0		Cold Damage: +10
 12268	toasty flimsy plastic shield	0		Hot Damage: +5, Damage Reduction: 3
 12269	narrow packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	zippy foul-smelling Portable Laughing Stock	0		Stench Damage: +10, Item Drop: +5, Initiative: +20, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
+12270	zippy foul-smelling Portable Laughing Stock	0		Stench Damage: +10, Item Drop: +5, Initiative: +20, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
 12271	spinning crafty Staff of Anachronistic Churning of the cougar of temperance	0		Moxie: +20, Maximum MP: +10, Sleaze Resistance: +5
 12272	moldy pulsating classic banana	4	crappy	Last Available: "2026-07"
-12273	fancy bland watermelon	3	decent	Effect: "Dirty Pear", Effect Duration: 45, Last Available: "2026-07"
-12274	small rotten quince	2	crappy	Last Available: "2026-07"
+12273	bland fancy watermelon	3	decent	Effect: "Dirty Pear", Effect Duration: 45, Last Available: "2026-07"
+12274	rotten small quince	2	crappy	Last Available: "2026-07"
 12275	olive Interesting Coin	0		Last Available: "2026-08"
 12276	spinning Interesting Coin Inheritance Letter	0		Free Pull, Last Available: "2026-08"
 12277	spoiled classic banana pie	3	crappy	Last Available: "2026-07"
 12278	ionized deionized altered essential banana decoction	0		Effect: "Mer-kinny Flavor", Effect Duration: 49, Last Available: "2026-07"
 12279	altered tumbling banana quintessence	0		Effect: "Sparkly!", Effect Duration: 40, Last Available: "2026-07"
 12280	drinkable skewed Aesop Daiquiri	4	good	Last Available: "2026-07"
-12281	delicious practically non-alcoholic pulsating Monkey Congress	1	awesome	Last Available: "2026-07"
+12281	practically non-alcoholic delicious pulsating Monkey Congress	1	awesome	Last Available: "2026-07"
 12282	spoiled watermelon pie	3	crappy	Last Available: "2026-07"
 12283	quadruple-flattened magnetized mirror concentrated watermelon juice	0		Effect: "Chalky White Pallor", Effect Duration: 46, Last Available: "2026-07"
 12284	galvanized yellow Aqua Citrulanatae	0		Effect: "Mayeaugh", Effect Duration: 11, Last Available: "2026-07"
@@ -12038,8 +12038,8 @@
 12288	energized improved quince quaff	0		Effect: "20/20 Vision", Effect Duration: 30, Last Available: "2026-07"
 12289	wet pickled Quickquince	0		Effect: "The Halls of Mysticality", Effect Duration: 63, Last Available: "2026-07"
 12290	tolerable Quiskey Sour	4	good	Last Available: "2026-07"
-12291	bad practically non-alcoholic Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
-12292	practically non-alcoholic tolerable Roth IPA	1	good	Last Available: "2026-08"
+12291	practically non-alcoholic bad Quincea&ntilde;era Cooler	1	decent	Last Available: "2026-07"
+12292	tolerable practically non-alcoholic Roth IPA	1	good	Last Available: "2026-08"
 12293	medical-grade brawny underdraft protection	0		Muscle Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
 12295	bite-sized adequate soybean futures	1	good	Last Available: "2026-08"

--- a/data/TCRS/TCRS_Turtle_Tamer_Vole_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Vole_cafe_booze.txt
@@ -1,9 +1,9 @@
--1	boozy tolerable Petite Porter	5	good	
--2	watered-down artisanal Scrawny Stout	2	EPIC	
+-1	tolerable boozy Petite Porter	5	good	
+-2	artisanal watered-down Scrawny Stout	2	EPIC	
 -3	bad pulsating Infinitesimal IPA	3	decent	
 -4	bad eggnogtini	4	decent	
 -5	mediocre spirit-forward blue candycaine	5	decent	
--6	perfectly mixed weak braincracker sweet	2	EPIC	
+-6	weak perfectly mixed braincracker sweet	2	EPIC	
 -16	acceptable fermented honey	4	good	
 -17	lousy moons-shine	3	decent	
 -18	perfectly mixed gin	3	EPIC	
@@ -13,21 +13,21 @@
 -49	lousy Cyder	3	decent	
 -50	bad Oil Nog	3	decent	
 -51	acceptable Hi-Octane Peppermint Jet Fuel	3	good	
--58	delicious weak Grimacider	2	awesome	
+-58	weak delicious Grimacider	2	awesome	
 -59	bad watered-down jittery Isotope Nog	2	decent	
 -60	smooth twirling Mutagin 'n' Tonic	3	awesome	
 -70	aged irresponsibly strong Gin and Herring	9	awesome	
 -71	perfectly mixed teal ghostly Black and Tan and Red All Over	4	EPIC	
 -72	hand-crafted special squat Antarctic Ice Tea	3	EPIC	
--76	weak delicious twirling CRIMBCO Ribbon Candy Schnapps	2	awesome	
+-76	delicious weak twirling CRIMBCO Ribbon Candy Schnapps	2	awesome	
 -77	lousy CRIMBCO Egg Substitute Nog Substitute	4	decent	
 -78	artisanal CRIMBCO Extreme Braincracker Sour	3	EPIC	
 -82	tolerable Horseradish-infused Vodka	4	good	
 -83	high-proof mediocre Jerkitini	8	decent	
--84	smooth practically non-alcoholic Desert Island Iced Tea	1	awesome	
--88	tolerable pulsating blinking Crimbo Saketini	3	good	
--89	practically non-alcoholic perfectly mixed Crimboku Drop	1	EPIC	
+-84	practically non-alcoholic smooth Desert Island Iced Tea	1	awesome	
+-88	tolerable blinking pulsating Crimbo Saketini	3	good	
+-89	perfectly mixed practically non-alcoholic Crimboku Drop	1	EPIC	
 -90	mediocre Flaming Crimbo Log	4	decent	
 -107	spirit-forward delicious Fortified Eggnog Slurry	5	awesome	
--108	strong special perfectly mixed huge Hot Buttered Rum	5	EPIC	
+-108	special perfectly mixed strong huge Hot Buttered Rum	5	EPIC	
 -109	fancy aged olive Spicy Hot Chocolate	3	awesome	

--- a/data/TCRS/TCRS_Turtle_Tamer_Vole_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Vole_cafe_food.txt
@@ -1,15 +1,15 @@
--1	super-sized flavorless Peche a la Frog	5	decent	
--2	miniature adequate As Jus Gezund Heit	2	good	
+-1	flavorless super-sized Peche a la Frog	5	decent	
+-2	adequate miniature As Jus Gezund Heit	2	good	
 -3	rotten pulsating Bouillabaise Coucher Avec Moi	3	crappy	
--7	small toothsome gumdrop chow mein	2	awesome	
+-7	toothsome small gumdrop chow mein	2	awesome	
 -8	half-sized rotten candy cane pizza	2	crappy	
 -9	moldy twirling gingerbread stir-fry	4	crappy	
--10	rotten thick blue twigs and gravel	5	crappy	
--11	normal thick shoots and leaves	5	good	
--12	gigantic bland bowl of unidentifiable goo	9	decent	
--13	thick special flavorless gingerbread massacre	5	decent	
--14	spoiled yellow blurry It Came From Beyond Dessert	3	crappy	
--15	moldy big vampire cake	5	crappy	
+-10	thick rotten blue twigs and gravel	5	crappy	
+-11	thick normal shoots and leaves	5	good	
+-12	bland gigantic bowl of unidentifiable goo	9	decent	
+-13	flavorless thick special gingerbread massacre	5	decent	
+-14	spoiled blurry yellow It Came From Beyond Dessert	3	crappy	
+-15	big moldy vampire cake	5	crappy	
 -52	adequate Soylent Red and Green	4	good	
 -53	rotten jumbo red Disc-Shaped Nutrition Unit	5	crappy	
 -54	tasty twirling Gingerborg Hive	4	awesome	
@@ -21,19 +21,19 @@
 -69	stale ghostly Red Herring Velvet Cake	3	decent	
 -73	normal CRIMBCO Reconstituted Gruel	3	good	
 -74	flavorless maroon New and Improved CRIMBCO Reconstituted Gruel	4	decent	
--75	yummy bite-sized tumbling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	awesome	
+-75	bite-sized yummy tumbling CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	1	awesome	
 -79	toothsome ghostly Brussels Sprout Stir-Fry	3	awesome	
 -80	delicious Carrot, Cabbage, and Kale Pizza	3	awesome	
 -81	tasty Turnip and Rutabaga Pie	3	awesome	
 -85	bland Rainbow Spider Fun Roll	3	decent	
--86	spoiled low-calorie cyan Vegas Volcano Lava Roll	1	crappy	
+-86	low-calorie spoiled cyan Vegas Volcano Lava Roll	1	crappy	
 -87	stale wobbly Crazy Dragon Shogun Buddha Roll	3	decent	
 -92	low-calorie flavorless basic hot dog	1	decent	
 -93	flavorless immense savage macho dog	6	decent	
--94	snack-sized decent squat one with everything	2	good	
+-94	decent snack-sized squat one with everything	2	good	
 -95	decent sly dog	4	good	
--96	huge spoiled devil dog	6	crappy	
--97	small adequate red chilly dog	2	good	
+-96	spoiled huge devil dog	6	crappy	
+-97	adequate small red chilly dog	2	good	
 -98	normal special ghost dog	3	good	
 -99	rotten junkyard dog	3	crappy	
 -100	rotten wet dog	3	crappy	

--- a/data/TCRS/TCRS_Turtle_Tamer_Wallaby.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wallaby.txt
@@ -10,9 +10,9 @@
 10	shaking disco ball	0		
 11	pulsating stolen accordion	0		Song Duration: 5
 12	mariachi pants	0		Familiar Effect: "8xPotato, cap 2"
-14	boiled blinking mirror moxie weed	1		Effect: "Twenty-three Squid, Ew", Effect Duration: 50
-15	boiled wobbly upside-down strongness elixir	1		
-16	dried shaking upside-down magicalness-in-a-can	1		Effect: "Heart Aflame", Effect Duration: 10
+14	boiled mirror blinking moxie weed	1		Effect: "Twenty-three Squid, Ew", Effect Duration: 50
+15	boiled upside-down wobbly strongness elixir	1		
+16	dried upside-down shaking magicalness-in-a-can	1		Effect: "Heart Aflame", Effect Duration: 10
 17	decent half-sized huge noodles	2	good	
 18	tortoise's blessing	0		
 19	green Van der Graaf asparagus knife	0		MP Regen Min: 5, MP Regen Max: 7
@@ -37,12 +37,12 @@
 38	banded Knob Goblin pants	0		Damage Absorption: +100, Familiar Effect: "atk, 5xPotato, cap 6"
 39	pretty flower	0		
 40	casino pass	0		
-41	artisanal fancy ice-cold Sir Schlitz	3	EPIC	Effect: "Muscularrr", Effect Duration: 25
+41	fancy artisanal ice-cold Sir Schlitz	3	EPIC	Effect: "Muscularrr", Effect Duration: 25
 42	squat hermit permit	0		
 43	narrow gray worthless trinket	0		
 44	worthless gewgaw	0		
 45	worthless knick-knack	0		
-46	tumbling green figurine	0		
+46	green tumbling figurine	0		
 47	bland hot buttered roll	3	decent	
 48	heart of rock and roll	0		
 49	adequate bowl of cottage cheese	3	good	
@@ -101,7 +101,7 @@
 102	shrunken head	0		
 103	tumbling blinking wicked Newton's staff	0		Experience (Mysticality): +3, Spell Damage: +5
 104	scarecrow	0		
-105	tiny decent ghostly bowl of charms	1	good	
+105	decent tiny ghostly bowl of charms	1	good	
 106	ketchup	1	good	
 107	narrow catsup	1	crappy	
 108	stick	0		
@@ -129,7 +129,7 @@
 130	spinning slick eyepatch	0		Moxie: +10, Familiar Effect: "4xBarrr, cap 8"
 131	frilly skirt	0		Familiar Effect: "4xFairy, cap 8"
 132	spinning Meat maid body	0		
-133	spinning teal squat Certificate of Participation	0		
+133	spinning squat teal Certificate of Participation	0		
 134	narrow bitchin' meatcar	0		
 135	blinking sweet rims	0		
 136	gray tires	0		
@@ -176,7 +176,7 @@
 177	brainy skull	0		
 178	detective skull	0		
 179	spoiled chorizo taco	3	crappy	
-180	acceptable huge cyan ice-cold fotie	4	good	
+180	acceptable cyan huge ice-cold fotie	4	good	
 181	baseball	0		
 182	mirror batgut	0		
 183	bat wing	0		
@@ -199,7 +199,7 @@
 201	normal bat wing kabob	3	good	
 202	adequate upside-down carob chunks	3	good	
 203	herbs	0		
-204	adequate miniature carob chunk cookies	2	good	
+204	miniature adequate carob chunk cookies	2	good	
 205	blurry secret blend of herbs and spices	0		
 206	piercing post	0		
 207	hippy herbal tea	1	good	
@@ -207,11 +207,11 @@
 209	blinking wad of tofu	0		
 210	Feng Shui for Big Dumb Idiots	0		
 211	olive decorative fountain	0		
-212	maroon pulsating windchimes	0		
+212	pulsating maroon windchimes	0		
 213	purple supercharged Da Vinci's filthy corduroys	0		Experience (Mysticality): +5, Maximum MP Percent: +30, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	cool filthy knitted dread sack	0		Moxie: +5, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	fancy normal bite-sized squat carob brownies	1	good	Effect: "Space Tripping", Effect Duration: 10
+216	bite-sized normal fancy squat carob brownies	1	good	Effect: "Space Tripping", Effect Duration: 10
 217	moldy diet herb brownies	1	crappy	
 218	hemp string	0		
 219	necklace chain	0		
@@ -220,7 +220,7 @@
 222	phat turquoise bead	0		
 223	brawny phat turquoise bracelet	0		Muscle Percent: +20
 224	jittery frightening eyepatch	0		Spooky Damage: +5, Familiar Effect: "3xBarrr, cap 6"
-225	stale bite-sized tofu casserole	1	decent	
+225	bite-sized stale tofu casserole	1	decent	
 226	altered wobbly can of Red Minotaur	1	crappy	
 227	Kentucky-fried meat sword of the businessman	0		Meat Drop: +50
 228	red Sinatra's Kentucky-fried meat staff	0		Experience (Moxie): +5
@@ -232,32 +232,32 @@
 234	Doc Galaktik's Homeopathic Elixir	0		
 235	therapeutic Bigger Bugfinder Blade of chilblains	0		Cold Damage: +25, HP Regen Min: 5, HP Regen Max: 7
 236	wobbly Queue Du Coq cocktailcrafting kit	0		
-237	perfectly mixed weak huge bottle of gin	2	EPIC	
+237	weak perfectly mixed huge bottle of gin	2	EPIC	
 238	mediocre irresponsibly strong enchanted tumbling blinking bottle of vodka	10	decent	Effect: "Frostbeard", Effect Duration: 15
 239	censurious asbestos-lined Orcish baseball cap	0		Hot Resistance: +5, Sleaze Resistance: +3, Familiar Effect: "1xVolley, 1xBarrr, cap 15"
 240	greedy steel-toed Orcish cargo shorts	0		Damage Reduction: 9, Meat Drop: +20, Familiar Effect: "sleaze atk, 2xGhuol, cap 15"
 241	resourceful Orcish frat-paddle	0		Maximum MP: +50
 242	normal	4	good	
 243	flavorless maroon grapefruit	3	decent	
-244	small flavorless grapes	2	decent	
-245	massive bland olive	9	decent	
-246	miniature rotten tomato	2	crappy	
+244	flavorless small grapes	2	decent	
+245	bland massive olive	9	decent	
+246	rotten miniature tomato	2	crappy	
 247	fermenting powder	0		
-248	practically non-alcoholic hand-crafted fancy salty dog	1	EPIC	Effect: "Craft Tea", Effect Duration: 45
-249	special acceptable strong bloody mary	5	good	Effect: "Voracious Gorging", Effect Duration: 25
-250	smooth practically non-alcoholic special screwdriver	1	awesome	Effect: "Hammertime", Effect Duration: 35
+248	practically non-alcoholic fancy hand-crafted salty dog	1	EPIC	Effect: "Craft Tea", Effect Duration: 45
+249	acceptable special strong bloody mary	5	good	Effect: "Voracious Gorging", Effect Duration: 25
+250	smooth special practically non-alcoholic screwdriver	1	awesome	Effect: "Hammertime", Effect Duration: 35
 251	fortified aged twirling martini	5	awesome	
-252	extra-dry aged bloody beer	5	awesome	
+252	aged extra-dry bloody beer	5	awesome	
 253	bad shot of schnapps	3	decent	
-254	watered-down bad shot of grapefruit schnapps	2	decent	
+254	bad watered-down shot of grapefruit schnapps	2	decent	
 255	tolerable strong fine wine	5	good	
-256	special extra-dry lousy shot of tomato schnapps	5	decent	Effect: "Slightly Mutated", Effect Duration: 25
+256	lousy special extra-dry shot of tomato schnapps	5	decent	Effect: "Slightly Mutated", Effect Duration: 25
 257	artisanal extra-spicy bloody mary	3	EPIC	
 258	dense meat stack	0		
 259	snake skin	0		
-260	moldy tumbling twirling White Citadel fries	3	crappy	
-261	spoiled tiny White Citadel burger	1	crappy	
-262	fancy yummy piece of wedding cake	4	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 40
+260	moldy twirling tumbling White Citadel fries	3	crappy	
+261	tiny spoiled White Citadel burger	1	crappy	
+262	yummy fancy piece of wedding cake	4	awesome	Effect: "The Chains Down In The Belly-O", Effect Duration: 40
 263	decent chocolate chips	4	good	
 264	normal chocolate chip cookies	4	good	
 265	Annie Oakley's satin pants	0		Critical Hit Percent: +20, Familiar Effect: "atk, 2xPotato, cap 10"
@@ -268,7 +268,7 @@
 270	picket fence	0		
 271	modified barbell	1		
 272	pickled maroon pulsating concentrated magicalness pill	1		
-273	dried mirror blinking bouncing moxie weed	1		
+273	dried bouncing blinking mirror moxie weed	1		
 274	lime green Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
 276	tumbling squat leprechaun hatchling	0		
@@ -312,12 +312,12 @@
 314	decent blinking bean burrito	4	good	
 315	small delicious cyan bean burrito	2	awesome	
 316	delicious insanely bean burrito	3	awesome	
-317	snack-sized bland purple bean burrito	2	decent	
+317	bland snack-sized purple bean burrito	2	decent	
 318	normal bean burrito	3	good	
-319	tasty small insanely bean burrito	2	awesome	
+319	small tasty insanely bean burrito	2	awesome	
 320	bland bat haggis	3	decent	
-321	toothsome small olive upside-down menudo	2	awesome	
-322	massive moldy goat cheese	7	crappy	
+321	small toothsome upside-down olive menudo	2	awesome	
+322	moldy massive goat cheese	7	crappy	
 323	tasty maroon plain pizza	3	awesome	
 324	stale sausage pizza	3	decent	
 325	yummy jittery blinking goat cheese pizza	4	awesome	
@@ -339,7 +339,7 @@
 341	modified magnetized electrified bouncing bouncing Knob Goblin love potion	0		Effect: "One Foot Heavier", Effect Duration: 30
 342	Knob Goblin stink bomb	0		
 343	unsweetened Knob Goblin sharpening spray	0		Effect: "Cool Spirit", Effect Duration: 51
-344	mirror narrow Knob Goblin seltzer	0		
+344	narrow mirror Knob Goblin seltzer	0		
 345	Knob Goblin superseltzer	0		
 346	scrumptious reagent	0		
 347	Dyspepsi-Cola	0		
@@ -362,7 +362,7 @@
 364	asbestos ore	0		
 365	chrome ore	0		
 366	pulsating shaking linoleum sword hilt	0		
-367	blinking jittery linoleum stick	0		
+367	jittery blinking linoleum stick	0		
 368	linoleum crossbow string	0		
 369	tumbling asbestos sword hilt	0		
 370	pulsating olive asbestos stick	0		
@@ -451,7 +451,7 @@
 453	olive sober pill	0		
 454	screwdriver	0		
 455	tiny rotten jumbo olive	1	crappy	
-456	watered-down special perfectly mixed dry martini	2	EPIC	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35
+456	special watered-down perfectly mixed dry martini	2	EPIC	Effect: "Blessing of the Pervy Noodles", Effect Duration: 35
 457	spinning ye olde golde frontes of doom	0		Spooky Spell Damage: +50, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
 459	jittery pixel	0		
@@ -459,14 +459,14 @@
 461	jittery pixel	0		
 462	pixel	0		
 463	skewed pixel	0		
-464	tumbling fuchsia pixel potion	0		
+464	fuchsia tumbling pixel potion	0		
 465	lime green pixel potion	0		
 466	pixel potion	0		
-467	bite-sized toothsome blurry pixel pie	1	awesome	
+467	toothsome bite-sized blurry pixel pie	1	awesome	
 468	wobbly ruby W	0		
 469	wussiness potion	0		
 470	acceptable Imp Ale	4	good	
-471	fancy bland hot wing	4	decent	Effect: "Gr8ness", Effect Duration: 50
+471	bland fancy hot wing	4	decent	Effect: "Gr8ness", Effect Duration: 50
 472	pulsating healthy diamond-studded cane	0		Maximum HP Percent: +20, Class: "Disco Bandit"
 473	foul-smelling crutch	0		Stench Damage: +10
 474	cast	0		
@@ -476,7 +476,7 @@
 478	wobbly evil arch	0		
 479	dodecagram	0		
 480	box of birthday candles	0		
-481	ghostly purple eldritch butterknife	0		
+481	purple ghostly eldritch butterknife	0		
 482	veiny Mr. Container	0		Maximum HP: +10, Last Available: "2004-12"
 483	narrow toasty Newbiesport&trade; backpack	0		Hot Damage: +5, Last Available: "2004-12"
 484	twirling twirling hemp backpack of dire peril	0		Weapon Damage: +20, Last Available: "2004-12"
@@ -488,12 +488,12 @@
 490	Jim Carey's Da Vinci's mesh cap	0		Experience (Mysticality): +5, Monster Level: +25, Familiar Effect: "atk, 1xVolley, cap 41"
 491	enormous belt buckle	0		
 492	bouncing asbestos-lined hale chaps	0		Maximum HP: +20, Hot Resistance: +5, Familiar Effect: "sleaze atk, 1xBarrr, cap 40"
-493	spinning red ketchup hound	0		
+493	red spinning ketchup hound	0		
 494	sage batblade	0		Mysticality Percent: +10
 495	catgut	0		
 496	cat appendix	0		
 497	gnatwing	0		
-498	moldy fancy papaya	3	crappy	Effect: "Dexteri Tea", Effect Duration: 25
+498	fancy moldy papaya	3	crappy	Effect: "Dexteri Tea", Effect Duration: 25
 499	fortified denim axe of the overflowing toilet	0		Damage Absorption: +60, Stench Spell Damage: +50
 500	Elf Farm Raffle ticket	0		
 501	decent Elfin shortbread	4	good	
@@ -501,16 +501,16 @@
 503	yummy skewered cat appendix	3	awesome	
 504	squat evil arches	0		
 505	olive lion tamer's gnatwing earring of the ox	0		Muscle: +20, Experience (familiar): +2
-506	normal big Hell broth	5	good	
+506	big normal Hell broth	5	good	
 507	spinning censurious thunderrr guitarrr	0		Sleaze Resistance: +3
 508	sonata	0		
 509	Hey Deze nuts	0		
 510	Boris's key lime	0		
 511	spinning Jarlsberg's key lime	0		
 512	narrow Sneaky Pete's key lime	0		
-513	miniature yummy Boris's key lime pie	2	awesome	
+513	yummy miniature Boris's key lime pie	2	awesome	
 514	stale Jarlsberg's key lime pie	3	decent	
-515	bland super-sized Sneaky Pete's key lime pie	5	decent	
+515	super-sized bland Sneaky Pete's key lime pie	5	decent	
 516	Hey Deze map	0		
 517	asbestos-lined bejeweled accordion strap	0		Hot Resistance: +5, Class: "Accordion Thief"
 518	mystery juice	0		
@@ -535,12 +535,12 @@
 537	pr0n legs	0		
 538	f3d0r4 of Leguizamo	0		Monster Level: +20, Familiar Effect: "atk, 1xLep, cap 27"
 539	fuchsia wobbly lowercase N	0		
-540	moist spinning wobbly Tasty Fun Good rice candy	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 69
+540	moist wobbly spinning Tasty Fun Good rice candy	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 69
 541	twirling Jim Carey's Newton's draggin' ball hat	0		Experience (Mysticality): +3, Monster Level: +25, Familiar Effect: "atk, 1xVolley, cap 25"
 542	fuchsia fireproof 1337 7r0uZ0RZ of incineration	0		Hot Spell Damage: +50, Hot Resistance: +3, Familiar Effect: "2xPotato, cap 27"
 543	tasty massive Trollhouse cookies	9	awesome	
 544	brawny boxer's talons	0		Muscle Percent: 30
-545	delicious huge upside-down Spam Witch sammich	10	awesome	
+545	huge delicious upside-down Spam Witch sammich	10	awesome	
 546	teal meat vortex	0		
 547	334 scroll	0		
 548	668 scroll	0		
@@ -553,9 +553,9 @@
 555	skewed miser's drywall axe of the cheetah	0		Meat Drop: +10, Initiative: +60
 556	mirror lard-coated Pine-Fresh air freshener	0		Sleaze Spell Damage: +25
 557	acceptable whiskey and cola	3	good	
-558	stale bite-sized papaya taco	1	decent	
+558	bite-sized stale papaya taco	1	decent	
 559	twirling razor-sharp can lid	0		
-560	miniature delicious stalk of asparagus	2	awesome	
+560	delicious miniature stalk of asparagus	2	awesome	
 561	bouncing pregnant mushroom	0		
 562	green ratgut	0		
 563	jittery sonar-in-a-biscuit	0		
@@ -566,10 +566,10 @@
 568	flavorless bite-sized yellow Double Bacon Beelzeburger	1	decent	
 569	normal Lord of the Flies-sized fries	3	good	
 570	moldy small Chicken Sandwich	2	crappy	
-571	blurry cyan Jumbo Dr. Lucifer	1	crappy	
+571	cyan blurry Jumbo Dr. Lucifer	1	crappy	
 572	spoiled Children's Meal of the Damned	3	crappy	
-573	adequate ghostly upside-down skewed noodles	3	good	
-574	rotten diet noodles	1	crappy	
+573	adequate upside-down skewed ghostly noodles	3	good	
+574	diet rotten noodles	1	crappy	
 575	spoiled painful penne pasta	3	crappy	
 576	snack-sized flavorless purple ravioli della hippy	2	decent	
 577	bland pr0n m4nic0tti	3	decent	
@@ -578,14 +578,14 @@
 580	sauce of the ages	0		
 581	schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
-583	diet yummy fettucini Inconnu	1	awesome	
+583	yummy diet fettucini Inconnu	1	awesome	
 584	decent ghostly spaghetti with Skullheads	4	good	
-585	special flavorless gnocchetti di Nietzsche	3	decent	Effect: "Fever From the Flavor", Effect Duration: 25
+585	flavorless special gnocchetti di Nietzsche	3	decent	Effect: "Fever From the Flavor", Effect Duration: 25
 586	blurry asbestos-lined ridiculously huge sword of the cheetah	0		Hot Resistance: +5, Initiative: +60
-587	liquefied colloidal huge shaking super-spiky hair gel	0		Effect: "Worth Your Salt", Effect Duration: 50
+587	liquefied colloidal shaking huge super-spiky hair gel	0		Effect: "Worth Your Salt", Effect Duration: 50
 588	soft echo eyedrop antidote	0		
 589	toothsome miniature mirror cocoa eggshell fragment	2	awesome	
-590	stale special bite-sized twirling cocoa eggshell fragment	1	decent	Effect: "Christmessy", Effect Duration: 25
+590	bite-sized special stale twirling cocoa eggshell fragment	1	decent	Effect: "Christmessy", Effect Duration: 25
 591	maroon cocoa egg	0		
 592	house	0		
 593	bouncing phonics down	0		
@@ -615,7 +615,7 @@
 617	ionized anodized blinking Angry Farmer candy	0		Effect: "The Spy Who Loved XP", Effect Duration: 56
 618	electrified Mick's IcyVapoHotness Rub	0		Effect: "Lit Up", Effect Duration: 14
 619	needle of extreme caution	0		Monster Level: -25
-620	magnetized diffused narrow twirling blue thin candle	0		Effect: "Chain Chain Chains", Effect Duration: 12
+620	magnetized diffused twirling narrow blue thin candle	0		Effect: "Chain Chain Chains", Effect Duration: 12
 621	Warm Subject gift certificate	0		
 622	huge pulsating awful poetry journal	0		
 623	huge WA	0		
@@ -634,13 +634,13 @@
 636	pulsating meat globe	0		
 637	huge toaster	0		
 638	purple mirror hale sage asshat	0		Mysticality Percent: +10, Maximum HP: +20, Familiar Effect: "stench atk, 1xVolley, cap 7"
-639	miniature flavorless mirror abominable snowcone	2	decent	
+639	flavorless miniature mirror abominable snowcone	2	decent	
 640	Ent cider	1	crappy	
 641	bland snack-sized toast	2	decent	
 642	skeleton key	0		
 643	skeleton key ring	0		
 644	upside-down Crimbo pressie	0		Last Available: "2003-12"
-645	blurry shaking wrapping paper	0		Last Available: "2003-12"
+645	shaking blurry wrapping paper	0		Last Available: "2003-12"
 646	rotten fancy fruitcake	3	crappy	Effect: "Oiled Skin", Effect Duration: 50
 647	present	0		Last Available: "2004-11"
 648	lard-coated Crimbo sword	0		Sleaze Spell Damage: +25, Last Available: "2004-10"
@@ -674,9 +674,9 @@
 676	twirling dragonbone belt buckle	0		
 677	olive studded badass belt	0		Damage Absorption: +80
 678	chest of the Bonerdagon	0		
-679	hand-crafted upside-down twirling spinning roll in the hay	3	EPIC	
+679	hand-crafted twirling spinning upside-down roll in the hay	3	EPIC	
 680	artisanal slap and tickle	3	EPIC	
-681	artisanal practically non-alcoholic gray slip 'n' slide	1	super ultra mega turbo EPIC	
+681	practically non-alcoholic artisanal gray slip 'n' slide	1	super ultra mega turbo EPIC	
 682	hand-crafted a sump'm sump'm	3	EPIC	
 683	practically non-alcoholic smooth jittery horizontal tango	1	awesome	
 684	fortified artisanal pink pony	5	EPIC	
@@ -716,7 +716,7 @@
 720	occult arcane researcher's porquoise necklace	0		Experience Percent (Mysticality): +10, Spell Damage Percent: +25, Single Equip
 721	Sinatra's porquoise bracelet of the bloodbag	0		Experience (Moxie): +5, Maximum HP: +100
 722	lard-coated Sinatra's porquoise ring of doom	0		Experience (Moxie): +5, Spooky Spell Damage: +50, Sleaze Spell Damage: +25, Single Equip
-723	special low-calorie decent Knoll mushroom	1	good	Effect: "Wet Willied", Effect Duration: 5
+723	low-calorie decent special Knoll mushroom	1	good	Effect: "Wet Willied", Effect Duration: 5
 724	diet toothsome spinning mushroom	1	awesome	
 725	mirror one million meat pancakes	0		
 726	spinning wizardly huge mirror shard	0		Mysticality: +25
@@ -725,26 +725,26 @@
 729	fishbowl	0		
 730	spinning fishtank	0		
 731	bouncing green fish hose	0		
-732	spinning maroon hosed tank	0		
+732	maroon spinning hosed tank	0		
 733	hosed fishbowl	0		
 734	blurry sizzling Van der Graaf dance instructor's makeshift SCUBA gear	0		Experience Percent (Moxie): +10, Hot Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Adventure Underwater
 735	tumbling huge asbestos-lined easter egg balloon	0		Hot Resistance: +5
-736	fuchsia narrow ghostly stone tablet (Sinister Strumming)	0		
+736	fuchsia ghostly narrow stone tablet (Sinister Strumming)	0		
 737	twirling stone tablet (Squeezings of Woe)	0		
 738	huge stone tablet (Really Evil Rhythm)	0		
 739	lime green tambourine bells	0		
 740	lard-coated tambourine	0		Sleaze Spell Damage: +25
 741	broken skull	0		
-742	flavorless bite-sized Knoll shroomkabob	1	decent	
-743	flavorless big enchanted mushroom	5	decent	Effect: "Litterboxing", Effect Duration: 15
+742	bite-sized flavorless Knoll shroomkabob	1	decent	
+743	flavorless enchanted big mushroom	5	decent	Effect: "Litterboxing", Effect Duration: 15
 744	galvanized hair spray	0		Effect: "Weird Flavor", Effect Duration: 42
 746	wobbly stat script	0		
-747	tumbling red Knob Goblin firecracker	0		
+747	red tumbling Knob Goblin firecracker	0		
 748	gourd potion	0		
 749	yummy miniature warm mushroom	2	awesome	
 750	normal mushroom quesadilla	4	good	
 751	flavorless super-sized narrow cool mushroom	5	decent	
-752	rotten miniature blue cool mushroom casserole	2	crappy	
+752	miniature rotten blue cool mushroom casserole	2	crappy	
 753	flavorless half-sized pointy mushroom	2	decent	
 754	bland small cream of pointy mushroom soup	2	decent	
 755	special stale mushroom	4	decent	Effect: "Blessing of Squirtlcthulli", Effect Duration: 50
@@ -753,9 +753,9 @@
 758	stale ghost cucumber	4	decent	
 759	dill	0		
 760	vinegar	0		
-761	yellow jittery pulsating brine	0		
+761	pulsating jittery yellow brine	0		
 762	drinkable especially salty dog	4	good	
-763	mirror squat ghostly pickling solution	0		
+763	squat mirror ghostly pickling solution	0		
 764	enchanted adequate spectral pickle	3	good	Effect: "Sticky Hands", Effect Duration: 45
 765	briny vinegar	0		
 766	green huge ghost pickle on a stick	0		
@@ -772,7 +772,7 @@
 777	vibrating iron pasta spoon	0		Maximum MP Percent: +10
 778	wobbly grievous support cummerbund	0		Weapon Damage Percent: +50
 779	Mob Penguin cellular phone	0		
-780	tumbling huge scroll of pasta summoning	0		
+780	huge tumbling scroll of pasta summoning	0		
 781	unsweetened non-frozen mafia aria	0		Effect: "Memories of Puppy Love", Effect Duration: 29
 782	jittery Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
@@ -793,7 +793,7 @@
 798	tolerable tumbling ocean motion	4	good	
 799	tolerable fuzzbump	3	good	
 800	rotten poutine	4	crappy	
-801	rotten fancy small Knob stir-fry	2	crappy	Effect: "Serenity", Effect Duration: 20
+801	rotten small fancy Knob stir-fry	2	crappy	Effect: "Serenity", Effect Duration: 20
 804	snack-sized tasty Knoll stir-fry	2	awesome	
 805	moldy stir-fry	4	crappy	
 806	small rotten asparagus stir-fry	2	crappy	
@@ -807,7 +807,7 @@
 814	spoiled blinking b&auml;tzle	4	crappy	
 815	spoiled ratini	3	crappy	
 816	tiny rotten skewed Knob stroganoff	1	crappy	
-817	super-sized stale enchanted menudo ravioli	5	decent	Effect: "Berry Berry Cold", Effect Duration: 50
+817	super-sized enchanted stale menudo ravioli	5	decent	Effect: "Berry Berry Cold", Effect Duration: 50
 818	plus sign	0		
 819	olive milky potion	0		
 820	blue squat swirly potion	0		
@@ -826,14 +826,14 @@
 833	vibrating vorpal blade	0		Maximum MP Percent: +10
 834	coward's Samson's cornuthaum	0		Experience (Muscle): +5, Monster Level: -20, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	spinning nasty ring of aggravate monster	0		Stench Damage: +5
-836	small toothsome mind flayer corpse	2	awesome	
-837	practically non-alcoholic aged wobbly jittery Uovo Marcio Shiraz	1	awesome	Last Available: "2004-10"
+836	toothsome small mind flayer corpse	2	awesome	
+837	aged practically non-alcoholic jittery wobbly Uovo Marcio Shiraz	1	awesome	Last Available: "2004-10"
 838	inspector's Mafia stogie of horror	0		Spooky Spell Damage: +25, Item Drop: +15, Last Available: "2004-10"
 839	hand-crafted Maiali Sifilitici Pinot Noir	3	super EPIC	Last Available: "2004-10"
 840	chilly electrified Mafia violin case	0		Cold Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2004-10"
 841	delicious spinning tomato daiquiri	3	awesome	
 842	weak lousy beertini	2	decent	
-843	irresponsibly strong artisanal salty slug	9	EPIC	
+843	artisanal irresponsibly strong salty slug	9	EPIC	
 844	aged papaya slung	4	awesome	
 845	MAHI fez of the storm	0		Maximum MP Percent: +40, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
@@ -854,7 +854,7 @@
 862	magnifying glass	0		Familiar Weight: +5
 863	skewer-mounted razor blade	0		Familiar Weight: +5
 864	stinger	0		Familiar Weight: +5
-865	upside-down squat maroon lead necklace	0		Familiar Weight: +3
+865	maroon squat upside-down lead necklace	0		Familiar Weight: +3
 866	shaving cream	0		
 867	improved liquefied pine tar	0		Effect: "Mint-Condition Breath", Effect Duration: 55
 869	forest tears	0		
@@ -870,7 +870,7 @@
 879	corrupted bottle of goofballs	0		Effect: "Human-Beast Hybrid", Effect Duration: 42
 880	twirling disbelief suspenders of the bloodbag	0		Maximum HP: +100
 881	lightning-fast supportive bra	0		Initiative: +40
-882	upside-down skewed Blatantly Canadian	0		
+882	skewed upside-down Blatantly Canadian	0		
 883	maple syrup	1	decent	
 884	baleful los chinos	0		Spell Damage: +25, Familiar Effect: "2xPotato, HP regen, cap 13"
 885	tumbling axe of horror	0		Spooky Spell Damage: +25
@@ -881,24 +881,24 @@
 890	enchanted rotten balaclava baklava	3	crappy	Effect: "Less Pervious", Effect Duration: 15
 891	narrow Warehouse 23 bling of the scaredy-cat	0		Monster Level: -15
 892	teal double-paned Sinatra's bugbear-smiting sword of terror	0		Experience (Moxie): +5, Spooky Spell Damage: +10, Cold Resistance: +5
-893	weak bad lumbering jack	2	decent	
+893	bad weak lumbering jack	2	decent	
 894	Dark Jill-O-Lantern	0		Free Pull, Last Available: "2011-12"
 895	frightening Ms. Accessory	0		Spooky Damage: +5, Softcore Only
 896	squat veiny Mr. Accessory Jr. of the brazier	0		Maximum HP: +10, Hot Spell Damage: +25, Softcore Only
 897	coffee sprite	0		Free Pull, Last Available: "2005-10"
-898	mirror shaking Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
+898	shaking mirror Cheshire Bitten	0		Free Pull, Last Available: "2005-10"
 899	custom avatar form	0		Free Pull
 900	smile-sharpening stone	0		Familiar Weight: +5
 901	purple espresso maker	0		Familiar Weight: +5
 902	100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	artisanal practically non-alcoholic skewed Spasmi Dolorosi Del Rene Champagne	1	super ultra mega turbo EPIC	Last Available: "2004-10"
 904	greedy lion tamer's school Mafia knickerbockers of Tarzan	0		Experience (Muscle): +3, Experience (familiar): +2, Meat Drop: +20, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
-905	flattened polarized red squat Yummy Tummy bean	0		Effect: "Slippery Tongue", Effect Duration: 63
+905	flattened polarized squat red Yummy Tummy bean	0		Effect: "Slippery Tongue", Effect Duration: 63
 906	pickled deionized ghostly Rock Pops	0		Effect: "Libra Rising", Effect Duration: 68
 907	unsweetened purple Mr. Mediocrebar	0		Effect: "Slimily Sagacious", Effect Duration: 47
-908	polarized twirling shaking Cold Hots candy	0		Effect: "Yes, Can Haz", Effect Duration: 26
+908	polarized shaking twirling Cold Hots candy	0		Effect: "Yes, Can Haz", Effect Duration: 26
 909	oxidized Wint-O-Fresh mint	0		Effect: "meat.enh", Effect Duration: 37
-910	small normal dwarf bread	2	good	
+910	normal small dwarf bread	2	good	
 911	super-alkaline Senior Mints	0		Effect: "Creepin' Up on You", Effect Duration: 25
 912	electrified Vulcanized pixellated candy heart	0		Effect: "Amorous", Effect Duration: 60
 913	concentrated dry spinning kobold	0		Effect: "Slightly Cursed, Mostly Lucky", Effect Duration: 56
@@ -909,13 +909,13 @@
 918	Radio Free Baseball Cap of the empath	0		Familiar Weight: +5, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
 919	shellacked Radio Free Pants	0		Damage Reduction: 7, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	ghostly Radio Free Foil of wisdom	0		Mysticality: +15, Last Available: "2006-07"
-921	gigantic rotten teal radio button candy	7	crappy	
+921	rotten gigantic teal radio button candy	7	crappy	
 922	severed rocking horse head of the ox	0		Muscle: +20
 923	broken cellular phone	0		Last Available: "2004-01"
 924	spinning crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	Vulcanized Hawking's Elixir of Brilliance	0		Effect: "Sated and Furious", Effect Duration: 17
-927	artisanal huge skewed Ferita Del Petto Zinfandel	4	EPIC	Last Available: "2006-12"
+927	artisanal skewed huge Ferita Del Petto Zinfandel	4	EPIC	Last Available: "2006-12"
 928	fuzzy bracelets of the overflowing toilet	0		Stench Spell Damage: +50
 929	Tesla arse-shooting crossbow	0		MP Regen Min: 7, MP Regen Max: 10
 931	delicious mirror spiced rum	3	awesome	
@@ -936,15 +936,15 @@
 946	skewered lime	0		Last Available: "2004-12"
 947	green ghostly skewered cherry	0		Last Available: "2004-12"
 948	artisanal irresponsibly strong pulsating martini	6	EPIC	Last Available: "2004-12"
-949	drinkable practically non-alcoholic shaking grogtini	1	good	Last Available: "2004-12"
-950	artisanal practically non-alcoholic upside-down cherry bomb	1	super ultra mega turbo EPIC	Last Available: "2004-12"
+949	practically non-alcoholic drinkable shaking grogtini	1	good	Last Available: "2004-12"
+950	practically non-alcoholic artisanal upside-down cherry bomb	1	super ultra mega turbo EPIC	Last Available: "2004-12"
 951	narrow extra special Crimbo stocking	0		Last Available: "2004-12"
 952	lime green double-paned hockey mask of the scaredy-cat	0		Monster Level: -15, Cold Resistance: +5, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 25"
 953	spinning penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	fez of etymology of the storm	0		Maximum MP Percent: +40, Familiar Effect: "1xLep, cap 30"
-956	snack-sized bland carob chunk noodles	2	decent	
-957	rotten low-calorie chorizo brownies	1	crappy	
+956	bland snack-sized carob chunk noodles	2	decent	
+957	low-calorie rotten chorizo brownies	1	crappy	
 958	half-sized adequate squat chocolate and tomato pizza	2	good	
 959	flange	0		
 960	clockwork key	0		
@@ -982,32 +982,32 @@
 992	experienced plastic Jarlsberg of mayonnaise	0		Experience: +2, Sleaze Spell Damage: +50, Item Drop: +5
 993	spinning flame-retardant clever supercool plastic Sneaky Pete	0		Moxie Percent: +20, Maximum MP: +20, Hot Resistance: +1
 994	gray plastic Susie of the wise owl	0		Mysticality: +20
-995	rotten small Lucky Surprise Egg	2	crappy	
+995	small rotten Lucky Surprise Egg	2	crappy	
 998	maiden wig	0		Familiar Effect: "2xPotato, cap 8"
 999	maid head	0		
 1000	Meat maid	0		
 1002	flame-wreathed Xlyinia's notebook	0		Hot Spell Damage: +10
 1003	soda water	0		
-1004	watered-down lousy gray bottle of tequila	2	decent	
-1005	fancy bad watered-down boxed wine	2	decent	Effect: "Oriental Mysticism", Effect Duration: 40
-1006	fancy adequate ghostly cherry	3	good	Effect: "Rage of the Reindeer", Effect Duration: 30
+1004	lousy watered-down gray bottle of tequila	2	decent	
+1005	bad watered-down fancy boxed wine	2	decent	Effect: "Oriental Mysticism", Effect Duration: 40
+1006	adequate fancy ghostly cherry	3	good	Effect: "Rage of the Reindeer", Effect Duration: 30
 1007	fireproof coconut shell	0		Hot Resistance: +3, Familiar Effect: "1xFairy, cap 7"
 1008	nippy ice cubes	0		Cold Damage: +10
 1009	perfectly mixed vodka martini	3	EPIC	
 1010	mediocre whiskey and soda	4	decent	
-1011	weak tolerable monkey wrench	2	good	
-1012	tolerable fortified ghostly bouncing tequila sunrise	5	good	
+1011	tolerable weak monkey wrench	2	good	
+1012	fortified tolerable ghostly bouncing tequila sunrise	5	good	
 1013	artisanal margarita	3	EPIC	
 1014	delicious jittery strawberry wine	3	awesome	
 1015	tolerable wine spritzer	3	good	
-1016	artisanal watered-down mirror perpendicular hula	2	EPIC	
-1017	fortified fancy lousy ducha de oro	5	decent	Effect: "Standard Issue Bravery", Effect Duration: 25
+1016	watered-down artisanal mirror perpendicular hula	2	EPIC	
+1017	lousy fortified fancy ducha de oro	5	decent	Effect: "Standard Issue Bravery", Effect Duration: 25
 1018	perfectly mixed calle de miel	3	EPIC	
 1019	practically non-alcoholic drinkable huge dry vodka martini	1	good	
 1020	smooth old-fashioned	3	awesome	
-1021	artisanal practically non-alcoholic tequila with training wheels	1	super EPIC	
+1021	practically non-alcoholic artisanal tequila with training wheels	1	super EPIC	
 1022	weak acceptable sangria	2	good	
-1023	practically non-alcoholic perfectly mixed vesper	1	super ultra mega turbo EPIC	Last Available: "2004-12"
+1023	perfectly mixed practically non-alcoholic vesper	1	super ultra mega turbo EPIC	Last Available: "2004-12"
 1024	perfectly mixed bodyslam	4	EPIC	Last Available: "2004-12"
 1025	extra-dry hand-crafted sangria del diablo	5	EPIC	Last Available: "2004-12"
 1026	huge Valentine	0		Free Pull
@@ -1037,10 +1037,10 @@
 1051	plastic oyster egg	0		
 1052	dried squat oyster egg	1		
 1053	dehydrated fuchsia oyster egg	1		
-1054	dehydrated twirling mirror upside-down oyster egg	1		Effect: "Berry Thorny", Effect Duration: 45
+1054	dehydrated mirror twirling upside-down oyster egg	1		Effect: "Berry Thorny", Effect Duration: 45
 1055	blinking plastic oyster egg	0		
-1056	denatured squat narrow puce oyster egg	1		
-1057	vaporized narrow blurry puce oyster egg	1		Effect: "Blackberry Politeness", Effect Duration: 5
+1056	denatured narrow squat puce oyster egg	1		
+1057	vaporized blurry narrow puce oyster egg	1		Effect: "Blackberry Politeness", Effect Duration: 5
 1058	dehydrated puce oyster egg	1		
 1059	puce plastic oyster egg	0		
 1060	modified mauve oyster egg	1		Effect: "Mushroom Magicalness", Effect Duration: 35
@@ -1054,13 +1054,13 @@
 1068	diluted oyster egg	1		Effect: "Dance Interpreter", Effect Duration: 35
 1069	mixed tumbling oyster egg	1		
 1070	altered olive upside-down oyster egg	1		Effect: "Hare-o-dynamic", Effect Duration: 50
-1071	squat mirror plastic oyster egg	0		
+1071	mirror squat plastic oyster egg	0		
 1072	mixed shaking off-white oyster egg	1		
 1073	altered blinking off-white oyster egg	1		
 1074	denatured off-white oyster egg	1		
 1075	off-white plastic oyster egg	0		
 1076	boiled oyster egg	1		
-1077	pickled upside-down narrow yellow oyster egg	1		
+1077	pickled upside-down yellow narrow oyster egg	1		
 1078	distilled oyster egg	1		
 1079	plastic oyster egg	0		
 1080	oyster basket	0		
@@ -1121,13 +1121,13 @@
 1135	warmed enhanced eyeliner	0		Effect: "Hot Buttoned", Effect Duration: 26
 1136	extra-pressed wobbly lipstick	0		Effect: "Brother Corsican's Blessing", Effect Duration: 62
 1137	tumbling sizzling weightlifter's bicycle chain	0		Muscle: +15, Hot Damage: +10
-1138	jittery shaking mushroom fermenting solution	0		
+1138	shaking jittery mushroom fermenting solution	0		
 1139	artisanal bouncing mushroom wine	3	EPIC	
 1140	perfectly mixed mirror icy mushroom wine	4	EPIC	
 1141	weak hand-crafted mushroom wine	2	EPIC	
 1142	weak bad pointy mushroom wine	2	decent	
-1143	special practically non-alcoholic hand-crafted bouncing gray flat mushroom wine	1	super ultra mega turbo EPIC	Effect: "Initiative and Let Die", Effect Duration: 20
-1144	boozy acceptable cool mushroom wine	5	good	
+1143	practically non-alcoholic hand-crafted special bouncing gray flat mushroom wine	1	super ultra mega turbo EPIC	Effect: "Initiative and Let Die", Effect Duration: 20
+1144	acceptable boozy cool mushroom wine	5	good	
 1145	weak smooth blue knob mushroom wine	2	awesome	
 1146	artisanal knoll mushroom wine	3	EPIC	
 1147	mediocre mushroom wine	3	decent	
@@ -1182,13 +1182,13 @@
 1197	spinning Mob Penguin	0		
 1198	sabre-toothed lime	0		
 1199	bugbear	0		
-1200	flavorless jumbo mugcake	5	decent	
+1200	jumbo flavorless mugcake	5	decent	
 1201	thick flavorless spinning urinal cake	5	decent	
-1202	fancy stale Happy Birthday, Claude! cake	4	decent	Effect: "Ancestral Disapproval", Effect Duration: 50
+1202	stale fancy Happy Birthday, Claude! cake	4	decent	Effect: "Ancestral Disapproval", Effect Duration: 50
 1203	stale jumbo squat personalized birthday cake	5	decent	
 1204	normal miniature tumbling three-tiered wedding cake	2	good	
-1205	small flavorless babycakes	2	decent	
-1206	fancy moldy massive velvet cake	9	crappy	Effect: "Cock of the Walk", Effect Duration: 30
+1205	flavorless small babycakes	2	decent	
+1206	massive moldy fancy velvet cake	9	crappy	Effect: "Cock of the Walk", Effect Duration: 30
 1207	normal squat congratulatory cake	3	good	
 1208	decent teal angel-food cake	3	good	
 1209	spoiled squat devil's-food cake	3	crappy	
@@ -1196,7 +1196,7 @@
 1211	purple balloon	0		
 1212	skewed balloon	0		
 1213	bouncing heart-shaped balloon	0		
-1214	pulsating fuchsia anniversary balloon	0		
+1214	fuchsia pulsating anniversary balloon	0		
 1215	Mylar balloon	0		
 1216	blinking Kevlar balloon	0		
 1217	thought balloon	0		
@@ -1236,9 +1236,9 @@
 1252	bland shroomkabob	3	decent	
 1253	pile of jumping beans	0		
 1254	tasty gigantic jumping bean burrito	7	awesome	
-1255	half-sized rotten jumping bean burrito	2	crappy	
-1256	flavorless jumbo insanely jumping bean burrito	5	decent	
-1257	special tasty rat scrapple	4	awesome	Effect: "Blackberry Politeness", Effect Duration: 15
+1255	rotten half-sized jumping bean burrito	2	crappy	
+1256	jumbo flavorless insanely jumping bean burrito	5	decent	
+1257	tasty special rat scrapple	4	awesome	Effect: "Blackberry Politeness", Effect Duration: 15
 1258	pail of pretentious paint	0		
 1259	traffic cone of Tarzan of James Dean	0		Experience (Muscle): +3, Experience (Moxie): +3, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
@@ -1255,7 +1255,7 @@
 1271	jittery aluminum wand	0		
 1272	marble wand	0		
 1273	olive lion tamer's magic lamp	0		Experience (familiar): +2
-1274	distilled teal shaking Medicinal Herb's medicinal herbs	1		
+1274	distilled shaking teal Medicinal Herb's medicinal herbs	1		
 1275	lightning-fast basic meat skirt	0		Initiative: +40, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
 1276	delicious Otorian Battle Scar	3	awesome	
 1277	occult basic meat kilt	0		Spell Damage Percent: +25, Familiar Effect: "3xPotato, 3xFairy, cap 10"
@@ -1290,7 +1290,7 @@
 1306	mirror curative Herculean traffic cone	0		Experience (Muscle): +1, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	ghostly unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
-1309	blurry spinning attention spanner	0		Familiar Weight: +5
+1309	spinning blurry attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
 1311	comfy blanket	0		Last Available: "2005-10"
 1312	prompt Baron von Ratsworth's monocle	0		Adventures: +3, Single Equip
@@ -1299,9 +1299,9 @@
 1315	jittery asbestos-lined rose-colored glasses	0		Hot Resistance: +5
 1316	facsimile dictionary	0		
 1317	blinking blood flower	0		
-1318	upside-down bouncing lovecat tail	0		
+1318	bouncing upside-down lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	enchanted flavorless questionable taco	3	decent	Effect: "Puddingskin", Effect Duration: 40
+1320	flavorless enchanted questionable taco	3	decent	Effect: "Puddingskin", Effect Duration: 40
 1321	upside-down Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
 1323	ghostly Temple Grandin's time helmet	0		Familiar Weight: +7, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
@@ -1332,7 +1332,7 @@
 1349	tumbling miniscule temporal rip	0		Free Pull, Last Available: "2005-11"
 1350	1.21 jigawatts	0		Familiar Weight: +5, Last Available: "2005-11"
 1351	jittery pinky ring of the detective	0		Item Drop: +20, Single Equip
-1352	delicious spirit-forward jittery redrum	5	awesome	
+1352	spirit-forward delicious jittery redrum	5	awesome	
 1353	spinning ninja pirate zombie robot	0		
 1354	twirling pile of pebbles	0		
 1355	decent pulsating bowl of oriole's nest soup	4	good	
@@ -1347,7 +1347,7 @@
 1364	blue rhesus monkey	0		Familiar Weight: +5
 1365	toothsome tofurkey leg	4	awesome	
 1366	yummy tofurkey gravy	4	awesome	
-1367	rotten olive blurry herbal stuffing	3	crappy	
+1367	rotten blurry olive herbal stuffing	3	crappy	
 1368	huge decent skewed can-shaped gelatinous cranberry sauce	6	good	
 1369	snack-sized moldy cyan yams	2	crappy	
 1370	blurry wizardly rhinestone cowboy shirt	0		Mysticality: +25
@@ -1360,7 +1360,7 @@
 1377	ghostly ribald plastic Crimbo elf	0		Sleaze Damage: +10, Last Available: "2005-12"
 1378	upside-down plastic sweet nutcracker of extreme caution	0		Monster Level: -25, Last Available: "2005-12"
 1379	hardened plastic Crimbo reindeer	0		Damage Reduction: 3, Single Equip, Last Available: "2005-12"
-1381	blurry purple spinning aspirin	0		Last Available: "2005-12"
+1381	spinning purple blurry aspirin	0		Last Available: "2005-12"
 1382	quadruple-wet chocolate	0		Effect: "Super-Mega-Charged", Effect Duration: 58, Last Available: "2015-11"
 1383	length of string	0		
 1384	spinning googly eye	0		
@@ -1370,7 +1370,7 @@
 1388	twirling toy wheel	0		
 1389	yo-yo	0		Last Available: "2010-12"
 1390	top	0		Last Available: "2010-12"
-1391	bouncing shaking ball	0		Last Available: "2010-12"
+1391	shaking bouncing ball	0		Last Available: "2010-12"
 1392	kite	0		Last Available: "2005-12"
 1393	pet rock	0		Last Available: "2005-12"
 1394	shaking doppelshifter	0		Last Available: "2005-12"
@@ -1385,16 +1385,16 @@
 1403	can of fake snow of bravery	0		Spooky Resistance: +5, Last Available: "2005-12"
 1404	Jim Carey's colored-light &quot;necklace&quot;	0		Monster Level: +25, Last Available: "2005-12"
 1405	ghostly mansplainer's tree skirt	0		Monster Level: +15, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
-1406	small flavorless wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
+1406	flavorless small wreath-shaped Crimbo cookie	2	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
 1407	bland wobbly bell-shaped Crimbo cookie	3	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	gigantic tasty tree-shaped Crimbo cookie	10	awesome	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	rosewater-soaked Unionize The Elves sign	0		Stench Resistance: +3, Last Available: "2005-12"
-1410	tumbling upside-down sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
+1410	upside-down tumbling sleeping snowy owl	0		Last Available: "2005-12"
+1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
 1412	ionized ionized snowcone	0		Effect: "Lobos Fresh", Effect Duration: 40, Last Available: "2006-01"
 1413	deionized snowcone	0		Effect: "Sewer-Drenched", Effect Duration: 40, Last Available: "2006-01"
 1414	dry modified snowcone	0		Effect: "Hot Jellied", Effect Duration: 28, Last Available: "2006-01"
-1415	ionized colloidal blurry green snowcone	0		Effect: "Just the Brown Ones", Effect Duration: 33, Last Available: "2006-01"
+1415	ionized colloidal green blurry snowcone	0		Effect: "Just the Brown Ones", Effect Duration: 33, Last Available: "2006-01"
 1416	polymerized super-tarnished green snowcone	0		Effect: "Cold Throat", Effect Duration: 38, Last Available: "2006-01"
 1417	anodized alkaline huge snowcone	0		Effect: "Vinegavotte", Effect Duration: 48, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
@@ -1402,12 +1402,12 @@
 1420	greedy traffic cone of the brute	0		Muscle Percent: +30, Meat Drop: +20, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	bouncing Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	jittery Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
-1423	upside-down maroon iceberglet	0		Last Available: "2006-02"
+1423	maroon upside-down iceberglet	0		Last Available: "2006-02"
 1424	bouncing asbestos-lined weightlifter's ice sickle	0		Muscle: +15, Hot Resistance: +5, Softcore Only, Last Available: "2006-02"
 1425	ice baby of the brute	0		Muscle Percent: +30, Softcore Only, Last Available: "2006-02"
 1426	horrifying ice pick	0		Spooky Damage: +25, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	Van der Graaf Rosewater's ice skates	0		Mysticality Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	flavorless special tiny ghostly grue egg omelette	1	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5
+1428	tiny flavorless special ghostly grue egg omelette	1	decent	Effect: "Aspect of the GravyPlum Fairy", Effect Duration: 5
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1419,7 +1419,7 @@
 1437	wobbly useless powder	0		
 1438	pressed twinkly powder	0		Effect: "Slime Time", Effect Duration: 13
 1439	modified pulsating hot powder	0		Effect: "Peppermint Bite", Effect Duration: 42
-1440	deionized lime green pulsating powder	0		Effect: "Wet Jaw", Effect Duration: 46
+1440	deionized pulsating lime green powder	0		Effect: "Wet Jaw", Effect Duration: 46
 1441	galvanized powder	0		Effect: "Flexibili Tea", Effect Duration: 41
 1442	polarized stench powder	0		Effect: "Hairy Palms", Effect Duration: 42
 1443	diffused frozen ghostly sleaze powder	0		Effect: "Big Punkin'", Effect Duration: 36
@@ -1432,7 +1432,7 @@
 1450	modified twinkly wad	1		
 1451	mixed bouncing tumbling hot wad	1		
 1452	powdered wad	1		
-1453	diluted blinking olive squat wad	1		Effect: "Berry Defensive", Effect Duration: 20
+1453	diluted squat blinking olive wad	1		Effect: "Berry Defensive", Effect Duration: 20
 1454	dehydrated stench wad	1		Effect: "Dancing Prowess", Effect Duration: 50
 1455	altered sleaze wad	1		
 1456	purple upside-down double daisy	0		
@@ -1466,8 +1466,8 @@
 1484	alpha-mail pants	0		Familiar Effect: "atk, 1xBarrr, cap 35"
 1485	squat frightening rabbit's foot of the empath	0		Familiar Weight: +5, Spooky Damage: +5
 1486	massive bag of catnip	0		
-1487	blinking jittery hang glider	0		
-1488	bouncing wobbly March hat	0		Free Pull
+1487	jittery blinking hang glider	0		
+1488	wobbly bouncing March hat	0		Free Pull
 1489	upside-down dormouse	0		
 1490	squat healthy boxer's chopsticks	0		Muscle Percent: +10, Maximum HP Percent: +20
 1491	yellow brainy rice bowl	0		Mysticality: +5
@@ -1477,21 +1477,21 @@
 1495	skewed scorching beefy traffic cone	0		Muscle: +10, Hot Damage: +25, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	watered-down lousy ghostly gloomy mushroom wine	2	decent	
 1497	hand-crafted mushroom wine	3	EPIC	
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	yellow fake fake vomit	0		Last Available: "2006-04"
 1501	tarnished extra-moist explosion-flavored chewing gum	0		Effect: "Analog Drunk", Effect Duration: 49, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
 1503	pulsating rubber emo roe	0		Last Available: "2006-04"
-1504	triple-improved wet mirror red snowcone	0		Effect: "Trivia Master", Effect Duration: 44, Last Available: "2006-04"
+1504	triple-improved wet red mirror snowcone	0		Effect: "Trivia Master", Effect Duration: 44, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
-1506	bad high-proof ghostly calle de miel with a fly in it	9	decent	Last Available: "2006-04"
-1507	watered-down smooth rockin' wagon with a fly in it	2	awesome	Last Available: "2006-04"
+1506	high-proof bad ghostly calle de miel with a fly in it	9	decent	Last Available: "2006-04"
+1507	smooth watered-down rockin' wagon with a fly in it	2	awesome	Last Available: "2006-04"
 1508	tolerable green perpendicular hula with a fly in it	3	good	Last Available: "2006-04"
 1509	lousy slap and tickle with a fly in it	3	decent	Last Available: "2006-04"
-1510	shaking blinking tumbling bag of airline peanuts	0		Last Available: "2006-04"
+1510	tumbling blinking shaking bag of airline peanuts	0		Last Available: "2006-04"
 1511	family-friendly fake hand	0		Sleaze Resistance: +1, Last Available: "2006-04"
-1512	pickled fuchsia blinking Knob Goblin pet-buffing spray	1		
+1512	pickled blinking fuchsia Knob Goblin pet-buffing spray	1		
 1513	twisted Knob Goblin learning pill	1		Effect: "Hustlin'", Effect Duration: 25
 1514	altered narrow Knob Goblin eyedrops	1		
 1515	vaporized red spinning Knob Goblin nasal spray	1		
@@ -1503,7 +1503,7 @@
 1522	knitted arcane researcher's Radio Free Jersey	0		Experience Percent (Mysticality): +10, Cold Resistance: +3
 1523	bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
-1525	joybuzzer	0		Last Available: "2006-04", Conditional Skill (Equipped): "Shake Hands"
+1525	joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
 1526	pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	green diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	Annie Oakley's banded corkscrew	0		Damage Absorption: +100, Critical Hit Percent: +20, Last Available: "2006-04"
@@ -1528,12 +1528,12 @@
 1548	wool Rosewater's Gazpacho's Glacial Grimoire	0		Mysticality Percent: +30, Cold Resistance: +1
 1549	MSG	0		
 1550	jittery second-hand knockoff engagement ring of the brute	0		Muscle Percent: +30, Single Equip
-1551	spirit-forward perfectly mixed bottle of Domesticated Turkey	5	EPIC	
-1552	bad practically non-alcoholic bottle of Definit	1	decent	
+1551	perfectly mixed spirit-forward bottle of Domesticated Turkey	5	EPIC	
+1552	practically non-alcoholic bad bottle of Definit	1	decent	
 1553	irresponsibly strong bad bottle of Calcutta Emerald	8	decent	
-1554	bad special bottle of Lieutenant Freeman	4	decent	Effect: "The Best a Pirate Can Get", Effect Duration: 30
+1554	special bad bottle of Lieutenant Freeman	4	decent	Effect: "The Best a Pirate Can Get", Effect Duration: 30
 1555	watered-down lousy twirling bottle of Jorge Sinsonte	2	decent	
-1556	artisanal watered-down enchanted boxed champagne	2	EPIC	Effect: "Shawarma Initiative", Effect Duration: 25
+1556	enchanted watered-down artisanal boxed champagne	2	EPIC	Effect: "Shawarma Initiative", Effect Duration: 25
 1557	miniature bland kumquat	2	decent	
 1558	decent small enchanted tangerine	2	good	Effect: "Fever From the Flavor", Effect Duration: 10
 1559	purple tonic water	0		
@@ -1541,24 +1541,24 @@
 1561	bland wobbly raspberry	3	decent	
 1562	normal kiwi	3	good	
 1563	lousy whiskey bittersweet	4	decent	
-1564	tolerable watered-down special mimosette	2	good	Effect: "Cat-Alyzed", Effect Duration: 45
+1564	tolerable special watered-down mimosette	2	good	Effect: "Cat-Alyzed", Effect Duration: 45
 1565	hand-crafted practically non-alcoholic tequila sunset	1	super EPIC	
-1566	drinkable high-proof zmobie	8	good	Wiki Name: "Zmobie (drink)"
+1566	high-proof drinkable zmobie	8	good	Wiki Name: "Zmobie (drink)"
 1567	artisanal gin and tonic	3	EPIC	
 1568	acceptable skewed vodka and tonic	3	good	
-1569	mediocre enchanted watered-down olive vodka gibson	2	decent	Effect: "Space Cowboy", Effect Duration: 20
+1569	watered-down mediocre enchanted olive vodka gibson	2	decent	Effect: "Space Cowboy", Effect Duration: 20
 1570	hand-crafted gibson	3	EPIC	
 1571	perfectly mixed parisian cathouse	4	EPIC	
 1572	perfectly mixed rabbit punch	3	EPIC	
-1573	fortified aged caipifruta	5	awesome	
+1573	aged fortified caipifruta	5	awesome	
 1574	bad teqiwila	3	decent	
 1575	aged Divine	3	awesome	
 1576	tolerable huge Gordon Bennett	3	good	
 1577	acceptable tangarita	4	good	
 1578	weak hand-crafted mandarina colada	2	super ultra EPIC	
 1579	delicious gimlet	4	awesome	
-1580	drinkable weak brick road	2	good	
-1581	perfectly mixed extra-dry vodka stratocaster	5	EPIC	
+1580	weak drinkable brick road	2	good	
+1581	extra-dry perfectly mixed vodka stratocaster	5	EPIC	
 1582	tolerable wobbly Neuromancer	4	good	
 1583	hand-crafted prussian cathouse	4	EPIC	
 1584	bad Mae West	4	decent	
@@ -1569,10 +1569,10 @@
 1589	rotten Knoll lo mein	3	crappy	
 1590	snack-sized tasty lo mein	2	awesome	
 1591	stale olive lo mein	3	decent	
-1592	half-sized rotten special huge hot hi mein	2	crappy	Effect: "All Glory To the Toad", Effect Duration: 5
-1593	spoiled thick lime green hi mein	5	crappy	
+1592	special rotten half-sized huge hot hi mein	2	crappy	Effect: "All Glory To the Toad", Effect Duration: 5
+1593	thick spoiled lime green hi mein	5	crappy	
 1594	delicious miniature hi mein	2	awesome	
-1595	delicious mirror tumbling hi mein	4	awesome	
+1595	delicious tumbling mirror hi mein	4	awesome	
 1596	normal pulsating sleazy hi mein	4	good	
 1597	Sherlock's Junior LAAAAME merit badge	0		Item Drop: +25, Last Available: "2006-05"
 1598	upside-down frosty Senior LAAAAME merit badge	0		Cold Spell Damage: +10, Last Available: "2006-05"
@@ -1583,7 +1583,7 @@
 1603	watered-down tolerable Mae West with a fly in it	2	good	
 1604	mixed astronaut ice-cream	1		Last Available: "2006-05"
 1605	delectable catalyst	0		
-1606	pickled olive shaking ultimate wad	1		
+1606	pickled shaking olive ultimate wad	1		
 1607	flattened corrupted teal shaking libation of liveliness	0		Effect: "Ermine Eyes", Effect Duration: 49
 1608	triple-magnetized pickled non-diffused blurry eyedrops of the ermine	0		Effect: "Filled with Magic", Effect Duration: 43
 1609	denatured perfume of prejudice	0		Effect: "Indescribable Flavor", Effect Duration: 49
@@ -1619,18 +1619,18 @@
 1639	extra-adjusted galvanized skewed lotion of spookiness	0		Effect: "Egged On", Effect Duration: 66
 1640	oxidized mirror lotion of stench	0		Effect: "Fishily Speeding", Effect Duration: 66
 1641	triple-liquefied frozen lotion of sleaziness	0		Effect: "Nothing Is Impossible", Effect Duration: 44
-1642	smooth weak Grimacite Bock	2	awesome	Last Available: "2008-11"
+1642	weak smooth Grimacite Bock	2	awesome	Last Available: "2008-11"
 1643	flavorless wedge of gray cheese	3	decent	Last Available: "2008-11"
-1644	blurry squat hot and sauce	0		
+1644	squat blurry hot and sauce	0		
 1645	and sauce	0		
 1646	and sauce	0		
 1647	jittery stench and sauce	0		
-1648	tumbling yellow sleazy and sauce	0		
+1648	yellow tumbling sleazy and sauce	0		
 1649	narrow wobbly brick	0		Free Pull
 1650	spinning milk of magnesium	0		
-1651	enchanted stale half-sized foie gras	2	decent	Effect: "Crusty Head", Effect Duration: 20
+1651	half-sized stale enchanted foie gras	2	decent	Effect: "Crusty Head", Effect Duration: 20
 1652	ionized improved pickled shaking candy brain	0		Effect: "Jelly Combed", Effect Duration: 27, Last Available: "2020-09"
-1653	red resourceful jewel-eyed wizard hat of the sewer of bravery	0		Maximum MP: +50, Stench Damage: +25, Spooky Resistance: +5, Softcore Only, Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Conditional Skill (Equipped): "Magic Missile"
+1653	red resourceful jewel-eyed wizard hat of the sewer of bravery	0		Maximum MP: +50, Stench Damage: +25, Spooky Resistance: +5, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	twirling perfumed Da Vinci's wad of Crovacite	0		Experience (Mysticality): +5, Stench Resistance: +5
 1655	blurry flame-retardant vibrating collar	0		Maximum MP Percent: +10, Hot Resistance: +1
 1656	huge White Citadel Satisfaction Satchel	0		
@@ -1648,7 +1648,7 @@
 1668	dangerous star boomerang	0		Weapon Damage: +10
 1669	teal star stiletto of courage	0		Spooky Resistance: +3
 1670	shaking fraudwort	0		
-1671	bouncing skewed shysterweed	0		
+1671	skewed bouncing shysterweed	0		
 1672	swindleblossom	0		
 1673	spinning frosty grave robbing shovel of the overflowing toilet	0		Cold Spell Damage: +10, Stench Spell Damage: +50
 1674	frosty superhero mask	0		Cold Spell Damage: +10, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
@@ -1673,12 +1673,12 @@
 1693	vacuum-sealed flattened eyedrops of newt	0		Effect: "Super-Mega-Charged", Effect Duration: 23
 1694	pickled green Frogade	0		Effect: "Sagittarius Rising", Effect Duration: 65
 1695	dry ionized papotion of papower	0		Effect: "20-20 Second Sight", Effect Duration: 11
-1696	snack-sized rotten royal jelly taco	2	crappy	
+1696	rotten snack-sized royal jelly taco	2	crappy	
 1697	flavorless tofu taco	3	decent	
-1698	half-sized rotten jumping bean taco	2	crappy	
+1698	rotten half-sized jumping bean taco	2	crappy	
 1699	rotten twirling catgut taco	3	crappy	
-1700	moldy special miniature pulsating goat cheese taco	2	crappy	Effect: "You Know Where to Go", Effect Duration: 5
-1701	bland fancy huge pr0n taco	4	decent	Effect: "Icy Demeanor", Effect Duration: 45
+1700	miniature moldy special pulsating goat cheese taco	2	crappy	Effect: "You Know Where to Go", Effect Duration: 5
+1701	fancy bland huge pr0n taco	4	decent	Effect: "Icy Demeanor", Effect Duration: 45
 1702	adjusted alphabet gum	0		Effect: "Poker Faced", Effect Duration: 11
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1745,8 +1745,8 @@
 1766	yellow Spookyraven ballroom key	0		
 1767	pack of chewing gum	0		
 1768	blurry Gnomish toolbox	0		
-1769	tiny normal huge fricasseed brains	1	good	
-1770	stale low-calorie brains casserole	1	decent	
+1769	normal tiny huge fricasseed brains	1	good	
+1770	low-calorie stale brains casserole	1	decent	
 1771	pulsating vibrating butcherknife	0		Maximum MP Percent: +10
 1772	therapeutic corn holder	0		HP Regen Min: 5, HP Regen Max: 7
 1773	teal skewed resourceful eggbeater	0		Maximum MP: +50
@@ -1767,7 +1767,7 @@
 1788	unrefined Mountain Stream syrup	0		
 1789	spinning Mob Penguin	0		
 1790	hand-crafted Ram's Face Lager	4	EPIC	
-1791	shaking jittery ram horns	0		
+1791	jittery shaking ram horns	0		
 1792	lion tamer's Temple Grandin's Oprah's Travoltan trousers	0		Maximum MP Percent: +50, Familiar Weight: +7, Experience (familiar): +2, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	nasty pool cue of temperance	0		Stench Damage: +5, Sleaze Resistance: +5
 1794	non-adjusted polarized shaking handful of hand chalk	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 52
@@ -1801,7 +1801,7 @@
 1822	second lumbar vertebra	0		
 1823	third lumbar vertebra	0		
 1824	fourth lumbar vertebra	0		
-1825	cyan wobbly jittery fifth lumbar vertebra	0		
+1825	jittery wobbly cyan fifth lumbar vertebra	0		
 1826	sixth lumbar vertebra	0		
 1827	seventh lumbar vertebra	0		
 1828	sacral vertebrae	0		
@@ -1813,7 +1813,7 @@
 1834	sixth caudal vertebra	0		
 1835	seventh caudal vertebra	0		
 1836	mirror wobbly eighth caudal vertebra	0		
-1837	jittery blurry ninth caudal vertebra	0		
+1837	blurry jittery ninth caudal vertebra	0		
 1838	blinking tenth caudal vertebra	0		
 1839	left first rib	0		
 1840	left second rib	0		
@@ -1823,7 +1823,7 @@
 1844	blurry left sixth rib	0		
 1845	twirling left seventh rib	0		
 1846	left eighth rib	0		
-1847	ghostly green jittery left ninth rib	0		
+1847	ghostly jittery green left ninth rib	0		
 1848	skewed left tenth rib	0		
 1849	blue left eleventh rib	0		
 1850	left twelfth rib	0		
@@ -1832,7 +1832,7 @@
 1853	right third rib	0		
 1854	right fourth rib	0		
 1855	right fifth rib	0		
-1856	tumbling yellow right sixth rib	0		
+1856	yellow tumbling right sixth rib	0		
 1857	maroon right seventh rib	0		
 1858	right eighth rib	0		
 1859	right ninth rib	0		
@@ -1857,7 +1857,7 @@
 1878	blurry blurry left fibula	0		
 1879	right fibula	0		
 1880	left kneecap	0		
-1881	blurry huge right kneecap	0		
+1881	huge blurry right kneecap	0		
 1882	left first front claw	0		
 1883	left second front claw	0		
 1884	left third front claw	0		
@@ -1896,7 +1896,7 @@
 1919	cyan English to A. F. U. E. Dictionary	0		
 1920	blurry green bizarre illegible sheet music	0		
 1921	cyan careful wakizashi	0		Monster Level: -10
-1922	narrow blue blinking gob of wet hair	0		
+1922	blinking narrow blue gob of wet hair	0		
 1923	roll of toilet paper	0		Free Pull
 1924	spinning tattered wolf standard	0		
 1925	tattered snake standard	0		
@@ -1926,15 +1926,15 @@
 1949	bland Manetwich	3	decent	
 1950	green bottle of Vangoghbitussin	0		
 1951	drinkable jittery bottle of Pinot Renoir	3	good	
-1952	miniature adequate desiccated apricot	2	good	
-1953	irresponsibly strong drinkable cyan spinning flute of flat champagne	9	good	
+1952	adequate miniature desiccated apricot	2	good	
+1953	drinkable irresponsibly strong cyan spinning flute of flat champagne	9	good	
 1954	normal miniature dehydrated caviar	2	good	
 1955	styrofoam peanuts	0		
 1956	acceptable snifter of thoroughly aged brandy	3	good	
 1957	quill pen	0		
 1958	inkwell	0		
 1959	tattered scrap of paper	0		
-1960	blinking spinning scroll of forbidden unspeakable evil	0		
+1960	spinning blinking scroll of forbidden unspeakable evil	0		
 1961	can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	galvanized denatured Bit O' Ectoplasm	0		Effect: "Cake Caked", Effect Duration: 60
 1963	dance card	0		
@@ -1996,10 +1996,10 @@
 2019	blinking cream pie	0		Free Pull
 2020	tasty snack-sized cherry pie	2	awesome	
 2021	miniature yummy strawberry pie	2	awesome	
-2022	bland miniature lemon meringue pie	2	decent	
+2022	miniature bland lemon meringue pie	2	decent	
 2023	blinking Genalen&trade; Bottle	1	good	
 2024	moldy low-calorie mixed wildflower greens	1	crappy	
-2025	huge flavorless handful of walnuts	8	decent	
+2025	flavorless huge handful of walnuts	8	decent	
 2026	bland mirror nutty organic salad	3	decent	
 2027	adequate miniature super salad	2	good	
 2028	adequate blue tofu wonton	4	good	
@@ -2019,11 +2019,11 @@
 2042	exploding hacky-sack	0		
 2043	skewed hemp net	0		
 2044	your father's MacGuffin diary	0		
-2045	gigantic tasty mirror brain-meltingly-hot chicken wings	8	awesome	
+2045	tasty gigantic mirror brain-meltingly-hot chicken wings	8	awesome	
 2046	moldy thick wobbly purple frat brats	5	crappy	
 2047	normal knob ka-bobs	3	good	
 2049	enchanted bad can of Swiller	3	decent	Effect: "Dexteri Tea", Effect Duration: 15
-2050	upside-down teal broken wings	0		
+2050	teal upside-down broken wings	0		
 2051	sunken eyes	0		
 2052	reassembled blackbird	0		
 2053	lime green spinning bust of Pallas	0		Familiar Weight: +5
@@ -2036,7 +2036,7 @@
 2060	cyan flame-wreathed sword of incineration	0		Hot Spell Damage: 60
 2061	maroon forbidden helmet	0		Spell Damage Percent: +50, Familiar Effect: "1xFairy, cap 40"
 2062	wicked shield of the brazier	0		Spell Damage: +5, Hot Spell Damage: +25, Damage Reduction: 10
-2063	moldy miniature blackberry	2	crappy	
+2063	miniature moldy blackberry	2	crappy	
 2064	forged identification documents	0		
 2065	PADL Phone	0		
 2066	huge bouncing vibrating Da Vinci's kick-ass kicks	0		Experience (Mysticality): +5, Maximum MP Percent: +10, Single Equip
@@ -2060,7 +2060,7 @@
 2084	huge can of starch	0		
 2085	boiled bottle of ultravitamins	1		Effect: "Some Cheese with Your Wine", Effect Duration: 35
 2086	distilled blurry bottle of cough syrup	1		
-2087	denatured blue jittery tube of hair oil	1		
+2087	denatured jittery blue tube of hair oil	1		
 2088	quantum Daffy Taffy	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 11
 2089	Crimboween memo	0		Last Available: "2006-10"
 2090	padded dangerous smooth pilgrim shield of Tarzan of terror	0		Moxie: +15, Experience (Muscle): +3, Weapon Damage: +10, Damage Absorption: +20, Spooky Spell Damage: +10, Damage Reduction: 1, Softcore Only, Last Available: "2006-11"
@@ -2105,7 +2105,7 @@
 2130	upside-down killer rag doll of James Dean	0		Experience (Moxie): +3, Last Available: "2006-12"
 2131	tree-eating kite	0		Last Available: "2006-12"
 2132	incredibly marionette of the boozehound	0		Booze Drop: +100, Last Available: "2006-12"
-2133	purple twirling dress ball	0		Last Available: "2010-12"
+2133	twirling purple dress ball	0		Last Available: "2010-12"
 2134	narrow shaking sharpshooter's mad scientist's sock monkey	0		Critical Hit Percent: +10, Last Available: "2006-12"
 2135	alien blob	0		Last Available: "2006-12"
 2136	jittery squat vampire duck-on-a-string of the wise owl of Flo-Jo	0		Mysticality: +20, Initiative: +100, Last Available: "2006-12"
@@ -2122,7 +2122,7 @@
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
 2149	delicious miniature frank	2	awesome	Last Available: "2011-12"
-2150	adequate small jittery plate of franks and beans	2	good	Last Available: "2011-12"
+2150	small adequate jittery plate of franks and beans	2	good	Last Available: "2011-12"
 2151	tolerable shot of blackberry schnapps	3	good	
 2152	capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2134,9 +2134,9 @@
 2159	quantum polarity inducer	0		Last Available: "2011-12"
 2160	bi-lateral logic compressor	0		Last Available: "2011-12"
 2161	mirror computronic processing unit	0		Last Available: "2011-12"
-2162	spinning pulsating reverse-oscillating klystron	0		Last Available: "2011-12"
+2162	pulsating spinning reverse-oscillating klystron	0		Last Available: "2011-12"
 2163	sub-molecular interocitor	0		Last Available: "2011-12"
-2164	wobbly jittery recursive spline reticulator	0		Last Available: "2011-12"
+2164	jittery wobbly recursive spline reticulator	0		Last Available: "2011-12"
 2165	atomic vector plotter	0		Last Available: "2011-12"
 2166	lime green spinning ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
@@ -2149,7 +2149,7 @@
 2174	mossy stone sphere	0		
 2175	bouncing smooth stone sphere	0		
 2176	cracked stone sphere	0		
-2177	cyan spinning rough stone sphere	0		
+2177	spinning cyan rough stone sphere	0		
 2178	bouncing twirling avaricious obsidian dagger	0		Meat Drop: +30
 2179	archaeologist's notebook	0		
 2180	twirling amulet	0		
@@ -2165,12 +2165,12 @@
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	massive normal candy stake	8	good	Last Available: "2006-12"
+2193	normal massive candy stake	8	good	Last Available: "2006-12"
 2194	artisanal eggnog	3	EPIC	Last Available: "2006-12"
-2195	decent miniature unspeakable fruitcake	2	good	Last Available: "2006-12"
+2195	miniature decent unspeakable fruitcake	2	good	Last Available: "2006-12"
 2196	decent gingerbread horror	4	good	Last Available: "2006-12"
 2197	activated vacuum-sealed bouncing but probably evil chocolate	0		Effect: "Salamanderenity", Effect Duration: 46, Last Available: "2006-12"
-2198	moldy bite-sized bat-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
+2198	bite-sized moldy bat-shaped Crimboween cookie	1	crappy	Effect: "Bells in the Batfry", Effect Duration: 5, Last Available: "2023-06"
 2199	adequate low-calorie skull-shaped Crimboween cookie	1	good	Effect: "Bells in the Batfry", Effect Duration: 10, Last Available: "2023-06"
 2200	decent tombstone-shaped Crimboween cookie	4	good	Effect: "Crimbo Epiphany", Effect Duration: 10, Last Available: "2023-06"
 2201	skewed chaotic plastic gift-wrapping vampire	0		Spell Critical Percent: +10, Last Available: "2006-12"
@@ -2182,9 +2182,9 @@
 2207	pulsating rock-hard Crimbo tiki necklace	0		Damage Reduction: 5, Last Available: "2006-12"
 2208	veiny bobble-hip hula elf doll of bravery	0		Maximum HP: +10, Spooky Resistance: +5, Last Available: "2006-12"
 2209	zippy Crimbo ukulele	0		Initiative: +20, Last Available: "2006-12"
-2210	Jeselnik's deadly Tiki lighter	0		Weapon Damage: +5, Sleaze Damage: +25, Last Available: "2006-12", Stat Tuning: "Moxie"
-2211	Annie Oakley's experienced deck of tropical cards	0		Experience: +2, Critical Hit Percent: +20, Last Available: "2006-12", Stat Tuning: "Mysticality"
-2212	tropical paperweight of chilblains of Flo-Jo	0		Cold Damage: +25, Initiative: +100, Last Available: "2006-12", Stat Tuning: "Muscle"
+2210	Jeselnik's deadly Tiki lighter	0		Weapon Damage: +5, Sleaze Damage: +25, Stat Tuning: "Moxie", Last Available: "2006-12"
+2211	Annie Oakley's experienced deck of tropical cards	0		Experience: +2, Critical Hit Percent: +20, Stat Tuning: "Mysticality", Last Available: "2006-12"
+2212	tropical paperweight of chilblains of Flo-Jo	0		Cold Damage: +25, Initiative: +100, Stat Tuning: "Muscle", Last Available: "2006-12"
 2213	wobbly tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	shaking tropical wrapping paper	0		Last Available: "2006-12"
 2215	maroon tumbling smooth Tropical Crimbo Hat	0		Moxie: +15, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
@@ -2230,23 +2230,23 @@
 2256	scorching furry earmuffs	0		Hot Damage: +25
 2257	teal dangerous reinforced furry underpants of the sweet-tooth	0		Weapon Damage: +10, Candy Drop: +100
 2258	shaking &quot;I Love Me, Vol. I&quot;	0		
-2259	purple blinking photograph of God	0		
+2259	blinking purple photograph of God	0		
 2260	hard rock candy	0		
 2261	hard-boiled ostrich egg	0		
 2262	bird rib	0		
 2263	upside-down lion oil	0		
-2264	moldy huge wobbly stunt nuts	8	crappy	
-2265	bite-sized spoiled wet stew	1	crappy	
+2264	huge moldy wobbly stunt nuts	8	crappy	
+2265	spoiled bite-sized wet stew	1	crappy	
 2266	wet stunt nut stew	0		
 2267	Mega Gem	0		
 2268	ghostly Staff of Fats of Leguizamo	0		Monster Level: +20
 2269	rotten small sausage wonton	2	crappy	
 2270	narrow wool belt of the glutton	0		Cold Resistance: +1, Food Drop: +100, Single Equip
-2271	bad distilled bottle of Merlot	5	decent	
+2271	distilled bad bottle of Merlot	5	decent	
 2272	mediocre irresponsibly strong bottle of Port	10	decent	
 2273	acceptable watered-down bouncing bottle of Pinot Noir	2	good	
-2274	mediocre fancy practically non-alcoholic bottle of Zinfandel	1	decent	Effect: "Shamboozled", Effect Duration: 50
-2275	tolerable weak bouncing bottle of Marsala	2	good	
+2274	mediocre practically non-alcoholic fancy bottle of Zinfandel	1	decent	Effect: "Shamboozled", Effect Duration: 50
+2275	weak tolerable bouncing bottle of Marsala	2	good	
 2276	tolerable ghostly bottle of Muscat	3	good	
 2277	pulsating Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2274,7 +2274,7 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	wobbly Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
+2303	wobbly Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
 2304	anodized candy heart	0		Effect: "Bone Chilling", Effect Duration: 37, Last Available: "2007-02"
 2305	polymerized boiled pink candy heart	0		Effect: "Army of One", Effect Duration: 42, Last Available: "2007-02"
 2306	tarnished candy heart	0		Effect: "Guts Feeling", Effect Duration: 64, Last Available: "2007-02"
@@ -2289,7 +2289,7 @@
 2315	bouncing candygram	0		Last Available: "2007-02"
 2316	broken carburetor	0		
 2317	bronze token	0		
-2318	spinning spinning mirror bomb	0		
+2318	mirror spinning spinning bomb	0		
 2319	green carved wheel	0		
 2320	worm-riding manual page	0		
 2321	tumbling worm-riding manual page 2	0		
@@ -2303,13 +2303,13 @@
 2329	handful of confetti	0		
 2330	chocolate-covered diamond-studded roses	0		
 2331	pulsating bouquet of circular saw blades	0		
-2332	moldy massive Better Than Cuddling Cake	10	crappy	
+2332	massive moldy Better Than Cuddling Cake	10	crappy	
 2333	narrow ninja snowman	0		
 2334	Holy MacGuffin	0		
 2335	huge rubber WWBBDD? bracelet	0		
 2336	nippy sinister pipe	0		Spell Damage: +10, Cold Damage: +10
 2337	bouncing chilly reinforced beaded headband	0		Cold Damage: +5, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
-2338	big spoiled blinking pudding	5	crappy	Wiki Name: "black pudding (food)"
+2338	spoiled big blinking pudding	5	crappy	Wiki Name: "black pudding (food)"
 2339	smooth Blackfly Chardonnay	4	awesome	
 2340	fortified hand-crafted & tan	5	EPIC	
 2341	ghostly pepper	0		
@@ -2344,11 +2344,11 @@
 2370	natural fennel soda	0		
 2371	ghostly smoke bomb	0		
 2372	bunch of bananas	0		
-2373	low-calorie normal upside-down banana	1	good	
+2373	normal low-calorie upside-down banana	1	good	
 2374	ghostly twirling banana peel	0		
-2375	bite-sized adequate banana cream pie	1	good	
+2375	adequate bite-sized banana cream pie	1	good	
 2376	bad banana daiquiri	4	decent	
-2377	bad triple-distilled bungle in the jungle	7	decent	
+2377	triple-distilled bad bungle in the jungle	7	decent	
 2378	banana spritzer	0		
 2379	adjusted aerosolized banana smoothie	0		Effect: "Flamingly Floral", Effect Duration: 36
 2380	tumbling dandy lion cub	0		Free Pull, Last Available: "2007-03"
@@ -2380,7 +2380,7 @@
 2406	tumbling Panda outfit	0		Familiar Weight: +5, Item Drop: +5
 2407	shaking pink bat eye	0		
 2408	worthless piece of glass	0		
-2409	twirling fuchsia billy idol	0		
+2409	fuchsia twirling billy idol	0		
 2410	rag	0		
 2411	broken petri dish	0		
 2412	squat sammich crust	0		
@@ -2403,12 +2403,12 @@
 2429	dry tarnished purple Eau de Guaneau	0		Effect: "Vinegavotte", Effect Duration: 31
 2430	activated bag of lard	0		Effect: "Blessing of the Creepy Pasta", Effect Duration: 57
 2431	unsweetened blinking bottle of Mystic Shell	0		Effect: "Trivia Master", Effect Duration: 24
-2432	concentrated frozen gray tumbling bouncing SPF 451 lip balm	0		Effect: "In the Slimelight", Effect Duration: 12
+2432	concentrated frozen tumbling gray bouncing SPF 451 lip balm	0		Effect: "In the Slimelight", Effect Duration: 12
 2433	boiled altered bottle of antifreeze	0		Effect: "Demonic Taint", Effect Duration: 63
 2434	energized quadruple-cold-filtered tarnished green eyedrops	0		Effect: "Hyperoffended", Effect Duration: 25
 2435	triple-aerosolized Dogsgotnonoz pills	0		Effect: "Man's Worst Enemy", Effect Duration: 34
-2436	quantum cold-filtered green bouncing donkey flipbook	0		Effect: "Spiky Frozen Hair", Effect Duration: 45
-2437	skewed tumbling New Cloaca-Cola	0		
+2436	quantum cold-filtered bouncing green donkey flipbook	0		Effect: "Spiky Frozen Hair", Effect Duration: 45
+2437	tumbling skewed New Cloaca-Cola	0		
 2438	blurry scented massage oil	0		
 2439	blurry poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
@@ -2434,11 +2434,11 @@
 2460	skewed mirror yak toupee of dire peril	0		Weapon Damage: +20, Familiar Effect: "atk, 1xPotato, cap 25"
 2462	odor extractor	0		Last Available: "2019-12"
 2463	Manual of Transcendent Olfaction	0		Skill: "Transcendent Olfaction"
-2464	gigantic rotten bowl of Bounty-Os	8	crappy	
-2465	fancy tolerable triple-distilled ghostly maroon narrow Oreille Divis&eacute;e brandy	9	good	Effect: "Knightlife", Effect Duration: 25
+2464	rotten gigantic bowl of Bounty-Os	8	crappy	
+2465	triple-distilled fancy tolerable narrow ghostly maroon Oreille Divis&eacute;e brandy	9	good	Effect: "Knightlife", Effect Duration: 25
 2466	pompadour'd puppy	0		
 2467	fuchsia suede shoes	0		Familiar Weight: +5
-2468	blurry ghostly callused fingerbone	0		
+2468	ghostly blurry callused fingerbone	0		
 2469	bundle of receipts	0		
 2470	huge cork	0		
 2471	pulsating stardust	0		
@@ -2462,7 +2462,7 @@
 2489	jittery supercharged tuxedo shirt	0		Maximum MP Percent: +30
 2490	gravedigger's dance instructor's gnauga hide vest	0		Experience Percent (Moxie): +10, Spooky Damage: +10
 2491	shirt kit	0		
-2492	upside-down mirror narrow tropical orchid	0		
+2492	narrow upside-down mirror tropical orchid	0		
 2493	stick of dynamite	0		
 2494	squat crafty hale Necrotelicomnicon	0		Maximum HP: +20, Maximum MP: +10
 2495	reassuring Cookbook of the Damned of the blizzard	0		Cold Spell Damage: +25, Spooky Resistance: +1
@@ -2471,7 +2471,7 @@
 2498	molybdenum hammer	0		
 2499	molybdenum screwdriver	0		
 2500	molybdenum pliers	0		
-2501	upside-down purple molybdenum crescent wrench	0		
+2501	purple upside-down molybdenum crescent wrench	0		
 2502	Really Expensive Jewelry and You	0		Skill: "Really Expensive Jewelrycrafting"
 2503	wobbly green extra-fancy ring setting	0		
 2504	precious piercing post	0		
@@ -2490,22 +2490,22 @@
 2517	blurry shaking hale deadly chain necklace	0		Weapon Damage: +5, Maximum HP: +20
 2518	resourceful sawblade shield	0		Maximum MP: +50, Damage Reduction: 11
 2519	boozy acceptable tumbling McMillicancuddy's Special Lager	5	good	
-2520	practically non-alcoholic perfectly mixed melted Jell-o shot	1	EPIC	
-2521	practically non-alcoholic acceptable blinking skewed cruelty-free wine	1	good	
-2522	artisanal weak thistle wine	2	EPIC	
+2520	perfectly mixed practically non-alcoholic melted Jell-o shot	1	EPIC	
+2521	practically non-alcoholic acceptable skewed blinking cruelty-free wine	1	good	
+2522	weak artisanal thistle wine	2	EPIC	
 2523	olive megatofu	0		
 2524	displaced fish	0		
-2525	enchanted decent fish	4	good	Effect: "The Magical Mojomuscular Melody", Effect Duration: 10
-2526	delicious small fish casserole	2	awesome	
+2525	decent enchanted fish	4	good	Effect: "The Magical Mojomuscular Melody", Effect Duration: 10
+2526	small delicious fish casserole	2	awesome	
 2527	tasty fish lasagna	3	awesome	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
 2529	stale miniature gnatloaf	2	decent	
-2530	bite-sized bland gnatloaf casserole	1	decent	
+2530	bland bite-sized gnatloaf casserole	1	decent	
 2531	toothsome low-calorie gnat lasagna	1	awesome	
 2532	pork	0		
-2533	spoiled huge blue pork chop sandwiches	9	crappy	
+2533	huge spoiled blue pork chop sandwiches	9	crappy	
 2534	spoiled pork casserole	3	crappy	
-2535	decent miniature pork lasagna	2	good	
+2535	miniature decent pork lasagna	2	good	
 2536	green canopic jar	0		
 2537	spice	0		
 2538	organs	0		
@@ -2559,17 +2559,17 @@
 2586	boxer's General Sage's Lonely Diamonds Club Jacket	0		Muscle Percent: +10
 2587	Corporal Fennel's Lonely Clubs Club Jacket of the sewer	0		Stench Damage: +25
 2588	blinking wobbly stylish Private Pepper's Lonely Hearts Club Jacket	0		Moxie: +25
-2589	small adequate hot date	2	good	
+2589	adequate small hot date	2	good	
 2590	bad distilled fortified wine	4	decent	
-2591	spoiled snack-sized tasty tart	2	crappy	
+2591	snack-sized spoiled tasty tart	2	crappy	
 2592	Knob Goblin lunchbox	0		
-2593	low-calorie rotten bouncing Knob pasty	1	crappy	
+2593	rotten low-calorie bouncing Knob pasty	1	crappy	
 2594	special perfectly mixed blinking thermos full of Knob coffee	3	EPIC	Effect: "Flame-Retardant Trousers", Effect Duration: 25
 2595	extra-electrified adjusted Ben-Gal&trade; Balm	0		Effect: "Reptilian Fortitude", Effect Duration: 69
 2596	twirling leathery cat skin	0		
 2597	jittery leathery bat skin	0		
 2598	leathery rat skin	0		
-2599	tumbling lime green Discount Telescope Warehouse gift certificate	0		
+2599	lime green tumbling Discount Telescope Warehouse gift certificate	0		
 2600	carbonated water lily	0		
 2601	resourceful Staff of the Midnight Snack of vim and vigor of courage	0		Maximum HP Percent: +50, Maximum MP: +50, Spooky Resistance: +3
 2602	Van der Graaf brawny Staff of Blood and Pudding of the cheetah	0		Muscle Percent: +20, Initiative: +60, MP Regen Min: 5, MP Regen Max: 7
@@ -2585,12 +2585,12 @@
 2612	vinyl coin purse	0		
 2613	green rocky raccoon	0		
 2614	mojo filter	0		
-2615	big normal savoy truffle	5	good	
+2615	normal big savoy truffle	5	good	
 2616	Magi-Wipes	0		
 2617	fuchsia boom	0		
 2618	Annie Oakley's Iiti Kitty phone charm	0		Critical Hit Percent: +20, Single Equip
 2619	jar of swamp gas	0		Last Available: "2007-05"
-2620	miniature adequate unidentified jerky	2	good	
+2620	adequate miniature unidentified jerky	2	good	
 2621	olive mirror hale shellacked nasty rat mask	0		Damage Reduction: 7, Maximum HP: +20, Familiar Effect: "sleaze atk, 1xBarrr, cap 45"
 2622	veiny stiffened ratskin belt	0		Damage Reduction: 1, Maximum HP: +10, Single Equip
 2623	red mansplainer's rattail whip of the bloodbag	0		Maximum HP: +100, Monster Level: +15
@@ -2602,7 +2602,7 @@
 2629	mansplainer's Socratic tail o' nine cats	0		Experience (Mysticality): +1, Monster Level: +15
 2630	Hugo's Weaving Manual	0		
 2631	extra-unsweetened corrupted spinning gremlin juice	0		Effect: "Cold Hard Skin", Effect Duration: 55
-2632	diffused pickled moist ghostly green mother's helper	0		Effect: "Smoking like a Bandit", Effect Duration: 62
+2632	diffused pickled moist green ghostly mother's helper	0		Effect: "Smoking like a Bandit", Effect Duration: 62
 2633	lightning-fast Samson's pat-a-cake pendant	0		Experience (Muscle): +5, Initiative: +40
 2634	mummy wrapping	0		
 2635	really thick bandage	0		
@@ -2622,8 +2622,8 @@
 2649	Lord Spookyraven's ear trumpet of the glutton	0		Food Drop: +100, Single Equip
 2650	blinking bottled pixie	0		Free Pull
 2651	green pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	adequate gigantic shaking S.T.L.T.	7	good	Last Available: "2007-06"
-2653	snack-sized normal honey-dew	2	good	Last Available: "2007-06"
+2652	gigantic adequate shaking S.T.L.T.	7	good	Last Available: "2007-06"
+2653	normal snack-sized honey-dew	2	good	Last Available: "2007-06"
 2654	artisanal Xanadian	4	EPIC	Last Available: "2007-06"
 2655	nitrogenated double-irradiated ionized bottle of absinthe	0		Effect: "Floundering", Effect Duration: 51, Last Available: "2007-06"
 2656	nippy dance instructor's Drowsy Sword	0		Experience Percent (Moxie): +10, Cold Damage: +10
@@ -2646,7 +2646,7 @@
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	altered unsweetened huge bottle of cat tonic	0		Effect: "The Power of Positive Thinking", Effect Duration: 31, Last Available: "2007-06"
 2675	powdered blinking handful of moss	1		Effect: "Nightstalkin'", Effect Duration: 10
-2676	vaporized huge spinning bit-o-cactus	1		
+2676	vaporized spinning huge bit-o-cactus	1		
 2677	dried shaking protein powder	1		
 2678	spectre scepter	0		
 2679	unsweetened aerosolized ionized blinking sparkler	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 55
@@ -2678,7 +2678,7 @@
 2705	shaking MacGyver's occult blackberry slippers of wisdom	0		Mysticality: +15, Spell Damage Percent: +25, Maximum MP: +100, Single Equip
 2706	chilly hardy cool blackberry moccasins	0		Moxie: +5, Maximum HP: +50, Cold Damage: +5, Single Equip
 2707	blurry horrifying educational blackberry combat boots of the brazier	0		Experience: +1, Hot Spell Damage: +25, Spooky Damage: +25, Single Equip
-2708	activated pulsating red funky dried mushroom	0		Effect: "Pyramid Power", Effect Duration: 67
+2708	activated red pulsating funky dried mushroom	0		Effect: "Pyramid Power", Effect Duration: 67
 2709	exotic parrot egg	0		
 2710	blinking cracker	0		Familiar Weight: +15
 2711	frozen improved huge facepaint	0		Effect: "Icy Demeanor", Effect Duration: 61
@@ -2695,24 +2695,24 @@
 2722	rosy-cheeked wicked smartaleck's Staff of the Greasefire of the detective	0		Moxie Percent: +30, Spell Damage: +5, Maximum HP Percent: +30, Item Drop: +20
 2723	mirror pulsating hale padded Staff of the Grand Flamb&eacute; of bravery	0		Damage Absorption: +20, Maximum HP: +20, Spooky Resistance: +5
 2724	toothsome bowl of rye sprouts	3	awesome	
-2725	bland special jumbo cob of corn	5	decent	Effect: "Disco Concentration", Effect Duration: 50
-2726	decent small blinking juniper berries	2	good	
+2725	bland jumbo special cob of corn	5	decent	Effect: "Disco Concentration", Effect Duration: 50
+2726	small decent blinking juniper berries	2	good	
 2727	bland plum	4	decent	
-2728	massive normal blurry skewed pear	9	good	
+2728	massive normal skewed blurry pear	9	good	
 2729	bland peach	3	decent	
 2730	aged plum wine	3	awesome	
-2731	weak lousy tumbling shot of pear schnapps	2	decent	
+2731	lousy weak tumbling shot of pear schnapps	2	decent	
 2732	weak bad shot of peach schnapps	2	decent	
 2733	moldy bunch of square grapes	3	crappy	
-2734	snack-sized rotten fancy brown sugar cane	2	crappy	Effect: "Eye of the Seal", Effect Duration: 40
+2734	fancy rotten snack-sized brown sugar cane	2	crappy	Effect: "Eye of the Seal", Effect Duration: 40
 2735	rotten half-sized sandwich of the gods	2	crappy	
-2736	perfectly mixed triple-distilled Pan-Dimensional Gargle Blaster	9	EPIC	
+2736	triple-distilled perfectly mixed Pan-Dimensional Gargle Blaster	9	EPIC	
 2737	compressed lime green leopard-print barbell	1	decent	
 2738	jittery pile of smoking rags	0		
 2739	anodized panty raider camouflage	0		Effect: "Moon'd", Effect Duration: 61
 2740	fireproof hardened sinister Staff of the Walk-In Freezer	0		Spell Damage: +10, Damage Reduction: 3, Hot Resistance: +3
-2741	mediocre practically non-alcoholic boilermaker	1	decent	
-2742	miniature rotten steel lasagna	2	quest	
+2741	practically non-alcoholic mediocre boilermaker	1	decent	
+2742	rotten miniature steel lasagna	2	quest	
 2743	hand-crafted steel margarita	3	quest	
 2744	twisted steel-scented air freshener	1		
 2745	chilled gremlin mutagen	0		Effect: "Wreathed in Merriment", Effect Duration: 51
@@ -2738,7 +2738,7 @@
 2765	Harold's bell	0		
 2766	red bowling ball	0		
 2767	rotten spinning Crimbo pie	3	crappy	
-2768	small adequate pulsating pear tart	2	good	
+2768	adequate small pulsating pear tart	2	good	
 2769	flavorless peach pie	3	decent	
 2770	non-warmed liquefied bouncing chunk of rock salt	0		Effect: "Flower Power", Effect Duration: 60
 2771	pickled Vulcanized red tumbling handful of pine needles	0		Effect: "Pyromania", Effect Duration: 45
@@ -2772,7 +2772,7 @@
 2799	Sherlock's horrifying Mudflap-Girl Necklace	0		Spooky Damage: +25, Item Drop: +25, Single Equip
 2800	zippy energetic Mudflap-Girl Ring	0		Maximum MP Percent: +20, Initiative: +20, Single Equip
 2801	vial of Gnomochloric acid	0		
-2802	ghostly blue flask of Gnomochloric acid	0		
+2802	blue ghostly flask of Gnomochloric acid	0		
 2803	jug of Gnomochloric acid	0		
 2804	energized nitrogenated irradiated vial of hamethyst juice	0		Effect: "Seeing Colors", Effect Duration: 25
 2805	altered liquefied vial of baconstone juice	0		Effect: "Insulated Trousers", Effect Duration: 43
@@ -2781,7 +2781,7 @@
 2808	quadruple-chilled blinking flask of baconstone juice	0		Effect: "Going Ape", Effect Duration: 38
 2809	irradiated pulsating flask of porquoise juice	0		Effect: "Squid Squint", Effect Duration: 27
 2810	super-vacuum-sealed super-chilled shaking jug of hamethyst juice	0		Effect: "Raging Animal", Effect Duration: 40
-2811	polymerized upside-down twirling jug of baconstone juice	0		Effect: "Pisces Rising", Effect Duration: 69
+2811	polymerized twirling upside-down jug of baconstone juice	0		Effect: "Pisces Rising", Effect Duration: 69
 2812	polymerized ionized jug of porquoise juice	0		Effect: "Pride of the Vampire", Effect Duration: 63
 2813	mirror twirling executive Beret of terror	0		Spooky Spell Damage: +10, Meat Drop: +40, Four Songs, Familiar Effect: "1xVolley, 1xLep"
 2814	purple greasy occult Bludgeon of extreme caution	0		Spell Damage Percent: +25, Monster Level: -25, Sleaze Spell Damage: +10
@@ -2803,17 +2803,17 @@
 2830	digital key lime	0		
 2831	star key lime	0		
 2832	delicious digital key lime pie	4	awesome	
-2833	decent green ghostly star key lime pie	4	good	
-2834	family-friendly Jim Carey's bottle-rocket crossbow of the early riser	0		Monster Level: +25, Sleaze Resistance: +1, Adventures: +7, Softcore Only, Last Available: "2007-07", Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket"
+2833	decent ghostly green star key lime pie	4	good	
+2834	family-friendly Jim Carey's bottle-rocket crossbow of the early riser	0		Monster Level: +25, Sleaze Resistance: +1, Adventures: +7, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	quilted indie comic hipster glasses	0		Damage Absorption: +40, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
 2836	wizard action figure	0		Free Pull, Last Available: "2011-12"
-2837	blurry shaking twirling mint-condition magic wand	0		Last Available: "2011-12"
+2837	twirling blurry shaking mint-condition magic wand	0		Last Available: "2011-12"
 2838	flame-retardant cool glowstick	0		Moxie: +5, Hot Resistance: +1, Last Available: "2007-08"
 2839	sharpshooter's Periodical Paintbrush	0		Critical Hit Percent: +10, Softcore Only
 2840	mediocre bottle of cooking sherry	4	decent	
 2841	moldy packet of ketchup	4	crappy	
 2842	tolerable accidental cider	3	good	
-2843	miniature tasty dire fudgesicle	2	awesome	
+2843	tasty miniature dire fudgesicle	2	awesome	
 2844	extremely unsafe stylish wizardly weightlifter's navel ring of navel gazing	0		Muscle: +15, Mysticality: +25, Moxie: +25, Weapon Damage Percent: +100, Single Equip, Softcore Only, Last Available: "2007-09"
 2845	class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	plastic bib	0		Last Available: "2011-12"
@@ -2826,11 +2826,11 @@
 2853	Phil Bunion's axe	0		
 2854	mirror bouquet of swamp roses	0		
 2855	rock-hard huge mosquito proboscis of the scaredy-cat	0		Damage Reduction: 5, Monster Level: -15
-2856	modified purple shaking squat swamp lolly	0		Effect: "Carrrsmic", Effect Duration: 29
-2857	deionized upside-down jittery seegar butt	0		Effect: "Ironclad", Effect Duration: 33
+2856	modified shaking squat purple swamp lolly	0		Effect: "Carrrsmic", Effect Duration: 29
+2857	deionized jittery upside-down seegar butt	0		Effect: "Ironclad", Effect Duration: 33
 2858	wobbly bottled swamp gas	0		
 2859	Rosewater's wizardly witch wart	0		Mysticality: +25, Mysticality Percent: +30
-2860	small spoiled swamp muck	2	crappy	
+2860	spoiled small swamp muck	2	crappy	
 2861	double-paned Jack Frost's experienced leechknife	0		Experience: +2, Cold Spell Damage: +50, Cold Resistance: +5
 2862	decomposed boot	0		
 2863	vacuum-sealed ionized double-vacuum-sealed dribbly candle	0		Effect: "Whippin' It Good", Effect Duration: 66
@@ -2915,7 +2915,7 @@
 2942	aerosolized chocolate filthy lucre	0		Effect: "Sourpuss", Effect Duration: 22
 2943	tarnished Angry Farmer's Wife Candy	0		Effect: "Warm Shoulders", Effect Duration: 13
 2945	Fonzie's party hat of the pedagogue	0		Experience: +3, Experience (Moxie): +1, Familiar Effect: "4xLep, cap 7"
-2946	vibrating weightlifter's V for Vivala mask	0		Muscle: +15, Maximum MP Percent: +10, Single Equip, Softcore Only, Last Available: "2007-11", Conditional Skill (Equipped): "Creepy Grin"
+2946	vibrating weightlifter's V for Vivala mask	0		Muscle: +15, Maximum MP Percent: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	The Big Book of Pirate Insults	0		
 2948	smooth shot of rotgut	3	awesome	
 2949	colloidal improved huge jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Swimming with Sharks", Effect Duration: 40
@@ -2930,7 +2930,7 @@
 2958	moldy tube of cranberry Go-Goo	4	crappy	
 2959	coward's rum barrel charrrm bracelet	0		Monster Level: -20
 2960	moldy gray single-serving herbal stuffing	3	crappy	
-2961	flavorless gigantic packet of tofurkey gravy	6	decent	
+2961	gigantic flavorless packet of tofurkey gravy	6	decent	
 2962	rotten tofurkey nugget	3	crappy	
 2963	rigging shampoo	0		
 2964	pulsating ball polish	0		
@@ -2949,13 +2949,13 @@
 2977	twirling ribald witty rapier	0		Sleaze Damage: +10
 2978	olive experienced yohohoyo of the cougar	0		Moxie: +20, Experience: +2
 2979	modified dry mirror fish-liver oil	0		Effect: "Cotton Mouthed", Effect Duration: 30
-2980	yellow mirror booty chest charrrm	0		
+2980	mirror yellow booty chest charrrm	0		
 2981	asbestos-lined booty chest charrrm bracelet	0		Hot Resistance: +5, Single Equip
 2982	cannonball charrrm	0		
 2983	cannonball charrrm bracelet	0		Single Equip
 2984	blinking copper ha'penny charrrm	0		
 2985	bouncing sinister copper ha'penny charrrm bracelet	0		Spell Damage: +10
-2986	blinking bouncing tongue charrrm	0		
+2986	bouncing blinking tongue charrrm	0		
 2987	perfumed tongue charrrm bracelet of the businessman	0		Stench Resistance: +5, Meat Drop: +50, Single Equip
 2988	blue bit of clingfilm	0		
 2989	blinking red clingfilm trousers of the wise owl	0		Mysticality: +20, Familiar Effect: "sleaze atk, 1xPotato, cap 37"
@@ -2994,19 +2994,19 @@
 3022	twirling medium stone triangle	0		
 3023	small stone triangle	0		
 3024	shaking stone pyramid	0		
-3025	fortified delicious jittery corpse on the beach	5	awesome	
+3025	delicious fortified jittery corpse on the beach	5	awesome	
 3026	mediocre extra-dry twirling corpsetini	5	decent	
 3027	artisanal corpsedriver	3	super EPIC	
 3028	smooth watered-down Corpse Island iced tea	2	awesome	
-3029	weak delicious red-headed corpse	2	awesome	
+3029	delicious weak red-headed corpse	2	awesome	
 3030	triple-distilled artisanal kamicorpse-ee	9	EPIC	
 3031	high-proof smooth corpsel	7	awesome	
 3032	acceptable wobbly corpsebite	4	good	
 3033	huge Jack Frost's pirate fledges	0		Cold Spell Damage: +50
-3034	jittery spinning piece of thirteen	0		
+3034	spinning jittery piece of thirteen	0		
 3035	normal pearl onion	3	good	
 3036	flavorless sea biscuit	4	decent	
-3037	fortified aged spinning bottle of rum	5	awesome	
+3037	aged fortified spinning bottle of rum	5	awesome	
 3038	mediocre blue bottle of black-label rum	4	decent	
 3039	shaking cannonball	0		
 3040	blinking voodoo skull	0		
@@ -3015,9 +3015,9 @@
 3043	squat metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
 3044	upside-down metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
 3045	moldy nanite-infested gingerbread bugbear	4	crappy	Last Available: "2007-12"
-3046	stale tiny wobbly nanite-infested candy cane	1	decent	Last Available: "2020-09"
+3046	tiny stale wobbly nanite-infested candy cane	1	decent	Last Available: "2020-09"
 3047	normal yellow nanite-infested fruitcake	3	good	Last Available: "2007-12"
-3048	boozy tolerable nanite-infested eggnog	5	good	Last Available: "2007-12"
+3048	tolerable boozy nanite-infested eggnog	5	good	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	blurry steel-toed eyepatch	0		Damage Reduction: 9, Familiar Effect: "spooky atk, 1xBarrr"
 3051	upside-down twirling Sherlock's cutlass	0		Item Drop: +25
@@ -3044,7 +3044,7 @@
 3072	carbonite visor	0		Last Available: "2007-12"
 3073	wobbly set of Unobtainium straps	0		Last Available: "2007-12"
 3074	polymorphic fastening apparatus	0		Last Available: "2007-12"
-3075	wobbly narrow General Assembly Module	0		Last Available: "2007-12"
+3075	narrow wobbly General Assembly Module	0		Last Available: "2007-12"
 3076	huge laser targeting chip	0		Last Available: "2007-12"
 3077	gray hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	spinning kevlateflocite helmet	0		Last Available: "2007-12"
@@ -3082,12 +3082,12 @@
 3110	blurry Miniborg strangler	0		Last Available: "2007-12"
 3111	twirling Miniborg laser	0		Last Available: "2007-12"
 3112	jittery Miniborg beeper	0		Last Available: "2007-12"
-3113	bouncing spinning upside-down Miniborg hiveminder	0		Last Available: "2007-12"
+3113	spinning upside-down bouncing Miniborg hiveminder	0		Last Available: "2007-12"
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
-3118	olive ghostly divine noisemaker	0		Last Available: "2008-01"
+3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3118	ghostly olive divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
 3121	divine champagne popper	0		Last Available: "2008-01"
@@ -3136,7 +3136,7 @@
 3164	yellow El Vibrato leg guards	0		Familiar Effect: "1xBarrr, 1xGhuol"
 3165	pulsating broken El Vibrato drone	0		
 3166	repaired El Vibrato drone	0		
-3167	purple shaking augmented El Vibrato drone	0		
+3167	shaking purple augmented El Vibrato drone	0		
 3168	diffused squat mirror seal eyeball	0		Effect: "Amorphous Cheer", Effect Duration: 68
 3169	yummy turtle soup	3	awesome	Effect: "[598]A Little Bit Evil"
 3170	blinking evil noodles	0		
@@ -3145,25 +3145,25 @@
 3173	quantum galvanized wobbly evil vihuela	0		Effect: "Pronounced Potency", Effect Duration: 20
 3174	small decent evil boring spaghetti	2	good	
 3175	adequate mirror evil noodles	3	good	
-3176	decent jumbo evil noodles	5	good	
+3176	jumbo decent evil noodles	5	good	
 3177	yummy miniature blue evil painful penne pasta	2	awesome	
 3178	decent 3vi1 pr0n m4nic0tti	4	good	
-3179	flavorless teal shaking evil ravioli della hippy	3	decent	
-3180	super-sized bland evil noodles	5	decent	
+3179	flavorless shaking teal evil ravioli della hippy	3	decent	
+3180	bland super-sized evil noodles	5	decent	
 3181	activated Vulcanized mirror evil potion of potency	0		Effect: "Trash-Wrapped", Effect Duration: 40
 3182	tarnished triple-diffused evil libation of liveliness	0		Effect: "Coy to the Hurled", Effect Duration: 29
 3183	adjusted evil tomato juice of powerful power	0		Effect: "Spiritually Awake", Effect Duration: 36
 3184	adjusted evil eyedrops of the ermine	0		Effect: "Ooh, Sour!", Effect Duration: 51
-3185	quadruple-modified extra-cold-filtered blurry purple evil ointment of the occult	0		Effect: "Altered Wavelengths", Effect Duration: 67
+3185	quadruple-modified extra-cold-filtered purple blurry evil ointment of the occult	0		Effect: "Altered Wavelengths", Effect Duration: 67
 3186	ionized anodized huge evil serum of sarcasm	0		Effect: "You Know Who to Call", Effect Duration: 20
 3187	pickled dry huge evil philter of phorce	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 26
 3188	tolerable practically non-alcoholic blinking an evil sump'm sump'm	1	good	
 3189	tolerable special evil ducha de oro	3	good	Effect: "Net Tea", Effect Duration: 35
 3190	triple-distilled perfectly mixed squat evil horizontal tango	9	EPIC	
-3191	perfectly mixed irresponsibly strong evil roll in the hay	9	EPIC	
+3191	irresponsibly strong perfectly mixed evil roll in the hay	9	EPIC	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
-3194	upside-down ghostly purple origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
+3194	purple upside-down ghostly origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
 3195	naughty paper shuriken	0		Last Available: "2008-02"
 3196	asbestos-lined origami pasties	0		Hot Resistance: +5, Softcore Only, Last Available: "2008-02"
 3197	aromatic sizzling hardened origami riding crop	0		Damage Reduction: 3, Hot Damage: +10, Stench Resistance: +1, Softcore Only, Last Available: "2008-02"
@@ -3186,15 +3186,15 @@
 3214	dwarvish parchment	0		
 3215	overcharged El Vibrato power sphere	0		
 3216	Fly-By-Knight Heraldry form	0		Free Pull
-3217	narrow bouncing El Vibrato Megadrone	0		
+3217	bouncing narrow El Vibrato Megadrone	0		
 3218	horrifying glowstick of the businessman	0		Spooky Damage: +25, Meat Drop: +50, Last Available: "2008-02"
 3219	pulsating sane hatrack	0		Free Pull, Last Available: "2011-12"
 3220	jittery hobo code binder	0		Free Pull
-3221	narrow green gator skin	0		
+3221	green narrow gator skin	0		
 3222	wool mansplainer's gatorskin umbrella	0		Monster Level: +15, Cold Resistance: +1
 3223	lime green sewer nuggets	0		
 3224	jittery sewer wad	0		
-3225	special acceptable bottle of sewage schnapps	4	good	Effect: "Action", Effect Duration: 30
+3225	acceptable special bottle of sewage schnapps	4	good	Effect: "Action", Effect Duration: 30
 3226	aged bottle of Ooze-O	3	awesome	
 3227	bland C.H.U.M. chum	3	decent	
 3228	delicious wobbly unfortunate dumplings	3	awesome	
@@ -3212,7 +3212,7 @@
 3240	Biddy Cracker's Old-Fashioned Cookbook	0		Skill: "Eggsplosion"
 3241	upside-down Travels with Jerry	0		Skill: "Mudbath"
 3242	Let Me Be!	0		Skill: "Raise Backup Dancer"
-3243	wobbly twirling Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
+3243	twirling wobbly Asleep in the Cemetery	0		Skill: "Creepy Lullaby"
 3244	Summer Nights	0		Skill: "Grease Lightning"
 3245	Sensual Massage for Creeps	0		Skill: "Inappropriate Backrub"
 3246	skewed mirror scandalous grievous Ol' Scratch's ol' britches	0		Weapon Damage Percent: +50, Sleaze Damage: +5, Class: "Sauceror", Familiar Effect: "hot atk, 1xPotato"
@@ -3232,7 +3232,7 @@
 3260	frightening Samson's Chester's moustache of the storm	0		Experience (Muscle): +5, Maximum MP Percent: +40, Spooky Damage: +5, Class: "Disco Bandit", Single Equip
 3261	narrow Van der Graaf supercharged Chester's bag of candy	0		Maximum MP Percent: +30, MP Regen Min: 5, MP Regen Max: 7, Class: "Disco Bandit"
 3262	blue toasty experienced Chester's cutoffs	0		Experience: +2, Hot Damage: +5, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
 3264	jittery candygram	0		Last Available: "2008-04"
 3265	mirror bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3240,9 +3240,9 @@
 3268	galvanized extra-frozen huge jittery handful of Crotchety Pine needles	0		Effect: "Spiky Frozen Hair", Effect Duration: 57
 3269	anodized double-polymerized lump of Saccharine Maple sap	0		Effect: "Unusual Perspective", Effect Duration: 54
 3270	irradiated ionized shaking handful of Laughing Willow bark	0		Effect: "Swordholder", Effect Duration: 11
-3271	narrow avaricious crotchety pants	0		Meat Drop: +30, Familiar Effect: "3xPotato, 2xGhuol, cap 18", Conditional Skill (Equipped): "Put Down Roots"
+3271	narrow avaricious crotchety pants	0		Meat Drop: +30, Conditional Skill (Equipped): "Put Down Roots", Familiar Effect: "3xPotato, 2xGhuol, cap 18"
 3272	Lo Pan's Saccharine Maple pendant	0		Spell Critical Percent: +30, Conditional Skill (Equipped): "Spray Sap"
-3273	vibrating willowy bonnet	0		Maximum MP Percent: +10, Familiar Effect: "1xFairy, cap 18", Conditional Skill (Equipped): "Rouse Sapling"
+3273	vibrating willowy bonnet	0		Maximum MP Percent: +10, Conditional Skill (Equipped): "Rouse Sapling", Familiar Effect: "1xFairy, cap 18"
 3274	flavored foot massage oil	0		Last Available: "2008-04"
 3275	dart	0		Last Available: "2008-04"
 3276	twirling black-and-blue light	0		Last Available: "2008-04"
@@ -3291,12 +3291,12 @@
 3319	up-at-dawn Mr. Joe's bangles	0		Adventures: +5, Single Equip
 3320	huge wool frayed rope belt	0		Cold Resistance: +1, Single Equip
 3321	olive packet of mayfly bait	0		Last Available: "2008-05"
-3322	ribald flame-wreathed mayfly bait necklace	0		Hot Spell Damage: +10, Sleaze Damage: +10, Single Equip, Softcore Only, Last Available: "2008-05", Conditional Skill (Equipped): "Summon Mayfly Swarm"
+3322	ribald flame-wreathed mayfly bait necklace	0		Hot Spell Damage: +10, Sleaze Damage: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Summon Mayfly Swarm", Last Available: "2008-05"
 3323	tumbling Ol' Scratch's salad fork	0		
 3324	olive Frosty's frosty mug	0		
-3325	lousy watered-down jar of fermented pickle juice	2	decent	
-3326	boiled huge fuchsia voodoo snuff	1	EPIC	
-3327	spoiled upside-down mirror extra-greasy slider	3	crappy	
+3325	watered-down lousy jar of fermented pickle juice	2	decent	
+3326	boiled fuchsia huge voodoo snuff	1	EPIC	
+3327	spoiled mirror upside-down extra-greasy slider	3	crappy	
 3328	cool crumpled felt fedora of the overflowing toilet	0		Moxie: +5, Stench Spell Damage: +50, Familiar Effect: "0.75xVolley, 0.75xLep"
 3329	Usain Bolt's executive battered top-hat	0		Meat Drop: +40, Initiative: +80, Familiar Effect: "0.5xVolley, 0.75xFairy"
 3330	tumbling chilly lion tamer's shapeless wide-brimmed hat	0		Experience (familiar): +2, Cold Damage: +5, Familiar Effect: "0.75xLep, 0.75xFairy"
@@ -3307,7 +3307,7 @@
 3335	rope with some soap on it	0		Spell Damage Percent: +100, Single Equip
 3336	dead guy's piece of double-sided tape	0		
 3337	yellow dead guy's memento of the cougar of James Dean	0		Moxie: +20, Experience (Moxie): +3, Single Equip
-3338	miniature delicious yellow banquet	2	awesome	
+3338	delicious miniature yellow banquet	2	awesome	
 3339	sharpened hubcap	0		
 3340	squat very caltrop	0		
 3341	ghostly The Six-Pack of Pain	0		
@@ -3323,7 +3323,7 @@
 3351	blinking llama lama cria	0		Free Pull, Last Available: "2008-06"
 3352	zen motorcycle	0		Last Available: "2008-06"
 3353	nitrogenated llama lama gong	0		Effect: "Rat-Faced", Effect Duration: 33, Last Available: "2008-06"
-3354	adequate diet mirror banana-frosted king cake	1	good	Last Available: "2008-08"
+3354	diet adequate mirror banana-frosted king cake	1	good	Last Available: "2008-08"
 3355	brown plastic baby of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2008-08"
 3356	skewed plump juicy grub	0		Last Available: "2008-06"
 3357	shimmering moth	0		Last Available: "2008-06"
@@ -3332,7 +3332,7 @@
 3360	blinking stinkbug	0		Last Available: "2008-06"
 3361	skewed yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
-3363	normal half-sized huge mole mol&eacute;	2	good	Last Available: "2008-06"
+3363	half-sized normal huge mole mol&eacute;	2	good	Last Available: "2008-06"
 3364	artisanal Morlock's Mark Bourbon	4	EPIC	Last Available: "2008-06"
 3365	chilled pulsating Climate Colada	0		Effect: "For Your Brain Only", Effect Duration: 60, Last Available: "2008-06"
 3366	enhanced concentrated triple-dry digital underground potion	0		Effect: "Stimulated Brain", Effect Duration: 36, Last Available: "2008-06"
@@ -3386,7 +3386,7 @@
 3414	Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
 3416	hobo fortress blueprints	0		
-3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Last Available: "2008-07", Conditional Skill (Equipped): "Fire off a Roman Candle"
+3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	ionized sterno-flavored Hob-O	0		Effect: "Coated Arms", Effect Duration: 47
 3423	adjusted skewed frostbite-flavored Hob-O	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 62
 3424	vacuum-sealed galvanized fry-oil-flavored Hob-O	0		Effect: "Human-Horror Hybrid", Effect Duration: 60
@@ -3407,7 +3407,7 @@
 3440	vaporized prismatic wad	1	decent	Last Available: "2008-07"
 3441	yellow nasty club of the five seasons	0		Stench Damage: +5, Last Available: "2008-07"
 3442	tumbling gravedigger's rainbow crossbow	0		Spooky Damage: +10, Last Available: "2008-07"
-3443	huge upside-down kitten	0		
+3443	upside-down huge kitten	0		
 3444	Newton's webbed comic mask	0		Experience (Mysticality): +3, Softcore Only, Familiar Effect: "1xVolley, 1xLep, cap 2"
 3445	Junior Adventurer's kit	0		
 3446	groovy prism necklace	0		Single Equip
@@ -3430,10 +3430,10 @@
 3463	tolerable gray bottle of sake	4	good	
 3464	shellacked round pebble	0		Damage Reduction: 7
 3465	gigantic moldy Bash-&#332;s cereal	7	crappy	Wiki Name: "Bash-Os cereal"
-3466	teal prompt hardy haiku katana of chilblains	0		Maximum HP: +50, Cold Damage: +25, Adventures: +3, Softcore Only, Last Available: "2008-09", Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
+3466	teal prompt hardy haiku katana of chilblains	0		Maximum HP: +50, Cold Damage: +25, Adventures: +3, Softcore Only, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts", Last Available: "2008-09"
 3467	bargain flash powder	0		
 3468	executive plastic baby	0		Meat Drop: +40, Single Equip, Last Available: "2008-12"
-3469	stale low-calorie blueberry-frosted king cake	1	decent	Last Available: "2008-12"
+3469	low-calorie stale blueberry-frosted king cake	1	decent	Last Available: "2008-12"
 3470	bitty bathysphere	0		Familiar Weight: -20, Underwater Familiar, Familiar Effect: "adventure underwater"
 3471	spinning damp boot	0		
 3472	tumbling fireproof double-paned Seasonal Beret of chilblains	0		Cold Damage: +25, Cold Resistance: +5, Hot Resistance: +3, Familiar Effect: "1xPotato, 1xFairy, cap 25"
@@ -3465,13 +3465,13 @@
 3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3499	upside-down witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
-3501	adequate fuchsia skewed canap&eacute;s	3	good	
+3501	adequate skewed fuchsia canap&eacute;s	3	good	
 3502	powdered thermos of brew	1	good	Last Available: "2011-12"
-3503	acceptable special weak jittery mirror glass of brandy	2	good	Effect: "Inner Dog", Effect Duration: 10, Last Available: "2011-12"
+3503	special weak acceptable jittery mirror glass of brandy	2	good	Effect: "Inner Dog", Effect Duration: 10, Last Available: "2011-12"
 3504	French slippers	0		
 3505	cool LWA ring	0		Moxie: +5
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
+3507	Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
 3508	pulsating twirling fortified scratch 'n' sniff sword	0		Damage Absorption: +60, Last Available: "2008-11"
 3509	purple scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	yellow scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3522,15 +3522,15 @@
 3555	snack-sized stale spinning sea carrot	2	decent	
 3556	rotten sea cucumber	4	crappy	
 3557	small adequate sea avocado	2	good	
-3558	bite-sized decent purple sea lychee	1	good	
-3559	thick moldy enchanted squat sea tangelo	5	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 25
+3558	decent bite-sized purple sea lychee	1	good	
+3559	moldy enchanted thick squat sea tangelo	5	crappy	Effect: "Human-Beast Hybrid", Effect Duration: 25
 3560	decent sea honeydew	3	good	
 3561	boiled green pressurized potion of puissance	0		Effect: "Bastard!", Effect Duration: 31
 3562	non-cold-filtered modified narrow pressurized potion of perspicacity	0		Effect: "Eggs-tra Sensory Perception", Effect Duration: 31
 3563	moist pressurized potion of pulchritude	0		Effect: "Peppermint Bite", Effect Duration: 41
-3564	practically non-alcoholic acceptable berry-infused sake	1	good	
+3564	acceptable practically non-alcoholic berry-infused sake	1	good	
 3565	smooth citrus-infused sake	3	awesome	
-3566	bad spinning red melon-infused sake	4	decent	
+3566	bad red spinning melon-infused sake	4	decent	
 3567	gray slab of sponge	0		
 3568	Van der Graaf rosy-cheeked sponge helmet of the storm	0		Maximum HP Percent: +30, Maximum MP Percent: +40, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "atk, 1xFairy"
 3569	wobbly wool Jack Frost's spongy shield of terror	0		Cold Spell Damage: +50, Spooky Spell Damage: +10, Cold Resistance: +1, Damage Reduction: 14
@@ -3548,18 +3548,18 @@
 3581	sushi-rolling mat	0		
 3582	small moldy rice	2	crappy	
 3584	flavorless massive bouncing irradiated candy cane	9	decent	Last Available: "2008-12"
-3585	small spoiled shaking gingerbread mutant bugbear	2	crappy	Last Available: "2008-12"
-3586	special acceptable narrow oozenog	3	good	Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2008-12"
+3585	spoiled small shaking gingerbread mutant bugbear	2	crappy	Last Available: "2008-12"
+3586	acceptable special narrow oozenog	3	good	Effect: "Hot Buttoned", Effect Duration: 10, Last Available: "2008-12"
 3587	aerosolized sugar plum	0		Effect: "Super-Mega-Charged", Effect Duration: 48, Last Available: "2008-12"
 3588	enhanced huge sugar banana	0		Effect: "Egg Burps", Effect Duration: 42, Last Available: "2008-12"
 3589	corrupted unsweetened extra-aerosolized twirling sugar lime	0		Effect: "Perception", Effect Duration: 64, Last Available: "2008-12"
 3590	ionized diffused sugar cherry	0		Effect: "The Q Is Talking To You", Effect Duration: 38, Last Available: "2008-12"
 3591	ribald energetic Mer-kin hookspear	0		Maximum MP Percent: +20, Sleaze Damage: +10
 3592	spinning Mer-kin takebag	0		Item Drop: +5
-3593	ghostly mirror Mer-kin thingpouch	0		
+3593	mirror ghostly Mer-kin thingpouch	0		
 3594	Mer-kin killscroll	0		
 3595	super-improved tarnished fuchsia Mer-kin fastjuice	0		Effect: "Prelude of Precision", Effect Duration: 56
-3596	blinking blue imitation crab crate	0		
+3596	blue blinking imitation crab crate	0		
 3597	imitation crab meat	0		
 3598	blurry imitation crab zoea	0		
 3599	pulsating miser's wicked supercool moist sailor's cap	0		Moxie Percent: +20, Spell Damage: +5, Meat Drop: +10, Familiar Effect: "stench atk"
@@ -3581,7 +3581,7 @@
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	pulsing flesh	0		Last Available: "2008-12"
 3617	electrified anodized unstable DNA	0		Effect: "Knightlife", Effect Duration: 30, Last Available: "2008-12"
-3618	ghostly jittery The Spirit of Crimbo	0		Free Pull, Last Available: "2008-12", Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'"
+3618	ghostly jittery The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	skewed wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
 3621	pair of twitching claws	0		Last Available: "2008-12"
@@ -3595,7 +3595,7 @@
 3629	burrowgrub hive	0		Last Available: "2008-12"
 3630	Crimbo crate	0		Last Available: "2008-12"
 3631	chilled Gummi-DNA	0		Effect: "[800]Chocolate Reign", Effect Duration: 21, Last Available: "2020-09"
-3632	narrow ghostly radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
+3632	ghostly narrow radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	Annie Oakley's curative elven socks	0		Critical Hit Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2008-12"
 3634	jittery Sherlock's studded elven gloves	0		Damage Absorption: +80, Item Drop: +25, Last Available: "2008-12"
 3635	sinister festive holiday hat of Calamity Jane	0		Spell Damage: +10, Critical Hit Percent: +15, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
@@ -3612,9 +3612,9 @@
 3646	stale blurry elven <i>limbos</i> gingerbread	3	decent	Last Available: "2008-12"
 3647	elven whittling knife	0		Last Available: "2008-12"
 3648	magic dragonfish fry	0		
-3649	squat blinking map to Madness Reef	0		
-3650	stale miniature toast with jam	2	decent	Last Available: "2008-12"
-3651	antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3649	blinking squat map to Madness Reef	0		
+3650	miniature stale toast with jam	2	decent	Last Available: "2008-12"
+3651	antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	triple-distilled acceptable shaking elven moonshine	8	good	Last Available: "2008-12"
 3653	bland knuckle sandwich	3	decent	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	wobbly avaricious extremely unsafe psycho sweater	0		Weapon Damage Percent: +100, Meat Drop: +30, Last Available: "2008-12"
@@ -3650,11 +3650,11 @@
 3684	flavorless tempura carrot	3	decent	
 3685	moldy massive tempura cucumber	10	crappy	
 3686	spoiled low-calorie teal tempura avocado	1	crappy	
-3687	rotten jittery yellow sea broccoli	3	crappy	
-3688	immense bland sea cauliflower	9	decent	
-3689	fancy decent tempura broccoli	3	good	Effect: "Oleaginous Soles", Effect Duration: 35
-3690	adequate immense tempura cauliflower	9	good	
-3691	tasty diet sea blueberry	1	awesome	
+3687	rotten yellow jittery sea broccoli	3	crappy	
+3688	bland immense sea cauliflower	9	decent	
+3689	decent fancy tempura broccoli	3	good	Effect: "Oleaginous Soles", Effect Duration: 35
+3690	immense adequate tempura cauliflower	9	good	
+3691	diet tasty sea blueberry	1	awesome	
 3692	massive spoiled sea persimmon	10	crappy	
 3693	ionized magnetized twirling pressurized potion of perception	0		Effect: "Wet Jaw", Effect Duration: 11
 3694	extra-chilled anodized jittery pressurized potion of proficiency	0		Effect: "White Blooded", Effect Duration: 20
@@ -3689,13 +3689,13 @@
 3723	bouncing tarnished rod	0		
 3724	tumbling brittle plastic handle	0		
 3725	mirror foggy glass globe	0		
-3726	cyan skewed possessed tomato	0		
+3726	skewed cyan possessed tomato	0		
 3727	gray Nardz energy beverage	0		
 3728	wobbly pile of coins	0		
 3729	narrow hand grenegg	0		
 3730	caret	0		
 3731	weightlifter's glass gnoll eye	0		Muscle: +15
-3732	boiled tumbling pulsating cigar butt	0		Effect: "Heart of Green", Effect Duration: 30
+3732	boiled pulsating tumbling cigar butt	0		Effect: "Heart of Green", Effect Duration: 30
 3733	huge family-friendly manly bloomers of Leguizamo	0		Monster Level: +20, Sleaze Resistance: +1, Familiar Effect: "3xBarrr, 1xGhuol, cap 13"
 3734	Colon Annihilation Hot Sauce	0		
 3735	fat wallet	0		
@@ -3705,7 +3705,7 @@
 3739	Boozehounds Anonymous token	0		
 3740	handful of bees	0		
 3741	spectral jelly	0		
-3742	polarized corrupted skewed olive jellyfish gel	0		Effect: "Dreadful Heat", Effect Duration: 19
+3742	polarized corrupted olive skewed jellyfish gel	0		Effect: "Dreadful Heat", Effect Duration: 19
 3743	huge narrow unstable quark	0		
 3744	software glitch	0		
 3745	fumble formula	0		Recipe: "concoction of clumsiness"
@@ -3713,24 +3713,24 @@
 3747	mother's secret recipe	0		Recipe: "white chocolate chip brownies"
 3749	liquefied squat blue concoction of clumsiness	0		Effect: "Pronounced Potency", Effect Duration: 18
 3750	deadly vampire pearl earring	0		Weapon Damage: +5, Single Equip
-3751	special bland huge chocolate chip brownies	4	decent	Effect: "Pumped Up", Effect Duration: 35
-3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
+3751	bland special huge chocolate chip brownies	4	decent	Effect: "Pumped Up", Effect Duration: 35
+3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
 3754	super-concentrated colloidal blue love song of vague ambiguity	0		Effect: "Shamboozled", Effect Duration: 16, Last Available: "2009-02"
 3755	irradiated blinking love song of smoldering passion	0		Effect: "Eyes Wide Propped", Effect Duration: 44, Last Available: "2009-02"
 3756	ionized love song of icy revenge	0		Effect: "Singer's Faithful Ocelot", Effect Duration: 31, Last Available: "2009-02"
 3757	magnetized boiled love song of sugary cuteness	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 53, Last Available: "2009-02"
 3758	moist pulsating love song of disturbing obsession	0		Effect: "Shawarma Warm War", Effect Duration: 58, Last Available: "2009-02"
-3759	double-altered pressed upside-down bouncing love song of naughty innuendo	0		Effect: "Once Bitten Twice Fried", Effect Duration: 62, Last Available: "2009-02"
+3759	double-altered pressed bouncing upside-down love song of naughty innuendo	0		Effect: "Once Bitten Twice Fried", Effect Duration: 62, Last Available: "2009-02"
 3760	unsweetened breath mint	0		Effect: "Lifted Spirits", Effect Duration: 53
 3761	lard-coated vampire pearl ring	0		Sleaze Spell Damage: +25, Single Equip
 3762	huge tumbling personal trainer's vampire pearl necklace	0		Experience Percent (Muscle): +10, Single Equip
 3763	bad slug of vodka	4	decent	
-3764	perfectly mixed fortified slug of rum	5	EPIC	
+3764	fortified perfectly mixed slug of rum	5	EPIC	
 3765	lousy squat slug of shochu	4	decent	
 3766	perfectly mixed screwdiver	4	EPIC	
-3767	lousy weak dew yoana lei	2	decent	
-3768	hand-crafted enchanted lychee chuhai	3	EPIC	Effect: "Slimed Stomach", Effect Duration: 30
-3769	weak bad twirling salacious screwdiver	2	decent	
+3767	weak lousy dew yoana lei	2	decent	
+3768	enchanted hand-crafted lychee chuhai	3	EPIC	Effect: "Slimed Stomach", Effect Duration: 30
+3769	bad weak twirling salacious screwdiver	2	decent	
 3770	tolerable dew yoana salacious lei	4	good	
 3771	aged red salacious lychee chuhai	4	awesome	
 3772	tolerable boozy narrow Alewife&trade; Ale	5	good	
@@ -3743,8 +3743,8 @@
 3779	pickled activated hair of the fish	0		Effect: "Insatiable Hunger", Effect Duration: 67
 3780	ribald coward's grievous nurse's hat	0		Weapon Damage Percent: +50, Monster Level: -20, Sleaze Damage: +10, Familiar Effect: "atk"
 3781	tumbling blank prescription sheet	0		
-3782	compressed blinking huge bottle of melodramamine	1		
-3783	powdered mirror bouncing bottle of extra-strength melodramamine	1		
+3782	compressed huge blinking bottle of melodramamine	1		
+3783	powdered bouncing mirror bottle of extra-strength melodramamine	1		
 3784	spinning paranormal ricotta	0		Class: "Pastamancer"
 3785	smoking talon	0		Class: "Pastamancer"
 3786	vampire glitter	0		Class: "Pastamancer"
@@ -3753,14 +3753,14 @@
 3789	twitching trigger finger	0		Class: "Pastamancer"
 3799	teal Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	shaking aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	purple squat crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3801	squat purple crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
 3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	Jeselnik's scorching Mer-kin roundshield of the storm	0		Maximum MP Percent: +40, Hot Damage: +25, Sleaze Damage: +25, Damage Reduction: 14
 3804	Jack Frost's Mer-kin breastplate of the pedagogue	0		Experience: +3, Cold Spell Damage: +50
 3805	blinking fortified stylish Mer-kin sneakmask	0		Moxie: +25, Damage Absorption: +60, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	jittery Mer-kin prayerbeads	0		
 3807	super-improved moist aerosolized Mer-kin hidepaint	0		Effect: "Rootin' Around", Effect Duration: 51
-3808	red upside-down Mer-kin trailmap	0		
+3808	upside-down red Mer-kin trailmap	0		
 3809	blurry lime green Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	Mer-kin stashbox	0		
@@ -3768,7 +3768,7 @@
 3813	pulsating teal lightning-fast plastic baby	0		Initiative: +40, Single Equip, Last Available: "2009-06"
 3815	midget clownfish	0		
 3816	half-height unicycle	0		Familiar Weight: +5
-3817	tasty tiny squat sea radish	1	awesome	
+3817	tiny tasty squat sea radish	1	awesome	
 3818	hale wholesome cool halibut	0		Moxie: +5, Maximum HP Percent: +10, Maximum HP: +20
 3819	eel sauce	0		
 3820	horrifying water-polo mitt	0		Spooky Damage: +25, Single Equip
@@ -3783,11 +3783,11 @@
 3829	decent tempura radish	4	good	
 3830	blurry water-polo cap of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	drinkable huge Typical Tavern swill	4	good	
-3832	weak mediocre upside-down green tropical swill	2	decent	
-3833	mediocre shaking blinking fruity girl swill	4	decent	
-3834	irresponsibly strong lousy blended swill	9	decent	
+3832	weak mediocre green upside-down tropical swill	2	decent	
+3833	mediocre blinking shaking fruity girl swill	4	decent	
+3834	lousy irresponsibly strong blended swill	9	decent	
 3835	costume wardrobe	0		Softcore Only
-3836	wobbly knitted chaotic stylish Elvish sunglasses of the detective	0		Moxie: +25, Spell Critical Percent: +10, Cold Resistance: +3, Item Drop: +20, Single Equip, Softcore Only, Last Available: "2009-04", Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
+3836	wobbly knitted chaotic stylish Elvish sunglasses of the detective	0		Moxie: +25, Spell Critical Percent: +10, Cold Resistance: +3, Item Drop: +20, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
 3837	personal trainer's anniversary safety glass vest	0		Experience Percent (Muscle): +10
 3838	anniversary burlap belt of temperance	0		Sleaze Resistance: +5
 3839	narrow auspicious anniversary balsa wood socks	0		Item Drop: +10
@@ -3844,7 +3844,7 @@
 3890	modified improved tumbling vial of violet slime	0		Effect: "Larger", Effect Duration: 58
 3891	warmed ionized vial of vermilion slime	0		Effect: "Pride of the Vampire", Effect Duration: 22
 3892	chilled vial of amber slime	0		Effect: "Unusual Fashion Sense", Effect Duration: 13
-3893	pickled shaking blinking vial of chartreuse slime	0		Effect: "Human-Hobo Hybrid", Effect Duration: 69
+3893	pickled blinking shaking vial of chartreuse slime	0		Effect: "Human-Hobo Hybrid", Effect Duration: 69
 3894	double-unsweetened diffused vial of teal slime	0		Effect: "Can't Be a Chooser", Effect Duration: 11
 3895	improved cyan vial of indigo slime	0		Effect: "Hare-o-dynamic", Effect Duration: 50
 3896	flattened improved ghostly ghostly vial of slime	0		Effect: "You're Not Cooking", Effect Duration: 21
@@ -3852,12 +3852,12 @@
 3898	bottle of G&uuml;-Gone	0		
 3901	skewed seal-blubber candle	0		Class: "Seal Clubber"
 3902	figurine of a wretched-looking seal	0		Class: "Seal Clubber"
-3903	red huge figurine of a baby seal	0		Class: "Seal Clubber"
+3903	huge red figurine of a baby seal	0		Class: "Seal Clubber"
 3904	figurine of an armored seal	0		Class: "Seal Clubber"
 3905	fuchsia figurine of an seal	0		Class: "Seal Clubber"
-3906	wobbly spinning figurine of a sleek seal	0		Class: "Seal Clubber"
+3906	spinning wobbly figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	figurine of a shadowy seal	0		Class: "Seal Clubber"
-3908	gray skewed figurine of a stinking seal	0		Class: "Seal Clubber"
+3908	skewed gray figurine of a stinking seal	0		Class: "Seal Clubber"
 3909	skewed figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	figurine of a slippery seal	0		Class: "Seal Clubber"
@@ -3986,8 +3986,8 @@
 4034	tumbling memory of an iron key	0		Last Available: "2009-06"
 4035	memory of a crystal	0		Last Available: "2009-06"
 4036	caustic slime nodule	0		
-4037	delicious super-sized slimy sweetbreads	5	awesome	
-4038	enchanted bad distilled slimy fermented bile bladder	5	decent	Effect: "Destructive Resolve", Effect Duration: 40
+4037	super-sized delicious slimy sweetbreads	5	awesome	
+4038	distilled enchanted bad slimy fermented bile bladder	5	decent	Effect: "Destructive Resolve", Effect Duration: 40
 4039	dried mirror slimy alveolus	1		
 4040	jittery memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
 4041	upside-down Jeselnik's pig-iron helm of extreme caution	0		Monster Level: -25, Sleaze Damage: +25, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
@@ -4034,7 +4034,7 @@
 4082	bouncing frightening arcane researcher's pernicious cudgel	0		Experience Percent (Mysticality): +10, Spooky Damage: +5, Slime Hates It: +1
 4083	spoiled huge cupcake-in-a-cup	4	crappy	Last Available: "2009-06"
 4084	pool of liquid	0		Last Available: "2009-06"
-4085	rotten huge protein paste	6	crappy	Last Available: "2009-06"
+4085	huge rotten protein paste	6	crappy	Last Available: "2009-06"
 4086	twirling fortified forbidden cyber-mattock	0		Spell Damage Percent: +50, Damage Absorption: +60, Last Available: "2009-06"
 4087	facehugging alien	0		Last Available: "2009-06"
 4088	X-37 gun	0		Last Available: "2009-06"
@@ -4064,7 +4064,7 @@
 4112	bouncing maroon studded extremely unsafe bitter bowtie	0		Weapon Damage Percent: +100, Damage Absorption: +80, Last Available: "2009-06"
 4113	upside-down smartaleck's bewitching boots	0		Moxie Percent: +30, Last Available: "2009-06"
 4114	jittery secret from the future	0		Last Available: "2009-06"
-4115	blinking jittery moist sack	0		
+4115	jittery blinking moist sack	0		
 4116	toasty sage rickety unicycle of extreme caution	0		Mysticality Percent: +10, Monster Level: -25, Hot Damage: +5, Single Equip
 4117	squat prompt horrifying smooth crusty hula hoop	0		Moxie: +15, Spooky Damage: +25, Adventures: +3, Single Equip
 4118	fireproof medical-grade wholesome Coily&trade;	0		Maximum HP Percent: +10, Hot Resistance: +3, HP Regen Min: 7, HP Regen Max: 10
@@ -4085,7 +4085,7 @@
 4133	cold-filtered tempura air	0		Effect: "On a Roll", Effect Duration: 59
 4134	extra-aerosolized super-moist pressurized potion of pneumaticity	0		Effect: "Chalky Hand", Effect Duration: 29
 4135	moveable feast	0		Familiar Weight: +5, Softcore Only, Last Available: "2009-11"
-4136	ghostly gravedigger's scorching Bag o' Tricks of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Damage: +25, Hot Spell Damage: +50, Spooky Damage: +10, Softcore Only, Last Available: "2009-07", Conditional Skill (Equipped): "Open the Bag o' Tricks"
+4136	ghostly gravedigger's scorching Bag o' Tricks of the blizzard of incineration	0		Cold Spell Damage: +25, Hot Damage: +25, Hot Spell Damage: +50, Spooky Damage: +10, Softcore Only, Conditional Skill (Equipped): "Open the Bag o' Tricks", Last Available: "2009-07"
 4137	bouncing slime stack	0		
 4138	squat a rumpled paper strip	0		
 4139	spinning a creased paper strip	0		
@@ -4095,7 +4095,7 @@
 4143	spinning a ragged paper strip	0		
 4144	a ripped paper strip	0		
 4145	green lion tamer's funny paper hat	0		Experience (familiar): +2, Familiar Effect: "1xVolley, 1xLep, cap 2"
-4146	ionized activated cyan blurry sand	0		Effect: "Antarctic Memories", Effect Duration: 67
+4146	ionized activated blurry cyan sand	0		Effect: "Antarctic Memories", Effect Duration: 67
 4147	wholesome slick charged magnet	0		Moxie: +10, Maximum HP Percent: +10, Last Available: "2009-09"
 4148	squat stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	squat quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
@@ -4108,11 +4108,11 @@
 4156	pebbles	0		Last Available: "2009-09"
 4157	narrow gravel	0		Last Available: "2009-09"
 4158	rock	0		Last Available: "2009-09"
-4159	ghostly gray rock lobster	0		Last Available: "2009-09"
+4159	gray ghostly rock lobster	0		Last Available: "2009-09"
 4160	acceptable pebblebr&auml;u	3	good	Last Available: "2009-09"
 4161	flavorless jumbo shaking rocky road ice cream	5	decent	Last Available: "2009-09"
 4162	lime green extra-strength rubber bands	0		Familiar Weight: +5
-4163	energized green shaking children of the candy corn	0		Effect: "Frigid Weapon", Effect Duration: 60
+4163	energized shaking green children of the candy corn	0		Effect: "Frigid Weapon", Effect Duration: 60
 4164	boiled anodized blinking Good 'n' Slimy	0		Effect: "Scorpio Rising", Effect Duration: 49
 4165	perfumed brainy Staff of the Soupbone of the glutton	0		Mysticality: +5, Stench Resistance: +5, Food Drop: +100
 4166	narrow flame-retardant Voluminous Radio Pants	0		Hot Resistance: +1, Familiar Effect: "2xGhoul, cap 37"
@@ -4166,7 +4166,7 @@
 4214	squat spangly unitard	0		
 4215	Jim Carey's collapsible baton of the brute	0		Muscle Percent: +30, Monster Level: +25
 4216	groupie lipstick	0		
-4217	jittery tumbling groupie bra	0		
+4217	tumbling jittery groupie bra	0		
 4218	ionized groupie spangles	0		Effect: "Briny Blood", Effect Duration: 13
 4219	Lo Pan's baleful skate board	0		Spell Damage: +25, Spell Critical Percent: +30
 4220	olive S.A.V.E. flyer	0		
@@ -4177,7 +4177,7 @@
 4225	roller skate doll	0		
 4226	shaking manspreader's Star of Bravery	0		Monster Level: +10, Single Equip
 4227	hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
-4228	cyan bouncing perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
+4228	bouncing cyan perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
 4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	spinning fuchsia bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
@@ -4187,7 +4187,7 @@
 4235	salt-shaker	0		
 4236	wobbly can of sterno	0		
 4237	Van der Graaf cheese-slicer	0		MP Regen Min: 5, MP Regen Max: 7
-4238	tiny tasty fuchsia blurry beef jerky	1	awesome	
+4238	tasty tiny blurry fuchsia beef jerky	1	awesome	
 4239	stiffened pipe wrench	0		Damage Reduction: 1
 4240	adjusted improved purple gun cleaning kit	0		Effect: "Far Out", Effect Duration: 50
 4241	sleep mask of the pedagogue	0		Experience: +3, Familiar Effect: "atk, 1xBarrr, cap 37"
@@ -4196,13 +4196,13 @@
 4244	sharpshooter's leather-bound tome	0		Critical Hit Percent: +10
 4245	bouncing bouncing bookmark	0		
 4246	upside-down shaking brawny ivory cue ball	0		Muscle Percent: +20
-4247	artisanal distilled spinning decanter of fine Scotch	5	EPIC	
+4247	distilled artisanal spinning decanter of fine Scotch	5	EPIC	
 4248	diluted fuchsia expensive cigar	1		
 4249	tophat	0		Familiar Weight: +5
 4250	skewed fisherman's sack	0		
 4251	fish-oil smoke bomb	0		
 4252	wet vial of squid ink	0		Effect: "Educated (Kinda)", Effect Duration: 49
-4253	quantum quadruple-galvanized mirror wobbly potion of speed	0		Effect: "Savage Beast Inside", Effect Duration: 24
+4253	quantum quadruple-galvanized wobbly mirror potion of speed	0		Effect: "Savage Beast Inside", Effect Duration: 24
 4254	bark	0		Last Available: "2009-10"
 4255	Wolfman Nardz	0		Last Available: "2009-10"
 4256	wet double-altered sap	0		Effect: "Mercenary", Effect Duration: 50, Last Available: "2009-10"
@@ -4249,15 +4249,15 @@
 4297	upside-down flame-wreathed Tesla boxer's Ass-Stompers of Violence	0		Muscle Percent: +10, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Conditional Skill (Equipped): "Stomp Ass"
 4298	bouncing resourceful stylish weightlifter's Brand of Violence	0		Muscle: +15, Moxie: +25, Maximum MP: +50, Conditional Skill (Equipped): "Brand"
 4299	yellow wicked Novelty Belt Buckle of Violence of the scaredy-cat of extreme caution	0		Spell Damage: +5, Monster Level: -40, Single Equip
-4300	fuchsia frightening Jim Carey's arcane researcher's Lens of Violence	0		Experience Percent (Mysticality): +10, Monster Level: +25, Spooky Damage: +5, Familiar Effect: "atk, 1xBarrr", Conditional Skill (Equipped): "Violent Gaze"
+4300	fuchsia frightening Jim Carey's arcane researcher's Lens of Violence	0		Experience Percent (Mysticality): +10, Monster Level: +25, Spooky Damage: +5, Conditional Skill (Equipped): "Violent Gaze", Familiar Effect: "atk, 1xBarrr"
 4301	smelly MacGyver's hale Pigsticker of Violence	0		Maximum HP: +20, Maximum MP: +100, Stench Spell Damage: +10
-4302	rosewater-soaked Jodhpurs of Violence of the scaredy-cat of the sewer	0		Monster Level: -15, Stench Damage: +25, Stench Resistance: +3, Familiar Effect: "atk, 1xPotato", Conditional Skill (Equipped): "Mosh"
+4302	rosewater-soaked Jodhpurs of Violence of the scaredy-cat of the sewer	0		Monster Level: -15, Stench Damage: +25, Stench Resistance: +3, Conditional Skill (Equipped): "Mosh", Familiar Effect: "atk, 1xPotato"
 4303	huge nippy deadly groovy Cold Stone of Hatred	0		Moxie Percent: +10, Weapon Damage: +5, Cold Damage: +10, Conditional Skill (Equipped): "Chilling Grip"
 4304	jittery quilted grievous stylish Girdle of Hatred	0		Moxie: +25, Weapon Damage Percent: +50, Damage Absorption: +40, Single Equip, Conditional Skill (Equipped): "Tighten Girdle"
 4305	bouncing dog trainer's Lo Pan's Staff of Simmering Hatred of dire peril	0		Weapon Damage: +20, Spell Critical Percent: +30, Experience (familiar): +1
-4306	blue upside-down wool Samson's Pantaloons of Hatred of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50, Cold Resistance: +1, Familiar Effect: "hot atk, 2xVolley", Conditional Skill (Equipped): "[7156]Static Shock"
+4306	blue upside-down wool Samson's Pantaloons of Hatred of the overflowing toilet	0		Experience (Muscle): +5, Stench Spell Damage: +50, Cold Resistance: +1, Conditional Skill (Equipped): "[7156]Static Shock", Familiar Effect: "hot atk, 2xVolley"
 4307	avaricious Oprah's Fuzzy Slippers of Hatred of Tarzan	0		Experience (Muscle): +3, Maximum MP Percent: +50, Meat Drop: +30, Single Equip
-4308	fireproof chaotic cool Lens of Hatred	0		Moxie: +5, Spell Critical Percent: +10, Hot Resistance: +3, Familiar Effect: "hot atk, 1xBarrr", Conditional Skill (Equipped): "Hateful Gaze"
+4308	fireproof chaotic cool Lens of Hatred	0		Moxie: +5, Spell Critical Percent: +10, Hot Resistance: +3, Conditional Skill (Equipped): "Hateful Gaze", Familiar Effect: "hot atk, 1xBarrr"
 4309	narrow foul-smelling studded Treads of Loathing of the overflowing toilet	0		Damage Absorption: +80, Stench Damage: +10, Stench Spell Damage: +50, Single Equip
 4310	reassuring hale educational Scepter of Loathing	0		Experience: +1, Maximum HP: +20, Spooky Resistance: +1
 4311	avaricious family-friendly educational Belt of Loathing	0		Experience: +1, Sleaze Resistance: +1, Meat Drop: +30, Single Equip
@@ -4277,10 +4277,10 @@
 4325	inspector's foul-smelling Gravyskin Belt of the Sauceblob of the sewer	0		Stench Damage: 35, Item Drop: +15, Class: "Sauceror", Single Equip
 4326	green energetic boxer's Bling of the New Wave of the bloodbag	0		Muscle Percent: +10, Maximum HP: +100, Maximum MP Percent: +20, Class: "Disco Bandit", Single Equip
 4327	blinking Sherlock's knitted cool La Hebilla del Cintur&oacute;n de Lopez	0		Moxie: +5, Cold Resistance: +3, Item Drop: +25, Class: "Accordion Thief", Single Equip
-4328	spinning mirror suspicious stocking	0		Free Pull, Last Available: "2009-12"
+4328	mirror spinning suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
 4330	bland shaking cyan candy kneecapping stick	3	decent	Last Available: "2009-12"
-4331	small spoiled licorice garrote	2	crappy	Last Available: "2009-12"
+4331	spoiled small licorice garrote	2	crappy	Last Available: "2009-12"
 4332	candy knuckles of courage	0		Spooky Resistance: +3, Last Available: "2009-12"
 4333	fancy normal skewed jawbruiser	3	good	Effect: "Buggy Flavor", Effect Duration: 30, Last Available: "2010-12"
 4334	vacuum-sealed Vulcanized fuchsia chocolate car	0		Effect: "Chow Downed", Effect Duration: 18, Last Available: "2009-12"
@@ -4291,17 +4291,17 @@
 4339	wobbly plastic Crimbomination of James Dean	0		Experience (Moxie): +3, Last Available: "2009-12"
 4340	frozen dry lime green Piddles	0		Effect: "Sweet, Nuts", Effect Duration: 30, Last Available: "2009-12"
 4341	moist magnetized BitterSweetTarts	0		Effect: "Favored by Lyle", Effect Duration: 18, Last Available: "2009-12"
-4342	modified activated squat ghostly Polka Pop	0		Effect: "Human-Slime Hybrid", Effect Duration: 37, Last Available: "2009-12"
+4342	modified activated ghostly squat Polka Pop	0		Effect: "Human-Slime Hybrid", Effect Duration: 37, Last Available: "2009-12"
 4343	Crimbuck	0		Last Available: "2009-12"
 4344	Crimbo wreath	0		Last Available: "2009-12"
-4345	mirror shaking string of Crimbo lights	0		Last Available: "2009-12"
+4345	shaking mirror string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
 4347	gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
 4349	gray snow hat of horror	0		Spooky Spell Damage: +25, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
 4350	snow pants of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	Socratic snow belly	0		Experience (Mysticality): +1, Single Equip, Last Available: "2009-12"
-4352	huge blurry pile of loose snow	0		Last Available: "2009-12"
+4352	blurry huge pile of loose snow	0		Last Available: "2009-12"
 4353	squat Crimbough	0		Last Available: "2009-12"
 4354	lime green A Crimbo Carol, Ch. 1	0		Skill: "Holiday Weight Gain", Last Available: "2009-12"
 4355	A Crimbo Carol, Ch. 2	0		Skill: "Jingle Bells", Last Available: "2009-12"
@@ -4310,12 +4310,12 @@
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
 4359	pulsating A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	flavorless blurry expired can of franks 'n' beans	3	decent	Last Available: "2009-12"
-4361	watered-down fancy tolerable shaking expired bottle of peppermint schnapps	2	good	Effect: "Got Your Boots On", Effect Duration: 40, Last Available: "2009-12"
+4361	watered-down tolerable fancy shaking expired bottle of peppermint schnapps	2	good	Effect: "Got Your Boots On", Effect Duration: 40, Last Available: "2009-12"
 4362	snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	pickled galvanized elven suicide capsule	0		Effect: "Ooh, Salty!", Effect Duration: 18, Last Available: "2009-12"
 4365	special yummy tumbling penguin focaccia bread	4	awesome	Effect: "Sizzling with Fury", Effect Duration: 35, Last Available: "2009-12"
-4366	bad high-proof ghostly herringcello	8	decent	Last Available: "2009-12"
+4366	high-proof bad ghostly herringcello	8	decent	Last Available: "2009-12"
 4367	tolerable elven cellocello	3	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	handful of headless bolts	0		Last Available: "2009-12"
@@ -4325,7 +4325,7 @@
 4373	grappling hook	0		Last Available: "2009-12"
 4374	huge elf ear	0		Last Available: "2009-12"
 4375	wobbly spiraling shape	0		Last Available: "2009-12"
-4376	pulsating blinking Crimbomination Contraption	0		Last Available: "2009-12"
+4376	blinking pulsating Crimbomination Contraption	0		Last Available: "2009-12"
 4377	electrified throwing wrench	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-12"
 4378	blinking padded pair of bolt cutters	0		Damage Absorption: +20, Last Available: "2009-12"
 4379	horrifying poison pen	0		Spooky Damage: +25, Last Available: "2009-12"
@@ -4340,7 +4340,7 @@
 4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	twirling peanut brittle shield of Flo-Jo	0		Initiative: +100, Damage Reduction: 3, Last Available: "2009-12"
 4390	Red Rover BB gun of the ox of the brazier	0		Muscle: +20, Hot Spell Damage: +25, Last Available: "2009-12"
-4391	wobbly sage red-and-green sweater	0		Mysticality Percent: +10, Last Available: "2009-12", Conditional Skill (Equipped): "[7094]Static Shock"
+4391	wobbly sage red-and-green sweater	0		Mysticality Percent: +10, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
 4392	bouncing Crimbo Candy Cookbook	0		Skill: "Summon Crimbo Candy", Last Available: "2009-12"
 4393	altered ionized maroon Crimbo peppermint bark	0		Effect: "Petit Forbearance", Effect Duration: 53, Last Available: "2009-12"
 4394	cold-filtered chilled purple Crimbo fudge	0		Effect: "Broberry Brotality", Effect Duration: 55, Last Available: "2009-12"
@@ -4351,7 +4351,7 @@
 4399	stiffened cheese sword	0		Damage Reduction: 1, Softcore Only, Last Available: "2010-01"
 4400	hardy cheese diaper	0		Maximum HP: +50, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	friendly cheese wheel	0		Familiar Weight: +3, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
-4402	cheese eye of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Last Available: "2010-01", Conditional Skill (Equipped): "Give Your Opponent the Stinkeye"
+4402	cheese eye of the blizzard	0		Cold Spell Damage: +25, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	lard-coated hardy Staff of Queso Escusado of Gandalf	0		Maximum HP: +50, Spell Critical Percent: +20, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2010-01"
 4405	tumbling foreign box	0		
 4406	ghostly mirror The Art of Slapfighting	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
@@ -4361,7 +4361,7 @@
 4410	yellow The Autobiography Of Dynamite Superman Jones	0		Class: "Disco Bandit", Skill: "Kung Fu Hustler", Last Available: "2011-01"
 4411	Inigo's Incantation of Inspiration	0		Class: "Accordion Thief", Skill: "Inigo's Incantation of Inspiration", Last Available: "2010-02"
 4412	toothsome quantum taco	0		Last Available: "2010-10"
-4413	practically non-alcoholic hand-crafted teal Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
+4413	hand-crafted practically non-alcoholic teal Schr&ouml;dinger's thermos	0		Last Available: "2010-04"
 4414	colorful plastic ball	0		Last Available: "2010-01"
 4415	mirror blinking family-friendly sealhide hood	0		Sleaze Resistance: +1, Familiar Effect: "atk, 1xBarrr, cap 40"
 4416	olive toasty sealhide leggings	0		Hot Damage: +5, Familiar Effect: "1xVolley, cap 40"
@@ -4393,7 +4393,7 @@
 4445	friendly spangly mariachi pants	0		Familiar Weight: +3, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4446	pulsating lard-coated clever spangly mariachi vest	0		Maximum MP: +20, Sleaze Spell Damage: +25
 4447	hale spangly sombrero	0		Maximum HP: +20, Familiar Effect: "2xFairy, 2xPotato, cap 37"
-4448	diluted upside-down olive Instant Karma	1	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
+4448	diluted olive upside-down Instant Karma	1	good	Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 45
 4449	bouncing painting of a landscape	0		Last Available: "2010-04"
 4450	mirror map to The Landscaper's Lair	0		Last Available: "2010-04"
 4451	sharpshooter's pointy hat	0		Critical Hit Percent: +10, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
@@ -4413,7 +4413,7 @@
 4465	quadruple-enhanced unsweetened chocolate saucepan	0		Effect: "Okee-Dokee Computer", Effect Duration: 59
 4466	alkaline chocolate disco ball	0		Effect: "Chain Chain Chains", Effect Duration: 64
 4467	magnetized wet chocolate stolen accordion	0		Effect: "Be a Mind Master", Effect Duration: 61
-4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
+4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
 4469	skewed BRICKO brick	0		Last Available: "2010-02"
 4470	gray BRICKO eye brick	0		Last Available: "2010-02"
 4471	wicked BRICKO hat	0		Spell Damage: +5, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
@@ -4459,15 +4459,15 @@
 4511	tiny normal beautiful soup	1	good	Last Available: "2010-03"
 4512	blinking eggman noodles	0		Last Available: "2010-03"
 4513	huge Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
-4514	enchanted small adequate blinking Humpty Dumplings	2	good	Effect: "Mushroom Magicalness", Effect Duration: 15, Last Available: "2010-03"
+4514	small enchanted adequate blinking Humpty Dumplings	2	good	Effect: "Mushroom Magicalness", Effect Duration: 15, Last Available: "2010-03"
 4515	stale blinking Lobster <i>qua</i> Grill	3	decent	Last Available: "2010-03"
-4516	strong perfectly mixed cyan narrow missing wine	5	EPIC	Last Available: "2010-03"
+4516	perfectly mixed strong cyan narrow missing wine	5	EPIC	Last Available: "2010-03"
 4517	rotten massive matter custard	10	crappy	Last Available: "2010-03"
 4518	energized modified squat narrow comfit?	0		Effect: "Patched In", Effect Duration: 56, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	baleful flamingo mallet of dire peril	0		Weapon Damage: +20, Spell Damage: +25, Last Available: "2010-03"
-4521	squat bouncing croquet hedgehog	0		Last Available: "2010-03"
-4522	special squat yellow Tiger-lily's milk	1	awesome	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2010-03"
+4521	bouncing squat croquet hedgehog	0		Last Available: "2010-03"
+4522	special yellow squat Tiger-lily's milk	1	awesome	Effect: "Eyes of the Dragon", Effect Duration: 25, Last Available: "2010-03"
 4523	squat mansplainer's steel-toed eye of the Tiger-lily	0		Damage Reduction: 9, Monster Level: +15, Last Available: "2010-03"
 4524	nippy sage wig	0		Mysticality Percent: +10, Cold Damage: +10, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	bland huge huge red donut	7	decent	Last Available: "2010-03"
@@ -4480,7 +4480,7 @@
 4532	flavorless bishop cookie	3	decent	Last Available: "2010-03"
 4533	moldy half-sized knight cookie	2	crappy	Last Available: "2010-03"
 4534	normal king cookie	3	good	Last Available: "2010-03"
-4535	adequate tumbling blinking queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
+4535	adequate blinking tumbling queen cookie	3	good	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
 4537	blinking narrow knitted insane tophat	0		Cold Resistance: +3, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
 4538	wool groovy helm of the knight	0		Moxie Percent: +10, Cold Resistance: +1, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
@@ -4528,7 +4528,7 @@
 4580	upside-down frosty school Mafi<i>a kni</i>cke&frac12;&aelig;	0		Cold Spell Damage: +10, Last Available: "2010-04"
 4581	green steel-toed savvy T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Mysticality Percent: +20, Damage Reduction: 9, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	skewed fat bottom quark	0		Last Available: "2010-05"
-4583	skewed lime green glob of skin	0		
+4583	lime green skewed glob of skin	0		
 4584	adequate snack-sized six wedges of goat cheese	2	good	
 4585	upside-down collection of objects	0		
 4586	wobbly boulder	0		
@@ -4550,7 +4550,7 @@
 4602	cyan orquette's phone number	0		Last Available: "2010-06"
 4603	tumbling bronze handcuffs	0		Last Available: "2010-06"
 4604	jittery keg	0		Last Available: "2010-06"
-4605	Fonzie's bottle of Goldschn&ouml;ckered of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Last Available: "2010-06", Conditional Skill (Equipped): "Goldensh&ouml;wer"
+4605	Fonzie's bottle of Goldschn&ouml;ckered of Flo-Jo	0		Experience (Moxie): +1, Initiative: +100, Conditional Skill (Equipped): "Goldensh&ouml;wer", Last Available: "2010-06"
 4606	jumbo spoiled squat sun-dried tofu	5	crappy	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4607	lousy blinking soyburger juice	3	decent	Effect: "Oversaturated Palate", Effect Duration: 1, Last Available: "2010-08"
 4608	blinking respected companion biscuit	0		Last Available: "2010-08"
@@ -4558,9 +4558,9 @@
 4610	activated vacuum-sealed squat essential soy	0		Effect: "You Read The Manual", Effect Duration: 15, Last Available: "2010-08"
 4611	altered magnetized essential cameraderie	0		Effect: "Vanity Rage", Effect Duration: 57, Last Available: "2010-08"
 4612	skewed souvenir drawing	0		Last Available: "2010-08"
-4613	blinking narrow lime green map to the Magic Commune	0		Last Available: "2010-08"
+4613	narrow lime green blinking map to the Magic Commune	0		Last Available: "2010-08"
 4614	teal Crown of Thrones	0		Item Drop: +5, Softcore Only, Last Available: "2010-05"
-4615	artisanal practically non-alcoholic Cinco Mayo Lager	1	super ultra mega turbo EPIC	Last Available: "2010-05"
+4615	practically non-alcoholic artisanal Cinco Mayo Lager	1	super ultra mega turbo EPIC	Last Available: "2010-05"
 4616	Underworld sapling	0		Last Available: "2009-10"
 4617	pruning shears	0		Familiar Weight: +5
 4618	plastic cup of flat beer	0		
@@ -4569,12 +4569,12 @@
 4621	Game Grid token	0		Last Available: "2010-06"
 4622	jittery Game Grid ticket	0		Last Available: "2010-06"
 4623	extra-chilled chocolate-covered caviar	0		Effect: "Favored by Lyle", Effect Duration: 36, Last Available: "2020-09"
-4624	thick stale special pawn cookie	5	decent	Effect: "Good Karma", Effect Duration: 20, Last Available: "2010-06"
+4624	special stale thick pawn cookie	5	decent	Effect: "Good Karma", Effect Duration: 20, Last Available: "2010-06"
 4625	diluted shaking coffee pixie stick	1	awesome	Effect: "White-boy Angst", Effect Duration: 15, Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	teal finger cuffs	0		Last Available: "2010-06"
-4628	blinking shaking lime green parachute guy	0		Last Available: "2010-06"
-4629	Fonzie's plastic spider ring	0		Experience (Moxie): +1, Single Equip, Last Available: "2010-06", Conditional Skill (Equipped): "Shoot Web"
+4628	blinking lime green shaking parachute guy	0		Last Available: "2010-06"
+4629	Fonzie's plastic spider ring	0		Experience (Moxie): +1, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	clever plastic kazoo	0		Maximum MP: +20, Last Available: "2010-06"
 4631	inflatable baseball bat of Gandalf	0		Spell Critical Percent: +20, Last Available: "2010-06"
 4632	teal forbidden googly-star hat of courage	0		Spell Damage Percent: +50, Spooky Resistance: +3, Last Available: "2010-06", Familiar Effect: "atk"
@@ -4606,7 +4606,7 @@
 4658	shaking olive map to Ellsbury's Claim	0		Last Available: "2010-09"
 4659	strapping blackberry galoshes	0		Muscle: +5, Single Equip
 4660	bouncing squat Temple Grandin's Van der Graaf trout fang	0		Familiar Weight: +7, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2010-09"
-4661	snack-sized fancy decent jittery poisonous caviar	2	good	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2010-09"
+4661	fancy snack-sized decent jittery poisonous caviar	2	good	Effect: "Weasels Underfoot", Effect Duration: 25, Last Available: "2010-09"
 4662	diffused huge green wet venom duct	0		Effect: "Adventurer's Best Friendship", Effect Duration: 24, Last Available: "2010-09"
 4663	Ellsbury's journal	0		Skill: "Unaccompanied Miner", Last Available: "2010-09"
 4664	Ellsbury's skull of dire peril of chilblains	0		Weapon Damage: +20, Cold Damage: +25, Last Available: "2010-09"
@@ -4616,12 +4616,12 @@
 4668	sage observational glasses	0		Mysticality Percent: +10
 4669	maroon deadly hilarious comedy prop	0		Weapon Damage: +5
 4670	beer-scented teddy bear	0		
-4671	practically non-alcoholic drinkable booze-soaked cherry	1	good	
+4671	drinkable practically non-alcoholic booze-soaked cherry	1	good	
 4672	twirling comfy pillow	0		
 4673	flavorless marshmallow	4	decent	
 4674	normal special tiny sponge cake	1	good	Effect: "Big Flaming Whip", Effect Duration: 15
 4675	bad gin-soaked blotter paper	3	decent	
-4676	green tumbling tree-holed coin	0		
+4676	tumbling green tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
 4678	unearthed potsherd	0		
 4679	volcanic ash	0		
@@ -4652,22 +4652,22 @@
 4704	cyan fossilized demon skull	0		Last Available: "2010-09"
 4705	fossilized spider skull	0		Last Available: "2010-09"
 4706	shaking sinister tablet	0		
-4707	tumbling gray E-Z Cook&trade; oven	0		
+4707	gray tumbling E-Z Cook&trade; oven	0		
 4708	My First Shaker&trade;	0		
 4709	green hippo tutu	0		Last Available: "2011-09"
 4710	immense ballet shoes	0		Familiar Weight: +5
 4711	spinning sweatpants	0		Familiar Effect: "8xPotato, cap 2"
 4712	blinking GameInformPowerDailyPro subscription card	0		Free Pull, Last Available: "2013-02"
 4713	pulsating popsicle stick	0		
-4714	miniature stale lemon popsicle	2	decent	
-4715	super-sized spoiled popsicle	5	crappy	
-4716	low-calorie normal strawberry popsicle	1	good	
-4717	bland small squat liver popsicle	2	decent	
+4714	stale miniature lemon popsicle	2	decent	
+4715	spoiled super-sized popsicle	5	crappy	
+4716	normal low-calorie strawberry popsicle	1	good	
+4717	small bland squat liver popsicle	2	decent	
 4718	sinister mariachi hat	0		Spell Damage: +10, Familiar Effect: "atk, cap 2"
 4719	cool Hollandaise helmet	0		Moxie: +5, Familiar Effect: "atk, cap 2"
 4720	organ grinder	0		Free Pull, Last Available: "2011-12"
 4721	microwave stogie	0		Last Available: "2011-12"
-4722	bland tiny red liver and let pie	1	decent	Last Available: "2010-10"
+4722	tiny bland red liver and let pie	1	decent	Last Available: "2010-10"
 4723	snack-sized delicious tumbling badass pie	2	awesome	Last Available: "2010-10"
 4724	gigantic yummy shoo-fish pie	6	awesome	Last Available: "2010-10"
 4725	spoiled huge piping organ pie	3	crappy	Last Available: "2010-10"
@@ -4683,7 +4683,7 @@
 4735	purple prop sword	0		Familiar Weight: +5
 4736	tangle of rat tails	0		
 4737	narrow forbidden beer-soaked mop	0		Spell Damage Percent: +50
-4738	perfectly mixed weak day-old beer	2	EPIC	
+4738	weak perfectly mixed day-old beer	2	EPIC	
 4739	watered-down tolerable purple plain beer	2	good	
 4740	drinkable overpriced &quot;imported&quot; beer	4	good	
 4741	smiling rat	0		
@@ -4692,8 +4692,8 @@
 4744	irradiated huge PlexiPips	0		Effect: "Took Eleven", Effect Duration: 11
 4745	tarnished electrified Wax Flask	0		Effect: "Bottle in front of Me", Effect Duration: 45
 4746	quantum Pain Dip	0		Effect: "Jittery", Effect Duration: 17
-4747	super-sized bland narrow bone meal	5	decent	Last Available: "2010-10"
-4748	weak drinkable bone aperitif	2	good	Last Available: "2010-10"
+4747	bland super-sized narrow bone meal	5	decent	Last Available: "2010-10"
+4748	drinkable weak bone aperitif	2	good	Last Available: "2010-10"
 4749	Socratic bonerang	0		Experience (Mysticality): +1, Last Available: "2010-10"
 4750	maroon wool bone and arrows	0		Cold Resistance: +1, Last Available: "2010-10"
 4751	shellacked boning knife	0		Damage Reduction: 7, Last Available: "2010-10"
@@ -4709,8 +4709,8 @@
 4761	pumpkin	0		Last Available: "2010-11"
 4762	huge pumpkin	0		Last Available: "2010-11"
 4763	fancy spoiled snack-sized blurry pumpkin pie	2	crappy	Effect: "Fire Inside", Effect Duration: 40, Last Available: "2010-11"
-4764	watered-down bad spinning pumpkin beer	2	decent	Last Available: "2010-11"
-4765	vacuum-sealed dry skewed spinning pumpkin juice	0		Effect: "Mad at Science", Effect Duration: 20, Last Available: "2010-11"
+4764	bad watered-down spinning pumpkin beer	2	decent	Last Available: "2010-11"
+4765	vacuum-sealed dry spinning skewed pumpkin juice	0		Effect: "Mad at Science", Effect Duration: 20, Last Available: "2010-11"
 4766	pumpkin bomb	0		Last Available: "2010-11"
 4767	red shellacked savvy shin gourds	0		Mysticality Percent: +20, Damage Reduction: 7, Single Equip, Last Available: "2010-11"
 4768	blinking stanky rosy-cheeked Staff of the November Jack-O-Lantern of the pedagogue	0		Experience: +3, Maximum HP Percent: +30, Stench Spell Damage: +25, Last Available: "2010-11"
@@ -4724,9 +4724,9 @@
 4810	Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	decent snack-sized CRIMBCOIDS mints	2	good	Last Available: "2011-01"
+4818	snack-sized decent CRIMBCOIDS mints	2	good	Last Available: "2011-01"
 4819	can of CRIMBCOLA	0		Last Available: "2010-12"
-4820	small spoiled CRIMBCOLOAF	2	crappy	Last Available: "2011-01"
+4820	spoiled small CRIMBCOLOAF	2	crappy	Last Available: "2011-01"
 4821	decent circular CRIMBCOOKIE	3	good	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	zippy plastic CRIMBCO HQ	0		Initiative: +20, Last Available: "2010-12"
 4823	beefcake's plastic fax machine	0		Muscle: +25, Last Available: "2010-12"
@@ -4746,9 +4746,9 @@
 4837	robot reindeer protocol R.U.D.O.L.P.H.	0		Last Available: "2010-12"
 4838	robot reindeer protocol O.L.I.V.E.	0		Last Available: "2010-12"
 4839	thick bland triangular CRIMBCOOKIE	5	decent	Effect: "Triangle, Man", Effect Duration: 10, Last Available: "2010-12"
-4840	huge rotten teal ghostly square CRIMBCOOKIE	7	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
+4840	rotten huge ghostly teal square CRIMBCOOKIE	7	crappy	Effect: "Square to be Hip", Effect Duration: 10, Last Available: "2010-12"
 4841	Lo Pan's Oprah's bindlestocking of the empath	0		Maximum MP Percent: +50, Spell Critical Percent: +30, Familiar Weight: +5, Last Available: "2010-12"
-4842	blurry jittery sleeping stocking	0		Last Available: "2010-12"
+4842	jittery blurry sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
 4845	tumbling medical-grade baleful Uncle Hobo's stocking cap	0		Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2010-12", Familiar Effect: "atk"
@@ -4794,7 +4794,7 @@
 4885	traffic jam	0		Last Available: "2011-01"
 4886	flavorless tiny traffic jam toast	1	decent	Last Available: "2011-01"
 4887	cyan space jam	0		Last Available: "2011-01"
-4888	toothsome special low-calorie space jam toast	1	awesome	Effect: "Clean-Shaven", Effect Duration: 20, Last Available: "2011-01"
+4888	special low-calorie toothsome space jam toast	1	awesome	Effect: "Clean-Shaven", Effect Duration: 20, Last Available: "2011-01"
 4889	super-electrified dry spinning motivational poster	0		Effect: "Broberry Brotality", Effect Duration: 41, Last Available: "2011-01"
 4890	sack lunch	0		Last Available: "2011-01"
 4891	tumbling bath ball gift set	0		Last Available: "2011-01"
@@ -4841,7 +4841,7 @@
 4938	shaking quake of arrows	0		Last Available: "2011-12"
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	arrowgram	0		Free Pull, Last Available: "2011-12"
-4941	moldy enchanted Knob jelly donut	3	crappy	Effect: "Quiet 'n' Good", Effect Duration: 40
+4941	enchanted moldy Knob jelly donut	3	crappy	Effect: "Quiet 'n' Good", Effect Duration: 40
 4942	Knob cake	0		
 4943	Knob cake pan	0		
 4944	Knob batter	0		
@@ -4856,11 +4856,11 @@
 4953	quilted whalebone corset of courage	0		Damage Absorption: +40, Spooky Resistance: +3, Single Equip
 4954	oven mitts of the cheetah	0		Initiative: +60, Single Equip
 4955	rotten narrow overcookie	4	crappy	
-4956	thick moldy twirling green philosopher's scone	5	crappy	
+4956	moldy thick twirling green philosopher's scone	5	crappy	
 4957	aerosolized skewed half-baked potion	0		Effect: "Strong Spirit", Effect Duration: 22
 4958	friendly Knob Goblin deluxe scimitar	0		Familiar Weight: +3
 4959	special bland wobbly Knob nuts	3	decent	Effect: "Cute Vision", Effect Duration: 15
-4960	practically non-alcoholic lousy Cobb's Knob Wurstbrau	1	decent	
+4960	lousy practically non-alcoholic Cobb's Knob Wurstbrau	1	decent	
 4961	Subject 37 file	0		
 4962	gray huge up-at-dawn mysterious lapel pin of wisdom	0		Mysticality: +15, Adventures: +5, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4884,7 +4884,7 @@
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	spinning Alice's Army Coward	0		Last Available: "2011-03"
 4983	Alice's Army Cleric	0		Last Available: "2011-03"
-4984	mirror maroon Alice's Army Sniper	0		Last Available: "2011-03"
+4984	maroon mirror Alice's Army Sniper	0		Last Available: "2011-03"
 4985	squat Alice's Army Dervish	0		Last Available: "2011-03"
 4986	spinning Alice's Army Martyr	0		Last Available: "2011-03"
 4987	Pack of Alice's Army Foil Cards	0		Last Available: "2011-03"
@@ -4914,17 +4914,17 @@
 5011	Alice's Army Foil tattoo	0		Last Available: "2011-03"
 5012	Ye Wizard's Shack snack voucher	0		Last Available: "2011-03"
 5013	adequate miniature wasabi pocky	2	good	Last Available: "2011-03"
-5014	rotten low-calorie tobiko pocky	1	crappy	Last Available: "2011-03"
+5014	low-calorie rotten tobiko pocky	1	crappy	Last Available: "2011-03"
 5015	bite-sized normal natto pocky	1	good	Last Available: "2011-03"
-5016	acceptable watered-down wasabi-infused sake	2	good	Last Available: "2011-03"
-5017	hand-crafted strong tobiko-infused sake	5	EPIC	Last Available: "2011-03"
+5016	watered-down acceptable wasabi-infused sake	2	good	Last Available: "2011-03"
+5017	strong hand-crafted tobiko-infused sake	5	EPIC	Last Available: "2011-03"
 5018	hand-crafted natto-infused sake	3	EPIC	Last Available: "2011-03"
 5019	galvanized double-dry wasabi marble soda	0		Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 49, Last Available: "2011-03"
 5020	tarnished dry chilled tobiko marble soda	0		Effect: "Thick-Skinned", Effect Duration: 12, Last Available: "2011-03"
 5021	modified spinning natto marble soda	0		Effect: "Burning Ears", Effect Duration: 46, Last Available: "2011-03"
 5022	Alice's Army booster box	0		Last Available: "2011-03"
 5023	corrupted triple-improved magnetized elderly jawbreaker	0		Effect: "Tin, Man", Effect Duration: 23, Last Available: "2020-09"
-5024	weak special drinkable marshmallow flamb&eacute;	2	good	Effect: "Wit Tea", Effect Duration: 35, Last Available: "2011-03"
+5024	weak drinkable special marshmallow flamb&eacute;	2	good	Effect: "Wit Tea", Effect Duration: 35, Last Available: "2011-03"
 5025	artisanal fancy cranberry schnapps	4	EPIC	Effect: "Dilated Pupils", Effect Duration: 30, Last Available: "2011-03"
 5026	enchanted drinkable breaded beer	3	good	Effect: "Celestial Body", Effect Duration: 15, Last Available: "2011-03"
 5027	strong mediocre soy cordial	5	decent	Last Available: "2011-03"
@@ -4943,8 +4943,8 @@
 5040	astral pet sweater	0		Familiar Weight: +10
 5041	aromatic strapping astral shirt of the dark arts	0		Muscle: +5, Spell Damage Percent: +100, Stench Resistance: +1
 5042	shellacked weightlifter's astral belt	0		Muscle: +15, Damage Reduction: 7
-5043	normal huge special astral hot dog	10		Effect: "Low on the Hog", Effect Duration: 15
-5044	smooth weak jittery gray astral pilsner	2		
+5043	huge special normal astral hot dog	10		Effect: "Low on the Hog", Effect Duration: 15
+5044	smooth weak gray jittery astral pilsner	2		
 5045	astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
@@ -4956,7 +4956,7 @@
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	intriguing puzzle box	0		Last Available: "2011-04"
 5055	squat obnoxious riddle	0		Last Available: "2011-04"
-5056	huge skewed best joke ever	0		Last Available: "2011-04"
+5056	skewed huge best joke ever	0		Last Available: "2011-04"
 5057	warmed flattened blurry Atomic Comic	0		Effect: "Flagrantly Fragrant", Effect Duration: 20, Last Available: "2011-04"
 5058	Vulcanized dry Red Pill	0		Effect: "Flagrantly Fragrant", Effect Duration: 68, Last Available: "2011-04"
 5059	Skullhead's Screw	0		Last Available: "2011-04"
@@ -4965,7 +4965,7 @@
 5062	voodoo doll	0		Last Available: "2011-04"
 5063	tumbling the finger	0		Last Available: "2011-04"
 5064	Salsa de las Epocas	0		Last Available: "2011-04"
-5065	enchanted bland skewed twirling spaghetti con calaveras	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 50, Last Available: "2011-04"
+5065	bland enchanted skewed twirling spaghetti con calaveras	4	decent	Effect: "Crimbo Epiphany", Effect Duration: 50, Last Available: "2011-04"
 5066	s'more gun	0		Last Available: "2011-04"
 5067	bland popcorn	4	decent	Last Available: "2011-04"
 5068	rotten chaos popcorn	4	crappy	Last Available: "2011-04"
@@ -4986,7 +4986,7 @@
 5083	rubber band gun of the brazier	0		Hot Spell Damage: +25, Last Available: "2011-05"
 5084	blue wool pin-stripe slacks	0		Cold Resistance: +1, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	electrified gloves	0		MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2011-05"
-5086	frozen polarized blurry huge red correction fluid	0		Effect: "Cake Caked", Effect Duration: 37, Last Available: "2011-05"
+5086	frozen polarized red blurry huge correction fluid	0		Effect: "Cake Caked", Effect Duration: 37, Last Available: "2011-05"
 5087	upside-down brainy Pok&euml;mann figurine: Porkachu	0		Mysticality: +5, Single Equip, Last Available: "2011-05"
 5088	tumbling wobbly censurious Pok&euml;mann figurine: Magikrap	0		Sleaze Resistance: +3, Single Equip, Last Available: "2011-05"
 5089	grievous Pok&euml;mann figurine: Vegemite	0		Weapon Damage Percent: +50, Single Equip, Last Available: "2011-05"
@@ -5009,11 +5009,11 @@
 5106	gray hideous egg	0		Last Available: "2011-05"
 5107	delicious spirit-forward Jeppson's Malort	5	awesome	Last Available: "2011-06"
 5108	fistful of ashes	0		
-5109	twirling stress ball of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2011-05", Conditional Skill (Equipped): "Squeeze Stress Ball"
+5109	twirling stress ball of vim and vigor	0		Maximum HP Percent: +50, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
 5111	huge Ultracolor&trade; shirt of terror	0		Spooky Spell Damage: +10, Last Available: "2011-05"
 5112	My Own Pen Pal kit	0		Free Pull, Last Available: "2011-12"
-5113	yellow shaking packet of orchid seeds	0		
+5113	shaking yellow packet of orchid seeds	0		
 5114	stomp box	0		Familiar Weight: +5, Last Available: "2011-12"
 5115	hedge trimmers	0		
 5116	A. W. O. L. commendation	0		Last Available: "2011-05"
@@ -5036,7 +5036,7 @@
 5133	hand-crafted elven squeeze	4	EPIC	Last Available: "2011-06"
 5134	twirling lunar isotope	0		Last Available: "2011-06"
 5135	green E.M.U. joystick	0		Last Available: "2011-06"
-5136	blurry twirling E.M.U. rocket thrusters	0		Last Available: "2011-06"
+5136	twirling blurry E.M.U. rocket thrusters	0		Last Available: "2011-06"
 5137	E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
 5139	olive carton of astral energy drinks	0		
@@ -5078,7 +5078,7 @@
 5175	acceptable Moonthril Schnapps	3	good	Last Available: "2011-06"
 5176	mediocre Wrecked Generator	3	decent	Last Available: "2011-06"
 5177	adequate Spaghetti with Moonballs	4	good	Last Available: "2011-06"
-5178	small adequate Crepes a la Lune	2	good	Last Available: "2011-06"
+5178	adequate small Crepes a la Lune	2	good	Last Available: "2011-06"
 5179	low-calorie stale wobbly Moon Pie	1	decent	Last Available: "2011-06"
 5180	tarnished magnetized fuchsia pulsating Comet Pop	0		Effect: "Salt Rockin'", Effect Duration: 33, Last Available: "2011-06"
 5181	irradiated Flan in the Moon	0		Effect: "Stinky Weapon", Effect Duration: 17, Last Available: "2011-06"
@@ -5090,7 +5090,7 @@
 5187	pulsating red Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	double-flattened magnetized enhanced honey stick	0		Effect: "Superheroic", Effect Duration: 29
 5189	ionized Vulcanized double-ice gum	0		Effect: "Capricorn Rising", Effect Duration: 43, Last Available: "2011-04"
-5190	executive frightening Operation Patriot Shield of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +5, Meat Drop: +40, Damage Reduction: 1, Softcore Only, Last Available: "2011-07", Conditional Skill (Equipped): "Throw Shield"
+5190	executive frightening Operation Patriot Shield of the blizzard	0		Cold Spell Damage: +25, Spooky Damage: +5, Meat Drop: +40, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	frozen enhanced squat corrupted data	0		Effect: "Rain Dancin'", Effect Duration: 15, Last Available: "2011-06"
 5193	lime green 11-inch knob sausage	0		
@@ -5110,7 +5110,7 @@
 5207	dehydrated indescribably horrible paste	1	decent	Effect: "Provocative Perkiness", Effect Duration: 5, Last Available: "2011-08"
 5208	pickled maroon paste	1	EPIC	Last Available: "2011-08"
 5209	distilled goblin paste	1	EPIC	Last Available: "2011-08"
-5210	denatured teal narrow blinking pirate paste	1	good	Last Available: "2011-08"
+5210	denatured narrow blinking teal pirate paste	1	good	Last Available: "2011-08"
 5211	boiled wobbly chlorophyll paste	1	crappy	Effect: "Block-Rockin' Beet", Effect Duration: 10, Last Available: "2011-08"
 5212	dehydrated ghostly shaking paste	1	EPIC	Last Available: "2011-08"
 5213	twisted wobbly Mer-kin paste	1	awesome	Last Available: "2011-08"
@@ -5121,9 +5121,9 @@
 5218	vaporized shaking hobo paste	1	good	Last Available: "2011-08"
 5219	compressed blurry Crimbo paste	1	decent	Last Available: "2011-08"
 5220	shaking Teachings of the Fist	0		
-5221	cyan skewed fat loot token	0		No Pull
+5221	skewed cyan fat loot token	0		No Pull
 5222	Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
+5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
 5224	moldy Ur-Donut	3	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5133,22 +5133,22 @@
 5230	snowflake	0		Last Available: "2011-09"
 5231	crystal skull	0		Last Available: "2011-09"
 5232	twirling borrowed time	0		Last Available: "2011-09"
-5233	twirling gray box of hammers	0		Last Available: "2011-09"
+5233	gray twirling box of hammers	0		Last Available: "2011-09"
 5234	cyan savvy shining halo	0		Mysticality Percent: +20, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5235	lime green Jim Carey's furry halo	0		Monster Level: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5236	frosty halo of the pedagogue	0		Experience: +3, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5237	blurry scorching time halo	0		Hot Damage: +25, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	lousy weak Lumineux Limnio	2	decent	Last Available: "2011-09"
-5239	watered-down perfectly mixed Morto Moreto	2	EPIC	Last Available: "2011-09"
+5239	perfectly mixed watered-down Morto Moreto	2	EPIC	Last Available: "2011-09"
 5240	weak aged Temps Tempranillo	2	awesome	Last Available: "2011-09"
 5241	acceptable practically non-alcoholic Bordeaux Marteaux	1	good	Last Available: "2011-09"
 5242	tolerable practically non-alcoholic Fromage Pinotage	1	good	Last Available: "2011-09"
 5243	smooth gray Beignet Milgranet	4	awesome	Last Available: "2011-09"
-5244	special tolerable triple-distilled Muschat	6	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 20, Last Available: "2011-09"
+5244	tolerable triple-distilled special Muschat	6	good	Effect: "Jackasses' Symphony of Destruction", Effect Duration: 20, Last Available: "2011-09"
 5245	normal cool jelly donut	4	good	Last Available: "2011-09"
 5246	normal shrapnel jelly donut	3	good	Last Available: "2011-09"
 5247	half-sized adequate twirling occult jelly donut	2	good	Last Available: "2011-09"
-5248	tiny decent jittery thyme jelly donut	1	good	Last Available: "2011-09"
+5248	decent tiny jittery thyme jelly donut	1	good	Last Available: "2011-09"
 5249	yummy twirling danish	3	awesome	Last Available: "2011-09"
 5250	moldy squat smashed danish	4	crappy	Last Available: "2011-09"
 5251	flavorless forbidden danish	3	decent	Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	twirling broken clock of Gandalf	0		Spell Critical Percent: +20, Last Available: "2011-09"
 5282	dethklok of the cougar	0		Moxie: +20, Last Available: "2011-09"
 5283	spinning boxer's glacial clock	0		Muscle Percent: +10, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
+5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	bouncing huge d8	0		Last Available: "2011-09"
@@ -5199,9 +5199,9 @@
 5296	slightly thicker filthy rags	0		Familiar Weight: +5, Last Available: "2011-09"
 5297	dungeon dragon chest	0		Last Available: "2011-09"
 5298	moldy phish stick	3	crappy	Last Available: "2011-09"
-5299	yellow avaricious nippy plastic vampire fangs of the glutton	0		Cold Damage: +10, Meat Drop: +30, Food Drop: +100, Single Equip, Softcore Only, Last Available: "2011-10", Conditional Skill (Equipped): "Feed"
+5299	yellow avaricious nippy plastic vampire fangs of the glutton	0		Cold Damage: +10, Meat Drop: +30, Food Drop: +100, Single Equip, Softcore Only, Conditional Skill (Equipped): "Feed", Last Available: "2011-10"
 5300	Interview With You (a Vampire)	0		Last Available: "2011-10"
-5301	wobbly fuchsia Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
+5301	fuchsia wobbly Make-Your-Own-Vampire-Fangs kit	0		Last Available: "2011-10"
 5302	your own heart	0		Last Available: "2011-10"
 5303	Sword of the Brouhaha Prince of Leguizamo	0		Monster Level: +20, Last Available: "2011-10"
 5304	huge vibrating smartaleck's Chalice of the Malkovich Prince of Tarzan	0		Moxie Percent: +30, Experience (Muscle): +3, Maximum MP Percent: +10, Last Available: "2011-10"
@@ -5219,19 +5219,19 @@
 5316	pressed triple-anodized pickled press-on ribs	0		Effect: "Knightlife", Effect Duration: 44, Last Available: "2011-10"
 5317	corrupted spinning Rattlin' Chains	0		Effect: "Afternoon Insight", Effect Duration: 26, Last Available: "2011-10"
 5318	polarized Gummy Brains	0		Effect: "Memories of Puppy Love", Effect Duration: 39, Last Available: "2011-10"
-5319	cold-filtered ionized adjusted bouncing maroon Blood 'n' Plenty	0		Effect: "Scarysauce", Effect Duration: 61, Last Available: "2011-10"
+5319	cold-filtered ionized adjusted maroon bouncing Blood 'n' Plenty	0		Effect: "Scarysauce", Effect Duration: 61, Last Available: "2011-10"
 5320	pickled Lobos Mints	0		Effect: "Wet Rub", Effect Duration: 13, Last Available: "2011-10"
 5321	triple-altered moist Sweet Sword	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 26, Last Available: "2011-10"
-5322	irresponsibly strong special tolerable blue Ecto-Cooler	6	good	Effect: "Amorous Avarice", Effect Duration: 40, Last Available: "2011-10"
+5322	tolerable irresponsibly strong special blue Ecto-Cooler	6	good	Effect: "Amorous Avarice", Effect Duration: 40, Last Available: "2011-10"
 5323	hand-crafted gray Bartles and BRAAAINS wine cooler	4	EPIC	Last Available: "2011-10"
-5324	perfectly mixed enchanted high-proof bouncing Blood Light	8	EPIC	Effect: "Berry Defensive", Effect Duration: 10, Last Available: "2011-10"
-5325	watered-down mediocre Silver Bullet beer	2	decent	Last Available: "2011-10"
-5326	boozy tolerable enchanted Bone's Farm &quot;wine&quot;	5	good	Effect: "Seriously Mutated", Effect Duration: 35, Last Available: "2011-10"
+5324	perfectly mixed high-proof enchanted bouncing Blood Light	8	EPIC	Effect: "Berry Defensive", Effect Duration: 10, Last Available: "2011-10"
+5325	mediocre watered-down Silver Bullet beer	2	decent	Last Available: "2011-10"
+5326	boozy enchanted tolerable Bone's Farm &quot;wine&quot;	5	good	Effect: "Seriously Mutated", Effect Duration: 35, Last Available: "2011-10"
 5327	blurry ghost protocol	0		Last Available: "2011-10"
 5328	denatured sorority brain	0		Effect: "Swimming Head", Effect Duration: 25, Last Available: "2011-10"
 5329	galvanized Nightstalker perfume	0		Effect: "Lit Up", Effect Duration: 16, Last Available: "2011-10"
 5330	warmed drum of pomade	0		Effect: "Cold Jellied", Effect Duration: 36, Last Available: "2011-10"
-5331	upside-down maroon throwing bone	0		Last Available: "2011-10"
+5331	maroon upside-down throwing bone	0		Last Available: "2011-10"
 5332	pulsating weightlifter's extra-see-thru nightie	0		Muscle: +15, Last Available: "2011-10"
 5333	nasty crafty BRAINS shorts	0		Maximum MP: +10, Stench Damage: +5, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	Tesla Mesmereyes&trade; contact lenses	0		MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2011-10"
@@ -5242,7 +5242,7 @@
 5339	tumbling lard-coated MacGyver's The Necbromancer's Shorts of the cheetah	0		Maximum MP: +100, Sleaze Spell Damage: +25, Initiative: +60, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	bouncing careful chaotic The Necbromancer's Wizard Staff of Gandalf	0		Spell Critical Percent: 30, Monster Level: -10, Last Available: "2011-10"
 5341	shaking The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
-5342	acceptable watered-down The Cooler Out of Space	2	good	Last Available: "2011-10"
+5342	watered-down acceptable The Cooler Out of Space	2	good	Last Available: "2011-10"
 5343	maroon The Necbronomicon (used)	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5344	green sorority girl's box	0		Last Available: "2011-10"
 5345	tarnished squat Necbro wafers	0		Effect: "Heart of Lavender", Effect Duration: 56, Last Available: "2020-09"
@@ -5309,17 +5309,17 @@
 5406	tumbling horrifying Van der Graaf cane-mail pants of the ox	0		Muscle: +20, Spooky Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	artisanal watered-down Vodka Matryoshka	2	EPIC	Last Available: "2011-12"
 5408	drinkable pulsating Gin Mint	4	good	Last Available: "2011-12"
-5409	weak drinkable Tequiz Navidad	2	good	Last Available: "2011-12"
+5409	drinkable weak Tequiz Navidad	2	good	Last Available: "2011-12"
 5410	bad high-proof Mint Yulep	7	decent	Last Available: "2011-12"
 5411	perfectly mixed narrow Crimbojito	3	EPIC	Last Available: "2011-12"
 5412	artisanal spirit-forward Sangria de Menthe	5	EPIC	Last Available: "2011-12"
-5413	blinking blue candycaine powder	0		Last Available: "2011-12"
+5413	blue blinking candycaine powder	0		Last Available: "2011-12"
 5414	gray licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	vacuum-sealed purple licorice root	0		Effect: "Lobos Fresh", Effect Duration: 63, Last Available: "2011-12"
 5416	non-unsweetened banana supersucker	0		Effect: "Smokin'", Effect Duration: 51, Last Available: "2011-11"
 5417	energized polarized pear supersucker	0		Effect: "So You Can Work More...", Effect Duration: 16, Last Available: "2011-11"
 5418	improved lime supersucker	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 68, Last Available: "2011-11"
-5419	polarized dry deionized green mirror tumbling kumquat supersucker	0		Effect: "Bustle Hustlin'", Effect Duration: 13, Last Available: "2011-11"
+5419	polarized dry deionized mirror tumbling green kumquat supersucker	0		Effect: "Bustle Hustlin'", Effect Duration: 13, Last Available: "2011-11"
 5420	ionized modified strawberry supersucker	0		Effect: "Pemmican't", Effect Duration: 67, Last Available: "2011-11"
 5421	lion tamer's bananarama bangle	0		Experience (familiar): +2, Single Equip, Last Available: "2011-11"
 5422	mirror brainy pair of pearidot earrings	0		Mysticality: +5, Single Equip, Last Available: "2011-11"
@@ -5337,7 +5337,7 @@
 5434	mirror DNOTC Box	0		Last Available: "2017-12"
 5435	twirling fudgecule	0		Last Available: "2011-11"
 5436	super-pressed gray fudge lily	0		Effect: "Ancestral Disapproval", Effect Duration: 11, Last Available: "2011-11"
-5437	spinning blinking superheated fudge	0		Last Available: "2011-11"
+5437	blinking spinning superheated fudge	0		Last Available: "2011-11"
 5438	tarnished maroon fluid of fudge-finding	0		Effect: "Bestial Sympathy", Effect Duration: 16, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
 5440	flavorless fudgesicle	3	decent	Last Available: "2011-11"
@@ -5363,7 +5363,7 @@
 5460	frightening Samson's fudgecycle of the scaredy-cat	0		Experience (Muscle): +5, Monster Level: -15, Spooky Damage: +5, Single Equip, Last Available: "2011-11"
 5461	fuchsia fudge cube	0		Last Available: "2011-11"
 5462	blank fudge mold	0		Last Available: "2011-11"
-5463	upside-down mirror Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
+5463	upside-down mirror Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
 5464	Vulcanized unsweetened resolution: be wealthier	0		Effect: "Witch Breaded", Effect Duration: 12, Last Available: "2012-01"
 5465	extra-warmed cold-filtered enhanced resolution: be happier	0		Effect: "Hyperoffended", Effect Duration: 45, Last Available: "2012-01"
 5466	triple-modified narrow resolution: be stronger	0		Effect: "Blessing of Bulbazinalli", Effect Duration: 40, Last Available: "2012-01"
@@ -5402,12 +5402,12 @@
 5499	slick Big Candy's tophat of the ox	0		Muscle: +20, Moxie: +10, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	blurry Jackass Plumber home game	0		Last Available: "2011-11"
-5502	narrow wobbly Trivial Avocations board game	0		Last Available: "2011-11"
+5502	wobbly narrow Trivial Avocations board game	0		Last Available: "2011-11"
 5503	Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	pack of pogs	0		Last Available: "2011-11"
 5506	flavorless jerky coins	3	decent	Last Available: "2011-11"
-5507	enchanted lousy huge jittery Go-Wassail	3	decent	Effect: "Tiki Toughness", Effect Duration: 10, Last Available: "2011-11"
+5507	lousy enchanted jittery huge Go-Wassail	3	decent	Effect: "Tiki Toughness", Effect Duration: 10, Last Available: "2011-11"
 5508	double-altered Uncle Greenspan's Bathroom Finance Guide	0		Effect: "Heart of Yellow", Effect Duration: 61, Last Available: "2011-11"
 5509	concentrated irradiated bottle of bubbles	0		Effect: "Sucrose-Colored Glasses", Effect Duration: 33, Last Available: "2011-11"
 5510	dry quantum wind-up meatcar	0		Effect: "Turtle Power", Effect Duration: 53, Last Available: "2011-11"
@@ -5423,20 +5423,20 @@
 5520	twirling pog #06 (filthy hippy)	0		Last Available: "2011-11"
 5521	pog #07 (orcish frat boy)	0		Last Available: "2011-11"
 5522	pog #08 (hellion)	0		Last Available: "2011-11"
-5523	huge spinning pog #09 (pirate)	0		Last Available: "2011-11"
+5523	spinning huge pog #09 (pirate)	0		Last Available: "2011-11"
 5524	pog #10 (hobo)	0		Last Available: "2011-11"
 5525	squat pog #11 (Naughty Sorceress)	0		Last Available: "2011-11"
 5526	boiled tarnished ghostly Atomic Pop	0		Effect: "Burning Ears", Effect Duration: 35, Last Available: "2020-09"
 5527	skewed mirror do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	skewed whimpering willow bark	0		Last Available: "2012-12"
-5529	moldy thick berries of suffering	5	crappy	Last Available: "2012-12"
+5529	thick moldy berries of suffering	5	crappy	Last Available: "2012-12"
 5530	non-aerosolized baobab sap	0		Effect: "Purity of Spirit", Effect Duration: 38, Last Available: "2012-12"
 5531	skewed cup of hickory chicory	0		Last Available: "2012-12"
 5532	bouncing magnolia blossom	0		Last Available: "2012-12"
-5533	anodized frozen twirling huge Mortimer's nostrum	0		Effect: "Okee-Dokee Go!", Effect Duration: 26, Last Available: "2012-12"
-5534	bad irresponsibly strong blue Barulio's bottle	7	decent	Last Available: "2012-12"
+5533	anodized frozen huge twirling Mortimer's nostrum	0		Effect: "Okee-Dokee Go!", Effect Duration: 26, Last Available: "2012-12"
+5534	irresponsibly strong bad blue Barulio's bottle	7	decent	Last Available: "2012-12"
 5535	alkaline irradiated maroon Marvin's marvelous pill	0		Effect: "Prelude of Precision", Effect Duration: 19, Last Available: "2012-12"
-5536	pulsating olive Winifred's whistle	0		Last Available: "2012-12"
+5536	olive pulsating Winifred's whistle	0		Last Available: "2012-12"
 5537	prose pen	0		Last Available: "2012-12"
 5538	skewed half-empty carton of milk	0		Last Available: "2012-12"
 5539	glass of warm water	0		Free Pull
@@ -5444,7 +5444,7 @@
 5541	Vivian's Vitamin	0		Last Available: "2012-12"
 5542	pink-belly slapper	0		Last Available: "2012-12"
 5543	clever Leapin' Trousers of the cheetah	0		Maximum MP: +20, Initiative: +60
-5544	bad boozy eggnog	5	decent	Last Available: "2012-12"
+5544	boozy bad eggnog	5	decent	Last Available: "2012-12"
 5545	small normal hamhock	2	good	Last Available: "2012-12"
 5546	The Thorax's Codex of Tormenting Plants	0		Skill: "Torment Plant", Last Available: "2012-12"
 5547	Clancy's sackbut	0		Last Available: "2012-12"
@@ -5455,7 +5455,7 @@
 5552	frightening Trusty	0		Spooky Damage: +5
 5553	jittery can of Rain-Doh	0		Last Available: "2012-02"
 5554	red empty Rain-Doh can	0		Last Available: "2012-02"
-5555	electrified dry lime green tumbling fireclutch	0		Effect: "Super-Charged", Effect Duration: 43
+5555	electrified dry tumbling lime green fireclutch	0		Effect: "Super-Charged", Effect Duration: 43
 5556	ghostly miser's family-friendly Rain-Doh wings	0		Sleaze Resistance: +1, Meat Drop: +10, Softcore Only, Last Available: "2012-02"
 5557	narrow Rain-Doh agent	0		Last Available: "2012-02"
 5558	upside-down cyan MacGyver's Rain-Doh laser gun of the businessman	0		Maximum MP: +100, Meat Drop: +50, Softcore Only, Last Available: "2012-02"
@@ -5470,23 +5470,23 @@
 5567	adequate shaking corned-beef Reuben	3	good	
 5568	narrow frayed ninja rope	0		
 5569	maroon dull ninja crampons	0		
-5570	mirror skewed loose ninja carabiner	0		
+5570	skewed mirror loose ninja carabiner	0		
 5571	Groar's fur	0		
 5572	maroon Thwaitgold stag beetle statuette	0		
 5573	tolerable Drac & Tan	3	good	Last Available: "2012-03"
-5574	watered-down artisanal Transylvania Sling	2	EPIC	Last Available: "2012-03"
-5575	weak tolerable ghostly Shot of the Living Dead	2	good	Last Available: "2012-03"
+5574	artisanal watered-down Transylvania Sling	2	EPIC	Last Available: "2012-03"
+5575	tolerable weak ghostly Shot of the Living Dead	2	good	Last Available: "2012-03"
 5576	fancy bad tumbling Buttery Knob	4	decent	Effect: "Cravin' for a Ravin'", Effect Duration: 35, Last Available: "2012-03"
 5577	mediocre Slippery Knob	4	decent	Last Available: "2012-03"
 5578	tolerable narrow Flaming Knob	4	good	Last Available: "2012-03"
 5579	watered-down perfectly mixed Grasshopper	2	EPIC	Last Available: "2012-03"
-5580	irresponsibly strong mediocre Locust	7	decent	Last Available: "2012-03"
+5580	mediocre irresponsibly strong Locust	7	decent	Last Available: "2012-03"
 5581	bad Plague of Locusts	4	decent	Last Available: "2012-03"
 5582	mediocre Red Dwarf	4	decent	Last Available: "2012-03"
 5583	perfectly mixed Golden Mean	3	EPIC	Last Available: "2012-03"
 5584	tolerable squat Green Giant	4	good	Last Available: "2012-03"
 5585	tolerable Aye Aye	4	good	Last Available: "2012-03"
-5586	drinkable fancy green blurry Aye Aye, Captain	3	good	Effect: "Dreadful Chill", Effect Duration: 45, Last Available: "2012-03"
+5586	fancy drinkable green blurry Aye Aye, Captain	3	good	Effect: "Dreadful Chill", Effect Duration: 45, Last Available: "2012-03"
 5587	lousy squat Aye Aye, Tooth Tooth	3	decent	Last Available: "2012-03"
 5588	drinkable Humanitini	4	good	Last Available: "2012-03"
 5589	triple-distilled bad gray More Humanitini than Humanitini	10	decent	Last Available: "2012-03"
@@ -5499,27 +5499,27 @@
 5596	mediocre practically non-alcoholic shaking Sloe Comfortable Zoo on Fire	1	decent	Last Available: "2012-03"
 5597	tolerable huge Suffering Sinner	3	good	Last Available: "2012-03"
 5598	perfectly mixed weak Suppurating Sinner	2	EPIC	Last Available: "2012-03"
-5599	practically non-alcoholic lousy Sizzling Sinner	1	decent	Last Available: "2012-03"
+5599	lousy practically non-alcoholic Sizzling Sinner	1	decent	Last Available: "2012-03"
 5600	smooth enchanted distilled Firewater	5	awesome	Effect: "Vinegavotte", Effect Duration: 20, Last Available: "2012-03"
 5601	bad practically non-alcoholic Earth and Firewater	1	decent	Last Available: "2012-03"
 5602	acceptable Earth, Wind and Firewater	3	good	Last Available: "2012-03"
 5603	practically non-alcoholic bad Slimosa	1	decent	Last Available: "2012-03"
 5604	distilled smooth Extra-slimy Slimosa	5	awesome	Last Available: "2012-03"
 5605	hand-crafted Slimebite	4	EPIC	Last Available: "2012-03"
-5606	mediocre fancy practically non-alcoholic Cement Mixer	1	decent	Effect: "Human-Demon Hybrid", Effect Duration: 45, Last Available: "2012-03"
-5607	perfectly mixed distilled twirling ghostly Jackhammer	5	EPIC	Last Available: "2012-03"
+5606	practically non-alcoholic fancy mediocre Cement Mixer	1	decent	Effect: "Human-Demon Hybrid", Effect Duration: 45, Last Available: "2012-03"
+5607	perfectly mixed distilled ghostly twirling Jackhammer	5	EPIC	Last Available: "2012-03"
 5608	delicious Dump Truck	4	awesome	Last Available: "2012-03"
 5609	lousy twirling Fauna Libre	4	decent	Last Available: "2012-03"
 5610	spirit-forward acceptable ghostly Chakra Libre	5	good	Last Available: "2012-03"
-5611	special acceptable purple ghostly Aura Libre	4	good	Effect: "Drunk With Power", Effect Duration: 30, Last Available: "2012-03"
+5611	special acceptable ghostly purple Aura Libre	4	good	Effect: "Drunk With Power", Effect Duration: 30, Last Available: "2012-03"
 5612	tolerable Sazerorc	4	good	Last Available: "2012-03"
-5613	perfectly mixed practically non-alcoholic Sazuruk-hai	1	EPIC	Last Available: "2012-03"
+5613	practically non-alcoholic perfectly mixed Sazuruk-hai	1	EPIC	Last Available: "2012-03"
 5614	lousy Flaming Sazerorc	3	decent	Last Available: "2012-03"
 5615	drinkable boozy pulsating Green Velvet	5	good	Last Available: "2012-03"
-5616	lousy watered-down Green Muslin	2	decent	Last Available: "2012-03"
+5616	watered-down lousy Green Muslin	2	decent	Last Available: "2012-03"
 5617	mediocre Green Burlap	4	decent	Last Available: "2012-03"
-5618	perfectly mixed fortified shaking Mohobo	5	EPIC	Last Available: "2012-03"
-5619	special perfectly mixed tumbling Moonshine Mohobo	4	EPIC	Effect: "Rushtacean'", Effect Duration: 15, Last Available: "2012-03"
+5618	fortified perfectly mixed shaking Mohobo	5	EPIC	Last Available: "2012-03"
+5619	perfectly mixed special tumbling Moonshine Mohobo	4	EPIC	Effect: "Rushtacean'", Effect Duration: 15, Last Available: "2012-03"
 5620	perfectly mixed Flaming Mohobo	3	EPIC	Last Available: "2012-03"
 5621	bad Drunken Philosopher	3	decent	Last Available: "2012-03"
 5622	hand-crafted spirit-forward fancy gray Drunken Neurologist	5	EPIC	Effect: "Twen Tea", Effect Duration: 50, Last Available: "2012-03"
@@ -5529,8 +5529,8 @@
 5626	high-proof lousy gray Event Horizon	10	decent	Last Available: "2012-03"
 5627	watered-down artisanal Herring Daiquiri	2	EPIC	Last Available: "2012-03"
 5628	perfectly mixed Herring Wallbanger	3	EPIC	Last Available: "2012-03"
-5629	watered-down acceptable Herringtini	2	good	Last Available: "2012-03"
-5630	acceptable huge spinning green Lollipop Drop	3	good	Last Available: "2012-03"
+5629	acceptable watered-down Herringtini	2	good	Last Available: "2012-03"
+5630	acceptable green huge spinning Lollipop Drop	3	good	Last Available: "2012-03"
 5631	drinkable practically non-alcoholic jittery Candy Alexander	1	good	Last Available: "2012-03"
 5632	lousy high-proof Candicaine	6	decent	Last Available: "2012-03"
 5633	watered-down artisanal blue Caipiranha	2	EPIC	Last Available: "2012-03"
@@ -5539,7 +5539,7 @@
 5636	high-proof hand-crafted Punchplanter	10	EPIC	Last Available: "2012-03"
 5637	lousy Doublepunchplanter	3	decent	Last Available: "2012-03"
 5638	perfectly mixed upside-down Haymaker	3	EPIC	Last Available: "2012-03"
-5639	bouncing lime green Small Medium	0		Free Pull, Last Available: "2012-03"
+5639	lime green bouncing Small Medium	0		Free Pull, Last Available: "2012-03"
 5640	crystal decanter	0		Familiar Weight: +5, Last Available: "2012-03"
 5641	delicious fungus	3	awesome	
 5642	poisoned dart	0		
@@ -5555,7 +5555,7 @@
 5652	wobbly blue Monster Manuel	0		Free Pull
 5653	key-o-tron	0		
 5654	rotten nailswurst	3	crappy	
-5655	aged fortified used beer	5	awesome	
+5655	fortified aged used beer	5	awesome	
 5656	Huggler Radio	0		Free Pull
 5657	blurry fettucini &eacute;pines Inconnu recipe	0		Recipe: "fettucini &eacute;pines Inconnu"
 5658	slap and slap again recipe	0		Recipe: "slap and slap again"
@@ -5580,7 +5580,7 @@
 5677	boxer's Ze&trade; goggles	0		Muscle Percent: +10, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	jittery soggy used band-aid	0		Last Available: "2012-05"
 5679	squat cyan rosy-cheeked stylish swimsuit of the brazier	0		Maximum HP Percent: +30, Hot Spell Damage: +25, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
-5680	maroon twirling lost key	0		Last Available: "2012-05"
+5680	twirling maroon lost key	0		Last Available: "2012-05"
 5681	bland P.B.L.T.	3	decent	
 5682	note from Clancy	0		Skill: "Request Sandwich"
 5683	BURT	0		
@@ -5614,7 +5614,7 @@
 5713	Jeselnik's educational fire extinguisher of the boozehound	0		Experience: +1, Sleaze Damage: +25, Booze Drop: +100, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
 5715	wobbly Hjodor's Guide to Arctic Dalmatians	0		Skill: "Frigidalmatian", Last Available: "2012-07"
-5716	skewed ghostly Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
+5716	ghostly skewed Hjodor's Guide to Arctic Dalmatians (used)	0		Skill: "Frigidalmatian", Last Available: "2012-07"
 5717	stale mirror FDKOL hotcakes	3	decent	Last Available: "2012-07"
 5718	hot egg	0		Last Available: "2012-07"
 5719	smoking grass	0		Last Available: "2012-07"
@@ -5633,7 +5633,7 @@
 5732	blank note	0		
 5733	mirror eerily silent box	0		
 5734	adequate forbidden sausage	4	good	
-5735	Lord Flameface's cloak of the boozehound	0		Booze Drop: +100, Last Available: "2012-07", Conditional Skill (Equipped): "Swirl Cloak"
+5735	Lord Flameface's cloak of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	denatured dry magnetized bouncing Drizzlers&trade; Black Licorice	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 35
 5737	electrified super-dry electrified squat daub-breaker	0		Effect: "Dweeby", Effect Duration: 20, Last Available: "2020-09"
 5738	upside-down Camp Scout backpack of Tarzan	0		Experience (Muscle): +3, Softcore Only, Last Available: "2012-07"
@@ -5670,7 +5670,7 @@
 5770	gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
 5771	lime green gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
 5772	gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
-5773	shaking pulsating Thwaitgold maggot statuette	0		
+5773	pulsating shaking Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	shaking fronts	0		Familiar Weight: +5
 5776	wobbly Temple Grandin's Barney's rake of wisdom	0		Mysticality: +15, Familiar Weight: +7
@@ -5687,14 +5687,14 @@
 5788	smut orc keepsake box	0		
 5789	bubblin' crude	0		
 5790	pulsating box of bear arms	0		Last Available: "2012-09"
-5791	upside-down sage right bear arm of the cheetah	0		Mysticality Percent: +10, Initiative: +60, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene"
-5792	green bouncing auspicious sizzling beefcake's left bear arm	0		Muscle: +25, Hot Damage: +10, Item Drop: +10, Softcore Only, Last Available: "2012-09", Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal"
+5791	upside-down sage right bear arm of the cheetah	0		Mysticality Percent: +10, Initiative: +60, Softcore Only, Conditional Skill (Equipped): "Kodiak Moment", Conditional Skill (Equipped): "Grizzly Scene", Last Available: "2012-09"
+5792	green bouncing auspicious sizzling beefcake's left bear arm	0		Muscle: +25, Hot Damage: +10, Item Drop: +10, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	occult Hat O' Nine Tails	0		Spell Damage Percent: +25
 5794	Vulcanized irradiated narrow Enchanted Plunger	0		Effect: "Voracious Gorging", Effect Duration: 16
 5795	improved gray Enchanted Flyswatter	0		Effect: "Big", Effect Duration: 68
 5796	electrified improved jittery Gearhead Goo	0		Effect: "Black Lung", Effect Duration: 45
 5797	improved frozen blurry Missing Eye Simulation Device	0		Effect: "Healthy Green Glow", Effect Duration: 55
-5798	super-ionized enhanced energized twirling blinking narrow Gnollish Crossdress	0		Effect: "Bear Clawed", Effect Duration: 46
+5798	super-ionized enhanced energized blinking narrow twirling Gnollish Crossdress	0		Effect: "Bear Clawed", Effect Duration: 46
 5799	dry liquefied tumbling eldritch dough	0		Effect: "Stands Alone", Effect Duration: 54
 5800	alkaline tarnished pulsating Charity's choker	0		Effect: "Cat-Alyzed", Effect Duration: 47
 5801	energized pickled non-enhanced Smart Bone Dust	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 24
@@ -5753,15 +5753,15 @@
 5854	denatured energized concentrated BRICKO stud	0		Effect: "Saucefingers", Effect Duration: 61
 5855	triple-electrified energized Osk'r Chow	0		Effect: "You Know Who to Call", Effect Duration: 15
 5856	chilled Scuba Snack	0		Effect: "Dexteri Tea", Effect Duration: 16
-5857	super-oxidized upside-down jittery grey cube	0		Effect: "Grape Expectations", Effect Duration: 59
+5857	super-oxidized jittery upside-down grey cube	0		Effect: "Grape Expectations", Effect Duration: 59
 5858	polarized votive candle	0		Effect: "EVISCERATE!", Effect Duration: 50
 5859	cold-filtered booby trap	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 53
 5860	super-quantum cold-filtered frozen olive Agent Corrigan's cigarette	0		Effect: "Gunky Dory", Effect Duration: 51
 5861	magnetized dry quantum lime green good ash	0		Effect: "Extra Terrestrial", Effect Duration: 66
-5862	upside-down Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
+5862	upside-down Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
-5865	polarized jittery upside-down papier-mochi	0		Effect: "Artificially Sweet", Effect Duration: 16, Last Available: "2012-09"
+5865	polarized upside-down jittery papier-mochi	0		Effect: "Artificially Sweet", Effect Duration: 16, Last Available: "2012-09"
 5866	quantum papier-m&acirc;chaeranthera	0		Effect: "Bilious Brawn", Effect Duration: 14, Last Available: "2012-09"
 5867	non-nitrogenated red papier-m&acirc;ch&eacute; toothpicks	0		Effect: "You Read The Manual", Effect Duration: 63, Last Available: "2012-09"
 5868	beefy papier-m&acirc;ch&eacute;te of the ox	0		Muscle: 30, Last Available: "2012-09"
@@ -5783,7 +5783,7 @@
 5884	narrow skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	fireproof extremely unsafe personal trainer's smooth Bonestabber	0		Moxie: +15, Experience Percent (Muscle): +10, Weapon Damage Percent: +100, Hot Resistance: +3, Last Available: "2012-10"
-5887	perfectly mixed special twirling crystal skeleton vodka	3	EPIC	Effect: "Spiky Frozen Hair", Effect Duration: 15, Last Available: "2012-10"
+5887	special perfectly mixed twirling crystal skeleton vodka	3	EPIC	Effect: "Spiky Frozen Hair", Effect Duration: 15, Last Available: "2012-10"
 5888	Lazybones&trade; recliner	0		Last Available: "2012-10"
 5889	auxiliary backbone of the bloodbag	0		Maximum HP: +100, Last Available: "2012-10"
 5890	bouncing skulldozer egg	0		Last Available: "2012-10"
@@ -5810,8 +5810,8 @@
 5912	Usain Bolt's Solstice Shield of the detective	0		Item Drop: +20, Initiative: +80
 5913	non-adjusted candy sushi set	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 12, Last Available: "2012-12"
 5914	concentrated galvanized diffused ghostly sweet mochi ball	0		Effect: "In Vino Vires", Effect Duration: 59, Last Available: "2012-12"
-5915	triple-electrified tarnished green twirling squat huge beet-flavored Mr. Mediocrebar	0		Effect: "Haunted Stomach", Effect Duration: 13, Last Available: "2012-12"
-5916	wet galvanized skewed fuchsia ghostly sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Sticky Hands", Effect Duration: 69, Last Available: "2012-12"
+5915	triple-electrified tarnished twirling huge green squat beet-flavored Mr. Mediocrebar	0		Effect: "Haunted Stomach", Effect Duration: 13, Last Available: "2012-12"
+5916	wet galvanized skewed ghostly fuchsia sweet-corn-flavored Mr. Mediocrebar	0		Effect: "Sticky Hands", Effect Duration: 69, Last Available: "2012-12"
 5917	anodized pressed lime green cabbage-flavored Mr. Mediocrebar	0		Effect: "Cat-Alyzed", Effect Duration: 66, Last Available: "2012-12"
 5918	plastic animelf of the scaredy-cat	0		Monster Level: -15, Last Available: "2012-12"
 5919	blurry plastic ChibiBuddy&trade; of the detective	0		Item Drop: +20, Last Available: "2012-12"
@@ -5823,7 +5823,7 @@
 5925	ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	blurry rosy-cheeked brainwave-controlled unicorn horn	0		Maximum HP Percent: +30, Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2", Conditional Skill (Equipped): "Uni-Gore"
+5928	blurry rosy-cheeked brainwave-controlled unicorn horn	0		Maximum HP Percent: +30, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	family-friendly manspreader's sage plastic four-shadowed mime	0		Mysticality Percent: +10, Monster Level: +10, Sleaze Resistance: +1, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	huge baleful plastic Father McGruber	0		Spell Damage: +25, Last Available: "2012-12"
 5961	careful plastic Hank North, Photojournalist	0		Monster Level: -10, Last Available: "2012-12"
 5962	sinister plastic blazing bat	0		Spell Damage: +10, Last Available: "2012-12"
-5963	greedy resourceful electronic dulcimer pants	0		Maximum MP: +50, Meat Drop: +20, Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2", Conditional Skill (Equipped): "Play Hog Fiddle"
+5963	greedy resourceful electronic dulcimer pants	0		Maximum MP: +50, Meat Drop: +20, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	A-Boo clue	0		
 5965	aromatic Frown Exerciser of Tarzan	0		Experience (Muscle): +3, Stench Resistance: +1, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5881,11 +5881,11 @@
 5983	vial of holy water	0		Last Available: "2013-02"
 5984	yellow sharpshooter's MacGyver's brainy cloth cap	0		Mysticality: +5, Maximum MP: +100, Critical Hit Percent: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	wobbly jittery extremely unsafe iron dagger of wisdom of the early riser	0		Mysticality: +15, Weapon Damage Percent: +100, Adventures: +7, Last Available: "2013-02"
-5986	decent bite-sized hamburger	1	good	Last Available: "2013-02"
+5986	bite-sized decent hamburger	1	good	Last Available: "2013-02"
 5987	dollar-sign bag	0		Last Available: "2013-02"
 5988	potion	0		Last Available: "2013-02"
 5989	potion	0		Last Available: "2013-02"
-5990	special perfectly mixed bottle of wine	4	EPIC	Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2013-02"
+5990	perfectly mixed special bottle of wine	4	EPIC	Effect: "Egg-stra Arm", Effect Duration: 50, Last Available: "2013-02"
 5991	squat round bomb	0		Last Available: "2013-02"
 5992	miser's iron helmet of Calamity Jane of temperance	0		Critical Hit Percent: +15, Sleaze Resistance: +5, Meat Drop: +10, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	shaking nippy educational steel sword of wisdom	0		Mysticality: +15, Experience: +1, Cold Damage: +10, Last Available: "2013-02"
@@ -5923,7 +5923,7 @@
 6025	pickled pressed Polysniff Perfume	0		Effect: "Deadly Lampblade", Effect Duration: 66
 6026	lime green Duskwalker syringe	0		
 6027	shaking Space Tours Tripple	0		
-6028	shaking pulsating Battlie Light Saver	0		
+6028	pulsating shaking Battlie Light Saver	0		
 6029	T.U.R.D.S. Key	0		
 6030	stanky dress pants	0		Stench Spell Damage: +25, Familiar Effect: "2xFairy, cap 28"
 6031	miser's badge of authority	0		Meat Drop: +10, Single Equip
@@ -5946,9 +5946,9 @@
 6048	dance instructor's experienced Misty Robe	0		Experience: +2, Experience Percent (Moxie): +10
 6049	purple Da Vinci's experienced slick Misty Cape	0		Moxie: +10, Experience: +2, Experience (Mysticality): +5
 6050	woimbook	0		Familiar Weight: +5
-6051	cyan spinning Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
-6052	massive stale Taco Dan's Taco Stand Taco	6	decent	Last Available: "2012-12"
-6053	lousy special distilled Taco Dan's Taco Stand Chimichangarita	5	decent	Effect: "Morninja", Effect Duration: 40, Last Available: "2012-12"
+6051	spinning cyan Taco Dan's Taco Stand Flier	0		Last Available: "2012-12"
+6052	stale massive Taco Dan's Taco Stand Taco	6	decent	Last Available: "2012-12"
+6053	special distilled lousy Taco Dan's Taco Stand Chimichangarita	5	decent	Effect: "Morninja", Effect Duration: 40, Last Available: "2012-12"
 6054	polarized deionized Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Snobby", Effect Duration: 56, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
 6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
@@ -5966,17 +5966,17 @@
 6068	ghostly loose blade	0		
 6069	ghostly goblin bone hilt	0		
 6070	sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
 6072	blurry confusing LED clock	0		Last Available: "2012-12"
 6073	altered vacuum-sealed bouncing green haggis-infused soap	0		Effect: "Okee-Dokee Computer", Effect Duration: 51, Last Available: "2012-12"
 6074	triple-deionized upside-down magicberry tablets	0		Effect: "Provocative Perkiness", Effect Duration: 37, Last Available: "2012-12"
 6075	magnetized alkaline 37x37x37 puzzle cube	0		Effect: "Savage Beast Inside", Effect Duration: 67, Last Available: "2012-12"
-6076	weak perfectly mixed blurry olive McLeod's Hard Haggis-Ade	2	EPIC	Last Available: "2012-12"
+6076	perfectly mixed weak olive blurry McLeod's Hard Haggis-Ade	2	EPIC	Last Available: "2012-12"
 6077	small delicious haggis-wrapped haggis-stuffed haggis	2	awesome	Last Available: "2012-12"
 6078	upside-down blue home robotics kit	0		Last Available: "2012-12"
 6079	school calculator watch	0		Last Available: "2012-12"
-6080	auspicious haggis socks	0		Item Drop: +10, Single Equip, Last Available: "2012-12", Conditional Skill (Equipped): "Haggis Kick"
-6081	airblaster gun	0		Last Available: "2012-12", Conditional Skill (Equipped): "Air Blast"
+6080	auspicious haggis socks	0		Item Drop: +10, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
+6081	airblaster gun	0		Conditional Skill (Equipped): "Air Blast", Last Available: "2012-12"
 6082	Thinknerd T-shirt grab bag	0		Last Available: "2012-12"
 6083	maroon actual reality goggles	0		Single Equip, Free Pull, Last Available: "2012-12"
 6084	Mr. Haggis	0		Last Available: "2012-12"
@@ -5992,7 +5992,7 @@
 6094	Microplushie: Dorkonide of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2012-12"
 6095	MacGyver's Microplushie: Fauxnerditide	0		Maximum MP: +100, Last Available: "2012-12"
 6096	Microplushie: Hipsterine of extreme caution	0		Monster Level: -25, Last Available: "2012-12"
-6097	cyan upside-down classy monkey	0		Last Available: "2012-12"
+6097	upside-down cyan classy monkey	0		Last Available: "2012-12"
 6098	wobbly gourd potion	0		Last Available: "2013-12"
 6099	chilly Thinknerd T-Shirt	0		Cold Damage: +5, Last Available: "2012-12"
 6100	pile of useless robot parts	0		Last Available: "2012-12"
@@ -6004,7 +6004,7 @@
 6106	Artist's Cookie Cutter of Loneliness	0		Last Available: "2013-12"
 6107	Artist's Cr&egrave;me Brul&eacute;e Torch of Fury	0		Last Available: "2013-12"
 6108	grievous arcane researcher's Ginsu&trade;	0		Experience Percent (Mysticality): +10, Weapon Damage Percent: +50, Last Available: "2013-12"
-6109	squat pulsating bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
+6109	pulsating squat bubble-wrap simulator (one broken button)	0		Last Available: "2012-12"
 6110	twirling bubble-wrap simulator (half broken)	0		Last Available: "2012-12"
 6111	shaking bubble-wrap simulator (one button left)	0		Last Available: "2012-12"
 6112	blurry zaibatsu lobby card	0		Last Available: "2013-12"
@@ -6035,10 +6035,10 @@
 6137	weighted paperclip chain of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2013-12"
 6138	huge great capacitor	0		Last Available: "2013-12"
 6139	rubber gloves of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2013-12"
-6140	blurry huge narrow Chinese curse words	0		Last Available: "2013-12"
+6140	huge blurry narrow Chinese curse words	0		Last Available: "2013-12"
 6141	triad summoning scroll	0		Last Available: "2013-12"
 6142	toothsome teal roasted duck	4	awesome	Last Available: "2013-12"
-6143	fancy gigantic tasty dead meat bun	7	awesome	Effect: "Emotion Sickness", Effect Duration: 30, Last Available: "2013-12"
+6143	gigantic tasty fancy dead meat bun	7	awesome	Effect: "Emotion Sickness", Effect Duration: 30, Last Available: "2013-12"
 6144	Rosewater's cat collar	0		Mysticality Percent: +30, Single Equip, Last Available: "2013-12"
 6145	lard-coated suspicious-looking fedora of the ox	0		Muscle: +20, Sleaze Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
@@ -6049,13 +6049,13 @@
 6152	spoiled spinning gray carrot cake	4	crappy	Last Available: "2013-01"
 6153	hand-crafted carrot claret	3	EPIC	Last Available: "2013-01"
 6154	mixed blue carrot juice	1	EPIC	Last Available: "2013-01"
-6155	yellow tumbling pixel power cell	0		Last Available: "2013-12"
+6155	tumbling yellow pixel power cell	0		Last Available: "2013-12"
 6156	flickering pixel	0		Last Available: "2013-12"
 6157	cyan friendly Byte of extreme caution	0		Monster Level: -25, Familiar Weight: +3, Last Available: "2013-12"
-6158	mirror forbidden anger blaster	0		Spell Damage Percent: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Rage Flame"
-6159	brainy doubt cannon	0		Mysticality: +5, Last Available: "2013-12", Conditional Skill (Equipped): "Doubt Shackles"
-6160	grievous fear condenser	0		Weapon Damage Percent: +50, Last Available: "2013-12", Conditional Skill (Equipped): "Fear Vapor"
-6161	spinning arcane researcher's regret hose	0		Experience Percent (Mysticality): +10, Last Available: "2013-12", Conditional Skill (Equipped): "Tear Wave"
+6158	mirror forbidden anger blaster	0		Spell Damage Percent: +50, Conditional Skill (Equipped): "Rage Flame", Last Available: "2013-12"
+6159	brainy doubt cannon	0		Mysticality: +5, Conditional Skill (Equipped): "Doubt Shackles", Last Available: "2013-12"
+6160	grievous fear condenser	0		Weapon Damage Percent: +50, Conditional Skill (Equipped): "Fear Vapor", Last Available: "2013-12"
+6161	spinning arcane researcher's regret hose	0		Experience Percent (Mysticality): +10, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
 6164	dangerous Sinatra's commodore's hat	0		Experience (Moxie): +5, Weapon Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
@@ -6063,8 +6063,8 @@
 6166	steel-toed dance instructor's deck cannon	0		Experience Percent (Moxie): +10, Damage Reduction: 9, Last Available: "2013-12"
 6167	Newton's ornamental sextant	0		Experience (Mysticality): +3, Last Available: "2013-12"
 6168	inspector's manspreader's Bloodbath	0		Monster Level: +10, Item Drop: +15, Last Available: "2013-12"
-6169	enchanted watered-down bad Hundred Headed IPA	2	decent	Effect: "Frisky Spirit", Effect Duration: 40, Last Available: "2013-12"
-6170	huge stale chum	10	decent	Last Available: "2013-12"
+6169	bad enchanted watered-down Hundred Headed IPA	2	decent	Effect: "Frisky Spirit", Effect Duration: 40, Last Available: "2013-12"
+6170	stale huge chum	10	decent	Last Available: "2013-12"
 6171	wet chilled fuchsia crude crudit&eacute;s	0		Effect: "Vented Spleen", Effect Duration: 38
 6172	unsweetened candy crayons	0		Effect: "Sweet and Red", Effect Duration: 61, Last Available: "2020-09"
 6173	maroon narrow Jeselnik's pixel grappling hook	0		Sleaze Damage: +25, Item Drop: +5
@@ -6081,17 +6081,17 @@
 6184	twirling sharpshooter's Fonzie's Jarlsberg's hat of temperance	0		Experience (Moxie): +1, Critical Hit Percent: +10, Sleaze Resistance: +5
 6185	massive spoiled wobbly consummate hard-boiled egg	10	crappy	
 6186	decent cyan consummate fried egg	4	good	
-6187	fancy rotten consummate egg salad	4	crappy	Effect: "Big Meat Big Prizes", Effect Duration: 30
+6187	rotten fancy consummate egg salad	4	crappy	Effect: "Big Meat Big Prizes", Effect Duration: 30
 6188	decent big consummate bagel	5	good	
-6189	rotten special small consummate sliced bread	2	crappy	Effect: "Livin' Large", Effect Duration: 30
+6189	special rotten small consummate sliced bread	2	crappy	Effect: "Livin' Large", Effect Duration: 30
 6190	snack-sized stale upside-down consummate hot dog bun	2	decent	
-6191	fancy stale miniature consummate brownie	2	decent	Effect: "The Wisdom... of the Future", Effect Duration: 5
+6191	miniature fancy stale consummate brownie	2	decent	Effect: "The Wisdom... of the Future", Effect Duration: 5
 6192	snack-sized flavorless consummate toast	2	decent	
-6193	weak bad passable stout	2	decent	
-6194	bland gigantic huge consummate soup	10	decent	
+6193	bad weak passable stout	2	decent	
+6194	gigantic bland huge consummate soup	10	decent	
 6195	flavorless fancy consummate corn chips	3	decent	Effect: "Patent Prevention", Effect Duration: 5
-6196	enchanted flavorless snack-sized consummate salad	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50
-6197	gigantic spoiled consummate salsa	10	crappy	
+6196	flavorless enchanted snack-sized consummate salad	2	decent	Effect: "Can't Be a Chooser", Effect Duration: 50
+6197	spoiled gigantic consummate salsa	10	crappy	
 6198	moldy consummate sauerkraut	4	crappy	
 6199	stale consummate cheese slice	3	decent	
 6200	bite-sized adequate consummate melted cheese	1	good	
@@ -6102,22 +6102,22 @@
 6205	bland consummate frankfurter	3	decent	
 6206	spoiled super-sized fancy consummate french fries	5	crappy	Effect: "Sizzling with Fury", Effect Duration: 35
 6207	tasty small twirling consummate baked potato	2	awesome	
-6208	aged practically non-alcoholic red acceptable vodka	1	awesome	
+6208	practically non-alcoholic aged red acceptable vodka	1	awesome	
 6209	snack-sized yummy skewed consummate ice cream	2	awesome	
 6210	normal consummate whipped cream	4	good	
-6211	flavorless half-sized consummate cream	2	decent	
+6211	half-sized flavorless consummate cream	2	decent	
 6212	tasty consummate strawberries	3	awesome	
 6213	tasty consummate sorbet	4	awesome	
-6214	artisanal watered-down adequate rum	2	EPIC	
+6214	watered-down artisanal adequate rum	2	EPIC	
 6215	acceptable enchanted mediocre lager	3	good	Effect: "Nightlit", Effect Duration: 25
 6216	rotten upside-down immaculate grilled cheese	4	crappy	
-6217	delicious miniature blinking immaculate ice cream sandwich	2	awesome	
+6217	miniature delicious blinking immaculate ice cream sandwich	2	awesome	
 6218	decent immaculate hot dog	4	good	
 6219	flavorless immaculate egg salad sandwich	3	decent	
 6220	spoiled perfect sandwich	4	crappy	
 6221	rotten perfect chef salad	4	crappy	
-6222	miniature decent perfect breakfast	2	good	
-6223	rotten immense sublime deluxe hot dog	6	crappy	
+6222	decent miniature perfect breakfast	2	good	
+6223	immense rotten sublime deluxe hot dog	6	crappy	
 6224	flavorless sublime stew	3	decent	
 6225	rotten blue sublime nachos	4	crappy	
 6226	normal Ultimate Breakfast Sandwich	3	good	
@@ -6125,14 +6125,14 @@
 6228	normal blinking Omega Sundae	4	good	
 6229	high-proof enchanted tolerable Das Sauerlager	6	good	Effect: "Butt-Rock Hair", Effect Duration: 5
 6230	practically non-alcoholic hand-crafted spinning Bologna Lambic	1	super ultra EPIC	
-6231	triple-distilled delicious Vodka Dog	9	awesome	
+6231	delicious triple-distilled Vodka Dog	9	awesome	
 6232	bad watered-down spinning Disappointed Russian	2	decent	
 6233	bad Chunky Mary	3	decent	
 6234	bad Nachojito	4	decent	
 6235	lousy Le Roi	3	decent	
-6236	lousy high-proof yellow Over Easy Rider	6	decent	
-6237	spinning skewed cosmic six-pack	0		
-6239	magnetized tumbling fuchsia cube of ectoplasm	0		Effect: "Shamboozled", Effect Duration: 22
+6236	high-proof lousy yellow Over Easy Rider	6	decent	
+6237	skewed spinning cosmic six-pack	0		
+6239	magnetized fuchsia tumbling cube of ectoplasm	0		Effect: "Shamboozled", Effect Duration: 22
 6240	unsweetened triple-irradiated gray Illuminati earpiece	0		Effect: "Fishy", Effect Duration: 33
 6241	wet gray blurry censored can label	0		Effect: "Full Bottle in front of Me", Effect Duration: 49
 6242	quadruple-ionized altered ectoplasm <i>au jus</i>	0		Effect: "Joy", Effect Duration: 11
@@ -6140,7 +6140,7 @@
 6244	dry ghostly cat's paw	0		Effect: "Sappy Blood", Effect Duration: 55
 6245	alkaline ASCII fu manchu	0		Effect: "damage.enh", Effect Duration: 29
 6246	nitrogenated vacuum-sealed pulsating demonic surgical gloves	0		Effect: "Newt Gets In Your Eyes", Effect Duration: 42
-6247	polymerized frozen squat narrow cyan clip-on ninja tie	0		Effect: "Bilious Brains", Effect Duration: 18
+6247	polymerized frozen narrow cyan squat clip-on ninja tie	0		Effect: "Bilious Brains", Effect Duration: 18
 6248	flattened activated pulsating gamer slurry	0		Effect: "Stop and Smell the Fudge", Effect Duration: 28
 6249	jittery dungeoneering kit	0		Last Available: "2013-02"
 6250	bouncing mirror rosewater-soaked sharpshooter's rosy-cheeked steel-toed Da Vinci's numberwang of the early riser	0		Experience (Mysticality): +5, Damage Reduction: 9, Maximum HP Percent: +30, Critical Hit Percent: +10, Stench Resistance: +3, Adventures: +7, Single Equip
@@ -6160,13 +6160,13 @@
 6264	sharpshooter's slick Staff of Fruit Salad of the boozehound	0		Moxie: +10, Critical Hit Percent: +10, Booze Drop: +100, Jiggle: "Deal Some Prismatic Damage"
 6265	family-friendly wool friendly Staff of the Cream of the Cream	0		Familiar Weight: +3, Cold Resistance: +1, Sleaze Resistance: +1, Jiggle: "Attune to Monster's Essence"
 6266	jar of protein powder	0		
-6267	decent snack-sized green grain of protein powder	2	good	
+6267	snack-sized decent green grain of protein powder	2	good	
 6268	concentrated deionized pec oil	0		Effect: "20-20 Second Sight", Effect Duration: 17
 6269	perfumed gym membership card	0		Stench Resistance: +5
 6270	diffused Squat-Thrust Magazine	0		Effect: "Man's Worst Enemy", Effect Duration: 63
-6271	narrow skewed massive dumbbell	0		
+6271	skewed narrow massive dumbbell	0		
 6272	maroon avaricious medical-grade penguin keychain	0		Meat Drop: +30, HP Regen Min: 7, HP Regen Max: 10, Damage Reduction: 10
-6273	magnetized energized tarnished shaking spinning purple O'RLY manual	0		Effect: "Healthy Blue Glow", Effect Duration: 46
+6273	magnetized energized tarnished purple shaking spinning O'RLY manual	0		Effect: "Healthy Blue Glow", Effect Duration: 46
 6274	distilled acceptable upside-down open sauce	5	good	
 6275	blurry Jeselnik's boxer's turkey leg	0		Muscle Percent: +10, Sleaze Damage: +25
 6276	acceptable irresponsibly strong Ye Olde Meade	10	good	
@@ -6174,7 +6174,7 @@
 6278	Ye Olde Medieval Insult	0		
 6279	tumbling rock-hard pewter claymore	0		Damage Reduction: 5
 6280	lime green artisanal rice peeler of the empath	0		Familiar Weight: +5
-6281	normal special heirloom grape tomato	3	good	Effect: "Total Protonic Reversal", Effect Duration: 15
+6281	special normal heirloom grape tomato	3	good	Effect: "Total Protonic Reversal", Effect Duration: 15
 6282	maroon chipotle wasabi cilantro aioli	0		
 6283	wobbly extremely unsafe brown felt tophat	0		Weapon Damage Percent: +100, Familiar Effect: "1xLep, cap 37"
 6284	spinning gear	0		
@@ -6182,7 +6182,7 @@
 6286	up-at-dawn coward's medical-grade Mark II Steam-Hat	0		Monster Level: -20, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xLep, cap 37"
 6287	rosewater-soaked electrified steel-toed Mark III Steam-Hat of dire peril	0		Weapon Damage: +20, Damage Reduction: 9, Stench Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xLep, cap 37"
 6288	squat lightning-fast frightening sinister cool Mark IV Steam-Hat of James Dean	0		Moxie: +5, Experience (Moxie): +3, Spell Damage: +10, Spooky Damage: +5, Initiative: +40, Familiar Effect: "1xLep, cap 37"
-6289	blue reassuring flame-retardant gravedigger's Temple Grandin's Mark V Steam-Hat of terror	0		Familiar Weight: +7, Spooky Damage: +10, Spooky Spell Damage: +10, Hot Resistance: +1, Spooky Resistance: +1, Familiar Effect: "1xLep, cap 37", Conditional Skill (Equipped): "Fire Death Ray"
+6289	blue reassuring flame-retardant gravedigger's Temple Grandin's Mark V Steam-Hat of terror	0		Familiar Weight: +7, Spooky Damage: +10, Spooky Spell Damage: +10, Hot Resistance: +1, Spooky Resistance: +1, Conditional Skill (Equipped): "Fire Death Ray", Familiar Effect: "1xLep, cap 37"
 6290	ghostly steam-powered model rocketship	0		
 6291	tumbling Van der Graaf energetic punk rock jacket	0		Maximum MP Percent: +20, MP Regen Min: 5, MP Regen Max: 7
 6292	wobbly Socratic weightlifter's safety pin	0		Muscle: +15, Experience (Mysticality): +1
@@ -6237,9 +6237,9 @@
 6341	rock-hard spectral axe of the storm	0		Damage Reduction: 5, Maximum MP Percent: +40
 6342	nasty padded super-strong air freshener	0		Damage Absorption: +20, Stench Damage: +5
 6343	colloidal Mer-kin lipstick	0		Effect: "Extra-Thick Blood", Effect Duration: 69
-6344	jittery squat purple Mer-kin mouthsoap	0		
+6344	squat jittery purple Mer-kin mouthsoap	0		
 6345	ionized magnetized blinking Mer-kin strongjuice	0		Effect: "Hagnk's Gratitude", Effect Duration: 29
-6346	green spinning Mer-kin fitbrine	0		
+6346	spinning green Mer-kin fitbrine	0		
 6347	polymerized frozen alkaline Mer-kin ragejuice	0		Effect: "Amorous", Effect Duration: 49
 6348	Mer-kin dragbelt of chilblains	0		Cold Damage: +25, Experience (Muscle): +20, Single Equip
 6349	upside-down Mer-kin eyeglasses of the wise owl	0		Mysticality: +20, Experience (Mysticality): +20, Single Equip
@@ -6253,7 +6253,7 @@
 6357	Mer-kin knucklebone	0		
 6358	Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	Mer-kin begsign	0		Item Drop: +5, Meat Drop: +40
-6360	jittery Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
+6360	jittery Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
 6361	liquefied chilled double-corrupted pulled taffy	0		Effect: "Jacked In", Effect Duration: 66, Last Available: "2013-04"
 6362	adjusted vacuum-sealed moist blurry pulled indigo taffy	0		Effect: "Gonna Get You, Sucker", Effect Duration: 15, Last Available: "2013-04"
 6363	cold-filtered maroon pulled taffy	0		Effect: "Human-Insect Hybrid", Effect Duration: 33, Last Available: "2013-04"
@@ -6266,17 +6266,17 @@
 6370	squat twisted piece of wire	0		
 6371	aged can of the cheapest beer	3	awesome	
 6372	drinkable high-proof bottle of fruity &quot;wine&quot;	9	good	
-6373	artisanal weak single swig of vodka	2	EPIC	
+6373	weak artisanal single swig of vodka	2	EPIC	
 6374	skewed angry inch	0		
 6375	extremely unsafe testy toolbox	0		Weapon Damage Percent: +100
 6376	yellow Jick-o-User	0		
-6378	blue twirling eraser nubbin	0		
+6378	twirling blue eraser nubbin	0		
 6379	chlorine crystal	0		
 6380	super-alkaline cyan ph balancer	0		Effect: "Heart of Pink", Effect Duration: 40
 6381	nitrogenated mysterious chemical residue	0		Effect: "Super Structure", Effect Duration: 26
 6382	nugget of sodium	0		
 6383	root beer	1	decent	
-6384	shaking olive jigsaw blade	0		
+6384	olive shaking jigsaw blade	0		
 6385	wood screw	0		
 6386	balsa plank	0		
 6387	twirling blob of wood glue	0		
@@ -6303,25 +6303,25 @@
 6408	corrupted stardust	0		
 6409	Star Spawn	0		
 6410	bow from beyond the stars	0		Familiar Weight: +5
-6411	teal squat wobbly squat KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
+6411	wobbly squat teal squat KoLHS Pep Squad Box	0		Free Pull, Last Available: "2013-09"
 6412	shaking skull	0		No Pull
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	normal flavorless gruel	3	good	
-6416	snack-sized bland mana curds	2	decent	
+6416	bland snack-sized mana curds	2	decent	
 6417	twist of lime	0		
 6418	pencil stub	0		
-6419	boiled huge ghostly moth dust	0		Effect: "Omphalotus Omnipresence", Effect Duration: 36
+6419	boiled ghostly huge moth dust	0		Effect: "Omphalotus Omnipresence", Effect Duration: 36
 6420	activated nitrogenated mirror glob of spoiled mayo	0		Effect: "Hennaliciousness", Effect Duration: 49
 6421	tonic djinn	0		
 6422	normal miniature vampire chowder	2	good	
 6423	yellow Tales of Dread	0		Free Pull
 6424	blurry Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	gigantic moldy shaking Dreadsylvanian stew	10	crappy	
+6426	moldy gigantic shaking Dreadsylvanian stew	10	crappy	
 6427	mediocre distilled Dreadsylvanian	5	decent	
 6428	enhanced extra-corrupted Dreadsylvanian flask	0		Effect: "Serenity", Effect Duration: 61
-6429	enhanced gray huge Dreadsylvanian flask	0		Effect: "Impregnably Delicious", Effect Duration: 45
+6429	enhanced huge gray Dreadsylvanian flask	0		Effect: "Impregnably Delicious", Effect Duration: 45
 6430	bouncing up-at-dawn energetic dreadful fedora	0		Maximum MP Percent: +20, Adventures: +5, Kruegerand Drop: 5, Familiar Effect: "spooky atk, 1xLep"
 6431	blurry ghostly banded dreadful sweater	0		Damage Absorption: +100, Kruegerand Drop: 5
 6432	nippy dreadful glove	0		Cold Damage: +10, Kruegerand Drop: 5
@@ -6338,7 +6338,7 @@
 6443	fireproof MacGyver's Helps-You-Sleep	0		Maximum MP: +100, Hot Resistance: +3, Single Equip
 6444	auspicious studded Quiets-Your-Steps of temperance	0		Damage Absorption: +80, Sleaze Resistance: +5, Item Drop: +10, Single Equip
 6445	narrow toasty lion tamer's Protects-Your-Junk	0		Experience (familiar): +2, Hot Damage: +5, Single Equip
-6446	fancy hand-crafted Gets-You-Drunk	3	EPIC	Effect: "Stuck That Way", Effect Duration: 25
+6446	hand-crafted fancy Gets-You-Drunk	3	EPIC	Effect: "Stuck That Way", Effect Duration: 25
 6447	mirror Great Wolf's headband of the cougar of the bloodbag of the cheetah	0		Moxie: +20, Maximum HP: +100, Initiative: +60, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	aromatic stylish thinker's Great Wolf's left paw	0		Mysticality: +10, Moxie: +25, Stench Resistance: +1, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	jittery auspicious experienced smartaleck's Great Wolf's right paw	0		Moxie Percent: +30, Experience: +2, Item Drop: +10, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
@@ -6367,7 +6367,7 @@
 6472	Drunkula's bell	0		
 6473	narrow foul-smelling Lo Pan's Drunkula's ring of haze of dire peril	0		Weapon Damage: +20, Spell Critical Percent: +30, Stench Damage: +10, Avoid Attack: 1, Single Equip
 6474	shaking knitted Drunkula's wineglass	0		Cold Resistance: +3
-6475	acceptable watered-down blinking bottle of Bloodweiser	2	good	
+6475	watered-down acceptable blinking bottle of Bloodweiser	2	good	
 6476	beefy Unkillable Skeleton's skullcap of the blizzard of the sweet-tooth	0		Muscle: +10, Cold Spell Damage: +25, Candy Drop: +100, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	Tesla hardened cool Unkillable Skeleton's breastplate	0		Moxie: +5, Damage Reduction: 3, MP Regen Min: 7, MP Regen Max: 10, Class: "Turtle Tamer"
 6478	blurry crafty forbidden Unkillable Skeleton's shinguards of the brazier	0		Spell Damage Percent: +50, Maximum MP: +10, Hot Spell Damage: +25, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	bone flour	0		
 6486	dreadful roast	0		
 6487	olive stinking agaricus	0		
-6488	rotten jumbo enchanted Dreadsylvanian shepherd's pie	5	crappy	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 35
+6488	enchanted rotten jumbo Dreadsylvanian shepherd's pie	5	crappy	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 35
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	squat tailfeathers	0		Familiar Weight: +5
@@ -6408,7 +6408,7 @@
 6513	wicked warm fur	0		Spell Damage: +5
 6514	Fonzie's snowstick	0		Experience (Moxie): +1
 6515	blurry clever eerie fetish	0		Maximum MP: +20, Single Equip
-6516	weak bad stinkwater	2	decent	
+6516	bad weak stinkwater	2	decent	
 6517	dubious loincloth	0		Familiar Effect: "atk, 1.5xVolley"
 6518	low-calorie rotten mirror accidental mutton	1	crappy	
 6519	drafty drawers of Gandalf of bravery	0		Spell Critical Percent: +20, Spooky Resistance: +5, Familiar Effect: "1.5xVolley"
@@ -6429,7 +6429,7 @@
 6534	brainy remorseless knife	0		Mysticality: +5
 6535	spinning clever intimidating coiffure	0		Maximum MP: +20, Familiar Effect: "hot afk, 1xPotato"
 6536	shaking savvy thinker's cod cape	0		Mysticality: +10, Mysticality Percent: +20
-6537	thick spoiled purple blood sausage	5	crappy	
+6537	spoiled thick purple blood sausage	5	crappy	
 6538	Oprah's energetic frying brainpan	0		Maximum MP Percent: 70
 6539	vibrating smooth ball and chain	0		Moxie: +15, Maximum MP Percent: +10, Single Equip
 6540	dry bone of the wise owl	0		Mysticality: +20
@@ -6470,7 +6470,7 @@
 6576	blurry clusterbomb	0		
 6577	blurry stench clusterbomb	0		
 6578	sleaze clusterbomb	0		
-6579	upside-down mirror Dreadsylvanian Almanac page	0		
+6579	mirror upside-down Dreadsylvanian Almanac page	0		
 6580	length of fuse	0		
 6581	narrow dreadful box	0		
 6582	yellow Clan hot dog stand	0		Free Pull, Last Available: "2013-07"
@@ -6482,9 +6482,9 @@
 6588	spinning grievous deadly gnawed-up dog bone	0		Weapon Damage: +5, Weapon Damage Percent: +50
 6589	red foul-smelling Grey Guanon	0		Stench Damage: +10
 6590	ghostly Annie Oakley's sharpshooter's wizardly Engorged Sausages and You	0		Mysticality: +25, Critical Hit Percent: 30
-6591	acceptable triple-distilled enchanted narrow dream of a dog	10	good	Effect: "Gummi Badass", Effect Duration: 20
+6591	acceptable enchanted triple-distilled narrow dream of a dog	10	good	Effect: "Gummi Badass", Effect Duration: 20
 6592	bouncing Jack Frost's crafty optimal spreadsheet of the pedagogue	0		Experience: +3, Maximum MP: +10, Cold Spell Damage: +50
-6593	cyan twirling defective Game Grid token	0		
+6593	twirling cyan defective Game Grid token	0		
 6594	hot Dreadsylvanian cocoa	0		
 6595	compressed epic cluster	1	good	
 6596	clockwork egg	0		
@@ -6509,7 +6509,7 @@
 6615	hand-crafted Cold One	3	???	
 6616	stale jumbo spaghetti breakfast	5	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
-6618	mirror yellow folder (red)	0		Muscle: +20, Last Available: "2013-08"
+6618	yellow mirror folder (red)	0		Muscle: +20, Last Available: "2013-08"
 6619	upside-down folder (blue)	0		Mysticality: +20, Last Available: "2013-08"
 6620	folder (green)	0		Moxie: +20, Last Available: "2013-08"
 6621	folder (magenta)	0		Muscle: +15, Mysticality: +15, Last Available: "2013-08"
@@ -6541,7 +6541,7 @@
 6649	irradiated Vulcanized tumbling Ogres and Oubliettes&trade; module	0		Effect: "Frost Tea", Effect Duration: 58
 6650	Mountain Stream Code Black Alert	0		
 6651	twisted-up wet towel	0		
-6652	high-proof aged twirling stepmom's booze	10	awesome	
+6652	aged high-proof twirling stepmom's booze	10	awesome	
 6653	surgical tape	0		
 6654	stiffened band T-shirt	0		Damage Reduction: 1
 6655	aged fountain 'soda'	3	awesome	
@@ -6550,7 +6550,7 @@
 6658	boiled modified bouncing hair oil	0		Effect: "damage.enh", Effect Duration: 47
 6659	colloidal shaking scrap	0		Effect: "Bandersnatched", Effect Duration: 69
 6660	green school spirit socket set	0		
-6661	teal blurry suspension bridge	0		
+6661	blurry teal suspension bridge	0		
 6662	clever Da Vinci's sage Staff of the Lunch Lady of Leguizamo	0		Mysticality Percent: +10, Experience (Mysticality): +5, Maximum MP: +20, Monster Level: +20
 6663	universal key	0		
 6664	world's most dangerous birdhouse	0		
@@ -6602,7 +6602,7 @@
 6710	ribald pygmy briefs of Flo-Jo	0		Sleaze Damage: +10, Initiative: +100, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	bouncing short writ of habeas corpus	0		
 6712	blue bone abacus	0		
-6713	twirling narrow adder	0		
+6713	narrow twirling adder	0		
 6714	short calculator	0		
 6715	jittery mirror avaricious occult sphygmomanometer	0		Spell Damage Percent: +25, Meat Drop: +30
 6716	concentrated denatured bag of pygmy blood	0		Effect: "Puddingface", Effect Duration: 48
@@ -6612,14 +6612,14 @@
 6720	polymerized pill cup	0		Effect: "Cold Throat", Effect Duration: 20
 6721	horrifying quilted Newton's water bottle	0		Experience (Mysticality): +3, Damage Absorption: +40, Spooky Damage: +25, Familiar Effect: "atk, 1xFairy, cap 40"
 6722	anodized pygmy phone number	0		Effect: "Favored by Lyle", Effect Duration: 51
-6723	ghostly shaking Boozehounds Anonymous token	0		
+6723	shaking ghostly Boozehounds Anonymous token	0		
 6724	super-sized moldy blurry exotic jungle fruit	5	crappy	
 6725	Shore Inc. Ship Trip Scrip	0		
 6726	dude ranch souvenir crate	0		
 6727	tropical island souvenir crate	0		
 6728	ski resort souvenir crate	0		
 6729	UV-resistant compass	0		
-6730	teal skewed funky junk key	0		
+6730	skewed teal funky junk key	0		
 6731	fuchsia Worse Homes and Gardens	0		
 6732	twirling claw-foot bathtub	0		
 6733	clothesline pole	0		
@@ -6634,7 +6634,7 @@
 6742	electrified junk band	0		MP Regen Min: 3, MP Regen Max: 5
 6743	narrow shaking miser's junk trunks	0		Meat Drop: +10, Familiar Effect: "cap 15"
 6744	MacGyver's junk-mail shirt	0		Maximum MP: +100
-6745	special flavorless junk food	3	decent	Effect: "Donho's Bubbly Ballad", Effect Duration: 40
+6745	flavorless special junk food	3	decent	Effect: "Donho's Bubbly Ballad", Effect Duration: 40
 6746	hand-crafted junk yard	4	EPIC	
 6747	squat purple sinister groovy swordzall	0		Moxie Percent: +10, Spell Damage: +10
 6748	twirling arm buzzer of the boozehound	0		Booze Drop: +100, Damage Reduction: 6
@@ -6646,15 +6646,15 @@
 6754	squat beer bottle	0		
 6755	beer label	0		
 6756	artisanal homebrew sampler	0		
-6757	bad weak can of Br&uuml;talbr&auml;u	2	decent	Last Available: "2013-09"
+6757	weak bad can of Br&uuml;talbr&auml;u	2	decent	Last Available: "2013-09"
 6758	artisanal ghostly can of Drooling Monk	4	EPIC	Last Available: "2013-09"
 6759	delicious maroon can of Impetuous Scofflaw	3	awesome	Last Available: "2013-09"
 6760	watered-down smooth jittery bottle of Old Pugilist	2	awesome	Last Available: "2013-09"
 6761	delicious bottle of Professor Beer	3	awesome	Last Available: "2013-09"
-6762	perfectly mixed special high-proof bottle of Rapier Witbier	8	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 10, Last Available: "2013-09"
-6763	high-proof smooth mirror bottle of Race Car Red	6	awesome	Last Available: "2013-09"
-6764	spirit-forward aged pulsating bottle of Greedy Dog	5	awesome	Last Available: "2013-09"
-6765	weak acceptable bottle of Lambada Lambic	2	good	Last Available: "2013-09"
+6762	perfectly mixed high-proof special bottle of Rapier Witbier	8	EPIC	Effect: "Aspect of the Twinklefairy", Effect Duration: 10, Last Available: "2013-09"
+6763	smooth high-proof mirror bottle of Race Car Red	6	awesome	Last Available: "2013-09"
+6764	aged spirit-forward pulsating bottle of Greedy Dog	5	awesome	Last Available: "2013-09"
+6765	acceptable weak bottle of Lambada Lambic	2	good	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	artisanal homebrew gift package	0		
 6768	liquid bread	1	good	Last Available: "2013-09"
@@ -6679,12 +6679,12 @@
 6789	boot knife	0		
 6790	teal broken beer bottle	0		
 6791	sharpened spoon	0		
-6792	upside-down blue bouncing candy knife	0		
+6792	blue upside-down bouncing candy knife	0		
 6793	soap knife	0		
 6795	corrupted modified disco horoscope (Aquarius)	0		Effect: "Frigid Weapon", Effect Duration: 54
 6796	anodized disco horoscope (Pisces)	0		Effect: "Frosty the Hitman", Effect Duration: 44
 6797	corrupted ghostly disco horoscope (Aries)	0		Effect: "Holiday Disappointment", Effect Duration: 42
-6798	concentrated ionized shaking purple blurry disco horoscope (Taurus)	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 61
+6798	concentrated ionized purple shaking blurry disco horoscope (Taurus)	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 61
 6799	quadruple-chilled super-warmed disco horoscope (Gemini)	0		Effect: "Eldritch Concentration", Effect Duration: 45
 6800	altered quadruple-dry pulsating disco horoscope (Cancer)	0		Effect: "Stuck-Up Hair", Effect Duration: 63
 6801	triple-nitrogenated polarized narrow disco horoscope (Leo)	0		Effect: "Marco Polarity", Effect Duration: 39
@@ -6695,7 +6695,7 @@
 6806	Vulcanized pressed disco horoscope (Capricorn)	0		Effect: "On Pins and Needles", Effect Duration: 62
 6807	bouncing shaking zippy The Sagittarian's leisure pants of wisdom	0		Mysticality: +15, Initiative: +20, Familiar Effect: "atk, cap 18"
 6808	toy accordion	0		Song Duration: 5
-6809	cyan shaking accordion	0		Song Duration: 10
+6809	shaking cyan accordion	0		Song Duration: 10
 6810	blinking mansplainer's beer-battered accordion	0		Monster Level: +15, Class: "Accordion Thief", Song Duration: 6
 6811	huge bouncing savvy baritone accordion	0		Mysticality Percent: +20, Class: "Accordion Thief", Song Duration: 7
 6812	mama's squeezebox of the wise owl	0		Mysticality: +20, Class: "Accordion Thief", Song Duration: 8
@@ -6714,7 +6714,7 @@
 6825	stanky grievous alarm accordion	0		Weapon Damage Percent: +50, Stench Spell Damage: +25, Class: "Accordion Thief", Song Duration: 20
 6826	perfumed gravedigger's vibrating All-Hallow's Steve's fright wig	0		Maximum MP Percent: +10, Spooky Damage: +10, Stench Resistance: +5, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	sizzling chilly KoL Con X Treasure Map	0		Cold Damage: +5, Hot Damage: +10
-6828	weak artisanal discocktail	2	EPIC	
+6828	artisanal weak discocktail	2	EPIC	
 6829	flame-wreathed KoL Con X Bingo Card	0		Hot Spell Damage: +10
 6830	Da Vinci's Temporal Tempera Tube	0		Experience (Mysticality): +5
 6831	triple-liquefied polymerized mirror Tallowcreme Halloween Pumpkin	0		Effect: "Sappy Blood", Effect Duration: 21
@@ -6724,7 +6724,7 @@
 6835	Vulcanized pickled pulsating bag of W&Ws	0		Effect: "Don't Rest Ye, Bold Adventurer", Effect Duration: 61
 6836	irradiated tarnished PEEZ dispenser	0		Effect: "Mayeaugh", Effect Duration: 52
 6837	quadruple-tarnished corrupted wobbly Swizzler	0		Effect: "Proprie Tea", Effect Duration: 41
-6838	adjusted diffused lime green pulsating Bugbearclaw Donut	0		Effect: "Squirming Like a Toad", Effect Duration: 12
+6838	adjusted diffused pulsating lime green Bugbearclaw Donut	0		Effect: "Squirming Like a Toad", Effect Duration: 12
 6839	cold-filtered polarized jam	0		Effect: "Human-Hobo Hybrid", Effect Duration: 23
 6840	ionized anodized teal Whenchamacallit bar	0		Effect: "Ancestral Disapproval", Effect Duration: 46
 6841	flattened purple 8-bit banana	0		Effect: "Eye of the Seal", Effect Duration: 45
@@ -6746,22 +6746,22 @@
 6857	stiffened Cajun accordion	0		Damage Reduction: 1, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	greasy quirky accordion	0		Sleaze Spell Damage: +10, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	brawny Skipper's accordion	0		Muscle Percent: +20, Item Drop: +5, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	rosewater-soaked gravedigger's medical-grade Pantsgiving of the pedagogue	0		Experience: +3, Spooky Damage: +10, Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25", Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry"
+6860	rosewater-soaked gravedigger's medical-grade Pantsgiving of the pedagogue	0		Experience: +3, Spooky Damage: +10, Stench Resistance: +3, HP Regen Min: 7, HP Regen Max: 10, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	normal bite-sized can of sardines	1	good	Last Available: "2013-11"
-6862	adequate upside-down blurry high-calorie sugar substitute	3	good	Last Available: "2013-11"
-6863	normal half-sized pat of butter	2	good	Last Available: "2013-11"
+6862	adequate blurry upside-down high-calorie sugar substitute	3	good	Last Available: "2013-11"
+6863	half-sized normal pat of butter	2	good	Last Available: "2013-11"
 6864	immense adequate skewed dinner roll	10	good	Last Available: "2013-11"
 6865	moldy pulsating lime green mashed potatoes	3	crappy	Last Available: "2013-11"
 6866	tiny spoiled whole turkey leg	1	crappy	Last Available: "2013-11"
-6867	moldy miniature deviled egg	2	crappy	Last Available: "2013-11"
+6867	miniature moldy deviled egg	2	crappy	Last Available: "2013-11"
 6868	dry finger exerciser	0		Effect: "Human-Insect Hybrid", Effect Duration: 11, Last Available: "2013-11"
-6869	non-irradiated boiled bouncing blinking dented spoon	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 26, Last Available: "2013-11"
+6869	non-irradiated boiled blinking bouncing dented spoon	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 26, Last Available: "2013-11"
 6870	polarized magnetized love note	0		Effect: "Mad at Science", Effect Duration: 52, Last Available: "2013-11"
 6871	red school beer pull tab	0		Last Available: "2013-11"
 6872	irradiated tumbling nail file	0		Effect: "Nas Tea", Effect Duration: 69, Last Available: "2013-11"
 6873	quadruple-dry galvanized concentrated blurry candy wrapper	0		Effect: "Weapon of Mass Destruction", Effect Duration: 50, Last Available: "2013-11"
 6874	gym membership card	0		Last Available: "2013-11"
-6875	aerosolized modified shaking cyan post-holiday sale coupon	0		Effect: "Human-Hobo Hybrid", Effect Duration: 57, Last Available: "2013-11"
+6875	aerosolized modified cyan shaking post-holiday sale coupon	0		Effect: "Human-Hobo Hybrid", Effect Duration: 57, Last Available: "2013-11"
 6876	squat dry cleaning receipt	0		Last Available: "2013-11"
 6877	pocket lint (blue)	0		Last Available: "2013-11"
 6878	pocket lint (green)	0		Last Available: "2013-11"
@@ -6775,8 +6775,8 @@
 6886	spirit pillow	0		
 6887	blinking spirit sheet	0		
 6888	jittery spirit mattress	0		
-6889	maroon blinking spirit blanket	0		
-6890	squat gray spirit bed	0		
+6889	blinking maroon spirit blanket	0		
+6890	gray squat spirit bed	0		
 6891	coward's spirit bell of the bloodbag of the boozehound	0		Maximum HP: +100, Monster Level: -20, Booze Drop: +100, Class: "Turtle Tamer"
 6892	quadruple-galvanized chilled cyan spoonful of Linguine-Os	0		Effect: "Always In Motion", Effect Duration: 33, Last Available: "2013-11"
 6893	activated concentrated freezer-burned frost-bitten tortellini	0		Effect: "Aspect of the Twinklefairy", Effect Duration: 27, Last Available: "2013-11"
@@ -6792,7 +6792,7 @@
 6903	diffused colloidal diffused spinning nuts	0		Effect: "Preternatural Greed", Effect Duration: 59, Last Available: "2013-12"
 6904	energized energized gray bolts	0		Effect: "Eyes Wide Propped", Effect Duration: 39, Last Available: "2013-12"
 6905	toothsome enchanted gingerbread robot	4	awesome	Effect: "Heart of Green", Effect Duration: 30, Last Available: "2013-12"
-6906	diet stale bouncing petit 4.1	1	decent	Last Available: "2013-12"
+6906	stale diet bouncing petit 4.1	1	decent	Last Available: "2013-12"
 6907	flavorless olive nut-shaped Crimbo cookie	3	decent	Last Available: "2023-06"
 6908	electrified plastic GORM-8	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2013-12"
 6909	family-friendly plastic warbear	0		Sleaze Resistance: +1, Last Available: "2013-12"
@@ -6810,8 +6810,8 @@
 6921	adequate warbear feasting bread	3	good	Last Available: "2013-12"
 6922	moldy bouncing warbear warrior bread	4	crappy	Last Available: "2013-12"
 6923	diet spoiled jittery warbear thermoregulator bread	1	crappy	Last Available: "2013-12"
-6924	acceptable fancy high-proof warbear feasting mead	7	good	Effect: "Tiki Thoughtfulness", Effect Duration: 10, Last Available: "2013-12"
-6925	smooth high-proof warbear bearserker mead	6	awesome	Last Available: "2013-12"
+6924	fancy high-proof acceptable warbear feasting mead	7	good	Effect: "Tiki Thoughtfulness", Effect Duration: 10, Last Available: "2013-12"
+6925	high-proof smooth warbear bearserker mead	6	awesome	Last Available: "2013-12"
 6926	artisanal warbear blizzard mead	3	EPIC	Last Available: "2013-12"
 6927	bouncing twirling warbear helm fragment	0		Last Available: "2013-12"
 6928	yellow Annie Oakley's baleful Herculean warbear plain fedora	0		Experience (Muscle): +1, Spell Damage: +25, Critical Hit Percent: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
@@ -6847,7 +6847,7 @@
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
 6959	warbear foil hat of courage	0		Spooky Resistance: +3, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
-6961	flame-retardant quilted warbear oil pan	0		Damage Absorption: +40, Hot Resistance: +1, Class: "Sauceror", Last Available: "2013-12", Conditional Skill (Equipped): "Spray Hot Grease"
+6961	flame-retardant quilted warbear oil pan	0		Damage Absorption: +40, Hot Resistance: +1, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
 6963	fortified warbear exhaust manifold	0		Damage Absorption: +60, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-12"
 6964	warbear jackhammer drill press	0		Last Available: "2013-12"
@@ -6889,16 +6889,16 @@
 7000	sage die-cast Don Crimbo of chilblains	0		Mysticality Percent: +10, Cold Damage: +25, Last Available: "2013-12"
 7001	blue perfumed Tesla die-cast Uncle Hobo	0		Stench Resistance: +5, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
 7002	Usain Bolt's Samson's die-cast Father Crimbo	0		Experience (Muscle): +5, Initiative: +80, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
+7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
 7004	nitrogenated triple-aerosolized bouncing Flaskfull of Hollow	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 67, Last Available: "2013-12"
-7005	squat narrow gray lump of Brituminous coal	0		Last Available: "2013-12"
+7005	gray narrow squat lump of Brituminous coal	0		Last Available: "2013-12"
 7006	diluted maroon handful of Smithereens	1	awesome	Last Available: "2013-12"
 7007	flavorless twirling Every Day is Like This Sundae	4	decent	Last Available: "2013-12"
 7008	moldy huge yellow blurry Miserable Pie	6	crappy	Last Available: "2013-12"
 7009	spoiled This Charming Flan	4	crappy	Last Available: "2013-12"
-7010	irresponsibly strong bad Irish Coffee, English Heart	6	decent	Last Available: "2013-12"
-7011	fancy acceptable extra-dry shaking spinning Strikes Again Bigmouth	5	good	Effect: "Chalked-Up Teeth", Effect Duration: 5, Last Available: "2013-12"
-7012	weak smooth Paint A Vulgar Pitcher	2	awesome	Last Available: "2013-12"
+7010	bad irresponsibly strong Irish Coffee, English Heart	6	decent	Last Available: "2013-12"
+7011	acceptable extra-dry fancy spinning shaking Strikes Again Bigmouth	5	good	Effect: "Chalked-Up Teeth", Effect Duration: 5, Last Available: "2013-12"
+7012	smooth weak Paint A Vulgar Pitcher	2	awesome	Last Available: "2013-12"
 7013	blinking Golden Light	0		Last Available: "2013-12"
 7014	Louder Than Bomb	0		Last Available: "2013-12"
 7015	Handsome Devil	0		Last Available: "2013-12"
@@ -6936,7 +6936,7 @@
 7047	polymerized super-boiled frozen warbear liquid lasers	0		Effect: "Over-Familiar With Dactyls", Effect Duration: 56, Last Available: "2013-12"
 7048	pickled ionized teal warbear rejuvenation potion	0		Effect: "Prelude of Precision", Effect Duration: 21, Last Available: "2013-12"
 7049	broken warbear gyrocopter	0		Last Available: "2013-12"
-7050	spoiled gigantic warbear gyro	8	crappy	Last Available: "2013-12"
+7050	gigantic spoiled warbear gyro	8	crappy	Last Available: "2013-12"
 7051	quantum recording of Rolando's Rondo of Resisto	0		Effect: "Lucky Cat Is Lucky", Effect Duration: 24, Last Available: "2013-12"
 7052	upside-down warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	yellow squat warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
@@ -6957,14 +6957,14 @@
 7068	polymerized single of Donho's Bubbly Ballad	0		Effect: "Benetton's Medley of Diversity", Effect Duration: 56
 7069	Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	rotten miniature snow berries	2	crappy	Last Available: "2014-01"
+7071	miniature rotten snow berries	2	crappy	Last Available: "2014-01"
 7072	bland gigantic upside-down ice harvest	6	decent	Last Available: "2014-01"
 7073	vacuum-sealed nitrogenated ionized cyan frost flower	0		Effect: "Hammertime", Effect Duration: 15, Last Available: "2014-01"
 7074	liquefied snow cleats	0		Effect: "Extra Backbone", Effect Duration: 23, Last Available: "2014-01"
 7075	polarized liquid ice pack	0		Effect: "Perfect Hair", Effect Duration: 53, Last Available: "2014-01"
 7076	fuchsia snow boards	0		Last Available: "2014-01"
 7077	rotten purple snow crab	4	crappy	Last Available: "2014-01"
-7078	acceptable weak narrow Ice Island Long Tea	2	good	Last Available: "2014-01"
+7078	weak acceptable narrow Ice Island Long Tea	2	good	Last Available: "2014-01"
 7079	spinning unfinished ice sculpture	0		Last Available: "2014-01"
 7080	spinning ice sculpture	0		Last Available: "2014-01"
 7081	ice house	0		Last Available: "2014-01"
@@ -6992,9 +6992,9 @@
 7103	aerosolized activated powder	0		Effect: "Mana Tea", Effect Duration: 34, Last Available: "2014-12"
 7104	friendly licorice whip	0		Familiar Weight: +3, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	enchanted hand-crafted snakebite	3	EPIC	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2014-12"
+7106	hand-crafted enchanted snakebite	3	EPIC	Effect: "Feline Ferocity", Effect Duration: 30, Last Available: "2014-12"
 7107	Jeselnik's candy stick	0		Sleaze Damage: +25, Item Drop: +5, Last Available: "2014-12"
-7108	flavorless immense pecan	7	decent	Last Available: "2014-12"
+7108	immense flavorless pecan	7	decent	Last Available: "2014-12"
 7109	normal pecan pie	3	good	Last Available: "2014-12"
 7110	bouncing chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	low-calorie decent candy mountain oyster	1	good	Last Available: "2014-12"
@@ -7004,24 +7004,24 @@
 7115	normal small candy carrot cake	2	good	Last Available: "2014-12"
 7116	Annie Oakley's carrot-on-a-stick of James Dean	0		Experience (Moxie): +3, Critical Hit Percent: +20, Last Available: "2014-12"
 7117	brawny weasel stomping pants of Tarzan	0		Muscle Percent: +20, Experience (Muscle): +3, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
-7118	stale half-sized mulberry	2	decent	Last Available: "2014-12"
-7119	irresponsibly strong drinkable upside-down mulled berry wine	7	good	Last Available: "2014-12"
+7118	half-sized stale mulberry	2	decent	Last Available: "2014-12"
+7119	drinkable irresponsibly strong upside-down mulled berry wine	7	good	Last Available: "2014-12"
 7120	lemony scales	0		Last Available: "2014-12"
 7121	lemon party hat of the sweet-tooth	0		Candy Drop: +100, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	zippy lemon shirt	0		Initiative: +20, Lasts Until Rollover, Last Available: "2014-12"
 7123	lemon drop trousers of chilblains	0		Cold Damage: +25, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
-7124	double-activated narrow blinking lemonhead caviar	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 53, Last Available: "2014-12"
+7124	double-activated blinking narrow lemonhead caviar	0		Effect: "Pygmy Drinking Buddy", Effect Duration: 53, Last Available: "2014-12"
 7125	bouncing stanky fortified gummi sword	0		Damage Absorption: +60, Stench Spell Damage: +25, Last Available: "2014-12"
-7126	double-pressed jittery bouncing small gummi fin	0		Effect: "Helping Comes Second", Effect Duration: 68, Last Available: "2014-12"
+7126	double-pressed bouncing jittery small gummi fin	0		Effect: "Helping Comes Second", Effect Duration: 68, Last Available: "2014-12"
 7127	chocolate cow bone of the boozehound	0		Booze Drop: +100, Last Available: "2014-12"
 7128	quadruple-denatured deionized gummi fang	0		Effect: "Stemonitis Storm", Effect Duration: 69, Last Available: "2014-12"
 7129	enchanted normal half-sized huge leftover canap&eacute;s	2	good	Effect: "Memento Moir&eacute;", Effect Duration: 15, Last Available: "2014-12"
-7130	practically non-alcoholic bad magnum of champagne	1	decent	Last Available: "2014-12"
+7130	bad practically non-alcoholic magnum of champagne	1	decent	Last Available: "2014-12"
 7131	bouncing supercharged banded cow creamer of doom	0		Damage Absorption: +100, Maximum MP Percent: +30, Spooky Spell Damage: +50, Last Available: "2014-12"
 7132	galvanized diffused narrow Outer Wolf&trade; cologne	0		Effect: "Alchemical, Brother", Effect Duration: 68, Last Available: "2014-12"
 7133	lupine appetite hormones	0		Last Available: "2014-12"
-7134	shaking groovy wolf whistle of bravery	0		Moxie Percent: +10, Spooky Resistance: +5, Last Available: "2014-12", Conditional Skill (Equipped): "Blow Wolf Whistle"
-7135	moldy big enchanted witch's bread	5	crappy	Effect: "It's Soporiffic!", Effect Duration: 40, Last Available: "2014-12"
+7134	shaking groovy wolf whistle of bravery	0		Moxie Percent: +10, Spooky Resistance: +5, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
+7135	big enchanted moldy witch's bread	5	crappy	Effect: "It's Soporiffic!", Effect Duration: 40, Last Available: "2014-12"
 7136	triple-colloidal liquefied huge witch's brew	0		Effect: "items.enh", Effect Duration: 14, Last Available: "2014-12"
 7137	nippy occult witch's bra of the bloodbag	0		Spell Damage Percent: +25, Maximum HP: +100, Cold Damage: +10, Last Available: "2014-12"
 7138	delicious watered-down blinking mid-level medieval mead	2	awesome	Last Available: "2014-12"
@@ -7030,9 +7030,9 @@
 7141	chilled polymerized skewed hi-octane carrot juice	0		Effect: "Serenity", Effect Duration: 49, Last Available: "2014-12"
 7142	moist hare brush	0		Effect: "Heart of White", Effect Duration: 69, Last Available: "2014-12"
 7143	sizzling veiny hare pin	0		Maximum HP: +10, Hot Damage: +10, Single Equip, Last Available: "2014-12"
-7144	green upside-down odd coin	0		Last Available: "2014-12"
+7144	upside-down green odd coin	0		Last Available: "2014-12"
 7145	diet bland tumbling teal squat cinnamon cannoli	1	decent	Last Available: "2014-12"
-7146	enchanted perfectly mixed practically non-alcoholic huge expensive champagne	1	EPIC	Effect: "Spookypants", Effect Duration: 30, Last Available: "2014-12"
+7146	enchanted practically non-alcoholic perfectly mixed huge expensive champagne	1	EPIC	Effect: "Spookypants", Effect Duration: 30, Last Available: "2014-12"
 7147	polarized magnetized polo trophy	0		Effect: "Twinkly Weapon", Effect Duration: 26, Last Available: "2014-12"
 7148	oil painting	0		Last Available: "2014-12"
 7149	rosary	0		Last Available: "2014-12"
@@ -7044,11 +7044,11 @@
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
 7157	greedy chilly razor-sharp fire hose	0		Weapon Damage Percent: +25, Cold Damage: +5, Meat Drop: +20, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
-7158	huge moldy fireman's lunch	9	crappy	Last Available: "2014-12"
+7158	moldy huge fireman's lunch	9	crappy	Last Available: "2014-12"
 7159	inspector's ruddy plain paper hat of Leguizamo	0		Maximum HP Percent: +40, Monster Level: +20, Item Drop: +15, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
-7160	huge toothsome ice cream sandwich	7	awesome	Last Available: "2014-12"
+7160	toothsome huge ice cream sandwich	7	awesome	Last Available: "2014-12"
 7161	hale hardened &quot;honey&quot; dipper of the brazier	0		Damage Reduction: 3, Maximum HP: +20, Hot Spell Damage: +25, Last Available: "2014-12"
-7162	bite-sized tasty plumber's lunch	1	awesome	Last Available: "2014-12"
+7162	tasty bite-sized plumber's lunch	1	awesome	Last Available: "2014-12"
 7163	spinning sharpshooter's skull gearshift knob of the wise owl of the sewer	0		Mysticality: +20, Critical Hit Percent: +10, Stench Damage: +25, Last Available: "2014-12"
 7164	spoiled bite-sized upside-down nachos of the night	1	crappy	Last Available: "2014-12"
 7165	Tesla steel-toed Sketcherz&trade; of the glutton	0		Damage Reduction: 9, Food Drop: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2014-12"
@@ -7112,13 +7112,13 @@
 7223	concentrated concentrated oxidized lynyrd musk	0		Effect: "The Power of Positive Thinking", Effect Duration: 20
 7224	stiffened Kashmir sweater of the bloodbag	0		Damage Reduction: 1, Maximum HP: +100
 7225	spoiled custard pie	3	crappy	
-7226	special bouncing squat blue tea for one	1	EPIC	Effect: "Fishy", Effect Duration: 25
-7227	weak lousy bottle of Evermore	2	decent	
+7226	special squat bouncing blue tea for one	1	EPIC	Effect: "Fishy", Effect Duration: 25
+7227	lousy weak bottle of Evermore	2	decent	
 7228	purple blurry box	0		
-7229	aged enchanted distilled huge wine	5	awesome	Effect: "Wings of the Grasshopper", Effect Duration: 35
+7229	distilled aged enchanted huge wine	5	awesome	Effect: "Wings of the Grasshopper", Effect Duration: 35
 7230	practically non-alcoholic drinkable mirror rum	1	good	
 7231	tolerable irresponsibly strong Murderer's Punch	8	good	
-7232	jumbo decent spinning velvet cake	5	good	
+7232	decent jumbo spinning velvet cake	5	good	
 7233	extra-polarized triple-warmed letter	0		Effect: "Pemmican't", Effect Duration: 65
 7234	extremely unsafe book of the brazier	0		Weapon Damage Percent: +100, Hot Spell Damage: +25
 7235	prompt baleful masque	0		Spell Damage: +25, Adventures: +3, Single Equip
@@ -7143,7 +7143,7 @@
 7254	red really cocktail shaker	0		Familiar Weight: +5
 7255	mediocre weak mini-martini	2	decent	
 7256	smoke grenade	0		
-7257	altered skewed blinking tumbling molotov soda	1	crappy	
+7257	altered blinking tumbling skewed molotov soda	1	crappy	
 7258	denatured extra-quantum polarized pile of ashes	0		Effect: "Pla-see-bo", Effect Duration: 47
 7259	crate of firebombs	0		
 7260	firebomb	0		
@@ -7165,7 +7165,7 @@
 7276	twirling wholesome plastic Captain Kerkard	0		Maximum HP Percent: +10
 7277	aerosolized robot grease	0		Effect: "Weird Vibrations", Effect Duration: 13
 7278	returned Thinknerd package	0		
-7279	polymerized upside-down mirror yellow wind-up Whatsian robot	0		Effect: "Frozen Shoulders", Effect Duration: 69
+7279	polymerized yellow mirror upside-down wind-up Whatsian robot	0		Effect: "Frozen Shoulders", Effect Duration: 69
 7280	denatured quantum wind-up vampire teeth	0		Effect: "Tiki Thoughtfulness", Effect Duration: 48
 7281	magnetized wind-up navigation droid	0		Effect: "It Didn't Kill You", Effect Duration: 69
 7282	pressed cold-filtered super-boiled shaking wind-up owl	0		Effect: "Worth Your Salt", Effect Duration: 66
@@ -7178,7 +7178,7 @@
 7289	yellow brawny weightlifter's amok putter of the pedagogue	0		Muscle: +15, Muscle Percent: +20, Experience: +3
 7290	rotten big amok pudding	5	crappy	
 7291	blinking deactivated putty buddy	0		
-7292	squat fuchsia putty coat	0		Familiar Weight: +5
+7292	fuchsia squat putty coat	0		Familiar Weight: +5
 7293	ionized can of V-11	0		Effect: "Cake Caked", Effect Duration: 29, Last Available: "2014-03"
 7294	flame-wreathed electrified elevennis shoes	0		Hot Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-03"
 7295	teal elevent	0		Last Available: "2014-03"
@@ -7193,7 +7193,7 @@
 7304	telegram from Lady Spookyraven	0		
 7305	Lady Spookyraven's powder puff	0		
 7306	Lady Spookyraven's finest gown	0		
-7307	skewed bouncing Lady Spookyraven's dancing shoes	0		
+7307	bouncing skewed Lady Spookyraven's dancing shoes	0		
 7308	oxidized pressed eyebrow pencil	0		Effect: "It's Soporiffic!", Effect Duration: 57
 7309	warmed mirror rosewater cream	0		Effect: "The Smeezingtons", Effect Duration: 53
 7310	moist bronzer	0		Effect: "Egg on your Face", Effect Duration: 13
@@ -7201,7 +7201,7 @@
 7312	huge still grill	0		Free Pull, Last Available: "2014-06"
 7313	box of hickory chips	0		Familiar Weight: +5
 7314	bouncing poppet	0		
-7315	fuchsia upside-down squat rickety rocking horse	0		
+7315	fuchsia squat upside-down rickety rocking horse	0		
 7316	jack-in-the-box	0		
 7317	jar of baby ghosts	0		
 7318	narrow Sherlock's stanky beefy ghost of a necklace	0		Muscle: +10, Stench Spell Damage: +25, Item Drop: +25
@@ -7220,14 +7220,14 @@
 7331	flavorless gunky chicken	3	decent	
 7332	blurry friendly doll head	0		Familiar Weight: +3
 7333	droopy doll eye	0		
-7334	jittery pulsating purple voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
+7334	pulsating purple jittery voice box	0		Conditional Skill (Equipped): "Pull Voice Box String"
 7335	green pulsating auspicious curative paddle-ball	0		Item Drop: +10, HP Regen Min: 3, HP Regen Max: 5
 7336	aerosolized sound effects record	0		Effect: "On Pins and Needles", Effect Duration: 31
 7337	narrow alphabet block	0		
 7338	tarnished super-activated dancer	0		Effect: "Well-Swabbed Ear", Effect Duration: 28
 7339	music box mechanism	0		
 7340	brainy moose antlers	0		Mysticality: +5, Familiar Effect: "atk, 1xLep, cap 27"
-7341	enhanced alkaline squat twirling spinning moose thought	0		Effect: "Very Clean Teeth", Effect Duration: 52
+7341	enhanced alkaline twirling spinning squat moose thought	0		Effect: "Very Clean Teeth", Effect Duration: 52
 7342	jumbo delicious pulsating moose chocolate	5	awesome	
 7343	aged painting of a glass of wine	4	awesome	
 7344	oil painting of yourself	0		
@@ -7238,9 +7238,9 @@
 7349	ghost key	0		
 7350	picture of you	0		
 7351	arcane researcher's Staff of the Electric Range of the storm of the blizzard	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +40, Cold Spell Damage: +25
-7352	adequate snack-sized deluxe layer cake	2	good	
+7352	snack-sized adequate deluxe layer cake	2	good	
 7353	chunk of hot iron	0		
-7354	mediocre triple-distilled red-hot boilermaker	6	decent	
+7354	triple-distilled mediocre red-hot boilermaker	6	decent	
 7355	blurry mirror coal shovel of the empath	0		Familiar Weight: +5, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	super-activated irradiated hot coal	0		Effect: "Dirge of Dreadfulness", Effect Duration: 45
 7357	aerosolized coal dust	0		Effect: "Bootyliciousness", Effect Duration: 61
@@ -7272,7 +7272,7 @@
 7383	DNA extraction syringe	0		Last Available: "2014-04"
 7384	super-dry Gene Tonic: Dude	0		Effect: "Bark of the Dog", Effect Duration: 44, Last Available: "2014-04"
 7385	triple-galvanized polarized Gene Tonic: Beast	0		Effect: "Jingle Jangle Jingle", Effect Duration: 20, Last Available: "2014-04"
-7386	electrified wobbly twirling Gene Tonic: Construct	0		Effect: "Turtle Titters", Effect Duration: 11, Last Available: "2014-04"
+7386	electrified twirling wobbly Gene Tonic: Construct	0		Effect: "Turtle Titters", Effect Duration: 11, Last Available: "2014-04"
 7387	Vulcanized corrupted twirling Gene Tonic: Undead	0		Effect: "Ooh, Umami!", Effect Duration: 59, Last Available: "2014-04"
 7388	modified double-cold-filtered Gene Tonic: Humanoid	0		Effect: "Full-Body Tan", Effect Duration: 37, Last Available: "2014-04"
 7389	adjusted non-nitrogenated adjusted Gene Tonic: Insect	0		Effect: "Fit To Be Tide", Effect Duration: 52, Last Available: "2014-04"
@@ -7307,7 +7307,7 @@
 7418	pulsating Steam Card: Jackass Plumber (#1)	0		
 7419	Steam Card: Jackass Plumber (#2)	0		
 7420	Steam Card: Jackass Plumber (#3)	0		
-7421	bouncing blurry pencil thin mushroom	0		Last Available: "2014-05"
+7421	blurry bouncing pencil thin mushroom	0		Last Available: "2014-05"
 7422	huge Paradaisical Cheeseburger recipe	0		Last Available: "2014-05"
 7423	narrow salty sailor salt	0		Last Available: "2014-05"
 7424	bike rental broupon	0		Last Available: "2014-05"
@@ -7324,16 +7324,16 @@
 7435	dry modified pulsating Stemonitis Staticus mushroom	0		Effect: "Updated", Effect Duration: 34, Last Available: "2014-05"
 7436	cold-filtered denatured Tremella Tarantella mushroom	0		Effect: "Neutered Nostrils", Effect Duration: 33, Last Available: "2014-05"
 7437	Pastaco shell	0		Last Available: "2014-05"
-7438	gigantic flavorless ghostly Beefy Crunch Pastaco	8	decent	Last Available: "2014-05"
+7438	flavorless gigantic ghostly Beefy Crunch Pastaco	8	decent	Last Available: "2014-05"
 7439	flavorless Brain Food Pastaco	3	decent	Last Available: "2014-05"
 7440	bland wobbly Cool Brunch Pastaco	3	decent	Last Available: "2014-05"
 7441	decent immense gray Medical Pastaco	8	good	Last Available: "2014-05"
-7442	moldy snack-sized Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
-7443	huge normal narrow blue Ludovico Pastaco	6	good	Last Available: "2014-05"
-7444	delicious weak overpowering mushroom wine	2	awesome	Last Available: "2014-05"
+7442	snack-sized moldy Energy Buzz Pastaco	2	crappy	Last Available: "2014-05"
+7443	normal huge blue narrow Ludovico Pastaco	6	good	Last Available: "2014-05"
+7444	weak delicious overpowering mushroom wine	2	awesome	Last Available: "2014-05"
 7445	bad complex mushroom wine	4	decent	Last Available: "2014-05"
 7446	smooth smooth mushroom wine	4	awesome	Last Available: "2014-05"
-7447	irresponsibly strong special mediocre blood-red mushroom wine	6	decent	Effect: "Izchak's Blessing", Effect Duration: 15, Last Available: "2014-05"
+7447	irresponsibly strong mediocre special blood-red mushroom wine	6	decent	Effect: "Izchak's Blessing", Effect Duration: 15, Last Available: "2014-05"
 7448	hand-crafted buzzing mushroom wine	3	super ultra EPIC	Last Available: "2014-05"
 7449	delicious skewed swirling mushroom wine	3	awesome	Last Available: "2014-05"
 7450	rotten Taco Dan's Basic Taco Dan Taco	3	crappy	Last Available: "2014-05"
@@ -7341,8 +7341,8 @@
 7452	jittery Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	perfectly mixed narrow regular-size brogurt	3	EPIC	Last Available: "2014-05"
 7454	hand-crafted lime green super-size brogurt	3	EPIC	Last Available: "2014-05"
-7455	irresponsibly strong tolerable broberry brogurt	6	good	Last Available: "2014-05"
-7456	strong mediocre brocolate brogurt	5	decent	Last Available: "2014-05"
+7455	tolerable irresponsibly strong broberry brogurt	6	good	Last Available: "2014-05"
+7456	mediocre strong brocolate brogurt	5	decent	Last Available: "2014-05"
 7457	acceptable French bronilla brogurt	3	good	Last Available: "2014-05"
 7458	blinking History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
@@ -7351,7 +7351,7 @@
 7462	occult Brogre brorts	0		Spell Damage Percent: +25, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	curative Brogre brolo shirt	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-05"
 7464	Brogre bucket hat of the dark arts	0		Spell Damage Percent: +100, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
-7465	pulsating lime green Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
+7465	lime green pulsating Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	spinning airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
 7468	toasty sharpshooter's groovy 8-billed baseball cap	0		Moxie Percent: +10, Critical Hit Percent: +10, Hot Damage: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
@@ -7366,7 +7366,7 @@
 7477	tarnished activated double-polymerized jittery Meat-inflating powder	0		Effect: "Grumpy and Ornery", Effect Duration: 41, Last Available: "2014-05"
 7478	blue possessed sugar cube	0		Last Available: "2014-05"
 7479	quantum sugar fairy	0		Effect: "Venomous Weapon", Effect Duration: 63, Last Available: "2014-05"
-7480	dry liquefied irradiated huge jittery squat sugar bunny	0		Effect: "Third Based", Effect Duration: 55, Last Available: "2014-05"
+7480	dry liquefied irradiated jittery huge squat sugar bunny	0		Effect: "Third Based", Effect Duration: 55, Last Available: "2014-05"
 7481	upside-down sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
 7482	lousy Rompedores de Fantasmas	4	decent	
 7483	lousy spinning La Fantasma y La Oscuridad	3	decent	
@@ -7394,7 +7394,7 @@
 7505	executive dark porquoise ring	0		Meat Drop: +40
 7506	shaking Jack Frost's thinker's book	0		Mysticality: +10, Cold Spell Damage: +50
 7507	stylish cloak	0		Moxie: +25
-7508	blinking narrow label	0		
+7508	narrow blinking label	0		
 7509	tiny stale fuchsia Mornington crescent roll	1	decent	
 7510	Vulcanized eye shadow	0		Effect: "Tasting the Rainbow", Effect Duration: 61
 7511	crumbling wheel	0		
@@ -7405,18 +7405,18 @@
 7516	tumbling witch's spare house key	0		
 7517	wicked experienced spider leg	0		Experience: +2, Spell Damage: +5
 7518	wand of pigification	0		
-7519	watered-down hand-crafted glass of bourbon	2	EPIC	
+7519	hand-crafted watered-down glass of bourbon	2	EPIC	
 7520	burned government manual fragment	0		Last Available: "2014-05"
 7521	spoiled narrow government cheese	4	crappy	Last Available: "2014-05"
 7522	olive Temple Grandin's pair of government shades	0		Familiar Weight: +7, Single Equip, Last Available: "2014-05"
 7523	space junk	0		Last Available: "2014-05"
-7524	unsweetened skewed huge government	0		Effect: "Toast Tea", Effect Duration: 46, Last Available: "2014-05"
+7524	unsweetened huge skewed government	0		Effect: "Toast Tea", Effect Duration: 46, Last Available: "2014-05"
 7525	vacuum-sealed vacuum-sealed alien drugs	0		Effect: "Tremella Tremens", Effect Duration: 49, Last Available: "2023-09"
 7526	weird space book	0		Last Available: "2014-05"
 7527	alien force field disruptor bean	0		Last Available: "2014-05"
 7528	Fonzie's government-issued night-vision goggles of Leguizamo	0		Experience (Moxie): +1, Monster Level: +20, Single Equip, Last Available: "2014-05"
-7529	diet decent maroon loaf of alien bread	1	good	Last Available: "2014-05"
-7530	spoiled half-sized grilled cheese sandwich	2	crappy	Last Available: "2014-05"
+7529	decent diet maroon loaf of alien bread	1	good	Last Available: "2014-05"
+7530	half-sized spoiled grilled cheese sandwich	2	crappy	Last Available: "2014-05"
 7531	dehydrated jittery blinking alien protein powder	1	decent	Last Available: "2014-05"
 7532	perfectly mixed irresponsibly strong rocket fuel	8	EPIC	Last Available: "2014-05"
 7533	alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
@@ -7429,27 +7429,27 @@
 7540	green flame-retardant space beast fur pants	0		Hot Resistance: +1, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	squat space beast fur whip of the boozehound	0		Booze Drop: +100, Last Available: "2014-05"
 7542	bouncing space invader	0		Last Available: "2014-05"
-7543	upside-down jittery frosty space heater of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50, Last Available: "2014-05", Conditional Skill (Equipped): "Heat Space"
+7543	upside-down jittery frosty space heater of doom	0		Cold Spell Damage: +10, Spooky Spell Damage: +50, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
 7544	space bar	0		Last Available: "2014-05"
 7545	tolerable extra-dry wobbly space port	5	good	Last Available: "2014-05"
 7546	hale arcane researcher's space needle	0		Experience Percent (Mysticality): +10, Maximum HP: +20, Last Available: "2014-05"
 7547	dry lime green buffed alien drugs	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 14, Last Available: "2014-05"
-7548	spinning blue hot ashes	0		Last Available: "2014-06"
+7548	blue spinning hot ashes	0		Last Available: "2014-06"
 7549	Vulcanized diffused ash soda	0		Effect: "Tiki Temerity", Effect Duration: 55, Last Available: "2014-06"
 7550	alkaline bouncing liquid smoke	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 49, Last Available: "2014-06"
 7551	quadruple-colloidal huge dollop of barbecue sauce	0		Effect: "Brother Corsican's Blessing", Effect Duration: 12, Last Available: "2014-06"
 7552	energized frozen skewed bowl of marinade	0		Effect: "Fungal Flambé", Effect Duration: 45, Last Available: "2014-06"
-7553	purple jittery shaker of dry rub	0		Last Available: "2014-06"
+7553	jittery purple shaker of dry rub	0		Last Available: "2014-06"
 7554	denatured deionized skewed bottle of lighter fluid	0		Effect: "Violent Night", Effect Duration: 66, Last Available: "2014-06"
 7555	blinking page	0		
 7556	squat elephant gift	0		
 7557	ionized ionized blood cells	0		Effect: "Pemmican't", Effect Duration: 40
-7558	delicious special practically non-alcoholic spinning wine	1	awesome	Effect: "Patience of the Tortoise", Effect Duration: 30
-7559	ionized colloidal wobbly ghostly gummi turtle	0		Effect: "Bone Homie", Effect Duration: 43
-7560	fuchsia squat turtle-shaped rock	0		
+7558	practically non-alcoholic delicious special spinning wine	1	awesome	Effect: "Patience of the Tortoise", Effect Duration: 30
+7559	ionized colloidal ghostly wobbly gummi turtle	0		Effect: "Bone Homie", Effect Duration: 43
+7560	squat fuchsia turtle-shaped rock	0		
 7561	improved chilled giraffe-necked turtle	0		Effect: "Patent Prevention", Effect Duration: 19
 7562	wet maroon spinning musk turtle	0		Effect: "Ginger Snapped", Effect Duration: 63
-7563	liquefied modified huge spinning programmable turtle	0		Effect: "Engorged Weapon", Effect Duration: 54
+7563	liquefied modified spinning huge programmable turtle	0		Effect: "Engorged Weapon", Effect Duration: 54
 7564	non-magnetized blurry mocking turtle	0		Effect: "Memory of Resilience", Effect Duration: 52
 7565	delicious ham steak	4	awesome	
 7566	foul-smelling time-twitching toolbelt	0		Stench Damage: +10, Single Equip, Free Pull
@@ -7458,7 +7458,7 @@
 7569	ribald Oprah's Time Bandit Badge of Courage of extreme caution	0		Maximum MP Percent: +50, Monster Level: -25, Sleaze Damage: +10
 7570	polymerized frozen Friendliness Beverage	0		Effect: "Egg-headedness", Effect Duration: 54
 7571	tumbling stiffened extremely unsafe silent pea shooter	0		Weapon Damage Percent: +100, Damage Reduction: 1
-7572	flavorless jumbo D roll	5	decent	
+7572	jumbo flavorless D roll	5	decent	
 7573	censurious MacGyver's kiwi beak	0		Maximum MP: +100, Sleaze Resistance: +3
 7574	triple-distilled smooth New Zealand iced tea	7	awesome	
 7575	frosty personal trainer's droll monocle	0		Experience Percent (Muscle): +10, Cold Spell Damage: +10, Single Equip
@@ -7475,17 +7475,17 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	olive Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	lousy triple-distilled glass of &quot;milk&quot;	7	decent	Last Available: "2014-07"
+7589	triple-distilled lousy glass of &quot;milk&quot;	7	decent	Last Available: "2014-07"
 7590	drinkable cup of &quot;tea&quot;	4	good	Last Available: "2014-07"
 7591	drinkable special thermos of &quot;whiskey&quot;	3	good	Effect: "Texas Elegance", Effect Duration: 50, Last Available: "2014-07"
 7592	practically non-alcoholic tolerable huge Lucky Lindy	1	good	Last Available: "2014-07"
 7593	acceptable Bee's Knees	3	good	Last Available: "2014-07"
-7594	distilled aged Sockdollager	5	awesome	Last Available: "2014-07"
+7594	aged distilled Sockdollager	5	awesome	Last Available: "2014-07"
 7595	hand-crafted Ish Kabibble	3	EPIC	Last Available: "2014-07"
 7596	tolerable Hot Socks	3	good	Last Available: "2014-07"
 7597	bad cyan Phonus Balonus	3	decent	Last Available: "2014-07"
-7598	mediocre weak Flivver	2	decent	Last Available: "2014-07"
-7599	aged extra-dry special Sloppy Jalopy	5	awesome	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2014-07"
+7598	weak mediocre Flivver	2	decent	Last Available: "2014-07"
+7599	special extra-dry aged Sloppy Jalopy	5	awesome	Effect: "Trufflin'", Effect Duration: 35, Last Available: "2014-07"
 7600	concentrated squat fuchsia flame	0		Effect: "It Didn't Kill You", Effect Duration: 25
 7601	magnetized electrified temporary yak tattoo	0		Effect: "Supafly", Effect Duration: 17
 7602	pickled denatured wobbly Fitspiration&trade; poster	0		Effect: "Fishy Fortification", Effect Duration: 35
@@ -7498,7 +7498,7 @@
 7609	liquefied Redeye&trade; Eyedrops	0		Effect: "In the Saucestream", Effect Duration: 60
 7610	galvanized mirror Dweebisol&trade; inhaler	0		Effect: "Fratty Flavor", Effect Duration: 58
 7611	cold-filtered skewed Lewd Lemmy Hair Oil	0		Effect: "Savage Beast Inside", Effect Duration: 37
-7612	ionized wet bouncing blinking tomato soup poster	0		Effect: "El Vibrations", Effect Duration: 55
+7612	ionized wet blinking bouncing tomato soup poster	0		Effect: "El Vibrations", Effect Duration: 55
 7613	oxidized wet bubblin' chemistry solution	0		Effect: "Eye of the Seal", Effect Duration: 25
 7614	quadruple-dry modified voodoo glowskull	0		Effect: "Broken Fast", Effect Duration: 66
 7615	colloidal huge jittery pygmy adder oil	0		Effect: "Mushroom Moxiousness", Effect Duration: 15
@@ -7521,7 +7521,7 @@
 7632	irradiated spinning government-issue identification badge	0		Effect: "All Branned Up", Effect Duration: 57
 7633	liquefied modified alien hologram projector	0		Effect: "Cute Vision", Effect Duration: 59
 7634	warmed cyan irradiated turtle	0		Effect: "Vital", Effect Duration: 46
-7635	adjusted deionized blurry purple cigar box turtle	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 58
+7635	adjusted deionized purple blurry cigar box turtle	0		Effect: "[1342]Slicked-Back Do", Effect Duration: 58
 7636	Newton's educational shellacked shell	0		Experience: +1, Experience (Mysticality): +3, Class: "Turtle Tamer"
 7637	pillow shell of the wise owl	0		Mysticality: +20, Class: "Turtle Tamer"
 7638	hardened whatsit-covered turtle shell	0		Damage Reduction: 3, Class: "Turtle Tamer"
@@ -7529,7 +7529,7 @@
 7640	knitted wholesome smooth turtle shell	0		Moxie: +15, Maximum HP Percent: +10, Cold Resistance: +3, Class: "Turtle Tamer"
 7641	wobbly shocked shell	0		Class: "Turtle Tamer"
 7642	ingot turtle	0		
-7643	red tumbling duty umbrella	0		
+7643	tumbling red duty umbrella	0		
 7644	pool skimmer	0		
 7645	life preserver	0		
 7646	lightning milk	0		
@@ -7539,14 +7539,14 @@
 7650	double-alkaline bouncing catfish whiskers	0		Effect: "Stick Emporium Membership", Effect Duration: 34
 7651	freshwater fishbone	0		
 7652	fishbone catcher's mitt	0		
-7653	jittery narrow fishbone kneepads	0		Initiative: +60, Single Equip
+7653	narrow jittery fishbone kneepads	0		Initiative: +60, Single Equip
 7654	fishbone corset	0		
 7655	cyan fishbone fins	0		Single Equip
 7656	fishbone facemask	0		Monster Level: -30
 7657	fishbone belt	0		Critical Hit Percent: +25, Weapon Damage: +25, Single Equip
 7658	blurry fishbone bracers	0		Spell Critical Percent: +20, Spell Damage Percent: +100, Single Equip
 7659	tumbling manspreader's neoprene skullcap	0		Monster Level: +10, Familiar Effect: "atk, 1xFairy, cap 16"
-7660	super-dry dry bouncing wobbly goblin water	0		Effect: "Hot Buttoned", Effect Duration: 43
+7660	super-dry dry wobbly bouncing goblin water	0		Effect: "Hot Buttoned", Effect Duration: 43
 7661	red twirling dumb mud	0		
 7662	bland gigantic Sogg-Os	10	decent	
 7663	tumbling occult slick Lord Soggyraven's Slippers of the glutton	0		Moxie: +10, Spell Damage Percent: +25, Food Drop: +100, Single Equip
@@ -7561,9 +7561,9 @@
 7672	flame-retardant law-abiding citizen cane	0		Hot Resistance: +1, Single Equip
 7673	practically non-alcoholic bad blurry legitimate business on the beach	1	decent	
 7674	hep waders of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xPotato, 1xVolley, cap 12"
-7675	small adequate jive turkey leg	2	good	
+7675	adequate small jive turkey leg	2	good	
 7676	vibrating birdbone corset	0		Maximum MP Percent: +10
-7677	denatured ghostly wobbly red candy cigarette	0		Effect: "Wet Jaw", Effect Duration: 64
+7677	denatured ghostly red wobbly candy cigarette	0		Effect: "Wet Jaw", Effect Duration: 64
 7678	supercool 4-dimensional fez	0		Moxie Percent: +20, Familiar Effect: "atk, 1xLep, cap 12"
 7679	tumbling throwing candy	0		
 7680	ghostly toasty super-absorbent tarp	0		Hot Damage: +5
@@ -7581,7 +7581,7 @@
 7692	razor-sharp thinker's beefy hand whip	0		Muscle: +10, Mysticality: +10, Weapon Damage Percent: +25, Last Available: "2014-08"
 7693	ghostly ghostly shellacked quilted glow-in-the-dark necklace of bravery	0		Damage Absorption: +40, Damage Reduction: 7, Spooky Resistance: +5, Last Available: "2014-08"
 7694	Groll doll	0		Single Equip, Last Available: "2014-08"
-7695	blinking hale hardened stiffened cap gun	0		Damage Reduction: 8, Maximum HP: +20, Last Available: "2014-08", Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!"
+7695	blinking hale hardened stiffened cap gun	0		Damage Reduction: 8, Maximum HP: +20, Conditional Skill (Equipped): "Bang! Bang! Bang! Bang!", Last Available: "2014-08"
 7696	smelly cassette player of the storm	0		Maximum MP Percent: +40, Stench Spell Damage: +10, Single Equip, Last Available: "2014-08"
 7697	chewable paper	0		Free Pull, Last Available: "2014-08"
 7698	blinking rubber spider	0		Last Available: "2014-08"
@@ -7592,13 +7592,13 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	yellow LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	squat The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
+7706	squat The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
 7707	electrified narrow rubber nubbin	0		Effect: "Stimulated Body", Effect Duration: 26, Last Available: "2014-08"
 7708	lightning-fast padded rubber cape	0		Damage Absorption: +20, Initiative: +40, Last Available: "2014-08"
-7709	zippy wool Jeselnik's sharpshooter's Thor's Pliers	0		Critical Hit Percent: +10, Sleaze Damage: +25, Cold Resistance: +1, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Last Available: "2014-09", Conditional Skill (Equipped): "Ply Reality"
+7709	zippy wool Jeselnik's sharpshooter's Thor's Pliers	0		Critical Hit Percent: +10, Sleaze Damage: +25, Cold Resistance: +1, Initiative: +20, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	frozen magnetized candy UFOs	0		Effect: "Strawberry Alarm", Effect Duration: 54
 7711	auspicious stylish water wings for babies	0		Moxie: +25, Item Drop: +10
-7712	skewed beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7712	skewed beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
 7713	spoiled squat Strix stix	3	crappy	
 7714	blinking twirling scorching dog trainer's Newton's vampire pellet	0		Experience (Mysticality): +3, Experience (familiar): +1, Hot Damage: +25
 7715	hand-crafted jittery non-aged vinegar	3	EPIC	
@@ -7643,7 +7643,7 @@
 7754	tumbling coward's wholesome Xiblaxian stealth trousers	0		Maximum HP Percent: +10, Monster Level: -20, Last Available: "2014-09"
 7755	blurry scandalous Xiblaxian stealth vest of the cougar	0		Moxie: +20, Sleaze Damage: +5, Last Available: "2014-09"
 7756	moldy gigantic Xiblaxian ultraburrito	9	crappy	Last Available: "2014-09"
-7757	spirit-forward perfectly mixed special Xiblaxian space-whiskey	5	EPIC	Effect: "Eldritch Concentration", Effect Duration: 25, Last Available: "2014-09"
+7757	special spirit-forward perfectly mixed Xiblaxian space-whiskey	5	EPIC	Effect: "Eldritch Concentration", Effect Duration: 25, Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	super-ionized improved activated They liver	0		Effect: "Pecan Pied Piper", Effect Duration: 58, Last Available: "2014-09"
 7760	decent They liver popsicle	3	good	Last Available: "2014-09"
@@ -7673,11 +7673,11 @@
 7784	activated adjusted monkey barf	0		Effect: "Psalm of Pointiness", Effect Duration: 38, Last Available: "2014-10"
 7785	boiled modified candy	0		Effect: "Unusual Fashion Sense", Effect Duration: 25, Last Available: "2014-10"
 7786	censurious horrifying jangly bracelet of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Sleaze Resistance: +3, Last Available: "2014-10"
-7787	therapeutic cuddly teddy bear	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-10", Conditional Skill (Equipped): "Overload Teddy Bear"
+7787	therapeutic cuddly teddy bear	0		HP Regen Min: 5, HP Regen Max: 7, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
 7788	mirror ice-cold Cloaca Zero	0		Last Available: "2014-10"
 7789	Fonzie's Herculean first-aid pouch	0		Experience (Muscle): +1, Experience (Moxie): +1, Last Available: "2014-10"
 7790	khaki duffel bag	0		Last Available: "2014-10"
-7791	vacuum-sealed wobbly narrow airborne mutagen	0		Effect: "Flaming Weapon", Effect Duration: 23, Last Available: "2014-10"
+7791	vacuum-sealed narrow wobbly airborne mutagen	0		Effect: "Flaming Weapon", Effect Duration: 23, Last Available: "2014-10"
 7792	SHAWARMA Initiative Keycard	0		Last Available: "2014-10"
 7793	bottle-opener keycard	0		Last Available: "2014-10"
 7794	Armory keycard	0		Last Available: "2014-10"
@@ -7699,14 +7699,14 @@
 7810	Z-Bone steak	0		
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
-7813	stale half-sized seared dino steak	2	decent	
-7814	weak lousy bottle of drinkin' gas	2	decent	
+7813	half-sized stale seared dino steak	2	decent	
+7814	lousy weak bottle of drinkin' gas	2	decent	
 7815	handful of napalm	0		
 7816	dove DNA	0		
 7817	yellow gelatinous meat mass	0		
 7818	99.44% pure math	0		
 7819	red simple AI	0		
-7820	ghostly teal corrupted bird DNA	0		
+7820	teal ghostly corrupted bird DNA	0		
 7821	blurry sentient meat mass	0		
 7822	spinning zombie dinosaur egg	0		
 7823	french-fry grabber	0		Familiar Weight: +5
@@ -7714,7 +7714,7 @@
 7825	crafty baleful Fonzie's earbuds	0		Experience (Moxie): +1, Spell Damage: +25, Maximum MP: +10, Single Equip
 7826	knitted hale iFlail of wisdom	0		Mysticality: +15, Maximum HP: +20, Cold Resistance: +3
 7827	spoiled unidentifiable dried fruit	4	crappy	
-7828	practically non-alcoholic acceptable flat cider	1	good	
+7828	acceptable practically non-alcoholic flat cider	1	good	
 7829	miser's supercool thinker's trench lighter	0		Mysticality: +10, Moxie Percent: +20, Meat Drop: +10, Last Available: "2014-10"
 7830	adjusted gray experimental serum P-00	0		Effect: "Dancing Prowess", Effect Duration: 56, Last Available: "2014-10"
 7831	military-grade fingernail clippers	0		Last Available: "2014-10"
@@ -7732,10 +7732,10 @@
 7843	huge special clip: boneburners	0		Last Available: "2014-10"
 7844	squat special clip: graveburpers	0		Last Available: "2014-10"
 7845	triple-anodized diffused purple perl necklace	0		Effect: "Haunted Stomach", Effect Duration: 32, Last Available: "2014-12"
-7846	quantum colloidal tumbling shaking Fudge Fiber Armor Plating	0		Effect: "Milk Studly", Effect Duration: 49, Last Available: "2014-12"
+7846	quantum colloidal shaking tumbling Fudge Fiber Armor Plating	0		Effect: "Milk Studly", Effect Duration: 49, Last Available: "2014-12"
 7847	adjusted blurry ruby on canes	0		Effect: "Cancer Rising", Effect Duration: 27, Last Available: "2014-12"
 7848	diet normal petit fortran	1	good	Last Available: "2014-12"
-7849	moldy gigantic skewed java cookie	9	crappy	Last Available: "2014-12"
+7849	gigantic moldy skewed java cookie	9	crappy	Last Available: "2014-12"
 7850	miniature rotten cookie cookie	2	crappy	Last Available: "2014-12"
 7851	Fonzie's plastic exo-suited miner	0		Experience (Moxie): +1, Last Available: "2014-12"
 7852	upside-down Annie Oakley's plastic semi-autonomous drill unit	0		Critical Hit Percent: +20, Last Available: "2014-12"
@@ -7747,7 +7747,7 @@
 7858	electrified servo-assisted exo-pants	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	high-energy mining laser of the blizzard of the businessman	0		Cold Spell Damage: +25, Meat Drop: +50, Last Available: "2014-12"
 7860	bouncing peppermint tailings	0		Last Available: "2014-12"
-7861	blurry jittery nugget of Crimbonium	0		Last Available: "2014-12"
+7861	jittery blurry nugget of Crimbonium	0		Last Available: "2014-12"
 7862	lime green cylindrical mold	0		Last Available: "2014-12"
 7863	huge Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	Petite Paintbrush	0		Adventures: +1
@@ -7797,7 +7797,7 @@
 7908	recovered elf underpants	0		Last Available: "2014-12"
 7909	recovered elf wallet	0		Last Available: "2014-12"
 7910	blurry recovered elf pocketwatch	0		Last Available: "2014-12"
-7911	red shaking recovered elf photo album	0		Last Available: "2014-12"
+7911	shaking red recovered elf photo album	0		Last Available: "2014-12"
 7912	jittery recovered elf smartphone	0		Last Available: "2014-12"
 7913	spinning zippy lion tamer's Temple Grandin's Size XI Wizard's Robe	0		Familiar Weight: +7, Experience (familiar): +2, Initiative: +20, Last Available: "2014-09"
 7914	dry Bit O' Quail Spleen	0		Effect: "Strength of Ten Ettins", Effect Duration: 49
@@ -7811,7 +7811,7 @@
 7922	boozy acceptable Friendly Turkey	5	good	Last Available: "2014-11"
 7923	perfectly mixed tumbling Agitated Turkey	3	EPIC	Last Available: "2014-11"
 7924	artisanal ghostly Ambitious Turkey	4	EPIC	Last Available: "2014-11"
-7925	normal jittery blue neutron lollipop	3	good	Last Available: "2014-12"
+7925	normal blue jittery neutron lollipop	3	good	Last Available: "2014-12"
 7926	extra-dry tolerable gamma nog	5	good	Last Available: "2014-12"
 7934	sneaky wrapping paper	0		Last Available: "2014-12"
 7935	Thwaitgold nit statuette	0		
@@ -7827,7 +7827,7 @@
 7945	twirling table	0		
 7946	avaricious supercharged sinister outlaw bandana	0		Spell Damage: +10, Maximum MP Percent: +30, Meat Drop: +30
 7947	artisanal whiskey in a broken glass	3	EPIC	
-7948	drinkable watered-down ghostly shot of mescal	2	good	
+7948	watered-down drinkable ghostly shot of mescal	2	good	
 7949	mediocre special glass of herbal tequila	3	decent	Effect: "Bonelording", Effect Duration: 20
 7950	bouncing minin' dynamite	0		
 7951	ghostly gravedigger's smelly plaid cowboy hat	0		Stench Spell Damage: +10, Spooky Damage: +10, Familiar Effect: "2xLep, 1xBarrr, cap 25"
@@ -7878,20 +7878,20 @@
 7996	cyan Newton's phantom mask of the blizzard	0		Experience (Mysticality): +3, Cold Spell Damage: +25, Single Equip, Last Available: "2015-12"
 7997	denatured polyesterene powder	1		Last Available: "2015-12"
 7998	modified maroon powder	1		Last Available: "2015-12"
-7999	irradiated moist cold-filtered gray upside-down choco-Crimbot	0		Effect: "Flexibili Tea", Effect Duration: 20, Last Available: "2014-12"
+7999	irradiated moist cold-filtered upside-down gray choco-Crimbot	0		Effect: "Flexibili Tea", Effect Duration: 20, Last Available: "2014-12"
 8000	wet smart watch	0		Effect: "Powder Power", Effect Duration: 41, Last Available: "2014-12"
 8001	wet super-moist augmented-reality shades	0		Effect: "Blessing of the Stinking Alphredo&trade;", Effect Duration: 25, Last Available: "2014-12"
-8002	toy Crimbot mega face of the overflowing toilet	0		Stench Spell Damage: +50, Crimbot Outfit Power: +1, Last Available: "2014-12", Familiar Effect: "hot atk, cap 12", Conditional Skill (Equipped): "LIGHT"
-8003	steel-toed toy Crimbot power glove	0		Damage Reduction: 9, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "ZAP"
-8004	toy Crimbot super fist of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "POW"
-8005	toy Crimbot rocket legs of the cheetah	0		Initiative: +60, Crimbot Outfit Power: +1, Last Available: "2014-12", Conditional Skill (Equipped): "BURN"
+8002	toy Crimbot mega face of the overflowing toilet	0		Stench Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
+8003	steel-toed toy Crimbot power glove	0		Damage Reduction: 9, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
+8004	toy Crimbot super fist of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
+8005	toy Crimbot rocket legs of the cheetah	0		Initiative: +60, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	boiled Crimbot battery	0		Effect: "You Drank Fish Wine", Effect Duration: 34, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8009	Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	wobbly Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
-8012	green Oprah's smooth Crimbomega drive chain of the early riser	0		Moxie: +15, Maximum MP Percent: +50, Adventures: +7, Crimbot Outfit Power: +1, Single Equip, Last Available: "2014-12", Conditional Skill (Equipped): "LUBE"
+8012	green Oprah's smooth Crimbomega drive chain of the early riser	0		Moxie: +15, Maximum MP Percent: +50, Adventures: +7, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
 8013	Crimbot ROM: Rapid Prototyping (dirty)	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8014	fuchsia Crimbot ROM: Mathematical Precision (dirty)	0		Skill: "Mathematical Precision", Last Available: "2014-12"
 8015	Crimbot ROM: Ruthless Efficiency (dirty)	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
@@ -7916,7 +7916,7 @@
 8034	asbestos-lined tope&eacute; of the detective	0		Hot Resistance: +5, Item Drop: +20, Familiar Effect: "3xBarrr, cap 12"
 8035	topiary tights of wisdom of Leguizamo	0		Mysticality: +15, Monster Level: +20
 8036	topiary necktie of mayonnaise	0		Sleaze Spell Damage: +50
-8037	flavorless thick bowl of topioca	5	decent	
+8037	thick flavorless bowl of topioca	5	decent	
 8038	topiary skunk	0		
 8039	topiary noseplugs	0		Familiar Weight: +5
 8040	jittery trusty whip	0		
@@ -7996,7 +7996,7 @@
 8121	olive mansplainer's Tesla garland	0		Monster Level: +15, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2018-12"
 8122	lime green skewed Usain Bolt's chilly gunnysack	0		Cold Damage: +5, Initiative: +80, Last Available: "2018-12"
 8123	fuchsia thinker's garibaldi of the dark arts	0		Mysticality: +10, Spell Damage Percent: +100, Last Available: "2018-12"
-8124	rosewater-soaked padded girdle	0		Damage Absorption: +20, Stench Resistance: +3, Single Equip, Last Available: "2018-12", Conditional Skill (Equipped): "Unleash Disco Pudge"
+8124	rosewater-soaked padded girdle	0		Damage Absorption: +20, Stench Resistance: +3, Single Equip, Conditional Skill (Equipped): "Unleash Disco Pudge", Last Available: "2018-12"
 8125	frightening chilly gloves	0		Cold Damage: +5, Spooky Damage: +5, Single Equip, Last Available: "2018-12"
 8126	powdered gray smithereens	1		Last Available: "2018-12"
 8127	spinning aromatic fiberglass fetish of incineration	0		Hot Spell Damage: +50, Stench Resistance: +1, Last Available: "2018-12"
@@ -8023,7 +8023,7 @@
 8149	energized gray Glo-Pop	0		Effect: "Aloofah", Effect Duration: 47
 8150	galvanized sugar sphere	0		Effect: "New and Improved", Effect Duration: 46
 8151	chilled Shrubble Bubble	0		Effect: "Amorous", Effect Duration: 12
-8152	irradiated wobbly yellow spinning polyeaster egg	0		Effect: "A Taste of Rainbow", Effect Duration: 11
+8152	irradiated spinning wobbly yellow polyeaster egg	0		Effect: "A Taste of Rainbow", Effect Duration: 11
 8153	polymerized shaking spinning candy dish	0		Effect: "Slightly Larger Than Usual", Effect Duration: 34
 8154	Vulcanized squat Spechunky bar	0		Effect: "Wintry Breath", Effect Duration: 35
 8155	electrified gray talisman of Horus	0		Effect: "Stench Jellied", Effect Duration: 50
@@ -8042,12 +8042,12 @@
 8168	glob of icing	0		
 8169	alkaline corrupted jittery red ginger snaps	0		Effect: "Jelly Combed", Effect Duration: 50
 8170	ionized mostly-broken sunglasses	0		Effect: "Human-Elemental Hybrid", Effect Duration: 13
-8171	delicious irresponsibly strong special unflavored wine cooler	7	awesome	Effect: "Gummiskin", Effect Duration: 20
+8171	delicious special irresponsibly strong unflavored wine cooler	7	awesome	Effect: "Gummiskin", Effect Duration: 20
 8172	mirror carton of snake milk	1	crappy	
 8173	yellow sage sewer snake	0		Mysticality Percent: +10
 8174	adequate pigeon egg	4	good	
 8175	blue mansplainer's jaunty feather of the storm	0		Maximum MP Percent: +40, Monster Level: +15
-8176	drinkable watered-down pulsating premium malt liquor	2	good	
+8176	watered-down drinkable pulsating premium malt liquor	2	good	
 8177	narrow banded Fonzie's brown paper pants	0		Experience (Moxie): +1, Damage Absorption: +100
 8178	brown paper bag mask of Calamity Jane of the businessman	0		Critical Hit Percent: +15, Meat Drop: +50
 8179	squat ring of telling skeletons what to do of chilblains	0		Cold Damage: +25, Conditional Skill (Equipped): "Tell a Skeleton What To Do", Conditional Skill (Equipped): "Tell This Skeleton What To Do"
@@ -8059,20 +8059,20 @@
 8185	gray pulsating lightning-fast wicked The Crown of Ed the Undying	0		Spell Damage: +5, Initiative: +40, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	blurry blurry map to a hidden booze cache	0		
-8188	fortified smooth wobbly upside-down Cherrytastrophe wine cooler	5	awesome	
+8188	smooth fortified upside-down wobbly Cherrytastrophe wine cooler	5	awesome	
 8189	bad Radberry Rip wine cooler	3	decent	
-8190	delicious irresponsibly strong ghostly Orangemageddon wine cooler	10	awesome	
+8190	irresponsibly strong delicious ghostly Orangemageddon wine cooler	10	awesome	
 8191	bad Breakfast Blast wine cooler	4	decent	
-8192	lousy irresponsibly strong bouncing Citrus Crush wine cooler	8	decent	
+8192	irresponsibly strong lousy bouncing Citrus Crush wine cooler	8	decent	
 8193	adequate snack-sized plain bagel	2	good	
 8194	thick bland huge glob of cream cheese	5	decent	
-8195	enchanted decent low-calorie loaf of soda bread	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
-8196	snack-sized spoiled acceptable bagel	2	crappy	
+8195	enchanted low-calorie decent loaf of soda bread	1	good	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 5
+8196	spoiled snack-sized acceptable bagel	2	crappy	
 8197	bland standard-issue cupcake	3	decent	
 8198	stale ultra-deluxe cupcake	3	decent	
-8199	purple blinking hypnotic breadcrumbs	0		
-8200	bland jumbo popular tart	5	decent	
-8201	upside-down wobbly no-handed pie	0		
+8199	blinking purple hypnotic breadcrumbs	0		
+8200	jumbo bland popular tart	5	decent	
+8201	wobbly upside-down no-handed pie	0		
 8202	polymerized huge Doc Galaktik's Vitality Serum	0		Effect: "Muscle Unbound", Effect Duration: 52
 8203	pulsating airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
 8204	green one-day ticket to Dinseylandfill	0		Last Available: "2015-04"
@@ -8086,16 +8086,16 @@
 8212	upside-down grogpagne	0		Last Available: "2021-07"
 8213	tumbling rock-hard Fonzie's rigging rope	0		Experience (Moxie): +1, Damage Reduction: 5, Last Available: "2015-04"
 8214	dried blurry nasty snuff	1	crappy	Last Available: "2015-04"
-8215	olive wobbly wool Samson's sewage-clogged pistol	0		Experience (Muscle): +5, Cold Resistance: +1, Last Available: "2015-04", Conditional Skill (Equipped): "Fire Sewage Pistol"
+8215	olive wobbly wool Samson's sewage-clogged pistol	0		Experience (Muscle): +5, Cold Resistance: +1, Conditional Skill (Equipped): "Fire Sewage Pistol", Last Available: "2015-04"
 8216	dry adjusted green beard incense	0		Effect: "Celestial Body", Effect Duration: 66, Last Available: "2015-04"
 8217	upside-down blurry stanky perfume-soaked bandana of the cheetah	0		Stench Spell Damage: +25, Initiative: +60, Single Equip, Last Available: "2015-04"
 8218	spinning toxic globule	0		Last Available: "2015-04"
 8219	yummy toxo	3	awesome	Last Available: "2015-04"
-8220	drinkable jittery shaking Lemonade-235	3	good	Last Available: "2015-04"
+8220	drinkable shaking jittery Lemonade-235	3	good	Last Available: "2015-04"
 8221	careful hale isotophat	0		Maximum HP: +20, Monster Level: -10, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	avaricious Three Mile Island shorts of the blizzard	0		Cold Spell Damage: +25, Meat Drop: +30, Last Available: "2015-04"
 8223	spinning zippy toxic mop of the blizzard	0		Cold Spell Damage: +25, Initiative: +20, Last Available: "2015-04"
-8224	skewed blurry inert sludgepuppy	0		Last Available: "2015-04"
+8224	blurry skewed inert sludgepuppy	0		Last Available: "2015-04"
 8225	lead collar	0		Familiar Weight: +5, Last Available: "2015-04"
 8226	jar of swamp honey	0		Last Available: "2015-04"
 8227	huge extremely unsafe dangerous beefcake's backwoods banjo	0		Muscle: +25, Weapon Damage: +10, Weapon Damage Percent: +100, Last Available: "2015-04"
@@ -8143,13 +8143,13 @@
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
 8270	decent immense unappetizing mayolus	9	good	Last Available: "2015-05"
 8271	flavorless uninteresting mayolus	4	decent	Last Available: "2015-05"
-8272	spoiled huge acceptable mayolus	7	crappy	Last Available: "2015-05"
+8272	huge spoiled acceptable mayolus	7	crappy	Last Available: "2015-05"
 8273	moldy gigantic enticing mayolus	9	crappy	Last Available: "2015-05"
 8274	rotten mouth-watering mayolus	3	crappy	Last Available: "2015-05"
 8275	newly-hatched mayonnaise wasp	0		Last Available: "2015-05"
 8276	mayo pump	0		Familiar Weight: +5
 8277	squat Essence of Bear	0		Skill: "Bear Essence"
-8278	acceptable fancy watered-down cyan Afternoon Delight	2	good	Effect: "20-20 Second Sight", Effect Duration: 40, Last Available: "2015-04"
+8278	watered-down fancy acceptable cyan Afternoon Delight	2	good	Effect: "20-20 Second Sight", Effect Duration: 40, Last Available: "2015-04"
 8279	gray Kokomo Resort Chip	0		Last Available: "2015-04"
 8280	Golden Kokomo Resort Chip	0		Last Available: "2015-04"
 8281	electrified jittery Kokomo Resort Brand Suntan Oil	0		Effect: "Sharp Weapon", Effect Duration: 18, Last Available: "2015-04"
@@ -8159,7 +8159,7 @@
 8285	blinking Mayo Minder&trade;	0		Last Available: "2015-05"
 8286	warmed deionized Mayo de Mayo&trade; mayo	0		Effect: "Fudgehound", Effect Duration: 13
 8287	ghostly puck	0		Free Pull, Last Available: "2015-06"
-8288	gray blinking kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
+8288	blinking gray kill screen	0		Random Monster Modifiers: +1, Last Available: "2015-06"
 8289	boxing gloves	0		Last Available: "2015-06"
 8290	bouncing careful dice ring	0		Monster Level: -10, Single Equip
 8291	bouncing resourceful dice belt buckle	0		Maximum MP: +50, Single Equip
@@ -8176,7 +8176,7 @@
 8302	yummy pixel banana	3	awesome	Last Available: "2015-06"
 8303	distilled delicious bouncing pixel beer	5	awesome	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
-8305	blinking cyan pumps	0		Last Available: "2015-06"
+8305	cyan blinking pumps	0		Last Available: "2015-06"
 8306	cold-filtered blue sludgesicle	0		Effect: "Bells in the Batfry", Effect Duration: 44
 8307	double-electrified activated &Uuml;berraschthexengebr&auml;u	0		Effect: "Appeteyes", Effect Duration: 38
 8308	dry piggy tattoo	0		Effect: "Pride of the Vampire", Effect Duration: 17
@@ -8218,7 +8218,7 @@
 8344	energized warmed bronze polish	0		Effect: "Fit To Be Tide", Effect Duration: 67
 8345	Vulcanized skewed crident	0		Effect: "Bugbear in Tooth and Claw", Effect Duration: 19
 8346	galvanized double-enhanced purple totally sweet mohawk helmet	0		Effect: "Tea-hee", Effect Duration: 48
-8347	activated corrupted tumbling blue spray chrome	0		Effect: "Mariachi Mood", Effect Duration: 22
+8347	activated corrupted blue tumbling spray chrome	0		Effect: "Mariachi Mood", Effect Duration: 22
 8348	vacuum-sealed altered pressed skewed gray filthy monkey head	0		Effect: "Serenity", Effect Duration: 35
 8349	super-alkaline hand of cards	0		Effect: "Electrolit Up", Effect Duration: 45
 8350	nitrogenated green damp bar rag	0		Effect: "Boschface", Effect Duration: 65
@@ -8227,14 +8227,14 @@
 8353	pressed moist shaking grimy lab coat	0		Effect: "Alpine Mintiness", Effect Duration: 45
 8354	altered nursery rhyme	0		Effect: "Dweeby", Effect Duration: 25
 8355	tarnished squat iron torso box	0		Effect: "Danish Cunning", Effect Duration: 32
-8356	concentrated liquefied narrow lime green mercenary headband	0		Effect: "It Didn't Kill You", Effect Duration: 39
+8356	concentrated liquefied lime green narrow mercenary headband	0		Effect: "It Didn't Kill You", Effect Duration: 39
 8357	liquefied twirling radioactive spider venom	0		Effect: "Fit To Be Tide", Effect Duration: 25
 8358	unsweetened concentrated x-ray mirror	0		Effect: "Pecan Pied Piper", Effect Duration: 58
 8359	warmed polymerized wrestling mask	0		Effect: "Polka Face", Effect Duration: 61
 8360	deionized pickled hawkface potion	0		Effect: "Oiled Skin", Effect Duration: 26
 8361	magnetized aerosolized twirling child-sized dracula cloak	0		Effect: "Tingly Elbows", Effect Duration: 51
-8362	pressed adjusted squat mirror devil-summoning hat	0		Effect: "Amplified Fabulousness", Effect Duration: 60
-8363	quadruple-deionized vacuum-sealed double-ionized mirror fuchsia bouncing shopkeeper beard	0		Effect: "Slime Time", Effect Duration: 62
+8362	pressed adjusted mirror squat devil-summoning hat	0		Effect: "Amplified Fabulousness", Effect Duration: 60
+8363	quadruple-deionized vacuum-sealed double-ionized mirror bouncing fuchsia shopkeeper beard	0		Effect: "Slime Time", Effect Duration: 62
 8364	electrified upside-down shaking alien autoautopsy kit	0		Effect: "Morbidi Tea", Effect Duration: 28
 8365	magnetized unsweetened pulsating novelty fruit hat	0		Effect: "Carrrsmic", Effect Duration: 43
 8366	flattened deionized invisibility cream	0		Effect: "[1609]Dancin' Fool", Effect Duration: 13
@@ -8244,12 +8244,12 @@
 8370	ionized corrupted funky eyepatch	0		Effect: "Dances with Tweedles", Effect Duration: 21
 8371	activated boiled bucket of fish juice	0		Effect: "Taurus Rising", Effect Duration: 26
 8372	adjusted tumbling flashy pirate dreadlocks	0		Effect: "Banono", Effect Duration: 28
-8373	concentrated purple shaking captured boozles	0		Effect: "Thanksgot", Effect Duration: 67
+8373	concentrated shaking purple captured boozles	0		Effect: "Thanksgot", Effect Duration: 67
 8374	non-boiled squat twirling drinks tray	0		Effect: "Pisces Rising", Effect Duration: 22
 8375	liquefied pressed tumbling eyebrow lifter	0		Effect: "[800]Chocolate Reign", Effect Duration: 27
 8376	submarine	0		Last Available: "2015-06"
 8377	immense stale spinning pixel lemon	10	decent	Last Available: "2015-06"
-8378	distilled acceptable pixel daiquiri	5	good	Last Available: "2015-06"
+8378	acceptable distilled pixel daiquiri	5	good	Last Available: "2015-06"
 8379	liquefied enhanced liquefied power pill	0		Effect: "Venomous Weapon", Effect Duration: 17, Last Available: "2015-06"
 8380	frozen squat pixel potion	0		Effect: "In the Slimelight", Effect Duration: 68, Last Available: "2015-06"
 8381	wobbly Pack of Every Card	0		Free Pull, Last Available: "2015-07"
@@ -8278,7 +8278,7 @@
 8404	jittery 1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	savory dry noodles	0		
-8407	enchanted moldy pestopiary	4	crappy	Effect: "Libra Rising", Effect Duration: 30
+8407	moldy enchanted pestopiary	4	crappy	Effect: "Libra Rising", Effect Duration: 30
 8408	wet ectoplasmic orbs	0		Effect: "Salamanderenity", Effect Duration: 46
 8409	normal fuchsia crudles	3	good	
 8410	adequate twirling blurry agnolotti arboli	3	good	
@@ -8288,7 +8288,7 @@
 8414	small moldy fusilli marrownarrow	2	crappy	
 8415	rotten suggestive strozzapreti	4	crappy	
 8416	ghostly ghostly Mountain Stream gastrique	0		
-8417	moldy jumbo Mt. McLargeHuge oyster	5	crappy	
+8417	jumbo moldy Mt. McLargeHuge oyster	5	crappy	
 8418	oyster sauce	0		
 8419	toothsome linguini immondizia bianco	3	awesome	
 8420	flavorless shells a la shellfish	3	decent	
@@ -8319,14 +8319,14 @@
 8445	huge lava globs	0		Last Available: "2015-08"
 8446	SMOOCH bottlecap	0		Last Available: "2020-09"
 8447	uncapped lava bottle	0		Last Available: "2015-08"
-8448	ghostly cyan twirling uncapped lava bottle	0		Last Available: "2015-08"
+8448	ghostly twirling cyan uncapped lava bottle	0		Last Available: "2015-08"
 8449	uncapped lava bottle	0		Last Available: "2015-08"
 8450	capped lava bottle	0		Last Available: "2015-08"
 8451	mirror capped lava bottle	0		Last Available: "2015-08"
 8452	capped lava bottle	0		Last Available: "2015-08"
-8453	tumbling huge jittery heat-resistant sheet	0		Last Available: "2015-08"
+8453	jittery tumbling huge heat-resistant sheet	0		Last Available: "2015-08"
 8454	LavaCo&trade; Lamp housing	0		Last Available: "2015-08"
-8455	cyan pulsating New Age crystal	0		Last Available: "2015-08"
+8455	pulsating cyan New Age crystal	0		Last Available: "2015-08"
 8456	crystalline light bulb	0		Last Available: "2015-08"
 8457	blue broken high-temperature mining drill	0		Last Available: "2015-08"
 8458	high-temperature mining mask of the ox of Calamity Jane	0		Muscle: +20, Critical Hit Percent: +15, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
@@ -8341,7 +8341,7 @@
 8467	lion tamer's rosy-cheeked lava balaclava of terror	0		Maximum HP Percent: +30, Experience (familiar): +2, Spooky Spell Damage: +10, Last Available: "2015-08"
 8468	manspreader's basaltamander buckler of the pedagogue of Calamity Jane	0		Experience: +3, Critical Hit Percent: +15, Monster Level: +10, Damage Reduction: 15, Last Available: "2015-08"
 8469	wet blue lava globs	0		Effect: "Sepia Tan", Effect Duration: 30, Last Available: "2015-08"
-8470	spoiled special gooey lava globs	4	crappy	Effect: "Disco Neuropathy", Effect Duration: 5, Last Available: "2015-08"
+8470	special spoiled gooey lava globs	4	crappy	Effect: "Disco Neuropathy", Effect Duration: 5, Last Available: "2015-08"
 8471	bouncing supercool lava-proof pants of dire peril	0		Moxie Percent: +20, Weapon Damage: +20, Last Available: "2015-08"
 8472	knitted foul-smelling heat-resistant necktie	0		Stench Damage: +10, Cold Resistance: +3, Single Equip, Last Available: "2015-08"
 8473	avaricious resourceful Newton's heat-resistant gloves	0		Experience (Mysticality): +3, Maximum MP: +50, Meat Drop: +30, Single Equip, Last Available: "2015-08"
@@ -8396,11 +8396,11 @@
 8522	spinning superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
 8524	superheated	0		Last Available: "2015-08"
-8525	thick decent skewed lava cake	5	good	Last Available: "2015-08"
+8525	decent thick skewed lava cake	5	good	Last Available: "2015-08"
 8526	tasty pink slime	3	awesome	
 8527	Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	fancy delicious blurry devil hair pasta	3	awesome	Effect: "Coming Up Roses", Effect Duration: 15
+8529	delicious fancy blurry devil hair pasta	3	awesome	Effect: "Coming Up Roses", Effect Duration: 15
 8530	adequate spagecialetti	3	good	
 8531	ghostly Salsa Libre	0		
 8532	good gravy	0		
@@ -8420,8 +8420,8 @@
 8547	magnetized ionized pocket maze	0		Effect: "Liquidy Smoky", Effect Duration: 56
 8548	super-altered altered modified shady shades	0		Effect: "Cockroach Scurry", Effect Duration: 27
 8549	Vulcanized squeaky toy rose	0		Effect: "Flamingly Floral", Effect Duration: 52
-8550	massive bland bouncing weird gazelle steak	7	decent	
-8551	spoiled miniature sausage without a cause	2	crappy	
+8550	bland massive bouncing weird gazelle steak	7	decent	
+8551	miniature spoiled sausage without a cause	2	crappy	
 8552	anodized dry face paint	0		Effect: "Expert Vacationer", Effect Duration: 18
 8553	drinkable emergency margarita	3	good	
 8554	watered-down bad vintage smart drink	2	decent	
@@ -8438,7 +8438,7 @@
 8565	frightening Annie Oakley's supercharged barrel lid	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Spooky Damage: +5, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	twirling lard-coated medical-grade arcane researcher's barrel hoop earring	0		Experience Percent (Mysticality): +10, Sleaze Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2015-09"
 8567	bouncing avaricious beefcake's bankruptcy barrel of Flo-Jo	0		Muscle: +25, Meat Drop: +30, Initiative: +100, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
-8568	shaking huge firkin	0		Last Available: "2015-09"
+8568	huge shaking firkin	0		Last Available: "2015-09"
 8569	huge normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
 8571	blurry weathered barrel	0		Last Available: "2015-09"
@@ -8447,7 +8447,7 @@
 8574	maroon moist barrel	0		Last Available: "2015-09"
 8575	rotting barrel	0		Last Available: "2015-09"
 8576	mouldering barrel	0		Last Available: "2015-09"
-8577	skewed skewed maroon barnacled barrel	0		Last Available: "2015-09"
+8577	skewed maroon skewed barnacled barrel	0		Last Available: "2015-09"
 8578	artisanal bottle of Amontillado	4	EPIC	Last Available: "2015-09"
 8579	tolerable watered-down barrel-aged martini	2	good	Last Available: "2015-09"
 8580	delicious barrel pickle	4	awesome	Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	twirling greedy barrel gun	0		Meat Drop: +20, Last Available: "2015-09"
 8587	barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	small stale enchanted squat water log	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45, Last Available: "2015-09"
+8589	stale enchanted small squat water log	2	decent	Effect: "Hagnk's Gratitude", Effect Duration: 45, Last Available: "2015-09"
 8590	Van der Graaf Herculean barrelhead	0		Experience (Muscle): +1, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-09"
 8591	MacGyver's grievous bottoms of the barrel	0		Weapon Damage Percent: +50, Maximum MP: +100, Last Available: "2015-09"
 8592	avaricious Socratic chest barrel	0		Experience (Mysticality): +1, Meat Drop: +30, Last Available: "2015-09"
@@ -8473,13 +8473,13 @@
 8600	bouncing potted tea tree	0		Last Available: "2015-09"
 8601	unsweetened cuppa Flamibili tea	0		Effect: "Seal Clubbing Frenzy", Effect Duration: 22, Last Available: "2015-09"
 8602	energized cuppa Yet tea	0		Effect: "Hot Hands", Effect Duration: 54, Last Available: "2015-09"
-8603	warmed jittery maroon cuppa Boo tea	0		Effect: "Wet Rub", Effect Duration: 29, Last Available: "2015-09"
+8603	warmed maroon jittery cuppa Boo tea	0		Effect: "Wet Rub", Effect Duration: 29, Last Available: "2015-09"
 8604	activated red cuppa Nas tea	0		Effect: "The Magic of Sharing", Effect Duration: 24, Last Available: "2015-09"
 8605	pressed non-Vulcanized mirror cuppa Improprie tea	0		Effect: "PERL of Great Price", Effect Duration: 13, Last Available: "2015-09"
-8606	tarnished oxidized squat gray cuppa Frost tea	0		Effect: "Liquidy Smoky", Effect Duration: 40, Last Available: "2015-09"
+8606	tarnished oxidized gray squat cuppa Frost tea	0		Effect: "Liquidy Smoky", Effect Duration: 40, Last Available: "2015-09"
 8607	polarized cuppa Toast tea	0		Effect: "Pockets of Fire", Effect Duration: 13, Last Available: "2015-09"
-8608	flattened liquefied narrow huge cuppa Net tea	0		Effect: "Liquidy Smoky", Effect Duration: 41, Last Available: "2015-09"
-8609	denatured wobbly red cuppa Proprie tea	0		Effect: "Spooky Demeanor", Effect Duration: 54, Last Available: "2015-09"
+8608	flattened liquefied huge narrow cuppa Net tea	0		Effect: "Liquidy Smoky", Effect Duration: 41, Last Available: "2015-09"
+8609	denatured red wobbly cuppa Proprie tea	0		Effect: "Spooky Demeanor", Effect Duration: 54, Last Available: "2015-09"
 8610	warmed extra-colloidal huge cuppa Morbidi tea	0		Effect: "One For Tea", Effect Duration: 18, Last Available: "2015-09"
 8611	chilled nitrogenated cuppa Chari tea	0		Effect: "Coming Up Roses", Effect Duration: 39, Last Available: "2015-09"
 8612	pickled quantum cuppa Serendipi tea	0		Effect: "Rain Dancin'", Effect Duration: 11, Last Available: "2015-09"
@@ -8492,8 +8492,8 @@
 8619	non-deionized concentrated cuppa Impregnabili tea	0		Effect: "Space Tripping", Effect Duration: 51, Last Available: "2015-09"
 8620	galvanized concentrated cuppa Obscuri tea	0		Effect: "Venomous Weapon", Effect Duration: 67, Last Available: "2015-09"
 8621	anodized cuppa Irritabili tea	0		Effect: "Scorpio Rising", Effect Duration: 48, Last Available: "2015-09"
-8622	anodized magnetized pulsating red cuppa Mediocri tea	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 64, Last Available: "2015-09"
-8623	altered shaking bouncing cuppa Loyal tea	0		Effect: "Sinuses For Miles", Effect Duration: 11, Last Available: "2015-09"
+8622	anodized magnetized red pulsating cuppa Mediocri tea	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 64, Last Available: "2015-09"
+8623	altered bouncing shaking cuppa Loyal tea	0		Effect: "Sinuses For Miles", Effect Duration: 11, Last Available: "2015-09"
 8624	modified cuppa Activi tea	1	EPIC	Effect: "Whitened Teeth", Effect Duration: 30, Last Available: "2015-09"
 8625	twisted huge bouncing cuppa Cruel tea	1		Effect: "X-Ray Vision", Effect Duration: 35, Last Available: "2015-09"
 8626	wet cuppa Alacri tea	0		Effect: "Super-Electrified", Effect Duration: 62, Last Available: "2015-09"
@@ -8512,11 +8512,11 @@
 8639	doghouse	0		Free Pull, Last Available: "2015-10"
 8640	purple Ghost Dog Chow	0		Last Available: "2015-10"
 8641	decent huge bowl of eyeballs	3	good	Last Available: "2015-10"
-8642	gigantic yummy bowl of mummy guts	8	awesome	Last Available: "2015-10"
+8642	yummy gigantic bowl of mummy guts	8	awesome	Last Available: "2015-10"
 8643	bite-sized moldy ghostly bowl of maggots	1	crappy	Last Available: "2015-10"
 8644	mediocre fuchsia blood and blood	3	decent	Last Available: "2015-10"
-8645	artisanal irresponsibly strong huge Jack-O-Lantern beer	9	EPIC	Last Available: "2015-10"
-8646	practically non-alcoholic mediocre zombie	1	decent	Last Available: "2015-10"
+8645	irresponsibly strong artisanal huge Jack-O-Lantern beer	9	EPIC	Last Available: "2015-10"
+8646	mediocre practically non-alcoholic zombie	1	decent	Last Available: "2015-10"
 8647	Telltale&trade; rubber heart	0		Last Available: "2015-10"
 8648	wind-up spider	0		Last Available: "2015-10"
 8649	shaking plastic nightmare troll	0		Last Available: "2015-10"
@@ -8533,7 +8533,7 @@
 8660	shaking grip key	0		
 8661	How to Play Othello	0		
 8662	inspector's therapeutic baleful ghostly dagger	0		Spell Damage: +25, Item Drop: +15, HP Regen Min: 5, HP Regen Max: 7
-8663	enchanted lousy watered-down ghost beer	2	decent	Effect: "Can't Smell Nothin'", Effect Duration: 30
+8663	enchanted watered-down lousy ghost beer	2	decent	Effect: "Can't Smell Nothin'", Effect Duration: 30
 8664	twirling Othello set of dire peril	0		Weapon Damage: +20
 8665	mirror rotten tomato	0		
 8666	Twelve Night Energy	0		
@@ -8566,20 +8566,20 @@
 8693	red hotel minibar key	0		Last Available: "2015-11"
 8694	shaking ice hotel bell	0		Last Available: "2015-11"
 8695	Martialest Arts trophy	0		Last Available: "2016-01"
-8696	pickled mirror purple bouncing medicinal herbs	1		Last Available: "2016-01"
+8696	pickled purple bouncing mirror medicinal herbs	1		Last Available: "2016-01"
 8697	moldy enchanted ice rice	4	crappy	Effect: "Night of the Nachos", Effect Duration: 35, Last Available: "2016-01"
 8698	acceptable iced plum wine	4	good	Last Available: "2016-01"
 8699	Usain Bolt's energetic Herculean training belt	0		Experience (Muscle): +1, Maximum MP Percent: +20, Initiative: +80, Single Equip, Last Available: "2016-01"
 8700	upside-down Rosewater's training legwarmers of the dark arts of mayonnaise	0		Mysticality Percent: +30, Spell Damage Percent: +100, Sleaze Spell Damage: +50, Single Equip, Last Available: "2016-01"
 8701	upside-down shaking blinking Annie Oakley's experienced training helmet of extreme caution	0		Experience: +2, Critical Hit Percent: +20, Monster Level: -25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
-8702	squat wobbly training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
+8702	wobbly squat training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
 8703	wobbly training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
 8705	X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	blurry blurry self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	altered skewed abstraction: action	1		Last Available: "2015-12"
-8709	powdered spinning red abstraction: thought	1		Last Available: "2015-12"
+8709	powdered red spinning abstraction: thought	1		Last Available: "2015-12"
 8710	denatured narrow abstraction: sensation	1		Last Available: "2015-12"
 8711	denatured abstraction: purpose	1		Effect: "A Few Extra Pounds", Effect Duration: 30, Last Available: "2015-12"
 8712	vaporized wobbly abstraction: category	1		Effect: "Bolts about Candy", Effect Duration: 50, Last Available: "2015-12"
@@ -8588,7 +8588,7 @@
 8715	dehydrated blinking abstraction: joy	1		Last Available: "2015-12"
 8716	mixed abstraction: certainty	1		Effect: "Rave Concentration", Effect Duration: 10, Last Available: "2015-12"
 8717	vaporized abstraction: comprehension	1		Last Available: "2015-12"
-8718	tumbling narrow squat modern picture frame	0		Last Available: "2015-12"
+8718	narrow squat tumbling modern picture frame	0		Last Available: "2015-12"
 8719	moldy massive olive VYKEA meatballs	7	crappy	Last Available: "2015-11"
 8720	drinkable VYKEA mead	3	good	Last Available: "2015-11"
 8721	modified adjusted VYKEA woadpaint	0		Effect: "Physicali Tea", Effect Duration: 28, Last Available: "2015-11"
@@ -8603,15 +8603,15 @@
 8730	jittery VYKEA instructions	0		Last Available: "2015-11"
 8731	normal fancy tin of submardines	4	good	Effect: "Fustulent", Effect Duration: 10, Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	artisanal teal bottle of norwhiskey	3	EPIC	Last Available: "2015-11"
-8733	modified shaking red skewed octolus oculus	1	good	Last Available: "2015-11"
+8733	modified red skewed shaking octolus oculus	1	good	Last Available: "2015-11"
 8734	shaking greasy careful sardine can key of Flo-Jo	0		Monster Level: -10, Sleaze Spell Damage: +10, Initiative: +100, Last Available: "2015-11"
 8735	dog trainer's experienced norwhal helmet of the ox	0		Muscle: +20, Experience: +2, Experience (familiar): +1, Last Available: "2015-11", Familiar Effect: "atk"
 8736	horrifying chilly octolus-skin cloak of the pedagogue	0		Experience: +3, Cold Damage: +5, Spooky Damage: +25, Last Available: "2015-11"
-8737	artisanal irresponsibly strong perfect cosmopolitan	10	EPIC	Last Available: "2015-11"
-8738	practically non-alcoholic acceptable special perfect negroni	1	good	Effect: "Bloodstain-Resistant", Effect Duration: 30, Last Available: "2015-11"
-8739	watered-down hand-crafted perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
-8740	enchanted weak drinkable perfect mimosa	2	good	Effect: "Old School Pompadour", Effect Duration: 5, Last Available: "2015-11"
-8741	weak acceptable perfect old-fashioned	2	good	Last Available: "2015-11"
+8737	irresponsibly strong artisanal perfect cosmopolitan	10	EPIC	Last Available: "2015-11"
+8738	special practically non-alcoholic acceptable perfect negroni	1	good	Effect: "Bloodstain-Resistant", Effect Duration: 30, Last Available: "2015-11"
+8739	hand-crafted watered-down perfect dark and stormy	2	super ultra EPIC	Last Available: "2015-11"
+8740	weak enchanted drinkable perfect mimosa	2	good	Effect: "Old School Pompadour", Effect Duration: 5, Last Available: "2015-11"
+8741	acceptable weak perfect old-fashioned	2	good	Last Available: "2015-11"
 8742	hand-crafted perfect paloma	4	EPIC	Last Available: "2015-11"
 8743	nitrogenated corrupted denatured huge That 70s Cologne	0		Effect: "Items Are Forever", Effect Duration: 44, Last Available: "2015-11"
 8744	dry boiled wobbly Wal-Mart &quot;diamond&quot; ring	0		Effect: "Surreally Buff", Effect Duration: 22, Last Available: "2015-11"
@@ -8623,15 +8623,15 @@
 8750	magnetized cold-filtered hemp candy necklace	0		Effect: "Dreadful Sheen", Effect Duration: 63, Last Available: "2015-12"
 8751	double-corrupted blue communal gobstopper	0		Effect: "The Smile of Mr. A.", Effect Duration: 37, Last Available: "2015-12"
 8752	spoiled low-calorie lime green Crimbo salad	1	crappy	Last Available: "2015-12"
-8753	small decent bread line	2	good	Last Available: "2015-12"
+8753	decent small bread line	2	good	Last Available: "2015-12"
 8754	bad bark rootbeer	4	decent	Last Available: "2015-12"
-8755	hand-crafted weak ale	2	EPIC	Last Available: "2015-12"
+8755	weak hand-crafted ale	2	EPIC	Last Available: "2015-12"
 8756	spinning plastic Tammy the Tambourine Elf of the businessman	0		Meat Drop: +50, Last Available: "2015-12"
 8757	mirror pulsating inspector's plastic Rudolph the Red	0		Item Drop: +15, Last Available: "2015-12"
 8758	cool plastic Gaia'ajh-dsli Ak'lwej	0		Moxie: +5, Last Available: "2015-12"
 8759	Tesla plastic Crimborgatron	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-12"
 8760	narrow avaricious plastic Crimbodhisattva	0		Meat Drop: +30, Last Available: "2015-12"
-8761	squat cyan bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
+8761	cyan squat bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
 8763	BACON	0		Last Available: "2016-05"
 8764	wobbly box of Gratitude chocolates	0		Last Available: "2016-02"
@@ -8654,7 +8654,7 @@
 8782	jittery twirling nasty reindeer hammer	0		Stench Damage: +5, Last Available: "2015-12"
 8783	Van der Graaf elf ploughshare	0		MP Regen Min: 5, MP Regen Max: 7, Last Available: "2015-12"
 8784	circle drum	0		Last Available: "2015-12"
-8785	upside-down The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
+8785	upside-down The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
 8786	gray faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8691,12 +8691,12 @@
 8819	fancy rotten The Plumber's mushroom stew	4	crappy	Effect: "Blessing of the Frozen Tortellini", Effect Duration: 45, Last Available: "2016-12"
 8820	dehydrated blurry The Author's ink	1		Last Available: "2016-02"
 8821	bad narrow The Mad Liquor	3	decent	Last Available: "2016-12"
-8822	boozy smooth Doc Clock's thyme cocktail	5	awesome	Last Available: "2016-12"
+8822	smooth boozy Doc Clock's thyme cocktail	5	awesome	Last Available: "2016-12"
 8823	flavorless Mr. Burnsger	3	decent	Last Available: "2016-12"
 8824	dehydrated narrow The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
-8825	shaking foul-smelling deadly supercool The Jokester's gun	0		Moxie Percent: +20, Weapon Damage: +5, Stench Damage: +10, Last Available: "2016-12", Conditional Skill (Equipped): "Fire the Jokester's Gun"
-8826	maroon Jeselnik's savvy stylish The Jokester's wig	0		Moxie: +25, Mysticality Percent: +20, Sleaze Damage: +25, Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol", Conditional Skill (Equipped): "Adjust the Jokester's Wig"
-8827	squat dance instructor's groovy The Jokester's pants of the cougar	0		Moxie: +20, Moxie Percent: +10, Experience Percent (Moxie): +10, Last Available: "2016-12", Conditional Skill (Equipped): "Adjust the Jokester's Pants"
+8825	shaking foul-smelling deadly supercool The Jokester's gun	0		Moxie Percent: +20, Weapon Damage: +5, Stench Damage: +10, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
+8826	maroon Jeselnik's savvy stylish The Jokester's wig	0		Moxie: +25, Mysticality Percent: +20, Sleaze Damage: +25, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
+8827	squat dance instructor's groovy The Jokester's pants of the cougar	0		Moxie: +20, Moxie Percent: +10, Experience Percent (Moxie): +10, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	frozen green Jokester makeup	0		Effect: "Human-Elf Hybrid", Effect Duration: 28, Last Available: "2016-12"
 8829	blinking jittery replica bat-oomerang	0		Last Available: "2016-12"
 8830	blinking battoo kit	0		Last Available: "2016-12"
@@ -8719,7 +8719,7 @@
 8847	alkaline wet double-colloidal red-hot jawbreaker	0		Effect: "Coldfinger", Effect Duration: 69
 8848	irradiated question juice	0		Effect: "Crimbo Flavor", Effect Duration: 14
 8849	altered narrow tube of villain	0		Effect: "Human-Undead Hybrid", Effect Duration: 50
-8850	your cowboy boots of the early riser	0		Adventures: +7, Last Available: "2016-02", Conditional Skill (Equipped): "Cowboy Kick"
+8850	your cowboy boots of the early riser	0		Adventures: +7, Conditional Skill (Equipped): "Cowboy Kick", Last Available: "2016-02"
 8851	inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	nugget of quicksilver	0		Last Available: "2016-02"
 8853	nugget of thicksilver	0		Last Available: "2016-02"
@@ -8746,12 +8746,12 @@
 8874	avaricious medical-grade Socratic brawny Val-U Brand Every Bean Salad of Calamity Jane	0		Muscle Percent: +20, Experience (Mysticality): +1, Critical Hit Percent: +15, Meat Drop: +30, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-02"
 8875	mansplainer's chaotic Shrub's Premium Baked Beans	0		Spell Critical Percent: +10, Monster Level: +15, Item Drop: +5, Last Available: "2016-02"
 8876	bite-sized flavorless blinking plate of Heimz Fortified Kidney Beans	1	decent	Last Available: "2016-02"
-8877	small adequate plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
+8877	adequate small plate of Tesla's Electroplated Beans	2	good	Last Available: "2016-02"
 8878	thick rotten plate of Mixed Garbanzos and Chickpeas	5	crappy	Last Available: "2016-02"
 8879	decent plate of Hellfire Spicy Beans	3	good	Last Available: "2016-02"
 8880	moldy plate of Frigid Northern Beans	4	crappy	Last Available: "2016-02"
 8881	spoiled blinking plate of World's Blackest-Eyed Peas	3	crappy	Last Available: "2016-02"
-8882	bland miniature tumbling plate of Trader Olaf's Exotic Stinkbeans	2	decent	Last Available: "2016-02"
+8882	miniature bland tumbling plate of Trader Olaf's Exotic Stinkbeans	2	decent	Last Available: "2016-02"
 8883	big rotten huge plate of Pork 'n' Pork 'n' Pork 'n' Beans	5	crappy	Last Available: "2016-02"
 8884	moldy plate of Val-U Brand Every Bean Salad	4	crappy	Last Available: "2016-02"
 8885	snack-sized normal ghostly plate of Shrub's Premium Baked Beans	2	good	Last Available: "2016-02"
@@ -8779,16 +8779,16 @@
 8907	ionized nitrogenated bouncing half-digested coal	0		Effect: "Creepin' Up on You", Effect Duration: 13, Last Available: "2016-02"
 8908	electrified tightly-wound spine	0		Effect: "Mitre Cut", Effect Duration: 43, Last Available: "2016-02"
 8909	adequate rotting beefsteak	4	good	Last Available: "2016-02"
-8910	practically non-alcoholic lousy ghostly firemilk	1	decent	Last Available: "2016-02"
+8910	lousy practically non-alcoholic ghostly firemilk	1	decent	Last Available: "2016-02"
 8911	polymerized extra-cold-filtered squat upside-down spidercow eye-cluster	0		Effect: "Jalape&ntilde;o Saucesphere", Effect Duration: 55, Last Available: "2016-02"
 8912	mixed moomy dust	1		Effect: "Executive Greed", Effect Duration: 50, Last Available: "2016-02"
 8913	Jack Frost's western-style skinning knife of bravery	0		Cold Spell Damage: +50, Spooky Resistance: +5, Last Available: "2016-02"
 8914	reliable sixgun	0		Last Available: "2016-02"
 8915	therapeutic steel knuckles	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-02"
-8916	gray tumbling Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
+8916	tumbling gray Tales of Western Braggadoccio	0		Skill: "Bow-Legged Swagger", Last Available: "2016-02"
 8917	squat Hell and How I Bent It	0		Skill: "Bend Hell", Last Available: "2016-02"
 8918	yellow The Western Look	0		Skill: "Steely-Eyed Squint", Last Available: "2016-02"
-8919	bouncing teal LT&T tattoo kit	0		Last Available: "2016-02"
+8919	teal bouncing LT&T tattoo kit	0		Last Available: "2016-02"
 8920	Western Slang Vol. 1: Violence	0		Free Pull, Last Available: "2016-02"
 8921	Western Slang Vol. 2: Cooking	0		Free Pull, Last Available: "2016-02"
 8922	Western Slang Vol. 3: Fraud	0		Free Pull, Last Available: "2016-02"
@@ -8807,7 +8807,7 @@
 8935	porquoise-handled sixgun	0		Last Available: "2016-02"
 8936	hamethyst-handled sixgun	0		Last Available: "2016-02"
 8937	tumbling mountain lion skin	0		Moxie Percent: +50, Last Available: "2016-02"
-8938	shaking bouncing grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
+8938	bouncing shaking grizzled bearskin	0		Muscle Percent: +50, Last Available: "2016-02"
 8939	diamondback skin	0		Last Available: "2016-02"
 8940	wobbly coal snakeskin	0		Last Available: "2016-02"
 8941	frontwinder skin	0		Mysticality Percent: +50, Last Available: "2016-02"
@@ -8848,7 +8848,7 @@
 8976	frozen blinking patent preventative tonic	0		Effect: "Florid Cheeks", Effect Duration: 44
 8977	moist narrow huge patent invisibility tonic	0		Effect: "Gamer Rage", Effect Duration: 56
 8978	extra-diffused vacuum-sealed teal patent aggression tonic	0		Effect: "Boon of She-Who-Was", Effect Duration: 60
-8979	corrupted purple upside-down narrow patent sallowness tonic	0		Effect: "Hardened Fabric", Effect Duration: 50
+8979	corrupted narrow purple upside-down patent sallowness tonic	0		Effect: "Hardened Fabric", Effect Duration: 50
 8980	boiled patent avarice tonic	0		Effect: "Spore-Wreathed", Effect Duration: 58
 8981	polymerized polarized tumbling patent alacrity tonic	0		Effect: "Livin' Large", Effect Duration: 33
 8982	wet corrupted marrow	0		Effect: "Demonic Flavor", Effect Duration: 38
@@ -8878,7 +8878,7 @@
 9006	spinning fireproof frightening tunac of the storm of the overflowing toilet	0		Maximum MP Percent: +40, Stench Spell Damage: +50, Spooky Damage: +5, Hot Resistance: +3, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	enhanced altered moist green wriggling worm	0		Effect: "Got Your Boots On", Effect Duration: 65, Last Available: "2016-04"
-9009	artisanal practically non-alcoholic purple bottle of Fishhead 900-Day IPA	1	super ultra mega turbo EPIC	Last Available: "2016-04"
+9009	practically non-alcoholic artisanal purple bottle of Fishhead 900-Day IPA	1	super ultra mega turbo EPIC	Last Available: "2016-04"
 9010	tarnished narrow high-test fishing line	0		Effect: "Deep-Seated Rage", Effect Duration: 49, Last Available: "2016-04"
 9011	spinning lard-coated fishin' hat	0		Sleaze Spell Damage: +25, Last Available: "2016-04"
 9012	skewed Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8888,9 +8888,9 @@
 9016	blue disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	viral video	0		Last Available: "2016-05"
 9018	internet point	0		Last Available: "2016-05"
-9019	blurry fuchsia jittery meme generator	0		Last Available: "2016-05"
+9019	fuchsia blurry jittery meme generator	0		Last Available: "2016-05"
 9020	upside-down plus one	0		Last Available: "2016-05"
-9021	half-sized moldy gallon of milk	2	crappy	Last Available: "2016-05"
+9021	moldy half-sized gallon of milk	2	crappy	Last Available: "2016-05"
 9022	blinking print screen button	0		Last Available: "2016-05"
 9023	screencapped monster	0		Last Available: "2016-05"
 9024	squat daily dungeon malware	0		Last Available: "2016-05"
@@ -8899,13 +8899,13 @@
 9027	asbestos-lined vibrating First Post shirt - Cir Senam of the brute	0		Muscle Percent: +30, Maximum MP Percent: +10, Hot Resistance: +5, Last Available: "2016-05"
 9028	high-speed upgrade	0		Familiar Weight: +5, Last Available: "2016-05"
 9029	no spoon	0		
-9030	super-sized moldy star salad	5	crappy	
+9030	moldy super-sized star salad	5	crappy	
 9031	fuchsia Thwaitgold moth statuette	0		
-9032	tasty tiny tumbling bowl of Tastee-Wheet&trade;	1	awesome	
+9032	tiny tasty tumbling bowl of Tastee-Wheet&trade;	1	awesome	
 9033	Source terminal	0		Free Pull, Last Available: "2016-06"
 9034	tumbling Source essence	0		Last Available: "2016-06"
-9035	special moldy super-sized browser cookie	5	crappy	Effect: "Stinky Weapon", Effect Duration: 35, Last Available: "2016-06"
-9036	smooth watered-down narrow hacked gibson	2	awesome	Last Available: "2016-06"
+9035	moldy super-sized special browser cookie	5	crappy	Effect: "Stinky Weapon", Effect Duration: 35, Last Available: "2016-06"
+9036	watered-down smooth narrow hacked gibson	2	awesome	Last Available: "2016-06"
 9037	curative Source shades	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2016-06"
 9038	software bug	0		Last Available: "2016-06"
 9039	mirror missing semicolon	0		Familiar Weight: +11
@@ -8947,11 +8947,11 @@
 9075	extra-pressed modified galvanized shoe gum	0		Effect: "Neutered Nostrils", Effect Duration: 55, Last Available: "2016-07"
 9076	mansplainer's therapeutic brainy noir fedora	0		Mysticality: +5, Monster Level: +15, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2016-07"
 9077	spinning Jim Carey's educational beefy trench coat	0		Muscle: +10, Experience: +1, Monster Level: +25, Last Available: "2016-07"
-9078	weak hand-crafted Falcon&trade; Maltese Liquor	2	EPIC	Last Available: "2016-07"
-9079	big decent upside-down hardboiled egg	5	good	Last Available: "2016-07"
+9078	hand-crafted weak Falcon&trade; Maltese Liquor	2	EPIC	Last Available: "2016-07"
+9079	decent big upside-down hardboiled egg	5	good	Last Available: "2016-07"
 9080	spinning detective tattoo	0		Last Available: "2016-07"
 9081	pulsating spinning DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
-9082	red rosewater-soaked smelly dog trainer's grievous supercool protonic accelerator pack of wisdom	0		Mysticality: +15, Moxie Percent: +20, Weapon Damage Percent: +50, Experience (familiar): +1, Stench Spell Damage: +10, Stench Resistance: +3, Last Available: "2016-08", Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost"
+9082	red rosewater-soaked smelly dog trainer's grievous supercool protonic accelerator pack of wisdom	0		Mysticality: +15, Moxie Percent: +20, Weapon Damage Percent: +50, Experience (familiar): +1, Stench Spell Damage: +10, Stench Resistance: +3, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
 9083	almost-dead walkie-talkie	0		Last Available: "2016-08"
 9084	weightlifter's Adventurer bobblehead	0		Muscle: +15, Last Available: "2016-11"
 9085	psychokinetic energy blob	0		Last Available: "2016-08"
@@ -8964,7 +8964,7 @@
 9092	olive Sherlock's smartaleck's Spookyraven signet of vim and vigor	0		Moxie Percent: +30, Maximum HP Percent: +50, Item Drop: +25, Single Equip, Last Available: "2016-08"
 9093	inspector's frightening tie-dyed fannypack	0		Spooky Damage: +5, Item Drop: +15, Single Equip, Last Available: "2016-08"
 9094	mansplainer's ruddy burnt snowpants	0		Maximum HP Percent: +40, Monster Level: +15, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
-9095	smelly standards and practices guide	0		Stench Spell Damage: +10, Last Available: "2016-08", Conditional Skill (Equipped): "Censorious Lecture"
+9095	smelly standards and practices guide	0		Stench Spell Damage: +10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	skewed resourceful Carpathian longsword of the scaredy-cat of chilblains	0		Maximum MP: +50, Monster Level: -15, Cold Damage: +25, Last Available: "2016-08"
 9097	twirling bouncing healthy savvy cool Liam's mail	0		Moxie: +5, Mysticality Percent: +20, Maximum HP Percent: +20, Last Available: "2016-08"
 9098	twirling Oprah's hardy weightlifter's Unfortunato's foolscap	0		Muscle: +15, Maximum HP: +50, Maximum MP Percent: +50, Last Available: "2016-08"
@@ -8988,7 +8988,7 @@
 9116	time residue	0		Last Available: "2016-09"
 9117	repaid diaper of horror	0		Spooky Spell Damage: +25
 9118	jittery yellow Riker's Search History	0		Last Available: "2016-09"
-9119	artisanal extra-dry Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
+9119	extra-dry artisanal Shot of Kardashian Gin	5	EPIC	Last Available: "2016-09"
 9120	mirror Usain Bolt's Unstable Pointy Ears	0		Initiative: +80, Lasts Until Rollover, Last Available: "2016-09"
 9121	shaking ghostly Memory Disk, Alpha	0		Last Available: "2016-09"
 9122	yellow Tea, Earl Grey, Hot	1	good	Last Available: "2016-09"
@@ -9003,7 +9003,7 @@
 9131	extremely confusing manual	0		
 9132	sinister weightlifter's pistol	0		Muscle: +15, Spell Damage: +10
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	decent diet pulsating leftover pasty	1	good	
+9134	diet decent pulsating leftover pasty	1	good	
 9135	practically non-alcoholic hand-crafted mirror very whiskey	1	super ultra mega turbo EPIC	
 9136	lime green li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
@@ -9025,12 +9025,12 @@
 9153	enchanted spoiled raw sweet potato	4	crappy	Effect: "Tea-hee", Effect Duration: 10, Last Available: "2016-11"
 9154	yummy raw beans	3	awesome	Last Available: "2016-11"
 9155	moldy raw stuffing	3	crappy	Last Available: "2016-11"
-9156	low-calorie normal twirling raw cranberry sauce	1	good	Last Available: "2016-11"
+9156	normal low-calorie twirling raw cranberry sauce	1	good	Last Available: "2016-11"
 9157	yummy miniature raw turkey	2	awesome	Last Available: "2016-11"
-9158	moldy fancy raw mincemeat	3	crappy	Effect: "Bestial Sympathy", Effect Duration: 25, Last Available: "2016-11"
+9158	fancy moldy raw mincemeat	3	crappy	Effect: "Bestial Sympathy", Effect Duration: 25, Last Available: "2016-11"
 9159	massive adequate ghostly raw potato	7	good	Last Available: "2016-11"
 9160	stale raw gravy	3	decent	Last Available: "2016-11"
-9161	big decent raw bread	5	good	Last Available: "2016-11"
+9161	decent big raw bread	5	good	Last Available: "2016-11"
 9162	Usain Bolt's mini-marshmallow dispenser of courage	0		Spooky Resistance: +3, Initiative: +80, Last Available: "2016-11"
 9163	gravedigger's resourceful energetic glass casserole dish	0		Maximum MP Percent: +20, Maximum MP: +50, Spooky Damage: +10, Last Available: "2016-11"
 9164	huge stuffing fluffer	0		Last Available: "2016-11"
@@ -9041,12 +9041,12 @@
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	toothsome sweet potatoes	3	awesome	Last Available: "2016-11"
-9172	immense spoiled bean casserole	10	crappy	Last Available: "2016-11"
+9172	spoiled immense bean casserole	10	crappy	Last Available: "2016-11"
 9173	normal baked stuffing	3	good	Last Available: "2016-11"
 9174	flavorless cranberry cylinder	3	decent	Last Available: "2016-11"
 9175	flavorless spinning narrow thanksgiving turkey	3	decent	Last Available: "2016-11"
 9176	delicious mince pie	4	awesome	Last Available: "2016-11"
-9177	fancy diet flavorless ghostly mashed potatoes	1	decent	Effect: "Okee-Dokee Go!", Effect Duration: 20, Last Available: "2016-11"
+9177	fancy flavorless diet ghostly mashed potatoes	1	decent	Effect: "Okee-Dokee Go!", Effect Duration: 20, Last Available: "2016-11"
 9178	decent warm gravy	4	good	Last Available: "2016-11"
 9179	yummy bread roll	4	awesome	Last Available: "2016-11"
 9180	rotten leftovers	3	crappy	Last Available: "2016-11"
@@ -9064,11 +9064,11 @@
 9192	lousy eldritch extract	3	decent	Last Available: "2016-11"
 9193	gravedigger's shellacked Official Council Aide Pin	0		Damage Reduction: 7, Spooky Damage: +10, Last Available: "2016-11"
 9194	mediocre spinning eldritch distillate	4	decent	Last Available: "2016-11"
-9195	dried skewed shaking eldritch essence	1		Last Available: "2016-11"
+9195	dried shaking skewed eldritch essence	1		Last Available: "2016-11"
 9196	pulsating knitted Science Notebook	0		Cold Resistance: +3
 9197	prompt eldritch hat of the ox of extreme caution	0		Muscle: +20, Monster Level: -25, Adventures: +3, Last Available: "2016-11"
 9198	rosewater-soaked eldritch pants of mayonnaise of bravery	0		Sleaze Spell Damage: +50, Spooky Resistance: +5, Stench Resistance: +3, Last Available: "2016-11"
-9199	watered-down aged eldritch elixir	2	awesome	Last Available: "2016-11"
+9199	aged watered-down eldritch elixir	2	awesome	Last Available: "2016-11"
 9200	studded weightlifter's Quartet of Flare Masters Jacket	0		Muscle: +15, Damage Absorption: +80, Last Available: "2016-11"
 9201	lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
@@ -9090,7 +9090,7 @@
 9218	blinking shaking sprinkle-begging cup	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9219	massive delicious animal part cracker	7	awesome	Last Available: "2016-12"
 9220	delicious gingerbread wine	4	awesome	Last Available: "2016-12"
-9221	thick decent bouncing gingerbread mug	5	good	Last Available: "2016-12"
+9221	decent thick bouncing gingerbread mug	5	good	Last Available: "2016-12"
 9222	rosy-cheeked gingerbread mask	0		Maximum HP Percent: +30, Last Available: "2016-12"
 9223	aromatic gingerservo of the empath	0		Familiar Weight: +5, Stench Resistance: +1, Item Drop: +5, Single Equip, Last Available: "2016-12"
 9224	wet cold-filtered twirling tainted icing	0		Effect: "Dances with Tweedles", Effect Duration: 56, Last Available: "2016-12"
@@ -9108,7 +9108,7 @@
 9236	crafty gingerbread gavel of the scaredy-cat	0		Maximum MP: +10, Monster Level: -15, Last Available: "2016-12"
 9237	gingerbread cigarette	0		Last Available: "2016-12"
 9238	jittery gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
-9239	watered-down drinkable narrow ginger beer	2	good	Last Available: "2016-12"
+9239	drinkable watered-down narrow ginger beer	2	good	Last Available: "2016-12"
 9240	spare chocolate parts	0		Last Available: "2016-12"
 9241	Vulcanized industrial frosting	0		Effect: "Ghost Finger", Effect Duration: 33, Last Available: "2016-12"
 9242	deionized altered fake cocktail	0		Effect: "Vanity Rage", Effect Duration: 64, Last Available: "2016-12"
@@ -9145,9 +9145,9 @@
 9273	skewed Third Eye of James Dean of bravery	0		Experience (Moxie): +3, Spooky Resistance: +5, Last Available: "2016-12"
 9274	dog trainer's Krampus Horn of the scaredy-cat	0		Monster Level: -15, Experience (familiar): +1, Single Equip, Last Available: "2016-12"
 9275	adequate hambrosier	3	good	Last Available: "2016-12"
-9276	lousy irresponsibly strong chakra-mental wine	6	decent	Last Available: "2016-12"
+9276	irresponsibly strong lousy chakra-mental wine	6	decent	Last Available: "2016-12"
 9277	wet unsweetened chakra malt	0		Effect: "Icy Demeanor", Effect Duration: 13, Last Available: "2016-12"
-9278	tasty small Black Angus blackburger	2	awesome	Last Available: "2016-12"
+9278	small tasty Black Angus blackburger	2	awesome	Last Available: "2016-12"
 9279	practically non-alcoholic aged mirror twirling brandy	1	awesome	Last Available: "2016-12"
 9280	cold-filtered potion of spiritual gunkifying	0		Effect: "Mana Tea", Effect Duration: 16, Last Available: "2016-12"
 9281	fuchsia narrow strapping bad vibroknife of courage	0		Muscle: +5, Spooky Resistance: +3, Last Available: "2016-12"
@@ -9168,7 +9168,7 @@
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	spoiled toast with hot jelly	3	crappy	Last Available: "2017-01"
 9298	moldy toast with jelly	3	crappy	Last Available: "2017-01"
-9299	toothsome half-sized toast with jelly	2	awesome	Last Available: "2017-01"
+9299	half-sized toothsome toast with jelly	2	awesome	Last Available: "2017-01"
 9300	enchanted rotten toast with sleaze jelly	4	crappy	Effect: "Human-Hobo Hybrid", Effect Duration: 35, Last Available: "2017-01"
 9301	snack-sized flavorless toast with stench jelly	2	decent	Last Available: "2017-01"
 9302	space jellybicycle	0		Familiar Weight: +5
@@ -9201,7 +9201,7 @@
 9329	triple-aerosolized eldritch alignment spray	0		Effect: "Witch Breaded", Effect Duration: 42, Last Available: "2017-02"
 9330	LOV Entrance Pass	0		Last Available: "2017-02"
 9331	Usain Bolt's horrifying eldritch hammer of the brazier	0		Hot Spell Damage: +25, Spooky Damage: +25, Initiative: +80, Last Available: "2017-01"
-9332	super-sized yummy wobbly eldritch mushroom	5	awesome	Last Available: "2017-03"
+9332	yummy super-sized wobbly eldritch mushroom	5	awesome	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	adequate eldritch mushroom pizza	3	good	Last Available: "2017-03"
 9335	ghostly eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9218,7 +9218,7 @@
 9346	Thwaitgold amoeba statuette	0		
 9347	pickled grasshopper	0		Last Available: "2017-03"
 9348	bottle of an&iacute;s	0		Last Available: "2017-03"
-9349	olive spinning bottle of novelty hot sauce	0		Last Available: "2017-03"
+9349	spinning olive bottle of novelty hot sauce	0		Last Available: "2017-03"
 9350	blurry elemental sugarcube	0		Last Available: "2017-03"
 9351	peppermint sprig	0		Last Available: "2017-03"
 9352	pulsating bottle of clam juice	0		Last Available: "2017-03"
@@ -9238,36 +9238,36 @@
 9366	practically non-alcoholic artisanal double entendre	1	EPIC	Last Available: "2017-03"
 9367	drinkable Phlegethon	3	good	Last Available: "2017-03"
 9368	aged Siberian sunrise	3	awesome	Last Available: "2017-03"
-9369	drinkable special practically non-alcoholic mentholated wine	1	good	Effect: "The Wisdom... of the Future", Effect Duration: 30, Last Available: "2017-03"
+9369	special practically non-alcoholic drinkable mentholated wine	1	good	Effect: "The Wisdom... of the Future", Effect Duration: 30, Last Available: "2017-03"
 9370	watered-down smooth twirling low tide martini	2	awesome	Last Available: "2017-03"
 9371	triple-distilled acceptable shroomtini	10	good	Last Available: "2017-03"
 9372	artisanal ghostly morning dew	4	EPIC	Last Available: "2017-03"
 9373	extra-dry tolerable whiskey squeeze	5	good	Last Available: "2017-03"
 9374	mediocre great fashioned	4	decent	Last Available: "2017-03"
 9375	practically non-alcoholic mediocre Gnomish sagngria	1	decent	Last Available: "2017-03"
-9376	perfectly mixed weak mirror vodka stinger	2	EPIC	Last Available: "2017-03"
+9376	weak perfectly mixed mirror vodka stinger	2	EPIC	Last Available: "2017-03"
 9377	mediocre spinning extremely slippery nipple	3	decent	Last Available: "2017-03"
 9378	hand-crafted piscatini	4	EPIC	Last Available: "2017-03"
-9379	tolerable watered-down Churchill	2	good	Last Available: "2017-03"
+9379	watered-down tolerable Churchill	2	good	Last Available: "2017-03"
 9380	bad soilzerac	3	decent	Last Available: "2017-03"
 9381	artisanal London frog	3	EPIC	Last Available: "2017-03"
 9382	high-proof smooth nothingtini	7	awesome	Last Available: "2017-03"
 9383	delicious pulsating eighth plague	3	awesome	Last Available: "2017-03"
 9384	bad squat single entendre	3	decent	Last Available: "2017-03"
-9385	practically non-alcoholic drinkable reverse Tantalus	1	good	Last Available: "2017-03"
+9385	drinkable practically non-alcoholic reverse Tantalus	1	good	Last Available: "2017-03"
 9386	bad elemental caipiroska	3	decent	Last Available: "2017-03"
 9387	artisanal Feliz Navidad	4	EPIC	Last Available: "2017-03"
 9388	perfectly mixed Bloody Nora	3	EPIC	Last Available: "2017-03"
-9389	aged watered-down moreltini	2	awesome	Last Available: "2017-03"
-9390	drinkable irresponsibly strong hell in a bucket	10	good	Last Available: "2017-03"
-9391	enchanted perfectly mixed weak Newark	2	EPIC	Effect: "Vinegavotte", Effect Duration: 15, Last Available: "2017-03"
+9389	watered-down aged moreltini	2	awesome	Last Available: "2017-03"
+9390	irresponsibly strong drinkable hell in a bucket	10	good	Last Available: "2017-03"
+9391	perfectly mixed enchanted weak Newark	2	EPIC	Effect: "Vinegavotte", Effect Duration: 15, Last Available: "2017-03"
 9392	smooth weak R'lyeh	2	awesome	Last Available: "2017-03"
 9393	hand-crafted skewed wobbly Gnollish sangria	3	EPIC	Last Available: "2017-03"
 9394	acceptable watered-down vodka barracuda	2	good	Last Available: "2017-03"
 9395	acceptable mirror Mysterious Island iced tea	4	good	Last Available: "2017-03"
 9396	drinkable fortified gray drive-by shooting	5	good	Last Available: "2017-03"
 9397	mediocre gunner's daughter	4	decent	Last Available: "2017-03"
-9398	delicious special dirt julep	3	awesome	Effect: "Alchemical, Brother", Effect Duration: 15, Last Available: "2017-03"
+9398	special delicious dirt julep	3	awesome	Effect: "Alchemical, Brother", Effect Duration: 15, Last Available: "2017-03"
 9399	drinkable triple-distilled Simepore slime	6	good	Last Available: "2017-03"
 9400	hand-crafted Phil Collins	4	EPIC	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9282,8 +9282,8 @@
 9410	bouncing Spacegate Research	0		Last Available: "2017-04"
 9411	wobbly blurry alien rock sample	0		Last Available: "2017-04"
 9412	squat alien gemstone	0		Last Available: "2017-04"
-9413	squat twirling geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
-9414	squat blinking botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9413	twirling squat geological sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
+9414	blinking squat botanical sample kit	0		Lasts Until Rollover, Last Available: "2017-04"
 9415	normal jittery edible alien plant bit	3	good	Last Available: "2017-04"
 9416	alien plant fibers	0		Last Available: "2017-04"
 9417	alien plant sample	0		Last Available: "2017-04"
@@ -9301,7 +9301,7 @@
 9429	spinning spinning alien animal milk	0		Last Available: "2017-04"
 9430	spant egg casing	0		Last Available: "2017-04"
 9431	murderbot data core	0		Last Available: "2017-04"
-9432	deionized squat green alien medicine	0		Effect: "Yes, Can Haz", Effect Duration: 59, Last Available: "2017-04"
+9432	deionized green squat alien medicine	0		Effect: "Yes, Can Haz", Effect Duration: 59, Last Available: "2017-04"
 9433	moldy diet alien salad	1	crappy	Last Available: "2017-04"
 9434	practically non-alcoholic drinkable alien booze	1	good	Last Available: "2017-04"
 9435	Sherlock's nippy experienced alien mask	0		Experience: +2, Cold Damage: +10, Item Drop: +25, Last Available: "2017-04"
@@ -9325,7 +9325,7 @@
 9453	gravedigger's weightlifter's murderbot mask of temperance	0		Muscle: +15, Spooky Damage: +10, Sleaze Resistance: +5, Avatar: "Murderbot", Last Available: "2017-04"
 9454	alkaline irradiated wobbly murderbot spring injector	0		Effect: "Saucemastery", Effect Duration: 39, Last Available: "2017-04"
 9455	jittery sinister slick murderbot whip	0		Moxie: +10, Spell Damage: +10, Last Available: "2017-04"
-9456	gray greedy Newton's murderbot plasma rifle	0		Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2017-04", Conditional Skill (Equipped): "EXTERMINATE SPANT"
+9456	gray greedy Newton's murderbot plasma rifle	0		Experience (Mysticality): +3, Meat Drop: +20, Conditional Skill (Equipped): "EXTERMINATE SPANT", Last Available: "2017-04"
 9457	mirror murderbot memory chip	0		Last Available: "2017-04"
 9458	yellow space pirate treasure map	0		Last Available: "2017-04"
 9459	Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
@@ -9335,7 +9335,7 @@
 9463	twirling Space Baby children's book	0		Last Available: "2017-04"
 9464	upside-down Space Baby bawbaw	0		Last Available: "2017-04"
 9465	Spacegate	0		Last Available: "2017-04"
-9466	fancy normal massive Aldebaran sardines	10	good	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2017-04"
+9466	normal fancy massive Aldebaran sardines	10	good	Effect: "Human-Hippy Hybrid", Effect Duration: 25, Last Available: "2017-04"
 9467	mediocre narrow Centauri fish wine	3	decent	Last Available: "2017-04"
 9468	denatured jittery oxygen	1		Effect: "Cruisin' for a Bruisin'", Effect Duration: 40, Last Available: "2017-04"
 9469	Spacegate scientist's insignia of Calamity Jane of extreme caution	0		Critical Hit Percent: +15, Monster Level: -25, Single Equip, Last Available: "2017-04"
@@ -9362,7 +9362,7 @@
 9490	super-cold-filtered improved Threatening Missive	0		Effect: "New Zeal", Effect Duration: 21
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
-9493	Kremlin's Greatest Briefcase of bravery of the boozehound of the early riser	0		Spooky Resistance: +5, Booze Drop: +100, Adventures: +7, Single Equip, Last Available: "2017-06", Conditional Skill (Equipped): "KGB tranquilizer dart"
+9493	Kremlin's Greatest Briefcase of bravery of the boozehound of the early riser	0		Spooky Resistance: +5, Booze Drop: +100, Adventures: +7, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
 9494	acceptable triple-distilled basic martini	6	good	Last Available: "2017-06"
 9495	boozy hand-crafted improved martini	5	EPIC	Last Available: "2017-06"
 9496	hand-crafted watered-down jittery splendid martini	2	EPIC	Last Available: "2017-06"
@@ -9379,7 +9379,7 @@
 9507	LI-11 Motor Pool voucher	0		Free Pull, Last Available: "2017-07"
 9508	lime green Asdon Martin keyfob (on ring)	0		Last Available: "2017-07"
 9509	L.I.M.P. Stock Certificate	0		
-9510	squat wobbly fuchsia Dust bunny	0		
+9510	wobbly squat fuchsia Dust bunny	0		
 9511	Pocket Meteor Guide	0		Last Available: "2017-08"
 9512	Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
@@ -9396,7 +9396,7 @@
 9524	skewed meteor shower cap	0		Familiar Weight: +5
 9525	jittery Thwaitgold time fly statuette	0		
 9526	skewed perfectly fair coin	0		Last Available: "2017-11"
-9527	skewed pulsating Horsery contract	0		Free Pull, Last Available: "2018-08"
+9527	pulsating skewed Horsery contract	0		Free Pull, Last Available: "2018-08"
 9528	corked genie bottle	0		Free Pull, Last Available: "2017-09"
 9529	twirling genie bottle	0		Last Available: "2017-09"
 9530	Annie Oakley's occult wicked blessed rustproof +2 gray dragon scale mail	0		Spell Damage: +5, Spell Damage Percent: +25, Critical Hit Percent: +20, Last Available: "2023-09"
@@ -9414,12 +9414,12 @@
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
 9543	X	0		Last Available: "2017-10"
 9544	mirror O	0		Last Available: "2017-10"
-9545	watered-down lousy DUFRESNE Suds	2	decent	Last Available: "2017-09"
+9545	lousy watered-down DUFRESNE Suds	2	decent	Last Available: "2017-09"
 9546	mirror Samson's mafia pinky ring	0		Experience (Muscle): +5, Item Drop: +5, Single Equip
-9547	smooth high-proof upside-down flask of port	8	awesome	
+9547	high-proof smooth upside-down flask of port	8	awesome	
 9548	flame-retardant scorching contract enforcement stick	0		Hot Damage: +25, Hot Resistance: +1
 9549	spoiled squat Hide-rox&trade; cookie	3	crappy	Last Available: "2017-10"
-9550	watered-down bad jug of booze	2	decent	Last Available: "2017-10"
+9550	bad watered-down jug of booze	2	decent	Last Available: "2017-10"
 9551	tarnished galvanized pair of candy glasses	0		Effect: "Cold Hands", Effect Duration: 69, Last Available: "2017-10"
 9552	ionized squat temporary X tattoos	0		Effect: "OMG WTF", Effect Duration: 60, Last Available: "2017-10"
 9553	vaporized glyph of athleticism	1		Effect: "Spooky Demeanor", Effect Duration: 15, Last Available: "2017-10"
@@ -9442,19 +9442,19 @@
 9570	dangerous worksite credentials	0		Weapon Damage: +10, Single Equip
 9571	mirror Sherlock's scorching strapping negotiatin' hammer of horror	0		Muscle: +5, Hot Damage: +25, Spooky Spell Damage: +25, Item Drop: +25
 9572	pantogram	0		Free Pull, Last Available: "2017-11"
-9573	jittery wobbly lime green pantogram	0		Last Available: "2017-11"
+9573	lime green wobbly jittery pantogram	0		Last Available: "2017-11"
 9574	pantogram pants	0		Lasts Until Rollover, Last Available: "2017-11"
 9575	spinning tumbling deadly mafia wedding ring of the boozehound	0		Weapon Damage: +5, Booze Drop: +100, Single Equip
 9576	mafia organizer badge of Leguizamo	0		Monster Level: +20, Single Equip
 9577	mafia filofax	0		
 9578	transparent nog	1	awesome	Last Available: "2017-12"
-9579	yummy bite-sized squat unfinished fruitcake	1	awesome	Last Available: "2017-12"
+9579	bite-sized yummy squat unfinished fruitcake	1	awesome	Last Available: "2017-12"
 9580	extra-activated and cracker	0		Effect: "Rainbow Bright", Effect Duration: 38, Last Available: "2017-12"
 9581	hand-crafted neg grog	3	EPIC	Last Available: "2017-12"
 9582	stale half double fruitcake	3	decent	Last Available: "2017-12"
-9583	half-sized normal hushed puppy	2	good	Last Available: "2017-12"
-9584	adequate big muffled muffuletta	5	good	Last Available: "2017-12"
-9585	stale half-sized special upside-down shushed potatoes	2	decent	Effect: "Human-Horror Hybrid", Effect Duration: 35, Last Available: "2017-12"
+9583	normal half-sized hushed puppy	2	good	Last Available: "2017-12"
+9584	big adequate muffled muffuletta	5	good	Last Available: "2017-12"
+9585	half-sized stale special upside-down shushed potatoes	2	decent	Effect: "Human-Horror Hybrid", Effect Duration: 35, Last Available: "2017-12"
 9586	stylish plastic mime functionary	0		Moxie: +25, Last Available: "2017-12"
 9587	brainy plastic mime scientist	0		Mysticality: +5, Last Available: "2017-12"
 9588	Jeselnik's plastic mime soldier	0		Sleaze Damage: +25, Last Available: "2017-12"
@@ -9466,7 +9466,7 @@
 9594	galvanized lime green wishbone	0		Effect: "Patched In", Effect Duration: 24, Last Available: "2017-11"
 9595	delicious Racisto Ruidoso	3	awesome	Last Available: "2017-11"
 9596	blurry pulsating earthenware muffin tin	0		
-9597	massive decent blue bran muffin	10	good	
+9597	decent massive blue bran muffin	10	good	
 9598	moldy teal blueberry muffin	3	crappy	
 9599	huge silent A	0		Last Available: "2017-12"
 9600	tumbling silent B	0		Last Available: "2017-12"
@@ -9498,7 +9498,7 @@
 9626	anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
-9629	lousy distilled stale cheer wine	5	decent	Last Available: "2017-12"
+9629	distilled lousy stale cheer wine	5	decent	Last Available: "2017-12"
 9630	small flavorless tumbling stale Cheer-E-Os	2	decent	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	frightening sinister cheerful antler hat	0		Spell Damage: +10, Spooky Damage: +5, Last Available: "2017-12"
@@ -9517,12 +9517,12 @@
 9645	jittery The Journal of Mime Science Vol. 6	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9646	blinking The Journal of Mime Science Vol. 6 (used)	0		Skill: "Quiet Desperation", Last Available: "2017-12"
 9647	lime green mime eraser	0		Last Available: "2017-12"
-9648	extra-dry acceptable shaking executive mime flask	5	good	Last Available: "2017-12"
+9648	acceptable extra-dry shaking executive mime flask	5	good	Last Available: "2017-12"
 9649	stale super-sized enchanted nega-mushroom	5	decent	Effect: "Boon of the Storm Tortoise", Effect Duration: 15, Last Available: "2017-12"
 9650	tolerable weak wobbly narrow nega-mushroom wine	2	good	Last Available: "2017-12"
 9651	super-cold-filtered energized bouncing Cheer-Up soda	0		Effect: "Rampage!", Effect Duration: 25, Last Available: "2017-12"
 9652	spoiled jittery mime army rations	3	crappy	Last Available: "2017-12"
-9653	fancy acceptable mime army wine	3	good	Effect: "Inebriate Pride", Effect Duration: 30, Last Available: "2017-12"
+9653	acceptable fancy mime army wine	3	good	Effect: "Inebriate Pride", Effect Duration: 30, Last Available: "2017-12"
 9654	compressed shaking bouncing mime army superserum	1		Last Available: "2017-12"
 9655	aerosolized triple-galvanized wobbly mime army camouflage kit	0		Effect: "Updated", Effect Duration: 25, Last Available: "2017-12"
 9656	Jim Carey's miming beret of the boozehound	0		Monster Level: +25, Booze Drop: +100, Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	deionized digital honeypot	0		Effect: "Bloodstain-Resistant", Effect Duration: 21, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	narrow perfumed mime army insignia (infantry)	0		Stench Resistance: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
-9668	pulsating razor-sharp mime army insignia (intelligence)	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
-9669	mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
+9667	narrow perfumed mime army insignia (infantry)	0		Stench Resistance: +5, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
+9668	pulsating razor-sharp mime army insignia (intelligence)	0		Weapon Damage Percent: +25, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
+9669	mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
 9670	twirling mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9551,7 +9551,7 @@
 9679	spinning kerosene-soaked skip	0		Free Pull, Last Available: "2018-12"
 9680	huge fireproof skip lid	0		Familiar Weight: +5
 9681	diet moldy extra-toasted half sandwich	1	crappy	Last Available: "2018-12"
-9682	triple-distilled mediocre mulled hobo wine	9	decent	Last Available: "2018-12"
+9682	mediocre triple-distilled mulled hobo wine	9	decent	Last Available: "2018-12"
 9683	burning newspaper	0		Last Available: "2018-12"
 9684	Jeselnik's boxer's beefcake's burning paper hat	0		Muscle: +25, Muscle Percent: +10, Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2018-12"
 9685	tumbling maroon flame-wreathed scorching burning cape of the dark arts	0		Spell Damage Percent: +100, Hot Damage: +25, Hot Spell Damage: +10, Lasts Until Rollover, Last Available: "2018-12"
@@ -9572,13 +9572,13 @@
 9700	sinister novelty monorail ticket of the storm	0		Spell Damage: +10, Maximum MP Percent: +40
 9701	altered red pills	1		
 9702	distilled furry pill	1		Effect: "Almost Cool", Effect Duration: 15
-9703	denatured blue squat mirror mirror beefy pill	1		Effect: "Memory of Smarts", Effect Duration: 50
-9704	compressed tumbling upside-down excitement pill	1		
+9703	denatured blue mirror squat mirror beefy pill	1		Effect: "Memory of Smarts", Effect Duration: 50
+9704	compressed upside-down tumbling excitement pill	1		
 9705	mixed fuchsia vitamin G pill	1		
 9706	dried teal lucky-ish pill	1		
 9707	dehydrated dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
-9713	spinning shaking How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
+9713	shaking spinning How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	ghostly Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
 9716	yellow spinning Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
@@ -9640,7 +9640,7 @@
 9772	spinning Morphan	0		Last Available: "2018-03"
 9773	huge Cycloney	0		Last Available: "2018-03"
 9774	Peaclock	0		Last Available: "2018-03"
-9775	wobbly spinning Turtive	0		Last Available: "2018-03"
+9775	spinning wobbly Turtive	0		Last Available: "2018-03"
 9776	Lepardner	0		Last Available: "2018-03"
 9777	blinking purple Aiolion	0		Last Available: "2018-03"
 9778	wobbly Waifuton	0		Last Available: "2018-03"
@@ -9650,7 +9650,7 @@
 9782	Ruffalo	0		Last Available: "2018-03"
 9783	bouncing Vaporpoise	0		Last Available: "2018-03"
 9784	yellow Ghosprey	0		Last Available: "2018-03"
-9785	olive squat Straypler	0		Last Available: "2018-03"
+9785	squat olive Straypler	0		Last Available: "2018-03"
 9786	ghostly Flan	0		Last Available: "2018-03"
 9787	Mustardigrade	0		Last Available: "2018-03"
 9788	cyan Ched	0		Last Available: "2018-03"
@@ -9662,7 +9662,7 @@
 9794	ghostly Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
 9796	Ungulant	0		Last Available: "2018-03"
-9797	bouncing gray Caramel	0		Last Available: "2018-03"
+9797	gray bouncing Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
 9799	upside-down Amanitee	0		Last Available: "2018-03"
 9800	Smashmoth	0		Last Available: "2018-03"
@@ -9674,7 +9674,7 @@
 9806	Glamare	0		Last Available: "2018-03"
 9807	Unspeakachu	0		Last Available: "2018-03"
 9808	Stooper	0		Last Available: "2018-03"
-9809	red upside-down mirror Disgeist	0		Last Available: "2018-03"
+9809	upside-down red mirror Disgeist	0		Last Available: "2018-03"
 9810	Bowlet	0		Last Available: "2018-03"
 9811	Cornbeefadon	0		Last Available: "2018-03"
 9812	Mu	0		Last Available: "2018-03"
@@ -9727,15 +9727,15 @@
 9859	fuchsia LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9860	FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	stale gigantic FantasyRealm turkey leg	8	decent	Last Available: "2018-04"
-9863	acceptable practically non-alcoholic FantasyRealm mead	1	good	Last Available: "2018-04"
-9864	twirling olive jittery nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
+9862	gigantic stale FantasyRealm turkey leg	8	decent	Last Available: "2018-04"
+9863	practically non-alcoholic acceptable FantasyRealm mead	1	good	Last Available: "2018-04"
+9864	jittery twirling olive nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	skewed Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
 9866	arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9867	hero's skull	0		Lasts Until Rollover, Last Available: "2018-04"
 9868	grolblin rum	0		Lasts Until Rollover, Last Available: "2018-04"
 9869	toothsome pulsating druidic s'more	4	awesome	Last Available: "2018-04"
-9870	powdered blinking blurry sachet of powder	1		Effect: "Knightlife", Effect Duration: 25, Last Available: "2018-04"
+9870	powdered blurry blinking sachet of powder	1		Effect: "Knightlife", Effect Duration: 25, Last Available: "2018-04"
 9871	weak acceptable olive mourning wine	2	good	Last Available: "2018-04"
 9872	squat sanctified cola	0		Lasts Until Rollover, Last Available: "2018-04"
 9873	map to the Towering Mountains	0		Last Available: "2018-04"
@@ -9744,7 +9744,7 @@
 9876	map to the Cursed Village	0		Last Available: "2018-04"
 9877	map to the Sprawling Cemetery	0		Last Available: "2018-04"
 9878	stale denastified haunch	4	decent	Last Available: "2018-04"
-9879	watered-down hand-crafted bad rum and good cola	2	EPIC	Last Available: "2018-04"
+9879	hand-crafted watered-down bad rum and good cola	2	EPIC	Last Available: "2018-04"
 9880	concentrated blinking Potion of Heroism	0		Effect: "Ruthlessly Efficient", Effect Duration: 42, Last Available: "2018-04"
 9881	Sinatra's leggings of the Spider Queen of the blizzard of the cheetah	0		Experience (Moxie): +5, Cold Spell Damage: +25, Initiative: +60, Last Available: "2018-04"
 9882	red resourceful studded occult Master Thief's utility belt	0		Spell Damage Percent: +25, Damage Absorption: +80, Maximum MP: +50, Single Equip, Last Available: "2018-04"
@@ -9764,14 +9764,14 @@
 9896	wobbly dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	smooth two meat muck	4	awesome	
-9899	rotten half-sized chocolate Ogre Chieftain	2	crappy	
+9899	half-sized rotten chocolate Ogre Chieftain	2	crappy	
 9900	moldy chocolate &quot;Phoenix&quot;	4	crappy	
 9901	normal chocolate Spider Queen	3	good	
-9902	watered-down lousy hipster cocktail	2	decent	
+9902	lousy watered-down hipster cocktail	2	decent	
 9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
 9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
 9905	fuchsia God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
-9906	ghostly huge God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9906	huge ghostly God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
 9907	God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	G	0		
@@ -9783,7 +9783,7 @@
 9915	massive stale good guava	9	decent	
 9916	weak hand-crafted blurry gin and ginger	2	EPIC	
 9917	Thwaitgold chigger statuette	0		
-9918	compressed twirling shaking gaseous gravy	1		Effect: "Clyde's Blessing", Effect Duration: 10
+9918	compressed shaking twirling gaseous gravy	1		Effect: "Clyde's Blessing", Effect Duration: 10
 9919	squat SongBoom&trade; BoomBox	0		Last Available: "2018-06"
 9920	SongBoom&trade; BoomBox Box	0		Free Pull, Last Available: "2018-06"
 9921	narrow A Guide to Safari	0		Skill: "Experience Safari"
@@ -9792,13 +9792,13 @@
 9924	Special Seasoning	0		Last Available: "2018-06"
 9925	diluted spinning cyan Nightmare Fuel	1		Effect: "Once Bitten Twice Fried", Effect Duration: 5, Last Available: "2018-06"
 9926	green Gathered Meat-Clip	0		Last Available: "2020-09"
-9927	spinning bouncing Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
+9927	bouncing spinning Bastille Battalion control rig crate	0		Free Pull, Last Available: "2018-07"
 9928	fuchsia Bastille Battalion control rig	0		Free Pull, Last Available: "2018-07"
 9929	ribald studded strapping Brutal brogues of the early riser	0		Muscle: +5, Damage Absorption: +80, Sleaze Damage: +10, Adventures: +7, Lasts Until Rollover, Last Available: "2018-07"
 9930	greasy manspreader's deadly Draftsman's driving gloves of Calamity Jane	0		Weapon Damage: +5, Critical Hit Percent: +15, Monster Level: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2018-07"
 9931	ribald hardened Socratic Nouveau nosering of the early riser	0		Experience (Mysticality): +1, Damage Reduction: 3, Sleaze Damage: +10, Adventures: +7, Lasts Until Rollover, Last Available: "2018-07"
 9932	Vulcanized flattened sharkfin gumbo	0		Effect: "Booooooze", Effect Duration: 15, Last Available: "2018-07"
-9933	energized twirling jittery boiling broth	0		Effect: "Human-Penguin Hybrid", Effect Duration: 63, Last Available: "2018-07"
+9933	energized jittery twirling boiling broth	0		Effect: "Human-Penguin Hybrid", Effect Duration: 63, Last Available: "2018-07"
 9934	galvanized interrogative elixir	0		Effect: "Some Cheese with Your Wine", Effect Duration: 29, Last Available: "2018-07"
 9935	squat Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
 9936	Bastille Battalion tattoo kit	0		Last Available: "2018-07"
@@ -9813,15 +9813,15 @@
 9945	Neverending Party favor	0		Last Available: "2018-09"
 9946	deluxe Neverending Party favor	0		Last Available: "2018-09"
 9947	gas can	0		Last Available: "2018-09"
-9948	drinkable special high-proof pulsating Middle of the Road&trade; brand whiskey	7	good	Effect: "Chalky Hand", Effect Duration: 40, Last Available: "2018-09"
+9948	drinkable high-proof special pulsating Middle of the Road&trade; brand whiskey	7	good	Effect: "Chalky Hand", Effect Duration: 40, Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	avaricious pentagram bandana of the sweet-tooth	0		Meat Drop: +30, Candy Drop: +100, Last Available: "2018-09"
 9951	skewed boxer's skull ring	0		Muscle Percent: +10, Single Equip, Last Available: "2018-09"
-9952	ghostly maroon electronics kit	0		Last Available: "2018-09"
+9952	maroon ghostly electronics kit	0		Last Available: "2018-09"
 9953	stale skewed PB&J with the crusts cut off	3	decent	Last Available: "2018-09"
 9954	ghostly pulsating dorky glasses of extreme caution of the detective	0		Monster Level: -25, Item Drop: +20, Single Equip, Last Available: "2018-09"
 9955	shaking greasy ponytail clip of the brazier	0		Hot Spell Damage: +25, Sleaze Spell Damage: +10, Last Available: "2018-09"
-9956	Jeselnik's paint palette	0		Sleaze Damage: +25, Last Available: "2018-09", Conditional Skill (Equipped): "Paint Job"
+9956	Jeselnik's paint palette	0		Sleaze Damage: +25, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	spinning unremarkable duffel bag	0		Last Available: "2018-09"
 9958	altered lime green wobbly Purple Beast energy drink	1		Last Available: "2018-09"
 9959	sharpshooter's cosmetic football	0		Critical Hit Percent: +10, Last Available: "2018-09"
@@ -9831,7 +9831,7 @@
 9963	blinking very small dress	0		Last Available: "2018-09"
 9964	energetic noticeable pumps of incineration	0		Maximum MP Percent: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	bad special everfull glass	3		Effect: "Bilious Brawn", Effect Duration: 45, Last Available: "2018-09"
+9966	special bad everfull glass	3		Effect: "Bilious Brawn", Effect Duration: 45, Last Available: "2018-09"
 9967	olive van key	0		Last Available: "2018-09"
 9968	jam band bootleg	0		Last Available: "2018-09"
 9969	Usain Bolt's experienced denim jacket	0		Experience: +2, Initiative: +80, Last Available: "2018-09"
@@ -9844,14 +9844,14 @@
 9977	jittery Temple Grandin's sharpshooter's therapeutic party whip	0		Critical Hit Percent: +10, Familiar Weight: +7, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2018-09"
 9978	purple Party Planning on a Budget	0		Skill: "Budget Conscious", Last Available: "2018-09"
 9979	smooth TRIO cup of beer	4	awesome	Last Available: "2018-09"
-9980	miniature normal party platter for one	2	good	Last Available: "2018-09"
+9980	normal miniature party platter for one	2	good	Last Available: "2018-09"
 9981	powdered pulsating narrow Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
-9983	spinning frosty cool party crasher	0		Moxie: +5, Cold Spell Damage: +10, Damage Reduction: 9, Last Available: "2018-09", Conditional Skill (Equipped): "Party Crash"
-9984	Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9983	spinning frosty cool party crasher	0		Moxie: +5, Cold Spell Damage: +10, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
+9984	Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
 9985	Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	wobbly party mouse hat	0		Familiar Weight: +5
-9987	ghostly latte lovers member's mug	0		Last Available: "2018-10", Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte"
+9987	ghostly latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	blinking latte lovers club card	0		Free Pull, Last Available: "2018-10"
 9989	twirling voter registration form	0		Free Pull, Last Available: "2018-11"
 9990	&quot;I Voted!&quot; sticker of the ox	0		Muscle: +20, Lasts Until Rollover, Last Available: "2018-11"
@@ -9860,7 +9860,7 @@
 9993	supercharged energetic snakeskin thighboots	0		Maximum MP Percent: 50, Last Available: "2018-11"
 9994	medical-grade snakeskin cowboy hat of the sweet-tooth	0		Candy Drop: +100, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2018-11"
 9995	blue rosewater-soaked crafty snakeskin jacket	0		Maximum MP: +10, Stench Resistance: +3, Last Available: "2018-11"
-9996	tumbling pulsating lime green slime glob	0		Last Available: "2018-11"
+9996	tumbling lime green pulsating slime glob	0		Last Available: "2018-11"
 9997	slime glob	0		Last Available: "2018-11"
 9998	olive slime glob	0		Last Available: "2018-11"
 9999	manspreader's shellacked slime waders of the storm	0		Damage Reduction: 7, Maximum MP Percent: +40, Monster Level: +10, Last Available: "2018-11"
@@ -9878,15 +9878,15 @@
 10012	tolerable bottle of vodka	3	good	Last Available: "2018-11"
 10013	decent pizza	4	good	Last Available: "2018-11"
 10014	practically non-alcoholic aged martini	1	awesome	Last Available: "2018-11"
-10015	normal big cherry pie	5	good	Last Available: "2018-11"
+10015	big normal cherry pie	5	good	Last Available: "2018-11"
 10016	artisanal eggnog	3	EPIC	Last Available: "2018-11"
 10017	mirror glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	bite-sized tasty tumbling Hell ramen	1	awesome	Last Available: "2018-11"
+10018	tasty bite-sized tumbling Hell ramen	1	awesome	Last Available: "2018-11"
 10019	artisanal gimlet	3	EPIC	Last Available: "2018-11"
 10020	bad strong spinning twice-haunted screwdriver	5	decent	Last Available: "2018-11"
 10021	big stale candy cane	5	decent	Last Available: "2018-12"
 10022	hand-crafted green runny fermented egg	3	EPIC	Last Available: "2018-12"
-10023	immense stale ghostly cyan oldcake	8	decent	Last Available: "2018-12"
+10023	immense stale cyan ghostly oldcake	8	decent	Last Available: "2018-12"
 10024	normal traditional Crimbo cookie	3	good	Last Available: "2023-06"
 10025	plastic wild beaver of the brute	0		Muscle Percent: +30, Last Available: "2018-12"
 10026	squat plastic reindeer of the brute	0		Muscle Percent: +30, Last Available: "2018-12"
@@ -9902,13 +9902,13 @@
 10036	squat bomb	0		Last Available: "2018-12"
 10037	squat plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	special spoiled small mirror grilled mooseflank	2	crappy	Effect: "Got Your Boots On", Effect Duration: 35, Last Available: "2018-12"
+10039	spoiled special small mirror grilled mooseflank	2	crappy	Effect: "Got Your Boots On", Effect Duration: 35, Last Available: "2018-12"
 10040	spoiled half-sized fuchsia skewed moosemeat pie	2	crappy	Last Available: "2018-12"
 10041	tumbling pulsating forbidden balanced antler	0		Spell Damage Percent: +50, Last Available: "2018-12"
 10042	dam of the cougar	0		Moxie: +20, Damage Reduction: 9, Last Available: "2018-12"
 10043	drinkable beavermouth	4	good	Last Available: "2018-12"
 10044	acceptable beaver punch (papaya)	3	good	Last Available: "2018-12"
-10045	perfectly mixed practically non-alcoholic bouncing tumbling beaver punch (peach)	1	super ultra mega EPIC	Last Available: "2018-12"
+10045	perfectly mixed practically non-alcoholic tumbling bouncing beaver punch (peach)	1	super ultra mega EPIC	Last Available: "2018-12"
 10046	drinkable huge beaver punch (cherry)	3	good	Last Available: "2018-12"
 10047	twirling clever smooth Canadian lantern	0		Moxie: +15, Maximum MP: +20, Last Available: "2018-12"
 10048	asbestos-lined muskox-skin cap	0		Hot Resistance: +5, Last Available: "2018-12"
@@ -9925,7 +9925,7 @@
 10059	sausage casing	0		Last Available: "2019-01"
 10060	gigantic moldy sausage	6	crappy	Last Available: "2019-01"
 10061	bouncing wholesome hardened red-hot sausage fork	0		Damage Reduction: 3, Maximum HP Percent: +10, Last Available: "2019-01"
-10062	wobbly huge lime green bag of sausage links	0		Last Available: "2019-01"
+10062	lime green huge wobbly bag of sausage links	0		Last Available: "2019-01"
 10063	sausage golem	0		Last Available: "2019-01"
 10064	jar of relish	0		Familiar Weight: +5
 10065	wobbly Toyleporter	0		Last Available: "2018-12"
@@ -9933,7 +9933,7 @@
 10067	stale blurry yule gruel	3	decent	Last Available: "2018-12"
 10068	practically non-alcoholic tolerable hot watered rum	1	good	Last Available: "2018-12"
 10069	hand-crafted pulsating bottle of Crimbognac	4	EPIC	Last Available: "2018-12"
-10070	toothsome jumbo Crimboysters Rockefeller	5	awesome	Last Available: "2018-12"
+10070	jumbo toothsome Crimboysters Rockefeller	5	awesome	Last Available: "2018-12"
 10071	twisted tumbling twirling Crimbeau de toilette	1		Last Available: "2018-12"
 10072	blurry Crimbo candle	0		Last Available: "2018-12"
 10073	Carol of the Bulls	0		Skill: "Carol of the Bulls", Last Available: "2018-12"
@@ -9943,7 +9943,7 @@
 10077	pulsating Carol of the Thrills	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10078	Carol of the Thrills (used)	0		Skill: "Carol of the Thrills", Last Available: "2018-12"
 10079	padded Crimbolex watch of the cougar of incineration	0		Moxie: +20, Damage Absorption: +20, Hot Spell Damage: +50, Single Equip, Last Available: "2018-12"
-10080	squat narrow Crimbo tattoo kit	0		Last Available: "2018-12"
+10080	narrow squat Crimbo tattoo kit	0		Last Available: "2018-12"
 10081	Sinatra's Fonzie's hand-knitted Crimbo socks of wisdom	0		Mysticality: +15, Experience (Moxie): 6
 10082	prompt horrifying chalk chlamys	0		Spooky Damage: +25, Adventures: +3, Last Available: "2019-12"
 10083	squat Temple Grandin's occult chalk chain	0		Spell Damage Percent: +25, Familiar Weight: +7, Single Equip, Last Available: "2019-12"
@@ -9961,22 +9961,22 @@
 10095	shaking deadly marble mariachi hat of the dark arts	0		Weapon Damage: +5, Spell Damage Percent: +100, Last Available: "2019-12"
 10096	dehydrated marble molecules	1		Effect: "Corruption of Wretched Wally", Effect Duration: 20, Last Available: "2019-12"
 10097	quadruple-polarized tumbling Mallomarbles	0		Effect: "Human-Penguin Hybrid", Effect Duration: 58
-10098	greasy careful punching bag	0		Monster Level: -10, Sleaze Spell Damage: +10, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10099	avaricious padded pith helmet	0		Damage Absorption: +20, Meat Drop: +30, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10100	smooth poncho of the businessman	0		Moxie: +15, Meat Drop: +50, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10101	spinning teal Temple Grandin's Jim Carey's pendant	0		Monster Level: +25, Familiar Weight: +7, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10102	palazzos of chilblains of the brazier	0		Cold Damage: +25, Hot Spell Damage: +25, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
-10103	pulsating pseudoaccordion of Leguizamo of bravery	0		Monster Level: +20, Spooky Resistance: +5, Song Duration: 5, Last Available: "2020-12", Conditional Skill (Equipped): "Paraffin Prism"
+10098	greasy careful punching bag	0		Monster Level: -10, Sleaze Spell Damage: +10, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10099	avaricious padded pith helmet	0		Damage Absorption: +20, Meat Drop: +30, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10100	smooth poncho of the businessman	0		Moxie: +15, Meat Drop: +50, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10101	spinning teal Temple Grandin's Jim Carey's pendant	0		Monster Level: +25, Familiar Weight: +7, Single Equip, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10102	palazzos of chilblains of the brazier	0		Cold Damage: +25, Hot Spell Damage: +25, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
+10103	pulsating pseudoaccordion of Leguizamo of bravery	0		Monster Level: +20, Spooky Resistance: +5, Song Duration: 5, Conditional Skill (Equipped): "Paraffin Prism", Last Available: "2020-12"
 10104	modified yellow tumbling pieces	1		Effect: "Less Pervious", Effect Duration: 20, Last Available: "2020-12"
 10105	enhanced adjusted Para-Pop	0		Effect: "Hot Blooded", Effect Duration: 26
-10106	Annie Oakley's arcane researcher's terra cotta truss	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10107	manspreader's Annie Oakley's terra cotta trousers	0		Critical Hit Percent: +20, Monster Level: +10, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10108	narrow rosy-cheeked Fonzie's terra cotta tongs	0		Experience (Moxie): +1, Maximum HP Percent: +30, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10109	family-friendly double-paned terra cotta train	0		Cold Resistance: +5, Sleaze Resistance: +1, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10110	cyan executive quilted terra cotta tie tack	0		Damage Absorption: +40, Meat Drop: +40, Single Equip, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
-10111	lightning-fast dance instructor's terra cotta tambourine	0		Experience Percent (Moxie): +10, Initiative: +40, Last Available: "2020-12", Conditional Skill (Equipped): "Unleash Terra Cotta Army"
+10106	Annie Oakley's arcane researcher's terra cotta truss	0		Experience Percent (Mysticality): +10, Critical Hit Percent: +20, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10107	manspreader's Annie Oakley's terra cotta trousers	0		Critical Hit Percent: +20, Monster Level: +10, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10108	narrow rosy-cheeked Fonzie's terra cotta tongs	0		Experience (Moxie): +1, Maximum HP Percent: +30, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10109	family-friendly double-paned terra cotta train	0		Cold Resistance: +5, Sleaze Resistance: +1, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10110	cyan executive quilted terra cotta tie tack	0		Damage Absorption: +40, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
+10111	lightning-fast dance instructor's terra cotta tambourine	0		Experience Percent (Moxie): +10, Initiative: +40, Conditional Skill (Equipped): "Unleash Terra Cotta Army", Last Available: "2020-12"
 10112	vaporized jittery terra cotta tidbits	1		Last Available: "2020-12"
-10113	alkaline fuchsia blurry terra panna cotta	0		Effect: "Analog Drunk", Effect Duration: 34
+10113	alkaline blurry fuchsia terra panna cotta	0		Effect: "Analog Drunk", Effect Duration: 34
 10114	censurious Samson's velour voulge	0		Experience (Muscle): +5, Sleaze Resistance: +3, Last Available: "2021-12"
 10115	therapeutic velour vambraces of the brazier	0		Hot Spell Damage: +25, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2021-12"
 10116	medical-grade dance instructor's velour veil	0		Experience Percent (Moxie): +10, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2021-12"
@@ -9991,37 +9991,37 @@
 10125	blurry careful fortified glass spectacles	0		Damage Absorption: +60, Monster Level: -10, Single Equip, Last Available: "2021-12"
 10126	knitted Fonzie's glass shiv	0		Experience (Moxie): +1, Cold Resistance: +3, Last Available: "2021-12"
 10127	razor-sharp glass serape of horror	0		Weapon Damage Percent: +25, Spooky Spell Damage: +25, Last Available: "2021-12"
-10128	altered blinking olive glass shards	1		Last Available: "2021-12"
+10128	altered olive blinking glass shards	1		Last Available: "2021-12"
 10129	energized twirling hard candy	0		Effect: "Human-Demon Hybrid", Effect Duration: 18
-10130	greedy razor-sharp loofah lumberjack's hat	0		Weapon Damage Percent: +25, Meat Drop: +20, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Head-Scratch"
-10131	thinker's brainy loofah lei	0		Mysticality: 15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lei Lasso"
-10132	aromatic rock-hard loofah lederhosen	0		Damage Reduction: 5, Stench Resistance: +1, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Hosenzittern"
-10133	bouncing greedy electrified loofah ladle	0		Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Stew"
-10134	pulsating loofah legwarmers of the dark arts of the scaredy-cat	0		Spell Damage Percent: +100, Monster Level: -15, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Leglifts"
-10135	grievous loofah lavalier of the cougar	0		Moxie: +20, Weapon Damage Percent: +50, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Loofah Lava"
+10130	greedy razor-sharp loofah lumberjack's hat	0		Weapon Damage Percent: +25, Meat Drop: +20, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
+10131	thinker's brainy loofah lei	0		Mysticality: 15, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
+10132	aromatic rock-hard loofah lederhosen	0		Damage Reduction: 5, Stench Resistance: +1, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
+10133	bouncing greedy electrified loofah ladle	0		Meat Drop: +20, MP Regen Min: 3, MP Regen Max: 5, Conditional Skill (Equipped): "Loofah Stew", Last Available: "2022-12"
+10134	pulsating loofah legwarmers of the dark arts of the scaredy-cat	0		Spell Damage Percent: +100, Monster Level: -15, Single Equip, Conditional Skill (Equipped): "Loofah Leglifts", Last Available: "2022-12"
+10135	grievous loofah lavalier of the cougar	0		Moxie: +20, Weapon Damage Percent: +50, Single Equip, Conditional Skill (Equipped): "Loofah Lava", Last Available: "2022-12"
 10136	powdered olive loofah lumps	1		Last Available: "2022-12"
 10137	chilled chocolate-covered loofah	0		Effect: "Fizzier Than Light", Effect Duration: 17
-10138	forbidden flagstone flag of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Last Available: "2022-12", Conditional Skill (Equipped): "Flagellate"
-10139	flagstone flail of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, Last Available: "2022-12", Conditional Skill (Equipped): "Flagflog"
-10140	skewed healthy rock-hard flagstone flip-flops	0		Damage Reduction: 5, Maximum HP Percent: +20, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Flap Flip"
-10141	flagstone fez of the storm of the glutton	0		Maximum MP Percent: +40, Food Drop: +100, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fez Ritual"
-10142	Temple Grandin's boxer's flagstone fleece	0		Muscle Percent: +10, Familiar Weight: +7, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Fleece Flex"
-10143	red asbestos-lined rock-hard flagstone fringe	0		Damage Reduction: 5, Hot Resistance: +5, Single Equip, Last Available: "2022-12", Conditional Skill (Equipped): "Flagstone Foxtrot"
-10144	powdered cyan wobbly flagstone flagments	1		Last Available: "2022-12"
+10138	forbidden flagstone flag of the brute	0		Muscle Percent: +30, Spell Damage Percent: +50, Conditional Skill (Equipped): "Flagellate", Last Available: "2022-12"
+10139	flagstone flail of the storm of chilblains	0		Maximum MP Percent: +40, Cold Damage: +25, Conditional Skill (Equipped): "Flagflog", Last Available: "2022-12"
+10140	skewed healthy rock-hard flagstone flip-flops	0		Damage Reduction: 5, Maximum HP Percent: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Flap Flip", Last Available: "2022-12"
+10141	flagstone fez of the storm of the glutton	0		Maximum MP Percent: +40, Food Drop: +100, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
+10142	Temple Grandin's boxer's flagstone fleece	0		Muscle Percent: +10, Familiar Weight: +7, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
+10143	red asbestos-lined rock-hard flagstone fringe	0		Damage Reduction: 5, Hot Resistance: +5, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
+10144	powdered wobbly cyan flagstone flagments	1		Last Available: "2022-12"
 10145	denatured Flag by the Foot&trade;	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 63
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	bouncing red-and-green microcamera	0		Familiar Weight: +5
 10148	Sinatra's cobbled-together Meat detector	0		Experience (Moxie): +5, Lasts Until Rollover, Last Available: "2019-12"
 10149	deionized electrified upside-down shaking tin thermos of chai	0		Effect: "Salsa Satanica", Effect Duration: 43, Last Available: "2019-12"
-10150	boiled bouncing mirror prototype stimulant	1		Effect: "Hiding in Plain Sight", Effect Duration: 5, Last Available: "2019-12"
+10150	boiled mirror bouncing prototype stimulant	1		Effect: "Hiding in Plain Sight", Effect Duration: 5, Last Available: "2019-12"
 10151	Oprah's tailored vest	0		Maximum MP Percent: +50, Lasts Until Rollover, Last Available: "2019-12"
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	elf army poncho of the boozehound	0		Booze Drop: +100, Lasts Until Rollover, Last Available: "2019-12"
-10155	moldy low-calorie fancy elf army field rations	1	crappy	Effect: "Make Meat FA$T!", Effect Duration: 20, Last Available: "2019-12"
+10155	low-calorie fancy moldy elf army field rations	1	crappy	Effect: "Make Meat FA$T!", Effect Duration: 20, Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	Tesla Rosewater's discarded bowtie	0		Mysticality Percent: +30, MP Regen Min: 7, MP Regen Max: 10, Lasts Until Rollover, Last Available: "2019-12"
-10158	acceptable fancy mirror martiny	3	good	Effect: "Nightlit", Effect Duration: 5, Last Available: "2019-12"
+10158	fancy acceptable mirror martiny	3	good	Effect: "Nightlit", Effect Duration: 5, Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	polarized colloidal licorice snake	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 62
 10161	extra-chilled alkaline pulsating virgin jello shot	0		Effect: "Feet of Grapefruit", Effect Duration: 47
@@ -10029,16 +10029,16 @@
 10163	boiled government-issued candy	0		Effect: "Can Has Cyborger", Effect Duration: 64
 10164	triple-corrupted boiled chilled Pneumo bar	0		Effect: "[800]Chocolate Reign", Effect Duration: 44
 10165	mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
-10166	jittery arcane researcher's Lil' Doctor&trade; bag of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Single Equip, Last Available: "2019-02", Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray"
+10166	jittery arcane researcher's Lil' Doctor&trade; bag of extreme caution	0		Experience Percent (Mysticality): +10, Monster Level: -25, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	blood bag	0		
 10169	bite-sized bland bloodstick	1	decent	
 10170	lousy bottle of Sanguiovese	3	decent	
-10171	normal half-sized actual blood sausage	2	good	
+10171	half-sized normal actual blood sausage	2	good	
 10172	hand-crafted mulled blood	3	EPIC	
 10173	normal blood snowcone	4	good	
 10174	acceptable Red Russian	3	good	
 10175	bland gigantic blood roll-up	10	decent	
-10176	acceptable enchanted ghostly bottle of blood	3	good	Effect: "Earthen Fist", Effect Duration: 50
+10176	enchanted acceptable ghostly bottle of blood	3	good	Effect: "Earthen Fist", Effect Duration: 50
 10177	normal skewed blood-soaked sponge cake	3	good	
 10178	tolerable gray vampagne	4	good	
 10179	low-calorie normal skewed blinking plain snowcone	1	good	
@@ -10063,8 +10063,8 @@
 10198	Red Roger's map	0		Lasts Until Rollover, Last Available: "2019-04"
 10199	delicious twirling crabsicle	4	awesome	Last Available: "2019-04"
 10200	melty plastic grenade	0		Last Available: "2019-04"
-10201	practically non-alcoholic tolerable bottle of dark rhum	1	good	Last Available: "2019-04"
-10202	bad practically non-alcoholic bottle of extra-dark rhum	1	decent	Last Available: "2019-04"
+10201	tolerable practically non-alcoholic bottle of dark rhum	1	good	Last Available: "2019-04"
+10202	practically non-alcoholic bad bottle of extra-dark rhum	1	decent	Last Available: "2019-04"
 10203	drinkable bottle of super-extra-dark rhum	4	good	Last Available: "2019-04"
 10204	quadruple-colloidal super-polarized red pirate shaving cream	0		Effect: "Stinky Weapon", Effect Duration: 66, Last Available: "2019-04"
 10205	blinking friendly conquistador's breastplate of the wise owl	0		Mysticality: +20, Familiar Weight: +3, Last Available: "2019-04"
@@ -10075,7 +10075,7 @@
 10210	razor-sharp pirate radio ring of the dark arts	0		Weapon Damage Percent: +25, Spell Damage Percent: +100, Single Equip, Last Available: "2019-04"
 10211	Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	bland pulsating pineapple slab	3	decent	Last Available: "2019-04"
-10213	huge normal hibiscus petal	6	good	Last Available: "2019-04"
+10213	normal huge hibiscus petal	6	good	Last Available: "2019-04"
 10214	corrupted blinking huge mint leaf	0		Effect: "Berry Thorny", Effect Duration: 65, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	distilled pulsating maroon ice molecule	1		Effect: "Hypercubed", Effect Duration: 40, Last Available: "2019-04"
@@ -10083,10 +10083,10 @@
 10218	Red Roger's right hand	0		Last Available: "2019-04"
 10219	Red Roger's left hand	0		Last Available: "2019-04"
 10220	upside-down Red Roger's right foot	0		Single Equip, Last Available: "2019-04"
-10221	ghostly lime green Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
+10221	lime green ghostly Red Roger's left foot	0		Single Equip, Last Available: "2019-04"
 10222	Red Roger's skull	0		Last Available: "2019-04"
 10223	modified pewter shavings	1		Last Available: "2019-04"
-10224	narrow spinning yellow Red Roger tattoo kit	0		Last Available: "2019-04"
+10224	yellow narrow spinning Red Roger tattoo kit	0		Last Available: "2019-04"
 10225	bouncing PirateRealm fun-a-log	0		Last Available: "2019-04"
 10226	Annie Oakley's plush sea serpent	0		Critical Hit Percent: +20, Monster Level: -100, Single Equip, Last Available: "2019-04"
 10227	moldy pirate fork	3		Last Available: "2019-04"
@@ -10096,15 +10096,15 @@
 10231	ghostly gravedigger's studded wicked PirateRealm party hat	0		Spell Damage: +5, Damage Absorption: +80, Spooky Damage: +10, Last Available: "2019-04"
 10232	fancy tolerable practically non-alcoholic Island Landslide	1	good	Effect: "Jacked In", Effect Duration: 25, Last Available: "2019-04"
 10233	artisanal weak Island Thunderstorm	2	super EPIC	Last Available: "2019-04"
-10234	enchanted hand-crafted Island Hurricane	3	EPIC	Effect: "Super-Electrified", Effect Duration: 10, Last Available: "2019-04"
+10234	hand-crafted enchanted Island Hurricane	3	EPIC	Effect: "Super-Electrified", Effect Duration: 10, Last Available: "2019-04"
 10235	irresponsibly strong artisanal Skull Punch	6	EPIC	Last Available: "2019-04"
 10236	lousy Electric Punch	3	decent	Last Available: "2019-04"
 10237	tolerable Smuggler's Punch	4	good	Last Available: "2019-04"
-10238	enchanted hand-crafted Scorpion Bowl	3	super EPIC	Effect: "Gummibrain", Effect Duration: 15, Last Available: "2019-04"
+10238	hand-crafted enchanted Scorpion Bowl	3	super EPIC	Effect: "Gummibrain", Effect Duration: 15, Last Available: "2019-04"
 10239	extra-dry artisanal Turtle Bowl	5	EPIC	Last Available: "2019-04"
 10240	perfectly mixed Cobra Bowl	3	super EPIC	Last Available: "2019-04"
 10241	vampyric cloake pattern	0		Free Pull
-10242	executive ribald shellacked vampyric cloake of James Dean of mayonnaise	0		Experience (Moxie): +3, Damage Reduction: 7, Sleaze Damage: +10, Sleaze Spell Damage: +50, Meat Drop: +40, Last Available: "2019-03", Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat"
+10242	executive ribald shellacked vampyric cloake of James Dean of mayonnaise	0		Experience (Moxie): +3, Damage Reduction: 7, Sleaze Damage: +10, Sleaze Spell Damage: +50, Meat Drop: +40, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	extra-deionized wet one piece of bubble gum	0		Effect: "Stregngth of the Gnome", Effect Duration: 16
 10245	arcanoferric housing	0		
@@ -10113,16 +10113,16 @@
 10248	blown-out speaker cone	0		
 10249	overloaded short-pulse transistor	0		
 10250	Fourth of May Cosplay Saber kit	0		Free Pull
-10251	blinking skewed frightening Annie Oakley's Fourth of May Cosplay Saber of temperance	0		Critical Hit Percent: +20, Spooky Damage: +5, Sleaze Resistance: +5, Last Available: "2019-05", Conditional Skill (Equipped): "Use the Force"
+10251	blinking skewed frightening Annie Oakley's Fourth of May Cosplay Saber of temperance	0		Critical Hit Percent: +20, Spooky Damage: +5, Sleaze Resistance: +5, Conditional Skill (Equipped): "Use the Force", Last Available: "2019-05"
 10252	ring	0		Single Equip
 10253	Thwaitgold nymph statuette	0		
-10254	executive Sherlock's inspector's nasty flame-wreathed lion tamer's steel-toed wicked Sinatra's hewn moon-rune spoon of Calamity Jane of incineration	0		Experience (Moxie): +5, Spell Damage: +5, Damage Reduction: 9, Critical Hit Percent: +15, Experience (familiar): +2, Hot Spell Damage: 60, Stench Damage: +5, Item Drop: 40, Meat Drop: +40, Single Equip, Last Available: "2019-06", Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon"
+10254	executive Sherlock's inspector's nasty flame-wreathed lion tamer's steel-toed wicked Sinatra's hewn moon-rune spoon of Calamity Jane of incineration	0		Experience (Moxie): +5, Spell Damage: +5, Damage Reduction: 9, Critical Hit Percent: +15, Experience (familiar): +2, Hot Spell Damage: 60, Stench Damage: +5, Item Drop: 40, Meat Drop: +40, Single Equip, Conditional Skill (Equipped): "Dragoon Platoon", Conditional Skill (Equipped): "Spittoon Monsoon", Conditional Skill (Equipped): "Festoon Buffoon", Last Available: "2019-06"
 10255	cartoon harpoon	0		Last Available: "2019-06"
 10256	rune-strewn spoon cocoon	0		Free Pull, Last Available: "2019-06"
 10257	Beach Comb Box	0		Free Pull, Last Available: "2019-07"
-10258	miser's knitted Jack Frost's Beach Comb	0		Cold Spell Damage: +50, Cold Resistance: +3, Meat Drop: +10, Single Equip, Last Available: "2019-07", Conditional Skill (Equipped): "Beach Combo"
+10258	miser's knitted Jack Frost's Beach Comb	0		Cold Spell Damage: +50, Cold Resistance: +3, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Beach Combo", Last Available: "2019-07"
 10259	purple grain of sand	0		Last Available: "2019-07"
-10260	squat yellow small pile of sand	0		Last Available: "2019-07"
+10260	yellow squat small pile of sand	0		Last Available: "2019-07"
 10261	twirling pile of sand	0		Last Available: "2019-07"
 10262	pile of sand	0		Last Available: "2019-07"
 10263	teal empty hourglass	0		Last Available: "2019-07"
@@ -10169,7 +10169,7 @@
 10304	moldy campfire baked potato	4	crappy	Last Available: "2019-08"
 10305	flavorless olive campfire s'more	3	decent	Last Available: "2019-08"
 10306	bland green campfire beans	3	decent	Last Available: "2019-08"
-10307	enchanted flavorless jumbo campfire stew	5	decent	Effect: "[800]Chocolate Reign", Effect Duration: 25, Last Available: "2019-08"
+10307	jumbo flavorless enchanted campfire stew	5	decent	Effect: "[800]Chocolate Reign", Effect Duration: 25, Last Available: "2019-08"
 10308	campfire coffee	1	decent	Last Available: "2019-08"
 10309	energized dry squat leftover chocolate bar	0		Effect: "Weepy, Creepy", Effect Duration: 19
 10310	bouncing rare Meat isotope	0		
@@ -10183,7 +10183,7 @@
 10318	low-pressure oxygen tank	0		Single Equip
 10319	olive Thwaitgold bombardier beetle statuette	0		
 10320	adequate space chowder	4	good	
-10321	special bad space wine	3	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 35
+10321	bad special space wine	3	decent	Effect: "The Magical Mojomuscular Melody", Effect Duration: 35
 10322	The Imploded World	0		Skill: "Implode Universe"
 10323	packaged Pocket Professor	0		Free Pull, Last Available: "2019-09"
 10324	Pocket Professor memory chip	0		
@@ -10194,7 +10194,7 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	stale bu&ntilde;uelos Jaliscos	3	decent	Last Available: "2019-12"
-10338	massive stale flan del mar	8	decent	Last Available: "2019-12"
+10338	stale massive flan del mar	8	decent	Last Available: "2019-12"
 10339	adequate Baja sopapilla	3	good	Last Available: "2019-12"
 10340	lime green Socratic plastic Mer-kin baker	0		Experience (Mysticality): +1, Last Available: "2019-12"
 10341	chilly plastic sea elf	0		Cold Damage: +5, Last Available: "2019-12"
@@ -10216,8 +10216,8 @@
 10357	special bad boot flask	3	decent	Effect: "Beastly Flavor", Effect Duration: 25, Last Available: "2019-12"
 10358	moist modified infernal snowball	0		Effect: "Arabian Knighthood", Effect Duration: 62, Last Available: "2019-12"
 10359	madness	0		Last Available: "2019-12"
-10360	dehydrated jittery twirling fish sauce	1		Effect: "Spirit Bubble", Effect Duration: 25, Last Available: "2019-12"
-10361	decent snack-sized blinking guffin	2	good	Last Available: "2019-12"
+10360	dehydrated twirling jittery fish sauce	1		Effect: "Spirit Bubble", Effect Duration: 25, Last Available: "2019-12"
+10361	snack-sized decent blinking guffin	2	good	Last Available: "2019-12"
 10362	pickled Shantix&trade;	1		Last Available: "2019-12"
 10363	goodberry	0		Last Available: "2019-12"
 10364	powdered non-Euclidean angle	1		Last Available: "2019-12"
@@ -10227,7 +10227,7 @@
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	diluted spinning livid energy	1		Effect: "Hyphemariffic", Effect Duration: 40, Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	compressed gray mirror beggin' cologne	1		Last Available: "2019-12"
+10371	compressed mirror gray beggin' cologne	1		Last Available: "2019-12"
 10372	purple occult slick oxygenated eggnog helmet	0		Moxie: +10, Spell Damage Percent: +25, Adventure Underwater, Last Available: "2019-12"
 10373	hand-knitted diving booties	0		Last Available: "2019-12"
 10374	blurry peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10271,7 +10271,7 @@
 10412	nasty frosty nutcracker cape	0		Cold Spell Damage: +10, Stench Damage: +5, Last Available: "2019-12"
 10413	Sinatra's nutcracker epaulets of temperance	0		Experience (Moxie): +5, Sleaze Resistance: +5, Single Equip, Last Available: "2019-12"
 10414	nutcracker figurine	0		Last Available: "2019-12"
-10415	stale thick salt plum	5	decent	Last Available: "2019-12"
+10415	thick stale salt plum	5	decent	Last Available: "2019-12"
 10416	wobbly peppermint eel sauce	0		Last Available: "2019-12"
 10417	spoiled and bean	4	crappy	Last Available: "2019-12"
 10418	narrow nasty Jack Frost's kelp-holly gun of Tarzan	0		Experience (Muscle): +3, Cold Spell Damage: +50, Stench Damage: +5, Last Available: "2019-12"
@@ -10281,25 +10281,25 @@
 10422	Van der Graaf Crimbylow-rise jeans of the scaredy-cat	0		Monster Level: -15, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
 10423	skewed Usain Bolt's beefy kelp-holly drape	0		Muscle: +10, Initiative: +80, Last Available: "2019-12"
 10424	nasty Annie Oakley's Staff of the Peppermint Twist of the brazier of bravery	0		Critical Hit Percent: +20, Hot Spell Damage: +25, Stench Damage: +5, Spooky Resistance: +5, Last Available: "2019-12"
-10425	moldy narrow blurry tempura and bean	3	crappy	Last Available: "2019-12"
+10425	moldy blurry narrow tempura and bean	3	crappy	Last Available: "2019-12"
 10426	artisanal salt plum sake	4	EPIC	Last Available: "2019-12"
 10427	dry pressurized potion of possessiveness	0		Effect: "Piratastic", Effect Duration: 12, Last Available: "2019-12"
 10428	improved nitrogenated jittery upside-down almond	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 39
 10429	adjusted handful of mixed nuts	0		Effect: "Full-Body Tan", Effect Duration: 22, Last Available: "2019-12"
 10430	pulsating nutcracking pliers	0		
 10431	Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
-10432	Sherlock's medical-grade Retrospecs of Gandalf	0		Spell Critical Percent: +20, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Free Pull, Last Available: "2020-01", Conditional Skill (Equipped): "Detect Weakness"
+10432	Sherlock's medical-grade Retrospecs of Gandalf	0		Spell Critical Percent: +20, Item Drop: +25, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
 10434	fuchsia Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
-10438	cyan wool scandalous educational Powerful Glove of Calamity Jane of the early riser	0		Experience: +1, Critical Hit Percent: +15, Sleaze Damage: +5, Cold Resistance: +1, Adventures: +7, Single Equip, Last Available: "2020-02", Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size"
+10438	cyan wool scandalous educational Powerful Glove of Calamity Jane of the early riser	0		Experience: +1, Critical Hit Percent: +15, Sleaze Damage: +5, Cold Resistance: +1, Adventures: +7, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
 10440	squat status cymbal	0		Last Available: "2020-02"
 10441	spinning aromatic coward's Drip harness of Gandalf	0		Spell Critical Percent: +20, Monster Level: -20, Stench Resistance: +1
 10442	auspicious drippy truncheon	0		Item Drop: +10, Single Equip
 10443	Driplet	0		
 10444	drippy snail shell	0		
-10445	decent tiny mirror drippy nugget	1	drippy	
+10445	tiny decent mirror drippy nugget	1	drippy	
 10446	mediocre glass of drippy wine	3	drippy	
 10447	normal snack-sized drippy caviar	2	drippy	
 10448	rotten tiny squat drippy plum(?)	1	drippy	
@@ -10327,7 +10327,7 @@
 10470	mirror Thwaitgold buzzy beetle statuette	0		
 10471	Plumber's Union Handbook	0		
 10472	spinning twirling personal trainer's bony back shell	0		Experience Percent (Muscle): +10
-10473	teal jittery frosty button	0		Single Equip
+10473	jittery teal frosty button	0		Single Equip
 10474	tarnished blooper ink	0		Effect: "Human-Pirate Hybrid", Effect Duration: 26
 10475	coin	0		
 10476	rubber doll head	0		
@@ -10343,10 +10343,10 @@
 10486	free-range mushroom	0		Last Available: "2020-03"
 10487	immense free-range mushroom	0		Last Available: "2020-03"
 10488	colossal free-range mushroom	0		Last Available: "2020-03"
-10489	adequate huge green mushroom filet	8	good	Last Available: "2020-03"
+10489	huge adequate green mushroom filet	8	good	Last Available: "2020-03"
 10490	bouncing mushroom slab	0		Last Available: "2020-03"
 10491	diluted bouncing mushroom tea	1		Last Available: "2020-03"
-10492	smooth extra-dry twirling mushroom whiskey	5	awesome	Last Available: "2020-03"
+10492	extra-dry smooth twirling mushroom whiskey	5	awesome	Last Available: "2020-03"
 10493	blinking Da Vinci's mushroom cap of doom of the boozehound	0		Experience (Mysticality): +5, Spooky Spell Damage: +50, Booze Drop: +100, Last Available: "2020-03"
 10494	gray upside-down censurious deadly mushroom shield of the ox of the boozehound	0		Muscle: +20, Weapon Damage: +5, Sleaze Resistance: +3, Booze Drop: +100, Damage Reduction: 6, Last Available: "2020-03"
 10495	brainy mushroom pants of the ox of wisdom of the overflowing toilet	0		Muscle: +20, Mysticality: 20, Stench Spell Damage: +50, Last Available: "2020-03"
@@ -10376,7 +10376,7 @@
 10519	drippy enzyme	0		
 10520	drippy salt	0		
 10521	jittery drippy pigment	0		
-10522	olive mirror drippy bromide	0		
+10522	mirror olive drippy bromide	0		
 10523	drippy flux	0		
 10524	drippy stein	0		
 10525	enchanted smooth green drippy pilsner	3	drippy	Effect: "Electrolit Up", Effect Duration: 15
@@ -10389,13 +10389,13 @@
 10533	personal trainer's Samson's Guzzlr tablet	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Last Available: "2020-05"
 10534	Guzzlr cocktail set	0		Last Available: "2020-05"
 10535	lime green Guzzlrbuck	0		Last Available: "2020-05"
-10536	yellow twirling blinking Guzzlr hat	0		Last Available: "2020-05"
+10536	blinking twirling yellow Guzzlr hat	0		Last Available: "2020-05"
 10537	Guzzlr shoes	0		Single Equip, Last Available: "2020-05"
 10538	Guzzlr pants	0		Last Available: "2020-05"
 10539	occult Guzzlr souvenir stein	0		Spell Damage Percent: +25, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	special tolerable practically non-alcoholic Ghiaccio Colada	1	good	Effect: "Frigid Weapon", Effect Duration: 25, Last Available: "2020-05"
-10542	fortified mediocre skewed Sourfinger	5	decent	Last Available: "2020-05"
+10541	tolerable practically non-alcoholic special Ghiaccio Colada	1	good	Effect: "Frigid Weapon", Effect Duration: 25, Last Available: "2020-05"
+10542	mediocre fortified skewed Sourfinger	5	decent	Last Available: "2020-05"
 10543	perfectly mixed upside-down Nog-on-the-Cob	4	EPIC	Last Available: "2020-05"
 10544	perfectly mixed Steamboat	4	EPIC	Last Available: "2020-05"
 10545	mediocre watered-down Buttery Boy	2	decent	Last Available: "2020-05"
@@ -10438,9 +10438,9 @@
 10582	SpinMaster&trade; lathe	0		Last Available: "2020-08"
 10583	blurry flimsy hardwood scraps	0		Last Available: "2020-08"
 10584	chilly birch battery of the cougar	0		Moxie: +20, Cold Damage: +5, Lasts Until Rollover, Last Available: "2020-08"
-10585	upside-down beefcake's ebony epee of the ox of doom	0		Muscle: 45, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Disarming Thrust"
-10586	twirling chilly hardy smooth weeping willow wand	0		Moxie: +15, Maximum HP: +50, Cold Damage: +5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Barrage of Tears"
-10587	olive up-at-dawn baleful experienced beechwood blowgun	0		Experience: +2, Spell Damage: +25, Adventures: +5, Lasts Until Rollover, Last Available: "2020-08", Conditional Skill (Equipped): "Poison Dart"
+10585	upside-down beefcake's ebony epee of the ox of doom	0		Muscle: 45, Spooky Spell Damage: +50, Lasts Until Rollover, Conditional Skill (Equipped): "Disarming Thrust", Last Available: "2020-08"
+10586	twirling chilly hardy smooth weeping willow wand	0		Moxie: +15, Maximum HP: +50, Cold Damage: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Barrage of Tears", Last Available: "2020-08"
+10587	olive up-at-dawn baleful experienced beechwood blowgun	0		Experience: +2, Spell Damage: +25, Adventures: +5, Lasts Until Rollover, Conditional Skill (Equipped): "Poison Dart", Last Available: "2020-08"
 10588	grievous brawny maple magnet of the empath	0		Muscle Percent: +20, Weapon Damage Percent: +50, Familiar Weight: +5, Lasts Until Rollover, Last Available: "2020-08"
 10589	Dreadsylvanian hemlock	0		Last Available: "2020-08"
 10590	crafty occult savvy hemlock helm	0		Mysticality Percent: +20, Spell Damage Percent: +25, Maximum MP: +10, Last Available: "2020-08"
@@ -10460,7 +10460,7 @@
 10604	shaking Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
 10606	polymerized pickled Yeg's Motel toothbrush	0		Effect: "Creepypasted", Effect Duration: 59, Last Available: "2020-09"
-10607	concentrated boiled narrow blurry olive Yeg's Motel hand soap	0		Effect: "Thick-Skinned", Effect Duration: 17, Last Available: "2020-09"
+10607	concentrated boiled blurry olive narrow Yeg's Motel hand soap	0		Effect: "Thick-Skinned", Effect Duration: 17, Last Available: "2020-09"
 10608	squat Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	rotten upside-down Yeg's Motel pillow mint	4	crappy	Last Available: "2020-09"
 10610	Yeg's Motel disposable razor	0		Last Available: "2020-09"
@@ -10481,8 +10481,8 @@
 10625	cyan onyx rook	0		Last Available: "2020-09"
 10626	jittery onyx bishop	0		Last Available: "2020-09"
 10627	onyx knight	0		Last Available: "2020-09"
-10628	tumbling bouncing onyx pawn	0		Last Available: "2020-09"
-10629	lime green pulsating alabaster king	0		Last Available: "2020-09"
+10628	bouncing tumbling onyx pawn	0		Last Available: "2020-09"
+10629	pulsating lime green alabaster king	0		Last Available: "2020-09"
 10630	alabaster queen	0		Last Available: "2020-09"
 10631	maroon alabaster rook	0		Last Available: "2020-09"
 10632	alabaster bishop	0		Last Available: "2020-09"
@@ -10505,7 +10505,7 @@
 10649	gregarious ghostling	0		Free Pull, Last Available: "2020-12"
 10650	grinning ghostling	0		Free Pull, Last Available: "2020-12"
 10651	greedy ghostling	0		Free Pull, Last Available: "2020-12"
-10652	twirling fuchsia subscription cocoa dispenser	0		Last Available: "2020-12"
+10652	fuchsia twirling subscription cocoa dispenser	0		Last Available: "2020-12"
 10653	Vulcanized mirror fortifying hot cocoa	0		Effect: "Brocolate Brostidigitation", Effect Duration: 69, Last Available: "2020-12"
 10654	liquefied jittery boiling hot cocoa	0		Effect: "Frigid Weapon", Effect Duration: 54, Last Available: "2020-12"
 10655	deionized fuchsia cool hot cocoa	0		Effect: "Patent Avarice", Effect Duration: 52, Last Available: "2020-12"
@@ -10525,7 +10525,7 @@
 10669	jittery Newton's plastic Penny	0		Experience (Mysticality): +3, Last Available: "2020-12"
 10670	blinking overflowing gift basket	0		Last Available: "2020-12"
 10671	blurry personalized wassail stein	0		Last Available: "2020-12"
-10672	shaking gray tabletop candy dispenser	0		Last Available: "2020-12"
+10672	gray shaking tabletop candy dispenser	0		Last Available: "2020-12"
 10673	neck wreath of wisdom	0		Mysticality: [+15*event(December)], Single Equip, Last Available: "2020-12"
 10674	grievous shining star cap	0		Weapon Damage Percent: [+50*event(December)], Last Available: "2020-12"
 10675	skewed nativity shorts of the bloodbag	0		Maximum HP: [+100*event(December)], Last Available: "2020-12"
@@ -10543,7 +10543,7 @@
 10687	government candy shipment	0		Last Available: "2020-12"
 10688	Crimbo Cheer tattoo kit	0		Last Available: "2020-12"
 10689	Crimbo Carol tattoo kit	0		Last Available: "2020-12"
-10690	olive upside-down Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
+10690	upside-down olive Crimbo Commerce tattoo kit	0		Last Available: "2020-12"
 10691	skewed food drive button	0		Single Equip, Last Available: "2020-12"
 10692	olive booze drive button	0		Single Equip, Last Available: "2020-12"
 10693	bouncing candy drive button	0		Single Equip, Last Available: "2020-12"
@@ -10573,21 +10573,21 @@
 10717	spinning fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	shaking nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
 10719	goose mask	0		Familiar Weight: +5, Experience (Moxie): +3, Last Available: "2020-12"
-10720	delicious triple-distilled barrel-aged eggnog	7	awesome	Last Available: "2020-12"
+10720	triple-distilled delicious barrel-aged eggnog	7	awesome	Last Available: "2020-12"
 10721	rotten hand-crafted candy cane	3	crappy	Last Available: "2020-12"
 10722	delicious drive-thru burger	4	awesome	Last Available: "2020-12"
 10723	fancy mediocre Boulevardier cocktail	4	decent	Effect: "Altered Wavelengths", Effect Duration: 45, Last Available: "2020-12"
 10724	cold-filtered tumbling cyan Hotwire&trade; brand candy rope	0		Effect: "Cock of the Walk", Effect Duration: 63, Last Available: "2020-12"
 10725	rotten cyan bowl full of jelly	3	crappy	Last Available: "2020-12"
-10726	practically non-alcoholic hand-crafted Eye and a Twist	1	EPIC	Last Available: "2020-12"
+10726	hand-crafted practically non-alcoholic Eye and a Twist	1	EPIC	Last Available: "2020-12"
 10727	enhanced Chubby and Plump bar	0		Effect: "Reptilian Fortitude", Effect Duration: 15, Last Available: "2020-12"
 10728	digibritches	0		Last Available: "2025-12"
 10729	jittery packaged crystal ball	0		Free Pull, Last Available: "2021-01"
 10730	crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	lime green fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	green twirling fresh coat of paint	0		Last Available: "2021-12"
-10733	spinning emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
-10734	spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
+10733	spinning emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
+10734	spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	power seed	0		Free Pull, Last Available: "2021-03"
@@ -10600,19 +10600,19 @@
 10744	frozen adjusted improved battery (car)	0		Effect: "Ancestral Disapproval", Effect Duration: 21, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
-10747	tolerable upside-down twirling marshmallow bomb	3	good	Last Available: "2021-03"
+10747	tolerable twirling upside-down marshmallow bomb	3	good	Last Available: "2021-03"
 10748	yellow packaged backup camera	0		Free Pull, Last Available: "2021-04"
-10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Last Available: "2021-04", Conditional Skill (Equipped): "Back-Up to your Last Enemy"
+10749	backup camera	0		Maximum HP: +20, Maximum MP: +20, Meat Drop: +50, Single Equip, Conditional Skill (Equipped): "Back-Up to your Last Enemy", Last Available: "2021-04"
 10750	shortest-order cook	0		Free Pull, Last Available: "2021-05"
 10751	purple plate	0		Familiar Weight: +5
 10752	frozen triple-anodized altered short beer	0		Effect: "Motion", Effect Duration: 61, Last Available: "2021-05"
 10753	galvanized moist short stack of pancakes	0		Effect: "Extra Backbone", Effect Duration: 60, Last Available: "2021-05"
-10754	denatured ghostly gray short stick of butter	0		Effect: "Cold as Ice", Effect Duration: 64, Last Available: "2021-05"
+10754	denatured gray ghostly short stick of butter	0		Effect: "Cold as Ice", Effect Duration: 64, Last Available: "2021-05"
 10755	energized short glass of water	0		Effect: "Fever From the Flavor", Effect Duration: 54, Last Available: "2021-05"
 10756	boiled twirling short	0		Effect: "Izchak's Blessing", Effect Duration: 64, Last Available: "2021-05"
-10757	tumbling skewed narrow Thwaitgold quantum bug statuette	0		
-10758	green skewed quantum of familiar	0		
-10759	resourceful hale familiar scrapbook	0		Maximum HP: +20, Maximum MP: +50, Last Available: "2021-06", Conditional Skill (Equipped): "Show Your Boring Familiar Pictures"
+10757	skewed tumbling narrow Thwaitgold quantum bug statuette	0		
+10758	skewed green quantum of familiar	0		
+10759	resourceful hale familiar scrapbook	0		Maximum HP: +20, Maximum MP: +50, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
 10762	nasty MacGyver's fedora-mounted fountain of temperance	0		Maximum MP: +100, Stench Damage: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2021-07"
@@ -10621,7 +10621,7 @@
 10765	twirling rocket	0		Last Available: "2021-07"
 10766	upside-down rocket	0		Last Available: "2021-07"
 10767	rocket	0		Last Available: "2021-07"
-10768	small adequate shaking fire crackers	2	good	Last Available: "2021-07"
+10768	adequate small shaking fire crackers	2	good	Last Available: "2021-07"
 10769	Arr, M80	0		Last Available: "2021-07"
 10770	huge squat Catherine Wheel of the ox of the pedagogue	0		Muscle: +20, Experience: +3, Lasts Until Rollover, Last Available: "2021-07"
 10771	hardened rocket boots of the ox	0		Muscle: +20, Damage Reduction: 3, Single Equip, Lasts Until Rollover, Last Available: "2021-07"
@@ -10648,9 +10648,9 @@
 10792	empty nacho cheese can	0		Water: 1
 10793	literal bucket hat	0		Water: 5
 10794	rainproof barrel caulk	0		
-10795	twirling green pump grease	0		
-10796	squat red packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
-10797	medical-grade deadly savvy thinker's industrial fire extinguisher of Calamity Jane of the sewer	0		Mysticality: +10, Mysticality Percent: +20, Weapon Damage: +5, Critical Hit Percent: +15, Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2021-09", Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
+10795	green twirling pump grease	0		
+10796	red squat packaged industrial fire extinguisher	0		Free Pull, Last Available: "2021-09"
+10797	medical-grade deadly savvy thinker's industrial fire extinguisher of Calamity Jane of the sewer	0		Mysticality: +10, Mysticality Percent: +20, Weapon Damage: +5, Critical Hit Percent: +15, Stench Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific", Last Available: "2021-09"
 10798	The Nose Knows, A Guide to Smells	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10799	blurry The Nose Knows, A Guide to Smells (read)	0		Skill: "Dead Nostrils", Last Available: "2021-08"
 10800	1950 Vampire Vintner wine	1	awesome	
@@ -10661,28 +10661,28 @@
 10805	eggwater	1	good	Last Available: "2021-12"
 10806	normal bread man	3	good	Last Available: "2021-12"
 10807	tasty half-sized plain candy cane	2	awesome	Last Available: "2021-12"
-10808	flavorless massive flour cookie	10	decent	Last Available: "2021-12"
+10808	massive flavorless flour cookie	10	decent	Last Available: "2021-12"
 10809	manspreader's plastic food lab	0		Monster Level: +10, Single Equip, Last Available: "2021-12"
 10810	wobbly careful plastic nog lab	0		Monster Level: -10, Single Equip, Last Available: "2021-12"
 10811	twirling plastic chem lab of the blizzard	0		Cold Spell Damage: +25, Single Equip, Last Available: "2021-12"
 10812	nippy plastic primary lab	0		Cold Damage: +10, Single Equip, Last Available: "2021-12"
 10813	shaking energetic plastic Cheer Core	0		Maximum MP Percent: +20, Single Equip, Last Available: "2021-12"
-10814	bouncing twirling packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
+10814	twirling bouncing packaged medicine cabinet	0		Free Pull, Last Available: "2021-12"
 10815	red huge medicine cabinet	0		Last Available: "2021-12"
 10816	family-friendly manspreader's resourceful ice crown	0		Maximum MP: +50, Monster Level: +10, Sleaze Resistance: +1, Lasts Until Rollover, Last Available: "2021-12"
 10817	dance instructor's supercool jeans of the blizzard	0		Moxie Percent: +20, Experience Percent (Moxie): +10, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2021-12"
 10818	miser's ruddy dangerous ice wrap	0		Weapon Damage: +10, Maximum HP Percent: +40, Meat Drop: +10, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	adequate tofu pop	3	good	Last Available: "2021-12"
 10820	adequate fuchsia bowl of prescription candy	3	good	Last Available: "2021-12"
-10821	miniature adequate upside-down fishcake	2	good	Last Available: "2021-12"
+10821	adequate miniature upside-down fishcake	2	good	Last Available: "2021-12"
 10822	normal blinking bone broth	4	good	Last Available: "2021-12"
 10823	normal blinking star pop	3	good	Last Available: "2021-12"
-10824	drinkable enchanted narrow Doc's Fortifying Wine	4	good	Effect: "Don't Step to Your Stepmother", Effect Duration: 50, Last Available: "2021-12"
+10824	enchanted drinkable narrow Doc's Fortifying Wine	4	good	Effect: "Don't Step to Your Stepmother", Effect Duration: 50, Last Available: "2021-12"
 10825	perfectly mixed Doc's Smartifying Wine	4	EPIC	Last Available: "2021-12"
 10826	delicious fortified mirror Doc's Limbering Wine	5	awesome	Last Available: "2021-12"
 10827	mediocre shaking Doc's Medical-Grade Wine	4	decent	Last Available: "2021-12"
 10828	pickled skewed Homebodyl&trade;	1		Effect: "Unrunnable Face", Effect Duration: 5, Last Available: "2021-12"
-10829	dehydrated teal shaking Extrovermectin&trade;	1		Effect: "Standard Cheer", Effect Duration: 25, Last Available: "2021-12"
+10829	dehydrated shaking teal Extrovermectin&trade;	1		Effect: "Standard Cheer", Effect Duration: 25, Last Available: "2021-12"
 10830	twisted Breathitin&trade;	1		Last Available: "2021-12"
 10831	modified green Fleshazole&trade;	1		Last Available: "2021-12"
 10832	dry frozen anti-burn cream	0		Effect: "Piratastic", Effect Duration: 50, Last Available: "2021-12"
@@ -10693,10 +10693,10 @@
 10837	liquefied green ghostly anti-pain cream	0		Effect: "Smoking like a Bandit", Effect Duration: 11, Last Available: "2021-12"
 10838	smooth jittery pulsating Doc's Special Reserve Wine	3	awesome	Last Available: "2021-12"
 10839	toothsome big bread pie	5	awesome	Last Available: "2021-12"
-10840	practically non-alcoholic bad clear Russian	1	decent	Last Available: "2021-12"
+10840	bad practically non-alcoholic clear Russian	1	decent	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
-10843	upside-down wobbly Crimbo ball	0		Last Available: "2021-12"
+10843	wobbly upside-down Crimbo ball	0		Last Available: "2021-12"
 10844	gooified animal matter	0		Last Available: "2021-12"
 10845	gooified vegetable matter	0		Last Available: "2021-12"
 10846	gooified mineral matter	0		Last Available: "2021-12"
@@ -10706,7 +10706,7 @@
 10850	goo magnet	0		Last Available: "2021-12"
 10851	cozy scarf of the wise owl	0		Mysticality: +20, Last Available: "2021-12"
 10852	snack-sized decent huge Crimbo cookie	2	good	Last Available: "2023-06"
-10853	flattened oxidized ghostly jittery fleshy putty	0		Effect: "Shawarma Warm War", Effect Duration: 42, Last Available: "2021-12"
+10853	flattened oxidized jittery ghostly fleshy putty	0		Effect: "Shawarma Warm War", Effect Duration: 42, Last Available: "2021-12"
 10854	pulsating blurry chaotic third ear	0		Spell Critical Percent: +10, Single Equip, Last Available: "2021-12"
 10855	festive egg sac	0		Last Available: "2021-12"
 10856	blurry poisonsettia	0		Last Available: "2021-12"
@@ -10715,10 +10715,10 @@
 10859	jittery projectile chemistry set	0		Last Available: "2021-12"
 10860	bouncing wizardly depleted Crimbonium football helmet	0		Mysticality: +25, Last Available: "2021-12"
 10861	synthetic rock	0		Last Available: "2021-12"
-10862	moldy small shaking &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
+10862	small moldy shaking &quot;caramel&quot;	2	crappy	Last Available: "2021-12"
 10863	prompt self-repairing earmuffs	0		Adventures: +3, Last Available: "2021-12"
 10864	jittery savvy carnivorous potted plant	0		Mysticality Percent: +20, Last Available: "2021-12"
-10865	tumbling blue universal biscuit	0		Last Available: "2021-12"
+10865	blue tumbling universal biscuit	0		Last Available: "2021-12"
 10866	blurry wicked yule hatchet	0		Spell Damage: +5, Last Available: "2021-12"
 10867	potato alarm clock	0		Last Available: "2021-12"
 10868	rotten lab-grown meat	3	crappy	Last Available: "2021-12"
@@ -10736,12 +10736,12 @@
 10880	pickled mirror fried air	1		Last Available: "2021-12"
 10881	11-leaf clover	0		
 10882	carton of astral energy drinks	0		
-10883	dehydrated ghostly bouncing astral energy drink	1		Effect: "From Nantucket", Effect Duration: 40
+10883	dehydrated bouncing ghostly astral energy drink	1		Effect: "From Nantucket", Effect Duration: 40
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	yellow resourceful Sinatra's Samson's magnifying glass	0		Experience (Muscle): +5, Experience (Moxie): +5, Maximum MP: +50, Last Available: "2022-12"
 10886	delicious watered-down olive void lager	2	awesome	Last Available: "2022-12"
-10887	fancy rotten half-sized void burger	2	crappy	Effect: "Motion", Effect Duration: 15, Last Available: "2022-12"
-10888	lime green narrow tumbling void stone	0		Last Available: "2022-12"
+10887	half-sized fancy rotten void burger	2	crappy	Effect: "Motion", Effect Duration: 15, Last Available: "2022-12"
+10888	narrow lime green tumbling void stone	0		Last Available: "2022-12"
 10889	huge mirror Usain Bolt's horrifying wholesome brawny void shard	0		Muscle Percent: +20, Maximum HP Percent: +10, Spooky Damage: +25, Initiative: +80, Last Available: "2022-12"
 10890	undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	skewed cosmic bowling ball	0		Last Available: "2022-01"
@@ -10767,29 +10767,29 @@
 10911	liquefied liquefied gaffer's tape	0		Effect: "Gunky Dory", Effect Duration: 68, Last Available: "2022-05"
 10912	small normal 20-lb can of rice and beans	2	good	Last Available: "2022-05"
 10913	bar of freeze-dried water	1	EPIC	Last Available: "2022-05"
-10914	adequate gigantic upside-down expired MRE	9	good	Last Available: "2022-05"
-10915	bland thick teal cool mint precipice bar	5	decent	Last Available: "2022-05"
-10916	special rotten small blinking carrot cake precipice bar	2	crappy	Effect: "Creepin' Up on You", Effect Duration: 50, Last Available: "2022-05"
+10914	gigantic adequate upside-down expired MRE	9	good	Last Available: "2022-05"
+10915	thick bland teal cool mint precipice bar	5	decent	Last Available: "2022-05"
+10916	rotten small special blinking carrot cake precipice bar	2	crappy	Effect: "Creepin' Up on You", Effect Duration: 50, Last Available: "2022-05"
 10917	The Big Book of Every Skill	0		
 10918	twirling Thwaitgold harvestman statuette	0		
 10919	ghostly packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	family-friendly fireproof educational June cleaver	0		Experience: +1, Hot Resistance: +3, Sleaze Resistance: +1, Attacks Can't Miss, Last Available: "2022-06"
-10921	extra-dry tolerable Dad's brandy	5	good	Last Available: "2022-06"
+10921	tolerable extra-dry Dad's brandy	5	good	Last Available: "2022-06"
 10922	spinning razor-sharp teacher's pen of Calamity Jane	0		Weapon Damage Percent: +25, Critical Hit Percent: +15, Last Available: "2022-06"
 10923	tiny normal fire-roasted lake trout	1	good	Last Available: "2022-06"
-10924	snack-sized rotten guilty sprout	2	crappy	Last Available: "2022-06"
+10924	rotten snack-sized guilty sprout	2	crappy	Last Available: "2022-06"
 10925	banded Sinatra's mother's necklace	0		Experience (Moxie): +5, Damage Absorption: +100, Last Available: "2022-06"
 10926	deionized flattened trampled ticket stub	0		Effect: "Joyful Resolve", Effect Duration: 49, Last Available: "2022-06"
 10927	corrupted cyan savings bond	0		Effect: "Flagrantly Fragrant", Effect Duration: 16, Last Available: "2022-06"
 10928	designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	ghostly designer sweatpants	0		Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+10929	ghostly designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	altered skewed sweat-ade	1		Effect: "Granolarrrgh", Effect Duration: 40, Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	skewed stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
 10933	thick dinosaur	0		
 10934	cyan dinosaur scale	0		
 10935	pristine dinosaur feather	0		
-10936	huge tumbling nasty dinosaur spike	0		
+10936	tumbling huge nasty dinosaur spike	0		
 10937	Van der Graaf pterodactyl rifle	0		MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Snipe Pterodactyl"
 10938	birdseed hat	0		
 10939	blurry flatusaur gasmask	0		
@@ -10805,7 +10805,7 @@
 10949	frosty dinosaur	0		Cold Spell Damage: +10
 10950	Thwaitgold mosquito-in-amber statuette	0		
 10951	purple packaged Jurassic Parka	0		Free Pull, Last Available: "2022-09"
-10952	ribald scandalous Jurassic Parka	0		Sleaze Damage: 15, Last Available: "2022-09", Conditional Skill (Equipped): "Engage ultra-attractive parka mode"
+10952	ribald scandalous Jurassic Parka	0		Sleaze Damage: 15, Conditional Skill (Equipped): "Engage ultra-attractive parka mode", Last Available: "2022-09"
 10953	boxed autumn-aton	0		Free Pull, Last Available: "2022-10"
 10954	autumn-aton	0		Last Available: "2022-10"
 10955	modified double-ionized autumn leaf	0		Effect: "Healthy Green Glow", Effect Duration: 55, Last Available: "2022-10"
@@ -10829,12 +10829,12 @@
 10973	yummy St. Pete's sneaky smoothie	3	awesome	Last Available: "2022-11"
 10974	normal blurry Pete's wiley whey bar	4	good	Last Available: "2022-11"
 10975	spoiled Pete's rich ricotta	4	crappy	Last Available: "2022-11"
-10976	boozy tolerable wobbly Boris's beer	5	good	Last Available: "2022-11"
+10976	tolerable boozy wobbly Boris's beer	5	good	Last Available: "2022-11"
 10977	small flavorless honey bun of Boris	2	decent	Last Available: "2022-11"
 10978	yummy gigantic Boris's bread	10	awesome	Last Available: "2022-11"
 10979	red Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
 10980	wobbly Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
-10981	lime green ghostly Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10981	ghostly lime green Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
 10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
 10983	huge Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
 10984	Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
@@ -10842,7 +10842,7 @@
 10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
 10987	narrow Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	diet toothsome blinking baked veggie ricotta casserole	1	awesome	Last Available: "2022-11"
-10989	diet spoiled plain calzone	1	crappy	Last Available: "2022-11"
+10989	spoiled diet plain calzone	1	crappy	Last Available: "2022-11"
 10990	diet decent roasted vegetable focaccia	1	good	Last Available: "2022-11"
 10991	small rotten Pizza of Legend	2	crappy	Last Available: "2022-11"
 10992	normal thick fuchsia Calzone of Legend	5	good	Last Available: "2022-11"
@@ -10853,7 +10853,7 @@
 10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
 10999	Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
-11000	rotten gigantic Deep Dish of Legend	6	crappy	Last Available: "2022-11"
+11000	gigantic rotten Deep Dish of Legend	6	crappy	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	tumbling government per-diem	0		
@@ -10871,14 +10871,14 @@
 11015	hand-crafted wobbly Marltini	4	EPIC	
 11016	perfectly mixed Strong, Silent Type	4	EPIC	
 11017	bad narrow Mysterious Stranger	4	decent	
-11018	watered-down tolerable Champagne Shimmy	2	good	
+11018	tolerable watered-down Champagne Shimmy	2	good	
 11019	gray the Sot's parcel	0		
-11020	miser's sage ceramic cestus	0		Mysticality Percent: +10, Meat Drop: +10, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Punch"
-11021	knitted ceramic centurion shield of the blizzard of temperance	0		Cold Spell Damage: +25, Cold Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 9, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Bash"
-11022	horrifying ceramic celery grater of the businessman	0		Spooky Damage: +25, Meat Drop: +50, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Grate"
-11023	jittery flame-retardant therapeutic Newton's ceramic celsiturometer	0		Experience (Mysticality): +3, Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Boil"
-11024	frightening hale Da Vinci's ceramic cerecloth belt	0		Experience (Mysticality): +5, Maximum HP: +20, Spooky Damage: +5, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Skullgaze"
-11025	pulsating knitted manspreader's MacGyver's ceramic cenobite's robe	0		Maximum MP: +100, Monster Level: +10, Cold Resistance: +3, Last Available: "2023-12", Conditional Skill (Equipped): "Ceramic Cenobitize"
+11020	miser's sage ceramic cestus	0		Mysticality Percent: +10, Meat Drop: +10, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
+11021	knitted ceramic centurion shield of the blizzard of temperance	0		Cold Spell Damage: +25, Cold Resistance: +3, Sleaze Resistance: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Ceramic Bash", Last Available: "2023-12"
+11022	horrifying ceramic celery grater of the businessman	0		Spooky Damage: +25, Meat Drop: +50, Conditional Skill (Equipped): "Ceramic Grate", Last Available: "2023-12"
+11023	jittery flame-retardant therapeutic Newton's ceramic celsiturometer	0		Experience (Mysticality): +3, Hot Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Conditional Skill (Equipped): "Ceramic Boil", Last Available: "2023-12"
+11024	frightening hale Da Vinci's ceramic cerecloth belt	0		Experience (Mysticality): +5, Maximum HP: +20, Spooky Damage: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Skullgaze", Last Available: "2023-12"
+11025	pulsating knitted manspreader's MacGyver's ceramic cenobite's robe	0		Maximum MP: +100, Monster Level: +10, Cold Resistance: +3, Conditional Skill (Equipped): "Ceramic Cenobitize", Last Available: "2023-12"
 11026	vaporized lime green ceramic scree	1		Effect: "Action", Effect Duration: 40, Last Available: "2023-12"
 11027	double-liquefied cold-filtered extra-hard jawbreaker	0		Effect: "What's That Smell?", Effect Duration: 41
 11028	hardened wicked chiffon chevrons of vim and vigor	0		Spell Damage: +5, Damage Reduction: 3, Maximum HP Percent: +50, Single Equip, Last Available: "2023-12"
@@ -10897,7 +10897,7 @@
 11041	cool plastic dining car	0		Moxie: +5, Last Available: "2022-12"
 11042	green forbidden plastic coal car of the pedagogue	0		Experience: +3, Spell Damage Percent: +50, Last Available: "2022-12"
 11043	gray sinister plastic locomotive	0		Spell Damage: +10, Last Available: "2022-12"
-11044	blinking teal jittery packaged model train set	0		Free Pull, Last Available: "2022-12"
+11044	teal blinking jittery packaged model train set	0		Free Pull, Last Available: "2022-12"
 11045	jittery model train set	0		Last Available: "2022-12"
 11046	mirror Crimbo training manual	0		
 11047	Abuela Crimbo's special magnet	0		
@@ -10920,7 +10920,7 @@
 11064	mirror occult shoulder-mounted Trainbot of vim and vigor of Calamity Jane	0		Spell Damage Percent: +25, Maximum HP Percent: +50, Critical Hit Percent: +15, Single Equip, Last Available: "2022-12"
 11065	wobbly cinnamon machine oil	0		
 11066	Crimbo crystal shards	0		
-11067	triple-distilled drinkable dregs of a Crimbo cocktail	7	good	
+11067	drinkable triple-distilled dregs of a Crimbo cocktail	7	good	
 11068	lost elf luggage	0		
 11069	Trainbot luggage hook	0		Single Equip
 11070	adequate honey-drenched ham slice	4	good	
@@ -10934,7 +10934,7 @@
 11078	decent steamed oyster	4	good	
 11079	really nice lump of coal	0		
 11080	deactivated mini-Trainbot	0		Last Available: "2022-12"
-11081	ghostly wobbly lime green steam unit	0		Last Available: "2022-12"
+11081	lime green ghostly wobbly steam unit	0		Last Available: "2022-12"
 11082	crystal Crimbo goblet	0		
 11083	crystal Crimbo platter	0		
 11084	bad spinning Crimbosmopolitan	4	decent	Last Available: "2022-12"
@@ -10950,12 +10950,12 @@
 11094	stanky Jim Carey's grubby wool trousers of the dark arts	0		Spell Damage Percent: +100, Monster Level: +25, Stench Spell Damage: +25
 11095	tumbling nippy smooth grubby wool gloves of the brazier of the glutton	0		Moxie: +15, Cold Damage: +10, Hot Spell Damage: +25, Food Drop: +100, Single Equip
 11096	blinking mirror grubby wool beerwarmer	0		
-11097	lousy irresponsibly strong nice warm beer	10	decent	
+11097	irresponsibly strong lousy nice warm beer	10	decent	
 11098	grubby woolball	0		
 11099	maroon Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
 11100	packet of rock seeds	0		Last Available: "2023-01"
 11101	spinning groveling gravel	0		Last Available: "2023-01"
-11102	altered blurry twirling fruity pebble	1		Effect: "Grrrrrrreat!", Effect Duration: 30, Last Available: "2023-01"
+11102	altered twirling blurry fruity pebble	1		Effect: "Grrrrrrreat!", Effect Duration: 30, Last Available: "2023-01"
 11103	wobbly lodestone	0		Effect: "Loded", Effect Duration: 5, Last Available: "2023-01"
 11104	ghostly milestone	0		Last Available: "2023-01"
 11105	twirling bolder boulder	0		Last Available: "2023-01"
@@ -10964,7 +10964,7 @@
 11108	hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
-11112	super-sized yummy pixel bread	5	awesome	
+11112	yummy super-sized pixel bread	5	awesome	
 11113	artisanal pixel whiskey	3	EPIC	
 11114	olive pixel rock	0		
 11115	S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
@@ -10972,10 +10972,10 @@
 11117	extra-aerosolized huge glob of extra-green chlorophyll	0		Effect: "Executive Greed", Effect Duration: 53, Last Available: "2023-02"
 11118	diffused Vulcanized pulsating mushroom	0		Effect: "Texas Elegance", Effect Duration: 21, Last Available: "2023-02"
 11119	aerosolized five-fingered fern resin	0		Effect: "Flashing Eyes", Effect Duration: 42, Last Available: "2023-02"
-11120	moldy half-sized jittery gray super good fruit	2	crappy	Last Available: "2023-02"
+11120	half-sized moldy gray jittery super good fruit	2	crappy	Last Available: "2023-02"
 11121	compressed green energized spores	1		Last Available: "2023-02"
 11122	gravedigger's friendly hot pepper	0		Familiar Weight: +3, Spooky Damage: +10, Last Available: "2023-02", Lantern Element: "Hot"
-11123	corrupted quantum blinking pulsating mirror out-of-work circus flea	0		Effect: "Oleaginous Soles", Effect Duration: 24, Last Available: "2023-02"
+11123	corrupted quantum mirror pulsating blinking out-of-work circus flea	0		Effect: "Oleaginous Soles", Effect Duration: 24, Last Available: "2023-02"
 11124	jittery extra-grubby grub	0		Last Available: "2023-02"
 11125	improved triple-electrified shaking fire ant pheromones	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 58, Last Available: "2023-02"
 11126	polarized Vulcanized flapper fly	0		Effect: "Unrunnable Face", Effect Duration: 66, Last Available: "2023-02"
@@ -10994,10 +10994,10 @@
 11139	bouncing shadow ice	0		Last Available: "2023-03"
 11140	acceptable twirling shadow fluid	4	good	Last Available: "2023-03"
 11141	lime green shadow glass	0		Last Available: "2023-03"
-11142	squat mirror shadow brick	0		Last Available: "2023-03"
-11143	cyan shaking squat shadow sinew	0		Last Available: "2023-03"
+11142	mirror squat shadow brick	0		Last Available: "2023-03"
+11143	cyan squat shaking shadow sinew	0		Last Available: "2023-03"
 11144	hand-crafted shadow venom	3	EPIC	Last Available: "2023-03"
-11145	powdered shaking jittery shadow nectar	1		Last Available: "2023-03"
+11145	powdered jittery shaking shadow nectar	1		Last Available: "2023-03"
 11146	ghostly beefcake's shadow stick of temperance	0		Muscle: +25, Sleaze Resistance: +5, Item Drop: +5, Last Available: "2023-03"
 11147	greedy friendly bat paw	0		Familiar Weight: +3, Meat Drop: +20
 11148	lard-coated uncursed bat paw	0		Sleaze Spell Damage: +25
@@ -11034,11 +11034,11 @@
 11179	ribald smelly shadow hammer	0		Stench Spell Damage: +10, Sleaze Damage: +10
 11180	blurry blinking manspreader's vibrating ruddy shadow monocle	0		Maximum HP Percent: +40, Maximum MP Percent: +10, Monster Level: +10, Single Equip
 11181	shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
-11182	decent miniature shadow hot dog	2	good	
+11182	miniature decent shadow hot dog	2	good	
 11183	tolerable shadow martini	4	good	
 11184	pickled bouncing pulsating shadow pill	1		
 11185	fuchsia shadow needle	0		
-11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Last Available: "2023-04", Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch"
+11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
 11187	monkey glove	0		Free Pull, Last Available: "2023-04"
 11188	improved deionized jittery shadow candy	0		Effect: "Bear Clawed", Effect Duration: 61
 11189	replica Mr. Accessory	0		
@@ -11075,8 +11075,8 @@
 11220	replica over-the-shoulder Folder Holder	0		
 11221	replica Order of the Green Thumb Order Form	0		
 11222	shrink-wrapped Cincho de Mayo	0		Free Pull, Last Available: "2023-05"
-11223	yellow up-at-dawn supercharged arcane researcher's Cincho de Mayo of Gandalf	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Adventures: +5, Last Available: "2023-05", Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
-11224	ghostly green dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
+11223	yellow up-at-dawn supercharged arcane researcher's Cincho de Mayo of Gandalf	0		Experience Percent (Mysticality): +10, Maximum MP Percent: +30, Spell Critical Percent: +20, Adventures: +5, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza", Last Available: "2023-05"
+11224	green ghostly dedigitizer schematic: psilocyber mushroom	0		Last Available: "2025-12"
 11225	lime green replica Little Geneticist DNA-Splicing Lab	0		
 11226	replica still grill	0		
 11227	replica Crimbo sapling	0		
@@ -11103,7 +11103,7 @@
 11248	replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	rosewater-soaked frosty replica Jurassic Parka	0		Cold Spell Damage: +10, Stench Resistance: +3
 11250	replica grey gosling	0		
-11251	replica designer sweatpants	0		Conditional Skill (Inventory): "Sweat Out Some Booze", Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat"
+11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
 11253	squat replica Ten Dollars	0		
 11254	nippy experienced replica Cincho de Mayo of the empath of courage	0		Experience: +2, Familiar Weight: +5, Cold Damage: +10, Spooky Resistance: +3, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
@@ -11112,13 +11112,13 @@
 11257	blinking 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11258	blurry foul-smelling vibrating Da Vinci's boxer's wizardly &quot;I survived Y2K&quot; T-Shirt of vim and vigor	0		Mysticality: +25, Muscle Percent: +10, Experience (Mysticality): +5, Maximum HP Percent: +50, Maximum MP Percent: +10, Stench Damage: +10, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
-11260	blinking huge foul-smelling pro skateboard of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +10, Last Available: "2023-06", Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!"
+11260	blinking huge foul-smelling pro skateboard of the dark arts	0		Spell Damage Percent: +100, Stench Damage: +10, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
 11261	spinning Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	red Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	tumbling Charter: Nellyville	0		Last Available: "2023-06"
-11265	Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
-11266	ghostly scandalous Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Damage: +5, Last Available: "2023-06", Conditional Skill (Equipped): "Douse Foe"
+11265	Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11266	ghostly scandalous Flash Liquidizer Ultra Dousing Accessory	0		Sleaze Damage: +5, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	lightning-fast fireproof banded dance instructor's Amulet of Perpetual Darkness	0		Experience Percent (Moxie): +10, Damage Absorption: +100, Hot Resistance: +3, Initiative: +40, Last Available: "2023-06"
 11268	blurry Giant monolith	0		Last Available: "2023-06"
 11269	skewed Crimbo cookie sheet	0		Last Available: "2023-06"
@@ -11134,7 +11134,7 @@
 11279	shaking Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
 11280	gray shaking Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	upside-down Mr. Big's Wallet	0		Last Available: "2023-06"
-11282	practically non-alcoholic artisanal blue Sexy Cosmo	1	super ultra mega turbo EPIC	Last Available: "2023-06"
+11282	artisanal practically non-alcoholic blue Sexy Cosmo	1	super ultra mega turbo EPIC	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	Jeselnik's red-soled high heels of the dark arts of Leguizamo	0		Spell Damage Percent: +100, Monster Level: +20, Sleaze Damage: +25, Last Available: "2023-06"
 11285	gigantic normal ghostly cyburger	10	good	Last Available: "2025-12"
@@ -11146,13 +11146,13 @@
 11291	boxer's spider leg	0		Muscle Percent: +10
 11292	beetle antenna of the brazier	0		Hot Spell Damage: +25
 11293	mantis skull of chilblains	0		Cold Damage: +25
-11294	concentrated oxidized ghostly green chitin powder	0		Effect: "Orchid Blood", Effect Duration: 49
+11294	concentrated oxidized green ghostly chitin powder	0		Effect: "Orchid Blood", Effect Duration: 49
 11295	pulsating scorching hardened daddy shortlegs leg	0		Damage Reduction: 3, Hot Damage: +25
 11296	asbestos-lined birdybug antenna of vim and vigor	0		Maximum HP Percent: +50, Hot Resistance: +5
 11297	chilly hale kilopede skull	0		Maximum HP: +20, Cold Damage: +5
 11298	diffused extra-polarized deionized haemolymphnode	0		Effect: "Good Karma", Effect Duration: 55
 11299	chilled chitin powder paste	0		Effect: "Sweet and Red", Effect Duration: 35
-11300	twirling cyan mirror sleeping patriotic eagle	0		Free Pull
+11300	mirror cyan twirling sleeping patriotic eagle	0		Free Pull
 11301	claw-held flag	0		Familiar Weight: +5
 11302	souvenir flag	0		
 11303	jittery name change form	0		
@@ -11172,21 +11172,21 @@
 11317	mirror handful of toilet paper	0		
 11318	ghostly Mrs. Rush	0		
 11319	medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
-11320	high-proof artisanal bottle of Cabernet Sauvignon	7	EPIC	
+11320	artisanal high-proof bottle of Cabernet Sauvignon	7	EPIC	
 11321	hale occult cool baywatch	0		Moxie: +5, Spell Damage Percent: +25, Maximum HP: +20, Lasts Until Rollover
-11322	Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
-11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11322	Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
 11324	consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	squat Thwaitgold fairyfly statue	0		
 11327	residual chitin paste	0		Skill: "Chitinous Soul"
 11328	dehydrated concentrated cooking	1		
 11329	dried meat	1		
-11330	modified tumbling yellow upside-down sparkling orb	1		
+11330	modified upside-down yellow tumbling sparkling orb	1		
 11331	vaporized hardening cream	1		Effect: "Standard Issue Bravery", Effect Duration: 30
 11332	denatured gray pool shark hair oil	1		
 11333	shaking book of facts	0		Skill: "Just the Facts", Last Available: "2023-09"
-11334	squat blurry blue book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
+11334	blurry blue squat book of facts (dog-eared)	0		Skill: "Just the Facts", Last Available: "2023-09"
 11335	Dark Jill-of-All-Trades	0		Free Pull, Last Available: "2023-10"
 11336	LED candle	0		Familiar Weight: +5, Last Available: "2023-10"
 11337	map to a candy-rich block	0		Last Available: "2023-10"
@@ -11196,7 +11196,7 @@
 11341	blinking wobbly inflammable leaf	0		
 11342	green rake	0		Item Drop: +1
 11343	squat stiffened rake	0		Damage Reduction: 1
-11344	upside-down blinking autumnic bomb	0		
+11344	blinking upside-down autumnic bomb	0		
 11345	forest canopy bed	0		
 11346	purple day shortener	0		
 11347	extra time	0		
@@ -11253,14 +11253,14 @@
 11398	wobbly military-grade peppermint oil	0		Last Available: "2023-12"
 11399	Crimbuccaneer whale oil	0		Last Available: "2023-12"
 11400	Elf Guard tinsel grenade	0		Last Available: "2023-12"
-11401	practically non-alcoholic mediocre Crimbuccaneer mologrog cocktail	1	decent	Last Available: "2023-12"
+11401	mediocre practically non-alcoholic Crimbuccaneer mologrog cocktail	1	decent	Last Available: "2023-12"
 11402	Elf Army machine parts	0		Last Available: "2023-12"
 11403	Crimbuccaneer rigging lasso	0		Last Available: "2023-12"
 11404	nippy experienced strapping Crimbuccaneer lantern	0		Muscle: +5, Experience: +2, Cold Damage: +10, Last Available: "2023-12"
 11405	Crimbuccaneer flotsam	0		Last Available: "2023-12"
 11406	Crimbuccaneer invasion map	0		Last Available: "2023-12"
 11407	greedy Crimbuccaneer shirt	0		Meat Drop: [+20*event(December)], Last Available: "2023-12"
-11408	mirror shaking Elf Guard MPC	0		Last Available: "2023-12"
+11408	shaking mirror Elf Guard MPC	0		Last Available: "2023-12"
 11409	Crimbuccaneer piece of 12	0		Last Available: "2023-12"
 11410	blue ribald Elf Guard commandeering gloves	0		Sleaze Damage: +10, Single Equip, Last Available: "2023-12"
 11411	concentrated Elf Guard eyedrops	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 24, Last Available: "2023-12"
@@ -11278,7 +11278,7 @@
 11423	rotten enchanted grog nuts	4	crappy	Effect: "Nightstalkin'", Effect Duration: 45, Last Available: "2023-12"
 11424	wobbly wool Jim Carey's thinker's sawed-off blunderbuss	0		Mysticality: +10, Monster Level: +25, Cold Resistance: +1, Last Available: "2023-12"
 11425	practically non-alcoholic drinkable yellow officer's nog	1	good	Last Available: "2023-12"
-11426	ghostly shaking peppermint bomb	0		Last Available: "2023-12"
+11426	shaking ghostly peppermint bomb	0		Last Available: "2023-12"
 11427	toothsome sundae ration	4	awesome	Last Available: "2023-12"
 11428	bland spinning peppermint tack	3	decent	Last Available: "2023-12"
 11429	shaking Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
@@ -11307,19 +11307,19 @@
 11452	flame-wreathed quilted occult Fonzie's supercool Elf dessert spoon of extreme caution	0		Moxie Percent: +20, Experience (Moxie): +1, Spell Damage Percent: +25, Damage Absorption: +40, Monster Level: -25, Hot Spell Damage: +10, Last Available: "2023-12"
 11453	scandalous Elf Guard SCUBA tank of extreme caution	0		Monster Level: -25, Sleaze Damage: +5, Last Available: "2023-12"
 11454	narrow Elf Guard Field Manual: Wilderness Sleeping	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
-11455	cyan blinking aromatic mansplainer's free boots	0		Monster Level: +15, Stench Resistance: +1, Single Equip, Last Available: "2023-12", Conditional Skill (Equipped): "The Old One-Two (Kick)"
+11455	cyan blinking aromatic mansplainer's free boots	0		Monster Level: +15, Stench Resistance: +1, Single Equip, Conditional Skill (Equipped): "The Old One-Two (Kick)", Last Available: "2023-12"
 11456	baby rigging snake	0		Last Available: "2023-12"
 11457	lard-coated sharpshooter's Elvish underarmor of the businessman	0		Critical Hit Percent: +10, Sleaze Spell Damage: +25, Meat Drop: +50, Single Equip, Last Available: "2023-12"
 11458	wobbly asbestos-lined Van der Graaf Crimbuccaneer bombjacket	0		Hot Resistance: +5, MP Regen Min: 5, MP Regen Max: 7, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	moldy sugarplum ration	3	crappy	Last Available: "2023-12"
 11460	bite-sized decent gingerbread nylons	1	good	Last Available: "2023-12"
 11461	bland upside-down rum-soaked fruitcake	3	decent	Last Available: "2023-12"
-11462	spoiled huge lime	8	crappy	Last Available: "2023-12"
-11463	rotten snack-sized cyan twirling gingerbread pirate	2	crappy	Last Available: "2023-12"
-11464	rotten super-sized fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
+11462	huge spoiled lime	8	crappy	Last Available: "2023-12"
+11463	snack-sized rotten twirling cyan gingerbread pirate	2	crappy	Last Available: "2023-12"
+11464	super-sized rotten fruit-stuffed rumcake	5	crappy	Last Available: "2023-12"
 11465	lousy boozy mulled wine	5	decent	Last Available: "2023-12"
-11466	acceptable spinning skewed Swedish coffee	3	good	Last Available: "2023-12"
-11467	lousy watered-down squat canteen of eggnog	2	decent	Last Available: "2023-12"
+11466	acceptable skewed spinning Swedish coffee	3	good	Last Available: "2023-12"
+11467	watered-down lousy squat canteen of eggnog	2	decent	Last Available: "2023-12"
 11468	artisanal hot wine	4	EPIC	Last Available: "2023-12"
 11469	tolerable Jamaican coffee	3	good	Last Available: "2023-12"
 11470	delicious flask of egggrog	3	awesome	Last Available: "2023-12"
@@ -11329,11 +11329,11 @@
 11474	hand-crafted yule grog	3	EPIC	Last Available: "2023-12"
 11475	moldy wet tack	3	crappy	Last Available: "2023-12"
 11476	diet spoiled whalecake	1	crappy	Last Available: "2023-12"
-11477	blinking Sinatra's savvy gunwale whalegun of the sewer	0		Mysticality Percent: +20, Experience (Moxie): +5, Stench Damage: +25, Last Available: "2023-12", Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!"
+11477	blinking Sinatra's savvy gunwale whalegun of the sewer	0		Mysticality Percent: +20, Experience (Moxie): +5, Stench Damage: +25, Conditional Skill (Equipped): "Shoot, Gunwale Whalegun, Shoot!", Last Available: "2023-12"
 11478	acceptable fuchsia and claret	4	good	Last Available: "2023-12"
 11479	pulsating rigging knot	0		Familiar Weight: +5
 11480	tumbling trick coin	0		Last Available: "2023-12"
-11481	razor-sharp Elf Guard squirtgun of the scaredy-cat	0		Weapon Damage Percent: +25, Monster Level: -15, Last Available: "2023-12", Conditional Skill (Equipped): "Peppermint Squirt"
+11481	razor-sharp Elf Guard squirtgun of the scaredy-cat	0		Weapon Damage Percent: +25, Monster Level: -15, Conditional Skill (Equipped): "Peppermint Squirt", Last Available: "2023-12"
 11482	spinning chest of &quot;pirate gold&quot;	0		Last Available: "2023-12"
 11483	mirror rosy-cheeked sequin-encrusted sweater	0		Maximum HP Percent: +30, Last Available: "2023-12"
 11484	mirror lime green reassuring deadly replica Elf Guard medal of mayonnaise	0		Weapon Damage: +5, Sleaze Spell Damage: +50, Spooky Resistance: +1, Last Available: "2023-12"
@@ -11344,7 +11344,7 @@
 11489	My First Paycheck envelope	0		Last Available: "2023-12"
 11490	miser's wicked supercool barnacle-encrusted sweater	0		Moxie Percent: +20, Spell Damage: +5, Meat Drop: +10, Last Available: "2023-12"
 11491	horrifying Socratic cool Crimbuccaneer nose ring	0		Moxie: +5, Experience (Mysticality): +1, Spooky Damage: +25, Last Available: "2023-12"
-11492	mirror fuchsia pet anchor	0		Last Available: "2023-12"
+11492	fuchsia mirror pet anchor	0		Last Available: "2023-12"
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	mirror Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
@@ -11356,11 +11356,11 @@
 11501	Elf Guard Field Manual: Wilderness Sleeping (used)	0		Skill: "Elf Guard Relaxation Techniques", Last Available: "2023-12"
 11502	electrified magnetized military candy cane	0		Effect: "Just the Brown Ones", Effect Duration: 19
 11503	deionized super-ionized triple-oxidized red groggipop	0		Effect: "Belch the Rainbow&trade;", Effect Duration: 39
-11504	moss mace of dire peril of mayonnaise	0		Weapon Damage: +20, Sleaze Spell Damage: +50, Last Available: "2024-12", Conditional Skill (Equipped): "Moss Mugging"
-11505	wholesome occult moss megaphone	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Megaphone Whisper"
-11506	electrified moss medal of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2024-12", Conditional Skill (Equipped): "Brandish Moss Medal"
-11507	squat rosewater-soaked Socratic moss mitre	0		Experience (Mysticality): +1, Stench Resistance: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Soul Genuflection"
-11508	moss mantle of wisdom of the detective	0		Mysticality: +15, Item Drop: +20, Last Available: "2024-12", Conditional Skill (Equipped): "Drop Mantle"
+11504	moss mace of dire peril of mayonnaise	0		Weapon Damage: +20, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Moss Mugging", Last Available: "2024-12"
+11505	wholesome occult moss megaphone	0		Spell Damage Percent: +25, Maximum HP Percent: +10, Conditional Skill (Equipped): "Megaphone Whisper", Last Available: "2024-12"
+11506	electrified moss medal of Calamity Jane	0		Critical Hit Percent: +15, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Brandish Moss Medal", Last Available: "2024-12"
+11507	squat rosewater-soaked Socratic moss mitre	0		Experience (Mysticality): +1, Stench Resistance: +3, Conditional Skill (Equipped): "Soul Genuflection", Last Available: "2024-12"
+11508	moss mantle of wisdom of the detective	0		Mysticality: +15, Item Drop: +20, Conditional Skill (Equipped): "Drop Mantle", Last Available: "2024-12"
 11509	greasy moss marlinspike of the ox	0		Muscle: +20, Sleaze Spell Damage: +10, Extra Pickpocket, Single Equip, Last Available: "2024-12"
 11510	modified moss mulch	1		Last Available: "2024-12"
 11511	vacuum-sealed polymerized wobbly moss floss	0		Effect: "Dweeby", Effect Duration: 29
@@ -11372,12 +11372,12 @@
 11517	olive adobe abaya	0		Last Available: "2024-12"
 11518	dried adobe assortment	1		Effect: "Fishy Fortification", Effect Duration: 15, Last Available: "2024-12"
 11519	quadruple-dry mirror adobe brittle	0		Effect: "Floundering", Effect Duration: 24
-11520	Newton's smooth crepe paper phrygian cap of wisdom	0		Mysticality: +15, Moxie: +15, Experience (Mysticality): +3, Last Available: "2025-12", Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap"
+11520	Newton's smooth crepe paper phrygian cap of wisdom	0		Mysticality: +15, Moxie: +15, Experience (Mysticality): +3, Conditional Skill (Equipped): "Pull down your crepe paper phrygian cap", Last Available: "2025-12"
 11521	gray prompt hardy experienced crepe paper parachute cape	0		Experience: +2, Maximum HP: +50, Adventures: +3, Last Available: "2025-12"
-11522	wobbly clever wicked thinker's crepe paper pie clip	0		Mysticality: +10, Spell Damage: +5, Maximum MP: +20, Last Available: "2025-12", Conditional Skill (Equipped): "Look through your crepe paper pie clip"
-11523	flame-wreathed hardened crepe paper puzzle cube of the glutton	0		Damage Reduction: 3, Hot Spell Damage: +10, Food Drop: +100, Last Available: "2025-12", Conditional Skill (Equipped): "Play with your crepe paper puzzle"
-11524	knitted Fonzie's crepe paper plunge camisole of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Cold Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Leave nothing to the imagination"
-11525	fireproof rock-hard Da Vinci's crepe paper polka charm	0		Experience (Mysticality): +5, Damage Reduction: 5, Hot Resistance: +3, Last Available: "2025-12", Conditional Skill (Equipped): "Embrace polka"
+11522	wobbly clever wicked thinker's crepe paper pie clip	0		Mysticality: +10, Spell Damage: +5, Maximum MP: +20, Conditional Skill (Equipped): "Look through your crepe paper pie clip", Last Available: "2025-12"
+11523	flame-wreathed hardened crepe paper puzzle cube of the glutton	0		Damage Reduction: 3, Hot Spell Damage: +10, Food Drop: +100, Conditional Skill (Equipped): "Play with your crepe paper puzzle", Last Available: "2025-12"
+11524	knitted Fonzie's crepe paper plunge camisole of mayonnaise	0		Experience (Moxie): +1, Sleaze Spell Damage: +50, Cold Resistance: +3, Conditional Skill (Equipped): "Leave nothing to the imagination", Last Available: "2025-12"
+11525	fireproof rock-hard Da Vinci's crepe paper polka charm	0		Experience (Mysticality): +5, Damage Reduction: 5, Hot Resistance: +3, Conditional Skill (Equipped): "Embrace polka", Last Available: "2025-12"
 11526	dried crepe paper pared cuttings	1		Last Available: "2025-12"
 11527	dry crepe paper peanut candy	0		Effect: "Tightly-Wound Spine", Effect Duration: 12
 11528	dangerous smartaleck's petrified wood war pike	0		Moxie Percent: +30, Weapon Damage: +10, Last Available: "2025-12"
@@ -11390,15 +11390,15 @@
 11535	wet petrified wood wafer praline	0		Effect: "Radiant Personality", Effect Duration: 55
 11536	hand-crafted cybeer	3	EPIC	Last Available: "2025-12"
 11537	ICEbox	0		Last Available: "2025-12"
-11538	wired underwear	0		Last Available: "2025-12", Conditional Skill (Equipped): "Refresh HP"
-11539	encrypted shuriken	0		Last Available: "2025-12", Conditional Skill (Equipped): "Encrypted Shuriken"
+11538	wired underwear	0		Conditional Skill (Equipped): "Refresh HP", Last Available: "2025-12"
+11539	encrypted shuriken	0		Conditional Skill (Equipped): "Encrypted Shuriken", Last Available: "2025-12"
 11540	baby chest mimic	0		Free Pull
 11541	googly chest eyes	0		Familiar Weight: +5
 11542	mimic egg	0		
 11543	foul-smelling Crimbuccaneer war standard of the detective	0		Stench Damage: +10, Item Drop: +20, Last Available: "2023-12"
 11544	twirling family-friendly Elf Guard war standard of extreme caution	0		Monster Level: -25, Sleaze Resistance: +1, Last Available: "2023-12"
 11545	tumbling in-the-box spring shoes	0		Free Pull, Last Available: "2024-02"
-11546	blurry lard-coated stiffened spring shoes of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Sleaze Spell Damage: +25, Last Available: "2024-02", Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt"
+11546	blurry lard-coated stiffened spring shoes of dire peril	0		Weapon Damage: +20, Damage Reduction: 1, Sleaze Spell Damage: +25, Conditional Skill (Equipped): "Spring Away", Conditional Skill (Equipped): "Spring Kick", Conditional Skill (Equipped): "Spring Growth Spurt", Last Available: "2024-02"
 11547	extra-adjusted liquefied ionized ultra-soft ferns	0		Effect: "Ichorous Intensity", Effect Duration: 52, Last Available: "2024-02"
 11548	boiled triple-polarized crunchy brush	0		Effect: "Educated (Kinda)", Effect Duration: 43, Last Available: "2024-02"
 11549	smashed scientific equipment	0		
@@ -11426,29 +11426,29 @@
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	shaking Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11573	snack-sized decent squat yam	2	good	Last Available: "2024-05"
-11574	watered-down artisanal green skewed yam martini	2	EPIC	Last Available: "2024-05"
+11574	watered-down artisanal skewed green yam martini	2	EPIC	Last Available: "2024-05"
 11575	artisanal weak gray sweet potato o' mine	2	EPIC	Last Available: "2024-05"
 11576	triple-distilled hand-crafted bouncing Southern yam	6	EPIC	Last Available: "2024-05"
 11577	perfectly mixed sweet potato punch	3	EPIC	Last Available: "2024-05"
 11578	decent jittery Mayam spinach	3	good	Last Available: "2024-05"
 11579	normal jittery yam and swiss	4	good	Last Available: "2024-05"
 11580	Temple Grandin's steel-toed deadly yam cannon	0		Weapon Damage: +5, Damage Reduction: 9, Familiar Weight: +7, Lasts Until Rollover, Last Available: "2024-05"
-11581	shaking cyan squat yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
+11581	squat cyan shaking yam cannon	0		Initiative: +50, Lasts Until Rollover, Last Available: "2024-05"
 11582	yam battery	0		Last Available: "2024-05"
 11583	skewed yam stinkbomb	0		Last Available: "2024-05"
 11584	mirror blinking mansplainer's occult Samson's furry yam buckler	0		Experience (Muscle): +5, Spell Damage Percent: +25, Monster Level: +15, Damage Reduction: 3, Lasts Until Rollover, Last Available: "2024-05"
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	auspicious dance instructor's brainy yamtility belt	0		Mysticality: +5, Experience Percent (Moxie): +10, Item Drop: +10, Lasts Until Rollover, Last Available: "2024-05"
 11587	spoiled yam slider	3	crappy	Last Available: "2024-05"
-11588	tiny moldy ghostly yam mayo	1	crappy	Last Available: "2024-05"
-11589	moldy big blurry yam burrito	5	crappy	Last Available: "2024-05"
+11588	moldy tiny ghostly yam mayo	1	crappy	Last Available: "2024-05"
+11589	big moldy blurry yam burrito	5	crappy	Last Available: "2024-05"
 11590	squat ghostly visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
 11592	aviator goggles	0		
 11593	green Thwaitgold Illinigina illinoiensis model	0		
 11594	bite-sized bland wobbly mini kiwi	1	decent	Last Available: "2024-06"
 11595	squat flame-retardant friendly rock-hard mini kiwi bikini	0		Damage Reduction: 5, Familiar Weight: +3, Hot Resistance: +1, Last Available: "2024-06"
-11596	mediocre spirit-forward mini kiwitini	5	decent	Last Available: "2024-06"
+11596	spirit-forward mediocre mini kiwitini	5	decent	Last Available: "2024-06"
 11597	teal mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	supercharged hale mini kiwi silicon tiepin of Gandalf	0		Maximum HP: +20, Maximum MP Percent: +30, Spell Critical Percent: +20
@@ -11456,12 +11456,12 @@
 11601	moldy jumbo mini kiwi digitized cookies	5	crappy	
 11602	drinkable mini kiwi intoxicating spirits	4	good	
 11603	chilled extra-oxidized mini kiwi antimilitaristic hippy petition	0		Effect: "Curiosity of Br'er Tarrypin", Effect Duration: 11
-11604	modified polarized huge squat upside-down mini kiwi illicit antibiotic	0		Effect: "Comprehensively Nourished", Effect Duration: 54
+11604	modified polarized upside-down squat huge mini kiwi illicit antibiotic	0		Effect: "Comprehensively Nourished", Effect Duration: 54
 11605	bouncing up-at-dawn reassuring mini kiwi whipping stick	0		Spooky Resistance: +1, Adventures: +5
 11606	fuchsia huge brawny mini kiwi icepick	0		Muscle Percent: +20
 11607	enhanced upside-down upside-down mini kiwi-flavored aspirin-injecting lipstick	0		Effect: "Jaba&ntilde;ero Saucesphere", Effect Duration: 19
 11608	packaged Roman Candelabra	0		Free Pull
-11609	Roman Candelabra	0		Last Available: "2024-07", Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!"
+11609	Roman Candelabra	0		Conditional Skill (Equipped): "Blow the Blue Candle!", Conditional Skill (Equipped): "Blow the Green Candle!", Conditional Skill (Equipped): "Blow the Purple Candle!", Conditional Skill (Equipped): "Blow the Red Candle!", Conditional Skill (Equipped): "Blow the Yellow Candle!", Last Available: "2024-07"
 11610	protogenetic chunklet (synapse)	0		
 11611	protogenetic chunklet (muscle)	0		
 11612	protogenetic chunklet (flagellum)	0		
@@ -11469,10 +11469,10 @@
 11614	protogenetic chunklet (lips)	0		
 11615	twirling Van der Graaf studded savvy messenger bag RNA	0		Mysticality Percent: +20, Damage Absorption: +80, MP Regen Min: 5, MP Regen Max: 7
 11616	flagellate flagon	0		
-11617	skewed blue squat proto-proto-protozoa	0		
+11617	blue skewed squat proto-proto-protozoa	0		
 11618	normal lime green twirling bacteria bisque	3	good	
 11619	delicious ciliophora chowder	3	awesome	
-11620	delicious fancy massive cream of chloroplasts	9	awesome	Effect: "Robocamo", Effect Duration: 10
+11620	delicious massive fancy cream of chloroplasts	9	awesome	Effect: "Robocamo", Effect Duration: 10
 11621	synaptic soup	0		
 11622	fuchsia muscular soup	0		
 11623	flagellate soup	0		
@@ -11502,7 +11502,7 @@
 11647	structural ember	0		Last Available: "2024-09"
 11648	aromatic flame-retardant sizzling embers-only jacket	0		Hot Damage: +10, Hot Resistance: +1, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-09"
 11649	strapping bembershoot	0		Muscle: +5, Lasts Until Rollover, Last Available: "2024-09"
-11650	spoiled gigantic wheel of camembert	7	crappy	Last Available: "2024-09"
+11650	gigantic spoiled wheel of camembert	7	crappy	Last Available: "2024-09"
 11651	fortified strapping hat of remembering of the glutton	0		Muscle: +5, Damage Absorption: +60, Food Drop: +100, Lasts Until Rollover, Last Available: "2024-09"
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	green head of emberg lettuce	0		Last Available: "2024-09"
@@ -11510,7 +11510,7 @@
 11655	upside-down soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	mirror boxed bat wings	0		Free Pull, Last Available: "2024-10"
-11658	personal trainer's bat wings of the dark arts of incineration	0		Experience Percent (Muscle): +10, Spell Damage Percent: +100, Hot Spell Damage: +50, Last Available: "2024-10", Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats"
+11658	personal trainer's bat wings of the dark arts of incineration	0		Experience Percent (Muscle): +10, Spell Damage Percent: +100, Hot Spell Damage: +50, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
 11659	yellow ember egg	0		Last Available: "2024-09"
 11660	teal ember	0		Cold Resistance: +1
 11661	resourceful cool monocle on a stick	0		Moxie: +5, Maximum MP: +50, Lasts Until Rollover, Last Available: "2024-10"
@@ -11523,11 +11523,11 @@
 11668	sizzling Sheriff badge of Tarzan	0		Experience (Muscle): +3, Hot Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
 11669	blurry aromatic baleful Sheriff pistol	0		Spell Damage: +25, Stench Resistance: +1, Lasts Until Rollover, Last Available: "2024-10"
 11670	nippy Sheriff moustache of the empath	0		Familiar Weight: +5, Cold Damage: +10, Single Equip, Lasts Until Rollover, Last Available: "2024-10"
-11671	aromatic medical-grade photo booth supply list	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Last Available: "2024-10", Conditional Skill (Equipped): "Check for photo booth supplies"
+11671	aromatic medical-grade photo booth supply list	0		Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Lasts Until Rollover, Conditional Skill (Equipped): "Check for photo booth supplies", Last Available: "2024-10"
 11672	red peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	spinning tie-dye headband	0		
 11674	spoiled whirled peas	3	crappy	Last Available: "2024-11"
-11675	stale low-calorie gray peaza	1	decent	Last Available: "2024-11"
+11675	low-calorie stale gray peaza	1	decent	Last Available: "2024-11"
 11676	pulsating upside-down peace shooter	0		Last Available: "2024-11"
 11677	twisted drenchrome 2.0	1		Last Available: "2025-12"
 11678	mixed Synapse Blaster	1		Last Available: "2025-12"
@@ -11539,9 +11539,9 @@
 11684	stale piece of cake	4	decent	Last Available: "2024-11"
 11685	handful of split pea soup	0		Last Available: "2024-11"
 11686	Sealed TakerSpace letter of Marque	0		Free Pull, Last Available: "2024-12"
-11687	upside-down teal TakerSpace letter of Marque	0		Last Available: "2024-12"
+11687	teal upside-down TakerSpace letter of Marque	0		Last Available: "2024-12"
 11688	avaricious experienced deft pirate hook	0		Experience: +2, Meat Drop: +30, Lasts Until Rollover, Last Available: "2024-12"
-11689	sizzling iron tricorn hat of the empath	0		Familiar Weight: +5, Hot Damage: +10, Lasts Until Rollover, Last Available: "2024-12", Conditional Skill (Equipped): "Iron Tricorn Headbutt"
+11689	sizzling iron tricorn hat of the empath	0		Familiar Weight: +5, Hot Damage: +10, Lasts Until Rollover, Conditional Skill (Equipped): "Iron Tricorn Headbutt", Last Available: "2024-12"
 11690	narrow healthy jolly roger flag	0		Maximum HP Percent: +20, Lasts Until Rollover, Last Available: "2024-12"
 11691	sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
@@ -11562,8 +11562,8 @@
 11707	double-paned silky pirate drawers of chilblains	0		Cold Damage: +25, Cold Resistance: +5, Last Available: "2024-12"
 11708	profane eye patch	0		Sleaze Damage: +3
 11709	Vulcanized peppermint pegleg	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 12, Last Available: "2024-12"
-11710	mediocre special hard cocoa	3	decent	Effect: "Stop the Presses!", Effect Duration: 5, Last Available: "2024-12"
-11711	immense stale pulsating salmagumdi	7	decent	Last Available: "2024-12"
+11710	special mediocre hard cocoa	3	decent	Effect: "Stop the Presses!", Effect Duration: 5, Last Available: "2024-12"
+11711	stale immense pulsating salmagumdi	7	decent	Last Available: "2024-12"
 11712	smartaleck's plastic Easter Island Bunny	0		Moxie Percent: +30, Last Available: "2024-12"
 11713	cool plastic St. Patrick	0		Moxie: +5, Last Available: "2024-12"
 11714	tumbling Jack Frost's therapeutic plastic Colonel Brando	0		Cold Spell Damage: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2024-12"
@@ -11573,79 +11573,79 @@
 11718	Spirit of St. Patrick's Day	0		Last Available: "2024-12"
 11719	Spirit of Veteran's Day	0		Last Available: "2024-12"
 11720	wobbly Spirit of Thanksgiving	0		Last Available: "2024-12"
-11721	fuchsia twirling Spirit of Christmas	0		Last Available: "2024-12"
-11722	fancy miniature spoiled coney haunch	2	crappy	Effect: "Rain Dancin'", Effect Duration: 45, Last Available: "2024-12"
+11721	twirling fuchsia Spirit of Christmas	0		Last Available: "2024-12"
+11722	spoiled fancy miniature coney haunch	2	crappy	Effect: "Rain Dancin'", Effect Duration: 45, Last Available: "2024-12"
 11723	double-enhanced olive dark chocolate egg	0		Effect: "Scrappy, Shadowy", Effect Duration: 35, Last Available: "2024-12"
 11724	weak smooth moai toai	2	awesome	
 11725	squat clever smooth strapping moaiball	0		Muscle: +5, Moxie: +15, Maximum MP: +20, Last Available: "2024-12"
 11726	half-digested rat	0		Last Available: "2024-12"
 11727	pickled quantum upside-down narrow four-leaf potato sprout	0		Effect: "Buff as a Baobab", Effect Duration: 27, Last Available: "2024-12"
 11728	healthy Herculean potato jacket of the cheetah	0		Experience (Muscle): +1, Maximum HP Percent: +20, Initiative: +60, Last Available: "2024-12"
-11729	teal upside-down traumatic holiday memory	0		Last Available: "2024-12"
+11729	upside-down teal traumatic holiday memory	0		Last Available: "2024-12"
 11730	Brandonian footlocker key	0		Last Available: "2024-12"
-11731	personal trainer's Rosewater's military orb	0		Mysticality Percent: +30, Experience Percent (Muscle): +10, Last Available: "2024-12", Conditional Skill (Equipped): "Throw Military Orb"
+11731	personal trainer's Rosewater's military orb	0		Mysticality Percent: +30, Experience Percent (Muscle): +10, Conditional Skill (Equipped): "Throw Military Orb", Last Available: "2024-12"
 11732	polymerized tumbling rum ball	0		Effect: "Litterboxing", Effect Duration: 48
-11733	bouncing skewed gravy skin	0		Last Available: "2024-12"
+11733	skewed bouncing gravy skin	0		Last Available: "2024-12"
 11734	yellow executive greedy gravyskin hat	0		Meat Drop: 60, Last Available: "2024-12"
 11735	twirling miser's wizardly gravyskin buckler	0		Mysticality: +25, Meat Drop: +10, Damage Reduction: 7, Last Available: "2024-12"
 11736	teal cool gravyskin skirt of Tarzan	0		Moxie: +5, Experience (Muscle): +3, Last Available: "2024-12"
 11737	lightning-fast coward's gravyskin pants	0		Monster Level: -20, Initiative: +40, Last Available: "2024-12"
 11738	unsweetened polarized aerosolized crystallized pumpkin spice	0		Effect: "Flashing Eyes", Effect Duration: 23, Last Available: "2024-12"
-11739	spoiled miniature jittery room scale bean casserole	2	crappy	Last Available: "2024-12"
+11739	miniature spoiled jittery room scale bean casserole	2	crappy	Last Available: "2024-12"
 11740	fragile Christmas ornament	0		Last Available: "2024-12"
 11741	yellow squat ragged wool yarn	0		Last Available: "2024-12"
 11742	lightning-fast flame-wreathed razor-sharp perfect Christmas scarf	0		Weapon Damage Percent: [+25*event(December)], Hot Spell Damage: [+10*event(December)], Initiative: [+40*event(December)], Single Equip, Last Available: "2024-12"
-11743	groovy beefy snowman-enchanting tophat	0		Muscle: +10, Moxie Percent: +10, Last Available: "2024-12", Conditional Skill (Equipped): "Place your hat on their head"
+11743	groovy beefy snowman-enchanting tophat	0		Muscle: +10, Moxie Percent: +10, Conditional Skill (Equipped): "Place your hat on their head", Last Available: "2024-12"
 11744	tarnished quantum mirror LIDAR candle	0		Effect: "Extra Backbone", Effect Duration: 14, Last Available: "2024-12"
 11745	flame-retardant ribald slick Congressional Medal of Insanity	0		Moxie: +10, Sleaze Damage: +10, Hot Resistance: +1, Last Available: "2024-12"
 11746	pumpkin spice whorl	0		Last Available: "2024-12"
-11747	triple-distilled perfectly mixed olive Easter grasshopper	9	EPIC	Last Available: "2024-12"
+11747	perfectly mixed triple-distilled olive Easter grasshopper	9	EPIC	Last Available: "2024-12"
 11748	smooth Irish eggnog	3	awesome	Last Available: "2024-12"
-11749	tolerable extra-dry canteen of jungle juice	5	good	Last Available: "2024-12"
-11750	artisanal special triple-distilled turchucken	7	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 40, Last Available: "2024-12"
+11749	extra-dry tolerable canteen of jungle juice	5	good	Last Available: "2024-12"
+11750	special artisanal triple-distilled turchucken	7	EPIC	Effect: "Red-Shirted Escort", Effect Duration: 40, Last Available: "2024-12"
 11751	enchanted bad triple-distilled mechanically-mulled cider	6	decent	Effect: "Fire Inside", Effect Duration: 50, Last Available: "2024-12"
 11752	artisanal yellow holiday trip around the world	4	super EPIC	Last Available: "2024-12"
-11753	bite-sized decent chocolate ostrich egg	1	good	Last Available: "2024-12"
+11753	decent bite-sized chocolate ostrich egg	1	good	Last Available: "2024-12"
 11754	decent shaking beef and cabbage	4	good	Last Available: "2024-12"
 11755	thick decent tumbling fuchsia candy rations	5	good	Last Available: "2024-12"
 11756	stale enchanted olive double-candied yams	3	decent	Effect: "Amorous", Effect Duration: 45, Last Available: "2024-12"
-11757	diet moldy enchanted Christmas ham	1	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2024-12"
+11757	enchanted moldy diet Christmas ham	1	crappy	Effect: "Superhuman Sarcasm", Effect Duration: 45, Last Available: "2024-12"
 11758	yummy holiday smorgasbord	3	awesome	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	bejazzled eyepatch of the glutton	0		Food Drop: +100, Last Available: "2024-12"
-11761	Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11762	wobbly twirling Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
-11763	yellow How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
-11765	wobbly Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
-11767	maroon Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
-11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
-11770	skewed Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11761	Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11762	twirling wobbly Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
+11763	yellow How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
+11765	wobbly Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
+11767	maroon Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
+11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11770	skewed Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
 11771	moai statuette	0		Last Available: "2024-12"
-11772	prompt Jeselnik's chaotic egg gun of the boozehound	0		Spell Critical Percent: +10, Sleaze Damage: +25, Booze Drop: +100, Adventures: +3, Last Available: "2024-12", Conditional Skill (Equipped): "Egg the face"
+11772	prompt Jeselnik's chaotic egg gun of the boozehound	0		Spell Critical Percent: +10, Sleaze Damage: +25, Booze Drop: +100, Adventures: +3, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	red zippy reassuring nasty groovy army helmet	0		Moxie Percent: +10, Stench Damage: +5, Spooky Resistance: +1, Initiative: +20, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	red napkin	0		Last Available: "2024-12"
 11776	spoiled Thanksgiving ration	4	crappy	Last Available: "2024-12"
-11777	perfectly mixed spirit-forward Easter eggnog	5	EPIC	Last Available: "2024-12"
-11778	dehydrated pulsating spinning clovermint	1		Effect: "Healthy Bronze Glow", Effect Duration: 30, Last Available: "2024-12"
+11777	spirit-forward perfectly mixed Easter eggnog	5	EPIC	Last Available: "2024-12"
+11778	dehydrated spinning pulsating clovermint	1		Effect: "Healthy Bronze Glow", Effect Duration: 30, Last Available: "2024-12"
 11779	executive Jack Frost's friendly mansplainer's nylon Christmas stockings	0		Monster Level: +15, Familiar Weight: +3, Cold Spell Damage: +50, Meat Drop: +40, Single Equip, Last Available: "2024-12"
 11780	tattoo of two turkeys	0		Last Available: "2024-12"
-11781	boiled cyan twirling deviled candy egg	0		Effect: "Chalky White Pallor", Effect Duration: 59, Last Available: "2024-12"
+11781	boiled twirling cyan deviled candy egg	0		Effect: "Chalky White Pallor", Effect Duration: 59, Last Available: "2024-12"
 11782	bouncing McHugeLarge deluxe ski set	0		Free Pull, Last Available: "2025-01"
 11783	maroon supercharged McHugeLarge duffel bag of Calamity Jane	0		Maximum MP Percent: +30, Critical Hit Percent: +15, Last Available: "2025-01"
-11784	squat prompt asbestos-lined wicked McHugeLarge left pole	0		Spell Damage: +5, Hot Resistance: +5, Adventures: +3, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Slash"
-11785	wobbly sizzling sinister Fonzie's McHugeLarge right pole	0		Experience (Moxie): +1, Spell Damage: +10, Hot Damage: +10, Single Equip, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Stab"
-11786	McHugeLarge left ski of incineration of doom	0		Hot Spell Damage: +50, Spooky Spell Damage: +50, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Avalanche"
-11787	McHugeLarge right ski of the brute of the glutton	0		Muscle Percent: +30, Food Drop: +100, Last Available: "2025-01", Conditional Skill (Equipped): "McHugeLarge Ski Plow"
+11784	squat prompt asbestos-lined wicked McHugeLarge left pole	0		Spell Damage: +5, Hot Resistance: +5, Adventures: +3, Conditional Skill (Equipped): "McHugeLarge Slash", Last Available: "2025-01"
+11785	wobbly sizzling sinister Fonzie's McHugeLarge right pole	0		Experience (Moxie): +1, Spell Damage: +10, Hot Damage: +10, Single Equip, Conditional Skill (Equipped): "McHugeLarge Stab", Last Available: "2025-01"
+11786	McHugeLarge left ski of incineration of doom	0		Hot Spell Damage: +50, Spooky Spell Damage: +50, Conditional Skill (Equipped): "McHugeLarge Avalanche", Last Available: "2025-01"
+11787	McHugeLarge right ski of the brute of the glutton	0		Muscle Percent: +30, Food Drop: +100, Conditional Skill (Equipped): "McHugeLarge Ski Plow", Last Available: "2025-01"
 11788	red 1	0		Last Available: "2025-12"
 11789	0	0		Last Available: "2025-12"
-11790	twisted twirling olive blinking eXpand	1		Effect: "Highland Sheen", Effect Duration: 30, Last Available: "2025-12"
-11791	brute force hammer	0		Last Available: "2025-12", Conditional Skill (Equipped): "Brute Force Hammer"
+11790	twisted olive twirling blinking eXpand	1		Effect: "Highland Sheen", Effect Duration: 30, Last Available: "2025-12"
+11791	brute force hammer	0		Conditional Skill (Equipped): "Brute Force Hammer", Last Available: "2025-12"
 11792	datastick	0		Last Available: "2025-12"
-11793	blinking twirling dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
+11793	twirling blinking dedigitizer schematic: brute force hammer	0		Last Available: "2025-12"
 11794	red dedigitizer schematic: malware injector	0		Last Available: "2025-12"
 11795	dedigitizer schematic: cybervisor	0		Last Available: "2025-12"
 11796	dedigitizer schematic: digibritches	0		Last Available: "2025-12"
@@ -11658,7 +11658,7 @@
 11803	jittery cybervisor	0		Last Available: "2025-12"
 11804	spinning retro floppy disk	0		Last Available: "2025-12"
 11805	jittery pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	malware injector	0		Last Available: "2025-12", Conditional Skill (Equipped): "Inject Malware"
+11806	malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	pulsating CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	bouncing server room key	0		Last Available: "2025-12"
 11809	wobbly 3d printed server room key	0		Last Available: "2025-12"
@@ -11679,12 +11679,12 @@
 11824	tumbling insignificant bit	0		Last Available: "2025-12"
 11825	parity bit	0		Familiar Weight: +5
 11826	hashing vise	0		Last Available: "2025-12"
-11827	geofencing rapier	0		Single Equip, Last Available: "2025-12", Conditional Skill (Equipped): "Thrust your geofencing rapier"
+11827	geofencing rapier	0		Single Equip, Conditional Skill (Equipped): "Thrust your geofencing rapier", Last Available: "2025-12"
 11828	geofencing shield	0		Last Available: "2025-12"
 11829	virtual cybertattoo	0		Last Available: "2025-12"
 11830	ninja rope	0		
 11831	blue ninja crampons	0		
-11832	shaking maroon ninja carabiner	0		
+11832	maroon shaking ninja carabiner	0		
 11833	enhanced boiled corrupted green synthetic coffee	0		Effect: "Papowerful", Effect Duration: 61
 11834	polarized iDrops	0		Effect: "Mystic Circle", Effect Duration: 69
 11835	shame coil	0		
@@ -11693,7 +11693,7 @@
 11838	fuchsia heat arc	0		
 11839	scrape	0		
 11840	twirling phantom digit	0		
-11841	bouncing jittery wobbly foul line	0		
+11841	bouncing wobbly jittery foul line	0		
 11842	dark manioc	0		
 11843	Observer source code	0		
 11844	skewed chill gherkin	0		
@@ -11707,8 +11707,8 @@
 11852	phantom brace	0		Spooky Damage: +10, Spooky Spell Damage: +10
 11853	gray narrow foul cozy	0		Stench Damage: +10, Stench Spell Damage: +10
 11854	grim cellophane	0		Combat Rate: -5
-11855	spinning ghostly rift oculus	0		Combat Rate: +5
-11856	cyan skewed sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
+11855	ghostly spinning rift oculus	0		Combat Rate: +5
+11856	skewed cyan sweaty egg	0		HP Regen Min: 4, HP Regen Max: 8
 11857	carton of extra-sharp, staples	0		Weapon Damage: +10, Spell Damage: +10
 11858	glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
@@ -11725,16 +11725,16 @@
 11870	spinning bar dart	0		Last Available: "2025-03"
 11871	powdered leprechaun antidepressant pill	1		Last Available: "2025-03"
 11872	normal Heck ramen	4	good	Last Available: "2025-03"
-11873	flavorless big burrito	5	decent	Last Available: "2025-03"
+11873	big flavorless burrito	5	decent	Last Available: "2025-03"
 11874	jumbo adequate small beer brat	5	good	Last Available: "2025-03"
 11875	half-sized adequate peach pie	2	good	Last Available: "2025-03"
-11876	bland tiny incredible mini-pizza	1	decent	Last Available: "2025-03"
-11877	aged watered-down blurry Divine sidecar	2	awesome	Last Available: "2025-03"
-11878	acceptable spirit-forward tangarita sidecar	5	good	Last Available: "2025-03"
+11876	tiny bland incredible mini-pizza	1	decent	Last Available: "2025-03"
+11877	watered-down aged blurry Divine sidecar	2	awesome	Last Available: "2025-03"
+11878	spirit-forward acceptable tangarita sidecar	5	good	Last Available: "2025-03"
 11879	hand-crafted gimlet sidecar	3	EPIC	Last Available: "2025-03"
-11880	spirit-forward hand-crafted blinking tumbling vodka stratocaster sidecar	5	EPIC	Last Available: "2025-03"
-11881	irresponsibly strong artisanal prussian cathouse sidecar	9	EPIC	Last Available: "2025-03"
-11882	hand-crafted weak mirror Mon Tiki sidecar	2	EPIC	Last Available: "2025-03"
+11880	spirit-forward hand-crafted tumbling blinking vodka stratocaster sidecar	5	EPIC	Last Available: "2025-03"
+11881	artisanal irresponsibly strong prussian cathouse sidecar	9	EPIC	Last Available: "2025-03"
+11882	weak hand-crafted mirror Mon Tiki sidecar	2	EPIC	Last Available: "2025-03"
 11883	blurry Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	frosty shellacked April Shower Thoughts shield	0		Damage Reduction: 13, Cold Spell Damage: +10, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
@@ -11771,7 +11771,7 @@
 11916	stylish bycocket of horror	0		Spooky Spell Damage: +25
 11917	jittery Thwaitgold mad hatterpillar statuette	0		
 11918	packaged prismatic beret	0		Free Pull
-11919	blush beret	0		Last Available: "2025-06", Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking"
+11919	blush beret	0		Conditional Skill (Equipped): "Beret Blast", Conditional Skill (Equipped): "Beret Boast", Conditional Skill (Equipped): "Beret Busking", Last Available: "2025-06"
 11920	ghostly flak shield	0		Damage Reduction: 9
 11921	blurry Axis HQ Code	0		
 11922	yeti in a travel cooler	0		Free Pull, Last Available: "2025-07"
@@ -11807,8 +11807,8 @@
 11952	mixed lime green mixed berry jelly	1		Last Available: "2025-08"
 11953	decent skewed toast with mixed berry jelly	4	good	Last Available: "2025-08"
 11954	super-sized rotten purple cup of sugar	5	crappy	Last Available: "2025-08"
-11955	tasty snack-sized Susie's cupcake	2	awesome	Last Available: "2025-08"
-11956	shaking yellow clock	0		Last Available: "2025-08"
+11955	snack-sized tasty Susie's cupcake	2	awesome	Last Available: "2025-08"
+11956	yellow shaking clock	0		Last Available: "2025-08"
 11957	resourceful razor-sharp the gun of Flo-Jo	0		Weapon Damage Percent: +25, Maximum MP: +50, Initiative: +100, Last Available: "2025-08"
 11958	bad wine	3	decent	Last Available: "2025-08"
 11960	really, really nice swimming trunks	0		
@@ -11816,7 +11816,7 @@
 11962	huge blurry Lo Pan's undersea surveying goggles	0		Spell Critical Percent: +30, Lasts Until Rollover
 11963	bad watered-down enchanted Ocean-Touched Rum	2	decent	Effect: "Polka of Plenty", Effect Duration: 5
 11964	dehydrated gray water-logged pill	1		
-11965	thick tasty kelp puck	5	awesome	
+11965	tasty thick kelp puck	5	awesome	
 11966	scroll of sea strength	0		
 11967	tumbling scroll of sea smarts	0		
 11968	tumbling scroll of sea smarm	0		
@@ -11826,22 +11826,22 @@
 11972	durable dolphin whistle	0		
 11973	Thwaitgold lobster statuette	0		
 11974	spinning packaged Monodent of the Sea	0		Free Pull
-11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Last Available: "2025-09", Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish"
+11975	Monodent of the Sea	0		Hot Damage: +25, Muscle Percent: +5, Mysticality Percent: +5, Moxie Percent: +5, Experience: +1, Conditional Skill (Equipped): "Sea *dent: Throw a Lightning Bolt", Conditional Skill (Equipped): "Sea *dent: Summon a Wave", Conditional Skill (Equipped): "Sea *dent: Talk to Some Fish", Last Available: "2025-09"
 11976	unblemished pearl	0		
 11977	wobbly lime green dentadent of terror	0		Spooky Spell Damage: +10
 11986	lab-grown blood cubic zirconia	0		Free Pull, Last Available: "2025-10"
-11987	pulsating greedy flame-retardant resourceful Newton's weightlifter's beefy blood cubic zirconia	0		Muscle: 25, Experience (Mysticality): +3, Maximum MP: +50, Hot Resistance: +1, Meat Drop: +20, Last Available: "2025-10", Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail"
+11987	pulsating greedy flame-retardant resourceful Newton's weightlifter's beefy blood cubic zirconia	0		Muscle: 25, Experience (Mysticality): +3, Maximum MP: +50, Hot Resistance: +1, Meat Drop: +20, Conditional Skill (Equipped): "BCZ: Blood Geyser", Conditional Skill (Equipped): "BCZ: Refracted Gaze", Conditional Skill (Equipped): "BCZ: Sweat Bullets", Conditional Skill (Equipped): "BCZ: Blood Bath", Conditional Skill (Equipped): "BCZ: Dial it up to 11", Conditional Skill (Equipped): "BCZ: Sweat Equity", Conditional Skill (Equipped): "BCZ: Create Blood Thinner", Conditional Skill (Equipped): "BCZ: Prepare Spinal Tapas", Conditional Skill (Equipped): "BCZ: Craft a Pheromone Cocktail", Last Available: "2025-10"
 12044	altered blood thinner	1		Last Available: "2025-10"
 12045	lousy pheromone cocktail	3	decent	Last Available: "2025-10"
 12046	adequate tiny spinal tapas	1	good	Last Available: "2025-10"
 12047	cyan shrunken head in a duffel bag	0		Free Pull, Last Available: "2025-11"
-12048	mirror healthy occult shrunken head of bravery	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Spooky Resistance: +5, Last Available: "2025-11", Conditional Skill (Equipped): "Prepare to reanimate your Foe"
+12048	mirror healthy occult shrunken head of bravery	0		Spell Damage Percent: +25, Maximum HP Percent: +20, Spooky Resistance: +5, Conditional Skill (Equipped): "Prepare to reanimate your Foe", Last Available: "2025-11"
 12049	stocking full of bones	0		Free Pull, Last Available: "2025-12"
 12050	olive narrow small peppermint-flavored sugar walking crook	0		
 12051	yellow knucklebone	0		
-12052	drinkable strong Smoking Pope	5	good	
-12053	adequate half-sized prize turkey	2	good	
-12054	altered tumbling mirror medicinal gruel	1		Effect: "Joyful Resolve", Effect Duration: 50
+12052	strong drinkable Smoking Pope	5	good	
+12053	half-sized adequate prize turkey	2	good	
+12054	altered mirror tumbling medicinal gruel	1		Effect: "Joyful Resolve", Effect Duration: 50
 12055	moldy full-sized pumpkin pie	3	crappy	Last Available: "2025-11"
 12056	mediocre vodka cranberry sauce	4	decent	Last Available: "2025-11"
 12057	irradiated non-colloidal mirror yammed candy	0		Effect: "Ready to Snap", Effect Duration: 54, Last Available: "2025-11"
@@ -11869,7 +11869,7 @@
 12079	devilbone corset of the brazier	0		Hot Spell Damage: +25, Last Available: "2026-12"
 12080	flame-retardant supercool devilbone flute	0		Moxie Percent: +20, Hot Resistance: +1, Last Available: "2026-12"
 12081	padded devilbone rosary	0		Damage Absorption: +20, Single Equip, Last Available: "2026-12"
-12082	mixed tumbling red squat devilbone chunks	1		Last Available: "2026-12"
+12082	mixed red squat tumbling devilbone chunks	1		Last Available: "2026-12"
 12083	frozen Gehenna tattoo	0		Effect: "Remaining Alive", Effect Duration: 48
 12116	burnt incisor	0		Last Available: "2025-12"
 12117	burnt phalange	0		Last Available: "2025-12"
@@ -11889,7 +11889,7 @@
 12131	polymerized liquefied anodized boiling synovial fluid	0		Effect: "Black Eyes", Effect Duration: 40, Last Available: "2025-12"
 12132	blue reassuring stanky clever smoldering vertebra	0		Maximum MP: +20, Stench Spell Damage: +25, Spooky Resistance: +1, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
-12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Last Available: "2026-01", Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time"
+12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
 12135	purple smoldering bone dust	0		Last Available: "2025-12"
 12136	shaking blue volatile bone bomb	0		Last Available: "2025-12"
 12137	groovy hot boning knife of the storm of the sweet-tooth	0		Moxie Percent: +10, Maximum MP Percent: +40, Candy Drop: +100, Single Equip, Last Available: "2025-12"
@@ -11936,7 +11936,7 @@
 12178	alkaline liquefied gummi fingerbone	0		Effect: "Stimulated Body", Effect Duration: 31
 12179	blinking supercharged dance instructor's glimmering crystal	0		Experience Percent (Moxie): +10, Maximum MP Percent: +30, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
-12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Last Available: "2026-02", Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff"
+12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
 12182	Thwaitgold meat bee statuette	0		
 12183	mirror loose Meats	0		
 12184	Archaeologist's Spade	0		Last Available: "2026-03"
@@ -11950,7 +11950,7 @@
 12192	yellow Pork Elf toiletries kit	0		Last Available: "2026-03"
 12193	chilled activated ghostly Pork Elf mouthwash	0		Effect: "Buff as a Baobab", Effect Duration: 65, Last Available: "2026-03"
 12194	triple-galvanized polymerized huge Pork Elf deodorant	0		Effect: "Oriental Mysticism", Effect Duration: 57, Last Available: "2026-03"
-12195	nitrogenated polarized bouncing wobbly Pork Elf toothpaste	0		Effect: "Squid Squint", Effect Duration: 48, Last Available: "2026-03"
+12195	nitrogenated polarized wobbly bouncing Pork Elf toothpaste	0		Effect: "Squid Squint", Effect Duration: 48, Last Available: "2026-03"
 12196	bolt of fabric	0		Last Available: "2026-03"
 12197	rock-hard and dress of the detective	0		Damage Reduction: 5, Item Drop: +20, Last Available: "2026-03"
 12198	upside-down flame-wreathed and dress of Flo-Jo	0		Hot Spell Damage: +10, Initiative: +100, Last Available: "2026-03"
@@ -11959,7 +11959,7 @@
 12201	nasty dinosaur bone club	0		Stench Damage: +5, Last Available: "2026-03"
 12202	yellow ghostly Oprah's dinosaur skull helmet of extreme caution	0		Maximum MP Percent: +50, Monster Level: -25, Last Available: "2026-03"
 12203	blurry executive educational dinosaur bone corset of the sweet-tooth	0		Experience: +1, Meat Drop: +40, Candy Drop: +100, Last Available: "2026-03"
-12204	hand-crafted weak narrow Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
+12204	weak hand-crafted narrow Pork Elf cough syrup	2	EPIC	Last Available: "2026-03"
 12205	narrow Pork Elf neti pot	0		Last Available: "2026-03"
 12206	huge Pork Elf medicine cabinet	0		Last Available: "2026-03"
 12207	Pork Elf sink	0		Last Available: "2026-03"
@@ -11978,11 +11978,11 @@
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	cyan legendary noodles	0		Last Available: "2026-05"
 12226	bland small can of tuna	2	decent	
-12227	snack-sized normal alien salad	2	good	
+12227	normal snack-sized alien salad	2	good	
 12228	half-sized normal ratbatatouille	2	good	
-12229	normal big onigiri	5	good	
+12229	big normal onigiri	5	good	
 12230	spoiled crudit&eacute;s	4	crappy	
-12231	tasty super-sized sauced mutton	5	awesome	
+12231	super-sized tasty sauced mutton	5	awesome	
 12232	spoiled special hot honey ant	3	crappy	Effect: "Haunted Liver", Effect Duration: 45
 12233	stale snack-sized tomb aspic	2	decent	
 12234	delicious maroon later tots	3	awesome	
@@ -11991,7 +11991,7 @@
 12237	normal pulsating Arrattabbattabiata	4	good	Last Available: "2026-05"
 12238	flavorless wobbly Orzo di Riso	4	decent	Last Available: "2026-05"
 12239	moldy immense Pasta Grimavera	9	crappy	Last Available: "2026-05"
-12240	decent huge Linguini Ubriacapa	8	good	Last Available: "2026-05"
+12240	huge decent Linguini Ubriacapa	8	good	Last Available: "2026-05"
 12241	adequate ghostly yellow Formica e Pepe	3	good	Last Available: "2026-05"
 12242	fancy stale Tubetto Gelatto	3	decent	Effect: "Vitali Tea", Effect Duration: 35, Last Available: "2026-05"
 12243	normal thick narrow Gnocci Domani	5	good	Last Available: "2026-05"
@@ -12017,9 +12017,9 @@
 12267	flimsy plastic breastplate of horror	0		Spooky Spell Damage: +25
 12268	skewed Rosewater's flimsy plastic shield	0		Mysticality Percent: +30, Damage Reduction: 3
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
-12270	flame-retardant vibrating Da Vinci's Portable Laughing Stock	0		Experience (Mysticality): +5, Maximum MP Percent: +10, Hot Resistance: +1, Last Available: "2026-07", Conditional Skill (Equipped): "Taunt Your Foe"
+12270	flame-retardant vibrating Da Vinci's Portable Laughing Stock	0		Experience (Mysticality): +5, Maximum MP Percent: +10, Hot Resistance: +1, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	Jim Carey's steel-toed arcane researcher's Staff of Anachronistic Churning	0		Experience Percent (Mysticality): +10, Damage Reduction: 9, Monster Level: +25
-12272	spoiled thick classic banana	5	crappy	Last Available: "2026-07"
+12272	thick spoiled classic banana	5	crappy	Last Available: "2026-07"
 12273	toothsome watermelon	3	awesome	Last Available: "2026-07"
 12274	decent wobbly quince	3	good	Last Available: "2026-07"
 12275	blurry Interesting Coin	0		Last Available: "2026-08"
@@ -12034,15 +12034,15 @@
 12284	corrupted Aqua Citrulanatae	0		Effect: "Cravin' for a Ravin'", Effect Duration: 39, Last Available: "2026-07"
 12285	artisanal squat Melonegroni	3	EPIC	Last Available: "2026-07"
 12286	hand-crafted blurry Melonade Spritz	3	EPIC	Last Available: "2026-07"
-12287	snack-sized yummy quince pie	2	awesome	Last Available: "2026-07"
-12288	nitrogenated blurry purple quince quaff	0		Effect: "Jelly Combed", Effect Duration: 36, Last Available: "2026-07"
-12289	liquefied yellow wobbly Quickquince	0		Effect: "Bloody-minded", Effect Duration: 22, Last Available: "2026-07"
-12290	irresponsibly strong bad bouncing Quiskey Sour	7	decent	Last Available: "2026-07"
-12291	irresponsibly strong hand-crafted yellow Quincea&ntilde;era Cooler	6	EPIC	Last Available: "2026-07"
+12287	yummy snack-sized quince pie	2	awesome	Last Available: "2026-07"
+12288	nitrogenated purple blurry quince quaff	0		Effect: "Jelly Combed", Effect Duration: 36, Last Available: "2026-07"
+12289	liquefied wobbly yellow Quickquince	0		Effect: "Bloody-minded", Effect Duration: 22, Last Available: "2026-07"
+12290	bad irresponsibly strong bouncing Quiskey Sour	7	decent	Last Available: "2026-07"
+12291	hand-crafted irresponsibly strong yellow Quincea&ntilde;era Cooler	6	EPIC	Last Available: "2026-07"
 12292	weak aged Roth IPA	2	awesome	Last Available: "2026-08"
 12293	up-at-dawn sage underdraft protection	0		Mysticality Percent: +10, Adventures: +5, Last Available: "2026-08"
 12294	olive solvent	0		Last Available: "2026-08"
-12295	adequate snack-sized soybean futures	2	good	Last Available: "2026-08"
+12295	snack-sized adequate soybean futures	2	good	Last Available: "2026-08"
 12296	corrupted housing bubble	0		Effect: "Salamanderenity", Effect Duration: 63, Last Available: "2026-08"
 12297	enhanced Pixie-Swordz	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 32
 12298	blue skewed jittery lightning-fast financial instrument of the scaredy-cat	0		Monster Level: -15, Initiative: +40, Last Available: "2026-08"
@@ -12051,13 +12051,13 @@
 12301	bouncing bear tattoo	0		Last Available: "2026-08"
 12302	bull tattoo	0		Last Available: "2026-08"
 12303	blurry avaricious Jeselnik's 401k ring	0		Sleaze Damage: +25, Meat Drop: +30, Last Available: "2026-08"
-12304	mirror fuchsia balance sheet	0		Last Available: "2026-08"
+12304	fuchsia mirror balance sheet	0		Last Available: "2026-08"
 12305	pickled alkaline mirror narrow invisible hand	0		Effect: "Feeling No Pain", Effect Duration: 60, Last Available: "2026-08"
 12306	alkaline circle of overdraft protection scroll	0		Effect: "For Your Brain Only", Effect Duration: 52, Last Available: "2026-08"
 12307	extra-frozen shaking mint	0		Effect: "Flambé-a-thon", Effect Duration: 68, Last Available: "2026-08"
 12308	ghostly savings bondo	0		Last Available: "2026-08"
 12309	teal homeowner's loam	0		Last Available: "2026-08"
-12310	distilled blurry skewed blue toxic asset	1		Effect: "Salty Mouth", Effect Duration: 30, Last Available: "2026-08"
+12310	distilled blue blurry skewed toxic asset	1		Effect: "Salty Mouth", Effect Duration: 30, Last Available: "2026-08"
 12311	pickled tumbling intangible asset	1		Effect: "Happy Trails", Effect Duration: 15, Last Available: "2026-08"
 12312	altered spinning liquid asset	1		Effect: "Psalm of Pointiness", Effect Duration: 15, Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"

--- a/data/TCRS/TCRS_Turtle_Tamer_Wallaby_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wallaby_cafe_booze.txt
@@ -1,20 +1,20 @@
 -1	aged Petite Porter	3	awesome	
 -2	bad Scrawny Stout	3	decent	
 -3	practically non-alcoholic artisanal Infinitesimal IPA	1	EPIC	
--4	high-proof mediocre eggnogtini	6	decent	
+-4	mediocre high-proof eggnogtini	6	decent	
 -5	lousy candycaine	4	decent	
 -6	hand-crafted weak braincracker sweet	2	EPIC	
 -16	mediocre fermented honey	3	decent	
--17	bad irresponsibly strong moons-shine	10	decent	
+-17	irresponsibly strong bad moons-shine	10	decent	
 -18	smooth huge gin	3	awesome	
 -19	perfectly mixed ecto-nog	3	EPIC	
--20	bad watered-down hot toady	2	decent	
--21	mediocre fancy blinking hot choculate	4	decent	
+-20	watered-down bad hot toady	2	decent	
+-21	fancy mediocre blinking hot choculate	4	decent	
 -49	drinkable Cyder	4	good	
 -50	high-proof perfectly mixed Oil Nog	6	EPIC	
--51	acceptable strong maroon Hi-Octane Peppermint Jet Fuel	5	good	
+-51	strong acceptable maroon Hi-Octane Peppermint Jet Fuel	5	good	
 -58	artisanal twirling Grimacider	4	EPIC	
--59	watered-down perfectly mixed Isotope Nog	2	EPIC	
+-59	perfectly mixed watered-down Isotope Nog	2	EPIC	
 -60	mediocre Mutagin 'n' Tonic	4	decent	
 -70	irresponsibly strong bad twirling Gin and Herring	10	decent	
 -71	bad spinning Black and Tan and Red All Over	3	decent	
@@ -22,12 +22,12 @@
 -76	lousy CRIMBCO Ribbon Candy Schnapps	4	decent	
 -77	perfectly mixed CRIMBCO Egg Substitute Nog Substitute	4	EPIC	
 -78	bad practically non-alcoholic CRIMBCO Extreme Braincracker Sour	1	decent	
--82	weak bad bouncing huge Horseradish-infused Vodka	2	decent	
--83	weak aged Jerkitini	2	awesome	
+-82	bad weak huge bouncing Horseradish-infused Vodka	2	decent	
+-83	aged weak Jerkitini	2	awesome	
 -84	perfectly mixed watered-down Desert Island Iced Tea	2	EPIC	
 -88	aged distilled Crimbo Saketini	5	awesome	
 -89	artisanal strong Crimboku Drop	5	EPIC	
--90	hand-crafted watered-down Flaming Crimbo Log	2	EPIC	
+-90	watered-down hand-crafted Flaming Crimbo Log	2	EPIC	
 -107	bad Fortified Eggnog Slurry	3	decent	
--108	lousy practically non-alcoholic Hot Buttered Rum	1	decent	
+-108	practically non-alcoholic lousy Hot Buttered Rum	1	decent	
 -109	drinkable Spicy Hot Chocolate	3	good	

--- a/data/TCRS/TCRS_Turtle_Tamer_Wallaby_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wallaby_cafe_food.txt
@@ -2,21 +2,21 @@
 -2	rotten fancy As Jus Gezund Heit	3	crappy	
 -3	bite-sized adequate Bouillabaise Coucher Avec Moi	1	good	
 -7	bland teal pulsating gumdrop chow mein	4	decent	
--8	thick fancy flavorless candy cane pizza	5	decent	
--9	half-sized moldy gingerbread stir-fry	2	crappy	
+-8	fancy flavorless thick candy cane pizza	5	decent	
+-9	moldy half-sized gingerbread stir-fry	2	crappy	
 -10	bland twigs and gravel	3	decent	
 -11	spoiled shoots and leaves	4	crappy	
--12	normal super-sized tumbling bowl of unidentifiable goo	5	good	
--13	snack-sized yummy gingerbread massacre	2	awesome	
+-12	super-sized normal tumbling bowl of unidentifiable goo	5	good	
+-13	yummy snack-sized gingerbread massacre	2	awesome	
 -14	rotten It Came From Beyond Dessert	3	crappy	
 -15	spoiled vampire cake	3	crappy	
--52	adequate small Soylent Red and Green	2	good	
--53	big decent Disc-Shaped Nutrition Unit	5	good	
+-52	small adequate Soylent Red and Green	2	good	
+-53	decent big Disc-Shaped Nutrition Unit	5	good	
 -54	bland ghostly Gingerborg Hive	3	decent	
 -61	spoiled thick Candy Cane Surprise	5	crappy	
 -62	bite-sized flavorless Grimdrop Chow Mein	1	decent	
 -63	normal Grimgerbread House	3	good	
--67	rotten diet maroon Caviar Carbonara	1	crappy	
+-67	diet rotten maroon Caviar Carbonara	1	crappy	
 -68	flavorless huge Halibut Alfredo	3	decent	
 -69	decent gigantic Red Herring Velvet Cake	6	good	
 -73	stale CRIMBCO Reconstituted Gruel	4	decent	
@@ -24,21 +24,21 @@
 -75	thick moldy CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	5	crappy	
 -79	normal Brussels Sprout Stir-Fry	3	good	
 -80	rotten Carrot, Cabbage, and Kale Pizza	3	crappy	
--81	thick decent huge Turnip and Rutabaga Pie	5	good	
--85	spoiled big Rainbow Spider Fun Roll	5	crappy	
+-81	decent thick huge Turnip and Rutabaga Pie	5	good	
+-85	big spoiled Rainbow Spider Fun Roll	5	crappy	
 -86	adequate tiny Vegas Volcano Lava Roll	1	good	
--87	jumbo spoiled Crazy Dragon Shogun Buddha Roll	5	crappy	
+-87	spoiled jumbo Crazy Dragon Shogun Buddha Roll	5	crappy	
 -92	stale basic hot dog	3	decent	
 -93	toothsome gray savage macho dog	3	awesome	
 -94	adequate one with everything	3	good	
--95	decent snack-sized sly dog	2	good	
+-95	snack-sized decent sly dog	2	good	
 -96	normal devil dog	3	good	
 -97	low-calorie moldy blurry chilly dog	1	crappy	
--98	small rotten ghost dog	2	crappy	
+-98	rotten small ghost dog	2	crappy	
 -99	spoiled junkyard dog	3	crappy	
--100	huge stale skewed wet dog	6	decent	
+-100	stale huge skewed wet dog	6	decent	
 -101	adequate red sleeping dog	4	good	
--102	enchanted tiny spoiled optimal dog	1	crappy	
+-102	spoiled tiny enchanted optimal dog	1	crappy	
 -103	stale video games hot dog	3	decent	
 -104	spoiled Peppermint Nutrition Block	3	crappy	
 -105	spoiled Gingerbread Nutrition Block	4	crappy	

--- a/data/TCRS/TCRS_Turtle_Tamer_Wombat.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wombat.txt
@@ -1,4 +1,4 @@
-1	mirror blinking seal-clubbing club	0		
+1	blinking mirror seal-clubbing club	0		
 2	seal tooth	0		
 3	upside-down helmet turtle of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "atk, cap 2"
 4	turtle totem	0		
@@ -13,7 +13,7 @@
 14	vaporized cyan moxie weed	1		
 15	dehydrated huge strongness elixir	1		Effect: "Stimulated Body", Effect Duration: 25
 16	dehydrated magicalness-in-a-can	1		Effect: "Spooky Jellied", Effect Duration: 25
-17	diet rotten noodles	1	crappy	
+17	rotten diet noodles	1	crappy	
 18	upside-down tortoise's blessing	0		
 19	Sinatra's asparagus knife	0		Experience (Moxie): +5
 20	mirror Kentucky-style derby	0		Familiar Effect: "atk, cap 5"
@@ -21,7 +21,7 @@
 22	studded boxer shorts	0		Familiar Effect: "atk, 4xVolley, cap 5"
 23	chewing gum on a string	0		
 24	ten-leaf clover	0		
-25	jittery squat meat paste	0		
+25	squat jittery meat paste	0		
 26	lime green Dolphin King's map	0		
 27	spider web	0		
 28	green really spider web	0		
@@ -45,7 +45,7 @@
 46	blue figurine	0		
 47	rotten hot buttered roll	3	crappy	
 48	heart of rock and roll	0		
-49	delicious huge bowl of cottage cheese	9	awesome	
+49	huge delicious bowl of cottage cheese	9	awesome	
 50	baleful Rock and Roll Legend	0		Spell Damage: +25, Class: "Accordion Thief", Song Duration: 10
 51	steel-toed Knob Goblin Uberpants	0		Damage Reduction: 9, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 52	narrow banjo strings	0		
@@ -57,7 +57,7 @@
 58	wobbly stone turtle	0		
 59	slingshot	0		
 60	blurry prompt Mace of the Tortoise	0		Adventures: +3, Class: "Turtle Tamer"
-61	tiny adequate fortune cookie	1	good	
+61	adequate tiny fortune cookie	1	good	
 62	personal trainer's oriole-feather headdress	0		Experience Percent (Muscle): +10, Familiar Effect: "atk, 3xVolley, cap 3"
 63	green action figure body	0		
 64	action figure head	0		
@@ -142,7 +142,7 @@
 143	cottage	0		
 144	mirror stone of eXtreme power	0		
 145	barbed-wire fence	0		
-146	green ghostly dinghy plans	0		
+146	ghostly green dinghy plans	0		
 147	mirror dog trainer's eXtreme meat sword	0		Experience (familiar): +1
 148	bouncing squat stanky eXtreme meat staff	0		Stench Spell Damage: +25
 149	eXtreme meat crossbow of Leguizamo	0		Monster Level: +20
@@ -158,12 +158,12 @@
 159	shaking wad of dough	0		
 160	pie crust	0		
 161	flavorless tumbling ghuol egg	3	decent	
-162	adequate gigantic tumbling squat ghuol egg quiche	10	good	
+162	adequate gigantic squat tumbling ghuol egg quiche	10	good	
 163	pulsating extremely unsafe skeleton bone	0		Weapon Damage Percent: +100
 164	smart skull	0		
 165	skewer	0		
 166	ghuol ears	0		
-167	enchanted diet decent ghuol-ear kabob	1	good	Effect: "Muddled", Effect Duration: 15
+167	diet enchanted decent ghuol-ear kabob	1	good	Effect: "Muddled", Effect Duration: 15
 168	experienced bone rattle	0		Experience: +2
 169	bugbear beanie	0		Familiar Effect: "atk, cap 7"
 170	lihc eye	0		
@@ -176,10 +176,10 @@
 177	blurry brainy skull	0		
 178	fuchsia detective skull	0		
 179	moldy chorizo taco	4	crappy	
-180	drinkable triple-distilled ice-cold fotie	7	good	
+180	triple-distilled drinkable ice-cold fotie	7	good	
 181	baseball	0		
 182	batgut	0		
-183	olive wobbly shaking bat wing	0		
+183	wobbly shaking olive bat wing	0		
 184	briefcase	0		
 185	squat shaking fat stacks of cash	0		
 186	bean	0		
@@ -192,7 +192,7 @@
 194	gray blurry veiny Mr. Accessory	0		Maximum HP: +10, Softcore Only
 195	arcane researcher's eXtreme nose ring	0		Experience Percent (Mysticality): +10
 196	shaking disassembled clover	0		
-197	skewed cyan rat whisker	0		
+197	cyan skewed rat whisker	0		
 198	teal rat appendix	0		
 199	shaking Socratic ring	0		Experience (Mysticality): +1
 200	miniature flavorless wobbly rat appendix kabob	2	decent	
@@ -211,7 +211,7 @@
 213	huge wholesome filthy corduroys of Leguizamo	0		Maximum HP Percent: +10, Monster Level: +20, Familiar Effect: "stench atk, 2xPotato, cap 15"
 214	blurry filthy knitted dread sack of horror	0		Spooky Spell Damage: +25, Familiar Effect: "1xVolley, 1xPotato, cap 15"
 215	Uncle Jick's Brownie Mix	0		
-216	yummy enchanted carob brownies	3	awesome	Effect: "Stone-Faced", Effect Duration: 15
+216	enchanted yummy carob brownies	3	awesome	Effect: "Stone-Faced", Effect Duration: 15
 217	small decent herb brownies	2	good	
 218	hemp string	0		
 219	necklace chain	0		
@@ -240,8 +240,8 @@
 242	normal big	5	good	
 243	snack-sized rotten grapefruit	2	crappy	
 244	spoiled grapes	3	crappy	
-245	tasty miniature purple twirling olive	2	awesome	
-246	yummy bite-sized tomato	1	awesome	
+245	miniature tasty twirling purple olive	2	awesome	
+246	bite-sized yummy tomato	1	awesome	
 247	fermenting powder	0		
 248	tolerable narrow salty dog	3	good	
 249	aged blurry bloody mary	3	awesome	
@@ -251,14 +251,14 @@
 253	mediocre bouncing shot of schnapps	4	decent	
 254	weak mediocre shot of grapefruit schnapps	2	decent	
 255	acceptable fine wine	3	good	
-256	hand-crafted watered-down shot of tomato schnapps	2	EPIC	
+256	watered-down hand-crafted shot of tomato schnapps	2	EPIC	
 257	smooth extra-spicy bloody mary	3	awesome	
 258	skewed dense meat stack	0		
 259	snake skin	0		
 260	moldy White Citadel fries	4	crappy	
 261	decent immense narrow White Citadel burger	10	good	
-262	huge moldy squat piece of wedding cake	8	crappy	
-263	snack-sized moldy chocolate chips	2	crappy	
+262	moldy huge squat piece of wedding cake	8	crappy	
+263	moldy snack-sized chocolate chips	2	crappy	
 264	stale chocolate chip cookies	3	decent	
 265	smelly satin pants	0		Stench Spell Damage: +10, Familiar Effect: "atk, 2xPotato, cap 10"
 266	lousy weak wobbly lightning	2	decent	
@@ -267,7 +267,7 @@
 269	wobbly Jim Carey's sword	0		Monster Level: +25
 270	narrow picket fence	0		
 271	denatured barbell	1		
-272	vaporized huge tumbling concentrated magicalness pill	1		Effect: "Be a Mind Master", Effect Duration: 25
+272	vaporized tumbling huge concentrated magicalness pill	1		Effect: "Be a Mind Master", Effect Duration: 25
 273	dehydrated shaking moxie weed	1		
 274	Familiar-Gro&trade; Terrarium	0		
 275	mosquito larva	0		
@@ -297,8 +297,8 @@
 299	nitrogenated tumbling pickle-flavored chewing gum	0		Effect: "Ichorous Intensity", Effect Duration: 59
 300	extra-flattened ionized polarized jaba&ntilde;ero-flavored chewing gum	0		Effect: "Stenchtastic", Effect Duration: 40
 301	shaking flat dough	0		
-302	tiny decent red Knob sausage	1	good	
-303	half-sized moldy blue Knob mushroom	2	crappy	
+302	decent tiny red Knob sausage	1	good	
+303	moldy half-sized blue Knob mushroom	2	crappy	
 304	dry noodles	0		
 305	skewed medical-grade Knob Goblin harem pants	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "sleaze atk, 8xPotato, cap 2"
 306	spinning hale Knob Goblin harem veil	0		Maximum HP: +20, Familiar Effect: "5xLep, cap 2"
@@ -311,16 +311,16 @@
 313	electrified Crown of the Goblin King	0		MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "2xBarrr, 1xGhuol, cap 17"
 314	moldy bean burrito	3	crappy	
 315	stale snack-sized teal bean burrito	2	decent	
-316	spoiled blurry teal insanely bean burrito	3	crappy	
-317	moldy small bean burrito	2	crappy	
+316	spoiled teal blurry insanely bean burrito	3	crappy	
+317	small moldy bean burrito	2	crappy	
 318	delicious bean burrito	3	awesome	
 319	spoiled bouncing insanely bean burrito	4	crappy	
 320	super-sized moldy bat haggis	5	crappy	
-321	flavorless special ghostly menudo	3	decent	Effect: "Purpose", Effect Duration: 35
+321	special flavorless ghostly menudo	3	decent	Effect: "Purpose", Effect Duration: 35
 322	yummy goat cheese	3	awesome	
-323	diet rotten plain pizza	1	crappy	
-324	moldy jumbo sausage pizza	5	crappy	
-325	immense toothsome cyan goat cheese pizza	10	awesome	
+323	rotten diet plain pizza	1	crappy	
+324	jumbo moldy sausage pizza	5	crappy	
+325	toothsome immense cyan goat cheese pizza	10	awesome	
 326	stale twirling mushroom pizza	3	decent	
 327	skewed goat	0		
 328	watered-down artisanal bottle of whiskey	2	EPIC	
@@ -439,7 +439,7 @@
 441	chef-skull-in-the-box	0		
 442	pulsating bartender-skull-in-the-box	0		
 443	beer lens	0		
-444	mirror olive beer goggles	0		
+444	olive mirror beer goggles	0		
 445	upside-down shaking inspector's box-in-the-box	0		Item Drop: +15
 446	nothing-in-the-box-in-the-box	0		
 447	smelly box-in-the-box-in-the-box	0		Stench Spell Damage: +10
@@ -450,7 +450,7 @@
 452	disease	0		
 453	sober pill	0		
 454	screwdriver	0		
-455	adequate huge enchanted jumbo olive	7	good	Effect: "Tremella Tremens", Effect Duration: 30
+455	enchanted adequate huge jumbo olive	7	good	Effect: "Tremella Tremens", Effect Duration: 30
 456	weak drinkable dry martini	2	good	
 457	shaking tumbling aromatic ye olde golde frontes	0		Stench Resistance: +1, Class: "Disco Bandit", Single Equip
 458	continuum transfunctioner	0		
@@ -495,10 +495,10 @@
 497	upside-down gnatwing	0		
 498	toothsome immense papaya	7	awesome	
 499	asbestos-lined supercharged denim axe	0		Maximum MP Percent: +30, Hot Resistance: +5
-500	shaking lime green Elf Farm Raffle ticket	0		
-501	moldy snack-sized Elfin shortbread	2	crappy	
+500	lime green shaking Elf Farm Raffle ticket	0		
+501	snack-sized moldy Elfin shortbread	2	crappy	
 502	pagoda plans	0		
-503	decent gigantic upside-down skewered cat appendix	7	good	
+503	gigantic decent upside-down skewered cat appendix	7	good	
 504	lime green evil arches	0		
 505	nippy gnatwing earring of the empath	0		Familiar Weight: +5, Cold Damage: +10
 506	huge flavorless Hell broth	8	decent	
@@ -509,9 +509,9 @@
 511	Jarlsberg's key lime	0		
 512	Sneaky Pete's key lime	0		
 513	bland enchanted Boris's key lime pie	3	decent	Effect: "Castaway Physique", Effect Duration: 40
-514	miniature decent Jarlsberg's key lime pie	2	good	
+514	decent miniature Jarlsberg's key lime pie	2	good	
 515	rotten big teal Sneaky Pete's key lime pie	5	crappy	
-516	ghostly bouncing Hey Deze map	0		
+516	bouncing ghostly Hey Deze map	0		
 517	squat bejeweled accordion strap of the storm	0		Maximum MP Percent: +40, Class: "Accordion Thief"
 518	upside-down mystery juice	0		
 519	moxie magnet	0		
@@ -519,7 +519,7 @@
 521	olive arcane researcher's kickback cookbook	0		Experience Percent (Mysticality): +10
 522	one-winged stab bat	0		
 523	rewinged stab bat	0		
-524	acceptable watered-down papaya sling	2	good	
+524	watered-down acceptable papaya sling	2	good	
 525	shaking grue egg	0		
 526	Frobozz Real-Estate Company Instant House (TM)	0		
 527	teal volleyball	0		
@@ -540,7 +540,7 @@
 542	wicked 1337 7r0uZ0RZ of wisdom	0		Mysticality: +15, Spell Damage: +5, Familiar Effect: "2xPotato, cap 27"
 543	toothsome Trollhouse cookies	3	awesome	
 544	pulsating blue talons of wisdom of dire peril	0		Mysticality: +15, Weapon Damage: +20
-545	fancy normal Spam Witch sammich	3	good	Effect: "Staying Frosty", Effect Duration: 45
+545	normal fancy Spam Witch sammich	3	good	Effect: "Staying Frosty", Effect Duration: 45
 546	meat vortex	0		
 547	narrow 334 scroll	0		
 548	ghostly 668 scroll	0		
@@ -559,7 +559,7 @@
 561	pregnant mushroom	0		
 562	ratgut	0		
 563	sonar-in-a-biscuit	0		
-564	watered-down artisanal teal Mad Train wine	2	EPIC	
+564	artisanal watered-down teal Mad Train wine	2	EPIC	
 565	green Samson's hobo gloves	0		Experience (Muscle): +5, Single Equip
 566	jittery bum cheek of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "stench atk, 1xVolley, cap 5"
 567	fuchsia narrow hermit script	0		
@@ -569,22 +569,22 @@
 571	Jumbo Dr. Lucifer	1	good	
 572	flavorless Children's Meal of the Damned	4	decent	
 573	massive moldy noodles	6	crappy	
-574	normal spinning maroon narrow noodles	4	good	
-575	stale immense painful penne pasta	9	decent	
+574	normal narrow spinning maroon noodles	4	good	
+575	immense stale painful penne pasta	9	decent	
 576	snack-sized normal wobbly ravioli della hippy	2	good	
 577	yummy pr0n m4nic0tti	3	awesome	
-578	snack-sized toothsome Hell ramen	2	awesome	
-579	huge moldy blinking boring spaghetti	6	crappy	
+578	toothsome snack-sized Hell ramen	2	awesome	
+579	moldy huge blinking boring spaghetti	6	crappy	
 580	sauce of the ages	0		
 581	ghostly schmancy cheese sauce	0		
 582	Himalayan Hidalgo sauce	0		
 583	rotten fettucini Inconnu	4	crappy	
-584	thick adequate spaghetti with Skullheads	5	good	
+584	adequate thick spaghetti with Skullheads	5	good	
 585	normal green gnocchetti di Nietzsche	4	good	
 586	spinning aromatic veiny ridiculously huge sword	0		Maximum HP: +10, Stench Resistance: +1
 587	galvanized altered super-spiky hair gel	0		Effect: "Trufflin'", Effect Duration: 35
 588	soft echo eyedrop antidote	0		
-589	normal jumbo cocoa eggshell fragment	5	good	
+589	jumbo normal cocoa eggshell fragment	5	good	
 590	stale low-calorie tumbling cocoa eggshell fragment	1	decent	
 591	spinning cocoa egg	0		
 592	jittery house	0		
@@ -621,7 +621,7 @@
 623	red WA	0		
 624	cyan NG	0		
 625	wang	0		
-626	blinking blue Wand of Nagamar	0		
+626	blue blinking Wand of Nagamar	0		
 627	ND	0		
 628	metallic A	0		
 629	tumbling rosy-cheeked eye	0		Maximum HP Percent: +30
@@ -636,16 +636,16 @@
 638	forbidden Fonzie's asshat	0		Experience (Moxie): +1, Spell Damage Percent: +50, Familiar Effect: "stench atk, 1xVolley, cap 7"
 639	miniature decent abominable snowcone	2	good	
 640	Ent cider	1	awesome	
-641	stale low-calorie toast	1	decent	
+641	low-calorie stale toast	1	decent	
 642	skeleton key	0		
 643	blinking skeleton key ring	0		
 644	pulsating Crimbo pressie	0		Last Available: "2003-12"
 645	wrapping paper	0		Last Available: "2003-12"
-646	flavorless big fruitcake	5	decent	
+646	big flavorless fruitcake	5	decent	
 647	present	0		Last Available: "2004-11"
 648	ghostly wobbly Crimbo sword of chilblains	0		Cold Damage: +25, Last Available: "2004-10"
-649	wobbly Annie Oakley's Crimbo hat	0		Critical Hit Percent: +20, Familiar Effect: "1.75xVolley, 1.75xLep, cap 25", Last Available: "2004-10"
-650	blurry Crimbo pants of the boozehound	0		Booze Drop: +100, Familiar Effect: "atk, cap 25", Last Available: "2004-10"
+649	wobbly Annie Oakley's Crimbo hat	0		Critical Hit Percent: +20, Last Available: "2004-10", Familiar Effect: "1.75xVolley, 1.75xLep, cap 25"
+650	blurry Crimbo pants of the boozehound	0		Booze Drop: +100, Last Available: "2004-10", Familiar Effect: "atk, cap 25"
 651	exclusive ultra-rare item of vim and vigor	0		Maximum HP Percent: +50
 652	quantum egg	0		
 653	intragalactic rowboat	0		
@@ -664,7 +664,7 @@
 666	olive toasty MacGyver's clever steaming evil	0		Maximum MP: 120, Hot Damage: +5
 667	castle map	0		
 668	mirror spinning censurious spiked femur	0		Sleaze Resistance: +3
-669	low-calorie yummy narrow ghuol guolash	1	awesome	
+669	yummy low-calorie narrow ghuol guolash	1	awesome	
 670	lihc face of the storm	0		Maximum MP Percent: +40, Familiar Effect: "spooky atk, 1xBarrr, cap 22"
 671	supercool grave robbing shovel of vim and vigor	0		Moxie Percent: +20, Maximum HP Percent: +50
 672	decent cranberries	3	good	
@@ -673,13 +673,13 @@
 675	studded skull of the Bonerdagon	0		Damage Absorption: +80
 676	dragonbone belt buckle	0		
 677	badass belt of Gandalf	0		Spell Critical Percent: +20
-678	narrow tumbling yellow chest of the Bonerdagon	0		
-679	smooth yellow narrow roll in the hay	4	awesome	
+678	narrow yellow tumbling chest of the Bonerdagon	0		
+679	smooth narrow yellow roll in the hay	4	awesome	
 680	delicious slap and tickle	4	awesome	
 681	weak acceptable red slip 'n' slide	2	good	
-682	artisanal practically non-alcoholic a sump'm sump'm	1	super ultra mega turbo EPIC	
+682	practically non-alcoholic artisanal a sump'm sump'm	1	super ultra mega turbo EPIC	
 683	mediocre horizontal tango	3	decent	
-684	practically non-alcoholic delicious pink pony	1	awesome	
+684	delicious practically non-alcoholic pink pony	1	awesome	
 685	upside-down scorching ruddy boxer's Mr. Shirt	0		Muscle Percent: +10, Maximum HP Percent: +40, Hot Damage: +25
 686	blurry educational knuckles	0		Experience: +1
 687	nitrogenated blood of the Wereseal	0		Effect: "Lemon Enlightenment", Effect Duration: 28
@@ -716,7 +716,7 @@
 720	blue mirror healthy porquoise necklace of the empath	0		Maximum HP Percent: +20, Familiar Weight: +5, Single Equip
 721	gravedigger's porquoise bracelet of Flo-Jo	0		Spooky Damage: +10, Initiative: +100
 722	resourceful savvy porquoise ring of mayonnaise	0		Mysticality Percent: +20, Maximum MP: +50, Sleaze Spell Damage: +50, Single Equip
-723	adequate thick pulsating Knoll mushroom	5	good	
+723	thick adequate pulsating Knoll mushroom	5	good	
 724	decent mushroom	4	good	
 725	shaking teal one million meat pancakes	0		
 726	strapping huge mirror shard	0		Muscle: +5
@@ -726,7 +726,7 @@
 730	fishtank	0		
 731	fish hose	0		
 732	shaking hosed tank	0		
-733	lime green blinking hosed fishbowl	0		
+733	blinking lime green hosed fishbowl	0		
 734	lard-coated frosty medical-grade makeshift SCUBA gear	0		Cold Spell Damage: +10, Sleaze Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Adventure Underwater
 735	manspreader's easter egg balloon	0		Monster Level: +10
 736	twirling stone tablet (Sinister Strumming)	0		
@@ -735,8 +735,8 @@
 739	blinking tambourine bells	0		
 740	upside-down ribald tambourine	0		Sleaze Damage: +10
 741	red broken skull	0		
-742	rotten snack-sized Knoll shroomkabob	2	crappy	
-743	snack-sized normal squat mushroom	2	good	
+742	snack-sized rotten Knoll shroomkabob	2	crappy	
+743	normal snack-sized squat mushroom	2	good	
 744	colloidal jittery hair spray	0		Effect: "Bureaucratized", Effect Duration: 28
 746	blinking jittery stat script	0		
 747	Knob Goblin firecracker	0		
@@ -744,10 +744,10 @@
 749	decent warm mushroom	4	good	
 750	flavorless mushroom quesadilla	4	decent	
 751	decent gigantic cool mushroom	9	good	
-752	half-sized adequate maroon cool mushroom casserole	2	good	
+752	adequate half-sized maroon cool mushroom casserole	2	good	
 753	spoiled pointy mushroom	4	crappy	
-754	tasty miniature fancy cream of pointy mushroom soup	2	awesome	Effect: "Shot in the Arse", Effect Duration: 20
-755	moldy bite-sized fancy mushroom	1	crappy	Effect: "Slimily Strong", Effect Duration: 15
+754	miniature tasty fancy cream of pointy mushroom soup	2	awesome	Effect: "Shot in the Arse", Effect Duration: 20
+755	moldy fancy bite-sized mushroom	1	crappy	Effect: "Slimily Strong", Effect Duration: 15
 756	bite-sized rotten wobbly mushroom	1	crappy	
 757	rotten jumbo mushroom	5	crappy	
 758	spoiled tumbling ghost cucumber	3	crappy	
@@ -776,13 +776,13 @@
 781	energized mafia aria	0		Effect: "Litterboxing", Effect Duration: 55
 782	Mr. Exploiter	0		Last Available: "2009-12"
 783	'Villa' document	0		
-784	perfectly mixed weak Acqua Del Piatto Merlot	2	super ultra mega EPIC	Last Available: "2004-10"
-785	jittery shaking raffle ticket	0		
+784	weak perfectly mixed Acqua Del Piatto Merlot	2	super ultra mega EPIC	Last Available: "2004-10"
+785	shaking jittery raffle ticket	0		
 786	yummy strawberry	4	awesome	
-787	high-proof tolerable bottle of rum	9	good	
+787	tolerable high-proof bottle of rum	9	good	
 788	lousy strawberry daiquiri	3	decent	
 789	mediocre ghostly rum and cola	4	decent	
-790	extra-dry acceptable blue grog	5	good	
+790	acceptable extra-dry blue grog	5	good	
 791	gravedigger's grievous Mafia bow tie	0		Weapon Damage Percent: +50, Spooky Damage: +10, Last Available: "2004-10"
 792	resourceful Golden Mr. Accessory	0		Maximum MP: +50, Softcore Only
 793	concentrated quadruple-improved pulsating oil of stability	0		Effect: "Flamingly Floral", Effect Duration: 37
@@ -790,25 +790,25 @@
 795	aged Acque Luride Grezze Cabernet	3	awesome	Last Available: "2004-10"
 796	supercool cement shoes of the wise owl of the overflowing toilet	0		Mysticality: +20, Moxie Percent: +20, Stench Spell Damage: +50, Last Available: "2004-10"
 797	weak acceptable rockin' wagon	2	good	
-798	mediocre practically non-alcoholic ocean motion	1	decent	
-799	fancy drinkable fuzzbump	3	good	Effect: "Weapon of Mass Destruction", Effect Duration: 20
+798	practically non-alcoholic mediocre ocean motion	1	decent	
+799	drinkable fancy fuzzbump	3	good	Effect: "Weapon of Mass Destruction", Effect Duration: 20
 800	adequate jittery poutine	3	good	
-801	bite-sized decent shaking Knob stir-fry	1	good	
+801	decent bite-sized shaking Knob stir-fry	1	good	
 804	rotten Knoll stir-fry	4	crappy	
-805	rotten small stir-fry	2	crappy	
-806	immense bland asparagus stir-fry	10	decent	
+805	small rotten stir-fry	2	crappy	
+806	bland immense asparagus stir-fry	10	decent	
 807	spoiled olive stir-fry	3	crappy	
 808	decent Knob sausage stir-fry	4	good	
 809	moldy bat wing stir-fry	3	crappy	
 810	delicious miniature rat appendix stir-fry	2	awesome	
 811	yummy tofu stir-fry	4	awesome	
 812	flavorless huge pr0n stir-fry	9	decent	
-813	tasty special narrow Knob shells	4	awesome	Effect: "Unrunnable Face", Effect Duration: 35
+813	special tasty narrow Knob shells	4	awesome	Effect: "Unrunnable Face", Effect Duration: 35
 814	spoiled b&auml;tzle	4	crappy	
 815	moldy ratini	3	crappy	
 816	adequate Knob stroganoff	3	good	
 817	spoiled massive menudo ravioli	6	crappy	
-818	pulsating green plus sign	0		
+818	green pulsating plus sign	0		
 819	milky potion	0		
 820	teal swirly potion	0		
 821	pulsating bubbly potion	0		
@@ -816,25 +816,25 @@
 823	cloudy potion	0		
 824	skewed effervescent potion	0		
 825	narrow fizzy potion	0		
-826	shaking jittery dark potion	0		
+826	jittery shaking dark potion	0		
 827	murky potion	0		
 828	baby killer bee	0		
 829	upside-down spinning anti-anti-antidote	0		
 830	spoiled royal jelly	3	crappy	
-831	bouncing lime green small box	0		
+831	lime green bouncing small box	0		
 832	pulsating box	0		
 833	dangerous vorpal blade	0		Weapon Damage: +10
 834	auspicious flame-wreathed cornuthaum	0		Hot Spell Damage: +10, Item Drop: +10, Familiar Effect: "1.5xPotato, 1.25xFairy, cap 21"
 835	banded ring of aggravate monster	0		Damage Absorption: +100
-836	gigantic normal mind flayer corpse	9	good	
+836	normal gigantic mind flayer corpse	9	good	
 837	weak hand-crafted Uovo Marcio Shiraz	2	super ultra mega EPIC	Last Available: "2004-10"
 838	mirror zippy stanky Mafia stogie	0		Stench Spell Damage: +25, Initiative: +20, Last Available: "2004-10"
-839	perfectly mixed weak Maiali Sifilitici Pinot Noir	2	super ultra mega EPIC	Last Available: "2004-10"
+839	weak perfectly mixed Maiali Sifilitici Pinot Noir	2	super ultra mega EPIC	Last Available: "2004-10"
 840	Jack Frost's Mafia violin case of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50, Last Available: "2004-10"
 841	mediocre tomato daiquiri	4	decent	
 842	smooth beertini	3	awesome	
 843	drinkable squat salty slug	4	good	
-844	perfectly mixed high-proof papaya slung	10	EPIC	
+844	high-proof perfectly mixed papaya slung	10	EPIC	
 845	veiny MAHI fez	0		Maximum HP: +10, Familiar Effect: "0.5xVolley, 0.5xPotato, 0.5xLep, 0.5xFairy"
 847	heteroerotic frat-paddle	0		
 848	wobbly hypodermic needle	0		Familiar Weight: +5
@@ -846,7 +846,7 @@
 854	sucky decal	0		Familiar Weight: +5
 855	balloon knife	0		Familiar Weight: +5
 856	shock collar	0		
-857	wobbly lime green moonglasses	0		
+857	lime green wobbly moonglasses	0		
 858	palm-frond toupee	0		Familiar Weight: +5
 859	knife and fork	0		Familiar Weight: +5
 860	eye-pod	0		Familiar Weight: +5
@@ -890,9 +890,9 @@
 899	custom avatar form	0		Free Pull
 900	maroon smile-sharpening stone	0		Familiar Weight: +5
 901	espresso maker	0		Familiar Weight: +5
-902	yellow twirling 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
+902	twirling yellow 100-Watt bulb	0		Familiar Weight: +5, Last Available: "2011-12"
 903	lousy Spasmi Dolorosi Del Rene Champagne	4	decent	Last Available: "2004-10"
-904	baleful grievous school Mafia knickerbockers of Flo-Jo	0		Weapon Damage Percent: +50, Spell Damage: +25, Initiative: +100, Familiar Effect: "5xGhoul, cap 25", Last Available: "2004-10"
+904	baleful grievous school Mafia knickerbockers of Flo-Jo	0		Weapon Damage Percent: +50, Spell Damage: +25, Initiative: +100, Last Available: "2004-10", Familiar Effect: "5xGhoul, cap 25"
 905	extra-adjusted liquefied dry wobbly Yummy Tummy bean	0		Effect: "Billiards Belligerence", Effect Duration: 47
 906	aerosolized Rock Pops	0		Effect: "Mmmmmelon", Effect Duration: 22
 907	flattened maroon Mr. Mediocrebar	0		Effect: "Slimed Stomach", Effect Duration: 56
@@ -901,13 +901,13 @@
 910	stale small mirror dwarf bread	2	decent	
 911	denatured liquefied corrupted fuchsia blurry Senior Mints	0		Effect: "La Bamba", Effect Duration: 39
 912	flattened double-vacuum-sealed oxidized pixellated candy heart	0		Effect: "Carol of the Bones", Effect Duration: 56
-913	super-diffused corrupted twirling wobbly kobold	0		Effect: "Nano-juiced", Effect Duration: 41
+913	super-diffused corrupted wobbly twirling kobold	0		Effect: "Nano-juiced", Effect Duration: 41
 914	yellow hand turkey outline	0		Free Pull, Last Available: "2004-11"
 915	yam pinky ring	0		Familiar Weight: +5, Last Available: "2011-12"
 916	deadly arcane researcher's intergalactic pom poms	0		Experience Percent (Mysticality): +10, Weapon Damage: +5
 917	lime green Mob Penguin protection contract	0		
-918	wholesome Radio Free Baseball Cap	0		Maximum HP Percent: +10, Familiar Effect: "1xLep, 1xFairy, cap 37", Last Available: "2006-07"
-919	pulsating Radio Free Pants of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37", Last Available: "2006-07"
+918	wholesome Radio Free Baseball Cap	0		Maximum HP Percent: +10, Last Available: "2006-07", Familiar Effect: "1xLep, 1xFairy, cap 37"
+919	pulsating Radio Free Pants of Calamity Jane	0		Critical Hit Percent: +15, Last Available: "2006-07", Familiar Effect: "1xVolley, 1xGhoul, 1xLep, cap 37"
 920	shaking therapeutic Radio Free Foil	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-07"
 921	bland radio button candy	4	decent	
 922	ghostly wicked severed rocking horse head	0		Spell Damage: +5
@@ -915,11 +915,11 @@
 924	cyan crimbo elfling	0		Free Pull, Last Available: "2011-12"
 925	dental pliers	0		Familiar Weight: +5, Last Available: "2011-12"
 926	adjusted deionized Hawking's Elixir of Brilliance	0		Effect: "Starry-Eyed", Effect Duration: 15
-927	watered-down delicious bouncing Ferita Del Petto Zinfandel	2	awesome	Last Available: "2006-12"
+927	delicious watered-down bouncing Ferita Del Petto Zinfandel	2	awesome	Last Available: "2006-12"
 928	upside-down smelly fuzzy bracelets	0		Stench Spell Damage: +10
 929	personal trainer's arse-shooting crossbow	0		Experience Percent (Muscle): +10
 931	tolerable fortified twirling spiced rum	5	good	
-932	hand-crafted boozy eggnog	5	EPIC	
+932	boozy hand-crafted eggnog	5	EPIC	
 933	tiny adequate candy cane	1	good	
 934	rotten gingerbread bugbear	3	crappy	
 935	huge resourceful imitation nice watch	0		Maximum MP: +50, Single Equip, Last Available: "2004-12"
@@ -929,9 +929,9 @@
 939	red spinning small Crimbo Pressie	0		Last Available: "2004-12"
 940	bow	0		Last Available: "2004-12"
 941	Crimbo stocking	0		Last Available: "2004-12"
-942	banded bowler	0		Damage Absorption: +100, Familiar Effect: "1.5xVolley, 1.5xLep, cap 25", Last Available: "2004-12"
+942	banded bowler	0		Damage Absorption: +100, Last Available: "2004-12", Familiar Effect: "1.5xVolley, 1.5xLep, cap 25"
 943	energetic bow staff of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +20, Last Available: "2004-12"
-944	bowlegged pants of extreme caution	0		Monster Level: -25, Familiar Effect: "1xGhoul, cap 25", Last Available: "2004-12"
+944	bowlegged pants of extreme caution	0		Monster Level: -25, Last Available: "2004-12", Familiar Effect: "1xGhoul, cap 25"
 945	skewered jumbo olive	0		Last Available: "2004-12"
 946	skewered lime	0		Last Available: "2004-12"
 947	skewered cherry	0		Last Available: "2004-12"
@@ -943,7 +943,7 @@
 953	penguin-smacking club	0		Familiar Damage: +15
 954	orphan baby yeti	0		Free Pull, Last Available: "2011-12"
 955	blurry fez of etymology of the businessman	0		Meat Drop: +50, Familiar Effect: "1xLep, cap 30"
-956	small yummy carob chunk noodles	2	awesome	
+956	yummy small carob chunk noodles	2	awesome	
 957	rotten chorizo brownies	4	crappy	
 958	spoiled low-calorie red chocolate and tomato pizza	1	crappy	
 959	lime green flange	0		
@@ -997,16 +997,16 @@
 1010	smooth olive whiskey and soda	3	awesome	
 1011	artisanal blue monkey wrench	3	EPIC	
 1012	high-proof delicious tequila sunrise	10	awesome	
-1013	weak lousy ghostly green margarita	2	decent	
+1013	lousy weak green ghostly margarita	2	decent	
 1014	acceptable upside-down strawberry wine	3	good	
-1015	practically non-alcoholic bad shaking wine spritzer	1	decent	
+1015	bad practically non-alcoholic shaking wine spritzer	1	decent	
 1016	tolerable perpendicular hula	3	good	
 1017	bad ducha de oro	3	decent	
 1018	artisanal calle de miel	3	EPIC	
 1019	tolerable yellow dry vodka martini	3	good	
 1020	acceptable olive old-fashioned	3	good	
 1021	lousy tequila with training wheels	3	decent	
-1022	perfectly mixed practically non-alcoholic teal sangria	1	super EPIC	
+1022	practically non-alcoholic perfectly mixed teal sangria	1	super EPIC	
 1023	mediocre practically non-alcoholic special vesper	1	decent	Effect: "Funky Coal Patina", Effect Duration: 45, Last Available: "2004-12"
 1024	perfectly mixed enchanted triple-distilled bodyslam	6	EPIC	Effect: "Overstimulated", Effect Duration: 40, Last Available: "2004-12"
 1025	perfectly mixed sangria del diablo	3	super ultra EPIC	Last Available: "2004-12"
@@ -1029,7 +1029,7 @@
 1043	tumbling educational string of beads	0		Experience: +1
 1044	string of beads of the overflowing toilet	0		Stench Spell Damage: +50
 1045	plastic bottle opener of Flo-Jo	0		Initiative: +100
-1046	prompt friendly traffic cone	0		Familiar Weight: +3, Adventures: +3, Familiar Effect: "cap 15", Last Available: "2005-03"
+1046	prompt friendly traffic cone	0		Familiar Weight: +3, Adventures: +3, Last Available: "2005-03", Familiar Effect: "cap 15"
 1047	acceptable N. O. Beer	4	good	
 1048	vaporized blue oyster egg	1		Effect: "Visions of the Deep Dark Deeps", Effect Duration: 10
 1049	dehydrated oyster egg	1		
@@ -1040,8 +1040,8 @@
 1054	denatured oyster egg	1		
 1055	plastic oyster egg	0		
 1056	dehydrated yellow puce oyster egg	1		
-1057	boiled skewed pulsating purple puce oyster egg	1		Effect: "Waxing", Effect Duration: 40
-1058	modified gray ghostly puce oyster egg	1		Effect: "Human-Hobo Hybrid", Effect Duration: 10
+1057	boiled pulsating skewed purple puce oyster egg	1		Effect: "Waxing", Effect Duration: 40
+1058	modified ghostly gray puce oyster egg	1		Effect: "Human-Hobo Hybrid", Effect Duration: 10
 1059	puce plastic oyster egg	0		
 1060	pickled purple mauve oyster egg	1		
 1061	altered pulsating mauve oyster egg	1		
@@ -1095,7 +1095,7 @@
 1109	clockwork bartender-head-in-the-box	0		
 1110	clockwork chef-head-in-the-box	0		
 1111	clockwork bartender-in-the-box	0		
-1112	ghostly spinning clockwork chef-in-the-box	0		
+1112	spinning ghostly clockwork chef-in-the-box	0		
 1113	jittery clockwork maid	0		
 1114	tisket	0		
 1115	tasket	0		
@@ -1127,7 +1127,7 @@
 1141	weak perfectly mixed mushroom wine	2	EPIC	
 1142	delicious pointy mushroom wine	3	awesome	
 1143	tolerable purple flat mushroom wine	4	good	
-1144	perfectly mixed distilled cool mushroom wine	5	EPIC	
+1144	distilled perfectly mixed cool mushroom wine	5	EPIC	
 1145	mediocre knob mushroom wine	3	decent	
 1146	weak mediocre teal knoll mushroom wine	2	decent	
 1147	practically non-alcoholic delicious mushroom wine	1	awesome	
@@ -1150,7 +1150,7 @@
 1165	hovering sombrero	0		
 1166	tumbling maracas	0		Familiar Weight: +5
 1167	plain brown wrapper	0		
-1168	upside-down ghostly less-than-three-shaped box	0		
+1168	ghostly upside-down less-than-three-shaped box	0		
 1169	blue bouncing exactly-three-shaped box	0		
 1170	chocolate box	0		
 1171	coffin	0		
@@ -1162,7 +1162,7 @@
 1177	pulsating magnetic field	0		
 1178	red potted cactus	0		
 1179	daisy	0		
-1180	spinning twirling potted fern	0		
+1180	twirling spinning potted fern	0		
 1181	blue tulip	0		
 1182	Venus flytrap	0		
 1183	blue all-purpose flower	0		
@@ -1181,17 +1181,17 @@
 1196	yeti	0		
 1197	Mob Penguin	0		
 1198	skewed sabre-toothed lime	0		
-1199	skewed olive jittery bugbear	0		
-1200	bland special pulsating mugcake	3	decent	Effect: "Saucefingers", Effect Duration: 20
+1199	olive jittery skewed bugbear	0		
+1200	special bland pulsating mugcake	3	decent	Effect: "Saucefingers", Effect Duration: 20
 1201	bland urinal cake	4	decent	
 1202	rotten Happy Birthday, Claude! cake	4	crappy	
 1203	decent miniature personalized birthday cake	2	good	
 1204	tasty three-tiered wedding cake	3	awesome	
 1205	delicious jittery babycakes	4	awesome	
-1206	half-sized stale enchanted velvet cake	2	decent	Effect: "Rotten Memories", Effect Duration: 10
+1206	half-sized enchanted stale velvet cake	2	decent	Effect: "Rotten Memories", Effect Duration: 10
 1207	immense yummy congratulatory cake	6	awesome	
-1208	stale snack-sized angel-food cake	2	decent	
-1209	miniature bland devil's-food cake	2	decent	
+1208	snack-sized stale angel-food cake	2	decent	
+1209	bland miniature devil's-food cake	2	decent	
 1210	spoiled birthday party jellybean cheesecake	3	crappy	
 1211	upside-down balloon	0		
 1212	maroon balloon	0		
@@ -1200,7 +1200,7 @@
 1215	huge teal Mylar balloon	0		
 1216	huge Kevlar balloon	0		
 1217	tumbling thought balloon	0		
-1218	squat twirling teal rat head balloon	0		Familiar Weight: -3
+1218	teal squat twirling rat head balloon	0		Familiar Weight: -3
 1219	mini-zeppelin	0		
 1220	reassuring Mr. Balloon	0		Spooky Resistance: +1
 1221	pulsating balloon	0		
@@ -1233,19 +1233,19 @@
 1249	Boss Bat britches of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 3xGhuol, cap 16"
 1250	cyan coward's sharpshooter's Boss Bat bling	0		Critical Hit Percent: +10, Monster Level: -20
 1251	diet decent Knob shroomkabob	1	good	
-1252	enchanted flavorless ghostly shroomkabob	4	decent	Effect: "Frog In Your Throat", Effect Duration: 30
+1252	flavorless enchanted ghostly shroomkabob	4	decent	Effect: "Frog In Your Throat", Effect Duration: 30
 1253	bouncing pile of jumping beans	0		
 1254	enchanted bland bite-sized jumping bean burrito	1	decent	Effect: "Rushin' Hands", Effect Duration: 5
-1255	diet stale jumping bean burrito	1	decent	
+1255	stale diet jumping bean burrito	1	decent	
 1256	normal insanely jumping bean burrito	3	good	
-1257	enchanted normal rat scrapple	4	good	Effect: "Sleazy Hands", Effect Duration: 50
-1258	fuchsia wobbly pail of pretentious paint	0		
-1259	mansplainer's rosy-cheeked traffic cone	0		Maximum HP Percent: +30, Monster Level: +15, Familiar Effect: "1xVolley, 1xLep, cap 15", Last Available: "2005-06"
+1257	normal enchanted rat scrapple	4	good	Effect: "Sleazy Hands", Effect Duration: 50
+1258	wobbly fuchsia pail of pretentious paint	0		
+1259	mansplainer's rosy-cheeked traffic cone	0		Maximum HP Percent: +30, Monster Level: +15, Last Available: "2005-06", Familiar Effect: "1xVolley, 1xLep, cap 15"
 1260	wax lips	0		Experience: +3, Softcore Only, Last Available: "2005-07"
 1261	powdered Hatorade	1		
 1262	Sherlock's crafty rosy-cheeked off-hand balloon	0		Maximum HP Percent: +30, Maximum MP: +10, Item Drop: +25
 1263	pygmy bugbear shaman	0		Free Pull, Last Available: "2011-12"
-1264	bouncing mirror nose-bone fetish	0		Last Available: "2011-12"
+1264	mirror bouncing nose-bone fetish	0		Last Available: "2011-12"
 1265	box of sunshine	0		Free Pull
 1266	snack-sized bland green gloomy mushroom	2	decent	
 1267	dead mimic	0		
@@ -1257,7 +1257,7 @@
 1273	squat mansplainer's magic lamp	0		Monster Level: +15
 1274	boiled Medicinal Herb's medicinal herbs	1		
 1275	Sinatra's basic meat skirt	0		Experience (Moxie): +5, Familiar Effect: "3xBarrr, 3xFairy, cap 10"
-1276	artisanal fancy weak Otorian Battle Scar	2	EPIC	Effect: "Witch's Brood", Effect Duration: 40
+1276	fancy weak artisanal Otorian Battle Scar	2	EPIC	Effect: "Witch's Brood", Effect Duration: 40
 1277	basic meat kilt	0		Item Drop: +5, Familiar Effect: "3xPotato, 3xFairy, cap 10"
 1278	upside-down meat skirt of the blizzard	0		Cold Spell Damage: +25, Familiar Effect: "3xPotato, 3xFairy, cap 11"
 1279	twirling purple miser's meat kilt	0		Meat Drop: +10, Familiar Effect: "3xPotato, 3xFairy, cap 11"
@@ -1287,12 +1287,12 @@
 1303	Mjolnir Jr.	0		
 1304	doppelshifter egg	0		Free Pull
 1305	makeup kit	0		Familiar Weight: +15
-1306	tumbling maroon manspreader's traffic cone of the empath	0		Monster Level: +10, Familiar Weight: +5, Familiar Effect: "2xVolley, 2xLep, cap 15", Last Available: "2005-10"
+1306	tumbling maroon manspreader's traffic cone of the empath	0		Monster Level: +10, Familiar Weight: +5, Last Available: "2005-10", Familiar Effect: "2xVolley, 2xLep, cap 15"
 1307	tumbling calm attention-deficit demon	0		Free Pull, Last Available: "2006-10"
 1308	unwound cymbal-playing monkey	0		Free Pull, Last Available: "2006-10"
 1309	attention spanner	0		Familiar Weight: +5
 1310	funky fez	0		Familiar Weight: +5
-1311	narrow pulsating comfy blanket	0		Last Available: "2005-10"
+1311	pulsating narrow comfy blanket	0		Last Available: "2005-10"
 1312	beefcake's Baron von Ratsworth's monocle	0		Muscle: +25, Single Equip
 1313	Baron von Ratsworth's money clip of bravery	0		Spooky Resistance: +5, Single Equip
 1314	Sinatra's Baron von Ratsworth's tophat	0		Experience (Moxie): +5, Familiar Effect: "1xPotato, 3xGhuol, cap 18"
@@ -1301,11 +1301,11 @@
 1317	pulsating blood flower	0		
 1318	lovecat tail	0		
 1319	plastic passion fruit	0		
-1320	snack-sized special adequate purple questionable taco	2	good	Effect: "Melancholy Burden", Effect Duration: 25
+1320	adequate snack-sized special purple questionable taco	2	good	Effect: "Melancholy Burden", Effect Duration: 25
 1321	Doc's Miracle Cure	0		Last Available: "2011-12"
 1322	petrified time	0		Last Available: "2005-10"
-1323	flame-wreathed time helmet	0		Hot Spell Damage: +10, Familiar Effect: "0.5xPotato, 1xFairy, cap 25", Last Available: "2005-10"
-1324	time trousers of Gandalf	0		Spell Critical Percent: +20, Familiar Effect: "1xPotato, cap 25", Last Available: "2005-10"
+1323	flame-wreathed time helmet	0		Hot Spell Damage: +10, Last Available: "2005-10", Familiar Effect: "0.5xPotato, 1xFairy, cap 25"
+1324	time trousers of Gandalf	0		Spell Critical Percent: +20, Last Available: "2005-10", Familiar Effect: "1xPotato, cap 25"
 1325	time sword of wisdom	0		Mysticality: +15, Last Available: "2005-10"
 1326	slick Dyspepsi-Cola helmet	0		Moxie: +10, Familiar Effect: "3xFairy, cap 7"
 1327	mirror inspector's Cloaca-Cola shield	0		Item Drop: +15, Damage Reduction: 4
@@ -1343,12 +1343,12 @@
 1360	yellow pirate zombie robot head	0		Last Available: "2005-11"
 1361	Newton's disembodied smile	0		Experience (Mysticality): +3, Single Equip
 1362	wobbly sausage	0		
-1363	upside-down skewed clockwork pirate skull	0		
+1363	skewed upside-down clockwork pirate skull	0		
 1364	wobbly rhesus monkey	0		Familiar Weight: +5
 1365	moldy tofurkey leg	4	crappy	
 1366	super-sized flavorless tofurkey gravy	5	decent	
-1367	adequate snack-sized mirror herbal stuffing	2	good	
-1368	spoiled bite-sized ghostly can-shaped gelatinous cranberry sauce	1	crappy	
+1367	snack-sized adequate mirror herbal stuffing	2	good	
+1368	bite-sized spoiled ghostly can-shaped gelatinous cranberry sauce	1	crappy	
 1369	adequate yams	3	good	
 1370	rhinestone cowboy shirt of terror	0		Spooky Spell Damage: +10
 1371	twirling sinister gingham blouse	0		Spell Damage: +10
@@ -1372,7 +1372,7 @@
 1390	squat top	0		Last Available: "2010-12"
 1391	squat bouncing ball	0		Last Available: "2010-12"
 1392	kite	0		Last Available: "2005-12"
-1393	tumbling twirling pet rock	0		Last Available: "2005-12"
+1393	twirling tumbling pet rock	0		Last Available: "2005-12"
 1394	blinking doppelshifter	0		Last Available: "2005-12"
 1395	red teddy bear	0		Last Available: "2005-12"
 1396	baleful duck-on-a-string of Flo-Jo	0		Spell Damage: +25, Initiative: +100, Last Available: "2005-12"
@@ -1384,13 +1384,13 @@
 1402	rag doll of the cheetah	0		Initiative: +60, Last Available: "2005-12"
 1403	huge cyan blinking can of fake snow of the early riser	0		Adventures: +7, Last Available: "2005-12"
 1404	toasty colored-light &quot;necklace&quot;	0		Hot Damage: +5, Last Available: "2005-12"
-1405	mirror Tesla tree skirt	0		MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "hot atk, 2xFairy, cap 25", Last Available: "2005-12"
+1405	mirror Tesla tree skirt	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2005-12", Familiar Effect: "hot atk, 2xFairy, cap 25"
 1406	stale spinning huge wreath-shaped Crimbo cookie	3	decent	Effect: "Wreathed in Merriment", Effect Duration: 10, Last Available: "2023-06"
-1407	stale mirror blinking bell-shaped Crimbo cookie	4	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
+1407	stale blinking mirror bell-shaped Crimbo cookie	4	decent	Effect: "Fury of the Bells", Effect Duration: 10, Last Available: "2023-06"
 1408	normal half-sized pulsating tree-shaped Crimbo cookie	2	good	Effect: "Yuletide Sappiness", Effect Duration: 10, Last Available: "2023-06"
 1409	gray baleful Unionize The Elves sign	0		Spell Damage: +25, Last Available: "2005-12"
 1410	olive sleeping snowy owl	0		Last Available: "2005-12"
-1411	Tome of Snowcone Summoning	0		Free Pull, Skill: "Summon Snowcones", Last Available: "2006-01"
+1411	Tome of Snowcone Summoning	0		Free Pull, Last Available: "2006-01", Skill: "Summon Snowcones"
 1412	super-moist snowcone	0		Effect: "Rosewater Mark", Effect Duration: 20, Last Available: "2006-01"
 1413	frozen enhanced upside-down snowcone	0		Effect: "Salamanderenity", Effect Duration: 34, Last Available: "2006-01"
 1414	extra-improved quadruple-polymerized snowcone	0		Effect: "Intimidating Mien", Effect Duration: 16, Last Available: "2006-01"
@@ -1399,15 +1399,15 @@
 1417	super-denatured snowcone	0		Effect: "Granolarrrgh", Effect Duration: 27, Last Available: "2006-01"
 1418	Pretty Predator Clawicure Kit	0		Familiar Weight: +5, Last Available: "2006-01"
 1419	teddy bear sewing kit	0		Last Available: "2006-01"
-1420	gravedigger's Van der Graaf traffic cone	0		Spooky Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-01"
+1420	gravedigger's Van der Graaf traffic cone	0		Spooky Damage: +10, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2006-01", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1421	Scandalously Skimpy Bikini	0		Four Songs, Single Equip
 1422	Sombrero De Vida	0		Four Songs, Familiar Effect: "1xVolley, 1xPotato, 1xLep, cap 12"
 1423	iceberglet	0		Last Available: "2006-02"
 1424	huge cool ice sickle of the blizzard	0		Moxie: +5, Cold Spell Damage: +25, Softcore Only, Last Available: "2006-02"
 1425	arcane researcher's ice baby	0		Experience Percent (Mysticality): +10, Softcore Only, Last Available: "2006-02"
-1426	scandalous ice pick	0		Sleaze Damage: +5, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2006-02"
+1426	scandalous ice pick	0		Sleaze Damage: +5, Softcore Only, Last Available: "2006-02", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 1427	olive ice skates of vim and vigor of the storm	0		Maximum HP Percent: +50, Maximum MP Percent: +40, Single Equip, Softcore Only, Last Available: "2006-02"
-1428	jumbo bland grue egg omelette	5	decent	
+1428	bland jumbo grue egg omelette	5	decent	
 1429	roll of drink tickets	0		
 1430	pregnant gloomy mushroom	0		
 1431	pregnant mushroom	0		
@@ -1422,12 +1422,12 @@
 1440	quantum twirling powder	0		Effect: "Wolf's Bane", Effect Duration: 50
 1441	activated anodized powder	0		Effect: "Oiled Skin", Effect Duration: 21
 1442	adjusted corrupted stench powder	0		Effect: "Human-Elemental Hybrid", Effect Duration: 12
-1443	vacuum-sealed maroon wobbly skewed sleaze powder	0		Effect: "Crotchety, Pining", Effect Duration: 61
+1443	vacuum-sealed wobbly skewed maroon sleaze powder	0		Effect: "Crotchety, Pining", Effect Duration: 61
 1444	colloidal irradiated squat bouncing twinkly nuggets	0		Effect: "Sugar, Hello", Effect Duration: 41
 1445	polarized hot nuggets	0		Effect: "Norwhalloped", Effect Duration: 33
 1446	pickled blinking nuggets	0		Effect: "Gummibrain", Effect Duration: 28
 1447	super-polarized nuggets	0		Effect: "The Power of LOV", Effect Duration: 63
-1448	vacuum-sealed blurry olive stench nuggets	0		Effect: "Corruption of Wretched Wally", Effect Duration: 40
+1448	vacuum-sealed olive blurry stench nuggets	0		Effect: "Corruption of Wretched Wally", Effect Duration: 40
 1449	boiled lime green sleaze nuggets	0		Effect: "The Dark Lord Rides in Force Tonight", Effect Duration: 69
 1450	compressed narrow spinning twinkly wad	1		
 1451	mixed huge hot wad	1		Effect: "Morbidi Tea", Effect Duration: 5
@@ -1474,16 +1474,16 @@
 1492	bouncing banded ninja mop	0		Damage Absorption: +100
 1493	groovy smooth ridiculously overelaborate ninja weapon	0		Moxie: +15, Moxie Percent: +10
 1494	warmed sugar-coated pine cone	0		Effect: "Toast Tea", Effect Duration: 48, Last Available: "2020-09"
-1495	baleful traffic cone of Calamity Jane	0		Spell Damage: +25, Critical Hit Percent: +15, Familiar Effect: "2xLep, 2xFairy, cap 15", Last Available: "2006-03"
+1495	baleful traffic cone of Calamity Jane	0		Spell Damage: +25, Critical Hit Percent: +15, Last Available: "2006-03", Familiar Effect: "2xLep, 2xFairy, cap 15"
 1496	drinkable weak gloomy mushroom wine	2	good	
 1497	drinkable special huge mushroom wine	4	good	Effect: "Toast Tea", Effect Duration: 50
-1498	McPhee's Grimoire of Hilarious Object Summoning	0		Skill: "Summon Hilarious Objects", Last Available: "2006-04"
+1498	McPhee's Grimoire of Hilarious Object Summoning	0		Last Available: "2006-04", Skill: "Summon Hilarious Objects"
 1499	whoopie cushion	0		Last Available: "2006-04"
 1500	blurry squat fake fake vomit	0		Last Available: "2006-04"
 1501	aerosolized galvanized explosion-flavored chewing gum	0		Effect: "Phoenix, Right?", Effect Duration: 50, Last Available: "2006-04"
 1502	clown hammer	0		Last Available: "2006-04"
-1503	pulsating twirling purple rubber emo roe	0		Last Available: "2006-04"
-1504	dry narrow olive snowcone	0		Effect: "Optimist Primal", Effect Duration: 30, Last Available: "2006-04"
+1503	purple twirling pulsating rubber emo roe	0		Last Available: "2006-04"
+1504	dry olive narrow snowcone	0		Effect: "Optimist Primal", Effect Duration: 30, Last Available: "2006-04"
 1505	ice cube with a fly in it	0		Last Available: "2006-04"
 1506	special smooth jittery teal tumbling calle de miel with a fly in it	3	awesome	Effect: "Stuck-Up Hair", Effect Duration: 35, Last Available: "2006-04"
 1507	smooth blinking rockin' wagon with a fly in it	4	awesome	Last Available: "2006-04"
@@ -1492,7 +1492,7 @@
 1510	bag of airline peanuts	0		Last Available: "2006-04"
 1511	dance instructor's fake hand	0		Experience Percent (Moxie): +10, Last Available: "2006-04"
 1512	vaporized Knob Goblin pet-buffing spray	1		
-1513	compressed olive tumbling Knob Goblin learning pill	1		
+1513	compressed tumbling olive Knob Goblin learning pill	1		
 1514	dried ghostly Knob Goblin eyedrops	1		
 1515	denatured spinning blurry Knob Goblin nasal spray	1		Effect: "Empathy", Effect Duration: 40
 1516	KWE-brand transistor radio	0		
@@ -1504,22 +1504,22 @@
 1523	blinking bottle of used blood	0		
 1524	wind-up chattering teeth	0		Last Available: "2006-04"
 1525	green huge blinking joybuzzer	0		Conditional Skill (Equipped): "Shake Hands", Last Available: "2006-04"
-1526	narrow squat pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2006-04"
+1526	narrow squat pet rock &quot;Snooty&quot; disguise	0		Familiar Weight: +11, Last Available: "2006-04", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1527	cyan diamond-studded fronts	0		Familiar Weight: +5, Last Available: "2006-04"
 1528	zippy deadly corkscrew	0		Weapon Damage: +5, Initiative: +20, Last Available: "2006-04"
 1529	red St. Sneaky Pete's Day goodies basket	0		Last Available: "2006-04"
 1530	fake plastic grass	0		Last Available: "2011-01"
-1531	sage grass skirt	0		Mysticality Percent: +10, Familiar Effect: "atk, 1.5xFairy, cap 20", Last Available: "2011-01"
-1532	grass hat of the empath	0		Familiar Weight: +5, Familiar Effect: "2xVolley, 1xBarrr, cap 20", Last Available: "2011-01"
+1531	sage grass skirt	0		Mysticality Percent: +10, Last Available: "2011-01", Familiar Effect: "atk, 1.5xFairy, cap 20"
+1532	grass hat of the empath	0		Familiar Weight: +5, Last Available: "2011-01", Familiar Effect: "2xVolley, 1xBarrr, cap 20"
 1533	boxer's grass blade	0		Muscle Percent: +10, Last Available: "2011-01"
 1534	shaking raffle prize box	0		
 1536	homeless hobo spirit	0		Free Pull, Last Available: "2006-05"
 1537	squat weegee sqouija	0		Last Available: "2011-12"
 1538	jittery ruddy sparkly engagement ring	0		Maximum HP Percent: +40, Single Equip
 1539	jittery Tam O'Shatner	0		Meat Drop: +50, Softcore Only, Last Available: "2005-03"
-1540	miser's flame-wreathed Grimacite goggles	0		Hot Spell Damage: +10, Meat Drop: +10, Familiar Effect: "1xVolley, 1xLep, cap 31", Last Available: "2008-10"
+1540	miser's flame-wreathed Grimacite goggles	0		Hot Spell Damage: +10, Meat Drop: +10, Last Available: "2008-10", Familiar Effect: "1xVolley, 1xLep, cap 31"
 1541	upside-down Grimacite glaive of Tarzan of terror	0		Experience (Muscle): +3, Spooky Spell Damage: +10, Last Available: "2008-10"
-1542	sinister Da Vinci's Grimacite greaves	0		Experience (Mysticality): +5, Spell Damage: +10, Familiar Effect: "2xBarrr, 3xGhoul, cap 37", Last Available: "2008-10"
+1542	sinister Da Vinci's Grimacite greaves	0		Experience (Mysticality): +5, Spell Damage: +10, Last Available: "2008-10", Familiar Effect: "2xBarrr, 3xGhoul, cap 37"
 1543	Rosewater's beefcake's Grimacite garter	0		Muscle: +25, Mysticality Percent: +30, Last Available: "2008-10"
 1544	asbestos-lined Oprah's Grimacite galoshes	0		Maximum MP Percent: +50, Hot Resistance: +5, Last Available: "2008-10"
 1545	boxer's Grimacite gorget of vim and vigor	0		Muscle Percent: +10, Maximum HP Percent: +50, Last Available: "2008-10"
@@ -1528,7 +1528,7 @@
 1548	brainy beefcake's Gazpacho's Glacial Grimoire	0		Muscle: +25, Mysticality: +5
 1549	MSG	0		
 1550	second-hand knockoff engagement ring of the sewer	0		Stench Damage: +25, Single Equip
-1551	bad extra-dry skewed bottle of Domesticated Turkey	5	decent	
+1551	extra-dry bad skewed bottle of Domesticated Turkey	5	decent	
 1552	hand-crafted shaking bottle of Definit	4	EPIC	
 1553	bad bottle of Calcutta Emerald	3	decent	
 1554	watered-down drinkable bottle of Lieutenant Freeman	2	good	
@@ -1540,44 +1540,44 @@
 1560	moldy cocktail onion	4	crappy	
 1561	bite-sized stale raspberry	1	decent	
 1562	spoiled spinning tumbling kiwi	3	crappy	
-1563	weak mediocre spinning whiskey bittersweet	2	decent	
+1563	mediocre weak spinning whiskey bittersweet	2	decent	
 1564	aged weak wobbly mimosette	2	awesome	
 1565	mediocre lime green tequila sunset	3	decent	
 1566	bad zmobie	4	decent	Wiki Name: "Zmobie (drink)"
-1567	mediocre enchanted boozy gin and tonic	5	decent	Effect: "Proprie Tea", Effect Duration: 10
+1567	enchanted boozy mediocre gin and tonic	5	decent	Effect: "Proprie Tea", Effect Duration: 10
 1568	drinkable spinning vodka and tonic	3	good	
 1569	artisanal practically non-alcoholic vodka gibson	1	super EPIC	
 1570	drinkable gibson	4	good	
-1571	acceptable upside-down mirror parisian cathouse	3	good	
+1571	acceptable mirror upside-down parisian cathouse	3	good	
 1572	hand-crafted lime green rabbit punch	3	EPIC	
 1573	drinkable strong caipifruta	5	good	
 1574	hand-crafted teqiwila	3	EPIC	
 1575	acceptable Divine	4	good	
 1576	tolerable maroon Gordon Bennett	3	good	
-1577	weak perfectly mixed tangarita	2	super ultra EPIC	
+1577	perfectly mixed weak tangarita	2	super ultra EPIC	
 1578	drinkable mandarina colada	3	good	
-1579	mediocre watered-down wobbly gimlet	2	decent	
-1580	tolerable boozy maroon brick road	5	good	
+1579	watered-down mediocre wobbly gimlet	2	decent	
+1580	boozy tolerable maroon brick road	5	good	
 1581	hand-crafted vodka stratocaster	3	EPIC	
-1582	tolerable watered-down Neuromancer	2	good	
-1583	bad watered-down prussian cathouse	2	decent	
+1582	watered-down tolerable Neuromancer	2	good	
+1583	watered-down bad prussian cathouse	2	decent	
 1584	drinkable blinking Mae West	4	good	
-1585	perfectly mixed enchanted narrow Mon Tiki	4	EPIC	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10
+1585	enchanted perfectly mixed narrow Mon Tiki	4	EPIC	Effect: "Blessing of the Pervy Noodles", Effect Duration: 10
 1586	bad teqiwila slammer	3	decent	
-1587	stale snack-sized Knob lo mein	2	decent	
+1587	snack-sized stale Knob lo mein	2	decent	
 1588	miniature rotten asparagus lo mein	2	crappy	
-1589	adequate thick Knoll lo mein	5	good	
+1589	thick adequate Knoll lo mein	5	good	
 1590	flavorless huge lo mein	6	decent	
-1591	low-calorie flavorless upside-down olive lo mein	1	decent	
-1592	moldy enchanted hot hi mein	4	crappy	Effect: "Tearful, Fearful", Effect Duration: 10
+1591	flavorless low-calorie upside-down olive lo mein	1	decent	
+1592	enchanted moldy hot hi mein	4	crappy	Effect: "Tearful, Fearful", Effect Duration: 10
 1593	moldy hi mein	3	crappy	
-1594	tasty snack-sized blue wobbly hi mein	2	awesome	
+1594	tasty snack-sized wobbly blue hi mein	2	awesome	
 1595	flavorless blurry hi mein	3	decent	
-1596	enchanted spoiled sleazy hi mein	3	crappy	Effect: "Red-Shirted Escort", Effect Duration: 30
+1596	spoiled enchanted sleazy hi mein	3	crappy	Effect: "Red-Shirted Escort", Effect Duration: 30
 1597	auspicious Junior LAAAAME merit badge	0		Item Drop: +10, Last Available: "2006-05"
 1598	pulsating huge friendly Senior LAAAAME merit badge	0		Familiar Weight: +3, Last Available: "2006-05"
 1599	jazz soap	0		Free Pull, Effect: "Jazz Hands", Effect Duration: 20
-1600	watered-down drinkable gray tangarita with a fly in it	2	good	
+1600	drinkable watered-down gray tangarita with a fly in it	2	good	
 1601	artisanal mandarina colada with a fly in it	3	EPIC	
 1602	acceptable practically non-alcoholic prussian cathouse with a fly in it	1	good	
 1603	acceptable Mae West with a fly in it	3	good	
@@ -1592,8 +1592,8 @@
 1612	altered green concentrated cordial of concentration	0		Effect: "Pyromania", Effect Duration: 22
 1613	spinning reassuring coffin lid	0		Spooky Resistance: +1, Damage Reduction: 3
 1614	zippy satin shield	0		Initiative: +20, Damage Reduction: 5
-1615	squat twirling Lo Pan's Cerebral Cloche	0		Spell Critical Percent: +30, Familiar Effect: "1.5xLep, cap 22", Last Available: "2006-06"
-1616	bouncing aromatic Cerebral Culottes	0		Stench Resistance: +1, Familiar Effect: "3xBarrr, 1xGhoul, cap 22", Last Available: "2006-06"
+1615	squat twirling Lo Pan's Cerebral Cloche	0		Spell Critical Percent: +30, Last Available: "2006-06", Familiar Effect: "1.5xLep, cap 22"
+1616	bouncing aromatic Cerebral Culottes	0		Stench Resistance: +1, Last Available: "2006-06", Familiar Effect: "3xBarrr, 1xGhoul, cap 22"
 1617	mirror electrified grievous Cerebral Crossbow of the empath	0		Weapon Damage Percent: +50, Familiar Weight: +5, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-06"
 1618	ice stein	0		Last Available: "2006-06"
 1619	cyan munchies pill	0		Last Available: "2006-06"
@@ -1605,7 +1605,7 @@
 1625	polymerized magnetized green-frosted astral cupcake	0		Effect: "From Nantucket", Effect Duration: 68, Last Available: "2006-06"
 1626	deionized blinking shaking orange-frosted astral cupcake	0		Effect: "PERL of Great Price", Effect Duration: 56, Last Available: "2006-06"
 1627	unsweetened tumbling purple-frosted astral cupcake	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 14, Last Available: "2006-06"
-1628	polarized blinking green pink-frosted astral cupcake	0		Effect: "Salty Mouth", Effect Duration: 45, Last Available: "2006-06"
+1628	polarized green blinking pink-frosted astral cupcake	0		Effect: "Salty Mouth", Effect Duration: 45, Last Available: "2006-06"
 1629	upside-down raspberry beret of the wise owl	0		Mysticality: +20, Familiar Effect: "2xPotato, 2xLep, cap 12"
 1630	pixel shield of the dark arts	0		Spell Damage Percent: +100, Damage Reduction: 3
 1631	beer cartilage	0		
@@ -1616,21 +1616,21 @@
 1636	Toddler-sized Dragon Costume	0		Familiar Weight: +5, Item Drop: +5, Softcore Only
 1637	extra-dry teal lotion of hotness	0		Effect: "Fudgehound", Effect Duration: 24
 1638	alkaline cold-filtered lotion of coldness	0		Effect: "Bestial Sympathy", Effect Duration: 13
-1639	flattened magnetized denatured tumbling upside-down lotion of spookiness	0		Effect: "Compensatory Cruelness", Effect Duration: 23
+1639	flattened magnetized denatured upside-down tumbling lotion of spookiness	0		Effect: "Compensatory Cruelness", Effect Duration: 23
 1640	concentrated magnetized lotion of stench	0		Effect: "Impregnabili Tea", Effect Duration: 57
 1641	dry diffused gray blinking lotion of sleaziness	0		Effect: "Neuromancy", Effect Duration: 44
 1642	bad triple-distilled Grimacite Bock	7	decent	Last Available: "2008-11"
 1643	moldy pulsating wedge of gray cheese	4	crappy	Last Available: "2008-11"
 1644	hot and sauce	0		
 1645	and sauce	0		
-1646	shaking mirror lime green and sauce	0		
+1646	mirror lime green shaking and sauce	0		
 1647	stench and sauce	0		
 1648	shaking sleazy and sauce	0		
 1649	huge brick	0		Free Pull
 1650	tumbling milk of magnesium	0		
-1651	rotten immense foie gras	6	crappy	
+1651	immense rotten foie gras	6	crappy	
 1652	non-unsweetened candy brain	0		Effect: "Human-Demon Hybrid", Effect Duration: 67, Last Available: "2020-09"
-1653	bouncing tumbling zippy aromatic jewel-eyed wizard hat of doom	0		Spooky Spell Damage: +50, Stench Resistance: +1, Initiative: +20, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2", Last Available: "2006-07"
+1653	bouncing tumbling zippy aromatic jewel-eyed wizard hat of doom	0		Spooky Spell Damage: +50, Stench Resistance: +1, Initiative: +20, Softcore Only, Conditional Skill (Equipped): "Magic Missile", Last Available: "2006-07", Familiar Effect: "atk, 5xVolley, 5xLep, cap 2"
 1654	shaking educational wad of Crovacite of extreme caution	0		Experience: +1, Monster Level: -25
 1655	pulsating educational collar of the overflowing toilet	0		Experience: +1, Stench Spell Damage: +50
 1656	squat White Citadel Satisfaction Satchel	0		
@@ -1649,13 +1649,13 @@
 1669	Newton's star stiletto	0		Experience (Mysticality): +3
 1670	fraudwort	0		
 1671	shysterweed	0		
-1672	upside-down red shaking swindleblossom	0		
+1672	shaking red upside-down swindleblossom	0		
 1673	jittery ghostly curative ruddy grave robbing shovel	0		Maximum HP Percent: +40, HP Regen Min: 3, HP Regen Max: 5
 1674	mirror boxer's superhero mask	0		Muscle Percent: +10, Softcore Only, Familiar Effect: "1xLep, 1xFairy, cap 2"
-1675	mirror jittery ore	0		
+1675	jittery mirror ore	0		
 1676	red styrofoam ore	0		
 1677	mirror bubblewrap ore	0		
-1678	narrow pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log", Last Available: "2011-12"
+1678	narrow pet rock &quot;Groucho&quot; disguise	0		Familiar Weight: +11, Last Available: "2011-12", Equips On: "Pet Rock | Toothsome Rock | Bulky Buddy Box | Holiday Log"
 1679	miser's sword of courage	0		Spooky Resistance: +3, Meat Drop: +10
 1680	tumbling friendly sage staff	0		Mysticality Percent: +10, Familiar Weight: +3
 1681	yellow smartaleck's bubblewrap sword of horror	0		Moxie Percent: +30, Spooky Spell Damage: +25
@@ -1673,12 +1673,12 @@
 1693	denatured Vulcanized eyedrops of newt	0		Effect: "Flimsy Shield of the Pastalord", Effect Duration: 18
 1694	oxidized Frogade	0		Effect: "El Tango de la Maldita Suegra", Effect Duration: 42
 1695	alkaline liquefied papotion of papower	0		Effect: "Rage of the Reindeer", Effect Duration: 55
-1696	adequate low-calorie narrow royal jelly taco	1	good	
-1697	half-sized flavorless tofu taco	2	decent	
+1696	low-calorie adequate narrow royal jelly taco	1	good	
+1697	flavorless half-sized tofu taco	2	decent	
 1698	stale half-sized gray jumping bean taco	2	decent	
-1699	flavorless snack-sized enchanted catgut taco	2	decent	Effect: "Sparkling Consciousness", Effect Duration: 40
-1700	super-sized bland goat cheese taco	5	decent	
-1701	small normal bouncing pr0n taco	2	good	
+1699	snack-sized flavorless enchanted catgut taco	2	decent	Effect: "Sparkling Consciousness", Effect Duration: 40
+1700	bland super-sized goat cheese taco	5	decent	
+1701	normal small bouncing pr0n taco	2	good	
 1702	quantum adjusted alphabet gum	0		Effect: "Human-Weird Thing Hybrid", Effect Duration: 33
 1703	Comma Chameleon egg	0		Free Pull
 1704	shingle	0		
@@ -1750,7 +1750,7 @@
 1771	gray occult butcherknife	0		Spell Damage Percent: +25
 1772	maroon experienced corn holder	0		Experience: +2
 1773	tumbling brainy eggbeater	0		Mysticality: +5
-1774	smooth weak bottle of popskull	2	awesome	
+1774	weak smooth bottle of popskull	2	awesome	
 1775	blinking sizzling dishrag	0		Hot Damage: +10
 1776	super-sized normal stale baguette	5	good	
 1777	leftovers of indeterminate origin	0		
@@ -1759,7 +1759,7 @@
 1780	ram stick of the bloodbag	0		Maximum HP: +100
 1781	fuchsia careful enchantlers	0		Monster Level: -10, Familiar Effect: "hot atk, 1xLep, cap 28"
 1782	bouncing bouncing Lo Pan's curative ram-battering staff	0		Spell Critical Percent: +30, HP Regen Min: 3, HP Regen Max: 5
-1783	rotten snack-sized blurry crazy Turkish delight	2	crappy	
+1783	snack-sized rotten blurry crazy Turkish delight	2	crappy	
 1784	smartaleck's Snow Queen Crown of wisdom	0		Mysticality: +15, Moxie Percent: +30, Familiar Effect: "cold atk, 1xGhuol, cap 28"
 1785	prompt Temple Grandin's Van der Graaf ga-ga radio	0		Familiar Weight: +7, Adventures: +3, MP Regen Min: 5, MP Regen Max: 7
 1786	six pack of Mountain Stream	0		
@@ -1768,7 +1768,7 @@
 1789	huge Mob Penguin	0		
 1790	weak bad Ram's Face Lager	2	decent	
 1791	maroon ram horns	0		
-1792	avaricious Jack Frost's Travoltan trousers of the cheetah	0		Cold Spell Damage: +50, Meat Drop: +30, Initiative: +60, Softcore Only, Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25", Last Available: "2006-09"
+1792	avaricious Jack Frost's Travoltan trousers of the cheetah	0		Cold Spell Damage: +50, Meat Drop: +30, Initiative: +60, Softcore Only, Last Available: "2006-09", Familiar Effect: "1xVolley, 2xLep, 1xFairy, cap 25"
 1793	pool cue of the pedagogue of Leguizamo	0		Experience: +3, Monster Level: +20
 1794	triple-warmed spinning green handful of hand chalk	0		Effect: "Craft Tea", Effect Duration: 69
 1795	Counterclockwise Watch of Leguizamo	0		Monster Level: +20, Single Equip
@@ -1794,7 +1794,7 @@
 1815	blinking seventh thoracic vertebra	0		
 1816	eighth thoracic vertebra	0		
 1817	ninth thoracic vertebra	0		
-1818	jittery lime green tenth thoracic vertebra	0		
+1818	lime green jittery tenth thoracic vertebra	0		
 1819	upside-down eleventh thoracic vertebra	0		
 1820	twelfth thoracic vertebra	0		
 1821	first lumbar vertebra	0		
@@ -1838,7 +1838,7 @@
 1859	spinning right ninth rib	0		
 1860	right tenth rib	0		
 1861	right eleventh rib	0		
-1862	green mirror right twelfth rib	0		
+1862	mirror green right twelfth rib	0		
 1863	animal pelvis	0		
 1864	left scapula	0		
 1865	right scapula	0		
@@ -1923,19 +1923,19 @@
 1946	bouncing yellow steel-toed deadly accordion pin	0		Weapon Damage: +5, Damage Reduction: 9, Class: "Accordion Thief", Single Equip
 1947	pulsating flame-wreathed shellacked worn tophat	0		Damage Reduction: 7, Hot Spell Damage: +10, Familiar Effect: "1xBarrr, 1xLep, cap 31"
 1948	spinning pulsating occult tap shoes of Calamity Jane	0		Spell Damage Percent: +25, Critical Hit Percent: +15, Single Equip
-1949	rotten small olive Manetwich	2	crappy	
+1949	small rotten olive Manetwich	2	crappy	
 1950	bottle of Vangoghbitussin	0		
-1951	weak hand-crafted bottle of Pinot Renoir	2	EPIC	
-1952	rotten snack-sized red narrow desiccated apricot	2	crappy	
-1953	fortified delicious flute of flat champagne	5	awesome	
-1954	diet rotten dehydrated caviar	1	crappy	
+1951	hand-crafted weak bottle of Pinot Renoir	2	EPIC	
+1952	rotten snack-sized narrow red desiccated apricot	2	crappy	
+1953	delicious fortified flute of flat champagne	5	awesome	
+1954	rotten diet dehydrated caviar	1	crappy	
 1955	fuchsia styrofoam peanuts	0		
 1956	fancy weak mediocre tumbling blinking snifter of thoroughly aged brandy	2	decent	Effect: "Fire Inside", Effect Duration: 10
 1957	quill pen	0		
 1958	inkwell	0		
 1959	tattered scrap of paper	0		
 1960	blinking scroll of forbidden unspeakable evil	0		
-1961	blurry wobbly can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
+1961	wobbly blurry can of Binarrrca	0		Free Pull, Effect: "Talking Like a Pirate", Effect Duration: 50
 1962	quantum activated Bit O' Ectoplasm	0		Effect: "Graham Crackling", Effect Duration: 25
 1963	dance card	0		
 1964	sizzling opera mask	0		Hot Damage: +10, Familiar Effect: "spooky atk, 1xBarrr, cap 2"
@@ -1943,11 +1943,11 @@
 1966	Amulet of Yendor of the brazier of courage	0		Hot Spell Damage: +25, Spooky Resistance: +3, Single Equip, Last Available: "2011-12"
 1967	spinning jitterbug larva	0		Free Pull, Last Available: "2007-10"
 1968	pulsating bottle of perfume	0		Familiar Weight: +5
-1969	ghostly skewed spoon!	0		Familiar Weight: +5
+1969	skewed ghostly spoon!	0		Familiar Weight: +5
 1970	twirling nervous tick egg	0		Free Pull, Last Available: "2007-10"
 1971	plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13, Softcore Only, Last Available: "2006-10"
 1972	medical-grade personal trainer's shrimp fork	0		Experience Percent (Muscle): +10, HP Regen Min: 7, HP Regen Max: 10
-1973	ghostly upside-down purple half of a memo	0		
+1973	upside-down purple ghostly half of a memo	0		
 1974	pulsating cocoabo	0		
 1975	upside-down baby gravy fairy	0		
 1976	fuchsia gravy fairy	0		
@@ -1956,14 +1956,14 @@
 1979	pulsating tumbling gravy fairy	0		
 1980	pulsating sleazy gravy fairy	0		
 1981	teal astral badger	0		
-1982	bouncing mirror MagiMechTech MicroMechaMech	0		
+1982	mirror bouncing MagiMechTech MicroMechaMech	0		
 1983	hand turkey	0		
 1984	snowy owl	0		
 1985	mirror scary death orb	0		
 1986	mind flayer	0		
 1987	ghostly undead elbow macaroni	0		
 1988	fuchsia angry cow	0		
-1989	mirror tumbling Cheshire bitten	0		
+1989	tumbling mirror Cheshire bitten	0		
 1990	yo-yo	0		
 1991	shaking rubber WWJD? bracelet	0		
 1992	rubber WWBD? bracelet	0		
@@ -1981,7 +1981,7 @@
 2004	jittery Chori Zo trading card	0		
 2005	Morbidda trading card	0		
 2006	Poison Oak trading card	0		
-2007	twirling shaking Princess Rutabaga trading card	0		
+2007	shaking twirling Princess Rutabaga trading card	0		
 2008	spinning Roo trading card	0		
 2009	Woldo trading card	0		
 2010	The Snake trading card	0		
@@ -1994,7 +1994,7 @@
 2017	spade necklace	0		
 2018	upside-down club necklace	0		
 2019	cream pie	0		Free Pull
-2020	big tasty fuchsia cherry pie	5	awesome	
+2020	tasty big fuchsia cherry pie	5	awesome	
 2021	adequate squat strawberry pie	4	good	
 2022	bland lemon meringue pie	3	decent	
 2023	special Genalen&trade; Bottle	1	decent	Effect: "Well-Oiled", Effect Duration: 25
@@ -2021,8 +2021,8 @@
 2044	your father's MacGuffin diary	0		
 2045	bland small brain-meltingly-hot chicken wings	2	decent	
 2046	rotten frat brats	3	crappy	
-2047	jumbo decent knob ka-bobs	5	good	
-2049	bad watered-down can of Swiller	2	decent	
+2047	decent jumbo knob ka-bobs	5	good	
+2049	watered-down bad can of Swiller	2	decent	
 2050	spinning broken wings	0		
 2051	sunken eyes	0		
 2052	wobbly reassembled blackbird	0		
@@ -2090,7 +2090,7 @@
 2114	lime green narrow yo	0		Last Available: "2006-12"
 2115	boxer's prehistoric spear	0		Muscle Percent: +10, Last Available: "2006-12"
 2116	stick-on-a-string	0		Last Available: "2006-12"
-2117	MacGyver's fire of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Familiar Effect: "hot atk, 1xVolley, cap 2", Last Available: "2023-09"
+2117	MacGyver's fire of terror	0		Maximum MP: +100, Spooky Spell Damage: +10, Last Available: "2023-09", Familiar Effect: "hot atk, 1xVolley, cap 2"
 2118	twirling leaf tube	0		Last Available: "2006-12"
 2119	spinning lit cigar	0		Last Available: "2011-12"
 2120	weightlifter's Grateful Undead T-shirt	0		Muscle: +15
@@ -2121,8 +2121,8 @@
 2146	evil teddy bear	0		Last Available: "2006-12"
 2147	evil teddy bear sewing kit	0		
 2148	toothsome rock	0		
-2149	flavorless twirling shaking frank	3	decent	Last Available: "2011-12"
-2150	miniature delicious maroon pulsating mirror plate of franks and beans	2	awesome	Last Available: "2011-12"
+2149	flavorless shaking twirling frank	3	decent	Last Available: "2011-12"
+2150	delicious miniature mirror pulsating maroon plate of franks and beans	2	awesome	Last Available: "2011-12"
 2151	acceptable squat shot of blackberry schnapps	3	good	
 2152	mirror capacitor relay	0		Last Available: "2011-12"
 2153	carbon nanotube frame	0		Last Available: "2011-12"
@@ -2141,9 +2141,9 @@
 2166	ion-pulse modulation stabilizer	0		Last Available: "2011-12"
 2167	hyperbolic plasma focuser	0		Last Available: "2011-12"
 2168	wobbly prompt dangerous toy ray gun	0		Weapon Damage: +10, Adventures: +3, Last Available: "2006-12"
-2169	ghostly nasty sinister toy space helmet	0		Spell Damage: +10, Stench Damage: +5, Familiar Effect: "0.5xPotato, 1xFairy, cap 43", Last Available: "2006-12"
+2169	ghostly nasty sinister toy space helmet	0		Spell Damage: +10, Stench Damage: +5, Last Available: "2006-12", Familiar Effect: "0.5xPotato, 1xFairy, cap 43"
 2170	MagiMechTech NanoMechaMech	0		Single Equip, Last Available: "2006-12"
-2171	narrow nasty energetic astronaut pants	0		Maximum MP Percent: +20, Stench Damage: +5, Familiar Effect: "1xVolley, 1.5xPotato, cap 43", Last Available: "2006-12"
+2171	narrow nasty energetic astronaut pants	0		Maximum MP Percent: +20, Stench Damage: +5, Last Available: "2006-12", Familiar Effect: "1xVolley, 1.5xPotato, cap 43"
 2172	ghostly supercharged toy jet pack	0		Maximum MP Percent: +30, Last Available: "2006-12"
 2173	triangular stone	0		
 2174	mossy stone sphere	0		
@@ -2165,8 +2165,8 @@
 2190	yuletide troll chrysalis	0		Free Pull, Last Available: "2006-12"
 2191	upside-down book of carols	0		Last Available: "2006-12"
 2192	sheet music	0		Last Available: "2006-12"
-2193	diet flavorless yellow candy stake	1	decent	Last Available: "2006-12"
-2194	fortified drinkable eggnog	5	good	Last Available: "2006-12"
+2193	flavorless diet yellow candy stake	1	decent	Last Available: "2006-12"
+2194	drinkable fortified eggnog	5	good	Last Available: "2006-12"
 2195	moldy bouncing unspeakable fruitcake	4	crappy	Last Available: "2006-12"
 2196	normal gingerbread horror	4	good	Last Available: "2006-12"
 2197	warmed diffused maroon but probably evil chocolate	0		Effect: "Night of the Nachos", Effect Duration: 26, Last Available: "2006-12"
@@ -2182,19 +2182,19 @@
 2207	olive nippy Crimbo tiki necklace	0		Cold Damage: +10, Last Available: "2006-12"
 2208	curative Da Vinci's bobble-hip hula elf doll	0		Experience (Mysticality): +5, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2006-12"
 2209	careful Crimbo ukulele	0		Monster Level: -10, Last Available: "2006-12"
-2210	electrified Tiki lighter of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Stat Tuning: "Moxie", Last Available: "2006-12"
-2211	miser's deck of tropical cards of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +10, Stat Tuning: "Mysticality", Last Available: "2006-12"
-2212	rosewater-soaked chaotic tropical paperweight	0		Spell Critical Percent: +10, Stench Resistance: +3, Stat Tuning: "Muscle", Last Available: "2006-12"
+2210	electrified Tiki lighter of the brazier	0		Hot Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2006-12", Stat Tuning: "Moxie"
+2211	miser's deck of tropical cards of mayonnaise	0		Sleaze Spell Damage: +50, Meat Drop: +10, Last Available: "2006-12", Stat Tuning: "Mysticality"
+2212	rosewater-soaked chaotic tropical paperweight	0		Spell Critical Percent: +10, Stench Resistance: +3, Last Available: "2006-12", Stat Tuning: "Muscle"
 2213	tropical Crimbo pressie	0		Last Available: "2006-12"
 2214	tropical wrapping paper	0		Last Available: "2006-12"
-2215	twirling therapeutic Tropical Crimbo Hat	0		HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "1xLep, 1.5xFairy, cap 25", Last Available: "2006-12"
-2216	forbidden Tropical Crimbo Shorts	0		Spell Damage Percent: +50, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2006-12"
+2215	twirling therapeutic Tropical Crimbo Hat	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2006-12", Familiar Effect: "1xLep, 1.5xFairy, cap 25"
+2216	forbidden Tropical Crimbo Shorts	0		Spell Damage Percent: +50, Last Available: "2006-12", Familiar Effect: "1xPotato, 1xGhoul"
 2217	small toothsome twirling super ka-bob	2	awesome	
 2218	rotten ghostly beer basted brat	3	crappy	
 2219	wobbly narrow scorching Tropical Crimbo Sword	0		Hot Damage: +25, Last Available: "2006-12"
 2220	activated and Crimboween candy	0		Effect: "Enraged", Effect Duration: 66, Last Available: "2020-09"
 2221	Great Ball of Frozen Fire	0		Last Available: "2007-01"
-2222	Jim Carey's grievous liar's pants	0		Weapon Damage Percent: +50, Monster Level: +25, Softcore Only, Familiar Effect: "hot atk, cold atk, cap 25", Last Available: "2007-01"
+2222	Jim Carey's grievous liar's pants	0		Weapon Damage Percent: +50, Monster Level: +25, Softcore Only, Last Available: "2007-01", Familiar Effect: "hot atk, cold atk, cap 25"
 2223	chaotic smartaleck's juggler's balls	0		Moxie Percent: +30, Spell Critical Percent: +10, Softcore Only, Last Available: "2007-01"
 2224	maroon slick pink shirt	0		Moxie: +10, Softcore Only, Last Available: "2007-01"
 2225	familiar doppelg&auml;nger	0		Monster Level: +5, Softcore Only, Last Available: "2007-01"
@@ -2242,11 +2242,11 @@
 2268	toasty Staff of Fats	0		Hot Damage: +5
 2269	adequate sausage wonton	3	good	
 2270	jittery padded arcane researcher's belt	0		Experience Percent (Mysticality): +10, Damage Absorption: +20, Single Equip
-2271	fancy perfectly mixed blue shaking bottle of Merlot	3	EPIC	Effect: "Gummi-Grin", Effect Duration: 45
+2271	perfectly mixed fancy blue shaking bottle of Merlot	3	EPIC	Effect: "Gummi-Grin", Effect Duration: 45
 2272	drinkable bottle of Port	3	good	
 2273	aged bottle of Pinot Noir	4	awesome	
 2274	tolerable bottle of Zinfandel	4	good	
-2275	practically non-alcoholic aged fancy bottle of Marsala	1	awesome	Effect: "Highland Sheen", Effect Duration: 10
+2275	fancy aged practically non-alcoholic bottle of Marsala	1	awesome	Effect: "Highland Sheen", Effect Duration: 10
 2276	enchanted perfectly mixed bottle of Muscat	3	EPIC	Effect: "Your Favorite Flavor", Effect Duration: 15
 2277	maroon shaking Fernswarthy's key	0		
 2278	Fernswarthy's letter	0		
@@ -2274,10 +2274,10 @@
 2300	fingerless hobo gloves	0		
 2301	Chomsky's comic books	0		
 2302	worm-riding hooks	0		
-2303	spinning Libram of Candy Heart Summoning	0		Free Pull, Skill: "Summon Candy Heart", Last Available: "2011-12"
+2303	spinning Libram of Candy Heart Summoning	0		Free Pull, Last Available: "2011-12", Skill: "Summon Candy Heart"
 2304	warmed candy heart	0		Effect: "Egg-stra Arm", Effect Duration: 34, Last Available: "2007-02"
 2305	oxidized super-quantum pink candy heart	0		Effect: "Drunk With Power", Effect Duration: 64, Last Available: "2007-02"
-2306	vacuum-sealed skewed lime green candy heart	0		Effect: "Good Motivator", Effect Duration: 12, Last Available: "2007-02"
+2306	vacuum-sealed lime green skewed candy heart	0		Effect: "Good Motivator", Effect Duration: 12, Last Available: "2007-02"
 2307	quantum electrified candy heart	0		Effect: "Cold-Blooded Warm Fuzzies", Effect Duration: 50, Last Available: "2007-02"
 2308	denatured candy heart	0		Effect: "Dwarven Hardiness", Effect Duration: 67, Last Available: "2007-02"
 2309	quadruple-energized mirror candy heart	0		Effect: "Can't Smell Nothin'", Effect Duration: 20, Last Available: "2007-02"
@@ -2290,7 +2290,7 @@
 2316	broken carburetor	0		
 2317	ghostly bronze token	0		
 2318	bomb	0		
-2319	blue shaking carved wheel	0		
+2319	shaking blue carved wheel	0		
 2320	worm-riding manual page	0		
 2321	worm-riding manual page 2	0		
 2322	ghostly worm-riding manual pages 3-15	0		
@@ -2311,7 +2311,7 @@
 2337	baleful reinforced beaded headband	0		Spell Damage: +25, Familiar Effect: "0.5xBarrr, 1xFairy, cap 42"
 2338	delicious pudding	4	awesome	Wiki Name: "black pudding (food)"
 2339	hand-crafted irresponsibly strong Blackfly Chardonnay	10	EPIC	
-2340	watered-down acceptable & tan	2	good	
+2340	acceptable watered-down & tan	2	good	
 2341	pepper	0		
 2342	bland teal forest cake	3	decent	
 2343	yummy forest ham	3	awesome	
@@ -2344,9 +2344,9 @@
 2370	natural fennel soda	0		
 2371	tumbling smoke bomb	0		
 2372	bunch of bananas	0		
-2373	huge special spoiled banana	10	crappy	Effect: "Berry Critical", Effect Duration: 10
+2373	spoiled huge special banana	10	crappy	Effect: "Berry Critical", Effect Duration: 10
 2374	banana peel	0		
-2375	special spoiled banana cream pie	4	crappy	Effect: "Cletus's Canticle of Celerity", Effect Duration: 15
+2375	spoiled special banana cream pie	4	crappy	Effect: "Cletus's Canticle of Celerity", Effect Duration: 15
 2376	tolerable banana daiquiri	3	good	
 2377	drinkable weak bungle in the jungle	2	good	
 2378	red banana spritzer	0		
@@ -2393,7 +2393,7 @@
 2419	ionized ghostly bottle of rhinoceros hormones	0		Effect: "Human-Hippy Hybrid", Effect Duration: 26
 2420	activated dry teeny-tiny magic scroll	0		Effect: "Liquidy Smoky", Effect Duration: 23
 2421	warmed polymerized bottle of pirate juice	0		Effect: "Barbecue Saucy", Effect Duration: 62
-2422	super-liquefied blurry spinning irradiated pet snacks	0		Effect: "Whole Latte Love", Effect Duration: 28
+2422	super-liquefied spinning blurry irradiated pet snacks	0		Effect: "Whole Latte Love", Effect Duration: 28
 2423	galvanized irradiated Mick's IcyVapoHotness Inhaler	0		Effect: "Hood Ridin'", Effect Duration: 48
 2424	tarnished cyclops eyedrops	0		Effect: "Held Closer", Effect Duration: 35
 2425	extra-nitrogenated quadruple-colloidal olive can of spinach	0		Effect: "Ocelot Eyes", Effect Duration: 57
@@ -2403,19 +2403,19 @@
 2429	polarized quantum shaking Eau de Guaneau	0		Effect: "Feline Ferocity", Effect Duration: 42
 2430	non-warmed extra-enhanced bag of lard	0		Effect: "White Knuckles", Effect Duration: 14
 2431	irradiated non-pickled tumbling bottle of Mystic Shell	0		Effect: "Heart Aflame", Effect Duration: 50
-2432	double-activated non-galvanized olive shaking SPF 451 lip balm	0		Effect: "Ice Packed", Effect Duration: 33
+2432	double-activated non-galvanized shaking olive SPF 451 lip balm	0		Effect: "Ice Packed", Effect Duration: 33
 2433	boiled polarized skewed bottle of antifreeze	0		Effect: "Red Misty-Eyed", Effect Duration: 35
 2434	altered diffused oxidized eyedrops	0		Effect: "Cool, Catlike", Effect Duration: 39
 2435	non-cold-filtered Dogsgotnonoz pills	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 15
-2436	nitrogenated ghostly lime green donkey flipbook	0		Effect: "Fit To Be Tide", Effect Duration: 41
+2436	nitrogenated lime green ghostly donkey flipbook	0		Effect: "Fit To Be Tide", Effect Duration: 41
 2437	New Cloaca-Cola	0		
 2438	scented massage oil	0		
-2439	upside-down teal poltergeist-in-the-jar-o	0		
+2439	teal upside-down poltergeist-in-the-jar-o	0		
 2440	unnatural gas	0		
 2441	Knob Goblin Encryption Key	0		
 2442	Cobb's Knob map	0		
 2443	dangerous Samson's pink glowstick	0		Experience (Muscle): +5, Weapon Damage: +10, Last Available: "2007-03"
-2444	delicious high-proof wobbly Supernova Champagne	9	awesome	
+2444	high-proof delicious wobbly Supernova Champagne	9	awesome	
 2445	Deactivated O. A. F.	0		Last Available: "2007-04"
 2446	twirling tumbling hardware upgrade	0		Familiar Weight: +5, Last Available: "2007-04"
 2447	bad penguin egg	0		Free Pull
@@ -2495,11 +2495,11 @@
 2522	tolerable thistle wine	3	good	
 2523	megatofu	0		
 2524	shaking displaced fish	0		
-2525	special bland fish	4	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 25
-2526	tiny decent fish casserole	1	good	
-2527	bland tiny purple wobbly fish lasagna	1	decent	
+2525	bland special fish	4	decent	Effect: "Aloysius' Antiphon of Aptitude", Effect Duration: 25
+2526	decent tiny fish casserole	1	good	
+2527	tiny bland purple wobbly fish lasagna	1	decent	
 2528	filet of tangy gnat (&quot;fotelif&quot;)	0		
-2529	flavorless gigantic gray gnatloaf	8	decent	
+2529	gigantic flavorless gray gnatloaf	8	decent	
 2530	immense decent gnatloaf casserole	6	good	
 2531	delicious gigantic teal gnat lasagna	10	awesome	
 2532	jittery pork	0		
@@ -2514,11 +2514,11 @@
 2541	Mayflower bouquet	0		Familiar Weight: +5, Softcore Only, Last Available: "2007-05"
 2542	oxidized gray lesser grodulated violet	0		Effect: "Oriental Mysticism", Effect Duration: 42, Last Available: "2007-05"
 2543	quadruple-frozen quantum blurry tin magnolia	0		Effect: "Scavengers Scavenging", Effect Duration: 33, Last Available: "2007-05"
-2544	colloidal modified anodized blue twirling begpwnia	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 64, Last Available: "2007-05"
+2544	colloidal modified anodized twirling blue begpwnia	0		Effect: "Blessing of the Hot Linguine", Effect Duration: 64, Last Available: "2007-05"
 2545	dry blue upsy daisy	0		Effect: "Shawarma Warm War", Effect Duration: 66, Last Available: "2007-05"
 2546	frozen half-orchid	0		Effect: "There Wolf", Effect Duration: 11, Last Available: "2007-05"
 2547	blinking greedy tin star of the cheetah	0		Meat Drop: +20, Initiative: +60, Last Available: "2007-05"
-2548	mirror groovy sage outrageous sombrero	0		Mysticality Percent: +10, Moxie Percent: +10, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2007-05"
+2548	mirror groovy sage outrageous sombrero	0		Mysticality Percent: +10, Moxie Percent: +10, Last Available: "2007-05", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
 2549	&quot;Humorous&quot; T-shirt of the dark arts of the boozehound	0		Spell Damage Percent: +100, Booze Drop: +100, Last Available: "2007-05"
 2550	Peppercorns of Power	0		
 2551	vial of mojo	0		
@@ -2534,10 +2534,10 @@
 2561	skewed perfumed chaotic Greek Pasta Spoon of Peril of the bloodbag	0		Maximum HP: +100, Spell Critical Percent: +10, Stench Resistance: +5, Class: "Pastamancer"
 2562	squat half-rotten brain	0		
 2563	ghostly bonesaw	0		
-2564	ghostly shaking blinking plus-sized phylactery	0		
+2564	shaking ghostly blinking plus-sized phylactery	0		
 2565	can of Ghuol-B-Gone&trade;	0		
 2566	Azazel's unicorn	0		
-2567	pulsating green Azazel's lollipop	0		
+2567	green pulsating Azazel's lollipop	0		
 2568	Azazel's tutu	0		
 2569	electrified upside-down ant agonist	0		Effect: "Berry Defensive", Effect Duration: 21
 2570	tumbling pulsating ant hoe	0		Familiar Effect: "sleaze damage, meat"
@@ -2559,9 +2559,9 @@
 2586	extremely unsafe General Sage's Lonely Diamonds Club Jacket	0		Weapon Damage Percent: +100
 2587	wobbly wobbly Corporal Fennel's Lonely Clubs Club Jacket of Leguizamo	0		Monster Level: +20
 2588	Private Pepper's Lonely Hearts Club Jacket of wisdom	0		Mysticality: +15
-2589	tasty immense hot date	7	awesome	
+2589	immense tasty hot date	7	awesome	
 2590	acceptable distilled fortified wine	3	good	
-2591	small moldy tasty tart	2	crappy	
+2591	moldy small tasty tart	2	crappy	
 2592	blinking yellow Knob Goblin lunchbox	0		
 2593	moldy tiny pulsating Knob pasty	1	crappy	
 2594	weak artisanal skewed green thermos full of Knob coffee	2	EPIC	
@@ -2570,7 +2570,7 @@
 2597	leathery bat skin	0		
 2598	leathery rat skin	0		
 2599	Discount Telescope Warehouse gift certificate	0		
-2600	tumbling shaking ghostly carbonated water lily	0		
+2600	ghostly shaking tumbling carbonated water lily	0		
 2601	blurry lion tamer's sinister Staff of the Midnight Snack of the ox	0		Muscle: +20, Spell Damage: +10, Experience (familiar): +2
 2602	blinking wool Staff of Blood and Pudding of wisdom of Flo-Jo	0		Mysticality: +15, Cold Resistance: +1, Initiative: +100
 2603	smoldering box	0		
@@ -2585,7 +2585,7 @@
 2612	vinyl coin purse	0		
 2613	rocky raccoon	0		
 2614	mojo filter	0		
-2615	small stale savoy truffle	2	decent	
+2615	stale small savoy truffle	2	decent	
 2616	Magi-Wipes	0		
 2617	tumbling boom	0		
 2618	wobbly fuchsia sharpshooter's Iiti Kitty phone charm	0		Critical Hit Percent: +10, Single Equip
@@ -2622,31 +2622,31 @@
 2649	skewed savvy Lord Spookyraven's ear trumpet	0		Mysticality Percent: +20, Single Equip
 2650	bottled pixie	0		Free Pull
 2651	olive ghostly pixie spog	0		Familiar Weight: +5, Last Available: "2007-06"
-2652	flavorless huge S.T.L.T.	6	decent	Last Available: "2007-06"
+2652	huge flavorless S.T.L.T.	6	decent	Last Available: "2007-06"
 2653	bland honey-dew	3	decent	Last Available: "2007-06"
 2654	perfectly mixed Xanadian	4	EPIC	Last Available: "2007-06"
-2655	flattened liquefied jittery tumbling bottle of absinthe	0		Effect: "Space Cadet", Effect Duration: 30, Last Available: "2007-06"
+2655	flattened liquefied tumbling jittery bottle of absinthe	0		Effect: "Space Cadet", Effect Duration: 30, Last Available: "2007-06"
 2656	cyan blurry educational Drowsy Sword of temperance	0		Experience: +1, Sleaze Resistance: +5
 2657	adequate jittery upside-down escargotsicle	3	good	Last Available: "2007-06"
-2658	irresponsibly strong acceptable skewed bottle of realpagne	6	good	Last Available: "2007-06"
+2658	acceptable irresponsibly strong skewed bottle of realpagne	6	good	Last Available: "2007-06"
 2659	nippy albatross necklace	0		Cold Damage: +10, Single Equip, Last Available: "2007-06"
 2660	denatured shaking not-a-pipe	1	decent	Last Available: "2007-06"
 2661	delicious flask of Amontillado	3	awesome	Last Available: "2007-06"
-2662	educational ball mask	0		Experience: +1, Familiar Effect: "1xBarrr, 1xFairy, cap 22", Last Available: "2007-06"
-2663	horrifying Can-Can skirt	0		Spooky Damage: +25, Familiar Effect: "1.5xFairy, 2xPotato, cap 22", Last Available: "2007-06"
+2662	educational ball mask	0		Experience: +1, Last Available: "2007-06", Familiar Effect: "1xBarrr, 1xFairy, cap 22"
+2663	horrifying Can-Can skirt	0		Spooky Damage: +25, Last Available: "2007-06", Familiar Effect: "1.5xFairy, 2xPotato, cap 22"
 2664	anodized anodized sensitive poetry journal	0		Effect: "Weird Flavor", Effect Duration: 55, Last Available: "2007-06"
 2665	flattened super-warmed bottled inspiration	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 64, Last Available: "2007-06"
 2666	double-pickled cold-filtered bellhop bell	0		Effect: "Hella Smart", Effect Duration: 59, Last Available: "2007-06"
 2667	adjusted spiky collar	0		Effect: "Red Misty-Eyed", Effect Duration: 63, Last Available: "2007-06"
 2668	dried can-can-in-a-can	1		Last Available: "2007-06"
 2669	mixed blurry jittery patent antipsychotics	1		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 45, Last Available: "2007-06"
-2670	compressed ghostly huge upside-down Mariner's Friend cough drops	1		Effect: "Mercenary", Effect Duration: 45, Last Available: "2007-06"
+2670	compressed ghostly upside-down huge Mariner's Friend cough drops	1		Effect: "Mercenary", Effect Duration: 45, Last Available: "2007-06"
 2671	weak bad shot of nepenthe schnapps	2	decent	Last Available: "2007-06"
 2672	library card	0		Last Available: "2007-06"
 2673	Bohemian rhapsody	0		Last Available: "2007-06"
 2674	magnetized bottle of cat tonic	0		Effect: "Human-Undead Hybrid", Effect Duration: 12, Last Available: "2007-06"
 2675	modified green handful of moss	1		Effect: "Robocamo", Effect Duration: 35
-2676	dried tumbling bouncing bit-o-cactus	1		
+2676	dried bouncing tumbling bit-o-cactus	1		
 2677	vaporized maroon protein powder	1		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 30
 2678	spectre scepter	0		
 2679	vacuum-sealed mirror sparkler	0		Effect: "Altered Wavelengths", Effect Duration: 63
@@ -2694,7 +2694,7 @@
 2721	up-at-dawn Annie Oakley's hand-carved staff of the cheetah	0		Critical Hit Percent: +20, Initiative: +60, Adventures: +5
 2722	squat smelly ruddy smartaleck's Staff of the Greasefire of temperance	0		Moxie Percent: +30, Maximum HP Percent: +40, Stench Spell Damage: +10, Sleaze Resistance: +5
 2723	pulsating wool dance instructor's Staff of the Grand Flamb&eacute; of the cougar	0		Moxie: +20, Experience Percent (Moxie): +10, Cold Resistance: +1
-2724	massive normal blurry bowl of rye sprouts	9	good	
+2724	normal massive blurry bowl of rye sprouts	9	good	
 2725	yummy upside-down cob of corn	3	awesome	
 2726	yummy juniper berries	4	awesome	
 2727	spoiled plum	4	crappy	
@@ -2702,12 +2702,12 @@
 2729	snack-sized normal peach	2	good	
 2730	mediocre irresponsibly strong plum wine	8	decent	
 2731	acceptable weak shot of pear schnapps	2	good	
-2732	artisanal practically non-alcoholic shot of peach schnapps	1	EPIC	
+2732	practically non-alcoholic artisanal shot of peach schnapps	1	EPIC	
 2733	thick delicious bunch of square grapes	5	awesome	
 2734	half-sized spoiled brown sugar cane	2	crappy	
-2735	rotten snack-sized sandwich of the gods	2	crappy	
+2735	snack-sized rotten sandwich of the gods	2	crappy	
 2736	fancy hand-crafted Pan-Dimensional Gargle Blaster	3	super ultra EPIC	Effect: "Dance of the Sugar Fairy", Effect Duration: 15
-2737	boiled yellow wobbly skewed leopard-print barbell	1	good	
+2737	boiled skewed wobbly yellow leopard-print barbell	1	good	
 2738	pile of smoking rags	0		
 2739	warmed extra-colloidal denatured skewed panty raider camouflage	0		Effect: "Engorged Weapon", Effect Duration: 36
 2740	pulsating healthy stylish Staff of the Walk-In Freezer of Flo-Jo	0		Moxie: +25, Maximum HP Percent: +20, Initiative: +100
@@ -2789,20 +2789,20 @@
 2816	bouncing electrified Socratic sage Boxers	0		Mysticality Percent: +10, Experience (Mysticality): +1, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, 1xLep"
 2817	executive wool padded Brooch	0		Damage Absorption: +20, Cold Resistance: +1, Meat Drop: +40, Single Equip
 2818	inspector's chaotic personal trainer's Bracelet	0		Experience Percent (Muscle): +10, Spell Critical Percent: +10, Item Drop: +15, Single Equip
-2819	yellow huge sage strapping Grimacite gasmask	0		Muscle: +5, Mysticality Percent: +10, Familiar Effect: "1xLep, 1.5xFairy, cap 37", Last Available: "2008-11"
+2819	yellow huge sage strapping Grimacite gasmask	0		Muscle: +5, Mysticality Percent: +10, Last Available: "2008-11", Familiar Effect: "1xLep, 1.5xFairy, cap 37"
 2820	Jack Frost's Grimacite gat of Calamity Jane	0		Critical Hit Percent: +15, Cold Spell Damage: +50, Last Available: "2008-11"
-2821	rosewater-soaked Tesla Grimacite gaiters	0		Stench Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "3xBarrr, 2xGhoul, cap 37", Last Available: "2008-11"
+2821	rosewater-soaked Tesla Grimacite gaiters	0		Stench Resistance: +3, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2008-11", Familiar Effect: "3xBarrr, 2xGhoul, cap 37"
 2822	wool Grimacite gauntlets of the early riser	0		Cold Resistance: +1, Adventures: +7, Single Equip, Last Available: "2008-11"
 2823	lard-coated chilly Grimacite go-go boots	0		Cold Damage: +5, Sleaze Spell Damage: +25, Single Equip, Last Available: "2008-11"
 2824	rosewater-soaked shellacked Grimacite girdle	0		Damage Reduction: 7, Stench Resistance: +3, Single Equip, Last Available: "2008-11"
 2825	beefcake's Grimacite gown	0		Muscle: +25, Last Available: "2008-11"
 2826	avaricious energetic Samson's Staff of the Kitchen Floor	0		Experience (Muscle): +5, Maximum MP Percent: +20, Meat Drop: +30
-2827	skewed huge anniversary gift box	0		
+2827	huge skewed anniversary gift box	0		
 2828	loaded dice	0		
 2829	really dense meat stack	0		
 2830	digital key lime	0		
 2831	maroon star key lime	0		
-2832	half-sized rotten wobbly digital key lime pie	2	crappy	
+2832	rotten half-sized wobbly digital key lime pie	2	crappy	
 2833	decent star key lime pie	3	good	
 2834	shaking lion tamer's slick bottle-rocket crossbow of dire peril	0		Moxie: +10, Weapon Damage: +20, Experience (familiar): +2, Softcore Only, Conditional Skill (Equipped): "Fire red bottle-rocket", Conditional Skill (Equipped): "Fire blue bottle-rocket", Conditional Skill (Equipped): "Fire orange bottle-rocket", Conditional Skill (Equipped): "Fire purple bottle-rocket", Conditional Skill (Equipped): "Fire black bottle-rocket", Last Available: "2007-07"
 2835	indie comic hipster glasses of the brazier	0		Hot Spell Damage: +25, Softcore Only, Familiar Effect: "1xVolley, 8xLep, cap 2"
@@ -2815,20 +2815,20 @@
 2842	tolerable accidental cider	3	good	
 2843	spoiled dire fudgesicle	3	crappy	
 2844	spinning Sherlock's auspicious nippy curative navel ring of navel gazing	0		Cold Damage: +10, Item Drop: 35, HP Regen Min: 3, HP Regen Max: 5, Single Equip, Softcore Only, Last Available: "2007-09"
-2845	blue pulsating class five ecto-larva	0		Free Pull, Last Available: "2011-12"
+2845	pulsating blue class five ecto-larva	0		Free Pull, Last Available: "2011-12"
 2846	mirror cyan plastic bib	0		Last Available: "2011-12"
 2847	Dallas Dynasty Falcon Crest shield of Calamity Jane	0		Critical Hit Percent: +15, Damage Reduction: 15
 2848	huge Gnomitronic Hyperspatial Demodulizer	0		
 2849	blinking shrunken navigator head	0		
 2850	lousy moonberry wine cooler	4	decent	
-2851	stale huge fine aged cheddarwurst	6	decent	
+2851	huge stale fine aged cheddarwurst	6	decent	
 2852	branch from the Great Tree	0		
 2853	squat Phil Bunion's axe	0		
-2854	lime green spinning bouquet of swamp roses	0		
+2854	spinning lime green bouquet of swamp roses	0		
 2855	huge reassuring huge mosquito proboscis of Calamity Jane	0		Critical Hit Percent: +15, Spooky Resistance: +1
 2856	aerosolized flattened shaking lime green swamp lolly	0		Effect: "Tingly Biceps", Effect Duration: 43
 2857	diffused wobbly seegar butt	0		Effect: "Chalked-Up Teeth", Effect Duration: 37
-2858	squat narrow bottled swamp gas	0		
+2858	narrow squat bottled swamp gas	0		
 2859	gray crafty witch wart of Tarzan	0		Experience (Muscle): +3, Maximum MP: +10
 2860	normal red swamp muck	3	good	
 2861	foul-smelling beefcake's leechknife of the wise owl	0		Muscle: +25, Mysticality: +20, Stench Damage: +10
@@ -2911,26 +2911,26 @@
 2938	Jacob's ladder	0		Familiar Weight: +5
 2939	unemployed hunchbacked minion	0		Free Pull, Last Available: "2008-10"
 2940	spoiled Surprise Egg	3	crappy	
-2941	improved magnetized wet mirror yellow Steal This Candy	0		Effect: "Arcane in the Brain", Effect Duration: 39
+2941	improved magnetized wet yellow mirror Steal This Candy	0		Effect: "Arcane in the Brain", Effect Duration: 39
 2942	frozen aerosolized cyan chocolate filthy lucre	0		Effect: "Banono", Effect Duration: 57
 2943	super-improved Angry Farmer's Wife Candy	0		Effect: "Little Mouse Skull Buddy", Effect Duration: 12
 2945	flame-retardant scandalous party hat	0		Sleaze Damage: +5, Hot Resistance: +1, Familiar Effect: "4xLep, cap 7"
 2946	manspreader's smartaleck's V for Vivala mask	0		Moxie Percent: +30, Monster Level: +10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Creepy Grin", Last Available: "2007-11"
 2947	jittery The Big Book of Pirate Insults	0		
-2948	watered-down acceptable ghostly shot of rotgut	2	good	
+2948	acceptable watered-down ghostly shot of rotgut	2	good	
 2949	quadruple-deionized polarized tumbling jar of &quot;Creole Lady&quot; marrrmalade	0		Effect: "Irresistible Resolve", Effect Duration: 11
 2950	Cap'm Caronch's Map	0		
 2951	gray Orcish Frat House blueprints	0		
 2952	rosy-cheeked glowstick of the businessman	0		Maximum HP Percent: +30, Meat Drop: +50, Last Available: "2007-11"
 2953	yellow charrrm bracelet	0		
 2954	rosewater-soaked tip jar	0		Stench Resistance: +3
-2955	snack-sized yummy mirror yam candy	2	awesome	
+2955	yummy snack-sized mirror yam candy	2	awesome	
 2956	blinking cocktail napkin	0		
 2957	rum barrel charrrm	0		
 2958	adequate enchanted tube of cranberry Go-Goo	3	good	Effect: "Chief Executive Optimism", Effect Duration: 15
 2959	cool rum barrel charrrm bracelet	0		Moxie: +5
-2960	huge stale single-serving herbal stuffing	6	decent	
-2961	small normal packet of tofurkey gravy	2	good	
+2960	stale huge single-serving herbal stuffing	6	decent	
+2961	normal small packet of tofurkey gravy	2	good	
 2962	adequate spinning tofurkey nugget	3	good	
 2963	rigging shampoo	0		
 2964	blue ball polish	0		
@@ -2938,17 +2938,17 @@
 2966	Tom's of the Spanish Main Toothpaste	0		
 2967	activated improved bouncing maroon Swabbie&trade; swab	0		Effect: "Sugar High", Effect Duration: 57
 2968	double-modified blurry Oil of Parrrlay	0		Effect: "Oriental Mysticism", Effect Duration: 45
-2969	normal miniature creamsicle	2	good	
-2970	lousy green jittery cream stout	4	decent	
+2969	miniature normal creamsicle	2	good	
+2970	lousy jittery green cream stout	4	decent	
 2971	therapeutic curmudgel of the dark arts	0		Spell Damage Percent: +100, HP Regen Min: 5, HP Regen Max: 7
 2972	grumpy man charrrm	0		
 2973	sizzling grumpy man charrrm bracelet	0		Hot Damage: +10, Single Equip
 2974	skewed tarrrnish charrrm	0		
 2975	upside-down tarrrnished charrrm bracelet of doom of the cheetah	0		Spooky Spell Damage: +50, Initiative: +60, Single Equip
-2976	watered-down mediocre teal narrow bilge wine	2	decent	
+2976	watered-down mediocre narrow teal bilge wine	2	decent	
 2977	squat witty rapier of chilblains	0		Cold Damage: +25
 2978	blinking reassuring wool yohohoyo	0		Cold Resistance: +1, Spooky Resistance: +1
-2979	irradiated non-boiled maroon bouncing fish-liver oil	0		Effect: "Old School Pompadour", Effect Duration: 66
+2979	irradiated non-boiled bouncing maroon fish-liver oil	0		Effect: "Old School Pompadour", Effect Duration: 66
 2980	wobbly booty chest charrrm	0		
 2981	personal trainer's booty chest charrrm bracelet	0		Experience Percent (Muscle): +10, Single Equip
 2982	cannonball charrrm	0		
@@ -3001,11 +3001,11 @@
 3029	hand-crafted red-headed corpse	3	EPIC	
 3030	distilled lousy kamicorpse-ee	5	decent	
 3031	drinkable corpsel	4	good	
-3032	drinkable weak corpsebite	2	good	
+3032	weak drinkable corpsebite	2	good	
 3033	beefcake's pirate fledges	0		Muscle: +25
 3034	piece of thirteen	0		
 3035	tasty fancy pearl onion	4	awesome	Effect: "The Dinsey Way", Effect Duration: 20
-3036	diet normal sea biscuit	1	good	
+3036	normal diet sea biscuit	1	good	
 3037	drinkable irresponsibly strong bottle of rum	10	good	
 3038	irresponsibly strong hand-crafted bottle of black-label rum	8	EPIC	
 3039	cannonball	0		
@@ -3013,11 +3013,11 @@
 3041	joke scroll	0		
 3042	Crimbo P. R. E. S. S. I. E.	0		Free Pull, Last Available: "2011-12"
 3043	metallic foil bow	0		Familiar Weight: +5, Last Available: "2011-12"
-3044	metallic foil radar dish	0		Familiar Weight: +5, Equips On: "Crimbo P. R. E. S. S. I. E.", Last Available: "2011-12"
-3045	special bland fuchsia nanite-infested gingerbread bugbear	3	decent	Effect: "Almost Cool", Effect Duration: 50, Last Available: "2007-12"
+3044	metallic foil radar dish	0		Familiar Weight: +5, Last Available: "2011-12", Equips On: "Crimbo P. R. E. S. S. I. E."
+3045	bland special fuchsia nanite-infested gingerbread bugbear	3	decent	Effect: "Almost Cool", Effect Duration: 50, Last Available: "2007-12"
 3046	rotten nanite-infested candy cane	3	crappy	Last Available: "2020-09"
-3047	rotten gigantic nanite-infested fruitcake	9	crappy	Last Available: "2007-12"
-3048	triple-distilled lousy nanite-infested eggnog	10	decent	Last Available: "2007-12"
+3047	gigantic rotten nanite-infested fruitcake	9	crappy	Last Available: "2007-12"
+3048	lousy triple-distilled nanite-infested eggnog	10	decent	Last Available: "2007-12"
 3049	El Vibrato power sphere	0		
 3050	horrifying eyepatch	0		Spooky Damage: +25, Familiar Effect: "spooky atk, 1xBarrr"
 3051	Samson's cutlass	0		Experience (Muscle): +5
@@ -3025,7 +3025,7 @@
 3053	lime green mood ring	0		Last Available: "2007-02"
 3054	deionized liquefied quantum candy heart	0		Effect: "Disco State of Mind", Effect Duration: 25, Last Available: "2007-02"
 3055	galvanized cymbal syrup	0		Free Pull, Effect: "Appeteyes", Effect Duration: 56, Last Available: "2007-02"
-3056	hale metallic foil cat ears	0		Maximum HP: +20, Familiar Effect: "atk, cap 7", Last Available: "2007-02"
+3056	hale metallic foil cat ears	0		Maximum HP: +20, Last Available: "2007-02", Familiar Effect: "atk, cap 7"
 3057	nanofiber cloth	0		Last Available: "2007-12"
 3058	purple iGoogly	0		Last Available: "2007-12"
 3059	theoretical string	0		Last Available: "2007-12"
@@ -3043,23 +3043,23 @@
 3071	teal silicon-infused gluteal shield	0		Last Available: "2007-12"
 3072	jittery carbonite visor	0		Last Available: "2007-12"
 3073	set of Unobtainium straps	0		Last Available: "2007-12"
-3074	olive mirror polymorphic fastening apparatus	0		Last Available: "2007-12"
+3074	mirror olive polymorphic fastening apparatus	0		Last Available: "2007-12"
 3075	General Assembly Module	0		Last Available: "2007-12"
 3076	yellow laser targeting chip	0		Last Available: "2007-12"
 3077	hi-density nylocite leg armor	0		Last Available: "2007-12"
 3078	kevlateflocite helmet	0		Last Available: "2007-12"
-3079	Bulky Buddy Box	0		Last Available: "2007-12", Wiki Name: "Bulky Buddy Box (hatchling)"
+3079	Bulky Buddy Box	0		Wiki Name: "Bulky Buddy Box (hatchling)", Last Available: "2007-12"
 3080	teddy borg	0		Last Available: "2007-12"
 3081	blinking flame-wreathed marionette collective	0		Hot Spell Damage: +10, Last Available: "2007-12"
 3082	monomolecular yo-yo	0		Last Available: "2010-12"
-3083	upside-down twirling green gray blob	0		Last Available: "2007-12"
+3083	twirling upside-down green gray blob	0		Last Available: "2007-12"
 3084	narrow smartaleck's borg sock monkey	0		Moxie Percent: +30, Last Available: "2007-12"
 3085	smelly roboduck-on-a-string of Flo-Jo	0		Stench Spell Damage: +10, Initiative: +100, Last Available: "2007-12"
 3086	mylar scout drone	0		Last Available: "2007-12"
 3087	teddy borg sewing kit	0		Last Available: "2007-12"
-3088	purple therapeutic brainy biomechanical crimborg helmet	0		Mysticality: +5, HP Regen Min: 5, HP Regen Max: 7, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2007-12"
+3088	purple therapeutic brainy biomechanical crimborg helmet	0		Mysticality: +5, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2007-12", Familiar Effect: "atk, 1xFairy, cap 37"
 3089	clever Herculean C.B.F.G.	0		Experience (Muscle): +1, Maximum MP: +20, Last Available: "2007-12"
-3090	shellacked sage biomechanical crimborg leg armor	0		Mysticality Percent: +10, Damage Reduction: 7, Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37", Last Available: "2007-12"
+3090	shellacked sage biomechanical crimborg leg armor	0		Mysticality Percent: +10, Damage Reduction: 7, Last Available: "2007-12", Familiar Effect: "1xBarrr, 1.5xGhuol, cap 37"
 3091	double-flattened nitrogenated vitachoconutriment capsule	0		Effect: "Punchy, Murdery", Effect Duration: 58, Last Available: "2007-12"
 3092	shaking huge wicked handmade hobby horse	0		Spell Damage: +5, Last Available: "2007-12"
 3093	jittery ball-in-a-cup of the glutton	0		Food Drop: +100, Last Available: "2007-12"
@@ -3069,14 +3069,14 @@
 3097	fish scaler	0		Last Available: "2007-12"
 3098	huge killing feather	0		Last Available: "2007-12"
 3099	upside-down ring	0		Last Available: "2007-12"
-3100	bouncing squat robotronic egg	0		Last Available: "2007-12"
+3100	squat bouncing robotronic egg	0		Last Available: "2007-12"
 3101	rogue swarmer	0		Last Available: "2007-12"
 3102	sawblade fragment	0		Last Available: "2007-12"
 3103	huge unstable laser battery	0		Last Available: "2007-12"
 3104	hardened vibrating cyborg knife of the bloodbag	0		Damage Reduction: 3, Maximum HP: +100, Last Available: "2007-12"
 3105	blurry arcane researcher's immense cyborg hand of Leguizamo	0		Experience Percent (Mysticality): +10, Monster Level: +20, Last Available: "2007-12"
 3106	Jeselnik's forbidden cyborg stompin' boot of the storm	0		Spell Damage Percent: +50, Maximum MP Percent: +40, Sleaze Damage: +25, Single Equip, Last Available: "2007-12"
-3107	ghostly tumbling deactivated RoboGoose	0		Last Available: "2007-12"
+3107	tumbling ghostly deactivated RoboGoose	0		Last Available: "2007-12"
 3108	overclocked avian microprocessor	0		Familiar Weight: +5, Last Available: "2007-12"
 3109	Miniborg stomper	0		Last Available: "2007-12"
 3110	Miniborg strangler	0		Last Available: "2007-12"
@@ -3086,7 +3086,7 @@
 3114	Miniborg Destroy-O-Bot	0		Last Available: "2007-12"
 3115	twirling old-fashioned Crimbo Pressie	0		Last Available: "2007-12"
 3116	twirling Hodgman	0		
-3117	Libram of Divine Favors	0		Free Pull, Skill: "Summon Party Favor", Last Available: "2011-12"
+3117	Libram of Divine Favors	0		Free Pull, Last Available: "2011-12", Skill: "Summon Party Favor"
 3118	divine noisemaker	0		Last Available: "2008-01"
 3119	divine can of silly string	0		Last Available: "2008-01"
 3120	divine blowout	0		Last Available: "2008-01"
@@ -3125,9 +3125,9 @@
 3153	El Vibrato punchcard (88 holes)	0		
 3154	El Vibrato punchcard (182 holes)	0		
 3155	El Vibrato punchcard (176 holes)	0		
-3156	jittery upside-down El Vibrato punchcard (104 holes)	0		
+3156	upside-down jittery El Vibrato punchcard (104 holes)	0		
 3157	El Vibrato drone	0		
-3158	skewed jittery sparking El Vibrato drone	0		
+3158	jittery skewed sparking El Vibrato drone	0		
 3159	flattened warmed warm El Vibrato drone	0		Effect: "Helping Comes Second", Effect Duration: 15
 3160	colloidal tarnished humming El Vibrato drone	0		Effect: "World's Shortest Giant", Effect Duration: 43
 3161	energized concentrated blinking El Vibrato drone	0		Effect: "Disco State of Mind", Effect Duration: 14
@@ -3138,18 +3138,18 @@
 3166	repaired El Vibrato drone	0		
 3167	shaking augmented El Vibrato drone	0		
 3168	moist vacuum-sealed ghostly seal eyeball	0		Effect: "Standard Cheer", Effect Duration: 20
-3169	half-sized yummy turtle soup	2	awesome	Effect: "[598]A Little Bit Evil"
+3169	yummy half-sized turtle soup	2	awesome	Effect: "[598]A Little Bit Evil"
 3170	evil noodles	0		
 3171	nauseating reagent	0		
 3172	squat evil paper umbrella of extreme caution	0		Monster Level: -25
 3173	magnetized evil vihuela	0		Effect: "Lobos Fresh", Effect Duration: 62
 3174	decent evil boring spaghetti	4	good	
-3175	low-calorie stale blurry evil noodles	1	decent	
+3175	stale low-calorie blurry evil noodles	1	decent	
 3176	rotten blinking evil noodles	3	crappy	
-3177	half-sized fancy bland evil painful penne pasta	2	decent	Effect: "Ninja, Please", Effect Duration: 50
+3177	fancy half-sized bland evil painful penne pasta	2	decent	Effect: "Ninja, Please", Effect Duration: 50
 3178	adequate low-calorie 3vi1 pr0n m4nic0tti	1	good	
-3179	low-calorie spoiled evil ravioli della hippy	1	crappy	
-3180	small adequate evil noodles	2	good	
+3179	spoiled low-calorie evil ravioli della hippy	1	crappy	
+3180	adequate small evil noodles	2	good	
 3181	altered aerosolized olive evil potion of potency	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 42
 3182	frozen energized evil libation of liveliness	0		Effect: "Feroci Tea", Effect Duration: 23
 3183	frozen wobbly evil tomato juice of powerful power	0		Effect: "Human-Elf Hybrid", Effect Duration: 64
@@ -3159,8 +3159,8 @@
 3187	oxidized mirror narrow evil philter of phorce	0		Effect: "Berry Defensive", Effect Duration: 28
 3188	delicious irresponsibly strong an evil sump'm sump'm	9	awesome	
 3189	smooth watered-down evil ducha de oro	2	awesome	
-3190	triple-distilled hand-crafted evil horizontal tango	7	EPIC	
-3191	weak mediocre evil roll in the hay	2	decent	
+3190	hand-crafted triple-distilled evil horizontal tango	7	EPIC	
+3191	mediocre weak evil roll in the hay	2	decent	
 3192	naughty origami kit	0		Last Available: "2008-02"
 3193	naughty fortune teller	0		Softcore Only, Last Available: "2008-02"
 3194	bouncing origami &quot;gentlemen's&quot; magazine	0		Softcore Only, Last Available: "2008-02"
@@ -3192,9 +3192,9 @@
 3220	mirror hobo code binder	0		Free Pull
 3221	gator skin	0		
 3222	dangerous gatorskin umbrella of bravery	0		Weapon Damage: +10, Spooky Resistance: +5
-3223	bouncing wobbly sewer nuggets	0		
+3223	wobbly bouncing sewer nuggets	0		
 3224	sewer wad	0		
-3225	practically non-alcoholic perfectly mixed green bottle of sewage schnapps	1	EPIC	
+3225	perfectly mixed practically non-alcoholic green bottle of sewage schnapps	1	EPIC	
 3226	extra-dry tolerable yellow bottle of Ooze-O	5	good	
 3227	stale gigantic C.H.U.M. chum	7	decent	
 3228	moldy huge unfortunate dumplings	9	crappy	
@@ -3232,7 +3232,7 @@
 3260	chilly lion tamer's weightlifter's Chester's moustache	0		Muscle: +15, Experience (familiar): +2, Cold Damage: +5, Class: "Disco Bandit", Single Equip
 3261	Chester's bag of candy of the scaredy-cat of incineration	0		Monster Level: -15, Hot Spell Damage: +50, Class: "Disco Bandit"
 3262	sharpshooter's rosy-cheeked Chester's cutoffs	0		Maximum HP Percent: +30, Critical Hit Percent: +10, Class: "Disco Bandit", Familiar Effect: "sleaze atk, 1.5xGhuol"
-3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Skill: "Summon Tasteful Items", Last Available: "2008-04"
+3263	Sp'n-Zor's Grimoire of &quot;Tasteful&quot; Gifts	0		Last Available: "2008-04", Skill: "Summon Tasteful Items"
 3264	candygram	0		Last Available: "2008-04"
 3265	tumbling bag of Crotchety Pine saplings	0		
 3266	bag of Saccharine Maple saplings	0		
@@ -3258,7 +3258,7 @@
 3286	twirling miser's Frosty's snowball sack	0		Meat Drop: +10
 3287	quasi-ethereal macaroni fragments	0		Class: "Pastamancer"
 3288	shaking shimmering tendrils	0		Class: "Pastamancer"
-3289	upside-down huge scintillating powder	0		Class: "Pastamancer"
+3289	huge upside-down scintillating powder	0		Class: "Pastamancer"
 3290	cyan abandoned candy	0		
 3291	secret tropical island volcano lair map	0		
 3292	shaking adorable seal larva	0		
@@ -3277,8 +3277,8 @@
 3305	bouncing Safari Jack's moustache	0		
 3306	Yakisoba's hat	0		
 3307	skewed Heimandatz's heart	0		
-3308	red blurry Jocko Homo's head	0		
-3309	narrow olive The Mariachi's guitar case	0		
+3308	blurry red Jocko Homo's head	0		
+3309	olive narrow The Mariachi's guitar case	0		
 3310	narrow Da Vinci's sealskin drum	0		Experience (Mysticality): +5, Class: "Seal Clubber"
 3311	ghostly savvy washboard shield	0		Mysticality Percent: +20, Class: "Turtle Tamer", Damage Reduction: 10
 3312	horrifying spaghetti-box banjo	0		Spooky Damage: +25, Class: "Pastamancer"
@@ -3326,10 +3326,10 @@
 3354	stale banana-frosted king cake	4	decent	Last Available: "2008-08"
 3355	therapeutic brown plastic baby	0		HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2008-08"
 3356	plump juicy grub	0		Last Available: "2008-06"
-3357	spinning skewed shimmering moth	0		Last Available: "2008-06"
+3357	skewed spinning shimmering moth	0		Last Available: "2008-06"
 3358	delectable fire ant	0		Last Available: "2008-06"
 3359	skewed scrumptious ice ant	0		Last Available: "2008-06"
-3360	olive upside-down stinkbug	0		Last Available: "2008-06"
+3360	upside-down olive stinkbug	0		Last Available: "2008-06"
 3361	skewed maroon yummy death watch beetle	0		Last Available: "2008-06"
 3362	tasty louse	0		Last Available: "2008-06"
 3363	stale mole mol&eacute;	4	decent	Last Available: "2008-06"
@@ -3367,12 +3367,12 @@
 3395	huge pulsating careful quilted Hodgman's porkpie hat	0		Damage Absorption: +40, Monster Level: -10, Familiar Effect: "atk, 0.5xVolley, 0.5xFairy"
 3396	rosewater-soaked Annie Oakley's Hodgman's lobsterskin pants	0		Critical Hit Percent: +20, Stench Resistance: +3, Familiar Effect: "atk, 1xPotato"
 3397	mirror reassuring ribald Hodgman's bow tie	0		Sleaze Damage: +10, Spooky Resistance: +1, Single Equip
-3398	high-proof artisanal Hodgman's blanket	8	EPIC	
-3399	artisanal fortified jar of squeeze	5	EPIC	
+3398	artisanal high-proof Hodgman's blanket	8	EPIC	
+3399	fortified artisanal jar of squeeze	5	EPIC	
 3400	small bland bowl of fishysoisse	2	decent	
 3401	pickled triple-oxidized blinking deadly lampshade	0		Effect: "Quadrilled", Effect Duration: 16
 3402	energized fuchsia concentrated garbage juice	0		Effect: "Libra Rising", Effect Duration: 24
-3403	squat twirling lewd playing card	0		
+3403	twirling squat lewd playing card	0		
 3404	squat padded Sinatra's cool deck of lewd playing cards	0		Moxie: +5, Experience (Moxie): +5, Damage Absorption: +20
 3405	spinning sizzling Hodgman's sock	0		Hot Damage: +10, Single Equip
 3406	prompt Hodgman's varcolac paw	0		Adventures: +3
@@ -3385,7 +3385,7 @@
 3413	Hodgman's journal #2: Entrepreneurythmics	0		Skill: "Thrift and Grift"
 3414	maroon shaking Hodgman's journal #3: Pumping Tin	0		Skill: "Abs of Tin"
 3415	tumbling Hodgman's journal #4: View From The Big Top	0		Skill: "Marginally Insane"
-3416	blurry twirling hobo fortress blueprints	0		
+3416	twirling blurry hobo fortress blueprints	0		
 3421	box of fireworks	0		Familiar Weight: +5, Softcore Only, Conditional Skill (Equipped): "Fire off a Roman Candle", Last Available: "2008-07"
 3422	nitrogenated maroon sterno-flavored Hob-O	0		Effect: "Bread Burps", Effect Duration: 19
 3423	corrupted flattened jittery frostbite-flavored Hob-O	0		Effect: "Sweet Taste", Effect Duration: 45
@@ -3423,8 +3423,8 @@
 3456	trusty torch of the empath	0		Familiar Weight: +5, Last Available: "2011-12"
 3457	clever Junior Adventurer's merit badge	0		Maximum MP: +20
 3458	modified STYX deodorant body spray	0		Effect: "Hennaliciousness", Effect Duration: 11
-3459	watered-down fancy hand-crafted squat white-label gin	2	EPIC	Effect: "Stone-Faced", Effect Duration: 40
-3460	huge rotten jittery tin rations	8	crappy	
+3459	hand-crafted fancy watered-down squat white-label gin	2	EPIC	Effect: "Stone-Faced", Effect Duration: 40
+3460	rotten huge jittery tin rations	8	crappy	
 3461	haiku challenge map	0		
 3462	wobbly terrible poem	0		
 3463	lousy high-proof bottle of sake	10	decent	
@@ -3454,7 +3454,7 @@
 3487	rough fish scale	0		
 3488	pristine fish scale	0		
 3489	yummy beefy fish meat	3	awesome	Effect: "Fishy", Effect Duration: 5
-3490	diet spoiled glistening fish meat	1	crappy	Effect: "Fishy", Effect Duration: 5
+3490	spoiled diet glistening fish meat	1	crappy	Effect: "Fishy", Effect Duration: 5
 3491	super-sized toothsome maroon slick fish meat	5	awesome	Effect: "Fishy", Effect Duration: 5
 3492	fish scimitar of the cougar of terror	0		Moxie: +20, Spooky Spell Damage: +10
 3493	spinning razor-sharp fish stick of doom	0		Weapon Damage Percent: +25, Spooky Spell Damage: +50
@@ -3462,16 +3462,16 @@
 3495	Vulcanized narrow sea salt crystal	0		Effect: "Texas Elegance", Effect Duration: 25
 3496	electrified quadruple-polarized deionized bazookafish bubble gum	0		Effect: "Saucegoggles", Effect Duration: 62
 3497	lousy purple bottle of Pete's Sake	4	decent	
-3498	invisible bag	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3499	witch hat	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
-3500	beholed bedsheet	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2011-12"
+3498	invisible bag	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3499	witch hat	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
+3500	beholed bedsheet	0		Last Available: "2011-12", Familiar Effect: "8xVolley, 8xLep, cap 2"
 3501	toothsome thick canap&eacute;s	5	awesome	
-3502	dehydrated yellow squat thermos of brew	1	decent	Effect: "Seal Clubbing Frenzy", Effect Duration: 45, Last Available: "2011-12"
+3502	dehydrated squat yellow thermos of brew	1	decent	Effect: "Seal Clubbing Frenzy", Effect Duration: 45, Last Available: "2011-12"
 3503	distilled drinkable glass of brandy	5	good	Last Available: "2011-12"
 3504	skewed French slippers	0		
 3505	medical-grade LWA ring	0		HP Regen Min: 7, HP Regen Max: 10
 3506	LARP membership card	0		Last Available: "2008-10"
-3507	bouncing Scratch 'n' Sniff Sticker Tome	0		Free Pull, Skill: "Summon Stickers", Last Available: "2008-11"
+3507	bouncing Scratch 'n' Sniff Sticker Tome	0		Free Pull, Last Available: "2008-11", Skill: "Summon Stickers"
 3508	brainy scratch 'n' sniff sword	0		Mysticality: +5, Last Available: "2008-11"
 3509	huge scratch 'n' sniff unicorn sticker	0		Item Drop: +25, Last Available: "2008-11"
 3510	scratch 'n' sniff apple sticker	0		Experience: +2, Last Available: "2008-11"
@@ -3510,8 +3510,8 @@
 3543	red steel-toed Rosewater's depleted Grimacite gravy boat	0		Mysticality Percent: +30, Damage Reduction: 9, Last Available: "2011-12"
 3544	spinning mirror lightning-fast stanky depleted Grimacite weightlifting belt	0		Stench Spell Damage: +25, Initiative: +40, Single Equip, Last Available: "2011-12"
 3545	pulsating occult experienced depleted Grimacite grappling hook	0		Experience: +2, Spell Damage Percent: +25, Single Equip, Last Available: "2011-12"
-3546	huge sharpshooter's depleted Grimacite ninja mask of Flo-Jo	0		Critical Hit Percent: +10, Initiative: +100, Familiar Effect: "1xBarrr, 1xFairy, cap 25", Last Available: "2011-12"
-3547	red nasty depleted Grimacite shinguards of the cheetah	0		Stench Damage: +5, Initiative: +60, Familiar Effect: "atk, 3xBarrr, cap 25", Last Available: "2011-12"
+3546	huge sharpshooter's depleted Grimacite ninja mask of Flo-Jo	0		Critical Hit Percent: +10, Initiative: +100, Last Available: "2011-12", Familiar Effect: "1xBarrr, 1xFairy, cap 25"
+3547	red nasty depleted Grimacite shinguards of the cheetah	0		Stench Damage: +5, Initiative: +60, Last Available: "2011-12", Familiar Effect: "atk, 3xBarrr, cap 25"
 3548	avaricious Socratic depleted Grimacite astrolabe	0		Experience (Mysticality): +1, Meat Drop: +30, Single Equip, Last Available: "2011-12"
 3549	lard-coated dog trainer's KoL Con Cinco Pi&ntilde;ata Bat	0		Experience (familiar): +1, Sleaze Spell Damage: +25, Softcore Only, Last Available: "2008-09"
 3550	propeller beanie of Tarzan	0		Experience (Muscle): +3, Familiar Effect: "atk, cap 7"
@@ -3521,7 +3521,7 @@
 3554	blinking glob of slime	0		
 3555	decent huge sea carrot	6	good	
 3556	moldy sea cucumber	3	crappy	
-3557	normal miniature ghostly sea avocado	2	good	
+3557	miniature normal ghostly sea avocado	2	good	
 3558	stale sea lychee	3	decent	
 3559	spoiled fuchsia sea tangelo	3	crappy	
 3560	snack-sized normal sea honeydew	2	good	
@@ -3530,7 +3530,7 @@
 3563	quadruple-ionized pressurized potion of pulchritude	0		Effect: "Salamander In Your Stomach", Effect Duration: 26
 3564	artisanal berry-infused sake	3	EPIC	
 3565	hand-crafted extra-dry citrus-infused sake	5	EPIC	
-3566	acceptable weak melon-infused sake	2	good	
+3566	weak acceptable melon-infused sake	2	good	
 3567	slab of sponge	0		
 3568	wobbly ghostly asbestos-lined manspreader's forbidden sponge helmet	0		Spell Damage Percent: +50, Monster Level: +10, Hot Resistance: +5, Familiar Effect: "atk, 1xFairy"
 3569	pulsating auspicious resourceful dangerous spongy shield	0		Weapon Damage: +10, Maximum MP: +50, Item Drop: +10, Damage Reduction: 14
@@ -3547,8 +3547,8 @@
 3580	skewed wriggling flytrap pellet	0		
 3581	sushi-rolling mat	0		
 3582	spoiled ghostly rice	4	crappy	
-3584	big adequate irradiated candy cane	5	good	Last Available: "2008-12"
-3585	super-sized bland gingerbread mutant bugbear	5	decent	Last Available: "2008-12"
+3584	adequate big irradiated candy cane	5	good	Last Available: "2008-12"
+3585	bland super-sized gingerbread mutant bugbear	5	decent	Last Available: "2008-12"
 3586	bad oozenog	3	decent	Last Available: "2008-12"
 3587	polarized sugar plum	0		Effect: "Chilblains of the Corn", Effect Duration: 43, Last Available: "2008-12"
 3588	boiled non-magnetized skewed sugar banana	0		Effect: "Extra Terrestrial", Effect Duration: 49, Last Available: "2008-12"
@@ -3561,7 +3561,7 @@
 3595	flattened deionized Mer-kin fastjuice	0		Effect: "Filled with Magic", Effect Duration: 49
 3596	imitation crab crate	0		
 3597	imitation crab meat	0		
-3598	spinning pulsating imitation crab zoea	0		
+3598	pulsating spinning imitation crab zoea	0		
 3599	careful crafty moist sailor's cap of Flo-Jo	0		Maximum MP: +10, Monster Level: -10, Initiative: +100, Familiar Effect: "stench atk"
 3600	Usain Bolt's speargun	0		Item Drop: +5, Initiative: +80
 3601	skewed lion tamer's compass	0		Experience (familiar): +2
@@ -3580,7 +3580,7 @@
 3614	twirling twitching claw	0		Last Available: "2008-12"
 3615	rigid carapace	0		Last Available: "2008-12"
 3616	red pulsing flesh	0		Last Available: "2008-12"
-3617	pickled bouncing mirror unstable DNA	0		Effect: "Icy Demeanor", Effect Duration: 56, Last Available: "2008-12"
+3617	pickled mirror bouncing unstable DNA	0		Effect: "Icy Demeanor", Effect Duration: 56, Last Available: "2008-12"
 3618	The Spirit of Crimbo	0		Free Pull, Conditional Skill (Equipped): "Recite 'The Spirit of Crimbo'", Last Available: "2008-12"
 3619	green upside-down wriggling tentacle	0		Last Available: "2008-12"
 3620	mass of wriggling tentacles	0		Last Available: "2008-12"
@@ -3588,8 +3588,8 @@
 3622	gnashing teeth	0		Last Available: "2008-12"
 3623	chitinous pod	0		Last Available: "2008-12"
 3624	savvy parasitic claw	0		Mysticality Percent: +20, Last Available: "2008-12"
-3625	parasitic tentacles of the cougar	0		Moxie: +20, Familiar Effect: "spooky atk, 5xBarrr, cap 7", Last Available: "2008-12"
-3626	parasitic headgnawer of the empath	0		Familiar Weight: +5, Familiar Effect: "atk, cap 7", Last Available: "2008-12"
+3625	parasitic tentacles of the cougar	0		Moxie: +20, Last Available: "2008-12", Familiar Effect: "spooky atk, 5xBarrr, cap 7"
+3626	parasitic headgnawer of the empath	0		Familiar Weight: +5, Last Available: "2008-12", Familiar Effect: "atk, cap 7"
 3627	purple shaking parasitic strangleworm of Gandalf	0		Spell Critical Percent: +20, Last Available: "2008-12"
 3628	blurry pair of ragged claws	0		Last Available: "2008-12"
 3629	burrowgrub hive	0		Last Available: "2008-12"
@@ -3598,7 +3598,7 @@
 3632	radioactive chew toy	0		Familiar Weight: +5, Last Available: "2008-12"
 3633	pulsating huge Annie Oakley's Samson's elven socks	0		Experience (Muscle): +5, Critical Hit Percent: +20, Last Available: "2008-12"
 3634	gravedigger's elven gloves of the glutton	0		Spooky Damage: +10, Food Drop: +100, Last Available: "2008-12"
-3635	dog trainer's Temple Grandin's festive holiday hat	0		Familiar Weight: +7, Experience (familiar): +1, Familiar Effect: "1xFairy, cap 7", Last Available: "2008-12"
+3635	dog trainer's Temple Grandin's festive holiday hat	0		Familiar Weight: +7, Experience (familiar): +1, Last Available: "2008-12", Familiar Effect: "1xFairy, cap 7"
 3636	energetic patent shoes of the sewer	0		Maximum MP Percent: +20, Stench Damage: +25, Last Available: "2008-12"
 3637	blurry reassuring gray bow tie of the glutton	0		Spooky Resistance: +1, Food Drop: +100, Last Available: "2008-12"
 3638	clever penguin thesaurus of the sweet-tooth	0		Maximum MP: +20, Candy Drop: +100, Last Available: "2008-12"
@@ -3614,9 +3614,9 @@
 3648	magic dragonfish fry	0		
 3649	map to Madness Reef	0		
 3650	toothsome jittery toast with jam	3	awesome	Last Available: "2008-12"
-3651	skewed antlers	0		Familiar Weight: +4, Last Available: "2008-12"
+3651	skewed antlers	0		Familiar Weight: +5, Last Available: "2008-12"
 3652	mediocre elven moonshine	3	decent	Last Available: "2008-12"
-3653	rotten small knuckle sandwich	2	crappy	Last Available: "2008-12", Wiki Name: "knuckle sandwich"
+3653	rotten small knuckle sandwich	2	crappy	Wiki Name: "knuckle sandwich", Last Available: "2008-12"
 3654	blinking asbestos-lined rosy-cheeked psycho sweater	0		Maximum HP Percent: +30, Hot Resistance: +5, Last Available: "2008-12"
 3655	fin-bit wax	0		Familiar Weight: +5
 3656	squat educational plastic Mob Penguin	0		Experience: +1, Last Available: "2008-12"
@@ -3625,8 +3625,8 @@
 3659	nippy plastic strand of DNA	0		Cold Damage: +10, Last Available: "2008-12"
 3660	bouncing frosty plastic chunk of depleted Grimacite	0		Cold Spell Damage: +10, Last Available: "2008-12"
 3661	spinning container of Putty	0		Last Available: "2009-01"
-3662	skewed slick Putty mitre	0		Moxie: +10, Softcore Only, Familiar Effect: "1.5xLep, 1.5xFairy, cap 25", Last Available: "2009-01"
-3663	perfumed Putty leotard of the brute	0		Muscle Percent: +30, Stench Resistance: +5, Softcore Only, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2009-01"
+3662	skewed slick Putty mitre	0		Moxie: +10, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xLep, 1.5xFairy, cap 25"
+3663	perfumed Putty leotard of the brute	0		Muscle Percent: +30, Stench Resistance: +5, Softcore Only, Last Available: "2009-01", Familiar Effect: "1.5xVolley, cap 25"
 3664	blinking Putty ball of Gandalf	0		Spell Critical Percent: +20, Softcore Only, Last Available: "2009-01"
 3665	jittery Putty sheet	0		Last Available: "2009-01"
 3666	manspreader's thinker's Putty snake of the cougar	0		Mysticality: +10, Moxie: +20, Monster Level: +10, Softcore Only, Last Available: "2009-01"
@@ -3652,9 +3652,9 @@
 3686	thick decent tempura avocado	5	good	
 3687	flavorless mirror mirror sea broccoli	4	decent	
 3688	half-sized adequate sea cauliflower	2	good	
-3689	snack-sized bland blinking tempura broccoli	2	decent	
-3690	adequate half-sized tempura cauliflower	2	good	
-3691	snack-sized special moldy purple sea blueberry	2	crappy	Effect: "Video Game Hot Dog", Effect Duration: 25
+3689	bland snack-sized blinking tempura broccoli	2	decent	
+3690	half-sized adequate tempura cauliflower	2	good	
+3691	special moldy snack-sized purple sea blueberry	2	crappy	Effect: "Video Game Hot Dog", Effect Duration: 25
 3692	flavorless huge sea persimmon	3	decent	
 3693	wet fuchsia pressurized potion of perception	0		Effect: "In Tuna", Effect Duration: 40
 3694	aerosolized denatured pressurized potion of proficiency	0		Effect: "Stinking Cloud", Effect Duration: 55
@@ -3714,20 +3714,20 @@
 3749	altered concoction of clumsiness	0		Effect: "Fury of the Bells", Effect Duration: 34
 3750	occult vampire pearl earring	0		Spell Damage Percent: +25, Single Equip
 3751	stale chocolate chip brownies	4	decent	
-3753	Libram of Love Songs	0		Skill: "Summon Love Song", Last Available: "2009-02"
+3753	Libram of Love Songs	0		Last Available: "2009-02", Skill: "Summon Love Song"
 3754	pressed love song of vague ambiguity	0		Effect: "Carrrsmic", Effect Duration: 36, Last Available: "2009-02"
 3755	energized love song of smoldering passion	0		Effect: "Ode to Booze", Effect Duration: 53, Last Available: "2009-02"
 3756	super-wet ghostly love song of icy revenge	0		Effect: "Headstrong", Effect Duration: 51, Last Available: "2009-02"
-3757	concentrated triple-adjusted adjusted ghostly tumbling upside-down love song of sugary cuteness	0		Effect: "Banono", Effect Duration: 25, Last Available: "2009-02"
+3757	concentrated triple-adjusted adjusted upside-down ghostly tumbling love song of sugary cuteness	0		Effect: "Banono", Effect Duration: 25, Last Available: "2009-02"
 3758	extra-improved narrow love song of disturbing obsession	0		Effect: "Wallflowering", Effect Duration: 26, Last Available: "2009-02"
-3759	adjusted nitrogenated teal bouncing upside-down love song of naughty innuendo	0		Effect: "Beastly Flavor", Effect Duration: 61, Last Available: "2009-02"
+3759	adjusted nitrogenated upside-down bouncing teal love song of naughty innuendo	0		Effect: "Beastly Flavor", Effect Duration: 61, Last Available: "2009-02"
 3760	dry fuchsia breath mint	0		Effect: "Chalk Outline", Effect Duration: 26
 3761	lightning-fast vampire pearl ring	0		Initiative: +40, Single Equip
 3762	quilted vampire pearl necklace	0		Damage Absorption: +40, Single Equip
 3763	extra-dry smooth slug of vodka	5	awesome	
 3764	mediocre blurry slug of rum	3	decent	
-3765	high-proof mediocre blurry slug of shochu	8	decent	
-3766	high-proof artisanal fancy huge screwdiver	8	EPIC	Effect: "Hip to Be Square Dancin'", Effect Duration: 30
+3765	mediocre high-proof blurry slug of shochu	8	decent	
+3766	high-proof fancy artisanal huge screwdiver	8	EPIC	Effect: "Hip to Be Square Dancin'", Effect Duration: 30
 3767	practically non-alcoholic smooth dew yoana lei	1	awesome	
 3768	tolerable lychee chuhai	4	good	
 3769	mediocre boozy salacious screwdiver	5	decent	
@@ -3753,14 +3753,14 @@
 3789	tumbling twitching trigger finger	0		Class: "Pastamancer"
 3799	pulsating Apathargic Bandersnatch	0		Free Pull, Last Available: "2011-12"
 3800	blinking aquaviolet jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mys stats"
-3801	shaking squat skewed crimsilion jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mus stats", Equips On: "Frumious Bandersnatch"
-3802	charpuce jub-jub bird	0		Familiar Weight: +5, Familiar Effect: "mox stats", Equips On: "Frumious Bandersnatch"
+3801	shaking squat skewed crimsilion jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mus stats"
+3802	charpuce jub-jub bird	0		Familiar Weight: +5, Equips On: "Frumious Bandersnatch", Familiar Effect: "mox stats"
 3803	thinker's Mer-kin roundshield of the ox of Flo-Jo	0		Muscle: +20, Mysticality: +10, Initiative: +100, Damage Reduction: 14
 3804	grievous Mer-kin breastplate of the dark arts	0		Weapon Damage Percent: +50, Spell Damage Percent: +100
 3805	mirror coward's Oprah's Mer-kin sneakmask	0		Maximum MP Percent: +50, Monster Level: -20, Combat Rate (Underwater): -5, Familiar Effect: "1xBarrr, 1xFairy"
 3806	Mer-kin prayerbeads	0		
 3807	altered wet Mer-kin hidepaint	0		Effect: "Hair on Your Chest", Effect Duration: 61
-3808	wobbly huge Mer-kin trailmap	0		
+3808	huge wobbly Mer-kin trailmap	0		
 3809	squat mirror Mer-kin healscroll	0		
 3810	Mer-kin lockkey	0		
 3811	squat Mer-kin stashbox	0		
@@ -3784,7 +3784,7 @@
 3830	zippy water-polo cap	0		Initiative: +20, Familiar Effect: "1xVolley, 1xBarrr"
 3831	artisanal practically non-alcoholic twirling Typical Tavern swill	1	EPIC	
 3832	perfectly mixed tropical swill	4	EPIC	
-3833	bad fancy irresponsibly strong skewed fruity girl swill	9	decent	Effect: "Ruthlessly Efficient", Effect Duration: 10
+3833	fancy irresponsibly strong bad skewed fruity girl swill	9	decent	Effect: "Ruthlessly Efficient", Effect Duration: 10
 3834	delicious narrow blended swill	3	awesome	
 3835	costume wardrobe	0		Softcore Only
 3836	red Temple Grandin's friendly boxer's Elvish sunglasses of wisdom	0		Mysticality: +15, Muscle Percent: +10, Familiar Weight: 10, Single Equip, Softcore Only, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo", Last Available: "2009-04"
@@ -3839,7 +3839,7 @@
 3885	wet purple vial of slime	0		Effect: "Pockets of Fire", Effect Duration: 64
 3886	improved vial of slime	0		Effect: "Surreally Buff", Effect Duration: 49
 3887	flattened pickled vial of slime	0		Effect: "Bananas!", Effect Duration: 16
-3888	ionized chilled cyan spinning vial of slime	0		Effect: "Radiated and Grodiated", Effect Duration: 44
+3888	ionized chilled spinning cyan vial of slime	0		Effect: "Radiated and Grodiated", Effect Duration: 44
 3889	quadruple-irradiated ionized vial of slime	0		Effect: "Memories of Puppy Love", Effect Duration: 33
 3890	polarized energized concentrated ghostly vial of violet slime	0		Effect: "Tiki Temerity", Effect Duration: 30
 3891	adjusted spinning vial of vermilion slime	0		Effect: "Ruby-ous", Effect Duration: 38
@@ -3858,7 +3858,7 @@
 3906	jittery figurine of a sleek seal	0		Class: "Seal Clubber"
 3907	blue figurine of a shadowy seal	0		Class: "Seal Clubber"
 3908	figurine of a stinking seal	0		Class: "Seal Clubber"
-3909	upside-down ghostly figurine of a charred seal	0		Class: "Seal Clubber"
+3909	ghostly upside-down figurine of a charred seal	0		Class: "Seal Clubber"
 3910	figurine of a seal	0		Class: "Seal Clubber"
 3911	purple blurry figurine of a slippery seal	0		Class: "Seal Clubber"
 3912	green imbued seal-blubber candle	0		Class: "Seal Clubber"
@@ -3966,7 +3966,7 @@
 4014	memory of an AG base pair	0		Last Available: "2009-06"
 4015	memory of an AT base pair	0		Last Available: "2009-06"
 4016	memory of a GT base pair	0		Last Available: "2009-06"
-4017	tumbling teal squirming Slime larva	0		
+4017	teal tumbling squirming Slime larva	0		
 4018	boxer's greaves	0		Muscle Percent: +10, Familiar Effect: "1xBarrr, cap 37"
 4019	undissolvable contact lenses	0		
 4020	upside-down Fonzie's piece of rebar of the bloodbag	0		Experience (Moxie): +1, Maximum HP: +100
@@ -3990,15 +3990,15 @@
 4038	smooth slimy fermented bile bladder	4	awesome	
 4039	dehydrated jittery slimy alveolus	1		Effect: "Thunderheart", Effect Duration: 30
 4040	memory of a cultist's robe	0		Single Equip, Last Available: "2009-06"
-4041	shellacked strapping pig-iron helm	0		Muscle: +5, Damage Reduction: 7, Familiar Effect: "1xFairy, cap 22", Last Available: "2009-06"
-4042	skewed rosewater-soaked pig-iron shinguards of the sewer	0		Stench Damage: +25, Stench Resistance: +3, Familiar Effect: "2xBarrr, 1.5xFairy, cap 22", Last Available: "2009-06"
+4041	shellacked strapping pig-iron helm	0		Muscle: +5, Damage Reduction: 7, Last Available: "2009-06", Familiar Effect: "1xFairy, cap 22"
+4042	skewed rosewater-soaked pig-iron shinguards of the sewer	0		Stench Damage: +25, Stench Resistance: +3, Last Available: "2009-06", Familiar Effect: "2xBarrr, 1.5xFairy, cap 22"
 4043	flame-retardant dog trainer's pig-iron bracers	0		Experience (familiar): +1, Hot Resistance: +1, Single Equip, Last Available: "2009-06"
 4044	wumpus hair	0		Last Available: "2009-06"
 4045	wumpus-hair bolo	0		Last Available: "2009-06"
 4046	wumpus-hair net	0		Last Available: "2009-06"
 4047	green friendly wumpus-hair whip	0		Familiar Weight: +3, Last Available: "2009-06"
-4048	dog trainer's savvy thinker's wumpus-hair wig	0		Mysticality: +10, Mysticality Percent: +20, Experience (familiar): +1, Familiar Effect: "1xPotato, 1xGhuol, cap 25", Last Available: "2009-06"
-4049	manspreader's forbidden deadly wumpus-hair loincloth	0		Weapon Damage: +5, Spell Damage Percent: +50, Monster Level: +10, Familiar Effect: "1xVolley, 1xPotato, cap 5", Last Available: "2009-06"
+4048	dog trainer's savvy thinker's wumpus-hair wig	0		Mysticality: +10, Mysticality Percent: +20, Experience (familiar): +1, Last Available: "2009-06", Familiar Effect: "1xPotato, 1xGhuol, cap 25"
+4049	manspreader's forbidden deadly wumpus-hair loincloth	0		Weapon Damage: +5, Spell Damage Percent: +50, Monster Level: +10, Last Available: "2009-06", Familiar Effect: "1xVolley, 1xPotato, cap 5"
 4050	blinking olive Jim Carey's extremely unsafe wumpus-hair sweater	0		Weapon Damage Percent: +100, Monster Level: +25, Last Available: "2009-06"
 4051	nippy ring of teleportation	0		Cold Damage: +10, Single Equip
 4052	ghostly glass of baboon milk	1	crappy	Last Available: "2009-06"
@@ -4019,7 +4019,7 @@
 4067	wobbly essence of heat	0		Last Available: "2009-06"
 4068	ghostly essence of kink	0		Last Available: "2009-06"
 4069	essence of	0		Last Available: "2009-06"
-4070	bouncing narrow essence of stench	0		Last Available: "2009-06"
+4070	narrow bouncing essence of stench	0		Last Available: "2009-06"
 4071	blinking essence of fright	0		Last Available: "2009-06"
 4072	essence of	0		Last Available: "2009-06"
 4073	Supreme Being Glossary	0		Last Available: "2009-06"
@@ -4033,12 +4033,12 @@
 4081	quilted corroded breeches of the blizzard	0		Damage Absorption: +40, Cold Spell Damage: +25, Slime Hates It: +1, Familiar Effect: "sleaze atk, 1xPotato"
 4082	sharpshooter's pernicious cudgel of the storm	0		Maximum MP Percent: +40, Critical Hit Percent: +10, Slime Hates It: +1
 4083	normal cupcake-in-a-cup	4	good	Last Available: "2009-06"
-4084	twirling wobbly pool of liquid	0		Last Available: "2009-06"
+4084	wobbly twirling pool of liquid	0		Last Available: "2009-06"
 4085	tasty green protein paste	3	awesome	Last Available: "2009-06"
 4086	banded forbidden cyber-mattock	0		Spell Damage Percent: +50, Damage Absorption: +100, Last Available: "2009-06"
 4087	twirling facehugging alien	0		Last Available: "2009-06"
 4088	blinking X-37 gun	0		Last Available: "2009-06"
-4089	triple-adjusted super-alkaline spinning spinning cyan neurostim pill	0		Effect: "Sated and Furious", Effect Duration: 41, Last Available: "2009-06"
+4089	triple-adjusted super-alkaline cyan spinning spinning neurostim pill	0		Effect: "Sated and Furious", Effect Duration: 41, Last Available: "2009-06"
 4090	oxidized physiostim pill	0		Effect: "Uncucumbered", Effect Duration: 49, Last Available: "2009-06"
 4091	blurry slimy cyst	0		
 4092	small slimy cyst	0		
@@ -4100,7 +4100,7 @@
 4148	stone sphere	0		Free Pull, Last Available: "2009-09"
 4149	quadroculars	0		Familiar Weight: +5, Last Available: "2009-09"
 4150	twirling lint	0		Last Available: "2011-12"
-4151	electrified mirror spinning dubious peppermint	0		Effect: "Astral Shell", Effect Duration: 38, Last Available: "2020-09"
+4151	electrified spinning mirror dubious peppermint	0		Effect: "Astral Shell", Effect Duration: 38, Last Available: "2020-09"
 4152	warmed Elvish delight	0		Effect: "Devil Inside", Effect Duration: 63
 4153	maroon rockfish stomach	0		Last Available: "2009-09"
 4154	skewed live lobster	0		Last Available: "2011-12"
@@ -4111,9 +4111,9 @@
 4159	rock lobster	0		Last Available: "2009-09"
 4160	lousy pebblebr&auml;u	4	decent	Last Available: "2009-09"
 4161	decent rocky road ice cream	3	good	Last Available: "2009-09"
-4162	blinking upside-down extra-strength rubber bands	0		Familiar Weight: +5
+4162	upside-down blinking extra-strength rubber bands	0		Familiar Weight: +5
 4163	dry galvanized children of the candy corn	0		Effect: "Arcane in the Brain", Effect Duration: 46
-4164	super-corrupted wet polarized red mirror Good 'n' Slimy	0		Effect: "Serenity", Effect Duration: 38
+4164	super-corrupted wet polarized mirror red Good 'n' Slimy	0		Effect: "Serenity", Effect Duration: 38
 4165	skewed scorching groovy Rosewater's Staff of the Soupbone	0		Mysticality Percent: +30, Moxie Percent: +10, Hot Damage: +25
 4166	pulsating Samson's Voluminous Radio Pants	0		Experience (Muscle): +5, Familiar Effect: "2xGhoul, cap 37"
 4167	jittery shaking resourceful Voluminous Radio Hat	0		Maximum MP: +50, Familiar Effect: "1xPotato, 1xGhoul, cap 37"
@@ -4130,8 +4130,8 @@
 4178	Da Vinci's sugar shotgun	0		Experience (Mysticality): +5, Last Available: "2009-09"
 4179	sugar shillelagh of Tarzan	0		Experience (Muscle): +3, Last Available: "2009-09"
 4180	extremely unsafe sugar shank	0		Weapon Damage Percent: +100, Last Available: "2009-09"
-4181	wobbly flame-wreathed dangerous wizardly sugar chapeau	0		Mysticality: +25, Weapon Damage: +10, Hot Spell Damage: +10, Familiar Effect: "atk, 2xVolley, 2xLep, cap 25", Last Available: "2009-09"
-4182	beefy sugar shorts	0		Muscle: +10, Familiar Effect: "2xVolley, 1xLep, cap 25", Last Available: "2009-09"
+4181	wobbly flame-wreathed dangerous wizardly sugar chapeau	0		Mysticality: +25, Weapon Damage: +10, Hot Spell Damage: +10, Last Available: "2009-09", Familiar Effect: "atk, 2xVolley, 2xLep, cap 25"
+4182	beefy sugar shorts	0		Muscle: +10, Last Available: "2009-09", Familiar Effect: "2xVolley, 1xLep, cap 25"
 4183	twirling sugar shield	0		Familiar Weight: +10, Last Available: "2009-09"
 4184	slime convention swag bag	0		
 4185	slime convention flyers	0		
@@ -4153,7 +4153,7 @@
 4201	narrow spinning gill rings	0		Familiar Weight: +5
 4202	yellow urchin roe	0		
 4203	pet anemone	0		Familiar Weight: +5
-4204	mirror ghostly Mer-kin cheatsheet	0		
+4204	ghostly mirror Mer-kin cheatsheet	0		
 4205	twirling Mer-kin wordquiz	0		
 4206	spinning friendly brand new key of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3
 4207	pulsating auspicious dorsal fin	0		Item Drop: +10, Damage Reduction: 13
@@ -4161,9 +4161,9 @@
 4209	skate skin	0		
 4210	skewed roller skate decoy	0		
 4211	squat mermaid's purse	0		
-4212	pulsating wobbly purple underwater slingshot	0		
+4212	purple pulsating wobbly underwater slingshot	0		
 4213	pulsating frightening occult skate blade	0		Spell Damage Percent: +25, Spooky Damage: +5
-4214	spinning jittery spangly unitard	0		
+4214	jittery spinning spangly unitard	0		
 4215	nasty vibrating collapsible baton	0		Maximum MP Percent: +10, Stench Damage: +5
 4216	groupie lipstick	0		
 4217	groupie bra	0		
@@ -4178,7 +4178,7 @@
 4226	spinning experienced Star of Bravery	0		Experience: +2, Single Equip
 4227	pulsating pulsating hungover chauvinist pig	0		Free Pull, Last Available: "2010-10"
 4228	perfectly ordinary frog	0		Free Pull, Last Available: "2010-10"
-4229	amphibious tophat	0		Familiar Effect: "adventure underwater", Equips On: "Dancing Frog"
+4229	amphibious tophat	0		Equips On: "Dancing Frog", Familiar Effect: "adventure underwater"
 4230	bottle of Cochon Noir	0		Familiar Weight: +5
 4231	ice skate decoy	0		
 4232	ice skate doll	0		
@@ -4209,12 +4209,12 @@
 4257	petrified wood	0		Last Available: "2009-10"
 4258	normal big pulsating chocolate-covered scarab beetle	5	good	Last Available: "2009-10"
 4259	drinkable weak mulled cider	2	good	Last Available: "2009-10"
-4260	mirror wolfman mask	0		Familiar Effect: "8xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4261	pumpkinhead mask	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
-4262	mummy costume	0		Familiar Effect: "1xVolley, 8xLep, cap 2", Last Available: "2009-10"
+4260	mirror wolfman mask	0		Last Available: "2009-10", Familiar Effect: "8xVolley, 8xLep, cap 2"
+4261	pumpkinhead mask	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
+4262	mummy costume	0		Last Available: "2009-10", Familiar Effect: "1xVolley, 8xLep, cap 2"
 4263	Ax of L'rose	0		Last Available: "2009-10"
-4264	tumbling bark boxers of the bloodbag	0		Maximum HP: +100, Familiar Effect: "atk, 3xVolley, cap 10", Last Available: "2009-10"
-4265	personal trainer's bark beret	0		Experience Percent (Muscle): +10, Familiar Effect: "2xPotato, 2.5xLep, cap 10", Last Available: "2009-10"
+4264	tumbling bark boxers of the bloodbag	0		Maximum HP: +100, Last Available: "2009-10", Familiar Effect: "atk, 3xVolley, cap 10"
+4265	personal trainer's bark beret	0		Experience Percent (Muscle): +10, Last Available: "2009-10", Familiar Effect: "2xPotato, 2.5xLep, cap 10"
 4266	manspreader's bark bracelet	0		Monster Level: +10, Single Equip
 4267	nasty brawny Krakrox's Loincloth	0		Muscle Percent: +20, Stench Damage: +5, Class: "Seal Clubber", Familiar Effect: "1xVolley, 2xPotato, cap 31"
 4268	Temple Grandin's grievous Galapagosian Cuisses	0		Weapon Damage Percent: +50, Familiar Weight: +7, Class: "Turtle Tamer", Familiar Effect: "2xBarrr, MP regen, cap 31"
@@ -4279,10 +4279,10 @@
 4327	blurry knitted ruddy sinister La Hebilla del Cintur&oacute;n de Lopez	0		Spell Damage: +10, Maximum HP Percent: +40, Cold Resistance: +3, Class: "Accordion Thief", Single Equip
 4328	skewed suspicious stocking	0		Free Pull, Last Available: "2009-12"
 4329	bag of many confections	0		Last Available: "2009-12"
-4330	low-calorie flavorless candy kneecapping stick	1	decent	Last Available: "2009-12"
-4331	flavorless gigantic purple licorice garrote	6	decent	Last Available: "2009-12"
+4330	flavorless low-calorie candy kneecapping stick	1	decent	Last Available: "2009-12"
+4331	gigantic flavorless purple licorice garrote	6	decent	Last Available: "2009-12"
 4332	brawny candy knuckles	0		Muscle Percent: +20, Last Available: "2009-12"
-4333	snack-sized rotten jawbruiser	2	crappy	Last Available: "2010-12"
+4333	rotten snack-sized jawbruiser	2	crappy	Last Available: "2010-12"
 4334	anodized modified spinning chocolate car	0		Effect: "Chauve-Souris Merde Fou", Effect Duration: 34, Last Available: "2009-12"
 4335	flame-wreathed plastic 11 Dealer	0		Hot Spell Damage: +10, Last Available: "2009-12"
 4336	blurry zippy plastic Crimbo Casino	0		Initiative: +20, Last Available: "2009-12"
@@ -4296,10 +4296,10 @@
 4344	Crimbo wreath	0		Last Available: "2009-12"
 4345	huge string of Crimbo lights	0		Last Available: "2009-12"
 4346	plastic Crimbo reindeer	0		Last Available: "2009-12"
-4347	blurry pulsating gingerbread house	0		Last Available: "2009-12"
+4347	pulsating blurry gingerbread house	0		Last Available: "2009-12"
 4348	leftover Crimbo rations	0		Last Available: "2009-12"
-4349	red tumbling blurry censurious snow hat	0		Sleaze Resistance: +3, Familiar Effect: "cold atk, cap 12", Last Available: "2009-12"
-4350	cyan skewed greasy snow pants	0		Sleaze Spell Damage: +10, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2009-12"
+4349	red tumbling blurry censurious snow hat	0		Sleaze Resistance: +3, Last Available: "2009-12", Familiar Effect: "cold atk, cap 12"
+4350	cyan skewed greasy snow pants	0		Sleaze Spell Damage: +10, Last Available: "2009-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 4351	snow belly of Calamity Jane	0		Critical Hit Percent: +15, Single Equip, Last Available: "2009-12"
 4352	pile of loose snow	0		Last Available: "2009-12"
 4353	Crimbough	0		Last Available: "2009-12"
@@ -4308,14 +4308,14 @@
 4356	mirror A Crimbo Carol, Ch. 3	0		Skill: "Candyblast", Last Available: "2009-12"
 4357	twirling A Crimbo Carol, Ch. 4	0		Skill: "Surge of Icing", Last Available: "2009-12"
 4358	A Crimbo Carol, Ch. 5	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
-4359	shaking mirror A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+4359	mirror shaking A Crimbo Carol, Ch. 6	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 4360	snack-sized rotten expired can of franks 'n' beans	2	crappy	Last Available: "2009-12"
-4361	hand-crafted fortified expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
+4361	fortified hand-crafted expired bottle of peppermint schnapps	5	EPIC	Last Available: "2009-12"
 4362	green snow halo	0		Familiar Weight: +5, Last Available: "2009-12"
 4363	elf resistance button	0		Last Available: "2009-12"
 4364	triple-Vulcanized super-colloidal nitrogenated skewed elven suicide capsule	0		Effect: "Meadulla Oblongota", Effect Duration: 17, Last Available: "2009-12"
 4365	bland penguin focaccia bread	3	decent	Last Available: "2009-12"
-4366	weak hand-crafted herringcello	2	EPIC	Last Available: "2009-12"
+4366	hand-crafted weak herringcello	2	EPIC	Last Available: "2009-12"
 4367	drinkable extra-dry elven cellocello	5	good	Last Available: "2009-12"
 4368	wrench handle	0		Last Available: "2009-12"
 4369	blurry handful of headless bolts	0		Last Available: "2009-12"
@@ -4337,7 +4337,7 @@
 4385	avaricious electrified pocketwatch on a chain	0		Meat Drop: +30, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2009-12"
 4386	sharpshooter's smooth cement sandals	0		Moxie: +15, Critical Hit Percent: +10, Single Equip, Last Available: "2009-12"
 4387	Annie Oakley's padded night-vision goggles	0		Damage Absorption: +20, Critical Hit Percent: +20, Single Equip, Last Available: "2009-12"
-4388	passable elf mask	0		Familiar Effect: "atk, cap 2", Last Available: "2009-12"
+4388	passable elf mask	0		Last Available: "2009-12", Familiar Effect: "atk, cap 2"
 4389	peanut brittle shield of doom	0		Spooky Spell Damage: +50, Damage Reduction: 3, Last Available: "2009-12"
 4390	upside-down Jack Frost's beefcake's Red Rover BB gun	0		Muscle: +25, Cold Spell Damage: +50, Last Available: "2009-12"
 4391	fortified red-and-green sweater	0		Damage Absorption: +60, Conditional Skill (Equipped): "[7094]Static Shock", Last Available: "2009-12"
@@ -4349,7 +4349,7 @@
 4397	crank handle	0		Familiar Weight: +5, Last Available: "2009-12"
 4398	cheese ball	0		Last Available: "2010-01"
 4399	dangerous cheese sword	0		Weapon Damage: +10, Softcore Only, Last Available: "2010-01"
-4400	nippy cheese diaper	0		Cold Damage: +10, Softcore Only, Familiar Effect: "stench atk, 1.5xVolley, cap 25", Last Available: "2010-01"
+4400	nippy cheese diaper	0		Cold Damage: +10, Softcore Only, Last Available: "2010-01", Familiar Effect: "stench atk, 1.5xVolley, cap 25"
 4401	pulsating bouncing beefy cheese wheel	0		Muscle: +10, Damage Reduction: 6, Softcore Only, Last Available: "2010-01"
 4402	vibrating cheese eye	0		Maximum MP Percent: +10, Softcore Only, Conditional Skill (Equipped): "Give Your Opponent the Stinkeye", Last Available: "2010-01"
 4403	spinning upside-down reassuring Temple Grandin's hardened Staff of Queso Escusado	0		Damage Reduction: 3, Familiar Weight: +7, Spooky Resistance: +1, Softcore Only, Last Available: "2010-01"
@@ -4374,7 +4374,7 @@
 4423	sealhide snare	0		
 4424	mirror puzzling trophy	0		
 4425	double-frozen double-tarnished sealhide seal doll	0		Effect: "Black Eyes", Effect Duration: 37
-4426	purple blurry hymnal	0		Skill: "Canticle of Carboloading"
+4426	blurry purple hymnal	0		Skill: "Canticle of Carboloading"
 4428	Annie Oakley's glowstick on a string	0		Critical Hit Percent: +20
 4429	auspicious candy necklace	0		Item Drop: +10, Single Equip
 4430	blurry therapeutic teddybear backpack	0		HP Regen Min: 5, HP Regen Max: 7
@@ -4395,8 +4395,8 @@
 4447	Herculean spangly sombrero	0		Experience (Muscle): +1, Familiar Effect: "2xFairy, 2xPotato, cap 37"
 4448	pickled huge red Instant Karma	1	EPIC	
 4449	shaking painting of a landscape	0		Last Available: "2010-04"
-4450	narrow fuchsia map to The Landscaper's Lair	0		Last Available: "2010-04"
-4451	tumbling scandalous pointy hat	0		Sleaze Damage: +5, Familiar Effect: "1xVolley, 1xLep, cap 27", Last Available: "2010-04"
+4450	fuchsia narrow map to The Landscaper's Lair	0		Last Available: "2010-04"
+4451	tumbling scandalous pointy hat	0		Sleaze Damage: +5, Last Available: "2010-04", Familiar Effect: "1xVolley, 1xLep, cap 27"
 4452	censurious machetito	0		Sleaze Resistance: +3, Last Available: "2010-04"
 4453	lawnmower blade of extreme caution	0		Monster Level: -25, Last Available: "2010-04"
 4454	cyan grass clippings	0		Last Available: "2023-12"
@@ -4413,18 +4413,18 @@
 4465	ionized pickled ionized ghostly blinking chocolate saucepan	0		Effect: "Chain Chain Chains", Effect Duration: 16
 4466	energized teal chocolate disco ball	0		Effect: "Gobliny Flavor", Effect Duration: 26
 4467	quadruple-ionized vacuum-sealed chocolate stolen accordion	0		Effect: "Turtle Titters", Effect Duration: 12
-4468	Libram of BRICKOs	0		Free Pull, Skill: "Summon BRICKOs", Last Available: "2010-02"
+4468	Libram of BRICKOs	0		Free Pull, Last Available: "2010-02", Skill: "Summon BRICKOs"
 4469	cyan BRICKO brick	0		Last Available: "2010-02"
 4470	red BRICKO eye brick	0		Last Available: "2010-02"
-4471	scorching BRICKO hat	0		Hot Damage: +25, Familiar Effect: "atk, cap 7", Last Available: "2010-02"
-4472	bouncing thinker's BRICKO pants	0		Mysticality: +10, Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22", Last Available: "2010-02"
+4471	scorching BRICKO hat	0		Hot Damage: +25, Last Available: "2010-02", Familiar Effect: "atk, cap 7"
+4472	bouncing thinker's BRICKO pants	0		Mysticality: +10, Last Available: "2010-02", Familiar Effect: "1.5xVolley, 2xLep, 1xPotato, cap 22"
 4473	olive boxer's BRICKO sword	0		Muscle Percent: +10, Last Available: "2010-02"
 4474	BRICKO ooze	0		Last Available: "2010-02"
 4475	pulsating BRICKO bat	0		Last Available: "2010-02"
 4476	BRICKO oyster	0		Last Available: "2010-02"
 4477	BRICKO turtle	0		Last Available: "2010-02"
 4478	BRICKO elephant	0		Last Available: "2010-02"
-4479	twirling BRICKO octopus	0		Last Available: "2010-02", Wiki Name: "BRICKO octopus (item)"
+4479	twirling BRICKO octopus	0		Wiki Name: "BRICKO octopus (item)", Last Available: "2010-02"
 4480	BRICKO python	0		Last Available: "2010-02"
 4481	upside-down BRICKO vacuum cleaner	0		Last Available: "2010-02"
 4482	BRICKO airship	0		Last Available: "2010-02"
@@ -4460,32 +4460,32 @@
 4512	mirror cyan eggman noodles	0		Last Available: "2010-03"
 4513	squat Vial of <i>jus de larmes</i>	0		Last Available: "2010-03"
 4514	adequate tiny skewed skewed Humpty Dumplings	1	good	Last Available: "2010-03"
-4515	normal diet shaking Lobster <i>qua</i> Grill	1	good	Last Available: "2010-03"
+4515	diet normal shaking Lobster <i>qua</i> Grill	1	good	Last Available: "2010-03"
 4516	lousy missing wine	3	decent	Last Available: "2010-03"
-4517	tiny normal matter custard	1	good	Last Available: "2010-03"
+4517	normal tiny matter custard	1	good	Last Available: "2010-03"
 4518	warmed wet pulsating comfit?	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 32, Last Available: "2010-03"
 4519	ittah bittah hookah	0		Familiar Weight: +5, Last Available: "2010-03"
 4520	auspicious flamingo mallet of the brute	0		Muscle Percent: +30, Item Drop: +10, Last Available: "2010-03"
 4521	blurry croquet hedgehog	0		Last Available: "2010-03"
 4522	ghostly Tiger-lily's milk	1	crappy	Last Available: "2010-03"
 4523	Annie Oakley's supercharged eye of the Tiger-lily	0		Maximum MP Percent: +30, Critical Hit Percent: +20, Last Available: "2010-03"
-4524	Rosewater's boxer's wig	0		Muscle Percent: +10, Mysticality Percent: +30, Familiar Effect: "2xPotato, 1xGhuol, cap 17", Last Available: "2010-03"
+4524	Rosewater's boxer's wig	0		Muscle Percent: +10, Mysticality Percent: +30, Last Available: "2010-03", Familiar Effect: "2xPotato, 1xGhuol, cap 17"
 4525	decent donut	3	good	Last Available: "2010-03"
-4526	tasty miniature bucket of honey	2	awesome	Last Available: "2010-03"
+4526	miniature tasty bucket of honey	2	awesome	Last Available: "2010-03"
 4527	blue MacGyver's elephant stinger of the pedagogue	0		Experience: +3, Maximum MP: +100, Last Available: "2010-03"
 4528	bland dragon snaps	4	decent	Last Available: "2010-03"
 4529	skewed gravedigger's snapdragon pistil of vim and vigor	0		Maximum HP Percent: +50, Spooky Damage: +10, Last Available: "2010-03"
 4530	puff of smoke	0		Last Available: "2010-03"
-4531	decent fancy rook cookie	3	good	Effect: "Pill Power", Effect Duration: 15, Last Available: "2010-03"
-4532	super-sized delicious bishop cookie	5	awesome	Last Available: "2010-03"
+4531	fancy decent rook cookie	3	good	Effect: "Pill Power", Effect Duration: 15, Last Available: "2010-03"
+4532	delicious super-sized bishop cookie	5	awesome	Last Available: "2010-03"
 4533	spoiled spinning knight cookie	3	crappy	Last Available: "2010-03"
 4534	adequate king cookie	3	good	Last Available: "2010-03"
 4535	stale wobbly queen cookie	3	decent	Effect: "Towering Strength", Last Available: "2010-03"
 4536	fairy-worn boots	0		Free Pull, Last Available: "2011-08"
-4537	crafty insane tophat	0		Maximum MP: +10, Familiar Effect: "1xVolley, 1xLep, cap 7", Last Available: "2010-03"
-4538	electrified helm of the knight of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 1xVolley, cap 15", Last Available: "2010-03"
+4537	crafty insane tophat	0		Maximum MP: +10, Last Available: "2010-03", Familiar Effect: "1xVolley, 1xLep, cap 7"
+4538	electrified helm of the knight of vim and vigor	0		Maximum HP Percent: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2010-03", Familiar Effect: "atk, 1xVolley, cap 15"
 4539	Sherlock's Da Vinci's wristwatch of the knight	0		Experience (Mysticality): +5, Item Drop: +25, Single Equip, Last Available: "2010-03"
-4540	Jack Frost's trousers of the knight of the ox	0		Muscle: +20, Cold Spell Damage: +50, Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15", Last Available: "2010-03"
+4540	Jack Frost's trousers of the knight of the ox	0		Muscle: +20, Cold Spell Damage: +50, Last Available: "2010-03", Familiar Effect: "atk, 2.5xPotato, 2xLep, cap 15"
 4541	forbidden tophat	0		Spell Damage Percent: +50, Familiar Effect: "1xBarrr, cap 25"
 4542	tie of dire peril	0		Weapon Damage: +20, Single Equip
 4543	wobbly mansplainer's tuxedo pants	0		Monster Level: +15, Familiar Effect: "2xVolley, 1xPotato, cap 25"
@@ -4513,7 +4513,7 @@
 4565	yummy raisin	3	awesome	Last Available: "2010-04"
 4566	fly glasses	0		Experience (familiar): +1, Last Available: "2010-04"
 4567	careful Newton's flyest of shirts	0		Experience (Mysticality): +3, Monster Level: -10, Last Available: "2010-04"
-4568	bland snack-sized a dance upon the palate	2	decent	Last Available: "2010-04"
+4568	snack-sized bland a dance upon the palate	2	decent	Last Available: "2010-04"
 4569	spoiled prehistoric meteorite jawbreaker	4	crappy	Last Available: "2010-04"
 4570	shaking Crazyleg's razor	0		Last Available: "2010-04"
 4571	adequate half-sized squirmy violent party snack	2	good	Last Available: "2010-04"
@@ -4521,12 +4521,12 @@
 4573	maroon The Legendary Beat	0		Last Available: "2010-04"
 4574	lime green panicked kernel	0		Free Pull, Last Available: "2010-04"
 4575	bugged beanie	0		Familiar Weight: +10, Last Available: "2010-04"
-4576	blue bugged balaclava	0		Monster Level: +20, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
-4577	jittery bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Equips On: "Baby Bugged Bugbear", Last Available: "2010-04"
+4576	blue bugged balaclava	0		Monster Level: +20, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
+4577	jittery bugged b&Atilde;&para;n&plusmn;&Atilde;&copy;t	0		Food Drop: +5, Pants Drop: +5, Candy Drop: +5, Last Available: "2010-04", Equips On: "Baby Bugged Bugbear"
 4578	meat st&permil;&iquest;bing club	0		Last Available: "2010-04"
 4579	vacuum-sealed moist diffused gray Knob G&Atilde;&para;blin l&Atilde;&sup2;ve potion	0		Effect: "Seeing Colors", Effect Duration: 36, Last Available: "2010-04"
 4580	narrow therapeutic school Mafi<i>a kni</i>cke&frac12;&aelig;	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-04"
-4581	flame-retardant mansplainer's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Monster Level: +15, Hot Resistance: +1, Last Available: "2010-04", Wiki Name: "Bugged baio"
+4581	flame-retardant mansplainer's T&Icirc;&curren;&loz;lisman of Bai&oslash;&Dagger;	0		Monster Level: +15, Hot Resistance: +1, Wiki Name: "Bugged baio", Last Available: "2010-04"
 4582	fat bottom quark	0		Last Available: "2010-05"
 4583	glob of skin	0		
 4584	moldy six wedges of goat cheese	3	crappy	
@@ -4546,7 +4546,7 @@
 4598	shaking pixel stopwatch	0		Last Available: "2010-07"
 4599	bottle opener	0		Last Available: "2010-06"
 4600	map to the Kegger in the Woods	0		Last Available: "2010-06"
-4601	enchanted practically non-alcoholic acceptable bouncing plastic cup of beer	1	good	Effect: "Engorged Weapon", Effect Duration: 35, Last Available: "2010-06"
+4601	acceptable enchanted practically non-alcoholic bouncing plastic cup of beer	1	good	Effect: "Engorged Weapon", Effect Duration: 35, Last Available: "2010-06"
 4602	orquette's phone number	0		Last Available: "2010-06"
 4603	maroon bronze handcuffs	0		Last Available: "2010-06"
 4604	keg	0		Last Available: "2010-06"
@@ -4570,19 +4570,19 @@
 4622	Game Grid ticket	0		Last Available: "2010-06"
 4623	alkaline chocolate-covered caviar	0		Effect: "Good Karma", Effect Duration: 11, Last Available: "2020-09"
 4624	normal squat pawn cookie	3	good	Last Available: "2010-06"
-4625	compressed narrow shaking coffee pixie stick	1	decent	Last Available: "2010-06"
+4625	compressed shaking narrow coffee pixie stick	1	decent	Last Available: "2010-06"
 4626	superduperball	0		Last Available: "2010-06"
 4627	finger cuffs	0		Last Available: "2010-06"
 4628	parachute guy	0		Last Available: "2010-06"
 4629	ghostly wobbly curative plastic spider ring	0		HP Regen Min: 3, HP Regen Max: 5, Single Equip, Conditional Skill (Equipped): "Shoot Web", Last Available: "2010-06"
 4630	plastic kazoo of the early riser	0		Adventures: +7, Last Available: "2010-06"
 4631	pulsating Oprah's inflatable baseball bat	0		Maximum MP Percent: +50, Last Available: "2010-06"
-4632	maroon studded googly-star hat of doom	0		Damage Absorption: +80, Spooky Spell Damage: +50, Familiar Effect: "atk", Last Available: "2010-06"
+4632	maroon studded googly-star hat of doom	0		Damage Absorption: +80, Spooky Spell Damage: +50, Last Available: "2010-06", Familiar Effect: "atk"
 4633	frightening googly-ball hat of the ox	0		Muscle: +20, Spooky Damage: +5, Last Available: "2010-06"
 4634	zippy Fonzie's googly-heart hat	0		Experience (Moxie): +1, Initiative: +20, Last Available: "2010-06"
 4635	friendly Herculean super-sweet boom box	0		Experience (Muscle): +1, Familiar Weight: +3, Four Songs, Last Available: "2010-06"
 4636	jittery Game Grid valued membership card	0		Last Available: "2010-06"
-4637	spinning horrifying sinister demon mask of the bloodbag of chilblains	0		Maximum HP: +100, Cold Damage: +25, Spooky Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2010-06"
+4637	spinning horrifying sinister demon mask of the bloodbag of chilblains	0		Maximum HP: +100, Cold Damage: +25, Spooky Damage: +25, Last Available: "2010-06", Familiar Effect: "atk, cap 25"
 4638	bouncing Tesla resourceful Da Vinci's streetfighting champion's belt	0		Experience (Mysticality): +5, Maximum MP: +50, MP Regen Min: 7, MP Regen Max: 10, Single Equip, Last Available: "2010-06"
 4639	bouncing foul-smelling ruddy Space Trip safety headphones of horror	0		Maximum HP Percent: +40, Stench Damage: +10, Spooky Spell Damage: +25, Single Equip, Last Available: "2010-06"
 4640	pulsating Van der Graaf LARP carp	0		MP Regen Min: 5, MP Regen Max: 7
@@ -4594,8 +4594,8 @@
 4646	Jim Carey's banded Meteoid ice beam of wisdom	0		Mysticality: +15, Damage Absorption: +100, Monster Level: +25, Last Available: "2011-12"
 4647	upside-down miser's stiffened forbidden Dungeon Fist gauntlet	0		Spell Damage Percent: +50, Damage Reduction: 1, Meat Drop: +10, Last Available: "2011-06"
 4648	Schmalz's First Prize Beer	0		Free Pull, Last Available: "2011-12"
-4649	chiptune guitar	0		Item Drop: +25, Familiar Effect: "item drop", Equips On: "Mini-Hipster"
-4650	huge fixed-gear bicycle	0		Experience: +3, Familiar Effect: "stats", Equips On: "Mini-Hipster"
+4649	chiptune guitar	0		Item Drop: +25, Equips On: "Mini-Hipster", Familiar Effect: "item drop"
+4650	huge fixed-gear bicycle	0		Experience: +3, Equips On: "Mini-Hipster", Familiar Effect: "stats"
 4651	blue ironic moustache	0		Familiar Weight: +10, Familiar Effect: "+10 lbs"
 4652	ironic knit cap of wisdom of the empath	0		Mysticality: +15, Familiar Weight: +5, Familiar Effect: "1xVolley, 2xPotato, cap 10"
 4653	ironic sunglasses	0		Single Equip
@@ -4618,8 +4618,8 @@
 4670	wobbly beer-scented teddy bear	0		
 4671	acceptable booze-soaked cherry	4	good	
 4672	twirling comfy pillow	0		
-4673	bland tiny mirror marshmallow	1	decent	
-4674	jumbo normal shaking sponge cake	5	good	
+4673	tiny bland mirror marshmallow	1	decent	
+4674	normal jumbo shaking sponge cake	5	good	
 4675	drinkable gin-soaked blotter paper	3	good	
 4676	blurry tree-holed coin	0		
 4677	unearthed volcanic meteoroid	0		Skill: "Volcanometeor Showeruption", Last Available: "2011-12"
@@ -4627,8 +4627,8 @@
 4679	volcanic ash	0		
 4680	smoked potsherd	0		
 4681	avaricious pottery shield	0		Meat Drop: +30, Damage Reduction: 3, Last Available: "2010-09"
-4682	ribald pottery hat of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +10, Familiar Effect: "hot atk, cap 11", Last Available: "2010-09"
-4683	Jeselnik's pottery training pants of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +25, Familiar Effect: "hot atk, 2xGhuol, cap 12", Last Available: "2010-09"
+4682	ribald pottery hat of the bloodbag	0		Maximum HP: +100, Sleaze Damage: +10, Last Available: "2010-09", Familiar Effect: "hot atk, cap 11"
+4683	Jeselnik's pottery training pants of the scaredy-cat	0		Monster Level: -15, Sleaze Damage: +25, Last Available: "2010-09", Familiar Effect: "hot atk, 2xGhuol, cap 12"
 4684	therapeutic pottery club	0		HP Regen Min: 5, HP Regen Max: 7, Last Available: "2010-09"
 4685	frightening pottery yo-yo	0		Spooky Damage: +5, Last Available: "2010-09"
 4686	pottery barn owl figurine	0		Last Available: "2010-09"
@@ -4641,7 +4641,7 @@
 4693	fossilized torso	0		Last Available: "2010-09"
 4694	fossilized spine	0		Last Available: "2010-09"
 4695	olive affordable teak perch	0		Familiar Weight: +5, Last Available: "2010-09"
-4696	mirror therapeutic boxer's Greatest American Pants of the empath	0		Muscle Percent: +10, Familiar Weight: +5, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25", Last Available: "2010-09"
+4696	mirror therapeutic boxer's Greatest American Pants of the empath	0		Muscle Percent: +10, Familiar Weight: +5, HP Regen Min: 5, HP Regen Max: 7, Softcore Only, Last Available: "2010-09", Familiar Effect: "1.5xVolley, 2.5xBarrr, 2xLep, cap 25"
 4697	fossilized necklace of Tarzan	0		Experience (Muscle): +3, Last Available: "2010-09"
 4698	skewed imp air	0		
 4699	huge upside-down bus pass	0		
@@ -4670,11 +4670,11 @@
 4722	flavorless huge wobbly liver and let pie	7	decent	Last Available: "2010-10"
 4723	fancy decent badass pie	3	good	Effect: "Abominably Slippery", Effect Duration: 50, Last Available: "2010-10"
 4724	low-calorie toothsome shoo-fish pie	1	awesome	Last Available: "2010-10"
-4725	small tasty blinking piping organ pie	2	awesome	Last Available: "2010-10"
+4725	tasty small blinking piping organ pie	2	awesome	Last Available: "2010-10"
 4726	toothsome igloo pie	3	awesome	Last Available: "2010-10"
 4727	delicious stomach turnover	3	awesome	Last Available: "2010-10"
 4728	decent bouncing dead lights pie	4	good	Last Available: "2010-10"
-4729	rotten narrow red throbbing organ pie	4	crappy	Last Available: "2010-10"
+4729	rotten red narrow throbbing organ pie	4	crappy	Last Available: "2010-10"
 4730	slick stop shield	0		Moxie: +10, Damage Reduction: 6, Last Available: "2009-12"
 4731	nest egg	0		
 4732	sleeping piano cat	0		Free Pull, Last Available: "2011-12"
@@ -4683,8 +4683,8 @@
 4735	prop sword	0		Familiar Weight: +5
 4736	blue tangle of rat tails	0		
 4737	savvy beer-soaked mop	0		Mysticality Percent: +20
-4738	irresponsibly strong artisanal day-old beer	6	EPIC	
-4739	fortified acceptable upside-down plain beer	5	good	
+4738	artisanal irresponsibly strong day-old beer	6	EPIC	
+4739	acceptable fortified upside-down plain beer	5	good	
 4740	enchanted practically non-alcoholic artisanal overpriced &quot;imported&quot; beer	1	EPIC	Effect: "Vitali Tea", Effect Duration: 45
 4741	smiling rat	0		
 4742	yellow rat tooth polish	0		Familiar Weight: +5
@@ -4693,16 +4693,16 @@
 4745	deionized super-improved Wax Flask	0		Effect: "In Vino Vires", Effect Duration: 43
 4746	galvanized wet Pain Dip	0		Effect: "The Halls of Moxiousness", Effect Duration: 60
 4747	yummy miniature narrow bone meal	2	awesome	Last Available: "2010-10"
-4748	mediocre watered-down bone aperitif	2	decent	Last Available: "2010-10"
+4748	watered-down mediocre bone aperitif	2	decent	Last Available: "2010-10"
 4749	fortified bonerang	0		Damage Absorption: +60, Last Available: "2010-10"
 4750	razor-sharp bone and arrows	0		Weapon Damage Percent: +25, Last Available: "2010-10"
 4751	boning knife of horror	0		Spooky Spell Damage: +25, Last Available: "2010-10"
 4752	bone crusher of mayonnaise	0		Sleaze Spell Damage: +50, Last Available: "2010-10"
 4753	twirling ghostly bouncing banded bone spurs	0		Damage Absorption: +100, Single Equip, Last Available: "2010-10"
-4754	Jack Frost's razor-sharp bonedanna	0		Weapon Damage Percent: +25, Cold Spell Damage: +50, Familiar Effect: "atk, cap 30", Last Available: "2010-10"
-4755	wobbly boneana hammock of the wise owl of terror	0		Mysticality: +20, Spooky Spell Damage: +10, Familiar Effect: "sleaze atk, 1xVolley, cap 30", Last Available: "2010-10"
+4754	Jack Frost's razor-sharp bonedanna	0		Weapon Damage Percent: +25, Cold Spell Damage: +50, Last Available: "2010-10", Familiar Effect: "atk, cap 30"
+4755	wobbly boneana hammock of the wise owl of terror	0		Mysticality: +20, Spooky Spell Damage: +10, Last Available: "2010-10", Familiar Effect: "sleaze atk, 1xVolley, cap 30"
 4756	bag of bones	0		Last Available: "2010-10"
-4757	upside-down blue Stabonic scroll	0		Last Available: "2010-10"
+4757	blue upside-down Stabonic scroll	0		Last Available: "2010-10"
 4758	polymerized wet candy skeleton	0		Effect: "Altered Wavelengths", Effect Duration: 41, Last Available: "2020-09"
 4759	Grumpy Bumpkin's Pumpkin Seed Catalog	0		Last Available: "2010-11"
 4760	packet of pumpkin seeds	0		Last Available: "2010-11"
@@ -4724,8 +4724,8 @@
 4810	tumbling Holiday Hal's Happy-Time Fun Book!	0		Skill: "Summon Holiday Fun!"
 4811	Holiday Fun!	0		Free Pull, Last Available: "2014-12"
 4812	tumbling Antagonistic Snowman Kit	0		Skill: "Summon Carrot"
-4818	stale massive tumbling CRIMBCOIDS mints	6	decent	Last Available: "2011-01"
-4819	upside-down pulsating can of CRIMBCOLA	0		Last Available: "2010-12"
+4818	massive stale tumbling CRIMBCOIDS mints	6	decent	Last Available: "2011-01"
+4819	pulsating upside-down can of CRIMBCOLA	0		Last Available: "2010-12"
 4820	yummy half-sized CRIMBCOLOAF	2	awesome	Last Available: "2011-01"
 4821	moldy skewed circular CRIMBCOOKIE	4	crappy	Effect: "Mystic Circle", Effect Duration: 10, Last Available: "2010-12"
 4822	pulsating greedy plastic CRIMBCO HQ	0		Meat Drop: +20, Last Available: "2010-12"
@@ -4734,7 +4734,7 @@
 4825	cyan rock-hard plastic Mr. Mination	0		Damage Reduction: 5, Last Available: "2010-12"
 4826	gray ghostly shellacked plastic Best Game Ever	0		Damage Reduction: 7, Last Available: "2010-12"
 4827	hibernating robot reindeer	0		Free Pull, Last Available: "2010-12"
-4828	mirror tumbling S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
+4828	tumbling mirror S.L.E.I.G.H.B.E.L.L.S.	0		Familiar Weight: +5, Last Available: "2010-12"
 4829	narrow robot reindeer protocol P.R.A.N.C.E.R.	0		Last Available: "2010-12"
 4830	robot reindeer protocol D.A.S.H.E.R.	0		Last Available: "2010-12"
 4831	robot reindeer protocol D.O.N.N.E.R.	0		Last Available: "2010-12"
@@ -4751,22 +4751,22 @@
 4842	sleeping stocking	0		Last Available: "2010-12"
 4843	Tales of a Kansas Toymaker	0		Skill: "Toynado", Last Available: "2010-12"
 4844	The Joy of Wassailing	0		Skill: "Wassail", Last Available: "2010-12"
-4845	fireproof shellacked Uncle Hobo's stocking cap	0		Damage Reduction: 7, Hot Resistance: +3, Familiar Effect: "atk", Last Available: "2010-12"
+4845	fireproof shellacked Uncle Hobo's stocking cap	0		Damage Reduction: 7, Hot Resistance: +3, Last Available: "2010-12", Familiar Effect: "atk"
 4846	slick weightlifter's Uncle Hobo's epic beard	0		Muscle: +15, Moxie: +10, Single Equip, Last Available: "2010-12"
-4847	pulsating knitted deadly Uncle Hobo's gift baggy pants	0		Weapon Damage: +5, Cold Resistance: +3, Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2010-12"
+4847	pulsating knitted deadly Uncle Hobo's gift baggy pants	0		Weapon Damage: +5, Cold Resistance: +3, Last Available: "2010-12", Familiar Effect: "1xPotato, 1xGhuol"
 4848	perfumed Annie Oakley's Uncle Hobo's fingerless tinsel gloves	0		Critical Hit Percent: +20, Stench Resistance: +5, Single Equip, Last Available: "2010-12"
 4849	pulsating asbestos-lined knitted Uncle Hobo's highest bough	0		Cold Resistance: +3, Hot Resistance: +5, Last Available: "2010-12"
 4850	hale Sinatra's Uncle Hobo's belt	0		Experience (Moxie): +5, Maximum HP: +20, Single Equip, Last Available: "2010-12"
 4851	wet unsweetened chocolate cigar	0		Effect: "You Can Taste the Darkness", Effect Duration: 51, Last Available: "2010-12"
 4852	gift-a-pult of bravery	0		Spooky Resistance: +5, Last Available: "2010-12"
-4853	activated denatured boiled blinking cyan holly-flavored Hob-O	0		Effect: "Barbecue Saucy", Effect Duration: 49, Last Available: "2020-09"
+4853	activated denatured boiled cyan blinking holly-flavored Hob-O	0		Effect: "Barbecue Saucy", Effect Duration: 49, Last Available: "2020-09"
 4854	CRIMBCO scrip	0		Last Available: "2011-01"
 4855	Toot Oriole care package	0		
 4856	paperclip	0		Last Available: "2011-01"
 4857	blue bottle of Blank-Out	0		Last Available: "2011-01"
 4858	pulsating CRIMBCO lanyard of courage	0		Spooky Resistance: +3, Single Equip, Last Available: "2011-01"
 4859	fuchsia CRIMBCO Employee Handbook (chapter 1)	0		Skill: "Fashionably Late", Last Available: "2011-01"
-4860	green squat squat CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
+4860	squat squat green CRIMBCO Employee Handbook (chapter 2)	0		Skill: "Executive Narcolepsy", Last Available: "2011-01"
 4861	blurry CRIMBCO Employee Handbook (chapter 3)	0		Skill: "Lunch Break", Last Available: "2011-01"
 4862	twirling CRIMBCO Employee Handbook (chapter 4)	0		Skill: "Offensive Joke", Last Available: "2011-01"
 4863	CRIMBCO Employee Handbook (chapter 5)	0		Skill: "Managerial Manipulation", Last Available: "2011-01"
@@ -4775,8 +4775,8 @@
 4866	red Workytime Tea	0		Last Available: "2011-01"
 4867	paperclip sproinger	0		Last Available: "2011-01"
 4868	shaking blurry grievous deadly strapping paperclip-on tie	0		Muscle: +5, Weapon Damage: +5, Weapon Damage Percent: +50, Single Equip, Last Available: "2011-01"
-4869	scorching hardy paperclip pants	0		Maximum HP: +50, Hot Damage: +25, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2011-01"
-4870	twirling upside-down energetic curative banded paperclip turban	0		Damage Absorption: +100, Maximum MP Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Familiar Effect: "atk, cap 12", Last Available: "2011-01"
+4869	scorching hardy paperclip pants	0		Maximum HP: +50, Hot Damage: +25, Last Available: "2011-01", Familiar Effect: "atk, 3xBarrr, cap 12"
+4870	twirling upside-down energetic curative banded paperclip turban	0		Damage Absorption: +100, Maximum MP Percent: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2011-01", Familiar Effect: "atk, cap 12"
 4871	jittery frightening paperclip cape	0		Spooky Damage: +5, Last Available: "2011-01"
 4872	wobbly yellow glob of Blank-Out	0		Last Available: "2011-01"
 4873	photocopied monster	0		Last Available: "2011-01"
@@ -4794,7 +4794,7 @@
 4885	mirror squat traffic jam	0		Last Available: "2011-01"
 4886	decent traffic jam toast	3	good	Last Available: "2011-01"
 4887	space jam	0		Last Available: "2011-01"
-4888	half-sized normal huge space jam toast	2	good	Last Available: "2011-01"
+4888	normal half-sized huge space jam toast	2	good	Last Available: "2011-01"
 4889	quantum motivational poster	0		Effect: "Mariachi Mood", Effect Duration: 34, Last Available: "2011-01"
 4890	mirror sack lunch	0		Last Available: "2011-01"
 4891	blurry bath ball gift set	0		Last Available: "2011-01"
@@ -4812,7 +4812,7 @@
 4903	adhesive tape dolly of the pedagogue	0		Experience: +3, Last Available: "2010-12"
 4904	banded scissor duck	0		Damage Absorption: +100, Last Available: "2010-12"
 4905	coal paperweight	0		Last Available: "2010-12"
-4906	bouncing blurry jingle bell	0		Last Available: "2010-12"
+4906	blurry bouncing jingle bell	0		Last Available: "2010-12"
 4907	Seven Loco of the storm of the boozehound	0		Maximum MP Percent: +40, Booze Drop: +100, Last Available: "2010-09"
 4908	Loathing Legion knife	0		Last Available: "2011-01"
 4909	fortified Loathing Legion many-purpose hook	0		Damage Absorption: +60, Softcore Only, Last Available: "2011-01"
@@ -4842,7 +4842,7 @@
 4939	time's arrow	0		Free Pull, Last Available: "2011-12"
 4940	blinking arrowgram	0		Free Pull, Last Available: "2011-12"
 4941	flavorless Knob jelly donut	3	decent	
-4942	jittery shaking Knob cake	0		
+4942	shaking jittery Knob cake	0		
 4943	Knob cake pan	0		
 4944	wobbly Knob batter	0		
 4945	Knob frosting	0		
@@ -4852,7 +4852,7 @@
 4949	double-electrified enhanced weremoose spit	0		Effect: "Alpine Mintiness", Effect Duration: 33
 4950	ionized abominable blubber	0		Effect: "All Is Forgiven", Effect Duration: 53
 4951	beefcake's flimsy clipboard	0		Muscle: +25, Damage Reduction: 3
-4952	double-altered super-polarized wobbly fuchsia baggie of sugar	0		Effect: "Tennis Elbow-wow", Effect Duration: 60
+4952	double-altered super-polarized fuchsia wobbly baggie of sugar	0		Effect: "Tennis Elbow-wow", Effect Duration: 60
 4953	lion tamer's resourceful whalebone corset	0		Maximum MP: +50, Experience (familiar): +2, Single Equip
 4954	up-at-dawn oven mitts	0		Adventures: +5, Single Equip
 4955	yummy overcookie	3	awesome	
@@ -4860,7 +4860,7 @@
 4957	altered spinning half-baked potion	0		Effect: "Jelly Combed", Effect Duration: 22
 4958	Tesla Knob Goblin deluxe scimitar	0		MP Regen Min: 7, MP Regen Max: 10
 4959	stale lime green Knob nuts	3	decent	
-4960	mediocre irresponsibly strong Cobb's Knob Wurstbrau	9	decent	
+4960	irresponsibly strong mediocre Cobb's Knob Wurstbrau	9	decent	
 4961	Subject 37 file	0		
 4962	narrow groovy mysterious lapel pin of terror	0		Moxie Percent: +10, Spooky Spell Damage: +10, Single Equip
 4963	state loom	0		Familiar Weight: +10
@@ -4869,18 +4869,18 @@
 4966	mirror Pack of Alice's Army Cards	0		Last Available: "2011-03"
 4967	Alice's Army Swordsman	0		Last Available: "2011-03"
 4968	Alice's Army Spearsman	0		Last Available: "2011-03"
-4969	bouncing mirror Alice's Army Halberder	0		Last Available: "2011-03"
+4969	mirror bouncing Alice's Army Halberder	0		Last Available: "2011-03"
 4970	upside-down Alice's Army Guard	0		Last Available: "2011-03"
 4971	Alice's Army Wallman	0		Last Available: "2011-03"
 4972	Alice's Army Ninja	0		Last Available: "2011-03"
-4973	jittery olive skewed Alice's Army Alchemist	0		Last Available: "2011-03"
+4973	jittery skewed olive Alice's Army Alchemist	0		Last Available: "2011-03"
 4974	huge Alice's Army Page	0		Last Available: "2011-03"
 4975	Alice's Army Shieldmaiden	0		Last Available: "2011-03"
 4976	cyan Alice's Army Mad Bomber	0		Last Available: "2011-03"
 4977	Alice's Army Nurse	0		Last Available: "2011-03"
 4978	Alice's Army Hammerman	0		Last Available: "2011-03"
 4979	Alice's Army Bowman	0		Last Available: "2011-03"
-4980	shaking skewed Alice's Army Lanceman	0		Last Available: "2011-03"
+4980	skewed shaking Alice's Army Lanceman	0		Last Available: "2011-03"
 4981	Alice's Army Horseman	0		Last Available: "2011-03"
 4982	Alice's Army Coward	0		Last Available: "2011-03"
 4983	twirling Alice's Army Cleric	0		Last Available: "2011-03"
@@ -4917,15 +4917,15 @@
 5014	adequate tobiko pocky	3	good	Last Available: "2011-03"
 5015	tasty maroon natto pocky	3	awesome	Last Available: "2011-03"
 5016	hand-crafted bouncing wasabi-infused sake	4	EPIC	Last Available: "2011-03"
-5017	lousy weak tobiko-infused sake	2	decent	Last Available: "2011-03"
-5018	perfectly mixed watered-down natto-infused sake	2	EPIC	Last Available: "2011-03"
+5017	weak lousy tobiko-infused sake	2	decent	Last Available: "2011-03"
+5018	watered-down perfectly mixed natto-infused sake	2	EPIC	Last Available: "2011-03"
 5019	unsweetened alkaline narrow wasabi marble soda	0		Effect: "Witch's Brood", Effect Duration: 11, Last Available: "2011-03"
 5020	liquefied frozen huge tobiko marble soda	0		Effect: "Magically Delicious", Effect Duration: 52, Last Available: "2011-03"
 5021	super-moist unsweetened jittery natto marble soda	0		Effect: "Jelly Combed", Effect Duration: 58, Last Available: "2011-03"
 5022	upside-down Alice's Army booster box	0		Last Available: "2011-03"
 5023	nitrogenated irradiated ghostly elderly jawbreaker	0		Effect: "Coldfinger", Effect Duration: 23, Last Available: "2020-09"
-5024	watered-down drinkable marshmallow flamb&eacute;	2	good	Last Available: "2011-03"
-5025	tolerable teal tumbling cranberry schnapps	3	good	Last Available: "2011-03"
+5024	drinkable watered-down marshmallow flamb&eacute;	2	good	Last Available: "2011-03"
+5025	tolerable tumbling teal cranberry schnapps	3	good	Last Available: "2011-03"
 5026	acceptable breaded beer	3	good	Last Available: "2011-03"
 5027	acceptable soy cordial	4	good	Last Available: "2011-03"
 5028	huge huge wool crafty astral bludgeon of Calamity Jane	0		Maximum MP: +10, Critical Hit Percent: +15, Cold Resistance: +1
@@ -4943,20 +4943,20 @@
 5040	wobbly astral pet sweater	0		Familiar Weight: +10
 5041	red flame-retardant lard-coated brawny astral shirt	0		Muscle Percent: +20, Sleaze Spell Damage: +25, Hot Resistance: +1
 5042	gray narrow narrow wobbly double-paned Temple Grandin's astral belt	0		Familiar Weight: +7, Cold Resistance: +5
-5043	tiny rotten astral hot dog	1		
-5044	enchanted mediocre practically non-alcoholic astral pilsner	1		Effect: "Frostbeard", Effect Duration: 45
-5045	wobbly mirror astral hot dog dinner	0		
+5043	rotten tiny astral hot dog	1		
+5044	enchanted practically non-alcoholic mediocre astral pilsner	1		Effect: "Frostbeard", Effect Duration: 45
+5045	mirror wobbly astral hot dog dinner	0		
 5046	astral six-pack	0		
 5047	Clan shower	0		Free Pull, Last Available: "2011-04"
-5048	skewed huge shard of double-ice	0		Last Available: "2011-04"
-5049	stanky studded razor-sharp double-ice cap	0		Weapon Damage Percent: +25, Damage Absorption: +80, Stench Spell Damage: +25, Familiar Effect: "1xPotato, 1xFairy, cap 17", Last Available: "2011-04"
+5048	huge skewed shard of double-ice	0		Last Available: "2011-04"
+5049	stanky studded razor-sharp double-ice cap	0		Weapon Damage Percent: +25, Damage Absorption: +80, Stench Spell Damage: +25, Last Available: "2011-04", Familiar Effect: "1xPotato, 1xFairy, cap 17"
 5050	blurry miser's smelly weightlifter's double-ice box	0		Muscle: +15, Stench Spell Damage: +10, Meat Drop: +10, Last Available: "2011-04"
-5051	inspector's family-friendly Jeselnik's double-ice britches	0		Sleaze Damage: +25, Sleaze Resistance: +1, Item Drop: +15, Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17", Last Available: "2011-04"
+5051	inspector's family-friendly Jeselnik's double-ice britches	0		Sleaze Damage: +25, Sleaze Resistance: +1, Item Drop: +15, Last Available: "2011-04", Familiar Effect: "cold atk, 3xVolley, 3xLep, cap 17"
 5052	blue handful of numbers	0		Last Available: "2020-09"
 5053	Lars the Cyberian	0		Last Available: "2011-04"
 5054	blinking jittery intriguing puzzle box	0		Last Available: "2011-04"
 5055	wobbly obnoxious riddle	0		Last Available: "2011-04"
-5056	red jittery upside-down best joke ever	0		Last Available: "2011-04"
+5056	red upside-down jittery best joke ever	0		Last Available: "2011-04"
 5057	triple-energized oxidized Atomic Comic	0		Effect: "Sharpened Sweet Tooth", Effect Duration: 30, Last Available: "2011-04"
 5058	polarized spinning Red Pill	0		Effect: "Mariachi Mood", Effect Duration: 63, Last Available: "2011-04"
 5059	shaking Skullhead's Screw	0		Last Available: "2011-04"
@@ -4976,17 +4976,17 @@
 5073	drinkable weak Russian Ice	2	good	Last Available: "2011-04"
 5074	squat hardened clay ashtray	0		Damage Reduction: 6, Last Available: "2011-05"
 5075	frightening lanyard	0		Spooky Damage: +5, Single Equip, Last Available: "2011-05"
-5076	avaricious monster pants	0		Meat Drop: +30, Familiar Effect: "3xVolley, 3xPotato, cap 17", Last Available: "2011-05"
+5076	avaricious monster pants	0		Meat Drop: +30, Last Available: "2011-05", Familiar Effect: "3xVolley, 3xPotato, cap 17"
 5077	fuchsia box of Pok&euml;mann band-aids	0		Last Available: "2011-05"
 5078	dry tarnished Pok&euml;mann band-aid	0		Effect: "Bright!", Effect Duration: 52, Last Available: "2011-05"
-5079	green gravedigger's Van der Graaf helmet of doom	0		Spooky Damage: +10, Spooky Spell Damage: +50, Familiar Effect: "3xPotato, cap 7", Last Available: "2011-05"
+5079	green gravedigger's Van der Graaf helmet of doom	0		Spooky Damage: +10, Spooky Spell Damage: +50, Last Available: "2011-05", Familiar Effect: "3xPotato, cap 7"
 5080	shaking fireproof crutch	0		Hot Resistance: +3, Last Available: "2011-05"
 5081	rosy-cheeked shock belt	0		Maximum HP Percent: +30, Single Equip, Last Available: "2011-05"
 5082	quantum jittery tumbling Okee-Dokee soda	0		Effect: "Leo Rising", Effect Duration: 23, Last Available: "2011-05"
 5083	skewed dangerous rubber band gun	0		Weapon Damage: +10, Last Available: "2011-05"
-5084	up-at-dawn pin-stripe slacks	0		Adventures: +5, Familiar Effect: "6xSombrero, 2xPotato, cap 7", Last Available: "2011-05"
+5084	up-at-dawn pin-stripe slacks	0		Adventures: +5, Last Available: "2011-05", Familiar Effect: "6xSombrero, 2xPotato, cap 7"
 5085	rock-hard gloves	0		Damage Reduction: 5, Single Equip, Last Available: "2011-05"
-5086	anodized ionized spinning blurry cyan correction fluid	0		Effect: "Stop the Presses!", Effect Duration: 63, Last Available: "2011-05"
+5086	anodized ionized blurry spinning cyan correction fluid	0		Effect: "Stop the Presses!", Effect Duration: 63, Last Available: "2011-05"
 5087	clever Pok&euml;mann figurine: Porkachu	0		Maximum MP: +20, Single Equip, Last Available: "2011-05"
 5088	stylish Pok&euml;mann figurine: Magikrap	0		Moxie: +25, Single Equip, Last Available: "2011-05"
 5089	Pok&euml;mann figurine: Vegemite	0		Item Drop: +5, Single Equip, Last Available: "2011-05"
@@ -5004,10 +5004,10 @@
 5101	fuchsia beefcake's Pok&euml;mann figurine: Moog	0		Muscle: +25, Single Equip, Last Available: "2011-05"
 5102	colloidal improved extra-altered teal willyweed	0		Effect: "Stemonitis Storm", Effect Duration: 67, Last Available: "2011-05"
 5103	polymerized ionized Nuclear Blastball	0		Effect: "Stench Jellied", Effect Duration: 60, Last Available: "2011-05"
-5104	extra-chilled flattened ghostly squat fish juice box	0		Effect: "Tea-hee", Effect Duration: 23, Last Available: "2011-05"
+5104	extra-chilled flattened squat ghostly fish juice box	0		Effect: "Tea-hee", Effect Duration: 23, Last Available: "2011-05"
 5105	paint bomb	0		Last Available: "2011-05"
 5106	twirling hideous egg	0		Last Available: "2011-05"
-5107	watered-down mediocre squat Jeppson's Malort	2	decent	Last Available: "2011-06"
+5107	mediocre watered-down squat Jeppson's Malort	2	decent	Last Available: "2011-06"
 5108	fistful of ashes	0		
 5109	Van der Graaf stress ball	0		MP Regen Min: 5, MP Regen Max: 7, Conditional Skill (Equipped): "Squeeze Stress Ball", Last Available: "2011-05"
 5110	olive Li'l Businessman Kit	0		Meat Drop: +5, Item Drop: +5, Last Available: "2011-05"
@@ -5021,10 +5021,10 @@
 5118	pulsating huge bird brain	0		
 5119	busted wings	0		
 5120	mirror Massive Manual of Marauder Mockery	0		Last Available: "2011-05"
-5121	Jack Frost's medical-grade strapping Admiral's hat	0		Muscle: +5, Cold Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "atk", Last Available: "2011-05"
-5122	jittery blurry mansplainer's aviator's cap of the storm of the glutton	0		Maximum MP Percent: +40, Monster Level: +15, Food Drop: +100, Familiar Effect: "atk, cap 12", Last Available: "2011-05"
+5121	Jack Frost's medical-grade strapping Admiral's hat	0		Muscle: +5, Cold Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2011-05", Familiar Effect: "atk"
+5122	jittery blurry mansplainer's aviator's cap of the storm of the glutton	0		Maximum MP Percent: +40, Monster Level: +15, Food Drop: +100, Last Available: "2011-05", Familiar Effect: "atk, cap 12"
 5123	mirrored aviator shades of Flo-Jo of the early riser	0		Initiative: +100, Adventures: +7, Single Equip, Last Available: "2011-05"
-5124	bouncing ghostly Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
+5124	ghostly bouncing Field Guide to Skeletal Anatomy	0		Skill: "Natural Born Skeleton Killer", Last Available: "2011-05"
 5125	bouncing Notes from the Elfpocalypse, Chapter I	0		Last Available: "2011-06"
 5126	twirling Notes from the Elfpocalypse, Chapter II	0		Last Available: "2011-06"
 5127	blurry Notes from the Elfpocalypse, Chapter III	0		Last Available: "2011-06"
@@ -5034,10 +5034,10 @@
 5131	galvanized huge cyan Ultrasoldier Serum	0		Effect: "Chlorophyll Flavor", Effect Duration: 69, Last Available: "2011-06"
 5132	rotten upside-down elven hardtack	3	crappy	Last Available: "2011-06"
 5133	weak smooth blinking blurry elven squeeze	2	awesome	Last Available: "2011-06"
-5134	mirror cyan wobbly lunar isotope	0		Last Available: "2011-06"
+5134	mirror wobbly cyan lunar isotope	0		Last Available: "2011-06"
 5135	pulsating E.M.U. joystick	0		Last Available: "2011-06"
 5136	huge E.M.U. rocket thrusters	0		Last Available: "2011-06"
-5137	wobbly huge E.M.U. helmet	0		Last Available: "2011-06"
+5137	huge wobbly E.M.U. helmet	0		Last Available: "2011-06"
 5138	E.M.U. harness	0		Last Available: "2011-06"
 5139	carton of astral energy drinks	0		
 5140	pickled blurry astral energy drink	1		
@@ -5045,14 +5045,14 @@
 5142	moon unit	0		Last Available: "2011-06"
 5143	blurry E.M.U. Unit	0		Last Available: "2011-06"
 5144	handful of honey	0		
-5145	modified unsweetened bouncing huge honeypot	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 11
-5146	bite-sized adequate wild honey pie	1	good	
+5145	modified unsweetened huge bouncing honeypot	0		Effect: "Putting the Pro in Proletariat", Effect Duration: 11
+5146	adequate bite-sized wild honey pie	1	good	
 5147	hand-crafted honey mead	3	EPIC	
 5148	skewed dance instructor's Herculean honey dipper of the boozehound	0		Experience (Muscle): +1, Experience Percent (Moxie): +10, Booze Drop: +100
 5149	skewed bouncing bouncing mansplainer's sharpshooter's crafty honeybritches	0		Maximum MP: +10, Critical Hit Percent: +10, Monster Level: +15, Familiar Effect: "sleaze atk, 2xGhuol, cap 43"
 5150	greedy asbestos-lined smartaleck's honeycap	0		Moxie Percent: +30, Hot Resistance: +5, Meat Drop: +20, Familiar Effect: "1xPotato, cap 43"
-5151	wizardly Moonthril Circlet	0		Mysticality: +25, Familiar Effect: "2xVolley, cap 25", Last Available: "2011-06"
-5152	wobbly Moonthril Greaves of Leguizamo	0		Monster Level: +20, Familiar Effect: "cap 25", Last Available: "2011-06"
+5151	wizardly Moonthril Circlet	0		Mysticality: +25, Last Available: "2011-06", Familiar Effect: "2xVolley, cap 25"
+5152	wobbly Moonthril Greaves of Leguizamo	0		Monster Level: +20, Last Available: "2011-06", Familiar Effect: "cap 25"
 5153	wholesome Moonthril Flamberge	0		Maximum HP Percent: +10, Last Available: "2011-06"
 5154	frightening Moonthril Longbow	0		Spooky Damage: +5, Last Available: "2011-06"
 5155	huge electrified Moonthril Cuirass	0		MP Regen Min: 3, MP Regen Max: 5, Softcore Only, Last Available: "2011-06"
@@ -5076,11 +5076,11 @@
 5173	fuchsia elven magi-pack	0		Last Available: "2011-06"
 5174	distilled fancy perfectly mixed bouncing Saison du Lune	5	EPIC	Effect: "Chalky Hand", Effect Duration: 50, Last Available: "2011-06"
 5175	perfectly mixed Moonthril Schnapps	3	EPIC	Last Available: "2011-06"
-5176	mediocre fancy watered-down Wrecked Generator	2	decent	Effect: "Sharp Weapon", Effect Duration: 5, Last Available: "2011-06"
+5176	fancy watered-down mediocre Wrecked Generator	2	decent	Effect: "Sharp Weapon", Effect Duration: 5, Last Available: "2011-06"
 5177	rotten Spaghetti with Moonballs	3	crappy	Last Available: "2011-06"
-5178	moldy small Crepes a la Lune	2	crappy	Last Available: "2011-06"
+5178	small moldy Crepes a la Lune	2	crappy	Last Available: "2011-06"
 5179	adequate Moon Pie	4	good	Last Available: "2011-06"
-5180	pressed olive spinning Comet Pop	0		Effect: "Clyde's Blessing", Effect Duration: 68, Last Available: "2011-06"
+5180	pressed spinning olive Comet Pop	0		Effect: "Clyde's Blessing", Effect Duration: 68, Last Available: "2011-06"
 5181	quadruple-cold-filtered ionized bouncing Flan in the Moon	0		Effect: "New and Improved", Effect Duration: 68, Last Available: "2011-06"
 5182	vacuum-sealed 1/6th Pound Cake	0		Effect: "Burning Hands", Effect Duration: 37, Last Available: "2011-06"
 5183	yellow Mint-in-box Moonthril Circlet	0		Last Available: "2011-06"
@@ -5089,7 +5089,7 @@
 5186	twirling Mint-in-box Moonthril Flamberge	0		Last Available: "2011-06"
 5187	ghostly Mint-in-box Moonthril Longbow	0		Last Available: "2011-06"
 5188	non-wet pressed spinning honey stick	0		Effect: "Musky", Effect Duration: 54
-5189	pressed chilled bouncing ghostly double-ice gum	0		Effect: "Buttermilk Boogie", Effect Duration: 29, Last Available: "2011-04"
+5189	pressed chilled ghostly bouncing double-ice gum	0		Effect: "Buttermilk Boogie", Effect Duration: 29, Last Available: "2011-04"
 5190	olive up-at-dawn groovy Operation Patriot Shield of the detective	0		Moxie Percent: +10, Item Drop: +20, Adventures: +5, Damage Reduction: 1, Softcore Only, Conditional Skill (Equipped): "Throw Shield", Last Available: "2011-07"
 5191	squirming egg sac	0		Last Available: "2011-06"
 5192	moist flattened extra-deionized maroon corrupted data	0		Effect: "Castaway Physique", Effect Duration: 13, Last Available: "2011-06"
@@ -5105,25 +5105,25 @@
 5202	diluted greasy paste	1	awesome	Last Available: "2011-08"
 5203	twisted bug paste	1	awesome	Last Available: "2011-08"
 5204	twisted huge hippy paste	1	good	Last Available: "2011-08"
-5205	altered lime green blurry orc paste	1	crappy	Effect: "Liquid Luck", Effect Duration: 45, Last Available: "2011-08"
+5205	altered blurry lime green orc paste	1	crappy	Effect: "Liquid Luck", Effect Duration: 45, Last Available: "2011-08"
 5206	altered olive huge demonic paste	1	decent	Last Available: "2011-08"
-5207	modified lime green huge skewed indescribably horrible paste	1	decent	Effect: "Meatwise", Effect Duration: 40, Last Available: "2011-08"
+5207	modified skewed huge lime green indescribably horrible paste	1	decent	Effect: "Meatwise", Effect Duration: 40, Last Available: "2011-08"
 5208	altered skewed paste	1	EPIC	Last Available: "2011-08"
 5209	dried goblin paste	1	decent	Effect: "Sensation", Effect Duration: 15, Last Available: "2011-08"
 5210	pickled teal pirate paste	1	good	Last Available: "2011-08"
-5211	pickled blue narrow jittery chlorophyll paste	1	awesome	Last Available: "2011-08"
+5211	pickled jittery narrow blue chlorophyll paste	1	awesome	Last Available: "2011-08"
 5212	dehydrated tumbling paste	1	good	Last Available: "2011-08"
-5213	dried blurry skewed Mer-kin paste	1	decent	Effect: "Human-Penguin Hybrid", Effect Duration: 5, Last Available: "2011-08"
+5213	dried skewed blurry Mer-kin paste	1	decent	Effect: "Human-Penguin Hybrid", Effect Duration: 5, Last Available: "2011-08"
 5214	pickled slimy paste	1	decent	Effect: "Grape Expectations", Effect Duration: 5, Last Available: "2011-08"
 5215	powdered pulsating penguin paste	1	awesome	Last Available: "2011-08"
 5216	powdered skewed upside-down elemental paste	1	awesome	Last Available: "2011-08"
 5217	boiled narrow cosmic paste	1	good	Last Available: "2011-08"
-5218	pickled narrow twirling hobo paste	1	good	Last Available: "2011-08"
-5219	compressed jittery blinking jittery Crimbo paste	1	awesome	Last Available: "2011-08"
+5218	pickled twirling narrow hobo paste	1	good	Last Available: "2011-08"
+5219	compressed jittery jittery blinking Crimbo paste	1	awesome	Last Available: "2011-08"
 5220	purple Teachings of the Fist	0		
 5221	blinking fat loot token	0		No Pull
 5222	upside-down Thwaitgold grasshopper statuette	0		
-5223	Tome of Clip Art	0		Free Pull, Skill: "Summon Clip Art", Last Available: "2011-09"
+5223	Tome of Clip Art	0		Free Pull, Last Available: "2011-09", Skill: "Summon Clip Art"
 5224	moldy jumbo Ur-Donut	5	crappy	Last Available: "2011-09"
 5225	The Bomb	0		Last Available: "2011-09"
 5226	box of Familiar Jacks	0		Last Available: "2011-09"
@@ -5140,7 +5140,7 @@
 5237	olive weightlifter's time halo	0		Muscle: +15, Class: "Unarmed&nbsp;Characters", Single Equip, Last Available: "2011-09"
 5238	hand-crafted practically non-alcoholic Lumineux Limnio	1	EPIC	Last Available: "2011-09"
 5239	mediocre triple-distilled Morto Moreto	7	decent	Last Available: "2011-09"
-5240	enchanted triple-distilled perfectly mixed Temps Tempranillo	9	EPIC	Last Available: "2011-09"
+5240	triple-distilled enchanted perfectly mixed Temps Tempranillo	9	EPIC	Last Available: "2011-09"
 5241	smooth triple-distilled Bordeaux Marteaux	7	awesome	Last Available: "2011-09"
 5242	smooth spinning Fromage Pinotage	3	awesome	Last Available: "2011-09"
 5243	smooth Beignet Milgranet	3	awesome	Last Available: "2011-09"
@@ -5154,14 +5154,14 @@
 5251	normal snack-sized shaking forbidden danish	2	good	Last Available: "2011-09"
 5252	diet delicious cool cat claw	1	awesome	Last Available: "2011-09"
 5253	bland blunt cat claw	3	decent	Last Available: "2011-09"
-5254	spoiled jumbo bouncing shadowy cat claw	5	crappy	Last Available: "2011-09"
+5254	jumbo spoiled bouncing shadowy cat claw	5	crappy	Last Available: "2011-09"
 5255	spoiled pulsating cheezburger	4	crappy	Last Available: "2011-09"
 5256	snack-sized decent toasted brie	2	good	Last Available: "2011-09"
 5257	corrupted pickled lime green potion of the field gar	0		Effect: "Hella Smooth", Effect Duration: 16, Last Available: "2011-09"
 5258	polymerized too legit potion	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 37, Last Available: "2011-09"
 5259	vacuum-sealed twirling Bright Water	0		Effect: "Stop the Presses!", Effect Duration: 18, Last Available: "2011-09"
 5260	ionized cold-filtered water	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 63, Last Available: "2011-09"
-5261	quadruple-activated flattened gray tumbling graveyard snowglobe	0		Effect: "Outer Wolf&trade;", Effect Duration: 23, Last Available: "2011-09"
+5261	quadruple-activated flattened tumbling gray graveyard snowglobe	0		Effect: "Outer Wolf&trade;", Effect Duration: 23, Last Available: "2011-09"
 5262	galvanized ghostly cool cat elixir	0		Effect: "Helvella Health", Effect Duration: 30, Last Available: "2011-09"
 5263	diffused extra-colloidal potion of the captain's hammer	0		Effect: "Ermine Eyes", Effect Duration: 26, Last Available: "2011-09"
 5264	aerosolized electrified potion of X-ray vision	0		Effect: "The Halls of Mysticality", Effect Duration: 46, Last Available: "2011-09"
@@ -5184,7 +5184,7 @@
 5281	tumbling skewed cyan toasty broken clock	0		Hot Damage: +5, Last Available: "2011-09"
 5282	beefcake's dethklok	0		Muscle: +25, Last Available: "2011-09"
 5283	squat huge Annie Oakley's glacial clock	0		Critical Hit Percent: +20, Last Available: "2011-09"
-5284	Gygaxian Libram	0		Skill: "Summon Dice", Last Available: "2011-09"
+5284	Gygaxian Libram	0		Last Available: "2011-09", Skill: "Summon Dice"
 5285	d4	0		Last Available: "2011-09"
 5286	d6	0		Last Available: "2011-09"
 5287	d8	0		Last Available: "2011-09"
@@ -5223,23 +5223,23 @@
 5320	wet Lobos Mints	0		Effect: "Cringle's Curative Carol", Effect Duration: 34, Last Available: "2011-10"
 5321	altered huge Sweet Sword	0		Effect: "Sneaky Serpentine Subtlety", Effect Duration: 44, Last Available: "2011-10"
 5322	delicious watered-down Ecto-Cooler	2	awesome	Last Available: "2011-10"
-5323	weak hand-crafted Bartles and BRAAAINS wine cooler	2	EPIC	Last Available: "2011-10"
+5323	hand-crafted weak Bartles and BRAAAINS wine cooler	2	EPIC	Last Available: "2011-10"
 5324	delicious weak Blood Light	2	awesome	Last Available: "2011-10"
 5325	artisanal olive Silver Bullet beer	4	EPIC	Last Available: "2011-10"
 5326	perfectly mixed Bone's Farm &quot;wine&quot;	3	EPIC	Last Available: "2011-10"
-5327	tumbling blurry ghost protocol	0		Last Available: "2011-10"
+5327	blurry tumbling ghost protocol	0		Last Available: "2011-10"
 5328	dry narrow blurry sorority brain	0		Effect: "Cool, Catlike", Effect Duration: 14, Last Available: "2011-10"
 5329	irradiated ionized purple Nightstalker perfume	0		Effect: "Cockroach Scurry", Effect Duration: 21, Last Available: "2011-10"
 5330	liquefied drum of pomade	0		Effect: "Sticky Hands", Effect Duration: 69, Last Available: "2011-10"
 5331	throwing bone	0		Last Available: "2011-10"
 5332	mirror reassuring extra-see-thru nightie	0		Spooky Resistance: +1, Last Available: "2011-10"
-5333	lard-coated coward's BRAINS shorts	0		Monster Level: -20, Sleaze Spell Damage: +25, Familiar Effect: "sleaze atk, 1.5xGhuol", Last Available: "2011-10"
+5333	lard-coated coward's BRAINS shorts	0		Monster Level: -20, Sleaze Spell Damage: +25, Last Available: "2011-10", Familiar Effect: "sleaze atk, 1.5xGhuol"
 5334	fireproof Mesmereyes&trade; contact lenses	0		Hot Resistance: +3, Single Equip, Last Available: "2011-10"
 5335	tumbling pulsating scorching scrunchie	0		Hot Damage: +25, Single Equip, Last Available: "2011-10"
-5336	jittery dangerous extremely skinny jeans of the sweet-tooth	0		Weapon Damage: +10, Candy Drop: +100, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2011-10"
-5337	weightlifter's The Necbromancer's Hat of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50, Familiar Effect: "1xVolley, 1xBarrr", Last Available: "2011-10"
+5336	jittery dangerous extremely skinny jeans of the sweet-tooth	0		Weapon Damage: +10, Candy Drop: +100, Last Available: "2011-10", Familiar Effect: "1xPotato, 1xFairy"
+5337	weightlifter's The Necbromancer's Hat of vim and vigor	0		Muscle: +15, Maximum HP Percent: +50, Last Available: "2011-10", Familiar Effect: "1xVolley, 1xBarrr"
 5338	jittery greasy Jack Frost's veiny The Necbromancer's Stein	0		Maximum HP: +10, Cold Spell Damage: +50, Sleaze Spell Damage: +10, Last Available: "2011-10"
-5339	wobbly ribald nasty The Necbromancer's Shorts of temperance	0		Stench Damage: +5, Sleaze Damage: +10, Sleaze Resistance: +5, Familiar Effect: "atk, 2xGhuol", Last Available: "2011-10"
+5339	wobbly ribald nasty The Necbromancer's Shorts of temperance	0		Stench Damage: +5, Sleaze Damage: +10, Sleaze Resistance: +5, Last Available: "2011-10", Familiar Effect: "atk, 2xGhuol"
 5340	upside-down lion tamer's rosy-cheeked The Necbromancer's Wizard Staff of mayonnaise	0		Maximum HP Percent: +30, Experience (familiar): +2, Sleaze Spell Damage: +50, Last Available: "2011-10"
 5341	The Necbronomicon	0		Skill: "Summon &quot;Boner Battalion&quot;", Last Available: "2011-10"
 5342	mediocre The Cooler Out of Space	4	decent	Last Available: "2011-10"
@@ -5252,7 +5252,7 @@
 5349	twirling A Crimbo Carol, Ch. 3 (used)	0		Skill: "Candyblast", Last Available: "2009-12"
 5350	A Crimbo Carol, Ch. 4 (used)	0		Skill: "Surge of Icing", Last Available: "2009-12"
 5351	A Crimbo Carol, Ch. 5 (used)	0		Skill: "Stealth Mistletoe", Last Available: "2009-12"
-5352	lime green narrow A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
+5352	narrow lime green A Crimbo Carol, Ch. 6 (used)	0		Skill: "Cringle's Curative Carol", Last Available: "2009-12"
 5353	jar of oil	0		
 5354	The Art of Slapfighting (used)	0		Class: "Seal Clubber", Skill: "Iron Palm Technique", Last Available: "2010-06"
 5355	fuchsia Uncle Romulus (used)	0		Class: "Turtle Tamer", Skill: "Curiosity of Br'er Tarrypin", Last Available: "2010-03"
@@ -5290,7 +5290,7 @@
 5387	nippy ridiculous earring	0		Cold Damage: +10, Last Available: "2011-11"
 5388	blue electrified ridiculous sunglasses	0		MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11"
 5389	spoiled ridiculous sandwich	4	crappy	Last Available: "2011-11"
-5390	tolerable watered-down ridiculous cocktail	2	good	Last Available: "2011-11"
+5390	watered-down tolerable ridiculous cocktail	2	good	Last Available: "2011-11"
 5391	purple Fonzie's slick zombie monkey necklace	0		Moxie: +10, Experience (Moxie): +1
 5392	Thwaitgold butterfly statuette	0		
 5393	scrap of paper	0		
@@ -5306,13 +5306,13 @@
 5403	Mint Salton Pepper's Peppermint Seed Catalog	0		Last Available: "2011-11"
 5404	Peppermint Pip Packet	0		Last Available: "2011-11"
 5405	coward's forbidden strapping cane-mail shirt	0		Muscle: +5, Spell Damage Percent: +50, Monster Level: -20, Last Available: "2011-12"
-5406	bouncing censurious electrified forbidden cane-mail pants	0		Spell Damage Percent: +50, Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "atk, 2xBarrr, cap 25", Last Available: "2011-12"
+5406	bouncing censurious electrified forbidden cane-mail pants	0		Spell Damage Percent: +50, Sleaze Resistance: +3, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-12", Familiar Effect: "atk, 2xBarrr, cap 25"
 5407	artisanal Vodka Matryoshka	3	EPIC	Last Available: "2011-12"
-5408	delicious enchanted Gin Mint	4	awesome	Effect: "Bone Chilling", Effect Duration: 15, Last Available: "2011-12"
+5408	enchanted delicious Gin Mint	4	awesome	Effect: "Bone Chilling", Effect Duration: 15, Last Available: "2011-12"
 5409	smooth gray Tequiz Navidad	3	awesome	Last Available: "2011-12"
 5410	tolerable blinking Mint Yulep	3	good	Last Available: "2011-12"
-5411	tolerable distilled Crimbojito	5	good	Last Available: "2011-12"
-5412	weak acceptable Sangria de Menthe	2	good	Last Available: "2011-12"
+5411	distilled tolerable Crimbojito	5	good	Last Available: "2011-12"
+5412	acceptable weak Sangria de Menthe	2	good	Last Available: "2011-12"
 5413	upside-down candycaine powder	0		Last Available: "2011-12"
 5414	licorice boa	0		Familiar Weight: +5, Last Available: "2011-12"
 5415	extra-dry boiled licorice root	0		Effect: "Badger Underfoot", Effect Duration: 50, Last Available: "2011-12"
@@ -5327,8 +5327,8 @@
 5424	blurry supercharged kumquartz ring	0		Maximum MP Percent: +30, Single Equip, Last Available: "2011-11"
 5425	rosewater-soaked strawberyl necklace	0		Stench Resistance: +3, Single Equip, Last Available: "2011-11"
 5426	huge wholesome Rosewater's sucker bucket	0		Mysticality Percent: +30, Maximum HP Percent: +10, Last Available: "2011-11"
-5427	frightening sucker hakama	0		Spooky Damage: +5, Familiar Effect: "afk, cap 12", Last Available: "2011-11"
-5428	sucker kabuto of the detective	0		Item Drop: +20, Familiar Effect: "Atk, cap 12", Last Available: "2011-11"
+5427	frightening sucker hakama	0		Spooky Damage: +5, Last Available: "2011-11", Familiar Effect: "afk, cap 12"
+5428	sucker kabuto of the detective	0		Item Drop: +20, Last Available: "2011-11", Familiar Effect: "Atk, cap 12"
 5429	pulsating auspicious sucker tachi	0		Item Drop: +10, Last Available: "2011-11"
 5430	sucker scaffold	0		Last Available: "2011-11"
 5431	cinnamon troll doll	0		Last Available: "2011-11"
@@ -5340,7 +5340,7 @@
 5437	skewed superheated fudge	0		Last Available: "2011-11"
 5438	liquefied quadruple-diffused fluid of fudge-finding	0		Effect: "Boo Tea", Effect Duration: 36, Last Available: "2011-11"
 5439	fudgepuck	0		Last Available: "2011-11"
-5440	spoiled half-sized fancy fuchsia fudgesicle	2	crappy	Effect: "Coated Arms", Effect Duration: 45, Last Available: "2011-11"
+5440	half-sized fancy spoiled fuchsia fudgesicle	2	crappy	Effect: "Coated Arms", Effect Duration: 45, Last Available: "2011-11"
 5441	wand of fudge control	0		Last Available: "2011-11"
 5442	The Kloop in the Coop	0		Free Pull, Last Available: "2012-12"
 5443	miniscule beatbox	0		Familiar Weight: +5, Last Available: "2012-12"
@@ -5363,7 +5363,7 @@
 5460	tumbling pulsating bouncing resourceful educational smartaleck's fudgecycle	0		Moxie Percent: +30, Experience: +1, Maximum MP: +50, Single Equip, Last Available: "2011-11"
 5461	fudge cube	0		Last Available: "2011-11"
 5462	shaking blank fudge mold	0		Last Available: "2011-11"
-5463	Libram of Resolutions	0		Free Pull, Skill: "Summon Resolutions", Last Available: "2012-01"
+5463	Libram of Resolutions	0		Free Pull, Last Available: "2012-01", Skill: "Summon Resolutions"
 5464	wet quantum resolution: be wealthier	0		Effect: "Mmmmmelon", Effect Duration: 60, Last Available: "2012-01"
 5465	flattened triple-improved resolution: be happier	0		Effect: "Robocamo", Effect Duration: 68, Last Available: "2012-01"
 5466	chilled resolution: be stronger	0		Effect: "Berry Critical", Effect Duration: 21, Last Available: "2012-01"
@@ -5379,10 +5379,10 @@
 5476	pressed deionized blue tumbling gummi salamander	0		Effect: "Hombre Muerto Caminando", Effect Duration: 13, Last Available: "2011-11"
 5477	nitrogenated nitrogenated teal gummi snake	0		Effect: "Magically Delicious", Effect Duration: 13, Last Available: "2011-11"
 5478	flattened gummi canary	0		Effect: "Good Karma", Effect Duration: 40, Last Available: "2011-11"
-5479	stale half-sized huge gummi bear	2	decent	Last Available: "2011-11"
-5480	tasty low-calorie gray shaking blinking gummi bear	1	awesome	Last Available: "2011-11"
+5479	half-sized stale huge gummi bear	2	decent	Last Available: "2011-11"
+5480	low-calorie tasty shaking blinking gray gummi bear	1	awesome	Last Available: "2011-11"
 5481	flavorless gummi bear	3	decent	Last Available: "2011-11"
-5482	adequate small upside-down drunki-bear	2	good	Last Available: "2011-11"
+5482	small adequate upside-down drunki-bear	2	good	Last Available: "2011-11"
 5483	small decent shaking drunki-bear	2	good	Last Available: "2011-11"
 5484	toothsome tumbling drunki-bear	3	awesome	Last Available: "2011-11"
 5485	bouncing twirling Oprah's gummi bowtie	0		Maximum MP Percent: +50, Last Available: "2011-11"
@@ -5399,11 +5399,11 @@
 5496	warmed liquefied gummi belemnite	0		Effect: "Stogied", Effect Duration: 60, Last Available: "2011-11"
 5497	all-year sucker	0		Last Available: "2011-11"
 5498	twirling heart of dark chocolate	0		Last Available: "2011-11"
-5499	lime green electrified sage Big Candy's tophat	0		Mysticality Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xGhoul, 1xFairy, cap 25", Last Available: "2011-11"
+5499	lime green electrified sage Big Candy's tophat	0		Mysticality Percent: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2011-11", Familiar Effect: "1xGhoul, 1xFairy, cap 25"
 5500	huge Fuzzby	0		Free Pull, Last Available: "2011-11"
 5501	Jackass Plumber home game	0		Last Available: "2011-11"
 5502	upside-down Trivial Avocations board game	0		Last Available: "2011-11"
-5503	narrow spinning Tickle-Me Emilio	0		Last Available: "2011-11"
+5503	spinning narrow Tickle-Me Emilio	0		Last Available: "2011-11"
 5504	blessed box	0		
 5505	tumbling fuchsia pack of pogs	0		Last Available: "2011-11"
 5506	rotten jerky coins	4	crappy	Last Available: "2011-11"
@@ -5429,9 +5429,9 @@
 5526	triple-denatured Atomic Pop	0		Effect: "Big Meat Big Prizes", Effect Duration: 27, Last Available: "2020-09"
 5527	spinning do-rag	0		Familiar Weight: +5, Last Available: "2011-11"
 5528	whimpering willow bark	0		Last Available: "2012-12"
-5529	massive yummy olive berries of suffering	9	awesome	Last Available: "2012-12"
+5529	yummy massive olive berries of suffering	9	awesome	Last Available: "2012-12"
 5530	energized baobab sap	0		Effect: "Cletus's Canticle of Celerity", Effect Duration: 54, Last Available: "2012-12"
-5531	twirling gray cup of hickory chicory	0		Last Available: "2012-12"
+5531	gray twirling cup of hickory chicory	0		Last Available: "2012-12"
 5532	magnolia blossom	0		Last Available: "2012-12"
 5533	anodized triple-ionized twirling Mortimer's nostrum	0		Effect: "Demonic Flavor", Effect Duration: 38, Last Available: "2012-12"
 5534	artisanal wobbly Barulio's bottle	4	EPIC	Last Available: "2012-12"
@@ -5459,7 +5459,7 @@
 5556	boxer's weightlifter's Rain-Doh wings	0		Muscle: +15, Muscle Percent: +10, Softcore Only, Last Available: "2012-02"
 5557	blue Rain-Doh agent	0		Last Available: "2012-02"
 5558	coward's Rain-Doh laser gun of Flo-Jo	0		Monster Level: -20, Initiative: +100, Softcore Only, Last Available: "2012-02"
-5559	Rain-Doh lantern of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Softcore Only, Lantern Element: "Stench", Last Available: "2012-02"
+5559	Rain-Doh lantern of Leguizamo of the detective	0		Monster Level: +20, Item Drop: +20, Softcore Only, Last Available: "2012-02", Lantern Element: "Stench"
 5560	Rain-Doh balls	0		Last Available: "2012-02"
 5561	Rain-Doh indigo cup	0		Last Available: "2012-02"
 5562	squat horrifying savvy Rain-Doh violet bo	0		Mysticality Percent: +20, Spooky Damage: +25, Softcore Only, Last Available: "2012-02"
@@ -5467,31 +5467,31 @@
 5564	bouncing lime green Rain-Doh box full of monster	0		Last Available: "2012-02"
 5565	flavorless PB&BP	3	decent	
 5566	toothsome shaking club sandwich	3	awesome	
-5567	half-sized bland corned-beef Reuben	2	decent	
+5567	bland half-sized corned-beef Reuben	2	decent	
 5568	frayed ninja rope	0		
 5569	dull ninja crampons	0		
 5570	loose ninja carabiner	0		
 5571	wobbly Groar's fur	0		
 5572	purple bouncing Thwaitgold stag beetle statuette	0		
-5573	weak delicious pulsating Drac & Tan	2	awesome	Last Available: "2012-03"
+5573	delicious weak pulsating Drac & Tan	2	awesome	Last Available: "2012-03"
 5574	perfectly mixed upside-down Transylvania Sling	3	EPIC	Last Available: "2012-03"
-5575	acceptable distilled Shot of the Living Dead	5	good	Last Available: "2012-03"
-5576	tolerable distilled tumbling Buttery Knob	5	good	Last Available: "2012-03"
+5575	distilled acceptable Shot of the Living Dead	5	good	Last Available: "2012-03"
+5576	distilled tolerable tumbling Buttery Knob	5	good	Last Available: "2012-03"
 5577	mediocre Slippery Knob	4	decent	Last Available: "2012-03"
-5578	artisanal practically non-alcoholic Flaming Knob	1	super ultra EPIC	Last Available: "2012-03"
-5579	perfectly mixed irresponsibly strong Grasshopper	9	EPIC	Last Available: "2012-03"
+5578	practically non-alcoholic artisanal Flaming Knob	1	super ultra EPIC	Last Available: "2012-03"
+5579	irresponsibly strong perfectly mixed Grasshopper	9	EPIC	Last Available: "2012-03"
 5580	smooth ghostly Locust	3	awesome	Last Available: "2012-03"
 5581	mediocre upside-down Plague of Locusts	3	decent	Last Available: "2012-03"
 5582	delicious Red Dwarf	4	awesome	Last Available: "2012-03"
-5583	watered-down perfectly mixed fuchsia Golden Mean	2	EPIC	Last Available: "2012-03"
+5583	perfectly mixed watered-down fuchsia Golden Mean	2	EPIC	Last Available: "2012-03"
 5584	tolerable blurry Green Giant	4	good	Last Available: "2012-03"
 5585	practically non-alcoholic tolerable Aye Aye	1	good	Last Available: "2012-03"
 5586	boozy artisanal Aye Aye, Captain	5	EPIC	Last Available: "2012-03"
 5587	delicious Aye Aye, Tooth Tooth	3	awesome	Last Available: "2012-03"
-5588	aged watered-down Humanitini	2	awesome	Last Available: "2012-03"
+5588	watered-down aged Humanitini	2	awesome	Last Available: "2012-03"
 5589	practically non-alcoholic perfectly mixed tumbling More Humanitini than Humanitini	1	EPIC	Last Available: "2012-03"
 5590	tolerable Oh, the Humanitini	3	good	Last Available: "2012-03"
-5591	bad fancy Great Older Fashioned	4	decent	Effect: "Spiritually Awake", Effect Duration: 35, Last Available: "2012-03"
+5591	fancy bad Great Older Fashioned	4	decent	Effect: "Spiritually Awake", Effect Duration: 35, Last Available: "2012-03"
 5592	artisanal Fuzzy Tentacle	3	EPIC	Last Available: "2012-03"
 5593	enchanted mediocre weak blinking Crazymaker	2	decent	Effect: "Spooky Hands", Effect Duration: 50, Last Available: "2012-03"
 5594	lousy Zoodriver	3	decent	Last Available: "2012-03"
@@ -5501,39 +5501,39 @@
 5598	aged triple-distilled Suppurating Sinner	10	awesome	Last Available: "2012-03"
 5599	weak aged Sizzling Sinner	2	awesome	Last Available: "2012-03"
 5600	hand-crafted Firewater	3	EPIC	Last Available: "2012-03"
-5601	perfectly mixed practically non-alcoholic ghostly shaking Earth and Firewater	1	EPIC	Last Available: "2012-03"
+5601	perfectly mixed practically non-alcoholic shaking ghostly Earth and Firewater	1	EPIC	Last Available: "2012-03"
 5602	practically non-alcoholic aged blinking lime green Earth, Wind and Firewater	1	awesome	Last Available: "2012-03"
 5603	artisanal skewed Slimosa	3	EPIC	Last Available: "2012-03"
-5604	watered-down mediocre Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
+5604	mediocre watered-down Extra-slimy Slimosa	2	decent	Last Available: "2012-03"
 5605	drinkable Slimebite	4	good	Last Available: "2012-03"
-5606	practically non-alcoholic bad Cement Mixer	1	decent	Last Available: "2012-03"
+5606	bad practically non-alcoholic Cement Mixer	1	decent	Last Available: "2012-03"
 5607	lousy huge Jackhammer	4	decent	Last Available: "2012-03"
-5608	bad watered-down enchanted Dump Truck	2	decent	Effect: "The Sweats", Effect Duration: 5, Last Available: "2012-03"
+5608	bad enchanted watered-down Dump Truck	2	decent	Effect: "The Sweats", Effect Duration: 5, Last Available: "2012-03"
 5609	watered-down delicious squat Fauna Libre	2	awesome	Last Available: "2012-03"
 5610	artisanal Chakra Libre	4	EPIC	Last Available: "2012-03"
 5611	perfectly mixed wobbly Aura Libre	3	EPIC	Last Available: "2012-03"
-5612	boozy acceptable Sazerorc	5	good	Last Available: "2012-03"
+5612	acceptable boozy Sazerorc	5	good	Last Available: "2012-03"
 5613	enchanted hand-crafted Sazuruk-hai	3	EPIC	Effect: "Bats in the Belfry", Effect Duration: 45, Last Available: "2012-03"
 5614	artisanal weak Flaming Sazerorc	2	EPIC	Last Available: "2012-03"
-5615	delicious watered-down shaking Green Velvet	2	awesome	Last Available: "2012-03"
-5616	fortified lousy enchanted Green Muslin	5	decent	Effect: "Liquidy Smoky", Effect Duration: 30, Last Available: "2012-03"
-5617	strong mediocre Green Burlap	5	decent	Last Available: "2012-03"
+5615	watered-down delicious shaking Green Velvet	2	awesome	Last Available: "2012-03"
+5616	enchanted lousy fortified Green Muslin	5	decent	Effect: "Liquidy Smoky", Effect Duration: 30, Last Available: "2012-03"
+5617	mediocre strong Green Burlap	5	decent	Last Available: "2012-03"
 5618	artisanal Mohobo	3	EPIC	Last Available: "2012-03"
-5619	hand-crafted strong Moonshine Mohobo	5	EPIC	Last Available: "2012-03"
-5620	acceptable weak shaking Flaming Mohobo	2	good	Last Available: "2012-03"
-5621	watered-down perfectly mixed Drunken Philosopher	2	EPIC	Last Available: "2012-03"
-5622	weak acceptable squat Drunken Neurologist	2	good	Last Available: "2012-03"
+5619	strong hand-crafted Moonshine Mohobo	5	EPIC	Last Available: "2012-03"
+5620	weak acceptable shaking Flaming Mohobo	2	good	Last Available: "2012-03"
+5621	perfectly mixed watered-down Drunken Philosopher	2	EPIC	Last Available: "2012-03"
+5622	acceptable weak squat Drunken Neurologist	2	good	Last Available: "2012-03"
 5623	drinkable squat Drunken Astrophysicist	3	good	Last Available: "2012-03"
 5624	drinkable Dark & Starry	3	good	Last Available: "2012-03"
-5625	enchanted acceptable practically non-alcoholic mirror Black Hole	1	good	Effect: "Sparkling Consciousness", Effect Duration: 45, Last Available: "2012-03"
-5626	weak artisanal Event Horizon	2	EPIC	Last Available: "2012-03"
+5625	acceptable practically non-alcoholic enchanted mirror Black Hole	1	good	Effect: "Sparkling Consciousness", Effect Duration: 45, Last Available: "2012-03"
+5626	artisanal weak Event Horizon	2	EPIC	Last Available: "2012-03"
 5627	tolerable practically non-alcoholic Herring Daiquiri	1	good	Last Available: "2012-03"
 5628	artisanal distilled maroon Herring Wallbanger	5	EPIC	Last Available: "2012-03"
-5629	drinkable practically non-alcoholic Herringtini	1	good	Last Available: "2012-03"
+5629	practically non-alcoholic drinkable Herringtini	1	good	Last Available: "2012-03"
 5630	acceptable fortified wobbly cyan Lollipop Drop	5	good	Last Available: "2012-03"
 5631	aged Candy Alexander	4	awesome	Last Available: "2012-03"
 5632	perfectly mixed upside-down Candicaine	3	EPIC	Last Available: "2012-03"
-5633	boozy tolerable Caipiranha	5	good	Last Available: "2012-03"
+5633	tolerable boozy Caipiranha	5	good	Last Available: "2012-03"
 5634	hand-crafted practically non-alcoholic Flying Caipiranha	1	EPIC	Last Available: "2012-03"
 5635	delicious jittery tumbling Flaming Caipiranha	3	awesome	Last Available: "2012-03"
 5636	drinkable blue Punchplanter	3	good	Last Available: "2012-03"
@@ -5548,9 +5548,9 @@
 5645	the Nostril of the Serpent	0		
 5646	calendar fragment	0		
 5647	Van der Graaf calendar	0		MP Regen Min: 5, MP Regen Max: 7, Damage Reduction: 4
-5648	Oprah's experienced Boris's Helm	0		Experience: +2, Maximum MP Percent: +50, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5648	Oprah's experienced Boris's Helm	0		Experience: +2, Maximum MP Percent: +50, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5649	chilly ruddy staph of homophones	0		Maximum HP Percent: +40, Cold Damage: +5
-5650	narrow wobbly Usain Bolt's horrifying foul-smelling Boris's Helm (askew)	0		Stench Damage: +10, Spooky Damage: +25, Initiative: +80, Softcore Only, Free Pull, Familiar Effect: "atk, MP regen, cap 25", Last Available: "2012-04"
+5650	narrow wobbly Usain Bolt's horrifying foul-smelling Boris's Helm (askew)	0		Stench Damage: +10, Spooky Damage: +25, Initiative: +80, Softcore Only, Free Pull, Last Available: "2012-04", Familiar Effect: "atk, MP regen, cap 25"
 5651	pulsating mime soul fragment	0		Last Available: "2012-04"
 5652	Monster Manuel	0		Free Pull
 5653	olive key-o-tron	0		
@@ -5571,15 +5571,15 @@
 5668	bagged &quot;L&quot;	0		
 5669	club	0		
 5670	decent spinning fettucini &eacute;pines Inconnu	4	good	
-5671	smooth special slap and slap again	3	awesome	Effect: "Rave Nirvana", Effect Duration: 5
+5671	special smooth slap and slap again	3	awesome	Effect: "Rave Nirvana", Effect Duration: 5
 5672	gunpowder burrito	2	good	
 5673	beery blood	2	good	
 5674	&quot;L&quot;	0		
 5675	compressed purple watered-down Red Minotaur	1		Effect: "Buggy Flavor", Effect Duration: 45
 5676	pool torpedo	0		Last Available: "2012-05"
-5677	inspector's Ze&trade; goggles	0		Item Drop: +15, Familiar Effect: "Atk, cap 7", Last Available: "2012-05"
+5677	inspector's Ze&trade; goggles	0		Item Drop: +15, Last Available: "2012-05", Familiar Effect: "Atk, cap 7"
 5678	huge soggy used band-aid	0		Last Available: "2012-05"
-5679	blinking Van der Graaf stylish swimsuit of extreme caution	0		Monster Level: -25, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1xPotato, cap 10", Last Available: "2012-05"
+5679	blinking Van der Graaf stylish swimsuit of extreme caution	0		Monster Level: -25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2012-05", Familiar Effect: "1xPotato, cap 10"
 5680	lost key	0		Last Available: "2012-05"
 5681	yummy P.B.L.T.	3	awesome	
 5682	note from Clancy	0		Skill: "Request Sandwich"
@@ -5587,7 +5587,7 @@
 5684	handful of juicy garbage	0		
 5685	bugbear communicator badge	0		
 5686	quantum nanopolymer spider web	0		
-5687	skewed fuchsia bugbear autopsy tweezers	0		
+5687	fuchsia skewed bugbear autopsy tweezers	0		
 5688	lime green blinking Rosewater's UV monocular	0		Mysticality Percent: +30, Single Equip
 5689	drone self-destruct chip	0		
 5690	Jeff Goldblum larva	0		
@@ -5599,17 +5599,17 @@
 5696	bugbear purification pill	0		
 5697	1 Meat	0		
 5698	wobbly Fonzie's The Lost Glasses of the cougar	0		Moxie: +20, Experience (Moxie): +1, Single Equip
-5699	blue shaking twirling The Lost Pill Bottle	0		Last Available: "2012-05"
+5699	shaking blue twirling The Lost Pill Bottle	0		Last Available: "2012-05"
 5700	The Lost Comb	0		
 5701	skewed Moping Artistic Goth Kid	0		Free Pull, Last Available: "2012-06"
 5702	mannequin	0		Familiar Weight: +5
 5703	pulsating crayon shavings	0		Last Available: "2012-06"
 5704	wax bugbear	0		Last Available: "2012-06"
-5705	pulsating flame-retardant Herculean wax hat	0		Experience (Muscle): +1, Hot Resistance: +1, Familiar Effect: "1xPotato, 1xFairy", Last Available: "2012-06"
-5706	lime green upside-down Annie Oakley's personal trainer's wax pants	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Familiar Effect: "atk, 3xBarrr, cap 12", Last Available: "2012-06"
+5705	pulsating flame-retardant Herculean wax hat	0		Experience (Muscle): +1, Hot Resistance: +1, Last Available: "2012-06", Familiar Effect: "1xPotato, 1xFairy"
+5706	lime green upside-down Annie Oakley's personal trainer's wax pants	0		Experience Percent (Muscle): +10, Critical Hit Percent: +20, Last Available: "2012-06", Familiar Effect: "atk, 3xBarrr, cap 12"
 5707	FDKOL commendation	0		Last Available: "2012-07"
 5708	pressed aerosolized drop of water-37	0		Effect: "Larger", Effect Duration: 42, Last Available: "2012-07"
-5709	mansplainer's fireman's helmet of the boozehound	0		Monster Level: +15, Booze Drop: +100, Familiar Effect: "cold atk", Last Available: "2012-07"
+5709	mansplainer's fireman's helmet of the boozehound	0		Monster Level: +15, Booze Drop: +100, Last Available: "2012-07", Familiar Effect: "cold atk"
 5712	Socratic fire axe	0		Experience (Mysticality): +1, Last Available: "2012-07"
 5713	careful thinker's beefcake's fire extinguisher	0		Muscle: +25, Mysticality: +10, Monster Level: -10, Last Available: "2012-07"
 5714	FDKOL tattoo	0		
@@ -5621,18 +5621,18 @@
 5720	half-sized delicious blue fiery wing	2	awesome	Last Available: "2012-07"
 5721	skewed skewed electrified wings of fire of dire peril	0		Weapon Damage: +20, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2012-07"
 5722	studded FDKOL fire hose	0		Damage Absorption: +80, Last Available: "2012-07"
-5723	triple-corrupted Vulcanized magnetized twirling huge bottle of fire	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 42, Last Available: "2012-07"
-5724	skewed lime green molten brick	0		Last Available: "2012-07"
+5723	triple-corrupted Vulcanized magnetized huge twirling bottle of fire	0		Effect: "Jackasses' Symphony of Destruction", Effect Duration: 42, Last Available: "2012-07"
+5724	lime green skewed molten brick	0		Last Available: "2012-07"
 5725	hot daub	0		Last Available: "2012-07"
-5726	ribald weightlifter's hot daub bun	0		Muscle: +15, Sleaze Damage: +10, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
-5727	boxer's hot daub stand of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Familiar Effect: "hot atk, cap 21", Last Available: "2012-07"
+5726	ribald weightlifter's hot daub bun	0		Muscle: +15, Sleaze Damage: +10, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
+5727	boxer's hot daub stand of James Dean	0		Muscle Percent: +10, Experience (Moxie): +3, Last Available: "2012-07", Familiar Effect: "hot atk, cap 21"
 5728	scorching sizzling foot-long hot daub	0		Hot Damage: 35, Last Available: "2012-07"
 5729	ballpark hot daub	0		Last Available: "2012-07"
 5730	flavorless angst burger	3	decent	
 5731	watered-down drinkable 5-hour acrimony	2	good	
 5732	blank note	0		
 5733	eerily silent box	0		
-5734	normal miniature forbidden sausage	2	good	
+5734	miniature normal forbidden sausage	2	good	
 5735	Lord Flameface's cloak of Tarzan	0		Experience (Muscle): +3, Conditional Skill (Equipped): "Swirl Cloak", Last Available: "2012-07"
 5736	double-polarized Drizzlers&trade; Black Licorice	0		Effect: "Eye of the Seal", Effect Duration: 25
 5737	non-energized concentrated blue daub-breaker	0		Effect: "Je Ne Sais Porquoise", Effect Duration: 46, Last Available: "2020-09"
@@ -5644,7 +5644,7 @@
 5743	boozy lousy CSA scoutmaster's &quot;water&quot;	5	decent	Last Available: "2012-07"
 5744	yummy small bag of GORF	2	awesome	Last Available: "2012-07"
 5745	huge mirror CSA discount card	0		Last Available: "2020-09"
-5746	rotten yellow blinking bag of QWOP	3	crappy	Last Available: "2012-07"
+5746	rotten blinking yellow bag of QWOP	3	crappy	Last Available: "2012-07"
 5747	enhanced CSA bravery badge	0		Effect: "Vitamin-Maxed", Effect Duration: 46, Last Available: "2012-07"
 5748	huge CSA all-purpose soap	0		Last Available: "2012-07"
 5749	aged CSA cheerfulness ration	3	awesome	Last Available: "2012-07"
@@ -5654,7 +5654,7 @@
 5753	small flavorless decent brain	2	decent	
 5754	moldy fancy good brain	4	crappy	Effect: "Egg-headedness", Effect Duration: 35
 5755	tiny bland blurry boss brain	1	decent	
-5756	stale massive blinking hunter brain	10	decent	
+5756	massive stale blinking hunter brain	10	decent	
 5758	censurious nasty Staff of Holiday Sensations of the pedagogue	0		Experience: +3, Stench Damage: +5, Sleaze Resistance: +3, Last Available: "2011-11"
 5759	flame-wreathed Da Vinci's staff	0		Experience (Mysticality): +5, Hot Spell Damage: +10
 5760	Sherlock's Rosewater's staff of the sweet-tooth	0		Mysticality Percent: +30, Item Drop: +25, Candy Drop: +100
@@ -5665,11 +5665,11 @@
 5765	bouncing greedy inspector's fuzzy earmuffs	0		Item Drop: +15, Meat Drop: +20, Familiar Effect: "1.5xVolley, cap 32"
 5766	shaking auspicious Tesla quilted fuzzy montera	0		Damage Absorption: +40, Item Drop: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "1.5xVolley, cap 32"
 5767	skewed Unagnimated Gnome	0		Free Pull, Last Available: "2012-08"
-5768	gnomish swimmer's ears	0		Familiar Effect: "underwater", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5769	gnomish coal miner's lung	0		Familiar Effect: "block", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5770	upside-down gnomish tennis elbow	0		Familiar Effect: "damage", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5771	gnomish housemaid's kgnee	0		Familiar Effect: "gain advs", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
-5772	wobbly gnomish athlete's foot	0		Familiar Effect: "delevel", Equips On: "Reagnimated Gnome", Last Available: "2012-08"
+5768	gnomish swimmer's ears	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "underwater"
+5769	gnomish coal miner's lung	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "block"
+5770	upside-down gnomish tennis elbow	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "damage"
+5771	gnomish housemaid's kgnee	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "gain advs"
+5772	wobbly gnomish athlete's foot	0		Last Available: "2012-08", Equips On: "Reagnimated Gnome", Familiar Effect: "delevel"
 5773	squat Thwaitgold maggot statuette	0		
 5774	talkative skull	0		
 5775	fronts	0		Familiar Weight: +5
@@ -5677,7 +5677,7 @@
 5778	decent bouncing idiot brain	4	good	
 5779	cyan keel-haulin' knife of Flo-Jo	0		Initiative: +100
 5780	Samson's ice cream scoop	0		Experience (Muscle): +5
-5781	smooth watered-down soft echo eyedrop antidote martini	2	awesome	
+5781	watered-down smooth soft echo eyedrop antidote martini	2	awesome	
 5782	yellow morningwood plank	0		
 5783	raging hardwood plank	0		
 5784	weirdwood plank	0		
@@ -5691,16 +5691,16 @@
 5792	family-friendly ruddy left bear arm of the overflowing toilet	0		Maximum HP Percent: +40, Stench Spell Damage: +50, Sleaze Resistance: +1, Softcore Only, Conditional Skill (Equipped): "Bear-Backrub", Conditional Skill (Equipped): "Bear-ly Legal", Last Available: "2012-09"
 5793	wobbly MacGyver's Hat O' Nine Tails	0		Maximum MP: +100
 5794	wet upside-down Enchanted Plunger	0		Effect: "Also Schmeckt Zarathustra", Effect Duration: 49
-5795	chilled bouncing blue Enchanted Flyswatter	0		Effect: "There Is A Spoon", Effect Duration: 52
-5796	boiled bouncing twirling Gearhead Goo	0		Effect: "Flaming Weapon", Effect Duration: 44
+5795	chilled blue bouncing Enchanted Flyswatter	0		Effect: "There Is A Spoon", Effect Duration: 52
+5796	boiled twirling bouncing Gearhead Goo	0		Effect: "Flaming Weapon", Effect Duration: 44
 5797	corrupted spinning spinning Missing Eye Simulation Device	0		Effect: "Disco Nirvana", Effect Duration: 22
 5798	ionized shaking Gnollish Crossdress	0		Effect: "Chilblains of the Corn", Effect Duration: 67
-5799	ionized blurry bouncing eldritch dough	0		Effect: "Mushroom Samba", Effect Duration: 46
+5799	ionized bouncing blurry eldritch dough	0		Effect: "Mushroom Samba", Effect Duration: 46
 5800	nitrogenated flattened Charity's choker	0		Effect: "Norwhalloped", Effect Duration: 50
 5801	boiled super-deionized Smart Bone Dust	0		Effect: "Slightly Mutated", Effect Duration: 31
 5802	ionized red perpendicular guano	0		Effect: "Slimily Sagacious", Effect Duration: 65
-5803	Vulcanized frozen blurry teal White Chocolate Golem Seeds	0		Effect: "Tingly Elbows", Effect Duration: 41
-5804	quadruple-tarnished huge cyan Shivering Ch&egrave;vre	0		Effect: "Brother Smothers's Blessing", Effect Duration: 48
+5803	Vulcanized frozen teal blurry White Chocolate Golem Seeds	0		Effect: "Tingly Elbows", Effect Duration: 41
+5804	quadruple-tarnished cyan huge Shivering Ch&egrave;vre	0		Effect: "Brother Smothers's Blessing", Effect Duration: 48
 5805	extra-pickled modified frozen red breath mint	0		Effect: "Disco Inferno", Effect Duration: 65
 5806	pickled muesli	0		Effect: "I See Everything Thrice!", Effect Duration: 63
 5807	denatured quantum glass of warm milk	0		Effect: "The Solution", Effect Duration: 25
@@ -5726,7 +5726,7 @@
 5827	unsweetened quantum aerosolized ghostly skeletal banana	0		Effect: "Stickler for Promptness", Effect Duration: 11
 5828	boiled ionized gilt perfume bottle	0		Effect: "Dancing Prowess", Effect Duration: 23
 5829	dry janglin' bones	0		Effect: "Balls of Ectoplasm", Effect Duration: 16
-5830	extra-magnetized skewed spinning pygmy papers	0		Effect: "Pork Power", Effect Duration: 52
+5830	extra-magnetized spinning skewed pygmy papers	0		Effect: "Pork Power", Effect Duration: 52
 5831	electrified liquefied pygmy dart	0		Effect: "Frozen Hands", Effect Duration: 26
 5832	non-energized squat secret mummy herbs and spices	0		Effect: "On Pins and Needles", Effect Duration: 16
 5833	energized maroon brigand brittle	0		Effect: "Heart of Green", Effect Duration: 64
@@ -5739,12 +5739,12 @@
 5840	aerosolized double-activated teal Rogue Windmill Rouge	0		Effect: "Rampage!", Effect Duration: 37
 5841	extra-activated A muse-bouche	0		Effect: "Hippy Flavor", Effect Duration: 53
 5842	quadruple-deionized toothbrush	0		Effect: "Ginger Snapped", Effect Duration: 50
-5843	double-galvanized blinking jittery pirate cream pie	0		Effect: "The Best a Pirate Can Get", Effect Duration: 62
+5843	double-galvanized jittery blinking pirate cream pie	0		Effect: "The Best a Pirate Can Get", Effect Duration: 62
 5844	Vulcanized una poca de gracia	0		Effect: "Phairly Balanced", Effect Duration: 52
 5845	energized deionized wobbly compressed air canister	0		Effect: "Strange Mental Acuity", Effect Duration: 63
 5846	anodized tumbling salt water taffy	0		Effect: "Old School Pompadour", Effect Duration: 32
 5847	ionized cold-filtered unholy water	0		Effect: "Squid Squint", Effect Duration: 18
-5848	non-flattened cyan narrow Bangyomaman battle juice	0		Effect: "Old School Pompadour", Effect Duration: 53
+5848	non-flattened narrow cyan Bangyomaman battle juice	0		Effect: "Old School Pompadour", Effect Duration: 53
 5849	pressed pressed handyman &quot;hand soap&quot;	0		Effect: "Frozen Hands", Effect Duration: 42
 5850	colloidal space marine flash grenade	0		Effect: "Amorphous Cheer", Effect Duration: 40
 5851	cold-filtered wobbly temporary tribal tattoo	0		Effect: "Elemental Flavor", Effect Duration: 55
@@ -5758,17 +5758,17 @@
 5859	extra-dry flattened extra-cold-filtered booby trap	0		Effect: "Spiky Hair", Effect Duration: 56
 5860	deionized blinking Agent Corrigan's cigarette	0		Effect: "Impregnabili Tea", Effect Duration: 27
 5861	liquefied good ash	0		Effect: "Mushroom Magicalness", Effect Duration: 15
-5862	fuchsia pulsating Tome of Rad Libs	0		Free Pull, Skill: "Summon Rad Libs", Last Available: "2012-09"
+5862	fuchsia pulsating Tome of Rad Libs	0		Free Pull, Last Available: "2012-09", Skill: "Summon Rad Libs"
 5863	Rad Lib	0		Last Available: "2012-09"
 5864	blue papier-m&acirc;ch&eacute; glob	0		Last Available: "2012-09"
 5865	irradiated vacuum-sealed Vulcanized jittery papier-mochi	0		Effect: "Strange Mental Acuity", Effect Duration: 16, Last Available: "2012-09"
 5866	warmed triple-diffused flattened twirling papier-m&acirc;chaeranthera	0		Effect: "Berry Elemental", Effect Duration: 54, Last Available: "2012-09"
-5867	chilled tumbling twirling mirror papier-m&acirc;ch&eacute; toothpicks	0		Effect: "A View to Some Meat", Effect Duration: 34, Last Available: "2012-09"
+5867	chilled twirling mirror tumbling papier-m&acirc;ch&eacute; toothpicks	0		Effect: "A View to Some Meat", Effect Duration: 34, Last Available: "2012-09"
 5868	squat frightening banded papier-m&acirc;ch&eacute;te	0		Damage Absorption: +100, Spooky Damage: +5, Last Available: "2012-09"
 5869	twirling occult papier-m&acirc;chine gun of the storm	0		Spell Damage Percent: +25, Maximum MP Percent: +40, Last Available: "2012-09"
 5870	Sherlock's greasy papier-masque	0		Sleaze Spell Damage: +10, Item Drop: +25, Single Equip, Last Available: "2012-09"
-5871	papier-mitre of the brute of doom	0		Muscle Percent: +30, Spooky Spell Damage: +50, Familiar Effect: "1xVolley, cap 25", Last Available: "2012-09"
-5872	pulsating gray lard-coated papier-m&acirc;churidars of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +25, Familiar Effect: "1xFairy, cap 25", Last Available: "2012-09"
+5871	papier-mitre of the brute of doom	0		Muscle Percent: +30, Spooky Spell Damage: +50, Last Available: "2012-09", Familiar Effect: "1xVolley, cap 25"
+5872	pulsating gray lard-coated papier-m&acirc;churidars of wisdom	0		Mysticality: +15, Sleaze Spell Damage: +25, Last Available: "2012-09", Familiar Effect: "1xFairy, cap 25"
 5873	green papier-m&acirc;ch&eacute; plaque	0		Last Available: "2012-09"
 5874	skewed papier-m&acirc;ch&eacute; handle	0		Last Available: "2012-09"
 5875	pulsating red papier-m&acirc;ch&eacute; base	0		Last Available: "2012-09"
@@ -5779,7 +5779,7 @@
 5880	packet of dragon's teeth	0		Last Available: "2012-10"
 5881	skeleton	0		Last Available: "2012-10"
 5882	coward's electrified supercharged skeleton skis	0		Maximum MP Percent: +30, Monster Level: -20, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2012-10"
-5883	massive decent skeleton quiche	7	good	Last Available: "2012-10"
+5883	decent massive skeleton quiche	7	good	Last Available: "2012-10"
 5884	skeletal scabbard	0		Single Equip, Last Available: "2012-10"
 5885	skeletal skiff	0		Last Available: "2012-10"
 5886	Jack Frost's studded wizardly Bonestabber of wisdom	0		Mysticality: 40, Damage Absorption: +80, Cold Spell Damage: +50, Last Available: "2012-10"
@@ -5823,7 +5823,7 @@
 5925	jittery ChibiBuddy&trade; (off)	0		Last Available: "2012-12"
 5926	jittery BittyCar MeatCar	0		Last Available: "2012-12"
 5927	BittyCar HotCar	0		Last Available: "2012-12"
-5928	brainwave-controlled unicorn horn of James Dean	0		Experience (Moxie): +3, Conditional Skill (Equipped): "Uni-Gore", Familiar Effect: "atk, 5xVolley, cap 2", Last Available: "2012-12"
+5928	brainwave-controlled unicorn horn of James Dean	0		Experience (Moxie): +3, Conditional Skill (Equipped): "Uni-Gore", Last Available: "2012-12", Familiar Effect: "atk, 5xVolley, cap 2"
 5929	bubble-wrap simulator	0		Last Available: "2012-12"
 5930	blind-packed capsule toy	0		Last Available: "2012-12"
 5931	wobbly crafty hale deadly plastic four-shadowed mime	0		Weapon Damage: +5, Maximum HP: +20, Maximum MP: +10, Single Equip, Last Available: "2012-12"
@@ -5858,7 +5858,7 @@
 5960	skewed frosty plastic Father McGruber	0		Cold Spell Damage: +10, Last Available: "2012-12"
 5961	sharpshooter's plastic Hank North, Photojournalist	0		Critical Hit Percent: +10, Last Available: "2012-12"
 5962	plastic blazing bat of the detective	0		Item Drop: +20, Last Available: "2012-12"
-5963	teal supercool electronic dulcimer pants of the brazier	0		Moxie Percent: +20, Hot Spell Damage: +25, Conditional Skill (Equipped): "Play Hog Fiddle", Familiar Effect: "8xPotato, cap 2", Last Available: "2012-12"
+5963	teal supercool electronic dulcimer pants of the brazier	0		Moxie Percent: +20, Hot Spell Damage: +25, Conditional Skill (Equipped): "Play Hog Fiddle", Last Available: "2012-12", Familiar Effect: "8xPotato, cap 2"
 5964	squat A-Boo clue	0		
 5965	lard-coated manspreader's Frown Exerciser	0		Monster Level: +10, Sleaze Spell Damage: +25, Single Equip, Last Available: "2012-12"
 5966	soul monocle	0		Single Equip
@@ -5871,37 +5871,37 @@
 5973	fuchsia skewed record of tranquil silence	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5974	green record of tranquil silence (used)	0		Skill: "Silent Squirt", Last Available: "2012-10"
 5975	record of menacing silence	0		Skill: "Silent Slice", Last Available: "2012-10"
-5976	jittery ghostly record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
+5976	ghostly jittery record of menacing silence (used)	0		Skill: "Silent Slice", Last Available: "2012-10"
 5977	cyan Oprah's hardened Rosewater's silent beret	0		Mysticality Percent: +30, Damage Reduction: 3, Maximum MP Percent: +50, Familiar Effect: "1xVolley, cap 3"
-5978	bite-sized adequate slice of pizza	1	good	Last Available: "2013-02"
+5978	adequate bite-sized slice of pizza	1	good	Last Available: "2013-02"
 5979	huge coin	0		Last Available: "2013-02"
 5980	blue cartoon heart	0		Last Available: "2013-02"
 5981	star	0		Last Available: "2013-02"
 5982	hand-crafted squat tankard of ale	3	EPIC	Last Available: "2013-02"
 5983	vial of holy water	0		Last Available: "2013-02"
-5984	healthy supercool cloth cap of the scaredy-cat	0		Moxie Percent: +20, Maximum HP Percent: +20, Monster Level: -15, Familiar Effect: "atk, 1xVolley, cap 12", Last Available: "2013-02"
+5984	healthy supercool cloth cap of the scaredy-cat	0		Moxie Percent: +20, Maximum HP Percent: +20, Monster Level: -15, Last Available: "2013-02", Familiar Effect: "atk, 1xVolley, cap 12"
 5985	Sinatra's smartaleck's iron dagger of extreme caution	0		Moxie Percent: +30, Experience (Moxie): +5, Monster Level: -25, Last Available: "2013-02"
 5986	rotten hamburger	4	crappy	Last Available: "2013-02"
 5987	blinking dollar-sign bag	0		Last Available: "2013-02"
 5988	narrow potion	0		Last Available: "2013-02"
-5989	teal shaking potion	0		Last Available: "2013-02"
+5989	shaking teal potion	0		Last Available: "2013-02"
 5990	enchanted lousy bottle of wine	4	decent	Effect: "Joy", Effect Duration: 50, Last Available: "2013-02"
 5991	round bomb	0		Last Available: "2013-02"
-5992	squat tumbling dance instructor's iron helmet of the sweet-tooth of the early riser	0		Experience Percent (Moxie): +10, Candy Drop: +100, Adventures: +7, Familiar Effect: "atk, 1xFairy, cap 25", Last Available: "2013-02"
+5992	squat tumbling dance instructor's iron helmet of the sweet-tooth of the early riser	0		Experience Percent (Moxie): +10, Candy Drop: +100, Adventures: +7, Last Available: "2013-02", Familiar Effect: "atk, 1xFairy, cap 25"
 5993	foul-smelling brawny wizardly steel sword	0		Mysticality: +25, Muscle Percent: +20, Stench Damage: +10, Last Available: "2013-02"
-5994	half-sized flavorless whole roasted chicken	2	decent	Last Available: "2013-02"
+5994	flavorless half-sized whole roasted chicken	2	decent	Last Available: "2013-02"
 5995	purple squat massive gemstone	0		Last Available: "2013-02"
 5996	tumbling extra-strength potion	0		Last Available: "2013-02"
 5997	potion	0		Last Available: "2013-02"
 5998	artisanal shining goblet	3	EPIC	Last Available: "2013-02"
 5999	fireball	0		Last Available: "2013-02"
-6000	pulsating scandalous ruddy deadly crown	0		Weapon Damage: +5, Maximum HP Percent: +40, Sleaze Damage: +5, Familiar Effect: "3xGhoul, cap 37", Last Available: "2013-02"
+6000	pulsating scandalous ruddy deadly crown	0		Weapon Damage: +5, Maximum HP Percent: +40, Sleaze Damage: +5, Last Available: "2013-02", Familiar Effect: "3xGhoul, cap 37"
 6001	squat chaotic clever sword of the cheetah	0		Maximum MP: +20, Spell Critical Percent: +10, Initiative: +60, Last Available: "2013-02"
-6002	inspector's clever Helm of the Scream Emperor of the brazier	0		Maximum MP: +20, Hot Spell Damage: +25, Item Drop: +15, Familiar Effect: "spooky atk, 1xFairy, cap 30", Last Available: "2013-02"
+6002	inspector's clever Helm of the Scream Emperor of the brazier	0		Maximum MP: +20, Hot Spell Damage: +25, Item Drop: +15, Last Available: "2013-02", Familiar Effect: "spooky atk, 1xFairy, cap 30"
 6003	executive resourceful savvy Cloak of Dire Shadows	0		Mysticality Percent: +20, Maximum MP: +50, Meat Drop: +40, Last Available: "2013-02"
 6004	skewed purple quilted razor-sharp deadly Sword of Dark Omens	0		Weapon Damage: +5, Weapon Damage Percent: +25, Damage Absorption: +40, Last Available: "2013-02"
 6005	mirror flame-retardant double-paned Jeselnik's Shield of Icy Fate	0		Sleaze Damage: +25, Cold Resistance: +5, Hot Resistance: +1, Damage Reduction: 7, Last Available: "2013-02"
-6006	perfumed sizzling rosy-cheeked Greaves of the Murk Lord	0		Maximum HP Percent: +30, Hot Damage: +10, Stench Resistance: +5, Familiar Effect: "1xBarrr, cap 30", Last Available: "2013-02"
+6006	perfumed sizzling rosy-cheeked Greaves of the Murk Lord	0		Maximum HP Percent: +30, Hot Damage: +10, Stench Resistance: +5, Last Available: "2013-02", Familiar Effect: "1xBarrr, cap 30"
 6007	rock-hard thinker's Gauntlets of the Blood Moon of the businessman	0		Mysticality: +10, Damage Reduction: 5, Meat Drop: +50, Single Equip, Last Available: "2013-02"
 6008	knitted horrifying MacGyver's Boots of Twilight Whispers	0		Maximum MP: +100, Spooky Damage: +25, Cold Resistance: +3, Single Equip, Last Available: "2013-02"
 6009	auspicious supercharged Belt of Howling Anger of dire peril	0		Weapon Damage: +20, Maximum MP Percent: +30, Item Drop: +10, Single Equip, Last Available: "2013-02"
@@ -5913,11 +5913,11 @@
 6015	improved energized orcish hand lotion	0		Effect: "Aries Rising", Effect Duration: 63
 6016	unsweetened orcish rubber	0		Effect: "World's Shortest Giant", Effect Duration: 58
 6017	modified orcish nailing lube	0		Effect: "Seriously Mutated", Effect Duration: 66
-6018	tolerable extra-dry backwoods screwdriver	5	good	
+6018	extra-dry tolerable backwoods screwdriver	5	good	
 6019	spinning Usain Bolt's loadstone	0		Initiative: +80
 6020	Claybender glasses of the ox of the glutton	0		Muscle: +20, Food Drop: +100, Single Equip
 6021	mirror hale Duskwalker fangs of the ox	0		Muscle: +20, Maximum HP: +20
-6022	maroon tumbling Space Tourist Phaser	0		
+6022	tumbling maroon Space Tourist Phaser	0		
 6023	cyan Jack Frost's Whoompa Fur Pants of extreme caution	0		Monster Level: -25, Cold Spell Damage: +50, Familiar Effect: "atk, cap 27"
 6024	tumbling steel-toed Whatsian Ionic Pliers	0		Damage Reduction: 9
 6025	nitrogenated Polysniff Perfume	0		Effect: "Corruption of Wretched Wally", Effect Duration: 53
@@ -5931,7 +5931,7 @@
 6033	Lo Pan's stolen necklace of vim and vigor	0		Maximum HP Percent: +50, Spell Critical Percent: +30
 6034	vibrating troll britches of the brazier	0		Maximum MP Percent: +10, Hot Spell Damage: +25, Familiar Effect: "1.5xPotato, cap 28"
 6035	flattened dry pulsating vial of The Glistening	0		Effect: "Pronounced Potency", Effect Duration: 47
-6036	smooth triple-distilled artisanal limoncello	6	awesome	
+6036	triple-distilled smooth artisanal limoncello	6	awesome	
 6037	ginger ale	0		
 6038	flavorless incredible pizza	4	decent	
 6039	gray inspector's steel-toed oil cap	0		Damage Reduction: 9, Item Drop: +15, Familiar Effect: "cap 28"
@@ -5951,7 +5951,7 @@
 6053	drinkable Taco Dan's Taco Stand Chimichangarita	4	good	Last Available: "2012-12"
 6054	triple-pressed dry twirling Taco Dan's Taco Stand Chillacious Churro	0		Effect: "Deadly Lampblade", Effect Duration: 21, Last Available: "2012-12"
 6055	psychoanalytic jar	0		Last Available: "2013-12"
-6056	The Sword in the Steak	0		Last Available: "2013-12", Wiki Name: "The Sword in the Steak (item)"
+6056	The Sword in the Steak	0		Wiki Name: "The Sword in the Steak (item)", Last Available: "2013-12"
 6057	twirling olive Usain Bolt's crafty Meatcleaver	0		Maximum MP: +10, Initiative: +80, Last Available: "2013-12"
 6058	Crimbo Elf bobble-head of the storm	0		Maximum MP Percent: +40, Last Available: "2012-12"
 6059	fortified Crimbo stogie-scented room odorizer	0		Damage Absorption: +60, Last Available: "2012-12"
@@ -5966,13 +5966,13 @@
 6068	maroon loose blade	0		
 6069	goblin bone hilt	0		
 6070	shaking twirling sword blade	0		
-6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Skill: "Summon Geeky Gifts", Last Available: "2012-12"
+6071	Thinknerd's Grimoire of Geeky Gifts	0		Free Pull, Last Available: "2012-12", Skill: "Summon Geeky Gifts"
 6072	confusing LED clock	0		Last Available: "2012-12"
 6073	extra-polymerized yellow haggis-infused soap	0		Effect: "Souper Vengeful", Effect Duration: 27, Last Available: "2012-12"
 6074	irradiated ionized magicberry tablets	0		Effect: "Okee-Dokee Computer", Effect Duration: 45, Last Available: "2012-12"
 6075	quantum boiled anodized 37x37x37 puzzle cube	0		Effect: "Phoenix, Right?", Effect Duration: 33, Last Available: "2012-12"
-6076	high-proof acceptable McLeod's Hard Haggis-Ade	10	good	Last Available: "2012-12"
-6077	special normal ghostly haggis-wrapped haggis-stuffed haggis	3	good	Effect: "Red Door Syndrome", Effect Duration: 35, Last Available: "2012-12"
+6076	acceptable high-proof McLeod's Hard Haggis-Ade	10	good	Last Available: "2012-12"
+6077	normal special ghostly haggis-wrapped haggis-stuffed haggis	3	good	Effect: "Red Door Syndrome", Effect Duration: 35, Last Available: "2012-12"
 6078	home robotics kit	0		Last Available: "2012-12"
 6079	upside-down school calculator watch	0		Last Available: "2012-12"
 6080	narrow family-friendly haggis socks	0		Sleaze Resistance: +1, Single Equip, Conditional Skill (Equipped): "Haggis Kick", Last Available: "2012-12"
@@ -6016,7 +6016,7 @@
 6118	goggles	0		Last Available: "2013-12"
 6119	mirror abacus	0		Last Available: "2013-12"
 6120	twirling bonsai tree	0		Last Available: "2013-12"
-6121	watered-down perfectly mixed Chinese beer	2	EPIC	Last Available: "2013-12"
+6121	perfectly mixed watered-down Chinese beer	2	EPIC	Last Available: "2013-12"
 6122	cyan cat statue	0		Last Available: "2013-12"
 6123	rhinoceros horn	0		Last Available: "2013-12"
 6124	furry pink pillow	0		Last Available: "2013-12"
@@ -6030,7 +6030,7 @@
 6132	battery	0		Last Available: "2013-12"
 6133	blue White Dragon Fang of James Dean of vim and vigor of the empath	0		Experience (Moxie): +3, Maximum HP Percent: +50, Familiar Weight: +5, Last Available: "2013-12"
 6134	Tesla butterfly knife	0		MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12"
-6135	twirling olive tube of herbal ointment	0		Last Available: "2013-12"
+6135	olive twirling tube of herbal ointment	0		Last Available: "2013-12"
 6136	green pencil kunai	0		Last Available: "2013-12"
 6137	weighted paperclip chain of temperance	0		Sleaze Resistance: +5, Last Available: "2013-12"
 6138	ghostly great capacitor	0		Last Available: "2013-12"
@@ -6040,7 +6040,7 @@
 6142	small delicious jittery teal roasted duck	2	awesome	Last Available: "2013-12"
 6143	bland small dead meat bun	2	decent	Last Available: "2013-12"
 6144	pulsating cat collar of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2013-12"
-6145	suspicious-looking fedora of the wise owl of the sweet-tooth	0		Mysticality: +20, Candy Drop: +100, Familiar Effect: "atk, 1xFairy, cap 15", Last Available: "2013-12"
+6145	suspicious-looking fedora of the wise owl of the sweet-tooth	0		Mysticality: +20, Candy Drop: +100, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 15"
 6147	Bodacious MechaElf Hunter Saga:Relay Wolf	0		Last Available: "2012-12"
 6148	spinning Deactivated MiniMechaElf	0		Last Available: "2012-12"
 6149	MiniMechaElf Laser Punch Missile Launcher	0		Last Available: "2012-12"
@@ -6058,12 +6058,12 @@
 6161	executive regret hose	0		Meat Drop: +40, Conditional Skill (Equipped): "Tear Wave", Last Available: "2013-12"
 6162	Young Man's Crew Sequester	0		Last Available: "2013-12"
 6163	Young Man's Cargo Load	0		Last Available: "2013-12"
-6164	pulsating yellow strapping commodore's hat of dire peril	0		Muscle: +5, Weapon Damage: +20, Familiar Effect: "atk, 1xVolley", Last Available: "2013-12"
-6165	mirror dangerous naval trousers	0		Weapon Damage: +10, Familiar Effect: "sleaze atk, 1xPotato", Last Available: "2013-12"
+6164	pulsating yellow strapping commodore's hat of dire peril	0		Muscle: +5, Weapon Damage: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xVolley"
+6165	mirror dangerous naval trousers	0		Weapon Damage: +10, Last Available: "2013-12", Familiar Effect: "sleaze atk, 1xPotato"
 6166	blurry bouncing forbidden smartaleck's deck cannon	0		Moxie Percent: +30, Spell Damage Percent: +50, Last Available: "2013-12"
 6167	beefcake's ornamental sextant	0		Muscle: +25, Last Available: "2013-12"
 6168	horrifying MacGyver's Bloodbath	0		Maximum MP: +100, Spooky Damage: +25, Last Available: "2013-12"
-6169	enchanted mediocre Hundred Headed IPA	3	decent	Effect: "Bat Attitude", Effect Duration: 35, Last Available: "2013-12"
+6169	mediocre enchanted Hundred Headed IPA	3	decent	Effect: "Bat Attitude", Effect Duration: 35, Last Available: "2013-12"
 6170	moldy chum	4	crappy	Last Available: "2013-12"
 6171	extra-altered magnetized crude crudit&eacute;s	0		Effect: "Mushroom Magicalness", Effect Duration: 19
 6172	vacuum-sealed pressed candy crayons	0		Effect: "Marbles in Your Mouth", Effect Duration: 24, Last Available: "2020-09"
@@ -6080,59 +6080,59 @@
 6183	cosmic fruit	0		
 6184	pulsating twirling family-friendly veiny Jarlsberg's hat of mayonnaise	0		Maximum HP: +10, Sleaze Spell Damage: +50, Sleaze Resistance: +1
 6185	delicious huge consummate hard-boiled egg	4	awesome	
-6186	small adequate consummate fried egg	2	good	
-6187	flavorless small consummate egg salad	2	decent	
+6186	adequate small consummate fried egg	2	good	
+6187	small flavorless consummate egg salad	2	decent	
 6188	stale consummate bagel	3	decent	
 6189	stale consummate sliced bread	4	decent	
 6190	yummy consummate hot dog bun	3	awesome	
 6191	adequate consummate brownie	4	good	
 6192	normal consummate toast	3	good	
-6193	enchanted irresponsibly strong smooth passable stout	8	awesome	Effect: "Amorphous Cheer", Effect Duration: 10
-6194	bite-sized decent purple skewed consummate soup	1	good	
+6193	irresponsibly strong smooth enchanted passable stout	8	awesome	Effect: "Amorphous Cheer", Effect Duration: 10
+6194	decent bite-sized skewed purple consummate soup	1	good	
 6195	rotten consummate corn chips	4	crappy	
 6196	normal consummate salad	4	good	
-6197	snack-sized yummy consummate salsa	2	awesome	
+6197	yummy snack-sized consummate salsa	2	awesome	
 6198	flavorless consummate sauerkraut	3	decent	
 6199	flavorless mirror consummate cheese slice	4	decent	
 6200	tasty purple consummate melted cheese	3	awesome	
-6201	stale enchanted consummate bacon	4	decent	Effect: "You Know Who to Call", Effect Duration: 35
-6202	thick rotten tumbling consummate meatloaf	5	crappy	
+6201	enchanted stale consummate bacon	4	decent	Effect: "You Know Who to Call", Effect Duration: 35
+6202	rotten thick tumbling consummate meatloaf	5	crappy	
 6203	adequate skewed consummate steak	4	good	
 6204	fancy toothsome massive pulsating consummate cuts	8	awesome	Effect: "Booooooze", Effect Duration: 5
-6205	bland massive cyan consummate frankfurter	6	decent	
+6205	massive bland cyan consummate frankfurter	6	decent	
 6206	small rotten pulsating consummate french fries	2	crappy	
 6207	normal consummate baked potato	3	good	
-6208	hand-crafted watered-down bouncing acceptable vodka	2	EPIC	
+6208	watered-down hand-crafted bouncing acceptable vodka	2	EPIC	
 6209	low-calorie adequate consummate ice cream	1	good	
 6210	bland consummate whipped cream	4	decent	
-6211	enchanted rotten miniature tumbling consummate cream	2	crappy	Effect: "Almost Cool", Effect Duration: 40
+6211	miniature enchanted rotten tumbling consummate cream	2	crappy	Effect: "Almost Cool", Effect Duration: 40
 6212	miniature rotten consummate strawberries	2	crappy	
 6213	moldy skewed consummate sorbet	4	crappy	
-6214	weak acceptable adequate rum	2	good	
+6214	acceptable weak adequate rum	2	good	
 6215	drinkable boozy ghostly skewed mediocre lager	5	good	
 6216	normal immaculate grilled cheese	3	good	
 6217	decent immaculate ice cream sandwich	3	good	
-6218	gigantic normal jittery immaculate hot dog	7	good	
-6219	snack-sized normal fuchsia immaculate egg salad sandwich	2	good	
+6218	normal gigantic jittery immaculate hot dog	7	good	
+6219	normal snack-sized fuchsia immaculate egg salad sandwich	2	good	
 6220	rotten low-calorie perfect sandwich	1	crappy	
 6221	rotten perfect chef salad	4	crappy	
-6222	massive decent perfect breakfast	6	good	
-6223	rotten super-sized sublime deluxe hot dog	5	crappy	
+6222	decent massive perfect breakfast	6	good	
+6223	super-sized rotten sublime deluxe hot dog	5	crappy	
 6224	adequate sublime stew	4	good	
-6225	gigantic rotten twirling sublime nachos	10	crappy	
+6225	rotten gigantic twirling sublime nachos	10	crappy	
 6226	moldy Ultimate Breakfast Sandwich	4	crappy	
 6227	adequate low-calorie Loaded Baked Potato	1	good	
 6228	normal lime green Omega Sundae	3	good	
 6229	mediocre triple-distilled Das Sauerlager	7	decent	
 6230	artisanal irresponsibly strong yellow Bologna Lambic	7	EPIC	
-6231	weak drinkable Vodka Dog	2	good	
+6231	drinkable weak Vodka Dog	2	good	
 6232	fancy acceptable cyan Disappointed Russian	4	good	Effect: "Sweet, Nuts", Effect Duration: 25
 6233	hand-crafted Chunky Mary	3	EPIC	
 6234	mediocre jittery Nachojito	3	decent	
-6235	weak tolerable Le Roi	2	good	
-6236	strong tolerable mirror teal Over Easy Rider	5	good	
-6237	maroon shaking cosmic six-pack	0		
-6239	extra-denatured jittery huge cube of ectoplasm	0		Effect: "Sugar, Hello", Effect Duration: 46
+6235	tolerable weak Le Roi	2	good	
+6236	tolerable strong teal mirror Over Easy Rider	5	good	
+6237	shaking maroon cosmic six-pack	0		
+6239	extra-denatured huge jittery cube of ectoplasm	0		Effect: "Sugar, Hello", Effect Duration: 46
 6240	frozen narrow upside-down Illuminati earpiece	0		Effect: "Happy Trails", Effect Duration: 28
 6241	electrified narrow narrow censored can label	0		Effect: "Disco Nirvana", Effect Duration: 53
 6242	moist irradiated blinking ectoplasm <i>au jus</i>	0		Effect: "Frozen Shoulders", Effect Duration: 47
@@ -6166,7 +6166,7 @@
 6270	denatured vacuum-sealed tumbling Squat-Thrust Magazine	0		Effect: "Sparkly!", Effect Duration: 59
 6271	massive dumbbell	0		
 6272	auspicious crafty penguin keychain	0		Maximum MP: +10, Item Drop: +10, Damage Reduction: 10
-6273	concentrated upside-down ghostly O'RLY manual	0		Effect: "Tiki Toughness", Effect Duration: 66
+6273	concentrated ghostly upside-down O'RLY manual	0		Effect: "Tiki Toughness", Effect Duration: 66
 6274	mediocre high-proof open sauce	7	decent	
 6275	lion tamer's Jim Carey's turkey leg	0		Monster Level: +25, Experience (familiar): +2
 6276	delicious tumbling Ye Olde Meade	3	awesome	
@@ -6186,7 +6186,7 @@
 6290	steam-powered model rocketship	0		
 6291	jittery banded thinker's punk rock jacket	0		Mysticality: +10, Damage Absorption: +100
 6292	medical-grade safety pin of doom	0		Spooky Spell Damage: +50, HP Regen Min: 7, HP Regen Max: 10
-6293	moldy half-sized tumbling blurry stolen sushi	2	crappy	
+6293	half-sized moldy tumbling blurry stolen sushi	2	crappy	
 6294	huge very overdue library book	0		
 6295	spinning drum 'n' bass 'n' drum 'n' bass record	0		
 6296	cosmic bucket	0		Free Pull
@@ -6215,7 +6215,7 @@
 6319	electrified squat shavin' razor	0		Effect: "Swimming with Sharks", Effect Duration: 32
 6320	purple healthy long-forgotten necklace	0		Maximum HP Percent: +20
 6321	pearl	0		
-6322	bouncing huge sea lace	0		
+6322	huge bouncing sea lace	0		
 6323	Jeselnik's manspreader's stiffened jam band	0		Damage Reduction: 1, Monster Level: +10, Sleaze Damage: +25
 6324	lightning-fast MacGyver's supercool aquamariner's ring	0		Moxie Percent: +20, Maximum MP: +100, Initiative: +40, Single Equip
 6325	lightning-fast grievous aquamariner's necklace of Leguizamo	0		Weapon Damage Percent: +50, Monster Level: +20, Initiative: +40, Single Equip
@@ -6236,7 +6236,7 @@
 6340	family-friendly frightening floral-print skirt	0		Spooky Damage: +5, Sleaze Resistance: +1, Familiar Effect: "stench atk, 2xPotato, cap 15"
 6341	Tesla spectral axe of the blizzard	0		Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10
 6342	gray rock-hard beefy super-strong air freshener	0		Muscle: +10, Damage Reduction: 5
-6343	corrupted dry tumbling narrow Mer-kin lipstick	0		Effect: "Salt Rockin'", Effect Duration: 59
+6343	corrupted dry narrow tumbling Mer-kin lipstick	0		Effect: "Salt Rockin'", Effect Duration: 59
 6344	Mer-kin mouthsoap	0		
 6345	liquefied dry Mer-kin strongjuice	0		Effect: "Hair on Your Chest", Effect Duration: 15
 6346	skewed Mer-kin fitbrine	0		
@@ -6253,10 +6253,10 @@
 6357	skewed Mer-kin knucklebone	0		
 6358	narrow Mer-kin darkbook	0		Skill: "Deep Dark Visions"
 6359	tumbling flame-wreathed Mer-kin begsign	0		Hot Spell Damage: +10, Meat Drop: +40
-6360	upside-down Libram of Pulled Taffy	0		Free Pull, Skill: "Summon Taffy", Last Available: "2013-04"
+6360	upside-down Libram of Pulled Taffy	0		Free Pull, Last Available: "2013-04", Skill: "Summon Taffy"
 6361	denatured anodized adjusted twirling pulled taffy	0		Effect: "Radium Radicality", Effect Duration: 55, Last Available: "2013-04"
 6362	altered quadruple-colloidal mirror pulled indigo taffy	0		Effect: "Petit Forbearance", Effect Duration: 29, Last Available: "2013-04"
-6363	concentrated magnetized dry spinning bouncing pulled taffy	0		Effect: "Fruited", Effect Duration: 14, Last Available: "2013-04"
+6363	concentrated magnetized dry bouncing spinning pulled taffy	0		Effect: "Fruited", Effect Duration: 14, Last Available: "2013-04"
 6364	oxidized purple pulled taffy	0		Effect: "Cotton Mouthed", Effect Duration: 55, Last Available: "2013-04"
 6365	magnetized pulled taffy	0		Effect: "Ooh, Sour!", Effect Duration: 55, Last Available: "2013-04"
 6366	enhanced green pulled violet taffy	0		Effect: "Pork Power", Effect Duration: 50, Last Available: "2013-04"
@@ -6264,9 +6264,9 @@
 6368	shaking Mer-kin hallpass	0		
 6369	maroon lump of clay	0		
 6370	twisted piece of wire	0		
-6371	special distilled perfectly mixed can of the cheapest beer	5	EPIC	Effect: "Berry Critical", Effect Duration: 10
+6371	distilled special perfectly mixed can of the cheapest beer	5	EPIC	Effect: "Berry Critical", Effect Duration: 10
 6372	tolerable bottle of fruity &quot;wine&quot;	3	good	
-6373	bad practically non-alcoholic single swig of vodka	1	decent	
+6373	practically non-alcoholic bad single swig of vodka	1	decent	
 6374	angry inch	0		
 6375	shaking deadly testy toolbox	0		Weapon Damage: +5
 6376	Jick-o-User	0		
@@ -6308,17 +6308,17 @@
 6413	Order of the Green Thumb Order Form	0		Free Pull
 6414	clutch of dodecapede eggs	0		
 6415	rotten spinning flavorless gruel	4	crappy	
-6416	normal gigantic mana curds	10	good	
+6416	gigantic normal mana curds	10	good	
 6417	pulsating twist of lime	0		
 6418	mirror pencil stub	0		
 6419	galvanized tarnished tumbling moth dust	0		Effect: "Dirty Pear", Effect Duration: 64
 6420	polymerized teal glob of spoiled mayo	0		Effect: "Salamanderenity", Effect Duration: 61
 6421	shaking shaking tonic djinn	0		
-6422	fancy snack-sized spoiled vampire chowder	2	crappy	Effect: "Rad-ish", Effect Duration: 15
+6422	spoiled snack-sized fancy vampire chowder	2	crappy	Effect: "Rad-ish", Effect Duration: 15
 6423	Tales of Dread	0		Free Pull
 6424	Dreadsylvanian skeleton key	0		
 6425	Official Seal of Dreadsylvania	0		
-6426	stale twirling lime green Dreadsylvanian stew	4	decent	
+6426	stale lime green twirling Dreadsylvanian stew	4	decent	
 6427	artisanal fancy spinning Dreadsylvanian	3	EPIC	Effect: "It's Electric!", Effect Duration: 35
 6428	corrupted spinning Dreadsylvanian flask	0		Effect: "Heart Aflame", Effect Duration: 29
 6429	colloidal cold-filtered huge Dreadsylvanian flask	0		Effect: "Saucemastery", Effect Duration: 49
@@ -6329,7 +6329,7 @@
 6434	Mark of the Bugbear	0		
 6435	ghostly Mark of the Werewolf	0		
 6436	ghostly Mark of the Zombie	0		
-6437	purple bouncing squat Mark of the Ghost	0		
+6437	bouncing purple squat Mark of the Ghost	0		
 6438	Mark of the Vampire	0		
 6439	Mark of the Skeleton	0		
 6440	huge gravedigger's foul-smelling Covers-Your-Head of the businessman	0		Stench Damage: +10, Spooky Damage: +10, Meat Drop: +50, Class: "Disco Bandit", Familiar Effect: "atk, 2xVolley"
@@ -6338,13 +6338,13 @@
 6443	yellow blinking up-at-dawn greasy Helps-You-Sleep	0		Sleaze Spell Damage: +10, Adventures: +5, Single Equip
 6444	up-at-dawn veiny boxer's Quiets-Your-Steps	0		Muscle Percent: +10, Maximum HP: +10, Adventures: +5, Single Equip
 6445	cyan Van der Graaf personal trainer's Protects-Your-Junk	0		Experience Percent (Muscle): +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip
-6446	watered-down hand-crafted Gets-You-Drunk	2	EPIC	
+6446	hand-crafted watered-down Gets-You-Drunk	2	EPIC	
 6447	chaotic MacGyver's padded Great Wolf's headband	0		Damage Absorption: +20, Maximum MP: +100, Spell Critical Percent: +10, Class: "Seal Clubber", Familiar Effect: "atk, 1xVolley"
 6448	jittery reassuring therapeutic strapping Great Wolf's left paw	0		Muscle: +5, Spooky Resistance: +1, HP Regen Min: 5, HP Regen Max: 7, Class: "Seal Clubber", Conditional Skill (Equipped): "Great Slash"
 6449	upside-down Usain Bolt's Temple Grandin's experienced Great Wolf's right paw	0		Experience: +2, Familiar Weight: +7, Initiative: +80, Class: "Seal Clubber", Single Equip, Conditional Skill (Equipped): "Great Slash"
 6450	censurious groovy Great Wolf's rocket launcher	0		Moxie Percent: +10, Sleaze Resistance: +3, Single Equip, Conditional Skill (Equipped): "Fire Rocket"
 6451	executive stanky Great Wolf's beastly trousers of the early riser	0		Stench Spell Damage: +25, Meat Drop: +40, Adventures: +7, Familiar Effect: "1xPotato, 1.5xWhelp"
-6452	blinking twirling Great Wolf's lice	0		
+6452	twirling blinking Great Wolf's lice	0		
 6453	wet twirling Hunger&trade; Sauce	0		Effect: "Pyramid Power", Effect Duration: 55
 6454	veiny shellacked zombie mariachi hat of the cheetah	0		Damage Reduction: 7, Maximum HP: +10, Initiative: +60, Class: "Accordion Thief", Familiar Effect: "atk, 1xLep"
 6455	occult Socratic zombie accordion of the pedagogue	0		Experience: +3, Experience (Mysticality): +1, Spell Damage Percent: +25, Class: "Accordion Thief", Single Equip, Song Duration: 20
@@ -6367,7 +6367,7 @@
 6472	Drunkula's bell	0		
 6473	reassuring greasy padded Drunkula's ring of haze	0		Damage Absorption: +20, Sleaze Spell Damage: +10, Spooky Resistance: +1, Avoid Attack: 1, Single Equip
 6474	Drunkula's wineglass of temperance	0		Sleaze Resistance: +5
-6475	fancy weak perfectly mixed bottle of Bloodweiser	2	EPIC	Effect: "Using Protection", Effect Duration: 20
+6475	weak fancy perfectly mixed bottle of Bloodweiser	2	EPIC	Effect: "Using Protection", Effect Duration: 20
 6476	blue gravedigger's Unkillable Skeleton's skullcap of James Dean of bravery	0		Experience (Moxie): +3, Spooky Damage: +10, Spooky Resistance: +5, Class: "Turtle Tamer", Familiar Effect: "1xPotato, 1xFairy"
 6477	wool dance instructor's cool Unkillable Skeleton's breastplate	0		Moxie: +5, Experience Percent (Moxie): +10, Cold Resistance: +1, Class: "Turtle Tamer"
 6478	Jack Frost's careful healthy Unkillable Skeleton's shinguards	0		Maximum HP Percent: +20, Monster Level: -10, Cold Spell Damage: +50, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 1xBarrr"
@@ -6380,7 +6380,7 @@
 6485	twirling bone flour	0		
 6486	dreadful roast	0		
 6487	stinking agaricus	0		
-6488	diet bland Dreadsylvanian shepherd's pie	1	decent	
+6488	bland diet Dreadsylvanian shepherd's pie	1	decent	
 6489	music box parts	0		
 6490	unwound mechanical songbird	0		
 6491	gray tailfeathers	0		Familiar Weight: +5
@@ -6390,7 +6390,7 @@
 6495	sage Dreadsylvania Auditor's badge	0		Mysticality Percent: +10, Kruegerand Drop: 5, Single Equip
 6496	blood kiwi	0		
 6497	eau de mort	0		
-6498	distilled artisanal shaking bloody kiwitini	5	EPIC	
+6498	artisanal distilled shaking bloody kiwitini	5	EPIC	
 6499	moon-amber	0		
 6500	polished moon-amber	0		
 6501	jittery Fonzie's educational boxer's moon-amber necklace	0		Muscle Percent: +10, Experience: +1, Experience (Moxie): +1, Single Equip
@@ -6450,22 +6450,22 @@
 6556	corrupted phial of hotness	0		Effect: "Provocative Perkiness", Effect Duration: 27
 6557	tarnished narrow phial of coldness	0		Effect: "Thicker, Sicker", Effect Duration: 49
 6558	polarized polarized diffused phial of spookiness	0		Effect: "Stop the Presses!", Effect Duration: 28
-6559	wet bouncing red phial of stench	0		Effect: "Chari Tea", Effect Duration: 57
+6559	wet red bouncing phial of stench	0		Effect: "Chari Tea", Effect Duration: 57
 6560	double-colloidal shaking phial of sleaziness	0		Effect: "Down With Chow", Effect Duration: 63
 6561	adventurer clone egg	0		Free Pull, Last Available: "2013-06"
 6562	jittery shaking mini-Mr. Accessory	0		Familiar Weight: +5
 6563	hand of Mr. Cards of Calamity Jane	0		Critical Hit Percent: +15, Conditional Skill (Equipped): "Throw a Mr. Card"
-6564	adequate half-sized Dreadsylvanian hot pocket	2	good	
+6564	half-sized adequate Dreadsylvanian hot pocket	2	good	
 6565	adequate shaking Dreadsylvanian pocket	3	good	
 6566	moldy teal Dreadsylvanian pocket	4	crappy	
 6567	decent Dreadsylvanian stink pocket	3	good	
 6568	bland Dreadsylvanian sleaze pocket	3	decent	
 6569	hand-crafted irresponsibly strong Dreadsylvanian hot toddy	10	EPIC	
-6570	practically non-alcoholic delicious Dreadsylvanian cold-fashioned	1	awesome	
+6570	delicious practically non-alcoholic Dreadsylvanian cold-fashioned	1	awesome	
 6571	practically non-alcoholic lousy Dreadsylvanian grimlet	1	decent	
 6572	watered-down lousy squat Dreadsylvanian dank and stormy	2	decent	
 6573	hand-crafted practically non-alcoholic ghostly Dreadsylvanian slithery nipple	1	super ultra mega turbo EPIC	
-6574	cyan squat hot clusterbomb	0		
+6574	squat cyan hot clusterbomb	0		
 6575	clusterbomb	0		
 6576	clusterbomb	0		
 6577	twirling stench clusterbomb	0		
@@ -6493,7 +6493,7 @@
 6599	clockwork hand	0		
 6600	clockwork hand	0		
 6601	clockwork numeral I	0		
-6602	maroon wobbly clockwork numeral II	0		
+6602	wobbly maroon clockwork numeral II	0		
 6603	clockwork numeral III	0		
 6604	clockwork numeral IV	0		
 6605	clockwork numeral V	0		
@@ -6506,7 +6506,7 @@
 6612	clockwork numeral XII	0		
 6613	spinning clockwork cuckoo	0		
 6614	cuckoo clock	0		
-6615	watered-down special bad jittery Cold One	2	???	Effect: "Saucegoggles", Effect Duration: 10
+6615	special bad watered-down jittery Cold One	2	???	Effect: "Saucegoggles", Effect Duration: 10
 6616	super-sized adequate spaghetti breakfast	5	???	
 6617	over-the-shoulder Folder Holder	0		Single Equip, Softcore Only, Last Available: "2013-08"
 6618	folder (red)	0		Muscle: +20, Last Available: "2013-08"
@@ -6524,7 +6524,7 @@
 6630	wobbly folder (Knight Writer)	0		Initiative: +40, Last Available: "2013-08"
 6631	mirror folder (Jackass Plumber)	0		Monster Level: +25, Last Available: "2013-08"
 6632	folder (holographic fractal)	0		Spooky Resistance: +4, Stench Resistance: +4, Hot Resistance: +4, Cold Resistance: +4, Sleaze Resistance: +4, Last Available: "2013-08"
-6633	huge ghostly folder (barbarian)	0		Last Available: "2013-08"
+6633	ghostly huge folder (barbarian)	0		Last Available: "2013-08"
 6634	folder (rainbow unicorn)	0		Last Available: "2013-08"
 6635	folder (Seawolf)	0		Last Available: "2013-08"
 6636	folder (dancing dolphins)	0		Last Available: "2013-08"
@@ -6541,10 +6541,10 @@
 6649	moist energized alkaline Ogres and Oubliettes&trade; module	0		Effect: "Took Eleven", Effect Duration: 23
 6650	Mountain Stream Code Black Alert	0		
 6651	narrow twisted-up wet towel	0		
-6652	weak hand-crafted stepmom's booze	2	EPIC	
+6652	hand-crafted weak stepmom's booze	2	EPIC	
 6653	spinning surgical tape	0		
 6654	narrow band T-shirt of the ox	0		Muscle: +20
-6655	triple-distilled drinkable special purple fountain 'soda'	9	good	Effect: "Chain Chain Chains", Effect Duration: 50
+6655	drinkable triple-distilled special purple fountain 'soda'	9	good	Effect: "Chain Chain Chains", Effect Duration: 50
 6656	illegal firecracker	0		
 6657	clever shellacked pickelhaube	0		Damage Reduction: 7, Maximum MP: +20, Familiar Effect: "atk, 1xFairy, cap 18"
 6658	liquefied concentrated electrified blurry hair oil	0		Effect: "Extra Backbone", Effect Duration: 60
@@ -6565,11 +6565,11 @@
 6673	yellowcake bomb	0		
 6674	mirror stinkbomb	0		
 6675	chilled improved superwater	0		Effect: "Barbecue Saucy", Effect Duration: 68
-6676	yellow shaking Thwaitgold bookworm statuette	0		
+6676	shaking yellow Thwaitgold bookworm statuette	0		
 6677	crude monster sculpture	0		
 6678	horrifying Yearbook Club Camera	0		Spooky Damage: +25, Conditional Skill (Equipped): "Blinding Flash"
 6679	machete of chilblains	0		Cold Damage: +25
-6680	extra-dry smooth Cursed Punch	5	awesome	
+6680	smooth extra-dry Cursed Punch	5	awesome	
 6681	tolerable tumbling Bowl of Scorpions	3	good	
 6682	tolerable Fog Murderer	3	good	
 6683	book of matches	0		
@@ -6578,7 +6578,7 @@
 6686	wobbly dance instructor's half-size scalpel	0		Experience Percent (Moxie): +10, Surgeonosity: +1
 6687	huge wool surgical apron	0		Cold Resistance: +1, Surgeonosity: +1
 6688	twirling executive bloodied surgical dungarees	0		Meat Drop: +40, Surgeonosity: +1, Familiar Effect: "1xPotato, 1xFairy, cap 38"
-6689	mirror skewed McClusky file (page 1)	0		
+6689	skewed mirror McClusky file (page 1)	0		
 6690	olive McClusky file (page 2)	0		
 6691	skewed McClusky file (page 3)	0		
 6692	mirror McClusky file (page 4)	0		
@@ -6594,18 +6594,18 @@
 6702	upside-down bowler	0		
 6703	imitation White Russian	1	decent	
 6704	friendly short-handled mop of bravery	0		Familiar Weight: +3, Spooky Resistance: +5
-6705	enchanted moldy low-calorie jungle floor wax	1	crappy	Effect: "Eye of the Seal", Effect Duration: 45
+6705	moldy enchanted low-calorie jungle floor wax	1	crappy	Effect: "Eye of the Seal", Effect Duration: 45
 6706	ghostly smirking shrunken head	0		
 6707	anodized irradiated unsweetened green colorful toad	0		Effect: "There Wolf", Effect Duration: 69
 6708	crude voodoo doll	0		
 6709	attorney's badge	0		Single Equip
 6710	Oprah's pygmy briefs of incineration	0		Maximum MP Percent: +50, Hot Spell Damage: +50, Familiar Effect: "atk, 1xVolley, cap 41"
 6711	narrow short writ of habeas corpus	0		
-6712	upside-down mirror blinking bone abacus	0		
+6712	mirror blinking upside-down bone abacus	0		
 6713	adder	0		
 6714	short calculator	0		
 6715	tumbling clever savvy sphygmomanometer	0		Mysticality Percent: +20, Maximum MP: +20
-6716	ionized energized blinking mirror bag of pygmy blood	0		Effect: "Booze Goozles", Effect Duration: 46
+6716	ionized energized mirror blinking bag of pygmy blood	0		Effect: "Booze Goozles", Effect Duration: 46
 6717	tongue depressor	0		
 6718	Newton's brawny compression stocking	0		Muscle Percent: +20, Experience (Mysticality): +3
 6719	green rosy-cheeked midriff scrubs of Tarzan	0		Experience (Muscle): +3, Maximum HP Percent: +30
@@ -6635,7 +6635,7 @@
 6743	razor-sharp junk trunks	0		Weapon Damage Percent: +25, Familiar Effect: "cap 15"
 6744	Samson's junk-mail shirt	0		Experience (Muscle): +5
 6745	diet spoiled junk food	1	crappy	
-6746	artisanal weak spinning skewed junk yard	2	EPIC	
+6746	weak artisanal skewed spinning junk yard	2	EPIC	
 6747	blue Jack Frost's swordzall of the scaredy-cat	0		Monster Level: -15, Cold Spell Damage: +50
 6748	mirror Jim Carey's arm buzzer	0		Monster Level: +25, Damage Reduction: 6
 6749	wholesome boilgun of the brute	0		Muscle Percent: +30, Maximum HP Percent: +10
@@ -6647,18 +6647,18 @@
 6755	narrow beer label	0		
 6756	fuchsia artisanal homebrew sampler	0		
 6757	drinkable blurry can of Br&uuml;talbr&auml;u	4	good	Last Available: "2013-09"
-6758	artisanal watered-down twirling can of Drooling Monk	2	EPIC	Last Available: "2013-09"
-6759	mediocre cyan pulsating can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
+6758	watered-down artisanal twirling can of Drooling Monk	2	EPIC	Last Available: "2013-09"
+6759	mediocre pulsating cyan can of Impetuous Scofflaw	3	decent	Last Available: "2013-09"
 6760	spirit-forward tolerable bottle of Old Pugilist	5	good	Last Available: "2013-09"
 6761	tolerable bottle of Professor Beer	3	good	Last Available: "2013-09"
 6762	acceptable bottle of Rapier Witbier	3	good	Last Available: "2013-09"
 6763	bad wobbly bottle of Race Car Red	3	decent	Last Available: "2013-09"
-6764	aged watered-down teal ghostly bottle of Greedy Dog	2	awesome	Last Available: "2013-09"
+6764	aged watered-down ghostly teal bottle of Greedy Dog	2	awesome	Last Available: "2013-09"
 6765	weak artisanal bottle of Lambada Lambic	2	super ultra mega EPIC	Last Available: "2013-09"
 6766	tin beer can	0		
 6767	tumbling artisanal homebrew gift package	0		
 6768	enchanted liquid bread	1	awesome	Effect: "You Ate Some Hemp Candy", Effect Duration: 30, Last Available: "2013-09"
-6769	shellacked stylish tin tam of the detective	0		Moxie: +25, Damage Reduction: 7, Item Drop: +20, Familiar Effect: "MP regen, cap 25", Last Available: "2013-09"
+6769	shellacked stylish tin tam of the detective	0		Moxie: +25, Damage Reduction: 7, Item Drop: +20, Last Available: "2013-09", Familiar Effect: "MP regen, cap 25"
 6770	unsweetened blurry tin cup	0		Effect: "Vitali Tea", Effect Duration: 17, Last Available: "2013-09"
 6771	frosty Da Vinci's tin foil of the glutton	0		Experience (Mysticality): +5, Cold Spell Damage: +10, Food Drop: +100, Last Available: "2013-09"
 6772	huge frosty Oprah's dangerous tin drum	0		Weapon Damage: +10, Maximum MP Percent: +50, Cold Spell Damage: +10, Last Available: "2013-09"
@@ -6714,7 +6714,7 @@
 6825	blurry Socratic alarm accordion of dire peril	0		Experience (Mysticality): +1, Weapon Damage: +20, Class: "Accordion Thief", Song Duration: 20
 6826	prompt banded All-Hallow's Steve's fright wig of the early riser	0		Damage Absorption: +100, Adventures: 10, Familiar Effect: "0.5xVolley, 1xPotato, cap 13"
 6827	Da Vinci's KoL Con X Treasure Map of the sewer	0		Experience (Mysticality): +5, Stench Damage: +25
-6828	special artisanal discocktail	3	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 10
+6828	artisanal special discocktail	3	EPIC	Effect: "Crimbo Epiphany", Effect Duration: 10
 6829	narrow beefcake's KoL Con X Bingo Card	0		Muscle: +25
 6830	sizzling Temporal Tempera Tube	0		Hot Damage: +10
 6831	enhanced upside-down huge Tallowcreme Halloween Pumpkin	0		Effect: "Towering Strength", Effect Duration: 14
@@ -6725,9 +6725,9 @@
 6836	altered PEEZ dispenser	0		Effect: "Mer-kindliness", Effect Duration: 15
 6837	activated energized pressed Swizzler	0		Effect: "Fit To Be Tide", Effect Duration: 14
 6838	energized modified bouncing Bugbearclaw Donut	0		Effect: "Blessing of the Frozen Tortellini", Effect Duration: 38
-6839	triple-pressed nitrogenated gray pulsating jam	0		Effect: "Ooh, Bitter!", Effect Duration: 32
+6839	triple-pressed nitrogenated pulsating gray jam	0		Effect: "Ooh, Bitter!", Effect Duration: 32
 6840	diffused Whenchamacallit bar	0		Effect: "Stone-Faced", Effect Duration: 68
-6841	triple-diffused huge upside-down 8-bit banana	0		Effect: "Liquidy Smoky", Effect Duration: 28
+6841	triple-diffused upside-down huge 8-bit banana	0		Effect: "Liquidy Smoky", Effect Duration: 28
 6842	wet polymerized pulsating olive vial of blood simple syrup	0		Effect: "Hyperoffended", Effect Duration: 61
 6843	ionized chilled bone bons	0		Effect: "Three Days Slow", Effect Duration: 30
 6844	non-dry ironic mint	0		Effect: "Lemony Goodness", Effect Duration: 21
@@ -6737,7 +6737,7 @@
 6848	pulsating healthy security flashlight	0		Maximum HP Percent: +20
 6849	chilled deionized Effermint&trade; tablets	0		Effect: "Far Out", Effect Duration: 60
 6850	Jack Frost's veiny padded sturdy cane	0		Damage Absorption: +20, Maximum HP: +10, Cold Spell Damage: +50
-6851	lime green pulsating huge bowl of candy	0		
+6851	pulsating lime green huge bowl of candy	0		
 6852	Ultra Mega Sour Ball	0		
 6853	carton of rotten eggs	0		
 6854	red desert sightseeing pamphlet	0		
@@ -6746,7 +6746,7 @@
 6857	green Lo Pan's Cajun accordion	0		Spell Critical Percent: +30, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6858	horrifying quirky accordion	0		Spooky Damage: +25, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
 6859	padded beefy Skipper's accordion	0		Muscle: +10, Damage Absorption: +20, Class: "Accordion Thief", Song Duration: 10, Last Available: "2013-10"
-6860	nasty Jim Carey's shellacked Pantsgiving	0		Damage Reduction: 7, Monster Level: +25, Stench Damage: +5, Item Drop: +5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Familiar Effect: "1xPotato, cap 25", Last Available: "2013-11"
+6860	nasty Jim Carey's shellacked Pantsgiving	0		Damage Reduction: 7, Monster Level: +25, Stench Damage: +5, Item Drop: +5, Softcore Only, Conditional Skill (Equipped): "Talk About Politics", Conditional Skill (Equipped): "Pocket Crumbs", Conditional Skill (Equipped): "Air Dirty Laundry", Last Available: "2013-11", Familiar Effect: "1xPotato, cap 25"
 6861	flavorless can of sardines	4	decent	Last Available: "2013-11"
 6862	snack-sized normal high-calorie sugar substitute	2	good	Last Available: "2013-11"
 6863	moldy pat of butter	3	crappy	Last Available: "2013-11"
@@ -6809,30 +6809,30 @@
 6920	nitrogenated warbear liquid overcoat	0		Effect: "Taurus Rising", Effect Duration: 11, Last Available: "2013-12"
 6921	adequate warbear feasting bread	3	good	Last Available: "2013-12"
 6922	normal warbear warrior bread	4	good	Last Available: "2013-12"
-6923	miniature normal warbear thermoregulator bread	2	good	Last Available: "2013-12"
+6923	normal miniature warbear thermoregulator bread	2	good	Last Available: "2013-12"
 6924	tolerable gray warbear feasting mead	3	good	Last Available: "2013-12"
 6925	strong fancy aged warbear bearserker mead	5	awesome	Effect: "Broken Fast", Effect Duration: 20, Last Available: "2013-12"
 6926	mediocre squat warbear blizzard mead	3	decent	Last Available: "2013-12"
 6927	blue warbear helm fragment	0		Last Available: "2013-12"
-6928	jittery resourceful warbear plain fedora of the dark arts of horror	0		Spell Damage Percent: +100, Maximum MP: +50, Spooky Spell Damage: +25, Familiar Effect: "atk, 1xLep, cap 12", Last Available: "2013-12"
-6929	warbear feathered fedora of terror	0		Spooky Spell Damage: +10, Familiar Effect: "atk, 1xLep, cap 37", Last Available: "2013-12"
-6930	ghostly avaricious sinister warbear fedora of the storm	0		Spell Damage: +10, Maximum MP Percent: +40, Meat Drop: +30, Familiar Effect: "atk, 1xLep", Last Available: "2013-12"
-6931	twirling hale boxer's warbear plain helm of the wise owl	0		Mysticality: +20, Muscle Percent: +10, Maximum HP: +20, Familiar Effect: "atk, 1xFairy, cap 12", Last Available: "2013-12"
-6932	tumbling perfumed warbear spiked helm	0		Stench Resistance: +5, Familiar Effect: "atk, 1xFairy, cap 37", Last Available: "2013-12"
-6933	blinking executive mansplainer's warbear electro-spiked helm of the cougar	0		Moxie: +20, Monster Level: +15, Meat Drop: +40, Familiar Effect: "atk, 1xFairy", Last Available: "2013-12"
-6934	spinning purple friendly ruddy dance instructor's warbear plain ushanka	0		Experience Percent (Moxie): +10, Maximum HP Percent: +40, Familiar Weight: +3, Familiar Effect: "1xBarrr, 1xLep, cap 12", Last Available: "2013-12"
-6935	teal squat Rosewater's warbear lined ushanka	0		Mysticality Percent: +30, Familiar Effect: "1.5xBarrr, 1xLep, cap 37", Last Available: "2013-12"
-6936	dangerous warbear heated ushanka of Calamity Jane of courage	0		Weapon Damage: +10, Critical Hit Percent: +15, Spooky Resistance: +3, Familiar Effect: "1xatk, 1xLep", Last Available: "2013-12"
+6928	jittery resourceful warbear plain fedora of the dark arts of horror	0		Spell Damage Percent: +100, Maximum MP: +50, Spooky Spell Damage: +25, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 12"
+6929	warbear feathered fedora of terror	0		Spooky Spell Damage: +10, Last Available: "2013-12", Familiar Effect: "atk, 1xLep, cap 37"
+6930	ghostly avaricious sinister warbear fedora of the storm	0		Spell Damage: +10, Maximum MP Percent: +40, Meat Drop: +30, Last Available: "2013-12", Familiar Effect: "atk, 1xLep"
+6931	twirling hale boxer's warbear plain helm of the wise owl	0		Mysticality: +20, Muscle Percent: +10, Maximum HP: +20, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 12"
+6932	tumbling perfumed warbear spiked helm	0		Stench Resistance: +5, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy, cap 37"
+6933	blinking executive mansplainer's warbear electro-spiked helm of the cougar	0		Moxie: +20, Monster Level: +15, Meat Drop: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xFairy"
+6934	spinning purple friendly ruddy dance instructor's warbear plain ushanka	0		Experience Percent (Moxie): +10, Maximum HP Percent: +40, Familiar Weight: +3, Last Available: "2013-12", Familiar Effect: "1xBarrr, 1xLep, cap 12"
+6935	teal squat Rosewater's warbear lined ushanka	0		Mysticality Percent: +30, Last Available: "2013-12", Familiar Effect: "1.5xBarrr, 1xLep, cap 37"
+6936	dangerous warbear heated ushanka of Calamity Jane of courage	0		Weapon Damage: +10, Critical Hit Percent: +15, Spooky Resistance: +3, Last Available: "2013-12", Familiar Effect: "1xatk, 1xLep"
 6937	tumbling warbear trouser fragment	0		Last Available: "2013-12"
-6938	Sherlock's Samson's warbear party pants of dire peril	0		Experience (Muscle): +5, Weapon Damage: +20, Item Drop: +25, Familiar Effect: "1xPotato, 1xGhoul, cap 12", Last Available: "2013-12"
-6939	blinking ruddy warbear ceremonial party pants	0		Maximum HP Percent: +40, Familiar Effect: "1xPotato, 1xGhuol, cap 37", Last Available: "2013-12"
-6940	Lo Pan's warbear high festival pants of the dark arts of the storm	0		Spell Damage Percent: +100, Maximum MP Percent: +40, Spell Critical Percent: +30, Familiar Effect: "1xPotato, 1xGhoul", Last Available: "2013-12"
-6941	family-friendly gravedigger's educational warbear battle greaves	0		Experience: +1, Spooky Damage: +10, Sleaze Resistance: +1, Familiar Effect: "atk, 1xBarrr, cap 25", Last Available: "2013-12"
-6942	spinning Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Familiar Effect: "atk, 1xBarrr, cap 37", Last Available: "2013-12"
-6943	ruddy Samson's educational warbear bearserker greaves	0		Experience: +1, Experience (Muscle): +5, Maximum HP Percent: +40, Familiar Effect: "atk, 1xBarrr", Last Available: "2013-12"
-6944	gray Sherlock's frosty MacGyver's warbear johns	0		Maximum MP: +100, Cold Spell Damage: +10, Item Drop: +25, Familiar Effect: "hot atk, 1xVolley, cap 12", Last Available: "2013-12"
-6945	brainy warbear fleece-lined johns	0		Mysticality: +5, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2013-12"
-6946	Lo Pan's grievous warbear johns of Calamity Jane	0		Weapon Damage Percent: +50, Critical Hit Percent: +15, Spell Critical Percent: +30, Familiar Effect: "hot atk, 1xVolley", Last Available: "2013-12"
+6938	Sherlock's Samson's warbear party pants of dire peril	0		Experience (Muscle): +5, Weapon Damage: +20, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul, cap 12"
+6939	blinking ruddy warbear ceremonial party pants	0		Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhuol, cap 37"
+6940	Lo Pan's warbear high festival pants of the dark arts of the storm	0		Spell Damage Percent: +100, Maximum MP Percent: +40, Spell Critical Percent: +30, Last Available: "2013-12", Familiar Effect: "1xPotato, 1xGhoul"
+6941	family-friendly gravedigger's educational warbear battle greaves	0		Experience: +1, Spooky Damage: +10, Sleaze Resistance: +1, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 25"
+6942	spinning Da Vinci's warbear officer greaves	0		Experience (Mysticality): +5, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr, cap 37"
+6943	ruddy Samson's educational warbear bearserker greaves	0		Experience: +1, Experience (Muscle): +5, Maximum HP Percent: +40, Last Available: "2013-12", Familiar Effect: "atk, 1xBarrr"
+6944	gray Sherlock's frosty MacGyver's warbear johns	0		Maximum MP: +100, Cold Spell Damage: +10, Item Drop: +25, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 12"
+6945	brainy warbear fleece-lined johns	0		Mysticality: +5, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
+6946	Lo Pan's grievous warbear johns of Calamity Jane	0		Weapon Damage Percent: +50, Critical Hit Percent: +15, Spell Critical Percent: +30, Last Available: "2013-12", Familiar Effect: "hot atk, 1xVolley"
 6947	warbear accoutrements chunk	0		Last Available: "2013-12"
 6948	steel-toed warbear goggles of incineration of the early riser	0		Damage Reduction: 9, Hot Spell Damage: +50, Adventures: +7, Single Equip, Last Available: "2013-12"
 6949	ghostly stiffened warbear snowblindness goggles	0		Damage Reduction: 1, Single Equip, Last Available: "2013-12"
@@ -6845,7 +6845,7 @@
 6956	Samson's Herculean warbear warscarf of the sweet-tooth	0		Experience (Muscle): 6, Candy Drop: +100, Single Equip, Last Available: "2013-12"
 6957	warbear requisition box	0		Last Available: "2013-12"
 6958	warbear exo-arm	0		Class: "Seal Clubber", Single Equip, Last Available: "2013-12"
-6959	auspicious warbear foil hat	0		Item Drop: +10, Class: "Turtle Tamer", Familiar Effect: "1xVolley, 2xPotato, cap 25", Last Available: "2013-12"
+6959	auspicious warbear foil hat	0		Item Drop: +10, Class: "Turtle Tamer", Last Available: "2013-12", Familiar Effect: "1xVolley, 2xPotato, cap 25"
 6960	warbear energy bracers	0		Class: "Pastamancer", Single Equip, Last Available: "2013-12"
 6961	tumbling avaricious warbear oil pan of the brute	0		Muscle Percent: +30, Meat Drop: +30, Class: "Sauceror", Conditional Skill (Equipped): "Spray Hot Grease", Last Available: "2013-12"
 6962	bouncing warbear laser beacon	0		Class: "Disco Bandit", Single Equip, Last Available: "2013-12"
@@ -6855,7 +6855,7 @@
 6966	warbear induction oven	0		Last Available: "2013-12"
 6967	huge blinking warbear chemistry lab	0		Last Available: "2013-12"
 6968	warbear officer requisition box	0		Last Available: "2013-12"
-6969	maroon skewed warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
+6969	skewed maroon warbear empathy chip	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 6970	bouncing warbear drone assembler	0		Last Available: "2013-12"
 6971	shaking warbear breakfast machine assembler	0		Last Available: "2013-12"
 6972	blind-packed die-cast toy	0		Last Available: "2013-12"
@@ -6889,15 +6889,15 @@
 7000	Newton's experienced die-cast Don Crimbo	0		Experience: +2, Experience (Mysticality): +3, Last Available: "2013-12"
 7001	squat frightening razor-sharp die-cast Uncle Hobo	0		Weapon Damage Percent: +25, Spooky Damage: +5, Last Available: "2013-12"
 7002	mansplainer's beefy die-cast Father Crimbo	0		Muscle: +10, Monster Level: +15, Last Available: "2013-12"
-7003	The Smith's Tome	0		Free Pull, Skill: "Summon Smithsness", Last Available: "2013-12"
+7003	The Smith's Tome	0		Free Pull, Last Available: "2013-12", Skill: "Summon Smithsness"
 7004	polarized oxidized Flaskfull of Hollow	0		Effect: "Frosty the Hitman", Effect Duration: 59, Last Available: "2013-12"
 7005	lump of Brituminous coal	0		Last Available: "2013-12"
 7006	diluted handful of Smithereens	1	good	Last Available: "2013-12"
 7007	half-sized bland red skewed Every Day is Like This Sundae	2	decent	Last Available: "2013-12"
 7008	flavorless Miserable Pie	3	decent	Last Available: "2013-12"
-7009	spoiled tiny ghostly This Charming Flan	1	crappy	Last Available: "2013-12"
+7009	tiny spoiled ghostly This Charming Flan	1	crappy	Last Available: "2013-12"
 7010	enchanted hand-crafted Irish Coffee, English Heart	4	EPIC	Effect: "It Tickles!  It Tickles!", Effect Duration: 45, Last Available: "2013-12"
-7011	mediocre irresponsibly strong Strikes Again Bigmouth	9	decent	Last Available: "2013-12"
+7011	irresponsibly strong mediocre Strikes Again Bigmouth	9	decent	Last Available: "2013-12"
 7012	drinkable fortified Paint A Vulgar Pitcher	5	good	Last Available: "2013-12"
 7013	fuchsia Golden Light	0		Last Available: "2013-12"
 7014	yellow Louder Than Bomb	0		Last Available: "2013-12"
@@ -6907,8 +6907,8 @@
 7018	teal family-friendly asbestos-lined baleful Sheila Take a Crossbow of incineration	0		Spell Damage: +25, Hot Spell Damage: +50, Hot Resistance: +5, Sleaze Resistance: +1, Last Available: "2013-12"
 7019	fireproof lion tamer's studded brawny A Light that Never Goes Out	0		Muscle Percent: +20, Damage Absorption: +80, Experience (familiar): +2, Hot Resistance: +3, Last Available: "2013-12"
 7020	dog trainer's mansplainer's Half a Purse of the empath of the cheetah	0		Monster Level: +15, Familiar Weight: +5, Experience (familiar): +1, Initiative: +60, Last Available: "2013-12"
-7021	flame-retardant Jim Carey's Tesla energetic Hairpiece On Fire	0		Maximum MP Percent: +20, Monster Level: +25, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "atk, 1xPotato, cap 25", Last Available: "2013-12"
-7022	squat Van der Graaf wicked educational Vicar's Tutu of the wise owl	0		Mysticality: +20, Experience: +1, Spell Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Familiar Effect: "1.2xFairy, cap 25", Last Available: "2013-12"
+7021	flame-retardant Jim Carey's Tesla energetic Hairpiece On Fire	0		Maximum MP Percent: +20, Monster Level: +25, Hot Resistance: +1, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2013-12", Familiar Effect: "atk, 1xPotato, cap 25"
+7022	squat Van der Graaf wicked educational Vicar's Tutu of the wise owl	0		Mysticality: +20, Experience: +1, Spell Damage: +5, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2013-12", Familiar Effect: "1.2xFairy, cap 25"
 7023	electrified cool Hand in Glove of the sweet-tooth	0		Moxie: +5, Candy Drop: +100, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2013-12"
 7024	mirror executive stanky Meat Tenderizer is Murder of the cheetah	0		Stench Spell Damage: +25, Meat Drop: +40, Initiative: +60, Class: "Seal Clubber", Last Available: "2013-12"
 7025	mansplainer's rock-hard Rosewater's Ouija Board, Ouija Board	0		Mysticality Percent: +30, Damage Reduction: 12, Monster Level: +15, Class: "Turtle Tamer", Last Available: "2013-12"
@@ -6941,9 +6941,9 @@
 7052	warbear metalworking primer (used)	0		Skill: "Shrap", Last Available: "2013-12"
 7053	warbear empathy chip (used)	0		Skill: "Psychokinetic Hug", Last Available: "2013-12"
 7054	warbear drone codes	0		Last Available: "2013-12"
-7055	spoiled cyan bouncing breakfast mess	4	crappy	Last Available: "2013-12"
+7055	spoiled bouncing cyan breakfast mess	4	crappy	Last Available: "2013-12"
 7056	spinning warbear breakfast machine	0		Last Available: "2013-12"
-7057	miniature stale maroon breakfast miracle	2	decent	Last Available: "2013-12"
+7057	stale miniature maroon breakfast miracle	2	decent	Last Available: "2013-12"
 7058	polymerized quadruple-adjusted ghostly Cloaca Cola Polar	0		Effect: "Just Aged Enough", Effect Duration: 60, Last Available: "2013-12"
 7059	warbear soda machine	0		Last Available: "2013-12"
 7060	festive warbear bank	0		Last Available: "2013-12"
@@ -6953,23 +6953,23 @@
 7064	wobbly cyan hibernating Grimstone Golem	0		Free Pull, Last Available: "2014-12"
 7065	dehydrated skewed grim fairy tale	1	good	Effect: "Prelude of Precision", Effect Duration: 25, Last Available: "2014-12"
 7066	grimstone galoshes	0		Familiar Weight: +5
-7067	altered mirror ghostly single of Inigo's Incantation of Inspiration	0		Effect: "Fan-Cooled", Effect Duration: 56, Last Available: "2010-02"
+7067	altered ghostly mirror single of Inigo's Incantation of Inspiration	0		Effect: "Fan-Cooled", Effect Duration: 56, Last Available: "2010-02"
 7068	vacuum-sealed colloidal single of Donho's Bubbly Ballad	0		Effect: "Tightly-Wound Spine", Effect Duration: 20
 7069	squat Discontent&trade; Winter Garden Catalog	0		Free Pull, Last Available: "2014-01"
 7070	packet of winter seeds	0		Last Available: "2014-01"
-7071	fancy bland snow berries	4	decent	Effect: "Nothing Is Impossible", Effect Duration: 20, Last Available: "2014-01"
-7072	miniature normal ice harvest	2	good	Last Available: "2014-01"
+7071	bland fancy snow berries	4	decent	Effect: "Nothing Is Impossible", Effect Duration: 20, Last Available: "2014-01"
+7072	normal miniature ice harvest	2	good	Last Available: "2014-01"
 7073	improved frost flower	0		Effect: "Loco Motives", Effect Duration: 20, Last Available: "2014-01"
 7074	unsweetened snow cleats	0		Effect: "Dancing Prowess", Effect Duration: 23, Last Available: "2014-01"
 7075	triple-energized corrupted fuchsia liquid ice pack	0		Effect: "Dirty Pear", Effect Duration: 47, Last Available: "2014-01"
 7076	wobbly snow boards	0		Last Available: "2014-01"
 7077	miniature bland snow crab	2	decent	Last Available: "2014-01"
-7078	tolerable practically non-alcoholic Ice Island Long Tea	1	good	Last Available: "2014-01"
+7078	practically non-alcoholic tolerable Ice Island Long Tea	1	good	Last Available: "2014-01"
 7079	unfinished ice sculpture	0		Last Available: "2014-01"
 7080	ice sculpture	0		Last Available: "2014-01"
 7081	tumbling ice house	0		Last Available: "2014-01"
 7082	snow machine	0		Last Available: "2014-01"
-7083	wholesome snow mobile	0		Maximum HP Percent: +10, Lasts Until Rollover, Lantern Element: "Cold", Last Available: "2014-01"
+7083	wholesome snow mobile	0		Maximum HP Percent: +10, Lasts Until Rollover, Last Available: "2014-01", Lantern Element: "Cold"
 7084	maroon thinker's ice bucket	0		Mysticality: +10, Lasts Until Rollover, Last Available: "2014-01"
 7085	squat double-paned Jeselnik's snow shovel	0		Sleaze Damage: +25, Cold Resistance: +5, Lasts Until Rollover, Last Available: "2014-01"
 7086	fuchsia up-at-dawn scorching forbidden bod-ice	0		Spell Damage Percent: +50, Hot Damage: +25, Adventures: +5, Lasts Until Rollover, Last Available: "2014-01"
@@ -6978,11 +6978,11 @@
 7089	snow fort	0		Last Available: "2014-01"
 7090	hand-crafted weak En Una Fila Tequila	2	EPIC	
 7091	tumbling Skully's hot chocolate	1	good	
-7092	jittery reassuring hale warbear dress helmet	0		Maximum HP: +20, Spooky Resistance: +1, Familiar Effect: "cold atk, 1xVolley, cap 25", Last Available: "2013-12"
+7092	jittery reassuring hale warbear dress helmet	0		Maximum HP: +20, Spooky Resistance: +1, Last Available: "2013-12", Familiar Effect: "cold atk, 1xVolley, cap 25"
 7093	Annie Oakley's beefy warbear dress bracers	0		Muscle: +10, Critical Hit Percent: +20, Single Equip, Last Available: "2013-12"
-7094	friendly thinker's warbear dress greaves	0		Mysticality: +10, Familiar Weight: +3, Familiar Effect: "2xBarrr, cap 25", Last Available: "2013-12"
-7095	blurry sweatband of Leguizamo of the cheetah	0		Monster Level: +20, Initiative: +60, Familiar Effect: "sleaze atk, 1xFairy, cap 25", Last Available: "2014-12"
-7096	Annie Oakley's gym shorts of Gandalf	0		Critical Hit Percent: +20, Spell Critical Percent: +20, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-12"
+7094	friendly thinker's warbear dress greaves	0		Mysticality: +10, Familiar Weight: +3, Last Available: "2013-12", Familiar Effect: "2xBarrr, cap 25"
+7095	blurry sweatband of Leguizamo of the cheetah	0		Monster Level: +20, Initiative: +60, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xFairy, cap 25"
+7096	Annie Oakley's gym shorts of Gandalf	0		Critical Hit Percent: +20, Spell Critical Percent: +20, Last Available: "2014-12", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7097	blurry knitted ruddy ankleweights	0		Maximum HP Percent: +40, Cold Resistance: +3, Single Equip, Last Available: "2014-12"
 7098	jittery therapeutic forbidden razor-sharp Newton's sweat socks	0		Experience (Mysticality): +3, Weapon Damage Percent: +25, Spell Damage Percent: +50, HP Regen Min: 5, HP Regen Max: 7, Last Available: "2014-12"
 7099	pint of sweat	0		Last Available: "2014-12"
@@ -6992,10 +6992,10 @@
 7103	non-polarized irradiated green pulsating powder	0		Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 69, Last Available: "2014-12"
 7104	arcane researcher's licorice whip	0		Experience Percent (Mysticality): +10, Last Available: "2014-12"
 7105	anise-flavored venom	0		Last Available: "2014-12"
-7106	artisanal enchanted blurry snakebite	4	EPIC	Effect: "Horrid, Torrid", Effect Duration: 35, Last Available: "2014-12"
+7106	enchanted artisanal blurry snakebite	4	EPIC	Effect: "Horrid, Torrid", Effect Duration: 35, Last Available: "2014-12"
 7107	sage candy stick of the bloodbag	0		Mysticality Percent: +10, Maximum HP: +100, Last Available: "2014-12"
-7108	adequate huge pecan	7	good	Last Available: "2014-12"
-7109	big spoiled narrow pecan pie	5	crappy	Last Available: "2014-12"
+7108	huge adequate pecan	7	good	Last Available: "2014-12"
+7109	spoiled big narrow pecan pie	5	crappy	Last Available: "2014-12"
 7110	chocolate-stained collar	0		Candy Drop: +25, Last Available: "2014-12"
 7111	bland candy mountain oyster	3	decent	Last Available: "2014-12"
 7112	hand-crafted chocotini	3	EPIC	Last Available: "2014-12"
@@ -7003,35 +7003,35 @@
 7114	adequate candy carrot	4	good	Last Available: "2014-12"
 7115	normal lime green candy carrot cake	3	good	Last Available: "2014-12"
 7116	personal trainer's carrot-on-a-stick of the scaredy-cat	0		Experience Percent (Muscle): +10, Monster Level: -15, Last Available: "2014-12"
-7117	weasel stomping pants of the brute of the glutton	0		Muscle Percent: +30, Food Drop: +100, Familiar Effect: "1xGhoul, cap 20", Last Available: "2014-12"
+7117	weasel stomping pants of the brute of the glutton	0		Muscle Percent: +30, Food Drop: +100, Last Available: "2014-12", Familiar Effect: "1xGhoul, cap 20"
 7118	bland mulberry	4	decent	Last Available: "2014-12"
 7119	drinkable mulled berry wine	3	good	Last Available: "2014-12"
 7120	red narrow lemony scales	0		Last Available: "2014-12"
-7121	lemon party hat of Tarzan	0		Experience (Muscle): +3, Lasts Until Rollover, Familiar Effect: "1xVolley, cap 12", Last Available: "2014-12"
+7121	lemon party hat of Tarzan	0		Experience (Muscle): +3, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "1xVolley, cap 12"
 7122	shaking fuchsia shaking perfumed lemon shirt	0		Stench Resistance: +5, Lasts Until Rollover, Last Available: "2014-12"
-7123	lemon drop trousers of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Familiar Effect: "atk, 1xPotato, cap 12", Last Available: "2014-12"
+7123	lemon drop trousers of the scaredy-cat	0		Monster Level: -15, Lasts Until Rollover, Last Available: "2014-12", Familiar Effect: "atk, 1xPotato, cap 12"
 7124	ionized denatured lemonhead caviar	0		Effect: "Tomato Power", Effect Duration: 33, Last Available: "2014-12"
 7125	blurry clever curative gummi sword	0		Maximum MP: +20, HP Regen Min: 3, HP Regen Max: 5, Last Available: "2014-12"
 7126	unsweetened small gummi fin	0		Effect: "Spooky Blur", Effect Duration: 14, Last Available: "2014-12"
 7127	Usain Bolt's chocolate cow bone	0		Initiative: +80, Last Available: "2014-12"
 7128	pressed adjusted gummi fang	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 35, Last Available: "2014-12"
-7129	enchanted adequate leftover canap&eacute;s	3	good	Effect: "PERL of Great Price", Effect Duration: 50, Last Available: "2014-12"
-7130	strong hand-crafted magnum of champagne	5	EPIC	Last Available: "2014-12"
+7129	adequate enchanted leftover canap&eacute;s	3	good	Effect: "PERL of Great Price", Effect Duration: 50, Last Available: "2014-12"
+7130	hand-crafted strong magnum of champagne	5	EPIC	Last Available: "2014-12"
 7131	narrow friendly veiny cow creamer of the ox	0		Muscle: +20, Maximum HP: +10, Familiar Weight: +3, Last Available: "2014-12"
-7132	irradiated corrupted corrupted huge squat fuchsia Outer Wolf&trade; cologne	0		Effect: "Helping Comes Second", Effect Duration: 11, Last Available: "2014-12"
+7132	irradiated corrupted corrupted fuchsia huge squat Outer Wolf&trade; cologne	0		Effect: "Helping Comes Second", Effect Duration: 11, Last Available: "2014-12"
 7133	jittery twirling skewed lupine appetite hormones	0		Last Available: "2014-12"
 7134	upside-down careful wolf whistle of vim and vigor	0		Maximum HP Percent: +50, Monster Level: -10, Conditional Skill (Equipped): "Blow Wolf Whistle", Last Available: "2014-12"
-7135	rotten huge witch's bread	9	crappy	Last Available: "2014-12"
+7135	huge rotten witch's bread	9	crappy	Last Available: "2014-12"
 7136	tarnished polymerized witch's brew	0		Effect: "Destructive Resolve", Effect Duration: 17, Last Available: "2014-12"
 7137	stanky Annie Oakley's padded witch's bra	0		Damage Absorption: +20, Critical Hit Percent: +20, Stench Spell Damage: +25, Last Available: "2014-12"
-7138	weak smooth mid-level medieval mead	2	awesome	Last Available: "2014-12"
+7138	smooth weak mid-level medieval mead	2	awesome	Last Available: "2014-12"
 7139	vacuum-sealed double-cold-filtered galvanized R&uuml;mpelstiltz	0		Effect: "Shawarma Initiative", Effect Duration: 38, Last Available: "2014-12"
 7140	spinning wheel	0		Last Available: "2014-12"
 7141	Vulcanized polymerized ghostly bouncing hi-octane carrot juice	0		Effect: "Old Time Hydration", Effect Duration: 38, Last Available: "2014-12"
 7142	non-ionized polarized hare brush	0		Effect: "Superhuman Sarcasm", Effect Duration: 27, Last Available: "2014-12"
 7143	healthy supercool hare pin	0		Moxie Percent: +20, Maximum HP Percent: +20, Single Equip, Last Available: "2014-12"
 7144	odd coin	0		Last Available: "2014-12"
-7145	delicious half-sized twirling cinnamon cannoli	2	awesome	Last Available: "2014-12"
+7145	half-sized delicious twirling cinnamon cannoli	2	awesome	Last Available: "2014-12"
 7146	triple-distilled perfectly mixed expensive champagne	6	EPIC	Last Available: "2014-12"
 7147	colloidal non-improved altered polo trophy	0		Effect: "Spooky Jellied", Effect Duration: 42, Last Available: "2014-12"
 7148	tumbling oil painting	0		Last Available: "2014-12"
@@ -7043,10 +7043,10 @@
 7154	filling	0		Last Available: "2014-12"
 7155	parchment	0		Last Available: "2014-12"
 7156	glass	0		Last Available: "2014-12"
-7157	knitted Jack Frost's Lo Pan's fire hose	0		Spell Critical Percent: +30, Cold Spell Damage: +50, Cold Resistance: +3, Familiar Effect: "hot atk, 1xVolley, cap 37", Last Available: "2014-12"
+7157	knitted Jack Frost's Lo Pan's fire hose	0		Spell Critical Percent: +30, Cold Spell Damage: +50, Cold Resistance: +3, Last Available: "2014-12", Familiar Effect: "hot atk, 1xVolley, cap 37"
 7158	spoiled fireman's lunch	3	crappy	Last Available: "2014-12"
-7159	chilly friendly plain paper hat of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Cold Damage: +5, Familiar Effect: "cold atk, cap 37", Last Available: "2014-12"
-7160	adequate thick ice cream sandwich	5	good	Last Available: "2014-12"
+7159	chilly friendly plain paper hat of the bloodbag	0		Maximum HP: +100, Familiar Weight: +3, Cold Damage: +5, Last Available: "2014-12", Familiar Effect: "cold atk, cap 37"
+7160	thick adequate ice cream sandwich	5	good	Last Available: "2014-12"
 7161	Temple Grandin's wizardly &quot;honey&quot; dipper of Calamity Jane	0		Mysticality: +25, Critical Hit Percent: +15, Familiar Weight: +7, Last Available: "2014-12"
 7162	adequate skewed plumber's lunch	3	good	Last Available: "2014-12"
 7163	friendly Oprah's skull gearshift knob of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +50, Familiar Weight: +3, Last Available: "2014-12"
@@ -7063,7 +7063,7 @@
 7174	moldy humble pie	3	crappy	Last Available: "2014-12"
 7175	skewed small golem	0		Last Available: "2014-12"
 7176	huge shaking crappy camera	0		Last Available: "2014-12"
-7177	non-liquefied fuchsia jittery crappy waiter disguise	0		Effect: "Punchy, Murdery", Effect Duration: 25
+7177	non-liquefied jittery fuchsia crappy waiter disguise	0		Effect: "Punchy, Murdery", Effect Duration: 25
 7178	Copperhead Charm	0		
 7179	maroon The First Pizza	0		
 7180	The Lacrosse Stick of Lacoronado	0		
@@ -7079,7 +7079,7 @@
 7190	supercool tommy gun	0		Moxie Percent: +20, Conditional Skill (Equipped): "Unload Tommy Gun"
 7191	ghostly drum of tommy ammo	0		
 7192	blinking throwing knife	0		
-7193	tumbling shaking throwing spoon	0		
+7193	shaking tumbling throwing spoon	0		
 7194	throwing fork	0		
 7195	blue smelly clever breadchucks	0		Maximum MP: +20, Stench Spell Damage: +10
 7196	shuriken salad	0		
@@ -7092,7 +7092,7 @@
 7203	Saturday Night Special of the businessman	0		Meat Drop: +50
 7204	lynyrd snare	0		
 7205	stiffened fleetwood chain	0		Damage Reduction: 1
-7206	weak smooth mirror Green Manalishi	2	awesome	
+7206	smooth weak mirror Green Manalishi	2	awesome	
 7207	blade of the detective	0		Item Drop: +20
 7208	spinning fire of unknown origin	0		
 7209	eagle's milk	1	decent	
@@ -7101,21 +7101,21 @@
 7212	blurry inspector's Jefferson wings	0		Item Drop: +15
 7213	fuchsia fleetwood macaroni	0		
 7214	yellow cheesy eagle sauce	0		
-7215	miniature spoiled fleetwood mac 'n' cheese	2	crappy	
+7215	spoiled miniature fleetwood mac 'n' cheese	2	crappy	
 7216	wobbly huge lynyrd skin	0		
 7217	fuchsia lynyrdskin cap of Calamity Jane	0		Critical Hit Percent: +15, Familiar Effect: "1xPotato, 1xVolley, cap 42"
 7218	blurry up-at-dawn lynyrdskin tunic	0		Adventures: +5
 7219	medical-grade lynyrdskin breeches	0		HP Regen Min: 7, HP Regen Max: 10, Familiar Effect: "1xPotato, 1.5xGhuol, cap 42"
-7220	shaking yellow skewed cigarette lighter	0		
+7220	skewed yellow shaking cigarette lighter	0		
 7221	spinning priceless diamond	0		
 7222	drinkable Flamin' Whatshisname	4	good	
 7223	activated lynyrd musk	0		Effect: "Dances with Tweedles", Effect Duration: 52
 7224	Kashmir sweater of chilblains of bravery	0		Cold Damage: +25, Spooky Resistance: +5
-7225	normal big blurry custard pie	5	good	
+7225	big normal blurry custard pie	5	good	
 7226	tea for one	1	crappy	
 7227	tolerable bottle of Evermore	3	good	
 7228	mirror box	0		
-7229	practically non-alcoholic hand-crafted wine	1	EPIC	
+7229	hand-crafted practically non-alcoholic wine	1	EPIC	
 7230	hand-crafted rum	4	EPIC	
 7231	perfectly mixed Murderer's Punch	3	EPIC	
 7232	flavorless special velvet cake	3	decent	Effect: "Fit To Be Tide", Effect Duration: 15
@@ -7141,10 +7141,10 @@
 7252	yellow shot of Sneaky Pete's Mojo	0		Free Pull
 7253	Anniversary Miniature Sword & Martini Guy	0		
 7254	really cocktail shaker	0		Familiar Weight: +5
-7255	artisanal watered-down mini-martini	2	EPIC	
+7255	watered-down artisanal mini-martini	2	EPIC	
 7256	wobbly smoke grenade	0		
 7257	twisted molotov soda	1	good	
-7258	dry dry bouncing huge upside-down pile of ashes	0		Effect: "Turkey-Friendly", Effect Duration: 45
+7258	dry dry upside-down bouncing huge pile of ashes	0		Effect: "Turkey-Friendly", Effect Duration: 45
 7259	blinking crate of firebombs	0		
 7260	firebomb	0		
 7261	wobbly dance instructor's Sneaky Pete's basket of the pedagogue of courage	0		Experience: +3, Experience Percent (Moxie): +10, Spooky Resistance: +3
@@ -7167,7 +7167,7 @@
 7278	returned Thinknerd package	0		
 7279	non-liquefied non-diffused altered upside-down lime green wind-up Whatsian robot	0		Effect: "Blackberry Politeness", Effect Duration: 39
 7280	triple-cold-filtered corrupted skewed wind-up vampire teeth	0		Effect: "Chari Tea", Effect Duration: 35
-7281	flattened pickled cyan pulsating wind-up navigation droid	0		Effect: "Certainty", Effect Duration: 66
+7281	flattened pickled pulsating cyan wind-up navigation droid	0		Effect: "Certainty", Effect Duration: 66
 7282	improved ionized narrow wind-up owl	0		Effect: "Blessing of Squirtlcthulli", Effect Duration: 13
 7283	pickled boiled green wind-up ensign	0		Effect: "Natural 20", Effect Duration: 18
 7284	blurry flame-retardant medical-grade crying statue earrings	0		Hot Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover
@@ -7176,7 +7176,7 @@
 7287	up-at-dawn Gary Claybender's Time Screwer of the brute	0		Muscle Percent: +30, Adventures: +5, Single Equip, Lasts Until Rollover
 7288	manspreader's Space Tourist palmdoctor of Calamity Jane	0		Critical Hit Percent: +15, Monster Level: +10, Lasts Until Rollover
 7289	inspector's scandalous amok putter of extreme caution	0		Monster Level: -25, Sleaze Damage: +5, Item Drop: +15
-7290	half-sized adequate amok pudding	2	good	
+7290	adequate half-sized amok pudding	2	good	
 7291	deactivated putty buddy	0		
 7292	huge putty coat	0		Familiar Weight: +5
 7293	energized warmed lime green can of V-11	0		Effect: "Less Pervious", Effect Duration: 18, Last Available: "2014-03"
@@ -7240,7 +7240,7 @@
 7351	olive energetic therapeutic grievous Staff of the Electric Range	0		Weapon Damage Percent: +50, Maximum MP Percent: +20, HP Regen Min: 5, HP Regen Max: 7
 7352	spoiled spinning deluxe layer cake	3	crappy	
 7353	chunk of hot iron	0		
-7354	spirit-forward perfectly mixed red-hot boilermaker	5	EPIC	
+7354	perfectly mixed spirit-forward red-hot boilermaker	5	EPIC	
 7355	squat veiny coal shovel	0		Maximum HP: +10, Conditional Skill (Equipped): "Shovel Hot Coal"
 7356	altered maroon hot coal	0		Effect: "Irresistible Resolve", Effect Duration: 22
 7357	galvanized adjusted dry coal dust	0		Effect: "Stregngth of the Gnome", Effect Duration: 26
@@ -7269,7 +7269,7 @@
 7380	rosewater-soaked sinister ghast iron codpiece	0		Spell Damage: +10, Stench Resistance: +3, Familiar Effect: "atk, 1xBarrr, cap 42"
 7381	wobbly forbidden Pendant of Gargalesis	0		Spell Damage Percent: +50
 7382	Little Geneticist DNA-Splicing Lab	0		Last Available: "2014-04"
-7383	pulsating wobbly DNA extraction syringe	0		Last Available: "2014-04"
+7383	wobbly pulsating DNA extraction syringe	0		Last Available: "2014-04"
 7384	deionized pickled Gene Tonic: Dude	0		Effect: "Discomfited", Effect Duration: 33, Last Available: "2014-04"
 7385	galvanized quadruple-unsweetened bouncing Gene Tonic: Beast	0		Effect: "Badger Underfoot", Effect Duration: 52, Last Available: "2014-04"
 7386	cold-filtered colloidal spinning Gene Tonic: Construct	0		Effect: "[1701]Hip to the Jive", Effect Duration: 11, Last Available: "2014-04"
@@ -7323,7 +7323,7 @@
 7434	denatured Helvella Haemophilia mushroom	0		Effect: "Corruption of Wretched Wally", Effect Duration: 43, Last Available: "2014-05"
 7435	improved non-diffused Stemonitis Staticus mushroom	0		Effect: "Mushroom Moxiousness", Effect Duration: 57, Last Available: "2014-05"
 7436	tarnished non-pickled moist teal Tremella Tarantella mushroom	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 66, Last Available: "2014-05"
-7437	blurry yellow Pastaco shell	0		Last Available: "2014-05"
+7437	yellow blurry Pastaco shell	0		Last Available: "2014-05"
 7438	flavorless special Beefy Crunch Pastaco	3	decent	Effect: "Sneaky Serpentine Subtlety", Effect Duration: 10, Last Available: "2014-05"
 7439	flavorless upside-down Brain Food Pastaco	3	decent	Last Available: "2014-05"
 7440	snack-sized spoiled Cool Brunch Pastaco	2	crappy	Last Available: "2014-05"
@@ -7331,30 +7331,30 @@
 7442	spoiled Energy Buzz Pastaco	3	crappy	Last Available: "2014-05"
 7443	flavorless jumbo Ludovico Pastaco	5	decent	Last Available: "2014-05"
 7444	bad overpowering mushroom wine	3	decent	Last Available: "2014-05"
-7445	weak drinkable complex mushroom wine	2	good	Last Available: "2014-05"
-7446	perfectly mixed practically non-alcoholic smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
+7445	drinkable weak complex mushroom wine	2	good	Last Available: "2014-05"
+7446	practically non-alcoholic perfectly mixed smooth mushroom wine	1	super ultra mega turbo EPIC	Last Available: "2014-05"
 7447	lousy blurry blood-red mushroom wine	3	decent	Last Available: "2014-05"
 7448	bad buzzing mushroom wine	4	decent	Last Available: "2014-05"
 7449	acceptable swirling mushroom wine	4	good	Last Available: "2014-05"
-7450	half-sized bland Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
-7451	fancy decent Taco Dan's Taco Fish Fish Taco	4	good	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 10, Last Available: "2014-05"
+7450	bland half-sized Taco Dan's Basic Taco Dan Taco	2	decent	Last Available: "2014-05"
+7451	decent fancy Taco Dan's Taco Fish Fish Taco	4	good	Effect: "Fifty Ways to Bereave Your Lover", Effect Duration: 10, Last Available: "2014-05"
 7452	upside-down Taco Dan's Super Taco-Riffic Taco Sauce!	0		Last Available: "2014-05"
 7453	smooth extra-dry regular-size brogurt	5	awesome	Last Available: "2014-05"
-7454	high-proof lousy jittery tumbling super-size brogurt	10	decent	Last Available: "2014-05"
-7455	perfectly mixed weak broberry brogurt	2	super ultra EPIC	Last Available: "2014-05"
+7454	high-proof lousy tumbling jittery super-size brogurt	10	decent	Last Available: "2014-05"
+7455	weak perfectly mixed broberry brogurt	2	super ultra EPIC	Last Available: "2014-05"
 7456	lousy practically non-alcoholic brocolate brogurt	1	decent	Last Available: "2014-05"
 7457	artisanal skewed skewed French bronilla brogurt	3	EPIC	Last Available: "2014-05"
 7458	skewed History's Most Offensive Jokes, Vol. IX	0		Skill: "Unoffendable", Last Available: "2014-05"
 7459	Now You're Cooking With Grease	0		Skill: "Grease Up", Last Available: "2014-05"
 7460	Sloppy Seconds Diner Employee Handbook	0		Skill: "Sloppy Secrets", Last Available: "2014-05"
 7461	industrial strength anti-fungal spray	0		Last Available: "2014-05"
-7462	Herculean Brogre brorts	0		Experience (Muscle): +1, Familiar Effect: "sleaze atk, 1xGhuol, cap 25", Last Available: "2014-05"
+7462	Herculean Brogre brorts	0		Experience (Muscle): +1, Last Available: "2014-05", Familiar Effect: "sleaze atk, 1xGhuol, cap 25"
 7463	Fonzie's Brogre brolo shirt	0		Experience (Moxie): +1, Last Available: "2014-05"
-7464	up-at-dawn Brogre bucket hat	0		Adventures: +5, Familiar Effect: "1xVolley, 1xBarrr, cap 14", Last Available: "2014-05"
+7464	up-at-dawn Brogre bucket hat	0		Adventures: +5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 14"
 7465	spinning Spring Break Beach tattoo coupon	0		Last Available: "2014-05"
 7466	airplane charter: Spring Break Beach	0		Free Pull, Last Available: "2014-05"
 7467	green one-day ticket to Spring Break Beach	0		Last Available: "2014-05"
-7468	smelly electrified 8-billed baseball cap of vim and vigor	0		Maximum HP Percent: +50, Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Familiar Effect: "1xVolley, 1xBarrr, cap 12", Last Available: "2014-05"
+7468	smelly electrified 8-billed baseball cap of vim and vigor	0		Maximum HP Percent: +50, Stench Spell Damage: +10, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2014-05", Familiar Effect: "1xVolley, 1xBarrr, cap 12"
 7469	skewed Tesla Van der Graaf extremely wet T-shirt of courage	0		Spooky Resistance: +3, MP Regen Min: 12, MP Regen Max: 17, Last Available: "2014-05"
 7470	cyan nasty chaotic shrimp fork of the empath	0		Spell Critical Percent: +10, Familiar Weight: +5, Stench Damage: +5, Last Available: "2014-05"
 7471	ionized BROS Energy Drink	0		Effect: "Mad at Science", Effect Duration: 20, Last Available: "2014-05"
@@ -7367,9 +7367,9 @@
 7478	possessed sugar cube	0		Last Available: "2014-05"
 7479	altered denatured shaking squat sugar fairy	0		Effect: "Impregnably Delicious", Effect Duration: 20, Last Available: "2014-05"
 7480	wet super-moist sugar bunny	0		Effect: "Chorale of Companionship", Effect Duration: 59, Last Available: "2014-05"
-7481	mirror sweet tooth	0		Last Available: "2014-05", Wiki Name: "sweet tooth"
-7482	mediocre skewed spinning Rompedores de Fantasmas	4	decent	
-7483	smooth upside-down maroon La Fantasma y La Oscuridad	4	awesome	
+7481	mirror sweet tooth	0		Wiki Name: "sweet tooth", Last Available: "2014-05"
+7482	mediocre spinning skewed Rompedores de Fantasmas	4	decent	
+7483	smooth maroon upside-down La Fantasma y La Oscuridad	4	awesome	
 7484	acceptable Fantasma en la M&aacute;quina	3	good	
 7485	loosening powder	0		
 7486	yellow castoreum	0		
@@ -7395,10 +7395,10 @@
 7506	double-paned beefy book	0		Muscle: +10, Cold Resistance: +5
 7507	Tesla cloak	0		MP Regen Min: 7, MP Regen Max: 10
 7508	label	0		
-7509	miniature normal Mornington crescent roll	2	good	
+7509	normal miniature Mornington crescent roll	2	good	
 7510	adjusted super-anodized non-ionized eye shadow	0		Effect: "Work For Hours a Week", Effect Duration: 25
 7511	crumbling wheel	0		
-7512	ionized spinning ghostly poppy	0		Effect: "Motion", Effect Duration: 60
+7512	ionized ghostly spinning poppy	0		Effect: "Motion", Effect Duration: 60
 7513	skewed opium grenade	0		
 7514	cool brainy duonoculars	0		Mysticality: +5, Moxie: +5, Single Equip
 7515	maroon plastic rock	0		
@@ -7418,15 +7418,15 @@
 7529	delicious loaf of alien bread	4	awesome	Last Available: "2014-05"
 7530	adequate grilled cheese sandwich	4	good	Last Available: "2014-05"
 7531	compressed squat alien protein powder	1	awesome	Last Available: "2014-05"
-7532	acceptable weak wobbly rocket fuel	2	good	Last Available: "2014-05"
-7533	squat twirling alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
+7532	weak acceptable wobbly rocket fuel	2	good	Last Available: "2014-05"
+7533	twirling squat alien source code printout	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7534	alien source code printout (used)	0		Skill: "Alien Source Code", Last Available: "2014-05"
 7535	artisanal stealth bomber	3	EPIC	Last Available: "2014-05"
 7536	space beast fur	0		Last Available: "2014-05"
 7537	twitching space egg	0		Last Available: "2014-05"
 7538	ramekin of space nuts	0		Familiar Weight: +5, Last Available: "2014-05"
-7539	narrow zippy space beast fur hat	0		Initiative: +20, Familiar Effect: "1xVolley", Last Available: "2014-05"
-7540	flame-wreathed space beast fur pants	0		Hot Spell Damage: +10, Familiar Effect: "1xVolley", Last Available: "2014-05"
+7539	narrow zippy space beast fur hat	0		Initiative: +20, Last Available: "2014-05", Familiar Effect: "1xVolley"
+7540	flame-wreathed space beast fur pants	0		Hot Spell Damage: +10, Last Available: "2014-05", Familiar Effect: "1xVolley"
 7541	space beast fur whip of the wise owl	0		Mysticality: +20, Last Available: "2014-05"
 7542	space invader	0		Last Available: "2014-05"
 7543	squat MacGyver's smartaleck's space heater	0		Moxie Percent: +30, Maximum MP: +100, Conditional Skill (Equipped): "Heat Space", Last Available: "2014-05"
@@ -7447,11 +7447,11 @@
 7558	mediocre enchanted wine	4	decent	Effect: "Angry Bone", Effect Duration: 45
 7559	polymerized gummi turtle	0		Effect: "Human-Beast Hybrid", Effect Duration: 12
 7560	cyan turtle-shaped rock	0		
-7561	polymerized jittery gray giraffe-necked turtle	0		Effect: "Insatiable Hunger", Effect Duration: 18
+7561	polymerized gray jittery giraffe-necked turtle	0		Effect: "Insatiable Hunger", Effect Duration: 18
 7562	double-activated ghostly olive musk turtle	0		Effect: "Inigo's Incantation of Inspiration", Effect Duration: 55
 7563	magnetized non-wet warmed bouncing programmable turtle	0		Effect: "Macho Profundo", Effect Duration: 59
 7564	polymerized mocking turtle	0		Effect: "Outer Wolf&trade;", Effect Duration: 54
-7565	yummy diet ham steak	1	awesome	
+7565	diet yummy ham steak	1	awesome	
 7566	vibrating time-twitching toolbelt	0		Maximum MP Percent: +10, Single Equip, Free Pull
 7567	bouncing Chroner	0		
 7568	toasty Annie Oakley's vibrating Time Lord Badge of Honor	0		Maximum MP Percent: +10, Critical Hit Percent: +20, Hot Damage: +5
@@ -7475,7 +7475,7 @@
 7586	helix fossil	0		
 7587	S.S. Ticket	0		Familiar Weight: +5
 7588	wobbly Clan speakeasy	0		Free Pull, Last Available: "2014-07"
-7589	tolerable irresponsibly strong cyan glass of &quot;milk&quot;	8	good	Last Available: "2014-07"
+7589	irresponsibly strong tolerable cyan glass of &quot;milk&quot;	8	good	Last Available: "2014-07"
 7590	tolerable cup of &quot;tea&quot;	3	good	Last Available: "2014-07"
 7591	distilled delicious thermos of &quot;whiskey&quot;	5	awesome	Last Available: "2014-07"
 7592	perfectly mixed watered-down Lucky Lindy	2	super ultra EPIC	Last Available: "2014-07"
@@ -7491,7 +7491,7 @@
 7602	magnetized colloidal non-ionized olive Fitspiration&trade; poster	0		Effect: "The Q Is Talking To You", Effect Duration: 18
 7603	liquefied colloidal neckbeard	0		Effect: "Berry Statistical", Effect Duration: 55
 7604	energized double-altered twirling artisanal hand-squeezed wheatgrass juice	0		Effect: "Cravin' for a Ravin'", Effect Duration: 16
-7605	chilled moist irradiated wobbly lime green punk patch	0		Effect: "Got Your Boots On", Effect Duration: 24
+7605	chilled moist irradiated lime green wobbly punk patch	0		Effect: "Got Your Boots On", Effect Duration: 24
 7606	electrified tumbling steampunk potion	0		Effect: "Turtle Power", Effect Duration: 50
 7607	tarnished quadruple-diffused chilled vial of swamp vapors	0		Effect: "Patience of the Tortoise", Effect Duration: 37
 7608	unsweetened red turtle mud	0		Effect: "Extra-Sharp Weapon", Effect Duration: 46
@@ -7513,7 +7513,7 @@
 7624	enhanced triple-chilled improved lynyrd skinner toothblack	0		Effect: "Danish Cunning", Effect Duration: 29
 7625	irradiated flask of rainwater	0		Effect: "Gamer Rage", Effect Duration: 30
 7626	adjusted oyster badge	0		Effect: "Inner Dog", Effect Duration: 34
-7627	irradiated blurry tumbling plastic Jefferson wings	0		Effect: "Improprie Tea", Effect Duration: 14
+7627	irradiated tumbling blurry plastic Jefferson wings	0		Effect: "Improprie Tea", Effect Duration: 14
 7628	pickled boiled mirror dancing fan	0		Effect: "Slimy Flavor", Effect Duration: 45
 7629	diffused altered green page of the Necrohobocon	0		Effect: "Well-Lubed", Effect Duration: 15
 7630	wet magic powder	0		Effect: "Memory of Attractiveness", Effect Duration: 62
@@ -7592,14 +7592,14 @@
 7703	LCD game: Food Eater	0		Last Available: "2014-08"
 7704	LCD game: Garbage River	0		Last Available: "2014-08"
 7705	LCD game: Burger Belt	0		Last Available: "2014-08"
-7706	cyan The Confiscator's Grimoire	0		Free Pull, Skill: "Summon Confiscated Things", Last Available: "2014-08"
+7706	cyan The Confiscator's Grimoire	0		Free Pull, Last Available: "2014-08", Skill: "Summon Confiscated Things"
 7707	aerosolized tumbling rubber nubbin	0		Effect: "Dweeby", Effect Duration: 56, Last Available: "2014-08"
 7708	miser's rubber cape of James Dean	0		Experience (Moxie): +3, Meat Drop: +10, Last Available: "2014-08"
 7709	blurry teal perfumed sizzling chaotic dangerous Thor's Pliers	0		Weapon Damage: +10, Spell Critical Percent: +10, Hot Damage: +10, Stench Resistance: +5, Attacks Can't Miss, Single Equip, Softcore Only, Conditional Skill (Equipped): "Ply Reality", Last Available: "2014-09"
 7710	pickled quantum candy UFOs	0		Effect: "Shredding, Sweating", Effect Duration: 25
 7711	Jim Carey's sharpshooter's water wings for babies	0		Critical Hit Percent: +10, Monster Level: +25
-7712	wobbly beautiful rainbow	0		Skill: "Belch The Rainbow", Last Available: "2014-11"
-7713	bite-sized bland Strix stix	1	decent	
+7712	wobbly beautiful rainbow	0		Last Available: "2014-11", Skill: "Belch The Rainbow"
+7713	bland bite-sized Strix stix	1	decent	
 7714	veiny healthy fortified vampire pellet	0		Damage Absorption: +60, Maximum HP Percent: +20, Maximum HP: +10
 7715	acceptable non-aged vinegar	3	good	
 7716	fortified unsanitized scalpel	0		Damage Absorption: +60
@@ -7639,14 +7639,14 @@
 7750	Xiblaxian 5D printer	0		Last Available: "2014-09"
 7751	red narrow Xiblaxian holo-bowtie	0		Familiar Weight: +5, Last Available: "2014-09"
 7752	squat gray Xiblaxian xeno-detection goggles of the sweet-tooth	0		Candy Drop: +100, Single Equip, Last Available: "2014-09"
-7753	Annie Oakley's shellacked Xiblaxian stealth cowl	0		Damage Reduction: 7, Critical Hit Percent: +20, Familiar Effect: "spooky atk, cap 25", Last Available: "2014-09"
+7753	Annie Oakley's shellacked Xiblaxian stealth cowl	0		Damage Reduction: 7, Critical Hit Percent: +20, Last Available: "2014-09", Familiar Effect: "spooky atk, cap 25"
 7754	lightning-fast weightlifter's Xiblaxian stealth trousers	0		Muscle: +15, Initiative: +40, Last Available: "2014-09"
 7755	blurry hale wicked Xiblaxian stealth vest	0		Spell Damage: +5, Maximum HP: +20, Last Available: "2014-09"
 7756	diet flavorless Xiblaxian ultraburrito	1	decent	Last Available: "2014-09"
 7757	watered-down perfectly mixed Xiblaxian space-whiskey	2	super ultra mega EPIC	Last Available: "2014-09"
 7758	Xiblaxian residence-cube	0		Last Available: "2014-09"
 7759	ionized They liver	0		Effect: "Surreally Buff", Effect Duration: 57, Last Available: "2014-09"
-7760	yummy bite-sized They liver popsicle	1	awesome	Last Available: "2014-09"
+7760	bite-sized yummy They liver popsicle	1	awesome	Last Available: "2014-09"
 7761	holo-tank	0		Last Available: "2014-09"
 7762	holo-bomber	0		Last Available: "2014-09"
 7763	lime green tumbling holo-platoon	0		Last Available: "2014-09"
@@ -7657,7 +7657,7 @@
 7768	mirror one-day ticket to Conspiracy Island	0		Last Available: "2014-10"
 7769	Coinspiracy	0		Last Available: "2014-10"
 7770	sharpshooter's MacGyver's Da Vinci's Personal Ventilation Unit	0		Experience (Mysticality): +5, Maximum MP: +100, Critical Hit Percent: +10, Single Equip, Last Available: "2014-10"
-7771	unsweetened enhanced yellow shaking the most dangerous bait	0		Effect: "Scorpio Rising", Effect Duration: 16, Last Available: "2014-10"
+7771	unsweetened enhanced shaking yellow the most dangerous bait	0		Effect: "Scorpio Rising", Effect Duration: 16, Last Available: "2014-10"
 7772	bland &quot;meat&quot; stick	4	decent	Last Available: "2014-10"
 7773	altered transdermal smoke patch	1	awesome	Last Available: "2014-10"
 7774	specialty ammo bandolier	0		Last Available: "2014-10"
@@ -7669,8 +7669,8 @@
 7780	inspector's lion tamer's thinker's heavy-duty clipboard	0		Mysticality: +10, Experience (familiar): +2, Item Drop: +15, Damage Reduction: 8, Last Available: "2014-10"
 7781	prompt ribald educational battery-powered drill of the cheetah	0		Experience: +1, Sleaze Damage: +10, Initiative: +60, Adventures: +3, Last Available: "2014-10"
 7782	bland cyan limp broccoli	4	decent	Last Available: "2014-10"
-7783	smelly beefcake's hat of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Stench Spell Damage: +10, Familiar Effect: "2xFairy, 0.5xPotato, cap 31", Last Available: "2014-10"
-7784	frozen ionized quantum blinking fuchsia monkey barf	0		Effect: "Unusual Fashion Sense", Effect Duration: 54, Last Available: "2014-10"
+7783	smelly beefcake's hat of the dark arts	0		Muscle: +25, Spell Damage Percent: +100, Stench Spell Damage: +10, Last Available: "2014-10", Familiar Effect: "2xFairy, 0.5xPotato, cap 31"
+7784	frozen ionized quantum fuchsia blinking monkey barf	0		Effect: "Unusual Fashion Sense", Effect Duration: 54, Last Available: "2014-10"
 7785	diffused galvanized super-wet spinning candy	0		Effect: "Cuts Like a Buttered Knife", Effect Duration: 33, Last Available: "2014-10"
 7786	pulsating blinking Annie Oakley's personal trainer's Samson's jangly bracelet	0		Experience (Muscle): +5, Experience Percent (Muscle): +10, Critical Hit Percent: +20, Last Available: "2014-10"
 7787	cuddly teddy bear of horror	0		Spooky Spell Damage: +25, Conditional Skill (Equipped): "Overload Teddy Bear", Last Available: "2014-10"
@@ -7700,7 +7700,7 @@
 7811	viral DNA	0		
 7812	tarnished bottlecap	0		
 7813	tasty seared dino steak	3	awesome	
-7814	practically non-alcoholic mediocre bottle of drinkin' gas	1	decent	
+7814	mediocre practically non-alcoholic bottle of drinkin' gas	1	decent	
 7815	handful of napalm	0		
 7816	blinking dove DNA	0		
 7817	gelatinous meat mass	0		
@@ -7713,7 +7713,7 @@
 7824	greasy lion tamer's educational iShield	0		Experience: +1, Experience (familiar): +2, Sleaze Spell Damage: +10, Damage Reduction: 6
 7825	mirror hardy hardened earbuds of dire peril	0		Weapon Damage: +20, Damage Reduction: 3, Maximum HP: +50, Single Equip
 7826	huge spinning chaotic Da Vinci's iFlail of vim and vigor	0		Experience (Mysticality): +5, Maximum HP Percent: +50, Spell Critical Percent: +10
-7827	stale gigantic green unidentifiable dried fruit	6	decent	
+7827	gigantic stale green unidentifiable dried fruit	6	decent	
 7828	hand-crafted lime green flat cider	4	EPIC	
 7829	flame-wreathed trench lighter of the bloodbag of temperance	0		Maximum HP: +100, Hot Spell Damage: +10, Sleaze Resistance: +5, Last Available: "2014-10"
 7830	moist pickled experimental serum P-00	0		Effect: "Yuletide Mutations", Effect Duration: 32, Last Available: "2014-10"
@@ -7734,7 +7734,7 @@
 7845	moist teal jittery perl necklace	0		Effect: "Broken Bone Nubs", Effect Duration: 13, Last Available: "2014-12"
 7846	quantum colloidal tumbling Fudge Fiber Armor Plating	0		Effect: "Icy Demeanor", Effect Duration: 29, Last Available: "2014-12"
 7847	triple-boiled improved ruby on canes	0		Effect: "Well-Swabbed Ear", Effect Duration: 12, Last Available: "2014-12"
-7848	miniature moldy petit fortran	2	crappy	Last Available: "2014-12"
+7848	moldy miniature petit fortran	2	crappy	Last Available: "2014-12"
 7849	delicious java cookie	4	awesome	Last Available: "2014-12"
 7850	thick stale cookie cookie	5	decent	Last Available: "2014-12"
 7851	pulsating experienced plastic exo-suited miner	0		Experience: +2, Last Available: "2014-12"
@@ -7743,8 +7743,8 @@
 7854	wicked plastic Crimbot	0		Spell Damage: +5, Last Available: "2014-12"
 7855	bouncing cyan plastic Crimbomega of the businessman	0		Meat Drop: +50, Last Available: "2014-12"
 7856	ionized frozen tumbling flask of mining oil	0		Effect: "Intimidating Mien", Effect Duration: 49, Last Available: "2014-12"
-7857	huge baleful radiation-resistant helmet	0		Spell Damage: +25, Familiar Effect: "1xFairy, cap 12", Last Available: "2014-12"
-7858	servo-assisted exo-pants of the brazier	0		Hot Spell Damage: +25, Familiar Effect: "cold atk, 1xPotato, cap 12", Last Available: "2014-12"
+7857	huge baleful radiation-resistant helmet	0		Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "1xFairy, cap 12"
+7858	servo-assisted exo-pants of the brazier	0		Hot Spell Damage: +25, Last Available: "2014-12", Familiar Effect: "cold atk, 1xPotato, cap 12"
 7859	tumbling lard-coated flame-wreathed high-energy mining laser	0		Hot Spell Damage: +10, Sleaze Spell Damage: +25, Last Available: "2014-12"
 7860	teal peppermint tailings	0		Last Available: "2014-12"
 7861	nugget of Crimbonium	0		Last Available: "2014-12"
@@ -7752,7 +7752,7 @@
 7863	Crimbonium fuel rod	0		Last Available: "2014-12"
 7864	Petite Paintbrush	0		Adventures: +1
 7865	Crimbot schematic: Gun Face	0		Last Available: "2014-12"
-7866	blue blinking Crimbot schematic: Big Head	0		Last Available: "2014-12"
+7866	blinking blue Crimbot schematic: Big Head	0		Last Available: "2014-12"
 7867	Crimbot schematic: Security Chassis	0		Last Available: "2014-12"
 7868	Crimbot schematic: Military Chassis	0		Last Available: "2014-12"
 7869	gray Crimbot schematic: Crab Core	0		Last Available: "2014-12"
@@ -7798,7 +7798,7 @@
 7909	huge recovered elf wallet	0		Last Available: "2014-12"
 7910	spinning recovered elf pocketwatch	0		Last Available: "2014-12"
 7911	recovered elf photo album	0		Last Available: "2014-12"
-7912	purple tumbling recovered elf smartphone	0		Last Available: "2014-12"
+7912	tumbling purple recovered elf smartphone	0		Last Available: "2014-12"
 7913	prompt medical-grade hardy Size XI Wizard's Robe	0		Maximum HP: +50, Adventures: +3, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2014-09"
 7914	energized chilled polymerized blurry Bit O' Quail Spleen	0		Effect: "Nigh-Invincible", Effect Duration: 64
 7915	boiled mirror Take Eleven Bar	0		Effect: "Nigh-Invincible", Effect Duration: 22
@@ -7808,8 +7808,8 @@
 7919	warmed tumbling Big Punk	0		Effect: "Hagnk's Gratitude", Effect Duration: 47
 7920	fist turkey outline	0		Free Pull, Last Available: "2014-11"
 7921	turkey knuckles	0		Familiar Weight: +10, Last Available: "2014-11"
-7922	hand-crafted irresponsibly strong Friendly Turkey	7	EPIC	Last Available: "2014-11"
-7923	practically non-alcoholic smooth Agitated Turkey	1	awesome	Last Available: "2014-11"
+7922	irresponsibly strong hand-crafted Friendly Turkey	7	EPIC	Last Available: "2014-11"
+7923	smooth practically non-alcoholic Agitated Turkey	1	awesome	Last Available: "2014-11"
 7924	tolerable blurry Ambitious Turkey	3	good	Last Available: "2014-11"
 7925	normal twirling neutron lollipop	4	good	Last Available: "2014-12"
 7926	watered-down delicious bouncing fuchsia gamma nog	2	awesome	Last Available: "2014-12"
@@ -7818,7 +7818,7 @@
 7936	picky tweezers	0		Last Available: "2015-02"
 7937	teal Crimbo Credit	0		
 7938	denatured single atom	1	good	Effect: "Pyromania", Effect Duration: 35, Last Available: "2015-02"
-7939	shaking wobbly Time Cape	0		Last Available: "2014-11"
+7939	wobbly shaking Time Cape	0		Last Available: "2014-11"
 7940	squat yellow Time Cloak	0		Last Available: "2014-11"
 7941	ghostly sleeve deuce	0		
 7942	pocket ace	0		
@@ -7831,14 +7831,14 @@
 7949	lousy glass of herbal tequila	4	decent	
 7950	minin' dynamite	0		
 7951	fuchsia coward's steel-toed plaid cowboy hat	0		Damage Reduction: 9, Monster Level: -20, Familiar Effect: "2xLep, 1xBarrr, cap 25"
-7952	bouncing twirling lasso	0		
+7952	twirling bouncing lasso	0		
 7953	horrifying occult rusted-out shootin' iron of extreme caution	0		Spell Damage Percent: +25, Monster Level: -25, Spooky Damage: +25
 7954	rattler rattle	0		
-7955	ghostly bouncing bag of money	0		
+7955	bouncing ghostly bag of money	0		
 7956	Crimbo sapling	0		Free Pull, Last Available: "2014-12"
 7957	huge even more tinsel	0		Familiar Weight: +5
 7958	squat box of Crimbo decorations	0		
-7959	squat blinking letter to Ed the Undying	0		
+7959	blinking squat letter to Ed the Undying	0		
 7960	copy of a jerk adventurer's father's diary	0		
 7961	pulsating banded grievous boxer's Staff of Ed of the detective	0		Muscle Percent: +10, Weapon Damage Percent: +50, Damage Absorption: +100, Item Drop: +20
 7962	Eye of Ed	0		
@@ -7849,10 +7849,10 @@
 7967	World's Best Adventurer sash of the overflowing toilet	0		Stench Spell Damage: +50
 7968	shaking cyan topiary nugglet	0		
 7969	beehive	0		
-7970	tumbling squat boning knife	0		
+7970	squat tumbling boning knife	0		
 7971	Aggressive Carrot	0		Free Pull
 7972	mixed mummified fig	1	awesome	
-7973	vaporized skewed spinning mummified loaf of bread	1	good	
+7973	vaporized spinning skewed mummified loaf of bread	1	good	
 7974	altered jittery mummified beef haunch	1	decent	Effect: "Wintergreen Warmongery", Effect Duration: 45
 7975	linen bandages	0		
 7976	cotton bandages	0		
@@ -7881,14 +7881,14 @@
 7999	magnetized pressed shaking gray choco-Crimbot	0		Effect: "Crud&eacute;", Effect Duration: 25, Last Available: "2014-12"
 8000	tarnished smart watch	0		Effect: "Your Interest is Peaked", Effect Duration: 68, Last Available: "2014-12"
 8001	dry ghostly augmented-reality shades	0		Effect: "Larger", Effect Duration: 60, Last Available: "2014-12"
-8002	blurry Jack Frost's toy Crimbot mega face	0		Cold Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Familiar Effect: "hot atk, cap 12", Last Available: "2014-12"
+8002	blurry Jack Frost's toy Crimbot mega face	0		Cold Spell Damage: +50, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "LIGHT", Last Available: "2014-12", Familiar Effect: "hot atk, cap 12"
 8003	lime green studded toy Crimbot power glove	0		Damage Absorption: +80, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "ZAP", Last Available: "2014-12"
 8004	toy Crimbot super fist of temperance	0		Sleaze Resistance: +5, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "POW", Last Available: "2014-12"
 8005	mansplainer's toy Crimbot rocket legs	0		Monster Level: +15, Crimbot Outfit Power: +1, Conditional Skill (Equipped): "BURN", Last Available: "2014-12"
 8006	super-tarnished Crimbot battery	0		Effect: "Leash of Linguini", Effect Duration: 42, Last Available: "2014-12"
 8007	Crimbot ROM: Rapid Prototyping	0		Skill: "Rapid Prototyping", Last Available: "2014-12"
 8008	Crimbot ROM: Mathematical Precision	0		Skill: "Mathematical Precision", Last Available: "2014-12"
-8009	squat teal Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
+8009	teal squat Crimbot ROM: Ruthless Efficiency	0		Skill: "Ruthless Efficiency", Last Available: "2014-12"
 8010	Mini-Crimbot crate	0		Last Available: "2014-12"
 8011	heavy-duty Crimbot aerial	0		Familiar Weight: +5, Last Available: "2014-12"
 8012	twirling frightening careful occult Crimbomega drive chain	0		Spell Damage Percent: +25, Monster Level: -10, Spooky Damage: +5, Crimbot Outfit Power: +1, Single Equip, Conditional Skill (Equipped): "LUBE", Last Available: "2014-12"
@@ -7952,9 +7952,9 @@
 8071	warehouse inventory page	0		
 8072	bouncing janitor sponge	0		
 8073	narrow Spelunker of Fortune	0		Skill: "Speluck", Last Available: "2015-12"
-8074	mirror ribald scorching slick Spelunker's fedora	0		Moxie: +10, Hot Damage: +25, Sleaze Damage: +10, Familiar Effect: "atk, 1xLep, cap 25", Last Available: "2015-12"
+8074	mirror ribald scorching slick Spelunker's fedora	0		Moxie: +10, Hot Damage: +25, Sleaze Damage: +10, Last Available: "2015-12", Familiar Effect: "atk, 1xLep, cap 25"
 8075	sinister savvy beefy Spelunker's whip	0		Muscle: +10, Mysticality Percent: +20, Spell Damage: +10, Last Available: "2015-12"
-8076	blurry aromatic Lo Pan's Spelunker's khakis of Gandalf	0		Spell Critical Percent: 50, Stench Resistance: +1, Familiar Effect: "1.5xVolley, cap 25", Last Available: "2015-12"
+8076	blurry aromatic Lo Pan's Spelunker's khakis of Gandalf	0		Spell Critical Percent: 50, Stench Resistance: +1, Last Available: "2015-12", Familiar Effect: "1.5xVolley, cap 25"
 8077	Spelunker's Guild prize sack	0		Last Available: "2015-12"
 8084	LOLmec statuette	0		Last Available: "2015-12"
 8085	Spelunker of Fortune (used)	0		Skill: "Speluck"
@@ -7962,7 +7962,7 @@
 8087	purple Thwaitgold scarab beetle statuette	0		
 8088	mirror jewel	0		
 8089	blue headless sparrow	0		
-8090	huge yellow twirling mangled squirrel	0		
+8090	twirling huge yellow mangled squirrel	0		
 8091	twirling rat carcass	0		
 8092	toasty electrified wicker kickers	0		Hot Damage: +5, MP Regen Min: 3, MP Regen Max: 5, Single Equip, Last Available: "2016-12"
 8093	greedy medical-grade wicker slicker	0		Meat Drop: +20, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2016-12"
@@ -8005,7 +8005,7 @@
 8130	perfumed ruddy fiberglass frock	0		Maximum HP Percent: +40, Stench Resistance: +5, Last Available: "2018-12"
 8131	green mirror stanky fiberglass fingerguard of wisdom	0		Mysticality: +15, Stench Spell Damage: +25, Single Equip, Last Available: "2018-12"
 8132	healthy fiberglass fedora of Gandalf	0		Maximum HP Percent: +20, Spell Critical Percent: +20, Last Available: "2018-12"
-8133	diluted bouncing gray fiberglass fibers	1		Last Available: "2018-12"
+8133	diluted gray bouncing fiberglass fibers	1		Last Available: "2018-12"
 8134	bottle of lovebug pheromones	0		Free Pull
 8135	winged yeti fur	0		
 8136	talisman of Renenutet	0		
@@ -8042,7 +8042,7 @@
 8168	jittery glob of icing	0		
 8169	non-aerosolized ginger snaps	0		Effect: "Fireproof Lips", Effect Duration: 38
 8170	unsweetened blue mostly-broken sunglasses	0		Effect: "You Know When to Walk Away", Effect Duration: 60
-8171	mediocre weak unflavored wine cooler	2	decent	
+8171	weak mediocre unflavored wine cooler	2	decent	
 8172	carton of snake milk	1	EPIC	
 8173	wobbly vibrating sewer snake	0		Maximum MP Percent: +10
 8174	low-calorie spoiled blinking pigeon egg	1	crappy	
@@ -8056,22 +8056,22 @@
 8182	Map to Kokomo	0		Free Pull, Skill: "Summon Kokomo Resort Pass"
 8183	bouncing narrow experienced bread basket	0		Experience: +2
 8184	tumbling Ed the Undying exhibit crate	0		
-8185	Sherlock's Jeselnik's The Crown of Ed the Undying	0		Item Drop: +25, Softcore Only, Familiar Effect: "spooky atk, 1.5xVolley, cap 25", Last Available: "2015-03"
+8185	Sherlock's Jeselnik's The Crown of Ed the Undying	0		Item Drop: +25, Softcore Only, Last Available: "2015-03", Familiar Effect: "spooky atk, 1.5xVolley, cap 25"
 8186	Doc Galaktik's Invigorating Tonic	0		
 8187	blue map to a hidden booze cache	0		
-8188	practically non-alcoholic special drinkable Cherrytastrophe wine cooler	1	good	Effect: "Weird Flavor", Effect Duration: 30
-8189	bad watered-down red Radberry Rip wine cooler	2	decent	
+8188	special practically non-alcoholic drinkable Cherrytastrophe wine cooler	1	good	Effect: "Weird Flavor", Effect Duration: 30
+8189	watered-down bad red Radberry Rip wine cooler	2	decent	
 8190	perfectly mixed weak Orangemageddon wine cooler	2	EPIC	
 8191	lousy Breakfast Blast wine cooler	4	decent	
 8192	perfectly mixed fuchsia Citrus Crush wine cooler	3	EPIC	
 8193	flavorless half-sized plain bagel	2	decent	
 8194	spoiled snack-sized glob of cream cheese	2	crappy	
-8195	massive bland loaf of soda bread	10	decent	
-8196	bland bite-sized acceptable bagel	1	decent	
+8195	bland massive loaf of soda bread	10	decent	
+8196	bite-sized bland acceptable bagel	1	decent	
 8197	bland snack-sized standard-issue cupcake	2	decent	
 8198	big rotten cyan ultra-deluxe cupcake	5	crappy	
 8199	hypnotic breadcrumbs	0		
-8200	stale special squat popular tart	4	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 45
+8200	special stale squat popular tart	4	decent	Effect: "Flame-Retardant Trousers", Effect Duration: 45
 8201	no-handed pie	0		
 8202	liquefied Doc Galaktik's Vitality Serum	0		Effect: "Sugar Smacks", Effect Duration: 47
 8203	airplane charter: Dinseylandfill	0		Free Pull, Last Available: "2015-04"
@@ -8092,7 +8092,7 @@
 8218	toxic globule	0		Last Available: "2015-04"
 8219	decent special tiny toxo	1	good	Effect: "Sensation", Effect Duration: 30, Last Available: "2015-04"
 8220	weak mediocre ghostly Lemonade-235	2	decent	Last Available: "2015-04"
-8221	padded isotophat of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Familiar Effect: "stench atk, cap 25", Last Available: "2015-04"
+8221	padded isotophat of the brute	0		Muscle Percent: +30, Damage Absorption: +20, Last Available: "2015-04", Familiar Effect: "stench atk, cap 25"
 8222	narrow fortified educational Three Mile Island shorts	0		Experience: +1, Damage Absorption: +60, Last Available: "2015-04"
 8223	flame-retardant Jack Frost's toxic mop	0		Cold Spell Damage: +50, Hot Resistance: +1, Last Available: "2015-04"
 8224	blurry inert sludgepuppy	0		Last Available: "2015-04"
@@ -8118,7 +8118,7 @@
 8244	medical-grade lube-shoes	0		HP Regen Min: 7, HP Regen Max: 10, Last Available: "2015-04"
 8245	trash net	0		Last Available: "2015-04"
 8246	sharpshooter's Oprah's Samson's Dinsey mascot mask	0		Experience (Muscle): +5, Maximum MP Percent: +50, Critical Hit Percent: +10, Last Available: "2015-04"
-8247	spoiled miniature maroon Dinsey food-cone	2	crappy	Last Available: "2015-04"
+8247	miniature spoiled maroon Dinsey food-cone	2	crappy	Last Available: "2015-04"
 8248	hand-crafted Dinsey Whinskey	3	EPIC	Last Available: "2015-04"
 8249	concentrated Dinsey face paint	0		Effect: "Greasy Flavor", Effect Duration: 16, Last Available: "2015-04"
 8250	maroon squat jittery nippy fannypack of the overflowing toilet	0		Cold Damage: +10, Stench Spell Damage: +50, Last Available: "2015-04"
@@ -8128,7 +8128,7 @@
 8254	jittery Trash, a Memoir	0		Skill: "Garbage Nova", Last Available: "2015-04"
 8255	Dinsey Maintenance Manual	0		Skill: "Dinsey Operations Expert", Last Available: "2015-04"
 8256	teal Dinsey tattoo kit	0		Last Available: "2015-04"
-8257	extra-unsweetened maroon twirling nasty gum	0		Effect: "Spooky Hands", Effect Duration: 36
+8257	extra-unsweetened twirling maroon nasty gum	0		Effect: "Spooky Hands", Effect Duration: 36
 8258	narrow Wart Dinsey: An Afterlife	0		Skill: "Rotten Memories"
 8259	jittery The Lot's engagement ring of the boozehound	0		Booze Drop: +100, Conditional Skill (Equipped): "Propose To Your Opponent"
 8260	Mayo Clinic	0		Last Available: "2015-05"
@@ -8141,7 +8141,7 @@
 8267	manspreader's sphygmayomanometer	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2015-05"
 8268	huge tomayohawk-style reflex hammer	0		Lasts Until Rollover, Last Available: "2015-05"
 8269	mayo lance	0		Lasts Until Rollover, Last Available: "2015-05"
-8270	rotten snack-sized olive huge unappetizing mayolus	2	crappy	Last Available: "2015-05"
+8270	snack-sized rotten huge olive unappetizing mayolus	2	crappy	Last Available: "2015-05"
 8271	moldy snack-sized uninteresting mayolus	2	crappy	Last Available: "2015-05"
 8272	bland acceptable mayolus	3	decent	Last Available: "2015-05"
 8273	decent immense enticing mayolus	9	good	Last Available: "2015-05"
@@ -8173,7 +8173,7 @@
 8299	pixel coin	0		Last Available: "2015-06"
 8300	pickled oxidized power pill	0		Effect: "Sugary Tongue", Effect Duration: 66, Last Available: "2015-06"
 8301	magnetized activated skewed pixel star	0		Effect: "Rampage!", Effect Duration: 49, Last Available: "2015-06"
-8302	bland miniature pixel banana	2	decent	Last Available: "2015-06"
+8302	miniature bland pixel banana	2	decent	Last Available: "2015-06"
 8303	drinkable yellow pixel beer	3	good	Last Available: "2015-06"
 8304	puck with a bow on it	0		Free Pull, Last Available: "2015-06"
 8305	wobbly pumps	0		Last Available: "2015-06"
@@ -8194,7 +8194,7 @@
 8320	colloidal mirror one glove	0		Effect: "Fishily Speeding", Effect Duration: 12
 8321	dry deionized glove	0		Effect: "Pronounced Potency", Effect Duration: 65
 8322	vacuum-sealed energized handful of fire	0		Effect: "Took Eleven", Effect Duration: 57
-8323	pressed cold-filtered pulsating upside-down Cracklin' Oat Bran	0		Effect: "Twinkly Weapon", Effect Duration: 47
+8323	pressed cold-filtered upside-down pulsating Cracklin' Oat Bran	0		Effect: "Twinkly Weapon", Effect Duration: 47
 8324	corrupted magnetized quadruple-pressed mirror disposable lighter	0		Effect: "Anytwo Five Elevenis?", Effect Duration: 51
 8325	diffused coal contact lenses	0		Effect: "Retrograde Relaxation", Effect Duration: 53
 8326	tarnished narrow conjured ice cream	0		Effect: "Bananas!", Effect Duration: 26
@@ -8212,12 +8212,12 @@
 8338	non-unsweetened energized ghostly Leonard's glasses	0		Effect: "Wise Spirit", Effect Duration: 45
 8339	unsweetened vacuum-sealed galvanized warehouse walkie-talkie	0		Effect: "Mitre Cut", Effect Duration: 49
 8340	ionized triple-oxidized shaking janitor's mop	0		Effect: "Scorpio Rising", Effect Duration: 19
-8341	corrupted bouncing maroon ghostly warehouse clerk's glasses	0		Effect: "Crimbo Flavor", Effect Duration: 31
+8341	corrupted maroon bouncing ghostly warehouse clerk's glasses	0		Effect: "Crimbo Flavor", Effect Duration: 31
 8342	ionized tarnished twirling baloney rotgut	0		Effect: "Fat Leon's Phat Loot Lyric", Effect Duration: 38
 8343	ionized carton of gaspers	0		Effect: "Goldentongue", Effect Duration: 33
 8344	vacuum-sealed lime green skewed bronze polish	0		Effect: "Macho Profundo", Effect Duration: 56
 8345	frozen super-vacuum-sealed crident	0		Effect: "Berry Experiential", Effect Duration: 56
-8346	energized mirror olive totally sweet mohawk helmet	0		Effect: "Full-Body Tan", Effect Duration: 58
+8346	energized olive mirror totally sweet mohawk helmet	0		Effect: "Full-Body Tan", Effect Duration: 58
 8347	alkaline modified bouncing spray chrome	0		Effect: "Night Vision", Effect Duration: 59
 8348	polymerized nitrogenated filthy monkey head	0		Effect: "'Roids of the Rhinoceros", Effect Duration: 66
 8349	colloidal flattened hand of cards	0		Effect: "Strange Mental Acuity", Effect Duration: 28
@@ -8225,7 +8225,7 @@
 8351	improved wobbly lump of goofball ore	0		Effect: "Oh Hamlet Hamlet Hamlet Hamlet", Effect Duration: 64
 8352	denatured corrupted skeleton beans	0		Effect: "Sharp Weapon", Effect Duration: 49
 8353	Vulcanized purple grimy lab coat	0		Effect: "The Ballad of Richie Thingfinder", Effect Duration: 44
-8354	altered spinning narrow nursery rhyme	0		Effect: "Human-Plant Hybrid", Effect Duration: 26
+8354	altered narrow spinning nursery rhyme	0		Effect: "Human-Plant Hybrid", Effect Duration: 26
 8355	alkaline triple-modified gray iron torso box	0		Effect: "Spooky Flavor", Effect Duration: 26
 8356	wet quadruple-deionized ionized green mercenary headband	0		Effect: "items.enh", Effect Duration: 40
 8357	double-deionized vacuum-sealed radioactive spider venom	0		Effect: "Vitali Tea", Effect Duration: 15
@@ -8235,7 +8235,7 @@
 8361	alkaline child-sized dracula cloak	0		Effect: "Retrograde Relaxation", Effect Duration: 49
 8362	non-chilled devil-summoning hat	0		Effect: "Berry Critical", Effect Duration: 51
 8363	colloidal shopkeeper beard	0		Effect: "Sealed Brain", Effect Duration: 24
-8364	double-cold-filtered jittery ghostly alien autoautopsy kit	0		Effect: "Chlorophyll Flavor", Effect Duration: 62
+8364	double-cold-filtered ghostly jittery alien autoautopsy kit	0		Effect: "Chlorophyll Flavor", Effect Duration: 62
 8365	concentrated adjusted super-wet upside-down novelty fruit hat	0		Effect: "Dances with Tweedles", Effect Duration: 49
 8366	flattened huge invisibility cream	0		Effect: "Unrunnable Face", Effect Duration: 69
 8367	oxidized handful of stubble	0		Effect: "Ready to Snap", Effect Duration: 50
@@ -8248,19 +8248,19 @@
 8374	anodized Vulcanized oxidized narrow drinks tray	0		Effect: "Extra-Thick Blood", Effect Duration: 60
 8375	frozen adjusted irradiated eyebrow lifter	0		Effect: "Less Pervious", Effect Duration: 20
 8376	submarine	0		Last Available: "2015-06"
-8377	huge decent pixel lemon	6	good	Last Available: "2015-06"
+8377	decent huge pixel lemon	6	good	Last Available: "2015-06"
 8378	enchanted tolerable pixel daiquiri	4	good	Effect: "Notably Lovely", Effect Duration: 20, Last Available: "2015-06"
 8379	deionized power pill	0		Effect: "Antsy in your Pantsy", Effect Duration: 40, Last Available: "2015-06"
 8380	extra-concentrated pixel potion	0		Effect: "The Q Is Talking To You", Effect Duration: 42, Last Available: "2015-06"
 8381	lime green Pack of Every Card	0		Free Pull, Last Available: "2015-07"
-8382	ghostly tumbling Deck of Every Card	0		Last Available: "2015-07"
+8382	tumbling ghostly Deck of Every Card	0		Last Available: "2015-07"
 8383	tumbling popular part	0		
 8384	bubblegum heart	0		Last Available: "2015-07"
 8385	blinking cubic zirconia	0		Last Available: "2015-07"
 8386	twirling valuable coin	0		Last Available: "2015-07"
 8387	mana	0		Last Available: "2015-07"
 8388	mana	0		Last Available: "2015-07"
-8389	red pulsating mana	0		Last Available: "2015-07"
+8389	pulsating red mana	0		Last Available: "2015-07"
 8390	mana	0		Last Available: "2015-07"
 8391	tumbling mana	0		Last Available: "2015-07"
 8392	tumbling gift card	0		Last Available: "2015-07"
@@ -8278,19 +8278,19 @@
 8404	1952 Mickey Mantle card	0		Last Available: "2015-07"
 8405	talking spade	0		Free Pull
 8406	narrow savory dry noodles	0		
-8407	fancy stale lime green pestopiary	4	decent	Effect: "Crusty Head", Effect Duration: 50
+8407	stale fancy lime green pestopiary	4	decent	Effect: "Crusty Head", Effect Duration: 50
 8408	polymerized aerosolized ectoplasmic orbs	0		Effect: "Blessing of Charcoatl", Effect Duration: 39
-8409	gigantic stale crudles	7	decent	
-8410	small spoiled agnolotti arboli	2	crappy	
+8409	stale gigantic crudles	7	decent	
+8410	spoiled small agnolotti arboli	2	crappy	
 8411	stale spaghetti with ghost balls	4	decent	
-8412	half-sized bland succulent marrow	2	decent	
-8413	massive spoiled gray salacious crumbs	6	crappy	
-8414	flavorless miniature purple fusilli marrownarrow	2	decent	
+8412	bland half-sized succulent marrow	2	decent	
+8413	spoiled massive gray salacious crumbs	6	crappy	
+8414	miniature flavorless purple fusilli marrownarrow	2	decent	
 8415	rotten small suggestive strozzapreti	2	crappy	
 8416	Mountain Stream gastrique	0		
 8417	rotten Mt. McLargeHuge oyster	3	crappy	
 8418	oyster sauce	0		
-8419	tasty gigantic linguini immondizia bianco	8	awesome	
+8419	gigantic tasty linguini immondizia bianco	8	awesome	
 8420	low-calorie moldy cyan shells a la shellfish	1	crappy	
 8421	Jick's autograph	0		
 8422	high-temperature mining drill	0		Last Available: "2015-08"
@@ -8329,19 +8329,19 @@
 8455	New Age crystal	0		Last Available: "2015-08"
 8456	jittery crystalline light bulb	0		Last Available: "2015-08"
 8457	broken high-temperature mining drill	0		Last Available: "2015-08"
-8458	knitted high-temperature mining mask of extreme caution	0		Monster Level: -25, Cold Resistance: +3, Familiar Effect: "atk, cap 25", Last Available: "2015-08"
+8458	knitted high-temperature mining mask of extreme caution	0		Monster Level: -25, Cold Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk, cap 25"
 8459	auspicious fireproof megaphone of dire peril	0		Weapon Damage: +20, Item Drop: +10, Last Available: "2015-08"
 8460	adequate mineapple	3	good	Last Available: "2015-08"
-8461	practically non-alcoholic hand-crafted Gold Velvet&trade; whiskey	1	EPIC	Last Available: "2015-08"
+8461	hand-crafted practically non-alcoholic Gold Velvet&trade; whiskey	1	EPIC	Last Available: "2015-08"
 8462	SMOOCH soda	1	EPIC	Last Available: "2015-08"
 8463	spoiled smelted roe	3	crappy	Last Available: "2015-08"
-8464	special bad lavawater	3	decent	Effect: "Boon of She-Who-Was", Effect Duration: 50, Last Available: "2015-08"
+8464	bad special lavawater	3	decent	Effect: "Boon of She-Who-Was", Effect Duration: 50, Last Available: "2015-08"
 8465	double-alkaline pulsating basaltamander tongue	0		Effect: "Spooky Flavor", Effect Duration: 39, Last Available: "2015-08"
 8466	family-friendly rosewater-soaked Sinatra's lavalarva	0		Experience (Moxie): +5, Stench Resistance: +3, Sleaze Resistance: +1, Last Available: "2015-08"
 8467	wobbly stanky smelly slick lava balaclava	0		Moxie: +10, Stench Spell Damage: 35, Last Available: "2015-08"
 8468	lime green ghostly Lo Pan's experienced basaltamander buckler of dire peril	0		Experience: +2, Weapon Damage: +20, Spell Critical Percent: +30, Damage Reduction: 15, Last Available: "2015-08"
 8469	polarized lava globs	0		Effect: "Patent Avarice", Effect Duration: 18, Last Available: "2015-08"
-8470	low-calorie toothsome enchanted gooey lava globs	1	awesome	Effect: "Nothing Is Impossible", Effect Duration: 10, Last Available: "2015-08"
+8470	toothsome low-calorie enchanted gooey lava globs	1	awesome	Effect: "Nothing Is Impossible", Effect Duration: 10, Last Available: "2015-08"
 8471	lava-proof pants of the cougar of the detective	0		Moxie: +20, Item Drop: +20, Last Available: "2015-08"
 8472	slick brainy heat-resistant necktie	0		Mysticality: +5, Moxie: +10, Single Equip, Last Available: "2015-08"
 8473	skewed shellacked extremely unsafe smartaleck's heat-resistant gloves	0		Moxie Percent: +30, Weapon Damage Percent: +100, Damage Reduction: 7, Single Equip, Last Available: "2015-08"
@@ -8350,9 +8350,9 @@
 8476	tarnished flattened maroon liquid rhinestones	0		Effect: "Work For Hours a Week", Effect Duration: 17, Last Available: "2015-08"
 8477	adequate yellow disco biscuit	4	good	Last Available: "2015-08"
 8478	hand-crafted Quaatorade&trade;	4	EPIC	Last Available: "2015-08"
-8479	vibrating weightlifter's biker's hat of the overflowing toilet	0		Muscle: +15, Maximum MP Percent: +10, Stench Spell Damage: +50, Familiar Effect: "atk", Last Available: "2015-08"
-8480	double-paned nasty feathered headdress of extreme caution	0		Monster Level: -25, Stench Damage: +5, Cold Resistance: +5, Familiar Effect: "atk, 1xVolley", Last Available: "2015-08"
-8481	fireproof healthy electrician's hardhat of the overflowing toilet	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Hot Resistance: +3, Familiar Effect: "atk", Last Available: "2015-08"
+8479	vibrating weightlifter's biker's hat of the overflowing toilet	0		Muscle: +15, Maximum MP Percent: +10, Stench Spell Damage: +50, Last Available: "2015-08", Familiar Effect: "atk"
+8480	double-paned nasty feathered headdress of extreme caution	0		Monster Level: -25, Stench Damage: +5, Cold Resistance: +5, Last Available: "2015-08", Familiar Effect: "atk, 1xVolley"
+8481	fireproof healthy electrician's hardhat of the overflowing toilet	0		Maximum HP Percent: +20, Stench Spell Damage: +50, Hot Resistance: +3, Last Available: "2015-08", Familiar Effect: "atk"
 8482	Lava Miner's Daughter	0		Skill: "Asbestos Heart", Last Available: "2015-08"
 8483	Psycho From The Heat	0		Skill: "Pyromania", Last Available: "2015-08"
 8484	The Firegate Tapes	0		Skill: "Firegate", Last Available: "2015-08"
@@ -8361,7 +8361,7 @@
 8487	airplane charter: That 70s Volcano	0		Free Pull, Last Available: "2015-08"
 8488	Manual of Numberology	0		Skill: "Calculate the Universe"
 8489	bouncing New Age hurting crystal	0		Last Available: "2015-08"
-8490	teal huge rosewater-soaked smooth velvet pants	0		Stench Resistance: +3, Familiar Effect: "2xVolley, 2xPotato, cap 12", Last Available: "2015-08"
+8490	teal huge rosewater-soaked smooth velvet pants	0		Stench Resistance: +3, Last Available: "2015-08", Familiar Effect: "2xVolley, 2xPotato, cap 12"
 8491	blurry smooth velvet shirt of bravery	0		Spooky Resistance: +5, Last Available: "2015-08"
 8492	mirror censurious smooth velvet hat	0		Sleaze Resistance: +3, Last Available: "2015-08"
 8493	razor-sharp smooth velvet pocket square	0		Weapon Damage Percent: +25, Single Equip, Last Available: "2015-08"
@@ -8391,7 +8391,7 @@
 8517	yellow supercool SMOOCH bracers of the ox	0		Muscle: +20, Moxie Percent: +20, Single Equip, Last Available: "2015-08"
 8518	bouncing shellacked SMOOCH kneepads	0		Damage Reduction: 7, Single Equip, Last Available: "2015-08"
 8519	nasty SMOOCH spaulders	0		Stench Damage: +5, Single Equip, Last Available: "2015-08"
-8520	ghostly reassuring careful SMOOCH codpiece	0		Monster Level: -10, Spooky Resistance: +1, Familiar Effect: "atk, 1xBarrr, cap 20", Last Available: "2015-08"
+8520	ghostly reassuring careful SMOOCH codpiece	0		Monster Level: -10, Spooky Resistance: +1, Last Available: "2015-08", Familiar Effect: "atk, 1xBarrr, cap 20"
 8521	vibrating SMOOCH breastplate	0		Maximum MP Percent: +10, Last Available: "2015-08"
 8522	superduperheated	0		Last Available: "2015-08"
 8523	fused fuse	0		Last Available: "2015-08"
@@ -8400,25 +8400,25 @@
 8526	flavorless pink slime	3	decent	
 8527	olive Devil's Elbow Hot Sauce	0		
 8528	Special&trade; Sauce	0		
-8529	fancy rotten huge mirror shaking devil hair pasta	9	crappy	Effect: "Salsa Satanica", Effect Duration: 45
+8529	huge fancy rotten mirror shaking devil hair pasta	9	crappy	Effect: "Salsa Satanica", Effect Duration: 45
 8530	adequate spagecialetti	4	good	
 8531	Salsa Libre	0		
 8532	good gravy	0		
 8533	illicit fish sauce	0		
-8534	miniature rotten tumbling lime green libertagliatelle	2	crappy	
+8534	miniature rotten lime green tumbling libertagliatelle	2	crappy	
 8535	toothsome snack-sized ghostly turkish mostaccioli	2	awesome	
-8536	decent big linguini of the sea	5	good	
+8536	big decent linguini of the sea	5	good	
 8537	galvanized blurry Hersey&trade; SMOOCH	0		Effect: "Expert Vacationer", Effect Duration: 49
 8539	Alexy sauce	0		
 8540	spinning rainbow sauce	0		
 8541	bouncing drug cocktail sauce	0		
 8542	flavorless fancy Fettris	4	decent	Effect: "Fungal Fortification", Effect Duration: 30
-8543	delicious fancy fusillocybin	4	awesome	Effect: "Super Vision", Effect Duration: 15
+8543	fancy delicious fusillocybin	4	awesome	Effect: "Super Vision", Effect Duration: 15
 8544	immense bland mirror prescription noodles	9	decent	
 8545	distilled blood-drive sticker	1	crappy	
-8546	ionized colloidal jittery jittery olive bag of grain	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 60
+8546	ionized colloidal jittery olive jittery bag of grain	0		Effect: "Don't Step to Your Stepmother", Effect Duration: 60
 8547	aerosolized frozen ghostly pocket maze	0		Effect: "Provocative Perkiness", Effect Duration: 14
-8548	tarnished dry yellow pulsating shady shades	0		Effect: "Slippery Tongue", Effect Duration: 37
+8548	tarnished dry pulsating yellow shady shades	0		Effect: "Slippery Tongue", Effect Duration: 37
 8549	adjusted anodized squeaky toy rose	0		Effect: "Witch Breaded", Effect Duration: 44
 8550	rotten blurry weird gazelle steak	3	crappy	
 8551	spoiled tumbling sausage without a cause	4	crappy	
@@ -8437,7 +8437,7 @@
 8564	shrine to the Barrel god	0		Free Pull, Last Available: "2015-09"
 8565	Jack Frost's hardy barrel lid of Flo-Jo	0		Maximum HP: +50, Cold Spell Damage: +50, Initiative: +100, Damage Reduction: 9, Lasts Until Rollover, Last Available: "2015-09"
 8566	jittery blue grievous barrel hoop earring of Tarzan of courage	0		Experience (Muscle): +3, Weapon Damage Percent: +50, Spooky Resistance: +3, Lasts Until Rollover, Last Available: "2015-09"
-8567	pulsating sizzling Jack Frost's forbidden bankruptcy barrel	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Hot Damage: +10, Lasts Until Rollover, Familiar Effect: "1xPotato, 1xLep, cap 25", Last Available: "2015-09"
+8567	pulsating sizzling Jack Frost's forbidden bankruptcy barrel	0		Spell Damage Percent: +50, Cold Spell Damage: +50, Hot Damage: +10, Lasts Until Rollover, Last Available: "2015-09", Familiar Effect: "1xPotato, 1xLep, cap 25"
 8568	firkin	0		Last Available: "2015-09"
 8569	squat normal barrel	0		Last Available: "2015-09"
 8570	tun	0		Last Available: "2015-09"
@@ -8451,7 +8451,7 @@
 8578	acceptable narrow bottle of Amontillado	3	good	Last Available: "2015-09"
 8579	drinkable lime green barrel-aged martini	3	good	Last Available: "2015-09"
 8580	moldy barrel pickle	4	crappy	Last Available: "2015-09"
-8581	toothsome low-calorie blinking barrel cracker	1	awesome	Last Available: "2015-09"
+8581	low-calorie toothsome blinking barrel cracker	1	awesome	Last Available: "2015-09"
 8582	vaporized pulsating pulsating vibrating mushroom	1	awesome	Last Available: "2015-09"
 8583	dried huge mushroom	1	decent	Effect: "Hoity Toity", Effect Duration: 15, Last Available: "2015-09"
 8584	Sinatra's KoL Con 12-gauge	0		Experience (Moxie): +5, Last Available: "2015-09"
@@ -8459,7 +8459,7 @@
 8586	censurious barrel gun	0		Sleaze Resistance: +3, Last Available: "2015-09"
 8587	upside-down barrel	0		Last Available: "2015-09"
 8588	barrel beryl	0		Last Available: "2015-09"
-8589	bite-sized adequate ghostly water log	1	good	Last Available: "2015-09"
+8589	adequate bite-sized ghostly water log	1	good	Last Available: "2015-09"
 8590	rosewater-soaked lion tamer's barrelhead	0		Experience (familiar): +2, Stench Resistance: +3, Last Available: "2015-09"
 8591	executive horrifying bottoms of the barrel	0		Spooky Damage: +25, Meat Drop: +40, Last Available: "2015-09"
 8592	razor-sharp chest barrel of mayonnaise	0		Weapon Damage Percent: +25, Sleaze Spell Damage: +50, Last Available: "2015-09"
@@ -8505,7 +8505,7 @@
 8632	modified energized cuppa Uncertain tea	0		Effect: "Uncanny Shot", Effect Duration: 14, Last Available: "2015-09"
 8633	narrow cuppa Voraci tea	0		Last Available: "2015-09"
 8634	cuppa Sobrie tea	0		Last Available: "2015-09"
-8635	skewed narrow cuppa Royal tea	0		Last Available: "2015-09"
+8635	narrow skewed cuppa Royal tea	0		Last Available: "2015-09"
 8636	triple-polymerized polarized cuppa Craft tea	0		Effect: "Tiki Thoughtfulness", Effect Duration: 51, Last Available: "2015-09"
 8637	cold-filtered cuppa Insani tea	0		Effect: "Red Around the Gills", Effect Duration: 54, Last Available: "2015-09"
 8638	perfumed deadly smooth Royal scepter	0		Moxie: +15, Weapon Damage: +5, Stench Resistance: +5, Last Available: "2015-09"
@@ -8525,7 +8525,7 @@
 8652	ear poison	0		
 8653	narrow stink-penny	0		
 8654	shaking fireproof ribald brainy hawk	0		Mysticality: +5, Sleaze Damage: +10, Hot Resistance: +3
-8655	flavorless diet hamlet sandwich	1	decent	
+8655	diet flavorless hamlet sandwich	1	decent	
 8656	bouncing extremely unsafe Othello's military jacket	0		Weapon Damage Percent: +100
 8657	Othello's dagger of the detective	0		Item Drop: +20, Single Equip
 8658	Othello's handkerchief of the businessman	0		Meat Drop: +50, Single Equip
@@ -8547,19 +8547,19 @@
 8674	airplane charter: The Glaciest	0		Free Pull, Last Available: "2015-11"
 8675	skewed one-day ticket to The Glaciest	0		Last Available: "2015-11"
 8676	wet shoulder-warming lotion	0		Effect: "Sweet and Green", Effect Duration: 56, Last Available: "2015-11"
-8677	decent super-sized yellow iceberg lettuce	5	good	Last Available: "2015-11"
+8677	super-sized decent yellow iceberg lettuce	5	good	Last Available: "2015-11"
 8678	high-proof delicious ice wine	10	awesome	Last Available: "2015-11"
 8679	executive shellacked wicked Wal-Mart snowglobe	0		Spell Damage: +5, Damage Reduction: 7, Meat Drop: +40, Last Available: "2015-11"
 8680	scorching hardened Da Vinci's Wal-Mart nametag	0		Experience (Mysticality): +5, Damage Reduction: 3, Hot Damage: +25, Last Available: "2015-11"
 8681	flame-wreathed manspreader's Tesla Wal-Mart overalls	0		Monster Level: +10, Hot Spell Damage: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2015-11"
 8682	narrow To Build an Igloo	0		Skill: "Refusal to Freeze", Last Available: "2015-11"
 8683	The Chill of the Wild	0		Skill: "Beardfreeze", Last Available: "2015-11"
-8684	blurry upside-down Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
+8684	upside-down blurry Cold Fang	0		Skill: "Frost Bite", Last Available: "2015-11"
 8685	Wal-Mart tattoo kit	0		Last Available: "2015-11"
 8686	perfect ice cube	0		Last Available: "2015-11"
 8687	upside-down The Fun-Guy Cold Weather Bartender's Guide	0		Skill: "Perfect Freeze", Last Available: "2015-11"
-8688	supercool bellhop's hat	0		Moxie Percent: +20, Familiar Effect: "1xLep, 0.75xBarrr, cap 30", Last Available: "2015-11"
-8689	high-proof perfectly mixed ice porter	8	EPIC	Last Available: "2015-11", Wiki Name: "ice porter (drink)"
+8688	supercool bellhop's hat	0		Moxie Percent: +20, Last Available: "2015-11", Familiar Effect: "1xLep, 0.75xBarrr, cap 30"
+8689	perfectly mixed high-proof ice porter	8	EPIC	Wiki Name: "ice porter (drink)", Last Available: "2015-11"
 8690	tarnished exotic travel brochure	0		Effect: "Melancholy Burden", Effect Duration: 56, Last Available: "2015-11"
 8691	bag of foreign bribes	0		Last Available: "2015-11"
 8692	deionized triple-denatured pulsating shampoo-conditioner	0		Effect: "Boschface", Effect Duration: 61, Last Available: "2015-11"
@@ -8567,20 +8567,20 @@
 8694	ice hotel bell	0		Last Available: "2015-11"
 8695	olive Martialest Arts trophy	0		Last Available: "2016-01"
 8696	dehydrated medicinal herbs	1		Last Available: "2016-01"
-8697	adequate massive enchanted ice rice	8	good	Effect: "Cake Caked", Effect Duration: 20, Last Available: "2016-01"
+8697	massive adequate enchanted ice rice	8	good	Effect: "Cake Caked", Effect Duration: 20, Last Available: "2016-01"
 8698	tolerable iced plum wine	3	good	Last Available: "2016-01"
 8699	lard-coated personal trainer's training belt	0		Experience Percent (Muscle): +10, Sleaze Spell Damage: +25, Item Drop: +5, Single Equip, Last Available: "2016-01"
 8700	Van der Graaf extremely unsafe training legwarmers of courage	0		Weapon Damage Percent: +100, Spooky Resistance: +3, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2016-01"
-8701	lard-coated personal trainer's supercool training helmet	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Sleaze Spell Damage: +25, Familiar Effect: "atk, cap 25", Last Available: "2016-01"
+8701	lard-coated personal trainer's supercool training helmet	0		Moxie Percent: +20, Experience Percent (Muscle): +10, Sleaze Spell Damage: +25, Last Available: "2016-01", Familiar Effect: "atk, cap 25"
 8702	training scroll:  Shattering Punch	0		Skill: "Shattering Punch", Last Available: "2016-01"
-8703	blinking skewed training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
+8703	skewed blinking training scroll:  Snokebomb	0		Skill: "Snokebomb", Last Available: "2016-01"
 8704	training scroll:  Shivering Monkey Technique	0		Skill: "Shivering Monkey Technique", Last Available: "2016-01"
-8705	ghostly lime green jittery X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
+8705	lime green ghostly jittery X-32-F snowman crate	0		Free Pull, Last Available: "2016-01"
 8706	machine elf capsule	0		Free Pull, Last Available: "2015-12"
 8707	self-dribbling basketball	0		Familiar Weight: +10, Last Available: "2015-12"
 8708	mixed yellow abstraction: action	1		Effect: "Bats in the Belfry", Effect Duration: 20, Last Available: "2015-12"
 8709	distilled bouncing abstraction: thought	1		Last Available: "2015-12"
-8710	modified maroon narrow blinking abstraction: sensation	1		Last Available: "2015-12"
+8710	modified maroon blinking narrow abstraction: sensation	1		Last Available: "2015-12"
 8711	distilled abstraction: purpose	1		Last Available: "2015-12"
 8712	diluted abstraction: category	1		Last Available: "2015-12"
 8713	vaporized twirling twirling abstraction: perception	1		Last Available: "2015-12"
@@ -8590,29 +8590,29 @@
 8717	boiled purple abstraction: comprehension	1		Last Available: "2015-12"
 8718	shaking modern picture frame	0		Last Available: "2015-12"
 8719	flavorless VYKEA meatballs	4	decent	Last Available: "2015-11"
-8720	boozy bad VYKEA mead	5	decent	Last Available: "2015-11"
+8720	bad boozy VYKEA mead	5	decent	Last Available: "2015-11"
 8721	activated dry VYKEA woadpaint	0		Effect: "It's Soporiffic!", Effect Duration: 51, Last Available: "2015-11"
 8722	VYKEA frenzy rune	0		Last Available: "2015-11"
 8723	VYKEA blood rune	0		Last Available: "2015-11"
-8724	bouncing spinning VYKEA lightning rune	0		Last Available: "2015-11"
+8724	spinning bouncing VYKEA lightning rune	0		Last Available: "2015-11"
 8725	VYKEA plank	0		Last Available: "2015-11"
 8726	VYKEA rail	0		Last Available: "2015-11"
 8727	VYKEA bracket	0		Last Available: "2015-11"
 8728	wobbly VYKEA dowel	0		Last Available: "2015-11"
 8729	shaking family-friendly Jeselnik's VYKEA hex key of the cougar	0		Moxie: +20, Sleaze Damage: +25, Sleaze Resistance: +1, Last Available: "2015-11"
 8730	VYKEA instructions	0		Last Available: "2015-11"
-8731	tasty massive squat huge tin of submardines	9	awesome	Last Available: "2015-11", Wiki Name: "tin of submardines"
+8731	tasty massive huge squat tin of submardines	9	awesome	Wiki Name: "tin of submardines", Last Available: "2015-11"
 8732	perfectly mixed irresponsibly strong bouncing bottle of norwhiskey	9	EPIC	Last Available: "2015-11"
 8733	dehydrated ghostly blinking octolus oculus	1	EPIC	Effect: "Cuts Like a Lightly-Buttered Knife", Effect Duration: 35, Last Available: "2015-11"
 8734	upside-down auspicious rosy-cheeked sardine can key of dire peril	0		Weapon Damage: +20, Maximum HP Percent: +30, Item Drop: +10, Last Available: "2015-11"
-8735	olive bouncing jittery Temple Grandin's Annie Oakley's beefy norwhal helmet	0		Muscle: +10, Critical Hit Percent: +20, Familiar Weight: +7, Familiar Effect: "atk", Last Available: "2015-11"
+8735	olive bouncing jittery Temple Grandin's Annie Oakley's beefy norwhal helmet	0		Muscle: +10, Critical Hit Percent: +20, Familiar Weight: +7, Last Available: "2015-11", Familiar Effect: "atk"
 8736	wobbly horrifying banded octolus-skin cloak of the brazier	0		Damage Absorption: +100, Hot Spell Damage: +25, Spooky Damage: +25, Last Available: "2015-11"
 8737	watered-down perfectly mixed perfect cosmopolitan	2	super ultra EPIC	Last Available: "2015-11"
-8738	bad practically non-alcoholic perfect negroni	1	decent	Last Available: "2015-11"
+8738	practically non-alcoholic bad perfect negroni	1	decent	Last Available: "2015-11"
 8739	artisanal perfect dark and stormy	3	EPIC	Last Available: "2015-11"
 8740	bad perfect mimosa	3	decent	Last Available: "2015-11"
-8741	artisanal spirit-forward perfect old-fashioned	5	EPIC	Last Available: "2015-11"
-8742	lousy irresponsibly strong wobbly perfect paloma	10	decent	Last Available: "2015-11"
+8741	spirit-forward artisanal perfect old-fashioned	5	EPIC	Last Available: "2015-11"
+8742	irresponsibly strong lousy wobbly perfect paloma	10	decent	Last Available: "2015-11"
 8743	moist jittery cyan That 70s Cologne	0		Effect: "Eyes of the Dragon", Effect Duration: 55, Last Available: "2015-11"
 8744	deionized denatured dry Wal-Mart &quot;diamond&quot; ring	0		Effect: "Toast Tea", Effect Duration: 65, Last Available: "2015-11"
 8745	colloidal denatured unsweetened Puffstone cigar	0		Effect: "Enraged", Effect Duration: 29, Last Available: "2015-11"
@@ -8623,9 +8623,9 @@
 8750	colloidal dry boiled pulsating hemp candy necklace	0		Effect: "Power Ballad of the Arrowsmith", Effect Duration: 24, Last Available: "2015-12"
 8751	ionized wobbly communal gobstopper	0		Effect: "Burnt 'n' Turnt", Effect Duration: 15, Last Available: "2015-12"
 8752	adequate Crimbo salad	4	good	Last Available: "2015-12"
-8753	snack-sized stale fancy bread line	2	decent	Effect: "Squirming Like a Toad", Effect Duration: 10, Last Available: "2015-12"
+8753	fancy snack-sized stale bread line	2	decent	Effect: "Squirming Like a Toad", Effect Duration: 10, Last Available: "2015-12"
 8754	perfectly mixed bark rootbeer	3	EPIC	Last Available: "2015-12"
-8755	watered-down perfectly mixed ale	2	EPIC	Last Available: "2015-12"
+8755	perfectly mixed watered-down ale	2	EPIC	Last Available: "2015-12"
 8756	greasy plastic Tammy the Tambourine Elf	0		Sleaze Spell Damage: +10, Last Available: "2015-12"
 8757	censurious plastic Rudolph the Red	0		Sleaze Resistance: +3, Last Available: "2015-12"
 8758	plastic Gaia'ajh-dsli Ak'lwej of courage	0		Spooky Resistance: +3, Last Available: "2015-12"
@@ -8633,15 +8633,15 @@
 8760	squat zippy plastic Crimbodhisattva	0		Initiative: +20, Last Available: "2015-12"
 8761	bouquet of all-natural free-range flowers	0		Last Available: "2015-12"
 8762	stack of communist leaflets	0		Last Available: "2015-12"
-8763	wobbly lime green mirror BACON	0		Last Available: "2016-05"
+8763	mirror wobbly lime green BACON	0		Last Available: "2016-05"
 8764	box of Gratitude chocolates	0		Last Available: "2016-02"
 8765	olive Gratitude chocolate (thyme-filled)	0		Last Available: "2016-02"
-8766	lousy watered-down shaking Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
+8766	watered-down lousy shaking Gratitude chocolate (bourbon-filled)	2	decent	Last Available: "2016-02"
 8767	mirror mirror Gratitude chocolate (Meat-filled)	0		Last Available: "2016-02"
 8768	squat Gratitude chocolate (octopus-filled)	0		Last Available: "2016-02"
 8769	spinning chocolate bowtie	0		Familiar Weight: +5
 8770	quantum lime green pitted sheet	0		Effect: "Egg-headedness", Effect Duration: 54, Last Available: "2015-12"
-8771	twirling shaking sparking robo-battery	0		Last Available: "2015-12"
+8771	shaking twirling sparking robo-battery	0		Last Available: "2015-12"
 8772	overloaded micro-reactor	0		Last Available: "2015-12"
 8773	pulsating squat skewed frosty banded reusable shopping bag of the dark arts	0		Spell Damage Percent: +100, Damage Absorption: +100, Cold Spell Damage: +10, Last Available: "2015-12"
 8775	asbestos-lined coarse hemp socks	0		Hot Resistance: +5, Single Equip, Last Available: "2015-12"
@@ -8653,8 +8653,8 @@
 8781	Fonzie's pine cone necklace	0		Experience (Moxie): +1, Last Available: "2015-12"
 8782	pulsating wholesome reindeer hammer	0		Maximum HP Percent: +10, Last Available: "2015-12"
 8783	energetic elf ploughshare	0		Maximum MP Percent: +20, Last Available: "2015-12"
-8784	lime green blurry circle drum	0		Last Available: "2015-12"
-8785	The Big Book of Communism	0		Skill: "Communism!", Last Available: "2015-12"
+8784	blurry lime green circle drum	0		Last Available: "2015-12"
+8785	The Big Book of Communism	0		Last Available: "2015-12", Skill: "Communism!"
 8786	faded protest sign	0		Last Available: "2015-12"
 8787	faded protest sign	0		Last Available: "2015-12"
 8788	nasty-smelling moss	0		Last Available: "2015-12"
@@ -8686,16 +8686,16 @@
 8814	maroon Bat-Aid&trade; bandage	0		Last Available: "2017-01"
 8815	yellow bat-bearing	0		Last Available: "2017-01"
 8816	bland shaking Kudzu salad	4	decent	Last Available: "2016-12"
-8817	vaporized lime green twirling Mansquito Serum	1		Last Available: "2016-12"
+8817	vaporized twirling lime green Mansquito Serum	1		Last Available: "2016-12"
 8818	mediocre spirit-forward Miss Graves' vermouth	5	decent	Last Available: "2016-12"
-8819	low-calorie stale The Plumber's mushroom stew	1	decent	Last Available: "2016-12"
+8819	stale low-calorie The Plumber's mushroom stew	1	decent	Last Available: "2016-12"
 8820	modified squat The Author's ink	1		Effect: "License to Punch", Effect Duration: 5, Last Available: "2016-02"
 8821	mediocre watered-down wobbly The Mad Liquor	2	decent	Last Available: "2016-12"
 8822	tolerable Doc Clock's thyme cocktail	4	good	Last Available: "2016-12"
-8823	moldy diet blurry Mr. Burnsger	1	crappy	Last Available: "2016-12"
+8823	diet moldy blurry Mr. Burnsger	1	crappy	Last Available: "2016-12"
 8824	twisted twirling The Inquisitor's unidentifiable object	1		Last Available: "2016-12"
 8825	ghostly Jeselnik's fortified Da Vinci's The Jokester's gun	0		Experience (Mysticality): +5, Damage Absorption: +60, Sleaze Damage: +25, Conditional Skill (Equipped): "Fire the Jokester's Gun", Last Available: "2016-12"
-8826	reassuring frosty beefy The Jokester's wig	0		Muscle: +10, Cold Spell Damage: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Familiar Effect: "1xPotato, 1xGhuol", Last Available: "2016-12"
+8826	reassuring frosty beefy The Jokester's wig	0		Muscle: +10, Cold Spell Damage: +10, Spooky Resistance: +1, Conditional Skill (Equipped): "Adjust the Jokester's Wig", Last Available: "2016-12", Familiar Effect: "1xPotato, 1xGhuol"
 8827	avaricious The Jokester's pants of James Dean of vim and vigor	0		Experience (Moxie): +3, Maximum HP Percent: +50, Meat Drop: +30, Conditional Skill (Equipped): "Adjust the Jokester's Pants", Last Available: "2016-12"
 8828	warmed pickled Jokester makeup	0		Effect: "Piratey Flavor", Effect Duration: 19, Last Available: "2016-12"
 8829	replica bat-oomerang	0		Last Available: "2016-12"
@@ -8704,7 +8704,7 @@
 8832	skewed domino mask	0		Familiar Weight: +5
 8833	super-nitrogenated vacuum-sealed robin's egg	0		Effect: "Brother Flying Burrito's Blessing", Effect Duration: 48, Last Available: "2016-12"
 8834	decent snack-sized robin flan	2	good	Last Available: "2016-12"
-8835	watered-down hand-crafted robin nog	2	EPIC	Last Available: "2016-12"
+8835	hand-crafted watered-down robin nog	2	EPIC	Last Available: "2016-12"
 8836	LT&T telegraph office deed	0		Free Pull, Last Available: "2016-02"
 8837	plaintive telegram	0		Last Available: "2016-02"
 8838	exploding gum	0		
@@ -8723,7 +8723,7 @@
 8851	mirror inflatable LT&T telegraph office	0		Last Available: "2016-02"
 8852	olive nugget of quicksilver	0		Last Available: "2016-02"
 8853	tumbling nugget of thicksilver	0		Last Available: "2016-02"
-8854	upside-down squat nugget of wicksilver	0		Last Available: "2016-02"
+8854	squat upside-down nugget of wicksilver	0		Last Available: "2016-02"
 8855	nugget of slicksilver	0		Last Available: "2016-02"
 8856	nugget of sicksilver	0		Last Available: "2016-02"
 8857	nugget of nicksilver	0		Last Available: "2016-02"
@@ -8750,15 +8750,15 @@
 8878	massive flavorless plate of Mixed Garbanzos and Chickpeas	10	decent	Last Available: "2016-02"
 8879	stale plate of Hellfire Spicy Beans	3	decent	Last Available: "2016-02"
 8880	delicious tumbling plate of Frigid Northern Beans	4	awesome	Last Available: "2016-02"
-8881	big decent purple twirling plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
+8881	decent big twirling purple plate of World's Blackest-Eyed Peas	5	good	Last Available: "2016-02"
 8882	stale massive upside-down plate of Trader Olaf's Exotic Stinkbeans	8	decent	Last Available: "2016-02"
 8883	bland snack-sized jittery plate of Pork 'n' Pork 'n' Pork 'n' Beans	2	decent	Last Available: "2016-02"
 8884	adequate plate of Val-U Brand Every Bean Salad	3	good	Last Available: "2016-02"
 8885	normal plate of Shrub's Premium Baked Beans	4	good	Last Available: "2016-02"
 8886	blurry greasy Samson's Fancy Jeff's pocket square	0		Experience (Muscle): +5, Sleaze Spell Damage: +10, Last Available: "2016-02"
-8887	squat Tesla groovy Daisy's unclean bloomers of the ox	0		Muscle: +20, Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Familiar Effect: "2xBArrr, 1xGhuol, cap 37", Last Available: "2016-02"
+8887	squat Tesla groovy Daisy's unclean bloomers of the ox	0		Muscle: +20, Moxie Percent: +10, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-02", Familiar Effect: "2xBArrr, 1xGhuol, cap 37"
 8888	Pecos Dave's sixgun	0		Last Available: "2016-02"
-8889	nippy manspreader's Amoon-Ra Cowtep's nemes of the ox	0		Muscle: +20, Monster Level: +10, Cold Damage: +10, Familiar Effect: "atk, 1xVolley", Last Available: "2016-02"
+8889	nippy manspreader's Amoon-Ra Cowtep's nemes of the ox	0		Muscle: +20, Monster Level: +10, Cold Damage: +10, Last Available: "2016-02", Familiar Effect: "atk, 1xVolley"
 8890	Glenn's dice	0		Last Available: "2016-02"
 8891	wobbly lightning-fast double-paned rosy-cheeked steel-toed beefy Former Sheriff Dan's tin star	0		Muscle: +10, Damage Reduction: 9, Maximum HP Percent: +30, Cold Resistance: +5, Initiative: +40, Last Available: "2016-02"
 8892	El Vibrato restraints	0		Last Available: "2016-02"
@@ -8800,7 +8800,7 @@
 8928	disc (yellow)	0		
 8929	red-hot knucklebone	0		Last Available: "2016-02"
 8930	alkaline adjusted demonic cow's blood	0		Effect: "Angry like the Wolf", Effect Duration: 65, Last Available: "2016-02"
-8931	yellow wobbly rinky-dink sixgun	0		Last Available: "2016-02"
+8931	wobbly yellow rinky-dink sixgun	0		Last Available: "2016-02"
 8932	makeshift sixgun	0		Last Available: "2016-02"
 8933	tumbling custom sixgun	0		Last Available: "2016-02"
 8934	huge baconstone-handled sixgun	0		Last Available: "2016-02"
@@ -8849,7 +8849,7 @@
 8977	tarnished magnetized mirror patent invisibility tonic	0		Effect: "Good Motivator", Effect Duration: 62
 8978	super-adjusted non-dry upside-down patent aggression tonic	0		Effect: "Simulation Stimulation", Effect Duration: 12
 8979	boiled wobbly shaking patent sallowness tonic	0		Effect: "Human-Hobo Hybrid", Effect Duration: 38
-8980	dry huge narrow patent avarice tonic	0		Effect: "Muscularrr", Effect Duration: 59
+8980	dry narrow huge patent avarice tonic	0		Effect: "Muscularrr", Effect Duration: 59
 8981	cold-filtered polymerized patent alacrity tonic	0		Effect: "The Magical Mojomuscular Melody", Effect Duration: 22
 8982	modified anodized corrupted marrow	0		Effect: "Fury of the Bells", Effect Duration: 67
 8983	bad weak rodeo whiskey	2	decent	
@@ -8863,22 +8863,22 @@
 8991	do-it-yourself laser eye surgery kit	0		Skill: "20/20 Vision"
 8992	pickled yellow skewed armored prawn	1		Last Available: "2016-03"
 8993	massive adequate jumping horseradish	10	good	Last Available: "2016-03"
-8994	practically non-alcoholic drinkable blurry Sacramento wine	1	good	Last Available: "2016-03"
+8994	drinkable practically non-alcoholic blurry Sacramento wine	1	good	Last Available: "2016-03"
 8995	diffused magnetized Greek fire	0		Effect: "Jungle Juiced", Effect Duration: 27, Last Available: "2016-03"
 8996	censurious knitted supercool ox-head shield of the wise owl	0		Mysticality: +20, Moxie Percent: +20, Cold Resistance: +3, Sleaze Resistance: +3, Item Drop: +5, Damage Reduction: 16, Lasts Until Rollover, Last Available: "2016-03"
 8997	skewed Van der Graaf fortified brawny strapping dented scepter of Flo-Jo	0		Muscle: +5, Muscle Percent: +20, Damage Absorption: +60, Initiative: +100, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
-8998	upside-down auspicious friendly rosy-cheeked grievous Sinatra's very pointy crown	0		Experience (Moxie): +5, Weapon Damage Percent: +50, Maximum HP Percent: +30, Familiar Weight: +3, Item Drop: +10, Lasts Until Rollover, Familiar Effect: "atk, 1xGhuol", Last Available: "2016-03"
+8998	upside-down auspicious friendly rosy-cheeked grievous Sinatra's very pointy crown	0		Experience (Moxie): +5, Weapon Damage Percent: +50, Maximum HP Percent: +30, Familiar Weight: +3, Item Drop: +10, Lasts Until Rollover, Last Available: "2016-03", Familiar Effect: "atk, 1xGhuol"
 8999	narrow perfumed rosewater-soaked Jim Carey's healthy battle broom of the storm	0		Maximum HP Percent: +20, Maximum MP Percent: +40, Monster Level: +25, Stench Resistance: 8, Single Equip, Lasts Until Rollover, Last Available: "2016-03"
 9000	blurry Clan Floundry	0		Free Pull, Last Available: "2016-04"
 9001	lion tamer's banded Herculean carpe of the blizzard	0		Experience (Muscle): +1, Damage Absorption: +100, Experience (familiar): +2, Cold Spell Damage: +25, Lasts Until Rollover, Last Available: "2016-04"
 9002	squat asbestos-lined coward's quilted dance instructor's codpiece	0		Experience Percent (Moxie): +10, Damage Absorption: +40, Monster Level: -20, Hot Resistance: +5, Lasts Until Rollover, Last Available: "2016-04"
-9003	vibrating grievous cool strapping troutsers	0		Muscle: +5, Moxie: +5, Weapon Damage Percent: +50, Maximum MP Percent: +10, Lasts Until Rollover, Familiar Effect: "sleaze atk, 0.5xPotato", Last Available: "2016-04"
+9003	vibrating grievous cool strapping troutsers	0		Muscle: +5, Moxie: +5, Weapon Damage Percent: +50, Maximum MP Percent: +10, Lasts Until Rollover, Last Available: "2016-04", Familiar Effect: "sleaze atk, 0.5xPotato"
 9004	auspicious chilly energetic Rosewater's bass clarinet	0		Mysticality Percent: +30, Maximum MP Percent: +20, Cold Damage: +5, Item Drop: +10, Lasts Until Rollover, Last Available: "2016-04"
 9005	Usain Bolt's sizzling fish hatchet of temperance of the cheetah	0		Hot Damage: +10, Sleaze Resistance: +5, Initiative: 140, Lasts Until Rollover, Last Available: "2016-04"
 9006	upside-down perfumed tunac of the detective of the boozehound of the glutton	0		Stench Resistance: +5, Item Drop: +20, Booze Drop: +100, Food Drop: +100, Lasts Until Rollover, Last Available: "2016-04"
 9007	fishin' pole	0		Last Available: "2016-04"
 9008	irradiated wriggling worm	0		Effect: "Stinky Weapon", Effect Duration: 39, Last Available: "2016-04"
-9009	hand-crafted practically non-alcoholic blurry bottle of Fishhead 900-Day IPA	1	super ultra mega turbo EPIC	Last Available: "2016-04"
+9009	practically non-alcoholic hand-crafted blurry bottle of Fishhead 900-Day IPA	1	super ultra mega turbo EPIC	Last Available: "2016-04"
 9010	oxidized high-test fishing line	0		Effect: "Broken Fast", Effect Duration: 51, Last Available: "2016-04"
 9011	fishin' hat of the empath	0		Familiar Weight: +5, Last Available: "2016-04"
 9012	Trout Fishing in Loathing	0		Skill: "Astute Angler", Last Available: "2016-04"
@@ -8887,7 +8887,7 @@
 9015	bouncing tacklebox	0		Fishing Skill: +5, Last Available: "2016-04"
 9016	disconnected intergnat	0		Free Pull, Last Available: "2016-05"
 9017	narrow viral video	0		Last Available: "2016-05"
-9018	mirror lime green internet point	0		Last Available: "2016-05"
+9018	lime green mirror internet point	0		Last Available: "2016-05"
 9019	meme generator	0		Last Available: "2016-05"
 9020	plus one	0		Last Available: "2016-05"
 9021	adequate pulsating gallon of milk	3	good	Last Available: "2016-05"
@@ -8924,7 +8924,7 @@
 9052	Source terminal file: damage.enh	0		Last Available: "2016-06"
 9053	Source terminal file: critical.enh	0		Last Available: "2016-06"
 9054	bouncing Source terminal file: protect.enq	0		Last Available: "2016-06"
-9055	shaking blurry Source terminal file: stats.enq	0		Last Available: "2016-06"
+9055	blurry shaking Source terminal file: stats.enq	0		Last Available: "2016-06"
 9056	Source terminal file: compress.edu	0		Last Available: "2016-06"
 9057	Source terminal file: duplicate.edu	0		Last Available: "2016-06"
 9058	Source terminal file: portscan.edu	0		Last Available: "2016-06"
@@ -8933,7 +8933,7 @@
 9061	Source terminal file: pram.ext	0		Last Available: "2016-06"
 9062	Source terminal file: gram.ext	0		Last Available: "2016-06"
 9063	Source terminal file: spam.ext	0		Last Available: "2016-06"
-9064	twirling lime green Source terminal file: cram.ext	0		Last Available: "2016-06"
+9064	lime green twirling Source terminal file: cram.ext	0		Last Available: "2016-06"
 9065	tumbling fuchsia Source terminal file: dram.ext	0		Last Available: "2016-06"
 9066	Source terminal file: tram.ext	0		Last Available: "2016-06"
 9067	pill	0		Last Available: "2016-06"
@@ -8948,7 +8948,7 @@
 9076	spinning knitted dog trainer's Temple Grandin's noir fedora	0		Familiar Weight: +7, Experience (familiar): +1, Cold Resistance: +3, Last Available: "2016-07"
 9077	blinking miser's Oprah's brawny trench coat	0		Muscle Percent: +20, Maximum MP Percent: +50, Meat Drop: +10, Last Available: "2016-07"
 9078	practically non-alcoholic tolerable cyan Falcon&trade; Maltese Liquor	1	good	Last Available: "2016-07"
-9079	super-sized yummy hardboiled egg	5	awesome	Last Available: "2016-07"
+9079	yummy super-sized hardboiled egg	5	awesome	Last Available: "2016-07"
 9080	detective tattoo	0		Last Available: "2016-07"
 9081	DIY protonic accelerator kit	0		Free Pull, Last Available: "2016-08"
 9082	upside-down tumbling executive perfumed chilly sharpshooter's hale protonic accelerator pack of the bloodbag	0		Maximum HP: 120, Critical Hit Percent: +10, Cold Damage: +5, Stench Resistance: +5, Meat Drop: +40, Conditional Skill (Equipped): "Shoot Ghost", Conditional Skill (Equipped): "Trap Ghost", Last Available: "2016-08"
@@ -8963,7 +8963,7 @@
 9091	Mr. Screege's spectacles of the cougar	0		Moxie: +20, Single Equip, Last Available: "2016-08"
 9092	spinning flame-wreathed padded groovy Spookyraven signet	0		Moxie Percent: +10, Damage Absorption: +20, Hot Spell Damage: +10, Single Equip, Last Available: "2016-08"
 9093	blinking flame-retardant foul-smelling tie-dyed fannypack	0		Stench Damage: +10, Hot Resistance: +1, Single Equip, Last Available: "2016-08"
-9094	wool burnt snowpants of the sweet-tooth	0		Cold Resistance: +1, Candy Drop: +100, Familiar Effect: "1.5xPotato, cap 25", Last Available: "2016-08"
+9094	wool burnt snowpants of the sweet-tooth	0		Cold Resistance: +1, Candy Drop: +100, Last Available: "2016-08", Familiar Effect: "1.5xPotato, cap 25"
 9095	medical-grade standards and practices guide	0		HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Censorious Lecture", Last Available: "2016-08"
 9096	Tesla ruddy arcane researcher's Carpathian longsword	0		Experience Percent (Mysticality): +10, Maximum HP Percent: +40, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2016-08"
 9097	ribald Liam's mail of the scaredy-cat of chilblains	0		Monster Level: -15, Cold Damage: +25, Sleaze Damage: +10, Last Available: "2016-08"
@@ -8978,7 +8978,7 @@
 9106	maroon upside-down Rad-B-Gone (1 lb.)	0		
 9107	electrified Rad-Pro (1 oz.)	0		Effect: "Seeing Colors", Effect Duration: 52
 9108	lead umbrella	0		
-9109	super-deionized teal twirling blurry Shrieking Weasel holo-record	0		Effect: "Super-Mega-Charged", Effect Duration: 52
+9109	super-deionized blurry twirling teal Shrieking Weasel holo-record	0		Effect: "Super-Mega-Charged", Effect Duration: 52
 9110	wet Power-Guy 2000 holo-record	0		Effect: "Bear Clawed", Effect Duration: 63
 9111	tarnished Lucky Strikes holo-record	0		Effect: "Drunk With Power", Effect Duration: 19
 9112	quantum twirling huge EMD holo-record	0		Effect: "Dwarven Hardiness", Effect Duration: 48
@@ -9003,53 +9003,53 @@
 9131	extremely confusing manual	0		
 9132	tumbling rosewater-soaked pistol of doom	0		Spooky Spell Damage: +50, Stench Resistance: +3
 9133	KoL Con 13 snowglobe	0		Last Available: "2016-10"
-9134	huge rotten leftover pasty	8	crappy	
+9134	rotten huge leftover pasty	8	crappy	
 9135	bad pulsating very whiskey	4	decent	
 9136	squat li'l orphan tot	0		Free Pull, Last Available: "2016-10"
 9137	li'l knight costume	0		Muscle: +15, Mysticality: +15, Moxie: +15, Last Available: "2016-10"
-9138	bouncing skewed li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9143	li'l robot costume	0		Experience: +10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9144	li'l eyeball costume	0		Combat Rate: -10, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
-9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9138	bouncing skewed li'l unicorn costume	0		Adventures: +5, PvP Fights: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9139	li'l candy corn costume	0		Spooky Resistance: +5, Stench Resistance: +5, Hot Resistance: +5, Cold Resistance: +5, Sleaze Resistance: +5, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9140	li'l ninja costume	0		Item Drop: +150, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9141	li'l pirate costume	0		Meat Drop: +300, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9142	li'l clown costume	0		Experience: +15, Lasts Until Rollover, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9143	li'l robot costume	0		Experience: +10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9144	li'l eyeball costume	0		Combat Rate: -10, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
+9145	li'l liberty costume	0		Item Drop: +100, Meat Drop: +200, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9146	galvanized magnetized hoarded candy wad	0		Effect: "L'instinct F&eacute;lin", Effect Duration: 45, Last Available: "2016-10"
 9147	adjusted bouncing Prunets	0		Effect: "Crying, Dying", Effect Duration: 33
 9148	blurry Twitching Television Tattoo	0		
 9149	baby scorpion	0		Familiar Weight: +10
 9150	energized liquefied invisible string	0		Lasts Until Rollover, Effect: "Weird Vibrations", Effect Duration: 16, Last Available: "2016-10"
 9151	colloidal non-warmed skewed invisible seam ripper	0		Lasts Until Rollover, Effect: "Jacked In", Effect Duration: 56, Last Available: "2016-10"
-9152	teal li'l ghost costume	0		Initiative: +100, Equips On: "Trick-or-Treating Tot", Last Available: "2016-10"
+9152	teal li'l ghost costume	0		Initiative: +100, Last Available: "2016-10", Equips On: "Trick-or-Treating Tot"
 9153	moldy lime green raw sweet potato	3	crappy	Last Available: "2016-11"
-9154	miniature spoiled raw beans	2	crappy	Last Available: "2016-11"
-9155	gigantic delicious upside-down raw stuffing	9	awesome	Last Available: "2016-11"
+9154	spoiled miniature raw beans	2	crappy	Last Available: "2016-11"
+9155	delicious gigantic upside-down raw stuffing	9	awesome	Last Available: "2016-11"
 9156	spoiled small raw cranberry sauce	2	crappy	Last Available: "2016-11"
 9157	bland cyan raw turkey	3	decent	Last Available: "2016-11"
 9158	normal raw mincemeat	3	good	Last Available: "2016-11"
-9159	super-sized normal raw potato	5	good	Last Available: "2016-11"
+9159	normal super-sized raw potato	5	good	Last Available: "2016-11"
 9160	flavorless half-sized raw gravy	2	decent	Last Available: "2016-11"
 9161	adequate raw bread	3	good	Last Available: "2016-11"
 9162	huge executive Jack Frost's mini-marshmallow dispenser	0		Cold Spell Damage: +50, Meat Drop: +40, Last Available: "2016-11"
 9163	foul-smelling hardy glass casserole dish of the storm	0		Maximum HP: +50, Maximum MP Percent: +40, Stench Damage: +10, Last Available: "2016-11"
 9164	stuffing fluffer	0		Last Available: "2016-11"
 9165	spinning can opener of the ox of the blizzard	0		Muscle: +20, Cold Spell Damage: +25, Last Available: "2016-11"
-9166	denatured blue upside-down turkey blaster	1		Last Available: "2016-11"
+9166	denatured upside-down blue turkey blaster	1		Last Available: "2016-11"
 9167	bouncing forbidden glass pie plate of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Damage Reduction: 7, Last Available: "2016-11"
 9168	energetic groovy potato masher	0		Moxie Percent: +10, Maximum MP Percent: +20, Last Available: "2016-11"
 9169	gravy boat	0		Last Available: "2016-11"
 9170	bread mold	0		Last Available: "2016-11"
 9171	normal sweet potatoes	3	good	Last Available: "2016-11"
 9172	normal bean casserole	3	good	Last Available: "2016-11"
-9173	huge adequate fancy baked stuffing	10	good	Effect: "Pumped Stomach", Effect Duration: 20, Last Available: "2016-11"
+9173	huge fancy adequate baked stuffing	10	good	Effect: "Pumped Stomach", Effect Duration: 20, Last Available: "2016-11"
 9174	stale cranberry cylinder	4	decent	Last Available: "2016-11"
 9175	decent blurry skewed thanksgiving turkey	4	good	Last Available: "2016-11"
-9176	yummy big mince pie	5	awesome	Last Available: "2016-11"
+9176	big yummy mince pie	5	awesome	Last Available: "2016-11"
 9177	rotten mashed potatoes	3	crappy	Last Available: "2016-11"
 9178	flavorless warm gravy	3	decent	Last Available: "2016-11"
 9179	moldy snack-sized bread roll	2	crappy	Last Available: "2016-11"
-9180	small normal leftovers	2	good	Last Available: "2016-11"
+9180	normal small leftovers	2	good	Last Available: "2016-11"
 9181	flavorless spinning leftovers sandwich	3	decent	Last Available: "2016-11"
 9182	Eldritch Intellect: Journey into a Mind of Horror	0		Skill: "Eldritch Intellect"
 9183	jittery cornucopia	0		Last Available: "2016-11"
@@ -9061,20 +9061,20 @@
 9189	blurry teal Granny Tood's Thanksgarden Catalog	0		Free Pull, Last Available: "2016-11"
 9190	teal eldritch effluvium	0		
 9191	dry enhanced eldritch concentrate	0		Effect: "Abominably Slippery", Effect Duration: 14, Last Available: "2016-11"
-9192	drinkable watered-down squat eldritch extract	2	good	Last Available: "2016-11"
+9192	watered-down drinkable squat eldritch extract	2	good	Last Available: "2016-11"
 9193	padded personal trainer's Official Council Aide Pin	0		Experience Percent (Muscle): +10, Damage Absorption: +20, Last Available: "2016-11"
 9194	drinkable shaking eldritch distillate	4	good	Last Available: "2016-11"
 9195	dehydrated jittery maroon eldritch essence	1		Last Available: "2016-11"
 9196	scorching Science Notebook	0		Hot Damage: +25
 9197	chaotic Socratic eldritch hat of the brute	0		Muscle Percent: +30, Experience (Mysticality): +1, Spell Critical Percent: +10, Last Available: "2016-11"
 9198	reassuring Fonzie's eldritch pants of the storm	0		Experience (Moxie): +1, Maximum MP Percent: +40, Spooky Resistance: +1, Last Available: "2016-11"
-9199	special artisanal watered-down eldritch elixir	2	EPIC	Effect: "Spiky Hair", Effect Duration: 10, Last Available: "2016-11"
+9199	watered-down artisanal special eldritch elixir	2	EPIC	Effect: "Spiky Hair", Effect Duration: 10, Last Available: "2016-11"
 9200	greedy Newton's Quartet of Flare Masters Jacket	0		Experience (Mysticality): +3, Meat Drop: +20, Last Available: "2016-11"
 9201	squat lump of not really wriggling eldritch matter	0		
 9202	Adventurer's Kit	0		
 9203	Build-a-City Gingerbread kit	0		Free Pull, Last Available: "2016-12"
 9204	counterfeit city	0		Last Available: "2016-12"
-9205	jittery purple sprinkles	0		Last Available: "2016-12"
+9205	purple jittery sprinkles	0		Last Available: "2016-12"
 9206	olive The Gingerbread Vigilante's Handbook	0		Skill: "Licorice Rope", Last Available: "2016-12"
 9207	ball and chain of the cheetah	0		Initiative: +60, Sprinkle Drop: +50, Single Equip, Last Available: "2016-12"
 9208	ghostly candy dog collar	0		Sprinkle Drop: +25, Last Available: "2016-12"
@@ -9110,7 +9110,7 @@
 9238	gingerbread moneybag	0		Sprinkle Drop: +25, Last Available: "2016-12"
 9239	enchanted acceptable ginger beer	3	good	Effect: "Heart of Yellow", Effect Duration: 10, Last Available: "2016-12"
 9240	gray spare chocolate parts	0		Last Available: "2016-12"
-9241	super-denatured wobbly shaking shaking industrial frosting	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 43, Last Available: "2016-12"
+9241	super-denatured shaking shaking wobbly industrial frosting	0		Effect: "Stopping to Smell the Flowers", Effect Duration: 43, Last Available: "2016-12"
 9242	cold-filtered galvanized chilled tumbling fake cocktail	0		Effect: "Neuroplastici Tea", Effect Duration: 43, Last Available: "2016-12"
 9243	delicious gray high-end ginger wine	4	awesome	Last Available: "2016-12"
 9244	blurry knitted plastic bad vibe	0		Cold Resistance: +3, Last Available: "2016-12"
@@ -9123,7 +9123,7 @@
 9251	polymerized Inner Truth	0		Effect: "Funky Coal Patina", Effect Duration: 25, Last Available: "2016-12"
 9252	decent spiritual candy cane	3	good	Last Available: "2016-12"
 9253	bad spiritual eggnog	4	decent	Last Available: "2016-12"
-9254	normal huge olive spiritual fruitcake	3	good	Last Available: "2016-12"
+9254	normal olive huge spiritual fruitcake	3	good	Last Available: "2016-12"
 9255	flavorless diet spiritual gingerbread	1	decent	Last Available: "2016-12"
 9256	skewed chocolate puppy	0		Last Available: "2016-12"
 9257	skewed chocolate leash	0		Familiar Weight: +10, Last Available: "2016-12"
@@ -9136,7 +9136,7 @@
 9264	briefcase full of sprinkles	0		Last Available: "2016-12"
 9265	teethpick	0		Last Available: "2016-12"
 9266	dry green rock candy	0		Effect: "Helvella Health", Effect Duration: 26, Last Available: "2016-12"
-9267	small moldy blue green-iced sweet roll	2	crappy	Last Available: "2016-12"
+9267	moldy small blue green-iced sweet roll	2	crappy	Last Available: "2016-12"
 9268	tumbling sugar raygun	0		Sprinkle Drop: +50, Last Available: "2016-12"
 9269	mirror chocolate sculpture	0		Last Available: "2016-12"
 9270	no hat	0		Lasts Until Rollover, Last Available: "2016-12"
@@ -9162,14 +9162,14 @@
 9290	massive decent twirling Eldritch snap	6	good	Last Available: "2017-01"
 9291	denatured olive hot jelly	1		Last Available: "2017-01"
 9292	denatured wobbly jelly	1		Effect: "Inscrutable exoskeleton", Effect Duration: 25, Last Available: "2017-01"
-9293	dried blinking maroon jelly	1		Last Available: "2017-01"
+9293	dried maroon blinking jelly	1		Last Available: "2017-01"
 9294	compressed spinning spinning sleaze jelly	1		Last Available: "2017-01"
 9295	vaporized upside-down ghostly stench jelly	1		Last Available: "2017-01"
 9296	space planula	0		Free Pull, Last Available: "2017-01"
 9297	yummy toast with hot jelly	3	awesome	Last Available: "2017-01"
 9298	moldy huge toast with jelly	7	crappy	Last Available: "2017-01"
 9299	moldy toast with jelly	4	crappy	Last Available: "2017-01"
-9300	adequate big toast with sleaze jelly	5	good	Last Available: "2017-01"
+9300	big adequate toast with sleaze jelly	5	good	Last Available: "2017-01"
 9301	stale toast with stench jelly	3	decent	Last Available: "2017-01"
 9302	pulsating space jellybicycle	0		Familiar Weight: +5
 9303	twirling hopeful candle	0		Free Pull, Last Available: "2017-01"
@@ -9193,15 +9193,15 @@
 9321	greasy slick brainy LOV Epaulettes	0		Mysticality: +5, Moxie: +10, Sleaze Spell Damage: +10, Lasts Until Rollover, Last Available: "2017-02"
 9322	cyan executive miser's knitted LOV Earrings	0		Cold Resistance: +3, Meat Drop: 50, Single Equip, Lasts Until Rollover, Last Available: "2017-02"
 9323	LOV Enamorang	0		Last Available: "2017-02"
-9324	ghostly gray LOV Emotionizer	0		Last Available: "2017-02"
+9324	gray ghostly LOV Emotionizer	0		Last Available: "2017-02"
 9325	LOV Extraterrestrial Chocolate	0		Last Available: "2017-02"
-9326	vaporized fuchsia ghostly LOV Echinacea Bouquet	1		Effect: "[1701]Hip to the Jive", Effect Duration: 30, Last Available: "2017-02"
+9326	vaporized ghostly fuchsia LOV Echinacea Bouquet	1		Effect: "[1701]Hip to the Jive", Effect Duration: 30, Last Available: "2017-02"
 9327	purple LOV Elephant of incineration	0		Hot Spell Damage: +50, Damage Reduction: 6, Last Available: "2017-02"
 9328	mirror eldritch scanner of wisdom	0		Mysticality: +15, Last Available: "2017-02"
 9329	extra-liquefied eldritch alignment spray	0		Effect: "Mana Tea", Effect Duration: 27, Last Available: "2017-02"
 9330	lime green LOV Entrance Pass	0		Last Available: "2017-02"
 9331	gray executive energetic hardened eldritch hammer	0		Damage Reduction: 3, Maximum MP Percent: +20, Meat Drop: +40, Last Available: "2017-01"
-9332	yummy snack-sized bouncing eldritch mushroom	2	awesome	Last Available: "2017-03"
+9332	snack-sized yummy bouncing eldritch mushroom	2	awesome	Last Available: "2017-03"
 9333	eldritch ichor	0		
 9334	stale huge eldritch mushroom pizza	3	decent	Last Available: "2017-03"
 9335	eldritch tincture	0		Skill: "Evoke Eldritch Horror", Last Available: "2017-02"
@@ -9245,7 +9245,7 @@
 9373	bad practically non-alcoholic wobbly green whiskey squeeze	1	decent	Last Available: "2017-03"
 9374	hand-crafted great fashioned	3	EPIC	Last Available: "2017-03"
 9375	watered-down smooth Gnomish sagngria	2	awesome	Last Available: "2017-03"
-9376	high-proof lousy vodka stinger	9	decent	Last Available: "2017-03"
+9376	lousy high-proof vodka stinger	9	decent	Last Available: "2017-03"
 9377	hand-crafted extremely slippery nipple	3	EPIC	Last Available: "2017-03"
 9378	tolerable piscatini	3	good	Last Available: "2017-03"
 9379	hand-crafted fancy gray Churchill	4	EPIC	Effect: "Heart Aflame", Effect Duration: 10, Last Available: "2017-03"
@@ -9256,7 +9256,7 @@
 9384	enchanted acceptable single entendre	3	good	Effect: "Pwnd", Effect Duration: 15, Last Available: "2017-03"
 9385	smooth reverse Tantalus	3	awesome	Last Available: "2017-03"
 9386	delicious fortified elemental caipiroska	5	awesome	Last Available: "2017-03"
-9387	hand-crafted watered-down Feliz Navidad	2	EPIC	Last Available: "2017-03"
+9387	watered-down hand-crafted Feliz Navidad	2	EPIC	Last Available: "2017-03"
 9388	tolerable Bloody Nora	3	good	Last Available: "2017-03"
 9389	mediocre enchanted moreltini	4	decent	Effect: "Berry Thorny", Effect Duration: 20, Last Available: "2017-03"
 9390	watered-down delicious hell in a bucket	2	awesome	Last Available: "2017-03"
@@ -9264,10 +9264,10 @@
 9392	artisanal R'lyeh	3	EPIC	Last Available: "2017-03"
 9393	perfectly mixed Gnollish sangria	4	EPIC	Last Available: "2017-03"
 9394	strong drinkable vodka barracuda	5	good	Last Available: "2017-03"
-9395	drinkable fancy Mysterious Island iced tea	4	good	Effect: "Bananas!", Effect Duration: 30, Last Available: "2017-03"
+9395	fancy drinkable Mysterious Island iced tea	4	good	Effect: "Bananas!", Effect Duration: 30, Last Available: "2017-03"
 9396	lousy watered-down blinking drive-by shooting	2	decent	Last Available: "2017-03"
 9397	drinkable gunner's daughter	3	good	Last Available: "2017-03"
-9398	artisanal triple-distilled dirt julep	9	EPIC	Last Available: "2017-03"
+9398	triple-distilled artisanal dirt julep	9	EPIC	Last Available: "2017-03"
 9399	irresponsibly strong artisanal Simepore slime	6	EPIC	Last Available: "2017-03"
 9400	tolerable shaking Phil Collins	3	good	Last Available: "2017-03"
 9401	unpowered Robortender	0		Free Pull, Last Available: "2017-03"
@@ -9330,14 +9330,14 @@
 9458	squat space pirate treasure map	0		Last Available: "2017-04"
 9459	twirling Space Pirate Astrogation Handbook	0		Skill: "Quantum Movement", Last Available: "2017-04"
 9460	spinning Non-Euclidean Finance	0		Skill: "5-D Earning Potential", Last Available: "2017-04"
-9461	twirling fuchsia Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
+9461	fuchsia twirling Peek-a-Boo!	0		Skill: "Object Quasi-Permanence", Last Available: "2017-04"
 9462	skewed Procrastinator locker key	0		Last Available: "2017-04"
 9463	squat Space Baby children's book	0		Last Available: "2017-04"
 9464	blue Space Baby bawbaw	0		Last Available: "2017-04"
 9465	shaking Spacegate	0		Last Available: "2017-04"
 9466	flavorless bite-sized maroon Aldebaran sardines	1	decent	Last Available: "2017-04"
-9467	perfectly mixed weak pulsating Centauri fish wine	2	EPIC	Last Available: "2017-04"
-9468	dried blinking fuchsia oxygen	1		Last Available: "2017-04"
+9467	weak perfectly mixed pulsating Centauri fish wine	2	EPIC	Last Available: "2017-04"
+9468	dried fuchsia blinking oxygen	1		Last Available: "2017-04"
 9469	stanky sizzling Spacegate scientist's insignia	0		Hot Damage: +10, Stench Spell Damage: +25, Single Equip, Last Available: "2017-04"
 9470	mansplainer's Herculean Spacegate military insignia	0		Experience (Muscle): +1, Monster Level: +15, Single Equip, Last Available: "2017-04"
 9471	lime green family-friendly Da Vinci's Spacegate diplomat's insignia of Gandalf	0		Experience (Mysticality): +5, Spell Critical Percent: +20, Sleaze Resistance: +1, Single Equip, Last Available: "2017-04"
@@ -9363,7 +9363,7 @@
 9491	Targeted Plague Vector	0		
 9492	suspicious package	0		Free Pull, Last Available: "2017-06"
 9493	friendly resourceful cool Kremlin's Greatest Briefcase	0		Moxie: +5, Maximum MP: +50, Familiar Weight: +3, Single Equip, Conditional Skill (Equipped): "KGB tranquilizer dart", Last Available: "2017-06"
-9494	tolerable practically non-alcoholic basic martini	1	good	Last Available: "2017-06"
+9494	practically non-alcoholic tolerable basic martini	1	good	Last Available: "2017-06"
 9495	weak mediocre improved martini	2	decent	Last Available: "2017-06"
 9496	acceptable splendid martini	4	good	Last Available: "2017-06"
 9497	olive exploding cigar	0		Last Available: "2017-06"
@@ -9384,11 +9384,11 @@
 9512	upside-down Pocket Meteor Guide (well-thumbed)	0		Last Available: "2017-08"
 9513	Meteorite-Ade	0		Last Available: "2017-08"
 9514	tasty meteoreo	3	awesome	Last Available: "2017-08"
-9515	weak artisanal meadeorite	2	EPIC	Last Available: "2017-08"
+9515	artisanal weak meadeorite	2	EPIC	Last Available: "2017-08"
 9516	squat meteoroid	0		Last Available: "2017-08"
 9517	wholesome steel-toed meteortarboard of the sewer	0		Damage Reduction: 9, Maximum HP Percent: +10, Stench Damage: +25, Last Available: "2017-08"
 9518	perfumed friendly forbidden meteorite guard	0		Spell Damage Percent: +50, Familiar Weight: +3, Stench Resistance: +5, Damage Reduction: 9, Last Available: "2017-08"
-9519	blinking knitted sage meteorb	0		Mysticality Percent: +10, Cold Resistance: +3, Lantern Element: "Hot", Last Available: "2017-08"
+9519	blinking knitted sage meteorb	0		Mysticality Percent: +10, Cold Resistance: +3, Last Available: "2017-08", Lantern Element: "Hot"
 9520	supercool asteroid belt of the bloodbag	0		Moxie Percent: +20, Maximum HP: +100, Single Equip, Last Available: "2017-08"
 9521	Herculean meteorthopedic shoes of Gandalf of the detective	0		Experience (Muscle): +1, Spell Critical Percent: +20, Item Drop: +20, Single Equip, Last Available: "2017-08"
 9522	energetic medical-grade shooting morning star of vim and vigor	0		Maximum HP Percent: +50, Maximum MP Percent: +20, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2017-08"
@@ -9403,7 +9403,7 @@
 9531	gray pony: Dusk Shiny	0		Last Available: "2017-09"
 9532	pony: Shutterfly	0		Last Available: "2017-09"
 9533	pulsating pony: Pearjack	0		Last Available: "2017-09"
-9534	twirling bouncing pony: Uniquity	0		Last Available: "2017-09"
+9534	bouncing twirling pony: Uniquity	0		Last Available: "2017-09"
 9535	teal pony: Rosey Cake	0		Last Available: "2017-09"
 9536	shaking pony: Spectrum Dash	0		Last Available: "2017-09"
 9537	pocket wish	0		Last Available: "2023-09"
@@ -9412,11 +9412,11 @@
 9540	shovelful of dirt	0		
 9541	jittery xo-skeleton-in-a-box	0		Free Pull, Last Available: "2017-10"
 9542	exo-xo-skeleton-skeleton	0		Familiar Weight: +5
-9543	twirling blurry X	0		Last Available: "2017-10"
+9543	blurry twirling X	0		Last Available: "2017-10"
 9544	O	0		Last Available: "2017-10"
 9545	drinkable DUFRESNE Suds	4	good	Last Available: "2017-09"
 9546	clever arcane researcher's mafia pinky ring	0		Experience Percent (Mysticality): +10, Maximum MP: +20, Single Equip
-9547	lousy watered-down blinking spinning green flask of port	2	decent	
+9547	watered-down lousy spinning green blinking flask of port	2	decent	
 9548	up-at-dawn stiffened contract enforcement stick	0		Damage Reduction: 1, Adventures: +5
 9549	flavorless Hide-rox&trade; cookie	3	decent	Last Available: "2017-10"
 9550	artisanal jug of booze	4	EPIC	Last Available: "2017-10"
@@ -9453,8 +9453,8 @@
 9581	watered-down drinkable blue neg grog	2	good	Last Available: "2017-12"
 9582	normal half double fruitcake	4	good	Last Available: "2017-12"
 9583	stale upside-down hushed puppy	3	decent	Last Available: "2017-12"
-9584	huge adequate muffled muffuletta	7	good	Last Available: "2017-12"
-9585	spoiled jumbo skewed shushed potatoes	5	crappy	Last Available: "2017-12"
+9584	adequate huge muffled muffuletta	7	good	Last Available: "2017-12"
+9585	jumbo spoiled skewed shushed potatoes	5	crappy	Last Available: "2017-12"
 9586	huge plastic mime functionary of vim and vigor	0		Maximum HP Percent: +50, Last Available: "2017-12"
 9587	plastic mime scientist of Tarzan	0		Experience (Muscle): +3, Last Available: "2017-12"
 9588	plastic mime soldier of temperance	0		Sleaze Resistance: +5, Last Available: "2017-12"
@@ -9487,7 +9487,7 @@
 9615	silent Q	0		Last Available: "2017-12"
 9616	mirror silent R	0		Last Available: "2017-12"
 9617	silent S	0		Last Available: "2017-12"
-9618	huge pulsating huge silent T	0		Last Available: "2017-12"
+9618	pulsating huge huge silent T	0		Last Available: "2017-12"
 9619	silent U	0		Last Available: "2017-12"
 9620	blurry silent V	0		Last Available: "2017-12"
 9621	silent W	0		Last Available: "2017-12"
@@ -9498,7 +9498,7 @@
 9626	skewed anti-earplugs	0		Last Available: "2017-12"
 9627	warehouse key	0		Last Available: "2017-12"
 9628	mime pocket probe	0		Last Available: "2017-12"
-9629	mediocre distilled stale cheer wine	5	decent	Last Available: "2017-12"
+9629	distilled mediocre stale cheer wine	5	decent	Last Available: "2017-12"
 9630	rotten ghostly stale Cheer-E-Os	3	crappy	Last Available: "2017-12"
 9631	cheer-o-gram	0		Last Available: "2017-12"
 9632	twirling flame-retardant hale cheerful antler hat	0		Maximum HP: +20, Hot Resistance: +1, Last Available: "2017-12"
@@ -9519,7 +9519,7 @@
 9647	jittery mime eraser	0		Last Available: "2017-12"
 9648	mediocre executive mime flask	4	decent	Last Available: "2017-12"
 9649	adequate fancy pulsating nega-mushroom	4	good	Effect: "Mo' Hobo", Effect Duration: 25, Last Available: "2017-12"
-9650	high-proof mediocre nega-mushroom wine	10	decent	Last Available: "2017-12"
+9650	mediocre high-proof nega-mushroom wine	10	decent	Last Available: "2017-12"
 9651	frozen shaking Cheer-Up soda	0		Effect: "Almost Cool", Effect Duration: 45, Last Available: "2017-12"
 9652	stale mime army rations	3	decent	Last Available: "2017-12"
 9653	tolerable wobbly mime army wine	3	good	Last Available: "2017-12"
@@ -9536,9 +9536,9 @@
 9664	donated candy	0		
 9665	ionized colloidal digital honeypot	0		Effect: "No Vertigo", Effect Duration: 37, Last Available: "2025-12"
 9666	mime-proof sunglasses	0		Single Equip, Last Available: "2017-12"
-9667	personal trainer's mime army insignia (infantry)	0		Experience Percent (Muscle): +10, Single Equip, Stat Tuning: "Muscle (all)", Last Available: "2017-12"
-9668	supercharged mime army insignia (intelligence)	0		Maximum MP Percent: +30, Single Equip, Stat Tuning: "Mysticality (all)", Last Available: "2017-12"
-9669	mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Stat Tuning: "Moxie (all)", Last Available: "2017-12"
+9667	personal trainer's mime army insignia (infantry)	0		Experience Percent (Muscle): +10, Single Equip, Last Available: "2017-12", Stat Tuning: "Muscle (all)"
+9668	supercharged mime army insignia (intelligence)	0		Maximum MP Percent: +30, Single Equip, Last Available: "2017-12", Stat Tuning: "Mysticality (all)"
+9669	mime army insignia (espionage) of the empath	0		Familiar Weight: +5, Single Equip, Last Available: "2017-12", Stat Tuning: "Moxie (all)"
 9670	yellow mime army insignia (pyrotechnics)	0		Single Equip, Last Available: "2017-12"
 9671	teal mime army insignia (cryonics)	0		Single Equip, Last Available: "2017-12"
 9672	mime army insignia (psychological warfare)	0		Single Equip, Last Available: "2017-12"
@@ -9572,16 +9572,16 @@
 9700	novelty monorail ticket of the overflowing toilet	0		Stench Spell Damage: +50, Item Drop: +5
 9701	boiled pills	1		
 9702	altered spinning upside-down furry pill	1		
-9703	modified lime green shaking beefy pill	1		Effect: "Enraged", Effect Duration: 25
+9703	modified shaking lime green beefy pill	1		Effect: "Enraged", Effect Duration: 25
 9704	dried excitement pill	1		
 9705	dehydrated tumbling vitamin G pill	1		Effect: "Crying, Dying", Effect Duration: 20
 9706	denatured lucky-ish pill	1		
-9707	distilled ghostly green dieting pill	1		
+9707	distilled green ghostly dieting pill	1		
 9712	Clan Carnival Game	0		Free Pull, Last Available: "2018-02"
 9713	How To Get Bigger Without Really Trying	0		Skill: "Get Big", Last Available: "2018-02"
 9714	upside-down Illustrated Mating Rituals of the Gallapagos	0		Skill: "Gallapagosian Mating Call", Last Available: "2018-02"
 9715	Convincing People You Can See The Future	0		Skill: "Inscrutable Gaze", Last Available: "2018-02"
-9716	skewed shaking Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
+9716	shaking skewed Love Potions and the Wizards who Mix Them	0		Skill: "Love Mixology", Last Available: "2018-02"
 9717	They'll Love You In Rhinestones	0		Skill: "Acquire Rhinestones", Last Available: "2018-02"
 9718	Silly Little Love Song	0		Skill: "Paul's Passionate Pop Song", Last Available: "2018-02"
 9719	greedy strapping genie's turbane	0		Muscle: +5, Meat Drop: +20, Last Available: "2018-02"
@@ -9629,7 +9629,7 @@
 9761	pulsating Pok&eacute;-Gro fertilizer	0		Last Available: "2018-03"
 9762	Globmule	0		Last Available: "2018-03"
 9763	Bluzzard	0		Last Available: "2018-03"
-9764	huge pulsating Faux	0		Last Available: "2018-03"
+9764	pulsating huge Faux	0		Last Available: "2018-03"
 9765	twirling Sledgehamster	0		Last Available: "2018-03"
 9766	blinking skewed Pimpsqueak	0		Last Available: "2018-03"
 9767	Pillowbug	0		Last Available: "2018-03"
@@ -9661,7 +9661,7 @@
 9793	Wullabye	0		Last Available: "2018-03"
 9794	upside-down Nursine	0		Last Available: "2018-03"
 9795	Cantelope	0		Last Available: "2018-03"
-9796	olive wobbly Ungulant	0		Last Available: "2018-03"
+9796	wobbly olive Ungulant	0		Last Available: "2018-03"
 9797	Caramel	0		Last Available: "2018-03"
 9798	Oppossum	0		Last Available: "2018-03"
 9799	Amanitee	0		Last Available: "2018-03"
@@ -9688,7 +9688,7 @@
 9820	Keese berry	0		Last Available: "2018-03"
 9821	luck incense	0		Familiar Weight: +10, Item Drop: +25, Lasts Until Rollover, Last Available: "2018-03"
 9822	jittery bouncing shell bell	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
-9823	spinning fuchsia squat muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
+9823	fuchsia squat spinning muscle band	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9824	amulet coin	0		Familiar Weight: +10, Meat Drop: +50, Lasts Until Rollover, Last Available: "2018-03"
 9825	razor fang	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
 9826	red smoke ball	0		Familiar Weight: +10, Lasts Until Rollover, Last Available: "2018-03"
@@ -9697,7 +9697,7 @@
 9829	dried mirror brilliant oyster egg	1		Effect: "Prelude of Precision", Effect Duration: 50
 9830	pickled glistening oyster egg	1		
 9831	altered scintillating oyster egg	1		
-9832	mixed teal ghostly pearlescent oyster egg	1		Effect: "Hopped Up on Goofballs", Effect Duration: 5
+9832	mixed ghostly teal pearlescent oyster egg	1		Effect: "Hopped Up on Goofballs", Effect Duration: 5
 9833	dried spinning blue lustrous oyster egg	1		
 9834	mixed gleaming oyster egg	1		Effect: "Dancing Prowess", Effect Duration: 50
 9835	ghostly FantasyRealm membership packet	0		Free Pull, Last Available: "2018-04"
@@ -9710,7 +9710,7 @@
 9842	lump of bauxite	0		Last Available: "2018-12"
 9843	Rosewater's &quot;Remember the Trees&quot; Shirt of courage of the detective	0		Mysticality Percent: +30, Spooky Resistance: +3, Item Drop: +20
 9844	FantasyRealm key	0		Last Available: "2018-04"
-9845	skewed twirling plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
+9845	twirling skewed plump mushroom	0		Lasts Until Rollover, Last Available: "2018-04"
 9846	teal twirling tainted marshmallow	0		Lasts Until Rollover, Last Available: "2018-04"
 9847	Chewsick Copperbottom's notes	0		Lasts Until Rollover, Last Available: "2018-04"
 9848	cyan LyleCo premium pickaxe	0		Last Available: "2018-04"
@@ -9725,9 +9725,9 @@
 9857	extra-energized universal antivenin	0		Lasts Until Rollover, Effect: "Cotton Mouthed", Effect Duration: 56, Last Available: "2018-04"
 9858	LyleCo premium monocle	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
 9859	maroon LyleCo premium magnifying glass	0		Rubee Drop: 1, Single Equip, Last Available: "2018-04"
-9860	blurry mirror FantasyRealm tattoo kit	0		Last Available: "2018-04"
+9860	mirror blurry FantasyRealm tattoo kit	0		Last Available: "2018-04"
 9861	LyleCo Contractor's Manual	0		Skill: "Expert Corner-Cutter", Last Available: "2018-04"
-9862	adequate small FantasyRealm turkey leg	2	good	Last Available: "2018-04"
+9862	small adequate FantasyRealm turkey leg	2	good	Last Available: "2018-04"
 9863	bad FantasyRealm mead	4	decent	Last Available: "2018-04"
 9864	nasty haunch	0		Lasts Until Rollover, Last Available: "2018-04"
 9865	Cheswick Copperbottom's compass	0		Lasts Until Rollover, Last Available: "2018-04"
@@ -9760,19 +9760,19 @@
 9892	blinking smelly therapeutic scepter of the Skeleton Lord of vim and vigor	0		Maximum HP Percent: +50, Stench Spell Damage: +10, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2018-04"
 9893	teal mirror lightning-fast sizzling nippy deadfall branch of the sewer	0		Cold Damage: +10, Hot Damage: +10, Stench Damage: +25, Initiative: +40
 9894	shaking Usain Bolt's scandalous nippy Annie Oakley's padded Staff of Kitchen Royalty	0		Damage Absorption: +20, Critical Hit Percent: +20, Cold Damage: +10, Sleaze Damage: +5, Initiative: +80, Last Available: "2018-04"
-9895	shaking wobbly charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
+9895	wobbly shaking charged druidic orb	0		Lasts Until Rollover, Last Available: "2018-04"
 9896	green dragon slaying sword	0		Lasts Until Rollover, Last Available: "2018-04"
 9897	narrow notarized arrest warrant	0		Lasts Until Rollover, Last Available: "2018-04"
 9898	perfectly mixed two meat muck	4	EPIC	
-9899	flavorless bite-sized green chocolate Ogre Chieftain	1	decent	
-9900	delicious small chocolate &quot;Phoenix&quot;	2	awesome	
+9899	bite-sized flavorless green chocolate Ogre Chieftain	1	decent	
+9900	small delicious chocolate &quot;Phoenix&quot;	2	awesome	
 9901	decent snack-sized chocolate Spider Queen	2	good	
 9902	mediocre hipster cocktail	4	decent	
-9903	God Lobster's Scepter	0		Familiar Effect: "small fairy/lep", Equips On: "God Lobster", Last Available: "2018-05"
-9904	God Lobster's Ring	0		Familiar Effect: "sombrero", Equips On: "God Lobster", Last Available: "2018-05"
-9905	wobbly God Lobster's Rod	0		Familiar Effect: "whelp", Equips On: "God Lobster", Last Available: "2018-05"
-9906	pulsating God Lobster's Robe	0		Familiar Effect: "block", Equips On: "God Lobster", Last Available: "2018-05"
-9907	tumbling red God Lobster's Crown	0		Familiar Effect: "fairy", Equips On: "God Lobster", Last Available: "2018-05"
+9903	God Lobster's Scepter	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "small fairy/lep"
+9904	God Lobster's Ring	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "sombrero"
+9905	wobbly God Lobster's Rod	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "whelp"
+9906	pulsating God Lobster's Robe	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "block"
+9907	red tumbling God Lobster's Crown	0		Last Available: "2018-05", Equips On: "God Lobster", Familiar Effect: "fairy"
 9908	skewed Dish of Clarified Butter	0		Last Available: "2018-05"
 9909	wobbly G	0		
 9910	Garland of Greatness	0		
@@ -9781,7 +9781,7 @@
 9913	huge glued A-Boo clue	0		
 9914	crude oil congealer	0		
 9915	rotten low-calorie wobbly good guava	1	crappy	
-9916	hand-crafted extra-dry gin and ginger	5	EPIC	
+9916	extra-dry hand-crafted gin and ginger	5	EPIC	
 9917	wobbly Thwaitgold chigger statuette	0		
 9918	dehydrated mirror pulsating gaseous gravy	1		
 9919	pulsating SongBoom&trade; BoomBox	0		Last Available: "2018-06"
@@ -9797,7 +9797,7 @@
 9929	bouncing padded sinister Fonzie's savvy Brutal brogues	0		Mysticality Percent: +20, Experience (Moxie): +1, Spell Damage: +10, Damage Absorption: +20, Lasts Until Rollover, Last Available: "2018-07"
 9930	perfumed frosty vibrating Draftsman's driving gloves of temperance	0		Maximum MP Percent: +10, Cold Spell Damage: +10, Stench Resistance: +5, Sleaze Resistance: +5, Lasts Until Rollover, Last Available: "2018-07"
 9931	Temple Grandin's occult Nouveau nosering of the storm of doom	0		Spell Damage Percent: +25, Maximum MP Percent: +40, Familiar Weight: +7, Spooky Spell Damage: +50, Lasts Until Rollover, Last Available: "2018-07"
-9932	denatured dry teal wobbly sharkfin gumbo	0		Effect: "Venomous Weapon", Effect Duration: 30, Last Available: "2018-07"
+9932	denatured dry wobbly teal sharkfin gumbo	0		Effect: "Venomous Weapon", Effect Duration: 30, Last Available: "2018-07"
 9933	flattened squat boiling broth	0		Effect: "Pockets of Fire", Effect Duration: 39, Last Available: "2018-07"
 9934	flattened ionized galvanized interrogative elixir	0		Effect: "Celestial Sheen", Effect Duration: 52, Last Available: "2018-07"
 9935	Bastille Battalion Fondue Trophy	0		Last Available: "2018-07"
@@ -9807,12 +9807,12 @@
 9939	tumbling kitten burglar	0		Free Pull, Last Available: "2018-07"
 9940	burglar/sleep mask	0		Last Available: "2018-07"
 9941	Thwaitgold masked hunter statuette	0		
-9942	red jittery Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
+9942	jittery red Neverending Party invitation envelope	0		Free Pull, Last Available: "2018-09"
 9943	Neverending Party guest pass	0		Last Available: "2018-09"
 9944	reassuring nasty nippy PARTY HARD T-shirt	0		Cold Damage: +10, Stench Damage: +5, Spooky Resistance: +1, Last Available: "2018-09"
 9945	blinking Neverending Party favor	0		Last Available: "2018-09"
 9946	tumbling deluxe Neverending Party favor	0		Last Available: "2018-09"
-9947	blinking gray gas can	0		Last Available: "2018-09"
+9947	gray blinking gas can	0		Last Available: "2018-09"
 9948	lousy Middle of the Road&trade; brand whiskey	3	decent	Last Available: "2018-09"
 9949	neverending wallet chain	0		Last Available: "2018-09"
 9950	mirror Jeselnik's pentagram bandana of the overflowing toilet	0		Stench Spell Damage: +50, Sleaze Damage: +25, Last Available: "2018-09"
@@ -9823,7 +9823,7 @@
 9955	maroon smelly wholesome ponytail clip	0		Maximum HP Percent: +10, Stench Spell Damage: +10, Last Available: "2018-09"
 9956	gray quilted paint palette	0		Damage Absorption: +40, Conditional Skill (Equipped): "Paint Job", Last Available: "2018-09"
 9957	unremarkable duffel bag	0		Last Available: "2018-09"
-9958	powdered jittery huge mirror Purple Beast energy drink	1		Effect: "Wintergreen Warmongery", Effect Duration: 50, Last Available: "2018-09"
+9958	powdered mirror jittery huge Purple Beast energy drink	1		Effect: "Wintergreen Warmongery", Effect Duration: 50, Last Available: "2018-09"
 9959	pulsating cosmetic football of bravery	0		Spooky Resistance: +5, Last Available: "2018-09"
 9960	twirling sizzling Rosewater's shoe ad T-shirt	0		Mysticality Percent: +30, Hot Damage: +10, Last Available: "2018-09"
 9961	pump-up high-tops of the brute	0		Muscle Percent: +30, Single Equip, Last Available: "2018-09"
@@ -9831,7 +9831,7 @@
 9963	very small dress	0		Last Available: "2018-09"
 9964	supercool noticeable pumps of the cougar	0		Moxie: +20, Moxie Percent: +20, Single Equip, Last Available: "2018-09"
 9965	surprisingly capacious handbag	0		Last Available: "2018-09"
-9966	watered-down perfectly mixed bouncing squat everfull glass	2		Last Available: "2018-09"
+9966	watered-down perfectly mixed squat bouncing everfull glass	2		Last Available: "2018-09"
 9967	spinning van key	0		Last Available: "2018-09"
 9968	jam band bootleg	0		Last Available: "2018-09"
 9969	twirling gray clever Herculean denim jacket	0		Experience (Muscle): +1, Maximum MP: +20, Last Available: "2018-09"
@@ -9848,8 +9848,8 @@
 9981	pickled squat Party-in-a-Can&trade;	1		Last Available: "2018-09"
 9982	party pup	0		Last Available: "2018-09"
 9983	aromatic party crasher	0		Stench Resistance: +1, Item Drop: +5, Damage Reduction: 9, Conditional Skill (Equipped): "Party Crash", Last Available: "2018-09"
-9984	ghostly Living to Drink, Drinking to Live	0		Skill: "Drinking to Drink", Last Available: "2018-09"
-9985	skewed ghostly Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
+9984	ghostly Living to Drink, Drinking to Live	0		Last Available: "2018-09", Skill: "Drinking to Drink"
+9985	ghostly skewed Party Tattoo&trade; gift certificate	0		Last Available: "2018-09"
 9986	narrow party mouse hat	0		Familiar Weight: +5
 9987	latte lovers member's mug	0		Conditional Skill (Equipped): "Throw Latte on Opponent", Conditional Skill (Equipped): "Offer Latte to Opponent", Conditional Skill (Equipped): "Gulp Latte", Last Available: "2018-10"
 9988	maroon latte lovers club card	0		Free Pull, Last Available: "2018-10"
@@ -9874,27 +9874,27 @@
 10008	inspector's Temple Grandin's hardened mutant legs	0		Damage Reduction: 3, Familiar Weight: +7, Item Drop: +15, Last Available: "2018-11"
 10009	mansplainer's crafty Samson's mutant crown	0		Experience (Muscle): +5, Maximum MP: +10, Monster Level: +15, Last Available: "2018-11"
 10010	stale ghostly ectoplasm	4	decent	Last Available: "2018-11"
-10011	normal big red	5	good	Last Available: "2018-11"
+10011	big normal red	5	good	Last Available: "2018-11"
 10012	drinkable bottle of vodka	3	good	Last Available: "2018-11"
 10013	moldy pizza	4	crappy	Last Available: "2018-11"
 10014	hand-crafted huge martini	3	EPIC	Last Available: "2018-11"
-10015	huge bland cherry pie	8	decent	Last Available: "2018-11"
+10015	bland huge cherry pie	8	decent	Last Available: "2018-11"
 10016	fancy drinkable eggnog	3	good	Effect: "Work For Hours a Week", Effect Duration: 5, Last Available: "2018-11"
 10017	glob of undifferentiated tissue	0		Last Available: "2018-11"
-10018	half-sized moldy gray Hell ramen	2	crappy	Last Available: "2018-11"
+10018	moldy half-sized gray Hell ramen	2	crappy	Last Available: "2018-11"
 10019	acceptable fuchsia gimlet	3	good	Last Available: "2018-11"
 10020	watered-down aged spinning twice-haunted screwdriver	2	awesome	Last Available: "2018-11"
 10021	bland candy cane	3	decent	Last Available: "2018-12"
 10022	weak bad gray runny fermented egg	2	decent	Last Available: "2018-12"
 10023	adequate oldcake	4	good	Last Available: "2018-12"
-10024	snack-sized adequate traditional Crimbo cookie	2	good	Last Available: "2023-06"
+10024	adequate snack-sized traditional Crimbo cookie	2	good	Last Available: "2023-06"
 10025	arcane researcher's plastic wild beaver	0		Experience Percent (Mysticality): +10, Last Available: "2018-12"
 10026	Fonzie's plastic reindeer	0		Experience (Moxie): +1, Last Available: "2018-12"
 10027	lion tamer's plastic Caf&eacute; Elf	0		Experience (familiar): +2, Last Available: "2018-12"
 10028	squat Socratic plastic orphan	0		Experience (Mysticality): +1, Last Available: "2018-12"
 10029	clever plastic Abuela Crimbo	0		Maximum MP: +20, Last Available: "2018-12"
 10030	maroon ghostly yule pup	0		Last Available: "2018-12"
-10031	twirling squat Braindeer	0		Last Available: "2018-12"
+10031	squat twirling Braindeer	0		Last Available: "2018-12"
 10032	mirror Crimbo dog sweater	0		Familiar Weight: +5
 10033	foul-smelling rosy-cheeked pristine walrus tusk	0		Maximum HP Percent: +30, Stench Damage: +10, Last Available: "2018-12"
 10034	ghostly twirling thick walrus blubber	0		Last Available: "2018-12"
@@ -9902,19 +9902,19 @@
 10036	spinning bomb	0		Last Available: "2018-12"
 10037	plastic bazooka	0		Last Available: "2018-12"
 10038	mooseflank	0		Last Available: "2018-12"
-10039	normal half-sized grilled mooseflank	2	good	Last Available: "2018-12"
+10039	half-sized normal grilled mooseflank	2	good	Last Available: "2018-12"
 10040	moldy moosemeat pie	3	crappy	Last Available: "2018-12"
 10041	extremely unsafe balanced antler	0		Weapon Damage Percent: +100, Last Available: "2018-12"
 10042	inspector's dam	0		Item Drop: +15, Damage Reduction: 9, Last Available: "2018-12"
 10043	mediocre beavermouth	4	decent	Last Available: "2018-12"
-10044	smooth practically non-alcoholic beaver punch (papaya)	1	awesome	Last Available: "2018-12"
-10045	mediocre practically non-alcoholic beaver punch (peach)	1	decent	Last Available: "2018-12"
-10046	perfectly mixed practically non-alcoholic beaver punch (cherry)	1	super ultra mega EPIC	Last Available: "2018-12"
+10044	practically non-alcoholic smooth beaver punch (papaya)	1	awesome	Last Available: "2018-12"
+10045	practically non-alcoholic mediocre beaver punch (peach)	1	decent	Last Available: "2018-12"
+10046	practically non-alcoholic perfectly mixed beaver punch (cherry)	1	super ultra mega EPIC	Last Available: "2018-12"
 10047	clever Canadian lantern of the pedagogue	0		Experience: +3, Maximum MP: +20, Last Available: "2018-12"
 10048	shaking friendly muskox-skin cap	0		Familiar Weight: +3, Last Available: "2018-12"
 10049	Boxing Day care package	0		Free Pull, Last Available: "2018-12"
 10050	normal glass of raw eggs	3	good	Last Available: "2018-12"
-10051	special distilled perfectly mixed punch-drunk punch	5	EPIC	Effect: "Cold Blooded", Effect Duration: 15, Last Available: "2018-12"
+10051	distilled special perfectly mixed punch-drunk punch	5	EPIC	Effect: "Cold Blooded", Effect Duration: 15, Last Available: "2018-12"
 10052	distilled pulsating body spradium	1		Effect: "Chalky White Pallor", Effect Duration: 50, Last Available: "2018-12"
 10053	olive wobbly bauxite beret of the overflowing toilet	0		Stench Spell Damage: +50, Last Available: "2018-12"
 10054	bouncing nippy bauxite boxers	0		Cold Damage: +10, Last Available: "2018-12"
@@ -9931,8 +9931,8 @@
 10065	Toyleporter	0		Last Available: "2018-12"
 10066	bad beer	4	decent	Last Available: "2018-12"
 10067	normal yule gruel	3	good	Last Available: "2018-12"
-10068	acceptable practically non-alcoholic hot watered rum	1	good	Last Available: "2018-12"
-10069	acceptable watered-down bottle of Crimbognac	2	good	Last Available: "2018-12"
+10068	practically non-alcoholic acceptable hot watered rum	1	good	Last Available: "2018-12"
+10069	watered-down acceptable bottle of Crimbognac	2	good	Last Available: "2018-12"
 10070	decent Crimboysters Rockefeller	4	good	Last Available: "2018-12"
 10071	altered Crimbeau de toilette	1		Effect: "Berry Experiential", Effect Duration: 35, Last Available: "2018-12"
 10072	Crimbo candle	0		Last Available: "2018-12"
@@ -9992,7 +9992,7 @@
 10126	Jim Carey's padded glass shiv	0		Damage Absorption: +20, Monster Level: +25, Last Available: "2021-12"
 10127	Fonzie's glass serape of doom	0		Experience (Moxie): +1, Spooky Spell Damage: +50, Last Available: "2021-12"
 10128	altered glass shards	1		Effect: "Human-Hippy Hybrid", Effect Duration: 30, Last Available: "2021-12"
-10129	improved dry skewed blue hard candy	0		Effect: "Extra-Sharp Weapon", Effect Duration: 30
+10129	improved dry blue skewed hard candy	0		Effect: "Extra-Sharp Weapon", Effect Duration: 30
 10130	mirror family-friendly coward's loofah lumberjack's hat	0		Monster Level: -20, Sleaze Resistance: +1, Conditional Skill (Equipped): "Loofah Head-Scratch", Last Available: "2022-12"
 10131	hardened Rosewater's loofah lei	0		Mysticality Percent: +30, Damage Reduction: 3, Single Equip, Conditional Skill (Equipped): "Loofah Lei Lasso", Last Available: "2022-12"
 10132	fireproof supercharged loofah lederhosen	0		Maximum MP Percent: +30, Hot Resistance: +3, Conditional Skill (Equipped): "Loofah Hosenzittern", Last Available: "2022-12"
@@ -10007,7 +10007,7 @@
 10141	squat olive flagstone fez of the blizzard of mayonnaise	0		Cold Spell Damage: +25, Sleaze Spell Damage: +50, Conditional Skill (Equipped): "Flagstone Fez Ritual", Last Available: "2022-12"
 10142	bouncing perfumed flagstone fleece of mayonnaise	0		Sleaze Spell Damage: +50, Stench Resistance: +5, Conditional Skill (Equipped): "Flagstone Fleece Flex", Last Available: "2022-12"
 10143	energetic dance instructor's flagstone fringe	0		Experience Percent (Moxie): +10, Maximum MP Percent: +20, Single Equip, Conditional Skill (Equipped): "Flagstone Foxtrot", Last Available: "2022-12"
-10144	modified purple blinking flagstone flagments	1		Effect: "The Magic of LOV", Effect Duration: 15, Last Available: "2022-12"
+10144	modified blinking purple flagstone flagments	1		Effect: "The Magic of LOV", Effect Duration: 15, Last Available: "2022-12"
 10145	boiled boiled Flag by the Foot&trade;	0		Effect: "Grumpy and Ornery", Effect Duration: 20
 10146	elf sleeper agent	0		Free Pull, Last Available: "2019-12"
 10147	red-and-green microcamera	0		Familiar Weight: +5
@@ -10018,16 +10018,16 @@
 10152	sew-on bandage	0		Last Available: "2019-12"
 10153	really nice net	0		Last Available: "2019-12"
 10154	manspreader's elf army poncho	0		Monster Level: +10, Lasts Until Rollover, Last Available: "2019-12"
-10155	thick delicious elf army field rations	5	awesome	Last Available: "2019-12"
+10155	delicious thick elf army field rations	5	awesome	Last Available: "2019-12"
 10156	gingernade	0		Last Available: "2019-12"
 10157	discarded bowtie of the pedagogue of the scaredy-cat	0		Experience: +3, Monster Level: -15, Lasts Until Rollover, Last Available: "2019-12"
 10158	mediocre purple martiny	3	decent	Last Available: "2019-12"
 10159	tryptophan dart	0		Last Available: "2019-12"
 10160	moist wobbly licorice snake	0		Effect: "Fudgehound", Effect Duration: 27
-10161	boiled irradiated pulsating fuchsia virgin jello shot	0		Effect: "Tearful, Fearful", Effect Duration: 67
+10161	boiled irradiated fuchsia pulsating virgin jello shot	0		Effect: "Tearful, Fearful", Effect Duration: 67
 10162	colloidal skewed tumbling mutated candy lump	0		Effect: "Spell Transfer Complete", Effect Duration: 26
-10163	altered green squat government-issued candy	0		Effect: "Ooh, Bitter!", Effect Duration: 66
-10164	flattened blue skewed Pneumo bar	0		Effect: "Sweet and Green", Effect Duration: 32
+10163	altered squat green government-issued candy	0		Effect: "Ooh, Bitter!", Effect Duration: 66
+10164	flattened skewed blue Pneumo bar	0		Effect: "Sweet and Green", Effect Duration: 32
 10165	huge mint condition Lil' Doctor&trade; bag	0		Free Pull, Last Available: "2019-02"
 10166	resourceful Lil' Doctor&trade; bag of the sweet-tooth	0		Maximum MP: +50, Candy Drop: +100, Single Equip, Conditional Skill (Equipped): "Otoscope", Conditional Skill (Equipped): "Reflex Hammer", Conditional Skill (Equipped): "Chest X-Ray", Last Available: "2019-02"
 10168	yellow blood bag	0		
@@ -10036,12 +10036,12 @@
 10171	adequate actual blood sausage	3	good	
 10172	fortified mediocre mulled blood	5	decent	
 10173	yummy blood snowcone	3	awesome	
-10174	weak bad blurry Red Russian	2	decent	
-10175	rotten gray skewed wobbly blood roll-up	4	crappy	
+10174	bad weak blurry Red Russian	2	decent	
+10175	rotten skewed gray wobbly blood roll-up	4	crappy	
 10176	lousy irresponsibly strong bottle of blood	9	decent	
-10177	tiny stale green tumbling blood-soaked sponge cake	1	decent	
-10178	fancy high-proof delicious purple vampagne	10	awesome	Effect: "Arresistible", Effect Duration: 25
-10179	half-sized rotten fancy plain snowcone	2	crappy	Effect: "Limber as Mortimer", Effect Duration: 15
+10177	stale tiny green tumbling blood-soaked sponge cake	1	decent	
+10178	fancy delicious high-proof purple vampagne	10	awesome	Effect: "Arresistible", Effect Duration: 25
+10179	rotten fancy half-sized plain snowcone	2	crappy	Effect: "Limber as Mortimer", Effect Duration: 15
 10180	Booke of Vampyric Knowledge	0		
 10181	money bag	0		
 10182	cyan money bag	0		
@@ -10065,7 +10065,7 @@
 10200	huge melty plastic grenade	0		Last Available: "2019-04"
 10201	lousy weak fuchsia bottle of dark rhum	2	decent	Last Available: "2019-04"
 10202	smooth bottle of extra-dark rhum	3	awesome	Last Available: "2019-04"
-10203	delicious triple-distilled yellow bottle of super-extra-dark rhum	9	awesome	Last Available: "2019-04"
+10203	triple-distilled delicious yellow bottle of super-extra-dark rhum	9	awesome	Last Available: "2019-04"
 10204	non-boiled deionized pirate shaving cream	0		Effect: "Innately Wise", Effect Duration: 62, Last Available: "2019-04"
 10205	veiny conquistador's breastplate of Tarzan	0		Experience (Muscle): +3, Maximum HP: +10, Last Available: "2019-04"
 10206	ghostly squat vibrating brainy pirate pantaloons	0		Mysticality: +5, Maximum MP Percent: +10, Last Available: "2019-04"
@@ -10075,7 +10075,7 @@
 10210	tumbling cool pirate radio ring of the pedagogue	0		Moxie: +5, Experience: +3, Single Equip, Last Available: "2019-04"
 10211	fuchsia Island Drinkin', a Tiki Mixology Odyssey	0		Skill: "Tiki Mixology", Last Available: "2019-04"
 10212	spoiled half-sized cyan blinking pineapple slab	2	crappy	Last Available: "2019-04"
-10213	flavorless snack-sized huge hibiscus petal	2	decent	Last Available: "2019-04"
+10213	snack-sized flavorless huge hibiscus petal	2	decent	Last Available: "2019-04"
 10214	polarized pickled huge mint leaf	0		Effect: "Triangle, Man", Effect Duration: 60, Last Available: "2019-04"
 10215	cocoa of youth	0		Last Available: "2019-04"
 10216	diluted ice molecule	1		Last Available: "2019-04"
@@ -10103,7 +10103,7 @@
 10238	delicious spirit-forward Scorpion Bowl	5	awesome	Last Available: "2019-04"
 10239	hand-crafted wobbly Turtle Bowl	3	super EPIC	Last Available: "2019-04"
 10240	weak mediocre Cobra Bowl	2	decent	Last Available: "2019-04"
-10241	skewed blinking vampyric cloake pattern	0		Free Pull
+10241	blinking skewed vampyric cloake pattern	0		Free Pull
 10242	mirror Usain Bolt's foul-smelling Lo Pan's wholesome vampyric cloake of the overflowing toilet	0		Maximum HP Percent: +10, Spell Critical Percent: +30, Stench Damage: +10, Stench Spell Damage: +50, Initiative: +80, Conditional Skill (Equipped): "Become a Wolf", Conditional Skill (Equipped): "Become a Cloud of Mist", Conditional Skill (Equipped): "Become a Bat", Last Available: "2019-03"
 10243	plastic pirate hat	0		Familiar Weight: +5
 10244	frozen magnetized squat one piece of bubble gum	0		Effect: "Turkey-Agitated", Effect Duration: 49
@@ -10134,8 +10134,8 @@
 10269	adjusted tumbling seashell	0		Effect: "Grumpy and Ornery", Effect Duration: 58, Last Available: "2019-07"
 10270	deionized vacuum-sealed blurry seashell	0		Effect: "Hip to Be Square Dancin'", Effect Duration: 17, Last Available: "2019-07"
 10271	skewed bunch of sea grapes	0		Last Available: "2019-07"
-10272	drinkable watered-down bottle of sea wine	2	good	Last Available: "2019-07"
-10273	pickled wobbly huge kelp	1		Effect: "Pop-eyed", Effect Duration: 20, Last Available: "2019-07"
+10272	watered-down drinkable bottle of sea wine	2	good	Last Available: "2019-07"
+10273	pickled huge wobbly kelp	1		Effect: "Pop-eyed", Effect Duration: 20, Last Available: "2019-07"
 10274	executive asbestos-lined foul-smelling dog trainer's Lo Pan's rosy-cheeked wholesome arcane researcher's driftwood hat of the bloodbag	0		Experience Percent (Mysticality): +10, Maximum HP Percent: 40, Maximum HP: +100, Spell Critical Percent: +30, Experience (familiar): +1, Stench Damage: +10, Hot Resistance: +5, Meat Drop: +40, Lasts Until Rollover, Last Available: "2019-07"
 10275	blinking family-friendly greasy scandalous Socratic brawny slick driftwood pants of the empath of the detective of the cheetah	0		Moxie: +10, Muscle Percent: +20, Experience (Mysticality): +1, Familiar Weight: +5, Sleaze Damage: +5, Sleaze Spell Damage: +10, Sleaze Resistance: +1, Item Drop: +20, Initiative: +60, Lasts Until Rollover, Last Available: "2019-07"
 10276	medical-grade forbidden razor-sharp dance instructor's groovy wizardly driftwood bracelet of the ox of vim and vigor of the storm	0		Muscle: +20, Mysticality: +25, Moxie Percent: +10, Experience Percent (Moxie): +10, Weapon Damage Percent: +25, Spell Damage Percent: +50, Maximum HP Percent: +50, Maximum MP Percent: +40, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Lasts Until Rollover, Last Available: "2019-07"
@@ -10165,11 +10165,11 @@
 10300	chilly MacGyver's whittled owl figurine of the detective	0		Maximum MP: +100, Cold Damage: +5, Item Drop: +20, Single Equip, Last Available: "2019-08"
 10301	ribald savvy whittled fox figurine of temperance	0		Mysticality Percent: +20, Sleaze Damage: +10, Sleaze Resistance: +5, Single Equip, Last Available: "2019-08"
 10302	up-at-dawn medical-grade Da Vinci's whittled walking stick of the sweet-tooth	0		Experience (Mysticality): +5, Candy Drop: +100, Adventures: +5, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2019-08"
-10303	toothsome massive campfire hot dog	7	awesome	Last Available: "2019-08"
-10304	special moldy gigantic campfire baked potato	10	crappy	Effect: "Patent Avarice", Effect Duration: 20, Last Available: "2019-08"
+10303	massive toothsome campfire hot dog	7	awesome	Last Available: "2019-08"
+10304	moldy gigantic special campfire baked potato	10	crappy	Effect: "Patent Avarice", Effect Duration: 20, Last Available: "2019-08"
 10305	rotten cyan campfire s'more	4	crappy	Last Available: "2019-08"
 10306	decent campfire beans	3	good	Last Available: "2019-08"
-10307	adequate big campfire stew	5	good	Last Available: "2019-08"
+10307	big adequate campfire stew	5	good	Last Available: "2019-08"
 10308	twirling campfire coffee	1	good	Last Available: "2019-08"
 10309	vacuum-sealed leftover chocolate bar	0		Effect: "Sleaze-Resistant Trousers", Effect Duration: 62
 10310	rare Meat isotope	0		
@@ -10194,8 +10194,8 @@
 10335	diabolic pizza cube	0		Last Available: "2019-11"
 10336	diabolic pizza	3		Lasts Until Rollover
 10337	normal bu&ntilde;uelos Jaliscos	4	good	Last Available: "2019-12"
-10338	bland diet flan del mar	1	decent	Last Available: "2019-12"
-10339	low-calorie bland skewed Baja sopapilla	1	decent	Last Available: "2019-12"
+10338	diet bland flan del mar	1	decent	Last Available: "2019-12"
+10339	bland low-calorie skewed Baja sopapilla	1	decent	Last Available: "2019-12"
 10340	teal slick plastic Mer-kin baker	0		Moxie: +10, Last Available: "2019-12"
 10341	up-at-dawn plastic sea elf	0		Adventures: +5, Last Available: "2019-12"
 10342	plastic yuleviathan of the pedagogue	0		Experience: +3, Last Available: "2019-12"
@@ -10205,13 +10205,13 @@
 10346	jumbo rotten mana-coated yams	5	crappy	Last Available: "2019-11"
 10347	spoiled upside-down mana-basted tofurkey leg	3	crappy	Last Available: "2019-11"
 10348	adequate blue mana-fortified cranberry sauce	3	good	Last Available: "2019-11"
-10349	moldy pulsating cyan shaking mana-stuffed herbal stuffing	4	crappy	Last Available: "2019-11"
+10349	moldy shaking cyan pulsating mana-stuffed herbal stuffing	4	crappy	Last Available: "2019-11"
 10350	human musk	0		Last Available: "2019-12"
 10351	dry gray patch of extra-warm fur	0		Effect: "Pyramid Power", Effect Duration: 18, Last Available: "2019-12"
-10352	vaporized jittery bouncing twirling industrial lubricant	1		Last Available: "2019-12"
+10352	vaporized twirling bouncing jittery industrial lubricant	1		Last Available: "2019-12"
 10353	denatured denatured pulsating unfinished pleasure	0		Effect: "Hyphemariffic", Effect Duration: 37, Last Available: "2019-12"
 10354	boiled vial of humanoid growth hormone	1		Effect: "Flamibili Tea", Effect Duration: 25, Last Available: "2019-12"
-10355	dried twirling pulsating a bug's lymph	1		Effect: "You Liver", Effect Duration: 10, Last Available: "2019-12"
+10355	dried pulsating twirling a bug's lymph	1		Effect: "You Liver", Effect Duration: 10, Last Available: "2019-12"
 10356	aerosolized squat organic potpourri	0		Effect: "Preternatural Greed", Effect Duration: 39, Last Available: "2019-12"
 10357	bad boot flask	3	decent	Last Available: "2019-12"
 10358	nitrogenated infernal snowball	0		Effect: "The Power of Negative Thinking", Effect Duration: 67, Last Available: "2019-12"
@@ -10227,7 +10227,7 @@
 10368	envelope full of Meat	0		Last Available: "2019-12"
 10369	vaporized pulsating livid energy	1		Last Available: "2019-12"
 10370	micronova	0		Last Available: "2019-12"
-10371	modified blinking yellow beggin' cologne	1		Last Available: "2019-12"
+10371	modified yellow blinking beggin' cologne	1		Last Available: "2019-12"
 10372	crafty oxygenated eggnog helmet of chilblains	0		Maximum MP: +10, Cold Damage: +25, Adventure Underwater, Last Available: "2019-12"
 10373	spinning hand-knitted diving booties	0		Last Available: "2019-12"
 10374	peppermint harpoon gun	0		Last Available: "2019-12"
@@ -10239,7 +10239,7 @@
 10380	The Spirit of Giving	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10381	The Spirit of Giving (used)	0		Skill: "The Spirit of Taking", Last Available: "2019-12"
 10382	fuchsia Crimbo Factory surprise box	0		Last Available: "2019-12"
-10383	cyan tumbling soggy gingerbread chunk	0		Last Available: "2019-12"
+10383	tumbling cyan soggy gingerbread chunk	0		Last Available: "2019-12"
 10384	double-flattened salty gumdrop	0		Effect: "Memory of Smarts", Effect Duration: 21, Last Available: "2019-12"
 10385	spinning therapeutic ribbon candy ascot of the detective	0		Item Drop: +20, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Last Available: "2019-12"
 10386	moist Crimbo spices	0		Last Available: "2019-12"
@@ -10253,9 +10253,9 @@
 10394	skewed Mer-kin rollpin of Calamity Jane of the cheetah	0		Critical Hit Percent: +15, Initiative: +60, Last Available: "2019-12"
 10395	personalizable gingerbread cookie	0		Last Available: "2019-12"
 10396	tinsel fin	0		Familiar Weight: +5
-10397	moldy half-sized wobbly bowl of mernudo	2	crappy	Last Available: "2019-12"
-10398	bad high-proof fishelada	10	decent	Last Available: "2019-12"
-10399	spoiled miniature squat green ojo de pez burrito	2	crappy	Last Available: "2019-12"
+10397	half-sized moldy wobbly bowl of mernudo	2	crappy	Last Available: "2019-12"
+10398	high-proof bad fishelada	10	decent	Last Available: "2019-12"
+10399	spoiled miniature green squat ojo de pez burrito	2	crappy	Last Available: "2019-12"
 10400	olive waterlogged wood	0		Last Available: "2019-12"
 10401	waterlogged cloth	0		Last Available: "2019-12"
 10402	skewed waterlogged stuffing	0		Last Available: "2019-12"
@@ -10270,10 +10270,10 @@
 10411	blinking shellacked nutcracker beard of the scaredy-cat	0		Damage Reduction: 7, Monster Level: -15, Single Equip, Last Available: "2019-12"
 10412	careful wholesome nutcracker cape	0		Maximum HP Percent: +10, Monster Level: -10, Last Available: "2019-12"
 10413	asbestos-lined grievous nutcracker epaulets	0		Weapon Damage Percent: +50, Hot Resistance: +5, Single Equip, Last Available: "2019-12"
-10414	pulsating skewed nutcracker figurine	0		Last Available: "2019-12"
+10414	skewed pulsating nutcracker figurine	0		Last Available: "2019-12"
 10415	miniature decent salt plum	2	good	Last Available: "2019-12"
 10416	jittery peppermint eel sauce	0		Last Available: "2019-12"
-10417	half-sized stale and bean	2	decent	Last Available: "2019-12"
+10417	stale half-sized and bean	2	decent	Last Available: "2019-12"
 10418	blurry yellow lard-coated Van der Graaf vibrating kelp-holly gun	0		Maximum MP Percent: +10, Sleaze Spell Damage: +25, MP Regen Min: 5, MP Regen Max: 7, Last Available: "2019-12"
 10419	studded Yuleviathan necklace	0		Damage Absorption: +80, Item Drop: +5, Single Equip, Last Available: "2019-12"
 10420	upside-down electrified peppermint spine of mayonnaise	0		Sleaze Spell Damage: +50, MP Regen Min: 3, MP Regen Max: 5, Last Available: "2019-12"
@@ -10287,10 +10287,10 @@
 10428	boiled irradiated narrow almond	0		Effect: "Larger", Effect Duration: 48
 10429	pressed handful of mixed nuts	0		Effect: "Frozen Shoulders", Effect Duration: 29, Last Available: "2019-12"
 10430	nutcracking pliers	0		
-10431	mirror blinking Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
+10431	blinking mirror Retrospecs try-at-home kit	0		Free Pull, Last Available: "2020-01"
 10432	bouncing lightning-fast therapeutic shellacked Retrospecs	0		Damage Reduction: 7, Initiative: +40, HP Regen Min: 5, HP Regen Max: 7, Single Equip, Free Pull, Conditional Skill (Equipped): "Detect Weakness", Last Available: "2020-01"
 10433	unopened Bird-a-Day calendar	0		Free Pull, Last Available: "2020-01"
-10434	blurry upside-down bouncing Bird-a-Day calendar	0		Last Available: "2020-01"
+10434	bouncing blurry upside-down Bird-a-Day calendar	0		Last Available: "2020-01"
 10437	mint-in-box Powerful Glove	0		Free Pull, Last Available: "2020-02"
 10438	occult Samson's Herculean Powerful Glove of the empath of bravery	0		Experience (Muscle): 6, Spell Damage Percent: +25, Familiar Weight: +5, Spooky Resistance: +5, Single Equip, Conditional Skill (Equipped): "CHEAT CODE: Replace Enemy", Conditional Skill (Equipped): "CHEAT CODE: Shrink Enemy", Conditional Skill (Equipped): "CHEAT CODE: Invisible Avatar", Conditional Skill (Equipped): "CHEAT CODE: Triple Size", Last Available: "2020-02"
 10439	enhanced signal receiver	0		
@@ -10299,7 +10299,7 @@
 10442	jittery quilted drippy truncheon	0		Damage Absorption: +40, Single Equip
 10443	lime green Driplet	0		
 10444	gray narrow drippy snail shell	0		
-10445	enchanted jumbo delicious squat drippy nugget	5	drippy	Effect: "Stands Alone", Effect Duration: 40
+10445	delicious enchanted jumbo squat drippy nugget	5	drippy	Effect: "Stands Alone", Effect Duration: 40
 10446	lousy practically non-alcoholic glass of drippy wine	1	drippy	
 10447	moldy drippy caviar	3	drippy	
 10448	spoiled drippy plum(?)	4	drippy	
@@ -10345,8 +10345,8 @@
 10488	mirror colossal free-range mushroom	0		Last Available: "2020-03"
 10489	half-sized moldy fancy jittery mushroom filet	2	crappy	Effect: "Slimy Flavor", Effect Duration: 25, Last Available: "2020-03"
 10490	skewed twirling mushroom slab	0		Last Available: "2020-03"
-10491	modified twirling ghostly mushroom tea	1		Effect: "Bottle in front of Me", Effect Duration: 50, Last Available: "2020-03"
-10492	fortified drinkable wobbly mushroom whiskey	5	good	Last Available: "2020-03"
+10491	modified ghostly twirling mushroom tea	1		Effect: "Bottle in front of Me", Effect Duration: 50, Last Available: "2020-03"
+10492	drinkable fortified wobbly mushroom whiskey	5	good	Last Available: "2020-03"
 10493	thinker's mushroom cap of incineration of temperance	0		Mysticality: +10, Hot Spell Damage: +50, Sleaze Resistance: +5, Last Available: "2020-03"
 10494	friendly banded Newton's mushroom shield of the businessman	0		Experience (Mysticality): +3, Damage Absorption: +100, Familiar Weight: +3, Meat Drop: +50, Damage Reduction: 6, Last Available: "2020-03"
 10495	aromatic medical-grade mushroom pants of vim and vigor of the blizzard	0		Maximum HP Percent: +50, Cold Spell Damage: +25, Stench Resistance: +1, HP Regen Min: 7, HP Regen Max: 10, Last Available: "2020-03"
@@ -10377,7 +10377,7 @@
 10520	bouncing bouncing drippy salt	0		
 10521	drippy pigment	0		
 10522	drippy bromide	0		
-10523	tumbling pulsating bouncing drippy flux	0		
+10523	tumbling bouncing pulsating drippy flux	0		
 10524	drippy stein	0		
 10525	artisanal irresponsibly strong drippy pilsner	10	drippy	
 10526	drippy staff	0		Conditional Skill (Equipped): "Drip Blast"
@@ -10394,8 +10394,8 @@
 10538	jittery Guzzlr pants	0		Last Available: "2020-05"
 10539	Guzzlr souvenir stein of courage	0		Spooky Resistance: +3, Last Available: "2020-05"
 10540	Guzzlr tattoo kit	0		Last Available: "2020-05"
-10541	delicious practically non-alcoholic narrow Ghiaccio Colada	1	awesome	Last Available: "2020-05"
-10542	watered-down smooth Sourfinger	2	awesome	Last Available: "2020-05"
+10541	practically non-alcoholic delicious narrow Ghiaccio Colada	1	awesome	Last Available: "2020-05"
+10542	smooth watered-down Sourfinger	2	awesome	Last Available: "2020-05"
 10543	drinkable watered-down huge Nog-on-the-Cob	2	good	Last Available: "2020-05"
 10544	artisanal weak Steamboat	2	EPIC	Last Available: "2020-05"
 10545	smooth cyan Buttery Boy	3	awesome	Last Available: "2020-05"
@@ -10431,7 +10431,7 @@
 10575	drippy candy bar	0		
 10576	pressed salty drippy candy bar	0		Effect: "The Two-Prong Crown", Effect Duration: 12
 10577	double-alkaline twirling writhing drippy candy bar	0		Effect: "Pisces Rising", Effect Duration: 50
-10578	double-ionized blurry bouncing gooey drippy candy bar	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 50
+10578	double-ionized bouncing blurry gooey drippy candy bar	0		Effect: "Yeah, It's Just Gasoline", Effect Duration: 50
 10579	baby camelCalf	0		Free Pull, Last Available: "2020-07"
 10580	dromedary drinking helmet	0		
 10581	packaged SpinMaster&trade; lathe	0		Free Pull, Last Available: "2020-08"
@@ -10459,7 +10459,7 @@
 10603	shaking fistful of wood shavings	0		
 10604	Yeg's Motel ashtray	0		Last Available: "2020-09"
 10605	Yeg's Motel alarm clock	0		Last Available: "2020-09"
-10606	electrified non-altered tumbling blurry yellow Yeg's Motel toothbrush	0		Effect: "Bloodstain-Resistant", Effect Duration: 56, Last Available: "2020-09"
+10606	electrified non-altered tumbling yellow blurry Yeg's Motel toothbrush	0		Effect: "Bloodstain-Resistant", Effect Duration: 56, Last Available: "2020-09"
 10607	tarnished Yeg's Motel hand soap	0		Effect: "Standard Cheer", Effect Duration: 67, Last Available: "2020-09"
 10608	green Yeg's Motel sewing kit	0		Last Available: "2020-09"
 10609	huge yummy Yeg's Motel pillow mint	8	awesome	Last Available: "2020-09"
@@ -10477,8 +10477,8 @@
 10621	squat greasy desk bell	0		Last Available: "2020-09"
 10622	spinning chess set	0		Last Available: "2020-09"
 10623	jittery onyx king	0		Last Available: "2020-09"
-10624	upside-down maroon onyx queen	0		Last Available: "2020-09"
-10625	jittery squat yellow narrow onyx rook	0		Last Available: "2020-09"
+10624	maroon upside-down onyx queen	0		Last Available: "2020-09"
+10625	yellow squat jittery narrow onyx rook	0		Last Available: "2020-09"
 10626	onyx bishop	0		Last Available: "2020-09"
 10627	mirror onyx knight	0		Last Available: "2020-09"
 10628	narrow onyx pawn	0		Last Available: "2020-09"
@@ -10510,7 +10510,7 @@
 10654	quadruple-polymerized liquefied ghostly boiling hot cocoa	0		Effect: "Going Ape", Effect Duration: 23, Last Available: "2020-12"
 10655	frozen activated cool hot cocoa	0		Effect: "Icy Composition", Effect Duration: 61, Last Available: "2020-12"
 10656	flattened skewed twirling overly-fancy hot cocoa	0		Effect: "Like a Fish to Walter", Effect Duration: 12, Last Available: "2020-12"
-10657	cold-filtered chilled gray tumbling hot cocoa au beurre	0		Effect: "Gingerbread Robust", Effect Duration: 31, Last Available: "2020-12"
+10657	cold-filtered chilled tumbling gray hot cocoa au beurre	0		Effect: "Gingerbread Robust", Effect Duration: 31, Last Available: "2020-12"
 10658	liquefied corrupted hot cocoa with rainbow marshmallows	0		Effect: "Jawin'", Effect Duration: 69, Last Available: "2020-12"
 10659	family-friendly Book of Old-Timey Carols	0		Sleaze Resistance: [+1*event(December)], Last Available: "2020-12"
 10660	horrifying Crimbo smile	0		Spooky Damage: [+25*event(December)], Last Available: "2020-12"
@@ -10535,9 +10535,9 @@
 10679	flame-retardant &quot;reusable&quot; grocery bag	0		Hot Resistance: +1, Lasts Until Rollover, Last Available: "2020-12"
 10680	Jeselnik's wine carrier	0		Sleaze Damage: +25, Lasts Until Rollover, Last Available: "2020-12"
 10681	stiffened candy bucket	0		Damage Reduction: 1, Lasts Until Rollover, Last Available: "2020-12"
-10682	vacuum-sealed aerosolized oxidized lime green pulsating prescription teeth whitener	0		Effect: "Dragged Through the Coals", Effect Duration: 49, Last Available: "2020-12"
+10682	vacuum-sealed aerosolized oxidized pulsating lime green prescription teeth whitener	0		Effect: "Dragged Through the Coals", Effect Duration: 49, Last Available: "2020-12"
 10683	dry super-diffused imported lemon lozenge	0		Effect: "Stinking Cloud", Effect Duration: 53, Last Available: "2020-12"
-10684	non-diffused skewed spinning hermedisiac cologne	0		Effect: "Super Speed", Effect Duration: 40, Last Available: "2020-12"
+10684	non-diffused spinning skewed hermedisiac cologne	0		Effect: "Super Speed", Effect Duration: 40, Last Available: "2020-12"
 10685	government food shipment	0		Last Available: "2020-12"
 10686	wobbly government booze shipment	0		Last Available: "2020-12"
 10687	government candy shipment	0		Last Available: "2020-12"
@@ -10568,7 +10568,7 @@
 10712	upside-down squat The Night Before Crimbo, Ch. 5 (used)	0		Skill: "Dimples, How Merry!", Last Available: "2020-12"
 10713	The Night Before Crimbo, Ch. 6	0		Skill: "Chubby and Plump", Last Available: "2020-12"
 10714	The Night Before Crimbo, Ch. 6 (used)	0		Skill: "Chubby and Plump", Last Available: "2020-12"
-10715	flavorless massive and pepper (stale)	9	decent	Last Available: "2020-12"
+10715	massive flavorless and pepper (stale)	9	decent	Last Available: "2020-12"
 10716	acceptable special cranberry margarita (brackish)	4	good	Effect: "Ready to Snap", Effect Duration: 45, Last Available: "2020-12"
 10717	fuzzy polar bear ears	0		Familiar Weight: +5, Experience (Muscle): +3, Last Available: "2020-12"
 10718	nose	0		Familiar Weight: +5, Experience (Mysticality): +3, Last Available: "2020-12"
@@ -10586,8 +10586,8 @@
 10730	pulsating crystal ball	0		Initiative: +50, Last Available: "2021-01"
 10731	fresh can of paint	0		Free Pull, Last Available: "2021-12"
 10732	fresh coat of paint	0		Last Available: "2021-12"
-10733	emotion chip	0		Free Pull, Skill: "Emotionally Chipped", Last Available: "2021-02"
-10734	huge spinal-fluid-covered emotion chip	0		Skill: "Emotionally Chipped", Last Available: "2021-02"
+10733	emotion chip	0		Free Pull, Last Available: "2021-02", Skill: "Emotionally Chipped"
+10734	huge spinal-fluid-covered emotion chip	0		Last Available: "2021-02", Skill: "Emotionally Chipped"
 10735	robo-battery	0		
 10736	Thwaitgold listening bug statuette	0		
 10737	shaking power seed	0		Free Pull, Last Available: "2021-03"
@@ -10597,7 +10597,7 @@
 10741	modified energized battery (D)	0		Effect: "Turn On, Tune In, Play Ball!", Effect Duration: 22, Last Available: "2021-03"
 10742	super-deionized battery (9-Volt)	0		Effect: "Nature's Bounty", Effect Duration: 57, Last Available: "2021-03"
 10743	denatured battery (lantern)	0		Effect: "Ready to Snap", Effect Duration: 67, Last Available: "2021-03"
-10744	extra-flattened warmed concentrated spinning teal battery (car)	0		Effect: "White Knuckles", Effect Duration: 32, Last Available: "2021-03"
+10744	extra-flattened warmed concentrated teal spinning battery (car)	0		Effect: "White Knuckles", Effect Duration: 32, Last Available: "2021-03"
 10745	cryptocloak	0		Last Available: "2025-12"
 10746	marshmallow	0		
 10747	tolerable marshmallow bomb	3	good	Last Available: "2021-03"
@@ -10611,7 +10611,7 @@
 10755	adjusted short glass of water	0		Effect: "Granolarrrgh", Effect Duration: 52, Last Available: "2021-05"
 10756	diffused corrupted blurry short	0		Effect: "On the Trolley", Effect Duration: 68, Last Available: "2021-05"
 10757	Thwaitgold quantum bug statuette	0		
-10758	ghostly squat quantum of familiar	0		
+10758	squat ghostly quantum of familiar	0		
 10759	fuchsia careful familiar scrapbook of the sewer	0		Monster Level: -10, Stench Damage: +25, Conditional Skill (Equipped): "Show Your Boring Familiar Pictures", Last Available: "2021-06"
 10760	packaged familiar scrapbook	0		Free Pull, Last Available: "2021-06"
 10761	clan underground fireworks shop	0		Last Available: "2021-07"
@@ -10659,9 +10659,9 @@
 10803	tumbling packaged Daylight Shavings Helmet	0		Free Pull, Last Available: "2021-11"
 10804	perfumed extremely unsafe experienced Daylight Shavings Helmet	0		Experience: +2, Weapon Damage Percent: +100, Stench Resistance: +5, Last Available: "2021-11"
 10805	enchanted skewed eggwater	1	good	Effect: "Memory of Strength", Effect Duration: 40, Last Available: "2021-12"
-10806	bite-sized flavorless bread man	1	decent	Last Available: "2021-12"
-10807	adequate massive plain candy cane	6	good	Last Available: "2021-12"
-10808	fancy snack-sized stale narrow lime green flour cookie	2	decent	Effect: "Fudge Headache", Effect Duration: 45, Last Available: "2021-12"
+10806	flavorless bite-sized bread man	1	decent	Last Available: "2021-12"
+10807	massive adequate plain candy cane	6	good	Last Available: "2021-12"
+10808	fancy stale snack-sized narrow lime green flour cookie	2	decent	Effect: "Fudge Headache", Effect Duration: 45, Last Available: "2021-12"
 10809	plastic food lab of the bloodbag	0		Maximum HP: +100, Single Equip, Last Available: "2021-12"
 10810	upside-down plastic nog lab of wisdom	0		Mysticality: +15, Single Equip, Last Available: "2021-12"
 10811	slick plastic chem lab	0		Moxie: +10, Single Equip, Last Available: "2021-12"
@@ -10673,19 +10673,19 @@
 10817	ghostly Sherlock's dog trainer's grievous jeans	0		Weapon Damage Percent: +50, Experience (familiar): +1, Item Drop: +25, Lasts Until Rollover, Last Available: "2021-12"
 10818	Jim Carey's ice wrap of the dark arts of vim and vigor	0		Spell Damage Percent: +100, Maximum HP Percent: +50, Monster Level: +25, Single Equip, Lasts Until Rollover, Last Available: "2021-12"
 10819	adequate tofu pop	3	good	Last Available: "2021-12"
-10820	miniature bland narrow bowl of prescription candy	2	decent	Last Available: "2021-12"
+10820	bland miniature narrow bowl of prescription candy	2	decent	Last Available: "2021-12"
 10821	jumbo yummy tumbling fishcake	5	awesome	Last Available: "2021-12"
-10822	spoiled small mirror bone broth	2	crappy	Last Available: "2021-12"
-10823	immense bland star pop	7	decent	Last Available: "2021-12"
+10822	small spoiled mirror bone broth	2	crappy	Last Available: "2021-12"
+10823	bland immense star pop	7	decent	Last Available: "2021-12"
 10824	smooth Doc's Fortifying Wine	3	awesome	Last Available: "2021-12"
-10825	fancy mediocre Doc's Smartifying Wine	3	decent	Effect: "Disco Neuropathy", Effect Duration: 35, Last Available: "2021-12"
+10825	mediocre fancy Doc's Smartifying Wine	3	decent	Effect: "Disco Neuropathy", Effect Duration: 35, Last Available: "2021-12"
 10826	artisanal special Doc's Limbering Wine	4	EPIC	Effect: "Heal Thy Nanoself", Effect Duration: 30, Last Available: "2021-12"
-10827	acceptable practically non-alcoholic ghostly tumbling Doc's Medical-Grade Wine	1	good	Last Available: "2021-12"
+10827	practically non-alcoholic acceptable tumbling ghostly Doc's Medical-Grade Wine	1	good	Last Available: "2021-12"
 10828	dehydrated Homebodyl&trade;	1		Last Available: "2021-12"
 10829	boiled spinning Extrovermectin&trade;	1		Effect: "Bootyliciousness", Effect Duration: 5, Last Available: "2021-12"
 10830	dried Breathitin&trade;	1		Effect: "Shawarma Initiative", Effect Duration: 5, Last Available: "2021-12"
 10831	vaporized blinking Fleshazole&trade;	1		Last Available: "2021-12"
-10832	galvanized dry bouncing tumbling anti-burn cream	0		Effect: "Engorged Weapon", Effect Duration: 22, Last Available: "2021-12"
+10832	galvanized dry tumbling bouncing anti-burn cream	0		Effect: "Engorged Weapon", Effect Duration: 22, Last Available: "2021-12"
 10833	polarized anti-freeze cream	0		Effect: "Big Flaming Whip", Effect Duration: 20, Last Available: "2021-12"
 10834	dry shaking anti-goosebump cream	0		Effect: "Inner Dog", Effect Duration: 32, Last Available: "2021-12"
 10835	enhanced anodized anti-odor cream	0		Effect: "Turkey-Friendly", Effect Duration: 36, Last Available: "2021-12"
@@ -10693,7 +10693,7 @@
 10837	colloidal quadruple-wet anti-pain cream	0		Effect: "Yes, Can Haz", Effect Duration: 49, Last Available: "2021-12"
 10838	acceptable high-proof ghostly wobbly Doc's Special Reserve Wine	6	good	Last Available: "2021-12"
 10839	flavorless bread pie	4	decent	Last Available: "2021-12"
-10840	triple-distilled delicious clear Russian	9	awesome	Last Available: "2021-12"
+10840	delicious triple-distilled clear Russian	9	awesome	Last Available: "2021-12"
 10841	zero-trust tanktop	0		Last Available: "2025-12"
 10842	Crimbo ball	0		Last Available: "2021-12"
 10843	Crimbo ball	0		Last Available: "2021-12"
@@ -10721,15 +10721,15 @@
 10865	upside-down gray universal biscuit	0		Last Available: "2021-12"
 10866	yule hatchet of the cheetah	0		Initiative: +60, Last Available: "2021-12"
 10867	squat potato alarm clock	0		Last Available: "2021-12"
-10868	thick tasty lab-grown meat	5	awesome	Last Available: "2021-12"
+10868	tasty thick lab-grown meat	5	awesome	Last Available: "2021-12"
 10869	fleece of Gandalf	0		Spell Critical Percent: +20, Last Available: "2021-12"
 10870	boxed gumball machine	0		Last Available: "2021-12"
 10871	upside-down cloning kit	0		Last Available: "2021-12"
 10872	skewed boxer's pants	0		Muscle Percent: +10, Last Available: "2021-12"
 10873	gravedigger's deadly can of mixed everything of mayonnaise	0		Weapon Damage: +5, Spooky Damage: +10, Sleaze Spell Damage: +50, Last Available: "2021-12"
-10874	bouncing maroon squat Site Alpha ID badge	0		Familiar Weight: +5
+10874	squat bouncing maroon Site Alpha ID badge	0		Familiar Weight: +5
 10875	the Crymbich Manuscript (used)	0		Skill: "Ancient Crymbo Lore", Last Available: "2021-12"
-10876	normal miniature twirling meatball	2	good	Last Available: "2021-12"
+10876	miniature normal twirling meatball	2	good	Last Available: "2021-12"
 10877	cloned monster	0		Last Available: "2021-12"
 10878	upside-down meatball machine	0		Last Available: "2021-12"
 10879	refurbished air fryer	0		Last Available: "2021-12"
@@ -10739,11 +10739,11 @@
 10883	compressed astral energy drink	1		
 10884	mint condition magnifying glass	0		Last Available: "2022-12"
 10885	skewed Annie Oakley's Fonzie's magnifying glass of Calamity Jane	0		Experience (Moxie): +1, Critical Hit Percent: 35, Last Available: "2022-12"
-10886	perfectly mixed watered-down blue void lager	2	EPIC	Last Available: "2022-12"
-10887	normal thick olive void burger	5	good	Last Available: "2022-12"
+10886	watered-down perfectly mixed blue void lager	2	EPIC	Last Available: "2022-12"
+10887	thick normal olive void burger	5	good	Last Available: "2022-12"
 10888	void stone	0		Last Available: "2022-12"
 10889	Jim Carey's energetic void shard of the brazier of courage	0		Maximum MP Percent: +20, Monster Level: +25, Hot Spell Damage: +25, Spooky Resistance: +3, Last Available: "2022-12"
-10890	fuchsia ghostly undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
+10890	ghostly fuchsia undrilled cosmic bowling ball	0		Free Pull, Last Available: "2022-01"
 10891	jittery cosmic bowling ball	0		Last Available: "2022-01"
 10892	combat lover's locket lockbox	0		Free Pull, Last Available: "2022-02"
 10893	greedy combat lover's locket	0		Meat Drop: +20, Single Equip, Last Available: "2022-02"
@@ -10774,7 +10774,7 @@
 10918	Thwaitgold harvestman statuette	0		
 10919	packaged June cleaver	0		Free Pull, Last Available: "2022-06"
 10920	rosewater-soaked sage June cleaver of mayonnaise	0		Mysticality Percent: +10, Sleaze Spell Damage: +50, Stench Resistance: +3, Attacks Can't Miss, Last Available: "2022-06"
-10921	practically non-alcoholic mediocre Dad's brandy	1	decent	Last Available: "2022-06"
+10921	mediocre practically non-alcoholic Dad's brandy	1	decent	Last Available: "2022-06"
 10922	fireproof teacher's pen of the ox	0		Muscle: +20, Hot Resistance: +3, Last Available: "2022-06"
 10923	bite-sized bland fire-roasted lake trout	1	decent	Last Available: "2022-06"
 10924	spoiled big guilty sprout	5	crappy	Last Available: "2022-06"
@@ -10782,7 +10782,7 @@
 10926	energized red trampled ticket stub	0		Effect: "La Bamba", Effect Duration: 54, Last Available: "2022-06"
 10927	non-energized savings bond	0		Effect: "Go Get 'Em, Tiger!", Effect Duration: 12, Last Available: "2022-06"
 10928	narrow designer sweatpants (new stock)	0		Free Pull, Last Available: "2022-07"
-10929	upside-down wobbly designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze", Last Available: "2022-07"
+10929	wobbly upside-down designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Last Available: "2022-07", Conditional Skill (Inventory): "Sweat Out Some Booze"
 10930	dehydrated sweat-ade	1		Last Available: "2022-07"
 10931	unopened stillsuit	0		Free Pull, Last Available: "2022-08"
 10932	stillsuit	0		Familiar Weight: +5, Experience (familiar): +1, Familiar Damage: +10, Last Available: "2022-08"
@@ -10812,7 +10812,7 @@
 10956	boozy bad red AutumnFest ale	5	decent	Last Available: "2022-10"
 10957	ribald hardened dance instructor's autumn sweater-weather sweater	0		Experience Percent (Moxie): +10, Damage Reduction: 3, Sleaze Damage: +10, Lasts Until Rollover, Last Available: "2022-10"
 10958	electrified steel-toed autumn debris shield of the bloodbag of horror	0		Damage Reduction: 18, Maximum HP: +100, Spooky Spell Damage: +25, MP Regen Min: 3, MP Regen Max: 5, Lasts Until Rollover, Last Available: "2022-10"
-10959	spoiled miniature autumn-spice donut	2	crappy	Last Available: "2022-10"
+10959	miniature spoiled autumn-spice donut	2	crappy	Last Available: "2022-10"
 10960	ionized autumn dollar	0		Effect: "Extra-Sharp Weapon", Effect Duration: 35, Last Available: "2022-10"
 10961	bouncing mansplainer's forbidden smartaleck's autumn leaf pendant	0		Moxie Percent: +30, Spell Damage Percent: +50, Monster Level: +15, Lasts Until Rollover, Last Available: "2022-10"
 10962	twisted shaking autumn breeze	1		Last Available: "2022-10"
@@ -10826,34 +10826,34 @@
 10970	decent ratatouille de Jarlsberg	3	good	Last Available: "2022-11"
 10971	toothsome thick Jarlsberg's vegetable soup	5	awesome	Last Available: "2022-11"
 10972	normal roasted vegetable of Jarlsberg	3	good	Last Available: "2022-11"
-10973	miniature flavorless St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
+10973	flavorless miniature St. Pete's sneaky smoothie	2	decent	Last Available: "2022-11"
 10974	stale Pete's wiley whey bar	3	decent	Last Available: "2022-11"
 10975	decent Pete's rich ricotta	3	good	Last Available: "2022-11"
 10976	tolerable maroon Boris's beer	4	good	Last Available: "2022-11"
 10977	stale honey bun of Boris	3	decent	Last Available: "2022-11"
-10978	bland jumbo pulsating Boris's bread	5	decent	Last Available: "2022-11"
-10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Recipe: "ratatouille de Jarlsberg", Last Available: "2022-11"
-10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Recipe: "Jarlsberg's vegetable soup", Last Available: "2022-11"
-10981	Recipe of Before Yore: roasted vegetable of J.	0		Recipe: "roasted vegetable of Jarlsberg", Last Available: "2022-11"
-10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Recipe: "St. Pete's sneaky smoothie", Last Available: "2022-11"
-10983	Recipe of Before Yore: Pete's wily whey bar	0		Recipe: "Pete's wiley whey bar", Last Available: "2022-11"
-10984	ghostly Recipe of Before Yore: Pete's rich ricotta	0		Recipe: "Pete's rich ricotta", Last Available: "2022-11"
-10985	Recipe of Before Yore: Boris's beer	0		Recipe: "Boris's beer", Last Available: "2022-11"
-10986	Recipe of Before Yore: honey bun of Boris	0		Recipe: "honey bun of Boris", Last Available: "2022-11"
-10987	narrow Recipe of Before Yore: Boris's bread	0		Recipe: "Boris's bread", Last Available: "2022-11"
+10978	jumbo bland pulsating Boris's bread	5	decent	Last Available: "2022-11"
+10979	Recipe of Before Yore: ratatouille de Jarlsberg	0		Last Available: "2022-11", Recipe: "ratatouille de Jarlsberg"
+10980	Recipe of Before Yore: Jarlsberg's vegetable soup	0		Last Available: "2022-11", Recipe: "Jarlsberg's vegetable soup"
+10981	Recipe of Before Yore: roasted vegetable of J.	0		Last Available: "2022-11", Recipe: "roasted vegetable of Jarlsberg"
+10982	Recipe of Before Yore: St. Pete's sneaky smoothie	0		Last Available: "2022-11", Recipe: "St. Pete's sneaky smoothie"
+10983	Recipe of Before Yore: Pete's wily whey bar	0		Last Available: "2022-11", Recipe: "Pete's wiley whey bar"
+10984	ghostly Recipe of Before Yore: Pete's rich ricotta	0		Last Available: "2022-11", Recipe: "Pete's rich ricotta"
+10985	Recipe of Before Yore: Boris's beer	0		Last Available: "2022-11", Recipe: "Boris's beer"
+10986	Recipe of Before Yore: honey bun of Boris	0		Last Available: "2022-11", Recipe: "honey bun of Boris"
+10987	narrow Recipe of Before Yore: Boris's bread	0		Last Available: "2022-11", Recipe: "Boris's bread"
 10988	moldy snack-sized pulsating spinning baked veggie ricotta casserole	2	crappy	Last Available: "2022-11"
 10989	stale immense plain calzone	7	decent	Last Available: "2022-11"
 10990	bland ghostly roasted vegetable focaccia	3	decent	Last Available: "2022-11"
-10991	small normal Pizza of Legend	2	good	Last Available: "2022-11"
-10992	spoiled gigantic Calzone of Legend	10	crappy	Last Available: "2022-11"
-10993	Recipe of Before Yore: Calzone of Legend	0		Recipe: "Calzone of Legend", Last Available: "2022-11"
-10994	Recipe of Before Yore: Pizza of Legend	0		Recipe: "Pizza of Legend", Last Available: "2022-11"
-10995	Recipe of Before Yore: roasted vegetable focaccia	0		Recipe: "roasted vegetable focaccia", Last Available: "2022-11"
-10996	Recipe of Before Yore: plain calzone	0		Recipe: "plain calzone", Last Available: "2022-11"
-10997	Recipe of Before Yore: baked veggie ricotta	0		Recipe: "baked veggie ricotta casserole", Last Available: "2022-11"
+10991	normal small Pizza of Legend	2	good	Last Available: "2022-11"
+10992	gigantic spoiled Calzone of Legend	10	crappy	Last Available: "2022-11"
+10993	Recipe of Before Yore: Calzone of Legend	0		Last Available: "2022-11", Recipe: "Calzone of Legend"
+10994	Recipe of Before Yore: Pizza of Legend	0		Last Available: "2022-11", Recipe: "Pizza of Legend"
+10995	Recipe of Before Yore: roasted vegetable focaccia	0		Last Available: "2022-11", Recipe: "roasted vegetable focaccia"
+10996	Recipe of Before Yore: plain calzone	0		Last Available: "2022-11", Recipe: "plain calzone"
+10997	Recipe of Before Yore: baked veggie ricotta	0		Last Available: "2022-11", Recipe: "baked veggie ricotta casserole"
 10998	cookbookbat book	0		Familiar Weight: +5
-10999	huge Recipe of Before Yore: Deep Dish of Legend	0		Recipe: "Deep Dish of Legend", Last Available: "2022-11"
-11000	huge moldy huge Deep Dish of Legend	8	crappy	Last Available: "2022-11"
+10999	huge Recipe of Before Yore: Deep Dish of Legend	0		Last Available: "2022-11", Recipe: "Deep Dish of Legend"
+11000	moldy huge huge Deep Dish of Legend	8	crappy	Last Available: "2022-11"
 11001	deed to Oliver's Place	0		Free Pull
 11002	drink chit	0		
 11003	blinking government per-diem	0		
@@ -10870,7 +10870,7 @@
 11014	mediocre Velvet Veil	3	decent	
 11015	hand-crafted practically non-alcoholic Marltini	1	super ultra EPIC	
 11016	smooth enchanted Strong, Silent Type	3	awesome	Effect: "Ruby-ous", Effect Duration: 45
-11017	watered-down delicious upside-down Mysterious Stranger	2	awesome	
+11017	delicious watered-down upside-down Mysterious Stranger	2	awesome	
 11018	mediocre Champagne Shimmy	4	decent	
 11019	the Sot's parcel	0		
 11020	pulsating wicked dance instructor's ceramic cestus	0		Experience Percent (Moxie): +10, Spell Damage: +5, Single Equip, Conditional Skill (Equipped): "Ceramic Punch", Last Available: "2023-12"
@@ -10887,8 +10887,8 @@
 11031	executive ruddy chiffon chemise of the brazier	0		Maximum HP Percent: +40, Hot Spell Damage: +25, Meat Drop: +40, Last Available: "2023-12"
 11032	prompt forbidden weightlifter's chiffon chakram	0		Muscle: +15, Spell Damage Percent: +50, Adventures: +3, Last Available: "2023-12"
 11033	mirror nasty nippy supercool chiffon chaps	0		Moxie Percent: +20, Cold Damage: +10, Stench Damage: +5, Last Available: "2023-12"
-11034	modified purple jittery chiffon carbage	1		Last Available: "2023-12"
-11035	polarized alkaline energized tumbling blurry chiffon lemon	0		Effect: "Mitre Cut", Effect Duration: 50
+11034	modified jittery purple chiffon carbage	1		Last Available: "2023-12"
+11035	polarized alkaline energized blurry tumbling chiffon lemon	0		Effect: "Mitre Cut", Effect Duration: 50
 11036	bland chocomotive	3	decent	Last Available: "2022-12"
 11037	flavorless freightcake	3	decent	Last Available: "2022-12"
 11038	acceptable cabooze	4	good	Last Available: "2022-12"
@@ -10949,7 +10949,7 @@
 11093	miser's grubby wool scarf of temperance	0		Sleaze Resistance: +5, Meat Drop: +10, Single Equip
 11094	pulsating dog trainer's steel-toed grubby wool trousers of temperance	0		Damage Reduction: 9, Experience (familiar): +1, Sleaze Resistance: +5
 11095	Sherlock's wool supercharged shellacked grubby wool gloves	0		Damage Reduction: 7, Maximum MP Percent: +30, Cold Resistance: +1, Item Drop: +25, Single Equip
-11096	blurry narrow grubby wool beerwarmer	0		
+11096	narrow blurry grubby wool beerwarmer	0		
 11097	drinkable practically non-alcoholic cyan nice warm beer	1	good	
 11098	purple grubby woolball	0		
 11099	Rock Garden Guide	0		Free Pull, Last Available: "2023-01"
@@ -10961,11 +10961,11 @@
 11105	green bolder boulder	0		Last Available: "2023-01"
 11106	blinking molehill mountain	0		Last Available: "2023-01"
 11107	blurry whet stone	0		Last Available: "2023-01"
-11108	blurry mirror hard rock	0		Last Available: "2023-01"
+11108	mirror blurry hard rock	0		Last Available: "2023-01"
 11109	stalagmite	0		Last Available: "2023-01"
 11110	chocolate covered ping-pong ball	0		
 11112	spoiled huge pixel bread	3	crappy	
-11113	drinkable gray upside-down pixel whiskey	3	good	
+11113	drinkable upside-down gray pixel whiskey	3	good	
 11114	wobbly pixel rock	0		
 11115	red S.I.T. Course Voucher	0		Free Pull, Last Available: "2023-02"
 11116	S.I.T. Course Completion Certificate	0		Last Available: "2023-02"
@@ -10974,12 +10974,12 @@
 11119	diffused jittery huge five-fingered fern resin	0		Effect: "Ten out of Ten", Effect Duration: 34, Last Available: "2023-02"
 11120	delicious narrow super good fruit	3	awesome	Last Available: "2023-02"
 11121	dried energized spores	1		Last Available: "2023-02"
-11122	greedy padded hot pepper	0		Damage Absorption: +20, Meat Drop: +20, Lantern Element: "Hot", Last Available: "2023-02"
-11123	dry pulsating upside-down purple out-of-work circus flea	0		Effect: "Always be Collecting", Effect Duration: 54, Last Available: "2023-02"
+11122	greedy padded hot pepper	0		Damage Absorption: +20, Meat Drop: +20, Last Available: "2023-02", Lantern Element: "Hot"
+11123	dry purple upside-down pulsating out-of-work circus flea	0		Effect: "Always be Collecting", Effect Duration: 54, Last Available: "2023-02"
 11124	extra-grubby grub	0		Last Available: "2023-02"
 11125	flattened colloidal fire ant pheromones	0		Effect: "Punch Another Day", Effect Duration: 35, Last Available: "2023-02"
 11126	pickled huge flapper fly	0		Effect: "Rushtacean'", Effect Duration: 25, Last Available: "2023-02"
-11127	high-proof delicious blue shot of wasp venom	8	awesome	Last Available: "2023-02"
+11127	delicious high-proof blue shot of wasp venom	8	awesome	Last Available: "2023-02"
 11128	quantum filled mosquito	0		Effect: "Pharmaceutically Cool", Effect Duration: 49, Last Available: "2023-02"
 11129	extra-improved shim of shame shale	0		Effect: "Faboooo", Effect Duration: 62, Last Available: "2023-02"
 11130	tarnished blinking pebble of proud pyrite	0		Effect: "Stench Jellied", Effect Duration: 51, Last Available: "2023-02"
@@ -10987,14 +10987,14 @@
 11132	hollow rock	0		Last Available: "2023-02"
 11133	irradiated angry agate	0		Effect: "Well-Oiled", Effect Duration: 60, Last Available: "2023-02"
 11134	dry lump of loyal latite	0		Effect: "Hot Blooded", Effect Duration: 54, Last Available: "2023-02"
-11135	jumbo rotten jittery shadow sausage	5	crappy	Last Available: "2023-03"
+11135	rotten jumbo jittery shadow sausage	5	crappy	Last Available: "2023-03"
 11136	ghostly horrifying frosty shadow skin	0		Cold Spell Damage: +10, Spooky Damage: +25, Last Available: "2023-03"
 11137	wet shadow flame	0		Effect: "Spirit of Alph", Effect Duration: 68, Last Available: "2023-03"
 11138	delicious shadow bread	3	awesome	Last Available: "2023-03"
 11139	narrow shadow ice	0		Last Available: "2023-03"
 11140	tolerable shadow fluid	4	good	Last Available: "2023-03"
 11141	shadow glass	0		Last Available: "2023-03"
-11142	ghostly skewed shadow brick	0		Last Available: "2023-03"
+11142	skewed ghostly shadow brick	0		Last Available: "2023-03"
 11143	lime green shadow sinew	0		Last Available: "2023-03"
 11144	hand-crafted shadow venom	4	EPIC	Last Available: "2023-03"
 11145	vaporized olive shadow nectar	1		Last Available: "2023-03"
@@ -11035,7 +11035,7 @@
 11180	maroon horrifying hale dangerous shadow monocle	0		Weapon Damage: +10, Maximum HP: +20, Spooky Damage: +25, Single Equip
 11181	bouncing shadow candle	0		Conditional Skill (Equipped): "Shadow Flame"
 11182	spoiled snack-sized shadow hot dog	2	crappy	
-11183	mediocre special pulsating ghostly shadow martini	3	decent	Effect: "Frost Tea", Effect Duration: 40
+11183	mediocre special ghostly pulsating shadow martini	3	decent	Effect: "Frost Tea", Effect Duration: 40
 11184	twisted shadow pill	1		
 11185	wobbly shadow needle	0		
 11186	cursed monkey's paw	0		Muscle: +10, Mysticality: +10, Moxie: +10, Spooky Damage: +10, Spooky Spell Damage: +10, Spooky Resistance: +2, Stench Resistance: +2, Hot Resistance: +2, Cold Resistance: +2, Sleaze Resistance: +2, Single Equip, Conditional Skill (Equipped): "Monkey Slap", Conditional Skill (Equipped): "Monkey Tickle", Conditional Skill (Equipped): "Evil Monkey Eye", Conditional Skill (Equipped): "Monkey Peace Sign", Conditional Skill (Equipped): "Monkey Point", Conditional Skill (Equipped): "Monkey Punch", Last Available: "2023-04"
@@ -11045,7 +11045,7 @@
 11190	replica Dark Jill-O-Lantern	0		
 11191	shaking replica hand turkey outline	0		
 11192	replica crimbo elfling	0		
-11193	skewed blue replica pygmy bugbear shaman	0		
+11193	blue skewed replica pygmy bugbear shaman	0		
 11194	tumbling yellow dedigitizer schematic: cyburger	0		Last Available: "2025-12"
 11195	replica gravy-covered maypole	0		Item Drop: +25
 11196	wobbly replica wax lips	0		Experience: +3
@@ -11057,7 +11057,7 @@
 11202	supercharged weightlifter's replica V for Vivala mask	0		Muscle: +15, Maximum MP Percent: +30, Single Equip, Conditional Skill (Equipped): "Creepy Grin"
 11203	studded supercool replica haiku katana of the sweet-tooth	0		Moxie Percent: +20, Damage Absorption: +80, Candy Drop: +100, Conditional Skill (Equipped): "Spring Raindrop Attack", Conditional Skill (Equipped): "Summer Siesta", Conditional Skill (Equipped): "Falling Leaf Whirlwind", Conditional Skill (Equipped): "Winter's Bite Technique", Conditional Skill (Equipped): "The 17 Cuts"
 11204	replica box of fireworks	0		Familiar Weight: +5, Conditional Skill (Equipped): "Fire off a Roman Candle"
-11205	wobbly huge replica cotton candy cocoon	0		
+11205	huge wobbly replica cotton candy cocoon	0		
 11206	green tumbling double-paned Annie Oakley's healthy beefy replica Elvish sunglasses	0		Muscle: +10, Maximum HP Percent: +20, Critical Hit Percent: +20, Cold Resistance: +5, Single Equip, Conditional Skill (Equipped): "Play an Accordion Solo", Conditional Skill (Equipped): "Play a Guitar Solo", Conditional Skill (Equipped): "Play a Drum Solo", Conditional Skill (Equipped): "Play a Flute Solo"
 11207	replica squamous polyp	0		
 11208	replica stone sphere	0		
@@ -11083,7 +11083,7 @@
 11228	replica puck	0		
 11229	gray replica Chateau Mantegna room key	0		
 11230	replica Deck of Every Card	0		
-11231	bouncing yellow replica Source terminal	0		
+11231	yellow bouncing replica Source terminal	0		
 11232	replica disconnected intergnat	0		
 11233	replica Witchess Set	0		
 11234	replica genie bottle	0		
@@ -11100,12 +11100,12 @@
 11245	narrow aromatic wizardly beefy replica Cargo Cultist Shorts	0		Muscle: +10, Mysticality: +25, Stench Resistance: +1, Item Drop: +5
 11246	flame-retardant dog trainer's hardened forbidden sage replica industrial fire extinguisher of the scaredy-cat	0		Mysticality Percent: +10, Spell Damage Percent: +50, Damage Reduction: 3, Monster Level: -15, Experience (familiar): +1, Hot Resistance: +1, Conditional Skill (Equipped): "Fire Extinguisher: Foam 'em Up", Conditional Skill (Equipped): "Fire Extinguisher: Polar Vortex", Conditional Skill (Equipped): "Fire Extinguisher: Foam Yourself", Conditional Skill (Equipped): "Fire Extinguisher: Blast the Area", Conditional Skill (Equipped): "Fire Extinguisher: Zone Specific"
 11247	yellow replica crystal ball	0		Initiative: +50
-11248	skewed yellow replica emotion chip	0		Skill: "Replica Emotionally Chipped"
+11248	yellow skewed replica emotion chip	0		Skill: "Replica Emotionally Chipped"
 11249	frosty replica Jurassic Parka of vim and vigor	0		Maximum HP Percent: +50, Cold Spell Damage: +10
 11250	replica grey gosling	0		
 11251	replica designer sweatpants	0		Conditional Skill (Equipped): "Sweat Flick", Conditional Skill (Equipped): "Sweat Flood", Conditional Skill (Equipped): "Sweat Spray", Conditional Skill (Equipped): "Sweat Sip", Conditional Skill (Equipped): "Make Sweat-Ade", Conditional Skill (Equipped): "Drench Yourself in Sweat", Conditional Skill (Equipped): "Sip Some Sweat", Conditional Skill (Inventory): "Sweat Out Some Booze"
 11252	replica plastic pumpkin bucket	0		Familiar Weight: +5, Item Drop: +13
-11253	cyan narrow replica Ten Dollars	0		
+11253	narrow cyan replica Ten Dollars	0		
 11254	jittery stanky medical-grade Newton's experienced replica Cincho de Mayo	0		Experience: +2, Experience (Mysticality): +3, Stench Spell Damage: +25, HP Regen Min: 7, HP Regen Max: 10, Conditional Skill (Equipped): "Cincho: Dispense Salt and Lime", Conditional Skill (Equipped): "Cincho: Party Soundtrack", Conditional Skill (Equipped): "Cincho: Fiesta Exit", Conditional Skill (Equipped): "Cincho: Projectile Piñata", Conditional Skill (Equipped): "Cincho: Party Foul", Conditional Skill (Equipped): "Cincho: Confetti Extravaganza"
 11255	Thwaitgold splendor beetle statuette	0		
 11256	shrink-wrapped 2002 Mr. Store Catalog	0		Free Pull, Last Available: "2023-06"
@@ -11113,11 +11113,11 @@
 11258	squat teal family-friendly wool wicked sage beefcake's beefy &quot;I survived Y2K&quot; T-Shirt	0		Muscle: 35, Mysticality Percent: +10, Spell Damage: +5, Cold Resistance: +1, Sleaze Resistance: +1, Single Equip, Last Available: "2023-06"
 11259	Letter from Carrie Bradshaw	0		Last Available: "2023-06"
 11260	inspector's perfumed pro skateboard	0		Stench Resistance: +5, Item Drop: +15, Conditional Skill (Equipped): "Do a Kickflip", Conditional Skill (Equipped): "Do a Method!", Conditional Skill (Equipped): "Do an epic McTwist!", Last Available: "2023-06"
-11261	olive twirling Mr. Accessaturday	0		Last Available: "2023-06"
+11261	twirling olive Mr. Accessaturday	0		Last Available: "2023-06"
 11262	Meat Butler	0		Last Available: "2023-06"
 11263	Loathing Idol Microphone	0		Last Available: "2023-06"
 11264	blinking yellow Charter: Nellyville	0		Last Available: "2023-06"
-11265	fuchsia Manual of Secret Door Detection	0		Skill: "Secret Door Awareness", Last Available: "2023-06"
+11265	fuchsia Manual of Secret Door Detection	0		Last Available: "2023-06", Skill: "Secret Door Awareness"
 11266	wobbly Flash Liquidizer Ultra Dousing Accessory of the overflowing toilet	0		Stench Spell Damage: +50, Conditional Skill (Equipped): "Douse Foe", Last Available: "2023-06"
 11267	censurious flame-wreathed manspreader's thinker's Amulet of Perpetual Darkness	0		Mysticality: +10, Monster Level: +10, Hot Spell Damage: +10, Sleaze Resistance: +3, Last Available: "2023-06"
 11268	Giant monolith	0		Last Available: "2023-06"
@@ -11132,12 +11132,12 @@
 11277	bouncing Loathing Idol Microphone (75% charged)	0		Last Available: "2023-06"
 11278	Loathing Idol Microphone (50% charged)	0		Last Available: "2023-06"
 11279	Loathing Idol Microphone (25% charged)	0		Last Available: "2023-06"
-11280	blinking ghostly Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
+11280	ghostly blinking Replica 2002 Mr. Store Catalog	0		Last Available: "2023-06"
 11281	upside-down Mr. Big's Wallet	0		Last Available: "2023-06"
 11282	delicious triple-distilled Sexy Cosmo	7	awesome	Last Available: "2023-06"
 11283	Souvenir Chopsticks	0		Last Available: "2023-06"
 11284	skewed avaricious dog trainer's friendly red-soled high heels	0		Familiar Weight: +3, Experience (familiar): +1, Meat Drop: +30, Last Available: "2023-06"
-11285	flavorless tumbling teal cyburger	4	decent	Last Available: "2025-12"
+11285	flavorless teal tumbling cyburger	4	decent	Last Available: "2025-12"
 11286	purple ncle leg of the bloodbag	0		Maximum HP: +100
 11287	pulsating sizzling groovy rutabuga bag	0		Moxie Percent: +10, Hot Damage: +10
 11288	clever mesquito proboscis	0		Maximum MP: +20
@@ -11153,7 +11153,7 @@
 11298	galvanized olive haemolymphnode	0		Effect: "All Is Forgiven", Effect Duration: 39
 11299	galvanized corrupted chitin powder paste	0		Effect: "damage.enh", Effect Duration: 37
 11300	sleeping patriotic eagle	0		Free Pull
-11301	red upside-down claw-held flag	0		Familiar Weight: +5
+11301	upside-down red claw-held flag	0		Familiar Weight: +5
 11302	skewed souvenir flag	0		
 11303	name change form	0		
 11304	squat replica sleeping patriotic eagle	0		
@@ -11174,8 +11174,8 @@
 11319	shaking medal	0		Familiar Weight: +10, Experience (familiar): +1, Lasts Until Rollover
 11320	drinkable enchanted twirling bottle of Cabernet Sauvignon	3	good	Effect: "Chorale of Companionship", Effect Duration: 15
 11321	spinning experienced supercool baywatch of the scaredy-cat	0		Moxie Percent: +20, Experience: +2, Monster Level: -15, Lasts Until Rollover
-11322	green Pocket Guide to Mild Evil	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
-11323	Pocket Guide to Mild Evil (used)	0		Skill: "Perpetrate Mild Evil", Last Available: "2023-07"
+11322	green Pocket Guide to Mild Evil	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
+11323	Pocket Guide to Mild Evil (used)	0		Last Available: "2023-07", Skill: "Perpetrate Mild Evil"
 11324	bouncing consolation ribbon	0		Familiar Weight: -10, Experience (familiar): -1
 11325	replica august scepter	0		Muscle: +15, Mysticality: +15, Moxie: +15, HP Regen Min: 10, HP Regen Max: 15, MP Regen Min: 7, MP Regen Max: 10, Weapon Damage Percent: +50, Spell Damage Percent: +50, Conditional Skill (Inventory): "Aug. 1st: Mountain Climbing Day!", Conditional Skill (Inventory): "Aug. 2nd: Find an Eleven-Leaf Clover Day", Conditional Skill (Inventory): "Aug. 3rd: Watermelon Day!", Conditional Skill (Inventory): "Aug. 4th: Water Balloon Day!", Conditional Skill (Inventory): "Aug. 5th: Oyster Day!", Conditional Skill (Inventory): "Aug. 6th: Fresh Breath Day!", Conditional Skill (Inventory): "Aug. 7th: Lighthouse Day!", Conditional Skill (Inventory): "Aug. 8th: Cat Day!", Conditional Skill (Inventory): "Aug. 9th: Hand Holding Day!", Conditional Skill (Inventory): "Aug. 10th: World Lion Day!", Conditional Skill (Inventory): "Aug. 11th: Presidential Joke Day!", Conditional Skill (Inventory): "Aug. 12th: Elephant Day!", Conditional Skill (Inventory): "Aug. 13th: Left/Off Hander's Day!", Conditional Skill (Inventory): "Aug. 14th: Financial Awareness  Day!", Conditional Skill (Inventory): "Aug. 15th: Relaxation Day!", Conditional Skill (Inventory): "Aug. 16th: Roller Coaster Day!", Conditional Skill (Inventory): "Aug. 17th: Thriftshop Day!", Conditional Skill (Inventory): "Aug. 18th: Serendipity Day!", Conditional Skill (Inventory): "Aug. 19th: Honey Bee Awareness Day!", Conditional Skill (Inventory): "Aug. 20th: Mosquito Day!", Conditional Skill (Inventory): "Aug. 21st: Spumoni Day!", Conditional Skill (Inventory): "Aug. 22nd: Tooth Fairy Day!", Conditional Skill (Inventory): "Aug. 23rd: Ride the Wind Day!", Conditional Skill (Inventory): "Aug. 24th: Waffle Day!", Conditional Skill (Inventory): "Aug. 25th: Banana Split Day!", Conditional Skill (Inventory): "Aug. 26th: Toilet Paper Day!", Conditional Skill (Inventory): "Aug. 27th: Just Because Day!", Conditional Skill (Inventory): "Aug. 28th: Race Your Mouse Day!", Conditional Skill (Inventory): "Aug. 29th: More Herbs, Less Salt  Day!", Conditional Skill (Inventory): "Aug. 30th: Beach Day!", Conditional Skill (Inventory): "Aug. 31st: Cabernet Sauvignon  Day!"
 11326	Thwaitgold fairyfly statue	0		
@@ -11210,7 +11210,7 @@
 11355	bouncing experienced thinker's impromptu torch	0		Mysticality: +10, Experience: +2, Lasts Until Rollover
 11356	purple smooth fig leaf of courage	0		Moxie: +15, Spooky Resistance: +3, Lasts Until Rollover
 11357	up-at-dawn smoldering drape of Tarzan	0		Experience (Muscle): +3, Adventures: +5, Lasts Until Rollover
-11358	ghostly purple smoldering leafcutter ant egg	0		
+11358	purple ghostly smoldering leafcutter ant egg	0		
 11359	lard-coated steel-toed cool leaf crown of Calamity Jane of the sewer of temperance	0		Moxie: +5, Damage Reduction: 9, Critical Hit Percent: +15, Stench Damage: +25, Sleaze Spell Damage: +25, Sleaze Resistance: +5
 11360	bland leafy browns	3	decent	
 11361	enhanced adjusted autumnic balm	0		Effect: "Supafly", Effect Duration: 39
@@ -11218,10 +11218,10 @@
 11363	greasy ruddy rosy-cheeked candy cane sword cane of the scaredy-cat	0		Maximum HP Percent: 70, Monster Level: -15, Sleaze Spell Damage: +10, Item Drop: +5, Conditional Skill (Equipped): "Surprisingly Sweet Stab", Conditional Skill (Equipped): "Surprisingly Sweet Slash"
 11364	wrapped candy cane sword cane	0		Free Pull
 11365	Elf Guard patrol cap	0		Last Available: "2023-12"
-11366	upside-down narrow Elf Guard hotpants	0		Last Available: "2023-12"
+11366	narrow upside-down Elf Guard hotpants	0		Last Available: "2023-12"
 11367	Crimbuccaneer tricorn	0		Last Available: "2023-12"
 11368	Crimbuccaneer breeches	0		Last Available: "2023-12"
-11369	narrow blinking automa-bot parts	0		
+11369	blinking narrow automa-bot parts	0		
 11370	security automa-core	0		
 11371	clerical automa-core	0		
 11372	yellow handful of Boltsmann bearings	0		
@@ -11230,7 +11230,7 @@
 11375	Boltsmann ID badge	0		
 11376	housekeeping automa-core	0		
 11377	pulsating housekeeping robot	0		
-11378	low-calorie adequate pickled bread	1	good	Last Available: "2023-12"
+11378	adequate low-calorie pickled bread	1	good	Last Available: "2023-12"
 11379	yummy salted mutton	3	awesome	Last Available: "2023-12"
 11380	delicious tumbling corned beet	4	awesome	Last Available: "2023-12"
 11381	tiny plastic Elf Guard Armory	0		Weapon Damage: +3
@@ -11265,21 +11265,21 @@
 11410	supercharged Elf Guard commandeering gloves	0		Maximum MP Percent: +30, Single Equip, Last Available: "2023-12"
 11411	frozen galvanized quantum lime green Elf Guard eyedrops	0		Effect: "Puzzle Fury", Effect Duration: 37, Last Available: "2023-12"
 11412	upside-down Crimbuccaneer premium booty sack	0		Last Available: "2023-12"
-11413	green mirror mirror Elf Guard honor present	0		Last Available: "2023-12"
+11413	mirror green mirror Elf Guard honor present	0		Last Available: "2023-12"
 11414	blinking Temple Grandin's beefy Elf Guard officer's sidearm	0		Muscle: +10, Familiar Weight: +7, Last Available: "2023-12"
 11415	blinking Herculean Elf Guard insignia (general) of wisdom	0		Mysticality: +15, Experience (Muscle): +1, Single Equip, Last Available: "2023-12"
-11416	mediocre watered-down Crimbow Rainbo	2	decent	Last Available: "2023-12"
+11416	watered-down mediocre Crimbow Rainbo	2	decent	Last Available: "2023-12"
 11417	Elf Guard strategic map	0		Last Available: "2023-12"
 11418	Crimbuccaneer captain's purse	0		Last Available: "2023-12"
 11419	Sherlock's Newton's Elf Guard broom	0		Experience (Mysticality): +3, Item Drop: +25, Last Available: "2023-12"
 11420	Usain Bolt's Jeselnik's Tesla Crimbuccaneer tavern swab	0		Sleaze Damage: +25, Initiative: +80, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2023-12"
 11421	Elf Guard hangover cure	0		Last Available: "2023-12"
-11422	strong hand-crafted old-school pirate grog	5	EPIC	Last Available: "2023-12"
+11422	hand-crafted strong old-school pirate grog	5	EPIC	Last Available: "2023-12"
 11423	toothsome jumbo blurry grog nuts	5	awesome	Last Available: "2023-12"
 11424	ghostly up-at-dawn nippy sawed-off blunderbuss of Gandalf	0		Spell Critical Percent: +20, Cold Damage: +10, Adventures: +5, Last Available: "2023-12"
-11425	practically non-alcoholic aged officer's nog	1	awesome	Last Available: "2023-12"
+11425	aged practically non-alcoholic officer's nog	1	awesome	Last Available: "2023-12"
 11426	peppermint bomb	0		Last Available: "2023-12"
-11427	small delicious sundae ration	2	awesome	Last Available: "2023-12"
+11427	delicious small sundae ration	2	awesome	Last Available: "2023-12"
 11428	normal peppermint tack	3	good	Last Available: "2023-12"
 11429	Elf Guard Field Manual: Culinary Arts	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11430	rotten whalesteak	3	crappy	Last Available: "2023-12"
@@ -11288,7 +11288,7 @@
 11433	skewed Elf Guard payroll bag	0		Last Available: "2023-12"
 11434	Oprah's Elf Guard clipboard of the wise owl of the sweet-tooth	0		Mysticality: +20, Maximum MP Percent: +50, Candy Drop: +100, Last Available: "2023-12"
 11435	purple up-at-dawn pegfinger	0		Adventures: +5, Single Equip, Last Available: "2023-12"
-11436	mediocre weak and claret	2	decent	Last Available: "2023-12"
+11436	weak mediocre and claret	2	decent	Last Available: "2023-12"
 11437	avaricious Elf Guard and beret	0		Meat Drop: [+30*event(December)], Last Available: "2023-12"
 11438	ghostly zippy Sinatra's experienced shipwright's hammer	0		Experience: +2, Experience (Moxie): +5, Initiative: +20, Last Available: "2023-12"
 11439	twirling prompt hardy supercool gunwale	0		Moxie Percent: +20, Maximum HP: +50, Adventures: +3, Damage Reduction: 9, Last Available: "2023-12"
@@ -11312,16 +11312,16 @@
 11457	scorching dance instructor's Socratic Elvish underarmor	0		Experience (Mysticality): +1, Experience Percent (Moxie): +10, Hot Damage: +25, Single Equip, Last Available: "2023-12"
 11458	clever Crimbuccaneer bombjacket of the detective	0		Maximum MP: +20, Item Drop: +20, Combat Item Damage Percent: 100, Last Available: "2023-12"
 11459	spoiled upside-down bouncing sugarplum ration	4	crappy	Last Available: "2023-12"
-11460	massive flavorless gingerbread nylons	6	decent	Last Available: "2023-12"
-11461	immense decent squat rum-soaked fruitcake	7	good	Last Available: "2023-12"
+11460	flavorless massive gingerbread nylons	6	decent	Last Available: "2023-12"
+11461	decent immense squat rum-soaked fruitcake	7	good	Last Available: "2023-12"
 11462	decent ghostly lime	3	good	Last Available: "2023-12"
 11463	delicious upside-down gingerbread pirate	4	awesome	Last Available: "2023-12"
 11464	moldy snack-sized fruit-stuffed rumcake	2	crappy	Last Available: "2023-12"
 11465	perfectly mixed mirror mulled wine	3	EPIC	Last Available: "2023-12"
-11466	special bad Swedish coffee	4	decent	Effect: "Sugar, Hello", Effect Duration: 10, Last Available: "2023-12"
+11466	bad special Swedish coffee	4	decent	Effect: "Sugar, Hello", Effect Duration: 10, Last Available: "2023-12"
 11467	high-proof delicious canteen of eggnog	6	awesome	Last Available: "2023-12"
-11468	mediocre weak jittery hot wine	2	decent	Last Available: "2023-12"
-11469	mediocre irresponsibly strong upside-down Jamaican coffee	7	decent	Last Available: "2023-12"
+11468	weak mediocre jittery hot wine	2	decent	Last Available: "2023-12"
+11469	irresponsibly strong mediocre upside-down Jamaican coffee	7	decent	Last Available: "2023-12"
 11470	acceptable flask of egggrog	4	good	Last Available: "2023-12"
 11471	Black and White Apron Enrollment Form	0		Free Pull, Last Available: "2024-12"
 11472	Black and White Apron Meal Kit	0		Last Available: "2024-12"
@@ -11348,7 +11348,7 @@
 11493	Crimbuccaneer tattoo gift certificate	0		Last Available: "2023-12"
 11494	jittery Elf Guard safety bear	0		Last Available: "2023-12"
 11495	kraken	0		Last Available: "2023-12"
-11496	ghostly blurry precision snowball	0		Last Available: "2023-12"
+11496	blurry ghostly precision snowball	0		Last Available: "2023-12"
 11497	Elf Guard Field Manual: Culinary Arts (used)	0		Skill: "Elf Guard Cooking", Last Available: "2023-12"
 11498	Cocktails of the Age of Sail (used)	0		Skill: "Old-School Cocktailcrafting", Last Available: "2023-12"
 11499	mirror Elf Guard Field Manual: Extortion (used)	0		Skill: "Elf Guard Extortion Techniques", Last Available: "2023-12"
@@ -11382,8 +11382,8 @@
 11527	polymerized crepe paper peanut candy	0		Effect: "A Contender", Effect Duration: 53
 11528	shellacked brawny petrified wood war pike	0		Muscle Percent: +20, Damage Reduction: 7, Last Available: "2025-12"
 11529	ghostly Temple Grandin's groovy petrified wood waist protector	0		Moxie Percent: +10, Familiar Weight: +7, Single Equip, Last Available: "2025-12"
-11530	greedy scorching petrified wood wizard's pouch	0		Hot Damage: +25, Meat Drop: +20, Single Equip, Lantern Element: "Hot", Lantern Element: "None", Last Available: "2025-12"
-11531	olive greedy beefcake's petrified wood water purifier	0		Muscle: +25, Meat Drop: +20, Lantern Element: "Cold", Lantern Element: "Sleaze", Last Available: "2025-12"
+11530	greedy scorching petrified wood wizard's pouch	0		Hot Damage: +25, Meat Drop: +20, Single Equip, Last Available: "2025-12", Lantern Element: "Hot", Lantern Element: "None"
+11531	olive greedy beefcake's petrified wood water purifier	0		Muscle: +25, Meat Drop: +20, Last Available: "2025-12", Lantern Element: "Cold", Lantern Element: "Sleaze"
 11532	forbidden petrified wood whoopie panama of dire peril	0		Weapon Damage: +20, Spell Damage Percent: +50, Last Available: "2025-12"
 11533	scandalous petrified wood walking pants of the early riser	0		Sleaze Damage: +5, Adventures: +7, Last Available: "2025-12"
 11534	vaporized petrified wood waste parts	1		Last Available: "2025-12"
@@ -11425,10 +11425,10 @@
 11570	Apriling band piccolo	0		Familiar Weight: +10, Lasts Until Rollover
 11571	boxed Mayam Calendar	0		Free Pull, Last Available: "2024-05"
 11572	blinking Mayam Calendar	0		Free Pull, Last Available: "2024-05"
-11573	rotten low-calorie fuchsia yam	1	crappy	Last Available: "2024-05"
+11573	low-calorie rotten fuchsia yam	1	crappy	Last Available: "2024-05"
 11574	mediocre lime green yam martini	4	decent	Last Available: "2024-05"
 11575	drinkable sweet potato o' mine	4	good	Last Available: "2024-05"
-11576	practically non-alcoholic bad huge Southern yam	1	decent	Last Available: "2024-05"
+11576	bad practically non-alcoholic huge Southern yam	1	decent	Last Available: "2024-05"
 11577	fancy mediocre sweet potato punch	3	decent	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2024-05"
 11578	moldy Mayam spinach	3	crappy	Last Available: "2024-05"
 11579	toothsome yam and swiss	3	awesome	Last Available: "2024-05"
@@ -11440,7 +11440,7 @@
 11585	thanksgiving bomb	0		Last Available: "2024-05"
 11586	red greedy rosy-cheeked baleful yamtility belt	0		Spell Damage: +25, Maximum HP Percent: +30, Meat Drop: +20, Lasts Until Rollover, Last Available: "2024-05"
 11587	flavorless squat yam slider	3	decent	Last Available: "2024-05"
-11588	bland huge special tumbling yam mayo	8	decent	Effect: "No Worries", Effect Duration: 15, Last Available: "2024-05"
+11588	bland special huge tumbling yam mayo	8	decent	Effect: "No Worries", Effect Duration: 15, Last Available: "2024-05"
 11589	flavorless yam burrito	3	decent	Last Available: "2024-05"
 11590	blinking visual packet sniffer	0		Last Available: "2025-12"
 11591	mini kiwi egg	0		Free Pull, Last Available: "2024-06"
@@ -11448,13 +11448,13 @@
 11593	maroon Thwaitgold Illinigina illinoiensis model	0		
 11594	moldy low-calorie mini kiwi	1	crappy	Last Available: "2024-06"
 11595	blue Sherlock's veiny ruddy mini kiwi bikini	0		Maximum HP Percent: +40, Maximum HP: +10, Item Drop: +25, Last Available: "2024-06"
-11596	high-proof hand-crafted mini kiwitini	7	EPIC	Last Available: "2024-06"
+11596	hand-crafted high-proof mini kiwitini	7	EPIC	Last Available: "2024-06"
 11597	fuchsia mini kiwi invisible dirigible	0		Familiar Weight: -20, Last Available: "2024-06"
 11598	mini kiwi aioli	0		
 11599	fireproof scandalous stylish mini kiwi silicon tiepin	0		Moxie: +25, Sleaze Damage: +5, Hot Resistance: +3
-11600	squat yellow mini kiwi tipi	0		
+11600	yellow squat mini kiwi tipi	0		
 11601	delicious mini kiwi digitized cookies	3	awesome	
-11602	hand-crafted strong mini kiwi intoxicating spirits	5	EPIC	
+11602	strong hand-crafted mini kiwi intoxicating spirits	5	EPIC	
 11603	diffused non-corrupted mini kiwi antimilitaristic hippy petition	0		Effect: "Greased-Up Familiar", Effect Duration: 65
 11604	nitrogenated mini kiwi illicit antibiotic	0		Effect: "Wise Spirit", Effect Duration: 67
 11605	mirror maroon Rosewater's mini kiwi whipping stick of the wise owl	0		Mysticality: +20, Mysticality Percent: +30
@@ -11470,7 +11470,7 @@
 11615	dog trainer's Temple Grandin's messenger bag RNA of the blizzard	0		Familiar Weight: +7, Experience (familiar): +1, Cold Spell Damage: +25
 11616	flagellate flagon	0		
 11617	proto-proto-protozoa	0		
-11618	adequate big bacteria bisque	5	good	
+11618	big adequate bacteria bisque	5	good	
 11619	delicious mirror ciliophora chowder	4	awesome	
 11620	rotten yellow cream of chloroplasts	3	crappy	
 11621	synaptic soup	0		
@@ -11485,7 +11485,7 @@
 11630	toasty wholesome Rosewater's stylish tearaway pants of horror	0		Moxie: +25, Mysticality Percent: +30, Maximum HP Percent: +10, Hot Damage: +5, Spooky Spell Damage: +25, Conditional Skill (Equipped): "Tear Away your Pants!"
 11631	bouncing baby bodyguard	0		
 11632	Doll Moll violin case	0		
-11633	olive mirror Tina gun	0		Familiar Weight: +5
+11633	mirror olive Tina gun	0		Familiar Weight: +5
 11634	narrow tattoo gun	0		
 11635	hand-crafted wobbly Colera Peste Nebbiolo	3	EPIC	
 11636	longbox of Batfellow comics	0		
@@ -11507,7 +11507,7 @@
 11652	throwin' ember	0		Last Available: "2024-09"
 11653	head of emberg lettuce	0		Last Available: "2024-09"
 11654	embering hunk	0		Last Available: "2024-09"
-11655	spinning lime green soft cap of diminishing returns	0		
+11655	lime green spinning soft cap of diminishing returns	0		
 11656	photo booth sized crate	0		Free Pull, Last Available: "2024-10"
 11657	boxed bat wings	0		Free Pull, Last Available: "2024-10"
 11658	toasty smartaleck's slick bat wings	0		Moxie: +10, Moxie Percent: +30, Hot Damage: +5, Conditional Skill (Equipped): "Rest upside down", Conditional Skill (Equipped): "Swoop like a Bat", Conditional Skill (Equipped): "Summon Cauldron of Bats", Last Available: "2024-10"
@@ -11527,7 +11527,7 @@
 11672	peace turkey outline	0		Free Pull, Last Available: "2024-11"
 11673	tumbling tie-dye headband	0		
 11674	big flavorless whirled peas	5	decent	Last Available: "2024-11"
-11675	bland fancy spinning peaza	4	decent	Effect: "Pharmaceutically Cool", Effect Duration: 15, Last Available: "2024-11"
+11675	fancy bland spinning peaza	4	decent	Effect: "Pharmaceutically Cool", Effect Duration: 15, Last Available: "2024-11"
 11676	peace shooter	0		Last Available: "2024-11"
 11677	vaporized red drenchrome 2.0	1		Last Available: "2025-12"
 11678	boiled Synapse Blaster	1		Effect: "I See Everything Thrice!", Effect Duration: 35, Last Available: "2025-12"
@@ -11546,21 +11546,21 @@
 11691	blinking ghostly sleeping profane parrot	0		Last Available: "2024-12"
 11692	pirrrate's currrse	0		Last Available: "2024-12"
 11693	smooth twirling tankard of spiced rum	3	awesome	Last Available: "2024-12"
-11694	perfectly mixed watered-down bouncing tumbling tankard of spiced Goldschlepper	2	EPIC	Last Available: "2024-12"
+11694	perfectly mixed watered-down tumbling bouncing tankard of spiced Goldschlepper	2	EPIC	Last Available: "2024-12"
 11695	packaged luxury garment	0		Last Available: "2024-12"
 11696	green wool governor's daughter's lace collar	0		Cold Resistance: +1, Last Available: "2024-12"
 11697	shaking miser's governor's daughter's petticoats	0		Meat Drop: +10, Last Available: "2024-12"
 11698	governor's daughter's pearl hairpin of the brazier	0		Hot Spell Damage: +25, Last Available: "2024-12"
 11699	pulsating harpoon	0		Last Available: "2024-12"
 11700	scandalous chili powder cutlass	0		Sleaze Damage: +5, Last Available: "2024-12"
-11701	adequate super-sized twirling Aztec tamale	5	good	Last Available: "2024-12"
+11701	super-sized adequate twirling Aztec tamale	5	good	Last Available: "2024-12"
 11702	jolly roger tattoo kit	0		Last Available: "2024-12"
 11703	pet rock	0		Last Available: "2024-12"
 11704	groggles of the glutton	0		Food Drop: +100, Last Available: "2024-12"
 11705	spinning pirate dinghy	0		Last Available: "2024-12"
 11706	anchor bomb	0		Last Available: "2024-12"
 11707	jittery blinking dog trainer's silky pirate drawers of the sewer	0		Experience (familiar): +1, Stench Damage: +25, Last Available: "2024-12"
-11708	yellow spinning spinning profane eye patch	0		Sleaze Damage: +3
+11708	spinning spinning yellow profane eye patch	0		Sleaze Damage: +3
 11709	extra-polarized Vulcanized peppermint pegleg	0		Effect: "[1701]Hip to the Jive", Effect Duration: 12, Last Available: "2024-12"
 11710	tolerable hard cocoa	4	good	Last Available: "2024-12"
 11711	fancy normal salmagumdi	4	good	Effect: "Well-preserved", Effect Duration: 5, Last Available: "2024-12"
@@ -11590,7 +11590,7 @@
 11735	inspector's arcane researcher's gravyskin buckler	0		Experience Percent (Mysticality): +10, Item Drop: +15, Damage Reduction: 7, Last Available: "2024-12"
 11736	lard-coated gravyskin skirt of vim and vigor	0		Maximum HP Percent: +50, Sleaze Spell Damage: +25, Last Available: "2024-12"
 11737	greasy brawny gravyskin pants	0		Muscle Percent: +20, Sleaze Spell Damage: +10, Last Available: "2024-12"
-11738	colloidal activated twirling mirror crystallized pumpkin spice	0		Effect: "Sparkly!", Effect Duration: 19, Last Available: "2024-12"
+11738	colloidal activated mirror twirling crystallized pumpkin spice	0		Effect: "Sparkly!", Effect Duration: 19, Last Available: "2024-12"
 11739	stale room scale bean casserole	3	decent	Last Available: "2024-12"
 11740	gray fragile Christmas ornament	0		Last Available: "2024-12"
 11741	ragged wool yarn	0		Last Available: "2024-12"
@@ -11601,8 +11601,8 @@
 11746	mirror pumpkin spice whorl	0		Last Available: "2024-12"
 11747	bad practically non-alcoholic Easter grasshopper	1	decent	Last Available: "2024-12"
 11748	acceptable Irish eggnog	3	good	Last Available: "2024-12"
-11749	watered-down hand-crafted enchanted ghostly canteen of jungle juice	2	EPIC	Effect: "Beta Carotene Overdose", Effect Duration: 5, Last Available: "2024-12"
-11750	triple-distilled tolerable turchucken	9	good	Last Available: "2024-12"
+11749	enchanted watered-down hand-crafted ghostly canteen of jungle juice	2	EPIC	Effect: "Beta Carotene Overdose", Effect Duration: 5, Last Available: "2024-12"
+11750	tolerable triple-distilled turchucken	9	good	Last Available: "2024-12"
 11751	perfectly mixed mechanically-mulled cider	3	EPIC	Last Available: "2024-12"
 11752	tolerable boozy ghostly holiday trip around the world	5	good	Last Available: "2024-12"
 11753	huge bland pulsating chocolate ostrich egg	6	decent	Last Available: "2024-12"
@@ -11613,22 +11613,22 @@
 11758	adequate miniature holiday smorgasbord	2	good	Last Available: "2024-12"
 11759	Bowl of Infinite Jelly	0		Last Available: "2024-12"
 11760	lime green curative bejazzled eyepatch	0		HP Regen Min: 3, HP Regen Max: 5, Last Available: "2024-12"
-11761	blinking Secrets of the Master Egg Hunters	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11762	Secrets of the Master Egg Hunters (used)	0		Skill: "Master Egg Hunter", Last Available: "2024-12"
-11763	bouncing How to Lose Friends and Attract Snakes	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11764	How to Lose Friends and Attract Snakes (used)	0		Skill: "Attract Snakes", Last Available: "2024-12"
-11765	upside-down bouncing Covert Ops for Kids	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11766	Covert Ops for Kids (used)	0		Skill: "Hide From Seekers", Last Available: "2024-12"
-11767	Holiday Multitasking	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11768	Holiday Multitasking (used)	0		Skill: "Holiday Multitasking", Last Available: "2024-12"
-11769	Hoyle's Guide to Reindeer Games	0		Skill: "Reindeer Games", Last Available: "2024-12"
-11770	Hoyle's Guide to Reindeer Games (used)	0		Skill: "Reindeer Games", Last Available: "2024-12"
+11761	blinking Secrets of the Master Egg Hunters	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11762	Secrets of the Master Egg Hunters (used)	0		Last Available: "2024-12", Skill: "Master Egg Hunter"
+11763	bouncing How to Lose Friends and Attract Snakes	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11764	How to Lose Friends and Attract Snakes (used)	0		Last Available: "2024-12", Skill: "Attract Snakes"
+11765	bouncing upside-down Covert Ops for Kids	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11766	Covert Ops for Kids (used)	0		Last Available: "2024-12", Skill: "Hide From Seekers"
+11767	Holiday Multitasking	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11768	Holiday Multitasking (used)	0		Last Available: "2024-12", Skill: "Holiday Multitasking"
+11769	Hoyle's Guide to Reindeer Games	0		Last Available: "2024-12", Skill: "Reindeer Games"
+11770	Hoyle's Guide to Reindeer Games (used)	0		Last Available: "2024-12", Skill: "Reindeer Games"
 11771	moai statuette	0		Last Available: "2024-12"
 11772	shaking ghostly Tesla hardy boxer's egg gun of the blizzard	0		Muscle Percent: +10, Maximum HP: +50, Cold Spell Damage: +25, MP Regen Min: 7, MP Regen Max: 10, Conditional Skill (Equipped): "Egg the face", Last Available: "2024-12"
 11773	flame-wreathed army helmet of the brute of the bloodbag	0		Muscle Percent: +30, Maximum HP: +100, Hot Spell Damage: +10, Item Drop: +5, Last Available: "2024-12"
 11774	candy egg deviler	0		Last Available: "2024-12"
 11775	lime green pulsating napkin	0		Last Available: "2024-12"
-11776	super-sized bland Thanksgiving ration	5	decent	Last Available: "2024-12"
+11776	bland super-sized Thanksgiving ration	5	decent	Last Available: "2024-12"
 11777	aged Easter eggnog	3	awesome	Last Available: "2024-12"
 11778	vaporized clovermint	1		Effect: "Sugary Tongue", Effect Duration: 40, Last Available: "2024-12"
 11779	medical-grade studded Da Vinci's nylon Christmas stockings of the cheetah	0		Experience (Mysticality): +5, Damage Absorption: +80, Initiative: +60, HP Regen Min: 7, HP Regen Max: 10, Single Equip, Last Available: "2024-12"
@@ -11658,7 +11658,7 @@
 11803	cybervisor	0		Last Available: "2025-12"
 11804	retro floppy disk	0		Last Available: "2025-12"
 11805	pocket GPU	0		Single Equip, Last Available: "2025-12"
-11806	shaking skewed malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
+11806	skewed shaking malware injector	0		Conditional Skill (Equipped): "Inject Malware", Last Available: "2025-12"
 11807	CyberRealm keycode	0		Free Pull, Last Available: "2025-12"
 11808	server room key	0		Last Available: "2025-12"
 11809	3d printed server room key	0		Last Available: "2025-12"
@@ -11713,35 +11713,35 @@
 11858	glover liners	0		Pickpocket Chance: +10
 11859	mosquito speakers	0		Monster Level: +5
 11860	maroon assemble-it-yourself Leprecondo	0		Free Pull, Last Available: "2025-03"
-11861	maroon upside-down pulsating Leprecondo	0		Last Available: "2025-03"
+11861	upside-down maroon pulsating Leprecondo	0		Last Available: "2025-03"
 11862	pickled scoop of pre-workout powder	1		Last Available: "2025-03"
 11863	green table tennis ball	0		Last Available: "2025-03"
 11864	practically non-alcoholic hand-crafted fuchsia pint of Leprechaun Stout	1	EPIC	Last Available: "2025-03"
-11865	denatured skewed blinking phosphor traces	1		Last Available: "2025-03"
+11865	denatured blinking skewed phosphor traces	1		Last Available: "2025-03"
 11866	crafting plans	0		Last Available: "2025-03"
 11867	upside-down Book of Irony	0		Skill: "Generate Irony"
-11868	gray squat spoon	0		
+11868	squat gray spoon	0		
 11869	unironic knife	0		
 11870	bar dart	0		Last Available: "2025-03"
 11871	distilled teal leprechaun antidepressant pill	1		Effect: "Full-Body Tan", Effect Duration: 5, Last Available: "2025-03"
 11872	spoiled tumbling Heck ramen	3	crappy	Last Available: "2025-03"
-11873	jumbo moldy upside-down burrito	5	crappy	Last Available: "2025-03"
-11874	stale big huge small beer brat	5	decent	Last Available: "2025-03"
+11873	moldy jumbo upside-down burrito	5	crappy	Last Available: "2025-03"
+11874	big stale huge small beer brat	5	decent	Last Available: "2025-03"
 11875	spoiled peach pie	3	crappy	Last Available: "2025-03"
 11876	adequate incredible mini-pizza	3	good	Last Available: "2025-03"
 11877	smooth Divine sidecar	3	awesome	Last Available: "2025-03"
 11878	bad tumbling tangarita sidecar	4	decent	Last Available: "2025-03"
 11879	aged gimlet sidecar	3	awesome	Last Available: "2025-03"
 11880	drinkable extra-dry vodka stratocaster sidecar	5	good	Last Available: "2025-03"
-11881	aged weak prussian cathouse sidecar	2	awesome	Last Available: "2025-03"
-11882	drinkable watered-down spinning bouncing Mon Tiki sidecar	2	good	Last Available: "2025-03"
+11881	weak aged prussian cathouse sidecar	2	awesome	Last Available: "2025-03"
+11882	drinkable watered-down bouncing spinning Mon Tiki sidecar	2	good	Last Available: "2025-03"
 11883	Packaged April Shower Thoughts Calendar	0		Free Pull, Last Available: "2025-04"
 11884	tumbling forbidden April Shower Thoughts shield of the cougar	0		Moxie: +20, Spell Damage Percent: +50, Damage Reduction: 6, Last Available: "2025-04"
 11885	glob of wet paper	0		Last Available: "2025-04"
 11886	skewed spitball	0		Last Available: "2025-04"
 11887	unsweetened wet paper weights	0		Effect: "Rave Nirvana", Effect Duration: 34, Last Available: "2025-04"
 11888	practically non-alcoholic lousy Three Sheets to the Wind	1	decent	Last Available: "2025-04"
-11889	delicious snack-sized teal pile of wet dates	2	awesome	Last Available: "2025-04"
+11889	snack-sized delicious teal pile of wet dates	2	awesome	Last Available: "2025-04"
 11890	papier Mach 1 airplane	0		Last Available: "2025-04"
 11891	wet blanket	0		Last Available: "2025-04"
 11892	supercool wet shower cap	0		Moxie Percent: +20, Last Available: "2025-04"
@@ -11805,8 +11805,8 @@
 11950	time cop top hat of the empath	0		Familiar Weight: +5, Last Available: "2025-08"
 11951	Stock Certificate	0		Last Available: "2025-08"
 11952	distilled spinning mixed berry jelly	1		Last Available: "2025-08"
-11953	gigantic flavorless ghostly spinning toast with mixed berry jelly	7	decent	Last Available: "2025-08"
-11954	flavorless bite-sized shaking blue cup of sugar	1	decent	Last Available: "2025-08"
+11953	gigantic flavorless spinning ghostly toast with mixed berry jelly	7	decent	Last Available: "2025-08"
+11954	bite-sized flavorless blue shaking cup of sugar	1	decent	Last Available: "2025-08"
 11955	moldy Susie's cupcake	4	crappy	Last Available: "2025-08"
 11956	clock	0		Last Available: "2025-08"
 11957	shaking Sherlock's beefy the gun of the cougar	0		Muscle: +10, Moxie: +20, Item Drop: +25, Last Available: "2025-08"
@@ -11841,11 +11841,11 @@
 12051	knucklebone	0		
 12052	lousy Smoking Pope	3	decent	
 12053	bland prize turkey	3	decent	
-12054	compressed maroon twirling jittery medicinal gruel	1		
-12055	half-sized normal jittery full-sized pumpkin pie	2	good	Last Available: "2025-11"
+12054	compressed twirling jittery maroon medicinal gruel	1		
+12055	normal half-sized jittery full-sized pumpkin pie	2	good	Last Available: "2025-11"
 12056	mediocre vodka cranberry sauce	3	decent	Last Available: "2025-11"
 12057	magnetized irradiated flattened yammed candy	0		Effect: "Flexibili Tea", Effect Duration: 24, Last Available: "2025-11"
-12058	fancy rotten treasure chestnut	4	crappy	Effect: "Hypercubed", Effect Duration: 30, Last Available: "2025-12"
+12058	rotten fancy treasure chestnut	4	crappy	Effect: "Hypercubed", Effect Duration: 30, Last Available: "2025-12"
 12059	delicious watered-down mulled butter rum	2	awesome	Last Available: "2025-12"
 12060	boiled cold-filtered cinnamon doubloon	0		Effect: "Spore-Wreathed", Effect Duration: 18, Last Available: "2025-12"
 12061	skewed plastic left skeleton arm of the sewer	0		Stench Damage: +25, Last Available: "2025-12"
@@ -11861,7 +11861,7 @@
 12071	horrifying angelbone mantle of the overflowing toilet	0		Stench Spell Damage: +50, Spooky Damage: +25, Last Available: "2026-12"
 12072	hale angelbone dice	0		Maximum HP: +20, Single Equip, Last Available: "2026-12"
 12073	jittery frightening ruddy angelbone halo	0		Maximum HP Percent: +40, Spooky Damage: +5, Last Available: "2026-12"
-12074	altered huge mirror ghostly red angelbone fragments	1		Last Available: "2026-12"
+12074	altered red ghostly mirror huge angelbone fragments	1		Last Available: "2026-12"
 12075	magnetized shaking biblically accurate gumdrops	0		Effect: "Demonic Taint", Effect Duration: 37
 12076	devilbone helmet of Calamity Jane of chilblains	0		Critical Hit Percent: +15, Cold Damage: +25, Last Available: "2026-12"
 12077	Newton's devilbone greaves	0		Experience (Mysticality): +3, Last Available: "2026-12"
@@ -11879,7 +11879,7 @@
 12121	Crymbocurrency	0		Last Available: "2025-12"
 12122	bouncing fortified extra-thick Crimbo sweater	0		Damage Absorption: +60, Last Available: "2025-12"
 12123	The Encyclopedia of Holiday Funerary Rites	0		Skill: "Holiday Burial Knowledge", Last Available: "2025-12"
-12124	irresponsibly strong delicious squat Steve Abrams' Holiday Sampler Beer	7	awesome	Last Available: "2025-12"
+12124	delicious irresponsibly strong squat Steve Abrams' Holiday Sampler Beer	7	awesome	Last Available: "2025-12"
 12125	narrow crate of prize-winning rum	0		No Pull, Last Available: "2025-12"
 12126	perfectly mixed bottle of prize-winning rum	3	EPIC	Last Available: "2025-12"
 12127	teal zippy foul-smelling Santa-Slayer medal of the brute	0		Muscle Percent: +30, Stench Damage: +10, Initiative: +20, Single Equip, Last Available: "2025-12"
@@ -11890,7 +11890,7 @@
 12132	upside-down Van der Graaf veiny sage smoldering vertebra	0		Mysticality Percent: +10, Maximum HP: +10, MP Regen Min: 5, MP Regen Max: 7, Single Equip, Last Available: "2025-12"
 12133	seal-clubbing club loot box	0		Free Pull, Last Available: "2026-01"
 12134	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary seal-clubbing club</span>	0		Muscle Percent: +50, Weapon Damage: +10, Initiative: +50, Conditional Skill (Equipped): "Club 'Em Across the Battlefield", Conditional Skill (Equipped): "Club 'Em Into Next Week", Conditional Skill (Equipped): "Club 'Em Back in Time", Last Available: "2026-01"
-12135	narrow skewed smoldering bone dust	0		Last Available: "2025-12"
+12135	skewed narrow smoldering bone dust	0		Last Available: "2025-12"
 12136	gray volatile bone bomb	0		Last Available: "2025-12"
 12137	maroon inspector's rosy-cheeked hot boning knife of bravery	0		Maximum HP Percent: +30, Spooky Resistance: +5, Item Drop: +15, Single Equip, Last Available: "2025-12"
 12138	blue Tesla fistbone of James Dean of the dark arts	0		Experience (Moxie): +3, Spell Damage Percent: +100, MP Regen Min: 7, MP Regen Max: 10, Last Available: "2025-12"
@@ -11926,7 +11926,7 @@
 12168	Jim Carey's thinker's vermiculite shield	0		Mysticality: +10, Monster Level: +25, Damage Reduction: 9, Last Available: "2025-12"
 12169	educational ship's lantern	0		Experience: +1, Last Available: "2025-12"
 12170	lard-coated clever heat-resistant harpoon pistol	0		Maximum MP: +20, Sleaze Spell Damage: +25, Last Available: "2025-12"
-12171	stale gigantic special traditional gingerloaf	9	decent	Effect: "Faboooo", Effect Duration: 25, Last Available: "2025-12"
+12171	special gigantic stale traditional gingerloaf	9	decent	Effect: "Faboooo", Effect Duration: 25, Last Available: "2025-12"
 12172	practically non-alcoholic artisanal teal Scotch and eggnog	1	super ultra mega turbo EPIC	Last Available: "2025-12"
 12173	extra-deionized counterskeleton elixir	0		Effect: "Purity of Spirit", Effect Duration: 58, Last Available: "2025-12"
 12174	drinkable twirling &quot;salvaged&quot; wine	3	good	Last Available: "2025-12"
@@ -11937,7 +11937,7 @@
 12179	mansplainer's glimmering crystal of the scaredy-cat	0		Monster Level: 0, Last Available: "2025-12"
 12180	boxed Heartstone	0		Free Pull, Last Available: "2026-02"
 12181	Heartstone	0		Muscle Percent: +25, Mysticality Percent: +25, Moxie Percent: +25, Experience: +3, HP Regen Min: 15, HP Regen Max: 20, Single Equip, Conditional Skill (Equipped): "Steal Monster's Heart", Conditional Skill (Equipped): "Heartstone: %kill", Conditional Skill (Equipped): "Heartstone: %banish", Conditional Skill (Equipped): "Heartstone: %stun", Conditional Skill (Equipped): "Heartstone: %luck", Conditional Skill (Equipped): "Heartstone: %pals", Conditional Skill (Equipped): "Heartstone: %buff", Last Available: "2026-02"
-12182	twirling pulsating Thwaitgold meat bee statuette	0		
+12182	pulsating twirling Thwaitgold meat bee statuette	0		
 12183	loose Meats	0		
 12184	fuchsia Archaeologist's Spade	0		Last Available: "2026-03"
 12185	skewed boxed Archaeologist's Spade	0		Free Pull, Last Available: "2026-03"
@@ -11972,27 +11972,27 @@
 12214	vaporized candy bone	1		Effect: "Seeing Colors", Effect Duration: 35
 12215	blurry wrapped Baseball Diamond	0		Free Pull, Last Available: "2026-04"
 12216	Baseball Diamond	0		Weapon Damage: +20, Last Available: "2026-04"
-12217	bite-sized stale upside-down blurry discarded hot dog	1	decent	Last Available: "2026-04"
-12218	hand-crafted enchanted mirror most of a beer	4	EPIC	Effect: "Red Misty-Eyed", Effect Duration: 25, Last Available: "2026-04"
+12217	bite-sized stale blurry upside-down discarded hot dog	1	decent	Last Available: "2026-04"
+12218	enchanted hand-crafted mirror most of a beer	4	EPIC	Effect: "Red Misty-Eyed", Effect Duration: 25, Last Available: "2026-04"
 12222	pasta wand loot box	0		Free Pull, Last Available: "2026-05"
 12223	<span style='padding: 2px; color: #ff8000; background-color: black;'>legendary pasta wand</span>	0		Spooky Damage: +5, Stench Damage: +5, Hot Damage: +5, Cold Damage: +5, Sleaze Damage: +5, Spell Damage: +10, Spell Damage Percent: +50, Spell Critical Percent: +15, Pasta Thrall Experience: +1, Single Equip, Last Available: "2026-05"
 12225	legendary noodles	0		Last Available: "2026-05"
-12226	massive decent shaking can of tuna	10	good	
-12227	bite-sized moldy alien salad	1	crappy	
+12226	decent massive shaking can of tuna	10	good	
+12227	moldy bite-sized alien salad	1	crappy	
 12228	moldy ratbatatouille	3	crappy	
 12229	spoiled shaking onigiri	3	crappy	
 12230	spoiled crudit&eacute;s	3	crappy	
-12231	adequate half-sized sauced mutton	2	good	
+12231	half-sized adequate sauced mutton	2	good	
 12232	moldy hot honey ant	3	crappy	
 12233	miniature spoiled tomb aspic	2	crappy	
 12234	stale spinning later tots	3	decent	
-12235	stale fancy Frutti di Scatoletta	4	decent	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2026-05"
+12235	fancy stale Frutti di Scatoletta	4	decent	Effect: "A Few Extra Pounds", Effect Duration: 20, Last Available: "2026-05"
 12236	decent Pesto alla Marziano	3	good	Last Available: "2026-05"
 12237	toothsome special purple Arrattabbattabiata	3	awesome	Effect: "Overstimulated", Effect Duration: 50, Last Available: "2026-05"
-12238	bite-sized decent Orzo di Riso	1	good	Last Available: "2026-05"
-12239	spoiled half-sized special Pasta Grimavera	2	crappy	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2026-05"
+12238	decent bite-sized Orzo di Riso	1	good	Last Available: "2026-05"
+12239	special half-sized spoiled Pasta Grimavera	2	crappy	Effect: "Superveiny 9000", Effect Duration: 45, Last Available: "2026-05"
 12240	adequate Linguini Ubriacapa	4	good	Last Available: "2026-05"
-12241	rotten immense Formica e Pepe	10	crappy	Last Available: "2026-05"
+12241	immense rotten Formica e Pepe	10	crappy	Last Available: "2026-05"
 12242	decent snack-sized Tubetto Gelatto	2	good	Last Available: "2026-05"
 12243	yummy Gnocci Domani	3	awesome	Last Available: "2026-05"
 12244	bouncing Thwaitgold wallet moth statuette	0		
@@ -12019,7 +12019,7 @@
 12269	packaged Portable Laughing Stock	0		Free Pull, Last Available: "2026-07"
 12270	frightening shellacked wicked Portable Laughing Stock	0		Spell Damage: +5, Damage Reduction: 7, Spooky Damage: +5, Conditional Skill (Equipped): "Taunt Your Foe", Last Available: "2026-07"
 12271	family-friendly Temple Grandin's healthy Staff of Anachronistic Churning	0		Maximum HP Percent: +20, Familiar Weight: +7, Sleaze Resistance: +1
-12272	rotten miniature teal classic banana	2	crappy	Last Available: "2026-07"
+12272	miniature rotten teal classic banana	2	crappy	Last Available: "2026-07"
 12273	adequate watermelon	4	good	Last Available: "2026-07"
 12274	rotten skewed quince	3	crappy	Last Available: "2026-07"
 12275	jittery Interesting Coin	0		Last Available: "2026-08"
@@ -12037,12 +12037,12 @@
 12287	stale green quince pie	3	decent	Last Available: "2026-07"
 12288	moist activated quince quaff	0		Effect: "Mer-kindliness", Effect Duration: 34, Last Available: "2026-07"
 12289	super-energized Quickquince	0		Effect: "Salty Mouth", Effect Duration: 59, Last Available: "2026-07"
-12290	practically non-alcoholic hand-crafted twirling Quiskey Sour	1	super EPIC	Last Available: "2026-07"
-12291	perfectly mixed weak Quincea&ntilde;era Cooler	2	super EPIC	Last Available: "2026-07"
+12290	hand-crafted practically non-alcoholic twirling Quiskey Sour	1	super EPIC	Last Available: "2026-07"
+12291	weak perfectly mixed Quincea&ntilde;era Cooler	2	super EPIC	Last Available: "2026-07"
 12292	perfectly mixed maroon Roth IPA	3	EPIC	Last Available: "2026-08"
 12293	squat Fonzie's beefcake's underdraft protection	0		Muscle: +25, Experience (Moxie): +1, Last Available: "2026-08"
 12294	solvent	0		Last Available: "2026-08"
-12295	miniature flavorless soybean futures	2	decent	Last Available: "2026-08"
+12295	flavorless miniature soybean futures	2	decent	Last Available: "2026-08"
 12296	vacuum-sealed housing bubble	0		Effect: "Far Out", Effect Duration: 65, Last Available: "2026-08"
 12297	quadruple-dry skewed Pixie-Swordz	0		Effect: "Braaaains Over Braaaawwn", Effect Duration: 56
 12298	Rosewater's beefcake's financial instrument	0		Muscle: +25, Mysticality Percent: +30, Last Available: "2026-08"
@@ -12059,6 +12059,6 @@
 12309	homeowner's loam	0		Last Available: "2026-08"
 12310	twisted toxic asset	1		Last Available: "2026-08"
 12311	compressed intangible asset	1		Last Available: "2026-08"
-12312	dehydrated blurry ghostly blue liquid asset	1		Effect: "Flamingly Floral", Effect Duration: 50, Last Available: "2026-08"
+12312	dehydrated ghostly blue blurry liquid asset	1		Effect: "Flamingly Floral", Effect Duration: 50, Last Available: "2026-08"
 12313	gross prophet chrysalis	0		Last Available: "2026-08"
 12314	cast entrails	0		Familiar Weight: +5

--- a/data/TCRS/TCRS_Turtle_Tamer_Wombat_cafe_booze.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wombat_cafe_booze.txt
@@ -1,33 +1,33 @@
--1	special mediocre Petite Porter	4	decent	
--2	watered-down aged Scrawny Stout	2	awesome	
--3	high-proof artisanal Infinitesimal IPA	7	EPIC	
--4	perfectly mixed weak eggnogtini	2	EPIC	
--5	fortified tolerable candycaine	5	good	
+-1	mediocre special Petite Porter	4	decent	
+-2	aged watered-down Scrawny Stout	2	awesome	
+-3	artisanal high-proof Infinitesimal IPA	7	EPIC	
+-4	weak perfectly mixed eggnogtini	2	EPIC	
+-5	tolerable fortified candycaine	5	good	
 -6	lousy cyan braincracker sweet	3	decent	
--16	mediocre watered-down cyan wobbly fermented honey	2	decent	
+-16	watered-down mediocre wobbly cyan fermented honey	2	decent	
 -17	acceptable moons-shine	4	good	
 -18	smooth weak blinking gin	2	awesome	
 -19	smooth ecto-nog	3	awesome	
--20	lousy enchanted irresponsibly strong hot toady	6	decent	
--21	high-proof acceptable maroon hot choculate	6	good	
--49	watered-down delicious tumbling pulsating Cyder	2	awesome	
--50	perfectly mixed weak Oil Nog	2	EPIC	
+-20	lousy irresponsibly strong enchanted hot toady	6	decent	
+-21	acceptable high-proof maroon hot choculate	6	good	
+-49	delicious watered-down tumbling pulsating Cyder	2	awesome	
+-50	weak perfectly mixed Oil Nog	2	EPIC	
 -51	drinkable Hi-Octane Peppermint Jet Fuel	4	good	
 -58	tolerable tumbling Grimacider	3	good	
 -59	acceptable Isotope Nog	3	good	
 -60	lousy practically non-alcoholic Mutagin 'n' Tonic	1	decent	
 -70	tolerable Gin and Herring	3	good	
--71	practically non-alcoholic hand-crafted Black and Tan and Red All Over	1	EPIC	
+-71	hand-crafted practically non-alcoholic Black and Tan and Red All Over	1	EPIC	
 -72	bad Antarctic Ice Tea	3	decent	
 -76	tolerable CRIMBCO Ribbon Candy Schnapps	4	good	
--77	bad fancy CRIMBCO Egg Substitute Nog Substitute	4	decent	
--78	enchanted acceptable practically non-alcoholic CRIMBCO Extreme Braincracker Sour	1	good	
--82	artisanal weak Horseradish-infused Vodka	2	EPIC	
+-77	fancy bad CRIMBCO Egg Substitute Nog Substitute	4	decent	
+-78	practically non-alcoholic acceptable enchanted CRIMBCO Extreme Braincracker Sour	1	good	
+-82	weak artisanal Horseradish-infused Vodka	2	EPIC	
 -83	bad Jerkitini	3	decent	
--84	tolerable practically non-alcoholic Desert Island Iced Tea	1	good	
+-84	practically non-alcoholic tolerable Desert Island Iced Tea	1	good	
 -88	acceptable Crimbo Saketini	4	good	
 -89	practically non-alcoholic drinkable Crimboku Drop	1	good	
 -90	bad Flaming Crimbo Log	3	decent	
--107	artisanal weak purple Fortified Eggnog Slurry	2	EPIC	
+-107	weak artisanal purple Fortified Eggnog Slurry	2	EPIC	
 -108	hand-crafted special ghostly Hot Buttered Rum	4	EPIC	
 -109	hand-crafted weak Spicy Hot Chocolate	2	EPIC	

--- a/data/TCRS/TCRS_Turtle_Tamer_Wombat_cafe_food.txt
+++ b/data/TCRS/TCRS_Turtle_Tamer_Wombat_cafe_food.txt
@@ -1,14 +1,14 @@
 -1	moldy Peche a la Frog	4	crappy	
--2	half-sized normal As Jus Gezund Heit	2	good	
--3	gigantic adequate Bouillabaise Coucher Avec Moi	7	good	
+-2	normal half-sized As Jus Gezund Heit	2	good	
+-3	adequate gigantic Bouillabaise Coucher Avec Moi	7	good	
 -7	spoiled gumdrop chow mein	3	crappy	
--8	miniature adequate candy cane pizza	2	good	
--9	adequate diet gingerbread stir-fry	1	good	
--10	diet spoiled twigs and gravel	1	crappy	
+-8	adequate miniature candy cane pizza	2	good	
+-9	diet adequate gingerbread stir-fry	1	good	
+-10	spoiled diet twigs and gravel	1	crappy	
 -11	moldy small skewed shoots and leaves	2	crappy	
 -12	big decent upside-down squat bowl of unidentifiable goo	5	good	
 -13	moldy lime green gingerbread massacre	3	crappy	
--14	tiny stale purple It Came From Beyond Dessert	1	decent	
+-14	stale tiny purple It Came From Beyond Dessert	1	decent	
 -15	massive bland gray vampire cake	7	decent	
 -52	special spoiled yellow Soylent Red and Green	3	crappy	
 -53	bland squat Disc-Shaped Nutrition Unit	3	decent	
@@ -16,30 +16,30 @@
 -61	adequate Candy Cane Surprise	3	good	
 -62	normal enchanted Grimdrop Chow Mein	4	good	
 -63	moldy special half-sized Grimgerbread House	2	crappy	
--67	enchanted flavorless Caviar Carbonara	3	decent	
+-67	flavorless enchanted Caviar Carbonara	3	decent	
 -68	flavorless twirling Halibut Alfredo	4	decent	
 -69	stale Red Herring Velvet Cake	3	decent	
--73	rotten big CRIMBCO Reconstituted Gruel	5	crappy	
+-73	big rotten CRIMBCO Reconstituted Gruel	5	crappy	
 -74	tiny flavorless spinning New and Improved CRIMBCO Reconstituted Gruel	1	decent	
--75	gigantic delicious red CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	awesome	
+-75	delicious gigantic red CRIMBCO Deluxe Reconstituted Gruel with Simulated Raisins	8	awesome	
 -79	decent Brussels Sprout Stir-Fry	3	good	
 -80	normal Carrot, Cabbage, and Kale Pizza	3	good	
--81	flavorless low-calorie Turnip and Rutabaga Pie	1	decent	
--85	spoiled half-sized Rainbow Spider Fun Roll	2	crappy	
+-81	low-calorie flavorless Turnip and Rutabaga Pie	1	decent	
+-85	half-sized spoiled Rainbow Spider Fun Roll	2	crappy	
 -86	normal super-sized Vegas Volcano Lava Roll	5	good	
 -87	spoiled green skewed Crazy Dragon Shogun Buddha Roll	3	crappy	
--92	jumbo normal basic hot dog	5	good	
--93	small stale savage macho dog	2	decent	
--94	snack-sized normal wobbly one with everything	2	good	
+-92	normal jumbo basic hot dog	5	good	
+-93	stale small savage macho dog	2	decent	
+-94	normal snack-sized wobbly one with everything	2	good	
 -95	flavorless sly dog	3	decent	
--96	adequate big devil dog	5	good	
--97	stale bite-sized chilly dog	1	decent	
+-96	big adequate devil dog	5	good	
+-97	bite-sized stale chilly dog	1	decent	
 -98	small bland yellow ghost dog	2	decent	
--99	half-sized delicious junkyard dog	2	awesome	
+-99	delicious half-sized junkyard dog	2	awesome	
 -100	bland tiny cyan wet dog	1	decent	
--101	flavorless snack-sized squat sleeping dog	2	decent	
+-101	snack-sized flavorless squat sleeping dog	2	decent	
 -102	bite-sized adequate optimal dog	1	good	
--103	snack-sized spoiled video games hot dog	2	crappy	
+-103	spoiled snack-sized video games hot dog	2	crappy	
 -104	bland Peppermint Nutrition Block	4	decent	
--105	normal miniature ghostly Gingerbread Nutrition Block	2	good	
+-105	miniature normal ghostly Gingerbread Nutrition Block	2	good	
 -106	stale Cinnamon Nutrition Block	3	decent	


### PR DESCRIPTION
I mentioned to CDM and he fixed it. Confirmed by rederiving, and rederiving again - stable. I didn't notice before because you need to fully relog to get the reroll.
